### PR TITLE
chore(dingtalk): add mobile public form signoff kit

### DIFF
--- a/docs/development/dingtalk-public-form-mobile-signoff-design-20260429.md
+++ b/docs/development/dingtalk-public-form-mobile-signoff-design-20260429.md
@@ -1,0 +1,83 @@
+# DingTalk Public Form Mobile Signoff Design - 2026-04-29
+
+## Goal
+
+Close the last non-automated DingTalk public-form acceptance gap with a
+redaction-safe evidence packet that can be filled after a real DingTalk mobile
+run.
+
+The previous automated coverage already verifies backend guards, frontend
+access-matrix rendering, and 142 deployment health. What still cannot be faked
+in unit tests is the product loop inside a real DingTalk client. This slice
+makes that manual loop repeatable and auditable without requiring screenshots.
+
+## Scope
+
+Added script:
+
+- `scripts/ops/dingtalk-public-form-mobile-signoff.mjs`
+
+Added tests:
+
+- `scripts/ops/dingtalk-public-form-mobile-signoff.test.mjs`
+
+The script has two modes:
+
+- `--init-kit <dir>` writes an editable `mobile-signoff.json`, a checklist, and
+  per-check artifact folders.
+- `--input <file> --output-dir <dir> --strict` validates the filled evidence and
+  writes `summary.json`, `summary.md`, and `mobile-signoff.redacted.json`.
+
+## Access Matrix
+
+The kit covers the operator-facing cases that matter for the current DingTalk
+public-form plan:
+
+| Check ID | Scenario |
+| --- | --- |
+| `public-anonymous-submit` | Fully public anonymous form inserts a record. |
+| `dingtalk-unbound-rejected` | Login-required form rejects a local user without DingTalk binding. |
+| `dingtalk-bound-submit` | Login-required form accepts a DingTalk-bound user. |
+| `selected-unbound-rejected` | Selected-user form rejects a selected local user that is not DingTalk-bound. |
+| `selected-bound-submit` | Selected-user form accepts a selected DingTalk-bound user. |
+| `selected-unlisted-bound-rejected` | Selected-user form rejects a DingTalk-bound user outside the allowlist. |
+| `granted-bound-without-grant-rejected` | DingTalk-authorized form rejects a bound user without an enabled grant. |
+| `granted-bound-with-grant-submit` | DingTalk-authorized form accepts a bound user with an enabled grant. |
+| `password-change-bypass-observed` | A DingTalk public-form visitor with local `must_change_password=true` sees the form instead of the password-change page. |
+
+## Screenshot-Free Evidence
+
+Screenshots and recordings are optional. Strict mode accepts structured
+service-side evidence:
+
+- Allowed submit checks require a positive `recordInsertDelta` or increasing
+  `beforeRecordCount` / `afterRecordCount`.
+- Denied submit checks require `submitBlocked=true`, zero insert delta or equal
+  before/after counts, and a `blockedReason`.
+- Password-change bypass observation requires `formRendered=true` and
+  `passwordChangeRequiredShown=false`.
+
+This preserves an auditable acceptance trail even when the operator cannot or
+does not want to capture a DingTalk mobile screenshot.
+
+## Secret Handling
+
+The script rejects common raw secret shapes in JSON text and small text
+artifacts:
+
+- DingTalk robot webhook URLs.
+- DingTalk `SEC...` signing secrets.
+- `access_token` query parameters.
+- Bearer tokens and JWTs.
+- Public form tokens.
+- DingTalk client secrets.
+
+The compiled evidence file is always redacted again before writing
+`mobile-signoff.redacted.json`.
+
+## Non-goals
+
+- The script does not call DingTalk or staging.
+- The script does not create users, grants, forms, or records.
+- The script does not replace backend or frontend automated tests.
+- The script does not store temporary passwords or webhook secrets.

--- a/docs/development/dingtalk-public-form-mobile-signoff-verification-20260429.md
+++ b/docs/development/dingtalk-public-form-mobile-signoff-verification-20260429.md
@@ -9,6 +9,7 @@ Changed files:
 
 - `scripts/ops/dingtalk-public-form-mobile-signoff.mjs`
 - `scripts/ops/dingtalk-public-form-mobile-signoff.test.mjs`
+- `packages/core-backend/src/tests/rate-limiting.test.ts`
 - `docs/development/dingtalk-public-form-mobile-signoff-design-20260429.md`
 - `docs/development/dingtalk-public-form-mobile-signoff-verification-20260429.md`
 
