### PR TITLE
fix(integration): auto-sweep stale runs before starting a new pipeline run

### DIFF
--- a/docs/development/integration-core-stale-run-autowire-design-20260426.md
+++ b/docs/development/integration-core-stale-run-autowire-design-20260426.md
@@ -1,0 +1,82 @@
+# Integration-Core Stale-Run Autowire · Design
+
+> Date: 2026-04-26
+> PR: #1188
+> Depends on: PR #1187 (abandons the stale run; this PR wires the call)
+
+## Problem
+
+PR #1187 exported `pipelineRegistry.abandonStaleRuns` but left it uncalled. The tool
+exists; no caller invokes it automatically. Result: a process crash between `startRun`
+and `finishRun`/`failRun` leaves a run permanently `status='running'`. Once #1187's
+concurrent-run guard is active, this becomes a silent deadlock — every subsequent trigger
+of that pipeline returns HTTP 409 CONFLICT with `runningRunId` pointing at a ghost run
+that will never complete. The operator has no automated recovery path.
+
+## Solution
+
+`runPipeline` calls `pipelineRegistry.abandonStaleRuns` immediately after
+`loadPipelineContext` (pipeline validated) and before `runLogger.startRun`
+(run record created):
+
+```javascript
+if (typeof pipelineRegistry.abandonStaleRuns === 'function') {
+  await pipelineRegistry.abandonStaleRuns({
+    tenantId: context.tenantId,
+    workspaceId: context.workspaceId,
+    pipelineId: context.pipeline.id,
+  })
+}
+```
+
+**Why here:** The sweep is scoped to the specific pipeline being triggered.
+This is the natural gate: an operator triggers pipeline P → the runner sweeps
+for stuck runs of P (only P, not all pipelines) → clears any crash-ghost →
+startRun proceeds → concurrent-run guard checks again and finds nothing.
+
+**Why scoped to pipelineId:** A stuck run on pipeline Q should not be swept when
+pipeline P is triggered. The sweep only clears the ghost that would block the
+imminent trigger. This prevents unexpected side effects on unrelated pipelines.
+
+**Default staleness threshold:** `abandonStaleRuns` defaults to 4 hours. The
+longest expected PoC full-sync run is < 30 min. 4h means a crashed run is
+cleared no later than the next trigger after the 4h window closes.
+
+**typeof guard:** The call is conditional on `typeof pipelineRegistry.abandonStaleRuns
+=== 'function'`. This ensures:
+- Registries without `abandonStaleRuns` (pre-#1187 or test mocks) are unaffected
+- No new required dependency is added to `requireDependency` validation
+
+## Execution order after this PR
+
+```
+runPipeline(input)
+  ├─ loadPipelineContext  — validate pipeline exists + active
+  ├─ abandonStaleRuns     — [NEW] sweep crashed ghost runs for this pipeline
+  ├─ startRun             — concurrent-run guard fires here (#1187)
+  ├─ ... run body ...
+  └─ finishRun / failRun  — mark run terminal, watermark advance
+```
+
+## Files changed
+
+| File | Change |
+|---|---|
+| `lib/pipeline-runner.cjs` | 7 lines added between `loadPipelineContext` and `startRun` |
+| `__tests__/pipeline-runner.test.cjs` | `abandonStaleRunsCalls` tracker added to mock registry; `pipelineRegistry` added to `createRunnerHarness` return; 2 new scenarios |
+| this design doc | — |
+| matching verification doc | — |
+
+## What this does NOT change
+
+- **`abandonStaleRuns` API** — unchanged from #1187; threshold, return type, and scope
+  semantics are identical
+- **Happy-path behavior** — `abandonStaleRuns` returns `[]` (no stale runs) in the normal
+  case; no observable difference for successful previous runs
+- **Error handling** — if `abandonStaleRuns` itself throws, the error propagates out of
+  `runPipeline` before `startRun` is called; no orphaned run records are created
+
+## Cross-references
+
+- PR #1187 — `abandonStaleRuns` implementation + concurrent-run guard
+- PR #1189 — composite index for the concurrent-run guard query (independent)

--- a/docs/development/integration-core-stale-run-autowire-verification-20260426.md
+++ b/docs/development/integration-core-stale-run-autowire-verification-20260426.md
@@ -1,0 +1,78 @@
+# Integration-Core Stale-Run Autowire · Verification
+
+> Date: 2026-04-26
+> Companion: `integration-core-stale-run-autowire-design-20260426.md`
+> PR: #1188
+
+## Commands run
+
+```bash
+node plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs
+# Full regression:
+for f in plugins/plugin-integration-core/__tests__/*.test.cjs; do node "$f" 2>&1 | tail -1; done
+```
+
+## Result — pipeline-runner.test.cjs
+
+```
+✓ pipeline-runner: cleanse/idempotency/incremental E2E tests passed
+```
+
+## Result — full suite regression (18 files)
+
+```
+✓ adapter-contracts: registry + normalizer tests passed
+✓ credential-store: 10 scenarios passed
+✓ db.cjs: all CRUD + boundary + injection tests passed
+✓ e2e-plm-k3wise-writeback: mock PLM → K3 WISE → feedback tests passed
+✓ erp-feedback: normalize + writer tests passed
+✓ external-systems: registry + credential boundary tests passed
+✓ http-adapter: config-driven read/upsert tests passed
+http-routes: REST auth/list/upsert/run/dry-run/replay tests passed
+✓ k3-wise-adapters: WebAPI, SQL Server channel, and auto-flag coercion tests passed
+✓ migration-sql: 057 integration migration structure passed
+✓ payload-redaction: sensitive key redaction tests passed
+✓ pipeline-runner: cleanse/idempotency/incremental E2E tests passed
+✓ pipelines: registry + endpoint + field-mapping + run-ledger tests passed
+✓ plm-yuantus-wrapper: source facade tests passed
+✓ plugin-runtime-smoke: all assertions passed
+runner-support: idempotency/watermark/dead-letter/run-log tests passed
+✓ staging-installer: all 7 assertions passed
+[pass] transform-validator: transform engine + validator tests passed
+```
+
+18/18 test files pass. 0 regressions.
+
+## New test coverage breakdown (2 added in pipeline-runner.test.cjs)
+
+| # | Scenario | What it pins |
+|---|---|---|
+| 17a | `abandonStaleRuns` called once per `runPipeline` invocation, scoped to correct tenant + pipeline ID | Verifies the autowire fires and the scope is correct |
+| 17b | `runPipeline` succeeds when registry has no `abandonStaleRuns` method | Backward-compatibility: `typeof` guard prevents TypeError on pre-#1187 registries |
+
+## Manual code review checklist
+
+- [x] Call placed after `loadPipelineContext` — pipeline is validated before we attempt sweep
+- [x] Call placed before `runLogger.startRun` — no run record exists when the sweep fires;
+  if `abandonStaleRuns` throws, the error propagates cleanly with no orphaned run
+- [x] `typeof` guard — won't throw on registries that lack the method
+- [x] Scope is `{ tenantId, workspaceId, pipelineId }` — sweep is confined to the pipeline
+  being triggered, not a global sweep of all tenants or pipelines
+- [x] `abandonStaleRuns` return value is unused — the runner doesn't need to log or act on
+  the list of abandoned runs; callers that want that info should call it directly
+- [x] No new `requireDependency` constraint added — soft optional call only
+- [x] `createRunnerHarness` now returns `pipelineRegistry` — test can inspect call counts
+  without exposing internal implementation details to other scenarios
+
+## Interaction with #1187
+
+This PR is forward-compatible: it is safe to merge before or after #1187.
+
+- **Before #1187**: `abandonStaleRuns` doesn't exist on the registry; `typeof` guard
+  skips the call; behavior is unchanged from main.
+- **After #1187**: `abandonStaleRuns` exists; the recovery path activates automatically.
+
+The concurrent-run guard in #1187's `createPipelineRun` fires immediately after this sweep.
+The intended flow is: sweep removes any crashed ghost → guard finds nothing → new run is
+created. If the sweep itself finds nothing (normal case), no runs are abandoned and the
+guard check is a no-op.

--- a/plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs
@@ -120,6 +120,11 @@ function createPipelineRegistry(pipeline, db) {
         details: row.details,
       }
     },
