### PR TITLE
feat(integration): migrate credential store to host security

### DIFF
--- a/docs/development/integration-core-credential-store-host-security-design-20260424.md
+++ b/docs/development/integration-core-credential-store-host-security-design-20260424.md
@@ -1,0 +1,72 @@
+# Integration Core Credential Store Host Security Design — 2026-04-24
+
+## Context
+
+`plugin-integration-core` originally used a self-contained credential store with AES-256-GCM and an `INTEGRATION_ENCRYPTION_KEY` deployment key. That was necessary while the active CJS plugin runtime did not inject `context.services.security`.
+
+PR #1143 closed the host gap by injecting a `PluginRuntimeSecurityService` whose `encrypt()` and `decrypt()` use the platform `enc:` secret format. The plugin can now stop writing new credentials with its private `v1:` format without breaking already stored rows.
+
+## Decision
+
+`plugins/plugin-integration-core/lib/credential-store.cjs` now supports two modes:
+
+- Host-backed mode: `createCredentialStore({ logger, security })` when `security.encrypt/decrypt` exist.
+- Legacy fallback mode: `createCredentialStore({ logger })` when no host security service is available.
+
+Host-backed mode:
+
+- `store.source === 'host-security'`
+- `store.format === 'enc'`
+- `encrypt()` delegates to `security.encrypt()` and writes `enc:` values.
+- `decrypt('enc:...')` delegates to `security.decrypt()`.
+- `decrypt('v1:...')` still uses the legacy AES-GCM key path for backward compatibility.
+- `fingerprint()` uses `security.hash()` when available and truncates to 16 hex chars.
+
+Legacy fallback mode:
+
+- Keeps the old `v1:<iv>:<tag>:<data>` format.
+- Keeps production fail-fast when `INTEGRATION_ENCRYPTION_KEY` is absent.
+- Keeps deterministic dev fallback only outside production.
+
+## Runtime Wiring
+
+`plugins/plugin-integration-core/index.cjs` creates the credential store during plugin activation:
+
+```js
+credentialStore = createCredentialStore({
+  logger,
+  security: context.services && context.services.security,
+})
+```
+
+The communication `getStatus()` method exposes only non-secret operational metadata:
+
+```json
+{
+  "credentialStore": {
+    "source": "host-security",
+    "format": "enc"
+  }
+}
+```
+
+No plaintext decrypt API is exposed through HTTP or plugin communication.
+
+## Compatibility
+
+Existing database rows in `integration_external_systems.credentials_encrypted` can contain either:
+
+- `enc:` for new host-backed writes.
+- `v1:` for legacy plugin-encrypted values.
+
+The migration comment was updated to make this mixed-format period explicit. A future maintenance migration can re-encrypt `v1:` rows to `enc:` after staging confirms the host-backed path in real pipeline flows.
+
+## Trade-Off
+
+The credential-store API is now async because host `security.encrypt/decrypt/hash` are async. This is a deliberate tightening. There are no production plugin callers yet; tests now await the methods so future DB writes do not accidentally persist unresolved Promises.
+
+## Deferred
+
+- Bulk re-encryption of existing `v1:` rows to `enc:`.
+- A pipeline/admin API that writes real external system credentials.
+- Production fail-fast for missing platform `ENCRYPTION_KEY` / `ENCRYPTION_SALT`; that belongs to the shared platform secret helper, not this plugin slice.

