### PR TITLE
fix(integration): reject null/non-object sourcePayload before replay

### DIFF
--- a/docs/development/integration-core-replay-null-payload-design-20260426.md
+++ b/docs/development/integration-core-replay-null-payload-design-20260426.md
@@ -1,0 +1,67 @@
+# Design: Reject Null/Non-Object sourcePayload Before Replay
+
+**PR**: #1202  
+**Date**: 2026-04-26  
+**File**: `plugins/plugin-integration-core/lib/pipeline-runner.cjs`
+
+---
+
+## Problem
+
+`replayDeadLetter` passes `sourceRecords: [deadLetter.sourcePayload]` to `runPipeline` without verifying the payload is a record object:
+
+```javascript
+const result = await runPipeline({
+  ...
+  sourceRecords: [deadLetter.sourcePayload],  // ← could be null, array, string, number
+})
+```
+
+`createDeadLetter` validates that `sourcePayload` is non-null on write. But the DB row can be:
+- Directly inserted with `source_payload = NULL` (ops tooling, migration error)
+- From a schema version before the validation was added
+- Corrupted by a partial write
+
+When `sourcePayload` is `null`, the runner processes `[null]` as source records. `transformRecord(null, fieldMappings)` tries `null[sourceField]` → `TypeError: Cannot read properties of null`. This unhandled TypeError propagates from `processRecord` through the `for` loop, out of the success path, and into the outer `catch` block — crashing the entire replay run with a confusing error rather than a structured `PipelineRunnerError`.
+
+Similarly, array or scalar payloads (e.g., a string or number) are not valid record objects and would cause the same crash.
+
+## Fix
+
+Add explicit guards immediately after the existing `PAYLOAD_TRUNCATED` check:
+
+```javascript
+if (deadLetter.sourcePayload === null || deadLetter.sourcePayload === undefined) {
+  throw new PipelineRunnerError('dead letter source payload is null and cannot be replayed', {
+    id: deadLetter.id,
+    reason: 'NULL_PAYLOAD',
+  })
+}
+if (typeof deadLetter.sourcePayload !== 'object' || Array.isArray(deadLetter.sourcePayload)) {
+  throw new PipelineRunnerError('dead letter source payload is not a record object and cannot be replayed', {
+    id: deadLetter.id,
+    reason: 'INVALID_PAYLOAD_TYPE',
+  })
+}
+```
+
+Both checks run before `runPipeline` is called — no run record is created, no target writes happen.
+
+## Guard Ordering
+
+| Check | Reason |
+|-------|--------|
+| `PAYLOAD_TRUNCATED` (existing) | Intentionally truncated payload — `{ payloadTruncated: true }` object |
+| `NULL_PAYLOAD` (new) | null or undefined — unrepresentable as a record |
+| `INVALID_PAYLOAD_TYPE` (new) | Array, string, number — not a record object |
+
+## Why Not Catch in `processRecord`?
+
+`processRecord` already handles transform failures, validation failures, and idempotency failures by writing dead letters. But a `TypeError` from `null[field]` inside `transformRecord` is an unhandled exception — it bypasses the dead-letter path entirely and crashes the run. The pre-flight check is simpler and produces a cleaner error for ops.
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `lib/pipeline-runner.cjs` | Two guard blocks after `PAYLOAD_TRUNCATED` check in `replayDeadLetter` |
+| `__tests__/pipeline-runner.test.cjs` | Section 5b — 5 payload variants (null, undefined, array, string, number) |

--- a/docs/development/integration-core-replay-null-payload-verification-20260426.md
+++ b/docs/development/integration-core-replay-null-payload-verification-20260426.md
@@ -36,7 +36,7 @@ All 5 variants inject a DB row directly into `db.tables.get('integration_dead_le
 
 ## Regression Guard
 
-After merging current `origin/main` through the finishRun success-warning guard, all 18 `plugin-integration-core` test files pass:
+After merging current `origin/main` through the dry-run sampleLimit cap, all 18 `plugin-integration-core` test files pass:
 
 ```
 ✓ credential-store        ✓ adapter-contracts       ✓ http-adapter
