### PR TITLE
chore(dingtalk): add P4 release readiness gate

### DIFF
--- a/docs/development/dingtalk-p4-release-readiness-development-20260423.md
+++ b/docs/development/dingtalk-p4-release-readiness-development-20260423.md
@@ -1,0 +1,59 @@
+# DingTalk P4 Release Readiness Development
+
+- Date: 2026-04-23
+- Branch: `codex/dingtalk-p4-release-readiness-20260423`
+- Scope: local release gate orchestration; no DingTalk or staging calls.
+
+## Completed Work
+
+- Added `scripts/ops/dingtalk-p4-release-readiness.mjs`.
+- The script combines:
+  - private env readiness via `dingtalk-p4-env-bootstrap.mjs --check`
+  - local regression gate via `dingtalk-p4-regression-gate.mjs`
+- It writes a single redacted go/no-go report:
+  - `release-readiness-summary.json`
+  - `release-readiness-summary.md`
+- The default flow uses:
+  - env file: `$HOME/.config/yuantus/dingtalk-p4-staging.env`
+  - regression profile: `ops`
+  - output root: `output/dingtalk-p4-release-readiness/<run-id>`
+- The final smoke command is printed only when both env readiness and regression gate pass.
+
+## Behavior
+
+- `overallStatus: "pass"` means the operator can start the final P4 smoke session with `--require-manual-targets`.
+- `overallStatus: "fail"` means at least one required gate failed; the final remote smoke should not be started.
+- `overallStatus: "manual_pending"` means env readiness passed but regression was intentionally plan-only.
+- `--allow-failures` preserves a zero process exit for report collection while keeping the summary status as `fail` or `manual_pending`.
+
+## Secret Handling
+
+- The release readiness report reuses redaction for:
+  - bearer tokens
+  - DingTalk robot access tokens
+  - SEC secrets
+  - JWTs
+  - public form tokens
+  - DingTalk webhook timestamps and signatures
+- The script stores only redacted child stdout/stderr and child summaries.
+
+## Operator Command
+
+```bash
+node scripts/ops/dingtalk-p4-release-readiness.mjs
+```
+
+For a full product-level pre-smoke gate:
+
+```bash
+node scripts/ops/dingtalk-p4-release-readiness.mjs \
+  --regression-profile all \
+  --timeout-ms 1200000
+```
+
+## Out Of Scope
+
+- No robot message send.
+- No table/form creation.
+- No manual DingTalk client evidence collection.
+- No final packet export.

--- a/docs/development/dingtalk-p4-release-readiness-verification-20260423.md
+++ b/docs/development/dingtalk-p4-release-readiness-verification-20260423.md
@@ -1,0 +1,50 @@
+# DingTalk P4 Release Readiness Verification
+
+- Date: 2026-04-23
+- Branch: `codex/dingtalk-p4-release-readiness-20260423`
+
+## Commands Run
+
+```bash
+node --test scripts/ops/dingtalk-p4-release-readiness.test.mjs
+
+node --test \
+  scripts/ops/dingtalk-p4-release-readiness.test.mjs \
+  scripts/ops/dingtalk-p4-env-bootstrap.test.mjs \
+  scripts/ops/dingtalk-p4-regression-gate.test.mjs
+
+node --test $(ls scripts/ops/*dingtalk-p4*.test.mjs scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs scripts/ops/validate-dingtalk-staging-evidence-packet.test.mjs 2>/dev/null | sort)
+
+node scripts/ops/dingtalk-p4-release-readiness.mjs \
+  --output-dir /tmp/dingtalk-p4-release-readiness-default \
+  --allow-failures
+
+git diff --check
+```
+
+## Results
+
+- Release readiness tests: pass, 5 tests.
+- Release readiness plus adjacent env/regression gate tests: pass, 13 tests.
+- Full DingTalk P4 ops regression suite: pass, 95 tests.
+- Default release readiness dry run: expected fail because private env is still a placeholder; env gate failed and ops regression passed.
+- `git diff --check`: pass.
+
+## Covered Cases
+
+- Env readiness failure blocks release readiness even when local regression passes.
+- Complete env plus passing regression returns `overallStatus: "pass"` and prints the final smoke command.
+- Regression plan-only mode returns `overallStatus: "manual_pending"`.
+- `--allow-failures` exits zero while preserving a failed summary for report collection.
+- Invalid public regression profiles are rejected.
+- Secret-like child output and summaries are redacted.
+
+## Real External Dependency Status
+
+- Real 142/staging DingTalk P4 smoke was not executed.
+- Current local private env remains a placeholder template unless the operator fills:
+  - admin/table-owner bearer token
+  - two DingTalk robot webhooks
+  - at least one allowed local user or member group
+  - unauthorized DingTalk-bound local user
+  - no-email DingTalk external account target

