### PR TITLE
feat(integration): add run observability to K3 setup

### DIFF
--- a/apps/web/src/services/integration/k3WiseSetup.ts
+++ b/apps/web/src/services/integration/k3WiseSetup.ts
@@ -4,6 +4,8 @@ export type IntegrationSystemStatus = 'active' | 'inactive' | 'error'
 export type K3SqlServerMode = 'readonly' | 'middle-table' | 'stored-procedure'
 export type IntegrationPipelineRunMode = 'manual' | 'incremental' | 'full'
 export type K3WisePipelineTarget = 'material' | 'bom'
+export type IntegrationPipelineRunStatus = 'pending' | 'running' | 'succeeded' | 'partial' | 'failed' | 'cancelled'
+export type IntegrationDeadLetterStatus = 'open' | 'replayed' | 'discarded'
 
 export interface IntegrationApiEnvelope<T> {
   ok: boolean
@@ -61,6 +63,43 @@ export interface IntegrationPipelineRunResult {
   dryRun?: boolean
   metrics?: Record<string, unknown>
   [key: string]: unknown
+}
+
+export interface IntegrationPipelineRun {
+  id: string
+  tenantId: string
+  workspaceId: string | null
+  pipelineId: string
+  mode: IntegrationPipelineRunMode | string
+  triggeredBy?: string | null
+  status: IntegrationPipelineRunStatus | string
+  rowsRead: number
+  rowsCleaned: number
+  rowsWritten: number
+  rowsFailed: number
+  startedAt?: string | null
+  finishedAt?: string | null
+  durationMs?: number | null
+  errorSummary?: string | null
+  details?: Record<string, unknown>
+  createdAt?: string | null
+}
+
+export interface IntegrationDeadLetter {
+  id: string
+  tenantId: string
+  workspaceId: string | null
+  runId: string
+  pipelineId: string
+  idempotencyKey?: string | null
+  errorCode: string
+  errorMessage: string
+  retryCount: number
+  status: IntegrationDeadLetterStatus | string
+  lastReplayRunId?: string | null
+  payloadRedacted?: boolean
+  createdAt?: string | null
+  updatedAt?: string | null
 }
 
 export interface IntegrationStagingDescriptor {
@@ -148,6 +187,15 @@ export interface K3WisePipelineRunPayload {
   mode: IntegrationPipelineRunMode
   cursor?: string
   sampleLimit?: number
+}
+
+export interface K3WisePipelineObservationQuery {
+  tenantId: string
+  workspaceId?: string | null
+  pipelineId: string
+  status?: string
+  limit?: number
+  offset?: number
 }
 
 export interface K3WiseSetupValidationIssue {
@@ -351,6 +399,22 @@ export function validateK3WisePipelineRunForm(
   return issues
 }
 
+export function validateK3WisePipelineObservationForm(
+  form: K3WiseSetupForm,
+  target: K3WisePipelineTarget,
+): K3WiseSetupValidationIssue[] {
+  const issues: K3WiseSetupValidationIssue[] = []
+  const pipelineField: keyof K3WiseSetupForm = target === 'material' ? 'materialPipelineId' : 'bomPipelineId'
+  if (!trim(form.tenantId)) issues.push({ field: 'tenantId', message: 'tenantId is required' })
+  if (!trim(form[pipelineField])) {
+    issues.push({
+      field: pipelineField,
+      message: `${target === 'material' ? 'Material' : 'BOM'} pipeline ID is required before loading run history`,
+    })
+  }
+  return issues
+}
+
 export function buildK3WiseStagingInstallPayload(form: K3WiseSetupForm): K3WiseStagingInstallPayload {
   const issues = validateK3WiseStagingInstallForm(form)
   if (issues.length > 0) {
@@ -384,6 +448,28 @@ export function buildK3WisePipelineRunPayload(form: K3WiseSetupForm, target: K3W
   const cursor = optionalString(form.pipelineCursor)
   if (cursor) payload.cursor = cursor
   return payload
+}
+
+export function buildK3WisePipelineObservationQuery(
+  form: K3WiseSetupForm,
+  target: K3WisePipelineTarget,
+  options: { status?: string; limit?: number; offset?: number } = {},
+): K3WisePipelineObservationQuery {
+  const issues = validateK3WisePipelineObservationForm(form, target)
+  if (issues.length > 0) {
+    throw new Error(issues[0].message)
+  }
+
+  const limit = options.limit
+  const offset = options.offset
+  return {
+    tenantId: trim(form.tenantId),
+    workspaceId: optionalString(form.workspaceId) ?? null,
+    pipelineId: getK3WisePipelineId(form, target),
+    ...(options.status ? { status: options.status } : {}),
+    ...(typeof limit === 'number' && Number.isInteger(limit) && limit > 0 ? { limit } : {}),
+    ...(typeof offset === 'number' && Number.isInteger(offset) && offset >= 0 ? { offset } : {}),
+  }
 }
 
 export function buildK3WiseSetupPayloads(form: K3WiseSetupForm): K3WiseSetupPayloads {
@@ -748,6 +834,27 @@ export async function runIntegrationPipeline(
     body: JSON.stringify(payload),
   })
   return parseIntegrationResponse<IntegrationPipelineRunResult>(response)
+}
+
+function buildQueryString(input: object): string {
+  const params = new URLSearchParams()
+  for (const [key, value] of Object.entries(input as Record<string, unknown>)) {
+    if (value === undefined || value === null || value === '') continue
+    params.set(key, String(value))
+  }
+  return params.toString()
+}
+
+export async function listIntegrationPipelineRuns(query: K3WisePipelineObservationQuery): Promise<IntegrationPipelineRun[]> {
+  const response = await apiFetch(`/api/integration/runs?${buildQueryString(query)}`)
+  const data = await parseIntegrationResponse<IntegrationPipelineRun[]>(response)
+  return Array.isArray(data) ? data : []
+}
+
+export async function listIntegrationDeadLetters(query: K3WisePipelineObservationQuery): Promise<IntegrationDeadLetter[]> {
+  const response = await apiFetch(`/api/integration/dead-letters?${buildQueryString(query)}`)
+  const data = await parseIntegrationResponse<IntegrationDeadLetter[]>(response)
+  return Array.isArray(data) ? data : []
 }
 
 export async function listIntegrationStagingDescriptors(): Promise<IntegrationStagingDescriptor[]> {

--- a/apps/web/src/views/IntegrationK3WiseSetupView.vue
+++ b/apps/web/src/views/IntegrationK3WiseSetupView.vue
@@ -135,6 +135,67 @@
           </ul>
           <pre v-if="pipelineRunResult" class="k3-setup__test-result">{{ pipelineRunResult }}</pre>
         </div>
+
+        <div class="k3-setup__panel">
+          <div class="k3-setup__panel-head">
+            <h2>运行观察</h2>
+            <span>{{ observationSummary }}</span>
+          </div>
+          <button
+            class="k3-setup__btn k3-setup__btn--full"
+            type="button"
+            :disabled="isPipelineObservationDisabled('material')"
+            @click="refreshPipelineObservation('material')"
+          >
+            {{ observingPipeline === 'material' ? '刷新中' : '刷新物料状态' }}
+          </button>
+          <button
+            class="k3-setup__btn k3-setup__btn--full"
+            type="button"
+            :disabled="isPipelineObservationDisabled('bom')"
+            @click="refreshPipelineObservation('bom')"
+          >
+            {{ observingPipeline === 'bom' ? '刷新中' : '刷新 BOM 状态' }}
+          </button>
+
+          <div class="k3-setup__records">
+            <div class="k3-setup__record-head">
+              <span>最近运行</span>
+              <small>{{ observedPipelineTarget }}</small>
+            </div>
+            <div v-if="pipelineRuns.length === 0" class="k3-setup__empty">暂无运行记录。</div>
+            <template v-else>
+              <div v-for="run in pipelineRuns" :key="run.id" class="k3-setup__record">
+                <div class="k3-setup__record-main">
+                  <strong>{{ run.id }}</strong>
+                  <span class="k3-setup__badge" :data-status="run.status">{{ run.status }}</span>
+                </div>
+                <small>{{ formatRunMetrics(run) }}</small>
+                <small>{{ formatTimestamp(run.startedAt || run.createdAt || '') }}</small>
+                <small v-if="run.errorSummary" class="k3-setup__saved-error">{{ run.errorSummary }}</small>
+              </div>
+            </template>
+          </div>
+
+          <div class="k3-setup__records">
+            <div class="k3-setup__record-head">
+              <span>Open Dead Letters</span>
+              <small>{{ deadLetters.length }}</small>
+            </div>
+            <div v-if="deadLetters.length === 0" class="k3-setup__empty">暂无 open dead letters。</div>
+            <template v-else>
+              <div v-for="deadLetter in deadLetters" :key="deadLetter.id" class="k3-setup__record">
+                <div class="k3-setup__record-main">
+                  <strong>{{ deadLetter.errorCode }}</strong>
+                  <span class="k3-setup__badge" :data-status="deadLetter.status">{{ deadLetter.status }}</span>
+                </div>
+                <small>{{ deadLetter.id }} · retry {{ deadLetter.retryCount }}</small>
+                <small class="k3-setup__saved-error">{{ deadLetter.errorMessage }}</small>
+                <small v-if="deadLetter.payloadRedacted">payload redacted</small>
+              </div>
+            </template>
+          </div>
+        </div>
       </aside>
 
       <form class="k3-setup__form" @submit.prevent="saveConfiguration">
@@ -407,6 +468,7 @@ import {
   K3_WISE_SQLSERVER_KIND,
   K3_WISE_WEBAPI_KIND,
   applyExternalSystemToForm,
+  buildK3WisePipelineObservationQuery,
   buildK3WisePipelinePayloads,
   buildK3WisePipelineRunPayload,
   buildK3WiseSetupPayloads,
@@ -414,16 +476,21 @@ import {
   createDefaultK3WiseSetupForm,
   getK3WisePipelineId,
   installIntegrationStaging,
+  listIntegrationDeadLetters,
+  listIntegrationPipelineRuns,
   listIntegrationSystems,
   runIntegrationPipeline,
   testIntegrationSystem,
   upsertIntegrationPipeline,
   upsertIntegrationSystem,
   validateK3WisePipelineTemplateForm,
+  validateK3WisePipelineObservationForm,
   validateK3WisePipelineRunForm,
   validateK3WiseSetupForm,
   validateK3WiseStagingInstallForm,
+  type IntegrationDeadLetter,
   type IntegrationExternalSystem,
+  type IntegrationPipelineRun,
   type K3WisePipelineTarget,
 } from '../services/integration/k3WiseSetup'
 
@@ -437,12 +504,16 @@ const testingSql = ref(false)
 const installingStaging = ref(false)
 const creatingPipelines = ref(false)
 const runningPipeline = ref('')
+const observingPipeline = ref('')
+const observedPipelineTarget = ref<K3WisePipelineTarget>('material')
 const statusMessage = ref('')
 const statusKind = ref<'info' | 'success' | 'error'>('info')
 const testResult = ref('')
 const stagingResult = ref('')
 const pipelineResult = ref('')
 const pipelineRunResult = ref('')
+const pipelineRuns = ref<IntegrationPipelineRun[]>([])
+const deadLetters = ref<IntegrationDeadLetter[]>([])
 
 const savedSystems = computed(() => [...webApiSystems.value, ...sqlSystems.value])
 const validationIssues = computed(() => validateK3WiseSetupForm(form))
@@ -450,6 +521,7 @@ const stagingIssues = computed(() => validateK3WiseStagingInstallForm(form))
 const pipelineIssues = computed(() => validateK3WisePipelineTemplateForm(form))
 const materialRunIssues = computed(() => validateK3WisePipelineRunForm(form, 'material'))
 const bomRunIssues = computed(() => validateK3WisePipelineRunForm(form, 'bom'))
+const observationSummary = computed(() => `${pipelineRuns.value.length} runs / ${deadLetters.value.length} open`)
 
 function setStatus(message: string, kind: 'info' | 'success' | 'error' = 'info'): void {
   statusMessage.value = message
@@ -461,9 +533,14 @@ function formatError(error: unknown): string {
 }
 
 function formatTimestamp(value: string): string {
+  if (!value) return '-'
   const date = new Date(value)
   if (Number.isNaN(date.getTime())) return value
   return date.toLocaleString()
+}
+
+function formatRunMetrics(run: IntegrationPipelineRun): string {
+  return `read ${run.rowsRead} / clean ${run.rowsCleaned} / write ${run.rowsWritten} / failed ${run.rowsFailed}`
 }
 
 function loadSystemIntoForm(system: IntegrationExternalSystem): void {
@@ -601,6 +678,35 @@ function isPipelineRunDisabled(target: K3WisePipelineTarget, dryRun: boolean): b
   return Boolean(runningPipeline.value || issues.length > 0 || (!dryRun && !form.allowLivePipelineRun))
 }
 
+function isPipelineObservationDisabled(target: K3WisePipelineTarget): boolean {
+  return Boolean(observingPipeline.value || validateK3WisePipelineObservationForm(form, target).length > 0)
+}
+
+async function refreshPipelineObservation(target: K3WisePipelineTarget, silent = false): Promise<void> {
+  const issues = validateK3WisePipelineObservationForm(form, target)
+  if (issues.length > 0) {
+    if (!silent) setStatus(issues[0].message, 'error')
+    return
+  }
+  observingPipeline.value = target
+  observedPipelineTarget.value = target
+  try {
+    const [runs, openDeadLetters] = await Promise.all([
+      listIntegrationPipelineRuns(buildK3WisePipelineObservationQuery(form, target, { limit: 5 })),
+      listIntegrationDeadLetters(buildK3WisePipelineObservationQuery(form, target, { status: 'open', limit: 5 })),
+    ])
+    pipelineRuns.value = runs
+    deadLetters.value = openDeadLetters
+    if (!silent) {
+      setStatus(`${target === 'material' ? '物料' : 'BOM'} Pipeline 运行状态已刷新`, 'success')
+    }
+  } catch (error) {
+    if (!silent) setStatus(formatError(error), 'error')
+  } finally {
+    observingPipeline.value = ''
+  }
+}
+
 async function executePipeline(target: K3WisePipelineTarget, dryRun: boolean): Promise<void> {
   const issues = validateK3WisePipelineRunForm(form, target)
   if (issues.length > 0) {
@@ -622,6 +728,7 @@ async function executePipeline(target: K3WisePipelineTarget, dryRun: boolean): P
       pipelineId,
       result,
     }, null, 2)
+    await refreshPipelineObservation(target, true)
     setStatus(`${target === 'material' ? '物料' : 'BOM'} Pipeline ${dryRun ? 'dry-run' : 'run'} 已提交`, 'success')
   } catch (error) {
     setStatus(formatError(error), 'error')
@@ -867,6 +974,79 @@ onMounted(() => {
 
 .k3-setup__empty {
   color: #64748b;
+}
+
+.k3-setup__records {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.k3-setup__record-head,
+.k3-setup__record-main {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  align-items: center;
+}
+
+.k3-setup__record-head span {
+  color: #334155;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.k3-setup__record-head small {
+  color: #64748b;
+}
+
+.k3-setup__record {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  padding: 10px;
+  background: #f8fafc;
+}
+
+.k3-setup__record strong {
+  overflow-wrap: anywhere;
+  color: #172033;
+  font-size: 13px;
+}
+
+.k3-setup__record small {
+  overflow-wrap: anywhere;
+  color: #64748b;
+}
+
+.k3-setup__badge {
+  border-radius: 999px;
+  padding: 2px 8px;
+  background: #e2e8f0;
+  color: #334155;
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.k3-setup__badge[data-status="succeeded"],
+.k3-setup__badge[data-status="replayed"] {
+  background: #ccfbf1;
+  color: #115e59;
+}
+
+.k3-setup__badge[data-status="partial"],
+.k3-setup__badge[data-status="open"] {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.k3-setup__badge[data-status="failed"] {
+  background: #ffe4e6;
+  color: #9f1239;
 }
 
 .k3-setup__test-result {

--- a/apps/web/tests/k3WiseSetup.spec.ts
+++ b/apps/web/tests/k3WiseSetup.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   applyExternalSystemToForm,
+  buildK3WisePipelineObservationQuery,
   buildK3WisePipelinePayloads,
   buildK3WisePipelineRunPayload,
   buildK3WiseSetupPayloads,
@@ -8,6 +9,7 @@ import {
   createDefaultK3WiseSetupForm,
   getK3WisePipelineId,
   splitList,
+  validateK3WisePipelineObservationForm,
   validateK3WisePipelineTemplateForm,
   validateK3WisePipelineRunForm,
   validateK3WiseSetupForm,
@@ -282,5 +284,38 @@ describe('K3 WISE setup helpers', () => {
     expect(messages).toContain('Material pipeline ID is required before dry-run or run')
     expect(messages).toContain('Sample limit must be a positive integer')
     expect(() => buildK3WisePipelineRunPayload(form, 'material')).toThrow('tenantId is required')
+  })
+
+  it('builds run and dead-letter observation queries for selected pipelines', () => {
+    const form = createDefaultK3WiseSetupForm()
+    Object.assign(form, {
+      tenantId: 'tenant_1',
+      workspaceId: 'workspace_1',
+      materialPipelineId: 'pipe_material',
+      bomPipelineId: 'pipe_bom',
+    })
+
+    expect(validateK3WisePipelineObservationForm(form, 'bom')).toEqual([])
+    expect(buildK3WisePipelineObservationQuery(form, 'bom', { status: 'open', limit: 5, offset: 0 })).toEqual({
+      tenantId: 'tenant_1',
+      workspaceId: 'workspace_1',
+      pipelineId: 'pipe_bom',
+      status: 'open',
+      limit: 5,
+      offset: 0,
+    })
+  })
+
+  it('requires tenant and pipeline id before loading run history', () => {
+    const form = createDefaultK3WiseSetupForm()
+    Object.assign(form, {
+      tenantId: '',
+      bomPipelineId: '',
+    })
+
+    const messages = validateK3WisePipelineObservationForm(form, 'bom').map((issue) => issue.message)
+    expect(messages).toContain('tenantId is required')
+    expect(messages).toContain('BOM pipeline ID is required before loading run history')
+    expect(() => buildK3WisePipelineObservationQuery(form, 'bom')).toThrow('tenantId is required')
   })
 })

--- a/docs/development/integration-run-observability-ui-design-20260428.md
+++ b/docs/development/integration-run-observability-ui-design-20260428.md
@@ -1,0 +1,97 @@
+# Integration Run Observability UI Design - 2026-04-28
+
+## Status
+
+Implemented in `codex/integration-run-observability-ui-20260428`.
+
+This slice adds read-only operational visibility to the K3 WISE setup page after
+pipeline dry-run/run submission.
+
+## Files
+
+- `apps/web/src/views/IntegrationK3WiseSetupView.vue`
+- `apps/web/src/services/integration/k3WiseSetup.ts`
+- `apps/web/tests/k3WiseSetup.spec.ts`
+
+## Problem
+
+The previous K3 WISE setup page could save systems, install staging tables,
+create draft pipelines, and submit dry-run/run requests. It still left the
+operator dependent on raw JSON responses or backend logs to answer:
+
+- Did the run succeed or fail?
+- How many rows were read, cleaned, written, or failed?
+- Are there open dead letters to inspect before retrying?
+
+That gap matters for the K3 WISE Live PoC because the first customer run will
+need quick feedback without requiring shell access.
+
+## Design
+
+The page now has a `运行观察` panel in the side rail.
+
+The panel exposes two explicit refresh actions:
+
+- `刷新物料状态`
+- `刷新 BOM 状态`
+
+Each action reads the selected pipeline ID from the setup form and fetches:
+
+- latest 5 pipeline runs
+- latest 5 open dead letters
+
+The panel also refreshes automatically after a material/BOM dry-run or live run
+submission succeeds.
+
+## API Contract
+
+The frontend uses existing plugin routes:
+
+- `GET /api/integration/runs`
+- `GET /api/integration/dead-letters`
+
+The query builder sends only public read fields:
+
+```json
+{
+  "tenantId": "tenant_1",
+  "workspaceId": "workspace_1",
+  "pipelineId": "pipe_material",
+  "status": "open",
+  "limit": 5
+}
+```
+
+Dead-letter payloads are not requested. The backend already redacts payloads for
+non-admin users and returns `payloadRedacted: true`.
+
+## UI Data
+
+Run rows show:
+
+- run ID
+- status
+- rows read / cleaned / written / failed
+- started or created timestamp
+- error summary when present
+
+Dead-letter rows show:
+
+- error code
+- status
+- dead-letter ID
+- retry count
+- error message
+- payload redaction marker
+
+## Safety
+
+This slice is read-only. It does not add replay, discard, or full payload
+inspection to the page. Those operations remain separate because they need
+stronger review, authorization, and operator intent.
+
+## Fit With Multitable Cleansing
+
+The multitable staging surface remains the data-cleaning work area. This UI
+only gives operators the minimum run/dead-letter visibility needed to operate the
+cleaning chain from the K3 WISE page while waiting for customer GATE inputs.

--- a/docs/development/integration-run-observability-ui-verification-20260428.md
+++ b/docs/development/integration-run-observability-ui-verification-20260428.md
@@ -1,0 +1,108 @@
+# Integration Run Observability UI Verification - 2026-04-28
+
+## Scope
+
+Verified the frontend-only run observability slice for the K3 WISE setup page.
+
+Changed files:
+
+- `apps/web/src/views/IntegrationK3WiseSetupView.vue`
+- `apps/web/src/services/integration/k3WiseSetup.ts`
+- `apps/web/tests/k3WiseSetup.spec.ts`
+- `docs/development/integration-run-observability-ui-design-20260428.md`
+- `docs/development/integration-run-observability-ui-verification-20260428.md`
+
+## Checks Run
+
+### Helper Unit Tests
+
+Command:
+
+```bash
+NODE_PATH=/Users/chouhua/Downloads/Github/metasheet2/node_modules:/Users/chouhua/Downloads/Github/metasheet2/apps/web/node_modules \
+  /Users/chouhua/Downloads/Github/metasheet2/apps/web/node_modules/.bin/vitest run apps/web/tests/k3WiseSetup.spec.ts --watch=false
+```
+
+Result:
+
+```text
+apps/web/tests/k3WiseSetup.spec.ts: 13 tests passed
+```
+
+Coverage added:
+
+- Builds run/dead-letter observation queries for selected material/BOM pipelines.
+- Rejects missing tenant ID before loading run history.
+- Rejects missing material/BOM pipeline IDs before loading run history.
+
+### Vue SFC Compile
+
+Command:
+
+```bash
+node -e "const { parse, compileScript, compileTemplate } = require('/Users/chouhua/Downloads/Github/metasheet2/node_modules/.pnpm/@vue+compiler-sfc@3.5.24/node_modules/@vue/compiler-sfc'); const fs = require('fs'); const file = 'apps/web/src/views/IntegrationK3WiseSetupView.vue'; const source = fs.readFileSync(file, 'utf8'); const parsed = parse(source, { filename: file }); if (parsed.errors.length) throw parsed.errors[0]; compileScript(parsed.descriptor, { id: 'k3-wise-setup' }); if (parsed.descriptor.template) { const compiled = compileTemplate({ id: 'k3-wise-setup', source: parsed.descriptor.template.content, filename: file }); if (compiled.errors.length) throw compiled.errors[0]; } console.log('SFC compile ok')"
+```
+
+Result:
+
+```text
+SFC compile ok
+```
+
+### Frontend Type Check
+
+Command:
+
+```bash
+ln -s /Users/chouhua/Downloads/Github/metasheet2/node_modules node_modules 2>/dev/null || true
+ln -s /Users/chouhua/Downloads/Github/metasheet2/apps/web/node_modules apps/web/node_modules 2>/dev/null || true
+/Users/chouhua/Downloads/Github/metasheet2/apps/web/node_modules/.bin/vue-tsc -p apps/web/tsconfig.app.json --noEmit
+code=$?
+rm -rf node_modules apps/web/node_modules
+exit $code
+```
+
+Result:
+
+```text
+passed
+```
+
+### Whitespace Check
+
+Command:
+
+```bash
+git diff --check
+```
+
+Result:
+
+```text
+passed
+```
+
+## Manual Contract Review
+
+The UI helper uses existing backend routes:
+
+- `GET /api/integration/runs`
+- `GET /api/integration/dead-letters`
+
+The frontend only sends:
+
+- `tenantId`
+- `workspaceId`
+- `pipelineId`
+- `status`
+- `limit`
+- `offset`
+
+The UI does not request `includePayload=true`, so dead-letter payloads remain
+redacted by default.
+
+## Remaining Validation
+
+Live run/dead-letter content still depends on the customer M2 GATE response and
+the K3 WISE PoC environment. This slice verifies the UI contract and type
+surface, not real K3 WISE data.


### PR DESCRIPTION
## Summary
- add a read-only run observability panel to the K3 WISE setup page
- fetch latest pipeline runs and open dead letters for selected material/BOM pipelines
- refresh run/dead-letter visibility after successful dry-run/run submissions
- add frontend query helpers and validation for run-history loading
- add design and verification docs for the UI observability slice

## Verification
- NODE_PATH=/Users/chouhua/Downloads/Github/metasheet2/node_modules:/Users/chouhua/Downloads/Github/metasheet2/apps/web/node_modules /Users/chouhua/Downloads/Github/metasheet2/apps/web/node_modules/.bin/vitest run apps/web/tests/k3WiseSetup.spec.ts --watch=false
- node -e "SFC compile check for apps/web/src/views/IntegrationK3WiseSetupView.vue"
- /Users/chouhua/Downloads/Github/metasheet2/apps/web/node_modules/.bin/vue-tsc -p apps/web/tsconfig.app.json --noEmit
- git diff --check

## Notes
- Frontend only; uses existing GET /api/integration/runs and GET /api/integration/dead-letters routes.
- The UI does not request includePayload=true, so dead-letter payloads remain redacted by default.
- Live K3 validation still waits for the customer M2 GATE response.