### PR TITLE
fix(integration): harden external system registry boundaries

### DIFF
--- a/docs/development/integration-core-external-systems-registry-design-20260424.md
+++ b/docs/development/integration-core-external-systems-registry-design-20260424.md
@@ -71,7 +71,10 @@ Rules:
 - `config` and `capabilities` default to `{}`.
 - `credentials === undefined` preserves an existing credential on update.
 - `credentials === null` clears the stored credential.
-- object credentials are JSON-stringified before encryption.
+- Plain object credentials are JSON-stringified before encryption.
+- Credential arrays, dates, booleans, numbers, and other non-plain-object values
+  are rejected before encryption so accidental input shapes do not get silently
+  persisted.
 
 ## Public Output
 
@@ -96,14 +99,19 @@ No API in this slice returns decrypted credentials.
 
 - `enc` means the value was written by the host-backed platform security service.
 - `v1` means the row still contains a legacy plugin-local credential value.
-- `unknown` means a non-empty value exists but does not match a known prefix.
-- `null` means no credential is stored.
+- `null` means no credential is stored or the stored value has an unrecognized
+  prefix. Unknown encrypted payload prefixes are intentionally not surfaced as a
+  third public state.
 
 ## Trade-Offs
 
 This slice uses `selectOne -> insertOne/updateRow` instead of a database-native upsert because `db.cjs` intentionally has no raw SQL escape hatch and no scoped `upsert` primitive yet.
 
 That means concurrent same-scope same-name creates can race and rely on the database unique index to reject one writer. This is acceptable for the current seam. If external system registration becomes high-traffic or user-facing, add a validated `upsertByUnique()` helper to `db.cjs` rather than introducing raw SQL.
+
+The update path treats an empty `db.updateRow()` result as a lost-update race
+and throws `ExternalSystemNotFoundError` instead of returning an optimistic
+success shape.
 
 ## Deferred
 

--- a/docs/development/integration-core-external-systems-registry-verification-20260424.md
+++ b/docs/development/integration-core-external-systems-registry-verification-20260424.md
@@ -35,12 +35,20 @@ pnpm --filter @metasheet/core-backend exec tsc --noEmit
 - `upsertExternalSystem()` validates required tenant/name/kind fields.
 - `role` rejects values outside `source | target | bidirectional`.
 - `status` rejects values outside `active | inactive | error`.
+- `credentials` accepts only string, plain object, `null`, or `undefined`.
+- Credential arrays, dates, booleans, and numbers are rejected before encryption.
 - New rows encrypt `credentials` and store only `credentials_encrypted`.
 - Public result never contains plaintext credentials.
 - Public result never contains `credentials_encrypted`.
 - Public result exposes only coarse credential metadata: `hasCredentials`, `credentialFormat`, and `credentialFingerprint`.
+- Unknown stored credential prefixes map to `credentialFormat: null` rather than
+  adding an undocumented public format.
 - Updating without `credentials` preserves the stored credential.
 - Updating with `credentials: null` clears the stored credential.
+- A missing `db.select()` helper is rejected at registry construction because
+  `listExternalSystems()` requires it.
+- An empty `db.updateRow()` result during update throws
+  `ExternalSystemNotFoundError` instead of returning an optimistic success row.
 - `getExternalSystem()` returns safe public shape and throws `ExternalSystemNotFoundError` when absent.
 - `listExternalSystems()` scopes by tenant/workspace and supports `kind` filtering.
 - `workspaceId` scoping keeps `null` and another workspace isolated.

