### PR TITLE
feat(integration): add adapter contract and http adapter

### DIFF
--- a/docs/development/integration-core-adapter-contracts-design-20260424.md
+++ b/docs/development/integration-core-adapter-contracts-design-20260424.md
@@ -1,0 +1,154 @@
+# Integration Core Adapter Contracts Design - 2026-04-24
+
+## Context
+
+M1-PR1 adds the external-system registry. The next backend slice needs a stable
+internal adapter shape before the pipeline runner can read PLM/API/DB sources
+and write ERP/API/DB targets.
+
+This PR keeps the adapter surface local to `plugin-integration-core`. It does
+not expose a platform-wide plugin adapter API yet, because K3 WISE and Yuantus
+PLM still need PoC validation before the contract should be made public.
+
+## Decision
+
+Add two plugin-local modules:
+
+- `plugins/plugin-integration-core/lib/contracts.cjs`
+- `plugins/plugin-integration-core/lib/adapters/http-adapter.cjs`
+
+The adapter contract has five methods:
+
+```js
+testConnection(input?)
+listObjects(input?)
+getSchema(input?)
+read(input)
+upsert(input)
+```
+
+Every registered adapter must implement all five methods. Unsupported
+operations must fail with `UnsupportedAdapterOperationError` instead of leaving
+methods undefined. This keeps the future runner simple: it can dispatch a known
+method set and handle typed failures.
+
+## Contract Normalization
+
+`contracts.cjs` owns the shared normalization and result shapes:
+
+- `normalizeExternalSystemForAdapter(system)`
+- `normalizeReadRequest(input)`
+- `normalizeUpsertRequest(input)`
+- `createReadResult(result)`
+- `createUpsertResult(result)`
+- `createAdapterRegistry()`
+
+Read requests normalize to:
+
+```js
+{
+  object,
+  limit,
+  cursor,
+  filters,
+  watermark,
+  options
+}
+```
+
+Upsert requests normalize to:
+
+```js
+{
+  object,
+  records,
+  keyFields,
+  mode,
+  options
+}
+```
+
+The default read limit is `1000`; the hard cap is `10000`.
+
+## HTTP Adapter
+
+`http-adapter.cjs` is config-driven and dependency-injectable:
+
+```js
+createHttpAdapter({
+  system,
+  fetchImpl,
+  logger
+})
+```
+
+The adapter reads from `system.config`:
+
+```js
+{
+  baseUrl,
+  healthPath,
+  headers,
+  apiKeyHeader,
+  timeoutMs,
+  objects: {
+    materials: {
+      path,
+      upsertPath,
+      recordsPath,
+      nextCursorPath,
+      schema,
+      operations
+    }
+  }
+}
+```
+
+Credentials are not read from storage by the adapter. The current runner loads
+systems through `getExternalSystemForAdapter()` when available, so adapters
+receive hydrated `system.credentials` while public registry reads remain safe.
+Supported credential header mappings are:
+
+- `bearerToken` -> `Authorization: Bearer ...`
+- `apiKey` -> configurable header, default `X-API-Key`
+- `username/password` -> basic auth
+
+## Runtime Exposure
+
+`index.cjs` now creates an adapter registry during activation and registers:
+
+```js
+http
+```
+
+The `integration-core` communication namespace exposes:
+
+```js
+listAdapterKinds()
+```
+
+`getStatus()` includes:
+
+```json
+{
+  "adapters": ["http"]
+}
+```
+
+No runtime API in this slice executes arbitrary adapter reads or writes. Runner
+execution is intentionally deferred to the next PR.
+
+## Trade-Offs
+
+- The HTTP adapter is intentionally generic but not a full API designer.
+- It supports path-based record/cursor extraction, not arbitrary user JS.
+- It relies on injected `fetch` for tests and Node global `fetch` at runtime.
+- It validates base URLs as `http` or `https` and rejects absolute object paths
+  so object configs cannot silently escape the configured base URL.
+
+## Deferred
+
+- Pipeline runner dispatch.
+- Postgres/MySQL/Yuantus PLM/K3 WISE concrete adapters.
+- REST endpoints for adapter test/read/upsert.
+- Backoff/retry/rate-limit behavior for live HTTP systems.

--- a/docs/development/integration-core-adapter-contracts-verification-20260424.md
+++ b/docs/development/integration-core-adapter-contracts-verification-20260424.md
@@ -1,0 +1,81 @@
+# Integration Core Adapter Contracts Verification - 2026-04-24
+
+## Scope
+
+Verify M1-PR2 for `plugin-integration-core`:
+
+- Adapter registry enforces the required method contract.
+- Read/upsert request normalizers provide stable runner inputs.
+- HTTP adapter can test, list objects, read, and upsert through injected `fetch`.
+- Runtime status exposes the registered adapter kind.
+- Plugin manifest remains valid.
+
+This branch is based after M1-PR1 / PR #1145, which introduced the external
+system registry.
+
+## Commands Run
+
+```bash
+pnpm -F plugin-integration-core test
+pnpm validate:plugins
+node --import tsx scripts/validate-plugin-manifests.ts
+```
+
+## Results
+
+- `plugin-integration-core` package tests: passed, including 10 plugin-local
+  smoke/unit checks.
+- New `adapter-contracts.test.cjs`: passed.
+- New `http-adapter.test.cjs`: passed.
+- `node --import tsx scripts/validate-plugin-manifests.ts`: passed, 13/13 valid
+  plugin manifests, 0 errors.
+- `pnpm validate:plugins`: failed in this sandbox with the known `tsx` IPC
+  `listen EPERM` issue before validation logic ran.
+
+## Covered Behaviors
+
+`adapter-contracts.test.cjs` covers:
+
+- registering adapter factories by kind.
+- duplicate kind rejection unless `replace: true`.
+- factory output validation for required methods.
+- unknown adapter kind typed failure.
+- read request normalization and limit capping.
+- upsert request normalization and record validation.
+- read/upsert result shape helpers.
+- unsupported operation helper typed failure.
+
+`http-adapter.test.cjs` covers:
+
+- `testConnection()` calls `healthPath`.
+- static headers and credential-derived headers are applied.
+- `listObjects()` reflects configured objects.
+- `getSchema()` returns configured schema fields.
+- `read()` sends limit, cursor, filters, and watermark query params.
+- `read()` extracts nested records and next cursor.
+- `upsert()` posts normalized records and key fields.
+- read-only object rejects `upsert()`.
+- non-HTTP base URLs are rejected.
+- non-2xx HTTP responses throw `HttpAdapterError`.
+
+Runtime smoke tests cover:
+
+- `getStatus().adapters` is self-consistent with `listAdapterKinds()` when
+  adapters are registered.
+- communication namespace exposes `listAdapterKinds()` when adapter registry
+  wiring is present.
+
+For a PR2-only branch, hunk staging should leave only the generic `http`
+adapter registered, so `getStatus().adapters` should evaluate to `['http']`.
+The shared smoke tests intentionally avoid hard-coding this final value because
+later stacked slices add K3 WISE and PLM adapters.
+
+## Not Covered
+
+- Live external HTTP systems.
+- Pipeline runner dispatch.
+- PR2-only adapter tests do not decrypt stored credentials. The current stacked
+  integration-core path covers credential handoff through registry and runner
+  tests.
+- K3 WISE, PLM, Postgres, SQL Server, and MySQL adapters.
+- Retry/backoff/rate-limit behavior.

