### PR TITLE
chore(dingtalk): add safe setter for P4 staging env

### DIFF
--- a/docs/development/dingtalk-p4-env-safe-set-development-20260423.md
+++ b/docs/development/dingtalk-p4-env-safe-set-development-20260423.md
@@ -1,0 +1,56 @@
+# DingTalk P4 Env Safe Set Development
+
+- Date: 2026-04-23
+- Branch: `codex/dingtalk-p4-env-safe-set-20260423`
+- Base: `origin/main` at `76ddfeacd`
+- Scope: add a safe non-echoing way to fill the private DingTalk P4 staging env file
+
+## Problem
+
+`$HOME/.config/yuantus/dingtalk-p4-staging.env` exists with private `0600` permissions, but the required secret and target fields are still blank. Operators previously had to edit the file manually, and the only automated command was readiness checking after the fact.
+
+Manual editing creates two avoidable risks:
+
+- secret values can be accidentally pasted into shell output or committed files during debugging;
+- malformed or unsupported keys can be added without feedback until the release-readiness gate fails.
+
+## Changes
+
+- Extended `scripts/ops/dingtalk-p4-env-bootstrap.mjs` with safe update actions:
+  - `--set KEY=VALUE` for known DingTalk P4 env keys;
+  - `--set-from-env KEY` to copy secret values from the process environment without placing them in command output;
+  - `--unset KEY` to blank a known key.
+- Restricted updates to the existing DingTalk P4 key allowlist.
+- Preserved private file permissions by rewriting the env file with `0600` and calling `chmodSync(..., 0o600)`.
+- Redacted all secret-key update output. Secret values are never printed; non-secret list fields print counts only.
+- Added focused tests for safe update, missing process env values, unknown keys, and post-update readiness.
+
+## Operator Flow
+
+```bash
+DINGTALK_P4_AUTH_TOKEN="<jwt>" \
+node scripts/ops/dingtalk-p4-env-bootstrap.mjs \
+  --p4-env-file "$HOME/.config/yuantus/dingtalk-p4-staging.env" \
+  --set-from-env DINGTALK_P4_AUTH_TOKEN \
+  --set 'DINGTALK_P4_GROUP_A_WEBHOOK=https://oapi.dingtalk.com/robot/send?access_token=...' \
+  --set 'DINGTALK_P4_GROUP_B_WEBHOOK=https://oapi.dingtalk.com/robot/send?access_token=...' \
+  --set 'DINGTALK_P4_ALLOWED_USER_IDS=<authorized-local-user-id>' \
+  --set 'DINGTALK_P4_UNAUTHORIZED_USER_ID=<unauthorized-local-user-id>' \
+  --set 'DINGTALK_P4_NO_EMAIL_DINGTALK_EXTERNAL_ID=<no-email-dingtalk-external-id>'
+```
+
+Then run:
+
+```bash
+node scripts/ops/dingtalk-p4-release-readiness.mjs \
+  --p4-env-file "$HOME/.config/yuantus/dingtalk-p4-staging.env" \
+  --regression-profile ops
+```
+
+Only when release readiness passes should the real 142 remote smoke session start.
+
+## Non-Goals
+
+- No real staging secret values were added to the repository.
+- No remote smoke was executed in this slice.
+- No DingTalk webhook or backend API call was made by the new update path.

