### PR TITLE
feat(integration): add external system registry seam

### DIFF
--- a/docs/development/integration-core-external-systems-registry-design-20260424.md
+++ b/docs/development/integration-core-external-systems-registry-design-20260424.md
@@ -1,0 +1,114 @@
+# Integration Core External Systems Registry Design — 2026-04-24
+
+## Context
+
+`plugin-integration-core` now has a host-backed credential store that writes new secrets through `context.services.security` using the platform `enc:` format while retaining legacy `v1:` reads.
+
+The next M1 seam is to persist external PLM/ERP/DB system definitions in the `integration_external_systems` table from migration 057. This gives later pipeline-runner slices a concrete source/target registry without exposing credentials over plugin communication.
+
+## Decision
+
+Add `plugins/plugin-integration-core/lib/external-systems.cjs`.
+
+The registry is deliberately narrow:
+
+- It uses only the structured `db.cjs` CRUD helper.
+- It only touches `integration_external_systems`.
+- It encrypts incoming `credentials` via `credentialStore.encrypt()`.
+- It never returns plaintext credentials or `credentials_encrypted`.
+- Public rows expose `hasCredentials`, `credentialFormat`, and `credentialFingerprint` only.
+
+## Communication API
+
+`index.cjs` now creates the registry during `activate(context)`:
+
+```js
+const db = createDb({ database: context.api.database, logger })
+externalSystemRegistry = createExternalSystemRegistry({ db, credentialStore })
+```
+
+The `integration-core` namespace exposes:
+
+```js
+upsertExternalSystem(input)
+getExternalSystem(input)
+listExternalSystems(input)
+```
+
+`getStatus()` now includes:
+
+```json
+{
+  "externalSystems": true
+}
+```
+
+## Input Shape
+
+Minimum supported input:
+
+```ts
+{
+  id?: string
+  tenantId: string
+  workspaceId?: string | null
+  projectId?: string | null
+  name: string
+  kind: string
+  role?: 'source' | 'target' | 'bidirectional'
+  config?: Record<string, unknown>
+  credentials?: string | Record<string, unknown> | null
+  capabilities?: Record<string, unknown>
+  status?: 'active' | 'inactive' | 'error'
+}
+```
+
+Rules:
+
+- `workspaceId === ''` is normalized to `null`, matching the migration's `COALESCE(workspace_id, '')` uniqueness convention.
+- `role` defaults to `source`.
+- `status` defaults to `inactive`.
+- `config` and `capabilities` default to `{}`.
+- `credentials === undefined` preserves an existing credential on update.
+- `credentials === null` clears the stored credential.
+- object credentials are JSON-stringified before encryption.
+
+## Public Output
+
+Returned rows use camelCase metadata and safe credential indicators:
+
+```json
+{
+  "id": "sys_1",
+  "tenantId": "tenant_1",
+  "workspaceId": null,
+  "name": "K3 WISE",
+  "kind": "erp:k3-wise-webapi",
+  "hasCredentials": true,
+  "credentialFormat": "enc",
+  "credentialFingerprint": "..."
+}
+```
+
+No API in this slice returns decrypted credentials.
+
+`credentialFormat` is derived from the stored ciphertext prefix and is intentionally coarse:
+
+- `enc` means the value was written by the host-backed platform security service.
+- `v1` means the row still contains a legacy plugin-local credential value.
+- `unknown` means a non-empty value exists but does not match a known prefix.
+- `null` means no credential is stored.
+
+## Trade-Offs
+
+This slice uses `selectOne -> insertOne/updateRow` instead of a database-native upsert because `db.cjs` intentionally has no raw SQL escape hatch and no scoped `upsert` primitive yet.
+
+That means concurrent same-scope same-name creates can race and rely on the database unique index to reject one writer. This is acceptable for the current seam. If external system registration becomes high-traffic or user-facing, add a validated `upsertByUnique()` helper to `db.cjs` rather than introducing raw SQL.
+
+## Deferred
+
+- REST routes and UI for external system management.
+- Credential test/connect flows.
+- Decrypted credential handoff to concrete adapters.
+- Atomic DB-level upsert helper.
+- Bulk re-encryption of legacy `v1:` credentials.