--- a/docs/development/integration-core-pr2-adapter-shared-file-slicing-design-20260425.md
+++ b/docs/development/integration-core-pr2-adapter-shared-file-slicing-design-20260425.md
@@ -1,0 +1,145 @@
+# Integration Core PR2 Adapter Shared File Slicing Design - 2026-04-25
+
+## Context
+
+PR2 introduces the plugin-local adapter contract and the generic HTTP adapter.
+It should build on PR1 external systems, but it should not include pipeline,
+REST control plane, K3 WISE, PLM, or ERP feedback code.
+
+The current working tree is stacked beyond PR2, so the main risk is again in
+shared runtime files:
+
+```text
+plugins/plugin-integration-core/index.cjs
+plugins/plugin-integration-core/package.json
+plugins/plugin-integration-core/__tests__/plugin-runtime-smoke.test.cjs
+plugins/plugin-integration-core/__tests__/host-loader-smoke.test.mjs
+```
+
+## PR2-Owned Files
+
+Include these new files:
+
+```text
+plugins/plugin-integration-core/lib/contracts.cjs
+plugins/plugin-integration-core/lib/adapters/http-adapter.cjs
+plugins/plugin-integration-core/__tests__/adapter-contracts.test.cjs
+plugins/plugin-integration-core/__tests__/http-adapter.test.cjs
+docs/development/integration-core-adapter-contracts-design-20260424.md
+docs/development/integration-core-adapter-contracts-verification-20260424.md
+```
+
+## Shared-File Include Rules
+
+### `index.cjs`
+
+Include:
+
+- `createAdapterRegistry`.
+- `createHttpAdapterFactory`.
+- module state: `adapterRegistry`.
+- `getStatus().adapters`.
+- communication method: `listAdapterKinds()`.
+- activation wiring:
+
+```js
+adapterRegistry = createAdapterRegistry({ logger })
+  .registerAdapter('http', createHttpAdapterFactory())
+```
+
+- deactivate cleanup: `adapterRegistry = null`.
+- milestone may move to an adapter-contract milestone such as
+  `M1-adapter-contracts`.
+
+Exclude:
+
+- Yuantus PLM wrapper registration.
+- K3 WISE WebAPI or SQL Server adapter registration.
+- pipeline registry.
+- dead-letter, watermark, run-log, runner.
+- ERP feedback writer.
+- integration REST route registration beyond health.
+- pipeline CRUD, run, dry-run, dead-letter replay communication methods.
+
+### `package.json`
+
+Include:
+
+```text
+test:adapter-contracts
+test:http-adapter
+```
+
+The main `test` script may include those two tests once PR2 lands.
+
+Exclude later scripts until their own PRs land:
+
+```text
+test:pipelines
+test:transform-validator
+test:runner-support
+test:pipeline-runner
+test:http-routes
+test:k3-wise-adapters
+test:erp-feedback
+test:plm-yuantus-wrapper
+test:e2e-plm-k3wise-writeback
+test:payload-redaction
+```
+
+### Shared Smoke Tests
+
+The shared smoke tests should remain generic:
+
+- require the health route and communication namespace.
+- require PR1 external-system communication methods.
+- if `getStatus().adapters` is non-empty, require `listAdapterKinds()` and
+  assert it equals `getStatus().adapters`.
+- do not hard-code `['http']` in the generic smoke tests.
+- do not assert K3, PLM, pipeline, runner, REST route count, or ERP feedback in
+  the generic smoke tests.
+
+The exact `http` adapter behavior is covered by `adapter-contracts.test.cjs`
+and `http-adapter.test.cjs`.
+
+For a PR2-only branch, add a PR2-specific assertion that the runtime adapter
+list includes exactly `http` if the branch does not already have another focused
+runtime wiring check. Keep that assertion local to PR2 staging so later stacked
+branches can extend the list without rewriting the generic smoke contract.
+
+## Runtime Boundary
+
+PR2 may expose the adapter registry through status and communication, but it
+must not execute adapter reads or writes from runtime routes. Execution belongs
+to the later runner and REST control-plane slices.
+
+## Verification Strategy
+
+For the current stacked working tree:
+
+```bash
+pnpm -F plugin-integration-core test:adapter-contracts
+pnpm -F plugin-integration-core test:http-adapter
+pnpm -F plugin-integration-core test:runtime
+pnpm -F plugin-integration-core test:host-loader
+pnpm -F plugin-integration-core test
+node --import tsx scripts/validate-plugin-manifests.ts
+git diff --check
+```
+
+For a PR2-only branch after hunk staging:
+
+```bash
+pnpm -F plugin-integration-core test:adapter-contracts
+pnpm -F plugin-integration-core test:http-adapter
+pnpm -F plugin-integration-core test:runtime
+pnpm -F plugin-integration-core test:host-loader
+node --import tsx scripts/validate-plugin-manifests.ts
+git diff --check
+```
+
+## Notes
+
+- Do not include `output/delivery/*` or `docs/development/parallel-delivery-*`.
+- Do not include K3 WISE or PLM adapter files in PR2.
+- Do not include the pipeline runner or REST control-plane files in PR2.

--- a/docs/development/integration-core-pr2-adapter-shared-file-slicing-verification-20260425.md
+++ b/docs/development/integration-core-pr2-adapter-shared-file-slicing-verification-20260425.md
@@ -1,0 +1,174 @@
+# Integration Core PR2 Adapter Shared File Slicing Verification - 2026-04-25
+
+## Scope
+
+Verify that the PR2 adapter-contract slice has a documented split boundary and
+that the current stacked implementation still passes targeted and full plugin
+checks after the shared smoke tests were made layer-friendly.
+
+## Assertions
+
+- PR2-owned files are documented.
+- Shared-file include/exclude rules are documented for `index.cjs`,
+  `package.json`, and smoke tests.
+- Generic smoke tests do not hard-code `['http']` or the final stacked adapter
+  list.
+- Generic smoke tests check adapter status self-consistency when adapters are
+  present.
+- Generic smoke tests do not assert pipeline or runner communication methods.
+- Adapter contract tests pass.
+- HTTP adapter tests pass.
+- Runtime and host-loader smoke tests pass.
+- Full plugin tests pass.
+- Plugin manifests remain valid.
+- The diff has no whitespace errors.
+
+## Commands
+
+```bash
+rg -n "PR2-Owned Files|createAdapterRegistry|createHttpAdapterFactory|listAdapterKinds|Exclude|do not hard-code|test:adapter-contracts|test:http-adapter" \
+  docs/development/integration-core-pr2-adapter-shared-file-slicing-design-20260425.md
+
+rg -n "comm api adapter kinds match status|status\\.adapters|listAdapterKinds|erp:k3-wise|plm:yuantus-wrapper|\\['http'\\]" \
+  plugins/plugin-integration-core/__tests__/plugin-runtime-smoke.test.cjs \
+  plugins/plugin-integration-core/__tests__/host-loader-smoke.test.mjs \
+  docs/development/integration-core-adapter-contracts-verification-20260424.md
+
+pnpm -F plugin-integration-core test:adapter-contracts
+pnpm -F plugin-integration-core test:http-adapter
+pnpm -F plugin-integration-core test:runtime
+pnpm -F plugin-integration-core test:host-loader
+pnpm -F plugin-integration-core test
+
+node --import tsx scripts/validate-plugin-manifests.ts
+
+git diff --check
+```
+
+## Results
+
+### Document Shape
+
+Passed.
+
+`rg` confirmed the design document includes:
+
+- PR2-owned files.
+- `createAdapterRegistry`.
+- `createHttpAdapterFactory`.
+- `listAdapterKinds`.
+- explicit PR3+ exclusions.
+- PR2 validation commands for `test:adapter-contracts` and `test:http-adapter`.
+
+### Smoke Test Shape
+
+Passed.
+
+`rg` confirmed:
+
+- generic smoke tests compare adapter status with `listAdapterKinds()`.
+- generic smoke tests do not hard-code the final K3/PLM adapter list.
+- the adapter-contract verification document now states that a PR2-only branch
+  should evaluate to `['http']`, while the generic smoke test remains
+  self-consistency based for stacked branches.
+
+After the parallel review, shared smoke tests were further tightened so
+pipeline and runner communication assertions are no longer present in generic
+runtime smoke files.
+
+### Targeted PR2 Tests
+
+Passed.
+
+Commands:
+
+```bash
+pnpm -F plugin-integration-core test:adapter-contracts
+pnpm -F plugin-integration-core test:http-adapter
+pnpm -F plugin-integration-core test:runtime
+pnpm -F plugin-integration-core test:host-loader
+```
+
+Results:
+
+- `adapter-contracts`: passed.
+- `http-adapter`: passed.
+- `plugin-runtime-smoke`: passed.
+- `host-loader-smoke`: passed.
+
+### Full Plugin Test Suite
+
+Passed.
+
+Command:
+
+```bash
+pnpm -F plugin-integration-core test
+```
+
+Result:
+
+- `plugin-runtime-smoke`: passed.
+- `host-loader-smoke`: passed.
+- `credential-store`: passed, 10 scenarios.
+- `db.cjs`: passed.
+- `external-systems`: passed.
+- `adapter-contracts`: passed.
+- `http-adapter`: passed.
+- `plm-yuantus-wrapper`: passed.
+- `k3-wise-adapters`: passed.
+- `erp-feedback`: passed.
+- `pipelines`: passed.
+- `transform-validator`: passed.
+- `runner-support`: passed.
+- `payload-redaction`: passed.
+- `pipeline-runner`: passed.
+- `e2e-plm-k3wise-writeback`: passed.
+- `http-routes`: passed.
+- `staging-installer`: passed.
+- `migration-sql`: passed.
+
+### Manifest Validation
+
+Passed.
+
+Command:
+
+```bash
+node --import tsx scripts/validate-plugin-manifests.ts
+```
+
+Result:
+
+- found 16 plugin directories.
+- 13 manifests valid.
+- 0 invalid manifests.
+- 0 errors.
+- 10 warnings from unrelated existing plugins.
+- `plugin-integration-core`: valid.
+
+### Diff Check
+
+Passed.
+
+Command:
+
+```bash
+git diff --check
+```
+
+Result: no whitespace errors.
+
+## Parallel Review Notes
+
+A read-only parallel review confirmed the PR2 split:
+
+- include only `contracts.cjs`, `http-adapter.cjs`, their tests, and the PR2
+  adapter docs.
+- in shared files, include only adapter registry wiring, HTTP adapter
+  registration, `getStatus().adapters`, `listAdapterKinds()`, PR2 test scripts,
+  and adapter self-consistency smoke checks.
+- exclude PLM, K3 WISE, pipeline registry, dead-letter, watermark, run-log,
+  runner, ERP feedback, REST control plane, and their tests/scripts.
+- for a PR2-only branch, add or preserve a focused runtime assertion that the
+  adapter list is exactly `['http']`.

