### PR TITLE
chore(integration): add K3 WISE postdeploy smoke

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,7 @@ output/dingtalk-p4-final-input-status/
 output/dingtalk-p4-regression-gate/
 output/dingtalk-p4-release-readiness/
 artifacts/dingtalk-staging-evidence-packet/
+
+# K3 WISE postdeploy smoke artifacts can include deployment topology and
+# authenticated contract evidence.
+output/integration-k3wise-postdeploy-smoke/

--- a/docs/development/integration-k3wise-postdeploy-smoke-design-20260428.md
+++ b/docs/development/integration-k3wise-postdeploy-smoke-design-20260428.md
@@ -1,0 +1,69 @@
+# K3 WISE Postdeploy Smoke Design
+
+## Context
+
+The K3 WISE integration chain now has a deployable setup page, adapter registry, pipeline routes, staging descriptors, and customer-facing preflight/evidence scripts. After each deploy, operators still needed a small repeatable check that answers one question: is the deployed MetaSheet instance ready for the K3 WISE Live PoC path before the customer GATE packet arrives?
+
+## Scope
+
+This change adds `scripts/ops/integration-k3wise-postdeploy-smoke.mjs`.
+
+The script is intentionally a smoke tool, not a live K3 validator:
+
+- It does not connect to customer K3 WISE, PLM, SQL Server, or customer middleware.
+- It does not create external systems, pipelines, staging sheets, or ERP records.
+- It checks that the deployed MetaSheet surface required by the PoC is reachable and shaped as expected.
+- It writes JSON and Markdown evidence under `output/integration-k3wise-postdeploy-smoke/`.
+
+## Check Model
+
+Public checks always run:
+
+- `GET /api/health`: backend is alive and plugin summary reports zero failed plugins.
+- `GET /api/integration/health`: integration plugin health, when public on the target deployment.
+- `GET /integrations/k3-wise`: K3 WISE setup page route returns the frontend app shell.
+
+Authenticated checks run only when a bearer token is provided:
+
+- `GET /api/auth/me`: supplied token is valid.
+- `GET /api/integration/status`: required K3 adapter kinds and integration API routes are registered.
+- `GET /api/integration/staging/descriptors`: required K3 PoC staging descriptors exist.
+
+Some deployments protect `/api/integration/*` behind auth. In that case, an unauthenticated `401` or `403` from `/api/integration/health` is reported as `skipped`, not as a deploy failure. Supplying `--auth-token` or `--token-file` makes the plugin health check strict.
+
+## CLI Contract
+
+```bash
+node scripts/ops/integration-k3wise-postdeploy-smoke.mjs \
+  --base-url http://142.171.239.56:8081 \
+  --out-dir output/integration-k3wise-postdeploy-smoke/current-public
+```
+
+Optional auth:
+
+```bash
+node scripts/ops/integration-k3wise-postdeploy-smoke.mjs \
+  --base-url "$METASHEET_BASE_URL" \
+  --token-file "$METASHEET_AUTH_TOKEN_FILE" \
+  --require-auth
+```
+
+Supported environment fallbacks:
+
+- `METASHEET_BASE_URL`, `PUBLIC_APP_URL`
+- `METASHEET_AUTH_TOKEN`, `ADMIN_TOKEN`, `AUTH_TOKEN`
+- `METASHEET_AUTH_TOKEN_FILE`, `AUTH_TOKEN_FILE`
+
+## Safety
+
+- Token values are never written to stdout, stderr, JSON evidence, or Markdown evidence.
+- Response keys matching token/secret/password/authorization/credential are redacted recursively.
+- The tool is read-only and uses only `GET` requests.
+- `--require-auth` makes missing or invalid auth an explicit failure for operator signoff runs.
+
+## Files
+
+- `scripts/ops/integration-k3wise-postdeploy-smoke.mjs`
+- `scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs`
+- `docs/development/integration-k3wise-postdeploy-smoke-design-20260428.md`
+- `docs/development/integration-k3wise-postdeploy-smoke-verification-20260428.md`

