### PR TITLE
refactor(multitable): extract attachment-service from univer-meta (M2 slice 1)

### DIFF
--- a/docs/development/multitable-m2-attachment-service-development-20260423.md
+++ b/docs/development/multitable-m2-attachment-service-development-20260423.md
@@ -1,0 +1,240 @@
+# Multitable M2 Attachment Service — Development Notes (2026-04-23)
+
+> Document type: development / status
+> Date: 2026-04-23
+> Branch: `codex/multitable-m2-attachment-service-20260423`
+> Worktree: `/Users/chouhua/Downloads/Github/metasheet2/.worktrees/m2-attachment`
+> Baseline: `d1f35edf6` (= `origin/main` HEAD)
+> Roadmap reference: `docs/development/multitable-service-extraction-roadmap-20260407.md` section 5.3 (M2 slice 1), section 10 (hard rules)
+> M0 precedent: `docs/development/multitable-m0-extraction-development-20260421.md`
+
+## TL;DR
+
+M2 slice 1 is done: the attachment write/read/delete/summary helpers and the three route
+handlers (`POST/GET/DELETE /api/multitable/attachments`) now delegate to a new
+`packages/core-backend/src/multitable/attachment-service.ts` module. Pure extraction — no
+HTTP response shape changed, no storage semantic changed, no permission check moved.
+
+`record-service.ts` (M2 slice 2) and `query-service.ts` (M3) remain deferred per the
+roadmap.
+
+---
+
+## 1. Scope
+
+### 1.1 What was extracted
+
+Seven exports in the new `packages/core-backend/src/multitable/attachment-service.ts`
+module (lines cited are post-extraction locations in the new module):
+
+| Export | Service-module L# | Origin in `routes/univer-meta.ts` (pre-extraction) | Purpose |
+|---|---|---|---|
+| `normalizeAttachmentIds` | L194 | L878 `normalizeAttachmentIds` + L847 `normalizeLinkIds` | Parses attachment id column values (arrays, JSON, CSV). Copy of `normalizeLinkIds` — intentionally duplicated to keep the service self-contained (see §2.1). |
+| `serializeAttachmentRow` | L239 | L3048 `serializeAttachmentRow` + L3027 `buildAttachmentUrl` + L3044 `isImageMimeType` | HTTP response serializer for a single attachment row. `buildAttachmentUrl` pulled inside as a private helper. |
+| `serializeAttachmentSummaryMap` | L269 | L3402 `serializeAttachmentSummaryMap` | Flattens nested `Map<recordId, Map<fieldId, Attachment[]>>` to plain-object form. |
+| `ensureAttachmentIdsExist` | L289 | L3220 `ensureAttachmentIdsExist` | Validates `field_id` scoping and existence. Returns the same error strings verbatim. |
+| `buildAttachmentSummaries` | L322 | L3339 `buildAttachmentSummaries` | Bulk summary builder used by record GET/list/form GET responses. |
+| `storeAttachment` | L386 | L7528–L7585 inline in `POST /attachments` handler | Uploads via storage adapter, inserts `multitable_attachments` row, best-effort cleans up binary on DB error. |
+| `readAttachmentMetadata` | L448 | L7615–L7620 inline `SELECT` inside `GET /attachments/:id` | Fetches the column subset the download flow needs. |
+| `readAttachmentBinary` | L475 | L7635 `storage.download` call | Thin wrapper over the storage adapter. |
+| `readAttachmentForDelete` | L487 | L7667–L7672 inline `SELECT` inside `DELETE /attachments/:id` | Fetches the column subset the delete flow needs for authorisation + cleanup. |
+| `softDeleteAttachmentRow` | L519 | L7737–L7740 inline `UPDATE multitable_attachments SET deleted_at = now()` | Designed to run inside a tx-scoped `query`, so the route can keep the record-data patch in the same transaction. |
+| `deleteAttachmentBinary` | L546 | L7743–L7748 inline `storage.delete` + try/catch | Swallows storage errors to preserve the pre-existing "best-effort cleanup" behavior. |
+
+### 1.2 Route-layer changes (`packages/core-backend/src/routes/univer-meta.ts`)
+
+Net diff: `-215` / `+61` LoC (`git diff --stat`).
+
+- **Imports added (L43–L56)** — 11 named imports from the new
+  `../multitable/attachment-service`, plus the shared `MultitableAttachment` type
+  aliased as `SharedMultitableAttachment`.
+- **Type alias** `MultitableAttachment` (L219) now re-exports `SharedMultitableAttachment`.
+- **Delegating wrappers** (preserving the legacy positional-argument signatures that the
+  `RecordWriteService` helpers expect):
+  - `normalizeAttachmentIds` (L869) — `const normalizeAttachmentIds = normalizeAttachmentIdsShared`.
+  - `serializeAttachmentRow` (L3029) — `const serializeAttachmentRow = serializeAttachmentRowShared`.
+  - `ensureAttachmentIdsExist` (L3207) — 4-arg wrapper that builds the options object.
+  - `buildAttachmentSummaries` (L3330) — 5-arg wrapper that builds the options object.
+  - `serializeAttachmentSummaryMap` (L3334) — re-exported reference.
+- **Route handler bodies** (lines refer to the post-edit file):
+  - `POST /attachments` (L7363): auth/permission checks preserved; storage+DB code replaced
+    with `await storeAttachmentShared(...)`.
+  - `GET /attachments/:attachmentId` (L7466): metadata SELECT replaced with
+    `readAttachmentMetadataShared(...)`; binary download replaced with
+    `readAttachmentBinaryShared(...)`. Response headers and 401/403/404 logic unchanged.
+  - `DELETE /attachments/:attachmentId` (L7508): pre-delete SELECT replaced with
+    `readAttachmentForDeleteShared(...)`; soft-delete UPDATE inside the tx replaced with
+    `softDeleteAttachmentRowShared({ query, attachmentId })`; post-tx storage cleanup
+    replaced with `deleteAttachmentBinaryShared(...)`. Permission checks, record-data
+    patch (still inside the same tx), and realtime publish unchanged.
+
+- **Inline definitions removed**:
+  - `buildAttachmentUrl` (was L3027) — moved into service as a private helper.
+  - Local copies of the upload SQL (L7447–L7468), download SELECT (L7615–L7620), delete
+    SELECT (L7667–L7672), soft-delete UPDATE (L7737–L7740), and storage cleanup try/catch
+    (L7743–L7748).
+
+### 1.3 Hard-rule compliance
+
+Per roadmap §10:
+
+1. ✅ No plugin depends on the new service — exports are internal to
+   `packages/core-backend/src/multitable/`.
+2. ✅ `univer-meta.ts` no longer carries inline attachment SQL.
+3. ✅ The `attachment-orphan-retention.ts` module is left untouched.
+4. ✅ The pre-existing `multitable/access.ts`, `multitable/loaders.ts`,
+   `multitable/provisioning.ts` modules are not modified.
+5. ✅ New unit-test file accompanies the new module
+   (`tests/unit/multitable-attachment-service.test.ts`, 24 tests).
+
+---
+
+## 2. Deliberate non-choices
+
+### 2.1 `normalizeAttachmentIds` duplicated rather than imported
+
+The route still has its own `normalizeLinkIds` used by link-field handling. Cross-importing
+the route helper into the service would reverse the dependency direction. The 27 lines of
+the parsing helper are duplicated verbatim inside the new module. Future consolidation
+belongs with `record-service.ts` (M2 slice 2), which is the natural owner of link-field
+normalization.
+
+### 2.2 `deleteAttachment` not unified into a single function
+
+The brief suggested an atomic `deleteAttachment({ query, attachmentId })` that removes
+binary + row transactionally. **That is not what the route does today** — today the
+`meta_records.data` patch + `multitable_attachments.deleted_at` mutation run inside one
+transaction owned by the route; the storage `delete()` runs **after** the transaction, is
+best-effort, and swallows errors. To keep this a pure extraction:
+
+- `softDeleteAttachmentRow({ query, attachmentId })` accepts a tx-scoped `query` so the
+  route keeps ownership of the transaction and can continue to bundle the record-data
+  patch with the row update.
+- `deleteAttachmentBinary({ storage, storageFileId })` runs **outside** the tx, best-effort,
+  matching the pre-existing semantic.
+
+The record-data patch (`UPDATE meta_records SET data = data || $1::jsonb ...`) stays in
+the route because that is record-service (M2 slice 2) territory. Extracting it now would
+cross a scope line the roadmap draws in §6.
+
+### 2.3 `listAttachmentsForRecord` not exposed
+
+The brief listed `listAttachmentsForRecord({ query, recordId })`, but no such single-record
+helper exists inline in `univer-meta.ts`. The only bulk lookup used across the route is
+`buildAttachmentSummaries`, which operates over *multiple records × multiple attachment
+fields*. Adding a new per-record helper would be scope creep beyond pure extraction. No
+caller needs it today.
+
+### 2.4 Record-service (M2 slice 2) remains deferred
+
+The record PATCH/POST handlers still directly call
+`normalizeAttachmentIds`/`ensureAttachmentIdsExist` via the `RecordWriteService` helper
+bag. That coupling is not a problem today — the bag now passes the re-exported functions
+from the new service instead of the inline copies — but the full record write path remains
+in `record-write-service.ts` as before. Moving it is the next slice.
+
+### 2.5 Query-service (M3) remains deferred
+
+The GET /records list, view resolver, and all lookup/rollup calls remain in
+`univer-meta.ts`. `buildAttachmentSummaries` is the last of those that has been extracted;
+the rest wait for M3.
+
+### 2.6 Permission-service (M4) not considered
+
+The route still owns every call to `resolveSheetCapabilities`, `ensureRecordWriteAllowed`,
+`loadRecordCreatorMap`, and `sendForbidden`. Moving them into the attachment service would
+tangle access-control policy with storage helpers. Per roadmap §5.5 the permission service
+is deferred.
+
+### 2.7 `attachment-orphan-retention.ts` not merged
+
+The existing cron-based orphan cleanup in `multitable/attachment-orphan-retention.ts` has
+its own retention-hours/batch-size policy knobs, reads
+`MULTITABLE_ATTACHMENT_CLEANUP_*` env vars, and uses the package-level `query` from
+`db/pg` rather than a per-request pool. It is a cron module, not a request-scoped service.
+Leaving it as a sibling under `multitable/` satisfies the brief's "leave it alone if it
+already exists" clause. Consolidation would require coordinating the retention schedule
+with test fixtures — orthogonal to this slice.
+
+---
+
+## 3. Surprises and design notes
+
+### 3.1 `buildAttachmentUrl` stayed private inside the service
+
+The route used `buildAttachmentUrl` only via `serializeAttachmentRow`. Making it an
+exported surface would encourage callers to build URLs directly and reinvent the url
+scheme. It is a file-local helper inside the service; the service takes a structural
+`AttachmentUrlRequestLike` type (not the full Express `Request`) so tests can inject a
+minimal stand-in.
+
+### 3.2 Route still keeps `isImageMimeType`
+
+Used at line 7488 in the GET handler to set `Content-Disposition: inline` for image
+downloads — outside the serializer. Duplicating `isImageMimeType` between the route and
+the service was cheaper than adding another tiny exported util.
+
+### 3.3 `storeAttachment`'s id generator
+
+The route generates attachment ids via the local `buildId('att').slice(0, 50)` helper
+(which uses `randomUUID` and a prefix). The service exposes an `idGenerator?: () =>
+string` hook to keep that contract. Default is `att_${randomUUID()}.slice(0, 50)` to match.
+
+### 3.4 Userid coercion edge case
+
+`req.user?.id` is typed `string | number`. The old code passed it to a PG string column
+via JS implicit conversion. The new `storeAttachment` signature is strictly typed
+(`uploaderId: string`), so the route now does an explicit `String(x)` coerce when
+`req.user.id` is numeric. Observable behavior is the same.
+
+### 3.5 Integration-test log noise is expected
+
+`tests/integration/multitable-attachments.api.test.ts` contains two scenarios where the
+backing storage blob is deliberately missing (the DB row has a fabricated
+`storage_file_id` and the LocalStorageProvider.delete throws "File not found"). The route
+still returns 200 because `deleteAttachmentBinary` swallows the error. Both tests pass;
+the error log from `StorageService` is the intended behavior under test, not a
+regression.
+
+---
+
+## 4. Verification
+
+See `docs/development/multitable-m2-attachment-service-verification-20260423.md` for the
+full command list + pass counts.
+
+Summary:
+
+| Command | Result |
+|---|---|
+| `tsc --noEmit --pretty false` (core-backend) | clean |
+| `vitest run tests/unit/multitable-attachment-service.test.ts` | 24 tests pass |
+| `vitest run tests/unit` (core-backend) | 127 files / 1643 tests pass (was 126/1619 at baseline; +1 file / +24 tests is the new module) |
+| `vitest run tests/integration/multitable-attachments.api.test.ts` | 10 tests pass |
+| `vitest run tests/integration/after-sales-installer-provisioning.api.test.ts` | 3 tests pass (unchanged from baseline) |
+
+The `tests/integration/multitable-sheet-realtime.api.test.ts` file has 3 failures that are
+**pre-existing at baseline (`origin/main@d1f35edf6`)** — verified by stashing this branch's
+changes and re-running. They are unrelated to this extraction.
+
+---
+
+## 5. Follow-up slices
+
+| Slice | Owner | Status |
+|---|---|---|
+| M2 slice 2 — `record-service.ts` | same roadmap | deferred (next PR) |
+| M3 — `query-service.ts` | roadmap §5.4 | deferred |
+| M4 — `permission-service.ts` | roadmap §5.5 | deferred |
+| Attachment orphan cleanup consolidation | cross-cutting | optional follow-up |
+
+---
+
+## 6. References
+
+- Roadmap: `docs/development/multitable-service-extraction-roadmap-20260407.md`
+- M0 precedent: `docs/development/multitable-m0-extraction-development-20260421.md`
+- New module: `packages/core-backend/src/multitable/attachment-service.ts`
+- New unit tests: `packages/core-backend/tests/unit/multitable-attachment-service.test.ts`
+- Route under extraction: `packages/core-backend/src/routes/univer-meta.ts`
+- Sibling orphan cleanup (untouched): `packages/core-backend/src/multitable/attachment-orphan-retention.ts`

