### PR TITLE
feat(events): enrich publishes from request context

### DIFF
--- a/docs/development/eventbus-request-context-correlation-development-20260425.md
+++ b/docs/development/eventbus-request-context-correlation-development-20260425.md
@@ -1,0 +1,34 @@
+# EventBus Request Context Correlation Development - 2026-04-25
+
+## Context
+
+Correlation context now carries `correlationId`, `userId`, and `tenantId` after authentication. Logs can use that context, but EventBus publishers still had to pass `correlation_id` manually or events would lose request attribution.
+
+This slice makes EventBus publish inherit request context by default while preserving explicit caller overrides.
+
+## Changes
+
+- Imported `getRequestContext()` in `EventBusService`.
+- Added a small enrichment helper for publish options.
+- Defaulted `event.correlation_id` from the active request context.
+- Added `metadata.user_id` and `metadata.tenant_id` from request context when callers did not already provide those keys.
+- Added focused unit coverage for default enrichment, explicit overrides, and no-context behavior.
+
+## Design Notes
+
+- Explicit `options.correlation_id` wins over the request context.
+- Explicit `metadata.user_id` and `metadata.tenant_id` win over the request context.
+- Events outside a request context remain unchanged.
+- The metadata key names match the logger's snake_case metadata shape.
+
+## Explicit Non-Goals
+
+- No event schema changes.
+- No database migration.
+- No changes to replay behavior.
+- No attempt to inject request context into low-level `EventEmitter.emit()` calls; only `EventBusService.publish()` is enriched.
+
+## Files
+
+- `packages/core-backend/src/core/EventBusService.ts`
+- `packages/core-backend/tests/unit/eventbus-request-context.test.ts`