--- a/docs/development/dingtalk-p4-env-safe-set-verification-20260423.md
+++ b/docs/development/dingtalk-p4-env-safe-set-verification-20260423.md
@@ -1,0 +1,72 @@
+# DingTalk P4 Env Safe Set Verification
+
+- Date: 2026-04-23
+- Branch: `codex/dingtalk-p4-env-safe-set-20260423`
+- Base: `origin/main` at `76ddfeacd`
+- Result: safe env update tooling passes; real 142 remote smoke remains blocked because private staging values are still blank
+
+## Current Real Env Status
+
+Checked `$HOME/.config/yuantus/dingtalk-p4-staging.env` without printing raw secret values.
+
+- File exists.
+- File mode is `0600`.
+- `DINGTALK_P4_AUTH_TOKEN` is blank.
+- `DINGTALK_P4_GROUP_A_WEBHOOK` is blank.
+- `DINGTALK_P4_GROUP_B_WEBHOOK` is blank.
+- Allowlist fields are blank.
+- Manual target identities are blank.
+
+Release readiness with the real private env was run with `--allow-failures` and produced:
+
+- Output: `output/dingtalk-p4-release-readiness/real-env-20260423-152945/release-readiness-summary.json`
+- Overall status: `fail`
+- Regression gate: `pass`, 10 passed / 0 failed / 0 skipped
+- Failed env checks: `dingtalk_p4_auth_token`, `dingtalk_p4_group_a_webhook`, `group-a-webhook-shape`, `dingtalk_p4_group_b_webhook`, `group-b-webhook-shape`, `allowlist-present`, `manual-targets-declared`
+
+## Commands Run
+
+```bash
+node --check scripts/ops/dingtalk-p4-env-bootstrap.mjs
+node --check scripts/ops/dingtalk-p4-env-bootstrap.test.mjs
+```
+
+- Result: pass.
+
+```bash
+node --test scripts/ops/dingtalk-p4-env-bootstrap.test.mjs
+```
+
+- Result: pass, 6 tests.
+
+```bash
+node --test \
+  scripts/ops/dingtalk-p4-env-bootstrap.test.mjs \
+  scripts/ops/dingtalk-p4-release-readiness.test.mjs
+```
+
+- Result: pass, 12 tests.
+
+```bash
+TMPDIR=$(mktemp -d)
+ENV_FILE="$TMPDIR/dingtalk-p4.env"
+OUT="$TMPDIR/readiness"
+node scripts/ops/dingtalk-p4-env-bootstrap.mjs --init --p4-env-file "$ENV_FILE"
+DINGTALK_P4_AUTH_TOKEN='secret-admin-token' \
+node scripts/ops/dingtalk-p4-env-bootstrap.mjs \
+  --p4-env-file "$ENV_FILE" \
+  --set-from-env DINGTALK_P4_AUTH_TOKEN \
+  --set 'DINGTALK_P4_GROUP_A_WEBHOOK=https://oapi.dingtalk.com/robot/send?access_token=robot-secret-a' \
+  --set 'DINGTALK_P4_GROUP_B_WEBHOOK=https://oapi.dingtalk.com/robot/send?access_token=robot-secret-b' \
+  --set 'DINGTALK_P4_ALLOWED_USER_IDS=user_authorized' \
+  --set 'DINGTALK_P4_UNAUTHORIZED_USER_ID=user_unauthorized' \
+  --set 'DINGTALK_P4_NO_EMAIL_DINGTALK_EXTERNAL_ID=dt_no_email_001'
+node scripts/ops/dingtalk-p4-env-bootstrap.mjs --check --p4-env-file "$ENV_FILE" --output-dir "$OUT"
+```
+
+- Result: readiness pass.
+- Stdout was checked for `secret-admin-token`, `robot-secret-a`, and `robot-secret-b`; none were printed.
+
+## Residual Risk
+
+The new helper makes filling the env safer, but it does not create or discover the real values. A maintainer still needs to provide the staging admin JWT, two DingTalk robot webhooks, allowlist IDs, unauthorized user ID, and no-email DingTalk external ID before real remote smoke can run.

