### PR TITLE
chore(dingtalk): add mobile signoff todo closeout

### DIFF
--- a/docs/development/dingtalk-public-form-mobile-signoff-todo-design-20260429.md
+++ b/docs/development/dingtalk-public-form-mobile-signoff-todo-design-20260429.md
@@ -1,0 +1,133 @@
+# DingTalk Public Form Mobile Signoff TODO And Autocompile Design - 2026-04-29
+
+## Goal
+
+Make the remaining real DingTalk mobile checks visible and actionable from the
+current `mobile-signoff.json` file, then remove the final manual strict-compile
+step once the last check passes.
+
+The previous recorder slice removed hand-editing for individual evidence
+updates. This slice adds a `--todo` mode that turns the current signoff packet
+into a redaction-safe remaining-work report with exact `--record` command
+templates for each unfinished scenario. It also adds `--compile-when-ready` for
+record mode, so the final successful record writes the strict acceptance packet
+automatically.
+
+## Scope
+
+Changed script:
+
+- `scripts/ops/dingtalk-public-form-mobile-signoff.mjs`
+
+Changed tests:
+
+- `scripts/ops/dingtalk-public-form-mobile-signoff.test.mjs`
+
+Added docs:
+
+- `docs/development/dingtalk-public-form-mobile-signoff-todo-design-20260429.md`
+- `docs/development/dingtalk-public-form-mobile-signoff-todo-verification-20260429.md`
+
+## CLI Contract
+
+Generate a TODO report as files:
+
+```bash
+node scripts/ops/dingtalk-public-form-mobile-signoff.mjs \
+  --todo mobile-signoff.json \
+  --output-dir todo
+```
+
+Print the same TODO report to stdout:
+
+```bash
+node scripts/ops/dingtalk-public-form-mobile-signoff.mjs \
+  --todo mobile-signoff.json
+```
+
+Record one check and auto-compile only when all checks are ready:
+
+```bash
+node scripts/ops/dingtalk-public-form-mobile-signoff.mjs \
+  --record mobile-signoff.json \
+  --check-id public-anonymous-submit \
+  --status pass \
+  --source server-observation \
+  --operator qa \
+  --summary "Anonymous public form inserted one record." \
+  --record-insert-delta 1 \
+  --output-dir compiled \
+  --compile-when-ready
+```
+
+When `--output-dir` is provided, the tool writes:
+
+- `todo.md`: human-readable remaining-check report.
+- `todo.json`: machine-readable counts, remaining checks, warnings, and errors.
+- `mobile-signoff.redacted.json`: redacted copy of the source packet.
+
+## Report Semantics
+
+The TODO report includes:
+
+- Strict-ready state.
+- Pass, fail, pending, skipped, and missing counts.
+- Remaining checks with evidence recipes.
+- Suggested `--record` command templates.
+- Completed checks.
+- Validation errors and warnings.
+
+A check is complete only when its status is `pass` and the check-specific
+evidence validation has no errors. Pending, missing, skipped, failed, or invalid
+checks remain actionable in the report.
+
+Generated suggested commands include `--compile-when-ready` and a `compiled`
+output directory next to the source kit. This makes every copied command safe to
+use before the kit is complete: unfinished runs print the remaining check IDs
+and do not write strict output.
+
+## Autocompile Semantics
+
+`--compile-when-ready` is accepted only with `--record`.
+
+After a successful non-dry-run record:
+
+- The tool validates the whole packet using the TODO completeness rules.
+- If any required check remains incomplete, it prints the remaining check IDs
+  and exits successfully without writing `summary.json`.
+- If every required check is complete and valid, it runs the existing strict
+  compile path and writes `summary.json`, `summary.md`, and
+  `mobile-signoff.redacted.json`.
+
+`--compile-when-ready` is rejected with `--dry-run`, because dry-run must not
+write either the source packet or strict output.
+
+## Secret Handling
+
+The TODO mode reuses the existing validation and redaction path:
+
+- Raw webhook URLs, `access_token` values, DingTalk `SEC...` secrets, bearer
+  tokens, JWTs, public form tokens, and DingTalk client secrets are detected.
+- File output includes only a redacted source copy.
+- The report shows secret-pattern names in validation errors, not raw secret
+  values.
+- Secret-like input causes a non-zero exit code so the operator fixes the kit
+  before strict signoff.
+
+## Operator Flow
+
+1. Run `--init-kit`.
+2. Run `--todo` to confirm all nine scenarios are pending.
+3. Execute one real DingTalk mobile scenario.
+4. Run the suggested `--record` command for that scenario.
+5. Re-run `--todo` to see the remaining count.
+6. On the last successful `--record`, the strict packet is written automatically
+   when `--compile-when-ready` is present.
+
+## Non-goals
+
+- The TODO mode does not call DingTalk.
+- The TODO mode does not verify server-side record counts by itself.
+- The TODO mode does not create users, forms, grants, or records.
+- The TODO mode does not persist raw tokens, temporary passwords, screenshots,
+  or webhook secrets.

