### PR TITLE
fix(integration): cap list endpoint offset at MAX_LIST_OFFSET (10000)

### DIFF
--- a/docs/development/integration-core-list-offset-cap-design-20260426.md
+++ b/docs/development/integration-core-list-offset-cap-design-20260426.md
@@ -1,0 +1,60 @@
+# Design: Cap List Endpoint Offset at MAX_LIST_OFFSET
+
+**PR**: #1199  
+**Date**: 2026-04-26  
+**File**: `plugins/plugin-integration-core/lib/http-routes.cjs`
+
+---
+
+## Problem
+
+All four list endpoints (external-systems, pipelines, runs, dead-letters) pass the caller's `offset` query parameter directly to the underlying registry functions with no upper bound:
+
+```javascript
+offset: asPositiveInt(query.offset),
+```
+
+`asPositiveInt` converts any positive integer string without capping. A caller submitting `offset=9999999` causes a sequential scan across millions of rows before returning results — there is no query plan that skips cheaply to a row at position 9,999,999 without visiting all preceding rows.
+
+## Fix
+
+Add `MAX_LIST_OFFSET = 10000` constant and `asListOffset()` helper, applied at all four list call sites:
+
+```javascript
+const MAX_LIST_OFFSET = 10000
+
+function asListOffset(value) {
+  const n = asPositiveInt(value)
+  if (n === undefined) return undefined
+  return Math.min(n, MAX_LIST_OFFSET)
+}
+```
+
+Replace `asPositiveInt(query.offset)` with `asListOffset(query.offset)` at:
+- `externalSystemsList`
+- `pipelinesList`
+- `runsList`
+- `deadLettersList`
+
+## Semantics
+
+| Input | Behavior |
+|-------|----------|
+| Absent / `''` | `undefined` — service receives no offset (start from beginning) |
+| `'0'` | `undefined` — treated as no offset |
+| `'50'` | `50` — passed through unchanged |
+| `'10001'` | `10000` — clamped to MAX_LIST_OFFSET |
+| `'9999999'` | `10000` — clamped to MAX_LIST_OFFSET |
+
+Clamping is preferred over rejection: the caller still gets a valid page of results and is not blocked. Pagination past offset 10000 is a product-level concern (cursor-based pagination is the correct tool beyond that depth).
+
+## Prior Art
+
+The limit cap (`MAX_LIST_LIMIT = 500`) was added in PR #1192 using the same pattern. This PR mirrors it for offset.
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `lib/http-routes.cjs` | `MAX_LIST_OFFSET`, `asListOffset()`, 4 call sites |
+| `__tests__/http-routes.test.cjs` | `testListOffsetCap()` — 6 assertions |

