### PR TITLE
docs(dingtalk): record P4 env template post-merge verification

### DIFF
--- a/docs/development/dingtalk-final-development-plan-and-todo-20260423.md
+++ b/docs/development/dingtalk-final-development-plan-and-todo-20260423.md
@@ -3,7 +3,7 @@
 - Date: 2026-04-23
 - Goal: finish DingTalk group/person/form-access workflow through remote smoke and release evidence handoff
 - Current base branch: `codex/dingtalk-p4-next-20260423` from `origin/main`
-- Current base commit: `4e2c60ae1`
+- Current base commit: `a432a97a1`
 - Remaining work type: private remote-smoke inputs, remote smoke execution, evidence collection, final handoff, product gate, and final verification notes
 
 ## Current State

--- a/docs/development/dingtalk-p4-env-template-permission-development-20260423.md
+++ b/docs/development/dingtalk-p4-env-template-permission-development-20260423.md
@@ -2,7 +2,7 @@
 
 - Date: 2026-04-23
 - Branch: `codex/dingtalk-p4-next-20260423`
-- Base: `origin/main` at `4e2c60ae1`
+- Base: `origin/main` at `a432a97a1`
 - Scope: make the P4 smoke-session env template compatible with the release readiness private-file gate
 
 ## Problem

--- a/docs/development/dingtalk-p4-env-template-permission-verification-20260423.md
+++ b/docs/development/dingtalk-p4-env-template-permission-verification-20260423.md
@@ -2,7 +2,7 @@
 
 - Date: 2026-04-23
 - Branch: `codex/dingtalk-p4-next-20260423`
-- Base: `origin/main` at `4e2c60ae1`
+- Base: `origin/main` at `a432a97a1`
 - Result: local script and ops readiness checks pass except intentionally missing private remote-smoke inputs
 
 ## Commands Run
@@ -20,7 +20,7 @@ node --test \
   scripts/ops/dingtalk-p4-regression-gate.test.mjs
 ```
 
-- Result: pass, 13 tests.
+- Result: pass, 14 tests.
 
 ```bash
 node scripts/ops/dingtalk-p4-smoke-session.mjs \
@@ -65,3 +65,15 @@ node scripts/ops/dingtalk-p4-regression-gate.mjs \
 - No real admin token, DingTalk webhook, or manual target identity was used in this verification.
 - Final remote smoke remains blocked until private env values are supplied outside git.
 - Product profile was not run because this slice only changed Node ops tooling and no workspace dependencies were installed in the fresh worktree.
+
+## Post-Merge Verification - 2026-04-23
+
+- Verified after #1119 and #1120 were merged into `origin/main@a432a97a1`.
+- Re-ran the smoke-session permission test, adjacent release-readiness/env-bootstrap/regression-gate tests, ops regression gate, release readiness with blank private env, and `git diff --check`.
+- Smoke-session test result: 6 passed.
+- Adjacent release-readiness/env-bootstrap/regression-gate test result: 14 passed.
+- Env template permission: `0600`.
+- Ops gate result: 10 passed / 0 failed / 0 skipped.
+- Release readiness result: `overallStatus: "fail"` only because private env values remain blank.
+- Remaining failed env checks after the permission fix: `dingtalk_p4_auth_token`, `dingtalk_p4_group_a_webhook`, `group-a-webhook-shape`, `dingtalk_p4_group_b_webhook`, `group-b-webhook-shape`, `allowlist-present`, `manual-targets-declared`.
+- Conclusion: the env-template permission issue is fixed; the remote-smoke blocker is now strictly missing private staging credentials and manual target identities, not file mode.


### PR DESCRIPTION
## Summary
- Update DingTalk P4 env-template verification docs after #1119 and #1120 merged.
- Correct base commit references from 4e2c60ae1 to a432a97a1.
- Record the post-merge smoke-session permission, ops gate, and release-readiness checks.

## Verification
- `node --test scripts/ops/dingtalk-p4-smoke-session.test.mjs`
- `node --test scripts/ops/dingtalk-p4-release-readiness.test.mjs scripts/ops/dingtalk-p4-env-bootstrap.test.mjs scripts/ops/dingtalk-p4-regression-gate.test.mjs`
- `node scripts/ops/dingtalk-p4-smoke-session.mjs --init-env-template output/dingtalk-p4-remote-smoke-session/postmerge-1120-doc/dingtalk-p4.env`
- `node scripts/ops/dingtalk-p4-regression-gate.mjs --profile ops --output-dir output/dingtalk-p4-regression-gate/postmerge-1120-doc-ops --fail-fast`
- `node scripts/ops/dingtalk-p4-release-readiness.mjs --p4-env-file output/dingtalk-p4-remote-smoke-session/postmerge-1120-doc/dingtalk-p4.env --regression-profile ops --output-dir output/dingtalk-p4-release-readiness/postmerge-1120-doc --allow-failures`
- `git diff --check`

Release-readiness still fails only because private staging values are blank, which is the expected blocked state before real remote smoke.