### PR TITLE
feat(integration): add pipeline registry

### DIFF
--- a/docs/development/integration-core-pipeline-registry-design-20260424.md
+++ b/docs/development/integration-core-pipeline-registry-design-20260424.md
@@ -1,0 +1,121 @@
+# Integration Core Pipeline Registry Design - 2026-04-24
+
+## Context
+
+After M1-PR1 registers external PLM/ERP/DB systems, the next non-runner step is
+to persist pipeline definitions and their field mappings. This lets later slices
+wire adapter reads/writes into stable pipeline metadata without inventing the
+definition shape inside the runner.
+
+This slice stores definition state only. It does not execute adapters, transform
+records, advance watermarks, or write dead letters.
+
+## Decision
+
+Add `plugins/plugin-integration-core/lib/pipelines.cjs`.
+
+The registry manages:
+
+- `integration_pipelines`
+- `integration_field_mappings`
+- `integration_runs`
+
+It also reads `integration_external_systems` to validate that source and target
+systems exist in the same tenant/workspace and have compatible roles.
+
+## Communication API
+
+`index.cjs` creates the pipeline registry during activation:
+
+```js
+pipelineRegistry = createPipelineRegistry({ db })
+```
+
+The `integration-core` namespace exposes:
+
+```js
+upsertPipeline(input)
+getPipeline(input)
+listPipelines(input)
+createPipelineRun(input)
+updatePipelineRun(input)
+listPipelineRuns(input)
+```
+
+`getStatus()` includes:
+
+```json
+{
+  "pipelines": true
+}
+```
+
+## Pipeline Rules
+
+Pipeline inputs require:
+
+- `tenantId`
+- `name`
+- `sourceSystemId`
+- `sourceObject`
+- `targetSystemId`
+- `targetObject`
+
+Defaults:
+
+- `mode`: `incremental`
+- `status`: `draft`
+- `idempotencyKeyFields`: `[]`
+- `options`: `{}`
+
+Role enforcement:
+
+- source system role must be `source` or `bidirectional`
+- target system role must be `target` or `bidirectional`
+
+`workspaceId === ''` is normalized to `null`, matching migration 057's
+`COALESCE(workspace_id, '')` uniqueness convention.
+
+## Field Mappings
+
+`fieldMappings` is optional:
+
+- omitted means preserve existing mappings.
+- an explicit empty array clears mappings.
+- a non-empty array replaces mappings transactionally.
+
+Mappings validate:
+
+- `sourceField`
+- `targetField`
+- non-negative `sortOrder`
+- JSON-compatible `transform`, `validation`, and `defaultValue`
+
+## Run Ledger
+
+The run ledger is metadata-only in this slice:
+
+- `createPipelineRun()` creates a pending/running/etc. row after checking the
+  pipeline exists and is not disabled.
+- `updatePipelineRun()` updates counters, status, timestamps, error summary,
+  and details.
+- terminal statuses set `finished_at` when the caller did not provide one.
+
+The ledger does not call adapters and does not process rows.
+
+## Trade-Offs
+
+- Pipeline definition writes validate external systems before insert/update.
+- Field mapping replacement requires `db.transaction()` so partial mapping
+  updates do not leave a mixed definition.
+- Run counters are validated as non-negative integers here, before runner code
+  exists.
+
+## Deferred
+
+- Actual `runPipeline()` implementation.
+- Transform/validation execution.
+- Idempotency calculation.
+- Watermark advancement.
+- Dead-letter creation and replay.
+- REST routes and UI.

--- a/docs/development/integration-core-pipeline-registry-verification-20260424.md
+++ b/docs/development/integration-core-pipeline-registry-verification-20260424.md
@@ -1,0 +1,57 @@
+# Integration Core Pipeline Registry Verification - 2026-04-24
+
+## Scope
+
+Verify the pipeline definition registry and run ledger for
+`plugin-integration-core`.
+
+This slice does not execute the pipeline runner. It only verifies persisted
+pipeline definitions, field mappings, endpoint role checks, and run metadata.
+
+## Commands Run
+
+```bash
+node plugins/plugin-integration-core/__tests__/pipelines.test.cjs
+pnpm -F plugin-integration-core test
+node --import tsx scripts/validate-plugin-manifests.ts
+```
+
+## Results
+
+- `pipelines.test.cjs`: passed.
+- `plugin-integration-core` package tests: passed, including 10 plugin-local
+  smoke/unit checks.
+- Plugin manifest validation through `node --import tsx`: passed, 13/13 valid,
+  0 errors.
+
+`pnpm validate:plugins` was also attempted in this sandbox and failed before
+running validation due the known `tsx` IPC `listen EPERM` restriction.
+
+## Covered Behaviors
+
+- `upsertPipeline()` creates a pipeline in the correct tenant/workspace.
+- empty `workspaceId` normalizes to `null`.
+- source and target external systems must exist in the same tenant/workspace.
+- source role must be `source | bidirectional`.
+- target role must be `target | bidirectional`.
+- field mappings are written transactionally.
+- `getPipeline()` returns mappings by default.
+- output shape never includes credentials or ciphertext.
+- update without `fieldMappings` preserves existing mappings.
+- explicit `fieldMappings: []` clears mappings.
+- `listPipelines()` scopes by tenant/workspace and filters by status.
+- invalid mappings throw `PipelineValidationError`.
+- missing pipelines throw `PipelineNotFoundError`.
+- `createPipelineRun()` creates run metadata without executing adapters.
+- terminal `updatePipelineRun()` sets `finishedAt`.
+- negative run counters are rejected.
+- disabled pipelines cannot create new runs.
+
+## Not Covered
+
+- Actual row extraction from source adapters.
+- Transform and validation execution.
+- Target adapter writes.
+- Dead-letter writes or replay.
+- Watermark updates.
+- Live Postgres execution of these service methods.

