### PR TITLE
feat(integration): add integration rest api

### DIFF
--- a/docs/development/integration-core-rest-api-design-20260424.md
+++ b/docs/development/integration-core-rest-api-design-20260424.md
@@ -1,0 +1,129 @@
+# Integration Core REST API Design - 2026-04-24
+
+## Context
+
+M1 now has plugin-local registries, adapter contracts, and a pipeline runner.
+The next slice adds a thin REST control plane so the frontend and operational
+tools can configure and trigger integration work without calling the internal
+communication namespace directly.
+
+This REST layer does not own business logic. It delegates to the existing
+registries and runner.
+
+## Module
+
+Add:
+
+- `plugins/plugin-integration-core/lib/http-routes.cjs`
+
+`index.cjs` registers the route set during plugin activation after the service
+objects are created.
+
+## Routes
+
+Registered routes:
+
+```text
+GET  /api/integration/status
+GET  /api/integration/external-systems
+POST /api/integration/external-systems
+GET  /api/integration/external-systems/:id
+POST /api/integration/external-systems/:id/test
+GET  /api/integration/pipelines
+POST /api/integration/pipelines
+GET  /api/integration/pipelines/:id
+POST /api/integration/pipelines/:id/run
+POST /api/integration/pipelines/:id/dry-run
+GET  /api/integration/runs
+GET  /api/integration/dead-letters
+POST /api/integration/dead-letters/:id/replay
+```
+
+The existing health endpoint remains:
+
+```text
+GET /api/integration/health
+```
+
+## Auth And Scope
+
+The route layer expects global auth middleware to populate `req.user`. It still
+performs local defensive checks:
+
+- missing user -> `401 UNAUTHENTICATED`
+- missing permission -> `403 FORBIDDEN`
+- missing tenant -> `400 TENANT_REQUIRED`
+- request tenant mismatch with authenticated user's tenant -> `403 TENANT_MISMATCH`
+- non-admin users without an authenticated tenant context -> `403 TENANT_CONTEXT_REQUIRED`
+
+Supported permissions:
+
+- read routes: `integration:read`, `integration:write`, `integration:admin`, or admin role
+- write routes: `integration:write`, `integration:admin`, or admin role
+
+All service calls receive a normalized `tenantId` and `workspaceId`.
+
+Run and dry-run routes whitelist public fields before calling the runner:
+
+- `tenantId`
+- `workspaceId`
+- `mode`
+- `cursor`
+- `sampleLimit`
+
+They do not pass through internal runner fields such as `sourceRecords`,
+`allowInactive`, caller-supplied `triggeredBy`, or arbitrary `details`.
+
+## Error Shape
+
+All route errors use:
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "SOME_CODE",
+    "message": "Human-readable message",
+    "details": {}
+  }
+}
+```
+
+Successful responses use:
+
+```json
+{
+  "ok": true,
+  "data": {}
+}
+```
+
+Named service errors are translated before response:
+
+- `*Validation*` -> `400`
+- `*NotFound*` -> `404`
+- `PipelineRunnerError` -> `422`
+
+## Credential Safety
+
+The route layer never returns plaintext credentials. External-system public
+results already expose only credential metadata from the registry:
+
+- `hasCredentials`
+- `credentialFormat`
+- `credentialFingerprint`
+
+Connection tests use the same internal credential-aware registry method as the
+runner, then pass the hydrated system only to adapter construction. Responses
+still never include credentials.
+
+Dead-letter list responses omit `sourcePayload` and `transformedPayload` by
+default. Admin/integration-admin callers can request payloads with
+`includePayload=true`, but payloads still pass through sensitive-key redaction.
+
+## Deferred
+
+- OpenAPI contract generation.
+- Frontend wiring.
+- Fine-grained RBAC resources beyond `integration:*`.
+- Streaming run logs.

--- a/docs/development/integration-core-rest-api-verification-20260424.md
+++ b/docs/development/integration-core-rest-api-verification-20260424.md
@@ -1,0 +1,67 @@
+# Integration Core REST API Verification - 2026-04-24
+
+## Scope
+
+Verify the REST control plane for `plugin-integration-core`:
+
+- route registration during plugin activation.
+- read/write auth guard behavior.
+- tenant scope injection and mismatch rejection.
+- external system list/upsert/get/test.
+- pipeline list/upsert/get/run/dry-run.
+- run and dead-letter listing.
+- dead-letter replay endpoint.
+- consistent error response shape.
+
+## Commands Run
+
+```bash
+pnpm -F plugin-integration-core test
+node --import tsx scripts/validate-plugin-manifests.ts
+git diff --check
+```
+
+## Results
+
+- `plugin-integration-core` package tests: passed.
+- New `http-routes.test.cjs`: passed.
+- Plugin manifest validation through `node --import tsx`: passed, 13/13 valid,
+  0 errors.
+- `git diff --check`: passed.
+
+`pnpm validate:plugins` was also attempted and failed before validation due to
+the known sandbox `tsx` IPC `listen EPERM` restriction. The direct
+`node --import tsx` manifest validation above passed.
+
+## Covered Behaviors
+
+Expected route test coverage:
+
+- unauthenticated write request is rejected and does not reach services.
+- tenant mismatch is rejected.
+- non-admin users without tenant context are rejected.
+- successful external-system and pipeline writes receive scoped tenant input.
+- caller-supplied `createdBy` is ignored in favor of the authenticated actor.
+- run routes strip internal runner fields such as `sourceRecords`,
+  `allowInactive`, caller-supplied `triggeredBy`, and arbitrary `details`.
+- external-system test route uses the internal credential-aware registry method
+  and does not return credentials.
+- validation and not-found service errors map to `400` and `404`.
+- dead-letter list redacts payloads for non-admin read callers.
+- admin `includePayload=true` returns payloads with sensitive fields redacted.
+- route errors return `ok:false` with `error.code`.
+- `dry-run` calls runner with `dryRun: true`.
+- dead-letter replay calls `replayDeadLetter()`.
+
+Additional package-level coverage from this slice:
+
+- plugin activation registers health plus 13 REST routes.
+- `POST /api/integration/pipelines/:id/dry-run` returns preview-style runner output without target writes.
+- `POST /api/integration/dead-letters/:id/replay` returns replayed dead-letter status.
+
+## Not Covered
+
+- Real JWT middleware.
+- Browser/frontend flows.
+- OpenAPI generated client.
+- Live external PLM/ERP systems.

--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -1,0 +1,684 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const path = require('node:path')
+
+const HTTP_ROUTES_PATH = path.join(__dirname, '..', 'lib', 'http-routes.cjs')
+const httpRoutes = require(HTTP_ROUTES_PATH)
+
+const READ_USER = {
+  id: 'user_read',
+  tenantId: 'tenant_1',
+  permissions: ['integration:read'],
+}
+
+const WRITE_USER = {
+  id: 'user_write',
+  email: 'writer@example.test',
+  tenantId: 'tenant_1',
+  permissions: ['integration:write'],
+}
+
+const ADMIN_USER = {
+  id: 'user_admin',
+  tenantId: 'tenant_1',
+  roles: ['admin'],
+  permissions: ['integration:admin'],
+}
+
+function createMockContext() {
+  const routes = new Map()
+
+  return {
+    context: {
+      api: {
+        http: {
+          addRoute(method, routePath, handler) {
+            assert.equal(typeof method, 'string', 'method is a string')
+            assert.equal(typeof routePath, 'string', 'path is a string')
+            assert.equal(typeof handler, 'function', 'handler is a function')
+            routes.set(`${method.toUpperCase()} ${routePath}`, { method, path: routePath, handler })
+          },
+        },
+      },
+    },
+    routes,
+  }
+}
+
+function mergeServiceOverrides(target, overrides) {
+  for (const [key, value] of Object.entries(overrides || {})) {
+    if (
+      value &&
+      typeof value === 'object' &&
+      !Array.isArray(value) &&
+      target[key] &&
+      typeof target[key] === 'object'
+    ) {
+      Object.assign(target[key], value)
+    } else {
+      target[key] = value
+    }
+  }
+  return target
+}
+
+function createMockServices(overrides = {}) {
+  const calls = []
+  const system = {
+    id: 'sys_1',
+    tenantId: 'tenant_1',
+    workspaceId: 'workspace_1',
+    name: 'K3 WISE',
+    kind: 'erp',
+    role: 'target',
+    status: 'active',
+    hasCredentials: true,
+  }
+  const pipeline = {
+    id: 'pipe_1',
+    tenantId: 'tenant_1',
+    workspaceId: 'workspace_1',
+    name: 'Material sync',
+    status: 'active',
+    sourceSystemId: 'plm_1',
+    targetSystemId: 'sys_1',
+    fieldMappings: [],
+  }
+  const run = {
+    id: 'run_1',
+    tenantId: 'tenant_1',
+    workspaceId: 'workspace_1',
+    pipelineId: 'pipe_1',
+    status: 'succeeded',
+    rowsRead: 2,
+    rowsWritten: 2,
+  }
+  const deadLetter = {
+    id: 'dl_1',
+    tenantId: 'tenant_1',
+    workspaceId: 'workspace_1',
+    runId: 'run_1',
+    pipelineId: 'pipe_1',
+    status: 'open',
+    errorCode: 'VALIDATION_FAILED',
+    sourcePayload: {
+      code: 'MAT-001',
+      password: 'source-secret',
+      headers: { Authorization: 'Bearer source-token' },
+    },
+    transformedPayload: {
+      FNumber: 'MAT-001',
+      token: 'target-token',
+    },
+  }
+
+  const services = {
+    externalSystemRegistry: {
+      async listExternalSystems(input) {
+        calls.push(['listExternalSystems', input])
+        return [system]
+      },
+      async upsertExternalSystem(input) {
+        calls.push(['upsertExternalSystem', input])
+        return { ...system, ...input, id: input.id || system.id }
+      },
+      async getExternalSystem(input) {
+        calls.push(['getExternalSystem', input])
+        return { ...system, id: input.id }
+      },
+      async getExternalSystemForAdapter(input) {
+        calls.push(['getExternalSystemForAdapter', input])
+        return { ...system, id: input.id, credentials: { bearerToken: 'secret-token' } }
+      },
+    },
+    adapterRegistry: {
+      listAdapterKinds() {
+        calls.push(['listAdapterKinds'])
+        return ['http']
+      },
+      createAdapter(input) {
+        calls.push(['createAdapter', input])
+        return {
+          async testConnection(body) {
+            calls.push(['testConnection', body])
+            return { ok: true, status: 200 }
+          },
+        }
+      },
+    },
+    pipelineRegistry: {
+      async listPipelines(input) {
+        calls.push(['listPipelines', input])
+        return [pipeline]
+      },
+      async upsertPipeline(input) {
+        calls.push(['upsertPipeline', input])
+        return { ...pipeline, ...input, id: input.id || pipeline.id }
+      },
+      async getPipeline(input) {
+        calls.push(['getPipeline', input])
+        return { ...pipeline, id: input.id }
+      },
+      async listPipelineRuns(input) {
+        calls.push(['listPipelineRuns', input])
+        return [run]
+      },
+    },
+    pipelineRunner: {
+      async runPipeline(input) {
+        calls.push(['runPipeline', input])
+        return {
+          run: {
+            ...run,
+            pipelineId: input.pipelineId,
+            details: { dryRun: input.dryRun === true },
+          },
+          metrics: {
+            rowsRead: 2,
+            rowsCleaned: input.dryRun ? 2 : 0,
+            rowsWritten: input.dryRun ? 0 : 2,
+            rowsFailed: 0,
+          },
+        }
+      },
+      async replayDeadLetter(input) {
+        calls.push(['replayDeadLetter', input])
+        return {
+          deadLetter: { ...deadLetter, id: input.id, status: 'replayed' },
+          run: { ...run, id: 'run_replay_1', status: 'succeeded' },
+        }
+      },
+    },
+    deadLetterStore: {
+      async listDeadLetters(input) {
+        calls.push(['listDeadLetters', input])
+        return [deadLetter]
+      },
+    },
+  }
+
+  return {
+    calls,
+    services: mergeServiceOverrides(services, overrides),
+  }
+}
+
+function mountRoutes(services) {
+  const { context, routes } = createMockContext()
+  const registerRoutes = httpRoutes.registerIntegrationRoutes || httpRoutes.createIntegrationHttpRouter
+  assert.equal(typeof registerRoutes, 'function', 'HTTP routes module exports a registration function')
+
+  const registered = registerRoutes({
+    context,
+    services,
+    logger: {
+      warn() {},
+      error() {},
+      info() {},
+    },
+  })
+
+  return { routes, registered }
+}
+
+function getRoute(routes, method, routePath) {
+  const key = `${method.toUpperCase()} ${routePath}`
+  const route = routes.get(key)
+  assert.ok(route, `expected route ${key} to be registered`)
+  return route
+}
+
+function createResponse() {
+  return {
+    statusCode: 200,
+    body: undefined,
+    status(code) {
+      this.statusCode = code
+      return this
+    },
+    json(body) {
+      this.body = body
+      return this
+    },
+  }
+}
+
+async function invoke(routes, method, routePath, req = {}) {
+  const route = getRoute(routes, method, routePath)
+  const res = createResponse()
+  await route.handler({
+    user: req.user,
+    authUser: req.authUser,
+    body: req.body || {},
+    query: req.query || {},
+    params: req.params || {},
+  }, res)
+  assert.notEqual(res.body, undefined, `${method} ${routePath} produced a JSON body`)
+  return res
+}
+
+function findCall(calls, name) {
+  const call = calls.find(([callName]) => callName === name)
+  assert.ok(call, `expected ${name} to be called`)
+  return call
+}
+
+function findCalls(calls, name) {
+  return calls.filter(([callName]) => callName === name)
+}
+
+function assertOkResponse(res, expectedStatus) {
+  assert.equal(res.statusCode, expectedStatus)
+  assert.equal(res.body.ok, true)
+  assert.ok('data' in res.body, 'success responses wrap payload in data')
+}
+
+function assertErrorResponse(res, allowedStatuses) {
+  assert.ok(allowedStatuses.includes(res.statusCode), `status ${res.statusCode} is allowed`)
+  assert.equal(res.body.ok, false)
+  assert.equal(typeof res.body.error, 'object')
+  assert.equal(typeof res.body.error.code, 'string')
+  assert.ok(res.body.error.code.length > 0)
+}
+
+async function testUnauthenticatedWriteRequestIsRejected() {
+  const { calls, services } = createMockServices()
+  const { routes } = mountRoutes(services)
+
+  const res = await invoke(routes, 'POST', '/api/integration/pipelines', {
+    body: {
+      tenantId: 'tenant_1',
+      name: 'Material sync',
+    },
+  })
+
+  assertErrorResponse(res, [401, 403])
+  assert.equal(calls.length, 0, 'unauthenticated write did not reach services')
+}
+
+async function testExternalSystemRoutes() {
+  const { calls, services } = createMockServices()
+  const { routes, registered } = mountRoutes(services)
+
+  assert.ok(
+    registered.includes('GET /api/integration/external-systems'),
+    'external systems list route registered',
+  )
+
+  let res = await invoke(routes, 'GET', '/api/integration/external-systems', {
+    user: READ_USER,
+    query: {
+      workspaceId: 'workspace_1',
+      kind: 'erp',
+      status: 'active',
+      limit: '25',
+      offset: '2',
+    },
+  })
+  assertOkResponse(res, 200)
+  assert.deepEqual(res.body.data.map((item) => item.id), ['sys_1'])
+  assert.deepEqual(findCall(calls, 'listExternalSystems')[1], {
+    tenantId: 'tenant_1',
+    workspaceId: 'workspace_1',
+    kind: 'erp',
+    status: 'active',
+    limit: 25,
+    offset: 2,
+  })
+
+  res = await invoke(routes, 'POST', '/api/integration/external-systems', {
+    user: WRITE_USER,
+    body: {
+      id: 'sys_2',
+      tenantId: 'tenant_1',
+      workspaceId: 'workspace_1',
+      name: 'Kingdee K3',
+      kind: 'erp',
+      role: 'target',
+      status: 'active',
+      credentials: { token: 'secret' },
+    },
+  })
+  assertOkResponse(res, 201)
+  assert.equal(res.body.data.id, 'sys_2')
+  assert.deepEqual(findCall(calls, 'upsertExternalSystem')[1], {
+    id: 'sys_2',
+    tenantId: 'tenant_1',
+    workspaceId: 'workspace_1',
+    name: 'Kingdee K3',
+    kind: 'erp',
+    role: 'target',
+    status: 'active',
+    credentials: { token: 'secret' },
+  })
+
+  res = await invoke(routes, 'GET', '/api/integration/external-systems/:id', {
+    user: READ_USER,
+    params: { id: 'sys_2' },
+    query: { workspaceId: 'workspace_1' },
+  })
+  assertOkResponse(res, 200)
+  assert.equal(res.body.data.id, 'sys_2')
+  assert.deepEqual(findCall(calls, 'getExternalSystem')[1], {
+    id: 'sys_2',
+    tenantId: 'tenant_1',
+    workspaceId: 'workspace_1',
+  })
+
+  res = await invoke(routes, 'POST', '/api/integration/external-systems/:id/test', {
+    user: WRITE_USER,
+    params: { id: 'sys_2' },
+    query: { workspaceId: 'workspace_1' },
+    body: { path: '/health' },
+  })
+  assertOkResponse(res, 200)
+  assert.deepEqual(findCall(calls, 'getExternalSystemForAdapter')[1], {
+    id: 'sys_2',
+    tenantId: 'tenant_1',
+    workspaceId: 'workspace_1',
+  })
+  assert.deepEqual(findCall(calls, 'createAdapter')[1].credentials, { bearerToken: 'secret-token' })
+  assert.equal(res.body.data.ok, true)
+  assert.equal(res.body.data.credentials, undefined, 'test response does not leak credentials')
+}
+
+async function testPipelineRoutes() {
+  const { calls, services } = createMockServices()
+  const { routes } = mountRoutes(services)
+
+  let res = await invoke(routes, 'GET', '/api/integration/pipelines', {
+    user: READ_USER,
+    query: {
+      workspaceId: 'workspace_1',
+      status: 'active',
+      sourceSystemId: 'plm_1',
+      targetSystemId: 'sys_1',
+      limit: '10',
+      offset: '2',
+    },
+  })
+  assertOkResponse(res, 200)
+  assert.deepEqual(res.body.data.map((item) => item.id), ['pipe_1'])
+  assert.deepEqual(findCall(calls, 'listPipelines')[1], {
+    tenantId: 'tenant_1',
+    workspaceId: 'workspace_1',
+    status: 'active',
+    sourceSystemId: 'plm_1',
+    targetSystemId: 'sys_1',
+    limit: 10,
+    offset: 2,
+  })
+
+  res = await invoke(routes, 'POST', '/api/integration/pipelines', {
+    user: WRITE_USER,
+    body: {
+      tenantId: 'tenant_1',
+      workspaceId: 'workspace_1',
+      name: 'Material sync v2',
+      sourceSystemId: 'plm_1',
+      sourceObject: 'materials',
+      targetSystemId: 'sys_1',
+      targetObject: 'BD_MATERIAL',
+      status: 'active',
+      fieldMappings: [],
+      createdBy: 'spoofed_actor',
+    },
+  })
+  assertOkResponse(res, 201)
+  assert.equal(res.body.data.name, 'Material sync v2')
+  assert.equal(findCall(calls, 'upsertPipeline')[1].createdBy, 'user_write')
+
+  res = await invoke(routes, 'POST', '/api/integration/pipelines/:id/run', {
+    user: WRITE_USER,
+    params: { id: 'pipe_1' },
+    body: {
+      tenantId: 'tenant_1',
+      workspaceId: 'workspace_1',
+      mode: 'manual',
+      allowInactive: true,
+      sourceRecords: [{ code: 'spoofed' }],
+      triggeredBy: 'spoofed',
+      details: { unsafe: true },
+    },
+  })
+  assertOkResponse(res, 202)
+  const runCall = findCalls(calls, 'runPipeline')[0]
+  assert.deepEqual(runCall[1], {
+    tenantId: 'tenant_1',
+    workspaceId: 'workspace_1',
+    mode: 'manual',
+    pipelineId: 'pipe_1',
+    triggeredBy: 'api',
+  })
+  assert.equal('allowInactive' in runCall[1], false)
+  assert.equal('sourceRecords' in runCall[1], false)
+  assert.equal('details' in runCall[1], false)
+
+  res = await invoke(routes, 'POST', '/api/integration/pipelines/:id/dry-run', {
+    user: WRITE_USER,
+    params: { id: 'pipe_1' },
+    body: {
+      tenantId: 'tenant_1',
+      workspaceId: 'workspace_1',
+      mode: 'manual',
+      sampleLimit: 2,
+    },
+  })
+  assertOkResponse(res, 200)
+  const dryRunCall = findCalls(calls, 'runPipeline')[1]
+  assert.equal(dryRunCall[1].pipelineId, 'pipe_1')
+  assert.equal(dryRunCall[1].triggeredBy, 'api')
+  assert.equal(dryRunCall[1].dryRun, true)
+  assert.equal(dryRunCall[1].sampleLimit, 2)
+  assert.equal(res.body.data.metrics.rowsWritten, 0, 'dry-run response does not report target writes')
+}
+
+async function testRunAndDeadLetterRoutes() {
+  const { calls, services } = createMockServices()
+  const { routes } = mountRoutes(services)
+
+  let res = await invoke(routes, 'GET', '/api/integration/runs', {
+    user: READ_USER,
+    query: {
+      workspaceId: 'workspace_1',
+      pipelineId: 'pipe_1',
+      status: 'succeeded',
+      limit: '20',
+      offset: '2',
+    },
+  })
+  assertOkResponse(res, 200)
+  assert.deepEqual(res.body.data.map((item) => item.id), ['run_1'])
+  assert.deepEqual(findCall(calls, 'listPipelineRuns')[1], {
+    tenantId: 'tenant_1',
+    workspaceId: 'workspace_1',
+    pipelineId: 'pipe_1',
+    status: 'succeeded',
+    limit: 20,
+    offset: 2,
+  })
+
+  res = await invoke(routes, 'GET', '/api/integration/dead-letters', {
+    user: READ_USER,
+    query: {
+      workspaceId: 'workspace_1',
+      pipelineId: 'pipe_1',
+      runId: 'run_1',
+      status: 'open',
+      limit: '20',
+      offset: '2',
+    },
+  })
+  assertOkResponse(res, 200)
+  assert.deepEqual(res.body.data.map((item) => item.id), ['dl_1'])
+  assert.equal(res.body.data[0].sourcePayload, undefined, 'read users get redacted dead-letter payloads')
+  assert.equal(res.body.data[0].payloadRedacted, true)
+  assert.deepEqual(findCall(calls, 'listDeadLetters')[1], {
+    tenantId: 'tenant_1',
+    workspaceId: 'workspace_1',
+    pipelineId: 'pipe_1',
+    runId: 'run_1',
+    status: 'open',
+    limit: 20,
+    offset: 2,
+  })
+
+  res = await invoke(routes, 'GET', '/api/integration/dead-letters', {
+    user: WRITE_USER,
+    query: {
+      workspaceId: 'workspace_1',
+      includePayload: 'true',
+    },
+  })
+  assertOkResponse(res, 200)
+  assert.equal(res.body.data[0].sourcePayload, undefined, 'write users are not admins for full payload reads')
+  assert.equal(res.body.data[0].transformedPayload, undefined, 'write users cannot include dead-letter payloads')
+  assert.equal(res.body.data[0].payloadRedacted, true)
+
+  res = await invoke(routes, 'GET', '/api/integration/dead-letters', {
+    user: ADMIN_USER,
+    query: {
+      workspaceId: 'workspace_1',
+      includePayload: 'true',
+    },
+  })
+  assertOkResponse(res, 200)
+  assert.equal(res.body.data[0].sourcePayload.code, 'MAT-001')
+  assert.equal(res.body.data[0].sourcePayload.password, '[redacted]')
+  assert.equal(res.body.data[0].sourcePayload.headers.Authorization, '[redacted]')
+  assert.equal(res.body.data[0].transformedPayload.token, '[redacted]')
+  assert.equal(res.body.data[0].payloadRedacted, true)
+
+  res = await invoke(routes, 'POST', '/api/integration/dead-letters/:id/replay', {
+    user: WRITE_USER,
+    params: { id: 'dl_1' },
+    body: {
+      tenantId: 'tenant_1',
+      workspaceId: 'workspace_1',
+      mode: 'replay',
+      triggeredBy: 'spoofed_actor',
+      allowInactive: true,
+      sourceRecords: [{ code: 'spoofed' }],
+      details: { unsafe: true },
+    },
+  })
+  assertOkResponse(res, 202)
+  assert.equal(res.body.data.deadLetter.status, 'replayed')
+  assert.deepEqual(findCall(calls, 'replayDeadLetter')[1], {
+    tenantId: 'tenant_1',
+    workspaceId: 'workspace_1',
+    mode: 'replay',
+    id: 'dl_1',
+    triggeredBy: 'api',
+  })
+  assert.equal('allowInactive' in findCall(calls, 'replayDeadLetter')[1], false)
+  assert.equal('sourceRecords' in findCall(calls, 'replayDeadLetter')[1], false)
+  assert.equal('details' in findCall(calls, 'replayDeadLetter')[1], false)
+}
+
+async function testErrorResponseShape() {
+  const serviceError = new Error('external system conflict')
+  serviceError.status = 409
+  serviceError.code = 'EXTERNAL_SYSTEM_CONFLICT'
+  serviceError.details = { id: 'sys_1' }
+
+  const { services } = createMockServices({
+    externalSystemRegistry: {
+      async listExternalSystems() {
+        throw serviceError
+      },
+    },
+  })
+  const { routes } = mountRoutes(services)
+
+  const res = await invoke(routes, 'GET', '/api/integration/external-systems', {
+    user: READ_USER,
+    query: { workspaceId: 'workspace_1' },
+  })
+
+  assert.equal(res.statusCode, 409)
+  assert.equal(res.body.ok, false)
+  assert.deepEqual(res.body.error, {
+    code: 'EXTERNAL_SYSTEM_CONFLICT',
+    message: 'external system conflict',
+    details: { id: 'sys_1' },
+  })
+
+  const validationError = new Error('bad input')
+  validationError.name = 'PipelineValidationError'
+  const { services: validationServices } = createMockServices({
+    pipelineRegistry: {
+      async listPipelines() {
+        throw validationError
+      },
+    },
+  })
+  const { routes: validationRoutes } = mountRoutes(validationServices)
+  const validationRes = await invoke(validationRoutes, 'GET', '/api/integration/pipelines', {
+    user: READ_USER,
+    query: { workspaceId: 'workspace_1' },
+  })
+  assert.equal(validationRes.statusCode, 400)
+  assert.equal(validationRes.body.error.code, 'PipelineValidationError')
+
+  const notFoundError = new Error('not found')
+  notFoundError.name = 'ExternalSystemNotFoundError'
+  const { services: notFoundServices } = createMockServices({
+    externalSystemRegistry: {
+      async getExternalSystem() {
+        throw notFoundError
+      },
+    },
+  })
+  const { routes: notFoundRoutes } = mountRoutes(notFoundServices)
+  const notFoundRes = await invoke(notFoundRoutes, 'GET', '/api/integration/external-systems/:id', {
+    user: READ_USER,
+    params: { id: 'missing' },
+    query: { workspaceId: 'workspace_1' },
+  })
+  assert.equal(notFoundRes.statusCode, 404)
+}
+
+async function testTenantGuards() {
+  const { services } = createMockServices()
+  const { routes } = mountRoutes(services)
+
+  const mismatch = await invoke(routes, 'GET', '/api/integration/pipelines', {
+    user: READ_USER,
+    query: { tenantId: 'tenant_2', workspaceId: 'workspace_1' },
+  })
+  assert.equal(mismatch.statusCode, 403)
+  assert.equal(mismatch.body.error.code, 'TENANT_MISMATCH')
+
+  const missingContext = await invoke(routes, 'GET', '/api/integration/pipelines', {
+    user: { id: 'reader_without_tenant', permissions: ['integration:read'] },
+    query: { tenantId: 'tenant_1', workspaceId: 'workspace_1' },
+  })
+  assert.equal(missingContext.statusCode, 403)
+  assert.equal(missingContext.body.error.code, 'TENANT_CONTEXT_REQUIRED')
+
+  const blankContext = await invoke(routes, 'GET', '/api/integration/pipelines', {
+    user: { id: 'reader_blank_tenant', tenantId: '   ', permissions: ['integration:read'] },
+    query: { tenantId: 'tenant_1', workspaceId: 'workspace_1' },
+  })
+  assert.equal(blankContext.statusCode, 403)
+  assert.equal(blankContext.body.error.code, 'TENANT_CONTEXT_REQUIRED')
+}
+
+async function main() {
+  await testUnauthenticatedWriteRequestIsRejected()
+  await testExternalSystemRoutes()
+  await testPipelineRoutes()
+  await testRunAndDeadLetterRoutes()
+  await testErrorResponseShape()
+  await testTenantGuards()
+
+  console.log('http-routes: REST auth/list/upsert/run/dry-run/replay tests passed')
+}
+
+main().catch((err) => {
+  console.error('http-routes FAILED')
+  console.error(err)
+  process.exit(1)
+})

--- a/plugins/plugin-integration-core/index.cjs
+++ b/plugins/plugin-integration-core/index.cjs
@@ -26,6 +26,7 @@ const { createDeadLetterStore } = require('./lib/dead-letter.cjs')
 const { createWatermarkStore } = require('./lib/watermark.cjs')
 const { createRunLogger } = require('./lib/run-log.cjs')
 const { createPipelineRunner } = require('./lib/pipeline-runner.cjs')
+const { registerIntegrationRoutes } = require('./lib/http-routes.cjs')
 
 const registeredRoutes = []
 let activeContext = null
@@ -151,6 +152,17 @@ module.exports = {
       res.json(buildHealthPayload())
     })
     registeredRoutes.push('GET /api/integration/health')
+    registeredRoutes.push(...registerIntegrationRoutes({
+      context,
+      logger,
+      services: {
+        externalSystemRegistry,
+        adapterRegistry,
+        pipelineRegistry,
+        pipelineRunner,
+        deadLetterStore,
+      },
+    }))
 
     // --- Cross-plugin communication --------------------------------------
     context.communication.register(COMMUNICATION_NAMESPACE, buildCommunicationApi())

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -1,0 +1,397 @@
+'use strict'
+
+// ---------------------------------------------------------------------------
+// HTTP routes — plugin-integration-core
+//
+// Thin REST control plane over the plugin-local registries and runner. The
+// route layer handles auth/tenant scoping and error shaping; business behavior
+// stays in the underlying services.
+// ---------------------------------------------------------------------------
+
+const ROUTES = [
+  ['GET', '/api/integration/status', 'status'],
+  ['GET', '/api/integration/external-systems', 'externalSystemsList'],
+  ['POST', '/api/integration/external-systems', 'externalSystemsUpsert'],
+  ['GET', '/api/integration/external-systems/:id', 'externalSystemsGet'],
+  ['POST', '/api/integration/external-systems/:id/test', 'externalSystemsTest'],
+  ['GET', '/api/integration/pipelines', 'pipelinesList'],
+  ['POST', '/api/integration/pipelines', 'pipelinesUpsert'],
+  ['GET', '/api/integration/pipelines/:id', 'pipelinesGet'],
+  ['POST', '/api/integration/pipelines/:id/run', 'pipelinesRun'],
+  ['POST', '/api/integration/pipelines/:id/dry-run', 'pipelinesDryRun'],
+  ['GET', '/api/integration/runs', 'runsList'],
+  ['GET', '/api/integration/dead-letters', 'deadLettersList'],
+  ['POST', '/api/integration/dead-letters/:id/replay', 'deadLettersReplay'],
+]
+const { sanitizeIntegrationPayload } = require('./payload-redaction.cjs')
+
+class HttpRouteError extends Error {
+  constructor(status, code, message, details = {}) {
+    super(message)
+    this.name = 'HttpRouteError'
+    this.status = status
+    this.code = code
+    this.details = details
+  }
+}
+
+function sendJson(res, status, body) {
+  if (typeof res.status === 'function') {
+    return res.status(status).json(body)
+  }
+  res.statusCode = status
+  return res.json(body)
+}
+
+function sendOk(res, data, status = 200) {
+  return sendJson(res, status, { ok: true, data })
+}
+
+function sendError(res, error) {
+  const status = Number.isInteger(error.status) ? error.status : inferHttpStatus(error)
+  const code = error.code || error.name || 'INTERNAL_ERROR'
+  const message = error.message || 'Internal server error'
+  return sendJson(res, status, {
+    ok: false,
+    error: {
+      code,
+      message,
+      details: error.details || undefined,
+    },
+  })
+}
+
+function inferHttpStatus(error) {
+  const name = error && error.name ? String(error.name) : ''
+  if (/NotFound/.test(name)) return 404
+  if (/Validation|Transform|Watermark|DeadLetter/.test(name)) return 400
+  if (/PipelineRunner/.test(name)) return 422
+  return 500
+}
+
+function getUser(req) {
+  return req.user || req.authUser || null
+}
+
+function listUserPermissions(user) {
+  const permissions = []
+  if (Array.isArray(user && user.permissions)) permissions.push(...user.permissions)
+  if (Array.isArray(user && user.roles)) permissions.push(...user.roles.map((role) => `role:${role}`))
+  if (user && typeof user.role === 'string') permissions.push(`role:${user.role}`)
+  return permissions.map((permission) => String(permission))
+}
+
+function hasPermission(user, action) {
+  const permissions = listUserPermissions(user)
+  if (permissions.includes('role:admin') || permissions.includes('integration:admin')) return true
+  if (action === 'admin') return false
+  if (action === 'read') {
+    return permissions.includes('integration:read') || permissions.includes('integration:write')
+  }
+  return permissions.includes('integration:write')
+}
+
+function isAdmin(user) {
+  const permissions = listUserPermissions(user)
+  return permissions.includes('role:admin') || permissions.includes('integration:admin')
+}
+
+function requireAccess(req, action) {
+  const user = getUser(req)
+  if (!user) {
+    throw new HttpRouteError(401, 'UNAUTHENTICATED', 'Authentication required')
+  }
+  if (!hasPermission(user, action)) {
+    throw new HttpRouteError(403, 'FORBIDDEN', 'Insufficient integration permissions')
+  }
+  return user
+}
+
+function firstString(...values) {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim().length > 0) return value.trim()
+  }
+  return null
+}
+
+function resolveTenantId(req, input = {}) {
+  const user = getUser(req)
+  const tenantId = firstString(input.tenantId, req.query && req.query.tenantId, req.params && req.params.tenantId, user && user.tenantId)
+  if (!tenantId) {
+    throw new HttpRouteError(400, 'TENANT_REQUIRED', 'tenantId is required')
+  }
+  if (user && !isAdmin(user)) {
+    const userTenantId = typeof user.tenantId === 'string' ? user.tenantId.trim() : ''
+    if (!userTenantId) {
+      throw new HttpRouteError(403, 'TENANT_CONTEXT_REQUIRED', 'tenant context is required')
+    }
+    if (userTenantId !== tenantId) {
+      throw new HttpRouteError(403, 'TENANT_MISMATCH', 'tenant scope mismatch')
+    }
+  }
+  return tenantId
+}
+
+function resolveWorkspaceId(req, input = {}) {
+  return firstString(input.workspaceId, req.query && req.query.workspaceId, req.params && req.params.workspaceId)
+}
+
+function scopedInput(req, input = {}) {
+  return {
+    ...input,
+    tenantId: resolveTenantId(req, input),
+    workspaceId: resolveWorkspaceId(req, input),
+  }
+}
+
+function requestBody(req) {
+  return req.body && typeof req.body === 'object' ? req.body : {}
+}
+
+function requestQuery(req) {
+  return req.query && typeof req.query === 'object' ? req.query : {}
+}
+
+function requestParams(req) {
+  return req.params && typeof req.params === 'object' ? req.params : {}
+}
+
+function asPositiveInt(value) {
+  if (value === undefined || value === null || value === '') return undefined
+  const numeric = Number(value)
+  return Number.isInteger(numeric) && numeric > 0 ? numeric : undefined
+}
+
+function publicRunInput(body = {}) {
+  const input = {
+    tenantId: body.tenantId,
+    workspaceId: body.workspaceId,
+    mode: body.mode,
+    cursor: body.cursor,
+    sampleLimit: asPositiveInt(body.sampleLimit),
+  }
+  for (const key of Object.keys(input)) {
+    if (input[key] === undefined || input[key] === null || input[key] === '') delete input[key]
+  }
+  return input
+}
+
+function redactDeadLetter(deadLetter, fullPayload = false) {
+  if (!deadLetter || typeof deadLetter !== 'object') return deadLetter
+  if (fullPayload) {
+    return {
+      ...deadLetter,
+      sourcePayload: sanitizeIntegrationPayload(deadLetter.sourcePayload),
+      transformedPayload: sanitizeIntegrationPayload(deadLetter.transformedPayload),
+      payloadRedacted: true,
+    }
+  }
+  const { sourcePayload: _sourcePayload, transformedPayload: _transformedPayload, ...safe } = deadLetter
+  return {
+    ...safe,
+    payloadRedacted: true,
+  }
+}
+
+function redactSystemForTest(system) {
+  if (!system || typeof system !== 'object') return system
+  return {
+    ...system,
+    credentials: undefined,
+    credentialsEncrypted: undefined,
+  }
+}
+
+function createHandlers(services) {
+  function requireService(name, methods) {
+    const service = services[name]
+    if (!service) throw new Error(`registerIntegrationRoutes: ${name} is required`)
+    for (const method of methods) {
+      if (typeof service[method] !== 'function') {
+        throw new Error(`registerIntegrationRoutes: ${name}.${method} is required`)
+      }
+    }
+    return service
+  }
+
+  const externalSystems = requireService('externalSystemRegistry', ['upsertExternalSystem', 'getExternalSystem', 'listExternalSystems'])
+  const adapterRegistry = requireService('adapterRegistry', ['createAdapter', 'listAdapterKinds'])
+  const pipelineRegistry = requireService('pipelineRegistry', ['upsertPipeline', 'getPipeline', 'listPipelines', 'listPipelineRuns'])
+  const runner = requireService('pipelineRunner', ['runPipeline'])
+  const deadLetters = requireService('deadLetterStore', ['listDeadLetters'])
+
+  const handlers = {
+    async status(req, res) {
+      requireAccess(req, 'read')
+      return sendOk(res, {
+        adapters: adapterRegistry.listAdapterKinds(),
+        routes: ROUTES.map(([method, path]) => ({ method, path })),
+      })
+    },
+
+    async externalSystemsList(req, res) {
+      requireAccess(req, 'read')
+      const query = requestQuery(req)
+      return sendOk(res, await externalSystems.listExternalSystems(scopedInput(req, {
+        kind: query.kind,
+        status: query.status,
+        limit: asPositiveInt(query.limit),
+        offset: asPositiveInt(query.offset),
+      })))
+    },
+
+    async externalSystemsUpsert(req, res) {
+      requireAccess(req, 'write')
+      return sendOk(res, await externalSystems.upsertExternalSystem(scopedInput(req, requestBody(req))), 201)
+    },
+
+    async externalSystemsGet(req, res) {
+      requireAccess(req, 'read')
+      return sendOk(res, await externalSystems.getExternalSystem(scopedInput(req, { id: requestParams(req).id })))
+    },
+
+    async externalSystemsTest(req, res) {
+      requireAccess(req, 'write')
+      const loadSystem = typeof externalSystems.getExternalSystemForAdapter === 'function'
+        ? externalSystems.getExternalSystemForAdapter.bind(externalSystems)
+        : externalSystems.getExternalSystem.bind(externalSystems)
+      const system = await loadSystem(scopedInput(req, { id: requestParams(req).id }))
+      const adapter = adapterRegistry.createAdapter(system)
+      return sendOk(res, await adapter.testConnection(requestBody(req)))
+    },
+
+    async pipelinesList(req, res) {
+      requireAccess(req, 'read')
+      const query = requestQuery(req)
+      return sendOk(res, await pipelineRegistry.listPipelines(scopedInput(req, {
+        status: query.status,
+        sourceSystemId: query.sourceSystemId,
+        targetSystemId: query.targetSystemId,
+        limit: asPositiveInt(query.limit),
+        offset: asPositiveInt(query.offset),
+      })))
+    },
+
+    async pipelinesUpsert(req, res) {
+      requireAccess(req, 'write')
+      const user = getUser(req)
+      const body = requestBody(req)
+      return sendOk(res, await pipelineRegistry.upsertPipeline(scopedInput(req, {
+        ...body,
+        createdBy: user && (user.id || user.email),
+      })), 201)
+    },
+
+    async pipelinesGet(req, res) {
+      requireAccess(req, 'read')
+      const includeFieldMappings = requestQuery(req).includeFieldMappings !== 'false'
+      return sendOk(res, await pipelineRegistry.getPipeline(scopedInput(req, {
+        id: requestParams(req).id,
+        includeFieldMappings,
+      })))
+    },
+
+    async pipelinesRun(req, res) {
+      requireAccess(req, 'write')
+      const body = requestBody(req)
+      return sendOk(res, await runner.runPipeline(scopedInput(req, {
+        ...publicRunInput(body),
+        pipelineId: requestParams(req).id,
+        triggeredBy: 'api',
+      })), 202)
+    },
+
+    async pipelinesDryRun(req, res) {
+      requireAccess(req, 'write')
+      const body = requestBody(req)
+      return sendOk(res, await runner.runPipeline(scopedInput(req, {
+        ...publicRunInput(body),
+        pipelineId: requestParams(req).id,
+        triggeredBy: 'api',
+        dryRun: true,
+      })), 200)
+    },
+
+    async runsList(req, res) {
+      requireAccess(req, 'read')
+      const query = requestQuery(req)
+      return sendOk(res, await pipelineRegistry.listPipelineRuns(scopedInput(req, {
+        pipelineId: query.pipelineId,
+        status: query.status,
+        limit: asPositiveInt(query.limit),
+        offset: asPositiveInt(query.offset),
+      })))
+    },
+
+    async deadLettersList(req, res) {
+      requireAccess(req, 'read')
+      const query = requestQuery(req)
+      const fullPayload = isAdmin(getUser(req)) && query.includePayload === 'true'
+      const rows = await deadLetters.listDeadLetters(scopedInput(req, {
+        pipelineId: query.pipelineId,
+        runId: query.runId,
+        status: query.status,
+        limit: asPositiveInt(query.limit),
+        offset: asPositiveInt(query.offset),
+      }))
+      return sendOk(res, rows.map((row) => redactDeadLetter(row, fullPayload)))
+    },
+
+    async deadLettersReplay(req, res) {
+      requireAccess(req, 'write')
+      if (typeof runner.replayDeadLetter !== 'function') {
+        throw new HttpRouteError(501, 'REPLAY_NOT_IMPLEMENTED', 'Dead-letter replay is not implemented')
+      }
+      const body = requestBody(req)
+      return sendOk(res, await runner.replayDeadLetter(scopedInput(req, {
+        tenantId: body.tenantId,
+        workspaceId: body.workspaceId,
+        mode: body.mode,
+        id: requestParams(req).id,
+        triggeredBy: 'api',
+      })), 202)
+    },
+  }
+
+  return handlers
+}
+
+function registerIntegrationRoutes({ context, services, logger } = {}) {
+  if (!context || !context.api || !context.api.http || typeof context.api.http.addRoute !== 'function') {
+    throw new Error('registerIntegrationRoutes: context.api.http.addRoute is required')
+  }
+  const handlers = createHandlers(services || {})
+  const registered = []
+  for (const [method, path, handlerName] of ROUTES) {
+    const handler = handlers[handlerName]
+    context.api.http.addRoute(method, path, async (req, res) => {
+      try {
+        return await handler(req, res)
+      } catch (error) {
+        if (logger && typeof logger.warn === 'function' && !(error instanceof HttpRouteError)) {
+          logger.warn(`[plugin-integration-core] route failed: ${method} ${path}`)
+        }
+        return sendError(res, error)
+      }
+    })
+    registered.push(`${method} ${path}`)
+  }
+  return registered
+}
+
+module.exports = {
+  ROUTES,
+  HttpRouteError,
+  createHandlers,
+  registerIntegrationRoutes,
+  __internals: {
+    hasPermission,
+    requireAccess,
+    resolveTenantId,
+    scopedInput,
+    sendError,
+    inferHttpStatus,
+    publicRunInput,
+    redactDeadLetter,
+  },
+}

--- a/plugins/plugin-integration-core/package.json
+++ b/plugins/plugin-integration-core/package.json
@@ -6,7 +6,7 @@
   "license": "UNLICENSED",
   "private": true,
   "scripts": {
-    "test": "node __tests__/plugin-runtime-smoke.test.cjs && node --import tsx __tests__/host-loader-smoke.test.mjs && node __tests__/credential-store.test.cjs && node __tests__/db.test.cjs && node __tests__/external-systems.test.cjs && node __tests__/adapter-contracts.test.cjs && node __tests__/http-adapter.test.cjs && node __tests__/pipelines.test.cjs && node __tests__/transform-validator.test.cjs && node __tests__/runner-support.test.cjs && node __tests__/payload-redaction.test.cjs && node __tests__/pipeline-runner.test.cjs && node __tests__/staging-installer.test.cjs && node __tests__/migration-sql.test.cjs",
+    "test": "node __tests__/plugin-runtime-smoke.test.cjs && node --import tsx __tests__/host-loader-smoke.test.mjs && node __tests__/credential-store.test.cjs && node __tests__/db.test.cjs && node __tests__/external-systems.test.cjs && node __tests__/adapter-contracts.test.cjs && node __tests__/http-adapter.test.cjs && node __tests__/pipelines.test.cjs && node __tests__/transform-validator.test.cjs && node __tests__/runner-support.test.cjs && node __tests__/payload-redaction.test.cjs && node __tests__/pipeline-runner.test.cjs && node __tests__/http-routes.test.cjs && node __tests__/staging-installer.test.cjs && node __tests__/migration-sql.test.cjs",
     "test:runtime": "node __tests__/plugin-runtime-smoke.test.cjs",
     "test:host-loader": "node --import tsx __tests__/host-loader-smoke.test.mjs",
     "test:credential": "node __tests__/credential-store.test.cjs",
@@ -19,6 +19,7 @@
     "test:runner-support": "node __tests__/runner-support.test.cjs",
     "test:payload-redaction": "node __tests__/payload-redaction.test.cjs",
     "test:pipeline-runner": "node __tests__/pipeline-runner.test.cjs",
+    "test:http-routes": "node __tests__/http-routes.test.cjs",
     "test:staging": "node __tests__/staging-installer.test.cjs",
     "test:migration": "node __tests__/migration-sql.test.cjs"
   }


### PR DESCRIPTION
## Summary

M1 PR5 stacked on #1150. Adds the REST control plane on top of the pipeline runner layer.

Changes:
- Add `http-routes.cjs` for the integration control-plane REST surface.
- Register REST routes from plugin activation after the health route.
- Add route tests for auth/scope handling, list/upsert/get, run/dry-run, and dead-letter replay behavior.
- Add REST API design and verification docs.

## Scope Boundaries

This PR intentionally does not include:
- K3 WISE adapter imports or registrations
- Yuantus PLM wrapper imports or registrations
- ERP feedback writer
- PR7 feedback hunks in `pipeline-runner.cjs`
- frontend/OpenAPI generated clients
- PR6-PR9 bundle content

## Verification

Run from the stacked PR5 branch:

```bash
node --check plugins/plugin-integration-core/lib/http-routes.cjs
node --check plugins/plugin-integration-core/__tests__/http-routes.test.cjs
pnpm -F plugin-integration-core test:http-routes
pnpm -F plugin-integration-core test:runtime
pnpm -F plugin-integration-core test:host-loader
node --import tsx scripts/validate-plugin-manifests.ts
pnpm -F plugin-integration-core test
git diff --check
```

Results:
- http-routes passed
- runtime smoke passed
- host-loader smoke passed
- manifest validation passed: 13 valid, 0 errors
- full plugin-integration-core package test passed
- syntax and whitespace checks passed

## Stack Note

Base branch is `codex/integration-core-m1-runner-20260425` (#1150). Merge order should be #1148, #1149, #1150, then this PR.

This PR introduces the REST sentinel files required before PR6-PR9 can be applied:
- `plugins/plugin-integration-core/lib/http-routes.cjs`
- `plugins/plugin-integration-core/__tests__/http-routes.test.cjs`