### PR TITLE
fix(dingtalk): make P4 smoke env template private

### DIFF
--- a/docs/development/dingtalk-final-development-plan-and-todo-20260423.md
+++ b/docs/development/dingtalk-final-development-plan-and-todo-20260423.md
@@ -2,9 +2,9 @@
 
 - Date: 2026-04-23
 - Goal: finish DingTalk group/person/form-access workflow through remote smoke and release evidence handoff
-- Current base branch: `codex/dingtalk-p4-no-email-admin-evidence-helper-20260423`
-- Current base commit: `154fafd5d`
-- Remaining work type: remote smoke execution, evidence collection, final handoff, and final verification notes
+- Current base branch: `codex/dingtalk-p4-next-20260423` from `origin/main`
+- Current base commit: `4e2c60ae1`
+- Remaining work type: private remote-smoke inputs, remote smoke execution, evidence collection, final handoff, product gate, and final verification notes
 
 ## Current State
 
@@ -23,12 +23,13 @@
 
 ## PR Stack To Confirm
 
-- [ ] Confirm #1104 CI success: unauthorized denial evidence contract
-- [ ] Confirm #1105 CI success: remote smoke TODO export
-- [ ] Confirm #1106 CI success: session status autorefresh
-- [ ] Confirm #1107 CI success: no-email admin evidence helper
-- [ ] Merge or promote the stack in order after earlier base PRs are merged
-- [ ] Re-run targeted local checks after any promotion or rebase
+- [x] Confirm #1104 merged: unauthorized denial evidence contract
+- [x] Confirm #1105 merged: remote smoke TODO export
+- [x] Confirm #1106 merged: session status autorefresh
+- [x] Confirm #1107 merged: no-email admin evidence helper
+- [x] Confirm #1118 merged: organization-scoped DingTalk group destination catalog v1
+- [x] Merge or promote the stack in order after earlier base PRs are merged
+- [x] Re-run targeted local checks after promotion to `origin/main`: `node scripts/ops/dingtalk-p4-regression-gate.mjs --profile ops --output-dir output/dingtalk-p4-regression-gate/142-ops --fail-fast`
 
 ## Remote Smoke Inputs
 
@@ -50,13 +51,15 @@
 
 ## Remote Smoke Execution
 
-- [ ] Create env template:
+- [x] Create env template with private file permissions:
 
 ```bash
 node scripts/ops/dingtalk-p4-smoke-session.mjs \
   --init-env-template output/dingtalk-p4-remote-smoke-session/dingtalk-p4.env
 ```
 
+- Generated locally at `output/dingtalk-p4-remote-smoke-session/dingtalk-p4.env`.
+- The template is intentionally untracked and is now written with `0600` permissions.
 - [ ] Fill the env file outside git.
 - [ ] Run the session:
 
