### PR TITLE
fix(integration): call abandonStaleRuns as best-effort before each pipeline run

### DIFF
--- a/docs/development/integration-core-stale-run-besteffort-design-20260426.md
+++ b/docs/development/integration-core-stale-run-besteffort-design-20260426.md
@@ -1,0 +1,80 @@
+# Design: Call abandonStaleRuns Best-Effort Before Pipeline Runs
+
+**PR**: #1197  
+**Date**: 2026-04-26  
+**Supersedes**: #1188  
+**Primary file**: `plugins/plugin-integration-core/lib/pipeline-runner.cjs`
+
+## Problem
+
+PR #1187 made the concurrent-run invariant real: a pipeline can have at most
+one `status='running'` row in a tenant/workspace scope. That prevents duplicate
+watermark reads and double ERP writes, but it also means a crash-stuck
+`running` row can block the next run.
+
+`pipelineRegistry.abandonStaleRuns()` already exists after #1187. It marks
+old `running` rows as `failed`, using a default 4-hour threshold. The missing
+piece is wiring it into the normal run path.
+
+## Why #1188 Is Not Enough
+
+#1188 added the call, but treated stale-run cleanup as a hard prerequisite:
+
+```javascript
+await pipelineRegistry.abandonStaleRuns({ ... })
+```
+
+If the cleanup query throws because the DB is temporarily unhealthy, the main
+pipeline never starts. That is the wrong failure mode: stale-run cleanup is a
+recovery attempt, not a new required dependency for every run.
+
+## Solution
+
+Call `abandonStaleRuns()` after `loadPipelineContext()` and before
+`runLogger.startRun()`, but wrap it as best-effort:
+
+```javascript
+if (typeof pipelineRegistry.abandonStaleRuns === 'function') {
+  try {
+    await pipelineRegistry.abandonStaleRuns({
+      tenantId: context.tenantId,
+      workspaceId: context.workspaceId,
+      pipelineId: context.pipeline.id,
+    })
+  } catch {
+    // Non-fatal: stale-run cleanup is best-effort.
+  }
+}
+```
+
+The placement matters:
+
+- `loadPipelineContext()` has already resolved tenant, workspace, and pipeline.
+- No new run row exists yet, so a cleanup failure cannot leave another orphan.
+- A stale blocking run gets one automatic recovery attempt before the DB unique
+  guard from #1187 rejects the new run.
+
+## Behavior
+
+- Healthy cleanup path: stale rows for this pipeline are failed, then the new
+  run starts normally.
+- Cleanup throws: the runner continues. If a blocking `running` row still exists,
+  `startRun()` returns the normal `PipelineConflictError` path from #1187.
+- Registry lacks `abandonStaleRuns`: no-op for older mocks or alternate registry
+  implementations.
+
+## Scope
+
+This PR intentionally does not add tenant-wide startup sweep logic. That can be
+added later in plugin activation if operators need automatic cleanup across all
+pipelines. This change only handles the high-value path: an operator triggers a
+specific pipeline and gets one pipeline-scoped recovery attempt first.
+
+## Files Changed
+
+| File | Change |
+| --- | --- |
+| `plugins/plugin-integration-core/lib/pipeline-runner.cjs` | Best-effort `abandonStaleRuns()` call before `startRun()` |
+| `plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs` | Section 17 coverage for call, failure suppression, and missing-method compatibility |
+| `docs/development/integration-core-stale-run-besteffort-design-20260426.md` | This design note |
+| `docs/development/integration-core-stale-run-besteffort-verification-20260426.md` | Verification evidence |

