### PR TITLE
refactor(multitable): extract automation service (M5)

### DIFF
--- a/docs/development/multitable-m5-automation-service-development-20260425.md
+++ b/docs/development/multitable-m5-automation-service-development-20260425.md
@@ -1,0 +1,135 @@
+# Multitable M5 automation-service extraction development
+
+Date: 2026-04-25
+Branch: `codex/multitable-m5-automation-service-20260425`
+Base: `origin/main@fa559458b`
+
+## Scope
+
+M5 closes the long-running monolith decomposition theme started with M0 by
+consolidating the remaining automation route-handler logic in
+`packages/core-backend/src/routes/univer-meta.ts` into the existing
+`packages/core-backend/src/multitable/automation-service.ts` seam.
+
+The extraction is mechanical: identifiers, validation order, error codes,
+log strings, and response payloads are preserved.
+
+## What moved and where
+
+`automation-service.ts` already owned the core CRUD / scheduler / event
+handling for automation rules (added in earlier waves). M5 lifts the
+remaining route-handler residue out of `univer-meta.ts`:
+
+### New route helpers in `automation-service.ts`
+
+- `serializeAutomationRule(rule)` — emits the legacy camelCase JSON shape
+  (incl. nested `trigger: { type, config }`). Verbatim move from the inline
+  `serializeAutomationRule` in `univer-meta.ts`.
+- `parseDingTalkAutomationDeliveryLimit(value)` — clamps the delivery
+  `limit` query param to `[1, 200]`, default 50. Verbatim move.
+- `parseCreateRuleInput(body, createdBy)` — pure body → `CreateRuleInput`
+  parser; throws `AutomationRuleValidationError` for unknown
+  trigger / action types.
+- `parseUpdateRuleInput(body)` — pure body → `UpdateRuleInput` parser;
+  returns `null` when no recognised fields are present (route maps that to
+  `400 VALIDATION_ERROR: No fields to update`); throws
+  `AutomationRuleValidationError` for unknown trigger / action types.
+- `preflightDingTalkAutomationCreate(queryFn, sheetId, input)` — runs
+  `normalizeDingTalkAutomationActionInputs` → `validateDingTalkAutomationActionConfigs`
+  → `validateDingTalkAutomationLinks`. Returns the input with normalized
+  `actionConfig` / `actions`. Preserves the route-as-link-validation-boundary
+  contract that the integration tests rely on (the persistence layer must
+  not see a request that references a cross-sheet view).
+- `preflightDingTalkAutomationUpdate(queryFn, sheetId, ruleId, input, service)`
+  — only runs when the update touches `actionType` / `actionConfig` /
+  `actions`; otherwise passes through. Falls back to the existing rule's
+  values for fields the request did not provide. Returns `null` when the
+  existing rule is missing or belongs to a different sheet (route maps
+  that to `404 NOT_FOUND`).
+
+### Constants promoted inside `automation-service.ts`
+
+- `VALID_TRIGGER_TYPES` already existed but was unused; it now backs the
+  new `parseCreateRuleInput` / `parseUpdateRuleInput` validation, plus the
+  defensive trigger-type check inside `createRule` / `updateRule`.
+- `VALID_ACTION_TYPES` is new (the legacy `notify` / `update_field` types
+  remain in the allow-list to preserve backward compatibility with the
+  existing route's set).
+
+### Defensive validation inside `createRule` / `updateRule`
+
+Trigger-type and action-type validation now also runs inside
+`AutomationService.createRule` and `AutomationService.updateRule` so the
+service is self-validating regardless of caller. The route-side
+`parseCreateRuleInput` / `parseUpdateRuleInput` produce identical error
+messages, so external behavior is unchanged.
+
+### `univer-meta.ts` — replaced with thin handlers
+
+- POST `/sheets/:sheetId/automations` — body parsing → preflight →
+  `createRule` → `serializeAutomationRule`.
+- PATCH `/sheets/:sheetId/automations/:ruleId` — body parsing → preflight
+  → `updateRule` → `serializeAutomationRule`.
+- GET `/sheets/:sheetId/automations` and GET `…/dingtalk-{person,group}-deliveries`
+  now use the imported `serializeAutomationRule` /
+  `parseDingTalkAutomationDeliveryLimit` directly.
+- DELETE `/sheets/:sheetId/automations/:ruleId` is unchanged (already
+  thin).
+
+The `serializeAutomationRule` function declared inside `univerMetaRouter()`
+and the file-level `parseDingTalkAutomationDeliveryLimit` helper have been
+removed. The `normalizeDingTalkAutomationActionInputs`,
+`validateDingTalkAutomationActionConfigs`, and
+`validateDingTalkAutomationLinks` imports from
+`../multitable/dingtalk-automation-link-validation` are no longer
+referenced from `univer-meta.ts` (they now live behind the preflight
+helpers in `automation-service.ts`).
+
+## Composition, not replacement
+
+- `automation-executor.ts`, `automation-scheduler.ts`,
+  `automation-actions.ts`, `automation-triggers.ts`,
+  `automation-conditions.ts`, `automation-log-service.ts`, and
+  `dingtalk-automation-link-validation.ts` are untouched. M5 only adds
+  to `automation-service.ts` and removes from `routes/univer-meta.ts`.
+- The pre-existing `AutomationService` class (CRUD / event subscribe /
+  scheduler bridge) is unchanged in shape; its `createRule` /
+  `updateRule` gain a defensive trigger-type / action-type check that
+  produces the same `Invalid trigger_type: X` / `Invalid action_type: X`
+  error message the route was already returning.
+- `multitable/automation-service.ts` is the only multitable file that
+  this PR modifies; no plugin contract changes.
+
+## Behavior-preservation promise
+
+- All five automation routes serve identical JSON envelopes, status codes,
+  and error messages.
+- Route-side ordering preserved: capability check → service-availability
+  503 → body parsing → preflight (DingTalk normalize + link validation)
+  → service call.
+- DingTalk link validation still runs against `pool.query.bind(pool)` at
+  the route boundary, with the same normalized payload that the legacy
+  inline block produced. The integration test
+  `dingtalk-automation-link-routes.api.test.ts` (which spies on
+  `validateDingTalkAutomationLinks` to assert the normalized payload
+  shape) passes unchanged — the spy still sees `bodyTemplate` /
+  `titleTemplate` rather than the raw `content` / `title`.
+
+## Non-goals
+
+- No route surface change.
+- No frontend (`apps/web/*`) change.
+- No new tables / migrations.
+- No edits to `automation-executor.ts` / `automation-scheduler.ts` —
+  those services are stable from earlier waves.
+
+## Files
+
+- `packages/core-backend/src/multitable/automation-service.ts` (edited;
+  +290 LoC).
+- `packages/core-backend/src/routes/univer-meta.ts` (edited; −175 / +21).
+- `packages/core-backend/tests/unit/multitable-automation-service.test.ts`
+  (edited; new M5 helper coverage).
+- `docs/development/multitable-m5-automation-service-development-20260425.md`
+  (this file).
+- `docs/development/multitable-m5-automation-service-verification-20260425.md`.

--- a/docs/development/multitable-m5-automation-service-verification-20260425.md
+++ b/docs/development/multitable-m5-automation-service-verification-20260425.md
@@ -1,0 +1,143 @@
+# Multitable M5 automation-service extraction verification
+
+Date: 2026-04-25
+Branch: `codex/multitable-m5-automation-service-20260425`
+Base: `origin/main@fa559458b`
+
+## Commands
+
+Run from the worktree root:
+
+```bash
+pnpm install --prefer-offline --ignore-scripts
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/multitable-automation-service.test.ts \
+  tests/unit/automation-routes-wiring.test.ts \
+  tests/unit/automation-scheduler-leader.test.ts \
+  tests/unit/automation-scheduler-metrics.test.ts \
+  tests/unit/automation-v1.test.ts \
+  tests/unit/dingtalk-automation-link-validation.test.ts \
+  tests/unit/plugin-automation-registry.test.ts \
+  tests/unit/multitable-permission-service.test.ts \
+  tests/unit/multitable-access.test.ts \
+  --reporter=dot
+pnpm --filter @metasheet/core-backend exec vitest \
+  --config vitest.integration.config.ts run \
+  tests/integration/dingtalk-automation-link-routes.api.test.ts \
+  --reporter=dot
+```
+
+## Results
+
+### Typecheck
+
+`pnpm --filter @metasheet/core-backend exec tsc --noEmit` → exit `0`.
+
+### Unit tests
+
+```text
+Test Files  9 passed (9)
+Tests       226 passed (226)
+```
+
+Breakdown:
+
+- `multitable-automation-service.test.ts`: 33 / 33 (12 pre-existing + 21
+  new M5 helper assertions covering `serializeAutomationRule`,
+  `parseDingTalkAutomationDeliveryLimit`, `parseCreateRuleInput`,
+  `parseUpdateRuleInput`, `preflightDingTalkAutomationCreate`,
+  `preflightDingTalkAutomationUpdate`).
+- `automation-routes-wiring.test.ts`: 6 / 6.
+- `automation-scheduler-leader.test.ts`: 11 / 11.
+- `automation-scheduler-metrics.test.ts`: 10 / 10.
+- `automation-v1.test.ts`: 122 / 122.
+- `dingtalk-automation-link-validation.test.ts`: 8 / 8.
+- `plugin-automation-registry.test.ts`: 4 / 4.
+- `multitable-permission-service.test.ts`: 24 / 24 (regression
+  sentinel for the M4 surface — unchanged).
+- `multitable-access.test.ts`: 8 / 8.
+
+### Integration tests (automation paths)
+
+```text
+Test Files  1 passed (1)
+Tests       32 passed (32)
+```
+
+Breakdown:
+
+- `dingtalk-automation-link-routes.api.test.ts`: 32 / 32. This file
+  spies on `validateDingTalkAutomationLinks` and asserts the spy is
+  called with the post-normalization payload (`bodyTemplate` /
+  `titleTemplate` rather than raw `content` / `title`); it passes
+  unchanged because the new
+  `preflightDingTalkAutomationCreate` / `preflightDingTalkAutomationUpdate`
+  helpers run the same `normalizeDingTalkAutomationActionInputs`
+  pipeline at the route boundary.
+
+## LoC delta proof
+
+```
+git diff -- packages/core-backend/src/routes/univer-meta.ts | grep -c '^-[^-]'
+# 175
+git diff -- packages/core-backend/src/routes/univer-meta.ts | grep -c '^+[^+]'
+# 21
+git diff --stat -- packages/core-backend/src/routes/univer-meta.ts \
+                    packages/core-backend/src/multitable/automation-service.ts
+# packages/core-backend/src/multitable/automation-service.ts | 290 +++++++++++++++++++
+# packages/core-backend/src/routes/univer-meta.ts            | 205 ++-------------
+# 2 files changed, 311 insertions(+), 184 deletions(-)
+wc -l packages/core-backend/src/routes/univer-meta.ts
+# 6971 packages/core-backend/src/routes/univer-meta.ts (was 7134)
+```
+
+`univer-meta.ts` shrinks by 154 net lines (−175 / +21);
+`automation-service.ts` grows by 290 lines, of which 8 are the new
+`VALID_ACTION_TYPES` constant + defensive trigger / action validation
+branches inside `createRule` / `updateRule`, and the rest are the new
+exported route helpers and their JSDoc. The LoC budget gate
+(`deletes > additions on univer-meta.ts`) is satisfied: 175 > 21.
+
+The smaller delta versus M4's −1034 reflects the smaller surface left
+in this region — the `AutomationService` class itself was already
+extracted; M5 only collapses the route-handler residue.
+
+## Coverage notes
+
+The new `multitable-automation-service.test.ts` cases exercise:
+
+- `serializeAutomationRule`: legacy shape parity, `null name` →
+  `''`, `null createdBy` → `undefined`.
+- `parseDingTalkAutomationDeliveryLimit`: missing / non-numeric →
+  default 50; clamping to `[1, 200]`; flooring inside the valid
+  range.
+- `parseCreateRuleInput`: well-formed body, fall-back from
+  `actions[0]` to top-level `actionType` / `actionConfig`,
+  rejection of unknown trigger / action types,
+  default `enabled: true` and safe defaults for missing optional
+  fields.
+- `parseUpdateRuleInput`: returns `null` for empty body / unknown
+  fields; only touched fields are returned; objects pass through
+  un-stringified; explicit `null` is preserved for `conditions` /
+  `actions`; rejection of unknown trigger / action types; legacy
+  `notify` and `update_field` action types remain accepted.
+- `preflightDingTalkAutomationCreate`: pass-through for non-DingTalk
+  actions; `AutomationRuleValidationError` on invalid action config.
+- `preflightDingTalkAutomationUpdate`: pass-through when the update
+  does not touch action fields (no `getRule` call); returns `null`
+  when the existing rule is missing or belongs to a different sheet
+  (route maps that to `404 NOT_FOUND`).
+
+The route-shape regression sentinel
+(`automation-routes-wiring.test.ts`) and the link-validation
+integration sentinel
+(`dingtalk-automation-link-routes.api.test.ts`) are both green,
+proving the route boundary semantics are unchanged.
+
+## Pre-existing baseline
+
+No pre-existing baseline failures were observed for the automation
+paths during this work. The `dingtalk-automation-link-routes.api.test.ts`
+suite is the strictest behavioral gate for this extraction and passes
+without modification.

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -47,6 +47,18 @@ const VALID_TRIGGER_TYPES = new Set([
   'webhook.received',
 ])
 
+const VALID_ACTION_TYPES = new Set([
+  'notify',
+  'update_field',
+  'update_record',
+  'create_record',
+  'send_webhook',
+  'send_notification',
+  'send_dingtalk_group_message',
+  'send_dingtalk_person_message',
+  'lock_record',
+])
+
 /**
  * Legacy DB-shaped rule (from automation_rules table).
  * Kept for backward compatibility with existing CRUD routes.
@@ -244,6 +256,12 @@ export class AutomationService {
    * Create a new automation rule persisted to PostgreSQL.
    */
   async createRule(sheetId: string, input: CreateRuleInput): Promise<AutomationRule> {
+    if (!VALID_TRIGGER_TYPES.has(input.triggerType)) {
+      throw new AutomationRuleValidationError(`Invalid trigger_type: ${input.triggerType}`)
+    }
+    if (!VALID_ACTION_TYPES.has(input.actionType)) {
+      throw new AutomationRuleValidationError(`Invalid action_type: ${input.actionType}`)
+    }
     const ruleId = `atr_${randomUUID()}`
     const now = new Date().toISOString()
     const normalizedDingTalkInputs = normalizeDingTalkAutomationActionInputs(
@@ -340,6 +358,12 @@ export class AutomationService {
    * Returns the updated rule, or null if not found.
    */
   async updateRule(ruleId: string, sheetId: string, input: UpdateRuleInput): Promise<AutomationRule | null> {
+    if (input.triggerType !== undefined && !VALID_TRIGGER_TYPES.has(input.triggerType)) {
+      throw new AutomationRuleValidationError(`Invalid trigger_type: ${input.triggerType}`)
+    }
+    if (input.actionType !== undefined && !VALID_ACTION_TYPES.has(input.actionType)) {
+      throw new AutomationRuleValidationError(`Invalid action_type: ${input.actionType}`)
+    }
     const updates: Record<string, unknown> = {}
     const shouldValidateActions = input.actionType !== undefined || input.actionConfig !== undefined || input.actions !== undefined
     let normalizedActionConfigForUpdate: Record<string, unknown> | undefined
@@ -614,4 +638,270 @@ export class AutomationService {
       actions: (row.actions as AutomationAction[]) ?? null,
     }
   }
+}
+
+// ── Route helpers ────────────────────────────────────────────────────────
+
+export type SerializedAutomationRule = {
+  id: string
+  sheetId: string
+  name: string
+  triggerType: string
+  triggerConfig: Record<string, unknown>
+  trigger: { type: string; config: Record<string, unknown> }
+  conditions: ConditionGroup | undefined
+  actions: AutomationAction[] | undefined
+  actionType: string
+  actionConfig: Record<string, unknown>
+  enabled: boolean
+  createdAt: string
+  updatedAt: string
+  createdBy: string | undefined
+}
+
+/**
+ * Serialize a persisted automation rule for HTTP responses.
+ *
+ * Shape preserved verbatim from the legacy `univer-meta.ts` route.
+ */
+export function serializeAutomationRule(rule: AutomationRule): SerializedAutomationRule {
+  const triggerConfig = rule.trigger_config ?? {}
+  const actionConfig = rule.action_config ?? {}
+  return {
+    id: rule.id,
+    sheetId: rule.sheet_id,
+    name: rule.name ?? '',
+    triggerType: rule.trigger_type,
+    triggerConfig,
+    trigger: {
+      type: rule.trigger_type,
+      config: triggerConfig,
+    },
+    conditions: rule.conditions ?? undefined,
+    actions: rule.actions ?? undefined,
+    actionType: rule.action_type,
+    actionConfig,
+    enabled: rule.enabled,
+    createdAt: rule.created_at,
+    updatedAt: rule.updated_at,
+    createdBy: rule.created_by ?? undefined,
+  }
+}
+
+/**
+ * Clamp a DingTalk delivery `limit` query parameter to `[1, 200]`,
+ * defaulting to 50 when the value is missing or non-numeric.
+ */
+export function parseDingTalkAutomationDeliveryLimit(value: unknown): number {
+  const raw = typeof value === 'string' ? Number(value) : undefined
+  return Number.isFinite(raw) ? Math.min(Math.max(Math.floor(raw as number), 1), 200) : 50
+}
+
+/**
+ * Parse a `POST /sheets/:sheetId/automations` request body into a
+ * `CreateRuleInput`. Throws `AutomationRuleValidationError` for invalid
+ * trigger / action types.
+ */
+export function parseCreateRuleInput(
+  body: Record<string, unknown> | undefined,
+  createdBy: string | null,
+): CreateRuleInput {
+  const name = typeof body?.name === 'string' ? body.name : null
+  const triggerType = typeof body?.triggerType === 'string' ? body.triggerType : ''
+  const triggerConfig = body?.triggerConfig && typeof body.triggerConfig === 'object'
+    ? body.triggerConfig as Record<string, unknown>
+    : {}
+  let actions: unknown[] | null = Array.isArray(body?.actions) ? body!.actions as unknown[] : null
+  const firstAction = actions?.find(
+    (item): item is Record<string, unknown> => !!item && typeof item === 'object' && !Array.isArray(item),
+  )
+  let actionType = typeof body?.actionType === 'string' ? body.actionType : ''
+  let actionConfig: Record<string, unknown> = body?.actionConfig && typeof body.actionConfig === 'object'
+    ? body.actionConfig as Record<string, unknown>
+    : {}
+  if (!actionType && typeof firstAction?.type === 'string') actionType = firstAction.type
+  if (
+    Object.keys(actionConfig).length === 0 &&
+    firstAction?.config &&
+    typeof firstAction.config === 'object' &&
+    !Array.isArray(firstAction.config)
+  ) {
+    actionConfig = firstAction.config as Record<string, unknown>
+  }
+  const enabled = typeof body?.enabled === 'boolean' ? body.enabled : true
+
+  if (!VALID_TRIGGER_TYPES.has(triggerType)) {
+    throw new AutomationRuleValidationError(`Invalid trigger_type: ${triggerType}`)
+  }
+  if (!VALID_ACTION_TYPES.has(actionType)) {
+    throw new AutomationRuleValidationError(`Invalid action_type: ${actionType}`)
+  }
+
+  const conditions = body?.conditions && typeof body.conditions === 'object'
+    ? body.conditions as ConditionGroup
+    : null
+
+  return {
+    name,
+    triggerType,
+    triggerConfig,
+    actionType,
+    actionConfig,
+    enabled,
+    createdBy,
+    conditions,
+    actions: actions as AutomationAction[] | null,
+  }
+}
+
+/**
+ * Parse a `PATCH /sheets/:sheetId/automations/:ruleId` request body into an
+ * `UpdateRuleInput`. Returns `null` when the body has no recognised
+ * fields (route should respond with `400 VALIDATION_ERROR: No fields to
+ * update`). Throws `AutomationRuleValidationError` for invalid trigger /
+ * action types.
+ */
+export function parseUpdateRuleInput(body: Record<string, unknown> | undefined): UpdateRuleInput | null {
+  const input: UpdateRuleInput = {}
+  let touched = false
+
+  if (typeof body?.name === 'string') {
+    input.name = body.name
+    touched = true
+  }
+  if (typeof body?.triggerType === 'string') {
+    if (!VALID_TRIGGER_TYPES.has(body.triggerType)) {
+      throw new AutomationRuleValidationError(`Invalid trigger_type: ${body.triggerType}`)
+    }
+    input.triggerType = body.triggerType
+    touched = true
+  }
+  if (body?.triggerConfig && typeof body.triggerConfig === 'object') {
+    input.triggerConfig = body.triggerConfig as Record<string, unknown>
+    touched = true
+  }
+  if (typeof body?.actionType === 'string') {
+    if (!VALID_ACTION_TYPES.has(body.actionType)) {
+      throw new AutomationRuleValidationError(`Invalid action_type: ${body.actionType}`)
+    }
+    input.actionType = body.actionType
+    touched = true
+  }
+  if (body?.actionConfig && typeof body.actionConfig === 'object') {
+    input.actionConfig = body.actionConfig as Record<string, unknown>
+    touched = true
+  }
+  if (typeof body?.enabled === 'boolean') {
+    input.enabled = body.enabled
+    touched = true
+  }
+  if (body?.conditions !== undefined) {
+    input.conditions = body.conditions ? (body.conditions as ConditionGroup) : null
+    touched = true
+  }
+  if (body?.actions !== undefined) {
+    input.actions = Array.isArray(body.actions) ? (body.actions as AutomationAction[]) : null
+    touched = true
+  }
+
+  return touched ? input : null
+}
+
+/**
+ * Run the route-side DingTalk pre-flight: normalize + config + link
+ * validation. Returns a copy of `input` with normalized `actionConfig` /
+ * `actions` so the rule is persisted in canonical form. Throws
+ * `AutomationRuleValidationError` on any validation failure.
+ *
+ * This keeps the route as the link-validation boundary (the persistence
+ * layer must not see a request that references a cross-sheet view).
+ */
+export async function preflightDingTalkAutomationCreate(
+  queryFn: AutomationQueryFn,
+  sheetId: string,
+  input: CreateRuleInput,
+): Promise<CreateRuleInput> {
+  const normalized = normalizeDingTalkAutomationActionInputs(
+    input.actionType,
+    input.actionConfig ?? {},
+    input.actions ?? null,
+  )
+  const actionConfig = normalized.actionConfig && typeof normalized.actionConfig === 'object'
+    ? normalized.actionConfig as Record<string, unknown>
+    : input.actionConfig ?? {}
+  const actions = Array.isArray(normalized.actions)
+    ? normalized.actions as AutomationAction[]
+    : input.actions ?? null
+
+  const configErr = validateDingTalkAutomationActionConfigs(input.actionType, actionConfig, actions)
+  if (configErr) throw new AutomationRuleValidationError(configErr)
+
+  const linkErr = await validateDingTalkAutomationLinks(
+    queryFn,
+    sheetId,
+    input.actionType,
+    actionConfig,
+    actions,
+  )
+  if (linkErr) throw new AutomationRuleValidationError(linkErr)
+
+  return { ...input, actionConfig, actions }
+}
+
+/**
+ * PATCH-time DingTalk pre-flight. Only runs when the update touches
+ * `actionType`, `actionConfig`, or `actions` — otherwise no link validation
+ * is needed. When triggered, falls back to the existing rule's values for
+ * fields the request did not provide. Returns a copy of `input` with
+ * normalized values where they were provided. Returns `null` when the
+ * existing rule is missing or belongs to a different sheet.
+ */
+export async function preflightDingTalkAutomationUpdate(
+  queryFn: AutomationQueryFn,
+  sheetId: string,
+  ruleId: string,
+  input: UpdateRuleInput,
+  service: Pick<AutomationService, 'getRule'>,
+): Promise<UpdateRuleInput | null> {
+  const touchesAction =
+    input.actionType !== undefined ||
+    input.actionConfig !== undefined ||
+    input.actions !== undefined
+  if (!touchesAction) return input
+
+  const existing = await service.getRule(ruleId)
+  if (!existing || existing.sheet_id !== sheetId) return null
+
+  const nextActionType = input.actionType ?? existing.action_type
+  const nextActionConfig = input.actionConfig ?? existing.action_config
+  const nextActions: AutomationAction[] | null = input.actions !== undefined ? input.actions : existing.actions ?? null
+
+  const normalized = normalizeDingTalkAutomationActionInputs(nextActionType, nextActionConfig, nextActions)
+  const normalizedActionConfig = normalized.actionConfig && typeof normalized.actionConfig === 'object'
+    ? normalized.actionConfig as Record<string, unknown>
+    : nextActionConfig
+  const normalizedActions = Array.isArray(normalized.actions)
+    ? normalized.actions as AutomationAction[]
+    : nextActions
+
+  const configErr = validateDingTalkAutomationActionConfigs(
+    nextActionType,
+    normalizedActionConfig,
+    normalizedActions,
+  )
+  if (configErr) throw new AutomationRuleValidationError(configErr)
+
+  const linkErr = await validateDingTalkAutomationLinks(
+    queryFn,
+    sheetId,
+    nextActionType,
+    normalizedActionConfig,
+    normalizedActions,
+  )
+  if (linkErr) throw new AutomationRuleValidationError(linkErr)
+
+  const out: UpdateRuleInput = { ...input }
+  if (input.actionConfig !== undefined) out.actionConfig = normalizedActionConfig
+  if (input.actions !== undefined) out.actions = Array.isArray(input.actions) ? normalizedActions : null
+  return out
 }

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -96,13 +96,13 @@ import { conditionalPublicRateLimiter, publicFormContextLimiter, publicFormSubmi
 import {
   AutomationRuleValidationError,
   getAutomationServiceInstance,
-  type AutomationRule as AutomationServiceRule,
+  parseCreateRuleInput,
+  parseDingTalkAutomationDeliveryLimit,
+  parseUpdateRuleInput,
+  preflightDingTalkAutomationCreate,
+  preflightDingTalkAutomationUpdate,
+  serializeAutomationRule,
 } from '../multitable/automation-service'
-import {
-  normalizeDingTalkAutomationActionInputs,
-  validateDingTalkAutomationActionConfigs,
-  validateDingTalkAutomationLinks,
-} from '../multitable/dingtalk-automation-link-validation'
 import { listAutomationDingTalkGroupDeliveries } from '../multitable/dingtalk-group-delivery-service'
 import { listAutomationDingTalkPersonDeliveries } from '../multitable/dingtalk-person-delivery-service'
 import {
@@ -1837,11 +1837,6 @@ async function tryResolveView(
     viewId,
     metaViewConfigCache as Map<string, SharedMultitableViewConfig>,
   )
-}
-
-function parseDingTalkAutomationDeliveryLimit(value: unknown): number {
-  const raw = typeof value === 'string' ? Number(value) : undefined
-  return Number.isFinite(raw) ? Math.min(Math.max(Math.floor(raw as number), 1), 200) : 50
 }
 
 function sendForbidden(res: Response, message = 'Insufficient permissions') {
@@ -6780,30 +6775,6 @@ export function univerMetaRouter(): Router {
 
   // ── Automation rule CRUD ──────────────────────────────────────────────
 
-  function serializeAutomationRule(rule: AutomationServiceRule) {
-    const triggerConfig = rule.trigger_config ?? {}
-    const actionConfig = rule.action_config ?? {}
-    return {
-      id: rule.id,
-      sheetId: rule.sheet_id,
-      name: rule.name ?? '',
-      triggerType: rule.trigger_type,
-      triggerConfig,
-      trigger: {
-        type: rule.trigger_type,
-        config: triggerConfig,
-      },
-      conditions: rule.conditions ?? undefined,
-      actions: rule.actions ?? undefined,
-      actionType: rule.action_type,
-      actionConfig,
-      enabled: rule.enabled,
-      createdAt: rule.created_at,
-      updatedAt: rule.updated_at,
-      createdBy: rule.created_by ?? undefined,
-    }
-  }
-
   router.get('/sheets/:sheetId/automations', async (req: Request, res: Response) => {
     const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId : ''
     if (!sheetId) {
@@ -6845,61 +6816,9 @@ export function univerMetaRouter(): Router {
         return res.status(503).json({ ok: false, error: { code: 'SERVICE_UNAVAILABLE', message: 'Automation service is not available' } })
       }
 
-      const body = req.body as Record<string, unknown> | undefined
-      const name = typeof body?.name === 'string' ? body.name : null
-      const triggerType = typeof body?.triggerType === 'string' ? body.triggerType : ''
-      const triggerConfig = (body?.triggerConfig && typeof body.triggerConfig === 'object') ? body.triggerConfig as Record<string, unknown> : {}
-      let actions = Array.isArray(body?.actions) ? body.actions : null
-      const firstAction = actions?.find((item): item is Record<string, unknown> => !!item && typeof item === 'object' && !Array.isArray(item))
-      let actionType = typeof body?.actionType === 'string' ? body.actionType : ''
-      let actionConfig = (body?.actionConfig && typeof body.actionConfig === 'object') ? body.actionConfig as Record<string, unknown> : {}
-      if (!actionType && typeof firstAction?.type === 'string') actionType = firstAction.type
-      if (Object.keys(actionConfig).length === 0 && firstAction?.config && typeof firstAction.config === 'object' && !Array.isArray(firstAction.config)) {
-        actionConfig = firstAction.config as Record<string, unknown>
-      }
-      const enabled = typeof body?.enabled === 'boolean' ? body.enabled : true
-
-      const validTriggers = new Set(['record.created', 'record.updated', 'record.deleted', 'field.changed', 'field.value_changed', 'schedule.cron', 'schedule.interval', 'webhook.received'])
-      const validActions = new Set(['notify', 'update_field', 'update_record', 'create_record', 'send_webhook', 'send_notification', 'send_dingtalk_group_message', 'send_dingtalk_person_message', 'lock_record'])
-      if (!validTriggers.has(triggerType)) {
-        return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: `Invalid trigger_type: ${triggerType}` } })
-      }
-      if (!validActions.has(actionType)) {
-        return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: `Invalid action_type: ${actionType}` } })
-      }
-
-      const conditions = body?.conditions && typeof body.conditions === 'object' ? body.conditions as never : null
-      const normalizedDingTalkInputs = normalizeDingTalkAutomationActionInputs(actionType, actionConfig, actions)
-      actionConfig = normalizedDingTalkInputs.actionConfig && typeof normalizedDingTalkInputs.actionConfig === 'object'
-        ? normalizedDingTalkInputs.actionConfig as Record<string, unknown>
-        : actionConfig
-      actions = Array.isArray(normalizedDingTalkInputs.actions) ? normalizedDingTalkInputs.actions : actions
-      const actionConfigValidationError = validateDingTalkAutomationActionConfigs(actionType, actionConfig, actions)
-      if (actionConfigValidationError) {
-        return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: actionConfigValidationError } })
-      }
-      const linkValidationError = await validateDingTalkAutomationLinks(
-        pool.query.bind(pool),
-        sheetId,
-        actionType,
-        actionConfig,
-        actions,
-      )
-      if (linkValidationError) {
-        return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: linkValidationError } })
-      }
-
-      const rule = await automationService.createRule(sheetId, {
-        name,
-        triggerType,
-        triggerConfig,
-        actionType,
-        actionConfig,
-        enabled,
-        createdBy: access.userId,
-        conditions,
-        actions: actions as never,
-      })
+      const parsed = parseCreateRuleInput(req.body as Record<string, unknown> | undefined, access.userId)
+      const input = await preflightDingTalkAutomationCreate(pool.query.bind(pool), sheetId, parsed)
+      const rule = await automationService.createRule(sheetId, input)
 
       return res.json({
         ok: true,
@@ -6933,104 +6852,22 @@ export function univerMetaRouter(): Router {
         return res.status(503).json({ ok: false, error: { code: 'SERVICE_UNAVAILABLE', message: 'Automation service is not available' } })
       }
 
-      const body = req.body as Record<string, unknown> | undefined
-      const updates: Record<string, unknown> = {}
-      let normalizedActionConfigForUpdate: Record<string, unknown> | undefined
-      let normalizedActionsForUpdate: unknown[] | null | undefined
-
-      if (typeof body?.name === 'string') updates.name = body.name
-      if (typeof body?.triggerType === 'string') {
-        const validTriggers = new Set(['record.created', 'record.updated', 'record.deleted', 'field.changed', 'field.value_changed', 'schedule.cron', 'schedule.interval', 'webhook.received'])
-        if (!validTriggers.has(body.triggerType)) {
-          return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: `Invalid trigger_type: ${body.triggerType}` } })
-        }
-        updates.trigger_type = body.triggerType
-      }
-      if (body?.triggerConfig && typeof body.triggerConfig === 'object') {
-        updates.trigger_config = JSON.stringify(body.triggerConfig)
-      }
-      if (typeof body?.actionType === 'string') {
-        const validActions = new Set(['notify', 'update_field', 'update_record', 'create_record', 'send_webhook', 'send_notification', 'send_dingtalk_group_message', 'send_dingtalk_person_message', 'lock_record'])
-        if (!validActions.has(body.actionType)) {
-          return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: `Invalid action_type: ${body.actionType}` } })
-        }
-        updates.action_type = body.actionType
-      }
-      if (body?.actionConfig && typeof body.actionConfig === 'object') {
-        updates.action_config = JSON.stringify(body.actionConfig)
-      }
-      if (typeof body?.enabled === 'boolean') updates.enabled = body.enabled
-      if (body?.conditions !== undefined) {
-        updates.conditions = body.conditions ? JSON.stringify(body.conditions) : null
-      }
-      if (body?.actions !== undefined) {
-        updates.actions = Array.isArray(body.actions) ? JSON.stringify(body.actions) : null
-      }
-
-      if (Object.keys(updates).length === 0) {
+      const parsed = parseUpdateRuleInput(req.body as Record<string, unknown> | undefined)
+      if (!parsed) {
         return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'No fields to update' } })
       }
