### PR TITLE
feat(integration): add staging install action

### DIFF
--- a/apps/web/src/services/integration/k3WiseSetup.ts
+++ b/apps/web/src/services/integration/k3WiseSetup.ts
@@ -51,10 +51,22 @@ export interface IntegrationPipeline {
   updatedAt?: string | null
 }
 
+export interface IntegrationStagingDescriptor {
+  id: string
+  name: string
+  fields: string[]
+}
+
+export interface IntegrationStagingInstallResult {
+  sheetIds: Record<string, string>
+  warnings: string[]
+}
+
 export interface K3WiseSetupForm {
   tenantId: string
   workspaceId: string
   projectId: string
+  baseId: string
   webApiSystemId: string
   webApiHasCredentials: boolean
   webApiName: string
@@ -103,6 +115,13 @@ export interface K3WiseSetupPayloads {
 export interface K3WisePipelinePayloads {
   material: Record<string, unknown>
   bom: Record<string, unknown>
+}
+
+export interface K3WiseStagingInstallPayload {
+  tenantId: string
+  workspaceId: string | null
+  projectId: string
+  baseId?: string
 }
 
 export interface K3WiseSetupValidationIssue {
@@ -170,6 +189,7 @@ export function createDefaultK3WiseSetupForm(): K3WiseSetupForm {
     tenantId,
     workspaceId,
     projectId: '',
+    baseId: '',
     webApiSystemId: '',
     webApiHasCredentials: false,
     webApiName: 'K3 WISE WebAPI',
@@ -260,6 +280,26 @@ export function validateK3WisePipelineTemplateForm(form: K3WiseSetupForm): K3Wis
   if (!trim(form.materialStagingObjectId)) issues.push({ field: 'materialStagingObjectId', message: 'Material staging object is required' })
   if (!trim(form.bomStagingObjectId)) issues.push({ field: 'bomStagingObjectId', message: 'BOM staging object is required' })
   return issues
+}
+
+export function validateK3WiseStagingInstallForm(form: K3WiseSetupForm): K3WiseSetupValidationIssue[] {
+  const issues: K3WiseSetupValidationIssue[] = []
+  if (!trim(form.tenantId)) issues.push({ field: 'tenantId', message: 'tenantId is required' })
+  if (!trim(form.projectId)) issues.push({ field: 'projectId', message: 'projectId is required before installing staging tables' })
+  return issues
+}
+
+export function buildK3WiseStagingInstallPayload(form: K3WiseSetupForm): K3WiseStagingInstallPayload {
+  const issues = validateK3WiseStagingInstallForm(form)
+  if (issues.length > 0) {
+    throw new Error(issues[0].message)
+  }
+  return {
+    tenantId: trim(form.tenantId),
+    workspaceId: optionalString(form.workspaceId) ?? null,
+    projectId: trim(form.projectId),
+    ...(optionalString(form.baseId) ? { baseId: trim(form.baseId) } : {}),
+  }
 }
 
 export function buildK3WiseSetupPayloads(form: K3WiseSetupForm): K3WiseSetupPayloads {
@@ -611,6 +651,20 @@ export async function upsertIntegrationPipeline(payload: Record<string, unknown>
     body: JSON.stringify(payload),
   })
   return parseIntegrationResponse<IntegrationPipeline>(response)
+}
+
+export async function listIntegrationStagingDescriptors(): Promise<IntegrationStagingDescriptor[]> {
+  const response = await apiFetch('/api/integration/staging/descriptors')
+  const data = await parseIntegrationResponse<IntegrationStagingDescriptor[]>(response)
+  return Array.isArray(data) ? data : []
+}
+
+export async function installIntegrationStaging(payload: K3WiseStagingInstallPayload): Promise<IntegrationStagingInstallResult> {
+  const response = await apiFetch('/api/integration/staging/install', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  })
+  return parseIntegrationResponse<IntegrationStagingInstallResult>(response)
 }
 
 export const K3_WISE_WEBAPI_KIND = WEBAPI_KIND

--- a/apps/web/src/views/IntegrationK3WiseSetupView.vue
+++ b/apps/web/src/views/IntegrationK3WiseSetupView.vue
@@ -64,6 +64,20 @@
           <button
             class="k3-setup__btn k3-setup__btn--full"
             type="button"
+            :disabled="installingStaging || stagingIssues.length > 0"
+            @click="installStagingTables"
+          >
+            {{ installingStaging ? '安装中' : '安装 Staging 多维表' }}
+          </button>
+          <ul v-if="stagingIssues.length" class="k3-setup__issues k3-setup__issues--compact">
+            <li v-for="issue in stagingIssues" :key="`staging:${issue.field}:${issue.message}`">
+              {{ issue.message }}
+            </li>
+          </ul>
+          <pre v-if="stagingResult" class="k3-setup__test-result">{{ stagingResult }}</pre>
+          <button
+            class="k3-setup__btn k3-setup__btn--full"
+            type="button"
             :disabled="creatingPipelines || pipelineIssues.length > 0"
             @click="createPipelineTemplates"
           >
@@ -280,6 +294,10 @@
               <input v-model.trim="form.projectId" autocomplete="off" />
             </label>
             <label class="k3-setup__field">
+              <span>Base ID</span>
+              <input v-model.trim="form.baseId" autocomplete="off" />
+            </label>
+            <label class="k3-setup__field">
               <span>PLM Source System ID</span>
               <input v-model.trim="form.sourceSystemId" autocomplete="off" />
             </label>
@@ -318,13 +336,16 @@ import {
   applyExternalSystemToForm,
   buildK3WisePipelinePayloads,
   buildK3WiseSetupPayloads,
+  buildK3WiseStagingInstallPayload,
   createDefaultK3WiseSetupForm,
+  installIntegrationStaging,
   listIntegrationSystems,
   testIntegrationSystem,
   upsertIntegrationPipeline,
   upsertIntegrationSystem,
   validateK3WisePipelineTemplateForm,
   validateK3WiseSetupForm,
+  validateK3WiseStagingInstallForm,
   type IntegrationExternalSystem,
 } from '../services/integration/k3WiseSetup'
 
@@ -335,14 +356,17 @@ const loading = ref(false)
 const saving = ref(false)
 const testingWebApi = ref(false)
 const testingSql = ref(false)
+const installingStaging = ref(false)
 const creatingPipelines = ref(false)
 const statusMessage = ref('')
 const statusKind = ref<'info' | 'success' | 'error'>('info')
 const testResult = ref('')
+const stagingResult = ref('')
 const pipelineResult = ref('')
 
 const savedSystems = computed(() => [...webApiSystems.value, ...sqlSystems.value])
 const validationIssues = computed(() => validateK3WiseSetupForm(form))
+const stagingIssues = computed(() => validateK3WiseStagingInstallForm(form))
 const pipelineIssues = computed(() => validateK3WisePipelineTemplateForm(form))
 
 function setStatus(message: string, kind: 'info' | 'success' | 'error' = 'info'): void {
@@ -440,6 +464,25 @@ async function testSqlServer(): Promise<void> {
     setStatus(formatError(error), 'error')
   } finally {
     testingSql.value = false
+  }
+}
+
+async function installStagingTables(): Promise<void> {
+  const issues = validateK3WiseStagingInstallForm(form)
+  if (issues.length > 0) {
+    setStatus(issues[0].message, 'error')
+    return
+  }
+  installingStaging.value = true
+  stagingResult.value = ''
+  try {
+    const result = await installIntegrationStaging(buildK3WiseStagingInstallPayload(form))
+    stagingResult.value = JSON.stringify(result, null, 2)
+    setStatus('Staging 多维表已安装或确认存在', result.warnings.length > 0 ? 'info' : 'success')
+  } catch (error) {
+    setStatus(formatError(error), 'error')
+  } finally {
+    installingStaging.value = false
   }
 }
 

--- a/apps/web/tests/k3WiseSetup.spec.ts
+++ b/apps/web/tests/k3WiseSetup.spec.ts
@@ -3,10 +3,12 @@ import {
   applyExternalSystemToForm,
   buildK3WisePipelinePayloads,
   buildK3WiseSetupPayloads,
+  buildK3WiseStagingInstallPayload,
   createDefaultK3WiseSetupForm,
   splitList,
   validateK3WisePipelineTemplateForm,
   validateK3WiseSetupForm,
+  validateK3WiseStagingInstallForm,
   type IntegrationExternalSystem,
 } from '../src/services/integration/k3WiseSetup'
 
@@ -207,5 +209,35 @@ describe('K3 WISE setup helpers', () => {
     expect(messages).toContain('PLM source system ID is required')
     expect(messages).toContain('Save or select a K3 WISE WebAPI system before creating pipelines')
     expect(() => buildK3WisePipelinePayloads(form)).toThrow('PLM source system ID is required')
+  })
+
+  it('builds staging install payloads from tenant and project scope', () => {
+    const form = createDefaultK3WiseSetupForm()
+    Object.assign(form, {
+      tenantId: 'tenant_1',
+      workspaceId: 'workspace_1',
+      projectId: 'project_1',
+      baseId: 'base_1',
+    })
+
+    expect(validateK3WiseStagingInstallForm(form)).toEqual([])
+    expect(buildK3WiseStagingInstallPayload(form)).toEqual({
+      tenantId: 'tenant_1',
+      workspaceId: 'workspace_1',
+      projectId: 'project_1',
+      baseId: 'base_1',
+    })
+  })
+
+  it('requires project scope before staging install', () => {
+    const form = createDefaultK3WiseSetupForm()
+    Object.assign(form, {
+      tenantId: 'tenant_1',
+      projectId: '',
+    })
+
+    const messages = validateK3WiseStagingInstallForm(form).map((issue) => issue.message)
+    expect(messages).toContain('projectId is required before installing staging tables')
+    expect(() => buildK3WiseStagingInstallPayload(form)).toThrow('projectId is required before installing staging tables')
   })
 })

