### PR TITLE
feat(multitable): add long text field

### DIFF
--- a/apps/web/src/multitable/components/MetaFieldManager.vue
+++ b/apps/web/src/multitable/components/MetaFieldManager.vue
@@ -309,10 +309,10 @@ import {
 import MetaFieldValidationPanel from './MetaFieldValidationPanel.vue'
 
 /** Field types where the validation panel is configurable. */
-const VALIDATION_PANEL_TYPES: ReadonlySet<string> = new Set(['string', 'number', 'select'])
+const VALIDATION_PANEL_TYPES: ReadonlySet<string> = new Set(['string', 'longText', 'number', 'select'])
 
 function mapTypeForValidationPanel(fieldType: string): 'text' | 'number' | 'select' {
-  if (fieldType === 'string') return 'text'
+  if (fieldType === 'string' || fieldType === 'longText') return 'text'
   if (fieldType === 'number') return 'number'
   return 'select'
 }
@@ -397,12 +397,12 @@ function rulesToProperty(rules: FieldValidationRule[]): Array<Record<string, unk
 }
 
 const FIELD_TYPES: MetaFieldCreateType[] = [
-  'string', 'number', 'boolean', 'date', 'select', 'link', 'person',
+  'string', 'longText', 'number', 'boolean', 'date', 'select', 'link', 'person',
   'formula', 'lookup', 'rollup', 'attachment',
   'currency', 'percent', 'rating', 'url', 'email', 'phone',
 ]
 const FIELD_ICONS: Record<string, string> = {
-  string: 'Aa', number: '#', boolean: '\u2611', date: '\u{1F4C5}', select: '\u25CF',
+  string: 'Aa', longText: '\u00B6', number: '#', boolean: '\u2611', date: '\u{1F4C5}', select: '\u25CF',
   link: '\u21C4', person: '\u{1F464}', lookup: '\u2197', rollup: '\u03A3', formula: 'fx', attachment: '\uD83D\uDCCE',
   currency: '\u00A4', percent: '%', rating: '\u2605', url: '\u{1F517}', email: '\u2709', phone: '\u260E',
 }
