### PR TITLE
feat(integration): scaffold integration core plugin

### DIFF
--- a/docs/development/integration-core-m0-design-20260424.md
+++ b/docs/development/integration-core-m0-design-20260424.md
@@ -15,9 +15,9 @@ The goal is to prove that `plugin-integration-core` can be loaded as a CJS syste
 - `plugins/plugin-integration-core/lib/db.cjs`
 - `plugins/plugin-integration-core/lib/staging-installer.cjs`
 - `plugins/plugin-integration-core/__tests__/*.test.cjs`
+- `plugins/plugin-integration-core/__tests__/*.test.mjs`
 - `plugins/plugin-integration-core/SPIKE_NOTES.md`
 - `packages/core-backend/migrations/057_create_integration_core_tables.sql`
-- `docs/integration-todo.md`
 
 ## Runtime Design
 
@@ -34,6 +34,39 @@ The communication API is intentionally skeletal in M0:
 - `getStatus()`
 
 M1 should attach the adapter registry, pipeline runner, dead-letter replay, and credential store operations behind this namespace.
+
+## M0 Gate Hardening
+
+Two lightweight gates were added after the initial M0 scaffold review.
+
+### No-Listen Host Loader Smoke
+
+`host-loader-smoke.test.mjs` imports the real backend `PluginLoader`, discovers `plugin-integration-core` through the manifest path, calls `load()`, and then activates the loaded plugin with a minimal runtime context. This covers the real manifest/main/module-loading path without opening an HTTP listener, which keeps it usable in restricted local sandboxes.
+
+The smoke asserts:
+
+- the plugin is discovered by id;
+- the loaded CJS module exposes `activate`;
+- `activate()` registers the integration health route;
+- `activate()` registers the `integration-core` communication namespace;
+- `ping()` and `getStatus()` are callable from the registered namespace.
+
+### Migration SQL Structure Smoke
+
+`migration-sql.test.cjs` statically checks migration `057_create_integration_core_tables.sql` until a live Postgres/PGlite execution gate is available.
+
+The smoke asserts:
+
+- the `integration_set_updated_at()` trigger helper exists;
+- the migration is forward-only and does not drop tables;
+- all seven expected `integration_*` tables are declared;
+- primary-key shapes match the intended model, including `integration_watermarks.pipeline_id` as the 1:1 pipeline watermark key;
+- scoped operational tables include `tenant_id` and `workspace_id`;
+- tables with `updated_at` that are expected to mutate have an `integration_set_updated_at()` trigger;
+- workspace-null uniqueness uses `COALESCE(workspace_id, '')`;
+- DDL table references, index targets, and foreign key targets are limited to `integration_*` tables.
+
+This is not a substitute for applying the migration against Postgres. It is an early guard against accidental scope drift and obvious DDL regressions.
 
 ## Security Boundaries
 
@@ -88,7 +121,9 @@ Migration `057_create_integration_core_tables.sql` creates seven operational tab
 - `integration_dead_letters`
 - `integration_schedules`
 
-All operational tables are scoped with `tenant_id`; workspace/project scope is present where applicable. Unique indexes use `COALESCE(workspace_id, '')` to avoid the Postgres `NULL != NULL` uniqueness trap on single-workspace deployments.
+Root operational tables carry direct `tenant_id` scope; pipeline child tables such as mappings, watermarks, and schedules inherit tenant/workspace scope through `integration_pipelines`. Unique indexes use `COALESCE(workspace_id, '')` to avoid the Postgres `NULL != NULL` uniqueness trap on single-workspace deployments.
+
+M0 does not enforce tenant/workspace consistency across referenced rows at the database layer. That remains a service-layer or trigger-level M1 gate because nullable `workspace_id` makes simple composite foreign keys insufficient in Postgres 14.
 
 ## Known Kernel Gaps
 
@@ -99,6 +134,13 @@ M0 documents, but does not fix, three plugin-kernel gaps:
 - `services.security` is declared in types but not injected by the active CJS runtime path.
 
 These are kernel follow-ups before the M1 pipeline runner is considered production-ready.
+
+## Remaining M1 Gates
+
+- Run migration `057_create_integration_core_tables.sql` against live Postgres or an in-repo PGlite-backed test once the dependency/environment is available.
+- Add a full `MetaSheetServer` hot-load smoke that binds an ephemeral listener and exercises `/api/plugins` plus `/api/integration/health`.
+- Enforce cross-row tenant/workspace consistency for pipeline references in service code or DB triggers before accepting external write paths.
+- Keep route/communication teardown as a kernel follow-up before long-lived integration pipeline routes are introduced.
 
 ## Non-Goals
 

--- a/docs/development/integration-core-m0-design-20260424.md
+++ b/docs/development/integration-core-m0-design-20260424.md
@@ -1,0 +1,110 @@
+# Integration Core M0 Design - 2026-04-24
+
+## Objective
+
+Create the first reviewable system-plugin slice for the PLM/ERP integration pipeline. M0 is a runtime and security-boundary spike, not the full pipeline runner.
+
+The goal is to prove that `plugin-integration-core` can be loaded as a CJS system plugin, register a minimal health route, expose an in-process communication namespace, define its credential/data access boundaries, and provision the staging multitable descriptors that later M1/M2 work will use.
+
+## Scope
+
+- `plugins/plugin-integration-core/plugin.json`
+- `plugins/plugin-integration-core/package.json`
+- `plugins/plugin-integration-core/index.cjs`
+- `plugins/plugin-integration-core/lib/credential-store.cjs`
+- `plugins/plugin-integration-core/lib/db.cjs`
+- `plugins/plugin-integration-core/lib/staging-installer.cjs`
+- `plugins/plugin-integration-core/__tests__/*.test.cjs`
+- `plugins/plugin-integration-core/SPIKE_NOTES.md`
+- `packages/core-backend/migrations/057_create_integration_core_tables.sql`
+- `docs/integration-todo.md`
+
+## Runtime Design
+
+The plugin follows the existing CJS plugin path used by `plugin-after-sales`:
+
+- `PluginLoader` discovers `plugins/plugin-integration-core/plugin.json`.
+- `main: "index.cjs"` exports `activate(context)` and `deactivate()`.
+- `activate()` registers `GET /api/integration/health`.
+- `activate()` registers `communication.register("integration-core", api)`.
+
+The communication API is intentionally skeletal in M0:
+
+- `ping()`
+- `getStatus()`
+
+M1 should attach the adapter registry, pipeline runner, dead-letter replay, and credential store operations behind this namespace.
+
+## Security Boundaries
+
+### Credentials
+
+`lib/credential-store.cjs` uses AES-256-GCM envelope encryption.
+
+- Production requires `INTEGRATION_ENCRYPTION_KEY`.
+- Development/test may use a deterministic fallback key with a warning.
+- Public callers receive fingerprints, not plaintext.
+
+The plugin does not depend on `context.services.security` yet because the runtime path currently does not inject that service despite the type declaration. This gap is documented in `SPIKE_NOTES.md`.
+
+### Database
+
+`lib/db.cjs` deliberately exposes a structured CRUD builder only:
+
+- `select`
+- `selectOne`
+- `insertOne`
+- `insertMany`
+- `updateRow`
+- `deleteRows`
+- `countRows`
+- `transaction`
+
+There is no `rawQuery` escape hatch. Tables must start with `integration_`, identifiers must pass a strict whitelist, and all values are parameterized.
+
+This prevents the earlier regex-based SQL-scope bypass class such as quoted identifiers or injected `FROM "users"` clauses.
+
+### Staging Multitable
+
+`lib/staging-installer.cjs` provisions five user-visible staging surfaces:
+
+- `plm_raw_items`
+- `standard_materials`
+- `bom_cleanse`
+- `integration_exceptions`
+- `integration_run_log`
+
+The installer accepts local authoring sugar like `required: true`, but materializes it into the real multitable field contract under `property.validation`.
+
+## SQL Model
+
+Migration `057_create_integration_core_tables.sql` creates seven operational tables:
+
+- `integration_external_systems`
+- `integration_pipelines`
+- `integration_field_mappings`
+- `integration_runs`
+- `integration_watermarks`
+- `integration_dead_letters`
+- `integration_schedules`
+
+All operational tables are scoped with `tenant_id`; workspace/project scope is present where applicable. Unique indexes use `COALESCE(workspace_id, '')` to avoid the Postgres `NULL != NULL` uniqueness trap on single-workspace deployments.
+
+## Known Kernel Gaps
+
+M0 documents, but does not fix, three plugin-kernel gaps:
+
+- `http.addRoute` has no functional route removal.
+- `communication.register` has no matching unregister.
+- `services.security` is declared in types but not injected by the active CJS runtime path.
+
+These are kernel follow-ups before the M1 pipeline runner is considered production-ready.
+
+## Non-Goals
+
+- No external K3 WISE adapter.
+- No pipeline runner.
+- No transform/validator/idempotency/watermark engine.
+- No UI.
+- No raw SQL plugin surface.
+- No deletion or migration of the existing PLM adapter.

--- a/docs/development/integration-core-m0-verification-20260424.md
+++ b/docs/development/integration-core-m0-verification-20260424.md
@@ -1,0 +1,90 @@
+# Integration Core M0 Verification - 2026-04-24
+
+## Commands
+
+### CJS Syntax Check
+
+```bash
+find plugins/plugin-integration-core -maxdepth 3 -type f -name '*.cjs' -print | sort | xargs -n1 node --check
+```
+
+Result: passed.
+
+### Plugin Unit/Smoke Tests
+
+```bash
+pnpm -F plugin-integration-core test
+```
+
+Result: passed.
+
+Output summary:
+
+```text
+plugin-runtime-smoke: all assertions passed
+credential-store: 7 scenarios passed
+db.cjs: all CRUD + boundary + injection tests passed
+staging-installer: all 7 assertions passed
+```
+
+### Manifest Validation
+
+The default package script is blocked in this sandbox because `tsx` tries to create an IPC pipe and receives `listen EPERM`:
+
+```bash
+pnpm validate:plugins
+```
+
+Equivalent Node loader command:
+
+```bash
+node --import tsx scripts/validate-plugin-manifests.ts
+```
+
+Result: passed.
+
+Relevant line:
+
+```text
+plugin-integration-core: Valid
+```
+
+### Migration Placement Check
+
+```bash
+find packages/core-backend/migrations packages/core-backend/src/db/migrations -maxdepth 1 -type f \
+  | sed 's#^.*/##' \
+  | sort \
+  | rg '(^057|integration_core|integration)'
+```
+
+Result:
+
+```text
+057_create_integration_core_tables.sql
+zzzz20260202093000_create_attendance_integrations.ts
+```
+
+No duplicate `057_*` migration name was found.
+
+## Verified Behaviors
+
+- Plugin manifest parses and validates through the repository validator.
+- Plugin activation registers the health route and communication namespace against a mocked runtime context.
+- Plugin deactivation clears local state.
+- Credential store encrypts/decrypts, rejects tampered payloads, rejects missing production keys, and supports deterministic dev fallback.
+- DB helper rejects non-`integration_*` tables, invalid identifiers, quoted-identifier bypass attempts, unbounded update/delete, and value injection.
+- DB helper keeps host return shape for array-return query results, including `selectOne`, `countRows`, and empty `insertMany`.
+- Staging installer provisions all five descriptors idempotently and materializes `required` into `property.validation`.
+
+## Not Verified In This Slice
+
+- The SQL migration was not applied against a live Postgres database.
+- The plugin was not activated through a running `MetaSheetServer` process.
+- `pnpm validate:plugins` package script could not run directly in this sandbox because of `tsx` IPC restrictions; the equivalent `node --import tsx` command passed.
+
+## Required Follow-Up Before M1 Production Work
+
+- Add a real Postgres migration smoke for `057_create_integration_core_tables.sql`.
+- Add a backend hot-load smoke that exercises `PluginLoader -> createPluginContext -> plugin.activate()`.
+- Fix kernel route/communication teardown before adding long-lived integration pipeline routes.

--- a/docs/development/integration-core-m0-verification-20260424.md
+++ b/docs/development/integration-core-m0-verification-20260424.md
@@ -2,10 +2,11 @@
 
 ## Commands
 
-### CJS Syntax Check
+### CJS/MJS Syntax Check
 
 ```bash
 find plugins/plugin-integration-core -maxdepth 3 -type f -name '*.cjs' -print | sort | xargs -n1 node --check
+node --check plugins/plugin-integration-core/__tests__/host-loader-smoke.test.mjs
 ```
 
 Result: passed.
@@ -22,9 +23,11 @@ Output summary:
 
 ```text
 plugin-runtime-smoke: all assertions passed
+host-loader-smoke: PluginLoader load + activate path passed
 credential-store: 7 scenarios passed
 db.cjs: all CRUD + boundary + injection tests passed
 staging-installer: all 7 assertions passed
+migration-sql: 057 integration migration structure passed
 ```
 
 ### Manifest Validation
@@ -71,20 +74,24 @@ No duplicate `057_*` migration name was found.
 
 - Plugin manifest parses and validates through the repository validator.
 - Plugin activation registers the health route and communication namespace against a mocked runtime context.
+- Plugin discovery/loading uses the real backend `PluginLoader` in a no-listen smoke, then activates the loaded module with a minimal host context.
 - Plugin deactivation clears local state.
 - Credential store encrypts/decrypts, rejects tampered payloads, rejects missing production keys, and supports deterministic dev fallback.
 - DB helper rejects non-`integration_*` tables, invalid identifiers, quoted-identifier bypass attempts, unbounded update/delete, and value injection.
 - DB helper keeps host return shape for array-return query results, including `selectOne`, `countRows`, and empty `insertMany`.
 - Staging installer provisions all five descriptors idempotently and materializes `required` into `property.validation`.
+- Migration `057_create_integration_core_tables.sql` has the expected seven `integration_*` tables, scoped columns, primary-key shapes, updated-at trigger bindings, workspace-null unique indexes, and no DDL/index/FK table references outside the integration namespace.
 
 ## Not Verified In This Slice
 
 - The SQL migration was not applied against a live Postgres database.
-- The plugin was not activated through a running `MetaSheetServer` process.
+- The plugin was not activated through a running `MetaSheetServer` process with an HTTP listener.
+- Tenant/workspace consistency across referenced rows is not enforced at the database layer in M0; direct-scope root rows and integration-only references were verified, but M1 must add service or trigger enforcement before external writes.
 - `pnpm validate:plugins` package script could not run directly in this sandbox because of `tsx` IPC restrictions; the equivalent `node --import tsx` command passed.
 
 ## Required Follow-Up Before M1 Production Work
 
