### PR TITLE
test(integration): validate K3 staging field contract

### DIFF
--- a/docs/development/integration-k3wise-staging-field-contract-design-20260429.md
+++ b/docs/development/integration-k3wise-staging-field-contract-design-20260429.md
@@ -1,0 +1,85 @@
+# K3 WISE Staging Field Contract Guard Design - 2026-04-29
+
+## Context
+
+The K3 WISE postdeploy smoke already checks that the integration plugin exposes
+the five staging descriptors required by the PLM-to-ERP cleansing workflow:
+
+- `plm_raw_items`
+- `standard_materials`
+- `bom_cleanse`
+- `integration_exceptions`
+- `integration_run_log`
+
+Before this change, that guard stopped at descriptor IDs. A deployment could
+return all five descriptor IDs while omitting a critical user-facing field such
+as `standard_materials.erpSyncStatus` or
+`integration_exceptions.errorMessage`, and the postdeploy smoke would still
+pass.
+
+That is a real false-positive risk for the K3 WISE live PoC because the
+operator workflow depends on those staging fields to inspect cleansed records,
+ERP feedback, exception queues, and run logs.
+
+## Scope
+
+This change tightens only the postdeploy smoke contract. It does not change:
+
+- staging installation behavior.
+- multitable provisioning behavior.
+- pipeline execution.
+- ERP/PLM adapter behavior.
+- live data mutation.
+
+The smoke continues to call the authenticated read-only endpoint:
+
+`GET /api/integration/staging/descriptors`
+
+## Required Field Contract
+
+The guard now requires the descriptor field IDs defined by
+`plugins/plugin-integration-core/lib/staging-installer.cjs`:
+
+- `plm_raw_items`: source identity, raw payload, fetch timestamp, and run ID.
+- `standard_materials`: material master fields plus ERP feedback fields.
+- `bom_cleanse`: parent/child BOM line fields, quantity, validity, and status.
+- `integration_exceptions`: pipeline/run identity, error payloads, status, and
+  human triage fields.
+- `integration_run_log`: run identity, mode, counters, timestamps, and error
+  summary.
+
+The validator accepts either of these response shapes for forward compatibility:
+
+```json
+{ "fields": ["code", "name"] }
+```
+
+```json
+{ "fields": [{ "id": "code" }, { "id": "name" }] }
+```
+
+## Failure Evidence
+
+When a descriptor field is missing, the smoke fails
+`staging-descriptor-contract` and records sanitized details:
+
+```json
+{
+  "missingFields": {
+    "standard_materials": ["erpSyncStatus"]
+  }
+}
+```
+
+This keeps deployment evidence actionable without exposing auth tokens or
+secret-like values.
+
+The GitHub step summary renderer now also prints known failure-detail groups
+for failed checks:
+
+- `missingAdapters`
+- `missingRoutes`
+- `missingFields`
+
+That means operators can see the exact missing K3 WISE route or staging field in
+the workflow summary instead of downloading the JSON artifact first.

