### PR TITLE
fix(integration): require K3 preflight target mappings

### DIFF
--- a/docs/development/integration-k3wise-preflight-mapping-guard-design-20260429.md
+++ b/docs/development/integration-k3wise-preflight-mapping-guard-design-20260429.md
@@ -1,0 +1,41 @@
+# K3 WISE Preflight Mapping Guard Design - 2026-04-29
+
+## Goal
+
+Move one more live PoC failure from customer runtime into local preflight: a packet should not be `preflight-ready` if its field mappings cannot produce the minimum K3 WISE material/BOM payload shape.
+
+Before this change, preflight only required `fieldMappings.material` to contain at least one mapping. A customer packet could map a harmless field, pass preflight, then fail later when K3 Save received no material code/name or no BOM child quantity.
+
+## Scope
+
+Changed files:
+
+- `scripts/ops/integration-k3wise-live-poc-preflight.mjs`
+- `scripts/ops/integration-k3wise-live-poc-preflight.test.mjs`
+
+## Contract
+
+The guard checks target fields, not source fields. Customer PLM source field names vary, but the generated K3 WISE target payload must include stable K3 targets.
+
+Material PoC requires mappings to:
+
+- `FNumber`
+- `FName`
+
+BOM PoC, when enabled, requires mappings to:
+
+- `FParentItemNumber`
+- one child material target: `FChildItems[].FItemNumber`, `FChildItemNumber`, or `FItemNumber`
+- one child quantity target: `FChildItems[].FQty` or `FQty`
+
+The matching normalizes whitespace and `[]` notation so customer-authored field names like `FChildItems.FQty` and generated examples using `FChildItems[].FQty` align.
+
+## Safety
+
+This guard does not contact K3 WISE and does not inspect secret values. It only checks the shape of the customer GATE mapping before any packet is written.
+
+## Out Of Scope
+
+- Full K3 schema validation.
+- Customer-specific mandatory material dimensions or BOM effectivity fields.
+- Transform correctness beyond the target field presence check.

--- a/docs/development/integration-k3wise-preflight-mapping-guard-verification-20260429.md
+++ b/docs/development/integration-k3wise-preflight-mapping-guard-verification-20260429.md
@@ -1,0 +1,68 @@
+# K3 WISE Preflight Mapping Guard Verification - 2026-04-29
+
+## Scope
+
+Verified that K3 WISE live PoC preflight rejects packets missing the minimum K3 material/BOM target mappings before generating `preflight-ready`.
+
+Changed files:
+
+- `scripts/ops/integration-k3wise-live-poc-preflight.mjs`
+- `scripts/ops/integration-k3wise-live-poc-preflight.test.mjs`
+- `docs/development/integration-k3wise-preflight-mapping-guard-design-20260429.md`
+- `docs/development/integration-k3wise-preflight-mapping-guard-verification-20260429.md`
+
+## Checks
+
+### K3 WISE PoC Chain
+
+Command:
+
+```bash
+pnpm run verify:integration-k3wise:poc
+```
+
+Result:
+
+```text
+preflight: 16 tests passed
+evidence: 31 tests passed
+mock chain: K3 WISE PoC mock chain verified end-to-end (PASS)
+```
+
+### Focused Preflight Test
+
+Command:
+
+```bash
+node --test scripts/ops/integration-k3wise-live-poc-preflight.test.mjs
+```
+
+Expected result:
+
+```text
+scripts/ops/integration-k3wise-live-poc-preflight.test.mjs: 16 tests passed
+```
+
+Coverage added:
+
+- Material mappings without `FName` fail on `fieldMappings.material`.
+- BOM mappings without `FChildItems[].FQty` / `FQty` fail on `fieldMappings.bom`.
+- BOM mapping requirements are skipped when `bom.enabled` is false.
+
+### Diff Hygiene
+
+Command:
+
+```bash
+git diff --check
+```
+
+Expected result:
+
+```text
+passed
+```
+
+## Live Validation
+
+This is a preflight-only guard. It reduces avoidable customer GATE round trips but does not replace the live K3 WISE dry-run and Save-only test.

--- a/scripts/ops/integration-k3wise-live-poc-preflight.mjs
+++ b/scripts/ops/integration-k3wise-live-poc-preflight.mjs
@@ -19,6 +19,15 @@ const SQL_MODE_ALIASES = new Map([
   ['stored_procedure', 'stored-procedure'],
 ])
 const SQL_MODES = new Set(['readonly', 'middle-table', 'stored-procedure'])