--- a/output/delivery/dingtalk-p4-release-readiness-20260423/TEST_AND_VERIFICATION.md
+++ b/output/delivery/dingtalk-p4-release-readiness-20260423/TEST_AND_VERIFICATION.md
@@ -1,0 +1,62 @@
+# TEST AND VERIFICATION - DingTalk P4 Release Readiness
+
+## Summary
+
+Added a local release-readiness gate that composes private env readiness and local P4 regression results into one go/no-go report before the final 142/staging DingTalk smoke.
+
+This does not replace the real smoke. It prevents starting that smoke when credentials, robot webhooks, manual target IDs, or local regression gates are not ready.
+
+## Files
+
+- `scripts/ops/dingtalk-p4-release-readiness.mjs`
+- `scripts/ops/dingtalk-p4-release-readiness.test.mjs`
+- `docs/development/dingtalk-p4-release-readiness-development-20260423.md`
+- `docs/development/dingtalk-p4-release-readiness-verification-20260423.md`
+
+## Verification
+
+| Gate | Result |
+| --- | --- |
+| Release readiness Node tests | 5/5 passed |
+| Release readiness + adjacent env/regression gate tests | 13/13 passed |
+| Full DingTalk P4 ops regression suite | 95/95 passed |
+| Default release readiness dry run | expected fail: env missing, ops regression pass |
+| `git diff --check` | passed |
+
+## Commands
+
+```bash
+node --test scripts/ops/dingtalk-p4-release-readiness.test.mjs
+
+node --test \
+  scripts/ops/dingtalk-p4-release-readiness.test.mjs \
+  scripts/ops/dingtalk-p4-env-bootstrap.test.mjs \
+  scripts/ops/dingtalk-p4-regression-gate.test.mjs
+
+node --test $(ls scripts/ops/*dingtalk-p4*.test.mjs scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs scripts/ops/validate-dingtalk-staging-evidence-packet.test.mjs 2>/dev/null | sort)
+
+node scripts/ops/dingtalk-p4-release-readiness.mjs \
+  --output-dir /tmp/dingtalk-p4-release-readiness-default \
+  --allow-failures
+
+git diff --check
+```
+
+## Current Real Smoke Status
+
+The current private env template is still not filled, so release readiness should fail until real inputs are added.
+
+Run:
+
+```bash
+node scripts/ops/dingtalk-p4-release-readiness.mjs
+```
+
+Only if the report says `overallStatus: "pass"` should the operator run:
+
+```bash
+node scripts/ops/dingtalk-p4-smoke-session.mjs \
+  --env-file "$HOME/.config/yuantus/dingtalk-p4-staging.env" \
+  --require-manual-targets \
+  --output-dir output/dingtalk-p4-remote-smoke-session/142-session
+```

