### PR TITLE
feat(dingtalk): wire mobile signoff into final closeout

### DIFF
--- a/docs/development/dingtalk-p4-final-closeout-mobile-signoff-design-20260429.md
+++ b/docs/development/dingtalk-p4-final-closeout-mobile-signoff-design-20260429.md
@@ -62,6 +62,11 @@ exporter, which performs the strict signoff validation before copy.
 directory. The wrapper rejects the missing-input case before running the final
 handoff export, and closeout rejects it before finalizing the session.
 
+Before any pre-export validation can write a failure summary, final handoff now
+clears stale generated handoff markers. That prevents an old `publish-check.json`
+from making a failed rerun look like it still included passing mobile signoff
+evidence.
+
 ## Summary Output
 
 `dingtalk-p4-final-handoff.mjs` now records:

--- a/docs/development/dingtalk-p4-final-closeout-mobile-signoff-design-20260429.md
+++ b/docs/development/dingtalk-p4-final-closeout-mobile-signoff-design-20260429.md
@@ -89,6 +89,8 @@ This slice does not change the underlying redaction model:
 - only strict compiled and redacted mobile signoff output should be included;
 - handoff and closeout summaries still redact DingTalk webhooks, signing
   secrets, JWTs, bearer tokens, public form tokens, timestamps, and signatures;
+- final handoff failure arrays are sanitized before JSON/Markdown summary output
+  so validator or preflight errors cannot echo raw credential fragments;
 - docs contain placeholder paths only.
 
 ## Non-goals

--- a/docs/development/dingtalk-p4-final-closeout-mobile-signoff-design-20260429.md
+++ b/docs/development/dingtalk-p4-final-closeout-mobile-signoff-design-20260429.md
@@ -1,0 +1,100 @@
+# DingTalk P4 Final Closeout Mobile Signoff Design - 2026-04-29
+
+## Goal
+
+Make the final DingTalk P4 release closeout command include the strict mobile
+public-form signoff gate directly.
+
+The evidence packet exporter already supports `--include-mobile-signoff` and
+`--require-mobile-signoff-pass`. Before this slice, operators using the higher
+level `dingtalk-p4-final-handoff.mjs` or `dingtalk-p4-final-closeout.mjs`
+wrappers still had to run a second manual packet export to include mobile
+signoff. That left a last-mile gap in the recommended one-command closeout path.
+
+## Scope
+
+Updated scripts:
+
+- `scripts/ops/dingtalk-p4-final-handoff.mjs`
+- `scripts/ops/dingtalk-p4-final-closeout.mjs`
+
+Updated tests:
+
+- `scripts/ops/dingtalk-p4-final-handoff.test.mjs`
+- `scripts/ops/dingtalk-p4-final-closeout.test.mjs`
+
+Updated runbook:
+
+- `docs/dingtalk-remote-smoke-checklist-20260422.md`
+
+Added docs:
+
+- `docs/development/dingtalk-p4-final-closeout-mobile-signoff-design-20260429.md`
+- `docs/development/dingtalk-p4-final-closeout-mobile-signoff-verification-20260429.md`
+
+## CLI Contract
+
+Final handoff now accepts:
+
+```bash
+node scripts/ops/dingtalk-p4-final-handoff.mjs \
+  --session-dir output/dingtalk-p4-remote-smoke-session/142-session \
+  --output-dir artifacts/dingtalk-staging-evidence-packet/142-final \
+  --include-mobile-signoff output/dingtalk-public-form-mobile-signoff/142-compiled \
+  --require-mobile-signoff-pass
+```
+
+Final closeout now forwards the same mobile gate options into the final handoff
+step:
+
+```bash
+node scripts/ops/dingtalk-p4-final-closeout.mjs \
+  --session-dir output/dingtalk-p4-remote-smoke-session/142-session \
+  --packet-output-dir artifacts/dingtalk-staging-evidence-packet/142-final \
+  --include-mobile-signoff output/dingtalk-public-form-mobile-signoff/142-compiled \
+  --require-mobile-signoff-pass
+```
+
+`--include-mobile-signoff` can be repeated. Each path is passed to the packet
+exporter, which performs the strict signoff validation before copy.
+
+`--require-mobile-signoff-pass` requires at least one included mobile signoff
+directory. The wrapper rejects the missing-input case before running the final
+handoff export, and closeout rejects it before finalizing the session.
+
+## Summary Output
+
+`dingtalk-p4-final-handoff.mjs` now records:
+
+- whether the mobile signoff gate was required;
+- how many mobile signoff directories the publish validator accepted;
+- the source directories passed to the wrapper.
+
+`dingtalk-p4-final-closeout.mjs` now records:
+
+- `final.mobileSignoffRequired`;
+- `final.mobileSignoffCount`;
+- the forwarded final-handoff command containing the mobile gate options.
+
+The Markdown summaries also show the mobile gate state and accepted signoff
+count so release reviewers can confirm the one-command closeout covered both P4
+remote-smoke evidence and mobile public-form signoff.
+
+## Secret Handling
+
+This slice does not change the underlying redaction model:
+
+- raw mobile `mobile-signoff.json` kit directories are still rejected by the
+  packet exporter;
+- only strict compiled and redacted mobile signoff output should be included;
+- handoff and closeout summaries still redact DingTalk webhooks, signing
+  secrets, JWTs, bearer tokens, public form tokens, timestamps, and signatures;
+- docs contain placeholder paths only.
+
+## Non-goals
+
+- This does not execute DingTalk mobile login or form submission.
+- This does not generate or store real mobile signoff evidence.
+- This does not change P4 smoke finalization rules.
+- This does not replace human review of the final redacted packet before
+  external release handoff.