--- a/docs/development/integration-k3wise-postdeploy-smoke-verification-20260428.md
+++ b/docs/development/integration-k3wise-postdeploy-smoke-verification-20260428.md
@@ -1,0 +1,90 @@
+# K3 WISE Postdeploy Smoke Verification
+
+## Environment
+
+Executed from isolated worktree:
+
+```bash
+/tmp/ms2-integration-k3wise-postdeploy-smoke-20260428
+```
+
+Base branch:
+
+```bash
+origin/main d0151f8cb
+```
+
+## Checks
+
+```bash
+node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
+
+node scripts/ops/integration-k3wise-postdeploy-smoke.mjs --help
+
+node scripts/ops/integration-k3wise-postdeploy-smoke.mjs \
+  --base-url http://142.171.239.56:8081 \
+  --out-dir output/integration-k3wise-postdeploy-smoke/current-public
+```
+
+## Results
+
+`node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs`
+
+- Passed: 4 tests.
+- Covered public smoke without auth.
+- Covered protected `/api/integration/health` returning `401` without auth.
+- Covered authenticated route/staging contract checks.
+- Covered `--require-auth` failure behavior when no token is supplied.
+- Covered token redaction in stdout, stderr, and JSON evidence.
+
+`node scripts/ops/integration-k3wise-postdeploy-smoke.mjs --help`
+
+- Passed.
+- Printed CLI usage and environment fallback contract.
+
+Public 142 deployment smoke:
+
+```json
+{
+  "ok": true,
+  "baseUrl": "http://142.171.239.56:8081",
+  "authenticated": false,
+  "summary": {
+    "pass": 2,
+    "skipped": 2,
+    "fail": 0
+  }
+}
+```
+
+Public evidence details:
+
+- `api-health`: pass, `plugins=13`, `pluginsSummary.failed=0`.
+- `integration-plugin-health`: skipped because this deployment requires auth for `/api/integration/health`.
+- `k3-wise-frontend-route`: pass, HTTP 200 app shell.
+- `authenticated-integration-contract`: skipped because no bearer token was supplied.
+
+Generated local evidence:
+
+- `output/integration-k3wise-postdeploy-smoke/current-public/integration-k3wise-postdeploy-smoke.json`
+- `output/integration-k3wise-postdeploy-smoke/current-public/integration-k3wise-postdeploy-smoke.md`
+
+The generated `output/` evidence is not committed.
+
+## Follow-up Auth Signoff
+
+When an application admin token is available, run:
+
+```bash
+node scripts/ops/integration-k3wise-postdeploy-smoke.mjs \
+  --base-url http://142.171.239.56:8081 \
+  --token-file /path/to/token.txt \
+  --require-auth \
+  --out-dir output/integration-k3wise-postdeploy-smoke/current-auth
+```
+
+Expected authenticated additions:
+
+- `auth-me`: pass.
+- `integration-route-contract`: pass with K3 WebAPI and SQL Server adapter kinds registered.
+- `staging-descriptor-contract`: pass with `standard_materials` and `bom_cleanse`.

