### PR TITLE
ci(dingtalk): widen stability webhook secret fallback

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -37,7 +37,7 @@ This folder contains GitHub Actions that validate Phase 5 SLOs against a Prometh
 
 - `dingtalk-oauth-stability-recording-lite.yml`
   - Triggers every 2 hours (`15 */2 * * *`) and via manual dispatch.
-  - Restores the deploy SSH key, reapplies the on-prem Alertmanager webhook config from `SLACK_WEBHOOK_URL` when available, runs `scripts/ops/dingtalk-oauth-stability-check.sh` against `142.171.239.56`, and uploads JSON/log/summary artifacts.
+  - Restores the deploy SSH key, reapplies the on-prem Alertmanager webhook config from `ALERTMANAGER_WEBHOOK_URL`, `ALERT_WEBHOOK_URL`, `SLACK_WEBHOOK_URL`, or `ATTENDANCE_ALERT_SLACK_WEBHOOK_URL` when available, runs `scripts/ops/dingtalk-oauth-stability-check.sh` against `142.171.239.56`, and uploads JSON/log/summary artifacts.
   - Does not run the Slack drill; it is recording-only and fails the workflow when `healthy != true`.
   - Like other scheduled/manual workflows, it only becomes live after the workflow file exists on the default branch.
 
@@ -45,7 +45,7 @@ This folder contains GitHub Actions that validate Phase 5 SLOs against a Prometh
 
  - `METRICS_URL`: e.g., `https://staging.example.com/metrics/prom`.
  - `METRICS_AUTH_HEADER` (optional): e.g., `Authorization: Bearer <token>`.
- - `SLACK_WEBHOOK_URL` (optional for nightly failures / success enrichment; also used to self-heal on-prem Alertmanager webhook config before DingTalk OAuth stability checks).
+ - `ALERTMANAGER_WEBHOOK_URL`, `ALERT_WEBHOOK_URL`, `SLACK_WEBHOOK_URL`, or `ATTENDANCE_ALERT_SLACK_WEBHOOK_URL` (one optional webhook secret is used to self-heal on-prem Alertmanager config before DingTalk OAuth stability checks; `SLACK_WEBHOOK_URL` also powers older nightly notification workflows).
  - `SLACK_CHANNEL` (optional): e.g., `alerts`.
  - `GRAFANA_API_TOKEN` (ops deploy only, for dashboard upload).
  - `REDIS_URL` (optional: enables Redis-backed cache validation).

--- a/.github/workflows/dingtalk-oauth-stability-recording-lite.yml
+++ b/.github/workflows/dingtalk-oauth-stability-recording-lite.yml
@@ -29,16 +29,19 @@ jobs:
           chmod 600 ~/.ssh/deploy_key
 
       - name: Reapply Alertmanager webhook config
+        id: webhook_self_heal
         env:
-          ALERTMANAGER_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          ALERTMANAGER_WEBHOOK_URL: ${{ secrets.ALERTMANAGER_WEBHOOK_URL || secrets.ALERT_WEBHOOK_URL || secrets.SLACK_WEBHOOK_URL || secrets.ATTENDANCE_ALERT_SLACK_WEBHOOK_URL }}
           DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
           DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
         run: |
           set -euo pipefail
           if [[ -z "${ALERTMANAGER_WEBHOOK_URL:-}" ]]; then
-            echo "::notice::SLACK_WEBHOOK_URL is not set; Alertmanager webhook self-heal skipped."
+            echo "webhook_secret_available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No Alertmanager webhook secret is set; checked ALERTMANAGER_WEBHOOK_URL, ALERT_WEBHOOK_URL, SLACK_WEBHOOK_URL, and ATTENDANCE_ALERT_SLACK_WEBHOOK_URL. Alertmanager webhook self-heal skipped."
             exit 0
           fi
+          echo "webhook_secret_available=true" >> "$GITHUB_OUTPUT"
 
           SSH_USER_HOST="${DEPLOY_USER}@${DEPLOY_HOST}" \
           SSH_KEY="${HOME}/.ssh/deploy_key" \