--- a/docs/development/integration-core-external-systems-registry-verification-20260424.md
+++ b/docs/development/integration-core-external-systems-registry-verification-20260424.md
@@ -1,0 +1,54 @@
+# Integration Core External Systems Registry Verification — 2026-04-24
+
+## Scope
+
+Verify the M1 external-system registry seam for `plugin-integration-core`:
+
+- Registry persists external system metadata through the scoped DB helper.
+- Credential writes go through the host-backed credential store.
+- Public reads do not leak plaintext credentials or ciphertext.
+- Runtime communication exposes registry methods.
+
+## Commands Run
+
+```bash
+pnpm -F plugin-integration-core test
+node plugins/plugin-integration-core/__tests__/external-systems.test.cjs
+node --import tsx scripts/validate-plugin-manifests.ts
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/plugin-runtime-security.test.ts \
+  tests/unit/plugin-runtime-teardown.test.ts \
+  --reporter=dot
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+```
+
+## Results
+
+- `plugin-integration-core` package tests: passed.
+- `external-systems.test.cjs`: passed.
+- Plugin manifest validation: 13 valid, 0 invalid. Existing warnings remain in unrelated plugins.
+- Runtime security/teardown focused backend tests: 2 files, 6 tests passed.
+- Backend `tsc --noEmit`: passed.
+
+## Covered Behaviors
+
+- `upsertExternalSystem()` validates required tenant/name/kind fields.
+- `role` rejects values outside `source | target | bidirectional`.
+- `status` rejects values outside `active | inactive | error`.
+- New rows encrypt `credentials` and store only `credentials_encrypted`.
+- Public result never contains plaintext credentials.
+- Public result never contains `credentials_encrypted`.
+- Public result exposes only coarse credential metadata: `hasCredentials`, `credentialFormat`, and `credentialFingerprint`.
+- Updating without `credentials` preserves the stored credential.
+- Updating with `credentials: null` clears the stored credential.
+- `getExternalSystem()` returns safe public shape and throws `ExternalSystemNotFoundError` when absent.
+- `listExternalSystems()` scopes by tenant/workspace and supports `kind` filtering.
+- `workspaceId` scoping keeps `null` and another workspace isolated.
+- Plugin runtime smoke verifies the communication API exposes `upsertExternalSystem`, `getExternalSystem`, and `listExternalSystems`.
+- Host-loader smoke verifies `getStatus().externalSystems === true`.
+
+## Not Covered
+
+- Live Postgres execution of migration 057 in this local run.
+- REST authz, because this slice exposes only plugin communication methods.
+- Atomic concurrent same-name upsert. The current implementation relies on the DB unique index for race rejection.

