### PR TITLE
feat(approval): persist breach_notified_at + restart-resilient retry

### DIFF
--- a/docs/development/approval-breach-notified-persistence-design-20260426.md
+++ b/docs/development/approval-breach-notified-persistence-design-20260426.md
@@ -1,0 +1,71 @@
+# Approval Breach Notification Persistence · Design
+
+> Date: 2026-04-26
+> Follow-up to: PR #1171 (`feat(approval): add SLA breach notification channels`)
+> Closes: the "persistent breach_notified_at column" follow-up acknowledged in PR #1171's commit message and code comment.
+
+## Problem
+
+PR #1171 ships `ApprovalBreachNotifier` with **in-memory only** dedupe — a `Set<instanceId>` of already-notified rows on the leader process. The commit message and class doc-comment both flag this as a known limitation:
+
+> `A persistent breach_notified_at column is tracked as a follow-up.`
+
+The concrete failure mode this gap leaves open:
+
+1. SLA scheduler atomic flip (`UPDATE approval_metrics SET sla_breached = TRUE WHERE sla_breached = FALSE RETURNING instance_id`) returns row X.
+2. Notifier dispatches X via channel.send (succeeds at the wire).
+3. Leader process crashes **before** `markNotified(X)` runs.
+4. Restart: in-memory `notifiedIds` is empty.
+5. `checkSlaBreaches` will never return X again (its WHERE filters `sla_breached = FALSE` and X is already TRUE).
+6. **X is now permanently un-notified-in-the-record but actually was notified**, producing an inconsistency — operations cannot answer "did we send for X?" without log archaeology.
+
+A more concerning variant: dispatch failed, leader crashed before retry, X never gets retried — the notifier had no concept of "missed breach to retry" because the in-memory mark was the only state.
+
+PR #1171's commit message correctly noted that this **does not produce duplicate notifications** (the `sla_breached = FALSE` WHERE atomically excludes already-flagged rows from re-entering the pipeline). The cost is **missed dispatches stay missed**, not duplicates — but for an SLA system, missed escalations are a real customer-impact issue.
+
+## Solution
+
+Add the persistent column the previous PR's comment promised, plus the matching machinery to use it:
+
+1. **Migration `058_add_approval_breach_notified_at.sql`** — adds `breach_notified_at TIMESTAMPTZ NULL` to `approval_metrics`, plus a partial index `WHERE sla_breached = TRUE AND breach_notified_at IS NULL` to keep the recovery query cheap.
+2. **`ApprovalMetricsService.markBreachNotified(id, now)`** — guarded UPDATE that writes the timestamp only if it was previously NULL (so a redundant retry call is a safe no-op).
+3. **`ApprovalMetricsService.findUnnotifiedBreaches(limit = 500)`** — the recovery query, returning `sla_breached = TRUE AND breach_notified_at IS NULL` ordered by `sla_breached_at ASC` (oldest first), capped at 5000.
+4. **`ApprovalBreachNotifier.markNotified` becomes async** — keeps the in-memory dedupe (cheap, intra-process) but ALSO calls `metrics.markBreachNotified` so the dispatch survives restart. DB failure is logged and treated as non-fatal — in-memory dedupe still prevents same-process re-send, and the next leader will pick up via the recovery path.
+5. **`ApprovalBreachNotifier.notifyMissedBreaches()`** — new method that calls `metrics.findUnnotifiedBreaches()` then routes the result through the existing `notifyBreaches()` pipeline. Idempotent because `notifyBreaches` already deduplicates and `markBreachNotified` is a guarded UPDATE.
+6. **`packages/core-backend/src/index.ts` startup wiring** — fires `breachNotifier.notifyMissedBreaches()` once when the SLA scheduler starts, in fire-and-forget mode (best-effort recovery; failure must not block scheduler initialization).
+
+## Why this is the minimal viable fix
+
+Per the original task spec ("~60 line patch — migration + notifier one line + scheduler WHERE one line + unit test"), the implementation is intentionally compact. The major design decisions:
+
+- **No new database table.** A column on the existing `approval_metrics` row, plus one partial index. Zero new tables, zero new joins, zero new schema bootstrap version concerns.
+- **Async markNotified does NOT change the public `notifyBreaches` contract.** It already returned `Promise<NotifyResult>`; the inner await is invisible to callers.
+- **Persistent failure is not fatal.** If the DB UPDATE for `breach_notified_at` fails, we log and continue — the in-memory dedupe still prevents same-process re-send, and the next process will reconcile via `notifyMissedBreaches()`.
+- **Startup retry is fire-and-forget.** A best-effort recovery cannot block scheduler init; if `findUnnotifiedBreaches` fails on startup, the system is no worse than before this PR (still has working onBreach hook for new breaches).
+- **Cap on `findUnnotifiedBreaches(limit)`.** Hard upper bound of 5000 prevents a long-paused leader from triggering an unbounded query on restart. Future tooling can paginate if more is needed.
+
+## Out of scope
+
+- **Per-channel persistence** — we persist "at least one channel succeeded" (`anySent`). Per-channel ack would require a join table and is overkill for the current escalation use case.
+- **Re-notification on update** — if the requester / template metadata changes after notification, we do not re-dispatch. Out of scope for the original SLA breach feature.
+- **Multi-leader coordination** — assumes the leader-lock mechanism from PR #1160 still gates dispatch to a single process. The new column does not change that contract.
+- **Schema migration runtime auto-apply** — this PR only ships the SQL file; it relies on the existing migration runner to apply 058 next time `pnpm migrate` runs. Operations note: should be applied during the same maintenance window as future `feat(integration): scaffold integration core plugin (#1140)` style upgrades.
+
+## Files changed
+
+- `packages/core-backend/migrations/058_add_approval_breach_notified_at.sql` — new (12 lines)
+- `packages/core-backend/src/services/ApprovalMetricsService.ts` — `markBreachNotified` + `findUnnotifiedBreaches` (~40 lines added)
+- `packages/core-backend/src/services/ApprovalBreachNotifier.ts` — `markNotified` made async + persistence call + `notifyMissedBreaches` method (~40 lines added)
+- `packages/core-backend/src/index.ts` — startup retry wiring (~20 lines added)
+- `packages/core-backend/tests/unit/approval-breach-notifier.test.ts` — 6 new tests (markNotified persistence, partial-failure non-fatal, missed-breach replay happy / empty / DB-failure paths)
+- `packages/core-backend/tests/unit/approval-metrics-service.test.ts` — 6 new tests (markBreachNotified guards, findUnnotifiedBreaches ordering / cap / fallback)
+- this design doc + matching verification doc
+
+## Risks acknowledged
+
+| Risk | Mitigation |
+|---|---|
+| Migration 058 collides with another in-flight branch | Latest origin/main migration is 057; this PR claims 058 cleanly. Future migrations need to use 059+. |
+| Notifier persistence DB failure during high load | Logged and treated as non-fatal; in-memory dedupe still applies; next restart's `notifyMissedBreaches` reconciles. |
+| Startup `notifyMissedBreaches` discovers a large backlog (e.g. weeks of unnotified rows after a long DB outage) | Capped at 5000 per call; operator can run additional manual flush via `notifyMissedBreaches()` in REPL if needed. Considered acceptable because long-paused systems already need manual triage. |
+| `breach_notified_at` column appears as NULL on rows breached BEFORE this migration | Backfill is intentionally not done. Pre-existing breached rows will appear in `findUnnotifiedBreaches()` and trigger replay on next leader startup. Operations should expect a one-time replay burst on first deploy after this PR — bounded at 5000 per cycle. |

