### PR TITLE
chore(dingtalk): add mobile signoff recorder

### DIFF
--- a/docs/development/dingtalk-public-form-mobile-signoff-recorder-design-20260429.md
+++ b/docs/development/dingtalk-public-form-mobile-signoff-recorder-design-20260429.md
@@ -1,0 +1,99 @@
+# DingTalk Public Form Mobile Signoff Recorder Design - 2026-04-29
+
+## Goal
+
+Reduce the remaining real DingTalk mobile signoff work from hand-editing a full
+JSON packet to running one command per verified scenario.
+
+The previous mobile signoff kit already provides `--init-kit` and strict
+compile validation. This slice adds a narrow `--record` mode so operators can
+capture each public-form access-matrix result immediately after testing it on a
+real DingTalk client.
+
+## Scope
+
+Changed script:
+
+- `scripts/ops/dingtalk-public-form-mobile-signoff.mjs`
+
+Changed tests:
+
+- `scripts/ops/dingtalk-public-form-mobile-signoff.test.mjs`
+
+Added docs:
+
+- `docs/development/dingtalk-public-form-mobile-signoff-recorder-design-20260429.md`
+- `docs/development/dingtalk-public-form-mobile-signoff-recorder-verification-20260429.md`
+
+## CLI Contract
+
+Record one check:
+
+```bash
+node scripts/ops/dingtalk-public-form-mobile-signoff.mjs \
+  --record mobile-signoff.json \
+  --check-id public-anonymous-submit \
+  --status pass \
+  --source server-observation \
+  --operator qa \
+  --summary "Anonymous public form inserted one record." \
+  --record-insert-delta 1
+```
+
+Supported record fields:
+
+- `--check-id`: one of the known mobile signoff check IDs.
+- `--status`: `pass`, `fail`, `skipped`, or `pending`.
+- `--source`: `manual-client`, `server-observation`, or `operator-note`.
+- `--operator`, `--performed-at`, `--summary`, `--notes`.
+- `--artifact`: repeatable relative artifact path inside the kit.
+- `--before-record-count`, `--after-record-count`, `--record-insert-delta`.
+- `--submit-blocked`, `--blocked-reason`.
+- `--form-rendered`, `--password-change-required-shown`, `--no-password-change-required-shown`.
+- `--dry-run`: validates and prints the updated check without writing.
+
+## Validation Rules
+
+Record mode reuses the existing strict evidence semantics for a check marked
+`pass`:
+
+- Allowed submit checks require a positive insert delta or increasing before /
+  after counts.
+- Denied submit checks require `submitBlocked=true`, zero insert proof, and a
+  blocked reason.
+- Render checks require `formRendered=true` and
+  `passwordChangeRequiredShown=false`.
+
+For `pass` and `fail`, `performedAt` is auto-filled when absent. Artifact paths
+must be relative to the signoff kit and must exist before a passing record is
+accepted.
+
+## Secret Handling
+
+The recorder scans the updated check before writing:
+
+- DingTalk robot webhook URLs are rejected.
+- DingTalk `SEC...` signing secrets are rejected.
+- `access_token` query parameters are rejected.
+- Bearer tokens and JWTs are rejected.
+- Public form tokens and DingTalk client secrets are rejected.
+
+`--dry-run` prints the redacted check only after validation succeeds.
+
+## Operator Flow
+
+1. Initialize the kit with `--init-kit`.
+2. Run each real DingTalk mobile scenario.
+3. Immediately run `--record` for that scenario.
+4. Compile with `--input ... --strict` after all required checks are recorded.
+
+This keeps the final evidence packet deterministic while still allowing
+screenshot-free validation through service-side insert counts and visible block
+reasons.
+
+## Non-goals
+
+- The recorder does not call DingTalk.
+- The recorder does not create forms, grants, users, or records.
+- The recorder does not persist raw screenshots, tokens, temporary passwords, or
+  webhook secrets.