--- a/docs/development/integration-staging-install-ui-design-20260428.md
+++ b/docs/development/integration-staging-install-ui-design-20260428.md
@@ -1,0 +1,47 @@
+# Integration Staging Install UI Design
+
+## Context
+
+The integration plugin already had a staging installer for five user-visible multitable objects:
+
+- `plm_raw_items`
+- `standard_materials`
+- `bom_cleanse`
+- `integration_exceptions`
+- `integration_run_log`
+
+Before this slice, staging could only be provisioned through plugin activation/internal code paths. The K3 WISE setup page could save systems and create draft pipelines, but operators still had no UI action to create the multitable staging workspace those pipelines write feedback into.
+
+## Design
+
+This slice exposes staging installation as a first-class integration control-plane action.
+
+Backend routes:
+
+- `GET /api/integration/staging/descriptors`
+- `POST /api/integration/staging/install`
+
+The install route:
+
+- requires `integration:write`
+- requires tenant scope through the existing `scopedInput()` guard
+- requires `projectId`
+- accepts optional `workspaceId` and `baseId`
+- delegates to the existing `installStaging()` implementation
+
+Frontend:
+
+- The K3 WISE setup form now includes `Base ID` alongside `Project ID`.
+- The side rail now has `Install Staging Tables`.
+- The action sends tenant/workspace/project/base scope to the backend and renders returned `sheetIds` plus any warnings.
+
+The pipeline template still stores logical staging object ids such as `standard_materials` and `bom_cleanse`. The returned physical sheet ids are shown to the operator for traceability; they are not substituted into the pipeline feedback `objectId` fields because feedback writeback resolves logical plugin object ids through the multitable provisioning registry.
+
+## Files
+
+- `plugins/plugin-integration-core/index.cjs`
+- `plugins/plugin-integration-core/lib/http-routes.cjs`
+- `plugins/plugin-integration-core/__tests__/http-routes.test.cjs`
+- `apps/web/src/services/integration/k3WiseSetup.ts`
+- `apps/web/src/views/IntegrationK3WiseSetupView.vue`
+- `apps/web/tests/k3WiseSetup.spec.ts`

