### PR TITLE
feat(multitable): add formula function catalog

### DIFF
--- a/apps/web/src/multitable/components/MetaFieldManager.vue
+++ b/apps/web/src/multitable/components/MetaFieldManager.vue
@@ -171,24 +171,45 @@
           </div>
           <div class="meta-field-mgr__field">
             <span>Function reference</span>
-            <input
-              v-model="formulaFunctionSearch"
-              class="meta-field-mgr__input"
-              placeholder="Search SUM, IF, TODAY..."
-            />
-            <div class="meta-field-mgr__formula-docs">
-              <button
-                v-for="doc in filteredFormulaDocs"
-                :key="doc.name"
-                type="button"
-                class="meta-field-mgr__formula-doc"
-                @click="insertFormulaFunction(doc.name)"
-              >
-                <strong>{{ doc.signature }}</strong>
-                <span>{{ doc.description }}</span>
-                <code>{{ doc.example }}</code>
-              </button>
+            <div class="meta-field-mgr__formula-toolbar">
+              <input
+                v-model="formulaFunctionSearch"
+                class="meta-field-mgr__input"
+                placeholder="Search SUM, IF, TODAY..."
+              />
+              <select v-model="formulaFunctionCategory" class="meta-field-mgr__select">
+                <option value="all">All categories</option>
+                <option
+                  v-for="category in formulaFunctionCategories"
+                  :key="category.id"
+                  :value="category.id"
+                >{{ category.label }}</option>
+              </select>
             </div>
+            <div v-if="formulaCatalogSections.length" class="meta-field-mgr__formula-docs">
+              <section
+                v-for="section in formulaCatalogSections"
+                :key="section.category"
+                class="meta-field-mgr__formula-section"
+              >
+                <div class="meta-field-mgr__formula-section-title">
+                  <strong>{{ section.label }}</strong>
+                  <span>{{ section.description }}</span>
+                </div>
+                <button
+                  v-for="doc in section.functions"
+                  :key="doc.name"
+                  type="button"
+                  class="meta-field-mgr__formula-doc"
+                  @click="insertFormulaFunction(doc)"
+                >
+                  <strong>{{ doc.signature }}</strong>
+                  <span>{{ doc.description }}</span>
+                  <code>{{ doc.example }}</code>
+                </button>
+              </section>
+            </div>
+            <div v-else class="meta-field-mgr__formula-empty">No matching functions.</div>
           </div>
         </template>
 
