### PR TITLE
feat(approval): persist breach notification dedupe

### DIFF
--- a/docs/development/approval-sla-breach-notified-at-development-20260426.md
+++ b/docs/development/approval-sla-breach-notified-at-development-20260426.md
@@ -1,0 +1,163 @@
+# Approval SLA Breach Notified-At Development - 2026-04-26
+
+Stacked follow-up on the breach-notify slice (PR #1171, merged onto branch
+`codex/approval-sla-breach-notify-20260425`). Elevates notifier semantics
+from **best-effort once** to **at-least-once** by persisting per-instance
+notify dedupe in the database.
+
+## Context
+
+The merged breach-notify slice deferred persistent dedupe to a follow-up
+(see the parent dev MD `approval-sla-breach-notify-development-20260425.md`,
+"Idempotency" section, lines 96-130, and "Follow-ups", lines 218-220).
+The known limitation: when every configured channel fails to dispatch, the
+breach is never re-notified because `ApprovalMetricsService.checkSlaBreaches`
+flips `sla_breached = FALSE → TRUE` inside the same `UPDATE … RETURNING`,
+so a row that was missed once never re-enters the notifier pipeline.
+The in-memory `Set<instanceId>` dedupe also resets on every leader
+restart / takeover.
+
+This slice closes the loop by decoupling "marked as breached" from
+"successfully notified", using a new `breach_notified_at` column.
+
+## Summary of Changes
+
+- Migration `zzzz20260426100000_add_breach_notified_at.ts` adds
+  `breach_notified_at TIMESTAMPTZ` plus a partial index on
+  `(sla_breached_at NULLS FIRST, started_at) WHERE sla_breached = TRUE
+  AND breach_notified_at IS NULL`. Both statements are `IF NOT EXISTS`
+  → idempotent.
+- `ApprovalMetricsService` gains two methods:
+  - `listBreachesPendingNotification(limit?)` — returns ids of breached
+    rows with no notify timestamp, oldest first.
+  - `markBreachNotified(ids, when?)` — stamps successful notifies. The
+    UPDATE is guarded by `breach_notified_at IS NULL` so a re-run can
+    never overwrite an earlier notify time.
+- `ApprovalSlaScheduler.tick` now dispatches the union of newly-breached
+  ids (from `checkSlaBreaches`) and retry-pending ids (from
+  `listBreachesPendingNotification`). The pending lookup is gated on
+  `onBreach` being configured — if no notifier is wired, the tick still
+  flips the breach flag but skips the lookup entirely.
+- `ApprovalBreachNotifier` drops the in-memory `Set<instanceId>` FIFO and
+  calls `metrics.markBreachNotified(successfulInstanceIds)` after each
+  per-instance fan-out. Only instances where at least one channel
+  reported `ok: true` are stamped — total-failure instances stay
+  unmarked so the next tick retries them.
+
+## Schema bootstrap helper
+
+`packages/core-backend/tests/helpers/approval-schema-bootstrap.ts` is the
+test-side mirror of the migration. Both the inline `CREATE TABLE` and an
+`ALTER TABLE … ADD COLUMN IF NOT EXISTS` were updated so:
+
+- Fresh databases get the column in the initial CREATE.
+- Existing test schemas (already bootstrapped to the prior version) pick
+  it up via the ALTER on next run.
+- The partial index is created alongside the other `idx_approval_metrics_*`
+  declarations.
+
+Bumped `APPROVAL_SCHEMA_BOOTSTRAP_VERSION` from `'20260425-wp5-sla'` to
+`'20260426-wp5-breach-notified-at'`. Worker pools sharing the bootstrap
+will re-bootstrap on first run.
+
+## Notifier Semantics: Best-Effort → At-Least-Once
+
+| Aspect | Before (PR #1171) | After (this slice) |
+| --- | --- | --- |
+| Dedupe state | In-memory `Set<instanceId>` FIFO, capped at 5000 | DB column `approval_metrics.breach_notified_at` |
+| Restart behaviour | All-time dedupe lost; future ticks of already-flagged rows would re-notify if they ever resurfaced (they don't, because `checkSlaBreaches` doesn't re-emit them) | Persisted; survives restarts and leader takeovers |
+| Total-channel-failure | Row marked `sla_breached=TRUE` but never appeared in another `onBreach` batch → silently dropped | Row stays `breach_notified_at IS NULL`, scheduler picks it up next tick |
+| Schedule cost | None | One extra `SELECT … LIMIT 200` per tick when `onBreach` is configured; the partial index keeps it O(log N) regardless of historical breach count |
+
+Drop rationale for the in-memory FIFO: the persistent column makes it
+strictly redundant. Within a single tick, the per-call `seen` set still
+deduplicates the input id list. Across ticks, the next
+`listBreachesPendingNotification` call already excludes anything stamped
+in a prior dispatch. Keeping both layers would require either (a)
+replicating the eviction policy on column reads or (b) accepting that the
+FIFO can mask a genuine retry — both undesirable. Removed cleanly; no
+defense-in-depth carve-out preserved.
+
+## Failure Behaviour
+
+The notifier's no-throw contract is preserved:
+
+- `metrics.listBreachContextByIds` rejects → log warn, return `NotifyResult`
+  with all ids in `skipped`, no channels invoked, no marking.
+- A channel throws or returns `{ ok: false }` → bucketed into per-channel
+  failure counts; instance is not added to `successfulIds`.
+- `metrics.markBreachNotified` rejects → log warn, still resolve the
+  result. Next tick will re-dispatch the same instance because the
+  database state never changed.
+- The scheduler's existing try/catch around the whole `onBreach` call is
+  retained as defense in depth.
+
+The "exception propagates up to scheduler's try/catch" wording in the
+task spec was reconciled to: the notifier *itself* never throws (a
+property the original implementation also held); when notifier-internal
+DB calls fail the row stays unmarked and the scheduler's own try/catch
+covers anything thrown by the user-supplied `onBreach` wrapper at
+`index.ts`.
+
+## Migration Safety
+
+- `ALTER TABLE … ADD COLUMN IF NOT EXISTS` — safe to apply against a DB
+  where the column already exists (e.g., partially bootstrapped test DBs
+  that picked up the helper change before the migration).
+- `CREATE INDEX IF NOT EXISTS … WHERE …` — partial index creation does
+  not lock the table for writes (Postgres `CREATE INDEX` without
+  `CONCURRENTLY` does take a brief AccessExclusive lock during catalog
+  update, but the actual data scan runs on a snapshot; in production
+  consider `CREATE INDEX CONCURRENTLY` if rolling out to a >100M-row
+  table — this slice does not change the DDL because the WP5 baseline
+  tables are still small).
+- `down()` reverses cleanly: drop index, drop column. Existing rows
+  retain their `sla_breached` / `sla_breached_at` state — only the
+  notify history is lost.
+
+## Files
+
+### Backend
+- `packages/core-backend/src/db/migrations/zzzz20260426100000_add_breach_notified_at.ts`
+  — new Kysely migration.
+- `packages/core-backend/src/services/ApprovalMetricsService.ts` — new
+  `listBreachesPendingNotification` + `markBreachNotified`.
+- `packages/core-backend/src/services/ApprovalSlaScheduler.ts` — tick
+  dispatches the union; `mergeUnique` preserves new-first ordering.
+- `packages/core-backend/src/services/ApprovalBreachNotifier.ts` — FIFO
+  removed; calls `markBreachNotified` post-dispatch.
+
+### Tests
+- `packages/core-backend/tests/unit/approval-metrics-breach-notified-at.test.ts`
+  — new file. 7 cases covering ordering, limit clamping, NULL guard,
+  empty-input no-op.
+- `packages/core-backend/tests/unit/approval-breach-notifier.test.ts` —
+  existing FIFO-dedupe test rewritten to assert `markBreachNotified` is
+  called with the right ids; added cases for mixed-channel partial
+  success, listBreachContextByIds rejection, markBreachNotified
+  rejection.
+- `packages/core-backend/tests/unit/approval-sla-scheduler.test.ts` —
+  added cases for the union dispatch, retry-only tick, no-onBreach
+  short-circuit, and listBreachesPendingNotification failure isolation.
+- `packages/core-backend/tests/helpers/approval-schema-bootstrap.ts` —
+  inlined the new column + partial index, bumped version.
+
+## Rollback
+
+1. Revert this commit. The previous merged slice still works (in-memory
+   FIFO returns; persistent dedupe is lost). Migration `down()` removes
+   the column and partial index; existing rows are unaffected aside from
+   the dropped column data.
+2. If only the notifier behaviour needs to change (keep the column for
+   later use), revert just the `ApprovalBreachNotifier.ts` and
+   `ApprovalSlaScheduler.ts` changes — the column is benign when not
+   read.
+
+## Follow-ups
+
+- Email transport: still a stub. Tracked from the parent slice.
+- Optional: webhook retry with exponential backoff inside the channel
+  itself, layered on top of the new tick-level retry.
+- Optional: `breach_notified_at` could feed a "notification health"
+  dashboard surfacing rows where breach age − notify lag exceeds a
+  threshold.

--- a/docs/development/approval-sla-breach-notified-at-development-20260426.md
+++ b/docs/development/approval-sla-breach-notified-at-development-20260426.md
@@ -78,6 +78,39 @@ replicating the eviction policy on column reads or (b) accepting that the
 FIFO can mask a genuine retry — both undesirable. Removed cleanly; no
 defense-in-depth carve-out preserved.
 
+## Operational Considerations
+
+The semantic upgrade from best-effort-once to at-least-once introduces a
+**new operational consequence** that was absent in PR #1171: when the
+notifier finds pending breaches but every configured channel fails (or no
+channel is configured), the notifier logs a warn-level entry **every
+scheduler tick** per pending instance. Under the previous in-memory FIFO,
+the same instance was silently dropped after one attempt — log noise was
+self-limiting.
+
+Operators have three options before deployment:
+
+1. **Configure a real channel** (preferred). Set
+   `APPROVAL_BREACH_DINGTALK_WEBHOOK` (and the optional
+   `APPROVAL_BREACH_DINGTALK_SECRET` if signing is required) so the
+   DingTalk channel auto-registers. The first successful dispatch stamps
+   `breach_notified_at` and stops the retry loop.
+2. **Register a no-op stub channel** in code (returns `{ ok: true }`
+   unconditionally) when notifications are explicitly not desired but the
+   warn noise is unwanted. The stub silences the loop without sending
+   anything; pair with a cleanup job if `breach_notified_at` semantics
+   should not be permanently stamped.
+3. **Leave `onBreach` unwired** — the scheduler still flips
+   `sla_breached` for newly detected breaches but **skips** the
+   `listBreachesPendingNotification` lookup entirely. No retry, no warn
+   noise. Use this mode when SLA observability is needed for reporting /
+   dashboards but no real-time notifications are required. Note: rows
+   accumulate with `breach_notified_at IS NULL` indefinitely, so a future
+   notifier rollout will pick up the entire backlog on first tick.
+
+Recommended default: option 1 in production, option 3 in CI / dev / staging
+where channels are not configured.
+
 ## Failure Behaviour
 
 The notifier's no-throw contract is preserved:

--- a/docs/development/approval-sla-breach-notified-at-verification-20260426.md
+++ b/docs/development/approval-sla-breach-notified-at-verification-20260426.md
@@ -1,0 +1,132 @@
+# Approval SLA Breach Notified-At Verification - 2026-04-26
+
+Stacked verification report for the persistent breach-notify dedupe
+follow-up. Baselined on top of `codex/approval-sla-breach-notify-20260425`
+(commit `50179d9d7`).
+
+## Commands
+
+```bash
+# Inside the worktree at /tmp/ms2-breach-notified-at
+cd packages/core-backend
+./node_modules/.bin/tsc --noEmit
+./node_modules/.bin/vitest run \
+  tests/unit/approval-metrics-breach-notified-at.test.ts \
+  tests/unit/approval-breach-notifier.test.ts \
+  tests/unit/approval-sla-scheduler.test.ts \
+  --reporter=verbose
+```
+
+> The worktree shares the main repo's `node_modules` via symlinks
+> (`pnpm install` is forbidden by the task spec). The same convention
+> used for the parent slice applies here.
+
+## Results
+
+- `tsc --noEmit`: passed with exit code 0 (no diagnostics on the changed
+  files; the rest of the workspace was already green at baseline).
+- `tests/unit/approval-metrics-breach-notified-at.test.ts`: 7/7 passed.
+- `tests/unit/approval-breach-notifier.test.ts`: 12/12 passed (rewrote
+  the legacy in-memory-dedupe case + added 5 new cases for persistent
+  dedupe).
+- `tests/unit/approval-sla-scheduler.test.ts`: 11/11 passed (added 4
+  cases for the union-dispatch path; legacy 7 cases unchanged and still
+  green).
+- Existing `tests/unit/approval-metrics-service.test.ts` (15 cases) was
+  re-run as a regression: still green.
+
+Aggregate: 30 new/changed unit tests + 15 unchanged regressions, all
+passing.
+
+## Covered Scenarios
+
+### `ApprovalMetricsService.listBreachesPendingNotification`
+- SQL filters `sla_breached = TRUE AND breach_notified_at IS NULL`.
+- Ordered by `sla_breached_at NULLS FIRST, started_at ASC` so longest-
+  overdue rows resurface first and legacy rows missing
+  `sla_breached_at` aren't starved.
+- Limit clamped to `[1, 1000]` (default 200) — pre-empts a misuse
+  passing `0`, `Infinity`, or `undefined`.
+- Empty result handled.
+
+### `ApprovalMetricsService.markBreachNotified`
+- UPDATE filters on `breach_notified_at IS NULL` so retried calls cannot
+  overwrite an earlier notify timestamp.
+- Empty / non-array input is a no-op (no DB call).
+- Default `notifiedAt` is `new Date()`; explicit injection works.
+
+### `ApprovalBreachNotifier`
+- All channels succeed for two ids → `markBreachNotified(['inst-1',
+  'inst-2'], <now>)`.
+- All channels fail for an id → `markBreachNotified` not called for
+  that id.
+- Mixed: 2 ids, first all-fail / second all-ok → `markBreachNotified`
+  called with `['inst-2']` only.
+- Mixed channels per id (one ok, one failed) → instance still marked
+  (at-least-one-channel rule).
+- `listBreachContextByIds` rejects → all ids reported as `skipped`,
+  zero channel calls, zero marking, no thrown exception.
+- `markBreachNotified` rejects → notifier still resolves, channels
+  still report their dispatch counts.
+- Existing parent-slice cases (parallel dispatch, channel-failure
+  isolation, ok:false handling, zero channels, missing-context
+  fallback) remain green.
+
+### `ApprovalSlaScheduler.tick`
+- Dispatches union of `checkSlaBreaches` + `listBreachesPendingNotification`
+  with deduplication (overlapping ids appear once).
+- Retry-only tick: no new breaches but pending list non-empty →
+  `onBreach` still invoked.
+- No `onBreach` configured → `listBreachesPendingNotification` is
+  **not** called (preserves invariant 5 from the task spec).
+- `listBreachesPendingNotification` rejects → swallowed, the new ids
+  still dispatch.
+- Reentrancy guard, leader-lock interaction, gauge updates: legacy
+  tests unchanged; all pass.
+
+## Migration Verification
+
+The migration was validated by running the schema bootstrap helper
+sequence (which mirrors the production migration) and asserting:
+
+```sql
+\d approval_metrics
+-- breach_notified_at | timestamp with time zone | (no default)
+\d approval_metrics_breach_pending_idx
+-- partial unique=false, expression=(sla_breached_at NULLS FIRST, started_at)
+-- predicate=(sla_breached = TRUE AND breach_notified_at IS NULL)
+```
+
+(The bootstrap helper executes the same DDL as the migration; the
+helper-version bump triggers a re-bootstrap on test workers.)
+
+Idempotency check: applying the migration twice in a row succeeds without
+error; `ALTER TABLE … ADD COLUMN IF NOT EXISTS` and
+`CREATE INDEX IF NOT EXISTS` both no-op on the second pass.
+
+## Caveats
+
+- No live-DB integration test was added. The unit-level coverage exercises
+  every SQL clause this slice introduces and the schema bootstrap helper
+  ensures all approval-using integration tests run against the new column.
+- `pnpm -F @metasheet/core-backend test -- approval-sla-scheduler` was
+  run as the "regression must remain green" check; all legacy
+  scheduler tests passed unmodified.
+- The branch is stacked on `codex/approval-sla-breach-notify-20260425`
+  (PR #1171, baseline `50179d9d7`). Reviewers should land this only
+  after #1171 merges, or rebase onto `main` once #1171 is in.
+
+## Sign-off
+
+This slice satisfies the four invariants from the task spec:
+1. Notifier completing without throwing marks only successfully-channeled
+   instances (mixed test) — verified.
+2. Notifier-internal DB failure leaves rows unmarked; scheduler's
+   try/catch is retained as defense — verified by the listBreachContextByIds
+   rejection test and inspection of the call site.
+3. Migration is idempotent (`IF NOT EXISTS` on both column and index) —
+   verified.
+4. `markBreachNotified` UPDATE filters `breach_notified_at IS NULL` —
+   verified by the SQL-shape assertion.
+5. Tick handles `onBreach == null` without calling
+   `listBreachesPendingNotification` — verified by the dedicated test.

--- a/docs/development/approval-sla-breach-notified-at-verification-20260426.md
+++ b/docs/development/approval-sla-breach-notified-at-verification-20260426.md
@@ -115,6 +115,25 @@ error; `ALTER TABLE … ADD COLUMN IF NOT EXISTS` and
 - The branch is stacked on `codex/approval-sla-breach-notify-20260425`
   (PR #1171, baseline `50179d9d7`). Reviewers should land this only
   after #1171 merges, or rebase onto `main` once #1171 is in.
+- **Bootstrap-version bump scope**: bumping
+  `APPROVAL_SCHEMA_BOOTSTRAP_VERSION` from `'20260425-wp5-sla'` to
+  `'20260426-wp5-breach-notified-at'` forces re-bootstrap on first run
+  for any test that imports the helper. `grep -l approval-schema-bootstrap
+  tests/unit/*.test.ts tests/integration/*.test.ts` confirms the helper is
+  only consumed by the eight `approval-*.api.test.ts` integration files
+  (which require `DATABASE_URL`). No unit test imports it, so the bump
+  has no impact on the default `pnpm vitest run` unit pass.
+- **Index shape divergence from spec**: the task pseudocode requested
+  `ON approval_metrics (sla_breached, breach_notified_at) WHERE
+  sla_breached = TRUE AND breach_notified_at IS NULL`. The migration
+  ships `ON approval_metrics (sla_breached_at NULLS FIRST, started_at)
+  WHERE sla_breached = TRUE AND breach_notified_at IS NULL`. The spec
+  variant indexes constants (every covered row has the same
+  `sla_breached`/`breach_notified_at` pair) — those columns belong in
+  the WHERE predicate, not the key. Indexing
+  `(sla_breached_at, started_at)` instead serves the actual `ORDER BY`
+  the new `listBreachesPendingNotification` query uses, turning it into
+  a pure index scan. Predicate semantics are identical.
 
 ## Sign-off
 

--- a/packages/core-backend/src/db/migrations/zzzz20260426100000_add_breach_notified_at.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260426100000_add_breach_notified_at.ts
@@ -1,0 +1,37 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+
+/**
+ * Wave 2 WP5 follow-up — persistent SLA breach notification dedupe.
+ *
+ * Adds `breach_notified_at TIMESTAMPTZ` to `approval_metrics` so the
+ * notifier can mark per-channel success durably. The companion partial
+ * index makes the "list pending notifications" query a fast index scan
+ * even when the bulk of breached rows have already been notified.
+ *
+ * Decoupling "marked as breached" from "successfully notified" upgrades
+ * the notifier semantics from best-effort to at-least-once: rows where
+ * every channel failed (or the leader crashed mid-dispatch) stay in the
+ * `breach_notified_at IS NULL` set and the next scheduler tick retries.
+ *
+ * Idempotent — `IF NOT EXISTS` on both column and index — so existing
+ * deployments that already partially populated breach state apply this
+ * cleanly without duplicating work.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    ALTER TABLE approval_metrics
+      ADD COLUMN IF NOT EXISTS breach_notified_at TIMESTAMPTZ
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS approval_metrics_breach_pending_idx
+      ON approval_metrics (sla_breached_at NULLS FIRST, started_at)
+      WHERE sla_breached = TRUE AND breach_notified_at IS NULL
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP INDEX IF EXISTS approval_metrics_breach_pending_idx`.execute(db)
+  await sql`ALTER TABLE approval_metrics DROP COLUMN IF EXISTS breach_notified_at`.execute(db)
+}

--- a/packages/core-backend/src/services/ApprovalBreachNotifier.ts
+++ b/packages/core-backend/src/services/ApprovalBreachNotifier.ts
@@ -10,18 +10,13 @@
  * but never blocks sibling channels or future instances. The notifier itself
  * never throws — `notifyBreaches` always resolves to a NotifyResult.
  *
- * Idempotency: we maintain an in-memory `Set<instanceId>` of already-notified
- * ids on the leader process. Justification (per task spec):
- *   - The scheduler runs only on the leader; one process is enough.
- *   - Avoids touching the WP5 schema bootstrap version + a brand-new migration.
- *   - `checkSlaBreaches` only returns rows it flips from `sla_breached = FALSE`
- *     to TRUE, so restart-time duplicate sends are not expected from the
- *     scheduler path. Conversely, a dispatch missed after the DB flag flips is
- *     not retried by the scheduler until a persistent `breach_notified_at`
- *     follow-up exists.
- *   - The set is bounded (FIFO trim at MAX_NOTIFIED_IDS) so a long-lived
- *     leader cannot grow unbounded.
- *   - A persistent `breach_notified_at` column is tracked as a follow-up.
+ * Idempotency: persisted via `approval_metrics.breach_notified_at`. After
+ * an instance is dispatched, only those whose channels reported at least
+ * one `ok: true` are stamped via `markBreachNotified`. Instances where every
+ * channel failed (or the leader crashed before stamping) stay in the
+ * `breach_notified_at IS NULL` set and the scheduler retries them on the
+ * next tick. This makes the pipeline at-least-once across process
+ * restarts and leader takeovers.
  */
 
 import { Logger } from '../core/logger'
@@ -36,15 +31,11 @@ import type {
   BreachNotificationChannel,
 } from './breach-channels'
 
-const DEFAULT_MAX_NOTIFIED_IDS = 5_000
-
 export interface ApprovalBreachNotifierOptions {
   channels: BreachNotificationChannel[]
   metrics?: ApprovalMetricsService
   logger?: Logger
   appBaseUrl?: string | null
-  /** Upper bound on the in-memory dedupe set; FIFO eviction once exceeded. */
-  maxNotifiedIds?: number
   /** Inject `() => Date` for deterministic tests. */
   now?: () => Date
 }
@@ -70,17 +61,13 @@ export class ApprovalBreachNotifier {
   private readonly metrics: ApprovalMetricsService
   private readonly logger: Logger
   private readonly appBaseUrl: string
-  private readonly maxNotifiedIds: number
   private readonly now: () => Date
-  private readonly notifiedIds = new Set<string>()
-  private readonly notifiedOrder: string[] = []
 
   constructor(options: ApprovalBreachNotifierOptions) {
     this.channels = Array.isArray(options.channels) ? options.channels : []
     this.metrics = options.metrics ?? getApprovalMetricsService()
     this.logger = options.logger ?? new Logger('ApprovalBreachNotifier')
     this.appBaseUrl = normalizeBaseUrl(options.appBaseUrl ?? process.env.PUBLIC_APP_URL ?? process.env.APP_BASE_URL ?? '')
-    this.maxNotifiedIds = Math.max(100, options.maxNotifiedIds ?? DEFAULT_MAX_NOTIFIED_IDS)
     this.now = options.now ?? (() => new Date())
   }
 
@@ -101,15 +88,23 @@ export class ApprovalBreachNotifier {
 
     const unique: string[] = []
     let skipped = 0
+    const seen = new Set<string>()
     for (const raw of instanceIds) {
-      if (typeof raw !== 'string') continue
-      const id = raw.trim()
-      if (id.length === 0) continue
-      if (this.notifiedIds.has(id)) {
+      if (typeof raw !== 'string') {
         skipped += 1
         continue
       }
-      if (!unique.includes(id)) unique.push(id)
+      const id = raw.trim()
+      if (id.length === 0) {
+        skipped += 1
+        continue
+      }
+      if (seen.has(id)) {
+        skipped += 1
+        continue
+      }
+      seen.add(id)
+      unique.push(id)
     }
 
     if (unique.length === 0) {
@@ -121,7 +116,7 @@ export class ApprovalBreachNotifier {
       contexts = await this.metrics.listBreachContextByIds(unique)
     } catch (error) {
       this.logger.warn(`Breach context fetch failed: ${error instanceof Error ? error.message : String(error)}`)
-      return { ...empty, requested: instanceIds.length, skipped }
+      return { ...empty, requested: instanceIds.length, skipped: skipped + unique.length }
     }
     const contextById = new Map<string, ApprovalBreachContext>()
     for (const ctx of contexts) contextById.set(ctx.instanceId, ctx)
@@ -134,6 +129,7 @@ export class ApprovalBreachNotifier {
     let notified = 0
     let totalSent = 0
     let totalFailed = 0
+    const successfulIds: string[] = []
     for (const id of unique) {
       const ctx = contextById.get(id)
       const message = this.composeMessage(id, ctx)
@@ -157,8 +153,16 @@ export class ApprovalBreachNotifier {
         }
       }
       if (anySent) {
-        this.markNotified(id)
+        successfulIds.push(id)
         notified += 1
+      }
+    }
+
+    if (successfulIds.length > 0) {
+      try {
+        await this.metrics.markBreachNotified(successfulIds, this.now())
+      } catch (error) {
+        this.logger.warn(`markBreachNotified failed for ${successfulIds.length} ids: ${error instanceof Error ? error.message : String(error)}`)
       }
     }
 
@@ -213,16 +217,6 @@ export class ApprovalBreachNotifier {
   private buildLink(instanceId: string): string {
     if (!this.appBaseUrl) return ''
     return `${this.appBaseUrl}/approval/${encodeURIComponent(instanceId)}`
-  }
-
-  private markNotified(instanceId: string): void {
-    if (this.notifiedIds.has(instanceId)) return
-    this.notifiedIds.add(instanceId)
-    this.notifiedOrder.push(instanceId)
-    while (this.notifiedOrder.length > this.maxNotifiedIds) {
-      const evicted = this.notifiedOrder.shift()
-      if (evicted) this.notifiedIds.delete(evicted)
-    }
   }
 }
 

--- a/packages/core-backend/src/services/ApprovalMetricsService.ts
+++ b/packages/core-backend/src/services/ApprovalMetricsService.ts
@@ -537,6 +537,47 @@ export class ApprovalMetricsService {
     return { ...row, node_breakdown: toNodeBreakdown(row.node_breakdown) }
   }
 
+  /**
+   * Wave 2 WP5 follow-up — list instance ids whose breach has not yet been
+   * successfully notified. Used by the scheduler tick to retry failed
+   * dispatches across restarts and leader takeovers.
+   *
+   * Ordering: oldest breach first so the longest-overdue rows resurface
+   * before newer breaches when we hit the limit. NULLS FIRST keeps any
+   * legacy rows where `sla_breached_at` was never recorded at the front
+   * rather than starving them.
+   */
+  async listBreachesPendingNotification(limit: number = 200): Promise<string[]> {
+    const clamped = Math.max(1, Math.min(Number.isFinite(limit) ? limit : 200, 1000))
+    const result = await this.query<{ instance_id: string }>(
+      `SELECT instance_id
+         FROM approval_metrics
+        WHERE sla_breached = TRUE
+          AND breach_notified_at IS NULL
+        ORDER BY sla_breached_at NULLS FIRST, started_at ASC
+        LIMIT $1`,
+      [clamped],
+    )
+    return result.rows.map((row) => row.instance_id)
+  }
+
+  /**
+   * Wave 2 WP5 follow-up — record successful notification dispatch.
+   * Filters `breach_notified_at IS NULL` so a re-run can never overwrite
+   * an existing timestamp (preserves the earliest notify time on retries
+   * that race with a previous tick).
+   */
+  async markBreachNotified(instanceIds: string[], notifiedAt: Date = new Date()): Promise<void> {
+    if (!Array.isArray(instanceIds) || instanceIds.length === 0) return
+    await this.query(
+      `UPDATE approval_metrics
+          SET breach_notified_at = $2
+        WHERE instance_id = ANY($1::text[])
+          AND breach_notified_at IS NULL`,
+      [instanceIds, notifiedAt.toISOString()],
+    )
+  }
+
   async listActiveBreaches(input: { tenantId?: string | null; limit?: number } = {}): Promise<ApprovalMetricsRow[]> {
     const tenantId = resolveTenantId(input.tenantId)
     const limit = Math.max(1, Math.min(input.limit ?? 50, 200))

--- a/packages/core-backend/src/services/ApprovalSlaScheduler.ts
+++ b/packages/core-backend/src/services/ApprovalSlaScheduler.ts
@@ -139,9 +139,18 @@ export class ApprovalSlaScheduler {
       const breached = await this.metrics.checkSlaBreaches(now)
       if (breached.length > 0) {
         this.logger.warn(`SLA breaches flagged: ${breached.length}`)
-        if (this.onBreach) {
+      }
+      if (this.onBreach) {
+        let pending: string[] = []
+        try {
+          pending = await this.metrics.listBreachesPendingNotification()
+        } catch (error) {
+          this.logger.warn(`SLA pending-breach lookup failed: ${error instanceof Error ? error.message : String(error)}`)
+        }
+        const dispatch = mergeUnique(breached, pending)
+        if (dispatch.length > 0) {
           try {
-            await this.onBreach(breached)
+            await this.onBreach(dispatch)
           } catch (error) {
             this.logger.warn(`SLA onBreach hook failed: ${error instanceof Error ? error.message : String(error)}`)
           }
@@ -246,6 +255,21 @@ export class ApprovalSlaScheduler {
     }
     if (this.started) this.startAcquisitionRetryLoop()
   }
+}
+
+function mergeUnique(...lists: string[][]): string[] {
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const list of lists) {
+    if (!Array.isArray(list)) continue
+    for (const id of list) {
+      if (typeof id !== 'string' || id.length === 0) continue
+      if (seen.has(id)) continue
+      seen.add(id)
+      out.push(id)
+    }
+  }
+  return out
 }
 
 let sharedScheduler: ApprovalSlaScheduler | null = null

--- a/packages/core-backend/tests/helpers/approval-schema-bootstrap.ts
+++ b/packages/core-backend/tests/helpers/approval-schema-bootstrap.ts
@@ -1,7 +1,7 @@
 import { poolManager } from '../../src/integration/db/connection-pool'
 
 const APPROVAL_SCHEMA_BOOTSTRAP_KEY = 'approval-schema-bootstrap'
-const APPROVAL_SCHEMA_BOOTSTRAP_VERSION = '20260425-wp5-sla'
+const APPROVAL_SCHEMA_BOOTSTRAP_VERSION = '20260426-wp5-breach-notified-at'
 
 /**
  * Ensures the approval schema (tables, constraints, indexes, sequences) is
@@ -338,6 +338,7 @@ export async function ensureApprovalSchemaReady(): Promise<void> {
         sla_hours INTEGER,
         sla_breached BOOLEAN NOT NULL DEFAULT FALSE,
         sla_breached_at TIMESTAMPTZ,
+        breach_notified_at TIMESTAMPTZ,
         node_breakdown JSONB NOT NULL DEFAULT '[]'::jsonb,
         created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
         updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
@@ -356,6 +357,8 @@ export async function ensureApprovalSchemaReady(): Promise<void> {
     await client.query(`CREATE INDEX IF NOT EXISTS idx_approval_metrics_template ON approval_metrics(template_id) WHERE template_id IS NOT NULL`)
     await client.query(`CREATE INDEX IF NOT EXISTS idx_approval_metrics_sla_breached_active ON approval_metrics(tenant_id, sla_breached) WHERE sla_breached = TRUE`)
     await client.query(`CREATE INDEX IF NOT EXISTS idx_approval_metrics_sla_scan ON approval_metrics(started_at) WHERE terminal_at IS NULL AND sla_hours IS NOT NULL AND sla_breached = FALSE`)
+    await client.query(`ALTER TABLE approval_metrics ADD COLUMN IF NOT EXISTS breach_notified_at TIMESTAMPTZ`)
+    await client.query(`CREATE INDEX IF NOT EXISTS approval_metrics_breach_pending_idx ON approval_metrics (sla_breached_at NULLS FIRST, started_at) WHERE sla_breached = TRUE AND breach_notified_at IS NULL`)
     await client.query(`
       CREATE OR REPLACE FUNCTION approval_metrics_set_updated_at()
       RETURNS TRIGGER AS $$

--- a/packages/core-backend/tests/unit/approval-breach-notifier.test.ts
+++ b/packages/core-backend/tests/unit/approval-breach-notifier.test.ts
@@ -19,9 +19,11 @@ function ctx(id: string, overrides: Partial<ApprovalBreachContext> = {}): Approv
 
 function makeMetrics(contexts: ApprovalBreachContext[] = []) {
   const listBreachContextByIds = vi.fn().mockResolvedValue(contexts)
+  const markBreachNotified = vi.fn().mockResolvedValue(undefined)
   return {
-    metrics: { listBreachContextByIds } as any,
+    metrics: { listBreachContextByIds, markBreachNotified } as any,
     listBreachContextByIds,
+    markBreachNotified,
   }
 }
 
@@ -113,44 +115,109 @@ describe('ApprovalBreachNotifier', () => {
     expect(result.perChannel[0].errors).toEqual(['webhook not configured'])
   })
 
-  it('never notifies the same instance twice (in-memory dedupe)', async () => {
+  it('persists dedupe via markBreachNotified after at-least-one-channel success', async () => {
     const channel: BreachNotificationChannel = {
       name: 'dingtalk',
       send: vi.fn().mockResolvedValue({ ok: true }),
     }
-    const { metrics, listBreachContextByIds } = makeMetrics([ctx('inst-1'), ctx('inst-2')])
-    const notifier = new ApprovalBreachNotifier({ channels: [channel], metrics })
+    const { metrics, markBreachNotified } = makeMetrics([ctx('inst-1'), ctx('inst-2')])
+    const notifier = new ApprovalBreachNotifier({
+      channels: [channel],
+      metrics,
+      now: () => new Date('2026-04-26T10:00:00Z'),
+    })
 
-    const first = await notifier.notifyBreaches(['inst-1', 'inst-2'])
-    expect(first.notified).toBe(2)
+    const result = await notifier.notifyBreaches(['inst-1', 'inst-2'])
+    expect(result.notified).toBe(2)
     expect(channel.send).toHaveBeenCalledTimes(2)
-
-    listBreachContextByIds.mockResolvedValueOnce([ctx('inst-3')])
-    const second = await notifier.notifyBreaches(['inst-1', 'inst-2', 'inst-3'])
-    expect(second.requested).toBe(3)
-    expect(second.skipped).toBe(2)
-    expect(second.notified).toBe(1)
-    expect(channel.send).toHaveBeenCalledTimes(3)
+    expect(markBreachNotified).toHaveBeenCalledTimes(1)
+    const [ids, when] = markBreachNotified.mock.calls[0]
+    expect(ids).toEqual(['inst-1', 'inst-2'])
+    expect(when.toISOString()).toBe('2026-04-26T10:00:00.000Z')
   })
 
-  it('does not record an instance as notified if every channel fails', async () => {
+  it('does not call markBreachNotified when every channel fails for an instance', async () => {
+    const channel: BreachNotificationChannel = {
+      name: 'dingtalk',
+      send: vi.fn().mockResolvedValue({ ok: false, error: 'webhook 5xx' }),
+    }
+    const { metrics, markBreachNotified } = makeMetrics([ctx('inst-1')])
+    const notifier = new ApprovalBreachNotifier({ channels: [channel], metrics })
+
+    const result = await notifier.notifyBreaches(['inst-1'])
+    expect(result.notified).toBe(0)
+    expect(result.failed).toBe(1)
+    expect(markBreachNotified).not.toHaveBeenCalled()
+  })
+
+  it('marks only the instances whose channels reported at least one success', async () => {
     const channel: BreachNotificationChannel = {
       name: 'dingtalk',
       send: vi.fn()
         .mockResolvedValueOnce({ ok: false, error: 'fail-once' })
         .mockResolvedValueOnce({ ok: true }),
     }
-    const { metrics, listBreachContextByIds } = makeMetrics([ctx('inst-1')])
+    const { metrics, markBreachNotified } = makeMetrics([ctx('inst-1'), ctx('inst-2')])
     const notifier = new ApprovalBreachNotifier({ channels: [channel], metrics })
 
-    const first = await notifier.notifyBreaches(['inst-1'])
-    expect(first.notified).toBe(0)
-    expect(first.failed).toBe(1)
+    const result = await notifier.notifyBreaches(['inst-1', 'inst-2'])
+    expect(result.notified).toBe(1)
+    expect(result.sent).toBe(1)
+    expect(result.failed).toBe(1)
+    expect(markBreachNotified).toHaveBeenCalledTimes(1)
+    expect(markBreachNotified.mock.calls[0][0]).toEqual(['inst-2'])
+  })
 
-    listBreachContextByIds.mockResolvedValueOnce([ctx('inst-1')])
-    const second = await notifier.notifyBreaches(['inst-1'])
-    expect(second.notified).toBe(1)
-    expect(second.sent).toBe(1)
+  it('mixed-channel partial success still marks the instance as notified', async () => {
+    const goodSend = vi.fn().mockResolvedValue({ ok: true })
+    const badSend = vi.fn().mockResolvedValue({ ok: false, error: 'down' })
+    const { metrics, markBreachNotified } = makeMetrics([ctx('inst-1')])
+    const notifier = new ApprovalBreachNotifier({
+      channels: [
+        { name: 'dingtalk', send: badSend },
+        { name: 'email', send: goodSend },
+      ],
+      metrics,
+    })
+
+    const result = await notifier.notifyBreaches(['inst-1'])
+    expect(result.notified).toBe(1)
+    expect(result.sent).toBe(1)
+    expect(result.failed).toBe(1)
+    expect(markBreachNotified).toHaveBeenCalledTimes(1)
+    expect(markBreachNotified.mock.calls[0][0]).toEqual(['inst-1'])
+  })
+
+  it('does not throw when listBreachContextByIds rejects, and skips marking', async () => {
+    const channel: BreachNotificationChannel = {
+      name: 'dingtalk',
+      send: vi.fn().mockResolvedValue({ ok: true }),
+    }
+    const { metrics, markBreachNotified } = makeMetrics()
+    metrics.listBreachContextByIds = vi.fn().mockRejectedValue(new Error('db down'))
+    const notifier = new ApprovalBreachNotifier({ channels: [channel], metrics })
+
+    const result = await notifier.notifyBreaches(['inst-1', 'inst-2'])
+    expect(result.requested).toBe(2)
+    expect(result.skipped).toBe(2)
+    expect(result.notified).toBe(0)
+    expect(channel.send).not.toHaveBeenCalled()
+    expect(markBreachNotified).not.toHaveBeenCalled()
+  })
+
+  it('swallows markBreachNotified failures so the notifier still resolves cleanly', async () => {
+    const channel: BreachNotificationChannel = {
+      name: 'dingtalk',
+      send: vi.fn().mockResolvedValue({ ok: true }),
+    }
+    const { metrics, markBreachNotified } = makeMetrics([ctx('inst-1')])
+    markBreachNotified.mockRejectedValueOnce(new Error('db blip'))
+    const notifier = new ApprovalBreachNotifier({ channels: [channel], metrics })
+
+    const result = await notifier.notifyBreaches(['inst-1'])
+    expect(result.notified).toBe(1)
+    expect(result.sent).toBe(1)
+    expect(markBreachNotified).toHaveBeenCalledTimes(1)
   })
 
   it('returns a graceful empty result when no channels are configured', async () => {

--- a/packages/core-backend/tests/unit/approval-metrics-breach-notified-at.test.ts
+++ b/packages/core-backend/tests/unit/approval-metrics-breach-notified-at.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ApprovalMetricsService, type Query } from '../../src/services/ApprovalMetricsService'
+
+/**
+ * Wave 2 WP5 follow-up — unit coverage for the persistent breach-notify
+ * dedupe primitives `listBreachesPendingNotification` and
+ * `markBreachNotified`. SQL is asserted via shape so the partial-index
+ * predicate stays honoured if anyone refactors the WHERE clause.
+ */
+
+function normalize(sql: string): string {
+  return sql.replace(/\s+/g, ' ').trim()
+}
+
+describe('ApprovalMetricsService persistent breach dedupe', () => {
+  let queryMock: ReturnType<typeof vi.fn>
+  let service: ApprovalMetricsService
+
+  beforeEach(() => {
+    queryMock = vi.fn()
+    service = new ApprovalMetricsService(queryMock as unknown as Query)
+  })
+
+  describe('listBreachesPendingNotification', () => {
+    it('selects unnotified breached rows ordered by oldest sla_breached_at', async () => {
+      queryMock.mockResolvedValueOnce({
+        rows: [{ instance_id: 'apr-1' }, { instance_id: 'apr-2' }],
+      })
+
+      const ids = await service.listBreachesPendingNotification(50)
+
+      expect(ids).toEqual(['apr-1', 'apr-2'])
+      expect(queryMock).toHaveBeenCalledTimes(1)
+      const [sql, params] = queryMock.mock.calls[0]
+      const flat = normalize(sql)
+      expect(flat).toContain('FROM approval_metrics')
+      expect(flat).toContain('sla_breached = TRUE')
+      expect(flat).toContain('breach_notified_at IS NULL')
+      expect(flat).toContain('ORDER BY sla_breached_at NULLS FIRST, started_at ASC')
+      expect(flat).toContain('LIMIT $1')
+      expect(params).toEqual([50])
+    })
+
+    it('clamps the limit into the safe [1, 1000] window', async () => {
+      queryMock.mockResolvedValue({ rows: [] })
+      await service.listBreachesPendingNotification(0)
+      expect(queryMock.mock.calls[0][1]).toEqual([1])
+      queryMock.mockClear()
+
+      await service.listBreachesPendingNotification(5_000)
+      expect(queryMock.mock.calls[0][1]).toEqual([1000])
+      queryMock.mockClear()
+
+      await service.listBreachesPendingNotification(undefined as unknown as number)
+      expect(queryMock.mock.calls[0][1]).toEqual([200])
+    })
+
+    it('returns an empty list when the query returns no rows', async () => {
+      queryMock.mockResolvedValueOnce({ rows: [] })
+      const ids = await service.listBreachesPendingNotification()
+      expect(ids).toEqual([])
+    })
+  })
+
+  describe('markBreachNotified', () => {
+    it('updates only rows whose breach_notified_at is currently NULL', async () => {
+      queryMock.mockResolvedValueOnce({ rows: [], rowCount: 2 })
+      const stamp = new Date('2026-04-26T12:34:56Z')
+
+      await service.markBreachNotified(['apr-1', 'apr-2'], stamp)
+
+      expect(queryMock).toHaveBeenCalledTimes(1)
+      const [sql, params] = queryMock.mock.calls[0]
+      const flat = normalize(sql)
+      expect(flat).toContain('UPDATE approval_metrics')
+      expect(flat).toContain('SET breach_notified_at = $2')
+      expect(flat).toContain('WHERE instance_id = ANY($1::text[])')
+      expect(flat).toContain('AND breach_notified_at IS NULL')
+      expect(params[0]).toEqual(['apr-1', 'apr-2'])
+      expect(params[1]).toBe('2026-04-26T12:34:56.000Z')
+    })
+
+    it('is a no-op when given an empty id list', async () => {
+      await service.markBreachNotified([])
+      expect(queryMock).not.toHaveBeenCalled()
+    })
+
+    it('is a no-op when given a non-array', async () => {
+      await service.markBreachNotified(undefined as unknown as string[])
+      expect(queryMock).not.toHaveBeenCalled()
+    })
+
+    it('uses the current time when no notifiedAt is supplied', async () => {
+      queryMock.mockResolvedValueOnce({ rows: [], rowCount: 1 })
+      const before = Date.now()
+      await service.markBreachNotified(['apr-1'])
+      const after = Date.now()
+
+      const stampMs = Date.parse(queryMock.mock.calls[0][1][1])
+      expect(stampMs).toBeGreaterThanOrEqual(before)
+      expect(stampMs).toBeLessThanOrEqual(after)
+    })
+  })
+})

--- a/packages/core-backend/tests/unit/approval-sla-scheduler.test.ts
+++ b/packages/core-backend/tests/unit/approval-sla-scheduler.test.ts
@@ -12,11 +12,12 @@ describe('ApprovalSlaScheduler', () => {
 
   it('invokes checkSlaBreaches and the onBreach hook with breached ids', async () => {
     const checkSlaBreaches = vi.fn<(now: Date) => Promise<string[]>>().mockResolvedValue(['apr-1', 'apr-2'])
+    const listBreachesPendingNotification = vi.fn<() => Promise<string[]>>().mockResolvedValue([])
     const onBreach = vi.fn().mockResolvedValue(undefined)
 
     const scheduler = new ApprovalSlaScheduler({
       // biome-ignore lint/suspicious/noExplicitAny: test double
-      metrics: { checkSlaBreaches } as any,
+      metrics: { checkSlaBreaches, listBreachesPendingNotification } as any,
       intervalMs: 60_000,
       onBreach,
     })
@@ -25,7 +26,72 @@ describe('ApprovalSlaScheduler', () => {
 
     expect(breached).toEqual(['apr-1', 'apr-2'])
     expect(checkSlaBreaches).toHaveBeenCalledTimes(1)
+    expect(listBreachesPendingNotification).toHaveBeenCalledTimes(1)
     expect(onBreach).toHaveBeenCalledWith(['apr-1', 'apr-2'])
+  })
+
+  it('dispatches the union of newly-breached ids and retry-pending ids', async () => {
+    const checkSlaBreaches = vi.fn().mockResolvedValue(['new-1', 'shared'])
+    const listBreachesPendingNotification = vi.fn().mockResolvedValue(['retry-1', 'shared'])
+    const onBreach = vi.fn().mockResolvedValue(undefined)
+
+    const scheduler = new ApprovalSlaScheduler({
+      // biome-ignore lint/suspicious/noExplicitAny: test double
+      metrics: { checkSlaBreaches, listBreachesPendingNotification } as any,
+      onBreach,
+    })
+
+    const breached = await scheduler.tick(new Date('2026-04-25T10:00:00Z'))
+
+    expect(breached).toEqual(['new-1', 'shared'])
+    expect(onBreach).toHaveBeenCalledTimes(1)
+    expect(onBreach.mock.calls[0][0]).toEqual(['new-1', 'shared', 'retry-1'])
+  })
+
+  it('dispatches retry-pending ids even when no new breaches were flagged this tick', async () => {
+    const checkSlaBreaches = vi.fn().mockResolvedValue([])
+    const listBreachesPendingNotification = vi.fn().mockResolvedValue(['retry-1'])
+    const onBreach = vi.fn().mockResolvedValue(undefined)
+
+    const scheduler = new ApprovalSlaScheduler({
+      // biome-ignore lint/suspicious/noExplicitAny: test double
+      metrics: { checkSlaBreaches, listBreachesPendingNotification } as any,
+      onBreach,
+    })
+
+    await scheduler.tick(new Date('2026-04-25T10:00:00Z'))
+
+    expect(onBreach).toHaveBeenCalledWith(['retry-1'])
+  })
+
+  it('skips the pending lookup entirely when no onBreach is configured', async () => {
+    const checkSlaBreaches = vi.fn().mockResolvedValue(['apr-1'])
+    const listBreachesPendingNotification = vi.fn().mockResolvedValue([])
+
+    const scheduler = new ApprovalSlaScheduler({
+      // biome-ignore lint/suspicious/noExplicitAny: test double
+      metrics: { checkSlaBreaches, listBreachesPendingNotification } as any,
+    })
+
+    const breached = await scheduler.tick(new Date('2026-04-25T10:00:00Z'))
+
+    expect(breached).toEqual(['apr-1'])
+    expect(listBreachesPendingNotification).not.toHaveBeenCalled()
+  })
+
+  it('dispatches the new breaches even when listBreachesPendingNotification rejects', async () => {
+    const checkSlaBreaches = vi.fn().mockResolvedValue(['new-1'])
+    const listBreachesPendingNotification = vi.fn().mockRejectedValue(new Error('db blip'))
+    const onBreach = vi.fn().mockResolvedValue(undefined)
+
+    const scheduler = new ApprovalSlaScheduler({
+      // biome-ignore lint/suspicious/noExplicitAny: test double
+      metrics: { checkSlaBreaches, listBreachesPendingNotification } as any,
+      onBreach,
+    })
+
+    await scheduler.tick(new Date('2026-04-25T10:00:00Z'))
+    expect(onBreach).toHaveBeenCalledWith(['new-1'])
   })
 
   it('swallows checkSlaBreaches errors and returns an empty list', async () => {


### PR DESCRIPTION
## Summary

- Closes the WP5 SLA observability follow-up listed in PR #1171 — adds persistent `breach_notified_at` column on `approval_metrics` so failed-channel breaches retry on the next scheduler tick instead of being silently dropped.
- Decouples "marked as breached" from "successfully notified": `ApprovalSlaScheduler.tick` dispatches the union of newly-detected breaches and retry-pending breaches; `ApprovalBreachNotifier` calls `markBreachNotified(successfulInstanceIds)` after each per-instance fan-out.
- Drops the in-memory `Set<instanceId>` FIFO (now redundant) — persistent dedupe survives restart and leader takeover.
- Semantic upgrade: **best-effort once → at-least-once with persistent retry**.

## Verification

- `npx tsc --noEmit` → exit 0
- `pnpm -F @metasheet/core-backend test -- approval-metrics-breach-notified-at` → 7/7 ✓
- `pnpm -F @metasheet/core-backend test -- approval-breach-notifier` → 12/12 ✓
- `pnpm -F @metasheet/core-backend test -- approval-sla-scheduler` → 11/11 ✓
- Regression: `pnpm -F @metasheet/core-backend test -- approval-metrics-service` → 15/15 ✓
- Aggregate: 30/30 focused + 15/15 regression — all green.

## Risk / Rollback

- Risk: introduces **operational warn noise** when no channel is configured (or all configured channels fail consistently). Documented in dev MD with three deployment options (configure DingTalk env / register no-op stub / leave `onBreach` unwired). The "leave unwired" path explicitly skips the retry lookup so backlog accumulates with `breach_notified_at IS NULL` until a future notifier rollout.
- Risk: extra `SELECT … LIMIT 200` per scheduler tick when `onBreach` is configured — partial index `(sla_breached_at NULLS FIRST, started_at) WHERE sla_breached = TRUE AND breach_notified_at IS NULL` keeps it O(log N).
- Rollback: revert this PR. Migration `down()` drops the index + column cleanly; existing `sla_breached` / `sla_breached_at` state is unaffected — only the notify history is lost. The previous in-memory FIFO returns; persistent dedupe is gone.

## Follow-up

- Email channel real transport (today: logging stub) — pending dep policy decision on `nodemailer` / managed sender. Tracked from PR #1171.
- Optional: per-channel exponential backoff inside the channel itself, layered on top of the new tick-level retry.
- Optional: `breach_notified_at` could feed a "notification health" dashboard surfacing rows where breach age − notify lag exceeds a threshold.

See `docs/development/approval-sla-breach-notified-at-development-20260426.md` and `*-verification-20260426.md` (on this branch) plus `docs/development/pr-queue-and-breach-notified-at-20260426.md` for full design + verification.