@@ -187,8 +190,19 @@ node scripts/ops/dingtalk-p4-regression-gate.mjs \
   --output-dir output/dingtalk-p4-regression-gate/142-ops
 ```
 
-- [ ] Run the ops profile before final remote smoke.
-- [ ] Attach or reference `output/dingtalk-p4-regression-gate/142-ops/summary.json` and `summary.md` in final verification notes.
+- [x] Run the ops profile before final remote smoke.
+- [x] Attach or reference `output/dingtalk-p4-regression-gate/142-ops/summary.json` and `summary.md` in final verification notes.
+- [x] Run release readiness locally with the generated template and ops profile:
+
+```bash
+node scripts/ops/dingtalk-p4-release-readiness.mjs \
+  --p4-env-file output/dingtalk-p4-remote-smoke-session/dingtalk-p4.env \
+  --regression-profile ops \
+  --output-dir output/dingtalk-p4-release-readiness/142-local \
+  --allow-failures
+```
+
+- Current readiness status is `fail` only because private env values are intentionally blank: admin token, group A/B webhooks, allowlist, and manual target identities.
 
 ## Product Regression Gates
 

--- a/docs/development/dingtalk-p4-env-template-permission-development-20260423.md
+++ b/docs/development/dingtalk-p4-env-template-permission-development-20260423.md
@@ -1,0 +1,34 @@
+# DingTalk P4 Env Template Permission Development
+
+- Date: 2026-04-23
+- Branch: `codex/dingtalk-p4-next-20260423`
+- Base: `origin/main` at `4e2c60ae1`
+- Scope: make the P4 smoke-session env template compatible with the release readiness private-file gate
+
+## Problem
+
+`scripts/ops/dingtalk-p4-smoke-session.mjs --init-env-template` generated the editable P4 env file, but did not force private file permissions. The release readiness gate correctly rejected that file with `env-file-private-mode`, so an operator could generate the template from the documented smoke-session command and still fail readiness before any real secret values were entered.
+
+## Changes
+
+- `scripts/ops/dingtalk-p4-smoke-session.mjs` now writes the env template with `mode: 0o600` and calls `chmodSync(..., 0o600)` after write.
+- The CLI help and generated template now state that the template is written with `0600` permissions.
+- `scripts/ops/dingtalk-p4-smoke-session.test.mjs` now asserts the generated env template has `0600` permissions.
+- `docs/development/dingtalk-final-development-plan-and-todo-20260423.md` now reflects the current merged stack, generated env template, local `ops` gate pass, and release-readiness status.
+
+## Local Outputs
+
+- Env template: `output/dingtalk-p4-remote-smoke-session/dingtalk-p4.env`
+- Ops gate summary: `output/dingtalk-p4-regression-gate/142-ops/summary.json`
+- Ops gate markdown: `output/dingtalk-p4-regression-gate/142-ops/summary.md`
+- Release readiness summary: `output/dingtalk-p4-release-readiness/142-local/release-readiness-summary.json`
+- Release readiness markdown: `output/dingtalk-p4-release-readiness/142-local/release-readiness-summary.md`
+
+These outputs are intentionally untracked. The env file must be filled outside git with the real staging URL/token/webhook/user inputs.
+
+## Remaining Work
+
+- Fill private remote-smoke env values out-of-band.
+- Re-run release readiness without `--allow-failures` after the private env is complete.
+- Run final 142 remote smoke and record manual DingTalk evidence.
+- Run product profile when pnpm dependency/runtime state is ready.

--- a/docs/development/dingtalk-p4-env-template-permission-verification-20260423.md
+++ b/docs/development/dingtalk-p4-env-template-permission-verification-20260423.md
@@ -1,0 +1,67 @@
+# DingTalk P4 Env Template Permission Verification
+
+- Date: 2026-04-23
+- Branch: `codex/dingtalk-p4-next-20260423`
+- Base: `origin/main` at `4e2c60ae1`
+- Result: local script and ops readiness checks pass except intentionally missing private remote-smoke inputs
+
+## Commands Run
+
+```bash
+node --test scripts/ops/dingtalk-p4-smoke-session.test.mjs
+```
+
+- Result: pass, 6 tests.
+
+```bash
+node --test \
+  scripts/ops/dingtalk-p4-release-readiness.test.mjs \
+  scripts/ops/dingtalk-p4-env-bootstrap.test.mjs \
+  scripts/ops/dingtalk-p4-regression-gate.test.mjs
+```
+
+- Result: pass, 13 tests.
+
+```bash
+node scripts/ops/dingtalk-p4-smoke-session.mjs \
+  --init-env-template output/dingtalk-p4-remote-smoke-session/dingtalk-p4.env
+```
+
+- Result: env template generated.
+- Permission: `0600`.
+
+```bash
+node scripts/ops/dingtalk-p4-release-readiness.mjs \
+  --p4-env-file output/dingtalk-p4-remote-smoke-session/dingtalk-p4.env \
+  --regression-profile ops \
+  --output-dir output/dingtalk-p4-release-readiness/142-local \
+  --allow-failures
+```
+
+- Result: report generated with `overallStatus: "fail"` because private values are blank.
+- Fixed condition: `env-file-private-mode` is no longer a failed check.
+- Remaining failed env checks: `dingtalk_p4_auth_token`, `dingtalk_p4_group_a_webhook`, `group-a-webhook-shape`, `dingtalk_p4_group_b_webhook`, `group-b-webhook-shape`, `allowlist-present`, `manual-targets-declared`.
+- Local regression gate inside readiness: `pass`.
+
+```bash
+node scripts/ops/dingtalk-p4-regression-gate.mjs \
+  --profile ops \
+  --output-dir output/dingtalk-p4-regression-gate/142-ops \
+  --fail-fast
+```
+
+- Result: pass.
+- Summary: 10 passed, 0 failed, 0 skipped.
+
+## Evidence Paths
+
+- `output/dingtalk-p4-regression-gate/142-ops/summary.json`
+- `output/dingtalk-p4-regression-gate/142-ops/summary.md`
+- `output/dingtalk-p4-release-readiness/142-local/release-readiness-summary.json`
+- `output/dingtalk-p4-release-readiness/142-local/release-readiness-summary.md`
+
+## Residual Risks
+
+- No real admin token, DingTalk webhook, or manual target identity was used in this verification.
+- Final remote smoke remains blocked until private env values are supplied outside git.
+- Product profile was not run because this slice only changed Node ops tooling and no workspace dependencies were installed in the fresh worktree.

--- a/scripts/ops/dingtalk-p4-smoke-session.mjs
+++ b/scripts/ops/dingtalk-p4-smoke-session.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { spawnSync } from 'node:child_process'
 import path from 'node:path'
 
@@ -27,7 +27,7 @@ strict compile. After the session succeeds, place manual artifacts in the
 generated workspace and run --finalize <session-dir>.
 
 Options:
-  --init-env-template <file>       Write a safe editable env template and exit
+  --init-env-template <file>       Write a private 0600 safe editable env template and exit
   --finalize <session-dir>         Run strict compile for an existing session and refresh session summary
   --env-file <file>                Optional KEY=VALUE file to read before env/CLI
   --api-base <url>                 Backend API base, default ${DEFAULT_API_BASE}
@@ -280,6 +280,7 @@ function parseArgs(argv) {
 function renderEnvTemplate() {
   return `# DingTalk P4 smoke session env template
 # Fill this file locally or on the staging host. Do not commit it.
