### PR TITLE
test(dingtalk): add P4 regression gate runner

### DIFF
--- a/docs/development/dingtalk-feature-plan-and-todo-20260422.md
+++ b/docs/development/dingtalk-feature-plan-and-todo-20260422.md
@@ -90,6 +90,7 @@
 - [x] Add a final DingTalk development plan and TODO so remote smoke execution can be followed step-by-step.
 - [x] Add a P4 final remote-smoke docs generator so release-ready sessions produce final development and verification notes.
 - [x] Add a P4 manual target readiness gate so authorized, unauthorized, and no-email DingTalk validation targets are recorded before final smoke.
+- [x] Add a P4 local regression gate runner so ops/product verification commands produce JSON/MD evidence before final remote smoke.
 - [ ] Remote smoke: create a table and form view.
 - [ ] Remote smoke: bind at least two DingTalk groups to the table.
 - [ ] Remote smoke: set the form to `dingtalk_granted`.

--- a/docs/development/dingtalk-final-development-plan-and-todo-20260423.md
+++ b/docs/development/dingtalk-final-development-plan-and-todo-20260423.md
@@ -18,6 +18,7 @@
 - [x] No-email local user create-and-bind
 - [x] Delivery history for group/person sends
 - [x] P4 smoke session, evidence recorder, status TODO, strict finalization, handoff packet, and publish validation
+- [x] P4 local regression gate runner with redacted JSON/MD output for ops/product verification evidence
 
 ## PR Stack To Confirm
 
@@ -177,25 +178,29 @@ node scripts/ops/dingtalk-p4-smoke-status.mjs \
 
 ## Local Regression Gates
 
-- [ ] `node --test scripts/ops/dingtalk-p4-smoke-session.test.mjs`
-- [ ] `node --test scripts/ops/dingtalk-p4-smoke-status.test.mjs`
-- [ ] `node --test scripts/ops/dingtalk-p4-remote-smoke.test.mjs`
-- [ ] `node --test scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs`
-- [ ] `node --test scripts/ops/dingtalk-p4-evidence-record.test.mjs`
-- [ ] `node --test scripts/ops/dingtalk-p4-offline-handoff.test.mjs scripts/ops/dingtalk-p4-final-handoff.test.mjs scripts/ops/validate-dingtalk-staging-evidence-packet.test.mjs`
-- [ ] `git diff --check`
+- [x] Add one-command local regression gate with redacted JSON/MD reports:
+
+```bash
+node scripts/ops/dingtalk-p4-regression-gate.mjs \
+  --profile ops \
+  --output-dir output/dingtalk-p4-regression-gate/142-ops
+```
+
+- [ ] Run the ops profile before final remote smoke.
+- [ ] Attach or reference `output/dingtalk-p4-regression-gate/142-ops/summary.json` and `summary.md` in final verification notes.
 
 ## Product Regression Gates
 
-- [ ] `pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-automation-link-routes.api.test.ts --watch=false`
-- [ ] `pnpm --filter @metasheet/core-backend exec vitest run tests/integration/public-form-flow.test.ts --watch=false`
-- [ ] `pnpm --filter @metasheet/core-backend exec vitest run tests/integration/dingtalk-delivery-routes.api.test.ts --watch=false`
-- [ ] `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-group-destination-service.test.ts tests/unit/dingtalk-person-delivery-service.test.ts --watch=false`
-- [ ] `pnpm --filter @metasheet/web exec vitest run tests/multitable-api-token-manager.spec.ts --watch=false`
-- [ ] `pnpm --filter @metasheet/web exec vitest run tests/multitable-form-share-manager.spec.ts --watch=false`
-- [ ] `pnpm --filter @metasheet/web exec vitest run tests/multitable-client.spec.ts --watch=false`
-- [ ] `pnpm --filter @metasheet/core-backend build`
-- [ ] `pnpm --filter @metasheet/web build`
+- [ ] Run the product profile when dependency/runtime state is ready:
+
+```bash
+node scripts/ops/dingtalk-p4-regression-gate.mjs \
+  --profile product \
+  --output-dir output/dingtalk-p4-regression-gate/142-product
+```
+
+- [ ] Confirm `summary.json` has `overallStatus: "pass"`.
+- [ ] Review per-check logs under `logs/` if any product gate fails.
 
 ## Final Documentation Outputs
 

