### PR TITLE
fix(dingtalk): allow public form auth through password-change guard

### DIFF
--- a/apps/web/src/router/multitableRoute.ts
+++ b/apps/web/src/router/multitableRoute.ts
@@ -68,6 +68,6 @@ export function buildPublicMultitableFormRoute(component: NonNullable<RouteRecor
     name: AppRouteNames.MULTITABLE_PUBLIC_FORM,
     component,
     props: resolvePublicMultitableFormRouteProps,
-    meta: { title: 'Public Multitable Form', hideNavbar: true, requiresAuth: false },
+    meta: { title: 'Public Multitable Form', hideNavbar: true, requiresAuth: false, skipShellBootstrap: true },
   }
 }

--- a/apps/web/src/views/PublicMultitableFormView.vue
+++ b/apps/web/src/views/PublicMultitableFormView.vue
@@ -68,7 +68,7 @@ const redirectingToDingTalk = ref(false)
 
 const title = computed(() => context.value?.view?.name || context.value?.sheet?.name || 'Public multitable form')
 const subtitle = computed(() => {
-  if (!context.value) return 'Submit this form anonymously.'
+  if (!context.value) return 'Loading secure form access...'
   const parts = [context.value.sheet?.name, context.value.view?.name].filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
   return parts.length ? parts.join(' · ') : 'Submit this form anonymously.'
 })

