### PR TITLE
feat(dingtalk): add public form bind recovery CTA

### DIFF
--- a/apps/web/src/views/PublicMultitableFormView.vue
+++ b/apps/web/src/views/PublicMultitableFormView.vue
@@ -7,11 +7,21 @@
         <p v-if="subtitle" class="public-multitable-form__subtitle">{{ subtitle }}</p>
       </header>
 
-      <div v-if="loading || redirectingToDingTalk" class="public-multitable-form__state">
-        {{ redirectingToDingTalk ? redirectingMessage : 'Loading form…' }}
+      <div v-if="loading || redirectingToDingTalk || bindingToDingTalk" class="public-multitable-form__state">
+        {{ redirectingToDingTalk || bindingToDingTalk ? redirectingMessage : 'Loading form…' }}
       </div>
       <div v-else-if="loadError" class="public-multitable-form__state public-multitable-form__state--error">
-        {{ loadError }}
+        <p class="public-multitable-form__state-message">{{ loadError }}</p>
+        <button
+          v-if="canLaunchDingTalkBinding"
+          type="button"
+          class="public-multitable-form__button public-multitable-form__button--error"
+          data-dingtalk-bind
+          :disabled="bindingToDingTalk"
+          @click="launchDingTalkBinding"
+        >
+          Bind DingTalk and return to this form
+        </button>
       </div>
       <div v-else-if="submitted && submissionResult" class="public-multitable-form__state public-multitable-form__state--success">
         <h2>Submission received</h2>
@@ -65,6 +75,8 @@ const submitted = ref(false)
 const submissionResult = ref<FormSubmitResult | null>(null)
 const formKey = ref(0)
 const redirectingToDingTalk = ref(false)
