### PR TITLE
feat(approval): add approval metrics and SLA observability

### DIFF
--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -37,6 +37,7 @@
             <router-link v-if="canManageUsers" to="/admin/roles" class="nav-link">{{ navLabels.roles }}</router-link>
             <router-link v-if="canManageUsers" to="/admin/permissions" class="nav-link">{{ navLabels.permissions }}</router-link>
             <router-link v-if="canManageUsers" to="/admin/audit" class="nav-link">{{ navLabels.adminAudit }}</router-link>
+            <router-link v-if="canManageUsers" to="/approvals/metrics" class="nav-link">{{ navLabels.approvalMetrics }}</router-link>
             <router-link v-if="isAdmin" to="/admin/plugins" class="nav-link">{{ navLabels.plugins }}</router-link>
             <router-link v-if="canUsePlm" to="/plm" class="nav-link">{{ navLabels.plm }}</router-link>
             <router-link v-if="canUsePlm" to="/plm/audit" class="nav-link">{{ navLabels.audit }}</router-link>
@@ -126,6 +127,7 @@ const navLabels = computed(() => {
       roles: '角色',
       permissions: '权限',
       adminAudit: '管理审计',
+      approvalMetrics: '审批 SLA',
       plugins: '插件',
       plm: 'PLM',
       audit: '审计',
@@ -150,6 +152,7 @@ const navLabels = computed(() => {
     roles: 'Roles',
     permissions: 'Permissions',
     adminAudit: 'Admin Audit',
+    approvalMetrics: 'Approval SLA',
     plugins: 'Plugins',
     plm: 'PLM',
     audit: 'Audit',

--- a/apps/web/src/approvals/api.ts
+++ b/apps/web/src/approvals/api.ts
@@ -457,6 +457,7 @@ export interface ApprovalMetricsSummary {
   p50DurationSeconds: number | null
   p95DurationSeconds: number | null
   slaBreachCount: number
+  slaCandidateCount: number
   slaBreachRate: number
   byTemplate: ApprovalMetricsSummaryTemplateRow[]
 }
@@ -488,7 +489,7 @@ function emptyMetricsSummary(): ApprovalMetricsSummary {
   return {
     total: 0, approved: 0, rejected: 0, revoked: 0, returned: 0, running: 0,
     avgDurationSeconds: null, p50DurationSeconds: null, p95DurationSeconds: null,
-    slaBreachCount: 0, slaBreachRate: 0, byTemplate: [],
+    slaBreachCount: 0, slaCandidateCount: 0, slaBreachRate: 0, byTemplate: [],
   }
 }
 
@@ -500,7 +501,7 @@ export async function fetchApprovalMetricsSummary(query?: {
     return {
       total: 42, approved: 30, rejected: 5, revoked: 2, returned: 1, running: 4,
       avgDurationSeconds: 7200, p50DurationSeconds: 6000, p95DurationSeconds: 18000,
-      slaBreachCount: 3, slaBreachRate: 0.15,
+      slaBreachCount: 3, slaCandidateCount: 20, slaBreachRate: 0.15,
       byTemplate: [
         { templateId: 'tpl_1', total: 20, approved: 15, rejected: 3, revoked: 1, avgDurationSeconds: 6000, slaBreachRate: 0.1 },
         { templateId: 'tpl_2', total: 12, approved: 10, rejected: 1, revoked: 1, avgDurationSeconds: 9000, slaBreachRate: 0.25 },

--- a/apps/web/src/approvals/api.ts
+++ b/apps/web/src/approvals/api.ts
@@ -41,6 +41,7 @@ function mockTemplateListItem(index: number): ApprovalTemplateListItemDTO {
     description: index % 2 === 0 ? '通用审批模板' : null,
     category: MOCK_TEMPLATE_CATEGORIES[index % MOCK_TEMPLATE_CATEGORIES.length],
     visibilityScope: { type: 'all', ids: [] },
+    slaHours: null,
     status: statuses[index % statuses.length],
     activeVersionId: statuses[index % statuses.length] === 'published' ? `ver_${index}_1` : null,
     latestVersionId: `ver_${index}_1`,
@@ -408,6 +409,130 @@ export async function updateTemplateVisibilityScope(
     throw new Error(`API error: ${response.status} ${response.statusText}`)
   }
   return response.json()
+}
+
+/**
+ * Wave 2 WP5 slice 1 — update a template's SLA hours inline. `null` clears the
+ * SLA; positive integers set it. Admins only (backend enforces via RBAC).
+ */
+export async function updateTemplateSlaHours(
+  templateId: string,
+  slaHours: number | null,
+): Promise<ApprovalTemplateDetailDTO> {
+  if (USE_MOCK) {
+    return { ...mockTemplateDetail(templateId), slaHours }
+  }
+  const response = await apiFetch(`/api/approval-templates/${encodeURIComponent(templateId)}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ slaHours }),
+  })
+  if (!response.ok) {
+    throw new Error(`API error: ${response.status} ${response.statusText}`)
+  }
+  return response.json()
+}
+
+// ---------------------------------------------------------------------------
+// Wave 2 WP5 slice 1 — approval metrics (admin dashboard)
+// ---------------------------------------------------------------------------
+
+export interface ApprovalMetricsSummaryTemplateRow {
+  templateId: string | null
+  total: number
+  approved: number
+  rejected: number
+  revoked: number
+  avgDurationSeconds: number | null
+  slaBreachRate: number
+}
+
+export interface ApprovalMetricsSummary {
+  total: number
+  approved: number
+  rejected: number
+  revoked: number
+  returned: number
+  running: number
+  avgDurationSeconds: number | null
+  p50DurationSeconds: number | null
+  p95DurationSeconds: number | null
+  slaBreachCount: number
+  slaBreachRate: number
+  byTemplate: ApprovalMetricsSummaryTemplateRow[]
+}
+
+export interface ApprovalMetricsNodeBreakdownEntry {
+  nodeKey: string
+  activatedAt: string | null
+  decidedAt: string | null
+  durationSeconds: number | null
+  approverIds: string[]
+}
+
+export interface ApprovalMetricsRow {
+  id: string
+  instance_id: string
+  template_id: string | null
+  tenant_id: string
+  started_at: string
+  terminal_at: string | null
+  terminal_state: 'approved' | 'rejected' | 'revoked' | 'returned' | null
+  duration_seconds: number | null
+  sla_hours: number | null
+  sla_breached: boolean
+  sla_breached_at: string | null
+  node_breakdown: ApprovalMetricsNodeBreakdownEntry[]
+}
+
+function emptyMetricsSummary(): ApprovalMetricsSummary {
+  return {
+    total: 0, approved: 0, rejected: 0, revoked: 0, returned: 0, running: 0,
+    avgDurationSeconds: null, p50DurationSeconds: null, p95DurationSeconds: null,
+    slaBreachCount: 0, slaBreachRate: 0, byTemplate: [],
+  }
+}
+
+export async function fetchApprovalMetricsSummary(query?: {
+  since?: string
+  until?: string
+}): Promise<ApprovalMetricsSummary> {
+  if (USE_MOCK) {
+    return {
+      total: 42, approved: 30, rejected: 5, revoked: 2, returned: 1, running: 4,
+      avgDurationSeconds: 7200, p50DurationSeconds: 6000, p95DurationSeconds: 18000,
+      slaBreachCount: 3, slaBreachRate: 0.15,
+      byTemplate: [
+        { templateId: 'tpl_1', total: 20, approved: 15, rejected: 3, revoked: 1, avgDurationSeconds: 6000, slaBreachRate: 0.1 },
+        { templateId: 'tpl_2', total: 12, approved: 10, rejected: 1, revoked: 1, avgDurationSeconds: 9000, slaBreachRate: 0.25 },
+      ],
+    }
+  }
+  const params = new URLSearchParams()
+  if (query?.since) params.set('since', query.since)
+  if (query?.until) params.set('until', query.until)
+  const qs = params.toString()
+  const data = await apiGet<{ ok: boolean; data: ApprovalMetricsSummary }>(
+    `/api/approvals/metrics/summary${qs ? `?${qs}` : ''}`,
+  )
+  return data?.data ?? emptyMetricsSummary()
+}
+
+export async function fetchApprovalMetricsBreaches(): Promise<ApprovalMetricsRow[]> {
+  if (USE_MOCK) return []
+  const data = await apiGet<{ ok: boolean; data: ApprovalMetricsRow[] }>('/api/approvals/metrics/breaches')
+  return data?.data ?? []
+}
+
+export async function fetchApprovalInstanceMetrics(instanceId: string): Promise<ApprovalMetricsRow | null> {
+  if (USE_MOCK) return null
+  try {
+    const data = await apiGet<{ ok: boolean; data: ApprovalMetricsRow }>(
+      `/api/approvals/metrics/instances/${encodeURIComponent(instanceId)}`,
+    )
+    return data?.data ?? null
+  } catch {
+    return null
+  }
 }
 
 /**

--- a/apps/web/src/router/appRoutes.ts
+++ b/apps/web/src/router/appRoutes.ts
@@ -227,6 +227,12 @@ export const appRoutes: RouteRecordRaw[] = [
     meta: { title: 'Template Detail', titleZh: '模板详情', requiresAuth: true }
   },
   {
+    path: '/approvals/metrics',
+    name: 'approval-metrics',
+    component: () => import('../views/approval/ApprovalMetricsView.vue'),
+    meta: { title: 'Approval Metrics', titleZh: '审批耗时与 SLA', requiresAuth: true, requiresAdmin: true }
+  },
+  {
     path: '/admin/plugins',
     name: 'plugin-manager',
     component: PluginManagerView,

--- a/apps/web/src/types/approval.ts
+++ b/apps/web/src/types/approval.ts
@@ -206,6 +206,10 @@ export interface ApprovalTemplateListItemDTO {
    */
   category: string | null
   visibilityScope: ApprovalTemplateVisibilityScope
+  /**
+   * Wave 2 WP5 slice 1 — optional SLA in hours. `null` disables tracking.
+   */
+  slaHours: number | null
   status: ApprovalTemplateStatus
   activeVersionId: string | null
   latestVersionId: string | null

--- a/apps/web/src/views/approval/ApprovalMetricsView.vue
+++ b/apps/web/src/views/approval/ApprovalMetricsView.vue
@@ -1,0 +1,260 @@
+<template>
+  <section class="approval-metrics">
+    <header class="approval-metrics__header">
+      <h1>审批 SLA 与耗时</h1>
+      <div class="approval-metrics__toolbar">
+        <el-date-picker
+          v-model="dateRange"
+          type="daterange"
+          unlink-panels
+          range-separator="至"
+          start-placeholder="开始日期"
+          end-placeholder="结束日期"
+          value-format="YYYY-MM-DD"
+          @change="loadSummary"
+        />
+        <el-button type="primary" @click="loadAll" :loading="loading">
+          刷新
+        </el-button>
+      </div>
+    </header>
+
+    <el-alert
+      v-if="errorMessage"
+      :title="errorMessage"
+      type="error"
+      show-icon
+      closable
+      @close="errorMessage = ''"
+    />
+
+    <div class="approval-metrics__cards">
+      <el-card shadow="hover">
+        <div class="metric-label">总量</div>
+        <div class="metric-value" data-testid="metric-total">{{ summary.total }}</div>
+        <div class="metric-sub">运行中 {{ summary.running }}</div>
+      </el-card>
+      <el-card shadow="hover">
+        <div class="metric-label">通过率</div>
+        <div class="metric-value" data-testid="metric-approval-rate">{{ approvalRatePercent }}</div>
+        <div class="metric-sub">通过 {{ summary.approved }} · 驳回 {{ summary.rejected }}</div>
+      </el-card>
+      <el-card shadow="hover">
+        <div class="metric-label">平均耗时</div>
+        <div class="metric-value" data-testid="metric-avg-duration">{{ formatDuration(summary.avgDurationSeconds) }}</div>
+        <div class="metric-sub">
+          P50 {{ formatDuration(summary.p50DurationSeconds) }} · P95 {{ formatDuration(summary.p95DurationSeconds) }}
+        </div>
+      </el-card>
+      <el-card shadow="hover" class="approval-metrics__card--breach">
+        <div class="metric-label">SLA 超时率</div>
+        <div class="metric-value" data-testid="metric-sla-rate">{{ slaBreachRatePercent }}</div>
+        <div class="metric-sub">{{ summary.slaBreachCount }} / {{ slaCandidateCount }}</div>
+      </el-card>
+    </div>
+
+    <el-card class="approval-metrics__section">
+      <template #header>
+        <span>按模板汇总</span>
+      </template>
+      <el-table :data="summary.byTemplate" stripe v-loading="loading">
+        <el-table-column prop="templateId" label="模板 ID" min-width="240">
+          <template #default="{ row }">
+            <el-link
+              v-if="row.templateId"
+              :to="{ name: 'approval-template-detail', params: { id: row.templateId } }"
+              type="primary"
+              @click="goTemplate(row.templateId)"
+            >
+              {{ row.templateId }}
+            </el-link>
+            <span v-else class="metric-muted">未关联模板</span>
+          </template>
+        </el-table-column>
+        <el-table-column prop="total" label="总量" width="100" />
+        <el-table-column prop="approved" label="通过" width="100" />
+        <el-table-column prop="rejected" label="驳回" width="100" />
+        <el-table-column prop="revoked" label="撤回" width="100" />
+        <el-table-column label="平均耗时" width="160">
+          <template #default="{ row }">
+            {{ formatDuration(row.avgDurationSeconds) }}
+          </template>
+        </el-table-column>
+        <el-table-column label="SLA 超时率" width="160">
+          <template #default="{ row }">
+            {{ formatPercent(row.slaBreachRate) }}
+          </template>
+        </el-table-column>
+      </el-table>
+    </el-card>
+
+    <el-card class="approval-metrics__section">
+      <template #header>
+        <span>运行中且已超时实例</span>
+      </template>
+      <el-table :data="breaches" stripe v-loading="breachLoading" empty-text="当前无超时实例">
+        <el-table-column label="实例" min-width="260">
+          <template #default="{ row }">
+            <el-link type="primary" @click="goInstance(row.instance_id)">
+              {{ row.instance_id }}
+            </el-link>
+          </template>
+        </el-table-column>
+        <el-table-column prop="sla_hours" label="SLA (小时)" width="140" />
+        <el-table-column label="开始时间" width="220">
+          <template #default="{ row }">{{ formatTimestamp(row.started_at) }}</template>
+        </el-table-column>
+        <el-table-column label="超时标记时间" width="220">
+          <template #default="{ row }">{{ formatTimestamp(row.sla_breached_at) }}</template>
+        </el-table-column>
+      </el-table>
+    </el-card>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import {
+  fetchApprovalMetricsBreaches,
+  fetchApprovalMetricsSummary,
+  type ApprovalMetricsRow,
+  type ApprovalMetricsSummary,
+} from '../../approvals/api'
+
+const router = useRouter()
+
+const summary = ref<ApprovalMetricsSummary>({
+  total: 0, approved: 0, rejected: 0, revoked: 0, returned: 0, running: 0,
+  avgDurationSeconds: null, p50DurationSeconds: null, p95DurationSeconds: null,
+  slaBreachCount: 0, slaBreachRate: 0, byTemplate: [],
+})
+const breaches = ref<ApprovalMetricsRow[]>([])
+const dateRange = ref<[string, string] | null>(null)
+const loading = ref(false)
+const breachLoading = ref(false)
+const errorMessage = ref('')
+
+const approvalRatePercent = computed(() => {
+  const decided = summary.value.approved + summary.value.rejected + summary.value.revoked + summary.value.returned
+  if (decided === 0) return '-'
+  return `${((summary.value.approved / decided) * 100).toFixed(1)}%`
+})
+
+const slaBreachRatePercent = computed(() => formatPercent(summary.value.slaBreachRate))
+
+const slaCandidateCount = computed(() => {
+  if (summary.value.slaBreachRate <= 0) {
+    return summary.value.slaBreachCount
+  }
+  return Math.round(summary.value.slaBreachCount / summary.value.slaBreachRate)
+})
+
+async function loadSummary(): Promise<void> {
+  loading.value = true
+  errorMessage.value = ''
+  try {
+    const query: { since?: string; until?: string } = {}
+    if (dateRange.value && dateRange.value[0]) query.since = `${dateRange.value[0]}T00:00:00Z`
+    if (dateRange.value && dateRange.value[1]) query.until = `${dateRange.value[1]}T23:59:59Z`
+    summary.value = await fetchApprovalMetricsSummary(query)
+  } catch (error) {
+    errorMessage.value = `加载汇总失败: ${error instanceof Error ? error.message : String(error)}`
+  } finally {
+    loading.value = false
+  }
+}
+
+async function loadBreaches(): Promise<void> {
+  breachLoading.value = true
+  try {
+    breaches.value = await fetchApprovalMetricsBreaches()
+  } catch (error) {
+    errorMessage.value = `加载超时实例失败: ${error instanceof Error ? error.message : String(error)}`
+  } finally {
+    breachLoading.value = false
+  }
+}
+
+async function loadAll(): Promise<void> {
+  await Promise.all([loadSummary(), loadBreaches()])
+}
+
+function formatDuration(seconds: number | null | undefined): string {
+  if (seconds === null || seconds === undefined) return '-'
+  if (seconds < 60) return `${seconds.toFixed(0)}s`
+  if (seconds < 3600) return `${(seconds / 60).toFixed(1)}m`
+  return `${(seconds / 3600).toFixed(2)}h`
+}
+
+function formatPercent(value: number | null | undefined): string {
+  if (value === null || value === undefined) return '-'
+  return `${(value * 100).toFixed(1)}%`
+}
+
+function formatTimestamp(value: string | null): string {
+  if (!value) return '-'
+  const d = new Date(value)
+  if (!Number.isFinite(d.getTime())) return value
+  return d.toLocaleString()
+}
+
+function goInstance(instanceId: string): void {
+  router.push({ name: 'approval-detail', params: { id: instanceId } })
+}
+
+function goTemplate(templateId: string): void {
+  router.push({ name: 'approval-template-detail', params: { id: templateId } })
+}
+
+onMounted(() => { void loadAll() })
+</script>
+
+<style scoped>
+.approval-metrics {
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+.approval-metrics__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+.approval-metrics__toolbar {
+  display: flex;
+  gap: 12px;
+}
+.approval-metrics__cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 16px;
+}
+.approval-metrics__card--breach :deep(.el-card__body) {
+  background: #fff7e6;
+}
+.metric-label {
+  font-size: 13px;
+  color: #6b7280;
+  margin-bottom: 8px;
+}
+.metric-value {
+  font-size: 28px;
+  font-weight: 600;
+  color: #1f2937;
+}
+.metric-sub {
+  font-size: 12px;
+  color: #9ca3af;
+  margin-top: 6px;
+}
+.metric-muted {
+  color: #9ca3af;
+}
+.approval-metrics__section {
+  width: 100%;
+}
+</style>

--- a/apps/web/src/views/approval/ApprovalMetricsView.vue
+++ b/apps/web/src/views/approval/ApprovalMetricsView.vue
@@ -127,7 +127,7 @@ const router = useRouter()
 const summary = ref<ApprovalMetricsSummary>({
   total: 0, approved: 0, rejected: 0, revoked: 0, returned: 0, running: 0,
   avgDurationSeconds: null, p50DurationSeconds: null, p95DurationSeconds: null,
-  slaBreachCount: 0, slaBreachRate: 0, byTemplate: [],
+  slaBreachCount: 0, slaCandidateCount: 0, slaBreachRate: 0, byTemplate: [],
 })
 const breaches = ref<ApprovalMetricsRow[]>([])
 const dateRange = ref<[string, string] | null>(null)
@@ -143,12 +143,7 @@ const approvalRatePercent = computed(() => {
 
 const slaBreachRatePercent = computed(() => formatPercent(summary.value.slaBreachRate))
 
-const slaCandidateCount = computed(() => {
-  if (summary.value.slaBreachRate <= 0) {
-    return summary.value.slaBreachCount
-  }
-  return Math.round(summary.value.slaBreachCount / summary.value.slaBreachRate)
-})
+const slaCandidateCount = computed(() => summary.value.slaCandidateCount)
 
 async function loadSummary(): Promise<void> {
   loading.value = true

--- a/apps/web/src/views/approval/TemplateDetailView.vue
+++ b/apps/web/src/views/approval/TemplateDetailView.vue
@@ -170,6 +170,66 @@
               </el-button>
             </template>
           </div>
+          <!--
+            Wave 2 WP5 slice 1 — 模板 SLA. Positive integer hours or null
+            (留空). Visible to all; inline editable by admins.
+          -->
+          <div class="template-detail__sla">
+            <span class="template-detail__category-label">SLA (小时):</span>
+            <template v-if="!editingSla">
+              <el-tag
+                v-if="template.slaHours !== null && template.slaHours !== undefined"
+                size="small"
+                type="warning"
+                effect="plain"
+                data-testid="template-detail-sla-tag"
+              >
+                {{ template.slaHours }}
+              </el-tag>
+              <span v-else class="template-detail__category-empty" data-testid="template-detail-sla-empty">
+                未设置
+              </span>
+              <el-button
+                v-if="canManageTemplates"
+                text
+                size="small"
+                data-testid="template-detail-sla-edit-button"
+                style="margin-left: 8px"
+                @click="beginEditSla"
+              >
+                编辑
+              </el-button>
+            </template>
+            <template v-else>
+              <el-input-number
+                v-model="slaDraft"
+                :min="1"
+                :max="8760"
+                size="small"
+                style="width: 160px; margin-right: 8px"
+                data-testid="template-detail-sla-input"
+                placeholder="留空清除"
+                :controls="false"
+              />
+              <el-button
+                type="primary"
+                size="small"
+                :loading="slaSaving"
+                data-testid="template-detail-sla-save-button"
+                @click="saveSla"
+              >
+                保存
+              </el-button>
+              <el-button
+                size="small"
+                :disabled="slaSaving"
+                data-testid="template-detail-sla-cancel-button"
+                @click="cancelEditSla"
+              >
+                取消
+              </el-button>
+            </template>
+          </div>
           <div class="template-detail__meta">
             <span>模板 Key: {{ template.key }}</span>
             <span>当前版本: {{ template.activeVersionId ?? '无' }}</span>
@@ -287,7 +347,7 @@ import type {
 } from '../../types/approval'
 import { useApprovalTemplateStore } from '../../approvals/templateStore'
 import { useApprovalPermissions } from '../../approvals/permissions'
-import { updateTemplateCategory, updateTemplateVisibilityScope } from '../../approvals/api'
+import { updateTemplateCategory, updateTemplateSlaHours, updateTemplateVisibilityScope } from '../../approvals/api'
 
 const route = useRoute()
 const router = useRouter()
@@ -304,6 +364,47 @@ const editingVisibility = ref(false)
 const visibilityTypeDraft = ref<ApprovalTemplateVisibilityType>('all')
 const visibilityIdsDraft = ref('')
 const visibilitySaving = ref(false)
+// Wave 2 WP5 slice 1 — inline SLA editor state.
+const editingSla = ref(false)
+const slaDraft = ref<number | null>(null)
+const slaSaving = ref(false)
+
+function beginEditSla() {
+  if (!template.value) return
+  slaDraft.value = template.value.slaHours ?? null
+  editingSla.value = true
+}
+
+function cancelEditSla() {
+  editingSla.value = false
+  slaDraft.value = null
+}
+
+async function saveSla() {
+  if (!template.value || slaSaving.value) return
+  const raw = slaDraft.value
+  const nextSla = raw === null || raw === undefined || Number.isNaN(Number(raw)) ? null : Number(raw)
+  if (nextSla !== null && (!Number.isInteger(nextSla) || nextSla <= 0)) {
+    ElMessage.error('SLA 必须是正整数小时')
+    return
+  }
+  const current = template.value.slaHours ?? null
+  if (nextSla === current) {
+    editingSla.value = false
+    return
+  }
+  slaSaving.value = true
+  try {
+    const updated = await updateTemplateSlaHours(template.value.id, nextSla)
+    store.activeTemplate = updated
+    editingSla.value = false
+    ElMessage.success(nextSla === null ? '已清除 SLA' : `已更新 SLA 为 ${nextSla} 小时`)
+  } catch (e: any) {
+    ElMessage.error(e?.message ?? '更新 SLA 失败')
+  } finally {
+    slaSaving.value = false
+  }
+}
 
 function beginEditCategory() {
   if (!template.value) return

--- a/docs/development/approval-wave2-wp5-sla-development-20260425.md
+++ b/docs/development/approval-wave2-wp5-sla-development-20260425.md
@@ -1,0 +1,70 @@
+# Approval Wave 2 WP5 Slice 1 — Duration & SLA Development
+
+Scope: WP5 slice 1 adds a per-instance approval metrics pipeline (总耗时 + node breakdown) and a template-level SLA threshold with breach flagging, plus an admin dashboard for 耗时 / SLA 超时率 observability.
+
+## Design
+
+- New table `approval_metrics`, one row per `approval_instances.id`, storing
+  started_at, terminal_at, terminal_state, duration_seconds, sla_hours (denormalized from the template at creation time), sla_breached / sla_breached_at, and `node_breakdown JSONB` (array of `{nodeKey, activatedAt, decidedAt, durationSeconds, approverIds}`).
+- New column `approval_templates.sla_hours INTEGER` (nullable, CHECK `> 0`). Positive integer hours only; `NULL` disables tracking.
+- Writes are driven by hooks in `ApprovalProductService`:
+  - `createApproval`: after commit, call `recordInstanceStart` (guarded). The hook populates `started_at = now()` and seeds `node_breakdown` with the first approval node's activation.
+  - `dispatchAction`: after commit, emit `recordNodeDecision(currentNodeKey)`. On `approve` that advances, also emit `recordNodeActivation(resolution.currentNodeKey)`. On `approve → 'approved'`, emit `recordTerminal('approved')`. On `reject` / `revoke`, emit `recordTerminal('rejected' | 'revoked')`. On `return`, emit `recordNodeDecision` for the current node and `recordNodeActivation` for the new node.
+- All metrics calls are guarded: a local `safeMetricsCall` wraps each invocation so metrics errors are logged but never fail the approval flow. A missing start row is self-healing — subsequent decision/activation/terminal hooks are no-ops for that instance (service methods return silently when `loadBreakdown` finds no row), and the admin dashboard surfaces a 404 on `/api/approvals/metrics/instances/:id` which the UI tolerates.
+- Per-node breakdown is maintained by a transaction-wrapped `SELECT … FOR UPDATE` + JSON rewrite. The explicit transaction is load-bearing: without it, a bare `pool.query` would release the row lock immediately after the `SELECT`, allowing concurrent approval events to overwrite each other's `node_breakdown` changes.
+
+### SLA breach scanner
+
+- `ApprovalSlaScheduler` is a 15-minute `setInterval` job started from `src/index.ts` during `initialize`. The tick calls `ApprovalMetricsService.checkSlaBreaches(now)`, which runs a single `UPDATE … SET sla_breached = TRUE, sla_breached_at = now WHERE terminal_at IS NULL AND sla_hours IS NOT NULL AND NOT sla_breached AND started_at + interval 'sla_hours hours' < now RETURNING instance_id`.
+- Reentrancy is guarded with an in-memory `running` flag; the timer is `.unref()`-ed so it cannot keep the process alive on its own.
+- Multi-pod deployments must disable the scheduler on all-but-one instance via `APPROVAL_SLA_SCHEDULER_DISABLED=1`. A leader-lock wrapper is a follow-up.
+
+### Spec deviations (documented)
+
+The task spec proposed `instance_id UUID NOT NULL` + `tenant_id UUID NOT NULL`. Reality forced two deviations:
+
+1. `approval_instances.id` is declared `TEXT PRIMARY KEY` across every Kysely migration. `approval_metrics.instance_id` is therefore `TEXT NOT NULL UNIQUE REFERENCES approval_instances(id) ON DELETE CASCADE`. The metrics row's own `id` stays `UUID`. `template_id` stays `UUID` (approval_templates.id uses `gen_random_uuid()`).
+2. Approvals have no tenancy column. `approval_metrics.tenant_id` is `TEXT NOT NULL DEFAULT 'default'` mirroring the loose TEXT scoping in `integration_*` tables. Routes read `req.user?.tenantId` when present, otherwise fall back to `'default'`.
+
+Terminal states follow the production status enum: `approved | rejected | revoked | returned` (not the spec's `cancelled`). `revoked` is the codebase's name for requester-initiated cancellation.
+
+ApprovalGraphExecutor is pure in-memory; the task description mentioned adding hooks there. Metrics hooks live in `ApprovalProductService` only.
+
+## File list
+
+### Backend
+- `packages/core-backend/src/db/migrations/zzzz20260425100000_create_approval_metrics.ts` — Kysely migration (approval_metrics + approval_templates.sla_hours).
+- `packages/core-backend/src/services/ApprovalMetricsService.ts` — service with `recordInstanceStart / recordNodeActivation / recordNodeDecision / recordTerminal / checkSlaBreaches / getMetricsSummary / getInstanceMetrics / listActiveBreaches`. Supports dependency-injected `Query` and `TransactionRunner` for unit tests; production breakdown mutations use `pool.connect()` + `BEGIN` / `COMMIT`.
+- `packages/core-backend/src/services/ApprovalSlaScheduler.ts` — interval-based breach scanner with start/stop helpers, reentrancy guard, and optional `onBreach` hook.
+- `packages/core-backend/src/services/ApprovalProductService.ts` — inject `ApprovalMetricsService`, add `emitNodeDecisionMetric / emitNodeActivationMetric / emitTerminalMetric` helpers, wire hooks into `createApproval` (in-transaction insert) + all `dispatchAction` branches (post-commit). Also expose `sla_hours` through create/update, DTO, and TemplateRow.
+- `packages/core-backend/src/routes/approval-metrics.ts` — new router with `/summary`, `/breaches`, `/instances/:id`. Admin-only for the first two. `/instances/:id` requires `approvals:read` plus a participant-or-admin check against `approval_instances.requester_snapshot`, `approval_assignments`, and `approval_records`; non-participants get 403.
+- `packages/core-backend/src/types/approval-product.ts` — add `slaHours` to the list/detail DTO and create/update requests.
+- `packages/core-backend/src/index.ts` — mount `approvalMetricsRouter`, start/stop `ApprovalSlaScheduler`.
+- `packages/core-backend/tests/helpers/approval-schema-bootstrap.ts` — DDL for `approval_metrics` + `approval_templates.sla_hours`, bumped bootstrap version to `20260425-wp5-sla` so integration workers re-seed.
+
+### Tests
+- `packages/core-backend/tests/unit/approval-metrics-service.test.ts` — 13 cases covering all service methods via mocked `Query`.
+- `packages/core-backend/tests/unit/approval-sla-scheduler.test.ts` — 3 cases covering happy path, error swallow, and reentrancy guard.
+
+### Frontend
+- `apps/web/src/views/approval/ApprovalMetricsView.vue` — admin dashboard (summary cards, 模板汇总 table, 超时实例 table).
+- `apps/web/src/views/approval/TemplateDetailView.vue` — inline SLA editor under existing category / visibility editors.
+- `apps/web/src/router/appRoutes.ts` — `/approvals/metrics` route.
+- `apps/web/src/App.vue` — nav link for admins (`canManageUsers`).
+- `apps/web/src/approvals/api.ts` — `updateTemplateSlaHours`, `fetchApprovalMetricsSummary`, `fetchApprovalMetricsBreaches`, `fetchApprovalInstanceMetrics`.
+- `apps/web/src/types/approval.ts` — add `slaHours` to `ApprovalTemplateListItemDTO`.
+
+## Migration safety
+
+- Additive only. Migration adds one nullable column on `approval_templates` and one new table referencing `approval_instances` via `ON DELETE CASCADE`.
+- Idempotent: `ADD COLUMN IF NOT EXISTS`, `CREATE TABLE IF NOT EXISTS`, `CREATE INDEX IF NOT EXISTS`, constraint creation guarded by `DROP … IF EXISTS` + `ADD`.
+- Backfill on live data is unnecessary — only future instances collect metrics. Rows missing a metrics companion show up as `null` through `GET /api/approvals/metrics/instances/:id` (404), which the admin dashboard tolerates.
+
+## Rollback
+
+1. Stop writers: `APPROVAL_SLA_SCHEDULER_DISABLED=1` on restart, then revert the service hook commit.
+2. Drop data: `DROP TABLE approval_metrics;` (CASCADE is safe — no other objects depend on it).
+3. Drop column: `ALTER TABLE approval_templates DROP COLUMN sla_hours;`.
+4. Or invoke the Kysely `down()` in the migration which performs steps 2 + 3 plus the trigger and constraint cleanup.
+
+Frontend rollback: redeploy without the `ApprovalMetricsView` route; the sidebar entry is purely additive.

--- a/docs/development/approval-wave2-wp5-sla-development-20260425.md
+++ b/docs/development/approval-wave2-wp5-sla-development-20260425.md
@@ -68,3 +68,16 @@ ApprovalGraphExecutor is pure in-memory; the task description mentioned adding h
 4. Or invoke the Kysely `down()` in the migration which performs steps 2 + 3 plus the trigger and constraint cleanup.
 
 Frontend rollback: redeploy without the `ApprovalMetricsView` route; the sidebar entry is purely additive.
+
+## Review hardening — 2026-04-25
+
+- Changed SLA breach interval SQL from `(sla_hours || ' hours')::interval`
+  to `sla_hours * interval '1 hour'` so Postgres does not attempt integer
+  text concatenation.
+- Removed duplicate global-admin checks from the summary and breaches routes.
+  Both routes already use `rbacGuard('approvals:admin')`; the extra
+  `isAdminActor()` gate could incorrectly reject users granted
+  `approvals:admin` through RBAC tables.
+- Exposed `slaCandidateCount` directly in backend and frontend summary DTOs.
+  The dashboard now reads the exact denominator instead of reconstructing it
+  from `slaBreachCount / slaBreachRate`, which was wrong when rate was zero.

--- a/docs/development/approval-wave2-wp5-sla-development-20260425.md
+++ b/docs/development/approval-wave2-wp5-sla-development-20260425.md
@@ -15,7 +15,7 @@ Scope: WP5 slice 1 adds a per-instance approval metrics pipeline (总耗时 + no
 
 ### SLA breach scanner
 
-- `ApprovalSlaScheduler` is a 15-minute `setInterval` job started from `src/index.ts` during `initialize`. The tick calls `ApprovalMetricsService.checkSlaBreaches(now)`, which runs a single `UPDATE … SET sla_breached = TRUE, sla_breached_at = now WHERE terminal_at IS NULL AND sla_hours IS NOT NULL AND NOT sla_breached AND started_at + interval 'sla_hours hours' < now RETURNING instance_id`.
+- `ApprovalSlaScheduler` is a 15-minute `setInterval` job started from `src/index.ts` during `initialize`. The tick calls `ApprovalMetricsService.checkSlaBreaches(now)`, which runs a single `UPDATE … SET sla_breached = TRUE, sla_breached_at = now WHERE terminal_at IS NULL AND sla_hours IS NOT NULL AND NOT sla_breached AND started_at + (sla_hours * interval '1 hour') < now RETURNING instance_id`.
 - Reentrancy is guarded with an in-memory `running` flag; the timer is `.unref()`-ed so it cannot keep the process alive on its own.
 - Multi-pod deployments must disable the scheduler on all-but-one instance via `APPROVAL_SLA_SCHEDULER_DISABLED=1`. A leader-lock wrapper is a follow-up.
 

--- a/docs/development/approval-wave2-wp5-sla-verification-20260425.md
+++ b/docs/development/approval-wave2-wp5-sla-verification-20260425.md
@@ -74,9 +74,39 @@ Typecheck:
 
 ```bash
 pnpm --filter @metasheet/core-backend exec tsc --noEmit
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
 ```
 
-Result: exit 0.
+Result: both exit 0.
+
+## Review hardening verification — 2026-04-25
+
+Focused command:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/approval-metrics-service.test.ts \
+  tests/unit/approval-product-service.test.ts \
+  tests/unit/approval-sla-scheduler.test.ts \
+  --reporter=verbose
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+```
+
+Result:
+
+```text
+Test Files  3 passed (3)
+Tests       24 passed (24)
+backend tsc exit 0
+vue-tsc     exit 0
+```
+
+Assertions updated:
+
+- `checkSlaBreaches` now asserts the interval-safe
+  `started_at + (sla_hours * interval '1 hour') < $1` SQL.
+- `getMetricsSummary` now asserts `slaCandidateCount` is returned directly.
 
 Local note: `/tmp/ms2-wp5-sla` initially had no `node_modules/.bin/vitest`; `pnpm install --offline --ignore-scripts` could not complete because `bcryptjs@3.0.3` was missing from the local pnpm store. To avoid network access, the focused test reused the already-installed sibling workspace symlinks from `/tmp/ms2-correlation-id`. No tracked dependency files were changed.
 

--- a/docs/development/approval-wave2-wp5-sla-verification-20260425.md
+++ b/docs/development/approval-wave2-wp5-sla-verification-20260425.md
@@ -110,6 +110,32 @@ Assertions updated:
 
 Local note: `/tmp/ms2-wp5-sla` initially had no `node_modules/.bin/vitest`; `pnpm install --offline --ignore-scripts` could not complete because `bcryptjs@3.0.3` was missing from the local pnpm store. To avoid network access, the focused test reused the already-installed sibling workspace symlinks from `/tmp/ms2-correlation-id`. No tracked dependency files were changed.
 
+## Post-merge rebase verification — 2026-04-25
+
+After PRs #1156 and #1157 were merged, this branch was rebased onto
+`origin/main@b1da68fcf73b773e4104e0af2d985d58dfb580d2` with no conflicts.
+
+Commands:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/approval-metrics-service.test.ts \
+  tests/unit/approval-product-service.test.ts \
+  tests/unit/approval-sla-scheduler.test.ts \
+  --reporter=verbose
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+```
+
+Result:
+
+```text
+Test Files  3 passed (3)
+Tests       24 passed (24)
+backend tsc exit 0
+vue-tsc     exit 0
+```
+
 ## Manual smoke path
 
 1. Run migrations (`pnpm --filter @metasheet/core-backend run db:migrate`). Confirm `approval_metrics` exists and `approval_templates.sla_hours` column is present.

--- a/docs/development/approval-wave2-wp5-sla-verification-20260425.md
+++ b/docs/development/approval-wave2-wp5-sla-verification-20260425.md
@@ -1,0 +1,98 @@
+# Approval Wave 2 WP5 Slice 1 — Verification
+
+## Commands
+
+```bash
+# Backend unit tests (focused)
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-metrics-service.test.ts tests/unit/approval-sla-scheduler.test.ts --reporter=dot
+
+# Backend regression unit sweep (related approval surfaces)
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-metrics-service.test.ts tests/unit/approval-product-service.test.ts tests/unit/approval-realtime.test.ts tests/unit/approvals-routes.test.ts tests/unit/approval-template-routes.test.ts --reporter=dot
+
+# Full backend unit suite
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit --reporter=dot
+
+# Backend typecheck
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+
+# Frontend typecheck
+pnpm --filter web exec vue-tsc -b
+```
+
+## Results
+
+Focused service + scheduler:
+
+```
+ Test Files  2 passed (2)
+      Tests  16 passed (16)
+```
+
+Related approval suites:
+
+```
+ Test Files  5 passed (5)
+      Tests  39 passed (39)
+```
+
+Full backend unit sweep:
+
+```
+ Test Files  139 passed (139)
+      Tests  1715 passed (1715)
+```
+
+Backend `tsc --noEmit`: exit 0.
+
+Frontend `vue-tsc -b`: exit 0.
+
+## Review hardening — 2026-04-25
+
+- Fixed template route wiring: `POST /api/approval-templates` and `PATCH /api/approval-templates/:id` now forward `slaHours` into `ApprovalProductService`, so the inline SLA editor and API create path persist the new column.
+- Fixed tenant propagation: platform approval creation now passes `req.user.tenantId` into `ApprovalProductService.createApproval`, and metrics start rows store that tenant instead of always falling back to `default`.
+- Fixed initially auto-approved flows: when `resolveInitialState()` returns `approved`, the metrics hook writes `recordInstanceStart` and then `recordTerminal('approved')`, preventing those rows from remaining incorrectly `running`.
+- Fixed `node_breakdown` race risk: `recordNodeActivation` / `recordNodeDecision` now use an injected transaction runner; production wraps `SELECT ... FOR UPDATE` and JSON rewrite in `BEGIN` / `COMMIT`.
+
+Additional focused test added and run after review hardening:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/approval-metrics-service.test.ts \
+  tests/unit/approval-product-service.test.ts \
+  tests/unit/approval-sla-scheduler.test.ts \
+  --reporter=verbose
+```
+
+Result:
+
+```
+ Test Files  3 passed (3)
+      Tests  24 passed (24)
+```
+
+Typecheck:
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+```
+
+Result: exit 0.
+
+Local note: `/tmp/ms2-wp5-sla` initially had no `node_modules/.bin/vitest`; `pnpm install --offline --ignore-scripts` could not complete because `bcryptjs@3.0.3` was missing from the local pnpm store. To avoid network access, the focused test reused the already-installed sibling workspace symlinks from `/tmp/ms2-correlation-id`. No tracked dependency files were changed.
+
+## Manual smoke path
+
+1. Run migrations (`pnpm --filter @metasheet/core-backend run db:migrate`). Confirm `approval_metrics` exists and `approval_templates.sla_hours` column is present.
+2. As admin, open `/approval-templates/:id`. Set `SLA (小时)` to `1`.
+3. Start a new approval from that template. Verify a row in `approval_metrics` appears with `sla_hours = 1` and `started_at` ~= now.
+4. Wait for the scheduler tick (or set `APPROVAL_SLA_SCHEDULER_DISABLED=0` and trigger `ApprovalSlaScheduler.tick()` manually via REPL). Confirm `sla_breached = TRUE` after ~1 hour (or set a smaller test interval via SQL: `UPDATE approval_metrics SET started_at = now() - interval '2 hours' WHERE instance_id = ...;`).
+5. Open `/approvals/metrics` as admin. Verify summary cards render, 按模板汇总 has the row, 超时实例 list contains the instance.
+6. Approve or reject the instance. Confirm `terminal_state`, `terminal_at`, `duration_seconds` are filled; the instance drops off 超时实例 list (terminal_at IS NULL filter).
+
+## Known caveats / follow-ups
+
+- Multi-pod deployments must set `APPROVAL_SLA_SCHEDULER_DISABLED=1` on all-but-one instance; leader-lock integration is a follow-up.
+- `tenant_id` still falls back to `'default'` when the token has no `tenantId`, but routed platform approval creation now preserves `req.user.tenantId` when present. When approvals become first-class tenant-scoped rows, backfill existing default rows and tighten the fallback.
+- `node_breakdown` is best-effort — existing instances predate metrics so their first nodes won't have activation timestamps. New instances created after this change are fully instrumented.
+- Breach notifications are not emitted yet; the scheduler has an `onBreach(ids)` hook that future work can wire to email / 站内消息 once the approval notification service surface stabilizes.
+- We did not add an integration test. The `ensureApprovalSchemaReady()` helper was updated so any future integration test can rely on the new tables; kept the slice unit-only to avoid the historical DDL race issues.

--- a/packages/core-backend/src/db/migrations/zzzz20260425100000_create_approval_metrics.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260425100000_create_approval_metrics.ts
@@ -1,0 +1,119 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+
+/**
+ * Wave 2 WP5 slice 1 — SLA / approval-duration observability.
+ *
+ * Adds a per-instance metrics row (approval_metrics) and a nullable
+ * sla_hours column on approval_templates. Writes are additive and guarded
+ * in ApprovalProductService so metrics errors never fail the parent flow.
+ *
+ * Deviations from the task spec (documented in the dev MD):
+ *   - `instance_id` is TEXT (approval_instances.id is TEXT, not UUID).
+ *   - `tenant_id` is TEXT with a 'default' fallback — approval_instances
+ *     has no tenancy column, so the metrics row inherits the loose TEXT
+ *     scoping used by the integration_* tables.
+ *   - Terminal state mirrors the production status enum
+ *     (approved/rejected/revoked/returned). 'returned' is recorded on the
+ *     first return action; the row is re-opened when the instance loops
+ *     back to pending, but duration_seconds stays set until a subsequent
+ *     terminal transition overwrites it.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`CREATE EXTENSION IF NOT EXISTS pgcrypto`.execute(db)
+
+  await sql`
+    ALTER TABLE approval_templates
+      ADD COLUMN IF NOT EXISTS sla_hours INTEGER
+  `.execute(db)
+  await sql`
+    ALTER TABLE approval_templates
+      DROP CONSTRAINT IF EXISTS approval_templates_sla_hours_positive
+  `.execute(db)
+  await sql`
+    ALTER TABLE approval_templates
+      ADD CONSTRAINT approval_templates_sla_hours_positive
+      CHECK (sla_hours IS NULL OR sla_hours > 0)
+  `.execute(db)
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS approval_metrics (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      instance_id TEXT NOT NULL UNIQUE REFERENCES approval_instances(id) ON DELETE CASCADE,
+      template_id UUID,
+      tenant_id TEXT NOT NULL DEFAULT 'default',
+      started_at TIMESTAMPTZ NOT NULL,
+      terminal_at TIMESTAMPTZ,
+      terminal_state TEXT,
+      duration_seconds INTEGER,
+      sla_hours INTEGER,
+      sla_breached BOOLEAN NOT NULL DEFAULT FALSE,
+      sla_breached_at TIMESTAMPTZ,
+      node_breakdown JSONB NOT NULL DEFAULT '[]'::jsonb,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    )
+  `.execute(db)
+
+  await sql`
+    ALTER TABLE approval_metrics
+      DROP CONSTRAINT IF EXISTS approval_metrics_terminal_state_check
+  `.execute(db)
+  await sql`
+    ALTER TABLE approval_metrics
+      ADD CONSTRAINT approval_metrics_terminal_state_check
+      CHECK (terminal_state IS NULL OR terminal_state IN ('approved', 'rejected', 'revoked', 'returned'))
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_approval_metrics_tenant_terminal
+      ON approval_metrics(tenant_id, terminal_at DESC)
+  `.execute(db)
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_approval_metrics_template
+      ON approval_metrics(template_id)
+      WHERE template_id IS NOT NULL
+  `.execute(db)
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_approval_metrics_sla_breached_active
+      ON approval_metrics(tenant_id, sla_breached)
+      WHERE sla_breached = TRUE
+  `.execute(db)
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_approval_metrics_sla_scan
+      ON approval_metrics(started_at)
+      WHERE terminal_at IS NULL AND sla_hours IS NOT NULL AND sla_breached = FALSE
+  `.execute(db)
+
+  await sql`
+    CREATE OR REPLACE FUNCTION approval_metrics_set_updated_at()
+    RETURNS TRIGGER AS $$
+    BEGIN
+      NEW.updated_at = now();
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql
+  `.execute(db)
+  await sql`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'trg_approval_metrics_updated_at') THEN
+        CREATE TRIGGER trg_approval_metrics_updated_at
+          BEFORE UPDATE ON approval_metrics
+          FOR EACH ROW EXECUTE FUNCTION approval_metrics_set_updated_at();
+      END IF;
+    END $$
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP TRIGGER IF EXISTS trg_approval_metrics_updated_at ON approval_metrics`.execute(db)
+  await sql`DROP FUNCTION IF EXISTS approval_metrics_set_updated_at()`.execute(db)
+  await sql`DROP INDEX IF EXISTS idx_approval_metrics_sla_scan`.execute(db)
+  await sql`DROP INDEX IF EXISTS idx_approval_metrics_sla_breached_active`.execute(db)
+  await sql`DROP INDEX IF EXISTS idx_approval_metrics_template`.execute(db)
+  await sql`DROP INDEX IF EXISTS idx_approval_metrics_tenant_terminal`.execute(db)
+  await sql`DROP TABLE IF EXISTS approval_metrics`.execute(db)
+  await sql`ALTER TABLE approval_templates DROP CONSTRAINT IF EXISTS approval_templates_sla_hours_positive`.execute(db)
+  await sql`ALTER TABLE approval_templates DROP COLUMN IF EXISTS sla_hours`.execute(db)
+}

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -76,6 +76,8 @@ import { approvalsRouter } from './routes/approvals'
 import { authRouter } from './routes/auth'
 import { auditLogsRouter } from './routes/audit-logs'
 import { approvalHistoryRouter } from './routes/approval-history'
+import { approvalMetricsRouter } from './routes/approval-metrics'
+import { startApprovalSlaScheduler, stopApprovalSlaScheduler } from './services/ApprovalSlaScheduler'
 import { rolesRouter } from './routes/roles'
 import { snapshotsRouter } from './routes/snapshots'
 import changeManagementRouter from './routes/change-management'
@@ -938,6 +940,8 @@ export class MetaSheetServer {
     this.app.use(auditLogsRouter())
     // 路由：审批历史（从审计表衍生）
     this.app.use(approvalHistoryRouter({ injector: this.injector }))
+    // 路由：审批 SLA / 耗时指标（Wave 2 WP5）
+    this.app.use(approvalMetricsRouter())
     // 路由：角色/权限/表/文件/表权限（占位）
     this.app.use(rolesRouter())
     this.app.use(permissionsRouter())
@@ -1744,6 +1748,14 @@ export class MetaSheetServer {
       }
     })())
 
+    shutdownTasks.push((async () => {
+      try {
+        stopApprovalSlaScheduler()
+      } catch (err) {
+        this.logger.warn(`Approval SLA scheduler shutdown failed: ${err instanceof Error ? err.message : String(err)}`)
+      }
+    })())
+
     // 4. Destroy API Gateway resources (only if one was constructed during start()).
     shutdownTasks.push((async () => {
       try {
@@ -1876,6 +1888,13 @@ export class MetaSheetServer {
       this.logger.info('Directory sync scheduler initialized')
     } catch (e) {
       this.logger.error('Directory sync scheduler initialization failed; continuing in degraded mode', e as Error)
+    }
+
+    try {
+      startApprovalSlaScheduler()
+      this.logger.info('Approval SLA scheduler initialized')
+    } catch (e) {
+      this.logger.error('Approval SLA scheduler initialization failed; continuing in degraded mode', e as Error)
     }
 
     // 加载插件并启动 HTTP 服务

--- a/packages/core-backend/src/routes/approval-metrics.ts
+++ b/packages/core-backend/src/routes/approval-metrics.ts
@@ -60,9 +60,6 @@ export function approvalMetricsRouter(options?: ApprovalMetricsRouterOptions): R
     rbacGuard('approvals:admin'),
     async (req: Request, res: Response) => {
       try {
-        if (!isAdminActor(req)) {
-          return res.status(403).json({ ok: false, error: { code: 'FORBIDDEN', message: 'Admin role required' } })
-        }
         const summary = await metricsService.getMetricsSummary({
           tenantId: resolveTenantId(req),
           since: parseDate(req.query.since),
@@ -81,9 +78,6 @@ export function approvalMetricsRouter(options?: ApprovalMetricsRouterOptions): R
     rbacGuard('approvals:admin'),
     async (req: Request, res: Response) => {
       try {
-        if (!isAdminActor(req)) {
-          return res.status(403).json({ ok: false, error: { code: 'FORBIDDEN', message: 'Admin role required' } })
-        }
         const limit = Number.parseInt(String(req.query.limit ?? '50'), 10)
         const breaches = await metricsService.listActiveBreaches({
           tenantId: resolveTenantId(req),

--- a/packages/core-backend/src/routes/approval-metrics.ts
+++ b/packages/core-backend/src/routes/approval-metrics.ts
@@ -1,0 +1,176 @@
+/**
+ * Wave 2 WP5 slice 1 — approval metrics / SLA routes.
+ *
+ * Summary and breach endpoints are admin-only; per-instance metrics are
+ * visible to any authenticated caller that the main approval detail
+ * endpoint would show (no extra scoping here — the metrics row is keyed
+ * by instance_id and inherits the instance's own ACL).
+ */
+
+import { Router } from 'express'
+import type { Request, Response } from 'express'
+import { authenticate } from '../middleware/auth'
+import { rbacGuard } from '../rbac/rbac'
+import { Logger } from '../core/logger'
+import { pool } from '../db/pg'
+import {
+  ApprovalMetricsService,
+  getApprovalMetricsService,
+  type ApprovalMetricsService as ApprovalMetricsServiceType,
+} from '../services/ApprovalMetricsService'
+
+const logger = new Logger('ApprovalMetricsRouter')
+
+function resolveTenantId(req: Request): string {
+  const candidate = req.user?.tenantId
+  if (typeof candidate === 'string' && candidate.trim().length > 0) {
+    return candidate.trim()
+  }
+  return 'default'
+}
+
+function isAdminActor(req: Request): boolean {
+  if (req.user?.role === 'admin') return true
+  const roles = Array.isArray(req.user?.roles)
+    ? req.user!.roles.filter((r): r is string => typeof r === 'string')
+    : []
+  if (roles.includes('admin')) return true
+  const permissions = Array.isArray(req.user?.permissions)
+    ? req.user!.permissions.filter((p): p is string => typeof p === 'string')
+    : []
+  return permissions.includes('*:*')
+}
+
+function parseDate(value: unknown): Date | undefined {
+  if (typeof value !== 'string' || value.trim().length === 0) return undefined
+  const parsed = new Date(value)
+  return Number.isFinite(parsed.getTime()) ? parsed : undefined
+}
+
+export interface ApprovalMetricsRouterOptions {
+  metricsService?: ApprovalMetricsServiceType
+}
+
+export function approvalMetricsRouter(options?: ApprovalMetricsRouterOptions): Router {
+  const r = Router()
+  const metricsService = options?.metricsService ?? getApprovalMetricsService()
+
+  r.get('/api/approvals/metrics/summary',
+    authenticate,
+    rbacGuard('approvals:admin'),
+    async (req: Request, res: Response) => {
+      try {
+        if (!isAdminActor(req)) {
+          return res.status(403).json({ ok: false, error: { code: 'FORBIDDEN', message: 'Admin role required' } })
+        }
+        const summary = await metricsService.getMetricsSummary({
+          tenantId: resolveTenantId(req),
+          since: parseDate(req.query.since),
+          until: parseDate(req.query.until),
+        })
+        return res.json({ ok: true, data: summary })
+      } catch (error) {
+        logger.error(`metrics summary failed: ${error instanceof Error ? error.message : String(error)}`)
+        return res.status(500).json({ ok: false, error: { code: 'METRICS_SUMMARY_FAILED', message: 'Failed to load approval metrics summary' } })
+      }
+    },
+  )
+
+  r.get('/api/approvals/metrics/breaches',
+    authenticate,
+    rbacGuard('approvals:admin'),
+    async (req: Request, res: Response) => {
+      try {
+        if (!isAdminActor(req)) {
+          return res.status(403).json({ ok: false, error: { code: 'FORBIDDEN', message: 'Admin role required' } })
+        }
+        const limit = Number.parseInt(String(req.query.limit ?? '50'), 10)
+        const breaches = await metricsService.listActiveBreaches({
+          tenantId: resolveTenantId(req),
+          limit: Number.isFinite(limit) ? limit : 50,
+        })
+        return res.json({ ok: true, data: breaches })
+      } catch (error) {
+        logger.error(`metrics breaches failed: ${error instanceof Error ? error.message : String(error)}`)
+        return res.status(500).json({ ok: false, error: { code: 'METRICS_BREACHES_FAILED', message: 'Failed to load SLA breaches' } })
+      }
+    },
+  )
+
+  r.get('/api/approvals/metrics/instances/:instanceId',
+    authenticate,
+    rbacGuard('approvals:read'),
+    async (req: Request, res: Response) => {
+      try {
+        const instanceId = String(req.params.instanceId || '').trim()
+        if (!instanceId) {
+          return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'instanceId is required' } })
+        }
+        // Wave 2 WP5 slice 1 — participant-or-admin ACL. Admins see every
+        // instance's metrics. Non-admin callers must already be a requester,
+        // an active/historical assignee, or a recorded actor on the instance.
+        // We check both approval_assignments (role + user) and approval_records
+        // so transferred / returned participants are covered.
+        const isAdmin = isAdminActor(req)
+        if (!isAdmin) {
+          const actorId = typeof req.user?.id === 'string' ? req.user.id
+            : typeof req.user?.userId === 'string' ? req.user.userId
+            : typeof req.user?.sub === 'string' ? req.user.sub
+            : null
+          if (!actorId) {
+            return res.status(403).json({ ok: false, error: { code: 'FORBIDDEN', message: 'Actor required' } })
+          }
+          if (!pool) {
+            return res.status(503).json({ ok: false, error: { code: 'DB_UNAVAILABLE', message: 'Database not available' } })
+          }
+          const actorRoles = Array.isArray(req.user?.roles)
+            ? req.user!.roles.filter((r): r is string => typeof r === 'string' && r.trim().length > 0)
+            : []
+          if (typeof req.user?.role === 'string' && req.user.role.trim().length > 0) {
+            actorRoles.push(req.user.role.trim())
+          }
+          const participantCheck = await pool.query<{ exists: boolean }>(
+            `SELECT EXISTS(
+              SELECT 1 FROM approval_instances i
+              WHERE i.id = $1 AND (
+                COALESCE(i.requester_snapshot->>'id', '') = $2
+                OR EXISTS(
+                  SELECT 1 FROM approval_assignments a
+                  WHERE a.instance_id = i.id
+                    AND (
+                      (a.assignment_type = 'user' AND a.assignee_id = $2)
+                      OR (a.assignment_type = 'role' AND a.assignee_id = ANY($3::text[]))
+                    )
+                )
+                OR EXISTS(
+                  SELECT 1 FROM approval_records r
+                  WHERE r.instance_id = i.id AND r.actor_id = $2
+                )
+              )
+            ) AS exists`,
+            [instanceId, actorId, actorRoles.length > 0 ? actorRoles : ['__none__']],
+          )
+          if (!participantCheck.rows[0]?.exists) {
+            return res.status(403).json({ ok: false, error: { code: 'FORBIDDEN', message: 'Not a participant of this approval' } })
+          }
+        }
+
+        const metrics = await metricsService.getInstanceMetrics(instanceId)
+        if (!metrics) {
+          return res.status(404).json({ ok: false, error: { code: 'METRICS_NOT_FOUND', message: 'Metrics not found for instance' } })
+        }
+        return res.json({ ok: true, data: metrics })
+      } catch (error) {
+        logger.error(`metrics instance failed: ${error instanceof Error ? error.message : String(error)}`)
+        return res.status(500).json({ ok: false, error: { code: 'METRICS_INSTANCE_FAILED', message: 'Failed to load approval metrics' } })
+      }
+    },
+  )
+
+  return r
+}
+
+export { ApprovalMetricsService }
+export function __getPoolForTesting() {
+  return pool
+}

--- a/packages/core-backend/src/routes/approvals.ts
+++ b/packages/core-backend/src/routes/approvals.ts
@@ -133,6 +133,13 @@ function resolveApprovalActorDepartmentIds(req: Request): string[] {
   return Array.from(new Set([...fromScalars, ...fromArrays]))
 }
 
+function resolveApprovalTenantId(req: Request): string | undefined {
+  const candidate = req.user?.tenantId
+  if (typeof candidate !== 'string') return undefined
+  const normalized = candidate.trim()
+  return normalized.length > 0 ? normalized : undefined
+}
+
 function resolveApprovalTemplateVisibilityActor(req: Request): ApprovalTemplateVisibilityActor | undefined {
   const userId = resolveApprovalActorId(req)
   if (!userId) return undefined
@@ -333,6 +340,7 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
         description: req.body?.description,
         category: req.body?.category,
         visibilityScope: req.body?.visibilityScope,
+        slaHours: req.body?.slaHours,
         formSchema: req.body?.formSchema,
         approvalGraph: req.body?.approvalGraph,
       })
@@ -383,6 +391,7 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
         // values. `null` is a legitimate "clear" signal.
         ...('category' in (req.body ?? {}) ? { category: req.body.category } : {}),
         ...('visibilityScope' in (req.body ?? {}) ? { visibilityScope: req.body.visibilityScope } : {}),
+        ...('slaHours' in (req.body ?? {}) ? { slaHours: req.body.slaHours } : {}),
         formSchema: req.body?.formSchema,
         approvalGraph: req.body?.approvalGraph,
       })
@@ -620,6 +629,7 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
           userId,
           userName: resolveApprovalActorName(req, userId),
           email: typeof req.user?.email === 'string' ? req.user.email : undefined,
+          tenantId: resolveApprovalTenantId(req),
           department: typeof req.user?.department === 'string' ? req.user.department : undefined,
           departmentIds: resolveApprovalActorDepartmentIds(req),
           roles: resolveApprovalActorRoles(req),

--- a/packages/core-backend/src/services/ApprovalMetricsService.ts
+++ b/packages/core-backend/src/services/ApprovalMetricsService.ts
@@ -68,6 +68,7 @@ export interface MetricsSummary {
   p50DurationSeconds: number | null
   p95DurationSeconds: number | null
   slaBreachCount: number
+  slaCandidateCount: number
   slaBreachRate: number
   byTemplate: MetricsSummaryTemplateRow[]
 }
@@ -253,7 +254,7 @@ export class ApprovalMetricsService {
        WHERE terminal_at IS NULL
          AND sla_hours IS NOT NULL
          AND sla_breached = FALSE
-         AND started_at + (sla_hours || ' hours')::interval < $1
+         AND started_at + (sla_hours * interval '1 hour') < $1
        RETURNING instance_id`,
       [now.toISOString()],
     )
@@ -356,6 +357,7 @@ export class ApprovalMetricsService {
       p50DurationSeconds: parseNullableNumber(row?.p50_duration),
       p95DurationSeconds: parseNullableNumber(row?.p95_duration),
       slaBreachCount,
+      slaCandidateCount,
       slaBreachRate: slaCandidateCount > 0 ? slaBreachCount / slaCandidateCount : 0,
       byTemplate: perTemplate.rows.map((tpl) => {
         const tplCandidate = Number.parseInt(tpl.sla_candidate_count ?? '0', 10) || 0

--- a/packages/core-backend/src/services/ApprovalMetricsService.ts
+++ b/packages/core-backend/src/services/ApprovalMetricsService.ts
@@ -1,0 +1,472 @@
+/**
+ * Wave 2 WP5 slice 1 — SLA / approval-duration observability.
+ *
+ * Per-instance metrics pipeline. Writes are driven by hooks in
+ * ApprovalProductService; all hooks are guarded (log-and-swallow) so
+ * metrics failures cannot break the parent approval flow.
+ *
+ * Query API is injected via the `Query` type so unit tests can mock
+ * the pg pool without needing a live database.
+ */
+
+import { pool } from '../db/pg'
+
+export type Query = <T = unknown>(
+  sql: string,
+  params?: unknown[],
+) => Promise<{ rows: T[]; rowCount?: number | null }>
+
+export type TransactionRunner = <T>(
+  fn: (query: Query) => Promise<T>,
+) => Promise<T>
+
+export type ApprovalTerminalState = 'approved' | 'rejected' | 'revoked' | 'returned'
+
+export interface NodeBreakdownEntry {
+  nodeKey: string
+  activatedAt: string | null
+  decidedAt: string | null
+  durationSeconds: number | null
+  approverIds: string[]
+}
+
+export interface ApprovalMetricsRow {
+  id: string
+  instance_id: string
+  template_id: string | null
+  tenant_id: string
+  started_at: string
+  terminal_at: string | null
+  terminal_state: ApprovalTerminalState | null
+  duration_seconds: number | null
+  sla_hours: number | null
+  sla_breached: boolean
+  sla_breached_at: string | null
+  node_breakdown: NodeBreakdownEntry[]
+  created_at: string
+  updated_at: string
+}
+
+export interface MetricsSummaryTemplateRow {
+  templateId: string | null
+  total: number
+  approved: number
+  rejected: number
+  revoked: number
+  avgDurationSeconds: number | null
+  slaBreachRate: number
+}
+
+export interface MetricsSummary {
+  total: number
+  approved: number
+  rejected: number
+  revoked: number
+  returned: number
+  running: number
+  avgDurationSeconds: number | null
+  p50DurationSeconds: number | null
+  p95DurationSeconds: number | null
+  slaBreachCount: number
+  slaBreachRate: number
+  byTemplate: MetricsSummaryTemplateRow[]
+}
+
+export interface MetricsSummaryQuery {
+  tenantId?: string
+  since?: Date | string
+  until?: Date | string
+}
+
+const DEFAULT_TENANT_ID = 'default'
+
+function resolveTenantId(tenantId?: string | null): string {
+  const normalized = typeof tenantId === 'string' ? tenantId.trim() : ''
+  return normalized.length > 0 ? normalized : DEFAULT_TENANT_ID
+}
+
+function normalizeDate(value: Date | string | undefined | null): Date | null {
+  if (!value) return null
+  if (value instanceof Date) return value
+  const parsed = new Date(value)
+  return Number.isFinite(parsed.getTime()) ? parsed : null
+}
+
+function toNodeBreakdown(raw: unknown): NodeBreakdownEntry[] {
+  if (!Array.isArray(raw)) return []
+  return raw.filter((entry): entry is NodeBreakdownEntry => {
+    return Boolean(entry) && typeof entry === 'object' && 'nodeKey' in (entry as Record<string, unknown>)
+  })
+}
+
+export class ApprovalMetricsService {
+  private readonly transaction: TransactionRunner
+
+  constructor(
+    private readonly query: Query = defaultQuery,
+    transaction?: TransactionRunner,
+  ) {
+    this.transaction = transaction ?? (
+      query === defaultQuery
+        ? defaultTransaction
+        : ((fn) => fn(query))
+    )
+  }
+
+  /**
+   * Insert a metrics row when a new approval instance is created. Idempotent:
+   * a duplicate instance_id is a no-op (approval flow may retry internally).
+   */
+  async recordInstanceStart(input: {
+    instanceId: string
+    templateId: string | null
+    tenantId?: string | null
+    startedAt: Date
+    slaHours?: number | null
+    initialNodeKey?: string | null
+  }): Promise<void> {
+    const tenantId = resolveTenantId(input.tenantId)
+    const initialBreakdown: NodeBreakdownEntry[] = input.initialNodeKey
+      ? [{
+        nodeKey: input.initialNodeKey,
+        activatedAt: input.startedAt.toISOString(),
+        decidedAt: null,
+        durationSeconds: null,
+        approverIds: [],
+      }]
+      : []
+    await this.query(
+      `INSERT INTO approval_metrics
+         (instance_id, template_id, tenant_id, started_at, sla_hours, node_breakdown)
+       VALUES ($1, $2, $3, $4, $5, $6::jsonb)
+       ON CONFLICT (instance_id) DO NOTHING`,
+      [
+        input.instanceId,
+        input.templateId,
+        tenantId,
+        input.startedAt.toISOString(),
+        input.slaHours ?? null,
+        JSON.stringify(initialBreakdown),
+      ],
+    )
+  }
+
+  /**
+   * Append a fresh entry to node_breakdown marking the node's activation.
+   * If the node already has an open entry (same key, no decidedAt), leave it
+   * alone — ApprovalProductService may re-emit on retries.
+   */
+  async recordNodeActivation(input: {
+    instanceId: string
+    nodeKey: string
+    activatedAt: Date
+  }): Promise<void> {
+    await this.mutateBreakdown(input.instanceId, (breakdown) => {
+      const hasOpen = breakdown.some(
+        (entry) => entry.nodeKey === input.nodeKey && !entry.decidedAt,
+      )
+      if (hasOpen) return null
+      breakdown.push({
+        nodeKey: input.nodeKey,
+        activatedAt: input.activatedAt.toISOString(),
+        decidedAt: null,
+        durationSeconds: null,
+        approverIds: [],
+      })
+      return breakdown
+    })
+  }
+
+  /**
+   * Close the most recent open entry for `nodeKey`. If no open entry exists
+   * (e.g. metrics were wired mid-flight), synthesize a zero-duration entry
+   * so the audit trail isn't silently dropped.
+   */
+  async recordNodeDecision(input: {
+    instanceId: string
+    nodeKey: string
+    decidedAt: Date
+    approverIds: string[]
+  }): Promise<void> {
+    await this.mutateBreakdown(input.instanceId, (breakdown) => {
+      const openIndex = [...breakdown].reverse().findIndex(
+        (entry) => entry.nodeKey === input.nodeKey && !entry.decidedAt,
+      )
+      if (openIndex >= 0) {
+        const trueIndex = breakdown.length - 1 - openIndex
+        const entry = breakdown[trueIndex]
+        const activatedMs = entry.activatedAt ? Date.parse(entry.activatedAt) : NaN
+        const duration = Number.isFinite(activatedMs)
+          ? Math.max(0, Math.floor((input.decidedAt.getTime() - activatedMs) / 1000))
+          : null
+        breakdown[trueIndex] = {
+          ...entry,
+          decidedAt: input.decidedAt.toISOString(),
+          durationSeconds: duration,
+          approverIds: input.approverIds,
+        }
+      } else {
+        breakdown.push({
+          nodeKey: input.nodeKey,
+          activatedAt: null,
+          decidedAt: input.decidedAt.toISOString(),
+          durationSeconds: null,
+          approverIds: input.approverIds,
+        })
+      }
+      return breakdown
+    })
+  }
+
+  /**
+   * Mark the instance terminal: set terminal_at, terminal_state, and
+   * duration_seconds = terminal_at - started_at. Overwrites any previously
+   * set terminal fields — callers should only invoke when the approval
+   * instance actually enters a terminal status (approved/rejected/revoked),
+   * or when 'returned' is a deliberate close-out.
+   */
+  async recordTerminal(input: {
+    instanceId: string
+    terminalState: ApprovalTerminalState
+    terminalAt: Date
+  }): Promise<void> {
+    await this.query(
+      `UPDATE approval_metrics
+         SET terminal_at = $2,
+             terminal_state = $3,
+             duration_seconds = GREATEST(0, EXTRACT(EPOCH FROM ($2::timestamptz - started_at))::INTEGER)
+       WHERE instance_id = $1`,
+      [input.instanceId, input.terminalAt.toISOString(), input.terminalState],
+    )
+  }
+
+  /**
+   * Find all active rows where started_at + sla_hours has elapsed and mark
+   * them breached. Returns the list of newly-breached instance ids so the
+   * caller can emit audit events / notifications.
+   */
+  async checkSlaBreaches(now: Date): Promise<string[]> {
+    const result = await this.query<{ instance_id: string }>(
+      `UPDATE approval_metrics
+         SET sla_breached = TRUE,
+             sla_breached_at = $1
+       WHERE terminal_at IS NULL
+         AND sla_hours IS NOT NULL
+         AND sla_breached = FALSE
+         AND started_at + (sla_hours || ' hours')::interval < $1
+       RETURNING instance_id`,
+      [now.toISOString()],
+    )
+    return result.rows.map((row) => row.instance_id)
+  }
+
+  async getMetricsSummary(input: MetricsSummaryQuery = {}): Promise<MetricsSummary> {
+    const tenantId = resolveTenantId(input.tenantId)
+    const since = normalizeDate(input.since)
+    const until = normalizeDate(input.until)
+
+    const conditions: string[] = ['tenant_id = $1']
+    const params: unknown[] = [tenantId]
+    if (since) {
+      params.push(since.toISOString())
+      conditions.push(`started_at >= $${params.length}`)
+    }
+    if (until) {
+      params.push(until.toISOString())
+      conditions.push(`started_at <= $${params.length}`)
+    }
+    const where = `WHERE ${conditions.join(' AND ')}`
+
+    const overall = await this.query<{
+      total: string
+      approved: string
+      rejected: string
+      revoked: string
+      returned: string
+      running: string
+      avg_duration: string | null
+      p50_duration: string | null
+      p95_duration: string | null
+      sla_breach_count: string
+      sla_candidate_count: string
+    }>(
+      `SELECT
+         COUNT(*)::text AS total,
+         COUNT(*) FILTER (WHERE terminal_state = 'approved')::text AS approved,
+         COUNT(*) FILTER (WHERE terminal_state = 'rejected')::text AS rejected,
+         COUNT(*) FILTER (WHERE terminal_state = 'revoked')::text AS revoked,
+         COUNT(*) FILTER (WHERE terminal_state = 'returned')::text AS returned,
+         COUNT(*) FILTER (WHERE terminal_state IS NULL)::text AS running,
+         AVG(duration_seconds) FILTER (WHERE duration_seconds IS NOT NULL)::text AS avg_duration,
+         PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY duration_seconds)
+           FILTER (WHERE duration_seconds IS NOT NULL)::text AS p50_duration,
+         PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY duration_seconds)
+           FILTER (WHERE duration_seconds IS NOT NULL)::text AS p95_duration,
+         COUNT(*) FILTER (WHERE sla_breached = TRUE)::text AS sla_breach_count,
+         COUNT(*) FILTER (WHERE sla_hours IS NOT NULL)::text AS sla_candidate_count
+       FROM approval_metrics
+       ${where}`,
+      params,
+    )
+    const row = overall.rows[0]
+    const total = Number.parseInt(row?.total ?? '0', 10) || 0
+    const approved = Number.parseInt(row?.approved ?? '0', 10) || 0
+    const rejected = Number.parseInt(row?.rejected ?? '0', 10) || 0
+    const revoked = Number.parseInt(row?.revoked ?? '0', 10) || 0
+    const returned = Number.parseInt(row?.returned ?? '0', 10) || 0
+    const running = Number.parseInt(row?.running ?? '0', 10) || 0
+    const slaBreachCount = Number.parseInt(row?.sla_breach_count ?? '0', 10) || 0
+    const slaCandidateCount = Number.parseInt(row?.sla_candidate_count ?? '0', 10) || 0
+
+    const perTemplate = await this.query<{
+      template_id: string | null
+      total: string
+      approved: string
+      rejected: string
+      revoked: string
+      avg_duration: string | null
+      sla_breach_count: string
+      sla_candidate_count: string
+    }>(
+      `SELECT
+         template_id,
+         COUNT(*)::text AS total,
+         COUNT(*) FILTER (WHERE terminal_state = 'approved')::text AS approved,
+         COUNT(*) FILTER (WHERE terminal_state = 'rejected')::text AS rejected,
+         COUNT(*) FILTER (WHERE terminal_state = 'revoked')::text AS revoked,
+         AVG(duration_seconds) FILTER (WHERE duration_seconds IS NOT NULL)::text AS avg_duration,
+         COUNT(*) FILTER (WHERE sla_breached = TRUE)::text AS sla_breach_count,
+         COUNT(*) FILTER (WHERE sla_hours IS NOT NULL)::text AS sla_candidate_count
+       FROM approval_metrics
+       ${where}
+       GROUP BY template_id
+       ORDER BY COUNT(*) DESC
+       LIMIT 100`,
+      params,
+    )
+
+    return {
+      total,
+      approved,
+      rejected,
+      revoked,
+      returned,
+      running,
+      avgDurationSeconds: parseNullableNumber(row?.avg_duration),
+      p50DurationSeconds: parseNullableNumber(row?.p50_duration),
+      p95DurationSeconds: parseNullableNumber(row?.p95_duration),
+      slaBreachCount,
+      slaBreachRate: slaCandidateCount > 0 ? slaBreachCount / slaCandidateCount : 0,
+      byTemplate: perTemplate.rows.map((tpl) => {
+        const tplCandidate = Number.parseInt(tpl.sla_candidate_count ?? '0', 10) || 0
+        const tplBreach = Number.parseInt(tpl.sla_breach_count ?? '0', 10) || 0
+        return {
+          templateId: tpl.template_id,
+          total: Number.parseInt(tpl.total ?? '0', 10) || 0,
+          approved: Number.parseInt(tpl.approved ?? '0', 10) || 0,
+          rejected: Number.parseInt(tpl.rejected ?? '0', 10) || 0,
+          revoked: Number.parseInt(tpl.revoked ?? '0', 10) || 0,
+          avgDurationSeconds: parseNullableNumber(tpl.avg_duration),
+          slaBreachRate: tplCandidate > 0 ? tplBreach / tplCandidate : 0,
+        }
+      }),
+    }
+  }
+
+  async getInstanceMetrics(instanceId: string): Promise<ApprovalMetricsRow | null> {
+    const result = await this.query<ApprovalMetricsRow>(
+      `SELECT * FROM approval_metrics WHERE instance_id = $1`,
+      [instanceId],
+    )
+    const row = result.rows[0]
+    if (!row) return null
+    return { ...row, node_breakdown: toNodeBreakdown(row.node_breakdown) }
+  }
+
+  async listActiveBreaches(input: { tenantId?: string | null; limit?: number } = {}): Promise<ApprovalMetricsRow[]> {
+    const tenantId = resolveTenantId(input.tenantId)
+    const limit = Math.max(1, Math.min(input.limit ?? 50, 200))
+    const result = await this.query<ApprovalMetricsRow>(
+      `SELECT * FROM approval_metrics
+       WHERE tenant_id = $1
+         AND sla_breached = TRUE
+         AND terminal_at IS NULL
+       ORDER BY sla_breached_at DESC NULLS LAST, started_at ASC
+       LIMIT $2`,
+      [tenantId, limit],
+    )
+    return result.rows.map((row) => ({ ...row, node_breakdown: toNodeBreakdown(row.node_breakdown) }))
+  }
+
+  private async mutateBreakdown(
+    instanceId: string,
+    mutate: (breakdown: NodeBreakdownEntry[]) => NodeBreakdownEntry[] | null,
+  ): Promise<void> {
+    await this.transaction(async (query) => {
+      const row = await this.loadBreakdown(instanceId, query)
+      if (!row) return
+      const next = mutate(row.breakdown)
+      if (!next) return
+      await query(
+        `UPDATE approval_metrics SET node_breakdown = $2::jsonb WHERE instance_id = $1`,
+        [instanceId, JSON.stringify(next)],
+      )
+    })
+  }
+
+  private async loadBreakdown(instanceId: string, query: Query): Promise<{ breakdown: NodeBreakdownEntry[] } | null> {
+    const result = await query<{ node_breakdown: unknown }>(
+      `SELECT node_breakdown FROM approval_metrics WHERE instance_id = $1 FOR UPDATE`,
+      [instanceId],
+    )
+    const row = result.rows[0]
+    if (!row) return null
+    return { breakdown: toNodeBreakdown(row.node_breakdown) }
+  }
+}
+
+function parseNullableNumber(value: string | null | undefined): number | null {
+  if (value === null || value === undefined) return null
+  const parsed = Number.parseFloat(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+async function defaultQuery<T = unknown>(sql: string, params: unknown[] = []): Promise<{ rows: T[]; rowCount?: number | null }> {
+  if (!pool) throw new Error('Database not available')
+  const result = await pool.query<T>(sql, params)
+  return { rows: result.rows, rowCount: result.rowCount }
+}
+
+async function defaultTransaction<T>(fn: (query: Query) => Promise<T>): Promise<T> {
+  if (!pool) throw new Error('Database not available')
+  const client = await pool.connect()
+  const txQuery: Query = async <R = unknown>(sqlText: string, params: unknown[] = []) => {
+    const result = await client.query<R>(sqlText, params)
+    return { rows: result.rows, rowCount: result.rowCount }
+  }
+  try {
+    await client.query('BEGIN')
+    const result = await fn(txQuery)
+    await client.query('COMMIT')
+    return result
+  } catch (error) {
+    try {
+      await client.query('ROLLBACK')
+    } catch {
+      // Preserve the original metrics failure; rollback failures are secondary.
+    }
+    throw error
+  } finally {
+    client.release()
+  }
+}
+
+let sharedInstance: ApprovalMetricsService | null = null
+export function getApprovalMetricsService(): ApprovalMetricsService {
+  if (!sharedInstance) sharedInstance = new ApprovalMetricsService()
+  return sharedInstance
+}
+
+export function resetApprovalMetricsServiceForTesting(): void {
+  sharedInstance = null
+}

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -31,6 +31,18 @@ import type {
 } from './approval-bridge-types'
 import { APPROVAL_ERROR_CODES } from './approval-bridge-types'
 import { ServiceError } from './ApprovalBridgeService'
+import { getApprovalMetricsService, type ApprovalMetricsService, type ApprovalTerminalState } from './ApprovalMetricsService'
+import { Logger } from '../core/logger'
+
+const metricsLogger = new Logger('ApprovalMetricsHook')
+
+function safeMetricsCall(label: string, fn: () => Promise<void>): void {
+  Promise.resolve()
+    .then(fn)
+    .catch((error) => {
+      metricsLogger.warn(`metrics hook ${label} failed: ${error instanceof Error ? error.message : String(error)}`)
+    })
+}
 
 interface ApprovalTemplateListQuery {
   status?: string
@@ -53,6 +65,7 @@ interface CreateApprovalActor {
   userId: string
   userName?: string
   email?: string
+  tenantId?: string
   department?: string
   departmentIds?: string[]
   roles?: string[]
@@ -77,6 +90,10 @@ type TemplateRow = {
    */
   category: string | null
   visibility_scope?: Record<string, unknown> | null
+  /**
+   * Wave 2 WP5 slice 1 — optional SLA in hours. `null` disables SLA tracking.
+   */
+  sla_hours: number | null
   status: 'draft' | 'published' | 'archived'
   active_version_id: string | null
   latest_version_id: string | null
@@ -126,6 +143,11 @@ type TemplateMetadataPatch = {
    */
   category?: string | null
   visibilityScope?: ApprovalTemplateVisibilityScope
+  /**
+   * Wave 2 WP5 slice 1 — SLA edits. `null` clears the SLA; `undefined` leaves
+   * it untouched.
+   */
+  slaHours?: number | null
 }
 
 type ApprovalRecordInsert = {
@@ -602,6 +624,8 @@ function toApprovalTemplateListItemDTO(row: TemplateRow): ApprovalTemplateListIt
     // Wave 2 WP4 slice 1 — older rows predate the column; coerce undefined to null.
     category: row.category ?? null,
     visibilityScope: readTemplateVisibilityScope(row.visibility_scope),
+    // Wave 2 WP5 slice 1 — older rows predate the column; coerce undefined to null.
+    slaHours: typeof row.sla_hours === 'number' ? row.sla_hours : null,
     status: row.status,
     activeVersionId: row.active_version_id,
     latestVersionId: row.latest_version_id,
@@ -740,6 +764,29 @@ function normalizeTemplateCategory(value: unknown): string | null | undefined {
     )
   }
   return trimmed
+}
+
+/**
+ * Wave 2 WP5 slice 1 — normalize SLA hours. Accepts positive integers or null;
+ * `undefined` leaves the field unset.
+ */
+const APPROVAL_TEMPLATE_SLA_MAX_HOURS = 24 * 365 // 1 year upper bound
+
+function normalizeTemplateSlaHours(value: unknown): number | null | undefined {
+  if (value === undefined) return undefined
+  if (value === null || value === '') return null
+  const parsed = typeof value === 'number' ? value : Number(value)
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed <= 0) {
+    throw new ServiceError('slaHours must be a positive integer', 400, 'VALIDATION_ERROR')
+  }
+  if (parsed > APPROVAL_TEMPLATE_SLA_MAX_HOURS) {
+    throw new ServiceError(
+      `slaHours must be at most ${APPROVAL_TEMPLATE_SLA_MAX_HOURS}`,
+      400,
+      'VALIDATION_ERROR',
+    )
+  }
+  return parsed
 }
 
 function normalizeTemplateVisibilityScope(value: unknown): ApprovalTemplateVisibilityScope | undefined {
@@ -955,6 +1002,12 @@ function readParallelBranchStates(metadata: unknown): ParallelInstanceState | nu
 }
 
 export class ApprovalProductService {
+  /**
+   * Wave 2 WP5 slice 1 — optional metrics service injection so tests can
+   * pass a stub. Production default uses the process-wide singleton.
+   */
+  constructor(private readonly metrics: ApprovalMetricsService = getApprovalMetricsService()) {}
+
   async listTemplates(query: ApprovalTemplateListQuery): Promise<{ data: ApprovalTemplateListItemDTO[]; total: number }> {
     if (!pool) throw new Error('Database not available')
 
@@ -1017,6 +1070,8 @@ export class ApprovalProductService {
     // Wave 2 WP4 slice 1 — category is optional; `undefined`/empty → null.
     const category = normalizeTemplateCategory(request.category) ?? null
     const visibilityScope = normalizeTemplateVisibilityScope(request.visibilityScope) ?? { type: 'all', ids: [] }
+    const slaHoursNormalized = normalizeTemplateSlaHours(request.slaHours)
+    const slaHours = slaHoursNormalized === undefined ? null : slaHoursNormalized
     const formSchema = assertFormSchema(request.formSchema)
     const approvalGraph = assertApprovalGraph(request.approvalGraph)
 
@@ -1026,10 +1081,10 @@ export class ApprovalProductService {
       await client.query('BEGIN')
 
       const templateResult = await client.query<TemplateRow>(
-        `INSERT INTO approval_templates (key, name, description, category, visibility_scope, status)
-         VALUES ($1, $2, $3, $4, $5, 'draft')
+        `INSERT INTO approval_templates (key, name, description, category, visibility_scope, sla_hours, status)
+         VALUES ($1, $2, $3, $4, $5, $6, 'draft')
          RETURNING *`,
-        [key, name, description ?? null, category, JSON.stringify(visibilityScope)],
+        [key, name, description ?? null, category, JSON.stringify(visibilityScope), slaHours],
       )
       let template = templateResult.rows[0]
 
@@ -1081,6 +1136,10 @@ export class ApprovalProductService {
     if (request.visibilityScope !== undefined) {
       metadataPatch.visibilityScope = normalizeTemplateVisibilityScope(request.visibilityScope) ?? { type: 'all', ids: [] }
     }
+    if (request.slaHours !== undefined) {
+      const normalized = normalizeTemplateSlaHours(request.slaHours)
+      metadataPatch.slaHours = normalized === undefined ? null : normalized
+    }
 
     const formSchema = request.formSchema !== undefined ? assertFormSchema(request.formSchema) : undefined
     const approvalGraph = request.approvalGraph !== undefined ? assertApprovalGraph(request.approvalGraph) : undefined
@@ -1123,6 +1182,10 @@ export class ApprovalProductService {
         if (metadataPatch.visibilityScope !== undefined) {
           setClauses.push(`visibility_scope = $${index++}`)
           params.push(JSON.stringify(metadataPatch.visibilityScope))
+        }
+        if (metadataPatch.slaHours !== undefined) {
+          setClauses.push(`sla_hours = $${index++}`)
+          params.push(metadataPatch.slaHours)
         }
         setClauses.push('updated_at = now()')
         params.push(id)
@@ -1535,6 +1598,26 @@ export class ApprovalProductService {
       client?.release()
     }
 
+    // Wave 2 WP5 slice 1 — metrics start row is written after commit and
+    // guarded so a metrics failure cannot roll back the approval instance.
+    safeMetricsCall(`recordInstanceStart(${instanceId})`, async () => {
+      await this.metrics.recordInstanceStart({
+      instanceId,
+      templateId: bundle.template.id,
+      tenantId: actor.tenantId ?? null,
+      startedAt: new Date(),
+      slaHours: bundle.template.sla_hours ?? null,
+      initialNodeKey: initial.currentNodeKey,
+      })
+      if (initial.status === 'approved') {
+        await this.metrics.recordTerminal({
+          instanceId,
+          terminalState: 'approved',
+          terminalAt: new Date(),
+        })
+      }
+    })
+
     const approval = await this.getApproval(instanceId)
     if (!approval) {
       throw new ServiceError('Approval not found after creation', 500, 'APPROVAL_CREATE_FAILED')
@@ -1720,6 +1803,7 @@ export class ApprovalProductService {
           metadata: { nodeKey: currentNodeKey },
         }, actor)
         await client.query('COMMIT')
+        this.emitTerminalMetric(id, 'revoked')
         return (await this.getApproval(id))!
       }
 
@@ -1802,6 +1886,10 @@ export class ApprovalProductService {
         await this.insertAutoApprovalEvents(client, id, nextVersion, resolution.status, resolution.autoApprovalEvents)
         await this.insertCcEvents(client, id, nextVersion, resolution.status, resolution.ccEvents)
         await client.query('COMMIT')
+        this.emitNodeDecisionMetric(id, currentNodeKey, actor.userId)
+        if (resolution.currentNodeKey) {
+          this.emitNodeActivationMetric(id, resolution.currentNodeKey)
+        }
         return (await this.getApproval(id))!
       }
 
@@ -1830,6 +1918,8 @@ export class ApprovalProductService {
           metadata: { nodeKey: currentNodeKey },
         }, actor)
         await client.query('COMMIT')
+        this.emitNodeDecisionMetric(id, currentNodeKey, actor.userId)
+        this.emitTerminalMetric(id, 'rejected')
         return (await this.getApproval(id))!
       }
 
@@ -2077,6 +2167,15 @@ export class ApprovalProductService {
       await this.insertCcEvents(client, id, nextVersion, resolution.status, resolution.ccEvents)
 
       await client.query('COMMIT')
+
+      // Wave 2 WP5 slice 1 — emit metrics after commit so rollback failures
+      // never leave dangling breakdown entries. All hooks are guarded.
+      this.emitNodeDecisionMetric(id, currentNodeKey, actor.userId)
+      if (resolution.status === 'approved') {
+        this.emitTerminalMetric(id, 'approved')
+      } else if (resolution.currentNodeKey && resolution.currentNodeKey !== currentNodeKey) {
+        this.emitNodeActivationMetric(id, resolution.currentNodeKey)
+      }
     } catch (error) {
       await rollbackQuietly(client)
       throw error
@@ -2089,6 +2188,41 @@ export class ApprovalProductService {
       throw new ServiceError('Approval not found after action', 404, APPROVAL_ERROR_CODES.APPROVAL_NOT_FOUND)
     }
     return approval
+  }
+
+  /**
+   * Wave 2 WP5 slice 1 — metrics helpers. All calls are log-and-swallow so
+   * a metrics outage cannot fail the approval flow.
+   */
+  private emitNodeDecisionMetric(instanceId: string, nodeKey: string, actorId: string): void {
+    safeMetricsCall(`recordNodeDecision(${instanceId}/${nodeKey})`, () =>
+      this.metrics.recordNodeDecision({
+        instanceId,
+        nodeKey,
+        decidedAt: new Date(),
+        approverIds: [actorId],
+      }),
+    )
+  }
+
+  private emitNodeActivationMetric(instanceId: string, nodeKey: string): void {
+    safeMetricsCall(`recordNodeActivation(${instanceId}/${nodeKey})`, () =>
+      this.metrics.recordNodeActivation({
+        instanceId,
+        nodeKey,
+        activatedAt: new Date(),
+      }),
+    )
+  }
+
+  private emitTerminalMetric(instanceId: string, terminalState: ApprovalTerminalState): void {
+    safeMetricsCall(`recordTerminal(${instanceId}/${terminalState})`, () =>
+      this.metrics.recordTerminal({
+        instanceId,
+        terminalState,
+        terminalAt: new Date(),
+      }),
+    )
   }
 
   async getApproval(id: string): Promise<UnifiedApprovalDTO | null> {

--- a/packages/core-backend/src/services/ApprovalSlaScheduler.ts
+++ b/packages/core-backend/src/services/ApprovalSlaScheduler.ts
@@ -1,0 +1,98 @@
+/**
+ * Wave 2 WP5 slice 1 — SLA breach scanner.
+ *
+ * Runs a periodic (default 15 min) scan that flips `sla_breached = TRUE`
+ * on approval_metrics rows whose `started_at + sla_hours` have elapsed.
+ * Single-process interval with a one-run guard — multi-instance fleets
+ * should either disable the scheduler on all but one pod (env
+ * APPROVAL_SLA_SCHEDULER_DISABLED=1) or wrap this in leader election at
+ * a future point.
+ */
+
+import { Logger } from '../core/logger'
+import { getApprovalMetricsService, type ApprovalMetricsService } from './ApprovalMetricsService'
+
+const DEFAULT_INTERVAL_MS = 15 * 60 * 1000
+const MIN_INTERVAL_MS = 5000
+
+export interface ApprovalSlaSchedulerOptions {
+  metrics?: ApprovalMetricsService
+  intervalMs?: number
+  /**
+   * Optional hook invoked once per breach cycle with the newly-breached
+   * instance ids. Main caller wires it to approval audit + notifications.
+   */
+  onBreach?: (instanceIds: string[]) => Promise<void> | void
+  logger?: Logger
+}
+
+export class ApprovalSlaScheduler {
+  private readonly logger: Logger
+  private readonly metrics: ApprovalMetricsService
+  private readonly intervalMs: number
+  private readonly onBreach: ApprovalSlaSchedulerOptions['onBreach']
+  private timer: NodeJS.Timeout | null = null
+  private running = false
+
+  constructor(options: ApprovalSlaSchedulerOptions = {}) {
+    this.metrics = options.metrics ?? getApprovalMetricsService()
+    this.intervalMs = Math.max(MIN_INTERVAL_MS, options.intervalMs ?? DEFAULT_INTERVAL_MS)
+    this.onBreach = options.onBreach
+    this.logger = options.logger ?? new Logger('ApprovalSlaScheduler')
+  }
+
+  start(): void {
+    if (this.timer) return
+    this.logger.info(`SLA scheduler starting with interval ${this.intervalMs}ms`)
+    this.timer = setInterval(() => { void this.tick() }, this.intervalMs)
+    if (typeof this.timer.unref === 'function') this.timer.unref()
+  }
+
+  stop(): void {
+    if (!this.timer) return
+    clearInterval(this.timer)
+    this.timer = null
+    this.logger.info('SLA scheduler stopped')
+  }
+
+  async tick(now: Date = new Date()): Promise<string[]> {
+    if (this.running) return []
+    this.running = true
+    try {
+      const breached = await this.metrics.checkSlaBreaches(now)
+      if (breached.length > 0) {
+        this.logger.warn(`SLA breaches flagged: ${breached.length}`)
+        if (this.onBreach) {
+          try {
+            await this.onBreach(breached)
+          } catch (error) {
+            this.logger.warn(`SLA onBreach hook failed: ${error instanceof Error ? error.message : String(error)}`)
+          }
+        }
+      }
+      return breached
+    } catch (error) {
+      this.logger.error(`SLA tick failed: ${error instanceof Error ? error.message : String(error)}`)
+      return []
+    } finally {
+      this.running = false
+    }
+  }
+}
+
+let sharedScheduler: ApprovalSlaScheduler | null = null
+
+export function startApprovalSlaScheduler(options: ApprovalSlaSchedulerOptions = {}): ApprovalSlaScheduler | null {
+  if (process.env.APPROVAL_SLA_SCHEDULER_DISABLED === '1') return null
+  if (sharedScheduler) return sharedScheduler
+  sharedScheduler = new ApprovalSlaScheduler(options)
+  sharedScheduler.start()
+  return sharedScheduler
+}
+
+export function stopApprovalSlaScheduler(): void {
+  if (sharedScheduler) {
+    sharedScheduler.stop()
+    sharedScheduler = null
+  }
+}

--- a/packages/core-backend/src/types/approval-product.ts
+++ b/packages/core-backend/src/types/approval-product.ts
@@ -220,6 +220,11 @@ export interface ApprovalTemplateListItemDTO {
    * `{ type: 'all', ids: [] }` and remain globally visible.
    */
   visibilityScope: ApprovalTemplateVisibilityScope
+  /**
+   * Wave 2 WP5 slice 1 — SLA deadline for new instances in whole hours.
+   * `null` disables SLA tracking for the template.
+   */
+  slaHours: number | null
   status: ApprovalTemplateStatus
   activeVersionId: string | null
   latestVersionId: string | null
@@ -247,6 +252,11 @@ export interface CreateApprovalTemplateRequest {
    */
   category?: string | null
   visibilityScope?: ApprovalTemplateVisibilityScope | null
+  /**
+   * Wave 2 WP5 slice 1 — optional SLA in hours. `null`/undefined disables
+   * SLA tracking; positive integers are required, 0 and negatives reject.
+   */
+  slaHours?: number | null
   formSchema: FormSchema
   approvalGraph: ApprovalGraph
 }
@@ -261,6 +271,11 @@ export interface UpdateApprovalTemplateRequest {
    */
   category?: string | null
   visibilityScope?: ApprovalTemplateVisibilityScope | null
+  /**
+   * Wave 2 WP5 slice 1 — when provided, updates `approval_templates.sla_hours`.
+   * Pass `null` to clear the SLA.
+   */
+  slaHours?: number | null
   formSchema?: FormSchema
   approvalGraph?: ApprovalGraph
 }

--- a/packages/core-backend/tests/helpers/approval-schema-bootstrap.ts
+++ b/packages/core-backend/tests/helpers/approval-schema-bootstrap.ts
@@ -1,7 +1,7 @@
 import { poolManager } from '../../src/integration/db/connection-pool'
 
 const APPROVAL_SCHEMA_BOOTSTRAP_KEY = 'approval-schema-bootstrap'
-const APPROVAL_SCHEMA_BOOTSTRAP_VERSION = '20260423-wp4-template-acl'
+const APPROVAL_SCHEMA_BOOTSTRAP_VERSION = '20260425-wp5-sla'
 
 /**
  * Ensures the approval schema (tables, constraints, indexes, sequences) is
@@ -313,6 +313,68 @@ export async function ensureApprovalSchemaReady(): Promise<void> {
     await client.query(`CREATE UNIQUE INDEX IF NOT EXISTS idx_approval_published_definitions_active_template ON approval_published_definitions(template_id) WHERE is_active = TRUE`)
 
     await client.query(`CREATE SEQUENCE IF NOT EXISTS approval_request_no_seq START WITH 100001 INCREMENT BY 1`)
+
+    // Wave 2 WP5 slice 1 — approval metrics / SLA observability.
+    await client.query(`ALTER TABLE approval_templates ADD COLUMN IF NOT EXISTS sla_hours INTEGER`)
+    await client.query(`
+      DO $$
+      BEGIN
+        ALTER TABLE approval_templates
+          ADD CONSTRAINT approval_templates_sla_hours_positive
+          CHECK (sla_hours IS NULL OR sla_hours > 0);
+      EXCEPTION WHEN duplicate_object THEN NULL;
+      END $$;
+    `)
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS approval_metrics (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        instance_id TEXT NOT NULL UNIQUE REFERENCES approval_instances(id) ON DELETE CASCADE,
+        template_id UUID,
+        tenant_id TEXT NOT NULL DEFAULT 'default',
+        started_at TIMESTAMPTZ NOT NULL,
+        terminal_at TIMESTAMPTZ,
+        terminal_state TEXT,
+        duration_seconds INTEGER,
+        sla_hours INTEGER,
+        sla_breached BOOLEAN NOT NULL DEFAULT FALSE,
+        sla_breached_at TIMESTAMPTZ,
+        node_breakdown JSONB NOT NULL DEFAULT '[]'::jsonb,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+      )
+    `)
+    await client.query(`
+      DO $$
+      BEGIN
+        ALTER TABLE approval_metrics
+          ADD CONSTRAINT approval_metrics_terminal_state_check
+          CHECK (terminal_state IS NULL OR terminal_state IN ('approved', 'rejected', 'revoked', 'returned'));
+      EXCEPTION WHEN duplicate_object THEN NULL;
+      END $$;
+    `)
+    await client.query(`CREATE INDEX IF NOT EXISTS idx_approval_metrics_tenant_terminal ON approval_metrics(tenant_id, terminal_at DESC)`)
+    await client.query(`CREATE INDEX IF NOT EXISTS idx_approval_metrics_template ON approval_metrics(template_id) WHERE template_id IS NOT NULL`)
+    await client.query(`CREATE INDEX IF NOT EXISTS idx_approval_metrics_sla_breached_active ON approval_metrics(tenant_id, sla_breached) WHERE sla_breached = TRUE`)
+    await client.query(`CREATE INDEX IF NOT EXISTS idx_approval_metrics_sla_scan ON approval_metrics(started_at) WHERE terminal_at IS NULL AND sla_hours IS NOT NULL AND sla_breached = FALSE`)
+    await client.query(`
+      CREATE OR REPLACE FUNCTION approval_metrics_set_updated_at()
+      RETURNS TRIGGER AS $$
+      BEGIN
+        NEW.updated_at = now();
+        RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql
+    `)
+    await client.query(`
+      DO $$
+      BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'trg_approval_metrics_updated_at') THEN
+          CREATE TRIGGER trg_approval_metrics_updated_at
+            BEFORE UPDATE ON approval_metrics
+            FOR EACH ROW EXECUTE FUNCTION approval_metrics_set_updated_at();
+        END IF;
+      END $$;
+    `)
 
     await client.query(
       `INSERT INTO approval_test_schema_bootstrap_state (key, version, completed_at)

--- a/packages/core-backend/tests/unit/approval-metrics-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-metrics-service.test.ts
@@ -223,6 +223,7 @@ describe('ApprovalMetricsService', () => {
       expect(breached).toEqual(['apr-1', 'apr-9'])
       const [sql, params] = queryMock.mock.calls[0]
       expect(normalize(sql)).toContain(`sla_breached = TRUE`)
+      expect(normalize(sql)).toContain(`started_at + (sla_hours * interval '1 hour') < $1`)
       expect(normalize(sql)).toContain(`RETURNING instance_id`)
       expect(params[0]).toBe('2026-04-25T12:00:00.000Z')
     })
@@ -275,6 +276,7 @@ describe('ApprovalMetricsService', () => {
         p50DurationSeconds: 3600,
         p95DurationSeconds: 7200,
         slaBreachCount: 2,
+        slaCandidateCount: 5,
         slaBreachRate: 0.4,
       })
       expect(summary.byTemplate).toHaveLength(1)

--- a/packages/core-backend/tests/unit/approval-metrics-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-metrics-service.test.ts
@@ -1,0 +1,351 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ApprovalMetricsService, type Query, type TransactionRunner } from '../../src/services/ApprovalMetricsService'
+
+/**
+ * Unit coverage for ApprovalMetricsService — uses an injected mock `Query`
+ * so no pg is required. Covers the happy paths + the small amount of
+ * in-memory breakdown bookkeeping that the service owns.
+ */
+
+interface Row {
+  node_breakdown: unknown
+}
+
+function normalize(sql: string): string {
+  return sql.replace(/\s+/g, ' ').trim()
+}
+
+describe('ApprovalMetricsService', () => {
+  let queryMock: ReturnType<typeof vi.fn>
+  let service: ApprovalMetricsService
+
+  beforeEach(() => {
+    queryMock = vi.fn()
+    service = new ApprovalMetricsService(queryMock as unknown as Query)
+  })
+
+  describe('recordInstanceStart', () => {
+    it('inserts a metrics row with ON CONFLICT DO NOTHING', async () => {
+      queryMock.mockResolvedValueOnce({ rows: [], rowCount: 1 })
+
+      await service.recordInstanceStart({
+        instanceId: 'apr-1',
+        templateId: 'tmpl-1',
+        tenantId: 'tenant-a',
+        startedAt: new Date('2026-04-25T10:00:00Z'),
+        slaHours: 24,
+        initialNodeKey: 'approval_1',
+      })
+
+      expect(queryMock).toHaveBeenCalledTimes(1)
+      const [sql, params] = queryMock.mock.calls[0]
+      expect(normalize(sql)).toContain('INSERT INTO approval_metrics')
+      expect(normalize(sql)).toContain('ON CONFLICT (instance_id) DO NOTHING')
+      expect(params[0]).toBe('apr-1')
+      expect(params[1]).toBe('tmpl-1')
+      expect(params[2]).toBe('tenant-a')
+      expect(params[3]).toBe('2026-04-25T10:00:00.000Z')
+      expect(params[4]).toBe(24)
+      const breakdown = JSON.parse(params[5])
+      expect(breakdown).toHaveLength(1)
+      expect(breakdown[0]).toMatchObject({ nodeKey: 'approval_1', decidedAt: null, approverIds: [] })
+    })
+
+    it('falls back to "default" tenant id when blank', async () => {
+      queryMock.mockResolvedValueOnce({ rows: [], rowCount: 1 })
+
+      await service.recordInstanceStart({
+        instanceId: 'apr-2',
+        templateId: null,
+        tenantId: '   ',
+        startedAt: new Date('2026-04-25T10:00:00Z'),
+      })
+
+      expect(queryMock.mock.calls[0][1][2]).toBe('default')
+      expect(queryMock.mock.calls[0][1][5]).toBe('[]')
+    })
+  })
+
+  describe('recordNodeActivation', () => {
+    it('appends a new open entry and skips when one already exists', async () => {
+      // First call: select current breakdown, then update.
+      queryMock
+        .mockResolvedValueOnce({ rows: [{ node_breakdown: [] }] as Row[] })
+        .mockResolvedValueOnce({ rows: [], rowCount: 1 })
+
+      await service.recordNodeActivation({
+        instanceId: 'apr-1',
+        nodeKey: 'approval_2',
+        activatedAt: new Date('2026-04-25T11:00:00Z'),
+      })
+
+      expect(queryMock).toHaveBeenCalledTimes(2)
+      const updatePayload = JSON.parse(queryMock.mock.calls[1][1][1])
+      expect(updatePayload).toHaveLength(1)
+      expect(updatePayload[0]).toMatchObject({ nodeKey: 'approval_2', decidedAt: null })
+
+      queryMock.mockClear()
+      queryMock.mockResolvedValueOnce({
+        rows: [{ node_breakdown: [{ nodeKey: 'approval_2', activatedAt: 'x', decidedAt: null, durationSeconds: null, approverIds: [] }] }] as Row[],
+      })
+      await service.recordNodeActivation({
+        instanceId: 'apr-1',
+        nodeKey: 'approval_2',
+        activatedAt: new Date('2026-04-25T11:05:00Z'),
+      })
+      expect(queryMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('returns silently when the instance has no metrics row', async () => {
+      queryMock.mockResolvedValueOnce({ rows: [] as Row[] })
+
+      await service.recordNodeActivation({
+        instanceId: 'unknown',
+        nodeKey: 'approval_1',
+        activatedAt: new Date(),
+      })
+
+      expect(queryMock).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('recordNodeDecision', () => {
+    it('closes the open entry with a computed duration', async () => {
+      queryMock
+        .mockResolvedValueOnce({
+          rows: [{
+            node_breakdown: [
+              { nodeKey: 'approval_1', activatedAt: '2026-04-25T10:00:00.000Z', decidedAt: null, durationSeconds: null, approverIds: [] },
+            ],
+          }] as Row[],
+        })
+        .mockResolvedValueOnce({ rows: [], rowCount: 1 })
+
+      await service.recordNodeDecision({
+        instanceId: 'apr-1',
+        nodeKey: 'approval_1',
+        decidedAt: new Date('2026-04-25T10:30:00.000Z'),
+        approverIds: ['u1'],
+      })
+
+      const breakdown = JSON.parse(queryMock.mock.calls[1][1][1])
+      expect(breakdown[0]).toMatchObject({
+        nodeKey: 'approval_1',
+        decidedAt: '2026-04-25T10:30:00.000Z',
+        durationSeconds: 1800,
+        approverIds: ['u1'],
+      })
+    })
+
+    it('runs read-modify-write breakdown updates inside the injected transaction runner', async () => {
+      const calls: string[] = []
+      const txQuery = vi.fn<Query>()
+        .mockImplementation(async (sql) => {
+          calls.push(normalize(sql).startsWith('SELECT node_breakdown') ? 'select' : 'update')
+          if (normalize(sql).startsWith('SELECT node_breakdown')) {
+            return {
+              rows: [{
+                node_breakdown: [
+                  { nodeKey: 'approval_1', activatedAt: '2026-04-25T10:00:00.000Z', decidedAt: null, durationSeconds: null, approverIds: [] },
+                ],
+              }],
+              rowCount: 1,
+            }
+          }
+          return { rows: [], rowCount: 1 }
+        })
+      const transaction = vi.fn<TransactionRunner>(async (fn) => {
+        calls.push('begin')
+        const result = await fn(txQuery)
+        calls.push('commit')
+        return result
+      })
+      const serviceWithTransaction = new ApprovalMetricsService(queryMock as unknown as Query, transaction)
+
+      await serviceWithTransaction.recordNodeDecision({
+        instanceId: 'apr-1',
+        nodeKey: 'approval_1',
+        decidedAt: new Date('2026-04-25T10:30:00.000Z'),
+        approverIds: ['u1'],
+      })
+
+      expect(transaction).toHaveBeenCalledTimes(1)
+      expect(queryMock).not.toHaveBeenCalled()
+      expect(calls).toEqual(['begin', 'select', 'update', 'commit'])
+      expect(normalize(String(txQuery.mock.calls[0][0]))).toContain('FOR UPDATE')
+    })
+
+    it('synthesizes a zero-duration entry when no matching open entry exists', async () => {
+      queryMock
+        .mockResolvedValueOnce({ rows: [{ node_breakdown: [] }] as Row[] })
+        .mockResolvedValueOnce({ rows: [], rowCount: 1 })
+
+      await service.recordNodeDecision({
+        instanceId: 'apr-1',
+        nodeKey: 'approval_2',
+        decidedAt: new Date('2026-04-25T11:00:00Z'),
+        approverIds: ['u2'],
+      })
+
+      const breakdown = JSON.parse(queryMock.mock.calls[1][1][1])
+      expect(breakdown).toHaveLength(1)
+      expect(breakdown[0]).toMatchObject({ nodeKey: 'approval_2', activatedAt: null, durationSeconds: null })
+    })
+  })
+
+  describe('recordTerminal', () => {
+    it('issues a single UPDATE with duration computed in SQL', async () => {
+      queryMock.mockResolvedValueOnce({ rows: [], rowCount: 1 })
+
+      await service.recordTerminal({
+        instanceId: 'apr-1',
+        terminalState: 'approved',
+        terminalAt: new Date('2026-04-25T12:00:00Z'),
+      })
+
+      const [sql, params] = queryMock.mock.calls[0]
+      expect(normalize(sql)).toContain('UPDATE approval_metrics')
+      expect(normalize(sql)).toContain('EXTRACT(EPOCH FROM ($2::timestamptz - started_at))')
+      expect(params[2]).toBe('approved')
+    })
+  })
+
+  describe('checkSlaBreaches', () => {
+    it('returns breached instance ids from the update', async () => {
+      queryMock.mockResolvedValueOnce({
+        rows: [{ instance_id: 'apr-1' }, { instance_id: 'apr-9' }],
+        rowCount: 2,
+      })
+
+      const now = new Date('2026-04-25T12:00:00Z')
+      const breached = await service.checkSlaBreaches(now)
+
+      expect(breached).toEqual(['apr-1', 'apr-9'])
+      const [sql, params] = queryMock.mock.calls[0]
+      expect(normalize(sql)).toContain(`sla_breached = TRUE`)
+      expect(normalize(sql)).toContain(`RETURNING instance_id`)
+      expect(params[0]).toBe('2026-04-25T12:00:00.000Z')
+    })
+  })
+
+  describe('getMetricsSummary', () => {
+    it('aggregates counts, percentiles, and per-template rows', async () => {
+      queryMock
+        .mockResolvedValueOnce({
+          rows: [{
+            total: '10',
+            approved: '6',
+            rejected: '2',
+            revoked: '1',
+            returned: '0',
+            running: '1',
+            avg_duration: '3600',
+            p50_duration: '3600',
+            p95_duration: '7200',
+            sla_breach_count: '2',
+            sla_candidate_count: '5',
+          }],
+        })
+        .mockResolvedValueOnce({
+          rows: [{
+            template_id: 'tmpl-1',
+            total: '5',
+            approved: '3',
+            rejected: '1',
+            revoked: '1',
+            avg_duration: '1800',
+            sla_breach_count: '1',
+            sla_candidate_count: '2',
+          }],
+        })
+
+      const summary = await service.getMetricsSummary({
+        tenantId: 'tenant-a',
+        since: '2026-04-01T00:00:00Z',
+        until: '2026-04-30T00:00:00Z',
+      })
+
+      expect(summary).toMatchObject({
+        total: 10,
+        approved: 6,
+        rejected: 2,
+        revoked: 1,
+        running: 1,
+        avgDurationSeconds: 3600,
+        p50DurationSeconds: 3600,
+        p95DurationSeconds: 7200,
+        slaBreachCount: 2,
+        slaBreachRate: 0.4,
+      })
+      expect(summary.byTemplate).toHaveLength(1)
+      expect(summary.byTemplate[0]).toMatchObject({
+        templateId: 'tmpl-1',
+        total: 5,
+        approved: 3,
+        slaBreachRate: 0.5,
+      })
+    })
+
+    it('applies tenantId and date filters to both queries', async () => {
+      queryMock
+        .mockResolvedValueOnce({ rows: [{ total: '0', approved: '0', rejected: '0', revoked: '0', returned: '0', running: '0', avg_duration: null, p50_duration: null, p95_duration: null, sla_breach_count: '0', sla_candidate_count: '0' }] })
+        .mockResolvedValueOnce({ rows: [] })
+
+      await service.getMetricsSummary({ tenantId: 'tenant-z', since: new Date('2026-04-20Z'), until: new Date('2026-04-25Z') })
+
+      for (const call of queryMock.mock.calls) {
+        const sql = normalize(call[0])
+        expect(sql).toContain('tenant_id = $1')
+        expect(sql).toContain('started_at >= $2')
+        expect(sql).toContain('started_at <= $3')
+        expect(call[1][0]).toBe('tenant-z')
+      }
+    })
+  })
+
+  describe('listActiveBreaches', () => {
+    it('queries active breached rows ordered by breach time', async () => {
+      queryMock.mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'm1', instance_id: 'apr-1', template_id: 'tmpl-1', tenant_id: 'default',
+            started_at: 'x', terminal_at: null, terminal_state: null, duration_seconds: null,
+            sla_hours: 24, sla_breached: true, sla_breached_at: 'y', node_breakdown: [],
+            created_at: 'x', updated_at: 'x',
+          },
+        ],
+      })
+
+      const rows = await service.listActiveBreaches({ tenantId: 'default', limit: 10 })
+
+      expect(rows).toHaveLength(1)
+      expect(rows[0].instance_id).toBe('apr-1')
+      const sql = normalize(queryMock.mock.calls[0][0])
+      expect(sql).toContain('sla_breached = TRUE')
+      expect(sql).toContain('terminal_at IS NULL')
+    })
+  })
+
+  describe('getInstanceMetrics', () => {
+    it('returns the row when present', async () => {
+      queryMock.mockResolvedValueOnce({
+        rows: [{
+          id: 'm1', instance_id: 'apr-1', template_id: null, tenant_id: 'default',
+          started_at: 'x', terminal_at: null, terminal_state: null, duration_seconds: null,
+          sla_hours: null, sla_breached: false, sla_breached_at: null, node_breakdown: [],
+          created_at: 'x', updated_at: 'x',
+        }],
+      })
+
+      const row = await service.getInstanceMetrics('apr-1')
+
+      expect(row?.instance_id).toBe('apr-1')
+      expect(Array.isArray(row?.node_breakdown)).toBe(true)
+    })
+
+    it('returns null when absent', async () => {
+      queryMock.mockResolvedValueOnce({ rows: [] })
+      expect(await service.getInstanceMetrics('missing')).toBeNull()
+    })
+  })
+})

--- a/packages/core-backend/tests/unit/approval-product-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-product-service.test.ts
@@ -715,4 +715,127 @@ describe('ApprovalProductService', () => {
 
     randomBytesSpy.mockRestore()
   })
+
+  it('records terminal metrics for approvals auto-approved at creation', async () => {
+    const metrics = {
+      recordInstanceStart: vi.fn().mockResolvedValue(undefined),
+      recordTerminal: vi.fn().mockResolvedValue(undefined),
+      recordNodeActivation: vi.fn().mockResolvedValue(undefined),
+      recordNodeDecision: vi.fn().mockResolvedValue(undefined),
+      checkSlaBreaches: vi.fn().mockResolvedValue([]),
+      getMetricsSummary: vi.fn(),
+      getInstanceMetrics: vi.fn(),
+      listActiveBreaches: vi.fn(),
+    }
+    const autoApprovedGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        { key: 'approval_1', type: 'approval', config: { assigneeType: 'user', assigneeIds: [], emptyAssigneePolicy: 'auto-approve' } },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-approval', source: 'start', target: 'approval_1' },
+        { key: 'edge-approval-end', source: 'approval_1', target: 'end' },
+      ],
+      policy: { allowRevoke: true },
+    }
+
+    pgState.pool.query.mockImplementation(async (sql: string) => {
+      const statement = normalize(sql)
+      if (statement.startsWith('SELECT * FROM approval_templates WHERE id = $1')) {
+        return {
+          rows: [{
+            id: 'tpl-1',
+            key: 'auto',
+            name: 'Auto Approval',
+            description: null,
+            category: null,
+            visibility_scope: { type: 'all', ids: [] },
+            sla_hours: 4,
+            status: 'published',
+            active_version_id: 'ver-1',
+            latest_version_id: 'ver-1',
+            created_at: new Date(),
+            updated_at: new Date(),
+          }],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith('SELECT * FROM approval_template_versions WHERE id = $1')) {
+        return {
+          rows: [{
+            id: 'ver-1',
+            template_id: 'tpl-1',
+            version: 1,
+            status: 'published',
+            form_schema: { fields: [] },
+            approval_graph: autoApprovedGraph,
+            created_at: new Date(),
+            updated_at: new Date(),
+          }],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith('SELECT * FROM approval_published_definitions')) {
+        return {
+          rows: [{
+            id: 'pub-1',
+            template_id: 'tpl-1',
+            template_version_id: 'ver-1',
+            runtime_graph: autoApprovedGraph,
+            is_active: true,
+            published_at: new Date(),
+          }],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith(`SELECT 'AP-' || nextval('approval_request_no_seq')::text AS request_no`)) {
+        return { rows: [{ request_no: 'AP-100999' }], rowCount: 1 }
+      }
+      if (statement.startsWith('SELECT * FROM approval_instances WHERE id = $1')) {
+        return { rows: [buildInstanceRow({ status: 'approved', current_node_key: null })], rowCount: 1 }
+      }
+      if (statement.startsWith('SELECT * FROM approval_assignments WHERE instance_id = $1')) {
+        return { rows: [], rowCount: 0 }
+      }
+      throw new Error(`Unhandled pool query: ${statement}`)
+    })
+
+    pgState.client.query.mockImplementation(async (sql: string) => {
+      const statement = normalize(sql)
+      if (statement === 'BEGIN' || statement === 'COMMIT') {
+        return { rows: [], rowCount: 0 }
+      }
+      if (statement.startsWith('INSERT INTO approval_instances')) {
+        return { rows: [], rowCount: 1 }
+      }
+      if (statement.startsWith('INSERT INTO approval_assignments')) {
+        return { rows: [], rowCount: 0 }
+      }
+      if (statement.startsWith('INSERT INTO approval_records')) {
+        return { rows: [], rowCount: 1 }
+      }
+      throw new Error(`Unhandled client query: ${statement}`)
+    })
+
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const service = new ApprovalProductService(metrics as never)
+
+    await service.createApproval(
+      { templateId: 'tpl-1', formData: {} },
+      { userId: 'user-1', tenantId: 'tenant-a' },
+    )
+
+    await vi.waitFor(() => {
+      expect(metrics.recordInstanceStart).toHaveBeenCalledWith(expect.objectContaining({
+        templateId: 'tpl-1',
+        tenantId: 'tenant-a',
+        slaHours: 4,
+        initialNodeKey: null,
+      }))
+      expect(metrics.recordTerminal).toHaveBeenCalledWith(expect.objectContaining({
+        terminalState: 'approved',
+      }))
+    })
+  })
 })

--- a/packages/core-backend/tests/unit/approval-sla-scheduler.test.ts
+++ b/packages/core-backend/tests/unit/approval-sla-scheduler.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ApprovalSlaScheduler } from '../../src/services/ApprovalSlaScheduler'
+
+describe('ApprovalSlaScheduler', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('invokes checkSlaBreaches and the onBreach hook with breached ids', async () => {
+    const checkSlaBreaches = vi.fn<(now: Date) => Promise<string[]>>().mockResolvedValue(['apr-1', 'apr-2'])
+    const onBreach = vi.fn().mockResolvedValue(undefined)
+
+    const scheduler = new ApprovalSlaScheduler({
+      // biome-ignore lint/suspicious/noExplicitAny: test double
+      metrics: { checkSlaBreaches } as any,
+      intervalMs: 60_000,
+      onBreach,
+    })
+
+    const breached = await scheduler.tick(new Date('2026-04-25T10:00:00Z'))
+
+    expect(breached).toEqual(['apr-1', 'apr-2'])
+    expect(checkSlaBreaches).toHaveBeenCalledTimes(1)
+    expect(onBreach).toHaveBeenCalledWith(['apr-1', 'apr-2'])
+  })
+
+  it('swallows checkSlaBreaches errors and returns an empty list', async () => {
+    const checkSlaBreaches = vi.fn().mockRejectedValue(new Error('db down'))
+    const scheduler = new ApprovalSlaScheduler({
+      // biome-ignore lint/suspicious/noExplicitAny: test double
+      metrics: { checkSlaBreaches } as any,
+    })
+    const breached = await scheduler.tick()
+    expect(breached).toEqual([])
+  })
+
+  it('prevents reentrant ticks from overlapping', async () => {
+    let resolveFirst: ((v: string[]) => void) | null = null
+    const checkSlaBreaches = vi.fn()
+      .mockImplementationOnce(() => new Promise<string[]>((resolve) => { resolveFirst = resolve }))
+      .mockResolvedValue([])
+
+    const scheduler = new ApprovalSlaScheduler({
+      // biome-ignore lint/suspicious/noExplicitAny: test double
+      metrics: { checkSlaBreaches } as any,
+    })
+
+    const firstPromise = scheduler.tick()
+    const secondResult = await scheduler.tick()
+    expect(secondResult).toEqual([])
+    expect(checkSlaBreaches).toHaveBeenCalledTimes(1)
+
+    resolveFirst?.([])
+    await firstPromise
+  })
+})


### PR DESCRIPTION
## Summary
- Add approval metrics storage, SLA threshold support, scheduler, admin routes, and frontend dashboard.
- Persist `slaHours`, preserve tenant scope, handle initially auto-approved approvals, and transaction-wrap `node_breakdown` updates.
- Expose `slaCandidateCount` end-to-end and use interval-safe SLA breach SQL.

## Verification
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-metrics-service.test.ts tests/unit/approval-product-service.test.ts tests/unit/approval-sla-scheduler.test.ts --reporter=verbose` → 24/24 passed
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit` → exit 0
- `pnpm --filter @metasheet/web exec vue-tsc -b --noEmit` → exit 0

## Rebase Note
Rebased onto `main@b1da68fcf73b773e4104e0af2d985d58dfb580d2` after #1156 and #1157 merged. Rebase was conflict-free; verification MD includes the post-rebase command rerun.