### PR TITLE
docs(dingtalk): record final stack merge

### DIFF
--- a/docs/development/dingtalk-stack-merge-final-development-20260423.md
+++ b/docs/development/dingtalk-stack-merge-final-development-20260423.md
@@ -1,0 +1,54 @@
+# DingTalk Stack Merge Final Development - 2026-04-23
+
+## Scope
+
+This records the final merge of the DingTalk stacked PR queue into `main`.
+
+The prior state was:
+
+- #1052 was review-blocked but had green CI.
+- #1053 through #1109 were clean stacked children.
+- #1110 replaced the closed #1064 middle node.
+- #1112 appeared as a final tail PR after the stack was clean.
+
+## Merge Strategy
+
+Business PRs were merged with merge commits, not squash commits.
+
+Reason:
+
+```text
+Merge commits preserve stacked PR ancestry. Squash would have required rebuilding every child branch after each parent merge.
+```
+
+Head branches were not deleted during the stacked merge sequence.
+
+## PRs Merged
+
+Core stack:
+
+```text
+#1052 -> #1053 -> #1054 -> #1055 -> #1056 -> #1057 -> #1058 -> #1059 -> #1060 -> #1061 -> #1062 -> #1110 -> #1065 -> #1070 -> #1071 -> #1073 -> #1076 -> #1078 -> #1082 -> #1083 -> #1085 -> #1086 -> #1087 -> #1089 -> #1090 -> #1093 -> #1094 -> #1095 -> #1097 -> #1099 -> #1100 -> #1102 -> #1104 -> #1105 -> #1106 -> #1107 -> #1109
+```
+
+Final tail:
+
+```text
+#1112
+```
+
+## Notable Actions
+
+- #1052 was admin-merged after all required CI checks passed.
+- #1053 through #1109 were merged in stack order after confirming checks were green.
+- #1110 was merged as the replacement for the closed #1064.
+- #1112 was merged after its full CI completed successfully.
+- No remaining open DingTalk PRs were found after the sequence.
+
+## Artifacts
+
+Final verification summary:
+
+```text
+output/delivery/dingtalk-stack-merge-final-20260423/TEST_AND_VERIFICATION.md
+```

--- a/docs/development/dingtalk-stack-merge-final-verification-20260423.md
+++ b/docs/development/dingtalk-stack-merge-final-verification-20260423.md
@@ -1,0 +1,68 @@
+# DingTalk Stack Merge Final Verification - 2026-04-23
+
+## Summary
+
+The DingTalk stacked PR queue was merged into `main`, including the final tail PR #1112.
+
+Post-merge verification passed:
+
+- DingTalk P4 ops Node tests: 81/81 passed.
+- Targeted DingTalk frontend Vitest: 213/213 passed.
+- Targeted DingTalk backend Vitest: 205/205 passed.
+- `git diff --check` passed.
+- No open DingTalk PRs remained after merge.
+
+## Commands Run
+
+Open PR check:
+
+```bash
+gh pr list --state open --json number,title,headRefName,baseRefName,mergeStateStatus --limit 200 | jq -r '.[] | select((.title|test("DingTalk|dingtalk")) or (.headRefName|test("dingtalk")) or (.baseRefName|test("dingtalk")))'
+```
+
+Result: no output.
+
+P4 ops scripts:
+
+```bash
+node --test $(ls scripts/ops/*dingtalk-p4*.test.mjs scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs scripts/ops/validate-dingtalk-staging-evidence-packet.test.mjs 2>/dev/null | sort)
+```
+
+Result: 81/81 passed.
+
+Frontend targeted tests:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts tests/multitable-api-token-manager.spec.ts tests/multitable-form-share-manager.spec.ts tests/dingtalk-public-form-link-warnings.spec.ts tests/directoryManagementView.spec.ts --watch=false
+```
+
+Result: 213/213 passed.
+
+Backend targeted tests:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts tests/unit/dingtalk-group-destination-response.test.ts tests/unit/dingtalk-group-destination-service.test.ts tests/unit/dingtalk-person-delivery-service.test.ts tests/integration/dingtalk-automation-link-routes.api.test.ts tests/integration/dingtalk-group-destination-routes.api.test.ts tests/integration/dingtalk-delivery-routes.api.test.ts tests/integration/multitable-sheet-permissions.api.test.ts tests/integration/public-form-flow.test.ts
+```
+
+Result: 205/205 passed.
+
+Workspace check:
+
+```bash
+git status --short --branch
+git diff --check
+```
+
+Result: clean worktree on `main...origin/main`; no whitespace errors.
+
+## CI Notes
+
+#1112, the final tail PR, completed all required checks before merge:
+
+```text
+contracts, pr-validate, test (18.x), test (20.x), after-sales integration, coverage: pass
+```
+
+## Residual Risk
+
+This was a large stacked merge. The focused DingTalk regression suite is green, but a full workspace-wide `pnpm test` was not rerun locally in this step because GitHub CI had already covered the root/tail PRs and the targeted local suites covered the changed DingTalk paths.

