### PR TITLE
feat(approval): add remind action + pending count badge (WP3 slice 1)

### DIFF
--- a/apps/web/src/approvals/api.ts
+++ b/apps/web/src/approvals/api.ts
@@ -5,7 +5,7 @@
  * Uses apiFetch/apiGet/apiPost from project utils.
  * Includes mock fallback for development when backend is not available.
  */
-import { apiGet, apiPost } from '../utils/api'
+import { apiFetch, apiGet, apiPost } from '../utils/api'
 import type {
   ApprovalTemplateListItemDTO,
   ApprovalTemplateDetailDTO,
@@ -410,6 +410,106 @@ export async function createApproval(req: CreateApprovalRequest): Promise<Unifie
     }
   }
   return apiPost('/api/approvals', req)
+}
+
+/**
+ * Wave 2 WP3 slice 1 — pending count (红点数据源).
+ *
+ * Returns the total active-assignment count for the current user, scoped by
+ * source system. Used by the 待办 tab badge; the response is intentionally
+ * scalar so the caller does not need to fetch the full list just to render
+ * the indicator.
+ */
+export interface PendingCountResponse {
+  count: number
+  degraded?: boolean
+}
+
+export async function getPendingCount(
+  sourceSystem: 'all' | 'platform' | 'plm' = 'all',
+): Promise<PendingCountResponse> {
+  if (USE_MOCK) {
+    const fallback = sourceSystem === 'platform' ? 2 : sourceSystem === 'plm' ? 1 : 3
+    return { count: fallback }
+  }
+  const qs = sourceSystem ? `?sourceSystem=${encodeURIComponent(sourceSystem)}` : ''
+  return apiGet(`/api/approvals/pending-count${qs}`)
+}
+
+/**
+ * Wave 2 WP3 slice 1 — 催办 result shape. Exposes the 429 throttle state so
+ * the UI can surface "已在 N 分钟前催办过" instead of a generic error.
+ */
+export type RemindApprovalResult =
+  | {
+      ok: true
+      data: {
+        id: string
+        action: 'remind'
+        remindedAt: string
+        bridged: boolean
+        sourceSystem: string | null
+      }
+    }
+  | {
+      ok: false
+      error: {
+        code: string
+        message: string
+        lastRemindedAt?: string
+        retryAfterSeconds?: number
+      }
+      status: number
+    }
+
+/**
+ * Send a remind event on an approval instance.
+ *
+ * Uses `apiFetch` directly (not `apiPost`) so the caller can branch on the
+ * 429 rate-limit status without losing the `lastRemindedAt` hint carried in
+ * the response body.
+ */
+export async function remindApproval(id: string): Promise<RemindApprovalResult> {
+  if (USE_MOCK) {
+    return {
+      ok: true,
+      data: {
+        id,
+        action: 'remind',
+        remindedAt: new Date().toISOString(),
+        bridged: false,
+        sourceSystem: 'platform',
+      },
+    }
+  }
+  const response = await apiFetch(`/api/approvals/${encodeURIComponent(id)}/remind`, {
+    method: 'POST',
+    body: JSON.stringify({}),
+  })
+  const payload = await response.json().catch(() => null)
+  if (response.status === 429) {
+    return {
+      ok: false,
+      error: {
+        code: payload?.error?.code ?? 'APPROVAL_REMIND_THROTTLED',
+        message: payload?.error?.message ?? 'Remind is rate-limited',
+        lastRemindedAt: payload?.error?.lastRemindedAt,
+        retryAfterSeconds: payload?.error?.retryAfterSeconds,
+      },
+      status: 429,
+    }
+  }
+  if (!response.ok) {
+    return {
+      ok: false,
+      error: {
+        code: payload?.error?.code ?? 'APPROVAL_REMIND_FAILED',
+        message: payload?.error?.message ?? `API error: ${response.status} ${response.statusText}`,
+      },
+      status: response.status,
+    }
+  }
+  return payload as RemindApprovalResult
 }
 
 export async function dispatchAction(

--- a/apps/web/src/views/approval/ApprovalCenterView.vue
+++ b/apps/web/src/views/approval/ApprovalCenterView.vue
@@ -64,7 +64,25 @@
     </el-alert>
 
     <el-tabs v-model="activeTab" class="approval-center__tabs" @tab-change="handleTabChange">
-      <el-tab-pane label="待我处理" name="pending">
+      <el-tab-pane name="pending">
+        <!-- Wave 2 WP3 slice 1: 红点 / 待办计数 — render the server-provided
+             pending count alongside the tab label. Hidden when the count is
+             zero so the badge never shows an empty bubble. The count is the
+             total across the user's assignments (not the current page), so
+             use a dedicated state slot instead of the store's per-page
+             `pendingCount` computed. -->
+        <template #label>
+          <span class="approval-center__tab-label">
+            <span>待我处理</span>
+            <el-badge
+              v-if="pendingBadgeCount > 0"
+              :value="pendingBadgeCount"
+              :max="99"
+              class="approval-center__tab-badge"
+              data-testid="approval-pending-badge"
+            />
+          </span>
+        </template>
         <el-table
           v-loading="store.loading"
           :data="store.pendingApprovals"
@@ -262,10 +280,26 @@ import { Search } from '@element-plus/icons-vue'
 import type { UnifiedApprovalDTO, ApprovalStatus } from '../../types/approval'
 import { useApprovalStore } from '../../approvals/store'
 import { useApprovalPermissions } from '../../approvals/permissions'
+import { getPendingCount } from '../../approvals/api'
 
 const router = useRouter()
 const store = useApprovalStore()
 const { canWrite } = useApprovalPermissions()
+
+// Wave 2 WP3 slice 1: server-owned pending count. Refreshed on mount and tab
+// switch so the badge matches the 待办 tab after any action reduces the user's
+// assignment queue.
+const pendingBadgeCount = ref(0)
+async function refreshPendingBadgeCount(): Promise<void> {
+  try {
+    const result = await getPendingCount(sourceSystemFilter.value)
+    pendingBadgeCount.value = Number.isFinite(result.count) ? result.count : 0
+  } catch {
+    // Badge is decorative — do not surface errors here; the tab itself
+    // surfaces list-load failures via `store.error`.
+    pendingBadgeCount.value = 0
+  }
+}
 
 const activeTab = ref<'pending' | 'mine' | 'cc' | 'completed'>('pending')
 const searchText = ref('')
@@ -328,6 +362,9 @@ function loadCurrentTab() {
 function handleTabChange() {
   currentPage.value = 1
   loadCurrentTab()
+  // Refresh badge whenever the user re-enters the 待办 tab so recent actions
+  // reflect immediately.
+  void refreshPendingBadgeCount()
 }
 
 function handleSearch() {
@@ -346,6 +383,7 @@ function handleRowClick(row: UnifiedApprovalDTO) {
 
 onMounted(() => {
   loadCurrentTab()
+  void refreshPendingBadgeCount()
 })
 </script>
 
@@ -386,5 +424,15 @@ onMounted(() => {
   margin-top: 16px;
   display: flex;
   justify-content: flex-end;
+}
+
+.approval-center__tab-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.approval-center__tab-badge {
+  margin-left: 4px;
 }
 </style>

--- a/apps/web/src/views/approval/ApprovalDetailView.vue
+++ b/apps/web/src/views/approval/ApprovalDetailView.vue
@@ -235,6 +235,19 @@
             >
               转交
             </el-button>
+            <!-- Wave 2 WP3 slice 1: 催办. Visible only for the requester on
+                 a pending instance; server-side rate-limits to once per hour
+                 per user per instance (429 → surfaced as a friendly toast). -->
+            <el-button
+              v-if="isRequester"
+              type="primary"
+              plain
+              :loading="remindLoading"
+              data-testid="approval-remind-button"
+              @click="handleRemind"
+            >
+              <el-icon style="margin-right: 4px"><Bell /></el-icon>催一下
+            </el-button>
             <el-popconfirm
               v-if="isRequester"
               title="确认撤回此审批？"
@@ -400,6 +413,7 @@ import type { ApprovalActionType } from '../../types/approval'
 import { useApprovalStore } from '../../approvals/store'
 import { useApprovalPermissions } from '../../approvals/permissions'
 import { useApprovalTemplateStore } from '../../approvals/templateStore'
+import { remindApproval } from '../../approvals/api'
 
 const route = useRoute()
 const router = useRouter()
@@ -714,6 +728,43 @@ async function handleRevoke() {
     await store.loadHistory(id)
   } catch {
     ElMessage.error('撤回失败，请重试')
+  }
+}
+
+// Wave 2 WP3 slice 1: 催办. Loading state is local to this button so the main
+// approve/reject action row does not go into a spinner while a requester
+// nudges. On 429 we surface the server-supplied `lastRemindedAt` so the user
+// knows why the button rejected them.
+const remindLoading = ref(false)
+
+function formatRemindAgo(lastRemindedAt?: string): string {
+  if (!lastRemindedAt) return '刚刚'
+  const timestamp = new Date(lastRemindedAt).getTime()
+  if (!Number.isFinite(timestamp)) return '刚刚'
+  const diffMs = Math.max(0, Date.now() - timestamp)
+  const minutes = Math.floor(diffMs / 60000)
+  if (minutes <= 0) return '刚刚'
+  if (minutes < 60) return `${minutes} 分钟前`
+  const hours = Math.floor(minutes / 60)
+  return `${hours} 小时前`
+}
+
+async function handleRemind() {
+  const id = route.params.id as string
+  if (remindLoading.value) return
+  remindLoading.value = true
+  try {
+    const result = await remindApproval(id)
+    if (result.ok) {
+      ElMessage.success('已催办')
+      await store.loadHistory(id)
+    } else if (result.status === 429) {
+      ElMessage.warning(`已在 ${formatRemindAgo(result.error.lastRemindedAt)}催办过`)
+    } else {
+      ElMessage.error(result.error.message || '催办失败，请重试')
+    }
+  } finally {
+    remindLoading.value = false
   }
 }
 

--- a/apps/web/tests/approvalCenterRemindBadge.spec.ts
+++ b/apps/web/tests/approvalCenterRemindBadge.spec.ts
@@ -1,0 +1,542 @@
+/**
+ * Wave 2 WP3 slice 1 — 红点 / 催办 frontend specs.
+ *
+ * Covers two surfaces:
+ *   1. `ApprovalCenterView` renders a red badge on the 待我处理 tab with the
+ *      server-provided count when > 0, and hides it when 0.
+ *   2. `ApprovalDetailView` exposes a "催一下" button for the requester on a
+ *      pending instance and maps the API result (200 vs 429) to a toast.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, nextTick, ref, type App as VueApp } from 'vue'
+
+// ---------------------------------------------------------------------------
+// Module-level spies — hoisted so `vi.mock` factories can pick them up
+// without triggering the "cannot access X before initialization" guard.
+// ---------------------------------------------------------------------------
+const pushSpy = vi.fn().mockResolvedValue(undefined)
+const getPendingCountSpy = vi.fn<(sourceSystem?: 'all' | 'platform' | 'plm') => Promise<{ count: number }>>()
+const remindApprovalSpy = vi.fn()
+const elSuccessSpy = vi.fn()
+const elWarningSpy = vi.fn()
+const elErrorSpy = vi.fn()
+
+vi.mock('vue-router', async () => {
+  const actual = await vi.importActual<typeof import('vue-router')>('vue-router')
+  return {
+    ...actual,
+    useRouter: () => ({
+      push: pushSpy,
+      back: vi.fn(),
+    }),
+    useRoute: () => ({
+      params: { id: 'apv_remind_target' },
+      query: {},
+      path: '/approvals',
+      meta: {},
+    }),
+  }
+})
+
+vi.mock('element-plus', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('element-plus').catch(() => ({}))
+  return {
+    ...actual,
+    ElMessage: {
+      success: elSuccessSpy,
+      warning: elWarningSpy,
+      error: elErrorSpy,
+      info: vi.fn(),
+    },
+  }
+})
+
+vi.mock('../src/approvals/permissions', () => ({
+  useApprovalPermissions: () => ({
+    canWrite: ref(true),
+    canAct: ref(true),
+    canRead: ref(true),
+  }),
+}))
+
+const mockPendingApprovals = ref<any[]>([])
+const mockMyApprovals = ref<any[]>([])
+const mockCcApprovals = ref<any[]>([])
+const mockCompletedApprovals = ref<any[]>([])
+const mockActiveApproval = ref<any>(null)
+const mockHistory = ref<any[]>([])
+const mockLoading = ref(false)
+const mockError = ref<string | null>(null)
+
+vi.mock('../src/approvals/store', () => ({
+  useApprovalStore: () => ({
+    get approvals() { return [] },
+    get pendingApprovals() { return mockPendingApprovals.value },
+    get myApprovals() { return mockMyApprovals.value },
+    get ccApprovals() { return mockCcApprovals.value },
+    get completedApprovals() { return mockCompletedApprovals.value },
+    get activeApproval() { return mockActiveApproval.value },
+    get history() { return mockHistory.value },
+    get loading() { return mockLoading.value },
+    get error() { return mockError.value },
+    set error(value: string | null) { mockError.value = value },
+    get totalPending() { return mockPendingApprovals.value.length },
+    get totalMine() { return mockMyApprovals.value.length },
+    get totalCc() { return mockCcApprovals.value.length },
+    get totalCompleted() { return mockCompletedApprovals.value.length },
+    get pendingCount() { return mockPendingApprovals.value.length },
+    approvalById: () => undefined,
+    loadPending: vi.fn().mockResolvedValue(undefined),
+    loadMine: vi.fn().mockResolvedValue(undefined),
+    loadCc: vi.fn().mockResolvedValue(undefined),
+    loadCompleted: vi.fn().mockResolvedValue(undefined),
+    loadDetail: vi.fn().mockResolvedValue(undefined),
+    loadHistory: vi.fn().mockResolvedValue(undefined),
+    submitApproval: vi.fn(),
+    executeAction: vi.fn().mockResolvedValue(undefined),
+  }),
+}))
+
+vi.mock('../src/approvals/templateStore', () => ({
+  useApprovalTemplateStore: () => ({
+    loadTemplate: vi.fn().mockResolvedValue(undefined),
+    templateById: () => undefined,
+  }),
+}))
+
+vi.mock('../src/approvals/api', () => ({
+  getPendingCount: (sourceSystem?: 'all' | 'platform' | 'plm') => getPendingCountSpy(sourceSystem),
+  remindApproval: (...args: unknown[]) => remindApprovalSpy(...args),
+}))
+
+// ---------------------------------------------------------------------------
+// Element Plus component stubs (minimal reactive surface).
+// ---------------------------------------------------------------------------
+const ElTabs = defineComponent({
+  name: 'ElTabs',
+  props: { modelValue: String },
+  emits: ['update:modelValue', 'tab-change'],
+  render() {
+    return h('div', { 'data-el-tabs': this.modelValue }, this.$slots.default?.())
+  },
+})
+
+const ElTabPane = defineComponent({
+  name: 'ElTabPane',
+  props: { label: String, name: String },
+  render() {
+    return h(
+      'div',
+      { 'data-tab-pane': this.name, 'data-tab-label': this.label },
+      [this.$slots.label?.(), this.$slots.default?.()].filter(Boolean),
+    )
+  },
+})
+
+const ElTable = defineComponent({
+  name: 'ElTable',
+  props: { data: Array, loading: Boolean, stripe: Boolean, highlightCurrentRow: Boolean },
+  emits: ['row-click'],
+  render() {
+    return h('div', { 'data-el-table': 'true' }, this.$slots.default?.())
+  },
+})
+
+const ElTableColumn = defineComponent({
+  name: 'ElTableColumn',
+  props: { prop: String, label: String, width: [String, Number], minWidth: [String, Number], fixed: String },
+  render() {
+    return h('div', { 'data-column': this.prop || this.label })
+  },
+})
+
+const ElTag = defineComponent({
+  name: 'ElTag',
+  props: { type: String, size: String },
+  render() {
+    return h('span', { 'data-el-tag': this.type }, this.$slots.default?.())
+  },
+})
+
+const ElInput = defineComponent({
+  name: 'ElInput',
+  props: { modelValue: String, placeholder: String, clearable: Boolean },
+  emits: ['update:modelValue', 'clear'],
+  render() {
+    return h('input', { 'data-el-input': 'true' })
+  },
+})
+
+const ElSelect = defineComponent({
+  name: 'ElSelect',
+  props: { modelValue: [String, Array], placeholder: String, clearable: Boolean },
+  emits: ['update:modelValue', 'change'],
+  setup(props, { emit, slots, attrs }) {
+    return () => h(
+      'select',
+      {
+        ...attrs,
+        'data-el-select': 'true',
+        value: props.modelValue as string | undefined,
+        onChange: (event: Event) => {
+          const value = (event.target as HTMLSelectElement).value
+          emit('update:modelValue', value)
+          emit('change', value)
+        },
+      },
+      slots.default?.(),
+    )
+  },
+})
+
+const ElOption = defineComponent({
+  name: 'ElOption',
+  props: { label: String, value: String },
+  render() {
+    return h('option', { value: this.value }, this.label)
+  },
+})
+
+const ElPagination = defineComponent({
+  name: 'ElPagination',
+  props: { background: Boolean, layout: String, total: Number, currentPage: Number, pageSize: Number },
+  emits: ['update:currentPage'],
+  render() {
+    return h('div', { 'data-el-pagination': 'true' })
+  },
+})
+
+const ElButton = defineComponent({
+  name: 'ElButton',
+  props: {
+    type: String,
+    plain: Boolean,
+    text: Boolean,
+    disabled: Boolean,
+    loading: Boolean,
+  },
+  emits: ['click'],
+  render() {
+    return h(
+      'button',
+      {
+        'data-el-button': this.type || 'default',
+        'data-loading': this.loading ? 'true' : 'false',
+        disabled: this.disabled ? 'disabled' : undefined,
+        onClick: (event: Event) => this.$emit('click', event),
+      },
+      this.$slots.default?.(),
+    )
+  },
+})
+
+const ElAlert = defineComponent({
+  name: 'ElAlert',
+  props: { title: String, type: String, showIcon: Boolean, closable: Boolean },
+  render() {
+    return h('div', { 'data-el-alert': this.type }, this.title)
+  },
+})
+
+const ElEmpty = defineComponent({
+  name: 'ElEmpty',
+  props: { description: String, imageSize: Number },
+  render() {
+    return h('div', { 'data-el-empty': 'true' }, this.description)
+  },
+})
+
+const ElBadge = defineComponent({
+  name: 'ElBadge',
+  props: { value: [Number, String], max: Number, isDot: Boolean },
+  setup(props, { attrs, slots }) {
+    return () => h(
+      'sup',
+      {
+        ...attrs,
+        'data-el-badge': 'true',
+        'data-badge-value': String(props.value ?? ''),
+      },
+      slots.default?.() ?? String(props.value ?? ''),
+    )
+  },
+})
+
+const ElIcon = defineComponent({
+  name: 'ElIcon',
+  render() {
+    return h('i', { 'data-el-icon': 'true' }, this.$slots.default?.())
+  },
+})
+
+const ElPopconfirm = defineComponent({
+  name: 'ElPopconfirm',
+  props: { title: String, confirmButtonText: String, cancelButtonText: String },
+  emits: ['confirm', 'cancel'],
+  render() {
+    return h('div', { 'data-el-popconfirm': 'true' }, this.$slots.reference?.())
+  },
+})
+
+const ElDialog = defineComponent({
+  name: 'ElDialog',
+  props: { modelValue: Boolean, title: String, width: String },
+  emits: ['update:modelValue'],
+  render() {
+    return h('div', { 'data-el-dialog': 'true' }, this.$slots.default?.())
+  },
+})
+
+const ElForm = defineComponent({
+  name: 'ElForm',
+  render() {
+    return h('form', { 'data-el-form': 'true' }, this.$slots.default?.())
+  },
+})
+
+const ElFormItem = defineComponent({
+  name: 'ElFormItem',
+  props: { label: String },
+  render() {
+    return h('div', { 'data-el-form-item': 'true' }, this.$slots.default?.())
+  },
+})
+
+const ElDivider = defineComponent({
+  name: 'ElDivider',
+  render() {
+    return h('hr', { 'data-el-divider': 'true' })
+  },
+})
+
+const ElTimeline = defineComponent({
+  name: 'ElTimeline',
+  render() {
+    return h('div', { 'data-el-timeline': 'true' }, this.$slots.default?.())
+  },
+})
+
+const ElTimelineItem = defineComponent({
+  name: 'ElTimelineItem',
+  props: { type: String, hollow: Boolean, color: String, timestamp: String },
+  render() {
+    return h('div', { 'data-el-timeline-item': 'true' }, this.$slots.default?.())
+  },
+})
+
+const stubDirective = { mounted() {}, updated() {} }
+
+async function flushUi(cycles = 4): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+function registerCommonStubs(app: VueApp<Element>): void {
+  app.component('ElTabs', ElTabs)
+  app.component('ElTabPane', ElTabPane)
+  app.component('ElTable', ElTable)
+  app.component('ElTableColumn', ElTableColumn)
+  app.component('ElTag', ElTag)
+  app.component('ElInput', ElInput)
+  app.component('ElSelect', ElSelect)
+  app.component('ElOption', ElOption)
+  app.component('ElPagination', ElPagination)
+  app.component('ElButton', ElButton)
+  app.component('ElAlert', ElAlert)
+  app.component('ElEmpty', ElEmpty)
+  app.component('ElBadge', ElBadge)
+  app.component('ElIcon', ElIcon)
+  app.component('ElPopconfirm', ElPopconfirm)
+  app.component('ElDialog', ElDialog)
+  app.component('ElForm', ElForm)
+  app.component('ElFormItem', ElFormItem)
+  app.component('ElDivider', ElDivider)
+  app.component('ElTimeline', ElTimeline)
+  app.component('ElTimelineItem', ElTimelineItem)
+  app.directive('loading', stubDirective)
+}
+
+// ---------------------------------------------------------------------------
+// Specs
+// ---------------------------------------------------------------------------
+
+describe('ApprovalCenterView 待办红点 (WP3 slice 1)', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    getPendingCountSpy.mockReset()
+    remindApprovalSpy.mockReset()
+    pushSpy.mockClear()
+    elSuccessSpy.mockClear()
+    elWarningSpy.mockClear()
+    elErrorSpy.mockClear()
+    mockPendingApprovals.value = []
+    mockMyApprovals.value = []
+    mockCcApprovals.value = []
+    mockCompletedApprovals.value = []
+    mockLoading.value = false
+    mockError.value = null
+
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+    vi.clearAllMocks()
+  })
+
+  async function mountCenter(pendingCount: number): Promise<void> {
+    getPendingCountSpy.mockResolvedValue({ count: pendingCount })
+    const { default: ApprovalCenterView } = await import('../src/views/approval/ApprovalCenterView.vue')
+    const Host = defineComponent({
+      setup() {
+        return () => h(ApprovalCenterView as any)
+      },
+    })
+    app = createApp(Host)
+    registerCommonStubs(app)
+    app.mount(container!)
+    await flushUi(6)
+  }
+
+  it('renders a badge with the server count on mount when > 0', async () => {
+    await mountCenter(5)
+    expect(getPendingCountSpy).toHaveBeenCalledWith('all')
+    const badge = container!.querySelector('[data-testid="approval-pending-badge"]') as HTMLElement | null
+    expect(badge).toBeTruthy()
+    // el-badge prop is mapped to data-badge-value in our stub; the content is
+    // the same integer the endpoint returned.
+    expect(badge?.getAttribute('data-badge-value')).toBe('5')
+  })
+
+  it('hides the badge when the pending count is 0', async () => {
+    await mountCenter(0)
+    expect(getPendingCountSpy).toHaveBeenCalled()
+    const badge = container!.querySelector('[data-testid="approval-pending-badge"]')
+    expect(badge).toBeNull()
+  })
+})
+
+describe('ApprovalDetailView 催一下 (WP3 slice 1)', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    getPendingCountSpy.mockReset()
+    remindApprovalSpy.mockReset()
+    pushSpy.mockClear()
+    elSuccessSpy.mockClear()
+    elWarningSpy.mockClear()
+    elErrorSpy.mockClear()
+    mockActiveApproval.value = {
+      id: 'apv_remind_target',
+      sourceSystem: 'platform',
+      status: 'pending',
+      requester: { id: 'user_1', name: '申请人' },
+      title: '催办目标',
+      requestNo: 'AP-999999',
+      templateId: null,
+      templateVersionId: null,
+      publishedDefinitionId: null,
+      formSnapshot: null,
+      currentNodeKey: 'approval_1',
+      assignments: [],
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      totalSteps: 2,
+      currentStep: 1,
+    }
+    mockHistory.value = []
+
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+    vi.clearAllMocks()
+  })
+
+  async function mountDetail(): Promise<void> {
+    const { default: ApprovalDetailView } = await import('../src/views/approval/ApprovalDetailView.vue')
+    const Host = defineComponent({
+      setup() {
+        return () => h(ApprovalDetailView as any)
+      },
+    })
+    app = createApp(Host)
+    registerCommonStubs(app)
+    app.mount(container!)
+    await flushUi(6)
+  }
+
+  it('shows the 催一下 button for the requester on a pending approval', async () => {
+    await mountDetail()
+    const button = container!.querySelector('[data-testid="approval-remind-button"]') as HTMLButtonElement | null
+    expect(button).toBeTruthy()
+    expect(button!.textContent).toContain('催一下')
+  })
+
+  it('calls the remind API and shows a success toast on 200', async () => {
+    remindApprovalSpy.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        id: 'apv_remind_target',
+        action: 'remind',
+        remindedAt: new Date().toISOString(),
+        bridged: false,
+        sourceSystem: 'platform',
+      },
+    })
+    await mountDetail()
+    const button = container!.querySelector('[data-testid="approval-remind-button"]') as HTMLButtonElement
+    button.click()
+    await flushUi(6)
+    expect(remindApprovalSpy).toHaveBeenCalledWith('apv_remind_target')
+    expect(elSuccessSpy).toHaveBeenCalledWith('已催办')
+  })
+
+  it('surfaces the throttle message when the server returns 429', async () => {
+    const lastRemindedAt = new Date(Date.now() - 5 * 60 * 1000).toISOString()
+    remindApprovalSpy.mockResolvedValueOnce({
+      ok: false,
+      status: 429,
+      error: {
+        code: 'APPROVAL_REMIND_THROTTLED',
+        message: 'Remind is rate-limited',
+        lastRemindedAt,
+        retryAfterSeconds: 3600,
+      },
+    })
+    await mountDetail()
+    const button = container!.querySelector('[data-testid="approval-remind-button"]') as HTMLButtonElement
+    button.click()
+    await flushUi(6)
+    expect(remindApprovalSpy).toHaveBeenCalledWith('apv_remind_target')
+    expect(elWarningSpy).toHaveBeenCalled()
+    const message = elWarningSpy.mock.calls[0]?.[0] as string
+    expect(message).toContain('已在')
+    expect(message).toContain('催办过')
+    expect(elSuccessSpy).not.toHaveBeenCalled()
+  })
+
+  it('hides the 催一下 button when the current user is not the requester', async () => {
+    mockActiveApproval.value = {
+      ...mockActiveApproval.value,
+      requester: { id: 'user_not_the_current', name: '他人' },
+    }
+    await mountDetail()
+    const button = container!.querySelector('[data-testid="approval-remind-button"]')
+    expect(button).toBeNull()
+  })
+})

--- a/docs/development/approval-wave2-wp3-notifications-development-20260423.md
+++ b/docs/development/approval-wave2-wp3-notifications-development-20260423.md
@@ -1,0 +1,89 @@
+# Approval Wave 2 WP3 slice 1 — 催办 + 待办红点 (开发记录)
+
+- Date: 2026-04-23
+- Branch: `codex/approval-wave2-wp3-notifications-20260423`
+- Base: `origin/main@d1f35edf6`
+- Scope owner: `docs/development/approval-mvp-wave2-scope-breakdown-20260411.md` §WP3
+
+## 范围
+
+WP3 slice 1 按飞书 Gap Matrix 里前两条可独立落地的差距拆分，优先落地“催办 + 红点”两项最小闭环，其余 WP3 项目（读/未读持久化、跨系统推送、真实通知通道）沿用 `approval-mvp-feishu-gap-matrix-20260411.md` 里的排序推到后续 slice。
+
+- 催办 (remind / nudge)
+- 消息红点 / 待办计数
+
+## 后端契约
+
+### 新端点 1：`POST /api/approvals/:id/remind`
+
+- 独立路由，**不挂在** `/api/approvals/:id/actions` 联合处理器上。
+  - 理由：`/actions` 由 `rbacGuard('approvals', 'act')` 守卫，而催办允许“**发起人**或持有 `approvals:act` 的审批人”。如果合进 `/actions`，发起人只持 `approvals:read` 时会在 guard 层就 403；路由内再派发还要额外区分 afterSales bridge / template runtime / PLM bridge 三条分支。拆独立端点后：HTTP guard 改为 `approvals:read`，路由内部再校验 `requester OR approvals:act`，且完全跳过状态机 / 跨系统派发流程。
+- Body：允许为空 `{}`；目前不接受 `comment`，催办是事件而非意见。
+- 403 场景：非 requester 且无 `approvals:act` 时返回 `APPROVAL_REMIND_FORBIDDEN`。
+- 404 场景：instance id 不存在。
+- 400 场景：`status != 'pending'` 时返回 `APPROVAL_REMIND_STATUS_INVALID`，避免对已完结审批记录噪声事件。
+- 429 场景：同一 actor + 同一 instance 一小时内已有催办记录，直接返回 `APPROVAL_REMIND_THROTTLED`，响应体携带 `lastRemindedAt` 与 `retryAfterSeconds=3600`，前端以 toast 形式提示“已在 N 分钟前催办过”。
+- 200 成功：
+  - 写入一行 `approval_records`，`action='remind'`，`from_status = to_status = 'pending'`，`from_version = to_version = 0`（催办不推进流程）。
+  - `metadata = { remindedBy, remindedAt, sourceSystem, bridged:false }`。
+  - 响应体 `{ ok:true, data:{ id, action:'remind', remindedAt, bridged, sourceSystem } }`。
+
+### 速率限制实现
+
+使用 Postgres 侧的 `occurred_at > now() - INTERVAL '1 hour'` 作为判据。时钟与实际记录时间来自同一个数据库会话，不依赖客户端时钟；事务语义保证了“读取 + 插入”串行。
+
+### 新端点 2：`GET /api/approvals/pending-count`
+
+- Query：`sourceSystem = platform | plm | all`（默认 `all`）。
+- 返回：`{ count: number }`。
+- 语义：**对当前用户活跃的 `approval_assignments`（`is_active=TRUE`）** 计数，连接 `approval_instances` 过滤 `status='pending'`，并按 `sourceSystem` 可选过滤。同时包含 user 与 role 两种 assignment_type；actor 的角色集合由 `req.user.roles` 传入。
+- 与 LIST 的 PLM 分支有显著差异：LIST 在 `sourceSystem=plm` 且 `tab=pending` 时跳过 assignment join，用 `status='pending'` 直接呈现 PLM pending 队列（phase 1 限制）；但红点的契约定义是“当前用户活跃的 assignment 数量”，因此 pending-count 对所有来源统一使用 assignment join。两者的语义差异在 WP2 文档里已有明确边界，pending-count 不回退到 LIST 的妥协方案。
+- 输入错误：未知的 `sourceSystem` 返回 400 `APPROVAL_SOURCE_SYSTEM_INVALID`（与 LIST 的错误码一致）。
+
+### 数据库迁移
+
+`packages/core-backend/src/db/migrations/zzzz20260423120000_add_remind_action_to_approval_records.ts`：在 `approval_records_action_check` 里加 `'remind'`，复用 `zzzz20260411123000_add_created_action_to_approval_records.ts` 的 `DROP CONSTRAINT IF EXISTS` + `ADD CONSTRAINT` 的模板。
+
+测试端也同步更新 `packages/core-backend/tests/helpers/approval-schema-bootstrap.ts`，并把 bootstrap version 推进到 `20260423-wp3-remind-action`，确保并行 worker 会重新应用最新 DDL。
+
+## 前端改动
+
+### `apps/web/src/views/approval/ApprovalCenterView.vue`
+
+- 新增独立状态 `pendingBadgeCount`，由 `getPendingCount()` 端点驱动。故意不复用 store 里已有的 `pendingCount`（那是当前页列表长度，不是全局 assignment 数），避免切页时红点跟着跳。
+- 在 `待我处理` tab 的 `#label` 插槽里渲染 `<el-badge :value="pendingBadgeCount" :max="99" data-testid="approval-pending-badge" />`，仅当 `pendingBadgeCount > 0` 才渲染。
+- 挂载时 + tab 切换时刷新，sourceSystem 与列表过滤共享 `sourceSystemFilter` 的值，保证红点和列表严格一致。
+- 红点获取失败时不显示 toast（红点是装饰信息；列表加载错误仍通过 `store.error` 暴露）。
+
+### `apps/web/src/views/approval/ApprovalDetailView.vue`
+
+- 在 requester 看到的 actions-secondary 里新增 `催一下` 按钮（data-testid=`approval-remind-button`）。
+- 状态机：
+  - 200 → `ElMessage.success('已催办')`，并触发 `store.loadHistory(id)` 把新事件追加到时间线。
+  - 429 → `ElMessage.warning('已在 N 分钟前催办过')`，由 `lastRemindedAt` 换算出“分钟/小时前”。
+  - 其他错误 → 通用 `ElMessage.error('催办失败，请重试')`。
+- 使用独立的 `remindLoading` ref，不和审批动作的 `store.loading` 串联，避免“催一下”旋转影响 approve/reject 按钮。
+
+### `apps/web/src/approvals/api.ts`
+
+- 新增 `getPendingCount(sourceSystem)` + `remindApproval(id)`。
+- `remindApproval` 用原生 `apiFetch` 而不是 `apiPost`，这样 429 状态码能保留 `lastRemindedAt` 等字段交给 UI 层。
+
+## 显式 defer（未进入此 slice）
+
+- **读/未读（per user per instance）**：需要新建 `approval_reads` 表和读写路径，超出 slice 1 目标；slice 1 的“未读”口径近似为“当前用户仍有活跃 assignment”。
+- **PLM 催办外推**：PLM 目前不接受催办事件；此 slice 把 PLM 源的 instance 本地记录 `bridged:false`，不调用 `plmAdapter`。
+- **外部通知通道（IM / 邮件 / push）**：是 Phase 3 Notification Hub 的职责，本 slice 仅记录事件，不引入 `NotificationService` 或 `notification_topics` 表。
+- **抄送我的 / 已完成等 tab 的红点**：当前只覆盖 `待我处理`；其他 tab 不渲染红点，后续若需要再扩 endpoint。
+- **多端同步**：前端仅做“挂载时 + tab 切换时”拉取；WebSocket 推送与 WebView 多实例一致性是后续 slice 的任务。
+
+## 风险 / 已知副作用
+
+- `ensureApprovalSchemaReady` 的 `APPROVAL_SCHEMA_BOOTSTRAP_VERSION` 推进后，未清理的旧 worker DB 会在 `ADD CONSTRAINT` 前先 DROP，过程内有短暂的 CHECK 缺失窗口——由 advisory lock 保障单 worker 串行。
+- 催办未推进状态机，因此 `to_version = 0` 的行会出现在 `approval_records` 中；前端历史视图原本不显示 `remind` 动作，此 slice 不改历史视图排序规则；后续 slice 如果要展示催办徽章，可基于 `metadata.remindedAt` 检索最近一次催办。
+
+## Feishu Gap 进度
+
+- 催办：差距位 `❌` → `部分`（仅记录，未推送）
+- 消息红点 / 计数：差距位 `❌` → `部分`（待办红点已可用，其他 tab 红点未覆盖）
+- 已读/未读：仍为 `❌`（本 slice 不碰）

--- a/docs/development/approval-wave2-wp3-notifications-verification-20260423.md
+++ b/docs/development/approval-wave2-wp3-notifications-verification-20260423.md
@@ -1,0 +1,117 @@
+# Approval Wave 2 WP3 slice 1 — 催办 + 待办红点 (验证记录)
+
+- Date: 2026-04-23
+- Branch: `codex/approval-wave2-wp3-notifications-20260423`
+- Base: `origin/main@8d2d3e1b0` after final rebase
+- Related dev MD: `docs/development/approval-wave2-wp3-notifications-development-20260423.md`
+
+## 验证命令与结果
+
+所有命令都在 worktree 根目录 `/Users/chouhua/Downloads/Github/metasheet2/.worktrees/wp3-notifications` 执行。
+
+### 1) 依赖安装
+
+```bash
+pnpm install --prefer-offline
+```
+
+完成，无报错。
+
+### 2) Typecheck
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+```
+
+两者均无输出、退出码 0。
+
+### 3) WP3 新增集成测试
+
+```bash
+DATABASE_URL='postgresql://chouhua@127.0.0.1:5432/postgres' PGHOST=127.0.0.1 PGPORT=5432 PGDATABASE=postgres PGUSER=chouhua \
+  pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
+    tests/integration/approval-wp3-remind.api.test.ts \
+    tests/integration/approval-wp3-pending-count.api.test.ts --reporter=dot
+```
+
+```
+Test Files  2 passed (2)
+     Tests  12 passed (12)
+```
+
+- `approval-wp3-remind.api.test.ts` — 6 case pass (happy path / 429 / 403 / reviewer 允许 / 404 / 400 非 pending)
+- `approval-wp3-pending-count.api.test.ts` — 6 case pass (all / platform / plm / 默认值 / 400 / 过滤 inactive)
+
+### 4) 回归基线
+
+```bash
+DATABASE_URL='postgresql://chouhua@127.0.0.1:5432/postgres' PGHOST=127.0.0.1 PGPORT=5432 PGDATABASE=postgres PGUSER=chouhua \
+  pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
+    tests/integration/approval-wp2-source-filter.api.test.ts \
+    tests/integration/approval-pack1a-lifecycle.api.test.ts \
+    tests/integration/approval-wp1-any-mode.api.test.ts \
+    tests/integration/approval-wp1-parallel-gateway.api.test.ts --reporter=dot
+```
+
+```
+Test Files  4 passed (4)
+     Tests  15 passed (15)
+```
+
+各基线套件计数：
+- `approval-wp2-source-filter.api.test.ts` — 7 pass
+- `approval-pack1a-lifecycle.api.test.ts` — 3 pass
+- `approval-wp1-any-mode.api.test.ts` — 1 pass
+- `approval-wp1-parallel-gateway.api.test.ts` — 4 pass
+
+### 5) 前端 spec
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/approvalCenterRemindBadge.spec.ts --reporter=dot
+```
+
+```
+Test Files  1 passed (1)
+     Tests  6 passed (6)
+```
+
+覆盖：
+- `ApprovalCenterView` — pending-count=5 时渲染 `data-testid="approval-pending-badge"` 且值=5
+- `ApprovalCenterView` — pending-count=0 时 badge 隐藏
+- `ApprovalDetailView` — requester 能看到 `催一下` 按钮
+- `ApprovalDetailView` — 点击 `催一下` 触发 `remindApproval('apv_remind_target')` 并弹 success toast
+- `ApprovalDetailView` — 429 响应时 toast 文案包含“已在” + “催办过”
+- `ApprovalDetailView` — 非 requester 时 `催一下` 按钮不渲染
+
+并行回归：`tests/approvalCenterSourceFilter.spec.ts` 仍 4/4 pass，确认未破坏 WP2 的 source filter spec。
+
+## 基线参考
+
+- `main` 基线 HEAD: `d1f35edf6`（`test(ops): add stacked PR readiness guard (#1103)`）。
+- `approval-center.spec.ts` 在 baseline 即有 5 个 failing（`refreshApprovalAccess` 相关），本 slice 未引入新 regression（`git stash` 复现确认）。
+
+## 不纳入本 slice 的验证
+
+- 未做真实通知通道 E2E（外部 IM / 邮件 / push）。
+- 未做 WebSocket 多端红点实时推送验证；红点刷新目前是拉式（mount + tab switch）。
+- PLM 源的催办仅有本地记录覆盖（`bridged:false`），未对 PLM adapter 做集成调用（phase 1 未引入推送通道）。
+
+## Rebase Verification - 2026-04-23
+
+- Rebased `codex/approval-wave2-wp3-notifications-20260423` onto `origin/main@76ddfeacd`.
+- Rebased HEAD: `cc17db0d5`.
+- Dirty generated dependency entries under `plugins/` and `tools/` were cleared before rebase; no business-file conflicts occurred.
+- `pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false`: pass.
+- `pnpm --filter @metasheet/web exec vue-tsc --noEmit`: pass.
+- WP3 integration tests: 2 files / 12 tests passed.
+- WP2 + Pack 1A + WP1 regression integration tests: 4 files / 15 tests passed.
+- Frontend `approvalCenterRemindBadge` + `approvalCenterSourceFilter`: 2 files / 10 tests passed.
+- Integration startup still logs pre-existing degraded-mode messages for optional workflow/event/automation tables in this local DB, but all targeted API assertions pass.
+
+## Final Rebase - 2026-04-23
+
+- Rebased again onto `origin/main@8d2d3e1b0` after DingTalk P4 env/product-gate follow-ups merged.
+- Final HEAD: `8b3421486`.
+- No conflicts and no touched-file overlap with the new DingTalk P4 commits.
+- Final quick recheck: `git diff --check` passed; frontend `approvalCenterRemindBadge` + `approvalCenterSourceFilter` passed again, 10/10.

--- a/packages/core-backend/src/db/migrations/zzzz20260423120000_add_remind_action_to_approval_records.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260423120000_add_remind_action_to_approval_records.ts
@@ -1,0 +1,20 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+
+/**
+ * Wave 2 WP3 slice 1 (审批催办): accept `action = 'remind'` in approval_records
+ * so requesters can record a nudge without changing the approval's status.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`ALTER TABLE approval_records DROP CONSTRAINT IF EXISTS approval_records_action_check`.execute(db)
+  await sql`ALTER TABLE approval_records
+    ADD CONSTRAINT approval_records_action_check
+    CHECK (action IN ('created', 'approve', 'reject', 'return', 'revoke', 'transfer', 'sign', 'comment', 'cc', 'remind'))`.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`ALTER TABLE approval_records DROP CONSTRAINT IF EXISTS approval_records_action_check`.execute(db)
+  await sql`ALTER TABLE approval_records
+    ADD CONSTRAINT approval_records_action_check
+    CHECK (action IN ('created', 'approve', 'reject', 'return', 'revoke', 'transfer', 'sign', 'comment', 'cc'))`.execute(db)
+}

--- a/packages/core-backend/src/routes/approvals.ts
+++ b/packages/core-backend/src/routes/approvals.ts
@@ -542,6 +542,253 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
     }
   })
 
+  // Wave 2 WP3 slice 1: count the current user's active pending assignments so
+  // the 待办 tab can render a red-badge indicator. Filtered by sourceSystem so
+  // the frontend can ask for `all | platform | plm` without fetching the full
+  // list. Semantics mirror the LIST pending tab's assignment rule uniformly
+  // across source systems (user OR role match on approval_assignments), which
+  // diverges from LIST's PLM-specific "status=pending without assignment
+  // join" branch on purpose — the task contract explicitly defines this count
+  // as `is_active=TRUE assignments for the current user`.
+  r.get('/api/approvals/pending-count', authenticate, rbacGuard('approvals', 'read'), async (req: Request, res: Response) => {
+    try {
+      if (!pool) {
+        return res.status(503).json(
+          approvalErrorResponse('APPROVALS_DATABASE_UNAVAILABLE', 'Database not available'),
+        )
+      }
+
+      const userId = resolveApprovalActorId(req)
+      if (!userId) {
+        return res.status(401).json(
+          approvalErrorResponse('APPROVAL_USER_REQUIRED', 'User ID not found in token'),
+        )
+      }
+
+      const rawSourceSystem = typeof req.query.sourceSystem === 'string' ? req.query.sourceSystem.trim() : ''
+      if (rawSourceSystem && !['platform', 'plm', 'all'].includes(rawSourceSystem)) {
+        return res.status(400).json(
+          approvalErrorResponse(
+            'APPROVAL_SOURCE_SYSTEM_INVALID',
+            "sourceSystem must be one of 'platform', 'plm', or 'all'",
+          ),
+        )
+      }
+      const sourceSystem = rawSourceSystem === 'all' || rawSourceSystem === ''
+        ? null
+        : (rawSourceSystem as 'platform' | 'plm')
+      const actorRoles = resolveApprovalActorRoles(req)
+      const actorRolesParam = actorRoles.length > 0 ? actorRoles : ['__none__']
+
+      const conditions: string[] = [
+        `a.is_active = TRUE`,
+        `i.status = 'pending'`,
+        `(
+          (a.assignment_type = 'user' AND a.assignee_id = $1)
+          OR (a.assignment_type = 'role' AND a.assignee_id = ANY($2))
+        )`,
+      ]
+      const params: unknown[] = [userId, actorRolesParam]
+
+      if (sourceSystem) {
+        conditions.push(`COALESCE(i.source_system, 'platform') = $${params.length + 1}`)
+        params.push(sourceSystem)
+      }
+
+      const countResult = await pool.query<{ count: string }>(
+        `SELECT COUNT(DISTINCT a.instance_id)::text AS count
+         FROM approval_assignments a
+         INNER JOIN approval_instances i ON i.id = a.instance_id
+         WHERE ${conditions.join(' AND ')}`,
+        params,
+      )
+
+      res.json({ count: parseInt(countResult.rows[0]?.count || '0', 10) })
+    } catch (error) {
+      handleApprovalsError(
+        res,
+        error,
+        'APPROVAL_PENDING_COUNT_FAILED',
+        'Failed to compute pending approval count',
+        () => res.json({ count: 0, degraded: true }),
+      )
+    }
+  })
+
+  // Wave 2 WP3 slice 1: 催办 (remind / nudge). Records a `remind` row on
+  // approval_records so the timeline preserves the nudge event; the task
+  // boundary explicitly defers external notification channels (IM/email/push)
+  // to Phase 3 Notification Hub. PLM-sourced approvals are recorded locally
+  // but not forwarded upstream (bridged=false in the response).
+  //
+  // Permission model: a dedicated endpoint rather than bolting onto
+  // `/actions` so that the requester — who may not hold `approvals:act` —
+  // can still nudge. Guarded by `approvals:read`, then the handler refines:
+  // requester OR `approvals:act` perm.
+  //
+  // Rate limit: at most 1 remind per instance per user per hour. Uses
+  // `occurred_at > now() - interval '1 hour'` so the clock lives in the DB
+  // and stays consistent with the recorded timestamp.
+  r.post('/api/approvals/:id/remind', authenticate, rbacGuard('approvals', 'read'), async (req: Request, res: Response) => {
+    try {
+      if (!pool) {
+        return res.status(503).json(
+          approvalErrorResponse('APPROVALS_DATABASE_UNAVAILABLE', 'Database not available'),
+        )
+      }
+
+      const userId = resolveApprovalActorId(req)
+      if (!userId) {
+        return res.status(401).json(
+          approvalErrorResponse('APPROVAL_USER_REQUIRED', 'User ID not found in token'),
+        )
+      }
+
+      const { id } = req.params
+      const userName = resolveApprovalActorName(req, userId)
+
+      const client = await pool.connect()
+      try {
+        await client.query('BEGIN')
+
+        const instanceResult = await client.query<{
+          id: string
+          status: string
+          source_system: string | null
+          requester_snapshot: { id?: string | null } | null
+        }>(
+          `SELECT id, status, source_system, requester_snapshot
+           FROM approval_instances
+           WHERE id = $1
+           FOR UPDATE`,
+          [id],
+        )
+
+        if (instanceResult.rows.length === 0) {
+          await client.query('ROLLBACK')
+          return res.status(404).json(
+            approvalErrorResponse('APPROVAL_NOT_FOUND', 'Approval instance not found'),
+          )
+        }
+
+        const instance = instanceResult.rows[0]
+        const requesterId = instance.requester_snapshot?.id ?? null
+        const actorPerms = Array.isArray(req.user?.permissions)
+          ? req.user!.permissions.filter((p): p is string => typeof p === 'string')
+          : []
+        const actorPermsFromToken = Array.isArray((req.user as { perms?: unknown })?.perms)
+          ? ((req.user as { perms: unknown }).perms as unknown[]).filter((p): p is string => typeof p === 'string')
+          : []
+        const combinedPerms = [...actorPerms, ...actorPermsFromToken]
+        const actorRoles = resolveApprovalActorRoles(req)
+        const isAdminUser = actorRoles.includes('admin') || req.user?.role === 'admin'
+        const hasActPerm = isAdminUser
+          || combinedPerms.includes('*:*')
+          || combinedPerms.includes('approvals:*')
+          || combinedPerms.includes('approvals:act')
+        const isRequester = requesterId != null && requesterId === userId
+
+        if (!isRequester && !hasActPerm) {
+          await client.query('ROLLBACK')
+          return res.status(403).json(
+            approvalErrorResponse(
+              'APPROVAL_REMIND_FORBIDDEN',
+              'Only the requester or an approver may remind this approval',
+            ),
+          )
+        }
+
+        if (instance.status !== 'pending') {
+          await client.query('ROLLBACK')
+          return res.status(400).json(
+            approvalErrorResponse(
+              'APPROVAL_REMIND_STATUS_INVALID',
+              `Cannot remind: current status is ${instance.status}`,
+            ),
+          )
+        }
+
+        // 1-hour soft rate limit — a previous remind by the same actor on
+        // the same instance within the window returns 429 and never writes
+        // a duplicate record.
+        const recentResult = await client.query<{ occurred_at: Date }>(
+          `SELECT occurred_at FROM approval_records
+           WHERE instance_id = $1
+             AND action = 'remind'
+             AND actor_id = $2
+             AND occurred_at > now() - INTERVAL '1 hour'
+           ORDER BY occurred_at DESC
+           LIMIT 1`,
+          [id, userId],
+        )
+
+        if (recentResult.rows.length > 0) {
+          await client.query('ROLLBACK')
+          const lastAt = recentResult.rows[0].occurred_at
+          const lastIso = lastAt instanceof Date ? lastAt.toISOString() : String(lastAt)
+          return res.status(429).json({
+            ok: false,
+            error: {
+              code: 'APPROVAL_REMIND_THROTTLED',
+              message: 'Remind is rate-limited to once per instance per hour',
+              lastRemindedAt: lastIso,
+              retryAfterSeconds: 3600,
+            },
+          })
+        }
+
+        const bridged = false
+        const metadata = {
+          remindedBy: userId,
+          remindedAt: new Date().toISOString(),
+          sourceSystem: instance.source_system ?? 'platform',
+          bridged,
+        }
+
+        await client.query(
+          `INSERT INTO approval_records
+           (instance_id, action, actor_id, actor_name, comment, from_status, to_status, from_version, to_version, metadata, ip_address, user_agent)
+           VALUES ($1, 'remind', $2, $3, NULL, $4, $4, 0, 0, $5, $6, $7)`,
+          [
+            id,
+            userId,
+            userName,
+            instance.status,
+            JSON.stringify(metadata),
+            req.ip || null,
+            req.get('user-agent') || null,
+          ],
+        )
+
+        await client.query('COMMIT')
+
+        logger.info(`Approval ${id} reminded by ${userId}`)
+        res.json({
+          ok: true,
+          data: {
+            id,
+            action: 'remind',
+            remindedAt: metadata.remindedAt,
+            bridged,
+            sourceSystem: metadata.sourceSystem,
+          },
+        })
+      } catch (innerError) {
+        await client.query('ROLLBACK')
+        throw innerError
+      } finally {
+        client.release()
+      }
+    } catch (error) {
+      handleApprovalsError(
+        res,
+        error,
+        'APPROVAL_REMIND_FAILED',
+        'Failed to remind approval',
+      )
+    }
+  })
+
   r.post('/api/approvals/:id/actions', authenticate, rbacGuard('approvals', 'act'), async (req: Request, res: Response) => {
     try {
       const bridgeService = getBridgeService(options)

--- a/packages/core-backend/tests/helpers/approval-schema-bootstrap.ts
+++ b/packages/core-backend/tests/helpers/approval-schema-bootstrap.ts
@@ -1,7 +1,7 @@
 import { poolManager } from '../../src/integration/db/connection-pool'
 
 const APPROVAL_SCHEMA_BOOTSTRAP_KEY = 'approval-schema-bootstrap'
-const APPROVAL_SCHEMA_BOOTSTRAP_VERSION = '20260423-once-per-db'
+const APPROVAL_SCHEMA_BOOTSTRAP_VERSION = '20260423-wp3-remind-action'
 
 /**
  * Ensures the approval schema (tables, constraints, indexes, sequences) is
@@ -14,6 +14,7 @@ const APPROVAL_SCHEMA_BOOTSTRAP_VERSION = '20260423-once-per-db'
  *   - zzzz20260404100000_extend_approval_tables_for_bridge.ts
  *   - zzzz20260411120100_approval_templates_and_instance_extensions.ts
  *   - zzzz20260411123000_add_created_action_to_approval_records.ts
+ *   - zzzz20260423120000_add_remind_action_to_approval_records.ts
  *
  * ### Concurrency — why an advisory lock
  *
@@ -174,7 +175,7 @@ export async function ensureApprovalSchemaReady(): Promise<void> {
     await client.query(`
       ALTER TABLE approval_records
       ADD CONSTRAINT approval_records_action_check
-      CHECK (action IN ('created', 'approve', 'reject', 'return', 'revoke', 'transfer', 'sign', 'comment', 'cc'))
+      CHECK (action IN ('created', 'approve', 'reject', 'return', 'revoke', 'transfer', 'sign', 'comment', 'cc', 'remind'))
     `)
     await client.query(`CREATE INDEX IF NOT EXISTS idx_approval_records_instance ON approval_records(instance_id)`)
     await client.query(`CREATE INDEX IF NOT EXISTS idx_approval_records_instance_action_time ON approval_records(instance_id, action, occurred_at DESC)`)

--- a/packages/core-backend/tests/integration/approval-wp3-pending-count.api.test.ts
+++ b/packages/core-backend/tests/integration/approval-wp3-pending-count.api.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Wave 2 WP3 slice 1 — GET /api/approvals/pending-count.
+ *
+ * Asserts that the badge endpoint returns the count of active assignments for
+ * the current user, scoped by `sourceSystem`:
+ *   - all       → every pending assignment
+ *   - platform  → platform-owned pending only
+ *   - plm       → PLM-mirrored pending only
+ *
+ * Uses a dedicated actor id + suite suffix so other integration suites that
+ * seed assignments on shared tables cannot perturb the count.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import net from 'net'
+import { randomUUID } from 'node:crypto'
+import { MetaSheetServer } from '../../src/index'
+import { IPLMAdapter } from '../../src/di/identifiers'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { ensureApprovalSchemaReady } from '../helpers/approval-schema-bootstrap'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+async function canListenOnEphemeralPort(): Promise<boolean> {
+  return await new Promise((resolve) => {
+    const server = net.createServer()
+    server.once('error', () => resolve(false))
+    server.listen(0, '127.0.0.1', () => server.close(() => resolve(true)))
+  })
+}
+
+async function devToken(baseUrl: string, userId: string): Promise<string> {
+  const response = await fetch(
+    `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=${encodeURIComponent('*:*')}`,
+  )
+  expect(response.status).toBe(200)
+  const payload = await response.json() as { token: string }
+  return payload.token
+}
+
+async function fetchCount(baseUrl: string, token: string, sourceSystem: string): Promise<number> {
+  const response = await fetch(
+    `${baseUrl}/api/approvals/pending-count?sourceSystem=${encodeURIComponent(sourceSystem)}`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  )
+  expect(response.status).toBe(200)
+  const payload = await response.json() as { count: number }
+  return payload.count
+}
+
+describeIfDatabase('Approval Wave 2 WP3 slice 1 — pending-count endpoint', () => {
+  let server: MetaSheetServer | undefined
+  let baseUrl = ''
+  const suiteSuffix = randomUUID().slice(0, 8)
+  const actorId = `wp3-count-actor-${suiteSuffix}`
+  const instances = [
+    { id: `apv_wp3_count_platform_a_${suiteSuffix}`, sourceSystem: 'platform', workflowKey: `wp3-count-platform-a-${suiteSuffix}` },
+    { id: `apv_wp3_count_platform_b_${suiteSuffix}`, sourceSystem: 'platform', workflowKey: `wp3-count-platform-b-${suiteSuffix}` },
+    { id: `plm:wp3_count_plm_${suiteSuffix}`, sourceSystem: 'plm', workflowKey: `wp3-count-plm-${suiteSuffix}`, externalId: `wp3_count_plm_${suiteSuffix}` },
+  ] as const
+
+  beforeAll(async () => {
+    const canListen = await canListenOnEphemeralPort()
+    expect(canListen).toBe(true)
+
+    await ensureApprovalSchemaReady()
+
+    const pool = poolManager.get()
+
+    // Seed 2 platform + 1 PLM pending approvals, each with an active
+    // user-assignment targeting the actor. We also attach an inactive
+    // assignment to confirm the `is_active = TRUE` filter.
+    for (const instance of instances) {
+      if (instance.sourceSystem === 'platform') {
+        await pool.query(
+          `INSERT INTO approval_instances
+             (id, status, version, source_system, workflow_key, business_key, title,
+              requester_snapshot, subject_snapshot, policy_snapshot, metadata,
+              current_step, total_steps, sync_status, created_at, updated_at)
+           VALUES ($1, 'pending', 0, 'platform', $2, $3, $4,
+                   '{"id":"requester-platform","name":"平台发起人"}'::jsonb,
+                   '{}'::jsonb, '{}'::jsonb, '{}'::jsonb,
+                   0, 0, 'ok', now(), now())`,
+          [instance.id, instance.workflowKey, `wp3:count:${instance.workflowKey}`, `WP3 count ${instance.workflowKey}`],
+        )
+      } else {
+        await pool.query(
+          `INSERT INTO approval_instances
+             (id, status, version, source_system, external_approval_id, workflow_key, business_key, title,
+              requester_snapshot, subject_snapshot, policy_snapshot, metadata,
+              current_step, total_steps, sync_status, created_at, updated_at)
+           VALUES ($1, 'pending', 0, 'plm', $2, $3, $4, $5,
+                   '{"id":"plm-requester","name":"PLM 发起人"}'::jsonb,
+                   '{"productNumber":"P-WP3","productName":"产品"}'::jsonb,
+                   '{"rejectCommentRequired":true,"sourceOfTruth":"plm"}'::jsonb,
+                   '{"source_type":"eco","source_stage":"review","source_version":0}'::jsonb,
+                   0, 0, 'ok', now(), now())`,
+          [instance.id, instance.externalId, instance.workflowKey, `wp3:count:${instance.workflowKey}`, `WP3 count ${instance.workflowKey}`],
+        )
+      }
+
+      await pool.query(
+        `INSERT INTO approval_assignments
+           (id, instance_id, assignment_type, assignee_id, source_step, node_key, is_active, metadata, created_at, updated_at)
+         VALUES ($1, $2, 'user', $3, 0, $4, TRUE, '{}'::jsonb, now(), now())`,
+        [randomUUID(), instance.id, actorId, `wp3_count_node_${instance.sourceSystem}`],
+      )
+    }
+
+    // Seed an INACTIVE assignment on a different user — must not increment the
+    // count. This guards against a regression where `is_active` is dropped
+    // from the predicate.
+    await pool.query(
+      `INSERT INTO approval_assignments
+         (id, instance_id, assignment_type, assignee_id, source_step, node_key, is_active, metadata, created_at, updated_at)
+       VALUES ($1, $2, 'user', $3, 0, 'wp3_count_inactive', FALSE, '{}'::jsonb, now(), now())`,
+      [randomUUID(), instances[0].id, actorId],
+    )
+
+    server = new MetaSheetServer({
+      port: 0,
+      host: '127.0.0.1',
+      pluginDirs: [],
+    })
+    await server.start()
+    const address = server.getAddress()
+    expect(address?.port).toBeTruthy()
+    baseUrl = `http://127.0.0.1:${address.port}`
+
+    const injector = (server as unknown as { injector?: { get: (id: unknown) => unknown } }).injector
+    if (injector) {
+      const plmAdapter = injector.get(IPLMAdapter) as { connect?: () => Promise<void> }
+      if (typeof plmAdapter.connect === 'function') {
+        await plmAdapter.connect()
+      }
+    }
+  })
+
+  afterAll(async () => {
+    const pool = poolManager.get()
+    const ids = instances.map((instance) => instance.id)
+    try {
+      await pool.query('DELETE FROM approval_records WHERE instance_id = ANY($1::text[])', [ids])
+      await pool.query('DELETE FROM approval_assignments WHERE instance_id = ANY($1::text[])', [ids])
+      await pool.query('DELETE FROM approval_instances WHERE id = ANY($1::text[])', [ids])
+    } catch {
+      // cleanup failures shouldn't mask the test result
+    }
+
+    if (server) {
+      await server.stop()
+    }
+  })
+
+  it('returns the cross-source count when sourceSystem=all', async () => {
+    const token = await devToken(baseUrl, actorId)
+    const count = await fetchCount(baseUrl, token, 'all')
+    expect(count).toBe(3)
+  })
+
+  it('returns only platform assignments when sourceSystem=platform', async () => {
+    const token = await devToken(baseUrl, actorId)
+    const count = await fetchCount(baseUrl, token, 'platform')
+    expect(count).toBe(2)
+  })
+
+  it('returns only plm assignments when sourceSystem=plm', async () => {
+    const token = await devToken(baseUrl, actorId)
+    const count = await fetchCount(baseUrl, token, 'plm')
+    expect(count).toBe(1)
+  })
+
+  it('treats the sourceSystem query as optional and defaults to all', async () => {
+    const token = await devToken(baseUrl, actorId)
+    const response = await fetch(`${baseUrl}/api/approvals/pending-count`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    expect(response.status).toBe(200)
+    const payload = await response.json() as { count: number }
+    expect(payload.count).toBe(3)
+  })
+
+  it('rejects invalid sourceSystem values with 400', async () => {
+    const token = await devToken(baseUrl, actorId)
+    const response = await fetch(
+      `${baseUrl}/api/approvals/pending-count?sourceSystem=bogus`,
+      { headers: { Authorization: `Bearer ${token}` } },
+    )
+    expect(response.status).toBe(400)
+    const payload = await response.json() as { error: { code: string } }
+    expect(payload.error.code).toBe('APPROVAL_SOURCE_SYSTEM_INVALID')
+  })
+
+  it('excludes inactive assignments from the count', async () => {
+    // Isolation sanity: the actor has one inactive assignment; it must not
+    // bleed into the platform or all counts.
+    const token = await devToken(baseUrl, actorId)
+    expect(await fetchCount(baseUrl, token, 'platform')).toBe(2)
+  })
+})

--- a/packages/core-backend/tests/integration/approval-wp3-remind.api.test.ts
+++ b/packages/core-backend/tests/integration/approval-wp3-remind.api.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Wave 2 WP3 slice 1 — 催办 (remind action) integration tests.
+ *
+ * Validates:
+ *  - Happy path: requester with narrow perms → 200, approval_records row created.
+ *  - Rate limit: a second remind by the same user within an hour → 429.
+ *  - Authorization: non-requester without `approvals:act` → 403.
+ *  - Missing target: unknown instance id → 404.
+ *  - PLM source: remind records locally with bridged=false, no upstream hit.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import net from 'net'
+import { randomUUID } from 'node:crypto'
+import { MetaSheetServer } from '../../src/index'
+import { IPLMAdapter } from '../../src/di/identifiers'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { ensureApprovalSchemaReady } from '../helpers/approval-schema-bootstrap'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+async function canListenOnEphemeralPort(): Promise<boolean> {
+  return await new Promise((resolve) => {
+    const server = net.createServer()
+    server.once('error', () => resolve(false))
+    server.listen(0, '127.0.0.1', () => server.close(() => resolve(true)))
+  })
+}
+
+async function devToken(
+  baseUrl: string,
+  userId: string,
+  options: { roles?: string; perms?: string } = {},
+): Promise<string> {
+  const params = new URLSearchParams({
+    userId,
+    roles: options.roles ?? 'admin',
+    perms: options.perms ?? '*:*',
+  })
+  const response = await fetch(`${baseUrl}/api/auth/dev-token?${params.toString()}`)
+  expect(response.status).toBe(200)
+  const payload = await response.json() as { token: string }
+  return payload.token
+}
+
+describeIfDatabase('Approval Wave 2 WP3 slice 1 — remind', () => {
+  let server: MetaSheetServer | undefined
+  let baseUrl = ''
+  const suiteSuffix = randomUUID().slice(0, 8)
+  const requesterId = `wp3-remind-requester-${suiteSuffix}`
+  const strangerId = `wp3-remind-stranger-${suiteSuffix}`
+  const reviewerId = `wp3-remind-reviewer-${suiteSuffix}`
+  const platformInstanceId = `apv_wp3_remind_${suiteSuffix}`
+  const plmExternalId = `wp3_remind_plm_${suiteSuffix}`
+  const plmInstanceId = `plm:${plmExternalId}`
+  const completedInstanceId = `apv_wp3_remind_done_${suiteSuffix}`
+  const createdIds = [platformInstanceId, plmInstanceId, completedInstanceId]
+
+  beforeAll(async () => {
+    const canListen = await canListenOnEphemeralPort()
+    expect(canListen).toBe(true)
+
+    await ensureApprovalSchemaReady()
+
+    const pool = poolManager.get()
+
+    await pool.query(
+      `INSERT INTO approval_instances
+         (id, status, version, source_system, workflow_key, business_key, title,
+          requester_snapshot, subject_snapshot, policy_snapshot, metadata,
+          current_step, total_steps, sync_status, created_at, updated_at)
+       VALUES ($1, 'pending', 0, 'platform', $2, $3, $4,
+               $5::jsonb,
+               '{}'::jsonb, '{}'::jsonb, '{}'::jsonb,
+               0, 0, 'ok', now(), now())`,
+      [
+        platformInstanceId,
+        `wp3-remind-${suiteSuffix}`,
+        `wp3:remind:${suiteSuffix}`,
+        `WP3 remind approval ${suiteSuffix}`,
+        JSON.stringify({ id: requesterId, name: '催办发起人' }),
+      ],
+    )
+
+    await pool.query(
+      `INSERT INTO approval_instances
+         (id, status, version, source_system, external_approval_id, workflow_key, business_key, title,
+          requester_snapshot, subject_snapshot, policy_snapshot, metadata,
+          current_step, total_steps, sync_status, created_at, updated_at)
+       VALUES ($1, 'pending', 0, 'plm', $2, $3, $4, $5,
+               $6::jsonb,
+               '{"productNumber":"P-WP3","productName":"产品"}'::jsonb,
+               '{"rejectCommentRequired":true,"sourceOfTruth":"plm"}'::jsonb,
+               '{"source_type":"eco","source_stage":"review","source_version":0}'::jsonb,
+               0, 0, 'ok', now(), now())`,
+      [
+        plmInstanceId,
+        plmExternalId,
+        `wp3-remind-plm-${suiteSuffix}`,
+        `wp3:remind:plm:${suiteSuffix}`,
+        `WP3 PLM remind approval ${suiteSuffix}`,
+        JSON.stringify({ id: requesterId, name: '催办 PLM 发起人' }),
+      ],
+    )
+
+    await pool.query(
+      `INSERT INTO approval_instances
+         (id, status, version, source_system, workflow_key, business_key, title,
+          requester_snapshot, subject_snapshot, policy_snapshot, metadata,
+          current_step, total_steps, sync_status, created_at, updated_at)
+       VALUES ($1, 'approved', 1, 'platform', $2, $3, $4,
+               $5::jsonb,
+               '{}'::jsonb, '{}'::jsonb, '{}'::jsonb,
+               0, 0, 'ok', now(), now())`,
+      [
+        completedInstanceId,
+        `wp3-remind-done-${suiteSuffix}`,
+        `wp3:remind:done:${suiteSuffix}`,
+        `WP3 remind completed ${suiteSuffix}`,
+        JSON.stringify({ id: requesterId, name: '催办发起人' }),
+      ],
+    )
+
+    server = new MetaSheetServer({
+      port: 0,
+      host: '127.0.0.1',
+      pluginDirs: [],
+    })
+    await server.start()
+    const address = server.getAddress()
+    expect(address?.port).toBeTruthy()
+    baseUrl = `http://127.0.0.1:${address.port}`
+
+    // The PLM adapter is mock-mode in integration; remind must not hit it
+    // (bridged=false), so even without connect() the suite stays hermetic.
+    const injector = (server as unknown as { injector?: { get: (id: unknown) => unknown } }).injector
+    if (injector) {
+      const plmAdapter = injector.get(IPLMAdapter) as { connect?: () => Promise<void> }
+      if (typeof plmAdapter.connect === 'function') {
+        await plmAdapter.connect()
+      }
+    }
+  })
+
+  afterAll(async () => {
+    const pool = poolManager.get()
+    try {
+      await pool.query('DELETE FROM approval_records WHERE instance_id = ANY($1::text[])', [createdIds])
+      await pool.query('DELETE FROM approval_assignments WHERE instance_id = ANY($1::text[])', [createdIds])
+      await pool.query('DELETE FROM approval_instances WHERE id = ANY($1::text[])', [createdIds])
+    } catch {
+      // cleanup failures shouldn't mask the test result
+    }
+
+    if (server) {
+      await server.stop()
+    }
+  })
+
+  it('records a remind event when the requester nudges their pending approval', async () => {
+    const token = await devToken(baseUrl, requesterId, { roles: 'user', perms: 'approvals:read' })
+    const response = await fetch(`${baseUrl}/api/approvals/${platformInstanceId}/remind`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    })
+    expect(response.status).toBe(200)
+    const payload = await response.json() as { ok: boolean; data: { action: string; bridged: boolean; sourceSystem: string } }
+    expect(payload.ok).toBe(true)
+    expect(payload.data.action).toBe('remind')
+    expect(payload.data.bridged).toBe(false)
+    expect(payload.data.sourceSystem).toBe('platform')
+
+    const pool = poolManager.get()
+    const result = await pool.query<{
+      action: string
+      actor_id: string | null
+      metadata: Record<string, unknown>
+    }>(
+      `SELECT action, actor_id, metadata FROM approval_records
+       WHERE instance_id = $1 AND action = 'remind' AND actor_id = $2`,
+      [platformInstanceId, requesterId],
+    )
+    expect(result.rows).toHaveLength(1)
+    expect(result.rows[0].metadata.remindedBy).toBe(requesterId)
+    expect(typeof result.rows[0].metadata.remindedAt).toBe('string')
+    expect(result.rows[0].metadata.bridged).toBe(false)
+  })
+
+  it('throttles a second remind by the same user within an hour', async () => {
+    const token = await devToken(baseUrl, requesterId, { roles: 'user', perms: 'approvals:read' })
+    const response = await fetch(`${baseUrl}/api/approvals/${platformInstanceId}/remind`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    })
+    expect(response.status).toBe(429)
+    const payload = await response.json() as {
+      ok: boolean
+      error: { code: string; lastRemindedAt?: string; retryAfterSeconds?: number }
+    }
+    expect(payload.ok).toBe(false)
+    expect(payload.error.code).toBe('APPROVAL_REMIND_THROTTLED')
+    expect(typeof payload.error.lastRemindedAt).toBe('string')
+    expect(payload.error.retryAfterSeconds).toBe(3600)
+
+    // Sanity: a second record must not have been inserted.
+    const pool = poolManager.get()
+    const countResult = await pool.query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count FROM approval_records
+       WHERE instance_id = $1 AND action = 'remind' AND actor_id = $2`,
+      [platformInstanceId, requesterId],
+    )
+    expect(parseInt(countResult.rows[0].count, 10)).toBe(1)
+  })
+
+  it('rejects a non-requester without approvals:act perm with 403', async () => {
+    const token = await devToken(baseUrl, strangerId, { roles: 'user', perms: 'approvals:read' })
+    const response = await fetch(`${baseUrl}/api/approvals/${platformInstanceId}/remind`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    })
+    expect(response.status).toBe(403)
+    const payload = await response.json() as { error: { code: string } }
+    expect(payload.error.code).toBe('APPROVAL_REMIND_FORBIDDEN')
+  })
+
+  it('allows a non-requester reviewer who has approvals:act', async () => {
+    const token = await devToken(baseUrl, reviewerId, { roles: 'user', perms: 'approvals:read,approvals:act' })
+    // Reviewer targets a fresh row to avoid hitting the 1-hour throttle on the
+    // platform instance that the happy-path test already reminded.
+    const response = await fetch(`${baseUrl}/api/approvals/${plmInstanceId}/remind`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    })
+    expect(response.status).toBe(200)
+    const payload = await response.json() as { ok: boolean; data: { bridged: boolean; sourceSystem: string } }
+    expect(payload.ok).toBe(true)
+    expect(payload.data.bridged).toBe(false)
+    expect(payload.data.sourceSystem).toBe('plm')
+  })
+
+  it('returns 404 for an unknown approval id', async () => {
+    const token = await devToken(baseUrl, requesterId, { roles: 'user', perms: 'approvals:read' })
+    const response = await fetch(`${baseUrl}/api/approvals/apv_does_not_exist_${suiteSuffix}/remind`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    })
+    expect(response.status).toBe(404)
+    const payload = await response.json() as { error: { code: string } }
+    expect(payload.error.code).toBe('APPROVAL_NOT_FOUND')
+  })
+
+  it('rejects remind on a non-pending instance', async () => {
+    const token = await devToken(baseUrl, requesterId, { roles: 'user', perms: 'approvals:read' })
+    const response = await fetch(`${baseUrl}/api/approvals/${completedInstanceId}/remind`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    })
+    expect(response.status).toBe(400)
+    const payload = await response.json() as { error: { code: string } }
+    expect(payload.error.code).toBe('APPROVAL_REMIND_STATUS_INVALID')
+  })
+})


### PR DESCRIPTION
## Summary
- Add dedicated `POST /api/approvals/:id/remind` rather than extending the shared actions route.
- Add pending-count support and badge wiring for Approval Center.
- Add backend integration tests and frontend specs for requester-visible remind + badge behaviour.
- Record rebase verification on `origin/main@8d2d3e1b0`.

## Verification
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false`
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit`
- `DATABASE_URL=postgresql://chouhua@127.0.0.1:5432/postgres PGHOST=127.0.0.1 PGPORT=5432 PGDATABASE=postgres PGUSER=chouhua pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/approval-wp3-remind.api.test.ts tests/integration/approval-wp3-pending-count.api.test.ts --reporter=dot`
- `DATABASE_URL=postgresql://chouhua@127.0.0.1:5432/postgres PGHOST=127.0.0.1 PGPORT=5432 PGDATABASE=postgres PGUSER=chouhua pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/approval-wp2-source-filter.api.test.ts tests/integration/approval-pack1a-lifecycle.api.test.ts tests/integration/approval-wp1-any-mode.api.test.ts tests/integration/approval-wp1-parallel-gateway.api.test.ts --reporter=dot`
- `pnpm --filter @metasheet/web exec vitest run tests/approvalCenterRemindBadge.spec.ts tests/approvalCenterSourceFilter.spec.ts --reporter=dot`

## Reviewer note
Local integration startup still logs pre-existing degraded-mode warnings for optional workflow/event/automation tables in this DB, but the targeted approval API assertions pass.