--- a/docs/development/dingtalk-p4-final-closeout-mobile-signoff-verification-20260429.md
+++ b/docs/development/dingtalk-p4-final-closeout-mobile-signoff-verification-20260429.md
@@ -50,6 +50,8 @@ Final handoff tests now cover:
 - handoff summary `mobileSignoff.required=true` and `includedCount=1`;
 - rejection when `--require-mobile-signoff-pass` is used without an included
   mobile signoff directory;
+- sanitized failure arrays for validator and preflight errors, including
+  secret-like path fragments;
 - existing failure-summary and secret-redaction behavior.
 
 Final closeout tests now cover:

--- a/docs/development/dingtalk-p4-final-closeout-mobile-signoff-verification-20260429.md
+++ b/docs/development/dingtalk-p4-final-closeout-mobile-signoff-verification-20260429.md
@@ -31,7 +31,7 @@ git diff -- scripts/ops/dingtalk-p4-final-handoff.mjs scripts/ops/dingtalk-p4-fi
 
 ## Results
 
-- Final handoff test suite: passed, `10` tests.
+- Final handoff test suite: passed, `11` tests.
 - Final closeout test suite: passed, `7` tests.
 - Exporter regression suite: passed, `18` tests.
 - Packet validator regression suite: passed, `14` tests.
@@ -50,6 +50,8 @@ Final handoff tests now cover:
 - handoff summary `mobileSignoff.required=true` and `includedCount=1`;
 - rejection when `--require-mobile-signoff-pass` is used without an included
   mobile signoff directory;
+- stale `publish-check.json` cleanup before mobile signoff prevalidation
+  failures;
 - sanitized failure arrays for validator and preflight errors, including
   secret-like path fragments;
 - existing failure-summary and secret-redaction behavior.

--- a/docs/development/dingtalk-p4-final-closeout-mobile-signoff-verification-20260429.md
+++ b/docs/development/dingtalk-p4-final-closeout-mobile-signoff-verification-20260429.md
@@ -1,0 +1,89 @@
+# DingTalk P4 Final Closeout Mobile Signoff Verification - 2026-04-29
+
+## Scope
+
+This document verifies that the final P4 handoff and closeout wrappers can carry
+strict mobile public-form signoff evidence into the final staging evidence
+packet.
+
+Changed files:
+
+- `scripts/ops/dingtalk-p4-final-handoff.mjs`
+- `scripts/ops/dingtalk-p4-final-closeout.mjs`
+- `scripts/ops/dingtalk-p4-final-handoff.test.mjs`
+- `scripts/ops/dingtalk-p4-final-closeout.test.mjs`
+- `docs/dingtalk-remote-smoke-checklist-20260422.md`
+- `docs/development/dingtalk-p4-final-closeout-mobile-signoff-design-20260429.md`
+- `docs/development/dingtalk-p4-final-closeout-mobile-signoff-verification-20260429.md`
+
+## Commands
+
+```bash
+node --test scripts/ops/dingtalk-p4-final-handoff.test.mjs
+node --test scripts/ops/dingtalk-p4-final-closeout.test.mjs
+node --test scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs
+node --test scripts/ops/validate-dingtalk-staging-evidence-packet.test.mjs
+git diff --check
+git diff -- scripts/ops/dingtalk-p4-final-handoff.mjs scripts/ops/dingtalk-p4-final-closeout.mjs scripts/ops/dingtalk-p4-final-handoff.test.mjs scripts/ops/dingtalk-p4-final-closeout.test.mjs docs/dingtalk-remote-smoke-checklist-20260422.md docs/development/dingtalk-p4-final-closeout-mobile-signoff-design-20260429.md docs/development/dingtalk-p4-final-closeout-mobile-signoff-verification-20260429.md \
+  | rg -v "rg -n" \
+  | rg -n "(access_token=[A-Za-z0-9]|SEC[0-9a-fA-F]{8,}|Authorization:|Bearer [A-Za-z0-9._-]{20,}|https://oapi\\.dingtalk\\.com/robot/send|JWT_SECRET|DINGTALK_APP_SECRET|publicToken=[A-Za-z0-9._~+/=-]{12,})" || true
+```
+
+## Results
+
+- Final handoff test suite: passed, `10` tests.
+- Final closeout test suite: passed, `7` tests.
+- Exporter regression suite: passed, `18` tests.
+- Packet validator regression suite: passed, `14` tests.
+- `git diff --check`: passed.
+- Diff secret scan: no matches for DingTalk webhook, signing secret, JWT,
+  bearer token, public-token, or app-secret patterns.
+
+## Regression Coverage
+
+Final handoff tests now cover:
+
+- default final packet export without mobile signoff;
+- final packet export with strict mobile signoff required;
+- manifest `requireMobileSignoffPass=true`;
+- publish validator `includedMobileSignoffCount=1`;
+- handoff summary `mobileSignoff.required=true` and `includedCount=1`;
+- rejection when `--require-mobile-signoff-pass` is used without an included
+  mobile signoff directory;
+- existing failure-summary and secret-redaction behavior.
+
+Final closeout tests now cover:
+
+- default final closeout without mobile signoff;
+- final closeout forwarding `--include-mobile-signoff` and
+  `--require-mobile-signoff-pass` into the final handoff step;
+- final handoff summary preserving mobile signoff pass state;
+- closeout summary `final.mobileSignoffRequired=true` and
+  `final.mobileSignoffCount=1`;
+- existing finalize, release-ready, skip-docs, external-artifact, and failure
+  behavior.
+
+## Release Handoff
+
+The preferred real 142 closeout command after strict P4 evidence and strict
+mobile signoff evidence are both ready is:
+
+```bash
+node scripts/ops/dingtalk-p4-final-closeout.mjs \
+  --session-dir <finalized-session-dir> \
+  --packet-output-dir <packet-dir> \
+  --include-mobile-signoff <mobile-compiled-dir> \
+  --require-mobile-signoff-pass
+```
+
+The resulting packet should then show:
+
+- `handoff-summary.json.status=pass`;
+- `handoff-summary.json.mobileSignoff.includedCount > 0`;
+- `publish-check.json.includedMobileSignoffCount > 0`;
+- `closeout-summary.json.final.mobileSignoffRequired=true`;
+- `closeout-summary.json.final.mobileSignoffCount > 0`;
+- `publish-check.json.secretFindings=[]`.
+
+No raw mobile signoff kit or real DingTalk webhook/token value should be present
+in the final release packet.

