### PR TITLE
feat(integration): add K3 WISE live PoC preflight packet

### DIFF
--- a/docs/development/integration-core-k3wise-live-poc-design-20260425.md
+++ b/docs/development/integration-core-k3wise-live-poc-design-20260425.md
@@ -1,0 +1,280 @@
+# Integration Core K3 WISE Live PoC Design - 2026-04-25
+
+## 1. Purpose
+
+This document defines the first live PoC after the mock PLM to K3 WISE MVP.
+
+The goal is to prove that `plugin-integration-core` can read real PLM material data, clean and validate it through the integration pipeline, write a very small Save-only payload into a K3 WISE test account, and write ERP feedback back into MetaSheet staging.
+
+This PoC is not a production rollout. It must not write to a production K3 account, must not auto-submit or auto-audit by default, and must not directly update K3 core SQL Server business tables.
+
+## 2. Scope
+
+In scope:
+
+- Yuantus PLM or third-party PLM read path through the PLM wrapper or a documented HTTP/DB read adapter.
+- K3 WISE WebAPI/K3API write path for material master data.
+- Optional K3 WISE SQL Server channel for read-only reconciliation, or for customer-approved middle-table writes.
+- Integration staging sheets, mapping, transform, validator, idempotency, watermark, dead letter, run log, and ERP feedback.
+- One simple BOM PoC after material Save-only succeeds.
+
+Out of scope for this PoC:
+
+- Production K3 writes.
+- Default Submit/Audit automation.
+- Direct writes to `t_ICItem`, `t_ICBOM`, `t_ICBomChild`, or other K3 core business tables.
+- High-concurrency sync, multi-account orchestration, replacement materials, complex BOM effectivity, and production compensation transactions.
+- M3 UI. The UI phase starts only after the live backend path passes.
+
+## 3. GATE Before Work Starts
+
+M2 live PoC must not start until the customer returns this checklist.
+
+| Area | Required answer | Why it matters |
+|---|---|---|
+| K3 WISE version | Exact version and patch level | K3API/WebAPI payloads and response codes vary by deployment. |
+| K3 API endpoint | Internal/external URL, network path, TLS policy | Confirms MetaSheet can reach the test account. |
+| Test account | `acctId`, organization/account-set scope, write permission | Ensures all writes stay outside production. |
+| Credentials | Named test user, permission scope, expiry policy | Required for controlled `testConnection` and Save-only run. |
+| PLM access | API/table/view, auth method, sample material and BOM records | Defines source adapter and field mapping. |
+| Material fields | K3 field code list for item create/update | Prevents blind payload construction. |
+| BOM fields | K3 BOM header/child field code list | Needed before BOM PoC. |
+| Submit/Audit policy | Save-only, Submit, Audit, or customer manual audit | Default is Save-only unless explicitly approved. |
+| SQL Server scope | Read-only, middle table writable, stored procedures allowed, forbidden tables | Keeps SQL channel safe. |
+| Middle database | Database/table names and ownership if available | Preferred over direct K3 business-table access. |
+| Rollback SOP | How test items/BOMs are cleaned or marked invalid | Required before live write. |
+| Evidence owner | Customer contact who confirms K3 result | Avoids ambiguous acceptance. |
+
+## 4. Runtime Topology
+
+Recommended live topology:
+
+```text
+PLM API/table/view
+  -> plugin-integration-core adapter: plm:yuantus-wrapper or http/db source
+  -> integration pipeline
+  -> staging sheets: materials, bom, exceptions, run logs
+  -> transform + validation + idempotency + watermark
+  -> erp:k3-wise-webapi target
+  -> K3 WISE test account Save-only
+  -> erp feedback writeback
+```
+
+Optional SQL Server channel:
+
+```text
+K3 WISE SQL Server
+  -> erp:k3-wise-sqlserver
+  -> read-only reconciliation, duplicate checks, feedback lookup
+```
+
+The SQL Server channel can write only to a customer-approved integration database or middle table. Direct writes to K3 core business tables are not part of this PoC.
+
+## 5. External System Configuration
+
+Use redacted credentials in documentation and PRs.
+
+Before creating these records manually, generate a local preflight packet from the customer GATE answers:
+
+```bash
+node scripts/ops/integration-k3wise-live-poc-preflight.mjs \
+  --input /tmp/k3wise-live-gate.json \
+  --out-dir artifacts/integration-live-poc/customer-test
+```
+
+The preflight packet does not call PLM or K3. It only validates that the execution package stays non-production, Save-only, and free of committed secrets.
+
+PLM source example:
+
+```json
+{
+  "name": "customer-plm-test",
+  "type": "plm:yuantus-wrapper",
+  "tenantId": "tenant-test",
+  "workspaceId": "workspace-test",
+  "config": {
+    "baseUrl": "https://plm.example.test",
+    "defaultProductId": "PRODUCT-TEST-001",
+    "pageSize": 50
+  },
+  "credentials": {
+    "username": "<redacted>",
+    "password": "<redacted>"
+  }
+}
+```
+
+K3 WISE target example:
+
+```json
+{
+  "name": "k3-wise-test",
+  "type": "erp:k3-wise-webapi",
+  "tenantId": "tenant-test",
+  "workspaceId": "workspace-test",
+  "config": {
+    "baseUrl": "https://k3.example.test/K3API",
+    "loginPath": "/login",
+    "materialSavePath": "/material/save",
+    "bomSavePath": "/bom/save",
+    "autoSubmit": false,
+    "autoAudit": false,
+    "timeoutMs": 30000
+  },
+  "credentials": {
+    "username": "<redacted>",
+    "password": "<redacted>",
+    "acctId": "<test-acct-id>"
+  }
+}
+```
+
+SQL Server read-only channel example:
+
+```json
+{
+  "name": "k3-wise-sql-readonly",
+  "type": "erp:k3-wise-sqlserver",
+  "tenantId": "tenant-test",
+  "workspaceId": "workspace-test",
+  "config": {
+    "server": "10.0.0.10",
+    "database": "AIS_TEST",
+    "mode": "readonly",
+    "allowedTables": ["t_ICItem", "t_MeasureUnit"]
+  },
+  "credentials": {
+    "username": "<redacted>",
+    "password": "<redacted>"
+  }
+}
+```
+
+## 6. Pipeline Design
+
+Material pipeline:
+
+```json
+{
+  "name": "plm-material-to-k3-wise-test",
+  "mode": "manual",
+  "sourceSystem": "customer-plm-test",
+  "targetSystem": "k3-wise-test",
+  "objectType": "material",
+  "batchSize": 10,
+  "dryRunFirst": true,
+  "options": {
+    "writeMode": "saveOnly",
+    "advanceWatermarkOnPartialFailure": false
+  }
+}
+```
+
+Required material transforms:
+
+- `trim` and `upper` for material code.
+- `dictMap` for unit, material group, and ERP classification.
+- `defaultValue` for customer-approved defaults.
+- `toNumber` for numeric quantity or weight fields.
+- `toDate` only where the customer provides a stable source format.
+
+Required validations:
+
+- Material code is required and matches the K3 naming rule.
+- Material name is required.
+- Unit exists in the approved K3 unit dictionary.
+- Material group exists in the approved K3 group dictionary.
+- Idempotency key is stable: source system, object type, source id, revision, target system.
+- Save-only response must include a K3 business status or diagnostic error.
+
+BOM pipeline:
+
+- Run only after material Save-only succeeds.
+- `productId` must come from PLM external system `config.defaultProductId` or from direct adapter `filters.productId`.
+- Do not use legacy `pipeline.options.source.productId`.
+- Start with one parent item and one or two child rows.
+
+## 7. Execution Phases
+
+1. Gate intake
+   - Archive customer answers and sample payloads.
+   - Confirm test account and rollback owner.
+
+2. Connectivity smoke
+   - Run `testConnection` for PLM and K3 WISE WebAPI.
+   - Run SQL Server test only if the customer approved the channel.
+
+3. Staging installation
+   - Create or verify integration staging sheets.
+   - Confirm required fields and ERP feedback fields exist.
+
+4. Material dry-run
+   - Read 1-3 PLM material records.
+   - Run mapping, transform, validation, and preview.
+   - Confirm no K3 write occurs.
+
+5. Material Save-only live run
+   - Write 1-3 test material records to K3 WISE test account.
+   - Keep `autoSubmit=false` and `autoAudit=false`.
+   - Capture K3 response and ERP feedback.
+
+6. Failure and replay validation
+   - Intentionally fail one validation or dictionary mapping.
+   - Confirm dead letter, run log, and no watermark advance for failed rows.
+   - Fix mapping and replay.
+
+7. Simple BOM PoC
+   - Run one parent and one or two children.
+   - Confirm K3 response and feedback.
+
+8. Evidence package
+   - Produce the verification MD with redacted request/response IDs, run IDs, K3 bill numbers, screenshots if available, and residual gaps.
+
+## 8. Safety Guardrails
+
+- Use test account only.
+- Default to Save-only.
+- Keep Submit/Audit disabled unless the customer explicitly approves it in writing.
+- Never log plaintext credentials.
+- Never return plaintext credentials from REST APIs.
+- Redact tokens, passwords, session IDs, and SQL Server usernames in evidence.
+- Keep dead-letter payload access admin-only.
+- Do not advance watermark on partial failure.
+- Prefer middle database or API write paths over direct K3 table writes.
+- Keep rollback steps documented before the first live write.
+
+## 9. Acceptance Criteria
+
+The live PoC passes only if all items below are true:
+
+- PLM `testConnection` passes against the customer-approved test source.
+- K3 WISE WebAPI `testConnection` passes against the test account.
+- Material dry-run cleans and validates at least one real PLM row without writing to K3.
+- Save-only writes 1-3 material rows to the K3 WISE test account.
+- ERP feedback is written back with sync status, K3 external id or bill number when available, response code, response message, and sync timestamp.
+- A controlled failure enters dead letter and can be replayed after correction.
+- Watermark does not advance for failed rows.
+- Simple BOM PoC succeeds or produces a documented K3 business error that can be converted into an adapter hardening task.
+- Customer evidence owner confirms the K3 test-account result.
+
+## 10. Rollback
+
+Before live write:
+
+- Record the exact PLM source IDs and intended K3 material codes.
+- Confirm the K3 test-account cleanup owner.
+- Confirm whether test records should be deleted, disabled, or left as audit samples.
+
+After live write:
+
+- Export run log and K3 response.
+- Mark test records in K3 according to the customer rollback SOP.
+- Reset or document the watermark if the test must be repeated.
+- Keep dead-letter rows for audit unless the customer requests cleanup.
+
+## 11. Follow-Up Rules
+
+- If connectivity fails, do not change pipeline behavior first. Fix network, auth, version, or endpoint mismatch.
+- If K3 rejects payload shape, add adapter hardening in M2-LIVE-PR2.
+- If field mapping is incomplete, update mapping and dictionaries before retrying.
+- If Save-only succeeds, M3 UI can begin. If Save-only does not succeed, M3 UI remains blocked.