-- Add a real Postgres migration smoke for `057_create_integration_core_tables.sql`.
-- Add a backend hot-load smoke that exercises `PluginLoader -> createPluginContext -> plugin.activate()`.
+- Add a real Postgres or PGlite migration execution smoke for `057_create_integration_core_tables.sql`.
+- Add a full backend hot-load smoke that exercises `MetaSheetServer -> PluginLoader -> createPluginContext -> plugin.activate()` and hits `/api/integration/health` over HTTP.
+- Add service or trigger enforcement for cross-row tenant/workspace consistency on pipeline references.
 - Fix kernel route/communication teardown before adding long-lived integration pipeline routes.

--- a/packages/core-backend/migrations/057_create_integration_core_tables.sql
+++ b/packages/core-backend/migrations/057_create_integration_core_tables.sql
@@ -1,0 +1,210 @@
+-- 057_create_integration_core_tables.sql
+-- plugin-integration-core · MVP 数据模型（M0-T07 / M1-T01, M1-T02）
+--
+-- Scoping 惯例（与 bpmn_* / plugin_configs / plugin-after-sales ledger 对齐）：
+--   tenant_id     TEXT NOT NULL    —— 多租户必填
+--   workspace_id  TEXT             —— 租户内工作区；单工作区部署可为 NULL
+--   project_id    TEXT             —— 关联平台应用项目；可选
+-- K3 WISE 账套、Yuantus PLM 的 org_id 等外部系统维度不在本层拆列，
+-- 存放于 integration_external_systems.config JSONB 中，避免每家 ERP/PLM
+-- 拉一个专属列。
+--
+-- 所有表以 integration_ 前缀开头，与 plugin-integration-core/lib/db.cjs
+-- 的 ALLOWED_PREFIX 对齐。
+-- ---------------------------------------------------------------------------
+
+-- ---------------------------------------------------------------------------
+-- 1. External systems —— 已注册的 PLM / ERP / DB 连接
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS integration_external_systems (
+  id                    TEXT PRIMARY KEY,
+  tenant_id             TEXT NOT NULL,
+  workspace_id          TEXT,
+  project_id            TEXT,
+  name                  TEXT NOT NULL,
+  kind                  TEXT NOT NULL,       -- 'plm:yuantus' | 'erp:k3-wise-webapi' | 'erp:k3-wise-sqlserver' | 'http' | 'postgres' | ...
+  role                  TEXT NOT NULL CHECK (role IN ('source', 'target', 'bidirectional')),
+  config                JSONB NOT NULL DEFAULT '{}'::jsonb,        -- base_url / host / port / db_name / account_set_id / env / 其它非密码字段
+  credentials_encrypted TEXT,                                       -- lib/credential-store.cjs 加密后 ciphertext，永不明文
+  capabilities          JSONB NOT NULL DEFAULT '{}'::jsonb,        -- { read, write, introspect, watermarkFields: [] }
+  status                TEXT NOT NULL DEFAULT 'inactive' CHECK (status IN ('active', 'inactive', 'error')),
+  last_tested_at        TIMESTAMPTZ,
+  last_error            TEXT,
+  created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at            TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+-- NULL is not equal to NULL in Postgres's default UNIQUE semantics, so a
+-- plain UNIQUE(tenant_id, workspace_id, name) would allow duplicate rows
+-- when workspace_id IS NULL (single-workspace deployments). PG 14 has no
+-- NULLS NOT DISTINCT, so use an expression index that coerces NULL to ''.
+-- Application MUST treat '' and NULL workspace_id as equivalent — or simpler,
+-- never store '' — callers should pass NULL for "no workspace".
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_integration_external_systems_scope_name
+  ON integration_external_systems (tenant_id, COALESCE(workspace_id, ''), name);
+CREATE INDEX IF NOT EXISTS idx_integration_external_systems_scope ON integration_external_systems(tenant_id, workspace_id);
+CREATE INDEX IF NOT EXISTS idx_integration_external_systems_kind ON integration_external_systems(kind);
+CREATE INDEX IF NOT EXISTS idx_integration_external_systems_status ON integration_external_systems(status);
+
+-- ---------------------------------------------------------------------------
+-- 2. Pipelines —— 清洗/同步作业定义
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS integration_pipelines (
+  id                        TEXT PRIMARY KEY,
+  tenant_id                 TEXT NOT NULL,
+  workspace_id              TEXT,
+  project_id                TEXT,
+  name                      TEXT NOT NULL,
+  description               TEXT,
+  source_system_id          TEXT NOT NULL REFERENCES integration_external_systems(id) ON DELETE RESTRICT,
+  source_object             TEXT NOT NULL,                         -- 源对象名（物料 / BOM / 表名 / endpoint）
+  target_system_id          TEXT NOT NULL REFERENCES integration_external_systems(id) ON DELETE RESTRICT,
+  target_object             TEXT NOT NULL,
+  staging_sheet_id          TEXT,                                  -- 多维表格 staging 表 id（staging-installer 管理）
+  mode                      TEXT NOT NULL DEFAULT 'incremental' CHECK (mode IN ('incremental', 'full', 'manual')),
+  idempotency_key_fields    JSONB NOT NULL DEFAULT '[]'::jsonb,   -- ['sourceSystem','objectType','sourceId','revision']
+  options                   JSONB NOT NULL DEFAULT '{}'::jsonb,
+  status                    TEXT NOT NULL DEFAULT 'draft' CHECK (status IN ('draft', 'active', 'paused', 'disabled')),
+  created_by                TEXT,
+  created_at                TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at                TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+-- See note on integration_external_systems above — same NULL-handling trap.
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_integration_pipelines_scope_name
+  ON integration_pipelines (tenant_id, COALESCE(workspace_id, ''), name);
+CREATE INDEX IF NOT EXISTS idx_integration_pipelines_scope ON integration_pipelines(tenant_id, workspace_id);
+CREATE INDEX IF NOT EXISTS idx_integration_pipelines_status ON integration_pipelines(status);
+CREATE INDEX IF NOT EXISTS idx_integration_pipelines_source_system ON integration_pipelines(source_system_id);
+CREATE INDEX IF NOT EXISTS idx_integration_pipelines_target_system ON integration_pipelines(target_system_id);
+
+-- ---------------------------------------------------------------------------
+-- 3. Field mappings —— 字段映射 + transform + 校验
+--    作用域跟随 pipeline，不单独持 tenant_id（外键级联即可）。
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS integration_field_mappings (
+  id                TEXT PRIMARY KEY,
+  pipeline_id       TEXT NOT NULL REFERENCES integration_pipelines(id) ON DELETE CASCADE,
+  source_field      TEXT NOT NULL,
+  target_field      TEXT NOT NULL,
+  transform         JSONB,                                         -- { fn: 'trim'|'upper'|'toNumber'|'dictMap', args: {...} }
+  validation        JSONB,                                         -- FieldValidationConfig: [{ type, params?, message? }, ...]
+  default_value     JSONB,
+  sort_order        INTEGER NOT NULL DEFAULT 0,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_integration_field_mappings_pipeline ON integration_field_mappings(pipeline_id);
+
+-- ---------------------------------------------------------------------------
+-- 4. Runs —— 每次 pipeline 执行记录
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS integration_runs (
+  id                TEXT PRIMARY KEY,
+  tenant_id         TEXT NOT NULL,
+  workspace_id      TEXT,
+  pipeline_id       TEXT NOT NULL REFERENCES integration_pipelines(id) ON DELETE CASCADE,
+  mode              TEXT NOT NULL,                                 -- 'incremental' | 'full' | 'manual' | 'replay'
+  triggered_by      TEXT NOT NULL,                                 -- 'cron' | 'manual' | 'api' | 'replay'
+  status            TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'running', 'succeeded', 'partial', 'failed', 'cancelled')),
+  rows_read         INTEGER NOT NULL DEFAULT 0,
+  rows_cleaned      INTEGER NOT NULL DEFAULT 0,
+  rows_written      INTEGER NOT NULL DEFAULT 0,
+  rows_failed       INTEGER NOT NULL DEFAULT 0,
+  started_at        TIMESTAMPTZ,
+  finished_at       TIMESTAMPTZ,
+  duration_ms       INTEGER,
+  error_summary     TEXT,
+  details           JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_integration_runs_scope ON integration_runs(tenant_id, workspace_id);
+CREATE INDEX IF NOT EXISTS idx_integration_runs_pipeline ON integration_runs(pipeline_id);
+CREATE INDEX IF NOT EXISTS idx_integration_runs_status ON integration_runs(status);
+CREATE INDEX IF NOT EXISTS idx_integration_runs_created_at ON integration_runs(created_at DESC);
+
+-- ---------------------------------------------------------------------------
+-- 5. Watermarks —— 增量水位（作用域跟随 pipeline）
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS integration_watermarks (
+  pipeline_id       TEXT PRIMARY KEY REFERENCES integration_pipelines(id) ON DELETE CASCADE,
+  watermark_type    TEXT NOT NULL CHECK (watermark_type IN ('updated_at', 'monotonic_id')),
+  watermark_value   TEXT NOT NULL,                                 -- ISO8601 or integer-as-string
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- ---------------------------------------------------------------------------
+-- 6. Dead letters —— 失败记录 + 可重放
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS integration_dead_letters (
+  id                    TEXT PRIMARY KEY,
+  tenant_id             TEXT NOT NULL,
+  workspace_id          TEXT,
+  run_id                TEXT NOT NULL REFERENCES integration_runs(id) ON DELETE CASCADE,
+  pipeline_id           TEXT NOT NULL REFERENCES integration_pipelines(id) ON DELETE CASCADE,
+  idempotency_key       TEXT,
+  source_payload        JSONB NOT NULL,
+  transformed_payload   JSONB,
+  error_code            TEXT NOT NULL,
+  error_message         TEXT NOT NULL,
+  retry_count           INTEGER NOT NULL DEFAULT 0,
+  status                TEXT NOT NULL DEFAULT 'open' CHECK (status IN ('open', 'replayed', 'discarded')),
+  last_replay_run_id    TEXT,                                      -- references integration_runs.id；replay 保留原 run 关联
+  created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at            TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_integration_dead_letters_scope ON integration_dead_letters(tenant_id, workspace_id);
+CREATE INDEX IF NOT EXISTS idx_integration_dead_letters_pipeline ON integration_dead_letters(pipeline_id);
+CREATE INDEX IF NOT EXISTS idx_integration_dead_letters_run ON integration_dead_letters(run_id);
+CREATE INDEX IF NOT EXISTS idx_integration_dead_letters_status ON integration_dead_letters(status);
+CREATE INDEX IF NOT EXISTS idx_integration_dead_letters_idempotency_key ON integration_dead_letters(idempotency_key);
+
+-- ---------------------------------------------------------------------------
+-- 7. Schedules —— 定时触发（cron）
+--    作用域跟随 pipeline。
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS integration_schedules (
+  id                TEXT PRIMARY KEY,
+  pipeline_id       TEXT NOT NULL REFERENCES integration_pipelines(id) ON DELETE CASCADE,
+  cron_expression   TEXT NOT NULL,
+  timezone          TEXT NOT NULL DEFAULT 'UTC',
+  enabled           BOOLEAN NOT NULL DEFAULT true,
+  last_run_at       TIMESTAMPTZ,
+  next_run_at       TIMESTAMPTZ,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_integration_schedules_pipeline ON integration_schedules(pipeline_id);
+CREATE INDEX IF NOT EXISTS idx_integration_schedules_enabled_next_run ON integration_schedules(enabled, next_run_at);
+
+-- ---------------------------------------------------------------------------
+-- updated_at 触发器
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION integration_set_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'trg_integration_external_systems_updated_at') THEN
+    CREATE TRIGGER trg_integration_external_systems_updated_at
+      BEFORE UPDATE ON integration_external_systems
+      FOR EACH ROW EXECUTE FUNCTION integration_set_updated_at();
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'trg_integration_pipelines_updated_at') THEN
+    CREATE TRIGGER trg_integration_pipelines_updated_at
+      BEFORE UPDATE ON integration_pipelines
+      FOR EACH ROW EXECUTE FUNCTION integration_set_updated_at();
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'trg_integration_dead_letters_updated_at') THEN
+    CREATE TRIGGER trg_integration_dead_letters_updated_at
+      BEFORE UPDATE ON integration_dead_letters
+      FOR EACH ROW EXECUTE FUNCTION integration_set_updated_at();
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'trg_integration_schedules_updated_at') THEN
+    CREATE TRIGGER trg_integration_schedules_updated_at
+      BEFORE UPDATE ON integration_schedules
+      FOR EACH ROW EXECUTE FUNCTION integration_set_updated_at();
+  END IF;
+END $$;

--- a/packages/core-backend/migrations/057_create_integration_core_tables.sql
+++ b/packages/core-backend/migrations/057_create_integration_core_tables.sql
@@ -122,6 +122,8 @@ CREATE INDEX IF NOT EXISTS idx_integration_runs_created_at ON integration_runs(c
 
 -- ---------------------------------------------------------------------------
 -- 5. Watermarks —— 增量水位（作用域跟随 pipeline）
+--    NOTE: tenant/workspace scope is inherited from integration_pipelines.
+--    DB-level cross-row scope enforcement is deferred to the M1 service layer.
 -- ---------------------------------------------------------------------------
 CREATE TABLE IF NOT EXISTS integration_watermarks (
   pipeline_id       TEXT PRIMARY KEY REFERENCES integration_pipelines(id) ON DELETE CASCADE,
@@ -195,6 +197,11 @@ BEGIN
   IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'trg_integration_pipelines_updated_at') THEN
     CREATE TRIGGER trg_integration_pipelines_updated_at
       BEFORE UPDATE ON integration_pipelines
+      FOR EACH ROW EXECUTE FUNCTION integration_set_updated_at();
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'trg_integration_watermarks_updated_at') THEN
+    CREATE TRIGGER trg_integration_watermarks_updated_at
+      BEFORE UPDATE ON integration_watermarks
       FOR EACH ROW EXECUTE FUNCTION integration_set_updated_at();
   END IF;
   IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'trg_integration_dead_letters_updated_at') THEN