--- a/docs/development/integration-core-stale-run-besteffort-verification-20260426.md
+++ b/docs/development/integration-core-stale-run-besteffort-verification-20260426.md
@@ -1,0 +1,84 @@
+# Verification: Call abandonStaleRuns Best-Effort Before Pipeline Runs
+
+**PR**: #1197  
+**Date**: 2026-04-26  
+**Base after refresh**: `origin/main` includes #1187 (`0f3a51d8e`)
+
+## Commands
+
+```bash
+node plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs
+node plugins/plugin-integration-core/__tests__/pipelines.test.cjs
+node plugins/plugin-integration-core/__tests__/migration-sql.test.cjs
+for f in plugins/plugin-integration-core/__tests__/*.test.cjs; do node "$f"; done
+git diff --check
+```
+
+## Test Scenarios Added
+
+Section 17 in `pipeline-runner.test.cjs` covers:
+
+| Scenario | Expected result |
+| --- | --- |
+| `abandonStaleRuns()` exists and succeeds | Called once before the run, scoped to tenant/workspace/pipeline |
+| `abandonStaleRuns()` throws | Pipeline continues and reads the source record |
+| Registry has no `abandonStaleRuns()` method | Pipeline still runs; no `TypeError` |
+
+## Regression Relationship To #1187
+
+#1187 owns the registry-side guard and DB partial unique index. #1197 only wires
+the recovery call before `startRun()`.
+
+The important sequence after both PRs is:
+
+```text
+runPipeline()
+  loadPipelineContext()
+  abandonStaleRuns() best-effort
+  startRun()
+    createPipelineRun()
+      friendly running-row pre-check
+      DB unique index final guard
+```
+
+That means #1197 never weakens #1187. Cleanup failure falls through to #1187's
+normal conflict path rather than creating a second running row.
+
+## Current Local Results
+
+Direct changed-surface tests:
+
+```text
+pipeline-runner.test.cjs: pass
+pipelines.test.cjs: pass
+migration-sql.test.cjs: pass
+```
+
+Full plugin CJS sweep:
+
+```text
+adapter-contracts: pass
+credential-store: pass
+db.cjs: pass
+e2e-plm-k3wise-writeback: pass
+erp-feedback: pass
+external-systems: pass
+http-adapter: pass
+http-routes: pass
+k3-wise-adapters: pass
+migration-sql: pass
+payload-redaction: pass
+pipeline-runner: pass
+pipelines: pass
+plm-yuantus-wrapper: pass
+plugin-runtime-smoke: pass
+runner-support: pass
+staging-installer: pass
+transform-validator: pass
+```
+
+`git diff --check` also passes.
+
+The package script `pnpm -F plugin-integration-core test` may need the root
+workspace `node_modules`; temporary worktrees without dependencies can fail
+before tests when `node --import tsx` cannot resolve `tsx`.

--- a/plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs
@@ -712,6 +712,79 @@ async function main() {
     assert.ok(result.run, `allowInactive: ${JSON.stringify(truthyVariant)} lets the inactive pipeline run`)
   }
 