--- a/scripts/ops/dingtalk-p4-release-readiness.mjs
+++ b/scripts/ops/dingtalk-p4-release-readiness.mjs
@@ -1,0 +1,323 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { spawnSync } from 'node:child_process'
+import { homedir } from 'node:os'
+import path from 'node:path'
+
+const DEFAULT_ENV_FILE = path.join(homedir(), '.config', 'yuantus', 'dingtalk-p4-staging.env')
+const DEFAULT_OUTPUT_ROOT = 'output/dingtalk-p4-release-readiness'
+const SCHEMA_VERSION = 1
+const PUBLIC_REGRESSION_PROFILES = ['ops', 'product', 'all']
+
+function printHelp() {
+  console.log(`Usage: node scripts/ops/dingtalk-p4-release-readiness.mjs [options]
+
+Combines the private DingTalk P4 env readiness check and local P4 regression
+gate into one go/no-go report before the final 142/staging smoke.
+
+Options:
+  --p4-env-file <file>             Env file path, default ${DEFAULT_ENV_FILE}
+  --regression-profile <profile>   Regression profile: ops, product, or all; default ops
+  --regression-plan-only           Plan regression commands without executing them
+  --output-dir <dir>               Output dir, default ${DEFAULT_OUTPUT_ROOT}/<run-id>
+  --timeout-ms <ms>                Forwarded to regression gate
+  --allow-failures                 Exit 0 but still write fail/manual_pending status
+  --help                           Show this help
+
+Typical flow:
+  node scripts/ops/dingtalk-p4-release-readiness.mjs
+  # If overallStatus is pass, run:
+  node scripts/ops/dingtalk-p4-smoke-session.mjs --env-file ${DEFAULT_ENV_FILE} --require-manual-targets --output-dir output/dingtalk-p4-remote-smoke-session/142-session
+`)
+}
+
+function readRequiredValue(argv, index, flag) {
+  const next = argv[index + 1]
+  if (!next || next.startsWith('--')) {
+    throw new Error(`${flag} requires a value`)
+  }
+  return next
+}
+
+function makeRunId() {
+  return `dingtalk-p4-release-readiness-${new Date().toISOString().replace(/[:.]/g, '-').replace(/Z$/, 'Z')}`
+}
+
+function parsePositiveInteger(value, flag, { allowZero = false } = {}) {
+  if (!/^\d+$/.test(String(value))) {
+    throw new Error(`${flag} must be ${allowZero ? 'a non-negative' : 'a positive'} integer`)
+  }
+  const next = Number.parseInt(value, 10)
+  if (!allowZero && next <= 0) {
+    throw new Error(`${flag} must be a positive integer`)
+  }
+  return next
+}
+
+function parseArgs(argv) {
+  const opts = {
+    p4EnvFile: DEFAULT_ENV_FILE,
+    regressionProfile: 'ops',
+    regressionPlanOnly: false,
+    outputDir: '',
+    timeoutMs: 0,
+    allowFailures: false,
+  }
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    switch (arg) {
+      case '--p4-env-file':
+        opts.p4EnvFile = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
+        i += 1
+        break
+      case '--regression-profile':
+        opts.regressionProfile = readRequiredValue(argv, i, arg).trim()
+        i += 1
+        break
+      case '--regression-plan-only':
+        opts.regressionPlanOnly = true
+        break
+      case '--output-dir':
+        opts.outputDir = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
+        i += 1
+        break
+      case '--timeout-ms':
+        opts.timeoutMs = parsePositiveInteger(readRequiredValue(argv, i, arg), arg, { allowZero: true })
+        i += 1
+        break
+      case '--allow-failures':
+        opts.allowFailures = true
+        break
+      case '--help':
+        printHelp()
+        process.exit(0)
+        break
+      default:
+        throw new Error(`Unknown argument: ${arg}`)
+    }
+  }
+
+  if (!PUBLIC_REGRESSION_PROFILES.includes(opts.regressionProfile) && !opts.regressionProfile.startsWith('selftest')) {
+    throw new Error(`--regression-profile must be one of: ${PUBLIC_REGRESSION_PROFILES.join(', ')}`)
+  }
+
+  if (!opts.outputDir) {
+    opts.outputDir = path.resolve(process.cwd(), DEFAULT_OUTPUT_ROOT, makeRunId())
+  }
+  return opts
+}
+
+function redactString(value) {
+  return String(value ?? '')
+    .replace(/(access_token=)[^&\s)]+/gi, '$1<redacted>')
+    .replace(/(publicToken=)[^&\s)]+/gi, '$1<redacted>')
+    .replace(/([?&](?:sign|timestamp)=)[^&\s)]+/gi, '$1<redacted>')
+    .replace(/((?:client_secret|DINGTALK_CLIENT_SECRET|DINGTALK_STATE_SECRET)=)[^\s&]+/gi, '$1<redacted>')
+    .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]+/gi, 'Bearer <redacted>')
+    .replace(/\bSEC[A-Za-z0-9+/=_-]{8,}\b/g, 'SEC<redacted>')
+    .replace(/\beyJ[A-Za-z0-9._-]{20,}\b/g, '<jwt:redacted>')
+}
+
+function sanitizeValue(value) {
+  if (value === null || value === undefined) return value
+  if (typeof value === 'string') return redactString(value)
+  if (typeof value === 'number' || typeof value === 'boolean') return value
+  if (Array.isArray(value)) return value.map((entry) => sanitizeValue(entry))
+  if (typeof value === 'object') {
+    const next = {}
+    for (const [key, entryValue] of Object.entries(value)) {
+      next[key] = sanitizeValue(entryValue)
+    }
+    return next
+  }
+  return value
+}
+
+function relativePath(file) {
+  return path.relative(process.cwd(), file).replaceAll('\\', '/')
+}
+
+function shellQuote(value) {
+  return `'${String(value).replaceAll("'", "'\\''")}'`
+}
+
+function runNodeTool(args) {
+  const result = spawnSync(process.execPath, args, {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    maxBuffer: 20 * 1024 * 1024,
+  })
+  return {
+    exitCode: result.status ?? 1,
+    stdout: redactString(result.stdout ?? ''),
+    stderr: redactString(result.stderr || result.error?.message || ''),
+  }
+}
+
+function readJsonIfExists(file) {
+  if (!existsSync(file)) return null
+  return JSON.parse(readFileSync(file, 'utf8'))
+}
+
+function runEnvReadiness(opts, envDir) {
+  const jsonPath = path.join(envDir, 'readiness-summary.json')
+  const mdPath = path.join(envDir, 'readiness-summary.md')
+  const result = runNodeTool([
+    'scripts/ops/dingtalk-p4-env-bootstrap.mjs',
+    '--check',
+    '--p4-env-file',
+    opts.p4EnvFile,
+    '--output-dir',
+    envDir,
+  ])
+  const summary = readJsonIfExists(jsonPath)
+  return {
+    id: 'env-readiness',
+    label: 'Private DingTalk P4 env readiness',
+    status: summary?.overallStatus === 'pass' ? 'pass' : 'fail',
+    exitCode: result.exitCode,
+    summaryJson: existsSync(jsonPath) ? relativePath(jsonPath) : null,
+    summaryMd: existsSync(mdPath) ? relativePath(mdPath) : null,
+    stdout: result.stdout.trim(),
+    stderr: result.stderr.trim(),
+    details: summary
+      ? {
+          envFile: summary.envFile,
+          environment: summary.environment,
+          failedChecks: summary.checks.filter((check) => check.status === 'fail').map((check) => check.id),
+        }
+      : {},
+  }
+}
+
+function runRegressionGate(opts, regressionDir) {
+  const args = [
+    'scripts/ops/dingtalk-p4-regression-gate.mjs',
+    '--profile',
+    opts.regressionProfile,
+    '--output-dir',
+    regressionDir,
+  ]
+  if (opts.regressionPlanOnly) args.push('--plan-only')
+  if (opts.timeoutMs > 0) args.push('--timeout-ms', String(opts.timeoutMs))
+  const result = runNodeTool(args)
+  const jsonPath = path.join(regressionDir, 'summary.json')
+  const mdPath = path.join(regressionDir, 'summary.md')
+  const summary = readJsonIfExists(jsonPath)
+  const status = summary?.overallStatus === 'pass'
+    ? 'pass'
+    : summary?.overallStatus === 'plan_only'
+      ? 'skipped'
+      : 'fail'
+  return {
+    id: 'regression-gate',
+    label: `Local DingTalk P4 regression gate (${opts.regressionProfile})`,
+    status,
+    exitCode: result.exitCode,
+    summaryJson: existsSync(jsonPath) ? relativePath(jsonPath) : null,
+    summaryMd: existsSync(mdPath) ? relativePath(mdPath) : null,
+    stdout: result.stdout.trim(),
+    stderr: result.stderr.trim(),
+    details: summary
+      ? {
+          profile: summary.profile,
+          planOnly: summary.planOnly,
+          totals: summary.totals,
+          failedChecks: summary.checks.filter((check) => check.status === 'fail').map((check) => check.id),
+        }
+      : {},
+  }
+}
+
+function computeOverallStatus(checks) {
+  if (checks.some((check) => check.status === 'fail')) return 'fail'
+  if (checks.some((check) => check.status === 'skipped')) return 'manual_pending'
+  return 'pass'
+}
+
+function renderMarkdown(summary) {
+  const lines = [
+    '# DingTalk P4 Release Readiness',
+    '',
+    `- Overall status: **${summary.overallStatus}**`,
+    `- Generated at: \`${summary.generatedAt}\``,
+    `- Env file: \`${summary.p4EnvFile}\``,
+    `- Regression profile: \`${summary.regressionProfile}\``,
+    `- Regression plan only: \`${summary.regressionPlanOnly}\``,
+    '',
+    '## Gates',
+    '',
+    '| Gate | Status | Exit | Summary | Failed checks |',
+    '| --- | --- | ---: | --- | --- |',
+  ]
+
+  for (const gate of summary.gates) {
+    const failedChecks = gate.details?.failedChecks?.length ? gate.details.failedChecks.map((id) => `\`${id}\``).join('<br>') : ''
+    const summaryLink = gate.summaryMd ? `[md](${gate.summaryMd})` : ''
+    lines.push(`| \`${gate.id}\` | ${gate.status} | ${gate.exitCode} | ${summaryLink} | ${failedChecks} |`)
+  }
+
+  lines.push('')
+  lines.push('## Next Step')
+  lines.push('')
+  if (summary.overallStatus === 'pass') {
+    lines.push('Run the final remote smoke session:')
+    lines.push('')
+    lines.push('```bash')
+    lines.push(`node scripts/ops/dingtalk-p4-smoke-session.mjs \\`)
+    lines.push(`  --env-file ${shellQuote(summary.p4EnvFile)} \\`)
+    lines.push('  --require-manual-targets \\')
+    lines.push('  --output-dir output/dingtalk-p4-remote-smoke-session/142-session')
+    lines.push('```')
+  } else {
+    lines.push('Do not run the final remote smoke yet. Resolve failed gates first, then rerun this readiness command.')
+  }
+
+  lines.push('')
+  lines.push('## Secret Policy')
+  lines.push('')
+  lines.push('Bearer tokens, DingTalk robot access tokens, SEC secrets, JWTs, public form tokens, timestamps, and signs are redacted from this report.')
+  return `${lines.join('\n')}\n`
+}
+
+function run(opts) {
+  mkdirSync(opts.outputDir, { recursive: true })
+  const envDir = path.join(opts.outputDir, 'env-readiness')
+  const regressionDir = path.join(opts.outputDir, 'regression-gate')
+  mkdirSync(envDir, { recursive: true })
+  mkdirSync(regressionDir, { recursive: true })
+
+  const gates = [
+    runEnvReadiness(opts, envDir),
+    runRegressionGate(opts, regressionDir),
+  ]
+  const overallStatus = computeOverallStatus(gates)
+  const summary = sanitizeValue({
+    tool: 'dingtalk-p4-release-readiness',
+    schemaVersion: SCHEMA_VERSION,
+    generatedAt: new Date().toISOString(),
+    outputDir: relativePath(opts.outputDir),
+    p4EnvFile: opts.p4EnvFile,
+    regressionProfile: opts.regressionProfile,
+    regressionPlanOnly: opts.regressionPlanOnly,
+    overallStatus,
+    gates,
+  })
+
+  const jsonPath = path.join(opts.outputDir, 'release-readiness-summary.json')
+  const mdPath = path.join(opts.outputDir, 'release-readiness-summary.md')
+  writeFileSync(jsonPath, `${JSON.stringify(summary, null, 2)}\n`, 'utf8')
+  writeFileSync(mdPath, renderMarkdown(summary), 'utf8')
+  console.log(`[dingtalk-p4-release-readiness] ${overallStatus}: ${relativePath(jsonPath)}`)
+  return overallStatus === 'pass' || opts.allowFailures ? 0 : 1
+}
+
+try {
+  const opts = parseArgs(process.argv.slice(2))
+  process.exit(run(opts))
+} catch (error) {
+  console.error(`[dingtalk-p4-release-readiness] ERROR: ${redactString(error instanceof Error ? error.message : String(error))}`)
+  process.exit(1)
+}

