### PR TITLE
feat(integration): add pipeline run actions

### DIFF
--- a/apps/web/src/services/integration/k3WiseSetup.ts
+++ b/apps/web/src/services/integration/k3WiseSetup.ts
@@ -2,6 +2,8 @@ import { apiFetch } from '../../utils/api'
 
 export type IntegrationSystemStatus = 'active' | 'inactive' | 'error'
 export type K3SqlServerMode = 'readonly' | 'middle-table' | 'stored-procedure'
+export type IntegrationPipelineRunMode = 'manual' | 'incremental' | 'full'
+export type K3WisePipelineTarget = 'material' | 'bom'
 
 export interface IntegrationApiEnvelope<T> {
   ok: boolean
@@ -49,6 +51,16 @@ export interface IntegrationPipeline {
   fieldMappings?: Array<Record<string, unknown>>
   createdAt?: string | null
   updatedAt?: string | null
+}
+
+export interface IntegrationPipelineRunResult {
+  id?: string
+  runId?: string
+  pipelineId?: string
+  status?: string
+  dryRun?: boolean
+  metrics?: Record<string, unknown>
+  [key: string]: unknown
 }
 
 export interface IntegrationStagingDescriptor {
@@ -102,9 +114,15 @@ export interface K3WiseSetupForm {
   sqlStoredProcedures: string
   sourceSystemId: string
   materialPipelineName: string
+  materialPipelineId: string
   bomPipelineName: string
+  bomPipelineId: string
   materialStagingObjectId: string
   bomStagingObjectId: string
+  pipelineRunMode: IntegrationPipelineRunMode
+  pipelineSampleLimit: string
+  pipelineCursor: string
+  allowLivePipelineRun: boolean
 }
 
 export interface K3WiseSetupPayloads {
@@ -122,6 +140,14 @@ export interface K3WiseStagingInstallPayload {
   workspaceId: string | null
   projectId: string
   baseId?: string
+}
+
+export interface K3WisePipelineRunPayload {
+  tenantId: string
+  workspaceId?: string | null
+  mode: IntegrationPipelineRunMode
+  cursor?: string
+  sampleLimit?: number
 }
 
 export interface K3WiseSetupValidationIssue {
@@ -153,6 +179,13 @@ function parsePositiveInteger(value: string, fallback: number): number {
   if (!normalized) return fallback
   const parsed = Number(normalized)
   return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback
+}
+
+function parseOptionalPositiveInteger(value: string): number | undefined {
+  const normalized = trim(value)
+  if (!normalized) return undefined
+  const parsed = Number(normalized)
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined
 }
 
 function assertRelativePath(value: string, field: keyof K3WiseSetupForm, issues: K3WiseSetupValidationIssue[]): void {
@@ -225,9 +258,15 @@ export function createDefaultK3WiseSetupForm(): K3WiseSetupForm {
     sqlStoredProcedures: '',
     sourceSystemId: '',
     materialPipelineName: 'PLM Material to K3 WISE',
+    materialPipelineId: '',
     bomPipelineName: 'PLM BOM to K3 WISE',
+    bomPipelineId: '',
     materialStagingObjectId: 'standard_materials',
     bomStagingObjectId: 'bom_cleanse',
+    pipelineRunMode: 'manual',
+    pipelineSampleLimit: '20',
+    pipelineCursor: '',
+    allowLivePipelineRun: false,
   }
 }
 
@@ -289,6 +328,29 @@ export function validateK3WiseStagingInstallForm(form: K3WiseSetupForm): K3WiseS
   return issues
 }
 
+export function validateK3WisePipelineRunForm(
+  form: K3WiseSetupForm,
+  target: K3WisePipelineTarget,
+): K3WiseSetupValidationIssue[] {
+  const issues: K3WiseSetupValidationIssue[] = []
+  const pipelineField: keyof K3WiseSetupForm = target === 'material' ? 'materialPipelineId' : 'bomPipelineId'
+  const pipelineId = trim(form[pipelineField])
+  if (!trim(form.tenantId)) issues.push({ field: 'tenantId', message: 'tenantId is required' })
+  if (!pipelineId) {
+    issues.push({
+      field: pipelineField,
+      message: `${target === 'material' ? 'Material' : 'BOM'} pipeline ID is required before dry-run or run`,
+    })
+  }
+  if (!['manual', 'incremental', 'full'].includes(form.pipelineRunMode)) {
+    issues.push({ field: 'pipelineRunMode', message: 'Pipeline run mode must be manual, incremental, or full' })
+  }
+  if (trim(form.pipelineSampleLimit) && parseOptionalPositiveInteger(form.pipelineSampleLimit) === undefined) {
+    issues.push({ field: 'pipelineSampleLimit', message: 'Sample limit must be a positive integer' })
+  }
+  return issues
+}
+
 export function buildK3WiseStagingInstallPayload(form: K3WiseSetupForm): K3WiseStagingInstallPayload {
   const issues = validateK3WiseStagingInstallForm(form)
   if (issues.length > 0) {
@@ -300,6 +362,28 @@ export function buildK3WiseStagingInstallPayload(form: K3WiseSetupForm): K3WiseS
     projectId: trim(form.projectId),
     ...(optionalString(form.baseId) ? { baseId: trim(form.baseId) } : {}),
   }
+}
+
+export function getK3WisePipelineId(form: K3WiseSetupForm, target: K3WisePipelineTarget): string {
+  return target === 'material' ? trim(form.materialPipelineId) : trim(form.bomPipelineId)
+}
+
+export function buildK3WisePipelineRunPayload(form: K3WiseSetupForm, target: K3WisePipelineTarget): K3WisePipelineRunPayload {
+  const issues = validateK3WisePipelineRunForm(form, target)
+  if (issues.length > 0) {
+    throw new Error(issues[0].message)
+  }
+
+  const payload: K3WisePipelineRunPayload = {
+    tenantId: trim(form.tenantId),
+    workspaceId: optionalString(form.workspaceId) ?? null,
+    mode: form.pipelineRunMode,
+  }
+  const sampleLimit = parseOptionalPositiveInteger(form.pipelineSampleLimit)
+  if (sampleLimit !== undefined) payload.sampleLimit = sampleLimit
+  const cursor = optionalString(form.pipelineCursor)
+  if (cursor) payload.cursor = cursor
+  return payload
 }
 
 export function buildK3WiseSetupPayloads(form: K3WiseSetupForm): K3WiseSetupPayloads {
@@ -651,6 +735,19 @@ export async function upsertIntegrationPipeline(payload: Record<string, unknown>
     body: JSON.stringify(payload),
   })
   return parseIntegrationResponse<IntegrationPipeline>(response)
+}
+
+export async function runIntegrationPipeline(
+  pipelineId: string,
+  payload: K3WisePipelineRunPayload,
+  dryRun = false,
+): Promise<IntegrationPipelineRunResult> {
+  const endpoint = dryRun ? 'dry-run' : 'run'
+  const response = await apiFetch(`/api/integration/pipelines/${encodeURIComponent(pipelineId)}/${endpoint}`, {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  })
+  return parseIntegrationResponse<IntegrationPipelineRunResult>(response)
 }
 
 export async function listIntegrationStagingDescriptors(): Promise<IntegrationStagingDescriptor[]> {

--- a/apps/web/src/views/IntegrationK3WiseSetupView.vue
+++ b/apps/web/src/views/IntegrationK3WiseSetupView.vue
@@ -90,6 +90,51 @@
           </ul>
           <pre v-if="pipelineResult" class="k3-setup__test-result">{{ pipelineResult }}</pre>
         </div>
+
+        <div class="k3-setup__panel">
+          <div class="k3-setup__panel-head">
+            <h2>执行 Pipeline</h2>
+            <span>{{ form.allowLivePipelineRun ? 'run enabled' : 'dry-run first' }}</span>
+          </div>
+          <button
+            class="k3-setup__btn k3-setup__btn--full"
+            type="button"
+            :disabled="isPipelineRunDisabled('material', true)"
+            @click="executePipeline('material', true)"
+          >
+            {{ runningPipeline === 'material:dry-run' ? 'Dry-run 中' : 'Dry-run 物料' }}
+          </button>
+          <button
+            class="k3-setup__btn k3-setup__btn--full"
+            type="button"
+            :disabled="isPipelineRunDisabled('material', false)"
+            @click="executePipeline('material', false)"
+          >
+            {{ runningPipeline === 'material:run' ? '执行中' : '执行物料' }}
+          </button>
+          <button
+            class="k3-setup__btn k3-setup__btn--full"
+            type="button"
+            :disabled="isPipelineRunDisabled('bom', true)"
+            @click="executePipeline('bom', true)"
+          >
+            {{ runningPipeline === 'bom:dry-run' ? 'Dry-run 中' : 'Dry-run BOM' }}
+          </button>
+          <button
+            class="k3-setup__btn k3-setup__btn--full"
+            type="button"
+            :disabled="isPipelineRunDisabled('bom', false)"
+            @click="executePipeline('bom', false)"
+          >
+            {{ runningPipeline === 'bom:run' ? '执行中' : '执行 BOM' }}
+          </button>
+          <ul v-if="materialRunIssues.length || bomRunIssues.length" class="k3-setup__issues k3-setup__issues--compact">
+            <li v-for="issue in [...materialRunIssues, ...bomRunIssues]" :key="`run:${issue.field}:${issue.message}`">
+              {{ issue.message }}
+            </li>
+          </ul>
+          <pre v-if="pipelineRunResult" class="k3-setup__test-result">{{ pipelineRunResult }}</pre>
+        </div>
       </aside>
 
       <form class="k3-setup__form" @submit.prevent="saveConfiguration">
@@ -310,6 +355,10 @@
               <input v-model.trim="form.materialPipelineName" autocomplete="off" />
             </label>
             <label class="k3-setup__field">
+              <span>物料 Pipeline ID</span>
+              <input v-model.trim="form.materialPipelineId" autocomplete="off" />
+            </label>
+            <label class="k3-setup__field">
               <span>物料 Staging 对象</span>
               <input v-model.trim="form.materialStagingObjectId" autocomplete="off" />
             </label>
@@ -318,8 +367,32 @@
               <input v-model.trim="form.bomPipelineName" autocomplete="off" />
             </label>
             <label class="k3-setup__field">
+              <span>BOM Pipeline ID</span>
+              <input v-model.trim="form.bomPipelineId" autocomplete="off" />
+            </label>
+            <label class="k3-setup__field">
               <span>BOM Staging 对象</span>
               <input v-model.trim="form.bomStagingObjectId" autocomplete="off" />
+            </label>
+            <label class="k3-setup__field">
+              <span>执行模式</span>
+              <select v-model="form.pipelineRunMode">
+                <option value="manual">manual</option>
+                <option value="incremental">incremental</option>
+                <option value="full">full</option>
+              </select>
+            </label>
+            <label class="k3-setup__field">
+              <span>Sample Limit</span>
+              <input v-model.trim="form.pipelineSampleLimit" inputmode="numeric" autocomplete="off" />
+            </label>
+            <label class="k3-setup__field">
+              <span>Cursor</span>
+              <input v-model.trim="form.pipelineCursor" autocomplete="off" />
+            </label>
+            <label class="k3-setup__check">
+              <input v-model="form.allowLivePipelineRun" type="checkbox" />
+              <span>允许真实执行 Pipeline</span>
             </label>
           </div>
         </section>
@@ -335,18 +408,23 @@ import {
   K3_WISE_WEBAPI_KIND,
   applyExternalSystemToForm,
   buildK3WisePipelinePayloads,
+  buildK3WisePipelineRunPayload,
   buildK3WiseSetupPayloads,
   buildK3WiseStagingInstallPayload,
   createDefaultK3WiseSetupForm,
+  getK3WisePipelineId,
   installIntegrationStaging,
   listIntegrationSystems,
+  runIntegrationPipeline,
   testIntegrationSystem,
   upsertIntegrationPipeline,
   upsertIntegrationSystem,
   validateK3WisePipelineTemplateForm,
+  validateK3WisePipelineRunForm,
   validateK3WiseSetupForm,
   validateK3WiseStagingInstallForm,
   type IntegrationExternalSystem,
+  type K3WisePipelineTarget,
 } from '../services/integration/k3WiseSetup'
 
 const form = reactive(createDefaultK3WiseSetupForm())
@@ -358,16 +436,20 @@ const testingWebApi = ref(false)
 const testingSql = ref(false)
 const installingStaging = ref(false)
 const creatingPipelines = ref(false)
+const runningPipeline = ref('')
 const statusMessage = ref('')
 const statusKind = ref<'info' | 'success' | 'error'>('info')
 const testResult = ref('')
 const stagingResult = ref('')
 const pipelineResult = ref('')
+const pipelineRunResult = ref('')
 
 const savedSystems = computed(() => [...webApiSystems.value, ...sqlSystems.value])
 const validationIssues = computed(() => validateK3WiseSetupForm(form))
 const stagingIssues = computed(() => validateK3WiseStagingInstallForm(form))
 const pipelineIssues = computed(() => validateK3WisePipelineTemplateForm(form))
+const materialRunIssues = computed(() => validateK3WisePipelineRunForm(form, 'material'))
+const bomRunIssues = computed(() => validateK3WisePipelineRunForm(form, 'bom'))
 
 function setStatus(message: string, kind: 'info' | 'success' | 'error' = 'info'): void {
   statusMessage.value = message
@@ -500,6 +582,8 @@ async function createPipelineTemplates(): Promise<void> {
       upsertIntegrationPipeline(payloads.material),
       upsertIntegrationPipeline(payloads.bom),
     ])
+    form.materialPipelineId = material.id
+    form.bomPipelineId = bom.id
     pipelineResult.value = JSON.stringify({
       material: { id: material.id, name: material.name, status: material.status },
       bom: { id: bom.id, name: bom.name, status: bom.status },
@@ -509,6 +593,40 @@ async function createPipelineTemplates(): Promise<void> {
     setStatus(formatError(error), 'error')
   } finally {
     creatingPipelines.value = false
+  }
+}
+
+function isPipelineRunDisabled(target: K3WisePipelineTarget, dryRun: boolean): boolean {
+  const issues = target === 'material' ? materialRunIssues.value : bomRunIssues.value
+  return Boolean(runningPipeline.value || issues.length > 0 || (!dryRun && !form.allowLivePipelineRun))
+}
+
+async function executePipeline(target: K3WisePipelineTarget, dryRun: boolean): Promise<void> {
+  const issues = validateK3WisePipelineRunForm(form, target)
+  if (issues.length > 0) {
+    setStatus(issues[0].message, 'error')
+    return
+  }
+  if (!dryRun && !form.allowLivePipelineRun) {
+    setStatus('真实执行前需要勾选允许真实执行 Pipeline', 'error')
+    return
+  }
+  runningPipeline.value = `${target}:${dryRun ? 'dry-run' : 'run'}`
+  pipelineRunResult.value = ''
+  try {
+    const pipelineId = getK3WisePipelineId(form, target)
+    const result = await runIntegrationPipeline(pipelineId, buildK3WisePipelineRunPayload(form, target), dryRun)
+    pipelineRunResult.value = JSON.stringify({
+      target,
+      dryRun,
+      pipelineId,
+      result,
+    }, null, 2)
+    setStatus(`${target === 'material' ? '物料' : 'BOM'} Pipeline ${dryRun ? 'dry-run' : 'run'} 已提交`, 'success')
+  } catch (error) {
+    setStatus(formatError(error), 'error')
+  } finally {
+    runningPipeline.value = ''
   }
 }
 

--- a/apps/web/tests/k3WiseSetup.spec.ts
+++ b/apps/web/tests/k3WiseSetup.spec.ts
@@ -2,11 +2,14 @@ import { describe, expect, it } from 'vitest'
 import {
   applyExternalSystemToForm,
   buildK3WisePipelinePayloads,
+  buildK3WisePipelineRunPayload,
   buildK3WiseSetupPayloads,
   buildK3WiseStagingInstallPayload,
   createDefaultK3WiseSetupForm,
+  getK3WisePipelineId,
   splitList,
   validateK3WisePipelineTemplateForm,
+  validateK3WisePipelineRunForm,
   validateK3WiseSetupForm,
   validateK3WiseStagingInstallForm,
   type IntegrationExternalSystem,
@@ -239,5 +242,45 @@ describe('K3 WISE setup helpers', () => {
     const messages = validateK3WiseStagingInstallForm(form).map((issue) => issue.message)
     expect(messages).toContain('projectId is required before installing staging tables')
     expect(() => buildK3WiseStagingInstallPayload(form)).toThrow('projectId is required before installing staging tables')
+  })
+
+  it('builds pipeline dry-run and run payloads with only public run fields', () => {
+    const form = createDefaultK3WiseSetupForm()
+    Object.assign(form, {
+      tenantId: 'tenant_1',
+      workspaceId: 'workspace_1',
+      materialPipelineId: 'pipe_material',
+      bomPipelineId: 'pipe_bom',
+      pipelineRunMode: 'incremental',
+      pipelineSampleLimit: '25',
+      pipelineCursor: 'wm_123',
+      allowLivePipelineRun: true,
+    })
+
+    expect(validateK3WisePipelineRunForm(form, 'material')).toEqual([])
+    expect(getK3WisePipelineId(form, 'material')).toBe('pipe_material')
+    expect(getK3WisePipelineId(form, 'bom')).toBe('pipe_bom')
+    expect(buildK3WisePipelineRunPayload(form, 'material')).toEqual({
+      tenantId: 'tenant_1',
+      workspaceId: 'workspace_1',
+      mode: 'incremental',
+      sampleLimit: 25,
+      cursor: 'wm_123',
+    })
+  })
+
+  it('requires tenant, pipeline id, and positive sample limit before pipeline execution', () => {
+    const form = createDefaultK3WiseSetupForm()
+    Object.assign(form, {
+      tenantId: '',
+      materialPipelineId: '',
+      pipelineSampleLimit: '0',
+    })
+
+    const messages = validateK3WisePipelineRunForm(form, 'material').map((issue) => issue.message)
+    expect(messages).toContain('tenantId is required')
+    expect(messages).toContain('Material pipeline ID is required before dry-run or run')
+    expect(messages).toContain('Sample limit must be a positive integer')
+    expect(() => buildK3WisePipelineRunPayload(form, 'material')).toThrow('tenantId is required')
   })
 })

--- a/docs/development/integration-pipeline-run-ui-design-20260428.md
+++ b/docs/development/integration-pipeline-run-ui-design-20260428.md
@@ -1,0 +1,87 @@
+# Integration Pipeline Run UI Design - 2026-04-28
+
+## Status
+
+Implemented in `codex/integration-pipeline-run-ui-20260428`.
+
+This slice completes the K3 WISE setup page control loop after staging installation
+and draft pipeline creation:
+
+1. Save or select the K3 WISE WebAPI target.
+2. Install the PLM/K3 staging multitable objects.
+3. Create draft material and BOM cleansing pipelines.
+4. Dry-run or run those pipelines from the setup page.
+
+## Files
+
+- `apps/web/src/views/IntegrationK3WiseSetupView.vue`
+- `apps/web/src/services/integration/k3WiseSetup.ts`
+- `apps/web/tests/k3WiseSetup.spec.ts`
+
+## UI Behavior
+
+The `PLM -> K3 清洗链路` section now stores the generated or manually entered
+pipeline IDs:
+
+- `materialPipelineId`
+- `bomPipelineId`
+
+It also exposes the public run options accepted by the plugin REST API:
+
+- `pipelineRunMode`: `manual`, `incremental`, or `full`
+- `pipelineSampleLimit`: optional positive integer
+- `pipelineCursor`: optional string cursor
+- `allowLivePipelineRun`: explicit live-run guard
+
+The side rail now has an `执行 Pipeline` panel with four actions:
+
+- Dry-run material
+- Run material
+- Dry-run BOM
+- Run BOM
+
+Creating draft pipeline templates writes returned IDs back into the form, so the
+operator can dry-run immediately without copying IDs by hand.
+
+## API Contract
+
+The frontend posts to the existing plugin routes:
+
+- `POST /api/integration/pipelines/:id/dry-run`
+- `POST /api/integration/pipelines/:id/run`
+
+The request body is intentionally limited to the route whitelist:
+
+```json
+{
+  "tenantId": "tenant_1",
+  "workspaceId": "workspace_1",
+  "mode": "manual",
+  "sampleLimit": 20,
+  "cursor": "optional-watermark"
+}
+```
+
+The frontend does not send server-owned fields such as `dryRun`, `triggeredBy`,
+`sourceRecords`, `details`, or `allowInactive`. The plugin route continues to
+own those fields and strips unsafe input.
+
+## Safety
+
+Dry-run is available once tenant and pipeline ID validation passes.
+
+Live run requires the operator to explicitly check `允许真实执行 Pipeline`.
+This is a frontend guard only; backend authorization and route sanitization remain
+the enforcement layer.
+
+## Multitable Cleansing Model
+
+The cleansing chain still uses multitable staging as the operational surface:
+
+- PLM records are normalized into staging objects.
+- Pipeline field mappings transform PLM fields into K3 payload fields.
+- Validation and dead-letter handling happen in the pipeline runner.
+- ERP feedback writes run state back into staging objects when configured.
+
+The UI added here does not replace that model. It exposes the runner controls
+needed to operate the model from the K3 setup page.

--- a/docs/development/integration-pipeline-run-ui-verification-20260428.md
+++ b/docs/development/integration-pipeline-run-ui-verification-20260428.md
@@ -1,0 +1,91 @@
+# Integration Pipeline Run UI Verification - 2026-04-28
+
+## Scope
+
+Verified the frontend-only pipeline run slice for the K3 WISE setup page.
+
+Changed files:
+
+- `apps/web/src/views/IntegrationK3WiseSetupView.vue`
+- `apps/web/src/services/integration/k3WiseSetup.ts`
+- `apps/web/tests/k3WiseSetup.spec.ts`
+- `docs/development/integration-pipeline-run-ui-design-20260428.md`
+- `docs/development/integration-pipeline-run-ui-verification-20260428.md`
+
+## Checks Run
+
+### Helper Unit Tests
+
+Command:
+
+```bash
+NODE_PATH=/Users/chouhua/Downloads/Github/metasheet2/node_modules:/Users/chouhua/Downloads/Github/metasheet2/apps/web/node_modules \
+  /Users/chouhua/Downloads/Github/metasheet2/apps/web/node_modules/.bin/vitest run apps/web/tests/k3WiseSetup.spec.ts --watch=false
+```
+
+Result:
+
+```text
+apps/web/tests/k3WiseSetup.spec.ts: 11 tests passed
+```
+
+Coverage added:
+
+- Builds dry-run/run payloads with only public run fields.
+- Resolves material and BOM pipeline IDs.
+- Rejects missing tenant ID, missing pipeline ID, and non-positive sample limits.
+
+### Vue SFC Compile
+
+Command:
+
+```bash
+node -e "const { parse, compileScript, compileTemplate } = require('/Users/chouhua/Downloads/Github/metasheet2/node_modules/.pnpm/@vue+compiler-sfc@3.5.24/node_modules/@vue/compiler-sfc'); const fs = require('fs'); const file = 'apps/web/src/views/IntegrationK3WiseSetupView.vue'; const source = fs.readFileSync(file, 'utf8'); const parsed = parse(source, { filename: file }); if (parsed.errors.length) throw parsed.errors[0]; compileScript(parsed.descriptor, { id: 'k3-wise-setup' }); if (parsed.descriptor.template) { const compiled = compileTemplate({ id: 'k3-wise-setup', source: parsed.descriptor.template.content, filename: file }); if (compiled.errors.length) throw compiled.errors[0]; } console.log('SFC compile ok')"
+```
+
+Result:
+
+```text
+SFC compile ok
+```
+
+### Frontend Type Check
+
+Command:
+
+```bash
+ln -s /Users/chouhua/Downloads/Github/metasheet2/node_modules node_modules 2>/dev/null || true
+ln -s /Users/chouhua/Downloads/Github/metasheet2/apps/web/node_modules apps/web/node_modules 2>/dev/null || true
+/Users/chouhua/Downloads/Github/metasheet2/apps/web/node_modules/.bin/vue-tsc -p apps/web/tsconfig.app.json --noEmit
+code=$?
+rm -rf node_modules apps/web/node_modules
+exit $code
+```
+
+Result:
+
+```text
+passed
+```
+
+## Manual Contract Review
+
+The frontend helper calls these existing backend routes:
+
+- `POST /api/integration/pipelines/:id/dry-run`
+- `POST /api/integration/pipelines/:id/run`
+
+The payload builder sends only:
+
+- `tenantId`
+- `workspaceId`
+- `mode`
+- `cursor`
+- `sampleLimit`
+
+This matches `publicRunInput()` in `plugins/plugin-integration-core/lib/http-routes.cjs`.
+
+## Remaining Validation
+
+This slice does not run against a live K3 WISE tenant. Live validation still
+depends on the customer M2 GATE response and the K3 WISE PoC environment.


### PR DESCRIPTION
## Summary
- add material/BOM pipeline ID fields and dry-run/run controls to the K3 WISE setup page
- add frontend helpers that post only the public run contract fields to /dry-run and /run
- gate live pipeline execution behind an explicit UI checkbox and persist generated pipeline IDs after template creation
- add design and verification docs for the run UI slice

## Verification
- NODE_PATH=/Users/chouhua/Downloads/Github/metasheet2/node_modules:/Users/chouhua/Downloads/Github/metasheet2/apps/web/node_modules /Users/chouhua/Downloads/Github/metasheet2/apps/web/node_modules/.bin/vitest run apps/web/tests/k3WiseSetup.spec.ts --watch=false
- node -e "SFC compile check for apps/web/src/views/IntegrationK3WiseSetupView.vue"
- /Users/chouhua/Downloads/Github/metasheet2/apps/web/node_modules/.bin/vue-tsc -p apps/web/tsconfig.app.json --noEmit
- git diff --check

## Notes
- Frontend only; backend run/dry-run routes already exist and continue to own dryRun/triggeredBy sanitization.
- Live K3 validation still waits for the customer M2 GATE response.