--- a/scripts/ops/integration-k3wise-postdeploy-smoke.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-smoke.mjs
@@ -1,0 +1,442 @@
+#!/usr/bin/env node
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const DEFAULT_BASE_URL = 'http://142.171.239.56:8081'
+const DEFAULT_OUTPUT_ROOT = 'output/integration-k3wise-postdeploy-smoke'
+const REQUIRED_ADAPTERS = ['erp:k3-wise-webapi', 'erp:k3-wise-sqlserver']
+const REQUIRED_ROUTES = [
+  ['GET', '/api/integration/status'],
+  ['GET', '/api/integration/external-systems'],
+  ['POST', '/api/integration/external-systems'],
+  ['POST', '/api/integration/external-systems/:id/test'],
+  ['GET', '/api/integration/pipelines'],
+  ['POST', '/api/integration/pipelines'],
+  ['POST', '/api/integration/pipelines/:id/dry-run'],
+  ['POST', '/api/integration/pipelines/:id/run'],
+  ['GET', '/api/integration/runs'],
+  ['GET', '/api/integration/dead-letters'],
+  ['GET', '/api/integration/staging/descriptors'],
+  ['POST', '/api/integration/staging/install'],
+]
+const TOKEN_PATTERN = /([A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{16,}|Bearer\s+[A-Za-z0-9._-]{16,})/g
+
+class K3WisePostdeploySmokeError extends Error {
+  constructor(message, details = {}) {
+    super(message)
+    this.name = 'K3WisePostdeploySmokeError'
+    this.details = details
+  }
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/ops/integration-k3wise-postdeploy-smoke.mjs [options]
+
+Runs a post-deploy smoke against the deployed MetaSheet K3 WISE integration
+surface. Public checks always run; authenticated integration-route checks run
+when a bearer token is supplied.
+
+Options:
+  --base-url <url>       MetaSheet base URL, default ${DEFAULT_BASE_URL}
+  --auth-token <token>   Optional bearer token for authenticated checks
+  --token-file <path>    Optional file containing bearer token
+  --require-auth         Fail when no token is supplied or auth checks are skipped
+  --out-dir <dir>        Output directory, default ${DEFAULT_OUTPUT_ROOT}/<timestamp>
+  --timeout-ms <ms>      Per-request timeout, default 10000
+  --help                 Show this help
+
+Environment fallbacks:
+  METASHEET_BASE_URL, PUBLIC_APP_URL
+  METASHEET_AUTH_TOKEN, ADMIN_TOKEN, AUTH_TOKEN
+  METASHEET_AUTH_TOKEN_FILE, AUTH_TOKEN_FILE
+`)
+}
+
+function envValue(...names) {
+  for (const name of names) {
+    const value = process.env[name]
+    if (typeof value === 'string' && value.trim()) return value.trim()
+  }
+  return ''
+}
+
+function readRequiredValue(argv, index, flag) {
+  const next = argv[index + 1]
+  if (!next || next.startsWith('--')) {
+    throw new K3WisePostdeploySmokeError(`${flag} requires a value`, { flag })
+  }
+  return next
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+  const opts = {
+    baseUrl: envValue('METASHEET_BASE_URL', 'PUBLIC_APP_URL') || DEFAULT_BASE_URL,
+    authToken: envValue('METASHEET_AUTH_TOKEN', 'ADMIN_TOKEN', 'AUTH_TOKEN'),
+    tokenFile: envValue('METASHEET_AUTH_TOKEN_FILE', 'AUTH_TOKEN_FILE'),
+    requireAuth: false,
+    outDir: '',
+    timeoutMs: 10_000,
+    help: false,
+  }
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    switch (arg) {
+      case '--base-url':
+        opts.baseUrl = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--auth-token':
+        opts.authToken = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--token-file':
+        opts.tokenFile = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--require-auth':
+        opts.requireAuth = true
+        break
+      case '--out-dir':
+        opts.outDir = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--timeout-ms':
+        opts.timeoutMs = Number(readRequiredValue(argv, i, arg))
+        i += 1
+        break
+      case '--help':
+      case '-h':
+        opts.help = true
+        break
+      default:
+        throw new K3WisePostdeploySmokeError(`unknown option: ${arg}`, { arg })
+    }
+  }
+
+  if (!Number.isInteger(opts.timeoutMs) || opts.timeoutMs <= 0) {
+    throw new K3WisePostdeploySmokeError('--timeout-ms must be a positive integer', { timeoutMs: opts.timeoutMs })
+  }
+  opts.baseUrl = normalizeBaseUrl(opts.baseUrl)
+  return opts
+}
+
+function normalizeBaseUrl(value) {
+  let url
+  try {
+    url = new URL(value)
+  } catch {
+    throw new K3WisePostdeploySmokeError('--base-url must be a valid URL', { baseUrl: value })
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new K3WisePostdeploySmokeError('--base-url must use http or https', { baseUrl: value })
+  }
+  return url.toString().replace(/\/+$/, '')
+}
+
+function redactText(value) {
+  return String(value).replace(TOKEN_PATTERN, '<redacted-token>')
+}
+
+function nowStamp(date = new Date()) {
+  return date.toISOString().replace(/[:.]/g, '-')
+}
+
+function result(id, status, details = {}) {
+  return {
+    id,
+    ...details,
+    status,
+  }
+}
+
+function failResult(id, error) {
+  return result(id, 'fail', {
+    error: error && error.message ? redactText(error.message) : redactText(String(error)),
+  })
+}
+
+async function readToken(opts) {
+  if (opts.authToken) return opts.authToken.trim()
+  if (!opts.tokenFile) return ''
+  const raw = await readFile(opts.tokenFile, 'utf8')
+  return raw.trim()
+}
+
+async function fetchWithTimeout(url, options = {}, timeoutMs = 10_000) {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    return await fetch(url, {
+      ...options,
+      signal: controller.signal,
+    })
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+async function requestJson(baseUrl, pathname, { token = '', timeoutMs = 10_000, acceptStatuses = [200] } = {}) {
+  const headers = { Accept: 'application/json' }
+  if (token) headers.Authorization = `Bearer ${token}`
+  const response = await fetchWithTimeout(`${baseUrl}${pathname}`, { headers }, timeoutMs)
+  const text = await response.text()
+  let body = null
+  if (text) {
+    try {
+      body = JSON.parse(text)
+    } catch {
+      body = { raw: text.slice(0, 500) }
+    }
+  }
+  if (!acceptStatuses.includes(response.status)) {
+    throw new K3WisePostdeploySmokeError(`${pathname} returned HTTP ${response.status}`, {
+      status: response.status,
+      body: sanitizeBody(body),
+    })
+  }
+  return { status: response.status, body: sanitizeBody(body) }
+}
+
+async function requestText(baseUrl, pathname, { timeoutMs = 10_000 } = {}) {
+  const response = await fetchWithTimeout(`${baseUrl}${pathname}`, {
+    headers: { Accept: 'text/html,application/xhtml+xml' },
+  }, timeoutMs)
+  const text = await response.text()
+  if (response.status !== 200) {
+    throw new K3WisePostdeploySmokeError(`${pathname} returned HTTP ${response.status}`, { status: response.status })
+  }
+  return { status: response.status, text }
+}
+
+function sanitizeBody(value) {
+  if (Array.isArray(value)) return value.map(sanitizeBody)
+  if (!value || typeof value !== 'object') return typeof value === 'string' ? redactText(value) : value
+  const next = {}
+  for (const [key, child] of Object.entries(value)) {
+    if (/token|secret|password|authorization|credential/i.test(key)) {
+      next[key] = '<redacted>'
+    } else {
+      next[key] = sanitizeBody(child)
+    }
+  }
+  return next
+}
+
+function normalizeRoute(route) {
+  return `${String(route.method || '').toUpperCase()} ${String(route.path || '')}`
+}
+
+function assertStatusRoutes(statusBody) {
+  const data = statusBody && statusBody.data ? statusBody.data : statusBody
+  const adapters = Array.isArray(data?.adapters) ? data.adapters : []
+  const routes = Array.isArray(data?.routes) ? data.routes.map(normalizeRoute) : []
+
+  const missingAdapters = REQUIRED_ADAPTERS.filter((adapter) => !adapters.includes(adapter))
+  const missingRoutes = REQUIRED_ROUTES
+    .map(([method, routePath]) => `${method} ${routePath}`)
+    .filter((route) => !routes.includes(route))
+
+  if (missingAdapters.length > 0 || missingRoutes.length > 0) {
+    throw new K3WisePostdeploySmokeError('integration status is missing required adapters or routes', {
+      missingAdapters,
+      missingRoutes,
+    })
+  }
+
+  return { adapters, routesChecked: REQUIRED_ROUTES.length }
+}
+
+function assertStagingDescriptors(body) {
+  const data = body && body.data ? body.data : body
+  if (!Array.isArray(data)) {
+    throw new K3WisePostdeploySmokeError('staging descriptors response must be an array')
+  }
+  const ids = data.map((descriptor) => descriptor && descriptor.id).filter(Boolean)
+  for (const id of ['standard_materials', 'bom_cleanse']) {
+    if (!ids.includes(id)) {
+      throw new K3WisePostdeploySmokeError(`missing staging descriptor ${id}`, { ids })
+    }
+  }
+  return { descriptors: ids }
+}
+
+async function runSmoke(opts) {
+  const token = await readToken(opts)
+  const checks = []
+
+  try {
+    const health = await requestJson(opts.baseUrl, '/api/health', { timeoutMs: opts.timeoutMs })
+    const summary = health.body?.pluginsSummary || {}
+    if (health.body?.ok !== true && health.body?.success !== true && health.body?.status !== 'ok') {
+      throw new K3WisePostdeploySmokeError('/api/health did not report ok', { body: health.body })
+    }
+    if (summary.failed !== undefined && Number(summary.failed) !== 0) {
+      throw new K3WisePostdeploySmokeError('/api/health reports failed plugins', { pluginsSummary: summary })
+    }
+    checks.push(result('api-health', 'pass', {
+      plugins: health.body?.plugins ?? null,
+      pluginsSummary: summary,
+    }))
+  } catch (error) {
+    checks.push(failResult('api-health', error))
+  }
+
+  try {
+    const pluginHealth = await requestJson(opts.baseUrl, '/api/integration/health', { token, timeoutMs: opts.timeoutMs })
+    if (pluginHealth.body?.ok !== true || pluginHealth.body?.plugin !== 'plugin-integration-core') {
+      throw new K3WisePostdeploySmokeError('/api/integration/health did not report integration-core ok', {
+        body: pluginHealth.body,
+      })
+    }
+    checks.push(result('integration-plugin-health', 'pass', {
+      plugin: pluginHealth.body.plugin,
+      milestone: pluginHealth.body.milestone,
+    }))
+  } catch (error) {
+    if (!token && error?.details && (error.details.status === 401 || error.details.status === 403)) {
+      checks.push(result('integration-plugin-health', 'skipped', {
+        reason: '/api/integration/health requires an auth token on this deployment',
+      }))
+    } else {
+      checks.push(failResult('integration-plugin-health', error))
+    }
+  }
+
+  try {
+    const page = await requestText(opts.baseUrl, '/integrations/k3-wise', { timeoutMs: opts.timeoutMs })
+    if (!/id=["']app["']/.test(page.text) && !/K3 WISE|MetaSheet|metasheet/i.test(page.text)) {
+      throw new K3WisePostdeploySmokeError('K3 WISE frontend route did not look like the app shell')
+    }
+    checks.push(result('k3-wise-frontend-route', 'pass', {
+      httpStatus: page.status,
+      bytes: page.text.length,
+    }))
+  } catch (error) {
+    checks.push(failResult('k3-wise-frontend-route', error))
+  }
+
+  if (!token) {
+    const skipped = result('authenticated-integration-contract', opts.requireAuth ? 'fail' : 'skipped', {
+      reason: 'no bearer token supplied',
+    })
+    checks.push(skipped)
+  } else {
+    try {
+      const me = await requestJson(opts.baseUrl, '/api/auth/me', { token, timeoutMs: opts.timeoutMs })
+      const user = me.body?.user || me.body?.data?.user || me.body?.data || {}
+      checks.push(result('auth-me', 'pass', {
+        userId: user.id || user.userId || null,
+        role: user.role || null,
+      }))
+    } catch (error) {
+      checks.push(failResult('auth-me', error))
+    }
+
+    try {
+      const status = await requestJson(opts.baseUrl, '/api/integration/status', { token, timeoutMs: opts.timeoutMs })
+      checks.push(result('integration-route-contract', 'pass', assertStatusRoutes(status.body)))
+    } catch (error) {
+      checks.push(failResult('integration-route-contract', error))
+    }
+
+    try {
+      const descriptors = await requestJson(opts.baseUrl, '/api/integration/staging/descriptors', { token, timeoutMs: opts.timeoutMs })
+      checks.push(result('staging-descriptor-contract', 'pass', assertStagingDescriptors(descriptors.body)))
+    } catch (error) {
+      checks.push(failResult('staging-descriptor-contract', error))
+    }
+  }
+
+  const failed = checks.filter((check) => check.status === 'fail')
+  const evidence = {
+    ok: failed.length === 0,
+    generatedAt: new Date().toISOString(),
+    baseUrl: opts.baseUrl,
+    authenticated: Boolean(token),
+    requireAuth: opts.requireAuth,
+    checks,
+    summary: {
+      pass: checks.filter((check) => check.status === 'pass').length,
+      skipped: checks.filter((check) => check.status === 'skipped').length,
+      fail: failed.length,
+    },
+  }
+  return evidence
+}
+
+async function writeEvidence(evidence, opts) {
+  const outDir = path.resolve(opts.outDir || path.join(DEFAULT_OUTPUT_ROOT, nowStamp()))
+  await mkdir(outDir, { recursive: true })
+  const jsonPath = path.join(outDir, 'integration-k3wise-postdeploy-smoke.json')
+  const mdPath = path.join(outDir, 'integration-k3wise-postdeploy-smoke.md')
+  await writeFile(jsonPath, `${JSON.stringify(evidence, null, 2)}\n`)
+  await writeFile(mdPath, renderMarkdown(evidence))
+  return { outDir, jsonPath, mdPath }
+}
+
+function renderMarkdown(evidence) {
+  const lines = [
+    '# Integration K3 WISE Postdeploy Smoke',
+    '',
+    `- Generated at: ${evidence.generatedAt}`,
+    `- Base URL: ${evidence.baseUrl}`,
+    `- Authenticated checks: ${evidence.authenticated ? 'yes' : 'no'}`,
+    `- Result: ${evidence.ok ? 'PASS' : 'FAIL'}`,
+    `- Summary: ${evidence.summary.pass} pass / ${evidence.summary.skipped} skipped / ${evidence.summary.fail} fail`,
+    '',
+    '## Checks',
+    '',
+    '| Check | Status | Detail |',
+    '| --- | --- | --- |',
+  ]
+  for (const check of evidence.checks) {
+    const detail = check.error || check.reason || JSON.stringify({ ...check, id: undefined, status: undefined })
+    lines.push(`| ${check.id} | ${check.status} | ${String(detail).replace(/\|/g, '\\|')} |`)
+  }
+  lines.push('')
+  return `${lines.join('\n')}\n`
+}
+
+async function runCli(argv = process.argv.slice(2)) {
+  const opts = parseArgs(argv)
+  if (opts.help) {
+    printHelp()
+    return 0
+  }
+  const evidence = await runSmoke(opts)
+  const paths = await writeEvidence(evidence, opts)
+  console.log(JSON.stringify({
+    ok: evidence.ok,
+    baseUrl: evidence.baseUrl,
+    authenticated: evidence.authenticated,
+    summary: evidence.summary,
+    jsonPath: paths.jsonPath,
+    mdPath: paths.mdPath,
+  }, null, 2))
+  return evidence.ok ? 0 : 1
+}
+
+const entryPath = process.argv[1] ? pathToFileURL(path.resolve(process.argv[1])).href : null
+if (entryPath && import.meta.url === entryPath) {
+  runCli().then((code) => {
+    process.exit(code)
+  }).catch((error) => {
+    const body = error instanceof K3WisePostdeploySmokeError
+      ? { ok: false, code: error.name, message: error.message, details: error.details }
+      : { ok: false, code: error && error.name ? error.name : 'Error', message: error && error.message ? error.message : String(error) }
+    console.error(JSON.stringify(sanitizeBody(body), null, 2))
+    process.exit(1)
+  })
+}
+
+export {
+  K3WisePostdeploySmokeError,
+  assertStagingDescriptors,
+  assertStatusRoutes,
+  parseArgs,
+  renderMarkdown,
+  runCli,
+  runSmoke,
+}

--- a/scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
@@ -1,0 +1,270 @@
+import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import http from 'node:http'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const scriptPath = path.join(repoRoot, 'scripts', 'ops', 'integration-k3wise-postdeploy-smoke.mjs')
+
+function makeTmpDir() {
+  return mkdtempSync(path.join(tmpdir(), 'integration-k3wise-postdeploy-smoke-'))
+}
+
+function runScript(args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [scriptPath, ...args], { stdio: ['ignore', 'pipe', 'pipe'] })
+    let stdout = ''
+    let stderr = ''
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL')
+      reject(new Error(`script timed out\nstdout=${stdout}\nstderr=${stderr}`))
+    }, 15_000)
+
+    child.stdout.setEncoding('utf8')
+    child.stderr.setEncoding('utf8')
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk
+    })
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk
+    })
+    child.on('error', (error) => {
+      clearTimeout(timer)
+      reject(error)
+    })
+    child.on('close', (status) => {
+      clearTimeout(timer)
+      resolve({ status, stdout, stderr })
+    })
+  })
+}
+
+function sendJson(res, status, body) {
+  res.statusCode = status
+  res.setHeader('Content-Type', 'application/json')
+  res.end(JSON.stringify(body))
+}
+
+function sendHtml(res, status, body) {
+  res.statusCode = status
+  res.setHeader('Content-Type', 'text/html')
+  res.end(body)
+}
+
+function createFakeServer(options = {}) {
+  const requests = []
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url || '/', 'http://127.0.0.1')
+    requests.push({
+      method: req.method,
+      pathname: url.pathname,
+      authorization: req.headers.authorization || '',
+    })
+
+    if (req.method === 'GET' && url.pathname === '/api/health') {
+      sendJson(res, 200, {
+        status: 'ok',
+        ok: true,
+        success: true,
+        plugins: 13,
+        pluginsSummary: { total: 13, active: 13, failed: 0 },
+      })
+      return
+    }
+
+    if (req.method === 'GET' && url.pathname === '/api/integration/health') {
+      if (options.protectIntegrationHealth && req.headers.authorization !== 'Bearer test.jwt.token') {
+        sendJson(res, 401, { ok: false, error: { message: 'auth required' } })
+        return
+      }
+      sendJson(res, 200, {
+        ok: true,
+        plugin: 'plugin-integration-core',
+        milestone: 'M0-spike',
+      })
+      return
+    }
+
+    if (req.method === 'GET' && url.pathname === '/integrations/k3-wise') {
+      sendHtml(res, 200, '<!doctype html><html><body><div id="app"></div><script src="/assets/app.js"></script></body></html>')
+      return
+    }
+
+    if (req.method === 'GET' && url.pathname === '/api/auth/me') {
+      if (req.headers.authorization !== 'Bearer test.jwt.token') {
+        sendJson(res, 401, { ok: false, error: { message: 'bad token' } })
+        return
+      }
+      sendJson(res, 200, { success: true, user: { id: 'admin_1', role: 'admin' } })
+      return
+    }
+
+    if (req.method === 'GET' && url.pathname === '/api/integration/status') {
+      if (req.headers.authorization !== 'Bearer test.jwt.token') {
+        sendJson(res, 401, { ok: false, error: { message: 'bad token' } })
+        return
+      }
+      sendJson(res, 200, {
+        ok: true,
+        data: {
+          adapters: ['http', 'plm:yuantus-wrapper', 'erp:k3-wise-webapi', 'erp:k3-wise-sqlserver'],
+          routes: [
+            ['GET', '/api/integration/status'],
+            ['GET', '/api/integration/external-systems'],
+            ['POST', '/api/integration/external-systems'],
+            ['POST', '/api/integration/external-systems/:id/test'],
+            ['GET', '/api/integration/pipelines'],
+            ['POST', '/api/integration/pipelines'],
+            ['POST', '/api/integration/pipelines/:id/dry-run'],
+            ['POST', '/api/integration/pipelines/:id/run'],
+            ['GET', '/api/integration/runs'],
+            ['GET', '/api/integration/dead-letters'],
+            ['GET', '/api/integration/staging/descriptors'],
+            ['POST', '/api/integration/staging/install'],
+          ].map(([method, routePath]) => ({ method, path: routePath })),
+        },
+      })
+      return
+    }
+
+    if (req.method === 'GET' && url.pathname === '/api/integration/staging/descriptors') {
+      if (req.headers.authorization !== 'Bearer test.jwt.token') {
+        sendJson(res, 401, { ok: false, error: { message: 'bad token' } })
+        return
+      }
+      sendJson(res, 200, {
+        ok: true,
+        data: [
+          { id: 'standard_materials', name: 'Standard Materials' },
+          { id: 'bom_cleanse', name: 'BOM Cleanse' },
+        ],
+      })
+      return
+    }
+
+    sendJson(res, 404, { ok: false, error: { message: `not found: ${url.pathname}` } })
+  })
+
+  return {
+    requests,
+    async listen() {
+      await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve))
+      const address = server.address()
+      return `http://127.0.0.1:${address.port}`
+    },
+    async close() {
+      await new Promise((resolve) => server.close(resolve))
+    },
+  }
+}
+
+test('public postdeploy smoke passes without an auth token and skips authenticated contract checks', async () => {
+  const fake = createFakeServer()
+  const baseUrl = await fake.listen()
+  const outDir = makeTmpDir()
+  try {
+    const result = await runScript([
+      '--base-url', baseUrl,
+      '--out-dir', outDir,
+    ])
+
+    assert.equal(result.status, 0, result.stderr)
+    const stdout = JSON.parse(result.stdout)
+    assert.equal(stdout.ok, true)
+    assert.equal(stdout.authenticated, false)
+    assert.equal(stdout.summary.fail, 0)
+    assert.equal(stdout.summary.skipped, 1)
+    assert.equal(stdout.summary.pass, 3)
+
+    const evidence = JSON.parse(readFileSync(path.join(outDir, 'integration-k3wise-postdeploy-smoke.json'), 'utf8'))
+    assert.equal(evidence.checks.find((check) => check.id === 'authenticated-integration-contract').status, 'skipped')
+    assert.equal(evidence.checks.find((check) => check.id === 'k3-wise-frontend-route').status, 'pass')
+    assert.ok(fake.requests.some((request) => request.pathname === '/api/integration/health'))
+    assert.ok(fake.requests.some((request) => request.pathname === '/integrations/k3-wise'))
+  } finally {
+    await fake.close()
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('public postdeploy smoke skips plugin health when the deployment protects integration routes', async () => {
+  const fake = createFakeServer({ protectIntegrationHealth: true })
+  const baseUrl = await fake.listen()
+  const outDir = makeTmpDir()
+  try {
+    const result = await runScript([
+      '--base-url', baseUrl,
+      '--out-dir', outDir,
+    ])
+
+    assert.equal(result.status, 0, result.stderr)
+    const stdout = JSON.parse(result.stdout)
+    assert.equal(stdout.ok, true)
+    assert.equal(stdout.summary.fail, 0)
+    assert.equal(stdout.summary.skipped, 2)
+
+    const evidence = JSON.parse(readFileSync(path.join(outDir, 'integration-k3wise-postdeploy-smoke.json'), 'utf8'))
+    assert.equal(evidence.checks.find((check) => check.id === 'integration-plugin-health').status, 'skipped')
+    assert.equal(evidence.checks.find((check) => check.id === 'k3-wise-frontend-route').status, 'pass')
+  } finally {
+    await fake.close()
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('authenticated postdeploy smoke validates route and staging contracts without leaking token', async () => {
+  const fake = createFakeServer()
+  const baseUrl = await fake.listen()
+  const outDir = makeTmpDir()
+  const tokenPath = path.join(outDir, 'token.txt')
+  writeFileSync(tokenPath, 'test.jwt.token\n')
+  try {
+    const result = await runScript([
+      '--base-url', baseUrl,
+      '--token-file', tokenPath,
+      '--require-auth',
+      '--out-dir', outDir,
+    ])
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.equal(result.stdout.includes('test.jwt.token'), false)
+    assert.equal(result.stderr.includes('test.jwt.token'), false)
+
+    const evidenceText = readFileSync(path.join(outDir, 'integration-k3wise-postdeploy-smoke.json'), 'utf8')
+    assert.equal(evidenceText.includes('test.jwt.token'), false)
+    const evidence = JSON.parse(evidenceText)
+    assert.equal(evidence.authenticated, true)
+    assert.equal(evidence.summary.fail, 0)
+    assert.equal(evidence.checks.find((check) => check.id === 'integration-route-contract').status, 'pass')
+    assert.equal(evidence.checks.find((check) => check.id === 'staging-descriptor-contract').status, 'pass')
+    assert.ok(fake.requests.some((request) => request.pathname === '/api/auth/me' && request.authorization === 'Bearer test.jwt.token'))
+  } finally {
+    await fake.close()
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('require-auth turns missing token into a failing check', async () => {
+  const fake = createFakeServer()
+  const baseUrl = await fake.listen()
+  const outDir = makeTmpDir()
+  try {
+    const result = await runScript([
+      '--base-url', baseUrl,
+      '--require-auth',
+      '--out-dir', outDir,
+    ])
+
+    assert.equal(result.status, 1)
+    const stdout = JSON.parse(result.stdout)
+    assert.equal(stdout.ok, false)
+    assert.equal(stdout.summary.fail, 1)
+  } finally {
+    await fake.close()
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary

Adds a read-only K3 WISE post-deploy smoke script for the customer GATE waiting period.

The script checks the deployed MetaSheet K3 WISE integration surface before the live customer PoC packet arrives:

- public backend health and plugin failure summary
- integration plugin health when public, or skipped when the deployment protects `/api/integration/*`
- `/integrations/k3-wise` frontend route app shell
- authenticated integration route and staging descriptor contracts when a bearer token is supplied

It also adds design and verification docs, plus `.gitignore` coverage for generated smoke evidence under `output/integration-k3wise-postdeploy-smoke/`.

## Safety

- read-only `GET` requests only
- no customer PLM/K3/SQL Server calls
- no external system, pipeline, staging sheet, or ERP write mutation
- token-like values and secret-shaped response keys are redacted from stdout/stderr/evidence
- `--require-auth` makes missing auth a hard failure for operator signoff runs

## Verification

```bash
node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
node scripts/ops/integration-k3wise-postdeploy-smoke.mjs --help
node scripts/ops/integration-k3wise-postdeploy-smoke.mjs \
  --base-url http://142.171.239.56:8081 \
  --out-dir output/integration-k3wise-postdeploy-smoke/current-public
git diff --cached --check
```

Results:

- postdeploy smoke tests: 4 passed
- CLI help: passed
- public 142 deployment smoke: `ok=true`, `2 pass / 2 skipped / 0 fail`
- public smoke details: `/api/health` passed with `plugins=13`, `pluginsSummary.failed=0`; K3 WISE frontend route returned HTTP 200; auth-only checks skipped without token
- diff whitespace check: passed

Docs:

- `docs/development/integration-k3wise-postdeploy-smoke-design-20260428.md`
- `docs/development/integration-k3wise-postdeploy-smoke-verification-20260428.md`
