### PR TITLE
fix(integration): per-record guard for null/non-object source records

### DIFF
--- a/docs/development/integration-core-invalid-source-record-guard-design-20260427.md
+++ b/docs/development/integration-core-invalid-source-record-guard-design-20260427.md
@@ -1,0 +1,90 @@
+# Design: Per-Record Guard for Null/Non-Object Source Records
+
+**PR**: #1205  
+**Date**: 2026-04-27  
+**File**: `plugins/plugin-integration-core/lib/pipeline-runner.cjs`
+
+---
+
+## Problem
+
+`processRecord` calls `transformRecord(sourceRecord, fieldMappings)` directly, with no per-record type check:
+
+```javascript
+async function processRecord({ context, run, sourceRecord, ... }) {
+  metrics.rowsRead += 1
+  const transformed = transformRecord(sourceRecord, context.pipeline.fieldMappings || [])
+  ...
+}
+```
+
+`transformRecord` itself enforces a hard precondition (`transform-engine.cjs:182`):
+
+```javascript
+function transformRecord(sourceRecord, fieldMappings = []) {
+  if (!isPlainObject(sourceRecord)) {
+    throw new TransformError('sourceRecord must be an object')
+  }
+  ...
+}
+```
+
+When a source adapter returns `[null, validRecord, null]` (buggy or partially-failed paged read), `transformRecord(null, ...)` throws. The throw escapes `processRecord` → the `for` loop → the `while` loop → into `runPipeline`'s outer `catch (error)` block. The entire run is marked `failed`. The valid record that came after the bad one never gets a chance to write.
+
+The replay path was protected in #1202 (`NULL_PAYLOAD` / `INVALID_PAYLOAD_TYPE` pre-flight check), but the regular run path was left exposed — adapters that emit one bad row poison the whole batch.
+
+## Fix
+
+Add a per-record check at the top of `processRecord`. Anything that isn't a plain object becomes its own dead letter with `errorCode: 'INVALID_SOURCE_RECORD'`, and the loop continues:
+
+```javascript
+async function processRecord({ context, run, sourceRecord, cleanRecords, metrics, preview, dryRun }) {
+  metrics.rowsRead += 1
+  if (sourceRecord === null || sourceRecord === undefined ||
+      typeof sourceRecord !== 'object' || Array.isArray(sourceRecord)) {
+    metrics.rowsFailed += 1
+    const failure = {
+      ...
+      sourcePayload: sourceRecord === null || sourceRecord === undefined
+        ? { _adapterReturnedNullRecord: true }
+        : sanitizeIntegrationPayload({ _adapterReturnedNonObject: true, value: sourceRecord }),
+      transformedPayload: null,
+      errorCode: 'INVALID_SOURCE_RECORD',
+      errorMessage: `adapter returned ${typeOfSourceRecord} instead of a record object`,
+      dryRun,
+    }
+    await writeDeadLetter(failure)
+    if (preview) preview.errors.push({ ...failure, dryRun: undefined })
+    return
+  }
+  const transformed = transformRecord(sourceRecord, context.pipeline.fieldMappings || [])
+  ...
+}
+```
+
+## Why At This Layer?
+
+- `transformRecord` is a pure function; modifying it to handle non-objects would muddy its contract
+- `processRecord` already owns the dead-letter routing for `TRANSFORM_FAILED`, `VALIDATION_FAILED`, `IDEMPOTENCY_FAILED` — `INVALID_SOURCE_RECORD` belongs in the same family
+- The check needs the run/context/preview wiring that only `processRecord` has
+
+## Error Code Family
+
+| Code | Trigger |
+|------|---------|
+| `INVALID_SOURCE_RECORD` (new) | Adapter returned null/array/scalar instead of object |
+| `TRANSFORM_FAILED` | Field mapping transform threw (bad type coercion, etc.) |
+| `VALIDATION_FAILED` | Field validator rejected (required missing, pattern mismatch, etc.) |
+| `IDEMPOTENCY_FAILED` | Couldn't compute idempotency key |
+| `TARGET_WRITE_FAILED` | Target adapter rejected the record |
+
+## Sanitized Payload
+
+For `null`/`undefined`, the dead letter payload is a marker object `{ _adapterReturnedNullRecord: true }` (no actual data to redact). For other non-objects (string, number, array), the value is wrapped via `sanitizeIntegrationPayload({ _adapterReturnedNonObject: true, value })` so the redaction layer still scrubs sensitive content if any leaked into a string.
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `lib/pipeline-runner.cjs` | Type check + dead-letter write at top of `processRecord` |
+| `__tests__/pipeline-runner.test.cjs` | Section 20 — 6-record mixed batch (null, valid, undefined, string, valid, array) → 2 written, 4 dead letters with `INVALID_SOURCE_RECORD` |