@@ -82,6 +85,7 @@ jobs:
         env:
           STABILITY_RC: ${{ steps.stability.outputs.stability_rc }}
           HEALTHY: ${{ steps.stability.outputs.healthy }}
+          WEBHOOK_SECRET_AVAILABLE: ${{ steps.webhook_self_heal.outputs.webhook_secret_available || 'false' }}
           JSON_PATH: ${{ steps.stability.outputs.json_path }}
           LOG_PATH: ${{ steps.stability.outputs.log_path }}
         run: |

--- a/docs/development/dingtalk-oauth-stability-webhook-secret-fallback-design-20260429.md
+++ b/docs/development/dingtalk-oauth-stability-webhook-secret-fallback-design-20260429.md
@@ -1,0 +1,71 @@
+# DingTalk OAuth Stability Webhook Secret Fallback Design
+
+## Context
+
+The scheduled `DingTalk OAuth Stability Recording (Lite)` run
+`25109850840` failed with:
+
+- `STABILITY_RC=0`
+- `HEALTHY=false`
+- failure reason: `Alertmanager webhook is not configured`
+
+The uploaded evidence showed that backend health, Alertmanager notify errors,
+and the root disk gate were not the blocking issue. The workflow attempted the
+webhook self-heal step, but `secrets.SLACK_WEBHOOK_URL` was empty, so the step
+skipped and the remote Alertmanager env file remained absent.
+
+The repository uses more than one webhook naming convention:
+
+- `.env.example` documents `ALERT_WEBHOOK_URL`.
+- older Phase 5 workflows use `SLACK_WEBHOOK_URL`.
+- attendance notification workflows use `ATTENDANCE_ALERT_SLACK_WEBHOOK_URL`.
+- the on-prem helper writes `ALERTMANAGER_WEBHOOK_URL` into the remote
+  Alertmanager env file.
+
+Requiring only `SLACK_WEBHOOK_URL` makes the self-heal path brittle when the
+repository has a valid webhook stored under a more specific or newer name.
+
+## Change
+
+`.github/workflows/dingtalk-oauth-stability-recording-lite.yml` now resolves the
+webhook secret with this order:
+
+1. `secrets.ALERTMANAGER_WEBHOOK_URL`
+2. `secrets.ALERT_WEBHOOK_URL`
+3. `secrets.SLACK_WEBHOOK_URL`
+4. `secrets.ATTENDANCE_ALERT_SLACK_WEBHOOK_URL`
+
+The selected value is still passed only through the existing
+`ALERTMANAGER_WEBHOOK_URL` environment variable to
+`scripts/ops/set-dingtalk-onprem-alertmanager-webhook-config.sh set`.
+
+If no supported secret is set, the workflow still emits a notice and continues
+to the remote stability check. The final `healthy=false` gate is unchanged, so
+missing webhook configuration remains visible as a failed stability run.
+
+The workflow also records whether a webhook secret was available and passes that
+fact into `scripts/ops/github-dingtalk-oauth-stability-summary.py`. When the
+remote report says the Alertmanager webhook is not configured and no supported
+GitHub secret was available for self-heal, the summary artifact now names that
+missing-secret condition directly.
+
+## Safety
+
+- No webhook value is printed to logs.
+- The helper still validates the URL scheme and host.
+- The remote file is still written with `install -m 600`.
+- The workflow does not weaken the final health gate.
+- The summary only records whether a supported secret was present; it never
+  prints the secret value.
+- This change only broadens secret discovery; it does not create, rotate, or
+  store any secret.
+
+## Expected Outcome
+
+If the repo already has a valid webhook under one of the supported names, the
+next scheduled/manual stability run should self-heal the remote Alertmanager
+env file before checking health.
+
+If none of the supported secrets exists, the run will still fail with the same
+clear operator action in the summary artifact: configure one supported webhook
+secret or manually restore the on-prem Alertmanager env file.