--- a/output/delivery/dingtalk-p4-env-safe-set-20260423/TEST_AND_VERIFICATION.md
+++ b/output/delivery/dingtalk-p4-env-safe-set-20260423/TEST_AND_VERIFICATION.md
@@ -1,0 +1,31 @@
+# DingTalk P4 Env Safe Set - Test And Verification
+
+- Date: 2026-04-23
+- Branch: `codex/dingtalk-p4-env-safe-set-20260423`
+- Scope: safe private-env update support for DingTalk P4 staging smoke
+
+## Development Summary
+
+- Added `--set`, `--set-from-env`, and `--unset` to `scripts/ops/dingtalk-p4-env-bootstrap.mjs`.
+- Updates are restricted to known DingTalk P4 env keys.
+- The private env file is always rewritten as `0600`.
+- Secret update output is redacted; list fields report counts only.
+
+## Verification
+
+- `node --check scripts/ops/dingtalk-p4-env-bootstrap.mjs`: pass.
+- `node --check scripts/ops/dingtalk-p4-env-bootstrap.test.mjs`: pass.
+- `node --test scripts/ops/dingtalk-p4-env-bootstrap.test.mjs`: 6/6 pass.
+- `node --test scripts/ops/dingtalk-p4-env-bootstrap.test.mjs scripts/ops/dingtalk-p4-release-readiness.test.mjs`: 12/12 pass.
+- Temporary safe-set smoke reached readiness pass and did not print test secret strings.
+- Real `$HOME/.config/yuantus/dingtalk-p4-staging.env` remains fail-closed because required values are blank.
+
+## Next Step
+
+Fill the private env with real staging values using `--set-from-env` for secrets, then run:
+
+```bash
+node scripts/ops/dingtalk-p4-release-readiness.mjs \
+  --p4-env-file "$HOME/.config/yuantus/dingtalk-p4-staging.env" \
+  --regression-profile ops
+```

--- a/scripts/ops/dingtalk-p4-env-bootstrap.mjs
+++ b/scripts/ops/dingtalk-p4-env-bootstrap.mjs
@@ -9,6 +9,24 @@ const DEFAULT_OUTPUT_ROOT = 'output/dingtalk-p4-env-readiness'
 const DEFAULT_API_BASE = 'http://142.171.239.56:8900'
 const DEFAULT_WEB_BASE = 'http://142.171.239.56:8081'
 
