### PR TITLE
fix(integration): pass target options through pipeline runner

### DIFF
--- a/docs/development/integration-k3wise-saveonly-target-options-design-20260429.md
+++ b/docs/development/integration-k3wise-saveonly-target-options-design-20260429.md
@@ -1,0 +1,53 @@
+# K3 WISE Save-Only Target Options Design
+
+## Context
+
+The M2 live PoC preflight packet generates K3 WISE pipelines with an explicit
+Save-only target policy:
+
+```json
+{
+  "options": {
+    "target": {
+      "autoSubmit": false,
+      "autoAudit": false
+    }
+  }
+}
+```
+
+The K3 WISE WebAPI adapter already honors per-request `options.autoSubmit` and
+`options.autoAudit`, and those request options intentionally override the
+external-system config. However, the pipeline runner only sent object, records,
+and key fields into `targetAdapter.upsert()`. That meant a correctly generated
+Save-only pipeline could still fall back to the external-system config at write
+time.
+
+## Change
+
+`plugins/plugin-integration-core/lib/pipeline-runner.cjs` now resolves
+`pipeline.options.target` and passes a shallow copy as `input.options` to the
+target adapter:
+
+- Plain object target options are forwarded.
+- Missing, null, scalar, or array target options collapse to `{}`.
+- The runner does not interpret vendor-specific option keys.
+- K3 WISE keeps adapter ownership of boolean coercion and request-vs-config
+  precedence.
+
+This preserves the existing adapter contract while closing the runtime gap
+between preflight-generated pipeline config and K3 WISE target writes.
+
+## Safety
+
+- No external-system config schema change.
+- No database migration.
+- No new route or API surface.
+- The options object is shallow-copied before adapter handoff.
+- Default behavior remains `{}` for pipelines without target runtime options.
+
+## Non-Goals
+
+- Does not enable auto-submit or auto-audit.
+- Does not add vendor-specific option validation to the generic runner.
+- Does not call customer K3 WISE, PLM, SQL Server, or middleware.

--- a/docs/development/integration-k3wise-saveonly-target-options-verification-20260429.md
+++ b/docs/development/integration-k3wise-saveonly-target-options-verification-20260429.md
@@ -1,0 +1,37 @@
+# K3 WISE Save-Only Target Options Verification
+
+## Commands
+
+```bash
+node plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs
+node plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
+node plugins/plugin-integration-core/__tests__/e2e-plm-k3wise-writeback.test.cjs
+git diff --check
+```
+
+## Expected Result
+
+- `pipeline-runner.test.cjs` proves `pipeline.options.target` is passed to
+  `targetAdapter.upsert()` as `input.options`.
+- The same runner suite keeps cleanse, idempotency, incremental, dead-letter,
+  replay, ERP feedback, dry-run, pagination, status, coercion, and watermark
+  regression coverage green.
+- `k3-wise-adapters.test.cjs` continues to prove K3 WISE WebAPI per-request
+  `autoSubmit` and `autoAudit` options override external-system config.
+- The PLM -> K3 WISE writeback E2E remains green.
+- Diff has no whitespace errors.
+
+## Local Result
+
+- `pipeline-runner.test.cjs`: pass.
+- `k3-wise-adapters.test.cjs`: pass.
+- `e2e-plm-k3wise-writeback.test.cjs`: pass.
+- `git diff --check`: pass.
+
+## Live PoC Impact
+
+When the customer GATE packet is converted into a material or BOM pipeline, the
+Save-only flags must be present under `pipeline.options.target`. The runner now
+delivers those flags to the K3 adapter, so the PoC pipeline can force
+`autoSubmit=false` and `autoAudit=false` even if a shared K3 external-system
+record is later edited.

--- a/packages/core-backend/claudedocs/integration-plm-k3wise-mvp.md
+++ b/packages/core-backend/claudedocs/integration-plm-k3wise-mvp.md
@@ -206,6 +206,7 @@ Yuantus/现有 PLM wrapper：
 - credential 通过 external-system registry 写入，不从 API 响应返回明文。
 - `autoSubmit/autoAudit` 默认关闭。
 - **`autoSubmit/autoAudit` 输入硬化（PR #1183）**：config 与 pipeline `request.options` 都接受 `true/false`、字符串 `"true"/"false"/"yes"/"no"/"on"/"off"`、中文 `是/否/启用/禁用/开启/关闭`、数字 `0/1`。Tri-state semantics — 显式 request 值覆盖 config，request 未设时 config 决定，全部未设默认 `false`。错误手输（如 `"maybe"`、`2`、`NaN`）抛 `AdapterValidationError` 带字段名。
