### PR TITLE
fix(integration): guard dead-letter replay against non-open status

### DIFF
--- a/docs/development/integration-core-dead-letter-status-guard-design-20260426.md
+++ b/docs/development/integration-core-dead-letter-status-guard-design-20260426.md
@@ -1,0 +1,89 @@
+# Integration-Core Dead-Letter Status Guard · Design
+
+> Date: 2026-04-26
+> PR: #1191
+
+## Problem
+
+`replayDeadLetter` performs two checks before calling `runPipeline`:
+1. Dead letter exists (404 guard)
+2. Source payload is not truncated (PAYLOAD_TRUNCATED guard)
+
+Missing: **check that `deadLetter.status === 'open'`**.
+
+Two failure modes:
+
+### Double-replay (status='replayed')
+
+Operator replays DL-1 → succeeds → DL-1 is `status='replayed'`.
+A second replay attempt (double-click, automated retry, script) calls
+`replayDeadLetter` again with the same ID. The code fetches the dead
+letter (status='replayed'), passes both existing guards, and calls
+`runPipeline` with the same source payload.
+
+Consequences:
+- K3 WISE `login` + `Material Save` API calls fire again
+- A new `integration_runs` row is created (run-log pollution)
+- `markReplayed` is called on the already-replayed letter, updating `retryCount` and `lastReplayRunId` again
+- Idempotency layer blocks the duplicate ERP write — but the full adapter round-trip has already happened
+
+### Discarded-letter replay (status='discarded')
+
+A `status='discarded'` letter was deliberately excluded from the sync
+(operator decision: "this record should not go to ERP"). Nothing blocks
+a subsequent `POST /dead-letters/:id/replay` from re-introducing it.
+
+## Solution
+
+One guard added immediately after `getDeadLetter` and before the
+truncation check:
+
+```javascript
+if (deadLetter.status !== 'open') {
+  throw new PipelineRunnerError('dead letter cannot be replayed: status is not open', {
+    id: deadLetter.id,
+    status: deadLetter.status,
+  })
+}
+```
+
+**Error code**: `PipelineRunnerError` → HTTP 422 via the existing `inferHttpStatus`
+mapping (`/PipelineRunner/.test(name) → 422`). The operator sees the
+current status in `error.details.status`.
+
+**Why 422 and not 409**: 409 Conflict implies a concurrency conflict
+(another request is in progress). 422 Unprocessable Entity is the correct
+code for "request is well-formed but cannot be executed on this resource
+in its current state".
+
+**Why silent clamp is not appropriate**: Unlike the list-limit cap (where
+clamping is harmless), silently ignoring a non-open replay would mask the
+operator's misunderstanding of the dead-letter lifecycle.
+
+## Files changed
+
+| File | Change |
+|---|---|
+| `lib/pipeline-runner.cjs` | 7 lines: status guard before truncation check in `replayDeadLetter` |
+| `__tests__/pipeline-runner.test.cjs` | 3 new scenarios (double-replay, unchanged target, discarded) |
+| this design doc | — |
+| matching verification doc | — |
+
+## Dead-letter lifecycle reminder
+
+```
+open → replayed   (successful replay)
+open → open       (failed replay: rowsFailed > 0 — stays open for retry)
+open → discarded  (operator manually discards via future discard endpoint)
+replayed → [end]  (no further state transitions)
+discarded → [end] (no further state transitions)
+```
+
+The guard ensures only `open` letters can trigger a replay run. The
+other two terminal-or-final states are explicitly rejected.
+
+## Cross-references
+
+- `lib/dead-letter.cjs` — `VALID_STATUSES`, `markReplayed`
+- `lib/pipeline-runner.cjs` — `replayDeadLetter`, `isTruncatedReplayPayload`
+- PR #1187 — concurrent-run guard (the new run from replay is also protected)

--- a/docs/development/integration-core-dead-letter-status-guard-verification-20260426.md
+++ b/docs/development/integration-core-dead-letter-status-guard-verification-20260426.md
@@ -1,0 +1,43 @@
+# Integration-Core Dead-Letter Status Guard · Verification
+
+> Date: 2026-04-26
+> Companion: `integration-core-dead-letter-status-guard-design-20260426.md`
+> PR: #1191
+
+## Commands run
+
+```bash
+node plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs
+for f in plugins/plugin-integration-core/__tests__/*.test.cjs; do node "$f" 2>&1 | tail -1; done
+```
+
+## Result — pipeline-runner.test.cjs
+
+```
+✓ pipeline-runner: cleanse/idempotency/incremental E2E tests passed
+```
+
+## Result — full suite regression (18 files)
+
+All 18 integration-core test files pass. 0 regressions.
+
+## New test coverage breakdown (3 added)
+
+| # | Scenario | What it pins |
+|---|---|---|
+| 6a | Double-replay of `status='replayed'` letter → `PipelineRunnerError`, message contains "status is not open", details include `status:'replayed'` and `id:'dl_1'` | Main bug: second replay blocked before ERP call |
+| 6b | `targetRows.size` unchanged after rejected double-replay | No ERP side effect — `runPipeline` never called |
+| 6c | Replay of `status='discarded'` letter → `PipelineRunnerError` with `status:'discarded'` in details | Discarded-letter case covered |
+
+## Manual code review checklist
+
+- [x] Guard placed after `getDeadLetter` but before `isTruncatedReplayPayload` — both
+  non-open guards fire before any payload inspection or ERP call
+- [x] Error class is `PipelineRunnerError` — maps to HTTP 422 via existing `inferHttpStatus`
+  (`/PipelineRunner/.test(name)`)
+- [x] Error details include `id` and `status` — operator can diagnose without a DB query
+- [x] Message uses "status is not open" — test verifies this exact substring
+- [x] `status='open'` path unchanged — existing scenario 5 (successful replay) still passes
+- [x] No new external dependency introduced
+- [x] `createDeadLetterStore` status validation (`VALID_STATUSES`) enforces the
+  three-state domain at write time; the guard at read time is a defense-in-depth layer