--- a/docs/development/dingtalk-p4-regression-gate-development-20260423.md
+++ b/docs/development/dingtalk-p4-regression-gate-development-20260423.md
@@ -1,0 +1,44 @@
+# DingTalk P4 Regression Gate Development
+
+- Date: 2026-04-23
+- Scope: local DingTalk P4 ops/product regression gate runner
+- Branch: `codex/dingtalk-p4-regression-gate-20260423`
+
+## Changes
+
+- Added `scripts/ops/dingtalk-p4-regression-gate.mjs`.
+- Added profile-based execution:
+  - `ops`: P4 smoke/session/status/evidence/handoff/docs tooling tests plus `git diff --check`.
+  - `product`: backend/frontend DingTalk regression tests and builds from the final plan.
+  - `all`: ops and product profiles together.
+- Added `--plan-only` so operators can generate a command plan without running long product checks.
+- Added redacted `summary.json`, `summary.md`, and per-check stdout/stderr logs under `output/dingtalk-p4-regression-gate/<run-id>/`.
+- Updated the DingTalk P4 TODO and final plan so final smoke can reference one regression-gate output instead of hand-copying command lists.
+
+## Rationale
+
+The remaining DingTalk work depends on real staging credentials and DingTalk client/admin evidence. Before that run, the local verification contract should be reproducible and auditable. A single regression gate gives operators one command per profile and produces evidence that can be attached to final remote smoke notes without leaking tokens.
+
+## Usage
+
+Plan only:
+
+```bash
+node scripts/ops/dingtalk-p4-regression-gate.mjs --profile ops --plan-only
+```
+
+Run ops checks:
+
+```bash
+node scripts/ops/dingtalk-p4-regression-gate.mjs \
+  --profile ops \
+  --output-dir output/dingtalk-p4-regression-gate/142-ops
+```
+
+Run product checks:
+
+```bash
+node scripts/ops/dingtalk-p4-regression-gate.mjs \
+  --profile product \
+  --output-dir output/dingtalk-p4-regression-gate/142-product
+```

--- a/docs/development/dingtalk-p4-regression-gate-verification-20260423.md
+++ b/docs/development/dingtalk-p4-regression-gate-verification-20260423.md
@@ -1,0 +1,31 @@
+# DingTalk P4 Regression Gate Verification
+
+- Date: 2026-04-23
+- Scope: local verification for the DingTalk P4 regression gate runner
+
+## Commands
+
+```bash
+node --test scripts/ops/dingtalk-p4-regression-gate.test.mjs
+node scripts/ops/dingtalk-p4-regression-gate.mjs --profile ops --plan-only --output-dir /tmp/dingtalk-p4-regression-plan
+node scripts/ops/dingtalk-p4-regression-gate.mjs --profile ops --output-dir /tmp/dingtalk-p4-regression-ops
+git diff --check
+```
+
+## Results
+
+- `node --test scripts/ops/dingtalk-p4-regression-gate.test.mjs`: passed, 4 tests.
+- `--profile ops --plan-only`: passed and wrote `/tmp/dingtalk-p4-regression-plan/summary.json`.
+- `--profile ops`: passed and wrote `/tmp/dingtalk-p4-regression-ops/summary.json`.
+- `git diff --check`: passed.
+
+## Expected Coverage
+
+- Ops profile plan writes `summary.json` and `summary.md` without executing checks.
+- Fast selftest profile executes a real child process and captures stdout/stderr logs.
+- Secret-like command output is redacted in both logs and summaries.
+- Invalid profile input fails with a clear public profile list.
+
+## Remote Scope
+
+This verification does not call DingTalk, staging, or PLM. The product profile is intentionally available as an operator command but was not required for this local tooling slice.

