### PR TITLE
feat(multitable): polish visual filter builder

### DIFF
--- a/apps/web/src/multitable/components/MetaToolbar.vue
+++ b/apps/web/src/multitable/components/MetaToolbar.vue
@@ -53,20 +53,51 @@
             <span>conditions match</span>
           </div>
           <div v-for="(rule, idx) in filterRules" :key="idx" class="meta-toolbar__filter-rule">
-            <select :value="rule.fieldId" @change="onFilterFieldChange(idx, ($event.target as HTMLSelectElement).value)">
+            <select :value="rule.fieldId" aria-label="Filter field" @change="onFilterFieldChange(idx, ($event.target as HTMLSelectElement).value)">
               <option v-for="f in fields" :key="f.id" :value="f.id">{{ f.name }}</option>
             </select>
-            <select :value="rule.operator" @change="onFilterOperatorChange(idx, ($event.target as HTMLSelectElement).value)">
+            <span class="meta-toolbar__field-type">{{ getFilterFieldTypeLabel(rule.fieldId) }}</span>
+            <select :value="rule.operator" aria-label="Filter operator" @change="onFilterOperatorChange(idx, ($event.target as HTMLSelectElement).value)">
               <option v-for="op in getOperatorsForField(rule.fieldId)" :key="op.value" :value="op.value">{{ op.label }}</option>
             </select>
-            <input v-if="!isUnaryOp(rule.operator)" class="meta-toolbar__filter-value" :type="getInputType(rule.fieldId)" :value="rule.value ?? ''" @change="onFilterValueChange(idx, ($event.target as HTMLInputElement).value)" />
+            <span v-if="isUnaryOp(rule.operator)" class="meta-toolbar__filter-empty-hint">no value needed</span>
+            <select
+              v-else-if="isSelectLikeField(rule.fieldId)"
+              class="meta-toolbar__filter-value"
+              :value="String(rule.value ?? '')"
+              aria-label="Filter value"
+              @change="onFilterValueChange(idx, ($event.target as HTMLSelectElement).value)"
+            >
+              <option value="" disabled>{{ getSelectOptions(rule.fieldId).length ? 'Choose option...' : 'No options' }}</option>
+              <option v-for="option in getSelectOptions(rule.fieldId)" :key="option.value" :value="option.value">{{ option.label }}</option>
+            </select>
+            <select
+              v-else-if="getFieldType(rule.fieldId) === 'boolean'"
+              class="meta-toolbar__filter-value"
+              :value="String(rule.value ?? 'true')"
+              aria-label="Filter value"
+              @change="onFilterValueChange(idx, ($event.target as HTMLSelectElement).value)"
+            >
+              <option value="true">checked / true</option>
+              <option value="false">unchecked / false</option>
+            </select>
+            <input
+              v-else
+              class="meta-toolbar__filter-value"
+              :type="getInputType(rule.fieldId)"
+              :placeholder="getValuePlaceholder(rule.fieldId)"
+              :value="rule.value ?? ''"
+              aria-label="Filter value"
+              @change="onFilterValueChange(idx, ($event.target as HTMLInputElement).value)"
+            />
             <button class="meta-toolbar__remove" @click="emit('remove-filter', idx)">&times;</button>
           </div>
           <div class="meta-toolbar__filter-actions">
             <button v-if="fields.length" class="meta-toolbar__add" @click="onAddFilter">+ Add filter</button>
             <button v-if="filterRules.length" class="meta-toolbar__add meta-toolbar__add--danger" @click="emit('clear-filters')">Clear all</button>
           </div>
-          <button v-if="filterRules.length" class="meta-toolbar__apply" @click="emit('apply-sort-filter')">Apply</button>
+          <button v-if="filterRules.length" class="meta-toolbar__apply" @click="emit('apply-sort-filter')">{{ applyButtonLabel }}</button>
+          <p v-if="filterRules.length && sortFilterDirty" class="meta-toolbar__apply-hint">Filter changes are staged until applied.</p>
         </div>
       </div>
 
