### PR TITLE
feat(integration): add K3 pipeline template creation

### DIFF
--- a/apps/web/src/services/integration/k3WiseSetup.ts
+++ b/apps/web/src/services/integration/k3WiseSetup.ts
@@ -30,9 +30,31 @@ export interface IntegrationExternalSystem {
   credentialFingerprint?: string | null
 }
 
+export interface IntegrationPipeline {
+  id: string
+  tenantId: string
+  workspaceId: string | null
+  projectId?: string | null
+  name: string
+  description?: string | null
+  sourceSystemId: string
+  sourceObject: string
+  targetSystemId: string
+  targetObject: string
+  stagingSheetId?: string | null
+  mode: 'incremental' | 'full' | 'manual'
+  idempotencyKeyFields: string[]
+  options: Record<string, unknown>
+  status: 'draft' | 'active' | 'paused' | 'disabled'
+  fieldMappings?: Array<Record<string, unknown>>
+  createdAt?: string | null
+  updatedAt?: string | null
+}
+
 export interface K3WiseSetupForm {
   tenantId: string
   workspaceId: string
+  projectId: string
   webApiSystemId: string
   webApiHasCredentials: boolean
   webApiName: string
@@ -66,11 +88,21 @@ export interface K3WiseSetupForm {
   sqlAllowedTables: string
   sqlMiddleTables: string
   sqlStoredProcedures: string
+  sourceSystemId: string
+  materialPipelineName: string
+  bomPipelineName: string
+  materialStagingObjectId: string
+  bomStagingObjectId: string
 }
 
 export interface K3WiseSetupPayloads {
   webApi: Record<string, unknown>
   sqlServer: Record<string, unknown> | null
+}
+
+export interface K3WisePipelinePayloads {
+  material: Record<string, unknown>
+  bom: Record<string, unknown>
 }
 
 export interface K3WiseSetupValidationIssue {
@@ -137,6 +169,7 @@ export function createDefaultK3WiseSetupForm(): K3WiseSetupForm {
   return {
     tenantId,
     workspaceId,
+    projectId: '',
     webApiSystemId: '',
     webApiHasCredentials: false,
     webApiName: 'K3 WISE WebAPI',
@@ -170,6 +203,11 @@ export function createDefaultK3WiseSetupForm(): K3WiseSetupForm {
     sqlAllowedTables: 't_ICItem\nt_ICBOM\nt_ICBomChild',
     sqlMiddleTables: '',
     sqlStoredProcedures: '',
+    sourceSystemId: '',
+    materialPipelineName: 'PLM Material to K3 WISE',
+    bomPipelineName: 'PLM BOM to K3 WISE',
+    materialStagingObjectId: 'standard_materials',
+    bomStagingObjectId: 'bom_cleanse',
   }
 }
 
@@ -209,6 +247,18 @@ export function validateK3WiseSetupForm(form: K3WiseSetupForm): K3WiseSetupValid
       issues.push({ field: 'sqlPassword', message: 'SQL Server credentials must include both username and password' })
     }
   }
+  return issues
+}
+
+export function validateK3WisePipelineTemplateForm(form: K3WiseSetupForm): K3WiseSetupValidationIssue[] {
+  const issues: K3WiseSetupValidationIssue[] = []
+  if (!trim(form.tenantId)) issues.push({ field: 'tenantId', message: 'tenantId is required' })
+  if (!trim(form.sourceSystemId)) issues.push({ field: 'sourceSystemId', message: 'PLM source system ID is required' })
+  if (!trim(form.webApiSystemId)) issues.push({ field: 'webApiSystemId', message: 'Save or select a K3 WISE WebAPI system before creating pipelines' })
+  if (!trim(form.materialPipelineName)) issues.push({ field: 'materialPipelineName', message: 'Material pipeline name is required' })
+  if (!trim(form.bomPipelineName)) issues.push({ field: 'bomPipelineName', message: 'BOM pipeline name is required' })
+  if (!trim(form.materialStagingObjectId)) issues.push({ field: 'materialStagingObjectId', message: 'Material staging object is required' })
+  if (!trim(form.bomStagingObjectId)) issues.push({ field: 'bomStagingObjectId', message: 'BOM staging object is required' })
   return issues
 }
 
