### PR TITLE
test(integration): guard K3 WISE postdeploy workflows

### DIFF
--- a/docs/development/integration-k3wise-postdeploy-workflow-contract-design-20260429.md
+++ b/docs/development/integration-k3wise-postdeploy-workflow-contract-design-20260429.md
@@ -1,0 +1,33 @@
+# K3 WISE Postdeploy Workflow Contract Test Design
+
+## Context
+
+K3 WISE readiness now depends on two GitHub Actions entrypoints:
+
+- `Build and Push Docker Images` runs the postdeploy smoke after the production deploy job.
+- `K3 WISE Postdeploy Smoke` lets an operator manually rerun the same smoke against a selected MetaSheet base URL.
+
+Both entrypoints are operational glue. A future YAML edit could accidentally remove the smoke script, point the summary at the wrong JSON file, drop artifact upload, or disconnect `METASHEET_K3WISE_SMOKE_TOKEN` without breaking ordinary unit tests.
+
+## Change
+
+Add `scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs`.
+
+The test scans the two workflow YAML files for stable contract fragments and keeps the YAML syntax check as a separate verification command. It intentionally avoids extra npm package resolution so it can run with plain `node --test` like the surrounding ops tests.
+
+- Manual workflow remains `workflow_dispatch` with `base_url`, `require_auth`, and `timeout_ms` inputs.
+- Manual workflow still passes `METASHEET_K3WISE_SMOKE_TOKEN`, supports `--require-auth`, captures `stderr.log` and `cli-summary.json`, writes `smoke_rc`, uploads artifacts, and gates failure from the script exit code.
+- Deploy workflow still runs `scripts/ops/integration-k3wise-postdeploy-smoke.mjs` after a successful remote deploy.
+- Deploy summary still renders `output/deploy/k3wise-postdeploy-smoke/integration-k3wise-postdeploy-smoke.json` with `integration-k3wise-postdeploy-summary.mjs --missing-ok`.
+- Deploy artifact upload still includes `output/deploy/**`, which contains the K3 WISE smoke evidence.
+
+## Non-Goals
+
+- No runtime behavior change.
+- No customer PLM, K3 WISE, SQL Server, or middleware connection.
+- No secret generation or token rotation.
+- No attempt to make the manual smoke authenticated without `METASHEET_K3WISE_SMOKE_TOKEN`.
+
+## Risk
+
+This is a docs and test-only guard. The main risk is test brittleness if workflow step names intentionally change. That is acceptable because these step names are part of the operator-facing deployment summary and artifact audit trail.

--- a/docs/development/integration-k3wise-postdeploy-workflow-contract-verification-20260429.md
+++ b/docs/development/integration-k3wise-postdeploy-workflow-contract-verification-20260429.md
@@ -1,0 +1,35 @@
+# K3 WISE Postdeploy Workflow Contract Verification
+
+## Scope
+
+Verify the workflow contract test added for the K3 WISE postdeploy smoke chain.
+
+## Commands
+
+```bash
+node --test scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs
+node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
+node --test scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
+ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f) }; puts "workflow yaml ok"' \
+  .github/workflows/docker-build.yml \
+  .github/workflows/integration-k3wise-postdeploy-smoke.yml
+git diff --check
+```
+
+## Expected Result
+
+- Workflow contract test passes.
+- Existing postdeploy smoke and summary tests continue to pass.
+- Both workflow YAML files parse successfully.
+- Diff has no whitespace errors.
+
+## Live Environment
+
+This verification is intentionally local and read-only. It does not contact:
+
+- customer PLM;
+- customer K3 WISE;
+- customer SQL Server;
+- customer middleware or VPN.
+
+The previous post-merge workflow evidence remains the live deployment proof for `main`; this change adds a regression guard so future YAML edits keep that path intact.

