### PR TITLE
feat(core): inject plugin runtime security service

### DIFF
--- a/docs/development/plugin-services-security-injection-design-20260424.md
+++ b/docs/development/plugin-services-security-injection-design-20260424.md
@@ -1,0 +1,57 @@
+# Plugin Services Security Injection Design — 2026-04-24
+
+## Context
+
+`PluginServices.security` is declared as a required runtime service in `packages/core-backend/src/types/plugin.ts`, but the active CommonJS plugin runtime path in `MetaSheetServer.createPluginContext()` only injected notification, automation registry, RBAC provisioning, and platform app instance services.
+
+That meant a plugin written against the published type contract could pass TypeScript but receive `context.services.security === undefined` at runtime.
+
+This is the last kernel gap recorded by `plugins/plugin-integration-core/SPIKE_NOTES.md` after the plugin route and communication teardown fixes.
+
+## Decision
+
+Add a small host-backed adapter: `packages/core-backend/src/security/plugin-runtime-security-service.ts`.
+
+The adapter is intentionally not a direct `SecurityServiceImpl` singleton:
+
+- `SecurityServiceImpl` creates a cleanup timer and needs explicit lifecycle cleanup.
+- Without an injected key, `SecurityServiceImpl` uses a process-random encryption key, which is unsafe for persisted plugin credentials.
+- The runtime need for M1 integration-core is stable credential encryption, not VM sandbox execution.
+
+Instead, `PluginRuntimeSecurityService` reuses the existing platform secret helpers from `security/encrypted-secrets.ts`:
+
+- `encrypt()` returns the existing `enc:` AES-256-GCM storage format.
+- `decrypt()` accepts `enc:` values and preserves the existing plaintext passthrough behavior.
+- Per-call custom encryption keys are rejected explicitly to avoid introducing a second plugin-local key semantic.
+- `hash()`, `verify()`, `verifyHash()`, `generateToken()`, audit log, rate-limit, resource monitoring, and threat scanning are implemented in-memory.
+- `createSandbox()` returns a safe runtime stub whose `execute()` rejects with a clear error; the CJS runtime does not claim VM sandbox execution support.
+
+## Runtime Wiring
+
+`MetaSheetServer` now owns one `PluginRuntimeSecurityService` instance:
+
+```ts
+private pluginRuntimeSecurityService = new PluginRuntimeSecurityService()
+```
+
+`createPluginContext()` injects it into:
+
+```ts
+context.services.security
+```
+
+This keeps the fix scoped to the active CJS plugin path and does not change the enhanced plugin service factory path.
+
+## Compatibility
+
+`plugin-integration-core` keeps its current self-contained `v1:` credential-store format for now. The new host service creates a safe migration target for M1, but the migration should be backward-compatible:
+
+- Read old `v1:` values.
+- Write new `enc:` values through `context.services.security`.
+- Avoid one-shot destructive rewrites until staging has a credential migration plan.
+
+## Deferred
+
+- Full VM sandbox execution remains out of scope for this runtime adapter.
+- Production fail-fast for missing `ENCRYPTION_KEY` / `ENCRYPTION_SALT` is not introduced here because existing platform helpers currently fall back to defaults; changing that would be a broader operational behavior change.
+- Migrating `plugin-integration-core/lib/credential-store.cjs` from `v1:` to `enc:` is left for M1.

