### PR TITLE
fix(integration): cap list endpoint limit at MAX_LIST_LIMIT (500)

### DIFF
--- a/docs/development/integration-core-list-limit-cap-design-20260426.md
+++ b/docs/development/integration-core-list-limit-cap-design-20260426.md
@@ -1,0 +1,78 @@
+# Integration-Core List Endpoint Limit Cap · Design
+
+> Date: 2026-04-26
+> PR: #1192
+
+## Problem
+
+All four list endpoints (`listExternalSystems`, `listPipelines`, `listPipelineRuns`,
+`listDeadLetters`) read `limit` from the query string via `asPositiveInt(query.limit)`.
+`asPositiveInt` accepts any positive integer — a client can send `?limit=1000000`.
+
+The value is passed directly to `db.select` which translates it to `SELECT ... LIMIT 1000000`.
+With a large dataset this:
+- Scans the entire table (O(N) DB operation)
+- Allocates a large result set in Node.js heap
+- Produces a response body that may exceed proxy/load-balancer limits
+- Blocks the event loop during JSON serialization
+
+For the PoC phase this is low-risk (small datasets), but the fix is trivial and prevents
+the pattern from becoming load-bearing once production data accumulates.
+
+## Solution
+
+### `MAX_LIST_LIMIT = 500`
+
+Chosen as:
+- Large enough for any operational UI page (run history, dead-letter review)
+- Small enough to keep response bodies under typical proxy limits (< 5MB for typical records)
+- Round number, matches common pagination conventions
+
+### `asListLimit(value)`
+
+```javascript
+function asListLimit(value) {
+  const n = asPositiveInt(value)
+  if (n === undefined) return undefined
+  return Math.min(n, MAX_LIST_LIMIT)
+}
+```
+
+Silently clamps rather than rejecting. Rationale: a client that asks for 1000 rows
+gets 500 — correct behavior, paginate for the rest. Returning a 400 for `limit=1000`
+would be surprising and break clients that don't know about the cap.
+
+### Endpoints updated
+
+All four `limit` usages in `createHandlers`:
+
+```
+externalSystemsList  →  asListLimit(query.limit)
+pipelinesList        →  asListLimit(query.limit)
+runsList             →  asListLimit(query.limit)
+deadLettersList      →  asListLimit(query.limit)
+```
+
+`asPositiveInt` is retained for non-list uses (`offset`, `sampleLimit`, etc.) where
+clamping would be incorrect.
+
+## What `MAX_LIST_LIMIT` does NOT cap
+
+- `sampleLimit` on dry-run: intentionally uncapped because the operator controls batch size
+- `offset`: uncapped (pagination cursor, not a row-count multiplier)
+- Internal pipeline batch size (`batchSize`, `maxPages`): different surface, not HTTP-controlled
+
+## Files changed
+
+| File | Change |
+|---|---|
+| `lib/http-routes.cjs` | `MAX_LIST_LIMIT` constant; `asListLimit` helper; 4 call-sites updated; `MAX_LIST_LIMIT` + `asListLimit` exported |
+| `__tests__/http-routes.test.cjs` | Import `MAX_LIST_LIMIT`; 3 new scenarios |
+| this design doc | — |
+| matching verification doc | — |
+
+## Cross-references
+
+- `lib/pipelines.cjs` — `listPipelineRuns`, `listPipelines` (receive the capped limit)
+- `lib/dead-letter.cjs` — `listDeadLetters` (receives the capped limit)
+- `lib/external-systems.cjs` — `listExternalSystems` (receives the capped limit)