--- a/scripts/ops/dingtalk-p4-regression-gate.mjs
+++ b/scripts/ops/dingtalk-p4-regression-gate.mjs
@@ -1,0 +1,529 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
+import { spawnSync } from 'node:child_process'
+import path from 'node:path'
+
+const DEFAULT_OUTPUT_ROOT = 'output/dingtalk-p4-regression-gate'
+const SCHEMA_VERSION = 1
+
+const OPS_CHECKS = [
+  {
+    id: 'ops-regression-gate',
+    label: 'P4 regression gate runner',
+    command: ['node', '--test', 'scripts/ops/dingtalk-p4-regression-gate.test.mjs'],
+  },
+  {
+    id: 'ops-smoke-session',
+    label: 'P4 smoke session contract',
+    command: ['node', '--test', 'scripts/ops/dingtalk-p4-smoke-session.test.mjs'],
+  },
+  {
+    id: 'ops-smoke-status',
+    label: 'P4 smoke status and TODO reporter',
+    command: ['node', '--test', 'scripts/ops/dingtalk-p4-smoke-status.test.mjs'],
+  },
+  {
+    id: 'ops-remote-smoke',
+    label: 'P4 API-only remote smoke workspace',
+    command: ['node', '--test', 'scripts/ops/dingtalk-p4-remote-smoke.test.mjs'],
+  },
+  {
+    id: 'ops-smoke-preflight',
+    label: 'P4 remote smoke preflight',
+    command: ['node', '--test', 'scripts/ops/dingtalk-p4-smoke-preflight.test.mjs'],
+  },
+  {
+    id: 'ops-compile-evidence',
+    label: 'P4 evidence compiler',
+    command: ['node', '--test', 'scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs'],
+  },
+  {
+    id: 'ops-evidence-record',
+    label: 'P4 manual evidence recorder',
+    command: ['node', '--test', 'scripts/ops/dingtalk-p4-evidence-record.test.mjs'],
+  },
+  {
+    id: 'ops-handoff-packet',
+    label: 'P4 offline handoff and packet validation',
+    command: [
+      'node',
+      '--test',
+      'scripts/ops/dingtalk-p4-offline-handoff.test.mjs',
+      'scripts/ops/dingtalk-p4-final-handoff.test.mjs',
+      'scripts/ops/validate-dingtalk-staging-evidence-packet.test.mjs',
+    ],
+  },
+  {
+    id: 'ops-final-docs',
+    label: 'P4 final docs generator',
+    command: ['node', '--test', 'scripts/ops/dingtalk-p4-final-docs.test.mjs'],
+  },
+  {
+    id: 'ops-diff-check',
+    label: 'Git whitespace diff check',
+    command: ['git', 'diff', '--check'],
+  },
+]
+
+const PRODUCT_CHECKS = [
+  {
+    id: 'backend-automation-link-routes',
+    label: 'Backend DingTalk automation link routes',
+    command: [
+      'pnpm',
+      '--filter',
+      '@metasheet/core-backend',
+      'exec',
+      'vitest',
+      'run',
+      'tests/integration/dingtalk-automation-link-routes.api.test.ts',
+      '--watch=false',
+    ],
+  },
+  {
+    id: 'backend-public-form-flow',
+    label: 'Backend public form and DingTalk form flow',
+    command: [
+      'pnpm',
+      '--filter',
+      '@metasheet/core-backend',
+      'exec',
+      'vitest',
+      'run',
+      'tests/integration/public-form-flow.test.ts',
+      '--watch=false',
+    ],
+  },
+  {
+    id: 'backend-dingtalk-delivery-routes',
+    label: 'Backend DingTalk delivery routes',
+    command: [
+      'pnpm',
+      '--filter',
+      '@metasheet/core-backend',
+      'exec',
+      'vitest',
+      'run',
+      'tests/integration/dingtalk-delivery-routes.api.test.ts',
+      '--watch=false',
+    ],
+  },
+  {
+    id: 'backend-dingtalk-services',
+    label: 'Backend DingTalk group/person delivery services',
+    command: [
+      'pnpm',
+      '--filter',
+      '@metasheet/core-backend',
+      'exec',
+      'vitest',
+      'run',
+      'tests/unit/dingtalk-group-destination-service.test.ts',
+      'tests/unit/dingtalk-person-delivery-service.test.ts',
+      '--watch=false',
+    ],
+  },
+  {
+    id: 'web-api-token-manager',
+    label: 'Web API token manager DingTalk group binding UI',
+    command: [
+      'pnpm',
+      '--filter',
+      '@metasheet/web',
+      'exec',
+      'vitest',
+      'run',
+      'tests/multitable-api-token-manager.spec.ts',
+      '--watch=false',
+    ],
+  },
+  {
+    id: 'web-form-share-manager',
+    label: 'Web form share manager DingTalk access UI',
+    command: [
+      'pnpm',
+      '--filter',
+      '@metasheet/web',
+      'exec',
+      'vitest',
+      'run',
+      'tests/multitable-form-share-manager.spec.ts',
+      '--watch=false',
+    ],
+  },
+  {
+    id: 'web-multitable-client',
+    label: 'Web multitable client DingTalk form client coverage',
+    command: [
+      'pnpm',
+      '--filter',
+      '@metasheet/web',
+      'exec',
+      'vitest',
+      'run',
+      'tests/multitable-client.spec.ts',
+      '--watch=false',
+    ],
+  },
+  {
+    id: 'backend-build',
+    label: 'Backend build',
+    command: ['pnpm', '--filter', '@metasheet/core-backend', 'build'],
+  },
+  {
+    id: 'web-build',
+    label: 'Web build',
+    command: ['pnpm', '--filter', '@metasheet/web', 'build'],
+  },
+]
+
+const SELFTEST_CHECKS = [
+  {
+    id: 'selftest-pass',
+    label: 'Runner selftest pass',
+    command: ['node', '-e', "console.log('dingtalk-p4-regression-gate selftest ok')"],
+  },
+]
+
+const SELFTEST_SECRET_CHECKS = [
+  {
+    id: 'selftest-secret-redaction',
+    label: 'Runner selftest secret redaction',
+    command: [
+      'node',
+      '-e',
+      "console.log('Bearer abcdefghijklmnopqrstuvwxyz1234567890 access_token=0123456789abcdef0123456789abcdef SECabcdefghijklmnop12345678 publicToken=public-0123456789')",
+    ],
+  },
+]
+
+const PROFILES = new Map([
+  ['ops', OPS_CHECKS],
+  ['product', PRODUCT_CHECKS],
+  ['all', [...OPS_CHECKS, ...PRODUCT_CHECKS]],
+  ['selftest', SELFTEST_CHECKS],
+  ['selftest-secret', SELFTEST_SECRET_CHECKS],
+])
+
+const PUBLIC_PROFILES = ['ops', 'product', 'all']
+
+function printHelp() {
+  console.log(`Usage: node scripts/ops/dingtalk-p4-regression-gate.mjs [options]
+
+Runs or plans the local DingTalk P4 regression gate and writes redacted JSON/MD
+summaries. It does not call DingTalk or staging by itself; product checks only
+run when this command is explicitly executed with a non-plan profile.
+
+Options:
+  --profile <ops|product|all>   Check profile to run, default ops
+  --plan-only                   Write the selected command plan without executing checks
+  --output-dir <dir>            Output directory, default ${DEFAULT_OUTPUT_ROOT}/<run-id>
+  --summary-json <file>         Summary JSON path, default <output-dir>/summary.json
+  --summary-md <file>           Summary Markdown path, default <output-dir>/summary.md
+  --timeout-ms <ms>             Per-check timeout; default 0 means no timeout
+  --fail-fast                   Stop after the first failed check
+  --allow-failures              Exit 0 even if checks fail
+  --help                        Show this help
+`)
+}
+
+function readRequiredValue(argv, index, flag) {
+  const next = argv[index + 1]
+  if (!next || next.startsWith('--')) {
+    throw new Error(`${flag} requires a value`)
+  }
+  return next
+}
+
+function makeRunId() {
+  return `dingtalk-p4-regression-${new Date().toISOString().replace(/[:.]/g, '-').replace(/Z$/, 'Z')}`
+}
+
+function parsePositiveInteger(value, flag, { allowZero = false } = {}) {
+  if (!/^\d+$/.test(String(value))) {
+    throw new Error(`${flag} must be ${allowZero ? 'a non-negative' : 'a positive'} integer`)
+  }
+  const next = Number.parseInt(value, 10)
+  if (!allowZero && next <= 0) {
+    throw new Error(`${flag} must be a positive integer`)
+  }
+  return next
+}
+
+function parseArgs(argv) {
+  const opts = {
+    profile: 'ops',
+    planOnly: false,
+    outputDir: '',
+    summaryJson: '',
+    summaryMd: '',
+    timeoutMs: 0,
+    failFast: false,
+    allowFailures: false,
+  }
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    switch (arg) {
+      case '--profile':
+        opts.profile = readRequiredValue(argv, i, arg).trim()
+        i += 1
+        break
+      case '--plan-only':
+        opts.planOnly = true
+        break
+      case '--output-dir':
+        opts.outputDir = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
+        i += 1
+        break
+      case '--summary-json':
+        opts.summaryJson = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
+        i += 1
+        break
+      case '--summary-md':
+        opts.summaryMd = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
+        i += 1
+        break
+      case '--timeout-ms':
+        opts.timeoutMs = parsePositiveInteger(readRequiredValue(argv, i, arg), arg, { allowZero: true })
+        i += 1
+        break
+      case '--fail-fast':
+        opts.failFast = true
+        break
+      case '--allow-failures':
+        opts.allowFailures = true
+        break
+      case '--help':
+        printHelp()
+        process.exit(0)
+        break
+      default:
+        throw new Error(`Unknown argument: ${arg}`)
+    }
+  }
+
+  if (!PROFILES.has(opts.profile)) {
+    throw new Error(`--profile must be one of: ${PUBLIC_PROFILES.join(', ')}`)
+  }
+
+  if (!opts.outputDir) {
+    opts.outputDir = path.resolve(process.cwd(), DEFAULT_OUTPUT_ROOT, makeRunId())
+  }
+  opts.summaryJson ||= path.join(opts.outputDir, 'summary.json')
+  opts.summaryMd ||= path.join(opts.outputDir, 'summary.md')
+  return opts
+}
+
+function redactString(value) {
+  return String(value ?? '')
+    .replace(/(access_token=)[^&\s)]+/gi, '$1<redacted>')
+    .replace(/(publicToken=)[^&\s)]+/gi, '$1<redacted>')
+    .replace(/([?&](?:sign|timestamp)=)[^&\s)]+/gi, '$1<redacted>')
+    .replace(/((?:client_secret|DINGTALK_CLIENT_SECRET|DINGTALK_STATE_SECRET)=)[^\s&]+/gi, '$1<redacted>')
+    .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]+/gi, 'Bearer <redacted>')
+    .replace(/\bSEC[A-Za-z0-9+/=_-]{8,}\b/g, 'SEC<redacted>')
+    .replace(/\beyJ[A-Za-z0-9._-]{20,}\b/g, '<jwt:redacted>')
+}
+
+function sanitizeValue(value) {
+  if (value === null || value === undefined) return value
+  if (typeof value === 'string') return redactString(value)
+  if (typeof value === 'number' || typeof value === 'boolean') return value
+  if (Array.isArray(value)) return value.map((entry) => sanitizeValue(entry))
+  if (typeof value === 'object') {
+    const next = {}
+    for (const [key, entryValue] of Object.entries(value)) {
+      next[key] = sanitizeValue(entryValue)
+    }
+    return next
+  }
+  return value
+}
+
+function quoteShellArg(value) {
+  const text = String(value)
+  if (/^[A-Za-z0-9_./:@=+-]+$/.test(text)) return text
+  return `'${text.replaceAll("'", "'\\''")}'`
+}
+
+function commandText(command) {
+  return command.map((part) => quoteShellArg(part)).join(' ')
+}
+
+function relativePath(file) {
+  return path.relative(process.cwd(), file).replaceAll('\\', '/')
+}
+
+function ensureOutputDir(opts) {
+  mkdirSync(opts.outputDir, { recursive: true })
+  mkdirSync(path.join(opts.outputDir, 'logs'), { recursive: true })
+}
+
+function writeLog(opts, checkId, stream, content) {
+  const file = path.join(opts.outputDir, 'logs', `${checkId}.${stream}.log`)
+  writeFileSync(file, redactString(content), 'utf8')
+  return file
+}
+
+function compactText(value) {
+  const text = redactString(value ?? '').trim()
+  if (!text) return ''
+  return text.length > 1200 ? `${text.slice(0, 1197)}...` : text
+}
+
+function planCheck(check) {
+  return {
+    id: check.id,
+    label: check.label,
+    command: commandText(check.command),
+    status: 'skipped',
+    skippedReason: 'plan_only',
+    exitCode: null,
+    durationMs: 0,
+    stdoutLog: null,
+    stderrLog: null,
+    stdoutSample: '',
+    stderrSample: '',
+  }
+}
+
+function runCheck(opts, check) {
+  const startedAt = new Date().toISOString()
+  const startedMs = Date.now()
+  const [bin, ...args] = check.command
+  const result = spawnSync(bin, args, {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    timeout: opts.timeoutMs > 0 ? opts.timeoutMs : undefined,
+    maxBuffer: 20 * 1024 * 1024,
+  })
+  const finishedAt = new Date().toISOString()
+  const durationMs = Date.now() - startedMs
+  const timedOut = result.error?.code === 'ETIMEDOUT'
+  const exitCode = timedOut ? 124 : result.status ?? 1
+  const stdoutLog = writeLog(opts, check.id, 'stdout', result.stdout ?? '')
+  const stderrLog = writeLog(opts, check.id, 'stderr', result.stderr ?? String(result.error?.message ?? ''))
+
+  return {
+    id: check.id,
+    label: check.label,
+    command: commandText(check.command),
+    status: exitCode === 0 ? 'pass' : 'fail',
+    exitCode,
+    durationMs,
+    startedAt,
+    finishedAt,
+    timedOut,
+    stdoutLog: relativePath(stdoutLog),
+    stderrLog: relativePath(stderrLog),
+    stdoutSample: compactText(result.stdout),
+    stderrSample: compactText(result.stderr || result.error?.message || ''),
+  }
+}
+
+function buildTotals(checks) {
+  const totals = {
+    total: checks.length,
+    passed: checks.filter((check) => check.status === 'pass').length,
+    failed: checks.filter((check) => check.status === 'fail').length,
+    skipped: checks.filter((check) => check.status === 'skipped').length,
+  }
+  return totals
+}
+
+function renderMarkdown(summary) {
+  const lines = [
+    '# DingTalk P4 Regression Gate',
+    '',
+    `- Profile: \`${summary.profile}\``,
+    `- Overall status: **${summary.overallStatus}**`,
+    `- Plan only: \`${summary.planOnly}\``,
+    `- Started at: \`${summary.startedAt}\``,
+    `- Completed at: \`${summary.completedAt}\``,
+    `- Totals: ${summary.totals.passed} passed, ${summary.totals.failed} failed, ${summary.totals.skipped} skipped, ${summary.totals.total} total`,
+    '',
+    '## Checks',
+    '',
+    '| Check | Status | Exit | Duration | Command | Logs |',
+    '| --- | --- | ---: | ---: | --- | --- |',
+  ]
+
+  for (const check of summary.checks) {
+    const logs = check.stdoutLog
+      ? `[stdout](${check.stdoutLog}) / [stderr](${check.stderrLog})`
+      : check.skippedReason ?? ''
+    lines.push(`| \`${check.id}\` | ${check.status} | ${check.exitCode ?? ''} | ${check.durationMs}ms | \`${check.command.replaceAll('|', '\\|')}\` | ${logs} |`)
+  }
+
+  const failures = summary.checks.filter((check) => check.status === 'fail')
+  if (failures.length > 0) {
+    lines.push('')
+    lines.push('## Failures')
+    lines.push('')
+    for (const check of failures) {
+      const note = check.stderrSample || check.stdoutSample || 'No output captured.'
+      lines.push(`- \`${check.id}\`: ${note.replace(/\s+/g, ' ')}`)
+    }
+  }
+
+  return `${lines.join('\n')}\n`
+}
+
+function writeSummary(opts, summary) {
+  mkdirSync(path.dirname(opts.summaryJson), { recursive: true })
+  mkdirSync(path.dirname(opts.summaryMd), { recursive: true })
+  writeFileSync(opts.summaryJson, `${JSON.stringify(sanitizeValue(summary), null, 2)}\n`, 'utf8')
+  writeFileSync(opts.summaryMd, renderMarkdown(sanitizeValue(summary)), 'utf8')
+}
+
+function run(opts) {
+  ensureOutputDir(opts)
+  const startedAt = new Date().toISOString()
+  const selectedChecks = PROFILES.get(opts.profile)
+  const checks = []
+
+  for (const check of selectedChecks) {
+    if (opts.planOnly) {
+      checks.push(planCheck(check))
+      continue
+    }
+
+    const result = runCheck(opts, check)
+    checks.push(result)
+    if (result.status === 'fail' && opts.failFast) break
+  }
+
+  const totals = buildTotals(checks)
+  const overallStatus = opts.planOnly ? 'plan_only' : totals.failed > 0 ? 'fail' : 'pass'
+  const summary = {
+    tool: 'dingtalk-p4-regression-gate',
+    schemaVersion: SCHEMA_VERSION,
+    profile: opts.profile,
+    planOnly: opts.planOnly,
+    failFast: opts.failFast,
+    allowFailures: opts.allowFailures,
+    timeoutMs: opts.timeoutMs,
+    outputDir: relativePath(opts.outputDir),
+    summaryJson: relativePath(opts.summaryJson),
+    summaryMd: relativePath(opts.summaryMd),
+    startedAt,
+    completedAt: new Date().toISOString(),
+    overallStatus,
+    totals,
+    checks,
+  }
+
+  writeSummary(opts, summary)
+  console.log(`[dingtalk-p4-regression-gate] ${overallStatus}: ${relativePath(opts.summaryJson)}`)
+  return overallStatus === 'fail' && !opts.allowFailures ? 1 : 0
+}
+
+try {
+  const opts = parseArgs(process.argv.slice(2))
+  process.exit(run(opts))
+} catch (error) {
+  console.error(`[dingtalk-p4-regression-gate] ERROR: ${error instanceof Error ? error.message : String(error)}`)
+  process.exit(1)
+}

