### PR TITLE
fix(formula): add DATEDIFF runtime alias

### DIFF
--- a/docs/development/wave-m-feishu-2-formula-runtime-parity-design-20260429.md
+++ b/docs/development/wave-m-feishu-2-formula-runtime-parity-design-20260429.md
@@ -1,0 +1,53 @@
+# Wave M-Feishu-2 Formula Runtime Parity Design
+
+Date: 2026-04-29
+
+Branch: `codex/mfeishu2-formula-runtime-parity-20260429`
+
+Base: `origin/main@6a99c117d`
+
+Related PR: #1227 (`feat(multitable): add formula editor view builder and gantt view`)
+
+## Context
+
+#1227 exposes formula editor guidance for common Feishu-style functions. Backend formula runtime already supports almost all functions listed in that editor:
+
+- `SUM`
+- `AVERAGE`
+- `MIN`
+- `MAX`
+- `IF`
+- `AND`
+- `OR`
+- `CONCAT`
+- `LEN`
+- `TODAY`
+
+The only mismatch found during parallel review was `DATEDIFF`. The backend had Excel-style `DATEDIF(start, end, unit)` but no `DATEDIFF(end, start)` alias, while the editor docs expose `DATEDIFF(end_date, start_date)`.
+
+## Change
+
+Add `DATEDIFF` as a narrow alias in `FormulaEngine`:
+
+- Signature: `DATEDIFF(endDate, startDate)`
+- Semantics: day difference only
+- Implementation: delegates to existing `datedif(startDate, endDate, 'D')`
+
+This keeps runtime behavior conservative:
+
+- No parser rewrite.
+- No new date unit syntax.
+- Existing `DATEDIF` behavior remains unchanged.
+- Existing formulas remain backwards compatible.
+
+## Files
+
+- `packages/core-backend/src/formula/engine.ts`
+- `packages/core-backend/tests/unit/multitable-formula-engine.test.ts`
+
+## Deferred
+
+- Full Feishu/Airtable formula parity is still out of scope.
+- Rich date functions such as `DATEADD`, `WORKDAY`, `NETWORKDAYS`, and locale-aware formatting should be separate formula-runtime slices.
+- Formula editor autocomplete can later read a shared manifest instead of duplicating frontend docs and backend registrations.
+

--- a/docs/development/wave-m-feishu-2-formula-runtime-parity-verification-20260429.md
+++ b/docs/development/wave-m-feishu-2-formula-runtime-parity-verification-20260429.md
@@ -1,0 +1,55 @@
+# Wave M-Feishu-2 Formula Runtime Parity Verification
+
+Date: 2026-04-29
+
+Branch: `codex/mfeishu2-formula-runtime-parity-20260429`
+
+Base: `origin/main@6a99c117d`
+
+## Automated Verification
+
+### Focused Formula Runtime Spec
+
+Command:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/multitable-formula-engine.test.ts \
+  --reporter=verbose
+```
+
+Result:
+
+```text
+Test Files  1 passed (1)
+Tests       22 passed (22)
+```
+
+Coverage added:
+
+- `DATEDIFF("2024-01-31","2024-01-01") -> 30`
+- invalid `DATEDIFF` dates return `#VALUE!`
+
+Regression covered:
+
+- Existing `DATEDIF` day/month/year cases still pass.
+- Existing `CONCAT`, `COUNTA`, `SWITCH`, field reference extraction, field evaluation, lookup, and formula recalc tests still pass.
+
+### Backend Type Check
+
+Command:
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+```
+
+Result:
+
+```text
+EXIT 0
+```
+
+## Risk
+
+Low. `DATEDIFF` is an additive function registration that delegates to existing `DATEDIF`; it does not alter parser or existing function behavior.
+

--- a/packages/core-backend/src/formula/engine.ts
+++ b/packages/core-backend/src/formula/engine.ts
@@ -203,6 +203,7 @@ export class FormulaEngine {
     this.functions.set('SWITCH', this.switchFunction.bind(this))
     this.functions.set('CONCAT', this.concatenate.bind(this))
     this.functions.set('DATEDIF', this.datedif.bind(this))
+    this.functions.set('DATEDIFF', this.datediff.bind(this))
     this.functions.set('COUNTA', this.counta.bind(this))
   }
 
@@ -722,6 +723,10 @@ export class FormulaEngine {
       default:
         return '#VALUE!'
     }
+  }
+
+  private datediff(endDate: unknown, startDate: unknown): number | string {
+    return this.datedif(startDate, endDate, 'D')
   }
 
   private counta(...args: unknown[]): number {

--- a/packages/core-backend/tests/unit/multitable-formula-engine.test.ts
+++ b/packages/core-backend/tests/unit/multitable-formula-engine.test.ts
@@ -84,6 +84,18 @@ describe('FormulaEngine - new functions', () => {
     })
   })
 
+  describe('DATEDIFF', () => {
+    it('calculates day difference using end date then start date', async () => {
+      const result = await engine.calculate('=DATEDIFF("2024-01-31","2024-01-01")', makeContext())
+      expect(result).toBe(30)
+    })
+
+    it('returns #VALUE! for invalid dates', async () => {
+      const result = await engine.calculate('=DATEDIFF("not-a-date","2024-01-01")', makeContext())
+      expect(result).toBe('#VALUE!')
+    })
+  })
+
   describe('COUNTA', () => {
     it('counts non-empty values', async () => {
       const result = await engine.calculate('=COUNTA("a","b","",NULL)', makeContext())


### PR DESCRIPTION
## Summary

Runtime companion for #1227's formula editor docs.

#1227 exposes `DATEDIFF(end_date, start_date)` in the editor reference. Backend formula runtime already supported the other listed functions, but only had Excel-style `DATEDIF(start, end, unit)`. This PR adds a narrow `DATEDIFF(endDate, startDate)` alias that delegates to existing `DATEDIF(startDate, endDate, 'D')`.

## Design Notes

- Additive function registration only.
- No parser rewrite.
- Existing `DATEDIF` behavior remains unchanged.
- `DATEDIFF` is day-difference only by design.

Design MD:

- `docs/development/wave-m-feishu-2-formula-runtime-parity-design-20260429.md`

Verification MD:

- `docs/development/wave-m-feishu-2-formula-runtime-parity-verification-20260429.md`

## Verification

```bash
pnpm --filter @metasheet/core-backend exec vitest run \
  tests/unit/multitable-formula-engine.test.ts \
  --reporter=verbose
```

Result: 1 file / 22 tests passed.

```bash
pnpm --filter @metasheet/core-backend exec tsc --noEmit
```

Result: EXIT 0.

```bash
git diff --check
```

Result: EXIT 0.
