### PR TITLE
fix(integration): coerce remaining K3 WISE preflight boolean strings

### DIFF
--- a/docs/development/integration-core-k3wise-preflight-bool-coercion-design-20260425.md
+++ b/docs/development/integration-core-k3wise-preflight-bool-coercion-design-20260425.md
@@ -1,0 +1,50 @@
+# K3 WISE Preflight Boolean Coercion Sweep · Design
+
+> Date: 2026-04-25
+> Follow-up to: PR #1168 (boundary hardening)
+> Scope: Same-class bug audit on the K3 WISE live PoC preflight script
+
+## Problem
+
+PR #1168 introduced `normalizeSafeBoolean()` to fix a class of bugs where customer JSON containing string `"true"` / `"yes"` / `"是"` would slip past `=== true` strict equality checks for `k3Wise.autoSubmit` and `k3Wise.autoAudit` — making the customer think Save-only was on while the script actually treated those flags as not-true.
+
+Reviewer audit after the merge found **the same bug pattern still exists at three additional sites** in the same script:
+
+| Site | Original code | Risk if customer types `"true"` instead of `true` |
+|---|---|---|
+| `sqlServer.enabled === true` | line 212 | `sqlEnabled = false` → **entire SQL Server validation block is skipped**, including the K3 core-table guard. Customer thinks SQL channel is enabled with safety; script skipped all validation. |
+| `sqlServer.writeCoreTables === true` | line 216 | Even with `sqlEnabled` correctly true, `"true"` here would be read as falsy → core-table writes would not be blocked. |
+| `bom.enabled === true` | line 223 | `bomEnabled = false` → `bom.productId` requirement check does not fire → BOM PoC runs without product scope. |
+
+This is the most severe of the three (#1) because it cascades — disabling the entire SQL Server validation chain when the customer believed they had enabled it.
+
+## Solution
+
+1. Apply `normalizeSafeBoolean()` to all three sites. One-line change each.
+2. Persist normalized values back into the returned `gate` object so downstream consumers (`gate.sqlServer.enabled`, `gate.bom.enabled`, `gate.sqlServer.writeCoreTables`) see canonical `true`/`false` rather than the customer's original input form.
+3. Extend `normalizeSafeBoolean()` to accept numeric `0` and `1` — common spreadsheet-export convention. Any other number (including `NaN`/`Infinity`/`2`) throws with a clear message naming the field and the received value.
+
+## Files changed
+
+- `scripts/ops/integration-k3wise-live-poc-preflight.mjs`
+  - `normalizeSafeBoolean()` extended to handle `typeof value === 'number'` with explicit `0`/`1` mapping and `Number.isFinite` guard
+  - 3 call sites converted from `=== true` to `normalizeSafeBoolean(...)`
+  - Output `gate.sqlServer.{enabled,writeCoreTables}` and `gate.bom.enabled` now hold normalized booleans
+- `scripts/ops/integration-k3wise-live-poc-preflight.test.mjs`
+  - 4 new test cases (1 per fixed site + 1 covering numeric coercion)
+- This design doc + matching verification doc
+
+## Acceptance criteria
+
+- [x] `node --test scripts/ops/integration-k3wise-live-poc-preflight.test.mjs` reports 13/13 pass (was 9/9, +4 new)
+- [x] String `"true"` for `sqlServer.enabled` triggers `allowedTables` core-table guard
+- [x] String `"true"` for `sqlServer.writeCoreTables` triggers core-table guard
+- [x] String `"true"` for `bom.enabled` enforces `bom.productId` requirement
+- [x] Numeric `1` enables booleans; numeric `0` disables; numeric `2` rejected with clear "0 or 1" message; `NaN` rejected with "finite" message
+- [x] Existing 9 tests from PR #1168 unchanged and still pass (no regression)
+- [x] No `=== true` checks remaining on customer-supplied boolean fields in the script (downstream `gate.bom.enabled === true` reads are safe because the value is now canonically boolean)
+
+## Out of scope
+
+- The `mode: 'disabled'` UX message refinement (also flagged in review as item #2 — separate minor PR if pursued).
+- Sweeping other ops scripts (`integration-k3wise-live-poc-evidence.mjs` etc.) for the same pattern. Reviewer audit limited to the preflight script for this PR.

--- a/docs/development/integration-core-k3wise-preflight-bool-coercion-verification-20260425.md
+++ b/docs/development/integration-core-k3wise-preflight-bool-coercion-verification-20260425.md
@@ -1,0 +1,61 @@
+# K3 WISE Preflight Boolean Coercion Sweep · Verification
+
+> Date: 2026-04-25
+> Pairs with: `integration-core-k3wise-preflight-bool-coercion-design-20260425.md`
+
+## Commands run
+
+```bash
+node --test scripts/ops/integration-k3wise-live-poc-preflight.test.mjs
+node --check scripts/ops/integration-k3wise-live-poc-preflight.mjs
+git diff --check
+```
+
+## Results
+
+```
+✔ 13 tests pass (was 9; +4 new)
+✔ syntax check pass
+✔ no whitespace issues
+```
+
+### New test cases (all pass)
+
+1. **`buildPacket coerces sqlServer.enabled "true" string and still applies allowedTables guard`**
+   - Asserts: `enabled: 'true'` + `mode: 'middle-table'` + `allowedTables: ['t_ICItem']` → throws `sqlServer.allowedTables` violation
+   - Asserts: `enabled: 'no'` + no explicit mode → `safety.sqlServerMode === 'disabled'`
+
+2. **`buildPacket coerces sqlServer.writeCoreTables "true" string`**
+   - Asserts: `writeCoreTables: 'true'` + `enabled: true` + `mode: 'middle-table'` + safe `allowedTables` → still throws core-table violation (the writeCoreTables flag alone is enough to trigger guard)
+
+3. **`buildPacket coerces bom.enabled "true" string and enforces productId requirement`**
+   - Asserts: `bom: { enabled: 'true', productId: undefined }` + no PLM `defaultProductId` → throws `bom.productId` requirement
+   - Asserts: `bom: { enabled: '否' }` → BOM PoC pipeline absent from packet
+
+4. **`buildPacket accepts numeric 0/1 for boolean flags but rejects other numbers`**
+   - Asserts: `enabled: 1` + no mode → `sqlServerMode === 'readonly'` (default for enabled)
+   - Asserts: `enabled: 0` + no mode → `sqlServerMode === 'disabled'`
+   - Asserts: `autoSubmit: 2` → throws `/0 or 1/` message
+   - Asserts: `autoAudit: NaN` → throws `/finite/` message
+
+### Regression check (existing 9 tests unchanged)
+
+- `buildPacket emits Save-only external systems, pipelines, and BOM product scope` ✔
+- `buildPacket blocks production K3 WISE environments` ✔
+- `buildPacket blocks Submit/Audit automation in live PoC packet` ✔
+- `buildPacket blocks SQL Server writes to K3 core business tables` ✔
+- `buildPacket normalizes safe customer formatting variants` ✔
+- `buildPacket rejects truthy Submit/Audit strings and invalid flag values` ✔
+- `buildPacket blocks schema-qualified and quoted K3 core SQL table writes` ✔
+- `buildPacket requires BOM product scope when BOM PoC is enabled` ✔
+- `renderMarkdown and CLI outputs do not leak submitted secret values` ✔
+
+## Manual spot checks
+
+- Read the diff for `normalizeSafeBoolean()`: number branch sits between boolean and string checks, preserving precedence order; `Number.isFinite` rejects `NaN`/`Infinity` before strict 0/1 comparison.
+- Verified `gate.sqlServer.enabled`, `gate.sqlServer.writeCoreTables`, `gate.bom.enabled` are now canonical booleans in the returned object — confirmed by grep of `=== true` remaining only at lines 415 and 462 (`gate.bom.enabled === true`), which is now safe because the value is canonically `true`/`false` post-normalization.
+
+## Outstanding (not in this PR)
+
+- Reviewer item #2 (UX) — `mode: 'disabled'` while `enabled: true` produces the generic "must be readonly, middle-table, or stored-procedure" error; clearer guidance ("set `enabled: false` instead") deferred to a separate minor PR.
+- Same-class audit on `integration-k3wise-live-poc-evidence.mjs` deferred — that script reads pre-validated PoC output, so customer-side boolean inputs do not flow through it.

--- a/scripts/ops/integration-k3wise-live-poc-preflight.mjs
+++ b/scripts/ops/integration-k3wise-live-poc-preflight.mjs
@@ -62,13 +62,21 @@ function optionalArray(value, field) {
 function normalizeSafeBoolean(value, field) {
   if (value === undefined || value === null) return false
   if (typeof value === 'boolean') return value
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new LivePocPreflightError(`${field} must be a finite boolean, 0/1, or boolean-like string`, { field })
+    }
+    if (value === 1) return true
+    if (value === 0) return false
+    throw new LivePocPreflightError(`${field} must be 0 or 1 when given as a number`, { field, received: value })
+  }
   if (typeof value === 'string') {
     const normalized = value.trim().toLowerCase()
     if (normalized.length === 0) return false
     if (TRUE_BOOLEAN_TEXT.has(normalized)) return true
     if (FALSE_BOOLEAN_TEXT.has(normalized)) return false
   }
-  throw new LivePocPreflightError(`${field} must be a boolean or false-like string`, { field })
+  throw new LivePocPreflightError(`${field} must be a boolean, 0/1, or boolean-like string`, { field })
 }
 
 function normalizeSqlMode(value, sqlEnabled) {
@@ -201,18 +209,19 @@ function normalizeGate(input) {
     })
   }
 