--- a/docs/development/integration-core-k3wise-live-poc-preflight-design-20260425.md
+++ b/docs/development/integration-core-k3wise-live-poc-preflight-design-20260425.md
@@ -1,0 +1,122 @@
+# Integration Core K3 WISE Live PoC Preflight Design - 2026-04-25
+
+## Objective
+
+Add a local preflight packet generator for M2 live PoC.
+
+The generator turns a customer GATE answer JSON into a redacted execution packet for a K3 WISE test-account PoC. It does not call PLM, K3, SQL Server, or MetaSheet APIs. Its job is to catch unsafe live-test inputs before an operator creates external systems or pipelines.
+
+## New Files
+
+- `scripts/ops/integration-k3wise-live-poc-preflight.mjs`
+- `scripts/ops/integration-k3wise-live-poc-preflight.test.mjs`
+
+The existing live PoC docs remain the operator runbook:
+
+- `docs/development/integration-core-k3wise-live-poc-design-20260425.md`
+- `docs/development/integration-core-k3wise-live-poc-verification-20260425.md`
+
+## Input Contract
+
+The input is a JSON object with these required sections:
+
+- `tenantId`
+- `workspaceId`
+- `k3Wise`
+- `plm`
+- `rollback`
+- `fieldMappings.material`
+
+Required K3 WISE values:
+
+- `k3Wise.version`
+- `k3Wise.apiUrl`
+- `k3Wise.acctId`
+- `k3Wise.environment`
+
+Required PLM values:
+
+- `plm.readMethod`
+- optional `plm.defaultProductId` or `plm.config.defaultProductId` for BOM PoC
+
+Required rollback values:
+
+- `rollback.owner`
+- `rollback.strategy`
+
+## Safety Rules
+
+The preflight fails fast when:
+
+- `k3Wise.environment` is not a non-production value: `test`, `testing`, `uat`, `sandbox`, `staging`, `dev`, or `development`.
+- `k3Wise.autoSubmit` or `k3Wise.autoAudit` is `true`.
+- SQL Server channel is configured to write K3 core business tables such as `t_ICItem`, `t_ICBOM`, or `t_ICBomChild`.
+- BOM PoC is enabled but no `bom.productId`, `plm.defaultProductId`, or `plm.config.defaultProductId` is provided.
+- `fieldMappings.material` is empty.
+
+The generated packet always sets K3 target options to Save-only:
+
+```json
+{
+  "autoSubmit": false,
+  "autoAudit": false,
+  "writeMode": "saveOnly"
+}
+```
+
+## Output Contract
+
+The CLI writes two files:
+
+- `integration-k3wise-live-poc-packet.json`
+- `integration-k3wise-live-poc-packet.md`
+
+The JSON packet contains:
+
+- redacted GATE summary;
+- external system payload drafts;
+- material and optional BOM pipeline drafts;
+- safety flags;
+- operator checklist.
+
+The Markdown packet is a human-reviewable summary for the live PoC evidence folder.
+
+## Secret Handling
+
+The generator scans input keys matching password, secret, token, session, credential, API key, or authorization. Generated output must not contain those values. Credential fields are replaced with `<set-at-runtime>` and `requiredCredentialKeys`.
+
+This protects PRs and evidence docs from accidentally committing customer credentials.
+
+## Operator Flow
+
+1. Collect the customer GATE answers outside Git.
+2. Save them as a local JSON file, for example `/tmp/k3wise-live-gate.json`.
+3. Run:
+
+   ```bash
+   node scripts/ops/integration-k3wise-live-poc-preflight.mjs \
+     --input /tmp/k3wise-live-gate.json \
+     --out-dir artifacts/integration-live-poc/customer-test
+   ```
+
+4. Review the generated packet.
+5. Use the packet to create external systems and pipelines in MetaSheet.
+6. Execute the live PoC checklist from the verification document.
+
+## Sample Input
+
+Generate a template with:
+
+```bash
+node scripts/ops/integration-k3wise-live-poc-preflight.mjs --print-sample
+```
+
+The sample is intentionally non-production and keeps credentials as placeholders.
+
+## Non-Goals
+
+- No real PLM/K3 connectivity.
+- No database migration.
+- No new integration-core runtime feature.
+- No M3 UI.
+- No production write support.

