### PR TITLE
fix(integration): accept English/Chinese status synonyms in K3 WISE evidence

### DIFF
--- a/docs/development/integration-core-k3wise-evidence-status-synonyms-design-20260426.md
+++ b/docs/development/integration-core-k3wise-evidence-status-synonyms-design-20260426.md
@@ -1,0 +1,130 @@
+# K3 WISE Evidence Compiler Status Synonym Map · Design
+
+> Date: 2026-04-26
+> Picked up from: PR #1175 / #1176 "out of scope" lists
+> Stacked on: PR #1176 (text() numeric coercion)
+> Predecessors: PR #1175 (bool sweep), PR #1168 / #1169 (preflight)
+
+## Problem
+
+The evidence compiler's `normalizeStatus()` accepts only the canonical 6 statuses (`pass`, `partial`, `fail`, `skipped`, `todo`, `blocked`) and silently defaults *anything else* to `'todo'`:
+
+```javascript
+function normalizeStatus(value) {
+  const status = text(value).toLowerCase()
+  return VALID_STATUSES.has(status) ? status : 'todo'
+}
+```
+
+Customer evidence JSON is hand-written or exported from spreadsheets / form tools. Customers regularly write phase status using natural-language synonyms — English `"passed"` / `"complete"` / `"done"` or Chinese `"成功"` / `"通过"` / `"完成"`. Each of these silently becomes `'todo'`, which:
+
+1. **Flips a completed phase into a false PARTIAL decision.** A customer who finished GATE answers + connection tests + dry-run + Save-only correctly, but used `"passed"` instead of `"pass"` for status fields, gets a PARTIAL report saying their phases are `"todo"` (incomplete). They have no way to tell from the report what's wrong (the synonym error isn't raised — it's silent).
+2. **Erodes trust in the compiler.** Customers see "you said it's incomplete" when they know it's complete; they assume the compiler is broken or overly strict.
+
+This is the third item from PR #1175's "out of scope" list, and PR #1176 deferred it again as the next narrow follow-up.
+
+## Solution
+
+Add a `STATUS_SYNONYMS` map and consult it in `normalizeStatus()` after the canonical-set check:
+
+```javascript
+const STATUS_SYNONYMS = new Map([
+  // pass synonyms (English + Chinese)
+  ['passed', 'pass'], ['passing', 'pass'], ['complete', 'pass'], ['completed', 'pass'],
+  ['done', 'pass'], ['ok', 'pass'], ['success', 'pass'], ['successful', 'pass'], ['succeeded', 'pass'],
+  ['通过', 'pass'], ['成功', 'pass'], ['完成', 'pass'], ['已完成', 'pass'], ['已通过', 'pass'], ['完毕', 'pass'],
+  // fail synonyms
+  ['failed', 'fail'], ['fails', 'fail'], ['error', 'fail'], ['errored', 'fail'], ['failure', 'fail'],
+  ['失败', 'fail'], ['失败了', 'fail'], ['错误', 'fail'], ['出错', 'fail'],
+  // partial synonyms
+  ['partially', 'partial'], ['in-progress', 'partial'], ['in progress', 'partial'], ['inprogress', 'partial'],
+  ['ongoing', 'partial'], ['working', 'partial'],
+  ['进行中', 'partial'], ['部分通过', 'partial'], ['部分', 'partial'],
+  // skipped synonyms
+  ['skip', 'skipped'], ['n/a', 'skipped'], ['na', 'skipped'], ['not applicable', 'skipped'],
+  ['跳过', 'skipped'], ['不适用', 'skipped'],
+  // blocked synonyms
+  ['stuck', 'blocked'], ['waiting', 'blocked'], ['hold', 'blocked'], ['on hold', 'blocked'], ['on-hold', 'blocked'],
+  ['阻塞', 'blocked'], ['卡住', 'blocked'], ['等待中', 'blocked'],
+  // todo synonyms
+  ['pending', 'todo'], ['queued', 'todo'], ['planned', 'todo'], ['not started', 'todo'], ['not-started', 'todo'],
+  ['待办', 'todo'], ['待做', 'todo'], ['未开始', 'todo'], ['未做', 'todo'],
+])
+
+function normalizeStatus(value) {
+  const status = text(value).toLowerCase()
+  if (VALID_STATUSES.has(status)) return status
+  if (STATUS_SYNONYMS.has(status)) return STATUS_SYNONYMS.get(status)
+  return 'todo'
+}
+```
+
+### Coercion table (representative subset)
+
+| Customer input | Mapped status | Why |
+|---|---|---|
+| `"pass"` / `"PASS"` | `'pass'` | Canonical (case-insensitive via toLowerCase) |
+| `"passed"` / `"complete"` / `"done"` / `"ok"` | `'pass'` | English synonyms |
+| `"成功"` / `"通过"` / `"完成"` / `"已完成"` | `'pass'` | Chinese synonyms |
+| `"failed"` / `"error"` / `"errored"` | `'fail'` | English |
+| `"失败"` / `"错误"` / `"出错"` | `'fail'` | Chinese |
+| `"partially"` / `"in-progress"` / `"ongoing"` | `'partial'` | English |
+| `"进行中"` / `"部分"` / `"部分通过"` | `'partial'` | Chinese |
+| `"on-hold"` / `"waiting"` / `"stuck"` | `'blocked'` | English |
+| `"阻塞"` / `"卡住"` / `"等待中"` | `'blocked'` | Chinese |
+| `"skip"` / `"n/a"` / `"not applicable"` | `'skipped'` | English |
+| `"跳过"` / `"不适用"` | `'skipped'` | Chinese |
+| `"pending"` / `"planned"` / `"not started"` | `'todo'` | English |
+| `"待办"` / `"未开始"` / `"未做"` | `'todo'` | Chinese |
+| `"maybe"` / `"xxx"` / `"random"` | `'todo'` | Unknown — defaults to safe `'todo'` |
+
+The fallback to `'todo'` for unknown strings is preserved — synonyms expand the accepting set, but unrecognized inputs still produce the safe-incomplete status that the compiler then treats as a missing-evidence signal. No over-acceptance.
+
+## Why this safe-by-design
+
+The synonym map is **strictly an expansion** of the accepting set:
+- All 6 canonical statuses still work via the existing `VALID_STATUSES.has(status)` check (first).
+- Synonyms layer on top via the new `STATUS_SYNONYMS.has(status)` check (second).
+- Unknown inputs still fall through to `'todo'` (third).
+
+Existing behavior for canonical statuses is identical. Existing behavior for genuinely unknown inputs is identical. Only the previously-incorrectly-todo'd synonyms change behavior — and they change to the *correct* mapping.
+
+Crucially, this does NOT weaken any safety check:
+- `evaluateMaterialSaveOnly` still calls `normalizeStatus(save.status)` and skips Save-only safety checks only when status is non-`'pass'`. With synonyms, more inputs map to `'pass'` (correctly), so safety checks fire in *more* cases (the desired behavior — silent `'todo'` was previously bypassing them on completed runs).
+- `evaluateBom` similarly returns early on non-`'pass'`. Same logic: synonyms mapping to `'pass'` correctly trigger BOM evaluation.
+
+A test in this PR explicitly verifies that `'失败'` (a fail synonym) on `materialSaveOnly` correctly skips the Save-only safety checks (since the run failed and there's no data to safety-check), pinning the safety contract.
+
+## Files changed
+
+- `scripts/ops/integration-k3wise-live-poc-evidence.mjs` — `STATUS_SYNONYMS` Map added + `normalizeStatus()` extended (~25 lines added)
+- `scripts/ops/integration-k3wise-live-poc-evidence.test.mjs` — 7 new test cases (~85 lines added)
+- this design doc + matching verification doc
+
+## Acceptance criteria
+
+- [x] `node --test scripts/ops/integration-k3wise-live-poc-evidence.test.mjs` reports 23/23 pass (was 16/16, +7 new)
+- [x] English pass-synonyms (`passed`, `complete`, `completed`, `done`, `ok`, `success`, `successful`, `succeeded`) → `'pass'`
+- [x] Chinese pass-synonyms (`通过`, `成功`, `完成`, `已完成`, `已通过`, `完毕`) → `'pass'`
+- [x] Fail synonyms (English + Chinese) → `'fail'`
+- [x] Partial / blocked / skipped / todo synonyms (English + Chinese) → expected canonical
+- [x] Case-insensitive (`PASSED`, `Failed`, `DONE`) → expected canonical
+- [x] Genuinely unknown strings (`maybe`, `xxxxx`, `不确定`) STILL default to `'todo'` — no over-acceptance
+- [x] Fail synonym on `materialSaveOnly.status` correctly skips Save-only safety checks (does NOT raise SAVE_ONLY_VIOLATED on a failed run)
+- [x] All 16 prior tests pass unchanged (no regression)
+
+## Out of scope
+
+Same audit-style discipline:
+
+- **`requirePacketSafety` strict equality** at lines 94-96 — still deferred. Reads from preflight-canonicalized packet; safe IF customer doesn't hand-edit. Paranoid hardening, separate PR.
+- **`findSecretLeaks` non-string scanning** — still deferred. Edge case, low ROI.
+- **Refactor synonyms into a shared dictionary module** — would touch preflight too, collision risk with parallel codex sessions, kept local.
+- **Allow customer-defined synonyms via config** — out of scope; the built-in map covers the realistic Chinese/English customer surface.
+
+## Cross-references
+
+- PR #1176 — text() numeric ID coercion (this PR's predecessor; deferred this exact item)
+- PR #1175 — evidence bool-coercion sweep (predecessor's predecessor; first deferred this item)
+- PR #1166 — original evidence compiler ship
+- PR #1168 / #1169 — preflight bool-coercion sweep (input side)

--- a/docs/development/integration-core-k3wise-evidence-status-synonyms-verification-20260426.md
+++ b/docs/development/integration-core-k3wise-evidence-status-synonyms-verification-20260426.md
@@ -1,0 +1,99 @@
+# K3 WISE Evidence Compiler Status Synonym Map · Verification
+
+> Date: 2026-04-26
+> Companion: `integration-core-k3wise-evidence-status-synonyms-design-20260426.md`
+> Stacked on: PR #1176 (text() numeric coercion)
+
+## Commands run
+
+```bash
+node --test scripts/ops/integration-k3wise-live-poc-evidence.test.mjs
+git diff --stat scripts/ops/integration-k3wise-live-poc-evidence.mjs \
+                scripts/ops/integration-k3wise-live-poc-evidence.test.mjs
+```
+
+## Result · `node --test`
+
+```
+✔ buildEvidenceReport returns PASS for complete Save-only evidence
+✔ buildEvidenceReport returns PARTIAL when a required phase is missing
+✔ buildEvidenceReport returns FAIL when Save-only row count exceeds PoC limit
+✔ buildEvidenceReport returns FAIL when autoAudit appears in Save-only evidence
+✔ buildEvidenceReport rejects unredacted secret-like evidence fields
+✔ buildEvidenceReport returns FAIL when materialSaveOnly autoSubmit is the string "true"
+✔ buildEvidenceReport returns FAIL when materialSaveOnly autoAudit is "yes" / "是" / "on" / "Y"
+✔ buildEvidenceReport returns FAIL when bom.legacyPipelineOptionsSourceProductId is the string "true"
+✔ buildEvidenceReport returns FAIL when materialSaveOnly autoSubmit is the number 1 (spreadsheet boolean)
+✔ buildEvidenceReport accepts the number 0 / string "no" / "否" / "false" as legitimate Save-only confirmation
+✔ buildEvidenceReport throws clear errors for non-coercible boolean values
+✔ buildEvidenceReport accepts numeric runId / productId from spreadsheet exports
+✔ buildEvidenceReport accepts bigint productId for very large external IDs
+✔ buildEvidenceReport still rejects NaN / Infinity / object / array / null as missing IDs
+✔ buildEvidenceReport accepts numeric runId for materialSaveOnly evidence
+✔ normalizeStatus accepts English pass-synonyms ("passed", "complete", "done", "ok", "success", "succeeded")
+✔ normalizeStatus accepts Chinese pass-synonyms ("通过", "成功", "完成", "已完成", "已通过", "完毕")
+✔ normalizeStatus accepts fail synonyms (English + Chinese)
+✔ normalizeStatus accepts partial / blocked / skipped / todo synonyms
+✔ normalizeStatus is case-insensitive ("PASSED" / "Failed" / "DONE")
+✔ normalizeStatus still defaults unknown strings to "todo" (no over-acceptance)
+✔ normalizeStatus synonym for fail in materialSaveOnly correctly skips Save-only safety checks
+✔ CLI writes redacted JSON and Markdown reports
+
+ℹ tests 23
+ℹ pass 23
+ℹ fail 0
+ℹ duration_ms ~58
+```
+
+23/23 pass — was 16/16 before (PR #1176 baseline). +7 new tests, 0 regressions.
+
+## New test coverage breakdown (7 added)
+
+| # | Test | What it pins |
+|---|---|---|
+| 1 | `accepts English pass-synonyms` | 8 variants (`passed`, `complete`, `completed`, `done`, `ok`, `success`, `successful`, `succeeded`) all map to `'pass'`. Headline fix for English-speaking customers. |
+| 2 | `accepts Chinese pass-synonyms` | 6 variants (`通过`, `成功`, `完成`, `已完成`, `已通过`, `完毕`) all map to `'pass'`. Headline fix for Chinese customers. |
+| 3 | `accepts fail synonyms (English + Chinese)` | 7 variants from both languages map to `'fail'`. Symmetry: just as silent-todo on completed phases is bad, silent-todo on failed phases hides actual failures. |
+| 4 | `accepts partial / blocked / skipped / todo synonyms` | 12 variants covering the remaining 4 canonical statuses. Mixed Chinese/English. |
+| 5 | `is case-insensitive ("PASSED" / "Failed" / "DONE")` | Confirms the pre-existing `.toLowerCase()` chain still works for the new synonym map. Customers often write status in all-caps or title-case. |
+| 6 | `still defaults unknown strings to "todo" (no over-acceptance)` | Defensive: `maybe`, `xxxxx`, `random-junk`, `不确定`, `unknown` still default to `'todo'`. The synonym map expands the accepting set but does NOT silently accept everything. |
+| 7 | `synonym for fail in materialSaveOnly correctly skips Save-only safety checks` | Critical safety pin: `materialSaveOnly.status = '失败'` + `autoSubmit = true` does NOT raise `SAVE_ONLY_VIOLATED`. The Save-only safety check only matters for runs that actually wrote data; failed runs correctly skip the check. Pins the interaction between the synonym map and the safety contract. |
+
+## Existing test regression check
+
+The 16 prior tests (5 from PR #1166 + 6 from PR #1175 + 4 from PR #1176 + 1 CLI) all pass unchanged. The change is **additive**:
+
+- `VALID_STATUSES` set unchanged. Canonical statuses still match first.
+- `STATUS_SYNONYMS` map is new. Consulted only after canonical check fails.
+- Final fallback to `'todo'` unchanged.
+
+The only behavior change is for inputs that previously fell through to `'todo'` and are now in the synonym map — for those, behavior changes from `'todo'` to the correct canonical (which is what the customer meant in the first place).
+
+## Manual code review checklist
+
+- [x] Synonym map is exhaustive enough for realistic customer input but not over-broad — every entry has a clear, unambiguous mapping (no `"pass"` synonym that could also mean `"fail"`).
+- [x] Both English and Chinese synonyms covered for each canonical status, since both are realistic customer surfaces.
+- [x] `.toLowerCase()` is applied before lookup, so case variants of English synonyms work; Chinese characters are unaffected by toLowerCase (no-op).
+- [x] No new error paths — `normalizeStatus` remains pure with same return contract.
+- [x] No throws — synonym map adds no new failure modes.
+- [x] Fallback to `'todo'` preserved — guarantees no silent over-acceptance.
+- [x] Inline comment explains *why* (customer evidence often uses synonyms, silent `'todo'` flips correct phases to false PARTIAL).
+- [x] Safety-critical interaction tested explicitly: synonym-mapped `'fail'` status on `materialSaveOnly` correctly bypasses Save-only safety checks.
+
+## Why stacked on PR #1176
+
+PR #1176 (numeric ID coercion) and this PR both touch `evidence.mjs` in customer-input ergonomics. Stacking allows:
+
+- This branch can be reviewed and CI-validated *during* #1176's review, not after, halving the wall-clock time for the audit series.
+- Both PRs share the same theme (customer-input edge cases) so reviewing them together provides better context.
+- After #1176 merges, this branch rebases cleanly onto main with no conflicts (only different functions touched within the same file).
+
+If #1176 is rejected or substantially changed, this branch rebases against the new main and continues independently — the synonym-map change has no functional dependency on the numeric-coercion change.
+
+## Cross-references
+
+- Design doc: `docs/development/integration-core-k3wise-evidence-status-synonyms-design-20260426.md`
+- Predecessor PR: #1176 (text() numeric coercion — design doc deferred this exact item)
+- Predecessor PR: #1175 (bool sweep — first design doc that flagged status synonyms as out-of-scope)
+- Original ship: #1166 (evidence compiler v1)
+- Symmetric work: #1168 / #1169 (preflight bool-coercion sweep)

--- a/scripts/ops/integration-k3wise-live-poc-evidence.mjs
+++ b/scripts/ops/integration-k3wise-live-poc-evidence.mjs
@@ -6,6 +6,26 @@ import { pathToFileURL } from 'node:url'
 const SECRET_KEY_PATTERN = /password|secret|token|session|credential|api[-_]?key|authorization/i
 const SAFE_SECRET_PLACEHOLDERS = new Set(['', '<redacted>', '<set-at-runtime>', 'redacted', '***'])
 const VALID_STATUSES = new Set(['pass', 'partial', 'fail', 'skipped', 'todo', 'blocked'])
+// Customer evidence often spells phase status with localized or English
+// synonyms (e.g. "passed", "成功", "完成", "failed", "失败", "进行中").
+// Without a synonym map, anything not in VALID_STATUSES silently defaults
+// to 'todo' — flipping a completed phase into a false PARTIAL decision.
+const STATUS_SYNONYMS = new Map([
+  ['passed', 'pass'], ['passing', 'pass'], ['complete', 'pass'], ['completed', 'pass'],
+  ['done', 'pass'], ['ok', 'pass'], ['success', 'pass'], ['successful', 'pass'], ['succeeded', 'pass'],
+  ['通过', 'pass'], ['成功', 'pass'], ['完成', 'pass'], ['已完成', 'pass'], ['已通过', 'pass'], ['完毕', 'pass'],
+  ['failed', 'fail'], ['fails', 'fail'], ['error', 'fail'], ['errored', 'fail'], ['failure', 'fail'],
+  ['失败', 'fail'], ['失败了', 'fail'], ['错误', 'fail'], ['出错', 'fail'],
+  ['partially', 'partial'], ['in-progress', 'partial'], ['in progress', 'partial'], ['inprogress', 'partial'],
+  ['ongoing', 'partial'], ['working', 'partial'],
+  ['进行中', 'partial'], ['部分通过', 'partial'], ['部分', 'partial'],
+  ['skip', 'skipped'], ['n/a', 'skipped'], ['na', 'skipped'], ['not applicable', 'skipped'],
+  ['跳过', 'skipped'], ['不适用', 'skipped'],
+  ['stuck', 'blocked'], ['waiting', 'blocked'], ['hold', 'blocked'], ['on hold', 'blocked'], ['on-hold', 'blocked'],
+  ['阻塞', 'blocked'], ['卡住', 'blocked'], ['等待中', 'blocked'],
+  ['pending', 'todo'], ['queued', 'todo'], ['planned', 'todo'], ['not started', 'todo'], ['not-started', 'todo'],
+  ['待办', 'todo'], ['待做', 'todo'], ['未开始', 'todo'], ['未做', 'todo'],
+])
 // Customer-supplied evidence often carries spreadsheet-export style booleans
 // (string "true" / "yes" / "是", or number 0 / 1). Strict `=== true` checks
 // silently let those slip past — same bug class as preflight #1168 / #1169.
@@ -76,7 +96,9 @@ function text(value) {
 
 function normalizeStatus(value) {
   const status = text(value).toLowerCase()
-  return VALID_STATUSES.has(status) ? status : 'todo'
+  if (VALID_STATUSES.has(status)) return status
+  if (STATUS_SYNONYMS.has(status)) return STATUS_SYNONYMS.get(status)
+  return 'todo'
 }
 
 function redact(value) {

--- a/scripts/ops/integration-k3wise-live-poc-evidence.test.mjs
+++ b/scripts/ops/integration-k3wise-live-poc-evidence.test.mjs
@@ -200,6 +200,107 @@ test('buildEvidenceReport accepts numeric runId for materialSaveOnly evidence', 
   )
 })
 
+// ----- normalizeStatus synonym map (deferred from #1175 / #1176, picked up here) -----
+
+test('normalizeStatus accepts English pass-synonyms ("passed", "complete", "done", "ok", "success", "succeeded")', () => {
+  for (const variant of ['passed', 'complete', 'completed', 'done', 'ok', 'success', 'successful', 'succeeded']) {
+    const evidence = sampleEvidence()
+    evidence.materialDryRun.status = variant
+    const report = buildEvidenceReport(packet(), evidence)
+    const phase = report.phases.find((p) => p.id === 'materialDryRun')
+    assert.equal(phase.status, 'pass', `variant ${JSON.stringify(variant)} should normalize to 'pass'`)
+  }
+})
+
+test('normalizeStatus accepts Chinese pass-synonyms ("通过", "成功", "完成", "已完成", "已通过", "完毕")', () => {
+  for (const variant of ['通过', '成功', '完成', '已完成', '已通过', '完毕']) {
+    const evidence = sampleEvidence()
+    evidence.materialDryRun.status = variant
+    const report = buildEvidenceReport(packet(), evidence)
+    const phase = report.phases.find((p) => p.id === 'materialDryRun')
+    assert.equal(phase.status, 'pass', `variant ${JSON.stringify(variant)} should normalize to 'pass'`)
+  }
+})
+
+test('normalizeStatus accepts fail synonyms (English + Chinese)', () => {
+  for (const variant of ['failed', 'error', 'errored', 'failure', '失败', '错误', '出错']) {
+    const evidence = sampleEvidence()
+    evidence.materialDryRun.status = variant
+    const report = buildEvidenceReport(packet(), evidence)
+    const phase = report.phases.find((p) => p.id === 'materialDryRun')
+    assert.equal(phase.status, 'fail', `variant ${JSON.stringify(variant)} should normalize to 'fail'`)
+  }
+})
+
+test('normalizeStatus accepts partial / blocked / skipped / todo synonyms', () => {
+  const cases = [
+    { variant: 'partially', expected: 'partial' },
+    { variant: 'in-progress', expected: 'partial' },
+    { variant: '进行中', expected: 'partial' },
+    { variant: '部分', expected: 'partial' },
+    { variant: 'on-hold', expected: 'blocked' },
+    { variant: 'waiting', expected: 'blocked' },
+    { variant: '阻塞', expected: 'blocked' },
+    { variant: 'skip', expected: 'skipped' },
+    { variant: 'n/a', expected: 'skipped' },
+    { variant: '跳过', expected: 'skipped' },
+    { variant: 'pending', expected: 'todo' },
+    { variant: '待办', expected: 'todo' },
+  ]
+  for (const { variant, expected } of cases) {
+    const evidence = sampleEvidence()
+    evidence.materialDryRun.status = variant
+    const report = buildEvidenceReport(packet(), evidence)
+    const phase = report.phases.find((p) => p.id === 'materialDryRun')
+    assert.equal(phase.status, expected, `variant ${JSON.stringify(variant)} should normalize to '${expected}'`)
+  }
+})
+
+test('normalizeStatus is case-insensitive ("PASSED" / "Failed" / "DONE")', () => {
+  const cases = [
+    { variant: 'PASSED', expected: 'pass' },
+    { variant: 'Failed', expected: 'fail' },
+    { variant: 'DONE', expected: 'pass' },
+    { variant: 'Pending', expected: 'todo' },
+  ]
+  for (const { variant, expected } of cases) {
+    const evidence = sampleEvidence()
+    evidence.materialDryRun.status = variant
+    const report = buildEvidenceReport(packet(), evidence)
+    const phase = report.phases.find((p) => p.id === 'materialDryRun')
+    assert.equal(phase.status, expected, `variant ${JSON.stringify(variant)} should normalize to '${expected}'`)
+  }
+})
+
+test('normalizeStatus still defaults unknown strings to "todo" (no over-acceptance)', () => {
+  for (const unknown of ['maybe', 'wat', 'xxxxx', 'random-junk', '不确定', 'unknown']) {
+    const evidence = sampleEvidence()
+    evidence.materialDryRun.status = unknown
+    const report = buildEvidenceReport(packet(), evidence)
+    const phase = report.phases.find((p) => p.id === 'materialDryRun')
+    assert.equal(phase.status, 'todo', `unknown variant ${JSON.stringify(unknown)} should default to 'todo'`)
+  }
+})
+
+test('normalizeStatus synonym for fail in materialSaveOnly correctly skips Save-only safety checks', () => {
+  // When status is "失败" (a fail synonym), evaluateMaterialSaveOnly must
+  // recognize this as a fail and SKIP the autoSubmit/autoAudit safety
+  // checks (since they only matter for runs that actually wrote data).
+  const evidence = sampleEvidence()
+  evidence.materialSaveOnly.status = '失败'
+  evidence.materialSaveOnly.autoSubmit = true  // would normally raise SAVE_ONLY_VIOLATED
+  const report = buildEvidenceReport(packet(), evidence)
+  // Phase status reflects the synonym mapping; the run failed, so save-only
+  // checks are bypassed (matching existing logic that returns early on non-pass).
+  const phase = report.phases.find((p) => p.id === 'materialSaveOnly')
+  assert.equal(phase.status, 'fail')
+  assert.equal(
+    report.issues.some((issue) => issue.code === 'SAVE_ONLY_VIOLATED'),
+    false,
+    'SAVE_ONLY_VIOLATED should not be raised when the save-only run itself failed',
+  )
+})
+
 test('CLI writes redacted JSON and Markdown reports', async () => {
   const dir = await mkdtemp(path.join(os.tmpdir(), 'integration-live-evidence-'))
   try {


### PR DESCRIPTION
> **Stacked on #1176** — base branch is the numeric-coercion branch. After #1176 merges, this rebases onto main automatically.

## Summary
Picks up the next deferred item from PR #1175 / #1176 design docs:

> normalizeStatus defaulting `\"passed\"` / `\"成功\"` to `'todo'`. Localization / synonym ergonomics, not safety. Defer.

\`normalizeStatus()\` previously accepted only the 6 canonical statuses (\`pass\`, \`partial\`, \`fail\`, \`skipped\`, \`todo\`, \`blocked\`) and silently defaulted *everything else* to \`'todo'\`. Customer evidence routinely uses natural-language synonyms (\`\"passed\"\`, \`\"complete\"\`, \`\"成功\"\`, \`\"完成\"\`) and these silently flipped completed phases into a false PARTIAL decision — incorrect overall outcome that gates M3 UI build-out.

## Approach
Add a \`STATUS_SYNONYMS\` Map with English + Chinese coverage for each of the 6 canonical statuses. Map is consulted **after** the canonical-set check (so existing canonical inputs are unchanged); unknown inputs still default to \`'todo'\` (no over-acceptance).

| Status | English synonyms | Chinese synonyms |
|---|---|---|
| pass | passed, complete, completed, done, ok, success, successful, succeeded | 通过, 成功, 完成, 已完成, 已通过, 完毕 |
| fail | failed, fails, error, errored, failure | 失败, 失败了, 错误, 出错 |
| partial | partially, in-progress, in progress, inprogress, ongoing, working | 进行中, 部分通过, 部分 |
| skipped | skip, n/a, na, not applicable | 跳过, 不适用 |
| blocked | stuck, waiting, hold, on hold, on-hold | 阻塞, 卡住, 等待中 |
| todo | pending, queued, planned, not started, not-started | 待办, 待做, 未开始, 未做 |

## Why safe-by-design
The synonym map is **strictly additive**:
- VALID_STATUSES check runs first → canonical statuses unchanged
- STATUS_SYNONYMS check runs second → previously-incorrectly-todo'd inputs now map correctly
- Final fallback to \`'todo'\` unchanged → unknown inputs still produce safe-incomplete

Critically does NOT weaken safety: if anything, MORE inputs now correctly map to \`'pass'\` and trigger Save-only safety checks (which were previously bypassed on \`'todo'\` phases).

## Files changed
- \`scripts/ops/integration-k3wise-live-poc-evidence.mjs\` — STATUS_SYNONYMS Map + normalizeStatus extended (~25 lines)
- \`scripts/ops/integration-k3wise-live-poc-evidence.test.mjs\` — 7 new test cases (~85 lines)
- \`docs/development/integration-core-k3wise-evidence-status-synonyms-design-20260426.md\`
- \`docs/development/integration-core-k3wise-evidence-status-synonyms-verification-20260426.md\`

## Test plan
- [x] \`node --test scripts/ops/integration-k3wise-live-poc-evidence.test.mjs\` reports **23/23 pass** (was 16/16, +7 new)
- [x] English pass-synonyms (\`passed\`, \`complete\`, \`done\`, \`ok\`, \`success\`, \`succeeded\`, etc.) → \`'pass'\`
- [x] Chinese pass-synonyms (\`通过\`, \`成功\`, \`完成\`, \`已完成\`) → \`'pass'\`
- [x] Fail synonyms (English + Chinese) → \`'fail'\`
- [x] Partial / blocked / skipped / todo synonyms (English + Chinese)
- [x] Case-insensitive (\`PASSED\`, \`Failed\`, \`DONE\`)
- [x] Genuinely unknown strings (\`maybe\`, \`xxxxx\`, \`不确定\`) STILL default to \`'todo'\`
- [x] **Safety pin**: fail-synonym on \`materialSaveOnly\` correctly bypasses Save-only safety checks (no false SAVE_ONLY_VIOLATED on a failed run)
- [x] All 16 prior tests pass unchanged

## Out of scope (future PRs)
- \`requirePacketSafety\` strict equality (paranoid hardening)
- \`findSecretLeaks\` non-string children (edge case)
- Refactor synonyms into shared dictionary (collision risk)
- Customer-defined synonyms via config (out of scope)

## Cross-references
- PR #1176 — text() numeric ID coercion (predecessor; deferred this exact item)
- PR #1175 — bool-coercion sweep (first deferred this item)
- PR #1166 — original evidence compiler ship
- PR #1168 / #1169 — preflight bool-coercion sweep (input side)

🤖 Generated with [Claude Code](https://claude.com/claude-code)