### PR TITLE
feat(approval): add SLA breach notification channels

### DIFF
--- a/docs/development/approval-sla-breach-notify-development-20260425.md
+++ b/docs/development/approval-sla-breach-notify-development-20260425.md
@@ -98,10 +98,14 @@ Justification (the task spec asked us to pick simpler with a written
 rationale):
 
 - The scheduler runs only on the leader, so one process is enough to
-  dedupe. Follower failover is rare and re-notification on takeover is an
-  acceptable v0 tradeoff (the next 15-minute tick would re-flag the same
-  rows anyway since `sla_breached_at` is set once per breach, not per
-  notification).
+  dedupe. Follower failover and process restarts cause **under**
+  notification, not duplicates: `ApprovalMetricsService.checkSlaBreaches`
+  filters on `sla_breached = FALSE` and flips the flag inside the same
+  `UPDATE … RETURNING`, so a row already flagged in a previous epoch never
+  re-enters the notifier pipeline. Losing the in-memory set on restart
+  means at most a previously-missed dispatch stays missed; we never
+  spam-notify a row twice. Acceptable for v0; the persistent column
+  follow-up below covers the missed-on-restart case.
 - A persistent `breach_notified_at` column would require:
   - a new Kysely migration in `db/migrations/`,
   - bumping `APPROVAL_SCHEMA_BOOTSTRAP_VERSION` in