@@ -326,6 +376,147 @@ export function buildK3WiseSetupPayloads(form: K3WiseSetupForm): K3WiseSetupPayl
   return { webApi, sqlServer }
 }
 
+export function buildK3WisePipelinePayloads(form: K3WiseSetupForm): K3WisePipelinePayloads {
+  const issues = validateK3WisePipelineTemplateForm(form)
+  if (issues.length > 0) {
+    throw new Error(issues[0].message)
+  }
+
+  const tenantId = trim(form.tenantId)
+  const workspaceId = optionalString(form.workspaceId) ?? null
+  const projectId = optionalString(form.projectId) ?? null
+  const sourceSystemId = trim(form.sourceSystemId)
+  const targetSystemId = trim(form.webApiSystemId)
+  const base = {
+    tenantId,
+    workspaceId,
+    ...(projectId ? { projectId } : {}),
+    sourceSystemId,
+    targetSystemId,
+    status: 'draft',
+  }
+
+  return {
+    material: {
+      ...base,
+      name: trim(form.materialPipelineName),
+      description: 'Draft PLM material cleansing pipeline generated from the K3 WISE setup page.',
+      sourceObject: 'materials',
+      targetObject: 'material',
+      mode: 'incremental',
+      idempotencyKeyFields: ['sourceId', 'revision'],
+      options: {
+        batchSize: 100,
+        watermark: {
+          type: 'updated_at',
+          field: 'updatedAt',
+        },
+        erpFeedback: {
+          objectId: trim(form.materialStagingObjectId),
+          keyField: '_integration_idempotency_key',
+        },
+      },
+      fieldMappings: [
+        {
+          sourceField: 'code',
+          targetField: 'FNumber',
+          transform: ['trim', 'upper'],
+          validation: [{ type: 'required' }],
+        },
+        {
+          sourceField: 'name',
+          targetField: 'FName',
+          transform: { fn: 'trim' },
+          validation: [{ type: 'required' }],
+        },
+        {
+          sourceField: 'spec',
+          targetField: 'FModel',
+          transform: { fn: 'trim' },
+        },
+        {
+          sourceField: 'uom',
+          targetField: 'FBaseUnitID',
+          transform: {
+            fn: 'dictMap',
+            map: {
+              PCS: 'Pcs',
+              EA: 'Pcs',
+              KG: 'Kg',
+            },
+          },
+        },
+        {
+          sourceField: 'sourceId',
+          targetField: 'sourceId',
+          validation: [{ type: 'required' }],
+        },
+        {
+          sourceField: 'revision',
+          targetField: 'revision',
+          defaultValue: 'A',
+        },
+      ],
+    },
+    bom: {
+      ...base,
+      name: trim(form.bomPipelineName),
+      description: 'Draft PLM BOM cleansing pipeline generated from the K3 WISE setup page.',
+      sourceObject: 'bom',
+      targetObject: 'bom',
+      mode: 'manual',
+      idempotencyKeyFields: ['sourceId', 'revision'],
+      options: {
+        batchSize: 50,
+        erpFeedback: {
+          objectId: trim(form.bomStagingObjectId),
+          keyField: '_integration_idempotency_key',
+        },
+      },
+      fieldMappings: [
+        {
+          sourceField: 'parentCode',
+          targetField: 'FParentItemNumber',
+          transform: ['trim', 'upper'],
+          validation: [{ type: 'required' }],
+        },
+        {
+          sourceField: 'childCode',
+          targetField: 'FChildItemNumber',
+          transform: ['trim', 'upper'],
+          validation: [{ type: 'required' }],
+        },
+        {
+          sourceField: 'quantity',
+          targetField: 'FQty',
+          transform: { fn: 'toNumber' },
+          validation: [{ type: 'min', value: 0.000001 }],
+        },
+        {
+          sourceField: 'uom',
+          targetField: 'FUnitID',
+          transform: { fn: 'trim' },
+        },
+        {
+          sourceField: 'sequence',
+          targetField: 'FEntryID',
+          transform: { fn: 'toNumber' },
+        },
+        {
+          sourceField: 'sourceId',
+          targetField: 'sourceId',
+          validation: [{ type: 'required' }],
+        },
+        {
+          sourceField: 'revision',
+          targetField: 'revision',
+          defaultValue: 'A',
+        },
+      ],
+    },
+  }
+}
+
 export function applyExternalSystemToForm(form: K3WiseSetupForm, system: IntegrationExternalSystem): K3WiseSetupForm {
   const next = { ...form }
   if (system.kind === WEBAPI_KIND) {
@@ -412,6 +603,14 @@ export async function testIntegrationSystem(systemId: string, input: Record<stri
     body: JSON.stringify(input),
   })
   return parseIntegrationResponse<Record<string, unknown>>(response)
+}
+
+export async function upsertIntegrationPipeline(payload: Record<string, unknown>): Promise<IntegrationPipeline> {
+  const response = await apiFetch('/api/integration/pipelines', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  })
+  return parseIntegrationResponse<IntegrationPipeline>(response)
 }
 
 export const K3_WISE_WEBAPI_KIND = WEBAPI_KIND

