### PR TITLE
refactor(multitable): extract record create/delete service

### DIFF
--- a/docs/development/multitable-m2-record-service-development-20260423.md
+++ b/docs/development/multitable-m2-record-service-development-20260423.md
@@ -1,0 +1,91 @@
+# Multitable M2 slice 2 — record-service create/delete extraction
+
+Date: 2026-04-23
+Branch: `codex/multitable-m2-record-service-20260423`
+Initial base: `main@6d5f965e4`
+Rebased base before PR update: `main@78d382aa`
+
+## Goal
+
+Continue the M2 extraction after `attachment-service.ts` by moving direct
+record create/delete semantics out of the 7k+ line `univer-meta.ts` route and
+into a dedicated backend service seam.
+
+This is intentionally narrower than full record write service unification:
+
+- `POST /records` direct create is extracted
+- `DELETE /records/:recordId` direct delete is extracted
+- existing `POST /patch` remains owned by `RecordWriteService`
+- existing `PATCH /records/:recordId` and form submit paths remain unchanged
+
+## Code changes
+
+### 1. New service
+
+File:
+`packages/core-backend/src/multitable/record-service.ts`
+
+Added `RecordService` with:
+
+- `createRecord(input)`
+- `deleteRecord(input)`
+
+The service owns the non-HTTP business logic previously inline in the route:
+
+- create field guard construction
+- select/link/attachment/formula value handling
+- direct field-validation execution
+- transactional `meta_records` insert
+- `meta_links` fanout on create
+- delete preflight / record-level write policy
+- transactional `SELECT ... FOR UPDATE`, `expectedVersion` check, link cleanup,
+  and `meta_records` delete
+- realtime publish and `eventBus.emit`
+
+### 2. Route delegation
+
+File:
+`packages/core-backend/src/routes/univer-meta.ts`
+
+The route keeps:
+
+- zod request parsing
+- `resolveMetaSheetId`
+- request auth/access resolution
+- sheet capability resolution
+- HTTP status/error mapping
+
+The route delegates create/delete to `RecordService` and translates service
+errors back into the existing response shapes.
+
+### 3. Focused unit coverage
+
+File:
+`packages/core-backend/tests/unit/record-service.test.ts`
+
+New tests lock:
+
+- create success emits realtime + `multitable.record.created`
+- missing link target rejects create
+- direct field validation failure rejects create with structured field errors
+- delete success emits realtime + `multitable.record.deleted`
+- delete `expectedVersion` mismatch raises `VersionConflictError`
+- record-level own-write policy blocks delete
+- missing delete target raises `RecordNotFoundError`
+
+## Explicit defer
+
+- Do not move `POST /patch`; it is already on `RecordWriteService`
+- Do not move `PATCH /records/:recordId`; it has Yjs invalidation and hydration
+  semantics that deserve a separate slice
+- Do not move form submit create path
+- Do not refactor attachment delete
+- Do not add new create/delete Yjs bridge semantics
+
+## Risk notes
+
+- This slice is a pure extraction of create/delete semantics; no HTTP contract
+  change is intended.
+- `RecordService.deleteRecord()` still accepts a route-provided
+  `resolveSheetAccess()` callback so Express/user-context capability logic stays
+  in the route layer.

--- a/docs/development/multitable-m2-record-service-verification-20260423.md
+++ b/docs/development/multitable-m2-record-service-verification-20260423.md
@@ -1,0 +1,135 @@
+# Multitable M2 slice 2 — record-service verification log
+
+Date: 2026-04-23
+Branch: `codex/multitable-m2-record-service-20260423`
+Initial base: `main@6d5f965e4`
+Rebased base before PR update: `main@78d382aa`
+Paired with: `docs/development/multitable-m2-record-service-development-20260423.md`
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/record-service.test.ts \
+  --reporter=dot
+
+pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
+
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/record-service.test.ts \
+  tests/unit/record-write-service.test.ts \
+  tests/unit/multitable-attachment-service.test.ts \
+  --reporter=dot
+
+pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
+  tests/integration/multitable-sheet-permissions.api.test.ts \
+  -t "allows create, form submit, patch, and own delete when sheet permission is write-own without global multitable permission"
+
+pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
+  tests/integration/multitable-sheet-realtime.api.test.ts \
+  -t "publishes spreadsheet.cell.updated after creating a record"
+
+pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
+  tests/integration/multitable-sheet-realtime.api.test.ts \
+  --reporter=dot
+
+git diff --check
+```
+
+## Results
+
+### New focused service tests
+
+- `tests/unit/record-service.test.ts`: `7/7` pass
+
+Coverage:
+
+- create success
+- create missing link target
+- create field validation failure
+- delete success
+- delete expected-version conflict
+- delete own-write policy rejection
+- delete missing record
+
+### Type-check
+
+- `packages/core-backend`: `tsc --noEmit` passed with exit `0`
+
+### Adjacent regression
+
+- `tests/unit/record-service.test.ts`: `7/7` pass
+- `tests/unit/record-write-service.test.ts`: `25/25` pass
+- `tests/unit/multitable-attachment-service.test.ts`: `24/24` pass
+- Aggregate: `56/56` pass
+
+Known log during regression:
+
+- `record-write-service.test.ts` intentionally logs one Yjs invalidation failure
+  in the test that verifies invalidator errors are swallowed; this is expected.
+
+### Route-level regression
+
+- `multitable-sheet-permissions.api.test.ts`: write-own create/form/patch/delete
+  focused case passed (`1/1`; 38 skipped by `-t`)
+- `multitable-sheet-realtime.api.test.ts`: direct create realtime publish focused
+  case passed (`1/1`; 2 skipped by `-t`)
+- `multitable-sheet-realtime.api.test.ts`: full file passed (`3/3`) after
+  updating the isolated route mock for `created_by` projections and shared
+  sheet-permission scope queries.
+
+Known log during the write-own route regression:
+
+- The existing integration mock does not cover one formula dependency lookup in
+  the form/patch path, so the route logs a swallowed formula recalculation
+  warning. The focused test still passes and this is unrelated to the extracted
+  direct create/delete service path.
+
+### Whitespace
+
+- `git diff --check`: passed
+
+## Contract checks
+
+- Direct create still returns `{ ok: true, data: { record: { id, version, data } } }`
+- Direct create field-validation still returns HTTP `422` at the route layer
+- Direct delete still returns `{ ok: true, data: { deleted: recordId } }`
+- Direct delete `expectedVersion` mismatch still maps to HTTP `409`
+- Patch write path remains on `RecordWriteService` and was regression-tested
+
+## Rebase verification — 2026-04-23
+
+After `fix(metrics): add scrape token guard` landed on main, the branch was
+rebased from `main@6d5f965e4` to `main@78d382aa`.
+
+Commands rerun after rebase:
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
+
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/record-service.test.ts \
+  tests/unit/record-write-service.test.ts \
+  tests/unit/multitable-attachment-service.test.ts \
+  --reporter=dot
+
+pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
+  tests/integration/multitable-sheet-realtime.api.test.ts \
+  --reporter=dot
+
+git diff --check
+```
+
+Results:
+
+- `packages/core-backend`: `tsc --noEmit` passed with exit `0`
+- Unit regression: `56/56` passed
+- Route-level realtime integration: `3/3` passed
+- `git diff --check`: passed
+
+Known logs remained unchanged:
+
+- `record-write-service.test.ts` logs the intentional swallowed Yjs
+  invalidation error
+- `multitable-sheet-realtime.api.test.ts` logs the pre-existing formula
+  dependency mock warning in the form submit case