--- a/plugins/plugin-integration-core/__tests__/adapter-contracts.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/adapter-contracts.test.cjs
@@ -1,0 +1,122 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const path = require('node:path')
+const {
+  AdapterContractError,
+  AdapterValidationError,
+  UnsupportedAdapterOperationError,
+  createAdapterRegistry,
+  createReadResult,
+  createUpsertResult,
+  normalizeReadRequest,
+  normalizeUpsertRequest,
+  unsupportedAdapterOperation,
+} = require(path.join(__dirname, '..', 'lib', 'contracts.cjs'))
+
+function createCompleteAdapter() {
+  return {
+    async testConnection() { return { ok: true } },
+    async listObjects() { return [] },
+    async getSchema() { return { fields: [] } },
+    async read() { return createReadResult({ records: [] }) },
+    async upsert() { return createUpsertResult({ written: 0 }) },
+  }
+}
+
+async function main() {
+  // --- 1. Registry accepts complete adapter factories -------------------
+  const registry = createAdapterRegistry()
+  registry.registerAdapter('http', ({ system }) => ({
+    ...createCompleteAdapter(),
+    systemId: system.id,
+  }))
+
+  assert.deepEqual(registry.listAdapterKinds(), ['http'])
+  const adapter = registry.createAdapter({
+    id: 'sys_http',
+    name: 'HTTP PLM',
+    kind: 'http',
+    config: { baseUrl: 'https://plm.example.test' },
+  })
+  assert.equal(adapter.systemId, 'sys_http')
+
+  // --- 2. Registry rejects duplicate kinds unless replace is explicit ----
+  let duplicate = null
+  try {
+    registry.registerAdapter('http', () => createCompleteAdapter())
+  } catch (error) {
+    duplicate = error
+  }
+  assert.ok(duplicate instanceof AdapterValidationError, 'duplicate adapter kind rejected')
+
+  registry.registerAdapter('http', () => createCompleteAdapter(), { replace: true })
+  assert.deepEqual(registry.listAdapterKinds(), ['http'])
+
+  // --- 3. Factory output must satisfy the full adapter contract ----------
+  registry.registerAdapter('broken', () => ({ testConnection: async () => ({ ok: true }) }))
+  let broken = null
+  try {
+    registry.createAdapter({ kind: 'broken', config: {} })
+  } catch (error) {
+    broken = error
+  }
+  assert.ok(broken instanceof AdapterContractError, 'missing adapter methods rejected')
+  assert.match(broken.message, /missing listObjects/)
+
+  // --- 4. Unknown kinds throw a typed unsupported error ------------------
+  let unknown = null
+  try {
+    registry.createAdapter({ kind: 'erp:k3-wise-webapi', config: {} })
+  } catch (error) {
+    unknown = error
+  }
+  assert.ok(unknown instanceof UnsupportedAdapterOperationError, 'unknown adapter kind rejected')
+
+  // --- 5. Request/result normalizers keep runner inputs predictable ------
+  const read = normalizeReadRequest({
+    object: 'materials',
+    limit: 50000,
+    cursor: 'c1',
+    filters: { status: 'approved' },
+    watermark: { updated_at: '2026-04-24T00:00:00Z' },
+  })
+  assert.equal(read.object, 'materials')
+  assert.equal(read.limit, 10000, 'read limit is capped')
+  assert.equal(read.cursor, 'c1')
+  assert.deepEqual(read.filters, { status: 'approved' })
+
+  const upsert = normalizeUpsertRequest({
+    object: 'materials',
+    records: [{ code: 'A-01' }],
+    keyFields: ['code'],
+  })
+  assert.deepEqual(upsert.records, [{ code: 'A-01' }])
+  assert.deepEqual(upsert.keyFields, ['code'])
+  assert.equal(upsert.mode, 'upsert')
+
+  const readResult = createReadResult({ records: [{ code: 'A-01' }], nextCursor: null })
+  assert.equal(readResult.done, true)
+  assert.equal(readResult.records.length, 1)
+
+  const upsertResult = createUpsertResult({ written: 1, results: [{ id: 'k3_1' }] })
+  assert.equal(upsertResult.written, 1)
+  assert.equal(upsertResult.failed, 0)
+
+  // --- 6. Unsupported operation helper preserves typed failures ----------
+  let unsupported = null
+  try {
+    await unsupportedAdapterOperation('http', 'stream')()
+  } catch (error) {
+    unsupported = error
+  }
+  assert.ok(unsupported instanceof UnsupportedAdapterOperationError, 'unsupported operation throws typed error')
+
+  console.log('✓ adapter-contracts: registry + normalizer tests passed')
+}
+
+main().catch((err) => {
+  console.error('✗ adapter-contracts FAILED')
+  console.error(err)
+  process.exit(1)
+})