--- a/docs/development/integration-staging-install-ui-verification-20260428.md
+++ b/docs/development/integration-staging-install-ui-verification-20260428.md
@@ -1,0 +1,48 @@
+# Integration Staging Install UI Verification
+
+## Commands
+
+Executed from `/tmp/ms2-integration-staging-install-ui-20260428`.
+
+```bash
+node plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+
+NODE_PATH=/Users/chouhua/Downloads/Github/metasheet2/node_modules:/Users/chouhua/Downloads/Github/metasheet2/apps/web/node_modules \
+  /Users/chouhua/Downloads/Github/metasheet2/apps/web/node_modules/.bin/vitest run \
+  apps/web/tests/k3WiseSetup.spec.ts --watch=false
+
+node -c plugins/plugin-integration-core/lib/http-routes.cjs
+node -c plugins/plugin-integration-core/index.cjs
+
+node plugins/plugin-integration-core/__tests__/staging-installer.test.cjs
+
+node -e "const { parse, compileScript, compileTemplate } = require('/Users/chouhua/Downloads/Github/metasheet2/node_modules/.pnpm/@vue+compiler-sfc@3.5.24/node_modules/@vue/compiler-sfc'); const fs = require('fs'); const file = 'apps/web/src/views/IntegrationK3WiseSetupView.vue'; const source = fs.readFileSync(file, 'utf8'); const parsed = parse(source, { filename: file }); if (parsed.errors.length) throw parsed.errors[0]; compileScript(parsed.descriptor, { id: 'k3-wise-setup' }); if (parsed.descriptor.template) { const compiled = compileTemplate({ id: 'k3-wise-setup', source: parsed.descriptor.template.content, filename: file }); if (compiled.errors.length) throw compiled.errors[0]; } console.log('SFC compile ok')"
+
+ln -s /Users/chouhua/Downloads/Github/metasheet2/node_modules node_modules
+ln -s /Users/chouhua/Downloads/Github/metasheet2/packages/core-backend/node_modules packages/core-backend/node_modules
+node --import /Users/chouhua/Downloads/Github/metasheet2/node_modules/.pnpm/tsx@4.20.6/node_modules/tsx/dist/loader.mjs \
+  plugins/plugin-integration-core/__tests__/host-loader-smoke.test.mjs
+rm -rf node_modules packages/core-backend/node_modules
+
+ln -s /Users/chouhua/Downloads/Github/metasheet2/node_modules node_modules
+ln -s /Users/chouhua/Downloads/Github/metasheet2/apps/web/node_modules apps/web/node_modules
+/Users/chouhua/Downloads/Github/metasheet2/apps/web/node_modules/.bin/vue-tsc -p apps/web/tsconfig.app.json --noEmit
+rm -rf node_modules apps/web/node_modules
+
+git diff --check
+```
+
+## Results
+
+- `http-routes.test.cjs`: passed, including descriptor and install route coverage.
+- `k3WiseSetup.spec.ts`: passed, 9 tests.
+- `node -c` for changed CommonJS files: passed.
+- `staging-installer.test.cjs`: passed.
+- `IntegrationK3WiseSetupView.vue` SFC compile: passed.
+- `host-loader-smoke.test.mjs`: passed after temporarily linking main checkout dependencies into the isolated worktree.
+- `vue-tsc -p apps/web/tsconfig.app.json --noEmit`: passed after temporarily linking main checkout dependencies into the isolated worktree.
+- `git diff --check`: passed.
+
+## Notes
+
+The first host-loader attempt without dependency links failed because the isolated worktree could not resolve `tsx` / backend dependencies. The linked-dependency rerun passed and the temporary links were removed.