--- a/apps/web/src/views/IntegrationK3WiseSetupView.vue
+++ b/apps/web/src/views/IntegrationK3WiseSetupView.vue
@@ -55,6 +55,27 @@
           </button>
           <pre v-if="testResult" class="k3-setup__test-result">{{ testResult }}</pre>
         </div>
+
+        <div class="k3-setup__panel">
+          <div class="k3-setup__panel-head">
+            <h2>清洗链路</h2>
+            <span>draft</span>
+          </div>
+          <button
+            class="k3-setup__btn k3-setup__btn--full"
+            type="button"
+            :disabled="creatingPipelines || pipelineIssues.length > 0"
+            @click="createPipelineTemplates"
+          >
+            {{ creatingPipelines ? '创建中' : '创建清洗 Pipeline' }}
+          </button>
+          <ul v-if="pipelineIssues.length" class="k3-setup__issues k3-setup__issues--compact">
+            <li v-for="issue in pipelineIssues" :key="`pipeline:${issue.field}:${issue.message}`">
+              {{ issue.message }}
+            </li>
+          </ul>
+          <pre v-if="pipelineResult" class="k3-setup__test-result">{{ pipelineResult }}</pre>
+        </div>
       </aside>
 
       <form class="k3-setup__form" @submit.prevent="saveConfiguration">
@@ -247,6 +268,43 @@
             </li>
           </ul>
         </section>
+
+        <section class="k3-setup__section">
+          <div class="k3-setup__section-head">
+            <h2>PLM → K3 清洗链路</h2>
+            <span>multitable staging + pipeline runner</span>
+          </div>
+          <div class="k3-setup__grid">
+            <label class="k3-setup__field">
+              <span>Project ID</span>
+              <input v-model.trim="form.projectId" autocomplete="off" />
+            </label>
+            <label class="k3-setup__field">
+              <span>PLM Source System ID</span>
+              <input v-model.trim="form.sourceSystemId" autocomplete="off" />
+            </label>
+            <label class="k3-setup__field">
+              <span>K3 Target System ID</span>
+              <input v-model.trim="form.webApiSystemId" autocomplete="off" readonly />
+            </label>
+            <label class="k3-setup__field">
+              <span>物料 Pipeline 名称</span>
+              <input v-model.trim="form.materialPipelineName" autocomplete="off" />
+            </label>
+            <label class="k3-setup__field">
+              <span>物料 Staging 对象</span>
+              <input v-model.trim="form.materialStagingObjectId" autocomplete="off" />
+            </label>
+            <label class="k3-setup__field">
+              <span>BOM Pipeline 名称</span>
+              <input v-model.trim="form.bomPipelineName" autocomplete="off" />
+            </label>
+            <label class="k3-setup__field">
+              <span>BOM Staging 对象</span>
+              <input v-model.trim="form.bomStagingObjectId" autocomplete="off" />
+            </label>
+          </div>
+        </section>
       </form>
     </section>
   </section>
