### PR TITLE
fix(metrics): add scrape token guard

### DIFF
--- a/docs/development/metrics-prom-scrape-token-guard-development-20260423.md
+++ b/docs/development/metrics-prom-scrape-token-guard-development-20260423.md
@@ -1,0 +1,100 @@
+# `/metrics` / `/metrics/prom` scrape-token guard — development log
+
+Date: 2026-04-23
+Branch: `codex/metrics-prom-guard-20260423`
+Base: `main@6d5f965e4`
+
+## Goal
+
+Reduce the blast radius of the shared metrics endpoints without breaking the
+existing local / CI scrape path by default.
+
+The problem in `main` was:
+
+- `installMetrics()` registered `/metrics` and `/metrics/prom` as naked routes.
+- `jwt-middleware.ts` also listed both paths in `AUTH_WHITELIST`.
+- The global JWT middleware only protects `/api/**`, so the whitelist entry was
+  not the root cause, but it still documented the wrong mental model.
+
+## Scope
+
+This slice intentionally does **not** retroactively require JWT / RBAC for
+Prometheus. That would break existing anonymous scrape configurations and turn
+an observability hardening patch into a deployment cut-over.
+
+Instead it adds an explicit scrape-token seam:
+
+- when `METRICS_SCRAPE_TOKEN` is unset, behavior stays unchanged
+- when `METRICS_SCRAPE_TOKEN` is set, `/metrics` and `/metrics/prom` require
+  either:
+  - `Authorization: Bearer <token>`
+  - or `x-metrics-token: <token>`
+
+## Code changes
+
+### 1. Add reusable metrics auth middleware
+
+File:
+`packages/core-backend/src/metrics/metrics.ts`
+
+Added:
+
+- `resolveMetricsScrapeToken(env?)`
+- `createMetricsAuthMiddleware(getToken?)`
+
+Behavior:
+
+- trims `METRICS_SCRAPE_TOKEN`
+- treats blank values as disabled
+- returns `401 UNAUTHORIZED` + `WWW-Authenticate: Bearer realm="metrics"` when a
+  token is configured but missing / incorrect
+
+`installMetrics(app)` now applies the middleware to both `/metrics` and
+`/metrics/prom`.
+
+### 2. Remove stale metrics whitelist entries
+
+File:
+`packages/core-backend/src/auth/jwt-middleware.ts`
+
+Removed:
+
+- `/metrics`
+- `/metrics/prom`
+
+This does not change runtime auth for those endpoints by itself because the
+global JWT layer only intercepts `/api/**`, but it removes misleading
+whitelist state and locks the intended security ownership to the dedicated
+metrics guard.
+
+### 3. Add focused tests
+
+New file:
+`packages/core-backend/tests/unit/metrics-auth.test.ts`
+
+Coverage:
+
+- blank / unset token disables auth
+- no token configured keeps anonymous access working
+- configured token rejects anonymous access
+- configured token accepts bearer token
+- configured token accepts `x-metrics-token`
+
+Updated:
+
+- `packages/core-backend/tests/unit/jwt-middleware.test.ts`
+
+Added:
+
+- assertion that `/metrics` and `/metrics/prom` are no longer treated as JWT
+  whitelist paths
+
+## Explicit defer
+
+- No production-only fail-closed behavior when token is absent
+- No Prometheus docker compose reconfiguration in this slice
+- No RBAC / admin-user protection for metrics endpoints
+- No `/metrics` route removal
+
+Those are separate operational decisions and should land with coordinated
+scrape config changes.

