### PR TITLE
chore(integration): add manual K3 WISE smoke workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -580,25 +580,9 @@ jobs:
           echo "### K3 WISE Postdeploy Smoke" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           k3_smoke_json="output/deploy/k3wise-postdeploy-smoke/integration-k3wise-postdeploy-smoke.json"
-          if [[ -f "$k3_smoke_json" ]]; then
-            node - "$k3_smoke_json" >> "$GITHUB_STEP_SUMMARY" <<'NODE'
-          const fs = require('fs')
-          const evidence = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'))
-          const summary = evidence.summary || {}
-          const status = evidence.ok ? 'PASS' : 'FAIL'
-          console.log(`- Status: **${status}**`)
-          console.log(`- Base URL: \`${evidence.baseUrl || 'unknown'}\``)
-          console.log(`- Authenticated checks: \`${evidence.authenticated ? 'yes' : 'no'}\``)
-          console.log(`- Summary: \`${summary.pass || 0} pass / ${summary.skipped || 0} skipped / ${summary.fail || 0} fail\``)
-          console.log('- Checks:')
-          for (const check of evidence.checks || []) {
-            console.log(`  - \`${check.id}\`: \`${check.status}\``)
-          }
-          NODE
-          else
-            echo "- Status: **NOT RUN**" >> "$GITHUB_STEP_SUMMARY"
-            echo "- Reason: remote deploy did not complete successfully, or the K3 WISE smoke step did not produce evidence." >> "$GITHUB_STEP_SUMMARY"
-          fi
+          node scripts/ops/integration-k3wise-postdeploy-summary.mjs \
+            --input "$k3_smoke_json" \
+            --missing-ok >> "$GITHUB_STEP_SUMMARY"
 
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "### Artifacts" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/integration-k3wise-postdeploy-smoke.yml
+++ b/.github/workflows/integration-k3wise-postdeploy-smoke.yml
@@ -1,0 +1,98 @@
+name: K3 WISE Postdeploy Smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: 'MetaSheet base URL to smoke'
+        required: false
+        default: 'http://142.171.239.56:8081'
+      require_auth:
+        description: 'Require authenticated integration contract checks'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+      timeout_ms:
+        description: 'Per-request timeout in milliseconds'
+        required: false
+        default: '10000'
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run K3 WISE postdeploy smoke
+        id: smoke
+        continue-on-error: true
+        env:
+          METASHEET_BASE_URL: ${{ github.event.inputs.base_url || 'http://142.171.239.56:8081' }}
+          METASHEET_AUTH_TOKEN: ${{ secrets.METASHEET_K3WISE_SMOKE_TOKEN }}
+          REQUIRE_AUTH: ${{ github.event.inputs.require_auth || 'false' }}
+          TIMEOUT_MS: ${{ github.event.inputs.timeout_ms || '10000' }}
+        run: |
+          set -euo pipefail
+          smoke_out_dir="output/integration-k3wise-postdeploy-smoke/manual"
+          rm -rf "$smoke_out_dir"
+          mkdir -p "$smoke_out_dir"
+
+          args=(
+            --base-url "$METASHEET_BASE_URL"
+            --out-dir "$smoke_out_dir"
+            --timeout-ms "$TIMEOUT_MS"
+          )
+          if [[ "$REQUIRE_AUTH" == "true" ]]; then
+            args+=(--require-auth)
+          fi
+
+          set +e
+          node scripts/ops/integration-k3wise-postdeploy-smoke.mjs "${args[@]}" \
+            2> >(tee "$smoke_out_dir/stderr.log" >&2) \
+            | tee "$smoke_out_dir/cli-summary.json"
+          rc=${PIPESTATUS[0]}
+          set -e
+          echo "smoke_rc=$rc" >> "$GITHUB_OUTPUT"
+          exit "$rc"
+
+      - name: Write K3 WISE smoke summary
+        if: always()
+        run: |
+          set -euo pipefail
+          echo "## K3 WISE Postdeploy Smoke" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          node scripts/ops/integration-k3wise-postdeploy-summary.mjs \
+            --input output/integration-k3wise-postdeploy-smoke/manual/integration-k3wise-postdeploy-smoke.json \
+            --missing-ok >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Artifacts" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Evidence artifact: \`integration-k3wise-postdeploy-smoke-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}\`" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload K3 WISE smoke artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-k3wise-postdeploy-smoke-${{ github.run_id }}-${{ github.run_attempt }}
+          retention-days: 14
+          path: |
+            output/integration-k3wise-postdeploy-smoke/manual/**
+
+      - name: Fail when K3 WISE smoke failed
+        if: always()
+        run: |
+          rc="${{ steps.smoke.outputs.smoke_rc }}"
+          if [[ -z "$rc" ]]; then
+            echo "smoke_rc missing; failing workflow." >&2
+            exit 1
+          fi
+          if [[ "$rc" != "0" ]]; then
+            echo "K3 WISE postdeploy smoke failed: rc=$rc" >&2
+            exit 1
+          fi

--- a/docs/development/integration-k3wise-manual-smoke-workflow-design-20260429.md
+++ b/docs/development/integration-k3wise-manual-smoke-workflow-design-20260429.md
@@ -1,0 +1,59 @@
+# K3 WISE Manual Smoke Workflow Design
+
+## Context
+
+The deploy workflow now runs K3 WISE postdeploy smoke automatically after a successful remote deploy. Operators still need a way to rerun the same smoke without pushing a new commit or redeploying the stack, especially while waiting for the K3 WISE customer GATE packet and when checking whether a configured auth token unlocks the route/staging contract checks.
+
+## Design
+
+This change adds two pieces:
+
+- `scripts/ops/integration-k3wise-postdeploy-summary.mjs`
+- `.github/workflows/integration-k3wise-postdeploy-smoke.yml`
+
+The summary script turns the existing smoke evidence JSON into a compact GitHub Step Summary body. The deploy workflow now uses this script instead of inline JavaScript, so the rendering logic is tested and shared.
+
+The new manual workflow runs the existing read-only smoke script through `workflow_dispatch`:
+
+- `base_url`: target MetaSheet URL, default `http://142.171.239.56:8081`
+- `require_auth`: when `true`, missing or invalid auth fails the smoke
+- `timeout_ms`: per-request timeout
+
+The workflow reads optional secret `METASHEET_K3WISE_SMOKE_TOKEN`. If present, the smoke script automatically runs authenticated checks. If absent and `require_auth=false`, the public checks run and auth-only checks are reported as skipped.
+
+## Failure Model
+
+The manual workflow keeps summary/artifact collection reliable:
+
+- The smoke step records `smoke_rc` and is allowed to continue.
+- The summary step runs with `if: always()`.
+- The artifact upload step runs with `if: always()`.
+- The final step fails the workflow when `smoke_rc != 0`.
+
+This preserves evidence even when the smoke fails.
+
+## Artifact Model
+
+Manual workflow artifacts are uploaded as:
+
+```text
+integration-k3wise-postdeploy-smoke-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}
+```
+
+Contents:
+
+- `integration-k3wise-postdeploy-smoke.json`
+- `integration-k3wise-postdeploy-smoke.md`
+- `cli-summary.json`
+- `stderr.log`
+
+The workflow is read-only and does not call customer PLM, K3 WISE, SQL Server, staging install, pipeline run, or ERP write APIs.
+
+## Files
+
+- `.github/workflows/docker-build.yml`
+- `.github/workflows/integration-k3wise-postdeploy-smoke.yml`
+- `scripts/ops/integration-k3wise-postdeploy-summary.mjs`
+- `scripts/ops/integration-k3wise-postdeploy-summary.test.mjs`
+- `docs/development/integration-k3wise-manual-smoke-workflow-design-20260429.md`
+- `docs/development/integration-k3wise-manual-smoke-workflow-verification-20260429.md`

--- a/docs/development/integration-k3wise-manual-smoke-workflow-verification-20260429.md
+++ b/docs/development/integration-k3wise-manual-smoke-workflow-verification-20260429.md
@@ -1,0 +1,102 @@
+# K3 WISE Manual Smoke Workflow Verification
+
+## Environment
+
+Worktree:
+
+```bash
+/tmp/ms2-k3wise-postdeploy-manual-20260429
+```
+
+Base:
+
+```bash
+origin/main a9b3cf6ae
+```
+
+## Commands
+
+```bash
+node --test scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
+
+node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
+
+ruby -e 'require "yaml"; YAML.load_file(".github/workflows/docker-build.yml"); YAML.load_file(".github/workflows/integration-k3wise-postdeploy-smoke.yml"); puts "workflow yaml ok"'
+
+node --check scripts/ops/integration-k3wise-postdeploy-summary.mjs
+node --check scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
+
+rm -rf output/integration-k3wise-postdeploy-smoke/manual-local
+node scripts/ops/integration-k3wise-postdeploy-smoke.mjs \
+  --base-url http://142.171.239.56:8081 \
+  --out-dir output/integration-k3wise-postdeploy-smoke/manual-local
+
+node scripts/ops/integration-k3wise-postdeploy-summary.mjs \
+  --input output/integration-k3wise-postdeploy-smoke/manual-local/integration-k3wise-postdeploy-smoke.json
+
+git diff --check
+```
+
+## Results
+
+Summary renderer tests:
+
+- `scripts/ops/integration-k3wise-postdeploy-summary.test.mjs`: 5/5 passed.
+- Covered pass evidence rendering.
+- Covered fail evidence rendering without failing the renderer.
+- Covered `--missing-ok` for always-run workflow summaries.
+- Covered missing evidence default failure.
+- Covered `--help`.
+
+Existing smoke tests:
+
+- `scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs`: 4/4 passed.
+- No regression in public, protected-route, authenticated, or `--require-auth` behavior.
+
+Workflow syntax:
+
+- `docker-build.yml`: parsed successfully.
+- `integration-k3wise-postdeploy-smoke.yml`: parsed successfully.
+- `actionlint` was not installed in this environment.
+
+Script syntax:
+
+- `node --check scripts/ops/integration-k3wise-postdeploy-summary.mjs`: passed.
+- `node --check scripts/ops/integration-k3wise-postdeploy-summary.test.mjs`: passed.
+
+Public 142 smoke:
+
+```json
+{
+  "ok": true,
+  "baseUrl": "http://142.171.239.56:8081",
+  "authenticated": false,
+  "summary": {
+    "pass": 2,
+    "skipped": 2,
+    "fail": 0
+  }
+}
+```
+
+Summary renderer output:
+
+```markdown
+- Status: **PASS**
+- Base URL: `http://142.171.239.56:8081`
+- Authenticated checks: `no`
+- Summary: `2 pass / 2 skipped / 0 fail`
+- Checks:
+  - `api-health`: `pass`
+  - `integration-plugin-health`: `skipped`
+  - `k3-wise-frontend-route`: `pass`
+  - `authenticated-integration-contract`: `skipped`
+```
+
+Whitespace:
+
+- `git diff --check`: passed.
+
+## Notes
+
+The manual workflow can only be executed from GitHub Actions after merge because workflow files must exist on the default branch before `workflow_dispatch` is available. Local verification covered the shared renderer, existing smoke behavior, workflow YAML syntax, and real public 142 output.

--- a/scripts/ops/integration-k3wise-postdeploy-summary.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-summary.mjs
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+class K3WisePostdeploySummaryError extends Error {
+  constructor(message, details = {}) {
+    super(message)
+    this.name = 'K3WisePostdeploySummaryError'
+    this.details = details
+  }
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/ops/integration-k3wise-postdeploy-summary.mjs --input <path> [options]
+
+Renders a compact GitHub Step Summary section body from a K3 WISE postdeploy
+smoke evidence JSON file.
+
+Options:
+  --input <path>     Evidence JSON path
+  --missing-ok       Render NOT RUN and exit 0 when the evidence file is missing
+  --help             Show this help
+`)
+}
+
+function readRequiredValue(argv, index, flag) {
+  const next = argv[index + 1]
+  if (!next || next.startsWith('--')) {
+    throw new K3WisePostdeploySummaryError(`${flag} requires a value`, { flag })
+  }
+  return next
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+  const opts = {
+    input: '',
+    missingOk: false,
+    help: false,
+  }
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    switch (arg) {
+      case '--input':
+        opts.input = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--missing-ok':
+        opts.missingOk = true
+        break
+      case '--help':
+      case '-h':
+        opts.help = true
+        break
+      default:
+        throw new K3WisePostdeploySummaryError(`unknown option: ${arg}`, { arg })
+    }
+  }
+
+  if (!opts.help && !opts.input) {
+    throw new K3WisePostdeploySummaryError('--input is required')
+  }
+
+  return opts
+}
+
+function renderMissingSummary(inputPath) {
+  return [
+    '- Status: **NOT RUN**',
+    `- Reason: evidence file missing at \`${inputPath || 'unknown'}\``,
+    '',
+  ].join('\n')
+}
+
+function renderEvidenceSummary(evidence) {
+  const summary = evidence && typeof evidence === 'object' ? evidence.summary || {} : {}
+  const checks = Array.isArray(evidence?.checks) ? evidence.checks : []
+  const status = evidence?.ok ? 'PASS' : 'FAIL'
+  const lines = [
+    `- Status: **${status}**`,
+    `- Base URL: \`${evidence?.baseUrl || 'unknown'}\``,
+    `- Authenticated checks: \`${evidence?.authenticated ? 'yes' : 'no'}\``,
+    `- Summary: \`${Number(summary.pass || 0)} pass / ${Number(summary.skipped || 0)} skipped / ${Number(summary.fail || 0)} fail\``,
+    '- Checks:',
+  ]
+  for (const check of checks) {
+    lines.push(`  - \`${check?.id || 'unknown'}\`: \`${check?.status || 'unknown'}\``)
+  }
+  if (checks.length === 0) {
+    lines.push('  - `none`: `missing`')
+  }
+  lines.push('')
+  return lines.join('\n')
+}
+
+async function readEvidence(inputPath) {
+  const raw = await readFile(inputPath, 'utf8')
+  try {
+    return JSON.parse(raw)
+  } catch (error) {
+    throw new K3WisePostdeploySummaryError(`invalid evidence JSON: ${inputPath}`, {
+      cause: error && error.message ? error.message : String(error),
+    })
+  }
+}
+
+async function runCli(argv = process.argv.slice(2)) {
+  const opts = parseArgs(argv)
+  if (opts.help) {
+    printHelp()
+    return 0
+  }
+
+  const inputPath = path.resolve(opts.input)
+  try {
+    const evidence = await readEvidence(inputPath)
+    console.log(renderEvidenceSummary(evidence))
+    return 0
+  } catch (error) {
+    if (opts.missingOk && error && error.code === 'ENOENT') {
+      console.log(renderMissingSummary(opts.input))
+      return 0
+    }
+    throw error
+  }
+}
+
+const entryPath = process.argv[1] ? pathToFileURL(path.resolve(process.argv[1])).href : null
+if (entryPath && import.meta.url === entryPath) {
+  runCli().then((code) => {
+    process.exit(code)
+  }).catch((error) => {
+    const body = error instanceof K3WisePostdeploySummaryError
+      ? { ok: false, code: error.name, message: error.message, details: error.details }
+      : { ok: false, code: error && error.name ? error.name : 'Error', message: error && error.message ? error.message : String(error) }
+    console.error(JSON.stringify(body, null, 2))
+    process.exit(1)
+  })
+}
+
+export {
+  K3WisePostdeploySummaryError,
+  parseArgs,
+  renderEvidenceSummary,
+  renderMissingSummary,
+  runCli,
+}

--- a/scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
@@ -1,0 +1,131 @@
+import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const scriptPath = path.join(repoRoot, 'scripts', 'ops', 'integration-k3wise-postdeploy-summary.mjs')
+
+function makeTmpDir() {
+  return mkdtempSync(path.join(tmpdir(), 'integration-k3wise-postdeploy-summary-'))
+}
+
+function runScript(args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [scriptPath, ...args], { stdio: ['ignore', 'pipe', 'pipe'] })
+    let stdout = ''
+    let stderr = ''
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL')
+      reject(new Error(`script timed out\nstdout=${stdout}\nstderr=${stderr}`))
+    }, 10_000)
+
+    child.stdout.setEncoding('utf8')
+    child.stderr.setEncoding('utf8')
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk
+    })
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk
+    })
+    child.on('error', (error) => {
+      clearTimeout(timer)
+      reject(error)
+    })
+    child.on('close', (status) => {
+      clearTimeout(timer)
+      resolve({ status, stdout, stderr })
+    })
+  })
+}
+
+test('renders compact pass summary from evidence JSON', async () => {
+  const outDir = makeTmpDir()
+  const evidencePath = path.join(outDir, 'evidence.json')
+  try {
+    writeFileSync(evidencePath, `${JSON.stringify({
+      ok: true,
+      baseUrl: 'http://127.0.0.1:8081',
+      authenticated: false,
+      summary: { pass: 2, skipped: 1, fail: 0 },
+      checks: [
+        { id: 'api-health', status: 'pass' },
+        { id: 'authenticated-integration-contract', status: 'skipped' },
+      ],
+    })}\n`)
+
+    const result = await runScript(['--input', evidencePath])
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stdout, /Status: \*\*PASS\*\*/)
+    assert.match(result.stdout, /Summary: `2 pass \/ 1 skipped \/ 0 fail`/)
+    assert.match(result.stdout, /`api-health`: `pass`/)
+    assert.match(result.stdout, /`authenticated-integration-contract`: `skipped`/)
+  } finally {
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('renders fail summary without failing the summary renderer', async () => {
+  const outDir = makeTmpDir()
+  const evidencePath = path.join(outDir, 'evidence.json')
+  try {
+    writeFileSync(evidencePath, `${JSON.stringify({
+      ok: false,
+      baseUrl: 'http://127.0.0.1:8081',
+      authenticated: true,
+      summary: { pass: 1, skipped: 0, fail: 1 },
+      checks: [
+        { id: 'api-health', status: 'pass' },
+        { id: 'integration-route-contract', status: 'fail' },
+      ],
+    })}\n`)
+
+    const result = await runScript(['--input', evidencePath])
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stdout, /Status: \*\*FAIL\*\*/)
+    assert.match(result.stdout, /Authenticated checks: `yes`/)
+    assert.match(result.stdout, /`integration-route-contract`: `fail`/)
+  } finally {
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('missing evidence can be rendered as not run for always-run workflow summaries', async () => {
+  const outDir = makeTmpDir()
+  const evidencePath = path.join(outDir, 'missing.json')
+  try {
+    const result = await runScript(['--input', evidencePath, '--missing-ok'])
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stdout, /Status: \*\*NOT RUN\*\*/)
+    assert.match(result.stdout, /evidence file missing/)
+  } finally {
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('missing evidence fails by default', async () => {
+  const outDir = makeTmpDir()
+  const evidencePath = path.join(outDir, 'missing.json')
+  try {
+    const result = await runScript(['--input', evidencePath])
+
+    assert.equal(result.status, 1)
+    assert.match(result.stderr, /ENOENT/)
+    assert.equal(result.stdout, '')
+  } finally {
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('help prints usage', async () => {
+  const result = await runScript(['--help'])
+
+  assert.equal(result.status, 0, result.stderr)
+  assert.match(result.stdout, /Usage: node scripts\/ops\/integration-k3wise-postdeploy-summary\.mjs/)
+})


### PR DESCRIPTION
## Summary

Adds a manual `workflow_dispatch` K3 WISE postdeploy smoke workflow and extracts the smoke evidence Step Summary renderer into a tested script.

Changes:

- new `.github/workflows/integration-k3wise-postdeploy-smoke.yml`
- new `scripts/ops/integration-k3wise-postdeploy-summary.mjs`
- deploy workflow now uses the shared summary renderer instead of inline heredoc JS
- new design and verification docs

Manual workflow inputs:

- `base_url`, default `http://142.171.239.56:8081`
- `require_auth`, default `false`
- `timeout_ms`, default `10000`

It uses optional secret `METASHEET_K3WISE_SMOKE_TOKEN`. If present, authenticated route/staging checks run. If absent and `require_auth=false`, public checks run and auth-only checks are skipped.

## Safety

- read-only smoke only
- no PLM/K3/SQL Server/customer calls
- no external-system, pipeline, staging install, pipeline run, or ERP write mutations
- evidence is uploaded even on smoke failure
- final workflow step fails if the smoke rc is non-zero

## Verification

```bash
node --test scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
ruby -e 'require "yaml"; YAML.load_file(".github/workflows/docker-build.yml"); YAML.load_file(".github/workflows/integration-k3wise-postdeploy-smoke.yml"); puts "workflow yaml ok"'
node --check scripts/ops/integration-k3wise-postdeploy-summary.mjs
node --check scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
node scripts/ops/integration-k3wise-postdeploy-smoke.mjs \
  --base-url http://142.171.239.56:8081 \
  --out-dir output/integration-k3wise-postdeploy-smoke/manual-local
node scripts/ops/integration-k3wise-postdeploy-summary.mjs \
  --input output/integration-k3wise-postdeploy-smoke/manual-local/integration-k3wise-postdeploy-smoke.json
git diff --check
git diff --cached --check
```

Results:

- summary renderer tests: 5/5 passed
- existing smoke tests: 4/4 passed
- workflow YAML parse: passed
- script syntax checks: passed
- public 142 smoke: `ok=true`, `2 pass / 2 skipped / 0 fail`
- summary renderer output: PASS with `api-health` and `k3-wise-frontend-route` passed, auth checks skipped without token
- whitespace checks: passed

Docs:

- `docs/development/integration-k3wise-manual-smoke-workflow-design-20260429.md`
- `docs/development/integration-k3wise-manual-smoke-workflow-verification-20260429.md`
