### PR TITLE
test(dingtalk): require P4 manual smoke targets

### DIFF
--- a/docs/development/dingtalk-feature-plan-and-todo-20260422.md
+++ b/docs/development/dingtalk-feature-plan-and-todo-20260422.md
@@ -89,6 +89,7 @@
 - [x] Add a P4 no-email admin evidence helper so manual-admin proof uses concrete artifact names and structured result fields.
 - [x] Add a final DingTalk development plan and TODO so remote smoke execution can be followed step-by-step.
 - [x] Add a P4 final remote-smoke docs generator so release-ready sessions produce final development and verification notes.
+- [x] Add a P4 manual target readiness gate so authorized, unauthorized, and no-email DingTalk validation targets are recorded before final smoke.
 - [ ] Remote smoke: create a table and form view.
 - [ ] Remote smoke: bind at least two DingTalk groups to the table.
 - [ ] Remote smoke: set the form to `dingtalk_granted`.

--- a/docs/development/dingtalk-final-development-plan-and-todo-20260423.md
+++ b/docs/development/dingtalk-final-development-plan-and-todo-20260423.md
@@ -41,6 +41,10 @@
 - [ ] Optional allowed member group ID
 - [ ] Optional person-message local user ID
 - [ ] Synced DingTalk account without matched local user for no-email admin check
+- [x] Tooling records manual target identities in preflight/session/evidence outputs:
+  - `DINGTALK_P4_AUTHORIZED_USER_ID`
+  - `DINGTALK_P4_UNAUTHORIZED_USER_ID`
+  - `DINGTALK_P4_NO_EMAIL_DINGTALK_EXTERNAL_ID`
 
 ## Remote Smoke Execution
 
@@ -57,6 +61,7 @@ node scripts/ops/dingtalk-p4-smoke-session.mjs \
 ```bash
 node scripts/ops/dingtalk-p4-smoke-session.mjs \
   --env-file output/dingtalk-p4-remote-smoke-session/dingtalk-p4.env \
+  --require-manual-targets \
   --output-dir output/dingtalk-p4-remote-smoke-session/142-session
 ```
 
@@ -68,6 +73,7 @@ node scripts/ops/dingtalk-p4-smoke-session.mjs \
   - `smoke-status.json`
   - `smoke-status.md`
   - `smoke-todo.md`
+  - manual targets are present in `preflight/preflight-summary.json`, `workspace/evidence.json`, and `session-summary.json`
 
 - [ ] Confirm API/bootstrap checks pass:
   - `create-table-form`

--- a/docs/development/dingtalk-p4-manual-target-readiness-development-20260423.md
+++ b/docs/development/dingtalk-p4-manual-target-readiness-development-20260423.md
@@ -1,0 +1,26 @@
+# DingTalk P4 Manual Target Readiness Development
+
+- Date: 2026-04-23
+- Branch: `codex/dingtalk-p4-release-gate-20260423`
+- Scope: local P4 smoke tooling only; no DingTalk or staging calls.
+
+## Completed Work
+
+- Added manual target inputs to the P4 preflight/session/remote-smoke tooling:
+  - `DINGTALK_P4_AUTHORIZED_USER_ID`
+  - `DINGTALK_P4_UNAUTHORIZED_USER_ID`
+  - `DINGTALK_P4_NO_EMAIL_DINGTALK_EXTERNAL_ID`
+- Added CLI flags:
+  - `--authorized-user`
+  - `--unauthorized-user`
+  - `--no-email-dingtalk-external-id`
+  - `--require-manual-targets` for preflight/session gating.
+- Updated generated env templates so operators fill the three manual validation targets before final remote smoke.
+- Wrote manual target context into `preflight-summary.json`, `session-summary.json`, `workspace/evidence.json`, and `manual-evidence-checklist.md`.
+- Updated P4 plan/TODO docs so final remote smoke uses `--require-manual-targets`.
+
+## Behavior
+
+- If `--require-manual-targets` is set, preflight fails when the unauthorized target or no-email DingTalk external target is missing.
+- If `DINGTALK_P4_AUTHORIZED_USER_ID` is blank, the first allowed user is used as the suggested authorized submit target.
+- The new fields are IDs only; credentials, webhooks, bearer tokens, temporary passwords, and public form tokens remain excluded from tracked outputs.

