### PR TITLE
chore(integration): wire K3 WISE smoke into deploy workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -364,6 +364,19 @@ jobs:
           echo "deploy_log=$deploy_log" >> "$GITHUB_OUTPUT"
           exit 0
 
+      - name: K3 WISE postdeploy smoke
+        if: ${{ steps.remote_deploy.outputs.deploy_rc == '0' }}
+        env:
+          METASHEET_BASE_URL: ${{ vars.METASHEET_BASE_URL || vars.PUBLIC_APP_URL || 'http://142.171.239.56:8081' }}
+          METASHEET_AUTH_TOKEN: ${{ secrets.METASHEET_K3WISE_SMOKE_TOKEN }}
+        run: |
+          set -euo pipefail
+          smoke_out_dir="output/deploy/k3wise-postdeploy-smoke"
+          rm -rf "$smoke_out_dir"
+          node scripts/ops/integration-k3wise-postdeploy-smoke.mjs \
+            --base-url "$METASHEET_BASE_URL" \
+            --out-dir "$smoke_out_dir"
+
       - name: Write deploy summary (preflight + runbooks)
         if: always()
         env:
@@ -564,9 +577,34 @@ jobs:
           fi
 
           echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "### K3 WISE Postdeploy Smoke" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          k3_smoke_json="output/deploy/k3wise-postdeploy-smoke/integration-k3wise-postdeploy-smoke.json"
+          if [[ -f "$k3_smoke_json" ]]; then
+            node - "$k3_smoke_json" >> "$GITHUB_STEP_SUMMARY" <<'NODE'
+          const fs = require('fs')
+          const evidence = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'))
+          const summary = evidence.summary || {}
+          const status = evidence.ok ? 'PASS' : 'FAIL'
+          console.log(`- Status: **${status}**`)
+          console.log(`- Base URL: \`${evidence.baseUrl || 'unknown'}\``)
+          console.log(`- Authenticated checks: \`${evidence.authenticated ? 'yes' : 'no'}\``)
+          console.log(`- Summary: \`${summary.pass || 0} pass / ${summary.skipped || 0} skipped / ${summary.fail || 0} fail\``)
+          console.log('- Checks:')
+          for (const check of evidence.checks || []) {
+            console.log(`  - \`${check.id}\`: \`${check.status}\``)
+          }
+          NODE
+          else
+            echo "- Status: **NOT RUN**" >> "$GITHUB_STEP_SUMMARY"
+            echo "- Reason: remote deploy did not complete successfully, or the K3 WISE smoke step did not produce evidence." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "### Artifacts" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "- Deploy logs artifact: \`${artifact_name}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- K3 WISE smoke evidence: \`output/deploy/k3wise-postdeploy-smoke/\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- Local evidence path (after download): \`output/playwright/ga/${GITHUB_RUN_ID}/deploy.log\`" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "Download:" >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ artifacts/dingtalk-staging-evidence-packet/
 # K3 WISE postdeploy smoke artifacts can include deployment topology and
 # authenticated contract evidence.
 output/integration-k3wise-postdeploy-smoke/
+output/deploy/k3wise-postdeploy-smoke*/

--- a/docs/development/integration-k3wise-postdeploy-workflow-design-20260429.md
+++ b/docs/development/integration-k3wise-postdeploy-workflow-design-20260429.md
@@ -1,0 +1,55 @@
+# K3 WISE Postdeploy Workflow Design
+
+## Context
+
+`scripts/ops/integration-k3wise-postdeploy-smoke.mjs` made the K3 WISE postdeploy check repeatable, but it still required a human to remember to run it after the main deployment workflow. The next step is to wire the check into the existing `Build and Push Docker Images` deploy job so every successful main deploy leaves a K3 WISE integration smoke artifact.
+
+## Design
+
+The workflow integration is intentionally narrow:
+
+- It runs only after `Remote deploy (with preflight logs)` reports `deploy_rc=0`.
+- It executes from the GitHub runner against the public app URL, not from the deploy host.
+- It uses the existing read-only K3 WISE smoke script.
+- It writes evidence under `output/deploy/k3wise-postdeploy-smoke/`, so the existing `Upload deploy artifacts` step includes the JSON and Markdown smoke outputs.
+- It appends a compact K3 WISE section to `GITHUB_STEP_SUMMARY`.
+
+## Auth Model
+
+The default path is public-only:
+
+- backend health
+- K3 WISE frontend route
+- protected `/api/integration/*` checks are reported as skipped when no token is available
+
+If repository secret `METASHEET_K3WISE_SMOKE_TOKEN` is configured, the same step automatically runs the authenticated contract checks:
+
+- `/api/auth/me`
+- `/api/integration/status`
+- `/api/integration/staging/descriptors`
+
+The workflow does not pass `--require-auth`; missing auth is acceptable for the baseline deploy gate. A bad configured token still fails the smoke because the script treats supplied auth as strict.
+
+## Failure Behavior
+
+The K3 WISE smoke is a normal failing step. If public health or the app route regresses, the deploy job fails even though the remote deploy command itself may have returned `0`.
+
+The deploy summary keeps the remote deploy stage status separate from the K3 WISE postdeploy smoke status, making it clear whether a failure came from:
+
+- remote deploy/preflight/migrate/smoke
+- or the K3 WISE app-surface smoke that runs afterward
+
+## Artifact Handling
+
+Committed:
+
+- `.github/workflows/docker-build.yml`
+- `.gitignore`
+- `docs/development/integration-k3wise-postdeploy-workflow-design-20260429.md`
+- `docs/development/integration-k3wise-postdeploy-workflow-verification-20260429.md`
+
+Generated and ignored:
+
+- `output/deploy/k3wise-postdeploy-smoke*/`
+
+The ignored path can include authenticated evidence and deployment topology, so it should remain an artifact output rather than a tracked repository file.