--- a/plugins/plugin-integration-core/SPIKE_NOTES.md
+++ b/plugins/plugin-integration-core/SPIKE_NOTES.md
@@ -1,0 +1,100 @@
+# M0 Spike Findings — plugin-integration-core
+
+> Status: ✅ Spike complete. Runtime path confirmed. 4 committed tests pass.
+> Date: 2026-04-24
+> PR #0 review: all 5 issues resolved in-file; 3 kernel-side gaps remain (see below).
+
+---
+
+## ⚠ Known kernel gaps — TODO before production
+
+These are kernel-side limitations surfaced during spike. M0 works *around* them but they must be addressed (in the kernel, not in this plugin) before the M1 pipeline runner ships. Each bullet cites an exact file:line so a follow-up PR can target it.
+
+### 1. `http.addRoute` has no functional `removeRoute`
+
+`packages/core-backend/src/index.ts:284` implements `removeRoute(path)` as a no-op that only emits `logger.warn('Route removal not implemented')`. Consequence: when this plugin is deactivated or hot-reloaded the Express route registered at `plugins/plugin-integration-core/index.cjs:56` persists in the running process. In M1 that will mean stale `/api/integration/pipelines/*` endpoints bound to dead code after any reload.
+
+**Scope of fix**: either implement real route removal on the Express `Router` (rebuild router on deactivate) or introduce a plugin-scoped sub-router that can be dropped atomically.
+
+### 2. `communication.register` has no `unregister`
+
+`packages/core-backend/src/index.ts:1320-1338` builds the `communication` helper with `register(name, api)` that does `pluginApis.set(name, api)`. There is no matching delete. If this plugin re-activates under a new module instance, the previous namespace remains and `communication.call('integration-core', ...)` may hit the stale closure.
+
+**Scope of fix**: add `unregister(name)` to the `PluginCommunication` surface and call it from `deactivatePluginByName` (`src/index.ts:1410`).
+
+### 3. `services.security.encrypt/decrypt` declared in types but not wired
+
+`packages/core-backend/src/types/plugin.ts` declares `PluginServices.security` (and several other services) but the runtime factory at `src/index.ts:1351-1356` only injects `notification / automationRegistry / rbacProvisioning / platformAppInstances` and casts the result with `as unknown as PluginServices`. Any plugin written against the type declaration would silently get `undefined` at runtime.
+
+**Workaround in this plugin**: `lib/credential-store.cjs` is self-contained (Node `crypto`, `INTEGRATION_ENCRYPTION_KEY` env) and does not rely on `services.security`.
+
+**Scope of fix**: instantiate a security service backed by `packages/core-backend/src/security/encrypted-secrets.ts` and add it to the `services` object at `src/index.ts:1356`. Then credential-store can migrate.
+
+---
+
+## Runtime path (confirmed)
+
+Active plugin loader path: `packages/core-backend/src/index.ts:1087` — `createPluginContext(loaded)`.
+
+- Plugins discovered by `PluginLoader` (`packages/core-backend/src/core/plugin-loader.ts:221`), scanning `./plugins/` (override via `new MetaSheetServer({ pluginDirs: [...] })`).
+- Manifests validated against a lenient Zod schema (`PluginManifestSchema`, `plugin-loader.ts:51`). Our `plugin.json` passes: v2 format, array permissions, string `main`.
+- Activation goes through `activatePluginInstance()` → `plugin.activate(context)` (line 1392).
+- `core/plugin-manager.ts` has its own `createPluginContext()` — an *enhanced* V2 context — but that path is NOT invoked for CJS plugins. We follow the `src/index.ts` path, same as `plugin-after-sales`.
+
+## PluginContext shape at runtime (actual, not type-declared)
+
+- `context.api` → full `CoreAPI` with `http.addRoute`, `multitable` (scoped via `createPluginScopedMultitableApi`), `database`, `events`, etc.
+- `context.services` → at runtime only `notification / automationRegistry / rbacProvisioning / platformAppInstances`. The richer `PluginServices` type is a cast, not a binding.
+- `context.communication` → `{ call, register, on, emit }`; in-process `pluginApis` Map. **No unregister (see gap #2)**.
+- `context.storage` → in-memory `Map` per plugin — NOT persistent. Do not use for real state; use `context.api.database` instead.
+- `context.logger` → plugin-scoped `Logger`.
+
+## Scoping convention used in this plugin (aligns with existing tables)
+
+All operational SQL tables in `057_create_integration_core_tables.sql` carry `tenant_id TEXT NOT NULL`, and where applicable `workspace_id TEXT` and `project_id TEXT`. This mirrors:
+
+- `bpmn_process_definitions` (`packages/core-backend/migrations/049_*.sql`): `tenant_id TEXT` + `UNIQUE (key, version, tenant_id)`
+- `plugin_configs` (`008_*.sql`): `tenant_id VARCHAR(255)` + composite unique with `(plugin_name, config_key, tenant_id)`
+- `plugin-after-sales` ledger rows: `(tenant_id, app_id, project_id, …)`
+
+K3 WISE 账套 / Yuantus PLM org_id 等外部系统维度不单独拆列，存在 `integration_external_systems.config` JSONB 中。
+
+## DB access boundary (revised after review)
+
+`lib/db.cjs` now exposes a structured CRUD builder only:
+
+```
+select, selectOne, insertOne, insertMany,
+updateRow, deleteRows, countRows, transaction
+```
+
+The earlier regex-based SQL prefix scan has been removed — it was trivially bypassed by quoted identifiers like `FROM "users"`. The module has no `rawQuery` method. Table and column names pass through `IDENT_RE = /^[a-zA-Z_][a-zA-Z0-9_]*$/` and the table-prefix whitelist before any SQL is built; every value goes through parameterized placeholders.
+
+If future features require raw SQL, add a validated method here — do not reintroduce an escape hatch.
+
+## Plugin skeleton conventions (follow these for next plugins)
+
+- `index.cjs` with `module.exports = { async activate(context) { ... }, async deactivate() { ... } }`
+- `lib/*.cjs` for modular code (CommonJS throughout, no build step)
+- `__tests__/*.test.cjs` — standalone Node `assert` tests; runnable via `node <path>` or through the `test` npm script
+- Manifest v2.0 (`manifestVersion: "2.0.0"`)
+- `main: "index.cjs"` (string form)
+- `permissions: [...]` (array form) — normalized by `normalizePermissionList()` in plugin-loader
+- Optional `app.manifest.json` for runtime bindings / platformDependencies
+
+## Verification
+
+```bash
+cd /Users/chouhua/Downloads/Github/metasheet2
+node plugins/plugin-integration-core/__tests__/plugin-runtime-smoke.test.cjs
+node plugins/plugin-integration-core/__tests__/credential-store.test.cjs
+node plugins/plugin-integration-core/__tests__/db.test.cjs
+node plugins/plugin-integration-core/__tests__/staging-installer.test.cjs
+```
+
+Or: `pnpm -F plugin-integration-core test`.
+
+All 4 test files pass without a live database or the metasheet2 server — they exercise pure logic and mocked contexts. Two things remain untested at this layer and require downstream work:
+
+- The SQL migration `057_create_integration_core_tables.sql` has not been applied against a real Postgres instance. M1 must include `pnpm migrate` CI.
+- Full plugin activation through `PluginLoader` + `createPluginContext` requires booting the backend. The smoke test uses a mocked context that replicates the documented shape but does not exercise the real host.

--- a/plugins/plugin-integration-core/__tests__/credential-store.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/credential-store.test.cjs
@@ -1,0 +1,124 @@
+'use strict'
+
+// ---------------------------------------------------------------------------
+// credential-store.cjs — committed tests
+//
+// Verifies:
+//   1. Dev fallback path when INTEGRATION_ENCRYPTION_KEY is absent and
+//      NODE_ENV != production.
+//   2. Production refuses to start without the env key.
+//   3. Env key (64-hex-char, 32 bytes) works in production mode.
+//   4. Encrypt → decrypt round-trip for a variety of payloads.
+//   5. Tamper detection: flipping ciphertext bytes throws.
+//   6. Malformed ciphertext is rejected with a clear format error.
+//   7. Fingerprint is a stable short hex string.
+//
+// Run: node __tests__/credential-store.test.cjs
+// ---------------------------------------------------------------------------
+
+const assert = require('node:assert/strict')
+const path = require('node:path')
+const { createCredentialStore, __internals } = require(path.join(__dirname, '..', 'lib', 'credential-store.cjs'))
+
+function runInScope(envPatch, fn) {
+  const saved = {}
+  for (const k of Object.keys(envPatch)) {
+    saved[k] = process.env[k]
+    if (envPatch[k] === null || envPatch[k] === undefined) {
+      delete process.env[k]
+    } else {
+      process.env[k] = envPatch[k]
+    }
+  }
+  try {
+    return fn()
+  } finally {
+    for (const k of Object.keys(saved)) {
+      if (saved[k] === undefined) delete process.env[k]
+      else process.env[k] = saved[k]
+    }
+  }
+}
+
+async function main() {
+  // --- 1. Dev fallback -------------------------------------------------
+  runInScope({ NODE_ENV: 'development', INTEGRATION_ENCRYPTION_KEY: null }, () => {
+    const warnLogs = []
+    const store = createCredentialStore({ logger: { warn: (m) => warnLogs.push(m) } })
+    assert.equal(store.source, 'dev-fallback', 'dev fallback source')
+    assert.ok(warnLogs.length === 1 && /INTEGRATION_ENCRYPTION_KEY/.test(warnLogs[0]), 'warns about missing key')
+  })
+
+  // --- 2. Production refuses without key -------------------------------
+  runInScope({ NODE_ENV: 'production', INTEGRATION_ENCRYPTION_KEY: null }, () => {
+    let err = null
+    try { createCredentialStore() } catch (e) { err = e }
+    assert.ok(err, 'prod throws without key')
+    assert.match(err.message, /INTEGRATION_ENCRYPTION_KEY/, 'error message names the env var')
+  })
+
+  // --- 3-5. Production with key — roundtrip + tamper + format ----------
+  runInScope(
+    { NODE_ENV: 'production', INTEGRATION_ENCRYPTION_KEY: 'a'.repeat(64) },
+    () => {
+      const store = createCredentialStore()
+      assert.equal(store.source, 'env', 'env source')
+
+      const payloads = [
+        'simple',
+        'K3WISE_password_with_special!@#$%_chars',
+        '中文密码 with 空格',
+        '{"type":"json","nested":{"x":1}}',
+        '',  // empty string
+      ]
+      for (const p of payloads) {
+        const ct = store.encrypt(p)
+        assert.ok(ct.startsWith('v1:'), `ciphertext for "${p.slice(0, 20)}" is v1-tagged`)
+        assert.notEqual(ct, p, 'ciphertext differs from plaintext')
+        assert.equal(store.decrypt(ct), p, `roundtrip for "${p.slice(0, 20)}"`)
+      }
+
+      // Tamper: flip last 2 chars of the data segment — MUST throw
+      const ct = store.encrypt('hello')
+      const parts = ct.split(':')
+      const d = parts[3]
+      const tampered = [parts[0], parts[1], parts[2], d.slice(0, -2) + (d.slice(-2) === 'AA' ? 'BB' : 'AA')].join(':')
+      let tErr = null
+      try { store.decrypt(tampered) } catch (e) { tErr = e }
+      assert.ok(tErr, 'tamper must throw')
+
+      // Malformed ciphertext — format error
+      let fErr = null
+      try { store.decrypt('not-a-v1-ciphertext') } catch (e) { fErr = e }
+      assert.ok(fErr && /invalid ciphertext format/.test(fErr.message), 'format rejection')
+
+      // Fingerprint: stable and short
+      const fp1 = store.fingerprint(ct)
+      const fp2 = store.fingerprint(ct)
+      assert.equal(fp1, fp2, 'fingerprint stable')
+      assert.match(fp1, /^[0-9a-f]{16}$/, 'fingerprint shape')
+    },
+  )
+
+  // --- 6. Key decode accepts hex and base64 ----------------------------
+  const hexKey = 'a'.repeat(64)
+  assert.ok(__internals.decodeKey(hexKey), 'hex key decoded')
+  const rawBuf = Buffer.alloc(32, 7)
+  const b64Key = rawBuf.toString('base64')
+  const decoded = __internals.decodeKey(b64Key)
+  assert.ok(decoded && decoded.equals(rawBuf), 'base64 key decoded to original bytes')
+
+  // --- 7. Wrong-length keys rejected -----------------------------------
+  assert.equal(__internals.decodeKey('short'), null, 'short key rejected')
+  assert.equal(__internals.decodeKey('a'.repeat(10)), null, 'wrong hex length rejected')
+  assert.equal(__internals.decodeKey(null), null, 'null rejected')
+  assert.equal(__internals.decodeKey(''), null, 'empty rejected')
+
+  console.log('✓ credential-store: 7 scenarios passed')
+}
+
+main().catch((err) => {
+  console.error('✗ credential-store FAILED')
+  console.error(err)
+  process.exit(1)
+})

--- a/plugins/plugin-integration-core/__tests__/db.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/db.test.cjs
@@ -1,0 +1,250 @@
+'use strict'
+
+// ---------------------------------------------------------------------------
+// db.cjs — committed tests for the strict CRUD builder
+//
+// Verifies:
+//   1. Identifier whitelist — isAllowedTable, IDENT_RE
+//   2. assertTable / assertColumn throw ScopeViolationError for bad input
+//   3. Table prefix boundary: non-`integration_*` tables rejected
+//   4. Quoted-identifier bypass (the regression the review flagged) is
+//      no longer possible because the API accepts only raw identifiers
+//      — there is no path to inject quotes.
+//   5. select/insertOne/insertMany/updateRow/deleteRows/countRows build
+//      parameterized SQL with whitelisted identifiers and never concatenate
+//      user values into the statement.
+//   6. updateRow / deleteRows refuse empty where clauses (no unbounded ops).
+//   7. transaction() exposes the same scoped surface, no rawQuery.
+//   8. No rawQuery export at all.
+//
+// Run: node __tests__/db.test.cjs
+// ---------------------------------------------------------------------------
+
+const assert = require('node:assert/strict')
+const path = require('node:path')
+const { createDb, ScopeViolationError, ALLOWED_PREFIX, __internals } = require(
+  path.join(__dirname, '..', 'lib', 'db.cjs'),
+)
+
+// Host-contract mock: query() returns an array (Record<string,unknown>[])
+// directly, matching packages/core-backend/src/types/plugin.ts:685 and the
+// concrete runtime at packages/core-backend/src/index.ts:324
+// (`return (await pool.query(...)).rows`).
+function mockDatabase({ nextRows } = {}) {
+  const calls = []
+  const rowsQueue = Array.isArray(nextRows) ? nextRows.slice() : []
+  function takeRows() {
+    return rowsQueue.length > 0 ? rowsQueue.shift() : []
+  }
+  const db = {
+    calls,
+    async query(sql, params) {
+      calls.push({ sql, params: params ? params.slice() : undefined })
+      return takeRows()
+    },
+    async transaction(cb) {
+      return cb({
+        async query(sql, params) {
+          calls.push({ sql, params: params ? params.slice() : undefined, tx: true })
+          return takeRows()
+        },
+        async commit() { calls.push({ commit: true }) },
+        async rollback() { calls.push({ rollback: true }) },
+      })
+    },
+  }
+  return db
+}
+
+async function main() {
+  // --- 1-3. Identifier whitelist & table prefix ------------------------
+  assert.equal(ALLOWED_PREFIX, 'integration_')
+  assert.equal(__internals.isAllowedTable('integration_pipelines'), true)
+  assert.equal(__internals.isAllowedTable('integration_'), false)
+  assert.equal(__internals.isAllowedTable('multitable_records'), false)
+  assert.equal(__internals.isAllowedTable('integration_; DROP TABLE users; --'), false)
+  assert.equal(__internals.isAllowedTable('integration_pipelines_1'), true)
+
+  // assertTable
+  let e1 = null
+  try { __internals.assertTable('users') } catch (e) { e1 = e }
+  assert.ok(e1 instanceof ScopeViolationError)
+
+  // assertColumn: reject anything not matching IDENT_RE
+  for (const bad of ['', '1col', 'col-name', 'col name', 'col"', 'col;', 'col--', null, undefined]) {
+    let err = null
+    try { __internals.assertColumn(bad) } catch (e) { err = e }
+    assert.ok(err instanceof ScopeViolationError, `assertColumn rejects ${JSON.stringify(bad)}`)
+  }
+  assert.equal(__internals.assertColumn('valid_col_1'), 'valid_col_1')
+
+  // --- 4. There is no path to raw SQL / quoted identifiers ------------
+  // The exported surface exposes these methods only:
+  const db = createDb({ database: mockDatabase() })
+  const publicKeys = Object.keys(db).sort()
+  const expected = [
+    'ALLOWED_PREFIX', 'countRows', 'deleteRows', 'insertMany', 'insertOne',
+    'select', 'selectOne', 'transaction', 'updateRow',
+  ]
+  assert.deepEqual(publicKeys, expected, 'no rawQuery / execute / any raw SQL hook')
+
+  // --- 5. select builds parameterized SQL ------------------------------
+  const mockDb5 = mockDatabase()
+  const db5 = createDb({ database: mockDb5 })
+  await db5.select('integration_pipelines', { where: { status: 'active', tenant_id: 't1' }, orderBy: 'created_at', limit: 50, offset: 10 })
+  assert.equal(mockDb5.calls.length, 1)
+  const q5 = mockDb5.calls[0]
+  assert.match(q5.sql, /^SELECT \* FROM "integration_pipelines"/)
+  assert.match(q5.sql, / WHERE "status" = \$1 AND "tenant_id" = \$2/)
+  assert.match(q5.sql, / ORDER BY "created_at" ASC/)
+  assert.match(q5.sql, / LIMIT 50 OFFSET 10/)
+  assert.deepEqual(q5.params, ['active', 't1'])
+
+  // select with no WHERE
+  await db5.select('integration_runs', { limit: 1 })
+  const q5b = mockDb5.calls[1]
+  assert.match(q5b.sql, /^SELECT \* FROM "integration_runs" LIMIT 1 OFFSET 0$/)
+  assert.deepEqual(q5b.params, [])
+
+  // select rejects forbidden table
+  let selErr = null
+  try { await db5.select('users') } catch (e) { selErr = e }
+  assert.ok(selErr instanceof ScopeViolationError)
+
+  // insertOne
+  const mockDb6 = mockDatabase()
+  const db6 = createDb({ database: mockDb6 })
+  await db6.insertOne('integration_pipelines', { id: 'p1', name: 'X', status: 'draft' })
+  const q6 = mockDb6.calls[0]
+  assert.match(q6.sql, /^INSERT INTO "integration_pipelines" \("id", "name", "status"\) VALUES \(\$1, \$2, \$3\) RETURNING \*$/)
+  assert.deepEqual(q6.params, ['p1', 'X', 'draft'])
+
+  // insertMany with consistent keys
+  const mockDb7 = mockDatabase()
+  const db7 = createDb({ database: mockDb7 })
+  await db7.insertMany('integration_runs', [
+    { id: 'r1', pipeline_id: 'p1', status: 'running' },
+    { id: 'r2', pipeline_id: 'p1', status: 'succeeded' },
+  ])
+  const q7 = mockDb7.calls[0]
+  assert.match(q7.sql, /^INSERT INTO "integration_runs" \("id", "pipeline_id", "status"\) VALUES \(\$1, \$2, \$3\), \(\$4, \$5, \$6\) RETURNING \*$/)
+  assert.deepEqual(q7.params, ['r1', 'p1', 'running', 'r2', 'p1', 'succeeded'])
+
+  const emptyInsert = await db7.insertMany('integration_runs', [])
+  assert.deepEqual(emptyInsert, [], 'insertMany empty batch keeps host array-return shape')
+
+  // insertMany with inconsistent keys → throws
+  let imErr = null
+  try {
+    await db7.insertMany('integration_runs', [
+      { id: 'r3', pipeline_id: 'p1' },
+      { id: 'r4', pipeline_id: 'p1', status: 'failed' },
+    ])
+  } catch (e) { imErr = e }
+  assert.ok(imErr && /inconsistent keys/.test(imErr.message))
+
+  // updateRow
+  const mockDb8 = mockDatabase()
+  const db8 = createDb({ database: mockDb8 })
+  await db8.updateRow('integration_dead_letters', { status: 'replayed', retry_count: 1 }, { id: 'dl1' })
+  const q8 = mockDb8.calls[0]
+  assert.match(q8.sql, /^UPDATE "integration_dead_letters" SET "status" = \$1, "retry_count" = \$2 WHERE "id" = \$3 RETURNING \*$/)
+  assert.deepEqual(q8.params, ['replayed', 1, 'dl1'])
+
+  // --- 6. updateRow / deleteRows refuse empty where --------------------
+  let upErr = null
+  try { await db8.updateRow('integration_pipelines', { status: 'paused' }, {}) } catch (e) { upErr = e }
+  assert.ok(upErr && /non-empty/.test(upErr.message), 'updateRow refuses empty where')
+
+  let delErr = null
+  try { await db8.deleteRows('integration_pipelines', {}) } catch (e) { delErr = e }
+  assert.ok(delErr && /non-empty/.test(delErr.message), 'deleteRows refuses empty where')
+
+  // deleteRows with where
+  await db8.deleteRows('integration_dead_letters', { status: 'discarded' })
+  const q8b = mockDb8.calls[1]
+  assert.match(q8b.sql, /^DELETE FROM "integration_dead_letters" WHERE "status" = \$1 RETURNING \*$/)
+  assert.deepEqual(q8b.params, ['discarded'])
+
+  // countRows
+  await db8.countRows('integration_runs', { pipeline_id: 'p1' })
+  const q8c = mockDb8.calls[2]
+  assert.match(q8c.sql, /^SELECT COUNT\(\*\)::int AS count FROM "integration_runs" WHERE "pipeline_id" = \$1$/)
+
+  // --- 6b. Return-shape contract: host returns array directly ----------
+  // Regression: PR #0 v1 assumed { rows: [...] } wrapper; real runtime
+  // (types/plugin.ts:685, src/index.ts:324) returns Record<string,unknown>[]
+  // directly, which made selectOne/countRows silently return null/0.
+  const mockDb6b_one = mockDatabase({ nextRows: [
+    [{ id: 'p1', name: 'x', status: 'draft' }],  // selectOne → select() uses limit:1
+  ] })
+  const db6b_one = createDb({ database: mockDb6b_one })
+  const row = await db6b_one.selectOne('integration_pipelines', { id: 'p1' })
+  assert.ok(row && row.id === 'p1', 'selectOne unwraps array-return shape')
+
+  const mockDb6b_count = mockDatabase({ nextRows: [
+    [{ count: 42 }],
+  ] })
+  const db6b_count = createDb({ database: mockDb6b_count })
+  const n = await db6b_count.countRows('integration_runs', { pipeline_id: 'p1' })
+  assert.equal(n, 42, 'countRows unwraps array-return shape')
+
+  // And when host returns empty array, these degrade gracefully
+  const mockDb6b_empty = mockDatabase({ nextRows: [[], []] })
+  const db6b_empty = createDb({ database: mockDb6b_empty })
+  assert.equal(await db6b_empty.selectOne('integration_pipelines', { id: 'x' }), null, 'selectOne empty → null')
+  assert.equal(await db6b_empty.countRows('integration_runs', { pipeline_id: 'x' }), 0, 'countRows empty → 0')
+
+  // Defence: if a custom binding returns { rows: [...] }, we still work.
+  const legacyShapeDb = {
+    async query() { return { rows: [{ id: 'legacy' }] } },
+    async transaction() { throw new Error('not used') },
+  }
+  const dbLegacy = createDb({ database: legacyShapeDb })
+  const legacyRow = await dbLegacy.selectOne('integration_pipelines', { id: 'legacy' })
+  assert.ok(legacyRow && legacyRow.id === 'legacy', 'defensive: {rows:[]} shape still works')
+
+  // --- 7. transaction() exposes scoped surface, no rawQuery -----------
+  const mockDb9 = mockDatabase()
+  const db9 = createDb({ database: mockDb9 })
+  await db9.transaction(async (trx) => {
+    const trxKeys = Object.keys(trx).sort()
+    assert.deepEqual(
+      trxKeys,
+      ['commit', 'countRows', 'deleteRows', 'insertMany', 'insertOne', 'rollback', 'select', 'selectOne', 'updateRow'],
+      'transaction exposes scoped surface only, no rawQuery',
+    )
+    await trx.insertOne('integration_runs', { id: 'rtx', status: 'running' })
+  })
+  assert.ok(mockDb9.calls.some((c) => c.tx && /INSERT INTO "integration_runs"/.test(c.sql)))
+
+  // --- 8. No rawQuery export ------------------------------------------
+  assert.equal(typeof db.rawQuery, 'undefined', 'db has no rawQuery')
+
+  // --- 9. Injection attempt through values is harmless (parameterized) ---
+  const mockDb10 = mockDatabase()
+  const db10 = createDb({ database: mockDb10 })
+  await db10.insertOne('integration_pipelines', {
+    id: 'p_inj',
+    name: "'; DROP TABLE users; --",  // value, not identifier — safe
+  })
+  const q10 = mockDb10.calls[0]
+  // SQL must NOT contain the injection payload; it must be in params.
+  assert.doesNotMatch(q10.sql, /DROP/, 'injection payload not in SQL')
+  assert.ok(q10.params.includes("'; DROP TABLE users; --"), 'injection payload parameterized')
+
+  // --- 10. Injection attempt through identifier is rejected -----------
+  let idErr = null
+  try {
+    await db10.insertOne('integration_pipelines', { ['name"; DROP TABLE users; --']: 'x' })
+  } catch (e) { idErr = e }
+  assert.ok(idErr instanceof ScopeViolationError, 'identifier injection rejected')
+
+  console.log('✓ db.cjs: all CRUD + boundary + injection tests passed')
+}
+
+main().catch((err) => {
+  console.error('✗ db.cjs FAILED')
+  console.error(err)
+  process.exit(1)
+})

--- a/plugins/plugin-integration-core/__tests__/host-loader-smoke.test.mjs
+++ b/plugins/plugin-integration-core/__tests__/host-loader-smoke.test.mjs
@@ -1,0 +1,124 @@
+import assert from 'node:assert/strict'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const pluginDir = path.resolve(__dirname, '..')
+const pluginLoaderModuleUrl = new URL('../../../packages/core-backend/src/core/plugin-loader.ts', import.meta.url)
+
+async function loadPluginLoaderClass() {
+  process.env.METASHEET_VERSION = process.env.METASHEET_VERSION || '2.5.0'
+  const mod = await import(pluginLoaderModuleUrl.href)
+  const candidate = mod.PluginLoader || mod.default?.PluginLoader || mod.default
+  assert.equal(typeof candidate, 'function', 'PluginLoader export resolves to a class/function')
+  return candidate
+}
+
+function createHostContext() {
+  const routes = []
+  const namespaces = new Map()
+  const logs = []
+
+  const context = {
+    api: {
+      http: {
+        addRoute(method, routePath, handler) {
+          routes.push({ method, path: routePath, handler })
+        },
+      },
+      database: {
+        async query() {
+          return []
+        },
+      },
+      multitable: {
+        provisioning: {
+          async ensureObject() {
+            throw new Error('not used in host-loader smoke')
+          },
+        },
+      },
+      events: {
+        emit() {},
+        on() {},
+      },
+    },
+    communication: {
+      register(name, api) {
+        namespaces.set(name, api)
+      },
+      async call(name, method, ...args) {
+        const api = namespaces.get(name)
+        if (!api || typeof api[method] !== 'function') {
+          throw new Error(`missing communication method ${name}.${method}`)
+        }
+        return api[method](...args)
+      },
+      on() {},
+      emit() {},
+    },
+    logger: {
+      info(message) { logs.push(String(message)) },
+      warn(message) { logs.push(String(message)) },
+      error(message) { logs.push(String(message)) },
+    },
+    storage: {
+      async get() { return null },
+      async set() {},
+      async delete() {},
+      async list() { return [] },
+    },
+    services: {},
+    config: {},
+  }
+
+  return { context, routes, namespaces, logs }
+}
+
+async function main() {
+  const PluginLoader = await loadPluginLoaderClass()
+  const loader = new PluginLoader({}, { pluginDirs: [pluginDir] })
+  const discovered = await loader.discover()
+
+  assert.deepEqual(discovered, [pluginDir], 'PluginLoader discovers plugin-integration-core directory')
+
+  const loaded = await loader.load(discovered[0], { basePath: '/' })
+  assert.ok(loaded, 'PluginLoader loads plugin-integration-core')
+  assert.equal(loaded.manifest.name, 'plugin-integration-core')
+  assert.equal(typeof loaded.plugin.activate, 'function')
+  assert.equal(typeof loaded.plugin.deactivate, 'function')
+
+  const host = createHostContext()
+  await loaded.plugin.activate(host.context)
+
+  assert.equal(host.routes.length, 1, 'activate registers one route')
+  assert.equal(host.routes[0].method, 'GET')
+  assert.equal(host.routes[0].path, '/api/integration/health')
+  assert.ok(host.namespaces.has('integration-core'), 'activate registers communication namespace')
+
+  let responseBody = null
+  await host.routes[0].handler({}, { json(value) { responseBody = value } })
+  assert.equal(responseBody?.ok, true)
+  assert.equal(responseBody?.plugin, 'plugin-integration-core')
+
+  const ping = await host.context.communication.call('integration-core', 'ping')
+  assert.equal(ping.ok, true)
+  assert.equal(ping.plugin, 'plugin-integration-core')
+
+  const status = await host.context.communication.call('integration-core', 'getStatus')
+  assert.equal(status.plugin, 'plugin-integration-core')
+  assert.equal(status.routesRegistered, 1)
+
+  await loaded.plugin.deactivate()
+  assert.ok(host.logs.some((line) => line.includes('activated')), 'activation logged')
+  assert.ok(host.logs.some((line) => line.includes('deactivated')), 'deactivation logged')
+
+  console.log('✓ host-loader-smoke: PluginLoader load + activate path passed')
+}
+
+main().catch((err) => {
+  console.error('✗ host-loader-smoke FAILED')
+  console.error(err)
+  process.exit(1)
+})

--- a/plugins/plugin-integration-core/__tests__/migration-sql.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/migration-sql.test.cjs
@@ -1,0 +1,111 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+
+const repoRoot = path.resolve(__dirname, '..', '..', '..')
+const migrationPath = path.join(repoRoot, 'packages', 'core-backend', 'migrations', '057_create_integration_core_tables.sql')
+const sql = fs.readFileSync(migrationPath, 'utf8')
+
+const expectedTables = [
+  'integration_external_systems',
+  'integration_pipelines',
+  'integration_field_mappings',
+  'integration_runs',
+  'integration_watermarks',
+  'integration_dead_letters',
+  'integration_schedules',
+]
+
+const tablesWithUpdatedAtTriggers = [
+  'integration_external_systems',
+  'integration_pipelines',
+  'integration_watermarks',
+  'integration_dead_letters',
+  'integration_schedules',
+]
+
+function tableBlock(table) {
+  const match = sql.match(new RegExp(`CREATE TABLE IF NOT EXISTS ${table} \\(([\\s\\S]*?)\\n\\);`, 'm'))
+  assert.ok(match, `expected CREATE TABLE IF NOT EXISTS block for ${table}`)
+  return match[1]
+}
+
+function hasSecondaryIndexOn(table) {
+  return new RegExp(`CREATE (?:UNIQUE )?INDEX IF NOT EXISTS [\\s\\S]*?\\bON ${table}\\s*\\(`, 'm').test(sql)
+}
+
+function assertOnlyIntegrationTableRefs(kind, refs) {
+  const disallowed = refs.filter((table) => !table.startsWith('integration_'))
+  assert.deepEqual(disallowed, [], `${kind} only references integration_* tables`)
+}
+
+function main() {
+  assert.ok(sql.includes('CREATE OR REPLACE FUNCTION integration_set_updated_at()'), 'updated_at trigger function exists')
+  assert.doesNotMatch(sql, /\bDROP\s+TABLE\b/i, 'forward migration must not drop tables')
+
+  for (const table of expectedTables) {
+    const block = tableBlock(table)
+    if (table === 'integration_watermarks') {
+      assert.match(
+        block,
+        /\bpipeline_id\s+TEXT PRIMARY KEY REFERENCES integration_pipelines\(id\) ON DELETE CASCADE\b/,
+        `${table} uses pipeline_id as primary key`,
+      )
+    } else {
+      assert.match(block, /\bid\s+TEXT PRIMARY KEY\b/, `${table} has TEXT primary key id`)
+    }
+  }
+
+  for (const table of expectedTables.filter((table) => table !== 'integration_watermarks')) {
+    assert.ok(hasSecondaryIndexOn(table), `${table} has at least one secondary index`)
+  }
+
+  for (const table of tablesWithUpdatedAtTriggers) {
+    assert.match(
+      sql,
+      new RegExp(`CREATE TRIGGER trg_${table}_updated_at[\\s\\S]*?BEFORE UPDATE ON ${table}[\\s\\S]*?EXECUTE FUNCTION integration_set_updated_at\\(\\);`, 'm'),
+      `${table} updates updated_at through trigger`,
+    )
+  }
+
+  for (const scopedTable of [
+    'integration_external_systems',
+    'integration_pipelines',
+    'integration_runs',
+    'integration_dead_letters',
+  ]) {
+    const block = tableBlock(scopedTable)
+    assert.match(block, /\btenant_id\s+TEXT NOT NULL\b/, `${scopedTable} has tenant_id scope`)
+    assert.match(block, /\bworkspace_id\s+TEXT\b/, `${scopedTable} has workspace_id scope`)
+  }
+
+  assert.match(
+    sql,
+    /CREATE UNIQUE INDEX IF NOT EXISTS uniq_integration_external_systems_scope_name\s+ON integration_external_systems \(tenant_id, COALESCE\(workspace_id, ''\), name\);/m,
+    'external systems unique index treats NULL workspace_id deterministically',
+  )
+  assert.match(
+    sql,
+    /CREATE UNIQUE INDEX IF NOT EXISTS uniq_integration_pipelines_scope_name\s+ON integration_pipelines \(tenant_id, COALESCE\(workspace_id, ''\), name\);/m,
+    'pipelines unique index treats NULL workspace_id deterministically',
+  )
+
+  const ddlTableRefs = Array.from(sql.matchAll(/\b(?:CREATE|ALTER|DROP|TRUNCATE)\s+TABLE(?:\s+IF\s+(?:NOT\s+)?EXISTS)?\s+([a-zA-Z_][a-zA-Z0-9_]*)/gi))
+    .map((match) => match[1])
+    .filter((table) => table !== 'IF')
+  assertOnlyIntegrationTableRefs('DDL', ddlTableRefs)
+
+  const indexTableRefs = Array.from(sql.matchAll(/\bCREATE\s+(?:UNIQUE\s+)?INDEX\s+IF\s+NOT\s+EXISTS\s+[a-zA-Z_][a-zA-Z0-9_]*[\s\S]*?\bON\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*\(/gi))
+    .map((match) => match[1])
+  assertOnlyIntegrationTableRefs('index', indexTableRefs)
+
+  const foreignTableRefs = Array.from(sql.matchAll(/\bREFERENCES\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*\(/gi))
+    .map((match) => match[1])
+  assertOnlyIntegrationTableRefs('foreign key', foreignTableRefs)
+
+  console.log('✓ migration-sql: 057 integration migration structure passed')
+}
+
+main()

--- a/plugins/plugin-integration-core/__tests__/plugin-runtime-smoke.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/plugin-runtime-smoke.test.cjs
@@ -1,0 +1,146 @@
+'use strict'
+
+// ---------------------------------------------------------------------------
+// plugin-integration-core · M0 spike smoke test
+//
+// Verifies:
+//   1. plugin.json is a valid v2 manifest with required fields
+//   2. index.cjs exports { activate, deactivate }
+//   3. activate(context) registers GET /api/integration/health
+//   4. activate(context) registers a cross-plugin communication namespace
+//      that exposes { ping, getStatus }
+//   5. deactivate() clears internal state cleanly
+//
+// Runs as plain Node (no vitest/jest required):
+//   node plugins/plugin-integration-core/__tests__/plugin-runtime-smoke.test.cjs
+// ---------------------------------------------------------------------------
+
+const assert = require('node:assert/strict')
+const path = require('node:path')
+
+const PLUGIN_DIR = path.join(__dirname, '..')
+const MANIFEST_PATH = path.join(PLUGIN_DIR, 'plugin.json')
+const ENTRY_PATH = path.join(PLUGIN_DIR, 'index.cjs')
+
+function createMockContext() {
+  const routes = []
+  const registeredNamespaces = new Map()
+  const logs = []
+
+  return {
+    context: {
+      api: {
+        http: {
+          addRoute: (method, path, handler) => {
+            assert.equal(typeof method, 'string', 'addRoute method must be string')
+            assert.equal(typeof path, 'string', 'addRoute path must be string')
+            assert.equal(typeof handler, 'function', 'addRoute handler must be function')
+            routes.push({ method, path, handler })
+          },
+        },
+      },
+      communication: {
+        register: (namespace, api) => {
+          assert.equal(typeof namespace, 'string', 'namespace must be string')
+          assert.equal(typeof api, 'object', 'api must be object')
+          registeredNamespaces.set(namespace, api)
+        },
+        call: async () => { throw new Error('mock: call not implemented') },
+        on: () => {},
+        emit: () => {},
+      },
+      logger: {
+        info: (msg) => logs.push(['info', msg]),
+        warn: (msg) => logs.push(['warn', msg]),
+        error: (msg) => logs.push(['error', msg]),
+      },
+    },
+    inspect: { routes, namespaces: registeredNamespaces, logs },
+  }
+}
+
+async function runMockResponse(handler) {
+  return new Promise((resolve, reject) => {
+    const res = {
+      _body: undefined,
+      json(body) {
+        this._body = body
+        resolve(body)
+      },
+    }
+    try {
+      const maybePromise = handler({}, res)
+      if (maybePromise && typeof maybePromise.then === 'function') {
+        maybePromise.catch(reject)
+      }
+    } catch (err) {
+      reject(err)
+    }
+  })
+}
+
+async function main() {
+  // --- 1. Manifest structural checks -----------------------------------
+  const manifest = require(MANIFEST_PATH)
+  assert.equal(manifest.manifestVersion, '2.0.0', 'manifest.manifestVersion must be 2.0.0')
+  assert.equal(manifest.name, 'plugin-integration-core', 'manifest.name')
+  assert.ok(/^\d+\.\d+\.\d+/.test(manifest.version), 'manifest.version semver')
+  assert.equal(manifest.main, 'index.cjs', 'manifest.main')
+  assert.ok(Array.isArray(manifest.permissions), 'manifest.permissions is array')
+  for (const required of ['http.addRoute', 'events.emit', 'events.listen', 'database.read', 'database.write']) {
+    assert.ok(manifest.permissions.includes(required), `permissions must include ${required}`)
+  }
+
+  // --- 2. Entry module shape -------------------------------------------
+  const entry = require(ENTRY_PATH)
+  assert.equal(typeof entry.activate, 'function', 'entry.activate is a function')
+  assert.equal(typeof entry.deactivate, 'function', 'entry.deactivate is a function')
+
+  // --- 3. activate() registers route + namespace -----------------------
+  const { context, inspect } = createMockContext()
+  await entry.activate(context)
+
+  assert.equal(inspect.routes.length, 1, 'exactly one route registered')
+  assert.equal(inspect.routes[0].method, 'GET', 'route method')
+  assert.equal(inspect.routes[0].path, '/api/integration/health', 'health route path')
+
+  assert.ok(inspect.namespaces.has('integration-core'), 'integration-core namespace registered')
+  const commApi = inspect.namespaces.get('integration-core')
+  assert.equal(typeof commApi.ping, 'function', 'comm api exposes ping')
+  assert.equal(typeof commApi.getStatus, 'function', 'comm api exposes getStatus')
+
+  // --- 4. Health route returns expected shape --------------------------
+  const healthBody = await runMockResponse(inspect.routes[0].handler)
+  assert.equal(healthBody.ok, true, 'health.ok')
+  assert.equal(healthBody.plugin, 'plugin-integration-core', 'health.plugin')
+  assert.equal(typeof healthBody.ts, 'number', 'health.ts is number')
+
+  // --- 5. Comm API returns expected shape ------------------------------
+  const pingResult = await commApi.ping()
+  assert.equal(pingResult.ok, true, 'ping.ok')
+  const statusResult = await commApi.getStatus()
+  assert.equal(statusResult.plugin, 'plugin-integration-core', 'status.plugin')
+  assert.equal(statusResult.routesRegistered, 1, 'status.routesRegistered')
+
+  // --- 6. Activation logged --------------------------------------------
+  const hasActivationLog = inspect.logs.some(
+    ([level, msg]) => level === 'info' && /activated/.test(msg),
+  )
+  assert.ok(hasActivationLog, 'startup log written at info level')
+
+  // --- 7. Deactivate clears state --------------------------------------
+  await entry.deactivate()
+  // After deactivate, a re-activation must work with clean slate
+  const { context: context2, inspect: inspect2 } = createMockContext()
+  await entry.activate(context2)
+  assert.equal(inspect2.routes.length, 1, 'routes cleanly re-registered after deactivate')
+  await entry.deactivate()
+
+  console.log('✓ plugin-runtime-smoke: all assertions passed')
+}
+
+main().catch((err) => {
+  console.error('✗ plugin-runtime-smoke FAILED')
+  console.error(err)
+  process.exit(1)
+})

--- a/plugins/plugin-integration-core/__tests__/staging-installer.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/staging-installer.test.cjs
@@ -1,0 +1,180 @@
+'use strict'
+
+// ---------------------------------------------------------------------------
+// staging-installer.cjs — unit tests (Node assert, no framework dependency)
+//
+// Verifies:
+//   1. STAGING_DESCRIPTORS shape is valid (5 sheets, required fields present)
+//   2. installStaging() rejects when provisioning API is unavailable
+//   3. installStaging() rejects without projectId
+//   4. installStaging() calls ensureObject once per descriptor
+//   5. Repeat install (idempotency) — ensureObject is called the same count,
+//      same input shapes, returning the same sheet ids. No duplicate state.
+//   6. Partial failure — one descriptor throws, others still provisioned,
+//      warnings collected.
+//
+// Run:
+//   node plugins/plugin-integration-core/__tests__/staging-installer.test.cjs
+// ---------------------------------------------------------------------------
+
+const assert = require('node:assert/strict')
+const path = require('node:path')
+
+const {
+  installStaging,
+  listStagingDescriptors,
+  STAGING_DESCRIPTORS,
+  __internals,
+} = require(path.join(__dirname, '..', 'lib', 'staging-installer.cjs'))
+
+const EXPECTED_IDS = [
+  'plm_raw_items',
+  'standard_materials',
+  'bom_cleanse',
+  'integration_exceptions',
+  'integration_run_log',
+]
+
+function createMockContext({ failOn = new Set() } = {}) {
+  const calls = []
+  const sheetIdsByDescriptor = new Map()
+  return {
+    context: {
+      api: {
+        multitable: {
+          provisioning: {
+            async ensureObject({ projectId, baseId, descriptor }) {
+              calls.push({ projectId, baseId, descriptorId: descriptor.id, fields: descriptor.fields.map((f) => f.id) })
+              if (failOn.has(descriptor.id)) {
+                throw new Error(`mock: refused to provision ${descriptor.id}`)
+              }
+              // Idempotent mock: same descriptorId → same sheet id
+              if (!sheetIdsByDescriptor.has(descriptor.id)) {
+                sheetIdsByDescriptor.set(descriptor.id, `sheet_${descriptor.id}`)
+              }
+              return {
+                baseId: baseId || 'base_default',
+                sheet: { id: sheetIdsByDescriptor.get(descriptor.id), baseId, name: descriptor.name, description: null },
+                fields: descriptor.fields.map((f, i) => ({
+                  id: `fld_${descriptor.id}_${f.id}`,
+                  sheetId: sheetIdsByDescriptor.get(descriptor.id),
+                  name: f.name,
+                  type: f.type,
+                  property: {},
+                  order: i,
+                })),
+              }
+            },
+          },
+        },
+      },
+      logger: { info: () => {}, warn: () => {}, error: () => {} },
+    },
+    inspect: { calls, sheetIdsByDescriptor },
+  }
+}
+
+async function main() {
+  // --- 1. Descriptor shape sanity --------------------------------------
+  assert.equal(STAGING_DESCRIPTORS.length, 5, 'five staging sheets')
+  const descriptorIds = STAGING_DESCRIPTORS.map((d) => d.id)
+  assert.deepEqual(descriptorIds, EXPECTED_IDS, 'descriptor ids match plan')
+  for (const d of STAGING_DESCRIPTORS) {
+    assert.ok(Array.isArray(d.fields) && d.fields.length > 0, `${d.id} has fields`)
+    assert.ok(d.backing === 'multitable', `${d.id} backing=multitable`)
+    assert.ok(d.provisioning && d.provisioning.multitable === true, `${d.id} provisioning.multitable=true`)
+    for (const f of d.fields) {
+      assert.ok(typeof f.id === 'string' && f.id.length > 0, `${d.id}.field.id`)
+      assert.ok(['string', 'number', 'date', 'select'].includes(f.type), `${d.id}.${f.id} type`)
+      if (f.type === 'select') assert.ok(Array.isArray(f.options) && f.options.length > 0, `${d.id}.${f.id} select options`)
+      // Provisioning contract (multitable/contracts.ts:13) has no `required`
+      // at the top level; the materialization step must have removed it.
+      assert.equal(f.required, undefined, `${d.id}.${f.id} top-level required must be stripped`)
+    }
+  }
+  const summary = listStagingDescriptors()
+  assert.equal(summary.length, 5)
+  assert.equal(typeof summary[0].fields[0], 'string')
+
+  // --- 1b. Required fields materialize into property.validation --------
+  // Raw authored fields use `required: true`; the materialized descriptor
+  // must move that into property.validation to match multitable's
+  // field-validation contract (field-validation.ts:5 / contracts.ts:13).
+  const raw = __internals.RAW_DESCRIPTORS
+  const requiredRawByDescriptor = {}
+  for (const rd of raw) {
+    requiredRawByDescriptor[rd.id] = new Set(rd.fields.filter((f) => f.required === true).map((f) => f.id))
+  }
+  for (const d of STAGING_DESCRIPTORS) {
+    for (const f of d.fields) {
+      const wasRequired = requiredRawByDescriptor[d.id].has(f.id)
+      if (wasRequired) {
+        assert.ok(f.property && Array.isArray(f.property.validation), `${d.id}.${f.id} has property.validation array`)
+        const hasRequiredRule = f.property.validation.some((r) => r && r.type === 'required')
+        assert.ok(hasRequiredRule, `${d.id}.${f.id} property.validation contains required rule`)
+      }
+    }
+  }
+  // Spot-check the transform via the exposed helper too.
+  const mat = __internals.materializeField({ id: 'code', name: 'Code', type: 'string', required: true }, 0)
+  assert.deepEqual(mat.property.validation, [{ type: 'required' }], 'materializeField moves required into property.validation')
+  assert.equal(mat.required, undefined, 'materialized field strips top-level required')
+  const matNoReq = __internals.materializeField({ id: 'note', name: 'Note', type: 'string' }, 1)
+  assert.equal(matNoReq.property, undefined, 'no required → no property added')
+
+  // --- 2. Rejects when provisioning API unavailable --------------------
+  let err = null
+  try {
+    await installStaging({ context: { api: {} }, projectId: 'proj1' })
+  } catch (e) {
+    err = e
+  }
+  assert.ok(err && /provisioning/.test(err.message), 'rejects when provisioning missing')
+
+  // --- 3. Rejects without projectId ------------------------------------
+  const { context: okCtx } = createMockContext()
+  let err2 = null
+  try {
+    await installStaging({ context: okCtx })
+  } catch (e) {
+    err2 = e
+  }
+  assert.ok(err2 && /projectId/.test(err2.message), 'rejects without projectId')
+
+  // --- 4. Happy path: one call per descriptor --------------------------
+  const { context: ctx1, inspect: inspect1 } = createMockContext()
+  const res1 = await installStaging({ context: ctx1, projectId: 'proj1' })
+  assert.equal(inspect1.calls.length, 5, 'called once per descriptor')
+  assert.deepEqual(inspect1.calls.map((c) => c.descriptorId), EXPECTED_IDS)
+  assert.equal(Object.keys(res1.sheetIds).length, 5, 'all 5 sheet ids returned')
+  assert.equal(res1.warnings.length, 0, 'no warnings on happy path')
+  for (const id of EXPECTED_IDS) {
+    assert.equal(res1.sheetIds[id], `sheet_${id}`, `sheetId mapped for ${id}`)
+  }
+
+  // --- 5. Idempotency: second install returns same sheet ids -----------
+  const res2 = await installStaging({ context: ctx1, projectId: 'proj1' })
+  assert.equal(inspect1.calls.length, 10, '5 more calls on second install (ensureObject is idempotent upstream)')
+  assert.deepEqual(res1.sheetIds, res2.sheetIds, 'same sheet ids on re-install')
+
+  // --- 6. Partial failure: one descriptor fails, others continue ------
+  const { context: ctx2, inspect: inspect2 } = createMockContext({ failOn: new Set(['bom_cleanse']) })
+  const res3 = await installStaging({ context: ctx2, projectId: 'proj2' })
+  assert.equal(inspect2.calls.length, 5, 'still attempted all 5 descriptors')
+  assert.equal(Object.keys(res3.sheetIds).length, 4, '4 sheets provisioned')
+  assert.equal(res3.warnings.length, 1, 'one warning collected')
+  assert.match(res3.warnings[0], /bom_cleanse/, 'warning names the failing descriptor')
+  assert.ok(!('bom_cleanse' in res3.sheetIds), 'failing descriptor absent from sheetIds')
+
+  // --- 7. Internal helper ----------------------------------------------
+  assert.equal(__internals.isProvisioningAvailable({ api: {} }), false)
+  assert.equal(__internals.isProvisioningAvailable(ctx1), true)
+
+  console.log('✓ staging-installer: all 7 assertions passed')
+}
+
+main().catch((err) => {
+  console.error('✗ staging-installer FAILED')
+  console.error(err)
+  process.exit(1)
+})

--- a/plugins/plugin-integration-core/index.cjs
+++ b/plugins/plugin-integration-core/index.cjs
@@ -1,0 +1,77 @@
+'use strict'
+
+// ---------------------------------------------------------------------------
+// plugin-integration-core
+//
+// PLM/ERP integration pipeline — system plugin MVP.
+//
+// M0 scope: minimal runtime spike. Registers a health route and a cross-plugin
+// communication namespace so the rest of the plugin family can call into this
+// one via `context.communication.call('integration-core', ...)`.
+//
+// Runtime path confirmed by spike: activated from
+// packages/core-backend/src/index.ts:1087 (createPluginContext), discovered by
+// PluginLoader scanning ./plugins (core/plugin-loader.ts:221).
+// ---------------------------------------------------------------------------
+
+const PLUGIN_ID = 'plugin-integration-core'
+const COMMUNICATION_NAMESPACE = 'integration-core'
+
+const registeredRoutes = []
+let activeContext = null
+
+function buildHealthPayload() {
+  return {
+    ok: true,
+    plugin: PLUGIN_ID,
+    ts: Date.now(),
+    milestone: 'M0-spike',
+  }
+}
+
+function buildCommunicationApi() {
+  return {
+    // M0: bare skeleton. M1 will wire adapter-registry / pipeline-runner /
+    // dead-letter / credential-store into this namespace.
+    async ping() {
+      return { ok: true, plugin: PLUGIN_ID, ts: Date.now() }
+    },
+    async getStatus() {
+      return {
+        plugin: PLUGIN_ID,
+        version: '0.1.0',
+        milestone: 'M0-spike',
+        routesRegistered: registeredRoutes.length,
+      }
+    },
+  }
+}
+
+module.exports = {
+  async activate(context) {
+    activeContext = context
+    const logger = context.logger || console
+
+    // --- HTTP routes ------------------------------------------------------
+    context.api.http.addRoute('GET', '/api/integration/health', async (_req, res) => {
+      res.json(buildHealthPayload())
+    })
+    registeredRoutes.push('GET /api/integration/health')
+
+    // --- Cross-plugin communication --------------------------------------
+    context.communication.register(COMMUNICATION_NAMESPACE, buildCommunicationApi())
+
+    logger.info(`[${PLUGIN_ID}] activated (M0 spike). routes=${registeredRoutes.length}`)
+  },
+
+  async deactivate() {
+    if (!activeContext) return
+    const logger = activeContext.logger || console
+    // PluginContext currently exposes no removeRoute hook for the addRoute
+    // helper used above; host is expected to drop the router on deactivate.
+    // We clear local state here so a re-activation starts clean.
+    registeredRoutes.length = 0
+    activeContext = null
+    logger.info(`[${PLUGIN_ID}] deactivated`)
+  },
+}

--- a/plugins/plugin-integration-core/lib/credential-store.cjs
+++ b/plugins/plugin-integration-core/lib/credential-store.cjs
@@ -1,0 +1,143 @@
+'use strict'
+
+// ---------------------------------------------------------------------------
+// Credential store — plugin-integration-core
+//
+// Wraps external-system credentials (K3 WISE WebAPI passwords, SQL Server
+// connection strings, PLM tokens, etc.) in AES-256-GCM envelope encryption.
+//
+// Runtime note (see SPIKE_NOTES.md): the documented `context.services.security`
+// API is declared in types/plugin.ts but NOT wired at runtime
+// (src/index.ts:1351-1356 only binds notification / automationRegistry /
+// rbacProvisioning / platformAppInstances). We therefore keep this module
+// self-contained and depend only on Node's built-in `crypto`.
+//
+// Key provisioning:
+//   env INTEGRATION_ENCRYPTION_KEY = 64-hex-char (32-byte) or 44-b64-char key
+//   production (NODE_ENV=production): key required — startup refuses otherwise
+//   development / test: falls back to a deterministic dev key with a warning
+//
+// Ciphertext format (version-tagged so we can rotate in place later):
+//   "v1:<iv_b64>:<tag_b64>:<data_b64>"
+// ---------------------------------------------------------------------------
+
+const crypto = require('node:crypto')
+
+const ALGORITHM = 'aes-256-gcm'
+const KEY_BYTES = 32
+const IV_BYTES = 12
+const VERSION_TAG = 'v1'
+const ENV_KEY_NAME = 'INTEGRATION_ENCRYPTION_KEY'
+
+// Dev-only deterministic fallback. 32 bytes. Do NOT ship to production.
+const DEV_FALLBACK_KEY_HEX = '00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff'
+
+function isProduction() {
+  return process.env.NODE_ENV === 'production'
+}
+
+function decodeKey(raw) {
+  if (typeof raw !== 'string') return null
+  const trimmed = raw.trim()
+  if (!trimmed) return null
+
+  // Try hex (preferred — 64 chars for 32 bytes)
+  if (/^[0-9a-fA-F]+$/.test(trimmed) && trimmed.length === KEY_BYTES * 2) {
+    return Buffer.from(trimmed, 'hex')
+  }
+
+  // Try base64 (44 chars for 32 bytes with padding)
+  try {
+    const buf = Buffer.from(trimmed, 'base64')
+    if (buf.length === KEY_BYTES) return buf
+  } catch {
+    // fall through
+  }
+
+  return null
+}
+
+function resolveKey({ logger } = {}) {
+  const fromEnv = decodeKey(process.env[ENV_KEY_NAME])
+  if (fromEnv) return { key: fromEnv, source: 'env' }
+
+  if (isProduction()) {
+    throw new Error(
+      `[plugin-integration-core] ${ENV_KEY_NAME} is required in production. ` +
+      `Provide a 32-byte hex (64 chars) or base64 (44 chars) key.`,
+    )
+  }
+
+  const warnTarget = logger && typeof logger.warn === 'function' ? logger : console
+  warnTarget.warn(
+    `[plugin-integration-core] ${ENV_KEY_NAME} not set — using DEV fallback key. ` +
+    `Set a real key before any non-development use.`,
+  )
+  return { key: Buffer.from(DEV_FALLBACK_KEY_HEX, 'hex'), source: 'dev-fallback' }
+}
+
+function encrypt(plaintext, key) {
+  if (typeof plaintext !== 'string') {
+    throw new TypeError('encrypt: plaintext must be a string')
+  }
+  const iv = crypto.randomBytes(IV_BYTES)
+  const cipher = crypto.createCipheriv(ALGORITHM, key, iv)
+  const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()])
+  const tag = cipher.getAuthTag()
+  return `${VERSION_TAG}:${iv.toString('base64')}:${tag.toString('base64')}:${encrypted.toString('base64')}`
+}
+
+function decrypt(ciphertext, key) {
+  if (typeof ciphertext !== 'string') {
+    throw new TypeError('decrypt: ciphertext must be a string')
+  }
+  const parts = ciphertext.split(':')
+  if (parts.length !== 4 || parts[0] !== VERSION_TAG) {
+    throw new Error('decrypt: invalid ciphertext format (expected v1:<iv>:<tag>:<data>)')
+  }
+  const [, ivB64, tagB64, dataB64] = parts
+  const iv = Buffer.from(ivB64, 'base64')
+  const tag = Buffer.from(tagB64, 'base64')
+  const data = Buffer.from(dataB64, 'base64')
+  if (iv.length !== IV_BYTES) throw new Error('decrypt: invalid IV length')
+  const decipher = crypto.createDecipheriv(ALGORITHM, key, iv)
+  decipher.setAuthTag(tag)
+  const decrypted = Buffer.concat([decipher.update(data), decipher.final()])
+  return decrypted.toString('utf8')
+}
+
+/**
+ * Create a credential store bound to a concrete key. Exposed to other plugin
+ * modules during activate() so they never need to handle raw keys directly.
+ */
+function createCredentialStore({ logger } = {}) {
+  const { key, source } = resolveKey({ logger })
+
+  return {
+    source, // 'env' | 'dev-fallback' — for observability only
+    encrypt(plaintext) {
+      return encrypt(plaintext, key)
+    },
+    decrypt(ciphertext) {
+      return decrypt(ciphertext, key)
+    },
+    /**
+     * Produce a public-safe representation of a credential: never returns
+     * plaintext, always returns the ciphertext + a short fingerprint for
+     * correlation. Callers that need to hand a value back to a UI should use
+     * this instead of `decrypt`.
+     */
+    fingerprint(ciphertext) {
+      // HMAC-SHA256 truncated; key-scoped so fingerprints are stable per
+      // deployment but not reversible outside it.
+      const h = crypto.createHmac('sha256', key).update(ciphertext).digest('hex')
+      return h.slice(0, 16)
+    },
+  }
+}
+
+module.exports = {
+  createCredentialStore,
+  // Exposed for tests only — do not import from other plugin modules.
+  __internals: { encrypt, decrypt, decodeKey, DEV_FALLBACK_KEY_HEX, ENV_KEY_NAME },
+}

--- a/plugins/plugin-integration-core/lib/db.cjs
+++ b/plugins/plugin-integration-core/lib/db.cjs
@@ -1,0 +1,277 @@
+'use strict'
+
+// ---------------------------------------------------------------------------
+// DB helper — plugin-integration-core
+//
+// Security model (revised after PR #0 review):
+//
+//   This module does NOT accept raw SQL. A previous draft scanned user SQL
+//   with regex to enforce an `integration_*` table prefix; that approach was
+//   trivially bypassed by quoted identifiers (`FROM "users"`) and other
+//   well-known SQL syntax variants, so it was removed.
+//
+//   The surface is now a narrow, structured CRUD builder: table and column
+//   names pass through a strict identifier whitelist before any SQL is
+//   constructed, and every generated statement is parameterized. There is no
+//   escape hatch. If a future feature needs raw SQL, it must either (a) live
+//   in the kernel with its own access control, or (b) be added here as a
+//   new validated method.
+//
+//   Defence in depth: this is in addition to the `database.read` /
+//   `database.write` plugin permissions; those gate the capability, this
+//   narrows the scope inside that capability.
+// ---------------------------------------------------------------------------
+
+const ALLOWED_PREFIX = 'integration_'
+const IDENT_RE = /^[a-zA-Z_][a-zA-Z0-9_]*$/
+
+class ScopeViolationError extends Error {
+  constructor(message, { table, column } = {}) {
+    super(message)
+    this.name = 'ScopeViolationError'
+    this.table = table
+    this.column = column
+  }
+}
+
+function isAllowedTable(name) {
+  return (
+    typeof name === 'string' &&
+    name.startsWith(ALLOWED_PREFIX) &&
+    name.length > ALLOWED_PREFIX.length &&
+    IDENT_RE.test(name)
+  )
+}
+
+function assertTable(name) {
+  if (!isAllowedTable(name)) {
+    throw new ScopeViolationError(
+      `plugin-integration-core: table "${name}" is outside the "${ALLOWED_PREFIX}" scope`,
+      { table: name },
+    )
+  }
+  return name
+}
+
+function assertColumn(name) {
+  if (typeof name !== 'string' || !IDENT_RE.test(name)) {
+    throw new ScopeViolationError(
+      `plugin-integration-core: invalid column identifier "${name}"`,
+      { column: name },
+    )
+  }
+  return name
+}
+
+function quoteIdent(name) {
+  // Identifier has already passed the whitelist; surround with double quotes
+  // so Postgres treats it as a plain identifier (also defends against any
+  // future reserved-word collision).
+  return `"${name}"`
+}
+
+function buildWhereClause(where, startParamIndex) {
+  if (!where || typeof where !== 'object' || Array.isArray(where)) {
+    return { sql: '', params: [], nextIndex: startParamIndex }
+  }
+  const parts = []
+  const params = []
+  let idx = startParamIndex
+  for (const rawCol of Object.keys(where)) {
+    const col = assertColumn(rawCol)
+    const val = where[rawCol]
+    if (val === null || val === undefined) {
+      parts.push(`${quoteIdent(col)} IS NULL`)
+      continue
+    }
+    parts.push(`${quoteIdent(col)} = $${idx}`)
+    params.push(val)
+    idx += 1
+  }
+  return {
+    sql: parts.length > 0 ? ` WHERE ${parts.join(' AND ')}` : '',
+    params,
+    nextIndex: idx,
+  }
+}
+
+/**
+ * Build a scoped DB helper on top of `context.api.database`.
+ * The returned object never exposes `rawQuery`. Every method validates table
+ * and column identifiers before building SQL.
+ */
+function createDb({ database, logger } = {}) {
+  if (!database || typeof database.query !== 'function') {
+    throw new Error('createDb: context.api.database is required')
+  }
+
+  async function select(table, { where, orderBy, limit = 1000, offset = 0 } = {}) {
+    const tableIdent = quoteIdent(assertTable(table))
+    const whereClause = buildWhereClause(where, 1)
+    let orderSql = ''
+    if (orderBy) {
+      const [col, dir] = Array.isArray(orderBy) ? orderBy : [orderBy, 'ASC']
+      orderSql = ` ORDER BY ${quoteIdent(assertColumn(col))} ${dir === 'DESC' ? 'DESC' : 'ASC'}`
+    }
+    const lim = Number.isInteger(limit) && limit > 0 ? Math.min(limit, 10000) : 1000
+    const off = Number.isInteger(offset) && offset >= 0 ? offset : 0
+    const sql = `SELECT * FROM ${tableIdent}${whereClause.sql}${orderSql} LIMIT ${lim} OFFSET ${off}`
+    return database.query(sql, whereClause.params)
+  }
+
+  async function selectOne(table, where) {
+    if (!where || typeof where !== 'object') {
+      throw new Error('selectOne: where clause is required')
+    }
+    const result = await select(table, { where, limit: 1 })
+    // Host runtime returns rows as an array directly
+    // (types/plugin.ts:685 DatabaseQueryResult = Record<string, unknown>[];
+    // src/index.ts:324 `return (await pool.query(...)).rows`).
+    // We defensively also accept the `{ rows: [...] }` shape in case the
+    // caller supplies a different database binding.
+    const rows = Array.isArray(result)
+      ? result
+      : (result && Array.isArray(result.rows) ? result.rows : [])
+    return rows[0] || null
+  }
+
+  async function insertOne(table, row) {
+    const tableIdent = quoteIdent(assertTable(table))
+    if (!row || typeof row !== 'object' || Array.isArray(row)) {
+      throw new Error('insertOne: row must be a plain object')
+    }
+    const cols = Object.keys(row)
+    if (cols.length === 0) throw new Error('insertOne: row must have at least one column')
+    const colIdents = cols.map((c) => quoteIdent(assertColumn(c))).join(', ')
+    const placeholders = cols.map((_, i) => `$${i + 1}`).join(', ')
+    const values = cols.map((c) => row[c])
+    const sql = `INSERT INTO ${tableIdent} (${colIdents}) VALUES (${placeholders}) RETURNING *`
+    return database.query(sql, values)
+  }
+
+  async function insertMany(table, rows) {
+    if (!Array.isArray(rows)) throw new Error('insertMany: rows must be an array')
+    if (rows.length === 0) return []
+    const tableIdent = quoteIdent(assertTable(table))
+    // Deterministic column order from the first row; subsequent rows must
+    // have the same keyset. This keeps the query plan stable and surfaces
+    // schema-drift callers immediately.
+    const cols = Object.keys(rows[0])
+    if (cols.length === 0) throw new Error('insertMany: rows[0] must have at least one column')
+    for (const col of cols) assertColumn(col)
+    const colIdents = cols.map((c) => quoteIdent(c)).join(', ')
+    const params = []
+    const valueTuples = rows.map((row, rowIdx) => {
+      if (!row || typeof row !== 'object') {
+        throw new Error(`insertMany: rows[${rowIdx}] is not an object`)
+      }
+      const rowCols = Object.keys(row)
+      if (rowCols.length !== cols.length || !cols.every((c) => Object.prototype.hasOwnProperty.call(row, c))) {
+        throw new Error(`insertMany: rows[${rowIdx}] has inconsistent keys`)
+      }
+      const placeholders = cols.map((c) => {
+        params.push(row[c])
+        return `$${params.length}`
+      })
+      return `(${placeholders.join(', ')})`
+    })
+    const sql = `INSERT INTO ${tableIdent} (${colIdents}) VALUES ${valueTuples.join(', ')} RETURNING *`
+    return database.query(sql, params)
+  }
+
+  async function updateRow(table, set, where) {
+    const tableIdent = quoteIdent(assertTable(table))
+    if (!set || typeof set !== 'object' || Array.isArray(set) || Object.keys(set).length === 0) {
+      throw new Error('updateRow: set must be a non-empty object')
+    }
+    if (!where || typeof where !== 'object' || Array.isArray(where) || Object.keys(where).length === 0) {
+      throw new Error('updateRow: where must be a non-empty object (refusing unbounded UPDATE)')
+    }
+    const setCols = Object.keys(set)
+    const params = []
+    const setPairs = setCols.map((col) => {
+      params.push(set[col])
+      return `${quoteIdent(assertColumn(col))} = $${params.length}`
+    })
+    const whereClause = buildWhereClause(where, params.length + 1)
+    params.push(...whereClause.params)
+    const sql = `UPDATE ${tableIdent} SET ${setPairs.join(', ')}${whereClause.sql} RETURNING *`
+    return database.query(sql, params)
+  }
+
+  async function deleteRows(table, where) {
+    const tableIdent = quoteIdent(assertTable(table))
+    if (!where || typeof where !== 'object' || Array.isArray(where) || Object.keys(where).length === 0) {
+      throw new Error('deleteRows: where must be a non-empty object (refusing unbounded DELETE)')
+    }
+    const whereClause = buildWhereClause(where, 1)
+    const sql = `DELETE FROM ${tableIdent}${whereClause.sql} RETURNING *`
+    return database.query(sql, whereClause.params)
+  }
+
+  async function countRows(table, where) {
+    const tableIdent = quoteIdent(assertTable(table))
+    const whereClause = buildWhereClause(where, 1)
+    const sql = `SELECT COUNT(*)::int AS count FROM ${tableIdent}${whereClause.sql}`
+    const result = await database.query(sql, whereClause.params)
+    // Host runtime returns rows directly as an array (see selectOne note).
+    const rows = Array.isArray(result)
+      ? result
+      : (result && Array.isArray(result.rows) ? result.rows : [])
+    return rows[0] ? Number(rows[0].count) || 0 : 0
+  }
+
+  async function transaction(callback) {
+    if (typeof database.transaction !== 'function') {
+      throw new Error('transaction: underlying database.transaction is not available')
+    }
+    return database.transaction(async (trx) => {
+      // Wrap the transaction object with the same structured API so callers
+      // inside a transaction still cannot use raw SQL.
+      const scoped = createDb({
+        database: {
+          query: (...args) => trx.query(...args),
+          transaction: database.transaction.bind(database),
+        },
+      })
+      return callback({
+        select: scoped.select,
+        selectOne: scoped.selectOne,
+        insertOne: scoped.insertOne,
+        insertMany: scoped.insertMany,
+        updateRow: scoped.updateRow,
+        deleteRows: scoped.deleteRows,
+        countRows: scoped.countRows,
+        commit: () => trx.commit(),
+        rollback: () => trx.rollback(),
+      })
+    })
+  }
+
+  return {
+    ALLOWED_PREFIX,
+    select,
+    selectOne,
+    insertOne,
+    insertMany,
+    updateRow,
+    deleteRows,
+    countRows,
+    transaction,
+  }
+}
+
+module.exports = {
+  createDb,
+  ScopeViolationError,
+  ALLOWED_PREFIX,
+  // Exposed for tests only.
+  __internals: {
+    isAllowedTable,
+    assertTable,
+    assertColumn,
+    buildWhereClause,
+    quoteIdent,
+    IDENT_RE,
+  },
+}

--- a/plugins/plugin-integration-core/lib/staging-installer.cjs
+++ b/plugins/plugin-integration-core/lib/staging-installer.cjs
@@ -1,0 +1,228 @@
+'use strict'
+
+// ---------------------------------------------------------------------------
+// Staging installer — plugin-integration-core
+//
+// Provisions the multitable "sheets" that pipelines use as staging / audit
+// surfaces. These are user-visible sheets inside metasheet2, NOT SQL tables:
+// SQL operational state lives in 057_create_integration_core_tables.sql.
+//
+//   plm_raw_items          — raw records pulled from PLM before cleansing
+//   standard_materials     — cleansed, standardized material master
+//   bom_cleanse            — cleansed BOM line items
+//   integration_exceptions — user-visible exception queue (people fix here)
+//   integration_run_log    — human-readable run summary
+//
+// Field authoring note (fixed after PR #0 review):
+//   The multitable provisioning contract
+//   (packages/core-backend/src/multitable/contracts.ts:13) only accepts
+//   { id, name, type, order?, options?, property? } on a field descriptor.
+//   `required: true` at the top level is silently dropped. Validation rules
+//   are stored in `property.validation` as a FieldValidationConfig
+//   (see packages/core-backend/src/multitable/field-validation.ts:5).
+//
+//   We keep the authoring ergonomics (`required: true`) local to this file
+//   and `materializeDescriptor()` transforms each field before we hand the
+//   descriptor to ensureObject().
+//
+// All sheets are idempotent: re-running install() on an existing project
+// must not duplicate sheets or lose data (provisioning.ensureObject enforces
+// this at the multitable level).
+// ---------------------------------------------------------------------------
+
+const RAW_DESCRIPTORS = [
+  {
+    id: 'plm_raw_items',
+    name: 'PLM Raw Items',
+    fields: [
+      { id: 'sourceSystemId', name: 'Source System', type: 'string', required: true },
+      { id: 'objectType',     name: 'Object Type',   type: 'string', required: true },
+      { id: 'sourceId',       name: 'Source ID',     type: 'string', required: true },
+      { id: 'revision',       name: 'Revision',      type: 'string' },
+      { id: 'code',           name: 'Code',          type: 'string' },
+      { id: 'name',           name: 'Name',          type: 'string' },
+      { id: 'rawPayload',     name: 'Raw Payload',   type: 'string' },
+      { id: 'fetchedAt',      name: 'Fetched At',    type: 'date'   },
+      { id: 'pipelineRunId',  name: 'Run ID',        type: 'string' },
+    ],
+  },
+  {
+    id: 'standard_materials',
+    name: 'Standard Materials',
+    fields: [
+      { id: 'code',              name: 'Material Code',   type: 'string', required: true },
+      { id: 'name',              name: 'Material Name',   type: 'string', required: true },
+      { id: 'uom',               name: 'Unit of Measure', type: 'string' },
+      { id: 'category',          name: 'Category',        type: 'string' },
+      { id: 'status',            name: 'Status',          type: 'select', required: true, options: ['draft', 'active', 'obsolete'] },
+      { id: 'erpSyncStatus',     name: 'ERP Sync Status', type: 'select', options: ['pending', 'synced', 'failed'] },
+      { id: 'erpExternalId',     name: 'ERP External ID', type: 'string' },
+      { id: 'erpBillNo',         name: 'ERP Bill No',     type: 'string' },
+      { id: 'erpResponseCode',   name: 'ERP Resp Code',   type: 'string' },
+      { id: 'erpResponseMessage',name: 'ERP Resp Msg',    type: 'string' },
+      { id: 'lastSyncedAt',      name: 'Last Synced At',  type: 'date'   },
+    ],
+  },
+  {
+    id: 'bom_cleanse',
+    name: 'BOM Cleanse',
+    fields: [
+      { id: 'parentCode',   name: 'Parent Code',  type: 'string', required: true },
+      { id: 'childCode',    name: 'Child Code',   type: 'string', required: true },
+      { id: 'quantity',     name: 'Quantity',     type: 'number', required: true },
+      { id: 'uom',          name: 'UoM',          type: 'string' },
+      { id: 'sequence',     name: 'Sequence',     type: 'number' },
+      { id: 'revision',     name: 'Revision',     type: 'string' },
+      { id: 'validFrom',    name: 'Valid From',   type: 'date'   },
+      { id: 'validTo',      name: 'Valid To',     type: 'date'   },
+      { id: 'status',       name: 'Status',       type: 'select', required: true, options: ['draft', 'active', 'obsolete'] },
+    ],
+  },
+  {
+    id: 'integration_exceptions',
+    name: 'Integration Exceptions',
+    fields: [
+      { id: 'pipelineId',       name: 'Pipeline ID',     type: 'string', required: true },
+      { id: 'runId',            name: 'Run ID',          type: 'string', required: true },
+      { id: 'idempotencyKey',   name: 'Idempotency Key', type: 'string' },
+      { id: 'errorCode',        name: 'Error Code',      type: 'string', required: true },
+      { id: 'errorMessage',     name: 'Error Message',   type: 'string', required: true },
+      { id: 'sourcePayload',    name: 'Source Payload',  type: 'string' },
+      { id: 'transformedPayload',name: 'Transformed',    type: 'string' },
+      { id: 'status',           name: 'Status',          type: 'select', required: true, options: ['open', 'in_review', 'replayed', 'discarded'] },
+      { id: 'assignee',         name: 'Assignee',        type: 'string' },
+      { id: 'note',             name: 'Note',            type: 'string' },
+    ],
+  },
+  {
+    id: 'integration_run_log',
+    name: 'Integration Run Log',
+    fields: [
+      { id: 'pipelineId',   name: 'Pipeline ID', type: 'string', required: true },
+      { id: 'runId',        name: 'Run ID',      type: 'string', required: true },
+      { id: 'mode',         name: 'Mode',        type: 'select', required: true, options: ['incremental', 'full', 'manual', 'replay'] },
+      { id: 'triggeredBy',  name: 'Triggered By',type: 'string', required: true },
+      { id: 'status',       name: 'Status',      type: 'select', required: true, options: ['pending', 'running', 'succeeded', 'partial', 'failed', 'cancelled'] },
+      { id: 'rowsRead',     name: 'Rows Read',   type: 'number' },
+      { id: 'rowsCleaned',  name: 'Rows Cleaned',type: 'number' },
+      { id: 'rowsWritten',  name: 'Rows Written',type: 'number' },
+      { id: 'rowsFailed',   name: 'Rows Failed', type: 'number' },
+      { id: 'durationMs',   name: 'Duration ms', type: 'number' },
+      { id: 'startedAt',    name: 'Started At',  type: 'date'   },
+      { id: 'finishedAt',   name: 'Finished At', type: 'date'   },
+      { id: 'errorSummary', name: 'Error Summary',type: 'string'},
+    ],
+  },
+]
+
+// Transform authoring-ergonomic `required: true` fields into the real
+// contract shape: { id, name, type, options?, property: { validation: [...] } }.
+function materializeField(raw, order) {
+  const field = {
+    id: raw.id,
+    name: raw.name,
+    type: raw.type,
+    order,
+  }
+  if (Array.isArray(raw.options) && raw.options.length > 0) {
+    field.options = raw.options.slice()
+  }
+  const existingProperty = raw.property && typeof raw.property === 'object' ? { ...raw.property } : {}
+  const validation = Array.isArray(existingProperty.validation) ? existingProperty.validation.slice() : []
+  if (raw.required) {
+    const alreadyRequired = validation.some((rule) => rule && rule.type === 'required')
+    if (!alreadyRequired) validation.push({ type: 'required' })
+  }
+  if (validation.length > 0) {
+    existingProperty.validation = validation
+  }
+  if (Object.keys(existingProperty).length > 0) {
+    field.property = existingProperty
+  }
+  return field
+}
+
+function materializeDescriptor(raw) {
+  return {
+    id: raw.id,
+    name: raw.name,
+    // `backing` / `provisioning` are not part of the provisioning field
+    // contract but are tolerated by callers that still look at them
+    // (plugin-after-sales installer does). Keep them for forward-compat.
+    backing: 'multitable',
+    provisioning: { multitable: true },
+    fields: raw.fields.map((f, i) => materializeField(f, i)),
+  }
+}
+
+const STAGING_DESCRIPTORS = Object.freeze(RAW_DESCRIPTORS.map(materializeDescriptor))
+
+function isProvisioningAvailable(context) {
+  return Boolean(
+    context
+    && context.api
+    && context.api.multitable
+    && context.api.multitable.provisioning
+    && typeof context.api.multitable.provisioning.ensureObject === 'function',
+  )
+}
+
+/**
+ * Install the full staging sheet set for a given project.
+ * Idempotent — re-invoking does not duplicate sheets.
+ * Returns a map of `{ [descriptorId]: sheetId }` for downstream modules.
+ */
+async function installStaging({ context, projectId, baseId = null, logger } = {}) {
+  if (!isProvisioningAvailable(context)) {
+    throw new Error('staging-installer: context.api.multitable.provisioning.ensureObject not available')
+  }
+  if (!projectId || typeof projectId !== 'string') {
+    throw new Error('staging-installer: projectId is required')
+  }
+
+  const log = logger && typeof logger.info === 'function' ? logger : console
+  const result = {}
+  const warnings = []
+
+  for (const descriptor of STAGING_DESCRIPTORS) {
+    try {
+      const provisioned = await context.api.multitable.provisioning.ensureObject({
+        projectId,
+        baseId,
+        descriptor,
+      })
+      if (provisioned && provisioned.sheet && provisioned.sheet.id) {
+        result[descriptor.id] = provisioned.sheet.id
+      } else {
+        warnings.push(`ensureObject returned no sheet id for ${descriptor.id}`)
+      }
+    } catch (err) {
+      warnings.push(`failed to ensure ${descriptor.id}: ${err && err.message ? err.message : err}`)
+    }
+  }
+
+  log.info(
+    `[plugin-integration-core] staging install done. sheets=${Object.keys(result).length}/${STAGING_DESCRIPTORS.length} warnings=${warnings.length}`,
+  )
+  return { sheetIds: result, warnings }
+}
+
+function listStagingDescriptors() {
+  return STAGING_DESCRIPTORS.map((d) => ({
+    id: d.id,
+    name: d.name,
+    fields: d.fields.map((f) => f.id),
+  }))
+}
+
+module.exports = {
+  installStaging,
+  listStagingDescriptors,
+  STAGING_DESCRIPTORS,
+  __internals: {
+    isProvisioningAvailable,
+    materializeField,
+    materializeDescriptor,
+    RAW_DESCRIPTORS,
+  },
+}

--- a/plugins/plugin-integration-core/package.json
+++ b/plugins/plugin-integration-core/package.json
@@ -6,10 +6,12 @@
   "license": "UNLICENSED",
   "private": true,
   "scripts": {
-    "test": "node __tests__/plugin-runtime-smoke.test.cjs && node __tests__/credential-store.test.cjs && node __tests__/db.test.cjs && node __tests__/staging-installer.test.cjs",
+    "test": "node __tests__/plugin-runtime-smoke.test.cjs && node --import tsx __tests__/host-loader-smoke.test.mjs && node __tests__/credential-store.test.cjs && node __tests__/db.test.cjs && node __tests__/staging-installer.test.cjs && node __tests__/migration-sql.test.cjs",
     "test:runtime": "node __tests__/plugin-runtime-smoke.test.cjs",
+    "test:host-loader": "node --import tsx __tests__/host-loader-smoke.test.mjs",
     "test:credential": "node __tests__/credential-store.test.cjs",
     "test:db": "node __tests__/db.test.cjs",
-    "test:staging": "node __tests__/staging-installer.test.cjs"
+    "test:staging": "node __tests__/staging-installer.test.cjs",
+    "test:migration": "node __tests__/migration-sql.test.cjs"
   }
 }