--- a/docs/development/dingtalk-p4-manual-target-readiness-verification-20260423.md
+++ b/docs/development/dingtalk-p4-manual-target-readiness-verification-20260423.md
@@ -1,0 +1,44 @@
+# DingTalk P4 Manual Target Readiness Verification
+
+- Date: 2026-04-23
+- Branch: `codex/dingtalk-p4-release-gate-20260423`
+
+## Commands Run
+
+```bash
+node --test \
+  scripts/ops/dingtalk-p4-smoke-preflight.test.mjs \
+  scripts/ops/dingtalk-p4-remote-smoke.test.mjs \
+  scripts/ops/dingtalk-p4-smoke-session.test.mjs
+
+node --test \
+  scripts/ops/dingtalk-p4-smoke-session.test.mjs \
+  scripts/ops/dingtalk-p4-smoke-status.test.mjs \
+  scripts/ops/dingtalk-p4-remote-smoke.test.mjs \
+  scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs \
+  scripts/ops/dingtalk-p4-evidence-record.test.mjs \
+  scripts/ops/dingtalk-p4-smoke-preflight.test.mjs \
+  scripts/ops/dingtalk-p4-offline-handoff.test.mjs \
+  scripts/ops/dingtalk-p4-final-handoff.test.mjs \
+  scripts/ops/validate-dingtalk-staging-evidence-packet.test.mjs \
+  scripts/ops/dingtalk-p4-final-docs.test.mjs
+
+git diff --check
+```
+
+## Results
+
+- Targeted preflight/remote-smoke/session tests: pass, 15 tests.
+- Full P4 ops regression suite: pass, 70 tests.
+- `git diff --check`: pass.
+
+## Covered Cases
+
+- Preflight passes with declared authorized, unauthorized, and no-email targets and writes them to the redacted summary.
+- `--require-manual-targets` fails preflight when mandatory manual targets are missing.
+- Remote smoke writes manual targets to `evidence.json` and the manual evidence checklist.
+- Smoke session env template includes the new target variables and passes them through child tools.
+
+## Broader Gates
+
+- Product/backend/frontend integration and build gates were not rerun in this local slice because the change is limited to local P4 ops scripts and documentation.

--- a/scripts/ops/dingtalk-p4-remote-smoke.mjs
+++ b/scripts/ops/dingtalk-p4-remote-smoke.mjs
@@ -95,6 +95,10 @@ Options:
   --group-a-secret <secret>        Optional DingTalk group A SEC... secret
   --group-b-secret <secret>        Optional DingTalk group B SEC... secret
   --person-user <id>               Optional local user for person-message smoke; repeatable
+  --authorized-user <id>           DingTalk-bound allowed local user for manual submit proof
+  --unauthorized-user <id>         DingTalk-bound non-allowlisted local user for denial proof
+  --no-email-dingtalk-external-id <id>
+                                  Synced DingTalk account without local user/email for admin proof
   --output-dir <dir>               Output directory, default ${DEFAULT_OUTPUT_ROOT}/<run-id>
   --timeout-ms <ms>                Per-request timeout, default 15000
   --skip-health                    Skip GET /health
@@ -111,7 +115,8 @@ Environment fallbacks:
   DINGTALK_P4_GROUP_A_SECRET, DINGTALK_GROUP_A_SECRET
   DINGTALK_P4_GROUP_B_SECRET, DINGTALK_GROUP_B_SECRET
   DINGTALK_P4_ALLOWED_USER_IDS, DINGTALK_P4_ALLOWED_MEMBER_GROUP_IDS