+- **Save-only runtime guard**：M2 Live PoC 的 material/BOM pipeline 必须把 `options.target.autoSubmit=false` 与 `options.target.autoAudit=false` 写进 pipeline 配置；pipeline-runner 会把 `pipeline.options.target` 原样传给 target adapter，K3 adapter 的 request options 优先级高于 external-system config。即使 K3 external system config 被后续误改成 `autoSubmit=true`，PoC pipeline 仍以 Save-only 为准。
 - **历史 bug**：在 #1183 之前，操作员手输 `request.options.autoSubmit = "false"`（字符串）会被 `!== false` 判为 truthy，回退到 config，造成 auto-submit 仍触发——已修复并由 `__tests__/k3-wise-adapters.test.cjs` 中 10 项 `testK3WebApiAutoFlagCoercion` 场景固化。
 
 ### 5.3 K3 WISE SQL Server channel
@@ -274,6 +275,10 @@ SQL Server channel 当前是 skeleton：
       "type": "updated_at",
       "field": "updatedAt"
     },
+    "target": {
+      "autoSubmit": false,
+      "autoAudit": false
+    },
     "erpFeedback": {
       "objectId": "standard_materials",
       "keyField": "_integration_idempotency_key"
@@ -335,6 +340,10 @@ SQL Server channel 当前是 skeleton：
   "idempotencyKeyFields": ["sourceId", "revision"],
   "options": {
     "batchSize": 50,
+    "target": {
+      "autoSubmit": false,
+      "autoAudit": false
+    },
     "erpFeedback": {
       "objectId": "bom_cleanse",
       "keyField": "_integration_idempotency_key"

--- a/plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs
@@ -255,6 +255,32 @@ async function main() {
   assert.equal(cleanse.db.tables.get('integration_dead_letters').length, 1)
   assert.equal(await cleanse.db.selectOne('integration_watermarks', { pipeline_id: 'pipe_1' }), null, 'failed batch does not advance watermark')
 
+  // --- 1b. Target runtime options are passed through to the adapter ----
+  let observedTargetOptions = null
+  const targetOptions = createRunnerHarness({
+    sourceRecords: [
+      { code: 'save-01', revision: 'r1', qty: '1', name: 'Save Only', updatedAt: '2026-04-24T01:00:00.000Z' },
+    ],
+    pipelineOverrides: {
+      options: {
+        batchSize: 100,
+        watermark: { type: 'updated_at', field: 'updatedAt' },
+        target: { autoSubmit: false, autoAudit: false, marker: 'save-only' },
+      },
+    },
+    targetUpsert: async (input) => {
+      observedTargetOptions = input.options
+      return createUpsertResult({
+        written: input.records.length,
+        skipped: 0,
+        results: input.records.map((record) => ({ key: record._integration_idempotency_key })),
+      })
+    },
+  })
+  const targetOptionsRun = await targetOptions.runner.runPipeline({ tenantId: 'tenant_1', pipelineId: 'pipe_1', mode: 'full', triggeredBy: 'manual' })
+  assert.equal(targetOptionsRun.run.status, 'succeeded')
+  assert.deepEqual(observedTargetOptions, { autoSubmit: false, autoAudit: false, marker: 'save-only' })
+
   // --- 2. Idempotency prevents duplicate target writes ------------------
   const idem = createRunnerHarness({
     sourceRecords: [

--- a/plugins/plugin-integration-core/lib/pipeline-runner.cjs
+++ b/plugins/plugin-integration-core/lib/pipeline-runner.cjs
@@ -54,6 +54,15 @@ function normalizePositiveIntegerOption(value, { defaultValue, max }) {
   return Math.min(numeric, max)
 }
 
+function isPlainObject(value) {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value))
+}
+
+function resolveTargetOptions(pipeline = {}) {
+  const targetOptions = pipeline.options && pipeline.options.target
+  return isPlainObject(targetOptions) ? { ...targetOptions } : {}
+}
+
 function requireDependency(deps, name, methods) {
   const value = deps[name]
   if (!value) throw new Error(`createPipelineRunner: ${name} is required`)
@@ -458,6 +467,7 @@ function createPipelineRunner(deps = {}) {
             object: context.pipeline.targetObject,
             records: cleanRecords.map((item) => item.targetRecord),
             keyFields: ['_integration_idempotency_key'],
+            options: resolveTargetOptions(context.pipeline),
           }), cleanRecords)
           metrics.rowsWritten += writeResult.written || 0
           metrics.rowsFailed += writeResult.failed || 0


### PR DESCRIPTION
## Summary
- pass pipeline.options.target through to targetAdapter.upsert as request options
- add a pipeline-runner regression proving Save-only K3 flags reach the target adapter
- document the Save-only runtime guard and verification commands

## Verification
- node plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs
- node plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
- node plugins/plugin-integration-core/__tests__/e2e-plm-k3wise-writeback.test.cjs
- git diff --check

## Risk
- No migration, route, or API surface change. Generic runner forwards a shallow copy only; vendor-specific validation remains in adapters.