--- a/plugins/plugin-integration-core/__tests__/pipelines.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/pipelines.test.cjs
@@ -1,0 +1,340 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const path = require('node:path')
+const {
+  createPipelineRegistry,
+  PipelineNotFoundError,
+  PipelineValidationError,
+} = require(path.join(__dirname, '..', 'lib', 'pipelines.cjs'))
+
+function createIdGenerator() {
+  let next = 1
+  return () => `id_${next++}`
+}
+
+function createMockDb() {
+  const tables = new Map([
+    ['integration_external_systems', []],
+    ['integration_pipelines', []],
+    ['integration_field_mappings', []],
+    ['integration_runs', []],
+  ])
+  const calls = []
+
+  function tableRows(table) {
+    if (!tables.has(table)) tables.set(table, [])
+    return tables.get(table)
+  }
+
+  function matchesWhere(row, where) {
+    return Object.entries(where || {}).every(([key, value]) => {
+      if (value === null || value === undefined) return row[key] === null || row[key] === undefined
+      return row[key] === value
+    })
+  }
+
+  const db = {
+    tables,
+    calls,
+    seed(table, rows) {
+      tableRows(table).push(...rows)
+    },
+    async selectOne(table, where) {
+      calls.push(['selectOne', table, { ...where }])
+      return tableRows(table).find(row => matchesWhere(row, where)) || null
+    },
+    async insertOne(table, row) {
+      calls.push(['insertOne', table, { ...row }])
+      const stored = {
+        ...row,
+        created_at: row.created_at || '2026-04-24T00:00:00.000Z',
+        updated_at: row.updated_at || '2026-04-24T00:00:00.000Z',
+      }
+      tableRows(table).push(stored)
+      return [stored]
+    },
+    async insertMany(table, rows) {
+      calls.push(['insertMany', table, rows.map(row => ({ ...row }))])
+      const storedRows = rows.map((row, index) => ({
+        ...row,
+        created_at: row.created_at || `2026-04-24T00:00:0${index}.000Z`,
+      }))
+      tableRows(table).push(...storedRows)
+      return storedRows
+    },
+    async updateRow(table, set, where) {
+      calls.push(['updateRow', table, { ...set }, { ...where }])
+      const row = tableRows(table).find(candidate => matchesWhere(candidate, where))
+      if (!row) return []
+      Object.assign(row, set, { updated_at: '2026-04-24T01:00:00.000Z' })
+      return [row]
+    },
+    async deleteRows(table, where) {
+      calls.push(['deleteRows', table, { ...where }])
+      const rows = tableRows(table)
+      const kept = []
+      const removed = []
+      for (const row of rows) {
+        if (matchesWhere(row, where)) removed.push(row)
+        else kept.push(row)
+      }
+      tables.set(table, kept)
+      return removed
+    },
+    async select(table, options = {}) {
+      calls.push(['select', table, JSON.parse(JSON.stringify(options))])
+      const filtered = tableRows(table).filter(row => matchesWhere(row, options.where || {}))
+      const ordered = filtered.slice()
+      if (options.orderBy) {
+        const [field, direction] = options.orderBy
+        ordered.sort((a, b) => {
+          const left = a[field]
+          const right = b[field]
+          if (left === right) return 0
+          const result = left > right ? 1 : -1
+          return direction === 'DESC' ? -result : result
+        })
+      }
+      return ordered.slice(options.offset || 0, (options.offset || 0) + (options.limit || 1000))
+    },
+    async transaction(callback) {
+      calls.push(['transaction'])
+      return callback(this)
+    },
+  }
+
+  return db
+}
+
+async function main() {
+  const db = createMockDb()
+  db.seed('integration_external_systems', [
+    { id: 'plm_1', tenant_id: 'tenant_1', workspace_id: null, name: 'PLM', role: 'source', kind: 'plm:yuantus' },
+    { id: 'erp_1', tenant_id: 'tenant_1', workspace_id: null, name: 'K3', role: 'target', kind: 'erp:k3-wise-webapi' },
+    { id: 'target_in_other_workspace', tenant_id: 'tenant_1', workspace_id: 'other', name: 'K3 other', role: 'target', kind: 'erp:k3-wise-webapi' },
+    { id: 'source_only', tenant_id: 'tenant_1', workspace_id: null, name: 'Source only', role: 'source', kind: 'http' },
+  ])
+
+  const registry = createPipelineRegistry({
+    db,
+    idGenerator: createIdGenerator(),
+  })
+
+  // --- 1. Create validates endpoint systems and writes mappings in tx ----
+  const created = await registry.upsertPipeline({
+    tenantId: 'tenant_1',
+    workspaceId: '',
+    projectId: 'project_1',
+    name: 'Material sync',
+    description: 'PLM material to K3',
+    sourceSystemId: 'plm_1',
+    sourceObject: 'materials',
+    targetSystemId: 'erp_1',
+    targetObject: 'BD_MATERIAL',
+    stagingSheetId: 'sheet_1',
+    mode: 'incremental',
+    idempotencyKeyFields: ['sourceId', 'revision'],
+    options: { batchSize: 100 },
+    status: 'active',
+    createdBy: 'admin',
+    fieldMappings: [
+      { sourceField: 'code', targetField: 'FNumber', sortOrder: 0 },
+      { sourceField: 'name', targetField: 'FName', transform: { fn: 'trim' }, validation: [{ type: 'required' }], sortOrder: 1 },
+    ],
+  })
+
+  assert.equal(created.id, 'id_1')
+  assert.equal(created.workspaceId, null, 'empty workspace normalized to null')
+  assert.equal(created.sourceSystemId, 'plm_1')
+  assert.equal(created.targetSystemId, 'erp_1')
+  assert.equal(created.status, 'active')
+  assert.equal(created.fieldMappings.length, 2)
+  assert.deepEqual(created.fieldMappings.map(mapping => mapping.id), ['id_2', 'id_3'])
+  assert.ok(db.calls.some(([name]) => name === 'transaction'), 'field mapping writes are transactional')
+
+  // --- 2. getPipeline returns mappings and safe definition shape ---------
+  const fetched = await registry.getPipeline({ tenantId: 'tenant_1', workspaceId: null, id: 'id_1' })
+  assert.equal(fetched.id, 'id_1')
+  assert.equal(fetched.fieldMappings.length, 2)
+  assert.equal(fetched.fieldMappings[1].transform.fn, 'trim')
+  assert.equal(fetched.credentials, undefined, 'pipeline output never includes credentials')
+  assert.equal(fetched.credentialsEncrypted, undefined, 'pipeline output never includes ciphertext')
+
+  // --- 3. Update without fieldMappings preserves existing mappings -------
+  const updated = await registry.upsertPipeline({
+    tenantId: 'tenant_1',
+    workspaceId: null,
+    id: 'id_1',
+    name: 'Material sync v2',
+    sourceSystemId: 'plm_1',
+    sourceObject: 'materials',
+    targetSystemId: 'erp_1',
+    targetObject: 'BD_MATERIAL',
+    mode: 'manual',
+    status: 'paused',
+    createdBy: 'operator_should_not_replace_creator',
+  })
+  assert.equal(updated.id, 'id_1')
+  assert.equal(updated.name, 'Material sync v2')
+  assert.equal(updated.createdBy, 'admin', 'updates preserve original created_by audit field')
+  const pipelineUpdate = db.calls.find(call => call[0] === 'updateRow' && call[1] === 'integration_pipelines')
+  assert.equal(
+    Object.hasOwn(pipelineUpdate[2], 'created_by'),
+    false,
+    'pipeline update does not write created_by',
+  )
+  assert.equal(updated.fieldMappings, undefined, 'omitted fieldMappings are not implicitly loaded/replaced')
+  assert.equal(db.tables.get('integration_field_mappings').length, 2, 'existing mappings preserved when omitted')
+
+  // --- 4. Explicit empty fieldMappings clears mappings ------------------
+  const cleared = await registry.upsertPipeline({
+    tenantId: 'tenant_1',
+    workspaceId: null,
+    id: 'id_1',
+    name: 'Material sync v2',
+    sourceSystemId: 'plm_1',
+    sourceObject: 'materials',
+    targetSystemId: 'erp_1',
+    targetObject: 'BD_MATERIAL',
+    fieldMappings: [],
+  })
+  assert.deepEqual(cleared.fieldMappings, [])
+  assert.equal(db.tables.get('integration_field_mappings').length, 0, 'explicit empty mappings clears rows')
+
+  // --- 5. list scopes by tenant/workspace and filters status ------------
+  const listed = await registry.listPipelines({ tenantId: 'tenant_1', workspaceId: null, status: 'draft' })
+  assert.equal(listed.length, 1)
+  assert.equal(listed[0].id, 'id_1')
+
+  const isolated = await registry.listPipelines({ tenantId: 'tenant_1', workspaceId: 'other' })
+  assert.equal(isolated.length, 0, 'workspace scope isolates pipelines')
+
+  // --- 6. Endpoint existence and roles are enforced ---------------------
+  let missingSystem = null
+  try {
+    await registry.upsertPipeline({
+      tenantId: 'tenant_1',
+      name: 'Bad missing target',
+      sourceSystemId: 'plm_1',
+      sourceObject: 'x',
+      targetSystemId: 'missing',
+      targetObject: 'y',
+    })
+  } catch (error) {
+    missingSystem = error
+  }
+  assert.ok(missingSystem instanceof PipelineValidationError, 'missing target rejected')
+
+  let badRole = null
+  try {
+    await registry.upsertPipeline({
+      tenantId: 'tenant_1',
+      name: 'Bad target role',
+      sourceSystemId: 'plm_1',
+      sourceObject: 'x',
+      targetSystemId: 'source_only',
+      targetObject: 'y',
+    })
+  } catch (error) {
+    badRole = error
+  }
+  assert.ok(badRole instanceof PipelineValidationError, 'source-only system cannot be target')
+  assert.equal(badRole.details.field, 'targetSystemId')
+
+  // --- 7. Validation + not-found errors ---------------------------------
+  let badMapping = null
+  try {
+    await registry.upsertPipeline({
+      tenantId: 'tenant_1',
+      name: 'Bad mapping',
+      sourceSystemId: 'plm_1',
+      sourceObject: 'x',
+      targetSystemId: 'erp_1',
+      targetObject: 'y',
+      fieldMappings: [{ sourceField: 'a', targetField: '', sortOrder: -1 }],
+    })
+  } catch (error) {
+    badMapping = error
+  }
+  assert.ok(badMapping instanceof PipelineValidationError, 'invalid mapping rejected')
+
+  let notFound = null
+  try {
+    await registry.getPipeline({ tenantId: 'tenant_1', id: 'missing' })
+  } catch (error) {
+    notFound = error
+  }
+  assert.ok(notFound instanceof PipelineNotFoundError, 'missing pipeline throws not found')
+
+  // --- 8. Run ledger creates pending metadata without executing adapters -
+  const run = await registry.createPipelineRun({
+    tenantId: 'tenant_1',
+    workspaceId: null,
+    pipelineId: 'id_1',
+    mode: 'manual',
+    triggeredBy: 'api',
+    details: { dryRun: true },
+  })
+  assert.equal(run.id, 'id_4')
+  assert.equal(run.pipelineId, 'id_1')
+  assert.equal(run.status, 'pending')
+  assert.equal(run.rowsRead, 0)
+  assert.deepEqual(run.details, { dryRun: true })
+
+  const completedRun = await registry.updatePipelineRun({
+    tenantId: 'tenant_1',
+    workspaceId: null,
+    id: 'id_4',
+    status: 'succeeded',
+    rowsRead: 10,
+    rowsCleaned: 9,
+    rowsWritten: 8,
+    rowsFailed: 1,
+    durationMs: 1234,
+    details: { batch: 1 },
+  })
+  assert.equal(completedRun.status, 'succeeded')
+  assert.equal(completedRun.rowsWritten, 8)
+  assert.equal(completedRun.durationMs, 1234)
+  assert.ok(completedRun.finishedAt, 'terminal update sets finishedAt')
+
+  const runs = await registry.listPipelineRuns({ tenantId: 'tenant_1', workspaceId: null, pipelineId: 'id_1', status: 'succeeded' })
+  assert.equal(runs.length, 1)
+  assert.equal(runs[0].id, 'id_4')
+
+  let badCounter = null
+  try {
+    await registry.updatePipelineRun({
+      tenantId: 'tenant_1',
+      id: 'id_4',
+      status: 'failed',
+      rowsFailed: -1,
+    })
+  } catch (error) {
+    badCounter = error
+  }
+  assert.ok(badCounter instanceof PipelineValidationError, 'negative run counters rejected')
+
+  db.tables.get('integration_pipelines')[0].status = 'disabled'
+  let disabledRun = null
+  try {
+    await registry.createPipelineRun({
+      tenantId: 'tenant_1',
+      pipelineId: 'id_1',
+      mode: 'manual',
+      triggeredBy: 'manual',
+    })
+  } catch (error) {
+    disabledRun = error
+  }
+  assert.ok(disabledRun instanceof PipelineValidationError, 'disabled pipeline cannot create runs')
+
+  console.log('✓ pipelines: registry + endpoint + field-mapping + run-ledger tests passed')
+}
+
+main().catch((err) => {
+  console.error('✗ pipelines FAILED')
+  console.error(err)
+  process.exit(1)
+})

