### PR TITLE
feat(dingtalk): surface public form access matrix

### DIFF
--- a/apps/web/src/multitable/components/MetaFormShareManager.vue
+++ b/apps/web/src/multitable/components/MetaFormShareManager.vue
@@ -45,6 +45,15 @@
                 <option value="dingtalk_granted">DingTalk-authorized users only</option>
               </select>
               <p class="meta-form-share__hint">{{ accessModeHint }}</p>
+              <div
+                class="meta-form-share__audience-card"
+                data-form-share-audience-rule="true"
+                :data-access-mode="config.accessMode"
+                :data-has-local-allowlist="hasLocalAllowlist ? 'true' : 'false'"
+              >
+                <strong>{{ audienceRule.title }}</strong>
+                <span>{{ audienceRule.description }}</span>
+              </div>
             </div>
 
             <div v-if="showAllowlistSection" class="meta-form-share__allowlist-section">
@@ -88,6 +97,13 @@
                       {{ user.label }}
                       <span v-if="user.subtitle" class="meta-form-share__chip-subtitle">{{ user.subtitle }}</span>
                       <span v-if="!user.isActive" class="meta-form-share__chip-subtitle">Inactive user</span>
+                      <span
+                        v-if="subjectDingTalkStatus(user)"
+                        class="meta-form-share__chip-subtitle"
+                        :data-form-share-dingtalk-status="subjectDingTalkStatus(user)"
+                      >
+                        {{ subjectDingTalkStatus(user) }}
+                      </span>
                     </span>
                     <button
                       class="meta-form-share__chip-remove"
@@ -155,6 +171,13 @@
                       </span>
                     </span>
                     <span v-if="candidate.subtitle" class="meta-form-share__candidate-subtitle">{{ candidate.subtitle }}</span>
+                    <span
+                      v-if="subjectDingTalkStatus(candidate)"
+                      class="meta-form-share__candidate-subtitle"
+                      :data-form-share-dingtalk-status="subjectDingTalkStatus(candidate)"
+                    >
+                      {{ subjectDingTalkStatus(candidate) }}
+                    </span>
                     <span v-if="candidate.subjectType === 'user' && !candidate.isActive" class="meta-form-share__candidate-subtitle">
                       Inactive users cannot be added
                     </span>
@@ -299,6 +322,36 @@ const allowedUsers = computed(() => config.value?.allowedUsers ?? [])
 const allowedMemberGroups = computed(() => config.value?.allowedMemberGroups ?? [])
 const allowedUserCount = computed(() => config.value?.allowedUserIds?.length ?? allowedUsers.value.length)
 const allowedMemberGroupCount = computed(() => config.value?.allowedMemberGroupIds?.length ?? allowedMemberGroups.value.length)
