### PR TITLE
feat(approval): harden SLA scheduler leader takeover

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,7 @@ REDIS_URL=redis://localhost:6379
 # Approval SLA scheduler leader lock (optional, multi-replica deployments)
 # ENABLE_APPROVAL_SLA_LEADER_LOCK=true
 # APPROVAL_SLA_LEADER_LOCK_TTL_MS=30000
+# APPROVAL_SLA_LEADER_LOCK_RETRY_MS=10000
 
 # =============================================================================
 # OBSERVABILITY - Phase 5

--- a/docs/development/approval-sla-leader-retry-gauge-development-20260425.md
+++ b/docs/development/approval-sla-leader-retry-gauge-development-20260425.md
@@ -1,0 +1,51 @@
+# Approval SLA Leader Retry and Gauge Development - 2026-04-25
+
+## Context
+
+The first SLA leader-lock slice made the scheduler single-leader when Redis is enabled, but it intentionally left two operational gaps:
+
+- Followers did not attempt takeover after losing the initial election.
+- No Prometheus gauge exposed the current SLA scheduler leader state.
+
+This slice closes both gaps while preserving the existing opt-in behavior.
+
+## Changes
+
+- Added `retryIntervalMs` to `ApprovalSlaSchedulerLeaderOptions`.
+- Added follower retry loop that periodically re-attempts lock acquisition while the scheduler is started.
+- Restarted retry after renewal loss so a relinquished node can recover after the lock becomes available again.
+- Added injected `ApprovalSlaSchedulerLeaderGauge` runtime option.
+- Added `approval_sla_scheduler_leader{state="leader|follower|relinquished"}` Prometheus gauge.
+- Wired `MetaSheetServer.start()` to pass the shared metrics gauge into `startApprovalSlaScheduler()`.
+- Added `APPROVAL_SLA_LEADER_LOCK_RETRY_MS` to environment templates.
+
+## Design Notes
+
+- The feature remains behind `ENABLE_APPROVAL_SLA_LEADER_LOCK=true`.
+- Retry runs only after `start()`; constructing a scheduler no longer implies permanent background takeover attempts.
+- A successful retry stops the acquisition loop, starts renewal, and starts the normal SLA tick interval if the scheduler is still started.
+- Gauge writes are best-effort and cannot break scheduler behavior.
+- The gauge mirrors the existing automation scheduler shape so operators can use the same alerting pattern.
+
+## Configuration
+
+```bash
+ENABLE_APPROVAL_SLA_LEADER_LOCK=true
+APPROVAL_SLA_LEADER_LOCK_TTL_MS=30000
+APPROVAL_SLA_LEADER_LOCK_RETRY_MS=10000
+```
+
+## Explicit Non-Goals
+
+- No live Redis integration test in this slice.
+- No fail-closed behavior when Redis is unavailable; existing legacy fallback remains unchanged.
+- No changes to SLA breach SQL or notification/audit hooks.
+
+## Files
+
+- `.env.example`
+- `packages/core-backend/.env.development.example`
+- `packages/core-backend/src/index.ts`
+- `packages/core-backend/src/metrics/metrics.ts`
+- `packages/core-backend/src/services/ApprovalSlaScheduler.ts`
+- `packages/core-backend/tests/unit/approval-sla-scheduler.test.ts`