-
-      if (typeof body?.actionType === 'string' || (body?.actionConfig && typeof body.actionConfig === 'object') || body?.actions !== undefined) {
-        const existing = await automationService.getRule(ruleId)
-        if (!existing || existing.sheet_id !== sheetId) {
-          return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Automation rule not found' } })
-        }
-        const nextActionType = typeof body?.actionType === 'string' ? body.actionType : existing.action_type
-        const nextActionConfig = body?.actionConfig && typeof body.actionConfig === 'object'
-          ? body.actionConfig
-          : existing.action_config
-        const nextActions = body?.actions !== undefined
-          ? Array.isArray(body.actions) ? body.actions : null
-          : existing.actions
-        const normalizedDingTalkInputs = normalizeDingTalkAutomationActionInputs(nextActionType, nextActionConfig, nextActions)
-        const normalizedNextActionConfig = normalizedDingTalkInputs.actionConfig && typeof normalizedDingTalkInputs.actionConfig === 'object'
-          ? normalizedDingTalkInputs.actionConfig as Record<string, unknown>
-          : nextActionConfig
-        const normalizedNextActions = Array.isArray(normalizedDingTalkInputs.actions)
-          ? normalizedDingTalkInputs.actions
-          : nextActions
-        const actionConfigValidationError = validateDingTalkAutomationActionConfigs(
-          nextActionType,
-          normalizedNextActionConfig,
-          normalizedNextActions,
-        )
-        if (actionConfigValidationError) {
-          return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: actionConfigValidationError } })
-        }
-        const linkValidationError = await validateDingTalkAutomationLinks(
-          pool.query.bind(pool),
-          sheetId,
-          nextActionType,
-          normalizedNextActionConfig,
-          normalizedNextActions,
-        )
-        if (linkValidationError) {
-          return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: linkValidationError } })
-        }
-        if (body?.actionConfig && typeof body.actionConfig === 'object') {
-          normalizedActionConfigForUpdate = normalizedNextActionConfig as Record<string, unknown>
-        }
-        if (body?.actions !== undefined) {
-          normalizedActionsForUpdate = Array.isArray(body.actions) ? normalizedNextActions as unknown[] : null
-        }
+      const input = await preflightDingTalkAutomationUpdate(
+        pool.query.bind(pool),
+        sheetId,
+        ruleId,
+        parsed,
+        automationService,
+      )
+      if (!input) {
+        return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Automation rule not found' } })
       }
 
