### PR TITLE
refactor(multitable): extract record query service

### DIFF
--- a/docs/development/multitable-m3-query-service-development-20260423.md
+++ b/docs/development/multitable-m3-query-service-development-20260423.md
@@ -1,0 +1,73 @@
+# Multitable M3 query-service extraction development
+
+Date: 2026-04-23
+Branch: `codex/multitable-m3-query-service-20260423`
+Base: `origin/main@6a677f9c3`
+
+## Scope
+
+M3 extracts the read/query side of `packages/core-backend/src/multitable/records.ts`
+into a dedicated seam:
+
+- `listRecords`
+- `queryRecords`
+- `queryRecordsWithCursor`
+- cursor encode/decode helpers
+- deterministic record query cache key helper
+
+The public `multitable/records.ts` API remains compatible. Existing callers
+that import from `records.ts` continue to work; the file now delegates read
+queries to `query-service.ts` and keeps create/patch/delete/get behavior local.
+
+## Design
+
+### New module
+
+`packages/core-backend/src/multitable/query-service.ts` owns query-only behavior:
+
+- sheet/field existence loading before list/query operations
+- filter validation against loaded fields
+- search normalization
+- order normalization
+- offset/limit validation
+- cursor keyset pagination
+- `meta_records.data` JSON normalization for read rows
+
+This separates read-path SQL construction from write-path validation and link
+mutation logic.
+
+### Shared errors
+
+`MultitableRecordValidationError` and `MultitableRecordNotFoundError` moved to
+`packages/core-backend/src/multitable/record-errors.ts`.
+
+`records.ts` re-exports those classes so existing imports do not change.
+
+### Compatibility wrapper
+
+`records.ts` now:
+
+- re-exports query helper types and functions from `query-service.ts`
+- delegates `listRecords`, `queryRecords`, and `queryRecordsWithCursor`
+- keeps `getRecord`, `createRecord`, `patchRecord`, and `deleteRecord`
+  implementation unchanged
+
+No route or plugin caller was forced to change.
+
+## Non-goals
+
+- No behavior change to filtering, sorting, search, cursor pagination, or cache
+  key format.
+- No lookup/rollup materialization changes. This slice only creates the seam
+  needed for a future query service to own richer read projections.
+- No route rewiring. Existing route/plugin imports remain stable through
+  `records.ts`.
+
+## Files
+
+- `packages/core-backend/src/multitable/query-service.ts`
+- `packages/core-backend/src/multitable/record-errors.ts`
+- `packages/core-backend/src/multitable/records.ts`
+- `packages/core-backend/tests/unit/multitable-query-service.test.ts`
+- `docs/development/multitable-m3-query-service-development-20260423.md`
+- `docs/development/multitable-m3-query-service-verification-20260423.md`

--- a/docs/development/multitable-m3-query-service-verification-20260423.md
+++ b/docs/development/multitable-m3-query-service-verification-20260423.md
@@ -1,0 +1,55 @@
+# Multitable M3 query-service extraction verification
+
+Date: 2026-04-23
+Branch: `codex/multitable-m3-query-service-20260423`
+Base: `origin/main@6a677f9c3`
+
+## Commands
+
+Run from worktree root:
+
+```bash
+pnpm install --prefer-offline
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/multitable-query-service.test.ts \
+  tests/unit/multitable-records.test.ts \
+  tests/unit/multitable-cursor-pagination.test.ts \
+  tests/unit/multitable-plugin-scope.test.ts \
+  --reporter=dot
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+```
+
+## Results
+
+Focused test run:
+
+```text
+Test Files  4 passed (4)
+Tests       36 passed (36)
+```
+
+Breakdown:
+
+- `multitable-query-service.test.ts`: `4/4` passed.
+- `multitable-records.test.ts`: `13/13` passed.
+- `multitable-cursor-pagination.test.ts`: `12/12` passed.
+- `multitable-plugin-scope.test.ts`: `7/7` passed.
+
+TypeScript:
+
+- `pnpm --filter @metasheet/core-backend exec tsc --noEmit`: exit `0`.
+
+## Coverage Notes
+
+- New direct query-service coverage verifies cursor/cache helpers, list
+  delegation, filter/search/order SQL generation, and cursor pagination metadata.
+- Existing `records.ts` tests remain green, proving compatibility for imports
+  that still consume `multitable/records.ts`.
+- Existing plugin-scope tests remain green, proving plugin API callers are not
+  forced to move to the new module.
+
+## Local Environment Note
+
+`pnpm install --prefer-offline` was required because this newly created worktree
+did not have workspace dependency links yet. The resulting `node_modules` files
+are install artifacts and were not staged.

