### PR TITLE
fix(integration): wrap success-path finishRun in try-catch, return warning

### DIFF
--- a/docs/development/integration-core-finishrun-success-guard-design-20260426.md
+++ b/docs/development/integration-core-finishrun-success-guard-design-20260426.md
@@ -1,0 +1,78 @@
+# Design: Wrap Success-Path finishRun in Try-Catch
+
+**PR**: #1200  
+**Date**: 2026-04-26  
+**File**: `plugins/plugin-integration-core/lib/pipeline-runner.cjs`
+
+---
+
+## Problem
+
+In `runPipeline`, after all ERP writes have committed, the success path calls `finishRun` to mark the run as `succeeded` or `partial`:
+
+```javascript
+run = await runLogger.finishRun(run, metrics, status, { details: { ... } })
+return { run, metrics, preview }
+```
+
+If `updatePipelineRun` fails here (e.g. DB goes down in the narrow window after ERP writes but before the run-record update), the exception propagates to the outer `catch (error)` block:
+
+```javascript
+} catch (error) {
+  // error = the DB failure from finishRun
+  run = await runLogger.finishRun(run, metrics, 'failed', {
+    errorSummary: error.message || String(error),
+  })  // ← also throws (same DB down)
+  throw new PipelineRunnerError('pipeline run failed', { ... })
+}
+```
+
+The caller receives a `PipelineRunnerError` indicating failure, even though ERP writes already succeeded. Callers may retry the entire run — duplicate ERP writes can result (idempotency keys help but it's still unclean and generates noise in ERP change logs).
+
+## Fix
+
+Wrap `finishRun` in the success path with a dedicated try-catch. On failure, return the result with a `warning` field rather than propagating to the error path:
+
+```javascript
+let finishRunWarning = null
+try {
+  run = await runLogger.finishRun(run, metrics, status, {
+    details: { dryRun, watermarkAdvanced: ..., nextCursor: cursor, erpFeedback },
+  })
+} catch (finishError) {
+  // ERP writes already committed — don't propagate to catch block where
+  // callers would see a failure and potentially retry (duplicate writes).
+  finishRunWarning = {
+    code: 'FINISH_RUN_FAILED',
+    message: finishError.message || String(finishError),
+  }
+}
+return {
+  run,
+  metrics,
+  preview,
+  ...(finishRunWarning && { warning: finishRunWarning }),
+}
+```
+
+## Pattern
+
+Same pattern as PR #1195 (`markReplayed` best-effort in `replayDeadLetter`): once the irreversible external operation has completed, subsequent bookkeeping failures return a `warning` rather than masking the outcome as a failure.
+
+## Caller Contract
+
+- **Normal case**: `{ run, metrics, preview }` — no `warning` field; caller can read `run.status`.
+- **finishRun failure**: `{ run, metrics, preview, warning: { code: 'FINISH_RUN_FAILED', message: '...' } }` — caller receives 202; `run.status` is still `'running'` (the record was never updated); the ERP write outcome is in `metrics`.
+
+Callers checking `result.warning` can surface the issue in observability without triggering a retry.
+
+## Boundary
+
+Only the success path is wrapped. The catch block is intentionally left as-is (handled by PR #1193's nested try-catch): errors during the pipeline run itself are genuine failures and should propagate as `PipelineRunnerError`.
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `lib/pipeline-runner.cjs` | `finishRunWarning` try-catch in success path of `runPipeline` |
+| `__tests__/pipeline-runner.test.cjs` | Section 18 — 2 scenarios (18a: throws → warning, 18b: normal → no warning) |

--- a/docs/development/integration-core-finishrun-success-guard-verification-20260426.md
+++ b/docs/development/integration-core-finishrun-success-guard-verification-20260426.md
@@ -31,7 +31,7 @@ All scenarios use a fresh `buildRunner18` helper that creates a complete runner 
 
 ## Regression Guard
 
-After merging current `origin/main`, including stale-run cleanup, failed-run finalization, and replay bookkeeping guards, all 18 `plugin-integration-core` test files pass:
+After merging current `origin/main`, including stale-run cleanup, failed-run finalization, replay bookkeeping, and list offset guards, all 18 `plugin-integration-core` test files pass:
 
 ```
 ✓ adapter-contracts: registry + normalizer tests passed

--- a/docs/development/integration-core-finishrun-success-guard-verification-20260426.md
+++ b/docs/development/integration-core-finishrun-success-guard-verification-20260426.md
@@ -1,0 +1,49 @@
+# Verification: Wrap Success-Path finishRun in Try-Catch
+
+**PR**: #1200  
+**Date**: 2026-04-26
+
+---
+
+## Test Scenarios Added (Section 18)
+
+All scenarios use a fresh `buildRunner18` helper that creates a complete runner with one source record producing a successful ERP write (`targetRows18.size === 1`).
+
+### 18a: finishRun throws → result returned with warning, not error
+
+**Setup**: `updatePipelineRun` always throws `'DB connection lost after ERP write'`
+
+**Assertions**:
+- `warnResult.run` is truthy (original startRun object)
+- `warnResult.metrics.rowsWritten === 1` (ERP write completed)
+- `warnResult.warning.code === 'FINISH_RUN_FAILED'`
+- `typeof warnResult.warning.message === 'string'`
+- `targetRows18.size === 1` (target record was written despite finishRun failure)
+
+### 18b: Normal finishRun — no warning field
+
+**Setup**: Standard `createPipelineRegistry` — `updatePipelineRun` succeeds
+
+**Assertions**:
+- `normalResult.run` is truthy
+- `normalResult.run.status === 'succeeded'`
+- `normalResult.warning === undefined`
+
+## Regression Guard
+
+All 18 `plugin-integration-core` test files pass:
+
+```
+✓ credential-store        ✓ adapter-contracts       ✓ http-adapter
+✓ db.cjs                 ✓ plm-yuantus-wrapper     ✓ pipelines
+✓ external-systems       ✓ transform-validator      ✓ runner-support
+✓ payload-redaction      ✓ pipeline-runner          ✓ http-routes
+✓ k3-wise-adapters       ✓ erp-feedback             ✓ e2e-plm-k3wise-writeback
+✓ staging-installer      ✓ migration-sql
+```
+
+## Worktree
+
+Branch: `codex/integration-finishrun-success-guard-20260426`  
+Worktree: `/tmp/ms2-finishrun-success-guard`  
+Base: `202c10eff` (PR #1186, remote main)

--- a/plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs
@@ -712,6 +712,83 @@ async function main() {
     assert.ok(result.run, `allowInactive: ${JSON.stringify(truthyVariant)} lets the inactive pipeline run`)
   }
 
+  // --- 18. finishRun failure in success path returns warning, not error ----
+  {
+    const db18 = createMockDb()
+    const pipeline18 = {
+      id: 'pipe_1', tenantId: 'tenant_1', workspaceId: null, projectId: 'project_1',
+      sourceSystemId: 'source_1', sourceObject: 'materials',
+      targetSystemId: 'target_1', targetObject: 'BD_MATERIAL',
+      mode: 'manual', status: 'active',
+      idempotencyKeyFields: ['code', 'revision'],
+      options: { batchSize: 100 },
+      fieldMappings: [
+        { sourceField: 'code', targetField: 'FNumber', transform: ['trim', 'upper'], validation: [{ type: 'required' }] },
+        { sourceField: 'name', targetField: 'FName', transform: { fn: 'trim' }, validation: [{ type: 'required' }] },
+      ],
+    }
+    const targetRows18 = new Map()
+    const adapterRegistry18 = createAdapterRegistry()
+      .registerAdapter('mock-source', () => ({
+        async testConnection() { return { ok: true } },
+        async listObjects() { return [] },
+        async getSchema() { return { fields: [] } },
+        async read() {
+          return createReadResult({ records: [
+            { code: 'mat-01', revision: 'r1', name: 'Bolt', updatedAt: '2026-04-24T01:00:00.000Z' },
+          ] })
+        },
+        async upsert() { throw new Error('source upsert should not be called') },
+      }))
+      .registerAdapter('mock-target', () => ({
+        async testConnection() { return { ok: true } },
+        async listObjects() { return [] },
+        async getSchema() { return { fields: [] } },
+        async read() { return createReadResult({ records: [] }) },
+        async upsert(input) {
+          for (const record of input.records) targetRows18.set(record._integration_idempotency_key, record)
+          return createUpsertResult({ written: input.records.length, skipped: 0, results: [] })
+        },
+      }))
+
+    function buildRunner18(pipelineRegistryOverride = {}) {
+      const registry = { ...createPipelineRegistry(pipeline18, db18), ...pipelineRegistryOverride }
+      return createPipelineRunner({
+        pipelineRegistry: registry,
+        externalSystemRegistry: createExternalSystemRegistry(),
+        adapterRegistry: adapterRegistry18,
+        deadLetterStore: createDeadLetterStore({ db: db18 }),
+        watermarkStore: createWatermarkStore({ db: db18 }),
+        runLogger: createRunLogger({ pipelineRegistry: registry }),
+      })
+    }
+
+    // 18a: finishRun throws (DB down) after ERP write → returns warning, not error
+    const throwingRunner = buildRunner18({
+      async updatePipelineRun() {
+        throw new Error('DB connection lost after ERP write')
+      },
+    })
+    const warnResult = await throwingRunner.runPipeline({
+      tenantId: 'tenant_1', pipelineId: 'pipe_1', mode: 'manual', triggeredBy: 'api',
+    })
+    assert.ok(warnResult.run, 'result.run is present even when finishRun throws')
+    assert.equal(warnResult.metrics.rowsWritten, 1, 'ERP write completed before finishRun threw')
+    assert.ok(warnResult.warning, 'warning field present when finishRun fails')
+    assert.equal(warnResult.warning.code, 'FINISH_RUN_FAILED', 'warning code is FINISH_RUN_FAILED')
+    assert.equal(typeof warnResult.warning.message, 'string', 'warning message is a string')
+    assert.equal(targetRows18.size, 1, 'target record was written despite finishRun failure')
+
+    // 18b: normal finishRun (no override) — no warning field
+    const normalRunner = buildRunner18()
+    const normalResult = await normalRunner.runPipeline({
+      tenantId: 'tenant_1', pipelineId: 'pipe_1', mode: 'manual', triggeredBy: 'api',
+    })
+    assert.ok(normalResult.run, 'normal result has run')
+    assert.equal(normalResult.run.status, 'succeeded', 'run status is succeeded')
+    assert.equal(normalResult.warning, undefined, 'no warning when finishRun succeeds')
+  }
+
   console.log('✓ pipeline-runner: cleanse/idempotency/incremental E2E tests passed')
 }
 

--- a/plugins/plugin-integration-core/lib/pipeline-runner.cjs
+++ b/plugins/plugin-integration-core/lib/pipeline-runner.cjs
@@ -467,18 +467,29 @@ function createPipelineRunner(deps = {}) {
 
       metrics.durationMs = Math.max(0, clock() - started)
       const status = metrics.rowsFailed > 0 ? 'partial' : 'succeeded'
-      run = await runLogger.finishRun(run, metrics, status, {
-        details: {
-          dryRun,
-          watermarkAdvanced: !dryRun && metrics.rowsFailed === 0 && Boolean(lastSuccessfulWatermark),
-          nextCursor: cursor,
-          erpFeedback,
-        },
-      })
+      let finishRunWarning = null
+      try {
+        run = await runLogger.finishRun(run, metrics, status, {
+          details: {
+            dryRun,
+            watermarkAdvanced: !dryRun && metrics.rowsFailed === 0 && Boolean(lastSuccessfulWatermark),
+            nextCursor: cursor,
+            erpFeedback,
+          },
+        })
+      } catch (finishError) {
+        // ERP writes already committed — don't propagate to catch block where
+        // callers would see a failure and potentially retry (duplicate writes).
+        finishRunWarning = {
+          code: 'FINISH_RUN_FAILED',
+          message: finishError.message || String(finishError),
+        }
+      }
       return {
         run,
         metrics,
         preview,
+        ...(finishRunWarning && { warning: finishRunWarning }),
       }
     } catch (error) {
       metrics.durationMs = Math.max(0, clock() - started)


### PR DESCRIPTION
## Summary

- In `runPipeline`, wraps the success-path `finishRun` call in a dedicated try-catch
- If `updatePipelineRun` fails after ERP writes have committed (DB down in that narrow window), returns `{ run, metrics, preview, warning: { code: 'FINISH_RUN_FAILED', message } }` instead of propagating to the outer catch block
- Same pattern as #1195 (`markReplayed` best-effort)

**Problem**: `finishRun` failure in the success path propagated to the `catch (error)` block, which threw `PipelineRunnerError`. Callers received HTTP 500 even though ERP writes succeeded — they could retry, risking duplicate ERP writes.

**Fix**: once irreversible external work (ERP writes) has committed, DB bookkeeping failures return a `warning`, not an error. Callers receive 202 and can surface the warning in observability without retrying.

## Test plan

- [ ] Section 18a: `updatePipelineRun` throws → `warnResult.warning.code === 'FINISH_RUN_FAILED'`, `metrics.rowsWritten === 1`, no exception
- [ ] Section 18b: normal path → `run.status === 'succeeded'`, no `warning` field
- [ ] All 18 `plugin-integration-core` test files pass (0 regressions)
- [ ] Design: `docs/development/integration-core-finishrun-success-guard-design-20260426.md`
- [ ] Verification: `docs/development/integration-core-finishrun-success-guard-verification-20260426.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)