### PR TITLE
docs(integration): add ERP platform roadmap and vendor abstraction checklist

### DIFF
--- a/docs/development/integration-erp-platform-roadmap-20260425.md
+++ b/docs/development/integration-erp-platform-roadmap-20260425.md
@@ -1,0 +1,160 @@
+# 通用 ERP 集成平台 · 路线图（Roadmap）
+
+> 状态：**讨论稿，未列入交付**
+> 出处：2026-04-25 团队对话「我们能做通用型的 ERP 对接平台么？K3 只是试验」
+> 主笔：Claude（Sonnet 4.6, 1M context）+ 团队对话提取
+> 目的：在 K3 WISE Live PoC 进入门槛前，把"是否走平台化"这个战略问题落到文字，避免日后用错精力或错失时机
+
+---
+
+## 1. 背景与问题
+
+我们已经在 main 上交付了 `plugin-integration-core` 的 backend MVP（M0+M1+M2 mock 共 #1140-#1155 + #1162 + #1166 共 11 个 PR），当前正进入"K3 WISE 真客户测试账套 Live PoC"阶段。
+
+业务侧提出疑问：**这套基建是不是只能服务于 K3？还是可以演化成一个通用的 ERP 集成平台？**
+
+本文档的目标：基于代码现状给出**事实判断 + 阶段化路线 + 关键决策点**，让"是否走平台化"成为可量化讨论而非情绪决策。
+
+---
+
+## 2. 架构审计：现状有多通用？
+
+### 2.1 已可复用 / vendor-agnostic 基础已具备
+
+> **降级用语**：以下是 plugin-integration-core 内 vendor-agnostic 的基础设施，不代表"100% 通用"——尤其底层 Postgres/MySQL 适配器目前更多是**内核 data-adapters 资产**，尚未通过 plugin-integration-core 的 adapter contract 接入；HTTP adapter 是 plugin-local 的，可直接被 pipeline-runner 用作 source/target。
+
+| 模块 | 文件位置（已合 main） | 复用性证据 |
+|---|---|---|
+| Adapter 契约 | `plugins/plugin-integration-core/lib/contracts.cjs` | 5 个方法 `testConnection / listObjects / getSchema / read / upsert` 与任何 ERP/PLM 无关 |
+| Pipeline runner | `plugins/plugin-integration-core/lib/pipeline-runner.cjs` | 不知道 source/target 是谁；依赖注入 adapter 实例 |
+| Transform engine | `plugins/plugin-integration-core/lib/transform-engine.cjs` | 内置变换（trim/upper/toNumber/toDate/dictMap 等）vendor 无关 |
+| Validator | `plugins/plugin-integration-core/lib/validator.cjs` | required/pattern/enum/min/max/unique 通用规则 |
+| Idempotency / watermark / dead-letter / run-log | `plugins/plugin-integration-core/lib/{idempotency,watermark,dead-letter,run-log}.cjs` | 全部 vendor 无关 |
+| External system 注册表 + 凭据加密 | `plugins/plugin-integration-core/lib/external-systems.cjs` + `lib/credential-store.cjs` | tenant_id/workspace_id 已就绪；config JSONB 容纳任意 vendor 维度（K3 acctId、SAP CompanyCode、用友账套等） |
+| REST control plane | `plugins/plugin-integration-core/lib/http-routes.cjs` | pipeline CRUD / run / dry-run / dead-letter / replay vendor 无关 |
+| HTTP adapter（plugin-local） | `plugins/plugin-integration-core/lib/adapters/http-adapter.cjs` | REST 风格 ERP 可直接套配置 |
+| Postgres / MySQL（**内核 data-adapters 资产**） | `packages/core-backend/src/data-adapters/{PostgresAdapter,MySQLAdapter}.ts` | 内核已有，但**未通过 plugin-integration-core adapter contract 接入**——直接库连接 ERP 时需补一层 plugin adapter 包装 |
+
+**结论**：vendor-agnostic 底子已就位，不存在 K3 锁死。换 vendor 时，主要新增一个 **vendor adapter + vendor metadata 包**（包含 adapter 实现、vendor profile、错误字典、preflight rules、字段词典、测试 fixture、runbook 等——详见 `integration-vendor-abstraction-checklist-20260425.md`）。**注意**：不是只新增一个 adapter 文件就够。
+
+### 2.2 K3 特有但易抽离（4-6 人天工作量）
+
+| 特性 | 当前位置 | 抽离方向 |
+|---|---|---|
+| K3 WebAPI / SQL Server adapter | `lib/adapters/k3-wise-*.cjs` | 保持原样，作为 vendor 适配器实现之一即可 |
+| 字段映射（FNumber/FName/FChildItems） | 用户配置（`fieldMappings.material/bom`） | 已经是 user-config，不在代码里 → 已通用 |
+| Preflight intercept（autoSubmit/autoAudit/t_ICItem 黑名单） | `scripts/ops/integration-k3wise-live-poc-preflight.mjs` | 抽成"per-vendor preflight rules"配置；K3 是其中一份 |
+| Submit/Audit 二段提交 | adapter 内硬编码 | 改成 `adapter.lifecycle: ['save', 'submit', 'audit']` 由 adapter 声明，runner 按声明执行 |
+| K3 错误码 → 业务语义翻译 | adapter 内硬编码（部分） | 改成 vendor-scoped error dictionary（JSON 表） |
+
+详见同目录 `integration-vendor-abstraction-checklist-20260425.md`。
+
+### 2.3 需要新增的"平台化"工作（决定是否走平台化路线）
+
+| 新工作 | 价值 | 工作量 |
+|---|---|---|
+| Vendor profile 注册中心（capabilities / 必填字段 / 安全规则 / 默认 mappings / 错误字典） | 让运维不写代码就能新增 vendor | 1-2 人周 |
+| Adapter marketplace（插件包发现/安装/版本管理） | 第三方/客户工程师自己写 adapter，不用进 main 仓库 | 2-3 人周 |
+| 可视化 Adapter Builder（无代码新建 vendor）：填 REST endpoint + auth 模式 + 字段路径 → 生成 adapter | 80% 是 REST 的 ERP 不需要写代码 | 3-4 人周 |
+| Schema catalog / 字段词典 | 客户配置时不用查 K3 文档 | 2-3 人周（每家 vendor 1 人天填词典） |
+| 多 ERP 同时连接 scope 隔离 | 已有 `tenant_id/workspace_id` 基础，pipeline 层加 vendor scope 标签 | 3-5 人天 |
+
+---
+
+## 3. ERP 覆盖优先级（中国市场视角）
+
+按中国中型制造业市场覆盖，下面 6 家 ERP 覆盖 80%+：
+
+| 优先级 | ERP | API 成熟度 | 接入工作量预估（在已有基建上） | 备注 |
+|---|---|---|---|---|
+| 1 | **K3 WISE** | 中（K3API + SQL Server） | 已完成 mock，PoC 中 | 当前主线 |
+| 2 | **金蝶 K3 Cloud / 星空** | 高（REST + 签名） | 1-2 人周 | 同金蝶系，复用大量字段映射经验 |
+| 3 | **用友 U8/U9** | 中（REST + token） | 2-3 人周 | 国内最大装机量之一 |
+| 4 | **SAP S/4 HANA** | 高（OData / RFC / BAPI） | OData: 2-3 人周；RFC: 4-5 人周 | 大型/外企客户必备 |
+| 5 | **用友 YonBIP** | 高（REST） | 2 人周 | 用友新平台，新客户增长快 |
+| 6 | **鼎捷 / 浪潮 GS** | 中-低 | 3-4 人周 | 制造业垂直 |
+
+**国外**（未来）：NetSuite / Oracle EBS / Dynamics 365 / Acumatica / Workday 各 2-4 人周。
+
+---
+
+## 4. 四阶段路线图
+
+```
+阶段一（现在 - 1 个月）·  K3 PoC 跑通
+  目标：验证产品-市场契合度（PMF），不分散精力做平台化
+  关键交付：K3 真客户测试账套 Live PoC PASS
+  决策门槛：PoC PASS = 进入阶段二；FAIL = 修 K3 adapter 不开新战线
+
+阶段二（1-3 个月）· 抽离 + 第 2 家 ERP
+  目标：用真实复用证明"通用"不是 PPT
+  关键交付：
+    1. 完成 §2.2 抽离工作（4-6 人天，详见 vendor-abstraction-checklist）
+    2. 接 1 家 ERP 验证可复用性（推荐金蝶云星空 或 用友 U8，按客户需求选）
+    3. 第 2 家 ERP 的接入时间应 ≤ 3 周（如果 ≥ 4 周说明抽离不够好，回流改）
+  决策门槛：第 2 家 ≤ 3 周成功 = 进入阶段三；否则回流抽离
+
+阶段三（3-6 个月）· 平台化基建
+  目标：让"通用 ERP 集成平台"作为正式产品定位成立
+  关键交付：
+    1. Vendor profile 注册中心（§2.3）
+    2. Schema catalog（先填阶段二的 2 家 + 阶段三新增 1-2 家共 3-4 家）
+    3. 简单的 Adapter Builder（先支持 REST + Bearer/Basic auth）
+  决策门槛：基建上线 + 客户成功故事 ≥ 3 家 = 进入阶段四
+
+阶段四（6 个月+）· Marketplace + SaaS
+  目标：生态 + 商业化
+  关键交付：
+    1. Adapter marketplace（让 SI/客户上传第三方 adapter）
+    2. 多租户 SaaS 模式
+    3. 国外 ERP 选择性进入
+```
+
+---
+
+## 5. 关键风险
+
+| 风险 | 表现 | 缓解 |
+|---|---|---|
+| **过度工程**（最大风险） | K3 PoC 还没过就投入平台化，结果客户没买单，平台化沉没成本巨大 | 阶段一锁定不开新战线；任何"K3 之外"的工作必须等 PoC PASS 才启动 |
+| **Vendor 长尾陷阱** | 看似 80/20 实际是 20/80：每接一家 ERP 维护成本上升，国内 ERP 版本碎片严重 | 阶段二只接 1 家，证明 ROI 后才扩展；自我设限"每季度最多 1 家新 ERP" |
+| **Schema 版本漂移** | K3 WISE 15 vs K3 WISE 14 字段差异；用友 U8 v15 vs v17 | Vendor profile 中心引入 `vendor.version` 字段；mappings 按版本绑定 |
+| **认证方式异构爆炸** | OAuth2 / SAP login ticket / Oracle SSWS / 用友 token / NetSuite TBA / SAP Ariba SOAP-WSSE | 阶段三 Adapter Builder 优先支持 top 5 auth 模式；其他走 vendor adapter 自定义 |
+| **Adapter 质量参差** | 一旦开了 marketplace，第三方 adapter 出故障会反噬平台口碑 | 阶段四前不开 marketplace；阶段四引入 adapter 认证机制（自动测试 + 评级） |
+| **K3 PoC 客户拖延** | 客户 GATE 答卷迟迟不回，整个进度卡住 | 客户答卷与平台化路线解耦：阶段一可同步做内核打磨（不动 K3 PoC 路径），但不投入平台化代码 |
+
+---
+
+## 6. 决策清单（团队定期回顾）
+
+每月 review 一次以下问题，决定是否进入下一阶段：
+
+| 决策点 | 问题 | 当前状态（2026-04-25） |
+|---|---|---|
+| D1 | K3 PoC 是否 PASS？ | 等客户 GATE 答卷 |
+| D2 | 第 2 家 ERP 是哪家？是否有真实客户需求？ | 未确定 |
+| D3 | 第 2 家 ERP 的接入是否 ≤ 3 周完成？ | N/A |
+| D4 | 是否已有 ≥ 3 家成功案例？ | N/A |
+| D5 | 是否准备好承担 marketplace 的运营成本（adapter 审核 / 评级 / 支持）？ | N/A |
+
+---
+
+## 7. 文档关系
+
+- 本文（roadmap）：战略层
+- 同日 `integration-vendor-abstraction-checklist-20260425.md`：阶段二抽离工作的具体 task list
+- 已有 `integration-core-k3wise-live-poc-design-20260425.md` + `*-verification-20260425.md`：阶段一执行
+- 已合 main · K3 PoC 运行手册（#1155）：
+  - 本体：`packages/core-backend/claudedocs/integration-plm-k3wise-mvp.md`（703 行 runbook）
+  - 设计：`docs/development/integration-plm-k3wise-mvp-runbook-design-20260424.md`
+  - 验收：`docs/development/integration-plm-k3wise-mvp-runbook-verification-20260424.md`
+
+---
+
+## 8. 一句话总结
+
+> **架构上是通用的，K3 只占 `lib/adapters/` 里两个 vendor 文件 + 一份 preflight 脚本。不存在 K3 锁死风险。**
+>
+> **但"通用 ERP 集成平台"作为产品定位，需要再投 2-3 个月做平台化基建（vendor profile / schema catalog / adapter builder）才成立。**
+>
+> **建议节奏**：K3 PoC PASS → 抽离 4-6 人天 → 接第 2 家 ERP 实证 → 再决定是否投平台化基建。