--- a/plugins/plugin-integration-core/__tests__/external-systems.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/external-systems.test.cjs
@@ -1,0 +1,190 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const path = require('node:path')
+const {
+  createExternalSystemRegistry,
+  ExternalSystemNotFoundError,
+  ExternalSystemValidationError,
+} = require(path.join(__dirname, '..', 'lib', 'external-systems.cjs'))
+
+function createMockCredentialStore() {
+  return {
+    source: 'host-security',
+    format: 'enc',
+    calls: [],
+    async encrypt(value) {
+      this.calls.push(['encrypt', value])
+      return `enc:${Buffer.from(value, 'utf8').toString('base64')}`
+    },
+    async decrypt(value) {
+      this.calls.push(['decrypt', value])
+      return Buffer.from(value.slice(4), 'base64').toString('utf8')
+    },
+    async fingerprint(value) {
+      this.calls.push(['fingerprint', value])
+      return `fp_${Buffer.from(value).toString('hex').slice(0, 13)}`.slice(0, 16)
+    },
+  }
+}
+
+function createMockDb() {
+  const rows = []
+  const calls = []
+
+  function matchesWhere(row, where) {
+    return Object.entries(where || {}).every(([key, value]) => {
+      if (value === null || value === undefined) return row[key] === null || row[key] === undefined
+      return row[key] === value
+    })
+  }
+
+  return {
+    rows,
+    calls,
+    async selectOne(table, where) {
+      calls.push(['selectOne', table, { ...where }])
+      return rows.find(row => matchesWhere(row, where)) || null
+    },
+    async insertOne(table, row) {
+      calls.push(['insertOne', table, { ...row }])
+      const stored = {
+        ...row,
+        created_at: row.created_at || '2026-04-24T00:00:00.000Z',
+        updated_at: row.updated_at || '2026-04-24T00:00:00.000Z',
+      }
+      rows.push(stored)
+      return [stored]
+    },
+    async updateRow(table, set, where) {
+      calls.push(['updateRow', table, { ...set }, { ...where }])
+      const row = rows.find(candidate => matchesWhere(candidate, where))
+      if (!row) return []
+      Object.assign(row, set, { updated_at: '2026-04-24T01:00:00.000Z' })
+      return [row]
+    },
+    async select(table, options = {}) {
+      calls.push(['select', table, JSON.parse(JSON.stringify(options))])
+      const filtered = rows.filter(row => matchesWhere(row, options.where || {}))
+      return filtered.slice(options.offset || 0, (options.offset || 0) + (options.limit || 1000))
+    },
+  }
+}
+
+async function main() {
+  const db = createMockDb()
+  const credentialStore = createMockCredentialStore()
+  const registry = createExternalSystemRegistry({
+    db,
+    credentialStore,
+    idGenerator: () => 'sys_1',
+  })
+
+  // --- 1. Create encrypts credentials and returns public-safe shape ------
+  const created = await registry.upsertExternalSystem({
+    tenantId: 'tenant_1',
+    workspaceId: null,
+    projectId: 'project_1',
+    name: 'K3 WISE',
+    kind: 'erp:k3-wise-webapi',
+    role: 'source',
+    config: { baseUrl: 'https://k3.example.test' },
+    credentials: { username: 'u', password: 'secret' },
+    capabilities: { read: true, write: false },
+    status: 'active',
+  })
+
+  assert.equal(created.id, 'sys_1')
+  assert.equal(created.tenantId, 'tenant_1')
+  assert.equal(created.workspaceId, null)
+  assert.equal(created.hasCredentials, true)
+  assert.equal(created.credentialFormat, 'enc')
+  assert.match(created.credentialFingerprint, /^fp_/)
+  assert.equal(created.credentials, undefined, 'public result never exposes plaintext credentials')
+  assert.equal(db.rows[0].credentials_encrypted.startsWith('enc:'), true, 'stored credentials are host-encrypted')
+  assert.deepEqual(credentialStore.calls[0][0], 'encrypt')
+
+  // --- 2. Update without credentials preserves encrypted value -----------
+  const previousCiphertext = db.rows[0].credentials_encrypted
+  const updated = await registry.upsertExternalSystem({
+    tenantId: 'tenant_1',
+    workspaceId: null,
+    id: 'sys_1',
+    name: 'K3 WISE renamed',
+    kind: 'erp:k3-wise-webapi',
+    role: 'bidirectional',
+    config: { baseUrl: 'https://k3-new.example.test' },
+    capabilities: { read: true, write: true },
+    status: 'inactive',
+  })
+
+  assert.equal(updated.id, 'sys_1')
+  assert.equal(updated.name, 'K3 WISE renamed')
+  assert.equal(db.rows[0].credentials_encrypted, previousCiphertext, 'credential unchanged when omitted')
+
+  // --- 3. Get/list return public-safe rows and scope by workspace --------
+  const fetched = await registry.getExternalSystem({ tenantId: 'tenant_1', workspaceId: null, id: 'sys_1' })
+  assert.equal(fetched.id, 'sys_1')
+  assert.equal(fetched.hasCredentials, true)
+  assert.equal(fetched.credentialFormat, 'enc')
+  assert.equal(fetched.credentialsEncrypted, undefined, 'encrypted value is not exposed')
+
+  const listed = await registry.listExternalSystems({ tenantId: 'tenant_1', workspaceId: null, kind: 'erp:k3-wise-webapi' })
+  assert.equal(listed.length, 1)
+  assert.equal(listed[0].id, 'sys_1')
+
+  const isolated = await registry.listExternalSystems({ tenantId: 'tenant_1', workspaceId: 'other' })
+  assert.equal(isolated.length, 0, 'workspace scope isolates rows')
+
+  // --- 4. Credential clear writes NULL ----------------------------------
+  const cleared = await registry.upsertExternalSystem({
+    tenantId: 'tenant_1',
+    workspaceId: null,
+    id: 'sys_1',
+    name: 'K3 WISE renamed',
+    kind: 'erp:k3-wise-webapi',
+    role: 'source',
+    credentials: null,
+  })
+  assert.equal(db.rows[0].credentials_encrypted, null, 'credentials null clears stored secret')
+  assert.equal(cleared.hasCredentials, false)
+  assert.equal(cleared.credentialFormat, null)
+
+  // --- 5. Not-found and validation errors -------------------------------
+  let notFound = null
+  try {
+    await registry.getExternalSystem({ tenantId: 'tenant_1', id: 'missing' })
+  } catch (error) {
+    notFound = error
+  }
+  assert.ok(notFound instanceof ExternalSystemNotFoundError, 'missing row throws not found')
+
+  let badRole = null
+  try {
+    await registry.upsertExternalSystem({
+      tenantId: 'tenant_1',
+      name: 'bad',
+      kind: 'http',
+      role: 'reader',
+    })
+  } catch (error) {
+    badRole = error
+  }
+  assert.ok(badRole instanceof ExternalSystemValidationError, 'invalid role rejected')
+
+  let badShape = null
+  try {
+    createExternalSystemRegistry({ db, credentialStore: { encrypt: async () => 'enc:x' } })
+  } catch (error) {
+    badShape = error
+  }
+  assert.ok(badShape, 'bad credential store shape rejected')
+
+  console.log('✓ external-systems: registry + credential boundary tests passed')
+}
+
+main().catch((err) => {
+  console.error('✗ external-systems FAILED')
+  console.error(err)
+  process.exit(1)
+})

