### PR TITLE
feat(multitable): add send email automation action

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -129,6 +129,7 @@
                 <option value="create_record">Create record</option>
                 <option value="send_webhook">Send webhook</option>
                 <option value="send_notification">Send notification</option>
+                <option value="send_email">Send email</option>
                 <option value="send_dingtalk_group_message">Send DingTalk group message</option>
                 <option value="send_dingtalk_person_message">Send DingTalk person message</option>
                 <option value="lock_record">Lock record</option>
@@ -183,6 +184,35 @@
               <input v-model="action.config.userId" class="meta-rule-editor__input" type="text" placeholder="User ID" />
               <label class="meta-rule-editor__label">Message</label>
               <textarea v-model="action.config.message" class="meta-rule-editor__textarea" placeholder="Notification message" rows="3"></textarea>
+            </div>
+
+            <!-- send_email config -->
+            <div v-if="action.type === 'send_email'" class="meta-rule-editor__action-config">
+              <label class="meta-rule-editor__label">Recipients</label>
+              <textarea
+                v-model="action.config.recipientsText"
+                class="meta-rule-editor__textarea"
+                rows="3"
+                placeholder="ops@example.com, owner@example.com"
+                data-field="emailRecipients"
+              ></textarea>
+              <div class="meta-rule-editor__hint">Use comma or newline separated email addresses. Delivery uses the NotificationService email channel.</div>
+              <label class="meta-rule-editor__label">Subject template</label>
+              <input
+                v-model="action.config.subjectTemplate"
+                class="meta-rule-editor__input"
+                type="text"
+                placeholder="{{record.title}} needs attention"
+                data-field="emailSubjectTemplate"
+              />
+              <label class="meta-rule-editor__label">Body template</label>
+              <textarea
+                v-model="action.config.bodyTemplate"
+                class="meta-rule-editor__textarea"
+                rows="4"
+                placeholder="Record {{recordId}} changed. Status: {{record.status}}"
+                data-field="emailBodyTemplate"
+              ></textarea>
             </div>
 
             <!-- send_dingtalk_group_message config -->
@@ -853,6 +883,9 @@ type DraftActionConfig = Record<string, unknown> & {
   recipientFieldPath?: string
   memberGroupRecipientFieldPath?: string
   message?: string
+  recipientsText?: string
+  recipients?: string[]
+  subjectTemplate?: string
   destinationId?: string
   destinationIds?: string[]
   destinationPickerId?: string
@@ -991,6 +1024,14 @@ function draftConfigFromAction(type: AutomationActionType, config: Record<string
       userIdsSearch: '',
     }
   }
+  if (type === 'send_email') {
+    return {
+      ...config,
+      recipientsText: Array.isArray(config.recipients)
+        ? config.recipients.join(', ')
+        : '',
+    }
+  }
   return { ...config }
 }
 
@@ -1060,6 +1101,12 @@ const canSave = computed(() => {
       if (publicFormLinkBlockingErrors(action.config.publicFormViewId).length) return false
       if (internalViewLinkBlockingErrors(action.config.internalViewId).length) return false
     }
+    if (action.type === 'send_email') {
+      const recipients = parseEmailRecipientsText(action.config.recipientsText)
+      const subjectTemplate = typeof action.config.subjectTemplate === 'string' ? action.config.subjectTemplate.trim() : ''
+      const bodyTemplate = typeof action.config.bodyTemplate === 'string' ? action.config.bodyTemplate.trim() : ''
+      if (!recipients.length || !subjectTemplate || !bodyTemplate) return false
+    }
   }
   return true
 })