--- a/docs/development/integration-vendor-abstraction-checklist-20260425.md
+++ b/docs/development/integration-vendor-abstraction-checklist-20260425.md
@@ -1,0 +1,335 @@
+# Vendor 抽离 Checklist · 阶段二准备工作
+
+> 状态：**讨论稿，未列入交付**
+> 出处：2026-04-25 团队对话
+> 配套：`integration-erp-platform-roadmap-20260425.md` § 2.2 + § 4 阶段二
+> 触发条件：**K3 WISE Live PoC PASS 之后才启动**；PoC 结果尚未 PASS 时不要开工，避免基于错误经验做抽象
+
+---
+
+## 0. 背景与原则
+
+K3 WISE Live PoC 完成后，第一件事是**做一次有限抽离**——把当前与 K3 强耦合的 5 处代码拆成"vendor-agnostic 框架 + per-vendor 配置"。这是阶段二接入第 2 家 ERP（金蝶云星空 / 用友 U8 等）的前置条件。
+
+**总工作量**：4-6 人天（不含第 2 家 ERP 自身的 adapter 编写）
+**前置依赖**：K3 PoC PASS（否则可能基于错误的 K3 经验做抽象）
+**禁忌**：不要在抽离同时引入新 vendor；先抽再接，证明抽对了再扩展
+
+---
+
+## 1. 五项任务总览
+
+| ID | 任务 | 文件位置 | 工作量 | 验收 |
+|---|---|---|---|---|
+| **VA-T01** | Per-vendor preflight rules 抽离 | `scripts/ops/integration-k3wise-live-poc-preflight.mjs` → 拆基座 + per-vendor rules | 1.5 人天 | K3 rules 单独一份；新增空 SAP rules 文件能通过 lint |
+| **VA-T02** | Adapter lifecycle 声明化 | `lib/contracts.cjs` + `lib/pipeline-runner.cjs` + `lib/adapters/*` | 2 人天 | adapter 通过 `getLifecycle()` 声明 `['save','submit','audit']`；runner 按声明执行；K3 行为不变 |
+| **VA-T03** | Vendor-scoped error dictionary | 新建 `lib/error-dictionary/{k3-wise,sap,...}.cjs` + `lib/error-translator.cjs` | 1 人天 | K3 错误码 → 业务语义映射从 adapter 抽出；adapter 拒绝 hardcode error 翻译 |
+| **VA-T04** | Vendor profile 元数据（轻量版） | 新建 `lib/vendor-profiles/index.cjs` + 每家 vendor 一份 JSON | 1 人天 | profile 包含 vendor name、version、capabilities、required config keys、default safety rules；K3 profile 完整、SAP profile 占位 |
+| **VA-T05** | 抽象后的 contract 兼容性回归 | 全套 `__tests__/`（特别是 e2e-plm-k3wise-writeback） | 0.5 人天 | 所有现有测试不动通过；新增"vendor-agnostic contract"测试 |
+
+---
+
+## 2. VA-T01 · Per-vendor preflight rules 抽离
+
+### 现状
+
+`scripts/ops/integration-k3wise-live-poc-preflight.mjs` 里 K3 安全规则是硬编码：
+
+```js
+const NON_PRODUCTION_ENVS = new Set([...])
+const K3_CORE_TABLES = new Set(['t_icitem', 't_icbom', 't_icbomchild'])
+// ... if (k3Wise.autoSubmit === true || k3Wise.autoAudit === true) ...
+```
+
+### 目标结构
+
+```
+scripts/ops/
+├── integration-live-poc-preflight.mjs               (基座，vendor 无关)
+└── live-poc-preflight-rules/
+    ├── k3-wise.mjs                                  (K3 核心表黑名单 / autoSubmit/autoAudit / Save-only)
+    ├── sap-s4.mjs                                   (占位：BAPI 危险列表 / RFC 角色)
+    ├── kingdee-cloud.mjs                            (占位：星空特有规则)
+    └── yonyou-u8.mjs                                (占位)
+```
+
+每份 `*.mjs` 导出统一 shape：
+
+```js
+export default {
+  vendor: 'k3-wise',
+  requiredConfigKeys: ['version', 'apiUrl', 'acctId', 'environment'],
+  intercepts: [
+    { id: 'k3-no-prod', test: (cfg) => !NON_PRODUCTION_ENVS.has(cfg.environment), msg: '...' },
+    { id: 'k3-save-only', test: (cfg) => cfg.autoSubmit !== true && cfg.autoAudit !== true, msg: '...' },
+    { id: 'k3-no-core-table-write', test: (cfg) => !overlapsCoreTable(cfg), msg: '...' },
+  ],
+  defaultLifecycle: ['save'],   // 不开 submit/audit
+}
+```
+
+基座脚本 `integration-live-poc-preflight.mjs` 根据 `gate.targetVendor` 字段动态加载对应 rules。
+
+### 验收
+
+- [ ] K3 现有 8 个 preflight 测试不变通过
+- [ ] 创建空 `sap-s4.mjs`（只有 schema，没有 intercept），基座加载不报错
+- [ ] CLI 传 `--vendor=k3-wise` / `--vendor=sap-s4` 切换 rule set
+- [ ] 文档 `docs/development/integration-vendor-preflight-spec-*.md` 描述 rules 文件 schema
+
+---
+
+## 3. VA-T02 · Adapter lifecycle 声明化
+
+### 现状
+
+K3 的 Save → Submit → Audit 三段式硬编码在 K3 adapter 里；其他 vendor 没有这个概念，runner 不能区分。
+
+### 目标（**第一版 optional，不破坏现有契约**）
+
+在 `IExternalSystemAdapter` 契约新增 `getLifecycle()` 方法 ——**第一版作为 optional**，向后兼容：
+
+- adapter 实现了 `getLifecycle()` → runner 按声明阶段执行
+- adapter 没实现 → runner fallback 到当前 `upsert()` 单步行为
+- K3 adapter 这一步**不强制重写**，行为完全不变
+
+```js
+// K3 WISE adapter（可选迁移）
+getLifecycle() {
+  return ['save', 'submit', 'audit']  // 三段
+}
+// SAP S/4 adapter（可选迁移）
+getLifecycle() {
+  return ['create']                   // 单段
+}
+// Yonyou U8 adapter（可选迁移）
+getLifecycle() {
+  return ['save', 'verify']           // 二段
+}
+// 任何未实现 getLifecycle() 的 adapter
+// → runner 走老路径 adapter.upsert()，不进 lifecycle 分支
+```
+
+Pipeline runner 在配置侧也是可选：
+
+```js
+// pipeline.options（仅当 adapter 暴露了 getLifecycle 时有意义）
+{
+  lifecycleStages: {
+    save:   { enabled: true },
+    submit: { enabled: false },         // 默认 false（PoC Save-only）
+    audit:  { enabled: false }
+  }
+}
+```
+
+### 改动文件
+
+| 文件 | 改动 |
+|---|---|
+| `plugins/plugin-integration-core/lib/contracts.cjs` | `IExternalSystemAdapter` 加 `getLifecycle()` **可选**方法（注释明确"未实现则 fallback 到 upsert"） |
+| `plugins/plugin-integration-core/lib/pipeline-runner.cjs` | runner 检测 `typeof adapter.getLifecycle === 'function'`：有则按声明执行 + 查 `pipeline.options.lifecycleStages[name].enabled`；无则走原 `adapter.upsert()` 路径 |
+| `plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs` | **第一版不动**——继续走 upsert 单步路径，behavioral parity；M2 K3 PoC PASS 后再决定是否拆 lifecycle.save/submit/audit |
+| `plugins/plugin-integration-core/lib/adapters/http-adapter.cjs` | **第一版不动** |
+| `plugins/plugin-integration-core/lib/adapters/plm-yuantus-wrapper.cjs` | **第一版不动**（source-only adapter） |
+| `plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs` | 新增"adapter 暴露 lifecycle 时按声明阶段执行"测试 + "未暴露 lifecycle 时走 upsert"回归测试 |
+
+### 验收
+
+- [ ] **K3 adapter 的现有 Save-only PoC 行为完全不变**（adapter 不动 = behavior 不动）
+- [ ] 新增 "lifecycle-aware adapter 路径" 测试通过：用一个 mock adapter 暴露 `getLifecycle()=['save','submit']`，runner 调用两阶段
+- [ ] 新增 "lifecycle-unaware adapter 路径" 回归测试：用一个 mock adapter **不**暴露 `getLifecycle()`，runner 仍走 `upsert()`
+- [ ] e2e-plm-k3wise-writeback 测试不动通过（K3 adapter 没改，行为没变）
+- [ ] 所有现有 adapter 测试不动通过
+
+---
+
+## 4. VA-T03 · Vendor-scoped error dictionary
+
+### 现状
+
+K3 错误码翻译散在 K3 adapter 和 ERP feedback writeback 里；其他 vendor 接入时要翻一遍源码找翻译点。
+
+### 目标结构
+
+```
+plugins/plugin-integration-core/lib/error-dictionary/
+├── index.cjs                  (loader：按 vendor 加载)
+├── k3-wise.json               (K3 错误码 → 业务语义)
+├── sap-s4.json                (占位)
+├── kingdee-cloud.json         (占位)
+└── yonyou-u8.json             (占位)
+```
+
+`k3-wise.json` 形态示例：
+
+```json
+{
+  "vendor": "k3-wise",
+  "version": "1.0",
+  "errors": {
+    "K3_E_CONNECTION_TIMEOUT":     { "category": "transient",  "retry": true,  "userMsg": "K3 服务器响应超时，自动重试中..." },
+    "K3_E_AUTH_EXPIRED":           { "category": "auth",       "retry": false, "userMsg": "K3 登录会话过期，需重新登录" },
+    "K3_E_FNUMBER_DUPLICATE":      { "category": "validation", "retry": false, "userMsg": "物料编码已存在，请检查 FNumber 唯一性" },
+    "K3_E_FBASE_UNIT_NOT_FOUND":   { "category": "data",       "retry": false, "userMsg": "K3 计量单位字典未找到，请补全 dictMap.unit 配置" }
+  }
+}
+```
+
+### 改动文件
+
+| 文件 | 改动 |
+|---|---|
+| 新建 `plugins/plugin-integration-core/lib/error-dictionary/index.cjs` | `loadDictionary(vendor)` + `translateError(vendor, code, ctx)` |
+| 新建 `plugins/plugin-integration-core/lib/error-dictionary/k3-wise.json` | 把现有 K3 错误码迁过来 |
+| `plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs` | 删除 hardcode 翻译，改调 `translateError('k3-wise', code, ctx)` |
+| `plugins/plugin-integration-core/lib/erp-feedback.cjs` | 同上 |
+
+### 验收
+
+> **说明**：adapter 仍然需要**产生**原生 vendor 错误码（这是数据，不是翻译）。本任务的目标是确保**用户可见的错误翻译**统一走字典，而不是散落各处。
+
+- [ ] K3 现有 ERP feedback 测试不变通过
+- [ ] **用户可见错误翻译统一走 error dictionary**——`grep -rn '"用户可见错误信息文本"' plugins/plugin-integration-core/lib/adapters/ lib/erp-feedback.cjs` 不应找到散落的中文/英文错误描述（adapter 仍然返回 vendor code 是允许的）
+- [ ] `translateError('unknown-vendor', code, ctx)` 返回安全的 fallback（不抛错；返回 `{category: 'unknown', userMsg: <vendor code 原样>, retry: false}`）
+- [ ] `translateError('k3-wise', '<未知 K3 错误码>', ctx)` 同样 fallback 不抛错
+- [ ] 新增 SAP / 用友 / 金蝶云的空字典加载不报错
+- [ ] 字典覆盖率指标可观测——新增脚本或测试，输出"K3 字典覆盖了多少 K3 已知错误码"，便于后续补全
+
+---
+
+## 5. VA-T04 · Vendor profile 元数据（轻量版）
+
+### 目标
+
+每家 vendor 一份 metadata JSON，描述 vendor 的"指纹"：
+
+```
+plugins/plugin-integration-core/lib/vendor-profiles/
+├── index.cjs              (loader)
+├── k3-wise.json
+├── sap-s4.json
+├── kingdee-cloud.json
+└── yonyou-u8.json
+```
+
+`k3-wise.json` 完整示例（其他先占位）：
+
+```json
+{
+  "vendor": "k3-wise",
+  "displayName": "金蝶 K3 WISE",
+  "version": "15.x / 14.x",
+  "capabilities": {
+    "objects": ["material", "bom", "purchase-order", "sales-order"],
+    "writeProtocol": ["webapi", "sql-server"],
+    "readProtocol":  ["webapi", "sql-server"],
+    "auth":          ["acctId+username+password"]
+  },
+  "requiredConfigKeys": ["version", "apiUrl", "acctId", "environment"],
+  "lifecycle": ["save", "submit", "audit"],
+  "defaultSafety": {
+    "saveOnly":             true,
+    "blockProductionEnvs":  true,
+    "blockCoreTables":      ["t_ICItem", "t_ICBOM", "t_ICBomChild"]
+  },
+  "defaultMappings": {
+    "material": [
+      { "sourceField": "code", "targetField": "FNumber" },
+      { "sourceField": "name", "targetField": "FName" }
+    ]
+  }
+}
+```
+
+### 改动文件
+
+| 文件 | 改动 |
+|---|---|
+| 新建 `plugins/plugin-integration-core/lib/vendor-profiles/index.cjs` | `loadProfile(vendor)`、`listProfiles()`、`validateAgainstProfile(vendor, config)` 返回 `{ ok, missing, extra }`，**不抛错** |
+| 新建 `plugins/plugin-integration-core/lib/vendor-profiles/k3-wise.json` | 完整填 |
+| 新建 `plugins/plugin-integration-core/lib/vendor-profiles/{sap-s4,kingdee-cloud,yonyou-u8}.json` | 占位 |
+| `plugins/plugin-integration-core/lib/external-systems.cjs` | **draft 不强校验**——`upsertExternalSystem` 入库总是允许；只在以下三个 critical 阶段强校验 `requiredConfigKeys`： <br>1. `status` 从其他状态过渡到 `active` 时（要把 system 标记为可用必须满足完整配置） <br>2. `testConnection(systemId)` 调用时 <br>3. `runPipeline(pipelineId)` 触发时（如果 pipeline 引用的 system 不完整，run 拒绝启动并落入 dead-letter） |
+| `plugins/plugin-integration-core/lib/http-routes.cjs` | 把上述 3 个 critical 阶段的校验失败映射成清晰的 4xx 错误（含 missing keys 列表），便于前端引导用户补全 |
+
+### 验收
+
+- [ ] `loadProfile('k3-wise')` 返回完整 profile
+- [ ] `loadProfile('sap-s4')` 返回占位 profile（不抛错，返回 `{ vendor: 'sap-s4', placeholder: true }`）
+- [ ] `listProfiles()` 返回 4 项
+- [ ] **draft 路径**：`upsertExternalSystem({ status: 'inactive', config: {} })` 应**成功**入库（保留草稿能力）
+- [ ] **active 路径**：`upsertExternalSystem({ status: 'active', config: {} })` 应**失败**并返回缺失字段列表（kind=k3-wise 时缺 version/apiUrl/acctId/environment）
+- [ ] **testConnection 路径**：对状态 active 但仍缺字段的 system 调用 testConnection 应返回 4xx 含 missing keys
+- [ ] **runPipeline 路径**：pipeline 引用配置不完整的 source/target system，run 应被拒并写入 dead-letter（错误类别：`invalid-system-config`）
+- [ ] **现有所有未引入 vendor profile 的测试不变通过**（向后兼容）
+
+---
+
+## 6. VA-T05 · 抽象后的 contract 兼容性回归
+
+### 目标
+
+确保 VA-T01-T04 完成后：
+1. 所有现有测试不动通过
+2. K3 实际行为不变
+3. 新增"vendor-agnostic contract"测试，断言基座层不知道任何 vendor 名称
+
+### 改动文件
+
+| 文件 | 改动 |
+|---|---|
+| 新建 `plugins/plugin-integration-core/__tests__/vendor-agnostic-contract.test.cjs` | grep 检查 `lib/pipeline-runner.cjs` / `lib/contracts.cjs` 不包含 `'k3-wise'` / `'sap'` 等 vendor 字符串；遍历 vendor profiles 确认基座可热加载 |
+| 全套 `__tests__/*.cjs` | 不动，跑一遍 `pnpm -F plugin-integration-core test` |
+| `scripts/ops/integration-k3wise-live-poc-preflight.mjs` test 套 | 适应基座+rules 拆分后的入口 |
+
+### 验收
+
+- [ ] `pnpm -F plugin-integration-core test` 全绿
+- [ ] `pnpm -F plugin-integration-core test:e2e-plm-k3wise-writeback` 不变通过
+- [ ] 新增的 vendor-agnostic-contract 测试通过
+
+---
+
+## 7. 实施顺序与时间表（K3 PoC PASS 后启动）
+
+```
+Day 1   (1.5d) · VA-T01 preflight rules 拆基座
+Day 2-3 (2.0d) · VA-T02 adapter lifecycle 声明化（最难，影响 runner）
+Day 3   (1.0d) · VA-T03 error dictionary
+Day 4   (1.0d) · VA-T04 vendor profile 元数据
+Day 5   (0.5d) · VA-T05 兼容性回归 + 全套测试 + commit + PR
+```
+
+**总计 6 人天**（含测试、文档、PR review buffer）。
+
+---
+
+## 8. 完成定义（DoD）
+
+- [ ] 5 个 PR 全部合到 main（每个 task 一个 PR，按 #1140-1155 的节奏）
+- [ ] `pnpm -F plugin-integration-core test` 全绿
+- [ ] `pnpm validate:plugins` 全绿
+- [ ] 新增 vendor profile 4 份（K3 完整 + SAP/金蝶云/用友 U8 占位）
+- [ ] 抽离后的 K3 PoC 行为不变（重跑一次 K3 测试账套 dry-run）
+- [ ] 文档：本 checklist 上每项打勾 + 更新 `integration-erp-platform-roadmap-20260425.md` 阶段二状态
+
+---
+
+## 9. 不在本期范围（推到阶段三+）
+
+- 多 ERP 同时连接的 scope 隔离（runtime-level）
+- Adapter marketplace
+- 可视化 Adapter Builder
+- Schema catalog 完整填充
+- 第 2 家 ERP 真实接入（这是阶段二 §3 的下一步）
+
+---
+
+## 10. 风险与缓解
+
+| 风险 | 缓解 |
+|---|---|
+| 抽象层引入意外行为变化 | VA-T05 全套回归 + 在客户测试账套上重跑一次 K3 dry-run |
+| Adapter lifecycle 抽象过早，发现 SAP 不适配 | 阶段二接 SAP/金蝶云时如发现 lifecycle 模型不够，再扩展（YAGNI 原则） |
+| Error dictionary 扁平 JSON 不够表达复杂场景 | v1 用 JSON；v2 必要时升级到 JS 函数（每条 error 一个 handler） |
+| 6 人天估计偏低 | 如果某 task 卡住超过预算 2 倍，stop 并 review 是否需要分 PR |


