### PR TITLE
fix(integration): coerce K3 WISE adapter autoSubmit/autoAudit hand-edits

### DIFF
--- a/docs/development/integration-core-k3-wise-adapter-autosubmit-coercion-design-20260426.md
+++ b/docs/development/integration-core-k3-wise-adapter-autosubmit-coercion-design-20260426.md
@@ -1,0 +1,139 @@
+# K3 WISE WebAPI Adapter autoSubmit/autoAudit Coercion · Design
+
+> Date: 2026-04-26
+> Trigger: post-#1182 audit pass; surfaced same bug class in plugin internals
+> Bug class source: PR #1175 / #1176 / #1177 / #1182 evidence-script audit series
+> Scope: plugin-internal adapter (operator-facing), not customer-facing scripts
+
+## Problem
+
+The K3 WISE WebAPI adapter resolves `autoSubmit` / `autoAudit` from a combination of pipeline request options and external system config:
+
+```javascript
+// scripts/ops/.../k3-wise-webapi-adapter.cjs lines 442-443 (pre-fix)
+const autoSubmit = request.options.autoSubmit === true || (request.options.autoSubmit !== false && config.autoSubmit === true)
+const autoAudit  = request.options.autoAudit  === true || (request.options.autoAudit  !== false && config.autoAudit  === true)
+```
+
+Read literally: "request override is true → enabled; otherwise, if request override is *not literally `false`*, fall back to config." Strict equality on both branches.
+
+**The unsafe direction**: an operator who hand-edits `request.options.autoSubmit = "false"` (string) to disable auto-submit gets the **opposite** of intent:
+- First clause: `"false" === true` → `false`
+- Second clause: `"false" !== false` → **true** (because string ≠ boolean) → `&& config.autoSubmit === true` → `true` if config.autoSubmit is `true`
+- Overall: `false || (true && true)` = **true** → `autoSubmit` fires
+
+The operator wanted to disable auto-submit; the adapter fires auto-submit anyway because the strict-equality check failed to recognize the string `"false"` as a falsy override.
+
+This is the same bug class as the evidence compiler audit series (#1175, #1176, #1177, #1182) — strict equality silently failing on string/numeric/Chinese variants of booleans. **In this case the unsafe direction is a real safety concern**: K3 WISE auto-submit/audit moves a saved record into a workflow state that may require explicit customer approval to roll back.
+
+## Solution
+
+Add a tri-state coercion helper local to the adapter (mirroring the audit-script discipline of local helpers, no shared module dependency):
+
+```javascript
+const TRUE_BOOLEAN_TEXT = new Set(['true', '1', 'yes', 'y', 'on', '是', '启用', '开启'])
+const FALSE_BOOLEAN_TEXT = new Set(['false', '0', 'no', 'n', 'off', '否', '禁用', '关闭'])
+
+function coerceTriBool(value, field) {
+  if (value === undefined || value === null) return null  // truly unset
+  if (typeof value === 'boolean') return value
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) throw new AdapterValidationError(...)
+    if (value === 1) return true
+    if (value === 0) return false
+    throw new AdapterValidationError(...)
+  }
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase()
+    if (normalized.length === 0) return null  // empty string treated as unset
+    if (TRUE_BOOLEAN_TEXT.has(normalized)) return true
+    if (FALSE_BOOLEAN_TEXT.has(normalized)) return false
+  }
+  throw new AdapterValidationError(...)
+}
+
+function resolveAutoFlag(requestValue, configValue, field) {
+  const requestExplicit = coerceTriBool(requestValue, `request.options.${field}`)
+  if (requestExplicit !== null) return requestExplicit  // explicit request wins
+  const configExplicit = coerceTriBool(configValue, `config.${field}`)
+  return configExplicit === true  // config drives if request unset; default false
+}
+```
+
+Then the call sites become:
+
+```javascript
+const autoSubmit = resolveAutoFlag(request.options.autoSubmit, config.autoSubmit, 'autoSubmit')
+const autoAudit  = resolveAutoFlag(request.options.autoAudit,  config.autoAudit,  'autoAudit')
+```
+
+### Why tri-state (not 2-state)
+
+The original logic distinguishes 3 states for `request.options.autoSubmit`:
+1. **Explicit true** → enable
+2. **Explicit false** → disable (override config truthy)
+3. **Unset** → fall back to config
+
+A 2-state coercion (just true/false) would lose the "unset" signal — `coerceTriBool(undefined)` would have to return either `false` (over-disabling cases the config wanted) or `true` (over-enabling cases the operator never approved). The 3rd state (`null` = unset) preserves the intended "request overrides config when explicit, otherwise config drives" contract while fixing the string-coercion bug.
+
+### Coercion table
+
+| `request.options.autoSubmit` | `config.autoSubmit` | Result | Why |
+|---|---|---|---|
+| `true` | (any) | `true` | Explicit request true |
+| `false` | (any, even `true`) | `false` | Explicit request false (intent honored) |
+| `"true"` / `"是"` / `1` | (any) | `true` | Coerced explicit true |
+| `"false"` / `"否"` / `0` | (any, even `true`) | `false` | Coerced explicit false (HEADLINE FIX — was previously firing on config truthy) |
+| `undefined` / `null` / `""` | `true` | `true` | Request unset, config truthy |
+| `undefined` / `null` / `""` | `false` / `undefined` / `null` | `false` | Request unset, config also unset/false → default safe |
+| `undefined` / `null` / `""` | `"true"` / `1` / `"是"` | `true` | Request unset, config coerced truthy |
+| `"maybe"` / `2` / `NaN` | (any) | throws | No silent acceptance |
+
+## Files changed
+
+- `plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs` — `coerceTriBool` + `resolveAutoFlag` helpers added (~38 lines), 2 call sites converted (~2 lines net)
+- `plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs` — `testK3WebApiAutoFlagCoercion()` added with 10 scenarios (~110 lines), wired into `main()`
+- this design doc + matching verification doc
+
+## Acceptance criteria
+
+- [x] `node plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs` reports `✓ k3-wise-adapters: WebAPI, SQL Server channel, and auto-flag coercion tests passed`
+- [x] **Headline fix**: hand-edited `request.options.autoSubmit = "false"` overrides config `true` → adapter does NOT fire `/Material/Submit`
+- [x] Hand-edited `request.options.autoAudit = "否"` overrides config `true` → adapter does NOT fire `/Material/Audit`
+- [x] String `"true"` / `"是"` / numeric `1` for config or request all coerce to `true`
+- [x] String `"false"` / `"否"` / numeric `0` all coerce to `false`
+- [x] Empty string `""` treated as unset (falls back to config)
+- [x] Both unset → default `false` (safe default for safety-relevant flags)
+- [x] Invalid values (`"maybe"`, `NaN`, `2`) throw `AdapterValidationError` with field name in message
+- [x] Existing 2 K3 adapter tests (testK3WebApiAdapter, testK3SqlServerChannel) pass unchanged
+
+## Out of scope
+
+- **`businessSuccess()` at line 210** — accepts K3 WISE response bool variants (true/false/'true'/'false'/1/0/'1'/'0'). Could be widened to include `'yes'` / `'success'` / `'OK'` etc., but K3 WISE's API contract is the source of truth here, not customer typing. Defer until we observe actual K3 WISE response variants in the wild.
+- **`erp-feedback.cjs` strict equality** at lines 232/412/483 — these are pipeline configuration options sourced from REST API or stored config, lower hand-edit risk than adapter runtime. Defer.
+- **`pipeline-runner.cjs` strict equality** at lines 156/202/203/311/408 — internal flags from REST API requests or feedback responses (server-controlled). No customer/operator string-coercion risk. Skip.
+- **Refactor `coerceTriBool` / `coerceBoolOrUnset` into a shared helper** — would touch the audit-script trio (preflight + evidence) and risk collision with parallel codex sessions. The intentional local-duplication discipline keeps the adapter standalone in CJS-land.
+
+## Why this completes the integration-core safety audit
+
+After the evidence-script audit series (#1175, #1176, #1177, #1182) and this PR:
+
+| Code area | Bug class | Status |
+|---|---|---|
+| `preflight.mjs` GATE answer parsing | Customer bool strings | ✅ #1168 / #1169 |
+| `evidence.mjs` customer JSON | Customer bool strings | ✅ #1175 |
+| `evidence.mjs` customer JSON | Customer numeric IDs | ✅ #1176 |
+| `evidence.mjs` customer JSON | Customer status synonyms | ✅ #1177 |
+| `evidence.mjs` operator hand-edits | Packet safety bools | ✅ #1182 |
+| `k3-wise-webapi-adapter.cjs` runtime | Operator config + request bools | this PR |
+
+This PR closes the symmetric gap on the *plugin-internal* adapter that handles the safety-critical lifecycle (Save → Submit → Audit). The customer-runnable scripts and the production adapter now share the same hardened coercion contract for boolean inputs.
+
+## Cross-references
+
+- PR #1175 — evidence bool sweep (introduced normalizeSafeBoolean pattern)
+- PR #1176 — evidence numeric ID coercion
+- PR #1177 — evidence status synonyms
+- PR #1182 — evidence packet safety hand-edits
+- PR #1168 / #1169 — preflight bool sweep (input side)
+- PR #1152 — original K3 WISE WebAPI adapter ship

--- a/docs/development/integration-core-k3-wise-adapter-autosubmit-coercion-verification-20260426.md
+++ b/docs/development/integration-core-k3-wise-adapter-autosubmit-coercion-verification-20260426.md
@@ -1,0 +1,84 @@
+# K3 WISE WebAPI Adapter autoSubmit/autoAudit Coercion · Verification
+
+> Date: 2026-04-26
+> Companion: `integration-core-k3-wise-adapter-autosubmit-coercion-design-20260426.md`
+> Closes the integration-core safety audit (preflight + evidence + adapter runtime all hardened)
+
+## Commands run
+
+```bash
+node plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
+git diff --stat plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs \
+                plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
+```
+
+## Result · `node plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs`
+
+```
+✓ k3-wise-adapters: WebAPI, SQL Server channel, and auto-flag coercion tests passed
+```
+
+The adapter test file uses a single linear test runner (custom assertion harness, not Node test runner). The 3 test functions invoked from `main()` are:
+
+1. `testK3WebApiAdapter` — pre-existing (PR #1152), unchanged behavior
+2. `testK3SqlServerChannel` — pre-existing, unchanged behavior
+3. `testK3WebApiAutoFlagCoercion` — NEW in this PR, 10 scenarios (A-J)
+
+All three pass. Single line of stdout confirms the full suite ran to completion.
+
+## New test coverage breakdown (10 scenarios in `testK3WebApiAutoFlagCoercion`)
+
+| Scenario | What it pins |
+|---|---|
+| **A**: `config.autoSubmit = "true"`, `config.autoAudit = "是"`, no request override | Hand-edited string config → coerced to `true`. Most common operator hand-edit: pasted from a markdown table that JSON-stringified the bool. |
+| **B**: `config.autoSubmit = 1`, `config.autoAudit = 0` | Spreadsheet-export style numeric booleans. |
+| **C**: **HEADLINE FIX** — `config.autoSubmit/autoAudit = true`, `request.options.autoSubmit = "false"` / `"否"` | Operator hand-edits the request to disable. With strict equality this previously fired auto-submit anyway because `"false" !== false`. Now correctly disables. Test also asserts that `/Material/Submit` and `/Material/Audit` are NOT called — pins the actual lifecycle behavior, not just the metadata flag. |
+| **D**: `config.autoSubmit/autoAudit = false`, `request.options = "true"` / `1` | Reverse direction — operator overrides config-disabled with explicit enable. |
+| **E**: request unset, config drives | Preserves the existing "config default when request unset" contract. |
+| **F**: both unset | Safe default `false` — auto-submit/audit OFF when nothing is configured. |
+| **G**: `request.options.autoSubmit = ""` (empty string) | Empty string treated as unset (falls back to config). Common when REST API serializes optional fields as empty string. |
+| **H**: `config.autoSubmit = "maybe"` | Throws `AdapterValidationError` with `autoSubmit` in message — no silent acceptance of unknown strings. |
+| **I**: `config.autoSubmit = NaN` | Throws with "finite" in message — non-finite numbers are explicit errors. |
+| **J**: `config.autoSubmit = 2` | Throws with "0 or 1" in message — only 0/1 accepted as numeric booleans. |
+
+## Existing test regression check
+
+The pre-existing 2 test functions are unchanged in this PR:
+
+- `testK3WebApiAdapter` (line 122): exercises real-boolean `autoSubmit: true` / `autoAudit: true` config (lines 81-82 of test fixture). Asserts `upsert.metadata.autoSubmit === true` and `=== true` (lines 154-155). The new helpers preserve this exactly: `resolveAutoFlag(undefined, true, 'autoSubmit')` returns `true` because `coerceTriBool(undefined)` is `null` → falls through to `coerceTriBool(true) === true`.
+- `testK3SqlServerChannel` (line 233): exercises SQL Server channel; doesn't touch autoSubmit/autoAudit logic at all. Untouched.
+
+The `metadata.autoSubmit` / `metadata.autoAudit` exposure in upsert results is preserved verbatim — the helpers only change *how* the value is computed, not *what* gets returned.
+
+## Manual code review checklist
+
+- [x] `coerceTriBool` returns explicit `null` for unset/empty inputs (NOT `undefined`) — call sites can use `=== null` or `!= null` consistently to distinguish "set" from "unset".
+- [x] `resolveAutoFlag` correctly prioritizes explicit request → falls back to config → defaults to false. Three-tier semantics preserved.
+- [x] `TRUE_BOOLEAN_TEXT` / `FALSE_BOOLEAN_TEXT` sets are identical to the audit-script versions (preflight + evidence), keeping behavior consistent across the customer-facing and plugin-internal surfaces.
+- [x] Throws `AdapterValidationError` (not the script-level `LivePocPreflightError` / `LivePocEvidenceError`) — uses the adapter's existing error class for API consistency.
+- [x] Error messages include the field name (`request.options.autoSubmit` or `config.autoSubmit`) so an operator running into the error knows exactly which config field to fix.
+- [x] No new dependencies, no schema change, no contract change for callers of `createK3WiseWebApiAdapter`.
+- [x] Inline comment on the helper block explains both *what* (tri-state coercion) and *why* (strict equality silently fires lifecycle steps against operator intent).
+- [x] No mutation of `request.options` or `config` — coercion is read-only.
+
+## Why this is the right place to stop the audit series
+
+After this PR:
+
+1. **`preflight.mjs`** input parsing — fully bool-coerces customer GATE answers (#1168, #1169)
+2. **`evidence.mjs`** all customer-supplied JSON fields — fully coerced (bool: #1175, numeric ID: #1176, status synonym: #1177, packet safety hand-edit: #1182)
+3. **`k3-wise-webapi-adapter.cjs`** runtime safety flags — fully coerced (this PR)
+
+The remaining `=== true` / `=== false` sites I audited are NOT customer- or operator-typed:
+
+- `erp-feedback.cjs` lines 232/412/483 — pipeline configuration, REST-API-validated, lower hand-edit risk
+- `pipeline-runner.cjs` lines 156/202/203/311/408 — internal flags from REST requests / feedback objects (server-controlled)
+- `transform-engine.cjs` line 151 — transform spec arg (operator-defined but parsed via separate validation)
+
+These are intentionally NOT in scope. The audit gate was: "what data path actually receives customer- or operator-typed boolean strings?" — and after this PR, all such paths are hardened.
+
+## Cross-references
+
+- Design doc: `docs/development/integration-core-k3-wise-adapter-autosubmit-coercion-design-20260426.md`
+- Audit series: PR #1175 / #1176 / #1177 / #1182 (evidence script), #1168 / #1169 (preflight script)
+- Original adapter ship: PR #1152 (K3 WISE WebAPI + SQL Server channel)

--- a/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
@@ -348,10 +348,134 @@ async function testK3SqlServerChannel() {
   assert.ok(rawIdentifier instanceof AdapterValidationError, 'raw SQL-like identifiers are rejected')
 }
 
+async function testK3WebApiAutoFlagCoercion() {
+  // ----- helper: build adapter with custom autoSubmit/autoAudit config -----
+  function buildAdapter(systemConfigOverrides) {
+    const { calls, fetchImpl } = createK3FetchMock()
+    const system = createK3WebApiSystem({
+      config: {
+        baseUrl: 'https://k3.example.test',
+        healthPath: '/K3API/Health',
+        ...systemConfigOverrides,
+      },
+    })
+    const adapter = createK3WiseWebApiAdapter({ system, fetchImpl })
+    return { adapter, calls }
+  }
+
+  async function upsertOne(adapter, options = {}) {
+    return adapter.upsert({
+      object: 'material',
+      records: [{ FNumber: 'MAT-COERCE-001', FName: 'Coercion test bolt' }],
+      keyFields: ['FNumber'],
+      options,
+    })
+  }
+
+  // ----- Scenario A: hand-edited string "true" config respects intent -----
+  {
+    const { adapter } = buildAdapter({ autoSubmit: 'true', autoAudit: '是' })
+    const upsert = await upsertOne(adapter)
+    assert.equal(upsert.metadata.autoSubmit, true, 'config.autoSubmit="true" → resolved as true')
+    assert.equal(upsert.metadata.autoAudit, true, 'config.autoAudit="是" → resolved as true')
+  }
+
+  // ----- Scenario B: numeric 1 / 0 in config (spreadsheet booleans) -----
+  {
+    const { adapter } = buildAdapter({ autoSubmit: 1, autoAudit: 0 })
+    const upsert = await upsertOne(adapter)
+    assert.equal(upsert.metadata.autoSubmit, true, 'config.autoSubmit=1 → true')
+    assert.equal(upsert.metadata.autoAudit, false, 'config.autoAudit=0 → false')
+  }
+
+  // ----- Scenario C: HEADLINE FIX — request override "false" disables config truthy -----
+  {
+    const { adapter, calls } = buildAdapter({ autoSubmit: true, autoAudit: true })
+    const upsert = await upsertOne(adapter, { autoSubmit: 'false', autoAudit: '否' })
+    assert.equal(upsert.metadata.autoSubmit, false, 'request.options.autoSubmit="false" overrides config true')
+    assert.equal(upsert.metadata.autoAudit, false, 'request.options.autoAudit="否" overrides config true')
+    const submitCalls = calls.filter((call) => call.pathname === '/K3API/Material/Submit')
+    const auditCalls = calls.filter((call) => call.pathname === '/K3API/Material/Audit')
+    assert.equal(submitCalls.length, 0, 'Submit must NOT fire when operator hand-edited "false"')
+    assert.equal(auditCalls.length, 0, 'Audit must NOT fire when operator hand-edited "否"')
+  }
+
+  // ----- Scenario D: request override "true" enables when config is false -----
+  {
+    const { adapter } = buildAdapter({ autoSubmit: false, autoAudit: false })
+    const upsert = await upsertOne(adapter, { autoSubmit: 'true', autoAudit: 1 })
+    assert.equal(upsert.metadata.autoSubmit, true, 'request.options.autoSubmit="true" overrides config false')
+    assert.equal(upsert.metadata.autoAudit, true, 'request.options.autoAudit=1 overrides config false')
+  }
+
+  // ----- Scenario E: request unset, config drives (positive) -----
+  {
+    const { adapter } = buildAdapter({ autoSubmit: true, autoAudit: false })
+    const upsert = await upsertOne(adapter, {})
+    assert.equal(upsert.metadata.autoSubmit, true, 'unset request + config true → true')
+    assert.equal(upsert.metadata.autoAudit, false, 'unset request + config false → false')
+  }
+
+  // ----- Scenario F: both unset → default safe (false) -----
+  {
+    const { adapter } = buildAdapter({})
+    const upsert = await upsertOne(adapter, {})
+    assert.equal(upsert.metadata.autoSubmit, false, 'unset request + unset config → false (default safe)')
+    assert.equal(upsert.metadata.autoAudit, false, 'unset request + unset config → false (default safe)')
+  }
+
+  // ----- Scenario G: empty string treated as unset (falls through to config) -----
+  {
+    const { adapter } = buildAdapter({ autoSubmit: true })
+    const upsert = await upsertOne(adapter, { autoSubmit: '' })
+    assert.equal(upsert.metadata.autoSubmit, true, 'empty-string request → falls back to config (true)')
+  }
+
+  // ----- Scenario H: invalid value throws AdapterValidationError with field name -----
+  {
+    const { adapter } = buildAdapter({ autoSubmit: 'maybe' })
+    let threw = null
+    try {
+      await upsertOne(adapter)
+    } catch (error) {
+      threw = error
+    }
+    assert.ok(threw instanceof AdapterValidationError, 'unknown string boolean should throw AdapterValidationError')
+    assert.ok(/autoSubmit/.test(threw.message), 'error message includes field name autoSubmit')
+  }
+
+  // ----- Scenario I: NaN / non-finite number throws -----
+  {
+    const { adapter } = buildAdapter({ autoSubmit: NaN })
+    let threw = null
+    try {
+      await upsertOne(adapter)
+    } catch (error) {
+      threw = error
+    }
+    assert.ok(threw instanceof AdapterValidationError, 'NaN config should throw AdapterValidationError')
+    assert.ok(/finite/.test(threw.message), 'error message mentions "finite"')
+  }
+
+  // ----- Scenario J: number 2 (not 0/1) throws -----
+  {
+    const { adapter } = buildAdapter({ autoSubmit: 2 })
+    let threw = null
+    try {
+      await upsertOne(adapter)
+    } catch (error) {
+      threw = error
+    }
+    assert.ok(threw instanceof AdapterValidationError, 'numeric 2 should throw')
+    assert.ok(/0 or 1/.test(threw.message), 'error message mentions "0 or 1"')
+  }
+}
+
 async function main() {
   await testK3WebApiAdapter()
   await testK3SqlServerChannel()
-  console.log('✓ k3-wise-adapters: WebAPI and SQL Server channel tests passed')
+  await testK3WebApiAutoFlagCoercion()
+  console.log('✓ k3-wise-adapters: WebAPI, SQL Server channel, and auto-flag coercion tests passed')
 }
 
 main().catch((err) => {

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
@@ -128,6 +128,43 @@ function firstDefined(...values) {
   return undefined
 }
 
+// Tri-state coercion for autoSubmit / autoAudit decision logic.
+// Returns true / false for any boolean-like input, or null when the field is
+// truly unset (undefined / null / ""). The decision logic at upsert-time uses
+// null to mean "fall back to config default" — distinct from explicit false
+// which must always disable the lifecycle step. Strict `=== true / !== false`
+// would treat hand-edited string "false" as truthy (because "false" !== false),
+// silently firing auto-submit / auto-audit against operator intent.
+const TRUE_BOOLEAN_TEXT = new Set(['true', '1', 'yes', 'y', 'on', '是', '启用', '开启'])
+const FALSE_BOOLEAN_TEXT = new Set(['false', '0', 'no', 'n', 'off', '否', '禁用', '关闭'])
+
+function coerceTriBool(value, field) {
+  if (value === undefined || value === null) return null
+  if (typeof value === 'boolean') return value
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new AdapterValidationError(`${field} must be a finite boolean, 0/1, or boolean-like string`, { field })
+    }
+    if (value === 1) return true
+    if (value === 0) return false
+    throw new AdapterValidationError(`${field} must be 0 or 1 when given as a number`, { field, received: value })
+  }
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase()
+    if (normalized.length === 0) return null
+    if (TRUE_BOOLEAN_TEXT.has(normalized)) return true
+    if (FALSE_BOOLEAN_TEXT.has(normalized)) return false
+  }
+  throw new AdapterValidationError(`${field} must be a boolean, 0/1, or boolean-like string`, { field })
+}
+
+function resolveAutoFlag(requestValue, configValue, field) {
+  const requestExplicit = coerceTriBool(requestValue, `request.options.${field}`)
+  if (requestExplicit !== null) return requestExplicit
+  const configExplicit = coerceTriBool(configValue, `config.${field}`)
+  return configExplicit === true
+}
+
 async function parseResponseBody(response) {
   const text = typeof response.text === 'function' ? await response.text() : ''
   if (!text) return null
@@ -439,8 +476,8 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
     const savePath = assertRelativePath(objectConfig.savePath || objectConfig.path, 'object.savePath')
     const submitPath = objectConfig.submitPath ? assertRelativePath(objectConfig.submitPath, 'object.submitPath') : null
     const auditPath = objectConfig.auditPath ? assertRelativePath(objectConfig.auditPath, 'object.auditPath') : null
-    const autoSubmit = request.options.autoSubmit === true || (request.options.autoSubmit !== false && config.autoSubmit === true)
-    const autoAudit = request.options.autoAudit === true || (request.options.autoAudit !== false && config.autoAudit === true)
+    const autoSubmit = resolveAutoFlag(request.options.autoSubmit, config.autoSubmit, 'autoSubmit')
+    const autoAudit = resolveAutoFlag(request.options.autoAudit, config.autoAudit, 'autoAudit')
     const authHeaders = await login()
     const results = []
     const errors = []


### PR DESCRIPTION
> **Closes the integration-core safety audit** (preflight + evidence + adapter runtime). Same bug class previously addressed in #1175 / #1176 / #1177 / #1182 on the customer-facing scripts now fixed in the plugin-internal adapter.

## Summary
The K3 WISE WebAPI adapter resolved \`autoSubmit\` / \`autoAudit\` via:

\`\`\`js
const autoSubmit = request.options.autoSubmit === true
  || (request.options.autoSubmit !== false && config.autoSubmit === true)
\`\`\`

**Unsafe direction**: if an operator hand-edits \`request.options.autoSubmit = \"false\"\` (string) intending to disable, the strict \`!== false\` check treats \`\"false\"\` as truthy (because \`\"false\" !== false\`), the second clause fires, and \`config.autoSubmit\` drives the result. **Auto-submit fires against operator intent** — moves the saved K3 record into a workflow state that may need explicit customer approval to roll back.

## Approach
Adds tri-state \`coerceTriBool\` / \`resolveAutoFlag\` helpers (local to the adapter, mirroring the audit-script discipline of no shared module dependency). Three-state semantics preserve the existing \"explicit request wins, otherwise config drives, otherwise default false\" contract while fixing the string-coercion bug:

| \`request.options.autoSubmit\` | \`config.autoSubmit\` | Result |
|---|---|---|
| \`true\` / \`\"true\"\` / \`\"是\"\` / \`1\` | (any) | \`true\` |
| \`false\` / \`\"false\"\` / \`\"否\"\` / \`0\` | (any, even \`true\`) | \`false\` (HEADLINE FIX) |
| unset / null / \`\"\"\` | \`true\` / \`\"true\"\` / \`1\` | \`true\` |
| unset / null / \`\"\"\` | unset / \`false\` / \`0\` | \`false\` (default safe) |
| \`\"maybe\"\` / \`2\` / \`NaN\` | (any) | throws \`AdapterValidationError\` with field name |

## Files changed
- \`plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs\` — \`coerceTriBool\` + \`resolveAutoFlag\` helpers added (~38 lines), 2 call sites converted
- \`plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs\` — \`testK3WebApiAutoFlagCoercion\` added with 10 scenarios (~110 lines)
- \`docs/development/integration-core-k3-wise-adapter-autosubmit-coercion-design-20260426.md\`
- \`docs/development/integration-core-k3-wise-adapter-autosubmit-coercion-verification-20260426.md\`

## Test plan
- [x] \`node plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs\` reports \`✓ k3-wise-adapters: WebAPI, SQL Server channel, and auto-flag coercion tests passed\`
- [x] **HEADLINE FIX**: hand-edited \`request.options.autoSubmit = \"false\"\` overrides config \`true\` → adapter does NOT call \`/Material/Submit\`
- [x] Same for \`autoAudit = \"否\"\` → adapter does NOT call \`/Material/Audit\`
- [x] String / numeric / Chinese boolean variants in config or request all coerce correctly
- [x] Empty string treated as unset (falls back to config)
- [x] Both unset → default \`false\` (safe default for safety-relevant flags)
- [x] Invalid values throw \`AdapterValidationError\` with field name
- [x] Existing 2 K3 adapter tests pass unchanged

## Audit series complete
| Code area | PR |
|---|---|
| preflight.mjs GATE answer parsing | #1168 / #1169 |
| evidence.mjs customer JSON (bool / numeric / synonyms) | #1175 / #1176 / #1177 |
| evidence.mjs operator hand-edits | #1182 |
| **k3-wise-webapi-adapter.cjs runtime** | **this PR** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)