### PR TITLE
fix(integration): harden K3 WISE preflight boundaries

### DIFF
--- a/docs/development/integration-core-k3wise-preflight-boundary-hardening-design-20260425.md
+++ b/docs/development/integration-core-k3wise-preflight-boundary-hardening-design-20260425.md
@@ -1,0 +1,118 @@
+# Integration Core K3 WISE Preflight Boundary Hardening Design - 2026-04-25
+
+## Objective
+
+Harden the local K3 WISE live PoC preflight generator before customer GATE
+answers arrive.
+
+The goal is not to expand the PoC scope. It is to reduce avoidable round trips
+when a customer sends imperfect JSON and to keep the preflight safety gates from
+silently accepting unsafe intent.
+
+## Files
+
+- `scripts/ops/integration-k3wise-live-poc-preflight.mjs`
+- `scripts/ops/integration-k3wise-live-poc-preflight.test.mjs`
+
+## Boundary Findings
+
+The boundary probe covered common customer-input variants:
+
+- URL with trailing slash.
+- `apiUrl` omitted but `baseUrl` supplied.
+- upper-case or padded environment values.
+- Chinese production environment text.
+- `autoSubmit` / `autoAudit` supplied as strings instead of booleans.
+- upper-case SQL Server mode.
+- K3 core table names with case, whitespace, schema qualification, or SQL
+  quoting.
+- similar but non-core middle-table names.
+- plaintext credential values that must be redacted from generated output.
+
+The preflight behavior before this change had four unsafe or noisy edges:
+
+1. `k3Wise.environment: "UAT"` passed validation but was emitted as `UAT`
+   instead of canonical `uat`.
+2. `autoSubmit: "true"` or `autoAudit: "yes"` passed because only boolean
+   `true` was blocked.
+3. `sqlServer.mode: "READONLY"` was treated as a write mode and could
+   incorrectly block read-only access to K3 core tables.
+4. K3 core table names with whitespace, schema qualification, or brackets were
+   not detected by the core-table write guard.
+
+## Design
+
+### Environment Normalization
+
+`k3Wise.environment` is trimmed, lower-cased, validated against the existing
+non-production allowlist, and then emitted canonically in the packet.
+
+This keeps the packet stable even when the customer answers `UAT`, ` uat `, or
+similar safe variants.
+
+### Save-Only Boolean Guard
+
+`autoSubmit` and `autoAudit` now go through a safety-specific boolean parser.
+
+Accepted false-like values:
+
+- `false`
+- `0`
+- `no`
+- `n`
+- `off`
+- empty string
+- `否`
+- `禁用`
+- `关闭`
+
+Truthy values such as `true`, `1`, `yes`, `on`, `是`, `启用`, and `开启` are
+recognized and blocked by the existing Save-only error. Unknown strings such as
+`maybe` fail with a field-specific validation error.
+
+This is intentionally strict for unsafe intent but tolerant for harmless
+customer formatting mistakes.
+
+### SQL Server Mode Normalization
+
+`sqlServer.mode` is normalized before safety checks.
+
+Canonical modes remain:
+
+- `readonly`
+- `middle-table`
+- `stored-procedure`
+
+Accepted aliases include `READONLY`, `read only`, `read-only`, `middle table`,
+`middle_table`, `stored procedure`, and `stored_procedure`.
+
+Read-only mode can list K3 core tables because it does not write. Write-capable
+modes still cannot target K3 core business tables.
+
+### K3 Core Table Name Guard
+
+The core-table guard now normalizes SQL object names before comparison:
+
+- trim whitespace;
+- lower-case identifiers;
+- strip SQL quoting characters such as `[name]`, `"name"`, `` `name` ``, and
+  `'name'`;
+- use the final object segment for schema-qualified names such as
+  `dbo.t_ICItem`.
+
+The guard still uses exact canonical table names only:
+
+- `t_icitem`
+- `t_icbom`
+- `t_icbomchild`
+
+This blocks direct writes to K3 core tables while allowing customer-approved
+middle tables with similar names such as `t_ICItem_stage`.
+
+## Non-Goals
+
+- No live PLM/K3/SQL Server connectivity.
+- No adapter runtime behavior changes.
+- No new GATE fields.
+- No production-write support.
+- No broad vendor-abstraction work before K3 WISE live PoC PASS.