--- a/plugins/plugin-integration-core/package.json
+++ b/plugins/plugin-integration-core/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "plugin-integration-core",
+  "version": "0.1.0",
+  "description": "PLM/ERP integration pipeline core (system plugin).",
+  "main": "index.cjs",
+  "license": "UNLICENSED",
+  "private": true,
+  "scripts": {
+    "test": "node __tests__/plugin-runtime-smoke.test.cjs && node __tests__/credential-store.test.cjs && node __tests__/db.test.cjs && node __tests__/staging-installer.test.cjs",
+    "test:runtime": "node __tests__/plugin-runtime-smoke.test.cjs",
+    "test:credential": "node __tests__/credential-store.test.cjs",
+    "test:db": "node __tests__/db.test.cjs",
+    "test:staging": "node __tests__/staging-installer.test.cjs"
+  }
+}

--- a/plugins/plugin-integration-core/plugin.json
+++ b/plugins/plugin-integration-core/plugin.json
@@ -5,6 +5,7 @@
   "displayName": "Integration Core",
   "description": "PLM/ERP integration pipeline core: ingest, cleanse, validate, upsert, dead-letter, replay. System plugin.",
   "author": { "name": "MetaSheet" },
+  "license": "UNLICENSED",
   "engine": { "metasheet": ">=2.0.0-0" },
   "main": "index.cjs",
   "capabilities": { "views": [], "workflows": [], "functions": [] },