--- a/packages/core-backend/src/multitable/query-service.ts
+++ b/packages/core-backend/src/multitable/query-service.ts
@@ -1,0 +1,334 @@
+import { createHash } from 'crypto'
+
+import { loadFieldsForSheet, loadSheetRow } from './loaders'
+import { MultitableRecordNotFoundError, MultitableRecordValidationError } from './record-errors'
+
+export type MultitableRecordsQueryFn = (
+  sql: string,
+  params?: unknown[],
+) => Promise<{ rows: unknown[]; rowCount?: number | null }>
+
+export type MultitableRecordFilterValue = string | number | boolean | null
+
+export type MultitableRecordQueryOrder = {
+  fieldId?: string
+  direction?: 'asc' | 'desc'
+}
+
+export type ListMultitableRecordsInput = {
+  query: MultitableRecordsQueryFn
+  sheetId: string
+  limit?: number
+  offset?: number
+}
+
+export type QueryMultitableRecordsInput = {
+  query: MultitableRecordsQueryFn
+  sheetId: string
+  filters?: Record<string, MultitableRecordFilterValue>
+  search?: string
+  orderBy?: MultitableRecordQueryOrder
+  limit?: number
+  offset?: number
+}
+
+export type LoadedMultitableRecord = {
+  id: string
+  sheetId: string
+  version: number
+  data: Record<string, unknown>
+}
+
+export type CursorPaginatedResult<T> = {
+  items: T[]
+  nextCursor: string | null
+  hasMore: boolean
+}
+
+export type CursorQueryInput = {
+  query: MultitableRecordsQueryFn
+  sheetId: string
+  cursor?: string
+  limit?: number
+  sort?: MultitableRecordQueryOrder
+  filter?: Record<string, MultitableRecordFilterValue>
+}
+
+export function encodeRecordCursor(id: string, sortValue: string): string {
+  return Buffer.from(JSON.stringify({ id, sv: sortValue })).toString('base64url')
+}
+
+export function decodeRecordCursor(cursor: string): { id: string; sortValue: string } {
+  try {
+    const parsed = JSON.parse(Buffer.from(cursor, 'base64url').toString('utf8'))
+    if (typeof parsed.id !== 'string' || typeof parsed.sv !== 'string') {
+      throw new MultitableRecordValidationError('Invalid cursor format')
+    }
+    return { id: parsed.id, sortValue: parsed.sv }
+  } catch (err) {
+    if (err instanceof MultitableRecordValidationError) throw err
+    throw new MultitableRecordValidationError('Invalid cursor format')
+  }
+}
+
+/**
+ * Build a deterministic cache key hash from query parameters.
+ */
+export function buildRecordsCacheKey(
+  sheetId: string,
+  params: { filter?: Record<string, MultitableRecordFilterValue>; sort?: MultitableRecordQueryOrder; cursor?: string },
+): string {
+  const payload = JSON.stringify({
+    f: params.filter ?? {},
+    s: params.sort ?? {},
+    c: params.cursor ?? '',
+  })
+  const hash = createHash('sha256').update(payload).digest('hex').slice(0, 16)
+  return `mt:records:${sheetId}:${hash}`
+}
+
+function normalizeRecordData(value: unknown): Record<string, unknown> {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    return value as Record<string, unknown>
+  }
+  if (typeof value === 'string' && value.trim()) {
+    try {
+      const parsed = JSON.parse(value)
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>
+      }
+    } catch (err) {
+      console.warn('[multitable.query-service] Failed to parse meta_records.data JSON', err)
+      return {}
+    }
+  }
+  return {}
+}
+
+function normalizePagingValue(value: unknown, field: string): number | undefined {
+  if (value == null || value === '') return undefined
+  const parsed = typeof value === 'number' ? value : Number(value)
+  if (!Number.isFinite(parsed) || parsed < 0 || !Number.isInteger(parsed)) {
+    throw new MultitableRecordValidationError(`${field} must be a non-negative integer`)
+  }
+  return parsed
+}
+
+function normalizeQueryFilters(
+  fields: Array<{ id: string; type: string; options?: Array<{ value: string }> }>,
+  filters: Record<string, MultitableRecordFilterValue> | undefined,
+): Array<{ fieldId: string; value: MultitableRecordFilterValue }> {
+  const fieldIds = new Set(fields.map((field) => field.id))
+  return Object.entries(filters ?? {}).map(([fieldId, value]) => {
+    if (!fieldIds.has(fieldId)) {
+      throw new MultitableRecordValidationError(`Unknown fieldId: ${fieldId}`)
+    }
+    if (value == null) {
+      return { fieldId, value: null }
+    }
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+      return { fieldId, value }
+    }
+    throw new MultitableRecordValidationError(`Unsupported filter value for ${fieldId}`)
+  })
+}
+
+function normalizeQueryOrder(
+  fields: Array<{ id: string; type: string; options?: Array<{ value: string }> }>,
+  orderBy: MultitableRecordQueryOrder | undefined,
+): { fieldId: string | null; direction: 'asc' | 'desc' } {
+  const direction = orderBy?.direction === 'desc' ? 'desc' : 'asc'
+  if (!orderBy?.fieldId) {
+    return { fieldId: null, direction }
+  }
+  const exists = fields.some((field) => field.id === orderBy.fieldId)
+  if (!exists) {
+    throw new MultitableRecordValidationError(`Unknown fieldId: ${orderBy.fieldId}`)
+  }
+  return { fieldId: orderBy.fieldId, direction }
+}
+
+function normalizeQuerySearch(search: unknown): string | null {
+  if (typeof search !== 'string') return null
+  const trimmed = search.trim()
+  return trimmed ? trimmed : null
+}
+
+async function loadSheetAndFields(
+  query: MultitableRecordsQueryFn,
+  sheetId: string,
+): Promise<{
+  sheet: Awaited<ReturnType<typeof loadSheetRow>>
+  fields: Awaited<ReturnType<typeof loadFieldsForSheet>>
+}> {
+  const sheet = await loadSheetRow(query, sheetId)
+  if (!sheet) {
+    throw new MultitableRecordNotFoundError(`Sheet not found: ${sheetId}`)
+  }
+  const fields = await loadFieldsForSheet({ query }, sheetId)
+  if (fields.length === 0) {
+    throw new MultitableRecordNotFoundError(`Sheet not found: ${sheetId}`)
+  }
+  return { sheet, fields }
+}
+
+function mapRecordRow(row: any): LoadedMultitableRecord {
+  return {
+    id: String(row.id),
+    sheetId: String(row.sheet_id),
+    version: Number(row.version ?? 1),
+    data: normalizeRecordData(row.data),
+  }
+}
+
+export async function listRecords(
+  input: ListMultitableRecordsInput,
+): Promise<LoadedMultitableRecord[]> {
+  return queryRecords({
+    query: input.query,
+    sheetId: input.sheetId,
+    limit: input.limit,
+    offset: input.offset,
+  })
+}
+
+export async function queryRecords(
+  input: QueryMultitableRecordsInput,
+): Promise<LoadedMultitableRecord[]> {
+  const query = input.query
+  const { fields } = await loadSheetAndFields(query, input.sheetId)
+  const filters = normalizeQueryFilters(fields, input.filters)
+  const search = normalizeQuerySearch(input.search)
+  const orderBy = normalizeQueryOrder(fields, input.orderBy)
+  const limit = normalizePagingValue(input.limit, 'limit')
+  const offset = normalizePagingValue(input.offset, 'offset')
+
+  const params: unknown[] = [input.sheetId]
+  const where: string[] = ['sheet_id = $1']
+
+  for (const filter of filters) {
+    if (filter.value === null) {
+      params.push(filter.fieldId)
+      where.push(`data -> $${params.length} IS NULL`)
+      continue
+    }
+    params.push(filter.fieldId, String(filter.value))
+    where.push(`data ->> $${params.length - 1} = $${params.length}`)
+  }
+
+  if (search) {
+    params.push(`%${search}%`)
+    where.push(`data::text ILIKE $${params.length}`)
+  }
+
+  let orderSql = 'ORDER BY id ASC'
+  if (orderBy.fieldId) {
+    params.push(orderBy.fieldId)
+    const fieldParamIndex = params.length
+    orderSql = `ORDER BY data ->> $${fieldParamIndex} ${orderBy.direction.toUpperCase()} NULLS LAST, id ASC`
+  }
+
+  if (limit !== undefined) {
+    params.push(limit)
+  }
+  const limitParamIndex = limit !== undefined ? params.length : null
+  if (offset !== undefined) {
+    params.push(offset)
+  }
+  const offsetParamIndex = offset !== undefined ? params.length : null
+
+  const sqlParts = [
+    'SELECT id, sheet_id, version, data FROM meta_records',
+    `WHERE ${where.join(' AND ')}`,
+    orderSql,
+  ]
+  if (limitParamIndex !== null) {
+    sqlParts.push(`LIMIT $${limitParamIndex}`)
+  }
+  if (offsetParamIndex !== null) {
+    sqlParts.push(`OFFSET $${offsetParamIndex}`)
+  }
+
+  const recordRes = await query(sqlParts.join(' '), params)
+  return (recordRes.rows as any[]).map(mapRecordRow)
+}
+
+/**
+ * Cursor-based pagination query.
+ *
+ * Uses keyset pagination: `WHERE (sort_column, id) > ($cursorSort, $cursorId)`.
+ * Fetches `limit + 1` rows to detect `hasMore` without a separate COUNT query.
+ */
+export async function queryRecordsWithCursor(
+  input: CursorQueryInput,
+): Promise<CursorPaginatedResult<LoadedMultitableRecord>> {
+  const query = input.query
+  const { fields } = await loadSheetAndFields(query, input.sheetId)
+  const filters = normalizeQueryFilters(fields, input.filter)
+  const orderBy = normalizeQueryOrder(fields, input.sort)
+  const limit = Math.min(Math.max(Number(input.limit) || 100, 1), 5000)
+
+  const params: unknown[] = [input.sheetId]
+  const where: string[] = ['sheet_id = $1']
+
+  for (const filter of filters) {
+    if (filter.value === null) {
+      params.push(filter.fieldId)
+      where.push(`data -> $${params.length} IS NULL`)
+      continue
+    }
+    params.push(filter.fieldId, String(filter.value))
+    where.push(`data ->> $${params.length - 1} = $${params.length}`)
+  }
+
+  const direction = orderBy.direction.toUpperCase()
+  let sortExpr = 'id'
+  if (orderBy.fieldId) {
+    params.push(orderBy.fieldId)
+    sortExpr = `data ->> $${params.length}`
+  }
+
+  if (input.cursor) {
+    const decoded = decodeRecordCursor(input.cursor)
+    const op = direction === 'DESC' ? '<' : '>'
+    params.push(decoded.sortValue, decoded.id)
+    if (orderBy.fieldId) {
+      where.push(
+        `(${sortExpr}, id) ${op} ($${params.length - 1}, $${params.length})`,
+      )
+    } else {
+      where.push(`id ${op} $${params.length}`)
+    }
+  }
+
+  params.push(limit + 1)
+  const fetchLimitIndex = params.length
+
+  const orderSql = orderBy.fieldId
+    ? `ORDER BY ${sortExpr} ${direction} NULLS LAST, id ASC`
+    : `ORDER BY id ${direction}`
+
+  const sql = [
+    'SELECT id, sheet_id, version, data FROM meta_records',
+    `WHERE ${where.join(' AND ')}`,
+    orderSql,
+    `LIMIT $${fetchLimitIndex}`,
+  ].join(' ')
+
+  const recordRes = await query(sql, params)
+  const rows = (recordRes.rows as any[]).map(mapRecordRow)
+
+  const hasMore = rows.length > limit
+  const items = hasMore ? rows.slice(0, limit) : rows
+
+  let nextCursor: string | null = null
+  if (hasMore && items.length > 0) {
+    const last = items[items.length - 1]
+    const sortValue = orderBy.fieldId
+      ? String((last.data as Record<string, unknown>)[orderBy.fieldId] ?? '')
+      : last.id
+    nextCursor = encodeRecordCursor(last.id, sortValue)
+  }
+
+  return { items, nextCursor, hasMore }
+}