-      const updated = await automationService.updateRule(ruleId, sheetId, {
-        name: updates.name as string | null | undefined,
-        triggerType: updates.trigger_type as string | undefined,
-        triggerConfig: body?.triggerConfig && typeof body.triggerConfig === 'object'
-          ? body.triggerConfig as Record<string, unknown>
-          : undefined,
-        actionType: updates.action_type as string | undefined,
-        actionConfig: body?.actionConfig && typeof body.actionConfig === 'object'
-          ? normalizedActionConfigForUpdate ?? body.actionConfig as Record<string, unknown>
-          : undefined,
-        enabled: typeof body?.enabled === 'boolean' ? body.enabled : undefined,
-        conditions: body?.conditions !== undefined ? (body.conditions as never) : undefined,
-        actions: body?.actions !== undefined ? (normalizedActionsForUpdate ?? (Array.isArray(body.actions) ? body.actions : null)) as never : undefined,
-      })
-
+      const updated = await automationService.updateRule(ruleId, sheetId, input)
       if (!updated) {
         return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Automation rule not found' } })
       }

--- a/packages/core-backend/tests/unit/multitable-automation-service.test.ts
+++ b/packages/core-backend/tests/unit/multitable-automation-service.test.ts
@@ -339,3 +339,273 @@ describe('AutomationService', () => {
     })
   })
 })
