### PR TITLE
test(approval): cover SLA TopN report contracts

### DIFF
--- a/apps/web/tests/approvalMetricsTopnReport.spec.ts
+++ b/apps/web/tests/approvalMetricsTopnReport.spec.ts
@@ -1,0 +1,243 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  createApp,
+  defineComponent,
+  h,
+  inject,
+  nextTick,
+  provide,
+  reactive,
+  type App as VueApp,
+  type Slot,
+} from 'vue'
+
+const pushSpy = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('vue-router', async () => {
+  const actual = await vi.importActual<typeof import('vue-router')>('vue-router')
+  return {
+    ...actual,
+    useRouter: () => ({ push: pushSpy }),
+  }
+})
+
+const fetchSummarySpy = vi.fn().mockResolvedValue({
+  total: 2,
+  approved: 1,
+  rejected: 0,
+  revoked: 0,
+  returned: 0,
+  running: 1,
+  avgDurationSeconds: 3600,
+  p50DurationSeconds: 1800,
+  p95DurationSeconds: 7200,
+  slaBreachCount: 1,
+  slaCandidateCount: 2,
+  slaBreachRate: 0.5,
+  byTemplate: [],
+})
+const fetchBreachesSpy = vi.fn().mockResolvedValue([])
+const fetchReportSpy = vi.fn().mockResolvedValue({
+  summary: {},
+  slowestInstances: [{
+    instanceId: 'apr-slow-1',
+    templateId: 'tmpl-risk-1',
+    startedAt: '2026-04-25T08:00:00Z',
+    terminalAt: '2026-04-25T10:00:00Z',
+    terminalState: 'approved',
+    durationSeconds: 7200,
+    slaHours: 1,
+    slaBreached: true,
+    slaBreachedAt: '2026-04-25T09:00:00Z',
+  }],
+  breachedTemplates: [{
+    templateId: 'tmpl-risk-1',
+    total: 4,
+    slaCandidateCount: 4,
+    slaBreachCount: 2,
+    slaBreachRate: 0.5,
+    avgDurationSeconds: 1800,
+    p95DurationSeconds: 7200,
+  }],
+})
+
+vi.mock('../src/approvals/api', () => ({
+  fetchApprovalMetricsSummary: (query?: unknown) => fetchSummarySpy(query),
+  fetchApprovalMetricsBreaches: () => fetchBreachesSpy(),
+  fetchApprovalMetricsReport: (query?: unknown) => fetchReportSpy(query),
+}))
+
+type ColumnRegistryEntry = {
+  key: string
+  prop?: string
+  label?: string
+  defaultSlot?: Slot
+}
+type ColumnRegistry = {
+  columns: ColumnRegistryEntry[]
+  register: (entry: ColumnRegistryEntry) => void
+}
+const COLUMN_REGISTRY_KEY = Symbol('approval-metrics-table-columns')
+let columnSeq = 0
+
+const ElTable = defineComponent({
+  name: 'ElTable',
+  props: { data: Array, loading: Boolean, stripe: Boolean, emptyText: String },
+  setup(props, { slots }) {
+    const registry = reactive<ColumnRegistry>({
+      columns: [],
+      register(entry) {
+        registry.columns.push(entry)
+      },
+    })
+    provide(COLUMN_REGISTRY_KEY, registry)
+    return () => {
+      const columnInstances = slots.default?.() ?? []
+      const rows = (props.data as any[] | undefined) ?? []
+      return h('div', { 'data-el-table': 'true' }, [
+        h('div', { style: 'display:none' }, columnInstances),
+        ...rows.map((row, index) =>
+          h('div', { 'data-el-row': String(index) },
+            registry.columns.map((column) =>
+              h('div', { 'data-el-cell': column.prop || column.label || column.key },
+                column.defaultSlot ? column.defaultSlot({ row }) : String(row?.[column.prop ?? ''] ?? ''),
+              ),
+            ),
+          ),
+        ),
+      ])
+    }
+  },
+})
+
+const ElTableColumn = defineComponent({
+  name: 'ElTableColumn',
+  props: { prop: String, label: String, width: [String, Number], minWidth: [String, Number] },
+  setup(props, { slots }) {
+    const registry = inject<ColumnRegistry | null>(COLUMN_REGISTRY_KEY, null)
+    if (registry) {
+      registry.register({
+        key: `col-${columnSeq++}`,
+        prop: props.prop,
+        label: props.label,
+        defaultSlot: slots.default,
+      })
+    }
+    return () => null
+  },
+})
+
+const ElCard = defineComponent({
+  name: 'ElCard',
+  render() {
+    return h('section', { 'data-el-card': 'true' }, [
+      this.$slots.header?.(),
+      this.$slots.default?.(),
+    ])
+  },
+})
+
+const ElLink = defineComponent({
+  name: 'ElLink',
+  emits: ['click'],
+  render() {
+    return h('button', { type: 'button', onClick: () => this.$emit('click') }, this.$slots.default?.())
+  },
+})
+
+const ElButton = defineComponent({
+  name: 'ElButton',
+  emits: ['click'],
+  render() {
+    return h('button', { type: 'button', onClick: () => this.$emit('click') }, this.$slots.default?.())
+  },
+})
+
+const ElDatePicker = defineComponent({
+  name: 'ElDatePicker',
+  render() {
+    return h('input', { 'data-el-date-picker': 'true' })
+  },
+})
+
+const ElAlert = defineComponent({
+  name: 'ElAlert',
+  props: { title: String },
+  render() {
+    return h('div', { 'data-el-alert': 'true' }, this.title)
+  },
+})
+
+async function flushPromises(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+  await nextTick()
+}
+
+describe('ApprovalMetricsView TopN report', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    pushSpy.mockClear()
+    fetchSummarySpy.mockClear()
+    fetchBreachesSpy.mockClear()
+    fetchReportSpy.mockClear()
+    columnSeq = 0
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    app = null
+    container?.remove()
+    container = null
+  })
+
+  it('loads and renders TopN slowest instances and breached templates', async () => {
+    const { default: ApprovalMetricsView } = await import('../src/views/approval/ApprovalMetricsView.vue')
+    app = createApp(ApprovalMetricsView)
+    app.component('ElAlert', ElAlert)
+    app.component('ElButton', ElButton)
+    app.component('ElCard', ElCard)
+    app.component('ElDatePicker', ElDatePicker)
+    app.component('ElLink', ElLink)
+    app.component('ElTable', ElTable)
+    app.component('ElTableColumn', ElTableColumn)
+    app.directive('loading', {})
+    app.mount(container!)
+
+    await flushPromises()
+
+    expect(fetchReportSpy).toHaveBeenCalledWith({ limit: 10 })
+    expect(container!.textContent).toContain('TopN 最慢实例')
+    expect(container!.textContent).toContain('TopN SLA 风险模板')
+    expect(container!.textContent).toContain('apr-slow-1')
+    expect(container!.textContent).toContain('tmpl-risk-1')
+    expect(container!.textContent).toContain('2.00h')
+    expect(container!.textContent).toContain('50.0%')
+  })
+
+  it('routes from TopN row links to approval detail and template detail', async () => {
+    const { default: ApprovalMetricsView } = await import('../src/views/approval/ApprovalMetricsView.vue')
+    app = createApp(ApprovalMetricsView)
+    app.component('ElAlert', ElAlert)
+    app.component('ElButton', ElButton)
+    app.component('ElCard', ElCard)
+    app.component('ElDatePicker', ElDatePicker)
+    app.component('ElLink', ElLink)
+    app.component('ElTable', ElTable)
+    app.component('ElTableColumn', ElTableColumn)
+    app.directive('loading', {})
+    app.mount(container!)
+    await flushPromises()
+
+    const buttons = Array.from(container!.querySelectorAll('button'))
+    buttons.find((button) => button.textContent?.includes('apr-slow-1'))?.click()
+    buttons.find((button) => button.textContent?.includes('tmpl-risk-1'))?.click()
+
+    expect(pushSpy).toHaveBeenCalledWith({ name: 'approval-detail', params: { id: 'apr-slow-1' } })
+    expect(pushSpy).toHaveBeenCalledWith({ name: 'approval-template-detail', params: { id: 'tmpl-risk-1' } })
+  })
+})