+const P4_ENV_KEYS = [
+  'DINGTALK_P4_API_BASE',
+  'DINGTALK_P4_WEB_BASE',
+  'DINGTALK_P4_AUTH_TOKEN',
+  'DINGTALK_P4_GROUP_A_WEBHOOK',
+  'DINGTALK_P4_GROUP_B_WEBHOOK',
+  'DINGTALK_P4_GROUP_A_SECRET',
+  'DINGTALK_P4_GROUP_B_SECRET',
+  'DINGTALK_P4_ALLOWED_USER_IDS',
+  'DINGTALK_P4_ALLOWED_MEMBER_GROUP_IDS',
+  'DINGTALK_P4_PERSON_USER_IDS',
+  'DINGTALK_P4_AUTHORIZED_USER_ID',
+  'DINGTALK_P4_UNAUTHORIZED_USER_ID',
+  'DINGTALK_P4_NO_EMAIL_DINGTALK_EXTERNAL_ID',
+]
+
+const P4_ENV_KEY_SET = new Set(P4_ENV_KEYS)
+
 const SECRET_KEYS = new Set([
   'DINGTALK_P4_AUTH_TOKEN',
   'DINGTALK_P4_GROUP_A_WEBHOOK',
@@ -31,6 +49,9 @@ Options:
   --output-dir <dir>        Report output dir, default ${DEFAULT_OUTPUT_ROOT}/<run-id>
   --api-base <url>          Template API base, default ${DEFAULT_API_BASE}
   --web-base <url>          Template web base, default ${DEFAULT_WEB_BASE}
+  --set <KEY=VALUE>         Safely update one known P4 env key without echoing the value
+  --set-from-env <KEY>      Copy one known P4 env key from the current process environment
+  --unset <KEY>             Clear one known P4 env key
   --force                   Allow --init to overwrite an existing env file
   --help                    Show this help
 
@@ -38,6 +59,8 @@ Typical flow:
   node scripts/ops/dingtalk-p4-env-bootstrap.mjs --init
   # Fill ${DEFAULT_ENV_FILE} outside git.
   node scripts/ops/dingtalk-p4-env-bootstrap.mjs --check
+  # Or safely update fields without printing raw secret values:
+  DINGTALK_P4_AUTH_TOKEN=... node scripts/ops/dingtalk-p4-env-bootstrap.mjs --set-from-env DINGTALK_P4_AUTH_TOKEN
   node scripts/ops/dingtalk-p4-smoke-session.mjs --env-file ${DEFAULT_ENV_FILE} --require-manual-targets --output-dir output/dingtalk-p4-remote-smoke-session/142-session
 `)
 }
@@ -59,6 +82,9 @@ function parseArgs(argv) {
     apiBase: DEFAULT_API_BASE,
     webBase: DEFAULT_WEB_BASE,
     force: false,
+    set: [],
+    setFromEnv: [],
+    unset: [],
   }
 
   for (let i = 0; i < argv.length; i += 1) {
@@ -87,6 +113,18 @@ function parseArgs(argv) {
         opts.webBase = readRequiredValue(argv, i, arg)
         i += 1
         break
+      case '--set':
+        opts.set.push(parseEnvAssignment(readRequiredValue(argv, i, arg)))
+        i += 1
+        break
+      case '--set-from-env':
+        opts.setFromEnv.push(validateP4EnvKey(readRequiredValue(argv, i, arg), arg))
+        i += 1
+        break
+      case '--unset':
+        opts.unset.push(validateP4EnvKey(readRequiredValue(argv, i, arg), arg))
+        i += 1
+        break
       case '--force':
         opts.force = true
         break
@@ -99,11 +137,27 @@ function parseArgs(argv) {
     }
   }
 
-  if (!opts.init && !opts.check) {
-    throw new Error('expected --init, --check, or both')
+  if (!opts.init && !opts.check && opts.set.length === 0 && opts.setFromEnv.length === 0 && opts.unset.length === 0) {
+    throw new Error('expected --init, --check, --set, --set-from-env, or --unset')
   }
 
   return opts
+}
+
+function validateP4EnvKey(key, flag = '--set') {
+  if (!P4_ENV_KEY_SET.has(key)) {
+    throw new Error(`${flag} only supports known DingTalk P4 env keys: ${P4_ENV_KEYS.join(', ')}`)
+  }
+  return key
+}
+
+function parseEnvAssignment(raw) {
+  const equalsIndex = raw.indexOf('=')
+  if (equalsIndex <= 0) {
+    throw new Error('--set expects KEY=VALUE')
+  }
+  const key = validateP4EnvKey(raw.slice(0, equalsIndex), '--set')
+  return { key, value: raw.slice(equalsIndex + 1) }
 }
 
 function makeRunId() {
@@ -154,6 +208,74 @@ function initEnv(opts) {
   writeFileSync(opts.envFile, renderTemplate(opts), { encoding: 'utf8', mode: 0o600 })
   chmodSync(opts.envFile, 0o600)
   console.log(`[dingtalk-p4-env-bootstrap] wrote private env template: ${opts.envFile}`)
+}
+
+function collectUpdates(opts) {
+  const updates = new Map()
+  for (const { key, value } of opts.set) {
+    updates.set(key, value)
+  }
+  for (const key of opts.setFromEnv) {
+    if (process.env[key] === undefined) {
+      throw new Error(`--set-from-env ${key} is not present in the process environment`)
+    }
+    updates.set(key, process.env[key] ?? '')
+  }
+  for (const key of opts.unset) {
+    updates.set(key, '')
+  }
+  return updates
+}
+
+function summarizeUpdateValue(key, value) {
+  if (!value) return 'blank'
+  const listKeys = new Set([
+    'DINGTALK_P4_ALLOWED_USER_IDS',
+    'DINGTALK_P4_ALLOWED_MEMBER_GROUP_IDS',
+    'DINGTALK_P4_PERSON_USER_IDS',
+  ])
+  if (listKeys.has(key)) return `${splitList(value).length} entries`
+  if (SECRET_KEYS.has(key)) return `<redacted>, ${value.length} chars`
+  return `set, ${value.length} chars`
+}
+
+function renderEnvLine(key, value) {
+  return `${key}=${quoteEnv(value)}`
+}
+
+function updateEnv(opts) {
+  const updates = collectUpdates(opts)
+  if (updates.size === 0) return
+  if (!existsSync(opts.envFile)) {
+    throw new Error(`env file does not exist: ${opts.envFile}; run --init first`)
+  }
+
+  const content = readFileSync(opts.envFile, 'utf8')
+  const lines = content.replace(/\r?\n$/, '').split(/\r?\n/)
+  const remaining = new Map(updates)
+  const nextLines = lines.map((line) => {
+    const match = line.match(/^([A-Za-z_][A-Za-z0-9_]*)=/)
+    if (!match || !remaining.has(match[1])) return line
+    const key = match[1]
+    const value = remaining.get(key)
+    remaining.delete(key)
+    return renderEnvLine(key, value)
+  })
+
+  if (remaining.size > 0 && nextLines.some((line) => line.trim())) {
+    nextLines.push('')
+  }
+  for (const [key, value] of remaining.entries()) {
+    nextLines.push(renderEnvLine(key, value))
+  }
+
+  writeFileSync(opts.envFile, `${nextLines.join('\n')}\n`, { encoding: 'utf8', mode: 0o600 })
+  chmodSync(opts.envFile, 0o600)
+
+  console.log(`[dingtalk-p4-env-bootstrap] updated private env: ${opts.envFile}`)
+  for (const [key, value] of updates.entries()) {
+    console.log(`- ${key}: ${summarizeUpdateValue(key, value)}`)
+  }
 }
 
 function unquoteEnvValue(value) {
@@ -402,6 +524,7 @@ function main() {
   try {
     const opts = parseArgs(process.argv.slice(2))
     if (opts.init) initEnv(opts)
+    updateEnv(opts)
     if (opts.check) checkReadiness(opts)
   } catch (error) {
     console.error(`[dingtalk-p4-env-bootstrap] ERROR: ${redactString(error instanceof Error ? error.message : String(error))}`)

--- a/scripts/ops/dingtalk-p4-env-bootstrap.test.mjs
+++ b/scripts/ops/dingtalk-p4-env-bootstrap.test.mjs
@@ -13,11 +13,15 @@ function makeTmpDir() {
   return mkdtempSync(path.join(tmpdir(), 'dingtalk-p4-env-bootstrap-'))
 }
 
-function runScript(args) {
+function runScript(args, env = {}) {
+  const nextEnv = { ...process.env, ...env }
+  for (const [key, value] of Object.entries(env)) {
+    if (value === undefined) delete nextEnv[key]
+  }
   return spawnSync(process.execPath, [scriptPath, ...args], {
     cwd: repoRoot,
     encoding: 'utf8',
-    env: { ...process.env },
+    env: nextEnv,
   })
 }
 
@@ -129,6 +133,85 @@ test('dingtalk-p4-env-bootstrap passes with complete env and derives authorized 
     })
     assert.equal(summary.nextCommands.some((command) => command.includes('--require-manual-targets')), true)
     assert.doesNotMatch(readFileSync(path.join(outputDir, 'readiness-summary.md'), 'utf8'), /robot-secret/)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-p4-env-bootstrap safely updates private env values without leaking secrets', () => {
+  const tmpDir = makeTmpDir()
+  const envFile = path.join(tmpDir, 'dingtalk-p4.env')
+  const outputDir = path.join(tmpDir, 'readiness')
+
+  try {
+    const init = runScript(['--init', '--p4-env-file', envFile])
+    assert.equal(init.status, 0, init.stderr || init.stdout)
+
+    const update = runScript([
+      '--p4-env-file',
+      envFile,
+      '--set-from-env',
+      'DINGTALK_P4_AUTH_TOKEN',
+      '--set',
+      'DINGTALK_P4_GROUP_A_WEBHOOK=https://oapi.dingtalk.com/robot/send?access_token=robot-secret-a',
+      '--set',
+      'DINGTALK_P4_GROUP_B_WEBHOOK=https://oapi.dingtalk.com/robot/send?access_token=robot-secret-b',
+      '--set',
+      'DINGTALK_P4_ALLOWED_USER_IDS=user_authorized,user_secondary',
+      '--set',
+      'DINGTALK_P4_PERSON_USER_IDS=user_person_bound',
+      '--set',
+      'DINGTALK_P4_UNAUTHORIZED_USER_ID=user_unauthorized',
+      '--set',
+      'DINGTALK_P4_NO_EMAIL_DINGTALK_EXTERNAL_ID=dt_no_email_001',
+    ], {
+      DINGTALK_P4_AUTH_TOKEN: 'secret-admin-token',
+    })
+
+    assert.equal(update.status, 0, update.stderr || update.stdout)
+    assert.doesNotMatch(update.stdout, /secret-admin-token/)
+    assert.doesNotMatch(update.stdout, /robot-secret-a/)
+    assert.match(update.stdout, /DINGTALK_P4_AUTH_TOKEN: <redacted>/)
+    assert.match(update.stdout, /DINGTALK_P4_ALLOWED_USER_IDS: 2 entries/)
+    if (process.platform !== 'win32') {
+      assert.equal(statSync(envFile).mode & 0o777, 0o600)
+    }
+
+    const envText = readFileSync(envFile, 'utf8')
+    assert.match(envText, /DINGTALK_P4_AUTH_TOKEN="secret-admin-token"/)
+    assert.match(envText, /access_token=robot-secret-a/)
+
+    const check = runScript(['--check', '--p4-env-file', envFile, '--output-dir', outputDir])
+    assert.equal(check.status, 0, check.stderr || check.stdout)
+    const summary = JSON.parse(readFileSync(path.join(outputDir, 'readiness-summary.json'), 'utf8'))
+    assert.equal(summary.overallStatus, 'pass')
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-p4-env-bootstrap rejects unsafe update keys and missing source env values', () => {
+  const tmpDir = makeTmpDir()
+  const envFile = path.join(tmpDir, 'dingtalk-p4.env')
+
+  try {
+    const init = runScript(['--init', '--p4-env-file', envFile])
+    assert.equal(init.status, 0, init.stderr || init.stdout)
+
+    const unknown = runScript(['--p4-env-file', envFile, '--set', 'UNKNOWN=value'])
+    assert.equal(unknown.status, 1)
+    assert.match(unknown.stderr, /only supports known DingTalk P4 env keys/)
+
+    const missing = runScript([
+      '--p4-env-file',
+      envFile,
+      '--set-from-env',
+      'DINGTALK_P4_AUTH_TOKEN',
+    ], {
+      DINGTALK_P4_AUTH_TOKEN: undefined,
+    })
+    assert.equal(missing.status, 1)
+    assert.match(missing.stderr, /is not present in the process environment/)
   } finally {
     rmSync(tmpDir, { recursive: true, force: true })
   }


### PR DESCRIPTION
## Summary
- Add `--set`, `--set-from-env`, and `--unset` to `dingtalk-p4-env-bootstrap.mjs` for known P4 staging env keys.
- Keep the private env file at `0600` after updates.
- Redact secret update output and report list counts instead of raw values.
- Add development, verification, and delivery MDs.

## Verification
- `node --check scripts/ops/dingtalk-p4-env-bootstrap.mjs`
- `node --check scripts/ops/dingtalk-p4-env-bootstrap.test.mjs`
- `node --test scripts/ops/dingtalk-p4-env-bootstrap.test.mjs`
- `node --test scripts/ops/dingtalk-p4-env-bootstrap.test.mjs scripts/ops/dingtalk-p4-release-readiness.test.mjs`
- `node --test scripts/ops/dingtalk-p4-env-bootstrap.test.mjs scripts/ops/dingtalk-p4-release-readiness.test.mjs scripts/ops/dingtalk-p4-smoke-session.test.mjs`
- Temporary safe-set smoke reached readiness pass and stdout was checked for test secret leakage.

Real `$HOME/.config/yuantus/dingtalk-p4-staging.env` still fails readiness because required private values are blank; this PR only makes filling that env safer.