--- a/docs/development/approval-sla-breach-notify-development-20260425.md
+++ b/docs/development/approval-sla-breach-notify-development-20260425.md
@@ -1,0 +1,216 @@
+# Approval SLA Breach Notify Development - 2026-04-25
+
+## Context
+
+Wave 2 WP5 shipped the approval SLA observability stack:
+
+- `ApprovalSlaScheduler` periodically scans `approval_metrics` and flips
+  `sla_breached = TRUE` for active instances whose `started_at + sla_hours`
+  has elapsed.
+- Subsequent merges added a Redis leader lock (#1160) and follower-takeover
+  hardening (#1163) so a multi-pod deployment elects a single notifier.
+- The scheduler exposes an `onBreach(ids)` callback hook that was left
+  intentionally unwired so this slice could pick the output channel.
+
+This slice wires `onBreach` to a pluggable notification dispatcher with
+DingTalk and email channels.
+
+## Scope
+
+- New `ApprovalBreachNotifier` service that fans `onBreach(ids)` out to a
+  list of channels in parallel.
+- New channel contract under `services/breach-channels/` with two
+  implementations:
+  - `ApprovalBreachDingTalkChannel` — reuses
+    `integrations/dingtalk/robot.ts` helpers and posts a markdown payload
+    via `fetch`.
+  - `ApprovalBreachEmailChannel` — logging stub. No SMTP transport exists
+    in core-backend (`grep nodemailer|sendgrid|mailgun|transporter` is
+    empty) and the task forbids adding new dependencies. The stub observes
+    `APPROVAL_BREACH_EMAIL_FROM` / `APPROVAL_BREACH_EMAIL_TO` and logs a
+    warn line per dispatch but always reports `ok: false`.
+- Wired the notifier into `ApprovalSlaScheduler.onBreach` from
+  `MetaSheetServer.start()`. The scheduler's existing try/catch around
+  `onBreach` (ApprovalSlaScheduler.ts L138-144) absorbs notifier failures;
+  we still wrap the call site for explicit logging.
+- Added `ApprovalMetricsService.listBreachContextByIds(ids)` to JOIN
+  `approval_metrics` + `approval_instances` + `approval_templates` so the
+  notifier composes messages without reaching into pool directly.
+
+## Channel Reuse
+
+The DingTalk channel reuses the leaf helpers from
+`packages/core-backend/src/integrations/dingtalk/robot.ts`:
+
+- `normalizeDingTalkRobotWebhookUrl` — validates HTTPS + `oapi.dingtalk.com`
+  host + access_token query param. An invalid env value is logged and the
+  channel reports `webhook not configured` so a misconfiguration cannot
+  crash the scheduler.
+- `normalizeDingTalkRobotSecret` — guards on the `SEC` prefix.
+- `buildSignedDingTalkWebhookUrl` — appends timestamp/sign when a secret
+  exists.
+- `buildDingTalkMarkdown` — produces the `{ msgtype: 'markdown', markdown:
+  { title, text } }` payload shape.
+- `validateDingTalkRobotResponse` — surfaces non-zero `errcode` returns.
+
+The HTTP send mirrors `multitable/automation-executor.ts:1393-1402`: native
+`fetch` + an `AbortController` for timeout. We deliberately did **not**
+import `postJsonWithRetry` from `NotificationService.ts`. The scheduler
+already retries on the next tick (default 15 minutes), so a single attempt
+with an explicit `ok: false` return keeps the notifier behavior simple and
+the in-memory dedupe set clean (only successful sends mark the instance as
+notified).
+
+We did **not** reuse `DingTalkNotificationChannel` itself. Its
+`sender(notification, recipients)` signature is the legacy notification
+abstraction; making the breach notifier conform to it would force us to
+synthesize fake `Notification` / `NotificationRecipient` shapes. The new
+`BreachNotificationChannel` interface is shape-aligned with what
+`ApprovalBreachNotifier` actually needs (one message in, one ok/error
+out).
+
+## Failure Isolation
+
+Three nested layers:
+
+1. **Channel `send()`** — wrapped in try/catch inside
+   `ApprovalBreachNotifier.dispatch`. A throw becomes `{ ok: false,
+   error }`. A returned `ok: false` is logged but does not propagate.
+2. **`notifyBreaches`** — `Promise.all` over channels means one channel
+   slow / hanging cannot block others (we do `await`, but each `dispatch`
+   already converts errors to non-throwing results).
+3. **Scheduler call site** (`index.ts`) — explicit try/catch around
+   `notifier.notifyBreaches(ids)`, plus the scheduler's own try/catch
+   (`ApprovalSlaScheduler.ts:138-144`). Either layer alone would be enough;
+   keeping both is defense in depth.
+
+The notifier itself never throws — `notifyBreaches` always resolves to a
+`NotifyResult` even when `metrics.listBreachContextByIds` rejects (the DB
+error is logged, all input ids are reported as `skipped`, no channel
+dispatch attempt is made).
+
+## Idempotency
+
+In-memory `Set<instanceId>` on the leader process, FIFO-bounded at 5000
+entries by default.
+
+Justification (the task spec asked us to pick simpler with a written
+rationale):
+
+- The scheduler runs only on the leader, so one process is enough to
+  dedupe. Follower failover is rare and re-notification on takeover is an
+  acceptable v0 tradeoff (the next 15-minute tick would re-flag the same
+  rows anyway since `sla_breached_at` is set once per breach, not per
+  notification).
+- A persistent `breach_notified_at` column would require:
+  - a new Kysely migration in `db/migrations/`,
+  - bumping `APPROVAL_SCHEMA_BOOTSTRAP_VERSION` in
+    `tests/helpers/approval-schema-bootstrap.ts`, which is shared with
+    other in-flight branches and would force re-bootstrap of every
+    integration worker,
+  - updating `ApprovalMetricsService.listBreachContextByIds` to filter on
+    `breach_notified_at IS NULL`,
+  - extra UPDATE round-trips per dispatch.
+- The set is bounded — `markNotified` evicts the oldest entry once the
+  cap is hit, so a long-lived leader cannot grow unbounded memory.
+- Only successful dispatches mark an instance as notified. A run where
+  every channel fails is retried on the next breach tick.
+
+A persistent column is a follow-up. The dev MD records this so a future
+slice can land it without rediscovery.
+
+## Configuration
+
+| Env var | Default | Purpose |
+| --- | --- | --- |
+| `APPROVAL_BREACH_DINGTALK_WEBHOOK` | unset | DingTalk robot webhook URL with `access_token=` query string. Must be HTTPS on `oapi.dingtalk.com/robot/send`. Unset → channel reports `webhook not configured` and skips. |
+| `APPROVAL_BREACH_DINGTALK_SECRET` | unset | Optional `SEC...` signing secret. When provided, the channel appends `timestamp=` + `sign=` query params. |
+| `APPROVAL_BREACH_EMAIL_FROM` | unset | From-address for the email stub. Reserved for the follow-up that wires a real transport. |
+| `APPROVAL_BREACH_EMAIL_TO` | unset | Admin recipient for the email stub. |
+| `PUBLIC_APP_URL` / `APP_BASE_URL` | unset | Base URL prepended to `/approval/<id>` in the message body. Unset → the notifier still composes a message but the link is omitted. |
+
+Webhook setup steps:
+
+1. Open the DingTalk admin → 群机器人 → 添加自定义机器人.
+2. Name it (e.g. `MetaSheet 审批超时告警`) and choose 加签 + a keyword such as
+   `审批超时` (DingTalk requires at least one of: keyword / 加签 / IP
+   allowlist). Match the keyword to what `composeMessage` puts in the
+   title.
+3. Copy the webhook URL. If you enabled 加签, also copy the secret (starts
+   with `SEC`).
+4. Set both env vars on the leader-eligible API replicas and restart.
+
+Local test:
+
+```bash
+export APPROVAL_BREACH_DINGTALK_WEBHOOK="https://oapi.dingtalk.com/robot/send?access_token=<token>"
+export APPROVAL_BREACH_DINGTALK_SECRET="SEC<your-secret>"
+curl -X POST -H 'Content-Type: application/json' \
+  -d '{"msgtype":"markdown","markdown":{"title":"审批超时告警 (test)","text":"### 审批超时告警 (test)\n\n手动验证 webhook 可达"}}' \
+  "$APPROVAL_BREACH_DINGTALK_WEBHOOK"
+```
+
+If you also want to validate the signed flow without the backend, port the
+`buildSignedDingTalkWebhookUrl` snippet from
+`packages/core-backend/src/integrations/dingtalk/robot.ts:66-78` into a
+short Node script.
+
+## Files
+
+### Backend
+- `packages/core-backend/src/services/ApprovalBreachNotifier.ts` — new
+  notifier. Composes per-instance Chinese-language messages, dispatches in
+  parallel, returns aggregated NotifyResult, dedupes via in-memory FIFO
+  set.
+- `packages/core-backend/src/services/breach-channels/index.ts` — channel
+  contract + barrel export.
+- `packages/core-backend/src/services/breach-channels/dingtalk-channel.ts` —
+  DingTalk implementation reusing robot helpers + native fetch.
+- `packages/core-backend/src/services/breach-channels/email-channel.ts` —
+  email logging stub (no transport in repo; new deps forbidden).
+- `packages/core-backend/src/services/ApprovalMetricsService.ts` — new
+  `ApprovalBreachContext` interface + `listBreachContextByIds(ids)` JOIN
+  query.
+- `packages/core-backend/src/index.ts` — instantiate
+  `ApprovalBreachNotifier`, pass as `onBreach` to
+  `startApprovalSlaScheduler`, wrap call in try/catch.
+
+### Tests
+- `packages/core-backend/tests/unit/approval-breach-notifier.test.ts` — 8
+  cases covering empty input, parallel dispatch, channel-failure
+  isolation, ok:false handling, idempotency, retry-after-total-failure,
+  zero-channels, and missing-context fallback.
+- `packages/core-backend/tests/unit/dingtalk-breach-channel.test.ts` — 6
+  cases covering missing webhook, invalid webhook, signed POST shape,
+  HTTP errors, errcode handling, and network errors. All use a mocked
+  `fetchFn` — no real HTTP calls.
+
+No email channel test was added: the channel has no dispatch logic worth
+covering until a real transport lands. Tracked as a follow-up.
+
+## Migration / Schema
+
+None. The slice does not touch the database. The dedupe state is
+in-memory by design (see Idempotency section). A persistent
+`breach_notified_at` column is recorded as a follow-up.
+
+## Rollback
+
+1. `APPROVAL_BREACH_DINGTALK_WEBHOOK=` (empty) on the leader and restart.
+   The DingTalk channel reports `webhook not configured` and the scheduler
+   still flips `sla_breached`, just without notifications.
+2. To fully disable the notifier wiring, revert this commit. The
+   pre-merge `onBreach` hook was a no-op so the scheduler reverts cleanly.
+3. `APPROVAL_SLA_SCHEDULER_DISABLED=1` continues to disable the scheduler
+   entirely, as documented in the WP5 dev MD.
+
+## Follow-ups
+
+- Persistent `breach_notified_at` column for dedupe across restarts /
+  leader takeovers.
+- Wire a real email transport (likely SMTP via a vetted dependency
+  addition in a separate slice) and replace the email stub.
+- Optional: webhook retry with exponential backoff inside the channel,
+  rather than relying on the next 15-minute tick.
+- Optional: severity escalation (`severity: 'critical'`) once an instance
+  has been breached for more than `2 * sla_hours`.

--- a/docs/development/approval-sla-breach-notify-development-20260425.md
+++ b/docs/development/approval-sla-breach-notify-development-20260425.md
@@ -30,9 +30,12 @@ DingTalk and email channels.
     `APPROVAL_BREACH_EMAIL_FROM` / `APPROVAL_BREACH_EMAIL_TO` and logs a
     warn line per dispatch but always reports `ok: false`.
 - Wired the notifier into `ApprovalSlaScheduler.onBreach` from
-  `MetaSheetServer.start()`. The scheduler's existing try/catch around
-  `onBreach` (ApprovalSlaScheduler.ts L138-144) absorbs notifier failures;
-  we still wrap the call site for explicit logging.
+  `MetaSheetServer.start()`. Channels are registered only when their env is
+  explicitly configured so an unset DingTalk webhook / email stub does not
+  create noisy per-breach failure logs.
+  The scheduler's existing try/catch around `onBreach`
+  (ApprovalSlaScheduler.ts L138-144) absorbs notifier failures; we still
+  wrap the call site for explicit logging.
 - Added `ApprovalMetricsService.listBreachContextByIds(ids)` to JOIN
   `approval_metrics` + `approval_instances` + `approval_templates` so the
   notifier composes messages without reaching into pool directly.
@@ -56,10 +59,11 @@ The DingTalk channel reuses the leaf helpers from
 The HTTP send mirrors `multitable/automation-executor.ts:1393-1402`: native
 `fetch` + an `AbortController` for timeout. We deliberately did **not**
 import `postJsonWithRetry` from `NotificationService.ts`. The scheduler
-already retries on the next tick (default 15 minutes), so a single attempt
-with an explicit `ok: false` return keeps the notifier behavior simple and
-the in-memory dedupe set clean (only successful sends mark the instance as
-notified).
+marks a breach before notification (`checkSlaBreaches` flips
+`sla_breached = TRUE` and returns the ids), so this v0 path is best-effort:
+a channel failure is surfaced in logs / `NotifyResult`, but is not retried
+by a later scheduler tick. Persistent retry needs the follow-up
+`breach_notified_at` column.
 
 We did **not** reuse `DingTalkNotificationChannel` itself. Its
 `sender(notification, recipients)` signature is the legacy notification
@@ -98,7 +102,7 @@ Justification (the task spec asked us to pick simpler with a written
 rationale):
 
 - The scheduler runs only on the leader, so one process is enough to
-  dedupe. Follower failover and process restarts cause **under**
+  dedupe. Follower failover and process restarts can cause **under**
   notification, not duplicates: `ApprovalMetricsService.checkSlaBreaches`
   filters on `sla_breached = FALSE` and flips the flag inside the same
   `UPDATE … RETURNING`, so a row already flagged in a previous epoch never
@@ -117,8 +121,10 @@ rationale):
   - extra UPDATE round-trips per dispatch.
 - The set is bounded — `markNotified` evicts the oldest entry once the
   cap is hit, so a long-lived leader cannot grow unbounded memory.
-- Only successful dispatches mark an instance as notified. A run where
-  every channel fails is retried on the next breach tick.
+- Only successful dispatches mark an instance as notified inside the
+  notifier itself. This protects direct callers that retry the same id
+  batch, but the current scheduler path will not re-supply those ids after
+  the DB breach flag has been flipped.
 
 A persistent column is a follow-up. The dev MD records this so a future
 slice can land it without rediscovery.
@@ -127,10 +133,10 @@ slice can land it without rediscovery.
 
 | Env var | Default | Purpose |
 | --- | --- | --- |
-| `APPROVAL_BREACH_DINGTALK_WEBHOOK` | unset | DingTalk robot webhook URL with `access_token=` query string. Must be HTTPS on `oapi.dingtalk.com/robot/send`. Unset → channel reports `webhook not configured` and skips. |
+| `APPROVAL_BREACH_DINGTALK_WEBHOOK` | unset | DingTalk robot webhook URL with `access_token=` query string. Must be HTTPS on `oapi.dingtalk.com/robot/send`. Unset → DingTalk channel is not registered. |
 | `APPROVAL_BREACH_DINGTALK_SECRET` | unset | Optional `SEC...` signing secret. When provided, the channel appends `timestamp=` + `sign=` query params. |
 | `APPROVAL_BREACH_EMAIL_FROM` | unset | From-address for the email stub. Reserved for the follow-up that wires a real transport. |
-| `APPROVAL_BREACH_EMAIL_TO` | unset | Admin recipient for the email stub. |
+| `APPROVAL_BREACH_EMAIL_TO` | unset | Admin recipient for the email stub. Both email env vars must be set before the stub is registered. |
 | `PUBLIC_APP_URL` / `APP_BASE_URL` | unset | Base URL prepended to `/approval/<id>` in the message body. Unset → the notifier still composes a message but the link is omitted. |
 
 Webhook setup steps:
@@ -201,8 +207,8 @@ in-memory by design (see Idempotency section). A persistent
 ## Rollback
 
 1. `APPROVAL_BREACH_DINGTALK_WEBHOOK=` (empty) on the leader and restart.
-   The DingTalk channel reports `webhook not configured` and the scheduler
-   still flips `sla_breached`, just without notifications.
+   The DingTalk channel is not registered and the scheduler still flips
+   `sla_breached`, just without DingTalk notifications.
 2. To fully disable the notifier wiring, revert this commit. The
    pre-merge `onBreach` hook was a no-op so the scheduler reverts cleanly.
 3. `APPROVAL_SLA_SCHEDULER_DISABLED=1` continues to disable the scheduler

--- a/docs/development/approval-sla-breach-notify-verification-20260425.md
+++ b/docs/development/approval-sla-breach-notify-verification-20260425.md
@@ -29,11 +29,11 @@ cd packages/core-backend
 
 - Backend TypeScript check: passed with exit code 0 (no diagnostics).
 - `tests/unit/approval-breach-notifier.test.ts`: 8/8 passed.
-- `tests/unit/dingtalk-breach-channel.test.ts`: 6/6 passed.
+- `tests/unit/dingtalk-breach-channel.test.ts`: 9/9 passed.
 - `tests/unit/approval-sla-scheduler.test.ts`: 7/7 passed (regression
   green after notifier wiring).
 
-Aggregate: 21/21 tests, ~300ms total wall clock.
+Aggregate: 24/24 tests, ~300ms total wall clock.
 
 ## Covered Scenarios
 
@@ -48,9 +48,11 @@ Aggregate: 21/21 tests, ~300ms total wall clock.
 - Idempotency: two consecutive calls with overlapping ids re-dispatch only
   the genuinely new ids; previously-notified ones are reported in
   `skipped`.
-- Recovery: an instance whose every channel failed is **not** marked as
-  notified, so the next tick will re-dispatch and succeed once the
-  transient fault clears.
+- Direct-caller recovery: an instance whose every channel failed is **not**
+  marked as notified inside `ApprovalBreachNotifier`, so a caller that
+  retries the same id batch can re-dispatch. The scheduler path itself does
+  not retry after `checkSlaBreaches` flips `sla_breached = TRUE`; persistent
+  retry needs the documented `breach_notified_at` follow-up.
 - Zero configured channels reports a graceful `skipped` count without
   hitting the metrics service.
 - Missing context (notifier given an id whose JOIN returns nothing) still
@@ -71,6 +73,13 @@ Aggregate: 21/21 tests, ~300ms total wall clock.
   `validateDingTalkRobotResponse`.
 - Wraps network errors so the notifier sees `{ ok: false, error: <msg> }`
   instead of a thrown exception.
+
+### Channel env registration
+- No notification env → no channels are registered, avoiding noisy
+  `webhook not configured` / email-stub failure logs on every breach.
+- `APPROVAL_BREACH_DINGTALK_WEBHOOK` set → DingTalk channel is registered.
+- `APPROVAL_BREACH_EMAIL_FROM` + `APPROVAL_BREACH_EMAIL_TO` both set →
+  email stub is registered explicitly.
 
 All HTTP paths use a mocked `fetchFn`; no real HTTP calls are made.
 
@@ -139,5 +148,6 @@ template `请假申请`, requester `张三`, current node `manager`, started at
   as a follow-up.
 - Multi-process leader/notifier handoff. The notifier is leader-only by
   construction (it sits behind the scheduler's `onBreach`, which the
-  follower never invokes), and the in-memory dedupe is documented to
-  re-notify after a leader change.
+  follower never invokes). The current scheduler path is best-effort after
+  `sla_breached` flips; persistent retry / notified-state handoff is a
+  follow-up.