--- a/packages/core-backend/src/multitable/record-service.ts
+++ b/packages/core-backend/src/multitable/record-service.ts
@@ -1,0 +1,489 @@
+import { randomUUID } from 'crypto'
+
+import type { EventBus } from '../integration/events/event-bus'
+import type { MultitableCapabilities } from './access'
+import {
+  ensureAttachmentIdsExist as ensureAttachmentIdsExistShared,
+  normalizeAttachmentIds as normalizeAttachmentIdsShared,
+} from './attachment-service'
+import { extractSelectOptions, normalizeJson, normalizeJsonArray } from './field-codecs'
+import { getDefaultValidationRules, validateRecord } from './field-validation-engine'
+import type { FieldValidationConfig } from './field-validation'
+import { publishMultitableSheetRealtime } from './realtime-publish'
+import { ensureRecordWriteAllowed, type AccessInfo, type SheetPermissionScope } from './sheet-capabilities'
+
+export type QueryFn = (
+  sql: string,
+  params?: unknown[],
+) => Promise<{ rows: unknown[]; rowCount?: number | null }>
+
+export type TransactionHandler<T> = (client: { query: QueryFn }) => Promise<T>
+
+export interface ConnectionPool {
+  query: QueryFn
+  transaction: <T>(handler: TransactionHandler<T>) => Promise<T>
+}
+
+export type UniverMetaField = {
+  id: string
+  name: string
+  type: 'string' | 'number' | 'boolean' | 'date' | 'formula' | 'select' | 'link' | 'lookup' | 'rollup' | 'attachment'
+  options?: Array<{ value: string; color?: string }>
+  order?: number
+  property?: Record<string, unknown>
+}
+
+export type LinkFieldConfig = {
+  foreignSheetId: string
+  limitSingleRecord: boolean
+}
+
+type CreateFieldGuard = {
+  type: UniverMetaField['type']
+  options?: string[]
+  link?: LinkFieldConfig | null
+}
+
+export class VersionConflictError extends Error {
+  constructor(
+    public recordId: string,
+    public serverVersion: number,
+  ) {
+    super(`Version conflict for ${recordId}`)
+    this.name = 'VersionConflictError'
+  }
+}
+
+export class RecordNotFoundError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'RecordNotFoundError'
+  }
+}
+
+export class RecordValidationError extends Error {
+  constructor(
+    message: string,
+    public code: string = 'VALIDATION_ERROR',
+  ) {
+    super(message)
+    this.name = 'RecordValidationError'
+  }
+}
+
+export class RecordFieldForbiddenError extends Error {
+  constructor(
+    message: string,
+    public fieldId: string,
+    public code: string = 'FIELD_READONLY',
+  ) {
+    super(message)
+    this.name = 'RecordFieldForbiddenError'
+  }
+}
+
+export class RecordPermissionError extends Error {
+  constructor(message = 'Insufficient permissions') {
+    super(message)
+    this.name = 'RecordPermissionError'
+  }
+}
+
+export class RecordValidationFailedError extends Error {
+  constructor(public fieldErrors: unknown) {
+    super('Record validation failed')
+    this.name = 'RecordValidationFailedError'
+  }
+}
+
+export type RecordCreateInput = {
+  sheetId: string
+  data: Record<string, unknown>
+  actorId: string | null
+  capabilities: MultitableCapabilities
+}
+
+export type RecordCreateResult = {
+  recordId: string
+  version: number
+  data: Record<string, unknown>
+}
+
+export type RecordDeleteInput = {
+  recordId: string
+  expectedVersion?: number
+  actorId: string | null
+  access: AccessInfo
+  resolveSheetAccess: (
+    sheetId: string,
+  ) => Promise<{ capabilities: MultitableCapabilities; sheetScope?: SheetPermissionScope }>
+}
+
+export type RecordDeleteResult = {
+  recordId: string
+  sheetId: string
+}
+
+function isUndefinedTableError(err: unknown, tableName: string): boolean {
+  const code = typeof (err as { code?: unknown })?.code === 'string' ? (err as { code: string }).code : null
+  const message = typeof (err as { message?: unknown })?.message === 'string' ? (err as { message: string }).message : ''
+  if (code === '42P01') return message.includes(tableName)
+  return message.includes(`relation \"${tableName}\" does not exist`)
+}
+
+function mapFieldType(type: string): UniverMetaField['type'] {
+  const normalized = type.trim().toLowerCase()
+  if (normalized === 'number') return 'number'
+  if (normalized === 'boolean' || normalized === 'checkbox') return 'boolean'
+  if (normalized === 'date' || normalized === 'datetime') return 'date'
+  if (normalized === 'formula') return 'formula'
+  if (normalized === 'select' || normalized === 'multiselect') return 'select'
+  if (normalized === 'link') return 'link'
+  if (normalized === 'lookup') return 'lookup'
+  if (normalized === 'rollup') return 'rollup'
+  if (normalized === 'attachment') return 'attachment'
+  return 'string'
+}
+
+function parseLinkFieldConfig(property: unknown): LinkFieldConfig | null {
+  const obj = normalizeJson(property)
+  const foreign = obj.foreignDatasheetId ?? obj.foreignSheetId ?? obj.datasheetId
+  if (typeof foreign !== 'string' || foreign.trim().length === 0) return null
+
+  return {
+    foreignSheetId: foreign.trim(),
+    limitSingleRecord: obj.limitSingleRecord === true,
+  }
+}
+
+function normalizeLinkIds(value: unknown): string[] {
+  if (value === null || value === undefined) return []
+
+  const raw: string[] = []
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      if (typeof entry === 'string') raw.push(entry)
+      else if (typeof entry === 'number' && Number.isFinite(entry)) raw.push(String(entry))
+    }
+  } else if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (trimmed.length === 0) return []
+    const jsonParsed = normalizeJsonArray(trimmed)
+    if (jsonParsed.length > 0) raw.push(...jsonParsed)
+    else if (trimmed.includes(',')) raw.push(...trimmed.split(','))
+    else raw.push(trimmed)
+  } else if (typeof value === 'number' && Number.isFinite(value)) {
+    raw.push(String(value))
+  }
+
+  const seen = new Set<string>()
+  return raw
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0)
+    .filter((entry) => {
+      if (seen.has(entry)) return false
+      seen.add(entry)
+      return true
+    })
+}
+
+function buildCreateFieldGuardMap(rows: unknown[]): Map<string, CreateFieldGuard> {
+  const guards = new Map<string, CreateFieldGuard>()
+
+  for (const row of rows as Array<Record<string, unknown>>) {
+    const fieldId = typeof row.id === 'string' ? row.id : ''
+    if (!fieldId) continue
+
+    const type = mapFieldType(String(row.type ?? 'string'))
+    if (type === 'select') {
+      guards.set(fieldId, {
+        type,
+        options: extractSelectOptions(row.property)?.map((option) => option.value) ?? [],
+      })
+      continue
+    }
+
+    if (type === 'link') {
+      guards.set(fieldId, {
+        type,
+        link: parseLinkFieldConfig(row.property),
+      })
+      continue
+    }
+
+    guards.set(fieldId, { type })
+  }
+
+  return guards
+}
+
+function buildDirectValidationFields(rows: unknown[]) {
+  return (rows as Array<Record<string, unknown>>).map((row) => {
+    const property = normalizeJson(row.property)
+    const fieldType = mapFieldType(String(row.type ?? 'string'))
+    const explicitRules = Array.isArray(property.validation) ? property.validation as FieldValidationConfig : undefined
+    const defaultRules = getDefaultValidationRules(fieldType, property)
+    const mergedRules = explicitRules ?? defaultRules
+
+    return {
+      id: String(row.id),
+      name: typeof row.name === 'string' && row.name.length > 0 ? row.name : String(row.id),
+      type: fieldType,
+      config: mergedRules.length > 0 ? { validation: mergedRules } : undefined,
+    }
+  })
+}
+
+export class RecordService {
+  constructor(
+    private pool: ConnectionPool,
+    private eventBus: EventBus,
+  ) {}
+
+  async createRecord(input: RecordCreateInput): Promise<RecordCreateResult> {
+    const { sheetId, data, actorId, capabilities } = input
+
+    const sheetRes = await this.pool.query(
+      'SELECT id FROM meta_sheets WHERE id = $1 AND deleted_at IS NULL',
+      [sheetId],
+    )
+    if (sheetRes.rows.length === 0) {
+      throw new RecordNotFoundError(`Sheet not found: ${sheetId}`)
+    }
+
+    if (!capabilities.canCreateRecord) {
+      throw new RecordPermissionError('Insufficient permissions')
+    }
+
+    const fieldRes = await this.pool.query(
+      'SELECT id, name, type, property FROM meta_fields WHERE sheet_id = $1',
+      [sheetId],
+    )
+    if (fieldRes.rows.length === 0) {
+      throw new RecordNotFoundError(`Sheet not found: ${sheetId}`)
+    }
+
+    const fieldById = buildCreateFieldGuardMap(fieldRes.rows)
+    const patch: Record<string, unknown> = {}
+    const linkUpdates = new Map<string, { ids: string[]; cfg: LinkFieldConfig }>()
+
+    for (const [fieldId, value] of Object.entries(data)) {
+      const field = fieldById.get(fieldId)
+      if (!field) {
+        throw new RecordValidationError(`Unknown fieldId: ${fieldId}`)
+      }
+
+      if (field.type === 'lookup' || field.type === 'rollup') {
+        throw new RecordFieldForbiddenError(`Field is readonly: ${fieldId}`, fieldId)
+      }
+
+      if (field.type === 'select') {
+        if (typeof value !== 'string') {
+          throw new RecordValidationError(`Select value must be string: ${fieldId}`)
+        }
+        const allowed = new Set(field.options ?? [])
+        if (value !== '' && !allowed.has(value)) {
+          throw new RecordValidationError(`Invalid select option for ${fieldId}: ${value}`)
+        }
+      }
+
+      if (field.type === 'link') {
+        if (field.link) {
+          const ids = normalizeLinkIds(value)
+          if (field.link.limitSingleRecord && ids.length > 1) {
+            throw new RecordValidationError(`Link field only allows a single record: ${fieldId}`)
+          }
+          const tooLong = ids.find((id) => id.length > 50)
+          if (tooLong) {
+            throw new RecordValidationError(`Link id too long (>50): ${tooLong}`)
+          }
+
+          if (ids.length > 0) {
+            const exists = await this.pool.query(
+              'SELECT id FROM meta_records WHERE sheet_id = $1 AND id = ANY($2::text[])',
+              [field.link.foreignSheetId, ids],
+            )
+            const found = new Set(
+              (exists.rows as Array<Record<string, unknown>>)
+                .map((row) => (typeof row.id === 'string' ? row.id : ''))
+                .filter((id) => id.length > 0),
+            )
+            const missing = ids.filter((id) => !found.has(id))
+            if (missing.length > 0) {
+              throw new RecordValidationError(
+                `Linked record(s) not found in sheet ${field.link.foreignSheetId}: ${missing.join(', ')}`,
+              )
+            }
+          }
+
+          patch[fieldId] = ids
+          linkUpdates.set(fieldId, { ids, cfg: field.link })
+          continue
+        }
+
+        if (typeof value !== 'string') {
+          throw new RecordValidationError(`Link value must be string: ${fieldId}`)
+        }
+      }
+
+      if (field.type === 'attachment') {
+        const ids = normalizeAttachmentIdsShared(value)
+        const tooLong = ids.find((id) => id.length > 100)
+        if (tooLong) {
+          throw new RecordValidationError(`Attachment id too long: ${tooLong}`)
+        }
+        const attachmentError = await ensureAttachmentIdsExistShared({
+          query: this.pool.query.bind(this.pool),
+          sheetId,
+          fieldId,
+          attachmentIds: ids,
+        })
+        if (attachmentError) {
+          throw new RecordValidationError(attachmentError)
+        }
+        patch[fieldId] = ids
+        continue
+      }
+
+      if (field.type === 'formula') {
+        if (typeof value !== 'string') continue
+        if (value !== '' && !value.startsWith('=')) continue
+      }
+
+      patch[fieldId] = value
+    }
+
+    const directValidationResult = validateRecord(
+      buildDirectValidationFields(fieldRes.rows),
+      patch,
+    )
+    if (!directValidationResult.valid) {
+      throw new RecordValidationFailedError(directValidationResult.errors)
+    }
+
+    const recordId = `rec_${randomUUID()}`
+    const recordRes = await this.pool.transaction(async ({ query }) => {
+      const inserted = await query(
+        `INSERT INTO meta_records (id, sheet_id, data, version, created_by)
+         VALUES ($1, $2, $3::jsonb, 1, $4)
+         RETURNING version`,
+        [recordId, sheetId, JSON.stringify(patch), actorId],
+      )
+
+      if (linkUpdates.size > 0) {
+        for (const [fieldId, { ids }] of linkUpdates.entries()) {
+          for (const foreignId of ids) {
+            await query(
+              `INSERT INTO meta_links (id, field_id, record_id, foreign_record_id)
+               VALUES ($1, $2, $3, $4)
+               ON CONFLICT DO NOTHING`,
+              [`lnk_${randomUUID()}`.slice(0, 50), fieldId, recordId, foreignId],
+            )
+          }
+        }
+      }
+
+      return inserted
+    })
+
+    const version = Number((recordRes.rows[0] as { version?: unknown } | undefined)?.version ?? 1)
+
+    publishMultitableSheetRealtime({
+      spreadsheetId: sheetId,
+      actorId,
+      source: 'multitable',
+      kind: 'record-created',
+      recordId,
+      recordIds: [recordId],
+      fieldIds: Object.keys(patch),
+      recordPatches: [{
+        recordId,
+        version,
+        patch,
+      }],
+    })
+    this.eventBus.emit('multitable.record.created', {
+      sheetId,
+      recordId,
+      data: patch,
+      actorId,
+    })
+
+    return {
+      recordId,
+      version,
+      data: patch,
+    }
+  }
+
+  async deleteRecord(input: RecordDeleteInput): Promise<RecordDeleteResult> {
+    const { recordId, expectedVersion, actorId, access, resolveSheetAccess } = input
+
+    const recordRes = await this.pool.query(
+      'SELECT id, sheet_id, created_by FROM meta_records WHERE id = $1',
+      [recordId],
+    )
+    if (recordRes.rows.length === 0) {
+      throw new RecordNotFoundError(`Record not found: ${recordId}`)
+    }
+
+    const recordRow = recordRes.rows[0] as Record<string, unknown>
+    const sheetId = typeof recordRow.sheet_id === 'string' ? recordRow.sheet_id : ''
+    const createdBy = typeof recordRow.created_by === 'string' ? recordRow.created_by : null
+    const { capabilities, sheetScope } = await resolveSheetAccess(sheetId)
+
+    if (!capabilities.canDeleteRecord) {
+      throw new RecordPermissionError('Insufficient permissions')
+    }
+
+    if (!ensureRecordWriteAllowed(capabilities, sheetScope, access, createdBy, 'delete')) {
+      throw new RecordPermissionError('Record deletion is not allowed for this row')
+    }
+
+    await this.pool.transaction(async ({ query }) => {
+      const lockedRecordRes = await query(
+        'SELECT id, sheet_id, version FROM meta_records WHERE id = $1 FOR UPDATE',
+        [recordId],
+      )
+      if (lockedRecordRes.rows.length === 0) {
+        throw new RecordNotFoundError(`Record not found: ${recordId}`)
+      }
+
+      const currentRow = lockedRecordRes.rows[0] as Record<string, unknown>
+      const serverVersion = Number(currentRow.version ?? 1)
+      if (typeof expectedVersion === 'number' && expectedVersion !== serverVersion) {
+        throw new VersionConflictError(recordId, serverVersion)
+      }
+
+      try {
+        await query(
+          'DELETE FROM meta_links WHERE record_id = $1 OR foreign_record_id = $1',
+          [recordId],
+        )
+      } catch (err) {
+        if (!isUndefinedTableError(err, 'meta_links')) throw err
+      }
+
+      await query('DELETE FROM meta_records WHERE id = $1', [recordId])
+    })
+
+    publishMultitableSheetRealtime({
+      spreadsheetId: sheetId,
+      actorId,
+      source: 'multitable',
+      kind: 'record-deleted',
+      recordId,
+      recordIds: [recordId],
+    })
+    this.eventBus.emit('multitable.record.deleted', {
+      sheetId,
+      recordId,
+      actorId,
+    })
+
+    return {
+      recordId,
+      sheetId,
+    }
+  }
+}

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -86,6 +86,15 @@ import {
   type RecordWriteHelpers,
   type YjsInvalidator,
 } from '../multitable/record-write-service'
