### PR TITLE
fix(integration): record maxPagesReached + pagesProcessed in run details

### DIFF
--- a/docs/development/integration-core-maxpages-reached-signal-design-20260427.md
+++ b/docs/development/integration-core-maxpages-reached-signal-design-20260427.md
@@ -1,0 +1,74 @@
+# Design: Record maxPagesReached + pagesProcessed in Run Details
+
+**PR**: #1204  
+**Date**: 2026-04-27  
+**File**: `plugins/plugin-integration-core/lib/pipeline-runner.cjs`
+
+---
+
+## Problem
+
+`runPipeline` reads source records in a `while (page < maxPages)` loop. The loop exits via three breaks (dry-run sample exhausted, `readResult.done`, no `nextCursor`) or by hitting the page cap.
+
+When the page cap is hit but the source still has more data, the loop simply exits. The watermark advances to the last successful record, so subsequent runs do pick up where this one left off — there's no data loss. But:
+
+- Operators have no signal that the pipeline is bigger than `maxPages × batchSize` allows in one run
+- Dashboards can't surface "this pipeline keeps hitting the cap" patterns
+- Tuning `maxPages` (default 100) or `batchSize` (default 1000) requires guessing
+
+## Fix
+
+Track an `exitedNormally` flag that's set to `true` inside each break point. After the loop:
+
+```javascript
+const maxPagesReached = !exitedNormally && page >= maxPages
+```
+
+This distinguishes:
+- Loop exited via break (source done, dry-run sample reached, no more cursor) → `exitedNormally=true`
+- Loop exited because `page >= maxPages` was no longer true at the head → `maxPagesReached=true`
+
+Both `maxPagesReached` and `pagesProcessed` land in `run.details`:
+
+```javascript
+run = await runLogger.finishRun(run, metrics, status, {
+  details: {
+    dryRun,
+    watermarkAdvanced: ...,
+    nextCursor: cursor,
+    erpFeedback,
+    maxPagesReached,      // NEW
+    pagesProcessed: page, // NEW
+  },
+})
+```
+
+## Why Not a Top-Level Field?
+
+The runner already returns `{ run, metrics, preview }`. Adding a new top-level field would change the public API contract. Putting the signal in `run.details` is non-breaking — callers that care can read `result.run.details.maxPagesReached`; callers that don't are unaffected. Run details are already JSONB-stored and surfaced in run logs and the runs API.
+
+## Why Not Throw?
+
+Hitting `maxPages` is intended behavior — the cap exists to bound runtime per request. Throwing would mark the run `failed` and signal disaster, but the run did succeed for the records it processed and the watermark did advance. A non-fatal signal in details is the right shape.
+
+## Detection Logic
+
+```
+while (page < maxPages) {
+  page += 1
+  // ... read, process, write
+  if (dryRunSamplesExhausted)    { exitedNormally = true; break }
+  if (readDone || !nextCursor)   { exitedNormally = true; break }
+  cursor = nextCursor
+}
+maxPagesReached = !exitedNormally && page >= maxPages
+```
+
+If the loop finishes its final iteration *without* breaking, `cursor` was just advanced to a non-null `nextCursor` — meaning the source still has data. The next iteration's `while` check fails because `page === maxPages`. That's exactly the "cap hit with more work" case.
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `lib/pipeline-runner.cjs` | `exitedNormally` flag + 2 new keys in `run.details` |
+| `__tests__/pipeline-runner.test.cjs` | Section 19 — 2 scenarios (cap hit; clean exit) |

--- a/docs/development/integration-core-maxpages-reached-signal-verification-20260427.md
+++ b/docs/development/integration-core-maxpages-reached-signal-verification-20260427.md
@@ -30,7 +30,7 @@
 
 ## Regression Guard
 