--- a/docs/development/integration-core-invalid-source-record-guard-verification-20260427.md
+++ b/docs/development/integration-core-invalid-source-record-guard-verification-20260427.md
@@ -1,0 +1,62 @@
+# Verification: Per-Record Guard for Null/Non-Object Source Records
+
+**PR**: #1205  
+**Date**: 2026-04-27
+
+---
+
+## Test Scenarios Added (Section 20)
+
+### Mixed-batch run: 6 source records, 2 valid + 4 invalid
+
+**Setup**: Source returns a single page with this record array:
+
+```javascript
+[
+  null,
+  { code: 'valid-1', revision: 'r1', qty: '3', name: 'Bolt', ... },
+  undefined,
+  'raw-string-not-an-object',
+  { code: 'valid-2', revision: 'r1', qty: '5', name: 'Nut', ... },
+  [{ nested: 'array' }],
+]
+```
+
+**Without the fix**: `transformRecord(null, ...)` throws on the first record; the entire run fails before either valid record can be written.
+
+**With the fix**:
+- `result.run.status === 'partial'` (run completes despite invalid records)
+- `metrics.rowsRead === 6` (all 6 counted as read)
+- `metrics.rowsCleaned === 2` (only the two valid records cleaned)
+- `metrics.rowsWritten === 2` (both valid records written to target)
+- `metrics.rowsFailed === 4` (4 invalid records failed)
+- `targetRows.size === 2` (target has the two valid records only)
+
+### Per-record dead letters with INVALID_SOURCE_RECORD
+
+**Assertions on `integration_dead_letters` rows where `error_code === 'INVALID_SOURCE_RECORD'`**:
+- 4 dead letters created (one per invalid record)
+- `error_message` for each variant mentions its type:
+  - `null` → message contains `'null'`
+  - `undefined` → message contains `'undefined'`
+  - array (`[{nested:'array'}]`) → message contains `'array'`
+  - string (`'raw-string-not-an-object'`) → message contains `'string'`
+
+## Regression Guard
+
+All 18 `plugin-integration-core` test files pass on top of latest `origin/main` (`d7fd6d6ea`):
+
+```
+✓ credential-store        ✓ adapter-contracts       ✓ http-adapter
+✓ db.cjs                 ✓ plm-yuantus-wrapper     ✓ pipelines
+✓ external-systems       ✓ transform-validator      ✓ runner-support
+✓ payload-redaction      ✓ pipeline-runner          ✓ http-routes
+✓ k3-wise-adapters       ✓ erp-feedback             ✓ e2e-plm-k3wise-writeback
+✓ staging-installer      ✓ migration-sql
+```
+
+## Worktree
+
+Branch: `codex/integration-invalid-source-record-guard-20260427`  
+Worktree: `/tmp/ms2-invalid-source-record`  
+Base: `d7fd6d6ea` (origin/main after PR #1204)

--- a/plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs
@@ -1133,6 +1133,52 @@ async function main() {
       'pagesProcessed=1 when single page completes the run')
   }
 