--- a/plugins/plugin-integration-core/__tests__/host-loader-smoke.test.mjs
+++ b/plugins/plugin-integration-core/__tests__/host-loader-smoke.test.mjs
@@ -98,13 +98,13 @@ async function main() {
   const host = createHostContext()
   await loaded.plugin.activate(host.context)
 
-  assert.equal(host.routes.length, 1, 'activate registers one route')
-  assert.equal(host.routes[0].method, 'GET')
-  assert.equal(host.routes[0].path, '/api/integration/health')
+  assert.ok(host.routes.length >= 1, 'activate registers at least one route')
+  const healthRoute = host.routes.find((route) => route.method === 'GET' && route.path === '/api/integration/health')
+  assert.ok(healthRoute, 'health route registered')
   assert.ok(host.namespaces.has('integration-core'), 'activate registers communication namespace')
 
   let responseBody = null
-  await host.routes[0].handler({}, { json(value) { responseBody = value } })
+  await healthRoute.handler({}, { json(value) { responseBody = value } })
   assert.equal(responseBody?.ok, true)
   assert.equal(responseBody?.plugin, 'plugin-integration-core')
 
@@ -114,10 +114,15 @@ async function main() {
 
   const status = await host.context.communication.call('integration-core', 'getStatus')
   assert.equal(status.plugin, 'plugin-integration-core')
-  assert.equal(status.routesRegistered, 1)
+  assert.equal(status.routesRegistered, host.routes.length)
   assert.deepEqual(status.credentialStore, { source: 'host-security', format: 'enc' })
   assert.equal(status.externalSystems, true)
   assert.equal(typeof host.namespaces.get('integration-core').upsertExternalSystem, 'function')
+  assert.deepEqual(status.adapters, ['http'])
+  assert.deepEqual(
+    await host.context.communication.call('integration-core', 'listAdapterKinds'),
+    ['http'],
+  )
 
   await loaded.plugin.deactivate()
   assert.ok(host.logs.some((line) => line.includes('activated')), 'activation logged')

--- a/plugins/plugin-integration-core/__tests__/http-adapter.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-adapter.test.cjs
@@ -1,0 +1,211 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const path = require('node:path')
+const {
+  AdapterValidationError,
+  UnsupportedAdapterOperationError,
+} = require(path.join(__dirname, '..', 'lib', 'contracts.cjs'))
+const {
+  HttpAdapterError,
+  createHttpAdapter,
+} = require(path.join(__dirname, '..', 'lib', 'adapters', 'http-adapter.cjs'))
+
+function jsonResponse(status, body) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    async text() {
+      return JSON.stringify(body)
+    },
+  }
+}
+
+function createFetchMock() {
+  const calls = []
+  const fetchImpl = async (url, options = {}) => {
+    const parsed = new URL(url)
+    calls.push({
+      url,
+      pathname: parsed.pathname,
+      searchParams: Object.fromEntries(parsed.searchParams.entries()),
+      options,
+      body: options.body ? JSON.parse(options.body) : undefined,
+    })
+
+    if (parsed.pathname === '/health') {
+      return jsonResponse(200, { ok: true })
+    }
+    if (parsed.pathname === '/api/materials' && options.method === 'GET') {
+      return jsonResponse(200, {
+        payload: {
+          items: [
+            { code: 'A-01', name: 'Bolt' },
+            { code: 'B-02', name: 'Nut' },
+          ],
+          next: 'cursor-2',
+        },
+      })
+    }
+    if (parsed.pathname === '/api/materials/batch' && options.method === 'POST') {
+      return jsonResponse(200, {
+        written: 2,
+        skipped: 0,
+        failed: 0,
+        results: [
+          { code: 'A-01', externalId: 'k3_1' },
+          { code: 'B-02', externalId: 'k3_2' },
+        ],
+      })
+    }
+    if (parsed.pathname === '/api/fail') {
+      return jsonResponse(500, { error: 'boom' })
+    }
+    return jsonResponse(404, { error: 'not found' })
+  }
+  return { calls, fetchImpl }
+}
+
+function createSystem(overrides = {}) {
+  return {
+    id: 'sys_http',
+    name: 'HTTP PLM',
+    kind: 'http',
+    role: 'bidirectional',
+    credentials: {
+      bearerToken: 'token-1',
+      apiKey: 'key-1',
+    },
+    config: {
+      baseUrl: 'https://plm.example.test/root/',
+      healthPath: '/health',
+      apiKeyHeader: 'X-Test-Key',
+      headers: {
+        'X-Tenant': 'tenant_1',
+      },
+      objects: {
+        materials: {
+          label: 'Materials',
+          path: '/api/materials',
+          upsertPath: '/api/materials/batch',
+          recordsPath: 'payload.items',
+          nextCursorPath: 'payload.next',
+          operations: ['read', 'upsert'],
+          schema: [
+            { name: 'code', type: 'string', required: true },
+            { name: 'name', type: 'string' },
+          ],
+        },
+        read_only: {
+          path: '/api/materials',
+          operations: ['read'],
+        },
+        failing: {
+          path: '/api/fail',
+          operations: ['read'],
+        },
+      },
+    },
+    ...overrides,
+  }
+}
+
+async function main() {
+  const { calls, fetchImpl } = createFetchMock()
+  const adapter = createHttpAdapter({
+    system: createSystem(),
+    fetchImpl,
+  })
+
+  // --- 1. testConnection uses baseUrl, headers, and credential headers ---
+  const connection = await adapter.testConnection()
+  assert.deepEqual(connection, { ok: true, status: 200 })
+  assert.equal(calls[0].pathname, '/health')
+  assert.equal(calls[0].options.headers.Authorization, 'Bearer token-1')
+  assert.equal(calls[0].options.headers['X-Test-Key'], 'key-1')
+  assert.equal(calls[0].options.headers['X-Tenant'], 'tenant_1')
+
+  // --- 2. listObjects/getSchema read local config -----------------------
+  const objects = await adapter.listObjects()
+  assert.equal(objects.length, 3)
+  assert.deepEqual(objects.find((object) => object.name === 'materials').operations, ['read', 'upsert'])
+
+  const schema = await adapter.getSchema({ object: 'materials' })
+  assert.equal(schema.object, 'materials')
+  assert.deepEqual(schema.fields.map((field) => field.name), ['code', 'name'])
+
+  // --- 3. read() parses nested records and cursor -----------------------
+  const read = await adapter.read({
+    object: 'materials',
+    limit: 25,
+    cursor: 'cursor-1',
+    filters: { status: 'approved' },
+    watermark: { updated_at: '2026-04-24T00:00:00Z' },
+  })
+  assert.equal(read.records.length, 2)
+  assert.equal(read.nextCursor, 'cursor-2')
+  assert.equal(read.done, false)
+  const readCall = calls.find((call) => call.pathname === '/api/materials' && call.options.method === 'GET')
+  assert.equal(readCall.searchParams.limit, '25')
+  assert.equal(readCall.searchParams.cursor, 'cursor-1')
+  assert.equal(readCall.searchParams.status, 'approved')
+  assert.equal(readCall.searchParams.updated_at, '2026-04-24T00:00:00Z')
+
+  // --- 4. upsert() posts normalized records and parses counts -----------
+  const upsert = await adapter.upsert({
+    object: 'materials',
+    records: [
+      { code: 'A-01', name: 'Bolt' },
+      { code: 'B-02', name: 'Nut' },
+    ],
+    keyFields: ['code'],
+  })
+  assert.equal(upsert.written, 2)
+  assert.equal(upsert.failed, 0)
+  assert.equal(upsert.results[0].externalId, 'k3_1')
+  const upsertCall = calls.find((call) => call.pathname === '/api/materials/batch' && call.options.method === 'POST')
+  assert.deepEqual(upsertCall.body.keyFields, ['code'])
+  assert.deepEqual(upsertCall.body.records.map((record) => record.code), ['A-01', 'B-02'])
+
+  // --- 5. Unsupported and invalid configs fail with typed errors --------
+  let unsupported = null
+  try {
+    await adapter.upsert({ object: 'read_only', records: [{ code: 'A-01' }] })
+  } catch (error) {
+    unsupported = error
+  }
+  assert.ok(unsupported instanceof UnsupportedAdapterOperationError, 'read-only object rejects upsert')
+
+  let invalidConfig = null
+  try {
+    createHttpAdapter({
+      system: createSystem({
+        config: {
+          baseUrl: 'file:///tmp/nope',
+          objects: {},
+        },
+      }),
+      fetchImpl,
+    })
+  } catch (error) {
+    invalidConfig = error
+  }
+  assert.ok(invalidConfig instanceof AdapterValidationError, 'non-http baseUrl rejected')
+
+  let httpFailure = null
+  try {
+    await adapter.read({ object: 'failing' })
+  } catch (error) {
+    httpFailure = error
+  }
+  assert.ok(httpFailure instanceof HttpAdapterError, 'non-2xx response rejects with HttpAdapterError')
+  assert.equal(httpFailure.status, 500)
+
+  console.log('✓ http-adapter: config-driven read/upsert tests passed')
+}
+
+main().catch((err) => {
+  console.error('✗ http-adapter FAILED')
+  console.error(err)
+  process.exit(1)
+})

