### PR TITLE
fix(integration): normalize runner paging options

### DIFF
--- a/docs/development/integration-core-runner-option-normalization-design-20260427.md
+++ b/docs/development/integration-core-runner-option-normalization-design-20260427.md
@@ -1,0 +1,66 @@
+# Design: Normalize Pipeline Runner Paging Options
+
+**Date**: 2026-04-27  
+**Files**: `plugins/plugin-integration-core/lib/pipeline-runner.cjs`
+
+---
+
+## Problem
+
+`runPipeline` previously accepted `pipeline.options.batchSize` and `pipeline.options.maxPages` whenever `Number.isInteger(...)` returned true:
+
+```javascript
+const batchSize = Number.isInteger(context.pipeline.options?.batchSize)
+  ? context.pipeline.options.batchSize
+  : 1000
+const maxPages = Number.isInteger(context.pipeline.options?.maxPages)
+  ? context.pipeline.options.maxPages
+  : 100
+```
+
+This let invalid but integer values through:
+
+| Option | Bad value | Result before this change |
+|---|---:|---|
+| `maxPages` | `0` or negative | `while (page < maxPages)` never runs; run succeeds as a silent no-op |
+| `batchSize` | `0` or negative | invalid `limit` is passed into the source adapter |
+| `batchSize` | very large integer | oversized adapter read request can create memory/API pressure |
+
+These values can happen through hand-edited pipeline JSON, import tooling, or future UI bugs.
+
+## Fix
+
+Add a local runner option normalizer:
+
+```javascript
+function normalizePositiveIntegerOption(value, { defaultValue, max }) {
+  if (value === undefined || value === null || value === '') return defaultValue
+  const numeric = Number(value)
+  if (!Number.isInteger(numeric) || numeric <= 0) return defaultValue
+  return Math.min(numeric, max)
+}
+```
+
+Apply it to:
+
+| Option | Default | Max |
+|---|---:|---:|
+| `batchSize` | `1000` | `10000` |
+| `maxPages` | `100` | `10000` |
+
+## Behavior
+
+- Missing, empty, non-integer, zero, or negative values fall back to defaults.
+- Numeric strings such as `"200"` are accepted because pipeline configuration may come from JSON/form tooling.
+- Oversized values are capped before any source adapter call.
+
+## Why Fallback Instead of Throw?
+
+These options are safety limits, not business data. A bad value should not turn a scheduled PLM -> ERP sync into a successful no-op, and it should not fail the whole pipeline if a safe default is available. The runner already has stable defaults; using them keeps the integration moving while bounding resource usage.
+
+## Affected Surface
+
+| File | Change |
+|---|---|
+| `lib/pipeline-runner.cjs` | Adds option constants and `normalizePositiveIntegerOption`; uses it for `batchSize` and `maxPages` |
+| `__tests__/pipeline-runner.test.cjs` | Adds section 21 covering zero fallback and oversized batch cap |

--- a/docs/development/integration-core-runner-option-normalization-verification-20260427.md
+++ b/docs/development/integration-core-runner-option-normalization-verification-20260427.md
@@ -1,0 +1,46 @@
+# Verification: Normalize Pipeline Runner Paging Options
+
+**Date**: 2026-04-27  
+**Branch**: `codex/integration-next-hardening-20260427`  
+**Base**: `f372b9180` (`origin/main` after PR #1206)
+
+---
+
+## Test Scenarios Added
+
+### `batchSize = 0`, `maxPages = 0`
+
+Setup:
+
+- Pipeline options are hand-edited to `{ batchSize: 0, maxPages: 0 }`.
+- Source adapter returns one valid record.
+
+Expected:
+
+- Adapter receives `limit === 1000`.
+- Runner reads one page instead of producing a silent no-op.
+- `result.metrics.rowsRead === 1`.
+- `result.run.details.pagesProcessed === 1`.
+- Target receives the valid record.
+
+### Huge `batchSize`
+
+Setup:
+
+- Pipeline options are hand-edited to `{ batchSize: 999999, maxPages: 1 }`.
+
+Expected:
+
+- Source adapter receives `limit === 10000`.
+- Oversized batch requests are capped before they reach vendor adapters.
+
+## Local Commands
+
+```bash
+node plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs
+for f in plugins/plugin-integration-core/__tests__/*.test.cjs; do node "$f"; done
+```
+
+## Expected Result
+
+All 18 `plugin-integration-core` CJS test files pass on top of `origin/main`.

--- a/plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs
@@ -1179,6 +1179,52 @@ async function main() {
     assert.ok(messages.some((m) => m.includes('string')), 'string reported')
   }
 
+  // --- 21. invalid runner paging options fall back / cap safely ----------
+  {
+    const invalidOptionLimits = []
+    const invalidOptionHarness = createRunnerHarness({
+      sourceRecords: [],
+      pipelineOverrides: { options: { batchSize: 0, maxPages: 0 } },
+      sourceRead: async (input) => {
+        invalidOptionLimits.push(input.limit)
+        return createReadResult({
+          records: [
+            { code: 'fallback-1', revision: 'r1', qty: '1', name: 'Bolt', updatedAt: '2026-04-24T01:00:00.000Z' },
+          ],
+          done: true,
+          nextCursor: null,
+        })
+      },
+    })
+    const invalidOptionResult = await invalidOptionHarness.runner.runPipeline({
+      tenantId: 'tenant_1', pipelineId: 'pipe_1', mode: 'incremental', triggeredBy: 'manual',
+    })
+    assert.equal(invalidOptionLimits[0], 1000, 'batchSize=0 falls back to default batch size')
+    assert.equal(invalidOptionResult.metrics.rowsRead, 1, 'maxPages=0 falls back instead of producing a silent no-op')
+    assert.equal(invalidOptionResult.run.details.pagesProcessed, 1, 'fallback maxPages allows one page to run')
+    assert.equal(invalidOptionHarness.targetRows.size, 1, 'valid record still writes with invalid option fallbacks')
+
+    const hugeOptionLimits = []
+    const hugeOptionHarness = createRunnerHarness({
+      sourceRecords: [],
+      pipelineOverrides: { options: { batchSize: 999999, maxPages: 1 } },
+      sourceRead: async (input) => {
+        hugeOptionLimits.push(input.limit)
+        return createReadResult({
+          records: [
+            { code: 'cap-1', revision: 'r1', qty: '1', name: 'Nut', updatedAt: '2026-04-24T02:00:00.000Z' },
+          ],
+          done: true,
+          nextCursor: null,
+        })
+      },
+    })
+    await hugeOptionHarness.runner.runPipeline({
+      tenantId: 'tenant_1', pipelineId: 'pipe_1', mode: 'incremental', triggeredBy: 'manual',
+    })
+    assert.equal(hugeOptionLimits[0], 10000, 'huge batchSize is capped before adapter read()')
+  }
+
   console.log('✓ pipeline-runner: cleanse/idempotency/incremental E2E tests passed')
 }
 