--- a/docs/development/dingtalk-oauth-stability-webhook-secret-fallback-verification-20260429.md
+++ b/docs/development/dingtalk-oauth-stability-webhook-secret-fallback-verification-20260429.md
@@ -1,0 +1,102 @@
+# DingTalk OAuth Stability Webhook Secret Fallback Verification
+
+## Environment
+
+Executed from isolated worktree:
+
+```bash
+/tmp/ms2-dingtalk-oauth-stability-20260429
+```
+
+Base branch:
+
+```bash
+origin/main c3695f0e6
+```
+
+## Evidence From Failed Run
+
+Downloaded artifact from GitHub run `25109850840`:
+
+- workflow: `DingTalk OAuth Stability Recording (Lite)`
+- event: `schedule`
+- command result: `STABILITY_RC=0`
+- health result: `HEALTHY=false`
+- summary failure reason: `Alertmanager webhook is not configured`
+- backend health: `status=ok plugins=13 ok=True`
+- Alertmanager notify errors: `0`
+- root storage: `94% / 95% max`
+
+Workflow log for the self-heal step showed:
+
+- `ALERTMANAGER_WEBHOOK_URL` was empty.
+- the workflow emitted the skip notice.
+- no remote webhook config was reapplied before the health check.
+
+## Local Checks
+
+```bash
+bash -n scripts/ops/set-dingtalk-onprem-alertmanager-webhook-config.sh
+bash -n scripts/ops/dingtalk-oauth-stability-check.sh
+python3 -m py_compile scripts/ops/github-dingtalk-oauth-stability-summary.py
+node --test scripts/ops/dingtalk-oauth-stability-workflow-contract.test.mjs
+node --test scripts/ops/github-dingtalk-oauth-stability-summary.test.mjs
+ruby -e 'require "yaml"; YAML.load_file(".github/workflows/dingtalk-oauth-stability-recording-lite.yml"); puts "workflow yaml ok"'
+git diff --check
+```
+
+## Expected Assertions
+
+- The workflow keeps the deploy SSH key setup.
+- The self-heal step runs before the remote stability check.
+- The self-heal step resolves the webhook secret from:
+  - `ALERTMANAGER_WEBHOOK_URL`
+  - `ALERT_WEBHOOK_URL`
+  - `SLACK_WEBHOOK_URL`
+  - `ATTENDANCE_ALERT_SLACK_WEBHOOK_URL`
+- The skip notice names every supported secret.
+- The workflow passes `WEBHOOK_SECRET_AVAILABLE` to the summary renderer.
+- The summary renderer adds a missing-secret failure reason and next action
+  when the remote webhook is unconfigured and self-heal had no supported secret.
+- The final `healthy=false` hard gate remains present.
+- Shell syntax, Python syntax, workflow YAML parsing, and whitespace checks pass.
+
+## Observed Local Result
+
+- `bash -n scripts/ops/set-dingtalk-onprem-alertmanager-webhook-config.sh` passed.
+- `bash -n scripts/ops/dingtalk-oauth-stability-check.sh` passed.
+- `python3 -m py_compile scripts/ops/github-dingtalk-oauth-stability-summary.py` passed.
+- `node --test scripts/ops/dingtalk-oauth-stability-workflow-contract.test.mjs` passed: 1/1.
+- `node --test scripts/ops/github-dingtalk-oauth-stability-summary.test.mjs` passed: 1/1.
+- Workflow YAML parse passed.
+- `git diff --check` passed.
+
+## Current GitHub Secret State
+
+`gh secret list --repo zensgit/metasheet2 --json name,updatedAt` showed no
+supported webhook secret name at verification time. The available repo secrets
+were deploy/admin related only:
+
+- `ATTENDANCE_ADMIN_GH_TOKEN`
+- `ATTENDANCE_ADMIN_JWT`
+- `DEPLOY_COMPOSE_FILE`
+- `DEPLOY_HOST`
+- `DEPLOY_PATH`
+- `DEPLOY_SSH_KEY`
+- `DEPLOY_SSH_KEY_B64`
+- `DEPLOY_USER`
+
+Therefore this code change improves discovery and operator diagnostics, but the
+scheduled stability workflow still needs one supported webhook secret to be
+configured before it can self-heal the remote Alertmanager file.
+
+## Live Follow-Up
+
+After merge, run `DingTalk OAuth Stability Recording (Lite)` manually or wait
+for the next scheduled run. A PASS requires both:
+
+- one supported webhook secret configured in GitHub;
+- the remote stability report returning `healthy=true`.
+
+This PR cannot prove secret presence locally because GitHub secret values are
+not readable by design.

