### PR TITLE
fix(observability): harden correlation id middleware

### DIFF
--- a/docs/development/observability-correlation-id-development-20260425.md
+++ b/docs/development/observability-correlation-id-development-20260425.md
@@ -71,7 +71,7 @@ The middleware is placed **before `cors()`** and **before** the existing `x-requ
 
 ### Global error handler — additive
 
-The pre-existing codebase had **no** global 4-argument express error handler wired into `index.ts` (a `telemetryErrorHandler` in `middleware/telemetry.ts` exists but is never registered). Routes throw and express's default HTML error page is used. I added a minimal handler at the end of `setupMiddleware` that (a) routes the error through `this.logger.error` (picks up `correlation_id` automatically via `mergeMeta`), (b) echoes `correlationId` in the JSON body, and (c) honours `err.status`/`err.statusCode` when present. In production 5xx responses hide the raw message; other classes pass through. If `res.headersSent` is already true, the handler calls `next(err)` so Express can delegate or close the request lifecycle rather than silently returning.
+The pre-existing codebase had **no** global 4-argument express error handler wired into `index.ts` (a `telemetryErrorHandler` in `middleware/telemetry.ts` exists but is never registered). Routes throw and express's default HTML error page is used. I added a minimal handler via `installGlobalErrorHandler()`, called at the end of `start()` after routes, plugin routes, Yjs, and metrics stream wiring. It (a) routes the error through `this.logger.error` (picks up `correlation_id` automatically via `mergeMeta`), (b) echoes `correlationId` in the JSON body, and (c) honours `err.status`/`err.statusCode` when present. In production 5xx responses hide the raw message; other classes pass through. If `res.headersSent` is already true, the handler calls `next(err)` so Express can delegate or close the request lifecycle rather than silently returning.
 
 ### Logger format — top-level `correlation_id`
 
@@ -81,7 +81,7 @@ The pre-existing codebase had **no** global 4-argument express error handler wir
 
 `HTTPAdapter` is the only shared outbound-HTTP client in the backend (`grep axios.create` returned a single hit). Per-file bespoke `fetch`/`node-fetch` call sites exist in a handful of plugins and adapters but each uses direct `fetch(url, init)` — adding `X-Correlation-ID` there would require editing each call site and is out of scope. This is documented as a follow-up: if/when a shared `http` helper lands, it should wire the interceptor uniformly.
 
-The interceptor uses `require()` inside a `try/catch` rather than a static `import` so adapter instantiation never becomes coupled to the context module's availability — `HTTPAdapter` is also used by integration tests that construct adapters outside an Express request, and a missing correlation id is the normal, safe state there.
+The interceptor uses a static `getCorrelationId()` import from the in-package request context module. Adapter instances constructed outside an Express request safely receive `undefined` from `getCorrelationId()` and therefore send no correlation header.
 
 ## Rollout safety
 

--- a/docs/development/observability-correlation-id-development-20260425.md
+++ b/docs/development/observability-correlation-id-development-20260425.md
@@ -1,0 +1,101 @@
+# Correlation-id request tracing — development log (2026-04-25)
+
+- **Date**: 2026-04-25
+- **Branch**: `codex/observability-correlation-id-20260425`
+- **Worktree**: `/tmp/ms2-correlation-id`
+- **Base commit**: `5727a6f7a` (origin/main)
+
+## Scope
+
+Thread an end-to-end `X-Correlation-ID` through every inbound HTTP request so logs, errors, and outbound adapter calls share a single identifier. Additive and opt-out-safe: the middleware either echoes a well-formed client-supplied header or generates a UUID — nothing on the existing hot path changes behaviour beyond gaining one response header and one log field.
+
+## Contract
+
+- **Inbound**: clients MAY send `X-Correlation-ID: <value>` where `<value>` matches `^[A-Za-z0-9_-]{1,128}$`.
+- **Preservation**: a matching header is propagated verbatim.
+- **Fallback**: a missing/invalid header is replaced by `crypto.randomUUID()`.
+- **Outbound response**: every response echoes `X-Correlation-ID` (even error responses).
+- **Error body**: the global error handler emits `correlationId` in the JSON body so API clients can reference the id when filing bug reports.
+- **Logs**: every line emitted via `core/logger.ts` includes top-level `correlation_id` for the duration of the request.
+- **Downstream HTTP**: `HTTPAdapter` (the only shared outbound client) injects `X-Correlation-ID` on every request when a correlation id is in scope.
+
+## Request flow
+
+```
+HTTP request ─┐
+              │ correlationIdMiddleware    ← sets req.correlationId
+              │   └── runWithRequestContext({correlationId, userId?, tenantId?})
+              │        │
+              │        ├── cors()
+              │        ├── requestId/trace bridge (setLogContext)
+              │        ├── body parsers, metrics, request logger
+              │        ├── jwtAuthMiddleware / tenantContext / route handlers
+              │        │     └── logger.info/warn/error  ← mergeMeta() injects
+              │        │         correlation_id from getCorrelationId()
+              │        └── HTTPAdapter outbound call
+              │              └── request interceptor reads getCorrelationId()
+              │                  and sets outbound X-Correlation-ID
+              │
+              └── response headers include X-Correlation-ID
+                  error responses include { correlationId } in the JSON body
+```
+
+## Files added
+
+| Path | Purpose |
+| --- | --- |
+| `packages/core-backend/src/context/request-context.ts` | New `AsyncLocalStorage<{ correlationId, userId?, tenantId? }>` with `runWithRequestContext`, `getRequestContext`, `getCorrelationId`. Orthogonal to the existing `LogContext` ALS in `core/logger.ts`. |
+| `packages/core-backend/src/middleware/correlation.ts` | Reads/validates the inbound header, populates `req.correlationId`, sets the response header, and wraps `next()` inside `runWithRequestContext`. Exports `resolveCorrelationId` + `isValidCorrelationId` for unit coverage. |
+| `packages/core-backend/tests/unit/correlation.test.ts` | Regex boundaries, ALS isolation, express supertest round-trips, concurrent-request isolation, and CORS preflight coverage. |
+| `docs/development/observability-correlation-id-development-20260425.md` | This file. |
+| `docs/development/observability-correlation-id-verification-20260425.md` | Verification commands + output + sample log line. |
+
+## Files modified
+
+| Path | Change |
+| --- | --- |
+| `packages/core-backend/src/types/express.d.ts` | Adds `correlationId?: string` on `Express.Request` alongside the existing `requestId?` field. |
+| `packages/core-backend/src/core/logger.ts` | `mergeMeta()` imports `getCorrelationId` from the new context module and emits a **top-level** `correlation_id` field when a correlation id is in scope. Keys with `undefined` values are now stripped so downstream JSON formatters stay clean. |
+| `packages/core-backend/src/index.ts` | Registers `correlationIdMiddleware` before `cors()` and before the `x-request-id` bridge — the ALS scope wraps CORS preflights, every subsequent middleware, and every route handler. Adds a **new** global error handler at the end of `setupMiddleware` that logs via the core logger and emits `{ success: false, error, message, correlationId }` in the JSON body. If headers were already sent, it delegates with `next(err)` instead of swallowing the error. |
+| `packages/core-backend/src/data-adapters/HTTPAdapter.ts` | Extends the existing `axios` request interceptor to set `X-Correlation-ID` from `getCorrelationId()` on outbound calls only when the caller did not already provide a case-insensitive correlation header. Uses `require()` defensively so a missing/changed context module never crashes an adapter instance. |
+
+## Design decisions
+
+### Two orthogonal ALS stores, not one
+
+`core/logger.ts` already holds an `AsyncLocalStorage<{ traceId, spanId, requestId }>` keyed on per-hop request identity + OpenTelemetry trace IDs. The task requires a dedicated `src/context/request-context.ts` module owning `correlationId` (plus optional `userId` / `tenantId`). I kept the two stores separate: `correlationId` is an **end-to-end** identifier — the same value travels across process boundaries to upstream services — while `requestId` is **per-hop**, regenerated on every entry. Conflating them would hide a real distinction. The logger reads from the new ALS via a one-way dependency (`core/logger.ts → context/request-context.ts`) so the log output now includes both `requestId` and `correlation_id` on every line.
+
+### Registration order
+
+The middleware is placed **before `cors()`** and **before** the existing `x-request-id` bridge in `index.ts`. Any middleware registered after this line — CORS, body parsers, metrics, request logger, JWT, tenant context, attendance guards, every route — executes inside the ALS scope. This is load-bearing for `OPTIONS` preflight coverage because the CORS middleware may terminate the request before later middleware runs.
+
+### Global error handler — additive
+
+The pre-existing codebase had **no** global 4-argument express error handler wired into `index.ts` (a `telemetryErrorHandler` in `middleware/telemetry.ts` exists but is never registered). Routes throw and express's default HTML error page is used. I added a minimal handler at the end of `setupMiddleware` that (a) routes the error through `this.logger.error` (picks up `correlation_id` automatically via `mergeMeta`), (b) echoes `correlationId` in the JSON body, and (c) honours `err.status`/`err.statusCode` when present. In production 5xx responses hide the raw message; other classes pass through. If `res.headersSent` is already true, the handler calls `next(err)` so Express can delegate or close the request lifecycle rather than silently returning.
+
+### Logger format — top-level `correlation_id`
+
+`mergeMeta` flattens the correlation id as `correlation_id` at the top of the meta object. Winston's JSON formatter emits the full meta bag as sibling fields of `level`/`message`/`timestamp`, so downstream log tooling (Loki/ES) can filter `correlation_id=<uuid>` without any JSON path traversal. The key uses snake-case to match common log-field conventions; the `Express.Request` property stays `correlationId` to fit the TypeScript/JS camelCase norm.
+
+### Outbound HTTP coverage scope
+
+`HTTPAdapter` is the only shared outbound-HTTP client in the backend (`grep axios.create` returned a single hit). Per-file bespoke `fetch`/`node-fetch` call sites exist in a handful of plugins and adapters but each uses direct `fetch(url, init)` — adding `X-Correlation-ID` there would require editing each call site and is out of scope. This is documented as a follow-up: if/when a shared `http` helper lands, it should wire the interceptor uniformly.
+
+The interceptor uses `require()` inside a `try/catch` rather than a static `import` so adapter instantiation never becomes coupled to the context module's availability — `HTTPAdapter` is also used by integration tests that construct adapters outside an Express request, and a missing correlation id is the normal, safe state there.
+
+## Rollout safety
+
+- **Opt-out safe**: sending no header or an invalid header yields the generated UUID branch — callers see no failure.
+- **Response shape unchanged for success paths**: only the header is added; JSON bodies for 2xx are untouched.
+- **Error path change**: previously unhandled errors hit express's default HTML 500 page. Now they get a JSON body with `correlationId`. This is a strict improvement for API clients and does not alter success-path behaviour.
+- **No new environment variables, feature flags, or ports.**
+- **Logging volume**: one extra field per log line (~40 bytes). No new log lines.
+- **Performance**: `AsyncLocalStorage.run` plus one regex test per inbound request. Neither is on a measurable hot path.
+
+## Non-goals
+
+- Migrating all `fetch`/`node-fetch` call sites to propagate correlation id.
+- Backfilling correlation id on events already emitted before the middleware is registered (none exist in `setupMiddleware` prior to `correlationIdMiddleware`).
+- Surfacing correlation id in the Vue frontend — task scope is backend-only.
+- Wiring the pre-existing `telemetryMiddleware` / `telemetryErrorHandler` (`middleware/telemetry.ts`) into the server — that module depends on an OpenTelemetry path that's not enabled and is tracked as a separate cleanup.
+- Populating `userId` / `tenantId` on the request context. The fields exist as optional slots on `RequestContext` for future use, but this middleware runs **before** `jwtAuthMiddleware` so `req.user` is always undefined here. Filling those slots requires a small post-auth enrichment middleware that calls back into the ALS to overwrite the entry — a deliberate follow-up because the middleware must remain pre-auth so CORS preflights and public-form bypass paths still get a correlation id.

--- a/docs/development/observability-correlation-id-development-20260425.md
+++ b/docs/development/observability-correlation-id-development-20260425.md
@@ -47,6 +47,7 @@ HTTP request ─┐
 | `packages/core-backend/src/context/request-context.ts` | New `AsyncLocalStorage<{ correlationId, userId?, tenantId? }>` with `runWithRequestContext`, `getRequestContext`, `getCorrelationId`. Orthogonal to the existing `LogContext` ALS in `core/logger.ts`. |
 | `packages/core-backend/src/middleware/correlation.ts` | Reads/validates the inbound header, populates `req.correlationId`, sets the response header, and wraps `next()` inside `runWithRequestContext`. Exports `resolveCorrelationId` + `isValidCorrelationId` for unit coverage. |
 | `packages/core-backend/tests/unit/correlation.test.ts` | Regex boundaries, ALS isolation, express supertest round-trips, concurrent-request isolation, and CORS preflight coverage. |
+| `packages/core-backend/tests/unit/http-adapter-correlation.test.ts` | Unit coverage for the `HTTPAdapter` correlation-header helper used by the axios request interceptor. |
 | `docs/development/observability-correlation-id-development-20260425.md` | This file. |
 | `docs/development/observability-correlation-id-verification-20260425.md` | Verification commands + output + sample log line. |
 
@@ -56,8 +57,8 @@ HTTP request ─┐
 | --- | --- |
 | `packages/core-backend/src/types/express.d.ts` | Adds `correlationId?: string` on `Express.Request` alongside the existing `requestId?` field. |
 | `packages/core-backend/src/core/logger.ts` | `mergeMeta()` imports `getCorrelationId` from the new context module and emits a **top-level** `correlation_id` field when a correlation id is in scope. Keys with `undefined` values are now stripped so downstream JSON formatters stay clean. |
-| `packages/core-backend/src/index.ts` | Registers `correlationIdMiddleware` before `cors()` and before the `x-request-id` bridge — the ALS scope wraps CORS preflights, every subsequent middleware, and every route handler. Adds a **new** global error handler at the end of `setupMiddleware` that logs via the core logger and emits `{ success: false, error, message, correlationId }` in the JSON body. If headers were already sent, it delegates with `next(err)` instead of swallowing the error. |
-| `packages/core-backend/src/data-adapters/HTTPAdapter.ts` | Extends the existing `axios` request interceptor to set `X-Correlation-ID` from `getCorrelationId()` on outbound calls only when the caller did not already provide a case-insensitive correlation header. Uses `require()` defensively so a missing/changed context module never crashes an adapter instance. |
+| `packages/core-backend/src/index.ts` | Registers `correlationIdMiddleware` before `cors()` and before the `x-request-id` bridge — the ALS scope wraps CORS preflights, every subsequent middleware, and every route handler. Configures CORS to expose `X-Correlation-ID` to browser clients. Adds a **new** global error handler through `installGlobalErrorHandler()`, called late in `start()` after routes/plugin routes/Yjs/metrics wiring, that logs via the core logger and emits `{ success: false, error, message, correlationId }` in the JSON body. If headers were already sent, it delegates with `next(err)` instead of swallowing the error. |
+| `packages/core-backend/src/data-adapters/HTTPAdapter.ts` | Extends the existing `axios` request interceptor through `applyCorrelationHeader(config)`, which sets `X-Correlation-ID` from a static `getCorrelationId()` import only when the caller did not already provide a case-insensitive correlation header. Adapter instances outside a request scope send no correlation header. |
 
 ## Design decisions
 
@@ -81,7 +82,7 @@ The pre-existing codebase had **no** global 4-argument express error handler wir
 
 `HTTPAdapter` is the only shared outbound-HTTP client in the backend (`grep axios.create` returned a single hit). Per-file bespoke `fetch`/`node-fetch` call sites exist in a handful of plugins and adapters but each uses direct `fetch(url, init)` — adding `X-Correlation-ID` there would require editing each call site and is out of scope. This is documented as a follow-up: if/when a shared `http` helper lands, it should wire the interceptor uniformly.
 
-The interceptor uses a static `getCorrelationId()` import from the in-package request context module. Adapter instances constructed outside an Express request safely receive `undefined` from `getCorrelationId()` and therefore send no correlation header.
+The interceptor uses a static `getCorrelationId()` import from the in-package request context module. The header injection itself lives in `applyCorrelationHeader(config)`, so the load-bearing behaviour is unit-testable without brittle Axios module mocking. Adapter instances constructed outside an Express request safely receive `undefined` from `getCorrelationId()` and therefore send no correlation header.
 
 ## Rollout safety
 

--- a/docs/development/observability-correlation-id-verification-20260425.md
+++ b/docs/development/observability-correlation-id-verification-20260425.md
@@ -1,0 +1,119 @@
+# Correlation-id request tracing — verification (2026-04-25)
+
+- **Date**: 2026-04-25
+- **Branch**: `codex/observability-correlation-id-20260425`
+- **Worktree**: `/tmp/ms2-correlation-id`
+- **Base commit**: `5727a6f7a` (origin/main)
+
+## Commands
+
+| # | Command | Result |
+| --- | --- | --- |
+| 1 | `npx tsc --noEmit` (from `packages/core-backend`) | 0 errors, 0 warnings. |
+| 2 | `npx vitest run tests/unit/correlation.test.ts` | **10 / 10 passed**, 1 file. |
+| 3 | `npx vitest run tests/integration/correlation-header.api.test.ts` | **2 / 2 passed**, 1 file. |
+| 4 | `npx vitest run` (full unit + contract suite, from `packages/core-backend`) | **2555 passed, 47 skipped** across **194 files** (9 files skipped by config). |
+| 5 | `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/correlation.test.ts tests/integration/correlation-header.api.test.ts --reporter=verbose` after review hardening | **12 / 12 passed**, 2 files. |
+
+## Command output — full suite tail
+
+```
+ Test Files  194 passed | 9 skipped (203)
+      Tests  2555 passed | 47 skipped (2602)
+   Start at  00:59:03
+   Duration  7.67s (transform 3.65s, setup 5.42s, collect 19.29s, tests 16.47s, environment 19ms, prepare 7.07s)
+```
+
+(The pre-existing `BPMNWorkflowEngine` / `EventBusService` "database chouhua does not exist" log lines surface because the test host has no Postgres; every test that observes them asserts degraded-mode paths and still passes.)
+
+## Command output — targeted correlation suite
+
+```
+ ✓ tests/unit/correlation.test.ts > resolveCorrelationId > accepts a well-formed header value
+ ✓ tests/unit/correlation.test.ts > resolveCorrelationId > rejects empty strings, too-long values, and disallowed characters
+ ✓ tests/unit/correlation.test.ts > resolveCorrelationId > falls back to a UUID when header is missing or invalid
+ ✓ tests/unit/correlation.test.ts > request-context AsyncLocalStorage > returns undefined outside a context
+ ✓ tests/unit/correlation.test.ts > request-context AsyncLocalStorage > exposes the correlation id inside a run() scope
+ ✓ tests/unit/correlation.test.ts > correlationIdMiddleware (express integration) > generates a uuid when the header is missing and echoes it on the response
+ ✓ tests/unit/correlation.test.ts > correlationIdMiddleware (express integration) > preserves a valid inbound X-Correlation-ID header
+ ✓ tests/unit/correlation.test.ts > correlationIdMiddleware (express integration) > replaces an invalid inbound header with a generated uuid
+ ✓ tests/unit/correlation.test.ts > correlationIdMiddleware (express integration) > keeps each request isolated across concurrent invocations
+ ✓ tests/unit/correlation.test.ts > correlationIdMiddleware (express integration) > can wrap CORS preflight responses when installed before cors()
+
+ Test Files  1 passed (1)
+      Tests  10 passed (10)
+```
+
+## Sample log line
+
+Probe script:
+
+```js
+process.env.LOG_LEVEL = 'info'
+const { createLogger } = await import('.../src/core/logger.ts')
+const { runWithRequestContext } = await import('.../src/context/request-context.ts')
+const log = createLogger('VerifyProbe')
+runWithRequestContext({ correlationId: 'sample-uuid-123' }, () => {
+  log.info('request handled', { path: '/api/foo', status: 200 })
+})
+```
+
+Captured output:
+
+```
+info: request handled {"context":"VerifyProbe","correlation_id":"sample-uuid-123","path":"/api/foo","service":"metasheet","status":200,"timestamp":"2026-04-24T17:00:17.047Z"}
+```
+
+`correlation_id` is emitted **top-level** alongside `context`/`service`/`timestamp`, so a Loki/ES filter like `correlation_id="sample-uuid-123"` resolves without any JSON path traversal. When the caller is outside a correlation context, the key is simply absent (see the unit test `returns undefined outside a context`).
+
+## Response-header round-trip
+
+Proof is in the supertest-backed integration test (`tests/integration/correlation-header.api.test.ts`). The cases asserted:
+
+| Inbound header | Response `X-Correlation-ID` | Notes |
+| --- | --- | --- |
+| *(none)* | `<generated uuid>` | Matches `^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`. |
+| `end-to-end_42` | `end-to-end_42` | Verbatim preservation. |
+| `not valid!` (space + `!`) | `<generated uuid>` | Invalid header dropped, UUID generated. |
+| Two concurrent requests with distinct ids | Each request sees its own id both on the response and via `getCorrelationId()` inside the handler | Asserts ALS isolation across concurrent flights. |
+
+## Error-response body shape
+
+The new global error handler at the end of `setupMiddleware` emits:
+
+```json
+{
+  "success": false,
+  "error": "<message | 'Internal Server Error'>",
+  "message": "<details | undefined in production 5xx>",
+  "correlationId": "<request correlation id>"
+}
+```
+
+Routes that previously threw (and relied on express's default HTML 500) now surface JSON the client can reference in a bug report by quoting `correlationId`. Route handlers that already send their own JSON response are untouched — the handler only runs when the error bubbles past the route.
+
+## Outbound HTTP propagation
+
+`packages/core-backend/src/data-adapters/HTTPAdapter.ts` — the shared axios client — reads `getCorrelationId()` inside its request interceptor and sets `X-Correlation-ID` on every outbound call when a correlation id is in scope and the caller has not already supplied a case-insensitive correlation header. The interceptor uses `require()` inside a `try/catch` so adapter instances constructed outside a request (e.g. integration fixtures) keep working without any correlation header.
+
+## Review hardening — 2026-04-25
+
+- Moved `correlationIdMiddleware` before `cors()` so CORS preflight short-circuits still receive `X-Correlation-ID`.
+- Changed the global error handler to call `next(err)` when `res.headersSent` is already true.
+- Changed `HTTPAdapter` outbound propagation to preserve explicit caller-provided `X-Correlation-ID` / `x-correlation-id` headers.
+- Added a supertest CORS preflight assertion; targeted correlation tests now pass `12 / 12`.
+
+`grep -rn 'axios.create' packages/core-backend/src` returns exactly one hit — `HTTPAdapter` — so no other shared outbound client requires wiring. Ad-hoc `fetch(url, init)` call sites (a handful in plugin adapters) are deliberately not retrofitted; propagating the header there is follow-up work scoped to a shared `http` helper.
+
+## Rollout safety recap
+
+- **Client-visible**: one new response header (`X-Correlation-ID`) on every route. Error responses gain a JSON body with `correlationId`.
+- **Server-visible**: one new top-level field (`correlation_id`) per log line inside a request scope. No new log lines.
+- **No new env vars, feature flags, or ports.**
+- **No existing test regressed** (full suite = 2555 passed, same shape as base `5727a6f7a`).
+
+## Follow-ups
+
+- Wire the pre-existing `telemetryMiddleware` / `telemetryErrorHandler` in `packages/core-backend/src/middleware/telemetry.ts` into the server when OpenTelemetry is enabled. Those modules read/write `req.correlationId` from the same Express declaration now fed by the new middleware, so they'll compose cleanly once activated.
+- When a shared `http` helper replaces ad-hoc `fetch` calls, reuse the same interceptor pattern (`getCorrelationId() → X-Correlation-ID`) for uniform coverage.
+- Consider surfacing `correlationId` in the frontend error toasts so end-users can copy/paste a request id into bug reports without developer assistance.

--- a/docs/development/observability-correlation-id-verification-20260425.md
+++ b/docs/development/observability-correlation-id-verification-20260425.md
@@ -14,6 +14,8 @@
 | 3 | `npx vitest run tests/integration/correlation-header.api.test.ts` | **2 / 2 passed**, 1 file. |
 | 4 | `npx vitest run` (full unit + contract suite, from `packages/core-backend`) | **2555 passed, 47 skipped** across **194 files** (9 files skipped by config). |
 | 5 | `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/correlation.test.ts tests/integration/correlation-header.api.test.ts --reporter=verbose` after review hardening | **12 / 12 passed**, 2 files. |
+| 6 | `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/correlation.test.ts tests/unit/http-adapter-correlation.test.ts tests/integration/correlation-header.api.test.ts --reporter=verbose` after second review hardening | **18 / 18 passed**, 3 files. |
+| 7 | `pnpm --filter @metasheet/core-backend exec tsc --noEmit` after second review hardening | 0 errors, 0 warnings. |
 
 ## Command output — full suite tail
 
@@ -101,15 +103,18 @@ Routes that previously threw (and relied on express's default HTML 500) now surf
 - Moved `correlationIdMiddleware` before `cors()` so CORS preflight short-circuits still receive `X-Correlation-ID`.
 - Moved the global Express error handler out of early middleware setup and into a late `installGlobalErrorHandler()` call at the end of `MetaSheetServer.start()`, after routes and plugin routes are registered.
 - Changed the global error handler to call `next(err)` when `res.headersSent` is already true.
+- Configured CORS with `exposedHeaders: ['X-Correlation-ID']` so browser clients can read the response header.
 - Changed `HTTPAdapter` outbound propagation to preserve explicit caller-provided `X-Correlation-ID` / `x-correlation-id` headers.
 - Replaced the dynamic `require('../context/request-context')` in `HTTPAdapter` with a static import.
-- Added a supertest CORS preflight assertion; targeted correlation tests now pass `12 / 12`.
+- Extracted `applyCorrelationHeader(config)` from the `HTTPAdapter` interceptor so correlation propagation is covered without relying on Axios module-mock internals.
+- Added supertest CORS preflight/header-exposure assertions, error-handler `headersSent` coverage, and outbound header-helper tests; targeted correlation tests now pass `18 / 18`.
 
 Focused re-verification after review fixes:
 
 ```bash
 pnpm --filter @metasheet/core-backend exec vitest run \
   tests/unit/correlation.test.ts \
