### PR TITLE
fix(integration): tighten K3 postdeploy readiness smoke

### DIFF
--- a/docs/development/integration-k3wise-postdeploy-readiness-guard-design-20260429.md
+++ b/docs/development/integration-k3wise-postdeploy-readiness-guard-design-20260429.md
@@ -1,0 +1,73 @@
+# K3 WISE Postdeploy Readiness Guard Design
+
+## Context
+
+The K3 WISE postdeploy smoke is the operator-facing check that runs after a
+MetaSheet deploy and before the customer K3 WISE Live PoC packet is executed.
+It must not report authenticated readiness when only the K3 target side is
+present. The PoC path depends on the full chain:
+
+- generic HTTP source adapter
+- Yuantus PLM wrapper adapter
+- K3 WISE WebAPI target adapter
+- K3 WISE SQL Server channel adapter
+- five user-visible staging multitable descriptors
+
+Before this change, the authenticated route contract required only the two K3
+adapter kinds, and the staging contract required only `standard_materials` and
+`bom_cleanse`. That was enough to prove a partial ERP target path, but it could
+miss a deployment that had lost the PLM/source side or the human repair/audit
+staging surfaces.
+
+## Change
+
+`scripts/ops/integration-k3wise-postdeploy-smoke.mjs` now requires all adapter
+kinds registered by `plugins/plugin-integration-core/index.cjs`:
+
+- `http`
+- `plm:yuantus-wrapper`
+- `erp:k3-wise-webapi`
+- `erp:k3-wise-sqlserver`
+
+It also requires all staging descriptors authored by
+`plugins/plugin-integration-core/lib/staging-installer.cjs` and documented in
+`packages/core-backend/claudedocs/integration-plm-k3wise-mvp.md`:
+
+- `plm_raw_items`
+- `standard_materials`
+- `bom_cleanse`
+- `integration_exceptions`
+- `integration_run_log`
+
+The checks remain read-only. They still run through:
+
+- `GET /api/integration/status`
+- `GET /api/integration/staging/descriptors`
+
+No install, mutation, external PLM call, K3 call, or SQL Server call is added.
+
+## Failure Model
+
+Authenticated postdeploy smoke fails when:
+
+- any required adapter kind is missing from `/api/integration/status`
+- any required integration route is missing from `/api/integration/status`
+- any required staging descriptor is missing from
+  `/api/integration/staging/descriptors`
+
+Unauthenticated public smoke behavior is unchanged. It can still verify public
+backend health and the frontend route while marking authenticated contract
+checks as skipped unless `--require-auth` is supplied.
+
+## Operator Impact
+
+This makes the deploy signal stricter and more honest:
+
+- public smoke still answers "is the app shell and backend reachable?"
+- authenticated smoke now answers "is the deployed integration plugin ready for
+  the PLM to staging to K3 PoC chain?"
+
+When customer GATE data arrives, an authenticated postdeploy PASS has higher
+value because it covers the source adapter, target adapters, and all user-facing
+staging surfaces used by the runbook.
+

--- a/docs/development/integration-k3wise-postdeploy-readiness-guard-verification-20260429.md
+++ b/docs/development/integration-k3wise-postdeploy-readiness-guard-verification-20260429.md
@@ -1,0 +1,72 @@
+# K3 WISE Postdeploy Readiness Guard Verification
+
+## Environment
+
+Executed from isolated worktree:
+
+```bash
+/tmp/ms2-k3wise-postdeploy-readiness-20260429
+```
+
+Base branch:
+
+```bash
+origin/main 1bc4da47f
+```
+
+## Local Checks
+
+```bash
+node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
+node --test scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
+node --test scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs
+```
+
+## Results
+
+`node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs`
+
+- Passed: 9 tests.
+- Covered public smoke without auth.
+- Covered protected integration health route without auth.
+- Covered authenticated route, control-plane list, tenant scope, and staging
+  descriptor contracts.
+- Covered token redaction in stdout, stderr, and JSON evidence.
+- Added failure coverage for missing `plm:yuantus-wrapper` adapter.
+- Added failure coverage for missing `integration_exceptions` staging
+  descriptor.
+
+`node --test scripts/ops/integration-k3wise-postdeploy-summary.test.mjs`
+
+- Passed: 5 tests.
+- Summary rendering remains unchanged for PASS, FAIL, missing evidence, and
+  help output.
+
+`node --test scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs`
+
+- Passed: 2 tests.
+- Manual and deploy workflow wiring remains unchanged.
+
+## Expected Authenticated PASS Surface
+
+An authenticated postdeploy PASS now proves these plugin adapter kinds:
+
+- `http`
+- `plm:yuantus-wrapper`
+- `erp:k3-wise-webapi`
+- `erp:k3-wise-sqlserver`
+
+It also proves these staging descriptors:
+
+- `plm_raw_items`
+- `standard_materials`
+- `bom_cleanse`
+- `integration_exceptions`
+- `integration_run_log`
+
+## Notes
+
+No live customer PLM, K3 WISE, SQL Server, or middleware endpoint was contacted.
+The smoke remains a deployment-readiness check, not a customer-system
+connectivity check.
+