--- a/plugins/plugin-integration-core/index.cjs
+++ b/plugins/plugin-integration-core/index.cjs
@@ -21,12 +21,14 @@ const { createDb } = require('./lib/db.cjs')
 const { createExternalSystemRegistry } = require('./lib/external-systems.cjs')
 const { createAdapterRegistry } = require('./lib/contracts.cjs')
 const { createHttpAdapterFactory } = require('./lib/adapters/http-adapter.cjs')
+const { createPipelineRegistry } = require('./lib/pipelines.cjs')
 
 const registeredRoutes = []
 let activeContext = null
 let credentialStore = null
 let externalSystemRegistry = null
 let adapterRegistry = null
+let pipelineRegistry = null
 
 function buildHealthPayload() {
   return {
@@ -54,6 +56,7 @@ function buildCommunicationApi() {
           : null,
         externalSystems: Boolean(externalSystemRegistry),
         adapters: adapterRegistry ? adapterRegistry.listAdapterKinds() : [],
+        pipelines: Boolean(pipelineRegistry),
       }
     },
     async upsertExternalSystem(input) {
@@ -71,6 +74,30 @@ function buildCommunicationApi() {
     async listAdapterKinds() {
       if (!adapterRegistry) throw new Error('adapter registry is not initialized')
       return adapterRegistry.listAdapterKinds()
+    },
+    async upsertPipeline(input) {
+      if (!pipelineRegistry) throw new Error('pipeline registry is not initialized')
+      return pipelineRegistry.upsertPipeline(input)
+    },
+    async getPipeline(input) {
+      if (!pipelineRegistry) throw new Error('pipeline registry is not initialized')
+      return pipelineRegistry.getPipeline(input)
+    },
+    async listPipelines(input) {
+      if (!pipelineRegistry) throw new Error('pipeline registry is not initialized')
+      return pipelineRegistry.listPipelines(input)
+    },
+    async createPipelineRun(input) {
+      if (!pipelineRegistry) throw new Error('pipeline registry is not initialized')
+      return pipelineRegistry.createPipelineRun(input)
+    },
+    async updatePipelineRun(input) {
+      if (!pipelineRegistry) throw new Error('pipeline registry is not initialized')
+      return pipelineRegistry.updatePipelineRun(input)
+    },
+    async listPipelineRuns(input) {
+      if (!pipelineRegistry) throw new Error('pipeline registry is not initialized')
+      return pipelineRegistry.listPipelineRuns(input)
     },
   }
 }
@@ -93,6 +120,7 @@ module.exports = {
     })
     adapterRegistry = createAdapterRegistry({ logger })
       .registerAdapter('http', createHttpAdapterFactory())