--- a/docs/development/approval-sla-breach-notify-verification-20260425.md
+++ b/docs/development/approval-sla-breach-notify-verification-20260425.md
@@ -1,0 +1,143 @@
+# Approval SLA Breach Notify Verification - 2026-04-25
+
+## Commands
+
+```bash
+# Inside the worktree at /tmp/ms2-breach-notify
+cd packages/core-backend
+./node_modules/.bin/tsc --noEmit
+./node_modules/.bin/vitest run \
+  tests/unit/approval-breach-notifier.test.ts \
+  tests/unit/dingtalk-breach-channel.test.ts \
+  tests/unit/approval-sla-scheduler.test.ts \
+  --reporter=verbose
+```
+
+> Note: this worktree was baselined without a local `node_modules` tree.
+> A symlink to the main repo's installed deps was used to satisfy
+> `tsc` / `vitest` without invoking `pnpm install` (which the task spec
+> forbids):
+>
+> ```bash
+> ln -s /Users/chouhua/Downloads/Github/metasheet2/node_modules \
+>       /tmp/ms2-breach-notify/node_modules
+> ln -s /Users/chouhua/Downloads/Github/metasheet2/packages/core-backend/node_modules \
+>       /tmp/ms2-breach-notify/packages/core-backend/node_modules
+> ```
+
+## Results
+
+- Backend TypeScript check: passed with exit code 0 (no diagnostics).
+- `tests/unit/approval-breach-notifier.test.ts`: 8/8 passed.
+- `tests/unit/dingtalk-breach-channel.test.ts`: 6/6 passed.
+- `tests/unit/approval-sla-scheduler.test.ts`: 7/7 passed (regression
+  green after notifier wiring).
+
+Aggregate: 21/21 tests, ~300ms total wall clock.
+
+## Covered Scenarios
+
+### `ApprovalBreachNotifier`
+- Empty id input is a no-op; no metrics fetch, no channel call.
+- Both DingTalk and email channels receive every breached instance in
+  parallel; each call sees a Chinese-language title, body, and link.
+- Channel failures (thrown errors and `{ ok: false }` returns) are logged
+  but do not block sibling channels.
+- `ok: false` from a channel does not throw; the notifier reports
+  `failed: 1` in `NotifyResult.perChannel`.
+- Idempotency: two consecutive calls with overlapping ids re-dispatch only
+  the genuinely new ids; previously-notified ones are reported in
+  `skipped`.
+- Recovery: an instance whose every channel failed is **not** marked as
+  notified, so the next tick will re-dispatch and succeed once the
+  transient fault clears.
+- Zero configured channels reports a graceful `skipped` count without
+  hitting the metrics service.
+- Missing context (notifier given an id whose JOIN returns nothing) still
+  composes a usable message with `未命名模板 / 未知申请人 / 未知节点`
+  fallbacks.
+
+### `ApprovalBreachDingTalkChannel`
+- Returns `{ ok: false, error: 'webhook not configured' }` when the env
+  var is unset.
+- Same fallback when the configured URL fails the HTTPS / host /
+  access_token validation in `normalizeDingTalkRobotWebhookUrl`.
+- Posts a `msgtype: markdown` payload (title + `### title\n\nbody +
+  link`) to the signed webhook URL. The signed URL contains both
+  `timestamp=` and `sign=` query params when a `SEC...` secret is
+  provided.
+- Surfaces upstream HTTP errors as `HTTP <status>: <body>`.
+- Surfaces non-zero `errcode` JSON bodies via
+  `validateDingTalkRobotResponse`.
+- Wraps network errors so the notifier sees `{ ok: false, error: <msg> }`
+  instead of a thrown exception.
+
+All HTTP paths use a mocked `fetchFn`; no real HTTP calls are made.
+
+### `ApprovalSlaScheduler` regression
+The seven existing scheduler tests (happy path, error swallow, reentrancy
+guard, leader/follower election, takeover, and Prometheus gauge
+transitions) all pass unchanged after the notifier wiring landed. Wiring
+flows exclusively through the existing `onBreach` parameter, so no
+scheduler internals were modified.
+
+## Sample DingTalk Payload
+
+The body of the POST issued by the channel for a breached instance with
+template `请假申请`, requester `张三`, current node `manager`, started at
+`2026-04-25T08:00:00Z`, SLA `24` hours, breached at
+`2026-04-26T08:00:00Z`, observed at `2026-04-26T10:00:00Z`:
+
+```json
+{
+  "msgtype": "markdown",
+  "markdown": {
+    "title": "审批超时告警 | 请假申请 | 实例 #inst-1",
+    "text": "### 审批超时告警 | 请假申请 | 实例 #inst-1\n\n- 申请人：张三\n- 启动时间：2026-04-25 08:00:00 UTC\n- SLA 阈值：24 小时\n- 超时时长：2 小时\n- 当前节点：manager\n- 详情链接：https://app.example.com/approval/inst-1\n\n[查看详情](https://app.example.com/approval/inst-1)"
+  }
+}
+```
+
+## Local Validation
+
+1. Pick a DingTalk group, add a custom robot with 加签 + a keyword (e.g.
+   `审批超时` so the message title matches), copy the webhook URL and
+   `SEC...` secret.
+2. Export the env vars on a backend dev process:
+   ```bash
+   export APPROVAL_BREACH_DINGTALK_WEBHOOK="https://oapi.dingtalk.com/robot/send?access_token=..."
+   export APPROVAL_BREACH_DINGTALK_SECRET="SEC..."
+   export PUBLIC_APP_URL="http://localhost:3000"
+   ```
+3. Confirm webhook reachability with a manual `curl` (no signing required
+   if the robot is configured with keyword-only):
+   ```bash
+   curl -X POST -H 'Content-Type: application/json' \
+     -d '{"msgtype":"markdown","markdown":{"title":"审批超时告警 (preflight)","text":"### 审批超时告警 (preflight)\n\nready"}}' \
+     "$APPROVAL_BREACH_DINGTALK_WEBHOOK"
+   ```
+   Expected response: `{"errcode":0,"errmsg":"ok"}`.
+4. Trigger an SLA breach by inserting a row with `started_at` older than
+   `sla_hours`:
+   ```sql
+   INSERT INTO approval_metrics (instance_id, template_id, tenant_id, started_at, sla_hours)
+   VALUES ('demo-overdue', NULL, 'default', now() - interval '48 hours', 1);
+   ```
+5. Force a tick (the scheduler's default interval is 15 minutes; for a
+   faster feedback loop, set `intervalMs` lower in a one-off REPL script
+   or restart the backend with the row already present).
+6. Verify the DingTalk group received the markdown card with the title
+   `审批超时告警 | <模板名> | 实例 #demo-ove…`.
+
+## Not Run
+
+- Live DingTalk integration test. The channel uses a mocked `fetchFn` in
+  unit tests; the section above documents the manual curl verification
+  path.
+- Email channel — currently a logging stub. No transport exists in the
+  repo and adding `nodemailer` is out of scope per the task spec; tracked
+  as a follow-up.
+- Multi-process leader/notifier handoff. The notifier is leader-only by
+  construction (it sits behind the scheduler's `onBreach`, which the
+  follower never invokes), and the in-memory dedupe is documented to
+  re-notify after a leader change.

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -86,6 +86,11 @@ import {
   startApprovalSlaScheduler,
   stopApprovalSlaScheduler,
 } from './services/ApprovalSlaScheduler'