--- a/docs/development/dingtalk-oauth-stability-webhook-selfheal-design-20260429.md
+++ b/docs/development/dingtalk-oauth-stability-webhook-selfheal-design-20260429.md
@@ -23,9 +23,9 @@ Add a pre-check self-heal step to
 `.github/workflows/dingtalk-oauth-stability-recording-lite.yml`:
 
 1. Restore the deploy SSH key as before.
-2. If `SLACK_WEBHOOK_URL` is available, call
+2. If any supported webhook secret is available, call
    `scripts/ops/set-dingtalk-onprem-alertmanager-webhook-config.sh set` with:
-   - `ALERTMANAGER_WEBHOOK_URL=${{ secrets.SLACK_WEBHOOK_URL }}`
+   - `ALERTMANAGER_WEBHOOK_URL=${{ secrets.ALERTMANAGER_WEBHOOK_URL || secrets.ALERT_WEBHOOK_URL || secrets.SLACK_WEBHOOK_URL || secrets.ATTENDANCE_ALERT_SLACK_WEBHOOK_URL }}`
    - `SSH_USER_HOST=${DEPLOY_USER}@${DEPLOY_HOST}`
    - `SSH_KEY=${HOME}/.ssh/deploy_key`
 3. If the secret is absent, emit a GitHub notice and continue to the existing
@@ -39,8 +39,9 @@ missing or invalid.
 
 ## Safety
 
-- The webhook URL comes only from the existing GitHub secret
-  `SLACK_WEBHOOK_URL`.
+- The webhook URL comes only from GitHub secrets. The workflow checks
+  `ALERTMANAGER_WEBHOOK_URL`, `ALERT_WEBHOOK_URL`, `SLACK_WEBHOOK_URL`, then
+  `ATTENDANCE_ALERT_SLACK_WEBHOOK_URL`.
 - The helper script validates that the value is an HTTP/HTTPS URL.
 - The helper writes the remote env file via base64 and `install -m 600`.
 - The workflow does not print the webhook URL.
@@ -52,4 +53,4 @@ missing or invalid.
 - Does not create or rotate Slack webhooks.
 - Does not commit any webhook value.
 - Does not change the DingTalk OAuth health criteria.
-- Does not make missing `SLACK_WEBHOOK_URL` appear healthy.
+- Does not make missing webhook secrets appear healthy.

--- a/docs/development/dingtalk-oauth-stability-webhook-selfheal-verification-20260429.md
+++ b/docs/development/dingtalk-oauth-stability-webhook-selfheal-verification-20260429.md
@@ -17,7 +17,7 @@ git diff --check
 - Stability summary Python compiles.
 - Workflow contract test confirms:
   - the workflow still prepares the deploy SSH key;
-  - the new self-heal step reads `SLACK_WEBHOOK_URL`;
+  - the new self-heal step reads the supported webhook secret fallback chain;
   - the self-heal step uses the deploy host/user and deploy key;
   - the self-heal step runs before the remote stability check;
   - the final `healthy=false` gate remains present.
@@ -38,7 +38,9 @@ Run from `/tmp/ms2-dingtalk-stability-followup-20260429` on 2026-04-29:
 ## Live Follow-Up
 
 After merge, trigger `DingTalk OAuth Stability Recording (Lite)` or wait for the