--- a/plugins/plugin-integration-core/lib/pipeline-runner.cjs
+++ b/plugins/plugin-integration-core/lib/pipeline-runner.cjs
@@ -22,6 +22,10 @@ class PipelineRunnerError extends Error {
 // known truthy variants enable the flag and unknown values fail loudly.
 const TRUE_BOOLEAN_TEXT = new Set(['true', '1', 'yes', 'y', 'on', '是', '启用', '开启'])
 const FALSE_BOOLEAN_TEXT = new Set(['false', '0', 'no', 'n', 'off', '否', '禁用', '关闭'])
+const DEFAULT_BATCH_SIZE = 1000
+const MAX_BATCH_SIZE = 10000
+const DEFAULT_MAX_PAGES = 100
+const MAX_RUN_PAGES = 10000
 
 function coerceTruthyFlag(value, field) {
   if (value === undefined || value === null) return false
@@ -41,6 +45,13 @@ function coerceTruthyFlag(value, field) {
     if (FALSE_BOOLEAN_TEXT.has(normalized)) return false
   }
   throw new PipelineRunnerError(`${field} must be a boolean, 0/1, or boolean-like string`, { field })
+}
+
+function normalizePositiveIntegerOption(value, { defaultValue, max }) {
+  if (value === undefined || value === null || value === '') return defaultValue
+  const numeric = Number(value)
+  if (!Number.isInteger(numeric) || numeric <= 0) return defaultValue
+  return Math.min(numeric, max)
 }
 
 function requireDependency(deps, name, methods) {
@@ -399,15 +410,17 @@ function createPipelineRunner(deps = {}) {
       const currentWatermark = mode === 'incremental'
         ? await watermarkStore.getWatermark(context.pipeline.id)
         : null
-      const batchSize = Number.isInteger(context.pipeline.options?.batchSize)
-        ? context.pipeline.options.batchSize
-        : 1000
+      const batchSize = normalizePositiveIntegerOption(context.pipeline.options?.batchSize, {
+        defaultValue: DEFAULT_BATCH_SIZE,
+        max: MAX_BATCH_SIZE,
+      })
       const effectiveBatchSize = dryRun && Number.isInteger(input.sampleLimit) && input.sampleLimit > 0
         ? Math.min(input.sampleLimit, batchSize)
         : batchSize
-      const maxPages = Number.isInteger(context.pipeline.options?.maxPages)
-        ? context.pipeline.options.maxPages
-        : 100
+      const maxPages = normalizePositiveIntegerOption(context.pipeline.options?.maxPages, {
+        defaultValue: DEFAULT_MAX_PAGES,
+        max: MAX_RUN_PAGES,
+      })
       let cursor = input.cursor || null
       let page = 0
       let lastSuccessfulWatermark = null


### PR DESCRIPTION
## Summary
- normalize pipeline runner batchSize/maxPages with safe defaults and upper bounds
- prevent maxPages=0/negative from producing a silent successful no-op
- cap oversized batchSize before source adapter read()
- add design and verification docs

## Verification
- node plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs
- for f in plugins/plugin-integration-core/__tests__/*.test.cjs; do node ""; done