--- a/docs/development/integration-core-k3wise-preflight-boundary-hardening-verification-20260425.md
+++ b/docs/development/integration-core-k3wise-preflight-boundary-hardening-verification-20260425.md
@@ -1,0 +1,73 @@
+# Integration Core K3 WISE Preflight Boundary Hardening Verification - 2026-04-25
+
+## Scope
+
+This verifies the G1 boundary hardening for
+`scripts/ops/integration-k3wise-live-poc-preflight.mjs`.
+
+The verification is local only. It does not contact PLM, K3 WISE, SQL Server,
+MetaSheet backend, Redis, or Postgres.
+
+## Commands
+
+```bash
+node --test scripts/ops/integration-k3wise-live-poc-preflight.test.mjs
+node scripts/ops/integration-k3wise-live-poc-preflight.mjs --print-sample > /tmp/k3wise-preflight-sample.json
+node -e "JSON.parse(require('fs').readFileSync('/tmp/k3wise-preflight-sample.json','utf8')); console.log('sample json ok')"
+git diff --check -- scripts/ops/integration-k3wise-live-poc-preflight.mjs scripts/ops/integration-k3wise-live-poc-preflight.test.mjs docs/development/integration-core-k3wise-preflight-boundary-hardening-design-20260425.md docs/development/integration-core-k3wise-preflight-boundary-hardening-verification-20260425.md
+```
+
+## Boundary Matrix
+
+| Case | Expected | Actual | Result |
+|---|---:|---:|---:|
+| Baseline sample GATE | PASS | PASS | PASS |
+| K3 API URL with trailing slash | PASS | PASS | PASS |
+| `k3Wise.baseUrl` fallback when `apiUrl` is absent | PASS | PASS | PASS |
+| Upper-case `k3Wise.environment: "UAT"` | PASS, emit `uat` | PASS, emits `uat` | PASS |
+| Chinese production environment text | FAIL | FAIL | PASS |
+| `autoSubmit: "true"` | FAIL | FAIL | PASS |
+| `autoAudit: "yes"` | FAIL | FAIL | PASS |
+| `autoSubmit: "false"` and `autoAudit: "no"` | PASS | PASS | PASS |
+| `sqlServer.mode: "READONLY"` with K3 core table list | PASS | PASS | PASS |
+| Middle-table write to `T_ICITEM` | FAIL | FAIL | PASS |
+| Middle-table write to ` t_ICItem ` | FAIL | FAIL | PASS |
+| Middle-table write to `dbo.t_ICItem` | FAIL | FAIL | PASS |
+| Middle-table write to `[dbo].[t_ICBomChild]` | FAIL | FAIL | PASS |
+| Middle-table write to similar non-core `t_ICItem_stage` | PASS | PASS | PASS |
+| Plaintext credential values in input | PASS, redacted output | PASS, redacted output | PASS |
+
+## Unit Test Result
+
+`node --test scripts/ops/integration-k3wise-live-poc-preflight.test.mjs`
+
+```text
+tests 9
+pass 9
+fail 0
+duration_ms 46.013167
+```
+
+The test file now covers:
+
+- Save-only packet generation.
+- Production environment block.
+- boolean Submit/Audit block.
+- SQL Server K3 core-table write block.
+- safe customer formatting normalization.
+- truthy Submit/Audit string rejection.
+- schema-qualified and quoted K3 core table rejection.
+- BOM product scope requirement.
+- secret redaction for JSON and Markdown output.
+
+## Residual Risk
+
+This hardening only validates local packet generation. The live PoC still needs
+real customer GATE answers before we can verify:
+
+- customer PLM read connectivity;
+- K3 WISE WebAPI/K3API login and Save payload shape;
+- SQL Server account permissions;
+- real material and BOM field mappings;
+- ERP feedback writeback;
+- rollback SOP execution.