@@ -258,11 +316,14 @@ import {
   K3_WISE_SQLSERVER_KIND,
   K3_WISE_WEBAPI_KIND,
   applyExternalSystemToForm,
+  buildK3WisePipelinePayloads,
   buildK3WiseSetupPayloads,
   createDefaultK3WiseSetupForm,
   listIntegrationSystems,
   testIntegrationSystem,
+  upsertIntegrationPipeline,
   upsertIntegrationSystem,
+  validateK3WisePipelineTemplateForm,
   validateK3WiseSetupForm,
   type IntegrationExternalSystem,
 } from '../services/integration/k3WiseSetup'
@@ -274,12 +335,15 @@ const loading = ref(false)
 const saving = ref(false)
 const testingWebApi = ref(false)
 const testingSql = ref(false)
+const creatingPipelines = ref(false)
 const statusMessage = ref('')
 const statusKind = ref<'info' | 'success' | 'error'>('info')
 const testResult = ref('')
+const pipelineResult = ref('')
 
 const savedSystems = computed(() => [...webApiSystems.value, ...sqlSystems.value])
 const validationIssues = computed(() => validateK3WiseSetupForm(form))
+const pipelineIssues = computed(() => validateK3WisePipelineTemplateForm(form))
 
 function setStatus(message: string, kind: 'info' | 'success' | 'error' = 'info'): void {
   statusMessage.value = message
@@ -376,6 +440,32 @@ async function testSqlServer(): Promise<void> {
     setStatus(formatError(error), 'error')
   } finally {
     testingSql.value = false
+  }
+}
+
+async function createPipelineTemplates(): Promise<void> {
+  const issues = validateK3WisePipelineTemplateForm(form)
+  if (issues.length > 0) {
+    setStatus(issues[0].message, 'error')
+    return
+  }
+  creatingPipelines.value = true
+  pipelineResult.value = ''
+  try {
+    const payloads = buildK3WisePipelinePayloads(form)
+    const [material, bom] = await Promise.all([
+      upsertIntegrationPipeline(payloads.material),
+      upsertIntegrationPipeline(payloads.bom),
+    ])
+    pipelineResult.value = JSON.stringify({
+      material: { id: material.id, name: material.name, status: material.status },
+      bom: { id: bom.id, name: bom.name, status: bom.status },
+    }, null, 2)
+    setStatus('PLM → K3 清洗 Pipeline 已创建为 draft', 'success')
+  } catch (error) {
+    setStatus(formatError(error), 'error')
+  } finally {
+    creatingPipelines.value = false
   }
 }
 
