### PR TITLE
fix(integration): preserve config/capabilities on partial external system update

### DIFF
--- a/docs/development/integration-core-external-system-config-preserve-verification-20260427.md
+++ b/docs/development/integration-core-external-system-config-preserve-verification-20260427.md
@@ -21,7 +21,7 @@ for f in plugins/plugin-integration-core/__tests__/*.test.cjs; do node "$f"; don
 
 ## Results
 
-Local tests passed in `/private/tmp/ms2-config-preserve-2` after resolving the merge conflict with current `origin/main`.
+Local tests passed in `/private/tmp/ms2-config-preserve-2` after resolving the merge conflict with current `origin/main`. The same commands were repeated after merging the PR #1196 mainline update into this branch.
 
 ```text
 ✓ external-systems: registry + credential boundary tests passed

--- a/plugins/plugin-integration-core/__tests__/external-systems.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/external-systems.test.cjs
@@ -255,6 +255,73 @@ async function main() {
   }
   assert.ok(updateRace instanceof ExternalSystemNotFoundError, 'empty update result is not reported as success')
 
+  // --- 7. config/capabilities preserved when not provided on update -------
+  const preserveDb = createMockDb()
+  const preserveRegistry = createExternalSystemRegistry({
+    db: preserveDb,
+    credentialStore,
+    idGenerator: () => 'sys_preserve',
+  })
+  await preserveRegistry.upsertExternalSystem({
+    tenantId: 'tenant_1',
+    name: 'K3 WISE full',
+    kind: 'erp:k3-wise-webapi',
+    role: 'target',
+    config: { baseUrl: 'https://k3.internal', acctId: 'ACCT001', orgId: 'ORG1' },
+    capabilities: { read: true, write: true, bom: true },
+    status: 'active',
+  })
+
+  // 7a: status-only update — config and capabilities must be preserved
+  const statusOnlyUpdate = await preserveRegistry.upsertExternalSystem({
+    tenantId: 'tenant_1',
+    id: 'sys_preserve',
+    name: 'K3 WISE full',
+    kind: 'erp:k3-wise-webapi',
+    role: 'target',
+    status: 'inactive',
+    // config and capabilities intentionally omitted
+  })
+  const storedRow = preserveDb.rows.find((row) => row.id === 'sys_preserve')
+  assert.deepEqual(storedRow.config, { baseUrl: 'https://k3.internal', acctId: 'ACCT001', orgId: 'ORG1' },
+    'config preserved when not provided on update')
+  assert.deepEqual(storedRow.capabilities, { read: true, write: true, bom: true },
+    'capabilities preserved when not provided on update')
+  assert.equal(statusOnlyUpdate.status, 'inactive', 'status was updated as requested')
+
+  // 7b: explicit config: {} replaces (caller opted in to clearing)
+  await preserveRegistry.upsertExternalSystem({
+    tenantId: 'tenant_1',
+    id: 'sys_preserve',
+    name: 'K3 WISE full',
+    kind: 'erp:k3-wise-webapi',
+    role: 'target',
+    config: {},
+    status: 'inactive',
+    // capabilities omitted — should still be preserved
+  })
+  const afterExplicitEmpty = preserveDb.rows.find((row) => row.id === 'sys_preserve')
+  assert.deepEqual(afterExplicitEmpty.config, {}, 'explicit config: {} replaces existing config')
+  assert.deepEqual(afterExplicitEmpty.capabilities, { read: true, write: true, bom: true },
+    'capabilities still preserved when only config was explicitly cleared')
+
+  // 7c: full config replacement works normally
+  await preserveRegistry.upsertExternalSystem({
+    tenantId: 'tenant_1',
+    id: 'sys_preserve',
+    name: 'K3 WISE full',
+    kind: 'erp:k3-wise-webapi',
+    role: 'target',
+    config: { baseUrl: 'https://k3-new.internal', acctId: 'ACCT002' },
+    capabilities: { read: true, write: false },
+    status: 'active',
+  })
+  const afterFullUpdate = preserveDb.rows.find((row) => row.id === 'sys_preserve')
+  assert.deepEqual(afterFullUpdate.config, { baseUrl: 'https://k3-new.internal', acctId: 'ACCT002' },
+    'explicit config replacement works')
+  assert.deepEqual(afterFullUpdate.capabilities, { read: true, write: false },
+    'explicit capabilities replacement works')
+
   console.log('✓ external-systems: registry + credential boundary tests passed')
 }
 

--- a/plugins/plugin-integration-core/lib/external-systems.cjs
+++ b/plugins/plugin-integration-core/lib/external-systems.cjs
@@ -203,6 +203,12 @@ function createExternalSystemRegistry({ db, credentialStore, idGenerator = crypt
 
     if (existing) {
       const updateRow = { ...baseRow }
+      // Preserve stored config/capabilities when the caller did not explicitly
+      // provide them. A status-only or name-only update must not wipe stored
+      // connection config (baseUrl, orgId, etc.) or capability flags.
+      // Explicit null/empty-object still replaces (caller opted in).
+      if (input.config === undefined) updateRow.config = existing.config
+      if (input.capabilities === undefined) updateRow.capabilities = existing.capabilities
       if (credentialsEncrypted !== undefined) {
         updateRow.credentials_encrypted = credentialsEncrypted
       }


### PR DESCRIPTION
## Summary

- `upsertExternalSystem` normalizes `config` and `capabilities` from the request body on every update, defaulting to `{}` when absent. A status-only or name-only update silently wipes all stored connection configuration (baseUrl, acctId, orgId) and capability flags — data loss with no error signal.
- Fix: after `findExisting`, if `input.config === undefined` (not provided), restore `updateRow.config = existing.config`. Same for `capabilities`. Explicit `null` or `{}` still replaces (caller opted in to clearing).
- Does **not** affect inserts — new systems always start with provided or empty config.

## Test plan

- [ ] **7a**: Status-only update (no `config`/`capabilities` in body) → `config` and `capabilities` are unchanged in DB.
- [ ] **7b**: Explicit `config: {}` → config replaced with `{}`; capabilities still preserved (omitted).
- [ ] **7c**: Full `config`/`capabilities` provided → normal replacement.
- [ ] All 18 `plugin-integration-core` test files pass (0 regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)