### PR TITLE
fix(integration): reject non-string cursor at REST API boundary

### DIFF
--- a/docs/development/integration-core-cursor-string-guard-design-20260427.md
+++ b/docs/development/integration-core-cursor-string-guard-design-20260427.md
@@ -1,0 +1,76 @@
+# Design: Reject Non-String Cursor at REST API Boundary
+
+**PR**: #1203  
+**Date**: 2026-04-27  
+**File**: `plugins/plugin-integration-core/lib/http-routes.cjs`
+
+---
+
+## Problem
+
+`publicRunInput` passed `body.cursor` through without any type validation:
+
+```javascript
+const input = {
+  ...
+  cursor: body.cursor,  // could be object, array, number, etc.
+  ...
+}
+```
+
+The cursor is supposed to be a pagination token (a string returned by the previous read). When a caller sends a non-string value, it propagates to the runner:
+
+```javascript
+let cursor = input.cursor || null
+// ...
+await context.sourceAdapter.read({ ..., cursor, ... })
+```
+
+Adapters react badly:
+- HTTP adapters URL-encode the cursor — `{ malicious: true }` becomes `[object Object]` in the query string, breaking pagination
+- SQL adapters that use `cursor` in a `WHERE` clause may throw `invalid input syntax`
+- K3 WISE WebAPI adapter expects a string token; non-strings cause adapter-level crashes
+
+This is the only field in `publicRunInput` still unvalidated after the recent boundary-hardening work (#1196 mode, #1199 offset, #1201 sampleLimit).
+
+## Fix
+
+Validate cursor as a string at the input boundary. Empty/absent stays untouched (the existing falsy-strip loop handles it). Non-strings are rejected with `400 INVALID_CURSOR`:
+
+```javascript
+function publicRunInput(body = {}) {
+  if (body.cursor !== undefined && body.cursor !== null && body.cursor !== '') {
+    if (typeof body.cursor !== 'string') {
+      throw new HttpRouteError(400, 'INVALID_CURSOR', 'cursor must be a string', {
+        received: Array.isArray(body.cursor) ? 'array' : typeof body.cursor,
+      })
+    }
+  }
+  ...
+}
+```
+
+The `received` field distinguishes `'array'` from `'object'` (which `typeof` collapses) so callers can debug malformed clients quickly.
+
+## Semantics
+
+| Input | Behavior |
+|-------|----------|
+| Absent / `null` / `''` | Cursor omitted from runner input |
+| `'page-token-abc'` | Passed through unchanged |
+| `{ x: 1 }` | `400 INVALID_CURSOR` (`received: 'object'`) |
+| `[ 'a', 'b' ]` | `400 INVALID_CURSOR` (`received: 'array'`) |
+| `42` | `400 INVALID_CURSOR` (`received: 'number'`) |
+
+`publicRunInput` is shared between `/run` and `/dry-run`, so both endpoints are covered with a single change.
+
+## Pattern
+
+Mirrors `INVALID_RUN_MODE` (#1196). Same `HttpRouteError` shape: `(status, code, message, details)`. The `details` hint helps clients self-diagnose without guessing.
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `lib/http-routes.cjs` | cursor type-check at top of `publicRunInput` |
+| `__tests__/http-routes.test.cjs` | `testCursorStringGuard()` — 5 scenarios (object/array/number/string/absent) |

--- a/docs/development/integration-core-cursor-string-guard-verification-20260427.md
+++ b/docs/development/integration-core-cursor-string-guard-verification-20260427.md
@@ -44,7 +44,7 @@
 
 ## Regression Guard
 
-After merging current `origin/main` through the dry-run sampleLimit cap, all 18 `plugin-integration-core` test files pass:
+After merging current `origin/main` through the replay sourcePayload guard, all 18 `plugin-integration-core` test files pass:
 
 ```
 ✓ credential-store        ✓ adapter-contracts       ✓ http-adapter
@@ -59,4 +59,4 @@ After merging current `origin/main` through the dry-run sampleLimit cap, all 18 
 
 Branch: `codex/integration-cursor-string-guard-20260427`  
 Worktree: `/private/tmp/ms2-cursor-guard`  
-Base: `33a4078bb` (origin/main after PR #1201)
+Base: `2d7d616bb` (origin/main after PR #1202)

--- a/docs/development/integration-core-cursor-string-guard-verification-20260427.md
+++ b/docs/development/integration-core-cursor-string-guard-verification-20260427.md
@@ -1,0 +1,62 @@
+# Verification: Reject Non-String Cursor at REST API Boundary
+
+**PR**: #1203  
+**Date**: 2026-04-27
+
+---
+
+## Test Scenarios Added (`testCursorStringGuard`)
+
+### Object cursor → 400 INVALID_CURSOR
+
+**Input**: `body.cursor = { malicious: true }` on `/run`  
+**Assertions**:
+- `statusCode === 400`
+- `error.code === 'INVALID_CURSOR'`
+- `error.details.received === 'object'`
+
+### Array cursor → 400 INVALID_CURSOR (received='array')
+
+**Input**: `body.cursor = ['c', 'd']` on `/dry-run`  
+**Assertions**:
+- `statusCode === 400`
+- `error.code === 'INVALID_CURSOR'`
+- `error.details.received === 'array'` (distinguished from `object`)
+
+### Numeric cursor → 400 INVALID_CURSOR
+
+**Input**: `body.cursor = 42` on `/run`  
+**Assertions**:
+- `statusCode === 400`
+- `error.code === 'INVALID_CURSOR'`
+
+### String cursor → passes through
+
+**Input**: `body.cursor = 'page-token-abc'` on `/run`  
+**Assertions**:
+- `statusCode === 202`
+- `runPipeline` receives `cursor === 'page-token-abc'`
+
+### Absent cursor → not in input
+
+**Input**: no `cursor` field in body  
+**Assertion**: `'cursor' in runPipelineCall` is `false`
+
+## Regression Guard
+
+All 18 `plugin-integration-core` test files pass:
+
+```
+✓ credential-store        ✓ adapter-contracts       ✓ http-adapter
+✓ db.cjs                 ✓ plm-yuantus-wrapper     ✓ pipelines
+✓ external-systems       ✓ transform-validator      ✓ runner-support
+✓ payload-redaction      ✓ pipeline-runner          ✓ http-routes
+✓ k3-wise-adapters       ✓ erp-feedback             ✓ e2e-plm-k3wise-writeback
+✓ staging-installer      ✓ migration-sql
+```
+
+## Worktree
+
+Branch: `codex/integration-cursor-string-guard-20260427`  
+Worktree: `/tmp/ms2-cursor-guard`  
+Base: `202c10eff` (PR #1186, remote main)

--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -666,6 +666,60 @@ async function testTenantGuards() {
   assert.equal(blankContext.body.error.code, 'TENANT_CONTEXT_REQUIRED')
 }
 
+async function testCursorStringGuard() {
+  const { calls, services } = createMockServices()
+  const { routes } = mountRoutes(services)
+
+  // cursor as object → 400 INVALID_CURSOR
+  const objRes = await invoke(routes, 'POST', '/api/integration/pipelines/:id/run', {
+    user: WRITE_USER,
+    params: { id: 'pipe_1' },
+    body: { workspaceId: 'workspace_1', cursor: { malicious: true } },
+  })
+  assert.equal(objRes.statusCode, 400, 'object cursor → 400')
+  assert.equal(objRes.body.error.code, 'INVALID_CURSOR', 'error code is INVALID_CURSOR')
+  assert.equal(objRes.body.error.details.received, 'object', 'received=object reported')
+
+  // cursor as array → 400 INVALID_CURSOR (received=array, not object)
+  const arrRes = await invoke(routes, 'POST', '/api/integration/pipelines/:id/dry-run', {
+    user: WRITE_USER,
+    params: { id: 'pipe_1' },
+    body: { workspaceId: 'workspace_1', cursor: ['c', 'd'] },
+  })
+  assert.equal(arrRes.statusCode, 400, 'array cursor → 400')
+  assert.equal(arrRes.body.error.code, 'INVALID_CURSOR')
+  assert.equal(arrRes.body.error.details.received, 'array', 'received=array (distinguished from object)')
+
+  // cursor as number → 400 INVALID_CURSOR
+  const numRes = await invoke(routes, 'POST', '/api/integration/pipelines/:id/run', {
+    user: WRITE_USER,
+    params: { id: 'pipe_1' },
+    body: { workspaceId: 'workspace_1', cursor: 42 },
+  })
+  assert.equal(numRes.statusCode, 400, 'numeric cursor → 400')
+  assert.equal(numRes.body.error.code, 'INVALID_CURSOR')
+
+  // cursor as valid string → passes through to runPipeline
+  const strRes = await invoke(routes, 'POST', '/api/integration/pipelines/:id/run', {
+    user: WRITE_USER,
+    params: { id: 'pipe_1' },
+    body: { workspaceId: 'workspace_1', cursor: 'page-token-abc' },
+  })
+  assertOkResponse(strRes, 202)
+  const runCall = findCall(calls, 'runPipeline')
+  assert.equal(runCall[1].cursor, 'page-token-abc', 'string cursor passed through')
+
+  // No cursor → not in input
+  const { calls: noCalls, services: noServices } = createMockServices()
+  const { routes: noRoutes } = mountRoutes(noServices)
+  await invoke(noRoutes, 'POST', '/api/integration/pipelines/:id/run', {
+    user: WRITE_USER,
+    params: { id: 'pipe_1' },
+    body: { workspaceId: 'workspace_1' },
+  })
+  assert.equal('cursor' in findCall(noCalls, 'runPipeline')[1], false, 'absent cursor → not in input')
+}
+
 async function main() {
   await testUnauthenticatedWriteRequestIsRejected()
   await testExternalSystemRoutes()
@@ -673,6 +727,7 @@ async function main() {
   await testRunAndDeadLetterRoutes()
   await testErrorResponseShape()
   await testTenantGuards()
+  await testCursorStringGuard()
 
   console.log('http-routes: REST auth/list/upsert/run/dry-run/replay tests passed')
 }

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -163,6 +163,13 @@ function asPositiveInt(value) {
 }
 
 function publicRunInput(body = {}) {
+  if (body.cursor !== undefined && body.cursor !== null && body.cursor !== '') {
+    if (typeof body.cursor !== 'string') {
+      throw new HttpRouteError(400, 'INVALID_CURSOR', 'cursor must be a string', {
+        received: Array.isArray(body.cursor) ? 'array' : typeof body.cursor,
+      })
+    }
+  }
   const input = {
     tenantId: body.tenantId,
     workspaceId: body.workspaceId,


### PR DESCRIPTION
## Summary

- Adds cursor type-check at the top of `publicRunInput`: anything other than string/null/empty → `400 INVALID_CURSOR`
- `error.details.received` distinguishes `'array'` from `'object'` (which `typeof` collapses) so clients can debug malformed bodies
- Single change covers both `/run` and `/dry-run` since they share `publicRunInput`

**Problem**: cursor was the only field in `publicRunInput` left unvalidated after #1196 (mode), #1199 (offset), and #1201 (sampleLimit). A caller sending `cursor: { malicious: true }` had it forwarded to source adapters; HTTP-style adapters URL-encoded it as `[object Object]`, and SQL-style adapters threw mid-query.

## Test plan

- [ ] `testCursorStringGuard()` — 5 scenarios: object/array/number reject with `INVALID_CURSOR`, valid string passes through, absent cursor produces no input field
- [ ] `received: 'array'` reported separately from `'object'`
- [ ] All 18 `plugin-integration-core` test files pass (0 regressions)
- [ ] Design: `docs/development/integration-core-cursor-string-guard-design-20260427.md`
- [ ] Verification: `docs/development/integration-core-cursor-string-guard-verification-20260427.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)