### PR TITLE
fix(integration): cap dry-run sampleLimit at MAX_SAMPLE_LIMIT (10000)

### DIFF
--- a/docs/development/integration-core-sample-limit-cap-design-20260426.md
+++ b/docs/development/integration-core-sample-limit-cap-design-20260426.md
@@ -1,0 +1,72 @@
+# Design: Cap Dry-Run sampleLimit at MAX_SAMPLE_LIMIT
+
+**PR**: #1201  
+**Date**: 2026-04-26  
+**File**: `plugins/plugin-integration-core/lib/http-routes.cjs`
+
+---
+
+## Problem
+
+`publicRunInput` converts `body.sampleLimit` to a positive integer without any upper bound:
+
+```javascript
+sampleLimit: asPositiveInt(body.sampleLimit),
+```
+
+A caller submitting `sampleLimit: 9999999` signals they want a "sample" preview, but the pipeline runner would stream up to `maxPages × batchSize` records (e.g. 100 × 1000 = 100,000 rows). The name "sample" implies a bounded read; the missing cap breaks that contract.
+
+The underlying runner uses:
+
+```javascript
+const effectiveBatchSize = dryRun && sampleLimit > 0
+  ? Math.min(input.sampleLimit, batchSize)    // bounded by batchSize per page
+  : batchSize
+
+let remainingDryRunSamples = dryRun && sampleLimit > 0
+  ? input.sampleLimit                         // total cross-page cap — unbounded
+  : null
+```
+
+With `sampleLimit=9999999` and `batchSize=1000`, the effective per-page limit is 1000 but the total cap across 100 pages is 9,999,999 — effectively uncapped.
+
+## Fix
+
+Add `MAX_SAMPLE_LIMIT = 10000` and `asSampleLimit()` helper; apply in `publicRunInput`:
+
+```javascript
+const MAX_SAMPLE_LIMIT = 10000
+
+function asSampleLimit(value) {
+  const n = asPositiveInt(value)
+  if (n === undefined) return undefined
+  return Math.min(n, MAX_SAMPLE_LIMIT)
+}
+
+// in publicRunInput:
+sampleLimit: asSampleLimit(body.sampleLimit),
+```
+
+`publicRunInput` is called by both `/run` and `/dry-run` handlers, so both endpoints are covered with a single change.
+
+## Semantics
+
+| Input | Behavior |
+|-------|----------|
+| Absent / `''` / `0` | Stripped — runner reads all pages (no sample cap) |
+| `'5'` | `5` — passed through |
+| `'10001'` | `10000` — clamped |
+| `'9999999'` | `10000` — clamped |
+
+Clamping is preferred over rejection: the caller still gets a valid preview, just limited to a safe depth.
+
+## Prior Art
+
+Same pattern as `MAX_LIST_LIMIT = 500` (#1192) and `MAX_LIST_OFFSET = 10000` (#1199).
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `lib/http-routes.cjs` | `MAX_SAMPLE_LIMIT`, `asSampleLimit()`, applied in `publicRunInput` |
+| `__tests__/http-routes.test.cjs` | `testSampleLimitCap()` — 4 assertions |

--- a/docs/development/integration-core-sample-limit-cap-verification-20260426.md
+++ b/docs/development/integration-core-sample-limit-cap-verification-20260426.md
@@ -33,7 +33,7 @@
 
 ## Regression Guard
 
-After merging current `origin/main`, including list limit, list offset, and public run-mode guards, all 18 `plugin-integration-core` test files pass:
+After merging current `origin/main`, including list limit, list offset, public run-mode, and finishRun success warning guards, all 18 `plugin-integration-core` test files pass:
 
 ```
 http-routes: REST auth/list/upsert/run/dry-run/replay tests passed

--- a/docs/development/integration-core-sample-limit-cap-verification-20260426.md
+++ b/docs/development/integration-core-sample-limit-cap-verification-20260426.md
@@ -1,0 +1,51 @@
+# Verification: Cap Dry-Run sampleLimit at MAX_SAMPLE_LIMIT
+
+**PR**: #1201  
+**Date**: 2026-04-26
+
+---
+
+## Test Scenarios Added (`testSampleLimitCap`)
+
+### /run: huge sampleLimit clamped to MAX_SAMPLE_LIMIT
+
+**Input**: `sampleLimit: String(MAX_SAMPLE_LIMIT + 999999)` on `POST /api/integration/pipelines/:id/run`
+
+**Assertion**: `runPipeline` receives `sampleLimit === MAX_SAMPLE_LIMIT`
+
+### /dry-run: huge sampleLimit clamped to MAX_SAMPLE_LIMIT
+
+**Input**: `sampleLimit: String(MAX_SAMPLE_LIMIT + 999999)` on `POST /api/integration/pipelines/:id/dry-run`
+
+**Assertion**: `runPipeline` receives `sampleLimit === MAX_SAMPLE_LIMIT`
+
+### sampleLimit=0 is stripped (undefined)
+
+**Input**: `sampleLimit: 0`
+
+**Assertion**: `'sampleLimit' in runPipelineCall` is `false` (key deleted by `publicRunInput`'s falsy-strip loop)
+
+### Small valid sampleLimit passes through unchanged
+
+**Input**: `sampleLimit: 5`
+
+**Assertion**: `runPipeline` receives `sampleLimit === 5`
+
+## Regression Guard
+
+All 18 `plugin-integration-core` test files pass:
+
+```
+✓ credential-store        ✓ adapter-contracts       ✓ http-adapter
+✓ db.cjs                 ✓ plm-yuantus-wrapper     ✓ pipelines
+✓ external-systems       ✓ transform-validator      ✓ runner-support
+✓ payload-redaction      ✓ pipeline-runner          ✓ http-routes
+✓ k3-wise-adapters       ✓ erp-feedback             ✓ e2e-plm-k3wise-writeback
+✓ staging-installer      ✓ migration-sql
+```
+
+## Worktree
+
+Branch: `codex/integration-sample-limit-cap-20260426`  
+Worktree: `/tmp/ms2-sample-limit-cap`  
+Base: `202c10eff` (PR #1186, remote main)

--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -666,6 +666,56 @@ async function testTenantGuards() {
   assert.equal(blankContext.body.error.code, 'TENANT_CONTEXT_REQUIRED')
 }
 
+async function testSampleLimitCap() {
+  const { MAX_SAMPLE_LIMIT } = httpRoutes
+  assert.equal(typeof MAX_SAMPLE_LIMIT, 'number', 'MAX_SAMPLE_LIMIT is exported')
+
+  // Huge sampleLimit on /run is clamped to MAX_SAMPLE_LIMIT
+  const { calls: runCalls, services: runServices } = createMockServices()
+  const { routes: runRoutes } = mountRoutes(runServices)
+  const hugeLimit = String(MAX_SAMPLE_LIMIT + 999999)
+  await invoke(runRoutes, 'POST', '/api/integration/pipelines/:id/run', {
+    user: WRITE_USER,
+    params: { id: 'pipe_1' },
+    body: { workspaceId: 'workspace_1', sampleLimit: hugeLimit },
+  })
+  assert.equal(findCall(runCalls, 'runPipeline')[1].sampleLimit, MAX_SAMPLE_LIMIT,
+    '/run: huge sampleLimit clamped to MAX_SAMPLE_LIMIT')
+
+  // Huge sampleLimit on /dry-run is also clamped
+  const { calls: dryCalls, services: dryServices } = createMockServices()
+  const { routes: dryRoutes } = mountRoutes(dryServices)
+  await invoke(dryRoutes, 'POST', '/api/integration/pipelines/:id/dry-run', {
+    user: WRITE_USER,
+    params: { id: 'pipe_1' },
+    body: { workspaceId: 'workspace_1', sampleLimit: hugeLimit },
+  })
+  assert.equal(findCall(dryCalls, 'runPipeline')[1].sampleLimit, MAX_SAMPLE_LIMIT,
+    '/dry-run: huge sampleLimit clamped to MAX_SAMPLE_LIMIT')
+
+  // sampleLimit = 0 → stripped (undefined)
+  const { calls: zeroCalls, services: zeroServices } = createMockServices()
+  const { routes: zeroRoutes } = mountRoutes(zeroServices)
+  await invoke(zeroRoutes, 'POST', '/api/integration/pipelines/:id/dry-run', {
+    user: WRITE_USER,
+    params: { id: 'pipe_1' },
+    body: { workspaceId: 'workspace_1', sampleLimit: 0 },
+  })
+  assert.equal('sampleLimit' in findCall(zeroCalls, 'runPipeline')[1], false,
+    'sampleLimit=0 is stripped from input (publicRunInput deletes falsy keys)')
+
+  // Small valid sampleLimit passes through unchanged
+  const { calls: smallCalls, services: smallServices } = createMockServices()
+  const { routes: smallRoutes } = mountRoutes(smallServices)
+  await invoke(smallRoutes, 'POST', '/api/integration/pipelines/:id/dry-run', {
+    user: WRITE_USER,
+    params: { id: 'pipe_1' },
+    body: { workspaceId: 'workspace_1', sampleLimit: 5 },
+  })
+  assert.equal(findCall(smallCalls, 'runPipeline')[1].sampleLimit, 5,
+    'small valid sampleLimit passes through unchanged')
+}
+
 async function main() {
   await testUnauthenticatedWriteRequestIsRejected()
   await testExternalSystemRoutes()
@@ -673,6 +723,7 @@ async function main() {
   await testRunAndDeadLetterRoutes()
   await testErrorResponseShape()
   await testTenantGuards()
+  await testSampleLimitCap()
 
   console.log('http-routes: REST auth/list/upsert/run/dry-run/replay tests passed')
 }

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -156,10 +156,18 @@ function requestParams(req) {
   return req.params && typeof req.params === 'object' ? req.params : {}
 }
 
+const MAX_SAMPLE_LIMIT = 10000
+
 function asPositiveInt(value) {
   if (value === undefined || value === null || value === '') return undefined
   const numeric = Number(value)
   return Number.isInteger(numeric) && numeric > 0 ? numeric : undefined
+}
+
+function asSampleLimit(value) {
+  const n = asPositiveInt(value)
+  if (n === undefined) return undefined
+  return Math.min(n, MAX_SAMPLE_LIMIT)
 }
 
 function publicRunInput(body = {}) {
@@ -168,7 +176,7 @@ function publicRunInput(body = {}) {
     workspaceId: body.workspaceId,
     mode: body.mode,
     cursor: body.cursor,
-    sampleLimit: asPositiveInt(body.sampleLimit),
+    sampleLimit: asSampleLimit(body.sampleLimit),
   }
   for (const key of Object.keys(input)) {
     if (input[key] === undefined || input[key] === null || input[key] === '') delete input[key]
@@ -384,6 +392,7 @@ module.exports = {
   HttpRouteError,
   createHandlers,
   registerIntegrationRoutes,
+  MAX_SAMPLE_LIMIT,
   __internals: {
     hasPermission,
     requireAccess,
@@ -393,5 +402,7 @@ module.exports = {
     inferHttpStatus,
     publicRunInput,
     redactDeadLetter,
+    asSampleLimit,
+    asPositiveInt,
   },
 }


### PR DESCRIPTION
## Summary

- Adds `MAX_SAMPLE_LIMIT = 10000` and `asSampleLimit()` helper in `lib/http-routes.cjs`
- Replaces `asPositiveInt(body.sampleLimit)` with `asSampleLimit(body.sampleLimit)` in `publicRunInput`
- Covers both `/run` and `/dry-run` endpoints in a single change

**Problem**: `sampleLimit` had no upper bound. A dry-run with `sampleLimit=9999999` would stream up to `maxPages × batchSize` records (100 × 1000 = 100,000) — the same as a full run — while signalling to the caller it was a safe preview.

**Fix**: clamp at 10000, same strategy as limit (#1192) and offset (#1199) caps.

## Test plan

- [ ] `testSampleLimitCap()` — 4 assertions: huge limit clamped on `/run`, huge limit clamped on `/dry-run`, `sampleLimit=0` stripped, small limit unchanged
- [ ] All 18 `plugin-integration-core` test files pass (0 regressions)
- [ ] Design: `docs/development/integration-core-sample-limit-cap-design-20260426.md`
- [ ] Verification: `docs/development/integration-core-sample-limit-cap-verification-20260426.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)