### PR TITLE
docs(dingtalk): timestamp 142 observed image state

### DIFF
--- a/docs/development/dingtalk-public-form-access-matrix-142-design-20260428.md
+++ b/docs/development/dingtalk-public-form-access-matrix-142-design-20260428.md
@@ -52,7 +52,7 @@ The access-matrix change was first deployed to 142 with merge commit `1084f6ebb8
 - The existing public-form password-change bypass for DingTalk token-authenticated fill flows.
 - The operator-facing public-form DingTalk access-matrix UI and config-response enrichment from PR #1212.
 
-The final observed host state now runs a later mainline image, `1366cb7bf8728848bb743bfc57e43f907dd78efa`, which includes commit `1084f6ebb81f79423d33f25fb4baed8f28e98208`. The docs-only merge that records this evidence does not trigger a new Docker deploy because `.github/workflows/docker-build.yml` ignores `docs/**` changes.
+Later non-doc mainline deployments can supersede the container tag while still including the access-matrix commit. The latest observed host image during this verification window was `8cfcbab420ee2a8674379fc4d2a746b40ed87d53`, which includes commit `1084f6ebb81f79423d33f25fb4baed8f28e98208`. Docs-only merges that record this evidence do not trigger a new Docker deploy because `.github/workflows/docker-build.yml` ignores `docs/**` changes.
 
 Deployment happened through `.github/workflows/docker-build.yml` after the branch was merged to `main`.
 

--- a/docs/development/dingtalk-public-form-access-matrix-142-verification-20260428.md
+++ b/docs/development/dingtalk-public-form-access-matrix-142-verification-20260428.md
@@ -109,17 +109,17 @@ Remote container state after the successful deploy:
 - `metasheet-postgres`: healthy
 - `metasheet-redis`: healthy
 
-A later mainline deployment superseded the container image tag with `1366cb7bf8728848bb743bfc57e43f907dd78efa`, which includes `1084f6ebb81f79423d33f25fb4baed8f28e98208`.
+Later non-doc mainline deployments can supersede the container image tag while still including `1084f6ebb81f79423d33f25fb4baed8f28e98208`.
 
-Final observed 142 state after that deployment:
+Latest observed 142 state during this verification window:
 
-- `metasheet-backend`: `ghcr.io/zensgit/metasheet2-backend:1366cb7bf8728848bb743bfc57e43f907dd78efa`
-- `metasheet-web`: `ghcr.io/zensgit/metasheet2-web:1366cb7bf8728848bb743bfc57e43f907dd78efa`
+- `metasheet-backend`: `ghcr.io/zensgit/metasheet2-backend:8cfcbab420ee2a8674379fc4d2a746b40ed87d53`
+- `metasheet-web`: `ghcr.io/zensgit/metasheet2-web:8cfcbab420ee2a8674379fc4d2a746b40ed87d53`
 - `metasheet-postgres`: healthy
 - `metasheet-redis`: healthy
-- Root filesystem: `55G` used, `19G` available, `75%`.
+- Root filesystem: `56G` used, `19G` available, `76%`.
 
-The docs-only merge that records this evidence does not trigger another Docker deploy because `.github/workflows/docker-build.yml` ignores `docs/**`.
+Docs-only merges that record this evidence do not trigger another Docker deploy because `.github/workflows/docker-build.yml` ignores `docs/**`.
 
 Workflow deploy log markers:
 


### PR DESCRIPTION
## Summary

- Replace "now runs" wording with a time-window observation so future non-doc mainline deploys do not make the doc stale.
- Update the observed 142 image tags to the latest non-doc deployed commit seen during verification.
- Keep the key invariant explicit: later mainline images include the DingTalk access-matrix commit.

## Verification

- `git diff --check`
- Diff secret scan for DingTalk webhook/token patterns: no matches.