### PR DESCRIPTION
## Summary

Two team-aligned strategy documents anchoring the question raised after the M2 mock + live PoC asset PRs landed: **"can `plugin-integration-core` become a generic ERP integration platform, or is it K3-only?"**

This is a **docs-only PR**. No code changes, no CI risk, no impact on K3 live PoC schedule.

## What's in this PR

### `docs/development/integration-erp-platform-roadmap-20260425.md`

Strategic 4-phase roadmap with explicit decision gates:

1. **Phase 1 (now - 1 month)** · K3 WISE PoC — no platformization investment until PoC PASS
2. **Phase 2 (1-3 months)** · Abstraction (4-6 person-days) + 2nd ERP customer (must onboard ≤ 3 weeks)
3. **Phase 3 (3-6 months)** · Vendor profile center, schema catalog, low-code adapter builder
4. **Phase 4 (6 months+)** · Adapter marketplace, multi-tenant SaaS

Frames K3 as **pilot-not-lock-in**; documents what is vendor-agnostic today, what is K3-coupled-but-easy-to-extract, and what genuinely needs new platform-level work. Includes a Chinese ERP market priority matrix (K3 WISE → 金蝶云星空 → 用友 U8 → SAP S/4 → 用友 YonBIP → 鼎捷/浪潮) and a 6-item risk register with **over-engineering flagged as #1**.