+# This template is written with 0600 permissions by dingtalk-p4-smoke-session.mjs.
 # Run:
 #   node scripts/ops/dingtalk-p4-smoke-session.mjs --env-file <this-file> --output-dir output/dingtalk-p4-remote-smoke-session/<run>
 
@@ -315,7 +316,8 @@ DINGTALK_P4_NO_EMAIL_DINGTALK_EXTERNAL_ID=
 
 function writeEnvTemplate(file) {
   mkdirSync(path.dirname(file), { recursive: true })
-  writeFileSync(file, renderEnvTemplate(), 'utf8')
+  writeFileSync(file, renderEnvTemplate(), { encoding: 'utf8', mode: 0o600 })
+  chmodSync(file, 0o600)
   console.log(`Wrote ${relativePath(file)}`)
 }
 

--- a/scripts/ops/dingtalk-p4-smoke-session.test.mjs
+++ b/scripts/ops/dingtalk-p4-smoke-session.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import { spawn, spawnSync } from 'node:child_process'
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import http from 'node:http'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
@@ -319,6 +319,7 @@ test('dingtalk-p4-smoke-session writes an editable env template', () => {
     assert.match(content, /DINGTALK_P4_UNAUTHORIZED_USER_ID=/)
     assert.match(content, /DINGTALK_P4_NO_EMAIL_DINGTALK_EXTERNAL_ID=/)
     assert.doesNotMatch(content, /secret-admin-token/)
+    assert.equal(statSync(envPath).mode & 0o777, 0o600)
     assert.equal(existsSync(path.join(tmpDir, 'session-summary.json')), false)
   } finally {
     rmSync(tmpDir, { recursive: true, force: true })


### PR DESCRIPTION
## Summary
- Force `dingtalk-p4-smoke-session --init-env-template` output to `0600` so it passes the release-readiness private env-file gate.
- Add a smoke-session test assertion for generated env template permissions.
- Refresh the final DingTalk plan/TODO with the merged PR stack, local ops gate result, release-readiness status, and new development/verification docs.

## Verification
- `node --test scripts/ops/dingtalk-p4-smoke-session.test.mjs`
- `node --test scripts/ops/dingtalk-p4-release-readiness.test.mjs scripts/ops/dingtalk-p4-env-bootstrap.test.mjs scripts/ops/dingtalk-p4-regression-gate.test.mjs`
- `node scripts/ops/dingtalk-p4-regression-gate.mjs --profile ops --output-dir output/dingtalk-p4-regression-gate/142-ops --fail-fast`
- `node scripts/ops/dingtalk-p4-release-readiness.mjs --p4-env-file output/dingtalk-p4-remote-smoke-session/dingtalk-p4.env --regression-profile ops --output-dir output/dingtalk-p4-release-readiness/142-local --allow-failures` wrote a fail report only because private env values are blank; `env-file-private-mode` is no longer failing.
- `git diff --check`

## Notes
- No admin token, DingTalk webhook, signing secret, or manual target identity is committed or included in tracked docs.
- Runtime output remains under untracked `output/` paths.