--- a/scripts/ops/dingtalk-p4-regression-gate.test.mjs
+++ b/scripts/ops/dingtalk-p4-regression-gate.test.mjs
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const scriptPath = path.join(repoRoot, 'scripts', 'ops', 'dingtalk-p4-regression-gate.mjs')
+
+function makeTmpDir() {
+  return mkdtempSync(path.join(tmpdir(), 'dingtalk-p4-regression-gate-'))
+}
+
+function runScript(args) {
+  return spawnSync(process.execPath, [scriptPath, ...args], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  })
+}
+
+function readJson(file) {
+  return JSON.parse(readFileSync(file, 'utf8'))
+}
+
+test('dingtalk-p4-regression-gate writes an ops plan without executing checks', () => {
+  const outputDir = makeTmpDir()
+
+  try {
+    const result = runScript([
+      '--profile', 'ops',
+      '--plan-only',
+      '--output-dir', outputDir,
+    ])
+
+    assert.equal(result.status, 0, result.stderr || result.stdout)
+    const summaryPath = path.join(outputDir, 'summary.json')
+    const markdownPath = path.join(outputDir, 'summary.md')
+    assert.equal(existsSync(summaryPath), true)
+    assert.equal(existsSync(markdownPath), true)
+
+    const summary = readJson(summaryPath)
+    assert.equal(summary.tool, 'dingtalk-p4-regression-gate')
+    assert.equal(summary.profile, 'ops')
+    assert.equal(summary.planOnly, true)
+    assert.equal(summary.overallStatus, 'plan_only')
+    assert.equal(summary.totals.total, 10)
+    assert.equal(summary.totals.skipped, 10)
+    assert.ok(summary.checks.every((check) => check.status === 'skipped'))
+    assert.ok(summary.checks.some((check) => check.command.includes('dingtalk-p4-smoke-session.test.mjs')))
+
+    const markdown = readFileSync(markdownPath, 'utf8')
+    assert.match(markdown, /DingTalk P4 Regression Gate/)
+    assert.match(markdown, /ops-smoke-session/)
+    assert.match(markdown, /plan_only/)
+  } finally {
+    rmSync(outputDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-p4-regression-gate executes fast selftest checks and captures logs', () => {
+  const outputDir = makeTmpDir()
+
+  try {
+    const result = runScript([
+      '--profile', 'selftest',
+      '--output-dir', outputDir,
+    ])
+
+    assert.equal(result.status, 0, result.stderr || result.stdout)
+    const summary = readJson(path.join(outputDir, 'summary.json'))
+    assert.equal(summary.overallStatus, 'pass')
+    assert.equal(summary.totals.passed, 1)
+    assert.equal(summary.checks[0].status, 'pass')
+    assert.equal(existsSync(path.join(repoRoot, summary.checks[0].stdoutLog)), true)
+
+    const stdout = readFileSync(path.join(repoRoot, summary.checks[0].stdoutLog), 'utf8')
+    assert.match(stdout, /selftest ok/)
+  } finally {
+    rmSync(outputDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-p4-regression-gate redacts secret-like output in logs and summaries', () => {
+  const outputDir = makeTmpDir()
+
+  try {
+    const result = runScript([
+      '--profile', 'selftest-secret',
+      '--output-dir', outputDir,
+    ])
+
+    assert.equal(result.status, 0, result.stderr || result.stdout)
+    const summaryText = readFileSync(path.join(outputDir, 'summary.json'), 'utf8')
+    const summary = JSON.parse(summaryText)
+    const stdout = readFileSync(path.join(repoRoot, summary.checks[0].stdoutLog), 'utf8')
+
+    assert.doesNotMatch(summaryText, /0123456789abcdef0123456789abcdef/)
+    assert.doesNotMatch(summaryText, /abcdefghijklmnopqrstuvwxyz1234567890/)
+    assert.doesNotMatch(summaryText, /SECabcdefghijklmnop12345678/)
+    assert.doesNotMatch(summaryText, /public-0123456789/)
+    assert.match(stdout, /Bearer <redacted>/)
+    assert.match(stdout, /access_token=<redacted>/)
+    assert.match(stdout, /SEC<redacted>/)
+    assert.match(stdout, /publicToken=<redacted>/)
+  } finally {
+    rmSync(outputDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-p4-regression-gate rejects invalid public profiles', () => {
+  const result = runScript(['--profile', 'bad'])
+
+  assert.notEqual(result.status, 0)
+  assert.match(result.stderr, /--profile must be one of: ops, product, all/)
+})


### PR DESCRIPTION
## Summary
- Add `scripts/ops/dingtalk-p4-regression-gate.mjs` for profile-based DingTalk P4 local regression gates.
- Support `ops`, `product`, and `all` profiles plus `--plan-only`, per-check logs, redacted `summary.json`, and `summary.md` outputs.
- Update DingTalk P4 plan/TODO docs and add development/verification notes for the new gate.

## Verification
- `node --test scripts/ops/dingtalk-p4-regression-gate.test.mjs` (4 tests passed)
- `node scripts/ops/dingtalk-p4-regression-gate.mjs --profile ops --plan-only --output-dir /tmp/dingtalk-p4-regression-plan`
- `node scripts/ops/dingtalk-p4-regression-gate.mjs --profile ops --output-dir /tmp/dingtalk-p4-regression-ops`
- `git diff --check`

## Remote CI
- Phase 5 PR Validation (External Metrics Gate) #1881: success
- Attendance Gate Contract Matrix #1395: success
- Plugin System Tests #1973: success

## Notes
- The product profile is implemented as an operator command but was not run in this local tooling slice.
- No DingTalk, staging, PLM, or token-generating calls were made.