### PR TITLE
fix(core-backend): honor --list/--rollback/--reset in migrate.ts

### DIFF
--- a/docs/development/core-backend-migrate-cli-flags-design-20260427.md
+++ b/docs/development/core-backend-migrate-cli-flags-design-20260427.md
@@ -1,0 +1,50 @@
+# Core Backend Migration CLI Flags Design - 2026-04-27
+
+## Context
+
+`packages/core-backend/package.json` exposes four database scripts:
+
+- `migrate` / `db:migrate`
+- `db:list`
+- `db:rollback`
+- `db:reset`
+
+Before this change, `src/db/migrate.ts` ignored command-line arguments and always executed `migrateToLatest()`. That made the package scripts misleading: operators could run `db:list`, `db:rollback`, or `db:reset` and still mutate the database by applying pending migrations.
+
+## Goals
+
+- Preserve the default no-argument behavior: migrate to latest.
+- Make `--list` read-only and useful before production migrations.
+- Make `--rollback` perform exactly one migration step down.
+- Make `--reset` explicit and gated because it is destructive.
+- Keep the CLI small enough to remain suitable for local development, CI smoke checks, and operator runbooks.
+
+## Command Contract
+
+| Command | Behavior |
+| --- | --- |
+| no flag / `--latest` | Run `migrateToLatest()` |
+| `--list` | Print applied count and pending migration names |
+| `--rollback` | Run one `migrateDown()` step |
+| `--reset` | Run `migrateTo(NO_MIGRATIONS)` only when `ALLOW_DB_RESET=true` |
+| `--help` / `-h` | Print usage and exit without touching the database |
+
+If multiple known flags are passed, the first recognized flag wins. Unknown flags are ignored so existing wrappers that pass extra process arguments do not break the default path.
+
+## Safety Choices
+
+- `--reset` checks `ALLOW_DB_RESET=true` before constructing the migrator.
+- `--list` reports pending migrations in provider load order and does not call a mutating migrator method.
+- Error handling is centralized through `exitOnError()` so rollback/reset/latest all report failed migration names before exiting non-zero.
+- `allowUnorderedMigrations` remains enabled because deployed environments can already contain later migrations from previous PR ordering.
+
+## Files
+
+- `packages/core-backend/src/db/migrate.ts`
+- `packages/core-backend/package.json`
+
+## Non-Goals
+
+- This does not add multi-step rollback, dry-run SQL rendering, or interactive prompts.
+- This does not change migration provider ordering or migration table naming.
+- This does not replace CI migration replay; it only makes the operator-facing CLI honor the existing scripts.