--- a/docs/development/integration-core-k3wise-live-poc-preflight-verification-20260425.md
+++ b/docs/development/integration-core-k3wise-live-poc-preflight-verification-20260425.md
@@ -1,0 +1,82 @@
+# Integration Core K3 WISE Live PoC Preflight Verification - 2026-04-25
+
+## Scope
+
+This verifies the M2 live PoC preflight packet generator.
+
+The verification is local and does not contact customer PLM, K3 WISE, SQL Server, or a running MetaSheet backend.
+
+## Commands
+
+```bash
+node --test scripts/ops/integration-k3wise-live-poc-preflight.test.mjs
+node scripts/ops/integration-k3wise-live-poc-preflight.mjs --print-sample
+git diff --check -- scripts/ops/integration-k3wise-live-poc-preflight.mjs scripts/ops/integration-k3wise-live-poc-preflight.test.mjs docs/development/integration-core-k3wise-live-poc-preflight-design-20260425.md docs/development/integration-core-k3wise-live-poc-preflight-verification-20260425.md
+```
+
+## Expected Test Coverage
+
+| Case | Expected result |
+|---|---|
+| Valid non-production GATE | Generates Save-only external systems, material pipeline, optional BOM pipeline, and checklist. |
+| Production K3 environment | Fails before packet generation. |
+| `autoSubmit` or `autoAudit` enabled | Fails because M2 live PoC is Save-only. |
+| SQL Server write to K3 core tables | Fails unless channel is read-only. |
+| BOM enabled without product scope | Fails and asks for `bom.productId` or PLM default product id. |
+| Secret-bearing input | Generated JSON/MD do not contain submitted secret values. |
+
+## Verification Result
+
+| Check | Status | Evidence |
+|---|---|---|
+| Unit test | PASS | `node --test scripts/ops/integration-k3wise-live-poc-preflight.test.mjs` passed 6/6. |
+| Sample generation | PASS | `node scripts/ops/integration-k3wise-live-poc-preflight.mjs --print-sample` output parsed as JSON. |
+| Diff whitespace check | PASS | `git diff --check` exited 0 for the preflight script, test, and live PoC docs. |
+| Integration plugin regression | PASS | `pnpm -F plugin-integration-core test` passed all plugin test files, including mock PLM to K3 WISE writeback. |
+| Plugin manifest validation | PASS | `node --import tsx scripts/validate-plugin-manifests.ts` reported 13/13 valid, 0 errors. |
+
+Test output summary:
+
+```text
+tests 6
+pass 6
+fail 0
+duration_ms 46.430375
+```
+
+Plugin regression summary:
+
+```text
+plugin-runtime-smoke passed
+host-loader-smoke passed
+credential-store passed
+db.cjs passed
+external-systems passed
+adapter-contracts passed
+http-adapter passed
+plm-yuantus-wrapper passed
+pipelines passed
+transform-validator passed
+runner-support passed
+payload-redaction passed
+pipeline-runner passed
+http-routes passed
+k3-wise-adapters passed
+erp-feedback passed
+e2e-plm-k3wise-writeback passed
+staging-installer passed
+migration-sql passed
+```
+
+## Live PoC Boundary
+
+Passing this verification only proves that the operator packet is structurally safe to prepare. It does not prove customer connectivity, K3 payload correctness, or PLM data quality.
+
+The next live gate remains:
+
+- archive real customer GATE answers;
+- create external systems with credentials supplied out-of-band;
+- run PLM and K3 `testConnection`;
+- run material dry-run;
+- run 1-3 Save-only material writes in the K3 WISE test account;
+- capture feedback, dead letter, replay, watermark, and rollback evidence.