--- a/docs/development/approval-sla-leader-retry-gauge-verification-20260425.md
+++ b/docs/development/approval-sla-leader-retry-gauge-verification-20260425.md
@@ -1,0 +1,27 @@
+# Approval SLA Leader Retry and Gauge Verification - 2026-04-25
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-sla-scheduler.test.ts tests/unit/redis-leader-lock.test.ts --reporter=verbose
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+```
+
+## Results
+
+- `approval-sla-scheduler.test.ts` + `redis-leader-lock.test.ts`: 23/23 passed.
+- Backend TypeScript check: passed with exit code 0.
+
+## Covered Scenarios
+
+- Existing SLA tick behavior and error swallowing still pass.
+- Only the leader scans; followers skip work.
+- `stop()` releases the leader lock.
+- A follower retries acquisition and takes over after the leader stops.
+- Injected gauge transitions through `leader`, `follower`, and `relinquished` states.
+- Existing Redis leader-lock owner/renew/release semantics remain covered.
+
+## Not Run
+
+- Live Redis smoke. The scheduler integration is covered with `MemoryLeaderLockClient`; live Redis can be added as an ops smoke when the flag is enabled in staging.
+- Full backend suite. The focused scheduler/leader tests plus typecheck were used as the local gate.

--- a/packages/core-backend/.env.development.example
+++ b/packages/core-backend/.env.development.example
@@ -6,5 +6,6 @@ REDIS_URL=redis://localhost:6379
 # Optional: only one replica runs approval SLA scans when enabled.
 # ENABLE_APPROVAL_SLA_LEADER_LOCK=true
 # APPROVAL_SLA_LEADER_LOCK_TTL_MS=30000
+# APPROVAL_SLA_LEADER_LOCK_RETRY_MS=10000
 JWT_SECRET=your-dev-secret-key-here
 CORS_ORIGIN=http://localhost:8899

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -1904,7 +1904,10 @@ export class MetaSheetServer {
 
     try {
       const leaderOptions = await resolveApprovalSlaSchedulerLeaderOptions()
-      startApprovalSlaScheduler({ leaderOptions })
+      startApprovalSlaScheduler({
+        leaderOptions,
+        runtime: { leaderStateGauge: promMetrics.approvalSlaSchedulerLeaderGauge },
+      })
       this.logger.info('Approval SLA scheduler initialized')
     } catch (e) {
       this.logger.error('Approval SLA scheduler initialization failed; continuing in degraded mode', e as Error)

--- a/packages/core-backend/src/metrics/metrics.ts
+++ b/packages/core-backend/src/metrics/metrics.ts
@@ -450,6 +450,12 @@ const automationSchedulerLeaderGauge = new client.Gauge({
   labelNames: ['state'] as const
 })
 
+const approvalSlaSchedulerLeaderGauge = new client.Gauge({
+  name: 'approval_sla_scheduler_leader',
+  help: 'ApprovalSlaScheduler leader-lock state (1=current state, 0=other)',
+  labelNames: ['state'] as const
+})
+
 registry.registerMetric(httpHistogram)
 registry.registerMetric(httpSummary)
 registry.registerMetric(httpRequestsTotal)
@@ -519,6 +525,7 @@ registry.registerMetric(metricsStreamErrorsTotal)
 registry.registerMetric(apigwCbStoreUsedTotal)
 registry.registerMetric(apigwCbInitTotal)
 registry.registerMetric(automationSchedulerLeaderGauge)
+registry.registerMetric(approvalSlaSchedulerLeaderGauge)
 
 function trimConfiguredMetricsToken(raw: string | undefined): string | null {
   const token = typeof raw === 'string' ? raw.trim() : ''
@@ -665,7 +672,8 @@ export const metrics = {
   // APIGateway + CircuitBreaker (Lane 3 / collab-infra rollout)
   apigwCbStoreUsedTotal,
   apigwCbInitTotal,
-  automationSchedulerLeaderGauge
+  automationSchedulerLeaderGauge,
+  approvalSlaSchedulerLeaderGauge
 }
 
 /**

--- a/packages/core-backend/src/services/ApprovalSlaScheduler.ts
+++ b/packages/core-backend/src/services/ApprovalSlaScheduler.ts
@@ -21,6 +21,7 @@ export interface ApprovalSlaSchedulerOptions {
   metrics?: ApprovalMetricsService
   intervalMs?: number
   leaderOptions?: ApprovalSlaSchedulerLeaderOptions | null
+  runtime?: ApprovalSlaSchedulerRuntimeOptions
   /**
    * Optional hook invoked once per breach cycle with the newly-breached
    * instance ids. Main caller wires it to approval audit + notifications.
@@ -35,6 +36,17 @@ export interface ApprovalSlaSchedulerLeaderOptions {
   ownerId: string
   ttlMs?: number
   renewIntervalMs?: number
+  retryIntervalMs?: number
+}
+
+export interface ApprovalSlaSchedulerLeaderGauge {
+  labels(labels: {
+    state: 'leader' | 'follower' | 'relinquished'
+  }): { set(value: number): void }
+}
+
+export interface ApprovalSlaSchedulerRuntimeOptions {
+  leaderStateGauge?: ApprovalSlaSchedulerLeaderGauge
 }
 
 export class ApprovalSlaScheduler {
@@ -45,9 +57,12 @@ export class ApprovalSlaScheduler {
   private readonly lockKey: string
   private readonly ttlMs: number
   private readonly renewIntervalMs: number
+  private readonly retryIntervalMs: number
+  private readonly leaderStateGauge: ApprovalSlaSchedulerLeaderGauge | null
   private readonly onBreach: ApprovalSlaSchedulerOptions['onBreach']
   private timer: NodeJS.Timeout | null = null
   private renewalTimer: NodeJS.Timeout | null = null
+  private acquisitionTimer: NodeJS.Timeout | null = null
   private running = false
   private started = false
   private isLeader = false
@@ -60,15 +75,20 @@ export class ApprovalSlaScheduler {
     this.lockKey = this.leaderOptions?.lockKey ?? 'approval-sla-scheduler:leader'
     this.ttlMs = this.leaderOptions?.ttlMs ?? DEFAULT_LOCK_TTL_MS
     this.renewIntervalMs = this.leaderOptions?.renewIntervalMs ?? Math.max(1_000, Math.floor(this.ttlMs / 3))
+    this.retryIntervalMs = this.leaderOptions?.retryIntervalMs ?? Math.max(1_000, Math.floor(this.ttlMs / 3))
+    this.leaderStateGauge = options.runtime?.leaderStateGauge ?? null
     this.onBreach = options.onBreach
     this.logger = options.logger ?? new Logger('ApprovalSlaScheduler')
     if (this.leaderOptions) {
+      this.setLeaderGauge('follower')
       this.ready = this.attemptLeadership().catch((error) => {
         this.isLeader = false
+        this.setLeaderGauge('follower')
         this.logger.warn(`SLA leader-lock acquisition failed: ${error instanceof Error ? error.message : String(error)}`)
       })
     } else {
       this.isLeader = true
+      this.setLeaderGauge('leader')
       this.ready = Promise.resolve()
     }
   }
@@ -77,10 +97,12 @@ export class ApprovalSlaScheduler {
     if (this.started) return
     this.started = true
     this.ready.then(() => {
-      if (!this.started || !this.isLeader || this.timer) return
-      this.logger.info(`SLA scheduler starting with interval ${this.intervalMs}ms`)
-      this.timer = setInterval(() => { void this.tick() }, this.intervalMs)
-      if (typeof this.timer.unref === 'function') this.timer.unref()
+      if (!this.started) return
+      if (this.isLeader) {
+        this.startTickLoop()
+      } else {
+        this.startAcquisitionRetryLoop()
+      }
     }).catch((error) => {
       this.logger.warn(`SLA scheduler start skipped after leader-lock error: ${error instanceof Error ? error.message : String(error)}`)
     })
@@ -96,11 +118,16 @@ export class ApprovalSlaScheduler {
       clearInterval(this.renewalTimer)
       this.renewalTimer = null
     }
+    if (this.acquisitionTimer) {
+      clearInterval(this.acquisitionTimer)
+      this.acquisitionTimer = null
+    }
     if (this.leaderOptions && this.isLeader) {
       const { leaderLock, ownerId } = this.leaderOptions
       leaderLock.release(this.lockKey, ownerId).catch(() => {})
       this.isLeader = false
     }
+    this.setLeaderGauge('relinquished')
     this.logger.info('SLA scheduler stopped')
   }
 
@@ -140,10 +167,50 @@ export class ApprovalSlaScheduler {
     this.isLeader = won
     if (won) {
       this.logger.info(`Acquired SLA scheduler leader lock ${this.lockKey} (owner=${ownerId}, ttl=${this.ttlMs}ms)`)
+      this.setLeaderGauge('leader')
+      this.stopAcquisitionRetryLoop()
       this.startRenewalLoop()
+      if (this.started) this.startTickLoop()
     } else {
       this.logger.info(`Did not acquire SLA scheduler leader lock ${this.lockKey}; operating as non-leader (owner=${ownerId})`)
+      this.setLeaderGauge('follower')
     }
+  }
+
+  private setLeaderGauge(state: 'leader' | 'follower' | 'relinquished'): void {
+    if (!this.leaderStateGauge) return
+    try {
+      for (const candidate of ['leader', 'follower', 'relinquished'] as const) {
+        this.leaderStateGauge.labels({ state: candidate }).set(candidate === state ? 1 : 0)
+      }
+    } catch {
+      // Metrics failures must not break the scheduler.
+    }
+  }
+
+  private startTickLoop(): void {
+    if (!this.started || !this.isLeader || this.timer) return
+    this.logger.info(`SLA scheduler starting with interval ${this.intervalMs}ms`)
+    this.timer = setInterval(() => { void this.tick() }, this.intervalMs)
+    if (typeof this.timer.unref === 'function') this.timer.unref()
+  }
+
+  private startAcquisitionRetryLoop(): void {
+    if (!this.leaderOptions || this.acquisitionTimer || this.isLeader) return
+    this.acquisitionTimer = setInterval(() => {
+      this.attemptLeadership().catch((error) => {
+        this.isLeader = false
+        this.setLeaderGauge('follower')
+        this.logger.warn(`SLA leader-lock retry failed: ${error instanceof Error ? error.message : String(error)}`)
+      })
+    }, this.retryIntervalMs)
+    if (typeof this.acquisitionTimer.unref === 'function') this.acquisitionTimer.unref()
+  }
+
+  private stopAcquisitionRetryLoop(): void {
+    if (!this.acquisitionTimer) return
+    clearInterval(this.acquisitionTimer)
+    this.acquisitionTimer = null
   }
 
   private startRenewalLoop(): void {
@@ -168,6 +235,7 @@ export class ApprovalSlaScheduler {
     if (!this.isLeader) return
     this.logger.warn(`Relinquishing SLA scheduler leadership (${reason})`)
     this.isLeader = false
+    this.setLeaderGauge('relinquished')
     if (this.timer) {
       clearInterval(this.timer)
       this.timer = null
@@ -176,6 +244,7 @@ export class ApprovalSlaScheduler {
       clearInterval(this.renewalTimer)
       this.renewalTimer = null
     }
+    if (this.started) this.startAcquisitionRetryLoop()
   }
 }
 
@@ -203,9 +272,13 @@ export async function resolveApprovalSlaSchedulerLeaderOptions(): Promise<Approv
   const ttlMs = Number(process.env.APPROVAL_SLA_LEADER_LOCK_TTL_MS) > 0
     ? Number(process.env.APPROVAL_SLA_LEADER_LOCK_TTL_MS)
     : DEFAULT_LOCK_TTL_MS
+  const retryIntervalMs = Number(process.env.APPROVAL_SLA_LEADER_LOCK_RETRY_MS) > 0
+    ? Number(process.env.APPROVAL_SLA_LEADER_LOCK_RETRY_MS)
+    : undefined
   return {
     leaderLock: new RedisLeaderLock({ client: redis as unknown as RedisLeaderLockClient }),
     ownerId: `approval-sla:${process.pid}:${randomBytes(4).toString('hex')}`,
     ttlMs,
+    retryIntervalMs,
   }
 }

--- a/packages/core-backend/tests/unit/approval-sla-scheduler.test.ts
+++ b/packages/core-backend/tests/unit/approval-sla-scheduler.test.ts
@@ -111,4 +111,64 @@ describe('ApprovalSlaScheduler', () => {
     expect(second.leader).toBe(true)
     second.stop()
   })
+
+  it('retries acquisition as follower and takes over after the leader stops', async () => {
+    const store = new Map()
+    const leaderLock = new RedisLeaderLock({ client: new MemoryLeaderLockClient(store) })
+    const followerLock = new RedisLeaderLock({ client: new MemoryLeaderLockClient(store) })
+    const leaderCheck = vi.fn().mockResolvedValue([])
+    const followerCheck = vi.fn().mockResolvedValue(['apr-takeover'])
+
+    const leader = new ApprovalSlaScheduler({
+      // biome-ignore lint/suspicious/noExplicitAny: test double
+      metrics: { checkSlaBreaches: leaderCheck } as any,
+      leaderOptions: { leaderLock, ownerId: 'node-a', ttlMs: 30_000, retryIntervalMs: 100 },
+    })
+    const follower = new ApprovalSlaScheduler({
+      // biome-ignore lint/suspicious/noExplicitAny: test double
+      metrics: { checkSlaBreaches: followerCheck } as any,
+      intervalMs: 60_000,
+      leaderOptions: { leaderLock: followerLock, ownerId: 'node-b', ttlMs: 30_000, retryIntervalMs: 100 },
+    })
+    follower.start()
+    await Promise.all([leader.ready, follower.ready])
+
+    expect(leader.leader).toBe(true)
+    expect(follower.leader).toBe(false)
+
+    leader.stop()
+    await vi.advanceTimersByTimeAsync(120)
+
+    expect(follower.leader).toBe(true)
+    expect(await follower.tick(new Date('2026-04-25T10:00:00Z'))).toEqual(['apr-takeover'])
+    expect(followerCheck).toHaveBeenCalledTimes(1)
+    follower.stop()
+  })
+
+  it('updates the injected leader gauge across follower, leader, and relinquished states', async () => {
+    const values = new Map<string, number>()
+    const gauge = {
+      labels: ({ state }: { state: 'leader' | 'follower' | 'relinquished' }) => ({
+        set: (value: number) => { values.set(state, value) },
+      }),
+    }
+    const lock = new RedisLeaderLock({ client: new MemoryLeaderLockClient(new Map()) })
+
+    const scheduler = new ApprovalSlaScheduler({
+      // biome-ignore lint/suspicious/noExplicitAny: test double
+      metrics: { checkSlaBreaches: vi.fn().mockResolvedValue([]) } as any,
+      leaderOptions: { leaderLock: lock, ownerId: 'node-a', ttlMs: 30_000 },
+      runtime: { leaderStateGauge: gauge },
+    })
+    await scheduler.ready
+
+    expect(values.get('leader')).toBe(1)
+    expect(values.get('follower')).toBe(0)
+    expect(values.get('relinquished')).toBe(0)
+
+    scheduler.stop()
+    expect(values.get('leader')).toBe(0)
+    expect(values.get('follower')).toBe(0)
+    expect(values.get('relinquished')).toBe(1)
+  })
 })


### PR DESCRIPTION
## Summary
- Add follower retry loop for ApprovalSlaScheduler leader-lock takeover.
- Add approval_sla_scheduler_leader Prometheus gauge.
- Wire scheduler runtime gauge and document APPROVAL_SLA_LEADER_LOCK_RETRY_MS.

## Verification
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-sla-scheduler.test.ts tests/unit/redis-leader-lock.test.ts --reporter=verbose
- pnpm --filter @metasheet/core-backend exec tsc --noEmit

## Docs
- docs/development/approval-sla-leader-retry-gauge-development-20260425.md
- docs/development/approval-sla-leader-retry-gauge-verification-20260425.md