### PR TITLE
feat(dingtalk): add org destination catalog

### DIFF
--- a/apps/web/src/multitable/components/MetaApiTokenManager.vue
+++ b/apps/web/src/multitable/components/MetaApiTokenManager.vue
@@ -178,7 +178,7 @@
         <template v-if="canManageDingTalkGroups && activeTab === 'dingtalk-groups'">
           <section class="meta-api-mgr__notice" data-dingtalk-groups-scope-note="true">
             <strong>Table-scoped DingTalk groups</strong>
-            <span>Groups created here are bound to this table. You can add multiple groups and choose one or more in automations.</span>
+            <span>Groups created here are bound to this table. You can add multiple groups and choose one or more in automations; organization catalog groups are listed read-only when shared with your organization.</span>
             <span>Register DingTalk robot webhooks as send destinations for this table. This does not import DingTalk group members or control form access.</span>
           </section>
 
@@ -300,7 +300,7 @@
             <div class="meta-api-mgr__card-meta">
               <span>Webhook: {{ maskDingTalkWebhookUrl(group.webhookUrl) }}</span>
               <span>Secret: {{ group.hasSecret ? 'configured' : 'not configured' }}</span>
-              <span>{{ group.sheetId ? 'Shared with this sheet' : 'Private legacy group' }}</span>
+              <span>{{ dingTalkGroupScopeLabel(group) }}</span>
               <span>Created: {{ formatDate(group.createdAt) }}</span>
               <span v-if="group.lastTestedAt">Last test: {{ formatDate(group.lastTestedAt) }}</span>
               <span v-if="group.lastTestStatus" :data-dingtalk-group-test-status="group.lastTestStatus">
@@ -311,21 +311,24 @@
               <span>Last error: {{ group.lastTestError }}</span>
             </div>
             <div class="meta-api-mgr__card-actions">
-              <button class="meta-api-mgr__btn" type="button" data-dingtalk-group-edit="true" @click="openEditDingTalkGroup(group)">
+              <button v-if="canMutateDingTalkGroup(group)" class="meta-api-mgr__btn" type="button" data-dingtalk-group-edit="true" @click="openEditDingTalkGroup(group)">
                 Edit
               </button>
-              <button class="meta-api-mgr__btn" type="button" :disabled="busy" data-dingtalk-group-toggle="true" @click="onToggleDingTalkGroup(group)">
+              <button v-if="canMutateDingTalkGroup(group)" class="meta-api-mgr__btn" type="button" :disabled="busy" data-dingtalk-group-toggle="true" @click="onToggleDingTalkGroup(group)">
                 {{ group.enabled ? 'Disable' : 'Enable' }}
               </button>
-              <button class="meta-api-mgr__btn" type="button" data-dingtalk-group-deliveries="true" @click="onViewDingTalkDeliveries(group.id)">
+              <button class="meta-api-mgr__btn" type="button" data-dingtalk-group-deliveries="true" @click="onViewDingTalkDeliveries(group)">
                 Deliveries
               </button>
-              <button class="meta-api-mgr__btn" type="button" :disabled="busy" data-dingtalk-group-test-send="true" @click="onTestDingTalkGroup(group.id)">
+              <button v-if="canMutateDingTalkGroup(group)" class="meta-api-mgr__btn" type="button" :disabled="busy" data-dingtalk-group-test-send="true" @click="onTestDingTalkGroup(group)">
                 Test send
               </button>
-              <button class="meta-api-mgr__btn meta-api-mgr__btn--danger" type="button" :disabled="busy" data-dingtalk-group-delete="true" @click="onDeleteDingTalkGroup(group.id)">
+              <button v-if="canMutateDingTalkGroup(group)" class="meta-api-mgr__btn meta-api-mgr__btn--danger" type="button" :disabled="busy" data-dingtalk-group-delete="true" @click="onDeleteDingTalkGroup(group)">
                 Delete
               </button>
+              <span v-else class="meta-api-mgr__card-readonly" data-dingtalk-group-readonly="true">
+                Managed by organization admins
+              </span>
             </div>
 
             <div
@@ -519,6 +522,23 @@ function validateDingTalkGroupSecret(value: string): string {
   if (!secret) return ''
   if (!secret.startsWith('SEC')) return 'DingTalk robot secret must start with SEC'
   return ''
+}
+
+function dingTalkGroupScope(group: DingTalkGroupDestination): 'private' | 'sheet' | 'org' {
+  if (group.scope === 'org' || group.orgId) return 'org'
+  if (group.scope === 'sheet' || group.sheetId) return 'sheet'
+  return 'private'
+}
+
+function dingTalkGroupScopeLabel(group: DingTalkGroupDestination): string {
+  const scope = dingTalkGroupScope(group)
+  if (scope === 'org') return group.orgId ? `Organization catalog group: ${group.orgId}` : 'Organization catalog group'
+  if (scope === 'sheet') return group.sheetId ? `Shared with sheet: ${group.sheetId}` : 'Shared with this sheet'
+  return 'Private legacy group'
+}
+
+function canMutateDingTalkGroup(group: DingTalkGroupDestination): boolean {
+  return dingTalkGroupScope(group) !== 'org'
 }
 
 // ---- Token actions ----
