### PR TITLE
test(integration): tighten K3 postdeploy route contract

### DIFF
--- a/docs/development/integration-k3wise-postdeploy-route-contract-design-20260429.md
+++ b/docs/development/integration-k3wise-postdeploy-route-contract-design-20260429.md
@@ -1,0 +1,56 @@
+# K3 WISE Postdeploy Route Contract Guard Design - 2026-04-29
+
+## Context
+
+The K3 WISE postdeploy smoke already checked public deployment health, plugin
+adapter availability, read-only control-plane list probes, and staging descriptor
+coverage. Its authenticated route contract was still list-heavy: it did not
+require route inventory entries for detail reads or dead-letter replay even
+though the integration plugin exposes those routes from
+`plugins/plugin-integration-core/lib/http-routes.cjs`.
+
+That created a false-positive deployment risk: `/api/integration/status` could
+pass while the operator-facing recovery path was missing from the runtime route
+surface.
+
+## Scope
+
+This change tightens only the postdeploy smoke contract. It does not change
+runtime route handlers, adapter logic, pipeline execution, credentials, or
+production configuration.
+
+Updated guard surface:
+
+- `GET /api/integration/external-systems/:id`
+- `GET /api/integration/pipelines/:id`
+- `POST /api/integration/dead-letters/:id/replay`
+
+The full required route count is now 15. These routes are intentionally checked
+through the plugin status route inventory rather than by mutating live data:
+
+- detail routes prove that the operator can inspect saved external systems and
+  pipelines after deployment.
+- the replay route proves that the manual recovery control plane is registered.
+- list probes remain read-only and continue to avoid side effects on production
+  data.
+
+## Implementation
+
+Files changed:
+
+- `scripts/ops/integration-k3wise-postdeploy-smoke.mjs`
+  - extends `REQUIRED_ROUTES` with the three missing control-plane routes.
+  - preserves token redaction and authenticated-only behavior.
+  - includes sanitized failure details in failed check evidence so missing route
+    names are actionable without exposing secrets.
+- `scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs`
+  - extracts the fake status route inventory into `DEFAULT_ROUTES`.
+  - asserts the successful route guard checks all 15 routes.
+  - adds a regression test for missing dead-letter replay registration.
+
+## Safety
+
+The smoke still performs no write or replay operation against a deployed system.
+It validates route registration metadata returned by `/api/integration/status`.
+When a route is missing, the evidence file records the missing route name but
+continues to redact tokens, authorization headers, and secret-like values.

--- a/docs/development/integration-k3wise-postdeploy-route-contract-verification-20260429.md
+++ b/docs/development/integration-k3wise-postdeploy-route-contract-verification-20260429.md
@@ -1,0 +1,71 @@
+# K3 WISE Postdeploy Route Contract Guard Verification - 2026-04-29
+
+## Local Verification
+
+Worktree:
+
+`/tmp/ms2-k3wise-route-contract-20260429`
+
+Branch:
+
+`codex/k3wise-route-contract-20260429`
+
+Commands run:
+
+```bash
+node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
+node --test scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
+node --test scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs
+git diff --check
+```
+
+Results:
+
+- `integration-k3wise-postdeploy-smoke.test.mjs`: 10/10 passed.
+- `integration-k3wise-postdeploy-summary.test.mjs`: 5/5 passed.
+- `integration-k3wise-postdeploy-workflow-contract.test.mjs`: 2/2 passed.
+- `git diff --check`: passed.
+
+## Regression Coverage
+
+Added coverage:
+
+- successful authenticated smoke now verifies `routesChecked` equals 15.
+- fake server route inventory is centralized in `DEFAULT_ROUTES`.
+- missing `POST /api/integration/dead-letters/:id/replay` produces a failing
+  `integration-route-contract` check and records the missing route in sanitized
+  evidence details.
+
+Existing coverage preserved:
+
+- public smoke still skips authenticated integration checks when no token is
+  provided.
+- protected integration routes still skip plugin health rather than failing the
+  public-only path.
+- tenant-scoped read-only list probes still run for external systems, pipelines,
+  runs, and dead letters.
+- staging descriptor contract still requires all five K3 WISE staging tables.
+
+## Mainline Status Checked Before This Work
+
+The previous PR `#1249` merged at
+`f4acf8bf8bff28610691368f123d4259a6ed8395`. Post-merge push workflows on that
+commit were checked before opening this route-contract lane:
+
+- `Phase 5 Production Flags Guard`: success.
+- `Deploy to Production`: success.
+- `Build and Push Docker Images`: success.
+- `Plugin System Tests`: success.
+- `.github/workflows/monitoring-alert.yml`: success.
+
+## Remaining External Configuration
+
+This route-contract change is independent of the scheduled DingTalk stability
+webhook issue found during the same maintenance window. The scheduled stability
+workflow still requires one supported GitHub Actions secret to be configured for
+Alertmanager self-heal:
+
+- `ALERTMANAGER_WEBHOOK_URL`
+- `ALERT_WEBHOOK_URL`
+- `SLACK_WEBHOOK_URL`
+- `ATTENDANCE_ALERT_SLACK_WEBHOOK_URL`

