### PR TITLE
ci(dingtalk): self-heal stability webhook config

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -37,7 +37,7 @@ This folder contains GitHub Actions that validate Phase 5 SLOs against a Prometh
 
 - `dingtalk-oauth-stability-recording-lite.yml`
   - Triggers every 2 hours (`15 */2 * * *`) and via manual dispatch.
-  - Restores the deploy SSH key, runs `scripts/ops/dingtalk-oauth-stability-check.sh` against `142.171.239.56`, and uploads JSON/log/summary artifacts.
+  - Restores the deploy SSH key, reapplies the on-prem Alertmanager webhook config from `SLACK_WEBHOOK_URL` when available, runs `scripts/ops/dingtalk-oauth-stability-check.sh` against `142.171.239.56`, and uploads JSON/log/summary artifacts.
   - Does not run the Slack drill; it is recording-only and fails the workflow when `healthy != true`.
   - Like other scheduled/manual workflows, it only becomes live after the workflow file exists on the default branch.
 
@@ -45,7 +45,7 @@ This folder contains GitHub Actions that validate Phase 5 SLOs against a Prometh
 
  - `METRICS_URL`: e.g., `https://staging.example.com/metrics/prom`.
  - `METRICS_AUTH_HEADER` (optional): e.g., `Authorization: Bearer <token>`.
- - `SLACK_WEBHOOK_URL` (optional for nightly failures / success enrichment).
+ - `SLACK_WEBHOOK_URL` (optional for nightly failures / success enrichment; also used to self-heal on-prem Alertmanager webhook config before DingTalk OAuth stability checks).
  - `SLACK_CHANNEL` (optional): e.g., `alerts`.
  - `GRAFANA_API_TOKEN` (ops deploy only, for dashboard upload).
  - `REDIS_URL` (optional: enables Redis-backed cache validation).

--- a/.github/workflows/dingtalk-oauth-stability-recording-lite.yml
+++ b/.github/workflows/dingtalk-oauth-stability-recording-lite.yml
@@ -28,6 +28,22 @@ jobs:
           printf '%s' "$DEPLOY_SSH_KEY_B64" | base64 -d > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
 
+      - name: Reapply Alertmanager webhook config
+        env:
+          ALERTMANAGER_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${ALERTMANAGER_WEBHOOK_URL:-}" ]]; then
+            echo "::notice::SLACK_WEBHOOK_URL is not set; Alertmanager webhook self-heal skipped."
+            exit 0
+          fi
+
+          SSH_USER_HOST="${DEPLOY_USER}@${DEPLOY_HOST}" \
+          SSH_KEY="${HOME}/.ssh/deploy_key" \
+          bash scripts/ops/set-dingtalk-onprem-alertmanager-webhook-config.sh set
+
       - name: Run remote stability check
         id: stability
         continue-on-error: true