--- a/plugins/plugin-integration-core/__tests__/host-loader-smoke.test.mjs
+++ b/plugins/plugin-integration-core/__tests__/host-loader-smoke.test.mjs
@@ -116,6 +116,8 @@ async function main() {
   assert.equal(status.plugin, 'plugin-integration-core')
   assert.equal(status.routesRegistered, 1)
   assert.deepEqual(status.credentialStore, { source: 'host-security', format: 'enc' })
+  assert.equal(status.externalSystems, true)
+  assert.equal(typeof host.namespaces.get('integration-core').upsertExternalSystem, 'function')
 
   await loaded.plugin.deactivate()
   assert.ok(host.logs.some((line) => line.includes('activated')), 'activation logged')

--- a/plugins/plugin-integration-core/__tests__/plugin-runtime-smoke.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/plugin-runtime-smoke.test.cjs
@@ -26,6 +26,7 @@ function createMockContext() {
   const routes = []
   const registeredNamespaces = new Map()
   const logs = []
+  const databaseCalls = []
 
   return {
     context: {
@@ -36,6 +37,12 @@ function createMockContext() {
             assert.equal(typeof path, 'string', 'addRoute path must be string')
             assert.equal(typeof handler, 'function', 'addRoute handler must be function')
             routes.push({ method, path, handler })
+          },
+        },
+        database: {
+          async query(sql, params) {
+            databaseCalls.push({ sql, params })
+            return []
           },
         },
       },
@@ -62,7 +69,7 @@ function createMockContext() {
         },
       },
     },
-    inspect: { routes, namespaces: registeredNamespaces, logs },
+    inspect: { routes, namespaces: registeredNamespaces, logs, databaseCalls },
   }
 }
 
@@ -133,6 +140,12 @@ async function main() {
     { source: 'host-security', format: 'enc' },
     'status reports host-backed credential store',
   )