-  DINGTALK_P4_PERSON_USER_IDS
+  DINGTALK_P4_PERSON_USER_IDS, DINGTALK_P4_AUTHORIZED_USER_ID,
+  DINGTALK_P4_UNAUTHORIZED_USER_ID, DINGTALK_P4_NO_EMAIL_DINGTALK_EXTERNAL_ID
 `)
 }
 
@@ -160,6 +165,9 @@ function parseArgs(argv) {
     allowedUserIds: splitList(envValue('DINGTALK_P4_ALLOWED_USER_IDS', 'DINGTALK_P4_ALLOWED_USER_ID')),
     allowedMemberGroupIds: splitList(envValue('DINGTALK_P4_ALLOWED_MEMBER_GROUP_IDS', 'DINGTALK_P4_ALLOWED_MEMBER_GROUP_ID')),
     personUserIds: splitList(envValue('DINGTALK_P4_PERSON_USER_IDS', 'DINGTALK_P4_PERSON_USER_ID')),
+    authorizedUserId: envValue('DINGTALK_P4_AUTHORIZED_USER_ID'),
+    unauthorizedUserId: envValue('DINGTALK_P4_UNAUTHORIZED_USER_ID'),
+    noEmailDingTalkExternalId: envValue('DINGTALK_P4_NO_EMAIL_DINGTALK_EXTERNAL_ID'),
     outputDir: null,
     timeoutMs: 15_000,
     skipHealth: false,
@@ -208,6 +216,18 @@ function parseArgs(argv) {
         break
       case '--person-user':
         appendList(opts.personUserIds, readRequiredValue(argv, i, arg))
+        i += 1
+        break
+      case '--authorized-user':
+        opts.authorizedUserId = readRequiredValue(argv, i, arg).trim()
+        i += 1
+        break
+      case '--unauthorized-user':
+        opts.unauthorizedUserId = readRequiredValue(argv, i, arg).trim()
+        i += 1
+        break
+      case '--no-email-dingtalk-external-id':
+        opts.noEmailDingTalkExternalId = readRequiredValue(argv, i, arg).trim()
         i += 1
         break
       case '--output-dir':
@@ -344,6 +364,14 @@ function artifactDirForCheck(checkId) {
   return path.join('artifacts', checkId)
 }
 
+function manualTargets(opts) {
+  return {
+    authorizedUserId: opts.authorizedUserId || opts.allowedUserIds[0] || '',
+    unauthorizedUserId: opts.unauthorizedUserId || '',
+    noEmailDingTalkExternalId: opts.noEmailDingTalkExternalId || '',
+  }
+}
+
 function makeManualEvidenceSkeleton(checkId, notes, extra = {}) {
   const requirement = MANUAL_EVIDENCE_BY_ID.get(checkId)
   if (!requirement) {
@@ -352,6 +380,18 @@ function makeManualEvidenceSkeleton(checkId, notes, extra = {}) {
       ...extra,
     }
   }
+
+  const { adminEvidence: extraAdminEvidence, ...restExtra } = extra
+  const adminEvidence = checkId === 'no-email-user-create-bind'
+    ? {
+        emailWasBlank: null,
+        createdLocalUserId: '',
+        boundDingTalkExternalId: '',
+        accountLinkedAfterRefresh: null,
+        temporaryPasswordRedacted: true,
+        ...(extraAdminEvidence ?? {}),
+      }
+    : null
 
   return {
     source: requirement.source,
@@ -362,18 +402,8 @@ function makeManualEvidenceSkeleton(checkId, notes, extra = {}) {
     notes,
     instructions: `Required before strict pass: ${requirement.label}; place evidence files under ${artifactDirForCheck(checkId)}/ and reference them with relative paths.`,
     suggestedArtifacts: requirement.suggestedArtifacts ?? [],
-    ...(checkId === 'no-email-user-create-bind'
-      ? {
-          adminEvidence: {
-            emailWasBlank: null,
-            createdLocalUserId: '',
-            boundDingTalkExternalId: '',
-            accountLinkedAfterRefresh: null,
-            temporaryPasswordRedacted: true,
-          },
-        }
-      : {}),
-    ...extra,
+    ...(adminEvidence ? { adminEvidence } : {}),
+    ...restExtra,
   }
 }
 
@@ -397,6 +427,7 @@ function createEvidence(opts, runId) {
       apiBase: opts.apiBase,
       webBase: opts.webBase || '',
     },
+    manualTargets: manualTargets(opts),
     checks,
     artifacts: [],
   }
@@ -409,18 +440,40 @@ function setCheck(evidence, id, status, data) {
   check.evidence = sanitizeValue(data)
 }
 
-function pendingManualChecks(evidence) {
+function pendingManualChecks(evidence, opts) {
+  const targets = manualTargets(opts)
   setCheck(evidence, 'authorized-user-submit', 'pending', makeManualEvidenceSkeleton(
     'authorized-user-submit',
-    'Manual DingTalk-client validation required: open the group message as an allowed DingTalk-bound local user, sign in if prompted, submit, and verify a record was inserted.',
+    targets.authorizedUserId
+      ? `Manual DingTalk-client validation required: open the group message as allowed local user ${targets.authorizedUserId}, sign in if prompted, submit, and verify a record was inserted.`
+      : 'Manual DingTalk-client validation required: open the group message as an allowed DingTalk-bound local user, sign in if prompted, submit, and verify a record was inserted.',
+    {
+      manualTarget: {
+        authorizedUserId: targets.authorizedUserId,
+      },
+    },
   ))
   setCheck(evidence, 'unauthorized-user-denied', 'pending', makeManualEvidenceSkeleton(
     'unauthorized-user-denied',
-    'Manual DingTalk-client validation required: open the same form as a DingTalk-bound user outside the allowlist and verify access or submit is blocked with no record insert.',
+    targets.unauthorizedUserId
+      ? `Manual DingTalk-client validation required: open the same form as non-allowlisted local user ${targets.unauthorizedUserId} and verify access or submit is blocked with no record insert.`
+      : 'Manual DingTalk-client validation required: open the same form as a DingTalk-bound user outside the allowlist and verify access or submit is blocked with no record insert.',
+    {
+      manualTarget: {
+        unauthorizedUserId: targets.unauthorizedUserId,
+      },
+    },
   ))
   setCheck(evidence, 'no-email-user-create-bind', 'pending', makeManualEvidenceSkeleton(
     'no-email-user-create-bind',
-    'Manual admin validation required: create and bind a synced DingTalk account without email, confirm the onboarding packet is shown only in the result panel.',
+    targets.noEmailDingTalkExternalId
+      ? `Manual admin validation required: create and bind synced DingTalk account ${targets.noEmailDingTalkExternalId} without email, confirm the onboarding packet is shown only in the result panel.`
+      : 'Manual admin validation required: create and bind a synced DingTalk account without email, confirm the onboarding packet is shown only in the result panel.',
+    {
+      adminEvidence: {
+        targetDingTalkExternalId: targets.noEmailDingTalkExternalId,
+      },
+    },
   ))
 }
 
@@ -523,7 +576,23 @@ async function requestJson(opts, route, options = {}) {
   }
 }
 
-function renderManualEvidenceChecklist() {
+function markdownCell(value) {
+  return String(value ?? '').replaceAll('|', '\\|').replaceAll('\n', '<br>')
+}
+
+function renderManualTargets(evidence) {
+  const targets = evidence.manualTargets ?? {}
+  const rows = [
+    ['authorized-user-submit', 'allowed DingTalk-bound local user', targets.authorizedUserId || '<missing>'],
+    ['unauthorized-user-denied', 'non-allowlisted DingTalk-bound local user', targets.unauthorizedUserId || '<missing>'],
+    ['no-email-user-create-bind', 'synced DingTalk external account without local user/email', targets.noEmailDingTalkExternalId || '<missing>'],
+  ]
+  return rows
+    .map(([checkId, role, target]) => `| \`${checkId}\` | ${markdownCell(role)} | \`${markdownCell(target)}\` |`)
+    .join('\n')
+}
+
+function renderManualEvidenceChecklist(evidence) {
   const rows = MANUAL_EVIDENCE_REQUIREMENTS.map((requirement) => {
     const suggested = Array.isArray(requirement.suggestedArtifacts) && requirement.suggestedArtifacts.length
       ? requirement.suggestedArtifacts.map((artifact) => `\`${artifact}\``).join('<br>')
@@ -541,6 +610,12 @@ running strict compile.
 | Check ID | Required Source | What It Proves | Suggested Artifacts |
 | --- | --- | --- | --- |
 ${rows.join('\n')}
+
+## Manual Targets
+
+| Check ID | Target Role | Target ID |
+| --- | --- | --- |
+${renderManualTargets(evidence)}
 
 ## No-email Admin Evidence
 
@@ -576,7 +651,7 @@ function writeEvidenceWorkspace(outputDir, evidence) {
     mkdirSync(path.join(outputDir, artifactDirForCheck(requirement.id)), { recursive: true })
   }
   writeFileSync(evidencePath, `${JSON.stringify(sanitizeValue(evidence), null, 2)}\n`, 'utf8')
-  writeFileSync(checklistPath, renderManualEvidenceChecklist(), 'utf8')
+  writeFileSync(checklistPath, renderManualEvidenceChecklist(evidence), 'utf8')
   return evidencePath
 }
 
@@ -850,7 +925,7 @@ async function runSmoke(opts, evidence) {
     personUserCount: opts.personUserIds.length,
   })
 
-  pendingManualChecks(evidence)
+  pendingManualChecks(evidence, opts)
 }
 
 async function main() {

--- a/scripts/ops/dingtalk-p4-remote-smoke.test.mjs
+++ b/scripts/ops/dingtalk-p4-remote-smoke.test.mjs
@@ -283,6 +283,12 @@ test('dingtalk-p4-remote-smoke runs API chain, writes pending manual gates, and 
       'user_authorized',
       '--person-user',
       'user_person_bound',
+      '--authorized-user',
+      'user_authorized',
+      '--unauthorized-user',
+      'user_unauthorized',
+      '--no-email-dingtalk-external-id',
+      'dt_no_email_001',
       '--output-dir',
       outputDir,
     ])
