### PR TITLE
test(dingtalk): cover group routes and empty state

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -92,6 +92,13 @@
               </option>
             </select>
             <div
+              v-if="!dingTalkDestinations.length"
+              class="meta-automation__hint"
+              data-automation-field="dingtalkDestinationEmpty"
+            >
+              No DingTalk groups are bound to this table yet. Add one in API Tokens &amp; Webhooks &gt; DingTalk Groups, or use a record group field path below.
+            </div>
+            <div
               v-if="selectedDingTalkGroupDestinations.length"
               class="meta-automation__recipient-list meta-automation__recipient-list--selected"
             >

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -209,6 +209,13 @@
                 Only DingTalk group destinations registered for this table are listed here.
               </div>
               <div
+                v-if="!dingTalkDestinationsError && dingTalkDestinations.length === 0"
+                class="meta-rule-editor__hint"
+                data-field="dingtalkDestinationEmpty"
+              >
+                No DingTalk groups are bound to this table yet. Add one in API Tokens &amp; Webhooks &gt; DingTalk Groups, or use a record group field path below.
+              </div>
+              <div
                 v-if="selectedGroupDestinations(action).length"
                 class="meta-rule-editor__recipient-list meta-rule-editor__recipient-list--selected"
               >

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -39,6 +39,7 @@ function mockClient(
     groupDeliveryErrorMessage?: string
     personDeliveryErrorMessage?: string
     stats?: Record<string, unknown>
+    dingTalkGroups?: Array<Record<string, unknown>>
   } = {},
 ) {
   const ok = (body: unknown) => new Response(JSON.stringify({ data: body }), { status: 200, headers: { 'Content-Type': 'application/json' } })
@@ -79,7 +80,7 @@ function mockClient(
     const method = init?.method ?? 'GET'
     if (method === 'GET' && url.includes('/dingtalk-groups')) {
       return ok({
-        destinations: [
+        destinations: options.dingTalkGroups ?? [
           {
             id: 'dt_1',
             name: 'Ops Group',
@@ -819,6 +820,64 @@ describe('MetaAutomationManager', () => {
       internalViewId: 'view_grid',
     })
     expect(fetchFn.mock.calls.some(([url]) => String(url).includes('/api/multitable/dingtalk-groups?sheetId=sheet_1'))).toBe(true)
+  })
+
+  it('shows an empty state when no DingTalk groups are bound and still allows dynamic record destinations', async () => {
+    const { client, fetchFn } = mockClient([], { dingTalkGroups: [] })
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const nameInput = container.querySelector('[data-automation-field="name"]') as HTMLInputElement
+    nameInput.value = 'DingTalk dynamic groups'
+    nameInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_group_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const emptyState = container.querySelector('[data-automation-field="dingtalkDestinationEmpty"]')
+    expect(emptyState?.textContent).toContain('No DingTalk groups are bound to this table yet')
+    expect(emptyState?.textContent).toContain('API Tokens & Webhooks')
+    expect(emptyState?.textContent).toContain('record group field path')
+
+    const titleInput = container.querySelector('[data-automation-field="dingtalkTitleTemplate"]') as HTMLInputElement
+    titleInput.value = 'Ticket {{recordId}}'
+    titleInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const bodyInput = container.querySelector('[data-automation-field="dingtalkBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = 'Please fill {{record.status}}'
+    bodyInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushPromises()
+
+    const saveBtn = container.querySelector('.meta-automation__btn--primary') as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(true)
+    saveBtn.click()
+    await flushPromises()
+    expect(fetchFn.mock.calls.filter(([, init]: [string, RequestInit | undefined]) => init?.method === 'POST')).toHaveLength(0)
+
+    const destinationFieldInput = container.querySelector('[data-automation-field="dingtalkDestinationFieldPath"]') as HTMLInputElement
+    destinationFieldInput.value = 'record.fld_2'
+    destinationFieldInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushPromises()
+
+    expect(saveBtn.disabled).toBe(false)
+    saveBtn.click()
+    await flushPromises()
+
+    const postCalls = fetchFn.mock.calls.filter(([, init]: [string, RequestInit | undefined]) => init?.method === 'POST')
+    expect(postCalls.length).toBe(1)
+    const body = JSON.parse(postCalls[0][1]?.body as string)
+    expect(body.actionConfig).toEqual({
+      destinationIdFieldPath: 'record.fld_2',
+      destinationIdFieldPaths: ['record.fld_2'],
+      titleTemplate: 'Ticket {{recordId}}',
+      bodyTemplate: 'Please fill {{record.status}}',
+    })
   })
 
   it('filters internal processing options to the current sheet in the inline form', async () => {

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -563,6 +563,67 @@ describe('MetaAutomationRuleEditor', () => {
     expect(client.listDingTalkGroups).toHaveBeenCalledWith('sheet_1')
   })
 
+  it('shows an empty state when no DingTalk groups are bound and still allows dynamic record destinations', async () => {
+    const saved = vi.fn()
+    const client = {
+      ...mockClient(),
+      listDingTalkGroups: vi.fn(async () => []),
+    }
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+      onSave: saved,
+    })
+    await flushPromises()
+
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    nameInput.value = 'Notify dynamic groups'
+    nameInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_group_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const emptyState = container.querySelector('[data-field="dingtalkDestinationEmpty"]')
+    expect(emptyState?.textContent).toContain('No DingTalk groups are bound to this table yet')
+    expect(emptyState?.textContent).toContain('API Tokens & Webhooks')
+    expect(emptyState?.textContent).toContain('record group field path')
+
+    const titleInput = container.querySelector('[data-field="dingtalkTitleTemplate"]') as HTMLInputElement
+    titleInput.value = 'Ticket {{recordId}}'
+    titleInput.dispatchEvent(new Event('input'))
+
+    const bodyInput = container.querySelector('[data-field="dingtalkBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = 'Please review {{record.status}}'
+    bodyInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(true)
+
+    const destinationFieldInput = container.querySelector('[data-field="dingtalkDestinationFieldPath"]') as HTMLInputElement
+    destinationFieldInput.value = 'record.fld_2'
+    destinationFieldInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    expect(saveBtn.disabled).toBe(false)
+    saveBtn.click()
+    await flushPromises()
+
+    expect(saved).toHaveBeenCalledTimes(1)
+    expect(saved.mock.calls[0][0].actionConfig).toEqual({
+      destinationIdFieldPath: 'record.fld_2',
+      destinationIdFieldPaths: ['record.fld_2'],
+      titleTemplate: 'Ticket {{recordId}}',
+      bodyTemplate: 'Please review {{record.status}}',
+    })
+  })
+
   it('loads and saves DingTalk group config from V1 actions when legacy action fields are stale', async () => {
     const saved = vi.fn()
     const client = mockClient()

--- a/docs/development/dingtalk-group-route-and-empty-state-development-20260422.md
+++ b/docs/development/dingtalk-group-route-and-empty-state-development-20260422.md
@@ -1,0 +1,36 @@
+# DingTalk Group Route And Empty State Development - 2026-04-22
+
+## Goal
+
+Continue the DingTalk standard feature work by tightening the table-bound DingTalk group route contract and improving the automation authoring experience when a table has no bound DingTalk groups.
+
+## Implemented
+
+- Added route-level integration coverage for `/api/multitable/dingtalk-groups`.
+- Locked sheet-scoped permission behavior for list, update, delete, delivery history, and test-send routes.
+- Locked create response redaction so webhook credentials are masked and the stored robot secret is not returned.
+- Added an empty-state hint in both automation authoring entry points when the current table has no DingTalk group bindings.
+- Preserved dynamic record group field paths as the valid fallback path when no static DingTalk group can be selected.
+
+## Files
+
+- `packages/core-backend/tests/integration/dingtalk-group-destination-routes.api.test.ts`
+- `apps/web/src/multitable/components/MetaAutomationManager.vue`
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+- `apps/web/tests/multitable-automation-manager.spec.ts`
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+- `docs/development/dingtalk-group-route-and-empty-state-development-20260422.md`
+- `docs/development/dingtalk-group-route-and-empty-state-verification-20260422.md`
+
+## Behavior Notes
+
+- No backend runtime route or service behavior was changed in this slice; the backend work adds missing route contract tests.
+- The frontend now tells the user to bind a DingTalk group in API Tokens & Webhooks > DingTalk Groups, or use a record group field path.
+- Saving remains disabled when a DingTalk group action has no static destination and no valid dynamic destination field path.
+- Saving remains enabled when a valid dynamic field path such as `record.fld_2` is configured with title and body templates.
+
+## Out Of Scope
+
+- No DingTalk person-message behavior was changed.
+- No public form or granted-form runtime behavior was changed.
+- No existing unrelated `node_modules` worktree changes were touched.

--- a/docs/development/dingtalk-group-route-and-empty-state-verification-20260422.md
+++ b/docs/development/dingtalk-group-route-and-empty-state-verification-20260422.md
@@ -1,0 +1,64 @@
+# DingTalk Group Route And Empty State Verification - 2026-04-22
+
+## Result
+
+Passed local verification for the scoped backend route tests, related DingTalk backend regression tests, frontend automation tests, frontend DingTalk group management tests, backend build, frontend build, and diff hygiene.
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-group-destination-routes.api.test.ts --watch=false
+```
+
+Result: passed, 1 test file, 8 tests.
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --watch=false
+```
+
+Result: passed, 2 test files, 129 tests.
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-delivery-routes.api.test.ts tests/unit/dingtalk-group-destination-service.test.ts tests/unit/dingtalk-group-destination-response.test.ts --watch=false
+```
+
+Result: passed, 3 test files, 23 tests.
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-api-token-manager.spec.ts --watch=false
+```
+
+Result: passed, 1 test file, 24 tests.
+
+```bash
+pnpm --filter @metasheet/core-backend build
+```
+
+Result: passed.
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result: passed.
+
+```bash
+git diff --check
+```
+
+Result: passed.
+
+## Observations
+
+- Frontend Vitest printed `WebSocket server error: Port is already in use`, but all targeted frontend tests passed.
+- Frontend production build printed existing Vite warnings about a large chunk and `WorkflowDesigner.vue` being both dynamically and statically imported; build completed successfully.
+- Claude Code CLI was invoked in read-only mode with `Read,Grep,Glob` tools, but it produced no output after more than 3 minutes and was terminated. It is not counted as a completed verification signal.
+
+## Coverage Added
+
+- Sheet-scoped DingTalk group list rejects users without `canManageAutomation` before service access.
+- Sheet-scoped DingTalk group create returns a redacted response without exposing the robot secret.
+- Sheet-scoped update, delete, delivery history, and test-send routes reject users without `canManageAutomation` before service access.
+- Authorized delivery history clamps high limits to 200.
+- Authorized test-send passes the sheet ID to the destination service.
+- Both automation editors show the no-bound-group hint and keep dynamic destination field paths usable.

--- a/packages/core-backend/tests/integration/dingtalk-group-destination-routes.api.test.ts
+++ b/packages/core-backend/tests/integration/dingtalk-group-destination-routes.api.test.ts
@@ -1,0 +1,190 @@
+import express from 'express'
+import request from 'supertest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const SHEET_ID = 'sheet_dingtalk_group_routes'
+const DESTINATION_ID = 'dt_group_route_1'
+
+function makeDestination(overrides: Record<string, unknown> = {}) {
+  return {
+    id: DESTINATION_ID,
+    name: 'Ops DingTalk Group',
+    webhookUrl: 'https://oapi.dingtalk.com/robot/send?access_token=secret-token&timestamp=123&sign=abc',
+    secret: 'SECsecret',
+    enabled: true,
+    sheetId: SHEET_ID,
+    createdBy: 'user_1',
+    createdAt: '2026-04-22T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function makeDelivery(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'dgd_route_1',
+    destinationId: DESTINATION_ID,
+    sourceType: 'manual_test',
+    subject: 'MetaSheet DingTalk group test',
+    content: 'This is a standard DingTalk group destination test message.',
+    success: true,
+    httpStatus: 200,
+    responseBody: '{"errcode":0,"errmsg":"ok"}',
+    createdAt: '2026-04-22T00:01:00.000Z',
+    deliveredAt: '2026-04-22T00:01:01.000Z',
+    ...overrides,
+  }
+}
+
+async function createApp(options: {
+  canManageAutomation?: boolean
+  serviceOverrides?: Record<string, ReturnType<typeof vi.fn>>
+} = {}) {
+  vi.resetModules()
+
+  const service = {
+    listDestinations: vi.fn(async () => [makeDestination()]),
+    createDestination: vi.fn(async () => makeDestination()),
+    updateDestination: vi.fn(async () => makeDestination({ name: 'Updated DingTalk Group' })),
+    deleteDestination: vi.fn(async () => undefined),
+    getDestinationById: vi.fn(async () => makeDestination()),
+    listDeliveries: vi.fn(async () => [makeDelivery()]),
+    testSend: vi.fn(async () => ({ ok: true })),
+    ...options.serviceOverrides,
+  }
+  const resolveSheetCapabilitiesForUser = vi.fn(async () => ({
+    capabilities: { canManageAutomation: options.canManageAutomation ?? true },
+  }))
+  const query = vi.fn()
+
+  const authenticate = (req: any, _res: any, next: () => void) => {
+    req.user = { id: 'user_1', roles: [], perms: ['workflow:write'] }
+    next()
+  }
+
+  vi.doMock('../../src/middleware/auth', () => ({
+    authenticate,
+    authMiddleware: authenticate,
+    default: authenticate,
+  }))
+  vi.doMock('../../src/db/db', () => ({ db: {} }))
+  vi.doMock('../../src/db/pg', () => ({ query }))
+  vi.doMock('../../src/multitable/sheet-capabilities', () => ({
+    resolveSheetCapabilitiesForUser,
+  }))
+  vi.doMock('../../src/multitable/dingtalk-group-destination-service', () => ({
+    DingTalkGroupDestinationService: vi.fn(() => service),
+  }))
+
+  const { apiTokensRouter } = await import('../../src/routes/api-tokens')
+
+  const app = express()
+  app.use(express.json())
+  app.use(apiTokensRouter())
+
+  return { app, query, resolveSheetCapabilitiesForUser, service }
+}
+
+describe('DingTalk group destination routes', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.resetModules()
+  })
+
+  it('rejects sheet-scoped list access without automation permission before calling the service', async () => {
+    const { app, service, resolveSheetCapabilitiesForUser } = await createApp({ canManageAutomation: false })
+
+    const response = await request(app)
+      .get('/api/multitable/dingtalk-groups')
+      .query({ sheetId: SHEET_ID })
+      .expect(403)
+
+    expect(response.body).toEqual({
+      ok: false,
+      error: { code: 'FORBIDDEN' },
+    })
+    expect(resolveSheetCapabilitiesForUser).toHaveBeenCalledWith(expect.any(Function), SHEET_ID, 'user_1')
+    expect(service.listDestinations).not.toHaveBeenCalled()
+  })
+
+  it('creates a sheet-scoped destination and redacts webhook credentials and robot secret', async () => {
+    const { app, service } = await createApp()
+
+    const response = await request(app)
+      .post('/api/multitable/dingtalk-groups')
+      .send({
+        name: 'Ops DingTalk Group',
+        webhookUrl: 'https://oapi.dingtalk.com/robot/send?access_token=secret-token',
+        secret: 'SECsecret',
+        sheetId: SHEET_ID,
+      })
+      .expect(201)
+
+    expect(service.createDestination).toHaveBeenCalledWith('user_1', expect.objectContaining({
+      name: 'Ops DingTalk Group',
+      webhookUrl: 'https://oapi.dingtalk.com/robot/send?access_token=secret-token',
+      secret: 'SECsecret',
+      sheetId: SHEET_ID,
+    }))
+    expect(response.body.ok).toBe(true)
+    expect(response.body.data.webhookUrl).toContain('access_token=***')
+    expect(response.body.data.webhookUrl).toContain('timestamp=***')
+    expect(response.body.data.webhookUrl).toContain('sign=***')
+    expect(response.body.data.webhookUrl).not.toContain('secret-token')
+    expect(response.body.data.hasSecret).toBe(true)
+    expect(Object.prototype.hasOwnProperty.call(response.body.data, 'secret')).toBe(false)
+  })
+
+  it.each([
+    ['PATCH', `/api/multitable/dingtalk-groups/${DESTINATION_ID}`, 'updateDestination'],
+    ['DELETE', `/api/multitable/dingtalk-groups/${DESTINATION_ID}`, 'deleteDestination'],
+    ['GET', `/api/multitable/dingtalk-groups/${DESTINATION_ID}/deliveries`, 'getDestinationById'],
+    ['POST', `/api/multitable/dingtalk-groups/${DESTINATION_ID}/test-send`, 'testSend'],
+  ])('rejects %s %s without automation permission before calling %s', async (method, path, serviceMethod) => {
+    const { app, service } = await createApp({ canManageAutomation: false })
+
+    const requestBuilder = request(app)[method.toLowerCase() as 'get' | 'post' | 'patch' | 'delete'](path).query({ sheetId: SHEET_ID })
+    if (method === 'PATCH') requestBuilder.send({ enabled: false })
+    if (method === 'POST') requestBuilder.send({ subject: 'Test', content: 'Body' })
+
+    const response = await requestBuilder.expect(403)
+
+    expect(response.body).toEqual({
+      ok: false,
+      error: { code: 'FORBIDDEN' },
+    })
+    expect(service[serviceMethod as keyof typeof service]).not.toHaveBeenCalled()
+  })
+
+  it('lists delivery history for an authorized sheet-scoped destination', async () => {
+    const { app, service } = await createApp()
+
+    const response = await request(app)
+      .get(`/api/multitable/dingtalk-groups/${DESTINATION_ID}/deliveries`)
+      .query({ sheetId: SHEET_ID, limit: '999' })
+      .expect(200)
+
+    expect(service.getDestinationById).toHaveBeenCalledWith(DESTINATION_ID)
+    expect(service.listDeliveries).toHaveBeenCalledWith(DESTINATION_ID, 200)
+    expect(response.body).toEqual({
+      ok: true,
+      data: { deliveries: [makeDelivery()] },
+    })
+  })
+
+  it('test-sends an authorized sheet-scoped destination', async () => {
+    const { app, service } = await createApp()
+
+    await request(app)
+      .post(`/api/multitable/dingtalk-groups/${DESTINATION_ID}/test-send`)
+      .query({ sheetId: SHEET_ID })
+      .send({ subject: 'Route test', content: 'Body' })
+      .expect(204)
+
+    expect(service.testSend).toHaveBeenCalledWith(
+      DESTINATION_ID,
+      'user_1',
+      { subject: 'Route test', content: 'Body' },
+      SHEET_ID,
+    )
+  })
+})


### PR DESCRIPTION
## Summary\n- replacement PR for closed #1064\n- keeps the same head branch after stack rebuild\n- retargets the base to codex/dingtalk-person-granted-form-guard-20260422 so #1065 has an open parent PR\n\n## Verification\n- rebuilt locally from current main via cherry-pick stack reconstruction\n- pnpm --filter @metasheet/web exec vitest run targeted DingTalk frontend tests: 179/179 passed\n- pnpm --filter @metasheet/core-backend exec vitest run targeted DingTalk backend tests: 200/200 passed\n- node --test DingTalk P4 ops tests: 78/78 passed\n- git diff --check origin/main...HEAD passed\n\nClosed predecessor: #1064.