--- a/packages/core-backend/src/multitable/record-errors.ts
+++ b/packages/core-backend/src/multitable/record-errors.ts
@@ -1,0 +1,7 @@
+export class MultitableRecordValidationError extends Error {
+  code = 'VALIDATION_ERROR'
+}
+
+export class MultitableRecordNotFoundError extends Error {
+  code = 'NOT_FOUND'
+}

--- a/packages/core-backend/src/multitable/records.ts
+++ b/packages/core-backend/src/multitable/records.ts
@@ -1,20 +1,36 @@
-import { createHash, randomUUID } from 'crypto'
+import { randomUUID } from 'crypto'
 
 import { fieldTypeRegistry } from './field-type-registry'
 import { loadFieldsForSheet, loadSheetRow } from './loaders'
+import { MultitableRecordNotFoundError, MultitableRecordValidationError } from './record-errors'
+import {
+  listRecords as listRecordsViaQueryService,
+  queryRecords as queryRecordsViaQueryService,
+  queryRecordsWithCursor as queryRecordsWithCursorViaQueryService,
+  type CursorPaginatedResult,
+  type CursorQueryInput,
+  type ListMultitableRecordsInput,
+  type LoadedMultitableRecord,
+  type MultitableRecordsQueryFn,
+  type QueryMultitableRecordsInput,
+} from './query-service'
 