+  tests/unit/http-adapter-correlation.test.ts \
   tests/integration/correlation-header.api.test.ts \
   --reporter=verbose
 pnpm --filter @metasheet/core-backend exec tsc --noEmit
@@ -118,8 +123,8 @@ pnpm --filter @metasheet/core-backend exec tsc --noEmit
 Result:
 
 ```text
-Test Files  2 passed (2)
-Tests       12 passed (12)
+Test Files  3 passed (3)
+Tests       18 passed (18)
 tsc         exit 0
 ```
 

--- a/docs/development/observability-correlation-id-verification-20260425.md
+++ b/docs/development/observability-correlation-id-verification-20260425.md
@@ -79,7 +79,7 @@ Proof is in the supertest-backed integration test (`tests/integration/correlatio
 
 ## Error-response body shape
 
-The new global error handler at the end of `setupMiddleware` emits:
+The new global error handler installed by `installGlobalErrorHandler()` at the end of `MetaSheetServer.start()` emits:
 
 ```json
 {
@@ -94,14 +94,34 @@ Routes that previously threw (and relied on express's default HTML 500) now surf
 
 ## Outbound HTTP propagation
 
-`packages/core-backend/src/data-adapters/HTTPAdapter.ts` — the shared axios client — reads `getCorrelationId()` inside its request interceptor and sets `X-Correlation-ID` on every outbound call when a correlation id is in scope and the caller has not already supplied a case-insensitive correlation header. The interceptor uses `require()` inside a `try/catch` so adapter instances constructed outside a request (e.g. integration fixtures) keep working without any correlation header.
+`packages/core-backend/src/data-adapters/HTTPAdapter.ts` — the shared axios client — reads `getCorrelationId()` inside its request interceptor and sets `X-Correlation-ID` on every outbound call when a correlation id is in scope and the caller has not already supplied a case-insensitive correlation header. The interceptor uses a static import; adapter instances constructed outside a request keep working because `getCorrelationId()` safely returns `undefined` when no AsyncLocalStorage scope exists.
 
 ## Review hardening — 2026-04-25
 
 - Moved `correlationIdMiddleware` before `cors()` so CORS preflight short-circuits still receive `X-Correlation-ID`.
+- Moved the global Express error handler out of early middleware setup and into a late `installGlobalErrorHandler()` call at the end of `MetaSheetServer.start()`, after routes and plugin routes are registered.
 - Changed the global error handler to call `next(err)` when `res.headersSent` is already true.
 - Changed `HTTPAdapter` outbound propagation to preserve explicit caller-provided `X-Correlation-ID` / `x-correlation-id` headers.
+- Replaced the dynamic `require('../context/request-context')` in `HTTPAdapter` with a static import.
 - Added a supertest CORS preflight assertion; targeted correlation tests now pass `12 / 12`.
+
+Focused re-verification after review fixes:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/correlation.test.ts \
+  tests/integration/correlation-header.api.test.ts \
+  --reporter=verbose
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+```
+
+Result:
+
+```text
+Test Files  2 passed (2)
+Tests       12 passed (12)
+tsc         exit 0
+```
 
 `grep -rn 'axios.create' packages/core-backend/src` returns exactly one hit — `HTTPAdapter` — so no other shared outbound client requires wiring. Ad-hoc `fetch(url, init)` call sites (a handful in plugin adapters) are deliberately not retrofitted; propagating the header there is follow-up work scoped to a shared `http` helper.
 

--- a/packages/core-backend/src/context/request-context.ts
+++ b/packages/core-backend/src/context/request-context.ts
@@ -1,0 +1,33 @@
+/**
+ * Request-scoped context shared across async boundaries.
+ *
+ * A dedicated AsyncLocalStorage keyed on the end-to-end correlation id so
+ * downstream services can annotate logs, errors, and outbound calls without
+ * prop-drilling `req`.
+ */
+
+import { AsyncLocalStorage } from 'async_hooks'
+
+export interface RequestContext {
+  correlationId: string
+  userId?: string
+  tenantId?: string
+}
+
+const storage = new AsyncLocalStorage<RequestContext>()
+
+export function runWithRequestContext<T>(ctx: RequestContext, fn: () => T): T {
+  return storage.run(ctx, fn)
+}
+
+export function getRequestContext(): RequestContext | undefined {
+  return storage.getStore()
+}
+
+export function getCorrelationId(): string | undefined {
+  return storage.getStore()?.correlationId
+}
+
+export function getRequestContextStorage(): AsyncLocalStorage<RequestContext> {
+  return storage
+}

--- a/packages/core-backend/src/core/logger.ts
+++ b/packages/core-backend/src/core/logger.ts
@@ -5,6 +5,8 @@
 import { AsyncLocalStorage } from 'async_hooks'
 import winston from 'winston'
 
+import { getCorrelationId } from '../context/request-context'
+
 type LogContext = {
   traceId?: string
   spanId?: string
@@ -41,12 +43,20 @@ function currentTraceIds(): LogContext {
 function mergeMeta(meta?: Record<string, unknown>): Record<string, unknown> | undefined {
   const store = contextStore.getStore()
   const traceMeta = currentTraceIds()
-  const merged = {
+  const correlationId = getCorrelationId()
+  const merged: Record<string, unknown> = {
     ...meta,
     ...traceMeta,
     requestId: store?.requestId ?? traceMeta.requestId,
     spanId: store?.spanId ?? traceMeta.spanId,
     traceId: store?.traceId ?? traceMeta.traceId
+  }
+  if (correlationId) {
+    merged.correlation_id = correlationId
+  }
+  // Strip keys whose value is undefined so downstream formatters don't emit them.
+  for (const key of Object.keys(merged)) {
+    if (merged[key] === undefined) delete merged[key]
   }
   return Object.keys(merged).length ? merged : undefined
 }

--- a/packages/core-backend/src/data-adapters/HTTPAdapter.ts
+++ b/packages/core-backend/src/data-adapters/HTTPAdapter.ts
@@ -163,6 +163,20 @@ export class HTTPAdapter extends BaseDataAdapter {
               config.headers = { ...(config.headers || {}), Authorization: `Bearer ${token}` }
             }
           }
+          // Propagate the inbound correlation id on outbound requests so
+          // upstream systems can stitch logs across service boundaries.
+          try {
+            // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+            const { getCorrelationId } = require('../context/request-context') as typeof import('../context/request-context')
+            const correlationId = getCorrelationId()
+            const headers = { ...(config.headers || {}) }
+            const hasCorrelationHeader = Object.keys(headers).some(
+              (key) => key.toLowerCase() === 'x-correlation-id'
+            )
+            if (correlationId && !hasCorrelationHeader) {
+              config.headers = { ...headers, 'X-Correlation-ID': correlationId }
+            }
+          } catch { /* context module missing — skip */ }
           this.emit('request', { method: config.method, url: config.url })
           return config
         },

--- a/packages/core-backend/src/data-adapters/HTTPAdapter.ts
+++ b/packages/core-backend/src/data-adapters/HTTPAdapter.ts
@@ -104,6 +104,18 @@ interface TokenProvider {
   onAuthError?: () => void;
 }
 
+export function applyCorrelationHeader(config: AxiosRequestConfig): AxiosRequestConfig {
+  const correlationId = getCorrelationId()
+  const headers = { ...(config.headers || {}) }
+  const hasCorrelationHeader = Object.keys(headers).some(
+    (key) => key.toLowerCase() === 'x-correlation-id'
+  )
+  if (correlationId && !hasCorrelationHeader) {
+    config.headers = { ...headers, 'X-Correlation-ID': correlationId }
+  }
+  return config
+}
+
 export class HTTPAdapter extends BaseDataAdapter {
   protected client: AxiosInstance | null = null
   private endpoints: Map<string, EndpointConfig> = new Map()
@@ -164,16 +176,7 @@ export class HTTPAdapter extends BaseDataAdapter {
               config.headers = { ...(config.headers || {}), Authorization: `Bearer ${token}` }
             }
           }
-          // Propagate the inbound correlation id on outbound requests so
-          // upstream systems can stitch logs across service boundaries.
-          const correlationId = getCorrelationId()
-          const headers = { ...(config.headers || {}) }
-          const hasCorrelationHeader = Object.keys(headers).some(
-            (key) => key.toLowerCase() === 'x-correlation-id'
-          )
-          if (correlationId && !hasCorrelationHeader) {
-            config.headers = { ...headers, 'X-Correlation-ID': correlationId }
-          }
+          applyCorrelationHeader(config)
           this.emit('request', { method: config.method, url: config.url })
           return config
         },

--- a/packages/core-backend/src/data-adapters/HTTPAdapter.ts
+++ b/packages/core-backend/src/data-adapters/HTTPAdapter.ts
@@ -73,6 +73,7 @@ import {
   BaseDataAdapter,
   DataSourceConfig as _DataSourceConfig
 } from './BaseAdapter'
+import { getCorrelationId } from '../context/request-context'
 
 interface HTTPQueryOptions extends QueryOptions {
   method?: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH'
@@ -165,18 +166,14 @@ export class HTTPAdapter extends BaseDataAdapter {
           }
           // Propagate the inbound correlation id on outbound requests so
           // upstream systems can stitch logs across service boundaries.
-          try {
-            // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-            const { getCorrelationId } = require('../context/request-context') as typeof import('../context/request-context')
-            const correlationId = getCorrelationId()
-            const headers = { ...(config.headers || {}) }
-            const hasCorrelationHeader = Object.keys(headers).some(
-              (key) => key.toLowerCase() === 'x-correlation-id'
-            )
-            if (correlationId && !hasCorrelationHeader) {
-              config.headers = { ...headers, 'X-Correlation-ID': correlationId }
-            }
-          } catch { /* context module missing — skip */ }
+          const correlationId = getCorrelationId()
+          const headers = { ...(config.headers || {}) }
+          const hasCorrelationHeader = Object.keys(headers).some(
+            (key) => key.toLowerCase() === 'x-correlation-id'
+          )
+          if (correlationId && !hasCorrelationHeader) {
+            config.headers = { ...headers, 'X-Correlation-ID': correlationId }
+          }
           this.emit('request', { method: config.method, url: config.url })
           return config
         },

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -1148,10 +1148,13 @@ export class MetaSheetServer {
     })
 
     // Note: /metrics/prom endpoint is registered by installMetrics() in setupMiddleware()
+  }
 
+  private installGlobalErrorHandler(): void {
     // Global error handler — emits `correlationId` in the response body so API
-    // clients can reference the request when filing bug reports. Runs last so
-    // any route-level error bubbles up with the correlation context intact.
+    // clients can reference the request when filing bug reports. It must be
+    // registered after all routes/plugin routes; Express only dispatches errors
+    // to handlers that appear later in the middleware stack.
     this.app.use((err: unknown, req: Request, res: Response, next: NextFunction) => {
       const correlationId = req.correlationId ?? getCorrelationId()
       const message = err instanceof Error ? err.message : String(err)
@@ -2149,6 +2152,8 @@ export class MetaSheetServer {
     } catch (e) {
       this.logger.error('Failed to initialize MetricsStreamService', e as Error)
     }
+
+    this.installGlobalErrorHandler()
 
     this.logger.info('Starting HTTP server listen phase...')
     await new Promise<void>((resolve, reject) => {

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -71,6 +71,8 @@ import { startMultitableAttachmentCleanup } from './multitable/attachment-orphan
 import { AutomationService, setAutomationServiceInstance } from './multitable/automation-service'
 import { tenantContext } from './db/sharding/tenant-context'
 import { attendanceAuditMiddleware, attendanceSecurityMiddleware } from './middleware/attendance-production'
+import { correlationIdMiddleware } from './middleware/correlation'
+import { getCorrelationId } from './context/request-context'
 import { approvalsRouter } from './routes/approvals'
 import { authRouter } from './routes/auth'
 import { auditLogsRouter } from './routes/audit-logs'
@@ -811,6 +813,10 @@ export class MetaSheetServer {
    * 配置中间件
    */
   private setupMiddleware(): void {
+    // Correlation-id must wrap every downstream middleware so AsyncLocalStorage
+    // is populated before CORS, request logging, auth, and route handlers run.
+    this.app.use(correlationIdMiddleware)
+
     // CORS
     this.app.use(cors())
 
@@ -1142,6 +1148,27 @@ export class MetaSheetServer {
     })
 
     // Note: /metrics/prom endpoint is registered by installMetrics() in setupMiddleware()
+
+    // Global error handler — emits `correlationId` in the response body so API
+    // clients can reference the request when filing bug reports. Runs last so
+    // any route-level error bubbles up with the correlation context intact.
+    this.app.use((err: unknown, req: Request, res: Response, next: NextFunction) => {
+      const correlationId = req.correlationId ?? getCorrelationId()
+      const message = err instanceof Error ? err.message : String(err)
+      this.logger.error(`Unhandled route error: ${req.method} ${req.path}`, err instanceof Error ? err : new Error(message))
+      if (res.headersSent) return next(err)
+      const status = typeof (err as { status?: number })?.status === 'number'
+        ? (err as { status: number }).status
+        : typeof (err as { statusCode?: number })?.statusCode === 'number'
+          ? (err as { statusCode: number }).statusCode
+          : 500
+      res.status(status).json({
+        success: false,
+        error: status >= 500 ? 'Internal Server Error' : message,
+        message: process.env.NODE_ENV === 'production' && status >= 500 ? undefined : message,
+        correlationId
+      })
+    })
   }
 
   /**

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -71,8 +71,7 @@ import { startMultitableAttachmentCleanup } from './multitable/attachment-orphan
 import { AutomationService, setAutomationServiceInstance } from './multitable/automation-service'
 import { tenantContext } from './db/sharding/tenant-context'
 import { attendanceAuditMiddleware, attendanceSecurityMiddleware } from './middleware/attendance-production'
-import { correlationIdMiddleware } from './middleware/correlation'
-import { getCorrelationId } from './context/request-context'
+import { correlationErrorHandler, correlationIdMiddleware } from './middleware/correlation'
 import { approvalsRouter } from './routes/approvals'
 import { authRouter } from './routes/auth'
 import { auditLogsRouter } from './routes/audit-logs'
@@ -818,7 +817,9 @@ export class MetaSheetServer {
     this.app.use(correlationIdMiddleware)
 
     // CORS
-    this.app.use(cors())
+    this.app.use(cors({
+      exposedHeaders: ['X-Correlation-ID'],
+    }))
 
     // API responses should always opt out of MIME sniffing, including early 4xx replies.
     this.app.use('/api', (_req: Request, res: Response, next: NextFunction) => {
@@ -1155,23 +1156,7 @@ export class MetaSheetServer {
     // clients can reference the request when filing bug reports. It must be
     // registered after all routes/plugin routes; Express only dispatches errors
     // to handlers that appear later in the middleware stack.
-    this.app.use((err: unknown, req: Request, res: Response, next: NextFunction) => {
-      const correlationId = req.correlationId ?? getCorrelationId()
-      const message = err instanceof Error ? err.message : String(err)
-      this.logger.error(`Unhandled route error: ${req.method} ${req.path}`, err instanceof Error ? err : new Error(message))
-      if (res.headersSent) return next(err)
-      const status = typeof (err as { status?: number })?.status === 'number'
-        ? (err as { status: number }).status
-        : typeof (err as { statusCode?: number })?.statusCode === 'number'
-          ? (err as { statusCode: number }).statusCode
-          : 500
-      res.status(status).json({
-        success: false,
-        error: status >= 500 ? 'Internal Server Error' : message,
-        message: process.env.NODE_ENV === 'production' && status >= 500 ? undefined : message,
-        correlationId
-      })
-    })
+    this.app.use(correlationErrorHandler(this.logger))
   }
 
   /**

--- a/packages/core-backend/src/middleware/correlation.ts
+++ b/packages/core-backend/src/middleware/correlation.ts
@@ -1,0 +1,46 @@
+/**
+ * Correlation-id request tracing middleware.
+ *
+ * Reads the inbound `X-Correlation-ID` header (or generates a uuid when
+ * absent/invalid), echoes it on the response, and runs the rest of the
+ * request pipeline inside an AsyncLocalStorage scope so downstream code can
+ * retrieve the id via `getCorrelationId()`.
+ */
+
+import crypto from 'crypto'
+import type { NextFunction, Request, Response } from 'express'
+
+import { runWithRequestContext } from '../context/request-context'
+
+const CORRELATION_HEADER = 'x-correlation-id'
+const CORRELATION_PATTERN = /^[A-Za-z0-9_-]{1,128}$/
+
+export function isValidCorrelationId(value: unknown): value is string {
+  return typeof value === 'string' && CORRELATION_PATTERN.test(value)
+}
+
+export function resolveCorrelationId(headerValue: unknown): string {
+  if (Array.isArray(headerValue)) {
+    return resolveCorrelationId(headerValue[0])
+  }
+  if (isValidCorrelationId(headerValue)) {
+    return headerValue
+  }
+  return crypto.randomUUID()
+}
+
+export function correlationIdMiddleware(req: Request, res: Response, next: NextFunction): void {
+  const incoming = req.headers[CORRELATION_HEADER]
+  const correlationId = resolveCorrelationId(incoming)
+
+  req.correlationId = correlationId
+  res.setHeader('X-Correlation-ID', correlationId)
+
+  // NOTE: this middleware intentionally runs before auth so CORS preflights
+  // and whitelisted routes still get a correlation id. `userId` / `tenantId`
+  // on the context are populated later by a post-auth enrichment step
+  // (follow-up); attempting to read `req.user` here is always undefined.
+  runWithRequestContext({ correlationId }, () => next())
+}
+
+export const CORRELATION_ID_HEADER = 'X-Correlation-ID'

--- a/packages/core-backend/src/middleware/correlation.ts
+++ b/packages/core-backend/src/middleware/correlation.ts
@@ -10,7 +10,7 @@
 import crypto from 'crypto'
 import type { NextFunction, Request, Response } from 'express'
 
-import { runWithRequestContext } from '../context/request-context'
+import { getCorrelationId, runWithRequestContext } from '../context/request-context'
 
 const CORRELATION_HEADER = 'x-correlation-id'
 const CORRELATION_PATTERN = /^[A-Za-z0-9_-]{1,128}$/
@@ -44,3 +44,30 @@ export function correlationIdMiddleware(req: Request, res: Response, next: NextF
 }
 
 export const CORRELATION_ID_HEADER = 'X-Correlation-ID'
+
+export type CorrelationErrorLogger = {
+  error(message: string, error: Error): void
+}
+
+export function correlationErrorHandler(
+  logger: CorrelationErrorLogger,
+  nodeEnv: string | undefined = process.env.NODE_ENV,
+) {
+  return (err: unknown, req: Request, res: Response, next: NextFunction): void => {
+    const correlationId = req.correlationId ?? getCorrelationId()
+    const message = err instanceof Error ? err.message : String(err)
+    logger.error(`Unhandled route error: ${req.method} ${req.path}`, err instanceof Error ? err : new Error(message))
+    if (res.headersSent) return next(err)
+    const status = typeof (err as { status?: number })?.status === 'number'
+      ? (err as { status: number }).status
+      : typeof (err as { statusCode?: number })?.statusCode === 'number'
+        ? (err as { statusCode: number }).statusCode
+        : 500
+    res.status(status).json({
+      success: false,
+      error: status >= 500 ? 'Internal Server Error' : message,
+      message: nodeEnv === 'production' && status >= 500 ? undefined : message,
+      correlationId,
+    })
+  }
+}

--- a/packages/core-backend/src/types/express.d.ts
+++ b/packages/core-backend/src/types/express.d.ts
@@ -36,6 +36,12 @@ declare global {
       requestId?: string
 
       /**
+       * End-to-end correlation id populated by the correlation middleware.
+       * Echoed back to callers via the `X-Correlation-ID` response header.
+       */
+      correlationId?: string
+
+      /**
        * Timestamp when the request was received.
        */
       startTime?: number

--- a/packages/core-backend/tests/integration/correlation-header.api.test.ts
+++ b/packages/core-backend/tests/integration/correlation-header.api.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Integration-style smoke: boots the correlation middleware inside a small
+ * express app (supertest) and verifies the header contract end-to-end. A full
+ * `MetaSheetServer` bootstrap is not required for this contract — the
+ * middleware is the only surface being exercised.
+ */
+
+import express from 'express'
+import request from 'supertest'
+import { describe, expect, it } from 'vitest'
+
+import { correlationIdMiddleware } from '../../src/middleware/correlation'
+import { getCorrelationId } from '../../src/context/request-context'
+
+describe('correlation-id header integration', () => {
+  const app = express()
+  app.use(correlationIdMiddleware)
+  app.get('/echo', (_req, res) => {
+    res.json({ correlationId: getCorrelationId() })
+  })
+
+  it('generates a correlation id when the caller did not supply one', async () => {
+    const res = await request(app).get('/echo')
+    expect(res.status).toBe(200)
+    expect(res.headers['x-correlation-id']).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i)
+    expect(res.body.correlationId).toBe(res.headers['x-correlation-id'])
+  })
+
+  it('echoes a valid inbound X-Correlation-ID back to the client', async () => {
+    const res = await request(app).get('/echo').set('X-Correlation-ID', 'end-to-end_42')
+    expect(res.headers['x-correlation-id']).toBe('end-to-end_42')
+    expect(res.body.correlationId).toBe('end-to-end_42')
+  })
+})

--- a/packages/core-backend/tests/unit/correlation.test.ts
+++ b/packages/core-backend/tests/unit/correlation.test.ts
@@ -1,0 +1,105 @@
+import express from 'express'
+import cors from 'cors'
+import request from 'supertest'
+import { describe, expect, it } from 'vitest'
+
+import { getCorrelationId, getRequestContext, runWithRequestContext } from '../../src/context/request-context'
+import { correlationIdMiddleware, isValidCorrelationId, resolveCorrelationId } from '../../src/middleware/correlation'
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+function buildApp() {
+  const app = express()
+  app.use(correlationIdMiddleware)
+  app.get('/probe', (req, res) => {
+    res.json({
+      reqCorrelationId: req.correlationId,
+      alsCorrelationId: getCorrelationId(),
+      context: getRequestContext()
+    })
+  })
+  return app
+}
+
+describe('resolveCorrelationId', () => {
+  it('accepts a well-formed header value', () => {
+    expect(isValidCorrelationId('abc-123_XYZ')).toBe(true)
+    expect(resolveCorrelationId('abc-123_XYZ')).toBe('abc-123_XYZ')
+  })
+
+  it('rejects empty strings, too-long values, and disallowed characters', () => {
+    expect(isValidCorrelationId('')).toBe(false)
+    expect(isValidCorrelationId('x'.repeat(129))).toBe(false)
+    expect(isValidCorrelationId('has space')).toBe(false)
+    expect(isValidCorrelationId('semi;colon')).toBe(false)
+  })
+
+  it('falls back to a UUID when header is missing or invalid', () => {
+    expect(resolveCorrelationId(undefined)).toMatch(UUID_PATTERN)
+    expect(resolveCorrelationId('bad value!')).toMatch(UUID_PATTERN)
+    expect(resolveCorrelationId(['', 'second'])).toMatch(UUID_PATTERN)
+  })
+})
+
+describe('request-context AsyncLocalStorage', () => {
+  it('returns undefined outside a context', () => {
+    expect(getCorrelationId()).toBeUndefined()
+    expect(getRequestContext()).toBeUndefined()
+  })
+
+  it('exposes the correlation id inside a run() scope', () => {
+    const id = runWithRequestContext({ correlationId: 'scope-id' }, () => getCorrelationId())
+    expect(id).toBe('scope-id')
+  })
+})
+
+describe('correlationIdMiddleware (express integration)', () => {
+  it('generates a uuid when the header is missing and echoes it on the response', async () => {
+    const app = buildApp()
+    const res = await request(app).get('/probe')
+    expect(res.status).toBe(200)
+    expect(res.headers['x-correlation-id']).toMatch(UUID_PATTERN)
+    expect(res.body.reqCorrelationId).toBe(res.headers['x-correlation-id'])
+    expect(res.body.alsCorrelationId).toBe(res.headers['x-correlation-id'])
+  })
+
+  it('preserves a valid inbound X-Correlation-ID header', async () => {
+    const app = buildApp()
+    const res = await request(app).get('/probe').set('X-Correlation-ID', 'trace_abc-123')
+    expect(res.headers['x-correlation-id']).toBe('trace_abc-123')
+    expect(res.body.reqCorrelationId).toBe('trace_abc-123')
+    expect(res.body.context.correlationId).toBe('trace_abc-123')
+  })
+
+  it('replaces an invalid inbound header with a generated uuid', async () => {
+    const app = buildApp()
+    const res = await request(app).get('/probe').set('X-Correlation-ID', 'not valid!')
+    expect(res.headers['x-correlation-id']).toMatch(UUID_PATTERN)
+    expect(res.body.reqCorrelationId).not.toBe('not valid!')
+  })
+
+  it('keeps each request isolated across concurrent invocations', async () => {
+    const app = buildApp()
+    const [a, b] = await Promise.all([
+      request(app).get('/probe').set('X-Correlation-ID', 'aaa-111'),
+      request(app).get('/probe').set('X-Correlation-ID', 'bbb-222')
+    ])
+    expect(a.headers['x-correlation-id']).toBe('aaa-111')
+    expect(b.headers['x-correlation-id']).toBe('bbb-222')
+    expect(a.body.alsCorrelationId).toBe('aaa-111')
+    expect(b.body.alsCorrelationId).toBe('bbb-222')
+  })
+
+  it('can wrap CORS preflight responses when installed before cors()', async () => {
+    const app = express()
+    app.use(correlationIdMiddleware)
+    app.use(cors())
+
+    const res = await request(app)
+      .options('/probe')
+      .set('Origin', 'https://example.test')
+      .set('Access-Control-Request-Method', 'GET')
+
+    expect(res.headers['x-correlation-id']).toMatch(UUID_PATTERN)
+  })
+})

--- a/packages/core-backend/tests/unit/correlation.test.ts
+++ b/packages/core-backend/tests/unit/correlation.test.ts
@@ -1,10 +1,15 @@
 import express from 'express'
 import cors from 'cors'
 import request from 'supertest'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { getCorrelationId, getRequestContext, runWithRequestContext } from '../../src/context/request-context'
-import { correlationIdMiddleware, isValidCorrelationId, resolveCorrelationId } from '../../src/middleware/correlation'
+import {
+  correlationErrorHandler,
+  correlationIdMiddleware,
+  isValidCorrelationId,
+  resolveCorrelationId,
+} from '../../src/middleware/correlation'
 
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
@@ -93,7 +98,7 @@ describe('correlationIdMiddleware (express integration)', () => {
   it('can wrap CORS preflight responses when installed before cors()', async () => {
     const app = express()
     app.use(correlationIdMiddleware)
-    app.use(cors())
+    app.use(cors({ exposedHeaders: ['X-Correlation-ID'] }))
 
     const res = await request(app)
       .options('/probe')
@@ -101,5 +106,61 @@ describe('correlationIdMiddleware (express integration)', () => {
       .set('Access-Control-Request-Method', 'GET')
 
     expect(res.headers['x-correlation-id']).toMatch(UUID_PATTERN)
+  })
+
+  it('exposes X-Correlation-ID to browser clients through CORS', async () => {
+    const app = express()
+    app.use(correlationIdMiddleware)
+    app.use(cors({ exposedHeaders: ['X-Correlation-ID'] }))
+    app.get('/probe', (_req, res) => res.json({ ok: true }))
+
+    const res = await request(app)
+      .get('/probe')
+      .set('Origin', 'https://example.test')
+
+    expect(res.headers['access-control-expose-headers']).toContain('X-Correlation-ID')
+  })
+})
+
+describe('correlationErrorHandler', () => {
+  it('returns a JSON error body with the request correlation id', async () => {
+    const logger = { error: vi.fn() }
+    const app = express()
+    app.use(correlationIdMiddleware)
+    app.get('/boom', () => {
+      const error = new Error('teapot')
+      ;(error as Error & { status: number }).status = 418
+      throw error
+    })
+    app.use(correlationErrorHandler(logger, 'test'))
+
+    const res = await request(app)
+      .get('/boom')
+      .set('X-Correlation-ID', 'err-trace-1')
+
+    expect(res.status).toBe(418)
+    expect(res.body).toMatchObject({
+      success: false,
+      error: 'teapot',
+      message: 'teapot',
+      correlationId: 'err-trace-1',
+    })
+    expect(logger.error).toHaveBeenCalled()
+  })
+
+  it('delegates to next when headers were already sent', () => {
+    const logger = { error: vi.fn() }
+    const handler = correlationErrorHandler(logger)
+    const error = new Error('late failure')
+    const next = vi.fn()
+
+    handler(
+      error,
+      { method: 'GET', path: '/stream', correlationId: 'sent-trace' } as any,
+      { headersSent: true } as any,
+      next,
+    )
+
+    expect(next).toHaveBeenCalledWith(error)
   })
 })

--- a/packages/core-backend/tests/unit/http-adapter-correlation.test.ts
+++ b/packages/core-backend/tests/unit/http-adapter-correlation.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+
+import { runWithRequestContext } from '../../src/context/request-context'
+import { applyCorrelationHeader } from '../../src/data-adapters/HTTPAdapter'
+
+describe('HTTPAdapter correlation propagation', () => {
+  it('sets X-Correlation-ID on outbound requests when a request context is active', () => {
+    const config = runWithRequestContext(
+      { correlationId: 'trace-123' },
+      () => applyCorrelationHeader({ headers: {} }),
+    )
+
+    expect(config.headers?.['X-Correlation-ID']).toBe('trace-123')
+  })
+
+  it('does not override an explicit caller-supplied correlation header', () => {
+    const config = runWithRequestContext(
+      { correlationId: 'trace-123' },
+      () => applyCorrelationHeader({ headers: { 'x-correlation-id': 'caller-trace' } }),
+    )
+
+    expect(config.headers?.['x-correlation-id']).toBe('caller-trace')
+    expect(config.headers?.['X-Correlation-ID']).toBeUndefined()
+  })
+
+  it('leaves outbound requests unchanged when no request context is active', () => {
+    const config = applyCorrelationHeader({ headers: { Authorization: 'Bearer token' } })
+
+    expect(config.headers).toEqual({ Authorization: 'Bearer token' })
+  })
+})


### PR DESCRIPTION
## Summary
- Add request-scoped correlation-id propagation.
- Move correlation-id middleware before CORS so preflight responses carry the request id.
- Preserve caller-supplied outbound correlation headers, expose `X-Correlation-ID` via CORS, and delegate `headersSent` errors to Express.
- Extract `applyCorrelationHeader(config)` for direct unit coverage of outbound propagation.

## Verification
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/correlation.test.ts tests/unit/http-adapter-correlation.test.ts tests/integration/correlation-header.api.test.ts --reporter=verbose` → 18/18 passed
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit` → exit 0