@@ -140,6 +171,7 @@ const props = defineProps<{
   searchText?: string
   totalRows?: number
   rowDensity?: RowDensity
+  sortFilterDirty?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -181,13 +213,63 @@ const groupableFields = computed(() => props.fields.filter((f) => GROUPABLE_TYPE
 const hiddenCount = computed(() => props.hiddenFieldIds.length)
 const UNARY = new Set(['isEmpty', 'isNotEmpty'])
 const isUnaryOp = (op: string) => UNARY.has(op)
-const getFieldType = (id: string) => props.fields.find((f) => f.id === id)?.type ?? 'string'
-const getOperatorsForField = (id: string) => FILTER_OPERATORS_BY_TYPE[getFieldType(id)] ?? FILTER_OPERATORS_BY_TYPE.string
+const getField = (id: string) => props.fields.find((f) => f.id === id)
+const getFieldType = (id: string) => getField(id)?.type ?? 'string'
+const isSelectLikeField = (id: string) => {
+  const type = String(getFieldType(id))
+  return type === 'select' || type === 'multiSelect'
+}
+const getOperatorsForField = (id: string) => {
+  const type = String(getFieldType(id))
+  if (type === 'multiSelect') {
+    return FILTER_OPERATORS_BY_TYPE.multiSelect ?? FILTER_OPERATORS_BY_TYPE.select
+  }
+  return FILTER_OPERATORS_BY_TYPE[type] ?? FILTER_OPERATORS_BY_TYPE.string
+}
+const applyButtonLabel = computed(() => props.sortFilterDirty ? 'Apply filter changes' : 'Apply filters')
 const getInputType = (id: string) => {
   const t = getFieldType(id)
   if (t === 'number') return 'number'
   if (t === 'date') return 'date'
   return 'text'
+}
+const getFilterFieldTypeLabel = (id: string) => {
+  const labels: Record<string, string> = {
+    string: 'text',
+    longText: 'long text',
+    number: 'number',
+    boolean: 'checkbox',
+    select: 'select',
+    multiSelect: 'multi-select',
+    date: 'date',
+  }
+  return labels[getFieldType(id)] ?? getFieldType(id)
+}
+const getValuePlaceholder = (id: string) => {
+  const t = getFieldType(id)
+  if (t === 'number') return 'Enter a number'
+  if (t === 'date') return 'Pick a date'
+  return 'Enter filter text'
+}
+function getSelectOptions(id: string): Array<{ value: string; label: string }> {
+  const field = getField(id)
+  const rawOptions = field?.options ?? (Array.isArray(field?.property?.options) ? field.property.options : [])
+  return rawOptions
+    .map((option) => {
+      if (typeof option === 'string') return { value: option, label: option }
+      if (option && typeof option === 'object' && 'value' in option) {
+        const value = String((option as { value?: unknown }).value ?? '')
+        return value ? { value, label: value } : null
+      }
+      return null
+    })
+    .filter((option): option is { value: string; label: string } => option !== null)
+}
+function getDefaultFilterValue(fieldId: string): unknown {
+  const type = getFieldType(fieldId)
+  if (String(type) === 'select' || String(type) === 'multiSelect') return getSelectOptions(fieldId)[0]?.value ?? ''
+  if (type === 'boolean') return true
+  return ''
 }
 
 function onSortFieldChange(idx: number, fieldId: string) { emit('update-sort', idx, { ...props.sortRules[idx], fieldId }) }
@@ -195,20 +277,24 @@ function onSortDirChange(idx: number, direction: 'asc'|'desc') { emit('update-so
 function onAddFilter() {
   if (!props.fields.length) return
   const ops = getOperatorsForField(props.fields[0].id)
-  emit('add-filter', { fieldId: props.fields[0].id, operator: ops[0]?.value ?? 'is', value: '' })
+  emit('add-filter', { fieldId: props.fields[0].id, operator: ops[0]?.value ?? 'is', value: getDefaultFilterValue(props.fields[0].id) })
 }
 function onFilterFieldChange(idx: number, fieldId: string) {
   const ops = getOperatorsForField(fieldId)
-  emit('update-filter', idx, { ...props.filterRules[idx], fieldId, operator: ops[0]?.value ?? 'is', value: '' })
+  emit('update-filter', idx, { ...props.filterRules[idx], fieldId, operator: ops[0]?.value ?? 'is', value: getDefaultFilterValue(fieldId) })
 }
 function onFilterOperatorChange(idx: number, operator: string) {
   const r = { ...props.filterRules[idx], operator }
   if (isUnaryOp(operator)) r.value = undefined
+  else if (r.value === undefined) r.value = getDefaultFilterValue(r.fieldId)
   emit('update-filter', idx, r)
 }
 function onFilterValueChange(idx: number, value: string) {
   const ft = getFieldType(props.filterRules[idx].fieldId)
-  emit('update-filter', idx, { ...props.filterRules[idx], value: ft === 'number' && value !== '' ? Number(value) : value })
+  let nextValue: unknown = value
+  if (ft === 'number' && value !== '') nextValue = Number(value)
+  if (ft === 'boolean') nextValue = value === 'true'
+  emit('update-filter', idx, { ...props.filterRules[idx], value: nextValue })
 }
 </script>
 
@@ -231,6 +317,7 @@ function onFilterValueChange(idx: number, value: string) {
 .meta-toolbar__sort-rule, .meta-toolbar__filter-rule { display: flex; gap: 4px; margin-bottom: 4px; align-items: center; }
 .meta-toolbar__sort-rule select, .meta-toolbar__filter-rule select { padding: 2px 6px; font-size: 12px; border: 1px solid #ddd; border-radius: 3px; }
 .meta-toolbar__filter-value { flex: 1; min-width: 80px; padding: 2px 6px; font-size: 12px; border: 1px solid #ddd; border-radius: 3px; }
+.meta-toolbar__filter-empty-hint { flex: 1; min-width: 80px; color: #999; font-size: 12px; }
 .meta-toolbar__conjunction { display: flex; align-items: center; gap: 6px; font-size: 12px; color: #666; margin-bottom: 6px; }
 .meta-toolbar__conjunction select { padding: 2px 6px; font-size: 12px; border: 1px solid #ddd; border-radius: 3px; }
 .meta-toolbar__filter-actions { display: flex; gap: 12px; margin-top: 4px; }
@@ -241,6 +328,7 @@ function onFilterValueChange(idx: number, value: string) {
 .meta-toolbar__add--danger { color: #f56c6c; }
 .meta-toolbar__apply { display: block; width: 100%; margin-top: 8px; padding: 5px 0; background: #409eff; color: #fff; border: none; border-radius: 3px; font-size: 12px; cursor: pointer; }
 .meta-toolbar__apply:hover { background: #66b1ff; }
+.meta-toolbar__apply-hint { margin: 6px 0 0; color: #777; font-size: 11px; }
 .meta-toolbar__group-none { color: #999; }
 .meta-toolbar__field-type { font-size: 10px; color: #aaa; margin-left: auto; }
 .meta-toolbar__search { display: flex; align-items: center; gap: 4px; border: 1px solid #ddd; border-radius: 4px; padding: 2px 8px; background: #fafafa; transition: border-color 0.2s, background 0.2s; }

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -76,6 +76,7 @@
       :fields="propertyVisibleGridFields" :hidden-field-ids="grid.hiddenFieldIds.value"
       :sort-rules="grid.sortRules.value" :filter-rules="grid.filterRules.value"
       :filter-conjunction="grid.filterConjunction.value"
+      :sort-filter-dirty="grid.sortFilterDirty.value"
       :can-create-record="caps.canCreateRecord.value" :can-export="caps.canExport.value" :can-undo="grid.canUndo.value" :can-redo="grid.canRedo.value"
       @toggle-field="grid.toggleFieldVisibility" @add-sort="grid.addSortRule" @remove-sort="grid.removeSortRule"
       @update-sort="onUpdateSort" @add-filter="grid.addFilterRule" @update-filter="grid.updateFilterRule"

--- a/apps/web/tests/meta-toolbar-filter-builder.spec.ts
+++ b/apps/web/tests/meta-toolbar-filter-builder.spec.ts
@@ -1,0 +1,178 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, h, nextTick, reactive, type App } from 'vue'
+import MetaToolbar from '../src/multitable/components/MetaToolbar.vue'
+import type { FilterConjunction, FilterRule, SortRule } from '../src/multitable/composables/useMultitableGrid'
+import type { MetaField } from '../src/multitable/types'
+
+type ToolbarState = {
+  fields: MetaField[]
+  hiddenFieldIds: string[]
+  sortRules: SortRule[]
+  filterRules: FilterRule[]
+  filterConjunction: FilterConjunction
+  sortFilterDirty: boolean
+}
+
+let app: App<Element> | null = null
+let container: HTMLDivElement | null = null
+
+afterEach(() => {
+  app?.unmount()
+  app = null
+  container?.remove()
+  container = null
+})
+
+function mountToolbar(initial: Partial<ToolbarState> = {}) {
+  const state = reactive<ToolbarState>({
+    fields: [
+      {
+        id: 'status',
+        name: 'Status',
+        type: 'select',
+        options: [{ value: 'todo' }, { value: 'done' }],
+      },
+      { id: 'amount', name: 'Amount', type: 'number' },
+      { id: 'approved', name: 'Approved', type: 'boolean' },
+    ],
+    hiddenFieldIds: [],
+    sortRules: [],
+    filterRules: [],
+    filterConjunction: 'and',
+    sortFilterDirty: false,
+    ...initial,
+  })
+
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  app = createApp({
+    setup() {
+      return () => h(MetaToolbar, {
+        ...state,
+        canCreateRecord: true,
+        canExport: true,
+        canUndo: false,
+        canRedo: false,
+        onAddFilter: (rule: FilterRule) => { state.filterRules.push(rule) },
+        onUpdateFilter: (index: number, rule: FilterRule) => { state.filterRules[index] = rule },
+        onRemoveFilter: (index: number) => { state.filterRules.splice(index, 1) },
+        onClearFilters: () => {
+          state.filterRules = []
+          state.filterConjunction = 'and'
+        },
+        onSetConjunction: (conjunction: FilterConjunction) => { state.filterConjunction = conjunction },
+      })
+    },
+  })
+  app.mount(container)
+  return { state, container }
+}
+
+async function openFilterPanel(root: HTMLElement): Promise<HTMLElement> {
+  const button = Array.from(root.querySelectorAll('button'))
+    .find((candidate) => candidate.textContent?.includes('Filter')) as HTMLButtonElement | undefined
+  expect(button).toBeTruthy()
+  button?.click()
+  await nextTick()
+  const panel = root.querySelector('.meta-toolbar__panel--filter') as HTMLElement | null
+  expect(panel).toBeTruthy()
+  return panel!
+}
+
+async function setSelectValue(select: HTMLSelectElement, value: string): Promise<void> {
+  select.value = value
+  select.dispatchEvent(new Event('change'))
+  await nextTick()
+}
+
+describe('MetaToolbar filter builder', () => {
+  it('uses a select option dropdown and dirty apply copy for select filters', async () => {
+    const { state, container: root } = mountToolbar({
+      filterRules: [{ fieldId: 'status', operator: 'is', value: 'todo' }],
+      sortFilterDirty: true,
+    })
+
+    const panel = await openFilterPanel(root)
+    const valueSelect = panel.querySelector('select[aria-label="Filter value"]') as HTMLSelectElement | null
+
+    expect(valueSelect).toBeTruthy()
+    expect(Array.from(valueSelect!.options).map((option) => option.value)).toEqual(['', 'todo', 'done'])
+    expect(panel.textContent).toContain('select')
+    expect(panel.textContent).toContain('Apply filter changes')
+    expect(panel.textContent).toContain('Filter changes are staged until applied.')
+
+    await setSelectValue(valueSelect!, 'done')
+
+    expect(state.filterRules[0]).toEqual({ fieldId: 'status', operator: 'is', value: 'done' })
+  })
+
+  it('hides value input for empty operators and restores a typed value control when needed', async () => {
+    const { state, container: root } = mountToolbar({
+      filterRules: [{ fieldId: 'amount', operator: 'greater', value: 5 }],
+    })
+
+    const panel = await openFilterPanel(root)
+    const operatorSelect = panel.querySelector('select[aria-label="Filter operator"]') as HTMLSelectElement | null
+    expect(panel.querySelector('input[aria-label="Filter value"]')?.getAttribute('type')).toBe('number')
+
+    await setSelectValue(operatorSelect!, 'isEmpty')
+
+    expect(state.filterRules[0]).toEqual({ fieldId: 'amount', operator: 'isEmpty', value: undefined })
+    expect(panel.querySelector('[aria-label="Filter value"]')).toBeNull()
+    expect(panel.textContent).toContain('no value needed')
+
+    await setSelectValue(operatorSelect!, 'less')
+
+    expect(state.filterRules[0]).toEqual({ fieldId: 'amount', operator: 'less', value: '' })
+    expect(panel.querySelector('input[aria-label="Filter value"]')?.getAttribute('type')).toBe('number')
+  })
+
+  it('adds select and boolean filters with typed default values', async () => {
+    const { state, container: root } = mountToolbar()
+
+    const panel = await openFilterPanel(root)
+    const addButton = Array.from(panel.querySelectorAll('button'))
+      .find((candidate) => candidate.textContent?.includes('+ Add filter')) as HTMLButtonElement | undefined
+    expect(addButton).toBeTruthy()
+
+    addButton?.click()
+    await nextTick()
+
+    expect(state.filterRules[0]).toEqual({ fieldId: 'status', operator: 'is', value: 'todo' })
+
+    const fieldSelect = panel.querySelector('select[aria-label="Filter field"]') as HTMLSelectElement | null
+    await setSelectValue(fieldSelect!, 'approved')
+
+    expect(state.filterRules[0]).toEqual({ fieldId: 'approved', operator: 'is', value: true })
+    expect(panel.textContent).toContain('checkbox')
+  })
+
+  it('treats future multiSelect fields as option-backed filters', async () => {
+    const { state, container: root } = mountToolbar({
+      fields: [
+        {
+          id: 'tags',
+          name: 'Tags',
+          type: 'multiSelect' as MetaField['type'],
+          options: [{ value: 'urgent' }, { value: 'vip' }],
+        },
+      ],
+      filterRules: [],
+    })
+
+    const panel = await openFilterPanel(root)
+    const addButton = Array.from(panel.querySelectorAll('button'))
+      .find((candidate) => candidate.textContent?.includes('+ Add filter')) as HTMLButtonElement | undefined
+    expect(addButton).toBeTruthy()
+
+    addButton?.click()
+    await nextTick()
+
+    expect(state.filterRules[0]).toEqual({ fieldId: 'tags', operator: 'contains', value: 'urgent' })
+    expect(panel.textContent).toContain('multi-select')
+
+    const valueSelect = panel.querySelector('select[aria-label="Filter value"]') as HTMLSelectElement | null
+    expect(valueSelect).toBeTruthy()
+    expect(Array.from(valueSelect!.options).map((option) => option.value)).toEqual(['', 'urgent', 'vip'])
+  })
+})

--- a/docs/development/wave-m-feishu-4-filter-builder-design-20260429.md
+++ b/docs/development/wave-m-feishu-4-filter-builder-design-20260429.md
@@ -1,0 +1,21 @@
+# Wave M Feishu 4 Filter Builder Design - 2026-04-29
+
+## Scope
+
+Lane C improves the multitable visual filter builder experience in `apps/web/src/multitable/components/MetaToolbar.vue` without changing the backend view protocol. Existing `filterRules` and `filterInfo.conditions` remain the source of truth.
+
+## Design
+
+- Keep the current toolbar panel and `FilterRule` event contract.
+- Add field-type context next to each filter rule so users can see whether they are editing text, number, checkbox, select, or date logic.
+- Keep unary empty-value operators (`isEmpty`, `isNotEmpty`) value-free and show a short "no value needed" hint instead of a disabled text box.
+- Render select fields with their configured options as a dropdown; fallback options may come from `field.options` or `field.property.options`.
+- Render boolean fields as a true/false dropdown and keep numeric fields as number inputs.
+- Use typed default values when adding or retargeting filters: first select option for select fields, `true` for boolean fields, and an empty string for text/number/date.
+- Surface staged filter state with clearer apply copy: dirty filters show "Apply filter changes" and a note that changes are staged until applied.
+
+## Non-Goals
+
+- No backend API or `filterInfo` shape changes.
+- No rewrite of view management filtering or saved-view payloads.
+- No new filtering operators beyond the existing operator keys.

--- a/docs/development/wave-m-feishu-4-filter-builder-verification-20260429.md
+++ b/docs/development/wave-m-feishu-4-filter-builder-verification-20260429.md
@@ -1,0 +1,49 @@
+# Wave M Feishu 4 Filter Builder Verification - 2026-04-29
+
+## Targeted Coverage
+
+- `apps/web/tests/meta-toolbar-filter-builder.spec.ts`
+  - Select fields render option dropdowns and update filter values without changing the rule shape.
+  - Empty-value operators hide value controls and preserve `value: undefined`.
+  - Add/retarget flows choose typed defaults for select and boolean fields.
+  - Future `multiSelect` fields use option-backed filter controls instead of falling back to free text.
+  - Dirty state shows explicit "Apply filter changes" copy.
+
+## Commands
+
+Run from `/tmp/ms2-mfeishu4-filter-polish-20260429`.
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/meta-toolbar-filter-builder.spec.ts tests/multitable-grid.spec.ts --watch=false
+pnpm --filter @metasheet/web type-check
+git diff --check
+```
+
+Final rebase verification:
+
+- Rebased cleanly onto `origin/main@f76a105f7`.
+- Reran target Vitest: 2 files passed, 38 tests passed.
+- Reran `pnpm --filter @metasheet/web type-check`: passed.
+- The first cleanup wrapper exited after successful tests because an existing
+  `node_modules` directory required `rm -rf`; type-check was rerun separately
+  and the worktree was left clean.
+
+Forward-compatibility verification:
+
+- Added a `multiSelect` fixture to the toolbar tests so the filter builder is merge-order safe with the parallel multi-select field PR.
+- Reran target Vitest: 2 files passed, 39 tests passed.
+- Reran `pnpm --filter @metasheet/web type-check`: passed.
+- Reran `git diff --check`: passed.
+
+Post-#1242 rebase verification:
+
+- Rebased onto `origin/main@1bc4da47f` after the multi-select field PR landed.
+- Updated the `multiSelect` toolbar assertion from fallback `is` to canonical `contains`.
+- Reran target Vitest with the multi-select field spec included: 3 files passed, 43 tests passed.
+- Reran `pnpm --filter @metasheet/web type-check`: passed.
+- Reran `git diff --check`: passed.
+
+## Notes
+
+- The test scope is intentionally frontend-only; the change does not alter backend serialization or saved-view payloads.
+- Full workspace validation remains out of scope for Lane C unless requested.


### PR DESCRIPTION
## Summary
- Replace the raw filter value box with typed controls for select, boolean, number, and date fields.
- Hide value input for unary operators and preserve `value: undefined`.
- Surface dirty apply copy when staged sort/filter changes are waiting to be applied.
- Add forward-compatible `multiSelect` option-backed filter handling for the parallel field-type PR.
- Add design and verification docs under `docs/development/`.

## Verification
- `pnpm --filter @metasheet/web exec vitest run tests/meta-toolbar-filter-builder.spec.ts tests/multitable-grid.spec.ts --watch=false --reporter=dot`
- `pnpm --filter @metasheet/web type-check`
- `git diff --check`

## Merge Order
Merge after #1242 so `multiSelect` exists in the canonical field model first.