--- a/plugins/plugin-integration-core/plugin.json
+++ b/plugins/plugin-integration-core/plugin.json
@@ -1,0 +1,21 @@
+{
+  "manifestVersion": "2.0.0",
+  "name": "plugin-integration-core",
+  "version": "0.1.0",
+  "displayName": "Integration Core",
+  "description": "PLM/ERP integration pipeline core: ingest, cleanse, validate, upsert, dead-letter, replay. System plugin.",
+  "author": { "name": "MetaSheet" },
+  "engine": { "metasheet": ">=2.0.0-0" },
+  "main": "index.cjs",
+  "capabilities": { "views": [], "workflows": [], "functions": [] },
+  "contributes": {
+    "views": []
+  },
+  "permissions": [
+    "http.addRoute",
+    "events.emit",
+    "events.listen",
+    "database.read",
+    "database.write"
+  ]
+}


### PR DESCRIPTION
## Summary

- Add `plugin-integration-core` M0 system-plugin scaffold with health route and `integration-core` communication namespace.
- Add AES-256-GCM credential-store boundary with production key enforcement.
- Add strict structured DB helper limited to `integration_*` tables; no raw SQL escape hatch.
- Add staging multitable descriptor installer for PLM/ERP integration surfaces.
- Add core SQL migration `057_create_integration_core_tables.sql` for external systems, pipelines, mappings, runs, watermarks, dead letters, and schedules.
- Add M0 hardening gates: real `PluginLoader` no-listen load/activate smoke and static migration SQL structure smoke.
- Add design and verification MDs.