--- a/docs/development/approval-breach-notified-persistence-verification-20260426.md
+++ b/docs/development/approval-breach-notified-persistence-verification-20260426.md
@@ -1,0 +1,90 @@
+# Approval Breach Notification Persistence · Verification
+
+> Pairs with `approval-breach-notified-persistence-design-20260426.md`.
+
+## Commands run
+
+```bash
+cd packages/core-backend
+
+# Run both touched test files
+pnpm vitest run \
+  tests/unit/approval-metrics-service.test.ts \
+  tests/unit/approval-breach-notifier.test.ts \
+  --reporter=dot
+
+# Type check
+pnpm exec tsc --noEmit
+
+# Whitespace
+git diff --check
+```
+
+## Results
+
+```
+✔ approval-metrics-service.test.ts  21 tests pass (was 15; +6 new)
+✔ approval-breach-notifier.test.ts  14 tests pass (was 8; +6 new)
+✔ tsc --noEmit                      no errors
+✔ git diff --check                  clean
+```
+
+Total: **35/35** unit tests pass across the two touched test files. **+12 new tests, 0 regressions.**
+
+## New test coverage breakdown
+
+### `tests/unit/approval-metrics-service.test.ts` (+6)
+
+`describe('markBreachNotified', ...)`:
+
+1. **issues a guarded UPDATE that no-ops when breach_notified_at is already set** — verifies the SQL contains `SET breach_notified_at = $1`, `WHERE instance_id = $2`, `AND breach_notified_at IS NULL`, and the params list is `[ISO timestamp, id]`.
+2. **skips silently when given an empty or whitespace instance id (defensive)** — empty string and whitespace-only id should not issue a query at all.
+3. **defaults `now` to current time when omitted** — calling without explicit `now` uses `new Date()`.
+
+`describe('findUnnotifiedBreaches', ...)`:
+
+4. **returns instance ids ordered by sla_breached_at, capped at default 500** — verifies the WHERE clause filters `sla_breached = TRUE AND breach_notified_at IS NULL`, ORDER BY oldest-first, default LIMIT 500.
+5. **clamps the limit to a sane upper bound (5000)** — passing `99_999` produces `LIMIT 5000`.
+6. **falls back to default when limit is non-positive or non-finite** — passing `-1` produces `LIMIT 500`.
+
+### `tests/unit/approval-breach-notifier.test.ts` (+6)
+
+`// migration 058 / persistent breach_notified_at`:
+
+1. **persists breach_notified_at via metrics.markBreachNotified after a successful dispatch** — for two instance ids, both result in `markBreachNotified(id, now)` being invoked with the injected fixed `now` Date.
+2. **does not persist breach_notified_at when every channel fails** — failing channel returns `{ ok: false }`, `notified` stays 0, `markBreachNotified` is never called.
+3. **treats markBreachNotified failures as non-fatal (in-memory dedupe still applies)** — DB UPDATE rejects once, dispatch is still reported `notified: 1`; second call within the same process is correctly skipped via the in-memory Set.
+
+`// notifyMissedBreaches (startup retry path)`:
+
+4. **notifyMissedBreaches replays unnotified breaches from the previous epoch** — `findUnnotifiedBreaches` returns 2 ids, channel.send is invoked twice, `markBreachNotified` is invoked twice.
+5. **notifyMissedBreaches is a no-op when no unnotified breaches exist** — `findUnnotifiedBreaches` returns empty, channel.send is never called.
+6. **notifyMissedBreaches survives a findUnnotifiedBreaches DB failure** — DB query rejects, method returns an empty result, channel.send is never called, no exception bubbles.
+
+## Existing test regression check
+
+All 8 existing `approval-breach-notifier.test.ts` tests + all 15 existing `approval-metrics-service.test.ts` tests still pass without modification (the only test-file change in service is the addition of `markBreachNotified` and `findUnnotifiedBreaches` mocks to `makeMetrics()`, with the existing tests still receiving an undefined `unnotified` option that defaults to `[]`).
+
+## Manual code review checklist
+
+- [x] Migration 058 uses the next safe number after main's tip 057 (no collision)
+- [x] Migration uses `IF NOT EXISTS` for both column add and partial index — safe to re-run
+- [x] `markBreachNotified` UPDATE is guarded with `AND breach_notified_at IS NULL` — duplicate calls are no-ops, not timestamp overwrites
+- [x] `findUnnotifiedBreaches` LIMIT is clamped (`Math.min(Math.floor(...), 5000)`) — cannot be coerced into an unbounded scan
+- [x] `notifier.markNotified` made async; the only call site `await this.markNotified(id)` was updated; no other callers existed in the repo
+- [x] `notifier.notifyMissedBreaches` does NOT throw on DB failure — wrapped in try/catch with logging and empty-result return
+- [x] `index.ts` startup retry uses `void breachNotifier.notifyMissedBreaches().then(...).catch(...)` — fire-and-forget pattern, scheduler init never awaits it
+- [x] No changes to public types or method signatures other than the additions; `notifyBreaches`, `dispatch`, `composeMessage`, `buildLink` all unchanged
+- [x] No changes to `breach-channels/*.ts` (channel implementations unaffected)
+
+## Outstanding (not in this PR)
+
+- **Per-channel persistence** — currently we record "at least one channel succeeded" via the boolean `anySent`. If operations needs per-channel ack tracking (e.g. DingTalk delivered but email failed), that requires a separate join table and is out of scope.
+- **Re-notification on context update** — if requester / template metadata changes after notification, we don't re-dispatch. Out of scope for the original SLA breach feature.
+- **Backfill of pre-existing breached rows** — intentionally not done. First post-deploy leader startup will trigger a one-time replay burst capped at 5000; expected and documented.
+- **Pagination beyond 5000** — caller can re-invoke `notifyMissedBreaches()` in a loop if the backlog exceeds the cap. Not exposed via REST today.
+
+## Cross-references
+
+- PR #1171 (the predecessor): merged 2026-04-25 as commit `58862b394`. Code comment at `ApprovalBreachNotifier.ts` lines 17-24 explicitly named this follow-up.
+- Migration sequence: most recent on `origin/main` was `057_create_integration_core_tables.sql` (#1140); this PR claims `058_*`.

--- a/packages/core-backend/migrations/058_add_approval_breach_notified_at.sql
+++ b/packages/core-backend/migrations/058_add_approval_breach_notified_at.sql
@@ -1,0 +1,26 @@
+-- 058_add_approval_breach_notified_at.sql
+-- Persist breach-notification dispatch so the SLA notifier survives restarts.
+--
+-- Background: ApprovalBreachNotifier maintains an in-memory Set<instanceId>
+-- to dedupe within a single leader process. On restart, that set is lost,
+-- and any row whose dispatch was attempted but not yet acknowledged becomes
+-- permanently un-notified (the row's sla_breached flag is already TRUE so
+-- checkSlaBreaches's WHERE clause excludes it from future cycles).
+--
+-- This migration adds a persistent breach_notified_at column so:
+--   1. Successful dispatches survive restarts.
+--   2. A separate "find unnotified breaches" query can retry rows that were
+--      flagged but never dispatched.
+--   3. Operations / observability can answer "did we notify for instance X?"
+--      directly from the DB, without log-grepping.
+--
+-- The column is nullable (existing rows are backfilled to NULL implicitly)
+-- and a partial index optimises the common retry-query
+-- (sla_breached = TRUE AND breach_notified_at IS NULL).
+
+ALTER TABLE approval_metrics
+  ADD COLUMN IF NOT EXISTS breach_notified_at TIMESTAMPTZ NULL;
+
+CREATE INDEX IF NOT EXISTS idx_approval_metrics_unnotified_breach
+  ON approval_metrics(instance_id)
+  WHERE sla_breached = TRUE AND breach_notified_at IS NULL;

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -1911,6 +1911,26 @@ export class MetaSheetServer {
       const breachNotifier = new ApprovalBreachNotifier({
         channels: createApprovalBreachChannelsFromEnv(),
       })
+
+      // Retry breaches that were flagged in a prior epoch but never had
+      // breach_notified_at persisted (e.g. previous leader crashed between
+      // channel.send and the notifier's persistence call). Best-effort —
+      // failure here must not block scheduler startup.
+      void breachNotifier
+        .notifyMissedBreaches()
+        .then((result) => {
+          if (result.requested > 0) {
+            this.logger.info(
+              `Approval breach replay on startup: requested=${result.requested} notified=${result.notified} skipped=${result.skipped} sent=${result.sent} failed=${result.failed}`,
+            )
+          }
+        })
+        .catch((err) => {
+          this.logger.warn(
+            `Approval breach replay on startup failed: ${err instanceof Error ? err.message : String(err)}`,
+          )
+        })
+
       startApprovalSlaScheduler({
         leaderOptions,
         runtime: { leaderStateGauge: promMetrics.approvalSlaSchedulerLeaderGauge },

--- a/packages/core-backend/src/services/ApprovalBreachNotifier.ts
+++ b/packages/core-backend/src/services/ApprovalBreachNotifier.ts
@@ -157,7 +157,7 @@ export class ApprovalBreachNotifier {
         }
       }
       if (anySent) {
-        this.markNotified(id)
+        await this.markNotified(id)
         notified += 1
       }
     }
@@ -170,6 +170,47 @@ export class ApprovalBreachNotifier {
       failed: totalFailed,
       perChannel: this.channels.map((channel) => perChannel[channel.name]),
     }
+  }
+
+  /**
+   * Replay any breaches that were previously flagged in the DB but never
+   * had `breach_notified_at` persisted. Intended to be called once on
+   * leader startup to recover from a notifier crash that lost the
+   * in-memory dedupe set after channel.send returned but before
+   * markNotified persisted.
+   *
+   * Safe to call repeatedly — `notifyBreaches` deduplicates internally
+   * (in-memory + DB markBreachNotified is no-op when already set), and
+   * `findUnnotifiedBreaches` only returns rows that legitimately need
+   * dispatch.
+   */
+  async notifyMissedBreaches(limit = 500): Promise<NotifyResult> {
+    let ids: string[]
+    try {
+      ids = await this.metrics.findUnnotifiedBreaches(limit)
+    } catch (error) {
+      this.logger.warn(`Missed-breach lookup failed: ${error instanceof Error ? error.message : String(error)}`)
+      return {
+        requested: 0,
+        notified: 0,
+        skipped: 0,
+        sent: 0,
+        failed: 0,
+        perChannel: this.channels.map((channel) => ({ channel: channel.name, sent: 0, failed: 0, errors: [] })),
+      }
+    }
+    if (ids.length === 0) {
+      return {
+        requested: 0,
+        notified: 0,
+        skipped: 0,
+        sent: 0,
+        failed: 0,
+        perChannel: this.channels.map((channel) => ({ channel: channel.name, sent: 0, failed: 0, errors: [] })),
+      }
+    }
+    this.logger.info(`Replaying ${ids.length} missed breach notifications from previous epoch`)
+    return this.notifyBreaches(ids)
   }
 
   private async dispatch(
@@ -215,13 +256,29 @@ export class ApprovalBreachNotifier {
     return `${this.appBaseUrl}/approval/${encodeURIComponent(instanceId)}`
   }
 
-  private markNotified(instanceId: string): void {
-    if (this.notifiedIds.has(instanceId)) return
-    this.notifiedIds.add(instanceId)
-    this.notifiedOrder.push(instanceId)
-    while (this.notifiedOrder.length > this.maxNotifiedIds) {
-      const evicted = this.notifiedOrder.shift()
-      if (evicted) this.notifiedIds.delete(evicted)
+  private async markNotified(instanceId: string): Promise<void> {
+    // In-memory dedupe (cheap, fast, intra-process).
+    const alreadyMarkedInMemory = this.notifiedIds.has(instanceId)
+    if (!alreadyMarkedInMemory) {
+      this.notifiedIds.add(instanceId)
+      this.notifiedOrder.push(instanceId)
+      while (this.notifiedOrder.length > this.maxNotifiedIds) {
+        const evicted = this.notifiedOrder.shift()
+        if (evicted) this.notifiedIds.delete(evicted)
+      }
+    }
+
+    // Persistent dedupe (survives restart). Best-effort: if the UPDATE
+    // throws (DB transient, etc.), we log and continue — the in-memory
+    // mark already prevents same-process re-send. Future restarts may
+    // re-attempt dispatch via notifyMissedBreaches; that path is
+    // designed to be safely re-runnable.
+    try {
+      await this.metrics.markBreachNotified(instanceId, this.now())
+    } catch (error) {
+      this.logger.warn(
+        `Failed to persist breach_notified_at for ${instanceId}: ${error instanceof Error ? error.message : String(error)}`,
+      )
     }
   }
 }

--- a/packages/core-backend/src/services/ApprovalMetricsService.ts
+++ b/packages/core-backend/src/services/ApprovalMetricsService.ts
@@ -305,6 +305,49 @@ export class ApprovalMetricsService {
     return result.rows.map((row) => row.instance_id)
   }
 
+  /**
+   * Persist that the breach notifier successfully dispatched for the given
+   * instance. Sets `breach_notified_at` only if it was previously NULL — so
+   * a redundant call (e.g. retry after restart) is a safe no-op rather than
+   * a duplicate timestamp overwrite.
+   *
+   * Pairs with migration 058 (`breach_notified_at TIMESTAMPTZ NULL`).
+   */
+  async markBreachNotified(instanceId: string, now: Date = new Date()): Promise<void> {
+    if (typeof instanceId !== 'string' || instanceId.trim().length === 0) return
+    await this.query(
+      `UPDATE approval_metrics
+          SET breach_notified_at = $1
+        WHERE instance_id = $2
+          AND breach_notified_at IS NULL`,
+      [now.toISOString(), instanceId.trim()],
+    )
+  }
+
+  /**
+   * Find rows that were flagged as breached but never had a successful
+   * notifier dispatch persisted. Used by the notifier on startup to retry
+   * the dispatches that were lost when the previous leader process died
+   * between `channel.send` and `markNotified` (in-memory dedupe was lost
+   * but the DB flag was already TRUE so checkSlaBreaches would never
+   * return them again).
+   *
+   * Capped to keep the recovery query bounded; the caller is expected to
+   * iterate if more rows exist than the cap.
+   */
+  async findUnnotifiedBreaches(limit = 500): Promise<string[]> {
+    const cap = Number.isFinite(limit) && limit > 0 ? Math.min(Math.floor(limit), 5000) : 500
+    const result = await this.query<{ instance_id: string }>(
+      `SELECT instance_id
+         FROM approval_metrics
+        WHERE sla_breached = TRUE
+          AND breach_notified_at IS NULL
+        ORDER BY sla_breached_at ASC
+        LIMIT ${cap}`,
+    )
+    return result.rows.map((row) => row.instance_id)
+  }
+
   async getMetricsSummary(input: MetricsSummaryQuery = {}): Promise<MetricsSummary> {
     const tenantId = resolveTenantId(input.tenantId)
     const since = normalizeDate(input.since)

--- a/packages/core-backend/tests/unit/approval-breach-notifier.test.ts
+++ b/packages/core-backend/tests/unit/approval-breach-notifier.test.ts
@@ -17,11 +17,22 @@ function ctx(id: string, overrides: Partial<ApprovalBreachContext> = {}): Approv
   }
 }
 
-function makeMetrics(contexts: ApprovalBreachContext[] = []) {
+function makeMetrics(
+  contexts: ApprovalBreachContext[] = [],
+  options: { unnotified?: string[] } = {},
+) {
   const listBreachContextByIds = vi.fn().mockResolvedValue(contexts)
+  const markBreachNotified = vi.fn().mockResolvedValue(undefined)
+  const findUnnotifiedBreaches = vi.fn().mockResolvedValue(options.unnotified ?? [])
   return {
-    metrics: { listBreachContextByIds } as any,
+    metrics: {
+      listBreachContextByIds,
+      markBreachNotified,
+      findUnnotifiedBreaches,
+    } as any,
     listBreachContextByIds,
+    markBreachNotified,
+    findUnnotifiedBreaches,
   }
 }
 
@@ -178,5 +189,118 @@ describe('ApprovalBreachNotifier', () => {
     expect(message.body).toContain('未知申请人')
     expect(message.body).toContain('未知节点')
     expect(message.link).toBe('https://app.example.com/approval/orphan-1')
+  })
+
+  // ---- migration 058 / persistent breach_notified_at ----------------------
+
+  it('persists breach_notified_at via metrics.markBreachNotified after a successful dispatch', async () => {
+    const channel: BreachNotificationChannel = {
+      name: 'dingtalk',
+      send: vi.fn().mockResolvedValue({ ok: true }),
+    }
+    const { metrics, markBreachNotified } = makeMetrics([ctx('inst-1'), ctx('inst-2')])
+    const fixedNow = new Date('2026-04-26T10:00:00Z')
+    const notifier = new ApprovalBreachNotifier({
+      channels: [channel],
+      metrics,
+      now: () => fixedNow,
+    })
+
+    await notifier.notifyBreaches(['inst-1', 'inst-2'])
+
+    expect(markBreachNotified).toHaveBeenCalledTimes(2)
+    expect(markBreachNotified).toHaveBeenCalledWith('inst-1', fixedNow)
+    expect(markBreachNotified).toHaveBeenCalledWith('inst-2', fixedNow)
+  })
+
+  it('does not persist breach_notified_at when every channel fails', async () => {
+    const failingChannel: BreachNotificationChannel = {
+      name: 'dingtalk',
+      send: vi.fn().mockResolvedValue({ ok: false, error: 'webhook 5xx' }),
+    }
+    const { metrics, markBreachNotified } = makeMetrics([ctx('inst-1')])
+    const notifier = new ApprovalBreachNotifier({ channels: [failingChannel], metrics })
+
+    const result = await notifier.notifyBreaches(['inst-1'])
+
+    expect(result.notified).toBe(0)
+    expect(result.failed).toBe(1)
+    expect(markBreachNotified).not.toHaveBeenCalled()
+  })
+
+  it('treats markBreachNotified failures as non-fatal (in-memory dedupe still applies)', async () => {
+    const channel: BreachNotificationChannel = {
+      name: 'dingtalk',
+      send: vi.fn().mockResolvedValue({ ok: true }),
+    }
+    const { metrics, markBreachNotified } = makeMetrics([ctx('inst-1'), ctx('inst-1')])
+    markBreachNotified.mockRejectedValueOnce(new Error('db pool exhausted'))
+    const notifier = new ApprovalBreachNotifier({ channels: [channel], metrics })
+
+    const first = await notifier.notifyBreaches(['inst-1'])
+    expect(first.notified).toBe(1)        // dispatch reported notified despite persist failure
+    expect(first.failed).toBe(0)
+    expect(channel.send).toHaveBeenCalledTimes(1)
+
+    // Second call within same process: in-memory dedupe still works,
+    // so we don't dispatch again. The lost persist will be picked up
+    // by notifyMissedBreaches on next leader restart.
+    const second = await notifier.notifyBreaches(['inst-1'])
+    expect(second.notified).toBe(0)
+    expect(second.skipped).toBe(1)
+    expect(channel.send).toHaveBeenCalledTimes(1)
+  })
+
+  // ---- notifyMissedBreaches (startup retry path) --------------------------
+
+  it('notifyMissedBreaches replays unnotified breaches from the previous epoch', async () => {
+    const channel: BreachNotificationChannel = {
+      name: 'dingtalk',
+      send: vi.fn().mockResolvedValue({ ok: true }),
+    }
+    const { metrics, findUnnotifiedBreaches, markBreachNotified } = makeMetrics(
+      [ctx('inst-old-1'), ctx('inst-old-2')],
+      { unnotified: ['inst-old-1', 'inst-old-2'] },
+    )
+    const notifier = new ApprovalBreachNotifier({ channels: [channel], metrics })
+
+    const result = await notifier.notifyMissedBreaches()
+
+    expect(findUnnotifiedBreaches).toHaveBeenCalledTimes(1)
+    expect(channel.send).toHaveBeenCalledTimes(2)
+    expect(result.notified).toBe(2)
+    expect(markBreachNotified).toHaveBeenCalledTimes(2)
+  })
+
+  it('notifyMissedBreaches is a no-op when no unnotified breaches exist', async () => {
+    const channel: BreachNotificationChannel = {
+      name: 'dingtalk',
+      send: vi.fn().mockResolvedValue({ ok: true }),
+    }
+    const { metrics, findUnnotifiedBreaches, markBreachNotified } = makeMetrics([], { unnotified: [] })
+    const notifier = new ApprovalBreachNotifier({ channels: [channel], metrics })
+
+    const result = await notifier.notifyMissedBreaches()
+
+    expect(findUnnotifiedBreaches).toHaveBeenCalledTimes(1)
+    expect(channel.send).not.toHaveBeenCalled()
+    expect(markBreachNotified).not.toHaveBeenCalled()
+    expect(result.requested).toBe(0)
+  })
+
+  it('notifyMissedBreaches survives a findUnnotifiedBreaches DB failure', async () => {
+    const channel: BreachNotificationChannel = {
+      name: 'dingtalk',
+      send: vi.fn().mockResolvedValue({ ok: true }),
+    }
+    const { metrics, findUnnotifiedBreaches } = makeMetrics()
+    findUnnotifiedBreaches.mockRejectedValueOnce(new Error('db down'))
+    const notifier = new ApprovalBreachNotifier({ channels: [channel], metrics })
+
+    const result = await notifier.notifyMissedBreaches()
+
+    expect(channel.send).not.toHaveBeenCalled()
+    expect(result.requested).toBe(0)
+    expect(result.failed).toBe(0)
   })
 })

--- a/packages/core-backend/tests/unit/approval-metrics-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-metrics-service.test.ts
@@ -451,4 +451,70 @@ describe('ApprovalMetricsService', () => {
       expect(await service.getInstanceMetrics('missing')).toBeNull()
     })
   })