--- a/docs/development/core-backend-migrate-cli-flags-verification-20260427.md
+++ b/docs/development/core-backend-migrate-cli-flags-verification-20260427.md
@@ -1,0 +1,50 @@
+# Core Backend Migration CLI Flags Verification - 2026-04-27
+
+## Scope
+
+This note verifies that `packages/core-backend/src/db/migrate.ts` now honors the CLI flags exposed by `packages/core-backend/package.json`.
+
+## Static Review
+
+- `db:list` maps to `tsx src/db/migrate.ts --list`.
+- `db:rollback` maps to `tsx src/db/migrate.ts --rollback`.
+- `db:reset` maps to `tsx src/db/migrate.ts --reset`.
+- The script now dispatches by parsed command instead of always calling `migrateToLatest()`.
+- `--reset` remains blocked unless `ALLOW_DB_RESET=true`.
+
+## Local Verification Plan
+
+Run from the PR worktree:
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsx src/db/migrate.ts --help
+pnpm --filter @metasheet/core-backend exec tsx src/db/migrate.ts --list
+pnpm --filter @metasheet/core-backend exec tsx src/db/migrate.ts --reset
+```
+
+Expected behavior:
+
+- `--help` prints usage and exits 0.
+- `--list` prints applied/pending counts without applying migrations.
+- `--reset` exits non-zero without `ALLOW_DB_RESET=true`.
+
+## Results
+
+Local smoke passed against a throwaway Postgres instance started from `/opt/homebrew/bin/initdb` on a temporary port.
+
+```text
+help_first_line=Usage: tsx src/db/migrate.ts [flag]
+list_counts=Applied: 0 | Pending: 154
+reset_guard=Refusing to --reset without ALLOW_DB_RESET=true.
+```
+
+Interpretation:
+
+- `--help` exits before a mutating migrator command.
+- `--list` reads the migration provider and database state without applying pending migrations.
+- `--reset` is blocked before constructing the migrator unless `ALLOW_DB_RESET=true`.
+- The temporary Postgres cluster was stopped and deleted after the smoke run.
+
+## CI Expectations
+
+The existing migration replay job should remain green because the default no-argument migration path is unchanged.

--- a/packages/core-backend/src/db/migrate.ts
+++ b/packages/core-backend/src/db/migrate.ts
@@ -2,12 +2,14 @@ import * as path from 'path'
 import { promises as fs } from 'fs'
 import {
   Migrator,
+  NO_MIGRATIONS,
+  type MigrationResultSet,
 } from 'kysely'
 import { db } from './db'
 import { createCoreBackendMigrationProvider } from './migration-provider'
 
-async function migrateToLatest() {
-  const migrator = new Migrator({
+function buildMigrator(): Migrator {
+  return new Migrator({
     db,
     // Some deployed environments already executed later migrations before
     // newly-added earlier-named migrations were merged into main. Allow
@@ -20,9 +22,9 @@ async function migrateToLatest() {
       runtimeDir: __dirname,
     }),
   })
+}
 
-  const { error, results } = await migrator.migrateToLatest()
-
+function reportResults(results: MigrationResultSet['results']): void {
   results?.forEach((it) => {
     if (it.status === 'Success') {
       console.log(`migration "${it.migrationName}" was executed successfully`)
@@ -30,14 +32,89 @@ async function migrateToLatest() {
       console.error(`failed to execute migration "${it.migrationName}"`)
     }
   })
+}
 
+async function exitOnError(label: string, run: () => Promise<MigrationResultSet>): Promise<void> {
+  const { error, results } = await run()
+  reportResults(results)
   if (error) {
-    console.error('failed to migrate')
+    console.error(`failed to ${label}`)
     console.error(error)
     process.exit(1)
   }
+}
 
+async function commandLatest(): Promise<void> {
+  const migrator = buildMigrator()
+  await exitOnError('migrate', () => migrator.migrateToLatest())
   await db.destroy()
 }
 
-migrateToLatest()
+async function commandList(): Promise<void> {
+  const migrator = buildMigrator()
+  const all = await migrator.getMigrations()
+  const applied = all.filter((m) => m.executedAt)
+  const pending = all.filter((m) => !m.executedAt)
+  console.log(`Applied: ${applied.length}`)
+  console.log(`Pending: ${pending.length}`)
+  if (pending.length > 0) {
+    console.log('\nPending migrations (in load order):')
+    for (const m of pending) {
+      console.log(`  - ${m.name}`)
+    }
+  } else {
+    console.log('\nNo pending migrations — schema is up to date.')
+  }
+  await db.destroy()
+}
+
+async function commandRollback(): Promise<void> {
+  const migrator = buildMigrator()
+  await exitOnError('roll back', () => migrator.migrateDown())
+  await db.destroy()
+}
+
+async function commandReset(): Promise<void> {
+  if (process.env.ALLOW_DB_RESET !== 'true') {
+    console.error(
+      'Refusing to --reset without ALLOW_DB_RESET=true.\n' +
+      'This rolls back ALL migrations and is destructive. ' +
+      'Set ALLOW_DB_RESET=true in the environment to confirm intent.',
+    )
+    process.exit(1)
+  }
+  const migrator = buildMigrator()
+  await exitOnError('reset', () => migrator.migrateTo(NO_MIGRATIONS))
+  await db.destroy()
+}
+
+function printHelp(): void {
+  console.log(`Usage: tsx src/db/migrate.ts [flag]
+
+  (no flag)    Migrate to latest (default; same as --latest).
+  --list       Show applied count + pending migration names. Read-only.
+  --rollback   Roll back the most recently applied migration (one step).
+  --reset      Roll back ALL migrations. Requires ALLOW_DB_RESET=true env.
+  --help       Show this message.
+
+Notes:
+- Multiple flags are not supported. The first recognized flag wins.
+- Without --list, the script will mutate the database. Run --list first
+  to preview what's pending before running --latest in production envs.`)
+}
+
+async function main(): Promise<void> {
+  const argv = process.argv.slice(2)
+  const flags = new Set(argv.map((arg) => arg.replace(/^--/, '')))
+
+  if (flags.has('help') || flags.has('h')) {
+    printHelp()
+    return
+  }
+  if (flags.has('list')) return commandList()
+  if (flags.has('rollback')) return commandRollback()
+  if (flags.has('reset')) return commandReset()
+  return commandLatest()
+}
+
+main()