+const hasLocalAllowlist = computed(() => allowedUserCount.value > 0 || allowedMemberGroupCount.value > 0)
+const audienceRule = computed(() => {
+  const mode = config.value?.accessMode ?? 'public'
+  if (mode === 'public') {
+    return {
+      title: 'Fully public anonymous form',
+      description: 'Anyone with the link can open and submit without local login or DingTalk binding.',
+    }
+  }
+  if (mode === 'dingtalk_granted') {
+    return hasLocalAllowlist.value
+      ? {
+          title: 'Selected authorized DingTalk users',
+          description: 'Only selected local users or group members can fill, and each user must be DingTalk-bound with form authorization enabled.',
+        }
+      : {
+          title: 'All authorized DingTalk users',
+          description: 'Any DingTalk-bound local user can fill after an administrator enables their DingTalk form authorization.',
+        }
+  }
+  return hasLocalAllowlist.value
+    ? {
+        title: 'Selected DingTalk-bound users',
+        description: 'Only selected local users or group members can fill, and each user must be bound to DingTalk.',
+      }
+    : {
+        title: 'All DingTalk-bound users',
+        description: 'Any local user can fill after DingTalk sign-in when their account is bound to DingTalk.',
+      }
+})
 const allowlistAudienceSummary = computed(() => {
   const userCount = allowedUserCount.value
   const memberGroupCount = allowedMemberGroupCount.value
@@ -322,6 +375,23 @@ const selectedSubjectKeys = computed(() => new Set([
 const filteredCandidates = computed(() =>
   candidates.value.filter((candidate) => !selectedSubjectKeys.value.has(`${candidate.subjectType}:${candidate.subjectId}`)),
 )
+
+function subjectDingTalkStatus(
+  subject: Pick<MetaSheetPermissionCandidate, 'subjectType' | 'dingtalkBound' | 'dingtalkGrantEnabled' | 'dingtalkPersonDeliveryAvailable'>,
+): string {
+  const mode = config.value?.accessMode ?? 'public'
+  if (mode === 'public') return ''
+  if (subject.subjectType === 'member-group') return 'Members are checked individually'
+  if (subject.subjectType !== 'user') return ''
+  if (subject.dingtalkBound === false) return 'DingTalk not bound'
+  if (mode === 'dingtalk_granted') {
+    if (subject.dingtalkGrantEnabled === true) return 'DingTalk bound and authorized'
+    if (subject.dingtalkBound === true && subject.dingtalkGrantEnabled === false) return 'DingTalk authorization not enabled'
+  }
+  if (subject.dingtalkBound === true) return 'DingTalk bound'
+  if (subject.dingtalkPersonDeliveryAvailable === true) return 'DingTalk delivery linked'
+  return ''
+}
 
 async function loadConfig() {
   if (!props.client) return
@@ -773,6 +843,22 @@ watch(candidateQuery, () => {
 .meta-form-share__candidate-subtitle {
   font-size: 12px;
   color: #64748b;
+}
+
+.meta-form-share__audience-card {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 10px 12px;
+  border: 1px solid #bae6fd;
+  border-radius: 10px;
+  background: #f0f9ff;
+  color: #0c4a6e;
+  font-size: 12px;
+}
+
+.meta-form-share__audience-card strong {
+  font-size: 13px;
 }
 
 .meta-form-share__link-row,

--- a/apps/web/tests/multitable-form-share-manager.spec.ts
+++ b/apps/web/tests/multitable-form-share-manager.spec.ts
@@ -37,7 +37,7 @@ function mockClient(config = fakeConfig()) {
         items: [
           { subjectType: 'user', subjectId: 'user_1', label: 'Alice', subtitle: 'alice@test.local', isActive: true, accessLevel: 'write' },
           { subjectType: 'member-group', subjectId: 'group_ops', label: 'Ops', subtitle: 'Operations', isActive: true, accessLevel: 'write' },
-          { subjectType: 'user', subjectId: 'user_inactive', label: 'Inactive User', subtitle: 'inactive@test.local', isActive: false, accessLevel: 'write' },
+          { subjectType: 'user', subjectId: 'user_inactive', label: 'Inactive User', subtitle: 'inactive@test.local', isActive: false, accessLevel: 'write', dingtalkBound: false, dingtalkGrantEnabled: false, dingtalkPersonDeliveryAvailable: false },
         ],
         total: 3,
         limit: 20,
@@ -111,6 +111,10 @@ describe('MetaFormShareManager', () => {
     const copyBtn = document.querySelector('[data-form-share-copy]')
     expect(copyBtn).toBeTruthy()
     expect(copyBtn?.textContent?.trim()).toBe('Copy')
+    const audience = document.querySelector('[data-form-share-audience-rule]') as HTMLElement
+    expect(audience).toBeTruthy()
+    expect(audience.getAttribute('data-access-mode')).toBe('public')
+    expect(audience.textContent).toContain('Fully public anonymous form')
   })
 
   it('shows regenerate button', async () => {
@@ -212,6 +216,12 @@ describe('MetaFormShareManager', () => {
     expect(document.body.textContent).toContain('No local member-group allowlist configured. Add a local member group to let its members fill this form.')
     expect(document.querySelector('[data-form-share-add-subject="user:user_1"]')).toBeTruthy()
     expect(document.querySelector('[data-form-share-add-subject="member-group:group_ops"]')).toBeTruthy()
+    const audience = document.querySelector('[data-form-share-audience-rule]') as HTMLElement
+    expect(audience.getAttribute('data-access-mode')).toBe('dingtalk')
+    expect(audience.getAttribute('data-has-local-allowlist')).toBe('false')
+    expect(audience.textContent).toContain('All DingTalk-bound users')
+    expect(document.body.textContent).toContain('DingTalk not bound')
+    expect(document.body.textContent).toContain('Members are checked individually')
   })
 
   it('explains DingTalk delivery still uses local allowlists for granted mode', async () => {
@@ -224,6 +234,7 @@ describe('MetaFormShareManager', () => {
     expect(summary).toBeTruthy()
     expect(summary.textContent).toContain('No local allowlist limits are set; all users allowed by the selected DingTalk mode can fill this form.')
     expect(document.body.textContent).toContain('The form opens only for DingTalk-bound users whose DingTalk grant is enabled by an administrator.')
+    expect(document.querySelector('[data-form-share-audience-rule]')?.textContent).toContain('All authorized DingTalk users')
     expect(document.body.textContent).toContain('DingTalk is only the sign-in and delivery channel. The allowlist still targets your local users and member groups.')
     expect(document.body.textContent).toContain('No local user allowlist configured. Access is still gated by the selected DingTalk mode; add local users or member groups to narrow who can fill this form.')
   })
@@ -232,7 +243,7 @@ describe('MetaFormShareManager', () => {
     const { client } = mockClient(fakeConfig({
       accessMode: 'dingtalk',
       allowedUserIds: ['user_1'],
-      allowedUsers: [{ subjectType: 'user', subjectId: 'user_1', label: 'Alice', subtitle: 'alice@test.local', isActive: true }],
+      allowedUsers: [{ subjectType: 'user', subjectId: 'user_1', label: 'Alice', subtitle: 'alice@test.local', isActive: true, dingtalkBound: true, dingtalkGrantEnabled: false, dingtalkPersonDeliveryAvailable: true }],
       allowedMemberGroupIds: ['group_ops'],
       allowedMemberGroups: [{ subjectType: 'member-group', subjectId: 'group_ops', label: 'Ops', subtitle: 'Operations', isActive: true }],
     }))
@@ -244,6 +255,8 @@ describe('MetaFormShareManager', () => {
     expect(summary.getAttribute('data-user-count')).toBe('1')
     expect(summary.getAttribute('data-member-group-count')).toBe('1')
     expect(summary.textContent).toContain('Local allowlist limits: 1 local user and 1 local member group can fill after passing the selected DingTalk mode.')
+    expect(document.querySelector('[data-form-share-audience-rule]')?.textContent).toContain('Selected DingTalk-bound users')
+    expect(document.body.textContent).toContain('DingTalk bound')
   })
 
   it('adds an allowed user through the allowlist controls', async () => {

--- a/docs/development/dingtalk-public-form-access-matrix-142-design-20260428.md
+++ b/docs/development/dingtalk-public-form-access-matrix-142-design-20260428.md
@@ -1,0 +1,60 @@
+# DingTalk Public Form Access Matrix 142 Design - 2026-04-28
+
+## Goal
+
+Make the public-form share configuration page explain the real DingTalk access matrix before operators publish a form link.
+
+The runtime guard for public forms already enforces these modes:
+
+| Case | Access mode | Local allowlist | Expected behavior |
+| --- | --- | --- | --- |
+| Fully public anonymous fill | `public` | Empty | Anyone with the link can open and submit without local login or DingTalk binding. |
+| DingTalk login required | `dingtalk` | Empty | Any local user with a DingTalk binding can fill. Unbound users are rejected with `DINGTALK_BIND_REQUIRED`. |
+| DingTalk login required for selected users/groups | `dingtalk` | Non-empty users or groups | User must be DingTalk-bound and included directly or through a selected member group. Users outside the allowlist are rejected with `DINGTALK_FORM_NOT_ALLOWED`. |
+| DingTalk authorization required | `dingtalk_granted` | Empty | Any DingTalk-bound local user can fill only after the administrator enables the user's DingTalk form grant. Missing grant is rejected with `DINGTALK_GRANT_REQUIRED`. |
+| DingTalk authorization required for selected users/groups | `dingtalk_granted` | Non-empty users or groups | User must pass DingTalk binding, DingTalk grant, and local allowlist checks. |
+
+## Password-change Interaction
+
+The deployed `origin/main` baseline already includes the narrow public-form password-change fix. A platform-created DingTalk user with `must_change_password = true` should not be forced through local password change when filling a DingTalk-protected public form through the public-form token flow.
+
+The local password-change requirement still applies to normal application routes and local-password login flows.
+
+## Implementation
+
+Backend:
+
+- Extend `PublicFormAllowedSubjectSummary` with DingTalk status fields:
+  - `dingtalkBound`
+  - `dingtalkGrantEnabled`
+  - `dingtalkPersonDeliveryAvailable`
+- Reuse `enrichFormShareCandidatesWithDingTalkStatus()` for configured `allowedUsers` and `allowedMemberGroups`, not only search candidates.
+- Preserve existing allowlist ID ordering and fallback summaries for deleted or missing subjects.
+
+Frontend:
+
+- Add an access-rule card under the access-mode selector:
+  - `public`: fully public anonymous form
+  - `dingtalk`: all or selected DingTalk-bound users
+  - `dingtalk_granted`: all or selected authorized DingTalk users
+- Show per-subject DingTalk status for allowed users and candidate rows:
+  - `DingTalk not bound`
+  - `DingTalk bound`
+  - `DingTalk bound and authorized`
+  - `DingTalk authorization not enabled`
+  - `DingTalk delivery linked`
+  - `Members are checked individually`
+
+## Deployment Position
+
+142 currently runs GHCR images for commit `dba5c8eac44fbd468310078ecb7952752299dc5a`, which already contains the password-change public-form fix.
+
+This branch adds the remaining operator-visibility/access-matrix UI and config-response enrichment. It has not been deployed to 142 in this step because the local machine has no usable Docker daemon, and the repo's automated image build/deploy workflow is main-branch based.
+
+Recommended release path:
+
+1. Merge this branch to `main`.
+2. Let `.github/workflows/docker-build.yml` build and push backend/web images tagged by the merge commit SHA.
+3. Let the workflow deploy to 142, or manually deploy the pinned SHA with the existing production SOP.
+4. Run the post-deploy checks in the companion verification document.
+

--- a/docs/development/dingtalk-public-form-access-matrix-142-design-20260428.md
+++ b/docs/development/dingtalk-public-form-access-matrix-142-design-20260428.md
@@ -57,4 +57,3 @@ Recommended release path:
 2. Let `.github/workflows/docker-build.yml` build and push backend/web images tagged by the merge commit SHA.
 3. Let the workflow deploy to 142, or manually deploy the pinned SHA with the existing production SOP.
 4. Run the post-deploy checks in the companion verification document.
-

--- a/docs/development/dingtalk-public-form-access-matrix-142-verification-20260428.md
+++ b/docs/development/dingtalk-public-form-access-matrix-142-verification-20260428.md
@@ -1,0 +1,72 @@
+# DingTalk Public Form Access Matrix 142 Verification - 2026-04-28
+
+## Local Branch
+
+- Worktree: `/private/tmp/ms2-dingtalk-public-form-access-matrix-142-20260428`
+- Branch: `codex/dingtalk-public-form-access-matrix-142-20260428`
+- Base: latest `origin/main` at verification time
+
+## Commands Run
+
+```bash
+pnpm install
+git diff --check
+pnpm --filter @metasheet/core-backend exec vitest run tests/integration/public-form-flow.test.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/multitable-form-share-manager.spec.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/web build
+```
+
+## Results
+
+- `pnpm install`: passed, lockfile reused; no new package download required.
+- `git diff --check`: passed.
+- Backend public-form integration test: passed, 19 tests.
+- Frontend share-manager unit test: passed, 15 tests.
+- Backend build: passed.
+- Web build: passed.
+
+Non-blocking web build warnings:
+
+- Existing dynamic/static import chunk warning for `WorkflowDesigner.vue`.
+- Existing large chunk warnings after minification.
+
+Non-blocking frontend test warning:
+
+- Vite dev WebSocket port was already in use during the focused Vitest run; test process exited successfully.
+
+## 142 Read-only Check
+
+Read-only SSH and HTTP checks were run against `142.171.239.56`.
+
+Observed state:
+
+- Remote repo head: `dba5c8e fix(dingtalk): allow public form auth through password-change guard`
+- Backend image: `ghcr.io/zensgit/metasheet2-backend:dba5c8eac44fbd468310078ecb7952752299dc5a`
+- Web image: `ghcr.io/zensgit/metasheet2-web:dba5c8eac44fbd468310078ecb7952752299dc5a`
+- Health endpoint: `status=ok`, `plugins.total=13`, `plugins.active=13`, `plugins.failed=0`
+
+Backend log tail contained only startup-period database recovery / not-yet-accepting-connections warnings. No public-form or DingTalk access-matrix errors were observed in the checked tail.
+
+The previously supplied local admin JWT file no longer validates against `/api/auth/me` and returns `401 UNAUTHORIZED`; no token value was printed or written to tracked files.
+
+## Secret Handling
+
+No webhook URL, DingTalk signing secret, bearer token, JWT, or raw `Authorization` header was added to source or docs.
+
+Recommended post-merge/post-deploy secret scan: run the existing DingTalk release secret scan over the changed source files and this document set.
+
+## Post-deploy Checklist
+
+After the branch is merged and the GHCR images are deployed to 142:
+
+1. Confirm `/api/health` reports all plugins active.
+2. Generate or refresh a short-lived admin app token if needed; validate `/api/auth/me`.
+3. Open the form sharing panel and confirm the access-rule card appears for all three access modes.
+4. Confirm selected allowed users display DingTalk binding / authorization status.
+5. Confirm candidate search rows display DingTalk status.
+6. Re-run one real DingTalk public-form flow for each mode:
+   - `public`
+   - `dingtalk`
+   - `dingtalk_granted`
+7. Re-test a platform-created DingTalk user with `must_change_password = true`; expected behavior is form fill allowed through DingTalk public-form auth, while normal app routes still require password change.

--- a/docs/development/dingtalk-public-form-access-matrix-142-verification-20260428.md
+++ b/docs/development/dingtalk-public-form-access-matrix-142-verification-20260428.md
@@ -35,6 +35,26 @@ Non-blocking frontend test warning:
 
 - Vite dev WebSocket port was already in use during the focused Vitest run; test process exited successfully.
 
+## Codex Recheck
+
+Rechecked after PR review on 2026-04-28:
+
+```bash
+git diff --check
+pnpm --filter @metasheet/core-backend exec vitest run tests/integration/public-form-flow.test.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/multitable-form-share-manager.spec.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/web build
+```
+
+Results:
+
+- `git diff --check`: passed after removing one trailing blank line from the design MD.
+- Backend public-form integration test: passed, 19 tests.
+- Frontend share-manager unit test: passed, 15 tests.
+- Backend build: passed.
+- Web build: passed, with the same existing dynamic/static import and large chunk warnings.
+
 ## 142 Read-only Check
 
 Read-only SSH and HTTP checks were run against `142.171.239.56`.

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -355,6 +355,9 @@ type PublicFormAllowedSubjectSummary = {
   label: string
   subtitle: string | null
   isActive: boolean
+  dingtalkBound?: boolean | null
+  dingtalkGrantEnabled?: boolean | null
+  dingtalkPersonDeliveryAvailable?: boolean | null
 }
 
 type PublicFormShareConfigResponse = {
@@ -520,23 +523,32 @@ async function loadPublicFormAllowedSubjectSummaries(
       ]),
   )
 
-  return {
-    allowedUserIds,
-    allowedUsers: allowedUserIds.map((userId) => usersById.get(userId) ?? {
-      subjectType: 'user',
+  const subjects: PublicFormAllowedSubjectSummary[] = [
+    ...allowedUserIds.map((userId) => usersById.get(userId) ?? {
+      subjectType: 'user' as const,
       subjectId: userId,
       label: userId,
       subtitle: null,
       isActive: false,
-    }),
-    allowedMemberGroupIds,
-    allowedMemberGroups: allowedMemberGroupIds.map((groupId) => groupsById.get(groupId) ?? {
-      subjectType: 'member-group',
+    } satisfies PublicFormAllowedSubjectSummary),
+    ...allowedMemberGroupIds.map((groupId) => groupsById.get(groupId) ?? {
+      subjectType: 'member-group' as const,
       subjectId: groupId,
       label: groupId,
       subtitle: 'Member group',
       isActive: true,
-    }),
+    } satisfies PublicFormAllowedSubjectSummary),
+  ]
+  const enrichedSubjects = await enrichFormShareCandidatesWithDingTalkStatus(
+    query,
+    subjects as MultitableSheetPermissionCandidate[],
+  ) as PublicFormAllowedSubjectSummary[]
+
+  return {
+    allowedUserIds,
+    allowedUsers: enrichedSubjects.filter((subject) => subject.subjectType === 'user'),
+    allowedMemberGroupIds,
+    allowedMemberGroups: enrichedSubjects.filter((subject) => subject.subjectType === 'member-group'),
   }
 }
 

--- a/packages/core-backend/tests/integration/public-form-flow.test.ts
+++ b/packages/core-backend/tests/integration/public-form-flow.test.ts
@@ -432,6 +432,15 @@ describe('Public form flow', () => {
         if (sql.includes('FROM platform_member_groups')) {
           return { rows: [{ id: 'group_1', name: 'Ops', description: 'Operations', member_count: 3 }, { id: 'group_2', name: 'Sales', description: 'Sales team', member_count: 4 }] }
         }
+        if (sql.includes('FROM user_external_identities')) {
+          return { rows: [{ local_user_id: 'user_1' }, { local_user_id: 'user_2' }] }
+        }
+        if (sql.includes('FROM directory_account_links')) {
+          return { rows: [{ local_user_id: 'user_2' }] }
+        }
+        if (sql.includes('FROM user_external_auth_grants')) {
+          return { rows: [{ local_user_id: 'user_1', enabled: true }, { local_user_id: 'user_2', enabled: false }] }
+        }
         if (sql.includes('SELECT id FROM users WHERE id = ANY')) {
           const ids = Array.isArray(params?.[0]) ? (params?.[0] as string[]) : []
           return { rows: ids.map((id) => ({ id })) }
@@ -454,6 +463,9 @@ describe('Public form flow', () => {
 
     expect(getResponse.body.data.allowedUserIds).toEqual(['user_1'])
     expect(getResponse.body.data.allowedUsers[0].label).toBe('User 1')
+    expect(getResponse.body.data.allowedUsers[0].dingtalkBound).toBe(true)
+    expect(getResponse.body.data.allowedUsers[0].dingtalkGrantEnabled).toBe(true)
+    expect(getResponse.body.data.allowedUsers[0].dingtalkPersonDeliveryAvailable).toBe(false)
     expect(getResponse.body.data.allowedMemberGroupIds).toEqual(['group_1'])
 
     const patchResponse = await request(app)


### PR DESCRIPTION
## Summary
- Enrich public-form allowlist subjects with DingTalk binding, grant, and delivery-link status.
- Add an access-rule card to the public form sharing panel for public, DingTalk-bound, and DingTalk-authorized modes.
- Document 142 deployment position and post-deploy validation checklist.

## Verification
- pnpm install
- git diff --check
- pnpm --filter @metasheet/core-backend exec vitest run tests/integration/public-form-flow.test.ts --watch=false
- pnpm --filter @metasheet/web exec vitest run tests/multitable-form-share-manager.spec.ts --watch=false
- pnpm --filter @metasheet/core-backend build
- pnpm --filter @metasheet/web build
- secret scan over changed code/docs: no hits

## 142 status
- 142 currently runs dba5c8e images with the public-form password-change bypass already deployed.
- This PR has not been deployed yet; merge to main is the recommended path to trigger GHCR image build/deploy.
- The previous local admin JWT file now returns 401 from /api/auth/me, so refresh a short-lived app token before post-deploy authenticated checks if needed.