### PR TITLE
fix(integration): align public run modes with ledger

### DIFF
--- a/docs/development/integration-core-run-mode-contract-fix-design-20260427.md
+++ b/docs/development/integration-core-run-mode-contract-fix-design-20260427.md
@@ -1,8 +1,8 @@
-# Integration-Core Run Mode Contract Fix Development - 2026-04-27
+# Design: Integration-Core Run Mode Contract Fix
 
 ## Context
 
-Post-merge review of `origin/main@f372b9180` found a contract mismatch in the integration pipeline run route:
+Post-merge review after the runner paging-option hardening (`origin/main@fecbb787b`) found a contract mismatch in the integration pipeline run route:
 
 - REST `publicRunInput()` accepted `scheduled` as a public `mode`.
 - The run ledger `normalizeCreateRunInput()` accepts `manual`, `incremental`, `full`, and internal `replay`.

--- a/docs/development/integration-core-run-mode-contract-fix-development-20260427.md
+++ b/docs/development/integration-core-run-mode-contract-fix-development-20260427.md
@@ -1,0 +1,34 @@
+# Integration-Core Run Mode Contract Fix Development - 2026-04-27
+
+## Context
+
+Post-merge review of `origin/main@f372b9180` found a contract mismatch in the integration pipeline run route:
+
+- REST `publicRunInput()` accepted `scheduled` as a public `mode`.
+- The run ledger `normalizeCreateRunInput()` accepts `manual`, `incremental`, `full`, and internal `replay`.
+- `replay` must remain internal-only.
+
+That meant `mode = scheduled` passed the HTTP boundary and then failed later when creating the run. It also meant public `mode = full`, which the run ledger supports, was incorrectly rejected by the HTTP guard.
+
+## Change
+
+The public REST mode allowlist now matches the run-ledger public modes:
+
+- `manual`
+- `incremental`
+- `full`
+
+The route still rejects:
+
+- `replay` because it is internal-only for dead-letter replay.
+- `scheduled` because scheduling is a trigger/source concern, not a run execution mode.
+- unknown or incorrectly cased values.
+
+## Files
+
+- `plugins/plugin-integration-core/lib/http-routes.cjs`
+- `plugins/plugin-integration-core/__tests__/http-routes.test.cjs`
+
+## Notes
+
+No pipeline-runner or DB schema change was needed. This is a REST boundary correction so requests cannot pass a mode that the authoritative run ledger rejects.

--- a/docs/development/integration-core-run-mode-contract-fix-verification-20260427.md
+++ b/docs/development/integration-core-run-mode-contract-fix-verification-20260427.md
@@ -1,0 +1,69 @@
+# Integration-Core Run Mode Contract Fix Verification - 2026-04-27
+
+## Commands
+
+```bash
+node -c plugins/plugin-integration-core/lib/http-routes.cjs
+node -c plugins/plugin-integration-core/lib/pipeline-runner.cjs
+node -c plugins/plugin-integration-core/lib/pipelines.cjs
+node plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+node plugins/plugin-integration-core/__tests__/pipelines.test.cjs
+node plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs
+node plugins/plugin-integration-core/__tests__/external-systems.test.cjs
+node plugins/plugin-integration-core/__tests__/migration-sql.test.cjs
+node plugins/plugin-integration-core/__tests__/runner-support.test.cjs
+```
+
+## Expected Coverage
+
+- `/api/integration/pipelines/:id/run` accepts `manual`, `incremental`, and `full`.
+- `/api/integration/pipelines/:id/run` rejects `replay`, `scheduled`, unknown, and incorrectly cased modes.
+- Empty string remains treated as absent for backwards-compatible form submissions.
+- `/api/integration/pipelines/:id/dry-run` still rejects internal-only `replay`.
+- Existing pipeline registry, runner, external-system, migration SQL, and runner-support tests continue to pass.
+
+## Results
+
+Executed in `/tmp/ms2-main-review-DC7XyQ` on branch `codex/integration-run-mode-contract-fix-20260427`.
+
+Syntax checks:
+
+```text
+node -c plugins/plugin-integration-core/lib/http-routes.cjs
+node -c plugins/plugin-integration-core/lib/pipeline-runner.cjs
+node -c plugins/plugin-integration-core/lib/pipelines.cjs
+```
+
+Focused tests:
+
+```text
+http-routes: REST auth/list/upsert/run/dry-run/replay tests passed
+✓ pipelines: registry + endpoint + field-mapping + run-ledger + concurrent-guard + stale-run-cleanup tests passed
+✓ pipeline-runner: cleanse/idempotency/incremental E2E tests passed
+✓ external-systems: registry + credential boundary tests passed
+✓ migration-sql: 057/058/059 integration migration structure passed
+runner-support: idempotency/watermark/dead-letter/run-log tests passed
+```
+
+Full plugin integration-core regression:
+
+```text
+✓ adapter-contracts: registry + normalizer tests passed
+✓ credential-store: 10 scenarios passed
+✓ db.cjs: all CRUD + boundary + injection tests passed
+✓ e2e-plm-k3wise-writeback: mock PLM → K3 WISE → feedback tests passed
+✓ erp-feedback: normalize + writer tests passed
+✓ external-systems: registry + credential boundary tests passed
+✓ http-adapter: config-driven read/upsert tests passed
+http-routes: REST auth/list/upsert/run/dry-run/replay tests passed
+✓ k3-wise-adapters: WebAPI, SQL Server channel, and auto-flag coercion tests passed
+✓ migration-sql: 057/058/059 integration migration structure passed
+✓ payload-redaction: sensitive key redaction tests passed
+✓ pipeline-runner: cleanse/idempotency/incremental E2E tests passed
+✓ pipelines: registry + endpoint + field-mapping + run-ledger + concurrent-guard + stale-run-cleanup tests passed
+✓ plm-yuantus-wrapper: source facade tests passed
+✓ plugin-runtime-smoke: all assertions passed
+runner-support: idempotency/watermark/dead-letter/run-log tests passed
+✓ staging-installer: all 7 assertions passed
+[pass] transform-validator: transform engine + validator tests passed
+```

