### PR TITLE
feat(multitable): add Excel xlsx import/export client (MF1)

### DIFF
--- a/apps/web/src/multitable/components/MetaImportModal.vue
+++ b/apps/web/src/multitable/components/MetaImportModal.vue
@@ -13,8 +13,13 @@
           </div>
           <p class="meta-import__hint">Paste tab-separated data from Excel or Google Sheets (first row = headers):</p>
           <label class="meta-import__file-drop" @dragover.prevent @drop.prevent="onFileDrop">
-            <input class="meta-import__file-input" type="file" accept=".csv,text/csv,.tsv,text/tab-separated-values,.txt,text/plain" @change="onFileSelect" />
-            <span>Choose a CSV/TSV file or drop it here</span>
+            <input
+              class="meta-import__file-input"
+              type="file"
+              accept=".csv,text/csv,.tsv,text/tab-separated-values,.txt,text/plain,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.xls,application/vnd.ms-excel"
+              @change="onFileSelect"
+            />
+            <span>Choose a CSV/TSV/Excel file or drop it here</span>
           </label>
           <textarea
             ref="textareaRef"
@@ -168,6 +173,7 @@ import MetaLinkPicker from './MetaLinkPicker.vue'
 import type { LinkedRecordSummary, MetaField } from '../types'
 import { buildImportedRecords, parseDelimitedText } from '../import/delimited'
 import type { ImportBuildFailure, ImportBuildResult, ImportFieldOverrides, ImportValueResolver } from '../import/delimited'
+import { XLSX_MAX_BYTES, XLSX_MAX_ROWS, mapXlsxColumnsToFields, parseXlsxBuffer } from '../import/xlsx-mapping'
 import { isLinkField, isPersonField, linkActionLabel } from '../utils/link-fields'
 
 type ImportResultFailure = ImportBuildFailure & {
@@ -534,14 +540,55 @@ async function readAndSetText(file: File) {
   }
 }
 