--- a/docs/development/dingtalk-public-form-mobile-signoff-todo-verification-20260429.md
+++ b/docs/development/dingtalk-public-form-mobile-signoff-todo-verification-20260429.md
@@ -1,0 +1,90 @@
+# DingTalk Public Form Mobile Signoff TODO And Autocompile Verification - 2026-04-29
+
+## Scope
+
+This document verifies the remaining-check TODO report and record-time
+autocompile flow for DingTalk public-form mobile signoff.
+
+Changed files:
+
+- `scripts/ops/dingtalk-public-form-mobile-signoff.mjs`
+- `scripts/ops/dingtalk-public-form-mobile-signoff.test.mjs`
+- `docs/development/dingtalk-public-form-mobile-signoff-todo-design-20260429.md`
+- `docs/development/dingtalk-public-form-mobile-signoff-todo-verification-20260429.md`
+
+## Commands
+
+```bash
+node --test scripts/ops/dingtalk-public-form-mobile-signoff.test.mjs
+
+KIT=$(mktemp -d -t dingtalk-mobile-signoff-todo-kit)
+TODO_OUT=$(mktemp -d -t dingtalk-mobile-signoff-todo-report)
+node scripts/ops/dingtalk-public-form-mobile-signoff.mjs --init-kit "$KIT"
+node scripts/ops/dingtalk-public-form-mobile-signoff.mjs --todo "$KIT/mobile-signoff.json" --output-dir "$TODO_OUT/initial"
+node scripts/ops/dingtalk-public-form-mobile-signoff.mjs \
+  --record "$KIT/mobile-signoff.json" \
+  --check-id public-anonymous-submit \
+  --status pass \
+  --source server-observation \
+  --operator qa \
+  --summary "Anonymous public form inserted one record." \
+  --record-insert-delta 1 \
+  --output-dir "$KIT/compiled" \
+  --compile-when-ready
+node scripts/ops/dingtalk-public-form-mobile-signoff.mjs \
+  --record "$KIT/mobile-signoff.json" \
+  --check-id selected-unlisted-bound-rejected \
+  --status pass \
+  --source manual-client \
+  --operator qa \
+  --summary "The unlisted bound user was blocked before insert." \
+  --submit-blocked \
+  --record-insert-delta 0 \
+  --blocked-reason "Not in selected user or group allowlist." \
+  --output-dir "$KIT/compiled" \
+  --compile-when-ready
+node scripts/ops/dingtalk-public-form-mobile-signoff.mjs --todo "$KIT/mobile-signoff.json" --output-dir "$TODO_OUT/partial"
+node -e "const fs=require('fs');for (const label of ['initial','partial']) { const r=JSON.parse(fs.readFileSync(process.argv[1]+'/'+label+'/todo.json','utf8')); console.log(label+': '+JSON.stringify({strictReady:r.strictReady, remaining:r.remainingChecks.length, pass:r.counts.pass||0, pending:r.counts.pending||0, errors:r.errors.length})) }" "$TODO_OUT"
+
+git diff --check
+git diff -- scripts/ops/dingtalk-public-form-mobile-signoff.mjs scripts/ops/dingtalk-public-form-mobile-signoff.test.mjs docs/development/dingtalk-public-form-mobile-signoff-todo-design-20260429.md docs/development/dingtalk-public-form-mobile-signoff-todo-verification-20260429.md \
+  | rg -v "rg -n" \
+  | rg -n "(access_token=[A-Za-z0-9]|SEC[0-9a-fA-F]{8,}|Authorization:|Bearer [A-Za-z0-9._-]{20,}|https://oapi\\.dingtalk\\.com/robot/send|JWT_SECRET|DINGTALK_APP_SECRET|publicToken=[A-Za-z0-9._~+/=-]{12,})" || true
+```
+
+## Results
+
+- Node test: passed, 15 tests.
+- Initial TODO report: `strictReady=false`, `remaining=9`, `pass=0`, `pending=9`, `errors=0`.
+- Partial TODO report after two records: `strictReady=false`, `remaining=7`, `pass=2`, `pending=7`, `errors=0`.
+- `--compile-when-ready` did not write strict output while checks remained pending.
+- Final-record autocompile path is covered by the Node test suite and writes `summary.json`, `summary.md`, and `mobile-signoff.redacted.json`.
+- `git diff --check`: passed.
+- Diff secret scan: no matches for DingTalk webhook/token/JWT/public-token patterns.
+
+## Regression Coverage
+
+New Node tests cover:
+
+- File-based TODO report generation with remaining counts and command templates.
+- Stdout TODO report generation.
+- Secret-like TODO input detection with redacted source output.
+- `--compile-when-ready` remaining-check reporting.
+- `--compile-when-ready` strict output on the final passing record.
+- Rejection of `--compile-when-ready --dry-run`.
+- Rejection of secret-like record updates before autocompile output.
+
+Existing tests still cover:
+
+- Kit initialization.
+- Single-check record updates.
+- Dry-run record behavior.
+- Strict compile with screenshot-free structured evidence.
+- Secret-like compile input rejection.
+
+## Remaining Manual Step
+
+A real DingTalk mobile client still has to execute each scenario. The tool now
+handles the surrounding operator mechanics: list remaining checks, provide safe
+record commands, and write the strict packet automatically when the final check
+passes.