+  // --- 20. invalid source record (null/array/scalar) → dead letter, run continues
+  {
+    // Source returns a mix of nulls, valid records, and a scalar; transformRecord
+    // throws TransformError on non-objects, so without per-record guard the entire
+    // run dies on the first null. Verify each invalid record becomes its own
+    // dead letter with INVALID_SOURCE_RECORD and valid records still write.
+    let mixedPage = 0
+    const mixedHarness = createRunnerHarness({
+      sourceRecords: [],
+      sourceRead: async () => {
+        mixedPage += 1
+        return createReadResult({
+          records: [
+            null,
+            { code: 'valid-1', revision: 'r1', qty: '3', name: 'Bolt', updatedAt: '2026-04-24T01:00:00.000Z' },
+            undefined,
+            'raw-string-not-an-object',
+            { code: 'valid-2', revision: 'r1', qty: '5', name: 'Nut', updatedAt: '2026-04-24T01:10:00.000Z' },
+            [{ nested: 'array' }],
+          ],
+          done: true,
+          nextCursor: null,
+        })
+      },
+    })
+    const mixedResult = await mixedHarness.runner.runPipeline({
+      tenantId: 'tenant_1', pipelineId: 'pipe_1', mode: 'incremental', triggeredBy: 'manual',
+    })
+    assert.equal(mixedResult.run.status, 'partial', 'run completes with partial status')
+    assert.equal(mixedResult.metrics.rowsRead, 6, 'all 6 records counted as read')
+    assert.equal(mixedResult.metrics.rowsCleaned, 2, 'two valid records cleaned')
+    assert.equal(mixedResult.metrics.rowsWritten, 2, 'two valid records written to target')
+    assert.equal(mixedResult.metrics.rowsFailed, 4, 'four invalid records failed')
+    assert.equal(mixedHarness.targetRows.size, 2, 'target has the two valid records only')
+
+    // Each invalid record produced its own dead letter with INVALID_SOURCE_RECORD
+    const deadLetters = mixedHarness.db.tables.get('integration_dead_letters')
+    const invalidLetters = deadLetters.filter((row) => row.error_code === 'INVALID_SOURCE_RECORD')
+    assert.equal(invalidLetters.length, 4, 'four INVALID_SOURCE_RECORD dead letters created')
+    const messages = invalidLetters.map((row) => row.error_message).sort()
+    assert.ok(messages.some((m) => m.includes('null')), 'null reported in error message')
+    assert.ok(messages.some((m) => m.includes('undefined')), 'undefined reported')
+    assert.ok(messages.some((m) => m.includes('array')), 'array reported')
+    assert.ok(messages.some((m) => m.includes('string')), 'string reported')
+  }
+
   console.log('✓ pipeline-runner: cleanse/idempotency/incremental E2E tests passed')
 }
 

--- a/plugins/plugin-integration-core/lib/pipeline-runner.cjs
+++ b/plugins/plugin-integration-core/lib/pipeline-runner.cjs
@@ -251,6 +251,31 @@ function createPipelineRunner(deps = {}) {
 
   async function processRecord({ context, run, sourceRecord, cleanRecords, metrics, preview, dryRun }) {
     metrics.rowsRead += 1
+    if (sourceRecord === null || sourceRecord === undefined ||
+        typeof sourceRecord !== 'object' || Array.isArray(sourceRecord)) {
+      metrics.rowsFailed += 1
+      const failure = {
+        tenantId: context.tenantId,
+        workspaceId: context.workspaceId,
+        runId: run.id,
+        pipelineId: context.pipeline.id,
+        sourcePayload: sourceRecord === null || sourceRecord === undefined
+          ? { _adapterReturnedNullRecord: true }
+          : sanitizeIntegrationPayload({ _adapterReturnedNonObject: true, value: sourceRecord }),
+        transformedPayload: null,
+        errorCode: 'INVALID_SOURCE_RECORD',
+        errorMessage: `adapter returned ${
+          sourceRecord === null ? 'null'
+          : sourceRecord === undefined ? 'undefined'
+          : Array.isArray(sourceRecord) ? 'array'
+          : typeof sourceRecord
+        } instead of a record object`,
+        dryRun,
+      }
+      await writeDeadLetter(failure)
+      if (preview) preview.errors.push({ ...failure, dryRun: undefined })
+      return
+    }
     const transformed = transformRecord(sourceRecord, context.pipeline.fieldMappings || [])
     if (!transformed.ok) {
       metrics.rowsFailed += 1


### PR DESCRIPTION
## Summary

- Adds a per-record type check at the top of `processRecord` in `pipeline-runner.cjs`
- Anything that isn't a plain object → its own dead letter with `errorCode: 'INVALID_SOURCE_RECORD'`
- The for-loop continues; valid records that come after a bad one still get written

**Problem**: `transformRecord(sourceRecord, ...)` throws `TransformError` when `sourceRecord` is not a plain object (`transform-engine.cjs:182`). When a source adapter returned `[null, validRecord, null]`, the throw escaped `processRecord` → the for loop → the while loop → into the outer catch block. The whole run died on the first null; the valid record never wrote.

The replay path was protected in #1202 (`NULL_PAYLOAD` / `INVALID_PAYLOAD_TYPE`), but the regular run path was not. This PR closes the same gap on the read path.

## Test plan

- [ ] Section 20: 6-record mixed batch (null, valid, undefined, string, valid, array) → run completes with `partial`, both valid records written, 4 dead letters with `INVALID_SOURCE_RECORD`
- [ ] Each invalid type produces a distinct error message ('null', 'undefined', 'array', 'string')
- [ ] All 18 `plugin-integration-core` test files pass on top of latest main (`d7fd6d6ea`)
- [ ] Design: `docs/development/integration-core-invalid-source-record-guard-design-20260427.md`
- [ ] Verification: `docs/development/integration-core-invalid-source-record-guard-verification-20260427.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)