### PR TITLE
feat(approval): add SLA scheduler leader lock

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,10 @@ REDIS_URL=redis://localhost:6379
 # REDIS_PASSWORD=your-redis-password
 # REDIS_TLS=false
 
+# Approval SLA scheduler leader lock (optional, multi-replica deployments)
+# ENABLE_APPROVAL_SLA_LEADER_LOCK=true
+# APPROVAL_SLA_LEADER_LOCK_TTL_MS=30000
+
 # =============================================================================
 # OBSERVABILITY - Phase 5
 # =============================================================================

--- a/docs/development/approval-sla-leader-lock-development-20260425.md
+++ b/docs/development/approval-sla-leader-lock-development-20260425.md
@@ -1,0 +1,48 @@
+# Approval SLA Leader Lock Development - 2026-04-25
+
+## Context
+
+The approval SLA scheduler introduced periodic breach scanning, but every API replica could run the scan. The SQL path is idempotent, yet duplicate scans still add avoidable database pressure and make operational attribution noisy.
+
+This slice adds an opt-in Redis-backed leader lock for the SLA scheduler while keeping legacy single-process behavior as the default.
+
+## Changes
+
+- Extended `ApprovalSlaScheduler` with optional `leaderOptions`.
+- Added Redis lock acquisition, renewal, and release around scheduler startup/shutdown.
+- Added a `leader` getter and a follower guard so non-leaders return without scanning.
+- Added `resolveApprovalSlaSchedulerLeaderOptions()` to construct the Redis-backed lock from environment flags.
+- Wired `MetaSheetServer.start()` to pass resolved leader options into `startApprovalSlaScheduler()`.
+- Documented environment flags in `.env.example` and `packages/core-backend/.env.development.example`.
+- Added unit coverage for leader/follower behavior and lock release takeover.
+
+## Configuration
+
+```bash
+ENABLE_APPROVAL_SLA_LEADER_LOCK=true
+APPROVAL_SLA_LEADER_LOCK_TTL_MS=30000
+```
+
+The feature remains disabled unless `ENABLE_APPROVAL_SLA_LEADER_LOCK=true`.
+
+## Design Notes
+
+- Default behavior is unchanged. Without `leaderOptions`, the scheduler acts as leader immediately.
+- When the flag is enabled but Redis is unavailable, `resolveApprovalSlaSchedulerLeaderOptions()` returns `null`, preserving legacy behavior rather than blocking startup.
+- The lock owner is process-scoped: `approval-sla:<pid>:<random>`.
+- Renewal runs at half of the TTL with a minimum interval of 1000 ms.
+- If renewal fails, the scheduler relinquishes leadership and stops further scans.
+
+## Explicit Limitations
+
+- Follower processes do not currently run a background takeover loop after a failed initial election. A restart or future retry enhancement is needed for automatic follower promotion.
+- Redis outage with the flag enabled degrades to legacy all-replica scheduling instead of fail-closed single-leader mode.
+- No Prometheus leader gauge was added in this slice.
+
+## Files
+
+- `.env.example`
+- `packages/core-backend/.env.development.example`
+- `packages/core-backend/src/index.ts`
+- `packages/core-backend/src/services/ApprovalSlaScheduler.ts`
+- `packages/core-backend/tests/unit/approval-sla-scheduler.test.ts`