@@ -515,6 +605,11 @@ onMounted(() => {
   font: inherit;
 }
 
+.k3-setup__field input[readonly] {
+  background: #f8fafc;
+  color: #64748b;
+}
+
 .k3-setup__field textarea {
   resize: vertical;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
@@ -633,6 +728,11 @@ onMounted(() => {
   margin: 0;
   padding-left: 18px;
   color: #9a3412;
+}
+
+.k3-setup__issues--compact {
+  margin-top: 10px;
+  font-size: 13px;
 }
 
 @media (max-width: 1100px) {

--- a/apps/web/tests/k3WiseSetup.spec.ts
+++ b/apps/web/tests/k3WiseSetup.spec.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import {
   applyExternalSystemToForm,
+  buildK3WisePipelinePayloads,
   buildK3WiseSetupPayloads,
   createDefaultK3WiseSetupForm,
   splitList,
+  validateK3WisePipelineTemplateForm,
   validateK3WiseSetupForm,
   type IntegrationExternalSystem,
 } from '../src/services/integration/k3WiseSetup'
@@ -134,5 +136,76 @@ describe('K3 WISE setup helpers', () => {
 
   it('splits comma and newline table lists', () => {
     expect(splitList('t_ICItem, t_ICBOM\n t_ICBomChild')).toEqual(['t_ICItem', 't_ICBOM', 't_ICBomChild'])
+  })
+
+  it('builds draft material and BOM cleansing pipeline templates', () => {
+    const form = createDefaultK3WiseSetupForm()
+    Object.assign(form, {
+      tenantId: 'tenant_1',
+      workspaceId: 'workspace_1',
+      projectId: 'project_1',
+      sourceSystemId: 'plm_1',
+      webApiSystemId: 'k3_1',
+      materialStagingObjectId: 'standard_materials',
+      bomStagingObjectId: 'bom_cleanse',
+    })
+
+    expect(validateK3WisePipelineTemplateForm(form)).toEqual([])
+    const payloads = buildK3WisePipelinePayloads(form)
+
+    expect(payloads.material).toMatchObject({
+      tenantId: 'tenant_1',
+      workspaceId: 'workspace_1',
+      projectId: 'project_1',
+      sourceSystemId: 'plm_1',
+      targetSystemId: 'k3_1',
+      sourceObject: 'materials',
+      targetObject: 'material',
+      mode: 'incremental',
+      status: 'draft',
+      idempotencyKeyFields: ['sourceId', 'revision'],
+      options: {
+        erpFeedback: {
+          objectId: 'standard_materials',
+          keyField: '_integration_idempotency_key',
+        },
+      },
+    })
+    expect(payloads.material.fieldMappings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ sourceField: 'code', targetField: 'FNumber' }),
+        expect.objectContaining({ sourceField: 'name', targetField: 'FName' }),
+      ]),
+    )
+    expect(payloads.bom).toMatchObject({
+      sourceObject: 'bom',
+      targetObject: 'bom',
+      mode: 'manual',
+      options: {
+        erpFeedback: {
+          objectId: 'bom_cleanse',
+        },
+      },
+    })
+    expect(payloads.bom.fieldMappings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ sourceField: 'parentCode', targetField: 'FParentItemNumber' }),
+        expect.objectContaining({ sourceField: 'quantity', targetField: 'FQty' }),
+      ]),
+    )
+  })
+
+  it('requires saved PLM source and K3 target systems before pipeline template creation', () => {
+    const form = createDefaultK3WiseSetupForm()
+    Object.assign(form, {
+      tenantId: 'tenant_1',
+      sourceSystemId: '',
+      webApiSystemId: '',
+    })
+
+    const messages = validateK3WisePipelineTemplateForm(form).map((issue) => issue.message)
+    expect(messages).toContain('PLM source system ID is required')
+    expect(messages).toContain('Save or select a K3 WISE WebAPI system before creating pipelines')
+    expect(() => buildK3WisePipelinePayloads(form)).toThrow('PLM source system ID is required')
   })
 })

--- a/docs/development/integration-k3wise-pipeline-template-design-20260428.md
+++ b/docs/development/integration-k3wise-pipeline-template-design-20260428.md
@@ -1,0 +1,59 @@
+# K3 WISE Pipeline Template Design
+
+## Context
+
+The K3 WISE setup page already saves and tests ERP external-system records. The next missing operator step was turning a saved PLM source system and K3 target system into the first runnable cleansing pipelines.
+
+## Design
+
+The cleansing chain is split deliberately:
+
+- Multitable sheets are the user-visible staging and audit surface: raw PLM rows, standardized material rows, BOM cleanse rows, exception queues, and run logs.
+- The integration pipeline runner owns automated execution: adapter read, field mapping, transform, validation, idempotency, watermark, ERP write, dead letter, and feedback writeback.
+
+This change adds draft pipeline template creation to the K3 WISE setup page instead of moving cleansing logic into table formulas.
+
+## UI Flow
+
+The `/integrations/k3-wise` page now has a `PLM -> K3 cleansing chain` section:
+
+- `Project ID`
+- `PLM Source System ID`
+- read-only `K3 Target System ID` from the selected/saved WebAPI system
+- material pipeline name and staging object
+- BOM pipeline name and staging object
+
+The side rail has a `Create cleansing Pipeline` action that creates two draft pipelines:
+
+- `materials -> material`
+- `bom -> bom`
+
+They are intentionally `draft`; operators still review mappings and run dry-run before activation.
+
+## Pipeline Defaults
+
+Material pipeline:
+
+- mode: `incremental`
+- idempotency: `sourceId + revision`
+- watermark: `updatedAt`
+- feedback object: `standard_materials`
+- core mappings: `code -> FNumber`, `name -> FName`, `spec -> FModel`, `uom -> FBaseUnitID`
+
+BOM pipeline:
+
+- mode: `manual`
+- idempotency: `sourceId + revision`
+- feedback object: `bom_cleanse`
+- core mappings: `parentCode`, `childCode`, `quantity`, `uom`, `sequence`
+
+The payloads use the existing `POST /api/integration/pipelines` route and require both:
+
+- saved PLM source external-system id
+- saved K3 WISE WebAPI external-system id
+
+## Files
+
+- `apps/web/src/services/integration/k3WiseSetup.ts`
+- `apps/web/src/views/IntegrationK3WiseSetupView.vue`
+- `apps/web/tests/k3WiseSetup.spec.ts`