+    pipelineRegistry = createPipelineRegistry({ db })
 
     // --- HTTP routes ------------------------------------------------------
     context.api.http.addRoute('GET', '/api/integration/health', async (_req, res) => {
@@ -116,6 +144,7 @@ module.exports = {
     credentialStore = null
     externalSystemRegistry = null
     adapterRegistry = null
+    pipelineRegistry = null
     activeContext = null
     logger.info(`[${PLUGIN_ID}] deactivated`)
   },

--- a/plugins/plugin-integration-core/lib/pipelines.cjs
+++ b/plugins/plugin-integration-core/lib/pipelines.cjs
@@ -1,0 +1,587 @@
+'use strict'
+
+// ---------------------------------------------------------------------------
+// Pipeline registry - plugin-integration-core
+//
+// Stores pipeline definitions and optional field mappings. This is definition
+// state only: no external adapter calls, no run execution, no credential reads.
+// ---------------------------------------------------------------------------
+
+const crypto = require('node:crypto')
+
+const PIPELINES_TABLE = 'integration_pipelines'
+const FIELD_MAPPINGS_TABLE = 'integration_field_mappings'
+const EXTERNAL_SYSTEMS_TABLE = 'integration_external_systems'
+const RUNS_TABLE = 'integration_runs'
+const VALID_MODES = new Set(['incremental', 'full', 'manual'])
+const VALID_RUN_MODES = new Set(['incremental', 'full', 'manual', 'replay'])
+const VALID_STATUSES = new Set(['draft', 'active', 'paused', 'disabled'])
+const VALID_RUN_STATUSES = new Set(['pending', 'running', 'succeeded', 'partial', 'failed', 'cancelled'])
+const VALID_TRIGGERS = new Set(['cron', 'manual', 'api', 'replay'])
+const TERMINAL_RUN_STATUSES = new Set(['succeeded', 'partial', 'failed', 'cancelled'])
+const SOURCE_ROLES = new Set(['source', 'bidirectional'])
+const TARGET_ROLES = new Set(['target', 'bidirectional'])
+
+class PipelineValidationError extends Error {
+  constructor(message, details = {}) {
+    super(message)
+    this.name = 'PipelineValidationError'
+    this.details = details
+  }
+}
+
+class PipelineNotFoundError extends Error {
+  constructor(message, details = {}) {
+    super(message)
+    this.name = 'PipelineNotFoundError'
+    this.details = details
+  }
+}
+
+function requiredString(value, field) {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new PipelineValidationError(`${field} is required`, { field })
+  }
+  return value.trim()
+}
+
+function optionalString(value, field) {
+  if (value === undefined || value === null || value === '') return null
+  if (typeof value !== 'string') {
+    throw new PipelineValidationError(`${field} must be a string`, { field })
+  }
+  return value.trim() || null
+}
+
+function normalizeWorkspaceId(value) {
+  const normalized = optionalString(value, 'workspaceId')
+  return normalized === '' ? null : normalized
+}
+
+function jsonObject(value, field, fallback = {}) {
+  if (value === undefined || value === null) return fallback
+  if (typeof value !== 'object' || Array.isArray(value)) {
+    throw new PipelineValidationError(`${field} must be an object`, { field })
+  }
+  return { ...value }
+}
+
+function jsonArray(value, field, fallback = []) {
+  if (value === undefined || value === null) return fallback.slice()
+  if (!Array.isArray(value)) {
+    throw new PipelineValidationError(`${field} must be an array`, { field })
+  }
+  return value.slice()
+}
+
+function nonNegativeInteger(value, field, fallback = 0) {
+  if (value === undefined || value === null) return fallback
+  const numeric = Number(value)
+  if (!Number.isInteger(numeric) || numeric < 0) {
+    throw new PipelineValidationError(`${field} must be a non-negative integer`, { field })
+  }
+  return numeric
+}
+
+function optionalJson(value, field) {
+  if (value === undefined || value === null) return null
+  if (typeof value !== 'object') {
+    throw new PipelineValidationError(`${field} must be JSON-compatible`, { field })
+  }
+  return Array.isArray(value) ? value.slice() : { ...value }
+}
+
+function validateIsoTimestamp(value, field) {
+  if (value === undefined || value === null || value === '') return null
+  const text = requiredString(value, field)
+  if (Number.isNaN(Date.parse(text))) {
+    throw new PipelineValidationError(`${field} must be an ISO timestamp`, { field })
+  }
+  return text
+}
+
+function scopeWhere({ tenantId, workspaceId }) {
+  return {
+    tenant_id: tenantId,
+    workspace_id: workspaceId ?? null,
+  }
+}
+
+function normalizePipelineInput(input) {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    throw new PipelineValidationError('input must be an object')
+  }
+
+  const mode = input.mode === undefined ? 'incremental' : requiredString(input.mode, 'mode')
+  if (!VALID_MODES.has(mode)) {
+    throw new PipelineValidationError(`mode must be one of ${Array.from(VALID_MODES).join(', ')}`, { field: 'mode' })
+  }
+
+  const status = input.status === undefined ? 'draft' : requiredString(input.status, 'status')
+  if (!VALID_STATUSES.has(status)) {
+    throw new PipelineValidationError(`status must be one of ${Array.from(VALID_STATUSES).join(', ')}`, { field: 'status' })
+  }
+
+  const fieldMappings = input.fieldMappings === undefined
+    ? undefined
+    : normalizeFieldMappings(input.fieldMappings)
+
+  return {
+    id: optionalString(input.id, 'id'),
+    tenantId: requiredString(input.tenantId, 'tenantId'),
+    workspaceId: normalizeWorkspaceId(input.workspaceId),
+    projectId: optionalString(input.projectId, 'projectId'),
+    name: requiredString(input.name, 'name'),
+    description: optionalString(input.description, 'description'),
+    sourceSystemId: requiredString(input.sourceSystemId, 'sourceSystemId'),
+    sourceObject: requiredString(input.sourceObject, 'sourceObject'),
+    targetSystemId: requiredString(input.targetSystemId, 'targetSystemId'),
+    targetObject: requiredString(input.targetObject, 'targetObject'),
+    stagingSheetId: optionalString(input.stagingSheetId, 'stagingSheetId'),
+    mode,
+    idempotencyKeyFields: jsonArray(input.idempotencyKeyFields, 'idempotencyKeyFields'),
+    options: jsonObject(input.options, 'options'),
+    status,
+    createdBy: optionalString(input.createdBy, 'createdBy'),
+    fieldMappings,
+  }
+}
+
+function normalizeFieldMappings(value) {
+  if (!Array.isArray(value)) {
+    throw new PipelineValidationError('fieldMappings must be an array', { field: 'fieldMappings' })
+  }
+  return value.map((mapping, index) => {
+    if (!mapping || typeof mapping !== 'object' || Array.isArray(mapping)) {
+      throw new PipelineValidationError(`fieldMappings[${index}] must be an object`, { field: 'fieldMappings' })
+    }
+    const sortOrder = mapping.sortOrder === undefined ? index : Number(mapping.sortOrder)
+    if (!Number.isInteger(sortOrder) || sortOrder < 0) {
+      throw new PipelineValidationError(`fieldMappings[${index}].sortOrder must be a non-negative integer`, { field: 'sortOrder' })
+    }
+    return {
+      id: optionalString(mapping.id, `fieldMappings[${index}].id`),
+      sourceField: requiredString(mapping.sourceField, `fieldMappings[${index}].sourceField`),
+      targetField: requiredString(mapping.targetField, `fieldMappings[${index}].targetField`),
+      transform: optionalJson(mapping.transform, `fieldMappings[${index}].transform`),
+      validation: mapping.validation === undefined || mapping.validation === null
+        ? null
+        : jsonArray(mapping.validation, `fieldMappings[${index}].validation`),
+      defaultValue: mapping.defaultValue === undefined ? null : mapping.defaultValue,
+      sortOrder,
+    }
+  })
+}
+
+function normalizeCreateRunInput(input) {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    throw new PipelineValidationError('input must be an object')
+  }
+
+  const mode = input.mode === undefined ? 'manual' : requiredString(input.mode, 'mode')
+  if (!VALID_RUN_MODES.has(mode)) {
+    throw new PipelineValidationError(`mode must be one of ${Array.from(VALID_RUN_MODES).join(', ')}`, { field: 'mode' })
+  }
+  const triggeredBy = input.triggeredBy === undefined ? 'manual' : requiredString(input.triggeredBy, 'triggeredBy')
+  if (!VALID_TRIGGERS.has(triggeredBy)) {
+    throw new PipelineValidationError(`triggeredBy must be one of ${Array.from(VALID_TRIGGERS).join(', ')}`, { field: 'triggeredBy' })
+  }
+  const status = input.status === undefined ? 'pending' : requiredString(input.status, 'status')
+  if (!VALID_RUN_STATUSES.has(status)) {
+    throw new PipelineValidationError(`status must be one of ${Array.from(VALID_RUN_STATUSES).join(', ')}`, { field: 'status' })
+  }
+
+  return {
+    id: optionalString(input.id, 'id'),
+    tenantId: requiredString(input.tenantId, 'tenantId'),
+    workspaceId: normalizeWorkspaceId(input.workspaceId),
+    pipelineId: requiredString(input.pipelineId, 'pipelineId'),
+    mode,
+    triggeredBy,
+    status,
+    rowsRead: nonNegativeInteger(input.rowsRead, 'rowsRead'),
+    rowsCleaned: nonNegativeInteger(input.rowsCleaned, 'rowsCleaned'),
+    rowsWritten: nonNegativeInteger(input.rowsWritten, 'rowsWritten'),
+    rowsFailed: nonNegativeInteger(input.rowsFailed, 'rowsFailed'),
+    startedAt: validateIsoTimestamp(input.startedAt, 'startedAt'),
+    finishedAt: validateIsoTimestamp(input.finishedAt, 'finishedAt'),
+    durationMs: input.durationMs === undefined || input.durationMs === null ? null : nonNegativeInteger(input.durationMs, 'durationMs'),
+    errorSummary: optionalString(input.errorSummary, 'errorSummary'),
+    details: jsonObject(input.details, 'details'),
+  }
+}
+
+function normalizeUpdateRunInput(input, now) {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    throw new PipelineValidationError('input must be an object')
+  }
+  const status = requiredString(input.status, 'status')
+  if (!VALID_RUN_STATUSES.has(status)) {
+    throw new PipelineValidationError(`status must be one of ${Array.from(VALID_RUN_STATUSES).join(', ')}`, { field: 'status' })
+  }
+
+  const startedAt = validateIsoTimestamp(input.startedAt, 'startedAt')
+  const finishedAt = validateIsoTimestamp(input.finishedAt, 'finishedAt') || (TERMINAL_RUN_STATUSES.has(status) ? now() : null)
+  const set = {
+    status,
+    rows_read: nonNegativeInteger(input.rowsRead, 'rowsRead', undefined),
+    rows_cleaned: nonNegativeInteger(input.rowsCleaned, 'rowsCleaned', undefined),
+    rows_written: nonNegativeInteger(input.rowsWritten, 'rowsWritten', undefined),
+    rows_failed: nonNegativeInteger(input.rowsFailed, 'rowsFailed', undefined),
+    started_at: startedAt,
+    finished_at: finishedAt,
+    duration_ms: input.durationMs === undefined || input.durationMs === null ? null : nonNegativeInteger(input.durationMs, 'durationMs'),
+    error_summary: optionalString(input.errorSummary, 'errorSummary'),
+    details: input.details === undefined ? undefined : jsonObject(input.details, 'details'),
+  }
+  for (const key of Object.keys(set)) {
+    if (set[key] === undefined || set[key] === null) delete set[key]
+  }
+  return {
+    tenantId: requiredString(input.tenantId, 'tenantId'),
+    workspaceId: normalizeWorkspaceId(input.workspaceId),
+    id: requiredString(input.id, 'id'),
+    set,
+  }
+}
+
+function rowToPipeline(row, fieldMappings) {
+  if (!row) return null
+  const result = {
+    id: row.id,
+    tenantId: row.tenant_id,
+    workspaceId: row.workspace_id ?? null,
+    projectId: row.project_id ?? null,
+    name: row.name,
+    description: row.description ?? null,
+    sourceSystemId: row.source_system_id,
+    sourceObject: row.source_object,
+    targetSystemId: row.target_system_id,
+    targetObject: row.target_object,
+    stagingSheetId: row.staging_sheet_id ?? null,
+    mode: row.mode,
+    idempotencyKeyFields: row.idempotency_key_fields ?? [],
+    options: row.options ?? {},
+    status: row.status,
+    createdBy: row.created_by ?? null,
+    createdAt: row.created_at ?? null,
+    updatedAt: row.updated_at ?? null,
+  }
+  if (fieldMappings !== undefined) result.fieldMappings = fieldMappings
+  return result
+}
+
+function rowToFieldMapping(row) {
+  return {
+    id: row.id,
+    pipelineId: row.pipeline_id,
+    sourceField: row.source_field,
+    targetField: row.target_field,
+    transform: row.transform ?? null,
+    validation: row.validation ?? null,
+    defaultValue: row.default_value ?? null,
+    sortOrder: row.sort_order ?? 0,
+    createdAt: row.created_at ?? null,
+  }
+}
+
+function rowToPipelineRun(row) {
+  return {
+    id: row.id,
+    tenantId: row.tenant_id,
+    workspaceId: row.workspace_id ?? null,
+    pipelineId: row.pipeline_id,
+    mode: row.mode,
+    triggeredBy: row.triggered_by,
+    status: row.status,
+    rowsRead: row.rows_read ?? 0,
+    rowsCleaned: row.rows_cleaned ?? 0,
+    rowsWritten: row.rows_written ?? 0,
+    rowsFailed: row.rows_failed ?? 0,
+    startedAt: row.started_at ?? null,
+    finishedAt: row.finished_at ?? null,
+    durationMs: row.duration_ms ?? null,
+    errorSummary: row.error_summary ?? null,
+    details: row.details ?? {},
+    createdAt: row.created_at ?? null,
+  }
+}
+
+function unwrapRows(result) {
+  return Array.isArray(result) ? result : result?.rows ?? []
+}
+
+async function selectPipeline(db, input) {
+  if (input.id) {
+    return db.selectOne(PIPELINES_TABLE, {
+      ...scopeWhere(input),
+      id: input.id,
+    })
+  }
+  return db.selectOne(PIPELINES_TABLE, {
+    ...scopeWhere(input),
+    name: input.name,
+  })
+}
+
+async function requireExternalSystem(db, normalized, systemId, expectedRoles, field) {
+  const row = await db.selectOne(EXTERNAL_SYSTEMS_TABLE, {
+    ...scopeWhere(normalized),
+    id: systemId,
+  })
+  if (!row) {
+    throw new PipelineValidationError(`${field} does not exist in this tenant/workspace`, { field, systemId })
+  }
+  if (!expectedRoles.has(row.role)) {
+    throw new PipelineValidationError(`${field} role must be one of ${Array.from(expectedRoles).join(', ')}`, {
+      field,
+      systemId,
+      role: row.role,
+    })
+  }
+  return row
+}
+
+async function replaceFieldMappings(db, pipelineId, mappings, idGenerator) {
+  await db.deleteRows(FIELD_MAPPINGS_TABLE, { pipeline_id: pipelineId })
+  if (!mappings || mappings.length === 0) return []
+
+  const rows = mappings.map((mapping) => ({
+    id: mapping.id || idGenerator(),
+    pipeline_id: pipelineId,
+    source_field: mapping.sourceField,
+    target_field: mapping.targetField,
+    transform: mapping.transform,
+    validation: mapping.validation,
+    default_value: mapping.defaultValue,
+    sort_order: mapping.sortOrder,
+  }))
+  return unwrapRows(await db.insertMany(FIELD_MAPPINGS_TABLE, rows)).map(rowToFieldMapping)
+}
+
+async function loadFieldMappings(db, pipelineId) {
+  const rows = unwrapRows(await db.select(FIELD_MAPPINGS_TABLE, {
+    where: { pipeline_id: pipelineId },
+    orderBy: ['sort_order', 'ASC'],
+    limit: 10000,
+  }))
+  return rows.map(rowToFieldMapping)
+}
+
+function createPipelineRegistry({ db, idGenerator = crypto.randomUUID } = {}) {
+  if (!db || typeof db.selectOne !== 'function' || typeof db.insertOne !== 'function' || typeof db.updateRow !== 'function' || typeof db.select !== 'function') {
+    throw new Error('createPipelineRegistry: scoped db helper is required')
+  }
+
+  async function upsertPipeline(input) {
+    const normalized = normalizePipelineInput(input)
+
+    const write = async (scopedDb) => {
+      await requireExternalSystem(scopedDb, normalized, normalized.sourceSystemId, SOURCE_ROLES, 'sourceSystemId')
+      await requireExternalSystem(scopedDb, normalized, normalized.targetSystemId, TARGET_ROLES, 'targetSystemId')
+
+      const existing = await selectPipeline(scopedDb, normalized)
+      const baseRow = {
+        tenant_id: normalized.tenantId,
+        workspace_id: normalized.workspaceId,
+        project_id: normalized.projectId,
+        name: normalized.name,
+        description: normalized.description,
+        source_system_id: normalized.sourceSystemId,
+        source_object: normalized.sourceObject,
+        target_system_id: normalized.targetSystemId,
+        target_object: normalized.targetObject,
+        staging_sheet_id: normalized.stagingSheetId,
+        mode: normalized.mode,
+        idempotency_key_fields: normalized.idempotencyKeyFields,
+        options: normalized.options,
+        status: normalized.status,
+      }
+
+      let row
+      if (existing) {
+        const updateRow = { ...baseRow }
+        const rows = unwrapRows(await scopedDb.updateRow(PIPELINES_TABLE, updateRow, {
+          ...scopeWhere(normalized),
+          id: existing.id,
+        }))
+        row = rows[0] || { ...existing, ...updateRow }
+      } else {
+        const insertRow = {
+          id: normalized.id || idGenerator(),
+          ...baseRow,
+          created_by: normalized.createdBy,
+        }
+        const rows = unwrapRows(await scopedDb.insertOne(PIPELINES_TABLE, insertRow))
+        row = rows[0] || insertRow
+      }
+
+      let fieldMappings
+      if (normalized.fieldMappings !== undefined) {
+        fieldMappings = await replaceFieldMappings(scopedDb, row.id, normalized.fieldMappings, idGenerator)
+      }
+      return rowToPipeline(row, fieldMappings)
+    }
+
+    if (normalized.fieldMappings !== undefined) {
+      if (typeof db.transaction !== 'function') {
+        throw new Error('createPipelineRegistry: db.transaction is required when fieldMappings are provided')
+      }
+      return db.transaction(write)
+    }
+    return write(db)
+  }
+
+  async function getPipeline(input) {
+    const tenantId = requiredString(input?.tenantId, 'tenantId')
+    const workspaceId = normalizeWorkspaceId(input?.workspaceId)
+    const id = requiredString(input?.id, 'id')
+    const row = await db.selectOne(PIPELINES_TABLE, {
+      tenant_id: tenantId,
+      workspace_id: workspaceId,
+      id,
+    })
+    if (!row) {
+      throw new PipelineNotFoundError('pipeline not found', { id, tenantId, workspaceId })
+    }
+    const includeFieldMappings = input?.includeFieldMappings !== false
+    const fieldMappings = includeFieldMappings ? await loadFieldMappings(db, row.id) : undefined
+    return rowToPipeline(row, fieldMappings)
+  }
+
+  async function listPipelines(input = {}) {
+    const tenantId = requiredString(input.tenantId, 'tenantId')
+    const workspaceId = normalizeWorkspaceId(input.workspaceId)
+    const where = scopeWhere({ tenantId, workspaceId })
+    if (input.status) {
+      const status = requiredString(input.status, 'status')
+      if (!VALID_STATUSES.has(status)) {
+        throw new PipelineValidationError(`status must be one of ${Array.from(VALID_STATUSES).join(', ')}`, { field: 'status' })
+      }
+      where.status = status
+    }
+    if (input.sourceSystemId) where.source_system_id = requiredString(input.sourceSystemId, 'sourceSystemId')
+    if (input.targetSystemId) where.target_system_id = requiredString(input.targetSystemId, 'targetSystemId')
+
+    const rows = unwrapRows(await db.select(PIPELINES_TABLE, {
+      where,
+      orderBy: ['created_at', 'DESC'],
+      limit: input.limit,
+      offset: input.offset,
+    }))
+    return rows.map(row => rowToPipeline(row))
+  }
+
+  async function createPipelineRun(input) {
+    const normalized = normalizeCreateRunInput(input)
+    const pipeline = await db.selectOne(PIPELINES_TABLE, {
+      ...scopeWhere(normalized),
+      id: normalized.pipelineId,
+    })
+    if (!pipeline) {
+      throw new PipelineNotFoundError('pipeline not found', {
+        id: normalized.pipelineId,
+        tenantId: normalized.tenantId,
+        workspaceId: normalized.workspaceId,
+      })
+    }
+    if (pipeline.status === 'disabled') {
+      throw new PipelineValidationError('disabled pipeline cannot create runs', {
+        pipelineId: normalized.pipelineId,
+        status: pipeline.status,
+      })
+    }
+    const insertRow = {
+      id: normalized.id || idGenerator(),
+      tenant_id: normalized.tenantId,
+      workspace_id: normalized.workspaceId,
+      pipeline_id: normalized.pipelineId,
+      mode: normalized.mode,
+      triggered_by: normalized.triggeredBy,
+      status: normalized.status,
+      rows_read: normalized.rowsRead,
+      rows_cleaned: normalized.rowsCleaned,
+      rows_written: normalized.rowsWritten,
+      rows_failed: normalized.rowsFailed,
+      started_at: normalized.startedAt,
+      finished_at: normalized.finishedAt,
+      duration_ms: normalized.durationMs,
+      error_summary: normalized.errorSummary,
+      details: normalized.details,
+    }
+    const rows = unwrapRows(await db.insertOne(RUNS_TABLE, insertRow))
+    return rowToPipelineRun(rows[0] || insertRow)
+  }
+
+  async function updatePipelineRun(input) {
+    const normalized = normalizeUpdateRunInput(input, () => new Date().toISOString())
+    const rows = unwrapRows(await db.updateRow(RUNS_TABLE, normalized.set, {
+      tenant_id: normalized.tenantId,
+      workspace_id: normalized.workspaceId,
+      id: normalized.id,
+    }))
+    const row = rows[0]
+    if (!row) {
+      throw new PipelineNotFoundError('pipeline run not found', {
+        id: normalized.id,
+        tenantId: normalized.tenantId,
+        workspaceId: normalized.workspaceId,
+      })
+    }
+    return rowToPipelineRun(row)
+  }
+
+  async function listPipelineRuns(input = {}) {
+    const tenantId = requiredString(input.tenantId, 'tenantId')
+    const workspaceId = normalizeWorkspaceId(input.workspaceId)
+    const where = scopeWhere({ tenantId, workspaceId })
+    if (input.pipelineId) where.pipeline_id = requiredString(input.pipelineId, 'pipelineId')
+    if (input.status) {
+      const status = requiredString(input.status, 'status')
+      if (!VALID_RUN_STATUSES.has(status)) {
+        throw new PipelineValidationError(`status must be one of ${Array.from(VALID_RUN_STATUSES).join(', ')}`, { field: 'status' })
+      }
+      where.status = status
+    }
+    const rows = unwrapRows(await db.select(RUNS_TABLE, {
+      where,
+      orderBy: ['created_at', 'DESC'],
+      limit: input.limit,
+      offset: input.offset,
+    }))
+    return rows.map(rowToPipelineRun)
+  }
+
+  return {
+    upsertPipeline,
+    getPipeline,
+    listPipelines,
+    createPipelineRun,
+    updatePipelineRun,
+    listPipelineRuns,
+  }
+}
+
+module.exports = {
+  createPipelineRegistry,
+  PipelineValidationError,
+  PipelineNotFoundError,
+  __internals: {
+    PIPELINES_TABLE,
+    FIELD_MAPPINGS_TABLE,
+    EXTERNAL_SYSTEMS_TABLE,
+    RUNS_TABLE,
+    VALID_MODES,
+    VALID_RUN_MODES,
+    VALID_STATUSES,
+    VALID_RUN_STATUSES,
+    VALID_TRIGGERS,
+    normalizePipelineInput,
+    normalizeFieldMappings,
+    normalizeCreateRunInput,
+    normalizeUpdateRunInput,
+    rowToPipeline,
+    rowToFieldMapping,
+    rowToPipelineRun,
+  },
+}