--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -197,6 +197,25 @@ function createMockServices(overrides = {}) {
         return [deadLetter]
       },
     },
+    stagingInstaller: {
+      listStagingDescriptors() {
+        calls.push(['listStagingDescriptors'])
+        return [
+          { id: 'standard_materials', name: 'Standard Materials', fields: ['code', 'name'] },
+          { id: 'bom_cleanse', name: 'BOM Cleanse', fields: ['parentCode', 'childCode'] },
+        ]
+      },
+      async installStaging(input) {
+        calls.push(['installStaging', input])
+        return {
+          sheetIds: {
+            standard_materials: 'sheet_materials',
+            bom_cleanse: 'sheet_bom',
+          },
+          warnings: [],
+        }
+      },
+    },
   }
 
   return {
@@ -593,6 +612,58 @@ async function testPipelineRoutes() {
   })
   assert.equal(dryModeRes.statusCode, 400, "mode 'replay' must be rejected on dry-run too")
   assert.equal(dryModeRes.body.error.code, 'INVALID_RUN_MODE')
+}
+
+async function testStagingRoutes() {
+  const { calls, services } = createMockServices()
+  const { routes, registered } = mountRoutes(services)
+
+  assert.ok(
+    registered.includes('GET /api/integration/staging/descriptors'),
+    'staging descriptors route registered',
+  )
+  assert.ok(
+    registered.includes('POST /api/integration/staging/install'),
+    'staging install route registered',
+  )
+
+  let res = await invoke(routes, 'GET', '/api/integration/staging/descriptors', {
+    user: READ_USER,
+    query: { workspaceId: 'workspace_1' },
+  })
+  assertOkResponse(res, 200)
+  assert.deepEqual(res.body.data.map((item) => item.id), ['standard_materials', 'bom_cleanse'])
+  assert.equal(findCalls(calls, 'listStagingDescriptors').length, 1)
+
+  res = await invoke(routes, 'POST', '/api/integration/staging/install', {
+    user: WRITE_USER,
+    body: {
+      tenantId: 'tenant_1',
+      workspaceId: 'workspace_1',
+      projectId: 'project_1',
+      baseId: 'base_1',
+    },
+  })
+  assertOkResponse(res, 201)
+  assert.deepEqual(res.body.data.sheetIds, {
+    standard_materials: 'sheet_materials',
+    bom_cleanse: 'sheet_bom',
+  })
+  assert.deepEqual(findCall(calls, 'installStaging')[1], {
+    tenantId: 'tenant_1',
+    workspaceId: 'workspace_1',
+    projectId: 'project_1',
+    baseId: 'base_1',
+  })
+
+  const missingProject = await invoke(routes, 'POST', '/api/integration/staging/install', {
+    user: WRITE_USER,
+    body: {
+      tenantId: 'tenant_1',
+      workspaceId: 'workspace_1',
+    },
+  })
+  assertErrorResponse(missingProject, [400])
 }
 
 async function testRunAndDeadLetterRoutes() {
@@ -1011,6 +1082,7 @@ async function main() {
   await testExternalSystemRoutes()
   await testExternalSystemTestPersistsFailureAndPreservesInactive()
   await testPipelineRoutes()
+  await testStagingRoutes()
   await testRunAndDeadLetterRoutes()
   await testErrorResponseShape()
   await testTenantGuards()
@@ -1018,7 +1090,7 @@ async function main() {
   await testSampleLimitCap()
   await testListOffsetCap()
 
-  console.log('http-routes: REST auth/list/upsert/run/dry-run/replay tests passed')
+  console.log('http-routes: REST auth/list/upsert/run/dry-run/staging/replay tests passed')
 }
 
 main().catch((err) => {

--- a/plugins/plugin-integration-core/index.cjs
+++ b/plugins/plugin-integration-core/index.cjs
@@ -30,6 +30,7 @@ const { createWatermarkStore } = require('./lib/watermark.cjs')
 const { createRunLogger } = require('./lib/run-log.cjs')
 const { createErpFeedbackWriter } = require('./lib/erp-feedback.cjs')
 const { createPipelineRunner } = require('./lib/pipeline-runner.cjs')
+const { installStaging, listStagingDescriptors } = require('./lib/staging-installer.cjs')
 const { registerIntegrationRoutes } = require('./lib/http-routes.cjs')
 
 const registeredRoutes = []
@@ -43,6 +44,7 @@ let watermarkStore = null
 let runLogger = null
 let erpFeedbackWriter = null
 let pipelineRunner = null
+let stagingInstaller = null
 
 function buildHealthPayload() {
   return {
@@ -73,6 +75,7 @@ function buildCommunicationApi() {
         pipelines: Boolean(pipelineRegistry),
         runner: Boolean(pipelineRunner),
         erpFeedback: Boolean(erpFeedbackWriter),
+        staging: Boolean(stagingInstaller),
       }
     },
     async upsertExternalSystem(input) {
@@ -119,6 +122,14 @@ function buildCommunicationApi() {
       if (!pipelineRunner) throw new Error('pipeline runner is not initialized')
       return pipelineRunner.runPipeline(input)
     },
+    async listStagingDescriptors() {
+      if (!stagingInstaller) throw new Error('staging installer is not initialized')
+      return stagingInstaller.listStagingDescriptors()
+    },
+    async installStaging(input) {
+      if (!stagingInstaller) throw new Error('staging installer is not initialized')
+      return stagingInstaller.installStaging(input)
+    },
   }
 }
 
@@ -151,6 +162,17 @@ module.exports = {
       context,
       logger,
     })
+    stagingInstaller = {
+      listStagingDescriptors,
+      installStaging(input = {}) {
+        return installStaging({
+          context,
+          projectId: input.projectId,
+          baseId: input.baseId || null,
+          logger,
+        })
+      },
+    }
     pipelineRunner = createPipelineRunner({
       pipelineRegistry,
       externalSystemRegistry,
@@ -175,6 +197,7 @@ module.exports = {
         pipelineRegistry,
         pipelineRunner,
         deadLetterStore,
+        stagingInstaller,
       },
     }))
 
@@ -200,6 +223,7 @@ module.exports = {
     runLogger = null
     erpFeedbackWriter = null
     pipelineRunner = null
+    stagingInstaller = null
     activeContext = null
     logger.info(`[${PLUGIN_ID}] deactivated`)
   },

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -19,6 +19,8 @@ const ROUTES = [
   ['GET', '/api/integration/pipelines/:id', 'pipelinesGet'],
   ['POST', '/api/integration/pipelines/:id/run', 'pipelinesRun'],
   ['POST', '/api/integration/pipelines/:id/dry-run', 'pipelinesDryRun'],
+  ['GET', '/api/integration/staging/descriptors', 'stagingDescriptors'],
+  ['POST', '/api/integration/staging/install', 'stagingInstall'],
   ['GET', '/api/integration/runs', 'runsList'],
   ['GET', '/api/integration/dead-letters', 'deadLettersList'],
   ['POST', '/api/integration/dead-letters/:id/replay', 'deadLettersReplay'],
@@ -310,6 +312,7 @@ function createHandlers(services) {
   const pipelineRegistry = requireService('pipelineRegistry', ['upsertPipeline', 'getPipeline', 'listPipelines', 'listPipelineRuns'])
   const runner = requireService('pipelineRunner', ['runPipeline'])
   const deadLetters = requireService('deadLetterStore', ['listDeadLetters'])
+  const stagingInstaller = requireService('stagingInstaller', ['installStaging', 'listStagingDescriptors'])
 
   const handlers = {
     async status(req, res) {
@@ -411,6 +414,27 @@ function createHandlers(services) {
         triggeredBy: 'api',
         dryRun: true,
       })), 200)
+    },
+
+    async stagingDescriptors(req, res) {
+      requireAccess(req, 'read')
+      return sendOk(res, await stagingInstaller.listStagingDescriptors())
+    },
+
+    async stagingInstall(req, res) {
+      requireAccess(req, 'write')
+      const body = requestBody(req)
+      const projectId = firstString(body.projectId, requestQuery(req).projectId)
+      if (!projectId) {
+        throw new HttpRouteError(400, 'PROJECT_REQUIRED', 'projectId is required')
+      }
+      const baseId = firstString(body.baseId, requestQuery(req).baseId)
+      return sendOk(res, await stagingInstaller.installStaging(scopedInput(req, {
+        tenantId: body.tenantId,
+        workspaceId: body.workspaceId,
+        projectId,
+        baseId,
+      })), 201)
     },
 
     async runsList(req, res) {


### PR DESCRIPTION
## Summary
- expose integration staging descriptor/install routes backed by the existing staging-installer
- wire the integration plugin runtime and communication API to the staging installer
- add a K3 WISE setup-page action to install/confirm staging multitable objects before creating draft cleansing pipelines
- record design and verification notes

## Verification
- node plugins/plugin-integration-core/__tests__/http-routes.test.cjs
- NODE_PATH=/Users/chouhua/Downloads/Github/metasheet2/node_modules:/Users/chouhua/Downloads/Github/metasheet2/apps/web/node_modules /Users/chouhua/Downloads/Github/metasheet2/apps/web/node_modules/.bin/vitest run apps/web/tests/k3WiseSetup.spec.ts --watch=false
- node -c plugins/plugin-integration-core/lib/http-routes.cjs && node -c plugins/plugin-integration-core/index.cjs
- node plugins/plugin-integration-core/__tests__/staging-installer.test.cjs
- IntegrationK3WiseSetupView.vue SFC parse/script/template compile via @vue/compiler-sfc
- host-loader-smoke.test.mjs with temporary main-checkout dependency links
- vue-tsc -p apps/web/tsconfig.app.json --noEmit with temporary main-checkout dependency links
- git diff --check origin/main..HEAD