### PR TITLE
feat(multitable): add formula editor view builder and gantt view

### DIFF
--- a/apps/web/src/multitable/components/MetaFieldManager.vue
+++ b/apps/web/src/multitable/components/MetaFieldManager.vue
@@ -144,18 +144,50 @@
         <template v-else-if="configTargetType === 'formula'">
           <label class="meta-field-mgr__field">
             <span>Expression</span>
-            <textarea v-model="formulaDraft.expression" class="meta-field-mgr__textarea" placeholder="SUM({Price}, {Tax})"></textarea>
+            <textarea v-model="formulaDraft.expression" class="meta-field-mgr__textarea" placeholder="=SUM({fld_price}, {fld_tax})"></textarea>
           </label>
+          <div v-if="formulaDiagnostics.length" class="meta-field-mgr__formula-diagnostics">
+            <div
+              v-for="diagnostic in formulaDiagnostics"
+              :key="diagnostic.message"
+              class="meta-field-mgr__formula-diagnostic"
+              :class="`meta-field-mgr__formula-diagnostic--${diagnostic.severity}`"
+            >
+              {{ diagnostic.message }}
+            </div>
+          </div>
           <div class="meta-field-mgr__field">
-            <span>Insert field</span>
+            <span>Insert field token</span>
             <div class="meta-field-mgr__chips">
               <button
                 v-for="field in formulaSourceFields"
                 :key="field.id"
                 type="button"
                 class="meta-field-mgr__chip"
-                @click="insertFormulaField(field.name)"
+                :title="`Insert {${field.id}}`"
+                @click="insertFormulaField(field.id)"
               >{{ field.name }}</button>
+            </div>
+          </div>
+          <div class="meta-field-mgr__field">
+            <span>Function reference</span>
+            <input
+              v-model="formulaFunctionSearch"
+              class="meta-field-mgr__input"
+              placeholder="Search SUM, IF, TODAY..."
+            />
+            <div class="meta-field-mgr__formula-docs">
+              <button
+                v-for="doc in filteredFormulaDocs"
+                :key="doc.name"
+                type="button"
+                class="meta-field-mgr__formula-doc"
+                @click="insertFormulaFunction(doc.name)"
+              >
+                <strong>{{ doc.signature }}</strong>
+                <span>{{ doc.description }}</span>
+                <code>{{ doc.example }}</code>
+              </button>
             </div>
           </div>
         </template>
@@ -257,6 +289,11 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, reactive, ref, watch } from 'vue'
 import type { FieldValidationRule, MetaField, MetaFieldCreateType, MetaSheet } from '../types'