## Design Boundaries

- M0 only: runtime/security/storage boundary spike, not a full pipeline runner.
- No K3 WISE adapter, transform engine, validator engine, idempotency/watermark engine, REST management API, or UI in this slice.
- Known kernel gaps remain documented: route removal, communication unregister, and runtime `services.security` injection.
- Cross-row tenant/workspace consistency across referenced rows is not DB-enforced in M0; M1 must add service or trigger enforcement before accepting external write paths.
- Live Postgres migration execution and full `MetaSheetServer` HTTP hot-load are explicitly documented as M1 gates.

## Verification

- `find plugins/plugin-integration-core -maxdepth 3 -type f -name '*.cjs' -print | sort | xargs -n1 node --check && node --check plugins/plugin-integration-core/__tests__/host-loader-smoke.test.mjs` -> passed
- `pnpm -F plugin-integration-core test` -> passed
  - `plugin-runtime-smoke`
  - `host-loader-smoke`
  - `credential-store`
  - `db.cjs`
  - `staging-installer`
  - `migration-sql`
- `node --import tsx scripts/validate-plugin-manifests.ts` -> passed; `plugin-integration-core: Valid`
- migration placement check -> `057_create_integration_core_tables.sql` present, no duplicate `057_*` migration name
- `pnpm validate:plugins` direct script is sandbox-blocked by `tsx` IPC `listen EPERM`; equivalent Node loader command passed

Docs:
- `docs/development/integration-core-m0-design-20260424.md`
- `docs/development/integration-core-m0-verification-20260424.md`