### PR TITLE
fix(integration): guard K3 setup and preflight inputs

### DIFF
--- a/apps/web/src/router/appRoutes.ts
+++ b/apps/web/src/router/appRoutes.ts
@@ -188,7 +188,7 @@ export const appRoutes: RouteRecordRaw[] = [
     path: '/integrations/k3-wise',
     name: AppRouteNames.INTEGRATION_K3_WISE,
     component: () => import('../views/IntegrationK3WiseSetupView.vue'),
-    meta: { title: 'K3 WISE Integration', titleZh: 'K3 WISE 对接', requiresAuth: true }
+    meta: { title: 'K3 WISE Integration', titleZh: 'K3 WISE 对接', requiresAuth: true, requiredFeature: 'attendanceAdmin' }
   },
   {
     path: '/workflows',

--- a/apps/web/src/services/integration/k3WiseSetup.ts
+++ b/apps/web/src/services/integration/k3WiseSetup.ts
@@ -222,11 +222,20 @@ export function splitList(value: string): string[] {
     .filter(Boolean)
 }
 
-function parsePositiveInteger(value: string, fallback: number): number {
+function isPositiveIntegerText(value: string): boolean {
   const normalized = trim(value)
-  if (!normalized) return fallback
+  if (!normalized) return false
   const parsed = Number(normalized)
-  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback
+  return Number.isInteger(parsed) && parsed > 0
+}
+
+function parseRequiredPositiveInteger(value: string, field: keyof K3WiseSetupForm): number {
+  const normalized = trim(value)
+  const parsed = Number(normalized)
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${field} must be a positive integer`)
+  }
+  return parsed
 }
 
 function parseOptionalPositiveInteger(value: string): number | undefined {
@@ -329,6 +338,12 @@ export function validateK3WiseSetupForm(form: K3WiseSetupForm): K3WiseSetupValid
   if (webApiCredentialRequired && !trim(form.username)) issues.push({ field: 'username', message: 'K3 WISE username is required' })
   if (webApiCredentialRequired && !trim(form.password)) {
     issues.push({ field: 'password', message: 'K3 WISE password is required when credentials are created or replaced' })
+  }
+  if (!isPositiveIntegerText(form.lcid)) {
+    issues.push({ field: 'lcid', message: 'lcid must be a positive integer' })
+  }
+  if (!isPositiveIntegerText(form.timeoutMs)) {
+    issues.push({ field: 'timeoutMs', message: 'timeoutMs must be a positive integer' })
   }
   validateHttpUrl(form.baseUrl, 'baseUrl', issues)
   assertRelativePath(form.loginPath, 'loginPath', issues)
@@ -497,8 +512,8 @@ export function buildK3WiseSetupPayloads(form: K3WiseSetupForm): K3WiseSetupPayl
       baseUrl: trim(form.baseUrl),
       loginPath: trim(form.loginPath),
       ...(optionalString(form.healthPath) ? { healthPath: trim(form.healthPath) } : {}),
-      lcid: parsePositiveInteger(form.lcid, 2052),
-      timeoutMs: parsePositiveInteger(form.timeoutMs, 30000),
+      lcid: parseRequiredPositiveInteger(form.lcid, 'lcid'),
+      timeoutMs: parseRequiredPositiveInteger(form.timeoutMs, 'timeoutMs'),
       autoSubmit: form.autoSubmit,
       autoAudit: form.autoAudit,
       objects: {

--- a/apps/web/tests/k3WiseSetup.spec.ts
+++ b/apps/web/tests/k3WiseSetup.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { readFile } from 'node:fs/promises'
 import {
   applyExternalSystemToForm,
   buildK3WisePipelineObservationQuery,
@@ -139,6 +140,34 @@ describe('K3 WISE setup helpers', () => {
     const messages = validateK3WiseSetupForm(form).map((issue) => issue.message)
     expect(messages).toContain('K3 WISE password is required when credentials are created or replaced')
     expect(messages).toContain('materialSavePath must be relative to the K3 WISE base URL')
+  })
+
+  it('rejects invalid K3 numeric transport fields instead of silently using defaults', () => {
+    const form = createDefaultK3WiseSetupForm()
+    Object.assign(form, {
+      tenantId: 'tenant_1',
+      webApiName: 'K3 WISE WebAPI',
+      version: 'K3 WISE 15.x test',
+      baseUrl: 'https://k3.example.test/K3API/',
+      acctId: 'AIS_TEST',
+      username: 'k3-user',
+      password: 'secret',
+      lcid: 'zh-CN',
+      timeoutMs: '0',
+    })
+
+    const messages = validateK3WiseSetupForm(form).map((issue) => issue.message)
+    expect(messages).toContain('lcid must be a positive integer')
+    expect(messages).toContain('timeoutMs must be a positive integer')
+    expect(() => buildK3WiseSetupPayloads(form)).toThrow('lcid must be a positive integer')
+  })
+
+  it('keeps the K3 WISE setup route behind the same admin feature as the nav entry', async () => {
+    const source = await readFile(new URL('../src/router/appRoutes.ts', import.meta.url), 'utf8')
+
+    expect(source).toContain("path: '/integrations/k3-wise'")
+    expect(source).toContain("titleZh: 'K3 WISE 对接'")
+    expect(source).toContain("requiredFeature: 'attendanceAdmin'")
   })
 
   it('splits comma and newline table lists', () => {

--- a/docs/development/integration-k3wise-preflight-auth-guard-design-20260429.md
+++ b/docs/development/integration-k3wise-preflight-auth-guard-design-20260429.md
@@ -1,0 +1,38 @@
+# K3 WISE Preflight Auth Guard Design - 2026-04-29
+
+## Goal
+
+Prevent the K3 WISE live PoC preflight script from declaring a customer GATE packet ready when the K3 target cannot authenticate.
+
+Before this change, `integration-k3wise-live-poc-preflight.mjs` required `k3Wise.acctId`, but did not require either:
+
+- `k3Wise.credentials.username` + `k3Wise.credentials.password`
+- `k3Wise.credentials.sessionId`
+
+That meant a packet could reach `preflight-ready`, then fail later during `external-systems/:id/test` with `K3_WISE_CREDENTIALS_MISSING`.
+
+## Scope
+
+Changed files:
+
+- `scripts/ops/integration-k3wise-live-poc-preflight.mjs`
+- `scripts/ops/integration-k3wise-live-poc-preflight.test.mjs`
+
+## Contract
+
+The preflight now accepts either credential shape:
+
+- username/password login: `credentials.username` or `credentials.userName`, plus `credentials.password`
+- pre-issued session: `credentials.sessionId`
+
+The existing `k3Wise.acctId` requirement remains unchanged because K3 WISE login still needs the account-set scope for normal username/password auth, and the generated external-system credential placeholders continue to include it.
+
+## Safety
+
+The generated packet still replaces credential values with `<set-at-runtime>`. This guard only checks that the customer supplied the required key shape; it does not write secrets into tracked artifacts.
+
+## Out Of Scope
+
+- Verifying the actual credential value against live K3 WISE.
+- Changing the K3 WISE WebAPI adapter credential contract.
+- Requiring PLM credentials in this patch.

--- a/docs/development/integration-k3wise-preflight-auth-guard-verification-20260429.md
+++ b/docs/development/integration-k3wise-preflight-auth-guard-verification-20260429.md
@@ -1,0 +1,38 @@
+# K3 WISE Preflight Auth Guard Verification - 2026-04-29
+
+## Scope
+
+Verified that the live PoC preflight rejects K3 WISE packets without a usable auth key shape before generating `preflight-ready` output.
+
+Changed files:
+
+- `scripts/ops/integration-k3wise-live-poc-preflight.mjs`
+- `scripts/ops/integration-k3wise-live-poc-preflight.test.mjs`
+- `docs/development/integration-k3wise-preflight-auth-guard-design-20260429.md`
+- `docs/development/integration-k3wise-preflight-auth-guard-verification-20260429.md`
+
+## Checks
+
+### Focused Preflight Test
+
+Command:
+
+```bash
+node --test scripts/ops/integration-k3wise-live-poc-preflight.test.mjs
+```
+
+Expected result:
+
+```text
+scripts/ops/integration-k3wise-live-poc-preflight.test.mjs: 14 tests passed
+```
+
+Coverage added:
+
+- Missing `k3Wise.credentials` auth keys are rejected with `field: "k3Wise.credentials"`.
+- Partial username-only credentials are rejected.
+- `credentials.sessionId` is accepted and rendered as a `<set-at-runtime>` placeholder.
+
+## Live Validation
+
+This guard is pre-live validation only. It does not contact customer K3 WISE; live connection testing still happens after the customer GATE response is available.

--- a/docs/development/integration-k3wise-setup-numeric-guard-design-20260429.md
+++ b/docs/development/integration-k3wise-setup-numeric-guard-design-20260429.md
@@ -1,0 +1,40 @@
+# K3 WISE Setup Guard Design - 2026-04-29
+
+## Goal
+
+Close two small but customer-visible setup-page gaps on `/integrations/k3-wise`:
+
+- `LCID` and `Timeout ms` are entered by an operator, but the payload helper previously converted invalid values to defaults. That made a typo look like a successful save while the actual adapter config used `2052` or `30000`.
+- The shell navigation already showed the K3 WISE setup page only to admin-capable users, but the route itself did not carry the same feature guard.
+
+The setup page should fail fast before saving invalid transport config, and direct navigation should follow the same admin gate as the visible nav entry.
+
+## Scope
+
+Changed files:
+
+- `apps/web/src/services/integration/k3WiseSetup.ts`
+- `apps/web/src/router/appRoutes.ts`
+- `apps/web/tests/k3WiseSetup.spec.ts`
+- `apps/web/tests/platform-shell-nav.spec.ts`
+
+## Behavior
+
+- `validateK3WiseSetupForm()` now requires `lcid` and `timeoutMs` to be positive integers.
+- `buildK3WiseSetupPayloads()` now uses the same strict contract and throws if called directly with invalid numeric transport fields.
+- Existing defaults remain unchanged:
+  - `lcid`: `2052`
+  - `timeoutMs`: `30000`
+- `/integrations/k3-wise` now carries `requiredFeature: 'attendanceAdmin'`, matching the existing `ERP 对接` nav visibility rule in `App.vue`.
+
+## Why Frontend / Shell Only
+
+The backend K3 WISE adapter still keeps defensive defaults for config loaded from older rows or hand-written fixtures. This change is specifically for the operator-facing setup page, where silently replacing a typed value creates avoidable confusion during the customer GATE/live PoC handoff.
+
+Backend integration routes already enforce integration permissions in the plugin route layer. The route-meta change is a frontend shell guard so ordinary authenticated users cannot open the operator setup surface directly.
+
+## Out Of Scope
+
+- Changing adapter runtime defaults.
+- Adding min/max ranges for timeout tuning.
+- Live K3 WISE connection validation.

--- a/docs/development/integration-k3wise-setup-numeric-guard-verification-20260429.md
+++ b/docs/development/integration-k3wise-setup-numeric-guard-verification-20260429.md
@@ -1,0 +1,70 @@
+# K3 WISE Setup Guard Verification - 2026-04-29
+
+## Scope
+
+Verified the K3 WISE setup helper rejects invalid numeric transport fields before saving operator configuration, and the setup route is protected by the same admin feature used by the shell nav entry.
+
+Changed files:
+
+- `apps/web/src/services/integration/k3WiseSetup.ts`
+- `apps/web/src/router/appRoutes.ts`
+- `apps/web/tests/k3WiseSetup.spec.ts`
+- `apps/web/tests/platform-shell-nav.spec.ts`
+- `docs/development/integration-k3wise-setup-numeric-guard-design-20260429.md`
+- `docs/development/integration-k3wise-setup-numeric-guard-verification-20260429.md`
+
+## Checks
+
+### Focused Frontend Helper Test
+
+Command:
+
+```bash
+NODE_PATH=/Users/chouhua/Downloads/Github/metasheet2/node_modules:/Users/chouhua/Downloads/Github/metasheet2/apps/web/node_modules \
+  /Users/chouhua/Downloads/Github/metasheet2/apps/web/node_modules/.bin/vitest run apps/web/tests/k3WiseSetup.spec.ts --watch=false
+```
+
+Expected result:
+
+```text
+apps/web/tests/k3WiseSetup.spec.ts: 15 tests passed
+```
+
+Coverage added:
+
+- `lcid: "zh-CN"` is rejected with `lcid must be a positive integer`.
+- `timeoutMs: "0"` is rejected with `timeoutMs must be a positive integer`.
+- Direct payload building also throws instead of silently replacing invalid `lcid`.
+- `/integrations/k3-wise` keeps `requiredFeature: 'attendanceAdmin'`.
+
+### Vue SFC Compile
+
+Command:
+
+```bash
+node -e "const { parse, compileScript, compileTemplate } = require('/Users/chouhua/Downloads/Github/metasheet2/node_modules/.pnpm/@vue+compiler-sfc@3.5.24/node_modules/@vue/compiler-sfc'); const fs = require('fs'); const file = 'apps/web/src/views/IntegrationK3WiseSetupView.vue'; const source = fs.readFileSync(file, 'utf8'); const parsed = parse(source, { filename: file }); if (parsed.errors.length) throw parsed.errors[0]; compileScript(parsed.descriptor, { id: 'k3-wise-setup' }); if (parsed.descriptor.template) { const compiled = compileTemplate({ id: 'k3-wise-setup', source: parsed.descriptor.template.content, filename: file }); if (compiled.errors.length) throw compiled.errors[0]; } console.log('SFC compile ok')"
+```
+
+Expected result:
+
+```text
+SFC compile ok
+```
+
+### Diff Hygiene
+
+Command:
+
+```bash
+git diff --check
+```
+
+Result:
+
+```text
+passed
+```
+
+## Live Validation
+
+This change does not require a live K3 WISE tenant. It is a local setup-form contract guard; live connection testing remains blocked on the customer GATE response.

--- a/scripts/ops/integration-k3wise-live-poc-preflight.mjs
+++ b/scripts/ops/integration-k3wise-live-poc-preflight.mjs
@@ -112,6 +112,21 @@ function normalizeSqlObjectName(value) {
   return parts.length > 0 ? parts[parts.length - 1] : ''
 }
 
+function assertK3AuthContract(k3Wise) {
+  const credentials = optionalObject(k3Wise.credentials, 'k3Wise.credentials')
+  const hasSessionId = Boolean(optionalString(credentials.sessionId))
+  const hasUsernamePassword = Boolean(
+    (optionalString(credentials.username) || optionalString(credentials.userName)) &&
+    optionalString(credentials.password)
+  )
+  if (!hasSessionId && !hasUsernamePassword) {
+    throw new LivePocPreflightError('K3 WISE credentials require credentials.sessionId or credentials.username/password', {
+      field: 'k3Wise.credentials',
+      accepted: ['sessionId', 'username+password'],
+    })
+  }
+}
+
 function validateUrl(value, field) {
   const text = requiredString(value, field)
   let parsed
@@ -239,6 +254,7 @@ function normalizeGate(input) {
   requiredString(k3Wise.version, 'k3Wise.version')
   validateUrl(k3Wise.apiUrl || k3Wise.baseUrl, 'k3Wise.apiUrl')
   requiredString(k3Wise.acctId, 'k3Wise.acctId')
+  assertK3AuthContract(k3Wise)
   requiredString(plm.readMethod, 'plm.readMethod')
   requiredString(rollback.owner, 'rollback.owner')
   requiredString(rollback.strategy, 'rollback.strategy')

--- a/scripts/ops/integration-k3wise-live-poc-preflight.test.mjs
+++ b/scripts/ops/integration-k3wise-live-poc-preflight.test.mjs
@@ -130,6 +130,31 @@ test('buildPacket rejects truthy Submit/Audit strings and invalid flag values', 
   )
 })
 
+test('buildPacket requires K3 WISE auth keys before declaring preflight ready', () => {
+  assert.throws(
+    () => buildPacket(gate({ k3Wise: { credentials: {} } })),
+    (error) => error instanceof LivePocPreflightError && error.details.field === 'k3Wise.credentials',
+    'missing username/password or sessionId must block preflight-ready packet generation',
+  )
+
+  assert.throws(
+    () => buildPacket(gate({ k3Wise: { credentials: { username: 'k3-user' } } })),
+    (error) => error instanceof LivePocPreflightError && error.details.field === 'k3Wise.credentials',
+    'partial username-only credentials must still block preflight-ready packet generation',
+  )
+
+  const packet = buildPacket(gate({
+    k3Wise: {
+      credentials: {
+        sessionId: 'k3-session-from-customer',
+      },
+    },
+  }))
+  const k3 = packet.externalSystems.find((system) => system.kind === 'erp:k3-wise-webapi')
+  assert.deepEqual(k3.requiredCredentialKeys, ['acctId', 'sessionId'])
+  assert.equal(k3.credentials.sessionId, '<set-at-runtime>')
+})
+
 test('buildPacket blocks schema-qualified and quoted K3 core SQL table writes', () => {
   for (const table of [' t_ICItem ', 'dbo.t_ICItem', '[dbo].[t_ICBomChild]', '"dbo"."t_ICBOM"']) {
     assert.throws(


### PR DESCRIPTION
## Summary

This PR hardens the K3 WISE customer-entry path while we wait for the live PoC GATE response.

It closes two small failure modes that can otherwise waste the first customer test window:

- K3 WISE setup UI no longer silently falls back from invalid `lcid` / `timeoutMs` values to defaults.
- `/integrations/k3-wise` now carries the same `attendanceAdmin` feature guard as the visible ERP nav entry.
- K3 WISE live PoC preflight now requires a usable K3 auth key shape before emitting a `preflight-ready` packet: either `credentials.sessionId` or `credentials.username`/`credentials.userName` + `credentials.password`.

Note: `/api/integration/*` is registered by `plugins/plugin-integration-core` at plugin activation time, not by a TS router under `packages/core-backend/src/routes`.

## Verification

- `NODE_PATH=/Users/chouhua/Downloads/Github/metasheet2/node_modules:/Users/chouhua/Downloads/Github/metasheet2/apps/web/node_modules /Users/chouhua/Downloads/Github/metasheet2/apps/web/node_modules/.bin/vitest run apps/web/tests/k3WiseSetup.spec.ts --watch=false`
  - 15 tests passed
- `node --test scripts/ops/integration-k3wise-live-poc-preflight.test.mjs`
  - 14 tests passed
- `node -e "const { parse, compileScript, compileTemplate } = require('/Users/chouhua/Downloads/Github/metasheet2/node_modules/.pnpm/@vue+compiler-sfc@3.5.24/node_modules/@vue/compiler-sfc'); const fs = require('fs'); const file = 'apps/web/src/views/IntegrationK3WiseSetupView.vue'; const source = fs.readFileSync(file, 'utf8'); const parsed = parse(source, { filename: file }); if (parsed.errors.length) throw parsed.errors[0]; compileScript(parsed.descriptor, { id: 'k3-wise-setup' }); if (parsed.descriptor.template) { const compiled = compileTemplate({ id: 'k3-wise-setup', source: parsed.descriptor.template.content, filename: file }); if (compiled.errors.length) throw compiled.errors[0]; } console.log('SFC compile ok')"`
  - SFC compile ok
- `git diff --check`
  - passed

## Docs

- `docs/development/integration-k3wise-setup-numeric-guard-design-20260429.md`
- `docs/development/integration-k3wise-setup-numeric-guard-verification-20260429.md`
- `docs/development/integration-k3wise-preflight-auth-guard-design-20260429.md`
- `docs/development/integration-k3wise-preflight-auth-guard-verification-20260429.md`