--- a/scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const manualWorkflowPath = path.join(repoRoot, '.github', 'workflows', 'integration-k3wise-postdeploy-smoke.yml')
+const deployWorkflowPath = path.join(repoRoot, '.github', 'workflows', 'docker-build.yml')
+
+function assertContains(haystack, needle, label) {
+  assert.ok(
+    String(haystack).includes(needle),
+    `${label} must include ${needle}`,
+  )
+}
+
+test('manual K3 WISE postdeploy smoke workflow keeps dispatch and auth contract stable', () => {
+  const raw = readFileSync(manualWorkflowPath, 'utf8')
+
+  assertContains(raw, 'name: K3 WISE Postdeploy Smoke', 'manual workflow')
+  assertContains(raw, 'workflow_dispatch:', 'manual trigger')
+  assertContains(raw, 'base_url:', 'manual inputs')
+  assertContains(raw, "default: 'http://142.171.239.56:8081'", 'manual default base URL')
+  assertContains(raw, 'require_auth:', 'manual inputs')
+  assertContains(raw, 'type: choice', 'manual require_auth input')
+  assertContains(raw, "- 'false'", 'manual require_auth input')
+  assertContains(raw, "- 'true'", 'manual require_auth input')
+  assertContains(raw, "default: '10000'", 'manual timeout input')
+  assertContains(raw, 'contents: read', 'manual permissions')
+  assertContains(raw, 'actions: read', 'manual permissions')
+  assertContains(raw, '- name: Run K3 WISE postdeploy smoke', 'manual smoke step')
+  assertContains(raw, 'continue-on-error: true', 'manual smoke step')
+  assertContains(raw, 'METASHEET_AUTH_TOKEN: ${{ secrets.METASHEET_K3WISE_SMOKE_TOKEN }}', 'manual smoke step')
+  assertContains(raw, "REQUIRE_AUTH: ${{ github.event.inputs.require_auth || 'false' }}", 'manual smoke step')
+  assertContains(raw, 'smoke_out_dir="output/integration-k3wise-postdeploy-smoke/manual"', 'manual smoke step')
+  assertContains(raw, 'node scripts/ops/integration-k3wise-postdeploy-smoke.mjs', 'manual smoke step')
+  assertContains(raw, '--base-url "$METASHEET_BASE_URL"', 'manual smoke step')
+  assertContains(raw, '--out-dir "$smoke_out_dir"', 'manual smoke step')
+  assertContains(raw, '--timeout-ms "$TIMEOUT_MS"', 'manual smoke step')
+  assertContains(raw, 'args+=(--require-auth)', 'manual smoke step')
+  assertContains(raw, 'stderr.log', 'manual smoke step')
+  assertContains(raw, 'cli-summary.json', 'manual smoke step')
+  assertContains(raw, 'smoke_rc=$rc', 'manual smoke step')
+  assertContains(raw, '- name: Write K3 WISE smoke summary', 'manual summary step')
+  assertContains(raw, 'if: always()', 'manual always-run steps')
+  assertContains(raw, 'scripts/ops/integration-k3wise-postdeploy-summary.mjs', 'manual summary step')
+  assertContains(raw, 'output/integration-k3wise-postdeploy-smoke/manual/integration-k3wise-postdeploy-smoke.json', 'manual summary step')
+  assertContains(raw, '--missing-ok', 'manual summary step')
+  assertContains(raw, 'integration-k3wise-postdeploy-smoke-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}', 'manual summary step')
+  assertContains(raw, '- name: Upload K3 WISE smoke artifacts', 'manual artifact upload')
+  assertContains(raw, 'uses: actions/upload-artifact@v4', 'manual artifact upload')
+  assertContains(raw, 'name: integration-k3wise-postdeploy-smoke-${{ github.run_id }}-${{ github.run_attempt }}', 'manual artifact upload')
+  assertContains(raw, 'output/integration-k3wise-postdeploy-smoke/manual/**', 'manual artifact upload')
+  assertContains(raw, '- name: Fail when K3 WISE smoke failed', 'manual final gate')
+  assertContains(raw, 'steps.smoke.outputs.smoke_rc', 'manual final gate')
+  assertContains(raw, 'K3 WISE postdeploy smoke failed', 'manual final gate')
+})
+
+test('deploy workflow keeps K3 WISE smoke evidence wired into deploy summary and artifacts', () => {
+  const raw = readFileSync(deployWorkflowPath, 'utf8')
+
+  assertContains(raw, 'deploy:', 'docker-build deploy job')
+  assertContains(raw, '- name: K3 WISE postdeploy smoke', 'deploy smoke step')
+  assertContains(raw, "if: ${{ steps.remote_deploy.outputs.deploy_rc == '0' }}", 'deploy smoke step')
+  assertContains(raw, 'METASHEET_AUTH_TOKEN: ${{ secrets.METASHEET_K3WISE_SMOKE_TOKEN }}', 'deploy smoke step')
+  assertContains(raw, 'smoke_out_dir="output/deploy/k3wise-postdeploy-smoke"', 'deploy smoke step')
+  assertContains(raw, 'node scripts/ops/integration-k3wise-postdeploy-smoke.mjs', 'deploy smoke step')
+  assertContains(raw, '--base-url "$METASHEET_BASE_URL"', 'deploy smoke step')
+  assertContains(raw, '--out-dir "$smoke_out_dir"', 'deploy smoke step')
+  assertContains(raw, '- name: Write deploy summary (preflight + runbooks)', 'deploy summary step')
+  assertContains(raw, '### K3 WISE Postdeploy Smoke', 'deploy summary step')
+  assertContains(raw, 'k3_smoke_json="output/deploy/k3wise-postdeploy-smoke/integration-k3wise-postdeploy-smoke.json"', 'deploy summary step')
+  assertContains(raw, 'scripts/ops/integration-k3wise-postdeploy-summary.mjs', 'deploy summary step')
+  assertContains(raw, '--input "$k3_smoke_json"', 'deploy summary step')
+  assertContains(raw, '--missing-ok', 'deploy summary step')
+  assertContains(raw, 'K3 WISE smoke evidence:', 'deploy summary step')
+  assertContains(raw, 'output/deploy/k3wise-postdeploy-smoke/', 'deploy summary step')
+  assertContains(raw, 'cp "$GITHUB_STEP_SUMMARY" output/deploy/step-summary.md', 'deploy summary archive')
+  assertContains(raw, '- name: Upload deploy artifacts', 'deploy artifact upload')
+  assertContains(raw, 'uses: actions/upload-artifact@v4', 'deploy artifact upload')
+  assertContains(raw, 'output/deploy/**', 'deploy artifact upload')
+})


### PR DESCRIPTION
## Summary
- add a node:test contract guard for the K3 WISE manual smoke workflow and deploy workflow wiring
- assert the smoke script, summary renderer, artifact paths, manual inputs, require-auth plumbing, and smoke token secret stay connected
- add design and verification notes for the workflow contract guard

## Verification
- node --test scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs
- node --test scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
- node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f) }; puts "workflow yaml ok"' .github/workflows/docker-build.yml .github/workflows/integration-k3wise-postdeploy-smoke.yml
- git diff --cached --check