--- a/plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs
@@ -579,6 +579,42 @@ async function main() {
   assert.equal(replayError.details.reason, 'PAYLOAD_TRUNCATED')
   assert.equal(truncatedReplay.targetRows.size, 0, 'truncated replay is rejected before target write')
 
+  // --- 6. Dead-letter status guard — already-replayed letter is rejected --
+  // The first replay in scenario 5 left dl_1 in status='replayed'. A second
+  // replay attempt must throw before any ERP call happens.
+  const doubleReplay = await replay.runner.replayDeadLetter({
+    tenantId: 'tenant_1',
+    workspaceId: null,
+    id: 'dl_1',
+  }).catch((error) => error)
+  assert.equal(doubleReplay.name, 'PipelineRunnerError', 'double-replay rejected with PipelineRunnerError')
+  assert.match(doubleReplay.message, /status is not open/, 'error message identifies the problem')
+  assert.equal(doubleReplay.details.status, 'replayed', 'error details include current status')
+  assert.equal(doubleReplay.details.id, 'dl_1', 'error details include dead letter id')
+  assert.equal(replay.targetRows.size, 1, 'target unchanged after rejected double-replay')
+
+  // Discarded dead letter is also rejected
+  const discardHarness = createRunnerHarness({ sourceRecords: [] })
+  const discardStore = createDeadLetterStore({ db: discardHarness.db, idGenerator: () => 'dl_discarded' })
+  await discardStore.createDeadLetter({
+    tenantId: 'tenant_1',
+    workspaceId: null,
+    runId: 'run_original',
+    pipelineId: 'pipe_1',
+    sourcePayload: { code: 'c-04', revision: 'r1', qty: '1', name: 'Nut', updatedAt: '2026-04-24T04:00:00.000Z' },
+    errorCode: 'VALIDATION_FAILED',
+    errorMessage: 'failed',
+    status: 'discarded',
+  })
+  const discardReplay = await discardHarness.runner.replayDeadLetter({
+    tenantId: 'tenant_1',
+    workspaceId: null,
+    id: 'dl_discarded',
+  }).catch((error) => error)
+  assert.equal(discardReplay.name, 'PipelineRunnerError', 'discarded letter replay rejected')
+  assert.equal(discardReplay.details.status, 'discarded', 'error details include discarded status')
+  assert.equal(discardHarness.targetRows.size, 0, 'target unchanged after rejected discarded-letter replay')
+
   // --- 11. dryRun string coercion (REST API hand-typed booleans) ---------
   {
     const stringDry = createRunnerHarness({

--- a/plugins/plugin-integration-core/lib/pipeline-runner.cjs
+++ b/plugins/plugin-integration-core/lib/pipeline-runner.cjs
@@ -500,6 +500,15 @@ function createPipelineRunner(deps = {}) {
     if (!deadLetter) {
       throw new PipelineRunnerError('dead letter not found', { id: input.id })
     }
+    // Only 'open' letters can be replayed. 'replayed' or 'discarded' letters must not
+    // trigger another live ERP write — idempotency would block the write but the run
+    // record and K3 WISE session calls still fire, polluting the run log.
+    if (deadLetter.status !== 'open') {
+      throw new PipelineRunnerError('dead letter cannot be replayed: status is not open', {
+        id: deadLetter.id,
+        status: deadLetter.status,
+      })
+    }
     if (isTruncatedReplayPayload(deadLetter.sourcePayload)) {
       throw new PipelineRunnerError('dead letter payload is truncated and cannot be replayed safely', {
         id: deadLetter.id,


### PR DESCRIPTION
## Problem

`replayDeadLetter` fetches the dead letter by ID and immediately calls `runPipeline` — no check on `deadLetter.status`. Two failure scenarios:

1. **Double-replay**: Operator clicks "replay" on DL-1 → succeeds → DL-1 is `status='replayed'`. Operator or automated tool replays DL-1 again. The idempotency layer blocks the duplicate ERP write, but a full `runPipeline` executes: K3 WISE login + API call, a new run record in `integration_runs`, and watermark evaluation all fire unnecessarily.

2. **Discarded-letter replay**: A `status='discarded'` letter was deliberately excluded from the sync. Replaying it without a guard re-introduces it into the ERP without operator awareness.

## Fix

One guard after `getDeadLetter`, before `runPipeline`:

```javascript
if (deadLetter.status !== 'open') {
  throw new PipelineRunnerError('dead letter cannot be replayed: status is not open', {
    id: deadLetter.id,
    status: deadLetter.status,
  })
}
```

The error propagates to the route layer as HTTP 422 (existing `PipelineRunnerError` → 422 mapping in `inferHttpStatus`). The operator sees the current status in the error details.

## Tests added (+3 scenarios in `pipeline-runner.test.cjs`)

| # | Scenario | What it pins |
|---|---|---|
| 6a | Double-replay of `status='replayed'` dead letter → `PipelineRunnerError` with status + id in details | Main bug |
| 6b | Target unchanged after rejected double-replay | No side effects — ERP not called |
| 6c | Replay of `status='discarded'` dead letter → `PipelineRunnerError` with `status: 'discarded'` | Discarded coverage |

All 18 integration-core test files pass (0 regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)