### PR TITLE
test(dingtalk): generate final P4 remote smoke docs

### DIFF
--- a/docs/development/dingtalk-feature-plan-and-todo-20260422.md
+++ b/docs/development/dingtalk-feature-plan-and-todo-20260422.md
@@ -88,6 +88,7 @@
 - [x] Auto-refresh P4 smoke status and remote TODO reports from the session bootstrap/finalize commands.
 - [x] Add a P4 no-email admin evidence helper so manual-admin proof uses concrete artifact names and structured result fields.
 - [x] Add a final DingTalk development plan and TODO so remote smoke execution can be followed step-by-step.
+- [x] Add a P4 final remote-smoke docs generator so release-ready sessions produce final development and verification notes.
 - [ ] Remote smoke: create a table and form view.
 - [ ] Remote smoke: bind at least two DingTalk groups to the table.
 - [ ] Remote smoke: set the form to `dingtalk_granted`.

--- a/docs/development/dingtalk-final-development-plan-and-todo-20260423.md
+++ b/docs/development/dingtalk-final-development-plan-and-todo-20260423.md
@@ -193,6 +193,16 @@ node scripts/ops/dingtalk-p4-smoke-status.mjs \
 
 ## Final Documentation Outputs
 
+- [x] Add a gated final documentation generator:
+
+```bash
+node scripts/ops/dingtalk-p4-final-docs.mjs \
+  --session-dir output/dingtalk-p4-remote-smoke-session/142-session \
+  --handoff-summary artifacts/dingtalk-staging-evidence-packet/142-final/handoff-summary.json \
+  --require-release-ready \
+  --output-dir docs/development
+```
+
 - [ ] Create `docs/development/dingtalk-final-remote-smoke-development-20260423.md`
 - [ ] Create `docs/development/dingtalk-final-remote-smoke-verification-20260423.md`
 - [ ] Include remote smoke session path, final packet path, commands run, pass/fail status, and residual risks.

--- a/docs/development/dingtalk-p4-final-docs-generator-development-20260423.md
+++ b/docs/development/dingtalk-p4-final-docs-generator-development-20260423.md
@@ -1,0 +1,33 @@
+# DingTalk P4 Final Docs Generator Development
+
+- Date: 2026-04-23
+- Branch: `codex/dingtalk-p4-final-docs-generator-20260423`
+- Scope: local P4 tooling only; no DingTalk or staging network calls.
+
+## Completed Work
+
+- Added `scripts/ops/dingtalk-p4-final-docs.mjs` to generate final development and verification Markdown from a finalized P4 smoke session, release-ready status summary, compiled summary, and final handoff summary.
+- Added a `--require-release-ready` gate that rejects output unless session finalization, compiled evidence, smoke status, handoff, publish validation, required checks, manual evidence issues, and secret findings are all clean.
+- Added Markdown redaction and output scanning for token-like values before tracked final notes are written.
+- Updated the P4 final plan and master DingTalk TODO with the final docs generator step.
+
+## Output Contract
+
+- Default development output: `docs/development/dingtalk-final-remote-smoke-development-<yyyymmdd>.md`
+- Default verification output: `docs/development/dingtalk-final-remote-smoke-verification-<yyyymmdd>.md`
+- The generator is intentionally local-only and reads existing summaries; it does not call DingTalk, staging, PostgreSQL, Redis, or the PLM API.
+
+## Command
+
+```bash
+node scripts/ops/dingtalk-p4-final-docs.mjs \
+  --session-dir output/dingtalk-p4-remote-smoke-session/142-session \
+  --handoff-summary artifacts/dingtalk-staging-evidence-packet/142-final/handoff-summary.json \
+  --require-release-ready \
+  --output-dir docs/development
+```
+
+## Notes
+
+- Real final remote-smoke docs should only be generated after the actual `142-session` status is `release_ready`.
+- This change does not create or expose admin tokens, temporary passwords, DingTalk webhooks, cookies, or raw public form tokens.