--- a/docs/development/integration-core-k3wise-live-poc-verification-20260425.md
+++ b/docs/development/integration-core-k3wise-live-poc-verification-20260425.md
@@ -1,0 +1,150 @@
+# Integration Core K3 WISE Live PoC Verification - 2026-04-25
+
+## 1. Status
+
+Current status: backend mock MVP is merged, live customer-system verification is not yet executed.
+
+Local development verification for the preflight slice has passed: the packet generator unit test is 6/6, `plugin-integration-core` tests pass, plugin manifest validation reports 13/13 valid with 0 errors, and `git diff --check` is clean.
+
+Merged backend scope:
+
+- #1147 external system registry hardening.
+- #1148 adapter contract and HTTP adapter.
+- #1149 pipeline registry.
+- #1150 pipeline runner and support modules.
+- #1151 integration REST API.
+- #1152 K3 WISE adapters.
+- #1153 ERP feedback writeback.
+- #1154 Yuantus PLM wrapper and mock PLM to K3 WISE E2E.
+- #1155 PLM/K3 WISE MVP runbook.
+
+Live verification is blocked until the M2 GATE answers are archived: K3 WISE version, K3API/WebAPI URL, test `acctId`, PLM read method, field lists, Submit/Audit policy, SQL Server permissions, middle database policy, and rollback SOP.
+
+## 2. Pre-Live Verification
+
+Run these before touching a customer test system.
+
+| Check | Command | Expected result | Status |
+|---|---|---|---|
+| GATE preflight packet | `node scripts/ops/integration-k3wise-live-poc-preflight.mjs --input /tmp/k3wise-live-gate.json --out-dir artifacts/integration-live-poc/customer-test` | Generates redacted JSON/MD packet; blocks production, Submit/Audit, and unsafe SQL writes. | TODO |
+| Plugin tests | `pnpm -F plugin-integration-core test` | All plugin tests pass. | TODO |
+| Plugin manifest validation | `node --import tsx scripts/validate-plugin-manifests.ts` | `plugin-integration-core` is valid. | TODO |
+| Backend tests if available | `pnpm --filter @metasheet/core-backend test:unit` | No regression in plugin runtime or API tests. | TODO |
+| API process health | `curl -fsS "$METASHEET_API_URL/api/integration/health"` | Integration health returns success. | TODO |
+| Adapter registry | `curl -fsS "$METASHEET_API_URL/api/integration/status" > /tmp/integration-status.json && jq '.data.adapters' /tmp/integration-status.json` | Includes `plm:yuantus-wrapper`, `erp:k3-wise-webapi`, `erp:k3-wise-sqlserver`, and `http`. | TODO |
+| Migration state | `pnpm --filter @metasheet/core-backend migrate` or CI migration replay | `integration_*` tables exist and migrations replay cleanly. | TODO |
+
+If the local checkout is not fast-forwarded to latest `main`, use a clean worktree before running live verification. Do not run live tests from an older branch that lacks #1150-#1155.
+
+## 3. GATE Evidence
+
+| Evidence item | Required value | Status | Notes |
+|---|---|---|---|
+| K3 WISE version and patch | Exact version | BLOCKED | Waiting for customer. |
+| K3 WebAPI/K3API URL | Redacted URL and network route | BLOCKED | Waiting for customer. |
+| Test account | `acctId`, organization/account-set scope | BLOCKED | Waiting for customer. |
+| K3 test credentials | User and permission summary, no password in MD | BLOCKED | Waiting for customer. |
+| PLM read method | API/table/view and auth method | BLOCKED | Waiting for customer. |
+| Material field list | K3 field code mapping | BLOCKED | Waiting for customer. |
+| BOM field list | Header and child field mapping | BLOCKED | Waiting for customer. |
+| Submit/Audit policy | Save-only or explicit automation approval | BLOCKED | Default is Save-only. |
+| SQL Server permission | Read-only, middle-table writable, or disabled | BLOCKED | Waiting for customer. |
+| Rollback SOP | Delete/disable/retain test records | BLOCKED | Required before live write. |
+
+## 4. Live Connectivity Checklist
+
+| Check | How to verify | Expected result | Status |
+|---|---|---|---|
+| PLM external system created | Create `plm:yuantus-wrapper` or approved source adapter with redacted credentials. | Record exists; credentials are not returned in plaintext. | TODO |
+| K3 WISE external system created | Create `erp:k3-wise-webapi` with test `acctId`. | Record exists; `autoSubmit=false`, `autoAudit=false`. | TODO |
+| Optional SQL channel created | Create `erp:k3-wise-sqlserver` only if approved. | Mode is `readonly` or restricted middle-table mode. | TODO |
+| PLM testConnection | Call external-system test endpoint. | Business success; error details redacted if failure. | TODO |
+| K3 WebAPI testConnection | Call external-system test endpoint. | Login/session smoke succeeds against test account. | TODO |
+| SQL Server testConnection | Call only if approved. | Read-only or middle-table connection succeeds. | TODO |
+
+## 5. Material Dry-Run Checklist
+
+| Check | Expected result | Status |
+|---|---|---|
+| Staging sheets installed | Materials, BOM, exceptions/dead letters, and run log surfaces are available. | TODO |
+| Pipeline created | Source is PLM, target is K3 WISE test account, mode is manual. | TODO |
+| Sample source rows | 1-3 real PLM material rows selected and approved by customer. | TODO |
+| Transform output | Codes are trimmed/normalized; units and groups mapped through dictionaries. | TODO |
+| Validation output | Required fields, enums, patterns, and numeric fields pass or produce clear errors. | TODO |
+| Dry-run protection | No K3 write is performed. | TODO |
+| Preview evidence | Cleaned row preview is captured with sensitive values redacted. | TODO |
+
+## 6. Material Save-Only Checklist
+
+| Check | Expected result | Status |
+|---|---|---|
+| Save-only config | `autoSubmit=false`, `autoAudit=false`, write mode Save-only. | TODO |
+| Live write size | 1-3 material rows only. | TODO |
+| K3 response | K3 returns success status or a documented business error. | TODO |
+| ERP feedback | Staging row records `erpSyncStatus`, `erpExternalId`, `erpBillNo`, `erpResponseCode`, `erpResponseMessage`, and `lastSyncedAt` where available. | TODO |
+| Idempotency | Re-running the same batch does not duplicate successful target writes. | TODO |
+| Run log | Rows read, cleaned, written, failed, duration, status, and summary are recorded. | TODO |
+| Watermark | Successful rows can advance watermark; failed rows do not. | TODO |
+| Customer confirmation | Evidence owner confirms the K3 test-account record. | TODO |
+
+## 7. Failure, Dead Letter, and Replay Checklist
+
+| Scenario | Expected result | Status |
+|---|---|---|
+| Invalid required field | Row is rejected before K3 write and enters dead letter. | TODO |
+| Dictionary miss | Row enters dead letter with a clear error code/message. | TODO |
+| K3 business error | Error response is stored without exposing credentials or session tokens. | TODO |
+| Replay after correction | Corrected mapping or dictionary replay succeeds. | TODO |
+| Watermark safety | Failed rows do not cause watermark advance. | TODO |
+| Audit trail | Original run ID, replay run ID, retry count, and user are visible. | TODO |
+
+## 8. Simple BOM PoC Checklist
+
+| Check | Expected result | Status |
+|---|---|---|
+| Product scope | `productId` comes from PLM external system `config.defaultProductId` or direct adapter `filters.productId`. | TODO |
+| Legacy config avoided | `pipeline.options.source.productId` is not used. | TODO |
+| Parent material exists | Parent material was created or confirmed in K3 test account. | TODO |
+| Child rows exist | One or two child rows are selected and mapped. | TODO |
+| Save-only BOM write | K3 accepts the simple BOM or returns a documented business error. | TODO |
+| Feedback | BOM response is written back to staging/run log. | TODO |
+
+## 9. Rollback and Cleanup Checklist
+
+| Check | Expected result | Status |
+|---|---|---|
+| Test records identified | Source IDs, K3 material codes, bill numbers, and run IDs captured. | TODO |
+| Customer cleanup action | Records deleted, disabled, or retained according to rollback SOP. | TODO |
+| Watermark reset decision | Repeat-test strategy documented. | TODO |
+| Credentials removed or rotated | Temporary credentials revoked if required. | TODO |
+| Evidence package archived | This MD updated with final results and redacted logs/screenshots. | TODO |
+
+## 10. Not Covered by This Verification
+
+- Production account writes.
+- Automatic Submit/Audit.
+- High-concurrency or scheduled sync.
+- Multi-account, multi-organization, or multi-tenant production rollout.
+- Replacement materials, alternate BOM lines, effectivity dates, or complex BOM engineering rules.
+- Direct K3 SQL Server core-table writes.
+
+## 11. Result Template
+
+Use this section after the live PoC runs.
+
+| Area | Result | Evidence |
+|---|---|---|
+| GATE complete | TODO | Link or archive path. |
+| PLM connection | TODO | Redacted request ID or log line. |
+| K3 connection | TODO | Redacted request ID or log line. |
+| Material dry-run | TODO | Run ID. |
+| Material Save-only | TODO | Run ID and K3 test bill/material ID. |
+| Dead letter and replay | TODO | Original run ID and replay run ID. |
+| BOM PoC | TODO | Run ID and K3 response. |
+| Cleanup | TODO | Customer confirmation. |
+
+Final decision:
+
+- `PASS`: M3 UI can start.
+- `PARTIAL`: M2 adapter hardening required before M3.
+- `FAIL`: Stop live work and revisit GATE assumptions, connectivity, or K3 payload contract.