--- a/scripts/ops/integration-k3wise-postdeploy-smoke.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-smoke.mjs
@@ -15,13 +15,16 @@ const REQUIRED_ROUTES = [
   ['GET', '/api/integration/status'],
   ['GET', '/api/integration/external-systems'],
   ['POST', '/api/integration/external-systems'],
+  ['GET', '/api/integration/external-systems/:id'],
   ['POST', '/api/integration/external-systems/:id/test'],
   ['GET', '/api/integration/pipelines'],
   ['POST', '/api/integration/pipelines'],
+  ['GET', '/api/integration/pipelines/:id'],
   ['POST', '/api/integration/pipelines/:id/dry-run'],
   ['POST', '/api/integration/pipelines/:id/run'],
   ['GET', '/api/integration/runs'],
   ['GET', '/api/integration/dead-letters'],
+  ['POST', '/api/integration/dead-letters/:id/replay'],
   ['GET', '/api/integration/staging/descriptors'],
   ['POST', '/api/integration/staging/install'],
 ]
@@ -177,8 +180,12 @@ function result(id, status, details = {}) {
 }
 
 function failResult(id, error) {
+  const details = error && error.details && typeof error.details === 'object'
+    ? { details: sanitizeBody(error.details) }
+    : {}
   return result(id, 'fail', {
     error: error && error.message ? redactText(error.message) : redactText(String(error)),
+    ...details,
   })
 }
 

--- a/scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
@@ -15,6 +15,23 @@ const DEFAULT_ADAPTERS = [
   'erp:k3-wise-webapi',
   'erp:k3-wise-sqlserver',
 ]
+const DEFAULT_ROUTES = [
+  ['GET', '/api/integration/status'],
+  ['GET', '/api/integration/external-systems'],
+  ['POST', '/api/integration/external-systems'],
+  ['GET', '/api/integration/external-systems/:id'],
+  ['POST', '/api/integration/external-systems/:id/test'],
+  ['GET', '/api/integration/pipelines'],
+  ['POST', '/api/integration/pipelines'],
+  ['GET', '/api/integration/pipelines/:id'],
+  ['POST', '/api/integration/pipelines/:id/dry-run'],
+  ['POST', '/api/integration/pipelines/:id/run'],
+  ['GET', '/api/integration/runs'],
+  ['GET', '/api/integration/dead-letters'],
+  ['POST', '/api/integration/dead-letters/:id/replay'],
+  ['GET', '/api/integration/staging/descriptors'],
+  ['POST', '/api/integration/staging/install'],
+]
 const DEFAULT_STAGING_DESCRIPTORS = [
   { id: 'plm_raw_items', name: 'PLM Raw Items' },
   { id: 'standard_materials', name: 'Standard Materials' },
@@ -132,20 +149,8 @@ function createFakeServer(options = {}) {
         ok: true,
         data: {
           adapters: options.integrationAdapters || DEFAULT_ADAPTERS,
-          routes: [
-            ['GET', '/api/integration/status'],
-            ['GET', '/api/integration/external-systems'],
-            ['POST', '/api/integration/external-systems'],
-            ['POST', '/api/integration/external-systems/:id/test'],
-            ['GET', '/api/integration/pipelines'],
-            ['POST', '/api/integration/pipelines'],
-            ['POST', '/api/integration/pipelines/:id/dry-run'],
-            ['POST', '/api/integration/pipelines/:id/run'],
-            ['GET', '/api/integration/runs'],
-            ['GET', '/api/integration/dead-letters'],
-            ['GET', '/api/integration/staging/descriptors'],
-            ['POST', '/api/integration/staging/install'],
-          ].map(([method, routePath]) => ({ method, path: routePath })),
+          routes: (options.integrationRoutes || DEFAULT_ROUTES)
+            .map(([method, routePath]) => ({ method, path: routePath })),
         },
       })
       return