--- a/docs/development/integration-core-credential-store-host-security-verification-20260424.md
+++ b/docs/development/integration-core-credential-store-host-security-verification-20260424.md
@@ -1,0 +1,52 @@
+# Integration Core Credential Store Host Security Verification — 2026-04-24
+
+## Scope
+
+Verify the M1 credential-store migration for `plugin-integration-core`:
+
+- New writes use host `context.services.security` and produce `enc:` values.
+- Existing `v1:` values remain readable.
+- Legacy fallback behavior remains intact when no host security service exists.
+- Plugin activation reports the host-backed credential-store mode without exposing secrets.
+
+## Commands Run
+
+```bash
+pnpm -F plugin-integration-core test
+node plugins/plugin-integration-core/__tests__/credential-store.test.cjs
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/plugin-runtime-security.test.ts --reporter=dot
+node --import tsx scripts/validate-plugin-manifests.ts
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/plugin-runtime-security.test.ts tests/unit/plugin-runtime-teardown.test.ts --reporter=dot
+```
+
+## Results
+
+- `plugin-integration-core` package tests: passed.
+- `credential-store.test.cjs`: 10 scenarios passed.
+- Backend runtime security focused test: 3/3 passed.
+- Plugin manifest validation: 13 valid, 0 invalid. Existing warnings remain unrelated.
+- Backend TypeScript compile: passed.
+- Runtime security + teardown regression: 6/6 passed.
+
+## Coverage
+
+- Dev fallback still creates `v1:` values with a warning.
+- Production without host security and without `INTEGRATION_ENCRYPTION_KEY` still refuses to create a legacy store.
+- Production legacy env key still round-trips multiple payloads.
+- Legacy `v1:` tamper and malformed ciphertext rejection still work.
+- Host-backed mode delegates `encrypt/decrypt/hash` to `services.security`.
+- Host-backed mode writes `enc:` values.
+- Host-backed mode decrypts old `v1:` payloads without calling host decrypt.
+- Bad host security service shape is rejected.
+- `plugin-runtime-smoke` and `host-loader-smoke` both assert `getStatus().credentialStore` is `{ source: 'host-security', format: 'enc' }`.
+
+## Notes
+
+`pnpm --filter @metasheet/core-backend exec vitest run tests/unit/plugin-runtime-security.test.ts --reporter=dot` logs local database connection warnings because this machine has no default `chouhua` Postgres database. The target test file still passes.
+
+## Not Covered
+
+- Applying migration 057 against a live Postgres instance.
+- Real admin UI/API credential writes, because that API is not part of this slice.
+- Bulk migration of existing `v1:` rows.

--- a/docs/development/integration-core-m0-design-20260424.md
+++ b/docs/development/integration-core-m0-design-20260424.md
@@ -72,13 +72,12 @@ This is not a substitute for applying the migration against Postgres. It is an e
 
 ### Credentials
 
-`lib/credential-store.cjs` uses AES-256-GCM envelope encryption.
+`lib/credential-store.cjs` now prefers the host-backed `context.services.security` service when available.
 
-- Production requires `INTEGRATION_ENCRYPTION_KEY`.
-- Development/test may use a deterministic fallback key with a warning.
+- New host-backed writes use the platform `enc:` secret format.
+- Existing legacy `v1:` payloads remain readable through the previous AES-256-GCM key path.
+- If the host security service is not present, production still requires `INTEGRATION_ENCRYPTION_KEY`; development/test may use a deterministic fallback key with a warning.
 - Public callers receive fingerprints, not plaintext.
-
-The plugin does not depend on `context.services.security` yet because the runtime path currently does not inject that service despite the type declaration. This gap is documented in `SPIKE_NOTES.md`.
 
 ### Database
 

