### PR TITLE
fix(dingtalk): guard P4 readiness selftest profile

### DIFF
--- a/docs/development/dingtalk-p4-release-readiness-selftest-guard-development-20260423.md
+++ b/docs/development/dingtalk-p4-release-readiness-selftest-guard-development-20260423.md
@@ -1,0 +1,28 @@
+# DingTalk P4 Release Readiness Selftest Guard Development
+
+- Date: 2026-04-23
+- Branch: `codex/dingtalk-p4-release-readiness-selftest-guard-20260423`
+- Scope: local release-readiness gate hardening; no DingTalk or staging calls.
+
+## Completed Work
+
+- Restricted `scripts/ops/dingtalk-p4-release-readiness.mjs` so public operator runs only accept:
+  - `ops`
+  - `product`
+  - `all`
+- Kept test-only regression profiles available only when explicitly unlocked with:
+  - `DINGTALK_P4_RELEASE_READINESS_ALLOW_SELFTEST=1`
+- Updated release-readiness tests to use the explicit unlock when exercising `selftest`.
+- Added coverage that proves `--regression-profile selftest` is rejected by default.
+
+## Reasoning
+
+The release-readiness gate decides whether an operator may start final 142/staging P4 smoke. Hidden selftest profiles are useful for fast unit tests, but they must not be accepted in normal operator runs because they can bypass real `ops/product/all` regression coverage.
+
+This change keeps test speed while making the production CLI fail closed.
+
+## Out Of Scope
+
+- No product runtime change.
+- No real remote smoke.
+- No credential or env mutation.

--- a/docs/development/dingtalk-p4-release-readiness-selftest-guard-verification-20260423.md
+++ b/docs/development/dingtalk-p4-release-readiness-selftest-guard-verification-20260423.md
@@ -1,0 +1,36 @@
+# DingTalk P4 Release Readiness Selftest Guard Verification
+
+- Date: 2026-04-23
+- Branch: `codex/dingtalk-p4-release-readiness-selftest-guard-20260423`
+
+## Commands Run
+
+```bash
+node --test scripts/ops/dingtalk-p4-release-readiness.test.mjs
+
+node --test \
+  scripts/ops/dingtalk-p4-release-readiness.test.mjs \
+  scripts/ops/dingtalk-p4-regression-gate.test.mjs
+
+node --test $(ls scripts/ops/*dingtalk-p4*.test.mjs scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs scripts/ops/validate-dingtalk-staging-evidence-packet.test.mjs 2>/dev/null | sort)
+
+git diff --check
+```
+
+## Results
+
+- Release-readiness tests: pass, 6 tests.
+- Release-readiness plus regression-gate tests: pass, 10 tests.
+- Full DingTalk P4 ops regression suite: pass, 96 tests.
+- `git diff --check`: pass.
+
+## Covered Cases
+
+- `--regression-profile selftest` is rejected by default.
+- The same profile can be used in tests only when `DINGTALK_P4_RELEASE_READINESS_ALLOW_SELFTEST=1` is set.
+- Existing fail/pass/manual-pending/allow-failures release-readiness behavior remains covered.
+
+## Real External Dependency Status
+
+- Real 142/staging DingTalk P4 smoke was not executed.
+- Current private env remains a placeholder until real token, robot webhooks, allowlist, and manual targets are filled.

--- a/output/delivery/dingtalk-p4-release-readiness-selftest-guard-20260423/TEST_AND_VERIFICATION.md
+++ b/output/delivery/dingtalk-p4-release-readiness-selftest-guard-20260423/TEST_AND_VERIFICATION.md
@@ -1,0 +1,41 @@
+# TEST AND VERIFICATION - DingTalk P4 Release Readiness Selftest Guard
+
+## Summary
+
+Hardened the DingTalk P4 release-readiness gate so test-only regression profiles cannot be used by default in operator runs.
+
+The public CLI now only accepts `ops`, `product`, and `all`. Unit tests can still unlock `selftest` with `DINGTALK_P4_RELEASE_READINESS_ALLOW_SELFTEST=1`.
+
+## Files
+
+- `scripts/ops/dingtalk-p4-release-readiness.mjs`
+- `scripts/ops/dingtalk-p4-release-readiness.test.mjs`
+- `docs/development/dingtalk-p4-release-readiness-selftest-guard-development-20260423.md`
+- `docs/development/dingtalk-p4-release-readiness-selftest-guard-verification-20260423.md`
+
+## Verification
+
+| Gate | Result |
+| --- | --- |
+| Release-readiness tests | 6/6 passed |
+| Release-readiness + regression-gate tests | 10/10 passed |
+| Full DingTalk P4 ops regression suite | 96/96 passed |
+| `git diff --check` | passed |
+
+## Commands
+
+```bash
+node --test scripts/ops/dingtalk-p4-release-readiness.test.mjs
+
+node --test \
+  scripts/ops/dingtalk-p4-release-readiness.test.mjs \
+  scripts/ops/dingtalk-p4-regression-gate.test.mjs
+
+node --test $(ls scripts/ops/*dingtalk-p4*.test.mjs scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs scripts/ops/validate-dingtalk-staging-evidence-packet.test.mjs 2>/dev/null | sort)
+
+git diff --check
+```
+
+## Status
+
+This is local gate hardening only. It does not run the real 142/staging smoke and does not touch private env values.