+    abandonStaleRunsCalls: [],
+    async abandonStaleRuns(input) {
+      this.abandonStaleRunsCalls.push({ ...input })
+      return []
+    },
   }
 }
 
@@ -226,7 +231,7 @@ function createRunnerHarness({ sourceRecords, pipelineOverrides = {}, sourceRead
     })(),
   })
 
-  return { adapterSystems, db, pipeline, runner, sourceRecords, targetRows }
+  return { adapterSystems, db, pipeline, pipelineRegistry, runner, sourceRecords, targetRows }
 }
 
 async function main() {
@@ -710,6 +715,41 @@ async function main() {
       allowInactive: truthyVariant,
     })
     assert.ok(result.run, `allowInactive: ${JSON.stringify(truthyVariant)} lets the inactive pipeline run`)
+  }
+
+  // --- 17. abandonStaleRuns autowire ---------------------------------------
+  // runPipeline must call pipelineRegistry.abandonStaleRuns before startRun,
+  // scoped to the specific pipeline being triggered.
+  {
+    const harness = createRunnerHarness({
+      sourceRecords: [{ code: 'a-01', revision: 'r1', qty: '3', name: 'Bolt', updatedAt: '2026-04-24T01:00:00.000Z' }],
+    })
+    await harness.runner.runPipeline({
+      tenantId: 'tenant_1',
+      pipelineId: 'pipe_1',
+      mode: 'manual',
+      triggeredBy: 'api',
+    })
+    const calls = harness.pipelineRegistry.abandonStaleRunsCalls
+    assert.equal(calls.length, 1, 'abandonStaleRuns called once per run')
+    assert.equal(calls[0].tenantId, 'tenant_1', 'abandonStaleRuns scoped to correct tenant')
+    assert.equal(calls[0].pipelineId, 'pipe_1', 'abandonStaleRuns scoped to triggering pipeline')
+  }
+
+  // runPipeline works correctly when pipelineRegistry has no abandonStaleRuns method
+  // (backward-compatibility: existing registries that pre-date PR #1187 are unaffected)
+  {
+    const harness = createRunnerHarness({
+      sourceRecords: [{ code: 'a-01', revision: 'r1', qty: '3', name: 'Bolt', updatedAt: '2026-04-24T01:00:00.000Z' }],
+    })
+    delete harness.pipelineRegistry.abandonStaleRuns
+    const result = await harness.runner.runPipeline({
+      tenantId: 'tenant_1',
+      pipelineId: 'pipe_1',
+      mode: 'manual',
+      triggeredBy: 'api',
+    })
+    assert.ok(result.run, 'run succeeds even when abandonStaleRuns is not present on registry')
   }
 
   console.log('✓ pipeline-runner: cleanse/idempotency/incremental E2E tests passed')