--- a/docs/development/dingtalk-p4-final-docs-generator-verification-20260423.md
+++ b/docs/development/dingtalk-p4-final-docs-generator-verification-20260423.md
@@ -1,0 +1,36 @@
+# DingTalk P4 Final Docs Generator Verification
+
+- Date: 2026-04-23
+- Branch: `codex/dingtalk-p4-final-docs-generator-20260423`
+
+## Commands Run
+
+```bash
+node --test scripts/ops/dingtalk-p4-final-docs.test.mjs
+
+node --test \
+  scripts/ops/dingtalk-p4-final-docs.test.mjs \
+  scripts/ops/dingtalk-p4-smoke-status.test.mjs \
+  scripts/ops/dingtalk-p4-offline-handoff.test.mjs \
+  scripts/ops/dingtalk-p4-final-handoff.test.mjs \
+  scripts/ops/validate-dingtalk-staging-evidence-packet.test.mjs
+
+git diff --check
+```
+
+## Results
+
+- `node --test scripts/ops/dingtalk-p4-final-docs.test.mjs`: pass, 3 tests.
+- P4 tooling regression command: pass, 28 tests.
+- `git diff --check`: pass.
+
+## Covered Cases
+
+- Generates final development and verification notes from a release-ready offline fixture.
+- Rejects non-`release_ready` sessions when `--require-release-ready` is used.
+- Redacts token-like failure details before writing Markdown.
+
+## Broader Gates
+
+- Existing P4 smoke status, offline handoff, final handoff, and packet validation tests passed with the new generator included.
+- Product/backend/frontend integration and build gates were not rerun in this local slice because the change is limited to local P4 ops scripts and documentation.