--- a/docs/development/approval-sla-topn-contract-tests-development-20260425.md
+++ b/docs/development/approval-sla-topn-contract-tests-development-20260425.md
@@ -1,0 +1,36 @@
+# Approval SLA TopN Contract Tests Development - 2026-04-25
+
+## Context
+
+The TopN report implementation added the backend route, service method, frontend API, and dashboard tables. The implementation was verified at service/typecheck/OpenAPI level, but the route and Vue view contracts were not directly pinned.
+
+This slice adds the missing contract tests without changing runtime behavior.
+
+## Changes
+
+- Added `approval-metrics-router.test.ts` for `GET /api/approvals/metrics/report`.
+- Added `approvalMetricsTopnReport.spec.ts` for `ApprovalMetricsView`.
+- Kept production code unchanged.
+
+## Backend Test Coverage
+
+- Report route returns `{ ok: true, data }`.
+- Tenant id is resolved from authenticated user.
+- `since` / `until` are parsed as dates.
+- `limit` is clamped to `50`.
+- Invalid dates are ignored.
+- Invalid limit falls back to `10`.
+- Auth and RBAC gates are preserved.
+- Service failure returns stable `METRICS_REPORT_FAILED` payload.
+
+## Frontend Test Coverage
+
+- The view loads the report on mount with `{ limit: 10 }`.
+- TopN slowest instance and SLA risk template tables render returned rows.
+- Duration and percent formatters are exercised through rendered text.
+- Row links route to approval detail and template detail.
+
+## Files
+
+- `packages/core-backend/tests/unit/approval-metrics-router.test.ts`
+- `apps/web/tests/approvalMetricsTopnReport.spec.ts`