+  // --- 17. abandonStaleRuns called before run and is best-effort ----------
+  {
+    const staleDb = createMockDb()
+    const stalePipeline = {
+      id: 'pipe_1', tenantId: 'tenant_1', workspaceId: null, projectId: 'project_1',
+      sourceSystemId: 'source_1', sourceObject: 'materials',
+      targetSystemId: 'target_1', targetObject: 'BD_MATERIAL',
+      mode: 'manual', status: 'active',
+      idempotencyKeyFields: ['code', 'revision'],
+      options: { batchSize: 100 },
+      fieldMappings: [
+        { sourceField: 'code', targetField: 'FNumber', transform: ['trim', 'upper'], validation: [{ type: 'required' }] },
+        { sourceField: 'qty', targetField: 'FQty', transform: { fn: 'toNumber' }, validation: [{ type: 'min', value: 1 }] },
+        { sourceField: 'name', targetField: 'FName', transform: { fn: 'trim' }, validation: [{ type: 'required' }] },
+      ],
+    }
+    const staleSourceRecord = { code: 'a-01', revision: 'r1', qty: '3', name: 'Bolt', updatedAt: '2026-04-24T01:00:00.000Z' }
+    const staleAdapterRegistry = createAdapterRegistry()
+      .registerAdapter('mock-source', () => ({
+        async testConnection() { return { ok: true } },
+        async listObjects() { return [] },
+        async getSchema() { return { fields: [] } },
+        async read() { return createReadResult({ records: [staleSourceRecord] }) },
+        async upsert() { throw new Error('should not upsert on source') },
+      }))
+      .registerAdapter('mock-target', () => ({
+        async testConnection() { return { ok: true } },
+        async listObjects() { return [] },
+        async getSchema() { return { fields: [] } },
+        async read() { return createReadResult({ records: [] }) },
+        async upsert(input) { return createUpsertResult({ written: input.records.length, skipped: 0, results: [] }) },
+      }))
+
+    function buildRunner(registryExtension = {}) {
+      const registry = { ...createPipelineRegistry(stalePipeline, staleDb), ...registryExtension }
+      return createPipelineRunner({
+        pipelineRegistry: registry,
+        externalSystemRegistry: createExternalSystemRegistry(),
+        adapterRegistry: staleAdapterRegistry,
+        deadLetterStore: createDeadLetterStore({ db: staleDb }),
+        watermarkStore: createWatermarkStore({ db: staleDb }),
+        runLogger: createRunLogger({ pipelineRegistry: registry }),
+      })
+    }
+
+    // 17a: abandonStaleRuns is called with correct tenant/pipeline context
+    const abandonCalls = []
+    const runnerWithAbandon = buildRunner({
+      async abandonStaleRuns(input) { abandonCalls.push(input); return [] },
+    })
+    await runnerWithAbandon.runPipeline({ tenantId: 'tenant_1', pipelineId: 'pipe_1', mode: 'manual', triggeredBy: 'api' })
+    assert.equal(abandonCalls.length, 1, 'abandonStaleRuns called once before run')
+    assert.equal(abandonCalls[0].tenantId, 'tenant_1', 'abandonStaleRuns receives tenantId')
+    assert.equal(abandonCalls[0].pipelineId, 'pipe_1', 'abandonStaleRuns receives pipelineId')
+
+    // 17b: abandonStaleRuns throws → pipeline still runs (best-effort protection)
+    const resilientRunner = buildRunner({
+      async abandonStaleRuns() { throw new Error('DB connection lost during stale-run cleanup') },
+    })
+    const resilientResult = await resilientRunner.runPipeline({
+      tenantId: 'tenant_1', pipelineId: 'pipe_1', mode: 'manual', triggeredBy: 'api',
+    })
+    assert.ok(resilientResult.run, 'pipeline run succeeds even when abandonStaleRuns throws')
+    assert.equal(resilientResult.metrics.rowsRead, 1, 'pipeline reads source despite cleanup failure')
+
+    // 17c: registry without abandonStaleRuns (typeof check) → no TypeError
+    const plainRunner = buildRunner()
+    const plainResult = await plainRunner.runPipeline({
+      tenantId: 'tenant_1', pipelineId: 'pipe_1', mode: 'manual', triggeredBy: 'api',
+    })
+    assert.ok(plainResult.run, 'pipeline runs fine when registry has no abandonStaleRuns')
+  }
+
   console.log('✓ pipeline-runner: cleanse/idempotency/incremental E2E tests passed')
 }
 

--- a/plugins/plugin-integration-core/lib/pipeline-runner.cjs
+++ b/plugins/plugin-integration-core/lib/pipeline-runner.cjs
@@ -341,6 +341,21 @@ function createPipelineRunner(deps = {}) {
     const started = clock()
     const metrics = createMetrics()
     const preview = dryRun ? { records: [], errors: [] } : null
+
+    // Best-effort: recover any runs left stuck in 'running' by a previous crash.
+    // Wrapped in try-catch so a transient DB failure here never blocks the main run.
+    if (typeof pipelineRegistry.abandonStaleRuns === 'function') {
+      try {
+        await pipelineRegistry.abandonStaleRuns({
+          tenantId: context.tenantId,
+          workspaceId: context.workspaceId,
+          pipelineId: context.pipeline.id,
+        })
+      } catch {
+        // Non-fatal — stale-run cleanup is best-effort; proceed with the pipeline run.
+      }
+    }
+
     let run = await runLogger.startRun({
       tenantId: context.tenantId,
       workspaceId: context.workspaceId,


### PR DESCRIPTION
## Summary

- Wires `pipelineRegistry.abandonStaleRuns()` into `runPipeline` to recover stuck `running` rows from previous process crashes before starting a new run.
- Wraps the call in try-catch: a transient DB failure during stale-run cleanup must never block the main pipeline execution — this is a best-effort housekeeping step, not a hard prerequisite.
- **Supersedes PR #1188** which added the call without error protection. If #1188 merges before this PR, the effective behavior difference is the try-catch guard; the two PRs will conflict and this one should be used.

## Test plan

- [ ] **17a**: `abandonStaleRuns` is called once per `runPipeline` invocation with correct `tenantId`/`pipelineId`.
- [ ] **17b**: `abandonStaleRuns` throws `'DB connection lost'` → pipeline run still succeeds, `rowsRead === 1`.
- [ ] **17c**: Registry without `abandonStaleRuns` method → no `TypeError`, pipeline runs normally.
- [ ] All 18 `plugin-integration-core` test files pass (0 regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)