+import {
+  RecordService,
+  VersionConflictError as RecordServiceVersionConflictError,
+  RecordNotFoundError as RecordServiceNotFoundError,
+  RecordValidationError as RecordServiceValidationError,
+  RecordFieldForbiddenError as RecordServiceFieldForbiddenError,
+  RecordPermissionError as RecordServicePermissionError,
+  RecordValidationFailedError as RecordCreateValidationFailedError,
+} from '../multitable/record-service'
 
 const multitableFormulaEngine = new MultitableFormulaEngine()
 
@@ -7734,228 +7743,47 @@ export function univerMetaRouter(): Router {
       })
       const sheetId = resolved.sheetId
 
-      const sheetRes = await pool.query(
-        'SELECT id FROM meta_sheets WHERE id = $1 AND deleted_at IS NULL',
-        [sheetId],
-      )
-      if (sheetRes.rows.length === 0) {
-        return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Sheet not found: ${sheetId}` } })
-      }
       const { access, capabilities } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
       if (!access.userId) {
         return res.status(401).json({ error: 'Authentication required' })
       }
-      if (!capabilities.canCreateRecord) return sendForbidden(res)
-
-      const fieldRes = await pool.query(
-        'SELECT id, name, type, property FROM meta_fields WHERE sheet_id = $1',
-        [sheetId],
-      )
-      if (fieldRes.rows.length === 0) {
-        return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Sheet not found: ${sheetId}` } })
-      }
-
-      const fieldById = new Map<string, { type: UniverMetaField['type']; options?: string[]; link?: LinkFieldConfig | null }>()
-      for (const f of fieldRes.rows as any[]) {
-        const type = mapFieldType(String(f.type ?? 'string'))
-        if (type === 'select') {
-          const options = extractSelectOptions(f.property)?.map(o => o.value) ?? []
-          fieldById.set(String(f.id), { type, options })
-          continue
-        }
-        if (type === 'link') {
-          fieldById.set(String(f.id), { type, link: parseLinkFieldConfig(f.property) })
-          continue
-        }
-        fieldById.set(String(f.id), { type })
-      }
-
-      const patch: Record<string, unknown> = {}
-      const linkUpdates = new Map<string, { ids: string[]; cfg: LinkFieldConfig }>()
-      for (const [fieldId, value] of Object.entries(data)) {
-        const field = fieldById.get(fieldId)
-        if (!field) {
-          return res.status(400).json({
-            ok: false,
-            error: { code: 'VALIDATION_ERROR', message: `Unknown fieldId: ${fieldId}` },
-          })
-        }
-
-        if (field.type === 'lookup' || field.type === 'rollup') {
-          return res.status(403).json({
-            ok: false,
-            error: { code: 'FIELD_READONLY', message: `Field is readonly: ${fieldId}` },
-          })
-        }
-
-        if (field.type === 'select') {
-          if (typeof value !== 'string') {
-            return res.status(400).json({
-              ok: false,
-              error: { code: 'VALIDATION_ERROR', message: `Select value must be string: ${fieldId}` },
-            })
-          }
-          const allowed = new Set(field.options ?? [])
-          if (value !== '' && !allowed.has(value)) {
-            return res.status(400).json({
-              ok: false,
-              error: { code: 'VALIDATION_ERROR', message: `Invalid select option for ${fieldId}: ${value}` },
-            })
-          }
-        }
-
-        if (field.type === 'link') {
-          if (field.link) {
-            const ids = normalizeLinkIds(value)
-            if (field.link.limitSingleRecord && ids.length > 1) {
-              return res.status(400).json({
-                ok: false,
-                error: { code: 'VALIDATION_ERROR', message: `Link field only allows a single record: ${fieldId}` },
-              })
-            }
-            const tooLong = ids.find((id) => id.length > 50)
-            if (tooLong) {
-              return res.status(400).json({
-                ok: false,
-                error: { code: 'VALIDATION_ERROR', message: `Link id too long (>50): ${tooLong}` },
-              })
-            }
-
-            if (ids.length > 0) {
-              const exists = await pool.query(
-                'SELECT id FROM meta_records WHERE sheet_id = $1 AND id = ANY($2::text[])',
-                [field.link.foreignSheetId, ids],
-              )
-              const found = new Set((exists as any).rows.map((r: any) => String(r.id)))
-              const missing = ids.filter((id) => !found.has(id))
-              if (missing.length > 0) {
-                return res.status(400).json({
-                  ok: false,
-                  error: {
-                    code: 'VALIDATION_ERROR',
-                    message: `Linked record(s) not found in sheet ${field.link.foreignSheetId}: ${missing.join(', ')}`,
-                  },
-                })
-              }
-            }
-
-            patch[fieldId] = ids
-            linkUpdates.set(fieldId, { ids, cfg: field.link })
-            continue
-          }
-
-          if (typeof value !== 'string') {
-            return res.status(400).json({
-              ok: false,
-              error: { code: 'VALIDATION_ERROR', message: `Link value must be string: ${fieldId}` },
-            })
-          }
-        }
-
-        if (field.type === 'attachment') {
-          const ids = normalizeAttachmentIds(value)
-          const tooLong = ids.find((id) => id.length > 100)
-          if (tooLong) {
-            return res.status(400).json({
-              ok: false,
-              error: { code: 'VALIDATION_ERROR', message: `Attachment id too long: ${tooLong}` },
-            })
-          }
-          const attachmentError = await ensureAttachmentIdsExist(pool.query.bind(pool), sheetId, fieldId, ids)
-          if (attachmentError) {
-            return res.status(400).json({
-              ok: false,
-              error: { code: 'VALIDATION_ERROR', message: attachmentError },
-            })
-          }
-          patch[fieldId] = ids
-          continue
-        }
-
-        if (field.type === 'formula') {
-          if (typeof value !== 'string') continue
-          if (value !== '' && !value.startsWith('=')) continue
-        }
-
-        patch[fieldId] = value
-      }
-
-      // --- Field validation rules (direct record create) ---
-      const directValidationFields = (fieldRes.rows as any[]).map((f: any) => {
-        const prop = normalizeJson(f.property) as Record<string, unknown> | undefined
-        const fType = mapFieldType(String(f.type ?? 'string'))
-        const explicitRules = Array.isArray(prop?.validation) ? prop!.validation as FieldValidationConfig : undefined
-        const defaultRules = getDefaultValidationRules(fType, prop ?? undefined)
-        const mergedRules = explicitRules ?? defaultRules
-        return {
-          id: String(f.id),
-          name: String(f.name ?? f.id),
-          type: fType,
-          config: mergedRules.length > 0 ? { validation: mergedRules } : undefined,
-        }
+      const recordService = new RecordService(pool, eventBus)
+      const result = await recordService.createRecord({
+        sheetId,
+        capabilities,
+        actorId: getRequestActorId(req),
+        data,
       })
-      const directValidationResult = validateRecord(directValidationFields, patch)
-      if (!directValidationResult.valid) {
+
+      return res.json({
+        ok: true,
+        data: {
+          record: {
+            id: result.recordId,
+            version: result.version,
+            data: result.data,
+          },
+        },
+      })
+    } catch (err) {
+      if (err instanceof RecordCreateValidationFailedError) {
         return res.status(422).json({
           error: 'VALIDATION_FAILED',
           message: 'Record validation failed',
-          fieldErrors: directValidationResult.errors,
+          fieldErrors: err.fieldErrors,
         })
       }
-
-      const recordId = `rec_${randomUUID()}`
-      const recordRes = await pool.transaction(async ({ query }) => {
-        const inserted = await query(
-          `INSERT INTO meta_records (id, sheet_id, data, version, created_by)
-           VALUES ($1, $2, $3::jsonb, 1, $4)
-           RETURNING version`,
-          [recordId, sheetId, JSON.stringify(patch), getRequestActorId(req)],
-        )
-
-        if (linkUpdates.size > 0) {
-          for (const [fieldId, { ids }] of linkUpdates.entries()) {
-            for (const foreignId of ids) {
-              await query(
-                `INSERT INTO meta_links (id, field_id, record_id, foreign_record_id)
-                 VALUES ($1, $2, $3, $4)
-                 ON CONFLICT DO NOTHING`,
-                [buildId('lnk').slice(0, 50), fieldId, recordId, foreignId],
-              )
-            }
-          }
-        }
-
-        return inserted
-      })
-
-      const version = Number((recordRes.rows[0] as any)?.version ?? 1)
-      publishMultitableSheetRealtime({
-        spreadsheetId: sheetId,
-        actorId: getRequestActorId(req),
-        source: 'multitable',
-        kind: 'record-created',
-        recordId,
-        recordIds: [recordId],
-        fieldIds: Object.keys(patch),
-        recordPatches: [{
-          recordId,
-          version,
-          patch,
-        }],
-      })
-      eventBus.emit('multitable.record.created', {
-        sheetId,
-        recordId,
-        data: patch,
-        actorId: getRequestActorId(req),
-      })
-      return res.json({ ok: true, data: { record: { id: recordId, version, data: patch } } })
-    } catch (err) {
-      if (err instanceof ValidationError) {
-        return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: err.message } })
+      if (err instanceof RecordServiceFieldForbiddenError) {
+        return res.status(403).json({ ok: false, error: { code: err.code, message: err.message } })
       }
-      if (err instanceof NotFoundError) {
+      if (err instanceof RecordServiceValidationError || err instanceof ServiceValidationError) {
+        return res.status(400).json({ ok: false, error: { code: err.code || 'VALIDATION_ERROR', message: err.message } })
+      }
+      if (err instanceof RecordServiceNotFoundError || err instanceof ServiceNotFoundError) {
         return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: err.message } })