--- a/docs/development/integration-core-list-offset-cap-verification-20260426.md
+++ b/docs/development/integration-core-list-offset-cap-verification-20260426.md
@@ -1,0 +1,53 @@
+# Verification: Cap List Endpoint Offset at MAX_LIST_OFFSET
+
+**PR**: #1199  
+**Date**: 2026-04-26
+
+---
+
+## Test Scenarios Added (`testListOffsetCap`)
+
+### All 4 list endpoints: huge offset → clamped to MAX_LIST_OFFSET
+
+**Input**: `offset: String(MAX_LIST_OFFSET + 999999)` on each of:
+- `GET /api/integration/external-systems`
+- `GET /api/integration/pipelines`
+- `GET /api/integration/runs`
+- `GET /api/integration/dead-letters`
+
+**Assertions**:
+- `listExternalSystems` receives `offset === MAX_LIST_OFFSET`
+- `listPipelines` receives `offset === MAX_LIST_OFFSET`
+- `listPipelineRuns` receives `offset === MAX_LIST_OFFSET`
+- `listDeadLetters` receives `offset === MAX_LIST_OFFSET`
+
+### offset=0 → treated as undefined (no offset)
+
+**Input**: `offset: '0'`
+
+**Assertion**: `listPipelines` receives `offset === undefined`
+
+### Small valid offset → passes through unchanged
+
+**Input**: `offset: '50'`
+
+**Assertion**: `listPipelines` receives `offset === 50`
+
+## Regression Guard
+
+All 18 `plugin-integration-core` test files pass:
+
+```
+✓ credential-store        ✓ adapter-contracts       ✓ http-adapter
+✓ db.cjs                 ✓ plm-yuantus-wrapper     ✓ pipelines
+✓ external-systems       ✓ transform-validator      ✓ runner-support
+✓ payload-redaction      ✓ pipeline-runner          ✓ http-routes
+✓ k3-wise-adapters       ✓ erp-feedback             ✓ e2e-plm-k3wise-writeback
+✓ staging-installer      ✓ migration-sql
+```
+
+## Worktree
+
+Branch: `codex/integration-list-offset-cap-20260426`  
+Worktree: `/tmp/ms2-list-offset-cap`  
+Base: `202c10eff` (PR #1186, remote main)

--- a/docs/development/integration-core-list-offset-cap-verification-20260426.md
+++ b/docs/development/integration-core-list-offset-cap-verification-20260426.md
@@ -35,7 +35,7 @@
 
 ## Regression Guard
 
-After merging current `origin/main`, including PR #1192 list-limit cap and PR #1196 public run-mode validation, all 18 `plugin-integration-core` test files pass:
+After merging current `origin/main`, including PR #1192 list-limit cap, PR #1196 public run-mode validation, and PR #1198 external-system config preservation, all 18 `plugin-integration-core` test files pass:
 
 ```
 http-routes: REST auth/list/upsert/run/dry-run/replay tests passed

--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -666,6 +666,69 @@ async function testTenantGuards() {
   assert.equal(blankContext.body.error.code, 'TENANT_CONTEXT_REQUIRED')
 }
 
+async function testListOffsetCap() {
+  const { MAX_LIST_OFFSET } = httpRoutes
+  assert.equal(typeof MAX_LIST_OFFSET, 'number', 'MAX_LIST_OFFSET is exported')
+
+  // Large offset (above cap) must be clamped at all 4 list endpoints
+  const hugeOffset = String(MAX_LIST_OFFSET + 999999)
+  const { calls: sysCalls, services: sysServices } = createMockServices()
+  const { routes: sysRoutes } = mountRoutes(sysServices)
+  await invoke(sysRoutes, 'GET', '/api/integration/external-systems', {
+    user: READ_USER,
+    query: { workspaceId: 'workspace_1', offset: hugeOffset },
+  })
+  assert.equal(findCall(sysCalls, 'listExternalSystems')[1].offset, MAX_LIST_OFFSET,
+    'external-systems: huge offset clamped to MAX_LIST_OFFSET')
+
+  const { calls: pipCalls, services: pipServices } = createMockServices()
+  const { routes: pipRoutes } = mountRoutes(pipServices)
+  await invoke(pipRoutes, 'GET', '/api/integration/pipelines', {
+    user: READ_USER,
+    query: { workspaceId: 'workspace_1', offset: hugeOffset },
+  })
+  assert.equal(findCall(pipCalls, 'listPipelines')[1].offset, MAX_LIST_OFFSET,
+    'pipelines: huge offset clamped to MAX_LIST_OFFSET')
+
+  const { calls: runCalls, services: runServices } = createMockServices()
+  const { routes: runRoutes } = mountRoutes(runServices)
+  await invoke(runRoutes, 'GET', '/api/integration/runs', {
+    user: READ_USER,
+    query: { workspaceId: 'workspace_1', offset: hugeOffset },
+  })
+  assert.equal(findCall(runCalls, 'listPipelineRuns')[1].offset, MAX_LIST_OFFSET,
+    'runs: huge offset clamped to MAX_LIST_OFFSET')
+
+  const { calls: dlCalls, services: dlServices } = createMockServices()
+  const { routes: dlRoutes } = mountRoutes(dlServices)
+  await invoke(dlRoutes, 'GET', '/api/integration/dead-letters', {
+    user: READ_USER,
+    query: { workspaceId: 'workspace_1', offset: hugeOffset },
+  })
+  assert.equal(findCall(dlCalls, 'listDeadLetters')[1].offset, MAX_LIST_OFFSET,
+    'dead-letters: huge offset clamped to MAX_LIST_OFFSET')
+
+  // offset = 0 → treated as no offset (undefined)
+  const { calls: zeroCalls, services: zeroServices } = createMockServices()
+  const { routes: zeroRoutes } = mountRoutes(zeroServices)
+  await invoke(zeroRoutes, 'GET', '/api/integration/pipelines', {
+    user: READ_USER,
+    query: { workspaceId: 'workspace_1', offset: '0' },
+  })
+  assert.equal(findCall(zeroCalls, 'listPipelines')[1].offset, undefined,
+    'offset=0 is treated as no offset (undefined)')
+
+  // Small valid offset passes through unchanged
+  const { calls: smallCalls, services: smallServices } = createMockServices()
+  const { routes: smallRoutes } = mountRoutes(smallServices)
+  await invoke(smallRoutes, 'GET', '/api/integration/pipelines', {
+    user: READ_USER,
+    query: { workspaceId: 'workspace_1', offset: '50' },
+  })
+  assert.equal(findCall(smallCalls, 'listPipelines')[1].offset, 50,
+    'small valid offset passes through unchanged')
+}
+
 async function main() {
   await testUnauthenticatedWriteRequestIsRejected()
   await testExternalSystemRoutes()
@@ -673,6 +736,7 @@ async function main() {
   await testRunAndDeadLetterRoutes()
   await testErrorResponseShape()
   await testTenantGuards()
+  await testListOffsetCap()
 
   console.log('http-routes: REST auth/list/upsert/run/dry-run/replay tests passed')
 }

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -156,10 +156,18 @@ function requestParams(req) {
   return req.params && typeof req.params === 'object' ? req.params : {}
 }
 
+const MAX_LIST_OFFSET = 10000
+
 function asPositiveInt(value) {
   if (value === undefined || value === null || value === '') return undefined
   const numeric = Number(value)
   return Number.isInteger(numeric) && numeric > 0 ? numeric : undefined
+}
+
+function asListOffset(value) {
+  const n = asPositiveInt(value)
+  if (n === undefined) return undefined
+  return Math.min(n, MAX_LIST_OFFSET)
 }
 
 function publicRunInput(body = {}) {
@@ -236,7 +244,7 @@ function createHandlers(services) {
         kind: query.kind,
         status: query.status,
         limit: asPositiveInt(query.limit),
-        offset: asPositiveInt(query.offset),
+        offset: asListOffset(query.offset),
       })))
     },
 
@@ -268,7 +276,7 @@ function createHandlers(services) {
         sourceSystemId: query.sourceSystemId,
         targetSystemId: query.targetSystemId,
         limit: asPositiveInt(query.limit),
-        offset: asPositiveInt(query.offset),
+        offset: asListOffset(query.offset),
       })))
     },
 
@@ -319,7 +327,7 @@ function createHandlers(services) {
         pipelineId: query.pipelineId,
         status: query.status,
         limit: asPositiveInt(query.limit),
-        offset: asPositiveInt(query.offset),
+        offset: asListOffset(query.offset),
       })))
     },
 
@@ -332,7 +340,7 @@ function createHandlers(services) {
         runId: query.runId,
         status: query.status,
         limit: asPositiveInt(query.limit),
-        offset: asPositiveInt(query.offset),
+        offset: asListOffset(query.offset),
       }))
       return sendOk(res, rows.map((row) => redactDeadLetter(row, fullPayload)))
     },
@@ -384,6 +392,7 @@ module.exports = {
   HttpRouteError,
   createHandlers,
   registerIntegrationRoutes,
+  MAX_LIST_OFFSET,
   __internals: {
     hasPermission,
     requireAccess,
@@ -393,5 +402,7 @@ module.exports = {
     inferHttpStatus,
     publicRunInput,
     redactDeadLetter,
+    asListOffset,
+    asPositiveInt,
   },
 }


### PR DESCRIPTION
## Summary

- Adds `MAX_LIST_OFFSET = 10000` constant and `asListOffset()` helper to `lib/http-routes.cjs`
- Replaces unbounded `asPositiveInt(query.offset)` with `asListOffset(query.offset)` at all four list endpoints (external-systems, pipelines, runs, dead-letters)
- Mirrors the limit cap pattern added in #1192 (`MAX_LIST_LIMIT = 500`)

**Problem**: a caller passing `offset=9999999` triggered a sequential full-table scan across millions of rows before returning results. There is no cheap index skip to an arbitrary row offset.

**Fix**: clamp to 10000. Requests beyond that depth should use cursor-based pagination.

## Test plan

- [ ] `testListOffsetCap()` — 6 assertions: huge offset clamped at all 4 endpoints; offset=0 → undefined; small valid offset unchanged
- [ ] All 18 `plugin-integration-core` test files pass (0 regressions)
- [ ] Design: `docs/development/integration-core-list-offset-cap-design-20260426.md`
- [ ] Verification: `docs/development/integration-core-list-offset-cap-verification-20260426.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)