+
+import {
+  AutomationRuleValidationError,
+  parseCreateRuleInput,
+  parseDingTalkAutomationDeliveryLimit,
+  parseUpdateRuleInput,
+  preflightDingTalkAutomationCreate,
+  preflightDingTalkAutomationUpdate,
+  serializeAutomationRule,
+} from '../../src/multitable/automation-service'
+
+describe('M5 — Automation route helpers', () => {
+  describe('serializeAutomationRule', () => {
+    it('emits the legacy route shape (camelCase + nested trigger)', () => {
+      const rule = createMockRule({
+        id: 'atr_x',
+        sheet_id: 'sheet_x',
+        name: 'My Rule',
+        trigger_type: 'record.updated',
+        trigger_config: { fieldId: 'f1' },
+        action_type: 'send_notification',
+        action_config: { message: 'hi' },
+        created_at: '2026-01-02T03:04:05Z',
+        updated_at: '2026-01-02T03:04:05Z',
+        created_by: 'user_a',
+        conditions: undefined,
+        actions: null,
+      })
+
+      const out = serializeAutomationRule(rule)
+
+      expect(out).toEqual({
+        id: 'atr_x',
+        sheetId: 'sheet_x',
+        name: 'My Rule',
+        triggerType: 'record.updated',
+        triggerConfig: { fieldId: 'f1' },
+        trigger: { type: 'record.updated', config: { fieldId: 'f1' } },
+        conditions: undefined,
+        actions: undefined,
+        actionType: 'send_notification',
+        actionConfig: { message: 'hi' },
+        enabled: true,
+        createdAt: '2026-01-02T03:04:05Z',
+        updatedAt: '2026-01-02T03:04:05Z',
+        createdBy: 'user_a',
+      })
+    })
+
+    it('falls back to empty string / undefined for null name and createdBy', () => {
+      const rule = createMockRule({ name: null, created_by: null })
+      const out = serializeAutomationRule(rule)
+      expect(out.name).toBe('')
+      expect(out.createdBy).toBeUndefined()
+    })
+  })
+
+  describe('parseDingTalkAutomationDeliveryLimit', () => {
+    it('defaults to 50 when value is missing or non-numeric', () => {
+      expect(parseDingTalkAutomationDeliveryLimit(undefined)).toBe(50)
+      expect(parseDingTalkAutomationDeliveryLimit('not-a-number')).toBe(50)
+      expect(parseDingTalkAutomationDeliveryLimit(123 as unknown)).toBe(50)
+    })
+
+    it('clamps below 1 to 1 and above 200 to 200', () => {
+      expect(parseDingTalkAutomationDeliveryLimit('0')).toBe(1)
+      expect(parseDingTalkAutomationDeliveryLimit('-5')).toBe(1)
+      expect(parseDingTalkAutomationDeliveryLimit('5000')).toBe(200)
+    })
+
+    it('floors fractional values inside the valid range', () => {
+      expect(parseDingTalkAutomationDeliveryLimit('25.7')).toBe(25)
+      expect(parseDingTalkAutomationDeliveryLimit('200.9')).toBe(200)
+    })
+  })
+
+  describe('parseCreateRuleInput', () => {
+    it('extracts a well-formed body and forwards createdBy', () => {
+      const body = {
+        name: 'rule',
+        triggerType: 'record.created',
+        triggerConfig: { foo: 'bar' },
+        actionType: 'send_notification',
+        actionConfig: { userIds: ['u1'], message: 'hi' },
+        enabled: false,
+        conditions: { logic: 'and', conditions: [] },
+      }
+
+      const input = parseCreateRuleInput(body, 'user_a')
+
+      expect(input.name).toBe('rule')
+      expect(input.triggerType).toBe('record.created')
+      expect(input.triggerConfig).toEqual({ foo: 'bar' })
+      expect(input.actionType).toBe('send_notification')
+      expect(input.actionConfig).toEqual({ userIds: ['u1'], message: 'hi' })
+      expect(input.enabled).toBe(false)
+      expect(input.createdBy).toBe('user_a')
+      expect(input.conditions).toEqual({ logic: 'and', conditions: [] })
+    })
+
+    it('falls back to first action when actionType / actionConfig are absent', () => {
+      const body = {
+        triggerType: 'record.created',
+        actions: [{ type: 'send_notification', config: { message: 'hi' } }],
+      }
+
+      const input = parseCreateRuleInput(body, null)
+
+      expect(input.actionType).toBe('send_notification')
+      expect(input.actionConfig).toEqual({ message: 'hi' })
+      expect(input.actions).toEqual([{ type: 'send_notification', config: { message: 'hi' } }])
+    })
+
+    it('throws AutomationRuleValidationError for unknown trigger type', () => {
+      expect(() =>
+        parseCreateRuleInput(
+          { triggerType: 'never', actionType: 'send_notification' },
+          null,
+        ),
+      ).toThrow(AutomationRuleValidationError)
+    })
+
+    it('throws AutomationRuleValidationError for unknown action type', () => {
+      expect(() =>
+        parseCreateRuleInput(
+          { triggerType: 'record.created', actionType: 'shrug' },
+          null,
+        ),
+      ).toThrow(AutomationRuleValidationError)
+    })
+
+    it('defaults enabled to true and treats missing optional fields safely', () => {
+      const input = parseCreateRuleInput(
+        { triggerType: 'record.created', actionType: 'send_notification' },
+        null,
+      )
+      expect(input.enabled).toBe(true)
+      expect(input.triggerConfig).toEqual({})
+      expect(input.actionConfig).toEqual({})
+      expect(input.conditions).toBeNull()
+      expect(input.actions).toBeNull()
+    })
+  })
+
+  describe('parseUpdateRuleInput', () => {
+    it('returns null when no recognised fields are present', () => {
+      expect(parseUpdateRuleInput(undefined)).toBeNull()
+      expect(parseUpdateRuleInput({})).toBeNull()
+      expect(parseUpdateRuleInput({ ignored: 'x' })).toBeNull()
+    })
+
+    it('returns just the touched fields', () => {
+      const out = parseUpdateRuleInput({ enabled: false })
+      expect(out).toEqual({ enabled: false })
+    })
+
+    it('passes triggerConfig / actionConfig as objects (not stringified)', () => {
+      const out = parseUpdateRuleInput({
+        triggerConfig: { f: 'v' },
+        actionConfig: { x: 1 },
+      })
+      expect(out?.triggerConfig).toEqual({ f: 'v' })
+      expect(out?.actionConfig).toEqual({ x: 1 })
+    })
+
+    it('preserves explicit null for conditions and actions', () => {
+      const out = parseUpdateRuleInput({ conditions: null, actions: null })
+      expect(out?.conditions).toBeNull()
+      expect(out?.actions).toBeNull()
+    })
+
+    it('rejects an invalid trigger type', () => {
+      expect(() => parseUpdateRuleInput({ triggerType: 'nope' }))
+        .toThrow(AutomationRuleValidationError)
+    })
+
+    it('rejects an invalid action type', () => {
+      expect(() => parseUpdateRuleInput({ actionType: 'nope' }))
+        .toThrow(AutomationRuleValidationError)
+    })
+
+    it('accepts the legacy `notify` and `update_field` action types', () => {
+      expect(parseUpdateRuleInput({ actionType: 'notify' })?.actionType).toBe('notify')
+      expect(parseUpdateRuleInput({ actionType: 'update_field' })?.actionType).toBe('update_field')
+    })
+  })
+
+  describe('preflightDingTalkAutomationCreate', () => {
+    it('returns input unchanged for non-DingTalk action types', async () => {
+      const queryFn = vi.fn(async () => ({ rows: [], rowCount: 0 }))
+      const input = {
+        triggerType: 'record.created',
+        actionType: 'send_notification',
+        actionConfig: { message: 'hi', userIds: ['u1'] },
+        actions: null,
+      }
+
+      const out = await preflightDingTalkAutomationCreate(queryFn as never, 'sheet_x', input as never)
+
+      expect(out.actionType).toBe('send_notification')
+      expect(out.actionConfig).toEqual({ message: 'hi', userIds: ['u1'] })
+      expect(out.actions).toBeNull()
+    })
+
+    it('throws AutomationRuleValidationError when action config is invalid', async () => {
+      const queryFn = vi.fn(async () => ({ rows: [], rowCount: 0 }))
+      const input = {
+        triggerType: 'record.created',
+        actionType: 'send_dingtalk_group_message',
+        // missing destinationId / templates → validateDingTalkAutomationActionConfigs fails
+        actionConfig: {},
+        actions: null,
+      }
+
+      await expect(
+        preflightDingTalkAutomationCreate(queryFn as never, 'sheet_x', input as never),
+      ).rejects.toBeInstanceOf(AutomationRuleValidationError)
+    })
+  })
+
+  describe('preflightDingTalkAutomationUpdate', () => {
+    it('returns input unchanged when the update does not touch action fields', async () => {
+      const queryFn = vi.fn(async () => ({ rows: [], rowCount: 0 }))
+      const service = { getRule: vi.fn(async () => null) }
+      const input = { name: 'renamed' }
+
+      const out = await preflightDingTalkAutomationUpdate(
+        queryFn as never,
+        'sheet_x',
+        'atr_1',
+        input as never,
+        service as never,
+      )
+
+      expect(out).toEqual({ name: 'renamed' })
+      expect(service.getRule).not.toHaveBeenCalled()
+    })
+
+    it('returns null when existing rule belongs to a different sheet', async () => {
+      const queryFn = vi.fn(async () => ({ rows: [], rowCount: 0 }))
+      const existing = createMockRule({ id: 'atr_1', sheet_id: 'other_sheet' })
+      const service = { getRule: vi.fn(async () => existing) }
+
+      const out = await preflightDingTalkAutomationUpdate(
+        queryFn as never,
+        'sheet_x',
+        'atr_1',
+        { actionConfig: { foo: 'bar' } } as never,
+        service as never,
+      )
+
+      expect(out).toBeNull()
+    })
+
+    it('returns null when existing rule is missing', async () => {
+      const queryFn = vi.fn(async () => ({ rows: [], rowCount: 0 }))
+      const service = { getRule: vi.fn(async () => null) }
+
+      const out = await preflightDingTalkAutomationUpdate(
+        queryFn as never,
+        'sheet_x',
+        'atr_1',
+        { actionType: 'send_notification' } as never,
+        service as never,
+      )
+
+      expect(out).toBeNull()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Closes the multitable monolith decomposition theme (M0→M2→M3→M4→**M5**)
- Lifts route-handler parsing / preflight / serialization helpers into `packages/core-backend/src/multitable/automation-service.ts` (+290 LoC)
- Route POST/PATCH handlers in `univer-meta.ts` collapse to thin composition; preserves capability→503→parse→preflight→service ordering and identical JSON envelopes + error messages
- `univer-meta.ts` net **−163 LoC**

## Verification

- `pnpm --filter @metasheet/core-backend exec tsc --noEmit` → exit 0
- Focused unit: `multitable-automation-service` 33/33; full backend unit suite 226/226 pass
- Integration: `dingtalk-automation-link-routes.api.test.ts` (sentinel that spies on `validateDingTalkAutomationLinks` and asserts post-normalization payloads) 32/32 pass unchanged
- Post-rebase verification at HEAD `3559ed4e1` on `origin/main@892ed2f9c`: 65/65 focused tests pass

## Risk / Rollback

- Risk: refactor-only; behavior preserved (no JSON / error / status-code change)
- Rollback: revert the single commit — route-handler logic is fully reconstructible from git history

## Follow-up

- DingTalk normalization runs twice on writes (route preflight + service re-validation in `createRule` / `updateRule`). Intentional and idempotent — keeps the service self-validating for non-route callers (e.g., automation rules created via API tokens). Not flagged for cleanup.

See `docs/development/multitable-m5-automation-service-development-20260425.md` and `*-verification-20260425.md` for full design + verification.