--- a/scripts/ops/integration-k3wise-live-poc-preflight.mjs
+++ b/scripts/ops/integration-k3wise-live-poc-preflight.mjs
@@ -1,0 +1,620 @@
+#!/usr/bin/env node
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const REQUIRED_TOP_LEVEL = ['tenantId', 'workspaceId', 'k3Wise', 'plm', 'rollback']
+const SECRET_KEY_PATTERN = /password|secret|token|session|credential|api[-_]?key|authorization/i
+const NON_PRODUCTION_ENVS = new Set(['test', 'testing', 'uat', 'sandbox', 'staging', 'dev', 'development'])
+const K3_CORE_TABLES = new Set(['t_icitem', 't_icbom', 't_icbomchild'])
+
+class LivePocPreflightError extends Error {
+  constructor(message, details = {}) {
+    super(message)
+    this.name = 'LivePocPreflightError'
+    this.details = details
+  }
+}
+
+function isPlainObject(value) {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value))
+}
+
+function requiredString(value, field) {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new LivePocPreflightError(`${field} is required`, { field })
+  }
+  return value.trim()
+}
+
+function optionalString(value) {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null
+}
+
+function optionalObject(value, field) {
+  if (value === undefined || value === null) return {}
+  if (!isPlainObject(value)) {
+    throw new LivePocPreflightError(`${field} must be an object`, { field })
+  }
+  return value
+}
+
+function optionalArray(value, field) {
+  if (value === undefined || value === null) return []
+  if (!Array.isArray(value)) {
+    throw new LivePocPreflightError(`${field} must be an array`, { field })
+  }
+  return value
+}
+
+function validateUrl(value, field) {
+  const text = requiredString(value, field)
+  let parsed
+  try {
+    parsed = new URL(text)
+  } catch {
+    throw new LivePocPreflightError(`${field} must be a valid URL`, { field })
+  }
+  if (!['http:', 'https:'].includes(parsed.protocol)) {
+    throw new LivePocPreflightError(`${field} must use http or https`, { field })
+  }
+  return parsed.toString()
+}
+
+function assertNoSecretStrings(value, secrets, location = 'root') {
+  if (typeof value === 'string') {
+    for (const secret of secrets) {
+      if (secret && value.includes(secret)) {
+        throw new LivePocPreflightError(`generated packet leaks secret at ${location}`, { location })
+      }
+    }
+    return
+  }
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => assertNoSecretStrings(item, secrets, `${location}[${index}]`))
+    return
+  }
+  if (isPlainObject(value)) {
+    for (const [key, child] of Object.entries(value)) {
+      assertNoSecretStrings(child, secrets, `${location}.${key}`)
+    }
+  }
+}
+
+function collectSecretValues(value, acc = []) {
+  if (Array.isArray(value)) {
+    value.forEach((item) => collectSecretValues(item, acc))
+    return acc
+  }
+  if (!isPlainObject(value)) return acc
+  for (const [key, child] of Object.entries(value)) {
+    if (SECRET_KEY_PATTERN.test(key) && typeof child === 'string' && child.length >= 4) {
+      acc.push(child)
+      continue
+    }
+    collectSecretValues(child, acc)
+  }
+  return acc
+}
+
+function redact(value) {
+  if (Array.isArray(value)) return value.map(redact)
+  if (!isPlainObject(value)) return value
+  const result = {}
+  for (const [key, child] of Object.entries(value)) {
+    result[key] = SECRET_KEY_PATTERN.test(key) ? '<redacted>' : redact(child)
+  }
+  return result
+}
+
+function normalizeGate(input) {
+  if (!isPlainObject(input)) {
+    throw new LivePocPreflightError('gate input must be a JSON object')
+  }
+  for (const field of REQUIRED_TOP_LEVEL) {
+    if (input[field] === undefined || input[field] === null) {
+      throw new LivePocPreflightError(`${field} is required`, { field })
+    }
+  }
+
+  const tenantId = requiredString(input.tenantId, 'tenantId')
+  const workspaceId = requiredString(input.workspaceId, 'workspaceId')
+  const projectId = optionalString(input.projectId)
+  const operator = optionalString(input.operator) || 'integration-operator'
+  const k3Wise = optionalObject(input.k3Wise, 'k3Wise')
+  const plm = optionalObject(input.plm, 'plm')
+  const sqlServer = optionalObject(input.sqlServer, 'sqlServer')
+  const rollback = optionalObject(input.rollback, 'rollback')
+  const fieldMappings = optionalObject(input.fieldMappings, 'fieldMappings')
+  const bom = optionalObject(input.bom, 'bom')
+
+  const environment = requiredString(k3Wise.environment, 'k3Wise.environment').toLowerCase()
+  if (!NON_PRODUCTION_ENVS.has(environment)) {
+    throw new LivePocPreflightError('K3 WISE live PoC must target a non-production test environment', {
+      field: 'k3Wise.environment',
+      environment,
+    })
+  }
+
+  if (k3Wise.autoSubmit === true || k3Wise.autoAudit === true) {
+    throw new LivePocPreflightError('M2 live PoC packet is Save-only: autoSubmit and autoAudit must be false', {
+      field: 'k3Wise.autoSubmit/autoAudit',
+    })
+  }
+
+  const sqlEnabled = sqlServer.enabled === true
+  const sqlMode = optionalString(sqlServer.mode) || (sqlEnabled ? 'readonly' : 'disabled')
+  const allowedTables = optionalArray(sqlServer.allowedTables, 'sqlServer.allowedTables').map((table) => String(table))
+  const writesCoreTable = allowedTables.some((table) => K3_CORE_TABLES.has(table.toLowerCase()))
+  if (sqlEnabled && sqlMode !== 'readonly' && (sqlServer.writeCoreTables === true || writesCoreTable)) {
+    throw new LivePocPreflightError('SQL Server channel may not write K3 core business tables in live PoC', {
+      field: 'sqlServer.allowedTables',
+      allowedTables,
+    })
+  }
+  if (sqlEnabled && !['readonly', 'middle-table', 'stored-procedure'].includes(sqlMode)) {
+    throw new LivePocPreflightError('sqlServer.mode must be readonly, middle-table, or stored-procedure', {
+      field: 'sqlServer.mode',
+      mode: sqlMode,
+    })
+  }
+
+  const bomEnabled = bom.enabled === true
+  const bomProductId = optionalString(bom.productId) || optionalString(plm.defaultProductId) || optionalString(plm.config && plm.config.defaultProductId)
+  if (bomEnabled && !bomProductId) {
+    throw new LivePocPreflightError('BOM PoC requires bom.productId or plm.defaultProductId', {
+      field: 'bom.productId',
+    })
+  }
+
+  const materialMappings = optionalArray(fieldMappings.material, 'fieldMappings.material')
+  if (materialMappings.length === 0) {
+    throw new LivePocPreflightError('fieldMappings.material must contain at least one mapping', {
+      field: 'fieldMappings.material',
+    })
+  }
+
+  requiredString(k3Wise.version, 'k3Wise.version')
+  validateUrl(k3Wise.apiUrl || k3Wise.baseUrl, 'k3Wise.apiUrl')
+  requiredString(k3Wise.acctId, 'k3Wise.acctId')
+  requiredString(plm.readMethod, 'plm.readMethod')
+  requiredString(rollback.owner, 'rollback.owner')
+  requiredString(rollback.strategy, 'rollback.strategy')
+
+  return {
+    tenantId,
+    workspaceId,
+    projectId,
+    operator,
+    k3Wise,
+    plm,
+    sqlServer,
+    rollback,
+    fieldMappings,
+    bom: {
+      ...bom,
+      productId: bomProductId,
+    },
+    sqlEnabled,
+    sqlMode,
+  }
+}
+
+function credentialPlaceholder(source) {
+  const credentials = optionalObject(source.credentials, 'credentials')
+  const keys = Object.keys(credentials).filter((key) => credentials[key] !== undefined && credentials[key] !== null)
+  return {
+    requiredCredentialKeys: keys.sort(),
+    credentials: Object.fromEntries(keys.sort().map((key) => [key, '<set-at-runtime>'])),
+  }
+}
+
+function normalizeMaterialMapping(mapping, index) {
+  if (!isPlainObject(mapping)) {
+    throw new LivePocPreflightError(`fieldMappings.material[${index}] must be an object`, {
+      field: 'fieldMappings.material',
+      index,
+    })
+  }
+  return {
+    sourceField: requiredString(mapping.sourceField, `fieldMappings.material[${index}].sourceField`),
+    targetField: requiredString(mapping.targetField, `fieldMappings.material[${index}].targetField`),
+    transform: mapping.transform === undefined ? null : redact(mapping.transform),
+    validation: mapping.validation === undefined ? null : redact(mapping.validation),
+    defaultValue: mapping.defaultValue === undefined ? null : mapping.defaultValue,
+    sortOrder: Number.isInteger(mapping.sortOrder) ? mapping.sortOrder : index,
+  }
+}
+
+function buildExternalSystems(gate) {
+  const plmConfig = {
+    baseUrl: optionalString(gate.plm.baseUrl) || undefined,
+    readMethod: gate.plm.readMethod,
+    pageSize: gate.plm.pageSize || 50,
+    defaultProductId: gate.bom.productId || undefined,
+    ...(isPlainObject(gate.plm.config) ? redact(gate.plm.config) : {}),
+  }
+  if (gate.bom.productId) plmConfig.defaultProductId = gate.bom.productId
+
+  const plmCredentials = credentialPlaceholder(gate.plm)
+  const k3Credentials = credentialPlaceholder({
+    credentials: {
+      ...(isPlainObject(gate.k3Wise.credentials) ? gate.k3Wise.credentials : {}),
+      acctId: gate.k3Wise.acctId,
+    },
+  })
+
+  const systems = [
+    {
+      name: 'live-poc-plm-source',
+      tenantId: gate.tenantId,
+      workspaceId: gate.workspaceId,
+      projectId: gate.projectId,
+      kind: gate.plm.kind || 'plm:yuantus-wrapper',
+      role: 'source',
+      status: 'active',
+      config: plmConfig,
+      capabilities: { objects: ['materials', 'bom'], write: false },
+      ...plmCredentials,
+    },
+    {
+      name: 'live-poc-k3-wise-target',
+      tenantId: gate.tenantId,
+      workspaceId: gate.workspaceId,
+      projectId: gate.projectId,
+      kind: 'erp:k3-wise-webapi',
+      role: 'target',
+      status: 'active',
+      config: {
+        baseUrl: validateUrl(gate.k3Wise.apiUrl || gate.k3Wise.baseUrl, 'k3Wise.apiUrl'),
+        loginPath: gate.k3Wise.loginPath || '/K3API/Login',
+        healthPath: gate.k3Wise.healthPath || undefined,
+        autoSubmit: false,
+        autoAudit: false,
+        timeoutMs: Number.isInteger(gate.k3Wise.timeoutMs) ? gate.k3Wise.timeoutMs : 30000,
+        objects: redact(gate.k3Wise.objects || {}),
+      },
+      capabilities: { objects: ['material', 'bom'], write: true, lifecycleAutomation: false },
+      ...k3Credentials,
+    },
+  ]
+
+  if (gate.sqlEnabled) {
+    systems.push({
+      name: 'live-poc-k3-wise-sql-channel',
+      tenantId: gate.tenantId,
+      workspaceId: gate.workspaceId,
+      projectId: gate.projectId,
+      kind: 'erp:k3-wise-sqlserver',
+      role: 'source',
+      status: 'active',
+      config: {
+        mode: gate.sqlMode,
+        server: optionalString(gate.sqlServer.server) || '<provided-by-customer>',
+        database: optionalString(gate.sqlServer.database) || '<provided-by-customer>',
+        allowedTables: optionalArray(gate.sqlServer.allowedTables, 'sqlServer.allowedTables'),
+        middleTables: optionalArray(gate.sqlServer.middleTables, 'sqlServer.middleTables'),
+        storedProcedures: optionalArray(gate.sqlServer.storedProcedures, 'sqlServer.storedProcedures'),
+      },
+      capabilities: {
+        readOnly: gate.sqlMode === 'readonly',
+        middleTableOnly: gate.sqlMode === 'middle-table',
+      },
+      ...credentialPlaceholder(gate.sqlServer),
+    })
+  }
+
+  return systems
+}
+
+function buildPipelines(gate, externalSystems) {
+  const plm = externalSystems.find((system) => system.name === 'live-poc-plm-source')
+  const k3 = externalSystems.find((system) => system.name === 'live-poc-k3-wise-target')
+  const materialMappings = gate.fieldMappings.material.map(normalizeMaterialMapping)
+
+  const pipelines = [
+    {
+      name: 'live-poc-plm-material-to-k3-wise-save-only',
+      tenantId: gate.tenantId,
+      workspaceId: gate.workspaceId,
+      projectId: gate.projectId,
+      description: 'M2 live PoC material Save-only pipeline generated from GATE answers.',
+      sourceSystemName: plm.name,
+      targetSystemName: k3.name,
+      sourceObject: 'materials',
+      targetObject: 'material',
+      mode: 'manual',
+      status: 'draft',
+      idempotencyKeyFields: ['sourceSystemId', 'objectType', 'sourceId', 'revision'],
+      options: {
+        writeMode: 'saveOnly',
+        sampleLimit: gate.k3Wise.sampleLimit || 3,
+        advanceWatermarkOnPartialFailure: false,
+        target: {
+          autoSubmit: false,
+          autoAudit: false,
+        },
+      },
+      fieldMappings: materialMappings,
+    },
+  ]
+
+  if (gate.bom.enabled === true) {
+    pipelines.push({
+      name: 'live-poc-plm-bom-to-k3-wise-save-only',
+      tenantId: gate.tenantId,
+      workspaceId: gate.workspaceId,
+      projectId: gate.projectId,
+      description: 'M2 live PoC simple BOM Save-only pipeline generated from GATE answers.',
+      sourceSystemName: plm.name,
+      targetSystemName: k3.name,
+      sourceObject: 'bom',
+      targetObject: 'bom',
+      mode: 'manual',
+      status: 'draft',
+      idempotencyKeyFields: ['sourceSystemId', 'objectType', 'sourceId', 'revision'],
+      options: {
+        writeMode: 'saveOnly',
+        sampleLimit: 1,
+        advanceWatermarkOnPartialFailure: false,
+        source: {
+          filters: {
+            productId: gate.bom.productId,
+          },
+        },
+        target: {
+          autoSubmit: false,
+          autoAudit: false,
+        },
+      },
+      fieldMappings: optionalArray(gate.fieldMappings.bom, 'fieldMappings.bom').map((mapping, index) => ({
+        ...normalizeMaterialMapping(mapping, index),
+      })),
+    })
+  }
+
+  return pipelines
+}
+
+function buildChecklist(gate) {
+  const base = [
+    { id: 'GATE-01', status: 'ready', check: 'Customer GATE answers archived and secrets stored outside Git.' },
+    { id: 'CONN-01', status: 'todo', check: 'Create PLM external system, then run testConnection.' },
+    { id: 'CONN-02', status: 'todo', check: 'Create K3 WISE test-account external system, then run testConnection.' },
+    { id: 'DRY-01', status: 'todo', check: 'Create material pipeline and run dry-run for 1-3 rows.' },
+    { id: 'SAVE-01', status: 'todo', check: 'Run material Save-only with autoSubmit=false and autoAudit=false.' },
+    { id: 'FAIL-01', status: 'todo', check: 'Verify one controlled failure enters dead letter and can replay after correction.' },
+    { id: 'ROLLBACK-01', status: 'todo', check: `Execute rollback SOP owner=${gate.rollback.owner}, strategy=${gate.rollback.strategy}.` },
+  ]
+  if (gate.bom.enabled === true) {
+    base.splice(5, 0, {
+      id: 'BOM-01',
+      status: 'todo',
+      check: 'Run simple BOM PoC using config.defaultProductId or direct filters.productId only.',
+    })
+  }
+  return base
+}
+
+function buildPacket(input, { generatedAt = new Date().toISOString() } = {}) {
+  const gate = normalizeGate(input)
+  const secrets = collectSecretValues(input)
+  const externalSystems = buildExternalSystems(gate)
+  const pipelines = buildPipelines(gate, externalSystems)
+  const packet = {
+    schemaVersion: 1,
+    generatedAt,
+    tenantId: gate.tenantId,
+    workspaceId: gate.workspaceId,
+    projectId: gate.projectId,
+    operator: gate.operator,
+    status: 'preflight-ready',
+    safety: {
+      environment: gate.k3Wise.environment,
+      saveOnly: true,
+      autoSubmit: false,
+      autoAudit: false,
+      sqlServerMode: gate.sqlMode,
+      productionWriteBlocked: true,
+    },
+    gateSummary: {
+      k3Wise: {
+        version: gate.k3Wise.version,
+        apiUrl: validateUrl(gate.k3Wise.apiUrl || gate.k3Wise.baseUrl, 'k3Wise.apiUrl'),
+        acctId: gate.k3Wise.acctId,
+        environment: gate.k3Wise.environment,
+      },
+      plm: {
+        kind: gate.plm.kind || 'plm:yuantus-wrapper',
+        readMethod: gate.plm.readMethod,
+        baseUrl: optionalString(gate.plm.baseUrl) || null,
+      },
+      rollback: redact(gate.rollback),
+    },
+    externalSystems,
+    pipelines,
+    checklist: buildChecklist(gate),
+    notes: [
+      'This packet is safe to commit only after confirming no customer secrets are present.',
+      'Use the credentials placeholders when creating external systems; do not paste secrets into MD evidence.',
+      'BOM product scope is carried by PLM config.defaultProductId or direct adapter filters.productId.',
+      'Do not use pipeline.options.source.productId.',
+    ],
+  }
+
+  assertNoSecretStrings(packet, secrets)
+  return packet
+}
+
+function renderMarkdown(packet) {
+  const lines = [
+    `# K3 WISE Live PoC Packet - ${packet.generatedAt.slice(0, 10)}`,
+    '',
+    '## Summary',
+    '',
+    `- Status: ${packet.status}`,
+    `- Tenant: ${packet.tenantId}`,
+    `- Workspace: ${packet.workspaceId}`,
+    `- K3 environment: ${packet.safety.environment}`,
+    `- Save-only: ${packet.safety.saveOnly}`,
+    `- Auto Submit: ${packet.safety.autoSubmit}`,
+    `- Auto Audit: ${packet.safety.autoAudit}`,
+    `- SQL Server mode: ${packet.safety.sqlServerMode}`,
+    '',
+    '## External Systems',
+    '',
+    '| Name | Kind | Role | Status | Credential keys |',
+    '|---|---|---|---|---|',
+    ...packet.externalSystems.map((system) => `| ${system.name} | ${system.kind} | ${system.role} | ${system.status} | ${(system.requiredCredentialKeys || []).join(', ') || 'none'} |`),
+    '',
+    '## Pipelines',
+    '',
+    '| Name | Source object | Target object | Mode | Status |',
+    '|---|---|---|---|---|',
+    ...packet.pipelines.map((pipeline) => `| ${pipeline.name} | ${pipeline.sourceObject} | ${pipeline.targetObject} | ${pipeline.mode} | ${pipeline.status} |`),
+    '',
+    '## Checklist',
+    '',
+    '| ID | Status | Check |',
+    '|---|---|---|',
+    ...packet.checklist.map((item) => `| ${item.id} | ${item.status} | ${item.check} |`),
+    '',
+    '## Safety Notes',
+    '',
+    ...packet.notes.map((note) => `- ${note}`),
+    '',
+  ]
+  return `${lines.join('\n')}\n`
+}
+
+function parseArgs(argv) {
+  const args = { outDir: 'artifacts/integration-live-poc', printSample: false }
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    if (arg === '--input') {
+      args.input = argv[++i]
+    } else if (arg === '--out-dir') {
+      args.outDir = argv[++i]
+    } else if (arg === '--print-sample') {
+      args.printSample = true
+    } else if (arg === '--help' || arg === '-h') {
+      args.help = true
+    } else {
+      throw new LivePocPreflightError(`unknown argument: ${arg}`)
+    }
+  }
+  return args
+}
+
+function sampleGate() {
+  return {
+    tenantId: 'tenant-test',
+    workspaceId: 'workspace-test',
+    operator: 'integration-admin',
+    k3Wise: {
+      version: 'K3 WISE 15.x test',
+      apiUrl: 'https://k3.example.test/K3API/',
+      acctId: 'AIS_TEST',
+      environment: 'test',
+      credentials: {
+        username: 'k3-test-user',
+        password: '<fill-outside-git>',
+      },
+      autoSubmit: false,
+      autoAudit: false,
+    },
+    plm: {
+      kind: 'plm:yuantus-wrapper',
+      readMethod: 'api',
+      baseUrl: 'https://plm.example.test/',
+      defaultProductId: 'PRODUCT-TEST-001',
+      credentials: {
+        username: 'plm-test-user',
+        password: '<fill-outside-git>',
+      },
+    },
+    sqlServer: {
+      enabled: true,
+      mode: 'readonly',
+      server: '10.0.0.10',
+      database: 'AIS_TEST',
+      allowedTables: ['t_ICItem', 't_MeasureUnit'],
+    },
+    rollback: {
+      owner: 'customer-k3-admin',
+      strategy: 'disable-test-records',
+    },
+    bom: {
+      enabled: true,
+    },
+    fieldMappings: {
+      material: [
+        { sourceField: 'code', targetField: 'FNumber', transform: { type: 'upperTrim' }, validation: [{ type: 'required' }] },
+        { sourceField: 'name', targetField: 'FName', validation: [{ type: 'required' }] },
+        { sourceField: 'uom', targetField: 'FBaseUnitID', transform: { type: 'dictMap', dictionary: 'unit' } },
+      ],
+      bom: [
+        { sourceField: 'parentCode', targetField: 'FParentItemNumber', validation: [{ type: 'required' }] },
+        { sourceField: 'childCode', targetField: 'FChildItems[].FItemNumber', validation: [{ type: 'required' }] },
+        { sourceField: 'quantity', targetField: 'FChildItems[].FQty', transform: { type: 'toNumber' } },
+      ],
+    },
+  }
+}
+
+async function runCli(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv)
+  if (args.help) {
+    console.log('Usage: node scripts/ops/integration-k3wise-live-poc-preflight.mjs --input gate.json --out-dir artifacts/integration-live-poc')
+    console.log('       node scripts/ops/integration-k3wise-live-poc-preflight.mjs --print-sample')
+    return 0
+  }
+  if (args.printSample) {
+    console.log(JSON.stringify(sampleGate(), null, 2))
+    return 0
+  }
+  if (!args.input) {
+    throw new LivePocPreflightError('--input is required')
+  }
+
+  const raw = await readFile(args.input, 'utf8')
+  const gate = JSON.parse(raw)
+  const packet = buildPacket(gate)
+  const outDir = path.resolve(args.outDir)
+  await mkdir(outDir, { recursive: true })
+  const jsonPath = path.join(outDir, 'integration-k3wise-live-poc-packet.json')
+  const mdPath = path.join(outDir, 'integration-k3wise-live-poc-packet.md')
+  await writeFile(jsonPath, `${JSON.stringify(packet, null, 2)}\n`)
+  await writeFile(mdPath, renderMarkdown(packet))
+  console.log(JSON.stringify({
+    ok: true,
+    jsonPath,
+    mdPath,
+    status: packet.status,
+    externalSystems: packet.externalSystems.length,
+    pipelines: packet.pipelines.length,
+  }, null, 2))
+  return 0
+}
+
+const entryPath = process.argv[1] ? pathToFileURL(path.resolve(process.argv[1])).href : null
+if (entryPath && import.meta.url === entryPath) {
+  runCli().catch((error) => {
+    const body = error instanceof LivePocPreflightError
+      ? { ok: false, code: error.name, message: error.message, details: error.details }
+      : { ok: false, code: error && error.name ? error.name : 'Error', message: error && error.message ? error.message : String(error) }
+    console.error(JSON.stringify(body, null, 2))
+    process.exitCode = 1
+  })
+}
+
+export {
+  LivePocPreflightError,
+  buildPacket,
+  collectSecretValues,
+  normalizeGate,
+  redact,
+  renderMarkdown,
+  runCli,
+  sampleGate,
+}