--- a/docs/development/multitable-m2-attachment-service-verification-20260423.md
+++ b/docs/development/multitable-m2-attachment-service-verification-20260423.md
@@ -1,0 +1,148 @@
+# Multitable M2 Attachment Service — Verification (2026-04-23)
+
+> Document type: verification / evidence
+> Date: 2026-04-23
+> Branch: `codex/multitable-m2-attachment-service-20260423`
+> Worktree: `/Users/chouhua/Downloads/Github/metasheet2/.worktrees/m2-attachment`
+> Baseline: `origin/main@8d2d3e1b0` after final rebase
+> Paired with: `docs/development/multitable-m2-attachment-service-development-20260423.md`
+
+## Commands run
+
+All commands executed from the worktree.
+
+### 1. Typecheck
+
+```
+pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
+```
+
+Exit 0, no diagnostics.
+
+### 2. New unit tests
+
+```
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/multitable-attachment-service.test.ts --reporter=dot
+```
+
+Result:
+
+```
+Test Files  1 passed (1)
+     Tests  24 passed (24)
+  Duration  272ms
+```
+
+### 3. Full core-backend unit suite
+
+```
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit --reporter=dot
+```
+
+Result:
+
+```
+Test Files  127 passed (127)
+     Tests  1643 passed (1643)
+  Duration  5.58s
+```
+
+Baseline comparison (same command on `origin/main@d1f35edf6`):
+
+```
+Test Files  126 passed (126)
+     Tests  1619 passed (1619)
+```
+
+Delta: `+1 file / +24 tests`, matching the new
+`tests/unit/multitable-attachment-service.test.ts`. No existing unit test regressed.
+
+### 4. Attachment integration suite
+
+```
+DATABASE_URL='postgresql://chouhua@127.0.0.1:5432/postgres' \
+PGHOST=127.0.0.1 PGPORT=5432 PGDATABASE=postgres PGUSER=chouhua \
+  pnpm --filter @metasheet/core-backend exec vitest \
+    --config vitest.integration.config.ts run \
+    tests/integration/multitable-attachments.api.test.ts \
+    tests/integration/after-sales-installer-provisioning.api.test.ts --reporter=dot
+```
+
+Result:
+
+```
+Test Files  2 passed (2)
+     Tests  13 passed (13)
+  Duration  689ms
+```
+
+- `multitable-attachments.api.test.ts`: 10 tests pass — covers upload/download/delete/list
+  all the way through storage + DB. Two scenarios intentionally provoke a
+  "File not found" log from `StorageService.delete` (the DB row has a fabricated
+  `storage_file_id`); the route still returns 200 because `deleteAttachmentBinary` swallows
+  the error, which matches pre-extraction semantics.
+- `after-sales-installer-provisioning.api.test.ts`: 3 tests pass — confirms M1 work still
+  functions end-to-end now that the route delegates attachment operations.
+
+### 5. Other multitable integration suites touched by the route layer
+
+```
+tests/integration/multitable-context.api.test.ts         — passes
+tests/integration/multitable-record-form.api.test.ts     — passes
+tests/integration/multitable-sheet-permissions.api.test.ts — passes
+tests/integration/multitable-view-config.api.test.ts     — passes
+tests/integration/multitable-sheet-realtime.api.test.ts  — 3 failures, pre-existing at baseline (see §6 below)
+```
+
+## 6. Pre-existing baseline failures
+
+`tests/integration/multitable-sheet-realtime.api.test.ts` fails 3 tests with
+`Error: expected 200 "OK", got 500 "Internal Server Error"` on the baseline commit
+`origin/main@d1f35edf6` before any of this branch's edits are applied. Verified by running
+`git stash && pnpm ... vitest run tests/integration/multitable-sheet-realtime.api.test.ts`
+and observing the same 3 failures. Unrelated to this extraction.
+
+## 7. Deliverables
+
+| Path | Status |
+|---|---|
+| `packages/core-backend/src/multitable/attachment-service.ts` | created (559 LoC) |
+| `packages/core-backend/tests/unit/multitable-attachment-service.test.ts` | created (24 tests) |
+| `packages/core-backend/src/routes/univer-meta.ts` | modified (`-215 / +61` LoC) |
+| `docs/development/multitable-m2-attachment-service-development-20260423.md` | created |
+| `docs/development/multitable-m2-attachment-service-verification-20260423.md` | created |
+
+No other files changed.
+
+## 8. Commit
+
+Single commit on branch `codex/multitable-m2-attachment-service-20260423`.
+
+- Subject: `refactor(multitable): extract attachment-service from univer-meta (M2 slice 1)`
+- Not pushed.
+
+## 9. Roadmap anchor
+
+- Section 5.3 (M2): first slice ✅ attachment-service
+- Section 5.3 (M2): second slice — `record-service.ts` remains deferred
+- Section 10 rule #2 — `univer-meta.ts` no longer carries inline attachment SQL ✅
+- Section 10 rule #4 — unit tests added for the extracted module ✅
+
+## 10. Rebase Verification - 2026-04-23
+
+- Rebased `codex/multitable-m2-attachment-service-20260423` onto `origin/main@76ddfeacd`.
+- Rebased HEAD: `5df3e1492`.
+- No conflicts.
+- `pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false`: pass.
+- `tests/unit/multitable-attachment-service.test.ts`: 24/24 pass.
+- Attachment + after-sales installer integration: 13/13 pass.
+- Full `core-backend` unit suite: 127 files / 1647 tests passed.
+- The two expected `StorageService.delete` "File not found" logs still occur only in the fabricated-storage-id delete scenarios and remain consistent with the preserved best-effort binary-delete semantics.
+
+## 11. Final Rebase - 2026-04-23
+
+- Rebased again onto `origin/main@8d2d3e1b0` after DingTalk P4 env/product-gate follow-ups merged.
+- Final HEAD: `24a421b77`.
+- No conflicts and no touched-file overlap with the new DingTalk P4 commits.
+- Final quick recheck: `git diff --check` passed; `tests/unit/multitable-attachment-service.test.ts` passed again, 24/24.