--- a/scripts/ops/dingtalk-p4-release-readiness.test.mjs
+++ b/scripts/ops/dingtalk-p4-release-readiness.test.mjs
@@ -1,0 +1,163 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const scriptPath = path.join(repoRoot, 'scripts', 'ops', 'dingtalk-p4-release-readiness.mjs')
+
+function makeTmpDir() {
+  return mkdtempSync(path.join(tmpdir(), 'dingtalk-p4-release-readiness-'))
+}
+
+function runScript(args) {
+  return spawnSync(process.execPath, [scriptPath, ...args], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  })
+}
+
+function writeEnv(file, overrides = {}) {
+  const values = {
+    DINGTALK_P4_API_BASE: 'http://142.171.239.56:8900',
+    DINGTALK_P4_WEB_BASE: 'http://142.171.239.56:8081',
+    DINGTALK_P4_AUTH_TOKEN: 'secret-admin-token',
+    DINGTALK_P4_GROUP_A_WEBHOOK: 'https://oapi.dingtalk.com/robot/send?access_token=robot-secret-a&timestamp=1690000000000&sign=robot-sign-a',
+    DINGTALK_P4_GROUP_B_WEBHOOK: 'https://oapi.dingtalk.com/robot/send?access_token=robot-secret-b',
+    DINGTALK_P4_GROUP_A_SECRET: 'SECabcdefghijklmnop12345678',
+    DINGTALK_P4_GROUP_B_SECRET: '',
+    DINGTALK_P4_ALLOWED_USER_IDS: 'user_authorized',
+    DINGTALK_P4_ALLOWED_MEMBER_GROUP_IDS: '',
+    DINGTALK_P4_PERSON_USER_IDS: 'user_person_bound',
+    DINGTALK_P4_AUTHORIZED_USER_ID: '',
+    DINGTALK_P4_UNAUTHORIZED_USER_ID: 'user_unauthorized',
+    DINGTALK_P4_NO_EMAIL_DINGTALK_EXTERNAL_ID: 'dt_no_email_001',
+    ...overrides,
+  }
+  const content = Object.entries(values)
+    .map(([key, value]) => `${key}="${String(value).replaceAll('"', '\\"')}"`)
+    .join('\n')
+  writeFileSync(file, `${content}\n`, { encoding: 'utf8', mode: 0o600 })
+  chmodSync(file, 0o600)
+}
+
+function readSummary(outputDir) {
+  return JSON.parse(readFileSync(path.join(outputDir, 'release-readiness-summary.json'), 'utf8'))
+}
+
+test('dingtalk-p4-release-readiness fails when private env readiness fails even if regression passes', () => {
+  const tmpDir = makeTmpDir()
+  const envFile = path.join(tmpDir, 'dingtalk-p4.env')
+  const outputDir = path.join(tmpDir, 'readiness')
+
+  try {
+    writeEnv(envFile, {
+      DINGTALK_P4_AUTH_TOKEN: '',
+      DINGTALK_P4_GROUP_B_WEBHOOK: '',
+      DINGTALK_P4_UNAUTHORIZED_USER_ID: '',
+      DINGTALK_P4_NO_EMAIL_DINGTALK_EXTERNAL_ID: '',
+    })
+
+    const result = runScript([
+      '--p4-env-file', envFile,
+      '--regression-profile', 'selftest',
+      '--output-dir', outputDir,
+    ])
+
+    assert.equal(result.status, 1)
+    const summaryText = readFileSync(path.join(outputDir, 'release-readiness-summary.json'), 'utf8')
+    assert.doesNotMatch(summaryText, /secret-admin-token/)
+    assert.doesNotMatch(summaryText, /robot-secret-a/)
+    assert.match(summaryText, /access_token=<redacted>/)
+
+    const summary = JSON.parse(summaryText)
+    assert.equal(summary.overallStatus, 'fail')
+    assert.equal(summary.gates.find((gate) => gate.id === 'env-readiness').status, 'fail')
+    assert.equal(summary.gates.find((gate) => gate.id === 'regression-gate').status, 'pass')
+    assert.ok(summary.gates.find((gate) => gate.id === 'env-readiness').details.failedChecks.includes('dingtalk_p4_auth_token'))
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-p4-release-readiness passes with complete env and passing regression', () => {
+  const tmpDir = makeTmpDir()
+  const envFile = path.join(tmpDir, 'dingtalk-p4.env')
+  const outputDir = path.join(tmpDir, 'readiness')
+
+  try {
+    writeEnv(envFile)
+
+    const result = runScript([
+      '--p4-env-file', envFile,
+      '--regression-profile', 'selftest',
+      '--output-dir', outputDir,
+    ])
+
+    assert.equal(result.status, 0, result.stderr || result.stdout)
+    const summary = readSummary(outputDir)
+    assert.equal(summary.overallStatus, 'pass')
+    assert.equal(summary.gates.every((gate) => gate.status === 'pass'), true)
+    const markdown = readFileSync(path.join(outputDir, 'release-readiness-summary.md'), 'utf8')
+    assert.match(markdown, /dingtalk-p4-smoke-session\.mjs/)
+    assert.match(markdown, /--require-manual-targets/)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-p4-release-readiness reports manual_pending when regression is plan-only', () => {
+  const tmpDir = makeTmpDir()
+  const envFile = path.join(tmpDir, 'dingtalk-p4.env')
+  const outputDir = path.join(tmpDir, 'readiness')
+
+  try {
+    writeEnv(envFile)
+
+    const result = runScript([
+      '--p4-env-file', envFile,
+      '--regression-profile', 'selftest',
+      '--regression-plan-only',
+      '--output-dir', outputDir,
+    ])
+
+    assert.equal(result.status, 1)
+    const summary = readSummary(outputDir)
+    assert.equal(summary.overallStatus, 'manual_pending')
+    assert.equal(summary.gates.find((gate) => gate.id === 'regression-gate').status, 'skipped')
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-p4-release-readiness allow-failures keeps reports inspectable with zero exit', () => {
+  const tmpDir = makeTmpDir()
+  const envFile = path.join(tmpDir, 'dingtalk-p4.env')
+  const outputDir = path.join(tmpDir, 'readiness')
+
+  try {
+    writeEnv(envFile, { DINGTALK_P4_AUTH_TOKEN: '' })
+
+    const result = runScript([
+      '--p4-env-file', envFile,
+      '--regression-profile', 'selftest',
+      '--allow-failures',
+      '--output-dir', outputDir,
+    ])
+
+    assert.equal(result.status, 0)
+    assert.equal(readSummary(outputDir).overallStatus, 'fail')
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-p4-release-readiness rejects invalid public regression profile', () => {
+  const result = runScript(['--regression-profile', 'bad'])
+
+  assert.notEqual(result.status, 0)
+  assert.match(result.stderr, /--regression-profile must be one of: ops, product, all/)
+})


### PR DESCRIPTION
## Summary
- Add a local DingTalk P4 release-readiness gate that composes private env readiness with local P4 regression results.
- Write one redacted go/no-go JSON/Markdown report before final 142/staging smoke.
- Print the final smoke command only when env readiness and regression gates pass.
- Add development, verification, and delivery TEST_AND_VERIFICATION.md docs.

## Verification
- node --test scripts/ops/dingtalk-p4-release-readiness.test.mjs
- node --test scripts/ops/dingtalk-p4-release-readiness.test.mjs scripts/ops/dingtalk-p4-env-bootstrap.test.mjs scripts/ops/dingtalk-p4-regression-gate.test.mjs
- node --test $(ls scripts/ops/*dingtalk-p4*.test.mjs scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs scripts/ops/validate-dingtalk-staging-evidence-packet.test.mjs 2>/dev/null | sort)
- node scripts/ops/dingtalk-p4-release-readiness.mjs --output-dir /tmp/dingtalk-p4-release-readiness-default --allow-failures
- git diff --check

## Notes
- No real DingTalk or staging calls are made.
- Current local dry run correctly fails because the private P4 env template is not filled yet while local ops regression passes.