--- a/docs/development/dingtalk-public-form-mobile-signoff-recorder-verification-20260429.md
+++ b/docs/development/dingtalk-public-form-mobile-signoff-recorder-verification-20260429.md
@@ -1,0 +1,82 @@
+# DingTalk Public Form Mobile Signoff Recorder Verification - 2026-04-29
+
+## Scope
+
+This document verifies the `--record` mode added to the DingTalk public-form
+mobile signoff tool.
+
+Changed files:
+
+- `scripts/ops/dingtalk-public-form-mobile-signoff.mjs`
+- `scripts/ops/dingtalk-public-form-mobile-signoff.test.mjs`
+- `docs/development/dingtalk-public-form-mobile-signoff-recorder-design-20260429.md`
+- `docs/development/dingtalk-public-form-mobile-signoff-recorder-verification-20260429.md`
+
+## Commands
+
+```bash
+node --test scripts/ops/dingtalk-public-form-mobile-signoff.test.mjs
+
+KIT=$(mktemp -d -t dingtalk-mobile-signoff-recorder-kit)
+OUT=$(mktemp -d -t dingtalk-mobile-signoff-recorder-compiled)
+node scripts/ops/dingtalk-public-form-mobile-signoff.mjs --init-kit "$KIT"
+node scripts/ops/dingtalk-public-form-mobile-signoff.mjs \
+  --record "$KIT/mobile-signoff.json" \
+  --check-id public-anonymous-submit \
+  --status pass \
+  --source server-observation \
+  --operator qa \
+  --summary "Anonymous public form inserted one record." \
+  --record-insert-delta 1
+node scripts/ops/dingtalk-public-form-mobile-signoff.mjs \
+  --record "$KIT/mobile-signoff.json" \
+  --check-id selected-unlisted-bound-rejected \
+  --status pass \
+  --source manual-client \
+  --operator qa \
+  --summary "The unlisted bound user was blocked before insert." \
+  --submit-blocked \
+  --record-insert-delta 0 \
+  --blocked-reason "Not in selected user or group allowlist."
+node scripts/ops/dingtalk-public-form-mobile-signoff.mjs \
+  --input "$KIT/mobile-signoff.json" \
+  --output-dir "$OUT"
+node -e "const fs=require('fs');const s=JSON.parse(fs.readFileSync(process.argv[1],'utf8'));console.log(JSON.stringify({status:s.status, errors:s.errors.length, recorded:s.requiredChecks.filter(c=>c.status==='pass').length}))" "$OUT/summary.json"
+
+git diff --check
+git diff --cached -- scripts/ops/dingtalk-public-form-mobile-signoff.mjs scripts/ops/dingtalk-public-form-mobile-signoff.test.mjs docs/development/dingtalk-public-form-mobile-signoff-recorder-design-20260429.md docs/development/dingtalk-public-form-mobile-signoff-recorder-verification-20260429.md \
+  | rg -v "git diff --cached -- scripts/ops/dingtalk-public-form-mobile-signoff" \
+  | rg -v "rg -n" \
+  | rg -n "(access_token=[A-Za-z0-9]|SEC[0-9a-fA-F]{8,}|Authorization:|Bearer [A-Za-z0-9._-]{20,}|https://oapi\\.dingtalk\\.com/robot/send|JWT_SECRET|DINGTALK_APP_SECRET|publicToken=[A-Za-z0-9._~+/=-]{12,})" || true
+```
+
+## Results
+
+- Node test: passed, 8 tests.
+- Manual recorder flow: passed.
+- Partial non-strict compile after two recorded checks: `{"status":"pass","errors":0,"recorded":2}`.
+- `git diff --check`: passed.
+- Diff secret scan: no matches for DingTalk webhook/token/JWT/public-token patterns.
+
+## Regression Coverage
+
+The new Node tests cover:
+
+- Recording an allowed submit check with a positive insert delta.
+- Recording a denied submit check with `submitBlocked=true` and zero insert
+  proof.
+- Dry-running a render check without mutating `mobile-signoff.json`.
+- Rejecting secret-like record updates before write.
+
+Existing tests still cover:
+
+- Kit initialization.
+- Strict compile with screenshot-free structured evidence.
+- Rejection of denied-submit checks without zero-insert proof.
+- Rejection of secret-like evidence text during compile.
+
+## Remaining Manual Step
+
+A real DingTalk mobile client still has to execute each access-matrix scenario.
+This slice removes the need to hand-edit the JSON packet; it does not remove the
+need for the real client run.