--- a/plugins/plugin-integration-core/package.json
+++ b/plugins/plugin-integration-core/package.json
@@ -6,7 +6,7 @@
   "license": "UNLICENSED",
   "private": true,
   "scripts": {
-    "test": "node __tests__/plugin-runtime-smoke.test.cjs && node --import tsx __tests__/host-loader-smoke.test.mjs && node __tests__/credential-store.test.cjs && node __tests__/db.test.cjs && node __tests__/external-systems.test.cjs && node __tests__/adapter-contracts.test.cjs && node __tests__/http-adapter.test.cjs && node __tests__/staging-installer.test.cjs && node __tests__/migration-sql.test.cjs",
+    "test": "node __tests__/plugin-runtime-smoke.test.cjs && node --import tsx __tests__/host-loader-smoke.test.mjs && node __tests__/credential-store.test.cjs && node __tests__/db.test.cjs && node __tests__/external-systems.test.cjs && node __tests__/adapter-contracts.test.cjs && node __tests__/http-adapter.test.cjs && node __tests__/pipelines.test.cjs && node __tests__/staging-installer.test.cjs && node __tests__/migration-sql.test.cjs",
     "test:runtime": "node __tests__/plugin-runtime-smoke.test.cjs",
     "test:host-loader": "node --import tsx __tests__/host-loader-smoke.test.mjs",
     "test:credential": "node __tests__/credential-store.test.cjs",
@@ -14,6 +14,7 @@
     "test:external-systems": "node __tests__/external-systems.test.cjs",
     "test:adapter-contracts": "node __tests__/adapter-contracts.test.cjs",
     "test:http-adapter": "node __tests__/http-adapter.test.cjs",
+    "test:pipelines": "node __tests__/pipelines.test.cjs",
     "test:staging": "node __tests__/staging-installer.test.cjs",
     "test:migration": "node __tests__/migration-sql.test.cjs"
   }


