### PR TITLE
feat(observability): enrich correlation context after auth

### DIFF
--- a/docs/development/correlation-post-auth-enrichment-development-20260425.md
+++ b/docs/development/correlation-post-auth-enrichment-development-20260425.md
@@ -1,0 +1,38 @@
+# Correlation Post-Auth Enrichment Development - 2026-04-25
+
+## Context
+
+The correlation middleware already created an AsyncLocalStorage request context before auth. That guaranteed every request had a `correlationId`, but logs emitted after JWT authentication still could not include `userId` or `tenantId` because the request context was immutable from the middleware's point of view.
+
+This slice adds a post-auth enrichment seam so existing request-scoped logging can carry actor and tenant identity without changing route handlers.
+
+## Changes
+
+- Added `enrichRequestContext()` in `packages/core-backend/src/context/request-context.ts`.
+- Added `correlationContextEnrichmentMiddleware()` in `packages/core-backend/src/middleware/correlation.ts`.
+- Registered the enrichment middleware immediately after the global JWT middleware in `packages/core-backend/src/index.ts`.
+- Updated `packages/core-backend/src/core/logger.ts` to include `user_id` and `tenant_id` when present in the active request context.
+- Expanded `packages/core-backend/tests/unit/correlation.test.ts` to cover direct enrichment and the Express middleware ordering.
+
+## Design Notes
+
+- The enrichment function mutates only the active AsyncLocalStorage store. It returns `undefined` when called outside a request context.
+- Empty strings are ignored, and string values are trimmed before being stored.
+- User id resolution accepts `req.user.id`, `req.user.userId`, or `req.user.sub`; numeric finite ids are stringified.
+- Tenant id resolution accepts `req.tenantId`, `req.tenant?.id`, `req.user.tenantId`, or `req.user.tenant_id`.
+- The middleware is additive and optional: if auth is disabled or the auth middleware does not populate user data, correlation-only logging remains unchanged.
+
+## Explicit Non-Goals
+
+- No change to JWT verification semantics.
+- No route-level logging changes.
+- No persistence or response schema changes.
+- No attempt to infer tenant from arbitrary headers.
+
+## Files
+
+- `packages/core-backend/src/context/request-context.ts`
+- `packages/core-backend/src/core/logger.ts`
+- `packages/core-backend/src/index.ts`
+- `packages/core-backend/src/middleware/correlation.ts`
+- `packages/core-backend/tests/unit/correlation.test.ts`