--- a/scripts/ops/integration-k3wise-live-poc-preflight.test.mjs
+++ b/scripts/ops/integration-k3wise-live-poc-preflight.test.mjs
@@ -1,0 +1,131 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+
+import {
+  LivePocPreflightError,
+  buildPacket,
+  renderMarkdown,
+  runCli,
+  sampleGate,
+} from './integration-k3wise-live-poc-preflight.mjs'
+
+function gate(overrides = {}) {
+  return {
+    ...sampleGate(),
+    ...overrides,
+    k3Wise: {
+      ...sampleGate().k3Wise,
+      ...(overrides.k3Wise || {}),
+    },
+    plm: {
+      ...sampleGate().plm,
+      ...(overrides.plm || {}),
+    },
+    sqlServer: {
+      ...sampleGate().sqlServer,
+      ...(overrides.sqlServer || {}),
+    },
+    rollback: {
+      ...sampleGate().rollback,
+      ...(overrides.rollback || {}),
+    },
+    bom: {
+      ...sampleGate().bom,
+      ...(overrides.bom || {}),
+    },
+    fieldMappings: {
+      ...sampleGate().fieldMappings,
+      ...(overrides.fieldMappings || {}),
+    },
+  }
+}
+
+test('buildPacket emits Save-only external systems, pipelines, and BOM product scope', () => {
+  const packet = buildPacket(gate(), { generatedAt: '2026-04-25T00:00:00.000Z' })
+  assert.equal(packet.status, 'preflight-ready')
+  assert.equal(packet.safety.saveOnly, true)
+  assert.equal(packet.safety.autoSubmit, false)
+  assert.equal(packet.safety.autoAudit, false)
+
+  const k3 = packet.externalSystems.find((system) => system.kind === 'erp:k3-wise-webapi')
+  assert.ok(k3)
+  assert.equal(k3.config.autoSubmit, false)
+  assert.equal(k3.config.autoAudit, false)
+  assert.equal(k3.credentials.password, '<set-at-runtime>')
+  assert.deepEqual(k3.requiredCredentialKeys, ['acctId', 'password', 'username'])
+
+  const plm = packet.externalSystems.find((system) => system.kind === 'plm:yuantus-wrapper')
+  assert.equal(plm.config.defaultProductId, 'PRODUCT-TEST-001')
+
+  const bom = packet.pipelines.find((pipeline) => pipeline.targetObject === 'bom')
+  assert.equal(bom.options.source.filters.productId, 'PRODUCT-TEST-001')
+  assert.equal(bom.options.source.productId, undefined)
+})
+
+test('buildPacket blocks production K3 WISE environments', () => {
+  assert.throws(
+    () => buildPacket(gate({ k3Wise: { environment: 'production' } })),
+    (error) => error instanceof LivePocPreflightError && error.details.field === 'k3Wise.environment',
+  )
+})
+
+test('buildPacket blocks Submit/Audit automation in live PoC packet', () => {
+  assert.throws(
+    () => buildPacket(gate({ k3Wise: { autoAudit: true } })),
+    (error) => error instanceof LivePocPreflightError && /Save-only/.test(error.message),
+  )
+})
+
+test('buildPacket blocks SQL Server writes to K3 core business tables', () => {
+  assert.throws(
+    () => buildPacket(gate({
+      sqlServer: {
+        enabled: true,
+        mode: 'middle-table',
+        allowedTables: ['t_ICItem'],
+      },
+    })),
+    (error) => error instanceof LivePocPreflightError && error.details.field === 'sqlServer.allowedTables',
+  )
+})
+
+test('buildPacket requires BOM product scope when BOM PoC is enabled', () => {
+  assert.throws(
+    () => buildPacket(gate({
+      plm: { defaultProductId: undefined, config: {} },
+      bom: { enabled: true, productId: undefined },
+    })),
+    (error) => error instanceof LivePocPreflightError && error.details.field === 'bom.productId',
+  )
+})
+
+test('renderMarkdown and CLI outputs do not leak submitted secret values', async () => {
+  const input = gate({
+    k3Wise: { credentials: { username: 'k3-user', password: 'super-secret-k3' } },
+    plm: { credentials: { username: 'plm-user', password: 'super-secret-plm' } },
+  })
+  const packet = buildPacket(input, { generatedAt: '2026-04-25T00:00:00.000Z' })
+  const markdown = renderMarkdown(packet)
+  assert.equal(JSON.stringify(packet).includes('super-secret-k3'), false)
+  assert.equal(JSON.stringify(packet).includes('super-secret-plm'), false)
+  assert.equal(markdown.includes('super-secret-k3'), false)
+  assert.equal(markdown.includes('super-secret-plm'), false)
+
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'integration-live-poc-'))
+  try {
+    const inputPath = path.join(dir, 'gate.json')
+    await writeFile(inputPath, `${JSON.stringify(input, null, 2)}\n`)
+    await runCli(['--input', inputPath, '--out-dir', dir])
+    const json = await readFile(path.join(dir, 'integration-k3wise-live-poc-packet.json'), 'utf8')
+    const md = await readFile(path.join(dir, 'integration-k3wise-live-poc-packet.md'), 'utf8')
+    assert.equal(json.includes('super-secret-k3'), false)
+    assert.equal(json.includes('super-secret-plm'), false)
+    assert.equal(md.includes('super-secret-k3'), false)
+    assert.equal(md.includes('super-secret-plm'), false)
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary

Add the M2 live PoC preflight packet slice for PLM -> K3 WISE validation.

This PR does not connect to customer systems or add runtime write behavior. It adds a local operator preflight tool that turns customer GATE answers into a redacted JSON/MD execution packet, and blocks unsafe live-test inputs before external systems or pipelines are created.

## Changes

- Add `scripts/ops/integration-k3wise-live-poc-preflight.mjs`
  - validates non-production K3 WISE environment
  - blocks `autoSubmit=true` / `autoAudit=true`
  - blocks SQL Server writes to K3 core tables like `t_ICItem`, `t_ICBOM`, `t_ICBomChild`
  - requires BOM product scope via `bom.productId` or PLM default product id
  - redacts credential-like values from generated output
  - emits `integration-k3wise-live-poc-packet.json` and `.md`
- Add `scripts/ops/integration-k3wise-live-poc-preflight.test.mjs`
- Add live PoC design and verification docs
- Add preflight design and verification docs

## Verification

- `node --test scripts/ops/integration-k3wise-live-poc-preflight.test.mjs` -> 6/6 pass
- `node scripts/ops/integration-k3wise-live-poc-preflight.mjs --print-sample` -> sample parses as JSON
- `pnpm -F plugin-integration-core test` -> pass
- `node --import tsx scripts/validate-plugin-manifests.ts` -> 13/13 valid, 0 errors
- `git diff --check` -> pass

## Live-system boundary

This PR still does not prove real PLM or K3 WISE connectivity. Next step remains customer GATE intake, then test-account `testConnection`, dry-run, and 1-3 Save-only material writes.
