### PR TITLE
feat(integration): add K3 WISE setup UI

### DIFF
--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -38,6 +38,7 @@
             <router-link v-if="canManageUsers" to="/admin/permissions" class="nav-link">{{ navLabels.permissions }}</router-link>
             <router-link v-if="canManageUsers" to="/admin/audit" class="nav-link">{{ navLabels.adminAudit }}</router-link>
             <router-link v-if="canManageUsers" to="/approvals/metrics" class="nav-link">{{ navLabels.approvalMetrics }}</router-link>
+            <router-link v-if="isAdmin" to="/integrations/k3-wise" class="nav-link">{{ navLabels.erpIntegration }}</router-link>
             <router-link v-if="isAdmin" to="/admin/plugins" class="nav-link">{{ navLabels.plugins }}</router-link>
             <router-link v-if="canUsePlm" to="/plm" class="nav-link">{{ navLabels.plm }}</router-link>
             <router-link v-if="canUsePlm" to="/plm/audit" class="nav-link">{{ navLabels.audit }}</router-link>
@@ -128,6 +129,7 @@ const navLabels = computed(() => {
       permissions: '权限',
       adminAudit: '管理审计',
       approvalMetrics: '审批 SLA',
+      erpIntegration: 'ERP 对接',
       plugins: '插件',
       plm: 'PLM',
       audit: '审计',
@@ -153,6 +155,7 @@ const navLabels = computed(() => {
     permissions: 'Permissions',
     adminAudit: 'Admin Audit',
     approvalMetrics: 'Approval SLA',
+    erpIntegration: 'ERP Integration',
     plugins: 'Plugins',
     plm: 'PLM',
     audit: 'Audit',

--- a/apps/web/src/router/appRoutes.ts
+++ b/apps/web/src/router/appRoutes.ts
@@ -185,6 +185,12 @@ export const appRoutes: RouteRecordRaw[] = [
     meta: { title: 'Admin Audit', requiresAuth: true }
   },
   {
+    path: '/integrations/k3-wise',
+    name: AppRouteNames.INTEGRATION_K3_WISE,
+    component: () => import('../views/IntegrationK3WiseSetupView.vue'),
+    meta: { title: 'K3 WISE Integration', titleZh: 'K3 WISE 对接', requiresAuth: true }
+  },
+  {
     path: '/workflows',
     name: 'workflow-list',
     component: () => import('../views/WorkflowHubView.vue'),

--- a/apps/web/src/router/types.ts
+++ b/apps/web/src/router/types.ts
@@ -91,6 +91,7 @@ export const AppRouteNames = {
   ADMIN_DASHBOARD: 'admin-dashboard',
   ADMIN_SETTINGS: 'admin-settings',
   ADMIN_LOGS: 'admin-logs',
+  INTEGRATION_K3_WISE: 'integration-k3-wise',
 
   // Error routes
   NOT_FOUND: 'not-found',
@@ -158,6 +159,7 @@ export interface AppRouteParams {
   'admin-dashboard': Record<string, never>
   'admin-settings': Record<string, never>
   'admin-logs': Record<string, never>
+  'integration-k3-wise': Record<string, never>
   'not-found': Record<string, never>
   'forbidden': Record<string, never>
   'server-error': Record<string, never>

--- a/apps/web/src/services/integration/k3WiseSetup.ts
+++ b/apps/web/src/services/integration/k3WiseSetup.ts
@@ -1,0 +1,418 @@
+import { apiFetch } from '../../utils/api'
+
+export type IntegrationSystemStatus = 'active' | 'inactive' | 'error'
+export type K3SqlServerMode = 'readonly' | 'middle-table' | 'stored-procedure'
+
+export interface IntegrationApiEnvelope<T> {
+  ok: boolean
+  data?: T
+  error?: {
+    code?: string
+    message?: string
+    details?: Record<string, unknown>
+  }
+}
+
+export interface IntegrationExternalSystem {
+  id: string
+  tenantId: string
+  workspaceId: string | null
+  projectId?: string | null
+  name: string
+  kind: string
+  role: 'source' | 'target' | 'bidirectional'
+  config: Record<string, unknown>
+  capabilities: Record<string, unknown>
+  status: IntegrationSystemStatus
+  lastTestedAt?: string | null
+  lastError?: string | null
+  hasCredentials?: boolean
+  credentialFingerprint?: string | null
+}
+
+export interface K3WiseSetupForm {
+  tenantId: string
+  workspaceId: string
+  webApiSystemId: string
+  webApiHasCredentials: boolean
+  webApiName: string
+  version: string
+  environment: 'test' | 'uat' | 'staging' | 'production' | 'other'
+  baseUrl: string
+  loginPath: string
+  healthPath: string
+  acctId: string
+  username: string
+  password: string
+  lcid: string
+  timeoutMs: string
+  autoSubmit: boolean
+  autoAudit: boolean
+  materialSavePath: string
+  materialSubmitPath: string
+  materialAuditPath: string
+  bomSavePath: string
+  bomSubmitPath: string
+  bomAuditPath: string
+  sqlEnabled: boolean
+  sqlSystemId: string
+  sqlHasCredentials: boolean
+  sqlName: string
+  sqlMode: K3SqlServerMode
+  sqlServer: string
+  sqlDatabase: string
+  sqlUsername: string
+  sqlPassword: string
+  sqlAllowedTables: string
+  sqlMiddleTables: string
+  sqlStoredProcedures: string
+}
+
+export interface K3WiseSetupPayloads {
+  webApi: Record<string, unknown>
+  sqlServer: Record<string, unknown> | null
+}
+
+export interface K3WiseSetupValidationIssue {
+  field: keyof K3WiseSetupForm | 'form'
+  message: string
+}
+
+const WEBAPI_KIND = 'erp:k3-wise-webapi'
+const SQLSERVER_KIND = 'erp:k3-wise-sqlserver'
+
+function trim(value: string): string {
+  return value.trim()
+}
+
+function optionalString(value: string): string | undefined {
+  const normalized = trim(value)
+  return normalized.length > 0 ? normalized : undefined
+}
+
+export function splitList(value: string): string[] {
+  return value
+    .split(/\r?\n|,/)
+    .map((item) => item.trim())
+    .filter(Boolean)
+}
+
+function parsePositiveInteger(value: string, fallback: number): number {
+  const normalized = trim(value)
+  if (!normalized) return fallback
+  const parsed = Number(normalized)
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback
+}
+
+function assertRelativePath(value: string, field: keyof K3WiseSetupForm, issues: K3WiseSetupValidationIssue[]): void {
+  const normalized = trim(value)
+  if (!normalized) {
+    issues.push({ field, message: `${field} is required` })
+    return
+  }
+  if (/^https?:\/\//i.test(normalized)) {
+    issues.push({ field, message: `${field} must be relative to the K3 WISE base URL` })
+  }
+}
+
+function validateHttpUrl(value: string, field: keyof K3WiseSetupForm, issues: K3WiseSetupValidationIssue[]): void {
+  const normalized = trim(value)
+  if (!normalized) {
+    issues.push({ field, message: `${field} is required` })
+    return
+  }
+  try {
+    const url = new URL(normalized)
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      issues.push({ field, message: `${field} must use http or https` })
+    }
+  } catch {
+    issues.push({ field, message: `${field} must be a valid URL` })
+  }
+}
+
+export function createDefaultK3WiseSetupForm(): K3WiseSetupForm {
+  const tenantId = typeof localStorage === 'undefined' ? '' : localStorage.getItem('tenantId') || ''
+  const workspaceId = typeof localStorage === 'undefined' ? '' : localStorage.getItem('workspaceId') || ''
+  return {
+    tenantId,
+    workspaceId,
+    webApiSystemId: '',
+    webApiHasCredentials: false,
+    webApiName: 'K3 WISE WebAPI',
+    version: '',
+    environment: 'test',
+    baseUrl: '',
+    loginPath: '/K3API/Login',
+    healthPath: '/K3API/Health',
+    acctId: '',
+    username: '',
+    password: '',
+    lcid: '2052',
+    timeoutMs: '30000',
+    autoSubmit: false,
+    autoAudit: false,
+    materialSavePath: '/K3API/Material/Save',
+    materialSubmitPath: '/K3API/Material/Submit',
+    materialAuditPath: '/K3API/Material/Audit',
+    bomSavePath: '/K3API/BOM/Save',
+    bomSubmitPath: '/K3API/BOM/Submit',
+    bomAuditPath: '/K3API/BOM/Audit',
+    sqlEnabled: false,
+    sqlSystemId: '',
+    sqlHasCredentials: false,
+    sqlName: 'K3 WISE SQL Server',
+    sqlMode: 'readonly',
+    sqlServer: '',
+    sqlDatabase: '',
+    sqlUsername: '',
+    sqlPassword: '',
+    sqlAllowedTables: 't_ICItem\nt_ICBOM\nt_ICBomChild',
+    sqlMiddleTables: '',
+    sqlStoredProcedures: '',
+  }
+}
+
+export function validateK3WiseSetupForm(form: K3WiseSetupForm): K3WiseSetupValidationIssue[] {
+  const issues: K3WiseSetupValidationIssue[] = []
+  if (!trim(form.tenantId)) issues.push({ field: 'tenantId', message: 'tenantId is required' })
+  if (!trim(form.webApiName)) issues.push({ field: 'webApiName', message: 'WebAPI system name is required' })
+  if (!trim(form.version)) issues.push({ field: 'version', message: 'K3 WISE version is required' })
+  const webApiCredentialTouched = Boolean(trim(form.username) || trim(form.password) || trim(form.acctId))
+  const webApiCredentialRequired = !form.webApiSystemId || !form.webApiHasCredentials || webApiCredentialTouched
+  if (webApiCredentialRequired && !trim(form.acctId)) issues.push({ field: 'acctId', message: 'acctId is required' })
+  if (webApiCredentialRequired && !trim(form.username)) issues.push({ field: 'username', message: 'K3 WISE username is required' })
+  if (webApiCredentialRequired && !trim(form.password)) {
+    issues.push({ field: 'password', message: 'K3 WISE password is required when credentials are created or replaced' })
+  }
+  validateHttpUrl(form.baseUrl, 'baseUrl', issues)
+  assertRelativePath(form.loginPath, 'loginPath', issues)
+  if (trim(form.healthPath)) assertRelativePath(form.healthPath, 'healthPath', issues)
+  assertRelativePath(form.materialSavePath, 'materialSavePath', issues)
+  assertRelativePath(form.bomSavePath, 'bomSavePath', issues)
+  if (trim(form.materialSubmitPath)) assertRelativePath(form.materialSubmitPath, 'materialSubmitPath', issues)
+  if (trim(form.materialAuditPath)) assertRelativePath(form.materialAuditPath, 'materialAuditPath', issues)
+  if (trim(form.bomSubmitPath)) assertRelativePath(form.bomSubmitPath, 'bomSubmitPath', issues)
+  if (trim(form.bomAuditPath)) assertRelativePath(form.bomAuditPath, 'bomAuditPath', issues)
+  if (form.environment === 'production' && (form.autoSubmit || form.autoAudit)) {
+    issues.push({ field: 'form', message: 'Production auto-submit/audit requires a separate approval policy' })
+  }
+  if (form.sqlEnabled) {
+    if (!trim(form.sqlName)) issues.push({ field: 'sqlName', message: 'SQL Server system name is required' })
+    if (!trim(form.sqlServer)) issues.push({ field: 'sqlServer', message: 'SQL Server host is required' })
+    if (!trim(form.sqlDatabase)) issues.push({ field: 'sqlDatabase', message: 'SQL Server database is required' })
+    if (splitList(form.sqlAllowedTables).length === 0) {
+      issues.push({ field: 'sqlAllowedTables', message: 'At least one SQL Server table must be allowed' })
+    }
+    const sqlCredentialTouched = Boolean(trim(form.sqlUsername) || trim(form.sqlPassword))
+    if (sqlCredentialTouched && (!trim(form.sqlUsername) || !trim(form.sqlPassword))) {
+      issues.push({ field: 'sqlPassword', message: 'SQL Server credentials must include both username and password' })
+    }
+  }
+  return issues
+}
+
+export function buildK3WiseSetupPayloads(form: K3WiseSetupForm): K3WiseSetupPayloads {
+  const workspaceId = optionalString(form.workspaceId) ?? null
+  const baseSystem = {
+    tenantId: trim(form.tenantId),
+    workspaceId,
+    status: 'active',
+  }
+  const webApiCredentials: Record<string, unknown> = {}
+  if (trim(form.username) || trim(form.acctId) || trim(form.password)) {
+    webApiCredentials.username = trim(form.username)
+    webApiCredentials.acctId = trim(form.acctId)
+    webApiCredentials.password = form.password
+  }
+  const webApi = {
+    ...baseSystem,
+    ...(optionalString(form.webApiSystemId) ? { id: trim(form.webApiSystemId) } : {}),
+    name: trim(form.webApiName),
+    kind: WEBAPI_KIND,
+    role: 'target',
+    config: {
+      version: trim(form.version),
+      environment: form.environment,
+      baseUrl: trim(form.baseUrl),
+      loginPath: trim(form.loginPath),
+      ...(optionalString(form.healthPath) ? { healthPath: trim(form.healthPath) } : {}),
+      lcid: parsePositiveInteger(form.lcid, 2052),
+      timeoutMs: parsePositiveInteger(form.timeoutMs, 30000),
+      autoSubmit: form.autoSubmit,
+      autoAudit: form.autoAudit,
+      objects: {
+        material: {
+          savePath: trim(form.materialSavePath),
+          ...(optionalString(form.materialSubmitPath) ? { submitPath: trim(form.materialSubmitPath) } : {}),
+          ...(optionalString(form.materialAuditPath) ? { auditPath: trim(form.materialAuditPath) } : {}),
+          keyField: 'FNumber',
+        },
+        bom: {
+          savePath: trim(form.bomSavePath),
+          ...(optionalString(form.bomSubmitPath) ? { submitPath: trim(form.bomSubmitPath) } : {}),
+          ...(optionalString(form.bomAuditPath) ? { auditPath: trim(form.bomAuditPath) } : {}),
+          keyField: 'FNumber',
+        },
+      },
+    },
+    ...(Object.keys(webApiCredentials).length > 0 ? { credentials: webApiCredentials } : {}),
+    capabilities: {
+      write: true,
+      material: true,
+      bom: true,
+    },
+  }
+
+  if (!form.sqlEnabled) {
+    return { webApi, sqlServer: null }
+  }
+
+  const allowedTables = splitList(form.sqlAllowedTables)
+  const middleTables = splitList(form.sqlMiddleTables)
+  const storedProcedures = splitList(form.sqlStoredProcedures)
+  const sqlCredentials: Record<string, unknown> = {}
+  if (trim(form.sqlUsername)) sqlCredentials.username = trim(form.sqlUsername)
+  if (trim(form.sqlPassword)) sqlCredentials.password = form.sqlPassword
+  const sqlServer = {
+    ...baseSystem,
+    ...(optionalString(form.sqlSystemId) ? { id: trim(form.sqlSystemId) } : {}),
+    name: trim(form.sqlName),
+    kind: SQLSERVER_KIND,
+    role: 'bidirectional',
+    config: {
+      mode: form.sqlMode,
+      server: trim(form.sqlServer),
+      database: trim(form.sqlDatabase),
+      allowedTables,
+      middleTables,
+      storedProcedures,
+      readTables: allowedTables,
+      writeTables: middleTables,
+      objects: {
+        material: {
+          table: allowedTables[0] || 't_ICItem',
+          operations: ['read'],
+          columns: ['FItemID', 'FNumber', 'FName', 'FModel'],
+        },
+        bom: {
+          table: allowedTables.find((table) => /t_ICBOM$/i.test(table)) || 't_ICBOM',
+          operations: ['read'],
+        },
+        bom_child: {
+          table: allowedTables.find((table) => /t_ICBomChild$/i.test(table)) || 't_ICBomChild',
+          operations: ['read'],
+        },
+        ...(middleTables[0]
+          ? {
+              material_stage: {
+                table: middleTables[0],
+                operations: ['upsert'],
+                writeMode: 'middle-table',
+                keyField: 'FNumber',
+              },
+            }
+          : {}),
+      },
+    },
+    ...(Object.keys(sqlCredentials).length > 0 ? { credentials: sqlCredentials } : {}),
+    capabilities: {
+      read: true,
+      write: middleTables.length > 0,
+      sqlServer: true,
+    },
+  }
+
+  return { webApi, sqlServer }
+}
+
+export function applyExternalSystemToForm(form: K3WiseSetupForm, system: IntegrationExternalSystem): K3WiseSetupForm {
+  const next = { ...form }
+  if (system.kind === WEBAPI_KIND) {
+    const config = system.config || {}
+    const objects = (config.objects && typeof config.objects === 'object' ? config.objects : {}) as Record<string, Record<string, unknown>>
+    const material = objects.material || {}
+    const bom = objects.bom || {}
+    next.webApiSystemId = system.id
+    next.webApiHasCredentials = system.hasCredentials === true
+    next.tenantId = system.tenantId || next.tenantId
+    next.workspaceId = system.workspaceId || ''
+    next.webApiName = system.name
+    next.version = typeof config.version === 'string' ? config.version : next.version
+    next.environment = typeof config.environment === 'string' ? config.environment as K3WiseSetupForm['environment'] : next.environment
+    next.baseUrl = typeof config.baseUrl === 'string' ? config.baseUrl : next.baseUrl
+    next.loginPath = typeof config.loginPath === 'string' ? config.loginPath : next.loginPath
+    next.healthPath = typeof config.healthPath === 'string' ? config.healthPath : next.healthPath
+    next.lcid = config.lcid === undefined ? next.lcid : String(config.lcid)
+    next.timeoutMs = config.timeoutMs === undefined ? next.timeoutMs : String(config.timeoutMs)
+    next.autoSubmit = config.autoSubmit === true
+    next.autoAudit = config.autoAudit === true
+    next.materialSavePath = typeof material.savePath === 'string' ? material.savePath : next.materialSavePath
+    next.materialSubmitPath = typeof material.submitPath === 'string' ? material.submitPath : next.materialSubmitPath
+    next.materialAuditPath = typeof material.auditPath === 'string' ? material.auditPath : next.materialAuditPath
+    next.bomSavePath = typeof bom.savePath === 'string' ? bom.savePath : next.bomSavePath
+    next.bomSubmitPath = typeof bom.submitPath === 'string' ? bom.submitPath : next.bomSubmitPath
+    next.bomAuditPath = typeof bom.auditPath === 'string' ? bom.auditPath : next.bomAuditPath
+  }
+  if (system.kind === SQLSERVER_KIND) {
+    const config = system.config || {}
+    next.sqlEnabled = true
+    next.sqlSystemId = system.id
+    next.sqlHasCredentials = system.hasCredentials === true
+    next.tenantId = system.tenantId || next.tenantId
+    next.workspaceId = system.workspaceId || ''
+    next.sqlName = system.name
+    next.sqlMode = typeof config.mode === 'string' ? config.mode as K3SqlServerMode : next.sqlMode
+    next.sqlServer = typeof config.server === 'string' ? config.server : next.sqlServer
+    next.sqlDatabase = typeof config.database === 'string' ? config.database : next.sqlDatabase
+    next.sqlAllowedTables = Array.isArray(config.allowedTables) ? config.allowedTables.join('\n') : next.sqlAllowedTables
+    next.sqlMiddleTables = Array.isArray(config.middleTables) ? config.middleTables.join('\n') : next.sqlMiddleTables
+    next.sqlStoredProcedures = Array.isArray(config.storedProcedures) ? config.storedProcedures.join('\n') : next.sqlStoredProcedures
+  }
+  return next
+}
+
+async function parseIntegrationResponse<T>(response: Response): Promise<T> {
+  let payload: IntegrationApiEnvelope<T> | null = null
+  try {
+    payload = await response.json() as IntegrationApiEnvelope<T>
+  } catch {
+    payload = null
+  }
+  if (!response.ok || payload?.ok === false) {
+    const message = payload?.error?.message || `${response.status} ${response.statusText}`.trim()
+    throw new Error(message || 'Integration API request failed')
+  }
+  return payload?.data as T
+}
+
+export async function listIntegrationSystems(
+  kind: string,
+  scope: { tenantId?: string; workspaceId?: string | null } = {},
+): Promise<IntegrationExternalSystem[]> {
+  const params = new URLSearchParams({ kind })
+  if (scope.tenantId && scope.tenantId.trim()) params.set('tenantId', scope.tenantId.trim())
+  if (scope.workspaceId && scope.workspaceId.trim()) params.set('workspaceId', scope.workspaceId.trim())
+  const response = await apiFetch(`/api/integration/external-systems?${params.toString()}`)
+  const data = await parseIntegrationResponse<IntegrationExternalSystem[]>(response)
+  return Array.isArray(data) ? data : []
+}
+
+export async function upsertIntegrationSystem(payload: Record<string, unknown>): Promise<IntegrationExternalSystem> {
+  const response = await apiFetch('/api/integration/external-systems', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  })
+  return parseIntegrationResponse<IntegrationExternalSystem>(response)
+}
+
+export async function testIntegrationSystem(systemId: string, input: Record<string, unknown> = {}): Promise<Record<string, unknown>> {
+  const response = await apiFetch(`/api/integration/external-systems/${encodeURIComponent(systemId)}/test`, {
+    method: 'POST',
+    body: JSON.stringify(input),
+  })
+  return parseIntegrationResponse<Record<string, unknown>>(response)
+}
+
+export const K3_WISE_WEBAPI_KIND = WEBAPI_KIND
+export const K3_WISE_SQLSERVER_KIND = SQLSERVER_KIND

--- a/apps/web/src/views/IntegrationK3WiseSetupView.vue
+++ b/apps/web/src/views/IntegrationK3WiseSetupView.vue
@@ -1,0 +1,656 @@
+<template>
+  <section class="k3-setup" data-testid="k3-wise-setup">
+    <header class="k3-setup__header">
+      <div>
+        <p class="k3-setup__eyebrow">ERP Integration</p>
+        <h1>K3 WISE 对接配置</h1>
+        <p class="k3-setup__lead">维护 WebAPI、账套、凭据和 SQL Server 通道信息。</p>
+      </div>
+      <div class="k3-setup__header-actions">
+        <button class="k3-setup__btn" type="button" :disabled="loading" @click="loadSystems">
+          {{ loading ? '刷新中' : '刷新' }}
+        </button>
+        <button class="k3-setup__btn k3-setup__btn--primary" type="button" :disabled="saving" @click="saveConfiguration">
+          {{ saving ? '保存中' : '保存配置' }}
+        </button>
+      </div>
+    </header>
+
+    <p v-if="statusMessage" class="k3-setup__status" :data-kind="statusKind">{{ statusMessage }}</p>
+
+    <section class="k3-setup__layout">
+      <aside class="k3-setup__rail">
+        <div class="k3-setup__panel">
+          <div class="k3-setup__panel-head">
+            <h2>已保存系统</h2>
+            <span>{{ webApiSystems.length + sqlSystems.length }}</span>
+          </div>
+          <div v-if="loading" class="k3-setup__empty">Loading...</div>
+          <div v-else-if="webApiSystems.length + sqlSystems.length === 0" class="k3-setup__empty">暂无 K3 WISE 系统。</div>
+          <div v-else class="k3-setup__saved-list">
+            <button
+              v-for="system in savedSystems"
+              :key="system.id"
+              class="k3-setup__saved"
+              type="button"
+              @click="loadSystemIntoForm(system)"
+            >
+              <span>{{ system.name }}</span>
+              <small>{{ system.kind }} · {{ system.status }}</small>
+            </button>
+          </div>
+        </div>
+
+        <div class="k3-setup__panel">
+          <div class="k3-setup__panel-head">
+            <h2>连接测试</h2>
+          </div>
+          <button class="k3-setup__btn k3-setup__btn--full" type="button" :disabled="testingWebApi || !form.webApiSystemId" @click="testWebApi">
+            {{ testingWebApi ? '测试中' : '测试 WebAPI' }}
+          </button>
+          <button class="k3-setup__btn k3-setup__btn--full" type="button" :disabled="testingSql || !form.sqlSystemId" @click="testSqlServer">
+            {{ testingSql ? '测试中' : '测试 SQL Server' }}
+          </button>
+          <pre v-if="testResult" class="k3-setup__test-result">{{ testResult }}</pre>
+        </div>
+      </aside>
+
+      <form class="k3-setup__form" @submit.prevent="saveConfiguration">
+        <section class="k3-setup__section">
+          <div class="k3-setup__section-head">
+            <h2>作用域</h2>
+            <span>tenant / workspace</span>
+          </div>
+          <div class="k3-setup__grid">
+            <label class="k3-setup__field">
+              <span>Tenant ID</span>
+              <input v-model.trim="form.tenantId" autocomplete="off" />
+            </label>
+            <label class="k3-setup__field">
+              <span>Workspace ID</span>
+              <input v-model.trim="form.workspaceId" autocomplete="off" />
+            </label>
+          </div>
+        </section>
+
+        <section class="k3-setup__section">
+          <div class="k3-setup__section-head">
+            <h2>K3 WISE WebAPI</h2>
+            <span>{{ form.webApiSystemId ? '编辑现有系统' : '新建系统' }}</span>
+          </div>
+          <div class="k3-setup__grid">
+            <label class="k3-setup__field">
+              <span>名称</span>
+              <input v-model.trim="form.webApiName" autocomplete="off" />
+            </label>
+            <label class="k3-setup__field">
+              <span>K3 WISE 版本</span>
+              <input v-model.trim="form.version" placeholder="K3 WISE 15.x test" autocomplete="off" />
+            </label>
+            <label class="k3-setup__field">
+              <span>环境</span>
+              <select v-model="form.environment">
+                <option value="test">test</option>
+                <option value="uat">uat</option>
+                <option value="staging">staging</option>
+                <option value="production">production</option>
+                <option value="other">other</option>
+              </select>
+            </label>
+            <label class="k3-setup__field k3-setup__field--wide">
+              <span>WebAPI Base URL</span>
+              <input v-model.trim="form.baseUrl" placeholder="https://k3.example.test/K3API/" autocomplete="off" />
+            </label>
+            <label class="k3-setup__field">
+              <span>Login Path</span>
+              <input v-model.trim="form.loginPath" autocomplete="off" />
+            </label>
+            <label class="k3-setup__field">
+              <span>Health Path</span>
+              <input v-model.trim="form.healthPath" autocomplete="off" />
+            </label>
+            <label class="k3-setup__field">
+              <span>LCID</span>
+              <input v-model.trim="form.lcid" inputmode="numeric" autocomplete="off" />
+            </label>
+            <label class="k3-setup__field">
+              <span>Timeout ms</span>
+              <input v-model.trim="form.timeoutMs" inputmode="numeric" autocomplete="off" />
+            </label>
+          </div>
+        </section>
+
+        <section class="k3-setup__section">
+          <div class="k3-setup__section-head">
+            <h2>WebAPI 凭据</h2>
+            <span>{{ form.webApiHasCredentials ? '已有凭据，留空则保留' : '需要填写' }}</span>
+          </div>
+          <div class="k3-setup__grid">
+            <label class="k3-setup__field">
+              <span>Acct ID</span>
+              <input v-model.trim="form.acctId" autocomplete="off" />
+            </label>
+            <label class="k3-setup__field">
+              <span>用户名</span>
+              <input v-model.trim="form.username" autocomplete="off" />
+            </label>
+            <label class="k3-setup__field">
+              <span>密码</span>
+              <input v-model="form.password" type="password" autocomplete="new-password" />
+            </label>
+            <label class="k3-setup__check">
+              <input v-model="form.autoSubmit" type="checkbox" />
+              <span>Save 后自动 Submit</span>
+            </label>
+            <label class="k3-setup__check">
+              <input v-model="form.autoAudit" type="checkbox" />
+              <span>Submit 后自动 Audit</span>
+            </label>
+          </div>
+        </section>
+
+        <section class="k3-setup__section">
+          <div class="k3-setup__section-head">
+            <h2>物料 / BOM 接口</h2>
+            <span>relative paths</span>
+          </div>
+          <div class="k3-setup__grid">
+            <label class="k3-setup__field">
+              <span>Material Save</span>
+              <input v-model.trim="form.materialSavePath" autocomplete="off" />
+            </label>
+            <label class="k3-setup__field">
+              <span>Material Submit</span>
+              <input v-model.trim="form.materialSubmitPath" autocomplete="off" />
+            </label>
+            <label class="k3-setup__field">
+              <span>Material Audit</span>
+              <input v-model.trim="form.materialAuditPath" autocomplete="off" />
+            </label>
+            <label class="k3-setup__field">
+              <span>BOM Save</span>
+              <input v-model.trim="form.bomSavePath" autocomplete="off" />
+            </label>
+            <label class="k3-setup__field">
+              <span>BOM Submit</span>
+              <input v-model.trim="form.bomSubmitPath" autocomplete="off" />
+            </label>
+            <label class="k3-setup__field">
+              <span>BOM Audit</span>
+              <input v-model.trim="form.bomAuditPath" autocomplete="off" />
+            </label>
+          </div>
+        </section>
+
+        <section class="k3-setup__section">
+          <div class="k3-setup__section-head">
+            <h2>SQL Server 通道</h2>
+            <label class="k3-setup__switch">
+              <input v-model="form.sqlEnabled" type="checkbox" />
+              <span>{{ form.sqlEnabled ? '启用' : '关闭' }}</span>
+            </label>
+          </div>
+          <div v-if="form.sqlEnabled" class="k3-setup__grid">
+            <label class="k3-setup__field">
+              <span>名称</span>
+              <input v-model.trim="form.sqlName" autocomplete="off" />
+            </label>
+            <label class="k3-setup__field">
+              <span>模式</span>
+              <select v-model="form.sqlMode">
+                <option value="readonly">readonly</option>
+                <option value="middle-table">middle-table</option>
+                <option value="stored-procedure">stored-procedure</option>
+              </select>
+            </label>
+            <label class="k3-setup__field">
+              <span>Server</span>
+              <input v-model.trim="form.sqlServer" autocomplete="off" />
+            </label>
+            <label class="k3-setup__field">
+              <span>Database</span>
+              <input v-model.trim="form.sqlDatabase" autocomplete="off" />
+            </label>
+            <label class="k3-setup__field">
+              <span>SQL 用户名</span>
+              <input v-model.trim="form.sqlUsername" autocomplete="off" />
+            </label>
+            <label class="k3-setup__field">
+              <span>SQL 密码</span>
+              <input v-model="form.sqlPassword" type="password" autocomplete="new-password" />
+            </label>
+            <label class="k3-setup__field k3-setup__field--wide">
+              <span>允许读取表</span>
+              <textarea v-model="form.sqlAllowedTables" rows="4" spellcheck="false" />
+            </label>
+            <label class="k3-setup__field">
+              <span>中间表</span>
+              <textarea v-model="form.sqlMiddleTables" rows="4" spellcheck="false" />
+            </label>
+            <label class="k3-setup__field">
+              <span>存储过程</span>
+              <textarea v-model="form.sqlStoredProcedures" rows="4" spellcheck="false" />
+            </label>
+          </div>
+        </section>
+
+        <section v-if="validationIssues.length" class="k3-setup__section k3-setup__section--issues">
+          <div class="k3-setup__section-head">
+            <h2>待补字段</h2>
+            <span>{{ validationIssues.length }}</span>
+          </div>
+          <ul class="k3-setup__issues">
+            <li v-for="issue in validationIssues" :key="`${issue.field}:${issue.message}`">
+              {{ issue.message }}
+            </li>
+          </ul>
+        </section>
+      </form>
+    </section>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, reactive, ref } from 'vue'
+import {
+  K3_WISE_SQLSERVER_KIND,
+  K3_WISE_WEBAPI_KIND,
+  applyExternalSystemToForm,
+  buildK3WiseSetupPayloads,
+  createDefaultK3WiseSetupForm,
+  listIntegrationSystems,
+  testIntegrationSystem,
+  upsertIntegrationSystem,
+  validateK3WiseSetupForm,
+  type IntegrationExternalSystem,
+} from '../services/integration/k3WiseSetup'
+
+const form = reactive(createDefaultK3WiseSetupForm())
+const webApiSystems = ref<IntegrationExternalSystem[]>([])
+const sqlSystems = ref<IntegrationExternalSystem[]>([])
+const loading = ref(false)
+const saving = ref(false)
+const testingWebApi = ref(false)
+const testingSql = ref(false)
+const statusMessage = ref('')
+const statusKind = ref<'info' | 'success' | 'error'>('info')
+const testResult = ref('')
+
+const savedSystems = computed(() => [...webApiSystems.value, ...sqlSystems.value])
+const validationIssues = computed(() => validateK3WiseSetupForm(form))
+
+function setStatus(message: string, kind: 'info' | 'success' | 'error' = 'info'): void {
+  statusMessage.value = message
+  statusKind.value = kind
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function loadSystemIntoForm(system: IntegrationExternalSystem): void {
+  Object.assign(form, applyExternalSystemToForm(form, system))
+  testResult.value = ''
+  setStatus(`已载入 ${system.name}`, 'info')
+}
+
+async function loadSystems(): Promise<void> {
+  loading.value = true
+  try {
+    const [webApi, sql] = await Promise.all([
+      listIntegrationSystems(K3_WISE_WEBAPI_KIND, form),
+      listIntegrationSystems(K3_WISE_SQLSERVER_KIND, form),
+    ])
+    webApiSystems.value = webApi
+    sqlSystems.value = sql
+    if (!form.webApiSystemId && webApi[0]) loadSystemIntoForm(webApi[0])
+    if (!form.sqlSystemId && sql[0]) loadSystemIntoForm(sql[0])
+    setStatus('K3 WISE 配置已刷新', 'success')
+  } catch (error) {
+    setStatus(formatError(error), 'error')
+  } finally {
+    loading.value = false
+  }
+}
+
+async function saveConfiguration(): Promise<void> {
+  const issues = validateK3WiseSetupForm(form)
+  if (issues.length > 0) {
+    setStatus(issues[0].message, 'error')
+    return
+  }
+  saving.value = true
+  try {
+    const payloads = buildK3WiseSetupPayloads(form)
+    const webApi = await upsertIntegrationSystem(payloads.webApi)
+    form.webApiSystemId = webApi.id
+    form.webApiHasCredentials = webApi.hasCredentials === true
+    if (payloads.sqlServer) {
+      const sql = await upsertIntegrationSystem(payloads.sqlServer)
+      form.sqlSystemId = sql.id
+      form.sqlHasCredentials = sql.hasCredentials === true
+    }
+    await loadSystems()
+    setStatus('K3 WISE 对接配置已保存', 'success')
+  } catch (error) {
+    setStatus(formatError(error), 'error')
+  } finally {
+    saving.value = false
+  }
+}
+
+async function testWebApi(): Promise<void> {
+  if (!form.webApiSystemId) return
+  testingWebApi.value = true
+  testResult.value = ''
+  try {
+    const result = await testIntegrationSystem(form.webApiSystemId, { skipHealth: !form.healthPath.trim() })
+    testResult.value = JSON.stringify(result, null, 2)
+    setStatus('WebAPI 连接测试完成', 'success')
+  } catch (error) {
+    setStatus(formatError(error), 'error')
+  } finally {
+    testingWebApi.value = false
+  }
+}
+
+async function testSqlServer(): Promise<void> {
+  if (!form.sqlSystemId) return
+  testingSql.value = true
+  testResult.value = ''
+  try {
+    const result = await testIntegrationSystem(form.sqlSystemId)
+    testResult.value = JSON.stringify(result, null, 2)
+    setStatus('SQL Server 通道测试完成', 'success')
+  } catch (error) {
+    setStatus(formatError(error), 'error')
+  } finally {
+    testingSql.value = false
+  }
+}
+
+onMounted(() => {
+  void loadSystems()
+})
+</script>
+
+<style scoped>
+.k3-setup {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-height: 100%;
+  padding: 24px;
+  background: #f6f8fb;
+  color: #172033;
+}
+
+.k3-setup__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 20px;
+  align-items: flex-start;
+  padding-bottom: 16px;
+  border-bottom: 1px solid #d9e1ec;
+}
+
+.k3-setup__eyebrow {
+  margin: 0 0 4px;
+  color: #64748b;
+  font-size: 12px;
+  text-transform: uppercase;
+}
+
+.k3-setup__header h1 {
+  margin: 0;
+  font-size: 28px;
+  line-height: 1.2;
+  color: #111827;
+}
+
+.k3-setup__lead {
+  margin: 8px 0 0;
+  color: #526072;
+}
+
+.k3-setup__header-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.k3-setup__layout {
+  display: grid;
+  grid-template-columns: minmax(240px, 320px) minmax(0, 1fr);
+  gap: 16px;
+  align-items: start;
+}
+
+.k3-setup__rail,
+.k3-setup__form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.k3-setup__panel,
+.k3-setup__section {
+  padding: 16px;
+  border: 1px solid #d9e1ec;
+  border-radius: 8px;
+  background: #fff;
+}
+
+.k3-setup__panel-head,
+.k3-setup__section-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: center;
+  margin-bottom: 14px;
+}
+
+.k3-setup__panel-head h2,
+.k3-setup__section-head h2 {
+  margin: 0;
+  font-size: 16px;
+  line-height: 1.3;
+  color: #111827;
+}
+
+.k3-setup__panel-head span,
+.k3-setup__section-head span {
+  color: #64748b;
+  font-size: 12px;
+}
+
+.k3-setup__grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(180px, 1fr));
+  gap: 14px;
+}
+
+.k3-setup__field,
+.k3-setup__check,
+.k3-setup__switch {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
+.k3-setup__field--wide {
+  grid-column: span 2;
+}
+
+.k3-setup__field span,
+.k3-setup__check span,
+.k3-setup__switch span {
+  color: #334155;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.k3-setup__field input,
+.k3-setup__field select,
+.k3-setup__field textarea {
+  width: 100%;
+  min-width: 0;
+  border: 1px solid #cbd5e1;
+  border-radius: 6px;
+  padding: 9px 10px;
+  background: #fff;
+  color: #111827;
+  font: inherit;
+}
+
+.k3-setup__field textarea {
+  resize: vertical;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 13px;
+}
+
+.k3-setup__check,
+.k3-setup__switch {
+  flex-direction: row;
+  align-items: center;
+  min-height: 38px;
+}
+
+.k3-setup__check input,
+.k3-setup__switch input {
+  width: 16px;
+  height: 16px;
+}
+
+.k3-setup__btn {
+  border: 1px solid #cbd5e1;
+  border-radius: 6px;
+  padding: 9px 12px;
+  background: #fff;
+  color: #172033;
+  font: inherit;
+  cursor: pointer;
+}
+
+.k3-setup__btn--primary {
+  border-color: #0f766e;
+  background: #0f766e;
+  color: #fff;
+}
+
+.k3-setup__btn--full {
+  width: 100%;
+  margin-top: 8px;
+}
+
+.k3-setup__btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.k3-setup__status {
+  margin: 0;
+  padding: 10px 12px;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  background: #fff;
+}
+
+.k3-setup__status[data-kind="success"] {
+  border-color: #99f6e4;
+  background: #f0fdfa;
+  color: #115e59;
+}
+
+.k3-setup__status[data-kind="error"] {
+  border-color: #fecaca;
+  background: #fff1f2;
+  color: #9f1239;
+}
+
+.k3-setup__saved-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.k3-setup__saved {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  width: 100%;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  padding: 10px;
+  background: #f8fafc;
+  color: #172033;
+  text-align: left;
+  cursor: pointer;
+}
+
+.k3-setup__saved small {
+  color: #64748b;
+}
+
+.k3-setup__empty {
+  color: #64748b;
+}
+
+.k3-setup__test-result {
+  overflow: auto;
+  max-height: 260px;
+  margin: 12px 0 0;
+  padding: 10px;
+  border-radius: 6px;
+  background: #0f172a;
+  color: #e2e8f0;
+  font-size: 12px;
+}
+
+.k3-setup__section--issues {
+  border-color: #fed7aa;
+  background: #fff7ed;
+}
+
+.k3-setup__issues {
+  margin: 0;
+  padding-left: 18px;
+  color: #9a3412;
+}
+
+@media (max-width: 1100px) {
+  .k3-setup__layout {
+    grid-template-columns: 1fr;
+  }
+
+  .k3-setup__rail {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 760px) {
+  .k3-setup {
+    padding: 16px;
+  }
+
+  .k3-setup__header {
+    flex-direction: column;
+  }
+
+  .k3-setup__header-actions,
+  .k3-setup__rail {
+    display: flex;
+  }
+
+  .k3-setup__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .k3-setup__field--wide {
+    grid-column: auto;
+  }
+}
+</style>

--- a/apps/web/tests/k3WiseSetup.spec.ts
+++ b/apps/web/tests/k3WiseSetup.spec.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest'
+import {
+  applyExternalSystemToForm,
+  buildK3WiseSetupPayloads,
+  createDefaultK3WiseSetupForm,
+  splitList,
+  validateK3WiseSetupForm,
+  type IntegrationExternalSystem,
+} from '../src/services/integration/k3WiseSetup'
+
+describe('K3 WISE setup helpers', () => {
+  it('builds WebAPI and SQL Server external-system payloads from the setup form', () => {
+    const form = createDefaultK3WiseSetupForm()
+    Object.assign(form, {
+      tenantId: 'tenant_1',
+      workspaceId: 'workspace_1',
+      webApiName: 'K3 WISE WebAPI',
+      version: 'K3 WISE 15.x test',
+      baseUrl: 'https://k3.example.test/K3API/',
+      acctId: 'AIS_TEST',
+      username: 'k3-user',
+      password: 'secret',
+      sqlEnabled: true,
+      sqlServer: '10.0.0.10',
+      sqlDatabase: 'AIS_TEST',
+      sqlAllowedTables: 'dbo.t_ICItem\ndbo.t_ICBOM, dbo.t_ICBomChild',
+      sqlMiddleTables: 'dbo.integration_material_stage',
+    })
+
+    expect(validateK3WiseSetupForm(form)).toEqual([])
+    const payloads = buildK3WiseSetupPayloads(form)
+
+    expect(payloads.webApi).toMatchObject({
+      tenantId: 'tenant_1',
+      workspaceId: 'workspace_1',
+      kind: 'erp:k3-wise-webapi',
+      role: 'target',
+      credentials: {
+        username: 'k3-user',
+        password: 'secret',
+        acctId: 'AIS_TEST',
+      },
+      config: {
+        baseUrl: 'https://k3.example.test/K3API/',
+        autoSubmit: false,
+        autoAudit: false,
+      },
+    })
+    expect(payloads.sqlServer).toMatchObject({
+      kind: 'erp:k3-wise-sqlserver',
+      role: 'bidirectional',
+      config: {
+        allowedTables: ['dbo.t_ICItem', 'dbo.t_ICBOM', 'dbo.t_ICBomChild'],
+        middleTables: ['dbo.integration_material_stage'],
+      },
+    })
+  })
+
+  it('preserves existing credential storage when editing without replacement fields', () => {
+    const form = createDefaultK3WiseSetupForm()
+    Object.assign(form, {
+      tenantId: 'tenant_1',
+      webApiSystemId: 'sys_1',
+      webApiHasCredentials: true,
+      webApiName: 'K3 WISE WebAPI',
+      version: 'K3 WISE 15.x test',
+      baseUrl: 'https://k3.example.test/K3API/',
+      username: '',
+      password: '',
+      acctId: '',
+    })
+
+    expect(validateK3WiseSetupForm(form)).toEqual([])
+    const payloads = buildK3WiseSetupPayloads(form)
+
+    expect(payloads.webApi).toMatchObject({
+      id: 'sys_1',
+      kind: 'erp:k3-wise-webapi',
+    })
+    expect(payloads.webApi).not.toHaveProperty('credentials')
+  })
+
+  it('loads public external-system config without exposing credentials', () => {
+    const form = createDefaultK3WiseSetupForm()
+    const system: IntegrationExternalSystem = {
+      id: 'sys_1',
+      tenantId: 'tenant_1',
+      workspaceId: null,
+      name: 'K3 loaded',
+      kind: 'erp:k3-wise-webapi',
+      role: 'target',
+      status: 'active',
+      hasCredentials: true,
+      config: {
+        version: 'K3 WISE 15.x',
+        environment: 'uat',
+        baseUrl: 'https://k3.example.test/',
+        loginPath: '/login',
+        objects: {
+          material: { savePath: '/material/save' },
+          bom: { savePath: '/bom/save' },
+        },
+      },
+      capabilities: {},
+    }
+
+    const next = applyExternalSystemToForm(form, system)
+
+    expect(next.webApiSystemId).toBe('sys_1')
+    expect(next.webApiHasCredentials).toBe(true)
+    expect(next.baseUrl).toBe('https://k3.example.test/')
+    expect(next.password).toBe('')
+  })
+
+  it('validates absolute endpoint paths and incomplete credential replacement', () => {
+    const form = createDefaultK3WiseSetupForm()
+    Object.assign(form, {
+      tenantId: 'tenant_1',
+      webApiSystemId: 'sys_1',
+      webApiHasCredentials: true,
+      webApiName: 'K3 WISE WebAPI',
+      version: 'K3 WISE 15.x test',
+      baseUrl: 'https://k3.example.test/K3API/',
+      username: 'new-user',
+      password: '',
+      acctId: 'AIS_TEST',
+      materialSavePath: 'https://evil.example/save',
+    })
+
+    const messages = validateK3WiseSetupForm(form).map((issue) => issue.message)
+    expect(messages).toContain('K3 WISE password is required when credentials are created or replaced')
+    expect(messages).toContain('materialSavePath must be relative to the K3 WISE base URL')
+  })
+
+  it('splits comma and newline table lists', () => {
+    expect(splitList('t_ICItem, t_ICBOM\n t_ICBomChild')).toEqual(['t_ICItem', 't_ICBOM', 't_ICBomChild'])
+  })
+})

--- a/docs/development/integration-k3wise-setup-ui-design-20260428.md
+++ b/docs/development/integration-k3wise-setup-ui-design-20260428.md
@@ -1,0 +1,68 @@
+# K3 WISE Setup UI Design - 2026-04-28
+
+## Goal
+
+Add an operator-facing ERP/K3 WISE setup page so admins can enter the information currently collected through the K3 WISE GATE packet:
+
+- MetaSheet tenant/workspace scope.
+- K3 WISE WebAPI URL, version, environment, endpoint paths, and Save/Submit/Audit flags.
+- K3 WISE credential fields: username, password, acctId.
+- Optional SQL Server channel metadata: server, database, read allowlist, middle tables, stored procedures, and optional SQL credentials.
+
+## Entry Point
+
+- Frontend route: `/integrations/k3-wise`
+- Vue view: `apps/web/src/views/IntegrationK3WiseSetupView.vue`
+- Nav entry: admin-only `ERP 对接` / `ERP Integration` in `apps/web/src/App.vue`
+
+The route is intentionally independent from PLM workbench screens. It is an integration control-plane page, not a PLM product-data page.
+
+## API Contract
+
+The page uses the existing plugin control-plane routes:
+
+- `GET /api/integration/external-systems?kind=erp:k3-wise-webapi`
+- `GET /api/integration/external-systems?kind=erp:k3-wise-sqlserver`
+- `POST /api/integration/external-systems`
+- `POST /api/integration/external-systems/:id/test`
+
+Payload construction lives in `apps/web/src/services/integration/k3WiseSetup.ts` so the Vue component remains mostly form state and user feedback.
+
+## Credential Boundary
+
+The public external-system API remains redaction-safe:
+
+- public reads expose `hasCredentials`, `credentialFormat`, and `credentialFingerprint`;
+- public reads do not expose plaintext credentials or ciphertext.
+
+This change also fills the internal adapter seam that was already referenced by `pipeline-runner.cjs` and `http-routes.cjs`:
+
+- `plugins/plugin-integration-core/lib/external-systems.cjs#getExternalSystemForAdapter`
+- decrypts credentials only for adapter/test/run execution;
+- returns adapter-local credentials without public fingerprint fields.
+
+This matters because the UI can now save a K3 WISE external system and then run `testConnection` through the real adapter path instead of only storing metadata.
+
+## Form Behavior
+
+WebAPI setup:
+
+- New systems require `tenantId`, name, version, base URL, username, password, and `acctId`.
+- Existing systems with stored credentials can be edited without re-entering the password; omitted credential fields preserve the stored secret.
+- If any credential field is re-entered on an existing system, the replacement must include username, password, and `acctId`.
+- Endpoint fields must be relative paths, matching the adapter contract.
+
+SQL Server channel:
+
+- Off by default.
+- When enabled, requires system name, server, database, and at least one allowed table.
+- Writes are represented through middle-table config; the adapter still blocks direct K3 core table writes unless explicitly configured in backend-only object config.
+
+## Out Of Scope
+
+- Creating PLM source systems from this page.
+- Creating material/BOM pipelines and field mappings from this page.
+- Installing a real SQL Server driver or live `queryExecutor`.
+- K3 production auto-submit/audit approval policy.
+
+Those remain part of the K3 live PoC/customer GATE flow and later platformization work.

--- a/docs/development/integration-k3wise-setup-ui-verification-20260428.md
+++ b/docs/development/integration-k3wise-setup-ui-verification-20260428.md
@@ -1,0 +1,83 @@
+# K3 WISE Setup UI Verification - 2026-04-28
+
+## Scope
+
+Verifies the K3 WISE setup page and the backend credential-read seam needed for `testConnection`.
+
+Changed files:
+
+- `plugins/plugin-integration-core/lib/external-systems.cjs`
+- `plugins/plugin-integration-core/__tests__/external-systems.test.cjs`
+- `apps/web/src/services/integration/k3WiseSetup.ts`
+- `apps/web/src/views/IntegrationK3WiseSetupView.vue`
+- `apps/web/src/router/appRoutes.ts`
+- `apps/web/src/router/types.ts`
+- `apps/web/src/App.vue`
+- `apps/web/tests/k3WiseSetup.spec.ts`
+
+## Commands Run
+
+```bash
+node plugins/plugin-integration-core/__tests__/external-systems.test.cjs
+```
+
+Result: PASS.
+
+Evidence:
+
+```text
+✓ external-systems: registry + credential boundary tests passed
+```
+
+```bash
+/Users/chouhua/Downloads/Github/metasheet2/node_modules/.bin/vitest run apps/web/tests/k3WiseSetup.spec.ts --watch=false
+```
+
+Result: PASS.
+
+Evidence:
+
+```text
+✓ apps/web/tests/k3WiseSetup.spec.ts (5 tests)
+Test Files  1 passed (1)
+Tests       5 passed (5)
+```
+
+```bash
+/Users/chouhua/Downloads/Github/metasheet2/node_modules/.bin/tsc --noEmit --target ES2022 --module ESNext --moduleResolution Bundler --strict --skipLibCheck apps/web/src/services/integration/k3WiseSetup.ts
+```
+
+Result: PASS.
+
+```bash
+node -e "<@vue/compiler-sfc parse + compileScript + compileTemplate for apps/web/src/views/IntegrationK3WiseSetupView.vue>"
+```
+
+Result: PASS.
+
+Evidence:
+
+```text
+SFC compile ok
+```
+
+## Assertions Covered
+
+- Public external-system rows remain redaction-safe.
+- Adapter-only external-system load decrypts JSON credentials.
+- Adapter-only load does not expose ciphertext or public credential fingerprint fields.
+- WebAPI payload construction maps form fields to `erp:k3-wise-webapi`.
+- SQL Server payload construction maps allowlists and middle tables to `erp:k3-wise-sqlserver`.
+- Existing credential storage is preserved when a user edits config without entering replacement secret fields.
+- Absolute endpoint URLs are rejected; endpoint fields must stay relative to `baseUrl`.
+
+## Known Local Validation Limit
+
+`vue-tsc -b apps/web/tsconfig.app.json` was attempted with the local Node 24 runtime and the dependency tree from the main checkout. It failed inside Volar before reporting project diagnostics:
+
+```text
+TypeError: Cannot read properties of undefined (reading 'fileName')
+    at @volar/typescript/lib/node/decorateProgram.js
+```
+
+This was not a TypeScript error from the changed files. A targeted service TypeScript check and Vue SFC parse/compile check were run instead. CI should run the normal Node 18/20 frontend gates on a clean dependency install.

--- a/plugins/plugin-integration-core/__tests__/external-systems.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/external-systems.test.cjs
@@ -134,6 +134,12 @@ async function main() {
   assert.equal(listed.length, 1)
   assert.equal(listed[0].id, 'sys_1')
 
+  const adapterSystem = await registry.getExternalSystemForAdapter({ tenantId: 'tenant_1', workspaceId: null, id: 'sys_1' })
+  assert.equal(adapterSystem.id, 'sys_1')
+  assert.deepEqual(adapterSystem.credentials, { username: 'u', password: 'secret' }, 'adapter load decrypts JSON credentials')
+  assert.equal(adapterSystem.credentialsEncrypted, undefined, 'adapter load never exposes ciphertext')
+  assert.equal(adapterSystem.credentialFingerprint, undefined, 'adapter load omits public fingerprint fields')
+
   const isolated = await registry.listExternalSystems({ tenantId: 'tenant_1', workspaceId: 'other' })
   assert.equal(isolated.length, 0, 'workspace scope isolates rows')
 

--- a/plugins/plugin-integration-core/lib/external-systems.cjs
+++ b/plugins/plugin-integration-core/lib/external-systems.cjs
@@ -120,6 +120,30 @@ function rowToPublicExternalSystem(row, credentialFingerprint = null) {
   }
 }
 
+function rowToAdapterExternalSystem(row, credentials = undefined) {
+  if (!row) return null
+  const system = {
+    id: row.id,
+    tenantId: row.tenant_id,
+    workspaceId: row.workspace_id ?? null,
+    projectId: row.project_id ?? null,
+    name: row.name,
+    kind: row.kind,
+    role: row.role,
+    config: row.config ?? {},
+    capabilities: row.capabilities ?? {},
+    status: row.status,
+    lastTestedAt: row.last_tested_at ?? null,
+    lastError: row.last_error ?? null,
+    createdAt: row.created_at ?? null,
+    updatedAt: row.updated_at ?? null,
+  }
+  if (credentials !== undefined) {
+    system.credentials = credentials
+  }
+  return system
+}
+
 function detectCredentialFormat(ciphertext) {
   if (typeof ciphertext !== 'string' || ciphertext.length === 0) return null
   if (ciphertext.startsWith('enc:')) return 'enc'
@@ -135,6 +159,18 @@ async function fingerprintCredential(credentialStore, ciphertext) {
 async function publicRow(credentialStore, row) {
   if (!row) return null
   return rowToPublicExternalSystem(row, await fingerprintCredential(credentialStore, row.credentials_encrypted))
+}
+
+async function parseAdapterCredentials(credentialStore, ciphertext) {
+  if (typeof ciphertext !== 'string' || ciphertext.length === 0) return undefined
+  const plaintext = await credentialStore.decrypt(ciphertext)
+  if (typeof plaintext !== 'string') return plaintext
+  try {
+    const parsed = JSON.parse(plaintext)
+    return isPlainObject(parsed) ? parsed : plaintext
+  } catch {
+    return plaintext
+  }
 }
 
 function isPlainObject(value) {
@@ -261,6 +297,22 @@ function createExternalSystemRegistry({ db, credentialStore, idGenerator = crypt
     return publicRow(credentialStore, row)
   }
 
+  async function getExternalSystemForAdapter(input) {
+    const tenantId = requiredString(input?.tenantId, 'tenantId')
+    const workspaceId = normalizeWorkspaceId(input?.workspaceId)
+    const id = requiredString(input?.id, 'id')
+    const row = await db.selectOne(TABLE, {
+      tenant_id: tenantId,
+      workspace_id: workspaceId,
+      id,
+    })
+    if (!row) {
+      throw new ExternalSystemNotFoundError('external system not found', { id, tenantId, workspaceId })
+    }
+    const credentials = await parseAdapterCredentials(credentialStore, row.credentials_encrypted)
+    return rowToAdapterExternalSystem(row, credentials)
+  }
+
   async function listExternalSystems(input = {}) {
     const tenantId = requiredString(input.tenantId, 'tenantId')
     const workspaceId = normalizeWorkspaceId(input.workspaceId)
@@ -286,6 +338,7 @@ function createExternalSystemRegistry({ db, credentialStore, idGenerator = crypt
   return {
     upsertExternalSystem,
     getExternalSystem,
+    getExternalSystemForAdapter,
     listExternalSystems,
   }
 }
@@ -300,6 +353,8 @@ module.exports = {
     VALID_STATUSES,
     detectCredentialFormat,
     normalizeExternalSystemInput,
+    parseAdapterCredentials,
+    rowToAdapterExternalSystem,
     rowToPublicExternalSystem,
   },
 }


### PR DESCRIPTION
## Summary
- add an admin K3 WISE setup page at /integrations/k3-wise for WebAPI, credentials, Save/Submit/Audit endpoints, and optional SQL Server channel metadata
- wire the page to existing /api/integration/external-systems and /:id/test control-plane routes
- add adapter-only external-system loading that decrypts credentials for test/run paths while public reads remain redaction-safe
- add design and verification docs for the setup UI and credential boundary

## Verification
- node plugins/plugin-integration-core/__tests__/external-systems.test.cjs
- /Users/chouhua/Downloads/Github/metasheet2/node_modules/.bin/vitest run apps/web/tests/k3WiseSetup.spec.ts --watch=false
- /Users/chouhua/Downloads/Github/metasheet2/node_modules/.bin/tsc --noEmit --target ES2022 --module ESNext --moduleResolution Bundler --strict --skipLibCheck apps/web/src/services/integration/k3WiseSetup.ts
- Vue SFC parse + compileScript + compileTemplate for apps/web/src/views/IntegrationK3WiseSetupView.vue

## Notes
- Full vue-tsc -b was attempted locally but failed inside Volar under Node 24 with TypeError: Cannot read properties of undefined (reading 'fileName') before project diagnostics. CI should run the normal Node 18/20 frontend gates on clean dependencies.
- Real K3 WISE connectivity still depends on customer GATE credentials/network access.