### PR TITLE
test(integration): probe K3 WISE control plane smoke

### DIFF
--- a/docs/development/integration-k3wise-postdeploy-control-plane-smoke-design-20260429.md
+++ b/docs/development/integration-k3wise-postdeploy-control-plane-smoke-design-20260429.md
@@ -1,0 +1,40 @@
+# K3 WISE Postdeploy Control Plane Smoke Design
+
+## Context
+
+The authenticated postdeploy smoke already checked `/api/auth/me`,
+`/api/integration/status`, and staging descriptors. That proved the integration
+plugin registered the expected adapters and routes, but it did not actually hit
+the DB-backed read-only control plane list endpoints.
+
+This left a gap: `/api/integration/status` could pass while a migration,
+tenant-scope, or service-wiring issue made `external-systems`, `pipelines`,
+`runs`, or `dead-letters` return 500 in the deployed instance.
+
+## Change
+
+`scripts/ops/integration-k3wise-postdeploy-smoke.mjs` now adds four authenticated,
+read-only probes when a bearer token is supplied:
+
+- `GET /api/integration/external-systems`
+- `GET /api/integration/pipelines`
+- `GET /api/integration/runs`
+- `GET /api/integration/dead-letters`
+
+Each probe expects HTTP 200 and array-shaped `data`.
+
+Tenant scoping is handled conservatively:
+
+- `--tenant-id <id>` or `METASHEET_TENANT_ID` can provide an explicit tenant.
+- Otherwise the smoke derives `tenantId` from `/api/auth/me` if present.
+- If neither exists, the probe still runs without a tenant query and the deployed
+  API decides whether that token has enough tenant context.
+
+## Safety
+
+The new probes are GET-only. They do not create external systems, pipelines,
+runs, dead letters, staging tables, PLM records, K3 WISE documents, or SQL Server
+rows.
+
+Public-only smoke behavior is unchanged: without a token, authenticated checks
+remain skipped unless `--require-auth` is supplied.

--- a/docs/development/integration-k3wise-postdeploy-control-plane-smoke-verification-20260429.md
+++ b/docs/development/integration-k3wise-postdeploy-control-plane-smoke-verification-20260429.md
@@ -1,0 +1,26 @@
+# K3 WISE Postdeploy Control Plane Smoke Verification
+
+## Commands
+
+```bash
+node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
+node --test scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
+node --check scripts/ops/integration-k3wise-postdeploy-smoke.mjs
+git diff --check
+```
+
+## Expected Result
+
+- Existing public-only smoke cases still pass.
+- Authenticated smoke now calls the four read-only control plane list endpoints.
+- A failing control-plane list endpoint makes the smoke exit non-zero and records
+  a specific failed check in the evidence JSON.
+- Smoke evidence does not leak the bearer token in stdout, stderr, or JSON.
+
+## Customer Impact
+
+This does not depend on the K3 WISE customer GATE packet and does not contact
+customer PLM, K3 WISE, SQL Server, or middleware.
+
+It only strengthens what our own deployed MetaSheet instance proves after a token
+is available.

--- a/scripts/ops/integration-k3wise-postdeploy-smoke.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-smoke.mjs
@@ -20,6 +20,12 @@ const REQUIRED_ROUTES = [
   ['GET', '/api/integration/staging/descriptors'],
   ['POST', '/api/integration/staging/install'],
 ]