-After merging current `origin/main` through the dry-run sampleLimit cap, all 18 `plugin-integration-core` test files pass:
+After merging current `origin/main` through the replay sourcePayload guard, all 18 `plugin-integration-core` test files pass:
 
 ```
 ✓ credential-store        ✓ adapter-contracts       ✓ http-adapter
@@ -45,4 +45,4 @@ After merging current `origin/main` through the dry-run sampleLimit cap, all 18 
 
 Branch: `codex/integration-maxpages-reached-signal-20260427`  
 Worktree: `/private/tmp/ms2-maxpages-signal`  
-Base: `33a4078bb` (origin/main after PR #1201)
+Base: `2d7d616bb` (origin/main after PR #1202)

--- a/docs/development/integration-core-maxpages-reached-signal-verification-20260427.md
+++ b/docs/development/integration-core-maxpages-reached-signal-verification-20260427.md
@@ -1,0 +1,48 @@
+# Verification: Record maxPagesReached + pagesProcessed in Run Details
+
+**PR**: #1204  
+**Date**: 2026-04-27
+
+---
+
+## Test Scenarios Added (Section 19)
+
+### 19a: Cap hit with more data → maxPagesReached=true
+
+**Setup**:
+- Pipeline `options.maxPages = 2`
+- Source returns 3 pages (each with `nextCursor` until the 3rd page)
+
+**Assertions**:
+- `result.run.details.maxPagesReached === true`
+- `result.run.details.pagesProcessed === 2`
+- Source `read()` called exactly 2 times (cap was respected)
+
+### 19b: Source done before cap → maxPagesReached=false
+
+**Setup**:
+- Pipeline `options.maxPages = 5`
+- Source returns 1 page with `done: true`, `nextCursor: null`
+
+**Assertions**:
+- `result.run.details.maxPagesReached === false`
+- `result.run.details.pagesProcessed === 1`
+
+## Regression Guard
+
+All 18 `plugin-integration-core` test files pass:
+
+```
+✓ credential-store        ✓ adapter-contracts       ✓ http-adapter
+✓ db.cjs                 ✓ plm-yuantus-wrapper     ✓ pipelines
+✓ external-systems       ✓ transform-validator      ✓ runner-support
+✓ payload-redaction      ✓ pipeline-runner          ✓ http-routes
+✓ k3-wise-adapters       ✓ erp-feedback             ✓ e2e-plm-k3wise-writeback
+✓ staging-installer      ✓ migration-sql
+```
+
+## Worktree
+
+Branch: `codex/integration-maxpages-reached-signal-20260427`  
+Worktree: `/tmp/ms2-maxpages-signal`  
+Base: `202c10eff` (PR #1186, remote main)

--- a/docs/development/integration-core-maxpages-reached-signal-verification-20260427.md
+++ b/docs/development/integration-core-maxpages-reached-signal-verification-20260427.md
@@ -30,7 +30,7 @@
 
 ## Regression Guard
 
-After merging current `origin/main` through the replay sourcePayload guard, all 18 `plugin-integration-core` test files pass:
+After merging current `origin/main` through the REST cursor guard, all 18 `plugin-integration-core` test files pass:
 
 ```
 ✓ credential-store        ✓ adapter-contracts       ✓ http-adapter
@@ -45,4 +45,4 @@ After merging current `origin/main` through the replay sourcePayload guard, all 
 
 Branch: `codex/integration-maxpages-reached-signal-20260427`  
 Worktree: `/private/tmp/ms2-maxpages-signal`  