--- a/docs/development/approval-sla-topn-contract-tests-verification-20260425.md
+++ b/docs/development/approval-sla-topn-contract-tests-verification-20260425.md
@@ -1,0 +1,26 @@
+# Approval SLA TopN Contract Tests Verification - 2026-04-25
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-metrics-router.test.ts tests/unit/approval-metrics-service.test.ts --reporter=verbose
+pnpm --filter @metasheet/web exec vitest run tests/approvalMetricsTopnReport.spec.ts --reporter=verbose
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+```
+
+## Results
+
+- Backend route + service tests: 19/19 passed.
+- Frontend TopN view spec: 2/2 passed.
+- Backend TypeScript check: passed with exit code 0.
+- Frontend Vue TypeScript check: passed with exit code 0.
+
+## Notes
+
+- The web Vitest run printed `WebSocket server error: Port is already in use`, but the focused spec completed successfully with exit code 0. No test failure was produced.
+- No OpenAPI build was needed because this slice changes tests only.
+
+## Not Run
+
+- Browser manual verification. The view contract is pinned by Vue unit tests; staging click verification remains an operational step.

--- a/packages/core-backend/tests/unit/approval-metrics-router.test.ts
+++ b/packages/core-backend/tests/unit/approval-metrics-router.test.ts
@@ -1,0 +1,142 @@
+import express from 'express'
+import type { NextFunction, Request, Response } from 'express'
+import request from 'supertest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ApprovalMetricsService as ApprovalMetricsServiceType } from '../../src/services/ApprovalMetricsService'
+
+const authState = vi.hoisted(() => ({
+  user: {
+    id: 'admin-1',
+    tenantId: 'tenant-a',
+    permissions: ['*:*'],
+  } as Record<string, unknown> | null,
+  allowRbac: true,
+}))
+
+vi.mock('../../src/middleware/auth', () => ({
+  authenticate: (req: Request, res: Response, next: NextFunction) => {
+    if (!authState.user) {
+      res.status(401).json({ ok: false, error: { code: 'UNAUTHORIZED', message: 'Unauthorized' } })
+      return
+    }
+    req.user = authState.user as never
+    next()
+  },
+}))
+
+vi.mock('../../src/rbac/rbac', () => ({
+  rbacGuard: () => (_req: Request, res: Response, next: NextFunction) => {
+    if (!authState.allowRbac) {
+      res.status(403).json({ ok: false, error: { code: 'FORBIDDEN', message: 'Forbidden' } })
+      return
+    }
+    next()
+  },
+}))
+
+function buildService() {
+  return {
+    getMetricsReport: vi.fn().mockResolvedValue({
+      summary: {
+        total: 1,
+        approved: 1,
+        rejected: 0,
+        revoked: 0,
+        returned: 0,
+        running: 0,
+        avgDurationSeconds: 120,
+        p50DurationSeconds: 120,
+        p95DurationSeconds: 120,
+        slaBreachCount: 1,
+        slaCandidateCount: 1,
+        slaBreachRate: 1,
+        byTemplate: [],
+      },
+      slowestInstances: [],
+      breachedTemplates: [],
+    }),
+  }
+}
+
+describe('approval metrics report route', () => {
+  let service: ReturnType<typeof buildService>
+  let app: express.Express
+
+  beforeEach(async () => {
+    vi.resetModules()
+    authState.user = {
+      id: 'admin-1',
+      tenantId: 'tenant-a',
+      permissions: ['*:*'],
+    }
+    authState.allowRbac = true
+    service = buildService()
+    const { approvalMetricsRouter } = await import('../../src/routes/approval-metrics')
+    app = express()
+    app.use(express.json())
+    app.use(approvalMetricsRouter({ metricsService: service as unknown as ApprovalMetricsServiceType }))
+  })
+
+  it('returns a TopN report and clamps limit/date query parameters', async () => {
+    const response = await request(app)
+      .get('/api/approvals/metrics/report')
+      .query({
+        since: '2026-04-01T00:00:00Z',
+        until: '2026-04-25T23:59:59Z',
+        limit: '999',
+      })
+
+    expect(response.status).toBe(200)
+    expect(response.body.ok).toBe(true)
+    expect(service.getMetricsReport).toHaveBeenCalledTimes(1)
+    expect(service.getMetricsReport).toHaveBeenCalledWith({
+      tenantId: 'tenant-a',
+      since: new Date('2026-04-01T00:00:00Z'),
+      until: new Date('2026-04-25T23:59:59Z'),
+      limit: 50,
+    })
+  })
+
+  it('falls back to default tenant and default limit for invalid query values', async () => {
+    authState.user = { id: 'admin-1', permissions: ['*:*'] }
+
+    await request(app)
+      .get('/api/approvals/metrics/report')
+      .query({ since: 'not-a-date', until: '', limit: 'not-a-number' })
+      .expect(200)
+
+    expect(service.getMetricsReport).toHaveBeenCalledWith({
+      tenantId: 'default',
+      since: undefined,
+      until: undefined,
+      limit: 10,
+    })
+  })
+
+  it('preserves auth and RBAC gates', async () => {
+    authState.user = null
+    await request(app).get('/api/approvals/metrics/report').expect(401)
+
+    authState.user = { id: 'viewer-1', tenantId: 'tenant-a' }
+    authState.allowRbac = false
+    await request(app).get('/api/approvals/metrics/report').expect(403)
+
+    expect(service.getMetricsReport).not.toHaveBeenCalled()
+  })
+
+  it('returns a stable 500 error payload when the service fails', async () => {
+    service.getMetricsReport.mockRejectedValueOnce(new Error('db down'))
+
+    const response = await request(app).get('/api/approvals/metrics/report')
+
+    expect(response.status).toBe(500)
+    expect(response.body).toEqual({
+      ok: false,
+      error: {
+        code: 'METRICS_REPORT_FAILED',
+        message: 'Failed to load approval metrics report',
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Add route contract tests for GET /api/approvals/metrics/report.
- Add Vue contract tests for ApprovalMetricsView TopN report rendering and navigation.
- No production runtime changes.

## Verification
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-metrics-router.test.ts tests/unit/approval-metrics-service.test.ts --reporter=verbose
- pnpm --filter @metasheet/web exec vitest run tests/approvalMetricsTopnReport.spec.ts --reporter=verbose
- pnpm --filter @metasheet/core-backend exec tsc --noEmit
- pnpm --filter @metasheet/web exec vue-tsc -b --noEmit

## Docs
- docs/development/approval-sla-topn-contract-tests-development-20260425.md
- docs/development/approval-sla-topn-contract-tests-verification-20260425.md