@@ -17,8 +18,9 @@ Changed files:
 ```bash
 node --test scripts/ops/dingtalk-public-form-mobile-signoff.test.mjs
 node scripts/ops/dingtalk-public-form-mobile-signoff.mjs --init-kit /tmp/dingtalk-mobile-signoff-kit-verify
+pnpm --filter @metasheet/core-backend exec vitest run src/tests/rate-limiting.test.ts --watch=false
 git diff --check
-git diff --cached -- scripts/ops/dingtalk-public-form-mobile-signoff.mjs scripts/ops/dingtalk-public-form-mobile-signoff.test.mjs docs/development/dingtalk-public-form-mobile-signoff-design-20260429.md docs/development/dingtalk-public-form-mobile-signoff-verification-20260429.md \
+git diff --cached -- scripts/ops/dingtalk-public-form-mobile-signoff.mjs scripts/ops/dingtalk-public-form-mobile-signoff.test.mjs packages/core-backend/src/tests/rate-limiting.test.ts docs/development/dingtalk-public-form-mobile-signoff-design-20260429.md docs/development/dingtalk-public-form-mobile-signoff-verification-20260429.md \
   | rg -v "git diff --cached -- scripts/ops/dingtalk-public-form-mobile-signoff" \
   | rg -v "rg -n" \
   | rg -n "(access_token=[A-Za-z0-9]|SEC[0-9a-fA-F]{8,}|Authorization:|Bearer [A-Za-z0-9._-]{20,}|https://oapi\\.dingtalk\\.com/robot/send|JWT_SECRET|DINGTALK_APP_SECRET|publicToken=[A-Za-z0-9._~+/=-]{12,})" || true
@@ -28,6 +30,7 @@ git diff --cached -- scripts/ops/dingtalk-public-form-mobile-signoff.mjs scripts
 
 - Node test: passed, 4 tests.
 - Kit initialization command: passed and wrote `/tmp/dingtalk-mobile-signoff-kit-verify`.
+- Focused rate-limiter test: passed, 36 tests.
 - `git diff --check`: passed.
 - Diff secret scan: no matches for DingTalk webhook/token/JWT/public-token patterns.
 
@@ -39,6 +42,11 @@ The new Node test covers:
 - Strict compile with screenshot-free structured evidence.
 - Rejection of denied-submit checks that do not prove zero record inserts.
 - Rejection of secret-like evidence text, including public form token leakage.
+
+The rate-limiter assertion changed from exact equality to a bounded range
+because token refill can add a fractional amount between two immediate
+consumes on CI. This keeps the behavioral proof intact: the multi-token request
+is rejected and the bucket still has roughly the two expected remaining tokens.
 
 ## Expected Operator Flow
 

--- a/docs/development/dingtalk-public-form-mobile-signoff-verification-20260429.md
+++ b/docs/development/dingtalk-public-form-mobile-signoff-verification-20260429.md
@@ -1,0 +1,73 @@
+# DingTalk Public Form Mobile Signoff Verification - 2026-04-29
+
+## Scope
+
+This document verifies the screenshot-optional mobile signoff evidence tooling
+for DingTalk public forms.
+
+Changed files:
+
+- `scripts/ops/dingtalk-public-form-mobile-signoff.mjs`
+- `scripts/ops/dingtalk-public-form-mobile-signoff.test.mjs`
+- `docs/development/dingtalk-public-form-mobile-signoff-design-20260429.md`
+- `docs/development/dingtalk-public-form-mobile-signoff-verification-20260429.md`
+
+## Commands
+
+```bash
+node --test scripts/ops/dingtalk-public-form-mobile-signoff.test.mjs
+node scripts/ops/dingtalk-public-form-mobile-signoff.mjs --init-kit /tmp/dingtalk-mobile-signoff-kit-verify
+git diff --check
+git diff --cached -- scripts/ops/dingtalk-public-form-mobile-signoff.mjs scripts/ops/dingtalk-public-form-mobile-signoff.test.mjs docs/development/dingtalk-public-form-mobile-signoff-design-20260429.md docs/development/dingtalk-public-form-mobile-signoff-verification-20260429.md \
+  | rg -v "git diff --cached -- scripts/ops/dingtalk-public-form-mobile-signoff" \
+  | rg -v "rg -n" \
+  | rg -n "(access_token=[A-Za-z0-9]|SEC[0-9a-fA-F]{8,}|Authorization:|Bearer [A-Za-z0-9._-]{20,}|https://oapi\\.dingtalk\\.com/robot/send|JWT_SECRET|DINGTALK_APP_SECRET|publicToken=[A-Za-z0-9._~+/=-]{12,})" || true
+```
+
+## Results
+
+- Node test: passed, 4 tests.
+- Kit initialization command: passed and wrote `/tmp/dingtalk-mobile-signoff-kit-verify`.
+- `git diff --check`: passed.
+- Diff secret scan: no matches for DingTalk webhook/token/JWT/public-token patterns.
+
+## Regression Coverage
+
+The new Node test covers:
+
+- Creating an editable signoff kit with template JSON, checklist, and artifact folders.
+- Strict compile with screenshot-free structured evidence.
+- Rejection of denied-submit checks that do not prove zero record inserts.
+- Rejection of secret-like evidence text, including public form token leakage.
+
+## Expected Operator Flow
+
+1. Create a kit:
+
+```bash
+node scripts/ops/dingtalk-public-form-mobile-signoff.mjs \
+  --init-kit output/dingtalk-public-form-mobile-signoff/142-kit
+```
+
+2. Fill `output/dingtalk-public-form-mobile-signoff/142-kit/mobile-signoff.json`
+   with real DingTalk mobile results.
+
+3. Compile strictly:
+
+```bash
+node scripts/ops/dingtalk-public-form-mobile-signoff.mjs \
+  --input output/dingtalk-public-form-mobile-signoff/142-kit/mobile-signoff.json \
+  --output-dir output/dingtalk-public-form-mobile-signoff/142-compiled \
+  --strict
+```
+
+## Remaining Manual Step
+
+A real DingTalk client must still perform the actions. The difference after this
+slice is that screenshots are optional; structured server-side counts and
+blocked reasons are accepted as the auditable evidence.
+
+## Secret Handling
+
+No webhook URL, DingTalk signing secret, bearer token, JWT, public form token,
+or raw `Authorization` header was added to source, tests, or docs.

--- a/packages/core-backend/src/tests/rate-limiting.test.ts
+++ b/packages/core-backend/src/tests/rate-limiting.test.ts
@@ -74,7 +74,8 @@ describe('TokenBucketRateLimiter', () => {
       const result = rateLimiter.consume('tenant-1', 5)
 
       expect(result.allowed).toBe(false)
-      expect(result.tokensRemaining).toBe(2)
+      expect(result.tokensRemaining).toBeGreaterThanOrEqual(2)
+      expect(result.tokensRemaining).toBeLessThan(3)
     })
 
     it('should maintain separate buckets for different keys', () => {

--- a/scripts/ops/dingtalk-public-form-mobile-signoff.mjs
+++ b/scripts/ops/dingtalk-public-form-mobile-signoff.mjs
@@ -1,0 +1,532 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+
+const DEFAULT_OUTPUT_ROOT = 'output/dingtalk-public-form-mobile-signoff'
+const VALID_STATUSES = new Set(['pass', 'fail', 'skipped', 'pending'])
+const VALID_SOURCES = new Set(['manual-client', 'server-observation', 'operator-note'])
+const CHECKS = [
+  {
+    id: 'public-anonymous-submit',
+    label: 'Public anonymous submit succeeds',
+    scenario: 'Fully public anonymous form',
+    kind: 'allow-submit',
+    commandHint: '--record-insert-delta 1',
+  },
+  {
+    id: 'dingtalk-unbound-rejected',
+    label: 'DingTalk login required form rejects an unbound user',
+    scenario: 'Login-required form, local user is not DingTalk-bound',
+    kind: 'deny-submit',
+    commandHint: '--submit-blocked --record-insert-delta 0 --blocked-reason "DingTalk binding required"',
+  },
+  {
+    id: 'dingtalk-bound-submit',
+    label: 'DingTalk login required form accepts a bound user',
+    scenario: 'Login-required form, local user is DingTalk-bound',
+    kind: 'allow-submit',
+    commandHint: '--record-insert-delta 1',
+  },
+  {
+    id: 'selected-unbound-rejected',
+    label: 'Selected-user form rejects a selected but unbound user',
+    scenario: 'Selected users or groups, selected local user is not DingTalk-bound',
+    kind: 'deny-submit',
+    commandHint: '--submit-blocked --record-insert-delta 0 --blocked-reason "DingTalk binding required"',
+  },
+  {
+    id: 'selected-bound-submit',
+    label: 'Selected-user form accepts a selected bound user',
+    scenario: 'Selected users or groups, selected local user is DingTalk-bound',
+    kind: 'allow-submit',
+    commandHint: '--record-insert-delta 1',
+  },
+  {
+    id: 'selected-unlisted-bound-rejected',
+    label: 'Selected-user form rejects a bound user outside the allowlist',
+    scenario: 'Selected users or groups, DingTalk-bound local user is not selected',
+    kind: 'deny-submit',
+    commandHint: '--submit-blocked --record-insert-delta 0 --blocked-reason "Not in selected user or group allowlist"',
+  },
+  {
+    id: 'granted-bound-without-grant-rejected',
+    label: 'DingTalk-authorized form rejects a bound user without an enabled grant',
+    scenario: 'DingTalk-authorized form, local user is bound but grant is disabled or missing',
+    kind: 'deny-submit',
+    commandHint: '--submit-blocked --record-insert-delta 0 --blocked-reason "DingTalk grant required"',
+  },
+  {
+    id: 'granted-bound-with-grant-submit',
+    label: 'DingTalk-authorized form accepts a bound user with an enabled grant',
+    scenario: 'DingTalk-authorized form, local user is bound and grant is enabled',
+    kind: 'allow-submit',
+    commandHint: '--record-insert-delta 1',
+  },
+  {
+    id: 'password-change-bypass-observed',
+    label: 'DingTalk public form is not blocked by local password-change requirement',
+    scenario: 'DingTalk-bound public-form visitor still has local must_change_password=true',
+    kind: 'render',
+    commandHint: '--form-rendered --no-password-change-required-shown',
+  },
+]
+const CHECK_BY_ID = new Map(CHECKS.map((check) => [check.id, check]))
+const SECRET_PATTERNS = [
+  {
+    name: 'dingtalk_robot_webhook',
+    regex: /https:\/\/oapi\.dingtalk\.com\/robot\/send\?[^\s"'`<>]*access_token=(?!<redacted>|\$|%24|\(\?)[^\s&"'`<>]{8,}/i,
+  },
+  {
+    name: 'access_token_param',
+    regex: /(?:^|[?&])access_token=(?!<redacted>|\$|%24|replace-me|\(\?)[A-Za-z0-9._~+/=-]{16,}/i,
+  },
+  {
+    name: 'bearer_token',
+    regex: /\bBearer\s+(?!<redacted>|\$|\{)[A-Za-z0-9._~+/=-]{20,}/i,
+  },
+  {
+    name: 'dingtalk_sec_secret',
+    regex: /\bSEC(?=[A-Za-z0-9+/=-]{12,}\b)(?=[A-Za-z0-9+/=-]*\d)[A-Za-z0-9+/=-]{12,}\b/,
+  },
+  {
+    name: 'jwt',
+    regex: /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/,
+  },
+  {
+    name: 'public_form_token',
+    regex: /\bpublicToken=(?!<redacted>|\$)[A-Za-z0-9._~+/=-]{12,}/i,
+  },
+  {
+    name: 'client_secret',
+    regex: /(?:^|[\s"'`&?])(?:client_secret|DINGTALK_CLIENT_SECRET|DINGTALK_STATE_SECRET)=(?!<redacted>|\$|\{)[^\s&"'`<>]{8,}/i,
+  },
+]
+
+function printHelp() {
+  console.log(`Usage: node scripts/ops/dingtalk-public-form-mobile-signoff.mjs [options]
+
+Builds and validates a redaction-safe mobile signoff packet for DingTalk public
+form access modes. It does not call DingTalk or staging.
+
+Options:
+  --init-kit <dir>       Write mobile-signoff.json, checklist, and artifact folders
+  --input <file>         Input mobile-signoff.json to compile
+  --output-dir <dir>     Output dir, default ${DEFAULT_OUTPUT_ROOT}/<run-id>
+  --strict               Exit non-zero unless every required check passes
+  --help                 Show this help
+
+Evidence can be screenshot-free. For allowed submits, record a positive
+recordInsertDelta or before/after record counts. For blocked submits, record
+submitBlocked=true plus zero delta or equal before/after counts. Screenshots or
+recordings may be attached as optional local artifacts.
+`)
+}
+
+function readRequiredValue(argv, index, flag) {
+  const next = argv[index + 1]
+  if (!next || next.startsWith('--')) {
+    throw new Error(`${flag} requires a value`)
+  }
+  return next
+}
+
+function parseArgs(argv) {
+  const opts = {
+    initKit: '',
+    input: '',
+    outputDir: '',
+    strict: false,
+  }
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    switch (arg) {
+      case '--init-kit':
+        opts.initKit = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
+        i += 1
+        break
+      case '--input':
+        opts.input = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
+        i += 1
+        break
+      case '--output-dir':
+        opts.outputDir = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
+        i += 1
+        break
+      case '--strict':
+        opts.strict = true
+        break
+      case '--help':
+        printHelp()
+        process.exit(0)
+        break
+      default:
+        throw new Error(`Unknown argument: ${arg}`)
+    }
+  }
+
+  if (opts.initKit && opts.input) {
+    throw new Error('--init-kit and --input are mutually exclusive')
+  }
+  if (!opts.initKit && !opts.input) {
+    throw new Error('one of --init-kit or --input is required')
+  }
+  return opts
+}
+
+function nowIso() {
+  return new Date().toISOString()
+}
+
+function makeRunId() {
+  return `dingtalk-mobile-${nowIso().replace(/[:.]/g, '-').replace(/Z$/, 'Z')}`
+}
+
+function makeTemplateCheck(check) {
+  return {
+    id: check.id,
+    status: 'pending',
+    evidence: {
+      source: '',
+      operator: '',
+      performedAt: '',
+      summary: '',
+      notes: '',
+      artifacts: [],
+      beforeRecordCount: null,
+      afterRecordCount: null,
+      recordInsertDelta: null,
+      submitBlocked: null,
+      blockedReason: '',
+      formRendered: null,
+      passwordChangeRequiredShown: null,
+    },
+  }
+}
+
+function makeTemplate() {
+  return {
+    tool: 'dingtalk-public-form-mobile-signoff',
+    runId: makeRunId(),
+    createdAt: nowIso(),
+    environment: '',
+    commit: '',
+    checks: CHECKS.map(makeTemplateCheck),
+  }
+}
+
+function writeJson(file, value) {
+  mkdirSync(path.dirname(file), { recursive: true })
+  writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`, 'utf8')
+}
+
+function renderChecklist() {
+  const rows = CHECKS.map((check) => (
+    `| \`${check.id}\` | ${check.label} | ${check.scenario} | \`${check.commandHint}\` |`
+  )).join('\n')
+
+  return `# DingTalk Public Form Mobile Signoff Checklist
+
+This kit records the final real DingTalk mobile checks without storing secrets.
+Screenshots are optional. Service-side record counts and visible blocked reasons
+are enough when they are captured in \`mobile-signoff.json\`.
+
+Do not paste webhook URLs, signing secrets, bearer tokens, JWTs, public form
+tokens, or temporary passwords into this kit.
+
+| Check ID | Expected result | Scenario | Screenshot-free evidence hint |
+| --- | --- | --- | --- |
+${rows}
+
+Compile after filling \`mobile-signoff.json\`:
+
+\`\`\`bash
+node scripts/ops/dingtalk-public-form-mobile-signoff.mjs \\
+  --input mobile-signoff.json \\
+  --output-dir compiled \\
+  --strict
+\`\`\`
+`
+}
+
+function initKit(outputDir) {
+  mkdirSync(outputDir, { recursive: true })
+  const artifactsDir = path.join(outputDir, 'artifacts')
+  for (const check of CHECKS) {
+    mkdirSync(path.join(artifactsDir, check.id), { recursive: true })
+  }
+  writeJson(path.join(outputDir, 'mobile-signoff.json'), makeTemplate())
+  writeFileSync(path.join(outputDir, 'mobile-signoff-checklist.md'), renderChecklist(), 'utf8')
+  console.log(`[dingtalk-public-form-mobile-signoff] wrote kit: ${outputDir}`)
+}
+
+function isObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function readJson(file) {
+  return JSON.parse(readFileSync(file, 'utf8'))
+}
+
+function numberOrNull(value) {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+function hasPositiveInsert(evidence) {
+  const delta = numberOrNull(evidence.recordInsertDelta)
+  if (delta !== null) return delta > 0
+  const before = numberOrNull(evidence.beforeRecordCount)
+  const after = numberOrNull(evidence.afterRecordCount)
+  return before !== null && after !== null && after > before
+}
+
+function hasZeroInsert(evidence) {
+  const delta = numberOrNull(evidence.recordInsertDelta)
+  if (delta !== null) return delta === 0
+  const before = numberOrNull(evidence.beforeRecordCount)
+  const after = numberOrNull(evidence.afterRecordCount)
+  return before !== null && after !== null && after === before
+}
+
+function validateArtifactRef(inputDir, checkId, ref, errors) {
+  if (typeof ref !== 'string' || !ref.trim()) {
+    errors.push(`${checkId}: artifact refs must be non-empty strings`)
+    return
+  }
+  if (path.isAbsolute(ref) || ref.includes('\0')) {
+    errors.push(`${checkId}: artifact must be a relative path`)
+    return
+  }
+  const normalized = path.normalize(ref)
+  if (normalized.startsWith('..') || normalized.includes(`${path.sep}..${path.sep}`)) {
+    errors.push(`${checkId}: artifact must stay inside the signoff kit`)
+    return
+  }
+  const artifactPath = path.join(inputDir, normalized)
+  if (!existsSync(artifactPath)) {
+    errors.push(`${checkId}: artifact does not exist: ${ref}`)
+    return
+  }
+  const stat = statSync(artifactPath)
+  if (!stat.isFile() || stat.size === 0) {
+    errors.push(`${checkId}: artifact must be a non-empty file: ${ref}`)
+    return
+  }
+  if (stat.size <= 2 * 1024 * 1024 && /\.(?:txt|md|json|log|csv)$/i.test(ref)) {
+    scanSecrets(readFileSync(artifactPath, 'utf8'), `${checkId}: artifact ${ref}`, errors)
+  }
+}
+
+function scanSecrets(value, label, errors) {
+  if (typeof value !== 'string' || value.length === 0) return
+  for (const pattern of SECRET_PATTERNS) {
+    if (pattern.regex.test(value)) {
+      errors.push(`${label} contains secret-like value: ${pattern.name}`)
+    }
+  }
+}
+
+function scanObjectStrings(value, label, errors) {
+  if (typeof value === 'string') {
+    scanSecrets(value, label, errors)
+    return
+  }
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => scanObjectStrings(item, `${label}[${index}]`, errors))
+    return
+  }
+  if (isObject(value)) {
+    for (const [key, nested] of Object.entries(value)) {
+      scanObjectStrings(nested, `${label}.${key}`, errors)
+    }
+  }
+}
+
+function validatePassCheck(inputDir, check, entry, errors) {
+  const evidence = isObject(entry.evidence) ? entry.evidence : {}
+  const summary = typeof evidence.summary === 'string' ? evidence.summary.trim() : ''
+  const notes = typeof evidence.notes === 'string' ? evidence.notes.trim() : ''
+  const source = typeof evidence.source === 'string' ? evidence.source.trim() : ''
+  const artifacts = Array.isArray(evidence.artifacts) ? evidence.artifacts : []
+
+  if (!source || !VALID_SOURCES.has(source)) {
+    errors.push(`${check.id}: pass evidence requires source ${Array.from(VALID_SOURCES).join(', ')}`)
+  }
+  if (!summary && !notes) {
+    errors.push(`${check.id}: pass evidence requires summary or notes`)
+  }
+  for (const artifact of artifacts) {
+    validateArtifactRef(inputDir, check.id, artifact, errors)
+  }
+
+  if (check.kind === 'allow-submit' && !hasPositiveInsert(evidence)) {
+    errors.push(`${check.id}: allowed submit requires a positive recordInsertDelta or increasing before/after record counts`)
+  }
+  if (check.kind === 'deny-submit') {
+    if (evidence.submitBlocked !== true) {
+      errors.push(`${check.id}: denied submit requires submitBlocked=true`)
+    }
+    if (!hasZeroInsert(evidence)) {
+      errors.push(`${check.id}: denied submit requires recordInsertDelta=0 or equal before/after record counts`)
+    }
+    if (typeof evidence.blockedReason !== 'string' || !evidence.blockedReason.trim()) {
+      errors.push(`${check.id}: denied submit requires blockedReason`)
+    }
+  }
+  if (check.kind === 'render') {
+    if (evidence.formRendered !== true) {
+      errors.push(`${check.id}: render check requires formRendered=true`)
+    }
+    if (evidence.passwordChangeRequiredShown !== false) {
+      errors.push(`${check.id}: render check requires passwordChangeRequiredShown=false`)
+    }
+  }
+}
+
+function validateEvidence(inputFile, evidence, strict) {
+  const errors = []
+  const warnings = []
+  const inputDir = path.dirname(inputFile)
+  const entries = Array.isArray(evidence.checks) ? evidence.checks : []
+  const entryById = new Map(entries.map((entry) => [entry?.id, entry]))
+
+  scanObjectStrings(evidence, 'evidence', errors)
+
+  for (const check of CHECKS) {
+    const entry = entryById.get(check.id)
+    if (!entry) {
+      errors.push(`missing check: ${check.id}`)
+      continue
+    }
+    if (!VALID_STATUSES.has(entry.status)) {
+      errors.push(`${check.id}: invalid status ${JSON.stringify(entry.status)}`)
+      continue
+    }
+    if (entry.status === 'fail') {
+      warnings.push(`${check.id}: marked fail`)
+    }
+    if (strict && entry.status !== 'pass') {
+      errors.push(`${check.id}: strict mode requires pass, got ${entry.status}`)
+    }
+    if (entry.status === 'pass') {
+      validatePassCheck(inputDir, check, entry, errors)
+    }
+  }
+
+  for (const entry of entries) {
+    if (!CHECK_BY_ID.has(entry?.id)) {
+      warnings.push(`unknown check ignored: ${entry?.id ?? '<missing id>'}`)
+    }
+  }
+
+  return { errors, warnings }
+}
+
+function redactString(value) {
+  let redacted = value
+  for (const pattern of SECRET_PATTERNS) {
+    redacted = redacted.replace(pattern.regex, `<redacted:${pattern.name}>`)
+  }
+  return redacted
+}
+
+function redactValue(value) {
+  if (typeof value === 'string') return redactString(value)
+  if (Array.isArray(value)) return value.map(redactValue)
+  if (isObject(value)) {
+    return Object.fromEntries(Object.entries(value).map(([key, nested]) => [key, redactValue(nested)]))
+  }
+  return value
+}
+
+function summarize(evidence, validation) {
+  const entries = Array.isArray(evidence.checks) ? evidence.checks : []
+  const entryById = new Map(entries.map((entry) => [entry?.id, entry]))
+  const rows = CHECKS.map((check) => {
+    const status = entryById.get(check.id)?.status ?? 'missing'
+    return `| \`${check.id}\` | ${check.label} | ${status} | ${check.scenario} |`
+  }).join('\n')
+  const counts = CHECKS.reduce((acc, check) => {
+    const status = entryById.get(check.id)?.status ?? 'missing'
+    acc[status] = (acc[status] ?? 0) + 1
+    return acc
+  }, {})
+
+  return `# DingTalk Public Form Mobile Signoff Summary
+
+- Run ID: \`${evidence.runId || 'unknown'}\`
+- Environment: \`${evidence.environment || 'not recorded'}\`
+- Commit: \`${evidence.commit || 'not recorded'}\`
+- Strict-ready: \`${validation.errors.length === 0 ? 'yes' : 'no'}\`
+- Pass: ${counts.pass ?? 0}
+- Fail: ${counts.fail ?? 0}
+- Pending: ${counts.pending ?? 0}
+- Skipped: ${counts.skipped ?? 0}
+- Missing: ${counts.missing ?? 0}
+
+| Check ID | Expected result | Status | Scenario |
+| --- | --- | --- | --- |
+${rows}
+
+## Errors
+
+${validation.errors.length ? validation.errors.map((error) => `- ${error}`).join('\n') : '- None'}
+
+## Warnings
+
+${validation.warnings.length ? validation.warnings.map((warning) => `- ${warning}`).join('\n') : '- None'}
+`
+}
+
+function compileEvidence(opts) {
+  const evidence = readJson(opts.input)
+  const validation = validateEvidence(opts.input, evidence, opts.strict)
+  const outputDir = opts.outputDir || path.join(process.cwd(), DEFAULT_OUTPUT_ROOT, evidence.runId || makeRunId())
+  mkdirSync(outputDir, { recursive: true })
+
+  const summary = {
+    tool: 'dingtalk-public-form-mobile-signoff',
+    runId: evidence.runId || '',
+    generatedAt: nowIso(),
+    strict: opts.strict,
+    status: validation.errors.length === 0 ? 'pass' : 'fail',
+    errors: validation.errors,
+    warnings: validation.warnings,
+    requiredChecks: CHECKS.map((check) => ({
+      id: check.id,
+      status: evidence.checks?.find((entry) => entry.id === check.id)?.status ?? 'missing',
+      kind: check.kind,
+    })),
+  }
+
+  writeJson(path.join(outputDir, 'summary.json'), summary)
+  writeFileSync(path.join(outputDir, 'summary.md'), summarize(evidence, validation), 'utf8')
+  writeJson(path.join(outputDir, 'mobile-signoff.redacted.json'), redactValue(evidence))
+
+  if (validation.errors.length > 0) {
+    console.error(`[dingtalk-public-form-mobile-signoff] validation failed: ${validation.errors.length} error(s)`)
+    for (const error of validation.errors) {
+      console.error(`- ${error}`)
+    }
+    process.exitCode = 1
+    return
+  }
+  console.log(`[dingtalk-public-form-mobile-signoff] wrote summary: ${path.join(outputDir, 'summary.md')}`)
+}
+
+function main() {
+  try {
+    const opts = parseArgs(process.argv.slice(2))
+    if (opts.initKit) {
+      initKit(opts.initKit)
+      return
+    }
+    compileEvidence(opts)
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exitCode = 1
+  }
+}
+
+main()