--- a/docs/development/eventbus-request-context-correlation-verification-20260425.md
+++ b/docs/development/eventbus-request-context-correlation-verification-20260425.md
@@ -1,0 +1,25 @@
+# EventBus Request Context Correlation Verification - 2026-04-25
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/eventbus-request-context.test.ts tests/unit/correlation.test.ts --reporter=verbose
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+```
+
+## Results
+
+- `eventbus-request-context.test.ts` + `correlation.test.ts`: 19/19 passed.
+- Backend TypeScript check: passed with exit code 0.
+
+## Covered Scenarios
+
+- Published events inherit `correlation_id`, `metadata.user_id`, and `metadata.tenant_id` from `runWithRequestContext()`.
+- Explicit publish options override request-context values.
+- Events published without request context retain the previous shape.
+- Existing correlation middleware tests still pass.
+
+## Not Run
+
+- Persistent EventBus integration against a real database. The new behavior is applied before persistence and is covered by the emitted event object in a DB-free unit test.
+- Full backend suite. Focused EventBus/correlation tests plus typecheck were used as the local gate.

--- a/packages/core-backend/src/core/EventBusService.ts
+++ b/packages/core-backend/src/core/EventBusService.ts
@@ -9,6 +9,7 @@ import { sql } from 'kysely'
 import { Logger } from './logger'
 import * as Ajv from 'ajv'
 import type { CoreAPI } from '../types/plugin'
+import { getRequestContext } from '../context/request-context'
 
 // JSON Schema type for event validation
 interface JSONSchema {
@@ -78,6 +79,31 @@ interface Event {
   payload: unknown
   metadata: Record<string, unknown>
   occurred_at: Date
+}
+
+function enrichEventFromRequestContext(
+  options?: {
+    correlation_id?: string
+    metadata?: Record<string, unknown>
+  },
+): {
+  correlation_id?: string
+  metadata: Record<string, unknown>
+} {
+  const requestContext = getRequestContext()
+  const metadata = { ...(options?.metadata || {}) }
+
+  if (requestContext?.userId && metadata.user_id === undefined) {
+    metadata.user_id = requestContext.userId
+  }
+  if (requestContext?.tenantId && metadata.tenant_id === undefined) {
+    metadata.tenant_id = requestContext.tenantId
+  }
+
+  return {
+    correlation_id: options?.correlation_id || requestContext?.correlationId,
+    metadata,
+  }
 }
 
 interface EventHandler {
@@ -217,16 +243,18 @@ export class EventBusService extends EventEmitter {
     // Validate event schema
     await this.validateEventSchema(eventName, payload)
 
+    const requestContextDefaults = enrichEventFromRequestContext(options)
+
     const event: Event = {
       event_id: eventId,
       event_name: eventName,
       event_version: '1.0.0',
       source_id: options?.source_id || 'system',
       source_type: options?.source_type || 'system',
-      correlation_id: options?.correlation_id,
+      correlation_id: requestContextDefaults.correlation_id,
       causation_id: options?.causation_id,
       payload,
-      metadata: options?.metadata || {},
+      metadata: requestContextDefaults.metadata,
       occurred_at: new Date()
     }
 

--- a/packages/core-backend/tests/unit/eventbus-request-context.test.ts
+++ b/packages/core-backend/tests/unit/eventbus-request-context.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { EventBusService } from '../../src/core/EventBusService'
+import { runWithRequestContext } from '../../src/context/request-context'
+
+function buildService(): EventBusService {
+  const service = new EventBusService()
+  const testable = service as unknown as {
+    validateEventSchema: ReturnType<typeof vi.fn>
+    getEventType: ReturnType<typeof vi.fn>
+  }
+  testable.validateEventSchema = vi.fn().mockResolvedValue(undefined)
+  testable.getEventType = vi.fn().mockResolvedValue({
+    id: 'evt-test',
+    event_name: 'approval.test',
+    category: 'test',
+    is_async: true,
+    is_persistent: false,
+    is_transactional: false,
+    max_retries: 0,
+    retry_delay_ms: 0,
+  })
+  return service
+}
+
+describe('EventBusService request-context enrichment', () => {
+  it('defaults event correlation and actor metadata from the active request context', async () => {
+    const service = buildService()
+    const emitted: unknown[] = []
+    service.on('approval.test', (event) => emitted.push(event))
+
+    await runWithRequestContext(
+      { correlationId: 'corr-123', userId: 'user-1', tenantId: 'tenant-a' },
+      () => service.publish('approval.test', { ok: true }, {
+        metadata: { source: 'unit' },
+      }),
+    )
+
+    expect(emitted).toHaveLength(1)
+    expect(emitted[0]).toMatchObject({
+      event_name: 'approval.test',
+      correlation_id: 'corr-123',
+      metadata: {
+        source: 'unit',
+        user_id: 'user-1',
+        tenant_id: 'tenant-a',
+      },
+    })
+  })
+
+  it('preserves explicit correlation and metadata overrides', async () => {
+    const service = buildService()
+    const emitted: unknown[] = []
+    service.on('approval.test', (event) => emitted.push(event))
+
+    await runWithRequestContext(
+      { correlationId: 'corr-request', userId: 'user-request', tenantId: 'tenant-request' },
+      () => service.publish('approval.test', { ok: true }, {
+        correlation_id: 'corr-explicit',
+        metadata: {
+          user_id: 'user-explicit',
+          tenant_id: 'tenant-explicit',
+        },
+      }),
+    )
+
+    expect(emitted[0]).toMatchObject({
+      correlation_id: 'corr-explicit',
+      metadata: {
+        user_id: 'user-explicit',
+        tenant_id: 'tenant-explicit',
+      },
+    })
+  })
+
+  it('keeps events outside a request context unchanged', async () => {
+    const service = buildService()
+    const emitted: unknown[] = []
+    service.on('approval.test', (event) => emitted.push(event))
+
+    await service.publish('approval.test', { ok: true }, {
+      metadata: { source: 'system' },
+    })
+
+    expect(emitted[0]).toMatchObject({
+      correlation_id: undefined,
+      metadata: { source: 'system' },
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Default EventBusService.publish correlation_id from active request context.
- Add request user/tenant metadata when callers do not explicitly provide them.
- Preserve explicit publish overrides and no-context behavior.

## Verification
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/eventbus-request-context.test.ts tests/unit/correlation.test.ts --reporter=verbose
- pnpm --filter @metasheet/core-backend exec tsc --noEmit

## Docs
- docs/development/eventbus-request-context-correlation-development-20260425.md
- docs/development/eventbus-request-context-correlation-verification-20260425.md