--- a/docs/development/dingtalk-oauth-stability-webhook-selfheal-design-20260429.md
+++ b/docs/development/dingtalk-oauth-stability-webhook-selfheal-design-20260429.md
@@ -1,0 +1,55 @@
+# DingTalk OAuth Stability Webhook Self-Heal Design
+
+## Context
+
+The scheduled `DingTalk OAuth Stability Recording (Lite)` workflow failed on
+`main@5ddd8ebbe` even though the remote stability command returned `rc=0`.
+The uploaded summary reported:
+
+- backend health was ok;
+- Alertmanager had no active alerts and no notify errors;
+- root disk usage was below the gate;
+- the only blocking reason was `Alertmanager webhook is not configured`.
+
+The repository already has
+`scripts/ops/set-dingtalk-onprem-alertmanager-webhook-config.sh`, which writes
+the on-prem Alertmanager webhook env file through the deploy SSH key without
+printing the secret. The workflow was only observing drift; it was not
+attempting to reapply the persisted configuration before running the gate.
+
+## Change
+
+Add a pre-check self-heal step to
+`.github/workflows/dingtalk-oauth-stability-recording-lite.yml`:
+
+1. Restore the deploy SSH key as before.
+2. If `SLACK_WEBHOOK_URL` is available, call
+   `scripts/ops/set-dingtalk-onprem-alertmanager-webhook-config.sh set` with:
+   - `ALERTMANAGER_WEBHOOK_URL=${{ secrets.SLACK_WEBHOOK_URL }}`
+   - `SSH_USER_HOST=${DEPLOY_USER}@${DEPLOY_HOST}`
+   - `SSH_KEY=${HOME}/.ssh/deploy_key`
+3. If the secret is absent, emit a GitHub notice and continue to the existing
+   health check.
+4. Keep the final hard gate unchanged: the workflow still fails when the remote
+   health report says `healthy=false`.
+
+This turns the workflow from a passive drift detector into a safe drift repair
+attempt, while keeping misconfiguration visible when the repository secret is
+missing or invalid.
+
+## Safety
+
+- The webhook URL comes only from the existing GitHub secret
+  `SLACK_WEBHOOK_URL`.
+- The helper script validates that the value is an HTTP/HTTPS URL.
+- The helper writes the remote env file via base64 and `install -m 600`.
+- The workflow does not print the webhook URL.
+- The failure gate is not weakened. If self-heal cannot make the deployment
+  healthy, the run still fails and uploads the same artifacts.
+
+## Non-Goals
+
+- Does not create or rotate Slack webhooks.
+- Does not commit any webhook value.
+- Does not change the DingTalk OAuth health criteria.
+- Does not make missing `SLACK_WEBHOOK_URL` appear healthy.

--- a/docs/development/dingtalk-oauth-stability-webhook-selfheal-verification-20260429.md
+++ b/docs/development/dingtalk-oauth-stability-webhook-selfheal-verification-20260429.md
@@ -1,0 +1,44 @@
+# DingTalk OAuth Stability Webhook Self-Heal Verification
+
+## Commands
+
+```bash
+bash -n scripts/ops/set-dingtalk-onprem-alertmanager-webhook-config.sh
+bash -n scripts/ops/dingtalk-oauth-stability-check.sh
+python3 -m py_compile scripts/ops/github-dingtalk-oauth-stability-summary.py
+node --test scripts/ops/dingtalk-oauth-stability-workflow-contract.test.mjs
+ruby -e 'require "yaml"; YAML.load_file(".github/workflows/dingtalk-oauth-stability-recording-lite.yml"); puts "workflow yaml ok"'
+git diff --check
+```
+
+## Expected Result
+
+- Shell syntax passes for both ops scripts.
+- Stability summary Python compiles.
+- Workflow contract test confirms:
+  - the workflow still prepares the deploy SSH key;
+  - the new self-heal step reads `SLACK_WEBHOOK_URL`;
+  - the self-heal step uses the deploy host/user and deploy key;
+  - the self-heal step runs before the remote stability check;
+  - the final `healthy=false` gate remains present.
+- Workflow YAML parses.
+- Diff has no whitespace errors.
+
+## Observed Result
+
+Run from `/tmp/ms2-dingtalk-stability-followup-20260429` on 2026-04-29:
+
+- `bash -n scripts/ops/set-dingtalk-onprem-alertmanager-webhook-config.sh` passed.
+- `bash -n scripts/ops/dingtalk-oauth-stability-check.sh` passed.
+- `python3 -m py_compile scripts/ops/github-dingtalk-oauth-stability-summary.py` passed.
+- `node --test scripts/ops/dingtalk-oauth-stability-workflow-contract.test.mjs` passed: 1/1.
+- Workflow YAML parse passed.
+- `git diff --check` passed.
+
+## Live Follow-Up
+
+After merge, trigger `DingTalk OAuth Stability Recording (Lite)` or wait for the
+next scheduled run. If `SLACK_WEBHOOK_URL` is configured correctly, the workflow
+should reapply the on-prem Alertmanager env file before checking health. If the
+secret is absent, invalid, or revoked, the run should still fail with the
+existing `Alertmanager webhook is not configured` or host-drift reason.