--- a/docs/development/integration-core-run-mode-contract-fix-verification-20260427.md
+++ b/docs/development/integration-core-run-mode-contract-fix-verification-20260427.md
@@ -24,7 +24,7 @@ node plugins/plugin-integration-core/__tests__/runner-support.test.cjs
 
 ## Results
 
-Executed in `/tmp/ms2-main-review-DC7XyQ` on branch `codex/integration-run-mode-contract-fix-20260427`.
+Executed in `/tmp/ms2-runmode-contract-refresh` on branch `codex/integration-run-mode-contract-fix-20260427`, after merging `origin/main@fecbb787b`.
 
 Syntax checks:
 

--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -474,8 +474,19 @@ async function testPipelineRoutes() {
   assert.equal(dryRunCall[1].sampleLimit, 2)
   assert.equal(res.body.data.metrics.rowsWritten, 0, 'dry-run response does not report target writes')
 
-  // --- run mode validation: internal-only and unknown modes are rejected ---
-  for (const badMode of ['replay', 'hacker', 'MANUAL', 'Incremental', '']) {
+  // --- run mode validation: only run-ledger modes exposed to users pass ---
+  for (const goodMode of ['manual', 'incremental', 'full']) {
+    const modeRes = await invoke(routes, 'POST', '/api/integration/pipelines/:id/run', {
+      user: WRITE_USER,
+      params: { id: 'pipe_1' },
+      body: { tenantId: 'tenant_1', workspaceId: 'workspace_1', mode: goodMode },
+    })
+    assertOkResponse(modeRes, 202)
+    assert.equal(findCalls(calls, 'runPipeline').at(-1)[1].mode, goodMode)
+  }
+
+  // internal-only, scheduler trigger labels, and unknown modes are rejected
+  for (const badMode of ['replay', 'scheduled', 'hacker', 'MANUAL', 'Incremental', '']) {
     const modeRes = await invoke(routes, 'POST', '/api/integration/pipelines/:id/run', {
       user: WRITE_USER,
       params: { id: 'pipe_1' },

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -168,7 +168,7 @@ function asPositiveInt(value) {
 }
 
 // 'replay' is internal-only: set by replayDeadLetter, not accepted over the API.
-const VALID_USER_RUN_MODES = new Set(['manual', 'incremental', 'scheduled'])
+const VALID_USER_RUN_MODES = new Set(['manual', 'incremental', 'full'])
 
 function asListLimit(value) {
   const n = asPositiveInt(value)


### PR DESCRIPTION
## Summary

Post-merge review found a REST/run-ledger contract mismatch in integration pipeline execution modes.

- REST `publicRunInput()` allowed `scheduled` as a public `mode`.
- The authoritative run ledger accepts `manual`, `incremental`, `full`, and internal `replay`.
- Result: `mode=scheduled` passed the HTTP boundary and failed later when creating the run, while `mode=full` was incorrectly rejected at the HTTP boundary.

This PR aligns the public REST allowlist to `manual`, `incremental`, `full`; `replay` remains internal-only and `scheduled` is treated as a trigger/source concern, not an execution mode.

## Verification

```bash
node -c plugins/plugin-integration-core/lib/http-routes.cjs
node -c plugins/plugin-integration-core/lib/pipeline-runner.cjs
node -c plugins/plugin-integration-core/lib/pipelines.cjs
node plugins/plugin-integration-core/__tests__/http-routes.test.cjs
node plugins/plugin-integration-core/__tests__/pipelines.test.cjs
node plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs
node plugins/plugin-integration-core/__tests__/external-systems.test.cjs
node plugins/plugin-integration-core/__tests__/migration-sql.test.cjs
node plugins/plugin-integration-core/__tests__/runner-support.test.cjs
for f in plugins/plugin-integration-core/__tests__/*.test.cjs; do node "$f" || exit 1; done
```

Full integration-core plugin regression passed locally.

## Docs

- `docs/development/integration-core-run-mode-contract-fix-development-20260427.md`
- `docs/development/integration-core-run-mode-contract-fix-verification-20260427.md`