--- a/scripts/ops/dingtalk-public-form-mobile-signoff.mjs
+++ b/scripts/ops/dingtalk-public-form-mobile-signoff.mjs
@@ -111,10 +111,30 @@ form access modes. It does not call DingTalk or staging.
 
 Options:
   --init-kit <dir>       Write mobile-signoff.json, checklist, and artifact folders
+  --record <file>        Update one check in an existing mobile-signoff.json
   --input <file>         Input mobile-signoff.json to compile
   --output-dir <dir>     Output dir, default ${DEFAULT_OUTPUT_ROOT}/<run-id>
   --strict               Exit non-zero unless every required check passes
   --help                 Show this help
+
+Record mode options:
+  --check-id <id>        Required with --record
+  --status <status>      Required with --record: pass, fail, skipped, pending
+  --source <source>      manual-client, server-observation, or operator-note
+  --operator <name>      Operator name or role, not a token or password
+  --performed-at <iso>   Defaults to now for pass/fail if not already present
+  --summary <text>       Short evidence summary
+  --notes <text>         Extra evidence notes
+  --artifact <path>      Relative artifact path, repeatable
+  --before-record-count <n>
+  --after-record-count <n>
+  --record-insert-delta <n>
+  --submit-blocked
+  --blocked-reason <text>
+  --form-rendered
+  --password-change-required-shown
+  --no-password-change-required-shown
+  --dry-run              Validate and print the updated check without writing
 
 Evidence can be screenshot-free. For allowed submits, record a positive
 recordInsertDelta or before/after record counts. For blocked submits, record