@@ -277,7 +282,9 @@ test('authenticated postdeploy smoke validates route and staging contracts witho
     const evidence = JSON.parse(evidenceText)
     assert.equal(evidence.authenticated, true)
     assert.equal(evidence.summary.fail, 0)
-    assert.equal(evidence.checks.find((check) => check.id === 'integration-route-contract').status, 'pass')
+    const routeCheck = evidence.checks.find((check) => check.id === 'integration-route-contract')
+    assert.equal(routeCheck.status, 'pass')
+    assert.equal(routeCheck.routesChecked, DEFAULT_ROUTES.length)
     for (const id of [
       'integration-list-external-systems',
       'integration-list-pipelines',
@@ -428,6 +435,35 @@ test('authenticated postdeploy smoke fails when status omits a required source a
     const routeCheck = evidence.checks.find((check) => check.id === 'integration-route-contract')
     assert.equal(routeCheck.status, 'fail')
     assert.match(routeCheck.error, /missing required adapters or routes/)
+  } finally {
+    await fake.close()
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('authenticated postdeploy smoke fails when status omits a required replay route', async () => {
+  const fake = createFakeServer({
+    integrationRoutes: DEFAULT_ROUTES.filter(
+      ([method, routePath]) =>
+        `${method} ${routePath}` !== 'POST /api/integration/dead-letters/:id/replay',
+    ),
+  })
+  const baseUrl = await fake.listen()
+  const outDir = makeTmpDir()
+  try {
+    const result = await runScript([
+      '--base-url', baseUrl,
+      '--auth-token', 'test.jwt.token',
+      '--require-auth',
+      '--out-dir', outDir,
+    ])
+
+    assert.equal(result.status, 1)
+    const evidence = JSON.parse(readFileSync(path.join(outDir, 'integration-k3wise-postdeploy-smoke.json'), 'utf8'))
+    const routeCheck = evidence.checks.find((check) => check.id === 'integration-route-contract')
+    assert.equal(routeCheck.status, 'fail')
+    assert.match(routeCheck.error, /missing required adapters or routes/)
+    assert.deepEqual(routeCheck.details.missingRoutes, ['POST /api/integration/dead-letters/:id/replay'])
   } finally {
     await fake.close()
     rmSync(outDir, { recursive: true, force: true })


### PR DESCRIPTION
## Summary
- Tighten the K3 WISE postdeploy smoke route inventory from list/run-only checks to the full 15-route integration control-plane contract.
- Add required checks for external-system detail, pipeline detail, and dead-letter replay registration.
- Preserve read-only deployment behavior: the smoke validates `/api/integration/status` metadata and does not invoke replay or write operations.
- Add sanitized failure details so missing route names are actionable in evidence output.

## Design / Verification Docs
- `docs/development/integration-k3wise-postdeploy-route-contract-design-20260429.md`
- `docs/development/integration-k3wise-postdeploy-route-contract-verification-20260429.md`

## Verification
- `node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs` 10/10 pass
- `node --test scripts/ops/integration-k3wise-postdeploy-summary.test.mjs` 5/5 pass
- `node --test scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs` 2/2 pass
- `git diff --check` pass

## Notes
- Based on latest `origin/main` after #1249.
- #1249 post-merge push workflows were checked green before this PR: deploy, build images, monitoring, production flags, and plugin tests.