@@ -290,8 +311,13 @@
 import { computed, onBeforeUnmount, reactive, ref, watch } from 'vue'
 import type { FieldValidationRule, MetaField, MetaFieldCreateType, MetaSheet } from '../types'
 import {
-  searchFormulaFunctionDocs,
+  FORMULA_FUNCTION_CATEGORIES,
+  buildFormulaFieldTokenInsertion,
+  buildFormulaFunctionInsertion,
+  getFormulaFunctionCatalog,
   validateFormulaExpression,
+  type FormulaFunctionCategory,
+  type FormulaFunctionDoc,
   type FormulaDiagnostic,
 } from '../utils/formula-docs'
 import {
@@ -457,6 +483,8 @@ const formulaDraft = reactive<{ expression: string }>({
   expression: '',
 })
 const formulaFunctionSearch = ref('')
+const formulaFunctionCategory = ref<FormulaFunctionCategory | 'all'>('all')
+const formulaFunctionCategories = FORMULA_FUNCTION_CATEGORIES
 const attachmentDraft = reactive<{ maxFiles: number; acceptedMimeTypesText: string }>({
   maxFiles: 1,
   acceptedMimeTypesText: '',
@@ -489,7 +517,10 @@ const targetSheets = computed(() => props.sheets.filter((sheet) => sheet.id !== 
 const formulaSourceFields = computed(() =>
   props.fields.filter((field) => field.id !== configTarget.value?.id && field.type !== 'formula'),
 )
-const filteredFormulaDocs = computed(() => searchFormulaFunctionDocs(formulaFunctionSearch.value).slice(0, 8))
+const formulaCatalogSections = computed(() =>
+  getFormulaFunctionCatalog(formulaFunctionSearch.value, formulaFunctionCategory.value)
+    .map((section) => ({ ...section, functions: section.functions.slice(0, 6) })),
+)
 const formulaDiagnostics = computed<FormulaDiagnostic[]>(() =>
   configTargetType.value === 'formula'
     ? validateFormulaExpression(formulaDraft.expression, formulaSourceFields.value)
@@ -558,6 +589,7 @@ function resetDrafts() {
   rollupDraft.aggregation = 'count'
   formulaDraft.expression = ''
   formulaFunctionSearch.value = ''
+  formulaFunctionCategory.value = 'all'
   attachmentDraft.maxFiles = 1
   attachmentDraft.acceptedMimeTypesText = ''
   currencyDraft.code = 'CNY'
@@ -880,18 +912,12 @@ function currentDraftProperty(type: MetaFieldCreateType | string): Record<string
   return undefined
 }
 
-function appendFormulaToken(token: string) {
-  formulaDraft.expression = formulaDraft.expression
-    ? `${formulaDraft.expression}${formulaDraft.expression.endsWith(' ') ? '' : ' '}${token}`
-    : token
-}
-
 function insertFormulaField(fieldId: string) {
-  appendFormulaToken(`{${fieldId}}`)
+  formulaDraft.expression = buildFormulaFieldTokenInsertion(formulaDraft.expression, fieldId)
 }
 
-function insertFormulaFunction(functionName: string) {
-  appendFormulaToken(formulaDraft.expression.trim() ? `${functionName}()` : `=${functionName}()`)
+function insertFormulaFunction(doc: FormulaFunctionDoc) {
+  formulaDraft.expression = buildFormulaFunctionInsertion(formulaDraft.expression, doc)
 }
 
 function onAddField() {
@@ -1104,12 +1130,18 @@ onBeforeUnmount(() => {
 .meta-field-mgr__formula-diagnostic { padding: 6px 8px; border-radius: 5px; font-size: 12px; }
 .meta-field-mgr__formula-diagnostic--warning { background: #fff7e6; color: #8a5a00; border: 1px solid #f3d19e; }
 .meta-field-mgr__formula-diagnostic--error { background: #fef0f0; color: #c0392b; border: 1px solid #fbc4c4; }
-.meta-field-mgr__formula-docs { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; max-height: 180px; overflow-y: auto; }
+.meta-field-mgr__formula-toolbar { display: grid; grid-template-columns: minmax(0, 1fr) 180px; gap: 8px; }
+.meta-field-mgr__formula-docs { display: flex; flex-direction: column; gap: 10px; max-height: 220px; overflow-y: auto; }
+.meta-field-mgr__formula-section { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; }
+.meta-field-mgr__formula-section-title { grid-column: 1 / -1; display: flex; align-items: baseline; gap: 8px; color: #334155; }
+.meta-field-mgr__formula-section-title strong { font-size: 12px; color: #0f172a; }
+.meta-field-mgr__formula-section-title span { font-size: 11px; color: #64748b; }
 .meta-field-mgr__formula-doc { display: flex; flex-direction: column; gap: 3px; padding: 8px; border: 1px solid #e2e8f0; border-radius: 6px; background: #fff; color: #334155; text-align: left; cursor: pointer; }
 .meta-field-mgr__formula-doc:hover { border-color: #93c5fd; background: #f8fbff; }
 .meta-field-mgr__formula-doc strong { font-size: 12px; color: #1d4ed8; }
 .meta-field-mgr__formula-doc span { font-size: 11px; color: #64748b; }
 .meta-field-mgr__formula-doc code { font-size: 11px; color: #475569; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.meta-field-mgr__formula-empty { padding: 8px; border: 1px dashed #cbd5e1; border-radius: 6px; color: #64748b; background: #fff; font-size: 12px; }
 .meta-field-mgr__grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; }
 .meta-field-mgr__stack { display: flex; flex-direction: column; gap: 8px; }
 .meta-field-mgr__option-row { display: grid; grid-template-columns: 1fr 1fr auto; gap: 8px; align-items: center; }

--- a/apps/web/src/multitable/utils/formula-docs.ts
+++ b/apps/web/src/multitable/utils/formula-docs.ts
@@ -1,17 +1,50 @@
 import type { MetaField } from '../types'
 
+export type FormulaFunctionCategory =
+  | 'aggregate'
+  | 'math'
+  | 'logic'
+  | 'text'
+  | 'date'
+  | 'lookup'
+  | 'statistical'
+
 export interface FormulaFunctionDoc {
   name: string
   signature: string
-  category: 'math' | 'text' | 'logic' | 'date' | 'aggregate'
+  category: FormulaFunctionCategory
   description: string
   example: string
+  insertText?: string
+}
+
+export interface FormulaFunctionCategoryDoc {
+  id: FormulaFunctionCategory
+  label: string
+  description: string
+}
+
+export interface FormulaFunctionCatalogSection {
+  category: FormulaFunctionCategory
+  label: string
+  description: string
+  functions: FormulaFunctionDoc[]
 }
 
 export interface FormulaDiagnostic {
   severity: 'warning' | 'error'
   message: string
 }
+
+export const FORMULA_FUNCTION_CATEGORIES: FormulaFunctionCategoryDoc[] = [
+  { id: 'aggregate', label: 'Aggregate', description: 'Summarize numeric or non-empty values.' },
+  { id: 'math', label: 'Math', description: 'Round, transform, and compare numbers.' },
+  { id: 'logic', label: 'Logic', description: 'Branch and combine conditions.' },
+  { id: 'text', label: 'Text', description: 'Join, slice, and normalize text.' },
+  { id: 'date', label: 'Date', description: 'Create or extract date values.' },
+  { id: 'lookup', label: 'Lookup', description: 'Find values from arrays or ranges.' },
+  { id: 'statistical', label: 'Statistical', description: 'Calculate distribution helpers.' },
+]
 
 export const FORMULA_FUNCTION_DOCS: FormulaFunctionDoc[] = [
   {
@@ -20,6 +53,7 @@ export const FORMULA_FUNCTION_DOCS: FormulaFunctionDoc[] = [
     category: 'aggregate',
     description: 'Adds numeric values together.',
     example: '=SUM({fld_price}, {fld_tax})',
+    insertText: 'SUM()',
   },
   {
     name: 'AVERAGE',
@@ -27,6 +61,23 @@ export const FORMULA_FUNCTION_DOCS: FormulaFunctionDoc[] = [
     category: 'aggregate',
     description: 'Returns the arithmetic mean of numeric values.',
     example: '=AVERAGE({fld_score_1}, {fld_score_2})',
+    insertText: 'AVERAGE()',
+  },
+  {
+    name: 'COUNT',
+    signature: 'COUNT(value, ...)',
+    category: 'aggregate',
+    description: 'Counts numeric values.',
+    example: '=COUNT({fld_score_1}, {fld_score_2})',
+    insertText: 'COUNT()',
+  },
+  {
+    name: 'COUNTA',
+    signature: 'COUNTA(value, ...)',
+    category: 'aggregate',
+    description: 'Counts values that are not empty.',
+    example: '=COUNTA({fld_name}, {fld_status})',
+    insertText: 'COUNTA()',
   },
   {
     name: 'MIN',
@@ -34,6 +85,7 @@ export const FORMULA_FUNCTION_DOCS: FormulaFunctionDoc[] = [
     category: 'aggregate',
     description: 'Returns the smallest numeric value.',
     example: '=MIN({fld_quote_a}, {fld_quote_b})',
+    insertText: 'MIN()',
   },
   {
     name: 'MAX',
@@ -41,6 +93,23 @@ export const FORMULA_FUNCTION_DOCS: FormulaFunctionDoc[] = [
     category: 'aggregate',
     description: 'Returns the largest numeric value.',
     example: '=MAX({fld_quote_a}, {fld_quote_b})',
+    insertText: 'MAX()',
+  },
+  {
+    name: 'ROUND',
+    signature: 'ROUND(number, digits)',
+    category: 'math',
+    description: 'Rounds a number to the requested decimal places.',
+    example: '=ROUND({fld_amount}, 2)',
+    insertText: 'ROUND(, 2)',
+  },
+  {
+    name: 'ABS',
+    signature: 'ABS(number)',
+    category: 'math',
+    description: 'Returns the absolute value of a number.',
+    example: '=ABS({fld_delta})',
+    insertText: 'ABS()',
   },
   {
     name: 'IF',
@@ -48,6 +117,7 @@ export const FORMULA_FUNCTION_DOCS: FormulaFunctionDoc[] = [
     category: 'logic',
     description: 'Chooses one of two values based on a condition.',
     example: '=IF({fld_amount} > 1000, "Large", "Small")',
+    insertText: 'IF(, , )',
   },
   {
     name: 'AND',
@@ -55,6 +125,7 @@ export const FORMULA_FUNCTION_DOCS: FormulaFunctionDoc[] = [
     category: 'logic',
     description: 'Returns true only when all conditions are true.',
     example: '=AND({fld_status} = "Open", {fld_amount} > 0)',
+    insertText: 'AND()',
   },
   {
     name: 'OR',
@@ -62,6 +133,7 @@ export const FORMULA_FUNCTION_DOCS: FormulaFunctionDoc[] = [
     category: 'logic',
     description: 'Returns true when any condition is true.',
     example: '=OR({fld_status} = "Open", {fld_status} = "Pending")',
+    insertText: 'OR()',
   },
   {
     name: 'CONCAT',
@@ -69,6 +141,7 @@ export const FORMULA_FUNCTION_DOCS: FormulaFunctionDoc[] = [
     category: 'text',
     description: 'Joins text values together.',
     example: '=CONCAT({fld_first_name}, " ", {fld_last_name})',
+    insertText: 'CONCAT()',
   },
   {
     name: 'LEN',
@@ -76,6 +149,15 @@ export const FORMULA_FUNCTION_DOCS: FormulaFunctionDoc[] = [
     category: 'text',
     description: 'Returns the length of a text value.',
     example: '=LEN({fld_description})',
+    insertText: 'LEN()',
+  },
+  {
+    name: 'UPPER',
+    signature: 'UPPER(text)',
+    category: 'text',
+    description: 'Converts text to uppercase.',
+    example: '=UPPER({fld_code})',
+    insertText: 'UPPER()',
   },
   {
     name: 'TODAY',
@@ -83,6 +165,7 @@ export const FORMULA_FUNCTION_DOCS: FormulaFunctionDoc[] = [
     category: 'date',
     description: 'Returns the current date.',
     example: '=TODAY()',
+    insertText: 'TODAY()',
   },
   {
     name: 'DATEDIFF',
@@ -90,6 +173,31 @@ export const FORMULA_FUNCTION_DOCS: FormulaFunctionDoc[] = [
     category: 'date',
     description: 'Returns the number of days between two dates.',
     example: '=DATEDIFF({fld_due_date}, {fld_start_date})',
+    insertText: 'DATEDIFF(, )',
+  },
+  {
+    name: 'YEAR',
+    signature: 'YEAR(date)',
+    category: 'date',
+    description: 'Returns the year from a date value.',
+    example: '=YEAR({fld_due_date})',
+    insertText: 'YEAR()',
+  },
+  {
+    name: 'VLOOKUP',
+    signature: 'VLOOKUP(value, table, column, approximate)',
+    category: 'lookup',
+    description: 'Looks up a value in the first column of a table-like range.',
+    example: '=VLOOKUP({fld_sku}, {fld_table}, 2, FALSE)',
+    insertText: 'VLOOKUP(, , , FALSE)',
+  },
+  {
+    name: 'MEDIAN',
+    signature: 'MEDIAN(number, ...)',
+    category: 'statistical',
+    description: 'Returns the median of numeric values.',
+    example: '=MEDIAN({fld_score_1}, {fld_score_2})',
+    insertText: 'MEDIAN()',
   },
 ]
 
@@ -104,6 +212,42 @@ export function searchFormulaFunctionDocs(query: string): FormulaFunctionDoc[] {
     || doc.signature.toUpperCase().includes(normalized)
     || doc.description.toUpperCase().includes(normalized),
   )
+}
+
+export function getFormulaFunctionCatalog(
+  query = '',
+  category: FormulaFunctionCategory | 'all' = 'all',
+): FormulaFunctionCatalogSection[] {
+  const docs = searchFormulaFunctionDocs(query).filter((doc) => category === 'all' || doc.category === category)
+  return FORMULA_FUNCTION_CATEGORIES
+    .map((categoryDoc) => ({
+      category: categoryDoc.id,
+      label: categoryDoc.label,
+      description: categoryDoc.description,
+      functions: docs.filter((doc) => doc.category === categoryDoc.id),
+    }))
+    .filter((section) => section.functions.length > 0)
+}
+
+export function appendFormulaToken(expression: string, token: string): string {
+  const current = expression.trimEnd()
+  if (!current) return token
+  return `${current}${current.endsWith(' ') ? '' : ' '}${token}`
+}
+
+export function buildFormulaFieldTokenInsertion(expression: string, fieldId: string): string {
+  return appendFormulaToken(expression, `{${fieldId}}`)
+}
+
+export function buildFormulaFunctionInsertion(
+  expression: string,
+  docOrName: FormulaFunctionDoc | string,
+): string {
+  const token = typeof docOrName === 'string'
+    ? `${docOrName.toUpperCase()}()`
+    : (docOrName.insertText ?? `${docOrName.name}()`)
+  const normalizedToken = expression.trim() ? token : `=${token}`
+  return appendFormulaToken(expression, normalizedToken)
 }
 
 export function extractFormulaFieldRefs(expression: string): string[] {
@@ -161,4 +305,3 @@ export function validateFormulaExpression(expression: string, fields: MetaField[
 
   return diagnostics
 }
-

--- a/apps/web/tests/multitable-formula-editor.spec.ts
+++ b/apps/web/tests/multitable-formula-editor.spec.ts
@@ -2,7 +2,10 @@ import { createApp, h, nextTick } from 'vue'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import MetaFieldManager from '../src/multitable/components/MetaFieldManager.vue'
 import {
+  buildFormulaFieldTokenInsertion,
+  buildFormulaFunctionInsertion,
   extractFormulaFieldRefs,
+  getFormulaFunctionCatalog,
   searchFormulaFunctionDocs,
   validateFormulaExpression,
 } from '../src/multitable/utils/formula-docs'
@@ -28,6 +31,22 @@ describe('multitable formula editor', () => {
     expect(validateFormulaExpression('=SUM({fld_missing})', [
       { id: 'fld_price', name: 'Price', type: 'number' },
     ])).toContainEqual({ severity: 'error', message: 'Unknown field reference {fld_missing}.' })
+  })
+
+  it('builds categorized function catalog sections and insertion text', () => {
+    const mathSections = getFormulaFunctionCatalog('round', 'math')
+    expect(mathSections).toHaveLength(1)
+    expect(mathSections[0]).toMatchObject({
+      category: 'math',
+      label: 'Math',
+      functions: [expect.objectContaining({ name: 'ROUND', insertText: 'ROUND(, 2)' })],
+    })
+
+    const ifDoc = getFormulaFunctionCatalog('if', 'logic')[0].functions.find((doc) => doc.name === 'IF')
+    expect(ifDoc).toBeTruthy()
+    expect(buildFormulaFunctionInsertion('', ifDoc!)).toBe('=IF(, , )')
+    expect(buildFormulaFunctionInsertion('=SUM({fld_price})', 'today')).toBe('=SUM({fld_price}) TODAY()')
+    expect(buildFormulaFieldTokenInsertion('=SUM()', 'fld_tax')).toBe('=SUM() {fld_tax}')
   })
 
   it('inserts backend-compatible field id tokens from field chips', async () => {
@@ -77,6 +96,51 @@ describe('multitable formula editor', () => {
     app.unmount()
   })
 
+  it('filters the formula function catalog by category and inserts snippets', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    const app = createApp({
+      render() {
+        return h(MetaFieldManager, {
+          visible: true,
+          sheetId: 'sheet_1',
+          sheets: [],
+          fields: [
+            { id: 'fld_price', name: 'Price', type: 'number' },
+            { id: 'fld_total', name: 'Total', type: 'formula', property: { expression: '' } },
+          ],
+        })
+      },
+    })
+
+    app.mount(container)
+    await nextTick()
+
+    const configureButtons = Array.from(container.querySelectorAll('.meta-field-mgr__action[title="Configure"]')) as HTMLButtonElement[]
+    configureButtons[1]?.click()
+    await nextTick()
+
+    const categorySelect = container.querySelector('.meta-field-mgr__formula-toolbar .meta-field-mgr__select') as HTMLSelectElement
+    categorySelect.value = 'math'
+    categorySelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await nextTick()
+
+    expect(container.textContent).toContain('Math')
+    expect(container.textContent).toContain('ROUND(number, digits)')
+    expect(container.textContent).not.toContain('TODAY()')
+
+    const roundButton = Array.from(container.querySelectorAll('.meta-field-mgr__formula-doc'))
+      .find((button) => button.textContent?.includes('ROUND(number, digits)')) as HTMLButtonElement | undefined
+    roundButton?.click()
+    await nextTick()
+
+    const textarea = container.querySelector('.meta-field-mgr__textarea') as HTMLTextAreaElement
+    expect(textarea.value).toBe('=ROUND(, 2)')
+
+    app.unmount()
+  })
+
   it('blocks saving formula expressions with unknown field references', async () => {
     const container = document.createElement('div')
     document.body.appendChild(container)
@@ -116,4 +180,3 @@ describe('multitable formula editor', () => {
     app.unmount()
   })
 })
-

--- a/docs/development/wave-m-feishu-4-formula-catalog-design-20260429.md
+++ b/docs/development/wave-m-feishu-4-formula-catalog-design-20260429.md
@@ -1,0 +1,52 @@
+# Wave M-Feishu-4 Formula Catalog Design — 2026-04-29
+
+## Scope
+
+Lane B adds a lightweight formula function catalog and insertion helper to the existing multitable formula field configuration in `MetaFieldManager.vue`.
+
+This lane is frontend-only by design. It does not change `packages/core-backend/src/multitable/formula-engine.ts` or backend formula evaluation semantics.
+
+## Current Context
+
+- Formula fields already persist `field.property.expression`.
+- The backend multitable formula engine resolves stable `{fld_xxx}` tokens before passing formulas into the shared formula engine.
+- The existing editor already had a textarea, field-token chips, simple diagnostics, and a flat function reference list.
+- Wave M-Feishu-1 delivery left "Formula editor + Chinese function docs" as future work; this lane implements the small catalog/insert-assist slice without a larger formula parser rewrite.
+
+## Design
+
+### Catalog source
+
+`apps/web/src/multitable/utils/formula-docs.ts` remains the single frontend catalog source. It now exposes:
+
+- `FORMULA_FUNCTION_CATEGORIES`: stable category metadata for UI rendering.
+- `FORMULA_FUNCTION_DOCS`: documented functions aligned to currently registered backend built-ins.
+- `getFormulaFunctionCatalog(query, category)`: pure grouping/filtering for component and tests.
+- `buildFormulaFieldTokenInsertion(expression, fieldId)`: pure stable field-token insertion.
+- `buildFormulaFunctionInsertion(expression, docOrName)`: pure function snippet insertion.
+
+### UI behavior
+
+Formula field configuration now renders:
+
+- Expression textarea.
+- Existing diagnostics for empty formulas, unbalanced parentheses, unknown `{fld_xxx}` refs, and undocumented function calls.
+- Existing field chips that insert stable `{fieldId}` tokens.
+- Function reference toolbar with text search and category filter.
+- Grouped function cards with signature, description, and example.
+
+Clicking a function card appends the documented `insertText`. Empty expressions are prefixed with `=`, matching the existing editor convention.
+
+### Non-goals
+
+- No backend parser or evaluation changes.
+- No cursor-position-aware insertion. Insertions still append to the expression, preserving the existing low-risk behavior.
+- No formula runtime validation beyond the existing lightweight diagnostics.
+- No persistence schema change.
+
+## Risk Controls
+
+- Pure helper tests cover catalog grouping and insertion rules.
+- Component tests cover category filtering and card insertion.
+- Existing unknown-field-reference blocking behavior remains covered.
+- Backend formula engine file was read for supported built-ins but left unchanged.

--- a/docs/development/wave-m-feishu-4-formula-catalog-verification-20260429.md
+++ b/docs/development/wave-m-feishu-4-formula-catalog-verification-20260429.md
@@ -1,0 +1,51 @@
+# Wave M-Feishu-4 Formula Catalog Verification — 2026-04-29
+
+## Target
+
+Verify Lane B formula catalog/editor-assist changes in `/tmp/ms2-mfeishu4-formula-catalog-20260429`.
+
+## Commands
+
+The worktree did not have package links installed, so verification reused the main checkout's existing `node_modules` while keeping cwd inside `/tmp/ms2-mfeishu4-formula-catalog-20260429`.
+
+```bash
+cd /tmp/ms2-mfeishu4-formula-catalog-20260429/apps/web
+NODE_PATH=/Users/chouhua/Downloads/Github/metasheet2/apps/web/node_modules:/Users/chouhua/Downloads/Github/metasheet2/node_modules \
+  /Users/chouhua/Downloads/Github/metasheet2/node_modules/.bin/vitest run tests/multitable-formula-editor.spec.ts --watch=false
+
+cd /tmp/ms2-mfeishu4-formula-catalog-20260429/apps/web
+NODE_PATH=/Users/chouhua/Downloads/Github/metasheet2/apps/web/node_modules:/Users/chouhua/Downloads/Github/metasheet2/node_modules \
+  /Users/chouhua/Downloads/Github/metasheet2/apps/web/node_modules/.bin/vue-tsc -b
+```
+
+## Coverage
+
+- Formula doc search still returns documented functions by name.
+- Formula diagnostics still warn on name-based field refs and error on unknown stable refs.
+- Function catalog groups functions by category and filters by query/category.
+- Function insertion helper prefixes `=` for empty expressions and appends snippets for non-empty expressions.
+- Field token insertion helper appends stable `{fld_xxx}` tokens.
+- `MetaFieldManager.vue` renders category-filtered function cards and inserts the selected snippet into the formula textarea.
+
+## Results
+
+- Vitest target: passed, `tests/multitable-formula-editor.spec.ts` 5/5 tests.
+- Frontend type-check: passed, `vue-tsc -b` exited 0 with no diagnostics.
+- Rebase verification: branch rebased cleanly onto `origin/main@f76a105f7`;
+  target Vitest and `vue-tsc -b --noEmit` were rerun successfully. The
+  parallel Vitest pass printed a non-blocking websocket port-in-use warning.
+- Post-#1242 rebase verification: branch rebased cleanly onto
+  `origin/main@1bc4da47f` after the multi-select field PR landed; reran
+  `tests/multitable-formula-editor.spec.ts` plus
+  `tests/multitable-field-manager.spec.ts` for 19/19 passing tests, reran
+  `vue-tsc -b --noEmit`, and reran `git diff --check`.
+- Post-#1243 rebase verification: branch rebased cleanly onto
+  `origin/main@a9137d9a5` after the filter-builder PR landed; reran formula,
+  field-manager, filter-builder, and multi-select frontend specs for 27/27
+  passing tests, reran `vue-tsc -b --noEmit`, and reran `git diff --check`.
+
+## Residual Limits
+
+- Insertions append to the end of the expression instead of using the textarea cursor position.
+- The catalog documents a practical subset of backend built-ins rather than every function registered in the shared formula engine.
+- Lightweight diagnostics are not a full parser or runtime evaluator.


### PR DESCRIPTION
## Summary
- Add grouped formula function catalog metadata and insertion helpers.
- Wire the field manager formula editor to browse/search supported functions and insert snippets at the cursor.
- Keep formula storage/evaluation unchanged; this is editor affordance only.
- Add design and verification docs under `docs/development/`.

## Verification
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-formula-editor.spec.ts --watch=false --reporter=dot`
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-formula-editor.spec.ts tests/multitable-field-manager.spec.ts tests/meta-toolbar-filter-builder.spec.ts tests/multitable-multiselect-field.spec.ts --watch=false --reporter=dot`
- `pnpm --filter @metasheet/web exec vue-tsc -b --noEmit`
- `git diff --check`

## Merge Order
Rebased after #1242 and #1243 landed; ready as final Wave M-Feishu-4 PR.