@@ -1106,6 +1153,16 @@ function parseMemberGroupIdsText(value: unknown): string[] {
     .split(/[\n,]+/)
     .map((entry) => entry.trim())
     .filter(Boolean)
+}
+
+function parseEmailRecipientsText(value: unknown): string[] {
+  if (typeof value !== 'string') return []
+  return Array.from(new Set(
+    value
+      .split(/[\n,]+/)
+      .map((entry) => entry.trim())
+      .filter(Boolean),
+  ))
 }
 
 function personRecipientDirectoryKey(subjectType: 'user' | 'member-group', subjectId: string) {
@@ -1592,6 +1649,8 @@ function defaultConfigForActionType(type: AutomationActionType): DraftActionConf
       return { method: 'POST' }
     case 'send_notification':
       return { userId: '', message: '' }
+    case 'send_email':
+      return { recipientsText: '', subjectTemplate: '', bodyTemplate: '' }
     case 'send_dingtalk_group_message':
       return {
         destinationId: '',
@@ -1718,6 +1777,16 @@ function buildPayload(): Partial<AutomationRule> {
           internalViewId: typeof action.config.internalViewId === 'string' && action.config.internalViewId.trim()
             ? action.config.internalViewId.trim()
             : undefined,
+        },
+      }
+    }
+    if (action.type === 'send_email') {
+      return {
+        type: action.type,
+        config: {
+          recipients: parseEmailRecipientsText(action.config.recipientsText),
+          subjectTemplate: typeof action.config.subjectTemplate === 'string' ? action.config.subjectTemplate.trim() : '',
+          bodyTemplate: typeof action.config.bodyTemplate === 'string' ? action.config.bodyTemplate.trim() : '',
         },
       }
     }

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -644,6 +644,7 @@ export type AutomationActionType =
   | 'create_record'
   | 'send_webhook'
   | 'send_notification'
+  | 'send_email'
   | 'send_dingtalk_group_message'
   | 'send_dingtalk_person_message'
   | 'lock_record'

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -509,6 +509,96 @@ describe('MetaAutomationRuleEditor', () => {
     expect(triggerSelect.value).toBe('record.updated')
   })
 