--- a/docs/development/integration-k3wise-staging-field-contract-verification-20260429.md
+++ b/docs/development/integration-k3wise-staging-field-contract-verification-20260429.md
@@ -1,0 +1,73 @@
+# K3 WISE Staging Field Contract Guard Verification - 2026-04-29
+
+## Local Verification
+
+Worktree:
+
+`/tmp/ms2-k3wise-staging-field-contract-20260429`
+
+Branch:
+
+`codex/k3wise-staging-field-contract-20260429`
+
+Commands run:
+
+```bash
+node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
+node --test scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
+node --test scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs
+git diff --check
+```
+
+Results:
+
+- `integration-k3wise-postdeploy-smoke.test.mjs`: 11/11 passed.
+- `integration-k3wise-postdeploy-summary.test.mjs`: 6/6 passed.
+- `integration-k3wise-postdeploy-workflow-contract.test.mjs`: 2/2 passed.
+- `git diff --check`: passed.
+
+## Regression Coverage
+
+Added coverage:
+
+- successful authenticated smoke now reports `fieldsChecked` for all required
+  staging fields.
+- missing `standard_materials.erpSyncStatus` fails
+  `staging-descriptor-contract`.
+- failure evidence includes `details.missingFields` with the exact missing
+  descriptor-field pair.
+- GitHub summary rendering includes `missingAdapters`, `missingRoutes`, and
+  nested `missingFields` details for failed checks.
+
+Existing coverage preserved:
+
+- public smoke still skips authenticated integration checks when no token is
+  provided.
+- protected integration routes still skip plugin health instead of failing the
+  public-only path.
+- authenticated smoke still validates the 15-route integration contract.
+- read-only control-plane list probes remain unchanged.
+- missing descriptor ID still fails before field validation.
+
+## Mainline Baseline
+
+This work started from `origin/main` at:
+
+`592fe8a6c1ee5bd91f57df97537f35747f0cae8f`
+
+That commit is the merge of PR `#1250`. Its post-merge workflows were checked
+before this branch:
+
+- `Phase 5 Production Flags Guard`: success.
+- `Deploy to Production`: success.
+- `Build and Push Docker Images`: success.
+- `Plugin System Tests`: success.
+- `.github/workflows/monitoring-alert.yml`: success.
+
+## Residual Risk
+
+The smoke validates descriptor field IDs, not field types or select options.
+That is intentional for this slice because the runtime descriptor endpoint
+currently exposes field IDs. Type/option validation should either use a richer
+descriptor response contract or a plugin-local unit test against
+`STAGING_DESCRIPTORS`.

--- a/scripts/ops/integration-k3wise-postdeploy-smoke.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-smoke.mjs
@@ -41,6 +41,70 @@ const REQUIRED_STAGING_DESCRIPTORS = [
   'integration_exceptions',
   'integration_run_log',
 ]