+const bindingToDingTalk = ref(false)
+const loadErrorCode = ref('')
 
 const title = computed(() => context.value?.view?.name || context.value?.sheet?.name || 'Public multitable form')
 const subtitle = computed(() => {
@@ -78,16 +90,21 @@ const submissionMessage = computed(() => {
     ? 'Your response has been updated successfully.'
     : 'Your response has been submitted successfully.'
 })
-const redirectingMessage = computed(() => 'Redirecting to DingTalk sign-in…')
+const redirectingMessage = computed(() => (
+  bindingToDingTalk.value ? 'Redirecting to DingTalk binding…' : 'Redirecting to DingTalk sign-in…'
+))
+const canLaunchDingTalkBinding = computed(() => loadErrorCode.value === 'DINGTALK_BIND_REQUIRED')
 
 async function loadForm(): Promise<void> {
   loading.value = true
   loadError.value = null
+  loadErrorCode.value = ''
   submitError.value = null
   fieldErrors.value = null
   submitted.value = false
   submissionResult.value = null
   redirectingToDingTalk.value = false
+  bindingToDingTalk.value = false
   try {
     const publicToken = props.publicToken?.trim()
     if (!publicToken) {
@@ -107,9 +124,10 @@ async function loadForm(): Promise<void> {
       if (launched) return
     }
     context.value = null
+    loadErrorCode.value = readErrorCode(error)
     loadError.value = readPublicFormErrorMessage(error, 'Failed to load public form')
   } finally {
-    if (!redirectingToDingTalk.value) {
+    if (!redirectingToDingTalk.value && !bindingToDingTalk.value) {
       loading.value = false
     }
   }
@@ -193,6 +211,7 @@ function currentPublicFormRedirect(): string {
 async function launchDingTalkSignIn(): Promise<boolean> {
   redirectingToDingTalk.value = true
   loadError.value = null
+  loadErrorCode.value = ''
   try {
     const response = await apiFetch(
       `/api/auth/dingtalk/launch?redirect=${encodeURIComponent(currentPublicFormRedirect())}`,
@@ -214,6 +233,37 @@ async function launchDingTalkSignIn(): Promise<boolean> {
   } catch (error) {
     redirectingToDingTalk.value = false
     loadError.value = readErrorMessage(error, 'Failed to start DingTalk sign-in')
+    loadErrorCode.value = ''
+    return false
+  }
+}
+
+async function launchDingTalkBinding(): Promise<boolean> {
+  bindingToDingTalk.value = true
+  loadError.value = null
+  loadErrorCode.value = ''
+  try {
+    const response = await apiFetch(
+      `/api/auth/dingtalk/launch?intent=bind&redirect=${encodeURIComponent(currentPublicFormRedirect())}`,
+      { suppressUnauthorizedRedirect: true },
+    )
+    const payload = await response.json().catch(() => null)
+    if (!response.ok || !payload?.success || typeof payload?.data?.url !== 'string' || payload.data.url.trim().length === 0) {
+      throw new Error(readErrorMessage(payload, 'Failed to start DingTalk binding'))
+    }
+    if (typeof window !== 'undefined' && typeof window.location?.assign === 'function') {
+      window.location.assign(payload.data.url)
+      return true
+    }
+    if (typeof window !== 'undefined') {
+      window.location.href = payload.data.url
+      return true
+    }
+    return false
+  } catch (error) {
+    bindingToDingTalk.value = false
+    loadError.value = readErrorMessage(error, 'Failed to start DingTalk binding')
+    loadErrorCode.value = 'DINGTALK_BIND_REQUIRED'
     return false
   }
 }
@@ -284,7 +334,13 @@ watch(
   color: #334155;
 }
 
+.public-multitable-form__state-message {
+  margin: 0;
+}
+
 .public-multitable-form__state--error {
+  display: grid;
+  gap: 12px;
   background: #fff1f2;
   color: #be123c;
 }
@@ -318,5 +374,18 @@ watch(
 
 .public-multitable-form__button:hover {
   background: #166534;
+}
+
+.public-multitable-form__button--error {
+  background: #be123c;
+}
+
+.public-multitable-form__button--error:hover {
+  background: #9f1239;
+}
+
+.public-multitable-form__button:disabled {
+  cursor: not-allowed;
+  opacity: 0.72;
 }
 </style>

--- a/apps/web/tests/public-multitable-form.spec.ts
+++ b/apps/web/tests/public-multitable-form.spec.ts
@@ -171,6 +171,51 @@ describe('PublicMultitableFormView', () => {
     expect(container.textContent).toContain('Redirecting to DingTalk sign-in…')
   })
 
+  it('offers DingTalk binding when a signed-in user is not bound', async () => {
+    loadFormContextSpy.mockRejectedValue(Object.assign(new Error('DingTalk binding is required for this form'), {
+      code: 'DINGTALK_BIND_REQUIRED',
+    }))
+    apiFetchSpy.mockResolvedValue(new Response(JSON.stringify({
+      success: true,
+      data: { url: 'https://login.dingtalk.com/oauth2/auth?bind=1' },
+    }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }))
+
+    const { default: PublicMultitableFormView } = await import('../src/views/PublicMultitableFormView.vue')
+
+    container = document.createElement('div')
+    document.body.appendChild(container)
+
+    const Root = defineComponent({
+      render() {
+        return h(PublicMultitableFormView, {
+          sheetId: 'sheet_orders',
+          viewId: 'view_form',
+          publicToken: 'pub_123',
+        })
+      },
+    })
+
+    app = createApp(Root)
+    app.mount(container)
+    await flushUi()
+
+    expect(container.textContent).toContain('This form only accepts users with a bound DingTalk account.')
+    const bindButton = container.querySelector<HTMLButtonElement>('[data-dingtalk-bind]')
+    expect(bindButton?.textContent).toContain('Bind DingTalk and return to this form')
+
+    bindButton?.click()
+    await flushUi()
+
+    expect(apiFetchSpy).toHaveBeenCalledWith(
+      expect.stringContaining('/api/auth/dingtalk/launch?intent=bind&redirect='),
+      expect.objectContaining({ suppressUnauthorizedRedirect: true }),
+    )
+    expect(container.textContent).toContain('Redirecting to DingTalk binding…')
+  })
+
   it('shows an allowlist message when the DingTalk user is not selected for the form', async () => {
     loadFormContextSpy.mockRejectedValue(Object.assign(new Error('Only selected system users or member groups can access this form'), {
       code: 'DINGTALK_FORM_NOT_ALLOWED',

--- a/docs/development/dingtalk-public-form-bind-cta-design-20260429.md
+++ b/docs/development/dingtalk-public-form-bind-cta-design-20260429.md
@@ -1,0 +1,49 @@
+# DingTalk Public Form Bind CTA Design - 2026-04-29
+
+## Goal
+
+When a signed-in local user opens a DingTalk-protected public multitable form but
+has not bound a DingTalk identity, the form should provide a direct recovery
+action instead of a dead-end error message.
+
+Before this slice, `DINGTALK_BIND_REQUIRED` displayed only static copy. Users
+had to know to leave the form, bind DingTalk elsewhere, and then return to the
+same public form link.
+
+## Scope
+
+Updated frontend view:
+
+- `apps/web/src/views/PublicMultitableFormView.vue`
+
+Updated frontend test:
+
+- `apps/web/tests/public-multitable-form.spec.ts`
+
+## Behavior
+
+`DINGTALK_AUTH_REQUIRED` remains unchanged:
+
+- anonymous users are redirected through `GET /api/auth/dingtalk/launch`;
+- the current public form URL is passed as `redirect`.
+
+`DINGTALK_BIND_REQUIRED` now renders:
+
+- the existing error text: `This form only accepts users with a bound DingTalk account.`;
+- a CTA: `Bind DingTalk and return to this form`;
+- a launch call to `GET /api/auth/dingtalk/launch?intent=bind&redirect=<current-public-form-url>`.
+
+The bind launch uses `suppressUnauthorizedRedirect: true` so the public form
+view owns the error state instead of being silently redirected by the generic API
+client. If launch fails, the user stays on the public form and the bind CTA is
+shown again with a launch failure message.
+
+## Non-goals
+
+- This does not change backend access rules for `public`, `dingtalk`, or
+  `dingtalk_granted` modes.
+- This does not change password-change bypass behavior; current main already
+  allows public-token form context and submit requests to continue through the
+  DingTalk public form path.
+- This does not change selected-user or member-group allowlist evaluation.
+- This does not store or expose any DingTalk token, webhook, or signing secret.

--- a/docs/development/dingtalk-public-form-bind-cta-verification-20260429.md
+++ b/docs/development/dingtalk-public-form-bind-cta-verification-20260429.md
@@ -1,0 +1,53 @@
+# DingTalk Public Form Bind CTA Verification - 2026-04-29
+
+## Scope
+
+This document verifies the frontend recovery path for `DINGTALK_BIND_REQUIRED`
+on public multitable forms.
+
+Changed files:
+
+- `apps/web/src/views/PublicMultitableFormView.vue`
+- `apps/web/tests/public-multitable-form.spec.ts`
+- `docs/development/dingtalk-public-form-bind-cta-design-20260429.md`
+- `docs/development/dingtalk-public-form-bind-cta-verification-20260429.md`
+
+## Commands
+
+```bash
+cd apps/web
+../../node_modules/.bin/vitest run tests/public-multitable-form.spec.ts --watch=false
+cd ../..
+git diff --check
+git diff -- apps/web/src/views/PublicMultitableFormView.vue apps/web/tests/public-multitable-form.spec.ts docs/development/dingtalk-public-form-bind-cta-design-20260429.md docs/development/dingtalk-public-form-bind-cta-verification-20260429.md \
+  | rg -v "rg -n" \
+  | rg -n "(access_token=[A-Za-z0-9]|SEC[0-9a-fA-F]{8,}|Authorization:|Bearer [A-Za-z0-9._-]{20,}|https://oapi\\.dingtalk\\.com/robot/send|JWT_SECRET|DINGTALK_APP_SECRET|publicToken=[A-Za-z0-9._~+/=-]{12,})" || true
+```
+
+## Results
+
+- Public multitable form frontend spec: passed, `4` tests.
+- `git diff --check`: passed.
+- Diff secret scan: no matches for DingTalk webhook, signing secret, JWT,
+  bearer token, public-token, or app-secret patterns.
+
+## Regression Coverage
+
+The frontend spec now covers:
+
+- anonymous public form context load and submit with public token;
+- anonymous DingTalk-protected form launching DingTalk sign-in;
+- signed-in but unbound DingTalk user seeing a bind CTA;
+- bind CTA calling `GET /api/auth/dingtalk/launch?intent=bind&redirect=...`;
+- bind redirect state showing `Redirecting to DingTalk binding...`;
+- selected-user/member-group rejection still showing the allowlist error copy.
+
+## Manual Acceptance
+
+For a DingTalk-protected public form:
+
+- Anonymous user: still redirects to DingTalk sign-in.
+- Signed-in local user without DingTalk binding: sees the bind CTA and returns
+  to the same public form URL after successful DingTalk binding.
+- Bound user outside allowlist: still sees the selected-user/member-group
+  rejection copy.


### PR DESCRIPTION
## Summary
- Add a public-form recovery CTA for signed-in users blocked by `DINGTALK_BIND_REQUIRED`.
- Launch DingTalk OAuth with `intent=bind` and preserve the current public form URL as redirect.
- Add focused frontend coverage plus design and verification markdown.

## Verification
- `/Users/chouhua/Downloads/Github/metasheet2/apps/web/node_modules/.bin/vitest run tests/public-multitable-form.spec.ts --watch=false` from `apps/web`: passed, 4 tests.
- `git diff --check`: passed.
- Diff secret scan for DingTalk webhook/signing secret/JWT/app-secret/public-token patterns: no matches.

## Notes
- The jsdom navigation warning appears for both existing sign-in redirect and new binding redirect; it is not a test failure.
- No DingTalk webhook URLs, signing secrets, or JWT values are included in docs or PR body.