### PR TITLE
fix(integration): persist external system test status

### DIFF
--- a/apps/web/src/views/IntegrationK3WiseSetupView.vue
+++ b/apps/web/src/views/IntegrationK3WiseSetupView.vue
@@ -37,6 +37,8 @@
             >
               <span>{{ system.name }}</span>
               <small>{{ system.kind }} · {{ system.status }}</small>
+              <small v-if="system.lastTestedAt">Last test: {{ formatTimestamp(system.lastTestedAt) }}</small>
+              <small v-if="system.lastError" class="k3-setup__saved-error">{{ system.lastError }}</small>
             </button>
           </div>
         </div>
@@ -288,6 +290,12 @@ function formatError(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
 }
 
+function formatTimestamp(value: string): string {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return date.toLocaleString()
+}
+
 function loadSystemIntoForm(system: IntegrationExternalSystem): void {
   Object.assign(form, applyExternalSystemToForm(form, system))
   testResult.value = ''
@@ -346,6 +354,7 @@ async function testWebApi(): Promise<void> {
   try {
     const result = await testIntegrationSystem(form.webApiSystemId, { skipHealth: !form.healthPath.trim() })
     testResult.value = JSON.stringify(result, null, 2)
+    await loadSystems()
     setStatus('WebAPI 连接测试完成', 'success')
   } catch (error) {
     setStatus(formatError(error), 'error')
@@ -361,6 +370,7 @@ async function testSqlServer(): Promise<void> {
   try {
     const result = await testIntegrationSystem(form.sqlSystemId)
     testResult.value = JSON.stringify(result, null, 2)
+    await loadSystems()
     setStatus('SQL Server 通道测试完成', 'success')
   } catch (error) {
     setStatus(formatError(error), 'error')
@@ -592,6 +602,11 @@ onMounted(() => {
 
 .k3-setup__saved small {
   color: #64748b;
+}
+
+.k3-setup__saved-error {
+  color: #9f1239;
+  overflow-wrap: anywhere;
 }
 
 .k3-setup__empty {

--- a/docs/development/integration-test-status-persist-design-20260428.md
+++ b/docs/development/integration-test-status-persist-design-20260428.md
@@ -1,0 +1,86 @@
+# Integration Test Status Persistence Design - 2026-04-28
+
+## Goal
+
+Make `POST /api/integration/external-systems/:id/test` update the external-system status fields that the new K3 WISE setup page displays:
+
+- `lastTestedAt`
+- `lastError`
+- `status`
+
+Before this change, a connection test returned `{ ok: ... }` to the caller but did not persist anything. After page refresh, operators could not tell whether the saved ERP/PLM/DB endpoint had ever been tested.
+
+## Backend Behavior
+
+Route changed:
+
+- `plugins/plugin-integration-core/lib/http-routes.cjs`
+
+On test completion:
+
+- successful result clears `lastError`;
+- failed result stores a readable `lastError`;
+- `lastTestedAt` is set to the current ISO timestamp;
+- failed result marks the system `error`;
+- successful result marks previous `error`/active systems as `active`;
+- successful result preserves `inactive` systems as `inactive`.
+
+The inactive preservation is deliberate. A connection test must not turn a disabled integration into a runnable pipeline dependency.
+
+## Error Handling
+
+Adapters are expected to return `{ ok: false, ... }` for failed tests, but the route now also handles a thrown adapter test error by converting it to a non-throwing test result:
+
+```json
+{
+  "ok": false,
+  "code": "TEST_CONNECTION_FAILED",
+  "message": "..."
+}
+```
+
+This keeps the control-plane UX consistent: clicking Test records the failure instead of losing the result behind a generic 500.
+
+## Response Shape
+
+The route still returns a success envelope:
+
+```json
+{
+  "ok": true,
+  "data": {
+    "ok": true,
+    "status": 200,
+    "system": {
+      "id": "...",
+      "status": "active",
+      "lastTestedAt": "..."
+    }
+  }
+}
+```
+
+The returned system is redaction-safe. It strips `credentials` and `credentialsEncrypted`.
+
+## Frontend Behavior
+
+Route:
+
+- `/integrations/k3-wise`
+
+Files:
+
+- `apps/web/src/views/IntegrationK3WiseSetupView.vue`
+
+After a WebAPI or SQL Server test completes, the page reloads saved systems and shows:
+
+- current external-system status;
+- last test timestamp;
+- last error summary.
+
+## Non-Goals
+
+- No schema change; the columns already exist in `integration_external_systems`.
+- No pipeline run behavior change.
+- No automatic retry scheduling.
+- No direct K3 production write behavior change.

--- a/docs/development/integration-test-status-persist-verification-20260428.md
+++ b/docs/development/integration-test-status-persist-verification-20260428.md
@@ -1,0 +1,62 @@
+# Integration Test Status Persistence Verification - 2026-04-28
+
+## Scope
+
+Changed files:
+
+- `plugins/plugin-integration-core/lib/http-routes.cjs`
+- `plugins/plugin-integration-core/__tests__/http-routes.test.cjs`
+- `apps/web/src/views/IntegrationK3WiseSetupView.vue`
+- `docs/development/integration-test-status-persist-design-20260428.md`
+- `docs/development/integration-test-status-persist-verification-20260428.md`
+
+## Commands Run
+
+```bash
+node plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+```
+
+Result: PASS.
+
+Evidence:
+
+```text
+http-routes: REST auth/list/upsert/run/dry-run/replay tests passed
+```
+
+```bash
+node -c plugins/plugin-integration-core/lib/http-routes.cjs
+```
+
+Result: PASS.
+
+```bash
+node -e "<@vue/compiler-sfc parse + compileScript + compileTemplate for apps/web/src/views/IntegrationK3WiseSetupView.vue>"
+```
+
+Result: PASS.
+
+Evidence:
+
+```text
+SFC compile ok
+```
+
+```bash
+git diff --check
+```
+
+Result: PASS.
+
+## Regression Assertions
+
+The expanded `http-routes.test.cjs` covers:
+
+- `externalSystemsTest` loads the adapter-scoped external system and keeps credentials out of the response.
+- successful test persists `status: active`, `lastTestedAt`, and `lastError: null`.
+- failed test persists `status: error` and a readable `lastError`.
+- successful test does not activate a system that was intentionally `inactive`.
+
+## Local Limit
+
+This slice did not rerun the full frontend workspace type-check. The previous K3 WISE UI slice recorded that local `vue-tsc -b` fails in the current Node 24/Volar environment before project diagnostics. This slice instead uses the direct Vue SFC compile check for the touched component plus backend unit coverage for the changed route behavior.

--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -382,6 +382,90 @@ async function testExternalSystemRoutes() {
   assert.deepEqual(findCall(calls, 'createAdapter')[1].credentials, { bearerToken: 'secret-token' })
   assert.equal(res.body.data.ok, true)
   assert.equal(res.body.data.credentials, undefined, 'test response does not leak credentials')
+  assert.equal(res.body.data.system.credentials, undefined, 'test response system does not leak credentials')
+  assert.equal(res.body.data.system.credentialsEncrypted, undefined, 'test response system does not leak ciphertext')
+  const statusUpdates = findCalls(calls, 'upsertExternalSystem')
+  assert.equal(statusUpdates.length, 2, 'external system create plus test status update were persisted')
+  assert.deepEqual(statusUpdates[1][1], {
+    id: 'sys_2',
+    tenantId: 'tenant_1',
+    workspaceId: 'workspace_1',
+    name: 'K3 WISE',
+    kind: 'erp',
+    role: 'target',
+    status: 'active',
+    lastTestedAt: statusUpdates[1][1].lastTestedAt,
+    lastError: null,
+  })
+  assert.ok(!Number.isNaN(Date.parse(statusUpdates[1][1].lastTestedAt)), 'test status update stores ISO timestamp')
+}
+
+async function testExternalSystemTestPersistsFailureAndPreservesInactive() {
+  const { calls, services } = createMockServices({
+    externalSystemRegistry: {
+      async getExternalSystemForAdapter(input) {
+        calls.push(['getExternalSystemForAdapter', input])
+        return {
+          id: input.id,
+          tenantId: input.tenantId,
+          workspaceId: input.workspaceId,
+          name: 'Inactive ERP',
+          kind: 'erp',
+          role: 'target',
+          status: 'inactive',
+          credentials: { bearerToken: 'secret-token' },
+        }
+      },
+    },
+    adapterRegistry: {
+      createAdapter(input) {
+        calls.push(['createAdapter', input])
+        return {
+          async testConnection() {
+            calls.push(['testConnection'])
+            return { ok: false, code: 'ERP_DOWN', message: 'ERP endpoint unavailable' }
+          },
+        }
+      },
+    },
+  })
+  const { routes } = mountRoutes(services)
+
+  const res = await invoke(routes, 'POST', '/api/integration/external-systems/:id/test', {
+    user: WRITE_USER,
+    params: { id: 'sys_inactive' },
+    query: { workspaceId: 'workspace_1' },
+  })
+
+  assertOkResponse(res, 200)
+  assert.equal(res.body.data.ok, false)
+  assert.equal(res.body.data.system.status, 'error')
+  const statusUpdate = findCall(calls, 'upsertExternalSystem')[1]
+  assert.equal(statusUpdate.status, 'error')
+  assert.equal(statusUpdate.lastError, 'ERP endpoint unavailable')
+
+  calls.length = 0
+  services.adapterRegistry.createAdapter = (input) => {
+    calls.push(['createAdapter', input])
+    return {
+      async testConnection() {
+        calls.push(['testConnection'])
+        return { ok: true, status: 200 }
+      },
+    }
+  }
+
+  const success = await invoke(routes, 'POST', '/api/integration/external-systems/:id/test', {
+    user: WRITE_USER,
+    params: { id: 'sys_inactive' },
+    query: { workspaceId: 'workspace_1' },
+  })
+
+  assertOkResponse(success, 200)
+  assert.equal(success.body.data.ok, true)
+  const inactiveUpdate = findCall(calls, 'upsertExternalSystem')[1]
+  assert.equal(inactiveUpdate.status, 'inactive', 'successful test does not activate inactive systems')
+  assert.equal(inactiveUpdate.lastError, null)
 }
 
 async function testPipelineRoutes() {
@@ -925,6 +1009,7 @@ async function testListOffsetCap() {
 async function main() {
   await testUnauthenticatedWriteRequestIsRejected()
   await testExternalSystemRoutes()
+  await testExternalSystemTestPersistsFailureAndPreservesInactive()
   await testPipelineRoutes()
   await testRunAndDeadLetterRoutes()
   await testErrorResponseShape()

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -245,6 +245,54 @@ function redactSystemForTest(system) {
   }
 }
 
+function normalizeTestConnectionResult(result) {
+  if (result && typeof result === 'object' && !Array.isArray(result)) {
+    return { ...result }
+  }
+  return {
+    ok: result !== false,
+    raw: result,
+  }
+}
+
+function testConnectionErrorResult(error) {
+  return {
+    ok: false,
+    code: error && (error.code || error.name) ? String(error.code || error.name) : 'TEST_CONNECTION_FAILED',
+    message: error && error.message ? error.message : String(error),
+  }
+}
+
+function resolveTestedStatus(system, result) {
+  if (!result || result.ok !== true) return 'error'
+  // A connection test must not silently enable an intentionally inactive
+  // external system. It only clears a previous error status after success.
+  if (system && system.status === 'inactive') return 'inactive'
+  return 'active'
+}
+
+function resolveTestError(result) {
+  if (result && result.ok === true) return null
+  return firstString(
+    result && result.message,
+    result && result.code,
+    'connection test failed',
+  )
+}
+
+async function persistExternalSystemTestResult(externalSystems, req, system, result) {
+  if (!system || !system.id || !system.name || !system.kind) return null
+  return externalSystems.upsertExternalSystem(scopedInput(req, {
+    id: system.id,
+    name: system.name,
+    kind: system.kind,
+    role: system.role || 'bidirectional',
+    status: resolveTestedStatus(system, result),
+    lastTestedAt: new Date().toISOString(),
+    lastError: resolveTestError(result),
+  }))
+}
+
 function createHandlers(services) {
   function requireService(name, methods) {
     const service = services[name]
@@ -300,7 +348,17 @@ function createHandlers(services) {
         : externalSystems.getExternalSystem.bind(externalSystems)
       const system = await loadSystem(scopedInput(req, { id: requestParams(req).id }))
       const adapter = adapterRegistry.createAdapter(system)
-      return sendOk(res, await adapter.testConnection(requestBody(req)))
+      let result
+      try {
+        result = normalizeTestConnectionResult(await adapter.testConnection(requestBody(req)))
+      } catch (error) {
+        result = testConnectionErrorResult(error)
+      }
+      const updatedSystem = await persistExternalSystemTestResult(externalSystems, req, system, result)
+      return sendOk(res, {
+        ...result,
+        system: redactSystemForTest(updatedSystem),
+      })
     },
 
     async pipelinesList(req, res) {


### PR DESCRIPTION
## Summary
- persist lastTestedAt, lastError, and status from /api/integration/external-systems/:id/test
- convert thrown adapter test failures into recorded { ok: false } test results
- keep inactive external systems inactive after successful tests so Test does not silently enable disabled integrations
- refresh the K3 WISE setup page after WebAPI/SQL Server tests and show last test/error metadata
- add design and verification docs

## Verification
- node plugins/plugin-integration-core/__tests__/http-routes.test.cjs
- node -c plugins/plugin-integration-core/lib/http-routes.cjs
- Vue SFC parse + compileScript + compileTemplate for apps/web/src/views/IntegrationK3WiseSetupView.vue
- git diff --check origin/main..HEAD

## Notes
- No migration needed; integration_external_systems already has last_tested_at and last_error.
- Does not change pipeline execution semantics.