--- a/docs/dingtalk-remote-smoke-checklist-20260422.md
+++ b/docs/dingtalk-remote-smoke-checklist-20260422.md
@@ -290,6 +290,8 @@ After all manual evidence has been recorded, prefer the closeout wrapper when yo
 node scripts/ops/dingtalk-p4-final-closeout.mjs \
   --session-dir output/dingtalk-p4-remote-smoke-session/142-session \
   --packet-output-dir artifacts/dingtalk-staging-evidence-packet/142-final \
+  --include-mobile-signoff output/dingtalk-public-form-mobile-signoff/142-compiled \
+  --require-mobile-signoff-pass \
   --docs-output-dir docs/development \
   --date 20260423
 ```
@@ -315,7 +317,9 @@ After finalization passes, prefer the one-command final handoff wrapper. It expo
 ```bash
 node scripts/ops/dingtalk-p4-final-handoff.mjs \
   --session-dir output/dingtalk-p4-remote-smoke-session/142-session \
-  --output-dir artifacts/dingtalk-staging-evidence-packet/142-final
+  --output-dir artifacts/dingtalk-staging-evidence-packet/142-final \
+  --include-mobile-signoff output/dingtalk-public-form-mobile-signoff/142-compiled \
+  --require-mobile-signoff-pass
 ```
 
 After final handoff, re-run status with the handoff summary when you need a single release-readiness gate:
@@ -333,6 +337,8 @@ If debugging the individual steps, export a handoff packet with the final-pass g
 node scripts/ops/export-dingtalk-staging-evidence-packet.mjs \
   --include-output output/dingtalk-p4-remote-smoke-session/142-session \
   --require-dingtalk-p4-pass \
+  --include-mobile-signoff output/dingtalk-public-form-mobile-signoff/142-compiled \
+  --require-mobile-signoff-pass \
   --output-dir artifacts/dingtalk-staging-evidence-packet/142-final
 ```
 
@@ -343,6 +349,7 @@ The packet exporter rejects the included session unless the final pass is machin
 - `remoteSmokePhase` is copied into packet metadata when present and must be one of `bootstrap_pending`, `manual_pending`, `finalize_pending`, or `fail`.
 - All eight required checks must exist with `status: "pass"`.
 - `requiredChecksNotPassed`, `manualEvidenceIssues`, `failedChecks`, and `missingRequiredChecks` must be arrays and empty.
+- When `--require-mobile-signoff-pass` is used, the mobile signoff output must be a strict compiled directory containing `summary.json` and `mobile-signoff.redacted.json`, and must not include raw `mobile-signoff.json`.
 - The exporter does not create secrets, but it copies raw included evidence. Review and redact raw workspace/artifact files before release handoff.
 
 Before publishing or sending the packet, run the release handoff validator:

--- a/scripts/ops/dingtalk-p4-final-closeout.mjs
+++ b/scripts/ops/dingtalk-p4-final-closeout.mjs
@@ -27,6 +27,8 @@ session workspace and handoff packet.
 Options:
   --session-dir <dir>                 DingTalk P4 smoke session directory (required)
   --packet-output-dir <dir>           Packet directory, default ${DEFAULT_PACKET_ROOT}/<session-name>-final
+  --include-mobile-signoff <dir>      Optional strict mobile public-form signoff output dir
+  --require-mobile-signoff-pass       Require every included mobile signoff output to be strict passing
   --docs-output-dir <dir>             Final docs directory, default ${DEFAULT_DOCS_DIR}
   --date <yyyymmdd>                   Final docs date suffix, default current UTC date
   --summary-json <file>               Closeout JSON summary, default <packet-output-dir>/closeout-summary.json