--- a/plugins/plugin-integration-core/lib/pipeline-runner.cjs
+++ b/plugins/plugin-integration-core/lib/pipeline-runner.cjs
@@ -338,6 +338,16 @@ function createPipelineRunner(deps = {}) {
     const mode = input.mode || context.pipeline.mode || 'manual'
     const triggeredBy = input.triggeredBy || 'manual'
     const dryRun = coerceTruthyFlag(input.dryRun, 'input.dryRun')
+    // Sweep for stale 'running' runs on this pipeline before creating a new one.
+    // Recovers from process crashes that left a run permanently 'running', which
+    // would otherwise block the concurrent-run guard from ever accepting new runs.
+    if (typeof pipelineRegistry.abandonStaleRuns === 'function') {
+      await pipelineRegistry.abandonStaleRuns({
+        tenantId: context.tenantId,
+        workspaceId: context.workspaceId,
+        pipelineId: context.pipeline.id,
+      })
+    }
     const started = clock()
     const metrics = createMetrics()
     const preview = dryRun ? { records: [], errors: [] } : null


### PR DESCRIPTION
## Problem

PR #1187 added `abandonStaleRuns` to the pipeline registry and exported it — but nothing called it automatically. A process crash between `startRun` and `finishRun/failRun` would leave a run permanently `status='running'`. Once the concurrent-run guard from #1187 is active, this becomes a silent deadlock: every subsequent trigger of that pipeline returns 409 CONFLICT with no way to recover short of a manual DB update.

## Fix

`runPipeline` now calls `pipelineRegistry.abandonStaleRuns` scoped to the triggering pipeline before handing off to `runLogger.startRun`. The call is defensive (`typeof check`) — existing registries without `abandonStaleRuns` (pre-#1187 or test mocks) are unaffected.

**Order after this change:**
1. `loadPipelineContext` — validates pipeline exists and is active
2. **`abandonStaleRuns`** — marks crashed/stuck running runs as failed (auto-recovery)
3. `runLogger.startRun` → `createPipelineRun` — concurrent-run guard now sees a clean slate

An operator who triggers a run after a previous crash gets automatic recovery on the first attempt rather than a confusing 409 CONFLICT followed by a manual support ticket.

## Tests added (+2 scenarios in `pipeline-runner.test.cjs`)

| # | Scenario | What it pins |
|---|---|---|
| 17a | `abandonStaleRuns` called once per `runPipeline`, scoped to correct tenant + pipeline | Verifies the autowire actually fires |
| 17b | `runPipeline` works when registry has no `abandonStaleRuns` method | Backward-compatibility: pre-#1187 registries are unaffected |

All 18 integration-core test files pass (0 regressions).

## Note

This PR is useful standalone but its full effect is only visible once #1187 is merged (before #1187, there is no concurrent-run guard to unlock). Both PRs are independent — merging this before #1187 is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)