@@ -51,4 +51,4 @@ After merging current `origin/main` through the finishRun success-warning guard,
 
 Branch: `codex/integration-replay-null-payload-20260426`  
 Worktree: `/private/tmp/ms2-replay-null-payload`  
-Base: `4ba8d3d50` (origin/main after PR #1200)
+Base: `33a4078bb` (origin/main after PR #1201)

--- a/docs/development/integration-core-replay-null-payload-verification-20260426.md
+++ b/docs/development/integration-core-replay-null-payload-verification-20260426.md
@@ -1,0 +1,54 @@
+# Verification: Reject Null/Non-Object sourcePayload Before Replay
+
+**PR**: #1202  
+**Date**: 2026-04-26
+
+---
+
+## Test Scenarios Added (Section 5b)
+
+All 5 variants inject a DB row directly into `db.tables.get('integration_dead_letters')` to bypass `createDeadLetter`'s own sourcePayload validation (which correctly rejects null on write — this tests the read/replay path).
+
+### null → NULL_PAYLOAD
+
+**DB row**: `source_payload: null`  
+**Assertions**: error is `PipelineRunnerError`, `reason === 'NULL_PAYLOAD'`, `targetRows.size === 0`
+
+### undefined → NULL_PAYLOAD
+
+**DB row**: `source_payload: undefined`  
+**Assertions**: error is `PipelineRunnerError`, `reason === 'NULL_PAYLOAD'`, `targetRows.size === 0`
+
+### array → INVALID_PAYLOAD_TYPE
+
+**DB row**: `source_payload: [{ code: 'x' }]`  
+**Assertions**: error is `PipelineRunnerError`, `reason === 'INVALID_PAYLOAD_TYPE'`, `targetRows.size === 0`
+
+### string → INVALID_PAYLOAD_TYPE
+
+**DB row**: `source_payload: 'raw-value'`  
+**Assertions**: error is `PipelineRunnerError`, `reason === 'INVALID_PAYLOAD_TYPE'`, `targetRows.size === 0`
+
+### number → INVALID_PAYLOAD_TYPE
+
+**DB row**: `source_payload: 42`  
+**Assertions**: error is `PipelineRunnerError`, `reason === 'INVALID_PAYLOAD_TYPE'`, `targetRows.size === 0`
+
+## Regression Guard
+
+All 18 `plugin-integration-core` test files pass:
+
+```
+✓ credential-store        ✓ adapter-contracts       ✓ http-adapter
+✓ db.cjs                 ✓ plm-yuantus-wrapper     ✓ pipelines
+✓ external-systems       ✓ transform-validator      ✓ runner-support
+✓ payload-redaction      ✓ pipeline-runner          ✓ http-routes
+✓ k3-wise-adapters       ✓ erp-feedback             ✓ e2e-plm-k3wise-writeback
+✓ staging-installer      ✓ migration-sql
+```
+
+## Worktree
+
+Branch: `codex/integration-replay-null-payload-20260426`  
+Worktree: `/tmp/ms2-replay-null-payload`  
+Base: `202c10eff` (PR #1186, remote main)

--- a/plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs
@@ -579,6 +579,50 @@ async function main() {
   assert.equal(replayError.details.reason, 'PAYLOAD_TRUNCATED')
   assert.equal(truncatedReplay.targetRows.size, 0, 'truncated replay is rejected before target write')
 
+  // --- 5b. null / non-object sourcePayload is rejected before target write -
+  // createDeadLetter validates sourcePayload is non-null, so simulate rows
+  // that arrive with corrupted payloads via direct DB table injection.
+  for (const [label, badPayload, expectedReason] of [
+    ['null', null, 'NULL_PAYLOAD'],
+    ['undefined', undefined, 'NULL_PAYLOAD'],
+    ['array', [{ code: 'x' }], 'INVALID_PAYLOAD_TYPE'],
+    ['string', 'raw-value', 'INVALID_PAYLOAD_TYPE'],
+    ['number', 42, 'INVALID_PAYLOAD_TYPE'],
+  ]) {
+    const badPayloadHarness = createRunnerHarness({ sourceRecords: [] })
+    const badStore = createDeadLetterStore({
+      db: badPayloadHarness.db,
+      idGenerator: () => `dl_bad_${label}`,
+    })
+    // Inject a row directly into the DB table to bypass createDeadLetter validation
+    badPayloadHarness.db.tables.get('integration_dead_letters').push({
+      id: `dl_bad_${label}`,
+      tenant_id: 'tenant_1',
+      workspace_id: null,
+      run_id: 'run_original',
+      pipeline_id: 'pipe_1',
+      source_payload: badPayload,
+      transformed_payload: null,
+      error_code: 'VALIDATION_FAILED',
+      error_message: `bad payload: ${label}`,
+      retry_count: 0,
+      status: 'open',
+      created_at: '2026-04-26T00:00:00.000Z',
+      updated_at: '2026-04-26T00:00:00.000Z',
+    })
+    const badError = await badPayloadHarness.runner.replayDeadLetter({
+      tenantId: 'tenant_1',
+      workspaceId: null,
+      id: `dl_bad_${label}`,
+    }).catch((error) => error)
+    assert.equal(badError.name, 'PipelineRunnerError',
+      `${label} payload rejected with PipelineRunnerError`)
+    assert.equal(badError.details.reason, expectedReason,
+      `${label} payload reason is ${expectedReason}`)
+    assert.equal(badPayloadHarness.targetRows.size, 0,
+      `${label} payload is rejected before any target write`)
+  }
+
   // --- 11. dryRun string coercion (REST API hand-typed booleans) ---------
   {
     const stringDry = createRunnerHarness({

--- a/plugins/plugin-integration-core/lib/pipeline-runner.cjs
+++ b/plugins/plugin-integration-core/lib/pipeline-runner.cjs
@@ -506,6 +506,18 @@ function createPipelineRunner(deps = {}) {
         reason: 'PAYLOAD_TRUNCATED',
       })
     }
+    if (deadLetter.sourcePayload === null || deadLetter.sourcePayload === undefined) {
+      throw new PipelineRunnerError('dead letter source payload is null and cannot be replayed', {
+        id: deadLetter.id,
+        reason: 'NULL_PAYLOAD',
+      })
+    }
+    if (typeof deadLetter.sourcePayload !== 'object' || Array.isArray(deadLetter.sourcePayload)) {
+      throw new PipelineRunnerError('dead letter source payload is not a record object and cannot be replayed', {
+        id: deadLetter.id,
+        reason: 'INVALID_PAYLOAD_TYPE',
+      })
+    }
     const result = await runPipeline({
       tenantId: deadLetter.tenantId,
       workspaceId: deadLetter.workspaceId,


### PR DESCRIPTION
## Summary

- Adds two pre-flight guards in `replayDeadLetter` (after the existing `PAYLOAD_TRUNCATED` check)
- `null`/`undefined` sourcePayload → `PipelineRunnerError('NULL_PAYLOAD')` before any run is started
- Array/scalar sourcePayload → `PipelineRunnerError('INVALID_PAYLOAD_TYPE')` before any run is started

**Problem**: `replayDeadLetter` passed `sourceRecords: [deadLetter.sourcePayload]` without validating the payload was a record object. A null payload (from a corrupted or directly-inserted DB row) caused `transformRecord(null, fieldMappings)` to throw `TypeError: Cannot read properties of null`, crashing the entire replay run rather than producing a structured error.

**Note**: `createDeadLetter` already rejects null on write — this protects the read/replay path for rows that predate that validation or were directly inserted via ops tooling.

## Test plan

- [ ] Section 5b — 5 payload variants injected directly into DB table (bypassing `createDeadLetter`): null, undefined, array, string, number — all rejected with structured `PipelineRunnerError`, `targetRows.size === 0` in each case
- [ ] All 18 `plugin-integration-core` test files pass (0 regressions)
- [ ] Design: `docs/development/integration-core-replay-null-payload-design-20260426.md`
- [ ] Verification: `docs/development/integration-core-replay-null-payload-verification-20260426.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)