+import { ApprovalBreachNotifier } from './services/ApprovalBreachNotifier'
+import {
+  createApprovalBreachDingTalkChannel,
+  createApprovalBreachEmailChannel,
+} from './services/breach-channels'
 import { rolesRouter } from './routes/roles'
 import { snapshotsRouter } from './routes/snapshots'
 import changeManagementRouter from './routes/change-management'
@@ -1904,9 +1909,24 @@ export class MetaSheetServer {
 
     try {
       const leaderOptions = await resolveApprovalSlaSchedulerLeaderOptions()
+      const breachNotifier = new ApprovalBreachNotifier({
+        channels: [
+          createApprovalBreachDingTalkChannel(),
+          createApprovalBreachEmailChannel(),
+        ],
+      })
       startApprovalSlaScheduler({
         leaderOptions,
         runtime: { leaderStateGauge: promMetrics.approvalSlaSchedulerLeaderGauge },
+        onBreach: async (ids) => {
+          try {
+            await breachNotifier.notifyBreaches(ids)
+          } catch (notifyError) {
+            this.logger.warn(
+              `ApprovalBreachNotifier dispatch failed: ${notifyError instanceof Error ? notifyError.message : String(notifyError)}`,
+            )
+          }
+        },
       })
       this.logger.info('Approval SLA scheduler initialized')
     } catch (e) {

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -88,8 +88,7 @@ import {
 } from './services/ApprovalSlaScheduler'
 import { ApprovalBreachNotifier } from './services/ApprovalBreachNotifier'
 import {
-  createApprovalBreachDingTalkChannel,
-  createApprovalBreachEmailChannel,
+  createApprovalBreachChannelsFromEnv,
 } from './services/breach-channels'
 import { rolesRouter } from './routes/roles'
 import { snapshotsRouter } from './routes/snapshots'
@@ -1910,10 +1909,7 @@ export class MetaSheetServer {
     try {
       const leaderOptions = await resolveApprovalSlaSchedulerLeaderOptions()
       const breachNotifier = new ApprovalBreachNotifier({
-        channels: [
-          createApprovalBreachDingTalkChannel(),
-          createApprovalBreachEmailChannel(),
-        ],
+        channels: createApprovalBreachChannelsFromEnv(),
       })
       startApprovalSlaScheduler({
         leaderOptions,

--- a/packages/core-backend/src/services/ApprovalBreachNotifier.ts
+++ b/packages/core-backend/src/services/ApprovalBreachNotifier.ts
@@ -14,9 +14,11 @@
  * ids on the leader process. Justification (per task spec):
  *   - The scheduler runs only on the leader; one process is enough.
  *   - Avoids touching the WP5 schema bootstrap version + a brand-new migration.
- *   - Restart-time re-notification is acceptable for v0; the next 15-min tick
- *     would re-flag breaches whose `sla_breached` was set in a previous epoch
- *     anyway, so re-notify on cold start is a conservative default.
+ *   - `checkSlaBreaches` only returns rows it flips from `sla_breached = FALSE`
+ *     to TRUE, so restart-time duplicate sends are not expected from the
+ *     scheduler path. Conversely, a dispatch missed after the DB flag flips is
+ *     not retried by the scheduler until a persistent `breach_notified_at`
+ *     follow-up exists.
  *   - The set is bounded (FIFO trim at MAX_NOTIFIED_IDS) so a long-lived
  *     leader cannot grow unbounded.
  *   - A persistent `breach_notified_at` column is tracked as a follow-up.

--- a/packages/core-backend/src/services/ApprovalBreachNotifier.ts
+++ b/packages/core-backend/src/services/ApprovalBreachNotifier.ts
@@ -1,0 +1,259 @@
+/**
+ * Wave 2 WP5 — ApprovalBreachNotifier.
+ *
+ * Wires the SLA scheduler's `onBreach(ids)` hook to one or more output
+ * channels (DingTalk webhook, email stub). Composes a per-instance
+ * Chinese-language message from approval_metrics + approval_instances +
+ * approval_templates context, then dispatches in parallel.
+ *
+ * Failure isolation: a channel that throws or returns `ok: false` is logged
+ * but never blocks sibling channels or future instances. The notifier itself
+ * never throws — `notifyBreaches` always resolves to a NotifyResult.
+ *
+ * Idempotency: we maintain an in-memory `Set<instanceId>` of already-notified
+ * ids on the leader process. Justification (per task spec):
+ *   - The scheduler runs only on the leader; one process is enough.
+ *   - Avoids touching the WP5 schema bootstrap version + a brand-new migration.
+ *   - Restart-time re-notification is acceptable for v0; the next 15-min tick
+ *     would re-flag breaches whose `sla_breached` was set in a previous epoch
+ *     anyway, so re-notify on cold start is a conservative default.
+ *   - The set is bounded (FIFO trim at MAX_NOTIFIED_IDS) so a long-lived
+ *     leader cannot grow unbounded.
+ *   - A persistent `breach_notified_at` column is tracked as a follow-up.
+ */
+
+import { Logger } from '../core/logger'
+import {
+  getApprovalMetricsService,
+  type ApprovalBreachContext,
+  type ApprovalMetricsService,
+} from './ApprovalMetricsService'
+import type {
+  BreachChannelResult,
+  BreachMessage,
+  BreachNotificationChannel,
+} from './breach-channels'
+
+const DEFAULT_MAX_NOTIFIED_IDS = 5_000
+
+export interface ApprovalBreachNotifierOptions {
+  channels: BreachNotificationChannel[]
+  metrics?: ApprovalMetricsService
+  logger?: Logger
+  appBaseUrl?: string | null
+  /** Upper bound on the in-memory dedupe set; FIFO eviction once exceeded. */
+  maxNotifiedIds?: number
+  /** Inject `() => Date` for deterministic tests. */
+  now?: () => Date
+}
+
+export interface NotifyResultPerChannel {
+  channel: string
+  sent: number
+  failed: number
+  errors: string[]
+}
+
+export interface NotifyResult {
+  requested: number
+  notified: number
+  skipped: number
+  sent: number
+  failed: number
+  perChannel: NotifyResultPerChannel[]
+}
+
+export class ApprovalBreachNotifier {
+  private readonly channels: BreachNotificationChannel[]
+  private readonly metrics: ApprovalMetricsService
+  private readonly logger: Logger
+  private readonly appBaseUrl: string
+  private readonly maxNotifiedIds: number
+  private readonly now: () => Date
+  private readonly notifiedIds = new Set<string>()
+  private readonly notifiedOrder: string[] = []
+
+  constructor(options: ApprovalBreachNotifierOptions) {
+    this.channels = Array.isArray(options.channels) ? options.channels : []
+    this.metrics = options.metrics ?? getApprovalMetricsService()
+    this.logger = options.logger ?? new Logger('ApprovalBreachNotifier')
+    this.appBaseUrl = normalizeBaseUrl(options.appBaseUrl ?? process.env.PUBLIC_APP_URL ?? process.env.APP_BASE_URL ?? '')
+    this.maxNotifiedIds = Math.max(100, options.maxNotifiedIds ?? DEFAULT_MAX_NOTIFIED_IDS)
+    this.now = options.now ?? (() => new Date())
+  }
+
+  async notifyBreaches(instanceIds: string[]): Promise<NotifyResult> {
+    const empty: NotifyResult = {
+      requested: 0,
+      notified: 0,
+      skipped: 0,
+      sent: 0,
+      failed: 0,
+      perChannel: this.channels.map((channel) => ({ channel: channel.name, sent: 0, failed: 0, errors: [] })),
+    }
+    if (!Array.isArray(instanceIds) || instanceIds.length === 0) return empty
+    if (this.channels.length === 0) {
+      this.logger.warn('ApprovalBreachNotifier invoked with zero channels; skipping')
+      return { ...empty, requested: instanceIds.length, skipped: instanceIds.length, perChannel: [] }
+    }
+
+    const unique: string[] = []
+    let skipped = 0
+    for (const raw of instanceIds) {
+      if (typeof raw !== 'string') continue
+      const id = raw.trim()
+      if (id.length === 0) continue
+      if (this.notifiedIds.has(id)) {
+        skipped += 1
+        continue
+      }
+      if (!unique.includes(id)) unique.push(id)
+    }
+
+    if (unique.length === 0) {
+      return { ...empty, requested: instanceIds.length, skipped }
+    }
+
+    let contexts: ApprovalBreachContext[]
+    try {
+      contexts = await this.metrics.listBreachContextByIds(unique)
+    } catch (error) {
+      this.logger.warn(`Breach context fetch failed: ${error instanceof Error ? error.message : String(error)}`)
+      return { ...empty, requested: instanceIds.length, skipped }
+    }
+    const contextById = new Map<string, ApprovalBreachContext>()
+    for (const ctx of contexts) contextById.set(ctx.instanceId, ctx)
+
+    const perChannel: Record<string, NotifyResultPerChannel> = {}
+    for (const channel of this.channels) {
+      perChannel[channel.name] = { channel: channel.name, sent: 0, failed: 0, errors: [] }
+    }
+
+    let notified = 0
+    let totalSent = 0
+    let totalFailed = 0
+    for (const id of unique) {
+      const ctx = contextById.get(id)
+      const message = this.composeMessage(id, ctx)
+      const settlements = await Promise.all(
+        this.channels.map(async (channel) => {
+          const result = await this.dispatch(channel, message)
+          return { channel, result }
+        }),
+      )
+      let anySent = false
+      for (const { channel, result } of settlements) {
+        const bucket = perChannel[channel.name]
+        if (result.ok) {
+          bucket.sent += 1
+          totalSent += 1
+          anySent = true
+        } else {
+          bucket.failed += 1
+          totalFailed += 1
+          if (result.error) bucket.errors.push(result.error)
+        }
+      }
+      if (anySent) {
+        this.markNotified(id)
+        notified += 1
+      }
+    }
+
+    return {
+      requested: instanceIds.length,
+      notified,
+      skipped,
+      sent: totalSent,
+      failed: totalFailed,
+      perChannel: this.channels.map((channel) => perChannel[channel.name]),
+    }
+  }
+
+  private async dispatch(
+    channel: BreachNotificationChannel,
+    message: BreachMessage,
+  ): Promise<BreachChannelResult> {
+    try {
+      const result = await channel.send(message)
+      if (!result.ok) {
+        this.logger.warn(`Breach channel ${channel.name} reported failure for ${message.instanceId}: ${result.error ?? 'unknown'}`)
+      }
+      return result
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error)
+      this.logger.warn(`Breach channel ${channel.name} threw for ${message.instanceId}: ${reason}`)
+      return { ok: false, error: reason }
+    }
+  }
+
+  private composeMessage(instanceId: string, ctx: ApprovalBreachContext | undefined): BreachMessage {
+    const templateName = ctx?.templateName?.trim() || '未命名模板'
+    const requester = ctx?.requesterName?.trim() || '未知申请人'
+    const node = ctx?.currentNodeKey?.trim() || '未知节点'
+    const startedAt = ctx?.startedAt ? formatTimestamp(ctx.startedAt) : '未知'
+    const slaHours = typeof ctx?.slaHours === 'number' && Number.isFinite(ctx.slaHours) ? `${ctx.slaHours} 小时` : '未配置'
+    const overdue = describeOverdue(ctx, this.now())
+    const shortId = abbreviateId(instanceId)
+    const title = `审批超时告警 | ${templateName} | 实例 #${shortId}`
+    const link = this.buildLink(instanceId)
+    const body = [
+      `- 申请人：${requester}`,
+      `- 启动时间：${startedAt}`,
+      `- SLA 阈值：${slaHours}`,
+      `- 超时时长：${overdue}`,
+      `- 当前节点：${node}`,
+      `- 详情链接：${link || '(未配置 PUBLIC_APP_URL)'}`,
+    ].join('\n')
+    return { instanceId, title, body, link, severity: 'warning' }
+  }
+
+  private buildLink(instanceId: string): string {
+    if (!this.appBaseUrl) return ''
+    return `${this.appBaseUrl}/approval/${encodeURIComponent(instanceId)}`
+  }
+
+  private markNotified(instanceId: string): void {
+    if (this.notifiedIds.has(instanceId)) return
+    this.notifiedIds.add(instanceId)
+    this.notifiedOrder.push(instanceId)
+    while (this.notifiedOrder.length > this.maxNotifiedIds) {
+      const evicted = this.notifiedOrder.shift()
+      if (evicted) this.notifiedIds.delete(evicted)
+    }
+  }
+}
+
+function normalizeBaseUrl(value: string): string {
+  const trimmed = (value ?? '').trim()
+  if (!trimmed) return ''
+  return trimmed.replace(/\/+$/, '')
+}
+
+function abbreviateId(id: string): string {
+  return id.length > 8 ? id.slice(0, 8) : id
+}
+
+function formatTimestamp(value: string): string {
+  const parsed = new Date(value)
+  if (!Number.isFinite(parsed.getTime())) return value
+  return parsed.toISOString().replace('T', ' ').replace(/\.\d+Z$/, ' UTC')
+}
+
+function describeOverdue(ctx: ApprovalBreachContext | undefined, now: Date): string {
+  if (!ctx) return '未知'
+  const baseTs = ctx.breachedAt ?? ctx.startedAt
+  if (!baseTs) return '未知'
+  const baseMs = Date.parse(baseTs)
+  if (!Number.isFinite(baseMs)) return '未知'
+  const slaHours = typeof ctx.slaHours === 'number' && Number.isFinite(ctx.slaHours) ? ctx.slaHours : 0
+  const breachStartMs = ctx.breachedAt
+    ? baseMs
+    : baseMs + slaHours * 60 * 60 * 1000
+  const elapsedMs = Math.max(0, now.getTime() - breachStartMs)
+  const totalMinutes = Math.floor(elapsedMs / 60_000)
+  if (totalMinutes < 60) return `${totalMinutes} 分钟`
+  const hours = Math.floor(totalMinutes / 60)
+  const minutes = totalMinutes % 60
+  return minutes === 0 ? `${hours} 小时` : `${hours} 小时 ${minutes} 分钟`
+}

--- a/packages/core-backend/src/services/ApprovalMetricsService.ts
+++ b/packages/core-backend/src/services/ApprovalMetricsService.ts
@@ -101,6 +101,17 @@ export interface MetricsReport {
   breachedTemplates: MetricsTopTemplateRow[]
 }
 
+export interface ApprovalBreachContext {
+  instanceId: string
+  templateId: string | null
+  templateName: string | null
+  currentNodeKey: string | null
+  requesterName: string | null
+  startedAt: string
+  slaHours: number | null
+  breachedAt: string | null
+}
+
 export interface MetricsSummaryQuery {
   tenantId?: string
   since?: Date | string
@@ -539,6 +550,67 @@ export class ApprovalMetricsService {
       [tenantId, limit],
     )
     return result.rows.map((row) => ({ ...row, node_breakdown: toNodeBreakdown(row.node_breakdown) }))
+  }
+
+  /**
+   * Wave 2 WP5 — breach notifier support. Returns per-instance context the
+   * notifier needs to compose human-readable messages: template name, current
+   * node, requester display name, started_at, sla_hours.
+   *
+   * The JOINs are LEFT so a missing template / instance row degrades to
+   * `null` rather than silently dropping a breach from the notification batch.
+   */
+  async listBreachContextByIds(instanceIds: string[]): Promise<ApprovalBreachContext[]> {
+    if (!Array.isArray(instanceIds) || instanceIds.length === 0) return []
+    const result = await this.query<{
+      instance_id: string
+      template_id: string | null
+      template_name: string | null
+      instance_title: string | null
+      current_node_key: string | null
+      requester_snapshot: unknown
+      started_at: string
+      sla_hours: string | number | null
+      sla_breached_at: string | null
+    }>(
+      `SELECT m.instance_id,
+              m.template_id,
+              m.started_at,
+              m.sla_hours,
+              m.sla_breached_at,
+              t.name AS template_name,
+              i.title AS instance_title,
+              i.current_node_key,
+              i.requester_snapshot
+         FROM approval_metrics m
+         LEFT JOIN approval_instances i ON i.id = m.instance_id
+         LEFT JOIN approval_templates t ON t.id = m.template_id
+        WHERE m.instance_id = ANY($1::text[])`,
+      [instanceIds],
+    )
+    return result.rows.map((row) => {
+      const requester = row.requester_snapshot && typeof row.requester_snapshot === 'object'
+        ? row.requester_snapshot as Record<string, unknown>
+        : null
+      const requesterName = typeof requester?.name === 'string' && requester.name.trim().length > 0
+        ? requester.name.trim()
+        : typeof requester?.id === 'string' && requester.id.trim().length > 0
+          ? requester.id.trim()
+          : null
+      const slaHours = row.sla_hours === null || row.sla_hours === undefined
+        ? null
+        : Number(row.sla_hours)
+      return {
+        instanceId: row.instance_id,
+        templateId: row.template_id,
+        templateName: row.template_name ?? row.instance_title ?? null,
+        currentNodeKey: row.current_node_key,
+        requesterName,
+        startedAt: row.started_at,
+        slaHours: Number.isFinite(slaHours) ? (slaHours as number) : null,
+        breachedAt: row.sla_breached_at,
+      }
+    })
   }
 
   private async mutateBreakdown(

--- a/packages/core-backend/src/services/breach-channels/dingtalk-channel.ts
+++ b/packages/core-backend/src/services/breach-channels/dingtalk-channel.ts
@@ -1,0 +1,145 @@
+/**
+ * Wave 2 WP5 — DingTalk webhook channel for SLA breach notifications.
+ *
+ * Reuses `integrations/dingtalk/robot.ts` helpers for payload composition,
+ * webhook normalization, signing, and response validation. The HTTP send
+ * itself uses native `fetch` (Node 18+) to avoid pulling extra deps.
+ *
+ * Configuration:
+ *   APPROVAL_BREACH_DINGTALK_WEBHOOK   robot webhook URL (with access_token)
+ *   APPROVAL_BREACH_DINGTALK_SECRET    optional signing secret (SEC...)
+ *
+ * If the webhook env var is unset, `send()` resolves to
+ * `{ ok: false, error: 'webhook not configured' }` so registering the
+ * channel without configuration is safe.
+ */
+
+import { Logger } from '../../core/logger'
+import {
+  buildDingTalkMarkdown,
+  buildSignedDingTalkWebhookUrl,
+  normalizeDingTalkRobotWebhookUrl,
+  normalizeDingTalkRobotSecret,
+  validateDingTalkRobotResponse,
+} from '../../integrations/dingtalk/robot'
+import type {
+  BreachChannelResult,
+  BreachMessage,
+  BreachNotificationChannel,
+} from './index'
+
+export interface ApprovalBreachDingTalkChannelOptions {
+  webhookUrl?: string | null
+  secret?: string | null
+  fetchFn?: typeof fetch
+  timeoutMs?: number
+  logger?: Logger
+}
+
+const DEFAULT_TIMEOUT_MS = 10_000
+
+export class ApprovalBreachDingTalkChannel implements BreachNotificationChannel {
+  readonly name = 'dingtalk'
+  private readonly webhookUrl: string | null
+  private readonly secret: string | undefined
+  private readonly fetchFn: typeof fetch
+  private readonly timeoutMs: number
+  private readonly logger: Logger
+
+  constructor(options: ApprovalBreachDingTalkChannelOptions = {}) {
+    this.logger = options.logger ?? new Logger('ApprovalBreachDingTalk')
+    this.fetchFn = options.fetchFn ?? globalThis.fetch
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+    const rawUrl = typeof options.webhookUrl === 'string' && options.webhookUrl.trim().length > 0
+      ? options.webhookUrl.trim()
+      : null
+    if (rawUrl) {
+      try {
+        this.webhookUrl = normalizeDingTalkRobotWebhookUrl(rawUrl)
+      } catch (error) {
+        this.logger.warn(`Invalid DingTalk webhook URL ignored: ${error instanceof Error ? error.message : String(error)}`)
+        this.webhookUrl = null
+      }
+    } else {
+      this.webhookUrl = null
+    }
+    const rawSecret = typeof options.secret === 'string' && options.secret.trim().length > 0
+      ? options.secret.trim()
+      : undefined
+    try {
+      this.secret = normalizeDingTalkRobotSecret(rawSecret)
+    } catch (error) {
+      this.logger.warn(`Invalid DingTalk secret ignored: ${error instanceof Error ? error.message : String(error)}`)
+      this.secret = undefined
+    }
+  }
+
+  async send(message: BreachMessage): Promise<BreachChannelResult> {
+    if (!this.webhookUrl) {
+      return { ok: false, error: 'webhook not configured' }
+    }
+    const payload = buildDingTalkMarkdown(message.title, this.composeBody(message))
+    const signedUrl = buildSignedDingTalkWebhookUrl(this.webhookUrl, this.secret)
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs)
+    try {
+      const response = await this.fetchFn(signedUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'User-Agent': 'MetaSheet-Approval-Breach/1.0',
+        },
+        body: JSON.stringify(payload),
+        signal: controller.signal,
+      })
+      const text = await readBodyText(response)
+      if (!response.ok) {
+        return { ok: false, error: `HTTP ${response.status}: ${text || response.statusText}` }
+      }
+      const parsed = parseJson(text)
+      try {
+        validateDingTalkRobotResponse(parsed)
+      } catch (error) {
+        return { ok: false, error: error instanceof Error ? error.message : String(error) }
+      }
+      return { ok: true }
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error)
+      this.logger.warn(`DingTalk breach notification failed: ${reason}`)
+      return { ok: false, error: reason }
+    } finally {
+      clearTimeout(timer)
+    }
+  }
+
+  private composeBody(message: BreachMessage): string {
+    const link = message.link.trim()
+    if (link.length === 0) return message.body
+    return `${message.body}\n\n[查看详情](${link})`
+  }
+}
+
+async function readBodyText(response: Response): Promise<string> {
+  try {
+    return await response.text()
+  } catch {
+    return ''
+  }
+}
+
+function parseJson(text: string): unknown {
+  if (!text) return null
+  try {
+    return JSON.parse(text) as unknown
+  } catch {
+    return null
+  }
+}
+
+export function createApprovalBreachDingTalkChannel(
+  options: ApprovalBreachDingTalkChannelOptions = {},
+): ApprovalBreachDingTalkChannel {
+  const webhookUrl = options.webhookUrl ?? process.env.APPROVAL_BREACH_DINGTALK_WEBHOOK ?? null
+  const secret = options.secret ?? process.env.APPROVAL_BREACH_DINGTALK_SECRET ?? null
+  return new ApprovalBreachDingTalkChannel({ ...options, webhookUrl, secret })
+}

--- a/packages/core-backend/src/services/breach-channels/email-channel.ts
+++ b/packages/core-backend/src/services/breach-channels/email-channel.ts
@@ -1,0 +1,62 @@
+/**
+ * Wave 2 WP5 — email breach channel stub.
+ *
+ * No SMTP / SES / SendGrid transport currently exists in core-backend
+ * (`grep nodemailer|sendgrid|mailgun|transporter` is empty). The task
+ * explicitly forbids adding new dependencies for this slice, so the email
+ * channel ships as a logging stub: it observes `APPROVAL_BREACH_EMAIL_FROM`
+ * + `APPROVAL_BREACH_EMAIL_TO` and emits a structured warn entry per
+ * dispatch, but `send()` always resolves to `{ ok: false, error: ... }`.
+ *
+ * Wiring an actual transport is a follow-up tracked in the dev MD.
+ */
+
+import { Logger } from '../../core/logger'
+import type {
+  BreachChannelResult,
+  BreachMessage,
+  BreachNotificationChannel,
+} from './index'
+
+export interface ApprovalBreachEmailChannelOptions {
+  from?: string | null
+  to?: string | null
+  logger?: Logger
+}
+
+export class ApprovalBreachEmailChannel implements BreachNotificationChannel {
+  readonly name = 'email'
+  private readonly from: string | null
+  private readonly to: string | null
+  private readonly logger: Logger
+
+  constructor(options: ApprovalBreachEmailChannelOptions = {}) {
+    this.logger = options.logger ?? new Logger('ApprovalBreachEmail')
+    this.from = trimOrNull(options.from)
+    this.to = trimOrNull(options.to)
+  }
+
+  async send(message: BreachMessage): Promise<BreachChannelResult> {
+    if (!this.from || !this.to) {
+      return { ok: false, error: 'email transport not configured' }
+    }
+    this.logger.warn(
+      `Email breach channel stub fired (from=${this.from} to=${this.to} instance=${message.instanceId} title=${message.title})`,
+    )
+    return { ok: false, error: 'email transport not configured' }
+  }
+}
+
+function trimOrNull(value: string | null | undefined): string | null {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+export function createApprovalBreachEmailChannel(
+  options: ApprovalBreachEmailChannelOptions = {},
+): ApprovalBreachEmailChannel {
+  const from = options.from ?? process.env.APPROVAL_BREACH_EMAIL_FROM ?? null
+  const to = options.to ?? process.env.APPROVAL_BREACH_EMAIL_TO ?? null
+  return new ApprovalBreachEmailChannel({ ...options, from, to })
+}

--- a/packages/core-backend/src/services/breach-channels/index.ts
+++ b/packages/core-backend/src/services/breach-channels/index.ts
@@ -1,0 +1,30 @@
+/**
+ * Wave 2 WP5 — SLA breach notification channel contract.
+ *
+ * Channels are pluggable adapters dispatched in parallel by
+ * ApprovalBreachNotifier. A channel that throws or returns `ok: false`
+ * does not block sibling channels.
+ */
+
+export type BreachSeverity = 'warning' | 'critical'
+
+export interface BreachMessage {
+  instanceId: string
+  title: string
+  body: string
+  link: string
+  severity: BreachSeverity
+}
+
+export interface BreachChannelResult {
+  ok: boolean
+  error?: string
+}
+
+export interface BreachNotificationChannel {
+  readonly name: string
+  send(message: BreachMessage): Promise<BreachChannelResult>
+}
+
+export { ApprovalBreachDingTalkChannel, createApprovalBreachDingTalkChannel } from './dingtalk-channel'
+export { ApprovalBreachEmailChannel, createApprovalBreachEmailChannel } from './email-channel'

--- a/packages/core-backend/src/services/breach-channels/index.ts
+++ b/packages/core-backend/src/services/breach-channels/index.ts
@@ -6,6 +6,9 @@
  * does not block sibling channels.
  */
 
+import { createApprovalBreachDingTalkChannel } from './dingtalk-channel'
+import { createApprovalBreachEmailChannel } from './email-channel'
+
 export type BreachSeverity = 'warning' | 'critical'
 
 export interface BreachMessage {
@@ -28,3 +31,25 @@ export interface BreachNotificationChannel {
 
 export { ApprovalBreachDingTalkChannel, createApprovalBreachDingTalkChannel } from './dingtalk-channel'
 export { ApprovalBreachEmailChannel, createApprovalBreachEmailChannel } from './email-channel'
+
+export function createApprovalBreachChannelsFromEnv(env: NodeJS.ProcessEnv = process.env): BreachNotificationChannel[] {
+  const channels: BreachNotificationChannel[] = []
+  if (typeof env.APPROVAL_BREACH_DINGTALK_WEBHOOK === 'string' && env.APPROVAL_BREACH_DINGTALK_WEBHOOK.trim().length > 0) {
+    channels.push(createApprovalBreachDingTalkChannel({
+      webhookUrl: env.APPROVAL_BREACH_DINGTALK_WEBHOOK,
+      secret: env.APPROVAL_BREACH_DINGTALK_SECRET,
+    }))
+  }
+  if (
+    typeof env.APPROVAL_BREACH_EMAIL_FROM === 'string' &&
+    env.APPROVAL_BREACH_EMAIL_FROM.trim().length > 0 &&
+    typeof env.APPROVAL_BREACH_EMAIL_TO === 'string' &&
+    env.APPROVAL_BREACH_EMAIL_TO.trim().length > 0
+  ) {
+    channels.push(createApprovalBreachEmailChannel({
+      from: env.APPROVAL_BREACH_EMAIL_FROM,
+      to: env.APPROVAL_BREACH_EMAIL_TO,
+    }))
+  }
+  return channels
+}

--- a/packages/core-backend/tests/unit/approval-breach-notifier.test.ts
+++ b/packages/core-backend/tests/unit/approval-breach-notifier.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it, vi } from 'vitest'
+import { ApprovalBreachNotifier } from '../../src/services/ApprovalBreachNotifier'
+import type { ApprovalBreachContext } from '../../src/services/ApprovalMetricsService'
+import type { BreachNotificationChannel } from '../../src/services/breach-channels'
+
+function ctx(id: string, overrides: Partial<ApprovalBreachContext> = {}): ApprovalBreachContext {
+  return {
+    instanceId: id,
+    templateId: 'tmpl-1',
+    templateName: '请假申请',
+    currentNodeKey: 'manager',
+    requesterName: '张三',
+    startedAt: '2026-04-25T08:00:00Z',
+    slaHours: 24,
+    breachedAt: '2026-04-26T08:00:00Z',
+    ...overrides,
+  }
+}
+
+function makeMetrics(contexts: ApprovalBreachContext[] = []) {
+  const listBreachContextByIds = vi.fn().mockResolvedValue(contexts)
+  return {
+    metrics: { listBreachContextByIds } as any,
+    listBreachContextByIds,
+  }
+}
+
+describe('ApprovalBreachNotifier', () => {
+  it('returns an empty result when no ids are supplied', async () => {
+    const channel: BreachNotificationChannel = {
+      name: 'noop',
+      send: vi.fn().mockResolvedValue({ ok: true }),
+    }
+    const { metrics, listBreachContextByIds } = makeMetrics()
+    const notifier = new ApprovalBreachNotifier({ channels: [channel], metrics })
+    const result = await notifier.notifyBreaches([])
+    expect(result.requested).toBe(0)
+    expect(result.notified).toBe(0)
+    expect(listBreachContextByIds).not.toHaveBeenCalled()
+    expect(channel.send).not.toHaveBeenCalled()
+  })
+
+  it('dispatches each instance to every configured channel in parallel', async () => {
+    const dingtalkSend = vi.fn().mockResolvedValue({ ok: true })
+    const emailSend = vi.fn().mockResolvedValue({ ok: true })
+    const channels: BreachNotificationChannel[] = [
+      { name: 'dingtalk', send: dingtalkSend },
+      { name: 'email', send: emailSend },
+    ]
+    const { metrics } = makeMetrics([ctx('inst-1'), ctx('inst-2')])
+    const notifier = new ApprovalBreachNotifier({
+      channels,
+      metrics,
+      appBaseUrl: 'https://app.example.com',
+      now: () => new Date('2026-04-26T10:00:00Z'),
+    })
+
+    const result = await notifier.notifyBreaches(['inst-1', 'inst-2'])
+
+    expect(dingtalkSend).toHaveBeenCalledTimes(2)
+    expect(emailSend).toHaveBeenCalledTimes(2)
+    expect(result.requested).toBe(2)
+    expect(result.notified).toBe(2)
+    expect(result.sent).toBe(4)
+    expect(result.failed).toBe(0)
+    expect(result.perChannel).toEqual([
+      { channel: 'dingtalk', sent: 2, failed: 0, errors: [] },
+      { channel: 'email', sent: 2, failed: 0, errors: [] },
+    ])
+    const firstMessage = dingtalkSend.mock.calls[0][0]
+    expect(firstMessage.title).toContain('审批超时告警')
+    expect(firstMessage.title).toContain('请假申请')
+    expect(firstMessage.body).toContain('张三')
+    expect(firstMessage.body).toContain('manager')
+    expect(firstMessage.link).toBe('https://app.example.com/approval/inst-1')
+  })
+
+  it('isolates channel failures so siblings still dispatch', async () => {
+    const flaky: BreachNotificationChannel = {
+      name: 'dingtalk',
+      send: vi.fn().mockRejectedValue(new Error('webhook 5xx')),
+    }
+    const healthy: BreachNotificationChannel = {
+      name: 'email',
+      send: vi.fn().mockResolvedValue({ ok: true }),
+    }
+    const { metrics } = makeMetrics([ctx('inst-1')])
+    const notifier = new ApprovalBreachNotifier({ channels: [flaky, healthy], metrics })
+
+    const result = await notifier.notifyBreaches(['inst-1'])
+
+    expect(flaky.send).toHaveBeenCalledTimes(1)
+    expect(healthy.send).toHaveBeenCalledTimes(1)
+    expect(result.notified).toBe(1)
+    expect(result.sent).toBe(1)
+    expect(result.failed).toBe(1)
+    const dingtalkBucket = result.perChannel.find((entry) => entry.channel === 'dingtalk')
+    expect(dingtalkBucket?.failed).toBe(1)
+    expect(dingtalkBucket?.errors).toEqual(['webhook 5xx'])
+  })
+
+  it('treats `ok:false` channel responses as failures without throwing', async () => {
+    const channel: BreachNotificationChannel = {
+      name: 'dingtalk',
+      send: vi.fn().mockResolvedValue({ ok: false, error: 'webhook not configured' }),
+    }
+    const { metrics } = makeMetrics([ctx('inst-1')])
+    const notifier = new ApprovalBreachNotifier({ channels: [channel], metrics })
+    const result = await notifier.notifyBreaches(['inst-1'])
+    expect(result.sent).toBe(0)
+    expect(result.failed).toBe(1)
+    expect(result.notified).toBe(0)
+    expect(result.perChannel[0].errors).toEqual(['webhook not configured'])
+  })
+
+  it('never notifies the same instance twice (in-memory dedupe)', async () => {
+    const channel: BreachNotificationChannel = {
+      name: 'dingtalk',
+      send: vi.fn().mockResolvedValue({ ok: true }),
+    }
+    const { metrics, listBreachContextByIds } = makeMetrics([ctx('inst-1'), ctx('inst-2')])
+    const notifier = new ApprovalBreachNotifier({ channels: [channel], metrics })
+
+    const first = await notifier.notifyBreaches(['inst-1', 'inst-2'])
+    expect(first.notified).toBe(2)
+    expect(channel.send).toHaveBeenCalledTimes(2)
+
+    listBreachContextByIds.mockResolvedValueOnce([ctx('inst-3')])
+    const second = await notifier.notifyBreaches(['inst-1', 'inst-2', 'inst-3'])
+    expect(second.requested).toBe(3)
+    expect(second.skipped).toBe(2)
+    expect(second.notified).toBe(1)
+    expect(channel.send).toHaveBeenCalledTimes(3)
+  })
+
+  it('does not record an instance as notified if every channel fails', async () => {
+    const channel: BreachNotificationChannel = {
+      name: 'dingtalk',
+      send: vi.fn()
+        .mockResolvedValueOnce({ ok: false, error: 'fail-once' })
+        .mockResolvedValueOnce({ ok: true }),
+    }
+    const { metrics, listBreachContextByIds } = makeMetrics([ctx('inst-1')])
+    const notifier = new ApprovalBreachNotifier({ channels: [channel], metrics })
+
+    const first = await notifier.notifyBreaches(['inst-1'])
+    expect(first.notified).toBe(0)
+    expect(first.failed).toBe(1)
+
+    listBreachContextByIds.mockResolvedValueOnce([ctx('inst-1')])
+    const second = await notifier.notifyBreaches(['inst-1'])
+    expect(second.notified).toBe(1)
+    expect(second.sent).toBe(1)
+  })
+
+  it('returns a graceful empty result when no channels are configured', async () => {
+    const { metrics, listBreachContextByIds } = makeMetrics()
+    const notifier = new ApprovalBreachNotifier({ channels: [], metrics })
+    const result = await notifier.notifyBreaches(['inst-1'])
+    expect(result.requested).toBe(1)
+    expect(result.skipped).toBe(1)
+    expect(result.notified).toBe(0)
+    expect(listBreachContextByIds).not.toHaveBeenCalled()
+  })
+
+  it('still composes a usable message when context lookup returns nothing', async () => {
+    const channel: BreachNotificationChannel = {
+      name: 'dingtalk',
+      send: vi.fn().mockResolvedValue({ ok: true }),
+    }
+    const { metrics } = makeMetrics([])
+    const notifier = new ApprovalBreachNotifier({ channels: [channel], metrics, appBaseUrl: 'https://app.example.com' })
+    const result = await notifier.notifyBreaches(['orphan-1'])
+    expect(result.notified).toBe(1)
+    const message = (channel.send as any).mock.calls[0][0]
+    expect(message.title).toContain('审批超时告警')
+    expect(message.title).toContain('未命名模板')
+    expect(message.body).toContain('未知申请人')
+    expect(message.body).toContain('未知节点')
+    expect(message.link).toBe('https://app.example.com/approval/orphan-1')
+  })
+})

--- a/packages/core-backend/tests/unit/dingtalk-breach-channel.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-breach-channel.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from 'vitest'
+import { ApprovalBreachDingTalkChannel } from '../../src/services/breach-channels/dingtalk-channel'
+import type { BreachMessage } from '../../src/services/breach-channels'
+
+const VALID_WEBHOOK = 'https://oapi.dingtalk.com/robot/send?access_token=abc123'
+const VALID_SECRET = 'SECexamplesecret'
+
+function sampleMessage(overrides: Partial<BreachMessage> = {}): BreachMessage {
+  return {
+    instanceId: 'inst-1',
+    title: '审批超时告警 | 请假申请 | 实例 #inst-1',
+    body: '- 申请人：张三\n- 启动时间：2026-04-25 08:00:00 UTC\n- SLA 阈值：24 小时',
+    link: 'https://app.example.com/approval/inst-1',
+    severity: 'warning',
+    ...overrides,
+  }
+}
+
+describe('ApprovalBreachDingTalkChannel', () => {
+  it('returns ok:false when no webhook URL is configured', async () => {
+    const channel = new ApprovalBreachDingTalkChannel({})
+    const result = await channel.send(sampleMessage())
+    expect(result.ok).toBe(false)
+    expect(result.error).toBe('webhook not configured')
+  })
+
+  it('treats an invalid webhook URL as not configured', async () => {
+    const channel = new ApprovalBreachDingTalkChannel({ webhookUrl: 'http://insecure.example.com/robot/send?access_token=x' })
+    const result = await channel.send(sampleMessage())
+    expect(result.ok).toBe(false)
+    expect(result.error).toBe('webhook not configured')
+  })
+
+  it('posts a markdown payload to the signed webhook URL', async () => {
+    const fetchFn = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: async () => '{"errcode":0}',
+    } as unknown as Response) as unknown as typeof fetch
+
+    const channel = new ApprovalBreachDingTalkChannel({
+      webhookUrl: VALID_WEBHOOK,
+      secret: VALID_SECRET,
+      fetchFn,
+    })
+    const message = sampleMessage()
+    const result = await channel.send(message)
+
+    expect(result.ok).toBe(true)
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+    const [calledUrl, init] = (fetchFn as any).mock.calls[0]
+    expect(typeof calledUrl).toBe('string')
+    expect(calledUrl).toContain('oapi.dingtalk.com/robot/send')
+    expect(calledUrl).toContain('access_token=abc123')
+    expect(calledUrl).toContain('timestamp=')
+    expect(calledUrl).toContain('sign=')
+    expect(init.method).toBe('POST')
+    expect(init.headers['Content-Type']).toBe('application/json')
+
+    const payload = JSON.parse(init.body as string)
+    expect(payload).toMatchObject({
+      msgtype: 'markdown',
+      markdown: {
+        title: message.title,
+      },
+    })
+    expect(payload.markdown.text).toContain(`### ${message.title}`)
+    expect(payload.markdown.text).toContain(message.body)
+    expect(payload.markdown.text).toContain(`[查看详情](${message.link})`)
+  })
+
+  it('returns the upstream HTTP error when DingTalk returns a non-2xx status', async () => {
+    const fetchFn = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Error',
+      text: async () => 'boom',
+    } as unknown as Response) as unknown as typeof fetch
+
+    const channel = new ApprovalBreachDingTalkChannel({ webhookUrl: VALID_WEBHOOK, fetchFn })
+    const result = await channel.send(sampleMessage())
+    expect(result.ok).toBe(false)
+    expect(result.error).toContain('HTTP 500')
+  })
+
+  it('treats a non-zero errcode body as a failure', async () => {
+    const fetchFn = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: async () => '{"errcode":310000,"errmsg":"keyword not in content"}',
+    } as unknown as Response) as unknown as typeof fetch
+
+    const channel = new ApprovalBreachDingTalkChannel({ webhookUrl: VALID_WEBHOOK, fetchFn })
+    const result = await channel.send(sampleMessage())
+    expect(result.ok).toBe(false)
+    expect(result.error).toContain('310000')
+    expect(result.error).toContain('keyword not in content')
+  })
+
+  it('captures network errors without throwing', async () => {
+    const fetchFn = vi.fn().mockRejectedValue(new Error('connect ECONNREFUSED')) as unknown as typeof fetch
+    const channel = new ApprovalBreachDingTalkChannel({ webhookUrl: VALID_WEBHOOK, fetchFn })
+    const result = await channel.send(sampleMessage())
+    expect(result.ok).toBe(false)
+    expect(result.error).toBe('connect ECONNREFUSED')
+  })
+})