--- a/docs/development/metrics-prom-scrape-token-guard-verification-20260423.md
+++ b/docs/development/metrics-prom-scrape-token-guard-verification-20260423.md
@@ -1,0 +1,49 @@
+# `/metrics` / `/metrics/prom` scrape-token guard — verification log
+
+Date: 2026-04-23
+Branch: `codex/metrics-prom-guard-20260423`
+Base: `main@6d5f965e4`
+Paired with: `docs/development/metrics-prom-scrape-token-guard-development-20260423.md`
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/metrics-auth.test.ts \
+  tests/unit/jwt-middleware.test.ts \
+  tests/unit/metrics-endpoint.test.ts \
+  --reporter=dot
+
+pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
+```
+
+## Results
+
+### Focused unit tests
+
+- `tests/unit/metrics-auth.test.ts`: `5/5` pass
+- `tests/unit/jwt-middleware.test.ts`: `13/13` pass
+- `tests/unit/metrics-endpoint.test.ts`: `2/2` pass
+- Aggregate: `20/20` pass
+
+### Type-check
+
+- `packages/core-backend`: `tsc --noEmit` passed with exit `0`
+
+## Assertions locked by this slice
+
+- `/metrics` and `/metrics/prom` are no longer JWT-whitelisted paths
+- metrics auth is disabled when `METRICS_SCRAPE_TOKEN` is unset or blank
+- metrics auth returns `401` when a token is configured but not supplied
+- bearer-token access works when the supplied token matches
+- `x-metrics-token` access works when the supplied token matches
+- the legacy metrics endpoint smoke contract remains intact
+
+## Operational note
+
+This patch is intentionally backward-compatible by default:
+
+- if `METRICS_SCRAPE_TOKEN` is **not** configured, current anonymous scrape
+  behavior remains unchanged
+- to actually close public exposure in staging / production, ops must set
+  `METRICS_SCRAPE_TOKEN` and update Prometheus scrape auth accordingly

--- a/packages/core-backend/src/auth/jwt-middleware.ts
+++ b/packages/core-backend/src/auth/jwt-middleware.ts
@@ -6,8 +6,6 @@ import { authService } from './AuthService'
 const AUTH_WHITELIST = [
   '/health',
   '/api/health',
-  '/metrics',
-  '/metrics/prom',
   '/api/auth/login',
   '/api/auth/register',
   '/api/auth/invite/preview',

--- a/packages/core-backend/src/metrics/metrics.ts
+++ b/packages/core-backend/src/metrics/metrics.ts
@@ -520,11 +520,51 @@ registry.registerMetric(apigwCbStoreUsedTotal)
 registry.registerMetric(apigwCbInitTotal)
 registry.registerMetric(automationSchedulerLeaderGauge)
 
+function trimConfiguredMetricsToken(raw: string | undefined): string | null {
+  const token = typeof raw === 'string' ? raw.trim() : ''
+  return token.length > 0 ? token : null
+}
+
+export function resolveMetricsScrapeToken(env: NodeJS.ProcessEnv = process.env): string | null {
+  return trimConfiguredMetricsToken(env.METRICS_SCRAPE_TOKEN)
+}
+
+function resolveProvidedMetricsToken(req: Request): string | null {
+  const bearer = typeof req.headers.authorization === 'string' ? req.headers.authorization.trim() : ''
+  if (bearer.startsWith('Bearer ')) {
+    const token = bearer.slice(7).trim()
+    if (token) return token
+  }
+  const headerToken = typeof req.headers['x-metrics-token'] === 'string' ? req.headers['x-metrics-token'].trim() : ''
+  return headerToken || null
+}
+
+export function createMetricsAuthMiddleware(getToken: () => string | null = () => resolveMetricsScrapeToken()) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const expectedToken = getToken()
+    if (!expectedToken) return next()
+
+    const providedToken = resolveProvidedMetricsToken(req)
+    if (providedToken === expectedToken) return next()
+
+    res.setHeader('WWW-Authenticate', 'Bearer realm="metrics"')
+    return res.status(401).json({
+      ok: false,
+      error: {
+        code: 'UNAUTHORIZED',
+        message: 'Metrics scrape token required',
+      },
+    })
+  }
+}
+
 export function installMetrics(app: Application) {
-  app.get('/metrics', async (_req, res) => {
+  const metricsAuthMiddleware = createMetricsAuthMiddleware()
+
+  app.get('/metrics', metricsAuthMiddleware, async (_req, res) => {
     res.json(await registry.getMetricsAsJSON())
   })
-  app.get('/metrics/prom', async (_req, res) => {
+  app.get('/metrics/prom', metricsAuthMiddleware, async (_req, res) => {
     res.set('Content-Type', registry.contentType)
     res.end(await registry.metrics())
   })

--- a/packages/core-backend/tests/unit/jwt-middleware.test.ts
+++ b/packages/core-backend/tests/unit/jwt-middleware.test.ts
@@ -21,6 +21,11 @@ vi.mock('../../src/metrics/metrics', () => ({
 import { isPublicFormAuthBypass, isWhitelisted, jwtAuthMiddleware, optionalJwtAuthMiddleware } from '../../src/auth/jwt-middleware'
 
 describe('jwt auth whitelist', () => {
+  it('does not whitelist metrics endpoints anymore', () => {
+    expect(isWhitelisted('/metrics')).toBe(false)
+    expect(isWhitelisted('/metrics/prom')).toBe(false)
+  })
+
   it('allows DingTalk launch without a bearer token', () => {
     expect(isWhitelisted('/api/auth/dingtalk/launch')).toBe(true)
     expect(isWhitelisted('/api/auth/dingtalk/launch?redirect=%2Fdashboard')).toBe(true)

--- a/packages/core-backend/tests/unit/metrics-auth.test.ts
+++ b/packages/core-backend/tests/unit/metrics-auth.test.ts
@@ -1,0 +1,76 @@
+import express from 'express'
+import request from 'supertest'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { createMetricsAuthMiddleware, resolveMetricsScrapeToken } from '../../src/metrics/metrics'
+
+describe('metrics auth middleware', () => {
+  afterEach(() => {
+    delete process.env.METRICS_SCRAPE_TOKEN
+  })
+
+  it('returns null when METRICS_SCRAPE_TOKEN is unset or blank', () => {
+    delete process.env.METRICS_SCRAPE_TOKEN
+    expect(resolveMetricsScrapeToken()).toBeNull()
+
+    process.env.METRICS_SCRAPE_TOKEN = '   '
+    expect(resolveMetricsScrapeToken()).toBeNull()
+  })
+
+  it('allows anonymous access when no metrics token is configured', async () => {
+    const app = express()
+    app.get('/metrics/prom', createMetricsAuthMiddleware(() => null), (_req, res) => {
+      res.type('text/plain').send('metric_a 1\n')
+    })
+
+    const res = await request(app).get('/metrics/prom')
+    expect(res.status).toBe(200)
+    expect(res.text).toContain('metric_a 1')
+  })
+
+  it('rejects requests without the configured bearer token', async () => {
+    const app = express()
+    app.get('/metrics/prom', createMetricsAuthMiddleware(() => 'secret-token'), (_req, res) => {
+      res.type('text/plain').send('metric_a 1\n')
+    })
+
+    const res = await request(app).get('/metrics/prom')
+    expect(res.status).toBe(401)
+    expect(res.headers['www-authenticate']).toContain('Bearer')
+    expect(res.body).toEqual({
+      ok: false,
+      error: {
+        code: 'UNAUTHORIZED',
+        message: 'Metrics scrape token required',
+      },
+    })
+  })
+
+  it('accepts a matching bearer token', async () => {
+    const app = express()
+    app.get('/metrics/prom', createMetricsAuthMiddleware(() => 'secret-token'), (_req, res) => {
+      res.type('text/plain').send('metric_a 1\n')
+    })
+
+    const res = await request(app)
+      .get('/metrics/prom')
+      .set('Authorization', 'Bearer secret-token')
+
+    expect(res.status).toBe(200)
+    expect(res.text).toContain('metric_a 1')
+  })
+
+  it('accepts the x-metrics-token header for non-Prometheus callers', async () => {
+    const app = express()
+    app.get('/metrics', createMetricsAuthMiddleware(() => 'secret-token'), (_req, res) => {
+      res.json({ ok: true })
+    })
+
+    const res = await request(app)
+      .get('/metrics')
+      .set('x-metrics-token', 'secret-token')
+
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ ok: true })
+  })
+})


### PR DESCRIPTION
## Summary
- add optional METRICS_SCRAPE_TOKEN protection for /metrics and /metrics/prom
- allow Prometheus-friendly Authorization: Bearer token and x-metrics-token access
- remove stale metrics paths from JWT whitelist while keeping anonymous scrape behavior unchanged when the token is unset

## Testing
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/metrics-auth.test.ts tests/unit/jwt-middleware.test.ts tests/unit/metrics-endpoint.test.ts --reporter=dot
- pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false

## Notes
- Backward-compatible by default. Staging/production must set METRICS_SCRAPE_TOKEN and update Prometheus scrape auth to actually close anonymous access.