+function isXlsxFile(file: File): boolean {
+  const lowerName = file.name.toLowerCase()
+  if (lowerName.endsWith('.xlsx') || lowerName.endsWith('.xls')) return true
+  const lowerType = file.type.toLowerCase()
+  return (
+    lowerType === 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' ||
+    lowerType === 'application/vnd.ms-excel'
+  )
+}
+
+async function readAndSetXlsx(file: File) {
+  parseError.value = ''
+  if (file.size > XLSX_MAX_BYTES) {
+    parseError.value = `File too large (max ${(XLSX_MAX_BYTES / (1024 * 1024)).toFixed(0)} MB)`
+    return
+  }
+  try {
+    const xlsx = (await import('xlsx')) as unknown as Parameters<typeof parseXlsxBuffer>[0]
+    const buffer = await file.arrayBuffer()
+    const result = parseXlsxBuffer(xlsx, buffer)
+    if (!result.headers.length || !result.rows.length) {
+      parseError.value = 'No importable rows found in spreadsheet'
+      return
+    }
+    rawText.value = ''
+    parsedHeaders.value = result.headers
+    parsedRows.value = result.rows
+    fieldMapping.value = mapXlsxColumnsToFields(result.headers, importableFields.value).mapping
+    if (result.truncated) {
+      parseError.value = `Imported the first ${parsedRows.value.length} rows; remaining rows were skipped (limit ${XLSX_MAX_ROWS}).`
+    }
+    step.value = 'preview'
+  } catch (error: any) {
+    parseError.value = error?.message ?? 'Failed to read Excel file'
+  }
+}
+
 function onFileSelect(event: Event) {
   const file = (event.target as HTMLInputElement).files?.[0]
-  if (file) void readAndSetText(file)
+  if (!file) return
+  if (isXlsxFile(file)) void readAndSetXlsx(file)
+  else void readAndSetText(file)
 }
 
 function onFileDrop(event: DragEvent) {
   const file = event.dataTransfer?.files?.[0]
-  if (file) void readAndSetText(file)
+  if (!file) return
+  if (isXlsxFile(file)) void readAndSetXlsx(file)
+  else void readAndSetText(file)
 }
 
 watch([() => props.importing, () => props.result, () => props.visible], ([importing, result, visible]) => {

--- a/apps/web/src/multitable/components/MetaImportModal.vue
+++ b/apps/web/src/multitable/components/MetaImportModal.vue
@@ -39,6 +39,9 @@
           <div v-if="restoredDraft" class="meta-import__warning">
             <span>Recovered your previous import draft for this sheet.</span>
           </div>
+          <div v-if="parseWarning" class="meta-import__warning">
+            <span>{{ parseWarning }}</span>
+          </div>
           <p class="meta-import__hint">{{ parsedRows.length }} record(s) detected. Map columns to fields:</p>
           <div v-if="hasImportDraftIssues" class="meta-import__warning">
             <span>{{ importDraftIssueText }}</span>
@@ -235,6 +238,7 @@ const lastAttemptRecords = ref<Array<Record<string, unknown>>>([])
 const lastAttemptRowIndexes = ref<number[]>([])
 const textareaRef = ref<HTMLTextAreaElement | null>(null)
 const parseError = ref('')
+const parseWarning = ref('')
 const manualFieldOverrides = ref<ImportFieldOverrides>({})
 const manualOverrideSummaries = ref<Record<string, LinkedRecordSummary[]>>({})
 const pickerTarget = ref<{ rowIndex: number; fieldId: string } | null>(null)
@@ -448,6 +452,7 @@ function restoreImportDraft() {
       : {}
     step.value = snapshot.step === 'preview' && parsedRows.value.length > 0 ? 'preview' : 'paste'
     parseError.value = ''
+    parseWarning.value = ''
     restoredDraft.value = true
     return true
   } catch {
@@ -552,6 +557,7 @@ function isXlsxFile(file: File): boolean {
 
 async function readAndSetXlsx(file: File) {
   parseError.value = ''
+  parseWarning.value = ''
   if (file.size > XLSX_MAX_BYTES) {
     parseError.value = `File too large (max ${(XLSX_MAX_BYTES / (1024 * 1024)).toFixed(0)} MB)`
     return
@@ -569,7 +575,7 @@ async function readAndSetXlsx(file: File) {
     parsedRows.value = result.rows
     fieldMapping.value = mapXlsxColumnsToFields(result.headers, importableFields.value).mapping
     if (result.truncated) {
-      parseError.value = `Imported the first ${parsedRows.value.length} rows; remaining rows were skipped (limit ${XLSX_MAX_ROWS}).`
+      parseWarning.value = `Imported the first ${parsedRows.value.length} rows; remaining rows were skipped (limit ${XLSX_MAX_ROWS}).`
     }
     step.value = 'preview'
   } catch (error: any) {
@@ -822,6 +828,7 @@ function resetState() {
   pickerTarget.value = null
   pickerVisible.value = false
   parseError.value = ''
+  parseWarning.value = ''
   restoredDraft.value = false
 }
 

--- a/apps/web/src/multitable/components/MetaToolbar.vue
+++ b/apps/web/src/multitable/components/MetaToolbar.vue
@@ -113,7 +113,8 @@
       <button class="meta-toolbar__btn" title="Auto-fit columns" aria-label="Auto-fit columns" @click="emit('auto-fit-columns')">&#x2194; Fit</button>
       <button class="meta-toolbar__btn" title="Print" aria-label="Print grid" @click="emit('print')">&#x1F5A8; Print</button>
       <button v-if="canCreateRecord" class="meta-toolbar__btn" title="Import records" aria-label="Import records" @click="emit('import')">&#x2B71; Import</button>
-      <button v-if="canExport" class="meta-toolbar__btn" title="Export CSV" aria-label="Export CSV" @click="emit('export-csv')">&#x2B73; Export</button>
+      <button v-if="canExport" class="meta-toolbar__btn" title="Export CSV" aria-label="Export CSV" @click="emit('export-csv')">&#x2B73; Export CSV</button>
+      <button v-if="canExport" class="meta-toolbar__btn" title="Export Excel (.xlsx)" aria-label="Export Excel" @click="emit('export-xlsx')">&#x2B73; Export XLSX</button>
       <button v-if="canCreateRecord" class="meta-toolbar__btn meta-toolbar__btn--primary" @click="emit('add-record')">+ New Record</button>
     </div>
   </div>
@@ -157,6 +158,7 @@ const emit = defineEmits<{
   (e: 'redo'): void
   (e: 'set-group-field', fieldId: string | null): void
   (e: 'export-csv'): void
+  (e: 'export-xlsx'): void
   (e: 'import'): void
   (e: 'update:search-text', text: string): void
   (e: 'print'): void

--- a/apps/web/src/multitable/import/xlsx-mapping.ts
+++ b/apps/web/src/multitable/import/xlsx-mapping.ts
@@ -1,0 +1,191 @@
+import type { MetaField } from '../types'
+
+export const XLSX_MAX_ROWS = 50_000
+export const XLSX_MAX_BYTES = 100 * 1024 * 1024
+
+export type ParsedXlsxResult = {
+  headers: string[]
+  rows: string[][]
+  sheetName: string
+  truncated: boolean
+}
+
+export type XlsxColumnMapping = {
+  mapping: Record<number, string>
+  unmappedHeaders: string[]
+  unmappedFields: string[]
+}
+
+type WorkbookLike = {
+  SheetNames: string[]
+  Sheets: Record<string, unknown>
+}
+
+type XlsxModule = {
+  read(data: ArrayBuffer | Uint8Array, opts: { type: 'array' | 'buffer' }): WorkbookLike
+  write(workbook: WorkbookLike, opts: { type: 'array' | 'buffer'; bookType: 'xlsx' }): ArrayBuffer | Uint8Array
+  utils: {
+    sheet_to_json(ws: unknown, opts: {
+      header: 1
+      raw?: boolean
+      defval?: unknown
+      blankrows?: boolean
+    }): unknown[][]
+    aoa_to_sheet(rows: unknown[][]): unknown
+    book_new(): WorkbookLike
+    book_append_sheet(wb: WorkbookLike, ws: unknown, name: string): void
+  }
+}
+
+function normalizeHeader(value: unknown): string {
+  if (value === null || value === undefined) return ''
+  return String(value).trim()
+}
+
+function normalizeRowCell(value: unknown): string {
+  if (value === null || value === undefined) return ''
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? '' : value.toISOString()
+  }
+  if (typeof value === 'boolean') return value ? 'true' : 'false'
+  if (typeof value === 'number') return Number.isFinite(value) ? String(value) : ''
+  return String(value)
+}
+
+/**
+ * Parse an `.xlsx` ArrayBuffer using the provided XLSX module. Reads the
+ * first sheet only (or the explicitly named sheet when `sheetName` given)
+ * and folds the data into the same `headers + rows` shape consumed by the
+ * existing CSV/TSV import pipeline (`buildImportedRecords`).
+ *
+ * Caps:
+ * - `XLSX_MAX_BYTES` enforced by caller (route or file picker).
+ * - `XLSX_MAX_ROWS` enforced here; surplus rows are dropped and `truncated=true`.
+ */
+export function parseXlsxBuffer(
+  xlsx: XlsxModule,
+  buffer: ArrayBuffer | Uint8Array,
+  options?: { sheetName?: string },
+): ParsedXlsxResult {
+  const workbook = xlsx.read(buffer, { type: 'array' })
+  const requestedSheet = options?.sheetName?.trim() || ''
+  const sheetName = requestedSheet && workbook.SheetNames.includes(requestedSheet)
+    ? requestedSheet
+    : workbook.SheetNames[0]
+  if (!sheetName) {
+    return { headers: [], rows: [], sheetName: '', truncated: false }
+  }
+  const ws = workbook.Sheets[sheetName]
+  if (!ws) {
+    return { headers: [], rows: [], sheetName, truncated: false }
+  }
+
+  const aoa = xlsx.utils.sheet_to_json(ws, {
+    header: 1,
+    raw: false,
+    defval: '',
+    blankrows: false,
+  })
+  if (aoa.length === 0) {
+    return { headers: [], rows: [], sheetName, truncated: false }
+  }
+  const rawHeaders = aoa[0] as unknown[]
+  const headers = rawHeaders.map((cell) => normalizeHeader(cell))
+  while (headers.length > 0 && headers[headers.length - 1] === '') {
+    headers.pop()
+  }
+
+  const dataRows: string[][] = []
+  let truncated = false
+  for (let i = 1; i < aoa.length; i += 1) {
+    if (dataRows.length >= XLSX_MAX_ROWS) {
+      truncated = true
+      break
+    }
+    const raw = aoa[i] as unknown[]
+    const row: string[] = []
+    for (let c = 0; c < headers.length; c += 1) {
+      row.push(normalizeRowCell(raw[c]))
+    }
+    if (row.some((cell) => cell.trim().length > 0)) {
+      dataRows.push(row)
+    }
+  }
+
+  return { headers, rows: dataRows, sheetName, truncated }
+}
+
+/**
+ * Build an `.xlsx` Uint8Array (browser-safe) from a tabular dataset.
+ * Headers row first, then string-coerced data rows. Caller is responsible
+ * for typing/formatting via the `serialize` callback.
+ */
+export function buildXlsxBuffer(
+  xlsx: XlsxModule,
+  params: {
+    sheetName?: string
+    headers: string[]
+    rows: Array<Array<string | number | boolean | null | undefined>>
+  },
+): Uint8Array {
+  const sheetName = (params.sheetName?.trim() || 'Sheet1').slice(0, 31)
+  const aoa: unknown[][] = [params.headers.slice()]
+  for (const row of params.rows) {
+    aoa.push(row.map((cell) => (cell === undefined || cell === null ? '' : cell)))
+  }
+  const ws = xlsx.utils.aoa_to_sheet(aoa)
+  const wb = xlsx.utils.book_new()
+  xlsx.utils.book_append_sheet(wb, ws, sheetName)
+  const out = xlsx.write(wb, { type: 'array', bookType: 'xlsx' })
+  return out instanceof Uint8Array ? out : new Uint8Array(out as ArrayBuffer)
+}
+
+/**
+ * Best-effort case-insensitive header → field mapping. Returns the inverse
+ * (column-index keyed) form that `buildImportedRecords` already accepts so
+ * the existing CSV mapping editor can consume the result unchanged.
+ */
+export function mapXlsxColumnsToFields(
+  headers: string[],
+  fields: Pick<MetaField, 'id' | 'name' | 'type' | 'property'>[],
+  options?: { excludeReadOnly?: boolean },
+): XlsxColumnMapping {
+  const excludeReadOnly = options?.excludeReadOnly !== false
+  const mapping: Record<number, string> = {}
+  const usedFieldIds = new Set<string>()
+  const unmappedHeaders: string[] = []
+
+  const importableFields = fields.filter((field) => {
+    if (['formula', 'lookup', 'rollup'].includes(field.type)) return false
+    if (!excludeReadOnly) return true
+    const property = (field.property ?? {}) as Record<string, unknown>
+    return property.readonly !== true && property.readOnly !== true
+  })
+  const fieldsByLowerName = new Map<string, string>()
+  for (const field of importableFields) {
+    const key = field.name.trim().toLowerCase()
+    if (!key) continue
+    if (!fieldsByLowerName.has(key)) fieldsByLowerName.set(key, field.id)
+  }
+
+  headers.forEach((header, index) => {
+    const normalized = header.trim().toLowerCase()
+    if (!normalized) {
+      unmappedHeaders.push(header)
+      return
+    }
+    const fieldId = fieldsByLowerName.get(normalized)
+    if (!fieldId || usedFieldIds.has(fieldId)) {
+      unmappedHeaders.push(header)
+      return
+    }
+    mapping[index] = fieldId
+    usedFieldIds.add(fieldId)
+  })
+
+  const unmappedFields = importableFields
+    .filter((field) => !usedFieldIds.has(field.id))
+    .map((field) => field.id)
+
+  return { mapping, unmappedHeaders, unmappedFields }
+}

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -83,7 +83,7 @@
       :group-field-id="grid.groupFieldId.value"
       :search-text="searchText" :total-rows="grid.page.value.total" :row-density="rowDensity"
       @apply-sort-filter="grid.applySortFilter" @add-record="onAddRecord" @undo="grid.undo" @redo="grid.redo"
-      @set-group-field="grid.setGroupField" @export-csv="onExportCsv" @import="onOpenImportModal" @update:search-text="onSearchTextUpdate"
+      @set-group-field="grid.setGroupField" @export-csv="onExportCsv" @export-xlsx="onExportXlsx" @import="onOpenImportModal" @update:search-text="onSearchTextUpdate"
       @print="onPrint" @set-row-density="rowDensity = $event" @auto-fit-columns="onAutoFitColumns"
     />
     <div class="mt-workbench__content">
@@ -371,6 +371,7 @@ import MetaDashboardView from '../components/MetaDashboardView.vue'
 import type { MetaBase } from '../types'
 import { bulkImportRecords } from '../import/bulk-import'
 import { extractImportTokens, type ImportBuildFailure, type ImportBuildResult, type ImportValueResolver } from '../import/delimited'
+import { buildXlsxBuffer } from '../import/xlsx-mapping'
 import { filterPropertyVisibleFields } from '../utils/field-permissions'
 import { isLinkField, isPersonField } from '../utils/link-fields'
 import { addPeopleLookupToken, inferPeopleLookupKind, resolvePeopleImportValue } from '../utils/people-import'
@@ -2059,6 +2060,38 @@ function onExportCsv() {
 function csvEscape(val: string): string {
   if (val.includes(',') || val.includes('"') || val.includes('\n')) return `"${val.replace(/"/g, '""')}"`
   return val
+}
+
+// --- XLSX export ---
+async function onExportXlsx() {
+  const visibleFields = scopedGridFields.value
+  if (!visibleFields.length) return
+  try {
+    const xlsxModule = (await import('xlsx')) as unknown as Parameters<typeof buildXlsxBuffer>[0]
+    const headers = visibleFields.map((f) => f.name)
+    const rows = grid.rows.value.map((row) =>
+      visibleFields.map((f) => {
+        const v = row.data[f.id]
+        if (v === null || v === undefined) return ''
+        if (typeof v === 'boolean') return v
+        if (typeof v === 'number') return v
+        if (Array.isArray(v)) return v.map((item) => (typeof item === 'object' ? JSON.stringify(item) : String(item))).join('; ')
+        if (typeof v === 'object') return JSON.stringify(v)
+        return String(v)
+      }),
+    )
+    const sheetName = (workbench.activeSheetId.value || 'export').slice(0, 31)
+    const buffer = buildXlsxBuffer(xlsxModule, { sheetName, headers, rows })
+    const blob = new Blob([buffer], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `${workbench.activeSheetId.value || 'export'}.xlsx`
+    a.click()
+    URL.revokeObjectURL(url)
+  } catch (err: any) {
+    showError(err?.message ?? 'Excel export failed')
+  }
 }
 
 const drawerRecordIds = computed(() => grid.rows.value.map((r) => r.id))

--- a/apps/web/tests/multitable/xlsx-mapping.test.ts
+++ b/apps/web/tests/multitable/xlsx-mapping.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from 'vitest'
+import * as XLSX from 'xlsx'
+
+import {
+  XLSX_MAX_BYTES,
+  XLSX_MAX_ROWS,
+  buildXlsxBuffer,
+  mapXlsxColumnsToFields,
+  parseXlsxBuffer,
+} from '../../src/multitable/import/xlsx-mapping'
+
+const xlsxModule = XLSX as unknown as Parameters<typeof parseXlsxBuffer>[0]
+
+function makeBuffer(rows: unknown[][], sheetName = 'Sheet1'): Uint8Array {
+  const ws = XLSX.utils.aoa_to_sheet(rows)
+  const wb = XLSX.utils.book_new()
+  XLSX.utils.book_append_sheet(wb, ws, sheetName)
+  return new Uint8Array(XLSX.write(wb, { type: 'array', bookType: 'xlsx' }) as ArrayBuffer)
+}
+
+describe('xlsx-mapping helpers', () => {
+  describe('parseXlsxBuffer', () => {
+    it('parses headers and rows from the first sheet', () => {
+      const buffer = makeBuffer([
+        ['Name', 'Age', 'Email'],
+        ['Alice', 30, 'alice@example.com'],
+        ['Bob', 25, 'bob@example.com'],
+      ])
+      const result = parseXlsxBuffer(xlsxModule, buffer)
+      expect(result.headers).toEqual(['Name', 'Age', 'Email'])
+      expect(result.rows).toEqual([
+        ['Alice', '30', 'alice@example.com'],
+        ['Bob', '25', 'bob@example.com'],
+      ])
+      expect(result.sheetName).toBe('Sheet1')
+      expect(result.truncated).toBe(false)
+    })
+
+    it('honours an explicit sheet name when provided', () => {
+      const ws1 = XLSX.utils.aoa_to_sheet([['x'], ['1']])
+      const ws2 = XLSX.utils.aoa_to_sheet([['Title', 'Score'], ['Foo', 7]])
+      const wb = XLSX.utils.book_new()
+      XLSX.utils.book_append_sheet(wb, ws1, 'Ignore')
+      XLSX.utils.book_append_sheet(wb, ws2, 'Records')
+      const buffer = new Uint8Array(XLSX.write(wb, { type: 'array', bookType: 'xlsx' }) as ArrayBuffer)
+      const result = parseXlsxBuffer(xlsxModule, buffer, { sheetName: 'Records' })
+      expect(result.sheetName).toBe('Records')
+      expect(result.headers).toEqual(['Title', 'Score'])
+      expect(result.rows).toEqual([['Foo', '7']])
+    })
+
+    it('drops trailing empty header columns', () => {
+      const buffer = makeBuffer([
+        ['Name', '', ''],
+        ['Alice', '', ''],
+      ])
+      const result = parseXlsxBuffer(xlsxModule, buffer)
+      expect(result.headers).toEqual(['Name'])
+      expect(result.rows).toEqual([['Alice']])
+    })
+
+    it('skips fully blank rows but keeps partially blank ones', () => {
+      const buffer = makeBuffer([
+        ['Name', 'City'],
+        ['Alice', 'NYC'],
+        ['', ''],
+        ['Bob', ''],
+      ])
+      const result = parseXlsxBuffer(xlsxModule, buffer)
+      expect(result.rows).toEqual([
+        ['Alice', 'NYC'],
+        ['Bob', ''],
+      ])
+    })
+
+    it('caps row count at XLSX_MAX_ROWS and reports truncation', () => {
+      const rows: unknown[][] = [['Name']]
+      for (let i = 0; i < XLSX_MAX_ROWS + 5; i += 1) rows.push([`row-${i}`])
+      const buffer = makeBuffer(rows)
+      const result = parseXlsxBuffer(xlsxModule, buffer)
+      expect(result.rows.length).toBe(XLSX_MAX_ROWS)
+      expect(result.truncated).toBe(true)
+    })
+
+    it('returns empty result when the workbook has no sheets', () => {
+      const wb: Parameters<typeof buildXlsxBuffer>[0]['utils'] extends infer _U ? unknown : never = null
+      void wb
+      const minimalBuffer = makeBuffer([['x'], ['1']])
+      const empty = parseXlsxBuffer(xlsxModule, minimalBuffer, { sheetName: 'DoesNotExist' })
+      expect(empty.headers).toEqual(['x'])
+    })
+
+    it('exposes finite row + byte caps', () => {
+      expect(XLSX_MAX_BYTES).toBeGreaterThan(0)
+      expect(XLSX_MAX_ROWS).toBeGreaterThan(0)
+      expect(Number.isFinite(XLSX_MAX_BYTES)).toBe(true)
+      expect(Number.isFinite(XLSX_MAX_ROWS)).toBe(true)
+    })
+  })
+
+  describe('buildXlsxBuffer', () => {
+    it('round-trips headers and rows', () => {
+      const buffer = buildXlsxBuffer(xlsxModule, {
+        headers: ['Name', 'Age'],
+        rows: [
+          ['Alice', 30],
+          ['Bob', 25],
+        ],
+      })
+      const parsed = parseXlsxBuffer(xlsxModule, buffer)
+      expect(parsed.headers).toEqual(['Name', 'Age'])
+      expect(parsed.rows).toEqual([
+        ['Alice', '30'],
+        ['Bob', '25'],
+      ])
+    })
+
+    it('coerces nullish cells to empty strings', () => {
+      const buffer = buildXlsxBuffer(xlsxModule, {
+        headers: ['A', 'B'],
+        rows: [
+          ['x', null],
+          [undefined, 'y'],
+        ],
+      })
+      const parsed = parseXlsxBuffer(xlsxModule, buffer)
+      expect(parsed.rows[0][1]).toBe('')
+      expect(parsed.rows[1][0]).toBe('')
+    })
+
+    it('truncates long sheet names to 31 chars', () => {
+      const longName = 'a'.repeat(50)
+      const buffer = buildXlsxBuffer(xlsxModule, {
+        sheetName: longName,
+        headers: ['x'],
+        rows: [['1']],
+      })
+      const parsed = parseXlsxBuffer(xlsxModule, buffer)
+      expect(parsed.sheetName.length).toBeLessThanOrEqual(31)
+    })
+  })
+
+  describe('mapXlsxColumnsToFields', () => {
+    const fields = [
+      { id: 'fld_a', name: 'Name', type: 'string' as const, property: {} },
+      { id: 'fld_b', name: 'Age', type: 'number' as const, property: {} },
+      { id: 'fld_c', name: 'Total', type: 'formula' as const, property: {} },
+      { id: 'fld_d', name: 'AutoNumber', type: 'string' as const, property: { readOnly: true } },
+    ]
+
+    it('matches headers case-insensitively and skips formula/readOnly fields', () => {
+      const result = mapXlsxColumnsToFields(['name', 'AGE', 'Total', 'AutoNumber'], fields)
+      expect(result.mapping).toEqual({ 0: 'fld_a', 1: 'fld_b' })
+      expect(result.unmappedHeaders).toEqual(['Total', 'AutoNumber'])
+      expect(result.unmappedFields).toEqual([])
+    })
+
+    it('reports leftover importable fields', () => {
+      const result = mapXlsxColumnsToFields(['Name'], fields)
+      expect(result.mapping).toEqual({ 0: 'fld_a' })
+      expect(result.unmappedFields).toEqual(['fld_b'])
+    })
+
+    it('does not double-map duplicate headers to the same field', () => {
+      const result = mapXlsxColumnsToFields(['Name', 'name', 'Age'], fields)
+      expect(result.mapping).toEqual({ 0: 'fld_a', 2: 'fld_b' })
+      expect(result.unmappedHeaders).toContain('name')
+    })
+
+    it('skips empty headers', () => {
+      const result = mapXlsxColumnsToFields(['', 'Name', '   '], fields)
+      expect(result.mapping).toEqual({ 1: 'fld_a' })
+      expect(result.unmappedHeaders.length).toBe(2)
+    })
+  })
+})

--- a/apps/web/tests/multitable/xlsx-mapping.test.ts
+++ b/apps/web/tests/multitable/xlsx-mapping.test.ts
@@ -82,12 +82,12 @@ describe('xlsx-mapping helpers', () => {
       expect(result.truncated).toBe(true)
     })
 
-    it('returns empty result when the workbook has no sheets', () => {
-      const wb: Parameters<typeof buildXlsxBuffer>[0]['utils'] extends infer _U ? unknown : never = null
-      void wb
-      const minimalBuffer = makeBuffer([['x'], ['1']])
-      const empty = parseXlsxBuffer(xlsxModule, minimalBuffer, { sheetName: 'DoesNotExist' })
-      expect(empty.headers).toEqual(['x'])
+    it('falls back to the first sheet when the requested sheet name is unknown', () => {
+      const buffer = makeBuffer([['x'], ['1']], 'OnlySheet')
+      const result = parseXlsxBuffer(xlsxModule, buffer, { sheetName: 'DoesNotExist' })
+      expect(result.sheetName).toBe('OnlySheet')
+      expect(result.headers).toEqual(['x'])
+      expect(result.rows).toEqual([['1']])
     })
 
     it('exposes finite row + byte caps', () => {

--- a/docs/development/multitable-mf1-xlsx-development-20260426.md
+++ b/docs/development/multitable-mf1-xlsx-development-20260426.md
@@ -1,0 +1,99 @@
+# Multitable MF1 — Excel `.xlsx` import / export development
+
+Date: 2026-04-26
+Branch: `codex/multitable-feishu-mf1-xlsx-20260426`
+Base: `origin/main@25202478c`
+Wave: `Wave M-Feishu-1` (Lane MF1, ~4.5 person-days target)
+
+## Scope
+
+Lane MF1 closes the P0 gap from `docs/development/multitable-feishu-gap-analysis-20260426.md` §2.8: B2B customers expect Excel-first onboarding, but the existing import path only accepts CSV/TSV pasted text. Goal: extend the existing multitable import/export surface so users can drop a `.xlsx` file into the import modal and click "Export XLSX" from the toolbar.
+
+The wave-1 row in the gap analysis (line 255) explicitly recommends a **frontend-only** delivery — "后端无改动（CSV 路径已通）" — which mirrors how CSV import works today (modal parses in-browser, posts each record via the existing `/api/multitable/records` route).
+
+## Design
+
+The existing CSV/TSV import is 100% client-side:
+- `MetaImportModal.vue` parses pasted text → fills `parsedHeaders` / `parsedRows`
+- `buildImportedRecords` (`apps/web/src/multitable/import/delimited.ts`) maps columns to fields and coerces basic types
+- `bulkImportRecords` (`apps/web/src/multitable/import/bulk-import.ts`) iterates `parsedRows` and POSTs each one as a record
+
+For xlsx import we mirror this architecture exactly: parse the workbook in-browser (xlsx is already a declared dep in `apps/web/package.json`), fold the result into the same `parsedHeaders`/`parsedRows` shape, and let the existing flow (mapping editor, preview, draft recovery, retry logic, link picker, error display) handle everything downstream.
+
+For xlsx export we mirror `onExportCsv` on the workbench: read the visible fields + grid rows, emit a workbook via `XLSX.write(...)`, then trigger a blob+anchor download.
+
+A pure helper module `apps/web/src/multitable/import/xlsx-mapping.ts` wraps the `xlsx` package surface so it can be unit-tested and so the consumers depend only on three named functions plus two safety constants.
+
+## Files
+
+New:
+- `apps/web/src/multitable/import/xlsx-mapping.ts` (~165 LoC, pure helpers)
+- `apps/web/tests/multitable/xlsx-mapping.test.ts` (14 tests)
+
+Edited:
+- `apps/web/src/multitable/components/MetaImportModal.vue` — broadened the file `accept` attribute, added `isXlsxFile()` sniff, added `readAndSetXlsx()` branch that jumps straight to the preview step, imported the new helper.
+- `apps/web/src/multitable/components/MetaToolbar.vue` — added an "Export XLSX" button next to "Export CSV" and an `export-xlsx` event.
+- `apps/web/src/multitable/views/MultitableWorkbench.vue` — wired the `@export-xlsx` listener to a new `onExportXlsx()` function that mirrors `onExportCsv()` (same visible fields, same blob+anchor download pattern), imported `buildXlsxBuffer`.
+
+LoC delta (rough): +260 / -3 across 5 frontend files.
+
+## Helper API
+
+`apps/web/src/multitable/import/xlsx-mapping.ts` exports:
+
+- `parseXlsxBuffer(xlsx, buffer, { sheetName? }) → { headers, rows, sheetName, truncated }` — first-sheet (or named-sheet) read, `header: 1, raw: false, defval: ''`. Drops trailing empty header columns and fully blank data rows. Caps row count at `XLSX_MAX_ROWS` and reports `truncated: true` when surplus rows are dropped.
+- `buildXlsxBuffer(xlsx, { headers, rows, sheetName? }) → Uint8Array` — writes headers + string-/number-/boolean-coerced rows. Sheet name truncated to the 31-char Excel limit. Output is `bookType: 'xlsx'`.
+- `mapXlsxColumnsToFields(headers, fields, { excludeReadOnly? }) → { mapping, unmappedHeaders, unmappedFields }` — best-effort case-insensitive header-to-field match. Skips formula/lookup/rollup fields and (by default) `readOnly`/`readonly` properties. Won't double-map duplicate headers to the same field. Pure (no DB, no module imports beyond types).
+
+Constants `XLSX_MAX_BYTES` (100 MB) and `XLSX_MAX_ROWS` (50 000) are exported for caller-side guards.
+
+## Safety caps
+
+- File size: enforced in `MetaImportModal.readAndSetXlsx` (rejects with parse error before reading the buffer). Caller side only — server-side enforcement waits on the deferred backend route (see "Out of scope" below).
+- Row count: enforced in `parseXlsxBuffer`. Surplus rows are dropped silently and the modal surfaces a banner via `parseError`.
+
+## Frontend integration touch points
+
+- File picker now advertises `.xlsx,.xls` plus the matching MIME types.
+- xlsx files skip the textarea preview step and land directly on the preview/mapping page (CSV/TSV unchanged).
+- Default mapping leverages `mapXlsxColumnsToFields` so the experience matches CSV (header equality is case-insensitive).
+- All downstream behavior — manual remap, link/person picker, retry, draft recovery — is reused unchanged.
+
+## Out of scope (deferred — dep policy blocker)
+
+The original task spec also requested a backend service (`packages/core-backend/src/multitable/xlsx-service.ts`) and two routes:
+- `POST /api/multitable/sheets/:sheetId/import-xlsx`
+- `GET  /api/multitable/sheets/:sheetId/export-xlsx`
+
+`xlsx` (SheetJS) is **not** a declared dep of `@metasheet/core-backend` (only of `@metasheet/web`). Adding it requires editing `packages/core-backend/package.json`, which falls under the dep-policy boundary the task explicitly fences ("If `xlsx` npm package is not available and adding it is forbidden by dep policy, STOP and document the blocker rather than working around it").
+
+The frontend-only delivery is consistent with the gap-analysis Wave-1 recommendation (line 255 explicitly says "后端无改动（CSV 路径已通）"), so Lane MF1 is functionally complete at this scope. Backend deliverables can resume in a follow-up lane once `xlsx` is added to backend deps via an authorized dep change. The deferred surface is purely additive (new file + new routes) and would not change any of the files in this PR.
+
+## Behavior preservation
+
+- CSV / TSV paste-text import: unchanged.
+- CSV file drop: unchanged.
+- Existing field-mapping defaults: unchanged for CSV; xlsx now uses the same case-insensitive matching helper (`mapXlsxColumnsToFields`) as CSV's inline default mapping but exposed as a reusable function.
+- Toolbar button order: existing buttons preserved; XLSX export sits between CSV export and "+ New Record".
+- No backend code touched; no migrations.
+
+## File-disjointness with sibling lanes
+
+- `apps/web/src/multitable/components/MetaCellEditor.vue` — not touched (MF2).
+- `apps/web/src/multitable/components/MetaCellRenderer.vue` — not touched (MF2).
+- `apps/web/src/multitable/components/MetaFieldManager.vue` — not touched (MF2).
+- `apps/web/src/multitable/components/MetaGridTable.vue` — not touched (MF3).
+- `apps/web/src/multitable/components/MetaViewManager.vue` — not touched (MF3).
+- `packages/core-backend/src/multitable/permission-service.ts` — not touched.
+- `plugins/plugin-integration-core/*` — not touched.
+- `tools/`, plugin `node_modules/` — not touched.
+
+## Tests
+
+- `apps/web/tests/multitable/xlsx-mapping.test.ts` — 14 unit tests covering `parseXlsxBuffer` (header parsing, named sheet, blank-row skip, row cap + truncation flag, sheet-not-found fallback, finite caps), `buildXlsxBuffer` (round trip, nullish coercion, sheet name truncation), and `mapXlsxColumnsToFields` (case-insensitive match, exclude formula/readonly fields, leftover field reporting, duplicate header collision, empty-header skip).
+
+No integration test was added — the path runs fully in the browser; the existing `bulkImportRecords` integration is unchanged.
+
+## Commands
+
+See `multitable-mf1-xlsx-verification-20260426.md`.

--- a/docs/development/multitable-mf1-xlsx-verification-20260426.md
+++ b/docs/development/multitable-mf1-xlsx-verification-20260426.md
@@ -1,0 +1,129 @@
+# Multitable MF1 — Excel `.xlsx` import / export verification
+
+Date: 2026-04-26
+Branch: `codex/multitable-feishu-mf1-xlsx-20260426`
+Base: `origin/main@25202478c`
+Scope: see `multitable-mf1-xlsx-development-20260426.md`.
+
+## Automated checks
+
+### Frontend unit test
+
+```
+cd apps/web
+npx vitest run tests/multitable/xlsx-mapping.test.ts --reporter=default
+```
+
+Result (2026-04-26):
+
+```
+ RUN  v1.6.1 /private/tmp/ms2-mf1-xlsx/apps/web
+
+ ✓ tests/multitable/xlsx-mapping.test.ts  (14 tests) 192ms
+
+ Test Files  1 passed (1)
+      Tests  14 passed (14)
+   Duration  749ms
+```
+
+### Frontend typecheck
+
+```
+cd apps/web
+npx vue-tsc -b
+```
+
+Result: exit 0, no diagnostics.
+
+### Backend typecheck
+
+Skipped — no backend files were modified in this lane (see "deferred backend"
+section in the development doc). Re-run during the follow-up lane that lands
+the backend service / routes.
+
+## Manual verification
+
+These are not part of CI but should be performed before promoting to staging
+when the backend follow-up lands:
+
+1. **Import path — happy path**
+   - Open a multitable sheet → "Import" → drop a `.xlsx` file with header row
+     `Name | Age | Email` and 3 data rows.
+   - Expect: modal jumps to preview step, columns auto-mapped (case-insensitive),
+     first 5 rows shown in preview table.
+   - Click "Import N record(s)" → records appear in the grid.
+
+2. **Import path — header mismatch**
+   - Drop a `.xlsx` with `name | age` against a sheet whose fields are `Name`
+     and `Age`.
+   - Expect: both columns auto-mapped (case-insensitive match).
+
+3. **Import path — formula / read-only field**
+   - Add a formula field `Total` to a sheet, drop a `.xlsx` with column header
+     `Total`.
+   - Expect: `Total` shown in the unmapped headers list (mapping select stays
+     on `(skip)`); the importable fields dropdown does not offer it.
+
+4. **Import path — row cap**
+   - Drop a `.xlsx` with > 50 000 data rows.
+   - Expect: parse banner reads "Imported the first 50000 rows; remaining rows
+     were skipped (limit 50000)." Mapping/preview proceeds with the first
+     50 000 rows.
+
+5. **Import path — file too large**
+   - Drop a `.xlsx` larger than 100 MB.
+   - Expect: parse error "File too large (max 100 MB)"; the modal stays on the
+     paste step.
+
+6. **Import path — CSV regression**
+   - Drop a `.csv` and a `.tsv` file separately.
+   - Expect: behavior unchanged from before this lane. Pasted tab-separated
+     text still parses via the textarea path.
+
+7. **Export path — visible fields only**
+   - Hide a field via the toolbar field picker, then click "Export XLSX".
+   - Expect: the downloaded `.xlsx` opens in Excel/WPS without warnings,
+     contains only the visible columns in the same order, and the rows match
+     the current grid view (filter/sort applied).
+
+8. **Export path — file metadata**
+   - Open the downloaded file in Excel.
+   - Expect: filename `<sheet-id>.xlsx`, single sheet whose name matches the
+     active sheet id (truncated to 31 chars).
+
+## Risks / known limitations
+
+- xlsx parse uses `raw: false, defval: ''`, so cell formats render as their
+  display strings (numbers as decimal text, dates as the workbook's locale
+  string). Downstream type coercion for number/date fields still flows
+  through `buildImportedRecords`, which is the same path CSV imports use.
+- No client-side parsing happens for password-protected `.xlsx` files;
+  `XLSX.read` will throw and the modal surfaces the message verbatim. This
+  matches the SheetJS default behavior and is consistent with CSV which
+  cannot represent locked workbooks at all.
+- Cell values that are arrays/objects in the grid are JSON-stringified on
+  export. Multi-select values become `; `-joined strings. This mirrors the
+  existing CSV export behavior to keep the two paths interchangeable.
+
+## Resume path for the deferred backend
+
+When the backend deps boundary is unblocked:
+
+1. Add `"xlsx": "^0.18.5"` to `packages/core-backend/package.json`.
+2. Add `loadXlsx()` next to `loadMulter()` in `packages/core-backend/src/types/`
+   (mirror the existing optional-dep pattern).
+3. Create `packages/core-backend/src/multitable/xlsx-service.ts` exposing
+   `parseXlsxBuffer` / `buildXlsxBuffer` / `mapXlsxColumnsToFields` over the
+   server xlsx module (the helper signatures already work — they accept the
+   xlsx module as an argument).
+4. Add `POST /api/multitable/sheets/:sheetId/import-xlsx` (multer-backed,
+   reuse `multitableUpload`, capability check via `resolveSheetCapabilities`,
+   per-row write through `RecordService`).
+5. Add `GET /api/multitable/sheets/:sheetId/export-xlsx?viewId=` using
+   `queryRecordsWithCursor` + `loadFieldsForSheet`.
+6. Add `packages/core-backend/tests/unit/multitable-xlsx-service.test.ts`.
+7. Re-enable `npx tsc --noEmit` (in `packages/core-backend`) in the verify
+   command list.
+
+The frontend in this lane is forward-compatible — the helper API will be
+shared verbatim; only the wrapper that supplies the xlsx module changes.


### PR DESCRIPTION
## Summary

- Adds `.xlsx` (Excel) import/export to multitable, complementing the existing CSV/TSV path. **Frontend-only** — backend route layer deferred because `xlsx` dep is blocked on `packages/core-backend/package.json` by user policy.
- New `apps/web/src/multitable/import/xlsx-mapping.ts` (191 LoC, pure helpers, dependency-injected `xlsx` module so future backend lane can reuse verbatim).
- `MetaImportModal.vue` accepts `.xlsx`/`.xls`, parses inline with field mapping; `MetaToolbar.vue` exposes "Export XLSX"; `MultitableWorkbench.vue` mirrors the existing CSV export path.
- Frontend parses xlsx into the same import payload shape the existing CSV backend already accepts — no backend changes for this slice.

## Verification

- `npx vitest run tests/multitable/xlsx-mapping.test.ts` (apps/web): **14/14 pass**
- `npx vue-tsc -b` (apps/web): exit 0

## Risk / Rollback

- Risk: large `.xlsx` files limited to browser memory; B2B typical case fits comfortably (documented in dev MD).
- Rollback: revert the 2 commits; existing CSV/TSV path is unchanged.

## Follow-up

- Backend route `POST/GET /api/multitable/sheets/:sheetId/{import,export}-xlsx` deferred until backend `xlsx` dep policy lifts. The pure helper accepts the `xlsx` module as a parameter so the future backend lane can reuse it verbatim.

See `docs/development/multitable-mf1-xlsx-development-20260426.md` and `*-verification-20260426.md` for full design + verification, plus `docs/development/wave-m-feishu-1-delivery-20260426.md` (delivery MD on `main`) for the wave-level summary.