--- a/docs/development/correlation-post-auth-enrichment-verification-20260425.md
+++ b/docs/development/correlation-post-auth-enrichment-verification-20260425.md
@@ -1,0 +1,25 @@
+# Correlation Post-Auth Enrichment Verification - 2026-04-25
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/correlation.test.ts --reporter=verbose
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+```
+
+## Results
+
+- `tests/unit/correlation.test.ts`: 16/16 passed.
+- Backend TypeScript check: passed with exit code 0.
+
+## Covered Scenarios
+
+- Active request context can be enriched with trimmed `userId` and `tenantId`.
+- Calling enrichment outside AsyncLocalStorage returns `undefined`.
+- Express middleware order works as intended: correlation context is created first, auth-like middleware attaches request identity, post-auth enrichment makes identity visible to route code through `getRequestContext()`.
+- Existing correlation id behavior remains covered by the pre-existing correlation tests.
+
+## Not Run
+
+- Full backend test suite. This slice is isolated to correlation context and logger metadata; the focused test plus backend typecheck were used as the gate.
+- Runtime log sink verification. Logger metadata shape is covered by TypeScript and existing logger context wiring, but no external collector was started.

--- a/packages/core-backend/src/context/request-context.ts
+++ b/packages/core-backend/src/context/request-context.ts
@@ -24,6 +24,18 @@ export function getRequestContext(): RequestContext | undefined {
   return storage.getStore()
 }
 
+export function enrichRequestContext(patch: Partial<Omit<RequestContext, 'correlationId'>>): RequestContext | undefined {
+  const current = storage.getStore()
+  if (!current) return undefined
+  if (typeof patch.userId === 'string' && patch.userId.trim().length > 0) {
+    current.userId = patch.userId.trim()
+  }
+  if (typeof patch.tenantId === 'string' && patch.tenantId.trim().length > 0) {
+    current.tenantId = patch.tenantId.trim()
+  }
+  return current
+}
+
 export function getCorrelationId(): string | undefined {
   return storage.getStore()?.correlationId
 }

--- a/packages/core-backend/src/core/logger.ts
+++ b/packages/core-backend/src/core/logger.ts
@@ -5,7 +5,7 @@
 import { AsyncLocalStorage } from 'async_hooks'
 import winston from 'winston'
 
-import { getCorrelationId } from '../context/request-context'
+import { getRequestContext } from '../context/request-context'
 
 type LogContext = {
   traceId?: string
@@ -43,7 +43,8 @@ function currentTraceIds(): LogContext {
 function mergeMeta(meta?: Record<string, unknown>): Record<string, unknown> | undefined {
   const store = contextStore.getStore()
   const traceMeta = currentTraceIds()
-  const correlationId = getCorrelationId()
+  const requestContext = getRequestContext()
+  const correlationId = requestContext?.correlationId
   const merged: Record<string, unknown> = {
     ...meta,
     ...traceMeta,
@@ -53,6 +54,12 @@ function mergeMeta(meta?: Record<string, unknown>): Record<string, unknown> | un
   }
   if (correlationId) {
     merged.correlation_id = correlationId
+  }
+  if (requestContext?.userId) {
+    merged.user_id = requestContext.userId
+  }
+  if (requestContext?.tenantId) {
+    merged.tenant_id = requestContext.tenantId
   }
   // Strip keys whose value is undefined so downstream formatters don't emit them.
   for (const key of Object.keys(merged)) {

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -71,7 +71,11 @@ import { startMultitableAttachmentCleanup } from './multitable/attachment-orphan
 import { AutomationService, setAutomationServiceInstance } from './multitable/automation-service'
 import { tenantContext } from './db/sharding/tenant-context'
 import { attendanceAuditMiddleware, attendanceSecurityMiddleware } from './middleware/attendance-production'
-import { correlationErrorHandler, correlationIdMiddleware } from './middleware/correlation'
+import {
+  correlationContextEnrichmentMiddleware,
+  correlationErrorHandler,
+  correlationIdMiddleware,
+} from './middleware/correlation'
 import { approvalsRouter } from './routes/approvals'
 import { authRouter } from './routes/auth'
 import { auditLogsRouter } from './routes/audit-logs'
@@ -882,6 +886,10 @@ export class MetaSheetServer {
       if (req.path.startsWith('/api/')) return jwtAuthMiddleware(req, res, next)
       return next()
     })
+
+    // Post-auth enrichment: correlation ALS starts before auth so preflights
+    // are covered; once auth runs, attach user/tenant for downstream logs.
+    this.app.use(correlationContextEnrichmentMiddleware)
 
     this.app.use((req: Request, _res: Response, next: NextFunction) => {
       const tenantId = typeof req.user?.tenantId === 'string' && req.user.tenantId.trim().length > 0

--- a/packages/core-backend/src/middleware/correlation.ts
+++ b/packages/core-backend/src/middleware/correlation.ts
@@ -10,7 +10,7 @@
 import crypto from 'crypto'
 import type { NextFunction, Request, Response } from 'express'
 
-import { getCorrelationId, runWithRequestContext } from '../context/request-context'
+import { enrichRequestContext, getCorrelationId, runWithRequestContext } from '../context/request-context'
 
 const CORRELATION_HEADER = 'x-correlation-id'
 const CORRELATION_PATTERN = /^[A-Za-z0-9_-]{1,128}$/
@@ -38,12 +38,59 @@ export function correlationIdMiddleware(req: Request, res: Response, next: NextF
 
   // NOTE: this middleware intentionally runs before auth so CORS preflights
   // and whitelisted routes still get a correlation id. `userId` / `tenantId`
-  // on the context are populated later by a post-auth enrichment step
-  // (follow-up); attempting to read `req.user` here is always undefined.
+  // are populated later by `correlationContextEnrichmentMiddleware`, after
+  // authentication has attached `req.user`.
   runWithRequestContext({ correlationId }, () => next())
 }
 
 export const CORRELATION_ID_HEADER = 'X-Correlation-ID'
+
+function resolveRequestUserId(req: Request): string | undefined {
+  const candidates = [req.user?.id, req.user?.userId, req.user?.sub]
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.trim().length > 0) {
+      return candidate.trim()
+    }
+    if (typeof candidate === 'number' && Number.isFinite(candidate)) {
+      return String(candidate)
+    }
+  }
+  return undefined
+}
+
+function resolveRequestTenantId(req: Request): string | undefined {
+  const requestWithTenant = req as Request & {
+    tenantId?: unknown
+    tenant?: { id?: unknown } | null
+  }
+  const candidates = [
+    requestWithTenant.tenantId,
+    requestWithTenant.tenant?.id,
+    req.user?.tenantId,
+    req.user?.tenant_id,
+  ]
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.trim().length > 0) {
+      return candidate.trim()
+    }
+    if (typeof candidate === 'number' && Number.isFinite(candidate)) {
+      return String(candidate)
+    }
+  }
+  return undefined
+}
+
+export function correlationContextEnrichmentMiddleware(
+  req: Request,
+  _res: Response,
+  next: NextFunction,
+): void {
+  enrichRequestContext({
+    userId: resolveRequestUserId(req),
+    tenantId: resolveRequestTenantId(req),
+  })
+  next()
+}
 
 export type CorrelationErrorLogger = {
   error(message: string, error: Error): void

--- a/packages/core-backend/tests/unit/correlation.test.ts
+++ b/packages/core-backend/tests/unit/correlation.test.ts
@@ -3,8 +3,14 @@ import cors from 'cors'
 import request from 'supertest'
 import { describe, expect, it, vi } from 'vitest'
 
-import { getCorrelationId, getRequestContext, runWithRequestContext } from '../../src/context/request-context'
 import {
+  enrichRequestContext,
+  getCorrelationId,
+  getRequestContext,
+  runWithRequestContext,
+} from '../../src/context/request-context'
+import {
+  correlationContextEnrichmentMiddleware,
   correlationErrorHandler,
   correlationIdMiddleware,
   isValidCorrelationId,
@@ -55,6 +61,22 @@ describe('request-context AsyncLocalStorage', () => {
   it('exposes the correlation id inside a run() scope', () => {
     const id = runWithRequestContext({ correlationId: 'scope-id' }, () => getCorrelationId())
     expect(id).toBe('scope-id')
+  })
+
+  it('enriches the active context with authenticated user and tenant ids', () => {
+    const ctx = runWithRequestContext({ correlationId: 'scope-id' }, () => {
+      enrichRequestContext({ userId: ' user-1 ', tenantId: ' tenant-a ' })
+      return getRequestContext()
+    })
+    expect(ctx).toEqual({
+      correlationId: 'scope-id',
+      userId: 'user-1',
+      tenantId: 'tenant-a',
+    })
+  })
+
+  it('returns undefined when enrichment runs outside a context', () => {
+    expect(enrichRequestContext({ userId: 'user-1' })).toBeUndefined()
   })
 })
 
@@ -119,6 +141,28 @@ describe('correlationIdMiddleware (express integration)', () => {
       .set('Origin', 'https://example.test')
 
     expect(res.headers['access-control-expose-headers']).toContain('X-Correlation-ID')
+  })
+
+  it('enriches context after auth has populated req.user', async () => {
+    const app = express()
+    app.use(correlationIdMiddleware)
+    app.use((req, _res, next) => {
+      req.user = {
+        id: 'user-1',
+        tenantId: 'tenant-a',
+      } as Express.Request['user']
+      next()
+    })
+    app.use(correlationContextEnrichmentMiddleware)
+    app.get('/probe', (_req, res) => res.json({ context: getRequestContext() }))
+
+    const res = await request(app).get('/probe').set('X-Correlation-ID', 'trace-1')
+
+    expect(res.body.context).toEqual({
+      correlationId: 'trace-1',
+      userId: 'user-1',
+      tenantId: 'tenant-a',
+    })
   })
 })
 


### PR DESCRIPTION
## Summary
- Add post-auth correlation context enrichment for userId and tenantId.
- Register enrichment after JWT middleware so request-scoped logs include actor and tenant metadata.
- Extend correlation tests and document development/verification notes.

## Verification
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/correlation.test.ts --reporter=dot
- pnpm --filter @metasheet/core-backend exec tsc --noEmit

## Docs
- docs/development/correlation-post-auth-enrichment-development-20260425.md
- docs/development/correlation-post-auth-enrichment-verification-20260425.md