### PR TITLE
test(dingtalk): cover public form unbound users

### DIFF
--- a/docs/development/dingtalk-public-form-unbound-contract-design-20260429.md
+++ b/docs/development/dingtalk-public-form-unbound-contract-design-20260429.md
@@ -1,0 +1,43 @@
+# DingTalk Public Form Unbound Contract Design - 2026-04-29
+
+## Goal
+
+Lock the backend contract for signed-in users who can open a public multitable
+form link but have not bound a DingTalk identity.
+
+This covers the remaining access-matrix cases where the user is known to
+MetaSheet but still cannot satisfy DingTalk-protected form policy:
+
+- DingTalk-protected form, no explicit allowlist, signed-in user is not bound.
+- DingTalk-granted selected-user form, signed-in user is selected but not bound.
+- DingTalk-protected submit request, signed-in user is not bound.
+
+## Design
+
+No runtime behavior change is required in this slice. The existing backend gate
+already evaluates DingTalk public-form access in this order:
+
+1. Public token must be valid and unexpired.
+2. Anonymous DingTalk-protected access receives `DINGTALK_AUTH_REQUIRED`.
+3. Signed-in users must have a DingTalk binding before grant or allowlist
+   evaluation.
+4. `dingtalk_granted` users must have an enabled DingTalk grant.
+5. Selected-user or member-group allowlists are evaluated last.
+
+The new tests make that ordering explicit. In particular, a selected but
+unbound user must receive `DINGTALK_BIND_REQUIRED`, not `DINGTALK_GRANT_REQUIRED`
+or `DINGTALK_FORM_NOT_ALLOWED`.
+
+## Safety
+
+Submit denial is asserted before `INSERT INTO meta_records`, so an unbound user
+cannot create a record through a stale form context or direct API request.
+
+No DingTalk webhook, signing secret, access token, JWT, or real public form
+token is stored in this design note or in the test fixtures.
+
+## Files
+
+- `packages/core-backend/tests/integration/public-form-flow.test.ts`
+- `docs/development/dingtalk-public-form-unbound-contract-design-20260429.md`
+- `docs/development/dingtalk-public-form-unbound-contract-verification-20260429.md`

--- a/docs/development/dingtalk-public-form-unbound-contract-verification-20260429.md
+++ b/docs/development/dingtalk-public-form-unbound-contract-verification-20260429.md
@@ -1,0 +1,52 @@
+# DingTalk Public Form Unbound Contract Verification - 2026-04-29
+
+## Scope
+
+This document verifies backend access-matrix coverage for signed-in public-form
+users without a bound DingTalk identity.
+
+Changed files:
+
+- `packages/core-backend/tests/integration/public-form-flow.test.ts`
+- `docs/development/dingtalk-public-form-unbound-contract-design-20260429.md`
+- `docs/development/dingtalk-public-form-unbound-contract-verification-20260429.md`
+
+## Commands
+
+```bash
+cd packages/core-backend
+../../node_modules/.bin/vitest run tests/integration/public-form-flow.test.ts --watch=false
+cd ../..
+git diff --check
+git diff -- packages/core-backend/tests/integration/public-form-flow.test.ts docs/development/dingtalk-public-form-unbound-contract-design-20260429.md docs/development/dingtalk-public-form-unbound-contract-verification-20260429.md \
+  | rg -v "rg -n" \
+  | rg -n "(access_token=[A-Za-z0-9]|SEC[0-9a-fA-F]{8,}|Authorization:|Bearer [A-Za-z0-9._-]{20,}|https://oapi\\.dingtalk\\.com/robot/send|JWT_SECRET|DINGTALK_APP_SECRET|publicToken=[A-Za-z0-9._~+/=-]{12,})" || true
+```
+
+## Results
+
+- `public-form-flow.test.ts`: passed, `22` tests.
+- `git diff --check`: passed.
+- Diff secret scan: no matches after excluding the documented scan command
+  itself.
+
+## Regression Coverage
+
+The added cases verify:
+
+- signed-in but unbound users are rejected with `DINGTALK_BIND_REQUIRED`;
+- selected users still require DingTalk binding before grant or allowlist
+  evaluation;
+- submit requests from unbound users are rejected with `DINGTALK_BIND_REQUIRED`;
+- rejected submit requests do not insert `meta_records`.
+
+## Manual Acceptance
+
+For a live DingTalk-protected public form:
+
+- anonymous user should be sent to DingTalk sign-in;
+- signed-in local user without DingTalk binding should be asked to bind
+  DingTalk;
+- selected but unbound local user should still be asked to bind DingTalk;
+- bound but unauthorized selected-user/member-group user should continue to see
+  the selected-user/member-group rejection.