### PR DESCRIPTION
## Summary

M1 PR3 stacked on #1148. Adds the pipeline registry slice on top of the adapter-contract layer.

Changes:
- Add `pipelines.cjs` for pipeline definitions, endpoint metadata, field mappings, and run-ledger persistence.
- Expose pipeline registry methods on the `integration-core` communication namespace.
- Add runtime status for pipeline-registry initialization.
- Add focused `pipelines.test.cjs` coverage.
- Add pipeline-registry design and verification docs.

## Scope Boundaries

This PR intentionally does not include:
- pipeline runner execution
- transform/validator/idempotency/watermark/dead-letter/run-log modules
- REST control plane routes beyond health
- K3 WISE adapters
- Yuantus PLM wrapper
- ERP feedback writer
- PR6-PR9 bundle content

## Verification

Run from the stacked PR3 branch:

```bash
node --check plugins/plugin-integration-core/lib/pipelines.cjs
node --check plugins/plugin-integration-core/__tests__/pipelines.test.cjs
pnpm -F plugin-integration-core test:pipelines
pnpm -F plugin-integration-core test:external-systems
pnpm -F plugin-integration-core test:runtime
pnpm -F plugin-integration-core test:host-loader
pnpm -F plugin-integration-core test
git diff --check
```

Results:
- pipelines passed
- external-systems passed
- runtime smoke passed
- host-loader smoke passed
- full plugin-integration-core package test passed
- syntax and whitespace checks passed

## Stack Note

Base branch is `codex/integration-core-m1-adapters-20260425` (#1148). Merge order should be #1148 first, then this PR.