--- a/scripts/ops/dingtalk-p4-release-readiness.mjs
+++ b/scripts/ops/dingtalk-p4-release-readiness.mjs
@@ -9,6 +9,8 @@ const DEFAULT_ENV_FILE = path.join(homedir(), '.config', 'yuantus', 'dingtalk-p4
 const DEFAULT_OUTPUT_ROOT = 'output/dingtalk-p4-release-readiness'
 const SCHEMA_VERSION = 1
 const PUBLIC_REGRESSION_PROFILES = ['ops', 'product', 'all']
+const TEST_ONLY_REGRESSION_PROFILES = ['selftest', 'selftest-secret']
+const SELFTEST_UNLOCK_ENV = 'DINGTALK_P4_RELEASE_READINESS_ALLOW_SELFTEST'
 
 function printHelp() {
   console.log(`Usage: node scripts/ops/dingtalk-p4-release-readiness.mjs [options]
@@ -99,7 +101,9 @@ function parseArgs(argv) {
     }
   }
 
-  if (!PUBLIC_REGRESSION_PROFILES.includes(opts.regressionProfile) && !opts.regressionProfile.startsWith('selftest')) {
+  const selftestProfileAllowed = TEST_ONLY_REGRESSION_PROFILES.includes(opts.regressionProfile)
+    && process.env[SELFTEST_UNLOCK_ENV] === '1'
+  if (!PUBLIC_REGRESSION_PROFILES.includes(opts.regressionProfile) && !selftestProfileAllowed) {
     throw new Error(`--regression-profile must be one of: ${PUBLIC_REGRESSION_PROFILES.join(', ')}`)
   }
 

--- a/scripts/ops/dingtalk-p4-release-readiness.test.mjs
+++ b/scripts/ops/dingtalk-p4-release-readiness.test.mjs
@@ -13,10 +13,22 @@ function makeTmpDir() {
   return mkdtempSync(path.join(tmpdir(), 'dingtalk-p4-release-readiness-'))
 }
 
-function runScript(args) {
+function runScript(args, options = {}) {
   return spawnSync(process.execPath, [scriptPath, ...args], {
     cwd: repoRoot,
     encoding: 'utf8',
+    env: {
+      ...process.env,
+      ...(options.env ?? {}),
+    },
+  })
+}
+
+function runScriptWithSelftest(args) {
+  return runScript(args, {
+    env: {
+      DINGTALK_P4_RELEASE_READINESS_ALLOW_SELFTEST: '1',
+    },
   })
 }
 
@@ -61,7 +73,7 @@ test('dingtalk-p4-release-readiness fails when private env readiness fails even 
       DINGTALK_P4_NO_EMAIL_DINGTALK_EXTERNAL_ID: '',
     })
 
-    const result = runScript([
+    const result = runScriptWithSelftest([
       '--p4-env-file', envFile,
       '--regression-profile', 'selftest',
       '--output-dir', outputDir,
@@ -91,7 +103,7 @@ test('dingtalk-p4-release-readiness passes with complete env and passing regress
   try {
     writeEnv(envFile)
 
-    const result = runScript([
+    const result = runScriptWithSelftest([
       '--p4-env-file', envFile,
       '--regression-profile', 'selftest',
       '--output-dir', outputDir,
@@ -117,7 +129,7 @@ test('dingtalk-p4-release-readiness reports manual_pending when regression is pl
   try {
     writeEnv(envFile)
 
-    const result = runScript([
+    const result = runScriptWithSelftest([
       '--p4-env-file', envFile,
       '--regression-profile', 'selftest',
       '--regression-plan-only',
@@ -141,7 +153,7 @@ test('dingtalk-p4-release-readiness allow-failures keeps reports inspectable wit
   try {
     writeEnv(envFile, { DINGTALK_P4_AUTH_TOKEN: '' })
 
-    const result = runScript([
+    const result = runScriptWithSelftest([
       '--p4-env-file', envFile,
       '--regression-profile', 'selftest',
       '--allow-failures',
@@ -160,4 +172,24 @@ test('dingtalk-p4-release-readiness rejects invalid public regression profile', 
 
   assert.notEqual(result.status, 0)
   assert.match(result.stderr, /--regression-profile must be one of: ops, product, all/)
+})
+
+test('dingtalk-p4-release-readiness rejects test-only regression profile unless explicitly unlocked', () => {
+  const rejected = runScript(['--regression-profile', 'selftest'])
+
+  assert.notEqual(rejected.status, 0)
+  assert.match(rejected.stderr, /--regression-profile must be one of: ops, product, all/)
+
+  const tmpDir = makeTmpDir()
+  try {
+    const unlocked = runScript(['--regression-profile', 'selftest', '--regression-plan-only', '--output-dir', tmpDir], {
+      env: {
+        DINGTALK_P4_RELEASE_READINESS_ALLOW_SELFTEST: '1',
+      },
+    })
+    assert.notEqual(unlocked.status, 0)
+    assert.doesNotMatch(unlocked.stderr, /--regression-profile must be one of/)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
 })


### PR DESCRIPTION
## Summary
- Fail closed for DingTalk P4 release-readiness regression profiles: public operator runs now only accept ops/product/all.
- Keep selftest profiles available only when DINGTALK_P4_RELEASE_READINESS_ALLOW_SELFTEST=1 is explicitly set by tests.
- Add regression coverage and development/verification MD.

## Verification
- node --test scripts/ops/dingtalk-p4-release-readiness.test.mjs
- node --test scripts/ops/dingtalk-p4-release-readiness.test.mjs scripts/ops/dingtalk-p4-regression-gate.test.mjs
- node --test $(ls scripts/ops/*dingtalk-p4*.test.mjs scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs scripts/ops/validate-dingtalk-staging-evidence-packet.test.mjs 2>/dev/null | sort)
- node scripts/ops/dingtalk-p4-release-readiness.mjs --regression-profile selftest (expected reject)
- git diff --check

## Notes
- Local gate hardening only; no real DingTalk or 142/staging calls.