+const MATERIAL_REQUIRED_TARGET_FIELDS = [
+  { label: 'K3 material code', targets: ['FNumber'] },
+  { label: 'K3 material name', targets: ['FName'] },
+]
+const BOM_REQUIRED_TARGET_FIELDS = [
+  { label: 'K3 BOM parent material', targets: ['FParentItemNumber'] },
+  { label: 'K3 BOM child material', targets: ['FChildItems[].FItemNumber', 'FChildItemNumber', 'FItemNumber'] },
+  { label: 'K3 BOM child quantity', targets: ['FChildItems[].FQty', 'FQty'] },
+]
 
 class LivePocPreflightError extends Error {
   constructor(message, details = {}) {
@@ -124,6 +133,41 @@ function assertK3AuthContract(k3Wise) {
       field: 'k3Wise.credentials',
       accepted: ['sessionId', 'username+password'],
     })
+  }
+}
+
+function normalizeTargetPath(value) {
+  return String(value)
+    .trim()
+    .replace(/\[\]/g, '')
+    .replace(/\s+/g, '')
+    .toLowerCase()
+}
+
+function collectTargetFields(mappings, field) {
+  return mappings.map((mapping, index) => {
+    if (!isPlainObject(mapping)) {
+      throw new LivePocPreflightError(`${field}[${index}] must be an object`, {
+        field,
+        index,
+      })
+    }
+    return requiredString(mapping.targetField, `${field}[${index}].targetField`)
+  })
+}
+
+function assertRequiredTargetFields(mappings, requirements, field) {
+  const targetFields = collectTargetFields(mappings, field)
+  const normalizedTargets = new Set(targetFields.map(normalizeTargetPath))
+  for (const requirement of requirements) {
+    const acceptedTargets = requirement.targets.map(normalizeTargetPath)
+    if (!acceptedTargets.some((target) => normalizedTargets.has(target))) {
+      throw new LivePocPreflightError(`${field} must map ${requirement.label}`, {
+        field,
+        requiredTargetFields: requirement.targets,
+        targetFields,
+      })
+    }
   }
 }
 
@@ -249,6 +293,16 @@ function normalizeGate(input) {
     throw new LivePocPreflightError('fieldMappings.material must contain at least one mapping', {
       field: 'fieldMappings.material',
     })
+  }
+  assertRequiredTargetFields(materialMappings, MATERIAL_REQUIRED_TARGET_FIELDS, 'fieldMappings.material')
+  if (bomEnabled) {
+    const bomMappings = optionalArray(fieldMappings.bom, 'fieldMappings.bom')
+    if (bomMappings.length === 0) {
+      throw new LivePocPreflightError('fieldMappings.bom must contain at least one mapping when BOM PoC is enabled', {
+        field: 'fieldMappings.bom',
+      })
+    }
+    assertRequiredTargetFields(bomMappings, BOM_REQUIRED_TARGET_FIELDS, 'fieldMappings.bom')
   }
 
   requiredString(k3Wise.version, 'k3Wise.version')

--- a/scripts/ops/integration-k3wise-live-poc-preflight.test.mjs
+++ b/scripts/ops/integration-k3wise-live-poc-preflight.test.mjs
@@ -155,6 +155,47 @@ test('buildPacket requires K3 WISE auth keys before declaring preflight ready', 
   assert.equal(k3.credentials.sessionId, '<set-at-runtime>')
 })
 
+test('buildPacket requires minimum K3 material target mappings', () => {
+  assert.throws(
+    () => buildPacket(gate({
+      fieldMappings: {
+        material: [
+          { sourceField: 'code', targetField: 'FNumber' },
+        ],
+      },
+    })),
+    (error) => error instanceof LivePocPreflightError &&
+      error.details.field === 'fieldMappings.material' &&
+      error.details.requiredTargetFields.includes('FName'),
+    'material mappings must include K3 material name target field',
+  )
+})
+
+test('buildPacket requires minimum K3 BOM target mappings when BOM is enabled', () => {
+  assert.throws(
+    () => buildPacket(gate({
+      fieldMappings: {
+        bom: [
+          { sourceField: 'parentCode', targetField: 'FParentItemNumber' },
+          { sourceField: 'childCode', targetField: 'FChildItems[].FItemNumber' },
+        ],
+      },
+    })),
+    (error) => error instanceof LivePocPreflightError &&
+      error.details.field === 'fieldMappings.bom' &&
+      error.details.requiredTargetFields.includes('FChildItems[].FQty'),
+    'BOM mappings must include K3 child quantity target field',
+  )
+
+  const packet = buildPacket(gate({
+    bom: { enabled: false, productId: undefined },
+    fieldMappings: {
+      bom: [],
+    },
+  }))
+  assert.equal(packet.pipelines.some((pipeline) => pipeline.targetObject === 'bom'), false)
+})
+
 test('buildPacket blocks schema-qualified and quoted K3 core SQL table writes', () => {
   for (const table of [' t_ICItem ', 'dbo.t_ICItem', '[dbo].[t_ICBomChild]', '"dbo"."t_ICBOM"']) {
     assert.throws(


### PR DESCRIPTION
## Summary

Adds a stricter live PoC preflight mapping guard for K3 WISE packets.

Before this PR, the preflight only required `fieldMappings.material` to contain at least one mapping. A customer GATE packet could therefore become `preflight-ready` while still missing the minimum K3 target fields needed for the first material/BOM Save attempt.

This PR checks target fields only, so it does not constrain customer PLM source naming:

- material requires `FNumber` and `FName`
- BOM, when enabled, requires a parent material target, child material target, and child quantity target
- BOM mapping requirements are skipped when `bom.enabled` is false

## Verification

- `node --test scripts/ops/integration-k3wise-live-poc-preflight.test.mjs`
  - 16 tests passed
- `pnpm run verify:integration-k3wise:poc`
  - preflight: 16 tests passed
  - evidence: 31 tests passed
  - mock chain: `K3 WISE PoC mock chain verified end-to-end (PASS)`
- `git diff --check`
  - passed

## Docs

- `docs/development/integration-k3wise-preflight-mapping-guard-design-20260429.md`
- `docs/development/integration-k3wise-preflight-mapping-guard-verification-20260429.md`