-next scheduled run. If `SLACK_WEBHOOK_URL` is configured correctly, the workflow
-should reapply the on-prem Alertmanager env file before checking health. If the
-secret is absent, invalid, or revoked, the run should still fail with the
-existing `Alertmanager webhook is not configured` or host-drift reason.
+next scheduled run. If one of `ALERTMANAGER_WEBHOOK_URL`,
+`ALERT_WEBHOOK_URL`, `SLACK_WEBHOOK_URL`, or
+`ATTENDANCE_ALERT_SLACK_WEBHOOK_URL` is configured correctly, the workflow should
+reapply the on-prem Alertmanager env file before checking health. If all
+supported secrets are absent, invalid, or revoked, the run should still fail
+with the existing `Alertmanager webhook is not configured` or host-drift reason.

--- a/scripts/ops/dingtalk-oauth-stability-workflow-contract.test.mjs
+++ b/scripts/ops/dingtalk-oauth-stability-workflow-contract.test.mjs
@@ -21,10 +21,17 @@ test('DingTalk OAuth stability workflow reapplies Alertmanager webhook before ch
   assertContains(raw, 'cron:', 'workflow schedule')
   assertContains(raw, '- name: Prepare SSH key', 'ssh setup')
   assertContains(raw, '- name: Reapply Alertmanager webhook config', 'webhook self-heal step')
-  assertContains(raw, 'ALERTMANAGER_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}', 'webhook self-heal step')
+  assertContains(raw, 'id: webhook_self_heal', 'webhook self-heal step')
+  assertContains(
+    raw,
+    'ALERTMANAGER_WEBHOOK_URL: ${{ secrets.ALERTMANAGER_WEBHOOK_URL || secrets.ALERT_WEBHOOK_URL || secrets.SLACK_WEBHOOK_URL || secrets.ATTENDANCE_ALERT_SLACK_WEBHOOK_URL }}',
+    'webhook self-heal step',
+  )
   assertContains(raw, 'DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}', 'webhook self-heal step')
   assertContains(raw, 'DEPLOY_USER: ${{ secrets.DEPLOY_USER }}', 'webhook self-heal step')
-  assertContains(raw, 'SLACK_WEBHOOK_URL is not set; Alertmanager webhook self-heal skipped.', 'webhook self-heal skip notice')
+  assertContains(raw, 'echo "webhook_secret_available=false" >> "$GITHUB_OUTPUT"', 'webhook self-heal output')
+  assertContains(raw, 'echo "webhook_secret_available=true" >> "$GITHUB_OUTPUT"', 'webhook self-heal output')
+  assertContains(raw, 'No Alertmanager webhook secret is set; checked ALERTMANAGER_WEBHOOK_URL, ALERT_WEBHOOK_URL, SLACK_WEBHOOK_URL, and ATTENDANCE_ALERT_SLACK_WEBHOOK_URL. Alertmanager webhook self-heal skipped.', 'webhook self-heal skip notice')
   assertContains(raw, 'SSH_USER_HOST="${DEPLOY_USER}@${DEPLOY_HOST}"', 'webhook self-heal remote target')
   assertContains(raw, 'SSH_KEY="${HOME}/.ssh/deploy_key"', 'webhook self-heal remote key')
   assertContains(raw, 'scripts/ops/set-dingtalk-onprem-alertmanager-webhook-config.sh set', 'webhook self-heal command')
@@ -34,5 +41,6 @@ test('DingTalk OAuth stability workflow reapplies Alertmanager webhook before ch
     'webhook self-heal must run before remote stability check',
   )
   assertContains(raw, '- name: Fail if stability check is unhealthy', 'final hard gate')
+  assertContains(raw, "WEBHOOK_SECRET_AVAILABLE: ${{ steps.webhook_self_heal.outputs.webhook_secret_available || 'false' }}", 'summary env')
   assertContains(raw, 'stability check completed but reported healthy=false', 'final hard gate')
 })

--- a/scripts/ops/github-dingtalk-oauth-stability-summary.py
+++ b/scripts/ops/github-dingtalk-oauth-stability-summary.py
@@ -29,6 +29,7 @@ def infer_failure_reasons(
     payload: Optional[dict[str, Any]],
     stability_rc: str,
     healthy: str,
+    webhook_secret_available: str,
 ) -> list[str]:
     reasons: list[str] = []
     if stability_rc != '0':