--- a/apps/web/tests/multitable-embed-route.spec.ts
+++ b/apps/web/tests/multitable-embed-route.spec.ts
@@ -98,6 +98,11 @@ describe('public multitable form route wiring', () => {
     expect(router.currentRoute.value.name).toBe(AppRouteNames.MULTITABLE_PUBLIC_FORM)
     const matched = router.currentRoute.value.matched.find((record) => record.name === AppRouteNames.MULTITABLE_PUBLIC_FORM)
     expect(matched?.path).toBe(ROUTE_PATHS.MULTITABLE_PUBLIC_FORM)
+    expect(matched?.meta).toMatchObject({
+      hideNavbar: true,
+      requiresAuth: false,
+      skipShellBootstrap: true,
+    })
     expect(resolvePublicMultitableFormRouteProps(router.currentRoute.value as any)).toEqual({
       sheetId: 'sheet_orders',
       viewId: 'view_form',

--- a/apps/web/tests/public-multitable-form.spec.ts
+++ b/apps/web/tests/public-multitable-form.spec.ts
@@ -109,6 +109,9 @@ describe('PublicMultitableFormView', () => {
 
     app = createApp(Root)
     app.mount(container)
+
+    expect(container.textContent).toContain('Loading secure form access...')
+
     await flushUi()
 
     expect(loadFormContextSpy).toHaveBeenCalledWith({

--- a/docs/development/dingtalk-public-form-password-change-design-20260428.md
+++ b/docs/development/dingtalk-public-form-password-change-design-20260428.md
@@ -1,0 +1,43 @@
+# DingTalk Public Form Password-Change Guard Design
+
+- Date: 2026-04-28
+- Scope: DingTalk protected public multitable form login flow
+
+## Symptom
+
+When opening a DingTalk protected public-form link, the page could render a misleading anonymous-form shell and then stop on `Password change required` before the form access checks completed.
+
+## Root Cause
+
+The public form endpoints intentionally use optional JWT auth:
+
+- `GET /api/multitable/form-context?publicToken=...`
+- `POST /api/multitable/views/:viewId/submit?publicToken=...`
+
+Those endpoints must allow both anonymous public forms and DingTalk-protected forms. For DingTalk-protected forms, a bearer token carries the local user identity bound to a DingTalk account.
+
+The bug was that optional auth reused the normal password-change guard. If a DingTalk-bound local user had `must_change_password = true`, `hydrateAuthenticatedUser()` returned `403 PASSWORD_CHANGE_REQUIRED` before public-form DingTalk access rules could run.
+
+The public form route also did not opt out of shell bootstrap, so unrelated product-feature loading could run on a public route.
+
+## Fix
+
+Backend:
+
+- Keep password-change enforcement unchanged for normal authenticated API routes.
+- Allow password-change users to hydrate only when `isPublicFormAuthBypass(req)` is true.
+- Preserve the existing exact route and public-token guards, so sibling multitable routes and missing-token requests are not broadened.
+
+Frontend:
+
+- Add `skipShellBootstrap: true` to the public form route metadata.
+- Change the pre-context subtitle from anonymous-specific copy to neutral secure-loading copy.
+
+## Expected Behavior
+
+After this fix:
+
+- Public-token form context and submit requests can evaluate DingTalk binding/grant state even if the bound local account has a temporary-password flag.
+- Normal app routes still force `/force-password-change`.
+- Public form routes without a `publicToken` still do not receive the bypass.
+- Public form pages no longer display misleading anonymous copy while DingTalk-protected access is still loading.

--- a/docs/development/dingtalk-public-form-password-change-verification-20260428.md
+++ b/docs/development/dingtalk-public-form-password-change-verification-20260428.md
@@ -1,0 +1,61 @@
+# DingTalk Public Form Password-Change Guard Verification
+
+- Date: 2026-04-28
+- Scope: `jwt-middleware`, public form route metadata, public form page copy
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/jwt-middleware.test.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/public-multitable-form.spec.ts tests/multitable-embed-route.spec.ts tests/multitable-phase4.spec.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+## Regression Coverage
+
+- `jwt-middleware.test.ts` covers public-form context and submit requests with `publicToken` hydrating a `must_change_password` user instead of returning `PASSWORD_CHANGE_REQUIRED`.
+- `jwt-middleware.test.ts` also covers the negative case: the same public-form context path without `publicToken` still returns `PASSWORD_CHANGE_REQUIRED`.
+- `multitable-embed-route.spec.ts` covers `skipShellBootstrap: true` on the public form route.
+- `public-multitable-form.spec.ts` covers the neutral loading subtitle before form context is loaded.
+
+## Results
+
+Executed in `/tmp/ms2-dingtalk-public-form-password-change` on branch `codex/dingtalk-public-form-password-change-20260428`.
+
+Backend JWT middleware unit test:
+
+```text
+Test Files  1 passed (1)
+Tests       16 passed (16)
+```
+
+Frontend public form route/view/API tests:
+
+```text
+Test Files  3 passed (3)
+Tests       18 passed (18)
+```
+
+Builds:
+
+```text
+pnpm --filter @metasheet/core-backend build
+# pass
+
+pnpm --filter @metasheet/web build
+# pass
+```
+
+Diff hygiene:
+
+```text
+git diff --check
+# pass
+```
+
+## Non-Gating Observations
+
+- The frontend Vitest run printed a Vite websocket `Port is already in use` warning and a jsdom navigation warning from the DingTalk redirect test. Exit code was 0.
+- The frontend production build printed existing dynamic-import and large-chunk warnings. Exit code was 0.

--- a/packages/core-backend/src/auth/jwt-middleware.ts
+++ b/packages/core-backend/src/auth/jwt-middleware.ts
@@ -85,7 +85,13 @@ async function hydrateAuthenticatedUser(req: Request, token: string): Promise<
       }
     }
 
-    if (user.must_change_password === true && !isPasswordChangeWhitelisted(req.path || req.originalUrl || '')) {
+    // DingTalk-protected public forms use optional auth. A local temporary
+    // password requirement should not block this external-auth form flow.
+    if (
+      user.must_change_password === true &&
+      !isPasswordChangeWhitelisted(req.path || req.originalUrl || '') &&
+      !isPublicFormAuthBypass(req)
+    ) {
       return {
         ok: false,
         statusCode: 403,

--- a/packages/core-backend/tests/unit/jwt-middleware.test.ts
+++ b/packages/core-backend/tests/unit/jwt-middleware.test.ts
@@ -234,6 +234,108 @@ describe('jwt auth middleware', () => {
     expect(next).toHaveBeenCalledTimes(1)
   })
 
+  it('allows DingTalk protected public-form context when the user must change password', async () => {
+    authServiceMocks.verifyToken.mockResolvedValue({
+      id: 'user-5',
+      email: 'forced-public-form@example.com',
+      name: 'Forced Public Form User',
+      role: 'user',
+      permissions: ['multitable:read'],
+      must_change_password: true,
+      created_at: new Date('2026-04-28T00:00:00.000Z'),
+      updated_at: new Date('2026-04-28T00:00:00.000Z'),
+    })
+
+    const req = {
+      method: 'GET',
+      path: '/api/multitable/form-context',
+      query: { publicToken: 'pub_123' },
+      headers: {
+        authorization: 'Bearer forced-public-form-token',
+      },
+    } as unknown as Request
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn().mockReturnThis(),
+    } as unknown as Response
+    const next = vi.fn() as NextFunction
+
+    await optionalJwtAuthMiddleware(req, res, next)
+
+    expect(req.user).toMatchObject({ id: 'user-5' })
+    expect(res.status).not.toHaveBeenCalled()
+    expect(next).toHaveBeenCalledTimes(1)
+  })
+
+  it('allows DingTalk protected public-form submit when the user must change password', async () => {
+    authServiceMocks.verifyToken.mockResolvedValue({
+      id: 'user-6',
+      email: 'forced-public-form-submit@example.com',
+      name: 'Forced Public Form Submit User',
+      role: 'user',
+      permissions: ['multitable:read'],
+      must_change_password: true,
+      created_at: new Date('2026-04-28T00:00:00.000Z'),
+      updated_at: new Date('2026-04-28T00:00:00.000Z'),
+    })
+
+    const req = {
+      method: 'POST',
+      path: '/api/multitable/views/view_form/submit',
+      query: {},
+      body: { publicToken: 'pub_123', data: { fld_title: 'Alpha' } },
+      headers: {
+        authorization: 'Bearer forced-public-form-submit-token',
+      },
+    } as unknown as Request
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn().mockReturnThis(),
+    } as unknown as Response
+    const next = vi.fn() as NextFunction
+
+    await optionalJwtAuthMiddleware(req, res, next)
+
+    expect(req.user).toMatchObject({ id: 'user-6' })
+    expect(res.status).not.toHaveBeenCalled()
+    expect(next).toHaveBeenCalledTimes(1)
+  })
+
+  it('still blocks must-change-password users on public form routes without a public token', async () => {
+    authServiceMocks.verifyToken.mockResolvedValue({
+      id: 'user-7',
+      email: 'forced-no-token@example.com',
+      name: 'Forced No Token User',
+      role: 'user',
+      permissions: ['multitable:read'],
+      must_change_password: true,
+      created_at: new Date('2026-04-28T00:00:00.000Z'),
+      updated_at: new Date('2026-04-28T00:00:00.000Z'),
+    })
+
+    const req = {
+      method: 'GET',
+      path: '/api/multitable/form-context',
+      query: {},
+      headers: {
+        authorization: 'Bearer forced-no-public-token',
+      },
+    } as unknown as Request
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn().mockReturnThis(),
+    } as unknown as Response
+    const next = vi.fn() as NextFunction
+
+    await optionalJwtAuthMiddleware(req, res, next)
+
+    expect(res.status).toHaveBeenCalledWith(403)
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      error: expect.objectContaining({ code: 'PASSWORD_CHANGE_REQUIRED' }),
+    }))
+    expect(next).not.toHaveBeenCalled()
+  })
+
   it('optional public form auth bypass does not fail when no bearer token is present', async () => {
     authServiceMocks.verifyToken.mockReset()
     const req = {


### PR DESCRIPTION
## Summary

Fixes the DingTalk-protected public multitable form flow when the bound local account still has `must_change_password = true`.

- Keeps normal password-change enforcement unchanged for authenticated app/API routes.
- Lets optional public-form auth hydrate a must-change-password user only for exact public-form context/submit routes with a `publicToken`.
- Adds `skipShellBootstrap: true` to the public form route so shell/product bootstrap does not run on that public route.
- Changes the pre-context public form subtitle from anonymous-specific copy to neutral secure-loading copy.

## Verification

```bash
pnpm --filter @metasheet/core-backend exec vitest run tests/unit/jwt-middleware.test.ts --watch=false
pnpm --filter @metasheet/web exec vitest run tests/public-multitable-form.spec.ts tests/multitable-embed-route.spec.ts tests/multitable-phase4.spec.ts --watch=false
pnpm --filter @metasheet/core-backend build
pnpm --filter @metasheet/web build
git diff --check
```

Local results:

- Backend JWT middleware unit test: 1 file / 16 tests passed.
- Frontend public form route/view/API tests: 3 files / 18 tests passed.
- Backend build passed.
- Web build passed with existing dynamic-import / large-chunk warnings.
- `git diff --check` passed.

## Docs

- `docs/development/dingtalk-public-form-password-change-design-20260428.md`
- `docs/development/dingtalk-public-form-password-change-verification-20260428.md`
