### PR TITLE
fix(integration): coerce pipeline-runner REST API bool fields

### DIFF
--- a/docs/development/integration-core-pipeline-runner-rest-bool-coercion-design-20260426.md
+++ b/docs/development/integration-core-pipeline-runner-rest-bool-coercion-design-20260426.md
@@ -1,0 +1,127 @@
+# Pipeline Runner REST API Bool Coercion · Design
+
+> Date: 2026-04-26
+> Bug class source: PR #1175 / #1176 / #1177 / #1182 / #1183 audit series (K3 WISE preflight + evidence + adapter)
+> Scope: control plane (pipeline-runner.cjs) — REST API request fields
+
+## Problem
+
+The pipeline runner has 2 strict-equality checks against REST API request fields:
+
+```javascript
+// pipeline-runner.cjs line 156 — pre-fix
+if (pipeline.status !== 'active' && input.allowInactive !== true) {
+  throw new PipelineRunnerError('pipeline is not active', { ... })
+}
+
+// pipeline-runner.cjs line 311 — pre-fix
+const dryRun = input.dryRun === true
+```
+
+Both fields arrive over a JSON REST API. Admin tools, curl one-liners, and form helpers commonly serialize booleans as strings (`"true"` / `"false"`) or numerics (`0` / `1`) — and Express body parsers preserve those types verbatim.
+
+### Why dryRun is the **most safety-critical bug**
+
+If an operator or admin tool sends:
+
+```json
+POST /api/integration/pipelines/:id/run
+{ "dryRun": "true" }
+```
+
+The strict `=== true` is **false** (because `"true" !== true`), so `dryRun = false`, and the runner executes a **LIVE** pipeline run — writing real data to the K3 WISE target, advancing watermarks, and creating dead letters. The operator wanted a preview; they got a production write.
+
+This is the unsafe direction in its purest form: the operator's explicit safety flag is silently ignored.
+
+### allowInactive — UX issue, not safety
+
+```json
+POST /api/integration/pipelines/:id/run
+{ "allowInactive": "true" }
+```
+
+With strict `!== true`, this is **true** (because `"true" !== true`), so the inactive-pipeline guard fires and the request is rejected. The operator's hand-edit is ignored, but the safe direction (refuse to run a paused pipeline) is preserved. UX-impacting (operator confused why their flag was ignored), not safety-critical.
+
+Both deserve a fix, since the same coercion call covers both.
+
+## Solution
+
+Add a `coerceTruthyFlag(value, field)` helper local to the pipeline runner (mirrors the audit-script discipline of local helpers, no shared module dependency). Apply it at both call sites.
+
+```javascript
+const TRUE_BOOLEAN_TEXT = new Set(['true', '1', 'yes', 'y', 'on', '是', '启用', '开启'])
+const FALSE_BOOLEAN_TEXT = new Set(['false', '0', 'no', 'n', 'off', '否', '禁用', '关闭'])
+
+function coerceTruthyFlag(value, field) {
+  if (value === undefined || value === null) return false
+  if (typeof value === 'boolean') return value
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) throw new PipelineRunnerError(`${field} must be ...`, { field })
+    if (value === 1) return true
+    if (value === 0) return false
+    throw new PipelineRunnerError(`${field} must be 0 or 1 ...`, { field, received: value })
+  }
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase()
+    if (normalized.length === 0) return false
+    if (TRUE_BOOLEAN_TEXT.has(normalized)) return true
+    if (FALSE_BOOLEAN_TEXT.has(normalized)) return false
+  }
+  throw new PipelineRunnerError(`${field} must be ...`, { field })
+}
+```
+
+Replacements:
+
+```javascript
+// line 156 — fixed
+if (pipeline.status !== 'active' && !coerceTruthyFlag(input.allowInactive, 'input.allowInactive')) {
+
+// line 311 — fixed
+const dryRun = coerceTruthyFlag(input.dryRun, 'input.dryRun')
+```
+
+### Why throw on unknown values (not silent default-false)
+
+For dryRun specifically, defaulting unknown values to `false` is unsafe — `dryRun: "maybe"` would silently become a live run. Better to fail loudly so the operator sees a clear error message and can fix their request body. Same defensive-coercion discipline as the audit series (#1175 etc).
+
+For allowInactive, throw-on-unknown is consistent with dryRun and gives a clearer error than "pipeline is not active" (which would otherwise be returned even though the operator did set the flag).
+
+### Coercion table (covers both fields)
+
+| Operator request value | Resolved | Behavior |
+|---|---|---|
+| `true` / `"true"` / `"是"` / `1` / `"yes"` / `"on"` | `true` | dryRun=true (preview) or allowInactive=true (run paused pipeline) |
+| `false` / `"false"` / `"否"` / `0` / `"no"` / `"off"` | `false` | dryRun=false (live run) or allowInactive=false (reject paused pipeline) |
+| `undefined` / `null` / `""` (omitted) | `false` | Default-safe (live run requires explicit dryRun, paused pipeline requires explicit allowInactive) |
+| `"maybe"` / `2` / `NaN` / object / array | throws | `PipelineRunnerError` with field name in error message |
+
+## Files changed
+
+- `plugins/plugin-integration-core/lib/pipeline-runner.cjs` — `coerceTruthyFlag` helper added (~30 lines), 2 call sites converted (~2 lines net)
+- `plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs` — 6 new test sections (~115 lines) inside `main()`
+- this design doc + matching verification doc
+
+## Acceptance criteria
+
+- [x] `node plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs` reports `✓ pipeline-runner: cleanse/idempotency/incremental E2E tests passed`
+- [x] **HEADLINE FIX**: `dryRun: "true"` (string) is honored as dry-run — does NOT write to target, does NOT advance watermark, does NOT create dead letters, DOES produce a preview object
+- [x] `dryRun: 1` / `"是"` / `"YES"` / `"on"` all resolve to dry-run
+- [x] `dryRun: false` / `"false"` / `0` / `"否"` / `""` all resolve to live run (writes target)
+- [x] `dryRun: "maybe"` throws `PipelineRunnerError` with `field === 'input.dryRun'`
+- [x] **allowInactive HEADLINE FIX**: paused pipeline + `allowInactive: "true"` → run executes (was previously rejected)
+- [x] `allowInactive: "是"` / `1` / `"YES"` also allow inactive runs
+- [x] Existing 10 test sections (cleanse/idempotency/incremental/dry-run/dead-letter/replay/etc.) pass unchanged
+
+## Out of scope
+
+- **`erp-feedback.cjs` strict equality** at lines 232/412/483 — pipeline configuration, lower hand-edit risk than runtime request fields
+- **`pipeline-runner.cjs` line 202/203** — `feedback.ok !== false` / `feedback.skipped === true` — feedback objects from external code (server-controlled), not customer/operator typing
+- **`pipeline-runner.cjs` line 408** — `writeResult.inconsistent === true` — internal flag set by adapter, not operator-typed
+- **Refactor coercion into shared helper module** — would touch the audit-script trio + adapter, collision risk with parallel codex sessions
+
+## Cross-references
+
+- Audit series: PR #1175 / #1176 / #1177 / #1182 (evidence script), #1168 / #1169 (preflight script), #1183 (K3 adapter)
+- Original ship: PR #1150 (pipeline runner v1)
+- This PR: closes the integration-core control-plane safety gap

--- a/docs/development/integration-core-pipeline-runner-rest-bool-coercion-verification-20260426.md
+++ b/docs/development/integration-core-pipeline-runner-rest-bool-coercion-verification-20260426.md
@@ -1,0 +1,70 @@
+# Pipeline Runner REST API Bool Coercion · Verification
+
+> Date: 2026-04-26
+> Companion: `integration-core-pipeline-runner-rest-bool-coercion-design-20260426.md`
+
+## Commands run
+
+```bash
+node plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs
+git diff --stat plugins/plugin-integration-core/lib/pipeline-runner.cjs \
+                plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs
+```
+
+## Result · `node plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs`
+
+```
+✓ pipeline-runner: cleanse/idempotency/incremental E2E tests passed
+```
+
+The pipeline-runner test file uses a single linear `main()` with assertion-based subtests. All 16 sections (10 pre-existing + 6 new) pass to completion.
+
+## New test coverage breakdown (6 sections added inside `main()`)
+
+| # | Section | What it pins |
+|---|---|---|
+| **11** | `dryRun: "true"` (string) is honored | The headline safety fix. Asserts: target writes = 0, dead letters = 0, watermark = null, preview object exists with 1 record. With strict `=== true`, this would have been a LIVE run. |
+| **12** | `dryRun: 1` / `"是"` / `"YES"` / `"on"` | Other truthy variants (numeric, Chinese, uppercase, alternate keyword) all correctly route to dry-run path. |
+| **13** | `dryRun: false` / `"false"` / `0` / `"否"` / `""` | Negative direction — falsy variants correctly trigger LIVE run with target writes. Verifies the coercion doesn't over-accept. |
+| **14** | `dryRun: "maybe"` throws `PipelineRunnerError` | Defensive — unknown values fail loudly with field name in `error.details.field`. No silent default-false (which would be unsafe for dryRun specifically). |
+| **15** | `allowInactive: "true"` runs paused pipeline | Sets `pipelineOverrides.status = 'paused'`. Verifies (a) without flag → rejected with `'pipeline is not active'` (b) with `"true"` (string) → allowed and runs. |
+| **16** | `allowInactive: "是"` / `1` / `"YES"` also work | Symmetry with dryRun's coercion variants. |
+
+## Existing test regression check
+
+The 10 pre-existing test sections (1-10 in the original `main()`) all pass unchanged. The change is bounded:
+
+- The new helper `coerceTruthyFlag` is purely additive — no existing function modified.
+- The 2 call sites changed go from strict-equality to coercion-then-truthy. For real boolean inputs (which is what all existing tests use), behavior is identical.
+- The original dryRun test at lines 286-322 uses `dryRun: true` (real boolean); `coerceTruthyFlag(true)` returns `true`, identical to the original `=== true` result.
+
+## Manual code review checklist
+
+- [x] `coerceTruthyFlag` is identical in shape to the audit-series helpers (preflight `normalizeSafeBoolean`, evidence `normalizeSafeBoolean`, K3 adapter `coerceTriBool`) — same TRUE_BOOLEAN_TEXT / FALSE_BOOLEAN_TEXT sets, same throw-on-junk discipline, same field-name error messages.
+- [x] Throws `PipelineRunnerError` (not the script-level `LivePoc*Error` or adapter's `AdapterValidationError`) — uses the runner's existing error class so callers get a consistent exception type.
+- [x] Default for unset/null/empty is `false` for both flags — safe direction (no implicit dry-run, no implicit inactive-allow).
+- [x] Error messages include `input.dryRun` / `input.allowInactive` field names so the operator can fix their request body without guessing.
+- [x] Inline comment at the helper block explains both *what* (REST API bool coercion) and *why* (operator request bodies often serialize bools as strings, strict `=== true` silently fires live run on `dryRun: "true"`).
+- [x] No mutation of the `input` object — coercion is read-only.
+- [x] No new dependencies, no schema change, no contract change for callers of `runPipeline`.
+
+## Why this is the natural follow-up to the audit series
+
+After PR #1183 closed the K3 adapter runtime safety gap, I reviewed the remaining `=== true` / `=== false` sites in `plugin-integration-core/lib/`:
+
+| Site | Risk | Action |
+|---|---|---|
+| `pipeline-runner.cjs:311` `dryRun === true` | **Live run when operator typed `"true"`** — most safety-critical | **This PR** |
+| `pipeline-runner.cjs:156` `allowInactive !== true` | Operator's hand-edit ignored — UX issue | This PR (same helper, same call) |
+| `pipeline-runner.cjs:202/203` `feedback.ok / skipped` | Server-controlled feedback object | Skip — not customer/operator typing |
+| `pipeline-runner.cjs:408` `writeResult.inconsistent` | Internal adapter flag | Skip — not customer/operator typing |
+| `erp-feedback.cjs:232/412/483` | Pipeline configuration | Defer — REST-API-validated config, lower risk |
+| `transform-engine.cjs:151` | Transform spec arg | Skip — separate validation path |
+
+The dryRun bug is the largest remaining blast radius in the integration-core surface — an operator submitting `dryRun: "true"` via REST API would silently write to production K3 WISE. After this PR, that gap is closed and the integration-core safety audit truly is complete.
+
+## Cross-references
+
+- Design doc: `docs/development/integration-core-pipeline-runner-rest-bool-coercion-design-20260426.md`
+- Audit series: PR #1175 / #1176 / #1177 / #1182 (evidence), #1168 / #1169 (preflight), #1183 (K3 adapter)
+- Original ship: PR #1150 (pipeline runner)

--- a/plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs
@@ -579,6 +579,139 @@ async function main() {
   assert.equal(replayError.details.reason, 'PAYLOAD_TRUNCATED')
   assert.equal(truncatedReplay.targetRows.size, 0, 'truncated replay is rejected before target write')
 
+  // --- 11. dryRun string coercion (REST API hand-typed booleans) ---------
+  {
+    const stringDry = createRunnerHarness({
+      sourceRecords: [
+        { code: 'a-01', revision: 'r1', qty: '3', name: 'Bolt', updatedAt: '2026-04-24T01:00:00.000Z' },
+      ],
+    })
+    const result = await stringDry.runner.runPipeline({
+      tenantId: 'tenant_1',
+      pipelineId: 'pipe_1',
+      mode: 'incremental',
+      triggeredBy: 'manual',
+      dryRun: 'true',  // STRING — would previously fall through to LIVE run via strict ===
+      sampleLimit: 1,
+    })
+    assert.equal(stringDry.targetRows.size, 0, 'dryRun: "true" (string) must NOT write to target')
+    assert.equal(stringDry.db.tables.get('integration_dead_letters').length, 0, 'dryRun: "true" (string) must NOT create dead letters')
+    assert.equal(await stringDry.db.selectOne('integration_watermarks', { pipeline_id: 'pipe_1' }), null, 'dryRun: "true" (string) must NOT advance watermark')
+    assert.ok(result.preview, 'dryRun: "true" (string) must produce preview object')
+    assert.equal(result.preview.records.length, 1, 'preview captured the cleaned record')
+  }
+
+  // --- 12. dryRun numeric 1 / Chinese "是" also work ---------------------
+  for (const truthyVariant of [1, '是', 'YES', 'on']) {
+    const harness = createRunnerHarness({
+      sourceRecords: [
+        { code: 'a-01', revision: 'r1', qty: '3', name: 'Bolt', updatedAt: '2026-04-24T01:00:00.000Z' },
+      ],
+    })
+    await harness.runner.runPipeline({
+      tenantId: 'tenant_1',
+      pipelineId: 'pipe_1',
+      mode: 'incremental',
+      triggeredBy: 'manual',
+      dryRun: truthyVariant,
+      sampleLimit: 1,
+    })
+    assert.equal(
+      harness.targetRows.size,
+      0,
+      `dryRun: ${JSON.stringify(truthyVariant)} must be honored as truthy and NOT write to target`,
+    )
+  }
+
+  // --- 13. dryRun explicit "false" / 0 / "否" → real run ------------------
+  for (const falsyVariant of [false, 'false', 0, '否', '']) {
+    const harness = createRunnerHarness({
+      sourceRecords: [
+        { code: 'a-01', revision: 'r1', qty: '3', name: 'Bolt', updatedAt: '2026-04-24T01:00:00.000Z' },
+      ],
+    })
+    await harness.runner.runPipeline({
+      tenantId: 'tenant_1',
+      pipelineId: 'pipe_1',
+      mode: 'incremental',
+      triggeredBy: 'manual',
+      dryRun: falsyVariant,
+      sampleLimit: 1,
+    })
+    assert.equal(
+      harness.targetRows.size,
+      1,
+      `dryRun: ${JSON.stringify(falsyVariant)} should be falsy → live run writes 1 row`,
+    )
+  }
+
+  // --- 14. dryRun "maybe" (unknown) throws PipelineRunnerError -----------
+  {
+    const harness = createRunnerHarness({
+      sourceRecords: [
+        { code: 'a-01', revision: 'r1', qty: '3', name: 'Bolt', updatedAt: '2026-04-24T01:00:00.000Z' },
+      ],
+    })
+    const error = await harness.runner.runPipeline({
+      tenantId: 'tenant_1',
+      pipelineId: 'pipe_1',
+      mode: 'incremental',
+      triggeredBy: 'manual',
+      dryRun: 'maybe',
+    }).catch((err) => err)
+    assert.equal(error.name, 'PipelineRunnerError', 'unknown string for dryRun should throw PipelineRunnerError')
+    assert.equal(error.details.field, 'input.dryRun', 'error includes the field name')
+  }
+
+  // --- 15. allowInactive string coercion: inactive pipeline + "true" runs ---
+  {
+    const inactive = createRunnerHarness({
+      sourceRecords: [
+        { code: 'a-01', revision: 'r1', qty: '3', name: 'Bolt', updatedAt: '2026-04-24T01:00:00.000Z' },
+      ],
+      pipelineOverrides: { status: 'paused' },
+    })
+
+    // Without allowInactive: rejected
+    const rejected = await inactive.runner.runPipeline({
+      tenantId: 'tenant_1',
+      pipelineId: 'pipe_1',
+      mode: 'incremental',
+      triggeredBy: 'manual',
+    }).catch((err) => err)
+    assert.equal(rejected.name, 'PipelineRunnerError', 'paused pipeline rejected when allowInactive unset')
+    assert.equal(rejected.message, 'pipeline is not active')
+
+    // With allowInactive: "true" (string) — must allow the run
+    const allowed = await inactive.runner.runPipeline({
+      tenantId: 'tenant_1',
+      pipelineId: 'pipe_1',
+      mode: 'incremental',
+      triggeredBy: 'manual',
+      allowInactive: 'true',  // STRING — would previously be rejected via strict !== true
+    })
+    assert.ok(allowed.run, 'allowInactive: "true" (string) lets the inactive pipeline run')
+    assert.equal(allowed.metrics.rowsRead, 1, 'inactive pipeline with allowInactive: "true" reads source')
+  }
+
+  // --- 16. allowInactive Chinese "是" / numeric 1 also work --------------
+  for (const truthyVariant of ['是', 1, 'YES']) {
+    const inactive = createRunnerHarness({
+      sourceRecords: [
+        { code: 'a-01', revision: 'r1', qty: '3', name: 'Bolt', updatedAt: '2026-04-24T01:00:00.000Z' },
+      ],
+      pipelineOverrides: { status: 'paused' },
+    })
+    const result = await inactive.runner.runPipeline({
+      tenantId: 'tenant_1',
+      pipelineId: 'pipe_1',
+      mode: 'incremental',
+      triggeredBy: 'manual',
+      allowInactive: truthyVariant,
+    })
+    assert.ok(result.run, `allowInactive: ${JSON.stringify(truthyVariant)} lets the inactive pipeline run`)
+  }
+
   console.log('✓ pipeline-runner: cleanse/idempotency/incremental E2E tests passed')
 }
 

--- a/plugins/plugin-integration-core/lib/pipeline-runner.cjs
+++ b/plugins/plugin-integration-core/lib/pipeline-runner.cjs
@@ -14,6 +14,35 @@ class PipelineRunnerError extends Error {
   }
 }
 
+// REST API request fields like dryRun / allowInactive arrive over JSON, but
+// admin tools, curl one-liners, and form helpers commonly serialize booleans
+// as strings ("true" / "false") or numerics (0 / 1). Strict `=== true` on
+// dryRun would silently fall through to a LIVE run when the operator typed
+// dryRun: "true" in their request body. Coerce with a small allow-list so
+// known truthy variants enable the flag and unknown values fail loudly.
+const TRUE_BOOLEAN_TEXT = new Set(['true', '1', 'yes', 'y', 'on', '是', '启用', '开启'])
+const FALSE_BOOLEAN_TEXT = new Set(['false', '0', 'no', 'n', 'off', '否', '禁用', '关闭'])
+
+function coerceTruthyFlag(value, field) {
+  if (value === undefined || value === null) return false
+  if (typeof value === 'boolean') return value
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new PipelineRunnerError(`${field} must be a finite boolean, 0/1, or boolean-like string`, { field })
+    }
+    if (value === 1) return true
+    if (value === 0) return false
+    throw new PipelineRunnerError(`${field} must be 0 or 1 when given as a number`, { field, received: value })
+  }
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase()
+    if (normalized.length === 0) return false
+    if (TRUE_BOOLEAN_TEXT.has(normalized)) return true
+    if (FALSE_BOOLEAN_TEXT.has(normalized)) return false
+  }
+  throw new PipelineRunnerError(`${field} must be a boolean, 0/1, or boolean-like string`, { field })
+}
+
 function requireDependency(deps, name, methods) {
   const value = deps[name]
   if (!value) throw new Error(`createPipelineRunner: ${name} is required`)
@@ -153,7 +182,7 @@ function createPipelineRunner(deps = {}) {
       id: input.pipelineId,
       includeFieldMappings: true,
     })