--- a/scripts/ops/dingtalk-p4-final-docs.mjs
+++ b/scripts/ops/dingtalk-p4-final-docs.mjs
@@ -1,0 +1,385 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+
+const DEFAULT_OUTPUT_DIR = 'docs/development'
+const REQUIRED_CHECK_IDS = [
+  'create-table-form',
+  'bind-two-dingtalk-groups',
+  'set-form-dingtalk-granted',
+  'send-group-message-form-link',
+  'authorized-user-submit',
+  'unauthorized-user-denied',
+  'delivery-history-group-person',
+  'no-email-user-create-bind',
+]
+const SECRET_PATTERNS = [
+  /https:\/\/oapi\.dingtalk\.com\/robot\/send\?[^\s"'`<>]*access_token=(?!<redacted>)[^\s&"'`<>]{8,}/i,
+  /\bBearer\s+(?!<redacted>)[A-Za-z0-9._~+/=-]{20,}/i,
+  /\bSEC[A-Za-z0-9+/=_-]{8,}\b/,
+  /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/,
+  /\bpublicToken=(?!<redacted>)[A-Za-z0-9._~+/=-]{12,}/i,
+]
+
+function printHelp() {
+  console.log(`Usage: node scripts/ops/dingtalk-p4-final-docs.mjs [options]
+
+Generates final DingTalk remote-smoke development and verification Markdown from
+a finalized P4 session, release-ready smoke status, and final handoff summary.
+It does not call DingTalk or staging.
+
+Options:
+  --session-dir <dir>          Finalized DingTalk P4 smoke session directory
+  --handoff-summary <file>     Final handoff-summary.json path
+  --status-summary <file>      Smoke status JSON, default <session-dir>/smoke-status.json
+  --compiled-summary <file>    Compiled summary JSON, default <session-dir>/compiled/summary.json
+  --output-dir <dir>           Output docs directory, default ${DEFAULT_OUTPUT_DIR}
+  --date <yyyymmdd>            Date suffix, default current UTC date
+  --development-md <file>      Development Markdown path
+  --verification-md <file>     Verification Markdown path
+  --require-release-ready      Reject unless session, compiled, status, handoff, and publish checks pass
+  --help                       Show this help
+`)
+}
+
+function readRequiredValue(argv, index, flag) {
+  const next = argv[index + 1]
+  if (!next || next.startsWith('--')) throw new Error(`${flag} requires a value`)
+  return next
+}
+
+function defaultDate() {
+  return new Date().toISOString().slice(0, 10).replaceAll('-', '')
+}
+
+function parseArgs(argv) {
+  const opts = {
+    sessionDir: '',
+    handoffSummary: '',
+    statusSummary: '',
+    compiledSummary: '',
+    outputDir: path.resolve(process.cwd(), DEFAULT_OUTPUT_DIR),
+    date: defaultDate(),
+    developmentMd: '',
+    verificationMd: '',
+    requireReleaseReady: false,
+  }
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    switch (arg) {
+      case '--session-dir':
+        opts.sessionDir = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
+        i += 1
+        break
+      case '--handoff-summary':
+        opts.handoffSummary = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
+        i += 1
+        break
+      case '--status-summary':
+        opts.statusSummary = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
+        i += 1
+        break
+      case '--compiled-summary':
+        opts.compiledSummary = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
+        i += 1
+        break
+      case '--output-dir':
+        opts.outputDir = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
+        i += 1
+        break
+      case '--date':
+        opts.date = readRequiredValue(argv, i, arg).trim()
+        i += 1
+        break
+      case '--development-md':
+        opts.developmentMd = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
+        i += 1
+        break
+      case '--verification-md':
+        opts.verificationMd = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
+        i += 1
+        break
+      case '--require-release-ready':
+        opts.requireReleaseReady = true
+        break
+      case '--help':
+        printHelp()
+        process.exit(0)
+        break
+      default:
+        throw new Error(`Unknown argument: ${arg}`)
+    }
+  }
+
+  if (!opts.sessionDir) throw new Error('--session-dir is required')
+  if (!opts.handoffSummary) throw new Error('--handoff-summary is required')
+  if (!/^\d{8}$/.test(opts.date)) throw new Error('--date must be formatted as yyyymmdd')
+  opts.statusSummary ||= path.join(opts.sessionDir, 'smoke-status.json')
+  opts.compiledSummary ||= path.join(opts.sessionDir, 'compiled', 'summary.json')
+  opts.developmentMd ||= path.join(opts.outputDir, `dingtalk-final-remote-smoke-development-${opts.date}.md`)
+  opts.verificationMd ||= path.join(opts.outputDir, `dingtalk-final-remote-smoke-verification-${opts.date}.md`)
+  return opts
+}
+
+function relativePath(file) {
+  return path.relative(process.cwd(), file).replaceAll('\\', '/')
+}
+
+function assertFile(file, label) {
+  if (!existsSync(file) || !statSync(file).isFile()) {
+    throw new Error(`${label} does not exist or is not a file: ${relativePath(file)}`)
+  }
+}
+
+function readJson(file, label) {
+  assertFile(file, label)
+  try {
+    return JSON.parse(readFileSync(file, 'utf8'))
+  } catch (error) {
+    throw new Error(`${label} is not valid JSON: ${error instanceof Error ? error.message : String(error)}`)
+  }
+}
+
+function redactString(value) {
+  return String(value ?? '')
+    .replace(/(access_token=)[^&\s)]+/gi, '$1<redacted>')
+    .replace(/(publicToken=)[^&\s)]+/gi, '$1<redacted>')
+    .replace(/([?&](?:sign|timestamp)=)[^&\s)]+/gi, '$1<redacted>')
+    .replace(/((?:client_secret|DINGTALK_CLIENT_SECRET|DINGTALK_STATE_SECRET)=)[^\s&]+/gi, '$1<redacted>')
+    .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]+/gi, 'Bearer <redacted>')
+    .replace(/\bSEC[A-Za-z0-9+/=_-]{8,}\b/g, 'SEC<redacted>')
+    .replace(/\beyJ[A-Za-z0-9._-]{20,}\b/g, '<jwt:redacted>')
+}
+
+function markdownEscape(value) {
+  return redactString(value).replaceAll('|', '\\|').replaceAll('\n', '<br>')
+}
+
+function statusOf(value) {
+  return typeof value === 'string' && value.trim() ? value.trim() : 'not_available'
+}
+
+function requiredChecks(statusSummary, compiledSummary) {
+  const fromStatus = Array.isArray(statusSummary?.requiredChecks) ? statusSummary.requiredChecks : []
+  const fromCompiled = Array.isArray(compiledSummary?.requiredChecks) ? compiledSummary.requiredChecks : []
+  const byId = new Map([...fromCompiled, ...fromStatus]
+    .filter((check) => check && typeof check.id === 'string')
+    .map((check) => [check.id, check]))
+
+  return REQUIRED_CHECK_IDS.map((id) => {
+    const check = byId.get(id) ?? {}
+    return {
+      id,
+      status: statusOf(check.status),
+      source: statusOf(check.source ?? check.evidence?.source),
+      manualEvidenceIssueCount: Number.isFinite(check.manualEvidenceIssueCount) ? check.manualEvidenceIssueCount : 0,
+    }
+  })
+}
+
+function buildModel(opts) {
+  const sessionSummary = readJson(path.join(opts.sessionDir, 'session-summary.json'), 'session summary')
+  const statusSummary = readJson(opts.statusSummary, 'smoke status summary')
+  const compiledSummary = readJson(opts.compiledSummary, 'compiled summary')
+  const handoffSummary = readJson(opts.handoffSummary, 'handoff summary')
+  const checks = requiredChecks(statusSummary, compiledSummary)
+  const packetDir = handoffSummary.outputDir
+    ? handoffSummary.outputDir
+    : relativePath(path.dirname(opts.handoffSummary))
+  const publishStatus = handoffSummary.publishCheck?.status ?? statusSummary.handoff?.publishStatus ?? 'not_available'
+  const handoffStatus = handoffSummary.status ?? statusSummary.handoff?.status ?? 'not_available'
+  const secretFindingCount = Array.isArray(handoffSummary.publishCheck?.secretFindings)
+    ? handoffSummary.publishCheck.secretFindings.length
+    : statusSummary.handoff?.secretFindingCount ?? 0
+
+  return {
+    date: opts.date,
+    generatedAt: new Date().toISOString(),
+    sessionDir: relativePath(opts.sessionDir),
+    packetDir: redactString(packetDir),
+    handoffSummary: relativePath(opts.handoffSummary),
+    statusSummary: relativePath(opts.statusSummary),
+    compiledSummary: relativePath(opts.compiledSummary),
+    sessionPhase: statusOf(sessionSummary.sessionPhase),
+    sessionStatus: statusOf(sessionSummary.overallStatus),
+    finalStrictStatus: statusOf(sessionSummary.finalStrictStatus),
+    compiledStatus: statusOf(compiledSummary.overallStatus),
+    smokeStatus: statusOf(statusSummary.overallStatus),
+    apiBootstrapStatus: statusOf(compiledSummary.apiBootstrapStatus),
+    remoteClientStatus: statusOf(compiledSummary.remoteClientStatus),
+    handoffStatus: statusOf(handoffStatus),
+    publishStatus: statusOf(publishStatus),
+    secretFindingCount,
+    requiredChecks: checks,
+    totals: {
+      requiredChecks: checks.length,
+      passedChecks: checks.filter((check) => check.status === 'pass').length,
+      remainingChecks: checks.filter((check) => check.status !== 'pass').length,
+      manualEvidenceIssues: checks.reduce((total, check) => total + check.manualEvidenceIssueCount, 0),
+    },
+    failures: [
+      ...(Array.isArray(handoffSummary.failures) ? handoffSummary.failures : []),
+      ...(Array.isArray(statusSummary.handoff?.failures) ? statusSummary.handoff.failures : []),
+    ].map((failure) => redactString(failure)),
+  }
+}
+
+function validateReleaseReady(model, requireReleaseReady) {
+  if (!requireReleaseReady) return
+  const failures = []
+  if (model.sessionPhase !== 'finalize') failures.push('sessionPhase is not finalize')
+  if (model.sessionStatus !== 'pass') failures.push('session overallStatus is not pass')
+  if (model.finalStrictStatus !== 'pass') failures.push('finalStrictStatus is not pass')
+  if (model.compiledStatus !== 'pass') failures.push('compiled summary overallStatus is not pass')
+  if (model.apiBootstrapStatus !== 'pass') failures.push('API bootstrap status is not pass')
+  if (model.remoteClientStatus !== 'pass') failures.push('remote client status is not pass')
+  if (model.smokeStatus !== 'release_ready') failures.push('smoke status is not release_ready')
+  if (model.handoffStatus !== 'pass') failures.push('handoff status is not pass')
+  if (model.publishStatus !== 'pass') failures.push('publish status is not pass')
+  if (model.totals.remainingChecks !== 0) failures.push('not all required checks passed')
+  if (model.totals.manualEvidenceIssues !== 0) failures.push('manual evidence issues remain')
+  if (model.secretFindingCount !== 0) failures.push('publish check reported secret findings')
+  if (model.failures.length !== 0) failures.push('handoff or status failures remain')
+  if (failures.length > 0) throw new Error(`release-ready final docs rejected: ${failures.join('; ')}`)
+}
+
+function renderCheckRows(model) {
+  return model.requiredChecks
+    .map((check) => `| \`${markdownEscape(check.id)}\` | ${markdownEscape(check.status)} | ${markdownEscape(check.source)} | ${check.manualEvidenceIssueCount} |`)
+    .join('\n')
+}
+
+function renderDevelopment(model) {
+  return `# DingTalk Final Remote Smoke Development
+
+- Date: ${model.date}
+- Generated at: ${model.generatedAt}
+- Session directory: \`${model.sessionDir}\`
+- Packet directory: \`${model.packetDir}\`
+- Status summary: \`${model.statusSummary}\`
+- Handoff summary: \`${model.handoffSummary}\`
+
+## Completed Work
+
+- Ran the P4 smoke session through final strict evidence compilation.
+- Collected API/bootstrap, DingTalk-client, and manual-admin evidence.
+- Exported the final gated evidence packet.
+- Ran the publish validator and release-ready status gate.
+
+## Final Status
+
+- Session phase: **${model.sessionPhase}**
+- Session status: **${model.sessionStatus}**
+- Final strict status: **${model.finalStrictStatus}**
+- Compiled status: **${model.compiledStatus}**
+- API bootstrap status: **${model.apiBootstrapStatus}**
+- Remote client status: **${model.remoteClientStatus}**
+- Smoke status: **${model.smokeStatus}**
+- Handoff status: **${model.handoffStatus}**
+- Publish status: **${model.publishStatus}**
+
+## Required Checks
+
+| Check | Status | Source | Manual Issues |
+| --- | --- | --- | --- |
+${renderCheckRows(model)}
+
+## Residual Risks
+
+- Manual screenshot truthfulness still depends on operator evidence quality.
+- Raw artifacts must remain restricted to the release team unless separately reviewed.
+- Do not publish this packet externally until the human release owner reviews the final artifacts.
+`
+}
+
+function renderVerification(model) {
+  const failures = model.failures.length
+    ? model.failures.map((failure) => `- ${markdownEscape(failure)}`).join('\n')
+    : '- None'
+
+  return `# DingTalk Final Remote Smoke Verification
+
+- Date: ${model.date}
+- Generated at: ${model.generatedAt}
+
+## Commands
+
+\`\`\`bash
+node scripts/ops/dingtalk-p4-smoke-status.mjs \\
+  --session-dir ${model.sessionDir} \\
+  --handoff-summary ${model.handoffSummary} \\
+  --require-release-ready
+
+node scripts/ops/validate-dingtalk-staging-evidence-packet.mjs \\
+  --packet-dir ${model.packetDir} \\
+  --output-json ${model.packetDir}/publish-check.json
+
+node scripts/ops/dingtalk-p4-final-docs.mjs \\
+  --session-dir ${model.sessionDir} \\
+  --handoff-summary ${model.handoffSummary} \\
+  --require-release-ready \\
+  --output-dir docs/development
+\`\`\`
+
+## Actual Results
+
+- Required checks passed: ${model.totals.passedChecks}/${model.totals.requiredChecks}
+- Remaining checks: ${model.totals.remainingChecks}
+- Manual evidence issues: ${model.totals.manualEvidenceIssues}
+- Secret findings: ${model.secretFindingCount}
+- Session status: **${model.sessionStatus}**
+- Final strict status: **${model.finalStrictStatus}**
+- Compiled status: **${model.compiledStatus}**
+- API bootstrap status: **${model.apiBootstrapStatus}**
+- Remote client status: **${model.remoteClientStatus}**
+- Smoke status: **${model.smokeStatus}**
+- Handoff status: **${model.handoffStatus}**
+- Publish status: **${model.publishStatus}**
+
+## Required Checks
+
+| Check | Status | Source | Manual Issues |
+| --- | --- | --- | --- |
+${renderCheckRows(model)}
+
+## Failures
+
+${failures}
+
+## Evidence Hygiene
+
+- This report is generated from redacted summaries and does not include raw tokens, full webhooks, cookies, public form tokens, or temporary passwords.
+- Final raw artifacts still require human review before external sharing.
+`
+}
+
+function assertNoSecrets(text, label) {
+  for (const pattern of SECRET_PATTERNS) {
+    if (pattern.test(text)) throw new Error(`${label} contains secret-like value`)
+  }
+}
+
+function writeOutputs(opts, model) {
+  const development = renderDevelopment(model)
+  const verification = renderVerification(model)
+  assertNoSecrets(development, 'development markdown')
+  assertNoSecrets(verification, 'verification markdown')
+  mkdirSync(path.dirname(opts.developmentMd), { recursive: true })
+  mkdirSync(path.dirname(opts.verificationMd), { recursive: true })
+  writeFileSync(opts.developmentMd, development, 'utf8')
+  writeFileSync(opts.verificationMd, verification, 'utf8')
+  console.log(`Wrote ${relativePath(opts.developmentMd)}`)
+  console.log(`Wrote ${relativePath(opts.verificationMd)}`)
+}
+
+try {
+  const opts = parseArgs(process.argv.slice(2))
+  const model = buildModel(opts)
+  validateReleaseReady(model, opts.requireReleaseReady)
+  writeOutputs(opts, model)
+} catch (error) {
+  console.error(`[dingtalk-p4-final-docs] ERROR: ${redactString(error instanceof Error ? error.message : String(error))}`)
+  process.exit(1)
+}

