### PR TITLE
docs(dingtalk): note final 142 image state

### DIFF
--- a/docs/development/dingtalk-public-form-access-matrix-142-design-20260428.md
+++ b/docs/development/dingtalk-public-form-access-matrix-142-design-20260428.md
@@ -47,10 +47,12 @@ Frontend:
 
 ## Deployment Position
 
-142 now runs GHCR images for merge commit `1084f6ebb81f79423d33f25fb4baed8f28e98208`, which contains both:
+The access-matrix change was first deployed to 142 with merge commit `1084f6ebb81f79423d33f25fb4baed8f28e98208`, which contains both:
 
 - The existing public-form password-change bypass for DingTalk token-authenticated fill flows.
 - The operator-facing public-form DingTalk access-matrix UI and config-response enrichment from PR #1212.
+
+The final observed host state now runs a later mainline image, `1366cb7bf8728848bb743bfc57e43f907dd78efa`, which includes commit `1084f6ebb81f79423d33f25fb4baed8f28e98208`. The docs-only merge that records this evidence does not trigger a new Docker deploy because `.github/workflows/docker-build.yml` ignores `docs/**` changes.
 
 Deployment happened through `.github/workflows/docker-build.yml` after the branch was merged to `main`.
 

--- a/docs/development/dingtalk-public-form-access-matrix-142-verification-20260428.md
+++ b/docs/development/dingtalk-public-form-access-matrix-142-verification-20260428.md
@@ -109,6 +109,18 @@ Remote container state after the successful deploy:
 - `metasheet-postgres`: healthy
 - `metasheet-redis`: healthy
 
+A later mainline deployment superseded the container image tag with `1366cb7bf8728848bb743bfc57e43f907dd78efa`, which includes `1084f6ebb81f79423d33f25fb4baed8f28e98208`.
+
+Final observed 142 state after that deployment:
+
+- `metasheet-backend`: `ghcr.io/zensgit/metasheet2-backend:1366cb7bf8728848bb743bfc57e43f907dd78efa`
+- `metasheet-web`: `ghcr.io/zensgit/metasheet2-web:1366cb7bf8728848bb743bfc57e43f907dd78efa`
+- `metasheet-postgres`: healthy
+- `metasheet-redis`: healthy
+- Root filesystem: `55G` used, `19G` available, `75%`.
+
+The docs-only merge that records this evidence does not trigger another Docker deploy because `.github/workflows/docker-build.yml` ignores `docs/**`.
+
 Workflow deploy log markers:
 
 - `=== DEPLOY START ===` / `=== DEPLOY END ===`: present.


### PR DESCRIPTION
## Summary

- Clarify that the access-matrix change was first deployed with `1084f6e...` and later superseded on 142 by `1366cb7...`, which includes that change.
- Record the final observed backend/web image tags, healthy DB/Redis state, and filesystem headroom.
- Note that docs-only changes do not trigger Docker deploy because `docs/**` is ignored by the workflow.

## Verification

- `git diff --check`
- Diff secret scan for DingTalk webhook/token patterns: no matches.
- Live 142 check confirmed backend/web on `1366cb7...`, Postgres/Redis healthy, and `/api/health` status ok.