--- a/docs/development/integration-k3wise-postdeploy-workflow-verification-20260429.md
+++ b/docs/development/integration-k3wise-postdeploy-workflow-verification-20260429.md
@@ -1,0 +1,82 @@
+# K3 WISE Postdeploy Workflow Verification
+
+## Environment
+
+Worktree:
+
+```bash
+/tmp/ms2-k3wise-postdeploy-workflow-20260429
+```
+
+Base:
+
+```bash
+origin/main bf4cb7ec3
+```
+
+## Commands
+
+```bash
+node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
+
+ruby -e 'require "yaml"; YAML.load_file(".github/workflows/docker-build.yml"); puts "workflow yaml ok"'
+
+rm -rf output/deploy/k3wise-postdeploy-smoke-local
+node scripts/ops/integration-k3wise-postdeploy-smoke.mjs \
+  --base-url http://142.171.239.56:8081 \
+  --out-dir output/deploy/k3wise-postdeploy-smoke-local
+
+git diff --check
+```
+
+## Results
+
+`node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs`
+
+- Passed: 4/4 tests.
+- Covered public-only smoke.
+- Covered protected integration route behavior.
+- Covered authenticated contract checks.
+- Covered `--require-auth` missing-token failure and token redaction.
+
+Workflow YAML parse:
+
+- Passed with Ruby `YAML.load_file`.
+- `actionlint` was not installed in this environment.
+
+Public 142 smoke:
+
+```json
+{
+  "ok": true,
+  "baseUrl": "http://142.171.239.56:8081",
+  "authenticated": false,
+  "summary": {
+    "pass": 2,
+    "skipped": 2,
+    "fail": 0
+  }
+}
+```
+
+Step-summary renderer simulation:
+
+```markdown
+- Status: **PASS**
+- Base URL: `http://142.171.239.56:8081`
+- Authenticated checks: `no`
+- Summary: `2 pass / 2 skipped / 0 fail`
+- Checks:
+  - `api-health`: `pass`
+  - `integration-plugin-health`: `skipped`
+  - `k3-wise-frontend-route`: `pass`
+  - `authenticated-integration-contract`: `skipped`
+```
+
+Whitespace check:
+
+- `git diff --check`: passed.
+
+## Notes
+
+The full deploy workflow can only be proven on `main` after merge because `.github/workflows/docker-build.yml` deploys from the default branch and requires production deploy secrets. The local verification covered the workflow YAML syntax, the smoke script behavior, and the summary renderer against real public 142 output.


### PR DESCRIPTION
## Summary

Wires the existing read-only K3 WISE postdeploy smoke script into the `Build and Push Docker Images` deploy job.

The new deploy step:

- runs only after `Remote deploy (with preflight logs)` reports `deploy_rc=0`
- executes `scripts/ops/integration-k3wise-postdeploy-smoke.mjs` from the GitHub runner
- writes JSON/MD evidence to `output/deploy/k3wise-postdeploy-smoke/`
- lets the existing deploy artifact upload include the K3 WISE evidence
- appends a compact K3 WISE smoke section to `GITHUB_STEP_SUMMARY`
- accepts optional `METASHEET_K3WISE_SMOKE_TOKEN` for authenticated route/staging contract checks

## Safety

- read-only smoke only; no PLM/K3/SQL Server/customer calls
- no external-system/pipeline/staging/ERP mutations
- missing auth remains acceptable for the baseline deploy gate
- a configured bad auth token still fails the smoke because supplied auth is strict
- generated local evidence is ignored via `output/deploy/k3wise-postdeploy-smoke*/`

## Verification

```bash
node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
ruby -e 'require "yaml"; YAML.load_file(".github/workflows/docker-build.yml"); puts "workflow yaml ok"'
node --check scripts/ops/integration-k3wise-postdeploy-smoke.mjs
node --check scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
node scripts/ops/integration-k3wise-postdeploy-smoke.mjs \
  --base-url http://142.171.239.56:8081 \
  --out-dir output/deploy/k3wise-postdeploy-smoke-local
git diff --check
git diff --cached --check
```

Results:

- smoke tests: 4/4 passed
- workflow YAML parse: passed
- script syntax checks: passed
- public 142 smoke: `ok=true`, `2 pass / 2 skipped / 0 fail`
- summary renderer simulation: PASS output for api-health and K3 frontend route, auth checks skipped without token
- whitespace checks: passed

Docs:

- `docs/development/integration-k3wise-postdeploy-workflow-design-20260429.md`
- `docs/development/integration-k3wise-postdeploy-workflow-verification-20260429.md`