--- a/docs/development/approval-sla-leader-lock-verification-20260425.md
+++ b/docs/development/approval-sla-leader-lock-verification-20260425.md
@@ -1,0 +1,26 @@
+# Approval SLA Leader Lock Verification - 2026-04-25
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-sla-scheduler.test.ts tests/unit/redis-leader-lock.test.ts --reporter=verbose
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+```
+
+## Results
+
+- `tests/unit/approval-sla-scheduler.test.ts` + `tests/unit/redis-leader-lock.test.ts`: 21/21 passed.
+- Backend TypeScript check: passed with exit code 0.
+
+## Covered Scenarios
+
+- Legacy scheduler behavior still works without leader options.
+- A leader can scan and produce SLA breach work.
+- A follower skips scans and does not call the metrics service.
+- `stop()` releases the lock so a replacement scheduler can acquire leadership.
+- Existing `RedisLeaderLock` behavior remains covered by its focused unit tests.
+
+## Not Run
+
+- Live Redis integration. The slice reuses the existing Redis leader-lock adapter and validates scheduler integration with the in-memory lock client.
+- Multi-process runtime smoke. The unit tests cover the critical election and release semantics without starting multiple Node processes.

--- a/packages/core-backend/.env.development.example
+++ b/packages/core-backend/.env.development.example
@@ -2,5 +2,9 @@ NODE_ENV=development
 PORT=3000
 DATABASE_URL=postgresql://metasheet:YOUR_PASSWORD@localhost:5432/metasheet_v2
 REDIS_URL=redis://localhost:6379
+
+# Optional: only one replica runs approval SLA scans when enabled.
+# ENABLE_APPROVAL_SLA_LEADER_LOCK=true
+# APPROVAL_SLA_LEADER_LOCK_TTL_MS=30000
 JWT_SECRET=your-dev-secret-key-here
 CORS_ORIGIN=http://localhost:8899

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -81,7 +81,11 @@ import { authRouter } from './routes/auth'
 import { auditLogsRouter } from './routes/audit-logs'
 import { approvalHistoryRouter } from './routes/approval-history'
 import { approvalMetricsRouter } from './routes/approval-metrics'
-import { startApprovalSlaScheduler, stopApprovalSlaScheduler } from './services/ApprovalSlaScheduler'
+import {
+  resolveApprovalSlaSchedulerLeaderOptions,
+  startApprovalSlaScheduler,
+  stopApprovalSlaScheduler,
+} from './services/ApprovalSlaScheduler'
 import { rolesRouter } from './routes/roles'
 import { snapshotsRouter } from './routes/snapshots'
 import changeManagementRouter from './routes/change-management'
@@ -1899,7 +1903,8 @@ export class MetaSheetServer {
     }
 
     try {
-      startApprovalSlaScheduler()
+      const leaderOptions = await resolveApprovalSlaSchedulerLeaderOptions()
+      startApprovalSlaScheduler({ leaderOptions })
       this.logger.info('Approval SLA scheduler initialized')
     } catch (e) {
       this.logger.error('Approval SLA scheduler initialization failed; continuing in degraded mode', e as Error)

--- a/packages/core-backend/src/services/ApprovalSlaScheduler.ts
+++ b/packages/core-backend/src/services/ApprovalSlaScheduler.ts
@@ -3,21 +3,24 @@
  *
  * Runs a periodic (default 15 min) scan that flips `sla_breached = TRUE`
  * on approval_metrics rows whose `started_at + sla_hours` have elapsed.
- * Single-process interval with a one-run guard — multi-instance fleets
- * should either disable the scheduler on all but one pod (env
- * APPROVAL_SLA_SCHEDULER_DISABLED=1) or wrap this in leader election at
- * a future point.
+ * Single-process interval with a one-run guard. Multi-instance fleets can
+ * opt into a Redis leader lock via ENABLE_APPROVAL_SLA_LEADER_LOCK=true.
  */
 
+import { randomBytes } from 'crypto'
 import { Logger } from '../core/logger'
+import { getRedisClient } from '../db/redis'
+import { RedisLeaderLock, type RedisLeaderLockClient } from '../multitable/redis-leader-lock'
 import { getApprovalMetricsService, type ApprovalMetricsService } from './ApprovalMetricsService'
 
 const DEFAULT_INTERVAL_MS = 15 * 60 * 1000
 const MIN_INTERVAL_MS = 5000
+const DEFAULT_LOCK_TTL_MS = 30_000
 
 export interface ApprovalSlaSchedulerOptions {
   metrics?: ApprovalMetricsService
   intervalMs?: number
+  leaderOptions?: ApprovalSlaSchedulerLeaderOptions | null
   /**
    * Optional hook invoked once per breach cycle with the newly-breached
    * instance ids. Main caller wires it to approval audit + notifications.
@@ -26,36 +29,83 @@ export interface ApprovalSlaSchedulerOptions {
   logger?: Logger
 }
 
+export interface ApprovalSlaSchedulerLeaderOptions {
+  leaderLock: RedisLeaderLock
+  lockKey?: string
+  ownerId: string
+  ttlMs?: number
+  renewIntervalMs?: number
+}
+
 export class ApprovalSlaScheduler {
   private readonly logger: Logger
   private readonly metrics: ApprovalMetricsService
   private readonly intervalMs: number
+  private readonly leaderOptions: ApprovalSlaSchedulerLeaderOptions | null
+  private readonly lockKey: string
+  private readonly ttlMs: number
+  private readonly renewIntervalMs: number
   private readonly onBreach: ApprovalSlaSchedulerOptions['onBreach']
   private timer: NodeJS.Timeout | null = null
+  private renewalTimer: NodeJS.Timeout | null = null
   private running = false
+  private started = false
+  private isLeader = false
+  public readonly ready: Promise<void>
 
   constructor(options: ApprovalSlaSchedulerOptions = {}) {
     this.metrics = options.metrics ?? getApprovalMetricsService()
     this.intervalMs = Math.max(MIN_INTERVAL_MS, options.intervalMs ?? DEFAULT_INTERVAL_MS)
+    this.leaderOptions = options.leaderOptions ?? null
+    this.lockKey = this.leaderOptions?.lockKey ?? 'approval-sla-scheduler:leader'
+    this.ttlMs = this.leaderOptions?.ttlMs ?? DEFAULT_LOCK_TTL_MS
+    this.renewIntervalMs = this.leaderOptions?.renewIntervalMs ?? Math.max(1_000, Math.floor(this.ttlMs / 3))
     this.onBreach = options.onBreach
     this.logger = options.logger ?? new Logger('ApprovalSlaScheduler')
+    if (this.leaderOptions) {
+      this.ready = this.attemptLeadership().catch((error) => {
+        this.isLeader = false
+        this.logger.warn(`SLA leader-lock acquisition failed: ${error instanceof Error ? error.message : String(error)}`)
+      })
+    } else {
+      this.isLeader = true
+      this.ready = Promise.resolve()
+    }
   }
 
   start(): void {
-    if (this.timer) return
-    this.logger.info(`SLA scheduler starting with interval ${this.intervalMs}ms`)
-    this.timer = setInterval(() => { void this.tick() }, this.intervalMs)
-    if (typeof this.timer.unref === 'function') this.timer.unref()
+    if (this.started) return
+    this.started = true
+    this.ready.then(() => {
+      if (!this.started || !this.isLeader || this.timer) return
+      this.logger.info(`SLA scheduler starting with interval ${this.intervalMs}ms`)
+      this.timer = setInterval(() => { void this.tick() }, this.intervalMs)
+      if (typeof this.timer.unref === 'function') this.timer.unref()
+    }).catch((error) => {
+      this.logger.warn(`SLA scheduler start skipped after leader-lock error: ${error instanceof Error ? error.message : String(error)}`)
+    })
   }
 
   stop(): void {
-    if (!this.timer) return
-    clearInterval(this.timer)
-    this.timer = null
+    this.started = false
+    if (this.timer) {
+      clearInterval(this.timer)
+      this.timer = null
+    }
+    if (this.renewalTimer) {
+      clearInterval(this.renewalTimer)
+      this.renewalTimer = null
+    }
+    if (this.leaderOptions && this.isLeader) {
+      const { leaderLock, ownerId } = this.leaderOptions
+      leaderLock.release(this.lockKey, ownerId).catch(() => {})
+      this.isLeader = false
+    }
     this.logger.info('SLA scheduler stopped')
   }
 
   async tick(now: Date = new Date()): Promise<string[]> {
+    if (!this.isLeader) return []
     if (this.running) return []
     this.running = true
     try {
@@ -78,6 +128,55 @@ export class ApprovalSlaScheduler {
       this.running = false
     }
   }
+
+  get leader(): boolean {
+    return this.isLeader
+  }
+
+  private async attemptLeadership(): Promise<void> {
+    if (!this.leaderOptions) return
+    const { leaderLock, ownerId } = this.leaderOptions
+    const won = await leaderLock.acquire(this.lockKey, ownerId, this.ttlMs)
+    this.isLeader = won
+    if (won) {
+      this.logger.info(`Acquired SLA scheduler leader lock ${this.lockKey} (owner=${ownerId}, ttl=${this.ttlMs}ms)`)
+      this.startRenewalLoop()
+    } else {
+      this.logger.info(`Did not acquire SLA scheduler leader lock ${this.lockKey}; operating as non-leader (owner=${ownerId})`)
+    }
+  }
+
+  private startRenewalLoop(): void {
+    if (!this.leaderOptions) return
+    if (this.renewalTimer) clearInterval(this.renewalTimer)
+    const { leaderLock, ownerId } = this.leaderOptions
+    this.renewalTimer = setInterval(() => {
+      leaderLock.renew(this.lockKey, ownerId, this.ttlMs).then(
+        (ok) => {
+          if (!ok) this.relinquishLeadership('renewal rejected')
+        },
+        (error) => {
+          this.logger.warn(`SLA leader renewal error for ${this.lockKey}: ${error instanceof Error ? error.message : String(error)}`)
+          this.relinquishLeadership('renewal error')
+        },
+      )
+    }, this.renewIntervalMs)
+    if (typeof this.renewalTimer.unref === 'function') this.renewalTimer.unref()
+  }
+
+  private relinquishLeadership(reason: string): void {
+    if (!this.isLeader) return
+    this.logger.warn(`Relinquishing SLA scheduler leadership (${reason})`)
+    this.isLeader = false
+    if (this.timer) {
+      clearInterval(this.timer)
+      this.timer = null
+    }
+    if (this.renewalTimer) {
+      clearInterval(this.renewalTimer)
+      this.renewalTimer = null
+    }
+  }
 }
 
 let sharedScheduler: ApprovalSlaScheduler | null = null
@@ -94,5 +193,19 @@ export function stopApprovalSlaScheduler(): void {
   if (sharedScheduler) {
     sharedScheduler.stop()
     sharedScheduler = null
+  }
+}
+
+export async function resolveApprovalSlaSchedulerLeaderOptions(): Promise<ApprovalSlaSchedulerLeaderOptions | null> {
+  if (process.env.ENABLE_APPROVAL_SLA_LEADER_LOCK !== 'true') return null
+  const redis = await getRedisClient()
+  if (!redis) return null
+  const ttlMs = Number(process.env.APPROVAL_SLA_LEADER_LOCK_TTL_MS) > 0
+    ? Number(process.env.APPROVAL_SLA_LEADER_LOCK_TTL_MS)
+    : DEFAULT_LOCK_TTL_MS
+  return {
+    leaderLock: new RedisLeaderLock({ client: redis as unknown as RedisLeaderLockClient }),
+    ownerId: `approval-sla:${process.pid}:${randomBytes(4).toString('hex')}`,
+    ttlMs,
   }
 }

--- a/packages/core-backend/tests/unit/approval-sla-scheduler.test.ts
+++ b/packages/core-backend/tests/unit/approval-sla-scheduler.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ApprovalSlaScheduler } from '../../src/services/ApprovalSlaScheduler'
+import { MemoryLeaderLockClient, RedisLeaderLock } from '../../src/multitable/redis-leader-lock'
 
 describe('ApprovalSlaScheduler', () => {
   beforeEach(() => {
@@ -55,5 +56,59 @@ describe('ApprovalSlaScheduler', () => {
 
     resolveFirst?.([])
     await firstPromise
+  })
+
+  it('runs ticks only on the process that acquired the leader lock', async () => {
+    const store = new Map()
+    const leaderLockA = new RedisLeaderLock({ client: new MemoryLeaderLockClient(store) })
+    const leaderLockB = new RedisLeaderLock({ client: new MemoryLeaderLockClient(store) })
+    const leaderCheck = vi.fn().mockResolvedValue(['apr-1'])
+    const followerCheck = vi.fn().mockResolvedValue(['apr-2'])
+
+    const leader = new ApprovalSlaScheduler({
+      // biome-ignore lint/suspicious/noExplicitAny: test double
+      metrics: { checkSlaBreaches: leaderCheck } as any,
+      leaderOptions: { leaderLock: leaderLockA, ownerId: 'node-a', ttlMs: 30_000 },
+    })
+    const follower = new ApprovalSlaScheduler({
+      // biome-ignore lint/suspicious/noExplicitAny: test double
+      metrics: { checkSlaBreaches: followerCheck } as any,
+      leaderOptions: { leaderLock: leaderLockB, ownerId: 'node-b', ttlMs: 30_000 },
+    })
+
+    await Promise.all([leader.ready, follower.ready])
+
+    expect(leader.leader).toBe(true)
+    expect(follower.leader).toBe(false)
+    expect(await leader.tick(new Date('2026-04-25T10:00:00Z'))).toEqual(['apr-1'])
+    expect(await follower.tick(new Date('2026-04-25T10:00:00Z'))).toEqual([])
+    expect(leaderCheck).toHaveBeenCalledTimes(1)
+    expect(followerCheck).not.toHaveBeenCalled()
+  })
+
+  it('releases the leader lock on stop so a replacement can take over', async () => {
+    const store = new Map()
+    const firstLock = new RedisLeaderLock({ client: new MemoryLeaderLockClient(store) })
+    const secondLock = new RedisLeaderLock({ client: new MemoryLeaderLockClient(store) })
+
+    const first = new ApprovalSlaScheduler({
+      // biome-ignore lint/suspicious/noExplicitAny: test double
+      metrics: { checkSlaBreaches: vi.fn().mockResolvedValue([]) } as any,
+      leaderOptions: { leaderLock: firstLock, ownerId: 'node-a', ttlMs: 30_000 },
+    })
+    await first.ready
+    expect(first.leader).toBe(true)
+
+    first.stop()
+    await Promise.resolve()
+
+    const second = new ApprovalSlaScheduler({
+      // biome-ignore lint/suspicious/noExplicitAny: test double
+      metrics: { checkSlaBreaches: vi.fn().mockResolvedValue([]) } as any,
+      leaderOptions: { leaderLock: secondLock, ownerId: 'node-b', ttlMs: 30_000 },
+    })
+    await second.ready
+    expect(second.leader).toBe(true)
+    second.stop()
   })
 })


### PR DESCRIPTION
## Summary
- Add opt-in Redis leader lock for ApprovalSlaScheduler.
- Wire server startup to resolve leader options from ENABLE_APPROVAL_SLA_LEADER_LOCK.
- Keep default legacy behavior unchanged when the flag is off.

## Verification
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-sla-scheduler.test.ts tests/unit/redis-leader-lock.test.ts --reporter=dot
- pnpm --filter @metasheet/core-backend exec tsc --noEmit

## Notes
- Followers do not yet run a background takeover loop after initial election.
- Redis unavailable with the flag enabled degrades to legacy scheduling.

## Docs
- docs/development/approval-sla-leader-lock-development-20260425.md
- docs/development/approval-sla-leader-lock-verification-20260425.md