--- a/docs/development/plugin-services-security-injection-verification-20260424.md
+++ b/docs/development/plugin-services-security-injection-verification-20260424.md
@@ -1,0 +1,42 @@
+# Plugin Services Security Injection Verification — 2026-04-24
+
+## Scope
+
+Verify that the active `MetaSheetServer` CommonJS plugin runtime injects a usable `context.services.security` service and that the adapter does not regress the previously fixed runtime teardown path.
+
+## Commands Run
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/plugin-runtime-security.test.ts --reporter=verbose
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/plugin-runtime-security.test.ts tests/unit/plugin-runtime-teardown.test.ts --reporter=dot
+pnpm -F plugin-integration-core test
+node --import tsx scripts/validate-plugin-manifests.ts
+```
+
+## Results
+
+- `plugin-runtime-security.test.ts`: 3/3 passed.
+- Backend TypeScript compile: passed.
+- Runtime security + teardown regression: 6/6 passed.
+- `plugin-integration-core` package tests: passed.
+- Plugin manifest validation: 13 valid, 0 invalid. Existing warnings remain unrelated.
+
+## Covered Behaviors
+
+- Real activation path injects `context.services.security`.
+- `encrypt()` returns an `enc:` payload.
+- `decrypt()` round-trips `enc:` payloads.
+- Plaintext decrypt passthrough remains compatible with existing helper behavior.
+- Tampered encrypted payloads throw.
+- Per-call custom encryption keys are rejected explicitly.
+- `hash()` and `verify()` work through the injected runtime service.
+- Threat scanning detects critical `require()` and `process.*` usage.
+- Threat scans write audit events retrievable by plugin and event filter.
+- Rate-limit helper allows first request and rejects the second over limit.
+- `createSandbox()` registers a sandbox record, validates allowed API prefixes, and rejects code execution explicitly.
+- `destroy()` on the sandbox removes it from the service registry.
+
+## Follow-Up
+
+- Migrate `plugin-integration-core` credential-store to host-backed `services.security` in a separate M1 slice with backward-compatible `v1:` reads.

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -99,6 +99,7 @@ import { startDirectorySyncScheduler, stopDirectorySyncScheduler } from './direc
 import { canaryRoutes } from './routes/canary-routes'
 import { CanaryRouter } from './canary/CanaryRouter'
 import { createCanaryInterceptor } from './canary/CanaryInterceptor'
+import { PluginRuntimeSecurityService } from './security/plugin-runtime-security-service'
 import workflowRouter from './routes/workflow'
 import workflowDesignerRouter from './routes/workflow-designer'
 import plmWorkbenchRouter from './routes/plm-workbench'
@@ -185,6 +186,7 @@ export class MetaSheetServer {
   private yjsBridgeMetricsSource?: { getMetrics(): { pendingWriteCount: number; observedDocCount: number; flushSuccessCount: number; flushFailureCount: number } }
   private yjsSocketMetricsSource?: { getMetrics(): { activeRecordCount: number; activeSocketCount: number } }
   private afterSalesApprovalBridgeService: AfterSalesApprovalBridgeService
+  private pluginRuntimeSecurityService = new PluginRuntimeSecurityService()
   // Optional bypass/degraded-mode flags for local debug
   private disableWorkflow = process.env.DISABLE_WORKFLOW === 'true'
   private disableEventBus = process.env.DISABLE_EVENT_BUS === 'true'
@@ -1492,6 +1494,7 @@ export class MetaSheetServer {
         automationRegistry,
         rbacProvisioning,
         platformAppInstances,
+        security: this.pluginRuntimeSecurityService,
       } as unknown as import('./types/plugin').PluginServices,
       storage,
       config: {},

--- a/packages/core-backend/src/security/plugin-runtime-security-service.ts
+++ b/packages/core-backend/src/security/plugin-runtime-security-service.ts
@@ -1,0 +1,333 @@
+import crypto from 'node:crypto'
+import {
+  decryptStoredSecretValue,
+  encryptStoredSecretValue,
+  isEncryptedSecretValue,
+} from './encrypted-secrets'
+import { PERMISSION_WHITELIST } from '../types/plugin'
+import type {
+  AuditLogOptions,
+  PluginPermission,
+  PluginSandbox,
+  RateLimitResult,
+  ResourceLimits,
+  ResourceUsage,
+  SecurityAuditEvent,
+  SecurityService,
+  ThreatScanResult,
+} from '../types/plugin'
+
+type RuntimeSandbox = PluginSandbox & {
+  destroy(): void
+}
+
+type RuntimeRateLimit = {
+  count: number
+  resetAt: number
+}
+
+const DEFAULT_SANDBOX_APIS = ['console', 'JSON', 'Math', 'Date']
+const DEFAULT_RESOURCE_LIMITS: ResourceLimits = {
+  memory: 100,
+  cpu: 30,
+  disk: 50,
+  network: 60,
+  database: 300,
+}
+
+const THREAT_PATTERNS: Array<{
+  pattern: RegExp
+  type: string
+  severity: ThreatScanResult['threats'][number]['severity']
+  description: string
+}> = [
+  {
+    pattern: /require\s*\(/g,
+    type: 'module_access',
+    severity: 'critical',
+    description: 'Unauthorized require() usage',
+  },
+  {
+    pattern: /process\./g,
+    type: 'system_access',
+    severity: 'critical',
+    description: 'Unauthorized process access',
+  },
+  {
+    pattern: /\bfs\./g,
+    type: 'file_system',
+    severity: 'high',
+    description: 'Unauthorized file system access',
+  },
+  {
+    pattern: /child_process/g,
+    type: 'process_spawn',
+    severity: 'critical',
+    description: 'Unauthorized child process spawning',
+  },
+  {
+    pattern: /\beval\s*\(/g,
+    type: 'code_execution',
+    severity: 'high',
+    description: 'Dynamic code evaluation detected',
+  },
+  {
+    pattern: /\bFunction\s*\(/g,
+    type: 'code_generation',
+    severity: 'medium',
+    description: 'Dynamic function creation detected',
+  },
+  {
+    pattern: /__proto__|prototype\s*=/g,
+    type: 'prototype_pollution',
+    severity: 'high',
+    description: 'Potential prototype pollution',
+  },
+  {
+    pattern: /\bfetch\s*\(|XMLHttpRequest/g,
+    type: 'network_access',
+    severity: 'medium',
+    description: 'Network access detected',
+  },
+]
+
+function positionFor(source: string, index: number): { line: number; column: number } {
+  const before = source.slice(0, index)
+  const lines = before.split('\n')
+  return {
+    line: lines.length,
+    column: lines[lines.length - 1]?.length ?? 0,
+  }
+}
+
+function assertPlatformKeyOnly(key?: string): void {
+  if (key) {
+    throw new Error('Plugin runtime security service does not support per-call encryption keys')
+  }
+}
+
+function makeAuditId(prefix: string): string {
+  return `${prefix}_${Date.now()}_${crypto.randomBytes(6).toString('hex')}`
+}
+
+/**
+ * Host-backed security service for the active CJS plugin runtime.
+ *
+ * It intentionally reuses the platform `enc:` secret format instead of creating
+ * another per-plugin encryption scheme. Sandbox code execution remains
+ * unavailable in this runtime path; callers get an explicit error instead of a
+ * false sense of isolation.
+ */
+export class PluginRuntimeSecurityService implements SecurityService {
+  private readonly sandboxes = new Map<string, RuntimeSandbox>()
+  private readonly auditEvents: SecurityAuditEvent[] = []
+  private readonly rateLimits = new Map<string, RuntimeRateLimit>()
+  private readonly resourceUsage = new Map<string, ResourceUsage[]>()
+
+  createSandbox(
+    pluginName: string,
+    allowedAPIs: string[] = DEFAULT_SANDBOX_APIS,
+    limits: ResourceLimits = DEFAULT_RESOURCE_LIMITS,
+  ): PluginSandbox {
+    const sandbox: RuntimeSandbox = {
+      pluginName,
+      allowedAPIs,
+      resourceLimits: limits,
+      environment: { pluginName },
+      execute: async () => {
+        throw new Error('Plugin sandbox execution is not available in the CJS plugin runtime')
+      },
+      getResourceUsage: () => ({
+        timestamp: new Date(),
+      }),
+      destroy: () => {
+        this.sandboxes.delete(pluginName)
+      },
+    }
+    this.sandboxes.set(pluginName, sandbox)
+    return sandbox
+  }
+
+  getSandbox(pluginName: string): PluginSandbox | null {
+    return this.sandboxes.get(pluginName) ?? null
+  }
+
+  async checkPermission(pluginName: string, permission: string): Promise<boolean> {
+    const allowed = PERMISSION_WHITELIST.includes(permission as PluginPermission)
+    await this.audit({
+      id: makeAuditId('perm'),
+      pluginName,
+      event: 'permission_check',
+      resource: permission,
+      action: 'check',
+      timestamp: new Date(),
+      severity: allowed ? 'info' : 'warning',
+      metadata: { allowed },
+    })
+    return allowed
+  }
+
+  async checkPermissions(pluginName: string, permissions: string[]): Promise<boolean[]> {
+    return Promise.all(permissions.map(permission => this.checkPermission(pluginName, permission)))
+  }
+
+  async validateAPIAccess(pluginName: string, apiPath: string, method: string): Promise<boolean> {
+    const sandbox = this.getSandbox(pluginName)
+    const allowed = Boolean(sandbox?.allowedAPIs.some(api => apiPath.startsWith(api)))
+    await this.audit({
+      id: makeAuditId('api'),
+      pluginName,
+      event: 'api_access',
+      resource: apiPath,
+      action: method,
+      timestamp: new Date(),
+      severity: allowed ? 'info' : 'warning',
+      metadata: { allowed },
+    })
+    return allowed
+  }
+
+  async encrypt(data: string, key?: string): Promise<string> {
+    assertPlatformKeyOnly(key)
+    return encryptStoredSecretValue(data)
+  }
+
+  async decrypt(data: string, key?: string): Promise<string> {
+    assertPlatformKeyOnly(key)
+    return decryptStoredSecretValue(data)
+  }
+
+  hash(data: string, algorithm = 'sha256'): string {
+    return crypto.createHash(algorithm).update(data).digest('hex')
+  }
+
+  async verify(data: string, hash: string, algorithm = 'sha256'): Promise<boolean> {
+    return this.verifyHash(data, hash, algorithm)
+  }
+
+  verifyHash(data: string, hash: string, algorithm = 'sha256'): boolean {
+    return this.hash(data, algorithm) === hash
+  }
+
+  generateToken(length = 32): string {
+    const safeLength = Math.max(1, Math.floor(length))
+    return crypto.randomBytes(Math.ceil(safeLength / 2)).toString('hex').slice(0, safeLength)
+  }
+
+  async scanForThreats(pluginName: string, code: string): Promise<ThreatScanResult> {
+    const threats: ThreatScanResult['threats'] = []
+    for (const { pattern, type, severity, description } of THREAT_PATTERNS) {
+      pattern.lastIndex = 0
+      let match: RegExpExecArray | null
+      while ((match = pattern.exec(code)) !== null) {
+        const location = positionFor(code, match.index)
+        threats.push({
+          type,
+          severity,
+          description,
+          location,
+          line: location.line,
+          column: location.column,
+        })
+      }
+    }
+
+    const result: ThreatScanResult = {
+      safe: threats.every(threat => threat.severity !== 'critical'),
+      threats,
+    }
+
+    await this.audit({
+      id: makeAuditId('scan'),
+      pluginName,
+      event: 'threat_scan',
+      timestamp: new Date(),
+      severity: result.safe ? 'info' : 'warning',
+      metadata: {
+        safe: result.safe,
+        threatCount: threats.length,
+        criticalThreats: threats.filter(threat => threat.severity === 'critical').length,
+      },
+    })
+
+    return result
+  }
+
+  async rateLimit(key: string, limit: number, window: number): Promise<RateLimitResult> {
+    const now = Date.now()
+    const existing = this.rateLimits.get(key)
+    const current = existing && now < existing.resetAt
+      ? existing
+      : { count: 0, resetAt: now + window }
+
+    current.count += 1
+    this.rateLimits.set(key, current)
+
+    const allowed = current.count <= limit
+    const resetAt = new Date(current.resetAt)
+    return {
+      allowed,
+      remaining: Math.max(0, limit - current.count),
+      resetAt,
+      resetTime: resetAt,
+      retryAfter: allowed ? 0 : Math.ceil((current.resetAt - now) / 1000),
+    }
+  }
+
+  async checkRateLimit(pluginName: string, resource: string): Promise<RateLimitResult> {
+    return this.rateLimit(`${pluginName}:${resource}`, 100, 60_000)
+  }
+
+  async monitorResource(pluginName: string, _resource: string, usage: ResourceUsage): Promise<void> {
+    const entries = this.resourceUsage.get(pluginName) ?? []
+    entries.push({
+      ...usage,
+      timestamp: usage.timestamp ?? new Date(),
+    })
+    this.resourceUsage.set(pluginName, entries.slice(-1000))
+  }
+
+  async getResourceUsage(pluginName: string): Promise<ResourceUsage[]> {
+    return [...(this.resourceUsage.get(pluginName) ?? [])]
+  }
+
+  async audit(event: SecurityAuditEvent): Promise<void> {
+    this.auditEvents.unshift({
+      ...event,
+      id: event.id ?? makeAuditId('audit'),
+      event: event.event ?? event.type,
+      type: event.type ?? event.event,
+      timestamp: event.timestamp ?? new Date(),
+      severity: event.severity ?? 'info',
+    })
+    if (this.auditEvents.length > 50_000) {
+      this.auditEvents.length = 50_000
+    }
+  }
+
+  async getAuditLog(options: AuditLogOptions = {}): Promise<SecurityAuditEvent[]> {
+    const eventFilter = options.event ?? options.type
+    const actorFilter = options.userId ?? options.actor
+    const from = options.dateFrom ?? options.from
+    const to = options.dateTo ?? options.to
+    const offset = options.offset ?? 0
+    const limit = options.limit ?? 1000
+
+    return this.auditEvents
+      .filter(event => !options.pluginName || event.pluginName === options.pluginName)
+      .filter(event => !eventFilter || event.event === eventFilter || event.type === eventFilter)
+      .filter(event => !actorFilter || event.userId === actorFilter || event.actor === actorFilter)
+      .filter(event => !options.severity || event.severity === options.severity)
+      .filter(event => !from || !event.timestamp || event.timestamp >= from)
+      .filter(event => !to || !event.timestamp || event.timestamp <= to)
+      .slice(offset, offset + limit)
+  }
+
+  async getAuditLogs(options: AuditLogOptions = {}): Promise<SecurityAuditEvent[]> {
+    return this.getAuditLog(options)
+  }
+
+  isEncrypted(value: unknown): boolean {
+    return isEncryptedSecretValue(value)
+  }
+}

--- a/packages/core-backend/tests/unit/plugin-runtime-security.test.ts
+++ b/packages/core-backend/tests/unit/plugin-runtime-security.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest'
+import { MetaSheetServer } from '../../src/index'
+import type { PluginContext, SecurityService } from '../../src/types/plugin'
+
+function installLoadedPlugin(server: MetaSheetServer, name: string, plugin: Record<string, unknown>) {
+  const loader = (server as unknown as { pluginLoader: { loadedPlugins: Map<string, unknown> } }).pluginLoader
+  loader.loadedPlugins.set(name, {
+    manifest: {
+      name,
+      version: '1.0.0',
+      displayName: name,
+      description: `${name} test plugin`,
+    },
+    plugin,
+    path: `/tmp/${name}`,
+    loadedAt: new Date(),
+  })
+}
+
+describe('MetaSheetServer plugin runtime security service', () => {
+  it('injects services.security through the real activation path', async () => {
+    const server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [] })
+    const pluginName = 'plugin-runtime-security-probe'
+    let capturedSecurity: SecurityService | undefined
+    let encryptedSecret = ''
+    let decryptedSecret = ''
+    let digest = ''
+    let verified = false
+
+    installLoadedPlugin(server, pluginName, {
+      async activate(context: PluginContext) {
+        capturedSecurity = context.services.security
+        encryptedSecret = await context.services.security.encrypt('integration-secret')
+        decryptedSecret = await context.services.security.decrypt(encryptedSecret)
+        digest = await context.services.security.hash('payload')
+        verified = await context.services.security.verify?.('payload', digest) ?? false
+      },
+    })
+
+    await (server as unknown as { activatePluginByName(name: string): Promise<unknown> }).activatePluginByName(pluginName)
+
+    expect(capturedSecurity).toBeDefined()
+    expect(encryptedSecret).toMatch(/^enc:/)
+    expect(decryptedSecret).toBe('integration-secret')
+    expect(digest).toMatch(/^[a-f0-9]{64}$/)
+    expect(verified).toBe(true)
+  })
+
+  it('uses platform enc format and rejects unsupported per-call keys', async () => {
+    const server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [] })
+    let security: SecurityService | undefined
+
+    installLoadedPlugin(server, 'plugin-runtime-security-key-probe', {
+      async activate(context: PluginContext) {
+        security = context.services.security
+      },
+    })
+    await (server as unknown as { activatePluginByName(name: string): Promise<unknown> }).activatePluginByName('plugin-runtime-security-key-probe')
+
+    expect(security).toBeDefined()
+    const encrypted = await security!.encrypt('stable-secret')
+    const tampered = `${encrypted.slice(0, -1)}${encrypted.endsWith('a') ? 'b' : 'a'}`
+
+    await expect(security!.decrypt(encrypted)).resolves.toBe('stable-secret')
+    await expect(security!.decrypt('plain-value')).resolves.toBe('plain-value')
+    await expect(security!.decrypt(tampered)).rejects.toThrow()
+    await expect(security!.encrypt('stable-secret', 'custom-key')).rejects.toThrow(/per-call encryption keys/)
+  })
+
+  it('provides threat scanning, audit, rate-limit, and explicit sandbox rejection', async () => {
+    const server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [] })
+    const pluginName = 'plugin-runtime-security-scan-probe'
+    let security: SecurityService | undefined
+
+    installLoadedPlugin(server, pluginName, {
+      async activate(context: PluginContext) {
+        security = context.services.security
+      },
+    })
+    await (server as unknown as { activatePluginByName(name: string): Promise<unknown> }).activatePluginByName(pluginName)
+
+    const scan = await security!.scanForThreats(pluginName, 'const fs = require("fs"); process.exit(1)')
+    expect(scan.safe).toBe(false)
+    expect(scan.threats.map(threat => threat.type)).toEqual(
+      expect.arrayContaining(['module_access', 'system_access']),
+    )
+
+    const auditEvents = await security!.getAuditLog?.({ pluginName, event: 'threat_scan' })
+    expect(auditEvents?.length).toBeGreaterThanOrEqual(1)
+
+    const firstAttempt = await security!.rateLimit?.(`${pluginName}:api`, 1, 60_000)
+    const secondAttempt = await security!.rateLimit?.(`${pluginName}:api`, 1, 60_000)
+    expect(firstAttempt?.allowed).toBe(true)
+    expect(secondAttempt?.allowed).toBe(false)
+
+    const sandbox = security!.createSandbox(pluginName, ['api.allowed'])
+    expect(await security!.validateAPIAccess?.(pluginName, 'api.allowed.read', 'GET')).toBe(true)
+    expect(await security!.validateAPIAccess?.(pluginName, 'api.blocked.read', 'GET')).toBe(false)
+    await expect(sandbox.execute('1 + 1')).rejects.toThrow(/sandbox execution is not available/)
+    sandbox.destroy?.()
+    expect(security!.getSandbox?.(pluginName)).toBeNull()
+  })
+})

--- a/plugins/plugin-integration-core/SPIKE_NOTES.md
+++ b/plugins/plugin-integration-core/SPIKE_NOTES.md
@@ -1,8 +1,8 @@
 # M0 Spike Findings — plugin-integration-core
 
-> Status: ✅ Spike complete. Runtime path confirmed. Runtime teardown gaps #1/#2 have a host-side follow-up.
+> Status: ✅ Spike complete. Runtime path confirmed. Runtime teardown gaps #1/#2/#3 have host-side follow-ups.
 > Date: 2026-04-24
-> PR #0 review: all 5 issues resolved in-file; 1 kernel-side service gap remains (see below).
+> PR #0 review: all 5 issues resolved in-file; kernel-side runtime gaps are now tracked as fixed host capabilities.
 
 ---
 
@@ -20,13 +20,13 @@ Express stack entries are still not physically removed, but they are no longer b
 
 The runtime now records communication namespaces by owning plugin. Deactivation and activation failure delete owned namespaces from the host `pluginApis` map. The plugin context also exposes optional `communication.unregister(name)` for explicit cleanup, but plugins do not need to rely on it for host safety.
 
-### 3. `services.security.encrypt/decrypt` declared in types but not wired — still open
+### 3. `services.security.encrypt/decrypt` declared in types but not wired — fixed by host runtime adapter
 
-`packages/core-backend/src/types/plugin.ts` declares `PluginServices.security` (and several other services) but the runtime factory at `src/index.ts:1351-1356` only injects `notification / automationRegistry / rbacProvisioning / platformAppInstances` and casts the result with `as unknown as PluginServices`. Any plugin written against the type declaration would silently get `undefined` at runtime.
+`packages/core-backend/src/types/plugin.ts` declares `PluginServices.security` (and several other services). The active CJS runtime path now injects a host-backed `PluginRuntimeSecurityService` into `context.services.security` instead of leaving the typed property undefined.
 
-**Workaround in this plugin**: `lib/credential-store.cjs` is self-contained (Node `crypto`, `INTEGRATION_ENCRYPTION_KEY` env) and does not rely on `services.security`.
+The adapter intentionally reuses `packages/core-backend/src/security/encrypted-secrets.ts`, so plugin credentials can share the platform `enc:` AES-GCM secret format. It also exposes hash/verify/token/audit/rate-limit/threat-scan helpers. Sandbox code execution remains explicitly unavailable in this runtime path rather than pretending to provide full VM isolation.
 
-**Scope of fix**: instantiate a security service backed by `packages/core-backend/src/security/encrypted-secrets.ts` and add it to the `services` object at `src/index.ts:1356`. Then credential-store can migrate.
+**Current plugin state**: `lib/credential-store.cjs` remains self-contained (`v1:` format) for compatibility. M1 can migrate to `context.services.security.encrypt/decrypt` behind a backward-compatible reader that still accepts existing `v1:` payloads.
 
 ---
 


### PR DESCRIPTION
## Summary

Inject a host-backed `context.services.security` into the active CJS plugin runtime path.

- Adds `PluginRuntimeSecurityService`, backed by the existing platform `enc:` AES-GCM secret helpers.
- Wires the service into `MetaSheetServer.createPluginContext()`.
- Covers real plugin activation path, encryption/decryption, hash/verify, threat scanning, audit, rate limiting, and explicit sandbox execution rejection.
- Updates `plugin-integration-core` spike notes and adds design/verification MDs.

## Verification

```bash
pnpm --filter @metasheet/core-backend exec vitest run tests/unit/plugin-runtime-security.test.ts --reporter=verbose
pnpm --filter @metasheet/core-backend exec tsc --noEmit
pnpm --filter @metasheet/core-backend exec vitest run tests/unit/plugin-runtime-security.test.ts tests/unit/plugin-runtime-teardown.test.ts --reporter=dot
pnpm -F plugin-integration-core test
node --import tsx scripts/validate-plugin-manifests.ts
```

Notes:
- `pnpm --filter @metasheet/core-backend lint` is unavailable because this package has no `lint` script.
- `plugin-integration-core` still keeps its `v1:` credential-store format; migration to host-backed `enc:` writes is a separate M1 follow-up.