--- a/plugins/plugin-integration-core/__tests__/external-systems.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/external-systems.test.cjs
@@ -6,6 +6,7 @@ const {
   createExternalSystemRegistry,
   ExternalSystemNotFoundError,
   ExternalSystemValidationError,
+  __internals,
 } = require(path.join(__dirname, '..', 'lib', 'external-systems.cjs'))
 
 function createMockCredentialStore() {
@@ -150,7 +151,40 @@ async function main() {
   assert.equal(cleared.hasCredentials, false)
   assert.equal(cleared.credentialFormat, null)
 
-  // --- 5. Not-found and validation errors -------------------------------
+  // --- 5. Credential input and format boundaries ------------------------
+  for (const invalidCredentials of [123, true, ['token'], new Date('2026-04-24T00:00:00.000Z')]) {
+    let badCredentials = null
+    try {
+      await registry.upsertExternalSystem({
+        tenantId: 'tenant_1',
+        name: `bad-${typeof invalidCredentials}`,
+        kind: 'http',
+        credentials: invalidCredentials,
+      })
+    } catch (error) {
+      badCredentials = error
+    }
+    assert.ok(badCredentials instanceof ExternalSystemValidationError, 'invalid credential shape rejected')
+  }
+
+  db.rows.push({
+    id: 'sys_unknown',
+    tenant_id: 'tenant_1',
+    workspace_id: null,
+    project_id: null,
+    name: 'unknown credential',
+    kind: 'http',
+    role: 'source',
+    config: {},
+    capabilities: {},
+    status: 'active',
+    credentials_encrypted: 'legacy:opaque',
+  })
+  const unknownCredentialRows = await registry.listExternalSystems({ tenantId: 'tenant_1', workspaceId: null, kind: 'http' })
+  assert.equal(unknownCredentialRows[0].credentialFormat, null, 'unknown credential prefixes map to null')
+  assert.equal(__internals.detectCredentialFormat('legacy:opaque'), null)
+
+  // --- 6. Not-found and validation errors -------------------------------
   let notFound = null
   try {
     await registry.getExternalSystem({ tenantId: 'tenant_1', id: 'missing' })
@@ -179,6 +213,47 @@ async function main() {
     badShape = error
   }
   assert.ok(badShape, 'bad credential store shape rejected')
+
+  const dbWithoutSelect = { ...db }
+  delete dbWithoutSelect.select
+  let badDb = null
+  try {
+    createExternalSystemRegistry({ db: dbWithoutSelect, credentialStore })
+  } catch (error) {
+    badDb = error
+  }
+  assert.ok(badDb, 'db helper without select rejected')
+
+  const raceDb = createMockDb()
+  const raceRegistry = createExternalSystemRegistry({
+    db: {
+      ...raceDb,
+      async updateRow(table, set, where) {
+        raceDb.calls.push(['updateRow', table, { ...set }, { ...where }])
+        return []
+      },
+    },
+    credentialStore,
+    idGenerator: () => 'race_1',
+  })
+  await raceRegistry.upsertExternalSystem({
+    tenantId: 'tenant_1',
+    name: 'race',
+    kind: 'http',
+  })
+  let updateRace = null
+  try {
+    await raceRegistry.upsertExternalSystem({
+      tenantId: 'tenant_1',
+      id: 'race_1',
+      name: 'race',
+      kind: 'http',
+      status: 'active',
+    })
+  } catch (error) {
+    updateRace = error
+  }
+  assert.ok(updateRace instanceof ExternalSystemNotFoundError, 'empty update result is not reported as success')
 
   console.log('✓ external-systems: registry + credential boundary tests passed')
 }

--- a/plugins/plugin-integration-core/lib/external-systems.cjs
+++ b/plugins/plugin-integration-core/lib/external-systems.cjs
@@ -124,7 +124,7 @@ function detectCredentialFormat(ciphertext) {
   if (typeof ciphertext !== 'string' || ciphertext.length === 0) return null
   if (ciphertext.startsWith('enc:')) return 'enc'
   if (ciphertext.startsWith('v1:')) return 'v1'
-  return 'unknown'
+  return null
 }
 
 async function fingerprintCredential(credentialStore, ciphertext) {
@@ -133,20 +133,36 @@ async function fingerprintCredential(credentialStore, ciphertext) {
 }
 
 async function publicRow(credentialStore, row) {
+  if (!row) return null
   return rowToPublicExternalSystem(row, await fingerprintCredential(credentialStore, row.credentials_encrypted))
+}
+
+function isPlainObject(value) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
 }
 
 async function maybeEncryptCredentials(credentialStore, credentials) {
   if (credentials === undefined) return undefined
   if (credentials === null || credentials === '') return null
-  const plaintext = typeof credentials === 'string'
-    ? credentials
-    : JSON.stringify(credentials)
-  return credentialStore.encrypt(plaintext)
+  if (typeof credentials === 'string') {
+    return credentialStore.encrypt(credentials)
+  }
+  if (isPlainObject(credentials)) {
+    return credentialStore.encrypt(JSON.stringify(credentials))
+  }
+  throw new ExternalSystemValidationError('credentials must be a string, a plain object, or null', { field: 'credentials' })
 }
 
 function createExternalSystemRegistry({ db, credentialStore, idGenerator = crypto.randomUUID } = {}) {
-  if (!db || typeof db.selectOne !== 'function' || typeof db.insertOne !== 'function' || typeof db.updateRow !== 'function') {
+  if (
+    !db ||
+    typeof db.selectOne !== 'function' ||
+    typeof db.insertOne !== 'function' ||
+    typeof db.updateRow !== 'function' ||
+    typeof db.select !== 'function'
+  ) {
     throw new Error('createExternalSystemRegistry: scoped db helper is required')
   }
   if (!credentialStore || typeof credentialStore.encrypt !== 'function' || typeof credentialStore.fingerprint !== 'function') {
@@ -195,7 +211,14 @@ function createExternalSystemRegistry({ db, credentialStore, idGenerator = crypt
         id: existing.id,
       })
       const row = Array.isArray(rows) ? rows[0] : rows?.rows?.[0]
-      return publicRow(credentialStore, row || { ...existing, ...updateRow })
+      if (!row) {
+        throw new ExternalSystemNotFoundError('external system not found during update', {
+          id: existing.id,
+          tenantId: normalized.tenantId,
+          workspaceId: normalized.workspaceId,
+        })
+      }
+      return publicRow(credentialStore, row)
     }
 
     const insertRow = {


### PR DESCRIPTION
## Summary

Supersedes #1146 as a clean follow-up to #1145. #1145 already merged the external system registry seam; this PR carries only the review hardening delta on top of current `main`.

Changes:
- Guard `publicRow()` against null/undefined rows.
- Require the database facade to provide `select` as well as the existing CRUD methods.
- Tighten credential normalization to only accept string, plain-object, null, or undefined credentials before host encryption.
- Treat unknown credential envelope prefixes as `credentialFormat: null` instead of leaking misleading metadata.
- Treat empty `db.updateRow()` results as `ExternalSystemNotFoundError`.
- Update the external-system design and verification notes with the hardened credential/read/update boundaries.

## Verification

Run from a clean branch based on `5727a6f7a` (`main` after #1145):

```bash
node --check plugins/plugin-integration-core/lib/external-systems.cjs
node --check plugins/plugin-integration-core/__tests__/external-systems.test.cjs
git diff --check origin/main..HEAD
node plugins/plugin-integration-core/__tests__/external-systems.test.cjs
pnpm -F plugin-integration-core test:external-systems
pnpm -F plugin-integration-core test
```

Results:
- external-systems registry + credential boundary tests passed
- plugin-integration-core full test script passed
- syntax and whitespace checks passed

## Notes

This PR intentionally avoids the duplicate M1-PR1 content still present in #1146. After this PR is opened, #1146 should be closed as superseded.