+  it('emits normalized send_email action payload', async () => {
+    const saved = vi.fn()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      onSave: saved,
+    })
+    await flushPromises()
+
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    nameInput.value = 'Email owner'
+    nameInput.dispatchEvent(new Event('input'))
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_email'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const recipientsInput = container.querySelector('[data-field="emailRecipients"]') as HTMLTextAreaElement
+    recipientsInput.value = 'ops@example.com, owner@example.com\nops@example.com'
+    recipientsInput.dispatchEvent(new Event('input'))
+
+    const subjectInput = container.querySelector('[data-field="emailSubjectTemplate"]') as HTMLInputElement
+    subjectInput.value = 'Record {{record.name}} changed'
+    subjectInput.dispatchEvent(new Event('input'))
+
+    const bodyInput = container.querySelector('[data-field="emailBodyTemplate"]') as HTMLTextAreaElement
+    bodyInput.value = 'Open record {{recordId}}'
+    bodyInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(false)
+    saveBtn.click()
+    await flushPromises()
+
+    expect(saved).toHaveBeenCalledTimes(1)
+    const payload = saved.mock.calls[0][0]
+    expect(payload.actionType).toBe('send_email')
+    expect(payload.actionConfig).toEqual({
+      recipients: ['ops@example.com', 'owner@example.com'],
+      subjectTemplate: 'Record {{record.name}} changed',
+      bodyTemplate: 'Open record {{recordId}}',
+    })
+    expect(payload.actions[0]).toEqual({
+      type: 'send_email',
+      config: {
+        recipients: ['ops@example.com', 'owner@example.com'],
+        subjectTemplate: 'Record {{record.name}} changed',
+        bodyTemplate: 'Open record {{recordId}}',
+      },
+    })
+  })
+
+  it('keeps save disabled for incomplete send_email action', async () => {
+    const saved = vi.fn()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      onSave: saved,
+    })
+    await flushPromises()
+
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    nameInput.value = 'Email owner'
+    nameInput.dispatchEvent(new Event('input'))
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_email'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const recipientsInput = container.querySelector('[data-field="emailRecipients"]') as HTMLTextAreaElement
+    recipientsInput.value = 'ops@example.com'
+    recipientsInput.dispatchEvent(new Event('input'))
+
+    const subjectInput = container.querySelector('[data-field="emailSubjectTemplate"]') as HTMLInputElement
+    subjectInput.value = 'Subject'
+    subjectInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(true)
+    saveBtn.click()
+    await flushPromises()
+    expect(saved).not.toHaveBeenCalled()
+  })
+
   it('emits DingTalk group action config with optional links', async () => {
     const saved = vi.fn()
     const client = mockClient()

--- a/docs/development/wave-m-feishu-3-send-email-design-20260429.md
+++ b/docs/development/wave-m-feishu-3-send-email-design-20260429.md
@@ -1,0 +1,48 @@
+# Wave M-Feishu-3 Send Email Automation Design
+
+Date: 2026-04-29
+
+## Scope
+
+Wave M-Feishu-3 adds a first-class automation action type, `send_email`, for rule authors who need static email delivery from automation rules.
+
+This slice intentionally reuses the existing `NotificationService.send()` email channel. It does not add SMTP, SendGrid, SES, or any other real email provider integration. Provider wiring remains outside this PR.
+
+## Backend Contract
+
+`send_email` action config:
+
+```json
+{
+  "recipients": ["ops@example.com"],
+  "subjectTemplate": "Record {{record.title}} changed",
+  "bodyTemplate": "Status: {{record.status}}"
+}
+```
+
+Validation happens in `AutomationService` for both legacy single-action fields and V1 `actions[]`:
+
+- at least one static recipient is required
+- `subjectTemplate` is required
+- `bodyTemplate` is required
+
+Execution happens in `AutomationExecutor`:
+
+- renders templates with `sheetId`, `recordId`, `actorId`, and `record`
+- calls `notificationService.send({ channel: 'email', ... })`
+- treats `NotificationService` result status `failed` as action failure
+- fails clearly when `notificationService` is not injected
+
+## Frontend Contract
+
+`MetaAutomationRuleEditor` exposes a `Send email` action with:
+
+- static recipients textarea, comma or newline separated
+- subject template
+- body template
+
+Save is disabled until the action has at least one recipient and both templates. The saved payload is normalized to deduplicated `recipients[]`, trimmed `subjectTemplate`, and trimmed `bodyTemplate`.
+
+## Capability Boundary
+
+The current runtime capability is only as strong as the existing NotificationService email channel. In this repository, that channel is the abstraction point for email delivery. Real provider configuration, retries beyond the channel implementation, bounce handling, and operational email credentials are not part of Wave M-Feishu-3.

--- a/docs/development/wave-m-feishu-3-send-email-verification-20260429.md
+++ b/docs/development/wave-m-feishu-3-send-email-verification-20260429.md
@@ -9,6 +9,7 @@ Date: 2026-04-29
 - Backend execution fails clearly for missing recipients, missing templates, or missing `NotificationService`.
 - Rule editor saves normalized email payloads.
 - Rule editor disables save for incomplete email actions.
+- Branch was rebased onto `origin/main@74f96bc6c`.
 
 ## Focused Commands
 
@@ -17,8 +18,9 @@ Planned focused commands:
 ```bash
 pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts
 pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts --watch=false
-pnpm --filter @metasheet/core-backend type-check
-pnpm --filter @metasheet/web type-check
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+git diff --check origin/main...HEAD
 ```
 
 ## Real Capability Boundary
@@ -54,7 +56,13 @@ pnpm --filter @metasheet/core-backend build
 Result: passed. This runs `tsc` for the backend package.
 
 ```bash
-pnpm --filter @metasheet/web type-check
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
 ```
 
-Result: passed. This runs `vue-tsc -b`.
+Result: passed.
+
+```bash
+git diff --check origin/main...HEAD
+```
+
+Result: passed.

--- a/docs/development/wave-m-feishu-3-send-email-verification-20260429.md
+++ b/docs/development/wave-m-feishu-3-send-email-verification-20260429.md
@@ -1,0 +1,60 @@
+# Wave M-Feishu-3 Send Email Automation Verification
+
+Date: 2026-04-29
+
+## Verification Targets
+
+- Backend `send_email` action type is accepted by `AutomationService`.
+- Backend execution calls the injected `NotificationService.send()` email channel.
+- Backend execution fails clearly for missing recipients, missing templates, or missing `NotificationService`.
+- Rule editor saves normalized email payloads.
+- Rule editor disables save for incomplete email actions.
+
+## Focused Commands
+
+Planned focused commands:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts --watch=false
+pnpm --filter @metasheet/core-backend type-check
+pnpm --filter @metasheet/web type-check
+```
+
+## Real Capability Boundary
+
+`send_email` currently routes through the existing `NotificationService` email channel. Real email provider integration is not in this PR. If the deployment has no production email provider behind NotificationService, the automation action can validate and execute through the service abstraction but cannot guarantee external mailbox delivery.
+
+## Results
+
+Environment note: this worktree did not have dependencies installed. I temporarily linked `node_modules` from `/Users/chouhua/Downloads/Github/metasheet2` and package-level links for focused verification, then removed the links after verification.
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts
+```
+
+Result: passed, 1 file, 126 tests. Added `send_email` executor coverage for successful NotificationService email dispatch, missing recipients, missing templates, and missing NotificationService.
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts --watch=false
+```
+
+Result: passed, 1 file, 63 tests. The test environment printed `WebSocket server error: Port is already in use`, but the suite completed successfully.
+
+```bash
+pnpm --filter @metasheet/core-backend type-check
+```
+
+Result: not available; `@metasheet/core-backend` has no `type-check` script.
+
+```bash
+pnpm --filter @metasheet/core-backend build
+```
+
+Result: passed. This runs `tsc` for the backend package.
+
+```bash
+pnpm --filter @metasheet/web type-check
+```
+
+Result: passed. This runs `vue-tsc -b`.

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -1890,6 +1890,7 @@ export class MetaSheetServer {
         undefined,
         schedulerLeaderOptions,
         { leaderStateGauge: promMetrics.automationSchedulerLeaderGauge },
+        notificationService,
       )
       this.automationService.init()
       setAutomationServiceInstance(this.automationService)

--- a/packages/core-backend/src/multitable/automation-actions.ts
+++ b/packages/core-backend/src/multitable/automation-actions.ts
@@ -8,6 +8,7 @@ export type AutomationActionType =
   | 'create_record'
   | 'send_webhook'
   | 'send_notification'
+  | 'send_email'
   | 'send_dingtalk_group_message'
   | 'send_dingtalk_person_message'
   | 'lock_record'
@@ -17,6 +18,7 @@ export const ALL_ACTION_TYPES: AutomationActionType[] = [
   'create_record',
   'send_webhook',
   'send_notification',
+  'send_email',
   'send_dingtalk_group_message',
   'send_dingtalk_person_message',
   'lock_record',
@@ -45,6 +47,13 @@ export interface SendWebhookConfig {
 export interface SendNotificationConfig {
   userIds: string[]
   message: string
+}
+
+/** Config shape for send_email */
+export interface SendEmailConfig {
+  recipients: string[]
+  subjectTemplate: string
+  bodyTemplate: string
 }
 
 /** Config shape for send_dingtalk_group_message */

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -23,12 +23,14 @@ import {
 import type {
   AutomationAction,
   AutomationActionType,
+  SendEmailConfig,
   SendDingTalkGroupMessageConfig,
   SendDingTalkPersonMessageConfig,
 } from './automation-actions'
 import type { ConditionGroup } from './automation-conditions'
 import { evaluateConditions } from './automation-conditions'
 import type { AutomationTrigger } from './automation-triggers'
+import type { NotificationService } from '../types/plugin'
 
 const logger = new Logger('AutomationExecutor')
 
@@ -476,6 +478,7 @@ export interface AutomationDeps {
   eventBus: EventBus
   queryFn: (sql: string, params?: unknown[]) => Promise<{ rows: unknown[]; rowCount?: number | null }>
   fetchFn?: typeof fetch
+  notificationService?: Pick<NotificationService, 'send'>
 }
 
 // ── Executor class ────────────────────────────────────────────────────────
@@ -571,6 +574,9 @@ export class AutomationExecutor {
             break
           case 'send_notification':
             result = await this.executeSendNotification(action.config, context)
+            break
+          case 'send_email':
+            result = await this.executeSendEmail(action.config as unknown as SendEmailConfig, context)
             break
           case 'send_dingtalk_group_message':
             result = await this.executeSendDingTalkGroupMessage(action.config as unknown as SendDingTalkGroupMessageConfig, context)
@@ -780,6 +786,76 @@ export class AutomationExecutor {
       }
     } catch (err) {
       return { actionType: 'send_notification', status: 'failed', error: err instanceof Error ? err.message : String(err) }
+    }
+  }
+
+  private async executeSendEmail(
+    config: SendEmailConfig,
+    context: ExecutionContext,
+  ): Promise<AutomationStepResult> {
+    const recipients = Array.from(new Set(
+      (Array.isArray(config.recipients) ? config.recipients : [])
+        .filter((entry): entry is string => typeof entry === 'string')
+        .map((entry) => entry.trim())
+        .filter(Boolean),
+    ))
+    const subjectTemplate = typeof config.subjectTemplate === 'string' ? config.subjectTemplate.trim() : ''
+    const bodyTemplate = typeof config.bodyTemplate === 'string' ? config.bodyTemplate.trim() : ''
+
+    if (!recipients.length) {
+      return { actionType: 'send_email', status: 'failed', error: 'send_email requires at least one recipient' }
+    }
+    if (!subjectTemplate) {
+      return { actionType: 'send_email', status: 'failed', error: 'send_email subjectTemplate is required' }
+    }
+    if (!bodyTemplate) {
+      return { actionType: 'send_email', status: 'failed', error: 'send_email bodyTemplate is required' }
+    }
+    if (!this.deps.notificationService) {
+      return { actionType: 'send_email', status: 'failed', error: 'NotificationService is not configured for send_email automation action' }
+    }
+
+    const templateData: Record<string, unknown> = {
+      sheetId: context.sheetId,
+      recordId: context.recordId,
+      actorId: context.actorId ?? '',
+      record: context.recordData,
+    }
+    const subject = renderAutomationTemplate(subjectTemplate, templateData).trim()
+    const content = renderAutomationTemplate(bodyTemplate, templateData).trim()
+
+    const result = await this.deps.notificationService.send({
+      channel: 'email',
+      subject,
+      content,
+      recipients: recipients.map((recipient) => ({ id: recipient, type: 'email' })),
+      metadata: {
+        source: 'automation',
+        actionType: 'send_email',
+        ruleId: context.ruleId,
+        sheetId: context.sheetId,
+        recordId: context.recordId,
+        actorId: context.actorId ?? null,
+      },
+    })
+
+    if (result.status === 'failed') {
+      return {
+        actionType: 'send_email',
+        status: 'failed',
+        error: result.failedReason ?? 'NotificationService email send failed',
+        output: result,
+      }
+    }
+
+    return {
+      actionType: 'send_email',
+      status: 'success',
+      output: {
+        notificationId: result.id,
+        notificationStatus: result.status,
+        recipientCount: recipients.length,
+      },
     }
   }
 

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -54,10 +54,46 @@ const VALID_ACTION_TYPES = new Set([
   'create_record',
   'send_webhook',
   'send_notification',
+  'send_email',
   'send_dingtalk_group_message',
   'send_dingtalk_person_message',
   'lock_record',
 ])
+
+function normalizeStringList(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  return value
+    .filter((entry): entry is string => typeof entry === 'string')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+}
+
+function validateSendEmailConfig(config: Record<string, unknown>): string | null {
+  const recipients = normalizeStringList(config.recipients)
+  const subjectTemplate = typeof config.subjectTemplate === 'string' ? config.subjectTemplate.trim() : ''
+  const bodyTemplate = typeof config.bodyTemplate === 'string' ? config.bodyTemplate.trim() : ''
+  if (!recipients.length) return 'send_email requires at least one recipient'
+  if (!subjectTemplate) return 'send_email subjectTemplate is required'
+  if (!bodyTemplate) return 'send_email bodyTemplate is required'
+  return null
+}
+
+function validateSendEmailActionConfigs(
+  actionType: string,
+  actionConfig: Record<string, unknown>,
+  actions: AutomationAction[] | null | undefined,
+): string | null {
+  if (actionType === 'send_email') {
+    const error = validateSendEmailConfig(actionConfig)
+    if (error) return error
+  }
+  for (const action of actions ?? []) {
+    if (action.type !== 'send_email') continue
+    const error = validateSendEmailConfig(action.config)
+    if (error) return error
+  }
+  return null
+}
 
 /**
  * Legacy DB-shaped rule (from automation_rules table).
@@ -197,6 +233,7 @@ export class AutomationService {
     fetchFn?: typeof fetch,
     schedulerLeaderOptions: AutomationSchedulerLeaderOptions | null = null,
     schedulerRuntime: AutomationSchedulerRuntimeOptions = {},
+    notificationService?: AutomationDeps['notificationService'],
   ) {
     this.eventBus = eventBus
     this.db = db
@@ -206,6 +243,7 @@ export class AutomationService {
       eventBus,
       queryFn,
       fetchFn,
+      notificationService,
     }
     this.executor = new AutomationExecutor(deps)
     this.logService = new AutomationLogService()
@@ -277,6 +315,8 @@ export class AutomationService {
       : input.actions ?? null
     const actionConfigValidationError = validateDingTalkAutomationActionConfigs(input.actionType, actionConfig, actions)
     if (actionConfigValidationError) throw new AutomationRuleValidationError(actionConfigValidationError)
+    const sendEmailValidationError = validateSendEmailActionConfigs(input.actionType, actionConfig, actions)
+    if (sendEmailValidationError) throw new AutomationRuleValidationError(sendEmailValidationError)
     const linkValidationError = await validateDingTalkAutomationLinks(
       this.queryFn,
       sheetId,
@@ -389,6 +429,12 @@ export class AutomationService {
         normalizedNextActions,
       )
       if (actionConfigValidationError) throw new AutomationRuleValidationError(actionConfigValidationError)
+      const sendEmailValidationError = validateSendEmailActionConfigs(
+        nextActionType,
+        normalizedNextActionConfig,
+        normalizedNextActions,
+      )
+      if (sendEmailValidationError) throw new AutomationRuleValidationError(sendEmailValidationError)
       const linkValidationError = await validateDingTalkAutomationLinks(
         this.queryFn,
         sheetId,

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -399,6 +399,108 @@ describe('AutomationExecutor', () => {
     expect(emitSpy).toHaveBeenCalledWith('automation.notification', expect.objectContaining({ userIds: ['u1', 'u2'] }))
   })
 
+  it('executes send_email action successfully through NotificationService email channel', async () => {
+    const send = vi.fn(async () => ({ id: 'notif_1', status: 'sent' as const }))
+    deps = createMockDeps({ notificationService: { send } })
+    executor = new AutomationExecutor(deps)
+
+    const rule = createMockRule({
+      actions: [{
+        type: 'send_email',
+        config: {
+          recipients: ['ops@example.com', 'owner@example.com'],
+          subjectTemplate: 'Record {{record.title}} changed',
+          bodyTemplate: 'Status: {{record.status}}',
+        },
+      }],
+    })
+    const result = await executor.execute(rule, {
+      recordId: 'r1',
+      data: { title: 'Incident', status: 'open' },
+      sheetId: 'sheet_1',
+      actorId: 'user_1',
+    })
+
+    expect(result.status).toBe('success')
+    expect(result.steps[0].actionType).toBe('send_email')
+    expect(send).toHaveBeenCalledWith(expect.objectContaining({
+      channel: 'email',
+      subject: 'Record Incident changed',
+      content: 'Status: open',
+      recipients: [
+        { id: 'ops@example.com', type: 'email' },
+        { id: 'owner@example.com', type: 'email' },
+      ],
+      metadata: expect.objectContaining({
+        actionType: 'send_email',
+        ruleId: 'rule_1',
+        sheetId: 'sheet_1',
+        recordId: 'r1',
+      }),
+    }))
+  })
+
+  it('fails send_email with no recipients', async () => {
+    const send = vi.fn(async () => ({ id: 'notif_1', status: 'sent' as const }))
+    deps = createMockDeps({ notificationService: { send } })
+    executor = new AutomationExecutor(deps)
+
+    const rule = createMockRule({
+      actions: [{
+        type: 'send_email',
+        config: {
+          recipients: [],
+          subjectTemplate: 'Subject',
+          bodyTemplate: 'Body',
+        },
+      }],
+    })
+    const result = await executor.execute(rule, { recordId: 'r1', sheetId: 'sheet_1' })
+
+    expect(result.status).toBe('failed')
+    expect(result.steps[0].error).toContain('at least one recipient')
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it('fails send_email with missing templates', async () => {
+    const send = vi.fn(async () => ({ id: 'notif_1', status: 'sent' as const }))
+    deps = createMockDeps({ notificationService: { send } })
+    executor = new AutomationExecutor(deps)
+
+    const rule = createMockRule({
+      actions: [{
+        type: 'send_email',
+        config: {
+          recipients: ['ops@example.com'],
+          subjectTemplate: '',
+          bodyTemplate: 'Body',
+        },
+      }],
+    })
+    const result = await executor.execute(rule, { recordId: 'r1', sheetId: 'sheet_1' })
+
+    expect(result.status).toBe('failed')
+    expect(result.steps[0].error).toContain('subjectTemplate is required')
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it('fails send_email when NotificationService is not configured', async () => {
+    const rule = createMockRule({
+      actions: [{
+        type: 'send_email',
+        config: {
+          recipients: ['ops@example.com'],
+          subjectTemplate: 'Subject',
+          bodyTemplate: 'Body',
+        },
+      }],
+    })
+    const result = await executor.execute(rule, { recordId: 'r1', sheetId: 'sheet_1' })
+
+    expect(result.status).toBe('failed')
+    expect(result.steps[0].error).toContain('NotificationService is not configured')
+  })
+
   it('executes send_dingtalk_group_message action successfully', async () => {
     process.env.APP_BASE_URL = 'https://app.example.com'
     const queryFn = vi.fn()


### PR DESCRIPTION
## Summary

Adds a first-class `send_email` automation action for multitable automation rules.

- Backend `AutomationActionType`, validation, executor dispatch, and server wiring through the existing `NotificationService` email channel.
- Frontend rule editor controls for recipients, subject template, and body template.
- Design and verification docs included:
  - `docs/development/wave-m-feishu-3-send-email-design-20260429.md`
  - `docs/development/wave-m-feishu-3-send-email-verification-20260429.md`

## Verification

- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts` -> 126 passed
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts --watch=false` -> 63 passed
- `pnpm --filter @metasheet/core-backend build` -> passed
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit` -> passed
- `git diff --check origin/main...HEAD` -> passed

## Boundaries

- Reuses existing `NotificationService`; this PR does not add SMTP/SES/SendGrid/provider credentials.
- Static recipient list only; dynamic recipient fields are follow-up work.
- Recommended merge order: after #1233, then rebase if GitHub marks this branch behind/conflicted because both touch multitable shared types.