@@ -58,6 +60,8 @@ function parseArgs(argv) {
   const opts = {
     sessionDir: '',
     packetOutputDir: '',
+    includeMobileSignoffDirs: [],
+    requireMobileSignoffPass: false,
     docsOutputDir: path.resolve(process.cwd(), DEFAULT_DOCS_DIR),
     date: defaultDate(),
     summaryJson: '',
@@ -76,6 +80,13 @@ function parseArgs(argv) {
       case '--packet-output-dir':
         opts.packetOutputDir = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
         i += 1
+        break
+      case '--include-mobile-signoff':
+        opts.includeMobileSignoffDirs.push(path.resolve(process.cwd(), readRequiredValue(argv, i, arg)))
+        i += 1
+        break
+      case '--require-mobile-signoff-pass':
+        opts.requireMobileSignoffPass = true
         break
       case '--docs-output-dir':
         opts.docsOutputDir = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
@@ -161,10 +172,22 @@ function validatePaths(opts) {
   if (pathsOverlap(opts.packetOutputDir, opts.sessionDir)) {
     throw new Error('--packet-output-dir must not be the session directory or overlap with it')
   }
+  if (opts.requireMobileSignoffPass && opts.includeMobileSignoffDirs.length === 0) {
+    throw new Error('--require-mobile-signoff-pass requires at least one --include-mobile-signoff directory')
+  }
 }
 
 function scriptPath(envName, fallback) {
   return process.env[envName] || fallback
+}
+
+function mobileSignoffHandoffArgs(opts) {
+  const args = []
+  for (const dir of opts.includeMobileSignoffDirs) {
+    args.push('--include-mobile-signoff', dir)
+  }
+  if (opts.requireMobileSignoffPass) args.push('--require-mobile-signoff-pass')
+  return args
 }
 
 function runNodeStep(id, label, script, args) {
@@ -262,6 +285,10 @@ function buildSummary(opts, steps) {
       smokeStatus: status?.overallStatus ?? 'not_available',
       handoffStatus: handoff?.status ?? 'not_available',
       publishStatus: handoff?.publishCheck?.status ?? status?.handoff?.publishStatus ?? 'not_available',
+      mobileSignoffRequired: opts.requireMobileSignoffPass,
+      mobileSignoffCount: handoff?.mobileSignoff?.includedCount
+        ?? handoff?.publishCheck?.includedMobileSignoffCount
+        ?? 0,
       secretFindingCount: Array.isArray(handoff?.publishCheck?.secretFindings)
         ? handoff.publishCheck.secretFindings.length
         : status?.handoff?.secretFindingCount ?? 0,
@@ -316,6 +343,8 @@ ${stepRows.join('\n')}
 - Smoke status: **${summary.final.smokeStatus}**
 - Handoff status: **${summary.final.handoffStatus}**
 - Publish status: **${summary.final.publishStatus}**
+- Mobile signoff gate: **${summary.final.mobileSignoffRequired ? 'required' : 'not_required'}**
+- Included mobile signoff count: **${summary.final.mobileSignoffCount}**
 - Secret findings: **${summary.final.secretFindingCount}**
 
 ## Failures
@@ -366,6 +395,7 @@ function runCloseout(opts) {
         opts.sessionDir,
         '--output-dir',
         opts.packetOutputDir,
+        ...mobileSignoffHandoffArgs(opts),
       ],
     ))
   }

--- a/scripts/ops/dingtalk-p4-final-closeout.test.mjs
+++ b/scripts/ops/dingtalk-p4-final-closeout.test.mjs
@@ -18,6 +18,17 @@ const requiredCheckIds = [
   'delivery-history-group-person',
   'no-email-user-create-bind',
 ]
+const mobileSignoffRequiredCheckIds = [
+  'public-anonymous-submit',
+  'dingtalk-unbound-rejected',
+  'dingtalk-bound-submit',
+  'selected-unbound-rejected',
+  'selected-bound-submit',
+  'selected-unlisted-bound-rejected',
+  'granted-bound-without-grant-rejected',
+  'granted-bound-with-grant-submit',
+  'password-change-bypass-observed',
+]
 const manualClientIds = new Set([
   'send-group-message-form-link',
   'authorized-user-submit',
@@ -97,6 +108,26 @@ function writeReadyForFinalizeSession(sessionDir, overrides = {}) {
     ],
     pendingChecks: [],
     ...overrides.sessionSummary,
+  })
+}
+
+function writeMobileSignoffOutput(signoffDir, overrides = {}) {
+  mkdirSync(signoffDir, { recursive: true })
+  writeJson(path.join(signoffDir, 'summary.json'), {
+    tool: 'dingtalk-public-form-mobile-signoff',
+    generatedAt: '2026-04-29T00:00:00.000Z',
+    strict: true,
+    status: 'pass',
+    errors: [],
+    requiredChecks: mobileSignoffRequiredCheckIds.map((id) => ({ id, status: 'pass' })),
+    ...overrides.summary,
+  })
+  writeFileSync(path.join(signoffDir, 'summary.md'), '# Mobile signoff\n\nStatus: pass\n', 'utf8')
+  writeJson(path.join(signoffDir, 'mobile-signoff.redacted.json'), {
+    tool: 'dingtalk-public-form-mobile-signoff',
+    redacted: true,
+    checks: mobileSignoffRequiredCheckIds.map((id) => ({ id, status: 'pass' })),
+    ...overrides.redacted,
   })
 }
 
@@ -198,6 +229,49 @@ test('dingtalk-p4-final-closeout can stop after release-ready status when docs a
     assert.equal(summary.outputs.verificationMd, '')
     assert.equal(existsSync(path.join(docsDir, 'dingtalk-final-remote-smoke-development-20260423.md')), false)
     assert.equal(existsSync(path.join(docsDir, 'dingtalk-final-remote-smoke-verification-20260423.md')), false)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-p4-final-closeout forwards strict mobile signoff into final handoff', () => {
+  const tmpDir = makeTmpDir()
+  const sessionDir = path.join(tmpDir, '142-session')
+  const mobileSignoffDir = path.join(tmpDir, 'mobile-compiled')
+  const packetDir = path.join(tmpDir, 'packet')
+  const docsDir = path.join(tmpDir, 'docs')
+
+  try {
+    writeReadyForFinalizeSession(sessionDir)
+    writeMobileSignoffOutput(mobileSignoffDir)
+
+    const result = runScript([
+      '--session-dir',
+      sessionDir,
+      '--packet-output-dir',
+      packetDir,
+      '--include-mobile-signoff',
+      mobileSignoffDir,
+      '--require-mobile-signoff-pass',
+      '--docs-output-dir',
+      docsDir,
+      '--date',
+      '20260423',
+      '--skip-docs',
+    ])
+
+    assert.equal(result.status, 0, result.stderr || result.stdout)
+    const handoffSummary = JSON.parse(readFileSync(path.join(packetDir, 'handoff-summary.json'), 'utf8'))
+    assert.equal(handoffSummary.status, 'pass')
+    assert.equal(handoffSummary.mobileSignoff.required, true)
+    assert.equal(handoffSummary.mobileSignoff.includedCount, 1)
+    assert.equal(handoffSummary.publishCheck.includedMobileSignoffCount, 1)
+    const closeoutSummary = JSON.parse(readFileSync(path.join(packetDir, 'closeout-summary.json'), 'utf8'))
+    assert.equal(closeoutSummary.status, 'pass')
+    assert.equal(closeoutSummary.final.mobileSignoffRequired, true)
+    assert.equal(closeoutSummary.final.mobileSignoffCount, 1)
+    assert.match(closeoutSummary.steps[1].command, /--require-mobile-signoff-pass/)
+    assert.match(readFileSync(path.join(packetDir, 'closeout-summary.md'), 'utf8'), /Mobile signoff gate: \*\*required\*\*/)
   } finally {
     rmSync(tmpDir, { recursive: true, force: true })
   }

--- a/scripts/ops/dingtalk-p4-final-handoff.mjs
+++ b/scripts/ops/dingtalk-p4-final-handoff.mjs
@@ -325,8 +325,8 @@ async function main() {
     opts = parseArgs(process.argv.slice(2))
     validateSessionDir(opts.sessionDir)
     validateOutputDir(opts)
-    validateMobileSignoffArgs(opts)
     clearGeneratedHandoffMarkers(opts)
+    validateMobileSignoffArgs(opts)
 
     const exportStep = runNodeStep('export-packet', 'Export final gated packet', [
       'scripts/ops/export-dingtalk-staging-evidence-packet.mjs',

--- a/scripts/ops/dingtalk-p4-final-handoff.mjs
+++ b/scripts/ops/dingtalk-p4-final-handoff.mjs
@@ -115,6 +115,10 @@ function redactString(value) {
     .replace(/\beyJ[A-Za-z0-9._-]{20,}\b/g, '<jwt:redacted>')
 }
 
+function displayPath(file) {
+  return redactString(relativePath(file))
+}
+
 function readJsonIfExists(file) {
   if (!existsSync(file) || !statSync(file).isFile()) return null
   return JSON.parse(readFileSync(file, 'utf8'))
@@ -124,6 +128,21 @@ function compactText(value) {
   const text = redactString(value ?? '').trim()
   if (!text) return ''
   return text.length > 4000 ? `${text.slice(0, 3997)}...` : text
+}
+
+function sanitizeFailureMessage(value) {
+  return compactText(value) || '<empty failure>'
+}
+
+function sanitizeFailureMessages(value) {
+  return Array.isArray(value) ? value.map((failure) => sanitizeFailureMessage(failure)) : value
+}
+
+function sanitizeSummaryValue(value) {
+  if (typeof value === 'string') return redactString(value)
+  if (Array.isArray(value)) return value.map((item) => sanitizeSummaryValue(item))
+  if (!value || typeof value !== 'object') return value
+  return Object.fromEntries(Object.entries(value).map(([key, entry]) => [key, sanitizeSummaryValue(entry)]))
 }
 
 function runNodeStep(id, label, args) {
@@ -136,7 +155,7 @@ function runNodeStep(id, label, args) {
   return {
     id,
     label,
-    command: `node ${args.join(' ')}`,
+    command: compactText(`node ${args.join(' ')}`),
     status: result.status === 0 ? 'pass' : 'fail',
     exitCode: result.status ?? 1,
     startedAt,
@@ -191,14 +210,16 @@ function canWriteFailureSummary(opts) {
 
 function sanitizePublishCheck(value) {
   if (!value || typeof value !== 'object') return value
+  const sanitized = sanitizeSummaryValue(value)
   return {
-    ...value,
-    secretFindings: Array.isArray(value.secretFindings)
-      ? value.secretFindings.map((finding) => ({
+    ...sanitized,
+    failures: sanitizeFailureMessages(sanitized.failures),
+    secretFindings: Array.isArray(sanitized.secretFindings)
+      ? sanitized.secretFindings.map((finding) => ({
           ...finding,
           preview: finding?.preview ? '<redacted>' : finding?.preview,
         }))
-      : value.secretFindings,
+      : sanitized.secretFindings,
   }
 }
 
@@ -276,23 +297,23 @@ function buildSummary(opts, steps) {
     tool: 'dingtalk-p4-final-handoff',
     generatedAt: new Date().toISOString(),
     status: steps.every((step) => step.status === 'pass') && publishCheck?.status === 'pass' ? 'pass' : 'fail',
-    sessionDir: relativePath(opts.sessionDir),
-    sessionRunId: typeof sessionSummary?.runId === 'string' ? sessionSummary.runId : '',
-    outputDir: relativePath(opts.outputDir),
+    sessionDir: displayPath(opts.sessionDir),
+    sessionRunId: typeof sessionSummary?.runId === 'string' ? redactString(sessionSummary.runId) : '',
+    outputDir: displayPath(opts.outputDir),
     steps,
     publishCheck,
     mobileSignoff: {
       required: opts.requireMobileSignoffPass,
       includedCount: publishCheck?.includedMobileSignoffCount ?? 0,
-      sources: opts.includeMobileSignoffDirs.map((dir) => relativePath(dir)),
+      sources: opts.includeMobileSignoffDirs.map((dir) => displayPath(dir)),
     },
     failures,
     outputs: {
-      manifest: relativePath(path.join(opts.outputDir, 'manifest.json')),
-      readme: relativePath(path.join(opts.outputDir, 'README.md')),
-      publishCheckJson: relativePath(opts.publishCheckJson),
-      summaryJson: relativePath(opts.summaryJson),
-      summaryMd: relativePath(opts.summaryMd),
+      manifest: displayPath(path.join(opts.outputDir, 'manifest.json')),
+      readme: displayPath(path.join(opts.outputDir, 'README.md')),
+      publishCheckJson: displayPath(opts.publishCheckJson),
+      summaryJson: displayPath(opts.summaryJson),
+      summaryMd: displayPath(opts.summaryMd),
     },
   }
 }
@@ -331,19 +352,19 @@ async function main() {
 
     const summary = buildSummary(opts, steps)
     writeSummary(summary, opts)
-    console.log(`Wrote ${relativePath(opts.summaryJson)}`)
-    console.log(`Wrote ${relativePath(opts.summaryMd)}`)
+    console.log(`Wrote ${displayPath(opts.summaryJson)}`)
+    console.log(`Wrote ${displayPath(opts.summaryMd)}`)
     if (summary.status !== 'pass') process.exit(1)
   } catch (error) {
     if (opts && canWriteFailureSummary(opts)) {
       const summary = buildSummary(opts, steps)
       summary.status = 'fail'
-      summary.failures.push(error instanceof Error ? error.message : String(error))
+      summary.failures.push(sanitizeFailureMessage(error instanceof Error ? error.message : String(error)))
       writeSummary(summary, opts)
-      console.log(`Wrote ${relativePath(opts.summaryJson)}`)
-      console.log(`Wrote ${relativePath(opts.summaryMd)}`)
+      console.log(`Wrote ${displayPath(opts.summaryJson)}`)
+      console.log(`Wrote ${displayPath(opts.summaryMd)}`)
     }
-    console.error(`[dingtalk-p4-final-handoff] ERROR: ${error instanceof Error ? error.message : String(error)}`)
+    console.error(`[dingtalk-p4-final-handoff] ERROR: ${sanitizeFailureMessage(error instanceof Error ? error.message : String(error))}`)
     process.exit(1)
   }
 }

--- a/scripts/ops/dingtalk-p4-final-handoff.mjs
+++ b/scripts/ops/dingtalk-p4-final-handoff.mjs
@@ -14,6 +14,10 @@ Exports and validates a finalized DingTalk P4 smoke session in one local handoff
 Options:
   --session-dir <dir>          Finalized DingTalk P4 smoke session directory (required)
   --output-dir <dir>           Packet directory, default ${DEFAULT_PACKET_ROOT}/<session-name>-final
+  --include-mobile-signoff <dir>
+                               Optional strict mobile public-form signoff output dir
+  --require-mobile-signoff-pass
+                               Require every included mobile signoff output to be strict passing
   --publish-check-json <file>  Validator JSON output, default <output-dir>/publish-check.json
   --summary-json <file>        Handoff JSON summary, default <output-dir>/handoff-summary.json
   --summary-md <file>          Handoff Markdown summary, default <output-dir>/handoff-summary.md
@@ -40,6 +44,8 @@ function parseArgs(argv) {
   const opts = {
     sessionDir: '',
     outputDir: '',
+    includeMobileSignoffDirs: [],
+    requireMobileSignoffPass: false,
     publishCheckJson: '',
     summaryJson: '',
     summaryMd: '',
@@ -55,6 +61,13 @@ function parseArgs(argv) {
       case '--output-dir':
         opts.outputDir = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
         i += 1
+        break
+      case '--include-mobile-signoff':
+        opts.includeMobileSignoffDirs.push(path.resolve(process.cwd(), readRequiredValue(argv, i, arg)))
+        i += 1
+        break
+      case '--require-mobile-signoff-pass':
+        opts.requireMobileSignoffPass = true
         break
       case '--publish-check-json':
         opts.publishCheckJson = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
@@ -151,10 +164,25 @@ function validateOutputDir(opts) {
   }
 }
 
+function validateMobileSignoffArgs(opts) {
+  if (opts.requireMobileSignoffPass && opts.includeMobileSignoffDirs.length === 0) {
+    throw new Error('--require-mobile-signoff-pass requires at least one --include-mobile-signoff directory')
+  }
+}
+
 function clearGeneratedHandoffMarkers(opts) {
   for (const file of [opts.publishCheckJson, opts.summaryJson, opts.summaryMd]) {
     rmSync(file, { force: true })
   }
+}
+
+function mobileSignoffExportArgs(opts) {
+  const args = []
+  for (const dir of opts.includeMobileSignoffDirs) {
+    args.push('--include-mobile-signoff', relativePath(dir))
+  }
+  if (opts.requireMobileSignoffPass) args.push('--require-mobile-signoff-pass')
+  return args
 }
 
 function canWriteFailureSummary(opts) {
@@ -195,6 +223,10 @@ Session directory: \`${summary.sessionDir}\`
 Packet directory: \`${summary.outputDir}\`
 
 Publish check status: **${publishStatus}**
+
+Mobile signoff gate: **${summary.mobileSignoff.required ? 'required' : 'not_required'}**
+
+Included mobile signoff count: **${summary.mobileSignoff.includedCount}**
 
 ## Steps
 
@@ -249,6 +281,11 @@ function buildSummary(opts, steps) {
     outputDir: relativePath(opts.outputDir),
     steps,
     publishCheck,
+    mobileSignoff: {
+      required: opts.requireMobileSignoffPass,
+      includedCount: publishCheck?.includedMobileSignoffCount ?? 0,
+      sources: opts.includeMobileSignoffDirs.map((dir) => relativePath(dir)),
+    },
     failures,
     outputs: {
       manifest: relativePath(path.join(opts.outputDir, 'manifest.json')),
@@ -267,6 +304,7 @@ async function main() {
     opts = parseArgs(process.argv.slice(2))
     validateSessionDir(opts.sessionDir)
     validateOutputDir(opts)
+    validateMobileSignoffArgs(opts)
     clearGeneratedHandoffMarkers(opts)
 
     const exportStep = runNodeStep('export-packet', 'Export final gated packet', [
@@ -274,6 +312,7 @@ async function main() {
       '--include-output',
       relativePath(opts.sessionDir),
       '--require-dingtalk-p4-pass',
+      ...mobileSignoffExportArgs(opts),
       '--output-dir',
       relativePath(opts.outputDir),
     ])

--- a/scripts/ops/dingtalk-p4-final-handoff.test.mjs
+++ b/scripts/ops/dingtalk-p4-final-handoff.test.mjs
@@ -196,6 +196,41 @@ test('dingtalk-p4-final-handoff rejects required mobile signoff without input', 
   }
 })
 
+test('dingtalk-p4-final-handoff clears stale publish check before mobile signoff prevalidation failure', () => {
+  const tmpDir = makeTmpDir()
+  const sessionDir = path.join(tmpDir, '142-session')
+  const mobileSignoffDir = path.join(tmpDir, 'mobile-compiled')
+  const outputDir = path.join(tmpDir, 'packet')
+
+  try {
+    writeFinalSession(sessionDir)
+    writeMobileSignoffOutput(mobileSignoffDir)
+    const firstResult = runScript([
+      '--session-dir',
+      sessionDir,
+      '--output-dir',
+      outputDir,
+      '--include-mobile-signoff',
+      mobileSignoffDir,
+      '--require-mobile-signoff-pass',
+    ])
+    assert.equal(firstResult.status, 0, firstResult.stderr || firstResult.stdout)
+    assert.equal(existsSync(path.join(outputDir, 'publish-check.json')), true)
+
+    const secondResult = runScript(['--session-dir', sessionDir, '--output-dir', outputDir, '--require-mobile-signoff-pass'])
+
+    assert.equal(secondResult.status, 1)
+    assert.equal(existsSync(path.join(outputDir, 'publish-check.json')), false)
+    const summary = JSON.parse(readFileSync(path.join(outputDir, 'handoff-summary.json'), 'utf8'))
+    assert.equal(summary.status, 'fail')
+    assert.equal(summary.publishCheck, null)
+    assert.equal(summary.mobileSignoff.includedCount, 0)
+    assert.equal(summary.failures.some((failure) => failure.includes('--require-mobile-signoff-pass requires')), true)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
 test('dingtalk-p4-final-handoff fails and writes summary when export gate fails', () => {
   const tmpDir = makeTmpDir()
   const sessionDir = path.join(tmpDir, '142-session')

--- a/scripts/ops/dingtalk-p4-final-handoff.test.mjs
+++ b/scripts/ops/dingtalk-p4-final-handoff.test.mjs
@@ -255,6 +255,7 @@ test('dingtalk-p4-final-handoff fails validation without leaking secret previews
     assert.equal(summary.steps[1].status, 'fail')
     assert.equal(summary.publishCheck.status, 'fail')
     assert.equal(summary.publishCheck.secretFindings.some((finding) => finding.preview === '<redacted>'), true)
+    assert.equal(summary.failures.some((failure) => failure.includes('secret-like value detected')), true)
   } finally {
     rmSync(tmpDir, { recursive: true, force: true })
   }
@@ -306,15 +307,24 @@ test('dingtalk-p4-final-handoff requires session-dir', () => {
 test('dingtalk-p4-final-handoff rejects missing session directory and writes configured summary', () => {
   const tmpDir = makeTmpDir()
   const outputDir = path.join(tmpDir, 'packet')
+  const rawToken = '0123456789abcdef0123456789abcdef'
+  const rawSecret = 'SECabcdefghijklmnop12345678'
+  const missingSessionDir = path.join(tmpDir, `missing-${rawSecret}-access_token=${rawToken}`)
 
   try {
-    const result = runScript(['--session-dir', path.join(tmpDir, 'missing'), '--output-dir', outputDir])
+    const result = runScript(['--session-dir', missingSessionDir, '--output-dir', outputDir])
 
     assert.equal(result.status, 1)
     assert.match(result.stderr, /--session-dir must point to an existing directory/)
-    const summary = JSON.parse(readFileSync(path.join(outputDir, 'handoff-summary.json'), 'utf8'))
+    assert.doesNotMatch(result.stderr, new RegExp(rawToken))
+    assert.doesNotMatch(result.stderr, new RegExp(rawSecret))
+    const summaryText = readFileSync(path.join(outputDir, 'handoff-summary.json'), 'utf8')
+    assert.doesNotMatch(summaryText, new RegExp(rawToken))
+    assert.doesNotMatch(summaryText, new RegExp(rawSecret))
+    const summary = JSON.parse(summaryText)
     assert.equal(summary.status, 'fail')
     assert.equal(summary.failures.some((failure) => failure.includes('--session-dir must point')), true)
+    assert.equal(summary.failures.some((failure) => failure.includes('<redacted>')), true)
   } finally {
     rmSync(tmpDir, { recursive: true, force: true })
   }

--- a/scripts/ops/dingtalk-p4-final-handoff.test.mjs
+++ b/scripts/ops/dingtalk-p4-final-handoff.test.mjs
@@ -18,6 +18,17 @@ const requiredCheckIds = [
   'delivery-history-group-person',
   'no-email-user-create-bind',
 ]
+const mobileSignoffRequiredCheckIds = [
+  'public-anonymous-submit',
+  'dingtalk-unbound-rejected',
+  'dingtalk-bound-submit',
+  'selected-unbound-rejected',
+  'selected-bound-submit',
+  'selected-unlisted-bound-rejected',
+  'granted-bound-without-grant-rejected',
+  'granted-bound-with-grant-submit',
+  'password-change-bypass-observed',
+]
 
 function makeTmpDir() {
   return mkdtempSync(path.join(tmpdir(), 'dingtalk-p4-final-handoff-'))
@@ -71,6 +82,26 @@ function writeFinalSession(sessionDir, overrides = {}) {
   })
 }
 
+function writeMobileSignoffOutput(signoffDir, overrides = {}) {
+  mkdirSync(signoffDir, { recursive: true })
+  writeJson(path.join(signoffDir, 'summary.json'), {
+    tool: 'dingtalk-public-form-mobile-signoff',
+    generatedAt: '2026-04-29T00:00:00.000Z',
+    strict: true,
+    status: 'pass',
+    errors: [],
+    requiredChecks: mobileSignoffRequiredCheckIds.map((id) => ({ id, status: 'pass' })),
+    ...overrides.summary,
+  })
+  writeFileSync(path.join(signoffDir, 'summary.md'), '# Mobile signoff\n\nStatus: pass\n', 'utf8')
+  writeJson(path.join(signoffDir, 'mobile-signoff.redacted.json'), {
+    tool: 'dingtalk-public-form-mobile-signoff',
+    redacted: true,
+    checks: mobileSignoffRequiredCheckIds.map((id) => ({ id, status: 'pass' })),
+    ...overrides.redacted,
+  })
+}
+
 function runScript(args) {
   return spawnSync(process.execPath, [scriptPath, ...args], {
     cwd: repoRoot,
@@ -102,6 +133,64 @@ test('dingtalk-p4-final-handoff exports, validates, and summarizes a final sessi
     assert.deepEqual(summary.steps.map((step) => step.id), ['export-packet', 'validate-packet'])
     assert.equal(summary.steps.every((step) => step.status === 'pass'), true)
     assert.equal(summary.publishCheck.status, 'pass')
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-p4-final-handoff includes strict mobile signoff in final packet', () => {
+  const tmpDir = makeTmpDir()
+  const sessionDir = path.join(tmpDir, '142-session')
+  const mobileSignoffDir = path.join(tmpDir, 'mobile-compiled')
+  const outputDir = path.join(tmpDir, 'packet')
+
+  try {
+    writeFinalSession(sessionDir)
+    writeMobileSignoffOutput(mobileSignoffDir)
+
+    const result = runScript([
+      '--session-dir',
+      sessionDir,
+      '--output-dir',
+      outputDir,
+      '--include-mobile-signoff',
+      mobileSignoffDir,
+      '--require-mobile-signoff-pass',
+    ])
+
+    assert.equal(result.status, 0, result.stderr || result.stdout)
+    const manifest = JSON.parse(readFileSync(path.join(outputDir, 'manifest.json'), 'utf8'))
+    assert.equal(manifest.requireMobileSignoffPass, true)
+    assert.equal(manifest.includedMobileSignoff.length, 1)
+    const publishCheck = JSON.parse(readFileSync(path.join(outputDir, 'publish-check.json'), 'utf8'))
+    assert.equal(publishCheck.status, 'pass')
+    assert.equal(publishCheck.includedMobileSignoffCount, 1)
+    const summary = JSON.parse(readFileSync(path.join(outputDir, 'handoff-summary.json'), 'utf8'))
+    assert.equal(summary.status, 'pass')
+    assert.equal(summary.mobileSignoff.required, true)
+    assert.equal(summary.mobileSignoff.includedCount, 1)
+    assert.deepEqual(summary.mobileSignoff.sources, [path.relative(repoRoot, mobileSignoffDir).replaceAll('\\', '/')])
+    assert.match(readFileSync(path.join(outputDir, 'handoff-summary.md'), 'utf8'), /Mobile signoff gate: \*\*required\*\*/)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-p4-final-handoff rejects required mobile signoff without input', () => {
+  const tmpDir = makeTmpDir()
+  const sessionDir = path.join(tmpDir, '142-session')
+  const outputDir = path.join(tmpDir, 'packet')
+
+  try {
+    writeFinalSession(sessionDir)
+
+    const result = runScript(['--session-dir', sessionDir, '--output-dir', outputDir, '--require-mobile-signoff-pass'])
+
+    assert.equal(result.status, 1)
+    assert.match(result.stderr, /--require-mobile-signoff-pass requires at least one --include-mobile-signoff directory/)
+    const summary = JSON.parse(readFileSync(path.join(outputDir, 'handoff-summary.json'), 'utf8'))
+    assert.equal(summary.status, 'fail')
+    assert.equal(summary.failures.some((failure) => failure.includes('--require-mobile-signoff-pass requires')), true)
   } finally {
     rmSync(tmpDir, { recursive: true, force: true })
   }


### PR DESCRIPTION
## Summary

- Add `--include-mobile-signoff` and `--require-mobile-signoff-pass` to `dingtalk-p4-final-handoff.mjs`.
- Forward the same mobile signoff gate through `dingtalk-p4-final-closeout.mjs` so the preferred one-command closeout covers both P4 smoke and mobile public-form signoff.
- Record mobile gate state/count in handoff and closeout summaries.
- Update the DingTalk remote smoke checklist plus design/verification docs.

## Verification

- `node --test scripts/ops/dingtalk-p4-final-handoff.test.mjs`
- `node --test scripts/ops/dingtalk-p4-final-closeout.test.mjs`
- `node --test scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs`
- `node --test scripts/ops/validate-dingtalk-staging-evidence-packet.test.mjs`
- `git diff --check`
- Diff secret scan for DingTalk webhook/signing secret/JWT/bearer/public-token/app-secret patterns