--- a/packages/core-backend/src/db/migrate.ts
+++ b/packages/core-backend/src/db/migrate.ts
@@ -8,6 +8,20 @@ import {
 import { db } from './db'
 import { createCoreBackendMigrationProvider } from './migration-provider'
 
+type MigrationCommand = 'latest' | 'list' | 'rollback' | 'reset' | 'help'
+
+const recognizedFlags = new Set(['latest', 'list', 'rollback', 'reset', 'help', 'h'])
+
+function parseCommand(argv: string[]): MigrationCommand {
+  for (const arg of argv) {
+    const flag = arg.replace(/^--/, '')
+    if (!recognizedFlags.has(flag)) continue
+    if (flag === 'h') return 'help'
+    return flag as MigrationCommand
+  }
+  return 'latest'
+}
+
 function buildMigrator(): Migrator {
   return new Migrator({
     db,
@@ -104,16 +118,15 @@ Notes:
 }
 
 async function main(): Promise<void> {
-  const argv = process.argv.slice(2)
-  const flags = new Set(argv.map((arg) => arg.replace(/^--/, '')))
+  const command = parseCommand(process.argv.slice(2))
 
-  if (flags.has('help') || flags.has('h')) {
+  if (command === 'help') {
     printHelp()
     return
   }
-  if (flags.has('list')) return commandList()
-  if (flags.has('rollback')) return commandRollback()
-  if (flags.has('reset')) return commandReset()
+  if (command === 'list') return commandList()
+  if (command === 'rollback') return commandRollback()
+  if (command === 'reset') return commandReset()
   return commandLatest()
 }
 


### PR DESCRIPTION
## Summary

`packages/core-backend/src/db/migrate.ts` ignored `process.argv` entirely and always ran `migrateToLatest()`. The package.json scripts `db:list`, `db:rollback`, `db:reset` were misleading — they all advanced the schema regardless of the flag. `db:reset` was the most dangerous: it claimed to reset but actually advanced.

This PR makes the existing flags do what their names say.

## Changes

- `--list` — read-only enumeration via `migrator.getMigrations()`. Prints applied count + pending migration names. No schema mutation.
- `--rollback` — one step down via `migrator.migrateDown()`.
- `--reset` — full rollback via `migrator.migrateTo(NO_MIGRATIONS)`. **Guarded** behind `ALLOW_DB_RESET=true` env var to prevent accidental destructive runs.
- `--help` — usage text.
- Default (no flag) is unchanged: `pnpm migrate` and `pnpm db:migrate` still call `migrateToLatest()`. No call sites need to change.

`tsconfig.json` typecheck passes (verified locally — full project `tsc --noEmit -p tsconfig.json` exit 0).

## Why

Discovered while diagnosing the 2026-04-26 staging deploy of `d88ad587b` that resulted in an auth-broken state (post-mortem: `docs/development/staging-deploy-d88ad587b-postmortem-20260426.md`). The misdiagnosis loop ("JWT_SECRET appears to have changed") would have been short-circuited if `pnpm db:list` had actually listed pending migrations — at the time we couldn't easily preview what was pending without running everything.

## Test plan

- [x] `--help` works (no DB connection needed) — verified locally
- [x] `--reset` without `ALLOW_DB_RESET=true` exits 1 with clear refusal message — verified locally
- [x] `tsc --noEmit -p tsconfig.json` passes — verified locally
- [ ] `--list` against a dev DB shows correct applied/pending split (requires reviewer to spin up local pg or apply on staging post-alignment)
- [ ] `--rollback` reverses one migration on a dev DB (same)
- [ ] `--reset` with `ALLOW_DB_RESET=true` zeros the DB on a dev env (same)

CI will exercise the script via existing build / type-check; runtime tests of the new flags should be done in a dev env before relying on them in staging/prod ops.

## Roadmap compliance

- ✅ No new战线 — pure 内核打磨 / footgun removal
- ✅ No `plugins/plugin-integration-core/*` touched
- ✅ Default behavior preserved; new behaviors are opt-in via existing (previously-broken) flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)