+import {
+  searchFormulaFunctionDocs,
+  validateFormulaExpression,
+  type FormulaDiagnostic,
+} from '../utils/formula-docs'
 import {
   normalizeStringArray,
   resolveAttachmentFieldProperty,
@@ -419,6 +456,7 @@ const rollupDraft = reactive<{ linkFieldId: string; targetFieldId: string; forei
 const formulaDraft = reactive<{ expression: string }>({
   expression: '',
 })
+const formulaFunctionSearch = ref('')
 const attachmentDraft = reactive<{ maxFiles: number; acceptedMimeTypesText: string }>({
   maxFiles: 1,
   acceptedMimeTypesText: '',
@@ -450,6 +488,12 @@ const linkSourceFields = computed(() => props.fields.filter((field) => field.typ
 const targetSheets = computed(() => props.sheets.filter((sheet) => sheet.id !== props.sheetId))
 const formulaSourceFields = computed(() =>
   props.fields.filter((field) => field.id !== configTarget.value?.id && field.type !== 'formula'),
+)
+const filteredFormulaDocs = computed(() => searchFormulaFunctionDocs(formulaFunctionSearch.value).slice(0, 8))
+const formulaDiagnostics = computed<FormulaDiagnostic[]>(() =>
+  configTargetType.value === 'formula'
+    ? validateFormulaExpression(formulaDraft.expression, formulaSourceFields.value)
+    : [],
 )
 const configTargetType = computed(() => {
   if (configTarget.value) return configDraftType.value
@@ -513,6 +557,7 @@ function resetDrafts() {
   rollupDraft.foreignSheetId = ''
   rollupDraft.aggregation = 'count'
   formulaDraft.expression = ''
+  formulaFunctionSearch.value = ''
   attachmentDraft.maxFiles = 1
   attachmentDraft.acceptedMimeTypesText = ''
   currencyDraft.code = 'CNY'
@@ -787,6 +832,11 @@ function currentDraftProperty(type: MetaFieldCreateType | string): Record<string
     }
   }
   if (normalizedType === 'formula') {
+    const blockingDiagnostic = formulaDiagnostics.value.find((diagnostic) => diagnostic.severity === 'error')
+    if (blockingDiagnostic) {
+      fieldConfigError.value = blockingDiagnostic.message
+      return undefined
+    }
     return { expression: formulaDraft.expression.trim() }
   }
   if (normalizedType === 'attachment') {
@@ -830,11 +880,18 @@ function currentDraftProperty(type: MetaFieldCreateType | string): Record<string
   return undefined
 }
 
-function insertFormulaField(fieldName: string) {
-  const token = `{${fieldName}}`
+function appendFormulaToken(token: string) {
   formulaDraft.expression = formulaDraft.expression
     ? `${formulaDraft.expression}${formulaDraft.expression.endsWith(' ') ? '' : ' '}${token}`
     : token
+}
+
+function insertFormulaField(fieldId: string) {
+  appendFormulaToken(`{${fieldId}}`)
+}
+
+function insertFormulaFunction(functionName: string) {
+  appendFormulaToken(formulaDraft.expression.trim() ? `${functionName}()` : `=${functionName}()`)
 }
 
 function onAddField() {
@@ -1043,6 +1100,16 @@ onBeforeUnmount(() => {
 .meta-field-mgr__refresh { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 8px 10px; border: 1px solid #bfd6ff; border-radius: 6px; background: #eef5ff; color: #1d4ed8; font-size: 12px; }
 .meta-field-mgr__chips { display: flex; flex-wrap: wrap; gap: 6px; }
 .meta-field-mgr__chip { border: 1px solid #d9ecff; border-radius: 999px; background: #f0f7ff; color: #2563eb; padding: 3px 10px; cursor: pointer; font-size: 11px; }
+.meta-field-mgr__formula-diagnostics { display: flex; flex-direction: column; gap: 4px; }
+.meta-field-mgr__formula-diagnostic { padding: 6px 8px; border-radius: 5px; font-size: 12px; }
+.meta-field-mgr__formula-diagnostic--warning { background: #fff7e6; color: #8a5a00; border: 1px solid #f3d19e; }
+.meta-field-mgr__formula-diagnostic--error { background: #fef0f0; color: #c0392b; border: 1px solid #fbc4c4; }
+.meta-field-mgr__formula-docs { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; max-height: 180px; overflow-y: auto; }
+.meta-field-mgr__formula-doc { display: flex; flex-direction: column; gap: 3px; padding: 8px; border: 1px solid #e2e8f0; border-radius: 6px; background: #fff; color: #334155; text-align: left; cursor: pointer; }
+.meta-field-mgr__formula-doc:hover { border-color: #93c5fd; background: #f8fbff; }
+.meta-field-mgr__formula-doc strong { font-size: 12px; color: #1d4ed8; }
+.meta-field-mgr__formula-doc span { font-size: 11px; color: #64748b; }
+.meta-field-mgr__formula-doc code { font-size: 11px; color: #475569; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .meta-field-mgr__grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; }
 .meta-field-mgr__stack { display: flex; flex-direction: column; gap: 8px; }
 .meta-field-mgr__option-row { display: grid; grid-template-columns: 1fr 1fr auto; gap: 8px; align-items: center; }

--- a/apps/web/src/multitable/components/MetaGanttView.vue
+++ b/apps/web/src/multitable/components/MetaGanttView.vue
@@ -1,0 +1,332 @@
+<template>
+  <div class="meta-gantt" role="region" aria-label="Gantt view">
+    <div v-if="loading" class="meta-gantt__loading">Loading...</div>
+    <template v-else>
+      <div class="meta-gantt__toolbar">
+        <label class="meta-gantt__control">
+          Start
+          <select :value="startFieldId" @change="onConfigChange('startFieldId', ($event.target as HTMLSelectElement).value || null)">
+            <option value="">select</option>
+            <option v-for="field in dateFields" :key="field.id" :value="field.id">{{ field.name }}</option>
+          </select>
+        </label>
+        <label class="meta-gantt__control">
+          End
+          <select :value="endFieldId" @change="onConfigChange('endFieldId', ($event.target as HTMLSelectElement).value || null)">
+            <option value="">select</option>
+            <option v-for="field in dateFields" :key="field.id" :value="field.id">{{ field.name }}</option>
+          </select>
+        </label>
+        <label class="meta-gantt__control">
+          Title
+          <select :value="titleFieldId" @change="onConfigChange('titleFieldId', ($event.target as HTMLSelectElement).value || null)">
+            <option value="">auto</option>
+            <option v-for="field in titleFields" :key="field.id" :value="field.id">{{ field.name }}</option>
+          </select>
+        </label>
+        <label class="meta-gantt__control">
+          Progress
+          <select :value="progressFieldId" @change="onConfigChange('progressFieldId', ($event.target as HTMLSelectElement).value || null)">
+            <option value="">none</option>
+            <option v-for="field in numericFields" :key="field.id" :value="field.id">{{ field.name }}</option>
+          </select>
+        </label>
+        <label class="meta-gantt__control">
+          Group
+          <select :value="groupFieldId" @change="onConfigChange('groupFieldId', ($event.target as HTMLSelectElement).value || null)">
+            <option value="">none</option>
+            <option v-for="field in groupableFields" :key="field.id" :value="field.id">{{ field.name }}</option>
+          </select>
+        </label>
+        <label class="meta-gantt__control">
+          Zoom
+          <select :value="zoom" @change="onConfigChange('zoom', ($event.target as HTMLSelectElement).value)">
+            <option value="day">Day</option>
+            <option value="week">Week</option>
+            <option value="month">Month</option>
+          </select>
+        </label>
+        <button v-if="canCreate" class="meta-gantt__create" @click="onQuickCreate">+ Add task</button>
+      </div>
+
+      <div v-if="!startFieldId || !endFieldId" class="meta-gantt__placeholder">
+        Select start and end date fields to display Gantt tasks.
+      </div>
+
+      <template v-else>
+        <div class="meta-gantt__head">
+          <div class="meta-gantt__task-col">Task</div>
+          <div class="meta-gantt__axis">
+            <span v-for="tick in axisTicks" :key="tick.key" class="meta-gantt__tick" :style="{ left: tick.left + '%' }">
+              {{ tick.label }}
+            </span>
+          </div>
+        </div>
+
+        <div v-for="section in groupedSections" :key="section.key" class="meta-gantt__section">
+          <div v-if="groupFieldId" class="meta-gantt__group">{{ section.label }}</div>
+          <button
+            v-for="task in section.items"
+            :key="task.record.id"
+            class="meta-gantt__row"
+            :class="{ 'meta-gantt__row--selected': task.record.id === selectedRecordId }"
+            @click="selectRecord(task.record.id)"
+          >
+            <span class="meta-gantt__task-col">
+              <strong>{{ displayTitle(task.record) }}</strong>
+              <small>{{ task.startDate }} to {{ task.endDate }}</small>
+            </span>
+            <span class="meta-gantt__bar-area">
+              <span
+                class="meta-gantt__bar"
+                :style="{ left: task.left + '%', width: task.width + '%' }"
+              >
+                <span class="meta-gantt__bar-progress" :style="{ width: task.progress + '%' }"></span>
+              </span>
+            </span>
+          </button>
+        </div>
+
+        <div v-if="unscheduledRows.length" class="meta-gantt__unscheduled">
+          <strong>Unscheduled ({{ unscheduledRows.length }})</strong>
+          <button
+            v-for="row in unscheduledRows"
+            :key="row.id"
+            class="meta-gantt__unscheduled-row"
+            @click="selectRecord(row.id)"
+          >
+            {{ displayTitle(row) }}
+          </button>
+        </div>
+
+        <div v-if="!scheduledTasks.length && !unscheduledRows.length" class="meta-gantt__placeholder">
+          No records found.
+        </div>
+      </template>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import type { LinkedRecordSummary, MetaAttachment, MetaField, MetaGanttViewConfig, MetaRecord } from '../types'
+import { formatFieldDisplay } from '../utils/field-display'
+import { resolveGanttViewConfig } from '../utils/view-config'
+
+const props = defineProps<{
+  rows: MetaRecord[]
+  fields: MetaField[]
+  loading: boolean
+  canCreate?: boolean
+  viewConfig?: Record<string, unknown> | null
+  groupInfo?: Record<string, unknown> | null
+  linkSummaries?: Record<string, Record<string, LinkedRecordSummary[]>>
+  attachmentSummaries?: Record<string, Record<string, MetaAttachment[]>>
+}>()
+
+const emit = defineEmits<{
+  (e: 'select-record', recordId: string): void
+  (e: 'create-record', data: Record<string, unknown>): void
+  (e: 'update-view-config', input: { config: Record<string, unknown>; groupInfo?: Record<string, unknown> }): void
+}>()
+
+const startFieldId = ref('')
+const endFieldId = ref('')
+const titleFieldId = ref('')
+const progressFieldId = ref('')
+const groupFieldId = ref('')
+const zoom = ref<'day' | 'week' | 'month'>('week')
+const selectedRecordId = ref<string | null>(null)
+const pendingConfigKey = ref<string | null>(null)
+
+const resolvedConfig = computed<Required<MetaGanttViewConfig>>(() =>
+  resolveGanttViewConfig(props.fields, props.viewConfig, props.groupInfo),
+)
+
+watch(
+  resolvedConfig,
+  (config) => {
+    const key = JSON.stringify(config)
+    if (pendingConfigKey.value && pendingConfigKey.value !== key) return
+    startFieldId.value = config.startFieldId ?? ''
+    endFieldId.value = config.endFieldId ?? ''
+    titleFieldId.value = config.titleFieldId ?? ''
+    progressFieldId.value = config.progressFieldId ?? ''
+    groupFieldId.value = config.groupFieldId ?? ''
+    zoom.value = config.zoom
+    if (pendingConfigKey.value === key) pendingConfigKey.value = null
+  },
+  { immediate: true },
+)
+
+const dateFields = computed(() => props.fields.filter((field) => field.type === 'date'))
+const titleFields = computed(() => props.fields)
+const numericFields = computed(() => props.fields.filter((field) => ['number', 'percent', 'currency', 'rating'].includes(field.type)))
+const groupableFields = computed(() => props.fields.filter((field) => ['select', 'string', 'boolean', 'date'].includes(field.type)))
+
+function parseDate(value: unknown): Date | null {
+  if (!value) return null
+  const date = new Date(String(value))
+  return Number.isNaN(date.getTime()) ? null : date
+}
+
+function displayTitle(record: MetaRecord): string {
+  const field = props.fields.find((item) => item.id === titleFieldId.value)
+    ?? props.fields.find((item) => item.type === 'string')
+    ?? props.fields[0]
+    ?? null
+  if (!field) return record.id
+  const value = formatFieldDisplay({
+    field,
+    value: record.data[field.id],
+    linkSummaries: props.linkSummaries?.[record.id]?.[field.id],
+    attachmentSummaries: props.attachmentSummaries?.[record.id]?.[field.id],
+  })
+  return value === '-' || value === '\u2014' ? record.id : value
+}
+
+function progressValue(record: MetaRecord): number {
+  if (!progressFieldId.value) return 0
+  const raw = record.data[progressFieldId.value]
+  const value = typeof raw === 'number' ? raw : Number(raw)
+  if (!Number.isFinite(value)) return 0
+  return Math.max(0, Math.min(100, value > 0 && value <= 1 ? value * 100 : value))
+}
+
+const timeRange = computed(() => {
+  let min = Infinity
+  let max = -Infinity
+  for (const row of props.rows) {
+    const start = parseDate(row.data[startFieldId.value])
+    const end = parseDate(row.data[endFieldId.value])
+    if (start) { min = Math.min(min, start.getTime()); max = Math.max(max, start.getTime()) }
+    if (end) { min = Math.min(min, end.getTime()); max = Math.max(max, end.getTime()) }
+  }
+  if (min === Infinity) return { min: Date.now(), max: Date.now() + 86400000 * 30 }
+  const pad = (max - min) * 0.08 || 86400000
+  return { min: min - pad, max: max + pad }
+})
+
+const scheduledTasks = computed(() => {
+  if (!startFieldId.value || !endFieldId.value) return []
+  const { min, max } = timeRange.value
+  const range = max - min || 1
+  return props.rows
+    .map((record) => {
+      const start = parseDate(record.data[startFieldId.value])
+      const end = parseDate(record.data[endFieldId.value])
+      if (!start || !end) return null
+      const left = ((start.getTime() - min) / range) * 100
+      const width = Math.max(1, ((end.getTime() - start.getTime()) / range) * 100)
+      return {
+        record,
+        startDate: start.toISOString().slice(0, 10),
+        endDate: end.toISOString().slice(0, 10),
+        left: Math.max(0, left),
+        width: Math.min(100 - Math.max(0, left), width),
+        progress: progressValue(record),
+      }
+    })
+    .filter((item): item is NonNullable<typeof item> => item !== null)
+})
+
+const unscheduledRows = computed(() => {
+  if (!startFieldId.value || !endFieldId.value) return props.rows
+  return props.rows.filter((row) => !parseDate(row.data[startFieldId.value]) || !parseDate(row.data[endFieldId.value]))
+})
+
+const groupedSections = computed(() => {
+  const buckets = new Map<string, { key: string; label: string; items: typeof scheduledTasks.value }>()
+  for (const item of scheduledTasks.value) {
+    const raw = groupFieldId.value ? item.record.data[groupFieldId.value] : 'All tasks'
+    const key = raw === null || raw === undefined || raw === '' ? 'ungrouped' : String(raw)
+    const label = key === 'ungrouped' ? 'Ungrouped' : key
+    if (!buckets.has(key)) buckets.set(key, { key, label, items: [] })
+    buckets.get(key)?.items.push(item)
+  }
+  return [...buckets.values()]
+})
+
+const axisTicks = computed(() => {
+  const { min, max } = timeRange.value
+  const range = max - min || 1
+  const step = zoom.value === 'day' ? 86400000 : zoom.value === 'week' ? 86400000 * 7 : 86400000 * 30
+  const ticks: Array<{ key: string; label: string; left: number }> = []
+  for (let ts = min; ts <= max; ts += step) {
+    const date = new Date(ts)
+    ticks.push({
+      key: String(ts),
+      label: zoom.value === 'month'
+        ? date.toLocaleDateString(undefined, { month: 'short', year: '2-digit' })
+        : date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }),
+      left: ((ts - min) / range) * 100,
+    })
+  }
+  return ticks
+})
+
+function currentConfig(): Required<MetaGanttViewConfig> {
+  return {
+    startFieldId: startFieldId.value || null,
+    endFieldId: endFieldId.value || null,
+    titleFieldId: titleFieldId.value || null,
+    progressFieldId: progressFieldId.value || null,
+    groupFieldId: groupFieldId.value || null,
+    zoom: zoom.value,
+  }
+}
+
+function onConfigChange(key: keyof Required<MetaGanttViewConfig>, value: unknown) {
+  const next = { ...currentConfig(), [key]: value } as Required<MetaGanttViewConfig>
+  startFieldId.value = next.startFieldId ?? ''
+  endFieldId.value = next.endFieldId ?? ''
+  titleFieldId.value = next.titleFieldId ?? ''
+  progressFieldId.value = next.progressFieldId ?? ''
+  groupFieldId.value = next.groupFieldId ?? ''
+  zoom.value = next.zoom
+  pendingConfigKey.value = JSON.stringify(next)
+  emit('update-view-config', {
+    config: next,
+    groupInfo: next.groupFieldId ? { fieldId: next.groupFieldId } : {},
+  })
+}
+
+function selectRecord(recordId: string) {
+  selectedRecordId.value = recordId
+  emit('select-record', recordId)
+}
+
+function onQuickCreate() {
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  const value = today.toISOString().slice(0, 10)
+  const data: Record<string, unknown> = {}
+  if (startFieldId.value) data[startFieldId.value] = value
+  if (endFieldId.value) data[endFieldId.value] = value
+  emit('create-record', data)
+}
+</script>
+
+<style scoped>
+.meta-gantt { display: flex; flex-direction: column; flex: 1; min-height: 0; background: #f8fafc; color: #334155; }
+.meta-gantt__loading, .meta-gantt__placeholder { margin: 24px; padding: 28px; border: 1px dashed #cbd5e1; border-radius: 10px; background: #fff; color: #64748b; text-align: center; }
+.meta-gantt__toolbar { display: flex; flex-wrap: wrap; gap: 10px; padding: 12px 16px; border-bottom: 1px solid #e2e8f0; background: #fff; }
+.meta-gantt__control { display: flex; flex-direction: column; gap: 4px; min-width: 118px; font-size: 11px; color: #64748b; }
+.meta-gantt__control select { padding: 6px 8px; border: 1px solid #cbd5e1; border-radius: 6px; background: #fff; color: #334155; }
+.meta-gantt__create { align-self: end; padding: 7px 12px; border: 1px solid #2563eb; border-radius: 6px; background: #2563eb; color: #fff; cursor: pointer; }
+.meta-gantt__head { display: grid; grid-template-columns: 260px 1fr; min-height: 40px; border-bottom: 1px solid #e2e8f0; background: #f1f5f9; }
+.meta-gantt__task-col { padding: 8px 12px; border-right: 1px solid #e2e8f0; text-align: left; }
+.meta-gantt__task-col strong, .meta-gantt__task-col small { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.meta-gantt__task-col small { margin-top: 2px; color: #64748b; font-size: 11px; }
+.meta-gantt__axis { position: relative; min-height: 40px; overflow: hidden; }
+.meta-gantt__tick { position: absolute; top: 10px; transform: translateX(-50%); font-size: 11px; color: #64748b; white-space: nowrap; }
+.meta-gantt__section { display: flex; flex-direction: column; }
+.meta-gantt__group { padding: 7px 12px; border-bottom: 1px solid #e2e8f0; background: #eef2ff; color: #3730a3; font-size: 12px; font-weight: 600; }
+.meta-gantt__row { display: grid; grid-template-columns: 260px 1fr; min-height: 52px; border: 0; border-bottom: 1px solid #e2e8f0; background: #fff; color: inherit; cursor: pointer; }
+.meta-gantt__row:hover, .meta-gantt__row--selected { background: #eff6ff; }
+.meta-gantt__bar-area { position: relative; margin: 12px 16px; border-radius: 999px; background: linear-gradient(90deg, rgba(203,213,225,.28) 1px, transparent 1px); background-size: 8.333% 100%; }
+.meta-gantt__bar { position: absolute; top: 7px; height: 16px; min-width: 6px; overflow: hidden; border-radius: 999px; background: #93c5fd; box-shadow: 0 4px 10px rgba(37,99,235,.18); }
+.meta-gantt__bar-progress { display: block; height: 100%; border-radius: inherit; background: #2563eb; }
+.meta-gantt__unscheduled { margin: 16px; padding: 12px; border: 1px solid #e2e8f0; border-radius: 8px; background: #fff; }
+.meta-gantt__unscheduled-row { display: block; width: 100%; margin-top: 6px; padding: 6px 8px; border: 1px solid #e2e8f0; border-radius: 6px; background: #f8fafc; text-align: left; cursor: pointer; }
+</style>

--- a/apps/web/src/multitable/components/MetaViewManager.vue
+++ b/apps/web/src/multitable/components/MetaViewManager.vue
@@ -173,6 +173,58 @@
           </div>
         </template>
 
+        <template v-else-if="configTarget.type === 'gantt'">
+          <div class="meta-view-mgr__grid">
+            <label class="meta-view-mgr__field">
+              <span>Start field</span>
+              <select v-model="ganttDraft.startFieldId" class="meta-view-mgr__select">
+                <option value="">(auto)</option>
+                <option v-for="field in dateFields" :key="field.id" :value="field.id">{{ field.name }}</option>
+              </select>
+            </label>
+            <label class="meta-view-mgr__field">
+              <span>End field</span>
+              <select v-model="ganttDraft.endFieldId" class="meta-view-mgr__select">
+                <option value="">(auto)</option>
+                <option v-for="field in dateFields" :key="field.id" :value="field.id">{{ field.name }}</option>
+              </select>
+            </label>
+          </div>
+          <div class="meta-view-mgr__grid">
+            <label class="meta-view-mgr__field">
+              <span>Title field</span>
+              <select v-model="ganttDraft.titleFieldId" class="meta-view-mgr__select">
+                <option value="">(auto)</option>
+                <option v-for="field in configTargetFields" :key="field.id" :value="field.id">{{ field.name }}</option>
+              </select>
+            </label>
+            <label class="meta-view-mgr__field">
+              <span>Progress field</span>
+              <select v-model="ganttDraft.progressFieldId" class="meta-view-mgr__select">
+                <option value="">None</option>
+                <option v-for="field in numericFields" :key="field.id" :value="field.id">{{ field.name }}</option>
+              </select>
+            </label>
+          </div>
+          <div class="meta-view-mgr__grid">
+            <label class="meta-view-mgr__field">
+              <span>Gantt group field</span>
+              <select v-model="ganttDraft.groupFieldId" class="meta-view-mgr__select">
+                <option value="">None</option>
+                <option v-for="field in groupableFields" :key="field.id" :value="field.id">{{ field.name }}</option>
+              </select>
+            </label>
+            <label class="meta-view-mgr__field">
+              <span>Zoom</span>
+              <select v-model="ganttDraft.zoom" class="meta-view-mgr__select">
+                <option value="day">day</option>
+                <option value="week">week</option>
+                <option value="month">month</option>
+              </select>
+            </label>
+          </div>
+        </template>
+
         <template v-else-if="configTarget.type === 'kanban'">
           <label class="meta-view-mgr__field">
             <span>Group field</span>
@@ -198,6 +250,98 @@
 
         <div v-else class="meta-view-mgr__config-note">
           No additional configuration is required for this view type.
+        </div>
+
+        <div class="meta-view-mgr__common">
+          <div class="meta-view-mgr__common-header">
+            <strong>Filter, sort, group</strong>
+            <span>Shared by grid and visual views</span>
+          </div>
+
+          <div class="meta-view-mgr__field">
+            <div class="meta-view-mgr__subheader">
+              <span>Filters</span>
+              <select
+                v-if="filterDraft.conditions.length > 1"
+                v-model="filterDraft.conjunction"
+                class="meta-view-mgr__select meta-view-mgr__select--compact"
+              >
+                <option value="and">all conditions</option>
+                <option value="or">any condition</option>
+              </select>
+            </div>
+            <div v-if="filterDraft.conditions.length" class="meta-view-mgr__rules">
+              <div
+                v-for="(rule, idx) in filterDraft.conditions"
+                :key="idx"
+                class="meta-view-mgr__rule-row meta-view-mgr__rule-row--filter"
+              >
+                <select
+                  :value="rule.fieldId"
+                  class="meta-view-mgr__select"
+                  @change="updateFilterField(idx, ($event.target as HTMLSelectElement).value)"
+                >
+                  <option v-for="field in configTargetFields" :key="field.id" :value="field.id">{{ field.name }}</option>
+                </select>
+                <select
+                  :value="rule.operator"
+                  class="meta-view-mgr__select"
+                  @change="updateFilterOperator(idx, ($event.target as HTMLSelectElement).value)"
+                >
+                  <option v-for="operator in operatorsForField(rule.fieldId)" :key="operator.value" :value="operator.value">{{ operator.label }}</option>
+                </select>
+                <input
+                  v-if="!isUnaryFilterOperator(rule.operator)"
+                  class="meta-view-mgr__input"
+                  :type="inputTypeForField(rule.fieldId)"
+                  :value="rule.value ?? ''"
+                  @change="updateFilterValue(idx, ($event.target as HTMLInputElement).value)"
+                />
+                <span v-else class="meta-view-mgr__rule-empty">no value</span>
+                <button class="meta-view-mgr__action meta-view-mgr__action--danger" @click="removeFilterRule(idx)">&times;</button>
+              </div>
+            </div>
+            <button v-if="configTargetFields.length" class="meta-view-mgr__btn-inline" @click="addFilterRule">+ Add filter</button>
+          </div>
+
+          <div class="meta-view-mgr__field">
+            <div class="meta-view-mgr__subheader">
+              <span>Sorts</span>
+            </div>
+            <div v-if="sortDraft.rules.length" class="meta-view-mgr__rules">
+              <div
+                v-for="(rule, idx) in sortDraft.rules"
+                :key="idx"
+                class="meta-view-mgr__rule-row"
+              >
+                <select
+                  :value="rule.fieldId"
+                  class="meta-view-mgr__select"
+                  @change="updateSortField(idx, ($event.target as HTMLSelectElement).value)"
+                >
+                  <option v-for="field in configTargetFields" :key="field.id" :value="field.id">{{ field.name }}</option>
+                </select>
+                <select
+                  :value="rule.direction"
+                  class="meta-view-mgr__select"
+                  @change="updateSortDirection(idx, ($event.target as HTMLSelectElement).value as 'asc' | 'desc')"
+                >
+                  <option value="asc">A to Z</option>
+                  <option value="desc">Z to A</option>
+                </select>
+                <button class="meta-view-mgr__action meta-view-mgr__action--danger" @click="removeSortRule(idx)">&times;</button>
+              </div>
+            </div>
+            <button v-if="configTargetFields.length" class="meta-view-mgr__btn-inline" @click="addSortRule">+ Add sort</button>
+          </div>
+
+          <label v-if="configTarget.type !== 'kanban' && configTarget.type !== 'gantt'" class="meta-view-mgr__field">
+            <span>Group field</span>
+            <select v-model="groupDraft.fieldId" class="meta-view-mgr__select">
+              <option value="">None</option>
+              <option v-for="field in groupableFields" :key="field.id" :value="field.id">{{ field.name }}</option>
+            </select>
+          </label>
         </div>
 
         <div class="meta-view-mgr__config-actions">
@@ -246,20 +390,28 @@ import type {
   ConditionalFormattingRule,
   MetaCalendarViewConfig,
   MetaField,
+  MetaGanttViewConfig,
   MetaGalleryViewConfig,
   MetaKanbanViewConfig,
   MetaTimelineViewConfig,
   MetaView,
 } from '../types'
 import {
+  FILTER_OPERATORS_BY_TYPE,
+  type FilterConjunction,
+  type FilterRule,
+  type SortRule,
+} from '../composables/useMultitableGrid'
+import {
   resolveCalendarViewConfig,
+  resolveGanttViewConfig,
   resolveGalleryViewConfig,
   resolveKanbanViewConfig,
   resolveTimelineViewConfig,
 } from '../utils/view-config'
 import ConditionalFormattingDialog from './ConditionalFormattingDialog.vue'
 
-const VIEW_TYPES = ['grid', 'form', 'kanban', 'gallery', 'calendar', 'timeline'] as const
+const VIEW_TYPES = ['grid', 'form', 'kanban', 'gallery', 'calendar', 'timeline', 'gantt'] as const
 const VIEW_ICONS: Record<string, string> = {
   grid: '\u2637',
   form: '\u2263',
@@ -267,6 +419,7 @@ const VIEW_ICONS: Record<string, string> = {
   gallery: '\u25A6',
   calendar: '\u2339',
   timeline: '\u2500',
+  gantt: '\u25AC',
 }
 
 const props = defineProps<{
@@ -283,6 +436,8 @@ const emit = defineEmits<{
   (e: 'update-view', viewId: string, input: {
     name?: string
     config?: Record<string, unknown>
+    filterInfo?: Record<string, unknown>
+    sortInfo?: Record<string, unknown>
     groupInfo?: Record<string, unknown>
   }): void
   (e: 'delete-view', viewId: string): void
@@ -320,6 +475,24 @@ const timelineDraft = reactive<Required<MetaTimelineViewConfig>>({
   labelFieldId: null,
   zoom: 'week',
 })
+const ganttDraft = reactive<Required<MetaGanttViewConfig>>({
+  startFieldId: null,
+  endFieldId: null,
+  titleFieldId: null,
+  progressFieldId: null,
+  groupFieldId: null,
+  zoom: 'week',
+})
+const filterDraft = reactive<{ conjunction: FilterConjunction; conditions: FilterRule[] }>({
+  conjunction: 'and',
+  conditions: [],
+})
+const sortDraft = reactive<{ rules: SortRule[] }>({
+  rules: [],
+})
+const groupDraft = reactive<{ fieldId: string }>({
+  fieldId: '',
+})
 const viewConfigBaseline = ref('')
 const viewConfigOutdated = ref(false)
 const viewConfigLiveRefreshText = ref('')
@@ -336,14 +509,17 @@ const configTargetFields = computed(() => props.fields)
 const attachmentFields = computed(() => props.fields.filter((field) => field.type === 'attachment'))
 const dateFields = computed(() => props.fields.filter((field) => field.type === 'date'))
 const dateLikeFields = computed(() => props.fields.filter((field) => field.type === 'date' || field.type === 'string' || field.type === 'number'))
+const numericFields = computed(() => props.fields.filter((field) => ['number', 'currency', 'percent', 'rating'].includes(field.type)))
 const selectFields = computed(() => props.fields.filter((field) => field.type === 'select'))
 const stringFields = computed(() => props.fields.filter((field) => ['string', 'formula', 'lookup'].includes(field.type)))
+const groupableFields = computed(() => props.fields.filter((field) => ['select', 'string', 'boolean', 'number', 'date'].includes(field.type)))
 const validFieldIds = computed(() => new Set(props.fields.map((field) => field.id)))
 const validStringFieldIds = computed(() => new Set(stringFields.value.map((field) => field.id)))
 const validAttachmentFieldIds = computed(() => new Set(attachmentFields.value.map((field) => field.id)))
 const validDateFieldIds = computed(() => new Set(dateFields.value.map((field) => field.id)))
 const validDateLikeFieldIds = computed(() => new Set(dateLikeFields.value.map((field) => field.id)))
 const validSelectFieldIds = computed(() => new Set(selectFields.value.map((field) => field.id)))
+const validGroupableFieldIds = computed(() => new Set(groupableFields.value.map((field) => field.id)))
 
 const viewConfigBlockingReason = computed(() => {
   const target = configTarget.value
@@ -385,6 +561,24 @@ const viewConfigBlockingReason = computed(() => {
     }
   }
 
+  if (target.type === 'gantt') {
+    if (ganttDraft.startFieldId && !validDateFieldIds.value.has(ganttDraft.startFieldId)) {
+      return 'The selected start field is no longer a date field. Reload latest before saving.'
+    }
+    if (ganttDraft.endFieldId && !validDateFieldIds.value.has(ganttDraft.endFieldId)) {
+      return 'The selected end field is no longer a date field. Reload latest before saving.'
+    }
+    if (ganttDraft.titleFieldId && !validFieldIds.value.has(ganttDraft.titleFieldId)) {
+      return 'The selected title field disappeared in the background. Reload latest before saving.'
+    }
+    if (ganttDraft.progressFieldId && !numericFields.value.some((field) => field.id === ganttDraft.progressFieldId)) {
+      return 'The selected progress field is no longer numeric. Reload latest before saving.'
+    }
+    if (ganttDraft.groupFieldId && !validGroupableFieldIds.value.has(ganttDraft.groupFieldId)) {
+      return 'The selected Gantt group field is no longer groupable. Reload latest before saving.'
+    }
+  }
+
   if (target.type === 'kanban') {
     if (kanbanDraft.groupFieldId && !validSelectFieldIds.value.has(kanbanDraft.groupFieldId)) {
       return 'The selected group field is no longer a select field. Reload latest before saving.'
@@ -392,6 +586,16 @@ const viewConfigBlockingReason = computed(() => {
     if (kanbanDraft.cardFieldIds.some((fieldId) => !validFieldIds.value.has(fieldId))) {
       return 'One or more selected card fields disappeared in the background. Reload latest before saving.'
     }
+  }
+
+  if (filterDraft.conditions.some((condition) => condition.fieldId && !validFieldIds.value.has(condition.fieldId))) {
+    return 'One or more selected filter fields disappeared in the background. Reload latest before saving.'
+  }
+  if (sortDraft.rules.some((rule) => rule.fieldId && !validFieldIds.value.has(rule.fieldId))) {
+    return 'One or more selected sort fields disappeared in the background. Reload latest before saving.'
+  }
+  if (target.type !== 'kanban' && target.type !== 'gantt' && groupDraft.fieldId && !validGroupableFieldIds.value.has(groupDraft.fieldId)) {
+    return 'The selected group field is no longer groupable. Reload latest before saving.'
   }
 
   return ''
@@ -426,6 +630,18 @@ function resetConfigDrafts() {
     labelFieldId: null,
     zoom: 'week',
   } satisfies Required<MetaTimelineViewConfig>)
+  Object.assign(ganttDraft, {
+    startFieldId: null,
+    endFieldId: null,
+    titleFieldId: null,
+    progressFieldId: null,
+    groupFieldId: null,
+    zoom: 'week',
+  } satisfies Required<MetaGanttViewConfig>)
+  filterDraft.conjunction = 'and'
+  filterDraft.conditions.splice(0)
+  sortDraft.rules.splice(0)
+  groupDraft.fieldId = ''
 }
 
 function resetTransientState() {
@@ -492,6 +708,63 @@ function openConfig(view: MetaView) {
   hydrateExistingViewConfig(view)
 }
 
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {}
+}
+
+function hasPayload(value: Record<string, unknown> | null | undefined): boolean {
+  return Boolean(value && Object.keys(value).length > 0)
+}
+
+function hydrateCommonViewRules(view: MetaView) {
+  const filterInfo = asRecord(view.filterInfo)
+  const conditions = Array.isArray(filterInfo.conditions) ? filterInfo.conditions : []
+  filterDraft.conjunction = filterInfo.conjunction === 'or' ? 'or' : 'and'
+  filterDraft.conditions.splice(0, filterDraft.conditions.length, ...conditions
+    .filter((item): item is Record<string, unknown> => !!item && typeof item === 'object' && !Array.isArray(item))
+    .map((item) => ({
+      fieldId: String(item.fieldId ?? ''),
+      operator: String(item.operator ?? 'is'),
+      value: item.value,
+    }))
+    .filter((item) => item.fieldId))
+
+  const sortInfo = asRecord(view.sortInfo)
+  const sortRules = Array.isArray(sortInfo.rules) ? sortInfo.rules : []
+  sortDraft.rules.splice(0, sortDraft.rules.length, ...sortRules
+    .filter((item): item is Record<string, unknown> => !!item && typeof item === 'object' && !Array.isArray(item))
+    .map((item) => ({
+      fieldId: String(item.fieldId ?? ''),
+      direction: item.desc === true ? 'desc' as const : 'asc' as const,
+    }))
+    .filter((item) => item.fieldId))
+
+  const groupInfo = asRecord(view.groupInfo)
+  groupDraft.fieldId = typeof groupInfo.fieldId === 'string' ? groupInfo.fieldId : ''
+}
+
+function serializeCommonViewDraft(type: MetaView['type'] | null): Record<string, unknown> {
+  return {
+    filterInfo: filterDraft.conditions.map((condition) => ({
+      fieldId: condition.fieldId,
+      operator: condition.operator,
+      value: condition.value,
+    })),
+    filterConjunction: filterDraft.conjunction,
+    sortInfo: sortDraft.rules.map((rule) => ({
+      fieldId: rule.fieldId,
+      direction: rule.direction,
+    })),
+    groupInfo: type === 'kanban'
+      ? kanbanDraft.groupFieldId
+      : type === 'gantt'
+        ? ganttDraft.groupFieldId
+        : groupDraft.fieldId,
+  }
+}
+
 function serializeViewDraft(type: MetaView['type'] | null): string {
   if (type === 'gallery') {
     return JSON.stringify({
@@ -500,6 +773,7 @@ function serializeViewDraft(type: MetaView['type'] | null): string {
       fieldIds: [...galleryDraft.fieldIds],
       columns: galleryDraft.columns,
       cardSize: galleryDraft.cardSize,
+      ...serializeCommonViewDraft(type),
     })
   }
   if (type === 'calendar') {
@@ -509,6 +783,7 @@ function serializeViewDraft(type: MetaView['type'] | null): string {
       titleFieldId: calendarDraft.titleFieldId,
       defaultView: calendarDraft.defaultView,
       weekStartsOn: calendarDraft.weekStartsOn,
+      ...serializeCommonViewDraft(type),
     })
   }
   if (type === 'timeline') {
@@ -517,15 +792,28 @@ function serializeViewDraft(type: MetaView['type'] | null): string {
       endFieldId: timelineDraft.endFieldId,
       labelFieldId: timelineDraft.labelFieldId,
       zoom: timelineDraft.zoom,
+      ...serializeCommonViewDraft(type),
+    })
+  }
+  if (type === 'gantt') {
+    return JSON.stringify({
+      startFieldId: ganttDraft.startFieldId,
+      endFieldId: ganttDraft.endFieldId,
+      titleFieldId: ganttDraft.titleFieldId,
+      progressFieldId: ganttDraft.progressFieldId,
+      groupFieldId: ganttDraft.groupFieldId,
+      zoom: ganttDraft.zoom,
+      ...serializeCommonViewDraft(type),
     })
   }
   if (type === 'kanban') {
     return JSON.stringify({
       groupFieldId: kanbanDraft.groupFieldId,
       cardFieldIds: [...kanbanDraft.cardFieldIds],
+      ...serializeCommonViewDraft(type),
     })
   }
-  return ''
+  return JSON.stringify(serializeCommonViewDraft(type))
 }
 
 function serializeViewSourceSignature(view: MetaView | null): string {
@@ -535,6 +823,8 @@ function serializeViewSourceSignature(view: MetaView | null): string {
     name: view.name,
     type: view.type,
     config: view.config ?? null,
+    filterInfo: view.filterInfo ?? null,
+    sortInfo: view.sortInfo ?? null,
     groupInfo: view.groupInfo ?? null,
     fields: props.fields.map((field) => ({
       id: field.id,
@@ -548,12 +838,15 @@ function hydrateExistingViewConfig(view: MetaView, options?: { liveRefreshText?:
   configTargetId.value = view.id
   viewConfigOutdated.value = false
   viewConfigLiveRefreshText.value = options?.liveRefreshText ?? ''
+  hydrateCommonViewRules(view)
   if (view.type === 'gallery') {
     Object.assign(galleryDraft, resolveGalleryViewConfig(props.fields, view.config))
   } else if (view.type === 'calendar') {
     Object.assign(calendarDraft, resolveCalendarViewConfig(props.fields, view.config))
   } else if (view.type === 'timeline') {
     Object.assign(timelineDraft, resolveTimelineViewConfig(props.fields, view.config))
+  } else if (view.type === 'gantt') {
+    Object.assign(ganttDraft, resolveGanttViewConfig(props.fields, view.config, view.groupInfo))
   } else if (view.type === 'kanban') {
     Object.assign(kanbanDraft, resolveKanbanViewConfig(props.fields, view.config, view.groupInfo))
   }
@@ -592,13 +885,136 @@ function preserveConditionalFormattingRules(target: MetaView, config: Record<str
   }
 }
 
+const UNARY_FILTER_OPERATORS = new Set(['isEmpty', 'isNotEmpty'])
+
+function isUnaryFilterOperator(operator: string): boolean {
+  return UNARY_FILTER_OPERATORS.has(operator)
+}
+
+function operatorsForField(fieldId: string) {
+  const fieldType = props.fields.find((field) => field.id === fieldId)?.type ?? 'string'
+  return FILTER_OPERATORS_BY_TYPE[fieldType] ?? FILTER_OPERATORS_BY_TYPE.string
+}
+
+function inputTypeForField(fieldId: string): string {
+  const fieldType = props.fields.find((field) => field.id === fieldId)?.type ?? 'string'
+  if (fieldType === 'number' || fieldType === 'currency' || fieldType === 'percent' || fieldType === 'rating') return 'number'
+  if (fieldType === 'date') return 'date'
+  return 'text'
+}
+
+function addFilterRule() {
+  const firstField = configTargetFields.value[0]
+  if (!firstField) return
+  const operator = operatorsForField(firstField.id)[0]?.value ?? 'is'
+  filterDraft.conditions.push({ fieldId: firstField.id, operator, value: isUnaryFilterOperator(operator) ? undefined : '' })
+}
+
+function updateFilterField(index: number, fieldId: string) {
+  const operator = operatorsForField(fieldId)[0]?.value ?? 'is'
+  filterDraft.conditions[index] = {
+    fieldId,
+    operator,
+    value: isUnaryFilterOperator(operator) ? undefined : '',
+  }
+}
+
+function updateFilterOperator(index: number, operator: string) {
+  const rule = filterDraft.conditions[index]
+  if (!rule) return
+  filterDraft.conditions[index] = {
+    ...rule,
+    operator,
+    value: isUnaryFilterOperator(operator) ? undefined : rule.value ?? '',
+  }
+}
+
+function updateFilterValue(index: number, value: string) {
+  const rule = filterDraft.conditions[index]
+  if (!rule) return
+  const fieldType = props.fields.find((field) => field.id === rule.fieldId)?.type ?? 'string'
+  filterDraft.conditions[index] = {
+    ...rule,
+    value: ['number', 'currency', 'percent', 'rating'].includes(fieldType) && value !== '' ? Number(value) : value,
+  }
+}
+
+function removeFilterRule(index: number) {
+  filterDraft.conditions.splice(index, 1)
+}
+
+function addSortRule() {
+  const firstField = configTargetFields.value[0]
+  if (!firstField) return
+  sortDraft.rules.push({ fieldId: firstField.id, direction: 'asc' })
+}
+
+function updateSortField(index: number, fieldId: string) {
+  const rule = sortDraft.rules[index]
+  if (!rule) return
+  sortDraft.rules[index] = { ...rule, fieldId }
+}
+
+function updateSortDirection(index: number, direction: 'asc' | 'desc') {
+  const rule = sortDraft.rules[index]
+  if (!rule) return
+  sortDraft.rules[index] = { ...rule, direction }
+}
+
+function removeSortRule(index: number) {
+  sortDraft.rules.splice(index, 1)
+}
+
+function buildFilterInfoPayload(): Record<string, unknown> {
+  const conditions = filterDraft.conditions
+    .filter((condition) => validFieldIds.value.has(condition.fieldId))
+    .map((condition) => ({
+      fieldId: condition.fieldId,
+      operator: condition.operator,
+      value: condition.value,
+    }))
+  return conditions.length > 0 ? { conjunction: filterDraft.conjunction, conditions } : {}
+}
+
+function buildSortInfoPayload(): Record<string, unknown> {
+  const rules = sortDraft.rules
+    .filter((rule) => validFieldIds.value.has(rule.fieldId))
+    .map((rule) => ({ fieldId: rule.fieldId, desc: rule.direction === 'desc' }))
+  return rules.length > 0 ? { rules } : {}
+}
+
+function buildCommonViewPayload(target: MetaView): {
+  filterInfo?: Record<string, unknown>
+  sortInfo?: Record<string, unknown>
+  groupInfo?: Record<string, unknown>
+} {
+  const filterInfo = buildFilterInfoPayload()
+  const sortInfo = buildSortInfoPayload()
+  const groupInfo = target.type === 'kanban'
+    ? undefined
+    : target.type === 'gantt'
+      ? ganttDraft.groupFieldId && validGroupableFieldIds.value.has(ganttDraft.groupFieldId)
+        ? { fieldId: ganttDraft.groupFieldId }
+        : {}
+    : groupDraft.fieldId && validGroupableFieldIds.value.has(groupDraft.fieldId)
+      ? { fieldId: groupDraft.fieldId }
+      : {}
+  return {
+    ...(hasPayload(filterInfo) || hasPayload(target.filterInfo) ? { filterInfo } : {}),
+    ...(hasPayload(sortInfo) || hasPayload(target.sortInfo) ? { sortInfo } : {}),
+    ...(groupInfo && (hasPayload(groupInfo) || hasPayload(target.groupInfo)) ? { groupInfo } : {}),
+  }
+}
+
 function saveConfig() {
   const target = configTarget.value
   if (!target || viewConfigBlockingReason.value) return
+  const commonPayload = buildCommonViewPayload(target)
 
   if (target.type === 'gallery') {
     const fieldIds = galleryDraft.fieldIds.filter((fieldId) => validFieldIds.value.has(fieldId))
     emit('update-view', target.id, {
+      ...commonPayload,
       config: preserveConditionalFormattingRules(target, {
         titleFieldId: galleryDraft.titleFieldId && validStringFieldIds.value.has(galleryDraft.titleFieldId) ? galleryDraft.titleFieldId : null,
         coverFieldId: galleryDraft.coverFieldId && validAttachmentFieldIds.value.has(galleryDraft.coverFieldId) ? galleryDraft.coverFieldId : null,
@@ -609,6 +1025,7 @@ function saveConfig() {
     })
   } else if (target.type === 'calendar') {
     emit('update-view', target.id, {
+      ...commonPayload,
       config: preserveConditionalFormattingRules(target, {
         dateFieldId: calendarDraft.dateFieldId && validDateLikeFieldIds.value.has(calendarDraft.dateFieldId) ? calendarDraft.dateFieldId : null,
         endDateFieldId: calendarDraft.endDateFieldId && validDateLikeFieldIds.value.has(calendarDraft.endDateFieldId) ? calendarDraft.endDateFieldId : null,
@@ -619,11 +1036,24 @@ function saveConfig() {
     })
   } else if (target.type === 'timeline') {
     emit('update-view', target.id, {
+      ...commonPayload,
       config: preserveConditionalFormattingRules(target, {
         startFieldId: timelineDraft.startFieldId && validDateFieldIds.value.has(timelineDraft.startFieldId) ? timelineDraft.startFieldId : null,
         endFieldId: timelineDraft.endFieldId && validDateFieldIds.value.has(timelineDraft.endFieldId) ? timelineDraft.endFieldId : null,
         labelFieldId: timelineDraft.labelFieldId && validFieldIds.value.has(timelineDraft.labelFieldId) ? timelineDraft.labelFieldId : null,
         zoom: timelineDraft.zoom,
+      }),
+    })
+  } else if (target.type === 'gantt') {
+    emit('update-view', target.id, {
+      ...commonPayload,
+      config: preserveConditionalFormattingRules(target, {
+        startFieldId: ganttDraft.startFieldId && validDateFieldIds.value.has(ganttDraft.startFieldId) ? ganttDraft.startFieldId : null,
+        endFieldId: ganttDraft.endFieldId && validDateFieldIds.value.has(ganttDraft.endFieldId) ? ganttDraft.endFieldId : null,
+        titleFieldId: ganttDraft.titleFieldId && validFieldIds.value.has(ganttDraft.titleFieldId) ? ganttDraft.titleFieldId : null,
+        progressFieldId: ganttDraft.progressFieldId && numericFields.value.some((field) => field.id === ganttDraft.progressFieldId) ? ganttDraft.progressFieldId : null,
+        groupFieldId: ganttDraft.groupFieldId && validGroupableFieldIds.value.has(ganttDraft.groupFieldId) ? ganttDraft.groupFieldId : null,
+        zoom: ganttDraft.zoom,
       }),
     })
   } else if (target.type === 'kanban') {
@@ -632,12 +1062,15 @@ function saveConfig() {
       : null
     const cardFieldIds = kanbanDraft.cardFieldIds.filter((fieldId) => validFieldIds.value.has(fieldId))
     emit('update-view', target.id, {
+      ...commonPayload,
       config: preserveConditionalFormattingRules(target, {
         groupFieldId,
         cardFieldIds,
       }),
       groupInfo: groupFieldId ? { fieldId: groupFieldId } : {},
     })
+  } else {
+    emit('update-view', target.id, commonPayload)
   }
 
   closeConfig()
@@ -780,12 +1213,21 @@ onBeforeUnmount(() => {
 .meta-view-mgr__warning { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 8px 10px; border: 1px solid #f3d19e; border-radius: 6px; background: #fff7e6; color: #8a5a00; font-size: 12px; }
 .meta-view-mgr__refresh { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 8px 10px; border: 1px solid #bfd6ff; border-radius: 6px; background: #eef5ff; color: #1d4ed8; font-size: 12px; }
 .meta-view-mgr__field { display: flex; flex-direction: column; gap: 4px; font-size: 12px; color: #666; }
+.meta-view-mgr__common { display: flex; flex-direction: column; gap: 12px; padding: 12px; border: 1px solid #e2e8f0; border-radius: 8px; background: #fff; }
+.meta-view-mgr__common-header { display: flex; justify-content: space-between; gap: 8px; font-size: 12px; color: #64748b; }
+.meta-view-mgr__common-header strong { color: #334155; }
+.meta-view-mgr__subheader { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.meta-view-mgr__rules { display: flex; flex-direction: column; gap: 6px; }
+.meta-view-mgr__rule-row { display: grid; grid-template-columns: 1fr 120px auto; gap: 8px; align-items: center; }
+.meta-view-mgr__rule-row--filter { grid-template-columns: 1fr 130px minmax(80px, 1fr) auto; }
+.meta-view-mgr__rule-empty { padding: 5px 10px; border: 1px dashed #cbd5e1; border-radius: 4px; color: #94a3b8; background: #f8fafc; }
 .meta-view-mgr__grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; }
 .meta-view-mgr__checks { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 6px 12px; max-height: 180px; overflow: auto; padding: 8px; border: 1px solid #e5e7eb; border-radius: 6px; background: #fff; }
 .meta-view-mgr__check { display: flex; gap: 8px; align-items: center; font-size: 12px; color: #444; }
 .meta-view-mgr__add-section { padding: 10px 16px; border-top: 1px solid #eee; }
 .meta-view-mgr__add-row { display: flex; gap: 8px; }
 .meta-view-mgr__input, .meta-view-mgr__select { width: 100%; padding: 5px 10px; border: 1px solid #ddd; border-radius: 4px; font-size: 13px; background: #fff; }
+.meta-view-mgr__select--compact { width: auto; min-width: 130px; }
 .meta-view-mgr__btn-add { padding: 5px 14px; background: #409eff; color: #fff; border: none; border-radius: 4px; cursor: pointer; font-size: 12px; }
 .meta-view-mgr__btn-add:disabled { opacity: 0.4; cursor: not-allowed; }
 .meta-view-mgr__btn-add:hover:not(:disabled) { background: #66b1ff; }

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -576,6 +576,15 @@ export interface MetaTimelineViewConfig {
   zoom?: 'day' | 'week' | 'month'
 }
 
+export interface MetaGanttViewConfig {
+  startFieldId?: string | null
+  endFieldId?: string | null
+  titleFieldId?: string | null
+  progressFieldId?: string | null
+  groupFieldId?: string | null
+  zoom?: 'day' | 'week' | 'month'
+}
+
 // --- Record-level permissions ---
 export type RecordPermissionAccessLevel = 'read' | 'write' | 'admin'
 export type RecordPermissionSubjectType = 'user' | 'role' | 'member-group'

--- a/apps/web/src/multitable/utils/formula-docs.ts
+++ b/apps/web/src/multitable/utils/formula-docs.ts
@@ -1,0 +1,164 @@
+import type { MetaField } from '../types'
+
+export interface FormulaFunctionDoc {
+  name: string
+  signature: string
+  category: 'math' | 'text' | 'logic' | 'date' | 'aggregate'
+  description: string
+  example: string
+}
+
+export interface FormulaDiagnostic {
+  severity: 'warning' | 'error'
+  message: string
+}
+
+export const FORMULA_FUNCTION_DOCS: FormulaFunctionDoc[] = [
+  {
+    name: 'SUM',
+    signature: 'SUM(number, ...)',
+    category: 'aggregate',
+    description: 'Adds numeric values together.',
+    example: '=SUM({fld_price}, {fld_tax})',
+  },
+  {
+    name: 'AVERAGE',
+    signature: 'AVERAGE(number, ...)',
+    category: 'aggregate',
+    description: 'Returns the arithmetic mean of numeric values.',
+    example: '=AVERAGE({fld_score_1}, {fld_score_2})',
+  },
+  {
+    name: 'MIN',
+    signature: 'MIN(number, ...)',
+    category: 'aggregate',
+    description: 'Returns the smallest numeric value.',
+    example: '=MIN({fld_quote_a}, {fld_quote_b})',
+  },
+  {
+    name: 'MAX',
+    signature: 'MAX(number, ...)',
+    category: 'aggregate',
+    description: 'Returns the largest numeric value.',
+    example: '=MAX({fld_quote_a}, {fld_quote_b})',
+  },
+  {
+    name: 'IF',
+    signature: 'IF(condition, value_if_true, value_if_false)',
+    category: 'logic',
+    description: 'Chooses one of two values based on a condition.',
+    example: '=IF({fld_amount} > 1000, "Large", "Small")',
+  },
+  {
+    name: 'AND',
+    signature: 'AND(condition, ...)',
+    category: 'logic',
+    description: 'Returns true only when all conditions are true.',
+    example: '=AND({fld_status} = "Open", {fld_amount} > 0)',
+  },
+  {
+    name: 'OR',
+    signature: 'OR(condition, ...)',
+    category: 'logic',
+    description: 'Returns true when any condition is true.',
+    example: '=OR({fld_status} = "Open", {fld_status} = "Pending")',
+  },
+  {
+    name: 'CONCAT',
+    signature: 'CONCAT(text, ...)',
+    category: 'text',
+    description: 'Joins text values together.',
+    example: '=CONCAT({fld_first_name}, " ", {fld_last_name})',
+  },
+  {
+    name: 'LEN',
+    signature: 'LEN(text)',
+    category: 'text',
+    description: 'Returns the length of a text value.',
+    example: '=LEN({fld_description})',
+  },
+  {
+    name: 'TODAY',
+    signature: 'TODAY()',
+    category: 'date',
+    description: 'Returns the current date.',
+    example: '=TODAY()',
+  },
+  {
+    name: 'DATEDIFF',
+    signature: 'DATEDIFF(end_date, start_date)',
+    category: 'date',
+    description: 'Returns the number of days between two dates.',
+    example: '=DATEDIFF({fld_due_date}, {fld_start_date})',
+  },
+]
+
+const FUNCTION_CALL_PATTERN = /\b([A-Z][A-Z0-9_]*)\s*\(/g
+const FIELD_REF_PATTERN = /\{([^{}]+)\}/g
+
+export function searchFormulaFunctionDocs(query: string): FormulaFunctionDoc[] {
+  const normalized = query.trim().toUpperCase()
+  if (!normalized) return FORMULA_FUNCTION_DOCS
+  return FORMULA_FUNCTION_DOCS.filter((doc) =>
+    doc.name.includes(normalized)
+    || doc.signature.toUpperCase().includes(normalized)
+    || doc.description.toUpperCase().includes(normalized),
+  )
+}
+
+export function extractFormulaFieldRefs(expression: string): string[] {
+  const refs: string[] = []
+  const seen = new Set<string>()
+  let match: RegExpExecArray | null
+  FIELD_REF_PATTERN.lastIndex = 0
+  while ((match = FIELD_REF_PATTERN.exec(expression)) !== null) {
+    const ref = match[1]?.trim()
+    if (ref && !seen.has(ref)) {
+      seen.add(ref)
+      refs.push(ref)
+    }
+  }
+  return refs
+}
+
+export function validateFormulaExpression(expression: string, fields: MetaField[]): FormulaDiagnostic[] {
+  const diagnostics: FormulaDiagnostic[] = []
+  const trimmed = expression.trim()
+  if (!trimmed) {
+    diagnostics.push({ severity: 'warning', message: 'Formula expression is empty.' })
+    return diagnostics
+  }
+
+  const openCount = (trimmed.match(/\(/g) ?? []).length
+  const closeCount = (trimmed.match(/\)/g) ?? []).length
+  if (openCount !== closeCount) {
+    diagnostics.push({ severity: 'error', message: 'Parentheses are not balanced.' })
+  }
+
+  const fieldIds = new Set(fields.map((field) => field.id))
+  const fieldNames = new Set(fields.map((field) => field.name))
+  for (const ref of extractFormulaFieldRefs(trimmed)) {
+    if (fieldIds.has(ref)) continue
+    if (fieldNames.has(ref)) {
+      diagnostics.push({
+        severity: 'warning',
+        message: `Field reference {${ref}} uses a name. Use the field chip to insert a stable {fld_xxx} token.`,
+      })
+      continue
+    }
+    diagnostics.push({ severity: 'error', message: `Unknown field reference {${ref}}.` })
+  }
+
+  const knownFunctions = new Set(FORMULA_FUNCTION_DOCS.map((doc) => doc.name))
+  let match: RegExpExecArray | null
+  FUNCTION_CALL_PATTERN.lastIndex = 0
+  while ((match = FUNCTION_CALL_PATTERN.exec(trimmed.toUpperCase())) !== null) {
+    const fn = match[1]
+    if (fn && !knownFunctions.has(fn)) {
+      diagnostics.push({ severity: 'warning', message: `${fn} is not documented in this editor yet.` })
+    }
+  }
+
+  return diagnostics
+}
+

--- a/apps/web/src/multitable/utils/view-config.ts
+++ b/apps/web/src/multitable/utils/view-config.ts
@@ -1,6 +1,7 @@
 import type {
   MetaCalendarViewConfig,
   MetaField,
+  MetaGanttViewConfig,
   MetaGalleryViewConfig,
   MetaKanbanViewConfig,
   MetaTimelineViewConfig,
@@ -115,6 +116,25 @@ export function resolveTimelineViewConfig(
     startFieldId,
     endFieldId,
     labelFieldId: stringOrNull(raw?.labelFieldId) ?? firstNonMatchingFieldId(fields, [startFieldId, endFieldId], ['string']) ?? firstFieldId(fields),
+    zoom: raw?.zoom === 'day' || raw?.zoom === 'month' ? raw.zoom : 'week',
+  }
+}
+
+export function resolveGanttViewConfig(
+  fields: MetaField[],
+  raw?: Record<string, unknown> | null,
+  groupInfo?: Record<string, unknown> | null,
+): Required<MetaGanttViewConfig> {
+  const startFieldId = stringOrNull(raw?.startFieldId) ?? firstFieldId(fields, ['date'])
+  const endFieldId = stringOrNull(raw?.endFieldId)
+    ?? firstNonMatchingFieldId(fields, [startFieldId], ['date'])
+    ?? startFieldId
+  return {
+    startFieldId,
+    endFieldId,
+    titleFieldId: stringOrNull(raw?.titleFieldId) ?? firstNonMatchingFieldId(fields, [startFieldId, endFieldId], ['string']) ?? firstFieldId(fields),
+    progressFieldId: stringOrNull(raw?.progressFieldId) ?? firstNonMatchingFieldId(fields, [startFieldId, endFieldId], ['number', 'percent']),
+    groupFieldId: stringOrNull(raw?.groupFieldId) ?? stringOrNull(groupInfo?.fieldId),
     zoom: raw?.zoom === 'day' || raw?.zoom === 'month' ? raw.zoom : 'week',
   }
 }

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -168,6 +168,16 @@
           @patch-dates="onTimelinePatchDates"
           @update-view-config="onPersistActiveViewConfig"
         />
+        <MetaGanttView
+          v-else-if="activeViewType === 'gantt'"
+          :rows="grid.rows.value" :fields="scopedAllFields" :loading="grid.loading.value"
+          :view-config="workbench.activeView.value?.config"
+          :group-info="workbench.activeView.value?.groupInfo"
+          :link-summaries="grid.linkSummaries.value" :attachment-summaries="grid.attachmentSummaries.value"
+          :can-create="caps.canCreateRecord.value"
+          @select-record="onSelectRecord" @create-record="onKanbanCreateRecord"
+          @update-view-config="onPersistActiveViewConfig"
+        />
         <MetaGridTable
           v-else
           :rows="grid.rows.value" :visible-fields="scopedGridFields" :sort-rules="grid.sortRules.value"
@@ -365,6 +375,7 @@ import MetaKanbanView from '../components/MetaKanbanView.vue'
 import MetaGalleryView from '../components/MetaGalleryView.vue'
 import MetaCalendarView from '../components/MetaCalendarView.vue'
 import MetaTimelineView from '../components/MetaTimelineView.vue'
+import MetaGanttView from '../components/MetaGanttView.vue'
 import MetaToast from '../components/MetaToast.vue'
 import MetaImportModal from '../components/MetaImportModal.vue'
 import MetaMentionPopover from '../components/MetaMentionPopover.vue'
@@ -1482,13 +1493,23 @@ async function onDeleteField(fieldId: string) {
 }
 
 // --- View management ---
-async function onCreateView(input: { sheetId: string; name: string; type: string; config?: Record<string, unknown>; groupInfo?: Record<string, unknown> }) {
+async function onCreateView(input: {
+  sheetId: string
+  name: string
+  type: string
+  config?: Record<string, unknown>
+  filterInfo?: Record<string, unknown>
+  sortInfo?: Record<string, unknown>
+  groupInfo?: Record<string, unknown>
+}) {
   try {
     const res = await workbench.client.createView({
       sheetId: input.sheetId,
       name: input.name,
       type: input.type,
       config: input.config,
+      filterInfo: input.filterInfo,
+      sortInfo: input.sortInfo,
       groupInfo: input.groupInfo,
     })
     await workbench.loadSheetMeta(workbench.activeSheetId.value)
@@ -1497,11 +1518,22 @@ async function onCreateView(input: { sheetId: string; name: string; type: string
   } catch (e: any) { showError(e.message ?? 'Failed to create view') }
 }
 
-async function onUpdateView(viewId: string, input: { name?: string; config?: Record<string, unknown>; groupInfo?: Record<string, unknown> }) {
+async function onUpdateView(viewId: string, input: {
+  name?: string
+  config?: Record<string, unknown>
+  filterInfo?: Record<string, unknown>
+  sortInfo?: Record<string, unknown>
+  groupInfo?: Record<string, unknown>
+}) {
   await updateViewInternal(viewId, input, true)
 }
 
-async function onPersistActiveViewConfig(input: { config?: Record<string, unknown>; groupInfo?: Record<string, unknown> }) {
+async function onPersistActiveViewConfig(input: {
+  config?: Record<string, unknown>
+  filterInfo?: Record<string, unknown>
+  sortInfo?: Record<string, unknown>
+  groupInfo?: Record<string, unknown>
+}) {
   const viewId = workbench.activeViewId.value
   if (!viewId) return
   await updateViewInternal(viewId, input, false)
@@ -1509,7 +1541,13 @@ async function onPersistActiveViewConfig(input: { config?: Record<string, unknow
 
 async function updateViewInternal(
   viewId: string,
-  input: { name?: string; config?: Record<string, unknown>; groupInfo?: Record<string, unknown> },
+  input: {
+    name?: string
+    config?: Record<string, unknown>
+    filterInfo?: Record<string, unknown>
+    sortInfo?: Record<string, unknown>
+    groupInfo?: Record<string, unknown>
+  },
   notify: boolean,
 ) {
   try {

--- a/apps/web/src/router/types.ts
+++ b/apps/web/src/router/types.ts
@@ -234,7 +234,7 @@ export interface AppRouteQuery {
     commentId?: string
     fieldId?: string
     openComments?: string
-    mode?: 'grid' | 'form' | 'kanban' | 'gallery' | 'calendar' | 'timeline'
+    mode?: 'grid' | 'form' | 'kanban' | 'gallery' | 'calendar' | 'timeline' | 'gantt'
     embedded?: string
     role?: 'owner' | 'editor' | 'commenter' | 'viewer'
   }

--- a/apps/web/tests/multitable-formula-editor.spec.ts
+++ b/apps/web/tests/multitable-formula-editor.spec.ts
@@ -1,0 +1,119 @@
+import { createApp, h, nextTick } from 'vue'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import MetaFieldManager from '../src/multitable/components/MetaFieldManager.vue'
+import {
+  extractFormulaFieldRefs,
+  searchFormulaFunctionDocs,
+  validateFormulaExpression,
+} from '../src/multitable/utils/formula-docs'
+
+describe('multitable formula editor', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  it('searches function docs and validates stable field-id references', () => {
+    expect(searchFormulaFunctionDocs('sum').map((doc) => doc.name)).toContain('SUM')
+    expect(extractFormulaFieldRefs('=SUM({fld_price}, {fld_tax})')).toEqual(['fld_price', 'fld_tax'])
+
+    const diagnostics = validateFormulaExpression('=SUM({Price})', [
+      { id: 'fld_price', name: 'Price', type: 'number' },
+    ])
+    expect(diagnostics).toContainEqual({
+      severity: 'warning',
+      message: 'Field reference {Price} uses a name. Use the field chip to insert a stable {fld_xxx} token.',
+    })
+
+    expect(validateFormulaExpression('=SUM({fld_missing})', [
+      { id: 'fld_price', name: 'Price', type: 'number' },
+    ])).toContainEqual({ severity: 'error', message: 'Unknown field reference {fld_missing}.' })
+  })
+
+  it('inserts backend-compatible field id tokens from field chips', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const updateSpy = vi.fn()
+
+    const app = createApp({
+      render() {
+        return h(MetaFieldManager, {
+          visible: true,
+          sheetId: 'sheet_1',
+          sheets: [],
+          fields: [
+            { id: 'fld_price', name: 'Price', type: 'number' },
+            { id: 'fld_total', name: 'Total', type: 'formula', property: { expression: '' } },
+          ],
+          onUpdateField: updateSpy,
+        })
+      },
+    })
+
+    app.mount(container)
+    await nextTick()
+
+    const configureButtons = Array.from(container.querySelectorAll('.meta-field-mgr__action[title="Configure"]')) as HTMLButtonElement[]
+    configureButtons[1]?.click()
+    await nextTick()
+
+    const priceChip = Array.from(container.querySelectorAll('.meta-field-mgr__chip'))
+      .find((button) => button.textContent === 'Price') as HTMLButtonElement | undefined
+    priceChip?.click()
+    await nextTick()
+
+    const textarea = container.querySelector('.meta-field-mgr__textarea') as HTMLTextAreaElement
+    expect(textarea.value).toBe('{fld_price}')
+
+    ;(Array.from(container.querySelectorAll('.meta-field-mgr__btn-add')) as HTMLButtonElement[])
+      .find((button) => button.textContent?.includes('Save field settings'))
+      ?.click()
+    await nextTick()
+
+    expect(updateSpy).toHaveBeenCalledWith('fld_total', {
+      property: { expression: '{fld_price}' },
+    })
+
+    app.unmount()
+  })
+
+  it('blocks saving formula expressions with unknown field references', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const updateSpy = vi.fn()
+
+    const app = createApp({
+      render() {
+        return h(MetaFieldManager, {
+          visible: true,
+          sheetId: 'sheet_1',
+          sheets: [],
+          fields: [
+            { id: 'fld_price', name: 'Price', type: 'number' },
+            { id: 'fld_total', name: 'Total', type: 'formula', property: { expression: '=SUM({fld_missing})' } },
+          ],
+          onUpdateField: updateSpy,
+        })
+      },
+    })
+
+    app.mount(container)
+    await nextTick()
+
+    const configureButtons = Array.from(container.querySelectorAll('.meta-field-mgr__action[title="Configure"]')) as HTMLButtonElement[]
+    configureButtons[1]?.click()
+    await nextTick()
+
+    expect(container.textContent).toContain('Unknown field reference {fld_missing}.')
+
+    ;(Array.from(container.querySelectorAll('.meta-field-mgr__btn-add')) as HTMLButtonElement[])
+      .find((button) => button.textContent?.includes('Save field settings'))
+      ?.click()
+    await nextTick()
+
+    expect(updateSpy).not.toHaveBeenCalled()
+
+    app.unmount()
+  })
+})
+

--- a/apps/web/tests/multitable-gantt-view.spec.ts
+++ b/apps/web/tests/multitable-gantt-view.spec.ts
@@ -1,0 +1,127 @@
+import { createApp, h, nextTick } from 'vue'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import MetaGanttView from '../src/multitable/components/MetaGanttView.vue'
+import { resolveGanttViewConfig } from '../src/multitable/utils/view-config'
+
+describe('MetaGanttView', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  it('resolves sensible defaults from date, title, progress and group fields', () => {
+    const config = resolveGanttViewConfig([
+      { id: 'fld_name', name: 'Name', type: 'string' },
+      { id: 'fld_start', name: 'Start', type: 'date' },
+      { id: 'fld_end', name: 'End', type: 'date' },
+      { id: 'fld_progress', name: 'Progress', type: 'number' },
+      { id: 'fld_status', name: 'Status', type: 'select' },
+    ])
+
+    expect(config).toEqual({
+      startFieldId: 'fld_start',
+      endFieldId: 'fld_end',
+      titleFieldId: 'fld_name',
+      progressFieldId: 'fld_progress',
+      groupFieldId: null,
+      zoom: 'week',
+    })
+  })
+
+  it('renders grouped task bars and emits record selection', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const selectSpy = vi.fn()
+
+    const app = createApp({
+      render() {
+        return h(MetaGanttView, {
+          loading: false,
+          canCreate: true,
+          fields: [
+            { id: 'fld_name', name: 'Name', type: 'string' },
+            { id: 'fld_start', name: 'Start', type: 'date' },
+            { id: 'fld_end', name: 'End', type: 'date' },
+            { id: 'fld_progress', name: 'Progress', type: 'number' },
+            { id: 'fld_status', name: 'Status', type: 'select' },
+          ],
+          rows: [
+            {
+              id: 'rec_1',
+              version: 1,
+              data: {
+                fld_name: 'Design',
+                fld_start: '2026-04-01',
+                fld_end: '2026-04-10',
+                fld_progress: 60,
+                fld_status: 'Open',
+              },
+            },
+          ],
+          viewConfig: {
+            startFieldId: 'fld_start',
+            endFieldId: 'fld_end',
+            titleFieldId: 'fld_name',
+            progressFieldId: 'fld_progress',
+            groupFieldId: 'fld_status',
+          },
+          groupInfo: { fieldId: 'fld_status' },
+          onSelectRecord: selectSpy,
+        })
+      },
+    })
+
+    app.mount(container)
+    await nextTick()
+
+    expect(container.textContent).toContain('Open')
+    expect(container.textContent).toContain('Design')
+    expect(container.querySelector('.meta-gantt__bar-progress')?.getAttribute('style')).toContain('width: 60%')
+
+    ;(container.querySelector('.meta-gantt__row') as HTMLButtonElement).click()
+    await nextTick()
+
+    expect(selectSpy).toHaveBeenCalledWith('rec_1')
+
+    app.unmount()
+  })
+
+  it('emits persisted Gantt config and groupInfo from toolbar changes', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const updateSpy = vi.fn()
+
+    const app = createApp({
+      render() {
+        return h(MetaGanttView, {
+          loading: false,
+          fields: [
+            { id: 'fld_name', name: 'Name', type: 'string' },
+            { id: 'fld_start', name: 'Start', type: 'date' },
+            { id: 'fld_end', name: 'End', type: 'date' },
+            { id: 'fld_status', name: 'Status', type: 'select' },
+          ],
+          rows: [],
+          viewConfig: { startFieldId: 'fld_start', endFieldId: 'fld_end' },
+          onUpdateViewConfig: updateSpy,
+        })
+      },
+    })
+
+    app.mount(container)
+    await nextTick()
+
+    const controls = Array.from(container.querySelectorAll('.meta-gantt__control select')) as HTMLSelectElement[]
+    const groupSelect = controls[4]
+    groupSelect.value = 'fld_status'
+    groupSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await nextTick()
+
+    expect(updateSpy).toHaveBeenCalledWith({
+      config: expect.objectContaining({ groupFieldId: 'fld_status' }),
+      groupInfo: { fieldId: 'fld_status' },
+    })
+
+    app.unmount()
+  })
+})

--- a/apps/web/tests/multitable-view-manager.spec.ts
+++ b/apps/web/tests/multitable-view-manager.spec.ts
@@ -47,7 +47,7 @@ describe('MetaViewManager', () => {
     await nextTick()
 
     const selects = Array.from(container.querySelectorAll('.meta-view-mgr__config select')) as HTMLSelectElement[]
-    expect(selects).toHaveLength(4)
+    expect(selects.length).toBeGreaterThanOrEqual(4)
     selects[2].value = 'fld_owner'
     selects[2].dispatchEvent(new Event('change', { bubbles: true }))
     selects[3].value = 'month'
@@ -743,6 +743,90 @@ describe('MetaViewManager', () => {
     expect(titleOptionsAfterReload).not.toContain('Name')
     expect(coverSelectAfterReload.value).toBe('')
     expect(container.querySelector('.meta-view-mgr__warning')).toBeNull()
+
+    app.unmount()
+  })
+
+  it('emits visual filter sort and group settings from the shared builder', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const updateSpy = vi.fn()
+
+    const app = createApp({
+      render() {
+        return h(MetaViewManager, {
+          visible: true,
+          sheetId: 'sheet_1',
+          activeViewId: 'view_grid',
+          fields: [
+            { id: 'fld_name', name: 'Name', type: 'string' },
+            { id: 'fld_status', name: 'Status', type: 'select' },
+            { id: 'fld_due', name: 'Due', type: 'date' },
+          ],
+          views: [
+            { id: 'view_grid', sheetId: 'sheet_1', name: 'Grid', type: 'grid' },
+          ],
+          onUpdateView: updateSpy,
+        })
+      },
+    })
+
+    app.mount(container)
+    await nextTick()
+
+    ;(container.querySelector('.meta-view-mgr__action[title="Configure"]') as HTMLButtonElement | null)?.click()
+    await nextTick()
+
+    ;(Array.from(container.querySelectorAll('.meta-view-mgr__btn-inline')) as HTMLButtonElement[])
+      .find((button) => button.textContent?.includes('+ Add filter'))
+      ?.click()
+    await nextTick()
+
+    const filterRow = container.querySelector('.meta-view-mgr__rule-row--filter') as HTMLElement
+    const filterSelects = Array.from(filterRow.querySelectorAll('select')) as HTMLSelectElement[]
+    filterSelects[0].value = 'fld_status'
+    filterSelects[0].dispatchEvent(new Event('change', { bubbles: true }))
+    await nextTick()
+    filterSelects[1].value = 'is'
+    filterSelects[1].dispatchEvent(new Event('change', { bubbles: true }))
+    const filterInput = filterRow.querySelector('input') as HTMLInputElement
+    filterInput.value = 'Open'
+    filterInput.dispatchEvent(new Event('change', { bubbles: true }))
+
+    ;(Array.from(container.querySelectorAll('.meta-view-mgr__btn-inline')) as HTMLButtonElement[])
+      .find((button) => button.textContent?.includes('+ Add sort'))
+      ?.click()
+    await nextTick()
+
+    const sortRow = Array.from(container.querySelectorAll('.meta-view-mgr__rule-row'))
+      .find((row) => !row.classList.contains('meta-view-mgr__rule-row--filter')) as HTMLElement
+    const sortSelects = Array.from(sortRow.querySelectorAll('select')) as HTMLSelectElement[]
+    sortSelects[0].value = 'fld_due'
+    sortSelects[0].dispatchEvent(new Event('change', { bubbles: true }))
+    sortSelects[1].value = 'desc'
+    sortSelects[1].dispatchEvent(new Event('change', { bubbles: true }))
+
+    const groupSelects = Array.from(container.querySelectorAll('.meta-view-mgr__common > label select')) as HTMLSelectElement[]
+    const groupSelect = groupSelects[groupSelects.length - 1]
+    groupSelect.value = 'fld_status'
+    groupSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await nextTick()
+
+    ;(Array.from(container.querySelectorAll('.meta-view-mgr__btn-add')) as HTMLButtonElement[])
+      .find((button) => button.textContent?.includes('Save view settings'))
+      ?.click()
+    await nextTick()
+
+    expect(updateSpy).toHaveBeenCalledWith('view_grid', {
+      filterInfo: {
+        conjunction: 'and',
+        conditions: [{ fieldId: 'fld_status', operator: 'is', value: 'Open' }],
+      },
+      sortInfo: {
+        rules: [{ fieldId: 'fld_due', desc: true }],
+      },
+      groupInfo: { fieldId: 'fld_status' },
+    })
 
     app.unmount()
   })

--- a/docs/development/wave-m-feishu-2-formula-view-gantt-development-20260429.md
+++ b/docs/development/wave-m-feishu-2-formula-view-gantt-development-20260429.md
@@ -1,0 +1,93 @@
+# Wave M-Feishu-2 Development - Formula / View Builder / Gantt
+
+Date: 2026-04-29
+
+Branch: `codex/mfeishu2-formula-view-gantt-20260429`
+
+Base after rebase: `origin/main@6a99c117d`
+
+## Scope
+
+本轮继续对标飞书多维表格，但刻意避开当前钉钉集成窗口正在修改的 public form / JWT / DingTalk 路由文件。
+
+Implemented lanes:
+
+- MF4 Formula editor: function reference, field-token insertion, expression diagnostics.
+- MF5 Visual view builder: configure `filterInfo`, `sortInfo`, and `groupInfo` from `MetaViewManager`.
+- MF6 Gantt view: frontend `gantt` view type, workbench wiring, config resolver, tests.
+
+Explicitly not touched:
+
+- `apps/web/src/multitable/components/MetaFormShareManager.vue`
+- `apps/web/src/views/PublicMultitableFormView.vue`
+- `apps/web/src/router/multitableRoute.ts`
+- `packages/core-backend/src/auth/jwt-middleware.ts`
+- public form backend tests
+- DingTalk integration files
+
+## Design
+
+### MF4 Formula Editor
+
+Before this change, formula field chips inserted `{fieldName}` tokens. Backend formula dependency tracking only recognizes stable `{fld_xxx}` field-id tokens, so formulas could look valid in the UI while dependency tracking did not fire.
+
+Changes:
+
+- Added `apps/web/src/multitable/utils/formula-docs.ts`.
+- Formula field chips now insert `{field.id}` tokens.
+- Added documented functions for `SUM`, `AVERAGE`, `MIN`, `MAX`, `IF`, `AND`, `OR`, `CONCAT`, `LEN`, `TODAY`, `DATEDIFF`.
+- Added diagnostics for empty formulas, unknown field references, name-based references, unknown functions, and unbalanced parentheses.
+- Blocking errors prevent saving; warnings remain visible but do not block.
+
+### MF5 Visual Filter / Sort / Group Builder
+
+The toolbar already supported sort/filter/group, but view management did not expose those settings when configuring a view.
+
+Changes:
+
+- `MetaViewManager` now hydrates and persists shared view rules:
+  - `filterInfo.conditions`
+  - `filterInfo.conjunction`
+  - `sortInfo.rules`
+  - `groupInfo.fieldId`
+- The builder reuses the existing `useMultitableGrid` operator vocabulary and persistence shape.
+- Empty payloads are only sent when clearing previously configured settings, avoiding unnecessary clobbering on old views.
+- `MultitableWorkbench` update/create view payload types now include `filterInfo` and `sortInfo`.
+
+### MF6 Gantt View
+
+This is a frontend unlock using the existing `meta_views` config surface. It does not introduce a separate Gantt task table or dependency graph.
+
+Changes:
+
+- Added `MetaGanttView.vue`.
+- Added `MetaGanttViewConfig` to multitable types.
+- Added `resolveGanttViewConfig()` for default start/end/title/progress/group/zoom selection.
+- Added `gantt` to `MetaViewManager` create/config UI.
+- Wired `activeViewType === 'gantt'` in `MultitableWorkbench`.
+- Added router mode type support for `gantt`.
+
+## Files
+
+Core:
+
+- `apps/web/src/multitable/components/MetaFieldManager.vue`
+- `apps/web/src/multitable/components/MetaViewManager.vue`
+- `apps/web/src/multitable/components/MetaGanttView.vue`
+- `apps/web/src/multitable/utils/formula-docs.ts`
+- `apps/web/src/multitable/utils/view-config.ts`
+- `apps/web/src/multitable/types.ts`
+- `apps/web/src/multitable/views/MultitableWorkbench.vue`
+- `apps/web/src/router/types.ts`
+
+Tests:
+
+- `apps/web/tests/multitable-formula-editor.spec.ts`
+- `apps/web/tests/multitable-gantt-view.spec.ts`
+- `apps/web/tests/multitable-view-manager.spec.ts`
+
+## Deferred
+
+- Formula runtime parity remains backend-owned. This PR improves editor correctness and dependency-token insertion, but does not add new backend formula functions.
+- Gantt dependencies, hierarchy, critical path, and drag-resize are intentionally out of scope.
+- Backend OpenAPI schemas for `gantt` can be added in a separate contract PR if needed; current REST view routes accept string view types and `meta_views.type` has no active check constraint in the canonical meta schema.

--- a/docs/development/wave-m-feishu-2-formula-view-gantt-development-20260429.md
+++ b/docs/development/wave-m-feishu-2-formula-view-gantt-development-20260429.md
@@ -4,7 +4,7 @@ Date: 2026-04-29
 
 Branch: `codex/mfeishu2-formula-view-gantt-20260429`
 
-Base after rebase: `origin/main@6a99c117d`
+Base after final rebase: `origin/main@0635dc2a8`
 
 ## Scope
 
@@ -88,6 +88,6 @@ Tests:
 
 ## Deferred
 
-- Formula runtime parity remains backend-owned. This PR improves editor correctness and dependency-token insertion, but does not add new backend formula functions.
+- Formula runtime parity remains backend-owned. The companion #1228 backend PR adds the `DATEDIFF` runtime alias; this PR stays frontend-only for formula editing, view building, and Gantt rendering.
 - Gantt dependencies, hierarchy, critical path, and drag-resize are intentionally out of scope.
 - Backend OpenAPI schemas for `gantt` can be added in a separate contract PR if needed; current REST view routes accept string view types and `meta_views.type` has no active check constraint in the canonical meta schema.

--- a/docs/development/wave-m-feishu-2-formula-view-gantt-verification-20260429.md
+++ b/docs/development/wave-m-feishu-2-formula-view-gantt-verification-20260429.md
@@ -1,0 +1,88 @@
+# Wave M-Feishu-2 Verification - Formula / View Builder / Gantt
+
+Date: 2026-04-29
+
+Branch: `codex/mfeishu2-formula-view-gantt-20260429`
+
+Base after rebase: `origin/main@6a99c117d`
+
+## Automated Verification
+
+### Focused Frontend Specs
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/multitable-formula-editor.spec.ts \
+  tests/multitable-view-manager.spec.ts \
+  tests/multitable-gantt-view.spec.ts \
+  --reporter=verbose
+```
+
+Result:
+
+```text
+Test Files  3 passed (3)
+Tests       19 passed (19)
+```
+
+Covered:
+
+- Formula docs search and diagnostics.
+- Formula field chips insert backend-compatible `{fld_xxx}` tokens.
+- Formula save blocks unknown field references.
+- View manager still persists timeline config and preserves conditional formatting.
+- View manager persists visual filter / sort / group settings.
+- Gantt resolver chooses sensible defaults.
+- Gantt renders grouped task bars and emits record selection.
+- Gantt toolbar emits persisted config and `groupInfo`.
+
+### Frontend Type Check
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+```
+
+Result:
+
+```text
+EXIT 0
+```
+
+### Diff Hygiene
+
+Command:
+
+```bash
+git diff --check
+```
+
+Result:
+
+```text
+EXIT 0
+```
+
+## Manual Staging Checklist
+
+After deployment, verify the following in a normal multitable sheet:
+
+1. Create or edit a formula field.
+2. Click a source field chip and confirm the expression uses `{fld_xxx}`, not `{Field Name}`.
+3. Search a function such as `SUM` or `IF`; click the function card and confirm a snippet is inserted.
+4. Save a formula with an unknown `{fld_missing}` reference and confirm the UI blocks save.
+5. Open `Views -> Configure` for a grid view.
+6. Add a filter, sort, and group rule; save; reload; confirm the settings hydrate back.
+7. Create a `gantt` view.
+8. Select start/end/title/progress/group fields and confirm task bars render.
+9. Click a Gantt task and confirm the record drawer opens.
+
+## Known Limits
+
+- Gantt is a frontend record visualization, not a full project-management engine.
+- Gantt does not support dependencies, hierarchy, critical path, drag-resize, or baseline tracking yet.
+- Formula docs are editor-side guidance only; unsupported backend functions still require backend formula-engine work.
+- View builder shares existing sort/filter operator semantics. It does not add nested filter groups.

--- a/docs/development/wave-m-feishu-2-formula-view-gantt-verification-20260429.md
+++ b/docs/development/wave-m-feishu-2-formula-view-gantt-verification-20260429.md
@@ -4,7 +4,7 @@ Date: 2026-04-29
 
 Branch: `codex/mfeishu2-formula-view-gantt-20260429`
 
-Base after rebase: `origin/main@6a99c117d`
+Base after final rebase: `origin/main@0635dc2a8`
 
 ## Automated Verification
 
@@ -66,6 +66,18 @@ Result:
 EXIT 0
 ```
 
+### Final Rebase Verification
+
+After #1228 (`fix(formula): add DATEDIFF runtime alias`) merged to main, this branch was rebased onto `origin/main@0635dc2a8` and the same focused gate was rerun.
+
+Result:
+
+```text
+Focused frontend specs: 3 files / 19 tests passed
+Frontend type check:    EXIT 0
+Diff hygiene:           EXIT 0
+```
+
 ## Manual Staging Checklist
 
 After deployment, verify the following in a normal multitable sheet:
@@ -84,5 +96,5 @@ After deployment, verify the following in a normal multitable sheet:
 
 - Gantt is a frontend record visualization, not a full project-management engine.
 - Gantt does not support dependencies, hierarchy, critical path, drag-resize, or baseline tracking yet.
-- Formula docs are editor-side guidance only; unsupported backend functions still require backend formula-engine work.
+- Formula docs are editor-side guidance for the frontend editor. `DATEDIFF` runtime support is covered by companion #1228; other newly documented functions should stay aligned with backend formula-engine support before being exposed.
 - View builder shares existing sort/filter operator semantics. It does not add nested filter groups.


### PR DESCRIPTION
## Summary

Wave M-Feishu-2 frontend delivery for multitable Feishu parity:

- MF4 Formula editor: function reference, expression diagnostics, and stable `{fld_xxx}` field-token insertion.
- MF5 Visual view builder: configure `filterInfo`, `sortInfo`, and `groupInfo` from `MetaViewManager` using the existing grid persistence shapes.
- MF6 Gantt view: frontend `gantt` view type, resolver, workbench wiring, router mode type, and focused tests.

## Design Notes

- Avoids the active DingTalk/public-form/JWT integration surface.
- Formula field chips now insert backend-compatible field IDs instead of display names, matching `MultitableFormulaEngine` dependency tracking.
- Gantt is intentionally a record visualization over existing `meta_views.config`; no new task table, dependency graph, or backend route is introduced.

Design MD:

- `docs/development/wave-m-feishu-2-formula-view-gantt-development-20260429.md`

Verification MD:

- `docs/development/wave-m-feishu-2-formula-view-gantt-verification-20260429.md`

## Verification

```bash
pnpm --filter @metasheet/web exec vitest run \
  tests/multitable-formula-editor.spec.ts \
  tests/multitable-view-manager.spec.ts \
  tests/multitable-gantt-view.spec.ts \
  --reporter=verbose
```

Result: 3 files / 19 tests passed.

```bash
pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
```

Result: EXIT 0.

```bash
git diff --check
```

Result: EXIT 0.