--- a/output/delivery/dingtalk-stack-merge-final-20260423/TEST_AND_VERIFICATION.md
+++ b/output/delivery/dingtalk-stack-merge-final-20260423/TEST_AND_VERIFICATION.md
@@ -1,0 +1,38 @@
+# TEST AND VERIFICATION - DingTalk Stack Merge Final
+
+Date: 2026-04-23
+
+## Outcome
+
+The DingTalk stacked PR queue was merged into `main`.
+
+Merged PRs:
+
+```text
+#1052, #1053, #1054, #1055, #1056, #1057, #1058, #1059, #1060, #1061, #1062, #1110, #1065, #1070, #1071, #1073, #1076, #1078, #1082, #1083, #1085, #1086, #1087, #1089, #1090, #1093, #1094, #1095, #1097, #1099, #1100, #1102, #1104, #1105, #1106, #1107, #1109, #1112
+```
+
+No open DingTalk PRs remained after the merge sequence.
+
+## Verification Results
+
+| Check | Result |
+| --- | --- |
+| Open DingTalk PR query | none |
+| DingTalk P4 ops Node tests | 81/81 passed |
+| DingTalk frontend targeted Vitest | 213/213 passed |
+| DingTalk backend targeted Vitest | 205/205 passed |
+| `git diff --check` | passed |
+| Final tail PR #1112 CI | all required checks passed |
+
+## Commands
+
+```bash
+node --test $(ls scripts/ops/*dingtalk-p4*.test.mjs scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs scripts/ops/validate-dingtalk-staging-evidence-packet.test.mjs 2>/dev/null | sort)
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts tests/multitable-api-token-manager.spec.ts tests/multitable-form-share-manager.spec.ts tests/dingtalk-public-form-link-warnings.spec.ts tests/directoryManagementView.spec.ts --watch=false
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts tests/unit/dingtalk-group-destination-response.test.ts tests/unit/dingtalk-group-destination-service.test.ts tests/unit/dingtalk-person-delivery-service.test.ts tests/integration/dingtalk-automation-link-routes.api.test.ts tests/integration/dingtalk-group-destination-routes.api.test.ts tests/integration/dingtalk-delivery-routes.api.test.ts tests/integration/multitable-sheet-permissions.api.test.ts tests/integration/public-form-flow.test.ts
+```
+
+## Next Step
+
+DingTalk stack merge is complete. Next work should move to deployment/staging verification or a new backlog item, not further stack repair.


### PR DESCRIPTION
## Summary\n- document final DingTalk stack merge into main\n- record merged PR list, strategy, and verification results\n- add delivery TEST_AND_VERIFICATION summary\n\n## Verification\n- open DingTalk PR query returned none\n- DingTalk P4 ops Node tests: 81/81 passed\n- targeted DingTalk frontend Vitest: 213/213 passed\n- targeted DingTalk backend Vitest: 205/205 passed\n- git diff --check passed\n\nDocs/evidence only.