-Base: `2d7d616bb` (origin/main after PR #1202)
+Base: `7a999daeb` (origin/main after PR #1203)

--- a/plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs
@@ -712,6 +712,58 @@ async function main() {
     assert.ok(result.run, `allowInactive: ${JSON.stringify(truthyVariant)} lets the inactive pipeline run`)
   }
 
+  // --- 19. maxPagesReached signal in run details when cap exhausted ---------
+  {
+    // Source returns 3 pages of records; pipeline maxPages=2 → cap hit, more data unread
+    let cappedPage = 0
+    const cappedHarness = createRunnerHarness({
+      sourceRecords: [],
+      pipelineOverrides: { options: { batchSize: 100, maxPages: 2 } },
+      sourceRead: async () => {
+        cappedPage += 1
+        return createReadResult({
+          records: [
+            { code: `cap-${cappedPage}-1`, revision: 'r1', qty: '1', name: 'Bolt', updatedAt: `2026-04-24T0${cappedPage}:00:00.000Z` },
+          ],
+          nextCursor: cappedPage < 3 ? `cursor-${cappedPage + 1}` : null,
+          done: cappedPage >= 3,
+        })
+      },
+    })
+    const cappedResult = await cappedHarness.runner.runPipeline({
+      tenantId: 'tenant_1', pipelineId: 'pipe_1', mode: 'incremental', triggeredBy: 'manual',
+    })
+    assert.equal(cappedResult.run.details.maxPagesReached, true,
+      'maxPagesReached=true when source has more data and page cap is hit')
+    assert.equal(cappedResult.run.details.pagesProcessed, 2,
+      'pagesProcessed reflects the number of pages read')
+    assert.equal(cappedPage, 2, 'source read called exactly maxPages times')
+
+    // Source returns 1 page (done=true) → maxPagesReached=false, exited normally
+    let normalPage = 0
+    const normalHarness = createRunnerHarness({
+      sourceRecords: [],
+      pipelineOverrides: { options: { batchSize: 100, maxPages: 5 } },
+      sourceRead: async () => {
+        normalPage += 1
+        return createReadResult({
+          records: [
+            { code: `n-${normalPage}-1`, revision: 'r1', qty: '1', name: 'Bolt', updatedAt: `2026-04-24T01:00:00.000Z` },
+          ],
+          nextCursor: null,
+          done: true,
+        })
+      },
+    })
+    const normalResult = await normalHarness.runner.runPipeline({
+      tenantId: 'tenant_1', pipelineId: 'pipe_1', mode: 'incremental', triggeredBy: 'manual',
+    })
+    assert.equal(normalResult.run.details.maxPagesReached, false,
+      'maxPagesReached=false when source signals done before cap')
+    assert.equal(normalResult.run.details.pagesProcessed, 1,
+      'pagesProcessed=1 when single page completes the run')
+  }
+
   console.log('✓ pipeline-runner: cleanse/idempotency/incremental E2E tests passed')
 }
 

--- a/plugins/plugin-integration-core/lib/pipeline-runner.cjs
+++ b/plugins/plugin-integration-core/lib/pipeline-runner.cjs
@@ -371,6 +371,7 @@ function createPipelineRunner(deps = {}) {
       let cursor = input.cursor || null
       let page = 0
       let lastSuccessfulWatermark = null
+      let exitedNormally = false
       const erpFeedback = []
       let remainingDryRunSamples = dryRun && Number.isInteger(input.sampleLimit) && input.sampleLimit > 0
         ? input.sampleLimit
@@ -449,10 +450,17 @@ function createPipelineRunner(deps = {}) {
         if (metrics.rowsFailed === 0) {
           lastSuccessfulWatermark = deriveNextWatermark(records, watermarkConfig) || lastSuccessfulWatermark
         }
-        if (remainingDryRunSamples !== null && remainingDryRunSamples <= 0) break
-        if (readResult.done || !readResult.nextCursor) break
+        if (remainingDryRunSamples !== null && remainingDryRunSamples <= 0) {
+          exitedNormally = true
+          break
+        }
+        if (readResult.done || !readResult.nextCursor) {
+          exitedNormally = true
+          break
+        }
         cursor = readResult.nextCursor
       }
+      const maxPagesReached = !exitedNormally && page >= maxPages
 
       if (!dryRun && metrics.rowsFailed === 0 && lastSuccessfulWatermark) {
         const advance = typeof watermarkStore.advanceWatermark === 'function'
@@ -473,6 +481,8 @@ function createPipelineRunner(deps = {}) {
           watermarkAdvanced: !dryRun && metrics.rowsFailed === 0 && Boolean(lastSuccessfulWatermark),
           nextCursor: cursor,
           erpFeedback,
+          maxPagesReached,
+          pagesProcessed: page,
         },
       })
       return {


### PR DESCRIPTION
## Summary

- Adds `exitedNormally` flag to the page loop in `runPipeline`
- After the loop: `maxPagesReached = !exitedNormally && page >= maxPages`
- Both `maxPagesReached` and `pagesProcessed` land in `run.details` — non-breaking, surfaced in run logs and the runs API

**Problem**: when a pipeline hits the `maxPages` cap (default 100) but the source still has unread data, the loop exits silently. The watermark advances correctly so subsequent runs continue from where this one stopped — but operators have no signal that the pipeline keeps brushing the cap. Without that signal, tuning `maxPages` or `batchSize` is guesswork.

**Fix**: track an `exitedNormally` flag at each break point, derive `maxPagesReached` after the loop, surface both fields in `run.details` (no API contract change).

## Test plan

- [ ] Section 19a — pipeline `maxPages=2`, source has 3 pages → `details.maxPagesReached === true`, `details.pagesProcessed === 2`
- [ ] Section 19b — pipeline `maxPages=5`, source returns `done: true` after 1 page → `details.maxPagesReached === false`, `details.pagesProcessed === 1`
- [ ] All 18 `plugin-integration-core` test files pass (0 regressions)
- [ ] Design: `docs/development/integration-core-maxpages-reached-signal-design-20260427.md`
- [ ] Verification: `docs/development/integration-core-maxpages-reached-signal-verification-20260427.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)