### PR TITLE
test(dingtalk): automate public form access matrix UI checks

### DIFF
--- a/apps/web/src/multitable/components/MetaFormShareManager.vue
+++ b/apps/web/src/multitable/components/MetaFormShareManager.vue
@@ -133,6 +133,13 @@
                     <span class="meta-form-share__chip-text">
                       {{ group.label }}
                       <span v-if="group.subtitle" class="meta-form-share__chip-subtitle">{{ group.subtitle }}</span>
+                      <span
+                        v-if="subjectDingTalkStatus(group)"
+                        class="meta-form-share__chip-subtitle"
+                        :data-form-share-dingtalk-status="subjectDingTalkStatus(group)"
+                      >
+                        {{ subjectDingTalkStatus(group) }}
+                      </span>
                     </span>
                     <button
                       class="meta-form-share__chip-remove"

--- a/apps/web/tests/multitable-form-share-manager.spec.ts
+++ b/apps/web/tests/multitable-form-share-manager.spec.ts
@@ -35,7 +35,7 @@ function mockClient(config = fakeConfig()) {
     if (method === 'GET' && url.includes('/form-share-candidates')) {
       return ok({
         items: [
-          { subjectType: 'user', subjectId: 'user_1', label: 'Alice', subtitle: 'alice@test.local', isActive: true, accessLevel: 'write' },
+          { subjectType: 'user', subjectId: 'user_1', label: 'Alice', subtitle: 'alice@test.local', isActive: true, accessLevel: 'write', dingtalkBound: true, dingtalkGrantEnabled: true, dingtalkPersonDeliveryAvailable: true },
           { subjectType: 'member-group', subjectId: 'group_ops', label: 'Ops', subtitle: 'Operations', isActive: true, accessLevel: 'write' },
           { subjectType: 'user', subjectId: 'user_inactive', label: 'Inactive User', subtitle: 'inactive@test.local', isActive: false, accessLevel: 'write', dingtalkBound: false, dingtalkGrantEnabled: false, dingtalkPersonDeliveryAvailable: false },
         ],
@@ -237,6 +237,9 @@ describe('MetaFormShareManager', () => {
     expect(document.querySelector('[data-form-share-audience-rule]')?.textContent).toContain('All authorized DingTalk users')
     expect(document.body.textContent).toContain('DingTalk is only the sign-in and delivery channel. The allowlist still targets your local users and member groups.')
     expect(document.body.textContent).toContain('No local user allowlist configured. Access is still gated by the selected DingTalk mode; add local users or member groups to narrow who can fill this form.')
+    expect(document.body.textContent).toContain('DingTalk bound and authorized')
+    expect(document.body.textContent).toContain('DingTalk not bound')
+    expect(document.body.textContent).toContain('Members are checked individually')
   })
 
   it('summarizes the configured local allowlist audience', async () => {
@@ -257,6 +260,117 @@ describe('MetaFormShareManager', () => {
     expect(summary.textContent).toContain('Local allowlist limits: 1 local user and 1 local member group can fill after passing the selected DingTalk mode.')
     expect(document.querySelector('[data-form-share-audience-rule]')?.textContent).toContain('Selected DingTalk-bound users')
     expect(document.body.textContent).toContain('DingTalk bound')
+    expect(document.body.textContent).toContain('Members are checked individually')
+  })
+
+  it('renders the full DingTalk access matrix for operators', async () => {
+    const cases = [
+      {
+        config: fakeConfig({ accessMode: 'public' }),
+        expected: {
+          mode: 'public',
+          hasLocalAllowlist: 'false',
+          title: 'Fully public anonymous form',
+          description: 'Anyone with the link can open and submit without local login or DingTalk binding.',
+          allowlistVisible: false,
+        },
+      },
+      {
+        config: fakeConfig({ accessMode: 'dingtalk' }),
+        expected: {
+          mode: 'dingtalk',
+          hasLocalAllowlist: 'false',
+          title: 'All DingTalk-bound users',
+          description: 'Any local user can fill after DingTalk sign-in when their account is bound to DingTalk.',
+          allowlistVisible: true,
+        },
+      },
+      {
+        config: fakeConfig({
+          accessMode: 'dingtalk',
+          allowedUserIds: ['user_1'],
+          allowedUsers: [{ subjectType: 'user', subjectId: 'user_1', label: 'Alice', subtitle: 'alice@test.local', isActive: true, dingtalkBound: true, dingtalkGrantEnabled: true, dingtalkPersonDeliveryAvailable: true }],
+        }),
+        expected: {
+          mode: 'dingtalk',
+          hasLocalAllowlist: 'true',
+          title: 'Selected DingTalk-bound users',
+          description: 'Only selected local users or group members can fill, and each user must be bound to DingTalk.',
+          allowlistVisible: true,
+        },
+      },
+      {
+        config: fakeConfig({ accessMode: 'dingtalk_granted' }),
+        expected: {
+          mode: 'dingtalk_granted',
+          hasLocalAllowlist: 'false',
+          title: 'All authorized DingTalk users',
+          description: 'Any DingTalk-bound local user can fill after an administrator enables their DingTalk form authorization.',
+          allowlistVisible: true,
+        },
+      },
+      {
+        config: fakeConfig({
+          accessMode: 'dingtalk_granted',
+          allowedUserIds: ['user_authorized', 'user_needs_grant', 'user_unbound'],
+          allowedUsers: [
+            { subjectType: 'user', subjectId: 'user_authorized', label: 'Authorized User', subtitle: 'authorized@test.local', isActive: true, dingtalkBound: true, dingtalkGrantEnabled: true, dingtalkPersonDeliveryAvailable: true },
+            { subjectType: 'user', subjectId: 'user_needs_grant', label: 'Needs Grant', subtitle: 'needs-grant@test.local', isActive: true, dingtalkBound: true, dingtalkGrantEnabled: false, dingtalkPersonDeliveryAvailable: true },
+            { subjectType: 'user', subjectId: 'user_unbound', label: 'Unbound User', subtitle: 'unbound@test.local', isActive: true, dingtalkBound: false, dingtalkGrantEnabled: false, dingtalkPersonDeliveryAvailable: false },
+          ],
+          allowedMemberGroupIds: ['group_ops'],
+          allowedMemberGroups: [{ subjectType: 'member-group', subjectId: 'group_ops', label: 'Ops', subtitle: 'Operations', isActive: true }],
+        }),
+        expected: {
+          mode: 'dingtalk_granted',
+          hasLocalAllowlist: 'true',
+          title: 'Selected authorized DingTalk users',
+          description: 'Only selected local users or group members can fill, and each user must be DingTalk-bound with form authorization enabled.',
+          allowlistVisible: true,
+        },
+      },
+    ]
+
+    for (const item of cases) {
+      document.body.innerHTML = ''
+      const { client } = mockClient(item.config)
+      const { app } = mount({ visible: true, sheetId: 'sh_1', viewId: 'v_1', client })
+      await flushPromises()
+
+      const audience = document.querySelector('[data-form-share-audience-rule]') as HTMLElement
+      expect(audience).toBeTruthy()
+      expect(audience.getAttribute('data-access-mode')).toBe(item.expected.mode)
+      expect(audience.getAttribute('data-has-local-allowlist')).toBe(item.expected.hasLocalAllowlist)
+      expect(audience.textContent).toContain(item.expected.title)
+      expect(audience.textContent).toContain(item.expected.description)
+      expect(Boolean(document.querySelector('[data-form-share-allowlist-summary]'))).toBe(item.expected.allowlistVisible)
+
+      app.unmount()
+    }
+  })
+
+  it('shows DingTalk grant and member-group statuses for selected allowlist subjects', async () => {
+    const { client } = mockClient(fakeConfig({
+      accessMode: 'dingtalk_granted',
+      allowedUserIds: ['user_authorized', 'user_needs_grant', 'user_unbound'],
+      allowedUsers: [
+        { subjectType: 'user', subjectId: 'user_authorized', label: 'Authorized User', subtitle: 'authorized@test.local', isActive: true, dingtalkBound: true, dingtalkGrantEnabled: true, dingtalkPersonDeliveryAvailable: true },
+        { subjectType: 'user', subjectId: 'user_needs_grant', label: 'Needs Grant', subtitle: 'needs-grant@test.local', isActive: true, dingtalkBound: true, dingtalkGrantEnabled: false, dingtalkPersonDeliveryAvailable: true },
+        { subjectType: 'user', subjectId: 'user_unbound', label: 'Unbound User', subtitle: 'unbound@test.local', isActive: true, dingtalkBound: false, dingtalkGrantEnabled: false, dingtalkPersonDeliveryAvailable: false },
+      ],
+      allowedMemberGroupIds: ['group_ops'],
+      allowedMemberGroups: [{ subjectType: 'member-group', subjectId: 'group_ops', label: 'Ops', subtitle: 'Operations', isActive: true }],
+    }))
+    mount({ visible: true, sheetId: 'sh_1', viewId: 'v_1', client })
+    await flushPromises()
+
+    const statuses = Array.from(document.querySelectorAll('[data-form-share-dingtalk-status]'))
+      .map((el) => el.textContent?.trim())
+
+    expect(statuses).toContain('DingTalk bound and authorized')
+    expect(statuses).toContain('DingTalk authorization not enabled')
+    expect(statuses).toContain('DingTalk not bound')
+    expect(statuses).toContain('Members are checked individually')
   })
 
   it('adds an allowed user through the allowlist controls', async () => {

--- a/docs/development/dingtalk-public-form-access-matrix-142-verification-20260428.md
+++ b/docs/development/dingtalk-public-form-access-matrix-142-verification-20260428.md
@@ -148,8 +148,11 @@ Runtime log check:
 - No real backend error stack, public-form exception, or DingTalk access-matrix error was observed in the checked deploy window.
 - Web logs showed expected nginx startup and `200` responses for `/`, `/api/health`, and the public-form route.
 
-Remaining manual checks:
+Follow-up automated UI acceptance:
 
-- Open the form sharing panel in a browser and visually confirm the access-rule card for `public`, `dingtalk`, and `dingtalk_granted`.
-- Confirm selected allowed users and candidate search rows display DingTalk binding / grant status.
+- `docs/development/dingtalk-public-form-access-matrix-ui-acceptance-verification-20260428.md` covers the share-panel access-rule card for `public`, `dingtalk`, and `dingtalk_granted`.
+- The same follow-up verification covers selected allowed users, selected member groups, and candidate search rows displaying DingTalk binding / grant status.
+
+Remaining manual check:
+
 - Re-run a real DingTalk mobile flow for `public`, `dingtalk`, and `dingtalk_granted` if screenshots or product signoff evidence is required.

--- a/docs/development/dingtalk-public-form-access-matrix-ui-acceptance-design-20260428.md
+++ b/docs/development/dingtalk-public-form-access-matrix-ui-acceptance-design-20260428.md
@@ -1,0 +1,58 @@
+# DingTalk Public Form Access Matrix UI Acceptance Design - 2026-04-28
+
+## Goal
+
+Reduce the remaining manual verification for the public-form sharing panel by turning the operator-facing access-matrix checks into repeatable frontend assertions.
+
+The previous 142 verification left these checks as manual:
+
+- Open the form sharing panel and visually confirm the access-rule card for `public`, `dingtalk`, and `dingtalk_granted`.
+- Confirm selected allowed users and candidate search rows display DingTalk binding / grant status.
+- Re-run real DingTalk mobile flows if product signoff evidence is required.
+
+This slice automates the first two items as far as they can be validated without a real browser/device and DingTalk tenant session.
+
+## Design
+
+### Selected Member Group Status
+
+Allowed member groups now show the same DingTalk status helper used by candidate rows:
+
+- `Members are checked individually`
+
+This makes the configured allowlist chips match the candidate-search rows and explains that a group selection does not bypass per-user DingTalk binding / grant enforcement.
+
+### Access Matrix Assertions
+
+The frontend unit test now checks the full operator access matrix:
+
+| Mode | Local allowlist | Expected card |
+| --- | --- | --- |
+| `public` | empty | `Fully public anonymous form` |
+| `dingtalk` | empty | `All DingTalk-bound users` |
+| `dingtalk` | non-empty | `Selected DingTalk-bound users` |
+| `dingtalk_granted` | empty | `All authorized DingTalk users` |
+| `dingtalk_granted` | non-empty | `Selected authorized DingTalk users` |
+
+Each case asserts:
+
+- `data-form-share-audience-rule` exists.
+- `data-access-mode` matches the configured access mode.
+- `data-has-local-allowlist` matches the configured local allowlist state.
+- The card title and description match the expected operator-facing rule.
+- The allowlist section is hidden only for `public` mode.
+
+### DingTalk Subject Status Assertions
+
+The focused test now covers selected allowlist subjects and candidate rows:
+
+- bound and granted user: `DingTalk bound and authorized`
+- bound but not granted user: `DingTalk authorization not enabled`
+- unbound user: `DingTalk not bound`
+- member group: `Members are checked individually`
+
+## Non-goals
+
+- This does not replace real DingTalk mobile signoff. A real mobile flow still requires a live DingTalk account, tenant session, and product evidence capture.
+- This does not change backend public-form authorization enforcement. Enforcement was already covered by backend integration tests and the deployed 142 smoke checks.
+- This does not add or expose any DingTalk webhook, signing secret, JWT, or bearer token.

--- a/docs/development/dingtalk-public-form-access-matrix-ui-acceptance-verification-20260428.md
+++ b/docs/development/dingtalk-public-form-access-matrix-ui-acceptance-verification-20260428.md
@@ -1,0 +1,67 @@
+# DingTalk Public Form Access Matrix UI Acceptance Verification - 2026-04-28
+
+## Scope
+
+This document verifies the follow-up UI acceptance slice for the DingTalk public-form access matrix.
+
+Changed files:
+
+- `apps/web/src/multitable/components/MetaFormShareManager.vue`
+- `apps/web/tests/multitable-form-share-manager.spec.ts`
+- `docs/development/dingtalk-public-form-access-matrix-142-verification-20260428.md`
+- `docs/development/dingtalk-public-form-access-matrix-ui-acceptance-design-20260428.md`
+- `docs/development/dingtalk-public-form-access-matrix-ui-acceptance-verification-20260428.md`
+
+## Commands
+
+```bash
+pnpm install
+git diff --check
+git diff -- apps/web/src/multitable/components/MetaFormShareManager.vue apps/web/tests/multitable-form-share-manager.spec.ts docs/development/dingtalk-public-form-access-matrix-142-verification-20260428.md docs/development/dingtalk-public-form-access-matrix-ui-acceptance-design-20260428.md docs/development/dingtalk-public-form-access-matrix-ui-acceptance-verification-20260428.md | rg -n "(access_token=|SEC[0-9a-fA-F]{8,}|Authorization:|Bearer [A-Za-z0-9._-]+|https://oapi\\.dingtalk\\.com/robot/send|JWT_SECRET|DINGTALK_APP_SECRET)" || true
+pnpm --filter @metasheet/web exec vitest run tests/multitable-form-share-manager.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+```
+
+## Results
+
+- `pnpm install`: passed; lockfile was already up to date and packages were reused from the local store.
+- `git diff --check`: passed.
+- Diff secret scan: no matches for DingTalk webhook/token/JWT-secret patterns.
+- Focused frontend test: passed, 17 tests.
+- Frontend build: passed.
+
+Non-blocking build warnings:
+
+- Existing dynamic/static import warning for `WorkflowDesigner.vue`.
+- Existing large chunk warnings after minification.
+
+## Cleanup
+
+`pnpm install` rewrote several tracked workspace/plugin `node_modules` symlinks and `pnpm-lock.yaml` in the temporary worktree. Those install-only side effects were reverted before preparing this change.
+
+## Coverage Added
+
+- Access-rule card is asserted for all five operator-facing combinations:
+  - `public` with no local allowlist.
+  - `dingtalk` with no local allowlist.
+  - `dingtalk` with a local allowlist.
+  - `dingtalk_granted` with no local allowlist.
+  - `dingtalk_granted` with a local allowlist.
+- Candidate rows still display DingTalk user and member-group status.
+- Selected allowlist user chips display DingTalk binding and grant status.
+- Selected allowlist member-group chips now display `Members are checked individually`.
+
+## Remaining Manual Evidence
+
+A real DingTalk mobile signoff is still manual by design. It requires:
+
+- A real DingTalk client session.
+- A live DingTalk-bound local user.
+- If testing `dingtalk_granted`, an enabled DingTalk form grant.
+- Optional product evidence capture such as a screenshot or screen recording.
+
+This slice removes the need to manually inspect the share-configuration access matrix for every code change, but it does not fake live DingTalk client evidence.
+
+## Secret Handling
+
+No webhook URL, DingTalk signing secret, bearer token, JWT, or raw `Authorization` header was added to source, tests, or docs.


### PR DESCRIPTION
## Summary

- Show the DingTalk member-group status helper on selected allowed member-group chips.
- Add frontend acceptance coverage for the public-form access matrix across `public`, `dingtalk`, and `dingtalk_granted`, with and without local allowlists.
- Add selected-subject DingTalk status assertions and companion design/verification docs.
- Update the 142 verification doc so only the real DingTalk mobile flow remains manual.

## Verification

- `pnpm install`
- `git diff --check`
- Diff secret scan for DingTalk webhook/token/JWT-secret patterns: no matches.
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-form-share-manager.spec.ts --watch=false`
- `pnpm --filter @metasheet/web build`

Non-blocking: web build still reports the existing `WorkflowDesigner.vue` dynamic/static import warning and existing large chunk warnings.