--- a/scripts/ops/integration-k3wise-live-poc-preflight.mjs
+++ b/scripts/ops/integration-k3wise-live-poc-preflight.mjs
@@ -7,6 +7,18 @@ const REQUIRED_TOP_LEVEL = ['tenantId', 'workspaceId', 'k3Wise', 'plm', 'rollbac
 const SECRET_KEY_PATTERN = /password|secret|token|session|credential|api[-_]?key|authorization/i
 const NON_PRODUCTION_ENVS = new Set(['test', 'testing', 'uat', 'sandbox', 'staging', 'dev', 'development'])
 const K3_CORE_TABLES = new Set(['t_icitem', 't_icbom', 't_icbomchild'])
+const TRUE_BOOLEAN_TEXT = new Set(['true', '1', 'yes', 'y', 'on', '是', '启用', '开启'])
+const FALSE_BOOLEAN_TEXT = new Set(['false', '0', 'no', 'n', 'off', '否', '禁用', '关闭'])
+const SQL_MODE_ALIASES = new Map([
+  ['read only', 'readonly'],
+  ['read-only', 'readonly'],
+  ['read_only', 'readonly'],
+  ['middle table', 'middle-table'],
+  ['middle_table', 'middle-table'],
+  ['stored procedure', 'stored-procedure'],
+  ['stored_procedure', 'stored-procedure'],
+])
+const SQL_MODES = new Set(['readonly', 'middle-table', 'stored-procedure'])
 
 class LivePocPreflightError extends Error {
   constructor(message, details = {}) {
@@ -45,6 +57,51 @@ function optionalArray(value, field) {
     throw new LivePocPreflightError(`${field} must be an array`, { field })
   }
   return value
+}
+
+function normalizeSafeBoolean(value, field) {
+  if (value === undefined || value === null) return false
+  if (typeof value === 'boolean') return value
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase()
+    if (normalized.length === 0) return false
+    if (TRUE_BOOLEAN_TEXT.has(normalized)) return true
+    if (FALSE_BOOLEAN_TEXT.has(normalized)) return false
+  }
+  throw new LivePocPreflightError(`${field} must be a boolean or false-like string`, { field })
+}
+
+function normalizeSqlMode(value, sqlEnabled) {
+  const fallback = sqlEnabled ? 'readonly' : 'disabled'
+  const text = optionalString(value)
+  if (!text) return fallback
+  const key = text.toLowerCase().replace(/\s+/g, ' ')
+  const normalized = SQL_MODE_ALIASES.get(key) || key
+  if (normalized === 'disabled' && !sqlEnabled) return normalized
+  if (!SQL_MODES.has(normalized)) {
+    throw new LivePocPreflightError('sqlServer.mode must be readonly, middle-table, or stored-procedure', {
+      field: 'sqlServer.mode',
+      mode: text,
+    })
+  }
+  return normalized
+}
+
+function normalizeSqlIdentifierPart(part) {
+  return part
+    .trim()
+    .replace(/^[\[`"']+|[\]`"']+$/g, '')
+    .trim()
+}
+
+function normalizeSqlObjectName(value) {
+  const parts = String(value)
+    .trim()
+    .toLowerCase()
+    .split('.')
+    .map(normalizeSqlIdentifierPart)
+    .filter(Boolean)
+  return parts.length > 0 ? parts[parts.length - 1] : ''
 }
 
 function validateUrl(value, field) {
@@ -136,26 +193,22 @@ function normalizeGate(input) {
     })
   }
 
-  if (k3Wise.autoSubmit === true || k3Wise.autoAudit === true) {
+  const autoSubmit = normalizeSafeBoolean(k3Wise.autoSubmit, 'k3Wise.autoSubmit')
+  const autoAudit = normalizeSafeBoolean(k3Wise.autoAudit, 'k3Wise.autoAudit')
+  if (autoSubmit || autoAudit) {
     throw new LivePocPreflightError('M2 live PoC packet is Save-only: autoSubmit and autoAudit must be false', {
       field: 'k3Wise.autoSubmit/autoAudit',
     })
   }
 
   const sqlEnabled = sqlServer.enabled === true
-  const sqlMode = optionalString(sqlServer.mode) || (sqlEnabled ? 'readonly' : 'disabled')
+  const sqlMode = normalizeSqlMode(sqlServer.mode, sqlEnabled)
   const allowedTables = optionalArray(sqlServer.allowedTables, 'sqlServer.allowedTables').map((table) => String(table))
-  const writesCoreTable = allowedTables.some((table) => K3_CORE_TABLES.has(table.toLowerCase()))
+  const writesCoreTable = allowedTables.some((table) => K3_CORE_TABLES.has(normalizeSqlObjectName(table)))
   if (sqlEnabled && sqlMode !== 'readonly' && (sqlServer.writeCoreTables === true || writesCoreTable)) {
     throw new LivePocPreflightError('SQL Server channel may not write K3 core business tables in live PoC', {
       field: 'sqlServer.allowedTables',
       allowedTables,
-    })
-  }
-  if (sqlEnabled && !['readonly', 'middle-table', 'stored-procedure'].includes(sqlMode)) {
-    throw new LivePocPreflightError('sqlServer.mode must be readonly, middle-table, or stored-procedure', {
-      field: 'sqlServer.mode',
-      mode: sqlMode,
     })
   }
 
@@ -186,9 +239,17 @@ function normalizeGate(input) {
     workspaceId,
     projectId,
     operator,
-    k3Wise,
+    k3Wise: {
+      ...k3Wise,
+      environment,
+      autoSubmit: false,
+      autoAudit: false,
+    },
     plm,
-    sqlServer,
+    sqlServer: {
+      ...sqlServer,
+      mode: sqlMode,
+    },
     rollback,
     fieldMappings,
     bom: {

--- a/scripts/ops/integration-k3wise-live-poc-preflight.test.mjs
+++ b/scripts/ops/integration-k3wise-live-poc-preflight.test.mjs
@@ -92,6 +92,68 @@ test('buildPacket blocks SQL Server writes to K3 core business tables', () => {
   )
 })
 
+test('buildPacket normalizes safe customer formatting variants', () => {
+  const packet = buildPacket(gate({
+    k3Wise: {
+      environment: ' UAT ',
+      autoSubmit: 'false',
+      autoAudit: 'no',
+    },
+    sqlServer: {
+      enabled: true,
+      mode: 'READONLY',
+      allowedTables: ['T_ICITEM'],
+    },
+  }), { generatedAt: '2026-04-25T00:00:00.000Z' })
+
+  assert.equal(packet.safety.environment, 'uat')
+  assert.equal(packet.gateSummary.k3Wise.environment, 'uat')
+  assert.equal(packet.safety.sqlServerMode, 'readonly')
+  assert.equal(packet.externalSystems.find((system) => system.kind === 'erp:k3-wise-sqlserver').config.mode, 'readonly')
+})
+
+test('buildPacket rejects truthy Submit/Audit strings and invalid flag values', () => {
+  for (const k3Wise of [
+    { autoSubmit: 'true' },
+    { autoAudit: 'yes' },
+    { autoSubmit: '是' },
+  ]) {
+    assert.throws(
+      () => buildPacket(gate({ k3Wise })),
+      (error) => error instanceof LivePocPreflightError && /Save-only/.test(error.message),
+    )
+  }
+
+  assert.throws(
+    () => buildPacket(gate({ k3Wise: { autoSubmit: 'maybe' } })),
+    (error) => error instanceof LivePocPreflightError && error.details.field === 'k3Wise.autoSubmit',
+  )
+})
+
+test('buildPacket blocks schema-qualified and quoted K3 core SQL table writes', () => {
+  for (const table of [' t_ICItem ', 'dbo.t_ICItem', '[dbo].[t_ICBomChild]', '"dbo"."t_ICBOM"']) {
+    assert.throws(
+      () => buildPacket(gate({
+        sqlServer: {
+          enabled: true,
+          mode: 'middle table',
+          allowedTables: [table],
+        },
+      })),
+      (error) => error instanceof LivePocPreflightError && error.details.field === 'sqlServer.allowedTables',
+    )
+  }
+
+  const packet = buildPacket(gate({
+    sqlServer: {
+      enabled: true,
+      mode: 'middle table',
+      allowedTables: ['t_ICItem_stage'],
+    },
+  }))
+  assert.equal(packet.safety.sqlServerMode, 'middle-table')
+})
+
 test('buildPacket requires BOM product scope when BOM PoC is enabled', () => {
   assert.throws(
     () => buildPacket(gate({


### PR DESCRIPTION
## Summary
- harden K3 WISE live PoC preflight input normalization for customer GATE JSON variants
- reject truthy string Submit/Audit values instead of silently accepting unsafe intent
- normalize SQL Server mode aliases and detect schema-qualified/quoted K3 core table names before write-capable PoC modes
- add design and verification docs for the G1 boundary probe

## Boundary Probe
- 15/15 boundary cases pass after patch
- covered URL trailing slash, baseUrl fallback, environment casing, Chinese production text, string Submit/Audit flags, SQL mode casing, schema/quoted K3 core table names, similar middle-table names, and plaintext credential redaction

## Verification
- node --test scripts/ops/integration-k3wise-live-poc-preflight.test.mjs
- node scripts/ops/integration-k3wise-live-poc-preflight.mjs --print-sample > /tmp/k3wise-preflight-sample.json
- node -e "JSON.parse(require('fs').readFileSync('/tmp/k3wise-preflight-sample.json','utf8')); console.log('sample json ok')"
- git diff --check -- scripts/ops/integration-k3wise-live-poc-preflight.mjs scripts/ops/integration-k3wise-live-poc-preflight.test.mjs docs/development/integration-core-k3wise-preflight-boundary-hardening-design-20260425.md docs/development/integration-core-k3wise-preflight-boundary-hardening-verification-20260425.md
- node --check scripts/ops/integration-k3wise-live-poc-preflight.mjs && node --check scripts/ops/integration-k3wise-live-poc-preflight.test.mjs