@@ -309,6 +315,11 @@ test('dingtalk-p4-remote-smoke runs API chain, writes pending manual gates, and 
     assert.doesNotMatch(evidenceText, /public_token_should_not_leak/)
 
     const evidence = JSON.parse(evidenceText)
+    assert.deepEqual(evidence.manualTargets, {
+      authorizedUserId: 'user_authorized',
+      unauthorizedUserId: 'user_unauthorized',
+      noEmailDingTalkExternalId: 'dt_no_email_001',
+    })
     const byId = new Map(evidence.checks.map((check) => [check.id, check]))
     assert.equal(byId.get('create-table-form').status, 'pass')
     assert.equal(byId.get('bind-two-dingtalk-groups').status, 'pass')
@@ -322,7 +333,10 @@ test('dingtalk-p4-remote-smoke runs API chain, writes pending manual gates, and 
     assert.equal(byId.get('send-group-message-form-link').evidence.operator, '')
     assert.equal(byId.get('send-group-message-form-link').evidence.apiBootstrap.groupRuleDeliveryCount, 2)
     assert.equal(byId.get('authorized-user-submit').evidence.source, 'manual-client')
+    assert.equal(byId.get('authorized-user-submit').evidence.manualTarget.authorizedUserId, 'user_authorized')
+    assert.equal(byId.get('unauthorized-user-denied').evidence.manualTarget.unauthorizedUserId, 'user_unauthorized')
     assert.equal(byId.get('no-email-user-create-bind').evidence.source, 'manual-admin')
+    assert.equal(byId.get('no-email-user-create-bind').evidence.adminEvidence.targetDingTalkExternalId, 'dt_no_email_001')
     assert.deepEqual(
       byId.get('no-email-user-create-bind').evidence.suggestedArtifacts,
       [
@@ -337,6 +351,9 @@ test('dingtalk-p4-remote-smoke runs API chain, writes pending manual gates, and 
     const checklist = readFileSync(path.join(outputDir, 'manual-evidence-checklist.md'), 'utf8')
     assert.match(checklist, /manual-client/)
     assert.match(checklist, /manual-admin/)
+    assert.match(checklist, /Manual Targets/)
+    assert.match(checklist, /user_unauthorized/)
+    assert.match(checklist, /dt_no_email_001/)
     assert.match(checklist, /artifacts\/authorized-user-submit/)
     assert.match(checklist, /admin-create-bind-result\.png/)
     assert.match(checklist, /temporary password/)

--- a/scripts/ops/dingtalk-p4-smoke-preflight.mjs
+++ b/scripts/ops/dingtalk-p4-smoke-preflight.mjs
@@ -31,6 +31,11 @@ Options:
   --allowed-user <id>              Local user allowed to fill; repeatable
   --allowed-member-group <id>      Allowed local member group; repeatable
   --person-user <id>               Optional local user for person smoke; repeatable
+  --authorized-user <id>           DingTalk-bound allowed local user for manual submit proof
+  --unauthorized-user <id>         DingTalk-bound non-allowlisted local user for denial proof
+  --no-email-dingtalk-external-id <id>
+                                  Synced DingTalk account without local user/email for admin proof
+  --require-manual-targets         Fail if the three manual target IDs above are missing
   --output-dir <dir>               Output directory, default ${DEFAULT_OUTPUT_ROOT}/<run-id>
   --timeout-ms <ms>                API health timeout, default 10000
   --skip-api                       Skip GET /health
@@ -41,7 +46,8 @@ Environment fallbacks match dingtalk-p4-remote-smoke.mjs:
   DINGTALK_P4_GROUP_A_WEBHOOK, DINGTALK_P4_GROUP_B_WEBHOOK,
   DINGTALK_P4_GROUP_A_SECRET, DINGTALK_P4_GROUP_B_SECRET,
   DINGTALK_P4_ALLOWED_USER_IDS, DINGTALK_P4_ALLOWED_MEMBER_GROUP_IDS,
-  DINGTALK_P4_PERSON_USER_IDS
+  DINGTALK_P4_PERSON_USER_IDS, DINGTALK_P4_AUTHORIZED_USER_ID,
+  DINGTALK_P4_UNAUTHORIZED_USER_ID, DINGTALK_P4_NO_EMAIL_DINGTALK_EXTERNAL_ID
 `)
 }
 
@@ -128,6 +134,10 @@ function parseArgs(argv) {
     allowedUserIds: splitList(envValue(env, 'DINGTALK_P4_ALLOWED_USER_IDS', 'DINGTALK_P4_ALLOWED_USER_ID')),
     allowedMemberGroupIds: splitList(envValue(env, 'DINGTALK_P4_ALLOWED_MEMBER_GROUP_IDS', 'DINGTALK_P4_ALLOWED_MEMBER_GROUP_ID')),
     personUserIds: splitList(envValue(env, 'DINGTALK_P4_PERSON_USER_IDS', 'DINGTALK_P4_PERSON_USER_ID')),
+    authorizedUserId: envValue(env, 'DINGTALK_P4_AUTHORIZED_USER_ID'),
+    unauthorizedUserId: envValue(env, 'DINGTALK_P4_UNAUTHORIZED_USER_ID'),
+    noEmailDingTalkExternalId: envValue(env, 'DINGTALK_P4_NO_EMAIL_DINGTALK_EXTERNAL_ID'),
+    requireManualTargets: false,
     outputDir: null,
     timeoutMs: 10_000,
     skipApi: false,
@@ -178,6 +188,21 @@ function parseArgs(argv) {
       case '--person-user':
         appendList(opts.personUserIds, readRequiredValue(argv, i, arg))
         i += 1
+        break
+      case '--authorized-user':
+        opts.authorizedUserId = readRequiredValue(argv, i, arg).trim()
+        i += 1
+        break
+      case '--unauthorized-user':
+        opts.unauthorizedUserId = readRequiredValue(argv, i, arg).trim()
+        i += 1
+        break
+      case '--no-email-dingtalk-external-id':
+        opts.noEmailDingTalkExternalId = readRequiredValue(argv, i, arg).trim()
+        i += 1
+        break
+      case '--require-manual-targets':
+        opts.requireManualTargets = true
         break
       case '--output-dir':
         opts.outputDir = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
@@ -343,6 +368,36 @@ function validateAllowlist(opts, summary) {
   })
 }
 
+function manualTargets(opts) {
+  return {
+    authorizedUserId: opts.authorizedUserId || opts.allowedUserIds[0] || '',
+    unauthorizedUserId: opts.unauthorizedUserId || '',
+    noEmailDingTalkExternalId: opts.noEmailDingTalkExternalId || '',
+  }
+}
+
+function validateManualTargets(opts, summary) {
+  const targets = manualTargets(opts)
+  const missing = []
+  if (!targets.authorizedUserId) missing.push('authorized user')
+  if (!targets.unauthorizedUserId) missing.push('unauthorized user')
+  if (!targets.noEmailDingTalkExternalId) missing.push('no-email DingTalk external id')
+
+  addCheck(
+    summary,
+    'manual-targets-declared',
+    'Manual DingTalk-client/admin target identities are declared',
+    missing.length === 0 ? 'pass' : opts.requireManualTargets ? 'fail' : 'skipped',
+    {
+      ...targets,
+      missing,
+      notes: missing.length === 0
+        ? 'Manual evidence checklist can name each operator target.'
+        : 'Set manual target env values before final release smoke to avoid ambiguous screenshots.',
+    },
+  )
+}
+
 function validateLocalFiles(summary) {
   const missing = REQUIRED_LOCAL_FILES.filter((file) => !existsSync(path.resolve(process.cwd(), file)))
   addCheck(summary, 'local-tools-present', 'Remote-smoke docs and runner scripts are present', missing.length ? 'fail' : 'pass', {
@@ -447,6 +502,7 @@ async function runPreflight(opts) {
       allowedUserCount: 0,
       allowedMemberGroupCount: 0,
       personUserCount: 0,
+      manualTargets: {},
     },
     checks: [],
     overallStatus: 'fail',
@@ -458,6 +514,7 @@ async function runPreflight(opts) {
   validateWebhooks(opts, summary)
   validateSecrets(opts, summary)
   validateAllowlist(opts, summary)
+  validateManualTargets(opts, summary)
   await validateApiHealth(opts, summary)
 
   summary.environment = {
@@ -471,6 +528,7 @@ async function runPreflight(opts) {
     allowedUserCount: opts.allowedUserIds.length,
     allowedMemberGroupCount: opts.allowedMemberGroupIds.length,
     personUserCount: opts.personUserIds.length,
+    manualTargets: manualTargets(opts),
   }
   summary.overallStatus = hasFailure(summary) ? 'fail' : 'pass'
 

--- a/scripts/ops/dingtalk-p4-smoke-preflight.test.mjs
+++ b/scripts/ops/dingtalk-p4-smoke-preflight.test.mjs
@@ -100,6 +100,12 @@ test('dingtalk-p4-smoke-preflight passes with valid inputs and redacts secrets',
       'user_authorized',
       '--person-user',
       'user_person_bound',
+      '--authorized-user',
+      'user_authorized',
+      '--unauthorized-user',
+      'user_unauthorized',
+      '--no-email-dingtalk-external-id',
+      'dt_no_email_001',
       '--output-dir',
       outputDir,
     ])
@@ -129,10 +135,51 @@ test('dingtalk-p4-smoke-preflight passes with valid inputs and redacts secrets',
     assert.equal(byId.get('local-tools-present').status, 'pass')
     assert.equal(byId.get('api-health').status, 'pass')
     assert.equal(byId.get('person-smoke-input').status, 'pass')
+    assert.equal(byId.get('manual-targets-declared').status, 'pass')
     assert.equal(summary.environment.authTokenPresent, true)
     assert.equal(summary.environment.allowedUserCount, 1)
+    assert.deepEqual(summary.environment.manualTargets, {
+      authorizedUserId: 'user_authorized',
+      unauthorizedUserId: 'user_unauthorized',
+      noEmailDingTalkExternalId: 'dt_no_email_001',
+    })
   } finally {
     await server.close()
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-p4-smoke-preflight can require manual target identities', () => {
+  const tmpDir = makeTmpDir()
+  const outputDir = path.join(tmpDir, 'preflight')
+
+  try {
+    const result = runScript([
+      '--skip-api',
+      '--require-manual-targets',
+      '--api-base',
+      'http://127.0.0.1:8900',
+      '--web-base',
+      'https://metasheet.example.test',
+      '--auth-token',
+      'secret-admin-token',
+      '--group-a-webhook',
+      'https://oapi.dingtalk.com/robot/send?access_token=robot-secret-a',
+      '--group-b-webhook',
+      'https://oapi.dingtalk.com/robot/send?access_token=robot-secret-b',
+      '--allowed-user',
+      'user_authorized',
+      '--output-dir',
+      outputDir,
+    ])
+
+    assert.equal(result.status, 1)
+    const summary = JSON.parse(readFileSync(path.join(outputDir, 'preflight-summary.json'), 'utf8'))
+    const check = summary.checks.find((entry) => entry.id === 'manual-targets-declared')
+    assert.equal(summary.overallStatus, 'fail')
+    assert.equal(check.status, 'fail')
+    assert.deepEqual(check.details.missing, ['unauthorized user', 'no-email DingTalk external id'])
+  } finally {
     rmSync(tmpDir, { recursive: true, force: true })
   }
 })

--- a/scripts/ops/dingtalk-p4-smoke-session.mjs
+++ b/scripts/ops/dingtalk-p4-smoke-session.mjs
@@ -40,6 +40,11 @@ Options:
   --allowed-user <id>              Local user allowed to fill; repeatable
   --allowed-member-group <id>      Allowed local member group; repeatable
   --person-user <id>               Optional local user for person smoke; repeatable
+  --authorized-user <id>           DingTalk-bound allowed local user for manual submit proof
+  --unauthorized-user <id>         DingTalk-bound non-allowlisted local user for denial proof
+  --no-email-dingtalk-external-id <id>
+                                  Synced DingTalk account without local user/email for admin proof
+  --require-manual-targets         Fail preflight if manual target IDs are missing
   --output-dir <dir>               Session output directory, default ${DEFAULT_OUTPUT_ROOT}/<run-id>
   --timeout-ms <ms>                Per-request timeout for child tools, default 15000
   --skip-api                       Skip preflight GET /health only
@@ -58,7 +63,8 @@ Environment fallbacks:
   DINGTALK_P4_GROUP_A_SECRET, DINGTALK_GROUP_A_SECRET
   DINGTALK_P4_GROUP_B_SECRET, DINGTALK_GROUP_B_SECRET
   DINGTALK_P4_ALLOWED_USER_IDS, DINGTALK_P4_ALLOWED_MEMBER_GROUP_IDS
-  DINGTALK_P4_PERSON_USER_IDS
+  DINGTALK_P4_PERSON_USER_IDS, DINGTALK_P4_AUTHORIZED_USER_ID,
+  DINGTALK_P4_UNAUTHORIZED_USER_ID, DINGTALK_P4_NO_EMAIL_DINGTALK_EXTERNAL_ID
 `)
 }
 
@@ -147,12 +153,16 @@ function parseArgs(argv) {
     allowedUserIds: splitList(envValue(env, 'DINGTALK_P4_ALLOWED_USER_IDS', 'DINGTALK_P4_ALLOWED_USER_ID')),
     allowedMemberGroupIds: splitList(envValue(env, 'DINGTALK_P4_ALLOWED_MEMBER_GROUP_IDS', 'DINGTALK_P4_ALLOWED_MEMBER_GROUP_ID')),
     personUserIds: splitList(envValue(env, 'DINGTALK_P4_PERSON_USER_IDS', 'DINGTALK_P4_PERSON_USER_ID')),
+    authorizedUserId: envValue(env, 'DINGTALK_P4_AUTHORIZED_USER_ID'),
+    unauthorizedUserId: envValue(env, 'DINGTALK_P4_UNAUTHORIZED_USER_ID'),
+    noEmailDingTalkExternalId: envValue(env, 'DINGTALK_P4_NO_EMAIL_DINGTALK_EXTERNAL_ID'),
     outputDir: null,
     timeoutMs: 15_000,
     skipApi: false,
     skipHealth: false,
     skipTestSend: false,
     skipAutomationTestRun: false,
+    requireManualTargets: false,
     allowExternalArtifactRefs: false,
   }
 
@@ -210,6 +220,18 @@ function parseArgs(argv) {
         appendList(opts.personUserIds, readRequiredValue(argv, i, arg))
         i += 1
         break
+      case '--authorized-user':
+        opts.authorizedUserId = readRequiredValue(argv, i, arg).trim()
+        i += 1
+        break
+      case '--unauthorized-user':
+        opts.unauthorizedUserId = readRequiredValue(argv, i, arg).trim()
+        i += 1
+        break
+      case '--no-email-dingtalk-external-id':
+        opts.noEmailDingTalkExternalId = readRequiredValue(argv, i, arg).trim()
+        i += 1
+        break
       case '--output-dir':
         opts.outputDir = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
         i += 1
@@ -229,6 +251,9 @@ function parseArgs(argv) {
         break
       case '--skip-automation-test-run':
         opts.skipAutomationTestRun = true
+        break
+      case '--require-manual-targets':
+        opts.requireManualTargets = true
         break
       case '--allow-external-artifact-refs':
         opts.allowExternalArtifactRefs = true
@@ -279,6 +304,12 @@ DINGTALK_P4_ALLOWED_MEMBER_GROUP_IDS=
 
 # Optional local user IDs for direct DingTalk person-message delivery history.
 DINGTALK_P4_PERSON_USER_IDS=
+
+# Manual DingTalk-client/admin target identities for final screenshots.
+# If DINGTALK_P4_AUTHORIZED_USER_ID is blank, the first allowed user is used as the suggested authorized target.
+DINGTALK_P4_AUTHORIZED_USER_ID=
+DINGTALK_P4_UNAUTHORIZED_USER_ID=
+DINGTALK_P4_NO_EMAIL_DINGTALK_EXTERNAL_ID=
 `
 }
 
@@ -326,6 +357,17 @@ function buildChildEnv(opts) {
     DINGTALK_P4_ALLOWED_USER_IDS: opts.allowedUserIds.join(','),
     DINGTALK_P4_ALLOWED_MEMBER_GROUP_IDS: opts.allowedMemberGroupIds.join(','),
     DINGTALK_P4_PERSON_USER_IDS: opts.personUserIds.join(','),
+    DINGTALK_P4_AUTHORIZED_USER_ID: opts.authorizedUserId,
+    DINGTALK_P4_UNAUTHORIZED_USER_ID: opts.unauthorizedUserId,
+    DINGTALK_P4_NO_EMAIL_DINGTALK_EXTERNAL_ID: opts.noEmailDingTalkExternalId,
+  }
+}
+
+function manualTargets(opts) {
+  return {
+    authorizedUserId: opts.authorizedUserId || opts.allowedUserIds[0] || '',
+    unauthorizedUserId: opts.unauthorizedUserId || '',
+    noEmailDingTalkExternalId: opts.noEmailDingTalkExternalId || '',
   }
 }
 
@@ -587,6 +629,7 @@ function runSession(opts) {
     '--timeout-ms',
     String(opts.timeoutMs),
     ...(opts.skipApi ? ['--skip-api'] : []),
+    ...(opts.requireManualTargets ? ['--require-manual-targets'] : []),
   ]
   steps.push(runNodeStep('preflight', 'Validate P4 smoke inputs and backend health', preflightArgs[0], preflightArgs.slice(1), preflightDir, env))
 
@@ -628,6 +671,7 @@ function runSession(opts) {
     overallStatus: computeOverallStatus(steps, pendingChecks),
     sessionPhase: 'bootstrap',
     finalStrictStatus: 'not_run',
+    manualTargets: manualTargets(opts),
     steps,
     pendingChecks,
     nextCommands: [
@@ -701,6 +745,7 @@ function runFinalStrictCompile(opts) {
     overallStatus: strictPassed ? 'pass' : 'fail',
     sessionPhase: 'finalize',
     finalStrictStatus: strictPassed ? 'pass' : 'fail',
+    manualTargets: priorSummary?.manualTargets ?? manualTargets(opts),
     steps,
     pendingChecks,
     finalStrictSummary: compiledSummary

--- a/scripts/ops/dingtalk-p4-smoke-session.test.mjs
+++ b/scripts/ops/dingtalk-p4-smoke-session.test.mjs
@@ -315,6 +315,9 @@ test('dingtalk-p4-smoke-session writes an editable env template', () => {
     assert.match(content, /DINGTALK_P4_AUTH_TOKEN=/)
     assert.match(content, /DINGTALK_P4_GROUP_A_WEBHOOK=/)
     assert.match(content, /DINGTALK_P4_ALLOWED_USER_IDS=/)
+    assert.match(content, /DINGTALK_P4_AUTHORIZED_USER_ID=/)
+    assert.match(content, /DINGTALK_P4_UNAUTHORIZED_USER_ID=/)
+    assert.match(content, /DINGTALK_P4_NO_EMAIL_DINGTALK_EXTERNAL_ID=/)
     assert.doesNotMatch(content, /secret-admin-token/)
     assert.equal(existsSync(path.join(tmpDir, 'session-summary.json')), false)
   } finally {
@@ -339,6 +342,9 @@ test('dingtalk-p4-smoke-session runs preflight, API runner, and non-strict compi
       'DINGTALK_P4_GROUP_A_SECRET=SECabcdefghijklmnop12345678',
       'DINGTALK_P4_ALLOWED_USER_IDS=user_authorized',
       'DINGTALK_P4_PERSON_USER_IDS=user_person_bound',
+      'DINGTALK_P4_AUTHORIZED_USER_ID=user_authorized',
+      'DINGTALK_P4_UNAUTHORIZED_USER_ID=user_unauthorized',
+      'DINGTALK_P4_NO_EMAIL_DINGTALK_EXTERNAL_ID=dt_no_email_001',
     ].join('\n'), 'utf8')
 
     const result = await runScript([
@@ -367,6 +373,11 @@ test('dingtalk-p4-smoke-session runs preflight, API runner, and non-strict compi
     assert.equal(sessionSummary.overallStatus, 'manual_pending')
     assert.equal(sessionSummary.sessionPhase, 'bootstrap')
     assert.equal(sessionSummary.finalStrictStatus, 'not_run')
+    assert.deepEqual(sessionSummary.manualTargets, {
+      authorizedUserId: 'user_authorized',
+      unauthorizedUserId: 'user_unauthorized',
+      noEmailDingTalkExternalId: 'dt_no_email_001',
+    })
     assert.deepEqual(sessionSummary.steps.map((step) => step.id), ['preflight', 'api-runner', 'compile', 'status-report'])
     assert.equal(sessionSummary.steps.every((step) => step.status === 'pass'), true)
     assert.equal(sessionSummary.statusReport.status, 'pass')
@@ -381,6 +392,11 @@ test('dingtalk-p4-smoke-session runs preflight, API runner, and non-strict compi
     const compiledSummary = JSON.parse(readFileSync(path.join(outputDir, 'compiled/summary.json'), 'utf8'))
     assert.equal(compiledSummary.overallStatus, 'fail')
     assert.equal(compiledSummary.remoteClientStatus, 'fail')
+    const evidence = JSON.parse(readFileSync(path.join(outputDir, 'workspace/evidence.json'), 'utf8'))
+    assert.equal(evidence.manualTargets.unauthorizedUserId, 'user_unauthorized')
+    assert.equal(evidence.manualTargets.noEmailDingTalkExternalId, 'dt_no_email_001')
+    const preflightSummary = JSON.parse(readFileSync(path.join(outputDir, 'preflight/preflight-summary.json'), 'utf8'))
+    assert.equal(preflightSummary.checks.find((check) => check.id === 'manual-targets-declared').status, 'pass')
     assert.equal(fakeApi.requests.some((request) => request.pathname === '/health'), true)
     assert.equal(fakeApi.requests.some((request) => request.pathname.endsWith('/dingtalk-person-deliveries')), true)
   } finally {


### PR DESCRIPTION
## Summary
- Add P4 manual target inputs for authorized submit, unauthorized denial, and no-email DingTalk admin validation.
- Thread the target IDs through preflight, smoke session env/template, remote-smoke evidence, and manual checklist outputs.
- Add `--require-manual-targets` so final remote smoke sessions can fail early before ambiguous manual screenshots are collected.
- Update DingTalk P4 plan/TODO plus development and verification notes.

## Verification
- `node --test scripts/ops/dingtalk-p4-smoke-preflight.test.mjs scripts/ops/dingtalk-p4-remote-smoke.test.mjs scripts/ops/dingtalk-p4-smoke-session.test.mjs`
- `node --test scripts/ops/dingtalk-p4-smoke-session.test.mjs scripts/ops/dingtalk-p4-smoke-status.test.mjs scripts/ops/dingtalk-p4-remote-smoke.test.mjs scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs scripts/ops/dingtalk-p4-evidence-record.test.mjs scripts/ops/dingtalk-p4-smoke-preflight.test.mjs scripts/ops/dingtalk-p4-offline-handoff.test.mjs scripts/ops/dingtalk-p4-final-handoff.test.mjs scripts/ops/validate-dingtalk-staging-evidence-packet.test.mjs scripts/ops/dingtalk-p4-final-docs.test.mjs`
- `git diff --check`

## Remote CI
- Phase 5 PR Validation (External Metrics Gate) #1880: success
- Attendance Gate Contract Matrix #1394: success
- Plugin System Tests #1971: success

## Notes
- Local P4 tooling only; no DingTalk/staging calls were made.
- The new target values are operator/user IDs, not credentials. Tokens, webhooks, public form tokens, cookies, and temporary passwords remain excluded from generated reports.