--- a/scripts/ops/dingtalk-public-form-mobile-signoff.test.mjs
+++ b/scripts/ops/dingtalk-public-form-mobile-signoff.test.mjs
@@ -1,0 +1,165 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const scriptPath = path.join(repoRoot, 'scripts', 'ops', 'dingtalk-public-form-mobile-signoff.mjs')
+const allowSubmitChecks = new Set([
+  'public-anonymous-submit',
+  'dingtalk-bound-submit',
+  'selected-bound-submit',
+  'granted-bound-with-grant-submit',
+])
+const denySubmitChecks = new Set([
+  'dingtalk-unbound-rejected',
+  'selected-unbound-rejected',
+  'selected-unlisted-bound-rejected',
+  'granted-bound-without-grant-rejected',
+])
+const renderChecks = new Set([
+  'password-change-bypass-observed',
+])
+const requiredCheckIds = [
+  ...allowSubmitChecks,
+  ...denySubmitChecks,
+  ...renderChecks,
+]
+
+function makeTmpDir() {
+  return mkdtempSync(path.join(tmpdir(), 'dingtalk-public-form-mobile-signoff-'))
+}
+
+function runScript(args) {
+  return spawnSync(process.execPath, [scriptPath, ...args], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  })
+}
+
+function makePassingEvidence() {
+  return {
+    tool: 'dingtalk-public-form-mobile-signoff',
+    runId: 'mobile-signoff-test',
+    environment: '142',
+    commit: 'abcdef1',
+    checks: requiredCheckIds.map((id) => {
+      if (allowSubmitChecks.has(id)) {
+        return {
+          id,
+          status: 'pass',
+          evidence: {
+            source: 'server-observation',
+            operator: 'qa',
+            performedAt: '2026-04-29T00:00:00.000Z',
+            summary: `${id} inserted exactly one record.`,
+            recordInsertDelta: 1,
+          },
+        }
+      }
+      if (denySubmitChecks.has(id)) {
+        return {
+          id,
+          status: 'pass',
+          evidence: {
+            source: 'manual-client',
+            operator: 'qa',
+            performedAt: '2026-04-29T00:00:00.000Z',
+            summary: `${id} was blocked before insert.`,
+            submitBlocked: true,
+            recordInsertDelta: 0,
+            blockedReason: 'Visible form error matched the expected guard.',
+          },
+        }
+      }
+      return {
+        id,
+        status: 'pass',
+        evidence: {
+          source: 'manual-client',
+          operator: 'qa',
+          performedAt: '2026-04-29T00:00:00.000Z',
+          summary: 'The form rendered and did not show the password-change page.',
+          formRendered: true,
+          passwordChangeRequiredShown: false,
+        },
+      }
+    }),
+  }
+}
+
+function writeEvidence(tmpDir, evidence = makePassingEvidence()) {
+  const input = path.join(tmpDir, 'mobile-signoff.json')
+  writeFileSync(input, `${JSON.stringify(evidence, null, 2)}\n`, 'utf8')
+  return input
+}
+
+test('dingtalk-public-form-mobile-signoff initializes an editable kit', () => {
+  const tmpDir = makeTmpDir()
+  try {
+    const kitDir = path.join(tmpDir, 'kit')
+    const result = runScript(['--init-kit', kitDir])
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.ok(existsSync(path.join(kitDir, 'mobile-signoff.json')))
+    assert.ok(existsSync(path.join(kitDir, 'mobile-signoff-checklist.md')))
+    assert.ok(existsSync(path.join(kitDir, 'artifacts', 'public-anonymous-submit')))
+    const template = JSON.parse(readFileSync(path.join(kitDir, 'mobile-signoff.json'), 'utf8'))
+    assert.equal(template.tool, 'dingtalk-public-form-mobile-signoff')
+    assert.equal(template.checks.length, requiredCheckIds.length)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-public-form-mobile-signoff accepts screenshot-free strict evidence', () => {
+  const tmpDir = makeTmpDir()
+  try {
+    const input = writeEvidence(tmpDir)
+    const outputDir = path.join(tmpDir, 'compiled')
+    const result = runScript(['--input', input, '--output-dir', outputDir, '--strict'])
+
+    assert.equal(result.status, 0, result.stderr)
+    const summary = JSON.parse(readFileSync(path.join(outputDir, 'summary.json'), 'utf8'))
+    assert.equal(summary.status, 'pass')
+    assert.equal(summary.requiredChecks.length, requiredCheckIds.length)
+    assert.ok(readFileSync(path.join(outputDir, 'summary.md'), 'utf8').includes('Strict-ready: `yes`'))
+    assert.ok(existsSync(path.join(outputDir, 'mobile-signoff.redacted.json')))
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-public-form-mobile-signoff rejects denied checks without zero-insert proof', () => {
+  const tmpDir = makeTmpDir()
+  try {
+    const evidence = makePassingEvidence()
+    const denied = evidence.checks.find((check) => check.id === 'selected-unlisted-bound-rejected')
+    delete denied.evidence.recordInsertDelta
+    const input = writeEvidence(tmpDir, evidence)
+    const result = runScript(['--input', input, '--output-dir', path.join(tmpDir, 'compiled'), '--strict'])
+
+    assert.notEqual(result.status, 0)
+    assert.match(result.stderr, /selected-unlisted-bound-rejected: denied submit requires recordInsertDelta=0/)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-public-form-mobile-signoff rejects secret-like evidence text', () => {
+  const tmpDir = makeTmpDir()
+  try {
+    const evidence = makePassingEvidence()
+    evidence.checks[0].evidence.summary = `Opened https://example.test/form?public${'Token'}=secret-public-token-12345`
+    const input = writeEvidence(tmpDir, evidence)
+    const result = runScript(['--input', input, '--output-dir', path.join(tmpDir, 'compiled'), '--strict'])
+
+    assert.notEqual(result.status, 0)
+    assert.match(result.stderr, /public_form_token/)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary
- add a redaction-safe DingTalk public form mobile signoff kit generator/compiler
- allow screenshot-free strict evidence using record insert deltas, blocked reasons, and password-change bypass observations
- document the design and verification flow for the remaining real DingTalk mobile acceptance step

## Verification
- node --test scripts/ops/dingtalk-public-form-mobile-signoff.test.mjs
- node scripts/ops/dingtalk-public-form-mobile-signoff.mjs --init-kit /tmp/dingtalk-mobile-signoff-kit-verify
- git diff --cached --check
- staged diff secret-pattern scan