### PR TITLE
refactor(multitable): add record post-commit hooks

### DIFF
--- a/docs/development/multitable-post-commit-hooks-development-20260424.md
+++ b/docs/development/multitable-post-commit-hooks-development-20260424.md
@@ -1,0 +1,57 @@
+# Multitable Post-Commit Hooks Development - 2026-04-24
+
+## Goal
+
+Replace the direct Yjs invalidator seam in multitable record writes with a generic post-commit hook seam.
+
+This keeps REST/Yjs consistency cleanup in the authoritative write path, while avoiding a permanent dependency from `RecordWriteService` and `RecordService` to Yjs-specific infrastructure.
+
+## Scope
+
+- Added `packages/core-backend/src/multitable/post-commit-hooks.ts`.
+- Updated `RecordWriteService` to accept `RecordPostCommitHook[]`.
+- Updated `RecordService` to accept `RecordPostCommitHook[]`.
+- Kept `setYjsInvalidator(...)` as a compatibility shim.
+- Updated app boot and `univer-meta` route wiring to install `createYjsInvalidationPostCommitHook(...)`.
+- Updated focused unit/integration assertions to use the generic hook seam.
+
+## Design
+
+The new hook context is intentionally small:
+
+- `recordIds`
+- `sheetId`
+- `actorId`
+- `source`
+
+`createYjsInvalidationPostCommitHook(...)` preserves the previous source rule:
+
+- REST/default writes invalidate Yjs state.
+- `source === 'yjs-bridge'` skips invalidation.
+- Empty record sets are ignored.
+
+Hooks run immediately after the DB transaction succeeds, before lookup/rollup recomputation, summary rebuild, and realtime/eventBus fan-out. This preserves the Yjs invalidation timing requirement: cancel pending bridge flushes as soon as the authoritative REST write commits. Hook failures are best-effort: they are logged, later hooks still run, and the record write is not rolled back after the transaction has already committed.
+
+## Compatibility
+
+Existing callers that still use `setYjsInvalidator(...)` continue to work. New boot wiring uses `setPostCommitHooks(...)` directly.
+
+The route-level direct-SQL PATCH path still receives the same Yjs invalidation behavior because `univer-meta` now installs the hook after constructing the service.
+
+## Files
+
+- `packages/core-backend/src/multitable/post-commit-hooks.ts`
+- `packages/core-backend/src/multitable/record-write-service.ts`
+- `packages/core-backend/src/multitable/record-service.ts`
+- `packages/core-backend/src/routes/univer-meta.ts`
+- `packages/core-backend/src/index.ts`
+- `packages/core-backend/tests/unit/record-write-service.test.ts`
+- `packages/core-backend/tests/unit/record-service.test.ts`
+- `packages/core-backend/tests/unit/yjs-rest-invalidation.test.ts`
+- `packages/core-backend/tests/integration/multitable-record-patch.api.test.ts`
+
+## Remaining Work
+
+No functional follow-up is required for this slice.
+
+Optional follow-up: migrate future post-commit side effects such as audit-side cache invalidation or attachment-derived cleanup onto the same hook interface instead of adding new constructor arguments.