--- a/docs/development/integration-core-m0-verification-20260424.md
+++ b/docs/development/integration-core-m0-verification-20260424.md
@@ -24,7 +24,7 @@ Output summary:
 ```text
 plugin-runtime-smoke: all assertions passed
 host-loader-smoke: PluginLoader load + activate path passed
-credential-store: 7 scenarios passed
+credential-store: 10 scenarios passed
 db.cjs: all CRUD + boundary + injection tests passed
 staging-installer: all 7 assertions passed
 migration-sql: 057 integration migration structure passed

--- a/packages/core-backend/migrations/057_create_integration_core_tables.sql
+++ b/packages/core-backend/migrations/057_create_integration_core_tables.sql
@@ -25,7 +25,7 @@ CREATE TABLE IF NOT EXISTS integration_external_systems (
   kind                  TEXT NOT NULL,       -- 'plm:yuantus' | 'erp:k3-wise-webapi' | 'erp:k3-wise-sqlserver' | 'http' | 'postgres' | ...
   role                  TEXT NOT NULL CHECK (role IN ('source', 'target', 'bidirectional')),
   config                JSONB NOT NULL DEFAULT '{}'::jsonb,        -- base_url / host / port / db_name / account_set_id / env / 其它非密码字段
-  credentials_encrypted TEXT,                                       -- lib/credential-store.cjs 加密后 ciphertext，永不明文
+  credentials_encrypted TEXT,                                       -- lib/credential-store.cjs ciphertext；新写 enc:，兼容读旧 v1:，永不明文
   capabilities          JSONB NOT NULL DEFAULT '{}'::jsonb,        -- { read, write, introspect, watermarkFields: [] }
   status                TEXT NOT NULL DEFAULT 'inactive' CHECK (status IN ('active', 'inactive', 'error')),
   last_tested_at        TIMESTAMPTZ,

--- a/plugins/plugin-integration-core/SPIKE_NOTES.md
+++ b/plugins/plugin-integration-core/SPIKE_NOTES.md
@@ -26,7 +26,7 @@ The runtime now records communication namespaces by owning plugin. Deactivation 
 
 The adapter intentionally reuses `packages/core-backend/src/security/encrypted-secrets.ts`, so plugin credentials can share the platform `enc:` AES-GCM secret format. It also exposes hash/verify/token/audit/rate-limit/threat-scan helpers. Sandbox code execution remains explicitly unavailable in this runtime path rather than pretending to provide full VM isolation.
 
-**Current plugin state**: `lib/credential-store.cjs` remains self-contained (`v1:` format) for compatibility. M1 can migrate to `context.services.security.encrypt/decrypt` behind a backward-compatible reader that still accepts existing `v1:` payloads.
+**Current plugin state**: `lib/credential-store.cjs` now creates host-backed stores when `context.services.security` is present. New writes use the platform `enc:` format, and old `v1:` payloads remain readable through the legacy key path.
 
 ---
 

--- a/plugins/plugin-integration-core/__tests__/credential-store.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/credential-store.test.cjs
@@ -12,15 +12,18 @@
 //   5. Tamper detection: flipping ciphertext bytes throws.
 //   6. Malformed ciphertext is rejected with a clear format error.
 //   7. Fingerprint is a stable short hex string.
+//   8. Host-backed mode writes enc: values through services.security.
+//   9. Host-backed mode still reads legacy v1: ciphertext.
 //
 // Run: node __tests__/credential-store.test.cjs
 // ---------------------------------------------------------------------------
 
 const assert = require('node:assert/strict')
+const crypto = require('node:crypto')
 const path = require('node:path')
 const { createCredentialStore, __internals } = require(path.join(__dirname, '..', 'lib', 'credential-store.cjs'))
 
-function runInScope(envPatch, fn) {
+async function runInScope(envPatch, fn) {
   const saved = {}
   for (const k of Object.keys(envPatch)) {
     saved[k] = process.env[k]
@@ -31,7 +34,7 @@ function runInScope(envPatch, fn) {
     }
   }
   try {
-    return fn()
+    return await fn()
   } finally {
     for (const k of Object.keys(saved)) {
       if (saved[k] === undefined) delete process.env[k]
@@ -40,17 +43,39 @@ function runInScope(envPatch, fn) {
   }
 }
 
+function createMockSecurityService() {
+  return {
+    calls: [],
+    async encrypt(plaintext) {
+      this.calls.push(['encrypt', plaintext])
+      return `enc:${Buffer.from(plaintext, 'utf8').toString('base64')}`
+    },
+    async decrypt(ciphertext) {
+      this.calls.push(['decrypt', ciphertext])
+      if (!ciphertext.startsWith('enc:')) {
+        throw new Error('mock security decrypt expects enc: ciphertext')
+      }
+      return Buffer.from(ciphertext.slice(4), 'base64').toString('utf8')
+    },
+    async hash(value) {
+      this.calls.push(['hash', value])
+      return crypto.createHash('sha256').update(value).digest('hex')
+    },
+  }
+}
+
 async function main() {
   // --- 1. Dev fallback -------------------------------------------------
-  runInScope({ NODE_ENV: 'development', INTEGRATION_ENCRYPTION_KEY: null }, () => {
+  await runInScope({ NODE_ENV: 'development', INTEGRATION_ENCRYPTION_KEY: null }, async () => {
     const warnLogs = []
     const store = createCredentialStore({ logger: { warn: (m) => warnLogs.push(m) } })
     assert.equal(store.source, 'dev-fallback', 'dev fallback source')
+    assert.equal(store.format, 'v1', 'dev fallback writes v1')
     assert.ok(warnLogs.length === 1 && /INTEGRATION_ENCRYPTION_KEY/.test(warnLogs[0]), 'warns about missing key')
   })
 
   // --- 2. Production refuses without key -------------------------------
-  runInScope({ NODE_ENV: 'production', INTEGRATION_ENCRYPTION_KEY: null }, () => {
+  await runInScope({ NODE_ENV: 'production', INTEGRATION_ENCRYPTION_KEY: null }, async () => {
     let err = null
     try { createCredentialStore() } catch (e) { err = e }
     assert.ok(err, 'prod throws without key')
@@ -58,11 +83,12 @@ async function main() {
   })
 
   // --- 3-5. Production with key — roundtrip + tamper + format ----------
-  runInScope(
+  await runInScope(
     { NODE_ENV: 'production', INTEGRATION_ENCRYPTION_KEY: 'a'.repeat(64) },
-    () => {
+    async () => {
       const store = createCredentialStore()
       assert.equal(store.source, 'env', 'env source')
+      assert.equal(store.format, 'v1', 'env-backed fallback writes v1')
 
       const payloads = [
         'simple',
@@ -72,29 +98,29 @@ async function main() {
         '',  // empty string
       ]
       for (const p of payloads) {
-        const ct = store.encrypt(p)
+        const ct = await store.encrypt(p)
         assert.ok(ct.startsWith('v1:'), `ciphertext for "${p.slice(0, 20)}" is v1-tagged`)
         assert.notEqual(ct, p, 'ciphertext differs from plaintext')
-        assert.equal(store.decrypt(ct), p, `roundtrip for "${p.slice(0, 20)}"`)
+        assert.equal(await store.decrypt(ct), p, `roundtrip for "${p.slice(0, 20)}"`)
       }
 
       // Tamper: flip last 2 chars of the data segment — MUST throw
-      const ct = store.encrypt('hello')
+      const ct = await store.encrypt('hello')
       const parts = ct.split(':')
       const d = parts[3]
       const tampered = [parts[0], parts[1], parts[2], d.slice(0, -2) + (d.slice(-2) === 'AA' ? 'BB' : 'AA')].join(':')
       let tErr = null
-      try { store.decrypt(tampered) } catch (e) { tErr = e }
+      try { await store.decrypt(tampered) } catch (e) { tErr = e }
       assert.ok(tErr, 'tamper must throw')
 
       // Malformed ciphertext — format error
       let fErr = null
-      try { store.decrypt('not-a-v1-ciphertext') } catch (e) { fErr = e }
+      try { await store.decrypt('not-a-v1-ciphertext') } catch (e) { fErr = e }
       assert.ok(fErr && /invalid ciphertext format/.test(fErr.message), 'format rejection')
 
       // Fingerprint: stable and short
-      const fp1 = store.fingerprint(ct)
-      const fp2 = store.fingerprint(ct)
+      const fp1 = await store.fingerprint(ct)
+      const fp2 = await store.fingerprint(ct)
       assert.equal(fp1, fp2, 'fingerprint stable')
       assert.match(fp1, /^[0-9a-f]{16}$/, 'fingerprint shape')
     },
@@ -114,7 +140,48 @@ async function main() {
   assert.equal(__internals.decodeKey(null), null, 'null rejected')
   assert.equal(__internals.decodeKey(''), null, 'empty rejected')
 
-  console.log('✓ credential-store: 7 scenarios passed')
+  // --- 8. Host-backed mode writes enc: and delegates enc: reads ----------
+  await runInScope({ NODE_ENV: 'production', INTEGRATION_ENCRYPTION_KEY: null }, async () => {
+    const security = createMockSecurityService()
+    const store = createCredentialStore({ security })
+
+    assert.equal(store.source, 'host-security', 'host security source')
+    assert.equal(store.format, 'enc', 'host security writes enc')
+
+    const ct = await store.encrypt('host-secret')
+    assert.equal(ct, `enc:${Buffer.from('host-secret', 'utf8').toString('base64')}`, 'host encrypt delegated')
+    assert.equal(await store.decrypt(ct), 'host-secret', 'host decrypt delegated')
+
+    const fp1 = await store.fingerprint(ct)
+    const fp2 = await store.fingerprint(ct)
+    assert.equal(fp1, fp2, 'host fingerprint stable')
+    assert.match(fp1, /^[0-9a-f]{16}$/, 'host fingerprint shape')
+    assert.deepEqual(
+      security.calls.map(([name]) => name),
+      ['encrypt', 'decrypt', 'hash', 'hash'],
+      'host security calls recorded',
+    )
+  })
+
+  // --- 9. Host-backed mode still reads legacy v1 payloads ----------------
+  await runInScope({ NODE_ENV: 'production', INTEGRATION_ENCRYPTION_KEY: 'b'.repeat(64) }, async () => {
+    const legacyStore = createCredentialStore()
+    const legacyCiphertext = await legacyStore.encrypt('legacy-secret')
+    assert.ok(__internals.isLegacyCiphertext(legacyCiphertext), 'legacy ciphertext detected')
+
+    const security = createMockSecurityService()
+    const hostStore = createCredentialStore({ security })
+    assert.equal(await hostStore.decrypt(legacyCiphertext), 'legacy-secret', 'host store reads legacy v1')
+    assert.equal(security.calls.length, 0, 'legacy decrypt does not call host decrypt')
+  })
+
+  // --- 10. Bad security service shape rejected ---------------------------
+  let badSecurityErr = null
+  try { createCredentialStore({ security: { encrypt: async () => 'enc:x' } }) } catch (e) { badSecurityErr = e }
+  assert.ok(badSecurityErr, 'bad security service shape rejected')
+  assert.match(badSecurityErr.message, /security service/, 'bad security service error message')
+
+  console.log('✓ credential-store: 10 scenarios passed')
 }
 
 main().catch((err) => {

--- a/plugins/plugin-integration-core/__tests__/host-loader-smoke.test.mjs
+++ b/plugins/plugin-integration-core/__tests__/host-loader-smoke.test.mjs
@@ -69,7 +69,13 @@ function createHostContext() {
       async delete() {},
       async list() { return [] },
     },
-    services: {},
+    services: {
+      security: {
+        async encrypt(value) { return `enc:${Buffer.from(value, 'utf8').toString('base64')}` },
+        async decrypt(value) { return Buffer.from(value.slice(4), 'base64').toString('utf8') },
+        async hash(value) { return `hash:${value}` },
+      },
+    },
     config: {},
   }
 
@@ -109,6 +115,7 @@ async function main() {
   const status = await host.context.communication.call('integration-core', 'getStatus')
   assert.equal(status.plugin, 'plugin-integration-core')
   assert.equal(status.routesRegistered, 1)
+  assert.deepEqual(status.credentialStore, { source: 'host-security', format: 'enc' })
 
   await loaded.plugin.deactivate()
   assert.ok(host.logs.some((line) => line.includes('activated')), 'activation logged')

--- a/plugins/plugin-integration-core/__tests__/plugin-runtime-smoke.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/plugin-runtime-smoke.test.cjs
@@ -54,6 +54,13 @@ function createMockContext() {
         warn: (msg) => logs.push(['warn', msg]),
         error: (msg) => logs.push(['error', msg]),
       },
+      services: {
+        security: {
+          async encrypt(value) { return `enc:${Buffer.from(value, 'utf8').toString('base64')}` },
+          async decrypt(value) { return Buffer.from(value.slice(4), 'base64').toString('utf8') },
+          async hash(value) { return `hash:${value}` },
+        },
+      },
     },
     inspect: { routes, namespaces: registeredNamespaces, logs },
   }
@@ -121,6 +128,11 @@ async function main() {
   const statusResult = await commApi.getStatus()
   assert.equal(statusResult.plugin, 'plugin-integration-core', 'status.plugin')
   assert.equal(statusResult.routesRegistered, 1, 'status.routesRegistered')
+  assert.deepEqual(
+    statusResult.credentialStore,
+    { source: 'host-security', format: 'enc' },
+    'status reports host-backed credential store',
+  )
 
   // --- 6. Activation logged --------------------------------------------
   const hasActivationLog = inspect.logs.some(

--- a/plugins/plugin-integration-core/index.cjs
+++ b/plugins/plugin-integration-core/index.cjs
@@ -16,9 +16,11 @@
 
 const PLUGIN_ID = 'plugin-integration-core'
 const COMMUNICATION_NAMESPACE = 'integration-core'
+const { createCredentialStore } = require('./lib/credential-store.cjs')
 
 const registeredRoutes = []
 let activeContext = null
+let credentialStore = null
 
 function buildHealthPayload() {
   return {
@@ -42,6 +44,9 @@ function buildCommunicationApi() {
         version: '0.1.0',
         milestone: 'M0-spike',
         routesRegistered: registeredRoutes.length,
+        credentialStore: credentialStore
+          ? { source: credentialStore.source, format: credentialStore.format }
+          : null,
       }
     },
   }
@@ -51,6 +56,10 @@ module.exports = {
   async activate(context) {
     activeContext = context
     const logger = context.logger || console
+    credentialStore = createCredentialStore({
+      logger,
+      security: context.services && context.services.security,
+    })
 
     // --- HTTP routes ------------------------------------------------------
     context.api.http.addRoute('GET', '/api/integration/health', async (_req, res) => {
@@ -71,6 +80,7 @@ module.exports = {
     // helper used above; host is expected to drop the router on deactivate.
     // We clear local state here so a re-activation starts clean.
     registeredRoutes.length = 0
+    credentialStore = null
     activeContext = null
     logger.info(`[${PLUGIN_ID}] deactivated`)
   },

--- a/plugins/plugin-integration-core/lib/credential-store.cjs
+++ b/plugins/plugin-integration-core/lib/credential-store.cjs
@@ -6,19 +6,20 @@
 // Wraps external-system credentials (K3 WISE WebAPI passwords, SQL Server
 // connection strings, PLM tokens, etc.) in AES-256-GCM envelope encryption.
 //
-// Runtime note (see SPIKE_NOTES.md): the documented `context.services.security`
-// API is declared in types/plugin.ts but NOT wired at runtime
-// (src/index.ts:1351-1356 only binds notification / automationRegistry /
-// rbacProvisioning / platformAppInstances). We therefore keep this module
-// self-contained and depend only on Node's built-in `crypto`.
+// Runtime note (see SPIKE_NOTES.md): the host now injects
+// `context.services.security` into the active CJS plugin runtime. New
+// credentials should use that host-backed `enc:` format. This module still
+// keeps the legacy `v1:` implementation so existing encrypted values remain
+// readable during migration.
 //
 // Key provisioning:
 //   env INTEGRATION_ENCRYPTION_KEY = 64-hex-char (32-byte) or 44-b64-char key
 //   production (NODE_ENV=production): key required — startup refuses otherwise
 //   development / test: falls back to a deterministic dev key with a warning
 //
-// Ciphertext format (version-tagged so we can rotate in place later):
-//   "v1:<iv_b64>:<tag_b64>:<data_b64>"
+// Ciphertext formats:
+//   new host-backed values: "enc:<platform ciphertext>"
+//   legacy plugin values:  "v1:<iv_b64>:<tag_b64>:<data_b64>"
 // ---------------------------------------------------------------------------
 
 const crypto = require('node:crypto')
@@ -27,6 +28,7 @@ const ALGORITHM = 'aes-256-gcm'
 const KEY_BYTES = 32
 const IV_BYTES = 12
 const VERSION_TAG = 'v1'
+const HOST_PREFIX = 'enc:'
 const ENV_KEY_NAME = 'INTEGRATION_ENCRYPTION_KEY'
 
 // Dev-only deterministic fallback. 32 bytes. Do NOT ship to production.
@@ -106,19 +108,88 @@ function decrypt(ciphertext, key) {
   return decrypted.toString('utf8')
 }
 
+function isLegacyCiphertext(value) {
+  return typeof value === 'string' && value.startsWith(`${VERSION_TAG}:`)
+}
+
+function isHostCiphertext(value) {
+  return typeof value === 'string' && value.startsWith(HOST_PREFIX)
+}
+
+function isSecurityService(candidate) {
+  return Boolean(
+    candidate &&
+    typeof candidate.encrypt === 'function' &&
+    typeof candidate.decrypt === 'function',
+  )
+}
+
+async function hashWithSecurity(security, value) {
+  if (security && typeof security.hash === 'function') {
+    return security.hash(value)
+  }
+  return crypto.createHash('sha256').update(value).digest('hex')
+}
+
+function createLegacyKeyResolver({ logger } = {}) {
+  let resolved = null
+  return () => {
+    if (!resolved) resolved = resolveKey({ logger })
+    return resolved
+  }
+}
+
 /**
- * Create a credential store bound to a concrete key. Exposed to other plugin
- * modules during activate() so they never need to handle raw keys directly.
+ * Create a credential store exposed to other plugin modules during activate().
+ *
+ * With a host security service, new writes use the platform `enc:` format while
+ * legacy `v1:` payloads remain readable via the old key path. Without a host
+ * service, the store preserves the original self-contained `v1:` behavior.
  */
-function createCredentialStore({ logger } = {}) {
+function createCredentialStore({ logger, security } = {}) {
+  if (security !== undefined && !isSecurityService(security)) {
+    throw new Error('createCredentialStore: security service must expose encrypt() and decrypt()')
+  }
+
+  if (isSecurityService(security)) {
+    const resolveLegacyKey = createLegacyKeyResolver({ logger })
+    return {
+      source: 'host-security',
+      format: 'enc',
+      async encrypt(plaintext) {
+        if (typeof plaintext !== 'string') {
+          throw new TypeError('encrypt: plaintext must be a string')
+        }
+        return security.encrypt(plaintext)
+      },
+      async decrypt(ciphertext) {
+        if (typeof ciphertext !== 'string') {
+          throw new TypeError('decrypt: ciphertext must be a string')
+        }
+        if (isLegacyCiphertext(ciphertext)) {
+          return decrypt(ciphertext, resolveLegacyKey().key)
+        }
+        return security.decrypt(ciphertext)
+      },
+      async fingerprint(ciphertext) {
+        if (typeof ciphertext !== 'string') {
+          throw new TypeError('fingerprint: ciphertext must be a string')
+        }
+        const digest = await hashWithSecurity(security, ciphertext)
+        return String(digest).slice(0, 16)
+      },
+    }
+  }
+
   const { key, source } = resolveKey({ logger })
 
   return {
     source, // 'env' | 'dev-fallback' — for observability only
-    encrypt(plaintext) {
+    format: 'v1',
+    async encrypt(plaintext) {
       return encrypt(plaintext, key)
     },
-    decrypt(ciphertext) {
+    async decrypt(ciphertext) {
       return decrypt(ciphertext, key)
     },
     /**
@@ -127,7 +198,7 @@ function createCredentialStore({ logger } = {}) {
      * correlation. Callers that need to hand a value back to a UI should use
      * this instead of `decrypt`.
      */
-    fingerprint(ciphertext) {
+    async fingerprint(ciphertext) {
       // HMAC-SHA256 truncated; key-scoped so fingerprints are stable per
       // deployment but not reversible outside it.
       const h = crypto.createHmac('sha256', key).update(ciphertext).digest('hex')
@@ -139,5 +210,13 @@ function createCredentialStore({ logger } = {}) {
 module.exports = {
   createCredentialStore,
   // Exposed for tests only — do not import from other plugin modules.
-  __internals: { encrypt, decrypt, decodeKey, DEV_FALLBACK_KEY_HEX, ENV_KEY_NAME },
+  __internals: {
+    encrypt,
+    decrypt,
+    decodeKey,
+    isHostCiphertext,
+    isLegacyCiphertext,
+    DEV_FALLBACK_KEY_HEX,
+    ENV_KEY_NAME,
+  },
 }


### PR DESCRIPTION
## Summary

Move `plugin-integration-core` credential-store writes onto host-backed `context.services.security` while preserving legacy `v1:` reads.

- `createCredentialStore({ security })` writes new `enc:` payloads through the host security service.
- Legacy `v1:<iv>:<tag>:<data>` payloads remain readable through the old key path.
- Store methods are explicitly async to match host `security.encrypt/decrypt/hash` and avoid accidentally persisting unresolved Promises.
- `index.cjs` creates the credential store during activation and exposes only non-secret status metadata.
- Migration comments and design/verification docs now document the mixed-format period.

## Verification

```bash
pnpm -F plugin-integration-core test
node plugins/plugin-integration-core/__tests__/credential-store.test.cjs
pnpm --filter @metasheet/core-backend exec vitest run tests/unit/plugin-runtime-security.test.ts --reporter=dot
node --import tsx scripts/validate-plugin-manifests.ts
pnpm --filter @metasheet/core-backend exec tsc --noEmit
pnpm --filter @metasheet/core-backend exec vitest run tests/unit/plugin-runtime-security.test.ts tests/unit/plugin-runtime-teardown.test.ts --reporter=dot
```

Notes:
- Local backend vitest logs DB connection warnings because this machine has no default `chouhua` Postgres database; target tests passed.
- Bulk re-encryption of existing `v1:` rows is intentionally deferred.