-  const sqlEnabled = sqlServer.enabled === true
+  const sqlEnabled = normalizeSafeBoolean(sqlServer.enabled, 'sqlServer.enabled')
+  const sqlWriteCoreFlag = normalizeSafeBoolean(sqlServer.writeCoreTables, 'sqlServer.writeCoreTables')
   const sqlMode = normalizeSqlMode(sqlServer.mode, sqlEnabled)
   const allowedTables = optionalArray(sqlServer.allowedTables, 'sqlServer.allowedTables').map((table) => String(table))
   const writesCoreTable = allowedTables.some((table) => K3_CORE_TABLES.has(normalizeSqlObjectName(table)))
-  if (sqlEnabled && sqlMode !== 'readonly' && (sqlServer.writeCoreTables === true || writesCoreTable)) {
+  if (sqlEnabled && sqlMode !== 'readonly' && (sqlWriteCoreFlag || writesCoreTable)) {
     throw new LivePocPreflightError('SQL Server channel may not write K3 core business tables in live PoC', {
       field: 'sqlServer.allowedTables',
       allowedTables,
     })
   }
 
-  const bomEnabled = bom.enabled === true
+  const bomEnabled = normalizeSafeBoolean(bom.enabled, 'bom.enabled')
   const bomProductId = optionalString(bom.productId) || optionalString(plm.defaultProductId) || optionalString(plm.config && plm.config.defaultProductId)
   if (bomEnabled && !bomProductId) {
     throw new LivePocPreflightError('BOM PoC requires bom.productId or plm.defaultProductId', {
@@ -248,12 +257,15 @@ function normalizeGate(input) {
     plm,
     sqlServer: {
       ...sqlServer,
+      enabled: sqlEnabled,
+      writeCoreTables: sqlWriteCoreFlag,
       mode: sqlMode,
     },
     rollback,
     fieldMappings,
     bom: {
       ...bom,
+      enabled: bomEnabled,
       productId: bomProductId,
     },
     sqlEnabled,

--- a/scripts/ops/integration-k3wise-live-poc-preflight.test.mjs
+++ b/scripts/ops/integration-k3wise-live-poc-preflight.test.mjs
@@ -154,6 +154,95 @@ test('buildPacket blocks schema-qualified and quoted K3 core SQL table writes', 
   assert.equal(packet.safety.sqlServerMode, 'middle-table')
 })
 
+test('buildPacket coerces sqlServer.enabled "true" string and still applies allowedTables guard', () => {
+  // Customer types `enabled: "true"` instead of boolean true — without coercion
+  // the script would skip the entire SQL Server validation and the t_ICItem
+  // write would slip past. Same bug class as autoSubmit/autoAudit string truthy.
+  assert.throws(
+    () => buildPacket(gate({
+      sqlServer: {
+        enabled: 'true',
+        mode: 'middle-table',
+        allowedTables: ['t_ICItem'],
+      },
+    })),
+    (error) => error instanceof LivePocPreflightError && error.details.field === 'sqlServer.allowedTables',
+    'string "true" must enable SQL Server channel and trigger core-table guard',
+  )
+
+  // Mirror: enabled: false-like string disables the channel.
+  // Note: must override mode (sampleGate inherits mode='readonly') so the
+  // fallback 'disabled' actually fires; otherwise explicit mode wins.
+  const packet = buildPacket(gate({
+    sqlServer: { enabled: 'no', mode: undefined, allowedTables: [] },
+  }))
+  assert.equal(packet.safety.sqlServerMode, 'disabled', 'string "no" + no explicit mode disables sql server')
+})
+
+test('buildPacket coerces sqlServer.writeCoreTables "true" string', () => {
+  // Same string-truthy pattern: customer typing writeCoreTables: "true" was
+  // previously read as not-true (=== true comparison), bypassing the guard.
+  assert.throws(
+    () => buildPacket(gate({
+      sqlServer: {
+        enabled: true,
+        mode: 'middle-table',
+        writeCoreTables: 'true',
+        allowedTables: ['t_some_safe_table'],
+      },
+    })),
+    (error) => error instanceof LivePocPreflightError && error.details.field === 'sqlServer.allowedTables',
+    'string "true" on writeCoreTables must trigger core-table guard',
+  )
+})
+
+test('buildPacket coerces bom.enabled "true" string and enforces productId requirement', () => {
+  // Same bug class: customer types bom.enabled: "true" with no productId.
+  // Previously slipped past because === true read it as false → BOM PoC
+  // would run without a product scope.
+  assert.throws(
+    () => buildPacket(gate({
+      plm: { defaultProductId: undefined, config: {} },
+      bom: { enabled: 'true', productId: undefined },
+    })),
+    (error) => error instanceof LivePocPreflightError && error.details.field === 'bom.productId',
+    'string "true" on bom.enabled must trigger productId requirement',
+  )
+
+  // Mirror: false-like string disables BOM cleanly.
+  const packet = buildPacket(gate({
+    plm: { defaultProductId: undefined, config: {} },
+    bom: { enabled: '否', productId: undefined },
+  }))
+  const bomPipeline = packet.pipelines.find((pipeline) => pipeline.targetObject === 'bom')
+  assert.equal(bomPipeline, undefined, 'string "否" disables BOM PoC pipeline')
+})
+
+test('buildPacket accepts numeric 0/1 for boolean flags but rejects other numbers', () => {
+  // Common spreadsheet-export pattern: 0/1 as numeric booleans.
+  const packetTrue = buildPacket(gate({
+    sqlServer: { enabled: 1, mode: 'readonly', allowedTables: [] },
+  }))
+  assert.equal(packetTrue.safety.sqlServerMode, 'readonly', 'number 1 enables sql server')
+
+  const packetFalse = buildPacket(gate({
+    sqlServer: { enabled: 0, mode: undefined, allowedTables: [] },
+  }))
+  assert.equal(packetFalse.safety.sqlServerMode, 'disabled', 'number 0 + no explicit mode disables sql server')
+
+  // Non 0/1 number rejected with clear message.
+  assert.throws(
+    () => buildPacket(gate({ k3Wise: { autoSubmit: 2 } })),
+    (error) => error instanceof LivePocPreflightError && /0 or 1/.test(error.message),
+    'number 2 should produce a clear "0 or 1" error',
+  )
+  assert.throws(
+    () => buildPacket(gate({ k3Wise: { autoAudit: NaN } })),
+    (error) => error instanceof LivePocPreflightError && /finite/.test(error.message),
+    'NaN should produce a clear finite-number error',
+  )
+})
+
 test('buildPacket requires BOM product scope when BOM PoC is enabled', () => {
   assert.throws(
     () => buildPacket(gate({


### PR DESCRIPTION
## Summary

Follow-up to PR #1168 closing 3 same-class boolean-string bugs that the boundary hardening PR missed, plus extending numeric coercion (0/1 from spreadsheet exports).

**Scale**: +216/-4, 4 files (1 code, 1 test, 2 docs), 1 commit.

## What this PR fixes

PR #1168 introduced `normalizeSafeBoolean()` and applied it to `k3Wise.autoSubmit` and `k3Wise.autoAudit`. Reviewer audit found **the same `=== true` strict-equality pattern still in use at three additional customer-supplied boolean fields**:

| Site | Original code | Risk before this PR |
|---|---|---|
| `sqlServer.enabled === true` | line 212 | **Most severe.** Customer types `enabled: "true"` → script reads as falsy → `sqlEnabled = false` → entire SQL Server validation block (allowedTables guard, mode check, writeCoreTables guard) is silently skipped while customer believes they enabled it. |
| `sqlServer.writeCoreTables === true` | line 216 | Even with `sqlEnabled` correctly true, `writeCoreTables: "true"` would be read as falsy → core-table writes not blocked. |
| `bom.enabled === true` | line 223 | `bom.enabled: "true"` read as falsy → `bom.productId` requirement check skipped → BOM PoC runs without product scope. |

Same fix mechanism as PR #1168: route through `normalizeSafeBoolean()`, persist canonical boolean back into the returned `gate` object so downstream code reads true booleans.

## Number support extension

Customer JSON often comes from spreadsheet exports where booleans are 0/1. Extended `normalizeSafeBoolean()` to handle:
- `value === 1` → `true`
- `value === 0` → `false`
- Any other finite number → throws `\`${field} must be 0 or 1 when given as a number\``
- `NaN`/`Infinity` → throws `\`${field} must be a finite boolean, 0/1, or boolean-like string\``

## Verification

- [x] `node --test scripts/ops/integration-k3wise-live-poc-preflight.test.mjs` → **13/13 pass** (was 9/9, +4 new)
- [x] `node --check scripts/ops/integration-k3wise-live-poc-preflight.mjs` → syntax clean
- [x] `git diff --check` → no whitespace issues
- [x] All 9 existing tests from #1168 unchanged and still pass — no regression
- [x] Manual grep: no `=== true` checks remaining on customer-supplied boolean fields. Two remaining `gate.bom.enabled === true` reads (lines 415, 462) are post-normalization and now safe.

## New test cases

1. `buildPacket coerces sqlServer.enabled "true" string and still applies allowedTables guard`
2. `buildPacket coerces sqlServer.writeCoreTables "true" string`
3. `buildPacket coerces bom.enabled "true" string and enforces productId requirement`
4. `buildPacket accepts numeric 0/1 for boolean flags but rejects other numbers`

## Out of scope

- **Reviewer item #2 (UX)**: `mode: 'disabled'` while `enabled: true` produces the generic "must be readonly, middle-table, or stored-procedure" error. Clearer guidance ("set `enabled: false` instead") deferred to a separate minor PR.
- Same-class audit on `integration-k3wise-live-poc-evidence.mjs` — that script consumes pre-validated PoC output, no customer-side boolean inputs.

## Why this matters now

K3 WISE GATE email already sent to customer. Their JSON answer can land any time. Without this fix, a customer who types `"true"` instead of `true` (very common — JSON-by-hand or spreadsheet export) would unknowingly bypass safety checks. This PR closes that window before the answer arrives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)