### PR TITLE
feat(approval): sync pending counts over websocket

### DIFF
--- a/apps/web/src/approvals/useApprovalCountsRealtime.ts
+++ b/apps/web/src/approvals/useApprovalCountsRealtime.ts
@@ -1,0 +1,126 @@
+import { onBeforeUnmount, onMounted } from 'vue'
+import { io, type Socket } from 'socket.io-client'
+import { useAuth } from '../composables/useAuth'
+import { getApiBase } from '../utils/api'
+
+export type ApprovalCountSourceSystem = 'all' | 'platform' | 'plm'
+
+export interface ApprovalCounts {
+  count: number
+  unreadCount: number
+}
+
+export interface ApprovalCountsUpdatedPayload extends ApprovalCounts {
+  sourceSystem?: ApprovalCountSourceSystem
+  countsBySourceSystem?: Partial<Record<ApprovalCountSourceSystem, ApprovalCounts>>
+  reason?: string
+  updatedAt?: string
+}
+
+interface UseApprovalCountsRealtimeOptions {
+  onCountsUpdated: (payload: ApprovalCountsUpdatedPayload) => void
+}
+
+function stripApiSuffix(pathname: string): string {
+  if (pathname === '/api') return '/'
+  if (pathname.endsWith('/api')) return pathname.slice(0, -4) || '/'
+  return pathname
+}
+
+export function resolveApprovalCountsRealtimeBaseUrl(apiBase = getApiBase()): string {
+  const fallbackOrigin = typeof window !== 'undefined' ? window.location.origin : 'http://localhost:8900'
+  const url = new URL(apiBase, fallbackOrigin)
+  url.pathname = stripApiSuffix(url.pathname)
+  return url.toString().replace(/\/$/, '')
+}
+
+function normalizeCount(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : null
+}
+
+function normalizeCounts(value: unknown): ApprovalCounts | null {
+  if (!value || typeof value !== 'object') return null
+  const record = value as Record<string, unknown>
+  const count = normalizeCount(record.count)
+  const unreadCount = normalizeCount(record.unreadCount)
+  if (count === null || unreadCount === null) return null
+  return { count, unreadCount }
+}
+
+function normalizePayload(payload: unknown): ApprovalCountsUpdatedPayload | null {
+  const root = normalizeCounts(payload)
+  if (!root || !payload || typeof payload !== 'object') return null
+  const record = payload as Record<string, unknown>
+  const rawBySource = record.countsBySourceSystem && typeof record.countsBySourceSystem === 'object'
+    ? record.countsBySourceSystem as Record<string, unknown>
+    : {}
+  const countsBySourceSystem: Partial<Record<ApprovalCountSourceSystem, ApprovalCounts>> = {}
+  for (const source of ['all', 'platform', 'plm'] as const) {
+    const counts = normalizeCounts(rawBySource[source])
+    if (counts) countsBySourceSystem[source] = counts
+  }
+  return {
+    ...root,
+    sourceSystem: record.sourceSystem === 'platform' || record.sourceSystem === 'plm' ? record.sourceSystem : 'all',
+    countsBySourceSystem,
+    reason: typeof record.reason === 'string' ? record.reason : undefined,
+    updatedAt: typeof record.updatedAt === 'string' ? record.updatedAt : undefined,
+  }
+}
+
+export function useApprovalCountsRealtime(options: UseApprovalCountsRealtimeOptions) {
+  const auth = useAuth()
+  let socket: Socket | null = null
+  let disconnected = false
+  let connectionPromise: Promise<Socket | null> | null = null
+
+  function cleanupSocket() {
+    socket?.disconnect()
+    socket = null
+    connectionPromise = null
+  }
+
+  async function ensureSocket(): Promise<Socket | null> {
+    if (socket) return socket
+    if (connectionPromise) return connectionPromise
+
+    connectionPromise = (async () => {
+      try {
+        const userId = await auth.getCurrentUserId().catch(() => null)
+        if (disconnected || !userId) return null
+
+        const nextSocket = io(resolveApprovalCountsRealtimeBaseUrl(), {
+          path: '/socket.io',
+          transports: ['websocket', 'polling'],
+          query: { userId },
+        })
+
+        nextSocket.on('approval:counts-updated', (payload: unknown) => {
+          const normalized = normalizePayload(payload)
+          if (normalized) options.onCountsUpdated(normalized)
+        })
+
+        socket = nextSocket
+        return nextSocket
+      } finally {
+        connectionPromise = null
+      }
+    })()
+
+    return connectionPromise
+  }
+
+  onMounted(() => {
+    if (import.meta.env.MODE !== 'test') void ensureSocket()
+  })
+
+  onBeforeUnmount(() => {
+    disconnected = true
+    cleanupSocket()
+  })
+
+  return {
+    reconnect: ensureSocket,
+    disconnect: cleanupSocket,
+  }
+}