### `docs/development/integration-vendor-abstraction-checklist-20260425.md`

5-task implementation checklist (4-6 person-days) for the abstraction work in roadmap phase 2:

- **VA-T01** Per-vendor preflight rules abstraction (1.5d)
- **VA-T02** Optional adapter lifecycle declaration (2d) — **non-breaking, K3 adapter unchanged in v1**
- **VA-T03** Vendor-scoped error dictionary (1d) — adapters still produce native vendor codes; only user-visible translation goes through dictionary
- **VA-T04** Vendor profile metadata (1d) — drafts allowed; strict validation only at status→active / testConnection / runPipeline
- **VA-T05** Vendor-agnostic contract regression suite (0.5d)

Each task lists files, effort estimate, and acceptance criteria.

## Why this is a docs-only PR (not code)

Both docs are explicitly marked **"discussion drafts, not on the delivery plan"**. The implementation checklist is **gated behind K3 PoC PASS** to avoid building abstractions on incorrect K3 lessons. Merging these docs now gives the team a shared reference for upcoming ERP-strategy decisions without committing any code.

## Review revisions incorporated

The previous draft had several issues a reviewer flagged; this PR has them fixed:

- ✅ Roadmap §2.1 reframed from "100% generic" → "vendor-agnostic foundation in place"; flagged Postgres/MySQL adapters as **kernel `data-adapters` assets not yet wired through `plugin-integration-core`'s adapter contract**
- ✅ Roadmap §2.2 corrected from "only need a vendor adapter file" → "vendor adapter + vendor metadata package" (profile, error dictionary, preflight rules, field dictionary, test fixtures, runbook)
- ✅ Roadmap §7 runbook references updated to point at the actual #1155 files including `packages/core-backend/claudedocs/integration-plm-k3wise-mvp.md` (the 703-line canonical runbook)
- ✅ Checklist VA-T02 made `getLifecycle()` **optional** with fallback to `upsert()`; K3 adapter intentionally not modified in v1, preserving Save-only PoC behavior exactly
- ✅ Checklist VA-T03 acceptance softened: adapters may still produce vendor-native error codes; only user-visible translation must route through the dictionary
- ✅ Checklist VA-T04 validation timing scoped to `status=active` / `testConnection` / `runPipeline` transitions only — **preserves draft registry capability**

## Verification

- [x] `git diff --check` clean (whitespace OK)
- [x] No code changed; no test surface affected
- [x] Both docs cross-reference each other correctly (roadmap §2.2 / §7 → checklist; checklist references roadmap)
- [x] Runbook path verified against #1155 actual files

## Out of scope (intentional)

- Implementation of any VA-T01..T05 task (those start after K3 PoC PASS)
- Any change to `plugin-integration-core/lib/*` or kernel
- Any branch/stash cleanup of stale local Codex worktrees

🤖 Generated with [Claude Code](https://claude.com/claude-code)