+const CONTROL_PLANE_LIST_PROBES = [
+  ['integration-list-external-systems', '/api/integration/external-systems'],
+  ['integration-list-pipelines', '/api/integration/pipelines'],
+  ['integration-list-runs', '/api/integration/runs'],
+  ['integration-list-dead-letters', '/api/integration/dead-letters'],
+]
 const TOKEN_PATTERN = /([A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{16,}|Bearer\s+[A-Za-z0-9._-]{16,})/g
 
 class K3WisePostdeploySmokeError extends Error {
@@ -41,6 +47,7 @@ Options:
   --base-url <url>       MetaSheet base URL, default ${DEFAULT_BASE_URL}
   --auth-token <token>   Optional bearer token for authenticated checks
   --token-file <path>    Optional file containing bearer token
+  --tenant-id <id>       Optional tenant scope for authenticated list probes
   --require-auth         Fail when no token is supplied or auth checks are skipped
   --out-dir <dir>        Output directory, default ${DEFAULT_OUTPUT_ROOT}/<timestamp>
   --timeout-ms <ms>      Per-request timeout, default 10000
@@ -50,6 +57,7 @@ Environment fallbacks:
   METASHEET_BASE_URL, PUBLIC_APP_URL
   METASHEET_AUTH_TOKEN, ADMIN_TOKEN, AUTH_TOKEN
   METASHEET_AUTH_TOKEN_FILE, AUTH_TOKEN_FILE
+  METASHEET_TENANT_ID, TENANT_ID
 `)
 }
 
@@ -74,6 +82,7 @@ function parseArgs(argv = process.argv.slice(2)) {
     baseUrl: envValue('METASHEET_BASE_URL', 'PUBLIC_APP_URL') || DEFAULT_BASE_URL,
     authToken: envValue('METASHEET_AUTH_TOKEN', 'ADMIN_TOKEN', 'AUTH_TOKEN'),
     tokenFile: envValue('METASHEET_AUTH_TOKEN_FILE', 'AUTH_TOKEN_FILE'),
+    tenantId: envValue('METASHEET_TENANT_ID', 'TENANT_ID'),
     requireAuth: false,
     outDir: '',
     timeoutMs: 10_000,
@@ -93,6 +102,10 @@ function parseArgs(argv = process.argv.slice(2)) {
         break
       case '--token-file':
         opts.tokenFile = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--tenant-id':
+        opts.tenantId = readRequiredValue(argv, i, arg)
         i += 1
         break
       case '--require-auth':
@@ -199,6 +212,15 @@ async function requestJson(baseUrl, pathname, { token = '', timeoutMs = 10_000, 
   return { status: response.status, body: sanitizeBody(body) }
 }
 
+function withQuery(pathname, query = {}) {
+  const params = new URLSearchParams()
+  for (const [key, value] of Object.entries(query)) {
+    if (value !== undefined && value !== null && value !== '') params.set(key, String(value))
+  }
+  const search = params.toString()
+  return search ? `${pathname}?${search}` : pathname
+}
+
 async function requestText(baseUrl, pathname, { timeoutMs = 10_000 } = {}) {
   const response = await fetchWithTimeout(`${baseUrl}${pathname}`, {
     headers: { Accept: 'text/html,application/xhtml+xml' },
@@ -262,6 +284,29 @@ function assertStagingDescriptors(body) {
   return { descriptors: ids }
 }
 
+function assertListResponse(body, probeId) {
+  const data = body && body.data !== undefined ? body.data : body
+  if (!Array.isArray(data)) {
+    throw new K3WisePostdeploySmokeError(`${probeId} response data must be an array`, {
+      received: Array.isArray(data) ? 'array' : typeof data,
+    })
+  }
+  return { rows: data.length }
+}
+
+function extractTenantId(authBody) {
+  const candidates = [
+    authBody?.tenantId,
+    authBody?.user?.tenantId,
+    authBody?.data?.tenantId,
+    authBody?.data?.user?.tenantId,
+  ]
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.trim()) return candidate.trim()
+  }
+  return ''
+}
+
 async function runSmoke(opts) {
   const token = await readToken(opts)
   const checks = []
@@ -323,12 +368,15 @@ async function runSmoke(opts) {
     })
     checks.push(skipped)
   } else {
+    let tenantId = opts.tenantId
     try {
       const me = await requestJson(opts.baseUrl, '/api/auth/me', { token, timeoutMs: opts.timeoutMs })
       const user = me.body?.user || me.body?.data?.user || me.body?.data || {}
+      tenantId = tenantId || extractTenantId(me.body)
       checks.push(result('auth-me', 'pass', {
         userId: user.id || user.userId || null,
         role: user.role || null,
+        tenantId: tenantId || null,
       }))
     } catch (error) {
       checks.push(failResult('auth-me', error))
@@ -339,6 +387,22 @@ async function runSmoke(opts) {
       checks.push(result('integration-route-contract', 'pass', assertStatusRoutes(status.body)))
     } catch (error) {
       checks.push(failResult('integration-route-contract', error))
+    }
+
+    for (const [id, pathname] of CONTROL_PLANE_LIST_PROBES) {
+      try {
+        const response = await requestJson(opts.baseUrl, withQuery(pathname, {
+          tenantId,
+          limit: 1,
+        }), { token, timeoutMs: opts.timeoutMs })
+        checks.push(result(id, 'pass', {
+          path: pathname,
+          tenantId: tenantId || null,
+          ...assertListResponse(response.body, id),
+        }))
+      } catch (error) {
+        checks.push(failResult(id, error))
+      }
     }
 
     try {

--- a/scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
@@ -99,7 +99,7 @@ function createFakeServer(options = {}) {
         sendJson(res, 401, { ok: false, error: { message: 'bad token' } })
         return
       }
-      sendJson(res, 200, { success: true, user: { id: 'admin_1', role: 'admin' } })
+      sendJson(res, 200, { success: true, user: { id: 'admin_1', role: 'admin', tenantId: 'tenant-smoke' } })
       return
     }
 
@@ -128,6 +128,27 @@ function createFakeServer(options = {}) {
           ].map(([method, routePath]) => ({ method, path: routePath })),
         },
       })
+      return
+    }
+
+    if (
+      req.method === 'GET' &&
+      [
+        '/api/integration/external-systems',
+        '/api/integration/pipelines',
+        '/api/integration/runs',
+        '/api/integration/dead-letters',
+      ].includes(url.pathname)
+    ) {
+      if (req.headers.authorization !== 'Bearer test.jwt.token') {
+        sendJson(res, 401, { ok: false, error: { message: 'bad token' } })
+        return
+      }
+      if (options.failControlPlanePath === url.pathname) {
+        sendJson(res, 500, { ok: false, error: { message: `${url.pathname} unavailable` } })
+        return
+      }
+      sendJson(res, 200, { ok: true, data: [] })
       return
     }
 
@@ -240,8 +261,52 @@ test('authenticated postdeploy smoke validates route and staging contracts witho
     assert.equal(evidence.authenticated, true)
     assert.equal(evidence.summary.fail, 0)
     assert.equal(evidence.checks.find((check) => check.id === 'integration-route-contract').status, 'pass')
+    for (const id of [
+      'integration-list-external-systems',
+      'integration-list-pipelines',
+      'integration-list-runs',
+      'integration-list-dead-letters',
+    ]) {
+      const check = evidence.checks.find((candidate) => candidate.id === id)
+      assert.equal(check.status, 'pass')
+      assert.equal(check.tenantId, 'tenant-smoke')
+    }
     assert.equal(evidence.checks.find((check) => check.id === 'staging-descriptor-contract').status, 'pass')
     assert.ok(fake.requests.some((request) => request.pathname === '/api/auth/me' && request.authorization === 'Bearer test.jwt.token'))
+    assert.ok(fake.requests.some((request) => request.pathname === '/api/integration/external-systems'))
+    assert.ok(fake.requests.some((request) => request.pathname === '/api/integration/pipelines'))
+    assert.ok(fake.requests.some((request) => request.pathname === '/api/integration/runs'))
+    assert.ok(fake.requests.some((request) => request.pathname === '/api/integration/dead-letters'))
+  } finally {
+    await fake.close()
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('authenticated postdeploy smoke fails when a read-only control-plane endpoint fails', async () => {
+  const fake = createFakeServer({ failControlPlanePath: '/api/integration/pipelines' })
+  const baseUrl = await fake.listen()
+  const outDir = makeTmpDir()
+  try {
+    const result = await runScript([
+      '--base-url', baseUrl,
+      '--auth-token', 'test.jwt.token',
+      '--require-auth',
+      '--out-dir', outDir,
+    ])
+
+    assert.equal(result.status, 1)
+    assert.equal(result.stdout.includes('test.jwt.token'), false)
+    assert.equal(result.stderr.includes('test.jwt.token'), false)
+    const evidenceText = readFileSync(path.join(outDir, 'integration-k3wise-postdeploy-smoke.json'), 'utf8')
+    assert.equal(evidenceText.includes('test.jwt.token'), false)
+    const evidence = JSON.parse(evidenceText)
+    assert.equal(evidence.ok, false)
+    assert.equal(evidence.summary.fail, 1)
+    assert.equal(evidence.checks.find((check) => check.id === 'integration-list-external-systems').status, 'pass')
+    const pipelinesCheck = evidence.checks.find((check) => check.id === 'integration-list-pipelines')
+    assert.equal(pipelinesCheck.status, 'fail')
+    assert.match(pipelinesCheck.error, /\/api\/integration\/pipelines\?tenantId=tenant-smoke&limit=1 returned HTTP 500/)
   } finally {
     await fake.close()
     rmSync(outDir, { recursive: true, force: true })


### PR DESCRIPTION
## Summary
- extend authenticated K3 WISE postdeploy smoke with read-only probes for external-systems, pipelines, runs, and dead-letters list endpoints
- add optional tenant scope input via --tenant-id / METASHEET_TENANT_ID, otherwise derive tenantId from /api/auth/me when available
- add regression coverage for the success path and for a failing control-plane list endpoint
- add design and verification notes

## Verification
- node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
- node --test scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
- node --test scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs
- node --check scripts/ops/integration-k3wise-postdeploy-smoke.mjs
- git diff --check origin/main...HEAD

## Safety
Authenticated probes are GET-only. Public-only smoke behavior is unchanged when no token is supplied.