--- a/docs/development/multitable-post-commit-hooks-verification-20260424.md
+++ b/docs/development/multitable-post-commit-hooks-verification-20260424.md
@@ -1,0 +1,81 @@
+# Multitable Post-Commit Hooks Verification - 2026-04-24
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/record-write-service.test.ts \
+  tests/unit/record-service.test.ts \
+  tests/unit/yjs-rest-invalidation.test.ts \
+  --reporter=dot
+```
+
+Result: passed.
+
+- Test files: 3 passed.
+- Tests: 48 passed.
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
+```
+
+Result: passed.
+
+## Integration Check
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/integration/multitable-record-patch.api.test.ts \
+  --reporter=dot
+```
+
+Result: passed.
+
+- Test files: 1 passed.
+- Tests: 6 passed.
+
+## Coverage Notes
+
+The unit coverage verifies:
+
+- REST/default writes call the Yjs invalidation hook.
+- `source === 'yjs-bridge'` skips invalidation.
+- Hook replacement after construction works.
+- Hook failures do not fail the write.
+- Later hooks still run when an earlier hook throws.
+- `RecordWriteService` runs hooks immediately after the DB transaction, before
+  post-transaction recompute helpers.
+- Hooks still run when later recompute helpers fail after the transaction has
+  already committed.
+- Route wiring still installs a post-commit Yjs invalidation hook.
+
+## Risk Assessment
+
+Risk is low. This is a seam refactor, not a write semantics change. The compatibility shim keeps old callers working, while app boot and route construction have moved to the new hook API.
+
+## Rebase Verification - 2026-04-26
+
+PR #1137 was rebased onto `origin/main` after the integration-core and K3 WISE
+preflight work landed. The rebase completed without conflicts.
+
+Commands run after the rebase:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/record-write-service.test.ts \
+  tests/unit/record-service.test.ts \
+  tests/unit/yjs-rest-invalidation.test.ts \
+  tests/integration/multitable-record-patch.api.test.ts \
+  --reporter=dot
+```
+
+Result: passed.
+
+- Test files: 4 passed.
+- Tests: 54 passed.
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
+```
+
+Result: passed.

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -1947,6 +1947,7 @@ export class MetaSheetServer {
       const { YjsWebSocketAdapter } = await import('./collab/yjs-websocket-adapter')
       const { YjsRecordBridge } = await import('./collab/yjs-record-bridge')
       const { RecordWriteService } = await import('./multitable/record-write-service')
+      const { createYjsInvalidationPostCommitHook } = await import('./multitable/post-commit-hooks')
       const { db: kyselyDbYjs } = await import('./db/db')
       const collabIO = this.injector.get(ICollabService).getIO()
       if (collabIO) {
@@ -2137,7 +2138,9 @@ export class MetaSheetServer {
             yjsWsAdapter.notifyInvalidated(recordIds)
           }
         }
-        recordWriteService.setYjsInvalidator(yjsInvalidate)
+        recordWriteService.setPostCommitHooks([
+          createYjsInvalidationPostCommitHook(yjsInvalidate),
+        ])
         const univerMetaModule = await import('./routes/univer-meta')
         univerMetaModule.setYjsInvalidatorForRoutes(yjsInvalidate)
 

--- a/packages/core-backend/src/multitable/post-commit-hooks.ts
+++ b/packages/core-backend/src/multitable/post-commit-hooks.ts
@@ -1,0 +1,23 @@
+export type RecordWriteSource = 'rest' | 'yjs-bridge'
+
+export type YjsInvalidator = (recordIds: string[]) => Promise<void> | void
+
+export interface RecordPostCommitContext {
+  recordIds: string[]
+  sheetId: string
+  actorId: string | null
+  source?: RecordWriteSource
+}
+
+export type RecordPostCommitHook = (context: RecordPostCommitContext) => Promise<void> | void
+
+export function createYjsInvalidationPostCommitHook(
+  invalidator: YjsInvalidator,
+): RecordPostCommitHook {
+  return async ({ recordIds, source }) => {
+    if (source === 'yjs-bridge' || recordIds.length === 0) {
+      return
+    }
+    await invalidator(recordIds)
+  }
+}

--- a/packages/core-backend/src/multitable/record-service.ts
+++ b/packages/core-backend/src/multitable/record-service.ts
@@ -10,6 +10,12 @@ import { extractSelectOptions, normalizeJson, normalizeJsonArray, type Multitabl
 import { getDefaultValidationRules, validateRecord } from './field-validation-engine'
 import type { FieldValidationConfig } from './field-validation'
 import { loadFieldsForSheet } from './loaders'
+import {
+  createYjsInvalidationPostCommitHook,
+  type RecordPostCommitContext,
+  type RecordPostCommitHook,
+  type YjsInvalidator,
+} from './post-commit-hooks'
 import { isFieldAlwaysReadOnly, isFieldPermissionHidden } from './permission-derivation'
 import { publishMultitableSheetRealtime } from './realtime-publish'
 import { ensureRecordWriteAllowed, type AccessInfo, type SheetPermissionScope } from './sheet-capabilities'
@@ -46,8 +52,6 @@ type FieldMutationGuard = {
   hidden: boolean
   link?: LinkFieldConfig | null
 }
-
-export type YjsInvalidator = (recordIds: string[]) => Promise<void> | void
 
 export class VersionConflictError extends Error {
   constructor(
@@ -296,8 +300,16 @@ export class RecordService {
   constructor(
     private pool: ConnectionPool,
     private eventBus: EventBus,
-    private yjsInvalidator: YjsInvalidator | null = null,
+    private postCommitHooks: RecordPostCommitHook[] = [],
   ) {}
+
+  setPostCommitHooks(hooks: RecordPostCommitHook[]): void {
+    this.postCommitHooks = [...hooks]
+  }
+
+  setYjsInvalidator(invalidator: YjsInvalidator | null): void {
+    this.setPostCommitHooks(invalidator ? [createYjsInvalidationPostCommitHook(invalidator)] : [])
+  }
 
   async createRecord(input: RecordCreateInput): Promise<RecordCreateResult> {
     const { sheetId, data, actorId, capabilities } = input
@@ -729,14 +741,22 @@ export class RecordService {
       }
     })
 
-    if (this.yjsInvalidator) {
-      try {
-        await this.yjsInvalidator([recordId])
-      } catch (err) {
-        console.error(
-          `[record-service] Yjs invalidation failed for record ${recordId} — Yjs state may be stale until next idle-release:`,
-          err,
-        )
+    if (this.postCommitHooks.length > 0) {
+      const context: RecordPostCommitContext = {
+        recordIds: [recordId],
+        sheetId,
+        actorId: access.userId ?? 'system',
+        source: 'rest',
+      }
+      for (const hook of this.postCommitHooks) {
+        try {
+          await hook(context)
+        } catch (err) {
+          console.error(
+            `[record-service] Post-commit hook failed for record ${recordId} — downstream state may be stale until the next successful sync:`,
+            err,
+          )
+        }
       }
     }
 

--- a/packages/core-backend/src/multitable/record-write-service.ts
+++ b/packages/core-backend/src/multitable/record-write-service.ts
@@ -16,6 +16,12 @@
 
 import type { EventBus } from '../integration/events/event-bus'
 import { publishMultitableSheetRealtime } from './realtime-publish'
+import {
+  createYjsInvalidationPostCommitHook,
+  type RecordPostCommitContext,
+  type RecordPostCommitHook,
+  type YjsInvalidator,
+} from './post-commit-hooks'
 
 // ---------------------------------------------------------------------------
 // Shared types (mirrors the ones in univer-meta.ts to avoid coupling)
@@ -178,19 +184,8 @@ export interface RecordPatchInput {
    * because those writes originate from the in-memory Y.Doc; destroying
    * that doc immediately after would tear out a live editor's state.
    */
-  source?: 'rest' | 'yjs-bridge'
+  source?: RecordPostCommitContext['source']
 }
-
-/**
- * Injected by `index.ts` when the Yjs path is wired. Takes record IDs
- * whose REST write just committed and wipes any Yjs state for them
- * (in-memory + persisted). Must first cancel any bridge-pending flushes
- * for those records — the wiring in `index.ts` composes both.
- *
- * Best-effort: errors are logged and swallowed; a failed invalidation
- * does NOT fail the REST write that already succeeded.
- */
-export type YjsInvalidator = (recordIds: string[]) => Promise<void>
 
 export interface RecordPatchResult {
   updated: Array<{ recordId: string; version: number }>
@@ -282,21 +277,27 @@ export class RecordWriteService {
     private eventBus: EventBus,
     private helpers: RecordWriteHelpers,
     /**
-     * Optional Yjs invalidator. Leave `null` when the Yjs collab path is
-     * disabled (flag off, non-Yjs deployments). When present, called
-     * after every successful `patchRecords` that did NOT originate from
-     * the Yjs bridge itself.
+     * Post-commit hooks run after the DB transaction succeeds but before
+     * realtime + eventBus notifications fan out. This keeps authoritative
+     * state cleanup in one seam without coupling the service to Yjs.
      */
-    private yjsInvalidator: YjsInvalidator | null = null,
+    private postCommitHooks: RecordPostCommitHook[] = [],
   ) {}
 
   /**
-   * Replace the Yjs invalidator after construction. Used when
-   * `YjsSyncService`/bridge are wired up later in the boot sequence than
-   * `RecordWriteService`.
+   * Replace post-commit hooks after construction. Used when downstream
+   * infrastructure (for example Yjs invalidation) wires later in boot.
+   */
+  setPostCommitHooks(hooks: RecordPostCommitHook[]): void {
+    this.postCommitHooks = [...hooks]
+  }
+
+  /**
+   * Back-compat shim for callers that still think in terms of "the Yjs
+   * invalidator". New wiring should prefer `setPostCommitHooks(...)`.
    */
   setYjsInvalidator(invalidator: YjsInvalidator | null): void {
-    this.yjsInvalidator = invalidator
+    this.setPostCommitHooks(invalidator ? [createYjsInvalidationPostCommitHook(invalidator)] : [])
   }
 
   /**
@@ -401,11 +402,12 @@ export class RecordWriteService {
    * 0. Validate changes (field writability, value constraints, expectedVersion consistency)
    * 1. DB transaction: SELECT FOR UPDATE → version check → field-type handling
    *    → `data || patch::jsonb` → link mutation → version++
-   * 2. Computed field recalculation (lookup/rollup)
-   * 3. Related record recomputation (cross-sheet)
-   * 4. Link/attachment summary rebuild for response
-   * 5. Realtime broadcast via `publishMultitableSheetRealtime()`
-   * 6. EventBus emit → webhook/automation trigger
+   * 2. Post-commit hooks (best effort, immediately after commit)
+   * 3. Computed field recalculation (lookup/rollup)
+   * 4. Related record recomputation (cross-sheet)
+   * 5. Link/attachment summary rebuild for response
+   * 6. Realtime broadcast via `publishMultitableSheetRealtime()`
+   * 7. EventBus emit → webhook/automation trigger
    */
   async patchRecords(input: RecordPatchInput): Promise<RecordPatchResult> {
     const {
@@ -588,7 +590,29 @@ export class RecordWriteService {
     })
 
     // -----------------------------------------------------------------------
-    // Step 2: Computed field recalculation (lookup / rollup)
+    // Step 2: Post-commit hooks (best effort, immediately after commit)
+    // -----------------------------------------------------------------------
+    if (this.postCommitHooks.length > 0 && updates.length > 0) {
+      const context: RecordPostCommitContext = {
+        recordIds: updates.map((update) => update.recordId),
+        sheetId,
+        actorId,
+        source: input.source,
+      }
+      for (const hook of this.postCommitHooks) {
+        try {
+          await hook(context)
+        } catch (err) {
+          console.error(
+            `[record-write] Post-commit hook failed for records ${context.recordIds.join(',')} — downstream state may be stale until the next successful sync:`,
+            err,
+          )
+        }
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    // Step 3: Computed field recalculation (lookup / rollup)
     // -----------------------------------------------------------------------
     let computedRecords: Array<{ recordId: string; data: Record<string, unknown> }> | undefined
     let updatedRowsForSummaries: UniverMetaRecord[] = []
@@ -638,7 +662,7 @@ export class RecordWriteService {
     }
 
     // -----------------------------------------------------------------------
-    // Step 3: Related record recomputation (cross-sheet)
+    // Step 4: Related record recomputation (cross-sheet)
     // -----------------------------------------------------------------------
     const relatedRecords =
       updates.length > 0
@@ -658,7 +682,7 @@ export class RecordWriteService {
     const mergedRecords = h.mergeComputedRecords(computedRecords, sameSheetRelated)
 
     // -----------------------------------------------------------------------
-    // Step 4: Link / attachment summary rebuild
+    // Step 5: Link / attachment summary rebuild
     // -----------------------------------------------------------------------
     const relationalLinkFields = fields
       .map((field) => (field.type === 'link' ? { fieldId: field.id, cfg: h.parseLinkFieldConfig(field.property) } : null))
@@ -697,28 +721,6 @@ export class RecordWriteService {
             visiblePropertyFieldIds,
           )
         : undefined
-
-    // -----------------------------------------------------------------------
-    // Step 5: Yjs invalidation (post-commit, pre-notification, best effort)
-    //
-    // REST writes to meta_records.data make any persisted Y.Doc snapshot
-    // for those records stale. Drop in-memory + persisted Yjs state before
-    // notifying clients/listeners, so a fast reconnect cannot reopen the old
-    // snapshot. Skipped when the write itself originated from the Yjs bridge
-    // (those writes ARE the Y.Doc's content; invalidating would nuke a live
-    // editor).
-    // -----------------------------------------------------------------------
-    if (this.yjsInvalidator && input.source !== 'yjs-bridge' && updates.length > 0) {
-      const recordIds = updates.map((u) => u.recordId)
-      try {
-        await this.yjsInvalidator(recordIds)
-      } catch (err) {
-        console.error(
-          `[record-write] Yjs invalidation failed for records ${recordIds.join(',')} — Yjs state may be stale until next idle-release:`,
-          err,
-        )
-      }
-    }
 
     // -----------------------------------------------------------------------
     // Step 6: Realtime broadcast

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -117,7 +117,6 @@ import {
   RecordValidationError as ServiceValidationError,
   RecordFieldForbiddenError as ServiceFieldForbiddenError,
   type RecordWriteHelpers,
-  type YjsInvalidator,
 } from '../multitable/record-write-service'
 import {
   RecordService,
@@ -129,6 +128,10 @@ import {
   RecordValidationFailedError as RecordCreateValidationFailedError,
   RecordPatchFieldValidationError as RecordServicePatchFieldValidationError,
 } from '../multitable/record-service'
+import {
+  createYjsInvalidationPostCommitHook,
+  type YjsInvalidator,
+} from '../multitable/post-commit-hooks'
 
 const multitableFormulaEngine = new MultitableFormulaEngine()
 
@@ -5772,7 +5775,10 @@ export function univerMetaRouter(): Router {
       }
       if (!capabilities.canEditRecord) return sendForbidden(res)
 
-      const recordService = new RecordService(pool, eventBus, yjsInvalidator)
+      const recordService = new RecordService(pool, eventBus)
+      if (yjsInvalidator) {
+        recordService.setPostCommitHooks([createYjsInvalidationPostCommitHook(yjsInvalidator)])
+      }
       const patchResult = await recordService.patchRecord({
         recordId,
         sheetId,
@@ -6712,7 +6718,10 @@ export function univerMetaRouter(): Router {
         buildAttachmentSummaries: (q, sid, rows, af) => buildAttachmentSummaries(q, req, sid, rows, af),
         ensureAttachmentIdsExist,
       }
-      const recordWriteService = new RecordWriteService(pool, eventBus, writeHelpers, yjsInvalidator)
+      const recordWriteService = new RecordWriteService(pool, eventBus, writeHelpers)
+      if (yjsInvalidator) {
+        recordWriteService.setPostCommitHooks([createYjsInvalidationPostCommitHook(yjsInvalidator)])
+      }
 
       const result = await recordWriteService.patchRecords({
         sheetId,

--- a/packages/core-backend/tests/integration/multitable-record-patch.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-record-patch.api.test.ts
@@ -435,11 +435,11 @@ describe('Multitable PATCH /records/:recordId (record-service extraction)', () =
 
     expect(response.body.data.record.data.fld_files).toEqual(['att_new_1'])
     expect(yjsInvalidatorSpy).toHaveBeenCalledWith(['rec_1'])
-    // The warning log for invalidator failure must have fired so the
+    // The warning log for post-commit hook failure must have fired so the
     // operator can find the stale-snapshot lag.
     const hadWarning = errorSpy.mock.calls.some((call) => {
       const msg = call[0]
-      return typeof msg === 'string' && msg.includes('Yjs invalidation failed')
+      return typeof msg === 'string' && msg.includes('Post-commit hook failed')
     })
     expect(hadWarning).toBe(true)
     errorSpy.mockRestore()

--- a/packages/core-backend/tests/unit/record-service.test.ts
+++ b/packages/core-backend/tests/unit/record-service.test.ts
@@ -11,6 +11,7 @@ import {
   type ConnectionPool,
   type QueryFn,
 } from '../../src/multitable/record-service'
+import { createYjsInvalidationPostCommitHook } from '../../src/multitable/post-commit-hooks'
 
 const mockPublish = vi.fn()
 vi.mock('../../src/multitable/realtime-publish', () => ({
@@ -306,7 +307,9 @@ describe('RecordService', () => {
       SELECT_LINK_TARGETS: { rows: [{ id: 'rec_customer_2' }] },
       SELECT_CURRENT_LINKS: { rows: [{ foreign_record_id: 'rec_customer_1' }] },
     })
-    const service = new RecordService(pool, eventBus as any, yjsInvalidator)
+    const service = new RecordService(pool, eventBus as any, [
+      createYjsInvalidationPostCommitHook(yjsInvalidator),
+    ])
 
     const result = await service.patchRecord({
       recordId: 'rec_existing',

--- a/packages/core-backend/tests/unit/record-write-service.test.ts
+++ b/packages/core-backend/tests/unit/record-write-service.test.ts
@@ -11,6 +11,7 @@ import {
   type UniverMetaField,
   type UniverMetaRecord,
 } from '../../src/multitable/record-write-service'
+import { createYjsInvalidationPostCommitHook } from '../../src/multitable/post-commit-hooks'
 
 // ---------------------------------------------------------------------------
 // Mock: publishMultitableSheetRealtime
@@ -485,7 +486,7 @@ describe('RecordWriteService', () => {
   })
 
   // -------------------------------------------------------------------------
-  // Yjs invalidation wiring (REST → Yjs consistency hook)
+  // Post-commit wiring (REST → Yjs consistency hook)
   // -------------------------------------------------------------------------
   //
   // These tests prove that `patchRecords` correctly drives the injected
@@ -495,10 +496,12 @@ describe('RecordWriteService', () => {
   // the `source` field that prevents bridge-originated writes from
   // destroying the live Y.Doc they just read from.
   //
-  describe('Yjs invalidation hook', () => {
-    it('calls the invalidator with committed record IDs on a default (source unset) patch', async () => {
+  describe('post-commit hooks', () => {
+    it('calls the Yjs invalidation hook with committed record IDs on a default (source unset) patch', async () => {
       const invalidator = vi.fn().mockResolvedValue(undefined)
-      const service = new RecordWriteService(pool, eventBus as any, helpers, invalidator)
+      const service = new RecordWriteService(pool, eventBus as any, helpers, [
+        createYjsInvalidationPostCommitHook(invalidator),
+      ])
 
       await service.patchRecords(buildTestInput())
 
@@ -508,7 +511,9 @@ describe('RecordWriteService', () => {
 
     it('invalidates before realtime broadcast and eventBus notification', async () => {
       const invalidator = vi.fn().mockResolvedValue(undefined)
-      const service = new RecordWriteService(pool, eventBus as any, helpers, invalidator)
+      const service = new RecordWriteService(pool, eventBus as any, helpers, [
+        createYjsInvalidationPostCommitHook(invalidator),
+      ])
 
       await service.patchRecords(buildTestInput())
 
@@ -519,9 +524,38 @@ describe('RecordWriteService', () => {
       expect(invalidator.mock.invocationCallOrder[0]).toBeLessThan(eventBus.emit.mock.invocationCallOrder[0])
     })
 
+    it('runs post-commit hooks before post-transaction recompute helpers', async () => {
+      const invalidator = vi.fn().mockResolvedValue(undefined)
+      const service = new RecordWriteService(pool, eventBus as any, helpers, [
+        createYjsInvalidationPostCommitHook(invalidator),
+      ])
+
+      await service.patchRecords(buildTestInput())
+
+      expect(invalidator).toHaveBeenCalledOnce()
+      expect(helpers.computeDependentLookupRollupRecords).toHaveBeenCalledOnce()
+      expect(invalidator.mock.invocationCallOrder[0]).toBeLessThan(
+        vi.mocked(helpers.computeDependentLookupRollupRecords).mock.invocationCallOrder[0],
+      )
+    })
+
+    it('runs post-commit hooks even when later recompute helpers fail', async () => {
+      const invalidator = vi.fn().mockResolvedValue(undefined)
+      helpers.computeDependentLookupRollupRecords = vi.fn().mockRejectedValue(new Error('recompute failed'))
+      const service = new RecordWriteService(pool, eventBus as any, helpers, [
+        createYjsInvalidationPostCommitHook(invalidator),
+      ])
+
+      await expect(service.patchRecords(buildTestInput())).rejects.toThrow('recompute failed')
+
+      expect(invalidator).toHaveBeenCalledOnce()
+    })
+
     it("calls the invalidator when source === 'rest' (explicit)", async () => {
       const invalidator = vi.fn().mockResolvedValue(undefined)
-      const service = new RecordWriteService(pool, eventBus as any, helpers, invalidator)
+      const service = new RecordWriteService(pool, eventBus as any, helpers, [
+        createYjsInvalidationPostCommitHook(invalidator),
+      ])
 
       await service.patchRecords(buildTestInput({ source: 'rest' }))
 
@@ -530,7 +564,9 @@ describe('RecordWriteService', () => {
 
     it("does NOT call the invalidator when source === 'yjs-bridge'", async () => {
       const invalidator = vi.fn().mockResolvedValue(undefined)
-      const service = new RecordWriteService(pool, eventBus as any, helpers, invalidator)
+      const service = new RecordWriteService(pool, eventBus as any, helpers, [
+        createYjsInvalidationPostCommitHook(invalidator),
+      ])
 
       // The bridge's own writes must not invalidate the Y.Doc they were
       // derived from — that would tear out a live editor mid-session and
@@ -542,7 +578,9 @@ describe('RecordWriteService', () => {
 
     it('does not fail the REST patch when the invalidator throws', async () => {
       const invalidator = vi.fn().mockRejectedValue(new Error('purge failed'))
-      const service = new RecordWriteService(pool, eventBus as any, helpers, invalidator)
+      const service = new RecordWriteService(pool, eventBus as any, helpers, [
+        createYjsInvalidationPostCommitHook(invalidator),
+      ])
 
       const result = await service.patchRecords(buildTestInput())
 
@@ -550,23 +588,25 @@ describe('RecordWriteService', () => {
       expect(invalidator).toHaveBeenCalledOnce()
     })
 
-    it('setYjsInvalidator replaces the callable post-construction', async () => {
+    it('setPostCommitHooks replaces the callable post-construction', async () => {
       const service = new RecordWriteService(pool, eventBus as any, helpers)
       const first = vi.fn().mockResolvedValue(undefined)
-      service.setYjsInvalidator(first)
+      service.setPostCommitHooks([createYjsInvalidationPostCommitHook(first)])
 
       await service.patchRecords(buildTestInput())
       expect(first).toHaveBeenCalledTimes(1)
 
-      // Replace with null → no-op, no throw.
-      service.setYjsInvalidator(null)
+      // Replace with empty hooks → no-op, no throw.
+      service.setPostCommitHooks([])
       await service.patchRecords(buildTestInput())
       expect(first).toHaveBeenCalledTimes(1) // still 1, no new call
     })
 
     it('passes every committed record ID (multi-record patch)', async () => {
       const invalidator = vi.fn().mockResolvedValue(undefined)
-      const service = new RecordWriteService(pool, eventBus as any, helpers, invalidator)
+      const service = new RecordWriteService(pool, eventBus as any, helpers, [
+        createYjsInvalidationPostCommitHook(invalidator),
+      ])
 
       // Two records in the same patch. The mock pool returns version=2
       // for any UPDATE regardless of recordId, so both commit.
@@ -580,6 +620,18 @@ describe('RecordWriteService', () => {
       expect(invalidator).toHaveBeenCalledTimes(1)
       const args = invalidator.mock.calls[0][0] as string[]
       expect(args.sort()).toEqual(['rec1', 'rec2'])
+    })
+
+    it('keeps running later hooks when an earlier hook throws', async () => {
+      const failing = vi.fn().mockRejectedValue(new Error('hook failed'))
+      const succeeding = vi.fn().mockResolvedValue(undefined)
+      const service = new RecordWriteService(pool, eventBus as any, helpers, [failing, succeeding])
+
+      const result = await service.patchRecords(buildTestInput())
+
+      expect(result.updated).toHaveLength(1)
+      expect(failing).toHaveBeenCalledOnce()
+      expect(succeeding).toHaveBeenCalledOnce()
     })
   })
 })

--- a/packages/core-backend/tests/unit/yjs-rest-invalidation.test.ts
+++ b/packages/core-backend/tests/unit/yjs-rest-invalidation.test.ts
@@ -265,10 +265,11 @@ describe('YjsRecordBridge.cancelPending', () => {
     expect(() => routesModule.setYjsInvalidatorForRoutes(null)).not.toThrow()
   })
 
-  it('REST /patch route passes the module-level invalidator into RecordWriteService', async () => {
+  it('REST /patch route adapts the module-level invalidator into a post-commit hook', async () => {
     const source = await readFile(new URL('../../src/routes/univer-meta.ts', import.meta.url), 'utf8')
 
-    expect(source).toContain('new RecordWriteService(pool, eventBus, writeHelpers, yjsInvalidator)')
+    expect(source).toContain('new RecordWriteService(pool, eventBus, writeHelpers)')
+    expect(source).toContain('recordWriteService.setPostCommitHooks([createYjsInvalidationPostCommitHook(yjsInvalidator)])')
   })
 
   it('cancelPending on records with no pending flush is a no-op', () => {


### PR DESCRIPTION
## Summary

- Replace the direct Yjs invalidator seam in multitable record writes with a generic post-commit hook seam.
- Keep `setYjsInvalidator(...)` as a compatibility shim while wiring app boot and route construction through `setPostCommitHooks(...)`.
- Preserve existing REST/default invalidation and `source === 'yjs-bridge'` skip semantics.
- Add development and verification docs under `docs/development/`.

## Verification

- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/record-write-service.test.ts tests/unit/record-service.test.ts tests/unit/yjs-rest-invalidation.test.ts --reporter=dot` -> 46/46 passed
- `pnpm --filter @metasheet/core-backend exec vitest run tests/integration/multitable-record-patch.api.test.ts --reporter=dot` -> 6/6 passed
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false` -> passed

Docs:
- `docs/development/multitable-post-commit-hooks-development-20260424.md`
- `docs/development/multitable-post-commit-hooks-verification-20260424.md`