### PR TITLE
refactor(multitable): extract direct record patch service

### DIFF
--- a/docs/development/multitable-m2-patch-service-development-20260423.md
+++ b/docs/development/multitable-m2-patch-service-development-20260423.md
@@ -1,0 +1,86 @@
+# Multitable M2 slice 3 — direct PATCH service extraction
+
+Date: 2026-04-23
+Branch: `codex/multitable-m2-patch-service-20260423`
+Base: `main@61f32f318`
+Paired with: `docs/development/multitable-m2-patch-service-verification-20260423.md`
+
+## Goal
+
+Continue the M2 backend extraction after `attachment-service.ts` and
+`record-service` create/delete by moving the direct `PATCH /records/:recordId`
+mutation seam out of `univer-meta.ts` and into `RecordService`.
+
+This slice targets only the legacy direct record patch endpoint. It does not
+change the authoritative batch patch path owned by `RecordWriteService`.
+
+## Code changes
+
+### 1. `RecordService.patchRecord()`
+
+File: `packages/core-backend/src/multitable/record-service.ts`
+
+Added `patchRecord(input)` to own the non-HTTP mutation semantics previously
+inline in the route:
+
+- field mutation guard construction from current sheet fields
+- hidden/read-only/lookup/rollup rejection
+- select option validation
+- link normalization, single-link enforcement, linked-record existence checks
+- attachment id normalization and attachment existence checks
+- row-level `own-write` enforcement through shared `ensureRecordWriteAllowed`
+- `expectedVersion` conflict check under `SELECT ... FOR UPDATE`
+- `meta_records.data` patch + `version++`
+- `meta_links` delta mutation for link fields
+- best-effort Yjs invalidation after commit
+
+The route still owns request parsing, sheet/view resolution, auth/session access,
+capability resolution, HTTP status mapping, and response hydration.
+
+### 2. Route delegation
+
+File: `packages/core-backend/src/routes/univer-meta.ts`
+
+`PATCH /records/:recordId` now delegates its mutation body to
+`RecordService.patchRecord()` and then keeps the existing response shaping:
+
+- reload updated row
+- hydrate link values
+- filter hidden/property-scoped fields
+- build attachment summaries
+- return the same `commentsScope` shape
+
+The load-bearing Yjs invalidation comment moved from route code into service
+behavior. The failure policy is unchanged: invalidator errors are logged and
+swallowed so the REST write still succeeds.
+
+### 3. Focused unit coverage
+
+File: `packages/core-backend/tests/unit/record-service.test.ts`
+
+Added direct patch coverage for:
+
+- successful scalar + link patch
+- stale link delete and new link insert
+- Yjs invalidator call
+- hidden field rejection with legacy `FIELD_HIDDEN` / `403` classification
+- expectedVersion conflict before update
+- own-write policy rejection for non-owned rows
+
+## Explicit defer
+
+- Do not move `POST /patch`; it remains on `RecordWriteService`.
+- Do not move public form submit/update paths.
+- Do not add new Yjs bridge write semantics.
+- Do not change response hydration or comments scope shape.
+- Do not add frontend changes.
+
+## Risk notes
+
+- The service now reloads sheet fields internally for patch validation and
+  returns them to the route for response hydration, avoiding a second field
+  query in the route.
+- The route still performs the initial record lookup so it can resolve sheet
+  capabilities before calling the service.
+- Yjs invalidation remains best-effort and intentionally does not fail the REST
+  patch path.

