### PR TITLE
fix(integration): reject kind/role mutation on external system update

### DIFF
--- a/docs/development/integration-core-external-system-kind-immutable-design-20260427.md
+++ b/docs/development/integration-core-external-system-kind-immutable-design-20260427.md
@@ -1,0 +1,53 @@
+# Integration-Core External System Kind Immutability Design - 2026-04-27
+
+## Context
+
+External systems define the adapter contract used by pipelines. The `kind` selects the adapter implementation and the `role` determines whether the system is valid as a source, target, or both.
+
+Before this change, updating an existing external system could change `kind` or `role` in-place. That creates a risky identity mutation:
+
+- existing pipelines can point at the same external system ID but suddenly use a different adapter
+- credential/config shape may no longer match the adapter kind
+- a source-only system can become target-capable without explicit re-wiring
+
+## Goal
+
+Treat `kind` and `role` as creation-time identity fields. Operators can still update metadata, status, config, capabilities, and credentials, but changing adapter identity requires creating a new external system and explicitly reconnecting pipelines.
+
+## Design
+
+`upsertExternalSystem()` now checks the persisted row before applying an update:
+
+```javascript
+if (existing.kind !== normalized.kind || existing.role !== normalized.role) {
+  throw new ExternalSystemValidationError('kind and role cannot be changed after creation', {
+    id: existing.id,
+    existingKind: existing.kind,
+    existingRole: existing.role,
+    requestedKind: normalized.kind,
+    requestedRole: normalized.role,
+  })
+}
+```
+
+The error includes both existing and requested values so the REST layer can report a useful 400-class validation failure.
+
+## Behavior
+
+| Operation | Result |
+| --- | --- |
+| create system with `kind=http`, `role=source` | allowed |
+| update same system name/status/config with same `kind`/`role` | allowed |
+| update same system from `kind=http` to `kind=erp:k3-wise-webapi` | rejected |
+| update same system from `role=source` to `role=target` | rejected |
+
+## Files
+
+- `plugins/plugin-integration-core/lib/external-systems.cjs`
+- `plugins/plugin-integration-core/__tests__/external-systems.test.cjs`
+
+## Non-Goals
+
+- This does not add a migration for legacy rows; existing rows remain valid.
+- This does not block credential/config changes for the same adapter identity.
+- This does not add a clone/switch workflow for pipelines; that belongs in a higher-level UI task.

--- a/docs/development/integration-core-external-system-kind-immutable-verification-20260427.md
+++ b/docs/development/integration-core-external-system-kind-immutable-verification-20260427.md
@@ -1,0 +1,47 @@
+# Integration-Core External System Kind Immutability Verification - 2026-04-27
+
+## Scope
+
+This verifies that external system `kind` and `role` cannot be mutated after creation, while normal same-kind updates still work.
+
+## Local Commands
+
+```bash
+node plugins/plugin-integration-core/__tests__/external-systems.test.cjs
+for f in plugins/plugin-integration-core/__tests__/*.test.cjs; do node "$f"; done
+```
+
+## Expected Coverage
+
+- changing `kind` on an existing system throws `ExternalSystemValidationError`
+- changing `role` on an existing system throws `ExternalSystemValidationError`
+- error details include existing and requested values
+- updating name/status with unchanged `kind` and `role` still succeeds
+
+## Results
+
+Local tests passed in `/private/tmp/ms2-system-immutable`.
+
+```text
+✓ external-systems: registry + credential boundary tests passed
+✓ adapter-contracts: registry + normalizer tests passed
+✓ credential-store: 10 scenarios passed
+✓ db.cjs: all CRUD + boundary + injection tests passed
+✓ e2e-plm-k3wise-writeback: mock PLM -> K3 WISE -> feedback tests passed
+✓ erp-feedback: normalize + writer tests passed
+✓ external-systems: registry + credential boundary tests passed
+✓ http-adapter: config-driven read/upsert tests passed
+http-routes: REST auth/list/upsert/run/dry-run/replay tests passed
+✓ k3-wise-adapters: WebAPI, SQL Server channel, and auto-flag coercion tests passed
+✓ migration-sql: 057/058/059 integration migration structure passed
+✓ payload-redaction: sensitive key redaction tests passed
+✓ pipeline-runner: cleanse/idempotency/incremental E2E tests passed
+✓ pipelines: registry + endpoint + field-mapping + run-ledger + concurrent-guard + stale-run-cleanup tests passed
+✓ plm-yuantus-wrapper: source facade tests passed
+✓ plugin-runtime-smoke: all assertions passed
+runner-support: idempotency/watermark/dead-letter/run-log tests passed
+✓ staging-installer: all 7 assertions passed
+[pass] transform-validator: transform engine + validator tests passed
+```
+
+GitHub CI is pending after push.