--- a/docs/development/integration-k3wise-pipeline-template-verification-20260428.md
+++ b/docs/development/integration-k3wise-pipeline-template-verification-20260428.md
@@ -1,0 +1,34 @@
+# K3 WISE Pipeline Template Verification
+
+## Checks
+
+Executed from `/tmp/ms2-integration-pipeline-template-20260428`.
+
+```bash
+NODE_PATH=/Users/chouhua/Downloads/Github/metasheet2/node_modules:/Users/chouhua/Downloads/Github/metasheet2/apps/web/node_modules \
+  /Users/chouhua/Downloads/Github/metasheet2/apps/web/node_modules/.bin/vitest run \
+  apps/web/tests/k3WiseSetup.spec.ts --watch=false
+
+node -e "const { parse, compileScript, compileTemplate } = require('/Users/chouhua/Downloads/Github/metasheet2/node_modules/.pnpm/@vue+compiler-sfc@3.5.24/node_modules/@vue/compiler-sfc'); const fs = require('fs'); const file = 'apps/web/src/views/IntegrationK3WiseSetupView.vue'; const source = fs.readFileSync(file, 'utf8'); const parsed = parse(source, { filename: file }); if (parsed.errors.length) throw parsed.errors[0]; compileScript(parsed.descriptor, { id: 'k3-wise-setup' }); if (parsed.descriptor.template) { const compiled = compileTemplate({ id: 'k3-wise-setup', source: parsed.descriptor.template.content, filename: file }); if (compiled.errors.length) throw compiled.errors[0]; } console.log('SFC compile ok')"
+
+ln -s /Users/chouhua/Downloads/Github/metasheet2/node_modules node_modules
+ln -s /Users/chouhua/Downloads/Github/metasheet2/apps/web/node_modules apps/web/node_modules
+/Users/chouhua/Downloads/Github/metasheet2/apps/web/node_modules/.bin/vue-tsc -p apps/web/tsconfig.app.json --noEmit
+rm -rf node_modules apps/web/node_modules
+
+git diff --check origin/main..HEAD
+```
+
+## Results
+
+- `apps/web/tests/k3WiseSetup.spec.ts`: passed, 7 tests.
+- `IntegrationK3WiseSetupView.vue` SFC parse / script compile / template compile: passed.
+- `vue-tsc -p apps/web/tsconfig.app.json --noEmit`: passed after temporarily linking the main checkout dependency directories into the isolated worktree.
+- `git diff --check origin/main..HEAD`: passed.
+
+## Expected Behavior
+
+- Existing K3 setup payload behavior remains unchanged.
+- `buildK3WisePipelinePayloads()` creates material and BOM draft pipeline payloads using the selected K3 WebAPI external system as target.
+- Template validation blocks creation when the PLM source system id or K3 target system id is missing.
+- The setup page exposes pipeline creation without storing credentials or embedding secrets in the pipeline payload.


### PR DESCRIPTION
## Summary
- add draft PLM -> K3 WISE material and BOM pipeline template builders to the K3 setup service
- expose a setup-page section for PLM source id, project id, staging objects, and one-click draft pipeline creation
- add design and verification notes for the multitable staging + pipeline runner split

## Verification
- NODE_PATH=/Users/chouhua/Downloads/Github/metasheet2/node_modules:/Users/chouhua/Downloads/Github/metasheet2/apps/web/node_modules /Users/chouhua/Downloads/Github/metasheet2/apps/web/node_modules/.bin/vitest run apps/web/tests/k3WiseSetup.spec.ts --watch=false
- IntegrationK3WiseSetupView.vue SFC parse/script/template compile via @vue/compiler-sfc
- vue-tsc -p apps/web/tsconfig.app.json --noEmit after temporarily linking main checkout node_modules into the isolated worktree
- git diff --check origin/main..HEAD