+const REQUIRED_STAGING_FIELDS = {
+  plm_raw_items: [
+    'sourceSystemId',
+    'objectType',
+    'sourceId',
+    'revision',
+    'code',
+    'name',
+    'rawPayload',
+    'fetchedAt',
+    'pipelineRunId',
+  ],
+  standard_materials: [
+    'code',
+    'name',
+    'uom',
+    'category',
+    'status',
+    'erpSyncStatus',
+    'erpExternalId',
+    'erpBillNo',
+    'erpResponseCode',
+    'erpResponseMessage',
+    'lastSyncedAt',
+  ],
+  bom_cleanse: [
+    'parentCode',
+    'childCode',
+    'quantity',
+    'uom',
+    'sequence',
+    'revision',
+    'validFrom',
+    'validTo',
+    'status',
+  ],
+  integration_exceptions: [
+    'pipelineId',
+    'runId',
+    'idempotencyKey',
+    'errorCode',
+    'errorMessage',
+    'sourcePayload',
+    'transformedPayload',
+    'status',
+    'assignee',
+    'note',
+  ],
+  integration_run_log: [
+    'pipelineId',
+    'runId',
+    'mode',
+    'triggeredBy',
+    'status',
+    'rowsRead',
+    'rowsCleaned',
+    'rowsWritten',
+    'rowsFailed',
+    'durationMs',
+    'startedAt',
+    'finishedAt',
+    'errorSummary',
+  ],
+}
 const TOKEN_PATTERN = /([A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{16,}|Bearer\s+[A-Za-z0-9._-]{16,})/g
 
 class K3WisePostdeploySmokeError extends Error {
@@ -294,13 +358,46 @@ function assertStagingDescriptors(body) {
   if (!Array.isArray(data)) {
     throw new K3WisePostdeploySmokeError('staging descriptors response must be an array')
   }
-  const ids = data.map((descriptor) => descriptor && descriptor.id).filter(Boolean)
+  const descriptorsById = new Map()
+  for (const descriptor of data) {
+    if (descriptor && typeof descriptor.id === 'string') descriptorsById.set(descriptor.id, descriptor)
+  }
+  const ids = Array.from(descriptorsById.keys())
   for (const id of REQUIRED_STAGING_DESCRIPTORS) {
-    if (!ids.includes(id)) {
+    if (!descriptorsById.has(id)) {
       throw new K3WisePostdeploySmokeError(`missing staging descriptor ${id}`, { ids })
     }
   }
-  return { descriptors: ids, descriptorsChecked: REQUIRED_STAGING_DESCRIPTORS.length }
+  const missingFields = {}
+  let fieldsChecked = 0
+  for (const id of REQUIRED_STAGING_DESCRIPTORS) {
+    const descriptor = descriptorsById.get(id)
+    const fieldIds = new Set(
+      Array.isArray(descriptor.fields)
+        ? descriptor.fields
+          .map((field) => {
+            if (typeof field === 'string') return field
+            if (field && typeof field.id === 'string') return field.id
+            return ''
+          })
+          .filter(Boolean)
+        : [],
+    )
+    const requiredFields = REQUIRED_STAGING_FIELDS[id] || []
+    fieldsChecked += requiredFields.length
+    const missing = requiredFields.filter((fieldId) => !fieldIds.has(fieldId))
+    if (missing.length > 0) missingFields[id] = missing
+  }
+  if (Object.keys(missingFields).length > 0) {
+    throw new K3WisePostdeploySmokeError('staging descriptors are missing required fields', {
+      missingFields,
+    })
+  }
+  return {
+    descriptors: ids,
+    descriptorsChecked: REQUIRED_STAGING_DESCRIPTORS.length,
+    fieldsChecked,
+  }
 }
 
 function assertListResponse(body, probeId) {

--- a/scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
@@ -32,12 +32,76 @@ const DEFAULT_ROUTES = [
   ['GET', '/api/integration/staging/descriptors'],
   ['POST', '/api/integration/staging/install'],
 ]
+const DEFAULT_STAGING_FIELDS = {
+  plm_raw_items: [
+    'sourceSystemId',
+    'objectType',
+    'sourceId',
+    'revision',
+    'code',
+    'name',
+    'rawPayload',
+    'fetchedAt',
+    'pipelineRunId',
+  ],
+  standard_materials: [
+    'code',
+    'name',
+    'uom',
+    'category',
+    'status',
+    'erpSyncStatus',
+    'erpExternalId',
+    'erpBillNo',
+    'erpResponseCode',
+    'erpResponseMessage',
+    'lastSyncedAt',
+  ],
+  bom_cleanse: [
+    'parentCode',
+    'childCode',
+    'quantity',
+    'uom',
+    'sequence',
+    'revision',
+    'validFrom',
+    'validTo',
+    'status',
+  ],
+  integration_exceptions: [
+    'pipelineId',
+    'runId',
+    'idempotencyKey',
+    'errorCode',
+    'errorMessage',
+    'sourcePayload',
+    'transformedPayload',
+    'status',
+    'assignee',
+    'note',
+  ],
+  integration_run_log: [
+    'pipelineId',
+    'runId',
+    'mode',
+    'triggeredBy',
+    'status',
+    'rowsRead',
+    'rowsCleaned',
+    'rowsWritten',
+    'rowsFailed',
+    'durationMs',
+    'startedAt',
+    'finishedAt',
+    'errorSummary',
+  ],
+}
 const DEFAULT_STAGING_DESCRIPTORS = [
-  { id: 'plm_raw_items', name: 'PLM Raw Items' },
-  { id: 'standard_materials', name: 'Standard Materials' },
-  { id: 'bom_cleanse', name: 'BOM Cleanse' },
-  { id: 'integration_exceptions', name: 'Integration Exceptions' },
-  { id: 'integration_run_log', name: 'Integration Run Log' },
+  { id: 'plm_raw_items', name: 'PLM Raw Items', fields: DEFAULT_STAGING_FIELDS.plm_raw_items },
+  { id: 'standard_materials', name: 'Standard Materials', fields: DEFAULT_STAGING_FIELDS.standard_materials },
+  { id: 'bom_cleanse', name: 'BOM Cleanse', fields: DEFAULT_STAGING_FIELDS.bom_cleanse },
+  { id: 'integration_exceptions', name: 'Integration Exceptions', fields: DEFAULT_STAGING_FIELDS.integration_exceptions },
+  { id: 'integration_run_log', name: 'Integration Run Log', fields: DEFAULT_STAGING_FIELDS.integration_run_log },
 ]
 
 function makeTmpDir() {
@@ -295,7 +359,12 @@ test('authenticated postdeploy smoke validates route and staging contracts witho
       assert.equal(check.status, 'pass')
       assert.equal(check.tenantId, 'tenant-smoke')
     }
-    assert.equal(evidence.checks.find((check) => check.id === 'staging-descriptor-contract').status, 'pass')
+    const stagingCheck = evidence.checks.find((check) => check.id === 'staging-descriptor-contract')
+    assert.equal(stagingCheck.status, 'pass')
+    assert.equal(
+      stagingCheck.fieldsChecked,
+      Object.values(DEFAULT_STAGING_FIELDS).reduce((sum, fields) => sum + fields.length, 0),
+    )
     assert.ok(fake.requests.some((request) => request.pathname === '/api/auth/me' && request.authorization === 'Bearer test.jwt.token'))
     assert.ok(fake.requests.some((request) => request.pathname === '/api/integration/external-systems'))
     assert.ok(fake.requests.some((request) => request.pathname === '/api/integration/pipelines'))
@@ -489,6 +558,40 @@ test('authenticated postdeploy smoke fails when a required staging descriptor is
     const stagingCheck = evidence.checks.find((check) => check.id === 'staging-descriptor-contract')
     assert.equal(stagingCheck.status, 'fail')
     assert.match(stagingCheck.error, /missing staging descriptor integration_exceptions/)
+  } finally {
+    await fake.close()
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('authenticated postdeploy smoke fails when a required staging descriptor field is missing', async () => {
+  const fake = createFakeServer({
+    stagingDescriptors: DEFAULT_STAGING_DESCRIPTORS.map((descriptor) => {
+      if (descriptor.id !== 'standard_materials') return descriptor
+      return {
+        ...descriptor,
+        fields: descriptor.fields.filter((fieldId) => fieldId !== 'erpSyncStatus'),
+      }
+    }),
+  })
+  const baseUrl = await fake.listen()
+  const outDir = makeTmpDir()
+  try {
+    const result = await runScript([
+      '--base-url', baseUrl,
+      '--auth-token', 'test.jwt.token',
+      '--require-auth',
+      '--out-dir', outDir,
+    ])
+
+    assert.equal(result.status, 1)
+    const evidence = JSON.parse(readFileSync(path.join(outDir, 'integration-k3wise-postdeploy-smoke.json'), 'utf8'))
+    const stagingCheck = evidence.checks.find((check) => check.id === 'staging-descriptor-contract')
+    assert.equal(stagingCheck.status, 'fail')
+    assert.match(stagingCheck.error, /missing required fields/)
+    assert.deepEqual(stagingCheck.details.missingFields, {
+      standard_materials: ['erpSyncStatus'],
+    })
   } finally {
     await fake.close()
     rmSync(outDir, { recursive: true, force: true })

--- a/scripts/ops/integration-k3wise-postdeploy-summary.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-summary.mjs
@@ -73,6 +73,35 @@ function renderMissingSummary(inputPath) {
   ].join('\n')
 }
 
+function formatDetailValue(value) {
+  if (Array.isArray(value)) {
+    if (value.length === 0) return '`none`'
+    return value.map((item) => `\`${String(item)}\``).join(', ')
+  }
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value)
+      .filter(([, child]) => Array.isArray(child) ? child.length > 0 : child !== undefined && child !== null)
+      .map(([key, child]) => `${key}: ${formatDetailValue(child)}`)
+    return entries.length > 0 ? entries.join('; ') : '`none`'
+  }
+  return `\`${String(value)}\``
+}
+
+function summarizeCheckDetails(check) {
+  const details = check && check.details && typeof check.details === 'object' ? check.details : {}
+  const lines = []
+  for (const key of ['missingAdapters', 'missingRoutes', 'missingFields']) {
+    const value = details[key]
+    const hasValue = Array.isArray(value)
+      ? value.length > 0
+      : value && typeof value === 'object'
+        ? Object.keys(value).length > 0
+        : value !== undefined && value !== null && value !== ''
+    if (hasValue) lines.push(`    - ${key}: ${formatDetailValue(value)}`)
+  }
+  return lines
+}
+
 function renderEvidenceSummary(evidence) {
   const summary = evidence && typeof evidence === 'object' ? evidence.summary || {} : {}
   const checks = Array.isArray(evidence?.checks) ? evidence.checks : []
@@ -86,6 +115,9 @@ function renderEvidenceSummary(evidence) {
   ]
   for (const check of checks) {
     lines.push(`  - \`${check?.id || 'unknown'}\`: \`${check?.status || 'unknown'}\``)
+    if (check?.status === 'fail') {
+      lines.push(...summarizeCheckDetails(check))
+    }
   }
   if (checks.length === 0) {
     lines.push('  - `none`: `missing`')
@@ -141,8 +173,10 @@ if (entryPath && import.meta.url === entryPath) {
 
 export {
   K3WisePostdeploySummaryError,
+  formatDetailValue,
   parseArgs,
   renderEvidenceSummary,
   renderMissingSummary,
+  summarizeCheckDetails,
   runCli,
 }

--- a/scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
@@ -80,7 +80,14 @@ test('renders fail summary without failing the summary renderer', async () => {
       summary: { pass: 1, skipped: 0, fail: 1 },
       checks: [
         { id: 'api-health', status: 'pass' },
-        { id: 'integration-route-contract', status: 'fail' },
+        {
+          id: 'integration-route-contract',
+          status: 'fail',
+          details: {
+            missingAdapters: ['erp:k3-wise-webapi'],
+            missingRoutes: ['POST /api/integration/dead-letters/:id/replay'],
+          },
+        },
       ],
     })}\n`)
 
@@ -90,6 +97,42 @@ test('renders fail summary without failing the summary renderer', async () => {
     assert.match(result.stdout, /Status: \*\*FAIL\*\*/)
     assert.match(result.stdout, /Authenticated checks: `yes`/)
     assert.match(result.stdout, /`integration-route-contract`: `fail`/)
+    assert.match(result.stdout, /missingAdapters: `erp:k3-wise-webapi`/)
+    assert.match(result.stdout, /missingRoutes: `POST \/api\/integration\/dead-letters\/:id\/replay`/)
+  } finally {
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('renders staging missing field details for failed descriptor checks', async () => {
+  const outDir = makeTmpDir()
+  const evidencePath = path.join(outDir, 'evidence.json')
+  try {
+    writeFileSync(evidencePath, `${JSON.stringify({
+      ok: false,
+      baseUrl: 'http://127.0.0.1:8081',
+      authenticated: true,
+      summary: { pass: 3, skipped: 0, fail: 1 },
+      checks: [
+        {
+          id: 'staging-descriptor-contract',
+          status: 'fail',
+          details: {
+            missingFields: {
+              standard_materials: ['erpSyncStatus'],
+              integration_exceptions: ['errorMessage', 'status'],
+            },
+          },
+        },
+      ],
+    })}\n`)
+
+    const result = await runScript(['--input', evidencePath])
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stdout, /`staging-descriptor-contract`: `fail`/)
+    assert.match(result.stdout, /missingFields: standard_materials: `erpSyncStatus`/)
+    assert.match(result.stdout, /integration_exceptions: `errorMessage`, `status`/)
   } finally {
     rmSync(outDir, { recursive: true, force: true })
   }


### PR DESCRIPTION
## Summary
- Tighten K3 WISE postdeploy staging checks from descriptor-id presence to descriptor field-id contract validation.
- Require the staging field IDs used by the PLM-to-ERP cleansing workflow across raw PLM items, standard materials, BOM cleanse, exceptions, and run log sheets.
- Surface missing adapter/route/field details in the GitHub postdeploy summary so operators can see actionable failure details without downloading JSON artifacts.

## Design / Verification Docs
- `docs/development/integration-k3wise-staging-field-contract-design-20260429.md`
- `docs/development/integration-k3wise-staging-field-contract-verification-20260429.md`

## Verification
- `node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs` 11/11 pass
- `node --test scripts/ops/integration-k3wise-postdeploy-summary.test.mjs` 6/6 pass
- `node --test scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs` 2/2 pass
- `git diff --check` pass
- `git diff --cached --check` pass

## Notes
- Based on latest `origin/main` after #1250 (`592fe8a6c1ee5bd91f57df97537f35747f0cae8f`).
- This is read-only postdeploy smoke hardening. It does not change staging installation, pipeline execution, adapters, or live data mutation.