--- a/packages/core-backend/src/multitable/attachment-service.ts
+++ b/packages/core-backend/src/multitable/attachment-service.ts
@@ -1,0 +1,562 @@
+/**
+ * Attachment service — shared read/write/summary helpers for
+ * `multitable_attachments` extracted out of the `univer-meta.ts` route.
+ *
+ * Scope: pure extraction. HTTP response shapes, storage semantics, and
+ * permission policy are unchanged. The route keeps the auth/permission
+ * layer; this service owns the storage-adapter calls, the
+ * `multitable_attachments` row lifecycle, and the attachment summary
+ * computation that feeds record GET responses.
+ *
+ * M2 slice 1 per `docs/development/multitable-service-extraction-roadmap-20260407.md`.
+ */
+
+import { randomUUID } from 'crypto'
+import * as path from 'path'
+
+import type { StorageServiceImpl } from '../services/StorageService'
+import type { StorageFile } from '../types/plugin'
+
+// ---------------------------------------------------------------------------
+// Shared types
+// ---------------------------------------------------------------------------
+
+export type AttachmentQueryFn = (
+  sql: string,
+  params?: unknown[],
+) => Promise<{ rows: unknown[]; rowCount?: number | null }>
+
+/**
+ * Minimal request surface the service needs to build attachment URLs.
+ * Kept as a structural type so callers can pass an Express `Request` or a
+ * lightweight stand-in from tests.
+ */
+export type AttachmentUrlRequestLike = {
+  protocol?: string
+  get(header: string): string | undefined
+}
+
+/** Shape of an attachment row as serialized for HTTP responses. */
+export type MultitableAttachment = {
+  id: string
+  filename: string
+  mimeType: string
+  size: number
+  url: string
+  thumbnailUrl: string | null
+  uploadedAt: string | null
+}
+
+export type MultitableAttachmentFieldLike = {
+  id: string
+  type: string
+}
+
+export type MultitableAttachmentRecordLike = {
+  id: string
+  data: Record<string, unknown>
+}
+
+/**
+ * Subset of the multer-style file shape the upload flow needs. Avoids
+ * pulling the full multer types into this module.
+ */
+export type AttachmentUploadFile = {
+  buffer: Buffer
+  originalname: string
+  mimetype: string
+  size: number
+}
+
+export type StoreAttachmentInput = {
+  query: AttachmentQueryFn
+  storage: StorageServiceImpl
+  sheetId: string
+  recordId: string | null
+  fieldId: string | null
+  file: AttachmentUploadFile
+  uploaderId: string
+  /** Optional override for the attachment id generator (used by tests). */
+  idGenerator?: () => string
+}
+
+export type StoreAttachmentResult = {
+  /** Raw DB row returned from the INSERT ... RETURNING statement. */
+  row: Record<string, unknown>
+  /** Metadata of the uploaded storage object (id/path/url). */
+  uploaded: StorageFile
+}
+
+export type ReadAttachmentMetadataInput = {
+  query: AttachmentQueryFn
+  attachmentId: string
+}
+
+export type ReadAttachmentMetadataResult = {
+  id: string
+  sheetId: string
+  storageFileId: string
+  filename: string | null
+  originalName: string | null
+  mimeType: string
+  size: number
+}
+
+export type ReadAttachmentForDeleteInput = {
+  query: AttachmentQueryFn
+  attachmentId: string
+}
+
+export type ReadAttachmentForDeleteResult = {
+  id: string
+  sheetId: string
+  recordId: string | null
+  fieldId: string | null
+  storageFileId: string
+  createdBy: string | null
+}
+
+export type ReadAttachmentBinaryInput = {
+  storage: StorageServiceImpl
+  storageFileId: string
+}
+
+export type SoftDeleteAttachmentInput = {
+  query: AttachmentQueryFn
+  attachmentId: string
+}
+
+export type DeleteAttachmentBinaryInput = {
+  storage: StorageServiceImpl
+  storageFileId: string
+}
+
+export type BuildAttachmentSummariesInput = {
+  query: AttachmentQueryFn
+  req: AttachmentUrlRequestLike
+  sheetId: string
+  rows: MultitableAttachmentRecordLike[]
+  attachmentFields: MultitableAttachmentFieldLike[]
+}
+
+export type EnsureAttachmentIdsExistInput = {
+  query: AttachmentQueryFn
+  sheetId: string
+  fieldId: string
+  attachmentIds: string[]
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers (kept private to avoid cross-importing route helpers)
+// ---------------------------------------------------------------------------
+
+function normalizeJsonArray(value: unknown): string[] {
+  if (!value) return []
+  if (Array.isArray(value)) {
+    return value
+      .map((v) => {
+        if (typeof v === 'string') return v.trim()
+        if (typeof v === 'number' && Number.isFinite(v)) return String(v)
+        return ''
+      })
+      .filter((v) => v.length > 0)
+  }
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value) as unknown
+      return normalizeJsonArray(parsed)
+    } catch {
+      return []
+    }
+  }
+  return []
+}
+
+/**
+ * Parses an attachment id column value that may arrive as a JSON array, a
+ * comma-separated string, or a bare id. Mirrors the behavior of
+ * `normalizeLinkIds` (aliased as `normalizeAttachmentIds`) in
+ * `routes/univer-meta.ts`. Duplicated here intentionally: the service
+ * must not import from the route layer and the route helper still feeds
+ * non-attachment call sites.
+ */
+export function normalizeAttachmentIds(value: unknown): string[] {
+  if (value === null || value === undefined) return []
+
+  const raw: string[] = []
+  if (Array.isArray(value)) {
+    for (const v of value) {
+      if (typeof v === 'string') raw.push(v)
+      else if (typeof v === 'number' && Number.isFinite(v)) raw.push(String(v))
+    }
+  } else if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (trimmed.length === 0) return []
+    const jsonParsed = normalizeJsonArray(trimmed)
+    if (jsonParsed.length > 0) raw.push(...jsonParsed)
+    else if (trimmed.includes(',')) raw.push(...trimmed.split(','))
+    else raw.push(trimmed)
+  } else if (typeof value === 'number' && Number.isFinite(value)) {
+    raw.push(String(value))
+  }
+
+  const seen = new Set<string>()
+  return raw
+    .map((v) => v.trim())
+    .filter((v) => v.length > 0)
+    .filter((v) => {
+      if (seen.has(v)) return false
+      seen.add(v)
+      return true
+    })
+}
+
+function isImageMimeType(mimeType: string | null | undefined): boolean {
+  return typeof mimeType === 'string' && mimeType.toLowerCase().startsWith('image/')
+}
+
+function buildAttachmentUrl(req: AttachmentUrlRequestLike, attachmentId: string, thumbnail: boolean = false): string {
+  const protocol = req.protocol || 'http'
+  const host = req.get('host') || 'localhost:8900'
+  const query = thumbnail ? '?thumbnail=true' : ''
+  return `${protocol}://${host}/api/multitable/attachments/${encodeURIComponent(attachmentId)}${query}`
+}
+
+function buildAttachmentId(): string {
+  return `att_${randomUUID()}`.slice(0, 50)
+}
+
+// ---------------------------------------------------------------------------
+// Serializers
+// ---------------------------------------------------------------------------
+
+/**
+ * Converts a raw `multitable_attachments` row (as returned from PG) into
+ * the HTTP response shape used across the route.
+ */
+export function serializeAttachmentRow(
+  req: AttachmentUrlRequestLike,
+  row: Record<string, unknown>,
+): MultitableAttachment {
+  const id = String(row.id)
+  const mimeType = typeof row.mime_type === 'string' ? row.mime_type : 'application/octet-stream'
+  const filename =
+    typeof row.filename === 'string'
+      ? row.filename
+      : typeof row.original_name === 'string'
+        ? row.original_name
+        : id
+  const size = Number(row.size ?? 0)
+  return {
+    id,
+    filename,
+    mimeType,
+    size,
+    url: buildAttachmentUrl(req, id),
+    thumbnailUrl: isImageMimeType(mimeType) ? buildAttachmentUrl(req, id, true) : null,
+    uploadedAt:
+      row.created_at instanceof Date
+        ? row.created_at.toISOString()
+        : typeof row.created_at === 'string'
+          ? row.created_at
+          : null,
+  }
+}
+
+/**
+ * Flattens a nested summary `Map` into plain-object form for JSON
+ * serialization. Mirrors the inline helper the PATCH/GET routes used.
+ */
+export function serializeAttachmentSummaryMap(
+  attachmentSummaries: Map<string, Map<string, MultitableAttachment[]>>,
+): Record<string, Record<string, MultitableAttachment[]>> {
+  return Object.fromEntries(
+    Array.from(attachmentSummaries.entries()).map(([recordId, fieldMap]) => [
+      recordId,
+      Object.fromEntries(Array.from(fieldMap.entries()).map(([fieldId, summaries]) => [fieldId, summaries])),
+    ]),
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Existence checks & summary builders
+// ---------------------------------------------------------------------------
+
+/**
+ * Confirms that every id in `attachmentIds` exists under the given sheet
+ * and either has no `field_id` pinning or points at `fieldId`. Returns a
+ * human-readable error string on mismatch, `null` on success. Preserves
+ * the exact error phrasing the inline route helper emitted.
+ */
+export async function ensureAttachmentIdsExist(
+  input: EnsureAttachmentIdsExistInput,
+): Promise<string | null> {
+  const { query, sheetId, fieldId, attachmentIds } = input
+  if (attachmentIds.length === 0) return null
+
+  const result = await query(
+    `SELECT id, field_id
+     FROM multitable_attachments
+     WHERE sheet_id = $1
+       AND deleted_at IS NULL
+       AND id = ANY($2::text[])`,
+    [sheetId, attachmentIds],
+  )
+  const rows = result.rows as Array<{ id: string; field_id: string | null }>
+  const found = new Set(rows.map((row) => String(row.id)))
+  const missing = attachmentIds.filter((id) => !found.has(id))
+  if (missing.length > 0) {
+    return `Attachment(s) not found: ${missing.join(', ')}`
+  }
+  const mismatchedField = rows.find((row) => row.field_id && String(row.field_id) !== fieldId)
+  if (mismatchedField) {
+    return `Attachment belongs to a different field: ${mismatchedField.id}`
+  }
+  return null
+}
+
+/**
+ * Builds a `{recordId -> {fieldId -> MultitableAttachment[]}}` map used by
+ * record list and record GET responses. Only returns rows that match the
+ * record's attachment fields (and respects field-scoped `field_id`
+ * pinning on the attachment row).
+ */
+export async function buildAttachmentSummaries(
+  input: BuildAttachmentSummariesInput,
+): Promise<Map<string, Map<string, MultitableAttachment[]>>> {
+  const { query, req, sheetId, rows, attachmentFields } = input
+  const result = new Map<string, Map<string, MultitableAttachment[]>>()
+  if (rows.length === 0 || attachmentFields.length === 0) return result
+
+  const attachmentFieldIds = new Set(attachmentFields.map((field) => field.id))
+  const attachmentIds = new Set<string>()
+
+  for (const row of rows) {
+    for (const field of attachmentFields) {
+      for (const attachmentId of normalizeAttachmentIds(row.data[field.id])) {
+        attachmentIds.add(attachmentId)
+      }
+    }
+  }
+
+  const idList = Array.from(attachmentIds)
+  if (idList.length === 0) return result
+
+  const attachmentRes = await query(
+    `SELECT id, sheet_id, record_id, field_id, filename, original_name, mime_type, size, created_at
+     FROM multitable_attachments
+     WHERE sheet_id = $1
+       AND deleted_at IS NULL
+       AND id = ANY($2::text[])`,
+    [sheetId, idList],
+  )
+
+  const attachmentById = new Map<string, Record<string, unknown>>()
+  for (const row of attachmentRes.rows as Array<Record<string, unknown>>) {
+    attachmentById.set(String(row.id), row)
+  }
+
+  for (const row of rows) {
+    const byField = new Map<string, MultitableAttachment[]>()
+    for (const field of attachmentFields) {
+      const summaries = normalizeAttachmentIds(row.data[field.id])
+        .map((attachmentId) => attachmentById.get(attachmentId))
+        .filter((attachmentRow): attachmentRow is Record<string, unknown> => {
+          if (!attachmentRow) return false
+          if (attachmentRow.field_id && !attachmentFieldIds.has(String(attachmentRow.field_id))) return false
+          return !attachmentRow.field_id || String(attachmentRow.field_id) === field.id
+        })
+        .map((attachmentRow) => serializeAttachmentRow(req, attachmentRow))
+
+      if (summaries.length > 0) {
+        byField.set(field.id, summaries)
+      }
+    }
+
+    if (byField.size > 0) {
+      result.set(row.id, byField)
+    }
+  }
+
+  return result
+}
+
+// ---------------------------------------------------------------------------
+// Upload / store
+// ---------------------------------------------------------------------------
+
+/**
+ * Writes a binary to the provided storage adapter, inserts a
+ * `multitable_attachments` row, and returns both. On DB failure the
+ * binary is best-effort cleaned from storage to avoid orphan blobs
+ * (matching the route-layer behavior).
+ *
+ * The caller is responsible for auth/permission checks, for confirming
+ * the sheet/record exist, and for proving the target field is of type
+ * `attachment`. This function assumes those checks have already passed.
+ */
+export async function storeAttachment(
+  input: StoreAttachmentInput,
+): Promise<StoreAttachmentResult> {
+  const { query, storage, sheetId, recordId, fieldId, file, uploaderId } = input
+  const idGenerator = input.idGenerator ?? buildAttachmentId
+
+  const extension = path.extname(file.originalname || '')
+  const storageFilename = `${randomUUID()}${extension}`
+
+  const uploaded = await storage.upload(file.buffer, {
+    filename: storageFilename,
+    contentType: file.mimetype,
+    path: path.join(sheetId, fieldId ?? 'unassigned'),
+    metadata: {
+      originalName: file.originalname,
+      sheetId,
+      ...(recordId ? { recordId } : {}),
+      ...(fieldId ? { fieldId } : {}),
+    },
+  })
+
+  try {
+    const attachmentId = idGenerator()
+    const insert = await query(
+      `INSERT INTO multitable_attachments
+         (id, sheet_id, record_id, field_id, storage_file_id, filename, original_name, mime_type, size, storage_path, storage_provider, metadata, created_by)
+       VALUES
+         ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::jsonb, $13)
+       RETURNING id, filename, original_name, mime_type, size, created_at`,
+      [
+        attachmentId,
+        sheetId,
+        recordId,
+        fieldId,
+        uploaded.id,
+        file.originalname || storageFilename,
+        file.originalname || null,
+        file.mimetype || 'application/octet-stream',
+        file.size,
+        uploaded.path,
+        'local',
+        JSON.stringify({
+          storageFileId: uploaded.id,
+          storageUrl: uploaded.url,
+        }),
+        uploaderId,
+      ],
+    )
+    const row = (insert.rows as Array<Record<string, unknown>>)[0]
+    return { row, uploaded }
+  } catch (dbErr) {
+    try {
+      await storage.delete(uploaded.id)
+    } catch {
+      // best-effort cleanup after DB failure
+    }
+    throw dbErr
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Read / download
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetches the small column set needed to authorise and serve an
+ * attachment download. Returns `null` when the id is not found or the
+ * row is soft-deleted.
+ */
+export async function readAttachmentMetadata(
+  input: ReadAttachmentMetadataInput,
+): Promise<ReadAttachmentMetadataResult | null> {
+  const { query, attachmentId } = input
+  const result = await query(
+    `SELECT id, sheet_id, storage_file_id, filename, original_name, mime_type, size
+     FROM multitable_attachments
+     WHERE id = $1 AND deleted_at IS NULL`,
+    [attachmentId],
+  )
+  const row = (result.rows as Array<Record<string, unknown>>)[0]
+  if (!row) return null
+  return {
+    id: String(row.id),
+    // Matches the route's pre-extraction behavior: non-string sheet_id is
+    // normalized to '' so the auth block is short-circuited (see
+    // `GET /attachments/:attachmentId` usage).
+    sheetId: typeof row.sheet_id === 'string' ? row.sheet_id : '',
+    storageFileId: String(row.storage_file_id),
+    filename: typeof row.filename === 'string' ? row.filename : null,
+    originalName: typeof row.original_name === 'string' ? row.original_name : null,
+    mimeType: typeof row.mime_type === 'string' ? row.mime_type : 'application/octet-stream',
+    size: Number(row.size ?? 0),
+  }
+}
+
+/** Reads the binary bytes for the given storage file id. */
+export async function readAttachmentBinary(
+  input: ReadAttachmentBinaryInput,
+): Promise<Buffer> {
+  const { storage, storageFileId } = input
+  return storage.download(storageFileId)
+}
+
+/**
+ * Selects the columns the delete flow needs to authorise the request,
+ * maintain record data, and remove the storage blob. Returns `null` when
+ * the attachment does not exist or has already been soft-deleted.
+ */
+export async function readAttachmentForDelete(
+  input: ReadAttachmentForDeleteInput,
+): Promise<ReadAttachmentForDeleteResult | null> {
+  const { query, attachmentId } = input
+  const result = await query(
+    `SELECT id, sheet_id, record_id, field_id, storage_file_id, created_by
+     FROM multitable_attachments
+     WHERE id = $1 AND deleted_at IS NULL`,
+    [attachmentId],
+  )
+  const row = (result.rows as Array<Record<string, unknown>>)[0]
+  if (!row) return null
+  return {
+    id: String(row.id),
+    sheetId: String(row.sheet_id),
+    recordId: typeof row.record_id === 'string' ? row.record_id : null,
+    fieldId: typeof row.field_id === 'string' ? row.field_id : null,
+    storageFileId: String(row.storage_file_id),
+    createdBy: typeof row.created_by === 'string' ? row.created_by : null,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Delete
+// ---------------------------------------------------------------------------
+
+/**
+ * Soft-deletes the attachment row by setting `deleted_at`/`updated_at`.
+ * The caller is expected to run this inside the same transaction that
+ * patches the owning record's data column so that the two mutations
+ * stay consistent with each other.
+ */
+export async function softDeleteAttachmentRow(
+  input: SoftDeleteAttachmentInput,
+): Promise<void> {
+  const { query, attachmentId } = input
+  await query(
+    'UPDATE multitable_attachments SET deleted_at = now(), updated_at = now() WHERE id = $1',
+    [attachmentId],
+  )
+}
+
+/**
+ * Best-effort removal of the underlying storage blob. Intentionally
+ * swallows errors to mirror the route-layer behavior where a failed
+ * storage delete must not roll back the DB soft-delete.
+ */
+export async function deleteAttachmentBinary(
+  input: DeleteAttachmentBinaryInput,
+): Promise<void> {
+  const { storage, storageFileId } = input
+  try {
+    await storage.delete(storageFileId)
+  } catch {
+    // best-effort cleanup; mirrors route behavior
+  }
+}

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -39,6 +39,20 @@ import {
   type CursorPaginatedResult,
   type LoadedMultitableRecord,
 } from '../multitable/records'
+import {
+  buildAttachmentSummaries as buildAttachmentSummariesShared,
+  deleteAttachmentBinary as deleteAttachmentBinaryShared,
+  ensureAttachmentIdsExist as ensureAttachmentIdsExistShared,
+  normalizeAttachmentIds as normalizeAttachmentIdsShared,
+  readAttachmentBinary as readAttachmentBinaryShared,
+  readAttachmentForDelete as readAttachmentForDeleteShared,
+  readAttachmentMetadata as readAttachmentMetadataShared,
+  serializeAttachmentRow as serializeAttachmentRowShared,
+  serializeAttachmentSummaryMap as serializeAttachmentSummaryMapShared,
+  softDeleteAttachmentRow as softDeleteAttachmentRowShared,
+  storeAttachment as storeAttachmentShared,
+  type MultitableAttachment as SharedMultitableAttachment,
+} from '../multitable/attachment-service'
 import { StorageServiceImpl } from '../services/StorageService'
 import { createUploadMiddleware, loadMulter } from '../types/multer'
 import type { RequestWithFile } from '../types/multer'
@@ -228,15 +242,7 @@ type LinkedRecordSummary = {
   display: string
 }
 
-type MultitableAttachment = {
-  id: string
-  filename: string
-  mimeType: string
-  size: number
-  url: string
-  thumbnailUrl: string | null
-  uploadedAt: string | null
-}
+type MultitableAttachment = SharedMultitableAttachment
 
 type MultitableSheetRealtimePayload = {
   spreadsheetId: string
@@ -875,9 +881,7 @@ function normalizeLinkIds(value: unknown): string[] {
     })
 }
 
-function normalizeAttachmentIds(value: unknown): string[] {
-  return normalizeLinkIds(value)
-}
+const normalizeAttachmentIds = normalizeAttachmentIdsShared
 
 function normalizeSearchTerm(value: unknown): string {
   return typeof value === 'string' ? value.trim().toLowerCase() : ''
@@ -3116,13 +3120,6 @@ function getAttachmentStorageService(): StorageServiceImpl {
   return multitableAttachmentStorage
 }
 
-function buildAttachmentUrl(req: Request, attachmentId: string, thumbnail: boolean = false): string {
-  const protocol = req.protocol || 'http'
-  const host = req.get('host') || 'localhost:8900'
-  const query = thumbnail ? '?thumbnail=true' : ''
-  return `${protocol}://${host}/api/multitable/attachments/${encodeURIComponent(attachmentId)}${query}`
-}
-
 function getRequestActorId(req: Request): string | null {
   const actorId = req.user?.id
   return typeof actorId === 'string' && actorId.trim().length > 0 ? actorId.trim() : null
@@ -3137,23 +3134,7 @@ function isImageMimeType(mimeType: string | null | undefined): boolean {
   return typeof mimeType === 'string' && mimeType.toLowerCase().startsWith('image/')
 }
 
-function serializeAttachmentRow(req: Request, row: any): MultitableAttachment {
-  const id = String(row.id)
-  const mimeType = typeof row.mime_type === 'string' ? row.mime_type : 'application/octet-stream'
-  return {
-    id,
-    filename: typeof row.filename === 'string' ? row.filename : typeof row.original_name === 'string' ? row.original_name : id,
-    mimeType,
-    size: Number(row.size ?? 0),
-    url: buildAttachmentUrl(req, id),
-    thumbnailUrl: isImageMimeType(mimeType) ? buildAttachmentUrl(req, id, true) : null,
-    uploadedAt: row.created_at instanceof Date
-      ? row.created_at.toISOString()
-      : typeof row.created_at === 'string'
-        ? row.created_at
-        : null,
-  }
-}
+const serializeAttachmentRow = serializeAttachmentRowShared
 
 function serializeBaseRow(row: any): UniverMetaBase {
   return {
@@ -3315,27 +3296,7 @@ async function ensureAttachmentIdsExist(
   fieldId: string,
   attachmentIds: string[],
 ): Promise<string | null> {
-  if (attachmentIds.length === 0) return null
-
-  const result = await query(
-    `SELECT id, field_id
-     FROM multitable_attachments
-     WHERE sheet_id = $1
-       AND deleted_at IS NULL
-       AND id = ANY($2::text[])`,
-    [sheetId, attachmentIds],
-  )
-  const rows = result.rows as Array<{ id: string; field_id: string | null }>
-  const found = new Set(rows.map((row) => String(row.id)))
-  const missing = attachmentIds.filter((id) => !found.has(id))
-  if (missing.length > 0) {
-    return `Attachment(s) not found: ${missing.join(', ')}`
-  }
-  const mismatchedField = rows.find((row) => row.field_id && String(row.field_id) !== fieldId)
-  if (mismatchedField) {
-    return `Attachment belongs to a different field: ${mismatchedField.id}`
-  }
-  return null
+  return ensureAttachmentIdsExistShared({ query, sheetId, fieldId, attachmentIds })
 }
 
 async function buildLinkSummaries(
@@ -3435,72 +3396,10 @@ async function buildAttachmentSummaries(
   rows: UniverMetaRecord[],
   attachmentFields: UniverMetaField[],
 ): Promise<Map<string, Map<string, MultitableAttachment[]>>> {
-  const result = new Map<string, Map<string, MultitableAttachment[]>>()
-  if (rows.length === 0 || attachmentFields.length === 0) return result
-
-  const attachmentFieldIds = new Set(attachmentFields.map((field) => field.id))
-  const attachmentIds = new Set<string>()
-
-  for (const row of rows) {
-    for (const field of attachmentFields) {
-      for (const attachmentId of normalizeAttachmentIds(row.data[field.id])) {
-        attachmentIds.add(attachmentId)
-      }
-    }
-  }
-
-  const idList = Array.from(attachmentIds)
-  if (idList.length === 0) return result
-
-  const attachmentRes = await query(
-    `SELECT id, sheet_id, record_id, field_id, filename, original_name, mime_type, size, created_at
-     FROM multitable_attachments
-     WHERE sheet_id = $1
-       AND deleted_at IS NULL
-       AND id = ANY($2::text[])`,
-    [sheetId, idList],
-  )
-
-  const attachmentById = new Map<string, any>()
-  for (const row of attachmentRes.rows as any[]) {
-    attachmentById.set(String(row.id), row)
-  }
-
-  for (const row of rows) {
-    const byField = new Map<string, MultitableAttachment[]>()
-    for (const field of attachmentFields) {
-      const summaries = normalizeAttachmentIds(row.data[field.id])
-        .map((attachmentId) => attachmentById.get(attachmentId))
-        .filter((attachmentRow): attachmentRow is any => {
-          if (!attachmentRow) return false
-          if (attachmentRow.field_id && !attachmentFieldIds.has(String(attachmentRow.field_id))) return false
-          return !attachmentRow.field_id || String(attachmentRow.field_id) === field.id
-        })
-        .map((attachmentRow) => serializeAttachmentRow(req, attachmentRow))
-
-      if (summaries.length > 0) {
-        byField.set(field.id, summaries)
-      }
-    }
-
-    if (byField.size > 0) {
-      result.set(row.id, byField)
-    }
-  }
-
-  return result
+  return buildAttachmentSummariesShared({ query, req, sheetId, rows, attachmentFields })
 }
 
-function serializeAttachmentSummaryMap(
-  attachmentSummaries: Map<string, Map<string, MultitableAttachment[]>>,
-): Record<string, Record<string, MultitableAttachment[]>> {
-  return Object.fromEntries(
-    Array.from(attachmentSummaries.entries()).map(([recordId, fieldMap]) => [
-      recordId,
-      Object.fromEntries(Array.from(fieldMap.entries()).map(([fieldId, summaries]) => [fieldId, summaries])),
-    ]),
-  )
-}
+const serializeAttachmentSummaryMap = serializeAttachmentSummaryMapShared
 
 async function loadRecordSummaries(
   query: QueryFn,
@@ -7619,63 +7518,24 @@ export function univerMetaRouter(): Router {
           }
 
           const storage = getAttachmentStorageService()
-          const extension = path.extname(file.originalname || '')
-          const storageFilename = `${randomUUID()}${extension}`
-          const userId = req.user?.sub || req.user?.userId || req.user?.id || 'anonymous'
-          const uploaded = await storage.upload(file.buffer, {
-            filename: storageFilename,
-            contentType: file.mimetype,
-            path: path.join(sheetId, fieldId ?? 'unassigned'),
-            metadata: {
-              originalName: file.originalname,
-              sheetId,
-              ...(recordId ? { recordId } : {}),
-              ...(fieldId ? { fieldId } : {}),
+          const userIdRaw = req.user?.sub || req.user?.userId || req.user?.id || 'anonymous'
+          const userId = typeof userIdRaw === 'number' ? String(userIdRaw) : userIdRaw
+          const { row: attachmentRow } = await storeAttachmentShared({
+            query: pool.query.bind(pool),
+            storage,
+            sheetId,
+            recordId,
+            fieldId,
+            file,
+            uploaderId: userId,
+            idGenerator: () => buildId('att').slice(0, 50),
+          })
+          return res.status(201).json({
+            ok: true,
+            data: {
+              attachment: serializeAttachmentRow(req, attachmentRow),
             },
           })
-
-          try {
-            const attachmentId = buildId('att').slice(0, 50)
-            const insert = await pool.query(
-              `INSERT INTO multitable_attachments
-                 (id, sheet_id, record_id, field_id, storage_file_id, filename, original_name, mime_type, size, storage_path, storage_provider, metadata, created_by)
-               VALUES
-                 ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::jsonb, $13)
-               RETURNING id, filename, original_name, mime_type, size, created_at`,
-              [
-                attachmentId,
-                sheetId,
-                recordId,
-                fieldId,
-                uploaded.id,
-                file.originalname || storageFilename,
-                file.originalname || null,
-                file.mimetype || 'application/octet-stream',
-                file.size,
-                uploaded.path,
-                'local',
-                JSON.stringify({
-                  storageFileId: uploaded.id,
-                  storageUrl: uploaded.url,
-                }),
-                userId,
-              ],
-            )
-            const attachmentRow = (insert.rows as any[])[0]
-            return res.status(201).json({
-              ok: true,
-              data: {
-                attachment: serializeAttachmentRow(req, attachmentRow),
-              },
-            })
-          } catch (dbErr) {
-            try {
-              await storage.delete(uploaded.id)
-            } catch {
-              // best-effort cleanup after DB failure
-            }
-            throw dbErr
-          }
         } catch (err) {
           if (err instanceof ValidationError) {
             return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: err.message } })
@@ -7705,19 +7565,15 @@ export function univerMetaRouter(): Router {
 
     try {
       const pool = poolManager.get()
-      const attachmentRes = await pool.query(
-        `SELECT id, sheet_id, storage_file_id, filename, original_name, mime_type, size
-         FROM multitable_attachments
-         WHERE id = $1 AND deleted_at IS NULL`,
-        [attachmentId],
-      )
-      const row: any = attachmentRes.rows[0]
-      if (!row) {
+      const metadata = await readAttachmentMetadataShared({
+        query: pool.query.bind(pool),
+        attachmentId,
+      })
+      if (!metadata) {
         return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Attachment not found: ${attachmentId}` } })
       }
-      const sheetId = typeof row.sheet_id === 'string' ? row.sheet_id : ''
-      if (sheetId) {
-        const { access, capabilities } = await resolveSheetReadableCapabilities(req, pool.query.bind(pool), sheetId)
+      if (metadata.sheetId) {
+        const { access, capabilities } = await resolveSheetReadableCapabilities(req, pool.query.bind(pool), metadata.sheetId)
         if (!access.userId) {
           return res.status(401).json({ error: 'Authentication required' })
         }
@@ -7725,9 +7581,9 @@ export function univerMetaRouter(): Router {
       }
 
       const storage = getAttachmentStorageService()
-      const buffer = await storage.download(String(row.storage_file_id))
-      const mimeType = typeof row.mime_type === 'string' ? row.mime_type : 'application/octet-stream'
-      const fileName = typeof row.filename === 'string' ? row.filename : typeof row.original_name === 'string' ? row.original_name : attachmentId
+      const buffer = await readAttachmentBinaryShared({ storage, storageFileId: metadata.storageFileId })
+      const mimeType = metadata.mimeType
+      const fileName = metadata.filename ?? metadata.originalName ?? attachmentId
       const forceInline = req.query.thumbnail === 'true' || isImageMimeType(mimeType)
 
       res.setHeader('Content-Type', mimeType)
@@ -7757,46 +7613,43 @@ export function univerMetaRouter(): Router {
         version: number
         patch: Record<string, unknown>
       } | null = null
-      const attachmentRes = await pool.query(
-        `SELECT id, sheet_id, record_id, field_id, storage_file_id, created_by
-         FROM multitable_attachments
-         WHERE id = $1 AND deleted_at IS NULL`,
-        [attachmentId],
-      )
-      const attachmentRow: any = attachmentRes.rows[0]
+      const attachmentRow = await readAttachmentForDeleteShared({
+        query: pool.query.bind(pool),
+        attachmentId,
+      })
       if (!attachmentRow) {
         return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Attachment not found: ${attachmentId}` } })
       }
       const access = await resolveRequestAccess(req)
-      const sheetCapabilities = await resolveSheetCapabilities(req, pool.query.bind(pool), String(attachmentRow.sheet_id))
+      const sheetCapabilities = await resolveSheetCapabilities(req, pool.query.bind(pool), attachmentRow.sheetId)
       if (!sheetCapabilities.capabilities.canEditRecord) return sendForbidden(res)
-      if (typeof attachmentRow.record_id === 'string' && attachmentRow.record_id) {
+      if (attachmentRow.recordId) {
         const creatorMap = await loadRecordCreatorMap(
           pool.query.bind(pool),
-          String(attachmentRow.sheet_id),
-          [String(attachmentRow.record_id)],
+          attachmentRow.sheetId,
+          [attachmentRow.recordId],
         )
         if (!ensureRecordWriteAllowed(
           sheetCapabilities.capabilities,
           sheetCapabilities.sheetScope,
           access,
-          creatorMap.get(String(attachmentRow.record_id)),
+          creatorMap.get(attachmentRow.recordId),
           'edit',
         )) return sendForbidden(res, 'Record editing is not allowed for this row')
       } else if (!ensureRecordWriteAllowed(
         sheetCapabilities.capabilities,
         sheetCapabilities.sheetScope,
         access,
-        typeof attachmentRow.created_by === 'string' ? attachmentRow.created_by : null,
+        attachmentRow.createdBy,
         'edit',
       )) {
         return sendForbidden(res, 'Attachment deletion is not allowed for this draft attachment')
       }
 
       await pool.transaction(async ({ query }) => {
-        const recordId = typeof attachmentRow.record_id === 'string' ? attachmentRow.record_id : null
-        const fieldId = typeof attachmentRow.field_id === 'string' ? attachmentRow.field_id : null
-        const sheetId = String(attachmentRow.sheet_id)
+        const recordId = attachmentRow.recordId
+        const fieldId = attachmentRow.fieldId
+        const sheetId = attachmentRow.sheetId
 
         if (recordId && fieldId) {
           const recordRes = await query(
@@ -7827,18 +7680,11 @@ export function univerMetaRouter(): Router {
           }
         }
 
-        await query(
-          'UPDATE multitable_attachments SET deleted_at = now(), updated_at = now() WHERE id = $1',
-          [attachmentId],
-        )
+        await softDeleteAttachmentRowShared({ query, attachmentId })
       })
 
       const storage = getAttachmentStorageService()
-      try {
-        await storage.delete(String(attachmentRow.storage_file_id))
-      } catch {
-        // best-effort storage cleanup
-      }
+      await deleteAttachmentBinaryShared({ storage, storageFileId: attachmentRow.storageFileId })
 
       if (updatedRecordRealtimeScope) {
         publishMultitableSheetRealtime({

--- a/packages/core-backend/tests/unit/multitable-attachment-service.test.ts
+++ b/packages/core-backend/tests/unit/multitable-attachment-service.test.ts
@@ -1,0 +1,418 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  buildAttachmentSummaries,
+  deleteAttachmentBinary,
+  ensureAttachmentIdsExist,
+  normalizeAttachmentIds,
+  readAttachmentBinary,
+  readAttachmentForDelete,
+  readAttachmentMetadata,
+  serializeAttachmentRow,
+  serializeAttachmentSummaryMap,
+  softDeleteAttachmentRow,
+  storeAttachment,
+  type AttachmentQueryFn,
+  type AttachmentUrlRequestLike,
+} from '../../src/multitable/attachment-service'
+
+type QueryRow = Record<string, unknown>
+
+function createQuery(handler: (sql: string, params?: unknown[]) => QueryRow[] | Promise<QueryRow[]>) {
+  return vi.fn(async (sql: string, params?: unknown[]) => ({
+    rows: await handler(sql, params),
+  })) as unknown as AttachmentQueryFn
+}
+
+function createRequestLike(host: string = 'example.test', protocol: string = 'https'): AttachmentUrlRequestLike {
+  return {
+    protocol,
+    get: (name: string) => (name.toLowerCase() === 'host' ? host : undefined),
+  }
+}
+
+function createStorageMock(overrides: {
+  upload?: ReturnType<typeof vi.fn>
+  download?: ReturnType<typeof vi.fn>
+  deleteFn?: ReturnType<typeof vi.fn>
+} = {}) {
+  return {
+    upload: overrides.upload ?? vi.fn(async () => ({
+      id: 'file_123',
+      filename: 'out.bin',
+      originalName: 'in.bin',
+      mimeType: 'application/octet-stream',
+      size: 4,
+      path: 'sheets_sheet_1/unassigned/out.bin',
+      url: 'http://localhost/files/file_123',
+      provider: 'local',
+      createdAt: new Date('2026-04-23T00:00:00Z'),
+    })),
+    download: overrides.download ?? vi.fn(async () => Buffer.from('abcd')),
+    delete: overrides.deleteFn ?? vi.fn(async () => undefined),
+  } as any
+}
+
+describe('attachment-service: normalizeAttachmentIds', () => {
+  it('returns an empty array for null/undefined/empty inputs', () => {
+    expect(normalizeAttachmentIds(null)).toEqual([])
+    expect(normalizeAttachmentIds(undefined)).toEqual([])
+    expect(normalizeAttachmentIds('')).toEqual([])
+    expect(normalizeAttachmentIds('   ')).toEqual([])
+  })
+
+  it('de-duplicates arrays and preserves order', () => {
+    expect(normalizeAttachmentIds(['a', 'b', 'a', 'c '])).toEqual(['a', 'b', 'c'])
+  })
+
+  it('parses a JSON-encoded array string', () => {
+    expect(normalizeAttachmentIds('["x","y","x"]')).toEqual(['x', 'y'])
+  })
+
+  it('splits a comma-separated string', () => {
+    expect(normalizeAttachmentIds('one, two , three')).toEqual(['one', 'two', 'three'])
+  })
+
+  it('accepts numeric ids', () => {
+    expect(normalizeAttachmentIds([1, 2, 2])).toEqual(['1', '2'])
+    expect(normalizeAttachmentIds(42)).toEqual(['42'])
+  })
+})
+
+describe('attachment-service: serializers', () => {
+  it('builds attachment url including thumbnail variant when image mime', () => {
+    const req = createRequestLike('host.test', 'http')
+    const row = {
+      id: 'att_1',
+      filename: 'image.png',
+      original_name: 'IMG.png',
+      mime_type: 'image/png',
+      size: 100,
+      created_at: new Date('2026-04-23T12:00:00Z'),
+    }
+    const serialized = serializeAttachmentRow(req, row)
+    expect(serialized).toEqual({
+      id: 'att_1',
+      filename: 'image.png',
+      mimeType: 'image/png',
+      size: 100,
+      url: 'http://host.test/api/multitable/attachments/att_1',
+      thumbnailUrl: 'http://host.test/api/multitable/attachments/att_1?thumbnail=true',
+      uploadedAt: '2026-04-23T12:00:00.000Z',
+    })
+  })
+
+  it('omits thumbnail url for non-image mime types and falls back to original_name', () => {
+    const req = createRequestLike()
+    const row = {
+      id: 'att_2',
+      original_name: 'report.pdf',
+      mime_type: 'application/pdf',
+      size: 50,
+      created_at: '2026-04-20T01:00:00Z',
+    }
+    const serialized = serializeAttachmentRow(req, row)
+    expect(serialized.filename).toBe('report.pdf')
+    expect(serialized.mimeType).toBe('application/pdf')
+    expect(serialized.thumbnailUrl).toBeNull()
+    expect(serialized.uploadedAt).toBe('2026-04-20T01:00:00Z')
+  })
+
+  it('flattens the summary Map into plain-object form', () => {
+    const inner = new Map<string, any[]>()
+    inner.set('fld_att', [{ id: 'att_1' }])
+    const outer = new Map<string, Map<string, any[]>>()
+    outer.set('rec_1', inner)
+    expect(serializeAttachmentSummaryMap(outer as any)).toEqual({
+      rec_1: { fld_att: [{ id: 'att_1' }] },
+    })
+  })
+})
+
+describe('attachment-service: ensureAttachmentIdsExist', () => {
+  it('returns null when the input list is empty (no DB call)', async () => {
+    const query = createQuery(() => {
+      throw new Error('should not call')
+    })
+    expect(
+      await ensureAttachmentIdsExist({ query, sheetId: 's1', fieldId: 'f1', attachmentIds: [] }),
+    ).toBeNull()
+  })
+
+  it('reports missing ids with the canonical error message', async () => {
+    const query = createQuery(() => [{ id: 'att_known', field_id: null }])
+    const err = await ensureAttachmentIdsExist({
+      query,
+      sheetId: 's1',
+      fieldId: 'f1',
+      attachmentIds: ['att_known', 'att_missing'],
+    })
+    expect(err).toBe('Attachment(s) not found: att_missing')
+  })
+
+  it('reports mismatched field binding', async () => {
+    const query = createQuery(() => [{ id: 'att_wrong', field_id: 'fld_other' }])
+    const err = await ensureAttachmentIdsExist({
+      query,
+      sheetId: 's1',
+      fieldId: 'fld_me',
+      attachmentIds: ['att_wrong'],
+    })
+    expect(err).toBe('Attachment belongs to a different field: att_wrong')
+  })
+
+  it('returns null when all ids are present and correctly scoped', async () => {
+    const query = createQuery(() => [
+      { id: 'att_a', field_id: 'fld_me' },
+      { id: 'att_b', field_id: null },
+    ])
+    expect(
+      await ensureAttachmentIdsExist({
+        query,
+        sheetId: 's1',
+        fieldId: 'fld_me',
+        attachmentIds: ['att_a', 'att_b'],
+      }),
+    ).toBeNull()
+  })
+})
+
+describe('attachment-service: buildAttachmentSummaries', () => {
+  it('returns empty map when no rows or no attachment fields', async () => {
+    const query = createQuery(() => {
+      throw new Error('should not call')
+    })
+    const req = createRequestLike()
+    await expect(
+      buildAttachmentSummaries({
+        query,
+        req,
+        sheetId: 's1',
+        rows: [],
+        attachmentFields: [{ id: 'fld_att', type: 'attachment' }],
+      }),
+    ).resolves.toEqual(new Map())
+    await expect(
+      buildAttachmentSummaries({
+        query,
+        req,
+        sheetId: 's1',
+        rows: [{ id: 'rec_1', data: {} }],
+        attachmentFields: [],
+      }),
+    ).resolves.toEqual(new Map())
+  })
+
+  it('builds a nested map filtered by field pinning', async () => {
+    const query = createQuery((_sql, params) => {
+      expect(Array.isArray(params)).toBe(true)
+      return [
+        {
+          id: 'att_a',
+          sheet_id: 's1',
+          record_id: 'rec_1',
+          field_id: 'fld_att',
+          filename: 'a.png',
+          original_name: 'A.png',
+          mime_type: 'image/png',
+          size: 1,
+          created_at: '2026-04-23T00:00:00Z',
+        },
+        {
+          id: 'att_b',
+          sheet_id: 's1',
+          record_id: 'rec_1',
+          field_id: 'fld_other',
+          filename: 'b.pdf',
+          original_name: 'B.pdf',
+          mime_type: 'application/pdf',
+          size: 1,
+          created_at: '2026-04-23T00:00:00Z',
+        },
+      ]
+    })
+
+    const req = createRequestLike()
+    const result = await buildAttachmentSummaries({
+      query,
+      req,
+      sheetId: 's1',
+      rows: [{ id: 'rec_1', data: { fld_att: ['att_a', 'att_b'] } }],
+      attachmentFields: [{ id: 'fld_att', type: 'attachment' }],
+    })
+
+    const fieldMap = result.get('rec_1')
+    expect(fieldMap?.get('fld_att')?.map((a) => a.id)).toEqual(['att_a'])
+  })
+
+  it('skips records with no matching attachments', async () => {
+    const query = createQuery(() => [])
+    const req = createRequestLike()
+    const result = await buildAttachmentSummaries({
+      query,
+      req,
+      sheetId: 's1',
+      rows: [{ id: 'rec_1', data: { fld_att: ['att_missing'] } }],
+      attachmentFields: [{ id: 'fld_att', type: 'attachment' }],
+    })
+    expect(result.size).toBe(0)
+  })
+})
+
+describe('attachment-service: storeAttachment', () => {
+  it('uploads binary, inserts row, and returns the row + storage metadata', async () => {
+    const query = createQuery((sql, params) => {
+      expect(sql).toContain('INSERT INTO multitable_attachments')
+      expect(params?.[0]).toBe('att_fixed')
+      return [
+        {
+          id: 'att_fixed',
+          filename: 'hello.txt',
+          original_name: 'hello.txt',
+          mime_type: 'text/plain',
+          size: 5,
+          created_at: '2026-04-23T12:00:00Z',
+        },
+      ]
+    })
+    const storage = createStorageMock()
+    const result = await storeAttachment({
+      query,
+      storage,
+      sheetId: 's1',
+      recordId: 'rec_1',
+      fieldId: 'fld_att',
+      file: {
+        buffer: Buffer.from('hello'),
+        originalname: 'hello.txt',
+        mimetype: 'text/plain',
+        size: 5,
+      },
+      uploaderId: 'u1',
+      idGenerator: () => 'att_fixed',
+    })
+    expect(storage.upload).toHaveBeenCalledTimes(1)
+    expect(result.row.id).toBe('att_fixed')
+    expect(result.uploaded.id).toBe('file_123')
+  })
+
+  it('cleans up storage when the DB insert fails', async () => {
+    const dbError = new Error('boom')
+    const query = createQuery(() => {
+      throw dbError
+    })
+    const storage = createStorageMock()
+    await expect(
+      storeAttachment({
+        query,
+        storage,
+        sheetId: 's1',
+        recordId: null,
+        fieldId: null,
+        file: {
+          buffer: Buffer.from('x'),
+          originalname: 'x.bin',
+          mimetype: 'application/octet-stream',
+          size: 1,
+        },
+        uploaderId: 'u1',
+        idGenerator: () => 'att_tmp',
+      }),
+    ).rejects.toThrow('boom')
+    expect(storage.delete).toHaveBeenCalledWith('file_123')
+  })
+})
+
+describe('attachment-service: readAttachmentMetadata & readAttachmentBinary', () => {
+  it('returns null when no row matches', async () => {
+    const query = createQuery(() => [])
+    const result = await readAttachmentMetadata({ query, attachmentId: 'att_missing' })
+    expect(result).toBeNull()
+  })
+
+  it('maps the selected columns to the expected shape', async () => {
+    const query = createQuery(() => [
+      {
+        id: 'att_1',
+        sheet_id: 's1',
+        storage_file_id: 'file_42',
+        filename: 'report.pdf',
+        original_name: 'Report.pdf',
+        mime_type: 'application/pdf',
+        size: 100,
+      },
+    ])
+    const result = await readAttachmentMetadata({ query, attachmentId: 'att_1' })
+    expect(result).toEqual({
+      id: 'att_1',
+      sheetId: 's1',
+      storageFileId: 'file_42',
+      filename: 'report.pdf',
+      originalName: 'Report.pdf',
+      mimeType: 'application/pdf',
+      size: 100,
+    })
+  })
+
+  it('delegates readAttachmentBinary to the storage adapter', async () => {
+    const storage = createStorageMock({ download: vi.fn(async () => Buffer.from('payload')) as any })
+    const result = await readAttachmentBinary({ storage, storageFileId: 'file_42' })
+    expect(storage.download).toHaveBeenCalledWith('file_42')
+    expect(result.toString()).toBe('payload')
+  })
+})
+
+describe('attachment-service: readAttachmentForDelete', () => {
+  it('returns null when the attachment is absent or already soft-deleted', async () => {
+    const query = createQuery(() => [])
+    await expect(
+      readAttachmentForDelete({ query, attachmentId: 'att_gone' }),
+    ).resolves.toBeNull()
+  })
+
+  it('returns the permission-relevant columns', async () => {
+    const query = createQuery(() => [
+      {
+        id: 'att_1',
+        sheet_id: 's1',
+        record_id: 'rec_1',
+        field_id: 'fld_att',
+        storage_file_id: 'file_7',
+        created_by: 'user_1',
+      },
+    ])
+    await expect(
+      readAttachmentForDelete({ query, attachmentId: 'att_1' }),
+    ).resolves.toEqual({
+      id: 'att_1',
+      sheetId: 's1',
+      recordId: 'rec_1',
+      fieldId: 'fld_att',
+      storageFileId: 'file_7',
+      createdBy: 'user_1',
+    })
+  })
+})
+
+describe('attachment-service: soft delete and binary delete', () => {
+  it('softDeleteAttachmentRow issues the canonical UPDATE', async () => {
+    const query = createQuery((sql, params) => {
+      expect(sql).toContain('UPDATE multitable_attachments SET deleted_at')
+      expect(params).toEqual(['att_1'])
+      return []
+    })
+    await softDeleteAttachmentRow({ query, attachmentId: 'att_1' })
+  })
+
+  it('deleteAttachmentBinary swallows storage adapter errors', async () => {
+    const storage = createStorageMock({
+      deleteFn: vi.fn(async () => {
+        throw new Error('ENOENT')
+      }) as any,
+    })
+    await expect(
+      deleteAttachmentBinary({ storage, storageFileId: 'file_bad' }),
+    ).resolves.toBeUndefined()
+    expect(storage.delete).toHaveBeenCalledWith('file_bad')
+  })
+})


### PR DESCRIPTION
## Summary
- Extract multitable attachment read/write/delete logic into `attachment-service.ts`.
- Remove inline attachment SQL and permission branching from `univer-meta.ts` without changing existing route semantics.
- Preserve the current delete contract: transaction-scoped soft delete plus best-effort binary deletion outside the transaction.
- Record rebase verification on `origin/main@8d2d3e1b0`.

## Verification
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/multitable-attachment-service.test.ts --reporter=dot`
- `DATABASE_URL=postgresql://chouhua@127.0.0.1:5432/postgres PGHOST=127.0.0.1 PGPORT=5432 PGDATABASE=postgres PGUSER=chouhua pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/multitable-attachments.api.test.ts tests/integration/after-sales-installer-provisioning.api.test.ts --reporter=dot`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit --reporter=dot`