--- a/packages/core-backend/tests/integration/public-form-flow.test.ts
+++ b/packages/core-backend/tests/integration/public-form-flow.test.ts
@@ -261,6 +261,19 @@ describe('Public form flow', () => {
     expect(res.body.error?.code).toBe('DINGTALK_AUTH_REQUIRED')
   })
 
+  test('dingtalk-protected form rejects a signed-in user without DingTalk binding', async () => {
+    const { app } = await createApp({
+      queryHandler: buildQueryHandler(VALID_TOKEN, { accessMode: 'dingtalk' }),
+      user: { id: 'user_unbound' },
+    })
+
+    const res = await request(app)
+      .get(`/api/multitable/form-context?viewId=${TEST_VIEW_ID}&publicToken=${VALID_TOKEN}`)
+
+    expect(res.status).toBe(403)
+    expect(res.body.error?.code).toBe('DINGTALK_BIND_REQUIRED')
+  })
+
   test('dingtalk-protected form allows a bound signed-in user', async () => {
     const { app } = await createApp({
       queryHandler: buildQueryHandler(VALID_TOKEN, { accessMode: 'dingtalk', hasDingTalkBinding: true }),
@@ -289,6 +302,40 @@ describe('Public form flow', () => {
 
     expect(res.status).toBe(403)
     expect(res.body.error?.code).toBe('DINGTALK_GRANT_REQUIRED')
+  })
+
+  test('dingtalk-granted selected-user form rejects selected users without DingTalk binding first', async () => {
+    const { app } = await createApp({
+      queryHandler: buildQueryHandler(VALID_TOKEN, {
+        accessMode: 'dingtalk_granted',
+        allowedUserIds: ['user_unbound'],
+      }),
+      user: { id: 'user_unbound' },
+    })
+
+    const res = await request(app)
+      .get(`/api/multitable/form-context?viewId=${TEST_VIEW_ID}&publicToken=${VALID_TOKEN}`)
+
+    expect(res.status).toBe(403)
+    expect(res.body.error?.code).toBe('DINGTALK_BIND_REQUIRED')
+  })
+
+  test('dingtalk-protected form rejects submit from a signed-in user without DingTalk binding', async () => {
+    const { app, mockPool } = await createApp({
+      queryHandler: buildQueryHandler(VALID_TOKEN, { accessMode: 'dingtalk' }),
+      user: { id: 'user_unbound' },
+    })
+
+    const res = await request(app)
+      .post(`/api/multitable/views/${TEST_VIEW_ID}/submit?publicToken=${VALID_TOKEN}`)
+      .send({
+        publicToken: VALID_TOKEN,
+        data: { fld_1: 'Alice', fld_2: 'alice@test.com' },
+      })
+
+    expect(res.status).toBe(403)
+    expect(res.body.error?.code).toBe('DINGTALK_BIND_REQUIRED')
+    expect(mockPool.query.mock.calls.some(([sql]) => String(sql).includes('INSERT INTO meta_records'))).toBe(false)
   })
 
   test('dingtalk-granted form rejects submit from a bound user without grant', async () => {


### PR DESCRIPTION
## Summary
- Add backend access-matrix coverage for signed-in public-form users without a bound DingTalk identity.
- Verify selected-but-unbound users receive `DINGTALK_BIND_REQUIRED` before grant or allowlist evaluation.
- Verify submit requests from unbound users are rejected before `meta_records` insertion.
- Add design and verification markdown for this contract slice.

## Verification
- `../../node_modules/.bin/vitest run tests/integration/public-form-flow.test.ts --watch=false` from `packages/core-backend`: passed, 22 tests.
- `git diff --check`: passed.
- Diff secret scan for DingTalk webhook/signing secret/JWT/app-secret/public-token patterns: no matches after excluding the documented scan command itself.

## Notes
- This slice is intentionally test/documentation hardening only; no runtime behavior change was needed.
- No DingTalk webhook URLs, signing secrets, access tokens, JWTs, or real public form tokens are included.