--- a/scripts/ops/dingtalk-oauth-stability-workflow-contract.test.mjs
+++ b/scripts/ops/dingtalk-oauth-stability-workflow-contract.test.mjs
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const workflowPath = path.join(repoRoot, '.github', 'workflows', 'dingtalk-oauth-stability-recording-lite.yml')
+
+function assertContains(haystack, needle, label) {
+  assert.ok(
+    String(haystack).includes(needle),
+    `${label} must include ${needle}`,
+  )
+}
+
+test('DingTalk OAuth stability workflow reapplies Alertmanager webhook before checking health', () => {
+  const raw = readFileSync(workflowPath, 'utf8')
+
+  assertContains(raw, 'name: DingTalk OAuth Stability Recording (Lite)', 'workflow')
+  assertContains(raw, 'cron:', 'workflow schedule')
+  assertContains(raw, '- name: Prepare SSH key', 'ssh setup')
+  assertContains(raw, '- name: Reapply Alertmanager webhook config', 'webhook self-heal step')
+  assertContains(raw, 'ALERTMANAGER_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}', 'webhook self-heal step')
+  assertContains(raw, 'DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}', 'webhook self-heal step')
+  assertContains(raw, 'DEPLOY_USER: ${{ secrets.DEPLOY_USER }}', 'webhook self-heal step')
+  assertContains(raw, 'SLACK_WEBHOOK_URL is not set; Alertmanager webhook self-heal skipped.', 'webhook self-heal skip notice')
+  assertContains(raw, 'SSH_USER_HOST="${DEPLOY_USER}@${DEPLOY_HOST}"', 'webhook self-heal remote target')
+  assertContains(raw, 'SSH_KEY="${HOME}/.ssh/deploy_key"', 'webhook self-heal remote key')
+  assertContains(raw, 'scripts/ops/set-dingtalk-onprem-alertmanager-webhook-config.sh set', 'webhook self-heal command')
+  assertContains(raw, '- name: Run remote stability check', 'stability check step')
+  assert.ok(
+    raw.indexOf('- name: Reapply Alertmanager webhook config') < raw.indexOf('- name: Run remote stability check'),
+    'webhook self-heal must run before remote stability check',
+  )
+  assertContains(raw, '- name: Fail if stability check is unhealthy', 'final hard gate')
+  assertContains(raw, 'stability check completed but reported healthy=false', 'final hard gate')
+})


### PR DESCRIPTION
## Summary

Main currently has a red scheduled `DingTalk OAuth Stability Recording (Lite)` run on `5ddd8ebbe`: the remote check returned `rc=0`, backend health was ok, but `healthy=false` because Alertmanager webhook config was missing.

This PR adds a guarded self-heal step before the stability check:

- Reuses the existing deploy SSH key setup.
- If `SLACK_WEBHOOK_URL` is configured, reapplies the on-prem Alertmanager webhook env file through `scripts/ops/set-dingtalk-onprem-alertmanager-webhook-config.sh set`.
- If `SLACK_WEBHOOK_URL` is absent, emits a notice and continues to the existing check.
- Keeps the final `healthy=false` hard gate unchanged.
- Adds a workflow contract test plus design/verification docs.

## Verification

```bash
bash -n scripts/ops/set-dingtalk-onprem-alertmanager-webhook-config.sh
bash -n scripts/ops/dingtalk-oauth-stability-check.sh
python3 -m py_compile scripts/ops/github-dingtalk-oauth-stability-summary.py
node --test scripts/ops/dingtalk-oauth-stability-workflow-contract.test.mjs
ruby -e 'require "yaml"; YAML.load_file(".github/workflows/dingtalk-oauth-stability-recording-lite.yml"); puts "workflow yaml ok"'
git diff --check
```

Observed locally:

- Workflow contract test: 1/1 pass.
- Workflow YAML parse: pass.
- `git diff --check`: pass.

## Safety Notes

This does not weaken the stability gate and does not print or store webhook secrets in tracked files. Missing, invalid, or revoked `SLACK_WEBHOOK_URL` still leaves the scheduled workflow red with the existing failure reason.