+  assert.equal(statusResult.externalSystems, true, 'external-system registry initialized')
+
+  // --- 5b. Comm API exposes external-system registry methods ------------
+  assert.equal(typeof commApi.upsertExternalSystem, 'function', 'comm api exposes upsertExternalSystem')
+  assert.equal(typeof commApi.getExternalSystem, 'function', 'comm api exposes getExternalSystem')
+  assert.equal(typeof commApi.listExternalSystems, 'function', 'comm api exposes listExternalSystems')
 
   // --- 6. Activation logged --------------------------------------------
   const hasActivationLog = inspect.logs.some(

--- a/plugins/plugin-integration-core/index.cjs
+++ b/plugins/plugin-integration-core/index.cjs
@@ -17,10 +17,13 @@
 const PLUGIN_ID = 'plugin-integration-core'
 const COMMUNICATION_NAMESPACE = 'integration-core'
 const { createCredentialStore } = require('./lib/credential-store.cjs')
+const { createDb } = require('./lib/db.cjs')
+const { createExternalSystemRegistry } = require('./lib/external-systems.cjs')
 
 const registeredRoutes = []
 let activeContext = null
 let credentialStore = null
+let externalSystemRegistry = null
 
 function buildHealthPayload() {
   return {
@@ -33,8 +36,7 @@ function buildHealthPayload() {
 
 function buildCommunicationApi() {
   return {
-    // M0: bare skeleton. M1 will wire adapter-registry / pipeline-runner /
-    // dead-letter / credential-store into this namespace.
+    // M0/M1 seam. Later slices will add pipeline-runner / dead-letter replay.
     async ping() {
       return { ok: true, plugin: PLUGIN_ID, ts: Date.now() }
     },
@@ -47,7 +49,20 @@ function buildCommunicationApi() {
         credentialStore: credentialStore
           ? { source: credentialStore.source, format: credentialStore.format }
           : null,
+        externalSystems: Boolean(externalSystemRegistry),
       }
+    },
+    async upsertExternalSystem(input) {
+      if (!externalSystemRegistry) throw new Error('external system registry is not initialized')
+      return externalSystemRegistry.upsertExternalSystem(input)
+    },
+    async getExternalSystem(input) {
+      if (!externalSystemRegistry) throw new Error('external system registry is not initialized')
+      return externalSystemRegistry.getExternalSystem(input)
+    },
+    async listExternalSystems(input) {
+      if (!externalSystemRegistry) throw new Error('external system registry is not initialized')
+      return externalSystemRegistry.listExternalSystems(input)
     },
   }
 }
@@ -59,6 +74,14 @@ module.exports = {
     credentialStore = createCredentialStore({
       logger,
       security: context.services && context.services.security,
+    })
+    const db = createDb({
+      database: context.api && context.api.database,
+      logger,
+    })
+    externalSystemRegistry = createExternalSystemRegistry({
+      db,
+      credentialStore,
     })
 
     // --- HTTP routes ------------------------------------------------------
@@ -81,6 +104,7 @@ module.exports = {
     // We clear local state here so a re-activation starts clean.
     registeredRoutes.length = 0
     credentialStore = null
+    externalSystemRegistry = null
     activeContext = null
     logger.info(`[${PLUGIN_ID}] deactivated`)
   },

--- a/plugins/plugin-integration-core/lib/external-systems.cjs
+++ b/plugins/plugin-integration-core/lib/external-systems.cjs
@@ -1,0 +1,267 @@
+'use strict'
+
+// ---------------------------------------------------------------------------
+// External system registry — plugin-integration-core
+//
+// Stores PLM/ERP/DB connection metadata in integration_external_systems.
+// Credentials are write-only for public reads: callers receive a stable
+// fingerprint and a hasCredentials flag, never plaintext.
+// ---------------------------------------------------------------------------
+
+const crypto = require('node:crypto')
+
+const TABLE = 'integration_external_systems'
+const VALID_ROLES = new Set(['source', 'target', 'bidirectional'])
+const VALID_STATUSES = new Set(['active', 'inactive', 'error'])
+
+class ExternalSystemValidationError extends Error {
+  constructor(message, details = {}) {
+    super(message)
+    this.name = 'ExternalSystemValidationError'
+    this.details = details
+  }
+}
+
+class ExternalSystemNotFoundError extends Error {
+  constructor(message, details = {}) {
+    super(message)
+    this.name = 'ExternalSystemNotFoundError'
+    this.details = details
+  }
+}
+
+function requiredString(value, field) {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new ExternalSystemValidationError(`${field} is required`, { field })
+  }
+  return value.trim()
+}
+
+function optionalString(value, field) {
+  if (value === undefined || value === null || value === '') return null
+  if (typeof value !== 'string') {
+    throw new ExternalSystemValidationError(`${field} must be a string`, { field })
+  }
+  return value.trim() || null
+}
+
+function jsonObject(value, field, fallback = {}) {
+  if (value === undefined || value === null) return fallback
+  if (typeof value !== 'object' || Array.isArray(value)) {
+    throw new ExternalSystemValidationError(`${field} must be an object`, { field })
+  }
+  return { ...value }
+}
+
+function normalizeWorkspaceId(value) {
+  const normalized = optionalString(value, 'workspaceId')
+  return normalized === '' ? null : normalized
+}
+
+function normalizeExternalSystemInput(input) {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    throw new ExternalSystemValidationError('input must be an object')
+  }
+
+  const role = input.role === undefined ? 'source' : requiredString(input.role, 'role')
+  if (!VALID_ROLES.has(role)) {
+    throw new ExternalSystemValidationError(`role must be one of ${Array.from(VALID_ROLES).join(', ')}`, { field: 'role' })
+  }
+
+  const status = input.status === undefined ? 'inactive' : requiredString(input.status, 'status')
+  if (!VALID_STATUSES.has(status)) {
+    throw new ExternalSystemValidationError(`status must be one of ${Array.from(VALID_STATUSES).join(', ')}`, { field: 'status' })
+  }
+
+  return {
+    id: optionalString(input.id, 'id'),
+    tenantId: requiredString(input.tenantId, 'tenantId'),
+    workspaceId: normalizeWorkspaceId(input.workspaceId),
+    projectId: optionalString(input.projectId, 'projectId'),
+    name: requiredString(input.name, 'name'),
+    kind: requiredString(input.kind, 'kind'),
+    role,
+    config: jsonObject(input.config, 'config'),
+    credentials: input.credentials,
+    capabilities: jsonObject(input.capabilities, 'capabilities'),
+    status,
+    lastTestedAt: input.lastTestedAt ?? null,
+    lastError: optionalString(input.lastError, 'lastError'),
+  }
+}
+
+function scopeWhere({ tenantId, workspaceId }) {
+  return {
+    tenant_id: tenantId,
+    workspace_id: workspaceId ?? null,
+  }
+}
+
+function rowToPublicExternalSystem(row, credentialFingerprint = null) {
+  if (!row) return null
+  return {
+    id: row.id,
+    tenantId: row.tenant_id,
+    workspaceId: row.workspace_id ?? null,
+    projectId: row.project_id ?? null,
+    name: row.name,
+    kind: row.kind,
+    role: row.role,
+    config: row.config ?? {},
+    capabilities: row.capabilities ?? {},
+    status: row.status,
+    lastTestedAt: row.last_tested_at ?? null,
+    lastError: row.last_error ?? null,
+    hasCredentials: typeof row.credentials_encrypted === 'string' && row.credentials_encrypted.length > 0,
+    credentialFormat: detectCredentialFormat(row.credentials_encrypted),
+    credentialFingerprint,
+    createdAt: row.created_at ?? null,
+    updatedAt: row.updated_at ?? null,
+  }
+}
+
+function detectCredentialFormat(ciphertext) {
+  if (typeof ciphertext !== 'string' || ciphertext.length === 0) return null
+  if (ciphertext.startsWith('enc:')) return 'enc'
+  if (ciphertext.startsWith('v1:')) return 'v1'
+  return 'unknown'
+}
+
+async function fingerprintCredential(credentialStore, ciphertext) {
+  if (!ciphertext) return null
+  return credentialStore.fingerprint(ciphertext)
+}
+
+async function publicRow(credentialStore, row) {
+  return rowToPublicExternalSystem(row, await fingerprintCredential(credentialStore, row.credentials_encrypted))
+}
+
+async function maybeEncryptCredentials(credentialStore, credentials) {
+  if (credentials === undefined) return undefined
+  if (credentials === null || credentials === '') return null
+  const plaintext = typeof credentials === 'string'
+    ? credentials
+    : JSON.stringify(credentials)
+  return credentialStore.encrypt(plaintext)
+}
+
+function createExternalSystemRegistry({ db, credentialStore, idGenerator = crypto.randomUUID } = {}) {
+  if (!db || typeof db.selectOne !== 'function' || typeof db.insertOne !== 'function' || typeof db.updateRow !== 'function') {
+    throw new Error('createExternalSystemRegistry: scoped db helper is required')
+  }
+  if (!credentialStore || typeof credentialStore.encrypt !== 'function' || typeof credentialStore.fingerprint !== 'function') {
+    throw new Error('createExternalSystemRegistry: credentialStore is required')
+  }
+
+  async function findExisting(input) {
+    if (input.id) {
+      return db.selectOne(TABLE, {
+        ...scopeWhere(input),
+        id: input.id,
+      })
+    }
+    return db.selectOne(TABLE, {
+      ...scopeWhere(input),
+      name: input.name,
+    })
+  }
+
+  async function upsertExternalSystem(input) {
+    const normalized = normalizeExternalSystemInput(input)
+    const existing = await findExisting(normalized)
+    const credentialsEncrypted = await maybeEncryptCredentials(credentialStore, normalized.credentials)
+
+    const baseRow = {
+      tenant_id: normalized.tenantId,
+      workspace_id: normalized.workspaceId,
+      project_id: normalized.projectId,
+      name: normalized.name,
+      kind: normalized.kind,
+      role: normalized.role,
+      config: normalized.config,
+      capabilities: normalized.capabilities,
+      status: normalized.status,
+      last_tested_at: normalized.lastTestedAt,
+      last_error: normalized.lastError,
+    }
+
+    if (existing) {
+      const updateRow = { ...baseRow }
+      if (credentialsEncrypted !== undefined) {
+        updateRow.credentials_encrypted = credentialsEncrypted
+      }
+      const rows = await db.updateRow(TABLE, updateRow, {
+        ...scopeWhere(normalized),
+        id: existing.id,
+      })
+      const row = Array.isArray(rows) ? rows[0] : rows?.rows?.[0]
+      return publicRow(credentialStore, row || { ...existing, ...updateRow })
+    }
+
+    const insertRow = {
+      id: normalized.id || idGenerator(),
+      ...baseRow,
+      credentials_encrypted: credentialsEncrypted === undefined ? null : credentialsEncrypted,
+    }
+    const rows = await db.insertOne(TABLE, insertRow)
+    const row = Array.isArray(rows) ? rows[0] : rows?.rows?.[0]
+    return publicRow(credentialStore, row || insertRow)
+  }
+
+  async function getExternalSystem(input) {
+    const tenantId = requiredString(input?.tenantId, 'tenantId')
+    const workspaceId = normalizeWorkspaceId(input?.workspaceId)
+    const id = requiredString(input?.id, 'id')
+    const row = await db.selectOne(TABLE, {
+      tenant_id: tenantId,
+      workspace_id: workspaceId,
+      id,
+    })
+    if (!row) {
+      throw new ExternalSystemNotFoundError('external system not found', { id, tenantId, workspaceId })
+    }
+    return publicRow(credentialStore, row)
+  }
+
+  async function listExternalSystems(input = {}) {
+    const tenantId = requiredString(input.tenantId, 'tenantId')
+    const workspaceId = normalizeWorkspaceId(input.workspaceId)
+    const where = scopeWhere({ tenantId, workspaceId })
+    if (input.kind) where.kind = requiredString(input.kind, 'kind')
+    if (input.status) {
+      const status = requiredString(input.status, 'status')
+      if (!VALID_STATUSES.has(status)) {
+        throw new ExternalSystemValidationError(`status must be one of ${Array.from(VALID_STATUSES).join(', ')}`, { field: 'status' })
+      }
+      where.status = status
+    }
+    const rows = await db.select(TABLE, {
+      where,
+      orderBy: ['created_at', 'DESC'],
+      limit: input.limit,
+      offset: input.offset,
+    })
+    const list = Array.isArray(rows) ? rows : rows?.rows ?? []
+    return Promise.all(list.map(row => publicRow(credentialStore, row)))
+  }
+
+  return {
+    upsertExternalSystem,
+    getExternalSystem,
+    listExternalSystems,
+  }
+}
+
+module.exports = {
+  createExternalSystemRegistry,
+  ExternalSystemValidationError,
+  ExternalSystemNotFoundError,
+  __internals: {
+    TABLE,
+    VALID_ROLES,
+    VALID_STATUSES,
+    detectCredentialFormat,
+    normalizeExternalSystemInput,
+    rowToPublicExternalSystem,
+  },
+}

--- a/plugins/plugin-integration-core/package.json
+++ b/plugins/plugin-integration-core/package.json
@@ -6,11 +6,12 @@
   "license": "UNLICENSED",
   "private": true,
   "scripts": {
-    "test": "node __tests__/plugin-runtime-smoke.test.cjs && node --import tsx __tests__/host-loader-smoke.test.mjs && node __tests__/credential-store.test.cjs && node __tests__/db.test.cjs && node __tests__/staging-installer.test.cjs && node __tests__/migration-sql.test.cjs",
+    "test": "node __tests__/plugin-runtime-smoke.test.cjs && node --import tsx __tests__/host-loader-smoke.test.mjs && node __tests__/credential-store.test.cjs && node __tests__/db.test.cjs && node __tests__/external-systems.test.cjs && node __tests__/staging-installer.test.cjs && node __tests__/migration-sql.test.cjs",
     "test:runtime": "node __tests__/plugin-runtime-smoke.test.cjs",
     "test:host-loader": "node --import tsx __tests__/host-loader-smoke.test.mjs",
     "test:credential": "node __tests__/credential-store.test.cjs",
     "test:db": "node __tests__/db.test.cjs",
+    "test:external-systems": "node __tests__/external-systems.test.cjs",
     "test:staging": "node __tests__/staging-installer.test.cjs",
     "test:migration": "node __tests__/migration-sql.test.cjs"
   }


### PR DESCRIPTION
## Summary

Add the M1 external-system registry seam for `plugin-integration-core`.

- Adds `lib/external-systems.cjs` for scoped CRUD against `integration_external_systems`.
- Encrypts incoming credentials through the existing host-backed credential store.
- Returns only safe credential metadata: `hasCredentials`, `credentialFormat`, and `credentialFingerprint`; never plaintext or `credentials_encrypted`.
- Wires `upsertExternalSystem`, `getExternalSystem`, and `listExternalSystems` into the `integration-core` communication namespace.
- Extends runtime/host-loader smoke tests and package test script.
- Adds design and verification MDs for the seam and known trade-offs.

## Verification

```bash
pnpm -F plugin-integration-core test
node plugins/plugin-integration-core/__tests__/external-systems.test.cjs
node --import tsx scripts/validate-plugin-manifests.ts
pnpm --filter @metasheet/core-backend exec vitest run tests/unit/plugin-runtime-security.test.ts tests/unit/plugin-runtime-teardown.test.ts --reporter=dot
pnpm --filter @metasheet/core-backend exec tsc --noEmit
```

## Notes

- No REST/UI surface is added in this slice.
- No decrypted credential handoff API is exposed.
- The current implementation uses `selectOne -> insertOne/updateRow`; concurrent same-scope same-name creates rely on the DB unique index for race rejection until a scoped DB upsert helper exists.