+
+  // ---- migration 058 / persistent breach_notified_at -----------------
+
+  describe('markBreachNotified', () => {
+    it('issues a guarded UPDATE that no-ops when breach_notified_at is already set', async () => {
+      queryMock.mockResolvedValueOnce({ rows: [] })
+      const at = new Date('2026-04-26T10:00:00Z')
+
+      await service.markBreachNotified('inst-1', at)
+
+      expect(queryMock).toHaveBeenCalledTimes(1)
+      const [sql, params] = queryMock.mock.calls[0]
+      expect(normalize(sql)).toContain('UPDATE approval_metrics')
+      expect(normalize(sql)).toContain('SET breach_notified_at = $1')
+      expect(normalize(sql)).toContain('WHERE instance_id = $2')
+      expect(normalize(sql)).toContain('AND breach_notified_at IS NULL')
+      expect(params).toEqual(['2026-04-26T10:00:00.000Z', 'inst-1'])
+    })
+
+    it('skips silently when given an empty or whitespace instance id (defensive)', async () => {
+      await service.markBreachNotified('', new Date())
+      await service.markBreachNotified('   ', new Date())
+      expect(queryMock).not.toHaveBeenCalled()
+    })
+
+    it('defaults `now` to current time when omitted', async () => {
+      queryMock.mockResolvedValueOnce({ rows: [] })
+      await service.markBreachNotified('inst-2')
+      expect(queryMock).toHaveBeenCalledTimes(1)
+      const [, params] = queryMock.mock.calls[0]
+      expect(typeof params[0]).toBe('string')
+      expect(params[0]).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+    })
+  })
+
+  describe('findUnnotifiedBreaches', () => {
+    it('returns instance ids ordered by sla_breached_at, capped at default 500', async () => {
+      queryMock.mockResolvedValueOnce({
+        rows: [{ instance_id: 'inst-a' }, { instance_id: 'inst-b' }],
+      })
+
+      const ids = await service.findUnnotifiedBreaches()
+
+      expect(ids).toEqual(['inst-a', 'inst-b'])
+      const [sql] = queryMock.mock.calls[0]
+      expect(normalize(sql)).toContain('SELECT instance_id FROM approval_metrics')
+      expect(normalize(sql)).toContain('WHERE sla_breached = TRUE')
+      expect(normalize(sql)).toContain('AND breach_notified_at IS NULL')
+      expect(normalize(sql)).toContain('ORDER BY sla_breached_at ASC')
+      expect(normalize(sql)).toContain('LIMIT 500')
+    })
+
+    it('clamps the limit to a sane upper bound (5000)', async () => {
+      queryMock.mockResolvedValueOnce({ rows: [] })
+      await service.findUnnotifiedBreaches(99_999)
+      const [sql] = queryMock.mock.calls[0]
+      expect(normalize(sql)).toContain('LIMIT 5000')
+    })
+
+    it('falls back to default when limit is non-positive or non-finite', async () => {
+      queryMock.mockResolvedValueOnce({ rows: [] })
+      await service.findUnnotifiedBreaches(-1)
+      const [sql] = queryMock.mock.calls[0]
+      expect(normalize(sql)).toContain('LIMIT 500')
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Closes the persistent-column follow-up named in PR #1171's commit message and code comment.

**Scale**: +507/-10 across 8 files (1 migration, 4 code, 2 test, 2 docs), 1 commit.

## Problem

PR #1171 ships `ApprovalBreachNotifier` with **in-memory only** dedupe. Failure mode:

1. Scheduler atomic flip flags row X as `sla_breached = TRUE` and returns it.
2. Notifier dispatches X via `channel.send` (succeeds at the wire).
3. Leader process crashes **before** `markNotified(X)` runs.
4. Restart: `notifiedIds` is empty.
5. `checkSlaBreaches`'s WHERE filters `sla_breached = FALSE` — X never re-surfaces.
6. **X is permanently un-notified-in-the-record but actually was notified.** Operations cannot answer "did we send for X?" without log archaeology, and any failed dispatch has no retry path.

PR #1171's commit message correctly noted this **does not produce duplicates** (atomic UPDATE prevents re-entry). The cost is **missed escalations stay missed** — for an SLA system, that's a real customer-impact gap.

## Fix

| Layer | Change |
|---|---|
| Migration `058_add_approval_breach_notified_at.sql` | `ALTER TABLE approval_metrics ADD COLUMN breach_notified_at TIMESTAMPTZ NULL` + partial index on `instance_id WHERE sla_breached = TRUE AND breach_notified_at IS NULL` |
| `ApprovalMetricsService.markBreachNotified(id, now)` | Guarded UPDATE — sets timestamp only if NULL, so retry calls are safe no-ops |
| `ApprovalMetricsService.findUnnotifiedBreaches(limit)` | The recovery query, ordered oldest-first, capped at 5000 |
| `ApprovalBreachNotifier.markNotified` | Now `async`; persists after in-memory mark; persist failure logs and continues (in-memory dedupe still applies, future restart reconciles) |
| `ApprovalBreachNotifier.notifyMissedBreaches()` | New: pulls `findUnnotifiedBreaches` and routes through existing `notifyBreaches` pipeline. Idempotent. |
| `packages/core-backend/src/index.ts` startup | Fires `notifyMissedBreaches()` once when SLA scheduler initializes — fire-and-forget; failure logs and continues |

## Verification

- [x] `pnpm vitest run tests/unit/approval-metrics-service.test.ts tests/unit/approval-breach-notifier.test.ts` — **35/35 pass** (was 23 before; +12 new)
  - 6 new on `approval-metrics-service`: `markBreachNotified` guards (3) + `findUnnotifiedBreaches` ordering/cap/fallback (3)
  - 6 new on `approval-breach-notifier`: persistence-on-success / no-persist-on-fail / persist-failure-non-fatal / replay-happy / replay-empty / replay-DB-failure
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `git diff --check` — clean
- [x] No regression in existing 8 + 15 unit tests across the two files

## Design decisions intentionally minimal

- **Persistent-failure non-fatal**: DB UPDATE rejection logs and continues. In-memory dedupe still prevents same-process re-send; next leader's `notifyMissedBreaches` reconciles. Avoids cascading failure when DB has transient issues.
- **Startup retry fire-and-forget**: `void breachNotifier.notifyMissedBreaches().then().catch()` — scheduler init never awaits it. Best-effort recovery cannot block startup.
- **Cap at 5000**: A long-paused leader returning could trigger an unbounded query. Hard cap; operator can re-invoke for larger backlogs (manual triage scenario).
- **No backfill of pre-existing breached rows**: First post-deploy leader will trigger a one-time bounded replay burst — expected and documented in the design doc.
- **No per-channel persistence**: We record "at least one channel succeeded" via `anySent`. Per-channel ack tracking would require a join table; out of scope for this PR.

## Out of scope

- Per-channel ack tracking (DingTalk vs email separately)
- Re-notification on requester / template metadata change
- Multi-leader coordination (relies on PR #1160 leader lock)
- Pagination beyond the 5000 cap (caller can re-invoke if needed)

## Cross-references

- PR #1171 (the predecessor): merged 2026-04-25 as commit `58862b394`. Code comment at `ApprovalBreachNotifier.ts` lines 17-24 named this exact follow-up.
- Migration sequence: most recent on `origin/main` was `057_create_integration_core_tables.sql` (#1140); this PR claims `058`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)