--- a/docs/development/integration-k3wise-postdeploy-smoke-design-20260428.md
+++ b/docs/development/integration-k3wise-postdeploy-smoke-design-20260428.md
@@ -26,7 +26,7 @@ Public checks always run:
 Authenticated checks run only when a bearer token is provided:
 
 - `GET /api/auth/me`: supplied token is valid.
-- `GET /api/integration/status`: required K3 adapter kinds and integration API routes are registered.
+- `GET /api/integration/status`: required source, PLM, and K3 adapter kinds and integration API routes are registered.
 - `GET /api/integration/external-systems?tenantId=<tenant>&limit=1`: read-only external-system list endpoint is reachable.
 - `GET /api/integration/pipelines?tenantId=<tenant>&limit=1`: read-only pipeline list endpoint is reachable.
 - `GET /api/integration/runs?tenantId=<tenant>&limit=1`: read-only run-log list endpoint is reachable.

--- a/docs/development/integration-k3wise-postdeploy-smoke-verification-20260428.md
+++ b/docs/development/integration-k3wise-postdeploy-smoke-verification-20260428.md
@@ -86,5 +86,5 @@ node scripts/ops/integration-k3wise-postdeploy-smoke.mjs \
 Expected authenticated additions:
 
 - `auth-me`: pass.
-- `integration-route-contract`: pass with K3 WebAPI and SQL Server adapter kinds registered.
-- `staging-descriptor-contract`: pass with `standard_materials` and `bom_cleanse`.
+- `integration-route-contract`: pass with `http`, `plm:yuantus-wrapper`, K3 WebAPI, and K3 SQL Server adapter kinds registered.
+- `staging-descriptor-contract`: pass with `plm_raw_items`, `standard_materials`, `bom_cleanse`, `integration_exceptions`, and `integration_run_log`.

--- a/scripts/ops/integration-k3wise-postdeploy-smoke.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-smoke.mjs
@@ -5,7 +5,12 @@ import { pathToFileURL } from 'node:url'
 
 const DEFAULT_BASE_URL = 'http://142.171.239.56:8081'
 const DEFAULT_OUTPUT_ROOT = 'output/integration-k3wise-postdeploy-smoke'
-const REQUIRED_ADAPTERS = ['erp:k3-wise-webapi', 'erp:k3-wise-sqlserver']
+const REQUIRED_ADAPTERS = [
+  'http',
+  'plm:yuantus-wrapper',
+  'erp:k3-wise-webapi',
+  'erp:k3-wise-sqlserver',
+]
 const REQUIRED_ROUTES = [
   ['GET', '/api/integration/status'],
   ['GET', '/api/integration/external-systems'],
@@ -25,6 +30,13 @@ const CONTROL_PLANE_LIST_PROBES = [
   ['integration-list-pipelines', '/api/integration/pipelines'],
   ['integration-list-runs', '/api/integration/runs'],
   ['integration-list-dead-letters', '/api/integration/dead-letters'],
+]
+const REQUIRED_STAGING_DESCRIPTORS = [
+  'plm_raw_items',
+  'standard_materials',
+  'bom_cleanse',
+  'integration_exceptions',
+  'integration_run_log',
 ]
 const TOKEN_PATTERN = /([A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{16,}|Bearer\s+[A-Za-z0-9._-]{16,})/g
 
@@ -267,7 +279,7 @@ function assertStatusRoutes(statusBody) {
     })
   }
 