+      }
+      if (err instanceof RecordServicePermissionError) {
+        return sendForbidden(res, err.message)
       }
       const hint = getDbNotReadyMessage(err)
       if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
@@ -7979,67 +7807,27 @@ export function univerMetaRouter(): Router {
       if (!access.userId) {
         return res.status(401).json({ error: 'Authentication required' })
       }
-      let deletedSheetId: string | null = null
-      const recordRes = await pool.query('SELECT id, sheet_id, created_by FROM meta_records WHERE id = $1', [recordId])
-      if (recordRes.rows.length === 0) {
-        throw new NotFoundError(`Record not found: ${recordId}`)
-      }
-      deletedSheetId = typeof (recordRes.rows[0] as any)?.sheet_id === 'string' ? String((recordRes.rows[0] as any).sheet_id) : null
-      if (deletedSheetId) {
-        const { capabilities, sheetScope } = await resolveSheetCapabilities(req, pool.query.bind(pool), deletedSheetId)
-        if (!capabilities.canDeleteRecord) return sendForbidden(res)
-        if (!ensureRecordWriteAllowed(
-          capabilities,
-          sheetScope,
-          access,
-          typeof (recordRes.rows[0] as any)?.created_by === 'string' ? String((recordRes.rows[0] as any).created_by) : null,
-          'delete',
-        )) return sendForbidden(res, 'Record deletion is not allowed for this row')
-      }
-      await pool.transaction(async ({ query }) => {
-        const recordRes = await query('SELECT id, sheet_id, version FROM meta_records WHERE id = $1 FOR UPDATE', [recordId])
-        if ((recordRes as any).rows.length === 0) {
-          throw new NotFoundError(`Record not found: ${recordId}`)
-        }
-
-        const currentRow: any = (recordRes as any).rows[0]
-        deletedSheetId = typeof currentRow?.sheet_id === 'string' ? currentRow.sheet_id : null
-        const serverVersion = Number(currentRow?.version ?? 1)
-        if (typeof expectedVersion === 'number' && expectedVersion !== serverVersion) {
-          throw new VersionConflictError(recordId, serverVersion)
-        }
-
-        try {
-          await query('DELETE FROM meta_links WHERE record_id = $1 OR foreign_record_id = $1', [recordId])
-        } catch (err) {
-          if (!isUndefinedTableError(err, 'meta_links')) throw err
-        }
-
-        await query('DELETE FROM meta_records WHERE id = $1', [recordId])
+      const recordService = new RecordService(pool, eventBus)
+      await recordService.deleteRecord({
+        recordId,
+        actorId: getRequestActorId(req),
+        expectedVersion,
+        access,
+        resolveSheetAccess: async (sheetId) => {
+          const { capabilities, sheetScope } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
+          return { capabilities, ...(sheetScope ? { sheetScope } : {}) }
+        },
       })
-
-      if (deletedSheetId) {
-        publishMultitableSheetRealtime({
-          spreadsheetId: deletedSheetId,
-          actorId: getRequestActorId(req),
-          source: 'multitable',
-          kind: 'record-deleted',
-          recordId,
-          recordIds: [recordId],
-        })
-        eventBus.emit('multitable.record.deleted', {
-          sheetId: deletedSheetId,
-          recordId,
-          actorId: getRequestActorId(req),
-        })
-      }
 
       return res.json({ ok: true, data: { deleted: recordId } })
     } catch (err) {
-      if (err instanceof NotFoundError) {
+      if (err instanceof RecordServicePermissionError) {
+        return sendForbidden(res, err.message)
+      }
+      if (err instanceof RecordServiceNotFoundError || err instanceof ServiceNotFoundError) {
         return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: err.message } })
       }
-      if (err instanceof VersionConflictError) {
+      if (err instanceof RecordServiceVersionConflictError || err instanceof ServiceVersionConflictError) {
         return res.status(409).json({
           ok: false,
           error: {

--- a/packages/core-backend/tests/integration/multitable-sheet-realtime.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-sheet-realtime.api.test.ts
@@ -31,7 +31,7 @@ async function createApp(args: {
     getPermCacheStatus: vi.fn(),
   }))
   vi.doMock('../../src/integration/events/event-bus', () => ({
-    eventBus: { publish: publishSpy },
+    eventBus: { publish: publishSpy, emit: vi.fn() },
   }))
 
   const { poolManager } = await import('../../src/integration/db/connection-pool')
@@ -64,16 +64,25 @@ describe('Multitable sheet realtime events', () => {
     const { app, publishSpy } = await createApp({
       tokenPerms: ['multitable:write'],
       queryHandler: async (sql, params) => {
+        if (sql.includes('FROM spreadsheet_permissions')) {
+          expect(params).toEqual(['user_realtime_1', ['sheet_ops']])
+          return { rows: [] }
+        }
         if (sql.includes('SELECT id FROM meta_sheets WHERE id = $1 AND deleted_at IS NULL')) {
           expect(params).toEqual(['sheet_ops'])
           return { rows: [{ id: 'sheet_ops' }] }
         }
-        if (sql.includes('SELECT id, type, property FROM meta_fields WHERE sheet_id = $1')) {
+        if (sql.includes('SELECT id, name, type, property FROM meta_fields WHERE sheet_id = $1')) {
           expect(params).toEqual(['sheet_ops'])
-          return { rows: [{ id: 'fld_title', type: 'string', property: {} }] }
+          return { rows: [{ id: 'fld_title', name: 'Title', type: 'string', property: {} }] }
         }
         if (sql.includes('INSERT INTO meta_records') && sql.includes('RETURNING version')) {
-          expect(params).toEqual([expect.stringMatching(/^rec_/), 'sheet_ops', JSON.stringify({ fld_title: 'Alpha' })])
+          expect(params).toEqual([
+            expect.stringMatching(/^rec_/),
+            'sheet_ops',
+            JSON.stringify({ fld_title: 'Alpha' }),
+            'user_realtime_1',
+          ])
           return { rows: [{ version: 1 }] }
         }
         throw new Error(`Unhandled SQL in test: ${sql}`)
@@ -112,6 +121,10 @@ describe('Multitable sheet realtime events', () => {
     const { app, publishSpy } = await createApp({
       tokenPerms: ['multitable:write'],
       queryHandler: async (sql, params) => {
+        if (sql.includes('FROM spreadsheet_permissions')) {
+          expect(params).toEqual(['user_realtime_1', ['sheet_ops']])
+          return { rows: [] }
+        }
         if (sql.includes('SELECT id, sheet_id, name, type, filter_info, sort_info, group_info, hidden_field_ids, config FROM meta_views WHERE id = $1')) {
           expect(params).toEqual(['view_form_ops'])
           return {
@@ -136,9 +149,9 @@ describe('Multitable sheet realtime events', () => {
           expect(params).toEqual(['sheet_ops'])
           return { rows: [{ id: 'fld_title', name: 'Title', type: 'string', property: {}, order: 1 }] }
         }
-        if (sql.includes('SELECT id, version FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE')) {
+        if (sql.includes('SELECT id, version, created_by FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE')) {
           expect(params).toEqual(['rec_1', 'sheet_ops'])
-          return { rows: [{ id: 'rec_1', version: 4 }] }
+          return { rows: [{ id: 'rec_1', version: 4, created_by: 'user_realtime_1' }] }
         }
         if (sql.includes('UPDATE meta_records') && sql.includes('RETURNING version')) {
           expect(params).toEqual([JSON.stringify({ fld_title: 'Updated title' }), 'rec_1', 'sheet_ops'])
@@ -182,6 +195,10 @@ describe('Multitable sheet realtime events', () => {
     const { app, publishSpy } = await createApp({
       tokenPerms: ['multitable:write'],
       queryHandler: async (sql, params) => {
+        if (sql.includes('FROM spreadsheet_permissions')) {
+          expect(params).toEqual(['user_realtime_1', ['sheet_ops']])
+          return { rows: [] }
+        }
         if (sql.includes('SELECT id FROM meta_sheets WHERE id = $1 AND deleted_at IS NULL')) {
           expect(params).toEqual(['sheet_ops'])
           return { rows: [{ id: 'sheet_ops' }] }
@@ -190,9 +207,9 @@ describe('Multitable sheet realtime events', () => {
           expect(params).toEqual(['sheet_ops'])
           return { rows: [{ id: 'fld_title', name: 'Title', type: 'string', property: {} }] }
         }
-        if (sql.includes('SELECT id, version FROM meta_records WHERE sheet_id = $1 AND id = $2 FOR UPDATE')) {
+        if (sql.includes('SELECT id, version, created_by FROM meta_records WHERE sheet_id = $1 AND id = $2 FOR UPDATE')) {
           expect(params).toEqual(['sheet_ops', 'rec_1'])
-          return { rows: [{ id: 'rec_1', version: 2 }] }
+          return { rows: [{ id: 'rec_1', version: 2, created_by: 'user_realtime_1' }] }
         }
         if (sql.includes('UPDATE meta_records') && sql.includes('WHERE sheet_id = $2 AND id = $3')) {
           expect(params).toEqual([JSON.stringify({ fld_title: 'Bulk patched' }), 'sheet_ops', 'rec_1'])

--- a/packages/core-backend/tests/unit/record-service.test.ts
+++ b/packages/core-backend/tests/unit/record-service.test.ts
@@ -1,0 +1,314 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  RecordNotFoundError,
+  RecordPermissionError,
+  RecordService,
+  RecordValidationFailedError,
+  RecordValidationError,
+  VersionConflictError,
+  type ConnectionPool,
+  type QueryFn,
+} from '../../src/multitable/record-service'
+
+const mockPublish = vi.fn()
+vi.mock('../../src/multitable/realtime-publish', () => ({
+  publishMultitableSheetRealtime: (...args: unknown[]) => mockPublish(...args),
+}))
+
+type QueryResponse = { rows: unknown[]; rowCount?: number | null }
+
+function createMockEventBus() {
+  return {
+    emit: vi.fn(),
+    publish: vi.fn(),
+    subscribe: vi.fn().mockReturnValue('sub_1'),
+    unsubscribe: vi.fn(),
+  }
+}
+
+function createMockPool(
+  responses: Partial<Record<string, QueryResponse>> = {},
+): ConnectionPool & { queryMock: ReturnType<typeof vi.fn> } {
+  const queryMock = vi.fn(async (sql: string, _params?: unknown[]) => {
+    if (sql.includes('SELECT id FROM meta_sheets WHERE id = $1 AND deleted_at IS NULL')) {
+      return responses.SELECT_SHEET ?? { rows: [{ id: 'sheet_ops' }] }
+    }
+    if (sql.includes('SELECT id, name, type, property FROM meta_fields WHERE sheet_id = $1')) {
+      return responses.SELECT_FIELDS ?? {
+        rows: [{ id: 'fld_title', name: 'Title', type: 'string', property: {} }],
+      }
+    }
+    if (sql.includes('SELECT id FROM meta_records WHERE sheet_id = $1 AND id = ANY($2::text[])')) {
+      return responses.SELECT_LINK_TARGETS ?? { rows: [] }
+    }
+    if (sql.includes('INSERT INTO meta_records') && sql.includes('RETURNING version')) {
+      return responses.INSERT_RECORD ?? { rows: [{ version: 1 }] }
+    }
+    if (sql.includes('INSERT INTO meta_links')) {
+      return responses.INSERT_LINK ?? { rows: [], rowCount: 1 }
+    }
+    if (sql.includes('SELECT id, sheet_id, created_by FROM meta_records WHERE id = $1')) {
+      return responses.SELECT_DELETE_RECORD ?? {
+        rows: [{ id: 'rec_existing', sheet_id: 'sheet_ops', created_by: 'user_1' }],
+      }
+    }
+    if (sql.includes('SELECT id, sheet_id, version FROM meta_records WHERE id = $1 FOR UPDATE')) {
+      return responses.SELECT_DELETE_FOR_UPDATE ?? {
+        rows: [{ id: 'rec_existing', sheet_id: 'sheet_ops', version: 4 }],
+      }
+    }
+    if (sql.includes('DELETE FROM meta_links WHERE record_id = $1 OR foreign_record_id = $1')) {
+      return responses.DELETE_LINKS ?? { rows: [], rowCount: 1 }
+    }
+    if (sql.includes('DELETE FROM meta_records WHERE id = $1')) {
+      return responses.DELETE_RECORD ?? { rows: [], rowCount: 1 }
+    }
+    throw new Error(`Unhandled SQL in test: ${sql}`)
+  })
+
+  return {
+    query: queryMock as QueryFn,
+    queryMock,
+    transaction: vi.fn(async <T>(handler: (client: { query: QueryFn }) => Promise<T>) =>
+      handler({ query: queryMock as QueryFn })),
+  }
+}
+
+describe('RecordService', () => {
+  let pool: ReturnType<typeof createMockPool>
+  let eventBus: ReturnType<typeof createMockEventBus>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    pool = createMockPool()
+    eventBus = createMockEventBus()
+  })
+
+  it('creates a record and emits realtime + eventBus notifications', async () => {
+    const service = new RecordService(pool, eventBus as any)
+
+    const result = await service.createRecord({
+      sheetId: 'sheet_ops',
+      data: { fld_title: 'Alpha' },
+      actorId: 'user_1',
+      capabilities: {
+        canRead: true,
+        canCreateRecord: true,
+        canEditRecord: true,
+        canDeleteRecord: true,
+        canManageFields: true,
+        canManageSheetAccess: true,
+        canManageViews: true,
+        canComment: true,
+        canManageAutomation: true,
+        canExport: true,
+      },
+    })
+
+    expect(result.recordId).toMatch(/^rec_/)
+    expect(result.version).toBe(1)
+    expect(result.data).toEqual({ fld_title: 'Alpha' })
+    expect(eventBus.emit).toHaveBeenCalledWith('multitable.record.created', {
+      sheetId: 'sheet_ops',
+      recordId: result.recordId,
+      data: { fld_title: 'Alpha' },
+      actorId: 'user_1',
+    })
+    expect(mockPublish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        spreadsheetId: 'sheet_ops',
+        kind: 'record-created',
+        recordId: result.recordId,
+        recordIds: [result.recordId],
+        fieldIds: ['fld_title'],
+      }),
+    )
+  })
+
+  it('rejects create when a linked target record is missing', async () => {
+    pool = createMockPool({
+      SELECT_FIELDS: {
+        rows: [{
+          id: 'fld_customer',
+          name: 'Customer',
+          type: 'link',
+          property: { foreignSheetId: 'sheet_customer', limitSingleRecord: true },
+        }],
+      },
+      SELECT_LINK_TARGETS: { rows: [] },
+    })
+    const service = new RecordService(pool, eventBus as any)
+
+    await expect(service.createRecord({
+      sheetId: 'sheet_ops',
+      data: { fld_customer: 'rec_missing' },
+      actorId: 'user_1',
+      capabilities: {
+        canRead: true,
+        canCreateRecord: true,
+        canEditRecord: true,
+        canDeleteRecord: true,
+        canManageFields: true,
+        canManageSheetAccess: true,
+        canManageViews: true,
+        canComment: true,
+        canManageAutomation: true,
+        canExport: true,
+      },
+    })).rejects.toThrow(RecordValidationError)
+  })
+
+  it('surfaces direct field validation failures during create', async () => {
+    pool = createMockPool({
+      SELECT_FIELDS: {
+        rows: [{
+          id: 'fld_title',
+          name: 'Title',
+          type: 'string',
+          property: {
+            validation: [{ type: 'required', message: 'Title is required' }],
+          },
+        }],
+      },
+    })
+    const service = new RecordService(pool, eventBus as any)
+
+    await expect(service.createRecord({
+      sheetId: 'sheet_ops',
+      data: {},
+      actorId: 'user_1',
+      capabilities: {
+        canRead: true,
+        canCreateRecord: true,
+        canEditRecord: true,
+        canDeleteRecord: true,
+        canManageFields: true,
+        canManageSheetAccess: true,
+        canManageViews: true,
+        canComment: true,
+        canManageAutomation: true,
+        canExport: true,
+      },
+    })).rejects.toBeInstanceOf(RecordValidationFailedError)
+  })
+
+  it('deletes a record and emits realtime + eventBus notifications', async () => {
+    const service = new RecordService(pool, eventBus as any)
+
+    const result = await service.deleteRecord({
+      recordId: 'rec_existing',
+      actorId: 'user_1',
+      access: { userId: 'user_1', permissions: [], isAdminRole: false },
+      resolveSheetAccess: vi.fn().mockResolvedValue({
+        capabilities: {
+          canRead: true,
+          canCreateRecord: true,
+          canEditRecord: true,
+          canDeleteRecord: true,
+          canManageFields: true,
+          canManageSheetAccess: true,
+          canManageViews: true,
+          canComment: true,
+          canManageAutomation: true,
+          canExport: true,
+        },
+      }),
+    })
+
+    expect(result).toEqual({ recordId: 'rec_existing', sheetId: 'sheet_ops' })
+    expect(eventBus.emit).toHaveBeenCalledWith('multitable.record.deleted', {
+      sheetId: 'sheet_ops',
+      recordId: 'rec_existing',
+      actorId: 'user_1',
+    })
+    expect(mockPublish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        spreadsheetId: 'sheet_ops',
+        kind: 'record-deleted',
+        recordId: 'rec_existing',
+        recordIds: ['rec_existing'],
+      }),
+    )
+  })
+
+  it('throws VersionConflictError when delete expectedVersion does not match', async () => {
+    pool = createMockPool({
+      SELECT_DELETE_FOR_UPDATE: {
+        rows: [{ id: 'rec_existing', sheet_id: 'sheet_ops', version: 7 }],
+      },
+    })
+    const service = new RecordService(pool, eventBus as any)
+
+    await expect(service.deleteRecord({
+      recordId: 'rec_existing',
+      expectedVersion: 5,
+      actorId: 'user_1',
+      access: { userId: 'user_1', permissions: [], isAdminRole: false },
+      resolveSheetAccess: vi.fn().mockResolvedValue({
+        capabilities: {
+          canRead: true,
+          canCreateRecord: true,
+          canEditRecord: true,
+          canDeleteRecord: true,
+          canManageFields: true,
+          canManageSheetAccess: true,
+          canManageViews: true,
+          canComment: true,
+          canManageAutomation: true,
+          canExport: true,
+        },
+      }),
+    })).rejects.toThrow(VersionConflictError)
+  })
+
+  it('rejects delete when record-level own-write policy blocks the row', async () => {
+    pool = createMockPool({
+      SELECT_DELETE_RECORD: {
+        rows: [{ id: 'rec_existing', sheet_id: 'sheet_ops', created_by: 'user_2' }],
+      },
+    })
+    const service = new RecordService(pool, eventBus as any)
+
+    await expect(service.deleteRecord({
+      recordId: 'rec_existing',
+      actorId: 'user_1',
+      access: { userId: 'user_1', permissions: [], isAdminRole: false },
+      resolveSheetAccess: vi.fn().mockResolvedValue({
+        capabilities: {
+          canRead: true,
+          canCreateRecord: true,
+          canEditRecord: true,
+          canDeleteRecord: true,
+          canManageFields: true,
+          canManageSheetAccess: true,
+          canManageViews: true,
+          canComment: true,
+          canManageAutomation: true,
+          canExport: true,
+        },
+        sheetScope: {
+          hasAssignments: true,
+          canRead: true,
+          canWrite: false,
+          canWriteOwn: true,
+          canAdmin: false,
+        },
+      }),
+    })).rejects.toThrow(RecordPermissionError)
+  })
+
+  it('throws RecordNotFoundError when deleting a missing record', async () => {
+    pool = createMockPool({
+      SELECT_DELETE_RECORD: { rows: [] },
+    })
+    const service = new RecordService(pool, eventBus as any)
+
+    await expect(service.deleteRecord({
+      recordId: 'rec_missing',
+      actorId: 'user_1',
+      access: { userId: 'user_1', permissions: [], isAdminRole: false },
+      resolveSheetAccess: vi.fn(),
+    })).rejects.toThrow(RecordNotFoundError)
+  })
+})


### PR DESCRIPTION
## Summary
- add RecordService for direct multitable record create/delete semantics
- delegate POST /records and DELETE /records/:recordId from univer-meta.ts while keeping route-level auth, access, and HTTP error mapping
- keep PATCH, form submit, Yjs invalidation, and attachment delete out of scope
- update sheet realtime integration mocks for the extracted create path and current permission/created_by queries

## Testing
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/record-service.test.ts --reporter=dot
- pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/record-service.test.ts tests/unit/record-write-service.test.ts tests/unit/multitable-attachment-service.test.ts --reporter=dot
- pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/multitable-sheet-realtime.api.test.ts --reporter=dot
- git diff --check