@@ -771,7 +791,7 @@ function openDingTalkGroupForm() {
 }
 
 function openEditDingTalkGroup(group: DingTalkGroupDestination) {
-  if (!canManageDingTalkGroups.value) return
+  if (!canManageDingTalkGroups.value || !canMutateDingTalkGroup(group)) return
   editingDingTalkGroupId.value = group.id
   editingDingTalkGroupOriginal.value = {
     webhookUrl: group.webhookUrl,
@@ -832,7 +852,7 @@ async function onSaveDingTalkGroup() {
 }
 
 async function onToggleDingTalkGroup(group: DingTalkGroupDestination) {
-  if (!props.client || busy.value || !canManageDingTalkGroups.value) return
+  if (!props.client || busy.value || !canManageDingTalkGroups.value || !canMutateDingTalkGroup(group)) return
   busy.value = true
   error.value = null
   try {
@@ -845,15 +865,16 @@ async function onToggleDingTalkGroup(group: DingTalkGroupDestination) {
   }
 }
 
-async function onTestDingTalkGroup(groupId: string) {
-  if (!props.client || busy.value || !canManageDingTalkGroups.value) return
+async function onTestDingTalkGroup(group: DingTalkGroupDestination) {
+  if (!props.client || busy.value || !canManageDingTalkGroups.value || !canMutateDingTalkGroup(group)) return
+  const groupId = group.id
   busy.value = true
   error.value = null
   try {
     await props.client.testDingTalkGroup(groupId, undefined, props.sheetId)
     await loadDingTalkGroups()
     if (dingTalkDeliveriesGroupId.value === groupId) {
-      await loadDingTalkDeliveries(groupId)
+      await loadDingTalkDeliveries(group)
     }
   } catch (err) {
     error.value = err instanceof Error ? err.message : 'Failed to test DingTalk group'
@@ -862,15 +883,17 @@ async function onTestDingTalkGroup(groupId: string) {
   }
 }
 
-async function loadDingTalkDeliveries(groupId: string) {
+async function loadDingTalkDeliveries(group: DingTalkGroupDestination) {
   if (!props.client || !canManageDingTalkGroups.value) return
+  const groupId = group.id
+  const sheetId = dingTalkGroupScope(group) === 'org' ? undefined : props.sheetId
   const requestToken = ++dingTalkDeliveriesRequestToken
   dingTalkDeliveriesGroupId.value = groupId
   dingTalkDeliveriesLoading.value = true
   dingTalkDeliveries.value = []
   error.value = null
   try {
-    const deliveries = await props.client.getDingTalkGroupDeliveries(groupId, props.sheetId)
+    const deliveries = await props.client.getDingTalkGroupDeliveries(groupId, sheetId)
     if (requestToken !== dingTalkDeliveriesRequestToken || dingTalkDeliveriesGroupId.value !== groupId) {
       return
     }
@@ -887,8 +910,9 @@ async function loadDingTalkDeliveries(groupId: string) {
   }
 }
 
-async function onViewDingTalkDeliveries(groupId: string) {
+async function onViewDingTalkDeliveries(group: DingTalkGroupDestination) {
   if (!props.client || !canManageDingTalkGroups.value) return
+  const groupId = group.id
   if (dingTalkDeliveriesGroupId.value === groupId) {
     dingTalkDeliveriesRequestToken += 1
     dingTalkDeliveriesGroupId.value = null
@@ -896,11 +920,12 @@ async function onViewDingTalkDeliveries(groupId: string) {
     dingTalkDeliveries.value = []
     return
   }
-  await loadDingTalkDeliveries(groupId)
+  await loadDingTalkDeliveries(group)
 }
 
-async function onDeleteDingTalkGroup(groupId: string) {
-  if (!props.client || busy.value || !canManageDingTalkGroups.value) return
+async function onDeleteDingTalkGroup(group: DingTalkGroupDestination) {
+  if (!props.client || busy.value || !canManageDingTalkGroups.value || !canMutateDingTalkGroup(group)) return
+  const groupId = group.id
   busy.value = true
   error.value = null
   try {
@@ -1204,8 +1229,16 @@ watch(canManageDingTalkGroups, (canManage) => {
 
 .meta-api-mgr__card-actions {
   display: flex;
+  flex-wrap: wrap;
+  align-items: center;
   gap: 8px;
   margin-top: 4px;
+}
+
+.meta-api-mgr__card-readonly {
+  color: #64748b;
+  font-size: 12px;
+  font-weight: 600;
 }
 
 /* Deliveries */

--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -88,15 +88,18 @@
             >
               <option value="">-- add DingTalk group --</option>
               <option v-for="destination in availableDingTalkGroupDestinations" :key="destination.id" :value="destination.id">
-                {{ destination.name }}
+                {{ destination.name }} · {{ dingTalkDestinationScopeLabel(destination) }}
               </option>
             </select>
+            <div class="meta-automation__hint" data-automation-field="dingtalkDestinationPickerHint">
+              DingTalk groups registered for this table or shared from the organization catalog are listed here.
+            </div>
             <div
               v-if="!dingTalkDestinations.length"
               class="meta-automation__hint"
               data-automation-field="dingtalkDestinationEmpty"
             >
-              No DingTalk groups are bound to this table yet. Add one in API Tokens &amp; Webhooks &gt; DingTalk Groups, or use a record group field path below.
+              No DingTalk groups are available for this table yet. Add one in API Tokens &amp; Webhooks &gt; DingTalk Groups, ask an admin to share an organization catalog group, or use a record group field path below.
             </div>
             <div
               v-if="selectedDingTalkGroupDestinations.length"
@@ -1102,13 +1105,34 @@ function dingTalkGroupName(destinationId: string) {
   return dingTalkDestinations.value.find((item) => item.id === destinationId)?.name ?? destinationId
 }
 
+function dingTalkDestinationScope(destination?: DingTalkGroupDestination): 'private' | 'sheet' | 'org' {
+  if (!destination) return 'private'
+  if (destination.scope === 'org' || destination.orgId) return 'org'
+  if (destination.scope === 'sheet' || destination.sheetId) return 'sheet'
+  return 'private'
+}
+
+function dingTalkDestinationScopeLabel(destination?: DingTalkGroupDestination): string {
+  const scope = dingTalkDestinationScope(destination)
+  if (scope === 'org') return 'Organization catalog'
+  if (scope === 'sheet') return 'This table'
+  return 'Private'
+}
+
+function dingTalkDestinationSubtitle(destination?: DingTalkGroupDestination): string | undefined {
+  const scope = dingTalkDestinationScope(destination)
+  if (scope === 'org') return destination?.orgId ? `organization catalog: ${destination.orgId}` : 'organization catalog'
+  if (scope === 'sheet') return destination?.sheetId ? `sheet: ${destination.sheetId}` : 'this table'
+  return 'private'
+}
+
 const selectedDingTalkGroupDestinations = computed(() =>
   draft.value.dingtalkDestinationIds.map((id) => {
     const destination = dingTalkDestinations.value.find((item) => item.id === id)
     return {
       id,
       label: destination?.name ?? id,
-      subtitle: destination?.sheetId ? `sheet: ${destination.sheetId}` : undefined,
+      subtitle: dingTalkDestinationSubtitle(destination),
     }
   }),
 )

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -202,18 +202,18 @@
               >
                 <option value="">-- add DingTalk group --</option>
                 <option v-for="destination in availableGroupDestinations(action)" :key="destination.id" :value="destination.id">
-                  {{ destination.name }}
+                  {{ destination.name }} · {{ groupDestinationScopeLabel(destination) }}
                 </option>
               </select>
               <div class="meta-rule-editor__hint" data-field="dingtalkDestinationPickerHint">
-                Only DingTalk group destinations registered for this table are listed here.
+                DingTalk group destinations registered for this table or shared from the organization catalog are listed here.
               </div>
               <div
                 v-if="!dingTalkDestinationsError && dingTalkDestinations.length === 0"
                 class="meta-rule-editor__hint"
                 data-field="dingtalkDestinationEmpty"
               >
-                No DingTalk groups are bound to this table yet. Add one in API Tokens &amp; Webhooks &gt; DingTalk Groups, or use a record group field path below.
+                No DingTalk groups are available for this table yet. Add one in API Tokens &amp; Webhooks &gt; DingTalk Groups, ask an admin to share an organization catalog group, or use a record group field path below.
               </div>
               <div
                 v-if="selectedGroupDestinations(action).length"
@@ -1258,13 +1258,34 @@ function removePersonRecipient(action: DraftAction, userId: string) {
     .join(', ')
 }
 
+function groupDestinationScope(destination?: DingTalkGroupDestination): 'private' | 'sheet' | 'org' {
+  if (!destination) return 'private'
+  if (destination.scope === 'org' || destination.orgId) return 'org'
+  if (destination.scope === 'sheet' || destination.sheetId) return 'sheet'
+  return 'private'
+}
+
+function groupDestinationScopeLabel(destination?: DingTalkGroupDestination): string {
+  const scope = groupDestinationScope(destination)
+  if (scope === 'org') return 'Organization catalog'
+  if (scope === 'sheet') return 'This table'
+  return 'Private'
+}
+
+function groupDestinationSubtitle(destination?: DingTalkGroupDestination): string | undefined {
+  const scope = groupDestinationScope(destination)
+  if (scope === 'org') return destination?.orgId ? `organization catalog: ${destination.orgId}` : 'organization catalog'
+  if (scope === 'sheet') return destination?.sheetId ? `sheet: ${destination.sheetId}` : 'this table'
+  return 'private'
+}
+
 function selectedGroupDestinations(action: DraftAction) {
   return parseGroupDestinationIds(action.config.destinationIds ?? action.config.destinationId).map((id) => {
     const destination = dingTalkDestinations.value.find((item) => item.id === id)
     return {
       id,
       label: destination?.name ?? id,
-      subtitle: destination?.sheetId ? `sheet: ${destination.sheetId}` : undefined,
+      subtitle: groupDestinationSubtitle(destination),
     }
   })
 }

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -802,7 +802,9 @@ export interface DingTalkGroupDestination {
   secret?: string
   hasSecret?: boolean
   enabled: boolean
+  scope?: 'private' | 'sheet' | 'org'
   sheetId?: string
+  orgId?: string
   createdBy: string
   createdAt: string
   updatedAt?: string
@@ -816,7 +818,9 @@ export interface DingTalkGroupDestinationInput {
   webhookUrl: string
   secret?: string
   enabled?: boolean
+  scope?: 'private' | 'sheet' | 'org'
   sheetId?: string
+  orgId?: string
 }
 
 export interface DingTalkGroupDelivery {

--- a/apps/web/tests/multitable-api-token-manager.spec.ts
+++ b/apps/web/tests/multitable-api-token-manager.spec.ts
@@ -84,6 +84,7 @@ function fakeDingTalkGroup(overrides: Partial<DingTalkGroupDestination> = {}): D
     webhookUrl: 'https://oapi.dingtalk.com/robot/send?access_token=test-token',
     hasSecret: false,
     enabled: true,
+    scope: 'sheet',
     sheetId: 'sheet_1',
     createdBy: 'user_1',
     createdAt: '2026-04-01T00:00:00Z',
@@ -687,6 +688,32 @@ describe('MetaApiTokenManager', () => {
     expect(rows[0]?.textContent).toContain('Please fill incident details')
     expect(rows[0]?.textContent).toContain('Automation')
     expect(fetchFn.mock.calls.some(([url]) => String(url).includes('/api/multitable/dingtalk-groups/dt_1/deliveries?sheetId=sheet_1'))).toBe(true)
+  })
+
+  it('shows organization catalog DingTalk groups as read-only and loads deliveries without sheet scope', async () => {
+    const { client, fetchFn } = mockClient([], [], [], [
+      fakeDingTalkGroup({ scope: 'org', sheetId: undefined, orgId: 'org_1' }),
+    ], [fakeDingTalkDelivery()])
+    mount({ visible: true, client })
+    await flushPromises()
+
+    const dingTalkTab = document.querySelectorAll('[role="tab"]')[2] as HTMLButtonElement
+    dingTalkTab.click()
+    await flushPromises()
+
+    const card = document.querySelector('[data-dingtalk-group-id="dt_1"]') as HTMLElement
+    expect(card?.textContent).toContain('Organization catalog group: org_1')
+    expect(card?.querySelector('[data-dingtalk-group-readonly]')?.textContent).toContain('Managed by organization admins')
+    expect(card?.querySelector('[data-dingtalk-group-edit]')).toBeNull()
+    expect(card?.querySelector('[data-dingtalk-group-toggle]')).toBeNull()
+    expect(card?.querySelector('[data-dingtalk-group-test-send]')).toBeNull()
+    expect(card?.querySelector('[data-dingtalk-group-delete]')).toBeNull()
+
+    const deliveriesBtn = card.querySelector('[data-dingtalk-group-deliveries]') as HTMLButtonElement
+    deliveriesBtn.click()
+    await flushPromises()
+
+    expect(fetchFn.mock.calls.some(([url]) => String(url) === '/api/multitable/dingtalk-groups/dt_1/deliveries')).toBe(true)
   })
 
   it('refreshes open DingTalk delivery history after test send', async () => {

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -863,6 +863,67 @@ describe('MetaAutomationManager', () => {
     expect(fetchFn.mock.calls.some(([url]) => String(url).includes('/api/multitable/dingtalk-groups?sheetId=sheet_1'))).toBe(true)
   })
 
+  it('labels organization catalog DingTalk groups in the automation form', async () => {
+    const { client, fetchFn } = mockClient([], {
+      dingTalkGroups: [{
+        id: 'dt_org',
+        name: 'Org Ops Group',
+        webhookUrl: 'https://oapi.dingtalk.com/robot/send?access_token=test-org',
+        enabled: true,
+        scope: 'org',
+        orgId: 'org_1',
+        createdBy: 'admin_1',
+        createdAt: '2026-04-01T00:00:00Z',
+      }],
+    })
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('.meta-automation__btn-add') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const nameInput = container.querySelector('[data-automation-field="name"]') as HTMLInputElement
+    nameInput.value = 'Org DingTalk notify'
+    nameInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_group_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const destinationSelect = container.querySelector('[data-automation-field="dingtalkDestinationPickerId"]') as HTMLSelectElement
+    expect(destinationSelect.textContent).toContain('Organization catalog')
+    destinationSelect.value = 'dt_org'
+    destinationSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    const chip = container.querySelector('[data-automation-group-destination="dt_org"]') as HTMLElement
+    expect(chip?.textContent).toContain('Org Ops Group')
+    expect(chip?.textContent).toContain('organization catalog: org_1')
+
+    const titleInput = container.querySelector('[data-automation-field="dingtalkTitleTemplate"]') as HTMLInputElement
+    titleInput.value = 'Ticket {{recordId}}'
+    titleInput.dispatchEvent(new Event('input', { bubbles: true }))
+
+    const bodyInput = container.querySelector('[data-automation-field="dingtalkBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = 'Please fill {{record.status}}'
+    bodyInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushPromises()
+
+    const saveBtn = container.querySelector('.meta-automation__btn--primary') as HTMLButtonElement
+    saveBtn.click()
+    await flushPromises()
+
+    const postCalls = fetchFn.mock.calls.filter(([, init]: [string, RequestInit | undefined]) => init?.method === 'POST')
+    expect(postCalls.length).toBe(1)
+    const body = JSON.parse(postCalls[0][1]?.body as string)
+    expect(body.actionConfig).toMatchObject({
+      destinationId: 'dt_org',
+      destinationIds: ['dt_org'],
+    })
+  })
+
   it('shows an empty state when no DingTalk groups are bound and still allows dynamic record destinations', async () => {
     const { client, fetchFn } = mockClient([], { dingTalkGroups: [] })
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
@@ -882,7 +943,7 @@ describe('MetaAutomationManager', () => {
     await flushPromises()
 
     const emptyState = container.querySelector('[data-automation-field="dingtalkDestinationEmpty"]')
-    expect(emptyState?.textContent).toContain('No DingTalk groups are bound to this table yet')
+    expect(emptyState?.textContent).toContain('No DingTalk groups are available for this table yet')
     expect(emptyState?.textContent).toContain('API Tokens & Webhooks')
     expect(emptyState?.textContent).toContain('record group field path')
 

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -82,6 +82,7 @@ function mockClient() {
         name: 'Ops Group',
         webhookUrl: 'https://oapi.dingtalk.com/robot/send?access_token=test',
         enabled: true,
+        scope: 'sheet',
         sheetId: 'sheet_1',
         createdBy: 'user_1',
         createdAt: '2026-04-01T00:00:00Z',
@@ -91,6 +92,7 @@ function mockClient() {
         name: 'Escalation Group',
         webhookUrl: 'https://oapi.dingtalk.com/robot/send?access_token=test-2',
         enabled: true,
+        scope: 'sheet',
         sheetId: 'sheet_1',
         createdBy: 'user_1',
         createdAt: '2026-04-01T00:00:00Z',
@@ -590,6 +592,72 @@ describe('MetaAutomationRuleEditor', () => {
     expect(client.listDingTalkGroups).toHaveBeenCalledWith('sheet_1')
   })
 
+  it('labels organization catalog DingTalk groups in the advanced rule editor', async () => {
+    const saved = vi.fn()
+    const client = {
+      ...mockClient(),
+      listDingTalkGroups: vi.fn(async () => [{
+        id: 'dt_org',
+        name: 'Org Ops Group',
+        webhookUrl: 'https://oapi.dingtalk.com/robot/send?access_token=test-org',
+        enabled: true,
+        scope: 'org',
+        orgId: 'org_1',
+        createdBy: 'admin_1',
+        createdAt: '2026-04-01T00:00:00Z',
+      }]),
+    }
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+      onSave: saved,
+    })
+    await flushPromises()
+
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    nameInput.value = 'Notify org DingTalk'
+    nameInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_group_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const destinationSelect = container.querySelector('[data-field="dingtalkDestinationPickerId"]') as HTMLSelectElement
+    expect(destinationSelect.textContent).toContain('Organization catalog')
+    destinationSelect.value = 'dt_org'
+    destinationSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const chip = container.querySelector('[data-group-destination="dt_org"]') as HTMLElement
+    expect(chip?.textContent).toContain('Org Ops Group')
+    expect(chip?.textContent).toContain('organization catalog: org_1')
+
+    const titleInput = container.querySelector('[data-field="dingtalkTitleTemplate"]') as HTMLInputElement
+    titleInput.value = 'Ticket {{recordId}}'
+    titleInput.dispatchEvent(new Event('input'))
+
+    const bodyInput = container.querySelector('[data-field="dingtalkBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = 'Please review {{record.status}}'
+    bodyInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(false)
+    saveBtn.click()
+    await flushPromises()
+
+    expect(saved).toHaveBeenCalledTimes(1)
+    expect(saved.mock.calls[0][0].actionConfig).toMatchObject({
+      destinationId: 'dt_org',
+      destinationIds: ['dt_org'],
+    })
+  })
+
   it('shows an empty state when no DingTalk groups are bound and still allows dynamic record destinations', async () => {
     const saved = vi.fn()
     const client = {
@@ -617,7 +685,7 @@ describe('MetaAutomationRuleEditor', () => {
     await flushPromises()
 
     const emptyState = container.querySelector('[data-field="dingtalkDestinationEmpty"]')
-    expect(emptyState?.textContent).toContain('No DingTalk groups are bound to this table yet')
+    expect(emptyState?.textContent).toContain('No DingTalk groups are available for this table yet')
     expect(emptyState?.textContent).toContain('API Tokens & Webhooks')
     expect(emptyState?.textContent).toContain('record group field path')
 

--- a/docs/development/dingtalk-feature-plan-and-todo-20260422.md
+++ b/docs/development/dingtalk-feature-plan-and-todo-20260422.md
@@ -29,12 +29,14 @@
 ## P1: DingTalk Group Standard Workflow
 
 - [x] Backend: verify table-scoped DingTalk group destinations support multiple groups per table.
+- [x] Backend: add organization-scoped DingTalk group destination catalog v1 with org membership read/use and admin-only mutation.
 - [x] Backend: verify create, update, delete, list, test-send, and delivery history routes enforce automation/write permissions.
 - [x] Backend: verify webhook URLs and robot secrets are redacted in responses, logs, and delivery diagnostics.
 - [x] Frontend: expose DingTalk group binding in the table integration or existing API token manager surface.
 - [x] Frontend: let users add, edit, delete, and test-send DingTalk group robot destinations.
 - [x] Frontend: show that group binding does not import DingTalk group members and does not grant form fill permission by itself.
 - [x] Automation UI: let users choose a bound DingTalk group for `send_dingtalk_group_message`.
+- [x] Automation UI: show organization catalog DingTalk groups in selectors with read-only catalog labeling.
 - [x] Automation UI: let users include public form and internal processing links in group messages.
 - [x] Runtime: confirm a group message link opens the form and permission checks still gate access.
 

--- a/docs/development/dingtalk-final-development-plan-and-todo-20260423.md
+++ b/docs/development/dingtalk-final-development-plan-and-todo-20260423.md
@@ -10,6 +10,7 @@
 
 - [x] Multiple DingTalk groups per table
 - [x] Group robot binding UI/API
+- [x] Organization-scoped DingTalk group destination catalog v1
 - [x] Group automation with form links
 - [x] Form access modes: `public`, `dingtalk`, and `dingtalk_granted`
 - [x] Local user/member-group allowlist for DingTalk-protected forms

--- a/docs/development/dingtalk-org-destination-catalog-development-20260423.md
+++ b/docs/development/dingtalk-org-destination-catalog-development-20260423.md
@@ -1,0 +1,64 @@
+# DingTalk Organization Destination Catalog Development
+
+- Date: 2026-04-23
+- Branch: `codex/dingtalk-org-destination-catalog-20260423`
+- Base commit: `cf48825c1`
+- Scope: organization-scoped DingTalk group destination catalog v1
+
+## Goal
+
+Allow DingTalk group robot destinations to be shared through an organization catalog while preserving existing private and sheet-scoped destination behavior.
+
+## Implemented
+
+- Added nullable `org_id` to `dingtalk_group_destinations` with org lookup indexes and a database constraint that prevents a destination from being both sheet-scoped and organization-scoped.
+- Added `scope: private | sheet | org` and optional `orgId` to backend and frontend DingTalk group destination models.
+- Extended destination creation validation so:
+  - `scope=sheet` requires `sheetId`.
+  - `scope=org` requires `orgId`.
+  - `scope=private` rejects `sheetId` and `orgId`.
+  - `sheetId` and `orgId` cannot be used together.
+- Extended list/read behavior:
+  - Sheet views include sheet destinations, private user destinations, and active organization catalog destinations for org memberships.
+  - Explicit `orgId` list views include that organization catalog and the user's private destinations.
+  - Organization catalog delivery history is readable by active org members or admins.
+- Restricted organization catalog mutations:
+  - Create, update, delete, and test-send for `orgId` destinations require admin role/permission.
+  - Admin detection accepts `role`, `roles`, `permissions`, `perms`, `isAdmin`, and `is_admin`.
+- Extended automation runtime lookup so `send_dingtalk_group_message` can use organization destinations when the rule creator has an active `user_orgs` membership.
+- Updated table integration UI:
+  - Organization catalog destinations appear as read-only cards.
+  - Edit, toggle, test-send, and delete actions are hidden for organization catalog rows.
+  - Delivery history for organization rows is loaded without a sheet query scope.
+- Updated automation UIs:
+  - Quick automation manager and advanced rule editor label destinations as `This table`, `Private`, or `Organization catalog`.
+  - Selected chips show organization catalog subtitles with `orgId`.
+  - Empty and hint copy now mentions organization catalog availability.
+
+## Files Changed
+
+- Backend DB/API/runtime:
+  - `packages/core-backend/src/db/migrations/zzzz20260423130000_add_org_scope_to_dingtalk_group_destinations.ts`
+  - `packages/core-backend/src/db/types.ts`
+  - `packages/core-backend/src/multitable/dingtalk-group-destinations.ts`
+  - `packages/core-backend/src/multitable/dingtalk-group-destination-service.ts`
+  - `packages/core-backend/src/routes/api-tokens.ts`
+  - `packages/core-backend/src/multitable/automation-executor.ts`
+- Frontend:
+  - `apps/web/src/multitable/types.ts`
+  - `apps/web/src/multitable/components/MetaApiTokenManager.vue`
+  - `apps/web/src/multitable/components/MetaAutomationManager.vue`
+  - `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+- Tests:
+  - `packages/core-backend/tests/unit/dingtalk-group-destination-service.test.ts`
+  - `packages/core-backend/tests/unit/automation-v1.test.ts`
+  - `packages/core-backend/tests/integration/dingtalk-group-destination-routes.api.test.ts`
+  - `apps/web/tests/multitable-api-token-manager.spec.ts`
+  - `apps/web/tests/multitable-automation-manager.spec.ts`
+  - `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+
+## Notes
+
+- This is a v1 catalog implementation. It does not add a dedicated organization admin management page; org catalog rows can be managed through the API by admins.
+- Existing sheet-scoped table owners still manage table-local DingTalk robot destinations from the API token manager.
+- Remote smoke with real DingTalk clients remains outside this local implementation slice and is tracked in the P4 smoke plan.

--- a/docs/development/dingtalk-org-destination-catalog-verification-20260423.md
+++ b/docs/development/dingtalk-org-destination-catalog-verification-20260423.md
@@ -1,0 +1,72 @@
+# DingTalk Organization Destination Catalog Verification
+
+- Date: 2026-04-23
+- Branch: `codex/dingtalk-org-destination-catalog-20260423`
+- Base commit: `cf48825c1`
+
+## Local Setup
+
+The parallel worktree initially had no `node_modules` links, so dependencies were linked with:
+
+```bash
+pnpm install --offline
+```
+
+No packages were downloaded; the existing pnpm store was reused.
+
+## Commands Run
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-group-destination-service.test.ts tests/unit/automation-v1.test.ts tests/integration/dingtalk-group-destination-routes.api.test.ts --watch=false
+```
+
+Result: passed.
+
+- Test files: 3 passed
+- Tests: 154 passed
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-api-token-manager.spec.ts tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false
+```
+
+Result: passed.
+
+- Test files: 3 passed
+- Tests: 158 passed
+
+```bash
+pnpm --filter @metasheet/core-backend build
+```
+
+Result: passed.
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result: passed.
+
+- Vite emitted existing chunk-size and mixed static/dynamic import warnings.
+- No build failure.
+
+## Verified Behavior
+
+- Backend service creates and maps organization-scoped destinations with `scope=org` and `orgId`.
+- Backend rejects invalid scope combinations before insert.
+- Organization destination mutation requires matching `orgId` at service level and admin access at route level.
+- Organization catalog list requires active org membership or admin read access.
+- Automation destination lookup includes org catalog destinations when the rule creator has active org membership.
+- API responses continue to redact webhook credentials and robot secret.
+- Frontend integration manager renders organization catalog groups as read-only.
+- Frontend automation pickers label organization catalog destinations and preserve payload destination IDs.
+
+## Not Run
+
+- Real remote smoke with DingTalk clients and robot webhooks was not run in this local slice.
+- P4 final handoff packet generation was not run because it requires staging credentials and manual evidence.
+
+## Residual Risks
+
+- Organization admin semantics currently use global admin-style request claims. A future org-admin role model can narrow admin authority per `orgId`.
+- There is no dedicated org catalog admin UI in this slice; API-based management is supported.
+- Remote DingTalk client validation still needs the existing P4 smoke process.

--- a/packages/core-backend/src/db/migrations/zzzz20260423130000_add_org_scope_to_dingtalk_group_destinations.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260423130000_add_org_scope_to_dingtalk_group_destinations.ts
@@ -1,0 +1,50 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    ALTER TABLE dingtalk_group_destinations
+    ADD COLUMN IF NOT EXISTS org_id text
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_dingtalk_group_destinations_org_id
+    ON dingtalk_group_destinations(org_id)
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_dingtalk_group_destinations_org_enabled
+    ON dingtalk_group_destinations(org_id, enabled)
+    WHERE org_id IS NOT NULL
+  `.execute(db)
+
+  await sql`
+    DO $$ BEGIN
+      IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'dingtalk_group_destinations_scope_exclusive'
+          AND conrelid = 'dingtalk_group_destinations'::regclass
+      ) THEN
+        ALTER TABLE dingtalk_group_destinations
+        ADD CONSTRAINT dingtalk_group_destinations_scope_exclusive
+        CHECK (sheet_id IS NULL OR org_id IS NULL);
+      END IF;
+    END $$;
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    ALTER TABLE dingtalk_group_destinations
+    DROP CONSTRAINT IF EXISTS dingtalk_group_destinations_scope_exclusive
+  `.execute(db)
+
+  await sql`DROP INDEX IF EXISTS idx_dingtalk_group_destinations_org_enabled`.execute(db)
+  await sql`DROP INDEX IF EXISTS idx_dingtalk_group_destinations_org_id`.execute(db)
+
+  await sql`
+    ALTER TABLE dingtalk_group_destinations
+    DROP COLUMN IF EXISTS org_id
+  `.execute(db)
+}

--- a/packages/core-backend/src/db/types.ts
+++ b/packages/core-backend/src/db/types.ts
@@ -1316,6 +1316,7 @@ export interface DingTalkGroupDestinationsTable {
   secret: string | null
   enabled: boolean
   sheet_id: string | null
+  org_id: string | null
   created_by: string
   created_at: CreatedAt
   updated_at: NullableTimestamp

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -1185,11 +1185,22 @@ export class AutomationExecutor {
 
     const destinationResult = await this.deps.queryFn(
       `SELECT id, name, webhook_url, secret, enabled
-         FROM dingtalk_group_destinations
+         FROM dingtalk_group_destinations dg
         WHERE id = ANY($1)
           AND (
             sheet_id = $2
-            OR (sheet_id IS NULL AND created_by = $3)
+            OR (sheet_id IS NULL AND org_id IS NULL AND created_by = $3)
+            OR (
+              sheet_id IS NULL
+              AND org_id IS NOT NULL
+              AND EXISTS (
+                SELECT 1
+                FROM user_orgs uo
+                WHERE uo.user_id = $3
+                  AND uo.org_id = dg.org_id
+                  AND uo.is_active = true
+              )
+            )
           )`,
       [destinationIds, context.sheetId, context.ruleCreatedBy],
     )

--- a/packages/core-backend/src/multitable/dingtalk-group-destination-service.ts
+++ b/packages/core-backend/src/multitable/dingtalk-group-destination-service.ts
@@ -29,6 +29,7 @@ type DingTalkGroupDestinationRow = {
   secret: string | null
   enabled: boolean
   sheet_id: string | null
+  org_id: string | null
   created_by: string
   created_at: string | Date
   updated_at?: string | Date | null
@@ -42,13 +43,16 @@ function generateId(): string {
 }
 
 function rowToDestination(row: DingTalkGroupDestinationRow): DingTalkGroupDestination {
+  const scope = row.org_id ? 'org' : row.sheet_id ? 'sheet' : 'private'
   return {
     id: row.id,
     name: row.name,
     webhookUrl: row.webhook_url,
     secret: row.secret ?? undefined,
     enabled: row.enabled,
+    scope,
     sheetId: row.sheet_id ?? undefined,
+    orgId: row.org_id ?? undefined,
     createdBy: row.created_by,
     createdAt: row.created_at instanceof Date ? row.created_at.toISOString() : row.created_at,
     updatedAt: row.updated_at ? (row.updated_at instanceof Date ? row.updated_at.toISOString() : row.updated_at) : undefined,
@@ -116,7 +120,13 @@ export class DingTalkGroupDestinationService {
     const webhookUrl = normalizeDingTalkRobotWebhookUrl(input.webhookUrl)
     const secret = normalizeDingTalkRobotSecret(input.secret)
     const sheetId = typeof input.sheetId === 'string' && input.sheetId.trim() ? input.sheetId.trim() : null
+    const orgId = typeof input.orgId === 'string' && input.orgId.trim() ? input.orgId.trim() : null
+    const scope = input.scope ?? (orgId ? 'org' : sheetId ? 'sheet' : 'private')
     if (!name) throw new Error('Destination name is required')
+    if (sheetId && orgId) throw new Error('DingTalk group destination cannot be both sheet and organization scoped')
+    if (scope === 'sheet' && !sheetId) throw new Error('sheetId is required for sheet-scoped DingTalk group destinations')
+    if (scope === 'org' && !orgId) throw new Error('orgId is required for organization DingTalk group destinations')
+    if (scope === 'private' && (sheetId || orgId)) throw new Error('private DingTalk group destinations cannot include sheetId or orgId')
 
     const id = generateId()
     const enabled = input.enabled ?? true
@@ -129,6 +139,7 @@ export class DingTalkGroupDestinationService {
       secret: secret ?? null,
       enabled,
       sheet_id: sheetId,
+      org_id: orgId,
       created_by: userId,
       created_at: now,
     }).execute()
@@ -140,27 +151,64 @@ export class DingTalkGroupDestinationService {
       webhookUrl,
       secret,
       enabled,
+      scope,
       ...(sheetId ? { sheetId } : {}),
+      ...(orgId ? { orgId } : {}),
       createdBy: userId,
       createdAt: now,
     }
   }
 
-  async listDestinations(userId: string, sheetId?: string): Promise<DingTalkGroupDestination[]> {
+  async listDestinations(userId: string, sheetId?: string, orgId?: string): Promise<DingTalkGroupDestination[]> {
     const normalizedSheetId = typeof sheetId === 'string' && sheetId.trim() ? sheetId.trim() : ''
+    const normalizedOrgId = typeof orgId === 'string' && orgId.trim() ? orgId.trim() : ''
     let builder = this.db.selectFrom('dingtalk_group_destinations').selectAll()
-    if (normalizedSheetId) {
+    if (normalizedOrgId) {
+      builder = builder.where((eb) =>
+        eb.or([
+          eb('org_id', '=', normalizedOrgId),
+          eb.and([
+            eb('sheet_id', 'is', null),
+            eb('org_id', 'is', null),
+            eb('created_by', '=', userId),
+          ]),
+        ]),
+      )
+    } else if (normalizedSheetId) {
       builder = builder.where((eb) =>
         eb.or([
           eb('sheet_id', '=', normalizedSheetId),
+          eb.exists(
+            eb.selectFrom('user_orgs')
+              .select('user_id')
+              .whereRef('user_orgs.org_id', '=', 'dingtalk_group_destinations.org_id')
+              .where('user_orgs.user_id', '=', userId)
+              .where('user_orgs.is_active', '=', true),
+          ),
           eb.and([
             eb('sheet_id', 'is', null),
+            eb('org_id', 'is', null),
             eb('created_by', '=', userId),
           ]),
         ]),
       )
     } else {
-      builder = builder.where('created_by', '=', userId)
+      builder = builder.where((eb) =>
+        eb.or([
+          eb.exists(
+            eb.selectFrom('user_orgs')
+              .select('user_id')
+              .whereRef('user_orgs.org_id', '=', 'dingtalk_group_destinations.org_id')
+              .where('user_orgs.user_id', '=', userId)
+              .where('user_orgs.is_active', '=', true),
+          ),
+          eb.and([
+            eb('sheet_id', 'is', null),
+            eb('org_id', 'is', null),
+            eb('created_by', '=', userId),
+          ]),
+        ]),
+      )
     }
     const rows = await builder.orderBy('created_at', 'desc').execute()
     return rows.map((row) => rowToDestination(row as Parameters<typeof rowToDestination>[0]))
@@ -189,6 +237,7 @@ export class DingTalkGroupDestinationService {
     id: string,
     userId: string,
     sheetId?: string,
+    orgId?: string,
   ): Promise<DingTalkGroupDestinationRow> {
     const row = await this.db.selectFrom('dingtalk_group_destinations')
       .selectAll()
@@ -197,6 +246,10 @@ export class DingTalkGroupDestinationService {
     if (!row) throw new Error('Destination not found')
     if (row.sheet_id !== null) {
       if (!sheetId || row.sheet_id !== sheetId) throw new Error('Not authorized')
+      return row
+    }
+    if (row.org_id !== null) {
+      if (!orgId || row.org_id !== orgId) throw new Error('Not authorized')
       return row
     }
     if (row.created_by !== userId) throw new Error('Not authorized')
@@ -208,8 +261,9 @@ export class DingTalkGroupDestinationService {
     userId: string,
     input: DingTalkGroupDestinationUpdateInput,
     sheetId?: string,
+    orgId?: string,
   ): Promise<DingTalkGroupDestination> {
-    await this.loadAuthorizedDestination(id, userId, sheetId)
+    await this.loadAuthorizedDestination(id, userId, sheetId, orgId)
 
     const updates: Record<string, unknown> = { updated_at: nowTimestamp() }
     if (input.name !== undefined) {
@@ -235,8 +289,8 @@ export class DingTalkGroupDestinationService {
     return rowToDestination(updated as Parameters<typeof rowToDestination>[0])
   }
 
-  async deleteDestination(id: string, userId: string, sheetId?: string): Promise<void> {
-    await this.loadAuthorizedDestination(id, userId, sheetId)
+  async deleteDestination(id: string, userId: string, sheetId?: string, orgId?: string): Promise<void> {
+    await this.loadAuthorizedDestination(id, userId, sheetId, orgId)
     await this.db.deleteFrom('dingtalk_group_destinations')
       .where('id', '=', id)
       .execute()
@@ -247,8 +301,9 @@ export class DingTalkGroupDestinationService {
     userId: string,
     input: DingTalkGroupTestSendInput,
     sheetId?: string,
+    orgId?: string,
   ): Promise<{ ok: true }> {
-    const row = await this.loadAuthorizedDestination(id, userId, sheetId)
+    const row = await this.loadAuthorizedDestination(id, userId, sheetId, orgId)
 
     const subject = input.subject?.trim() || 'MetaSheet DingTalk group test'
     const content = input.content?.trim() || 'This is a standard DingTalk group destination test message.'

--- a/packages/core-backend/src/multitable/dingtalk-group-destinations.ts
+++ b/packages/core-backend/src/multitable/dingtalk-group-destinations.ts
@@ -5,7 +5,9 @@ export interface DingTalkGroupDestination {
   secret?: string
   hasSecret?: boolean
   enabled: boolean
+  scope: 'private' | 'sheet' | 'org'
   sheetId?: string
+  orgId?: string
   createdBy: string
   createdAt: string
   updatedAt?: string
@@ -19,7 +21,9 @@ export interface DingTalkGroupDestinationCreateInput {
   webhookUrl: string
   secret?: string
   enabled?: boolean
+  scope?: 'private' | 'sheet' | 'org'
   sheetId?: string
+  orgId?: string
 }
 
 export interface DingTalkGroupDestinationUpdateInput {

--- a/packages/core-backend/src/routes/api-tokens.ts
+++ b/packages/core-backend/src/routes/api-tokens.ts
@@ -60,7 +60,9 @@ const CreateDingTalkGroupSchema = z.object({
   webhookUrl: z.string().url(),
   secret: z.string().optional(),
   enabled: z.boolean().optional(),
+  scope: z.enum(['private', 'sheet', 'org']).optional(),
   sheetId: z.string().optional(),
+  orgId: z.string().optional(),
 })
 
 const UpdateDingTalkGroupSchema = z.object({
@@ -79,6 +81,65 @@ function getSheetId(value: unknown): string {
   return typeof value === 'string' ? value.trim() : ''
 }
 
+function getOrgId(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function isAdminRequest(req: Request): boolean {
+  const user = req.user as Record<string, unknown> | undefined
+  const role = typeof user?.role === 'string' ? user.role.trim() : ''
+  const roles = Array.isArray(user?.roles) ? user.roles.map((value) => String(value).trim()) : []
+  const permissions = [
+    ...(Array.isArray(user?.permissions) ? user.permissions : []),
+    ...(Array.isArray(user?.perms) ? user.perms : []),
+  ].map((value) => String(value).trim())
+  return Boolean(user?.isAdmin || user?.is_admin)
+    || role === 'admin'
+    || roles.includes('admin')
+    || permissions.includes('*')
+    || permissions.includes('admin')
+    || permissions.includes('dingtalk:admin')
+}
+
+function rejectMixedScope(res: Response, sheetId: string, orgId: string): boolean {
+  if (!sheetId || !orgId) return false
+  res.status(400).json({
+    ok: false,
+    error: { code: 'VALIDATION_ERROR', message: 'sheetId and orgId cannot be used together' },
+  })
+  return true
+}
+
+function rejectInvalidDingTalkGroupScope(
+  res: Response,
+  scope: 'private' | 'sheet' | 'org' | undefined,
+  sheetId: string,
+  orgId: string,
+): boolean {
+  if (scope === 'private' && (sheetId || orgId)) {
+    res.status(400).json({
+      ok: false,
+      error: { code: 'VALIDATION_ERROR', message: 'private DingTalk group destinations cannot include sheetId or orgId' },
+    })
+    return true
+  }
+  if (scope === 'sheet' && !sheetId) {
+    res.status(400).json({
+      ok: false,
+      error: { code: 'VALIDATION_ERROR', message: 'sheetId is required for sheet-scoped DingTalk group destinations' },
+    })
+    return true
+  }
+  if (scope === 'org' && !orgId) {
+    res.status(400).json({
+      ok: false,
+      error: { code: 'VALIDATION_ERROR', message: 'orgId is required for organization DingTalk group destinations' },
+    })
+    return true
+  }
+  return false
+}
+
 async function requireSheetAutomationAccess(res: Response, userId: string, sheetId: string): Promise<boolean> {
   if (!sheetId) {
     res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId is required' } })
@@ -90,6 +151,33 @@ async function requireSheetAutomationAccess(res: Response, userId: string, sheet
     return false
   }
   return true
+}
+
+async function requireOrgMemberAccess(res: Response, userId: string, orgId: string): Promise<boolean> {
+  if (!orgId) {
+    res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'orgId is required' } })
+    return false
+  }
+  const result = await query(
+    'SELECT 1 FROM user_orgs WHERE user_id = $1 AND org_id = $2 AND is_active = true LIMIT 1',
+    [userId, orgId],
+  )
+  if (!result.rows.length) {
+    res.status(403).json({ ok: false, error: { code: 'FORBIDDEN' } })
+    return false
+  }
+  return true
+}
+
+async function requireOrgReadAccess(req: Request, res: Response, userId: string, orgId: string): Promise<boolean> {
+  if (isAdminRequest(req)) return true
+  return requireOrgMemberAccess(res, userId, orgId)
+}
+
+function requireOrgAdminAccess(req: Request, res: Response): boolean {
+  if (isAdminRequest(req)) return true
+  res.status(403).json({ ok: false, error: { code: 'FORBIDDEN', message: 'Admin role required' } })
+  return false
 }
 
 function getUserId(req: Request): string {
@@ -319,9 +407,13 @@ export function apiTokensRouter(): Router {
       return
     }
     const sheetId = getSheetId(req.query.sheetId)
+    const orgId = getOrgId(req.query.orgId)
+    if (rejectMixedScope(res, sheetId, orgId)) return
     if (sheetId && !await requireSheetAutomationAccess(res, userId, sheetId)) return
-    const destinations = await dingTalkGroupDestinationService.listDestinations(userId, sheetId || undefined)
-    res.json({ ok: true, data: { destinations: destinations.map(toDingTalkGroupDestinationResponse) } })
+    if (orgId && !await requireOrgReadAccess(req, res, userId, orgId)) return
+    const destinations = await dingTalkGroupDestinationService.listDestinations(userId, sheetId || undefined, orgId || undefined)
+    const filtered = orgId ? destinations.filter((destination) => destination.orgId === orgId || destination.scope === 'private') : destinations
+    res.json({ ok: true, data: { destinations: filtered.map(toDingTalkGroupDestinationResponse) } })
   })
 
   router.post('/api/multitable/dingtalk-groups', async (req: Request, res: Response) => {
@@ -333,13 +425,19 @@ export function apiTokensRouter(): Router {
     try {
       const input = CreateDingTalkGroupSchema.parse(req.body)
       const sheetId = getSheetId(input.sheetId)
+      const orgId = getOrgId(input.orgId)
+      if (rejectMixedScope(res, sheetId, orgId)) return
+      if (rejectInvalidDingTalkGroupScope(res, input.scope, sheetId, orgId)) return
+      if ((orgId || input.scope === 'org') && !requireOrgAdminAccess(req, res)) return
       if (sheetId && !await requireSheetAutomationAccess(res, userId, sheetId)) return
       const destination = await dingTalkGroupDestinationService.createDestination(userId, {
         name: input.name,
         webhookUrl: input.webhookUrl,
         secret: input.secret,
         enabled: input.enabled,
+        scope: input.scope,
         sheetId: sheetId || undefined,
+        orgId: orgId || undefined,
       })
       res.status(201).json({ ok: true, data: toDingTalkGroupDestinationResponse(destination) })
     } catch (err) {
@@ -361,13 +459,16 @@ export function apiTokensRouter(): Router {
     try {
       const input = UpdateDingTalkGroupSchema.parse(req.body)
       const sheetId = getSheetId(req.query.sheetId)
+      const orgId = getOrgId(req.query.orgId)
+      if (rejectMixedScope(res, sheetId, orgId)) return
+      if (orgId && !requireOrgAdminAccess(req, res)) return
       if (sheetId && !await requireSheetAutomationAccess(res, userId, sheetId)) return
       const destination = await dingTalkGroupDestinationService.updateDestination(req.params.id, userId, {
         name: input.name,
         webhookUrl: input.webhookUrl,
         secret: input.secret,
         enabled: input.enabled,
-      }, sheetId || undefined)
+      }, sheetId || undefined, orgId || undefined)
       res.json({ ok: true, data: toDingTalkGroupDestinationResponse(destination) })
     } catch (err) {
       if (err instanceof z.ZodError) {
@@ -387,8 +488,11 @@ export function apiTokensRouter(): Router {
     }
     try {
       const sheetId = getSheetId(req.query.sheetId)
+      const orgId = getOrgId(req.query.orgId)
+      if (rejectMixedScope(res, sheetId, orgId)) return
+      if (orgId && !requireOrgAdminAccess(req, res)) return
       if (sheetId && !await requireSheetAutomationAccess(res, userId, sheetId)) return
-      await dingTalkGroupDestinationService.deleteDestination(req.params.id, userId, sheetId || undefined)
+      await dingTalkGroupDestinationService.deleteDestination(req.params.id, userId, sheetId || undefined, orgId || undefined)
       res.status(204).end()
     } catch (err) {
       logger.error('Failed to delete DingTalk group destination', err instanceof Error ? err : undefined)
@@ -403,13 +507,18 @@ export function apiTokensRouter(): Router {
       return
     }
     const sheetId = getSheetId(req.query.sheetId)
+    const orgId = getOrgId(req.query.orgId)
+    if (rejectMixedScope(res, sheetId, orgId)) return
     if (sheetId && !await requireSheetAutomationAccess(res, userId, sheetId)) return
+    if (orgId && !await requireOrgReadAccess(req, res, userId, orgId)) return
     const destination = await dingTalkGroupDestinationService.getDestinationById(req.params.id)
     if (!destination) {
       res.status(404).json({ ok: false, error: { code: 'NOT_FOUND' } })
       return
     }
-    if (destination.sheetId ? destination.sheetId !== sheetId : destination.createdBy !== userId) {
+    if (destination.orgId) {
+      if (!await requireOrgReadAccess(req, res, userId, destination.orgId)) return
+    } else if (destination.sheetId ? destination.sheetId !== sheetId : destination.createdBy !== userId) {
       res.status(403).json({ ok: false, error: { code: 'FORBIDDEN' } })
       return
     }
@@ -427,8 +536,11 @@ export function apiTokensRouter(): Router {
     try {
       const input = DingTalkGroupTestSendSchema.parse(req.body ?? {})
       const sheetId = getSheetId(req.query.sheetId)
+      const orgId = getOrgId(req.query.orgId)
+      if (rejectMixedScope(res, sheetId, orgId)) return
+      if (orgId && !requireOrgAdminAccess(req, res)) return
       if (sheetId && !await requireSheetAutomationAccess(res, userId, sheetId)) return
-      await dingTalkGroupDestinationService.testSend(req.params.id, userId, input, sheetId || undefined)
+      await dingTalkGroupDestinationService.testSend(req.params.id, userId, input, sheetId || undefined, orgId || undefined)
       res.status(204).end()
     } catch (err) {
       if (err instanceof z.ZodError) {

--- a/packages/core-backend/tests/integration/dingtalk-group-destination-routes.api.test.ts
+++ b/packages/core-backend/tests/integration/dingtalk-group-destination-routes.api.test.ts
@@ -12,6 +12,7 @@ function makeDestination(overrides: Record<string, unknown> = {}) {
     webhookUrl: 'https://oapi.dingtalk.com/robot/send?access_token=secret-token&timestamp=123&sign=abc',
     secret: 'SECsecret',
     enabled: true,
+    scope: 'sheet',
     sheetId: SHEET_ID,
     createdBy: 'user_1',
     createdAt: '2026-04-22T00:00:00.000Z',
@@ -37,6 +38,8 @@ function makeDelivery(overrides: Record<string, unknown> = {}) {
 
 async function createApp(options: {
   canManageAutomation?: boolean
+  authUser?: Record<string, unknown>
+  orgMember?: boolean
   serviceOverrides?: Record<string, ReturnType<typeof vi.fn>>
 } = {}) {
   vi.resetModules()
@@ -54,10 +57,13 @@ async function createApp(options: {
   const resolveSheetCapabilitiesForUser = vi.fn(async () => ({
     capabilities: { canManageAutomation: options.canManageAutomation ?? true },
   }))
-  const query = vi.fn()
+  const query = vi.fn(async () => ({
+    rows: options.orgMember === false ? [] : [{ ok: 1 }],
+    rowCount: options.orgMember === false ? 0 : 1,
+  }))
 
   const authenticate = (req: any, _res: any, next: () => void) => {
-    req.user = { id: 'user_1', roles: [], perms: ['workflow:write'] }
+    req.user = options.authUser ?? { id: 'user_1', roles: [], perms: ['workflow:write'] }
     next()
   }
 
@@ -134,6 +140,78 @@ describe('DingTalk group destination routes', () => {
     expect(Object.prototype.hasOwnProperty.call(response.body.data, 'secret')).toBe(false)
   })
 
+  it('creates an organization-scoped destination only for admins', async () => {
+    const { app, service } = await createApp({
+      authUser: { id: 'admin_1', roles: ['admin'], perms: ['workflow:write'] },
+      serviceOverrides: {
+        createDestination: vi.fn(async () => makeDestination({
+          scope: 'org',
+          sheetId: undefined,
+          orgId: 'org_1',
+          createdBy: 'admin_1',
+        })),
+      },
+    })
+
+    const response = await request(app)
+      .post('/api/multitable/dingtalk-groups')
+      .send({
+        name: 'Org Ops DingTalk Group',
+        webhookUrl: 'https://oapi.dingtalk.com/robot/send?access_token=secret-token',
+        scope: 'org',
+        orgId: 'org_1',
+      })
+      .expect(201)
+
+    expect(service.createDestination).toHaveBeenCalledWith('admin_1', expect.objectContaining({
+      name: 'Org Ops DingTalk Group',
+      scope: 'org',
+      orgId: 'org_1',
+    }))
+    expect(response.body.data.scope).toBe('org')
+    expect(response.body.data.orgId).toBe('org_1')
+  })
+
+  it('rejects organization-scoped destination creation for non-admins', async () => {
+    const { app, service } = await createApp()
+
+    await request(app)
+      .post('/api/multitable/dingtalk-groups')
+      .send({
+        name: 'Org Ops DingTalk Group',
+        webhookUrl: 'https://oapi.dingtalk.com/robot/send?access_token=secret-token',
+        scope: 'org',
+        orgId: 'org_1',
+      })
+      .expect(403)
+
+    expect(service.createDestination).not.toHaveBeenCalled()
+  })
+
+  it('lists an organization catalog with private destinations for active org members', async () => {
+    const { app, service, query } = await createApp({
+      serviceOverrides: {
+        listDestinations: vi.fn(async () => [
+          makeDestination({ id: 'dt_private', scope: 'private', sheetId: undefined }),
+          makeDestination({ id: 'dt_org_1', scope: 'org', sheetId: undefined, orgId: 'org_1' }),
+          makeDestination({ id: 'dt_org_2', scope: 'org', sheetId: undefined, orgId: 'org_2' }),
+        ]),
+      },
+    })
+
+    const response = await request(app)
+      .get('/api/multitable/dingtalk-groups')
+      .query({ orgId: 'org_1' })
+      .expect(200)
+
+    expect(query).toHaveBeenCalledWith(
+      'SELECT 1 FROM user_orgs WHERE user_id = $1 AND org_id = $2 AND is_active = true LIMIT 1',
+      ['user_1', 'org_1'],
+    )
+    expect(service.listDestinations).toHaveBeenCalledWith('user_1', undefined, 'org_1')
+    expect(response.body.data.destinations.map((item: { id: string }) => item.id)).toEqual(['dt_private', 'dt_org_1'])
+  })
+
   it.each([
     ['PATCH', `/api/multitable/dingtalk-groups/${DESTINATION_ID}`, 'updateDestination'],
     ['DELETE', `/api/multitable/dingtalk-groups/${DESTINATION_ID}`, 'deleteDestination'],
@@ -185,6 +263,30 @@ describe('DingTalk group destination routes', () => {
       'user_1',
       { subject: 'Route test', content: 'Body' },
       SHEET_ID,
+      undefined,
     )
+  })
+
+  it('lists delivery history for an organization destination shared with the caller org', async () => {
+    const { app, service, query } = await createApp({
+      serviceOverrides: {
+        getDestinationById: vi.fn(async () => makeDestination({
+          scope: 'org',
+          sheetId: undefined,
+          orgId: 'org_1',
+        })),
+      },
+    })
+
+    await request(app)
+      .get(`/api/multitable/dingtalk-groups/${DESTINATION_ID}/deliveries`)
+      .query({ limit: '20' })
+      .expect(200)
+
+    expect(query).toHaveBeenCalledWith(
+      'SELECT 1 FROM user_orgs WHERE user_id = $1 AND org_id = $2 AND is_active = true LIMIT 1',
+      ['user_1', 'org_1'],
+    )
+    expect(service.listDeliveries).toHaveBeenCalledWith(DESTINATION_ID, 20)
   })
 })

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -858,7 +858,9 @@ describe('AutomationExecutor', () => {
   it('scopes send_dingtalk_group_message destinations to the current sheet and rule creator', async () => {
     const queryFn = vi.fn(async (sql: string, params?: unknown[]) => {
       expect(sql).toContain('sheet_id = $2')
-      expect(sql).toContain('created_by = $3')
+      expect(sql).toContain('org_id IS NULL AND created_by = $3')
+      expect(sql).toContain('FROM user_orgs uo')
+      expect(sql).toContain('uo.org_id = dg.org_id')
       expect(params).toEqual([['dt_other_sheet'], 'sheet_1', 'user_1'])
       return { rows: [], rowCount: 0 }
     })

--- a/packages/core-backend/tests/unit/dingtalk-group-destination-service.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-group-destination-service.test.ts
@@ -68,6 +68,7 @@ function destinationRow(overrides: Record<string, unknown> = {}) {
     secret: 'SEC123',
     enabled: true,
     sheet_id: null,
+    org_id: null,
     created_by: 'user_1',
     created_at: '2026-04-19T10:00:00.000Z',
     updated_at: '2026-04-19T10:10:00.000Z',
@@ -118,16 +119,59 @@ describe('DingTalkGroupDestinationService', () => {
     expect(created.name).toBe('Ops DingTalk Group')
     expect(created.secret).toBe('SEC123')
     expect(created.enabled).toBe(true)
+    expect(created.scope).toBe('sheet')
     expect(created.sheetId).toBe('sheet_1')
     const insertChain = roots.insertInto.mock.results[0]?.value as MockChain | undefined
     const values = insertChain?.values?.mock.calls[0]?.[0] as Record<string, unknown> | undefined
     expect(values?.secret).toBe('SEC123')
+    expect(values?.org_id).toBeNull()
 
     executeQueue.push([destinationRow({ sheet_id: 'sheet_1' }), destinationRow({ id: 'dt_legacy', sheet_id: null })])
     const listed = await service.listDestinations('user_1', 'sheet_1')
     expect(listed).toHaveLength(2)
     expect(listed[0].name).toBe('Ops DingTalk Group')
+    expect(listed[0].scope).toBe('sheet')
     expect(listed[0].sheetId).toBe('sheet_1')
+  })
+
+  test('creates organization-scoped destinations', async () => {
+    const { db, roots } = createMockDb()
+    const service = new DingTalkGroupDestinationService(db, vi.fn())
+
+    const created = await service.createDestination('admin_1', {
+      name: 'Org Ops DingTalk Group',
+      webhookUrl: 'https://oapi.dingtalk.com/robot/send?access_token=test-token',
+      scope: 'org',
+      orgId: 'org_1',
+    })
+
+    expect(created.scope).toBe('org')
+    expect(created.orgId).toBe('org_1')
+    expect(created.sheetId).toBeUndefined()
+    const insertChain = roots.insertInto.mock.results[0]?.value as MockChain | undefined
+    const values = insertChain?.values?.mock.calls[0]?.[0] as Record<string, unknown> | undefined
+    expect(values?.sheet_id).toBeNull()
+    expect(values?.org_id).toBe('org_1')
+  })
+
+  test('rejects invalid organization destination scope combinations', async () => {
+    const { db, roots } = createMockDb()
+    const service = new DingTalkGroupDestinationService(db, vi.fn())
+
+    await expect(service.createDestination('admin_1', {
+      name: 'Org Ops DingTalk Group',
+      webhookUrl: 'https://oapi.dingtalk.com/robot/send?access_token=test-token',
+      scope: 'org',
+    })).rejects.toThrow('orgId is required')
+
+    await expect(service.createDestination('admin_1', {
+      name: 'Private Ops DingTalk Group',
+      webhookUrl: 'https://oapi.dingtalk.com/robot/send?access_token=test-token',
+      scope: 'private',
+      orgId: 'org_1',
+    })).rejects.toThrow('private DingTalk group destinations cannot include sheetId or orgId')
+
+    expect(roots.insertInto).not.toHaveBeenCalled()
   })
 
   test.each([
@@ -180,6 +224,30 @@ describe('DingTalkGroupDestinationService', () => {
     expect(updated.name).toBe('Updated shared group')
     expect(updated.sheetId).toBe('sheet_1')
     expect(roots.updateTable).toHaveBeenCalledWith('dingtalk_group_destinations')
+  })
+
+  test('organization destinations require matching org authorization for mutation', async () => {
+    const { db, roots } = createMockDb()
+    const service = new DingTalkGroupDestinationService(db, vi.fn())
+
+    executeTakeFirstQueue.push(destinationRow({ id: 'dt_org', org_id: 'org_1', created_by: 'admin_1' }))
+    executeTakeFirstQueue.push(destinationRow({
+      id: 'dt_org',
+      org_id: 'org_1',
+      created_by: 'admin_1',
+      name: 'Updated org group',
+    }))
+
+    const updated = await service.updateDestination('dt_org', 'admin_2', {
+      name: 'Updated org group',
+    }, undefined, 'org_1')
+
+    expect(updated.scope).toBe('org')
+    expect(updated.orgId).toBe('org_1')
+    expect(roots.updateTable).toHaveBeenCalledWith('dingtalk_group_destinations')
+
+    executeTakeFirstQueue.push(destinationRow({ id: 'dt_org', org_id: 'org_1', created_by: 'admin_1' }))
+    await expect(service.deleteDestination('dt_org', 'admin_2', undefined, 'org_2')).rejects.toThrow('Not authorized')
   })
 
   test('updates a destination', async () => {


### PR DESCRIPTION
## Summary

- Add organization-scoped DingTalk group destinations with `org_id`, `scope`, and `orgId` metadata.
- Allow active org members to list/read/use org catalog destinations in automation while keeping org catalog mutations admin-only.
- Extend automation runtime destination lookup to include org catalog rows for the rule creator's active org memberships.
- Render org catalog destinations as read-only in the table integration manager and label them in quick/advanced automation pickers.
- Add development and verification notes under `docs/development/`.

## Verification

```bash
pnpm install --offline
pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-group-destination-service.test.ts tests/unit/automation-v1.test.ts tests/integration/dingtalk-group-destination-routes.api.test.ts --watch=false
pnpm --filter @metasheet/web exec vitest run tests/multitable-api-token-manager.spec.ts tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false
pnpm --filter @metasheet/core-backend build
pnpm --filter @metasheet/web build
git diff --check -- packages/core-backend apps/web docs/development
```

Notes: frontend build passed with existing Vite chunk-size / mixed import warnings.