--- a/packages/core-backend/tests/unit/dingtalk-breach-channel.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-breach-channel.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import { ApprovalBreachDingTalkChannel } from '../../src/services/breach-channels/dingtalk-channel'
-import type { BreachMessage } from '../../src/services/breach-channels'
+import { createApprovalBreachChannelsFromEnv, type BreachMessage } from '../../src/services/breach-channels'
 
 const VALID_WEBHOOK = 'https://oapi.dingtalk.com/robot/send?access_token=abc123'
 const VALID_SECRET = 'SECexamplesecret'
@@ -105,5 +105,29 @@ describe('ApprovalBreachDingTalkChannel', () => {
     const result = await channel.send(sampleMessage())
     expect(result.ok).toBe(false)
     expect(result.error).toBe('connect ECONNREFUSED')
+  })
+})
+
+describe('createApprovalBreachChannelsFromEnv', () => {
+  it('does not register noisy channels when notification env is unset', () => {
+    const channels = createApprovalBreachChannelsFromEnv({})
+    expect(channels).toEqual([])
+  })
+
+  it('registers DingTalk only when a webhook is configured', () => {
+    const channels = createApprovalBreachChannelsFromEnv({
+      APPROVAL_BREACH_DINGTALK_WEBHOOK: VALID_WEBHOOK,
+      APPROVAL_BREACH_DINGTALK_SECRET: VALID_SECRET,
+    })
+    expect(channels.map((channel) => channel.name)).toEqual(['dingtalk'])
+  })
+
+  it('registers the email stub only when both endpoints are explicitly configured', () => {
+    expect(createApprovalBreachChannelsFromEnv({ APPROVAL_BREACH_EMAIL_FROM: 'ops@example.com' })).toEqual([])
+    const channels = createApprovalBreachChannelsFromEnv({
+      APPROVAL_BREACH_EMAIL_FROM: 'ops@example.com',
+      APPROVAL_BREACH_EMAIL_TO: 'admin@example.com',
+    })
+    expect(channels.map((channel) => channel.name)).toEqual(['email'])
   })
 })