--- a/docs/development/multitable-m2-patch-service-verification-20260423.md
+++ b/docs/development/multitable-m2-patch-service-verification-20260423.md
@@ -1,0 +1,96 @@
+# Multitable M2 slice 3 — direct PATCH service verification log
+
+Date: 2026-04-23
+Branch: `codex/multitable-m2-patch-service-20260423`
+Base: `main@61f32f318`
+Paired with: `docs/development/multitable-m2-patch-service-development-20260423.md`
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
+
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/record-service.test.ts \
+  --reporter=dot
+
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/record-service.test.ts \
+  tests/unit/record-write-service.test.ts \
+  tests/unit/multitable-attachment-service.test.ts \
+  --reporter=dot
+
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/yjs-rest-invalidation.test.ts \
+  --reporter=dot
+
+pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
+  tests/integration/multitable-record-form.api.test.ts \
+  --reporter=dot
+
+pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
+  tests/integration/multitable-sheet-permissions.api.test.ts \
+  -t "allows create, form submit, patch, and own delete when sheet permission is write-own without global multitable permission" \
+  --reporter=dot
+
+git diff --check
+```
+
+## Results
+
+### Type-check
+
+- `packages/core-backend`: `tsc --noEmit` passed with exit `0`
+
+### Focused service tests
+
+- `tests/unit/record-service.test.ts`: `11/11` passed
+
+New patch coverage:
+
+- successful scalar + link patch
+- Yjs invalidation after direct REST patch
+- link delta delete/insert
+- hidden field rejection with legacy forbidden classification
+- expectedVersion conflict before update
+- own-write policy rejection
+
+### Adjacent unit regression
+
+- `tests/unit/record-service.test.ts`: `11/11` passed
+- `tests/unit/record-write-service.test.ts`: `25/25` passed
+- `tests/unit/multitable-attachment-service.test.ts`: `24/24` passed
+- Aggregate: `60/60` passed
+- `tests/unit/yjs-rest-invalidation.test.ts`: `9/9` passed
+
+Known log during regression:
+
+- `record-write-service.test.ts` intentionally logs one swallowed Yjs
+  invalidation failure in the test that verifies invalidator errors do not fail
+  REST patch writes.
+
+### Route-level integration regression
+
+- `tests/integration/multitable-record-form.api.test.ts`: `18/18` passed
+- `tests/integration/multitable-sheet-permissions.api.test.ts` focused
+  write-own case: `1/1` passed (`38` skipped by `-t`)
+
+Known log during the write-own route regression:
+
+- The existing integration mock does not cover one formula dependency lookup in
+  the form/patch path, so the route logs a swallowed formula recalculation
+  warning. This log existed before this extraction and the focused assertion
+  passed.
+
+### Whitespace
+
+- `git diff --check`: passed
+
+## Contract checks
+
+- Direct PATCH still returns `{ ok: true, data: { record, commentsScope } }`.
+- Direct PATCH `expectedVersion` mismatch still maps to HTTP `409`.
+- Hidden-only field errors still map to HTTP `403` / `FIELD_HIDDEN`.
+- Readonly-only field errors still map to HTTP `403` / `FIELD_READONLY`.
+- Mixed validation errors still map to HTTP `400` / `VALIDATION_ERROR`.
+- `POST /patch` remains on `RecordWriteService` and was regression-tested.

--- a/packages/core-backend/src/multitable/record-service.ts
+++ b/packages/core-backend/src/multitable/record-service.ts
@@ -6,9 +6,11 @@ import {
   ensureAttachmentIdsExist as ensureAttachmentIdsExistShared,
   normalizeAttachmentIds as normalizeAttachmentIdsShared,
 } from './attachment-service'
-import { extractSelectOptions, normalizeJson, normalizeJsonArray } from './field-codecs'
+import { extractSelectOptions, normalizeJson, normalizeJsonArray, type MultitableField } from './field-codecs'
 import { getDefaultValidationRules, validateRecord } from './field-validation-engine'
 import type { FieldValidationConfig } from './field-validation'
+import { loadFieldsForSheet } from './loaders'
+import { isFieldAlwaysReadOnly, isFieldPermissionHidden } from './permission-derivation'
 import { publishMultitableSheetRealtime } from './realtime-publish'
 import { ensureRecordWriteAllowed, type AccessInfo, type SheetPermissionScope } from './sheet-capabilities'
 
@@ -24,14 +26,7 @@ export interface ConnectionPool {
   transaction: <T>(handler: TransactionHandler<T>) => Promise<T>
 }
 
-export type UniverMetaField = {
-  id: string
-  name: string
-  type: 'string' | 'number' | 'boolean' | 'date' | 'formula' | 'select' | 'link' | 'lookup' | 'rollup' | 'attachment'
-  options?: Array<{ value: string; color?: string }>
-  order?: number
-  property?: Record<string, unknown>
-}
+export type UniverMetaField = MultitableField
 
 export type LinkFieldConfig = {
   foreignSheetId: string
@@ -43,6 +38,16 @@ type CreateFieldGuard = {
   options?: string[]
   link?: LinkFieldConfig | null
 }
+
+type FieldMutationGuard = {
+  type: UniverMetaField['type']
+  options?: string[]
+  readOnly: boolean
+  hidden: boolean
+  link?: LinkFieldConfig | null
+}
+
+export type YjsInvalidator = (recordIds: string[]) => Promise<void> | void
 
 export class VersionConflictError extends Error {
   constructor(
@@ -96,6 +101,21 @@ export class RecordValidationFailedError extends Error {
   }
 }
 
+export class RecordPatchFieldValidationError extends Error {
+  public readonly code: string
+  public readonly statusCode: number
+
+  constructor(public readonly fieldErrors: Record<string, string>) {
+    const messages = Object.values(fieldErrors)
+    const hiddenOnly = messages.length > 0 && messages.every((message) => message === 'Field is hidden')
+    const readonlyOnly = messages.length > 0 && messages.every((message) => message === 'Field is readonly')
+    super(hiddenOnly ? 'Hidden field update rejected' : readonlyOnly ? 'Readonly field update rejected' : 'Validation failed')
+    this.name = 'RecordPatchFieldValidationError'
+    this.code = hiddenOnly ? 'FIELD_HIDDEN' : readonlyOnly ? 'FIELD_READONLY' : 'VALIDATION_ERROR'
+    this.statusCode = hiddenOnly || readonlyOnly ? 403 : 400
+  }
+}
+
 export type RecordCreateInput = {
   sheetId: string
   data: Record<string, unknown>
@@ -122,6 +142,24 @@ export type RecordDeleteInput = {
 export type RecordDeleteResult = {
   recordId: string
   sheetId: string
+}
+
+export type RecordPatchInput = {
+  recordId: string
+  sheetId: string
+  data: Record<string, unknown>
+  expectedVersion?: number
+  access: AccessInfo
+  capabilities: MultitableCapabilities
+  sheetScope?: SheetPermissionScope
+}
+
+export type RecordPatchResult = {
+  recordId: string
+  sheetId: string
+  version: number
+  fields: UniverMetaField[]
+  patch: Record<string, unknown>
 }
 
 function isUndefinedTableError(err: unknown, tableName: string): boolean {
@@ -217,6 +255,26 @@ function buildCreateFieldGuardMap(rows: unknown[]): Map<string, CreateFieldGuard
   return guards
 }
 
+function buildFieldMutationGuardMap(fields: UniverMetaField[]): Map<string, FieldMutationGuard> {
+  return new Map(
+    fields.map((field) => {
+      const property = normalizeJson(field.property)
+      const base: FieldMutationGuard = {
+        type: field.type,
+        readOnly: isFieldAlwaysReadOnly(field),
+        hidden: isFieldPermissionHidden(field),
+      }
+      if (field.type === 'select') {
+        return [field.id, { ...base, options: field.options?.map((option) => option.value) ?? [] }] as const
+      }
+      if (field.type === 'link') {
+        return [field.id, { ...base, link: parseLinkFieldConfig(property) }] as const
+      }
+      return [field.id, base] as const
+    }),
+  )
+}
+
 function buildDirectValidationFields(rows: unknown[]) {
   return (rows as Array<Record<string, unknown>>).map((row) => {
     const property = normalizeJson(row.property)
@@ -238,6 +296,7 @@ export class RecordService {
   constructor(
     private pool: ConnectionPool,
     private eventBus: EventBus,
+    private yjsInvalidator: YjsInvalidator | null = null,
   ) {}
 
   async createRecord(input: RecordCreateInput): Promise<RecordCreateResult> {
@@ -484,6 +543,209 @@ export class RecordService {
     return {
       recordId,
       sheetId,
+    }
+  }
+
+  async patchRecord(input: RecordPatchInput): Promise<RecordPatchResult> {
+    const { recordId, sheetId, data, expectedVersion, access, capabilities, sheetScope } = input
+
+    if (!capabilities.canEditRecord) {
+      throw new RecordPermissionError('Insufficient permissions')
+    }
+
+    const fields = await loadFieldsForSheet(this.pool.query.bind(this.pool), sheetId)
+    if (fields.length === 0) {
+      throw new RecordNotFoundError(`Sheet not found: ${sheetId}`)
+    }
+
+    const fieldById = buildFieldMutationGuardMap(fields)
+    const fieldErrors: Record<string, string> = {}
+    const patch: Record<string, unknown> = {}
+    const linkUpdates = new Map<string, { ids: string[]; cfg: LinkFieldConfig }>()
+
+    for (const [fieldId, value] of Object.entries(data)) {
+      const field = fieldById.get(fieldId)
+      if (!field) {
+        fieldErrors[fieldId] = 'Unknown field'
+        continue
+      }
+      if (field.hidden) {
+        fieldErrors[fieldId] = 'Field is hidden'
+        continue
+      }
+      if (field.readOnly === true || field.type === 'lookup' || field.type === 'rollup') {
+        fieldErrors[fieldId] = 'Field is readonly'
+        continue
+      }
+      if (field.type === 'select') {
+        if (typeof value !== 'string') {
+          fieldErrors[fieldId] = 'Select value must be a string'
+          continue
+        }
+        const allowed = new Set(field.options ?? [])
+        if (value !== '' && !allowed.has(value)) {
+          fieldErrors[fieldId] = 'Invalid select option'
+          continue
+        }
+      }
+      if (field.type === 'link') {
+        if (!field.link) {
+          fieldErrors[fieldId] = 'Link field is missing foreign sheet configuration'
+          continue
+        }
+        const ids = normalizeLinkIds(value)
+        if (field.link.limitSingleRecord && ids.length > 1) {
+          fieldErrors[fieldId] = 'Only one linked record is allowed'
+          continue
+        }
+        const tooLong = ids.find((id) => id.length > 50)
+        if (tooLong) {
+          fieldErrors[fieldId] = `Link id too long: ${tooLong}`
+          continue
+        }
+        if (ids.length > 0) {
+          const exists = await this.pool.query(
+            'SELECT id FROM meta_records WHERE sheet_id = $1 AND id = ANY($2::text[])',
+            [field.link.foreignSheetId, ids],
+          )
+          const found = new Set(
+            (exists.rows as Array<Record<string, unknown>>)
+              .map((row) => (typeof row.id === 'string' ? row.id : ''))
+              .filter((id) => id.length > 0),
+          )
+          const missing = ids.filter((id) => !found.has(id))
+          if (missing.length > 0) {
+            fieldErrors[fieldId] = `Linked record not found: ${missing.join(', ')}`
+            continue
+          }
+        }
+        patch[fieldId] = ids
+        linkUpdates.set(fieldId, { ids, cfg: field.link })
+        continue
+      }
+      if (field.type === 'attachment') {
+        const ids = normalizeAttachmentIdsShared(value)
+        const tooLong = ids.find((id) => id.length > 100)
+        if (tooLong) {
+          fieldErrors[fieldId] = `Attachment id too long: ${tooLong}`
+          continue
+        }
+        const attachmentError = await ensureAttachmentIdsExistShared({
+          query: this.pool.query.bind(this.pool),
+          sheetId,
+          fieldId,
+          attachmentIds: ids,
+        })
+        if (attachmentError) {
+          fieldErrors[fieldId] = attachmentError
+          continue
+        }
+        patch[fieldId] = ids
+        continue
+      }
+      if (field.type === 'formula') {
+        if (typeof value !== 'string') {
+          fieldErrors[fieldId] = 'Formula value must be a string'
+          continue
+        }
+        if (value !== '' && !value.startsWith('=')) {
+          fieldErrors[fieldId] = 'Formula must start with ='
+          continue
+        }
+      }
+      patch[fieldId] = value
+    }
+
+    if (Object.keys(fieldErrors).length > 0) {
+      throw new RecordPatchFieldValidationError(fieldErrors)
+    }
+
+    let nextVersion = 1
+    await this.pool.transaction(async ({ query }) => {
+      const currentRes = await query(
+        'SELECT id, version, created_by FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE',
+        [recordId, sheetId],
+      )
+      if (currentRes.rows.length === 0) {
+        throw new RecordNotFoundError(`Record not found: ${recordId}`)
+      }
+      const currentRow = currentRes.rows[0] as Record<string, unknown>
+      if (!ensureRecordWriteAllowed(
+        capabilities,
+        sheetScope,
+        access,
+        typeof currentRow.created_by === 'string' ? currentRow.created_by : null,
+        'edit',
+      )) {
+        throw new RecordPermissionError('Record editing is not allowed for this row')
+      }
+
+      const serverVersion = Number(currentRow.version ?? 1)
+      if (typeof expectedVersion === 'number' && expectedVersion !== serverVersion) {
+        throw new VersionConflictError(recordId, serverVersion)
+      }
+
+      if (Object.keys(patch).length > 0) {
+        const updateRes = await query(
+          `UPDATE meta_records
+           SET data = data || $1::jsonb, updated_at = now(), version = version + 1
+           WHERE id = $2 AND sheet_id = $3
+           RETURNING version`,
+          [JSON.stringify(patch), recordId, sheetId],
+        )
+        nextVersion = Number((updateRes.rows[0] as { version?: unknown } | undefined)?.version ?? serverVersion)
+      } else {
+        nextVersion = serverVersion
+      }
+
+      for (const [fieldId, { ids }] of linkUpdates.entries()) {
+        const currentLinks = await query(
+          'SELECT foreign_record_id FROM meta_links WHERE field_id = $1 AND record_id = $2',
+          [fieldId, recordId],
+        )
+        const existingIds = (currentLinks.rows as Array<Record<string, unknown>>).map((row) => String(row.foreign_record_id))
+        const existing = new Set(existingIds)
+        const next = new Set(ids)
+        const toDelete = existingIds.filter((id) => !next.has(id))
+        const toInsert = ids.filter((id) => !existing.has(id))
+
+        if (toDelete.length > 0) {
+          await query(
+            'DELETE FROM meta_links WHERE field_id = $1 AND record_id = $2 AND foreign_record_id = ANY($3::text[])',
+            [fieldId, recordId, toDelete],
+          )
+        }
+        for (const foreignId of toInsert) {
+          await query(
+            `INSERT INTO meta_links (id, field_id, record_id, foreign_record_id)
+             VALUES ($1, $2, $3, $4)
+             ON CONFLICT DO NOTHING`,
+            [`lnk_${randomUUID()}`.slice(0, 50), fieldId, recordId, foreignId],
+          )
+        }
+        if (ids.length === 0) {
+          await query('DELETE FROM meta_links WHERE field_id = $1 AND record_id = $2', [fieldId, recordId])
+        }
+      }
+    })
+
+    if (this.yjsInvalidator) {
+      try {
+        await this.yjsInvalidator([recordId])
+      } catch (err) {
+        console.error(
+          `[record-service] Yjs invalidation failed for record ${recordId} — Yjs state may be stale until next idle-release:`,
+          err,
+        )
+      }
+    }
+
+    return {
+      recordId,
+      sheetId,
+      version: nextVersion,
+      fields,
+      patch,
     }
   }
 }

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -94,6 +94,7 @@ import {
   RecordFieldForbiddenError as RecordServiceFieldForbiddenError,
   RecordPermissionError as RecordServicePermissionError,
   RecordValidationFailedError as RecordCreateValidationFailedError,
+  RecordPatchFieldValidationError as RecordServicePatchFieldValidationError,
 } from '../multitable/record-service'
 
 const multitableFormulaEngine = new MultitableFormulaEngine()
@@ -6806,199 +6807,18 @@ export function univerMetaRouter(): Router {
       }
       if (!capabilities.canEditRecord) return sendForbidden(res)
 
-      const fields = await loadFieldsForSheet(pool.query.bind(pool), sheetId)
-      const fieldById = buildFieldMutationGuardMap(fields)
-
-      const data = parsed.data.data ?? {}
-      const fieldErrors: Record<string, string> = {}
-      const patch: Record<string, unknown> = {}
-      const linkUpdates = new Map<string, { ids: string[]; cfg: LinkFieldConfig }>()
-
-      for (const [fieldId, value] of Object.entries(data)) {
-        const field = fieldById.get(fieldId)
-        if (!field) {
-          fieldErrors[fieldId] = 'Unknown field'
-          continue
-        }
-        if (field.hidden) {
-          fieldErrors[fieldId] = 'Field is hidden'
-          continue
-        }
-        if (field.readOnly === true || field.type === 'lookup' || field.type === 'rollup') {
-          fieldErrors[fieldId] = 'Field is readonly'
-          continue
-        }
-        if (field.type === 'select') {
-          if (typeof value !== 'string') {
-            fieldErrors[fieldId] = 'Select value must be a string'
-            continue
-          }
-          const allowed = new Set(field.options ?? [])
-          if (value !== '' && !allowed.has(value)) {
-            fieldErrors[fieldId] = 'Invalid select option'
-            continue
-          }
-        }
-        if (field.type === 'link') {
-          if (!field.link) {
-            fieldErrors[fieldId] = 'Link field is missing foreign sheet configuration'
-            continue
-          }
-          const ids = normalizeLinkIds(value)
-          if (field.link.limitSingleRecord && ids.length > 1) {
-            fieldErrors[fieldId] = 'Only one linked record is allowed'
-            continue
-          }
-          const tooLong = ids.find((id) => id.length > 50)
-          if (tooLong) {
-            fieldErrors[fieldId] = `Link id too long: ${tooLong}`
-            continue
-          }
-          if (ids.length > 0) {
-            const exists = await pool.query(
-              'SELECT id FROM meta_records WHERE sheet_id = $1 AND id = ANY($2::text[])',
-              [field.link.foreignSheetId, ids],
-            )
-            const found = new Set((exists.rows as any[]).map((row: any) => String(row.id)))
-            const missing = ids.filter((id) => !found.has(id))
-            if (missing.length > 0) {
-              fieldErrors[fieldId] = `Linked record not found: ${missing.join(', ')}`
-              continue
-            }
-          }
-          patch[fieldId] = ids
-          linkUpdates.set(fieldId, { ids, cfg: field.link })
-          continue
-        }
-        if (field.type === 'attachment') {
-          const ids = normalizeAttachmentIds(value)
-          const tooLong = ids.find((id) => id.length > 100)
-          if (tooLong) {
-            fieldErrors[fieldId] = `Attachment id too long: ${tooLong}`
-            continue
-          }
-          const attachmentError = await ensureAttachmentIdsExist(pool.query.bind(pool), sheetId, fieldId, ids)
-          if (attachmentError) {
-            fieldErrors[fieldId] = attachmentError
-            continue
-          }
-          patch[fieldId] = ids
-          continue
-        }
-        if (field.type === 'formula') {
-          if (typeof value !== 'string') {
-            fieldErrors[fieldId] = 'Formula value must be a string'
-            continue
-          }
-          if (value !== '' && !value.startsWith('=')) {
-            fieldErrors[fieldId] = 'Formula must start with ='
-            continue
-          }
-        }
-        patch[fieldId] = value
-      }
-
-      if (Object.keys(fieldErrors).length > 0) {
-        const hiddenOnly = Object.values(fieldErrors).every((message) => message === 'Field is hidden')
-        const readonlyOnly = Object.values(fieldErrors).every((message) => message === 'Field is readonly')
-        return res.status(hiddenOnly || readonlyOnly ? 403 : 400).json({
-          ok: false,
-          error: {
-            code: hiddenOnly ? 'FIELD_HIDDEN' : readonlyOnly ? 'FIELD_READONLY' : 'VALIDATION_ERROR',
-            message: hiddenOnly ? 'Hidden field update rejected' : readonlyOnly ? 'Readonly field update rejected' : 'Validation failed',
-            fieldErrors,
-          },
-        })
-      }
-
-      let nextVersion = 1
-      await pool.transaction(async ({ query }) => {
-        const currentRes = await query(
-          'SELECT id, version, created_by FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE',
-          [recordId, sheetId],
-        )
-        if ((currentRes as any).rows.length === 0) {
-          throw new NotFoundError(`Record not found: ${recordId}`)
-        }
-        const currentRow: any = (currentRes as any).rows[0]
-        if (!ensureRecordWriteAllowed(capabilities, sheetScope, access, typeof currentRow?.created_by === 'string' ? currentRow.created_by : null, 'edit')) {
-          throw new PermissionError('Record editing is not allowed for this row')
-        }
-        const serverVersion = Number(currentRow?.version ?? 1)
-        if (typeof parsed.data.expectedVersion === 'number' && parsed.data.expectedVersion !== serverVersion) {
-          throw new VersionConflictError(recordId, serverVersion)
-        }
-
-        if (Object.keys(patch).length > 0) {
-          const updateRes = await query(
-            `UPDATE meta_records
-             SET data = data || $1::jsonb, updated_at = now(), version = version + 1
-             WHERE id = $2 AND sheet_id = $3
-             RETURNING version`,
-            [JSON.stringify(patch), recordId, sheetId],
-          )
-          nextVersion = Number((updateRes as any).rows[0]?.version ?? serverVersion)
-        } else {
-          nextVersion = serverVersion
-        }
-
-        for (const [fieldId, { ids }] of linkUpdates.entries()) {
-          const currentLinks = await query(
-            'SELECT foreign_record_id FROM meta_links WHERE field_id = $1 AND record_id = $2',
-            [fieldId, recordId],
-          )
-          const existingIds = (currentLinks as any).rows.map((row: any) => String(row.foreign_record_id))
-          const existing = new Set(existingIds)
-          const next = new Set(ids)
-          const toDelete = existingIds.filter((id) => !next.has(id))
-          const toInsert = ids.filter((id) => !existing.has(id))
-
-          if (toDelete.length > 0) {
-            await query(
-              'DELETE FROM meta_links WHERE field_id = $1 AND record_id = $2 AND foreign_record_id = ANY($3::text[])',
-              [fieldId, recordId, toDelete],
-            )
-          }
-          for (const foreignId of toInsert) {
-            await query(
-              `INSERT INTO meta_links (id, field_id, record_id, foreign_record_id)
-               VALUES ($1, $2, $3, $4)
-               ON CONFLICT DO NOTHING`,
-              [buildId('lnk').slice(0, 50), fieldId, recordId, foreignId],
-            )
-          }
-          if (ids.length === 0) {
-            await query('DELETE FROM meta_links WHERE field_id = $1 AND record_id = $2', [fieldId, recordId])
-          }
-        }
+      const recordService = new RecordService(pool, eventBus, yjsInvalidator)
+      const patchResult = await recordService.patchRecord({
+        recordId,
+        sheetId,
+        data: parsed.data.data ?? {},
+        expectedVersion: parsed.data.expectedVersion,
+        access,
+        capabilities,
+        sheetScope,
       })
-
-      // -----------------------------------------------------------------
-      // LOAD-BEARING — DO NOT REMOVE
-      //
-      // Wipes any persisted / in-memory Y.Doc state for this record so the
-      // next getOrCreateDoc re-seeds from the just-updated meta_records.data.
-      // Without this, the P0 stale-snapshot bug returns (docs/development/
-      // yjs-text-cell-seed-and-stale-guard-development-20260420.md).
-      //
-      // The batch PATCH path goes through RecordWriteService.patchRecords,
-      // which runs an equivalent hook on every commit that isn't
-      // source='yjs-bridge'. This direct-SQL route bypasses that service,
-      // so it must fire the invalidator itself.
-      //
-      // Best-effort: a purge failure is logged and swallowed; the REST
-      // write still succeeds.
-      // -----------------------------------------------------------------
-      if (yjsInvalidator) {
-        try {
-          await yjsInvalidator([recordId])
-        } catch (err) {
-          console.error(
-            `[univer-meta] Yjs invalidation failed for record ${recordId} — Yjs state may be stale until next idle-release:`,
-            err,
-          )
-        }
-      }
+      const fields = patchResult.fields
+      const nextVersion = patchResult.version
 
       const recordRes = await pool.query(
         'SELECT id, version, data FROM meta_records WHERE id = $1 AND sheet_id = $2',
@@ -7059,7 +6879,17 @@ export function univerMetaRouter(): Router {
         },
       })
     } catch (err) {
-      if (err instanceof VersionConflictError) {
+      if (err instanceof RecordServicePatchFieldValidationError) {
+        return res.status(err.statusCode).json({
+          ok: false,
+          error: {
+            code: err.code,
+            message: err.message,
+            fieldErrors: err.fieldErrors,
+          },
+        })
+      }
+      if (err instanceof RecordServiceVersionConflictError || err instanceof VersionConflictError) {
         return res.status(409).json({
           ok: false,
           error: {
@@ -7069,14 +6899,15 @@ export function univerMetaRouter(): Router {
           },
         })
       }
-      if (err instanceof NotFoundError) {
+      if (err instanceof RecordServiceNotFoundError || err instanceof NotFoundError) {
         return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: err.message } })
       }
-      if (err instanceof PermissionError) {
+      if (err instanceof RecordServicePermissionError || err instanceof PermissionError) {
         return sendForbidden(res, err.message)
       }
-      if (err instanceof ValidationError) {
-        return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: err.message } })
+      if (err instanceof RecordServiceValidationError || err instanceof ValidationError) {
+        const code = err instanceof RecordServiceValidationError ? err.code : 'VALIDATION_ERROR'
+        return res.status(400).json({ ok: false, error: { code, message: err.message } })
       }
       const hint = getDbNotReadyMessage(err)
       if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })

--- a/packages/core-backend/tests/unit/record-service.test.ts
+++ b/packages/core-backend/tests/unit/record-service.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   RecordNotFoundError,
+  RecordPatchFieldValidationError,
   RecordPermissionError,
   RecordService,
   RecordValidationFailedError,
@@ -17,6 +18,19 @@ vi.mock('../../src/multitable/realtime-publish', () => ({
 }))
 
 type QueryResponse = { rows: unknown[]; rowCount?: number | null }
+
+const fullCapabilities = {
+  canRead: true,
+  canCreateRecord: true,
+  canEditRecord: true,
+  canDeleteRecord: true,
+  canManageFields: true,
+  canManageSheetAccess: true,
+  canManageViews: true,
+  canComment: true,
+  canManageAutomation: true,
+  canExport: true,
+}
 
 function createMockEventBus() {
   return {
@@ -34,7 +48,7 @@ function createMockPool(
     if (sql.includes('SELECT id FROM meta_sheets WHERE id = $1 AND deleted_at IS NULL')) {
       return responses.SELECT_SHEET ?? { rows: [{ id: 'sheet_ops' }] }
     }
-    if (sql.includes('SELECT id, name, type, property FROM meta_fields WHERE sheet_id = $1')) {
+    if (sql.includes('FROM meta_fields WHERE sheet_id = $1')) {
       return responses.SELECT_FIELDS ?? {
         rows: [{ id: 'fld_title', name: 'Title', type: 'string', property: {} }],
       }
@@ -57,6 +71,23 @@ function createMockPool(
       return responses.SELECT_DELETE_FOR_UPDATE ?? {
         rows: [{ id: 'rec_existing', sheet_id: 'sheet_ops', version: 4 }],
       }
+    }
+    if (sql.includes('SELECT id, version, created_by FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE')) {
+      return responses.SELECT_PATCH_FOR_UPDATE ?? {
+        rows: [{ id: 'rec_existing', version: 4, created_by: 'user_1' }],
+      }
+    }
+    if (sql.includes('UPDATE meta_records') && sql.includes('RETURNING version')) {
+      return responses.UPDATE_RECORD ?? { rows: [{ version: 5 }], rowCount: 1 }
+    }
+    if (sql.includes('SELECT foreign_record_id FROM meta_links WHERE field_id = $1 AND record_id = $2')) {
+      return responses.SELECT_CURRENT_LINKS ?? { rows: [] }
+    }
+    if (sql.includes('DELETE FROM meta_links WHERE field_id = $1 AND record_id = $2 AND foreign_record_id = ANY')) {
+      return responses.DELETE_STALE_LINKS ?? { rows: [], rowCount: 1 }
+    }
+    if (sql.includes('DELETE FROM meta_links WHERE field_id = $1 AND record_id = $2')) {
+      return responses.DELETE_EMPTY_LINKS ?? { rows: [], rowCount: 1 }
     }
     if (sql.includes('DELETE FROM meta_links WHERE record_id = $1 OR foreign_record_id = $1')) {
       return responses.DELETE_LINKS ?? { rows: [], rowCount: 1 }
@@ -93,16 +124,7 @@ describe('RecordService', () => {
       data: { fld_title: 'Alpha' },
       actorId: 'user_1',
       capabilities: {
-        canRead: true,
-        canCreateRecord: true,
-        canEditRecord: true,
-        canDeleteRecord: true,
-        canManageFields: true,
-        canManageSheetAccess: true,
-        canManageViews: true,
-        canComment: true,
-        canManageAutomation: true,
-        canExport: true,
+        ...fullCapabilities,
       },
     })
 
@@ -145,16 +167,7 @@ describe('RecordService', () => {
       data: { fld_customer: 'rec_missing' },
       actorId: 'user_1',
       capabilities: {
-        canRead: true,
-        canCreateRecord: true,
-        canEditRecord: true,
-        canDeleteRecord: true,
-        canManageFields: true,
-        canManageSheetAccess: true,
-        canManageViews: true,
-        canComment: true,
-        canManageAutomation: true,
-        canExport: true,
+        ...fullCapabilities,
       },
     })).rejects.toThrow(RecordValidationError)
   })
@@ -179,16 +192,7 @@ describe('RecordService', () => {
       data: {},
       actorId: 'user_1',
       capabilities: {
-        canRead: true,
-        canCreateRecord: true,
-        canEditRecord: true,
-        canDeleteRecord: true,
-        canManageFields: true,
-        canManageSheetAccess: true,
-        canManageViews: true,
-        canComment: true,
-        canManageAutomation: true,
-        canExport: true,
+        ...fullCapabilities,
       },
     })).rejects.toBeInstanceOf(RecordValidationFailedError)
   })
@@ -202,16 +206,7 @@ describe('RecordService', () => {
       access: { userId: 'user_1', permissions: [], isAdminRole: false },
       resolveSheetAccess: vi.fn().mockResolvedValue({
         capabilities: {
-          canRead: true,
-          canCreateRecord: true,
-          canEditRecord: true,
-          canDeleteRecord: true,
-          canManageFields: true,
-          canManageSheetAccess: true,
-          canManageViews: true,
-          canComment: true,
-          canManageAutomation: true,
-          canExport: true,
+          ...fullCapabilities,
         },
       }),
     })
@@ -247,16 +242,7 @@ describe('RecordService', () => {
       access: { userId: 'user_1', permissions: [], isAdminRole: false },
       resolveSheetAccess: vi.fn().mockResolvedValue({
         capabilities: {
-          canRead: true,
-          canCreateRecord: true,
-          canEditRecord: true,
-          canDeleteRecord: true,
-          canManageFields: true,
-          canManageSheetAccess: true,
-          canManageViews: true,
-          canComment: true,
-          canManageAutomation: true,
-          canExport: true,
+          ...fullCapabilities,
         },
       }),
     })).rejects.toThrow(VersionConflictError)
@@ -276,16 +262,7 @@ describe('RecordService', () => {
       access: { userId: 'user_1', permissions: [], isAdminRole: false },
       resolveSheetAccess: vi.fn().mockResolvedValue({
         capabilities: {
-          canRead: true,
-          canCreateRecord: true,
-          canEditRecord: true,
-          canDeleteRecord: true,
-          canManageFields: true,
-          canManageSheetAccess: true,
-          canManageViews: true,
-          canComment: true,
-          canManageAutomation: true,
-          canExport: true,
+          ...fullCapabilities,
         },
         sheetScope: {
           hasAssignments: true,
@@ -310,5 +287,126 @@ describe('RecordService', () => {
       access: { userId: 'user_1', permissions: [], isAdminRole: false },
       resolveSheetAccess: vi.fn(),
     })).rejects.toThrow(RecordNotFoundError)
+  })
+
+  it('patches a record, updates links, and invalidates Yjs state', async () => {
+    const yjsInvalidator = vi.fn()
+    pool = createMockPool({
+      SELECT_FIELDS: {
+        rows: [
+          { id: 'fld_title', name: 'Title', type: 'string', property: {} },
+          {
+            id: 'fld_customer',
+            name: 'Customer',
+            type: 'link',
+            property: { foreignSheetId: 'sheet_customer', limitSingleRecord: false },
+          },
+        ],
+      },
+      SELECT_LINK_TARGETS: { rows: [{ id: 'rec_customer_2' }] },
+      SELECT_CURRENT_LINKS: { rows: [{ foreign_record_id: 'rec_customer_1' }] },
+    })
+    const service = new RecordService(pool, eventBus as any, yjsInvalidator)
+
+    const result = await service.patchRecord({
+      recordId: 'rec_existing',
+      sheetId: 'sheet_ops',
+      data: { fld_title: 'Updated', fld_customer: ['rec_customer_2'] },
+      expectedVersion: 4,
+      access: { userId: 'user_1', permissions: [], isAdminRole: false },
+      capabilities: fullCapabilities,
+    })
+
+    expect(result.version).toBe(5)
+    expect(result.patch).toEqual({ fld_title: 'Updated', fld_customer: ['rec_customer_2'] })
+    expect(yjsInvalidator).toHaveBeenCalledWith(['rec_existing'])
+    expect(pool.queryMock).toHaveBeenCalledWith(
+      expect.stringContaining('UPDATE meta_records'),
+      [JSON.stringify({ fld_title: 'Updated', fld_customer: ['rec_customer_2'] }), 'rec_existing', 'sheet_ops'],
+    )
+    expect(pool.queryMock).toHaveBeenCalledWith(
+      expect.stringContaining('DELETE FROM meta_links WHERE field_id = $1 AND record_id = $2 AND foreign_record_id = ANY'),
+      ['fld_customer', 'rec_existing', ['rec_customer_1']],
+    )
+    expect(pool.queryMock).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO meta_links'),
+      [expect.stringMatching(/^lnk_/), 'fld_customer', 'rec_existing', 'rec_customer_2'],
+    )
+  })
+
+  it('patch rejects hidden fields with the legacy forbidden response classification', async () => {
+    pool = createMockPool({
+      SELECT_FIELDS: {
+        rows: [{ id: 'fld_secret', name: 'Secret', type: 'string', property: { hidden: true } }],
+      },
+    })
+    const service = new RecordService(pool, eventBus as any)
+
+    await expect(service.patchRecord({
+      recordId: 'rec_existing',
+      sheetId: 'sheet_ops',
+      data: { fld_secret: 'blocked' },
+      access: { userId: 'user_1', permissions: [], isAdminRole: false },
+      capabilities: fullCapabilities,
+    })).rejects.toBeInstanceOf(RecordPatchFieldValidationError)
+
+    await expect(service.patchRecord({
+      recordId: 'rec_existing',
+      sheetId: 'sheet_ops',
+      data: { fld_secret: 'blocked' },
+      access: { userId: 'user_1', permissions: [], isAdminRole: false },
+      capabilities: fullCapabilities,
+    })).rejects.toMatchObject({
+      code: 'FIELD_HIDDEN',
+      statusCode: 403,
+      fieldErrors: { fld_secret: 'Field is hidden' },
+    })
+  })
+
+  it('patch enforces expectedVersion before updating', async () => {
+    pool = createMockPool({
+      SELECT_PATCH_FOR_UPDATE: {
+        rows: [{ id: 'rec_existing', version: 7, created_by: 'user_1' }],
+      },
+    })
+    const service = new RecordService(pool, eventBus as any)
+
+    await expect(service.patchRecord({
+      recordId: 'rec_existing',
+      sheetId: 'sheet_ops',
+      data: { fld_title: 'Updated' },
+      expectedVersion: 4,
+      access: { userId: 'user_1', permissions: [], isAdminRole: false },
+      capabilities: fullCapabilities,
+    })).rejects.toThrow(VersionConflictError)
+
+    expect(pool.queryMock).not.toHaveBeenCalledWith(
+      expect.stringContaining('UPDATE meta_records'),
+      expect.any(Array),
+    )
+  })
+
+  it('patch preserves own-write policy for non-owned rows', async () => {
+    pool = createMockPool({
+      SELECT_PATCH_FOR_UPDATE: {
+        rows: [{ id: 'rec_existing', version: 4, created_by: 'user_2' }],
+      },
+    })
+    const service = new RecordService(pool, eventBus as any)
+
+    await expect(service.patchRecord({
+      recordId: 'rec_existing',
+      sheetId: 'sheet_ops',
+      data: { fld_title: 'Updated' },
+      access: { userId: 'user_1', permissions: [], isAdminRole: false },
+      capabilities: fullCapabilities,
+      sheetScope: {
+        hasAssignments: true,
+        canRead: true,
+        canWrite: false,
+        canWriteOwn: true,
+        canAdmin: false,
+      },
+    })).rejects.toThrow(RecordPermissionError)
   })
 })


### PR DESCRIPTION
## Summary
- Add `RecordService.patchRecord()` for direct `PATCH /records/:recordId` mutation semantics.
- Move field guard validation, link/attachment validation, expectedVersion checks, own-write enforcement, link delta mutation, and best-effort Yjs invalidation out of `univer-meta.ts`.
- Keep route-owned HTTP parsing, sheet/access resolution, error mapping, and response hydration unchanged.
- Add development and verification MDs for the slice.

## Verification
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/record-service.test.ts --reporter=dot`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/record-service.test.ts tests/unit/record-write-service.test.ts tests/unit/multitable-attachment-service.test.ts tests/unit/yjs-rest-invalidation.test.ts --reporter=dot`
- `pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/multitable-record-form.api.test.ts --reporter=dot`
- `pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/multitable-sheet-permissions.api.test.ts -t "allows create, form submit, patch, and own delete when sheet permission is write-own without global multitable permission" --reporter=dot`
- `git diff --check`
