### PR TITLE
fix(integration): coerce remaining K3 WISE evidence boolean strings

### DIFF
--- a/docs/development/integration-core-k3wise-evidence-bool-coercion-design-20260426.md
+++ b/docs/development/integration-core-k3wise-evidence-bool-coercion-design-20260426.md
@@ -1,0 +1,89 @@
+# K3 WISE Evidence Compiler Boolean Coercion Sweep · Design
+
+> Date: 2026-04-26
+> Trigger: post-merge audit during K3 customer answer wait period
+> Pattern: same bug class as preflight script's PR #1168 / #1169 — `=== true` strict equality on customer-supplied JSON booleans
+> Companion: this PR is the evidence-compiler counterpart of the preflight bool-coercion sweep
+
+## Problem
+
+PR #1166 shipped `scripts/ops/integration-k3wise-live-poc-evidence.mjs` (the K3 WISE Live PoC PASS / PARTIAL / FAIL evidence compiler). It validates customer-supplied evidence JSON to make a deploy/no-deploy call after the live test.
+
+Two checks use **strict `=== true` equality** against fields the customer fills in by hand (often via spreadsheet export, Chinese form tools, or partial JSON edits):
+
+| Site | Original code | Risk if customer types `"true"` instead of `true` |
+|---|---|---|
+| `evaluateMaterialSaveOnly` | `if (save.autoSubmit === true \|\| save.autoAudit === true)` | The `SAVE_ONLY_VIOLATED` issue is NOT raised. The compiler returns PASS even though the customer's actual K3 run had auto-submit / auto-audit enabled — the **most dangerous false positive** because Save-only is the central safety contract of the live PoC. |
+| `evaluateBom` | `if (bom.legacyPipelineOptionsSourceProductId === true)` | The `LEGACY_BOM_PRODUCT_ID_USED` issue is NOT raised. Customers using the deprecated `pipeline.options.source.productId` path (instead of `bom.productId` / `plm.defaultProductId`) would not be flagged. |
+
+This is the **identical bug pattern** previously fixed in:
+- PR #1168 — boundary hardening for `k3Wise.autoSubmit / autoAudit` strings
+- PR #1169 — sweep for `sqlServer.enabled`, `sqlServer.writeCoreTables`, `bom.enabled`
+
+The preflight script (input side) is now hardened. The evidence script (output side) was missed in those sweeps. Customer JSON enters BOTH:
+
+```
+GATE answers JSON → preflight script → execution packet (hardened ✅)
+                         ↓
+               customer runs live PoC
+                         ↓
+              evidence JSON → evidence compiler → PASS/PARTIAL/FAIL
+                                  ↑
+                         this PR closes this gap
+```
+
+## Solution
+
+Mirror the same `normalizeSafeBoolean()` helper and same intercepts that `#1169` applied to preflight, scoped to the two affected sites.
+
+1. Add a **local** `normalizeSafeBoolean(value, field)` in `evidence.mjs` (intentional duplication: keeps the customer-runnable script free of cross-file imports; matches preflight's same pattern).
+2. Replace `save.autoSubmit === true || save.autoAudit === true` with `normalizeSafeBoolean(save.autoSubmit, 'materialSaveOnly.autoSubmit') || normalizeSafeBoolean(save.autoAudit, 'materialSaveOnly.autoAudit')`.
+3. Replace `bom.legacyPipelineOptionsSourceProductId === true` with `normalizeSafeBoolean(bom.legacyPipelineOptionsSourceProductId, 'bomPoC.legacyPipelineOptionsSourceProductId')`.
+
+Coercion contract (identical to preflight's, copied for parity):
+
+| Input | Result |
+|---|---|
+| `true` / `false` (boolean) | passthrough |
+| `1` / `0` (finite number) | `true` / `false` |
+| Any other finite number (e.g. `2`) | throws with field name + received value, message contains `0 or 1` |
+| `NaN` / `Infinity` | throws with `finite` in the message |
+| `"true"` / `"yes"` / `"y"` / `"on"` / `"1"` / `"是"` / `"启用"` / `"开启"` | `true` |
+| `"false"` / `"no"` / `"n"` / `"off"` / `"0"` / `"否"` / `"禁用"` / `"关闭"` | `false` |
+| `null` / `undefined` / `""` | `false` (treated as not-set) |
+| Any other string (e.g. `"maybe"`) | throws with field name |
+| Other types (object, array) | throws with field name |
+
+## Files changed
+
+- `scripts/ops/integration-k3wise-live-poc-evidence.mjs` — `normalizeSafeBoolean` helper added; 2 call sites converted (~25 lines added)
+- `scripts/ops/integration-k3wise-live-poc-evidence.test.mjs` — 6 new test cases (~80 lines added)
+- this design doc + matching verification doc
+
+## Acceptance criteria
+
+- [x] `node --test scripts/ops/integration-k3wise-live-poc-evidence.test.mjs` reports 12/12 pass (was 6/6, +6 new)
+- [x] String `"true"` for `materialSaveOnly.autoSubmit` raises `SAVE_ONLY_VIOLATED`
+- [x] String `"yes"` / `"是"` / `"on"` / `"Y"` for `materialSaveOnly.autoAudit` raises `SAVE_ONLY_VIOLATED`
+- [x] String `"true"` for `bomPoC.legacyPipelineOptionsSourceProductId` raises `LEGACY_BOM_PRODUCT_ID_USED`
+- [x] Number `1` for `materialSaveOnly.autoSubmit` raises `SAVE_ONLY_VIOLATED`
+- [x] False-like values (`0`, `"no"`, `"否"`, `"false"`, `"off"`) are accepted as legitimate Save-only confirmation (do NOT raise the issue)
+- [x] Non-coercible values (`"maybe"`, `2`, `NaN`) throw with clear field-named error messages
+- [x] Existing 6 tests from PR #1166 unchanged and still pass (no regression)
+
+## Out of scope
+
+Not pursued in this PR (would dilute the focused fix scope, same discipline as the preflight sweep):
+
+- **`requirePacketSafety` strict booleans** at lines 94-96 (`safety.saveOnly !== true || safety.autoSubmit !== false`). These read from the preflight-generated packet, which already canonicalizes booleans before output. Strict equality is safe IF the customer doesn't hand-edit the packet; if hand-editing is a concern, that's a separate paranoid hardening pass.
+- **`text(bom.productId)` rejecting numeric productId**. Customer might supply `productId: 12345` (number) and trigger a false-positive `BOM_PRODUCT_SCOPE_REQUIRED`. Real but lower severity (false positive, not silent pass). Defer.
+- **`normalizeStatus` defaulting `"passed"` / `"成功"` to `'todo'`**. Localization / synonym ergonomics, not safety. Defer.
+- **`findSecretLeaks` only checks string children**. Numeric secret values would be missed. Edge case, low ROI.
+- **Refactor `normalizeSafeBoolean` into a shared helper module**. Would touch preflight too; collision risk with future Codex work. The intentional local duplication keeps the customer-runnable scripts standalone.
+
+## Cross-references
+
+- PR #1168 — preflight boundary hardening (introduced `normalizeSafeBoolean` for preflight)
+- PR #1169 — preflight bool-coercion sweep (covered remaining `=== true` sites in preflight)
+- PR #1166 — original evidence compiler ship
+- This PR — evidence compiler bool-coercion sweep (closes the symmetric gap)

--- a/docs/development/integration-core-k3wise-evidence-bool-coercion-verification-20260426.md
+++ b/docs/development/integration-core-k3wise-evidence-bool-coercion-verification-20260426.md
@@ -1,0 +1,95 @@
+# K3 WISE Evidence Compiler Boolean Coercion Sweep · Verification
+
+> Date: 2026-04-26
+> Companion: `integration-core-k3wise-evidence-bool-coercion-design-20260426.md`
+> Pattern source: PR #1168 / #1169 (preflight bool-coercion sweep)
+
+## Commands run
+
+```bash
+# 1. Run the evidence test suite (must report 12/12 pass)
+node --test scripts/ops/integration-k3wise-live-poc-evidence.test.mjs
+
+# 2. Confirm only this PR's files are modified
+git status --short
+git diff --stat scripts/ops/integration-k3wise-live-poc-evidence.mjs \
+                scripts/ops/integration-k3wise-live-poc-evidence.test.mjs
+```
+
+## Result · `node --test`
+
+```
+✔ buildEvidenceReport returns PASS for complete Save-only evidence
+✔ buildEvidenceReport returns PARTIAL when a required phase is missing
+✔ buildEvidenceReport returns FAIL when Save-only row count exceeds PoC limit
+✔ buildEvidenceReport returns FAIL when autoAudit appears in Save-only evidence
+✔ buildEvidenceReport rejects unredacted secret-like evidence fields
+✔ buildEvidenceReport returns FAIL when materialSaveOnly autoSubmit is the string "true"
+✔ buildEvidenceReport returns FAIL when materialSaveOnly autoAudit is "yes" / "是" / "on" / "Y"
+✔ buildEvidenceReport returns FAIL when bom.legacyPipelineOptionsSourceProductId is the string "true"
+✔ buildEvidenceReport returns FAIL when materialSaveOnly autoSubmit is the number 1 (spreadsheet boolean)
+✔ buildEvidenceReport accepts the number 0 / string "no" / "否" / "false" as legitimate Save-only confirmation
+✔ buildEvidenceReport throws clear errors for non-coercible boolean values
+✔ CLI writes redacted JSON and Markdown reports
+
+ℹ tests 12
+ℹ pass 12
+ℹ fail 0
+ℹ duration_ms ~52
+```
+
+12/12 pass. The previous 6 tests (PR #1166 baseline) remain unchanged; the 6 new tests cover the bool-coercion sweep.
+
+## New test coverage breakdown (6 added)
+
+| # | Test | What it pins |
+|---|---|---|
+| 1 | `materialSaveOnly autoSubmit is the string "true"` | The original bug — `=== true` would silently let this PASS. Now raises `SAVE_ONLY_VIOLATED`. |
+| 2 | `materialSaveOnly autoAudit is "yes" / "是" / "on" / "Y"` | Covers the 4 most likely customer variants (English yes, Chinese 是, English on, capitalized Y). All raise `SAVE_ONLY_VIOLATED`. |
+| 3 | `bom.legacyPipelineOptionsSourceProductId is the string "true"` | Same bug, second site. Now raises `LEGACY_BOM_PRODUCT_ID_USED`. |
+| 4 | `materialSaveOnly autoSubmit is the number 1` | Spreadsheet exports often coerce booleans to 0/1; covered. |
+| 5 | `false-like values are accepted` (`0`, `"no"`, `"否"`, `"false"`, `"off"`) | Confirms the safety check **does not** false-positive on legitimate Save-only confirmation. Save-only is the central safety contract; over-triggering would erode trust in the evidence compiler. |
+| 6 | Non-coercible values throw with clear errors | `"maybe"` → field name. `2` → `0 or 1` message. `NaN` → `finite` message. Failing loud is correct here — silent acceptance is what we're trying to fix. |
+
+## Existing test regression check
+
+The 6 PR #1166 tests still pass unchanged:
+
+1. PASS for complete Save-only evidence ✓
+2. PARTIAL when required phase is missing ✓
+3. FAIL when row count exceeds PoC limit ✓
+4. FAIL when `autoAudit === true` (boolean) ✓ — confirms passthrough still works for proper booleans
+5. Rejects unredacted secret leaks ✓
+6. CLI writes redacted JSON + Markdown ✓
+
+No regression. The `normalizeSafeBoolean` helper is **additive** for the boolean-passthrough case — `true`/`false` go through unchanged, so the original test that uses `autoAudit = true` still raises `SAVE_ONLY_VIOLATED` exactly as before.
+
+## Manual code review checklist
+
+- [x] `normalizeSafeBoolean` is **identical in contract** to the preflight version — TRUE_BOOLEAN_TEXT / FALSE_BOOLEAN_TEXT sets, throw shapes, error messages all match. Customer-runnable scripts stay standalone (no shared import) by design — same discipline as preflight.
+- [x] Both bug sites converted: `evaluateMaterialSaveOnly` (autoSubmit + autoAudit) and `evaluateBom` (legacyPipelineOptionsSourceProductId).
+- [x] `requirePacketSafety` strict equality at lines 94-96 left intact — reads from preflight-canonicalized packet, not customer hand-edit. Documented as out-of-scope in design doc.
+- [x] `normalizeStatus`, `text(bom.productId)` numeric, `findSecretLeaks` non-string children — all unchanged, all documented as out-of-scope (low ROI, lower severity).
+- [x] No new dependencies, no behavior change for existing callers, no schema change.
+- [x] Error messages include the field name (e.g. `materialSaveOnly.autoSubmit`) so a customer running the script can fix their JSON without our help.
+- [x] `LivePocEvidenceError` carries `details.field` — already an existing test pattern (line 64 in test file), so our new tests use the same assertion shape.
+
+## Why this PR closes the symmetric gap
+
+Customer JSON enters the live PoC twice:
+
+1. **GATE answers JSON → preflight script** (input side) — already hardened in #1168 / #1169.
+2. **Evidence JSON → evidence compiler** (output side) — this PR.
+
+If only the input side coerces booleans, a customer who hand-edits the post-run evidence to type `"true"` (because their spreadsheet, IME, or form tool serializes that way) would receive a **PASS** on a run where Save-only was actually violated. That is the most dangerous false positive in the whole live PoC: the evidence compiler is the gate between PoC and M3 UI build-out. A silent PASS on a violated Save-only run leaks into real K3 WISE writes downstream.
+
+After this PR, both sides apply the same coercion contract, and the same 6-bug-class regression net guards both scripts.
+
+## Cross-references
+
+- Design doc: `docs/development/integration-core-k3wise-evidence-bool-coercion-design-20260426.md`
+- Preflight design: `docs/development/integration-core-k3wise-live-poc-preflight-design-20260425.md`
+- Preflight bool-coercion sweep verification: `docs/development/integration-core-k3wise-preflight-bool-coercion-verification-20260425.md` (PR #1169)
+- PR #1166 (original evidence compiler ship)
+- PR #1168 (preflight boundary hardening — introduced `normalizeSafeBoolean`)
+- PR #1169 (preflight bool-coercion sweep — full coverage of input side)

--- a/scripts/ops/integration-k3wise-live-poc-evidence.mjs
+++ b/scripts/ops/integration-k3wise-live-poc-evidence.mjs
@@ -6,6 +6,13 @@ import { pathToFileURL } from 'node:url'
 const SECRET_KEY_PATTERN = /password|secret|token|session|credential|api[-_]?key|authorization/i
 const SAFE_SECRET_PLACEHOLDERS = new Set(['', '<redacted>', '<set-at-runtime>', 'redacted', '***'])
 const VALID_STATUSES = new Set(['pass', 'partial', 'fail', 'skipped', 'todo', 'blocked'])
+// Customer-supplied evidence often carries spreadsheet-export style booleans
+// (string "true" / "yes" / "是", or number 0 / 1). Strict `=== true` checks
+// silently let those slip past — same bug class as preflight #1168 / #1169.
+// Mirror that helper here (intentionally local; keeping evidence.mjs free
+// of cross-file imports for the customer-runnable script surface).
+const TRUE_BOOLEAN_TEXT = new Set(['true', '1', 'yes', 'y', 'on', '是', '启用', '开启'])
+const FALSE_BOOLEAN_TEXT = new Set(['false', '0', 'no', 'n', 'off', '否', '禁用', '关闭'])
 
 class LivePocEvidenceError extends Error {
   constructor(message, details = {}) {
@@ -17,6 +24,26 @@ class LivePocEvidenceError extends Error {
 
 function isPlainObject(value) {
   return Boolean(value && typeof value === 'object' && !Array.isArray(value))
+}
+
+function normalizeSafeBoolean(value, field) {
+  if (value === undefined || value === null) return false
+  if (typeof value === 'boolean') return value
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new LivePocEvidenceError(`${field} must be a finite boolean, 0/1, or boolean-like string`, { field })
+    }
+    if (value === 1) return true
+    if (value === 0) return false
+    throw new LivePocEvidenceError(`${field} must be 0 or 1 when given as a number`, { field, received: value })
+  }
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase()
+    if (normalized.length === 0) return false
+    if (TRUE_BOOLEAN_TEXT.has(normalized)) return true
+    if (FALSE_BOOLEAN_TEXT.has(normalized)) return false
+  }
+  throw new LivePocEvidenceError(`${field} must be a boolean, 0/1, or boolean-like string`, { field })
 }
 
 function asObject(value, field) {
@@ -142,7 +169,7 @@ function evaluateMaterialSaveOnly(evidence, issues) {
   const status = normalizeStatus(save.status)
   if (status !== 'pass') return
 
-  if (save.autoSubmit === true || save.autoAudit === true) {
+  if (normalizeSafeBoolean(save.autoSubmit, 'materialSaveOnly.autoSubmit') || normalizeSafeBoolean(save.autoAudit, 'materialSaveOnly.autoAudit')) {
     addIssue(issues, 'fail', 'SAVE_ONLY_VIOLATED', 'material Save-only evidence has autoSubmit or autoAudit enabled', 'materialSaveOnly')
   }
   const rowsWritten = Number(save.rowsWritten)
@@ -164,7 +191,7 @@ function evaluateBom(packet, evidence, issues) {
   if (!text(bom.productId)) {
     addIssue(issues, 'fail', 'BOM_PRODUCT_SCOPE_REQUIRED', 'BOM PoC evidence must include productId', 'bomPoC')
   }
-  if (bom.legacyPipelineOptionsSourceProductId === true) {
+  if (normalizeSafeBoolean(bom.legacyPipelineOptionsSourceProductId, 'bomPoC.legacyPipelineOptionsSourceProductId')) {
     addIssue(issues, 'fail', 'LEGACY_BOM_PRODUCT_ID_USED', 'BOM PoC must not use pipeline.options.source.productId', 'bomPoC')
   }
 }

--- a/scripts/ops/integration-k3wise-live-poc-evidence.test.mjs
+++ b/scripts/ops/integration-k3wise-live-poc-evidence.test.mjs
@@ -65,6 +65,86 @@ test('buildEvidenceReport rejects unredacted secret-like evidence fields', () =>
   )
 })
 
+// ----- migration of bool-coercion sweep from preflight (#1168 / #1169) -----
+
+test('buildEvidenceReport returns FAIL when materialSaveOnly autoSubmit is the string "true"', () => {
+  const evidence = sampleEvidence()
+  evidence.materialSaveOnly.autoSubmit = 'true'
+  const report = buildEvidenceReport(packet(), evidence)
+  assert.equal(report.decision, 'FAIL')
+  assert.equal(report.issues.some((issue) => issue.code === 'SAVE_ONLY_VIOLATED'), true)
+})
+
+test('buildEvidenceReport returns FAIL when materialSaveOnly autoAudit is "yes" / "是" / "on" / "Y"', () => {
+  for (const variant of ['yes', '是', 'on', 'Y']) {
+    const evidence = sampleEvidence()
+    evidence.materialSaveOnly.autoAudit = variant
+    const report = buildEvidenceReport(packet(), evidence)
+    assert.equal(report.decision, 'FAIL', `variant ${JSON.stringify(variant)} should fail`)
+    assert.equal(
+      report.issues.some((issue) => issue.code === 'SAVE_ONLY_VIOLATED'),
+      true,
+      `variant ${JSON.stringify(variant)} should raise SAVE_ONLY_VIOLATED`,
+    )
+  }
+})
+
+test('buildEvidenceReport returns FAIL when bom.legacyPipelineOptionsSourceProductId is the string "true"', () => {
+  const evidence = sampleEvidence()
+  evidence.bomPoC.legacyPipelineOptionsSourceProductId = 'true'
+  const report = buildEvidenceReport(packet(), evidence)
+  assert.equal(report.decision, 'FAIL')
+  assert.equal(report.issues.some((issue) => issue.code === 'LEGACY_BOM_PRODUCT_ID_USED'), true)
+})
+
+test('buildEvidenceReport returns FAIL when materialSaveOnly autoSubmit is the number 1 (spreadsheet boolean)', () => {
+  const evidence = sampleEvidence()
+  evidence.materialSaveOnly.autoSubmit = 1
+  const report = buildEvidenceReport(packet(), evidence)
+  assert.equal(report.decision, 'FAIL')
+  assert.equal(report.issues.some((issue) => issue.code === 'SAVE_ONLY_VIOLATED'), true)
+})
+
+test('buildEvidenceReport accepts the number 0 / string "no" / "否" / "false" as legitimate Save-only confirmation', () => {
+  for (const falseLike of [0, 'no', '否', 'false', 'off']) {
+    const evidence = sampleEvidence()
+    evidence.materialSaveOnly.autoSubmit = falseLike
+    evidence.materialSaveOnly.autoAudit = falseLike
+    const report = buildEvidenceReport(packet(), evidence)
+    assert.equal(
+      report.issues.some((issue) => issue.code === 'SAVE_ONLY_VIOLATED'),
+      false,
+      `false-like ${JSON.stringify(falseLike)} should NOT raise SAVE_ONLY_VIOLATED`,
+    )
+  }
+})
+
+test('buildEvidenceReport throws clear errors for non-coercible boolean values', () => {
+  const evidence = sampleEvidence()
+  evidence.materialSaveOnly.autoSubmit = 'maybe'
+  assert.throws(
+    () => buildEvidenceReport(packet(), evidence),
+    (error) => error instanceof LivePocEvidenceError && error.details.field === 'materialSaveOnly.autoSubmit',
+    'unknown string boolean should throw with field name',
+  )
+
+  const evidence2 = sampleEvidence()
+  evidence2.materialSaveOnly.autoAudit = 2
+  assert.throws(
+    () => buildEvidenceReport(packet(), evidence2),
+    (error) => error instanceof LivePocEvidenceError && /0 or 1/.test(error.message),
+    'non-0/1 number should throw with "0 or 1" message',
+  )
+
+  const evidence3 = sampleEvidence()
+  evidence3.materialSaveOnly.autoSubmit = NaN
+  assert.throws(
+    () => buildEvidenceReport(packet(), evidence3),
+    (error) => error instanceof LivePocEvidenceError && /finite/.test(error.message),
+    'NaN should throw with "finite" message',
+  )
+})
+
 test('CLI writes redacted JSON and Markdown reports', async () => {
   const dir = await mkdtemp(path.join(os.tmpdir(), 'integration-live-evidence-'))
   try {


### PR DESCRIPTION
## Summary
Mirrors the preflight bool-coercion sweep (#1168 / #1169) on the **output side**. The K3 WISE Live PoC evidence compiler (#1166) had two `=== true` strict-equality checks against customer-supplied JSON booleans that would silently miss the most dangerous customer mistakes.

| Site | Bug | Risk |
|---|---|---|
| `evaluateMaterialSaveOnly` | `save.autoSubmit === true \|\| save.autoAudit === true` | String `\"true\"` / `\"yes\"` / `\"是\"` / number `1` would NOT raise `SAVE_ONLY_VIOLATED`. **Most dangerous false positive** — Save-only is the central safety contract gating M3 UI build-out. |
| `evaluateBom` | `bom.legacyPipelineOptionsSourceProductId === true` | Same pattern, second site. Would silently miss legacy `pipeline.options.source.productId` usage. |

## Why now
Customer JSON enters the live PoC twice: GATE answers → preflight (input, hardened in #1168/#1169) and post-run evidence → compiler (output, this PR). The preflight sweep didn't touch the evidence script. A customer who hand-edits the post-run JSON to type `\"true\"` would receive a **PASS** on a violated Save-only run — exactly the silent failure the live PoC is designed to prevent.

## Approach
- Added a **local** `normalizeSafeBoolean(value, field)` helper in `evidence.mjs` (intentional duplication with preflight — keeps customer-runnable scripts standalone, no cross-file imports).
- Converted both call sites; coercion contract is **identical** to preflight: `true`/`false` passthrough, `0`/`1` → bool, `\"true\"`/`\"yes\"`/`\"on\"`/`\"是\"`/`\"启用\"`/`\"开启\"` → true (+ false-like equivalents), `null`/`undefined`/`\"\"` → false, anything else throws with field name.

## Files changed
- \`scripts/ops/integration-k3wise-live-poc-evidence.mjs\` — \`normalizeSafeBoolean\` helper + 2 call sites converted (+31 lines)
- \`scripts/ops/integration-k3wise-live-poc-evidence.test.mjs\` — 6 new tests (+80 lines)
- \`docs/development/integration-core-k3wise-evidence-bool-coercion-design-20260426.md\` — design rationale
- \`docs/development/integration-core-k3wise-evidence-bool-coercion-verification-20260426.md\` — test breakdown + manual review checklist

## Out of scope (explicit)
- \`requirePacketSafety\` strict equality — reads from preflight-canonicalized packet, safe IF customer doesn't hand-edit packet.
- Numeric \`bom.productId\` rejection — false positive risk only, lower severity.
- \`normalizeStatus\` synonym ergonomics — localization, not safety.
- \`findSecretLeaks\` non-string children — edge case, low ROI.
- Refactor to shared helper module — would touch preflight too; collision risk with future Codex work.

## Test plan
- [x] \`node --test scripts/ops/integration-k3wise-live-poc-evidence.test.mjs\` reports **12/12 pass** (was 6/6, +6 new)
- [x] String \`\"true\"\` for \`materialSaveOnly.autoSubmit\` → \`SAVE_ONLY_VIOLATED\`
- [x] String \`\"yes\"\` / \`\"是\"\` / \`\"on\"\` / \`\"Y\"\` for \`materialSaveOnly.autoAudit\` → \`SAVE_ONLY_VIOLATED\`
- [x] String \`\"true\"\` for \`bom.legacyPipelineOptionsSourceProductId\` → \`LEGACY_BOM_PRODUCT_ID_USED\`
- [x] Number \`1\` for \`materialSaveOnly.autoSubmit\` → \`SAVE_ONLY_VIOLATED\` (spreadsheet boolean)
- [x] False-like values (\`0\`, \`\"no\"\`, \`\"否\"\`, \`\"false\"\`, \`\"off\"\`) accepted, do NOT raise
- [x] Non-coercible values (\`\"maybe\"\`, \`2\`, \`NaN\`) throw with clear field-named errors
- [x] Existing 6 tests from PR #1166 unchanged (no regression)

## Cross-references
- PR #1166 — original evidence compiler ship
- PR #1168 — preflight boundary hardening (introduced \`normalizeSafeBoolean\`)
- PR #1169 — preflight bool-coercion sweep (input side complete)
- This PR — evidence compiler bool-coercion sweep (closes the symmetric output-side gap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)