--- a/plugins/plugin-integration-core/__tests__/external-systems.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/external-systems.test.cjs
@@ -113,7 +113,7 @@ async function main() {
     id: 'sys_1',
     name: 'K3 WISE renamed',
     kind: 'erp:k3-wise-webapi',
-    role: 'bidirectional',
+    role: 'source',
     config: { baseUrl: 'https://k3-new.example.test' },
     capabilities: { read: true, write: true },
     status: 'inactive',
@@ -254,6 +254,65 @@ async function main() {
     updateRace = error
   }
   assert.ok(updateRace instanceof ExternalSystemNotFoundError, 'empty update result is not reported as success')
+
+  // --- 7. kind/role immutability after creation -------------------------
+  const immutableDb = createMockDb()
+  const immutableRegistry = createExternalSystemRegistry({
+    db: immutableDb,
+    credentialStore,
+    idGenerator: () => 'sys_imm',
+  })
+  await immutableRegistry.upsertExternalSystem({
+    tenantId: 'tenant_1',
+    name: 'immutable-sys',
+    kind: 'http',
+    role: 'source',
+  })
+
+  let kindChanged = null
+  try {
+    await immutableRegistry.upsertExternalSystem({
+      tenantId: 'tenant_1',
+      id: 'sys_imm',
+      name: 'immutable-sys',
+      kind: 'erp:k3-wise-webapi',
+      role: 'source',
+    })
+  } catch (error) {
+    kindChanged = error
+  }
+  assert.ok(kindChanged instanceof ExternalSystemValidationError, 'changing kind after creation is rejected')
+  assert.match(kindChanged.message, /kind and role cannot be changed/, 'error message identifies the invariant')
+  assert.equal(kindChanged.details.existingKind, 'http', 'details includes original kind')
+  assert.equal(kindChanged.details.requestedKind, 'erp:k3-wise-webapi', 'details includes attempted kind')
+
+  let roleChanged = null
+  try {
+    await immutableRegistry.upsertExternalSystem({
+      tenantId: 'tenant_1',
+      id: 'sys_imm',
+      name: 'immutable-sys',
+      kind: 'http',
+      role: 'target',
+    })
+  } catch (error) {
+    roleChanged = error
+  }
+  assert.ok(roleChanged instanceof ExternalSystemValidationError, 'changing role after creation is rejected')
+  assert.equal(roleChanged.details.existingRole, 'source', 'details includes original role')
+  assert.equal(roleChanged.details.requestedRole, 'target', 'details includes attempted role')
+
+  // Updating other fields with same kind/role succeeds
+  const sameKindRole = await immutableRegistry.upsertExternalSystem({
+    tenantId: 'tenant_1',
+    id: 'sys_imm',
+    name: 'immutable-sys renamed',
+    kind: 'http',
+    role: 'source',
+    status: 'inactive',
+  })
+  assert.equal(sameKindRole.name, 'immutable-sys renamed', 'update with unchanged kind/role succeeds')
+  assert.equal(sameKindRole.status, 'inactive', 'status update applied')
 
   console.log('✓ external-systems: registry + credential boundary tests passed')
 }

--- a/plugins/plugin-integration-core/lib/external-systems.cjs
+++ b/plugins/plugin-integration-core/lib/external-systems.cjs
@@ -202,6 +202,15 @@ function createExternalSystemRegistry({ db, credentialStore, idGenerator = crypt
     }
 
     if (existing) {
+      if (existing.kind !== normalized.kind || existing.role !== normalized.role) {
+        throw new ExternalSystemValidationError('kind and role cannot be changed after creation', {
+          id: existing.id,
+          existingKind: existing.kind,
+          existingRole: existing.role,
+          requestedKind: normalized.kind,
+          requestedRole: normalized.role,
+        })
+      }
       const updateRow = { ...baseRow }
       if (credentialsEncrypted !== undefined) {
         updateRow.credentials_encrypted = credentialsEncrypted


### PR DESCRIPTION
## Summary

- `upsertExternalSystem` was writing `kind` and `role` on every update, allowing callers to silently change an adapter's type or source/target role after creation.
- Mutating `kind` changes which adapter class is loaded; mutating `role` violates the source/target contract assumed by all referencing pipelines.
- Guard: after `findExisting`, compare `existing.kind`/`existing.role` against the normalized input. If either differs, throw `ExternalSystemValidationError('kind and role cannot be changed after creation')` with `existingKind`, `existingRole`, `requestedKind`, `requestedRole` in `details`.
- Updated existing test that incorrectly changed `role` from `source` → `bidirectional` on update (was testing update persistence, not role mutability — fixed to keep `role: 'source'`).

## Test plan

- [ ] New scenario: changing `kind` from `'http'` to `'erp:k3-wise-webapi'` on update → `ExternalSystemValidationError` with message matching `/kind and role cannot be changed/`.
- [ ] New scenario: changing `role` from `'source'` to `'target'` on update → `ExternalSystemValidationError` with `details.existingRole === 'source'`.
- [ ] Control: update with same `kind` and `role` but different `name`/`status` → succeeds and returns updated name.
- [ ] All 18 `plugin-integration-core` test files pass (0 regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)