--- a/docs/development/integration-core-list-limit-cap-verification-20260426.md
+++ b/docs/development/integration-core-list-limit-cap-verification-20260426.md
@@ -1,0 +1,44 @@
+# Integration-Core List Endpoint Limit Cap · Verification
+
+> Date: 2026-04-26
+> Companion: `integration-core-list-limit-cap-design-20260426.md`
+> PR: #1192
+
+## Commands run
+
+```bash
+node plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+for f in plugins/plugin-integration-core/__tests__/*.test.cjs; do node "$f" 2>&1 | tail -1; done
+```
+
+## Result — http-routes.test.cjs
+
+```
+http-routes: REST auth/list/upsert/run/dry-run/replay tests passed
+```
+
+## Result — full suite regression (18 files)
+
+All 18 integration-core test files pass. 0 regressions.
+
+## New test coverage breakdown (3 added in `testRunAndDeadLetterRoutes`)
+
+| # | Scenario | What it pins |
+|---|---|---|
+| 1 | `limit=MAX_LIST_LIMIT+10000` on runs endpoint → registry receives `MAX_LIST_LIMIT` | Over-limit clamped |
+| 2 | `limit=10` on runs endpoint → registry receives `10` | Under-limit unchanged |
+| 3 | `limit=999999` on dead-letters endpoint → registry receives `MAX_LIST_LIMIT` | Dead-letters endpoint covered |
+
+## Manual code review checklist
+
+- [x] `asListLimit` uses `asPositiveInt` internally — inherits all existing edge-case handling
+  (undefined/null/empty → undefined; non-integer → undefined; zero/negative → undefined)
+- [x] `Math.min(n, MAX_LIST_LIMIT)` — caps but does not reject
+- [x] All four list endpoints use `asListLimit`; all three non-list uses (`offset`, `sampleLimit`,
+  body integer params) retain `asPositiveInt` — no unintended capping
+- [x] `MAX_LIST_LIMIT` exported at module level — UI and test code can reference the constant
+  rather than hardcoding 500
+- [x] `asListLimit` exported under `__internals` — available for unit tests without exposing
+  as a public API
+- [x] Existing test assertions for `limit: 20` and `limit: 20` (dead-letters) are unchanged
+  — 20 < 500, so they pass through

--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -5,6 +5,7 @@ const path = require('node:path')
 
 const HTTP_ROUTES_PATH = path.join(__dirname, '..', 'lib', 'http-routes.cjs')
 const httpRoutes = require(HTTP_ROUTES_PATH)
+const { MAX_LIST_LIMIT } = httpRoutes
 
 const READ_USER = {
   id: 'user_read',
@@ -499,6 +500,26 @@ async function testRunAndDeadLetterRoutes() {
     offset: 2,
   })
 
+  // limit above MAX_LIST_LIMIT is clamped
+  const { calls: largeCalls, services: largeServices } = createMockServices()
+  const { routes: largeRoutes } = mountRoutes(largeServices)
+  const largeRes = await invoke(largeRoutes, 'GET', '/api/integration/runs', {
+    user: READ_USER,
+    query: { workspaceId: 'workspace_1', limit: String(MAX_LIST_LIMIT + 10000) },
+  })
+  assertOkResponse(largeRes, 200)
+  assert.equal(findCall(largeCalls, 'listPipelineRuns')[1].limit, MAX_LIST_LIMIT,
+    `limit clamped to MAX_LIST_LIMIT (${MAX_LIST_LIMIT})`)
+
+  // limit within MAX_LIST_LIMIT is passed through unchanged
+  const { calls: smallCalls, services: smallServices } = createMockServices()
+  const { routes: smallRoutes } = mountRoutes(smallServices)
+  await invoke(smallRoutes, 'GET', '/api/integration/runs', {
+    user: READ_USER,
+    query: { workspaceId: 'workspace_1', limit: '10' },
+  })
+  assert.equal(findCall(smallCalls, 'listPipelineRuns')[1].limit, 10, 'small limit is unchanged')
+
   res = await invoke(routes, 'GET', '/api/integration/dead-letters', {
     user: READ_USER,
     query: {
@@ -523,6 +544,16 @@ async function testRunAndDeadLetterRoutes() {
     limit: 20,
     offset: 2,
   })
+
+  // dead-letters list also caps at MAX_LIST_LIMIT
+  const { calls: dlLargeCalls, services: dlLargeServices } = createMockServices()
+  const { routes: dlLargeRoutes } = mountRoutes(dlLargeServices)
+  await invoke(dlLargeRoutes, 'GET', '/api/integration/dead-letters', {
+    user: READ_USER,
+    query: { workspaceId: 'workspace_1', limit: '999999' },
+  })
+  assert.equal(findCall(dlLargeCalls, 'listDeadLetters')[1].limit, MAX_LIST_LIMIT,
+    'dead-letters limit clamped to MAX_LIST_LIMIT')
 
   res = await invoke(routes, 'GET', '/api/integration/dead-letters', {
     user: WRITE_USER,

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -156,10 +156,18 @@ function requestParams(req) {
   return req.params && typeof req.params === 'object' ? req.params : {}
 }
 
+const MAX_LIST_LIMIT = 500
+
 function asPositiveInt(value) {
   if (value === undefined || value === null || value === '') return undefined
   const numeric = Number(value)
   return Number.isInteger(numeric) && numeric > 0 ? numeric : undefined
+}
+
+function asListLimit(value) {
+  const n = asPositiveInt(value)
+  if (n === undefined) return undefined
+  return Math.min(n, MAX_LIST_LIMIT)
 }
 
 function publicRunInput(body = {}) {
@@ -235,7 +243,7 @@ function createHandlers(services) {
       return sendOk(res, await externalSystems.listExternalSystems(scopedInput(req, {
         kind: query.kind,
         status: query.status,
-        limit: asPositiveInt(query.limit),
+        limit: asListLimit(query.limit),
         offset: asPositiveInt(query.offset),
       })))
     },
@@ -267,7 +275,7 @@ function createHandlers(services) {
         status: query.status,
         sourceSystemId: query.sourceSystemId,
         targetSystemId: query.targetSystemId,
-        limit: asPositiveInt(query.limit),
+        limit: asListLimit(query.limit),
         offset: asPositiveInt(query.offset),
       })))
     },
@@ -318,7 +326,7 @@ function createHandlers(services) {
       return sendOk(res, await pipelineRegistry.listPipelineRuns(scopedInput(req, {
         pipelineId: query.pipelineId,
         status: query.status,
-        limit: asPositiveInt(query.limit),
+        limit: asListLimit(query.limit),
         offset: asPositiveInt(query.offset),
       })))
     },
@@ -331,7 +339,7 @@ function createHandlers(services) {
         pipelineId: query.pipelineId,
         runId: query.runId,
         status: query.status,
-        limit: asPositiveInt(query.limit),
+        limit: asListLimit(query.limit),
         offset: asPositiveInt(query.offset),
       }))
       return sendOk(res, rows.map((row) => redactDeadLetter(row, fullPayload)))