--- a/scripts/ops/dingtalk-p4-final-docs.test.mjs
+++ b/scripts/ops/dingtalk-p4-final-docs.test.mjs
@@ -1,0 +1,229 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const scriptPath = path.join(repoRoot, 'scripts', 'ops', 'dingtalk-p4-final-docs.mjs')
+const requiredCheckIds = [
+  'create-table-form',
+  'bind-two-dingtalk-groups',
+  'set-form-dingtalk-granted',
+  'send-group-message-form-link',
+  'authorized-user-submit',
+  'unauthorized-user-denied',
+  'delivery-history-group-person',
+  'no-email-user-create-bind',
+]
+
+function makeTmpDir() {
+  return mkdtempSync(path.join(tmpdir(), 'dingtalk-p4-final-docs-'))
+}
+
+function writeJson(file, value) {
+  mkdirSync(path.dirname(file), { recursive: true })
+  writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`, 'utf8')
+}
+
+function deepMerge(base, overrides) {
+  if (!overrides || typeof overrides !== 'object' || Array.isArray(overrides)) return base
+  const next = { ...base }
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value && typeof value === 'object' && !Array.isArray(value) && base[key] && typeof base[key] === 'object' && !Array.isArray(base[key])) {
+      next[key] = deepMerge(base[key], value)
+    } else {
+      next[key] = value
+    }
+  }
+  return next
+}
+
+function releaseReadyChecks() {
+  return requiredCheckIds.map((id) => ({
+    id,
+    status: 'pass',
+    source: id.includes('user') || id.includes('link') ? 'manual-client' : 'api-bootstrap',
+    manualEvidenceIssueCount: 0,
+  }))
+}
+
+function writeReleaseReadySession(rootDir, overrides = {}) {
+  const sessionDir = path.join(rootDir, '142-session')
+  const packetDir = path.join(rootDir, 'packet')
+  const checks = releaseReadyChecks()
+  const sessionSummary = deepMerge({
+    tool: 'dingtalk-p4-smoke-session',
+    runId: 'session-142',
+    sessionPhase: 'finalize',
+    overallStatus: 'pass',
+    finalStrictStatus: 'pass',
+    pendingChecks: [],
+    steps: [
+      { id: 'preflight', status: 'pass', exitCode: 0 },
+      { id: 'api-runner', status: 'pass', exitCode: 0 },
+      { id: 'compile', status: 'pass', exitCode: 0 },
+      { id: 'strict-compile', status: 'pass', exitCode: 0 },
+    ],
+  }, overrides.sessionSummary)
+  const compiledSummary = deepMerge({
+    tool: 'compile-dingtalk-p4-smoke-evidence',
+    overallStatus: 'pass',
+    apiBootstrapStatus: 'pass',
+    remoteClientStatus: 'pass',
+    requiredChecks: checks,
+    requiredChecksNotPassed: [],
+    manualEvidenceIssues: [],
+    failedChecks: [],
+    missingRequiredChecks: [],
+  }, overrides.compiledSummary)
+  const statusSummary = deepMerge({
+    tool: 'dingtalk-p4-smoke-status',
+    overallStatus: 'release_ready',
+    totals: {
+      requiredChecks: requiredCheckIds.length,
+      passedChecks: requiredCheckIds.length,
+      gaps: 0,
+    },
+    requiredChecks: checks,
+    handoff: {
+      status: 'pass',
+      publishStatus: 'pass',
+      secretFindingCount: 0,
+      failures: [],
+    },
+  }, overrides.statusSummary)
+  const handoffSummary = deepMerge({
+    tool: 'dingtalk-p4-final-handoff',
+    status: 'pass',
+    sessionDir,
+    outputDir: packetDir,
+    publishCheck: {
+      status: 'pass',
+      secretFindings: [],
+      failures: [],
+    },
+    failures: [],
+  }, overrides.handoffSummary)
+
+  writeJson(path.join(sessionDir, 'session-summary.json'), sessionSummary)
+  writeJson(path.join(sessionDir, 'compiled', 'summary.json'), compiledSummary)
+  writeJson(path.join(sessionDir, 'smoke-status.json'), statusSummary)
+  writeJson(path.join(packetDir, 'handoff-summary.json'), handoffSummary)
+
+  return {
+    sessionDir,
+    packetDir,
+    handoffSummary: path.join(packetDir, 'handoff-summary.json'),
+  }
+}
+
+function runScript(args) {
+  return spawnSync(process.execPath, [scriptPath, ...args], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  })
+}
+
+test('dingtalk-p4-final-docs generates release-ready development and verification notes', () => {
+  const tmpDir = makeTmpDir()
+
+  try {
+    const paths = writeReleaseReadySession(tmpDir)
+    const outputDir = path.join(tmpDir, 'docs')
+    const result = runScript([
+      '--session-dir', paths.sessionDir,
+      '--handoff-summary', paths.handoffSummary,
+      '--output-dir', outputDir,
+      '--date', '20260423',
+      '--require-release-ready',
+    ])
+
+    assert.equal(result.status, 0, result.stderr || result.stdout)
+    const developmentMd = path.join(outputDir, 'dingtalk-final-remote-smoke-development-20260423.md')
+    const verificationMd = path.join(outputDir, 'dingtalk-final-remote-smoke-verification-20260423.md')
+    assert.equal(existsSync(developmentMd), true)
+    assert.equal(existsSync(verificationMd), true)
+
+    const developmentText = readFileSync(developmentMd, 'utf8')
+    const verificationText = readFileSync(verificationMd, 'utf8')
+    assert.match(developmentText, /DingTalk Final Remote Smoke Development/)
+    assert.match(developmentText, /Smoke status: \*\*release_ready\*\*/)
+    assert.match(developmentText, /Compiled status: \*\*pass\*\*/)
+    assert.match(verificationText, /DingTalk Final Remote Smoke Verification/)
+    assert.match(verificationText, /dingtalk-p4-final-docs\.mjs/)
+    assert.match(verificationText, /Required checks passed: 8\/8/)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-p4-final-docs rejects non-release-ready sessions when required', () => {
+  const tmpDir = makeTmpDir()
+
+  try {
+    const paths = writeReleaseReadySession(tmpDir, {
+      statusSummary: {
+        overallStatus: 'handoff_pending',
+      },
+    })
+    const outputDir = path.join(tmpDir, 'docs')
+    const result = runScript([
+      '--session-dir', paths.sessionDir,
+      '--handoff-summary', paths.handoffSummary,
+      '--output-dir', outputDir,
+      '--date', '20260423',
+      '--require-release-ready',
+    ])
+
+    assert.equal(result.status, 1)
+    assert.match(result.stderr, /release-ready final docs rejected/)
+    assert.match(result.stderr, /smoke status is not release_ready/)
+    assert.equal(existsSync(path.join(outputDir, 'dingtalk-final-remote-smoke-development-20260423.md')), false)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-p4-final-docs redacts secret-like failure details before writing markdown', () => {
+  const tmpDir = makeTmpDir()
+  const rawWebhook = 'https://oapi.dingtalk.com/robot/send?access_token=0123456789abcdef0123456789abcdef'
+  const rawBearer = 'Bearer abcdefghijklmnopqrstuvwxyz1234567890'
+  const rawSecret = 'SECabcdefghijklmnop12345678'
+  const rawPublicToken = 'publicToken=abc1234567890xyz'
+
+  try {
+    const paths = writeReleaseReadySession(tmpDir, {
+      statusSummary: {
+        handoff: {
+          failures: [`status failure includes ${rawPublicToken}`],
+        },
+      },
+      handoffSummary: {
+        failures: [`handoff failure includes ${rawWebhook} ${rawBearer} ${rawSecret}`],
+      },
+    })
+    const outputDir = path.join(tmpDir, 'docs')
+    const result = runScript([
+      '--session-dir', paths.sessionDir,
+      '--handoff-summary', paths.handoffSummary,
+      '--output-dir', outputDir,
+      '--date', '20260423',
+    ])
+
+    assert.equal(result.status, 0, result.stderr || result.stdout)
+    const verificationText = readFileSync(path.join(outputDir, 'dingtalk-final-remote-smoke-verification-20260423.md'), 'utf8')
+    assert.doesNotMatch(verificationText, /0123456789abcdef0123456789abcdef/)
+    assert.doesNotMatch(verificationText, /abcdefghijklmnopqrstuvwxyz1234567890/)
+    assert.doesNotMatch(verificationText, /SECabcdefghijklmnop12345678/)
+    assert.doesNotMatch(verificationText, /abc1234567890xyz/)
+    assert.match(verificationText, /access_token=<redacted>/)
+    assert.match(verificationText, /Bearer <redacted>/)
+    assert.match(verificationText, /SEC<redacted>/)
+    assert.match(verificationText, /publicToken=<redacted>/)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary
- Add `scripts/ops/dingtalk-p4-final-docs.mjs` to generate final DingTalk P4 development and verification Markdown from release-ready smoke artifacts.
- Gate final docs behind session, compiled summary, smoke status, handoff, publish validation, required check, manual evidence, and secret-finding checks.
- Add offline node:test coverage plus development/verification notes and update the DingTalk P4 TODO plan.

## Verification
- `node --test scripts/ops/dingtalk-p4-final-docs.test.mjs`
- `node --test scripts/ops/dingtalk-p4-final-docs.test.mjs scripts/ops/dingtalk-p4-smoke-status.test.mjs scripts/ops/dingtalk-p4-offline-handoff.test.mjs scripts/ops/dingtalk-p4-final-handoff.test.mjs scripts/ops/validate-dingtalk-staging-evidence-packet.test.mjs`
- `git diff --check`

## Remote CI
- Phase 5 PR Validation (External Metrics Gate) #1878: success
- Attendance Gate Contract Matrix #1391: success
- Plugin System Tests #1968: success

## Notes
- This is local P4 tooling only; it does not call DingTalk or staging.
- Existing `node_modules` dirty files in the worktree are unrelated and were not staged.
- The remote parent stack branch for #1109 is no longer available as a base branch, so this PR is currently based on `main` while keeping a minimal 1-commit / 6-file diff.