-    if (pipeline.status !== 'active' && input.allowInactive !== true) {
+    if (pipeline.status !== 'active' && !coerceTruthyFlag(input.allowInactive, 'input.allowInactive')) {
       throw new PipelineRunnerError('pipeline is not active', {
         pipelineId: pipeline.id,
         status: pipeline.status,
@@ -308,7 +337,7 @@ function createPipelineRunner(deps = {}) {
     const context = await loadPipelineContext(input)
     const mode = input.mode || context.pipeline.mode || 'manual'
     const triggeredBy = input.triggeredBy || 'manual'
-    const dryRun = input.dryRun === true
+    const dryRun = coerceTruthyFlag(input.dryRun, 'input.dryRun')
     const started = clock()
     const metrics = createMetrics()
     const preview = dryRun ? { records: [], errors: [] } : null


### PR DESCRIPTION
> **Closes the integration-core control-plane safety gap.** Same bug class as #1175 / #1176 / #1177 / #1182 / #1183 — strict equality on REST API bool fields silently failing when operators send the JSON-stringified form.

## Summary

The pipeline runner has 2 strict-equality checks against operator-typed REST request fields:

| Site | Code (pre-fix) | Operator sends | Result | Risk |
|---|---|---|---|---|
| Line 311 | \`const dryRun = input.dryRun === true\` | \`dryRun: \"true\"\` (string) | dryRun=false → **live K3 WISE run** | **HEADLINE SAFETY** — operator wanted preview, got production write |
| Line 156 | \`input.allowInactive !== true\` | \`allowInactive: \"true\"\` | inactive-pipeline guard fires → rejected | UX — operator's flag silently ignored |

The dryRun bug is the highest-impact remaining gap in the integration-core surface — admin tools and curl one-liners commonly serialize bools as strings, and Express body parsers preserve those types verbatim.

## Approach

Add a local \`coerceTruthyFlag(value, field)\` helper to pipeline-runner.cjs (mirrors the audit-series helpers; no shared-module dependency to keep collision risk low with parallel codex sessions). Apply at both call sites.

| Operator request | Resolved | Behavior |
|---|---|---|
| \`true\` / \`\"true\"\` / \`\"是\"\` / \`1\` / \`\"yes\"\` / \`\"on\"\` | \`true\` | dryRun=preview, allowInactive=run paused pipeline |
| \`false\` / \`\"false\"\` / \`\"否\"\` / \`0\` / \`\"no\"\` / \`\"off\"\` | \`false\` | dryRun=live, allowInactive=reject paused |
| omitted / null / \`\"\"\` | \`false\` | Default-safe |
| \`\"maybe\"\` / \`2\` / \`NaN\` | throws \`PipelineRunnerError\` with field name | Defensive |

## Files changed
- \`plugins/plugin-integration-core/lib/pipeline-runner.cjs\` — \`coerceTruthyFlag\` helper added (~30 lines), 2 call sites converted
- \`plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs\` — 6 new sections in \`main()\` (~115 lines)
- \`docs/development/integration-core-pipeline-runner-rest-bool-coercion-design-20260426.md\`
- \`docs/development/integration-core-pipeline-runner-rest-bool-coercion-verification-20260426.md\`

## Test plan
- [x] \`node plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs\` reports \`✓ pipeline-runner: cleanse/idempotency/incremental E2E tests passed\`
- [x] **HEADLINE FIX**: \`dryRun: \"true\"\` (string) → no target writes, no watermark advance, no dead letters, preview object exists
- [x] \`dryRun: 1\` / \`\"是\"\` / \`\"YES\"\` / \`\"on\"\` all route to dry-run
- [x] \`dryRun: false\` / \`\"false\"\` / \`0\` / \`\"否\"\` / \`\"\"\` all route to live run
- [x] \`dryRun: \"maybe\"\` throws \`PipelineRunnerError\` with field name
- [x] **allowInactive HEADLINE FIX**: paused pipeline + \`allowInactive: \"true\"\` (string) → run executes
- [x] \`allowInactive: \"是\"\` / \`1\` / \`\"YES\"\` also work
- [x] All 10 prior test sections pass unchanged

## Out of scope
- \`erp-feedback.cjs\` strict equality — pipeline configuration, lower hand-edit risk
- \`pipeline-runner.cjs\` lines 202/203/408 — server-controlled feedback / internal flags
- Refactor coercion into shared helper — collision risk with parallel codex sessions

## Audit series — full closure
| Code area | Bug class | PR |
|---|---|---|
| preflight.mjs GATE answer parsing | bool strings | #1168 / #1169 |
| evidence.mjs customer JSON | bool / numeric / synonyms | #1175 / #1176 / #1177 |
| evidence.mjs operator hand-edits | packet safety bools | #1182 |
| k3-wise-webapi-adapter.cjs | autoSubmit/autoAudit bools | #1183 |
| **pipeline-runner.cjs** | **REST API dryRun/allowInactive bools** | **this PR** |

After this merges, every customer- and operator-typed boolean string in the integration-core safety surface is hardened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)