--- a/plugins/plugin-integration-core/__tests__/plugin-runtime-smoke.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/plugin-runtime-smoke.test.cjs
@@ -114,9 +114,9 @@ async function main() {
   const { context, inspect } = createMockContext()
   await entry.activate(context)
 
-  assert.equal(inspect.routes.length, 1, 'exactly one route registered')
-  assert.equal(inspect.routes[0].method, 'GET', 'route method')
-  assert.equal(inspect.routes[0].path, '/api/integration/health', 'health route path')
+  assert.ok(inspect.routes.length >= 1, 'at least one route registered')
+  const healthRoute = inspect.routes.find((route) => route.method === 'GET' && route.path === '/api/integration/health')
+  assert.ok(healthRoute, 'health route registered')
 
   assert.ok(inspect.namespaces.has('integration-core'), 'integration-core namespace registered')
   const commApi = inspect.namespaces.get('integration-core')
@@ -124,7 +124,7 @@ async function main() {
   assert.equal(typeof commApi.getStatus, 'function', 'comm api exposes getStatus')
 
   // --- 4. Health route returns expected shape --------------------------
-  const healthBody = await runMockResponse(inspect.routes[0].handler)
+  const healthBody = await runMockResponse(healthRoute.handler)
   assert.equal(healthBody.ok, true, 'health.ok')
   assert.equal(healthBody.plugin, 'plugin-integration-core', 'health.plugin')
   assert.equal(typeof healthBody.ts, 'number', 'health.ts is number')
@@ -134,7 +134,7 @@ async function main() {
   assert.equal(pingResult.ok, true, 'ping.ok')
   const statusResult = await commApi.getStatus()
   assert.equal(statusResult.plugin, 'plugin-integration-core', 'status.plugin')
-  assert.equal(statusResult.routesRegistered, 1, 'status.routesRegistered')
+  assert.equal(statusResult.routesRegistered, inspect.routes.length, 'status.routesRegistered matches registered routes')
   assert.deepEqual(
     statusResult.credentialStore,
     { source: 'host-security', format: 'enc' },
@@ -146,6 +146,9 @@ async function main() {
   assert.equal(typeof commApi.upsertExternalSystem, 'function', 'comm api exposes upsertExternalSystem')
   assert.equal(typeof commApi.getExternalSystem, 'function', 'comm api exposes getExternalSystem')
   assert.equal(typeof commApi.listExternalSystems, 'function', 'comm api exposes listExternalSystems')
+  assert.equal(typeof commApi.listAdapterKinds, 'function', 'comm api exposes listAdapterKinds')
+  assert.deepEqual(statusResult.adapters, ['http'], 'PR2 registers only the generic HTTP adapter')
+  assert.deepEqual(await commApi.listAdapterKinds(), ['http'], 'comm api exposes registered adapter kinds')
 
   // --- 6. Activation logged --------------------------------------------
   const hasActivationLog = inspect.logs.some(
@@ -158,7 +161,7 @@ async function main() {
   // After deactivate, a re-activation must work with clean slate
   const { context: context2, inspect: inspect2 } = createMockContext()
   await entry.activate(context2)
-  assert.equal(inspect2.routes.length, 1, 'routes cleanly re-registered after deactivate')
+  assert.ok(inspect2.routes.length >= 1, 'routes cleanly re-registered after deactivate')
   await entry.deactivate()
 
   console.log('✓ plugin-runtime-smoke: all assertions passed')

--- a/plugins/plugin-integration-core/index.cjs
+++ b/plugins/plugin-integration-core/index.cjs
@@ -19,11 +19,14 @@ const COMMUNICATION_NAMESPACE = 'integration-core'
 const { createCredentialStore } = require('./lib/credential-store.cjs')
 const { createDb } = require('./lib/db.cjs')
 const { createExternalSystemRegistry } = require('./lib/external-systems.cjs')
+const { createAdapterRegistry } = require('./lib/contracts.cjs')
+const { createHttpAdapterFactory } = require('./lib/adapters/http-adapter.cjs')
 
 const registeredRoutes = []
 let activeContext = null
 let credentialStore = null
 let externalSystemRegistry = null
+let adapterRegistry = null
 
 function buildHealthPayload() {
   return {
@@ -50,6 +53,7 @@ function buildCommunicationApi() {
           ? { source: credentialStore.source, format: credentialStore.format }
           : null,
         externalSystems: Boolean(externalSystemRegistry),
+        adapters: adapterRegistry ? adapterRegistry.listAdapterKinds() : [],
       }
     },
     async upsertExternalSystem(input) {
@@ -63,6 +67,10 @@ function buildCommunicationApi() {
     async listExternalSystems(input) {
       if (!externalSystemRegistry) throw new Error('external system registry is not initialized')
       return externalSystemRegistry.listExternalSystems(input)
+    },
+    async listAdapterKinds() {
+      if (!adapterRegistry) throw new Error('adapter registry is not initialized')
+      return adapterRegistry.listAdapterKinds()
     },
   }
 }
@@ -83,6 +91,8 @@ module.exports = {
       db,
       credentialStore,
     })
+    adapterRegistry = createAdapterRegistry({ logger })
+      .registerAdapter('http', createHttpAdapterFactory())
 
     // --- HTTP routes ------------------------------------------------------
     context.api.http.addRoute('GET', '/api/integration/health', async (_req, res) => {
@@ -105,6 +115,7 @@ module.exports = {
     registeredRoutes.length = 0
     credentialStore = null
     externalSystemRegistry = null
+    adapterRegistry = null
     activeContext = null
     logger.info(`[${PLUGIN_ID}] deactivated`)
   },

--- a/plugins/plugin-integration-core/lib/adapters/http-adapter.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/http-adapter.cjs
@@ -1,0 +1,397 @@
+'use strict'
+
+// ---------------------------------------------------------------------------
+// HTTP adapter - plugin-integration-core
+//
+// Config-driven HTTP source/target adapter for M1. It uses injected `fetch`
+// in tests and Node's global fetch in runtime. Credentials must be provided by
+// the caller as decrypted values; this adapter never reads credential storage.
+// ---------------------------------------------------------------------------
+
+const {
+  AdapterValidationError,
+  UnsupportedAdapterOperationError,
+  createReadResult,
+  createUpsertResult,
+  normalizeExternalSystemForAdapter,
+  normalizeReadRequest,
+  normalizeUpsertRequest,
+  unsupportedAdapterOperation,
+} = require('../contracts.cjs')
+
+class HttpAdapterError extends Error {
+  constructor(message, details = {}) {
+    super(message)
+    this.name = 'HttpAdapterError'
+    this.details = details
+    this.status = details.status
+  }
+}
+
+function isPlainObject(value) {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value))
+}
+
+function toPlainObject(value, field) {
+  if (value === undefined || value === null) return {}
+  if (!isPlainObject(value)) {
+    throw new AdapterValidationError(`${field} must be an object`, { field })
+  }
+  return { ...value }
+}
+
+function normalizeBaseUrl(value) {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new AdapterValidationError('HTTP adapter requires config.baseUrl', { field: 'config.baseUrl' })
+  }
+  const url = new URL(value)
+  if (!['http:', 'https:'].includes(url.protocol)) {
+    throw new AdapterValidationError('HTTP adapter baseUrl must be http or https', { field: 'config.baseUrl' })
+  }
+  return url.toString()
+}
+
+function assertRelativePath(path, field) {
+  if (typeof path !== 'string' || path.trim().length === 0) {
+    throw new AdapterValidationError(`${field} is required`, { field })
+  }
+  const trimmed = path.trim()
+  if (/^https?:\/\//i.test(trimmed)) {
+    throw new AdapterValidationError(`${field} must be relative to baseUrl`, { field })
+  }
+  return trimmed.startsWith('/') ? trimmed : `/${trimmed}`
+}
+
+function getPath(value, path) {
+  if (!path) return value
+  return String(path).split('.').reduce((current, key) => {
+    if (current === undefined || current === null) return undefined
+    return current[key]
+  }, value)
+}
+
+function getNumberPath(value, path, fallback) {
+  const located = getPath(value, path)
+  const numeric = Number(located)
+  return Number.isFinite(numeric) ? numeric : fallback
+}
+
+function appendQuery(url, query) {
+  for (const [key, value] of Object.entries(query || {})) {
+    if (value === undefined || value === null || value === '') continue
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        if (item !== undefined && item !== null && item !== '') url.searchParams.append(key, String(item))
+      }
+      continue
+    }
+    if (['string', 'number', 'boolean'].includes(typeof value)) {
+      url.searchParams.set(key, String(value))
+    }
+  }
+}
+
+function buildUrl(baseUrl, path, query) {
+  const url = new URL(assertRelativePath(path, 'path'), baseUrl)
+  appendQuery(url, query)
+  return url.toString()
+}
+
+function normalizeHeaders(value, field) {
+  const headers = toPlainObject(value, field)
+  const normalized = {}
+  for (const [key, val] of Object.entries(headers)) {
+    if (val === undefined || val === null) continue
+    normalized[key] = String(val)
+  }
+  return normalized
+}
+
+function credentialHeaders(credentials, config) {
+  if (!isPlainObject(credentials)) return {}
+  const headers = {}
+  if (credentials.bearerToken) {
+    headers.Authorization = `Bearer ${String(credentials.bearerToken)}`
+  }
+  if (credentials.apiKey) {
+    const header = typeof config.apiKeyHeader === 'string' && config.apiKeyHeader.trim()
+      ? config.apiKeyHeader.trim()
+      : 'X-API-Key'
+    headers[header] = String(credentials.apiKey)
+  }
+  if (credentials.username && credentials.password) {
+    const raw = `${String(credentials.username)}:${String(credentials.password)}`
+    headers.Authorization = `Basic ${Buffer.from(raw, 'utf8').toString('base64')}`
+  }
+  return headers
+}
+
+function mergeHeaders(...sets) {
+  return Object.assign({}, ...sets.filter(Boolean))
+}
+
+async function parseResponseBody(response) {
+  const text = typeof response.text === 'function' ? await response.text() : ''
+  if (!text) return null
+  try {
+    return JSON.parse(text)
+  } catch {
+    return text
+  }
+}
+
+function responseOk(response) {
+  if (typeof response.ok === 'boolean') return response.ok
+  return response.status >= 200 && response.status < 300
+}
+
+function normalizeObjectConfig(objects, object) {
+  const raw = objects[object]
+  if (typeof raw === 'string') return { path: raw }
+  if (!isPlainObject(raw)) {
+    throw new AdapterValidationError(`HTTP object is not configured: ${object}`, { object })
+  }
+  return { ...raw }
+}
+
+function ensureOperation(kind, object, objectConfig, operation) {
+  if (Array.isArray(objectConfig.operations) && !objectConfig.operations.includes(operation)) {
+    throw new UnsupportedAdapterOperationError(`${kind} object ${object} does not support ${operation}`, {
+      kind,
+      object,
+      operation,
+    })
+  }
+}
+
+function normalizeObjects(config) {
+  const objects = toPlainObject(config.objects, 'config.objects')
+  const normalized = {}
+  for (const [name, value] of Object.entries(objects)) {
+    if (typeof value === 'string') {
+      normalized[name] = { path: value }
+    } else if (isPlainObject(value)) {
+      normalized[name] = { ...value }
+    } else {
+      throw new AdapterValidationError(`config.objects.${name} must be a path string or object`, {
+        field: `config.objects.${name}`,
+      })
+    }
+  }
+  return normalized
+}
+
+function createHttpAdapter({ system, fetchImpl = globalThis.fetch, logger } = {}) {
+  const normalizedSystem = normalizeExternalSystemForAdapter(system)
+  const config = normalizedSystem.config
+  const baseUrl = normalizeBaseUrl(config.baseUrl || config.url)
+  const objects = normalizeObjects(config)
+  const defaultHeaders = mergeHeaders(
+    { Accept: 'application/json' },
+    normalizeHeaders(config.headers, 'config.headers'),
+    credentialHeaders(normalizedSystem.credentials, config),
+  )
+  const timeoutMs = Number.isInteger(config.timeoutMs) && config.timeoutMs > 0 ? config.timeoutMs : 30000
+
+  if (typeof fetchImpl !== 'function') {
+    throw new AdapterValidationError('HTTP adapter requires fetch implementation', { field: 'fetchImpl' })
+  }
+
+  async function requestJson(path, { method = 'GET', query, headers, body } = {}) {
+    const url = buildUrl(baseUrl, path, query)
+    const controller = typeof AbortController === 'function' ? new AbortController() : null
+    const timeout = controller ? setTimeout(() => controller.abort(), timeoutMs) : null
+    const requestHeaders = mergeHeaders(
+      defaultHeaders,
+      body === undefined ? null : { 'Content-Type': 'application/json' },
+      normalizeHeaders(headers, 'headers'),
+    )
+
+    try {
+      const response = await fetchImpl(url, {
+        method,
+        headers: requestHeaders,
+        body: body === undefined ? undefined : JSON.stringify(body),
+        signal: controller ? controller.signal : undefined,
+      })
+      const data = await parseResponseBody(response)
+      if (!responseOk(response)) {
+        throw new HttpAdapterError(`HTTP adapter request failed: ${method} ${path}`, {
+          status: response.status,
+          body: data,
+          method,
+          path,
+        })
+      }
+      return { response, data, url, headers: requestHeaders }
+    } catch (error) {
+      if (error && error.name === 'AbortError') {
+        throw new HttpAdapterError(`HTTP adapter request timed out: ${method} ${path}`, {
+          code: 'TIMEOUT',
+          method,
+          path,
+          timeoutMs,
+        })
+      }
+      if (error instanceof HttpAdapterError) throw error
+      if (logger && typeof logger.warn === 'function') {
+        logger.warn(`[plugin-integration-core] HTTP adapter request failed: ${method} ${path}`)
+      }
+      throw error
+    } finally {
+      if (timeout) clearTimeout(timeout)
+    }
+  }
+
+  function getObjectConfig(object) {
+    return normalizeObjectConfig(objects, object)
+  }
+
+  async function testConnection(input = {}) {
+    const healthPath = input.path || config.healthPath || '/'
+    try {
+      const { response } = await requestJson(healthPath, {
+        method: input.method || 'GET',
+        headers: input.headers,
+      })
+      return {
+        ok: true,
+        status: response.status,
+      }
+    } catch (error) {
+      return {
+        ok: false,
+        status: error && error.status,
+        code: error && error.details && error.details.code ? error.details.code : 'HTTP_TEST_FAILED',
+        message: error && error.message ? error.message : String(error),
+      }
+    }
+  }
+
+  async function listObjects() {
+    return Object.entries(objects).map(([name, objectConfig]) => ({
+      name,
+      label: objectConfig.label || name,
+      operations: Array.isArray(objectConfig.operations) ? [...objectConfig.operations] : ['read', 'upsert'],
+      schema: Array.isArray(objectConfig.schema) ? objectConfig.schema : undefined,
+    }))
+  }
+
+  async function getSchema(input = {}) {
+    const object = typeof input === 'string' ? input : input.object
+    const objectConfig = getObjectConfig(object)
+    if (Array.isArray(objectConfig.schema)) {
+      return {
+        object,
+        fields: objectConfig.schema.map((field) => ({ ...field })),
+      }
+    }
+    if (objectConfig.schemaPath) {
+      const { data } = await requestJson(objectConfig.schemaPath, {
+        method: objectConfig.schemaMethod || 'GET',
+        headers: objectConfig.headers,
+      })
+      const fields = getPath(data, objectConfig.schemaFieldsPath || 'fields')
+      return {
+        object,
+        fields: Array.isArray(fields) ? fields : [],
+        raw: data,
+      }
+    }
+    return { object, fields: [] }
+  }
+
+  async function read(input = {}) {
+    const request = normalizeReadRequest(input)
+    const objectConfig = getObjectConfig(request.object)
+    ensureOperation(normalizedSystem.kind, request.object, objectConfig, 'read')
+    const path = assertRelativePath(objectConfig.path || objectConfig.readPath, 'object.path')
+    const query = {
+      ...toPlainObject(objectConfig.query, 'object.query'),
+      ...request.filters,
+      limit: request.limit,
+      cursor: request.cursor,
+      ...request.watermark,
+      ...request.options.query,
+    }
+    const { data } = await requestJson(path, {
+      method: objectConfig.method || objectConfig.readMethod || 'GET',
+      query,
+      headers: objectConfig.headers,
+    })
+    const locatedRecords = objectConfig.recordsPath ? getPath(data, objectConfig.recordsPath) : data
+    const records = Array.isArray(locatedRecords) ? locatedRecords : []
+    const nextCursor = objectConfig.nextCursorPath ? getPath(data, objectConfig.nextCursorPath) : getPath(data, 'nextCursor')
+    return createReadResult({
+      records,
+      nextCursor,
+      done: objectConfig.donePath ? Boolean(getPath(data, objectConfig.donePath)) : nextCursor === undefined || nextCursor === null,
+      raw: data,
+      metadata: {
+        object: request.object,
+        count: records.length,
+      },
+    })
+  }
+
+  async function upsert(input = {}) {
+    const request = normalizeUpsertRequest(input)
+    const objectConfig = getObjectConfig(request.object)
+    ensureOperation(normalizedSystem.kind, request.object, objectConfig, 'upsert')
+    const path = assertRelativePath(objectConfig.upsertPath || objectConfig.path, 'object.upsertPath')
+    const body = objectConfig.bodyMode === 'array'
+      ? request.records
+      : {
+          records: request.records,
+          keyFields: request.keyFields,
+          mode: request.mode,
+        }
+    const { data } = await requestJson(path, {
+      method: objectConfig.upsertMethod || 'POST',
+      headers: objectConfig.headers,
+      body,
+    })
+    const results = objectConfig.resultsPath ? getPath(data, objectConfig.resultsPath) : getPath(data, 'results')
+    const errors = objectConfig.errorsPath ? getPath(data, objectConfig.errorsPath) : getPath(data, 'errors')
+    return createUpsertResult({
+      written: getNumberPath(data, objectConfig.writtenPath || 'written', Array.isArray(results) ? results.length : request.records.length),
+      skipped: getNumberPath(data, objectConfig.skippedPath || 'skipped', 0),
+      failed: getNumberPath(data, objectConfig.failedPath || 'failed', Array.isArray(errors) ? errors.length : 0),
+      results: Array.isArray(results) ? results : [],
+      errors: Array.isArray(errors) ? errors : [],
+      raw: data,
+      metadata: {
+        object: request.object,
+      },
+    })
+  }
+
+  return {
+    kind: normalizedSystem.kind,
+    systemId: normalizedSystem.id,
+    testConnection,
+    listObjects,
+    getSchema,
+    read,
+    upsert,
+  }
+}
+
+function createHttpAdapterFactory(defaults = {}) {
+  return (input = {}) => createHttpAdapter({ ...defaults, ...input })
+}
+
+module.exports = {
+  createHttpAdapter,
+  createHttpAdapterFactory,
+  HttpAdapterError,
+  // Exposed for contract completeness when a specific config disables writes.
+  unsupportedAdapterOperation,
+  __internals: {
+    buildUrl,
+    getPath,
+    normalizeBaseUrl,
+    normalizeObjects,
+    credentialHeaders,
+  },
+}

--- a/plugins/plugin-integration-core/lib/contracts.cjs
+++ b/plugins/plugin-integration-core/lib/contracts.cjs
@@ -1,0 +1,247 @@
+'use strict'
+
+// ---------------------------------------------------------------------------
+// Adapter contracts - plugin-integration-core
+//
+// Internal PLM/ERP/DB adapters use this narrow shape so the pipeline runner can
+// work with source and target systems without depending on each vendor module.
+// This is intentionally plugin-local for M1; wider platform exposure can come
+// later after the K3 WISE PoC proves the shape.
+// ---------------------------------------------------------------------------
+
+const REQUIRED_ADAPTER_METHODS = ['testConnection', 'listObjects', 'getSchema', 'read', 'upsert']
+const DEFAULT_READ_LIMIT = 1000
+const MAX_READ_LIMIT = 10000
+
+class AdapterContractError extends Error {
+  constructor(message, details = {}) {
+    super(message)
+    this.name = 'AdapterContractError'
+    this.details = details
+  }
+}
+
+class AdapterValidationError extends Error {
+  constructor(message, details = {}) {
+    super(message)
+    this.name = 'AdapterValidationError'
+    this.details = details
+  }
+}
+
+class UnsupportedAdapterOperationError extends Error {
+  constructor(message, details = {}) {
+    super(message)
+    this.name = 'UnsupportedAdapterOperationError'
+    this.details = details
+  }
+}
+
+function isPlainObject(value) {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value))
+}
+
+function requiredString(value, field) {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new AdapterValidationError(`${field} is required`, { field })
+  }
+  return value.trim()
+}
+
+function optionalString(value, field) {
+  if (value === undefined || value === null || value === '') return null
+  if (typeof value !== 'string') {
+    throw new AdapterValidationError(`${field} must be a string`, { field })
+  }
+  return value.trim() || null
+}
+
+function objectOrEmpty(value, field) {
+  if (value === undefined || value === null) return {}
+  if (!isPlainObject(value)) {
+    throw new AdapterValidationError(`${field} must be an object`, { field })
+  }
+  return { ...value }
+}
+
+function normalizeExternalSystemForAdapter(system) {
+  if (!isPlainObject(system)) {
+    throw new AdapterValidationError('system must be an object', { field: 'system' })
+  }
+  return {
+    id: optionalString(system.id, 'system.id'),
+    name: optionalString(system.name, 'system.name') || requiredString(system.kind, 'system.kind'),
+    kind: requiredString(system.kind, 'system.kind'),
+    role: optionalString(system.role, 'system.role') || 'bidirectional',
+    config: objectOrEmpty(system.config, 'system.config'),
+    capabilities: objectOrEmpty(system.capabilities, 'system.capabilities'),
+    credentials: system.credentials === undefined ? undefined : system.credentials,
+  }
+}
+
+function normalizeLimit(limit, { defaultValue = DEFAULT_READ_LIMIT, max = MAX_READ_LIMIT } = {}) {
+  if (limit === undefined || limit === null) return defaultValue
+  const numeric = Number(limit)
+  if (!Number.isInteger(numeric) || numeric <= 0) {
+    throw new AdapterValidationError('limit must be a positive integer', { field: 'limit' })
+  }
+  return Math.min(numeric, max)
+}
+
+function normalizeReadRequest(input = {}) {
+  if (!isPlainObject(input)) {
+    throw new AdapterValidationError('read input must be an object')
+  }
+  return {
+    object: requiredString(input.object, 'object'),
+    limit: normalizeLimit(input.limit),
+    cursor: optionalString(input.cursor, 'cursor'),
+    filters: objectOrEmpty(input.filters, 'filters'),
+    watermark: objectOrEmpty(input.watermark, 'watermark'),
+    options: objectOrEmpty(input.options, 'options'),
+  }
+}
+
+function normalizeUpsertRequest(input = {}) {
+  if (!isPlainObject(input)) {
+    throw new AdapterValidationError('upsert input must be an object')
+  }
+  if (!Array.isArray(input.records)) {
+    throw new AdapterValidationError('records must be an array', { field: 'records' })
+  }
+  return {
+    object: requiredString(input.object, 'object'),
+    records: input.records.map((record, index) => {
+      if (!isPlainObject(record)) {
+        throw new AdapterValidationError(`records[${index}] must be an object`, { field: 'records' })
+      }
+      return { ...record }
+    }),
+    keyFields: Array.isArray(input.keyFields) ? input.keyFields.map((field) => requiredString(field, 'keyFields[]')) : [],
+    mode: optionalString(input.mode, 'mode') || 'upsert',
+    options: objectOrEmpty(input.options, 'options'),
+  }
+}
+
+function createReadResult({ records, nextCursor = null, done, raw = undefined, metadata = {} } = {}) {
+  if (!Array.isArray(records)) {
+    throw new AdapterContractError('read result records must be an array', { field: 'records' })
+  }
+  const safeNextCursor = nextCursor === undefined || nextCursor === null ? null : String(nextCursor)
+  return {
+    records,
+    nextCursor: safeNextCursor,
+    done: done === undefined ? safeNextCursor === null : Boolean(done),
+    raw,
+    metadata: objectOrEmpty(metadata, 'metadata'),
+  }
+}
+
+function createUpsertResult({ written = 0, skipped = 0, failed = 0, results = [], errors = [], raw = undefined, metadata = {} } = {}) {
+  if (!Array.isArray(results)) {
+    throw new AdapterContractError('upsert result results must be an array', { field: 'results' })
+  }
+  if (!Array.isArray(errors)) {
+    throw new AdapterContractError('upsert result errors must be an array', { field: 'errors' })
+  }
+  return {
+    written: Number(written) || 0,
+    skipped: Number(skipped) || 0,
+    failed: Number(failed) || 0,
+    results,
+    errors,
+    raw,
+    metadata: objectOrEmpty(metadata, 'metadata'),
+  }
+}
+
+function unsupportedAdapterOperation(kind, operation) {
+  return async () => {
+    throw new UnsupportedAdapterOperationError(`${kind} adapter does not support ${operation}`, {
+      kind,
+      operation,
+    })
+  }
+}
+
+function assertAdapterContract(adapter, kind = 'unknown') {
+  if (!isPlainObject(adapter)) {
+    throw new AdapterContractError(`${kind} adapter factory must return an object`, { kind })
+  }
+  for (const method of REQUIRED_ADAPTER_METHODS) {
+    if (typeof adapter[method] !== 'function') {
+      throw new AdapterContractError(`${kind} adapter missing ${method}()`, { kind, method })
+    }
+  }
+  return adapter
+}
+
+function createAdapterRegistry({ logger } = {}) {
+  const factories = new Map()
+
+  function registerAdapter(kind, factory, { replace = false } = {}) {
+    const normalizedKind = requiredString(kind, 'kind')
+    if (typeof factory !== 'function') {
+      throw new AdapterValidationError('adapter factory must be a function', { kind: normalizedKind })
+    }
+    if (factories.has(normalizedKind) && !replace) {
+      throw new AdapterValidationError(`adapter already registered: ${normalizedKind}`, { kind: normalizedKind })
+    }
+    factories.set(normalizedKind, factory)
+    if (logger && typeof logger.info === 'function') {
+      logger.info(`[plugin-integration-core] adapter registered: ${normalizedKind}`)
+    }
+    return registry
+  }
+
+  function listAdapterKinds() {
+    return Array.from(factories.keys()).sort()
+  }
+
+  function createAdapter(system, deps = {}) {
+    const normalizedSystem = normalizeExternalSystemForAdapter(system)
+    const factory = factories.get(normalizedSystem.kind)
+    if (!factory) {
+      throw new UnsupportedAdapterOperationError(`adapter not registered: ${normalizedSystem.kind}`, {
+        kind: normalizedSystem.kind,
+      })
+    }
+    const adapter = factory({
+      ...deps,
+      system: normalizedSystem,
+      logger,
+    })
+    return assertAdapterContract(adapter, normalizedSystem.kind)
+  }
+
+  const registry = {
+    registerAdapter,
+    listAdapterKinds,
+    createAdapter,
+  }
+  return registry
+}
+
+module.exports = {
+  REQUIRED_ADAPTER_METHODS,
+  DEFAULT_READ_LIMIT,
+  MAX_READ_LIMIT,
+  AdapterContractError,
+  AdapterValidationError,
+  UnsupportedAdapterOperationError,
+  assertAdapterContract,
+  createAdapterRegistry,
+  createReadResult,
+  createUpsertResult,
+  normalizeExternalSystemForAdapter,
+  normalizeReadRequest,
+  normalizeUpsertRequest,
+  unsupportedAdapterOperation,
+  __internals: {
+    isPlainObject,
+    requiredString,
+    optionalString,
+    objectOrEmpty,
+    normalizeLimit,
+  },
+}

--- a/plugins/plugin-integration-core/package.json
+++ b/plugins/plugin-integration-core/package.json
@@ -6,12 +6,14 @@
   "license": "UNLICENSED",
   "private": true,
   "scripts": {
-    "test": "node __tests__/plugin-runtime-smoke.test.cjs && node --import tsx __tests__/host-loader-smoke.test.mjs && node __tests__/credential-store.test.cjs && node __tests__/db.test.cjs && node __tests__/external-systems.test.cjs && node __tests__/staging-installer.test.cjs && node __tests__/migration-sql.test.cjs",
+    "test": "node __tests__/plugin-runtime-smoke.test.cjs && node --import tsx __tests__/host-loader-smoke.test.mjs && node __tests__/credential-store.test.cjs && node __tests__/db.test.cjs && node __tests__/external-systems.test.cjs && node __tests__/adapter-contracts.test.cjs && node __tests__/http-adapter.test.cjs && node __tests__/staging-installer.test.cjs && node __tests__/migration-sql.test.cjs",
     "test:runtime": "node __tests__/plugin-runtime-smoke.test.cjs",
     "test:host-loader": "node --import tsx __tests__/host-loader-smoke.test.mjs",
     "test:credential": "node __tests__/credential-store.test.cjs",
     "test:db": "node __tests__/db.test.cjs",
     "test:external-systems": "node __tests__/external-systems.test.cjs",
+    "test:adapter-contracts": "node __tests__/adapter-contracts.test.cjs",
+    "test:http-adapter": "node __tests__/http-adapter.test.cjs",
     "test:staging": "node __tests__/staging-installer.test.cjs",
     "test:migration": "node __tests__/migration-sql.test.cjs"
   }


### PR DESCRIPTION
## Summary

M1 PR2 for `plugin-integration-core`. This PR adds the plugin-local adapter contract and the generic HTTP adapter on top of the merged external-system registry seam.

Changes:
- Add `contracts.cjs` with adapter registry, adapter shape validation, typed adapter errors, and row normalization helpers.
- Add `adapters/http-adapter.cjs` for config-driven HTTP source/target integration.
- Wire runtime status and communication to expose registered adapter kinds.
- Register only the generic `http` adapter in this slice.
- Add focused adapter-contract and HTTP-adapter tests.
- Update runtime smoke/host-loader smoke to assert PR2 adapter wiring only.
- Add PR2 design and verification docs.

## Scope Boundaries

This PR intentionally does not include:
- pipeline registry or pipeline runner
- REST control plane routes beyond the existing health route
- K3 WISE adapters
- Yuantus PLM wrapper
- ERP feedback writer
- PR6-PR9 bundle content

## Verification

Run from a clean branch based on `main` after #1145:

```bash
node --check plugins/plugin-integration-core/lib/contracts.cjs
node --check plugins/plugin-integration-core/lib/adapters/http-adapter.cjs
node --check plugins/plugin-integration-core/__tests__/adapter-contracts.test.cjs
node --check plugins/plugin-integration-core/__tests__/http-adapter.test.cjs
pnpm -F plugin-integration-core test:adapter-contracts
pnpm -F plugin-integration-core test:http-adapter
pnpm -F plugin-integration-core test:runtime
pnpm -F plugin-integration-core test:host-loader
pnpm -F plugin-integration-core test
node --import tsx scripts/validate-plugin-manifests.ts
git diff --check
```

Results:
- adapter-contracts passed
- http-adapter passed
- runtime smoke passed
- host-loader smoke passed
- full plugin-integration-core package test passed
- plugin manifest validation passed: 13 valid, 0 errors
- whitespace and syntax checks passed

## PR Stack Note

PR6-PR9 still require PR3, PR4, and PR5 to land first. This PR is only the adapter-contract layer.