-  return { adapters, routesChecked: REQUIRED_ROUTES.length }
+  return { adapters, adaptersChecked: REQUIRED_ADAPTERS.length, routesChecked: REQUIRED_ROUTES.length }
 }
 
 function assertStagingDescriptors(body) {
@@ -276,12 +288,12 @@ function assertStagingDescriptors(body) {
     throw new K3WisePostdeploySmokeError('staging descriptors response must be an array')
   }
   const ids = data.map((descriptor) => descriptor && descriptor.id).filter(Boolean)
-  for (const id of ['standard_materials', 'bom_cleanse']) {
+  for (const id of REQUIRED_STAGING_DESCRIPTORS) {
     if (!ids.includes(id)) {
       throw new K3WisePostdeploySmokeError(`missing staging descriptor ${id}`, { ids })
     }
   }
-  return { descriptors: ids }
+  return { descriptors: ids, descriptorsChecked: REQUIRED_STAGING_DESCRIPTORS.length }
 }
 
 function assertListResponse(body, probeId) {

--- a/scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
@@ -9,6 +9,19 @@ import { fileURLToPath } from 'node:url'
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
 const scriptPath = path.join(repoRoot, 'scripts', 'ops', 'integration-k3wise-postdeploy-smoke.mjs')
+const DEFAULT_ADAPTERS = [
+  'http',
+  'plm:yuantus-wrapper',
+  'erp:k3-wise-webapi',
+  'erp:k3-wise-sqlserver',
+]
+const DEFAULT_STAGING_DESCRIPTORS = [
+  { id: 'plm_raw_items', name: 'PLM Raw Items' },
+  { id: 'standard_materials', name: 'Standard Materials' },
+  { id: 'bom_cleanse', name: 'BOM Cleanse' },
+  { id: 'integration_exceptions', name: 'Integration Exceptions' },
+  { id: 'integration_run_log', name: 'Integration Run Log' },
+]
 
 function makeTmpDir() {
   return mkdtempSync(path.join(tmpdir(), 'integration-k3wise-postdeploy-smoke-'))
@@ -118,7 +131,7 @@ function createFakeServer(options = {}) {
       sendJson(res, 200, {
         ok: true,
         data: {
-          adapters: ['http', 'plm:yuantus-wrapper', 'erp:k3-wise-webapi', 'erp:k3-wise-sqlserver'],
+          adapters: options.integrationAdapters || DEFAULT_ADAPTERS,
           routes: [
             ['GET', '/api/integration/status'],
             ['GET', '/api/integration/external-systems'],
@@ -166,10 +179,7 @@ function createFakeServer(options = {}) {
       }
       sendJson(res, 200, {
         ok: true,
-        data: [
-          { id: 'standard_materials', name: 'Standard Materials' },
-          { id: 'bom_cleanse', name: 'BOM Cleanse' },
-        ],
+        data: options.stagingDescriptors || DEFAULT_STAGING_DESCRIPTORS,
       })
       return
     }
@@ -393,6 +403,56 @@ test('authenticated postdeploy smoke fails when a read-only control-plane endpoi
     const pipelinesCheck = evidence.checks.find((check) => check.id === 'integration-list-pipelines')
     assert.equal(pipelinesCheck.status, 'fail')
     assert.match(pipelinesCheck.error, /\/api\/integration\/pipelines\?tenantId=tenant-smoke&limit=1 returned HTTP 500/)
+  } finally {
+    await fake.close()
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('authenticated postdeploy smoke fails when status omits a required source adapter', async () => {
+  const fake = createFakeServer({
+    integrationAdapters: ['http', 'erp:k3-wise-webapi', 'erp:k3-wise-sqlserver'],
+  })
+  const baseUrl = await fake.listen()
+  const outDir = makeTmpDir()
+  try {
+    const result = await runScript([
+      '--base-url', baseUrl,
+      '--auth-token', 'test.jwt.token',
+      '--require-auth',
+      '--out-dir', outDir,
+    ])
+
+    assert.equal(result.status, 1)
+    const evidence = JSON.parse(readFileSync(path.join(outDir, 'integration-k3wise-postdeploy-smoke.json'), 'utf8'))
+    const routeCheck = evidence.checks.find((check) => check.id === 'integration-route-contract')
+    assert.equal(routeCheck.status, 'fail')
+    assert.match(routeCheck.error, /missing required adapters or routes/)
+  } finally {
+    await fake.close()
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('authenticated postdeploy smoke fails when a required staging descriptor is missing', async () => {
+  const fake = createFakeServer({
+    stagingDescriptors: DEFAULT_STAGING_DESCRIPTORS.filter((descriptor) => descriptor.id !== 'integration_exceptions'),
+  })
+  const baseUrl = await fake.listen()
+  const outDir = makeTmpDir()
+  try {
+    const result = await runScript([
+      '--base-url', baseUrl,
+      '--auth-token', 'test.jwt.token',
+      '--require-auth',
+      '--out-dir', outDir,
+    ])
+
+    assert.equal(result.status, 1)
+    const evidence = JSON.parse(readFileSync(path.join(outDir, 'integration-k3wise-postdeploy-smoke.json'), 'utf8'))
+    const stagingCheck = evidence.checks.find((check) => check.id === 'staging-descriptor-contract')
+    assert.equal(stagingCheck.status, 'fail')
+    assert.match(stagingCheck.error, /missing staging descriptor integration_exceptions/)
   } finally {
     await fake.close()
     rmSync(outDir, { recursive: true, force: true })


### PR DESCRIPTION
## Summary
- require the postdeploy authenticated smoke to see the full PLM/source/K3 adapter set: http, plm:yuantus-wrapper, K3 WebAPI, and K3 SQL Server
- require all five integration staging descriptors instead of only materials and BOM
- add regression coverage for missing PLM adapter and missing exception staging descriptor
- add design and verification docs for the tightened readiness contract

## Verification
- node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
- node --test scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
- node --test scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs
- git diff --check