### PR DESCRIPTION
## Summary

- Closes the WP5 SLA observability loop — wires `ApprovalSlaScheduler.onBreach` to DingTalk + email-stub channels
- Channels are **env-gated**: register only when env vars configured (no per-breach failure noise on default deployments)
- Failure isolation: a channel throwing does NOT block other channels; notifier throwing does NOT block scheduler tick
- DingTalk reuses leaf helpers from `integrations/dingtalk/robot.ts`; email is a logging stub (no SMTP/SendGrid in repo and task spec forbade new deps)

## Verification

- `npx tsc --noEmit` → clean
- `approval-breach-notifier`: 8/8 ✓
- `dingtalk-breach-channel`: 6/6 ✓
- `approval-sla-scheduler`: 7/7 ✓ (regression green)
- `approval-metrics-service`: 15/15 ✓ (existing coverage green after JOIN method added)
- Aggregate: 24/24 focused (post-review) at HEAD `50179d9d7` on `origin/main@892ed2f9c`

## Risk / Rollback

- Risk: **best-effort semantics** — failed-channel breaches do NOT retry on next scheduler tick (filtered by `sla_breached=TRUE`). Explicitly documented in dev MD; persistent `breach_notified_at` column is the planned follow-up.
- Risk: in-memory FIFO `Set<instanceId>` (bounded 5000) for in-process dedupe — bounded under steady state but cannot defend against rapid leader churn until persistent column lands.
- Rollback: revert the 3 commits; scheduler reverts to no-op `onBreach` behavior. No migration to undo.