-export type MultitableRecordsQueryFn = (
-  sql: string,
-  params?: unknown[],
-) => Promise<{ rows: unknown[]; rowCount?: number | null }>
-
-export class MultitableRecordValidationError extends Error {
-  code = 'VALIDATION_ERROR'
-}
-
-export class MultitableRecordNotFoundError extends Error {
-  code = 'NOT_FOUND'
-}
+export { MultitableRecordNotFoundError, MultitableRecordValidationError } from './record-errors'
+export {
+  buildRecordsCacheKey,
+  decodeRecordCursor,
+  encodeRecordCursor,
+} from './query-service'
+export type {
+  CursorPaginatedResult,
+  CursorQueryInput,
+  ListMultitableRecordsInput,
+  LoadedMultitableRecord,
+  MultitableRecordFilterValue,
+  MultitableRecordQueryOrder,
+  MultitableRecordsQueryFn,
+  QueryMultitableRecordsInput,
+} from './query-service'
 
 export type CreateMultitableRecordInput = {
   query: MultitableRecordsQueryFn
@@ -26,30 +42,6 @@ export type GetMultitableRecordInput = {
   query: MultitableRecordsQueryFn
   sheetId: string
   recordId: string
-}
-
-export type MultitableRecordFilterValue = string | number | boolean | null
-
-export type MultitableRecordQueryOrder = {
-  fieldId?: string
-  direction?: 'asc' | 'desc'
-}
-
-export type ListMultitableRecordsInput = {
-  query: MultitableRecordsQueryFn
-  sheetId: string
-  limit?: number
-  offset?: number
-}
-
-export type QueryMultitableRecordsInput = {
-  query: MultitableRecordsQueryFn
-  sheetId: string
-  filters?: Record<string, MultitableRecordFilterValue>
-  search?: string
-  orderBy?: MultitableRecordQueryOrder
-  limit?: number
-  offset?: number
 }
 
 export type DeleteMultitableRecordInput = {
@@ -72,69 +64,10 @@ export type CreatedMultitableRecord = {
   data: Record<string, unknown>
 }
 
-export type LoadedMultitableRecord = {
-  id: string
-  sheetId: string
-  version: number
-  data: Record<string, unknown>
-}
-
 export type DeletedMultitableRecord = {
   id: string
   sheetId: string
   version: number
-}
-
-// ---------------------------------------------------------------------------
-// Cursor-based pagination types and helpers
-// ---------------------------------------------------------------------------
-
-export type CursorPaginatedResult<T> = {
-  items: T[]
-  nextCursor: string | null
-  hasMore: boolean
-}
-
-export type CursorQueryInput = {
-  query: MultitableRecordsQueryFn
-  sheetId: string
-  cursor?: string
-  limit?: number
-  sort?: MultitableRecordQueryOrder
-  filter?: Record<string, MultitableRecordFilterValue>
-}
-
-export function encodeRecordCursor(id: string, sortValue: string): string {
-  return Buffer.from(JSON.stringify({ id, sv: sortValue })).toString('base64url')
-}
-
-export function decodeRecordCursor(cursor: string): { id: string; sortValue: string } {
-  try {
-    const parsed = JSON.parse(Buffer.from(cursor, 'base64url').toString('utf8'))
-    if (typeof parsed.id !== 'string' || typeof parsed.sv !== 'string') {
-      throw new MultitableRecordValidationError('Invalid cursor format')
-    }
-    return { id: parsed.id, sortValue: parsed.sv }
-  } catch (err) {
-    if (err instanceof MultitableRecordValidationError) throw err
-    throw new MultitableRecordValidationError('Invalid cursor format')
-  }
-}
-
-/**
- * Build a deterministic cache key hash from query parameters.
- */
-export function buildRecordsCacheKey(
-  sheetId: string,
-  params: { filter?: Record<string, MultitableRecordFilterValue>; sort?: MultitableRecordQueryOrder; cursor?: string },
-): string {
-  const payload = JSON.stringify({
-    f: params.filter ?? {},
-    s: params.sort ?? {},
-    c: params.cursor ?? '',
-  })
-  const hash = createHash('sha256').update(payload).digest('hex').slice(0, 16)
-  return `mt:records:${sheetId}:${hash}`
 }
 
 type LoadedMultitableField = Awaited<ReturnType<typeof loadFieldsForSheet>>[number]
@@ -395,55 +328,6 @@ async function replaceRecordLinks(
   }
 }
 
-function normalizePagingValue(value: unknown, field: string): number | undefined {
-  if (value == null || value === '') return undefined
-  const parsed = typeof value === 'number' ? value : Number(value)
-  if (!Number.isFinite(parsed) || parsed < 0 || !Number.isInteger(parsed)) {
-    throw new MultitableRecordValidationError(`${field} must be a non-negative integer`)
-  }
-  return parsed
-}
-
-function normalizeQueryFilters(
-  fields: Array<{ id: string; type: string; options?: Array<{ value: string }> }>,
-  filters: Record<string, MultitableRecordFilterValue> | undefined,
-): Array<{ fieldId: string; value: MultitableRecordFilterValue }> {
-  const fieldIds = new Set(fields.map((field) => field.id))
-  return Object.entries(filters ?? {}).map(([fieldId, value]) => {
-    if (!fieldIds.has(fieldId)) {
-      throw new MultitableRecordValidationError(`Unknown fieldId: ${fieldId}`)
-    }
-    if (value == null) {
-      return { fieldId, value: null }
-    }
-    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
-      return { fieldId, value }
-    }
-    throw new MultitableRecordValidationError(`Unsupported filter value for ${fieldId}`)
-  })
-}
-
-function normalizeQueryOrder(
-  fields: Array<{ id: string; type: string; options?: Array<{ value: string }> }>,
-  orderBy: MultitableRecordQueryOrder | undefined,
-): { fieldId: string | null; direction: 'asc' | 'desc' } {
-  const direction = orderBy?.direction === 'desc' ? 'desc' : 'asc'
-  if (!orderBy?.fieldId) {
-    return { fieldId: null, direction }
-  }
-  const exists = fields.some((field) => field.id === orderBy.fieldId)
-  if (!exists) {
-    throw new MultitableRecordValidationError(`Unknown fieldId: ${orderBy.fieldId}`)
-  }
-  return { fieldId: orderBy.fieldId, direction }
-}
-
-function normalizeQuerySearch(search: unknown): string | null {
-  if (typeof search !== 'string') return null
-  const trimmed = search.trim()
-  return trimmed ? trimmed : null
-}
-
 async function loadSheetAndFields(
   query: MultitableRecordsQueryFn,
   sheetId: string,
@@ -484,166 +368,19 @@ export async function getRecord(
 export async function listRecords(
   input: ListMultitableRecordsInput,
 ): Promise<LoadedMultitableRecord[]> {
-  return queryRecords({
-    query: input.query,
-    sheetId: input.sheetId,
-    limit: input.limit,
-    offset: input.offset,
-  })
+  return listRecordsViaQueryService(input)
 }
 
 export async function queryRecords(
   input: QueryMultitableRecordsInput,
 ): Promise<LoadedMultitableRecord[]> {
-  const query = input.query
-  const { fields } = await loadSheetAndFields(query, input.sheetId)
-  const filters = normalizeQueryFilters(fields, input.filters)
-  const search = normalizeQuerySearch(input.search)
-  const orderBy = normalizeQueryOrder(fields, input.orderBy)
-  const limit = normalizePagingValue(input.limit, 'limit')
-  const offset = normalizePagingValue(input.offset, 'offset')
-
-  const params: unknown[] = [input.sheetId]
-  const where: string[] = ['sheet_id = $1']
-
-  for (const filter of filters) {
-    if (filter.value === null) {
-      params.push(filter.fieldId)
-      where.push(`data -> $${params.length} IS NULL`)
-      continue
-    }
-    params.push(filter.fieldId, String(filter.value))
-    where.push(`data ->> $${params.length - 1} = $${params.length}`)
-  }
-
-  if (search) {
-    params.push(`%${search}%`)
-    where.push(`data::text ILIKE $${params.length}`)
-  }
-
-  let orderSql = 'ORDER BY id ASC'
-  if (orderBy.fieldId) {
-    params.push(orderBy.fieldId)
-    const fieldParamIndex = params.length
-    orderSql = `ORDER BY data ->> $${fieldParamIndex} ${orderBy.direction.toUpperCase()} NULLS LAST, id ASC`
-  }
-
-  if (limit !== undefined) {
-    params.push(limit)
-  }
-  const limitParamIndex = limit !== undefined ? params.length : null
-  if (offset !== undefined) {
-    params.push(offset)
-  }
-  const offsetParamIndex = offset !== undefined ? params.length : null
-
-  const sqlParts = [
-    'SELECT id, sheet_id, version, data FROM meta_records',
-    `WHERE ${where.join(' AND ')}`,
-    orderSql,
-  ]
-  if (limitParamIndex !== null) {
-    sqlParts.push(`LIMIT $${limitParamIndex}`)
-  }
-  if (offsetParamIndex !== null) {
-    sqlParts.push(`OFFSET $${offsetParamIndex}`)
-  }
-
-  const recordRes = await query(sqlParts.join(' '), params)
-  return (recordRes.rows as any[]).map((row) => ({
-    id: String(row.id),
-    sheetId: String(row.sheet_id),
-    version: Number(row.version ?? 1),
-    data: normalizeRecordData(row.data),
-  }))
+  return queryRecordsViaQueryService(input)
 }
 
-/**
- * Cursor-based pagination query.
- *
- * Uses keyset pagination: `WHERE (sort_column, id) > ($cursorSort, $cursorId)`.
- * Fetches `limit + 1` rows to detect `hasMore` without a separate COUNT query.
- */
 export async function queryRecordsWithCursor(
   input: CursorQueryInput,
 ): Promise<CursorPaginatedResult<LoadedMultitableRecord>> {
-  const query = input.query
-  const { fields } = await loadSheetAndFields(query, input.sheetId)
-  const filters = normalizeQueryFilters(fields, input.filter)
-  const orderBy = normalizeQueryOrder(fields, input.sort)
-  const limit = Math.min(Math.max(Number(input.limit) || 100, 1), 5000)
-
-  const params: unknown[] = [input.sheetId]
-  const where: string[] = ['sheet_id = $1']
-
-  for (const filter of filters) {
-    if (filter.value === null) {
-      params.push(filter.fieldId)
-      where.push(`data -> $${params.length} IS NULL`)
-      continue
-    }
-    params.push(filter.fieldId, String(filter.value))
-    where.push(`data ->> $${params.length - 1} = $${params.length}`)
-  }
-
-  // Determine sort column expression and direction
-  const direction = orderBy.direction.toUpperCase()
-  let sortExpr = 'id'
-  if (orderBy.fieldId) {
-    params.push(orderBy.fieldId)
-    sortExpr = `data ->> $${params.length}`
-  }
-
-  // Apply cursor keyset condition
-  if (input.cursor) {
-    const decoded = decodeRecordCursor(input.cursor)
-    const op = direction === 'DESC' ? '<' : '>'
-    params.push(decoded.sortValue, decoded.id)
-    if (orderBy.fieldId) {
-      where.push(
-        `(${sortExpr}, id) ${op} ($${params.length - 1}, $${params.length})`,
-      )
-    } else {
-      where.push(`id ${op} $${params.length}`)
-    }
-  }
-
-  // Fetch limit + 1 to detect hasMore
-  params.push(limit + 1)
-  const fetchLimitIndex = params.length
-
-  const orderSql = orderBy.fieldId
-    ? `ORDER BY ${sortExpr} ${direction} NULLS LAST, id ASC`
-    : `ORDER BY id ${direction}`
-
-  const sql = [
-    'SELECT id, sheet_id, version, data FROM meta_records',
-    `WHERE ${where.join(' AND ')}`,
-    orderSql,
-    `LIMIT $${fetchLimitIndex}`,
-  ].join(' ')
-
-  const recordRes = await query(sql, params)
-  const rows = (recordRes.rows as any[]).map((row) => ({
-    id: String(row.id),
-    sheetId: String(row.sheet_id),
-    version: Number(row.version ?? 1),
-    data: normalizeRecordData(row.data),
-  }))
-
-  const hasMore = rows.length > limit
-  const items = hasMore ? rows.slice(0, limit) : rows
-
-  let nextCursor: string | null = null
-  if (hasMore && items.length > 0) {
-    const last = items[items.length - 1]
-    const sortValue = orderBy.fieldId
-      ? String((last.data as Record<string, unknown>)[orderBy.fieldId] ?? '')
-      : last.id
-    nextCursor = encodeRecordCursor(last.id, sortValue)
-  }
-
-  return { items, nextCursor, hasMore }
+  return queryRecordsWithCursorViaQueryService(input)
 }
 
 export async function patchRecord(

--- a/packages/core-backend/tests/unit/multitable-query-service.test.ts
+++ b/packages/core-backend/tests/unit/multitable-query-service.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildRecordsCacheKey,
+  decodeRecordCursor,
+  encodeRecordCursor,
+  listRecords,
+  queryRecords,
+  queryRecordsWithCursor,
+  type MultitableRecordsQueryFn,
+} from '../../src/multitable/query-service'
+
+function createQuery(rows: any[] = []): {
+  query: MultitableRecordsQueryFn
+  calls: Array<{ sql: string; params?: unknown[] }>
+} {
+  const calls: Array<{ sql: string; params?: unknown[] }> = []
+  const query: MultitableRecordsQueryFn = async (sql, params) => {
+    calls.push({ sql, params })
+    if (sql.includes('FROM meta_sheets')) {
+      return { rows: [{ id: 'sheet_1', name: 'Tickets' }], rowCount: 1 }
+    }
+    if (sql.includes('FROM meta_fields')) {
+      return {
+        rows: [
+          { id: 'title', sheet_id: 'sheet_1', name: 'Title', type: 'string', property: {}, order: 1 },
+          { id: 'status', sheet_id: 'sheet_1', name: 'Status', type: 'select', property: {}, order: 2 },
+        ],
+        rowCount: 2,
+      }
+    }
+    return { rows, rowCount: rows.length }
+  }
+  return { query, calls }
+}
+
+describe('multitable query-service', () => {
+  it('keeps cursor and cache helpers available from the query seam', () => {
+    const cursor = encodeRecordCursor('rec_1', 'alpha')
+    expect(decodeRecordCursor(cursor)).toEqual({ id: 'rec_1', sortValue: 'alpha' })
+    expect(buildRecordsCacheKey('sheet_1', { filter: { status: 'open' }, cursor }))
+      .toMatch(/^mt:records:sheet_1:[a-f0-9]{16}$/)
+  })
+
+  it('lists records through the extracted query service', async () => {
+    const { query } = createQuery([
+      { id: 'rec_1', sheet_id: 'sheet_1', version: 3, data: { title: 'A' } },
+    ])
+
+    await expect(listRecords({ query, sheetId: 'sheet_1' })).resolves.toEqual([
+      { id: 'rec_1', sheetId: 'sheet_1', version: 3, data: { title: 'A' } },
+    ])
+  })
+
+  it('builds filter/search/order SQL without touching write helpers', async () => {
+    const { query, calls } = createQuery([
+      { id: 'rec_1', sheet_id: 'sheet_1', version: 1, data: JSON.stringify({ title: 'A', status: 'open' }) },
+    ])
+
+    await queryRecords({
+      query,
+      sheetId: 'sheet_1',
+      filters: { status: 'open' },
+      search: 'alpha',
+      orderBy: { fieldId: 'title', direction: 'desc' },
+      limit: 10,
+      offset: 5,
+    })
+
+    const recordQuery = calls.at(-1)
+    expect(recordQuery?.sql).toContain('FROM meta_records')
+    expect(recordQuery?.sql).toContain('data ->> $2 = $3')
+    expect(recordQuery?.sql).toContain('data::text ILIKE $4')
+    expect(recordQuery?.sql).toContain('ORDER BY data ->> $5 DESC NULLS LAST, id ASC')
+    expect(recordQuery?.sql).toContain('LIMIT $6')
+    expect(recordQuery?.sql).toContain('OFFSET $7')
+    expect(recordQuery?.params).toEqual(['sheet_1', 'status', 'open', '%alpha%', 'title', 10, 5])
+  })
+
+  it('returns cursor pagination metadata from the query seam', async () => {
+    const { query } = createQuery([
+      { id: 'rec_1', sheet_id: 'sheet_1', version: 1, data: { title: 'A' } },
+      { id: 'rec_2', sheet_id: 'sheet_1', version: 1, data: { title: 'B' } },
+    ])
+
+    const result = await queryRecordsWithCursor({ query, sheetId: 'sheet_1', limit: 1 })
+    expect(result.items).toEqual([
+      { id: 'rec_1', sheetId: 'sheet_1', version: 1, data: { title: 'A' } },
+    ])
+    expect(result.hasMore).toBe(true)
+    expect(result.nextCursor).toBe(encodeRecordCursor('rec_1', 'rec_1'))
+  })
+})


### PR DESCRIPTION
## Summary\n- Extract multitable record read/query helpers from records.ts into multitable/query-service.ts\n- Keep records.ts public API compatible via wrappers/re-exports\n- Move shared record errors to record-errors.ts\n- Add focused query-service coverage and development/verification docs\n\n## Verification\n- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/multitable-query-service.test.ts tests/unit/multitable-records.test.ts tests/unit/multitable-cursor-pagination.test.ts tests/unit/multitable-plugin-scope.test.ts --reporter=dot\n- pnpm --filter @metasheet/core-backend exec tsc --noEmit\n\nResult: 36/36 focused tests passed; backend typecheck exit 0.\n\nDocs:\n- docs/development/multitable-m3-query-service-development-20260423.md\n- docs/development/multitable-m3-query-service-verification-20260423.md