@@ -134,9 +154,26 @@ function readRequiredValue(argv, index, flag) {
 function parseArgs(argv) {
   const opts = {
     initKit: '',
+    record: '',
     input: '',
     outputDir: '',
     strict: false,
+    checkId: '',
+    status: '',
+    source: '',
+    operator: '',
+    performedAt: '',
+    summary: '',
+    notes: '',
+    artifacts: [],
+    beforeRecordCount: null,
+    afterRecordCount: null,
+    recordInsertDelta: null,
+    submitBlocked: null,
+    blockedReason: '',
+    formRendered: null,
+    passwordChangeRequiredShown: null,
+    dryRun: false,
   }
 
   for (let i = 0; i < argv.length; i += 1) {
@@ -144,6 +181,10 @@ function parseArgs(argv) {
     switch (arg) {
       case '--init-kit':
         opts.initKit = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
+        i += 1
+        break
+      case '--record':
+        opts.record = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
         i += 1
         break
       case '--input':
@@ -157,6 +198,69 @@ function parseArgs(argv) {
       case '--strict':
         opts.strict = true
         break
+      case '--check-id':
+        opts.checkId = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--status':
+        opts.status = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--source':
+        opts.source = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--operator':
+        opts.operator = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--performed-at':
+        opts.performedAt = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--summary':
+        opts.summary = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--notes':
+        opts.notes = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--artifact':
+        opts.artifacts.push(readRequiredValue(argv, i, arg))
+        i += 1
+        break
+      case '--before-record-count':
+        opts.beforeRecordCount = parseNonNegativeInteger(readRequiredValue(argv, i, arg), arg)
+        i += 1
+        break
+      case '--after-record-count':
+        opts.afterRecordCount = parseNonNegativeInteger(readRequiredValue(argv, i, arg), arg)
+        i += 1
+        break
+      case '--record-insert-delta':
+        opts.recordInsertDelta = parseNonNegativeInteger(readRequiredValue(argv, i, arg), arg)
+        i += 1
+        break
+      case '--submit-blocked':
+        opts.submitBlocked = true
+        break
+      case '--blocked-reason':
+        opts.blockedReason = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--form-rendered':
+        opts.formRendered = true
+        break
+      case '--password-change-required-shown':
+        opts.passwordChangeRequiredShown = true
+        break
+      case '--no-password-change-required-shown':
+        opts.passwordChangeRequiredShown = false
+        break
+      case '--dry-run':
+        opts.dryRun = true
+        break
       case '--help':
         printHelp()
         process.exit(0)
@@ -166,13 +270,39 @@ function parseArgs(argv) {
     }
   }
 
-  if (opts.initKit && opts.input) {
-    throw new Error('--init-kit and --input are mutually exclusive')
+  const modeCount = Number(Boolean(opts.initKit)) + Number(Boolean(opts.input)) + Number(Boolean(opts.record))
+  if (modeCount > 1) {
+    throw new Error('--init-kit, --record, and --input are mutually exclusive')
   }
-  if (!opts.initKit && !opts.input) {
-    throw new Error('one of --init-kit or --input is required')
+  if (modeCount === 0) {
+    throw new Error('one of --init-kit, --record, or --input is required')
+  }
+  if (opts.record) {
+    if (!opts.checkId) {
+      throw new Error('--record requires --check-id')
+    }
+    if (!CHECK_BY_ID.has(opts.checkId)) {
+      throw new Error(`unknown --check-id: ${opts.checkId}`)
+    }
+    if (!opts.status) {
+      throw new Error('--record requires --status')
+    }
+    if (!VALID_STATUSES.has(opts.status)) {
+      throw new Error(`invalid --status: ${opts.status}`)
+    }
+    if (opts.source && !VALID_SOURCES.has(opts.source)) {
+      throw new Error(`invalid --source: ${opts.source}`)
+    }
   }
   return opts
+}
+
+function parseNonNegativeInteger(value, flag) {
+  const parsed = Number(value)
+  if (!Number.isSafeInteger(parsed) || parsed < 0) {
+    throw new Error(`${flag} requires a non-negative integer`)
+  }
+  return parsed
 }
 
 function nowIso() {
@@ -246,6 +376,19 @@ node scripts/ops/dingtalk-public-form-mobile-signoff.mjs \\
   --input mobile-signoff.json \\
   --output-dir compiled \\
   --strict
+\`\`\`
+
+Record one check without hand-editing the JSON:
+
+\`\`\`bash
+node scripts/ops/dingtalk-public-form-mobile-signoff.mjs \\
+  --record mobile-signoff.json \\
+  --check-id public-anonymous-submit \\
+  --status pass \\
+  --source server-observation \\
+  --operator qa \\
+  --summary "Anonymous public form inserted one record." \\
+  --record-insert-delta 1
 \`\`\`
 `
 }
@@ -384,6 +527,27 @@ function validatePassCheck(inputDir, check, entry, errors) {
   }
 }
 
+function validateRecordedCheck(inputFile, check, entry) {
+  const errors = []
+  const inputDir = path.dirname(inputFile)
+  const evidence = isObject(entry.evidence) ? entry.evidence : {}
+  const summary = typeof evidence.summary === 'string' ? evidence.summary.trim() : ''
+  const notes = typeof evidence.notes === 'string' ? evidence.notes.trim() : ''
+
+  scanObjectStrings(entry, `record.${check.id}`, errors)
+
+  if (!VALID_STATUSES.has(entry.status)) {
+    errors.push(`${check.id}: invalid status ${JSON.stringify(entry.status)}`)
+  }
+  if (entry.status === 'pass') {
+    validatePassCheck(inputDir, check, entry, errors)
+  }
+  if (entry.status === 'fail' && !summary && !notes) {
+    errors.push(`${check.id}: fail evidence requires summary or notes`)
+  }
+  return errors
+}
+
 function validateEvidence(inputFile, evidence, strict) {
   const errors = []
   const warnings = []
@@ -515,11 +679,83 @@ function compileEvidence(opts) {
   console.log(`[dingtalk-public-form-mobile-signoff] wrote summary: ${path.join(outputDir, 'summary.md')}`)
 }
 
+function setEvidenceValue(evidence, key, value) {
+  if (value !== '' && value !== null) {
+    evidence[key] = value
+  }
+}
+
+function appendArtifacts(evidence, refs) {
+  if (refs.length === 0) return
+  const existing = Array.isArray(evidence.artifacts) ? evidence.artifacts : []
+  evidence.artifacts = Array.from(new Set([...existing, ...refs]))
+}
+
+function recordCheck(opts) {
+  const signoff = readJson(opts.record)
+  if (!Array.isArray(signoff.checks)) {
+    signoff.checks = []
+  }
+
+  const check = CHECK_BY_ID.get(opts.checkId)
+  let entry = signoff.checks.find((candidate) => candidate?.id === opts.checkId)
+  if (!entry) {
+    entry = makeTemplateCheck(check)
+    signoff.checks.push(entry)
+  }
+  if (!isObject(entry.evidence)) {
+    entry.evidence = {}
+  }
+
+  entry.status = opts.status
+  const evidence = entry.evidence
+  setEvidenceValue(evidence, 'source', opts.source)
+  setEvidenceValue(evidence, 'operator', opts.operator)
+  setEvidenceValue(evidence, 'summary', opts.summary)
+  setEvidenceValue(evidence, 'notes', opts.notes)
+  setEvidenceValue(evidence, 'beforeRecordCount', opts.beforeRecordCount)
+  setEvidenceValue(evidence, 'afterRecordCount', opts.afterRecordCount)
+  setEvidenceValue(evidence, 'recordInsertDelta', opts.recordInsertDelta)
+  setEvidenceValue(evidence, 'submitBlocked', opts.submitBlocked)
+  setEvidenceValue(evidence, 'blockedReason', opts.blockedReason)
+  setEvidenceValue(evidence, 'formRendered', opts.formRendered)
+  setEvidenceValue(evidence, 'passwordChangeRequiredShown', opts.passwordChangeRequiredShown)
+  appendArtifacts(evidence, opts.artifacts)
+
+  if ((opts.status === 'pass' || opts.status === 'fail') && !evidence.performedAt) {
+    evidence.performedAt = opts.performedAt || nowIso()
+  } else {
+    setEvidenceValue(evidence, 'performedAt', opts.performedAt)
+  }
+
+  const errors = validateRecordedCheck(opts.record, check, entry)
+  if (errors.length > 0) {
+    console.error(`[dingtalk-public-form-mobile-signoff] record rejected: ${errors.length} error(s)`)
+    for (const error of errors) {
+      console.error(`- ${error}`)
+    }
+    process.exitCode = 1
+    return
+  }
+
+  if (opts.dryRun) {
+    console.log(JSON.stringify(redactValue(entry), null, 2))
+    return
+  }
+
+  writeJson(opts.record, signoff)
+  console.log(`[dingtalk-public-form-mobile-signoff] recorded ${opts.checkId}: ${opts.status}`)
+}
+
 function main() {
   try {
     const opts = parseArgs(process.argv.slice(2))
     if (opts.initKit) {
       initKit(opts.initKit)
+      return
+    }
+    if (opts.record) {
+      recordCheck(opts)
       return
     }
     compileEvidence(opts)

--- a/scripts/ops/dingtalk-public-form-mobile-signoff.test.mjs
+++ b/scripts/ops/dingtalk-public-form-mobile-signoff.test.mjs
@@ -97,19 +97,129 @@ function writeEvidence(tmpDir, evidence = makePassingEvidence()) {
   return input
 }
 
+function initKit(tmpDir) {
+  const kitDir = path.join(tmpDir, 'kit')
+  const result = runScript(['--init-kit', kitDir])
+  assert.equal(result.status, 0, result.stderr)
+  return {
+    kitDir,
+    input: path.join(kitDir, 'mobile-signoff.json'),
+  }
+}
+
 test('dingtalk-public-form-mobile-signoff initializes an editable kit', () => {
   const tmpDir = makeTmpDir()
   try {
-    const kitDir = path.join(tmpDir, 'kit')
-    const result = runScript(['--init-kit', kitDir])
+    const { kitDir } = initKit(tmpDir)
 
-    assert.equal(result.status, 0, result.stderr)
     assert.ok(existsSync(path.join(kitDir, 'mobile-signoff.json')))
     assert.ok(existsSync(path.join(kitDir, 'mobile-signoff-checklist.md')))
     assert.ok(existsSync(path.join(kitDir, 'artifacts', 'public-anonymous-submit')))
     const template = JSON.parse(readFileSync(path.join(kitDir, 'mobile-signoff.json'), 'utf8'))
     assert.equal(template.tool, 'dingtalk-public-form-mobile-signoff')
     assert.equal(template.checks.length, requiredCheckIds.length)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-public-form-mobile-signoff records allowed submit evidence', () => {
+  const tmpDir = makeTmpDir()
+  try {
+    const { input } = initKit(tmpDir)
+    const result = runScript([
+      '--record', input,
+      '--check-id', 'public-anonymous-submit',
+      '--status', 'pass',
+      '--source', 'server-observation',
+      '--operator', 'qa',
+      '--summary', 'Anonymous public form inserted one record.',
+      '--record-insert-delta', '1',
+    ])
+
+    assert.equal(result.status, 0, result.stderr)
+    const signoff = JSON.parse(readFileSync(input, 'utf8'))
+    const entry = signoff.checks.find((check) => check.id === 'public-anonymous-submit')
+    assert.equal(entry.status, 'pass')
+    assert.equal(entry.evidence.source, 'server-observation')
+    assert.equal(entry.evidence.recordInsertDelta, 1)
+    assert.match(entry.evidence.performedAt, /^\d{4}-\d{2}-\d{2}T/)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-public-form-mobile-signoff records denied submit evidence', () => {
+  const tmpDir = makeTmpDir()
+  try {
+    const { input } = initKit(tmpDir)
+    const result = runScript([
+      '--record', input,
+      '--check-id', 'selected-unlisted-bound-rejected',
+      '--status', 'pass',
+      '--source', 'manual-client',
+      '--operator', 'qa',
+      '--summary', 'The unlisted bound user was blocked before insert.',
+      '--submit-blocked',
+      '--record-insert-delta', '0',
+      '--blocked-reason', 'Not in selected user or group allowlist.',
+    ])
+
+    assert.equal(result.status, 0, result.stderr)
+    const signoff = JSON.parse(readFileSync(input, 'utf8'))
+    const entry = signoff.checks.find((check) => check.id === 'selected-unlisted-bound-rejected')
+    assert.equal(entry.status, 'pass')
+    assert.equal(entry.evidence.submitBlocked, true)
+    assert.equal(entry.evidence.recordInsertDelta, 0)
+    assert.equal(entry.evidence.blockedReason, 'Not in selected user or group allowlist.')
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-public-form-mobile-signoff dry-runs a record without writing', () => {
+  const tmpDir = makeTmpDir()
+  try {
+    const { input } = initKit(tmpDir)
+    const before = readFileSync(input, 'utf8')
+    const result = runScript([
+      '--record', input,
+      '--check-id', 'password-change-bypass-observed',
+      '--status', 'pass',
+      '--source', 'manual-client',
+      '--operator', 'qa',
+      '--summary', 'The form rendered without the password-change page.',
+      '--form-rendered',
+      '--no-password-change-required-shown',
+      '--dry-run',
+    ])
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stdout, /"id": "password-change-bypass-observed"/)
+    assert.equal(readFileSync(input, 'utf8'), before)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-public-form-mobile-signoff rejects secret-like record updates', () => {
+  const tmpDir = makeTmpDir()
+  try {
+    const { input } = initKit(tmpDir)
+    const before = readFileSync(input, 'utf8')
+    const result = runScript([
+      '--record', input,
+      '--check-id', 'public-anonymous-submit',
+      '--status', 'pass',
+      '--source', 'operator-note',
+      '--operator', 'qa',
+      '--summary', `Do not store ${'SEC'}1234567890abcdef here.`,
+      '--record-insert-delta', '1',
+    ])
+
+    assert.notEqual(result.status, 0)
+    assert.match(result.stderr, /dingtalk_sec_secret/)
+    assert.equal(readFileSync(input, 'utf8'), before)
   } finally {
     rmSync(tmpDir, { recursive: true, force: true })
   }


### PR DESCRIPTION
## Summary

- Add `--record` mode to the DingTalk public-form mobile signoff tool so each real mobile scenario can be captured with one CLI command instead of hand-editing the full JSON packet.
- Validate recorded pass evidence with the existing screenshot-free rules for allowed submit, denied submit, and render checks.
- Keep secret hygiene on record updates and document the recorder design and verification results.

## Verification

- `node --test scripts/ops/dingtalk-public-form-mobile-signoff.test.mjs`
- Manual init/record/compile flow against a temp kit: `status=pass`, `errors=0`, `recorded=2`
- `git diff --cached --check`
- Staged diff secret scan for DingTalk webhook/token/JWT/public-token patterns: no matches

## Docs

- `docs/development/dingtalk-public-form-mobile-signoff-recorder-design-20260429.md`
- `docs/development/dingtalk-public-form-mobile-signoff-recorder-verification-20260429.md`