### PR TITLE
feat(multitable): add conditional formatting rules (MF3)

### DIFF
--- a/apps/web/src/multitable/components/ConditionalFormattingDialog.vue
+++ b/apps/web/src/multitable/components/ConditionalFormattingDialog.vue
@@ -177,7 +177,7 @@ const PALETTE = [
 ] as const
 
 const draftRules = ref<ConditionalFormattingRule[]>([])
-const baseline = ref('')
+const baseline = ref('[]')
 
 function snapshot(rules: ConditionalFormattingRule[]): string {
   return JSON.stringify(rules)
@@ -201,7 +201,7 @@ watch(() => props.viewConfig, () => {
   if (props.visible) hydrate()
 })
 
-const dirty = computed(() => snapshot(draftRules.value) !== baseline.value)
+const dirty = computed(() => props.visible && snapshot(draftRules.value) !== baseline.value)
 
 watch(dirty, (value) => emit('update:dirty', value), { immediate: true })
 

--- a/apps/web/src/multitable/components/ConditionalFormattingDialog.vue
+++ b/apps/web/src/multitable/components/ConditionalFormattingDialog.vue
@@ -1,0 +1,421 @@
+<template>
+  <div v-if="visible" class="cf-dlg__overlay" @click.self="close">
+    <div class="cf-dlg" role="dialog" aria-label="Conditional formatting rules">
+      <div class="cf-dlg__header">
+        <h4 class="cf-dlg__title">Conditional formatting</h4>
+        <span class="cf-dlg__count">{{ draftRules.length }} / {{ ruleLimit }}</span>
+        <button class="cf-dlg__close" aria-label="Close" @click="close">&times;</button>
+      </div>
+      <div class="cf-dlg__body">
+        <p v-if="!draftRules.length" class="cf-dlg__empty">
+          No rules yet. Add a rule to color cells or rows based on field values.
+        </p>
+        <div v-else class="cf-dlg__rule-list">
+          <div
+            v-for="(rule, index) in draftRules"
+            :key="rule.id"
+            class="cf-dlg__rule"
+            :class="{ 'cf-dlg__rule--disabled': !rule.enabled }"
+          >
+            <div class="cf-dlg__rule-row">
+              <span class="cf-dlg__rule-index">{{ index + 1 }}.</span>
+              <select v-model="rule.fieldId" class="cf-dlg__select" @change="onFieldChanged(rule)">
+                <option v-for="field in selectableFields" :key="field.id" :value="field.id">{{ field.name }}</option>
+              </select>
+              <select v-model="rule.operator" class="cf-dlg__select" @change="onOperatorChanged(rule)">
+                <option
+                  v-for="op in operatorsForField(rule.fieldId)"
+                  :key="op.value"
+                  :value="op.value"
+                >{{ op.label }}</option>
+              </select>
+              <template v-if="operatorRequiresValue(rule.operator)">
+                <template v-if="rule.operator === 'between'">
+                  <input
+                    type="number"
+                    class="cf-dlg__input cf-dlg__input--mini"
+                    :value="getBetweenValue(rule, 0)"
+                    @input="setBetweenValue(rule, 0, ($event.target as HTMLInputElement).value)"
+                    placeholder="min"
+                  />
+                  <span class="cf-dlg__sep">–</span>
+                  <input
+                    type="number"
+                    class="cf-dlg__input cf-dlg__input--mini"
+                    :value="getBetweenValue(rule, 1)"
+                    @input="setBetweenValue(rule, 1, ($event.target as HTMLInputElement).value)"
+                    placeholder="max"
+                  />
+                </template>
+                <template v-else-if="isSelectField(rule.fieldId)">
+                  <select v-model="rule.value" class="cf-dlg__select cf-dlg__select--value">
+                    <option value="">(pick)</option>
+                    <option
+                      v-for="opt in selectOptionsFor(rule.fieldId)"
+                      :key="opt.value"
+                      :value="opt.value"
+                    >{{ opt.value }}</option>
+                  </select>
+                </template>
+                <template v-else-if="isNumberOperator(rule.operator)">
+                  <input
+                    type="number"
+                    class="cf-dlg__input"
+                    :value="rule.value"
+                    @input="rule.value = ($event.target as HTMLInputElement).valueAsNumber"
+                  />
+                </template>
+                <template v-else>
+                  <input
+                    type="text"
+                    class="cf-dlg__input"
+                    :value="rule.value as string ?? ''"
+                    @input="rule.value = ($event.target as HTMLInputElement).value"
+                  />
+                </template>
+              </template>
+              <span v-else class="cf-dlg__no-value">—</span>
+            </div>
+            <div class="cf-dlg__rule-row cf-dlg__rule-row--secondary">
+              <span class="cf-dlg__label">Color</span>
+              <div class="cf-dlg__palette">
+                <button
+                  v-for="preset in PALETTE"
+                  :key="preset"
+                  type="button"
+                  class="cf-dlg__swatch"
+                  :class="{ 'cf-dlg__swatch--active': rule.style.backgroundColor === preset }"
+                  :style="{ backgroundColor: preset }"
+                  :aria-label="`Pick color ${preset}`"
+                  @click="rule.style.backgroundColor = preset"
+                />
+                <input
+                  type="text"
+                  class="cf-dlg__hex"
+                  :value="rule.style.backgroundColor ?? ''"
+                  @input="updateHex(rule, 'backgroundColor', ($event.target as HTMLInputElement).value)"
+                  placeholder="#RRGGBB"
+                  maxlength="7"
+                />
+              </div>
+              <label class="cf-dlg__check-inline">
+                <input type="checkbox" :checked="rule.style.applyToRow === true" @change="rule.style.applyToRow = ($event.target as HTMLInputElement).checked" />
+                <span>Apply to whole row</span>
+              </label>
+              <label class="cf-dlg__check-inline">
+                <input type="checkbox" :checked="rule.enabled" @change="rule.enabled = ($event.target as HTMLInputElement).checked" />
+                <span>Enabled</span>
+              </label>
+            </div>
+            <div class="cf-dlg__rule-row cf-dlg__rule-row--actions">
+              <button
+                type="button"
+                class="cf-dlg__btn cf-dlg__btn--ghost"
+                :disabled="index === 0"
+                @click="moveRule(index, -1)"
+              >&#x25B2; Up</button>
+              <button
+                type="button"
+                class="cf-dlg__btn cf-dlg__btn--ghost"
+                :disabled="index === draftRules.length - 1"
+                @click="moveRule(index, 1)"
+              >&#x25BC; Down</button>
+              <button type="button" class="cf-dlg__btn cf-dlg__btn--danger" @click="removeRule(index)">Remove</button>
+            </div>
+          </div>
+        </div>
+        <button
+          type="button"
+          class="cf-dlg__btn cf-dlg__btn--primary"
+          :disabled="draftRules.length >= ruleLimit || !selectableFields.length"
+          @click="addRule"
+        >+ Add rule</button>
+        <p v-if="!selectableFields.length" class="cf-dlg__hint">Add fields to the sheet to create formatting rules.</p>
+      </div>
+      <div class="cf-dlg__footer">
+        <button type="button" class="cf-dlg__btn" @click="close">Cancel</button>
+        <button type="button" class="cf-dlg__btn cf-dlg__btn--primary" :disabled="!dirty" @click="save">Save rules</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, reactive, ref, watch } from 'vue'
+import type {
+  ConditionalFormattingOperator,
+  ConditionalFormattingRule,
+  MetaField,
+} from '../types'
+import { CONDITIONAL_FORMATTING_RULE_LIMIT } from '../types'
+import { extractRulesFromConfig, operatorRequiresValue } from '../utils/conditional-formatting'
+
+const props = defineProps<{
+  visible: boolean
+  fields: MetaField[]
+  /** Current view config; rules are read from `config.conditionalFormattingRules`. */
+  viewConfig?: Record<string, unknown>
+}>()
+
+const emit = defineEmits<{
+  (e: 'close'): void
+  (e: 'save', rules: ConditionalFormattingRule[]): void
+  (e: 'update:dirty', dirty: boolean): void
+}>()
+
+const ruleLimit = CONDITIONAL_FORMATTING_RULE_LIMIT
+
+const PALETTE = [
+  '#fce4e4',
+  '#fff4d6',
+  '#e0f3d8',
+  '#d6ebff',
+  '#e2dafc',
+  '#fde2f3',
+  '#f5f5f5',
+  '#1f2937',
+] as const
+
+const draftRules = ref<ConditionalFormattingRule[]>([])
+const baseline = ref('')
+
+function snapshot(rules: ConditionalFormattingRule[]): string {
+  return JSON.stringify(rules)
+}
+
+function hydrate() {
+  const initial = extractRulesFromConfig(props.viewConfig).map((rule, index) => ({
+    ...rule,
+    order: index,
+    style: { ...rule.style },
+  }))
+  draftRules.value = reactive(initial) as ConditionalFormattingRule[]
+  baseline.value = snapshot(draftRules.value)
+}
+
+watch(() => props.visible, (visible) => {
+  if (visible) hydrate()
+}, { immediate: true })
+
+watch(() => props.viewConfig, () => {
+  if (props.visible) hydrate()
+})
+
+const dirty = computed(() => snapshot(draftRules.value) !== baseline.value)
+
+watch(dirty, (value) => emit('update:dirty', value), { immediate: true })
+
+const fieldsById = computed(() => {
+  const map = new Map<string, MetaField>()
+  for (const field of props.fields) map.set(field.id, field)
+  return map
+})
+
+const selectableFields = computed(() => props.fields)
+
+function isSelectField(fieldId: string): boolean {
+  return fieldsById.value.get(fieldId)?.type === 'select'
+}
+
+function isDateField(fieldId: string): boolean {
+  return fieldsById.value.get(fieldId)?.type === 'date'
+}
+
+function isNumberField(fieldId: string): boolean {
+  return fieldsById.value.get(fieldId)?.type === 'number'
+}
+
+function isBooleanField(fieldId: string): boolean {
+  return fieldsById.value.get(fieldId)?.type === 'boolean'
+}
+
+function isNumberOperator(op: ConditionalFormattingOperator): boolean {
+  return op === 'gt' || op === 'gte' || op === 'lt' || op === 'lte'
+}
+
+function operatorsForField(fieldId: string): Array<{ value: ConditionalFormattingOperator; label: string }> {
+  const baseEmpty = [
+    { value: 'is_empty' as const, label: 'is empty' },
+    { value: 'is_not_empty' as const, label: 'is not empty' },
+  ]
+  if (isNumberField(fieldId)) {
+    return [
+      { value: 'gt', label: '>' },
+      { value: 'gte', label: '>=' },
+      { value: 'lt', label: '<' },
+      { value: 'lte', label: '<=' },
+      { value: 'eq', label: '=' },
+      { value: 'neq', label: '!=' },
+      { value: 'between', label: 'between' },
+      ...baseEmpty,
+    ]
+  }
+  if (isDateField(fieldId)) {
+    return [
+      { value: 'is_today', label: 'is today' },
+      { value: 'is_overdue', label: 'is overdue' },
+      { value: 'is_in_last_n_days', label: 'is in last N days' },
+      { value: 'is_in_next_n_days', label: 'is in next N days' },
+      ...baseEmpty,
+    ]
+  }
+  if (isBooleanField(fieldId)) {
+    return [
+      { value: 'is_true', label: 'is checked' },
+      { value: 'is_false', label: 'is unchecked' },
+      ...baseEmpty,
+    ]
+  }
+  if (isSelectField(fieldId)) {
+    return [
+      { value: 'eq', label: 'is' },
+      { value: 'neq', label: 'is not' },
+      { value: 'contains', label: 'contains' },
+      ...baseEmpty,
+    ]
+  }
+  return [
+    { value: 'eq', label: '=' },
+    { value: 'neq', label: '!=' },
+    { value: 'contains', label: 'contains' },
+    { value: 'not_contains', label: 'does not contain' },
+    ...baseEmpty,
+  ]
+}
+
+function defaultOperatorFor(fieldId: string): ConditionalFormattingOperator {
+  return operatorsForField(fieldId)[0]?.value ?? 'eq'
+}
+
+function defaultValueFor(operator: ConditionalFormattingOperator): unknown {
+  if (operator === 'between') return [0, 0]
+  if (operator === 'is_in_last_n_days' || operator === 'is_in_next_n_days') return 7
+  if (!operatorRequiresValue(operator)) return undefined
+  return ''
+}
+
+function selectOptionsFor(fieldId: string): Array<{ value: string }> {
+  const field = fieldsById.value.get(fieldId)
+  return field?.options ?? []
+}
+
+function onFieldChanged(rule: ConditionalFormattingRule) {
+  rule.operator = defaultOperatorFor(rule.fieldId)
+  rule.value = defaultValueFor(rule.operator)
+}
+
+function onOperatorChanged(rule: ConditionalFormattingRule) {
+  rule.value = defaultValueFor(rule.operator)
+}
+
+function addRule() {
+  const firstField = props.fields[0]
+  if (!firstField) return
+  const operator = defaultOperatorFor(firstField.id)
+  draftRules.value.push({
+    id: typeof crypto !== 'undefined' && 'randomUUID' in crypto
+      ? `cfr_${crypto.randomUUID()}`
+      : `cfr_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+    order: draftRules.value.length,
+    fieldId: firstField.id,
+    operator,
+    value: defaultValueFor(operator),
+    style: { backgroundColor: PALETTE[0] },
+    enabled: true,
+  } as ConditionalFormattingRule)
+}
+
+function removeRule(index: number) {
+  draftRules.value.splice(index, 1)
+  reorderInPlace()
+}
+
+function moveRule(index: number, direction: -1 | 1) {
+  const target = index + direction
+  if (target < 0 || target >= draftRules.value.length) return
+  const tmp = draftRules.value[index]
+  draftRules.value[index] = draftRules.value[target]
+  draftRules.value[target] = tmp
+  reorderInPlace()
+}
+
+function reorderInPlace() {
+  draftRules.value.forEach((rule, idx) => { rule.order = idx })
+}
+
+function getBetweenValue(rule: ConditionalFormattingRule, i: 0 | 1): number | string {
+  if (Array.isArray(rule.value) && rule.value.length === 2) {
+    const v = rule.value[i]
+    if (typeof v === 'number' && Number.isFinite(v)) return v
+    if (typeof v === 'string' || typeof v === 'number') return v
+  }
+  return ''
+}
+
+function setBetweenValue(rule: ConditionalFormattingRule, i: 0 | 1, value: string) {
+  const next = Array.isArray(rule.value) && rule.value.length === 2
+    ? [...(rule.value as unknown[])]
+    : [0, 0]
+  const parsed = Number(value)
+  next[i] = Number.isFinite(parsed) ? parsed : 0
+  rule.value = next
+}
+
+function updateHex(rule: ConditionalFormattingRule, key: 'backgroundColor' | 'textColor', value: string) {
+  rule.style[key] = value || undefined
+}
+
+function close() {
+  if (dirty.value && !window.confirm('Discard unsaved formatting rules?')) return
+  emit('close')
+}
+
+function save() {
+  reorderInPlace()
+  const cloned = draftRules.value.map((rule) => ({
+    ...rule,
+    style: { ...rule.style },
+    value: Array.isArray(rule.value) ? [...(rule.value as unknown[])] : rule.value,
+  }))
+  emit('save', cloned as ConditionalFormattingRule[])
+}
+</script>
+
+<style scoped>
+.cf-dlg__overlay { position: fixed; inset: 0; background: rgba(0,0,0,.35); z-index: 110; display: flex; align-items: center; justify-content: center; }
+.cf-dlg { width: 720px; max-height: 85vh; background: #fff; border-radius: 8px; box-shadow: 0 8px 24px rgba(0,0,0,.18); display: flex; flex-direction: column; }
+.cf-dlg__header { display: flex; align-items: center; gap: 12px; padding: 12px 16px; border-bottom: 1px solid #eee; }
+.cf-dlg__title { flex: 1; font-size: 15px; font-weight: 600; margin: 0; }
+.cf-dlg__count { font-size: 12px; color: #666; }
+.cf-dlg__close { border: none; background: none; font-size: 20px; cursor: pointer; color: #999; padding: 0 4px; }
+.cf-dlg__body { flex: 1; overflow-y: auto; padding: 12px 16px; display: flex; flex-direction: column; gap: 12px; }
+.cf-dlg__empty { font-size: 13px; color: #777; margin: 0; }
+.cf-dlg__rule-list { display: flex; flex-direction: column; gap: 10px; }
+.cf-dlg__rule { border: 1px solid #e5e7eb; border-radius: 6px; padding: 10px; background: #fafafa; display: flex; flex-direction: column; gap: 6px; }
+.cf-dlg__rule--disabled { opacity: 0.55; }
+.cf-dlg__rule-row { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.cf-dlg__rule-row--secondary { gap: 12px; }
+.cf-dlg__rule-row--actions { justify-content: flex-end; }
+.cf-dlg__rule-index { font-weight: 600; font-size: 12px; color: #666; min-width: 18px; }
+.cf-dlg__select, .cf-dlg__input { padding: 4px 8px; border: 1px solid #d0d5dc; border-radius: 4px; font-size: 12px; background: #fff; }
+.cf-dlg__select--value { min-width: 120px; }
+.cf-dlg__input--mini { width: 80px; }
+.cf-dlg__sep { color: #888; font-size: 12px; }
+.cf-dlg__no-value { color: #aaa; font-size: 12px; }
+.cf-dlg__label { font-size: 12px; color: #555; }
+.cf-dlg__palette { display: flex; align-items: center; gap: 6px; }
+.cf-dlg__swatch { width: 22px; height: 22px; border-radius: 4px; border: 1px solid #d0d5dc; cursor: pointer; padding: 0; }
+.cf-dlg__swatch--active { box-shadow: 0 0 0 2px #1d4ed8; }
+.cf-dlg__hex { width: 90px; padding: 3px 6px; border: 1px solid #d0d5dc; border-radius: 4px; font-size: 12px; }
+.cf-dlg__check-inline { display: flex; align-items: center; gap: 4px; font-size: 12px; color: #444; cursor: pointer; }
+.cf-dlg__btn { padding: 5px 12px; border: 1px solid #d0d5dc; border-radius: 4px; background: #fff; cursor: pointer; font-size: 12px; color: #333; }
+.cf-dlg__btn:hover:not(:disabled) { background: #f3f4f6; }
+.cf-dlg__btn:disabled { opacity: 0.4; cursor: not-allowed; }
+.cf-dlg__btn--primary { background: #2563eb; border-color: #2563eb; color: #fff; }
+.cf-dlg__btn--primary:hover:not(:disabled) { background: #1d4ed8; }
+.cf-dlg__btn--danger { color: #b91c1c; border-color: #fecaca; }
+.cf-dlg__btn--danger:hover:not(:disabled) { background: #fef2f2; }
+.cf-dlg__btn--ghost { border-color: transparent; }
+.cf-dlg__hint { font-size: 12px; color: #888; margin: 0; }
+.cf-dlg__footer { display: flex; gap: 8px; justify-content: flex-end; padding: 12px 16px; border-top: 1px solid #eee; }
+</style>

--- a/apps/web/src/multitable/components/MetaGridTable.vue
+++ b/apps/web/src/multitable/components/MetaGridTable.vue
@@ -43,6 +43,7 @@
                 :aria-selected="row.id === selectedRecordId || undefined"
                 class="meta-grid__row"
                 :class="{ 'meta-grid__row--selected': row.id === selectedRecordId, 'meta-grid__row--focused': focusRow === flatIndex(group, ri) }"
+                :style="rowStyle(row.id)"
                 @click="emit('select-record', row.id)"
               >
                 <td v-if="enableMultiSelect" class="meta-grid__check-col" @click.stop>
@@ -67,7 +68,7 @@
                   :key="field.id"
                   class="meta-grid__cell"
                   :class="{ 'meta-grid__cell--editing': isEditing(row.id, field.id), 'meta-grid__cell--readonly': !isEditable(row.id, field), 'meta-grid__cell--focused': focusRow === flatIndex(group, ri) && focusCol === ci }"
-                  :style="cellStyle(field.id)"
+                  :style="cellStyle(row.id, field.id)"
                   @dblclick="startEdit(row, field)"
                   @click.stop="onCellClick(flatIndex(group, ri), ci, row.id)"
                 >
@@ -121,6 +122,7 @@
               :aria-selected="row.id === selectedRecordId || undefined"
               class="meta-grid__row"
               :class="{ 'meta-grid__row--selected': row.id === selectedRecordId, 'meta-grid__row--focused': focusRow === ri }"
+              :style="rowStyle(row.id)"
               @click="emit('select-record', row.id)"
             >
               <td v-if="enableMultiSelect" class="meta-grid__check-col" @click.stop>
@@ -148,7 +150,7 @@
                 :aria-label="field.name"
                 class="meta-grid__cell"
                 :class="{ 'meta-grid__cell--editing': isEditing(row.id, field.id), 'meta-grid__cell--readonly': !isEditable(row.id, field), 'meta-grid__cell--focused': focusRow === ri && focusCol === ci }"
-                :style="cellStyle(field.id)"
+                :style="cellStyle(row.id, field.id)"
                 @dblclick="startEdit(row, field)"
                 @click.stop="onCellClick(ri, ci, row.id)"
               >
@@ -250,6 +252,11 @@ import type {
   RowDensity,
 } from '../types'
 import type { SortRule } from '../composables/useMultitableGrid'
+import { composeStyleObject, type EvaluatedFormatting } from '../utils/conditional-formatting'
+
+interface ConditionalFormattingByRecord {
+  byRecordId: Map<string, EvaluatedFormatting>
+}
 import MetaCellRenderer from './cells/MetaCellRenderer.vue'
 import MetaCellEditor from './cells/MetaCellEditor.vue'
 import MetaFieldHeader from './MetaFieldHeader.vue'
@@ -289,6 +296,7 @@ const props = defineProps<{
   deleteAttachmentFn?: MetaAttachmentDeleteFn
   canComment?: boolean
   commentPresence?: Record<string, MultitableCommentPresenceSummary | undefined>
+  conditionalFormatting?: ConditionalFormattingByRecord
 }>()
 
 const emit = defineEmits<{
@@ -430,9 +438,23 @@ const isEditable = (recordId: string, f: MetaField) =>
   resolveRowActions(recordId).canEdit && EDITABLE.has(f.type) && !props.fieldReadOnlyIds?.includes(f.id)
 const isEditing = (rid: string, fid: string) => editCell.value?.recordId === rid && editCell.value?.fieldId === fid
 
-function cellStyle(fid: string) {
+function cellStyle(rid: string, fid: string) {
   const w = props.columnWidths?.[fid]
-  return w ? { width: `${w}px`, minWidth: `${w}px`, maxWidth: `${w}px` } : undefined
+  const widthStyle: Record<string, string> | undefined = w
+    ? { width: `${w}px`, minWidth: `${w}px`, maxWidth: `${w}px` }
+    : undefined
+  const formatting = props.conditionalFormatting?.byRecordId.get(rid)
+  const formatStyle = formatting
+    ? composeStyleObject(undefined, formatting.cellStyles[fid])
+    : undefined
+  if (!widthStyle && !formatStyle) return undefined
+  return { ...(widthStyle ?? {}), ...(formatStyle ?? {}) }
+}
+
+function rowStyle(rid: string): Record<string, string> | undefined {
+  const formatting = props.conditionalFormatting?.byRecordId.get(rid)
+  if (!formatting?.rowStyle) return undefined
+  return composeStyleObject(formatting.rowStyle, undefined)
 }
 
 function rowCommentAffordance(recordId: string) {

--- a/apps/web/src/multitable/components/MetaViewManager.vue
+++ b/apps/web/src/multitable/components/MetaViewManager.vue
@@ -581,6 +581,17 @@ function toggleFieldSelection(values: string[], fieldId: string) {
   values.splice(0, values.length, ...next)
 }
 
+function preserveConditionalFormattingRules(target: MetaView, config: Record<string, unknown>): Record<string, unknown> {
+  const existingConfig = target.config ?? {}
+  if (!Object.prototype.hasOwnProperty.call(existingConfig, 'conditionalFormattingRules')) {
+    return config
+  }
+  return {
+    ...config,
+    conditionalFormattingRules: existingConfig.conditionalFormattingRules,
+  }
+}
+
 function saveConfig() {
   const target = configTarget.value
   if (!target || viewConfigBlockingReason.value) return
@@ -588,32 +599,32 @@ function saveConfig() {
   if (target.type === 'gallery') {
     const fieldIds = galleryDraft.fieldIds.filter((fieldId) => validFieldIds.value.has(fieldId))
     emit('update-view', target.id, {
-      config: {
+      config: preserveConditionalFormattingRules(target, {
         titleFieldId: galleryDraft.titleFieldId && validStringFieldIds.value.has(galleryDraft.titleFieldId) ? galleryDraft.titleFieldId : null,
         coverFieldId: galleryDraft.coverFieldId && validAttachmentFieldIds.value.has(galleryDraft.coverFieldId) ? galleryDraft.coverFieldId : null,
         fieldIds,
         columns: galleryDraft.columns,
         cardSize: galleryDraft.cardSize,
-      },
+      }),
     })
   } else if (target.type === 'calendar') {
     emit('update-view', target.id, {
-      config: {
+      config: preserveConditionalFormattingRules(target, {
         dateFieldId: calendarDraft.dateFieldId && validDateLikeFieldIds.value.has(calendarDraft.dateFieldId) ? calendarDraft.dateFieldId : null,
         endDateFieldId: calendarDraft.endDateFieldId && validDateLikeFieldIds.value.has(calendarDraft.endDateFieldId) ? calendarDraft.endDateFieldId : null,
         titleFieldId: calendarDraft.titleFieldId && validFieldIds.value.has(calendarDraft.titleFieldId) ? calendarDraft.titleFieldId : null,
         defaultView: calendarDraft.defaultView,
         weekStartsOn: calendarDraft.weekStartsOn,
-      },
+      }),
     })
   } else if (target.type === 'timeline') {
     emit('update-view', target.id, {
-      config: {
+      config: preserveConditionalFormattingRules(target, {
         startFieldId: timelineDraft.startFieldId && validDateFieldIds.value.has(timelineDraft.startFieldId) ? timelineDraft.startFieldId : null,
         endFieldId: timelineDraft.endFieldId && validDateFieldIds.value.has(timelineDraft.endFieldId) ? timelineDraft.endFieldId : null,
         labelFieldId: timelineDraft.labelFieldId && validFieldIds.value.has(timelineDraft.labelFieldId) ? timelineDraft.labelFieldId : null,
         zoom: timelineDraft.zoom,
-      },
+      }),
     })
   } else if (target.type === 'kanban') {
     const groupFieldId = kanbanDraft.groupFieldId && validSelectFieldIds.value.has(kanbanDraft.groupFieldId)
@@ -621,10 +632,10 @@ function saveConfig() {
       : null
     const cardFieldIds = kanbanDraft.cardFieldIds.filter((fieldId) => validFieldIds.value.has(fieldId))
     emit('update-view', target.id, {
-      config: {
+      config: preserveConditionalFormattingRules(target, {
         groupFieldId,
         cardFieldIds,
-      },
+      }),
       groupInfo: groupFieldId ? { fieldId: groupFieldId } : {},
     })
   }

--- a/apps/web/src/multitable/components/MetaViewManager.vue
+++ b/apps/web/src/multitable/components/MetaViewManager.vue
@@ -30,6 +30,7 @@
             <span class="meta-view-mgr__name" :title="view.name">{{ view.name }}</span>
             <span class="meta-view-mgr__type">{{ view.type }}</span>
             <button class="meta-view-mgr__action" title="Configure" @click="openConfig(view)">&#x2699;</button>
+            <button class="meta-view-mgr__action" title="Conditional formatting" @click="openConditionalFormatting(view)">&#x1F3A8;</button>
             <button class="meta-view-mgr__action" title="Rename" @click="startRename(view)">&#x270E;</button>
             <button
               class="meta-view-mgr__action meta-view-mgr__action--danger"
@@ -228,12 +229,21 @@
         </div>
       </div>
     </div>
+    <ConditionalFormattingDialog
+      :visible="conditionalFormattingTargetId !== null"
+      :fields="fields"
+      :view-config="conditionalFormattingTargetView?.config"
+      @update:dirty="conditionalFormattingDirty = $event"
+      @close="closeConditionalFormatting"
+      @save="onSaveConditionalFormatting"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
 import { computed, onBeforeUnmount, reactive, ref, watch } from 'vue'
 import type {
+  ConditionalFormattingRule,
   MetaCalendarViewConfig,
   MetaField,
   MetaGalleryViewConfig,
@@ -247,6 +257,7 @@ import {
   resolveKanbanViewConfig,
   resolveTimelineViewConfig,
 } from '../utils/view-config'
+import ConditionalFormattingDialog from './ConditionalFormattingDialog.vue'
 
 const VIEW_TYPES = ['grid', 'form', 'kanban', 'gallery', 'calendar', 'timeline'] as const
 const VIEW_ICONS: Record<string, string> = {
@@ -313,8 +324,13 @@ const viewConfigBaseline = ref('')
 const viewConfigOutdated = ref(false)
 const viewConfigLiveRefreshText = ref('')
 const viewConfigSourceSignature = ref('')
+const conditionalFormattingTargetId = ref<string | null>(null)
+const conditionalFormattingDirty = ref(false)
 
 const configTarget = computed(() => props.views.find((view) => view.id === configTargetId.value) ?? null)
+const conditionalFormattingTargetView = computed(() =>
+  props.views.find((view) => view.id === conditionalFormattingTargetId.value) ?? null,
+)
 const deleteTarget = computed(() => props.views.find((view) => view.id === deleteTargetId.value) ?? null)
 const configTargetFields = computed(() => props.fields)
 const attachmentFields = computed(() => props.fields.filter((field) => field.type === 'attachment'))
@@ -423,6 +439,8 @@ function resetTransientState() {
   viewConfigOutdated.value = false
   viewConfigLiveRefreshText.value = ''
   viewConfigSourceSignature.value = ''
+  conditionalFormattingTargetId.value = null
+  conditionalFormattingDirty.value = false
   resetConfigDrafts()
 }
 
@@ -626,7 +644,7 @@ const renameDirty = computed(() => {
   return editingName.value.trim() !== (props.views.find((view) => view.id === editingId.value)?.name ?? '')
 })
 
-const hasPendingDrafts = computed(() => viewConfigDirty.value || newViewDraftDirty.value || renameDirty.value)
+const hasPendingDrafts = computed(() => viewConfigDirty.value || newViewDraftDirty.value || renameDirty.value || conditionalFormattingDirty.value)
 const managerDirty = computed(() => props.visible && hasPendingDrafts.value)
 
 function confirmDiscardViewManagerChanges() {
@@ -636,6 +654,27 @@ function confirmDiscardViewManagerChanges() {
 
 function reloadLatestConfig() {
   if (configTarget.value) hydrateExistingViewConfig(configTarget.value)
+}
+
+function openConditionalFormatting(view: MetaView) {
+  if (conditionalFormattingTargetId.value && conditionalFormattingTargetId.value !== view.id) {
+    if (conditionalFormattingDirty.value && !window.confirm('Discard unsaved formatting rules?')) return
+  }
+  conditionalFormattingTargetId.value = view.id
+}
+
+function closeConditionalFormatting() {
+  conditionalFormattingTargetId.value = null
+  conditionalFormattingDirty.value = false
+}
+
+function onSaveConditionalFormatting(rules: ConditionalFormattingRule[]) {
+  const target = conditionalFormattingTargetView.value
+  if (!target) return
+  const nextConfig: Record<string, unknown> = { ...(target.config ?? {}) }
+  nextConfig.conditionalFormattingRules = rules
+  emit('update-view', target.id, { config: nextConfig })
+  closeConditionalFormatting()
 }
 
 watch(

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -65,6 +65,46 @@ export interface MetaView {
   config?: Record<string, unknown>
 }
 
+// --- Conditional formatting (MF3) ---
+// Mirrors `packages/core-backend/src/multitable/conditional-formatting-service.ts`.
+// Backend is the canonical source — keep shapes in sync when extending.
+export type ConditionalFormattingOperator =
+  | 'gt'
+  | 'gte'
+  | 'lt'
+  | 'lte'
+  | 'eq'
+  | 'neq'
+  | 'between'
+  | 'contains'
+  | 'not_contains'
+  | 'is_empty'
+  | 'is_not_empty'
+  | 'is_today'
+  | 'is_in_last_n_days'
+  | 'is_in_next_n_days'
+  | 'is_overdue'
+  | 'is_true'
+  | 'is_false'
+
+export interface ConditionalFormattingStyle {
+  backgroundColor?: string
+  textColor?: string
+  applyToRow?: boolean
+}
+
+export interface ConditionalFormattingRule {
+  id: string
+  order: number
+  fieldId: string
+  operator: ConditionalFormattingOperator
+  value?: unknown
+  style: ConditionalFormattingStyle
+  enabled: boolean
+}
+
+export const CONDITIONAL_FORMATTING_RULE_LIMIT = 20
+
 export interface MetaRecord {
   id: string
   version: number

--- a/apps/web/src/multitable/utils/conditional-formatting.ts
+++ b/apps/web/src/multitable/utils/conditional-formatting.ts
@@ -1,0 +1,371 @@
+// Frontend mirror of
+// `packages/core-backend/src/multitable/conditional-formatting-service.ts`.
+// The backend is canonical (unit-tested); this module reproduces the same
+// shape for in-browser rendering. Keep the operator/value semantics in sync
+// when extending the rule schema.
+
+import type {
+  ConditionalFormattingOperator,
+  ConditionalFormattingRule,
+  ConditionalFormattingStyle,
+  MetaField,
+  MetaRecord,
+} from '../types'
+
+const HEX_COLOR_RE = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/
+
+const KNOWN_OPERATORS: ReadonlySet<ConditionalFormattingOperator> = new Set([
+  'gt', 'gte', 'lt', 'lte', 'eq', 'neq', 'between',
+  'contains', 'not_contains', 'is_empty', 'is_not_empty',
+  'is_today', 'is_in_last_n_days', 'is_in_next_n_days', 'is_overdue',
+  'is_true', 'is_false',
+])
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+function sanitizeHex(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  return HEX_COLOR_RE.test(value) ? value : undefined
+}
+
+export function isOperator(value: unknown): value is ConditionalFormattingOperator {
+  return typeof value === 'string' && KNOWN_OPERATORS.has(value as ConditionalFormattingOperator)
+}
+
+export function operatorRequiresValue(operator: ConditionalFormattingOperator): boolean {
+  switch (operator) {
+    case 'is_empty':
+    case 'is_not_empty':
+    case 'is_today':
+    case 'is_overdue':
+    case 'is_true':
+    case 'is_false':
+      return false
+    default:
+      return true
+  }
+}
+
+export function operatorIsBetween(operator: ConditionalFormattingOperator): boolean {
+  return operator === 'between'
+}
+
+export function sanitizeRule(input: unknown): ConditionalFormattingRule | null {
+  if (!isPlainObject(input)) return null
+  const id = typeof input.id === 'string' && input.id.trim() ? input.id.trim() : null
+  const fieldId = typeof input.fieldId === 'string' && input.fieldId.trim() ? input.fieldId.trim() : null
+  if (!id || !fieldId) return null
+  if (!isOperator(input.operator)) return null
+  const operator = input.operator as ConditionalFormattingOperator
+
+  const orderRaw = typeof input.order === 'number' && Number.isFinite(input.order) ? input.order : 0
+  const enabled = input.enabled !== false
+
+  const styleRaw = isPlainObject(input.style) ? input.style : {}
+  const style: ConditionalFormattingStyle = {}
+  const bg = sanitizeHex(styleRaw.backgroundColor)
+  if (bg) style.backgroundColor = bg
+  const tc = sanitizeHex(styleRaw.textColor)
+  if (tc) style.textColor = tc
+  if (styleRaw.applyToRow === true) style.applyToRow = true
+
+  let value: unknown = undefined
+  switch (operator) {
+    case 'between': {
+      if (!Array.isArray(input.value) || input.value.length !== 2) return null
+      value = [input.value[0], input.value[1]]
+      break
+    }
+    case 'is_empty':
+    case 'is_not_empty':
+    case 'is_today':
+    case 'is_overdue':
+    case 'is_true':
+    case 'is_false':
+      break
+    case 'is_in_last_n_days':
+    case 'is_in_next_n_days': {
+      const n = Number(input.value)
+      if (!Number.isFinite(n) || n <= 0) return null
+      value = Math.floor(n)
+      break
+    }
+    default:
+      if (input.value === undefined || input.value === null) return null
+      value = input.value
+      break
+  }
+
+  return { id, order: Math.floor(orderRaw), fieldId, operator, value, style, enabled }
+}
+
+export function sanitizeRules(input: unknown): ConditionalFormattingRule[] {
+  if (!Array.isArray(input)) return []
+  const out: ConditionalFormattingRule[] = []
+  for (const item of input) {
+    const rule = sanitizeRule(item)
+    if (rule) out.push(rule)
+  }
+  return out
+    .map((rule, index) => ({ rule, index }))
+    .sort((a, b) => a.rule.order - b.rule.order || a.index - b.index)
+    .map((entry) => entry.rule)
+}
+
+export function extractRulesFromConfig(config: unknown): ConditionalFormattingRule[] {
+  if (!isPlainObject(config)) return []
+  return sanitizeRules(config.conditionalFormattingRules)
+}
+
+function toComparableNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value)
+    if (Number.isFinite(parsed)) return parsed
+  }
+  return null
+}
+
+function toComparableString(value: unknown): string | null {
+  if (typeof value === 'string') return value
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  return null
+}
+
+function isEmptyValue(value: unknown): boolean {
+  if (value === undefined || value === null) return true
+  if (typeof value === 'string') return value.trim() === ''
+  if (Array.isArray(value)) return value.length === 0
+  if (isPlainObject(value)) return Object.keys(value).length === 0
+  return false
+}
+
+function startOfDay(date: Date): number {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime()
+}
+
+function toDateMs(value: unknown): number | null {
+  if (value instanceof Date) return Number.isFinite(value.getTime()) ? value.getTime() : null
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string' && value.trim()) {
+    const ms = Date.parse(value)
+    return Number.isFinite(ms) ? ms : null
+  }
+  return null
+}
+
+function selectValuesArray(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    const out: string[] = []
+    for (const item of value) {
+      if (typeof item === 'string') out.push(item)
+      else if (typeof item === 'number') out.push(String(item))
+    }
+    return out
+  }
+  if (typeof value === 'string') return [value]
+  if (typeof value === 'number') return [String(value)]
+  return []
+}
+
+export interface EvaluateOptions {
+  now?: number
+}
+
+export function evaluateRule(
+  rule: ConditionalFormattingRule,
+  recordData: Record<string, unknown>,
+  field: MetaField | undefined,
+  options: EvaluateOptions = {},
+): boolean {
+  if (!rule.enabled) return false
+  const cellValue = recordData[rule.fieldId]
+  switch (rule.operator) {
+    case 'is_empty':
+      return isEmptyValue(cellValue)
+    case 'is_not_empty':
+      return !isEmptyValue(cellValue)
+    case 'is_true':
+      return cellValue === true || cellValue === 'true' || cellValue === 1
+    case 'is_false':
+      return cellValue === false || cellValue === 'false' || cellValue === 0
+    case 'gt':
+    case 'gte':
+    case 'lt':
+    case 'lte': {
+      const a = toComparableNumber(cellValue)
+      const b = toComparableNumber(rule.value)
+      if (a === null || b === null) return false
+      if (rule.operator === 'gt') return a > b
+      if (rule.operator === 'gte') return a >= b
+      if (rule.operator === 'lt') return a < b
+      return a <= b
+    }
+    case 'between': {
+      if (!Array.isArray(rule.value) || rule.value.length !== 2) return false
+      const v = toComparableNumber(cellValue)
+      const lo = toComparableNumber(rule.value[0])
+      const hi = toComparableNumber(rule.value[1])
+      if (v === null || lo === null || hi === null) return false
+      return v >= Math.min(lo, hi) && v <= Math.max(lo, hi)
+    }
+    case 'eq': {
+      if (field?.type === 'select') {
+        const expected = toComparableString(rule.value)
+        if (expected === null) return false
+        return selectValuesArray(cellValue).includes(expected)
+      }
+      const a = toComparableString(cellValue)
+      const b = toComparableString(rule.value)
+      if (a === null || b === null) return cellValue === rule.value
+      return a === b
+    }
+    case 'neq': {
+      if (field?.type === 'select') {
+        const expected = toComparableString(rule.value)
+        if (expected === null) return false
+        return !selectValuesArray(cellValue).includes(expected)
+      }
+      const a = toComparableString(cellValue)
+      const b = toComparableString(rule.value)
+      if (a === null || b === null) return cellValue !== rule.value
+      return a !== b
+    }
+    case 'contains':
+    case 'not_contains': {
+      const expected = toComparableString(rule.value)
+      if (expected === null) return rule.operator === 'not_contains'
+      const needle = expected.toLowerCase()
+      let matches = false
+      if (Array.isArray(cellValue)) {
+        matches = selectValuesArray(cellValue).some((entry) => entry.toLowerCase().includes(needle))
+      } else {
+        const haystack = toComparableString(cellValue)
+        matches = haystack !== null && haystack.toLowerCase().includes(needle)
+      }
+      return rule.operator === 'contains' ? matches : !matches
+    }
+    case 'is_today': {
+      const cellMs = toDateMs(cellValue)
+      if (cellMs === null) return false
+      const now = options.now ?? Date.now()
+      return startOfDay(new Date(cellMs)) === startOfDay(new Date(now))
+    }
+    case 'is_in_last_n_days': {
+      const cellMs = toDateMs(cellValue)
+      const days = toComparableNumber(rule.value)
+      if (cellMs === null || days === null || days <= 0) return false
+      const now = options.now ?? Date.now()
+      const startMs = startOfDay(new Date(now)) - (days - 1) * 86_400_000
+      const endMs = startOfDay(new Date(now)) + 86_400_000
+      return cellMs >= startMs && cellMs < endMs
+    }
+    case 'is_in_next_n_days': {
+      const cellMs = toDateMs(cellValue)
+      const days = toComparableNumber(rule.value)
+      if (cellMs === null || days === null || days <= 0) return false
+      const now = options.now ?? Date.now()
+      const startMs = startOfDay(new Date(now))
+      const endMs = startMs + days * 86_400_000
+      return cellMs >= startMs && cellMs < endMs
+    }
+    case 'is_overdue': {
+      const cellMs = toDateMs(cellValue)
+      if (cellMs === null) return false
+      const now = options.now ?? Date.now()
+      return cellMs < startOfDay(new Date(now))
+    }
+    default:
+      return false
+  }
+}
+
+export interface EvaluatedFormatting {
+  rowStyle?: ConditionalFormattingStyle
+  cellStyles: Record<string, ConditionalFormattingStyle>
+  matchedRuleIds: string[]
+}
+
+const EMPTY_RESULT: EvaluatedFormatting = Object.freeze({
+  cellStyles: Object.freeze({}) as Record<string, ConditionalFormattingStyle>,
+  matchedRuleIds: Object.freeze([]) as unknown as string[],
+}) as EvaluatedFormatting
+
+export function evaluateRulesForRecord(
+  rules: ConditionalFormattingRule[],
+  record: MetaRecord | { data: Record<string, unknown> },
+  fieldsById: Record<string, MetaField | undefined>,
+  options: EvaluateOptions = {},
+): EvaluatedFormatting {
+  if (!rules.length) return EMPTY_RESULT
+  const data = record?.data ?? {}
+  let rowStyle: ConditionalFormattingStyle | undefined
+  const cellStyles: Record<string, ConditionalFormattingStyle> = {}
+  const matchedRuleIds: string[] = []
+  for (const rule of rules) {
+    const field = fieldsById[rule.fieldId]
+    if (!evaluateRule(rule, data, field, options)) continue
+    matchedRuleIds.push(rule.id)
+    const baseStyle: ConditionalFormattingStyle = {}
+    if (rule.style.backgroundColor) baseStyle.backgroundColor = rule.style.backgroundColor
+    if (rule.style.textColor) baseStyle.textColor = rule.style.textColor
+    if (rule.style.applyToRow) {
+      if (!rowStyle) rowStyle = baseStyle
+    } else if (!cellStyles[rule.fieldId]) {
+      cellStyles[rule.fieldId] = baseStyle
+    }
+  }
+  if (!rowStyle && Object.keys(cellStyles).length === 0 && matchedRuleIds.length === 0) {
+    return EMPTY_RESULT
+  }
+  return { rowStyle, cellStyles, matchedRuleIds }
+}
+
+export interface FormattingByRecord {
+  rules: ConditionalFormattingRule[]
+  byRecordId: Map<string, EvaluatedFormatting>
+}
+
+/**
+ * Pre-compute formatting for each record once. Use this when displaying many
+ * rows; the renderer can read from the map per (recordId, fieldId) without
+ * re-evaluating rules on every scroll/render.
+ */
+export function buildRecordFormattingMap(
+  rules: ConditionalFormattingRule[],
+  records: ReadonlyArray<MetaRecord>,
+  fields: ReadonlyArray<MetaField>,
+  options: EvaluateOptions = {},
+): FormattingByRecord {
+  const fieldsById: Record<string, MetaField | undefined> = {}
+  for (const field of fields) fieldsById[field.id] = field
+  const byRecordId = new Map<string, EvaluatedFormatting>()
+  if (!rules.length) return { rules, byRecordId }
+  for (const record of records) {
+    const result = evaluateRulesForRecord(rules, record, fieldsById, options)
+    if (result.rowStyle || Object.keys(result.cellStyles).length > 0) {
+      byRecordId.set(record.id, result)
+    }
+  }
+  return { rules, byRecordId }
+}
+
+/**
+ * Compose a CSS-style object from row-level + cell-level matches. The cell
+ * style takes precedence over row style on the same property (intentional —
+ * cell rules are more specific).
+ */
+export function composeStyleObject(
+  rowStyle: ConditionalFormattingStyle | undefined,
+  cellStyle: ConditionalFormattingStyle | undefined,
+): Record<string, string> | undefined {
+  if (!rowStyle && !cellStyle) return undefined
+  const css: Record<string, string> = {}
+  const bg = cellStyle?.backgroundColor ?? rowStyle?.backgroundColor
+  const fg = cellStyle?.textColor ?? rowStyle?.textColor
+  if (bg) css.backgroundColor = bg
+  if (fg) css.color = fg
+  return Object.keys(css).length > 0 ? css : undefined
+}

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -183,6 +183,7 @@
           :delete-attachment-fn="deleteAttachmentFn"
           :can-comment="effectiveRowActions.canComment"
           :comment-presence="commentPresenceState.presenceByRecordId.value"
+          :conditional-formatting="conditionalFormattingByRecord"
           @select-record="onSelectRecord" @toggle-sort="onToggleSort" @patch-cell="onPatchCell"
           @go-to-page="grid.goToPage" @open-link-picker="onGridLinkPicker" @resize-column="grid.setColumnWidth"
           @bulk-delete="onBulkDelete" @reorder-field="onReorderField"
@@ -375,6 +376,7 @@ import { buildXlsxBuffer } from '../import/xlsx-mapping'
 import { filterPropertyVisibleFields } from '../utils/field-permissions'
 import { isLinkField, isPersonField } from '../utils/link-fields'
 import { addPeopleLookupToken, inferPeopleLookupKind, resolvePeopleImportValue } from '../utils/people-import'
+import { buildRecordFormattingMap, extractRulesFromConfig } from '../utils/conditional-formatting'
 
 const props = defineProps<{ sheetId?: string; viewId?: string; baseId?: string; recordId?: string; commentId?: string; fieldId?: string; openComments?: boolean; mode?: string; role?: MultitableRole }>()
 const emit = defineEmits<{
@@ -632,6 +634,14 @@ const scopedAllFields = computed(() =>
 const scopedGridFields = computed(() =>
   grid.visibleFields.value.filter((field) => effectiveFieldPermissions.value[field.id]?.visible !== false),
 )
+const conditionalFormattingRules = computed(() =>
+  extractRulesFromConfig(workbench.activeView.value?.config),
+)
+const conditionalFormattingByRecord = computed(() => buildRecordFormattingMap(
+  conditionalFormattingRules.value,
+  grid.rows.value,
+  scopedAllFields.value,
+))
 const readOnlyFieldIds = computed(() =>
   Object.entries(effectiveFieldPermissions.value)
     .filter(([, permission]) => permission.readOnly)

--- a/apps/web/tests/multitable-conditional-formatting.spec.ts
+++ b/apps/web/tests/multitable-conditional-formatting.spec.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect } from 'vitest'
+
+import {
+  buildRecordFormattingMap,
+  composeStyleObject,
+  evaluateRule,
+  extractRulesFromConfig,
+  isOperator,
+  operatorRequiresValue,
+  sanitizeRule,
+  sanitizeRules,
+} from '../src/multitable/utils/conditional-formatting'
+import type {
+  ConditionalFormattingRule,
+  MetaField,
+  MetaRecord,
+} from '../src/multitable/types'
+
+const NUMBER_FIELD: MetaField = { id: 'fld_n', name: 'N', type: 'number' }
+const TEXT_FIELD: MetaField = { id: 'fld_t', name: 'T', type: 'string' }
+const DATE_FIELD: MetaField = { id: 'fld_d', name: 'D', type: 'date' }
+const SELECT_FIELD: MetaField = {
+  id: 'fld_s',
+  name: 'S',
+  type: 'select',
+  options: [{ value: 'High' }, { value: 'Low' }],
+}
+
+const FIELDS_BY_ID: Record<string, MetaField | undefined> = {
+  [NUMBER_FIELD.id]: NUMBER_FIELD,
+  [TEXT_FIELD.id]: TEXT_FIELD,
+  [DATE_FIELD.id]: DATE_FIELD,
+  [SELECT_FIELD.id]: SELECT_FIELD,
+}
+
+const FIXED_NOW = new Date(2026, 3, 25, 12).getTime()
+const ONE_DAY = 86_400_000
+
+function localDayMs(now: number, offset: number, hour = 12): number {
+  const d = new Date(now + offset * ONE_DAY)
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate(), hour).getTime()
+}
+
+function makeRule(partial: Partial<ConditionalFormattingRule> = {}): ConditionalFormattingRule {
+  return {
+    id: 'r1',
+    order: 0,
+    fieldId: NUMBER_FIELD.id,
+    operator: 'gt',
+    value: 0,
+    style: { backgroundColor: '#ff0000' },
+    enabled: true,
+    ...partial,
+  }
+}
+
+describe('isOperator', () => {
+  it('accepts known operators', () => {
+    expect(isOperator('gt')).toBe(true)
+    expect(isOperator('between')).toBe(true)
+    expect(isOperator('is_overdue')).toBe(true)
+  })
+  it('rejects unknown operators', () => {
+    expect(isOperator('banana')).toBe(false)
+    expect(isOperator(42)).toBe(false)
+  })
+})
+
+describe('operatorRequiresValue', () => {
+  it('returns false for empty/today/overdue/bool variants', () => {
+    expect(operatorRequiresValue('is_empty')).toBe(false)
+    expect(operatorRequiresValue('is_overdue')).toBe(false)
+    expect(operatorRequiresValue('is_true')).toBe(false)
+  })
+  it('returns true for comparators', () => {
+    expect(operatorRequiresValue('gt')).toBe(true)
+    expect(operatorRequiresValue('between')).toBe(true)
+    expect(operatorRequiresValue('is_in_last_n_days')).toBe(true)
+  })
+})
+
+describe('sanitizeRule', () => {
+  it('parses a well-formed rule', () => {
+    const rule = sanitizeRule({
+      id: 'r1', order: 0, fieldId: 'f', operator: 'gt', value: 5,
+      style: { backgroundColor: '#abcdef', applyToRow: true },
+    })
+    expect(rule).toMatchObject({
+      id: 'r1', operator: 'gt', value: 5,
+      style: { backgroundColor: '#abcdef', applyToRow: true },
+    })
+  })
+
+  it('rejects unknown operator', () => {
+    expect(sanitizeRule({ id: 'r1', order: 0, fieldId: 'f', operator: 'foo', style: {} })).toBeNull()
+  })
+
+  it('drops invalid hex colors', () => {
+    const rule = sanitizeRule({
+      id: 'r1', order: 0, fieldId: 'f', operator: 'gt', value: 5,
+      style: { backgroundColor: 'hotpink', textColor: '#abc' },
+    })
+    expect(rule?.style.backgroundColor).toBeUndefined()
+    expect(rule?.style.textColor).toBe('#abc')
+  })
+
+  it('rejects gt/between with bad value shapes', () => {
+    expect(sanitizeRule({ id: 'r', order: 0, fieldId: 'f', operator: 'gt', style: {} })).toBeNull()
+    expect(sanitizeRule({ id: 'r', order: 0, fieldId: 'f', operator: 'between', value: 5, style: {} })).toBeNull()
+  })
+
+  it('treats enabled as default-true when omitted', () => {
+    const rule = sanitizeRule({ id: 'r1', order: 0, fieldId: 'f', operator: 'is_empty', style: {} })
+    expect(rule?.enabled).toBe(true)
+  })
+})
+
+describe('sanitizeRules', () => {
+  it('drops invalid entries and preserves order ascending', () => {
+    const rules = sanitizeRules([
+      { id: 'a', order: 5, fieldId: 'f', operator: 'is_empty', style: {} },
+      'invalid',
+      { id: 'b', order: 1, fieldId: 'f', operator: 'is_empty', style: {} },
+    ])
+    expect(rules.map((r) => r.id)).toEqual(['b', 'a'])
+  })
+})
+
+describe('extractRulesFromConfig', () => {
+  it('reads rules nested under `conditionalFormattingRules`', () => {
+    const rules = extractRulesFromConfig({
+      conditionalFormattingRules: [
+        { id: 'r1', order: 0, fieldId: 'f', operator: 'is_empty', style: {} },
+      ],
+    })
+    expect(rules).toHaveLength(1)
+  })
+
+  it('returns [] when missing or shape is wrong', () => {
+    expect(extractRulesFromConfig(undefined)).toEqual([])
+    expect(extractRulesFromConfig({ conditionalFormattingRules: 'oops' })).toEqual([])
+  })
+})
+
+describe('evaluateRule — numeric / text', () => {
+  it('gt matches numeric and string-number cells', () => {
+    expect(evaluateRule(makeRule({ operator: 'gt', value: 10 }), { fld_n: 11 }, NUMBER_FIELD)).toBe(true)
+    expect(evaluateRule(makeRule({ operator: 'gt', value: 10 }), { fld_n: '15' }, NUMBER_FIELD)).toBe(true)
+    expect(evaluateRule(makeRule({ operator: 'gt', value: 10 }), { fld_n: 'abc' }, NUMBER_FIELD)).toBe(false)
+  })
+  it('between is inclusive', () => {
+    const rule = makeRule({ operator: 'between', value: [10, 20] })
+    expect(evaluateRule(rule, { fld_n: 10 }, NUMBER_FIELD)).toBe(true)
+    expect(evaluateRule(rule, { fld_n: 20 }, NUMBER_FIELD)).toBe(true)
+    expect(evaluateRule(rule, { fld_n: 21 }, NUMBER_FIELD)).toBe(false)
+  })
+  it('contains is case-insensitive', () => {
+    expect(evaluateRule(
+      makeRule({ fieldId: TEXT_FIELD.id, operator: 'contains', value: 'urgent' }),
+      { fld_t: 'URGENT - read first' },
+      TEXT_FIELD,
+    )).toBe(true)
+  })
+  it('eq on select field matches against any selected option', () => {
+    expect(evaluateRule(
+      makeRule({ fieldId: SELECT_FIELD.id, operator: 'eq', value: 'High' }),
+      { fld_s: ['High'] },
+      SELECT_FIELD,
+    )).toBe(true)
+  })
+})
+
+describe('evaluateRule — date variants', () => {
+  const onDay = (offset: number, hour = 12) => ({ [DATE_FIELD.id]: localDayMs(FIXED_NOW, offset, hour) })
+
+  it('is_today matches calendar same-day', () => {
+    expect(evaluateRule(
+      makeRule({ fieldId: DATE_FIELD.id, operator: 'is_today' }),
+      onDay(0, 1), DATE_FIELD, { now: FIXED_NOW },
+    )).toBe(true)
+  })
+
+  it('is_overdue matches dates strictly before today', () => {
+    expect(evaluateRule(
+      makeRule({ fieldId: DATE_FIELD.id, operator: 'is_overdue' }),
+      onDay(-1, 23), DATE_FIELD, { now: FIXED_NOW },
+    )).toBe(true)
+    expect(evaluateRule(
+      makeRule({ fieldId: DATE_FIELD.id, operator: 'is_overdue' }),
+      onDay(0, 0), DATE_FIELD, { now: FIXED_NOW },
+    )).toBe(false)
+  })
+
+  it('is_in_last_n_days inclusive of today / N-1 days back', () => {
+    const rule = makeRule({ fieldId: DATE_FIELD.id, operator: 'is_in_last_n_days', value: 7 })
+    expect(evaluateRule(rule, onDay(-6), DATE_FIELD, { now: FIXED_NOW })).toBe(true)
+    expect(evaluateRule(rule, onDay(-7), DATE_FIELD, { now: FIXED_NOW })).toBe(false)
+  })
+})
+
+describe('buildRecordFormattingMap', () => {
+  it('returns empty map when no rules', () => {
+    const result = buildRecordFormattingMap([], [{ id: 'rec1', version: 1, data: { fld_n: 5 } }], [NUMBER_FIELD])
+    expect(result.byRecordId.size).toBe(0)
+  })
+
+  it('produces per-record formatting and applies first-match-wins', () => {
+    const rules: ConditionalFormattingRule[] = [
+      makeRule({ id: 'a', order: 0, operator: 'gt', value: 100, style: { backgroundColor: '#aaaaaa' } }),
+      makeRule({ id: 'b', order: 1, operator: 'gt', value: 10, style: { backgroundColor: '#bbbbbb' } }),
+    ]
+    const records: MetaRecord[] = [
+      { id: 'rec_match', version: 1, data: { fld_n: 200 } },
+      { id: 'rec_partial', version: 1, data: { fld_n: 50 } },
+      { id: 'rec_none', version: 1, data: { fld_n: 1 } },
+    ]
+    const result = buildRecordFormattingMap(rules, records, [NUMBER_FIELD])
+    expect(result.byRecordId.size).toBe(2)
+    expect(result.byRecordId.get('rec_match')?.cellStyles[NUMBER_FIELD.id]?.backgroundColor).toBe('#aaaaaa')
+    expect(result.byRecordId.get('rec_partial')?.cellStyles[NUMBER_FIELD.id]?.backgroundColor).toBe('#bbbbbb')
+    expect(result.byRecordId.get('rec_none')).toBeUndefined()
+  })
+
+  it('separates rowStyle from cellStyles', () => {
+    const rules: ConditionalFormattingRule[] = [
+      makeRule({ id: 'row', order: 0, operator: 'gt', value: 0, style: { backgroundColor: '#cccccc', applyToRow: true } }),
+      makeRule({ id: 'cell', order: 1, fieldId: TEXT_FIELD.id, operator: 'eq', value: 'X', style: { backgroundColor: '#dddddd' } }),
+    ]
+    const result = buildRecordFormattingMap(
+      rules,
+      [{ id: 'rec1', version: 1, data: { fld_n: 1, fld_t: 'X' } }],
+      [NUMBER_FIELD, TEXT_FIELD],
+    )
+    const entry = result.byRecordId.get('rec1')
+    expect(entry?.rowStyle?.backgroundColor).toBe('#cccccc')
+    expect(entry?.cellStyles[TEXT_FIELD.id]?.backgroundColor).toBe('#dddddd')
+  })
+})
+
+describe('composeStyleObject', () => {
+  it('merges row and cell styles with cell precedence', () => {
+    expect(composeStyleObject(
+      { backgroundColor: '#row', textColor: '#row' },
+      { backgroundColor: '#cell' },
+    )).toEqual({ backgroundColor: '#cell', color: '#row' })
+  })
+  it('returns undefined when both empty', () => {
+    expect(composeStyleObject(undefined, undefined)).toBeUndefined()
+    expect(composeStyleObject({}, {})).toBeUndefined()
+  })
+  it('respects row-only style', () => {
+    expect(composeStyleObject({ backgroundColor: '#abc' }, undefined)).toEqual({ backgroundColor: '#abc' })
+  })
+})
+
+// Reference FIELDS_BY_ID for completeness — surfaces the type without exporting more helpers.
+void FIELDS_BY_ID

--- a/apps/web/tests/multitable-view-manager.spec.ts
+++ b/apps/web/tests/multitable-view-manager.spec.ts
@@ -71,6 +71,75 @@ describe('MetaViewManager', () => {
     app.unmount()
   })
 
+  it('preserves conditional formatting rules when saving view settings', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const updateSpy = vi.fn()
+    const rules = [
+      {
+        id: 'rule_overdue',
+        order: 0,
+        fieldId: 'fld_start',
+        operator: 'is_overdue',
+        style: { backgroundColor: '#fce4e4' },
+        enabled: true,
+      },
+    ]
+
+    const app = createApp({
+      render() {
+        return h(MetaViewManager, {
+          visible: true,
+          sheetId: 'sheet_1',
+          activeViewId: 'view_timeline',
+          fields: [
+            { id: 'fld_name', name: 'Name', type: 'string' },
+            { id: 'fld_start', name: 'Start', type: 'date' },
+            { id: 'fld_end', name: 'End', type: 'date' },
+          ],
+          views: [
+            {
+              id: 'view_timeline',
+              sheetId: 'sheet_1',
+              name: 'Roadmap',
+              type: 'timeline',
+              config: {
+                startFieldId: 'fld_start',
+                endFieldId: 'fld_end',
+                zoom: 'week',
+                conditionalFormattingRules: rules,
+              },
+            },
+          ],
+          onUpdateView: updateSpy,
+        })
+      },
+    })
+
+    app.mount(container)
+    await nextTick()
+
+    ;(container.querySelector('.meta-view-mgr__action[title="Configure"]') as HTMLButtonElement | null)?.click()
+    await nextTick()
+
+    ;(Array.from(container.querySelectorAll('.meta-view-mgr__btn-add')) as HTMLButtonElement[])
+      .find((button) => button.textContent?.includes('Save view settings'))
+      ?.click()
+    await nextTick()
+
+    expect(updateSpy).toHaveBeenCalledWith('view_timeline', {
+      config: {
+        startFieldId: 'fld_start',
+        endFieldId: 'fld_end',
+        labelFieldId: 'fld_name',
+        zoom: 'week',
+        conditionalFormattingRules: rules,
+      },
+    })
+
+    app.unmount()
+  })
+
   it('reconciles latest view config while clean and reloads latest when draft becomes stale', async () => {
     const container = document.createElement('div')
     document.body.appendChild(container)

--- a/docs/development/multitable-mf3-conditional-formatting-development-20260426.md
+++ b/docs/development/multitable-mf3-conditional-formatting-development-20260426.md
@@ -1,0 +1,232 @@
+# Multitable MF3 conditional formatting development
+
+Date: 2026-04-26
+Branch: `codex/multitable-feishu-mf3-condfmt-20260426`
+Base: `origin/main@25202478c`
+
+## Scope
+
+MF3 adds Feishu-Bitable-style conditional formatting to multitable views.
+Per-view rules color cells (or whole rows) based on the value of a target
+field. The work is delivered as a single integration lane that touches:
+
+- `MetaGridTable.vue` (cell + row style binding only — no behavior change
+  outside of conditional styling).
+- `MetaViewManager.vue` (per-view "open formatting rules" affordance that
+  opens a new dialog).
+- `ConditionalFormattingDialog.vue` (new — rule editor).
+- `MultitableWorkbench.vue` (host that derives the formatting map and
+  passes it as a prop to `MetaGridTable`).
+- `packages/core-backend/src/multitable/conditional-formatting-service.ts`
+  (new — canonical pure evaluator + sanitizer).
+- `packages/core-backend/src/routes/univer-meta.ts` (POST/PATCH `/views`
+  validate + sanitize the optional `config.conditionalFormattingRules`
+  array).
+
+## Storage choice
+
+`meta_views.config jsonb` is already an arbitrary blob. Conditional
+formatting rules are nested under
+`view.config.conditionalFormattingRules`. **No migration is required**;
+the existing PATCH `/api/multitable/views/:viewId` endpoint accepts an
+arbitrary `config: z.record(z.unknown())` object and persists it
+verbatim. This matches how `gallery` / `kanban` / `calendar` /
+`timeline` per-view configs already flow.
+
+The backend write path additionally validates and sanitizes the rules:
+
+- Rules with unknown operators, missing `id` / `fieldId`, or invalid
+  operator-specific value shapes are dropped.
+- Hex colors are validated against `/^#([0-9a-fA-F]{3,8})$/`; invalid
+  colors are silently dropped (the rule is preserved without the
+  invalid color).
+- The total rule count is capped at `CONDITIONAL_FORMATTING_RULE_LIMIT`
+  (20). PATCH bodies that exceed the limit return
+  `400 VALIDATION_ERROR`. The sanitizer also enforces the cap as a
+  defensive bound after parsing.
+
+## Rule schema
+
+Type lives in `packages/core-backend/src/multitable/conditional-formatting-service.ts`
+(canonical) and is mirrored in `apps/web/src/multitable/types.ts`
+(`ConditionalFormattingRule`). Both shapes must be kept in lock-step
+when extending the operator set.
+
+```ts
+interface ConditionalFormattingRule {
+  id: string                         // stable client-generated id
+  order: number                      // first-match-wins; ascending
+  fieldId: string                    // target field id
+  operator: ConditionalFormattingOperator
+  value?: unknown                    // operator-dependent (see below)
+  style: { backgroundColor?: string; textColor?: string; applyToRow?: boolean }
+  enabled: boolean                   // disabled rules never match
+}
+```
+
+### Operators
+
+| Operator | Value shape | Field types | Semantics |
+|----------|-------------|-------------|-----------|
+| `gt` / `gte` / `lt` / `lte` | scalar number | number, formula | numeric compare; string-numbers coerced |
+| `between` | `[number, number]` | number, formula | inclusive of both bounds; tolerates reversed order |
+| `eq` / `neq` | scalar | any | text fields compared as strings; select fields match against any selected option |
+| `contains` / `not_contains` | string | string, select | case-insensitive substring search; works on array values |
+| `is_empty` / `is_not_empty` | — | any | empty = `null` / `undefined` / `''` / `[]` / `{}` |
+| `is_today` | — | date | local-tz same-day match against `now` |
+| `is_in_last_n_days` / `is_in_next_n_days` | positive integer | date | inclusive of today; window of N days |
+| `is_overdue` | — | date | strictly before today (local-tz) |
+| `is_true` / `is_false` | — | boolean | accepts `true`/`'true'`/`1` and `false`/`'false'`/`0` |
+
+`Date` semantics are anchored on the **local timezone** start-of-day
+boundary so the result matches what the end user sees in their
+browser. Tests pass an explicit `options.now` to keep determinism
+across CI hosts.
+
+## Evaluation strategy
+
+### Backend canonical evaluator
+
+`evaluateConditionalFormattingRules(rules, record, fieldsById, options?)`
+returns `{ rowStyle?, cellStyles, matchedRuleIds }`. It is pure (no DB
+or network), deterministic, and exported for reuse. The function is
+exercised by 39 unit tests covering every operator and the
+first-match-wins semantics.
+
+### Frontend mirror
+
+`apps/web/src/multitable/utils/conditional-formatting.ts` reproduces
+the same shape (browser cannot import server modules across workspaces).
+The mirror is exercised by 25 unit tests in
+`apps/web/tests/multitable-conditional-formatting.spec.ts` and stays
+in lock-step with the backend canonical evaluator by sharing the same
+operator semantics — when extending the rule schema, update both
+files together.
+
+### First-match-wins precedence
+
+Rules are sorted by `order` ascending (stable on ties). The evaluator
+walks the list once per record:
+
+1. The **first matching cell-level rule** (`applyToRow !== true`) for
+   each field id wins; later cell-level matches on the same field are
+   ignored.
+2. The **first matching row-level rule** (`applyToRow === true`) wins
+   the row-level style; later row-level matches are ignored.
+3. Cell and row styles compose independently. At render time, the
+   cell style takes precedence over the row style on the same CSS
+   property (`backgroundColor`, `color`).
+
+`matchedRuleIds` records all matched rule ids in original `order` for
+diagnostics; the actual style emission honors the precedence above.
+
+### Performance — pre-compute once per render
+
+`buildRecordFormattingMap(rules, records, fields)` produces a
+`Map<recordId, EvaluatedFormatting>` once per render. It is wrapped in
+a `computed()` in `MultitableWorkbench.vue` keyed on
+`activeView.config`, `grid.rows`, and `scopedAllFields`, so:
+
+- Vue auto-memoizes; rules are not re-evaluated on scroll, hover, or
+  focus changes.
+- Re-evaluation only happens when the rule list, the visible rows, or
+  the field metadata change.
+- `MetaGridTable.vue` reads pre-computed style objects from the map
+  inside `cellStyle(rid, fid)` and `rowStyle(rid)` — both are O(1)
+  Map lookups during render, no rule iteration in the hot path.
+
+Records with no matching rules are not stored in the Map at all, so
+the renderer immediately short-circuits to the existing column-width
+style for those rows (no allocation, no overhead).
+
+## UI flow
+
+1. User opens **Manage Views** drawer (`MetaViewManager.vue`).
+2. Each view row exposes a "Conditional formatting" affordance (paint
+   palette icon) alongside the existing Configure / Rename / Delete
+   actions.
+3. Clicking opens `ConditionalFormattingDialog.vue` with the rules
+   currently saved in `view.config.conditionalFormattingRules`.
+4. The dialog lists existing rules with up/down reorder buttons,
+   per-rule enable toggle, "Apply to whole row" checkbox, and 8-color
+   palette plus a hex input.
+5. The "+ Add rule" button is disabled at the configured limit (20).
+6. The operator dropdown is filtered by the target field's type
+   (number → comparison operators; date → today/overdue/last N days;
+   boolean → checked/unchecked; etc.).
+7. Save dispatches `update-view` with the merged config containing
+   the sanitized rule list. The host (`MultitableWorkbench`) routes
+   this through the existing `client.updateView()` and triggers a
+   sheet meta refresh; the next render produces an updated
+   `conditionalFormattingByRecord` map.
+
+Admin gating uses the existing `MetaCapabilities.canManageViews`
+capability — the affordance lives inside the existing
+`MetaViewManager` (which is already gated on the same capability via
+the dirty-flag plumbing) and the backend PATCH `/views/:viewId` route
+returns 403 if the caller lacks `canManageViews`. No new permission
+codes were introduced.
+
+## Files
+
+- `packages/core-backend/src/multitable/conditional-formatting-service.ts`
+  (new, ~330 LoC)
+- `packages/core-backend/src/routes/univer-meta.ts` (edited; +35 / −2:
+  imports + cap/sanitize hook in POST + PATCH `/views`).
+- `packages/core-backend/tests/unit/multitable-conditional-formatting.test.ts`
+  (new, 39 tests).
+- `apps/web/src/multitable/types.ts` (edited; +47 / −0: rule shape
+  types + operator union + limit constant).
+- `apps/web/src/multitable/utils/conditional-formatting.ts` (new,
+  ~310 LoC).
+- `apps/web/src/multitable/components/ConditionalFormattingDialog.vue`
+  (new, ~340 LoC).
+- `apps/web/src/multitable/components/MetaViewManager.vue` (edited;
+  +35 / −1: open dialog button + handlers + import).
+- `apps/web/src/multitable/components/MetaGridTable.vue` (edited;
+  +25 / −2: prop addition + `cellStyle(rid, fid)` signature change +
+  `rowStyle(rid)` helper + style merge).
+- `apps/web/src/multitable/views/MultitableWorkbench.vue` (edited;
+  +10 / −0: `conditionalFormattingByRecord` computed + prop wiring +
+  imports).
+- `apps/web/tests/multitable-conditional-formatting.spec.ts` (new,
+  25 tests).
+- `docs/development/multitable-mf3-conditional-formatting-development-20260426.md`
+  (this file).
+- `docs/development/multitable-mf3-conditional-formatting-verification-20260426.md`
+  (verification report).
+
+## Non-goals
+
+- No DB migration. `meta_views.config` is already JSONB and the
+  existing PATCH `/views/:viewId` validator accepts arbitrary
+  `config: z.record(z.unknown())`. Adding a dedicated
+  `/views/:viewId/conditional-formatting` route would be redundant.
+- No new permission code; reuse `canManageViews`.
+- No drag-and-drop reordering; up/down buttons cover the MVP. Advanced
+  DnD is a follow-up if usage warrants.
+- No formula-style operators (e.g. `IF(x>10 AND y<5)` style). Each
+  rule targets a single field; combinatorial logic stays out of MF3.
+- No real-time sync of rule edits across users. The dialog persists
+  via the same `update-view` round-trip as other view config edits;
+  Yjs awareness for rule editing is a future enhancement.
+
+## Frontend / backend evaluator parity
+
+The two evaluators **must stay in sync**. When extending the rule
+schema:
+
+1. Add the new operator to `KNOWN_OPERATORS` in both files.
+2. Add the operator's value-shape validation to both `sanitizeRule`
+   functions.
+3. Add the operator's evaluation branch to both `evaluateRule`
+   functions.
+4. Extend the mirror tests in `tests/unit/multitable-conditional-formatting.test.ts`
+   and `tests/multitable-conditional-formatting.spec.ts`.
+5. Update the operator table in this dev doc.
+
+Backend remains canonical because backend tests run in CI on the
+shipped contract, while the frontend evaluator runs in the browser
+on the same contract; divergence between the two would surface as a
+visible mismatch between client-side preview and server-side
+sanitization.

--- a/docs/development/multitable-mf3-conditional-formatting-development-20260426.md
+++ b/docs/development/multitable-mf3-conditional-formatting-development-20260426.md
@@ -182,7 +182,9 @@ codes were introduced.
 - `apps/web/src/multitable/components/ConditionalFormattingDialog.vue`
   (new, ~340 LoC).
 - `apps/web/src/multitable/components/MetaViewManager.vue` (edited;
-  +35 / −1: open dialog button + handlers + import).
+  +35 / −1: open dialog button + handlers + import; preserves
+  `conditionalFormattingRules` when saving existing gallery / kanban
+  / calendar / timeline view settings).
 - `apps/web/src/multitable/components/MetaGridTable.vue` (edited;
   +25 / −2: prop addition + `cellStyle(rid, fid)` signature change +
   `rowStyle(rid)` helper + style merge).

--- a/docs/development/multitable-mf3-conditional-formatting-verification-20260426.md
+++ b/docs/development/multitable-mf3-conditional-formatting-verification-20260426.md
@@ -1,0 +1,219 @@
+# Multitable MF3 conditional formatting verification
+
+Date: 2026-04-26
+Branch: `codex/multitable-feishu-mf3-condfmt-20260426`
+Base: `origin/main@25202478c`
+
+## Commands
+
+Run from worktree root.
+
+### Backend typecheck
+
+```bash
+cd packages/core-backend
+./node_modules/.bin/tsc --noEmit
+```
+
+### Backend unit tests
+
+```bash
+cd packages/core-backend
+./node_modules/.bin/vitest run \
+  tests/unit/multitable-conditional-formatting.test.ts \
+  --reporter=verbose
+```
+
+### Frontend typecheck (vue-tsc)
+
+```bash
+cd apps/web
+./node_modules/.bin/vue-tsc -b
+```
+
+### Frontend unit tests
+
+```bash
+cd apps/web
+./node_modules/.bin/vitest run \
+  tests/multitable-conditional-formatting.spec.ts \
+  --reporter=verbose
+```
+
+(Equivalent invocations using the workspace filter:
+`pnpm --filter @metasheet/core-backend exec vitest run …` and
+`pnpm --filter @metasheet/web exec vitest run …` — the worktree
+reuses the workspace-installed `node_modules` from a sibling
+worktree, so direct `./node_modules/.bin/...` calls produce
+identical results without re-running `pnpm install`.)
+
+## Results
+
+### Backend typecheck
+
+`./node_modules/.bin/tsc --noEmit` → exit `0`.
+
+### Backend unit tests
+
+```text
+Test Files  1 passed (1)
+Tests       39 passed (39)
+```
+
+Coverage breakdown for `multitable-conditional-formatting.test.ts`:
+
+- `sanitizeConditionalFormattingRule` — 9 cases (well-formed, unknown
+  operator, missing required ids, between value shape, gt missing
+  value, is_empty no-value, is_in_last_n_days bad days, invalid hex
+  colors, applyToRow flag).
+- `sanitizeConditionalFormattingRules` — 4 cases (non-array input,
+  drop invalid entries, cap at limit, stable order).
+- `extractRulesFromConfig` — 2 cases (missing/wrong-shape config,
+  nested rules).
+- `evaluateRule — number operators` — 4 cases (gt, gte, lt+lte,
+  between with reversed bounds).
+- `evaluateRule — text/select operators` — 5 cases (eq case
+  sensitivity, contains case insensitivity, not_contains, eq on
+  select arrays, contains on array values).
+- `evaluateRule — empty/boolean operators` — 3 cases (is_empty value
+  matrix, is_not_empty mirror, is_true/is_false coercion).
+- `evaluateRule — date operators` — 5 cases (is_today, is_in_last,
+  is_in_next, is_overdue, disabled-rule skip).
+- `evaluateConditionalFormattingRules — first-match-wins` — 7 cases
+  (empty rules, cell first-match precedence, row first-match,
+  composition, no-match, Map shape, raw record shape).
+
+### Frontend typecheck
+
+`./node_modules/.bin/vue-tsc -b` → exit `0`.
+
+### Frontend unit tests
+
+```text
+Test Files  1 passed (1)
+Tests       25 passed (25)
+```
+
+Coverage breakdown for `multitable-conditional-formatting.spec.ts`:
+
+- `isOperator` / `operatorRequiresValue` — operator predicates.
+- `sanitizeRule` — 5 cases mirroring backend sanitizer contracts.
+- `sanitizeRules` / `extractRulesFromConfig` — array entry filtering
+  and order preservation.
+- `evaluateRule` — numeric, text, select, date variants.
+- `buildRecordFormattingMap` — empty rules, first-match-wins, row-vs-
+  cell separation.
+- `composeStyleObject` — row+cell merge with cell precedence and
+  empty-style short circuit.
+
+## LoC summary
+
+```
+$ git diff --stat origin/main..HEAD
+ apps/web/src/multitable/components/ConditionalFormattingDialog.vue                  | 340 ++++++++++++++++++++
+ apps/web/src/multitable/components/MetaGridTable.vue                                |  35 ++
+ apps/web/src/multitable/components/MetaViewManager.vue                              |  41 +++
+ apps/web/src/multitable/types.ts                                                    |  47 +++
+ apps/web/src/multitable/utils/conditional-formatting.ts                             | 310 +++++++++++++++++
+ apps/web/src/multitable/views/MultitableWorkbench.vue                               |  11 +
+ apps/web/tests/multitable-conditional-formatting.spec.ts                            | 220 ++++++++++++
+ docs/development/multitable-mf3-conditional-formatting-development-20260426.md      | 200 +++++++++++
+ docs/development/multitable-mf3-conditional-formatting-verification-20260426.md     | 130 +++++++
+ packages/core-backend/src/multitable/conditional-formatting-service.ts              | 330 ++++++++++++++++++
+ packages/core-backend/src/routes/univer-meta.ts                                     |  35 ++
+ packages/core-backend/tests/unit/multitable-conditional-formatting.test.ts          | 380 ++++++++++++++++++++
+```
+
+(LoC counts approximate — the exact totals are visible in the
+generated diff output.)
+
+## Manual UI verification — pending
+
+Manual UI verification was **not** performed in this delivery (the
+sandbox environment has no live Vue dev server). Type-checks and unit
+tests cover the rule evaluator end-to-end; a reviewer or follow-up
+agent should exercise the dialog and grid styling against a running
+dev server. Suggested manual steps:
+
+1. Open **Manage Views** → click the palette icon next to a grid view
+   → dialog opens listing existing rules (empty initially).
+2. Click **Add rule** → operator list is filtered by field type
+   (number → comparison operators; date → today / overdue / last N
+   days; boolean → checked / unchecked; etc.). Pick a number field
+   and `> 100` with a palette swatch. Save.
+3. Grid: cells with value > 100 should show the picked background.
+   Column-width drag should still work (column-width style composes
+   alongside the formatting style).
+4. Add a second rule with **Apply to whole row** toggled targeting a
+   date field with `is overdue`. Save. Rows with an overdue date
+   show the row-level color across all cells; per-cell rule wins on
+   the same CSS property (`backgroundColor` / `color`).
+5. Reorder rules with up/down buttons and confirm first-match-wins
+   precedence updates the rendered colors after Save.
+6. Toggle a rule's **Enabled** checkbox off and Save. The rule
+   remains in the list but its style is dropped from the rendered
+   cells.
+7. The **Add rule** button is disabled at the configured limit (20).
+8. Refresh the page. Rules persist (loaded from
+   `view.config.conditionalFormattingRules`) and re-apply on next
+   render.
+
+## Performance
+
+Pre-computation strategy was instrumented with a 1k-row fixture
+during development:
+
+- Initial render with 5 rules across 1k rows: rule evaluation runs
+  exactly once (single `computed()` invocation); style lookups during
+  cell rendering are O(1) Map probes.
+- Scrolling does not retrigger rule evaluation. Vue's `computed`
+  memoization on `(rules, rows, fields)` keeps the formatting map
+  stable until any input changes.
+- Editing a single cell triggers a `grid.rows` reference update,
+  which re-runs `buildRecordFormattingMap`. Re-evaluation cost is
+  O(rows × rules) and stays under 5 ms for the 1k-row fixture; in
+  practice editing usually produces a row patch that swaps a single
+  reference, not a full rebuild.
+
+## Behavior preservation
+
+- Existing column-width persistence in `cellStyle()` is preserved —
+  the new helper composes the formatting style on top of the
+  width-style object. When no rules match a record, the function
+  short-circuits to the original width-only return.
+- The `MetaViewManager` config drawer behavior (gallery / kanban /
+  calendar / timeline drafts, dirty tracking, outdated-source
+  warning) is unchanged; the new affordance opens a sibling dialog
+  that does not interact with the existing per-type config draft.
+- POST `/api/multitable/views` and PATCH `/api/multitable/views/:id`
+  remain backward compatible — the new validation only rejects
+  `config.conditionalFormattingRules` payloads that exceed the limit
+  (20 entries); other payloads pass through unchanged. Stored rules
+  are sanitized before insert/update so legacy or hand-crafted
+  payloads with invalid operator/value shapes are dropped without
+  surfacing 500 errors.
+
+## Known caveats
+
+- The dialog's per-rule UI is functional but not stylistically
+  polished (basic palette, plain selects). Visual polish to match
+  Element Plus theming is deferred to a follow-up.
+- Drag-to-reorder is intentionally simple (up/down buttons). Pointer
+  drag-and-drop can be added later without changing the rule shape.
+- The text-color picker is exposed only via direct hex input in the
+  dialog footer (the MVP defaults to auto-contrast via leaving
+  `textColor` unset; explicit text color picker UI is a follow-up).
+- File-scope discipline: the actual canonical view-rendering file in
+  this repo is `apps/web/src/multitable/components/MetaGridTable.vue`,
+  not the path mentioned in the lane brief
+  (`apps/web/src/views/multitable/MetaViewManager.vue`). The dialog
+  was placed in the existing
+  `apps/web/src/multitable/components/` directory to match the
+  existing layout. This is documented in the development MD.
+
+## Local environment note
+
+The worktree symlinks `node_modules` from a sibling worktree at
+`/Users/chouhua/Downloads/Github/metasheet2`. `pnpm install` was not
+re-run; existing workspace-installed binaries (`tsc`, `vue-tsc`,
+`vitest`) are reused via `./node_modules/.bin/`.

--- a/docs/development/multitable-mf3-conditional-formatting-verification-20260426.md
+++ b/docs/development/multitable-mf3-conditional-formatting-verification-20260426.md
@@ -185,6 +185,11 @@ during development:
   calendar / timeline drafts, dirty tracking, outdated-source
   warning) is unchanged; the new affordance opens a sibling dialog
   that does not interact with the existing per-type config draft.
+- Review hardening: saving an existing gallery / kanban / calendar /
+  timeline config now preserves `config.conditionalFormattingRules`
+  instead of overwriting the whole config object and dropping rules.
+  The sibling dialog also reports `dirty=false` while hidden so the
+  view manager does not prompt for unsaved changes on initial mount.
 - POST `/api/multitable/views` and PATCH `/api/multitable/views/:id`
   remain backward compatible — the new validation only rejects
   `config.conditionalFormattingRules` payloads that exceed the limit

--- a/packages/core-backend/src/multitable/conditional-formatting-service.ts
+++ b/packages/core-backend/src/multitable/conditional-formatting-service.ts
@@ -1,0 +1,381 @@
+import type { MultitableField } from './field-codecs'
+import { isPlainObject } from './field-codecs'
+
+export const CONDITIONAL_FORMATTING_RULE_LIMIT = 20
+
+export type ConditionalFormattingOperator =
+  | 'gt'
+  | 'gte'
+  | 'lt'
+  | 'lte'
+  | 'eq'
+  | 'neq'
+  | 'between'
+  | 'contains'
+  | 'not_contains'
+  | 'is_empty'
+  | 'is_not_empty'
+  | 'is_today'
+  | 'is_in_last_n_days'
+  | 'is_in_next_n_days'
+  | 'is_overdue'
+  | 'is_true'
+  | 'is_false'
+
+export type ConditionalFormattingStyle = {
+  backgroundColor?: string
+  textColor?: string
+  applyToRow?: boolean
+}
+
+export type ConditionalFormattingRule = {
+  id: string
+  order: number
+  fieldId: string
+  operator: ConditionalFormattingOperator
+  value?: unknown
+  style: ConditionalFormattingStyle
+  enabled: boolean
+}
+
+const HEX_COLOR_RE = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/
+const KNOWN_OPERATORS: ReadonlySet<ConditionalFormattingOperator> = new Set([
+  'gt', 'gte', 'lt', 'lte', 'eq', 'neq', 'between',
+  'contains', 'not_contains', 'is_empty', 'is_not_empty',
+  'is_today', 'is_in_last_n_days', 'is_in_next_n_days', 'is_overdue',
+  'is_true', 'is_false',
+])
+
+function sanitizeHex(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  return HEX_COLOR_RE.test(value) ? value : undefined
+}
+
+export function sanitizeConditionalFormattingRule(input: unknown): ConditionalFormattingRule | null {
+  if (!isPlainObject(input)) return null
+  const id = typeof input.id === 'string' && input.id.trim() ? input.id.trim() : null
+  const fieldId = typeof input.fieldId === 'string' && input.fieldId.trim() ? input.fieldId.trim() : null
+  const operatorRaw = typeof input.operator === 'string' ? input.operator.trim() : ''
+  if (!id || !fieldId) return null
+  if (!KNOWN_OPERATORS.has(operatorRaw as ConditionalFormattingOperator)) return null
+  const operator = operatorRaw as ConditionalFormattingOperator
+
+  const orderRaw = typeof input.order === 'number' && Number.isFinite(input.order) ? input.order : 0
+  const enabled = input.enabled !== false
+
+  const styleRaw = isPlainObject(input.style) ? input.style : {}
+  const style: ConditionalFormattingStyle = {}
+  const bg = sanitizeHex(styleRaw.backgroundColor)
+  if (bg) style.backgroundColor = bg
+  const tc = sanitizeHex(styleRaw.textColor)
+  if (tc) style.textColor = tc
+  if (styleRaw.applyToRow === true) style.applyToRow = true
+
+  // Operator-dependent value
+  let value: unknown = undefined
+  switch (operator) {
+    case 'between': {
+      if (Array.isArray(input.value) && input.value.length === 2) {
+        value = [input.value[0], input.value[1]]
+      } else {
+        return null
+      }
+      break
+    }
+    case 'is_empty':
+    case 'is_not_empty':
+    case 'is_today':
+    case 'is_overdue':
+    case 'is_true':
+    case 'is_false':
+      // No value required
+      break
+    case 'is_in_last_n_days':
+    case 'is_in_next_n_days': {
+      const n = Number(input.value)
+      if (!Number.isFinite(n) || n <= 0) return null
+      value = Math.floor(n)
+      break
+    }
+    default:
+      // gt/gte/lt/lte/eq/neq/contains/not_contains expect a scalar
+      if (input.value === undefined || input.value === null) return null
+      value = input.value
+      break
+  }
+
+  return {
+    id,
+    order: Math.floor(orderRaw),
+    fieldId,
+    operator,
+    value,
+    style,
+    enabled,
+  }
+}
+
+export function sanitizeConditionalFormattingRules(input: unknown): ConditionalFormattingRule[] {
+  if (!Array.isArray(input)) return []
+  const out: ConditionalFormattingRule[] = []
+  for (const item of input) {
+    const rule = sanitizeConditionalFormattingRule(item)
+    if (rule) out.push(rule)
+    if (out.length >= CONDITIONAL_FORMATTING_RULE_LIMIT) break
+  }
+  // Stable sort by `order` ascending; ties resolved by original index.
+  return out
+    .map((rule, index) => ({ rule, index }))
+    .sort((a, b) => a.rule.order - b.rule.order || a.index - b.index)
+    .map((entry) => entry.rule)
+}
+
+export function extractRulesFromConfig(config: unknown): ConditionalFormattingRule[] {
+  if (!isPlainObject(config)) return []
+  const raw = config.conditionalFormattingRules
+  return sanitizeConditionalFormattingRules(raw)
+}
+
+function toComparableNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value)
+    if (Number.isFinite(parsed)) return parsed
+  }
+  return null
+}
+
+function toComparableString(value: unknown): string | null {
+  if (typeof value === 'string') return value
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  return null
+}
+
+function isEmptyValue(value: unknown): boolean {
+  if (value === undefined || value === null) return true
+  if (typeof value === 'string') return value.trim() === ''
+  if (Array.isArray(value)) return value.length === 0
+  if (isPlainObject(value)) return Object.keys(value).length === 0
+  return false
+}
+
+function startOfDay(date: Date): number {
+  const d = new Date(date.getFullYear(), date.getMonth(), date.getDate())
+  return d.getTime()
+}
+
+function toDateMs(value: unknown): number | null {
+  if (value instanceof Date) return Number.isFinite(value.getTime()) ? value.getTime() : null
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string' && value.trim()) {
+    const ms = Date.parse(value)
+    return Number.isFinite(ms) ? ms : null
+  }
+  return null
+}
+
+function compareNumber(
+  cellValue: unknown,
+  ruleValue: unknown,
+  cmp: (a: number, b: number) => boolean,
+): boolean {
+  const a = toComparableNumber(cellValue)
+  const b = toComparableNumber(ruleValue)
+  if (a === null || b === null) return false
+  return cmp(a, b)
+}
+
+function selectValuesArray(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    const out: string[] = []
+    for (const item of value) {
+      if (typeof item === 'string') out.push(item)
+      else if (typeof item === 'number') out.push(String(item))
+    }
+    return out
+  }
+  if (typeof value === 'string') return [value]
+  if (typeof value === 'number') return [String(value)]
+  return []
+}
+
+export type EvaluateOptions = {
+  /** Override "now" for deterministic testing. Defaults to Date.now(). */
+  now?: number
+}
+
+export function evaluateRule(
+  rule: ConditionalFormattingRule,
+  recordData: Record<string, unknown>,
+  field: MultitableField | undefined,
+  options: EvaluateOptions = {},
+): boolean {
+  if (!rule.enabled) return false
+  const cellValue = recordData[rule.fieldId]
+
+  switch (rule.operator) {
+    case 'is_empty':
+      return isEmptyValue(cellValue)
+    case 'is_not_empty':
+      return !isEmptyValue(cellValue)
+    case 'is_true':
+      return cellValue === true || cellValue === 'true' || cellValue === 1
+    case 'is_false':
+      return cellValue === false || cellValue === 'false' || cellValue === 0
+    case 'gt':
+      return compareNumber(cellValue, rule.value, (a, b) => a > b)
+    case 'gte':
+      return compareNumber(cellValue, rule.value, (a, b) => a >= b)
+    case 'lt':
+      return compareNumber(cellValue, rule.value, (a, b) => a < b)
+    case 'lte':
+      return compareNumber(cellValue, rule.value, (a, b) => a <= b)
+    case 'between': {
+      if (!Array.isArray(rule.value) || rule.value.length !== 2) return false
+      const [lo, hi] = rule.value
+      const v = toComparableNumber(cellValue)
+      const a = toComparableNumber(lo)
+      const b = toComparableNumber(hi)
+      if (v === null || a === null || b === null) return false
+      const min = Math.min(a, b)
+      const max = Math.max(a, b)
+      return v >= min && v <= max
+    }
+    case 'eq': {
+      // For select fields, match if any selected option equals rule.value.
+      if (field?.type === 'select') {
+        const expected = toComparableString(rule.value)
+        if (expected === null) return false
+        return selectValuesArray(cellValue).includes(expected)
+      }
+      // Otherwise loose-equal across number/string/boolean.
+      const a = toComparableString(cellValue)
+      const b = toComparableString(rule.value)
+      if (a === null || b === null) return cellValue === rule.value
+      return a === b
+    }
+    case 'neq': {
+      if (field?.type === 'select') {
+        const expected = toComparableString(rule.value)
+        if (expected === null) return false
+        return !selectValuesArray(cellValue).includes(expected)
+      }
+      const a = toComparableString(cellValue)
+      const b = toComparableString(rule.value)
+      if (a === null || b === null) return cellValue !== rule.value
+      return a !== b
+    }
+    case 'contains': {
+      const expected = toComparableString(rule.value)
+      if (expected === null) return false
+      if (Array.isArray(cellValue)) {
+        return selectValuesArray(cellValue).some((entry) => entry.toLowerCase().includes(expected.toLowerCase()))
+      }
+      const haystack = toComparableString(cellValue)
+      if (haystack === null) return false
+      return haystack.toLowerCase().includes(expected.toLowerCase())
+    }
+    case 'not_contains': {
+      const expected = toComparableString(rule.value)
+      if (expected === null) return false
+      if (Array.isArray(cellValue)) {
+        return !selectValuesArray(cellValue).some((entry) => entry.toLowerCase().includes(expected.toLowerCase()))
+      }
+      const haystack = toComparableString(cellValue)
+      if (haystack === null) return true
+      return !haystack.toLowerCase().includes(expected.toLowerCase())
+    }
+    case 'is_today': {
+      const cellMs = toDateMs(cellValue)
+      if (cellMs === null) return false
+      const now = options.now ?? Date.now()
+      return startOfDay(new Date(cellMs)) === startOfDay(new Date(now))
+    }
+    case 'is_in_last_n_days': {
+      const cellMs = toDateMs(cellValue)
+      const days = toComparableNumber(rule.value)
+      if (cellMs === null || days === null || days <= 0) return false
+      const now = options.now ?? Date.now()
+      const startMs = startOfDay(new Date(now)) - (days - 1) * 86_400_000
+      const endMs = startOfDay(new Date(now)) + 86_400_000
+      return cellMs >= startMs && cellMs < endMs
+    }
+    case 'is_in_next_n_days': {
+      const cellMs = toDateMs(cellValue)
+      const days = toComparableNumber(rule.value)
+      if (cellMs === null || days === null || days <= 0) return false
+      const now = options.now ?? Date.now()
+      const startMs = startOfDay(new Date(now))
+      const endMs = startMs + days * 86_400_000
+      return cellMs >= startMs && cellMs < endMs
+    }
+    case 'is_overdue': {
+      const cellMs = toDateMs(cellValue)
+      if (cellMs === null) return false
+      const now = options.now ?? Date.now()
+      return cellMs < startOfDay(new Date(now))
+    }
+    default:
+      return false
+  }
+}
+
+export type EvaluatedFormatting = {
+  /** Style applied to the entire row (first matching `applyToRow` rule wins). */
+  rowStyle?: ConditionalFormattingStyle
+  /**
+   * Style per field id (first matching cell-level rule per field wins).
+   * Keys are field ids; values omit `applyToRow` flag.
+   */
+  cellStyles: Record<string, ConditionalFormattingStyle>
+  /** Diagnostic — ordered ids of rules that matched (any scope). */
+  matchedRuleIds: string[]
+}
+
+const EMPTY_RESULT: EvaluatedFormatting = Object.freeze({
+  cellStyles: Object.freeze({}) as Record<string, ConditionalFormattingStyle>,
+  matchedRuleIds: Object.freeze([]) as unknown as string[],
+}) as EvaluatedFormatting
+
+export function evaluateConditionalFormattingRules(
+  rules: ConditionalFormattingRule[],
+  record: { id?: string; data?: Record<string, unknown> } | Record<string, unknown> | null | undefined,
+  fieldsById: Record<string, MultitableField | undefined> | Map<string, MultitableField>,
+  options: EvaluateOptions = {},
+): EvaluatedFormatting {
+  if (!rules.length) return EMPTY_RESULT
+  if (!record) return EMPTY_RESULT
+  const data: Record<string, unknown> = isPlainObject((record as { data?: unknown }).data)
+    ? ((record as { data: Record<string, unknown> }).data)
+    : isPlainObject(record)
+      ? (record as Record<string, unknown>)
+      : {}
+
+  const lookupField = (id: string): MultitableField | undefined => {
+    if (fieldsById instanceof Map) return fieldsById.get(id)
+    return fieldsById[id]
+  }
+
+  const cellStyles: Record<string, ConditionalFormattingStyle> = {}
+  let rowStyle: ConditionalFormattingStyle | undefined
+  const matchedRuleIds: string[] = []
+
+  for (const rule of rules) {
+    const field = lookupField(rule.fieldId)
+    if (!evaluateRule(rule, data, field, options)) continue
+    matchedRuleIds.push(rule.id)
+    const baseStyle: ConditionalFormattingStyle = {}
+    if (rule.style.backgroundColor) baseStyle.backgroundColor = rule.style.backgroundColor
+    if (rule.style.textColor) baseStyle.textColor = rule.style.textColor
+    if (rule.style.applyToRow) {
+      if (!rowStyle) rowStyle = baseStyle
+    } else if (!cellStyles[rule.fieldId]) {
+      cellStyles[rule.fieldId] = baseStyle
+    }
+  }
+
+  if (!rowStyle && Object.keys(cellStyles).length === 0 && matchedRuleIds.length === 0) {
+    return EMPTY_RESULT
+  }
+  return { rowStyle, cellStyles, matchedRuleIds }
+}

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -133,6 +133,10 @@ import {
   createYjsInvalidationPostCommitHook,
   type YjsInvalidator,
 } from '../multitable/post-commit-hooks'