@@ -48,6 +49,10 @@ def infer_failure_reasons(
             )
         if webhook.get('configured') is not True:
             reasons.append('Alertmanager webhook is not configured')
+            if webhook_secret_available != 'true':
+                reasons.append(
+                    'No supported GitHub webhook secret was available for Alertmanager self-heal'
+                )
         elif webhook.get('host') != 'hooks.slack.com':
             reasons.append(f'Alertmanager webhook host drifted to {webhook.get("host")}')
         if int(alertmanager.get('notifyErrorsLastWindow') or 0) > 0:
@@ -85,6 +90,10 @@ def infer_next_actions(
             actions.append('Check the on-prem backend container health and `/health` response before retrying the workflow.')
         elif 'webhook is not configured' in reason or 'host drifted' in reason:
             actions.append('Reapply the persisted Alertmanager webhook configuration on the on-prem host.')
+        elif 'No supported GitHub webhook secret' in reason:
+            actions.append(
+                'Configure one supported GitHub Actions secret: ALERTMANAGER_WEBHOOK_URL, ALERT_WEBHOOK_URL, SLACK_WEBHOOK_URL, or ATTENDANCE_ALERT_SLACK_WEBHOOK_URL.'
+            )
         elif 'notify errors' in reason:
             actions.append('Inspect Alertmanager and webhook bridge logs, then confirm Slack delivery still resolves firing and resolved notifications.')
         elif 'root filesystem is at or above gate' in reason:
@@ -109,7 +118,8 @@ def make_summary_payload(
 ) -> dict[str, Any]:
     status = 'PASS' if stability_rc == '0' and healthy == 'true' else 'FAIL'
     run_url = github_run_url()
-    failure_reasons = infer_failure_reasons(payload, stability_rc, healthy)
+    webhook_secret_available = os.environ.get('WEBHOOK_SECRET_AVAILABLE', 'false')
+    failure_reasons = infer_failure_reasons(payload, stability_rc, healthy, webhook_secret_available)
     next_actions = infer_next_actions(payload, failure_reasons)
     summary_json_path = summary_path.with_suffix('.json')
 
@@ -129,6 +139,9 @@ def make_summary_payload(
             'runAttempt': os.environ.get('GITHUB_RUN_ATTEMPT', ''),
             'runUrl': run_url,
         },
+        'selfHeal': {
+            'webhookSecretAvailable': webhook_secret_available == 'true',
+        },
         'snapshot': payload,
         'artifacts': {
             'jsonPath': str(json_path),
@@ -146,9 +159,13 @@ def markdown_lines(summary: dict[str, Any]) -> list[str]:
     lines.append(f'- Stability rc: `{summary["stabilityRc"]}`')
     lines.append(f'- Healthy: `{str(summary["healthy"]).lower()}`')
     workflow = summary.get('workflow') or {}
+    self_heal = summary.get('selfHeal') or {}
     run_url = workflow.get('runUrl')
     if run_url:
         lines.append(f'- Run URL: `{run_url}`')
+    lines.append(
+        f'- Webhook self-heal secret available: `{str(bool(self_heal.get("webhookSecretAvailable"))).lower()}`'
+    )
     lines.append('')
 
     if payload:

--- a/scripts/ops/github-dingtalk-oauth-stability-summary.test.mjs
+++ b/scripts/ops/github-dingtalk-oauth-stability-summary.test.mjs
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const scriptPath = path.join(repoRoot, 'scripts', 'ops', 'github-dingtalk-oauth-stability-summary.py')
+
+function makeTmpDir() {
+  return mkdtempSync(path.join(tmpdir(), 'github-dingtalk-oauth-stability-summary-'))
+}
+
+function runSummary(args, env = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn('python3', [scriptPath, ...args], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: {
+        ...process.env,
+        ...env,
+      },
+    })
+    let stdout = ''
+    let stderr = ''
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL')
+      reject(new Error(`summary timed out\nstdout=${stdout}\nstderr=${stderr}`))
+    }, 10_000)
+
+    child.stdout.setEncoding('utf8')
+    child.stderr.setEncoding('utf8')
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk
+    })
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk
+    })
+    child.on('error', (error) => {
+      clearTimeout(timer)
+      reject(error)
+    })
+    child.on('close', (status) => {
+      clearTimeout(timer)
+      resolve({ status, stdout, stderr })
+    })
+  })
+}
+
+test('summary calls out missing GitHub webhook secret when self-heal was skipped', async () => {
+  const outDir = makeTmpDir()
+  const jsonPath = path.join(outDir, 'stability.json')
+  const logPath = path.join(outDir, 'stability.log')
+  const summaryPath = path.join(outDir, 'summary.md')
+  try {
+    writeFileSync(jsonPath, `${JSON.stringify({
+      checkedAt: '2026-04-29T12:50:55Z',
+      host: 'mainuser@142.171.239.56',
+      health: { status: 'ok', plugins: 13, ok: true },
+      webhookConfig: { configured: false, host: '', pathLength: 0 },
+      alertmanager: { activeAlertsCount: 0, notifyErrorsLastWindow: 0 },
+      storage: { root: { usePercent: 94, availableKBlocks: 4941512, maxUsePercent: 95 } },
+      bridge: { notifyEventsLastWindow: 0, resolvedEventsLastWindow: 0 },
+      metrics: { operationsSamples: [], fallbackSamples: [], redisSamples: [] },
+      healthy: false,
+    })}\n`)
+    writeFileSync(logPath, 'self-heal skipped\n')
+
+    const result = await runSummary([jsonPath, logPath, summaryPath], {
+      STABILITY_RC: '0',
+      HEALTHY: 'false',
+      WEBHOOK_SECRET_AVAILABLE: 'false',
+    })
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stdout, /Webhook self-heal secret available: `false`/)
+    assert.match(result.stdout, /Alertmanager webhook is not configured/)
+    assert.match(result.stdout, /No supported GitHub webhook secret was available/)
+    assert.match(result.stdout, /Configure one supported GitHub Actions secret/)
+
+    const summary = JSON.parse(readFileSync(path.join(outDir, 'summary.json'), 'utf8'))
+    assert.equal(summary.selfHeal.webhookSecretAvailable, false)
+    assert.deepEqual(summary.failureReasons, [
+      'Alertmanager webhook is not configured',
+      'No supported GitHub webhook secret was available for Alertmanager self-heal',
+    ])
+  } finally {
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+


### PR DESCRIPTION
## Summary
- let DingTalk OAuth stability self-heal use ALERTMANAGER_WEBHOOK_URL, ALERT_WEBHOOK_URL, SLACK_WEBHOOK_URL, or ATTENDANCE_ALERT_SLACK_WEBHOOK_URL
- record whether a webhook secret was available and surface missing-secret diagnostics in the summary artifact
- keep the final healthy=false hard gate unchanged
- add design and verification docs, plus a summary regression test

## Evidence
- Run 25109850840 had STABILITY_RC=0 but HEALTHY=false because Alertmanager webhook was not configured
- The self-heal step skipped because the webhook secret env was empty
- Current gh secret list shows no supported webhook secret name, so this PR improves fallback/diagnostics but a repo secret still needs to be configured for the scheduled run to self-heal

## Verification
- bash -n scripts/ops/set-dingtalk-onprem-alertmanager-webhook-config.sh && bash -n scripts/ops/dingtalk-oauth-stability-check.sh
- python3 -m py_compile scripts/ops/github-dingtalk-oauth-stability-summary.py
- node --test scripts/ops/dingtalk-oauth-stability-workflow-contract.test.mjs
- node --test scripts/ops/github-dingtalk-oauth-stability-summary.test.mjs
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/dingtalk-oauth-stability-recording-lite.yml"); puts "workflow yaml ok"'
- git diff --check