@@ -382,6 +390,7 @@ function registerIntegrationRoutes({ context, services, logger } = {}) {
 module.exports = {
   ROUTES,
   HttpRouteError,
+  MAX_LIST_LIMIT,
   createHandlers,
   registerIntegrationRoutes,
   __internals: {
@@ -393,5 +402,7 @@ module.exports = {
     inferHttpStatus,
     publicRunInput,
     redactDeadLetter,
+    asListLimit,
+    asPositiveInt,
   },
 }


### PR DESCRIPTION
## Problem

`listPipelineRuns`, `listDeadLetters`, `listPipelines`, and `listExternalSystems` all call `asPositiveInt(query.limit)` which returns any positive integer the client supplies. A request with `?limit=1000000` executes `SELECT ... LIMIT 1000000` against the DB, returning millions of rows in a single response — unbounded memory, response body, and DB scan.

## Fix

New `asListLimit(value)` helper: clamps the caller-supplied limit to `MAX_LIST_LIMIT` (500). Values within the cap pass through unchanged; values above are silently clamped (no error — the client gets up to 500 rows, which is the expected page size for operational lists). All four list endpoints now use `asListLimit` instead of `asPositiveInt` for the `limit` param.

`MAX_LIST_LIMIT = 500` was chosen as:
- Large enough to cover any reasonable single-page operational view
- Small enough to keep response sizes predictable
- Consistent with typical pagination conventions (100–500 per page)

## Tests added (+3 scenarios in `testRunAndDeadLetterRoutes`)

| # | Scenario | What it pins |
|---|---|---|
| 1 | `limit=MAX_LIST_LIMIT+10000` on runs endpoint → clamped to `MAX_LIST_LIMIT` | Main cap |
| 2 | `limit=10` on runs endpoint → passes through unchanged | Small limit not affected |
| 3 | `limit=999999` on dead-letters endpoint → clamped to `MAX_LIST_LIMIT` | Dead-letters covered |

All 18 integration-core test files pass (0 regressions).

`MAX_LIST_LIMIT` is exported so callers (UI, tests) can reference the constant rather than hardcoding 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)