--- a/scripts/ops/dingtalk-public-form-mobile-signoff.mjs
+++ b/scripts/ops/dingtalk-public-form-mobile-signoff.mjs
@@ -112,8 +112,9 @@ form access modes. It does not call DingTalk or staging.
 Options:
   --init-kit <dir>       Write mobile-signoff.json, checklist, and artifact folders
   --record <file>        Update one check in an existing mobile-signoff.json
+  --todo <file>          Write or print the remaining-check TODO report
   --input <file>         Input mobile-signoff.json to compile
-  --output-dir <dir>     Output dir, default ${DEFAULT_OUTPUT_ROOT}/<run-id>
+  --output-dir <dir>     Output dir for --input, --todo, or --compile-when-ready
   --strict               Exit non-zero unless every required check passes
   --help                 Show this help
 
@@ -134,6 +135,7 @@ Record mode options:
   --form-rendered
   --password-change-required-shown
   --no-password-change-required-shown
+  --compile-when-ready  After a successful --record, strict-compile when no checks remain
   --dry-run              Validate and print the updated check without writing
 
 Evidence can be screenshot-free. For allowed submits, record a positive
@@ -155,6 +157,7 @@ function parseArgs(argv) {
   const opts = {
     initKit: '',
     record: '',
+    todo: '',
     input: '',
     outputDir: '',
     strict: false,
@@ -173,6 +176,7 @@ function parseArgs(argv) {
     blockedReason: '',
     formRendered: null,
     passwordChangeRequiredShown: null,
+    compileWhenReady: false,
     dryRun: false,
   }
 
@@ -185,6 +189,10 @@ function parseArgs(argv) {
         break
       case '--record':
         opts.record = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
+        i += 1
+        break
+      case '--todo':
+        opts.todo = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
         i += 1
         break
       case '--input':
@@ -258,6 +266,9 @@ function parseArgs(argv) {
       case '--no-password-change-required-shown':
         opts.passwordChangeRequiredShown = false
         break
+      case '--compile-when-ready':
+        opts.compileWhenReady = true
+        break
       case '--dry-run':
         opts.dryRun = true
         break
@@ -270,12 +281,15 @@ function parseArgs(argv) {
     }
   }
 
-  const modeCount = Number(Boolean(opts.initKit)) + Number(Boolean(opts.input)) + Number(Boolean(opts.record))
+  const modeCount = Number(Boolean(opts.initKit))
+    + Number(Boolean(opts.input))
+    + Number(Boolean(opts.record))
+    + Number(Boolean(opts.todo))
   if (modeCount > 1) {
-    throw new Error('--init-kit, --record, and --input are mutually exclusive')
+    throw new Error('--init-kit, --record, --todo, and --input are mutually exclusive')
   }
   if (modeCount === 0) {
-    throw new Error('one of --init-kit, --record, or --input is required')
+    throw new Error('one of --init-kit, --record, --todo, or --input is required')
   }
   if (opts.record) {
     if (!opts.checkId) {
@@ -293,6 +307,12 @@ function parseArgs(argv) {
     if (opts.source && !VALID_SOURCES.has(opts.source)) {
       throw new Error(`invalid --source: ${opts.source}`)
     }
+  }
+  if (opts.compileWhenReady && !opts.record) {
+    throw new Error('--compile-when-ready requires --record')
+  }
+  if (opts.compileWhenReady && opts.dryRun) {
+    throw new Error('--compile-when-ready cannot be used with --dry-run')
   }
   return opts
 }
@@ -388,7 +408,17 @@ node scripts/ops/dingtalk-public-form-mobile-signoff.mjs \\
   --source server-observation \\
   --operator qa \\
   --summary "Anonymous public form inserted one record." \\
-  --record-insert-delta 1
+  --record-insert-delta 1 \\
+  --compile-when-ready \\
+  --output-dir compiled
+\`\`\`
+
+Generate the remaining-check TODO report:
+
+\`\`\`bash
+node scripts/ops/dingtalk-public-form-mobile-signoff.mjs \\
+  --todo mobile-signoff.json \\
+  --output-dir todo
 \`\`\`
 `
 }
@@ -643,17 +673,164 @@ ${validation.warnings.length ? validation.warnings.map((warning) => `- ${warning
 `
 }
 
+function getEntryById(evidence) {
+  const entries = Array.isArray(evidence.checks) ? evidence.checks : []
+  return new Map(entries.map((entry) => [entry?.id, entry]))
+}
+
+function getStatusCounts(evidence) {
+  const entryById = getEntryById(evidence)
+  return CHECKS.reduce((acc, check) => {
+    const status = entryById.get(check.id)?.status ?? 'missing'
+    acc[status] = (acc[status] ?? 0) + 1
+    return acc
+  }, {})
+}
+
+function getCheckErrors(validation, checkId) {
+  return validation.errors.filter((error) => error.startsWith(`${checkId}:`))
+}
+
+function getEvidenceRecipe(check) {
+  if (check.kind === 'allow-submit') {
+    return 'Record a positive recordInsertDelta or increasing before/after record counts.'
+  }
+  if (check.kind === 'deny-submit') {
+    return 'Record submitBlocked=true, zero insert proof, and blockedReason.'
+  }
+  return 'Record formRendered=true and passwordChangeRequiredShown=false.'
+}
+
+function shellQuote(value) {
+  if (/^[A-Za-z0-9_./:-]+$/.test(value)) return value
+  return `'${value.replaceAll("'", "'\\''")}'`
+}
+
+function formatCliPath(file) {
+  const relative = path.relative(process.cwd(), file)
+  if (relative && !relative.startsWith('..')) {
+    return shellQuote(relative)
+  }
+  return shellQuote(file)
+}
+
+function getSuggestedRecordCommand(inputFile, check) {
+  const sourceHint = check.kind === 'allow-submit' ? 'server-observation' : 'manual-client'
+  const compiledOutput = path.join(path.dirname(inputFile), 'compiled')
+  return [
+    'node scripts/ops/dingtalk-public-form-mobile-signoff.mjs \\',
+    `  --record ${formatCliPath(inputFile)} \\`,
+    `  --check-id ${check.id} \\`,
+    '  --status pass \\',
+    `  --source ${sourceHint} \\`,
+    '  --operator <operator> \\',
+    `  --summary "<redaction-safe summary>" \\`,
+    `  ${check.commandHint} \\`,
+    `  --output-dir ${formatCliPath(compiledOutput)} \\`,
+    '  --compile-when-ready',
+  ].join('\n')
+}
+
+function buildTodoReport(inputFile, evidence) {
+  const validation = validateEvidence(inputFile, evidence, false)
+  const entryById = getEntryById(evidence)
+  const requiredChecks = CHECKS.map((check) => {
+    const entry = entryById.get(check.id)
+    const status = entry?.status ?? 'missing'
+    const errors = getCheckErrors(validation, check.id)
+    const complete = status === 'pass' && errors.length === 0
+    return {
+      id: check.id,
+      label: check.label,
+      scenario: check.scenario,
+      kind: check.kind,
+      status,
+      complete,
+      errors,
+      evidenceRecipe: getEvidenceRecipe(check),
+      suggestedRecordCommand: getSuggestedRecordCommand(inputFile, check),
+    }
+  })
+  const remainingChecks = requiredChecks.filter((check) => !check.complete)
+  const counts = getStatusCounts(evidence)
+  const strictReady = remainingChecks.length === 0 && validation.errors.length === 0
+
+  return {
+    tool: 'dingtalk-public-form-mobile-signoff',
+    runId: evidence.runId || '',
+    generatedAt: nowIso(),
+    sourceFile: path.basename(inputFile),
+    strictReady,
+    counts,
+    remainingChecks,
+    requiredChecks,
+    errors: validation.errors,
+    warnings: validation.warnings,
+  }
+}
+
+function renderTodo(report) {
+  const counts = report.counts
+  const remainingRows = report.remainingChecks.map((check) => (
+    `| \`${check.id}\` | ${check.status} | ${check.label} | ${check.evidenceRecipe} |`
+  )).join('\n')
+  const completedRows = report.requiredChecks
+    .filter((check) => check.complete)
+    .map((check) => `| \`${check.id}\` | ${check.label} |`)
+    .join('\n')
+  const commandBlocks = report.remainingChecks.map((check) => (
+    `### ${check.id}\n\n${check.errors.length ? `${check.errors.map((error) => `- ${error}`).join('\n')}\n\n` : ''}\`\`\`bash\n${check.suggestedRecordCommand}\n\`\`\``
+  )).join('\n\n')
+
+  return `# DingTalk Public Form Mobile Signoff TODO
+
+- Run ID: \`${report.runId || 'unknown'}\`
+- Source: \`${report.sourceFile}\`
+- Strict-ready: \`${report.strictReady ? 'yes' : 'no'}\`
+- Pass: ${counts.pass ?? 0}
+- Fail: ${counts.fail ?? 0}
+- Pending: ${counts.pending ?? 0}
+- Skipped: ${counts.skipped ?? 0}
+- Missing: ${counts.missing ?? 0}
+- Remaining checks: ${report.remainingChecks.length}
+
+## Remaining Checks
+
+${remainingRows || '- None'}
+
+## Suggested Record Commands
+
+${commandBlocks || '- None'}
+
+## Completed Checks
+
+${completedRows ? `| Check ID | Expected result |\n| --- | --- |\n${completedRows}` : '- None'}
+
+## Errors
+
+${report.errors.length ? report.errors.map((error) => `- ${error}`).join('\n') : '- None'}
+
+## Warnings
+
+${report.warnings.length ? report.warnings.map((warning) => `- ${warning}`).join('\n') : '- None'}
+`
+}
+
 function compileEvidence(opts) {
   const evidence = readJson(opts.input)
-  const validation = validateEvidence(opts.input, evidence, opts.strict)
-  const outputDir = opts.outputDir || path.join(process.cwd(), DEFAULT_OUTPUT_ROOT, evidence.runId || makeRunId())
-  mkdirSync(outputDir, { recursive: true })
+  return writeCompiledEvidence(opts.input, evidence, opts.outputDir, opts.strict)
+}
+
+function writeCompiledEvidence(inputFile, evidence, outputDir, strict) {
+  const validation = validateEvidence(inputFile, evidence, strict)
+  const resolvedOutputDir = outputDir || path.join(process.cwd(), DEFAULT_OUTPUT_ROOT, evidence.runId || makeRunId())
+  mkdirSync(resolvedOutputDir, { recursive: true })
 
   const summary = {
     tool: 'dingtalk-public-form-mobile-signoff',
     runId: evidence.runId || '',
     generatedAt: nowIso(),
-    strict: opts.strict,
+    strict,
     status: validation.errors.length === 0 ? 'pass' : 'fail',
     errors: validation.errors,
     warnings: validation.warnings,
@@ -664,9 +841,9 @@ function compileEvidence(opts) {
     })),
   }
 
-  writeJson(path.join(outputDir, 'summary.json'), summary)
-  writeFileSync(path.join(outputDir, 'summary.md'), summarize(evidence, validation), 'utf8')
-  writeJson(path.join(outputDir, 'mobile-signoff.redacted.json'), redactValue(evidence))
+  writeJson(path.join(resolvedOutputDir, 'summary.json'), summary)
+  writeFileSync(path.join(resolvedOutputDir, 'summary.md'), summarize(evidence, validation), 'utf8')
+  writeJson(path.join(resolvedOutputDir, 'mobile-signoff.redacted.json'), redactValue(evidence))
 
   if (validation.errors.length > 0) {
     console.error(`[dingtalk-public-form-mobile-signoff] validation failed: ${validation.errors.length} error(s)`)
@@ -674,9 +851,31 @@ function compileEvidence(opts) {
       console.error(`- ${error}`)
     }
     process.exitCode = 1
-    return
+    return { validation, outputDir: resolvedOutputDir, summary }
   }
-  console.log(`[dingtalk-public-form-mobile-signoff] wrote summary: ${path.join(outputDir, 'summary.md')}`)
+  console.log(`[dingtalk-public-form-mobile-signoff] wrote summary: ${path.join(resolvedOutputDir, 'summary.md')}`)
+  return { validation, outputDir: resolvedOutputDir, summary }
+}
+
+function writeTodo(opts) {
+  const evidence = readJson(opts.todo)
+  const report = buildTodoReport(opts.todo, evidence)
+  const markdown = renderTodo(report)
+
+  if (opts.outputDir) {
+    mkdirSync(opts.outputDir, { recursive: true })
+    writeJson(path.join(opts.outputDir, 'todo.json'), report)
+    writeFileSync(path.join(opts.outputDir, 'todo.md'), markdown, 'utf8')
+    writeJson(path.join(opts.outputDir, 'mobile-signoff.redacted.json'), redactValue(evidence))
+    console.log(`[dingtalk-public-form-mobile-signoff] wrote todo: ${path.join(opts.outputDir, 'todo.md')}`)
+  } else {
+    console.log(markdown)
+  }
+
+  if (report.errors.length > 0) {
+    console.error(`[dingtalk-public-form-mobile-signoff] todo has ${report.errors.length} validation error(s)`)
+    process.exitCode = 1
+  }
 }
 
 function setEvidenceValue(evidence, key, value) {
@@ -689,6 +888,22 @@ function appendArtifacts(evidence, refs) {
   if (refs.length === 0) return
   const existing = Array.isArray(evidence.artifacts) ? evidence.artifacts : []
   evidence.artifacts = Array.from(new Set([...existing, ...refs]))
+}
+
+function maybeCompileWhenReady(opts, signoff) {
+  if (!opts.compileWhenReady) return
+
+  const report = buildTodoReport(opts.record, signoff)
+  if (!report.strictReady) {
+    const remainingIds = report.remainingChecks.map((check) => check.id).join(', ')
+    console.log(`[dingtalk-public-form-mobile-signoff] not ready for strict compile; remaining: ${remainingIds || 'none'}`)
+    if (report.errors.length > 0) {
+      console.log(`[dingtalk-public-form-mobile-signoff] validation errors: ${report.errors.length}`)
+    }
+    return
+  }
+
+  writeCompiledEvidence(opts.record, signoff, opts.outputDir, true)
 }
 
 function recordCheck(opts) {
@@ -745,6 +960,7 @@ function recordCheck(opts) {
 
   writeJson(opts.record, signoff)
   console.log(`[dingtalk-public-form-mobile-signoff] recorded ${opts.checkId}: ${opts.status}`)
+  maybeCompileWhenReady(opts, signoff)
 }
 
 function main() {
@@ -756,6 +972,10 @@ function main() {
     }
     if (opts.record) {
       recordCheck(opts)
+      return
+    }
+    if (opts.todo) {
+      writeTodo(opts)
       return
     }
     compileEvidence(opts)

--- a/scripts/ops/dingtalk-public-form-mobile-signoff.test.mjs
+++ b/scripts/ops/dingtalk-public-form-mobile-signoff.test.mjs
@@ -225,6 +225,197 @@ test('dingtalk-public-form-mobile-signoff rejects secret-like record updates', (
   }
 })
 
+test('dingtalk-public-form-mobile-signoff writes a remaining-check todo report', () => {
+  const tmpDir = makeTmpDir()
+  try {
+    const { input } = initKit(tmpDir)
+    const outputDir = path.join(tmpDir, 'todo')
+
+    const publicRecord = runScript([
+      '--record', input,
+      '--check-id', 'public-anonymous-submit',
+      '--status', 'pass',
+      '--source', 'server-observation',
+      '--operator', 'qa',
+      '--summary', 'Anonymous public form inserted one record.',
+      '--record-insert-delta', '1',
+    ])
+    assert.equal(publicRecord.status, 0, publicRecord.stderr)
+
+    const deniedRecord = runScript([
+      '--record', input,
+      '--check-id', 'selected-unlisted-bound-rejected',
+      '--status', 'pass',
+      '--source', 'manual-client',
+      '--operator', 'qa',
+      '--summary', 'The unlisted bound user was blocked before insert.',
+      '--submit-blocked',
+      '--record-insert-delta', '0',
+      '--blocked-reason', 'Not in selected user or group allowlist.',
+    ])
+    assert.equal(deniedRecord.status, 0, deniedRecord.stderr)
+
+    const result = runScript(['--todo', input, '--output-dir', outputDir])
+
+    assert.equal(result.status, 0, result.stderr)
+    const report = JSON.parse(readFileSync(path.join(outputDir, 'todo.json'), 'utf8'))
+    assert.equal(report.strictReady, false)
+    assert.equal(report.remainingChecks.length, requiredCheckIds.length - 2)
+    assert.equal(report.counts.pass, 2)
+    const markdown = readFileSync(path.join(outputDir, 'todo.md'), 'utf8')
+    assert.match(markdown, /Remaining checks: 7/)
+    assert.match(markdown, /--check-id dingtalk-unbound-rejected/)
+    assert.ok(existsSync(path.join(outputDir, 'mobile-signoff.redacted.json')))
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-public-form-mobile-signoff prints todo markdown to stdout', () => {
+  const tmpDir = makeTmpDir()
+  try {
+    const { input } = initKit(tmpDir)
+    const result = runScript(['--todo', input])
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stdout, /DingTalk Public Form Mobile Signoff TODO/)
+    assert.match(result.stdout, /--record .*mobile-signoff\.json/)
+    assert.match(result.stdout, /--compile-when-ready/)
+    assert.match(result.stdout, /Remaining checks: 9/)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-public-form-mobile-signoff flags secret-like todo inputs without leaking them', () => {
+  const tmpDir = makeTmpDir()
+  try {
+    const evidence = makePassingEvidence()
+    const secretValue = `https://example.test/form?public${'Token'}=secret-public-token-12345`
+    evidence.checks[0].evidence.summary = `Opened ${secretValue}`
+    const input = writeEvidence(tmpDir, evidence)
+    const outputDir = path.join(tmpDir, 'todo')
+    const result = runScript(['--todo', input, '--output-dir', outputDir])
+
+    assert.notEqual(result.status, 0)
+    assert.match(result.stderr, /todo has 1 validation error/)
+    assert.match(readFileSync(path.join(outputDir, 'todo.md'), 'utf8'), /public_form_token/)
+    const redacted = readFileSync(path.join(outputDir, 'mobile-signoff.redacted.json'), 'utf8')
+    assert.doesNotMatch(redacted, /secret-public-token-12345/)
+    assert.match(redacted, /<redacted:public_form_token>/)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-public-form-mobile-signoff compile-when-ready reports remaining checks', () => {
+  const tmpDir = makeTmpDir()
+  try {
+    const { input } = initKit(tmpDir)
+    const outputDir = path.join(tmpDir, 'compiled')
+    const result = runScript([
+      '--record', input,
+      '--check-id', 'public-anonymous-submit',
+      '--status', 'pass',
+      '--source', 'server-observation',
+      '--operator', 'qa',
+      '--summary', 'Anonymous public form inserted one record.',
+      '--record-insert-delta', '1',
+      '--output-dir', outputDir,
+      '--compile-when-ready',
+    ])
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stdout, /not ready for strict compile/)
+    assert.match(result.stdout, /dingtalk-unbound-rejected/)
+    assert.equal(existsSync(path.join(outputDir, 'summary.json')), false)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-public-form-mobile-signoff compile-when-ready writes strict output on final record', () => {
+  const tmpDir = makeTmpDir()
+  try {
+    const evidence = makePassingEvidence()
+    const finalCheck = evidence.checks.find((check) => check.id === 'password-change-bypass-observed')
+    finalCheck.status = 'pending'
+    finalCheck.evidence = {}
+    const input = writeEvidence(tmpDir, evidence)
+    const outputDir = path.join(tmpDir, 'compiled')
+    const result = runScript([
+      '--record', input,
+      '--check-id', 'password-change-bypass-observed',
+      '--status', 'pass',
+      '--source', 'manual-client',
+      '--operator', 'qa',
+      '--summary', 'The form rendered without the password-change page.',
+      '--form-rendered',
+      '--no-password-change-required-shown',
+      '--output-dir', outputDir,
+      '--compile-when-ready',
+    ])
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stdout, /wrote summary/)
+    const summary = JSON.parse(readFileSync(path.join(outputDir, 'summary.json'), 'utf8'))
+    assert.equal(summary.strict, true)
+    assert.equal(summary.status, 'pass')
+    assert.ok(readFileSync(path.join(outputDir, 'summary.md'), 'utf8').includes('Strict-ready: `yes`'))
+    assert.ok(existsSync(path.join(outputDir, 'mobile-signoff.redacted.json')))
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-public-form-mobile-signoff rejects compile-when-ready dry-run', () => {
+  const tmpDir = makeTmpDir()
+  try {
+    const { input } = initKit(tmpDir)
+    const result = runScript([
+      '--record', input,
+      '--check-id', 'public-anonymous-submit',
+      '--status', 'pass',
+      '--source', 'server-observation',
+      '--operator', 'qa',
+      '--summary', 'Anonymous public form inserted one record.',
+      '--record-insert-delta', '1',
+      '--compile-when-ready',
+      '--dry-run',
+    ])
+
+    assert.notEqual(result.status, 0)
+    assert.match(result.stderr, /--compile-when-ready cannot be used with --dry-run/)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-public-form-mobile-signoff rejects secret-like compile-when-ready records before output', () => {
+  const tmpDir = makeTmpDir()
+  try {
+    const { input } = initKit(tmpDir)
+    const outputDir = path.join(tmpDir, 'compiled')
+    const result = runScript([
+      '--record', input,
+      '--check-id', 'public-anonymous-submit',
+      '--status', 'pass',
+      '--source', 'server-observation',
+      '--operator', 'qa',
+      '--summary', `Do not store ${'SEC'}1234567890abcdef here.`,
+      '--record-insert-delta', '1',
+      '--output-dir', outputDir,
+      '--compile-when-ready',
+    ])
+
+    assert.notEqual(result.status, 0)
+    assert.match(result.stderr, /dingtalk_sec_secret/)
+    assert.equal(existsSync(path.join(outputDir, 'summary.json')), false)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
 test('dingtalk-public-form-mobile-signoff accepts screenshot-free strict evidence', () => {
   const tmpDir = makeTmpDir()
   try {


### PR DESCRIPTION
## Summary

- Add `--todo` mode for DingTalk public-form mobile signoff packets, producing `todo.md`, `todo.json`, and a redacted source copy.
- Include per-check evidence recipes and safe suggested `--record` commands with `--compile-when-ready`.
- Add `--compile-when-ready` to record mode so the final passing real-mobile check writes the strict acceptance packet automatically.

## Verification

- `node --test scripts/ops/dingtalk-public-form-mobile-signoff.test.mjs`
- Temp kit flow: initial TODO `remaining=9`, after two records `remaining=7`, no validation errors.
- `git diff --cached --check`
- Staged diff secret scan for DingTalk webhook/token/JWT/public-token patterns: no matches

## Docs

- `docs/development/dingtalk-public-form-mobile-signoff-todo-design-20260429.md`
- `docs/development/dingtalk-public-form-mobile-signoff-todo-verification-20260429.md`