### PR TITLE
feat(approval): add SLA metrics TopN report

### DIFF
--- a/apps/web/src/approvals/api.ts
+++ b/apps/web/src/approvals/api.ts
@@ -462,6 +462,34 @@ export interface ApprovalMetricsSummary {
   byTemplate: ApprovalMetricsSummaryTemplateRow[]
 }
 
+export interface ApprovalMetricsTopInstanceRow {
+  instanceId: string
+  templateId: string | null
+  startedAt: string
+  terminalAt: string | null
+  terminalState: 'approved' | 'rejected' | 'revoked' | 'returned' | null
+  durationSeconds: number
+  slaHours: number | null
+  slaBreached: boolean
+  slaBreachedAt: string | null
+}
+
+export interface ApprovalMetricsTopTemplateRow {
+  templateId: string | null
+  total: number
+  slaCandidateCount: number
+  slaBreachCount: number
+  slaBreachRate: number
+  avgDurationSeconds: number | null
+  p95DurationSeconds: number | null
+}
+
+export interface ApprovalMetricsReport {
+  summary: ApprovalMetricsSummary
+  slowestInstances: ApprovalMetricsTopInstanceRow[]
+  breachedTemplates: ApprovalMetricsTopTemplateRow[]
+}
+
 export interface ApprovalMetricsNodeBreakdownEntry {
   nodeKey: string
   activatedAt: string | null
@@ -516,6 +544,51 @@ export async function fetchApprovalMetricsSummary(query?: {
     `/api/approvals/metrics/summary${qs ? `?${qs}` : ''}`,
   )
   return data?.data ?? emptyMetricsSummary()
+}
+
+export async function fetchApprovalMetricsReport(query?: {
+  since?: string
+  until?: string
+  limit?: number
+}): Promise<ApprovalMetricsReport> {
+  if (USE_MOCK) {
+    return {
+      summary: await fetchApprovalMetricsSummary(query),
+      slowestInstances: [
+        {
+          instanceId: 'apr_slowest_1',
+          templateId: 'tpl_1',
+          startedAt: '2026-04-25T00:00:00Z',
+          terminalAt: '2026-04-25T06:00:00Z',
+          terminalState: 'approved',
+          durationSeconds: 21_600,
+          slaHours: 4,
+          slaBreached: true,
+          slaBreachedAt: '2026-04-25T04:05:00Z',
+        },
+      ],
+      breachedTemplates: [
+        {
+          templateId: 'tpl_2',
+          total: 12,
+          slaCandidateCount: 10,
+          slaBreachCount: 3,
+          slaBreachRate: 0.3,
+          avgDurationSeconds: 9000,
+          p95DurationSeconds: 18000,
+        },
+      ],
+    }
+  }
+  const params = new URLSearchParams()
+  if (query?.since) params.set('since', query.since)
+  if (query?.until) params.set('until', query.until)
+  if (query?.limit) params.set('limit', String(query.limit))
+  const qs = params.toString()
+  const data = await apiGet<{ ok: boolean; data: ApprovalMetricsReport }>(
+    `/api/approvals/metrics/report${qs ? `?${qs}` : ''}`,
+  )
+  return data.data
 }
 
 export async function fetchApprovalMetricsBreaches(): Promise<ApprovalMetricsRow[]> {

--- a/apps/web/src/views/approval/ApprovalMetricsView.vue
+++ b/apps/web/src/views/approval/ApprovalMetricsView.vue
@@ -11,7 +11,7 @@
           start-placeholder="开始日期"
           end-placeholder="结束日期"
           value-format="YYYY-MM-DD"
-          @change="loadSummary"
+          @change="loadAll"
         />
         <el-button type="primary" @click="loadAll" :loading="loading">
           刷新
@@ -109,6 +109,69 @@
         </el-table-column>
       </el-table>
     </el-card>
+
+    <div class="approval-metrics__topn">
+      <el-card class="approval-metrics__section">
+        <template #header>
+          <span>TopN 最慢实例</span>
+        </template>
+        <el-table :data="slowestInstances" stripe v-loading="reportLoading" empty-text="暂无已完成实例">
+          <el-table-column label="实例" min-width="220">
+            <template #default="{ row }">
+              <el-link type="primary" @click="goInstance(row.instanceId)">
+                {{ row.instanceId }}
+              </el-link>
+            </template>
+          </el-table-column>
+          <el-table-column label="模板" min-width="180">
+            <template #default="{ row }">
+              <el-link v-if="row.templateId" type="primary" @click="goTemplate(row.templateId)">
+                {{ row.templateId }}
+              </el-link>
+              <span v-else class="metric-muted">未关联模板</span>
+            </template>
+          </el-table-column>
+          <el-table-column label="耗时" width="120">
+            <template #default="{ row }">{{ formatDuration(row.durationSeconds) }}</template>
+          </el-table-column>
+          <el-table-column label="状态" width="120">
+            <template #default="{ row }">{{ row.terminalState || '-' }}</template>
+          </el-table-column>
+          <el-table-column label="完成时间" width="220">
+            <template #default="{ row }">{{ formatTimestamp(row.terminalAt) }}</template>
+          </el-table-column>
+        </el-table>
+      </el-card>
+
+      <el-card class="approval-metrics__section">
+        <template #header>
+          <span>TopN SLA 风险模板</span>
+        </template>
+        <el-table :data="breachedTemplates" stripe v-loading="reportLoading" empty-text="暂无 SLA 模板数据">
+          <el-table-column label="模板" min-width="220">
+            <template #default="{ row }">
+              <el-link v-if="row.templateId" type="primary" @click="goTemplate(row.templateId)">
+                {{ row.templateId }}
+              </el-link>
+              <span v-else class="metric-muted">未关联模板</span>
+            </template>
+          </el-table-column>
+          <el-table-column prop="total" label="总量" width="90" />
+          <el-table-column label="SLA 超时" width="120">
+            <template #default="{ row }">{{ row.slaBreachCount }} / {{ row.slaCandidateCount }}</template>
+          </el-table-column>
+          <el-table-column label="超时率" width="110">
+            <template #default="{ row }">{{ formatPercent(row.slaBreachRate) }}</template>
+          </el-table-column>
+          <el-table-column label="平均耗时" width="130">
+            <template #default="{ row }">{{ formatDuration(row.avgDurationSeconds) }}</template>
+          </el-table-column>
+          <el-table-column label="P95" width="130">
+            <template #default="{ row }">{{ formatDuration(row.p95DurationSeconds) }}</template>
+          </el-table-column>
+        </el-table>
+      </el-card>
+    </div>
   </section>
 </template>
 
@@ -117,9 +180,12 @@ import { computed, onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import {
   fetchApprovalMetricsBreaches,
+  fetchApprovalMetricsReport,
   fetchApprovalMetricsSummary,
   type ApprovalMetricsRow,
   type ApprovalMetricsSummary,
+  type ApprovalMetricsTopInstanceRow,
+  type ApprovalMetricsTopTemplateRow,
 } from '../../approvals/api'
 
 const router = useRouter()
@@ -130,9 +196,12 @@ const summary = ref<ApprovalMetricsSummary>({
   slaBreachCount: 0, slaCandidateCount: 0, slaBreachRate: 0, byTemplate: [],
 })
 const breaches = ref<ApprovalMetricsRow[]>([])
+const slowestInstances = ref<ApprovalMetricsTopInstanceRow[]>([])
+const breachedTemplates = ref<ApprovalMetricsTopTemplateRow[]>([])
 const dateRange = ref<[string, string] | null>(null)
 const loading = ref(false)
 const breachLoading = ref(false)
+const reportLoading = ref(false)
 const errorMessage = ref('')
 
 const approvalRatePercent = computed(() => {
@@ -171,8 +240,24 @@ async function loadBreaches(): Promise<void> {
   }
 }
 
+async function loadReport(): Promise<void> {
+  reportLoading.value = true
+  try {
+    const query: { since?: string; until?: string; limit?: number } = { limit: 10 }
+    if (dateRange.value && dateRange.value[0]) query.since = `${dateRange.value[0]}T00:00:00Z`
+    if (dateRange.value && dateRange.value[1]) query.until = `${dateRange.value[1]}T23:59:59Z`
+    const report = await fetchApprovalMetricsReport(query)
+    slowestInstances.value = report.slowestInstances
+    breachedTemplates.value = report.breachedTemplates
+  } catch (error) {
+    errorMessage.value = `加载 TopN 报表失败: ${error instanceof Error ? error.message : String(error)}`
+  } finally {
+    reportLoading.value = false
+  }
+}
+
 async function loadAll(): Promise<void> {
-  await Promise.all([loadSummary(), loadBreaches()])
+  await Promise.all([loadSummary(), loadBreaches(), loadReport()])
 }
 
 function formatDuration(seconds: number | null | undefined): string {
@@ -251,5 +336,10 @@ onMounted(() => { void loadAll() })
 }
 .approval-metrics__section {
   width: 100%;
+}
+.approval-metrics__topn {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+  gap: 16px;
 }
 </style>

--- a/docs/development/approval-sla-topn-report-development-20260425.md
+++ b/docs/development/approval-sla-topn-report-development-20260425.md
@@ -1,0 +1,58 @@
+# Approval SLA TopN Report Development - 2026-04-25
+
+## Context
+
+WP5 SLA metrics exposed summary and breach-list views, but operators still lacked a compact "what should I inspect first" report. This slice adds a TopN report API and frontend cards for slowest completed instances and templates with the highest SLA breach rate.
+
+## Changes
+
+- Added `ApprovalMetricsService.getMetricsReport()`.
+- Added `GET /api/approvals/metrics/report`.
+- Added frontend API types and `fetchApprovalMetricsReport()`.
+- Extended `ApprovalMetricsView.vue` with two TopN tables.
+- Added OpenAPI path documentation for the new report endpoint.
+- Added focused service tests for report query shape and DTO mapping.
+
+## API
+
+```http
+GET /api/approvals/metrics/report?since=<iso>&until=<iso>&limit=10
+```
+
+Access guard:
+
+- `authenticate`
+- `rbacGuard('approvals:admin')`
+
+Response shape:
+
+- `summary`: existing SLA metrics summary DTO.
+- `slowestInstances`: completed instances ordered by `durationSeconds` descending.
+- `breachedTemplates`: grouped template rows ordered by breach rate, breach count, and total candidates.
+
+## Design Notes
+
+- `limit` is clamped to `1..50`; default is `10`.
+- The report reuses `getMetricsSummary()` so the summary numbers stay aligned with the existing dashboard cards.
+- Slowest instances only include rows with non-null `duration_seconds`.
+- Template breach rate is computed from SLA candidate rows only and excludes rows without SLA information.
+- Frontend loading is intentionally additive: summary, breach list, and report are fetched together through `loadAll()`.
+
+## Explicit Non-Goals
+
+- No pagination for the TopN report.
+- No CSV export.
+- No route-level integration test in this slice.
+- No new database indexes. Current query shape is bounded by tenant/date filters and TopN limits; indexing can be added after staging metrics show pressure.
+
+## Files
+
+- `packages/core-backend/src/services/ApprovalMetricsService.ts`
+- `packages/core-backend/src/routes/approval-metrics.ts`
+- `packages/core-backend/tests/unit/approval-metrics-service.test.ts`
+- `apps/web/src/approvals/api.ts`
+- `apps/web/src/views/approval/ApprovalMetricsView.vue`
+- `packages/openapi/src/paths/approvals.yml`
+- `packages/openapi/dist/combined.openapi.yml`
+- `packages/openapi/dist/openapi.json`
+- `packages/openapi/dist/openapi.yaml`

--- a/docs/development/approval-sla-topn-report-verification-20260425.md
+++ b/docs/development/approval-sla-topn-report-verification-20260425.md
@@ -1,0 +1,31 @@
+# Approval SLA TopN Report Verification - 2026-04-25
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-metrics-service.test.ts --reporter=verbose
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+pnpm exec tsx packages/openapi/tools/build.ts
+```
+
+## Results
+
+- `tests/unit/approval-metrics-service.test.ts`: 15/15 passed.
+- Backend TypeScript check: passed with exit code 0.
+- Frontend Vue TypeScript check: passed with exit code 0.
+- OpenAPI build: passed and regenerated `packages/openapi/dist/*`.
+
+## Covered Scenarios
+
+- `getMetricsReport()` reuses summary retrieval and maps slowest-instance rows to camelCase DTOs.
+- Limit values are clamped to the service maximum.
+- SQL generation includes duration ordering for slowest instances.
+- SQL generation includes grouped template breach-rate ordering.
+- Frontend typecheck covers new API DTOs and `ApprovalMetricsView.vue` bindings.
+- OpenAPI build validates the new report path can be merged into the generated OpenAPI artifacts.
+
+## Not Run
+
+- Route-level supertest for `/api/approvals/metrics/report`. The route is thin and delegates to the tested service; adding route coverage is a reasonable follow-up if approval metrics route tests are introduced.
+- Browser screenshot/manual dashboard verification. This needs a running staging build with approval SLA sample data.

--- a/packages/core-backend/src/routes/approval-metrics.ts
+++ b/packages/core-backend/src/routes/approval-metrics.ts
@@ -47,6 +47,11 @@ function parseDate(value: unknown): Date | undefined {
   return Number.isFinite(parsed.getTime()) ? parsed : undefined
 }
 
+function parseLimit(value: unknown): number {
+  const parsed = Number.parseInt(String(value ?? '10'), 10)
+  return Math.max(1, Math.min(Number.isFinite(parsed) ? parsed : 10, 50))
+}
+
 export interface ApprovalMetricsRouterOptions {
   metricsService?: ApprovalMetricsServiceType
 }
@@ -69,6 +74,25 @@ export function approvalMetricsRouter(options?: ApprovalMetricsRouterOptions): R
       } catch (error) {
         logger.error(`metrics summary failed: ${error instanceof Error ? error.message : String(error)}`)
         return res.status(500).json({ ok: false, error: { code: 'METRICS_SUMMARY_FAILED', message: 'Failed to load approval metrics summary' } })
+      }
+    },
+  )
+
+  r.get('/api/approvals/metrics/report',
+    authenticate,
+    rbacGuard('approvals:admin'),
+    async (req: Request, res: Response) => {
+      try {
+        const report = await metricsService.getMetricsReport({
+          tenantId: resolveTenantId(req),
+          since: parseDate(req.query.since),
+          until: parseDate(req.query.until),
+          limit: parseLimit(req.query.limit),
+        })
+        return res.json({ ok: true, data: report })
+      } catch (error) {
+        logger.error(`metrics report failed: ${error instanceof Error ? error.message : String(error)}`)
+        return res.status(500).json({ ok: false, error: { code: 'METRICS_REPORT_FAILED', message: 'Failed to load approval metrics report' } })
       }
     },
   )

--- a/packages/core-backend/src/services/ApprovalMetricsService.ts
+++ b/packages/core-backend/src/services/ApprovalMetricsService.ts
@@ -73,10 +73,39 @@ export interface MetricsSummary {
   byTemplate: MetricsSummaryTemplateRow[]
 }
 
+export interface MetricsTopInstanceRow {
+  instanceId: string
+  templateId: string | null
+  startedAt: string
+  terminalAt: string | null
+  terminalState: ApprovalTerminalState | null
+  durationSeconds: number
+  slaHours: number | null
+  slaBreached: boolean
+  slaBreachedAt: string | null
+}
+
+export interface MetricsTopTemplateRow {
+  templateId: string | null
+  total: number
+  slaCandidateCount: number
+  slaBreachCount: number
+  slaBreachRate: number
+  avgDurationSeconds: number | null
+  p95DurationSeconds: number | null
+}
+
+export interface MetricsReport {
+  summary: MetricsSummary
+  slowestInstances: MetricsTopInstanceRow[]
+  breachedTemplates: MetricsTopTemplateRow[]
+}
+
 export interface MetricsSummaryQuery {
   tenantId?: string
   since?: Date | string
   until?: Date | string
+  limit?: number
 }
 
 const DEFAULT_TENANT_ID = 'default'
@@ -91,6 +120,10 @@ function normalizeDate(value: Date | string | undefined | null): Date | null {
   if (value instanceof Date) return value
   const parsed = new Date(value)
   return Number.isFinite(parsed.getTime()) ? parsed : null
+}
+
+function clampReportLimit(value: number | undefined | null): number {
+  return Math.max(1, Math.min(Number.isFinite(value) ? Number(value) : 10, 50))
 }
 
 function toNodeBreakdown(raw: unknown): NodeBreakdownEntry[] {
@@ -370,6 +403,114 @@ export class ApprovalMetricsService {
           revoked: Number.parseInt(tpl.revoked ?? '0', 10) || 0,
           avgDurationSeconds: parseNullableNumber(tpl.avg_duration),
           slaBreachRate: tplCandidate > 0 ? tplBreach / tplCandidate : 0,
+        }
+      }),
+    }
+  }
+
+  async getMetricsReport(input: MetricsSummaryQuery = {}): Promise<MetricsReport> {
+    const summary = await this.getMetricsSummary(input)
+    const tenantId = resolveTenantId(input.tenantId)
+    const since = normalizeDate(input.since)
+    const until = normalizeDate(input.until)
+    const limit = clampReportLimit(input.limit)
+
+    const conditions: string[] = ['tenant_id = $1']
+    const params: unknown[] = [tenantId]
+    if (since) {
+      params.push(since.toISOString())
+      conditions.push(`started_at >= $${params.length}`)
+    }
+    if (until) {
+      params.push(until.toISOString())
+      conditions.push(`started_at <= $${params.length}`)
+    }
+    const where = `WHERE ${conditions.join(' AND ')}`
+
+    const slowestLimitParam = [...params, limit]
+    const slowestInstances = await this.query<{
+      instance_id: string
+      template_id: string | null
+      started_at: string
+      terminal_at: string | null
+      terminal_state: ApprovalTerminalState | null
+      duration_seconds: string | number
+      sla_hours: string | number | null
+      sla_breached: boolean
+      sla_breached_at: string | null
+    }>(
+      `SELECT
+         instance_id,
+         template_id,
+         started_at,
+         terminal_at,
+         terminal_state,
+         duration_seconds,
+         sla_hours,
+         sla_breached,
+         sla_breached_at
+       FROM approval_metrics
+       ${where}
+         AND duration_seconds IS NOT NULL
+       ORDER BY duration_seconds DESC, terminal_at DESC NULLS LAST
+       LIMIT $${slowestLimitParam.length}`,
+      slowestLimitParam,
+    )
+
+    const templateLimitParam = [...params, limit]
+    const breachedTemplates = await this.query<{
+      template_id: string | null
+      total: string
+      sla_candidate_count: string
+      sla_breach_count: string
+      avg_duration: string | null
+      p95_duration: string | null
+    }>(
+      `SELECT
+         template_id,
+         COUNT(*)::text AS total,
+         COUNT(*) FILTER (WHERE sla_hours IS NOT NULL)::text AS sla_candidate_count,
+         COUNT(*) FILTER (WHERE sla_breached = TRUE)::text AS sla_breach_count,
+         AVG(duration_seconds) FILTER (WHERE duration_seconds IS NOT NULL)::text AS avg_duration,
+         PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY duration_seconds)
+           FILTER (WHERE duration_seconds IS NOT NULL)::text AS p95_duration
+       FROM approval_metrics
+       ${where}
+       GROUP BY template_id
+       HAVING COUNT(*) FILTER (WHERE sla_hours IS NOT NULL) > 0
+       ORDER BY
+         (COUNT(*) FILTER (WHERE sla_breached = TRUE))::float
+           / NULLIF(COUNT(*) FILTER (WHERE sla_hours IS NOT NULL), 0) DESC,
+         COUNT(*) FILTER (WHERE sla_breached = TRUE) DESC,
+         COUNT(*) DESC
+       LIMIT $${templateLimitParam.length}`,
+      templateLimitParam,
+    )
+
+    return {
+      summary,
+      slowestInstances: slowestInstances.rows.map((row) => ({
+        instanceId: row.instance_id,
+        templateId: row.template_id,
+        startedAt: row.started_at,
+        terminalAt: row.terminal_at,
+        terminalState: row.terminal_state,
+        durationSeconds: Number(row.duration_seconds) || 0,
+        slaHours: row.sla_hours === null ? null : Number(row.sla_hours),
+        slaBreached: row.sla_breached,
+        slaBreachedAt: row.sla_breached_at,
+      })),
+      breachedTemplates: breachedTemplates.rows.map((row) => {
+        const slaCandidateCount = Number.parseInt(row.sla_candidate_count ?? '0', 10) || 0
+        const slaBreachCount = Number.parseInt(row.sla_breach_count ?? '0', 10) || 0
+        return {
+          templateId: row.template_id,
+          total: Number.parseInt(row.total ?? '0', 10) || 0,
+          slaCandidateCount,
+          slaBreachCount,
+          slaBreachRate: slaCandidateCount > 0 ? slaBreachCount / slaCandidateCount : 0,
+          avgDurationSeconds: parseNullableNumber(row.avg_duration),
+          p95DurationSeconds: parseNullableNumber(row.p95_duration),
         }
       }),
     }

--- a/packages/core-backend/tests/unit/approval-metrics-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-metrics-service.test.ts
@@ -305,6 +305,107 @@ describe('ApprovalMetricsService', () => {
     })
   })
 
+  describe('getMetricsReport', () => {
+    it('returns summary plus slowest instances and riskiest SLA templates', async () => {
+      queryMock
+        .mockResolvedValueOnce({
+          rows: [{
+            total: '2',
+            approved: '1',
+            rejected: '0',
+            revoked: '0',
+            returned: '0',
+            running: '1',
+            avg_duration: '3600',
+            p50_duration: '3600',
+            p95_duration: '7200',
+            sla_breach_count: '1',
+            sla_candidate_count: '2',
+          }],
+        })
+        .mockResolvedValueOnce({
+          rows: [{
+            template_id: 'tmpl-1',
+            total: '2',
+            approved: '1',
+            rejected: '0',
+            revoked: '0',
+            avg_duration: '3600',
+            sla_breach_count: '1',
+            sla_candidate_count: '2',
+          }],
+        })
+        .mockResolvedValueOnce({
+          rows: [{
+            instance_id: 'apr-slow',
+            template_id: 'tmpl-1',
+            started_at: '2026-04-25T01:00:00Z',
+            terminal_at: '2026-04-25T03:00:00Z',
+            terminal_state: 'approved',
+            duration_seconds: '7200',
+            sla_hours: '1',
+            sla_breached: true,
+            sla_breached_at: '2026-04-25T02:05:00Z',
+          }],
+        })
+        .mockResolvedValueOnce({
+          rows: [{
+            template_id: 'tmpl-1',
+            total: '2',
+            sla_candidate_count: '2',
+            sla_breach_count: '1',
+            avg_duration: '3600',
+            p95_duration: '7200',
+          }],
+        })
+
+      const report = await service.getMetricsReport({
+        tenantId: 'tenant-a',
+        since: '2026-04-01T00:00:00Z',
+        until: '2026-04-30T00:00:00Z',
+        limit: 500,
+      })
+
+      expect(report.summary.total).toBe(2)
+      expect(report.slowestInstances).toEqual([{
+        instanceId: 'apr-slow',
+        templateId: 'tmpl-1',
+        startedAt: '2026-04-25T01:00:00Z',
+        terminalAt: '2026-04-25T03:00:00Z',
+        terminalState: 'approved',
+        durationSeconds: 7200,
+        slaHours: 1,
+        slaBreached: true,
+        slaBreachedAt: '2026-04-25T02:05:00Z',
+      }])
+      expect(report.breachedTemplates[0]).toMatchObject({
+        templateId: 'tmpl-1',
+        total: 2,
+        slaCandidateCount: 2,
+        slaBreachCount: 1,
+        slaBreachRate: 0.5,
+        avgDurationSeconds: 3600,
+        p95DurationSeconds: 7200,
+      })
+
+      const slowestSql = normalize(queryMock.mock.calls[2][0])
+      expect(slowestSql).toContain('duration_seconds IS NOT NULL')
+      expect(slowestSql).toContain('ORDER BY duration_seconds DESC')
+      expect(slowestSql).toContain('LIMIT $4')
+      expect(queryMock.mock.calls[2][1]).toEqual([
+        'tenant-a',
+        '2026-04-01T00:00:00.000Z',
+        '2026-04-30T00:00:00.000Z',
+        50,
+      ])
+
+      const templatesSql = normalize(queryMock.mock.calls[3][0])
+      expect(templatesSql).toContain('HAVING COUNT(*) FILTER (WHERE sla_hours IS NOT NULL) > 0')
+      expect(templatesSql).toContain('sla_breached = TRUE')
+      expect(templatesSql).toContain('LIMIT $4')
+    })
+  })
+
   describe('listActiveBreaches', () => {
     it('queries active breached rows ordered by breach time', async () => {
       queryMock.mockResolvedValueOnce({

--- a/packages/openapi/dist/combined.openapi.yml
+++ b/packages/openapi/dist/combined.openapi.yml
@@ -3783,6 +3783,172 @@ paths:
           $ref: '#/components/responses/NotFound'
         '503':
           $ref: '#/components/responses/ServiceUnavailable'
+  /api/approvals/metrics/report:
+    get:
+      operationId: getApprovalMetricsReport
+      tags:
+        - Approvals
+      summary: Get approval metrics TopN report
+      description: |
+        Returns admin-only approval observability data: the existing metrics
+        summary plus TopN slowest completed instances and templates with the
+        highest SLA breach rate.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: since
+          schema:
+            type: string
+            format: date-time
+        - in: query
+          name: until
+          schema:
+            type: string
+            format: date-time
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 50
+            default: 10
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    example: true
+                  data:
+                    type: object
+                    properties:
+                      summary:
+                        type: object
+                        properties:
+                          total:
+                            type: integer
+                          approved:
+                            type: integer
+                          rejected:
+                            type: integer
+                          revoked:
+                            type: integer
+                          returned:
+                            type: integer
+                          running:
+                            type: integer
+                          avgDurationSeconds:
+                            type: number
+                            nullable: true
+                          p50DurationSeconds:
+                            type: number
+                            nullable: true
+                          p95DurationSeconds:
+                            type: number
+                            nullable: true
+                          slaBreachCount:
+                            type: integer
+                          slaCandidateCount:
+                            type: integer
+                          slaBreachRate:
+                            type: number
+                          byTemplate:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                templateId:
+                                  type: string
+                                  nullable: true
+                                total:
+                                  type: integer
+                                approved:
+                                  type: integer
+                                rejected:
+                                  type: integer
+                                revoked:
+                                  type: integer
+                                avgDurationSeconds:
+                                  type: number
+                                  nullable: true
+                                slaBreachRate:
+                                  type: number
+                      slowestInstances:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            instanceId:
+                              type: string
+                            templateId:
+                              type: string
+                              nullable: true
+                            startedAt:
+                              type: string
+                              format: date-time
+                            terminalAt:
+                              type: string
+                              format: date-time
+                              nullable: true
+                            terminalState:
+                              type: string
+                              nullable: true
+                              enum:
+                                - approved
+                                - rejected
+                                - revoked
+                                - returned
+                            durationSeconds:
+                              type: integer
+                            slaHours:
+                              type: integer
+                              nullable: true
+                            slaBreached:
+                              type: boolean
+                            slaBreachedAt:
+                              type: string
+                              format: date-time
+                              nullable: true
+                      breachedTemplates:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            templateId:
+                              type: string
+                              nullable: true
+                            total:
+                              type: integer
+                            slaCandidateCount:
+                              type: integer
+                            slaBreachCount:
+                              type: integer
+                            slaBreachRate:
+                              type: number
+                            avgDurationSeconds:
+                              type: number
+                              nullable: true
+                            p95DurationSeconds:
+                              type: number
+                              nullable: true
+                    required:
+                      - summary
+                      - slowestInstances
+                      - breachedTemplates
+                required:
+                  - ok
+                  - data
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          description: Internal server error
   /api/approval-templates:
     get:
       operationId: listApprovalTemplates

--- a/packages/openapi/dist/openapi.json
+++ b/packages/openapi/dist/openapi.json
@@ -5514,6 +5514,246 @@
         }
       }
     },
+    "/api/approvals/metrics/report": {
+      "get": {
+        "operationId": "getApprovalMetricsReport",
+        "tags": [
+          "Approvals"
+        ],
+        "summary": "Get approval metrics TopN report",
+        "description": "Returns admin-only approval observability data: the existing metrics\nsummary plus TopN slowest completed instances and templates with the\nhighest SLA breach rate.\n",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "since",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "in": "query",
+            "name": "until",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 50,
+              "default": 10
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "summary": {
+                          "type": "object",
+                          "properties": {
+                            "total": {
+                              "type": "integer"
+                            },
+                            "approved": {
+                              "type": "integer"
+                            },
+                            "rejected": {
+                              "type": "integer"
+                            },
+                            "revoked": {
+                              "type": "integer"
+                            },
+                            "returned": {
+                              "type": "integer"
+                            },
+                            "running": {
+                              "type": "integer"
+                            },
+                            "avgDurationSeconds": {
+                              "type": "number",
+                              "nullable": true
+                            },
+                            "p50DurationSeconds": {
+                              "type": "number",
+                              "nullable": true
+                            },
+                            "p95DurationSeconds": {
+                              "type": "number",
+                              "nullable": true
+                            },
+                            "slaBreachCount": {
+                              "type": "integer"
+                            },
+                            "slaCandidateCount": {
+                              "type": "integer"
+                            },
+                            "slaBreachRate": {
+                              "type": "number"
+                            },
+                            "byTemplate": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "templateId": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "total": {
+                                    "type": "integer"
+                                  },
+                                  "approved": {
+                                    "type": "integer"
+                                  },
+                                  "rejected": {
+                                    "type": "integer"
+                                  },
+                                  "revoked": {
+                                    "type": "integer"
+                                  },
+                                  "avgDurationSeconds": {
+                                    "type": "number",
+                                    "nullable": true
+                                  },
+                                  "slaBreachRate": {
+                                    "type": "number"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "slowestInstances": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "instanceId": {
+                                "type": "string"
+                              },
+                              "templateId": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "startedAt": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "terminalAt": {
+                                "type": "string",
+                                "format": "date-time",
+                                "nullable": true
+                              },
+                              "terminalState": {
+                                "type": "string",
+                                "nullable": true,
+                                "enum": [
+                                  "approved",
+                                  "rejected",
+                                  "revoked",
+                                  "returned"
+                                ]
+                              },
+                              "durationSeconds": {
+                                "type": "integer"
+                              },
+                              "slaHours": {
+                                "type": "integer",
+                                "nullable": true
+                              },
+                              "slaBreached": {
+                                "type": "boolean"
+                              },
+                              "slaBreachedAt": {
+                                "type": "string",
+                                "format": "date-time",
+                                "nullable": true
+                              }
+                            }
+                          }
+                        },
+                        "breachedTemplates": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "templateId": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "total": {
+                                "type": "integer"
+                              },
+                              "slaCandidateCount": {
+                                "type": "integer"
+                              },
+                              "slaBreachCount": {
+                                "type": "integer"
+                              },
+                              "slaBreachRate": {
+                                "type": "number"
+                              },
+                              "avgDurationSeconds": {
+                                "type": "number",
+                                "nullable": true
+                              },
+                              "p95DurationSeconds": {
+                                "type": "number",
+                                "nullable": true
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "required": [
+                        "summary",
+                        "slowestInstances",
+                        "breachedTemplates"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "ok",
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
     "/api/approval-templates": {
       "get": {
         "operationId": "listApprovalTemplates",

--- a/packages/openapi/dist/openapi.yaml
+++ b/packages/openapi/dist/openapi.yaml
@@ -3783,6 +3783,172 @@ paths:
           $ref: '#/components/responses/NotFound'
         '503':
           $ref: '#/components/responses/ServiceUnavailable'
+  /api/approvals/metrics/report:
+    get:
+      operationId: getApprovalMetricsReport
+      tags:
+        - Approvals
+      summary: Get approval metrics TopN report
+      description: |
+        Returns admin-only approval observability data: the existing metrics
+        summary plus TopN slowest completed instances and templates with the
+        highest SLA breach rate.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: since
+          schema:
+            type: string
+            format: date-time
+        - in: query
+          name: until
+          schema:
+            type: string
+            format: date-time
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 50
+            default: 10
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    example: true
+                  data:
+                    type: object
+                    properties:
+                      summary:
+                        type: object
+                        properties:
+                          total:
+                            type: integer
+                          approved:
+                            type: integer
+                          rejected:
+                            type: integer
+                          revoked:
+                            type: integer
+                          returned:
+                            type: integer
+                          running:
+                            type: integer
+                          avgDurationSeconds:
+                            type: number
+                            nullable: true
+                          p50DurationSeconds:
+                            type: number
+                            nullable: true
+                          p95DurationSeconds:
+                            type: number
+                            nullable: true
+                          slaBreachCount:
+                            type: integer
+                          slaCandidateCount:
+                            type: integer
+                          slaBreachRate:
+                            type: number
+                          byTemplate:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                templateId:
+                                  type: string
+                                  nullable: true
+                                total:
+                                  type: integer
+                                approved:
+                                  type: integer
+                                rejected:
+                                  type: integer
+                                revoked:
+                                  type: integer
+                                avgDurationSeconds:
+                                  type: number
+                                  nullable: true
+                                slaBreachRate:
+                                  type: number
+                      slowestInstances:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            instanceId:
+                              type: string
+                            templateId:
+                              type: string
+                              nullable: true
+                            startedAt:
+                              type: string
+                              format: date-time
+                            terminalAt:
+                              type: string
+                              format: date-time
+                              nullable: true
+                            terminalState:
+                              type: string
+                              nullable: true
+                              enum:
+                                - approved
+                                - rejected
+                                - revoked
+                                - returned
+                            durationSeconds:
+                              type: integer
+                            slaHours:
+                              type: integer
+                              nullable: true
+                            slaBreached:
+                              type: boolean
+                            slaBreachedAt:
+                              type: string
+                              format: date-time
+                              nullable: true
+                      breachedTemplates:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            templateId:
+                              type: string
+                              nullable: true
+                            total:
+                              type: integer
+                            slaCandidateCount:
+                              type: integer
+                            slaBreachCount:
+                              type: integer
+                            slaBreachRate:
+                              type: number
+                            avgDurationSeconds:
+                              type: number
+                              nullable: true
+                            p95DurationSeconds:
+                              type: number
+                              nullable: true
+                    required:
+                      - summary
+                      - slowestInstances
+                      - breachedTemplates
+                required:
+                  - ok
+                  - data
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          description: Internal server error
   /api/approval-templates:
     get:
       operationId: listApprovalTemplates

--- a/packages/openapi/src/paths/approvals.yml
+++ b/packages/openapi/src/paths/approvals.yml
@@ -431,6 +431,111 @@ paths:
         '403': { $ref: '#/components/responses/Forbidden' }
         '404': { $ref: '#/components/responses/NotFound' }
         '503': { $ref: '#/components/responses/ServiceUnavailable' }
+  /api/approvals/metrics/report:
+    get:
+      operationId: getApprovalMetricsReport
+      tags: [Approvals]
+      summary: Get approval metrics TopN report
+      description: |
+        Returns admin-only approval observability data: the existing metrics
+        summary plus TopN slowest completed instances and templates with the
+        highest SLA breach rate.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: since
+          schema:
+            type: string
+            format: date-time
+        - in: query
+          name: until
+          schema:
+            type: string
+            format: date-time
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 50
+            default: 10
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    example: true
+                  data:
+                    type: object
+                    properties:
+                      summary:
+                        type: object
+                        properties:
+                          total: { type: integer }
+                          approved: { type: integer }
+                          rejected: { type: integer }
+                          revoked: { type: integer }
+                          returned: { type: integer }
+                          running: { type: integer }
+                          avgDurationSeconds: { type: number, nullable: true }
+                          p50DurationSeconds: { type: number, nullable: true }
+                          p95DurationSeconds: { type: number, nullable: true }
+                          slaBreachCount: { type: integer }
+                          slaCandidateCount: { type: integer }
+                          slaBreachRate: { type: number }
+                          byTemplate:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                templateId: { type: string, nullable: true }
+                                total: { type: integer }
+                                approved: { type: integer }
+                                rejected: { type: integer }
+                                revoked: { type: integer }
+                                avgDurationSeconds: { type: number, nullable: true }
+                                slaBreachRate: { type: number }
+                      slowestInstances:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            instanceId: { type: string }
+                            templateId: { type: string, nullable: true }
+                            startedAt: { type: string, format: date-time }
+                            terminalAt: { type: string, format: date-time, nullable: true }
+                            terminalState:
+                              type: string
+                              nullable: true
+                              enum: [approved, rejected, revoked, returned]
+                            durationSeconds: { type: integer }
+                            slaHours: { type: integer, nullable: true }
+                            slaBreached: { type: boolean }
+                            slaBreachedAt: { type: string, format: date-time, nullable: true }
+                      breachedTemplates:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            templateId: { type: string, nullable: true }
+                            total: { type: integer }
+                            slaCandidateCount: { type: integer }
+                            slaBreachCount: { type: integer }
+                            slaBreachRate: { type: number }
+                            avgDurationSeconds: { type: number, nullable: true }
+                            p95DurationSeconds: { type: number, nullable: true }
+                    required: [summary, slowestInstances, breachedTemplates]
+                required: [ok, data]
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '500':
+          description: Internal server error
   /api/approval-templates:
     get:
       operationId: listApprovalTemplates


### PR DESCRIPTION
## Summary
- Add ApprovalMetricsService.getMetricsReport().
- Add admin-only GET /api/approvals/metrics/report.
- Add frontend TopN slowest instances and breached templates cards.
- Update OpenAPI source and generated dist artifacts.

## Verification
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-metrics-service.test.ts --reporter=dot
- pnpm --filter @metasheet/core-backend exec tsc --noEmit
- pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
- pnpm exec tsx packages/openapi/tools/build.ts

## Docs
- docs/development/approval-sla-topn-report-development-20260425.md
- docs/development/approval-sla-topn-report-verification-20260425.md