## Follow-up

- Persistent `breach_notified_at` column for cross-restart / leader-takeover dedupe (small migration + WHERE-clause filter, ~60 LoC).
- Real SMTP transport (today: logging stub) — pending dep policy decision on `nodemailer` / a managed sender.
- Live DingTalk integration test (today: mock-only); manual `curl` verification path documented in verification MD.

See `docs/development/approval-sla-breach-notify-development-20260425.md` and `*-verification-20260425.md` for full design + verification.

---

## Follow-up branch ready (post-merge action)

The `breach_notified_at` persistent-dedupe follow-up listed above is **already implemented** on a stacked branch and verified — held off opening as a stacked PR per queue-drain discipline. To be opened as a normal PR (not Draft) once this PR (#1171) merges:

- Branch: `codex/approval-sla-breach-notified-at-20260426`
- HEAD: `3ffda7a1f`
- Stack baseline: `50179d9d7` (this PR's tip)
- Tests: 30/30 focused (7 metrics + 12 notifier + 11 scheduler) + 15/15 metrics-service regression — all green
- Files: +711 / −61 across 10 files (migration + 2 service methods + scheduler union dispatch + notifier rewrite dropping in-memory FIFO + 3 test files + 2 docs)
- Semantic upgrade: best-effort once → at-least-once with persistent retry

Delivery MD: `docs/development/pr-queue-and-breach-notified-at-20260426.md`.
Branch-local design + verification MDs:
- `docs/development/approval-sla-breach-notified-at-development-20260426.md`
- `docs/development/approval-sla-breach-notified-at-verification-20260426.md`
