### PR TITLE
fix(integration): guard against concurrent pipeline runs and stale run leaks

### DIFF
--- a/docs/development/integration-core-concurrent-run-guard-design-20260426.md
+++ b/docs/development/integration-core-concurrent-run-guard-design-20260426.md
@@ -70,13 +70,46 @@ if (runningRows.length > 0) {
 **Why here and not in `runPipeline`:** `createPipelineRun` is the DB-authoritative
 gate. Checking in `runPipeline` before calling `startRun` would have a TOCTOU
 window — two callers check simultaneously, both see no running run, both insert.
-This PR places the guard at the insert point and wraps the check+insert critical
-section in an in-process `(tenantId, workspaceId, pipelineId)` lock. That closes
-the async race for the single-node PoC runtime while keeping the invariant owned
-by `createPipelineRun`, where the `disabled` pipeline check also lives. A true
-distributed lock (advisory PG lock, `SELECT ... FOR UPDATE SKIP LOCKED`, or a
-partial unique index) would close the window across multiple Node processes and
-is left for production hardening.
+This PR places the friendly guard at the insert point and wraps the check+insert
+critical section in an in-process `(tenantId, workspaceId, pipelineId)` lock.
+That closes the async race for the single-node PoC runtime while keeping the
+invariant owned by `createPipelineRun`, where the `disabled` pipeline check also
+lives.
+
+### DB-authoritative partial unique index (migration 058)
+
+The in-process lock is not enough for a multi-node deployment: two separate Node
+processes can still both snapshot "no running row" before either insert commits.
+Migration 058 makes the invariant database-authoritative:
+
+```sql
+WITH duplicate_running AS (...)
+UPDATE integration_runs
+SET status = 'failed',
+    finished_at = COALESCE(finished_at, NOW()),
+    error_summary = COALESCE(error_summary, 'abandoned: duplicate running run closed before unique guard migration')
+WHERE id IN (SELECT id FROM duplicate_running WHERE duplicate_rank > 1);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_integration_runs_one_running_per_pipeline
+  ON integration_runs (tenant_id, COALESCE(workspace_id, ''), pipeline_id)
+  WHERE status = 'running';
+```
+
+`COALESCE(workspace_id, '')` is required because PostgreSQL unique indexes treat
+`NULL` values as distinct. Without the expression, two `workspace_id IS NULL`
+running rows for the same tenant/pipeline would still be allowed.
+
+The pre-index cleanup keeps the earliest `running` row per
+`(tenant_id, workspace_id, pipeline_id)` and fails duplicate running rows with a
+clear `error_summary`. That makes the migration replayable on an environment
+where the old bug already produced duplicate run rows instead of failing during
+`CREATE UNIQUE INDEX`.
+
+`createPipelineRun` keeps the pre-insert read for the normal operator path. If a
+real race still reaches `db.insertOne`, PostgreSQL raises `23505` on
+`uniq_integration_runs_one_running_per_pipeline`; the registry catches that
+specific constraint and converts it to the same `PipelineConflictError` shape,
+including `runningRunId` when the blocking row is visible.
 
 **Error fields in details:**
 - `pipelineId` — which pipeline is blocked
@@ -123,18 +156,17 @@ Also future-proofs any other `*ConflictError` class in the codebase.
 
 | File | Change |
 |---|---|
-| `lib/pipelines.cjs` | `PipelineConflictError` class; in-process keyed lock + guard in `createPipelineRun`; `abandonStaleRuns` function; export both |
+| `packages/core-backend/migrations/058_integration_runs_running_unique.sql` | duplicate-running cleanup + DB partial unique index for one `running` row per tenant/workspace/pipeline |
+| `lib/pipelines.cjs` | `PipelineConflictError` class; in-process keyed lock + friendly guard in `createPipelineRun`; DB unique-conflict normalization; `abandonStaleRuns` function; export both |
 | `lib/http-routes.cjs` | `inferHttpStatus`: add `Conflict` → 409 |
-| `__tests__/pipelines.test.cjs` | 6 new scenarios (conflict guard + in-process race + stale cleanup) |
+| `__tests__/pipelines.test.cjs` | conflict guard + in-process race + DB unique-conflict normalization + stale cleanup |
 | `__tests__/http-routes.test.cjs` | 1 new scenario (409 response shape for conflict) |
+| `__tests__/migration-sql.test.cjs` | validates migration 058 partial unique index shape |
 | this design doc | — |
 | matching verification doc | — |
 
 ## What this does NOT fix
 
-- **Distributed concurrent runs**: two Node processes on separate hosts can still
-  pass the guard simultaneously. The in-process lock closes the single-node async
-  race only. Production hardening should add a DB-level advisory/unique lock.
 - **Long-running legitimate runs blocked by strict threshold**: `olderThanMs` is
   configurable; callers that need > 4h runs should pass a larger value.
 - **Auto-wiring of `abandonStaleRuns`**: exported but not called anywhere yet.

--- a/docs/development/integration-core-concurrent-run-guard-design-20260426.md
+++ b/docs/development/integration-core-concurrent-run-guard-design-20260426.md
@@ -70,12 +70,13 @@ if (runningRows.length > 0) {
 **Why here and not in `runPipeline`:** `createPipelineRun` is the DB-authoritative
 gate. Checking in `runPipeline` before calling `startRun` would have a TOCTOU
 window — two callers check simultaneously, both see no running run, both insert.
-Placing the guard *inside* `createPipelineRun` (the insert point) does not
-close the window in pure application logic, but it is the correct layer to
-own the invariant since `createPipelineRun` is also where the `disabled`
-pipeline check lives. A true distributed lock (advisory PG lock,
-`SELECT ... FOR UPDATE SKIP LOCKED`) would close the window fully but is
-out of scope for single-node PoC.
+This PR places the guard at the insert point and wraps the check+insert critical
+section in an in-process `(tenantId, workspaceId, pipelineId)` lock. That closes
+the async race for the single-node PoC runtime while keeping the invariant owned
+by `createPipelineRun`, where the `disabled` pipeline check also lives. A true
+distributed lock (advisory PG lock, `SELECT ... FOR UPDATE SKIP LOCKED`, or a
+partial unique index) would close the window across multiple Node processes and
+is left for production hardening.
 
 **Error fields in details:**
 - `pipelineId` — which pipeline is blocked
@@ -122,17 +123,18 @@ Also future-proofs any other `*ConflictError` class in the codebase.
 
 | File | Change |
 |---|---|
-| `lib/pipelines.cjs` | `PipelineConflictError` class; guard in `createPipelineRun`; `abandonStaleRuns` function; export both |
+| `lib/pipelines.cjs` | `PipelineConflictError` class; in-process keyed lock + guard in `createPipelineRun`; `abandonStaleRuns` function; export both |
 | `lib/http-routes.cjs` | `inferHttpStatus`: add `Conflict` → 409 |
-| `__tests__/pipelines.test.cjs` | 5 new scenarios (conflict guard + stale cleanup) |
+| `__tests__/pipelines.test.cjs` | 6 new scenarios (conflict guard + in-process race + stale cleanup) |
 | `__tests__/http-routes.test.cjs` | 1 new scenario (409 response shape for conflict) |
 | this design doc | — |
 | matching verification doc | — |
 
 ## What this does NOT fix
 
-- **Distributed concurrent runs**: two Node processes on separate hosts can both
-  pass the guard simultaneously (TOCTOU). Not a concern for single-node PoC.
+- **Distributed concurrent runs**: two Node processes on separate hosts can still
+  pass the guard simultaneously. The in-process lock closes the single-node async
+  race only. Production hardening should add a DB-level advisory/unique lock.
 - **Long-running legitimate runs blocked by strict threshold**: `olderThanMs` is
   configurable; callers that need > 4h runs should pass a larger value.
 - **Auto-wiring of `abandonStaleRuns`**: exported but not called anywhere yet.

--- a/docs/development/integration-core-concurrent-run-guard-design-20260426.md
+++ b/docs/development/integration-core-concurrent-run-guard-design-20260426.md
@@ -1,0 +1,146 @@
+# Integration-Core Concurrent Run Guard · Design
+
+> Date: 2026-04-26
+> PR: #1187
+> Audit lane: race conditions in concurrent runs (new bug class post bool-coercion series)
+
+## Problem
+
+Two invariants were missing from `pipeline-runner` / `createPipelineRun`:
+
+### Invariant 1 — exclusivity
+
+At most one run may be in status `'running'` per pipeline at a time.
+
+Without this, two simultaneous `POST /pipelines/:id/run` calls both call
+`runLogger.startRun()` → `createPipelineRun()`. Both succeed. Both then:
+- read from the same watermark baseline
+- advance the watermark to the same endpoint
+- write to the target ERP
+
+Idempotency blocks duplicate ERP writes. But the double watermark advance
+means both runs consumed the same source records, and the watermark
+advances once to the value it would have taken if only one run had fired.
+Records that arrived *after* the read window but *before* the watermark
+advance are silently marked as processed in both runs — they will not be
+picked up by the next incremental run.
+
+In a K3 WISE PoC context this is particularly dangerous: a double-click on
+"Run" or two operators both triggering simultaneously would cause duplicate
+`autoSubmit`/`autoAudit` attempts (even with those flags off in PoC mode,
+the write-path executes twice against the test account).
+
+### Invariant 2 — bounded lifetime
+
+A run in status `'running'` must eventually reach a terminal status
+(`succeeded`, `partial`, `failed`, `cancelled`).
+
+`runPipeline` wraps its body in a try/catch and calls `failRun` in the
+catch block. But a SIGKILL, OOM, or infrastructure restart between
+`startRun` and the try/catch can leave the run permanently `'running'`.
+
+Once Invariant 1 is enforced, a permanently-stuck run means no future run
+of that pipeline can ever start. Without a cleanup mechanism, the pipeline
+is permanently deadlocked with no operator-facing error.
+
+## Solution
+
+### `PipelineConflictError` (pipelines.cjs)
+
+New error class, name matches `/Conflict/` so `inferHttpStatus` maps it to 409.
+
+### Concurrent run guard in `createPipelineRun` (pipelines.cjs)
+
+After validating the pipeline exists and is not disabled, query for existing
+`running` runs on the same `(tenant_id, workspace_id, pipeline_id)` tuple:
+
+```javascript
+const runningRows = unwrapRows(await db.select(RUNS_TABLE, {
+  where: { ...scopeWhere(normalized), pipeline_id: normalized.pipelineId, status: 'running' },
+  limit: 1,
+}))
+if (runningRows.length > 0) {
+  throw new PipelineConflictError('pipeline already has a run in progress', {
+    pipelineId: normalized.pipelineId,
+    runningRunId: runningRows[0].id,
+  })
+}
+```
+
+**Why here and not in `runPipeline`:** `createPipelineRun` is the DB-authoritative
+gate. Checking in `runPipeline` before calling `startRun` would have a TOCTOU
+window — two callers check simultaneously, both see no running run, both insert.
+Placing the guard *inside* `createPipelineRun` (the insert point) does not
+close the window in pure application logic, but it is the correct layer to
+own the invariant since `createPipelineRun` is also where the `disabled`
+pipeline check lives. A true distributed lock (advisory PG lock,
+`SELECT ... FOR UPDATE SKIP LOCKED`) would close the window fully but is
+out of scope for single-node PoC.
+
+**Error fields in details:**
+- `pipelineId` — which pipeline is blocked
+- `runningRunId` — the run that is blocking; operator can look it up in the
+  run log to understand why it is stuck
+
+### `abandonStaleRuns` (pipelines.cjs)
+
+```
+registry.abandonStaleRuns({ tenantId, workspaceId, [pipelineId], [olderThanMs], [now] })
+```
+
+1. Selects all `running` runs (scoped to tenant/workspace, optionally to pipeline)
+2. Filters in JS: `started_at < (now - olderThanMs)`
+   - JS filtering because `db.select` is equality-only (no `<` operator in the
+     current safe structured-query builder; a raw `WHERE started_at < $1` would
+     require `rawQuery` which is explicitly excluded for injection safety)
+3. For each stale run: `updateRow` → `status: 'failed'`, `finished_at: now`,
+   `error_summary: 'abandoned: run exceeded stale threshold ...'`
+4. Returns the list of abandoned `PipelineRun` objects
+
+Default threshold: **4 hours**. Chosen because the longest legitimate full-sync
+run in the PoC context (full BOM tree) is expected to complete in < 30 min.
+4h gives 8× headroom while still catching crashes within a working day.
+
+**When to call:** callers decide the lifecycle. Suggested places:
+- Plugin activation (`index.cjs`) — sweep all tenants' stale runs on startup
+- Before `POST /pipelines/:id/run` — sweep for the specific pipeline before
+  adding the new guard check (gives the operator one automatic recovery attempt)
+
+Both invocation patterns are out of scope for this PR; `abandonStaleRuns` is
+exported and available for the caller to wire up.
+
+### `inferHttpStatus` update (http-routes.cjs)
+
+```javascript
+if (/Conflict/.test(name)) return 409
+```
+
+Placed before the `Validation` check so `PipelineConflictError` → 409, not 400.
+Also future-proofs any other `*ConflictError` class in the codebase.
+
+## Files changed
+
+| File | Change |
+|---|---|
+| `lib/pipelines.cjs` | `PipelineConflictError` class; guard in `createPipelineRun`; `abandonStaleRuns` function; export both |
+| `lib/http-routes.cjs` | `inferHttpStatus`: add `Conflict` → 409 |
+| `__tests__/pipelines.test.cjs` | 5 new scenarios (conflict guard + stale cleanup) |
+| `__tests__/http-routes.test.cjs` | 1 new scenario (409 response shape for conflict) |
+| this design doc | — |
+| matching verification doc | — |
+
+## What this does NOT fix
+
+- **Distributed concurrent runs**: two Node processes on separate hosts can both
+  pass the guard simultaneously (TOCTOU). Not a concern for single-node PoC.
+- **Long-running legitimate runs blocked by strict threshold**: `olderThanMs` is
+  configurable; callers that need > 4h runs should pass a larger value.
+- **Auto-wiring of `abandonStaleRuns`**: exported but not called anywhere yet.
+  Wiring it to plugin startup or to the run-trigger route is follow-up work.
+
+## Cross-references
+
+- Broader-surface audit: `docs/development/bool-coercion-audit-broader-surface-20260426.md`
+  (this is the "race conditions in concurrent runs" lane flagged as next audit class)
+- Pipeline runner: `plugins/plugin-integration-core/lib/pipeline-runner.cjs`
+- Pipelines registry: `plugins/plugin-integration-core/lib/pipelines.cjs`

--- a/docs/development/integration-core-concurrent-run-guard-verification-20260426.md
+++ b/docs/development/integration-core-concurrent-run-guard-verification-20260426.md
@@ -1,0 +1,90 @@
+# Integration-Core Concurrent Run Guard · Verification
+
+> Date: 2026-04-26
+> Companion: `integration-core-concurrent-run-guard-design-20260426.md`
+> PR: #1187
+
+## Commands run
+
+```bash
+node plugins/plugin-integration-core/__tests__/pipelines.test.cjs
+node plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+# Full regression sweep:
+for f in plugins/plugin-integration-core/__tests__/*.test.cjs; do node "$f" 2>&1 | tail -1; done
+```
+
+## Result — pipelines.test.cjs
+
+```
+✓ pipelines: registry + endpoint + field-mapping + run-ledger + concurrent-guard + stale-run-cleanup tests passed
+```
+
+## Result — http-routes.test.cjs
+
+```
+http-routes: REST auth/list/upsert/run/dry-run/replay tests passed
+```
+
+## Result — full suite regression (18 files)
+
+```
+✓ adapter-contracts: registry + normalizer tests passed
+✓ credential-store: 10 scenarios passed
+✓ db.cjs: all CRUD + boundary + injection tests passed
+✓ e2e-plm-k3wise-writeback: mock PLM → K3 WISE → feedback tests passed
+✓ erp-feedback: normalize + writer tests passed
+✓ external-systems: registry + credential boundary tests passed
+✓ http-adapter: config-driven read/upsert tests passed
+http-routes: REST auth/list/upsert/run/dry-run/replay tests passed
+✓ k3-wise-adapters: WebAPI, SQL Server channel, and auto-flag coercion tests passed
+✓ migration-sql: 057 integration migration structure passed
+✓ payload-redaction: sensitive key redaction tests passed
+✓ pipeline-runner: cleanse/idempotency/incremental E2E tests passed
+✓ pipelines: registry + endpoint + field-mapping + run-ledger + concurrent-guard + stale-run-cleanup tests passed
+✓ plm-yuantus-wrapper: source facade tests passed
+✓ plugin-runtime-smoke: all assertions passed
+runner-support: idempotency/watermark/dead-letter/run-log tests passed
+✓ staging-installer: all 7 assertions passed
+[pass] transform-validator: transform engine + validator tests passed
+```
+
+18/18 test files pass. 0 regressions.
+
+## New test coverage breakdown (6 added)
+
+### pipelines.test.cjs (+5)
+
+| # | Scenario | What it pins |
+|---|---|---|
+| 1 | concurrent run rejected with `PipelineConflictError` | Guard fires when a `running` run exists for same pipeline; error class is correct |
+| 2 | error details include `runningRunId` | Operator can identify the blocking run without a DB query |
+| 3 | terminated run does not block | `succeeded` run allows new run — guard checks `status='running'` only |
+| 4 | running run on different pipeline does not block | Guard scopes to `pipeline_id`; unrelated pipelines are independent |
+| 5 | `abandonStaleRuns` default threshold (4h) | Stale run (5h old) abandoned; fresh run (30min) untouched; other-tenant run untouched |
+| 6 | `abandonStaleRuns` custom `olderThanMs` | 15min threshold correctly abandons the 30min-old run |
+
+### http-routes.test.cjs (+1, inside `testErrorResponseShape`)
+
+| # | Scenario | What it pins |
+|---|---|---|
+| 7 | `PipelineConflictError` → HTTP 409 | `inferHttpStatus` maps `Conflict` name to 409; error body includes `code` and `details` |
+
+## Manual code review checklist
+
+- [x] `PipelineConflictError` exported alongside `PipelineValidationError` / `PipelineNotFoundError`
+- [x] Guard placed after `disabled` check — ordering: pipeline exists → not disabled → not already running → insert
+- [x] Guard scopes correctly: `tenant_id`, `workspace_id`, `pipeline_id` all in WHERE clause
+- [x] `abandonStaleRuns` never abandons fresh runs (JS timestamp filter, not DB filter)
+- [x] `abandonStaleRuns` is tenant-scoped — other-tenant stale runs unaffected
+- [x] Abandoned run `error_summary` is human-readable and operator-actionable
+- [x] `returnType` of `abandonStaleRuns`: returns `PipelineRun[]` via `rowToPipelineRun()` for consistency with other registry return types
+- [x] `inferHttpStatus` regex order: `Conflict` before `Validation` — prevents accidental 400 if a future error name contained both
+- [x] No new shared module — local changes only to `pipelines.cjs` and `http-routes.cjs`
+- [x] No behavior change for the happy path — only new code paths for error conditions
+
+## Known limitations (documented in design)
+
+- **TOCTOU window still exists** for distributed multi-node deployments. Single-node
+  PoC: not a concern. Production hardening would use `SELECT ... FOR UPDATE SKIP LOCKED`.
+- **`abandonStaleRuns` not auto-wired**: exported but the caller (plugin activation or
+  run-trigger route) must decide when to invoke it. This PR only provides the tool.

--- a/docs/development/integration-core-concurrent-run-guard-verification-20260426.md
+++ b/docs/development/integration-core-concurrent-run-guard-verification-20260426.md
@@ -9,8 +9,16 @@
 ```bash
 node plugins/plugin-integration-core/__tests__/pipelines.test.cjs
 node plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+node plugins/plugin-integration-core/__tests__/migration-sql.test.cjs
 # Full regression sweep:
 for f in plugins/plugin-integration-core/__tests__/*.test.cjs; do node "$f" 2>&1 | tail -1; done
+
+# Real Postgres smoke:
+# 1. initdb a throwaway local cluster
+# 2. apply 057
+# 3. insert duplicate status='running' rows for one pipeline
+# 4. apply 058 inside a transaction
+# 5. verify one duplicate is failed and a new duplicate insert raises unique_violation
 ```
 
 ## Result — pipelines.test.cjs
@@ -37,7 +45,7 @@ http-routes: REST auth/list/upsert/run/dry-run/replay tests passed
 ✓ http-adapter: config-driven read/upsert tests passed
 http-routes: REST auth/list/upsert/run/dry-run/replay tests passed
 ✓ k3-wise-adapters: WebAPI, SQL Server channel, and auto-flag coercion tests passed
-✓ migration-sql: 057 integration migration structure passed
+✓ migration-sql: 057/058 integration migration structure passed
 ✓ payload-redaction: sensitive key redaction tests passed
 ✓ pipeline-runner: cleanse/idempotency/incremental E2E tests passed
 ✓ pipelines: registry + endpoint + field-mapping + run-ledger + concurrent-guard + stale-run-cleanup tests passed
@@ -50,9 +58,32 @@ runner-support: idempotency/watermark/dead-letter/run-log tests passed
 
 18/18 test files pass. 0 regressions.
 
-## New test coverage breakdown (6 added)
+## Result — real PostgreSQL migration smoke
 
-### pipelines.test.cjs (+6)
+Ran against a local throwaway Postgres cluster via `initdb`/`pg_ctl`, with 058
+executed in a transaction to match the migration runner behavior.
+
+```
+ status  | count
+---------+-------
+ failed  |     1
+ running |     1
+(2 rows)
+
+NOTICE:  unique violation blocked duplicate running run
+DO
+```
+
+This verifies:
+- 057 creates the integration tables cleanly on real Postgres
+- 058 can run transactionally after duplicate `running` rows already exist
+- 058 marks duplicate running rows `failed` before creating the unique index
+- `uniq_integration_runs_one_running_per_pipeline` blocks a new duplicate
+  `running` insert for the same tenant/workspace/pipeline
+
+## New test coverage breakdown
+
+### pipelines.test.cjs
 
 | # | Scenario | What it pins |
 |---|---|---|
@@ -61,8 +92,17 @@ runner-support: idempotency/watermark/dead-letter/run-log tests passed
 | 3 | terminated run does not block | `succeeded` run allows new run — guard checks `status='running'` only |
 | 4 | running run on different pipeline does not block | Guard scopes to `pipeline_id`; unrelated pipelines are independent |
 | 5 | two concurrent `createPipelineRun` calls serialize through the in-process keyed lock | Only one call inserts a `running` row; the other receives `PipelineConflictError` even when both would otherwise snapshot no running rows |
-| 6 | `abandonStaleRuns` default threshold (4h) | Stale run (5h old) abandoned; fresh run (30min) untouched; other-tenant run untouched |
-| 7 | `abandonStaleRuns` custom `olderThanMs` | 15min threshold correctly abandons the 30min-old run |
+| 6 | DB partial unique conflict from another process maps to `PipelineConflictError` | Simulated Postgres `23505` on `uniq_integration_runs_one_running_per_pipeline` is normalized to the same 409-ready error shape |
+| 7 | unique-conflict details include `constraint` and `runningRunId` when visible | Operator can see both the DB enforcing index and the blocking run |
+| 8 | `abandonStaleRuns` default threshold (4h) | Stale run (5h old) abandoned; fresh run (30min) untouched; other-tenant run untouched |
+| 9 | `abandonStaleRuns` custom `olderThanMs` | 15min threshold correctly abandons the 30min-old run |
+
+### migration-sql.test.cjs
+
+| # | Scenario | What it pins |
+|---|---|---|
+| 10 | migration 058 creates `uniq_integration_runs_one_running_per_pipeline` | DB enforces one `running` row per tenant/workspace/pipeline |
+| 11 | migration 058 pre-cleans duplicate running rows with `ROW_NUMBER()` | Existing duplicate data cannot make the unique-index migration fail |
 
 ### http-routes.test.cjs (+1, inside `testErrorResponseShape`)
 
@@ -75,6 +115,8 @@ runner-support: idempotency/watermark/dead-letter/run-log tests passed
 - [x] `PipelineConflictError` exported alongside `PipelineValidationError` / `PipelineNotFoundError`
 - [x] Guard placed after `disabled` check — ordering: pipeline exists → not disabled → not already running → insert
 - [x] In-process keyed lock wraps check+insert — closes the single-node async race
+- [x] DB partial unique index closes the cross-process race
+- [x] Postgres `23505` on the running-run unique index is normalized to `PipelineConflictError`
 - [x] Guard scopes correctly: `tenant_id`, `workspace_id`, `pipeline_id` all in WHERE clause
 - [x] `abandonStaleRuns` never abandons fresh runs (JS timestamp filter, not DB filter)
 - [x] `abandonStaleRuns` is tenant-scoped — other-tenant stale runs unaffected
@@ -86,9 +128,14 @@ runner-support: idempotency/watermark/dead-letter/run-log tests passed
 
 ## Known limitations (documented in design)
 
-- **TOCTOU window still exists** for distributed multi-node deployments. The
-  in-process keyed lock covers the single-node PoC race. Production hardening
-  would use `SELECT ... FOR UPDATE SKIP LOCKED`, advisory locks, or a partial
-  unique index.
 - **`abandonStaleRuns` not auto-wired**: exported but the caller (plugin activation or
   run-trigger route) must decide when to invoke it. This PR only provides the tool.
+
+## Environment note
+
+`pnpm -F plugin-integration-core test` was attempted in the temporary worktree but
+failed before the suite because this worktree has no `node_modules`, and this
+machine's default Node is v24.14.1. The package script's `node --import tsx`
+host-loader smoke needs the workspace dependency tree and is expected to run in
+CI's Node 18/20 jobs. The direct CJS tests and real Postgres migration smoke above
+cover this PR's changed runtime and schema surfaces locally.

--- a/docs/development/integration-core-concurrent-run-guard-verification-20260426.md
+++ b/docs/development/integration-core-concurrent-run-guard-verification-20260426.md
@@ -52,7 +52,7 @@ runner-support: idempotency/watermark/dead-letter/run-log tests passed
 
 ## New test coverage breakdown (6 added)
 
-### pipelines.test.cjs (+5)
+### pipelines.test.cjs (+6)
 
 | # | Scenario | What it pins |
 |---|---|---|
@@ -60,19 +60,21 @@ runner-support: idempotency/watermark/dead-letter/run-log tests passed
 | 2 | error details include `runningRunId` | Operator can identify the blocking run without a DB query |
 | 3 | terminated run does not block | `succeeded` run allows new run — guard checks `status='running'` only |
 | 4 | running run on different pipeline does not block | Guard scopes to `pipeline_id`; unrelated pipelines are independent |
-| 5 | `abandonStaleRuns` default threshold (4h) | Stale run (5h old) abandoned; fresh run (30min) untouched; other-tenant run untouched |
-| 6 | `abandonStaleRuns` custom `olderThanMs` | 15min threshold correctly abandons the 30min-old run |
+| 5 | two concurrent `createPipelineRun` calls serialize through the in-process keyed lock | Only one call inserts a `running` row; the other receives `PipelineConflictError` even when both would otherwise snapshot no running rows |
+| 6 | `abandonStaleRuns` default threshold (4h) | Stale run (5h old) abandoned; fresh run (30min) untouched; other-tenant run untouched |
+| 7 | `abandonStaleRuns` custom `olderThanMs` | 15min threshold correctly abandons the 30min-old run |
 
 ### http-routes.test.cjs (+1, inside `testErrorResponseShape`)
 
 | # | Scenario | What it pins |
 |---|---|---|
-| 7 | `PipelineConflictError` → HTTP 409 | `inferHttpStatus` maps `Conflict` name to 409; error body includes `code` and `details` |
+| 8 | `PipelineConflictError` → HTTP 409 | `inferHttpStatus` maps `Conflict` name to 409; error body includes `code` and `details` |
 
 ## Manual code review checklist
 
 - [x] `PipelineConflictError` exported alongside `PipelineValidationError` / `PipelineNotFoundError`
 - [x] Guard placed after `disabled` check — ordering: pipeline exists → not disabled → not already running → insert
+- [x] In-process keyed lock wraps check+insert — closes the single-node async race
 - [x] Guard scopes correctly: `tenant_id`, `workspace_id`, `pipeline_id` all in WHERE clause
 - [x] `abandonStaleRuns` never abandons fresh runs (JS timestamp filter, not DB filter)
 - [x] `abandonStaleRuns` is tenant-scoped — other-tenant stale runs unaffected
@@ -84,7 +86,9 @@ runner-support: idempotency/watermark/dead-letter/run-log tests passed
 
 ## Known limitations (documented in design)
 
-- **TOCTOU window still exists** for distributed multi-node deployments. Single-node
-  PoC: not a concern. Production hardening would use `SELECT ... FOR UPDATE SKIP LOCKED`.
+- **TOCTOU window still exists** for distributed multi-node deployments. The
+  in-process keyed lock covers the single-node PoC race. Production hardening
+  would use `SELECT ... FOR UPDATE SKIP LOCKED`, advisory locks, or a partial
+  unique index.
 - **`abandonStaleRuns` not auto-wired**: exported but the caller (plugin activation or
   run-trigger route) must decide when to invoke it. This PR only provides the tool.

--- a/packages/core-backend/migrations/058_integration_runs_running_unique.sql
+++ b/packages/core-backend/migrations/058_integration_runs_running_unique.sql
@@ -1,0 +1,36 @@
+-- 058_integration_runs_running_unique.sql
+-- plugin-integration-core · DB-authoritative concurrent-run guard
+--
+-- Enforce the invariant that a pipeline can have at most one active
+-- status='running' run in a tenant/workspace scope. The application-level
+-- check in plugin-integration-core gives a friendly 409 for normal requests,
+-- but this partial unique index is the final cross-process guard for real
+-- concurrent inserts.
+--
+-- workspace_id is nullable in the integration scope model, so COALESCE keeps
+-- NULL workspace rows in one deterministic bucket instead of allowing duplicate
+-- NULL keys through PostgreSQL unique-index semantics.
+-- ---------------------------------------------------------------------------
+
+WITH duplicate_running AS (
+  SELECT
+    id,
+    ROW_NUMBER() OVER (
+      PARTITION BY tenant_id, COALESCE(workspace_id, ''), pipeline_id
+      ORDER BY started_at NULLS LAST, created_at, id
+    ) AS duplicate_rank
+  FROM integration_runs
+  WHERE status = 'running'
+)
+UPDATE integration_runs
+SET
+  status = 'failed',
+  finished_at = COALESCE(finished_at, NOW()),
+  error_summary = COALESCE(error_summary, 'abandoned: duplicate running run closed before unique guard migration')
+WHERE id IN (
+  SELECT id FROM duplicate_running WHERE duplicate_rank > 1
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_integration_runs_one_running_per_pipeline
+  ON integration_runs (tenant_id, COALESCE(workspace_id, ''), pipeline_id)
+  WHERE status = 'running';

--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -638,6 +638,28 @@ async function testErrorResponseShape() {
     query: { workspaceId: 'workspace_1' },
   })
   assert.equal(notFoundRes.statusCode, 404)
+
+  // PipelineConflictError (thrown by concurrent-run guard) maps to 409
+  const conflictError = new Error('pipeline already has a run in progress')
+  conflictError.name = 'PipelineConflictError'
+  conflictError.details = { pipelineId: 'pipe_1', runningRunId: 'run_existing' }
+  const { services: conflictServices } = createMockServices({
+    pipelineRunner: {
+      async runPipeline() {
+        throw conflictError
+      },
+    },
+  })
+  const { routes: conflictRoutes } = mountRoutes(conflictServices)
+  const conflictRes = await invoke(conflictRoutes, 'POST', '/api/integration/pipelines/:id/run', {
+    user: WRITE_USER,
+    params: { id: 'pipe_1' },
+    body: { workspaceId: 'workspace_1' },
+  })
+  assert.equal(conflictRes.statusCode, 409)
+  assert.equal(conflictRes.body.ok, false)
+  assert.equal(conflictRes.body.error.code, 'PipelineConflictError')
+  assert.equal(conflictRes.body.error.details.runningRunId, 'run_existing')
 }
 
 async function testTenantGuards() {

--- a/plugins/plugin-integration-core/__tests__/migration-sql.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/migration-sql.test.cjs
@@ -6,7 +6,9 @@ const path = require('node:path')
 
 const repoRoot = path.resolve(__dirname, '..', '..', '..')
 const migrationPath = path.join(repoRoot, 'packages', 'core-backend', 'migrations', '057_create_integration_core_tables.sql')
+const runningUniqueMigrationPath = path.join(repoRoot, 'packages', 'core-backend', 'migrations', '058_integration_runs_running_unique.sql')
 const sql = fs.readFileSync(migrationPath, 'utf8')
+const runningUniqueSql = fs.readFileSync(runningUniqueMigrationPath, 'utf8')
 
 const expectedTables = [
   'integration_external_systems',
@@ -91,6 +93,17 @@ function main() {
     /CREATE UNIQUE INDEX IF NOT EXISTS uniq_integration_pipelines_scope_name\s+ON integration_pipelines \(tenant_id, COALESCE\(workspace_id, ''\), name\);/m,
     'pipelines unique index treats NULL workspace_id deterministically',
   )
+  assert.match(
+    runningUniqueSql,
+    /CREATE UNIQUE INDEX IF NOT EXISTS uniq_integration_runs_one_running_per_pipeline\s+ON integration_runs \(tenant_id, COALESCE\(workspace_id, ''\), pipeline_id\)\s+WHERE status = 'running';/m,
+    'running-run unique index enforces one running row per tenant/workspace/pipeline',
+  )
+  assert.match(
+    runningUniqueSql,
+    /ROW_NUMBER\(\) OVER \(\s+PARTITION BY tenant_id, COALESCE\(workspace_id, ''\), pipeline_id[\s\S]*?WHERE status = 'running'/m,
+    '058 migration closes duplicate running rows before creating unique index',
+  )
+  assert.doesNotMatch(runningUniqueSql, /\bDROP\s+(?:TABLE|INDEX)\b/i, '058 migration must not drop objects')
 
   const ddlTableRefs = Array.from(sql.matchAll(/\b(?:CREATE|ALTER|DROP|TRUNCATE)\s+TABLE(?:\s+IF\s+(?:NOT\s+)?EXISTS)?\s+([a-zA-Z_][a-zA-Z0-9_]*)/gi))
     .map((match) => match[1])
@@ -99,13 +112,15 @@ function main() {
 
   const indexTableRefs = Array.from(sql.matchAll(/\bCREATE\s+(?:UNIQUE\s+)?INDEX\s+IF\s+NOT\s+EXISTS\s+[a-zA-Z_][a-zA-Z0-9_]*[\s\S]*?\bON\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*\(/gi))
     .map((match) => match[1])
-  assertOnlyIntegrationTableRefs('index', indexTableRefs)
+  const runningUniqueIndexTableRefs = Array.from(runningUniqueSql.matchAll(/\bCREATE\s+(?:UNIQUE\s+)?INDEX\s+IF\s+NOT\s+EXISTS\s+[a-zA-Z_][a-zA-Z0-9_]*[\s\S]*?\bON\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*\(/gi))
+    .map((match) => match[1])
+  assertOnlyIntegrationTableRefs('index', indexTableRefs.concat(runningUniqueIndexTableRefs))
 
   const foreignTableRefs = Array.from(sql.matchAll(/\bREFERENCES\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*\(/gi))
     .map((match) => match[1])
   assertOnlyIntegrationTableRefs('foreign key', foreignTableRefs)
 
-  console.log('✓ migration-sql: 057 integration migration structure passed')
+  console.log('✓ migration-sql: 057/058 integration migration structure passed')
 }
 
 main()

--- a/plugins/plugin-integration-core/__tests__/pipelines.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/pipelines.test.cjs
@@ -7,6 +7,7 @@ const {
   PipelineNotFoundError,
   PipelineValidationError,
   PipelineConflictError,
+  __internals,
 } = require(path.join(__dirname, '..', 'lib', 'pipelines.cjs'))
 
 function createIdGenerator() {
@@ -444,6 +445,58 @@ async function main() {
     assert.ok(rejected && rejected.reason instanceof PipelineConflictError, 'second concurrent run sees conflict')
     const runningRows = raceDb.tables.get('integration_runs').filter((row) => row.pipeline_id === 'pipe_race' && row.status === 'running')
     assert.equal(runningRows.length, 1, 'only one running row is inserted for the pipeline')
+  }
+
+  // A DB-level unique violation from a different process is also normalized to
+  // PipelineConflictError. This covers the distributed race that an in-process
+  // lock cannot serialize.
+  {
+    const dbRace = createMockDb()
+    dbRace.seed('integration_pipelines', [{
+      id: 'pipe_db_race',
+      tenant_id: 'tenant_1',
+      workspace_id: null,
+      status: 'active',
+    }])
+    const originalInsert = dbRace.insertOne.bind(dbRace)
+    const uniqueViolation = new Error(`duplicate key value violates unique constraint "${__internals.RUNNING_RUN_UNIQUE_INDEX}"`)
+    uniqueViolation.code = '23505'
+    uniqueViolation.constraint = __internals.RUNNING_RUN_UNIQUE_INDEX
+    assert.equal(__internals.isRunningRunUniqueViolation(uniqueViolation), true,
+      'running-run unique violation is recognized by constraint name')
+
+    dbRace.insertOne = async (table, row) => {
+      if (table === 'integration_runs') {
+        dbRace.seed('integration_runs', [{
+          id: 'run_other_node',
+          tenant_id: row.tenant_id,
+          workspace_id: row.workspace_id,
+          pipeline_id: row.pipeline_id,
+          status: 'running',
+          started_at: new Date().toISOString(),
+        }])
+        throw uniqueViolation
+      }
+      return originalInsert(table, row)
+    }
+    const dbRaceRegistry = createPipelineRegistry({
+      db: dbRace,
+      idGenerator: createIdGenerator(),
+    })
+    const dbConflict = await dbRaceRegistry.createPipelineRun({
+      tenantId: 'tenant_1',
+      workspaceId: null,
+      pipelineId: 'pipe_db_race',
+      mode: 'manual',
+      triggeredBy: 'api',
+      status: 'running',
+      startedAt: new Date().toISOString(),
+    }).catch((error) => error)
+    assert.ok(dbConflict instanceof PipelineConflictError, 'DB unique violation maps to PipelineConflictError')
+    assert.equal(dbConflict.details.runningRunId, 'run_other_node',
+      'conflict details include the run inserted by the other process')
+    assert.equal(dbConflict.details.constraint, __internals.RUNNING_RUN_UNIQUE_INDEX,
+      'conflict details include the enforcing DB constraint')
   }
 
   // --- 10. abandonStaleRuns -----------------------------------------------

--- a/plugins/plugin-integration-core/__tests__/pipelines.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/pipelines.test.cjs
@@ -6,6 +6,7 @@ const {
   createPipelineRegistry,
   PipelineNotFoundError,
   PipelineValidationError,
+  PipelineConflictError,
 } = require(path.join(__dirname, '..', 'lib', 'pipelines.cjs'))
 
 function createIdGenerator() {
@@ -330,7 +331,123 @@ async function main() {
   }
   assert.ok(disabledRun instanceof PipelineValidationError, 'disabled pipeline cannot create runs')
 
-  console.log('✓ pipelines: registry + endpoint + field-mapping + run-ledger tests passed')
+  // re-enable pipeline for remaining tests
+  db.tables.get('integration_pipelines')[0].status = 'active'
+
+  // --- 9. Concurrent run guard -------------------------------------------
+  // Seed a 'running' run to simulate an in-progress execution
+  db.seed('integration_runs', [{
+    id: 'run_in_progress',
+    tenant_id: 'tenant_1',
+    workspace_id: null,
+    pipeline_id: 'id_1',
+    status: 'running',
+    started_at: new Date().toISOString(),
+  }])
+
+  let conflictError = null
+  try {
+    await registry.createPipelineRun({
+      tenantId: 'tenant_1',
+      workspaceId: null,
+      pipelineId: 'id_1',
+      mode: 'manual',
+      triggeredBy: 'api',
+    })
+  } catch (error) {
+    conflictError = error
+  }
+  assert.ok(conflictError instanceof PipelineConflictError, 'concurrent run rejected with PipelineConflictError')
+  assert.equal(conflictError.details.runningRunId, 'run_in_progress', 'conflict error includes the blocking run ID')
+  assert.ok(conflictError.message.includes('already has a run'), 'conflict error message is descriptive')
+
+  // A terminated run must not block future runs
+  db.tables.get('integration_runs').find(r => r.id === 'run_in_progress').status = 'succeeded'
+  const afterTerminal = await registry.createPipelineRun({
+    tenantId: 'tenant_1',
+    workspaceId: null,
+    pipelineId: 'id_1',
+    mode: 'manual',
+    triggeredBy: 'api',
+  })
+  assert.ok(afterTerminal.id, 'new run allowed once previous run terminates')
+
+  // A running run for a DIFFERENT pipeline must not block this pipeline
+  db.seed('integration_runs', [{
+    id: 'run_other_pipeline',
+    tenant_id: 'tenant_1',
+    workspace_id: null,
+    pipeline_id: 'id_2',
+    status: 'running',
+    started_at: new Date().toISOString(),
+  }])
+  const unrelatedPipelineRun = await registry.createPipelineRun({
+    tenantId: 'tenant_1',
+    workspaceId: null,
+    pipelineId: 'id_1',
+    mode: 'manual',
+    triggeredBy: 'api',
+  })
+  assert.ok(unrelatedPipelineRun.id, 'running run on other pipeline does not block this pipeline')
+
+  // --- 10. abandonStaleRuns -----------------------------------------------
+  // Clean up runs table; seed one stale running run and one fresh running run
+  db.tables.set('integration_runs', [])
+  const fiveHoursAgo = new Date(Date.now() - 5 * 60 * 60 * 1000).toISOString()
+  const thirtyMinutesAgo = new Date(Date.now() - 30 * 60 * 1000).toISOString()
+  db.seed('integration_runs', [
+    {
+      id: 'stale_run',
+      tenant_id: 'tenant_1',
+      workspace_id: null,
+      pipeline_id: 'id_1',
+      status: 'running',
+      started_at: fiveHoursAgo,
+    },
+    {
+      id: 'fresh_run',
+      tenant_id: 'tenant_1',
+      workspace_id: null,
+      pipeline_id: 'id_1',
+      status: 'running',
+      started_at: thirtyMinutesAgo,
+    },
+    {
+      id: 'other_tenant_stale',
+      tenant_id: 'tenant_2',
+      workspace_id: null,
+      pipeline_id: 'id_1',
+      status: 'running',
+      started_at: fiveHoursAgo,
+    },
+  ])
+
+  const abandoned = await registry.abandonStaleRuns({
+    tenantId: 'tenant_1',
+    workspaceId: null,
+  })
+  assert.equal(abandoned.length, 1, 'only the stale run is abandoned')
+  assert.equal(abandoned[0].id, 'stale_run', 'abandoned run ID matches')
+  assert.equal(abandoned[0].status, 'failed', 'abandoned run status is failed')
+  assert.ok(abandoned[0].finishedAt, 'abandoned run has finishedAt')
+
+  // The fresh run and other-tenant run must be untouched
+  const stillRunning = db.tables.get('integration_runs').find(r => r.id === 'fresh_run')
+  assert.equal(stillRunning.status, 'running', 'fresh run is not abandoned')
+  const otherTenantRun = db.tables.get('integration_runs').find(r => r.id === 'other_tenant_stale')
+  assert.equal(otherTenantRun.status, 'running', 'other-tenant stale run is not affected')
+
+  // abandonStaleRuns with a custom olderThanMs: threshold of 1h abandons the 30-min-old run too
+  db.tables.get('integration_runs').find(r => r.id === 'fresh_run').status = 'running'
+  const abandonedShortWindow = await registry.abandonStaleRuns({
+    tenantId: 'tenant_1',
+    workspaceId: null,
+    olderThanMs: 15 * 60 * 1000, // 15 minutes
+  })
+  assert.equal(abandonedShortWindow.length, 1, 'short threshold abandons the 30-min-old run')
+  assert.equal(abandonedShortWindow[0].id, 'fresh_run', 'correct run abandoned with short threshold')
+
+  console.log('✓ pipelines: registry + endpoint + field-mapping + run-ledger + concurrent-guard + stale-run-cleanup tests passed')
 }
 
 main().catch((err) => {

--- a/plugins/plugin-integration-core/__tests__/pipelines.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/pipelines.test.cjs
@@ -390,6 +390,62 @@ async function main() {
   })
   assert.ok(unrelatedPipelineRun.id, 'running run on other pipeline does not block this pipeline')
 
+  // The guard must serialize the check+insert critical section in-process.
+  // Without the keyed lock, both calls below can snapshot "no running rows" before
+  // either insert happens, allowing two concurrent running runs for one pipeline.
+  {
+    const raceDb = createMockDb()
+    raceDb.seed('integration_pipelines', [{
+      id: 'pipe_race',
+      tenant_id: 'tenant_1',
+      workspace_id: null,
+      status: 'active',
+    }])
+    const originalSelect = raceDb.select.bind(raceDb)
+    let releaseSelect
+    const selectGate = new Promise((resolve) => {
+      releaseSelect = resolve
+    })
+    raceDb.select = async (table, options = {}) => {
+      if (table === 'integration_runs' && options.where && options.where.status === 'running') {
+        const snapshot = await originalSelect(table, options)
+        await selectGate
+        return snapshot
+      }
+      return originalSelect(table, options)
+    }
+    const raceRegistry = createPipelineRegistry({
+      db: raceDb,
+      idGenerator: createIdGenerator(),
+    })
+    const first = raceRegistry.createPipelineRun({
+      tenantId: 'tenant_1',
+      workspaceId: null,
+      pipelineId: 'pipe_race',
+      mode: 'manual',
+      triggeredBy: 'api',
+      status: 'running',
+      startedAt: new Date().toISOString(),
+    })
+    const second = raceRegistry.createPipelineRun({
+      tenantId: 'tenant_1',
+      workspaceId: null,
+      pipelineId: 'pipe_race',
+      mode: 'manual',
+      triggeredBy: 'api',
+      status: 'running',
+      startedAt: new Date().toISOString(),
+    })
+    await new Promise((resolve) => setImmediate(resolve))
+    releaseSelect()
+    const results = await Promise.allSettled([first, second])
+    assert.equal(results.filter((result) => result.status === 'fulfilled').length, 1, 'only one concurrent run starts')
+    const rejected = results.find((result) => result.status === 'rejected')
+    assert.ok(rejected && rejected.reason instanceof PipelineConflictError, 'second concurrent run sees conflict')
+    const runningRows = raceDb.tables.get('integration_runs').filter((row) => row.pipeline_id === 'pipe_race' && row.status === 'running')
+    assert.equal(runningRows.length, 1, 'only one running row is inserted for the pipeline')
+  }
+
   // --- 10. abandonStaleRuns -----------------------------------------------
   // Clean up runs table; seed one stale running run and one fresh running run
   db.tables.set('integration_runs', [])

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -64,6 +64,7 @@ function sendError(res, error) {
 function inferHttpStatus(error) {
   const name = error && error.name ? String(error.name) : ''
   if (/NotFound/.test(name)) return 404
+  if (/Conflict/.test(name)) return 409
   if (/Validation|Transform|Watermark|DeadLetter/.test(name)) return 400
   if (/PipelineRunner/.test(name)) return 422
   return 500

--- a/plugins/plugin-integration-core/lib/pipelines.cjs
+++ b/plugins/plugin-integration-core/lib/pipelines.cjs
@@ -319,6 +319,10 @@ function unwrapRows(result) {
   return Array.isArray(result) ? result : result?.rows ?? []
 }
 
+function pipelineRunLockKey(input) {
+  return `${input.tenantId}\u0000${input.workspaceId || ''}\u0000${input.pipelineId}`
+}
+
 async function selectPipeline(db, input) {
   if (input.id) {
     return db.selectOne(PIPELINES_TABLE, {
@@ -379,6 +383,27 @@ async function loadFieldMappings(db, pipelineId) {
 function createPipelineRegistry({ db, idGenerator = crypto.randomUUID } = {}) {
   if (!db || typeof db.selectOne !== 'function' || typeof db.insertOne !== 'function' || typeof db.updateRow !== 'function' || typeof db.select !== 'function') {
     throw new Error('createPipelineRegistry: scoped db helper is required')
+  }
+  const runLocks = new Map()
+
+  async function withPipelineRunLock(key, task) {
+    const previous = runLocks.get(key) || Promise.resolve()
+    let release
+    const gate = new Promise((resolve) => {
+      release = resolve
+    })
+    const tail = previous.catch(() => undefined).then(() => gate)
+    runLocks.set(key, tail)
+
+    await previous.catch(() => undefined)
+    try {
+      return await task()
+    } finally {
+      release()
+      if (runLocks.get(key) === tail) {
+        runLocks.delete(key)
+      }
+    }
   }
 
   async function upsertPipeline(input) {
@@ -482,60 +507,62 @@ function createPipelineRegistry({ db, idGenerator = crypto.randomUUID } = {}) {
 
   async function createPipelineRun(input) {
     const normalized = normalizeCreateRunInput(input)
-    const pipeline = await db.selectOne(PIPELINES_TABLE, {
-      ...scopeWhere(normalized),
-      id: normalized.pipelineId,
-    })
-    if (!pipeline) {
-      throw new PipelineNotFoundError('pipeline not found', {
-        id: normalized.pipelineId,
-        tenantId: normalized.tenantId,
-        workspaceId: normalized.workspaceId,
-      })
-    }
-    if (pipeline.status === 'disabled') {
-      throw new PipelineValidationError('disabled pipeline cannot create runs', {
-        pipelineId: normalized.pipelineId,
-        status: pipeline.status,
-      })
-    }
-    // Reject concurrent runs: at most one run may be in the 'running' state per pipeline at a time.
-    // A second trigger (e.g. double-click, parallel API call) would otherwise cause both runs to
-    // read from the same watermark baseline and double-write to the target ERP.
-    const runningRows = unwrapRows(await db.select(RUNS_TABLE, {
-      where: {
+    return withPipelineRunLock(pipelineRunLockKey(normalized), async () => {
+      const pipeline = await db.selectOne(PIPELINES_TABLE, {
         ...scopeWhere(normalized),
-        pipeline_id: normalized.pipelineId,
-        status: 'running',
-      },
-      limit: 1,
-    }))
-    if (runningRows.length > 0) {
-      throw new PipelineConflictError('pipeline already has a run in progress', {
-        pipelineId: normalized.pipelineId,
-        runningRunId: runningRows[0].id,
+        id: normalized.pipelineId,
       })
-    }
-    const insertRow = {
-      id: normalized.id || idGenerator(),
-      tenant_id: normalized.tenantId,
-      workspace_id: normalized.workspaceId,
-      pipeline_id: normalized.pipelineId,
-      mode: normalized.mode,
-      triggered_by: normalized.triggeredBy,
-      status: normalized.status,
-      rows_read: normalized.rowsRead,
-      rows_cleaned: normalized.rowsCleaned,
-      rows_written: normalized.rowsWritten,
-      rows_failed: normalized.rowsFailed,
-      started_at: normalized.startedAt,
-      finished_at: normalized.finishedAt,
-      duration_ms: normalized.durationMs,
-      error_summary: normalized.errorSummary,
-      details: normalized.details,
-    }
-    const rows = unwrapRows(await db.insertOne(RUNS_TABLE, insertRow))
-    return rowToPipelineRun(rows[0] || insertRow)
+      if (!pipeline) {
+        throw new PipelineNotFoundError('pipeline not found', {
+          id: normalized.pipelineId,
+          tenantId: normalized.tenantId,
+          workspaceId: normalized.workspaceId,
+        })
+      }
+      if (pipeline.status === 'disabled') {
+        throw new PipelineValidationError('disabled pipeline cannot create runs', {
+          pipelineId: normalized.pipelineId,
+          status: pipeline.status,
+        })
+      }
+      // Reject concurrent runs: at most one run may be in the 'running' state per pipeline at a time.
+      // The keyed in-process lock serializes check+insert for single-node PoC deployments; multi-node
+      // deployments still need a DB-level advisory/unique lock follow-up.
+      const runningRows = unwrapRows(await db.select(RUNS_TABLE, {
+        where: {
+          ...scopeWhere(normalized),
+          pipeline_id: normalized.pipelineId,
+          status: 'running',
+        },
+        limit: 1,
+      }))
+      if (runningRows.length > 0) {
+        throw new PipelineConflictError('pipeline already has a run in progress', {
+          pipelineId: normalized.pipelineId,
+          runningRunId: runningRows[0].id,
+        })
+      }
+      const insertRow = {
+        id: normalized.id || idGenerator(),
+        tenant_id: normalized.tenantId,
+        workspace_id: normalized.workspaceId,
+        pipeline_id: normalized.pipelineId,
+        mode: normalized.mode,
+        triggered_by: normalized.triggeredBy,
+        status: normalized.status,
+        rows_read: normalized.rowsRead,
+        rows_cleaned: normalized.rowsCleaned,
+        rows_written: normalized.rowsWritten,
+        rows_failed: normalized.rowsFailed,
+        started_at: normalized.startedAt,
+        finished_at: normalized.finishedAt,
+        duration_ms: normalized.durationMs,
+        error_summary: normalized.errorSummary,
+        details: normalized.details,
+      }
+      const rows = unwrapRows(await db.insertOne(RUNS_TABLE, insertRow))
+      return rowToPipelineRun(rows[0] || insertRow)
+    })
   }
 
   async function updatePipelineRun(input) {
@@ -649,5 +676,6 @@ module.exports = {
     rowToPipeline,
     rowToFieldMapping,
     rowToPipelineRun,
+    pipelineRunLockKey,
   },
 }

--- a/plugins/plugin-integration-core/lib/pipelines.cjs
+++ b/plugins/plugin-integration-core/lib/pipelines.cjs
@@ -38,6 +38,14 @@ class PipelineNotFoundError extends Error {
   }
 }
 
+class PipelineConflictError extends Error {
+  constructor(message, details = {}) {
+    super(message)
+    this.name = 'PipelineConflictError'
+    this.details = details
+  }
+}
+
 function requiredString(value, field) {
   if (typeof value !== 'string' || value.trim().length === 0) {
     throw new PipelineValidationError(`${field} is required`, { field })
@@ -491,6 +499,23 @@ function createPipelineRegistry({ db, idGenerator = crypto.randomUUID } = {}) {
         status: pipeline.status,
       })
     }
+    // Reject concurrent runs: at most one run may be in the 'running' state per pipeline at a time.
+    // A second trigger (e.g. double-click, parallel API call) would otherwise cause both runs to
+    // read from the same watermark baseline and double-write to the target ERP.
+    const runningRows = unwrapRows(await db.select(RUNS_TABLE, {
+      where: {
+        ...scopeWhere(normalized),
+        pipeline_id: normalized.pipelineId,
+        status: 'running',
+      },
+      limit: 1,
+    }))
+    if (runningRows.length > 0) {
+      throw new PipelineConflictError('pipeline already has a run in progress', {
+        pipelineId: normalized.pipelineId,
+        runningRunId: runningRows[0].id,
+      })
+    }
     const insertRow = {
       id: normalized.id || idGenerator(),
       tenant_id: normalized.tenantId,
@@ -552,6 +577,45 @@ function createPipelineRegistry({ db, idGenerator = crypto.randomUUID } = {}) {
     return rows.map(rowToPipelineRun)
   }
 
+  // Marks 'running' runs that started more than `olderThanMs` milliseconds ago as 'failed'.
+  // Called on plugin startup or before creating a new run to recover from crashed runner processes
+  // that never called failRun(). Without this, a crash between startRun and finishRun permanently
+  // blocks future runs of the same pipeline.
+  async function abandonStaleRuns(input = {}) {
+    const tenantId = requiredString(input.tenantId, 'tenantId')
+    const workspaceId = normalizeWorkspaceId(input.workspaceId)
+    const olderThanMs = Number.isInteger(input.olderThanMs) && input.olderThanMs > 0
+      ? input.olderThanMs
+      : 4 * 60 * 60 * 1000 // 4 hours default
+    const nowMs = typeof input.now === 'function' ? input.now() : Date.now()
+    const cutoffMs = nowMs - olderThanMs
+
+    const where = { ...scopeWhere({ tenantId, workspaceId }), status: 'running' }
+    if (input.pipelineId) where.pipeline_id = requiredString(input.pipelineId, 'pipelineId')
+    const runningRows = unwrapRows(await db.select(RUNS_TABLE, { where }))
+
+    const stale = runningRows.filter((row) => {
+      const startedMs = row.started_at ? Date.parse(row.started_at) : NaN
+      return !Number.isNaN(startedMs) && startedMs < cutoffMs
+    })
+
+    const abandoned = []
+    for (const row of stale) {
+      const finishedAt = new Date(nowMs).toISOString()
+      await db.updateRow(
+        RUNS_TABLE,
+        {
+          status: 'failed',
+          finished_at: finishedAt,
+          error_summary: 'abandoned: run exceeded stale threshold and was automatically failed',
+        },
+        { tenant_id: row.tenant_id, workspace_id: row.workspace_id, id: row.id }
+      )
+      abandoned.push(rowToPipelineRun({ ...row, status: 'failed', finished_at: finishedAt }))
+    }
+    return abandoned
+  }
+
   return {
     upsertPipeline,
     getPipeline,
@@ -559,6 +623,7 @@ function createPipelineRegistry({ db, idGenerator = crypto.randomUUID } = {}) {
     createPipelineRun,
     updatePipelineRun,
     listPipelineRuns,
+    abandonStaleRuns,
   }
 }
 
@@ -566,6 +631,7 @@ module.exports = {
   createPipelineRegistry,
   PipelineValidationError,
   PipelineNotFoundError,
+  PipelineConflictError,
   __internals: {
     PIPELINES_TABLE,
     FIELD_MAPPINGS_TABLE,

--- a/plugins/plugin-integration-core/lib/pipelines.cjs
+++ b/plugins/plugin-integration-core/lib/pipelines.cjs
@@ -21,6 +21,7 @@ const VALID_TRIGGERS = new Set(['cron', 'manual', 'api', 'replay'])
 const TERMINAL_RUN_STATUSES = new Set(['succeeded', 'partial', 'failed', 'cancelled'])
 const SOURCE_ROLES = new Set(['source', 'bidirectional'])
 const TARGET_ROLES = new Set(['target', 'bidirectional'])
+const RUNNING_RUN_UNIQUE_INDEX = 'uniq_integration_runs_one_running_per_pipeline'
 
 class PipelineValidationError extends Error {
   constructor(message, details = {}) {
@@ -323,6 +324,28 @@ function pipelineRunLockKey(input) {
   return `${input.tenantId}\u0000${input.workspaceId || ''}\u0000${input.pipelineId}`
 }
 
+function uniqueViolationMetadata(error) {
+  let current = error
+  while (current && typeof current === 'object') {
+    if (current.code === '23505') {
+      return {
+        constraint: current.constraint,
+        message: current.message || '',
+        detail: current.detail || '',
+      }
+    }
+    current = current.cause
+  }
+  return null
+}
+
+function isRunningRunUniqueViolation(error) {
+  const meta = uniqueViolationMetadata(error)
+  if (!meta) return false
+  const text = `${meta.constraint || ''}\n${meta.message}\n${meta.detail}`
+  return text.includes(RUNNING_RUN_UNIQUE_INDEX)
+}
+
 async function selectPipeline(db, input) {
   if (input.id) {
     return db.selectOne(PIPELINES_TABLE, {
@@ -333,6 +356,22 @@ async function selectPipeline(db, input) {
   return db.selectOne(PIPELINES_TABLE, {
     ...scopeWhere(input),
     name: input.name,
+  })
+}
+
+async function conflictFromRunningRun(db, normalized, details = {}) {
+  const runningRows = unwrapRows(await db.select(RUNS_TABLE, {
+    where: {
+      ...scopeWhere(normalized),
+      pipeline_id: normalized.pipelineId,
+      status: 'running',
+    },
+    limit: 1,
+  }))
+  return new PipelineConflictError('pipeline already has a run in progress', {
+    pipelineId: normalized.pipelineId,
+    runningRunId: runningRows[0]?.id || null,
+    ...details,
   })
 }
 
@@ -525,9 +564,8 @@ function createPipelineRegistry({ db, idGenerator = crypto.randomUUID } = {}) {
           status: pipeline.status,
         })
       }
-      // Reject concurrent runs: at most one run may be in the 'running' state per pipeline at a time.
-      // The keyed in-process lock serializes check+insert for single-node PoC deployments; multi-node
-      // deployments still need a DB-level advisory/unique lock follow-up.
+      // Reject concurrent runs early for a friendly error. The DB partial unique
+      // index remains the authoritative cross-process guard for true races.
       const runningRows = unwrapRows(await db.select(RUNS_TABLE, {
         where: {
           ...scopeWhere(normalized),
@@ -560,8 +598,15 @@ function createPipelineRegistry({ db, idGenerator = crypto.randomUUID } = {}) {
         error_summary: normalized.errorSummary,
         details: normalized.details,
       }
-      const rows = unwrapRows(await db.insertOne(RUNS_TABLE, insertRow))
-      return rowToPipelineRun(rows[0] || insertRow)
+      try {
+        const rows = unwrapRows(await db.insertOne(RUNS_TABLE, insertRow))
+        return rowToPipelineRun(rows[0] || insertRow)
+      } catch (error) {
+        if (isRunningRunUniqueViolation(error)) {
+          throw await conflictFromRunningRun(db, normalized, { constraint: RUNNING_RUN_UNIQUE_INDEX })
+        }
+        throw error
+      }
     })
   }
 
@@ -669,6 +714,7 @@ module.exports = {
     VALID_STATUSES,
     VALID_RUN_STATUSES,
     VALID_TRIGGERS,
+    RUNNING_RUN_UNIQUE_INDEX,
     normalizePipelineInput,
     normalizeFieldMappings,
     normalizeCreateRunInput,
@@ -677,5 +723,6 @@ module.exports = {
     rowToFieldMapping,
     rowToPipelineRun,
     pipelineRunLockKey,
+    isRunningRunUniqueViolation,
   },
 }


### PR DESCRIPTION
## Problem

Two bugs in the same invariant — the `running` status of a pipeline run must be exclusive per pipeline and bounded in lifetime:

**Bug 1 — Concurrent run guard missing**: Two simultaneous `POST /pipelines/:id/run` requests both passed `createPipelineRun`. Both reads started from the same watermark baseline; both advanced the watermark to the same point; both wrote to the target ERP (idempotency blocked duplicates but the double watermark advance silently discarded work that should have been queued for the next incremental run).

**Bug 2 — Stuck-run / status leak**: A process crash between `startRun` and `finishRun`/`failRun` left a run permanently `status='running'`. Once the concurrent-run guard was added, this became a deadlock: no new runs could ever start for that pipeline, with no automatic recovery path.

## Fix

### `pipelines.cjs`
- Add `PipelineConflictError` error class
- In `createPipelineRun`: query for existing `running` runs on the same `(tenant_id, workspace_id, pipeline_id)` tuple before inserting; throw `PipelineConflictError` with the blocking run's ID if one exists
- Add `abandonStaleRuns({ tenantId, workspaceId, [pipelineId], [olderThanMs] })`: selects all `running` runs, filters those whose `started_at` predates the threshold (default 4h), marks them `failed` with an `error_summary` explaining why — call this on plugin startup or before launching a new run if you suspect a crash

### `http-routes.cjs`
- `inferHttpStatus`: add `Conflict` → 409 so `PipelineConflictError` returns HTTP 409 instead of 500

## Tests added (7 new scenarios)

**`pipelines.test.cjs`** (+5):
1. concurrent run rejected with `PipelineConflictError`, includes blocking run ID in details
2. terminated run (succeeded) does not block new run
3. running run on a different pipeline does not block this pipeline
4. `abandonStaleRuns` abandons runs older than threshold, leaves fresh and other-tenant runs untouched
5. `abandonStaleRuns` with custom `olderThanMs` threshold

**`http-routes.test.cjs`** (+1 in testErrorResponseShape):
6. `PipelineConflictError` thrown by runner → HTTP 409 with error body

All 18 integration-core test files pass.

## Out of scope

- Distributed lock (advisory PG lock, Redis) — the equality-based guard is sufficient for single-node PoC; if multi-node scale-out is needed later, replace `select + insert` with `SELECT ... FOR UPDATE SKIP LOCKED` in a real DB transaction
- Scheduler-triggered auto-abandon on startup — `abandonStaleRuns` is exported; caller decides when to invoke it

## Cross-references
- Broader-surface audit: `docs/development/bool-coercion-audit-broader-surface-20260426.md` § "What this means for the M2 GATE wait"
- Live PoC evidence compiler: PR #1182 (packet safety coercion, same module)

🤖 Generated with [Claude Code](https://claude.com/claude-code)