### PR TITLE
feat(multitable): add hierarchy view

### DIFF
--- a/apps/web/src/multitable/components/MetaHierarchyView.vue
+++ b/apps/web/src/multitable/components/MetaHierarchyView.vue
@@ -1,0 +1,397 @@
+<template>
+  <div class="meta-hierarchy" role="tree" aria-label="Hierarchy view">
+    <div class="meta-hierarchy__toolbar">
+      <label class="meta-hierarchy__control">
+        <span>Parent field</span>
+        <select :value="hierarchyDraft.parentFieldId ?? ''" @change="onPickParentField">
+          <option value="">(auto link field)</option>
+          <option v-for="field in linkFields" :key="field.id" :value="field.id">{{ field.name }}</option>
+        </select>
+      </label>
+      <label class="meta-hierarchy__control">
+        <span>Title field</span>
+        <select :value="hierarchyDraft.titleFieldId ?? ''" @change="onPickTitleField">
+          <option value="">(auto)</option>
+          <option v-for="field in fields" :key="field.id" :value="field.id">{{ field.name }}</option>
+        </select>
+      </label>
+      <label class="meta-hierarchy__control">
+        <span>Expand depth</span>
+        <input
+          :value="hierarchyDraft.defaultExpandDepth"
+          type="number"
+          min="0"
+          max="8"
+          @change="onPickExpandDepth"
+        />
+      </label>
+      <label class="meta-hierarchy__control">
+        <span>Orphans</span>
+        <select :value="hierarchyDraft.orphanMode" @change="onPickOrphanMode">
+          <option value="root">show at root</option>
+          <option value="hidden">hide</option>
+        </select>
+      </label>
+      <button v-if="canCreate" class="meta-hierarchy__create" @click="emit('create-record', {})">+ Add root</button>
+    </div>
+
+    <div v-if="!parentField" class="meta-hierarchy__placeholder">
+      <strong>No parent link field configured.</strong>
+      <span>Add or choose a link field to render parent-child relationships.</span>
+    </div>
+
+    <div v-else class="meta-hierarchy__body">
+      <div v-if="treeDiagnostics.length" class="meta-hierarchy__notice" role="status">
+        {{ treeDiagnostics.join(' ') }}
+      </div>
+      <ul v-if="visibleRoots.length" class="meta-hierarchy__list meta-hierarchy__list--root">
+        <HierarchyNode
+          v-for="node in visibleRoots"
+          :key="node.record.id"
+          :node="node"
+          :expanded-ids="expandedIds"
+          :title-for-row="titleForRow"
+          :can-create="canCreate"
+          :can-comment="canComment"
+          :comment-presence="commentPresence"
+          @toggle="toggleNode"
+          @select-record="(recordId) => emit('select-record', recordId)"
+          @open-comments="(recordId) => emit('open-comments', recordId)"
+          @create-child="createChild"
+        />
+      </ul>
+      <div v-else class="meta-hierarchy__empty">No records match this hierarchy view.</div>
+    </div>
+
+    <div v-if="loading" class="meta-hierarchy__loading">Loading...</div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, defineComponent, h, reactive, ref, watch, type PropType } from 'vue'
+import type { MetaField, MetaHierarchyViewConfig, MetaRecord, MultitableCommentPresenceSummary } from '../types'
+import { formatFieldDisplay } from '../utils/field-display'
+import { resolveHierarchyViewConfig } from '../utils/view-config'
+import MetaCommentActionChip from './MetaCommentActionChip.vue'
+import {
+  handleCommentAffordanceKeydown,
+  resolveCommentAffordanceStateClass,
+  resolveRecordCommentAffordance,
+} from '../utils/comment-affordance'
+
+type HierarchyNodeModel = {
+  record: MetaRecord
+  children: HierarchyNodeModel[]
+  depth: number
+}
+
+type TreeResult = {
+  roots: HierarchyNodeModel[]
+  diagnostics: string[]
+}
+
+const props = defineProps<{
+  rows: MetaRecord[]
+  fields: MetaField[]
+  loading: boolean
+  canCreate?: boolean
+  canComment?: boolean
+  viewConfig?: Record<string, unknown> | null
+  commentPresence?: Record<string, MultitableCommentPresenceSummary | undefined>
+}>()
+
+const emit = defineEmits<{
+  (e: 'select-record', recordId: string): void
+  (e: 'open-comments', recordId: string): void
+  (e: 'create-record', data: Record<string, unknown>): void
+  (e: 'update-view-config', input: { config: Record<string, unknown> }): void
+}>()
+
+const hierarchyDraft = reactive<Required<MetaHierarchyViewConfig>>({
+  parentFieldId: null,
+  titleFieldId: null,
+  defaultExpandDepth: 2,
+  orphanMode: 'root',
+})
+const pendingConfigKey = ref<string | null>(null)
+const expandedIds = ref<Set<string>>(new Set())
+
+const hierarchyConfig = computed<Required<MetaHierarchyViewConfig>>(() =>
+  resolveHierarchyViewConfig(props.fields, props.viewConfig),
+)
+
+watch(
+  hierarchyConfig,
+  (config) => {
+    const normalized = normalizeHierarchyConfig(config)
+    const configKey = JSON.stringify(normalized)
+    if (pendingConfigKey.value && pendingConfigKey.value !== configKey) return
+    Object.assign(hierarchyDraft, normalized)
+    if (pendingConfigKey.value === configKey) pendingConfigKey.value = null
+  },
+  { immediate: true },
+)
+
+const linkFields = computed(() => props.fields.filter((field) => field.type === 'link'))
+const parentField = computed(() =>
+  hierarchyDraft.parentFieldId
+    ? props.fields.find((field) => field.id === hierarchyDraft.parentFieldId && field.type === 'link') ?? null
+    : null,
+)
+const titleField = computed(() =>
+  hierarchyDraft.titleFieldId
+    ? props.fields.find((field) => field.id === hierarchyDraft.titleFieldId) ?? null
+    : props.fields.find((field) => field.type === 'string') ?? props.fields[0] ?? null,
+)
+const treeResult = computed<TreeResult>(() =>
+  buildHierarchyTree(props.rows, hierarchyDraft.parentFieldId, hierarchyDraft.orphanMode),
+)
+const visibleRoots = computed(() => treeResult.value.roots)
+const treeDiagnostics = computed(() => treeResult.value.diagnostics)
+
+watch(
+  [() => props.rows, () => hierarchyDraft.defaultExpandDepth, () => hierarchyDraft.parentFieldId],
+  () => {
+    expandedIds.value = defaultExpandedIds(treeResult.value.roots, hierarchyDraft.defaultExpandDepth)
+  },
+  { immediate: true },
+)
+
+function normalizeHierarchyConfig(config?: Partial<Required<MetaHierarchyViewConfig>>): Required<MetaHierarchyViewConfig> {
+  return {
+    parentFieldId: config?.parentFieldId ?? null,
+    titleFieldId: config?.titleFieldId ?? null,
+    defaultExpandDepth: config?.defaultExpandDepth ?? 2,
+    orphanMode: config?.orphanMode === 'hidden' ? 'hidden' : 'root',
+  }
+}
+
+function emitConfigUpdate(next: Partial<Required<MetaHierarchyViewConfig>>) {
+  const normalized = normalizeHierarchyConfig({
+    parentFieldId: hierarchyDraft.parentFieldId,
+    titleFieldId: hierarchyDraft.titleFieldId,
+    defaultExpandDepth: hierarchyDraft.defaultExpandDepth,
+    orphanMode: hierarchyDraft.orphanMode,
+    ...next,
+  })
+  Object.assign(hierarchyDraft, normalized)
+  pendingConfigKey.value = JSON.stringify(normalized)
+  emit('update-view-config', { config: normalized })
+}
+
+function onPickParentField(event: Event) {
+  emitConfigUpdate({ parentFieldId: (event.target as HTMLSelectElement).value || null })
+}
+
+function onPickTitleField(event: Event) {
+  emitConfigUpdate({ titleFieldId: (event.target as HTMLSelectElement).value || null })
+}
+
+function onPickExpandDepth(event: Event) {
+  const value = Number((event.target as HTMLInputElement).value)
+  emitConfigUpdate({ defaultExpandDepth: Math.max(0, Math.min(8, Number.isFinite(value) ? Math.round(value) : 2)) })
+}
+
+function onPickOrphanMode(event: Event) {
+  emitConfigUpdate({ orphanMode: (event.target as HTMLSelectElement).value === 'hidden' ? 'hidden' : 'root' })
+}
+
+function titleForRow(row: MetaRecord): string {
+  if (!titleField.value) return row.id
+  const display = formatFieldDisplay({ field: titleField.value, value: row.data[titleField.value.id] })
+  return display === '-' || display === '—' ? row.id : display
+}
+
+function toggleNode(recordId: string) {
+  const next = new Set(expandedIds.value)
+  if (next.has(recordId)) next.delete(recordId)
+  else next.add(recordId)
+  expandedIds.value = next
+}
+
+function createChild(recordId: string) {
+  const fieldId = hierarchyDraft.parentFieldId
+  emit('create-record', fieldId ? { [fieldId]: [recordId] } : {})
+}
+
+function firstParentId(value: unknown): string | null {
+  if (Array.isArray(value)) {
+    const first = value.find((item) => typeof item === 'string' && item.trim().length > 0)
+    return first ?? null
+  }
+  return typeof value === 'string' && value.trim().length > 0 ? value : null
+}
+
+function hasCycle(recordId: string, parentById: Map<string, string | null>): boolean {
+  const seen = new Set<string>()
+  let current: string | null = recordId
+  while (current) {
+    if (seen.has(current)) return true
+    seen.add(current)
+    current = parentById.get(current) ?? null
+  }
+  return false
+}
+
+function buildHierarchyTree(rows: MetaRecord[], parentFieldId: string | null, orphanMode: 'root' | 'hidden'): TreeResult {
+  const byId = new Map(rows.map((row) => [row.id, row]))
+  const parentById = new Map<string, string | null>()
+  const cyclicIds = new Set<string>()
+  let orphanCount = 0
+
+  for (const row of rows) {
+    const parentId = parentFieldId ? firstParentId(row.data[parentFieldId]) : null
+    parentById.set(row.id, parentId && byId.has(parentId) ? parentId : null)
+    if (parentId && !byId.has(parentId)) orphanCount += 1
+  }
+
+  for (const row of rows) {
+    if (hasCycle(row.id, parentById)) cyclicIds.add(row.id)
+  }
+  for (const rowId of cyclicIds) parentById.set(rowId, null)
+
+  const nodeById = new Map<string, HierarchyNodeModel>()
+  for (const row of rows) nodeById.set(row.id, { record: row, children: [], depth: 0 })
+
+  const roots: HierarchyNodeModel[] = []
+  for (const row of rows) {
+    const node = nodeById.get(row.id)!
+    const parentId = parentById.get(row.id)
+    if (parentId && !cyclicIds.has(row.id)) {
+      nodeById.get(parentId)?.children.push(node)
+    } else if (orphanMode === 'root' || !firstParentId(parentFieldId ? row.data[parentFieldId] : null) || cyclicIds.has(row.id)) {
+      roots.push(node)
+    }
+  }
+
+  function assignDepth(nodes: HierarchyNodeModel[], depth: number) {
+    for (const node of nodes) {
+      node.depth = depth
+      assignDepth(node.children, depth + 1)
+    }
+  }
+  assignDepth(roots, 0)
+
+  const diagnostics: string[] = []
+  if (orphanCount > 0 && orphanMode === 'root') diagnostics.push(`${orphanCount} orphan record${orphanCount === 1 ? '' : 's'} shown at root.`)
+  if (orphanCount > 0 && orphanMode === 'hidden') diagnostics.push(`${orphanCount} orphan record${orphanCount === 1 ? '' : 's'} hidden.`)
+  if (cyclicIds.size > 0) diagnostics.push(`${cyclicIds.size} cyclic record${cyclicIds.size === 1 ? '' : 's'} detached to root.`)
+  return { roots, diagnostics }
+}
+
+function defaultExpandedIds(nodes: HierarchyNodeModel[], depth: number): Set<string> {
+  const ids = new Set<string>()
+  function visit(node: HierarchyNodeModel) {
+    if (node.depth < depth && node.children.length > 0) ids.add(node.record.id)
+    node.children.forEach(visit)
+  }
+  nodes.forEach(visit)
+  return ids
+}
+
+const HierarchyNode = defineComponent({
+  name: 'HierarchyNode',
+  props: {
+    node: { type: Object as PropType<HierarchyNodeModel>, required: true },
+    expandedIds: { type: Object as PropType<Set<string>>, required: true },
+    titleForRow: { type: Function as PropType<(row: MetaRecord) => string>, required: true },
+    canCreate: { type: Boolean, default: false },
+    canComment: { type: Boolean, default: false },
+    commentPresence: { type: Object as PropType<Record<string, MultitableCommentPresenceSummary | undefined> | undefined>, default: undefined },
+  },
+  emits: ['toggle', 'select-record', 'open-comments', 'create-child'],
+  setup(nodeProps, { emit: nodeEmit }) {
+    function rowCommentAffordance(recordId: string) {
+      return resolveRecordCommentAffordance(nodeProps.commentPresence?.[recordId])
+    }
+    function rowCommentButtonClass(recordId: string): string {
+      return resolveCommentAffordanceStateClass('meta-hierarchy__comment-btn', rowCommentAffordance(recordId))
+    }
+    return () => {
+      const node = nodeProps.node
+      const title = nodeProps.titleForRow(node.record)
+      const expanded = nodeProps.expandedIds.has(node.record.id)
+      const hasChildren = node.children.length > 0
+      return h('li', { class: 'meta-hierarchy__item' }, [
+        h('div', {
+          class: 'meta-hierarchy__row',
+          role: 'treeitem',
+          'aria-expanded': hasChildren ? String(expanded) : undefined,
+          style: { paddingLeft: `${node.depth * 18 + 8}px` },
+        }, [
+          h('button', {
+            class: ['meta-hierarchy__toggle', { 'meta-hierarchy__toggle--empty': !hasChildren }],
+            type: 'button',
+            disabled: !hasChildren,
+            onClick: () => nodeEmit('toggle', node.record.id),
+          }, hasChildren ? (expanded ? '▾' : '▸') : '•'),
+          h('button', {
+            class: 'meta-hierarchy__title',
+            type: 'button',
+            onClick: () => nodeEmit('select-record', node.record.id),
+          }, title),
+          nodeProps.canComment
+            ? h('button', {
+              class: rowCommentButtonClass(node.record.id),
+              type: 'button',
+              'aria-label': `Open comments for ${title}`,
+              onClick: () => nodeEmit('open-comments', node.record.id),
+              onKeydown: (event: KeyboardEvent) => handleCommentAffordanceKeydown(event, () => nodeEmit('open-comments', node.record.id)),
+            }, [h(MetaCommentActionChip, { label: 'Comments', state: rowCommentAffordance(node.record.id) })])
+            : null,
+          nodeProps.canCreate
+            ? h('button', {
+              class: 'meta-hierarchy__child-btn',
+              type: 'button',
+              onClick: () => nodeEmit('create-child', node.record.id),
+            }, '+ Child')
+            : null,
+        ]),
+        hasChildren && expanded
+          ? h('ul', { class: 'meta-hierarchy__list', role: 'group' }, node.children.map((child) =>
+            h(HierarchyNode, {
+              key: child.record.id,
+              node: child,
+              expandedIds: nodeProps.expandedIds,
+              titleForRow: nodeProps.titleForRow,
+              canCreate: nodeProps.canCreate,
+              canComment: nodeProps.canComment,
+              commentPresence: nodeProps.commentPresence,
+              onToggle: (recordId: string) => nodeEmit('toggle', recordId),
+              onSelectRecord: (recordId: string) => nodeEmit('select-record', recordId),
+              onOpenComments: (recordId: string) => nodeEmit('open-comments', recordId),
+              onCreateChild: (recordId: string) => nodeEmit('create-child', recordId),
+            }),
+          ))
+          : null,
+      ])
+    }
+  },
+})
+</script>
+
+<style scoped>
+.meta-hierarchy { position: relative; display: flex; flex-direction: column; flex: 1; min-height: 0; background: #f8fafc; color: #334155; }
+.meta-hierarchy__toolbar { display: flex; flex-wrap: wrap; gap: 10px; align-items: end; padding: 12px 16px; border-bottom: 1px solid #e2e8f0; background: #fff; }
+.meta-hierarchy__control { display: flex; flex-direction: column; gap: 4px; min-width: 130px; font-size: 11px; color: #64748b; }
+.meta-hierarchy__control select, .meta-hierarchy__control input { padding: 6px 8px; border: 1px solid #cbd5e1; border-radius: 6px; background: #fff; color: #334155; }
+.meta-hierarchy__create { padding: 7px 12px; border: 1px solid #2563eb; border-radius: 6px; background: #2563eb; color: #fff; cursor: pointer; }
+.meta-hierarchy__placeholder, .meta-hierarchy__empty { margin: 24px; padding: 28px; border: 1px dashed #cbd5e1; border-radius: 10px; background: #fff; color: #64748b; text-align: center; display: flex; flex-direction: column; gap: 6px; }
+.meta-hierarchy__body { flex: 1; min-height: 0; overflow: auto; padding: 14px 16px 24px; }
+.meta-hierarchy__notice { margin-bottom: 10px; padding: 8px 10px; border: 1px solid #fde68a; border-radius: 8px; background: #fffbeb; color: #92400e; font-size: 12px; }
+.meta-hierarchy__list { margin: 0; padding: 0; list-style: none; }
+.meta-hierarchy__list--root { border: 1px solid #e2e8f0; border-radius: 10px; overflow: hidden; background: #fff; }
+.meta-hierarchy__row { display: flex; align-items: center; gap: 8px; min-height: 40px; border-bottom: 1px solid #edf2f7; }
+.meta-hierarchy__item:last-child > .meta-hierarchy__row { border-bottom: 0; }
+.meta-hierarchy__toggle { width: 24px; height: 24px; border: 0; border-radius: 6px; background: #eef2ff; color: #3730a3; cursor: pointer; }
+.meta-hierarchy__toggle--empty { background: transparent; color: #94a3b8; cursor: default; }
+.meta-hierarchy__title { min-width: 0; flex: 1; border: 0; background: transparent; color: #1e293b; font-weight: 600; text-align: left; cursor: pointer; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.meta-hierarchy__title:hover { color: #2563eb; }
+.meta-hierarchy__comment-btn { display: inline-flex; align-items: center; justify-content: center; min-height: 28px; padding: 2px 8px; border: 1px solid #d8e1ee; border-radius: 999px; background: #fff; cursor: pointer; color: #64748b; }
+.meta-hierarchy__comment-btn:hover { border-color: #93c5fd; background: #eff6ff; color: #2563eb; }
+.meta-hierarchy__comment-btn--active { border-color: #f59e0b; background: #fff7ed; color: #b45309; }
+.meta-hierarchy__comment-btn--idle { border-color: #d8e1ee; background: #fff; color: #64748b; }
+.meta-hierarchy__child-btn { margin-right: 10px; padding: 4px 8px; border: 1px dashed #cbd5e1; border-radius: 6px; background: #fff; color: #475569; cursor: pointer; font-size: 12px; }
+.meta-hierarchy__child-btn:hover { border-color: #2563eb; color: #2563eb; }
+.meta-hierarchy__loading { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; background: rgba(255,255,255,.7); font-size: 14px; color: #666; z-index: 10; }
+</style>

--- a/apps/web/src/multitable/components/MetaHierarchyView.vue
+++ b/apps/web/src/multitable/components/MetaHierarchyView.vue
@@ -55,8 +55,8 @@
           :can-comment="canComment"
           :comment-presence="commentPresence"
           @toggle="toggleNode"
-          @select-record="(recordId) => emit('select-record', recordId)"
-          @open-comments="(recordId) => emit('open-comments', recordId)"
+          @select-record="emitSelectRecord"
+          @open-comments="emitOpenComments"
           @create-child="createChild"
         />
       </ul>
@@ -68,7 +68,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, defineComponent, h, reactive, ref, watch, type PropType } from 'vue'
+import { computed, defineComponent, h, reactive, ref, watch, type PropType, type VNode } from 'vue'
 import type { MetaField, MetaHierarchyViewConfig, MetaRecord, MultitableCommentPresenceSummary } from '../types'
 import { formatFieldDisplay } from '../utils/field-display'
 import { resolveHierarchyViewConfig } from '../utils/view-config'
@@ -214,6 +214,14 @@ function createChild(recordId: string) {
   emit('create-record', fieldId ? { [fieldId]: [recordId] } : {})
 }
 
+function emitSelectRecord(recordId: string): void {
+  emit('select-record', recordId)
+}
+
+function emitOpenComments(recordId: string): void {
+  emit('open-comments', recordId)
+}
+
 function firstParentId(value: unknown): string | null {
   if (Array.isArray(value)) {
     const first = value.find((item) => typeof item === 'string' && item.trim().length > 0)
@@ -264,7 +272,7 @@ function buildHierarchyTree(rows: MetaRecord[], parentFieldId: string | null, or
     }
   }
 
-  function assignDepth(nodes: HierarchyNodeModel[], depth: number) {
+  function assignDepth(nodes: HierarchyNodeModel[], depth: number): void {
     for (const node of nodes) {
       node.depth = depth
       assignDepth(node.children, depth + 1)
@@ -281,7 +289,7 @@ function buildHierarchyTree(rows: MetaRecord[], parentFieldId: string | null, or
 
 function defaultExpandedIds(nodes: HierarchyNodeModel[], depth: number): Set<string> {
   const ids = new Set<string>()
-  function visit(node: HierarchyNodeModel) {
+  function visit(node: HierarchyNodeModel): void {
     if (node.depth < depth && node.children.length > 0) ids.add(node.record.id)
     node.children.forEach(visit)
   }
@@ -289,7 +297,7 @@ function defaultExpandedIds(nodes: HierarchyNodeModel[], depth: number): Set<str
   return ids
 }
 
-const HierarchyNode = defineComponent({
+const HierarchyNode: ReturnType<typeof defineComponent> = defineComponent({
   name: 'HierarchyNode',
   props: {
     node: { type: Object as PropType<HierarchyNodeModel>, required: true },
@@ -307,7 +315,7 @@ const HierarchyNode = defineComponent({
     function rowCommentButtonClass(recordId: string): string {
       return resolveCommentAffordanceStateClass('meta-hierarchy__comment-btn', rowCommentAffordance(recordId))
     }
-    return () => {
+    return (): VNode => {
       const node = nodeProps.node
       const title = nodeProps.titleForRow(node.record)
       const expanded = nodeProps.expandedIds.has(node.record.id)
@@ -348,7 +356,7 @@ const HierarchyNode = defineComponent({
             : null,
         ]),
         hasChildren && expanded
-          ? h('ul', { class: 'meta-hierarchy__list', role: 'group' }, node.children.map((child) =>
+          ? h('ul', { class: 'meta-hierarchy__list', role: 'group' }, node.children.map((child: HierarchyNodeModel): VNode =>
             h(HierarchyNode, {
               key: child.record.id,
               node: child,

--- a/apps/web/src/multitable/components/MetaViewManager.vue
+++ b/apps/web/src/multitable/components/MetaViewManager.vue
@@ -248,6 +248,38 @@
           </div>
         </template>
 
+        <template v-else-if="configTarget.type === 'hierarchy'">
+          <div class="meta-view-mgr__grid">
+            <label class="meta-view-mgr__field">
+              <span>Parent field</span>
+              <select v-model="hierarchyDraft.parentFieldId" class="meta-view-mgr__select">
+                <option value="">(auto link field)</option>
+                <option v-for="field in linkFields" :key="field.id" :value="field.id">{{ field.name }}</option>
+              </select>
+            </label>
+            <label class="meta-view-mgr__field">
+              <span>Title field</span>
+              <select v-model="hierarchyDraft.titleFieldId" class="meta-view-mgr__select">
+                <option value="">(auto)</option>
+                <option v-for="field in configTargetFields" :key="field.id" :value="field.id">{{ field.name }}</option>
+              </select>
+            </label>
+          </div>
+          <div class="meta-view-mgr__grid">
+            <label class="meta-view-mgr__field">
+              <span>Default expand depth</span>
+              <input v-model.number="hierarchyDraft.defaultExpandDepth" class="meta-view-mgr__input" type="number" min="0" max="8" />
+            </label>
+            <label class="meta-view-mgr__field">
+              <span>Orphan records</span>
+              <select v-model="hierarchyDraft.orphanMode" class="meta-view-mgr__select">
+                <option value="root">show at root</option>
+                <option value="hidden">hide</option>
+              </select>
+            </label>
+          </div>
+        </template>
+
         <div v-else class="meta-view-mgr__config-note">
           No additional configuration is required for this view type.
         </div>
@@ -335,7 +367,7 @@
             <button v-if="configTargetFields.length" class="meta-view-mgr__btn-inline" @click="addSortRule">+ Add sort</button>
           </div>
 
-          <label v-if="configTarget.type !== 'kanban' && configTarget.type !== 'gantt'" class="meta-view-mgr__field">
+          <label v-if="configTarget.type !== 'kanban' && configTarget.type !== 'gantt' && configTarget.type !== 'hierarchy'" class="meta-view-mgr__field">
             <span>Group field</span>
             <select v-model="groupDraft.fieldId" class="meta-view-mgr__select">
               <option value="">None</option>
@@ -392,6 +424,7 @@ import type {
   MetaField,
   MetaGanttViewConfig,
   MetaGalleryViewConfig,
+  MetaHierarchyViewConfig,
   MetaKanbanViewConfig,
   MetaTimelineViewConfig,
   MetaView,
@@ -406,12 +439,13 @@ import {
   resolveCalendarViewConfig,
   resolveGanttViewConfig,
   resolveGalleryViewConfig,
+  resolveHierarchyViewConfig,
   resolveKanbanViewConfig,
   resolveTimelineViewConfig,
 } from '../utils/view-config'
 import ConditionalFormattingDialog from './ConditionalFormattingDialog.vue'
 
-const VIEW_TYPES = ['grid', 'form', 'kanban', 'gallery', 'calendar', 'timeline', 'gantt'] as const
+const VIEW_TYPES = ['grid', 'form', 'kanban', 'gallery', 'calendar', 'timeline', 'gantt', 'hierarchy'] as const
 const VIEW_ICONS: Record<string, string> = {
   grid: '\u2637',
   form: '\u2263',
@@ -420,6 +454,7 @@ const VIEW_ICONS: Record<string, string> = {
   calendar: '\u2339',
   timeline: '\u2500',
   gantt: '\u25AC',
+  hierarchy: '\u251C',
 }
 
 const props = defineProps<{
@@ -483,6 +518,12 @@ const ganttDraft = reactive<Required<MetaGanttViewConfig>>({
   groupFieldId: null,
   zoom: 'week',
 })
+const hierarchyDraft = reactive<Required<MetaHierarchyViewConfig>>({
+  parentFieldId: null,
+  titleFieldId: null,
+  defaultExpandDepth: 2,
+  orphanMode: 'root',
+})
 const filterDraft = reactive<{ conjunction: FilterConjunction; conditions: FilterRule[] }>({
   conjunction: 'and',
   conditions: [],
@@ -511,6 +552,7 @@ const dateFields = computed(() => props.fields.filter((field) => field.type === 
 const dateLikeFields = computed(() => props.fields.filter((field) => field.type === 'date' || field.type === 'string' || field.type === 'number'))
 const numericFields = computed(() => props.fields.filter((field) => ['number', 'currency', 'percent', 'rating'].includes(field.type)))
 const selectFields = computed(() => props.fields.filter((field) => field.type === 'select'))
+const linkFields = computed(() => props.fields.filter((field) => field.type === 'link'))
 const stringFields = computed(() => props.fields.filter((field) => ['string', 'formula', 'lookup'].includes(field.type)))
 const groupableFields = computed(() => props.fields.filter((field) => ['select', 'string', 'boolean', 'number', 'date'].includes(field.type)))
 const validFieldIds = computed(() => new Set(props.fields.map((field) => field.id)))
@@ -519,6 +561,7 @@ const validAttachmentFieldIds = computed(() => new Set(attachmentFields.value.ma
 const validDateFieldIds = computed(() => new Set(dateFields.value.map((field) => field.id)))
 const validDateLikeFieldIds = computed(() => new Set(dateLikeFields.value.map((field) => field.id)))
 const validSelectFieldIds = computed(() => new Set(selectFields.value.map((field) => field.id)))
+const validLinkFieldIds = computed(() => new Set(linkFields.value.map((field) => field.id)))
 const validGroupableFieldIds = computed(() => new Set(groupableFields.value.map((field) => field.id)))
 
 const viewConfigBlockingReason = computed(() => {
@@ -588,13 +631,22 @@ const viewConfigBlockingReason = computed(() => {
     }
   }
 
+  if (target.type === 'hierarchy') {
+    if (hierarchyDraft.parentFieldId && !validLinkFieldIds.value.has(hierarchyDraft.parentFieldId)) {
+      return 'The selected parent field is no longer a link field. Reload latest before saving.'
+    }
+    if (hierarchyDraft.titleFieldId && !validFieldIds.value.has(hierarchyDraft.titleFieldId)) {
+      return 'The selected title field disappeared in the background. Reload latest before saving.'
+    }
+  }
+
   if (filterDraft.conditions.some((condition) => condition.fieldId && !validFieldIds.value.has(condition.fieldId))) {
     return 'One or more selected filter fields disappeared in the background. Reload latest before saving.'
   }
   if (sortDraft.rules.some((rule) => rule.fieldId && !validFieldIds.value.has(rule.fieldId))) {
     return 'One or more selected sort fields disappeared in the background. Reload latest before saving.'
   }
-  if (target.type !== 'kanban' && target.type !== 'gantt' && groupDraft.fieldId && !validGroupableFieldIds.value.has(groupDraft.fieldId)) {
+  if (target.type !== 'kanban' && target.type !== 'gantt' && target.type !== 'hierarchy' && groupDraft.fieldId && !validGroupableFieldIds.value.has(groupDraft.fieldId)) {
     return 'The selected group field is no longer groupable. Reload latest before saving.'
   }
 
@@ -638,6 +690,12 @@ function resetConfigDrafts() {
     groupFieldId: null,
     zoom: 'week',
   } satisfies Required<MetaGanttViewConfig>)
+  Object.assign(hierarchyDraft, {
+    parentFieldId: null,
+    titleFieldId: null,
+    defaultExpandDepth: 2,
+    orphanMode: 'root',
+  } satisfies Required<MetaHierarchyViewConfig>)
   filterDraft.conjunction = 'and'
   filterDraft.conditions.splice(0)
   sortDraft.rules.splice(0)
@@ -761,6 +819,8 @@ function serializeCommonViewDraft(type: MetaView['type'] | null): Record<string,
       ? kanbanDraft.groupFieldId
       : type === 'gantt'
         ? ganttDraft.groupFieldId
+        : type === 'hierarchy'
+          ? ''
         : groupDraft.fieldId,
   }
 }
@@ -813,6 +873,15 @@ function serializeViewDraft(type: MetaView['type'] | null): string {
       ...serializeCommonViewDraft(type),
     })
   }
+  if (type === 'hierarchy') {
+    return JSON.stringify({
+      parentFieldId: hierarchyDraft.parentFieldId,
+      titleFieldId: hierarchyDraft.titleFieldId,
+      defaultExpandDepth: hierarchyDraft.defaultExpandDepth,
+      orphanMode: hierarchyDraft.orphanMode,
+      ...serializeCommonViewDraft(type),
+    })
+  }
   return JSON.stringify(serializeCommonViewDraft(type))
 }
 
@@ -849,6 +918,8 @@ function hydrateExistingViewConfig(view: MetaView, options?: { liveRefreshText?:
     Object.assign(ganttDraft, resolveGanttViewConfig(props.fields, view.config, view.groupInfo))
   } else if (view.type === 'kanban') {
     Object.assign(kanbanDraft, resolveKanbanViewConfig(props.fields, view.config, view.groupInfo))
+  } else if (view.type === 'hierarchy') {
+    Object.assign(hierarchyDraft, resolveHierarchyViewConfig(props.fields, view.config))
   }
   viewConfigBaseline.value = serializeViewDraft(view.type)
   viewConfigSourceSignature.value = serializeViewSourceSignature(view)
@@ -996,9 +1067,11 @@ function buildCommonViewPayload(target: MetaView): {
       ? ganttDraft.groupFieldId && validGroupableFieldIds.value.has(ganttDraft.groupFieldId)
         ? { fieldId: ganttDraft.groupFieldId }
         : {}
-    : groupDraft.fieldId && validGroupableFieldIds.value.has(groupDraft.fieldId)
-      ? { fieldId: groupDraft.fieldId }
-      : {}
+      : target.type === 'hierarchy'
+        ? undefined
+        : groupDraft.fieldId && validGroupableFieldIds.value.has(groupDraft.fieldId)
+          ? { fieldId: groupDraft.fieldId }
+          : {}
   return {
     ...(hasPayload(filterInfo) || hasPayload(target.filterInfo) ? { filterInfo } : {}),
     ...(hasPayload(sortInfo) || hasPayload(target.sortInfo) ? { sortInfo } : {}),
@@ -1068,6 +1141,17 @@ function saveConfig() {
         cardFieldIds,
       }),
       groupInfo: groupFieldId ? { fieldId: groupFieldId } : {},
+    })
+  } else if (target.type === 'hierarchy') {
+    const defaultExpandDepth = Math.max(0, Math.min(8, Math.round(Number(hierarchyDraft.defaultExpandDepth) || 0)))
+    emit('update-view', target.id, {
+      ...commonPayload,
+      config: preserveConditionalFormattingRules(target, {
+        parentFieldId: hierarchyDraft.parentFieldId && validLinkFieldIds.value.has(hierarchyDraft.parentFieldId) ? hierarchyDraft.parentFieldId : null,
+        titleFieldId: hierarchyDraft.titleFieldId && validFieldIds.value.has(hierarchyDraft.titleFieldId) ? hierarchyDraft.titleFieldId : null,
+        defaultExpandDepth,
+        orphanMode: hierarchyDraft.orphanMode === 'hidden' ? 'hidden' : 'root',
+      }),
     })
   } else {
     emit('update-view', target.id, commonPayload)

--- a/apps/web/src/multitable/components/MetaViewTabBar.vue
+++ b/apps/web/src/multitable/components/MetaViewTabBar.vue
@@ -48,7 +48,7 @@ function onAddSheet() {
 }
 
 function viewTypeIcon(type: string): string {
-  const map: Record<string, string> = { grid: '\u2637', form: '\u2263', kanban: '\u2630', gallery: '\u25A6', calendar: '\u2339' }
+  const map: Record<string, string> = { grid: '\u2637', form: '\u2263', kanban: '\u2630', gallery: '\u25A6', calendar: '\u2339', timeline: '\u2500', gantt: '\u25AC', hierarchy: '\u251C' }
   return map[type] ?? '\u2637'
 }
 </script>

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -586,6 +586,13 @@ export interface MetaGanttViewConfig {
   zoom?: 'day' | 'week' | 'month'
 }
 
+export interface MetaHierarchyViewConfig {
+  parentFieldId?: string | null
+  titleFieldId?: string | null
+  defaultExpandDepth?: number
+  orphanMode?: 'root' | 'hidden'
+}
+
 // --- Record-level permissions ---
 export type RecordPermissionAccessLevel = 'read' | 'write' | 'admin'
 export type RecordPermissionSubjectType = 'user' | 'role' | 'member-group'

--- a/apps/web/src/multitable/utils/view-config.ts
+++ b/apps/web/src/multitable/utils/view-config.ts
@@ -3,6 +3,7 @@ import type {
   MetaField,
   MetaGanttViewConfig,
   MetaGalleryViewConfig,
+  MetaHierarchyViewConfig,
   MetaKanbanViewConfig,
   MetaTimelineViewConfig,
 } from '../types'
@@ -136,5 +137,21 @@ export function resolveGanttViewConfig(
     progressFieldId: stringOrNull(raw?.progressFieldId) ?? firstNonMatchingFieldId(fields, [startFieldId, endFieldId], ['number', 'percent']),
     groupFieldId: stringOrNull(raw?.groupFieldId) ?? stringOrNull(groupInfo?.fieldId),
     zoom: raw?.zoom === 'day' || raw?.zoom === 'month' ? raw.zoom : 'week',
+  }
+}
+
+export function resolveHierarchyViewConfig(
+  fields: MetaField[],
+  raw?: Record<string, unknown> | null,
+): Required<MetaHierarchyViewConfig> {
+  const configuredParentFieldId = stringOrNull(raw?.parentFieldId)
+  const parentFieldId = configuredParentFieldId && fields.some((field) => field.id === configuredParentFieldId && field.type === 'link')
+    ? configuredParentFieldId
+    : fields.find((field) => field.type === 'link')?.id ?? null
+  return {
+    parentFieldId,
+    titleFieldId: stringOrNull(raw?.titleFieldId) ?? firstFieldId(fields, ['string', 'formula', 'lookup']),
+    defaultExpandDepth: clamp(raw?.defaultExpandDepth, 0, 8, 2),
+    orphanMode: raw?.orphanMode === 'hidden' ? 'hidden' : 'root',
   }
 }

--- a/apps/web/src/multitable/views/MultitableEmbedHost.vue
+++ b/apps/web/src/multitable/views/MultitableEmbedHost.vue
@@ -36,7 +36,7 @@ const props = defineProps<{
   commentId?: string
   fieldId?: string
   openComments?: boolean
-  mode?: string // force view type: grid | form | kanban | gallery | calendar
+  mode?: string // force view type: grid | form | kanban | gallery | calendar | timeline | gantt | hierarchy
   embedded?: boolean
   role?: MultitableRole
   primaryColor?: string

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -178,6 +178,17 @@
           @select-record="onSelectRecord" @create-record="onKanbanCreateRecord"
           @update-view-config="onPersistActiveViewConfig"
         />
+        <MetaHierarchyView
+          v-else-if="activeViewType === 'hierarchy'"
+          :rows="grid.rows.value" :fields="scopedAllFields" :loading="grid.loading.value"
+          :view-config="workbench.activeView.value?.config"
+          :can-create="caps.canCreateRecord.value"
+          :can-comment="effectiveRowActions.canComment"
+          :comment-presence="commentPresenceState.presenceByRecordId.value"
+          @select-record="onSelectRecord" @create-record="onKanbanCreateRecord"
+          @open-comments="onOpenRecordComments"
+          @update-view-config="onPersistActiveViewConfig"
+        />
         <MetaGridTable
           v-else
           :rows="grid.rows.value" :visible-fields="scopedGridFields" :sort-rules="grid.sortRules.value"
@@ -376,6 +387,7 @@ import MetaGalleryView from '../components/MetaGalleryView.vue'
 import MetaCalendarView from '../components/MetaCalendarView.vue'
 import MetaTimelineView from '../components/MetaTimelineView.vue'
 import MetaGanttView from '../components/MetaGanttView.vue'
+import MetaHierarchyView from '../components/MetaHierarchyView.vue'
 import MetaToast from '../components/MetaToast.vue'
 import MetaImportModal from '../components/MetaImportModal.vue'
 import MetaMentionPopover from '../components/MetaMentionPopover.vue'

--- a/apps/web/src/router/types.ts
+++ b/apps/web/src/router/types.ts
@@ -234,7 +234,7 @@ export interface AppRouteQuery {
     commentId?: string
     fieldId?: string
     openComments?: string
-    mode?: 'grid' | 'form' | 'kanban' | 'gallery' | 'calendar' | 'timeline' | 'gantt'
+    mode?: 'grid' | 'form' | 'kanban' | 'gallery' | 'calendar' | 'timeline' | 'gantt' | 'hierarchy'
     embedded?: string
     role?: 'owner' | 'editor' | 'commenter' | 'viewer'
   }

--- a/apps/web/tests/multitable-hierarchy-view.spec.ts
+++ b/apps/web/tests/multitable-hierarchy-view.spec.ts
@@ -1,0 +1,121 @@
+import { createApp, h, nextTick } from 'vue'
+import { describe, expect, it, vi } from 'vitest'
+import MetaHierarchyView from '../src/multitable/components/MetaHierarchyView.vue'
+import type { MetaField, MetaRecord } from '../src/multitable/types'
+
+const fields: MetaField[] = [
+  { id: 'fld_title', name: 'Title', type: 'string' },
+  { id: 'fld_parent', name: 'Parent', type: 'link' },
+]
+
+function mountHierarchy(props: {
+  rows: MetaRecord[]
+  viewConfig?: Record<string, unknown>
+  canCreate?: boolean
+  canComment?: boolean
+  onSelectRecord?: (recordId: string) => void
+  onOpenComments?: (recordId: string) => void
+  onCreateRecord?: (data: Record<string, unknown>) => void
+  onUpdateViewConfig?: (input: { config: Record<string, unknown> }) => void
+}) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const app = createApp({
+    render() {
+      return h(MetaHierarchyView, {
+        fields,
+        loading: false,
+        ...props,
+      })
+    },
+  })
+  app.mount(container)
+  return {
+    container,
+    unmount: () => {
+      app.unmount()
+      container.remove()
+    },
+  }
+}
+
+describe('MetaHierarchyView', () => {
+  it('builds a tree from rows and the first parent link id', async () => {
+    const selectSpy = vi.fn()
+    const createSpy = vi.fn()
+    const { container, unmount } = mountHierarchy({
+      rows: [
+        { id: 'rec_root', version: 1, data: { fld_title: 'Root' } },
+        { id: 'rec_child', version: 1, data: { fld_title: 'Child', fld_parent: ['rec_root', 'ignored_parent'] } },
+      ],
+      viewConfig: { parentFieldId: 'fld_parent', titleFieldId: 'fld_title', defaultExpandDepth: 2 },
+      canCreate: true,
+      onSelectRecord: selectSpy,
+      onCreateRecord: createSpy,
+    })
+    await nextTick()
+
+    expect(container.textContent).toContain('Root')
+    expect(container.textContent).toContain('Child')
+
+    ;(Array.from(container.querySelectorAll('.meta-hierarchy__title')) as HTMLButtonElement[])
+      .find((button) => button.textContent === 'Child')
+      ?.click()
+    await nextTick()
+    expect(selectSpy).toHaveBeenCalledWith('rec_child')
+
+    ;(Array.from(container.querySelectorAll('.meta-hierarchy__child-btn')) as HTMLButtonElement[])
+      .find((button) => button.textContent?.includes('Child'))
+      ?.click()
+    await nextTick()
+    expect(createSpy).toHaveBeenCalledWith({ fld_parent: ['rec_root'] })
+
+    unmount()
+  })
+
+  it('falls back for missing parents and cycles on the client', async () => {
+    const { container, unmount } = mountHierarchy({
+      rows: [
+        { id: 'rec_orphan', version: 1, data: { fld_title: 'Orphan', fld_parent: ['missing'] } },
+        { id: 'rec_cycle_a', version: 1, data: { fld_title: 'Cycle A', fld_parent: ['rec_cycle_b'] } },
+        { id: 'rec_cycle_b', version: 1, data: { fld_title: 'Cycle B', fld_parent: ['rec_cycle_a'] } },
+      ],
+      viewConfig: { parentFieldId: 'fld_parent', titleFieldId: 'fld_title', orphanMode: 'root' },
+    })
+    await nextTick()
+
+    expect(container.textContent).toContain('Orphan')
+    expect(container.textContent).toContain('Cycle A')
+    expect(container.textContent).toContain('Cycle B')
+    expect(container.textContent).toContain('1 orphan record shown at root.')
+    expect(container.textContent).toContain('2 cyclic records detached to root.')
+
+    unmount()
+  })
+
+  it('emits hierarchy config updates from inline controls', async () => {
+    const updateSpy = vi.fn()
+    const { container, unmount } = mountHierarchy({
+      rows: [],
+      viewConfig: { parentFieldId: 'fld_parent', titleFieldId: 'fld_title', defaultExpandDepth: 2, orphanMode: 'root' },
+      onUpdateViewConfig: updateSpy,
+    })
+    await nextTick()
+
+    const orphanSelect = Array.from(container.querySelectorAll('.meta-hierarchy__control select'))[2] as HTMLSelectElement
+    orphanSelect.value = 'hidden'
+    orphanSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await nextTick()
+
+    expect(updateSpy).toHaveBeenCalledWith({
+      config: {
+        parentFieldId: 'fld_parent',
+        titleFieldId: 'fld_title',
+        defaultExpandDepth: 2,
+        orphanMode: 'hidden',
+      },
+    })
+
+    unmount()
+  })
+})

--- a/apps/web/tests/multitable-view-manager.spec.ts
+++ b/apps/web/tests/multitable-view-manager.spec.ts
@@ -71,6 +71,69 @@ describe('MetaViewManager', () => {
     app.unmount()
   })
 
+  it('emits persisted hierarchy config when saving view settings', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const updateSpy = vi.fn()
+
+    const app = createApp({
+      render() {
+        return h(MetaViewManager, {
+          visible: true,
+          sheetId: 'sheet_1',
+          activeViewId: 'view_hierarchy',
+          fields: [
+            { id: 'fld_name', name: 'Name', type: 'string' },
+            { id: 'fld_parent', name: 'Parent', type: 'link' },
+            { id: 'fld_alt_parent', name: 'Alt Parent', type: 'link' },
+          ],
+          views: [
+            {
+              id: 'view_hierarchy',
+              sheetId: 'sheet_1',
+              name: 'Hierarchy',
+              type: 'hierarchy',
+              config: { parentFieldId: 'fld_parent', titleFieldId: 'fld_name', defaultExpandDepth: 1, orphanMode: 'root' },
+            },
+          ],
+          onUpdateView: updateSpy,
+        })
+      },
+    })
+
+    app.mount(container)
+    await nextTick()
+
+    ;(container.querySelector('.meta-view-mgr__action[title="Configure"]') as HTMLButtonElement | null)?.click()
+    await nextTick()
+
+    const selects = Array.from(container.querySelectorAll('.meta-view-mgr__config select')) as HTMLSelectElement[]
+    selects[0].value = 'fld_alt_parent'
+    selects[0].dispatchEvent(new Event('change', { bubbles: true }))
+    selects[2].value = 'hidden'
+    selects[2].dispatchEvent(new Event('change', { bubbles: true }))
+    const depthInput = container.querySelector('.meta-view-mgr__config input[type="number"]') as HTMLInputElement
+    depthInput.value = '3'
+    depthInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await nextTick()
+
+    ;(Array.from(container.querySelectorAll('.meta-view-mgr__btn-add')) as HTMLButtonElement[])
+      .find((button) => button.textContent?.includes('Save view settings'))
+      ?.click()
+    await nextTick()
+
+    expect(updateSpy).toHaveBeenCalledWith('view_hierarchy', {
+      config: {
+        parentFieldId: 'fld_alt_parent',
+        titleFieldId: 'fld_name',
+        defaultExpandDepth: 3,
+        orphanMode: 'hidden',
+      },
+    })
+
+    app.unmount()
+  })
+
   it('preserves conditional formatting rules when saving view settings', async () => {
     const container = document.createElement('div')
     document.body.appendChild(container)

--- a/docs/development/wave-m-feishu-3-hierarchy-view-design-20260429.md
+++ b/docs/development/wave-m-feishu-3-hierarchy-view-design-20260429.md
@@ -1,0 +1,38 @@
+# Wave M-Feishu-3 Hierarchy View Design
+
+Date: 2026-04-29
+
+## Scope
+
+This wave adds the minimum frontend-only hierarchy tree view for multitable records.
+
+- New view type: `hierarchy`.
+- New component: `MetaHierarchyView.vue`.
+- Configuration keys: `parentFieldId`, `titleFieldId`, `defaultExpandDepth`, `orphanMode`.
+- Workbench integration reuses the existing record selection, comments drawer, and `createRecord(initialValues)` path.
+
+## Tree Rules
+
+- `parentFieldId` resolves to an explicit configured link field, or the first link field when omitted.
+- Parent extraction uses the first linked record id in the parent field value.
+- Rows without a parent are roots.
+- Rows with a missing parent are handled on the client:
+  - `orphanMode: "root"` shows them at root with a warning.
+  - `orphanMode: "hidden"` hides them with a warning.
+- Parent cycles are detected client-side and detached to root so the tree cannot recurse forever.
+- `titleFieldId` resolves to an explicit field, or the first string/formula/lookup-like field.
+- `defaultExpandDepth` controls initial expansion only; users can expand/collapse nodes locally.
+
+## Actions
+
+- Selecting a row emits `select-record` and opens the existing record drawer path in `MultitableWorkbench`.
+- Comment buttons emit `open-comments` and reuse the existing comments drawer path.
+- `+ Add root` emits an empty create payload.
+- `+ Child` emits `{ [parentFieldId]: [parentRecordId] }` when a parent link field is configured.
+
+## Explicit Non-Goals
+
+- No drag-and-drop reparenting in the first version.
+- No backend table or schema changes.
+- No dedicated hierarchy persistence beyond existing view `config`.
+- No cross-sheet or server-side hierarchy materialization.

--- a/docs/development/wave-m-feishu-3-hierarchy-view-verification-20260429.md
+++ b/docs/development/wave-m-feishu-3-hierarchy-view-verification-20260429.md
@@ -42,3 +42,26 @@ Because this worktree did not have dependencies installed, `node_modules` and `a
 ## Verification Notes
 
 The first Vitest attempt used repo-root-relative test paths while `pnpm --filter @metasheet/web exec` executed from `apps/web`, so Vitest found no files. The successful run used package-relative `tests/...` paths.
+
+## CI Repair Pass
+
+GitHub Actions initially caught stricter `vue-tsc -b` issues in the recursive local component:
+
+- Inline template event lambdas inferred `recordId` as `any`.
+- The recursive `HierarchyNode` render component needed explicit return/type annotations.
+
+Commands:
+
+```bash
+pnpm type-check
+pnpm --filter @metasheet/web exec vitest run --watch=false \
+  tests/multitable-hierarchy-view.spec.ts \
+  tests/multitable-view-manager.spec.ts
+git diff --check origin/main...HEAD
+```
+
+Result:
+
+- `pnpm type-check` passed.
+- 2 frontend files passed, 17 tests passed.
+- Diff hygiene passed.

--- a/docs/development/wave-m-feishu-3-hierarchy-view-verification-20260429.md
+++ b/docs/development/wave-m-feishu-3-hierarchy-view-verification-20260429.md
@@ -1,0 +1,41 @@
+# Wave M-Feishu-3 Hierarchy View Verification
+
+Date: 2026-04-29
+
+## Focused Coverage
+
+- `apps/web/tests/multitable-hierarchy-view.spec.ts`
+  - Builds a tree from `rows`, `fields`, and hierarchy config.
+  - Uses the first parent record id from a link field.
+  - Emits record selection and child creation initial values.
+  - Shows client-side fallback diagnostics for missing parents and cycles.
+  - Emits inline hierarchy config updates.
+- `apps/web/tests/multitable-view-manager.spec.ts`
+  - Saves hierarchy config from `MetaViewManager`.
+
+## Commands Run
+
+```bash
+pnpm --filter @metasheet/web exec vitest run --watch=false tests/multitable-hierarchy-view.spec.ts tests/multitable-view-manager.spec.ts
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+```
+
+Because this worktree did not have dependencies installed, `node_modules` and `apps/web/node_modules` were temporarily symlinked from the main repo for verification, then removed.
+
+## Results
+
+- `pnpm --filter @metasheet/web exec vitest run --watch=false tests/multitable-hierarchy-view.spec.ts tests/multitable-view-manager.spec.ts`
+  - Passed: 2 files, 17 tests.
+- `pnpm --filter @metasheet/web exec vue-tsc --noEmit`
+  - Passed.
+
+## Boundary Checks
+
+- This implementation is frontend-only.
+- It does not add backend tables or migrations.
+- It does not implement drag-to-change-parent; parent updates remain future work.
+- The create-child path depends on the existing create-record API accepting initial field values.
+
+## Verification Notes
+
+The first Vitest attempt used repo-root-relative test paths while `pnpm --filter @metasheet/web exec` executed from `apps/web`, so Vitest found no files. The successful run used package-relative `tests/...` paths.

--- a/docs/development/wave-m-feishu-3-hierarchy-view-verification-20260429.md
+++ b/docs/development/wave-m-feishu-3-hierarchy-view-verification-20260429.md
@@ -18,15 +18,18 @@ Date: 2026-04-29
 ```bash
 pnpm --filter @metasheet/web exec vitest run --watch=false tests/multitable-hierarchy-view.spec.ts tests/multitable-view-manager.spec.ts
 pnpm --filter @metasheet/web exec vue-tsc --noEmit
+git diff --check origin/main...HEAD
 ```
 
-Because this worktree did not have dependencies installed, `node_modules` and `apps/web/node_modules` were temporarily symlinked from the main repo for verification, then removed.
+Because this worktree did not have dependencies installed, `node_modules` and `apps/web/node_modules` were temporarily symlinked from the main repo for verification, then removed. The branch was rebased onto `origin/main@74f96bc6c` before the final verification pass.
 
 ## Results
 
 - `pnpm --filter @metasheet/web exec vitest run --watch=false tests/multitable-hierarchy-view.spec.ts tests/multitable-view-manager.spec.ts`
   - Passed: 2 files, 17 tests.
 - `pnpm --filter @metasheet/web exec vue-tsc --noEmit`
+  - Passed.
+- `git diff --check origin/main...HEAD`
   - Passed.
 
 ## Boundary Checks


### PR DESCRIPTION
## Summary

Adds a frontend-only `hierarchy` view for multitable records.

- New `MetaHierarchyView` component with link-field parent resolution, cycle diagnostics, orphan handling, expand/collapse, record selection, comments, and create-child initial values.
- View manager config for `parentFieldId`, `titleFieldId`, `defaultExpandDepth`, and `orphanMode`.
- Workbench/embed/tab integration.
- Design and verification docs included:
  - `docs/development/wave-m-feishu-3-hierarchy-view-design-20260429.md`
  - `docs/development/wave-m-feishu-3-hierarchy-view-verification-20260429.md`

## Verification

- `pnpm --filter @metasheet/web exec vitest run --watch=false tests/multitable-hierarchy-view.spec.ts tests/multitable-view-manager.spec.ts` -> 17 passed
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit` -> passed
- `git diff --check origin/main...HEAD` -> passed

## Boundaries

- Frontend-only; no backend tables or migrations.
- No drag-to-reparent in this slice.
- Child creation depends on the existing create-record API accepting initial field values.
- Recommended merge order: after #1233 and send_email, then rebase if shared multitable type edits conflict.