@@ -535,7 +535,7 @@ function onValidationRulesChange(rules: FieldValidationRule[]) {
 function requiresConfig(type: MetaFieldCreateType): boolean {
   return [
     'select', 'link', 'person', 'lookup', 'rollup', 'formula', 'attachment',
-    'currency', 'percent', 'rating',
+    'currency', 'percent', 'rating', 'longText',
   ].includes(type)
 }
 
@@ -626,7 +626,7 @@ function serializeFieldDraft(type: string | null): string {
   if (type === 'rating') {
     return JSON.stringify({ max: ratingDraft.max })
   }
-  if (type === 'string' || type === 'number') {
+  if (type === 'string' || type === 'longText' || type === 'number') {
     return JSON.stringify({ validation })
   }
   return ''
@@ -874,7 +874,7 @@ function currentDraftProperty(type: MetaFieldCreateType | string): Record<string
     }
     return { max: Math.round(max) }
   }
-  if (type === 'string' || type === 'number') {
+  if (type === 'string' || type === 'longText' || type === 'number') {
     return { ...validationProperty }
   }
   return undefined
@@ -927,7 +927,7 @@ function saveConfig() {
   // an empty `property: {}` would otherwise clobber existing values on
   // the server. Types with mandatory structural config (select/link/
   // lookup/rollup/formula/attachment) always have keys to persist.
-  const onlyValidationSurface = (fieldType === 'string' || fieldType === 'number')
+  const onlyValidationSurface = (fieldType === 'string' || fieldType === 'longText' || fieldType === 'number')
   if (onlyValidationSurface && !validationDraftTouched.value) {
     closeConfig()
     return

--- a/apps/web/src/multitable/components/MetaFormView.vue
+++ b/apps/web/src/multitable/components/MetaFormView.vue
@@ -37,6 +37,19 @@
             :value="formData[field.id] ?? ''"
             @input="formData[field.id] = ($event.target as HTMLInputElement).value"
           />
+          <textarea
+            v-else-if="field.type === 'longText'"
+            :id="`field_${field.id}`"
+            class="meta-form-view__textarea"
+            :class="{ 'meta-form-view__input--error': !!fieldErrors?.[field.id] || !!validationErrors[field.id] }"
+            rows="5"
+            :disabled="isFieldReadOnly(field.id)"
+            :aria-required="field.required ? 'true' : undefined"
+            :aria-invalid="(!!fieldErrors?.[field.id] || !!validationErrors[field.id]) ? 'true' : undefined"
+            :aria-describedby="(fieldErrors?.[field.id] || validationErrors[field.id]) ? `error_${field.id}` : undefined"
+            :value="formData[field.id] ?? ''"
+            @input="formData[field.id] = ($event.target as HTMLTextAreaElement).value"
+          />
           <input
             v-else-if="field.type === 'number'"
             :id="`field_${field.id}`"
@@ -565,8 +578,13 @@ function isSameFormValue(left: unknown, right: unknown): boolean {
 .meta-form-view__comment-anchor--active { border-color: #f59e0b; background: #fff7ed; color: #b45309; }
 .meta-form-view__comment-anchor--idle { border-color: #d8e1ee; background: #fff; color: #64748b; }
 .meta-form-view__input { width: 100%; padding: 6px 10px; border: 1px solid #ddd; border-radius: 4px; font-size: 13px; }
+.meta-form-view__textarea {
+  width: 100%; min-height: 120px; padding: 8px 10px; border: 1px solid #ddd; border-radius: 4px;
+  font-size: 13px; line-height: 1.5; resize: vertical; white-space: pre-wrap;
+}
 .meta-form-view__input--error { border-color: #f56c6c; background: #fff7f7; }
 .meta-form-view__input:disabled { background: #f5f7fa; color: #999; cursor: not-allowed; }
+.meta-form-view__textarea:disabled { background: #f5f7fa; color: #999; cursor: not-allowed; }
 .meta-form-view__check { display: flex; align-items: center; gap: 8px; font-size: 13px; cursor: pointer; }
 .meta-form-view__link-btn { padding: 6px 12px; border: 1px solid #409eff; border-radius: 4px; background: #ecf5ff; color: #409eff; cursor: pointer; font-size: 13px; }
 .meta-form-view__link-btn:disabled { opacity: 0.5; cursor: not-allowed; }

--- a/apps/web/src/multitable/components/MetaFormView.vue
+++ b/apps/web/src/multitable/components/MetaFormView.vue
@@ -34,7 +34,7 @@
             :aria-required="field.required ? 'true' : undefined"
             :aria-invalid="(!!fieldErrors?.[field.id] || !!validationErrors[field.id]) ? 'true' : undefined"
             :aria-describedby="(fieldErrors?.[field.id] || validationErrors[field.id]) ? `error_${field.id}` : undefined"
-            :value="formData[field.id] ?? ''"
+            :value="textControlValue(formData[field.id])"
             @input="formData[field.id] = ($event.target as HTMLInputElement).value"
           />
           <textarea
@@ -47,7 +47,7 @@
             :aria-required="field.required ? 'true' : undefined"
             :aria-invalid="(!!fieldErrors?.[field.id] || !!validationErrors[field.id]) ? 'true' : undefined"
             :aria-describedby="(fieldErrors?.[field.id] || validationErrors[field.id]) ? `error_${field.id}` : undefined"
-            :value="formData[field.id] ?? ''"
+            :value="textControlValue(formData[field.id])"
             @input="formData[field.id] = ($event.target as HTMLTextAreaElement).value"
           />
           <input
@@ -288,6 +288,10 @@ function formFieldAffordance(fieldId: string) {
 
 function formFieldAnchorClass(fieldId: string): string {
   return resolveCommentAffordanceStateClass('meta-form-view__comment-anchor', formFieldAffordance(fieldId))
+}
+
+function textControlValue(value: unknown): string {
+  return value === null || value === undefined ? '' : String(value)
 }
 
 function syncFromRecord(record: MetaRecord | null | undefined) {

--- a/apps/web/src/multitable/components/MetaRecordDrawer.vue
+++ b/apps/web/src/multitable/components/MetaRecordDrawer.vue
@@ -47,14 +47,14 @@
             :id="`drawer_field_${field.id}`"
             class="meta-record-drawer__input"
             type="text"
-            :value="record.data[field.id] ?? ''"
+            :value="textControlValue(record.data[field.id])"
             @change="emit('patch', field.id, ($event.target as HTMLInputElement).value)"
           />
           <textarea
             v-else-if="canEditField(field.id) && field.type === 'longText'"
             :id="`drawer_field_${field.id}`"
             class="meta-record-drawer__textarea"
-            :value="record.data[field.id] ?? ''"
+            :value="textControlValue(record.data[field.id])"
             rows="5"
             @change="emit('patch', field.id, ($event.target as HTMLTextAreaElement).value)"
           />
@@ -251,6 +251,10 @@ function formatValue(v: unknown): string {
   if (v === null || v === undefined) return '—'
   if (Array.isArray(v)) return v.join(', ')
   return String(v)
+}
+
+function textControlValue(value: unknown): string {
+  return value === null || value === undefined ? '' : String(value)
 }
 
 function linkButtonLabel(fieldId: string): string {

--- a/apps/web/src/multitable/components/MetaRecordDrawer.vue
+++ b/apps/web/src/multitable/components/MetaRecordDrawer.vue
@@ -50,6 +50,14 @@
             :value="record.data[field.id] ?? ''"
             @change="emit('patch', field.id, ($event.target as HTMLInputElement).value)"
           />
+          <textarea
+            v-else-if="canEditField(field.id) && field.type === 'longText'"
+            :id="`drawer_field_${field.id}`"
+            class="meta-record-drawer__textarea"
+            :value="record.data[field.id] ?? ''"
+            rows="5"
+            @change="emit('patch', field.id, ($event.target as HTMLTextAreaElement).value)"
+          />
           <input
             v-else-if="canEditField(field.id) && field.type === 'number'"
             :id="`drawer_field_${field.id}`"
@@ -464,6 +472,10 @@ function attachmentAllowsMultiple(field: MetaField): boolean {
 .meta-record-drawer__comment-anchor--active { border-color: #f59e0b; background: #fff7ed; color: #b45309; }
 .meta-record-drawer__comment-anchor--idle { border-color: #d8e1ee; background: #fff; color: #64748b; }
 .meta-record-drawer__input { width: 100%; padding: 4px 8px; border: 1px solid #ddd; border-radius: 3px; font-size: 13px; }
+.meta-record-drawer__textarea {
+  width: 100%; min-height: 104px; padding: 6px 8px; border: 1px solid #ddd; border-radius: 3px;
+  font-size: 13px; line-height: 1.45; resize: vertical; white-space: pre-wrap;
+}
 .meta-record-drawer__check { cursor: pointer; }
 .meta-record-drawer__link-btn { padding: 4px 10px; border: 1px solid #409eff; border-radius: 3px; background: #ecf5ff; color: #409eff; cursor: pointer; font-size: 12px; }
 .meta-record-drawer__link-summary { margin-top: 6px; font-size: 12px; color: #606266; }
@@ -475,6 +487,6 @@ function attachmentAllowsMultiple(field: MetaField): boolean {
 .meta-record-drawer__attachment-clear:disabled { opacity: 0.5; cursor: not-allowed; }
 .meta-record-drawer__uploading { font-size: 12px; color: #409eff; }
 .meta-record-drawer__error { color: #f56c6c; font-size: 12px; }
-.meta-record-drawer__text { font-size: 13px; color: #333; }
+.meta-record-drawer__text { font-size: 13px; color: #333; white-space: pre-wrap; word-break: break-word; }
 .meta-record-drawer__empty { padding: 32px; text-align: center; color: #999; }
 </style>

--- a/apps/web/src/multitable/components/cells/MetaCellEditor.vue
+++ b/apps/web/src/multitable/components/cells/MetaCellEditor.vue
@@ -6,7 +6,7 @@
       ref="inputRef"
       class="meta-cell-editor__input"
       type="date"
-      :value="modelValue ?? ''"
+      :value="textControlValue(modelValue)"
       @input="emit('update:modelValue', ($event.target as HTMLInputElement).value)"
       @keydown.enter="emit('confirm')"
       @keydown.escape="emit('cancel')"
@@ -17,7 +17,7 @@
       ref="inputRef"
       class="meta-cell-editor__input"
       type="date"
-      :value="modelValue ?? ''"
+      :value="textControlValue(modelValue)"
       @input="emit('update:modelValue', ($event.target as HTMLInputElement).value)"
       @keydown.enter="emit('confirm')"
       @keydown.escape="emit('cancel')"
@@ -47,7 +47,7 @@
       ref="inputRef"
       class="meta-cell-editor__textarea"
       rows="4"
-      :value="modelValue ?? ''"
+      :value="textControlValue(modelValue)"
       @input="emit('update:modelValue', ($event.target as HTMLTextAreaElement).value)"
       @keydown.meta.enter.prevent="emit('confirm')"
       @keydown.ctrl.enter.prevent="emit('confirm')"
@@ -264,6 +264,10 @@ const emit = defineEmits<{
    */
   (e: 'yjs-commit'): void
 }>()
+
+function textControlValue(value: unknown): string {
+  return value === null || value === undefined ? '' : String(value)
+}
 
 // --- Yjs opt-in binding (text cells only; inert when flag off) ---
 // See useYjsCellBinding for flag gating + timeout + fallback. The editor

--- a/apps/web/src/multitable/components/cells/MetaCellEditor.vue
+++ b/apps/web/src/multitable/components/cells/MetaCellEditor.vue
@@ -41,6 +41,19 @@
       />
     </div>
 
+    <!-- longText: multiline REST editor -->
+    <textarea
+      v-else-if="field.type === 'longText'"
+      ref="inputRef"
+      class="meta-cell-editor__textarea"
+      rows="4"
+      :value="modelValue ?? ''"
+      @input="emit('update:modelValue', ($event.target as HTMLTextAreaElement).value)"
+      @keydown.meta.enter.prevent="emit('confirm')"
+      @keydown.ctrl.enter.prevent="emit('confirm')"
+      @keydown.escape="emit('cancel')"
+    />
+
     <!-- number -->
     <input
       v-else-if="field.type === 'number'"
@@ -489,6 +502,10 @@ onMounted(() => {
 .meta-cell-editor__input {
   width: 100%; padding: 2px 6px; border: 1px solid #409eff; border-radius: 3px;
   font-size: 13px; outline: none;
+}
+.meta-cell-editor__textarea {
+  width: 100%; min-height: 88px; padding: 6px 8px; border: 1px solid #409eff; border-radius: 4px;
+  font-size: 13px; line-height: 1.45; outline: none; resize: vertical; white-space: pre-wrap;
 }
 .meta-cell-editor__presence {
   flex-shrink: 0;

--- a/apps/web/src/multitable/components/cells/MetaCellRenderer.vue
+++ b/apps/web/src/multitable/components/cells/MetaCellRenderer.vue
@@ -3,6 +3,11 @@
     <!-- string / formula -->
     <template v-if="field.type === 'string' || field.type === 'formula'">{{ displayValue }}</template>
 
+    <!-- long text -->
+    <template v-else-if="field.type === 'longText'">
+      <span class="meta-cell-renderer__long-text">{{ displayValue }}</span>
+    </template>
+
     <!-- date -->
     <template v-else-if="field.type === 'date'">
       <span class="meta-cell-renderer__date">{{ dateDisplay }}</span>
@@ -208,6 +213,12 @@ const conditionalClass = computed(() => {
 <style scoped>
 .meta-cell-renderer { font-size: 13px; line-height: 1.4; }
 .meta-cell-renderer__bool { font-size: 16px; }
+.meta-cell-renderer__long-text {
+  display: inline-block;
+  max-width: 100%;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
 .meta-cell-renderer__tag {
   display: inline-block; padding: 1px 6px; border-radius: 3px;
   font-size: 11px; margin-right: 4px; white-space: nowrap;

--- a/apps/web/src/multitable/composables/useMultitableGrid.ts
+++ b/apps/web/src/multitable/composables/useMultitableGrid.ts
@@ -94,6 +94,14 @@ export const FILTER_OPERATORS_BY_TYPE: Record<string, Array<{ value: string; lab
     { value: 'isEmpty', label: 'is empty' },
     { value: 'isNotEmpty', label: 'is not empty' },
   ],
+  longText: [
+    { value: 'is', label: 'is' },
+    { value: 'isNot', label: 'is not' },
+    { value: 'contains', label: 'contains' },
+    { value: 'doesNotContain', label: 'does not contain' },
+    { value: 'isEmpty', label: 'is empty' },
+    { value: 'isNotEmpty', label: 'is not empty' },
+  ],
   number: [
     { value: 'is', label: '=' },
     { value: 'isNot', label: '\u2260' },

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -20,6 +20,7 @@ export type MetaFieldType =
   | 'url'
   | 'email'
   | 'phone'
+  | 'longText'
 
 export type MetaFieldCreateType = MetaFieldType | 'person'
 

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -554,8 +554,8 @@ const currentViewPermission = computed<MetaViewPermission | null>(() => {
   return activeViewId ? effectiveViewPermissions.value[activeViewId] ?? null : null
 })
 const mentionDisplayFieldId = computed(() =>
-  grid.visibleFields.value.find((field) => field.type === 'string')?.id
-  ?? grid.fields.value.find((field) => field.type === 'string')?.id
+  grid.visibleFields.value.find((field) => field.type === 'string' || field.type === 'longText')?.id
+  ?? grid.fields.value.find((field) => field.type === 'string' || field.type === 'longText')?.id
   ?? null,
 )
 const canConfigureCurrentView = computed(() => currentViewPermission.value?.canConfigure ?? true)

--- a/apps/web/tests/multitable-field-manager.spec.ts
+++ b/apps/web/tests/multitable-field-manager.spec.ts
@@ -466,6 +466,37 @@ describe('MetaFieldManager', () => {
     app.unmount()
   })
 
+  it('renders the text validation panel for longText fields', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    const app = createApp({
+      render() {
+        return h(MetaFieldManager, {
+          visible: true,
+          sheetId: 'sheet_1',
+          sheets: [],
+          fields: [
+            { id: 'fld_notes', name: 'Notes', type: 'longText', property: {} },
+          ],
+        })
+      },
+    })
+
+    app.mount(container)
+    await nextTick()
+
+    ;(container.querySelector('.meta-field-mgr__action[title="Configure"]') as HTMLButtonElement | null)?.click()
+    await nextTick()
+
+    expect(container.querySelector('.meta-field-mgr__validation')).not.toBeNull()
+    expect(container.querySelector('[data-rule-type="minLength"]')).not.toBeNull()
+    expect(container.querySelector('[data-rule-type="pattern"]')).not.toBeNull()
+    expect(container.querySelector('[data-rule-type="min"]')).toBeNull()
+
+    app.unmount()
+  })
+
   it('hydrates stored engine-shape validation rules into the panel when opening', async () => {
     const container = document.createElement('div')
     document.body.appendChild(container)

--- a/apps/web/tests/multitable-form-view.spec.ts
+++ b/apps/web/tests/multitable-form-view.spec.ts
@@ -10,6 +10,54 @@ async function flushUi(cycles = 4) {
 }
 
 describe('MetaFormView attachment flow', () => {
+  it('renders longText as textarea and submits multiline values unchanged', async () => {
+    const submitSpy = vi.fn()
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    const app = createApp({
+      render() {
+        return h(MetaFormView, {
+          fields: [
+            { id: 'fld_notes', name: 'Notes', type: 'longText' },
+          ],
+          record: {
+            id: 'rec_1',
+            version: 1,
+            data: {
+              fld_notes: 'line 1',
+            },
+          },
+          loading: false,
+          readOnly: false,
+          onSubmit: submitSpy,
+          onOpenLinkPicker: vi.fn(),
+        })
+      },
+    })
+
+    app.mount(container)
+    await flushUi()
+
+    const textarea = container.querySelector('#field_fld_notes') as HTMLTextAreaElement | null
+    expect(textarea).not.toBeNull()
+    expect(textarea?.tagName).toBe('TEXTAREA')
+    textarea!.value = 'line 1\nline 2\n'
+    textarea!.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+
+    const form = container.querySelector('form') as HTMLFormElement | null
+    form?.dispatchEvent(new Event('submit'))
+    await flushUi()
+
+    expect(submitSpy).toHaveBeenCalledWith({
+      fld_notes: 'line 1\nline 2\n',
+    })
+
+    app.unmount()
+    container.remove()
+  })
+
   it('hides non-visible fields and disables read-only scoped fields', async () => {
     const container = document.createElement('div')
     document.body.appendChild(container)

--- a/apps/web/tests/multitable-longtext-cell.spec.ts
+++ b/apps/web/tests/multitable-longtext-cell.spec.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick } from 'vue'
+import MetaCellEditor from '../src/multitable/components/cells/MetaCellEditor.vue'
+import MetaCellRenderer from '../src/multitable/components/cells/MetaCellRenderer.vue'
+
+describe('longText cells', () => {
+  it('renders multiline values with the long-text renderer class', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    const app = createApp({
+      render() {
+        return h(MetaCellRenderer, {
+          field: { id: 'fld_notes', name: 'Notes', type: 'longText' },
+          value: 'line 1\nline 2',
+        })
+      },
+    })
+
+    app.mount(container)
+    await nextTick()
+
+    const value = container.querySelector('.meta-cell-renderer__long-text') as HTMLElement | null
+    expect(value).not.toBeNull()
+    expect(value?.textContent).toBe('line 1\nline 2')
+
+    app.unmount()
+    container.remove()
+  })
+
+  it('uses a textarea editor and confirms with Ctrl+Enter', async () => {
+    const updateSpy = vi.fn()
+    const confirmSpy = vi.fn()
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    const app = createApp({
+      render() {
+        return h(MetaCellEditor, {
+          field: { id: 'fld_notes', name: 'Notes', type: 'longText' },
+          modelValue: 'line 1',
+          recordId: 'rec_1',
+          'onUpdate:modelValue': updateSpy,
+          onConfirm: confirmSpy,
+          onCancel: vi.fn(),
+          onOpenLinkPicker: vi.fn(),
+        })
+      },
+    })
+
+    app.mount(container)
+    await nextTick()
+
+    const textarea = container.querySelector('textarea.meta-cell-editor__textarea') as HTMLTextAreaElement | null
+    expect(textarea).not.toBeNull()
+    textarea!.value = 'line 1\nline 2\n'
+    textarea!.dispatchEvent(new Event('input', { bubbles: true }))
+    await nextTick()
+
+    expect(updateSpy).toHaveBeenCalledWith('line 1\nline 2\n')
+    textarea!.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'Enter',
+      ctrlKey: true,
+      bubbles: true,
+    }))
+    await nextTick()
+
+    expect(confirmSpy).toHaveBeenCalledTimes(1)
+
+    app.unmount()
+    container.remove()
+  })
+})

--- a/apps/web/tests/multitable-record-drawer.spec.ts
+++ b/apps/web/tests/multitable-record-drawer.spec.ts
@@ -10,6 +10,48 @@ async function flushUi(cycles = 4) {
 }
 
 describe('MetaRecordDrawer', () => {
+  it('edits longText values with a textarea in the drawer', async () => {
+    const patchSpy = vi.fn()
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    const app = createApp({
+      render() {
+        return h(MetaRecordDrawer, {
+          visible: true,
+          record: {
+            id: 'rec_notes_1',
+            version: 1,
+            data: {
+              fld_notes: 'line 1',
+            },
+          },
+          fields: [
+            { id: 'fld_notes', name: 'Notes', type: 'longText' },
+          ],
+          canEdit: true,
+          canComment: false,
+          canDelete: false,
+          onPatch: patchSpy,
+        })
+      },
+    })
+
+    app.mount(container)
+    await flushUi()
+
+    const textarea = container.querySelector('.meta-record-drawer__textarea') as HTMLTextAreaElement | null
+    expect(textarea).not.toBeNull()
+    textarea!.value = 'line 1\nline 2'
+    textarea!.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+
+    expect(patchSpy).toHaveBeenCalledWith('fld_notes', 'line 1\nline 2')
+
+    app.unmount()
+    container.remove()
+  })
+
   it('uses scoped field permissions to render readonly fields as display-only values', async () => {
     const patchSpy = vi.fn()
     const container = document.createElement('div')

--- a/docs/development/wave-m-feishu-3-longtext-field-design-20260429.md
+++ b/docs/development/wave-m-feishu-3-longtext-field-design-20260429.md
@@ -1,0 +1,74 @@
+# Wave M-Feishu-3: Long Text Field Design
+
+Date: 2026-04-29
+Branch: `codex/mfeishu3-longtext-field-20260429`
+
+## Scope
+
+Add a first-class multitable `longText` field type aligned with Feishu-style multiline text cells.
+
+This slice covers:
+
+- Backend field type recognition and API contract exposure.
+- Shared REST/Yjs-authoritative record write validation through `RecordWriteService`.
+- Legacy `RecordService` create/patch validation.
+- Grid cell renderer/editor, record drawer editor, and form view textarea support.
+- Field manager creation/configuration with text validation rules.
+- Filter operator reuse from normal text fields.
+
+Out of scope:
+
+- Character-level Yjs collaboration for long text.
+- Rich text, markdown rendering, mentions, attachments inside text, or per-paragraph formatting.
+- Data migration. Existing `string` fields are not converted automatically.
+
+## Backend Design
+
+`longText` is stored in `meta_fields.type` and record JSONB data as a plain string. Empty values are normalized to `null` by the validation helper; non-string values are rejected.
+
+Key decisions:
+
+- `field-codecs.mapFieldType()` recognizes `longText`, `long_text`, `long-text`, `textarea`, `multi_line_text`, and `multiline`.
+- `validateLongTextValue()` preserves newline and whitespace content exactly. It intentionally does not `trim()` user text.
+- `field-validation-engine.getDefaultValidationRules()` treats `longText` like `string` and applies the existing default `maxLength: 10000`.
+- `RecordWriteService.validateChanges()` wraps long-text coercion failures as `RecordValidationError`, preserving the service error contract.
+- `RecordService.createRecord()` and `RecordService.patchRecord()` use the same helper so legacy paths and shared write paths stay consistent.
+- `univer-meta` field create/update schemas and OpenAPI field enums now accept `longText`.
+
+## Frontend Design
+
+`longText` is a separate `MetaFieldType` and intentionally uses textarea surfaces:
+
+- Grid cell editor: multiline `<textarea>`, `Ctrl/Cmd+Enter` commits, `Enter` inserts a newline.
+- Cell renderer: preserves newlines via `white-space: pre-wrap`.
+- Record drawer: editable multiline textarea and read-only newline-preserving display.
+- Form view/public form reuse: textarea input, submit payload preserves newlines.
+- Field manager: `longText` appears after `string`, reuses text validation panel rules (`required`, `minLength`, `maxLength`, `pattern`).
+- Grid filters: reuses string operators (`is`, `is not`, `contains`, `does not contain`, empty checks).
+
+Yjs eligibility remains limited to normal `string` fields. This is deliberate: long text editing can involve larger replace/paste operations and IME/composition behavior that should be validated in a separate collaboration slice.
+
+## Files
+
+- `packages/core-backend/src/multitable/field-codecs.ts`
+- `packages/core-backend/src/multitable/field-validation-engine.ts`
+- `packages/core-backend/src/multitable/record-service.ts`
+- `packages/core-backend/src/multitable/record-write-service.ts`
+- `packages/core-backend/src/routes/univer-meta.ts`
+- `packages/core-backend/src/multitable/contracts.ts`
+- `packages/openapi/src/base.yml`
+- `packages/openapi/src/paths/multitable.yml`
+- `apps/web/src/multitable/types.ts`
+- `apps/web/src/multitable/components/MetaFieldManager.vue`
+- `apps/web/src/multitable/components/MetaFormView.vue`
+- `apps/web/src/multitable/components/MetaRecordDrawer.vue`
+- `apps/web/src/multitable/components/cells/MetaCellEditor.vue`
+- `apps/web/src/multitable/components/cells/MetaCellRenderer.vue`
+- `apps/web/src/multitable/composables/useMultitableGrid.ts`
+- `apps/web/src/multitable/views/MultitableWorkbench.vue`
+
+## Follow-ups
+
+- Consider long-text Yjs opt-in only after textarea composition/IME and large paste behavior are tested.
+- Consider richer preview/collapse controls for dense grid cells.
+- Existing MF2 route/OpenAPI enum drift remains outside this slice and should be handled in a separate contract cleanup if needed.

--- a/docs/development/wave-m-feishu-3-longtext-field-verification-20260429.md
+++ b/docs/development/wave-m-feishu-3-longtext-field-verification-20260429.md
@@ -1,0 +1,116 @@
+# Wave M-Feishu-3: Long Text Field Verification
+
+Date: 2026-04-29
+Branch: `codex/mfeishu3-longtext-field-20260429`
+
+## Summary
+
+Result: passed.
+
+The slice was verified with focused backend unit tests, frontend component tests, frontend typecheck, backend build, and diff hygiene.
+
+## Backend Tests
+
+Command:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/multitable-field-types-batch1.test.ts \
+  tests/unit/record-write-service.test.ts
+```
+
+Result:
+
+- 2 files passed.
+- 88 tests passed.
+- Added coverage for `longText` aliases, property round-trip, multiline value preservation, non-string rejection, and `RecordWriteService` error typing.
+- Existing post-commit hook tests still log expected simulated hook failures; suite exits green.
+
+Command:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/record-service.test.ts \
+  tests/unit/field-validation.test.ts \
+  tests/unit/field-validation-wiring.test.ts
+```
+
+Result:
+
+- 3 files passed.
+- 84 tests passed.
+- Confirms legacy record service and validation wiring remain compatible.
+- Warning: `DATABASE_URL not set` is expected for this in-memory/mock suite and did not fail the run.
+
+Command:
+
+```bash
+pnpm --filter @metasheet/core-backend build
+```
+
+Result:
+
+- Passed.
+- Runs backend `tsc`.
+
+## Frontend Tests
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run --watch=false \
+  tests/multitable-longtext-cell.spec.ts \
+  tests/multitable-form-view.spec.ts \
+  tests/multitable-record-drawer.spec.ts \
+  tests/multitable-field-manager.spec.ts
+```
+
+Result:
+
+- 4 files passed.
+- 29 tests passed.
+- Added coverage for cell renderer/editor, form view submit, record drawer editing, and field manager text validation panel for `longText`.
+- Existing local warning: `WebSocket server error: Port is already in use`; suite exits green.
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+```
+
+Result:
+
+- Passed.
+
+## Hygiene
+
+Command:
+
+```bash
+git diff --check
+```
+
+Result:
+
+- Passed.
+
+Temporary `node_modules` symlinks were used only for local worktree validation and should be removed before commit/PR creation:
+
+```bash
+rm -f node_modules apps/web/node_modules packages/core-backend/node_modules
+```
+
+## Manual Smoke Checklist
+
+- Create a `longText` field from field manager.
+- Configure `required` and `maxLength` validation on the field.
+- Edit a grid cell with multiple lines and commit using `Ctrl/Cmd+Enter`.
+- Open the record drawer and confirm multiline text renders and edits correctly.
+- Open the form view and submit multiline content; verify the record keeps newline characters.
+- Search/filter with `contains` over long text.
+
+## Known Limits
+
+- `longText` does not use Yjs collaboration in this slice.
+- No rich text/markdown rendering.
+- No automatic migration from existing `string` fields.

--- a/docs/development/wave-m-feishu-3-longtext-field-verification-20260429.md
+++ b/docs/development/wave-m-feishu-3-longtext-field-verification-20260429.md
@@ -94,6 +94,31 @@ Result:
 
 - Passed.
 
+## CI Repair Pass
+
+GitHub Actions initially caught two issues that the focused local commands did not cover:
+
+- `pnpm type-check` runs project references through `vue-tsc -b`; the long-text textarea values needed explicit `unknown` to string conversion before binding to native `value`.
+- `contracts (openapi)` requires generated files under `packages/openapi/dist` to be committed after editing `packages/openapi/src`.
+
+Commands:
+
+```bash
+pnpm exec tsx packages/openapi/tools/build.ts
+pnpm type-check
+pnpm --filter @metasheet/web exec vitest run --watch=false \
+  tests/multitable-longtext-cell.spec.ts \
+  tests/multitable-form-view.spec.ts \
+  tests/multitable-record-drawer.spec.ts \
+  tests/multitable-field-manager.spec.ts
+```
+
+Result:
+
+- OpenAPI dist regenerated.
+- `pnpm type-check` passed.
+- 4 frontend files passed, 29 tests passed.
+
 Temporary `node_modules` symlinks were used only for local worktree validation and should be removed before commit/PR creation:
 
 ```bash

--- a/docs/development/wave-m-feishu-3-longtext-field-verification-20260429.md
+++ b/docs/development/wave-m-feishu-3-longtext-field-verification-20260429.md
@@ -7,7 +7,7 @@ Branch: `codex/mfeishu3-longtext-field-20260429`
 
 Result: passed.
 
-The slice was verified with focused backend unit tests, frontend component tests, frontend typecheck, backend build, and diff hygiene.
+The slice was rebased onto `origin/main@74f96bc6c` and verified with focused backend unit tests, frontend component tests, frontend typecheck, backend build, and diff hygiene.
 
 ## Backend Tests
 
@@ -87,7 +87,7 @@ Result:
 Command:
 
 ```bash
-git diff --check
+git diff --check origin/main...HEAD
 ```
 
 Result:

--- a/packages/core-backend/src/multitable/contracts.ts
+++ b/packages/core-backend/src/multitable/contracts.ts
@@ -9,6 +9,7 @@ export type MultitableProvisioningFieldType =
   | 'lookup'
   | 'rollup'
   | 'attachment'
+  | 'longText'
 
 export interface MultitableProvisioningFieldDescriptor {
   id: string

--- a/packages/core-backend/src/multitable/field-codecs.ts
+++ b/packages/core-backend/src/multitable/field-codecs.ts
@@ -17,6 +17,7 @@ export type MultitableFieldType =
   | 'url'
   | 'email'
   | 'phone'
+  | 'longText'
 
 export type MultitableField = {
   id: string
@@ -84,6 +85,16 @@ export function mapFieldType(type: string): MultitableFieldType | string {
   if (normalized === 'url') return 'url'
   if (normalized === 'email') return 'email'
   if (normalized === 'phone') return 'phone'
+  if (
+    normalized === 'longtext' ||
+    normalized === 'long_text' ||
+    normalized === 'long-text' ||
+    normalized === 'textarea' ||
+    normalized === 'multi_line_text' ||
+    normalized === 'multiline'
+  ) {
+    return 'longText'
+  }
   if (fieldTypeRegistry.has(normalized)) return normalized
   return 'string'
 }
@@ -270,7 +281,7 @@ export function sanitizeFieldProperty(
     return { ...obj, max }
   }
 
-  if (type === 'url' || type === 'email' || type === 'phone') {
+  if (type === 'url' || type === 'email' || type === 'phone' || type === 'longText') {
     return obj
   }
 
@@ -399,6 +410,14 @@ export function validatePhoneValue(value: unknown, fieldId: string): string | nu
     throw new Error(`Invalid phone number for ${fieldId}: ${trimmed}`)
   }
   return trimmed
+}
+
+export function validateLongTextValue(value: unknown, fieldId: string): string | null {
+  if (value === null || value === undefined || value === '') return null
+  if (typeof value !== 'string') {
+    throw new Error(`Long text value must be a string for ${fieldId}`)
+  }
+  return value
 }
 
 /**

--- a/packages/core-backend/src/multitable/field-validation-engine.ts
+++ b/packages/core-backend/src/multitable/field-validation-engine.ts
@@ -236,6 +236,7 @@ export function getDefaultValidationRules(
 ): FieldValidationConfig {
   switch (fieldType) {
     case 'string':
+    case 'longText':
       return [{ type: 'maxLength', params: { value: 10000 } }]
     case 'select': {
       const options = fieldProperty?.options

--- a/packages/core-backend/src/multitable/record-service.ts
+++ b/packages/core-backend/src/multitable/record-service.ts
@@ -12,6 +12,7 @@ import {
   extractSelectOptions,
   normalizeJson,
   normalizeJsonArray,
+  validateLongTextValue,
   type MultitableField,
 } from './field-codecs'
 import { getDefaultValidationRules, validateRecord } from './field-validation-engine'
@@ -51,10 +52,8 @@ type CreateFieldGuard = {
   options?: string[]
   link?: LinkFieldConfig | null
   /**
-   * Sanitized property (currency.code/decimals, percent.decimals,
-   * rating.max). Carried only for the MF2 batch-1 field types so the
-   * coercion helper in `field-codecs` can read the constraints without
-   * re-fetching the field row.
+   * Sanitized property carried for types whose write path or validation
+   * needs field-level configuration.
    */
   property?: Record<string, unknown>
 }
@@ -198,6 +197,16 @@ function mapFieldType(type: string): UniverMetaField['type'] {
   if (normalized === 'lookup') return 'lookup'
   if (normalized === 'rollup') return 'rollup'
   if (normalized === 'attachment') return 'attachment'
+  if (
+    normalized === 'longtext' ||
+    normalized === 'long_text' ||
+    normalized === 'long-text' ||
+    normalized === 'textarea' ||
+    normalized === 'multi_line_text' ||
+    normalized === 'multiline'
+  ) {
+    return 'longText'
+  }
   return 'string'
 }
 
@@ -438,6 +447,15 @@ export class RecordService {
       if (field.type === 'formula') {
         if (typeof value !== 'string') continue
         if (value !== '' && !value.startsWith('=')) continue
+      }
+
+      if (field.type === 'longText') {
+        try {
+          patch[fieldId] = validateLongTextValue(value, fieldId)
+        } catch (error) {
+          throw new RecordValidationError(error instanceof Error ? error.message : String(error))
+        }
+        continue
       }
 
       if (BATCH1_FIELD_TYPES.has(field.type)) {
@@ -692,6 +710,14 @@ export class RecordService {
           fieldErrors[fieldId] = 'Formula must start with ='
           continue
         }
+      }
+      if (field.type === 'longText') {
+        try {
+          patch[fieldId] = validateLongTextValue(value, fieldId)
+        } catch (error) {
+          fieldErrors[fieldId] = error instanceof Error ? error.message : String(error)
+        }
+        continue
       }
       patch[fieldId] = value
     }

--- a/packages/core-backend/src/multitable/record-write-service.ts
+++ b/packages/core-backend/src/multitable/record-write-service.ts
@@ -22,7 +22,7 @@ import {
   type RecordPostCommitHook,
   type YjsInvalidator,
 } from './post-commit-hooks'
-import { BATCH1_FIELD_TYPES, coerceBatch1Value } from './field-codecs'
+import { BATCH1_FIELD_TYPES, coerceBatch1Value, validateLongTextValue } from './field-codecs'
 
 // ---------------------------------------------------------------------------
 // Shared types (mirrors the ones in univer-meta.ts to avoid coupling)
@@ -58,6 +58,7 @@ export type UniverMetaField = {
     | 'url'
     | 'email'
     | 'phone'
+    | 'longText'
   options?: Array<{ value: string; color?: string }>
   order?: number
   property?: Record<string, unknown>
@@ -178,11 +179,7 @@ export type FieldMutationGuard = {
   readOnly: boolean
   hidden: boolean
   link?: LinkFieldConfig | null
-  /**
-   * Sanitized property. Required by the MF2 batch-1 field types
-   * (currency/percent/rating) so coercion can read `code`/`decimals`/`max`
-   * without re-fetching the field definition.
-   */
+  /** Sanitized property for field types whose write path needs config. */
   property?: Record<string, unknown>
 }
 
@@ -414,6 +411,14 @@ export class RecordWriteService {
             throw new RecordValidationError(attachmentError)
           }
         }
+
+        if (field.type === 'longText') {
+          try {
+            validateLongTextValue(change.value, change.fieldId)
+          } catch (error) {
+            throw new RecordValidationError(error instanceof Error ? error.message : String(error))
+          }
+        }
       }
     }
   }
@@ -514,6 +519,16 @@ export class RecordWriteService {
 
           if (field.type === 'attachment') {
             patch[change.fieldId] = h.normalizeAttachmentIds(change.value)
+            applied += 1
+            continue
+          }
+
+          if (field.type === 'longText') {
+            try {
+              patch[change.fieldId] = validateLongTextValue(change.value, change.fieldId)
+            } catch (error) {
+              throw new RecordValidationError(error instanceof Error ? error.message : String(error))
+            }
             applied += 1
             continue
           }

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -92,7 +92,7 @@ import type { RequestWithFile } from '../types/multer'
 import { MultitableFormulaEngine } from '../multitable/formula-engine'
 import { validateRecord, getDefaultValidationRules } from '../multitable/field-validation-engine'
 import type { FieldValidationConfig } from '../multitable/field-validation'
-import { BATCH1_FIELD_TYPES, coerceBatch1Value } from '../multitable/field-codecs'
+import { BATCH1_FIELD_TYPES, coerceBatch1Value, validateLongTextValue } from '../multitable/field-codecs'
 import { conditionalPublicRateLimiter, publicFormContextLimiter, publicFormSubmitLimiter } from '../middleware/rate-limiter'
 import {
   AutomationRuleValidationError,
@@ -173,6 +173,7 @@ type UniverMetaField = {
     | 'url'
     | 'email'
     | 'phone'
+    | 'longText'
   options?: Array<{ value: string; color?: string }>
   order?: number
   property?: Record<string, unknown>
@@ -943,7 +944,7 @@ function normalizeSearchTerm(value: unknown): string {
 }
 
 function isSearchableFieldType(type: UniverMetaField['type']): boolean {
-  return type === 'string' || type === 'number' || type === 'date' || type === 'select' || type === 'formula'
+  return type === 'string' || type === 'longText' || type === 'number' || type === 'date' || type === 'select' || type === 'formula'
 }
 
 function valueMatchesSearch(value: unknown, search: string): boolean {
@@ -996,6 +997,16 @@ function mapFieldType(type: string): UniverMetaField['type'] {
   if (normalized === 'lookup') return 'lookup'
   if (normalized === 'rollup') return 'rollup'
   if (normalized === 'attachment') return 'attachment'
+  if (
+    normalized === 'longtext' ||
+    normalized === 'long_text' ||
+    normalized === 'long-text' ||
+    normalized === 'textarea' ||
+    normalized === 'multi_line_text' ||
+    normalized === 'multiline'
+  ) {
+    return 'longText'
+  }
   return 'string'
 }
 
@@ -1882,7 +1893,7 @@ type FieldMutationGuard = {
   readOnly: boolean
   hidden: boolean
   link?: LinkFieldConfig | null
-  /** Sanitized property — populated for MF2 batch-1 field types only. */
+  /** Sanitized property — populated for field types whose write path needs config. */
   property?: Record<string, unknown>
 }
 
@@ -3671,7 +3682,7 @@ export function univerMetaRouter(): Router {
       id: z.string().min(1).max(50).optional(),
       sheetId: z.string().min(1).max(50),
       name: z.string().min(1).max(255),
-      type: z.enum(['string', 'number', 'boolean', 'date', 'formula', 'select', 'link', 'lookup', 'rollup', 'attachment']).default('string'),
+      type: z.enum(['string', 'number', 'boolean', 'date', 'formula', 'select', 'link', 'lookup', 'rollup', 'attachment', 'longText']).default('string'),
       property: z.record(z.unknown()).optional(),
       order: z.number().int().nonnegative().optional(),
     })
@@ -3927,7 +3938,7 @@ export function univerMetaRouter(): Router {
 
     const schema = z.object({
       name: z.string().min(1).max(255).optional(),
-      type: z.enum(['string', 'number', 'boolean', 'date', 'formula', 'select', 'link', 'lookup', 'rollup', 'attachment']).optional(),
+      type: z.enum(['string', 'number', 'boolean', 'date', 'formula', 'select', 'link', 'lookup', 'rollup', 'attachment', 'longText']).optional(),
       property: z.record(z.unknown()).optional(),
       order: z.number().int().nonnegative().optional(),
     }).refine((v) => Object.keys(v).length > 0, { message: 'At least one field must be updated' })
@@ -5524,6 +5535,15 @@ export function univerMetaRouter(): Router {
             fieldErrors[fieldId] = 'Formula must start with ='
             continue
           }
+        }
+
+        if (field.type === 'longText') {
+          try {
+            patch[fieldId] = validateLongTextValue(value, fieldId)
+          } catch (error) {
+            fieldErrors[fieldId] = error instanceof Error ? error.message : String(error)
+          }
+          continue
         }
 
         if (BATCH1_FIELD_TYPES.has(field.type)) {

--- a/packages/core-backend/tests/unit/multitable-field-types-batch1.test.ts
+++ b/packages/core-backend/tests/unit/multitable-field-types-batch1.test.ts
@@ -1,5 +1,5 @@
 /**
- * MF2 batch-1 field types — currency / percent / rating / url / email / phone.
+ * MF2/MF3 field types — currency / percent / rating / url / email / phone / longText.
  *
  * Covers:
  *   - mapFieldType: each new type is recognised (not falling through to 'string').
@@ -24,6 +24,7 @@ import {
   sanitizeFieldProperty,
   serializeFieldRow,
   validateEmailValue,
+  validateLongTextValue,
   validatePhoneValue,
   validateUrlValue,
 } from '../../src/multitable/field-codecs'
@@ -47,6 +48,13 @@ describe('mapFieldType — MF2 batch-1', () => {
     expect(mapFieldType('string')).toBe('string')
     expect(mapFieldType('number')).toBe('number')
     expect(mapFieldType('select')).toBe('select')
+  })
+
+  it('recognises longText aliases without falling back to string', () => {
+    expect(mapFieldType('longText')).toBe('longText')
+    expect(mapFieldType('long_text')).toBe('longText')
+    expect(mapFieldType('textarea')).toBe('longText')
+    expect(mapFieldType('multi_line_text')).toBe('longText')
   })
 
   it('exposes BATCH1_FIELD_TYPES set with all 6 names', () => {
@@ -129,6 +137,18 @@ describe('sanitizeFieldProperty — url / email / phone', () => {
   })
 })
 
+describe('sanitizeFieldProperty — longText', () => {
+  it('preserves validation config for multiline text', () => {
+    expect(sanitizeFieldProperty('longText', {
+      validation: [{ type: 'maxLength', params: { value: 2000 } }],
+      placeholder: 'Paste notes',
+    })).toEqual({
+      validation: [{ type: 'maxLength', params: { value: 2000 } }],
+      placeholder: 'Paste notes',
+    })
+  })
+})
+
 describe('serializeFieldRow — batch-1 round-trip', () => {
   it('persists currency type + property', () => {
     const row = {
@@ -153,6 +173,20 @@ describe('serializeFieldRow — batch-1 round-trip', () => {
     })
     expect(serialized.type).toBe('rating')
     expect(serialized.property).toEqual({ max: 7 })
+  })
+
+  it('persists longText type + property', () => {
+    const serialized = serializeFieldRow({
+      id: 'fld_notes',
+      name: 'Notes',
+      type: 'long_text',
+      property: { validation: [{ type: 'maxLength', params: { value: 5000 } }] },
+      order: 2,
+    })
+    expect(serialized.type).toBe('longText')
+    expect(serialized.property).toEqual({
+      validation: [{ type: 'maxLength', params: { value: 5000 } }],
+    })
   })
 })
 
@@ -284,6 +318,21 @@ describe('validatePhoneValue', () => {
 
   it('returns null for empty', () => {
     expect(validatePhoneValue('', 'fld')).toBeNull()
+  })
+})
+
+describe('validateLongTextValue', () => {
+  it('preserves multiline strings exactly', () => {
+    expect(validateLongTextValue('line 1\n  line 2\n', 'fld_notes')).toBe('line 1\n  line 2\n')
+  })
+
+  it('returns null for empty input', () => {
+    expect(validateLongTextValue(null, 'fld_notes')).toBeNull()
+    expect(validateLongTextValue('', 'fld_notes')).toBeNull()
+  })
+
+  it('rejects non-string input', () => {
+    expect(() => validateLongTextValue(['line'], 'fld_notes')).toThrow(/Long text value must be a string/)
   })
 })
 

--- a/packages/core-backend/tests/unit/record-write-service.test.ts
+++ b/packages/core-backend/tests/unit/record-write-service.test.ts
@@ -207,6 +207,53 @@ describe('RecordWriteService', () => {
     )
   })
 
+  it('preserves longText multiline values in the shared write path', async () => {
+    const service = new RecordWriteService(pool, eventBus as any, helpers)
+    const fields: UniverMetaField[] = [
+      { id: 'fld_notes', name: 'Notes', type: 'longText', order: 0 },
+    ]
+    const input = buildTestInput({
+      fields,
+      visiblePropertyFields: fields,
+      visiblePropertyFieldIds: new Set(['fld_notes']),
+      fieldById: new Map([
+        ['fld_notes', { type: 'longText' as const, readOnly: false, hidden: false }],
+      ]) as any,
+      changesByRecord: new Map([
+        ['rec1', [{ fieldId: 'fld_notes', value: 'line 1\n  line 2\n' }]],
+      ]),
+    })
+
+    await service.patchRecords(input)
+
+    const updateCall = (pool.query as any).mock.calls.find((call: unknown[]) =>
+      typeof call[0] === 'string' && call[0].includes('UPDATE meta_records'),
+    )
+    expect(JSON.parse(updateCall[1][0])).toEqual({
+      fld_notes: 'line 1\n  line 2\n',
+    })
+  })
+
+  it('rejects non-string longText writes in the shared write path', async () => {
+    const service = new RecordWriteService(pool, eventBus as any, helpers)
+    const fields: UniverMetaField[] = [
+      { id: 'fld_notes', name: 'Notes', type: 'longText', order: 0 },
+    ]
+    const input = buildTestInput({
+      fields,
+      visiblePropertyFields: fields,
+      visiblePropertyFieldIds: new Set(['fld_notes']),
+      fieldById: new Map([
+        ['fld_notes', { type: 'longText' as const, readOnly: false, hidden: false }],
+      ]) as any,
+      changesByRecord: new Map([
+        ['rec1', [{ fieldId: 'fld_notes', value: ['line'] }]],
+      ]),
+    })
+
+    await expect(service.patchRecords(input)).rejects.toThrow(RecordValidationError)
+  })
+
   it('should throw VersionConflictError when expectedVersion does not match', async () => {
     pool = createMockPool({
       SELECT_FOR_UPDATE: { rows: [{ id: 'rec1', version: 5, created_by: 'user1' }] },
@@ -482,6 +529,19 @@ describe('RecordWriteService', () => {
 
       await expect(service.validateChanges({ sheetId: 's1', changesByRecord, fieldById }))
         .resolves.not.toThrow()
+    })
+
+    it('rejects non-string longText values during preflight validation', async () => {
+      const service = new RecordWriteService(pool, eventBus as any, helpers)
+      const changesByRecord = new Map([
+        ['rec1', [{ fieldId: 'fld_notes', value: { text: 'line' } }]],
+      ])
+      const fieldById = new Map([
+        ['fld_notes', { type: 'longText' as const, readOnly: false, hidden: false }],
+      ])
+
+      await expect(service.validateChanges({ sheetId: 's1', changesByRecord, fieldById }))
+        .rejects.toThrow(/Long text value must be a string/)
     })
   })
 

--- a/packages/openapi/dist/combined.openapi.yml
+++ b/packages/openapi/dist/combined.openapi.yml
@@ -1614,6 +1614,7 @@ components:
             - lookup
             - rollup
             - attachment
+            - longText
         property:
           type: object
           additionalProperties: true
@@ -11330,6 +11331,7 @@ paths:
                     - lookup
                     - rollup
                     - attachment
+                    - longText
                 property:
                   type: object
                   additionalProperties: true
@@ -11402,6 +11404,7 @@ paths:
                     - lookup
                     - rollup
                     - attachment
+                    - longText
                 property:
                   type: object
                   additionalProperties: true

--- a/packages/openapi/dist/openapi.json
+++ b/packages/openapi/dist/openapi.json
@@ -2321,7 +2321,8 @@
               "link",
               "lookup",
               "rollup",
-              "attachment"
+              "attachment",
+              "longText"
             ]
           },
           "property": {
@@ -17466,7 +17467,8 @@
                       "link",
                       "lookup",
                       "rollup",
-                      "attachment"
+                      "attachment",
+                      "longText"
                     ]
                   },
                   "property": {
@@ -17577,7 +17579,8 @@
                       "link",
                       "lookup",
                       "rollup",
-                      "attachment"
+                      "attachment",
+                      "longText"
                     ]
                   },
                   "property": {

--- a/packages/openapi/dist/openapi.yaml
+++ b/packages/openapi/dist/openapi.yaml
@@ -1614,6 +1614,7 @@ components:
             - lookup
             - rollup
             - attachment
+            - longText
         property:
           type: object
           additionalProperties: true
@@ -11330,6 +11331,7 @@ paths:
                     - lookup
                     - rollup
                     - attachment
+                    - longText
                 property:
                   type: object
                   additionalProperties: true
@@ -11402,6 +11404,7 @@ paths:
                     - lookup
                     - rollup
                     - attachment
+                    - longText
                 property:
                   type: object
                   additionalProperties: true

--- a/packages/openapi/src/base.yml
+++ b/packages/openapi/src/base.yml
@@ -1557,6 +1557,7 @@ components:
             - lookup
             - rollup
             - attachment
+            - longText
         property:
           type: object
           additionalProperties: true

--- a/packages/openapi/src/paths/multitable.yml
+++ b/packages/openapi/src/paths/multitable.yml
@@ -358,7 +358,7 @@ paths:
                 name: { type: string }
                 type:
                   type: string
-                  enum: [string, number, boolean, date, formula, select, link, lookup, rollup, attachment]
+                  enum: [string, number, boolean, date, formula, select, link, lookup, rollup, attachment, longText]
                 property:
                   type: object
                   additionalProperties: true
@@ -409,7 +409,7 @@ paths:
                 name: { type: string }
                 type:
                   type: string
-                  enum: [string, number, boolean, date, formula, select, link, lookup, rollup, attachment]
+                  enum: [string, number, boolean, date, formula, select, link, lookup, rollup, attachment, longText]
                 property:
                   type: object
                   additionalProperties: true


### PR DESCRIPTION
## Summary

Adds first-class `longText` support for multitable records.

- Backend field codec, REST route schema, OpenAPI enum, `RecordService`, and `RecordWriteService` validation.
- Frontend field manager, grid cell renderer/editor, record drawer, form view, and filter support.
- Design and verification docs included:
  - `docs/development/wave-m-feishu-3-longtext-field-design-20260429.md`
  - `docs/development/wave-m-feishu-3-longtext-field-verification-20260429.md`

## Verification

- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/multitable-field-types-batch1.test.ts tests/unit/record-write-service.test.ts` -> 88 passed
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/record-service.test.ts tests/unit/field-validation.test.ts tests/unit/field-validation-wiring.test.ts` -> 84 passed
- `pnpm --filter @metasheet/web exec vitest run --watch=false tests/multitable-longtext-cell.spec.ts tests/multitable-form-view.spec.ts tests/multitable-record-drawer.spec.ts tests/multitable-field-manager.spec.ts` -> 29 passed
- `pnpm --filter @metasheet/core-backend build` -> passed
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit` -> passed
- `git diff --check origin/main...HEAD` -> passed

## Boundaries

- No Yjs collaborative editing for long text in this slice.
- No rich text or markdown rendering.
- No automatic migration from existing `string` fields.