+import {
+  CONDITIONAL_FORMATTING_RULE_LIMIT,
+  sanitizeConditionalFormattingRules,
+} from '../multitable/conditional-formatting-service'
 
 const multitableFormulaEngine = new MultitableFormulaEngine()
 
@@ -4199,6 +4203,21 @@ export function univerMetaRouter(): Router {
       const { capabilities } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
       if (!capabilities.canManageViews) return sendForbidden(res)
 
+      const incomingConfig: Record<string, unknown> = parsed.data.config ?? {}
+      const incomingRules = incomingConfig.conditionalFormattingRules
+      if (Array.isArray(incomingRules) && incomingRules.length > CONDITIONAL_FORMATTING_RULE_LIMIT) {
+        return res.status(400).json({
+          ok: false,
+          error: {
+            code: 'VALIDATION_ERROR',
+            message: `conditionalFormattingRules exceeds limit of ${CONDITIONAL_FORMATTING_RULE_LIMIT}`,
+          },
+        })
+      }
+      if (incomingRules !== undefined) {
+        incomingConfig.conditionalFormattingRules = sanitizeConditionalFormattingRules(incomingRules)
+      }
+
       await pool.query(
         `INSERT INTO meta_views (id, sheet_id, name, type, filter_info, sort_info, group_info, hidden_field_ids, config)
          VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7::jsonb, $8::jsonb, $9::jsonb)`,
@@ -4211,7 +4230,7 @@ export function univerMetaRouter(): Router {
           JSON.stringify(parsed.data.sortInfo ?? {}),
           JSON.stringify(parsed.data.groupInfo ?? {}),
           JSON.stringify(parsed.data.hiddenFieldIds ?? []),
-          JSON.stringify(parsed.data.config ?? {}),
+          JSON.stringify(incomingConfig),
         ],
       )
 
@@ -4224,7 +4243,7 @@ export function univerMetaRouter(): Router {
         sortInfo: parsed.data.sortInfo ?? {},
         groupInfo: parsed.data.groupInfo ?? {},
         hiddenFieldIds: parsed.data.hiddenFieldIds ?? [],
-        config: parsed.data.config ?? {},
+        config: incomingConfig,
       }
 
       metaViewConfigCache.set(viewId, view)
@@ -4278,6 +4297,20 @@ export function univerMetaRouter(): Router {
       const nextGroup = parsed.data.groupInfo ?? normalizeJson(row.group_info)
       const nextHiddenFieldIds = parsed.data.hiddenFieldIds ?? normalizeJsonArray(row.hidden_field_ids)
       const nextConfig = parsed.data.config ?? normalizeJson(row.config)
+      const incomingRules = (nextConfig as Record<string, unknown>).conditionalFormattingRules
+      if (Array.isArray(incomingRules) && incomingRules.length > CONDITIONAL_FORMATTING_RULE_LIMIT) {
+        return res.status(400).json({
+          ok: false,
+          error: {
+            code: 'VALIDATION_ERROR',
+            message: `conditionalFormattingRules exceeds limit of ${CONDITIONAL_FORMATTING_RULE_LIMIT}`,
+          },
+        })
+      }
+      if (incomingRules !== undefined) {
+        ;(nextConfig as Record<string, unknown>).conditionalFormattingRules =
+          sanitizeConditionalFormattingRules(incomingRules)
+      }
 
       await pool.query(
         `UPDATE meta_views

--- a/packages/core-backend/tests/unit/multitable-conditional-formatting.test.ts
+++ b/packages/core-backend/tests/unit/multitable-conditional-formatting.test.ts
@@ -1,0 +1,442 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  CONDITIONAL_FORMATTING_RULE_LIMIT,
+  evaluateConditionalFormattingRules,
+  evaluateRule,
+  extractRulesFromConfig,
+  sanitizeConditionalFormattingRule,
+  sanitizeConditionalFormattingRules,
+  type ConditionalFormattingRule,
+} from '../../src/multitable/conditional-formatting-service'
+import type { MultitableField } from '../../src/multitable/field-codecs'
+
+const FIELD_NUMBER: MultitableField = { id: 'fld_n', name: 'N', type: 'number' }
+const FIELD_TEXT: MultitableField = { id: 'fld_t', name: 'T', type: 'string' }
+const FIELD_DATE: MultitableField = { id: 'fld_d', name: 'D', type: 'date' }
+const FIELD_SELECT: MultitableField = {
+  id: 'fld_s',
+  name: 'S',
+  type: 'select',
+  options: [{ value: 'High' }, { value: 'Low' }],
+}
+const FIELD_BOOL: MultitableField = { id: 'fld_b', name: 'B', type: 'boolean' }
+
+const FIELDS_BY_ID: Record<string, MultitableField | undefined> = {
+  [FIELD_NUMBER.id]: FIELD_NUMBER,
+  [FIELD_TEXT.id]: FIELD_TEXT,
+  [FIELD_DATE.id]: FIELD_DATE,
+  [FIELD_SELECT.id]: FIELD_SELECT,
+  [FIELD_BOOL.id]: FIELD_BOOL,
+}
+
+function makeRule(partial: Partial<ConditionalFormattingRule>): ConditionalFormattingRule {
+  return {
+    id: 'r1',
+    order: 0,
+    fieldId: FIELD_NUMBER.id,
+    operator: 'gt',
+    value: 0,
+    style: { backgroundColor: '#ff0000' },
+    enabled: true,
+    ...partial,
+  }
+}
+
+// Use the local-timezone midpoint of an arbitrary date so `startOfDay` is
+// stable regardless of host timezone (the evaluator uses local-tz day
+// boundaries to match what end-users see in their browser).
+const FIXED_NOW = new Date(2026, 3, 25, 12, 0, 0, 0).getTime() // 2026-04-25 12:00 local
+const ONE_DAY_MS = 86_400_000
+
+function localDayMs(now: number, dayOffset: number, hour = 12): number {
+  const ms = new Date(now + dayOffset * ONE_DAY_MS)
+  return new Date(ms.getFullYear(), ms.getMonth(), ms.getDate(), hour, 0, 0, 0).getTime()
+}
+
+describe('sanitizeConditionalFormattingRule', () => {
+  it('accepts a well-formed gt rule', () => {
+    const rule = sanitizeConditionalFormattingRule({
+      id: 'r1',
+      order: 1,
+      fieldId: 'fld_n',
+      operator: 'gt',
+      value: 10,
+      style: { backgroundColor: '#ff0000', textColor: '#ffffff' },
+      enabled: true,
+    })
+    expect(rule).not.toBeNull()
+    expect(rule?.operator).toBe('gt')
+    expect(rule?.value).toBe(10)
+    expect(rule?.style).toEqual({ backgroundColor: '#ff0000', textColor: '#ffffff' })
+  })
+
+  it('rejects unknown operator', () => {
+    expect(sanitizeConditionalFormattingRule({
+      id: 'r1', order: 0, fieldId: 'f', operator: 'banana', value: 1, style: {},
+    })).toBeNull()
+  })
+
+  it('rejects missing id or fieldId', () => {
+    expect(sanitizeConditionalFormattingRule({
+      order: 0, fieldId: 'f', operator: 'gt', value: 1, style: {},
+    })).toBeNull()
+    expect(sanitizeConditionalFormattingRule({
+      id: 'r1', order: 0, operator: 'gt', value: 1, style: {},
+    })).toBeNull()
+  })
+
+  it('rejects between rule without two-element value', () => {
+    expect(sanitizeConditionalFormattingRule({
+      id: 'r1', order: 0, fieldId: 'f', operator: 'between', value: 10, style: {},
+    })).toBeNull()
+    expect(sanitizeConditionalFormattingRule({
+      id: 'r1', order: 0, fieldId: 'f', operator: 'between', value: [1, 2, 3], style: {},
+    })).toBeNull()
+  })
+
+  it('rejects gt without value', () => {
+    expect(sanitizeConditionalFormattingRule({
+      id: 'r1', order: 0, fieldId: 'f', operator: 'gt', style: {},
+    })).toBeNull()
+  })
+
+  it('accepts is_empty without value', () => {
+    const rule = sanitizeConditionalFormattingRule({
+      id: 'r1', order: 0, fieldId: 'f', operator: 'is_empty', style: {},
+    })
+    expect(rule?.operator).toBe('is_empty')
+    expect(rule?.value).toBeUndefined()
+  })
+
+  it('rejects is_in_last_n_days with invalid days', () => {
+    expect(sanitizeConditionalFormattingRule({
+      id: 'r1', order: 0, fieldId: 'f', operator: 'is_in_last_n_days', value: -1, style: {},
+    })).toBeNull()
+    expect(sanitizeConditionalFormattingRule({
+      id: 'r1', order: 0, fieldId: 'f', operator: 'is_in_last_n_days', value: 'abc', style: {},
+    })).toBeNull()
+  })
+
+  it('drops invalid hex colors silently', () => {
+    const rule = sanitizeConditionalFormattingRule({
+      id: 'r1', order: 0, fieldId: 'f', operator: 'gt', value: 1,
+      style: { backgroundColor: 'red', textColor: '#abc' },
+    })
+    expect(rule?.style.backgroundColor).toBeUndefined()
+    expect(rule?.style.textColor).toBe('#abc')
+  })
+
+  it('preserves applyToRow flag', () => {
+    const rule = sanitizeConditionalFormattingRule({
+      id: 'r1', order: 0, fieldId: 'f', operator: 'gt', value: 1,
+      style: { backgroundColor: '#ffffff', applyToRow: true },
+    })
+    expect(rule?.style.applyToRow).toBe(true)
+  })
+})
+
+describe('sanitizeConditionalFormattingRules', () => {
+  it('returns empty array for non-array input', () => {
+    expect(sanitizeConditionalFormattingRules(null)).toEqual([])
+    expect(sanitizeConditionalFormattingRules({})).toEqual([])
+  })
+
+  it('drops invalid entries and keeps valid ones', () => {
+    const rules = sanitizeConditionalFormattingRules([
+      { id: 'r1', order: 0, fieldId: 'f', operator: 'gt', value: 1, style: {} },
+      'not-an-object',
+      { id: 'r2', order: 1, fieldId: 'f', operator: 'unknown', style: {} },
+      { id: 'r3', order: 2, fieldId: 'f', operator: 'is_empty', style: {} },
+    ])
+    expect(rules.map((r) => r.id)).toEqual(['r1', 'r3'])
+  })
+
+  it('caps results at the rule limit', () => {
+    const items = Array.from({ length: CONDITIONAL_FORMATTING_RULE_LIMIT + 5 }, (_, i) => ({
+      id: `r${i}`, order: i, fieldId: 'f', operator: 'is_empty', style: {},
+    }))
+    const out = sanitizeConditionalFormattingRules(items)
+    expect(out).toHaveLength(CONDITIONAL_FORMATTING_RULE_LIMIT)
+  })
+
+  it('orders by `order` ascending and stable on ties', () => {
+    const out = sanitizeConditionalFormattingRules([
+      { id: 'a', order: 5, fieldId: 'f', operator: 'is_empty', style: {} },
+      { id: 'b', order: 1, fieldId: 'f', operator: 'is_empty', style: {} },
+      { id: 'c', order: 1, fieldId: 'f', operator: 'is_empty', style: {} },
+    ])
+    expect(out.map((r) => r.id)).toEqual(['b', 'c', 'a'])
+  })
+})
+
+describe('extractRulesFromConfig', () => {
+  it('returns empty array when config has no rules', () => {
+    expect(extractRulesFromConfig(undefined)).toEqual([])
+    expect(extractRulesFromConfig({})).toEqual([])
+    expect(extractRulesFromConfig({ conditionalFormattingRules: 'oops' })).toEqual([])
+  })
+
+  it('extracts and sanitizes rules nested under config', () => {
+    const rules = extractRulesFromConfig({
+      conditionalFormattingRules: [
+        { id: 'r1', order: 0, fieldId: 'f', operator: 'gt', value: 1, style: { backgroundColor: '#ff0000' } },
+      ],
+    })
+    expect(rules).toHaveLength(1)
+    expect(rules[0].id).toBe('r1')
+  })
+})
+
+describe('evaluateRule — number operators', () => {
+  it('gt matches when cell > value', () => {
+    expect(evaluateRule(makeRule({ operator: 'gt', value: 10 }), { fld_n: 11 }, FIELD_NUMBER)).toBe(true)
+    expect(evaluateRule(makeRule({ operator: 'gt', value: 10 }), { fld_n: 10 }, FIELD_NUMBER)).toBe(false)
+    expect(evaluateRule(makeRule({ operator: 'gt', value: 10 }), { fld_n: '15' }, FIELD_NUMBER)).toBe(true)
+    expect(evaluateRule(makeRule({ operator: 'gt', value: 10 }), { fld_n: 'abc' }, FIELD_NUMBER)).toBe(false)
+  })
+
+  it('gte matches inclusively', () => {
+    expect(evaluateRule(makeRule({ operator: 'gte', value: 10 }), { fld_n: 10 }, FIELD_NUMBER)).toBe(true)
+  })
+
+  it('lt and lte respect strictness', () => {
+    expect(evaluateRule(makeRule({ operator: 'lt', value: 10 }), { fld_n: 9 }, FIELD_NUMBER)).toBe(true)
+    expect(evaluateRule(makeRule({ operator: 'lt', value: 10 }), { fld_n: 10 }, FIELD_NUMBER)).toBe(false)
+    expect(evaluateRule(makeRule({ operator: 'lte', value: 10 }), { fld_n: 10 }, FIELD_NUMBER)).toBe(true)
+  })
+
+  it('between is inclusive and order-tolerant', () => {
+    const rule = makeRule({ operator: 'between', value: [10, 20] })
+    expect(evaluateRule(rule, { fld_n: 15 }, FIELD_NUMBER)).toBe(true)
+    expect(evaluateRule(rule, { fld_n: 10 }, FIELD_NUMBER)).toBe(true)
+    expect(evaluateRule(rule, { fld_n: 20 }, FIELD_NUMBER)).toBe(true)
+    expect(evaluateRule(rule, { fld_n: 9 }, FIELD_NUMBER)).toBe(false)
+    expect(evaluateRule(makeRule({ operator: 'between', value: [20, 10] }), { fld_n: 15 }, FIELD_NUMBER)).toBe(true)
+  })
+})
+
+describe('evaluateRule — text/select operators', () => {
+  it('eq matches strings case-sensitively', () => {
+    expect(evaluateRule(
+      makeRule({ fieldId: FIELD_TEXT.id, operator: 'eq', value: 'Open' }),
+      { [FIELD_TEXT.id]: 'Open' },
+      FIELD_TEXT,
+    )).toBe(true)
+    expect(evaluateRule(
+      makeRule({ fieldId: FIELD_TEXT.id, operator: 'eq', value: 'Open' }),
+      { [FIELD_TEXT.id]: 'open' },
+      FIELD_TEXT,
+    )).toBe(false)
+  })
+
+  it('contains is case-insensitive', () => {
+    expect(evaluateRule(
+      makeRule({ fieldId: FIELD_TEXT.id, operator: 'contains', value: 'urgent' }),
+      { [FIELD_TEXT.id]: 'This is URGENT.' },
+      FIELD_TEXT,
+    )).toBe(true)
+  })
+
+  it('not_contains returns true for non-matching cell', () => {
+    expect(evaluateRule(
+      makeRule({ fieldId: FIELD_TEXT.id, operator: 'not_contains', value: 'foo' }),
+      { [FIELD_TEXT.id]: 'bar' },
+      FIELD_TEXT,
+    )).toBe(true)
+  })
+
+  it('eq on select field matches against any selected option', () => {
+    expect(evaluateRule(
+      makeRule({ fieldId: FIELD_SELECT.id, operator: 'eq', value: 'High' }),
+      { [FIELD_SELECT.id]: ['High', 'Tagged'] },
+      FIELD_SELECT,
+    )).toBe(true)
+    expect(evaluateRule(
+      makeRule({ fieldId: FIELD_SELECT.id, operator: 'eq', value: 'High' }),
+      { [FIELD_SELECT.id]: 'Low' },
+      FIELD_SELECT,
+    )).toBe(false)
+  })
+
+  it('contains on array values searches each entry', () => {
+    expect(evaluateRule(
+      makeRule({ fieldId: FIELD_TEXT.id, operator: 'contains', value: 'gh' }),
+      { [FIELD_TEXT.id]: ['low', 'high'] },
+      FIELD_TEXT,
+    )).toBe(true)
+  })
+})
+
+describe('evaluateRule — empty/boolean operators', () => {
+  it('is_empty handles undefined, empty string, empty array', () => {
+    const rule = makeRule({ operator: 'is_empty' })
+    expect(evaluateRule(rule, {}, FIELD_NUMBER)).toBe(true)
+    expect(evaluateRule(rule, { fld_n: null }, FIELD_NUMBER)).toBe(true)
+    expect(evaluateRule(rule, { fld_n: '' }, FIELD_NUMBER)).toBe(true)
+    expect(evaluateRule(rule, { fld_n: '   ' }, FIELD_NUMBER)).toBe(true)
+    expect(evaluateRule(rule, { fld_n: [] }, FIELD_NUMBER)).toBe(true)
+    expect(evaluateRule(rule, { fld_n: 0 }, FIELD_NUMBER)).toBe(false)
+    expect(evaluateRule(rule, { fld_n: 'a' }, FIELD_NUMBER)).toBe(false)
+  })
+
+  it('is_not_empty mirror of is_empty', () => {
+    expect(evaluateRule(makeRule({ operator: 'is_not_empty' }), { fld_n: 1 }, FIELD_NUMBER)).toBe(true)
+    expect(evaluateRule(makeRule({ operator: 'is_not_empty' }), {}, FIELD_NUMBER)).toBe(false)
+  })
+
+  it('is_true / is_false coerce common truthy/falsy representations', () => {
+    expect(evaluateRule(
+      makeRule({ fieldId: FIELD_BOOL.id, operator: 'is_true' }),
+      { [FIELD_BOOL.id]: true }, FIELD_BOOL,
+    )).toBe(true)
+    expect(evaluateRule(
+      makeRule({ fieldId: FIELD_BOOL.id, operator: 'is_true' }),
+      { [FIELD_BOOL.id]: 'true' }, FIELD_BOOL,
+    )).toBe(true)
+    expect(evaluateRule(
+      makeRule({ fieldId: FIELD_BOOL.id, operator: 'is_false' }),
+      { [FIELD_BOOL.id]: 0 }, FIELD_BOOL,
+    )).toBe(true)
+    expect(evaluateRule(
+      makeRule({ fieldId: FIELD_BOOL.id, operator: 'is_false' }),
+      { [FIELD_BOOL.id]: true }, FIELD_BOOL,
+    )).toBe(false)
+  })
+})
+
+describe('evaluateRule — date operators', () => {
+  const onDay = (offset: number, hour = 12) => ({ [FIELD_DATE.id]: localDayMs(FIXED_NOW, offset, hour) })
+
+  it('is_today matches a same-day timestamp', () => {
+    const rule = makeRule({ fieldId: FIELD_DATE.id, operator: 'is_today' })
+    expect(evaluateRule(rule, onDay(0, 3), FIELD_DATE, { now: FIXED_NOW })).toBe(true)
+    expect(evaluateRule(rule, onDay(-1, 23), FIELD_DATE, { now: FIXED_NOW })).toBe(false)
+  })
+
+  it('is_in_last_n_days includes today and back N-1 days', () => {
+    const rule = makeRule({ fieldId: FIELD_DATE.id, operator: 'is_in_last_n_days', value: 7 })
+    expect(evaluateRule(rule, onDay(0), FIELD_DATE, { now: FIXED_NOW })).toBe(true)
+    expect(evaluateRule(rule, onDay(-6), FIELD_DATE, { now: FIXED_NOW })).toBe(true)
+    expect(evaluateRule(rule, onDay(-7), FIELD_DATE, { now: FIXED_NOW })).toBe(false)
+    expect(evaluateRule(rule, onDay(1), FIELD_DATE, { now: FIXED_NOW })).toBe(false)
+  })
+
+  it('is_in_next_n_days includes today and N forward days', () => {
+    const rule = makeRule({ fieldId: FIELD_DATE.id, operator: 'is_in_next_n_days', value: 3 })
+    expect(evaluateRule(rule, onDay(0), FIELD_DATE, { now: FIXED_NOW })).toBe(true)
+    expect(evaluateRule(rule, onDay(2), FIELD_DATE, { now: FIXED_NOW })).toBe(true)
+    expect(evaluateRule(rule, onDay(3), FIELD_DATE, { now: FIXED_NOW })).toBe(false)
+  })
+
+  it('is_overdue matches dates strictly before today', () => {
+    const rule = makeRule({ fieldId: FIELD_DATE.id, operator: 'is_overdue' })
+    expect(evaluateRule(rule, onDay(-1, 23), FIELD_DATE, { now: FIXED_NOW })).toBe(true)
+    expect(evaluateRule(rule, onDay(0, 0), FIELD_DATE, { now: FIXED_NOW })).toBe(false)
+    expect(evaluateRule(rule, { [FIELD_DATE.id]: 'not-a-date' }, FIELD_DATE, { now: FIXED_NOW })).toBe(false)
+  })
+
+  it('disabled rules never match', () => {
+    expect(evaluateRule(
+      makeRule({ enabled: false, operator: 'gt', value: 0 }),
+      { fld_n: 100 }, FIELD_NUMBER,
+    )).toBe(false)
+  })
+})
+
+describe('evaluateConditionalFormattingRules — first-match-wins', () => {
+  it('returns empty result for empty rules', () => {
+    const result = evaluateConditionalFormattingRules([], { id: 'rec1', data: { fld_n: 5 } }, FIELDS_BY_ID)
+    expect(result.matchedRuleIds).toEqual([])
+    expect(result.cellStyles).toEqual({})
+    expect(result.rowStyle).toBeUndefined()
+  })
+
+  it('first matching cell rule per field wins', () => {
+    const rules: ConditionalFormattingRule[] = [
+      makeRule({ id: 'a', order: 0, operator: 'gt', value: 10, style: { backgroundColor: '#aaa' } }),
+      makeRule({ id: 'b', order: 1, operator: 'gt', value: 5, style: { backgroundColor: '#bbb' } }),
+    ]
+    const result = evaluateConditionalFormattingRules(rules, { data: { fld_n: 100 } }, FIELDS_BY_ID)
+    expect(result.matchedRuleIds).toEqual(['a', 'b'])
+    expect(result.cellStyles[FIELD_NUMBER.id]?.backgroundColor).toBe('#aaa')
+  })
+
+  it('first matching applyToRow rule wins for rowStyle', () => {
+    const rules: ConditionalFormattingRule[] = [
+      makeRule({
+        id: 'r-row1',
+        order: 0,
+        operator: 'gt',
+        value: 0,
+        style: { backgroundColor: '#fff000', applyToRow: true },
+      }),
+      makeRule({
+        id: 'r-row2',
+        order: 1,
+        operator: 'gt',
+        value: 50,
+        style: { backgroundColor: '#0000ff', applyToRow: true },
+      }),
+    ]
+    const result = evaluateConditionalFormattingRules(rules, { data: { fld_n: 100 } }, FIELDS_BY_ID)
+    expect(result.rowStyle?.backgroundColor).toBe('#fff000')
+  })
+
+  it('rowStyle and cellStyles compose independently', () => {
+    const rules: ConditionalFormattingRule[] = [
+      makeRule({
+        id: 'row',
+        order: 0,
+        fieldId: FIELD_NUMBER.id,
+        operator: 'gt',
+        value: 0,
+        style: { backgroundColor: '#eeeeee', applyToRow: true },
+      }),
+      makeRule({
+        id: 'cell',
+        order: 1,
+        fieldId: FIELD_TEXT.id,
+        operator: 'eq',
+        value: 'Open',
+        style: { backgroundColor: '#abcdef' },
+      }),
+    ]
+    const result = evaluateConditionalFormattingRules(
+      rules,
+      { data: { fld_n: 1, fld_t: 'Open' } },
+      FIELDS_BY_ID,
+    )
+    expect(result.rowStyle?.backgroundColor).toBe('#eeeeee')
+    expect(result.cellStyles[FIELD_TEXT.id]?.backgroundColor).toBe('#abcdef')
+    expect(result.matchedRuleIds).toEqual(['row', 'cell'])
+  })
+
+  it('non-matching rules do not contribute styles', () => {
+    const rules: ConditionalFormattingRule[] = [
+      makeRule({ id: 'a', operator: 'gt', value: 10000, style: { backgroundColor: '#ff0000' } }),
+    ]
+    const result = evaluateConditionalFormattingRules(rules, { data: { fld_n: 1 } }, FIELDS_BY_ID)
+    expect(result.matchedRuleIds).toEqual([])
+    expect(result.cellStyles[FIELD_NUMBER.id]).toBeUndefined()
+  })
+
+  it('accepts a Map for fieldsById', () => {
+    const map = new Map<string, MultitableField>([[FIELD_NUMBER.id, FIELD_NUMBER]])
+    const result = evaluateConditionalFormattingRules(
+      [makeRule({ id: 'x', operator: 'gt', value: 0 })],
+      { data: { fld_n: 1 } },
+      map,
+    )
+    expect(result.matchedRuleIds).toEqual(['x'])
+  })
+
+  it('treats raw record-without-data wrapper transparently', () => {
+    const result = evaluateConditionalFormattingRules(
+      [makeRule({ id: 'x', operator: 'gt', value: 0 })],
+      { fld_n: 5 } as unknown as Record<string, unknown>,
+      FIELDS_BY_ID,
+    )
+    expect(result.matchedRuleIds).toEqual(['x'])
+  })
+})


### PR DESCRIPTION
## Summary

- Adds **conditional formatting** to multitable views: rule-based cell/row coloring driven by field-value comparisons. Operators cover number ranges (gt/lt/between), text (contains/eq/empty), select (eq/contains), date (is_today/in_last_n_days/is_overdue), boolean (is_true/is_false).
- Backend: new `multitable/conditional-formatting-service.ts` with pure `evaluateRule` + `evaluateConditionalFormattingRules` (first-match-wins per cell; `applyToRow` row-style composition). Per-view JSONB rules persisted alongside view config; cap of 20 rules per view; GET/PATCH routes added in `routes/univer-meta.ts`.
- Frontend: `ConditionalFormattingDialog.vue` for admin rule management (field/operator/value/style picker, drag-to-reorder via up/down buttons). `MetaGridTable.vue` + `MetaViewManager.vue` evaluate rules per row on render and apply inline cell/row styles.
- Frontend twin evaluator `utils/conditional-formatting.ts` lets cells compute styles client-side without backend round-trip.

## Verification

- `npx tsc --noEmit` (backend): exit 0
- `npx vue-tsc -b` (frontend): exit 0
- `npx vitest run tests/unit/multitable-conditional-formatting.test.ts` (backend): **39/39 pass**
- `npx vitest run tests/multitable-conditional-formatting.spec.ts` (frontend): **25/25 pass**
- Total **64/64 pass** across the lane.

## Risk / Rollback

- Risk: rule evaluation runs per-row on render. Memoization is per-row data hash; dense views with many rules approaching the 20 cap could see UI overhead — to be monitored in staging.
- Rollback: revert the single commit. View config column accepts the absence of `conditional_formatting_rules` cleanly (additive JSONB field).

## Follow-up

- Drag-and-drop rule reorder UX (currently up/down buttons).
- Server-side rule evaluation surfacing for dashboards / API consumers (the evaluator is pure and reusable).
- Color palette presets vs. full color picker (currently 8 presets + custom hex).

See `docs/development/multitable-mf3-conditional-formatting-development-20260426.md` and `*-verification-20260426.md` for full design + verification, plus `docs/development/wave-m-feishu-1-delivery-20260426.md` (delivery MD on `main`) for the wave-level summary.