### PR TITLE
feat(approval): add template visibility ACL

### DIFF
--- a/apps/web/src/approvals/api.ts
+++ b/apps/web/src/approvals/api.ts
@@ -16,6 +16,7 @@ import type {
   ApprovalActionRequest,
   ApprovalStatus,
   ApprovalTemplateStatus,
+  ApprovalTemplateVisibilityScope,
   FormField,
 } from '../types/approval'
 
@@ -39,6 +40,7 @@ function mockTemplateListItem(index: number): ApprovalTemplateListItemDTO {
     name: `审批模板 ${index}`,
     description: index % 2 === 0 ? '通用审批模板' : null,
     category: MOCK_TEMPLATE_CATEGORIES[index % MOCK_TEMPLATE_CATEGORIES.length],
+    visibilityScope: { type: 'all', ids: [] },
     status: statuses[index % statuses.length],
     activeVersionId: statuses[index % statuses.length] === 'published' ? `ver_${index}_1` : null,
     latestVersionId: `ver_${index}_1`,
@@ -384,6 +386,23 @@ export async function updateTemplateCategory(
   const response = await apiFetch(`/api/approval-templates/${encodeURIComponent(templateId)}`, {
     method: 'PATCH',
     body: JSON.stringify({ category }),
+  })
+  if (!response.ok) {
+    throw new Error(`API error: ${response.status} ${response.statusText}`)
+  }
+  return response.json()
+}
+
+export async function updateTemplateVisibilityScope(
+  templateId: string,
+  visibilityScope: ApprovalTemplateVisibilityScope,
+): Promise<ApprovalTemplateDetailDTO> {
+  if (USE_MOCK) {
+    return { ...mockTemplateDetail(templateId), visibilityScope }
+  }
+  const response = await apiFetch(`/api/approval-templates/${encodeURIComponent(templateId)}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ visibilityScope }),
   })
   if (!response.ok) {
     throw new Error(`API error: ${response.status} ${response.statusText}`)

--- a/apps/web/src/types/approval.ts
+++ b/apps/web/src/types/approval.ts
@@ -15,6 +15,7 @@ export type EmptyAssigneePolicy = 'error' | 'auto-approve'
 export type ApprovalActionType = 'approve' | 'reject' | 'transfer' | 'revoke' | 'comment' | 'return'
 export type ApprovalStatus = 'draft' | 'pending' | 'approved' | 'rejected' | 'revoked' | 'cancelled'
 export type ApprovalTemplateStatus = 'draft' | 'published' | 'archived'
+export type ApprovalTemplateVisibilityType = 'all' | 'dept' | 'role' | 'user'
 export type FormFieldType =
   | 'text'
   | 'textarea'
@@ -204,6 +205,7 @@ export interface ApprovalTemplateListItemDTO {
    * means the template is uncategorized. Mirrors the backend column.
    */
   category: string | null
+  visibilityScope: ApprovalTemplateVisibilityScope
   status: ApprovalTemplateStatus
   activeVersionId: string | null
   latestVersionId: string | null
@@ -214,6 +216,11 @@ export interface ApprovalTemplateListItemDTO {
 export interface ApprovalTemplateDetailDTO extends ApprovalTemplateListItemDTO {
   formSchema: FormSchema
   approvalGraph: ApprovalGraph
+}
+
+export interface ApprovalTemplateVisibilityScope {
+  type: ApprovalTemplateVisibilityType
+  ids: string[]
 }
 
 export interface ApprovalTemplateVersionDetailDTO {

--- a/apps/web/src/views/approval/TemplateCenterView.vue
+++ b/apps/web/src/views/approval/TemplateCenterView.vue
@@ -96,6 +96,13 @@
           <span v-else class="template-center__category-empty">未分组</span>
         </template>
       </el-table-column>
+      <el-table-column label="可见范围" width="160">
+        <template #default="{ row }">
+          <el-tag size="small" effect="plain" data-testid="template-center-row-visibility">
+            {{ visibilityScopeLabel(row.visibilityScope) }}
+          </el-tag>
+        </template>
+      </el-table-column>
       <el-table-column label="状态" width="100">
         <template #default="{ row }">
           <el-tag
@@ -198,6 +205,17 @@ function templateStatusLabel(status: string) {
     archived: '已归档',
   }
   return map[status] ?? status
+}
+
+function visibilityScopeLabel(scope: ApprovalTemplateListItemDTO['visibilityScope']) {
+  if (!scope || scope.type === 'all') return '全员可见'
+  const count = scope.ids?.length ?? 0
+  const map: Record<string, string> = {
+    dept: '部门',
+    role: '角色',
+    user: '用户',
+  }
+  return `${map[scope.type] ?? scope.type} ${count}`
 }
 
 function formatDate(dateStr: string) {

--- a/apps/web/src/views/approval/TemplateDetailView.vue
+++ b/apps/web/src/views/approval/TemplateDetailView.vue
@@ -105,6 +105,71 @@
               </el-button>
             </template>
           </div>
+          <div class="template-detail__visibility">
+            <span class="template-detail__category-label">可见范围:</span>
+            <template v-if="!editingVisibility">
+              <el-tag size="small" effect="plain" data-testid="template-detail-visibility-tag">
+                {{ visibilityScopeLabel(template.visibilityScope) }}
+              </el-tag>
+              <span
+                v-if="template.visibilityScope.type !== 'all'"
+                class="template-detail__visibility-ids"
+                data-testid="template-detail-visibility-ids"
+              >
+                {{ template.visibilityScope.ids.join(', ') }}
+              </span>
+              <el-button
+                v-if="canManageTemplates"
+                text
+                size="small"
+                data-testid="template-detail-visibility-edit-button"
+                style="margin-left: 8px"
+                @click="beginEditVisibility"
+              >
+                编辑
+              </el-button>
+            </template>
+            <template v-else>
+              <el-select
+                v-model="visibilityTypeDraft"
+                size="small"
+                style="width: 120px; margin-right: 8px"
+                data-testid="template-detail-visibility-type"
+              >
+                <el-option label="全员" value="all" />
+                <el-option label="部门" value="dept" />
+                <el-option label="角色" value="role" />
+                <el-option label="用户" value="user" />
+              </el-select>
+              <el-input
+                v-model="visibilityIdsDraft"
+                size="small"
+                placeholder="逗号分隔 id，如 dept-finance, role-manager"
+                style="width: 320px; margin-right: 8px"
+                :disabled="visibilityTypeDraft === 'all'"
+                data-testid="template-detail-visibility-ids-input"
+                @keyup.enter="saveVisibility"
+                @keyup.escape="cancelEditVisibility"
+              />
+              <el-button
+                type="primary"
+                size="small"
+                :loading="visibilitySaving"
+                data-testid="template-detail-visibility-save-button"
+                @click="saveVisibility"
+              >
+                保存
+              </el-button>
+              <el-button
+                size="small"
+                :disabled="visibilitySaving"
+                data-testid="template-detail-visibility-cancel-button"
+                @click="cancelEditVisibility"
+              >
+                取消
+              </el-button>
+            </template>
+          </div>
           <div class="template-detail__meta">
             <span>模板 Key: {{ template.key }}</span>
             <span>当前版本: {{ template.activeVersionId ?? '无' }}</span>
@@ -212,10 +277,17 @@ import {
   CircleCheckFilled,
 } from '@element-plus/icons-vue'
 import { ElMessage } from 'element-plus'
-import type { ApprovalNodeType, FormFieldType, ApprovalMode, EmptyAssigneePolicy } from '../../types/approval'
+import type {
+  ApprovalNodeType,
+  FormFieldType,
+  ApprovalMode,
+  EmptyAssigneePolicy,
+  ApprovalTemplateVisibilityScope,
+  ApprovalTemplateVisibilityType,
+} from '../../types/approval'
 import { useApprovalTemplateStore } from '../../approvals/templateStore'
 import { useApprovalPermissions } from '../../approvals/permissions'
-import { updateTemplateCategory } from '../../approvals/api'
+import { updateTemplateCategory, updateTemplateVisibilityScope } from '../../approvals/api'
 
 const route = useRoute()
 const router = useRouter()
@@ -228,6 +300,10 @@ const template = computed(() => store.activeTemplate)
 const editingCategory = ref(false)
 const categoryDraft = ref('')
 const categorySaving = ref(false)
+const editingVisibility = ref(false)
+const visibilityTypeDraft = ref<ApprovalTemplateVisibilityType>('all')
+const visibilityIdsDraft = ref('')
+const visibilitySaving = ref(false)
 
 function beginEditCategory() {
   if (!template.value) return
@@ -260,6 +336,61 @@ async function saveCategory() {
     ElMessage.error(e?.message ?? '更新分类失败')
   } finally {
     categorySaving.value = false
+  }
+}
+
+function visibilityScopeLabel(scope: ApprovalTemplateVisibilityScope): string {
+  if (!scope || scope.type === 'all') return '全员可见'
+  const map: Record<ApprovalTemplateVisibilityType, string> = {
+    all: '全员可见',
+    dept: '按部门',
+    role: '按角色',
+    user: '按用户',
+  }
+  return map[scope.type]
+}
+
+function beginEditVisibility() {
+  if (!template.value) return
+  visibilityTypeDraft.value = template.value.visibilityScope.type
+  visibilityIdsDraft.value = template.value.visibilityScope.ids.join(', ')
+  editingVisibility.value = true
+}
+
+function cancelEditVisibility() {
+  editingVisibility.value = false
+  visibilityTypeDraft.value = 'all'
+  visibilityIdsDraft.value = ''
+}
+
+async function saveVisibility() {
+  if (!template.value || visibilitySaving.value) return
+  const ids = visibilityIdsDraft.value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+  if (visibilityTypeDraft.value !== 'all' && ids.length === 0) {
+    ElMessage.error('可见范围至少需要一个 id')
+    return
+  }
+  const nextScope: ApprovalTemplateVisibilityScope = visibilityTypeDraft.value === 'all'
+    ? { type: 'all', ids: [] }
+    : { type: visibilityTypeDraft.value, ids: Array.from(new Set(ids)) }
+  const current = template.value.visibilityScope
+  if (current.type === nextScope.type && current.ids.join('\n') === nextScope.ids.join('\n')) {
+    editingVisibility.value = false
+    return
+  }
+  visibilitySaving.value = true
+  try {
+    const updated = await updateTemplateVisibilityScope(template.value.id, nextScope)
+    store.activeTemplate = updated
+    editingVisibility.value = false
+    ElMessage.success('已更新模板可见范围')
+  } catch (e: any) {
+    ElMessage.error(e?.message ?? '更新可见范围失败')
+  } finally {
+    visibilitySaving.value = false
   }
 }
 
@@ -427,12 +558,14 @@ onMounted(() => {
   flex-wrap: wrap;
 }
 
-.template-detail__category {
+.template-detail__category,
+.template-detail__visibility {
   display: flex;
   align-items: center;
   gap: 4px;
   margin-bottom: 12px;
   font-size: 13px;
+  flex-wrap: wrap;
 }
 
 .template-detail__category-label {
@@ -441,6 +574,10 @@ onMounted(() => {
 }
 
 .template-detail__category-empty {
+  color: var(--el-text-color-secondary, #909399);
+}
+
+.template-detail__visibility-ids {
   color: var(--el-text-color-secondary, #909399);
 }
 

--- a/apps/web/tests/approval-e2e-permissions.spec.ts
+++ b/apps/web/tests/approval-e2e-permissions.spec.ts
@@ -882,6 +882,20 @@ describe('Approval E2E Permissions', () => {
       expect(meta?.textContent).toContain('TPL-001')
     })
 
+    it('template detail shows visibility scope metadata', async () => {
+      setMockPermissions(['approval-templates:manage'])
+      routeParams = { id: 'tpl_1' }
+      mockActiveTemplate.value = mockPublishedTemplate({
+        visibilityScope: { type: 'role', ids: ['finance', 'manager'] },
+      })
+      await mountTemplateDetailView()
+
+      const visibilityTag = container!.querySelector('[data-testid="template-detail-visibility-tag"]')
+      expect(visibilityTag?.textContent).toContain('按角色')
+      const visibilityIds = container!.querySelector('[data-testid="template-detail-visibility-ids"]')
+      expect(visibilityIds?.textContent).toContain('finance, manager')
+    })
+
     it('back button navigates to /approval-templates', async () => {
       setMockPermissions(['approval-templates:manage'])
       routeParams = { id: 'tpl_1' }

--- a/apps/web/tests/approvalTemplateCenterCategory.spec.ts
+++ b/apps/web/tests/approvalTemplateCenterCategory.spec.ts
@@ -82,6 +82,7 @@ const listTemplateCategoriesSpy = vi.fn<[], Promise<string[]>>().mockResolvedVal
 const cloneTemplateSpy = vi.fn<[string], Promise<any>>().mockResolvedValue({
   id: 'tpl_clone_1',
   name: 'Clone',
+  visibilityScope: { type: 'all', ids: [] },
 })
 
 vi.mock('../src/approvals/api', () => ({
@@ -332,6 +333,7 @@ function buildTemplate(overrides: Record<string, unknown>) {
     name: '审批模板 1',
     description: null,
     category: null,
+    visibilityScope: { type: 'all', ids: [] },
     status: 'published',
     activeVersionId: 'ver_1',
     latestVersionId: 'ver_1',
@@ -368,6 +370,7 @@ describe('TemplateCenterView — WP4 slice 1 category filter + clone', () => {
       activeVersionId: null,
       latestVersionId: 'ver_clone_1',
       category: '请假',
+      visibilityScope: { type: 'all', ids: [] },
     })
     pushSpy.mockClear()
 
@@ -465,6 +468,18 @@ describe('TemplateCenterView — WP4 slice 1 category filter + clone', () => {
     const tagTexts = Array.from(tags).map((el) => (el.textContent ?? '').trim())
     expect(tagTexts).toContain('请假')
     expect(tagTexts).toContain('采购')
+  })
+
+  it('renders visibility scope summary per row', async () => {
+    mockTemplates.value = [
+      buildTemplate({ id: 'tpl_a', visibilityScope: { type: 'all', ids: [] } }),
+      buildTemplate({ id: 'tpl_b', visibilityScope: { type: 'role', ids: ['manager', 'finance'] } }),
+    ]
+    await mountView()
+    const tags = container!.querySelectorAll('[data-testid="template-center-row-visibility"]')
+    const texts = Array.from(tags).map((el) => (el.textContent ?? '').trim())
+    expect(texts).toContain('全员可见')
+    expect(texts).toContain('角色 2')
   })
 
   it('clicking 克隆 calls cloneTemplate + routes to the new detail page', async () => {

--- a/apps/web/tests/helpers/approval-test-fixtures.ts
+++ b/apps/web/tests/helpers/approval-test-fixtures.ts
@@ -159,6 +159,8 @@ export function mockPublishedTemplate(overrides?: Partial<ApprovalTemplateDetail
     key: 'TPL-001',
     name: '通用审批模板',
     description: '适用于日常审批流程',
+    category: null,
+    visibilityScope: { type: 'all', ids: [] },
     status: 'published',
     activeVersionId: 'ver_1_1',
     latestVersionId: 'ver_1_1',

--- a/docs/development/approval-wave2-wp4-template-acl-development-20260423.md
+++ b/docs/development/approval-wave2-wp4-template-acl-development-20260423.md
@@ -1,0 +1,44 @@
+# Approval Wave 2 WP4 Template ACL Development
+
+Scope: WP4 slice 2 adds approval template visibility ACL and fills the deferred OpenAPI contract for template category, clone, categories, and visibility metadata.
+
+## Design
+
+- `approval_templates.visibility_scope JSONB NOT NULL DEFAULT '{"type":"all","ids":[]}'` stores the visibility metadata on the parent template row.
+- Shape: `{ type: 'all' | 'dept' | 'role' | 'user', ids: string[] }`.
+- Existing templates remain compatible because old rows default to `all` and service reads also coalesce missing/invalid values to `all`.
+- `list/get/categories` filter by current actor unless the actor is a template manager.
+- Template managers are actors with `role=admin`, `roles` containing `admin`, `*:*`, or `approval-templates:manage`; they can still manage and see every template.
+- Non-manager visibility match rules:
+  - `all`: visible to everyone authenticated.
+  - `user`: current user id appears in `ids`.
+  - `role`: any current role appears in `ids`.
+  - `dept`: any current department id appears in `ids`.
+
+## API Notes
+
+- `POST /api/approval-templates` accepts optional `visibilityScope`; missing means all visible.
+- `PATCH /api/approval-templates/:id` can update `visibilityScope` without creating a new version.
+- `GET /api/approval-templates` and `GET /api/approval-templates/:id` are authenticated read surfaces, not manager-only surfaces; the ACL filter is the access boundary.
+- `POST /api/approvals` now checks the template ACL before initiating from a published template.
+- `POST /api/approval-templates/:id/clone` copies category and visibility scope into the draft clone.
+
+## Verification
+
+Focused commands:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-template-routes.test.ts --watch=false
+pnpm --filter @metasheet/core-backend exec vitest run tests/integration/approval-wp4-template-categories.api.test.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/approvalTemplateCenterCategory.spec.ts --watch=false
+pnpm --filter @metasheet/core-backend type-check
+pnpm --filter @metasheet/web type-check
+```
+
+Manual UI path:
+
+1. Open `/approval-templates`.
+2. Confirm visible templates show category and visibility summary.
+3. Open a template detail page as a template manager.
+4. Edit 可见范围 with `all`, `dept`, `role`, or `user`; for scoped modes enter comma-separated ids.
+5. Reload as a non-manager actor and verify only matching templates appear.

--- a/docs/development/approval-wave2-wp4-template-acl-development-20260423.md
+++ b/docs/development/approval-wave2-wp4-template-acl-development-20260423.md
@@ -9,6 +9,7 @@ Scope: WP4 slice 2 adds approval template visibility ACL and fills the deferred 
 - Existing templates remain compatible because old rows default to `all` and service reads also coalesce missing/invalid values to `all`.
 - `list/get/categories` filter by current actor unless the actor is a template manager.
 - Template managers are actors with `role=admin`, `roles` containing `admin`, `*:*`, or `approval-templates:manage`; they can still manage and see every template.
+- Route actor resolution accepts both legacy `req.user.role` and array `req.user.roles`, then de-duplicates them before visibility matching.
 - Non-manager visibility match rules:
   - `all`: visible to everyone authenticated.
   - `user`: current user id appears in `ids`.

--- a/docs/development/approval-wave2-wp4-template-acl-development-20260423.md
+++ b/docs/development/approval-wave2-wp4-template-acl-development-20260423.md
@@ -20,9 +20,10 @@ Scope: WP4 slice 2 adds approval template visibility ACL and fills the deferred 
 
 - `POST /api/approval-templates` accepts optional `visibilityScope`; missing means all visible.
 - `PATCH /api/approval-templates/:id` can update `visibilityScope` without creating a new version.
-- `GET /api/approval-templates` and `GET /api/approval-templates/:id` are authenticated read surfaces, not manager-only surfaces; the ACL filter is the access boundary.
+- `GET /api/approval-templates`, `GET /api/approval-templates/categories`, and `GET /api/approval-templates/:id` require `approvals:read`, then apply template ACL filtering. The ACL is not a replacement for route-level RBAC.
 - `POST /api/approvals` now checks the template ACL before initiating from a published template.
 - `POST /api/approval-templates/:id/clone` copies category and visibility scope into the draft clone.
+- The migration uses the Kysely migrator signature (`up(db: Kysely<unknown>)`) rather than a raw `pg.Pool`.
 
 ## Verification
 

--- a/docs/development/approval-wave2-wp4-template-acl-verification-20260423.md
+++ b/docs/development/approval-wave2-wp4-template-acl-verification-20260423.md
@@ -67,6 +67,14 @@ pnpm exec tsx packages/openapi/tools/build.ts
 
 Result: regenerated `packages/openapi/dist/{combined.openapi.yml,openapi.json,openapi.yaml}` for the new approval template visibility contract.
 
+OpenAPI contract gate:
+
+```bash
+./scripts/ops/attendance-run-gate-contract-case.sh openapi
+```
+
+Result: passed after committing the regenerated dist artifacts. The script intentionally verifies two known negative attendance import contract cases and reports them as expected failures before returning `OK`.
+
 Backend full unit/integration run without external PostgreSQL:
 
 ```bash

--- a/docs/development/approval-wave2-wp4-template-acl-verification-20260423.md
+++ b/docs/development/approval-wave2-wp4-template-acl-verification-20260423.md
@@ -1,0 +1,66 @@
+# Approval Wave 2 WP4 Template ACL Verification
+
+Date: 2026-04-23
+
+Scope: focused verification for template visibility ACL, delayed OpenAPI contract coverage, and the compatibility hardening that keeps legacy singular `req.user.role` actors eligible for role-scoped templates.
+
+## Local Verification
+
+Backend route unit coverage:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-template-routes.test.ts --watch=false --reporter=dot
+```
+
+Result: `5/5` passed.
+
+Frontend template and permission coverage:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/approvalTemplateCenterCategory.spec.ts tests/approval-e2e-permissions.spec.ts --watch=false --reporter=dot
+```
+
+Result: `45/45` passed (`7/7` template center + `38/38` permission regression). The run prints an existing Vue warning for the stubbed `el-badge` default slot; it does not fail the suite.
+
+Backend type check:
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+```
+
+Result: exit `0`.
+
+Frontend type check:
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+```
+
+Result: exit `0`.
+
+OpenAPI YAML parse smoke:
+
+```bash
+node -e "const fs=require('fs'); const yaml=require('js-yaml'); for (const f of ['packages/openapi/src/base.yml','packages/openapi/src/paths/approvals.yml']) { yaml.load(fs.readFileSync(f,'utf8')); console.log(f + ' ok') }"
+```
+
+Result:
+
+```text
+packages/openapi/src/base.yml ok
+packages/openapi/src/paths/approvals.yml ok
+```
+
+## Database-Backed Integration
+
+Command attempted:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/integration/approval-wp4-template-categories.api.test.ts --watch=false --reporter=dot
+```
+
+Local result: `10` tests skipped because this machine does not have `DATABASE_URL` configured and the default local PostgreSQL database `chouhua` does not exist. This matches the current local environment limitation; CI or a PG-backed developer environment should run this integration gate before merge.
+
+## Compatibility Note
+
+The route actor resolver was hardened after review to include both `req.user.role` and `req.user.roles`. This keeps older JWT/session shapes compatible with role-scoped template visibility while preserving the new multi-role behavior.

--- a/docs/development/approval-wave2-wp4-template-acl-verification-20260423.md
+++ b/docs/development/approval-wave2-wp4-template-acl-verification-20260423.md
@@ -14,6 +14,14 @@ pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-templa
 
 Result: `5/5` passed.
 
+Backend RBAC boundary coverage:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-rbac-boundary.test.ts tests/unit/approval-template-routes.test.ts --watch=false --reporter=dot
+```
+
+Result: `25/25` passed. This verifies users with no approval permissions still receive `403` on template read routes; route-level `approvals:read` remains the first boundary, with template ACL filtering applied after RBAC.
+
 Frontend template and permission coverage:
 
 ```bash
@@ -50,6 +58,30 @@ Result:
 packages/openapi/src/base.yml ok
 packages/openapi/src/paths/approvals.yml ok
 ```
+
+OpenAPI dist generation:
+
+```bash
+pnpm exec tsx packages/openapi/tools/build.ts
+```
+
+Result: regenerated `packages/openapi/dist/{combined.openapi.yml,openapi.json,openapi.yaml}` for the new approval template visibility contract.
+
+Backend full unit/integration run without external PostgreSQL:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run --reporter=dot
+```
+
+Result: `2533/2533` passed, `47` skipped. The run logs expected local PostgreSQL `database "chouhua" does not exist` messages from degraded lifecycle paths; the suite exits `0`.
+
+## CI Failure Follow-Up
+
+The first PR run exposed three issues and this branch now contains fixes:
+
+- Migration replay failed because the new migration accepted `pg.Pool`; it now uses `Kysely<unknown>` and `sql.execute(db)`.
+- OpenAPI contract failed because generated `dist` artifacts were not committed; the dist files have been regenerated.
+- RBAC boundary failed because template read routes were treated as authentication-only; they now require `approvals:read` before visibility ACL filtering.
 
 ## Database-Backed Integration
 

--- a/packages/core-backend/src/db/migrations/zzzz20260423162000_add_approval_template_visibility_scope.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260423162000_add_approval_template_visibility_scope.ts
@@ -1,0 +1,40 @@
+import type { Pool } from 'pg'
+
+export async function up(pool: Pool): Promise<void> {
+  await pool.query(`
+    ALTER TABLE approval_templates
+      ADD COLUMN IF NOT EXISTS visibility_scope JSONB NOT NULL DEFAULT '{"type":"all","ids":[]}'::jsonb
+  `)
+  await pool.query(`
+    UPDATE approval_templates
+    SET visibility_scope = '{"type":"all","ids":[]}'::jsonb
+    WHERE visibility_scope IS NULL
+  `)
+  await pool.query(`
+    ALTER TABLE approval_templates
+      DROP CONSTRAINT IF EXISTS approval_templates_visibility_scope_shape
+  `)
+  await pool.query(`
+    ALTER TABLE approval_templates
+      ADD CONSTRAINT approval_templates_visibility_scope_shape
+      CHECK (
+        jsonb_typeof(visibility_scope) = 'object'
+        AND visibility_scope ? 'type'
+        AND visibility_scope->>'type' IN ('all', 'dept', 'role', 'user')
+        AND (
+          NOT (visibility_scope ? 'ids')
+          OR jsonb_typeof(visibility_scope->'ids') = 'array'
+        )
+      )
+  `)
+  await pool.query(`
+    CREATE INDEX IF NOT EXISTS idx_approval_templates_visibility_scope_type
+      ON approval_templates ((visibility_scope->>'type'))
+  `)
+}
+
+export async function down(pool: Pool): Promise<void> {
+  await pool.query('DROP INDEX IF EXISTS idx_approval_templates_visibility_scope_type')
+  await pool.query('ALTER TABLE approval_templates DROP CONSTRAINT IF EXISTS approval_templates_visibility_scope_shape')
+  await pool.query('ALTER TABLE approval_templates DROP COLUMN IF EXISTS visibility_scope')
+}

--- a/packages/core-backend/src/db/migrations/zzzz20260423162000_add_approval_template_visibility_scope.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260423162000_add_approval_template_visibility_scope.ts
@@ -1,20 +1,21 @@
-import type { Pool } from 'pg'
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
 
-export async function up(pool: Pool): Promise<void> {
-  await pool.query(`
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
     ALTER TABLE approval_templates
       ADD COLUMN IF NOT EXISTS visibility_scope JSONB NOT NULL DEFAULT '{"type":"all","ids":[]}'::jsonb
-  `)
-  await pool.query(`
+  `.execute(db)
+  await sql`
     UPDATE approval_templates
     SET visibility_scope = '{"type":"all","ids":[]}'::jsonb
     WHERE visibility_scope IS NULL
-  `)
-  await pool.query(`
+  `.execute(db)
+  await sql`
     ALTER TABLE approval_templates
       DROP CONSTRAINT IF EXISTS approval_templates_visibility_scope_shape
-  `)
-  await pool.query(`
+  `.execute(db)
+  await sql`
     ALTER TABLE approval_templates
       ADD CONSTRAINT approval_templates_visibility_scope_shape
       CHECK (
@@ -26,15 +27,15 @@ export async function up(pool: Pool): Promise<void> {
           OR jsonb_typeof(visibility_scope->'ids') = 'array'
         )
       )
-  `)
-  await pool.query(`
+  `.execute(db)
+  await sql`
     CREATE INDEX IF NOT EXISTS idx_approval_templates_visibility_scope_type
       ON approval_templates ((visibility_scope->>'type'))
-  `)
+  `.execute(db)
 }
 
-export async function down(pool: Pool): Promise<void> {
-  await pool.query('DROP INDEX IF EXISTS idx_approval_templates_visibility_scope_type')
-  await pool.query('ALTER TABLE approval_templates DROP CONSTRAINT IF EXISTS approval_templates_visibility_scope_shape')
-  await pool.query('ALTER TABLE approval_templates DROP COLUMN IF EXISTS visibility_scope')
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP INDEX IF EXISTS idx_approval_templates_visibility_scope_type`.execute(db)
+  await sql`ALTER TABLE approval_templates DROP CONSTRAINT IF EXISTS approval_templates_visibility_scope_shape`.execute(db)
+  await sql`ALTER TABLE approval_templates DROP COLUMN IF EXISTS visibility_scope`.execute(db)
 }

--- a/packages/core-backend/src/routes/approvals.ts
+++ b/packages/core-backend/src/routes/approvals.ts
@@ -95,9 +95,13 @@ function resolveApprovalActorName(req: Request, fallbackId: string): string {
 }
 
 function resolveApprovalActorRoles(req: Request): string[] {
-  return Array.isArray(req.user?.roles)
+  const role = typeof req.user?.role === 'string' && req.user.role.trim().length > 0
+    ? [req.user.role.trim()]
+    : []
+  const roles = Array.isArray(req.user?.roles)
     ? req.user!.roles.filter((role): role is string => typeof role === 'string' && role.trim().length > 0)
     : []
+  return Array.from(new Set([...role, ...roles]))
 }
 
 function resolveApprovalActorPermissions(req: Request): string[] {

--- a/packages/core-backend/src/routes/approvals.ts
+++ b/packages/core-backend/src/routes/approvals.ts
@@ -226,7 +226,7 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
   const r = Router()
   const productService = getProductService()
 
-  r.get('/api/approval-templates', authenticate, async (req: Request, res: Response) => {
+  r.get('/api/approval-templates', authenticate, rbacGuard('approvals:read'), async (req: Request, res: Response) => {
     try {
       const actor = resolveApprovalTemplateVisibilityActor(req)
       if (!actor) {
@@ -268,7 +268,7 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
 
   // Wave 2 WP4 slice 1 — served *above* `/api/approval-templates/:id` so
   // Express's matcher does not mistake `categories` for a template id.
-  r.get('/api/approval-templates/categories', authenticate, async (req: Request, res: Response) => {
+  r.get('/api/approval-templates/categories', authenticate, rbacGuard('approvals:read'), async (req: Request, res: Response) => {
     try {
       const actor = resolveApprovalTemplateVisibilityActor(req)
       if (!actor) {
@@ -310,7 +310,7 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
     }
   })
 
-  r.get('/api/approval-templates/:id', authenticate, async (req: Request, res: Response) => {
+  r.get('/api/approval-templates/:id', authenticate, rbacGuard('approvals:read'), async (req: Request, res: Response) => {
     try {
       const actor = resolveApprovalTemplateVisibilityActor(req)
       if (!actor) {

--- a/packages/core-backend/src/routes/approvals.ts
+++ b/packages/core-backend/src/routes/approvals.ts
@@ -15,7 +15,11 @@ import { authenticate } from '../middleware/auth'
 import { rbacGuard } from '../rbac/rbac'
 import { REFUND_WORKFLOW_KEY, type AfterSalesApprovalBridgeService } from '../services/AfterSalesApprovalBridgeService'
 import { ApprovalBridgeService, ServiceError } from '../services/ApprovalBridgeService'
-import { ApprovalProductService, resolveApprovalListPaging } from '../services/ApprovalProductService'
+import {
+  ApprovalProductService,
+  resolveApprovalListPaging,
+  type ApprovalTemplateVisibilityActor,
+} from '../services/ApprovalProductService'
 import {
   APPROVAL_ERROR_CODES,
   type ApprovalBridgePlmAdapter,
@@ -96,6 +100,51 @@ function resolveApprovalActorRoles(req: Request): string[] {
     : []
 }
 
+function resolveApprovalActorPermissions(req: Request): string[] {
+  const permissions = Array.isArray(req.user?.permissions)
+    ? req.user!.permissions.filter((permission): permission is string => typeof permission === 'string')
+    : []
+  const tokenPerms = Array.isArray((req.user as { perms?: unknown })?.perms)
+    ? ((req.user as { perms: unknown }).perms as unknown[]).filter((permission): permission is string => typeof permission === 'string')
+    : []
+  return Array.from(new Set([...permissions, ...tokenPerms].map((permission) => permission.trim()).filter(Boolean)))
+}
+
+function resolveApprovalActorDepartmentIds(req: Request): string[] {
+  const user = req.user as Record<string, unknown> | undefined
+  const candidates = [
+    user?.department,
+    user?.departmentId,
+    user?.deptId,
+    user?.dept,
+  ]
+  const fromScalars = candidates
+    .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+    .map((value) => value.trim())
+  const fromArrays = [user?.departmentIds, user?.departments]
+    .flatMap((value) => Array.isArray(value) ? value : [])
+    .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+    .map((value) => value.trim())
+  return Array.from(new Set([...fromScalars, ...fromArrays]))
+}
+
+function resolveApprovalTemplateVisibilityActor(req: Request): ApprovalTemplateVisibilityActor | undefined {
+  const userId = resolveApprovalActorId(req)
+  if (!userId) return undefined
+  const roles = resolveApprovalActorRoles(req)
+  const permissions = resolveApprovalActorPermissions(req)
+  return {
+    userId,
+    departmentIds: resolveApprovalActorDepartmentIds(req),
+    roles,
+    permissions,
+    isTemplateManager: req.user?.role === 'admin'
+      || roles.includes('admin')
+      || permissions.includes('*:*')
+      || permissions.includes('approval-templates:manage'),
+  }
+}
+
 function approvalVersionConflictResponse(currentVersion: number) {
   return {
     ok: false,
@@ -173,8 +222,14 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
   const r = Router()
   const productService = getProductService()
 
-  r.get('/api/approval-templates', authenticate, rbacGuard('approval-templates:manage'), async (req: Request, res: Response) => {
+  r.get('/api/approval-templates', authenticate, async (req: Request, res: Response) => {
     try {
+      const actor = resolveApprovalTemplateVisibilityActor(req)
+      if (!actor) {
+        return res.status(401).json(
+          approvalErrorResponse('APPROVAL_USER_REQUIRED', 'User ID not found in token'),
+        )
+      }
       const page = parsePaging(req.query.page, 1, Number.MAX_SAFE_INTEGER)
       const pageSize = parsePaging(req.query.pageSize, 20)
       const { limit, offset } = resolveApprovalListPaging(page, pageSize)
@@ -186,6 +241,7 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
         status: typeof req.query.status === 'string' ? req.query.status : undefined,
         search: typeof req.query.search === 'string' ? req.query.search : undefined,
         category: rawCategory.length > 0 ? rawCategory : undefined,
+        actor,
         limit,
         offset,
       })
@@ -208,9 +264,15 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
 
   // Wave 2 WP4 slice 1 — served *above* `/api/approval-templates/:id` so
   // Express's matcher does not mistake `categories` for a template id.
-  r.get('/api/approval-templates/categories', authenticate, rbacGuard('approval-templates:manage'), async (_req: Request, res: Response) => {
+  r.get('/api/approval-templates/categories', authenticate, async (req: Request, res: Response) => {
     try {
-      const data = await productService.listTemplateCategories()
+      const actor = resolveApprovalTemplateVisibilityActor(req)
+      if (!actor) {
+        return res.status(401).json(
+          approvalErrorResponse('APPROVAL_USER_REQUIRED', 'User ID not found in token'),
+        )
+      }
+      const data = await productService.listTemplateCategories(actor)
       res.json({ data })
     } catch (error) {
       handleApprovalsError(
@@ -229,6 +291,7 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
         name: req.body?.name,
         description: req.body?.description,
         category: req.body?.category,
+        visibilityScope: req.body?.visibilityScope,
         formSchema: req.body?.formSchema,
         approvalGraph: req.body?.approvalGraph,
       })
@@ -243,9 +306,15 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
     }
   })
 
-  r.get('/api/approval-templates/:id', authenticate, rbacGuard('approval-templates:manage'), async (req: Request, res: Response) => {
+  r.get('/api/approval-templates/:id', authenticate, async (req: Request, res: Response) => {
     try {
-      const template = await productService.getTemplate(req.params.id)
+      const actor = resolveApprovalTemplateVisibilityActor(req)
+      if (!actor) {
+        return res.status(401).json(
+          approvalErrorResponse('APPROVAL_USER_REQUIRED', 'User ID not found in token'),
+        )
+      }
+      const template = await productService.getTemplate(req.params.id, actor)
       if (!template) {
         return res.status(404).json(
           approvalErrorResponse('APPROVAL_TEMPLATE_NOT_FOUND', 'Approval template not found'),
@@ -272,6 +341,7 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
         // explicitly included it, so an absent field does not wipe existing
         // values. `null` is a legitimate "clear" signal.
         ...('category' in (req.body ?? {}) ? { category: req.body.category } : {}),
+        ...('visibilityScope' in (req.body ?? {}) ? { visibilityScope: req.body.visibilityScope } : {}),
         formSchema: req.body?.formSchema,
         approvalGraph: req.body?.approvalGraph,
       })
@@ -510,10 +580,9 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
           userName: resolveApprovalActorName(req, userId),
           email: typeof req.user?.email === 'string' ? req.user.email : undefined,
           department: typeof req.user?.department === 'string' ? req.user.department : undefined,
+          departmentIds: resolveApprovalActorDepartmentIds(req),
           roles: resolveApprovalActorRoles(req),
-          permissions: Array.isArray(req.user?.permissions)
-            ? req.user!.permissions.filter((permission): permission is string => typeof permission === 'string')
-            : undefined,
+          permissions: resolveApprovalActorPermissions(req),
         },
       )
 

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -4,6 +4,7 @@ import type {
   ApprovalActionRequest,
   ApprovalTemplateDetailDTO,
   ApprovalTemplateListItemDTO,
+  ApprovalTemplateVisibilityScope,
   ApprovalTemplateVersionDetailDTO,
   ApprovalGraph,
   ApprovalMode,
@@ -40,6 +41,7 @@ interface ApprovalTemplateListQuery {
    * uncategorized rows). Trimmed by the router before reaching this layer.
    */
   category?: string
+  actor?: ApprovalTemplateVisibilityActor
   limit: number
   offset: number
 }
@@ -52,8 +54,17 @@ interface CreateApprovalActor {
   userName?: string
   email?: string
   department?: string
+  departmentIds?: string[]
   roles?: string[]
   permissions?: string[]
+}
+
+export interface ApprovalTemplateVisibilityActor {
+  userId: string
+  departmentIds: string[]
+  roles: string[]
+  permissions: string[]
+  isTemplateManager: boolean
 }
 
 type TemplateRow = {
@@ -65,6 +76,7 @@ type TemplateRow = {
    * Wave 2 WP4 slice 1 — nullable group label for the template center filter.
    */
   category: string | null
+  visibility_scope?: Record<string, unknown> | null
   status: 'draft' | 'published' | 'archived'
   active_version_id: string | null
   latest_version_id: string | null
@@ -113,6 +125,7 @@ type TemplateMetadataPatch = {
    * `null` clears the field; `undefined` leaves it untouched.
    */
   category?: string | null
+  visibilityScope?: ApprovalTemplateVisibilityScope
 }
 
 type ApprovalRecordInsert = {
@@ -588,6 +601,7 @@ function toApprovalTemplateListItemDTO(row: TemplateRow): ApprovalTemplateListIt
     description: row.description,
     // Wave 2 WP4 slice 1 — older rows predate the column; coerce undefined to null.
     category: row.category ?? null,
+    visibilityScope: readTemplateVisibilityScope(row.visibility_scope),
     status: row.status,
     activeVersionId: row.active_version_id,
     latestVersionId: row.latest_version_id,
@@ -706,6 +720,9 @@ function normalizeOptionalString(value: unknown): string | null | undefined {
  *   - non-string → 400 VALIDATION_ERROR
  */
 const APPROVAL_TEMPLATE_CATEGORY_MAX_LENGTH = 64
+const APPROVAL_TEMPLATE_VISIBILITY_ID_MAX_LENGTH = 128
+const APPROVAL_TEMPLATE_VISIBILITY_ID_MAX_COUNT = 100
+const APPROVAL_TEMPLATE_VISIBILITY_TYPES = new Set(['all', 'dept', 'role', 'user'])
 
 function normalizeTemplateCategory(value: unknown): string | null | undefined {
   if (value === undefined) return undefined
@@ -723,6 +740,107 @@ function normalizeTemplateCategory(value: unknown): string | null | undefined {
     )
   }
   return trimmed
+}
+
+function normalizeTemplateVisibilityScope(value: unknown): ApprovalTemplateVisibilityScope | undefined {
+  if (value === undefined) return undefined
+  if (value === null) return { type: 'all', ids: [] }
+  if (!isRecord(value)) {
+    throw new ServiceError('visibilityScope must be an object', 400, 'VALIDATION_ERROR')
+  }
+  if (typeof value.type !== 'string' || !APPROVAL_TEMPLATE_VISIBILITY_TYPES.has(value.type)) {
+    throw new ServiceError('visibilityScope.type must be all, dept, role, or user', 400, 'VALIDATION_ERROR')
+  }
+  if (value.type === 'all') return { type: 'all', ids: [] }
+  if (!Array.isArray(value.ids)) {
+    throw new ServiceError('visibilityScope.ids must be an array', 400, 'VALIDATION_ERROR')
+  }
+  const ids = Array.from(new Set(
+    value.ids.map((entry) => {
+      if (typeof entry !== 'string') {
+        throw new ServiceError('visibilityScope.ids must contain strings', 400, 'VALIDATION_ERROR')
+      }
+      const trimmed = entry.trim()
+      if (trimmed.length === 0) {
+        throw new ServiceError('visibilityScope.ids must not contain empty values', 400, 'VALIDATION_ERROR')
+      }
+      if (trimmed.length > APPROVAL_TEMPLATE_VISIBILITY_ID_MAX_LENGTH) {
+        throw new ServiceError(
+          `visibilityScope.ids values must be at most ${APPROVAL_TEMPLATE_VISIBILITY_ID_MAX_LENGTH} characters`,
+          400,
+          'VALIDATION_ERROR',
+        )
+      }
+      return trimmed
+    }),
+  ))
+  if (ids.length === 0) {
+    throw new ServiceError('visibilityScope.ids must contain at least one id for scoped templates', 400, 'VALIDATION_ERROR')
+  }
+  if (ids.length > APPROVAL_TEMPLATE_VISIBILITY_ID_MAX_COUNT) {
+    throw new ServiceError(
+      `visibilityScope.ids must contain at most ${APPROVAL_TEMPLATE_VISIBILITY_ID_MAX_COUNT} ids`,
+      400,
+      'VALIDATION_ERROR',
+    )
+  }
+  return { type: value.type, ids } as ApprovalTemplateVisibilityScope
+}
+
+function readTemplateVisibilityScope(value: unknown): ApprovalTemplateVisibilityScope {
+  if (!isRecord(value)) return { type: 'all', ids: [] }
+  if (typeof value.type !== 'string' || !APPROVAL_TEMPLATE_VISIBILITY_TYPES.has(value.type)) {
+    return { type: 'all', ids: [] }
+  }
+  if (value.type === 'all') return { type: 'all', ids: [] }
+  const ids = Array.isArray(value.ids)
+    ? value.ids
+        .filter((entry): entry is string => typeof entry === 'string' && entry.trim().length > 0)
+        .map((entry) => entry.trim())
+    : []
+  return { type: value.type, ids } as ApprovalTemplateVisibilityScope
+}
+
+function applyTemplateVisibilityFilter(
+  conditions: string[],
+  params: unknown[],
+  index: number,
+  actor?: ApprovalTemplateVisibilityActor,
+): number {
+  if (!actor || actor.isTemplateManager) return index
+
+  const userParam = index++
+  params.push(actor.userId)
+  const deptParam = index++
+  params.push(actor.departmentIds.length > 0 ? actor.departmentIds : ['__approval_template_no_dept__'])
+  const roleParam = index++
+  params.push(actor.roles.length > 0 ? actor.roles : ['__approval_template_no_role__'])
+
+  conditions.push(`(
+    COALESCE(visibility_scope->>'type', 'all') = 'all'
+    OR (
+      visibility_scope->>'type' = 'user'
+      AND EXISTS (
+        SELECT 1 FROM jsonb_array_elements_text(COALESCE(visibility_scope->'ids', '[]'::jsonb)) AS visible_ids(id)
+        WHERE visible_ids.id = $${userParam}
+      )
+    )
+    OR (
+      visibility_scope->>'type' = 'dept'
+      AND EXISTS (
+        SELECT 1 FROM jsonb_array_elements_text(COALESCE(visibility_scope->'ids', '[]'::jsonb)) AS visible_ids(id)
+        WHERE visible_ids.id = ANY($${deptParam}::text[])
+      )
+    )
+    OR (
+      visibility_scope->>'type' = 'role'
+      AND EXISTS (
+        SELECT 1 FROM jsonb_array_elements_text(COALESCE(visibility_scope->'ids', '[]'::jsonb)) AS visible_ids(id)
+        WHERE visible_ids.id = ANY($${roleParam}::text[])
+      )
+    )
+  )`)
+  return index
 }
 
 function assertApprovalGraph(value: unknown, context: ValidationContext = REQUEST_VALIDATION_CONTEXT): ApprovalGraph {
@@ -857,6 +975,7 @@ export class ApprovalProductService {
       conditions.push(`category = $${index++}`)
       params.push(query.category)
     }
+    index = applyTemplateVisibilityFilter(conditions, params, index, query.actor)
 
     const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : ''
 
@@ -879,8 +998,8 @@ export class ApprovalProductService {
     }
   }
 
-  async getTemplate(id: string): Promise<ApprovalTemplateDetailDTO | null> {
-    const bundle = await this.loadTemplateBundle(id, undefined, 'latest')
+  async getTemplate(id: string, actor?: ApprovalTemplateVisibilityActor): Promise<ApprovalTemplateDetailDTO | null> {
+    const bundle = await this.loadTemplateBundle(id, undefined, 'latest', actor)
     return bundle ? toApprovalTemplateDetailDTO(bundle) : null
   }
 
@@ -897,6 +1016,7 @@ export class ApprovalProductService {
     const description = normalizeOptionalString(request.description)
     // Wave 2 WP4 slice 1 — category is optional; `undefined`/empty → null.
     const category = normalizeTemplateCategory(request.category) ?? null
+    const visibilityScope = normalizeTemplateVisibilityScope(request.visibilityScope) ?? { type: 'all', ids: [] }
     const formSchema = assertFormSchema(request.formSchema)
     const approvalGraph = assertApprovalGraph(request.approvalGraph)
 
@@ -906,10 +1026,10 @@ export class ApprovalProductService {
       await client.query('BEGIN')
 
       const templateResult = await client.query<TemplateRow>(
-        `INSERT INTO approval_templates (key, name, description, category, status)
-         VALUES ($1, $2, $3, $4, 'draft')
+        `INSERT INTO approval_templates (key, name, description, category, visibility_scope, status)
+         VALUES ($1, $2, $3, $4, $5, 'draft')
          RETURNING *`,
-        [key, name, description ?? null, category],
+        [key, name, description ?? null, category, JSON.stringify(visibilityScope)],
       )
       let template = templateResult.rows[0]
 
@@ -958,6 +1078,9 @@ export class ApprovalProductService {
       // only category leaves the form/approval graph untouched.
       metadataPatch.category = normalizeTemplateCategory(request.category) ?? null
     }
+    if (request.visibilityScope !== undefined) {
+      metadataPatch.visibilityScope = normalizeTemplateVisibilityScope(request.visibilityScope) ?? { type: 'all', ids: [] }
+    }
 
     const formSchema = request.formSchema !== undefined ? assertFormSchema(request.formSchema) : undefined
     const approvalGraph = request.approvalGraph !== undefined ? assertApprovalGraph(request.approvalGraph) : undefined
@@ -996,6 +1119,10 @@ export class ApprovalProductService {
         if (metadataPatch.category !== undefined) {
           setClauses.push(`category = $${index++}`)
           params.push(metadataPatch.category)
+        }
+        if (metadataPatch.visibilityScope !== undefined) {
+          setClauses.push(`visibility_scope = $${index++}`)
+          params.push(JSON.stringify(metadataPatch.visibilityScope))
         }
         setClauses.push('updated_at = now()')
         params.push(id)
@@ -1167,13 +1294,18 @@ export class ApprovalProductService {
    * client-side because the template row count is small and this keeps the
    * frontend from paging through every template just to populate a filter.
    */
-  async listTemplateCategories(): Promise<string[]> {
+  async listTemplateCategories(actor?: ApprovalTemplateVisibilityActor): Promise<string[]> {
     if (!pool) throw new Error('Database not available')
+    const conditions: string[] = ['category IS NOT NULL']
+    const params: unknown[] = []
+    applyTemplateVisibilityFilter(conditions, params, 1, actor)
+    const where = `WHERE ${conditions.join(' AND ')}`
     const result = await pool.query<{ category: string }>(
       `SELECT DISTINCT category
        FROM approval_templates
-       WHERE category IS NOT NULL
+       ${where}
        ORDER BY category ASC`,
+      params,
     )
     return result.rows.map((row) => row.category).filter((v) => typeof v === 'string' && v.length > 0)
   }
@@ -1223,10 +1355,16 @@ export class ApprovalProductService {
         await client.query('BEGIN')
 
         const templateResult = await client.query<TemplateRow>(
-          `INSERT INTO approval_templates (key, name, description, category, status)
-           VALUES ($1, $2, $3, $4, 'draft')
+          `INSERT INTO approval_templates (key, name, description, category, visibility_scope, status)
+           VALUES ($1, $2, $3, $4, $5, 'draft')
            RETURNING *`,
-          [newKey, newName, source.template.description, source.template.category ?? null],
+          [
+            newKey,
+            newName,
+            source.template.description,
+            source.template.category ?? null,
+            JSON.stringify(readTemplateVisibilityScope(source.template.visibility_scope)),
+          ],
         )
         let template = templateResult.rows[0]
 
@@ -1286,7 +1424,15 @@ export class ApprovalProductService {
   async createApproval(request: CreateApprovalRequest, actor: CreateApprovalActor): Promise<UnifiedApprovalDTO> {
     if (!pool) throw new Error('Database not available')
 
-    const bundle = await this.loadTemplateBundle(request.templateId, undefined, 'active')
+    const bundle = await this.loadTemplateBundle(request.templateId, undefined, 'active', {
+      userId: actor.userId,
+      departmentIds: actor.departmentIds ?? (actor.department ? [actor.department] : []),
+      roles: actor.roles ?? [],
+      permissions: actor.permissions ?? [],
+      isTemplateManager: (actor.permissions ?? []).includes('approval-templates:manage')
+        || (actor.permissions ?? []).includes('*:*')
+        || (actor.roles ?? []).includes('admin'),
+    })
     if (!bundle) {
       throw new ServiceError('Approval template not found', 404, 'APPROVAL_TEMPLATE_NOT_FOUND')
     }
@@ -2004,10 +2150,11 @@ export class ApprovalProductService {
     templateId: string,
     explicitVersionId?: string,
     preferredVersion: TemplateVersionPreference = 'active',
+    actor?: ApprovalTemplateVisibilityActor,
   ): Promise<TemplateBundle | null> {
     if (!pool) throw new Error('Database not available')
 
-    return this.loadTemplateBundleWithClient(pool, templateId, explicitVersionId, preferredVersion)
+    return this.loadTemplateBundleWithClient(pool, templateId, explicitVersionId, preferredVersion, actor)
   }
 
   private async loadTemplateBundleWithClient(
@@ -2015,10 +2162,14 @@ export class ApprovalProductService {
     templateId: string,
     explicitVersionId?: string,
     preferredVersion: TemplateVersionPreference = 'active',
+    actor?: ApprovalTemplateVisibilityActor,
   ): Promise<TemplateBundle | null> {
+    const conditions = ['id = $1']
+    const params: unknown[] = [templateId]
+    applyTemplateVisibilityFilter(conditions, params, 2, actor)
     const templateResult = await client.query<TemplateRow>(
-      `SELECT * FROM approval_templates WHERE id = $1`,
-      [templateId],
+      `SELECT * FROM approval_templates WHERE ${conditions.join(' AND ')}`,
+      params,
     )
     const template = templateResult.rows[0]
     if (!template) return null

--- a/packages/core-backend/src/types/approval-product.ts
+++ b/packages/core-backend/src/types/approval-product.ts
@@ -15,6 +15,7 @@ export type EmptyAssigneePolicy = 'error' | 'auto-approve'
 export type ApprovalActionType = 'approve' | 'reject' | 'transfer' | 'revoke' | 'comment' | 'return'
 export type ApprovalStatus = 'draft' | 'pending' | 'approved' | 'rejected' | 'revoked' | 'cancelled'
 export type ApprovalTemplateStatus = 'draft' | 'published' | 'archived'
+export type ApprovalTemplateVisibilityType = 'all' | 'dept' | 'role' | 'user'
 export type FormFieldType =
   | 'text'
   | 'textarea'
@@ -214,6 +215,11 @@ export interface ApprovalTemplateListItemDTO {
    * does not spawn a new version.
    */
   category: string | null
+  /**
+   * Wave 2 WP4 slice 2 — template visibility ACL. Older templates default to
+   * `{ type: 'all', ids: [] }` and remain globally visible.
+   */
+  visibilityScope: ApprovalTemplateVisibilityScope
   status: ApprovalTemplateStatus
   activeVersionId: string | null
   latestVersionId: string | null
@@ -226,6 +232,11 @@ export interface ApprovalTemplateDetailDTO extends ApprovalTemplateListItemDTO {
   approvalGraph: ApprovalGraph
 }
 
+export interface ApprovalTemplateVisibilityScope {
+  type: ApprovalTemplateVisibilityType
+  ids: string[]
+}
+
 export interface CreateApprovalTemplateRequest {
   key: string
   name: string
@@ -235,6 +246,7 @@ export interface CreateApprovalTemplateRequest {
    * normalized to `null`; values longer than 64 chars trigger 400.
    */
   category?: string | null
+  visibilityScope?: ApprovalTemplateVisibilityScope | null
   formSchema: FormSchema
   approvalGraph: ApprovalGraph
 }
@@ -248,6 +260,7 @@ export interface UpdateApprovalTemplateRequest {
    * directly without creating a new template version.
    */
   category?: string | null
+  visibilityScope?: ApprovalTemplateVisibilityScope | null
   formSchema?: FormSchema
   approvalGraph?: ApprovalGraph
 }

--- a/packages/core-backend/tests/helpers/approval-schema-bootstrap.ts
+++ b/packages/core-backend/tests/helpers/approval-schema-bootstrap.ts
@@ -1,7 +1,7 @@
 import { poolManager } from '../../src/integration/db/connection-pool'
 
 const APPROVAL_SCHEMA_BOOTSTRAP_KEY = 'approval-schema-bootstrap'
-const APPROVAL_SCHEMA_BOOTSTRAP_VERSION = '20260423-wp4-template-category'
+const APPROVAL_SCHEMA_BOOTSTRAP_VERSION = '20260423-wp4-template-acl'
 
 /**
  * Ensures the approval schema (tables, constraints, indexes, sequences) is
@@ -287,7 +287,27 @@ export async function ensureApprovalSchemaReady(): Promise<void> {
     `)
     await client.query(`CREATE INDEX IF NOT EXISTS idx_approval_templates_status_updated ON approval_templates(status, updated_at DESC)`)
     await client.query(`ALTER TABLE approval_templates ADD COLUMN IF NOT EXISTS category TEXT`)
+    await client.query(`ALTER TABLE approval_templates ADD COLUMN IF NOT EXISTS visibility_scope JSONB NOT NULL DEFAULT '{"type":"all","ids":[]}'::jsonb`)
+    await client.query(`UPDATE approval_templates SET visibility_scope = '{"type":"all","ids":[]}'::jsonb WHERE visibility_scope IS NULL`)
+    await client.query(`
+      DO $$
+      BEGIN
+        ALTER TABLE approval_templates
+          ADD CONSTRAINT approval_templates_visibility_scope_shape
+          CHECK (
+            jsonb_typeof(visibility_scope) = 'object'
+            AND visibility_scope ? 'type'
+            AND visibility_scope->>'type' IN ('all', 'dept', 'role', 'user')
+            AND (
+              NOT (visibility_scope ? 'ids')
+              OR jsonb_typeof(visibility_scope->'ids') = 'array'
+            )
+          );
+      EXCEPTION WHEN duplicate_object THEN NULL;
+      END $$;
+    `)
     await client.query(`CREATE INDEX IF NOT EXISTS idx_approval_templates_category_status ON approval_templates(category, status) WHERE category IS NOT NULL`)
+    await client.query(`CREATE INDEX IF NOT EXISTS idx_approval_templates_visibility_scope_type ON approval_templates ((visibility_scope->>'type'))`)
     await client.query(`CREATE INDEX IF NOT EXISTS idx_approval_template_versions_template ON approval_template_versions(template_id, version DESC)`)
     await client.query(`CREATE INDEX IF NOT EXISTS idx_approval_published_definitions_template_version ON approval_published_definitions(template_version_id, published_at DESC)`)
     await client.query(`CREATE UNIQUE INDEX IF NOT EXISTS idx_approval_published_definitions_active_template ON approval_published_definitions(template_id) WHERE is_active = TRUE`)

--- a/packages/core-backend/tests/integration/approval-wp4-template-categories.api.test.ts
+++ b/packages/core-backend/tests/integration/approval-wp4-template-categories.api.test.ts
@@ -11,11 +11,10 @@
  *       - key:   `"{original}_copy_<6 hex chars>"`
  *       - same formSchema + approvalGraph + category
  *       - status 'draft' (no `publishedDefinition` carried over)
- *   - 403 when the caller lacks `approval-templates:manage`
+ *   - 403 when the caller lacks `approval-templates:manage` for clone
  *   - 404 when the source template id does not exist
  *
- * ACL / 可见范围, 字段联动, 条件显隐 are other WP4 targets explicitly deferred
- * to later slices.
+ * Slice 2 extends the same surface with template visibility ACL.
  */
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import net from 'net'
@@ -104,7 +103,7 @@ describeIfDatabase('Approval Wave 2 WP4 slice 1 — template categories & clone'
     await ensureApprovalSchemaReady()
 
     // The approval schema bootstrap does not cover the RBAC tables, so the
-    // route-level `rbacGuard('approval-templates:manage')` fallback path
+    // clone's route-level `rbacGuard('approval-templates:manage')` fallback path
     // (DB isAdmin + userHasPermission + namespace-admission) would throw
     // against missing relations and surface as 500 instead of the 403 we
     // want to assert below. Materializing empty stub tables lets the normal
@@ -182,7 +181,12 @@ describeIfDatabase('Approval Wave 2 WP4 slice 1 — template categories & clone'
 
   async function createTemplate(
     token: string,
-    overrides: { key: string; name: string; category?: string | null },
+    overrides: {
+      key: string
+      name: string
+      category?: string | null
+      visibilityScope?: { type: 'all' | 'dept' | 'role' | 'user'; ids: string[] }
+    },
   ): Promise<{ id: string; category: string | null; key: string; name: string }> {
     const body: Record<string, unknown> = {
       key: overrides.key,
@@ -191,6 +195,7 @@ describeIfDatabase('Approval Wave 2 WP4 slice 1 — template categories & clone'
       approvalGraph: buildLinearGraph(),
     }
     if (overrides.category !== undefined) body.category = overrides.category
+    if (overrides.visibilityScope !== undefined) body.visibilityScope = overrides.visibilityScope
     const response = await jsonRequest(baseUrl, '/api/approval-templates', token, {
       method: 'POST',
       body,
@@ -430,5 +435,82 @@ describeIfDatabase('Approval Wave 2 WP4 slice 1 — template categories & clone'
     expect(response.status).toBe(404)
     const payload = await response.json() as { error?: { code?: string } }
     expect(payload.error?.code).toBe('APPROVAL_TEMPLATE_NOT_FOUND')
+  })
+
+  it('filters template list/detail by user and role visibility for non-managers', async () => {
+    const adminToken = await devToken(baseUrl, `wp4-admin-acl-${suiteSuffix}`)
+    const userOnly = await createTemplate(adminToken, {
+      key: `wp4-acl-user-${suiteSuffix}`,
+      name: 'WP4 ACL User',
+      visibilityScope: { type: 'user', ids: [`visible-user-${suiteSuffix}`] },
+    })
+    const roleOnly = await createTemplate(adminToken, {
+      key: `wp4-acl-role-${suiteSuffix}`,
+      name: 'WP4 ACL Role',
+      visibilityScope: { type: 'role', ids: [`visible-role-${suiteSuffix}`] },
+    })
+    const allVisible = await createTemplate(adminToken, {
+      key: `wp4-acl-all-${suiteSuffix}`,
+      name: 'WP4 ACL All',
+    })
+
+    const visibleUserToken = await devToken(baseUrl, `visible-user-${suiteSuffix}`, {
+      roles: 'employee',
+      perms: 'approvals:read',
+    })
+    const hiddenUserToken = await devToken(baseUrl, `hidden-user-${suiteSuffix}`, {
+      roles: 'employee',
+      perms: 'approvals:read',
+    })
+    const roleUserToken = await devToken(baseUrl, `role-user-${suiteSuffix}`, {
+      roles: `employee,visible-role-${suiteSuffix}`,
+      perms: 'approvals:read',
+    })
+
+    const visibleResponse = await jsonRequest(baseUrl, `/api/approval-templates?pageSize=200`, visibleUserToken)
+    expect(visibleResponse.status).toBe(200)
+    const visiblePayload = await visibleResponse.json() as { data: Array<{ id: string }> }
+    const visibleIds = new Set(visiblePayload.data.map((row) => row.id))
+    expect(visibleIds.has(userOnly.id)).toBe(true)
+    expect(visibleIds.has(roleOnly.id)).toBe(false)
+    expect(visibleIds.has(allVisible.id)).toBe(true)
+
+    const hiddenResponse = await jsonRequest(baseUrl, `/api/approval-templates?pageSize=200`, hiddenUserToken)
+    expect(hiddenResponse.status).toBe(200)
+    const hiddenPayload = await hiddenResponse.json() as { data: Array<{ id: string }> }
+    const hiddenIds = new Set(hiddenPayload.data.map((row) => row.id))
+    expect(hiddenIds.has(userOnly.id)).toBe(false)
+    expect(hiddenIds.has(roleOnly.id)).toBe(false)
+    expect(hiddenIds.has(allVisible.id)).toBe(true)
+
+    const roleResponse = await jsonRequest(baseUrl, `/api/approval-templates?pageSize=200`, roleUserToken)
+    expect(roleResponse.status).toBe(200)
+    const rolePayload = await roleResponse.json() as { data: Array<{ id: string }> }
+    const roleIds = new Set(rolePayload.data.map((row) => row.id))
+    expect(roleIds.has(roleOnly.id)).toBe(true)
+
+    const hiddenDetailResponse = await jsonRequest(baseUrl, `/api/approval-templates/${userOnly.id}`, hiddenUserToken)
+    expect(hiddenDetailResponse.status).toBe(404)
+    const visibleDetailResponse = await jsonRequest(baseUrl, `/api/approval-templates/${userOnly.id}`, visibleUserToken)
+    expect(visibleDetailResponse.status).toBe(200)
+    const visibleDetail = await visibleDetailResponse.json() as {
+      visibilityScope: { type: string; ids: string[] }
+    }
+    expect(visibleDetail.visibilityScope).toEqual({ type: 'user', ids: [`visible-user-${suiteSuffix}`] })
+  })
+
+  it('lets template managers see scoped templates regardless of visibility scope', async () => {
+    const adminToken = await devToken(baseUrl, `wp4-admin-acl-manager-${suiteSuffix}`)
+    const scoped = await createTemplate(adminToken, {
+      key: `wp4-acl-manager-${suiteSuffix}`,
+      name: 'WP4 ACL Manager',
+      visibilityScope: { type: 'user', ids: [`someone-else-${suiteSuffix}`] },
+    })
+
+    const managerResponse = await jsonRequest(baseUrl, `/api/approval-templates/${scoped.id}`, adminToken)
+    expect(managerResponse.status).toBe(200)
+    const detail = await managerResponse.json() as { id: string; visibilityScope: { type: string; ids: string[] } }
+    expect(detail.id).toBe(scoped.id)
+    expect(detail.visibilityScope).toEqual({ type: 'user', ids: [`someone-else-${suiteSuffix}`] })
   })
 })

--- a/packages/core-backend/tests/unit/approval-template-routes.test.ts
+++ b/packages/core-backend/tests/unit/approval-template-routes.test.ts
@@ -8,6 +8,7 @@ type TemplateRow = {
   name: string
   description: string | null
   category: string | null
+  visibility_scope: Record<string, unknown> | null
   status: 'draft' | 'published' | 'archived'
   active_version_id: string | null
   latest_version_id: string | null
@@ -64,6 +65,7 @@ const routeState = vi.hoisted(() => {
       name: 'Travel Request',
       description: 'Base template',
       category: null,
+      visibility_scope: { type: 'all', ids: [] },
       status: 'draft',
       active_version_id: null,
       latest_version_id: null,
@@ -123,7 +125,15 @@ const routeState = vi.hoisted(() => {
     }
 
     if (normalized.startsWith('SELECT COUNT(*)::text AS count FROM approval_templates')) {
-      return { rows: [{ count: String(state.templates.size) }], rowCount: 1 }
+      const rows = Array.from(state.templates.values()).filter((row) => {
+        if (!normalized.includes('visibility_scope')) return true
+        const scope = row.visibility_scope
+        if (!scope || scope.type === 'all') return true
+        if (scope.type === 'user') return (scope.ids as string[]).includes('template-admin')
+        if (scope.type === 'role') return (scope.ids as string[]).includes('admin')
+        return false
+      })
+      return { rows: [{ count: String(rows.length) }], rowCount: 1 }
     }
 
     if (
@@ -131,6 +141,14 @@ const routeState = vi.hoisted(() => {
       || normalized.startsWith('SELECT * FROM approval_templates WHERE id = $1')
     ) {
       const row = state.templates.get(String(params[0]))
+      if (row && normalized.includes('visibility_scope')) {
+        const scope = row.visibility_scope
+        const visible = !scope
+          || scope.type === 'all'
+          || (scope.type === 'user' && (scope.ids as string[]).includes('template-admin'))
+          || (scope.type === 'role' && (scope.ids as string[]).includes('admin'))
+        return { rows: visible ? [row] : [], rowCount: visible ? 1 : 0 }
+      }
       return { rows: row ? [row] : [], rowCount: row ? 1 : 0 }
     }
 
@@ -148,15 +166,16 @@ const routeState = vi.hoisted(() => {
 
     if (normalized.startsWith('INSERT INTO approval_templates')) {
       const timestamp = now()
-      // Wave 2 WP4 slice 1 — production SQL is:
-      //   INSERT INTO approval_templates (key, name, description, category, status)
-      //   VALUES ($1, $2, $3, $4, 'draft')
+      const hasVisibilityScope = normalized.includes('visibility_scope')
       const row: TemplateRow = {
         id: `tpl-${state.templateSeq++}`,
         key: String(params[0]),
         name: String(params[1]),
         description: params[2] == null ? null : String(params[2]),
         category: params[3] == null ? null : String(params[3]),
+        visibility_scope: hasVisibilityScope
+          ? parseJson(params[4])
+          : { type: 'all', ids: [] },
         status: 'draft',
         active_version_id: null,
         latest_version_id: null,
@@ -199,6 +218,9 @@ const routeState = vi.hoisted(() => {
         // Wave 2 WP4 slice 1 — category updates on the parent row.
         const value = params[index++]
         row.category = value == null ? null : String(value)
+      }
+      if (normalized.includes('visibility_scope = $')) {
+        row.visibility_scope = parseJson(params[index++])
       }
       row.updated_at = now()
       return { rows: [row], rowCount: 1 }
@@ -369,6 +391,7 @@ describe('approval template routes', () => {
     expect(response.body.key).toBe('expense-approval')
     expect(response.body.status).toBe('draft')
     expect(response.body.latestVersionId).toMatch(/^ver-/)
+    expect(response.body.visibilityScope).toEqual({ type: 'all', ids: [] })
     expect(response.body.formSchema.fields).toHaveLength(1)
     expect(response.body.approvalGraph.nodes[1].config).toEqual({
       assigneeType: 'role',
@@ -376,6 +399,47 @@ describe('approval template routes', () => {
       approvalMode: 'all',
       emptyAssigneePolicy: 'auto-approve',
     })
+  })
+
+  it('creates and patches template visibility scope metadata without rotating versions', async () => {
+    const app = createApp()
+
+    const createResponse = await request(app)
+      .post('/api/approval-templates')
+      .send({
+        key: 'dept-expense',
+        name: 'Dept Expense',
+        visibilityScope: { type: 'dept', ids: ['finance', 'ops'] },
+        formSchema: {
+          fields: [{ id: 'amount', type: 'number', label: 'Amount', required: true }],
+        },
+        approvalGraph: {
+          nodes: [
+            { key: 'start', type: 'start', config: {} },
+            { key: 'approve_1', type: 'approval', config: { assigneeType: 'role', assigneeIds: ['finance'] } },
+            { key: 'end', type: 'end', config: {} },
+          ],
+          edges: [
+            { key: 'e1', source: 'start', target: 'approve_1' },
+            { key: 'e2', source: 'approve_1', target: 'end' },
+          ],
+        },
+      })
+
+    expect(createResponse.status).toBe(201)
+    expect(createResponse.body.visibilityScope).toEqual({ type: 'dept', ids: ['finance', 'ops'] })
+    const originalVersionId = createResponse.body.latestVersionId
+
+    const patchResponse = await request(app)
+      .patch(`/api/approval-templates/${createResponse.body.id}`)
+      .send({
+        visibilityScope: { type: 'role', ids: ['manager'] },
+      })
+
+    expect(patchResponse.status).toBe(200)
+    expect(patchResponse.body.visibilityScope).toEqual({ type: 'role', ids: ['manager'] })
+    expect(patchResponse.body.latestVersionId).toBe(originalVersionId)
+    expect(routeState.state.versions.size).toBe(1)
   })
 
   it('patches template metadata and creates a new draft version when graph changes', async () => {

--- a/packages/openapi/dist/combined.openapi.yml
+++ b/packages/openapi/dist/combined.openapi.yml
@@ -2701,6 +2701,12 @@ components:
         description:
           type: string
           nullable: true
+        category:
+          type: string
+          nullable: true
+          maxLength: 64
+        visibilityScope:
+          $ref: '#/components/schemas/ApprovalTemplateVisibilityScope'
         status:
           type: string
           enum:
@@ -2723,11 +2729,33 @@ components:
         - id
         - key
         - name
+        - category
+        - visibilityScope
         - status
         - activeVersionId
         - latestVersionId
         - createdAt
         - updatedAt
+    ApprovalTemplateVisibilityScope:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - all
+            - dept
+            - role
+            - user
+          description: Visibility mode. `all` ignores `ids`.
+        ids:
+          type: array
+          items:
+            type: string
+          maxItems: 100
+          description: Department, role, or user ids for scoped visibility.
+      required:
+        - type
+        - ids
     ApprovalTemplateDetail:
       allOf:
         - $ref: '#/components/schemas/ApprovalTemplateListItem'
@@ -2750,6 +2778,12 @@ components:
         description:
           type: string
           nullable: true
+        category:
+          type: string
+          nullable: true
+          maxLength: 64
+        visibilityScope:
+          $ref: '#/components/schemas/ApprovalTemplateVisibilityScope'
         formSchema:
           $ref: '#/components/schemas/FormSchema'
         approvalGraph:
@@ -2769,6 +2803,12 @@ components:
         description:
           type: string
           nullable: true
+        category:
+          type: string
+          nullable: true
+          maxLength: 64
+        visibilityScope:
+          $ref: '#/components/schemas/ApprovalTemplateVisibilityScope'
         formSchema:
           $ref: '#/components/schemas/FormSchema'
         approvalGraph:
@@ -3751,7 +3791,9 @@ paths:
       summary: List approval templates
       description: |
         Returns a paginated list of approval templates. Supports search by name
-        and filtering by status (draft, published, archived).
+        and filtering by status/category. Non-template-managers only receive
+        templates visible to their actor scope (`all`, matching department,
+        role, or user). Template managers can see all templates.
       security:
         - bearerAuth: []
       parameters:
@@ -3768,16 +3810,20 @@ paths:
               - published
               - archived
         - in: query
-          name: limit
+          name: category
+          schema:
+            type: string
+        - in: query
+          name: page
+          schema:
+            type: integer
+            minimum: 1
+        - in: query
+          name: pageSize
           schema:
             type: integer
             minimum: 1
             maximum: 200
-        - in: query
-          name: offset
-          schema:
-            type: integer
-            minimum: 0
       responses:
         '200':
           description: OK
@@ -3786,30 +3832,23 @@ paths:
               schema:
                 type: object
                 properties:
-                  ok:
-                    type: boolean
-                    example: true
                   data:
-                    type: object
-                    properties:
-                      items:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/ApprovalTemplateListItem'
-                      total:
-                        type: integer
-                      limit:
-                        type: integer
-                      offset:
-                        type: integer
-                    required:
-                      - items
-                      - total
-                      - limit
-                      - offset
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ApprovalTemplateListItem'
+                  total:
+                    type: integer
+                  limit:
+                    type: integer
+                    description: Effective page size.
+                  offset:
+                    type: integer
+                    description: Zero-based offset derived from page/pageSize.
                 required:
-                  - ok
                   - data
+                  - total
+                  - limit
+                  - offset
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -3826,6 +3865,10 @@ paths:
 
         The template must be published before it can be used to initiate
         approvals.
+
+        Optional category and visibilityScope metadata live on the parent
+
+        template row and do not become version snapshots.
       security:
         - bearerAuth: []
       requestBody:
@@ -3856,6 +3899,32 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
+  /api/approval-templates/categories:
+    get:
+      operationId: listApprovalTemplateCategories
+      tags:
+        - Approval Templates
+      summary: List approval template categories
+      description: |
+        Returns distinct non-null categories visible to the current actor.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: string
+                required:
+                  - data
+        '401':
+          $ref: '#/components/responses/Unauthorized'
   /api/approval-templates/{id}:
     get:
       operationId: getApprovalTemplate
@@ -3863,7 +3932,9 @@ paths:
         - Approval Templates
       summary: Get approval template detail
       description: |
-        Returns the full template including formSchema and approvalGraph.
+        Returns the full template including formSchema and approvalGraph when
+        the current actor can see the template. Template managers can see all
+        templates.
       security:
         - bearerAuth: []
       parameters:
@@ -3900,8 +3971,9 @@ paths:
         - Approval Templates
       summary: Update approval template draft
       description: |
-        Updates an existing template. Each update automatically creates a new
-        version. All fields are optional; only provided fields are updated.
+        Updates an existing template. formSchema/approvalGraph updates create a
+        new version; metadata-only updates such as category or visibilityScope
+        update the parent row in place. All fields are optional.
       security:
         - bearerAuth: []
       parameters:
@@ -3940,6 +4012,43 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
+  /api/approval-templates/{id}/clone:
+    post:
+      operationId: cloneApprovalTemplate
+      tags:
+        - Approval Templates
+      summary: Clone approval template
+      description: |
+        Clones an existing template's latest formSchema/approvalGraph into a
+        new draft template. Category and visibilityScope are copied; published
+        definitions and version history are not copied.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApprovalTemplateDetail'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: Clone key conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /api/approval-templates/{id}/publish:
     post:
       operationId: publishApprovalTemplate

--- a/packages/openapi/dist/openapi.json
+++ b/packages/openapi/dist/openapi.json
@@ -3873,6 +3873,14 @@
             "type": "string",
             "nullable": true
           },
+          "category": {
+            "type": "string",
+            "nullable": true,
+            "maxLength": 64
+          },
+          "visibilityScope": {
+            "$ref": "#/components/schemas/ApprovalTemplateVisibilityScope"
+          },
           "status": {
             "type": "string",
             "enum": [
@@ -3902,11 +3910,40 @@
           "id",
           "key",
           "name",
+          "category",
+          "visibilityScope",
           "status",
           "activeVersionId",
           "latestVersionId",
           "createdAt",
           "updatedAt"
+        ]
+      },
+      "ApprovalTemplateVisibilityScope": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "all",
+              "dept",
+              "role",
+              "user"
+            ],
+            "description": "Visibility mode. `all` ignores `ids`."
+          },
+          "ids": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 100,
+            "description": "Department, role, or user ids for scoped visibility."
+          }
+        },
+        "required": [
+          "type",
+          "ids"
         ]
       },
       "ApprovalTemplateDetail": {
@@ -3944,6 +3981,14 @@
             "type": "string",
             "nullable": true
           },
+          "category": {
+            "type": "string",
+            "nullable": true,
+            "maxLength": 64
+          },
+          "visibilityScope": {
+            "$ref": "#/components/schemas/ApprovalTemplateVisibilityScope"
+          },
           "formSchema": {
             "$ref": "#/components/schemas/FormSchema"
           },
@@ -3970,6 +4015,14 @@
           "description": {
             "type": "string",
             "nullable": true
+          },
+          "category": {
+            "type": "string",
+            "nullable": true,
+            "maxLength": 64
+          },
+          "visibilityScope": {
+            "$ref": "#/components/schemas/ApprovalTemplateVisibilityScope"
           },
           "formSchema": {
             "$ref": "#/components/schemas/FormSchema"
@@ -5468,7 +5521,7 @@
           "Approval Templates"
         ],
         "summary": "List approval templates",
-        "description": "Returns a paginated list of approval templates. Supports search by name\nand filtering by status (draft, published, archived).\n",
+        "description": "Returns a paginated list of approval templates. Supports search by name\nand filtering by status/category. Non-template-managers only receive\ntemplates visible to their actor scope (`all`, matching department,\nrole, or user). Template managers can see all templates.\n",
         "security": [
           {
             "bearerAuth": []
@@ -5496,19 +5549,26 @@
           },
           {
             "in": "query",
-            "name": "limit",
+            "name": "category",
             "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "maximum": 200
+              "type": "string"
             }
           },
           {
             "in": "query",
-            "name": "offset",
+            "name": "page",
             "schema": {
               "type": "integer",
-              "minimum": 0
+              "minimum": 1
+            }
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 200
             }
           }
         ],
@@ -5520,40 +5580,29 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "ok": {
-                      "type": "boolean",
-                      "example": true
-                    },
                     "data": {
-                      "type": "object",
-                      "properties": {
-                        "items": {
-                          "type": "array",
-                          "items": {
-                            "$ref": "#/components/schemas/ApprovalTemplateListItem"
-                          }
-                        },
-                        "total": {
-                          "type": "integer"
-                        },
-                        "limit": {
-                          "type": "integer"
-                        },
-                        "offset": {
-                          "type": "integer"
-                        }
-                      },
-                      "required": [
-                        "items",
-                        "total",
-                        "limit",
-                        "offset"
-                      ]
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/ApprovalTemplateListItem"
+                      }
+                    },
+                    "total": {
+                      "type": "integer"
+                    },
+                    "limit": {
+                      "type": "integer",
+                      "description": "Effective page size."
+                    },
+                    "offset": {
+                      "type": "integer",
+                      "description": "Zero-based offset derived from page/pageSize."
                     }
                   },
                   "required": [
-                    "ok",
-                    "data"
+                    "data",
+                    "total",
+                    "limit",
+                    "offset"
                   ]
                 }
               }
@@ -5573,7 +5622,7 @@
           "Approval Templates"
         ],
         "summary": "Create approval template",
-        "description": "Creates a new approval template in draft status. Requires key (unique),\nname, formSchema (with fields), and approvalGraph (nodes + edges).\nThe template must be published before it can be used to initiate approvals.\n",
+        "description": "Creates a new approval template in draft status. Requires key (unique),\nname, formSchema (with fields), and approvalGraph (nodes + edges).\nThe template must be published before it can be used to initiate approvals.\nOptional category and visibilityScope metadata live on the parent\ntemplate row and do not become version snapshots.\n",
         "security": [
           {
             "bearerAuth": []
@@ -5625,6 +5674,47 @@
         }
       }
     },
+    "/api/approval-templates/categories": {
+      "get": {
+        "operationId": "listApprovalTemplateCategories",
+        "tags": [
+          "Approval Templates"
+        ],
+        "summary": "List approval template categories",
+        "description": "Returns distinct non-null categories visible to the current actor.\n",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
     "/api/approval-templates/{id}": {
       "get": {
         "operationId": "getApprovalTemplate",
@@ -5632,7 +5722,7 @@
           "Approval Templates"
         ],
         "summary": "Get approval template detail",
-        "description": "Returns the full template including formSchema and approvalGraph.\n",
+        "description": "Returns the full template including formSchema and approvalGraph when\nthe current actor can see the template. Template managers can see all\ntemplates.\n",
         "security": [
           {
             "bearerAuth": []
@@ -5689,7 +5779,7 @@
           "Approval Templates"
         ],
         "summary": "Update approval template draft",
-        "description": "Updates an existing template. Each update automatically creates a new\nversion. All fields are optional; only provided fields are updated.\n",
+        "description": "Updates an existing template. formSchema/approvalGraph updates create a\nnew version; metadata-only updates such as category or visibilityScope\nupdate the parent row in place. All fields are optional.\n",
         "security": [
           {
             "bearerAuth": []
@@ -5750,6 +5840,62 @@
           },
           "404": {
             "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/api/approval-templates/{id}/clone": {
+      "post": {
+        "operationId": "cloneApprovalTemplate",
+        "tags": [
+          "Approval Templates"
+        ],
+        "summary": "Clone approval template",
+        "description": "Clones an existing template's latest formSchema/approvalGraph into a\nnew draft template. Category and visibilityScope are copied; published\ndefinitions and version history are not copied.\n",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApprovalTemplateDetail"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "description": "Clone key conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }

--- a/packages/openapi/dist/openapi.yaml
+++ b/packages/openapi/dist/openapi.yaml
@@ -2701,6 +2701,12 @@ components:
         description:
           type: string
           nullable: true
+        category:
+          type: string
+          nullable: true
+          maxLength: 64
+        visibilityScope:
+          $ref: '#/components/schemas/ApprovalTemplateVisibilityScope'
         status:
           type: string
           enum:
@@ -2723,11 +2729,33 @@ components:
         - id
         - key
         - name
+        - category
+        - visibilityScope
         - status
         - activeVersionId
         - latestVersionId
         - createdAt
         - updatedAt
+    ApprovalTemplateVisibilityScope:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - all
+            - dept
+            - role
+            - user
+          description: Visibility mode. `all` ignores `ids`.
+        ids:
+          type: array
+          items:
+            type: string
+          maxItems: 100
+          description: Department, role, or user ids for scoped visibility.
+      required:
+        - type
+        - ids
     ApprovalTemplateDetail:
       allOf:
         - $ref: '#/components/schemas/ApprovalTemplateListItem'
@@ -2750,6 +2778,12 @@ components:
         description:
           type: string
           nullable: true
+        category:
+          type: string
+          nullable: true
+          maxLength: 64
+        visibilityScope:
+          $ref: '#/components/schemas/ApprovalTemplateVisibilityScope'
         formSchema:
           $ref: '#/components/schemas/FormSchema'
         approvalGraph:
@@ -2769,6 +2803,12 @@ components:
         description:
           type: string
           nullable: true
+        category:
+          type: string
+          nullable: true
+          maxLength: 64
+        visibilityScope:
+          $ref: '#/components/schemas/ApprovalTemplateVisibilityScope'
         formSchema:
           $ref: '#/components/schemas/FormSchema'
         approvalGraph:
@@ -3751,7 +3791,9 @@ paths:
       summary: List approval templates
       description: |
         Returns a paginated list of approval templates. Supports search by name
-        and filtering by status (draft, published, archived).
+        and filtering by status/category. Non-template-managers only receive
+        templates visible to their actor scope (`all`, matching department,
+        role, or user). Template managers can see all templates.
       security:
         - bearerAuth: []
       parameters:
@@ -3768,16 +3810,20 @@ paths:
               - published
               - archived
         - in: query
-          name: limit
+          name: category
+          schema:
+            type: string
+        - in: query
+          name: page
+          schema:
+            type: integer
+            minimum: 1
+        - in: query
+          name: pageSize
           schema:
             type: integer
             minimum: 1
             maximum: 200
-        - in: query
-          name: offset
-          schema:
-            type: integer
-            minimum: 0
       responses:
         '200':
           description: OK
@@ -3786,30 +3832,23 @@ paths:
               schema:
                 type: object
                 properties:
-                  ok:
-                    type: boolean
-                    example: true
                   data:
-                    type: object
-                    properties:
-                      items:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/ApprovalTemplateListItem'
-                      total:
-                        type: integer
-                      limit:
-                        type: integer
-                      offset:
-                        type: integer
-                    required:
-                      - items
-                      - total
-                      - limit
-                      - offset
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ApprovalTemplateListItem'
+                  total:
+                    type: integer
+                  limit:
+                    type: integer
+                    description: Effective page size.
+                  offset:
+                    type: integer
+                    description: Zero-based offset derived from page/pageSize.
                 required:
-                  - ok
                   - data
+                  - total
+                  - limit
+                  - offset
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -3826,6 +3865,10 @@ paths:
 
         The template must be published before it can be used to initiate
         approvals.
+
+        Optional category and visibilityScope metadata live on the parent
+
+        template row and do not become version snapshots.
       security:
         - bearerAuth: []
       requestBody:
@@ -3856,6 +3899,32 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
+  /api/approval-templates/categories:
+    get:
+      operationId: listApprovalTemplateCategories
+      tags:
+        - Approval Templates
+      summary: List approval template categories
+      description: |
+        Returns distinct non-null categories visible to the current actor.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: string
+                required:
+                  - data
+        '401':
+          $ref: '#/components/responses/Unauthorized'
   /api/approval-templates/{id}:
     get:
       operationId: getApprovalTemplate
@@ -3863,7 +3932,9 @@ paths:
         - Approval Templates
       summary: Get approval template detail
       description: |
-        Returns the full template including formSchema and approvalGraph.
+        Returns the full template including formSchema and approvalGraph when
+        the current actor can see the template. Template managers can see all
+        templates.
       security:
         - bearerAuth: []
       parameters:
@@ -3900,8 +3971,9 @@ paths:
         - Approval Templates
       summary: Update approval template draft
       description: |
-        Updates an existing template. Each update automatically creates a new
-        version. All fields are optional; only provided fields are updated.
+        Updates an existing template. formSchema/approvalGraph updates create a
+        new version; metadata-only updates such as category or visibilityScope
+        update the parent row in place. All fields are optional.
       security:
         - bearerAuth: []
       parameters:
@@ -3940,6 +4012,43 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
+  /api/approval-templates/{id}/clone:
+    post:
+      operationId: cloneApprovalTemplate
+      tags:
+        - Approval Templates
+      summary: Clone approval template
+      description: |
+        Clones an existing template's latest formSchema/approvalGraph into a
+        new draft template. Category and visibilityScope are copied; published
+        definitions and version history are not copied.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApprovalTemplateDetail'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: Clone key conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /api/approval-templates/{id}/publish:
     post:
       operationId: publishApprovalTemplate

--- a/packages/openapi/src/base.yml
+++ b/packages/openapi/src/base.yml
@@ -2538,6 +2538,12 @@ components:
         description:
           type: string
           nullable: true
+        category:
+          type: string
+          nullable: true
+          maxLength: 64
+        visibilityScope:
+          $ref: '#/components/schemas/ApprovalTemplateVisibilityScope'
         status:
           type: string
           enum: [draft, published, archived]
@@ -2553,7 +2559,21 @@ components:
         updatedAt:
           type: string
           format: date-time
-      required: [id, key, name, status, activeVersionId, latestVersionId, createdAt, updatedAt]
+      required: [id, key, name, category, visibilityScope, status, activeVersionId, latestVersionId, createdAt, updatedAt]
+    ApprovalTemplateVisibilityScope:
+      type: object
+      properties:
+        type:
+          type: string
+          enum: [all, dept, role, user]
+          description: Visibility mode. `all` ignores `ids`.
+        ids:
+          type: array
+          items:
+            type: string
+          maxItems: 100
+          description: Department, role, or user ids for scoped visibility.
+      required: [type, ids]
     ApprovalTemplateDetail:
       allOf:
         - $ref: '#/components/schemas/ApprovalTemplateListItem'
@@ -2574,6 +2594,12 @@ components:
         description:
           type: string
           nullable: true
+        category:
+          type: string
+          nullable: true
+          maxLength: 64
+        visibilityScope:
+          $ref: '#/components/schemas/ApprovalTemplateVisibilityScope'
         formSchema:
           $ref: '#/components/schemas/FormSchema'
         approvalGraph:
@@ -2589,6 +2615,12 @@ components:
         description:
           type: string
           nullable: true
+        category:
+          type: string
+          nullable: true
+          maxLength: 64
+        visibilityScope:
+          $ref: '#/components/schemas/ApprovalTemplateVisibilityScope'
         formSchema:
           $ref: '#/components/schemas/FormSchema'
         approvalGraph:

--- a/packages/openapi/src/paths/approvals.yml
+++ b/packages/openapi/src/paths/approvals.yml
@@ -438,7 +438,9 @@ paths:
       summary: List approval templates
       description: |
         Returns a paginated list of approval templates. Supports search by name
-        and filtering by status (draft, published, archived).
+        and filtering by status/category. Non-template-managers only receive
+        templates visible to their actor scope (`all`, matching department,
+        role, or user). Template managers can see all templates.
       security:
         - bearerAuth: []
       parameters:
@@ -452,16 +454,20 @@ paths:
             type: string
             enum: [draft, published, archived]
         - in: query
-          name: limit
+          name: category
+          schema:
+            type: string
+        - in: query
+          name: page
+          schema:
+            type: integer
+            minimum: 1
+        - in: query
+          name: pageSize
           schema:
             type: integer
             minimum: 1
             maximum: 200
-        - in: query
-          name: offset
-          schema:
-            type: integer
-            minimum: 0
       responses:
         '200':
           description: OK
@@ -470,24 +476,19 @@ paths:
               schema:
                 type: object
                 properties:
-                  ok:
-                    type: boolean
-                    example: true
                   data:
-                    type: object
-                    properties:
-                      items:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/ApprovalTemplateListItem'
-                      total:
-                        type: integer
-                      limit:
-                        type: integer
-                      offset:
-                        type: integer
-                    required: [items, total, limit, offset]
-                required: [ok, data]
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ApprovalTemplateListItem'
+                  total:
+                    type: integer
+                  limit:
+                    type: integer
+                    description: Effective page size.
+                  offset:
+                    type: integer
+                    description: Zero-based offset derived from page/pageSize.
+                required: [data, total, limit, offset]
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
     post:
@@ -498,6 +499,8 @@ paths:
         Creates a new approval template in draft status. Requires key (unique),
         name, formSchema (with fields), and approvalGraph (nodes + edges).
         The template must be published before it can be used to initiate approvals.
+        Optional category and visibilityScope metadata live on the parent
+        template row and do not become version snapshots.
       security:
         - bearerAuth: []
       requestBody:
@@ -523,13 +526,38 @@ paths:
         '400': { $ref: '#/components/responses/ValidationError' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
+  /api/approval-templates/categories:
+    get:
+      operationId: listApprovalTemplateCategories
+      tags: [Approval Templates]
+      summary: List approval template categories
+      description: |
+        Returns distinct non-null categories visible to the current actor.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: string
+                required: [data]
+        '401': { $ref: '#/components/responses/Unauthorized' }
   /api/approval-templates/{id}:
     get:
       operationId: getApprovalTemplate
       tags: [Approval Templates]
       summary: Get approval template detail
       description: |
-        Returns the full template including formSchema and approvalGraph.
+        Returns the full template including formSchema and approvalGraph when
+        the current actor can see the template. Template managers can see all
+        templates.
       security:
         - bearerAuth: []
       parameters:
@@ -560,8 +588,9 @@ paths:
       tags: [Approval Templates]
       summary: Update approval template draft
       description: |
-        Updates an existing template. Each update automatically creates a new
-        version. All fields are optional; only provided fields are updated.
+        Updates an existing template. formSchema/approvalGraph updates create a
+        new version; metadata-only updates such as category or visibilityScope
+        update the parent row in place. All fields are optional.
       security:
         - bearerAuth: []
       parameters:
@@ -594,6 +623,39 @@ paths:
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
         '404': { $ref: '#/components/responses/NotFound' }
+  /api/approval-templates/{id}/clone:
+    post:
+      operationId: cloneApprovalTemplate
+      tags: [Approval Templates]
+      summary: Clone approval template
+      description: |
+        Clones an existing template's latest formSchema/approvalGraph into a
+        new draft template. Category and visibilityScope are copied; published
+        definitions and version history are not copied.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApprovalTemplateDetail'
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '409':
+          description: Clone key conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /api/approval-templates/{id}/publish:
     post:
       operationId: publishApprovalTemplate


### PR DESCRIPTION
## Summary
- add approval template visibility scope support (`all`, `dept`, `role`, `user`) with manager bypass
- filter template list/detail/categories and approval start by current actor visibility
- expose visibility/category/clone contracts in OpenAPI and frontend template center/detail UI
- preserve legacy singular `req.user.role` alongside `req.user.roles` for role-scoped templates
- harden CI gates: Kysely migration signature, route-level `approvals:read` before ACL filtering, regenerated OpenAPI dist

## Verification
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-template-routes.test.ts --watch=false --reporter=dot` → 5/5 passed
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-rbac-boundary.test.ts tests/unit/approval-template-routes.test.ts --watch=false --reporter=dot` → 25/25 passed
- `pnpm --filter @metasheet/web exec vitest run tests/approvalTemplateCenterCategory.spec.ts tests/approval-e2e-permissions.spec.ts --watch=false --reporter=dot` → 45/45 passed
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit` → exit 0
- `pnpm --filter @metasheet/web exec vue-tsc -b --noEmit` → exit 0
- `pnpm --filter @metasheet/core-backend exec vitest run --reporter=dot` → 2533/2533 passed, 47 skipped
- `pnpm exec tsx packages/openapi/tools/build.ts` → regenerated dist
- `./scripts/ops/attendance-run-gate-contract-case.sh openapi` → OK

## Note
- Local DB-backed integration command was attempted earlier; 10 tests skipped because this machine has no `DATABASE_URL` and no default `chouhua` PostgreSQL database. CI/PG environment should run this gate before merge.
- Development MD: `docs/development/approval-wave2-wp4-template-acl-development-20260423.md`
- Verification MD: `docs/development/approval-wave2-wp4-template-acl-verification-20260423.md`