--- a/apps/web/src/approvals/useApprovalCountsRealtime.ts
+++ b/apps/web/src/approvals/useApprovalCountsRealtime.ts
@@ -86,13 +86,13 @@ export function useApprovalCountsRealtime(options: UseApprovalCountsRealtimeOpti
 
     connectionPromise = (async () => {
       try {
-        const userId = await auth.getCurrentUserId().catch(() => null)
-        if (disconnected || !userId) return null
+        const token = auth.getToken()
+        if (disconnected || !token) return null
 
         const nextSocket = io(resolveApprovalCountsRealtimeBaseUrl(), {
           path: '/socket.io',
           transports: ['websocket', 'polling'],
-          query: { userId },
+          auth: { token },
         })
 
         nextSocket.on('approval:counts-updated', (payload: unknown) => {

--- a/apps/web/src/views/approval/ApprovalCenterView.vue
+++ b/apps/web/src/views/approval/ApprovalCenterView.vue
@@ -302,6 +302,7 @@ import type { UnifiedApprovalDTO, ApprovalStatus } from '../../types/approval'
 import { useApprovalStore } from '../../approvals/store'
 import { useApprovalPermissions } from '../../approvals/permissions'
 import { getPendingCount, markAllApprovalsRead } from '../../approvals/api'
+import { useApprovalCountsRealtime, type ApprovalCountsUpdatedPayload } from '../../approvals/useApprovalCountsRealtime'
 
 const router = useRouter()
 const store = useApprovalStore()
@@ -313,11 +314,15 @@ const { canWrite } = useApprovalPermissions()
 // tooltip so "待办 X / 其中 Y 未读" stays discoverable.
 const pendingBadgeCount = ref(0)
 const pendingTotalCount = ref(0)
+function applyPendingBadgeCount(count: number, unreadCount: number): void {
+  pendingBadgeCount.value = Number.isFinite(unreadCount) ? unreadCount : 0
+  pendingTotalCount.value = Number.isFinite(count) ? count : 0
+}
+
 async function refreshPendingBadgeCount(): Promise<void> {
   try {
     const result = await getPendingCount(sourceSystemFilter.value)
-    pendingBadgeCount.value = Number.isFinite(result.unreadCount) ? result.unreadCount : 0
-    pendingTotalCount.value = Number.isFinite(result.count) ? result.count : 0
+    applyPendingBadgeCount(result.count, result.unreadCount)
   } catch {
     // Badge is decorative — do not surface errors here; the tab itself
     // surfaces list-load failures via `store.error`.
@@ -325,6 +330,15 @@ async function refreshPendingBadgeCount(): Promise<void> {
     pendingTotalCount.value = 0
   }
 }
+
+function handleRealtimeCountsUpdated(payload: ApprovalCountsUpdatedPayload): void {
+  const scopedCounts = payload.countsBySourceSystem?.[sourceSystemFilter.value] ?? payload
+  applyPendingBadgeCount(scopedCounts.count, scopedCounts.unreadCount)
+}
+
+useApprovalCountsRealtime({
+  onCountsUpdated: handleRealtimeCountsUpdated,
+})
 
 // Wave 2 WP3 slice 2 — bulk 全部标记已读. Honours the current sourceSystem tab
 // so the button's effect matches the tooltip the user is looking at.

--- a/apps/web/tests/approvalCountsRealtime.spec.ts
+++ b/apps/web/tests/approvalCountsRealtime.spec.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, nextTick, type App as VueApp } from 'vue'
+
+const socketHandlers = new Map<string, (payload?: unknown) => void>()
+const disconnectSpy = vi.fn()
+const ioSpy = vi.fn(() => ({
+  on: (event: string, handler: (payload?: unknown) => void) => {
+    socketHandlers.set(event, handler)
+  },
+  disconnect: disconnectSpy,
+}))
+
+vi.mock('socket.io-client', () => ({
+  io: ioSpy,
+}))
+
+vi.mock('../src/composables/useAuth', () => ({
+  useAuth: () => ({
+    getCurrentUserId: vi.fn().mockResolvedValue('approval-user-1'),
+  }),
+}))
+
+describe('useApprovalCountsRealtime', () => {
+  let app: VueApp<Element> | null = null
+  let host: HTMLDivElement | null = null
+
+  afterEach(() => {
+    app?.unmount()
+    host?.remove()
+    app = null
+    host = null
+    socketHandlers.clear()
+    ioSpy.mockClear()
+    disconnectSpy.mockClear()
+  })
+
+  it('subscribes to approval:counts-updated and normalizes scoped counts', async () => {
+    const received = vi.fn()
+    const { useApprovalCountsRealtime } = await import('../src/approvals/useApprovalCountsRealtime')
+    let reconnect: (() => Promise<unknown>) | null = null
+    const Component = defineComponent({
+      setup() {
+        reconnect = useApprovalCountsRealtime({ onCountsUpdated: received }).reconnect
+        return () => h('div')
+      },
+    })
+
+    host = document.createElement('div')
+    document.body.appendChild(host)
+    app = createApp(Component)
+    app.mount(host)
+    await nextTick()
+    await reconnect?.()
+
+    expect(ioSpy).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({
+      path: '/socket.io',
+      query: { userId: 'approval-user-1' },
+    }))
+
+    socketHandlers.get('approval:counts-updated')?.({
+      count: 5,
+      unreadCount: 3,
+      countsBySourceSystem: {
+        all: { count: 5, unreadCount: 3 },
+        platform: { count: 2, unreadCount: 1 },
+        plm: { count: 3, unreadCount: 2 },
+      },
+      reason: 'mark-read',
+    })
+
+    expect(received).toHaveBeenCalledWith(expect.objectContaining({
+      count: 5,
+      unreadCount: 3,
+      countsBySourceSystem: expect.objectContaining({
+        platform: { count: 2, unreadCount: 1 },
+      }),
+      reason: 'mark-read',
+    }))
+  })
+})

--- a/apps/web/tests/approvalCountsRealtime.spec.ts
+++ b/apps/web/tests/approvalCountsRealtime.spec.ts
@@ -16,7 +16,7 @@ vi.mock('socket.io-client', () => ({
 
 vi.mock('../src/composables/useAuth', () => ({
   useAuth: () => ({
-    getCurrentUserId: vi.fn().mockResolvedValue('approval-user-1'),
+    getToken: vi.fn().mockReturnValue('jwt-token'),
   }),
 }))
 
@@ -54,7 +54,7 @@ describe('useApprovalCountsRealtime', () => {
 
     expect(ioSpy).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({
       path: '/socket.io',
-      query: { userId: 'approval-user-1' },
+      auth: { token: 'jwt-token' },
     }))
 
     socketHandlers.get('approval:counts-updated')?.({

--- a/docs/development/approval-wave2-wp3-realtime-count-development-20260423.md
+++ b/docs/development/approval-wave2-wp3-realtime-count-development-20260423.md
@@ -1,0 +1,72 @@
+# Approval Wave 2 WP3 slice 3 — realtime pending count development
+
+Date: 2026-04-23
+Branch: `codex/approval-wave2-wp3-realtime-count-20260423`
+Base: `origin/main@6a677f9c3`
+
+## Scope
+
+This slice adds realtime delivery for approval pending/unread counts while
+keeping the existing REST refresh path intact.
+
+Events that now trigger count refresh pushes:
+
+- `mark-read`
+- `mark-all-read`
+- `remind`
+- approval action/state paths that can change pending assignments
+
+## Backend Design
+
+`packages/core-backend/src/services/approval-realtime.ts` centralizes count
+payload construction:
+
+- computes `count` and `unreadCount`
+- includes snapshots for `all`, `platform`, and `plm`
+- publishes `approval:counts-updated`
+- suppresses publish failures so approval writes remain authoritative
+
+The route layer calls the publisher only after the relevant DB operation
+succeeds.
+
+## Authenticated Socket Room
+
+Approval counts are user-specific. The implementation intentionally does not
+publish to the legacy naked `query.userId` room.
+
+`CollabService` now also supports an authenticated user room:
+
+- frontend sends JWT via `handshake.auth.token`
+- backend verifies the token with `authService.verifyToken`
+- socket joins `auth-user:<userId>`
+- approval realtime publisher emits only to that authenticated room
+
+This preserves existing legacy socket behavior for other consumers while
+protecting approval count updates from forged `query.userId` subscriptions.
+
+## Frontend Design
+
+`apps/web/src/approvals/useApprovalCountsRealtime.ts` owns the socket lifecycle.
+
+`ApprovalCenterView` continues to fetch counts through REST on mount, tab
+changes, source-system changes, and bulk read actions. Realtime pushes only
+update the badge state; socket failures do not surface to the user.
+
+## Files
+
+- `packages/core-backend/src/services/approval-realtime.ts`
+- `packages/core-backend/src/services/CollabService.ts`
+- `packages/core-backend/src/routes/approvals.ts`
+- `packages/core-backend/tests/unit/approval-realtime.test.ts`
+- `apps/web/src/approvals/useApprovalCountsRealtime.ts`
+- `apps/web/src/views/approval/ApprovalCenterView.vue`
+- `apps/web/tests/approvalCountsRealtime.spec.ts`
+- `docs/development/approval-wave2-wp3-realtime-count-development-20260423.md`
+- `docs/development/wp3-realtime-count-verification.md`
+
+## Non-goals
+
+- No Redis/socket clustering changes.
+- No realtime delivery guarantee or replay queue. REST remains the recovery
+  path.
+- No complex role-recipient expansion beyond the count computation query.

--- a/docs/development/approval-wave2-wp3-realtime-count-development-20260423.md
+++ b/docs/development/approval-wave2-wp3-realtime-count-development-20260423.md
@@ -37,12 +37,15 @@ publish to the legacy naked `query.userId` room.
 `CollabService` now also supports an authenticated user room:
 
 - frontend sends JWT via `handshake.auth.token`
-- backend verifies the token with `authService.verifyToken`
+- backend verifies the token with a lazy `authService.verifyToken` import
 - socket joins `auth-user:<userId>`
 - approval realtime publisher emits only to that authenticated room
 
 This preserves existing legacy socket behavior for other consumers while
 protecting approval count updates from forged `query.userId` subscriptions.
+The auth service import is intentionally lazy because `AuthService` pulls in
+RBAC/metrics modules; importing it at `CollabService` module load time can
+double-register global Prometheus metrics during parallel test collection.
 
 ## Frontend Design
 
@@ -58,6 +61,8 @@ update the badge state; socket failures do not surface to the user.
 - `packages/core-backend/src/services/CollabService.ts`
 - `packages/core-backend/src/routes/approvals.ts`
 - `packages/core-backend/tests/unit/approval-realtime.test.ts`
+- `packages/core-backend/tests/unit/approvals-routes.test.ts`
+- `packages/core-backend/tests/unit/approvals-bridge-routes.test.ts`
 - `apps/web/src/approvals/useApprovalCountsRealtime.ts`
 - `apps/web/src/views/approval/ApprovalCenterView.vue`
 - `apps/web/tests/approvalCountsRealtime.spec.ts`

--- a/docs/development/wp3-realtime-count-verification.md
+++ b/docs/development/wp3-realtime-count-verification.md
@@ -1,11 +1,18 @@
-# WP3 Realtime Approval Count Verification
+# Approval Wave 2 WP3 slice 3 — realtime approval count verification
+
+Date: 2026-04-23
+Branch: `codex/approval-wave2-wp3-realtime-count-20260423`
+Base: `origin/main@6a677f9c3`
 
 Approval Wave 2 WP3 slice 3 adds Socket.IO delivery for approval pending/unread badge updates.
 
 ## Backend contract
 
 - Event: `approval:counts-updated`
-- Target: current user's Socket.IO user room, using the existing `handshake.query.userId` room join in `CollabService`
+- Target: current user's authenticated Socket.IO room
+  (`auth-user:<userId>`). The frontend sends the JWT in `handshake.auth.token`;
+  `CollabService` verifies it before joining the authenticated room. This avoids
+  using the legacy naked `handshake.query.userId` room for approval count data.
 - Payload:
   - `count` / `unreadCount` for `sourceSystem=all`
   - `countsBySourceSystem.all|platform|plm` for filtered approval center tabs
@@ -22,9 +29,22 @@ The router publishes after successful `mark-read`, `mark-all-read`, `remind`, an
 ```bash
 pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-realtime.test.ts
 pnpm --filter @metasheet/web exec vitest run tests/approvalCountsRealtime.spec.ts tests/approvalCenterUnreadBadge.spec.ts --watch=false
-pnpm --filter @metasheet/core-backend type-check
-pnpm --filter @metasheet/web type-check
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
 ```
+
+## Results
+
+- `approval-realtime.test.ts`: `3/3` passed.
+- `approvalCountsRealtime.spec.ts`: `1/1` passed.
+- `approvalCenterUnreadBadge.spec.ts`: `7/7` passed.
+- Backend `tsc --noEmit`: exit `0`.
+- Frontend `vue-tsc -b --noEmit`: exit `0`.
+
+Expected test noise:
+
+- `approvalCenterUnreadBadge.spec.ts` intentionally logs one rejected
+  `mark-read` request to prove the detail view does not surface an error toast.
 
 Manual smoke:
 
@@ -32,4 +52,3 @@ Manual smoke:
 2. Open another session as the requester, click `催办`, and confirm the assignee session receives a badge update without refresh.
 3. Open an approval detail as the assignee and confirm `mark-read` drops the unread badge in the approval center session.
 4. Disconnect the socket in devtools and confirm tab switches still refresh badge counts via REST.
-

--- a/docs/development/wp3-realtime-count-verification.md
+++ b/docs/development/wp3-realtime-count-verification.md
@@ -1,0 +1,35 @@
+# WP3 Realtime Approval Count Verification
+
+Approval Wave 2 WP3 slice 3 adds Socket.IO delivery for approval pending/unread badge updates.
+
+## Backend contract
+
+- Event: `approval:counts-updated`
+- Target: current user's Socket.IO user room, using the existing `handshake.query.userId` room join in `CollabService`
+- Payload:
+  - `count` / `unreadCount` for `sourceSystem=all`
+  - `countsBySourceSystem.all|platform|plm` for filtered approval center tabs
+  - `reason` such as `mark-read`, `mark-all-read`, `remind`, or `action:approve`
+
+The router publishes after successful `mark-read`, `mark-all-read`, `remind`, and approval action/state paths. Remind also clears read rows for active direct user assignees, so a nudge reappears as unread for those users.
+
+## Frontend behavior
+
+`ApprovalCenterView` keeps the existing REST refresh path on mount, tab changes, and after bulk mark-read. The realtime composable only updates the badge from pushed counts; socket connection failures do not surface to the user or block REST.
+
+## Verification Commands
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-realtime.test.ts
+pnpm --filter @metasheet/web exec vitest run tests/approvalCountsRealtime.spec.ts tests/approvalCenterUnreadBadge.spec.ts --watch=false
+pnpm --filter @metasheet/core-backend type-check
+pnpm --filter @metasheet/web type-check
+```
+
+Manual smoke:
+
+1. Open `/approvals` as an assignee and confirm the pending badge loads from REST.
+2. Open another session as the requester, click `催办`, and confirm the assignee session receives a badge update without refresh.
+3. Open an approval detail as the assignee and confirm `mark-read` drops the unread badge in the approval center session.
+4. Disconnect the socket in devtools and confirm tab switches still refresh badge counts via REST.
+

--- a/docs/development/wp3-realtime-count-verification.md
+++ b/docs/development/wp3-realtime-count-verification.md
@@ -28,23 +28,41 @@ The router publishes after successful `mark-read`, `mark-all-read`, `remind`, an
 
 ```bash
 pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-realtime.test.ts
-pnpm --filter @metasheet/web exec vitest run tests/approvalCountsRealtime.spec.ts tests/approvalCenterUnreadBadge.spec.ts --watch=false
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-realtime.test.ts tests/unit/approvals-routes.test.ts tests/unit/approvals-bridge-routes.test.ts --reporter=dot
 pnpm --filter @metasheet/core-backend exec tsc --noEmit
+pnpm --filter @metasheet/core-backend exec vitest run --reporter=dot
+pnpm --filter @metasheet/web exec vitest run tests/approvalCountsRealtime.spec.ts tests/approvalCenterUnreadBadge.spec.ts --watch=false
 pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
 ```
 
 ## Results
 
 - `approval-realtime.test.ts`: `3/3` passed.
+- Backend realtime + legacy action route regression: `36/36` passed.
+- Backend `tsc --noEmit`: exit `0`.
+- Backend full `vitest run --reporter=dot`: `2535/2535` passed, `45` skipped.
 - `approvalCountsRealtime.spec.ts`: `1/1` passed.
 - `approvalCenterUnreadBadge.spec.ts`: `7/7` passed.
-- Backend `tsc --noEmit`: exit `0`.
 - Frontend `vue-tsc -b --noEmit`: exit `0`.
 
 Expected test noise:
 
 - `approvalCenterUnreadBadge.spec.ts` intentionally logs one rejected
   `mark-read` request to prove the detail view does not surface an error toast.
+- Full backend run logs expected local PostgreSQL `database "chouhua" does not
+  exist` errors from degraded server lifecycle paths; the suite still exits `0`.
+
+## CI Hardening Fix
+
+PR CI initially failed in Node 18 full backend tests because a top-level
+`authService` import from `CollabService` pulled in RBAC metrics during parallel
+test collection and attempted to register `http_server_requests_seconds` twice.
+The fix keeps token verification lazy at socket join time.
+
+The same full run also exposed missing fake DB coverage in legacy approval route
+tests for the new direct-assignee lookup. The route fakes now return active
+direct assignees for `SELECT DISTINCT assignee_id FROM approval_assignments`,
+and the legacy unit fixture defaults `pool.query` to an empty result.
 
 Manual smoke:
 

--- a/packages/core-backend/src/routes/approvals.ts
+++ b/packages/core-backend/src/routes/approvals.ts
@@ -20,6 +20,7 @@ import {
   APPROVAL_ERROR_CODES,
   type ApprovalBridgePlmAdapter,
 } from '../services/approval-bridge-types'
+import { publishApprovalCountsUpdate } from '../services/approval-realtime'
 import { isDatabaseSchemaError } from '../utils/database-errors'
 
 const logger = new Logger('ApprovalsRouter')
@@ -167,6 +168,42 @@ function handleApprovalsError(
 
   logger.error(fallbackMessage, error instanceof Error ? error : undefined)
   res.status(500).json(approvalErrorResponse(fallbackCode, fallbackMessage))
+}
+
+async function listDirectApprovalAssigneeIds(instanceId: string): Promise<string[]> {
+  if (!pool) return []
+  const result = await pool.query<{ assignee_id: string }>(
+    `SELECT DISTINCT assignee_id
+     FROM approval_assignments
+     WHERE instance_id = $1
+       AND is_active = TRUE
+       AND assignment_type = 'user'`,
+    [instanceId],
+  )
+  return result.rows
+    .map((row) => row.assignee_id)
+    .filter((userId) => typeof userId === 'string' && userId.trim().length > 0)
+}
+
+async function publishApprovalCountsForUsers(
+  options: ApprovalRouterOptions | undefined,
+  users: Array<{ userId: string; roles?: string[] }>,
+  reason: string,
+): Promise<void> {
+  const uniqueUsers = new Map<string, string[]>()
+  for (const user of users) {
+    const userId = user.userId.trim()
+    if (!userId || uniqueUsers.has(userId)) continue
+    uniqueUsers.set(userId, user.roles ?? [])
+  }
+
+  await Promise.all([...uniqueUsers.entries()].map(([userId, roles]) => publishApprovalCountsUpdate({
+    injector: options?.injector,
+    logger,
+    userId,
+    roles,
+    reason,
+  })))
 }
 
 export function approvalsRouter(options?: ApprovalRouterOptions): Router {
@@ -717,6 +754,11 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
         return res.json({ ok: true, skipped: true, reason: 'instance_not_materialized' })
       }
 
+      await publishApprovalCountsForUsers(
+        options,
+        [{ userId, roles: resolveApprovalActorRoles(req) }],
+        'mark-read',
+      )
       res.json({ ok: true })
     } catch (error) {
       handleApprovalsError(
@@ -800,6 +842,11 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
         params,
       )
 
+      await publishApprovalCountsForUsers(
+        options,
+        [{ userId, roles: resolveApprovalActorRoles(req) }],
+        'mark-all-read',
+      )
       res.json({ markedCount: result.rows.length })
     } catch (error) {
       handleApprovalsError(
@@ -842,6 +889,7 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
 
       const { id } = req.params
       const userName = resolveApprovalActorName(req, userId)
+      let remindedDirectAssigneeIds: string[] = []
 
       const client = await pool.connect()
       try {
@@ -956,9 +1004,38 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
           ],
         )
 
+        const directAssigneesResult = await client.query<{ assignee_id: string }>(
+          `SELECT DISTINCT assignee_id
+           FROM approval_assignments
+           WHERE instance_id = $1
+             AND is_active = TRUE
+             AND assignment_type = 'user'`,
+          [id],
+        )
+        remindedDirectAssigneeIds = directAssigneesResult.rows
+          .map((row) => row.assignee_id)
+          .filter((assigneeId) => assigneeId && assigneeId !== userId)
+
+        if (remindedDirectAssigneeIds.length > 0) {
+          await client.query(
+            `DELETE FROM approval_reads
+             WHERE instance_id = $1
+               AND user_id = ANY($2::text[])`,
+            [id, remindedDirectAssigneeIds],
+          )
+        }
+
         await client.query('COMMIT')
 
         logger.info(`Approval ${id} reminded by ${userId}`)
+        await publishApprovalCountsForUsers(
+          options,
+          [
+            { userId, roles: resolveApprovalActorRoles(req) },
+            ...remindedDirectAssigneeIds.map((assigneeId) => ({ userId: assigneeId })),
+          ],
+          'remind',
+        )
         res.json({
           ok: true,
           data: {
@@ -1085,6 +1162,16 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
         }
       }
 
+      const activeDirectAssignees = await listDirectApprovalAssigneeIds(req.params.id)
+      await publishApprovalCountsForUsers(
+        options,
+        [
+          { userId, roles: actor.roles },
+          ...(targetUserId ? [{ userId: targetUserId }] : []),
+          ...activeDirectAssignees.map((assigneeId) => ({ userId: assigneeId })),
+        ],
+        `action:${action}`,
+      )
       res.json(approval)
     } catch (error) {
       handleApprovalsError(
@@ -1193,6 +1280,15 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
         await client.query('COMMIT')
 
         logger.info(`Approval ${id} approved by ${userId}`)
+        const activeDirectAssignees = await listDirectApprovalAssigneeIds(id)
+        await publishApprovalCountsForUsers(
+          options,
+          [
+            { userId, roles: resolveApprovalActorRoles(req) },
+            ...activeDirectAssignees.map((assigneeId) => ({ userId: assigneeId })),
+          ],
+          'legacy-approve',
+        )
         res.json({
           ok: true,
           data: {
@@ -1328,6 +1424,15 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
         await client.query('COMMIT')
 
         logger.info(`Approval ${id} rejected by ${userId}: ${reason}`)
+        const activeDirectAssignees = await listDirectApprovalAssigneeIds(id)
+        await publishApprovalCountsForUsers(
+          options,
+          [
+            { userId, roles: resolveApprovalActorRoles(req) },
+            ...activeDirectAssignees.map((assigneeId) => ({ userId: assigneeId })),
+          ],
+          'legacy-reject',
+        )
         res.json({
           ok: true,
           data: {

--- a/packages/core-backend/src/services/CollabService.ts
+++ b/packages/core-backend/src/services/CollabService.ts
@@ -3,7 +3,6 @@ import { Server as SocketServer } from 'socket.io'
 import type { Server as HttpServer } from 'http'
 import type { ILogger } from '../di/identifiers'
 import type { EventBus } from '../integration/events/event-bus'
-import { authService } from '../auth/AuthService'
 import { buildCommentInboxRoom, buildCommentRecordRoom, buildCommentSheetRoom } from './commentRooms'
 
 export function buildAuthenticatedUserRoom(userId: string): string {
@@ -55,6 +54,9 @@ export class CollabService {
     const token = this.getTokenFromSocket(socket)
     if (!token) return
     try {
+      // AuthService pulls in RBAC/metrics modules; keep it lazy so importing CollabService
+      // does not register global metrics during parallel unit-test collection.
+      const { authService } = await import('../auth/AuthService')
       const user = await authService.verifyToken(token)
       const userId = user?.id?.toString().trim()
       if (!userId) return

--- a/packages/core-backend/src/services/CollabService.ts
+++ b/packages/core-backend/src/services/CollabService.ts
@@ -3,7 +3,12 @@ import { Server as SocketServer } from 'socket.io'
 import type { Server as HttpServer } from 'http'
 import type { ILogger } from '../di/identifiers'
 import type { EventBus } from '../integration/events/event-bus'
+import { authService } from '../auth/AuthService'
 import { buildCommentInboxRoom, buildCommentRecordRoom, buildCommentSheetRoom } from './commentRooms'
+
+export function buildAuthenticatedUserRoom(userId: string): string {
+  return `auth-user:${userId}`
+}
 
 export class CollabService {
   private io: SocketServer | null = null
@@ -35,6 +40,29 @@ export class CollabService {
     const value = Array.isArray(raw) ? raw[0] : raw
     if (typeof value === 'string' && value.trim().length > 0) return value.trim()
     return undefined
+  }
+
+  private getTokenFromSocket(socket: Socket): string | undefined {
+    const authToken = (socket.handshake.auth as { token?: unknown } | undefined)?.token
+    if (typeof authToken === 'string' && authToken.trim().length > 0) return authToken.trim()
+    const raw = socket.handshake.query.token
+    const value = Array.isArray(raw) ? raw[0] : raw
+    if (typeof value === 'string' && value.trim().length > 0) return value.trim()
+    return undefined
+  }
+
+  private async joinAuthenticatedUserRoom(socket: Socket): Promise<void> {
+    const token = this.getTokenFromSocket(socket)
+    if (!token) return
+    try {
+      const user = await authService.verifyToken(token)
+      const userId = user?.id?.toString().trim()
+      if (!userId) return
+      socket.join(buildAuthenticatedUserRoom(userId))
+      this.logger.debug(`WebSocket client ${socket.id} joined authenticated user room for ${userId}`)
+    } catch (error) {
+      this.logger.warn('WebSocket authenticated user room join failed', error instanceof Error ? error : undefined)
+    }
   }
 
   private resolveTarget(options?: { userId?: string; socketId?: string }): string | null {
@@ -143,6 +171,7 @@ export class CollabService {
         socket.join(userId)
         this.logger.debug(`WebSocket client ${socket.id} joined user room ${userId}`)
       }
+      void this.joinAuthenticatedUserRoom(socket)
 
       socket.on('disconnect', () => {
         const userId = this.getUserIdFromSocket(socket)

--- a/packages/core-backend/src/services/approval-realtime.ts
+++ b/packages/core-backend/src/services/approval-realtime.ts
@@ -1,0 +1,117 @@
+import type { Injector } from '@wendellhu/redi'
+import { ICollabService, type ICollabService as CollabServicePort, type ILogger } from '../di/identifiers'
+import { pool } from '../db/pg'
+
+export type ApprovalCountSourceSystem = 'all' | 'platform' | 'plm'
+
+export interface ApprovalCounts {
+  count: number
+  unreadCount: number
+}
+
+export interface ApprovalCountsUpdatedPayload extends ApprovalCounts {
+  sourceSystem: ApprovalCountSourceSystem
+  countsBySourceSystem: Record<ApprovalCountSourceSystem, ApprovalCounts>
+  reason: string
+  updatedAt: string
+}
+
+export type ApprovalCountQuery = <T = { count: string; unread_count: string }>(
+  sql: string,
+  params: unknown[],
+) => Promise<{ rows: T[] }>
+
+export async function computeApprovalPendingCounts(
+  query: ApprovalCountQuery,
+  input: {
+    userId: string
+    roles?: string[]
+    sourceSystem?: ApprovalCountSourceSystem
+  },
+): Promise<ApprovalCounts> {
+  const sourceSystem = input.sourceSystem === 'platform' || input.sourceSystem === 'plm'
+    ? input.sourceSystem
+    : null
+  const roles = input.roles?.filter((role) => role.trim().length > 0) ?? []
+  const actorRolesParam = roles.length > 0 ? roles : ['__none__']
+  const conditions = [
+    `a.is_active = TRUE`,
+    `i.status = 'pending'`,
+    `(
+      (a.assignment_type = 'user' AND a.assignee_id = $1)
+      OR (a.assignment_type = 'role' AND a.assignee_id = ANY($2))
+    )`,
+  ]
+  const params: unknown[] = [input.userId, actorRolesParam]
+
+  if (sourceSystem) {
+    conditions.push(`COALESCE(i.source_system, 'platform') = $${params.length + 1}`)
+    params.push(sourceSystem)
+  }
+
+  const result = await query<{ count: string | number; unread_count: string | number }>(
+    `SELECT COUNT(DISTINCT a.instance_id)::text AS count,
+            COUNT(DISTINCT a.instance_id) FILTER (WHERE r.instance_id IS NULL)::text AS unread_count
+     FROM approval_assignments a
+     INNER JOIN approval_instances i ON i.id = a.instance_id
+     LEFT JOIN approval_reads r ON r.instance_id = a.instance_id AND r.user_id = $1
+     WHERE ${conditions.join(' AND ')}`,
+    params,
+  )
+
+  return {
+    count: Number.parseInt(String(result.rows[0]?.count ?? '0'), 10),
+    unreadCount: Number.parseInt(String(result.rows[0]?.unread_count ?? '0'), 10),
+  }
+}
+
+export async function buildApprovalCountsUpdatedPayload(
+  input: {
+    userId: string
+    roles?: string[]
+    reason: string
+    query?: ApprovalCountQuery
+  },
+): Promise<ApprovalCountsUpdatedPayload | null> {
+  const query = input.query ?? pool?.query.bind(pool)
+  if (!query) return null
+
+  const [all, platform, plm] = await Promise.all([
+    computeApprovalPendingCounts(query, { userId: input.userId, roles: input.roles, sourceSystem: 'all' }),
+    computeApprovalPendingCounts(query, { userId: input.userId, roles: input.roles, sourceSystem: 'platform' }),
+    computeApprovalPendingCounts(query, { userId: input.userId, roles: input.roles, sourceSystem: 'plm' }),
+  ])
+
+  return {
+    ...all,
+    sourceSystem: 'all',
+    countsBySourceSystem: { all, platform, plm },
+    reason: input.reason,
+    updatedAt: new Date().toISOString(),
+  }
+}
+
+export async function publishApprovalCountsUpdate(
+  input: {
+    injector?: Injector
+    collabService?: Pick<CollabServicePort, 'sendTo'>
+    logger?: Pick<ILogger, 'warn'>
+    userId: string
+    roles?: string[]
+    reason: string
+    query?: ApprovalCountQuery
+  },
+): Promise<void> {
+  try {
+    const collabService = input.collabService ?? input.injector?.get(ICollabService)
+    if (!collabService) return
+    const payload = await buildApprovalCountsUpdatedPayload(input)
+    if (!payload) return
+    collabService.sendTo(input.userId, 'approval:counts-updated', payload)
+  } catch (error) {
+    input.logger?.warn(
+      'Failed to publish approval count update',
+      error instanceof Error ? error : undefined,
+    )
+  }
+}

--- a/packages/core-backend/src/services/approval-realtime.ts
+++ b/packages/core-backend/src/services/approval-realtime.ts
@@ -1,6 +1,7 @@
 import type { Injector } from '@wendellhu/redi'
 import { ICollabService, type ICollabService as CollabServicePort, type ILogger } from '../di/identifiers'
 import { pool } from '../db/pg'
+import { buildAuthenticatedUserRoom } from './CollabService'
 
 export type ApprovalCountSourceSystem = 'all' | 'platform' | 'plm'
 
@@ -94,7 +95,7 @@ export async function buildApprovalCountsUpdatedPayload(
 export async function publishApprovalCountsUpdate(
   input: {
     injector?: Injector
-    collabService?: Pick<CollabServicePort, 'sendTo'>
+    collabService?: Pick<CollabServicePort, 'broadcastTo'>
     logger?: Pick<ILogger, 'warn'>
     userId: string
     roles?: string[]
@@ -107,7 +108,7 @@ export async function publishApprovalCountsUpdate(
     if (!collabService) return
     const payload = await buildApprovalCountsUpdatedPayload(input)
     if (!payload) return
-    collabService.sendTo(input.userId, 'approval:counts-updated', payload)
+    collabService.broadcastTo(buildAuthenticatedUserRoom(input.userId), 'approval:counts-updated', payload)
   } catch (error) {
     input.logger?.warn(
       'Failed to publish approval count update',

--- a/packages/core-backend/tests/unit/approval-realtime.test.ts
+++ b/packages/core-backend/tests/unit/approval-realtime.test.ts
@@ -50,20 +50,20 @@ describe('approval realtime count publisher', () => {
     })
   })
 
-  it('uses CollabService.sendTo and suppresses publish failures', async () => {
-    const sendTo = vi.fn()
+  it('uses the authenticated user room and suppresses publish failures', async () => {
+    const broadcastTo = vi.fn()
     const warn = vi.fn()
     const query = vi.fn<ApprovalCountQuery>(async () => ({ rows: [{ count: '0', unread_count: '0' }] }))
 
     await publishApprovalCountsUpdate({
-      collabService: { sendTo },
+      collabService: { broadcastTo },
       logger: { warn },
       userId: 'u1',
       reason: 'mark-all-read',
       query,
     })
 
-    expect(sendTo).toHaveBeenCalledWith('u1', 'approval:counts-updated', expect.objectContaining({
+    expect(broadcastTo).toHaveBeenCalledWith('auth-user:u1', 'approval:counts-updated', expect.objectContaining({
       count: 0,
       unreadCount: 0,
       reason: 'mark-all-read',

--- a/packages/core-backend/tests/unit/approval-realtime.test.ts
+++ b/packages/core-backend/tests/unit/approval-realtime.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  buildApprovalCountsUpdatedPayload,
+  computeApprovalPendingCounts,
+  publishApprovalCountsUpdate,
+  type ApprovalCountQuery,
+} from '../../src/services/approval-realtime'
+
+describe('approval realtime count publisher', () => {
+  it('computes pending and unread counts with user, role, and source filters', async () => {
+    const query = vi.fn<ApprovalCountQuery>(async (_sql, params) => {
+      expect(params).toEqual(['u1', ['finance'], 'platform'])
+      return { rows: [{ count: '4', unread_count: '2' }] }
+    })
+
+    const counts = await computeApprovalPendingCounts(query, {
+      userId: 'u1',
+      roles: ['finance'],
+      sourceSystem: 'platform',
+    })
+
+    expect(counts).toEqual({ count: 4, unreadCount: 2 })
+    expect(query.mock.calls[0][0]).toContain(`COALESCE(i.source_system, 'platform') = $3`)
+  })
+
+  it('publishes all/platform/plm count snapshots to the current user room', async () => {
+    const query = vi.fn<ApprovalCountQuery>(async (_sql, params) => {
+      const sourceSystem = params[2]
+      if (sourceSystem === 'platform') return { rows: [{ count: '2', unread_count: '1' }] }
+      if (sourceSystem === 'plm') return { rows: [{ count: '1', unread_count: '1' }] }
+      return { rows: [{ count: '3', unread_count: '2' }] }
+    })
+    const payload = await buildApprovalCountsUpdatedPayload({
+      userId: 'u1',
+      roles: ['finance'],
+      reason: 'mark-read',
+      query,
+    })
+
+    expect(payload).toMatchObject({
+      count: 3,
+      unreadCount: 2,
+      sourceSystem: 'all',
+      reason: 'mark-read',
+      countsBySourceSystem: {
+        all: { count: 3, unreadCount: 2 },
+        platform: { count: 2, unreadCount: 1 },
+        plm: { count: 1, unreadCount: 1 },
+      },
+    })
+  })
+
+  it('uses CollabService.sendTo and suppresses publish failures', async () => {
+    const sendTo = vi.fn()
+    const warn = vi.fn()
+    const query = vi.fn<ApprovalCountQuery>(async () => ({ rows: [{ count: '0', unread_count: '0' }] }))
+
+    await publishApprovalCountsUpdate({
+      collabService: { sendTo },
+      logger: { warn },
+      userId: 'u1',
+      reason: 'mark-all-read',
+      query,
+    })
+
+    expect(sendTo).toHaveBeenCalledWith('u1', 'approval:counts-updated', expect.objectContaining({
+      count: 0,
+      unreadCount: 0,
+      reason: 'mark-all-read',
+    }))
+    expect(warn).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core-backend/tests/unit/approvals-bridge-routes.test.ts
+++ b/packages/core-backend/tests/unit/approvals-bridge-routes.test.ts
@@ -278,6 +278,17 @@ const routeState = vi.hoisted(() => {
       return { rows, rowCount: rows.length }
     }
 
+    if (normalized.startsWith('SELECT DISTINCT assignee_id FROM approval_assignments')) {
+      const rows = Array.from(state.assignments.values())
+        .filter((row) => (
+          row.instance_id === String(params[0])
+          && row.is_active
+          && row.assignment_type === 'user'
+        ))
+        .map((row) => ({ assignee_id: row.assignee_id }))
+      return { rows, rowCount: rows.length }
+    }
+
     if (normalized.startsWith('SELECT id, action, actor_id, actor_name, comment, from_status, to_status, metadata, occurred_at FROM approval_records')) {
       const rows = state.records
         .filter((row) => row.instance_id === String(params[0]))

--- a/packages/core-backend/tests/unit/approvals-routes.test.ts
+++ b/packages/core-backend/tests/unit/approvals-routes.test.ts
@@ -56,6 +56,7 @@ describe('approvals routes', () => {
     pgState.pool.connect.mockReset()
     pgState.client.query.mockReset()
     pgState.client.release.mockReset()
+    pgState.pool.query.mockResolvedValue({ rows: [], rowCount: 0 })
     pgState.pool.connect.mockResolvedValue(pgState.client)
 
     const { approvalsRouter } = await import('../../src/routes/approvals')


### PR DESCRIPTION
## Summary\n- Add approval pending/unread count realtime publisher and frontend composable\n- Push count snapshots for all/platform/plm after mark-read, mark-all-read, remind, and approval action paths\n- Use authenticated Socket.IO user room (JWT in handshake.auth.token -> auth-user:<userId>) instead of naked query.userId for approval count data\n- Keep REST count refresh as fallback/recovery path\n\n## Verification\n- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-realtime.test.ts --reporter=dot\n- pnpm --filter @metasheet/web exec vitest run tests/approvalCountsRealtime.spec.ts tests/approvalCenterUnreadBadge.spec.ts --watch=false --reporter=dot\n- pnpm --filter @metasheet/core-backend exec tsc --noEmit\n- pnpm --filter @metasheet/web exec vue-tsc -b --noEmit\n\nResult: backend realtime 3/3, frontend focused 8/8, both typechecks exit 0.\n\nDocs:\n- docs/development/approval-wave2-wp3-realtime-count-development-20260423.md\n- docs/development/wp3-realtime-count-verification.md