### PR TITLE
test(dingtalk): include public form checks in P4 gate

### DIFF
--- a/docs/development/dingtalk-p4-regression-gate-publicform-mobile-design-20260429.md
+++ b/docs/development/dingtalk-p4-regression-gate-publicform-mobile-design-20260429.md
@@ -1,0 +1,42 @@
+# DingTalk P4 Regression Gate Public Form/Mobile Design - 2026-04-29
+
+## Goal
+
+Increase local pre-release coverage for the real DingTalk P4 acceptance path
+without introducing new live DingTalk or staging calls.
+
+Before this slice, the P4 regression gate covered backend public-form flow and
+several DingTalk admin UIs, but the `all` profile did not explicitly include:
+
+- public multitable form runtime UI behavior;
+- public-form mobile signoff tooling.
+
+Those two areas are directly used by final 142 validation, so they should be
+visible in the gate plan instead of relying on separate manual commands.
+
+## Design
+
+The gate now adds two existing tests:
+
+- `ops-mobile-signoff` in the `ops` profile:
+  `node --test scripts/ops/dingtalk-public-form-mobile-signoff.test.mjs`
+- `web-public-multitable-form` in the `product` profile:
+  `pnpm --filter @metasheet/web exec vitest run tests/public-multitable-form.spec.ts --watch=false`
+
+Because the `all` profile is defined as `ops + product`, it now includes both
+checks automatically.
+
+## Safety
+
+This slice only changes local regression-gate planning/execution. It does not
+call DingTalk, does not call 142, and does not store real webhook, signing
+secret, access token, JWT, or public-form token values.
+
+The runner keeps using the existing redacted summary/log pipeline.
+
+## Files
+
+- `scripts/ops/dingtalk-p4-regression-gate.mjs`
+- `scripts/ops/dingtalk-p4-regression-gate.test.mjs`
+- `docs/development/dingtalk-p4-regression-gate-publicform-mobile-design-20260429.md`
+- `docs/development/dingtalk-p4-regression-gate-publicform-mobile-verification-20260429.md`

--- a/docs/development/dingtalk-p4-regression-gate-publicform-mobile-verification-20260429.md
+++ b/docs/development/dingtalk-p4-regression-gate-publicform-mobile-verification-20260429.md
@@ -1,0 +1,40 @@
+# DingTalk P4 Regression Gate Public Form/Mobile Verification - 2026-04-29
+
+## Scope
+
+This document verifies that the P4 regression gate includes existing coverage
+for public form runtime UI and mobile signoff tooling.
+
+Changed files:
+
+- `scripts/ops/dingtalk-p4-regression-gate.mjs`
+- `scripts/ops/dingtalk-p4-regression-gate.test.mjs`
+- `docs/development/dingtalk-p4-regression-gate-publicform-mobile-design-20260429.md`
+- `docs/development/dingtalk-p4-regression-gate-publicform-mobile-verification-20260429.md`
+
+## Commands
+
+```bash
+node --test scripts/ops/dingtalk-p4-regression-gate.test.mjs
+node scripts/ops/dingtalk-p4-regression-gate.mjs --profile all --plan-only --output-dir output/dingtalk-p4-regression-gate/publicform-mobile-plan
+node --test scripts/ops/dingtalk-public-form-mobile-signoff.test.mjs
+cd apps/web
+../../node_modules/.bin/vitest run tests/public-multitable-form.spec.ts --watch=false
+cd ../..
+git diff --check
+git diff -- scripts/ops/dingtalk-p4-regression-gate.mjs scripts/ops/dingtalk-p4-regression-gate.test.mjs docs/development/dingtalk-p4-regression-gate-publicform-mobile-design-20260429.md docs/development/dingtalk-p4-regression-gate-publicform-mobile-verification-20260429.md \
+  | rg -v "rg -n" \
+  | rg -n "(access_token=[A-Za-z0-9]|SEC[0-9a-fA-F]{8,}|Authorization:|Bearer [A-Za-z0-9._-]{20,}|https://oapi\\.dingtalk\\.com/robot/send|JWT_SECRET|DINGTALK_APP_SECRET|publicToken=[A-Za-z0-9._~+/=-]{12,})" || true
+```
+
+## Results
+
+- Regression gate unit tests: passed, `6` tests.
+- `--profile all --plan-only`: passed, `25` checks planned.
+- Plan summary contains `ops-mobile-signoff`: yes.
+- Plan summary contains `web-public-multitable-form`: yes.
+- Mobile signoff tool tests: passed, `15` tests.
+- Public multitable form frontend tests: passed, `3` tests.
+- `git diff --check`: passed.
+- Diff secret scan: no matches after excluding the documented scan command
+  itself.

--- a/scripts/ops/dingtalk-p4-regression-gate.mjs
+++ b/scripts/ops/dingtalk-p4-regression-gate.mjs
@@ -60,6 +60,11 @@ const OPS_CHECKS = [
     command: ['node', '--test', 'scripts/ops/dingtalk-p4-final-docs.test.mjs'],
   },
   {
+    id: 'ops-mobile-signoff',
+    label: 'DingTalk public form mobile signoff tooling',
+    command: ['node', '--test', 'scripts/ops/dingtalk-public-form-mobile-signoff.test.mjs'],
+  },
+  {
     id: 'ops-diff-check',
     label: 'Git whitespace diff check',
     command: ['git', 'diff', '--check'],
@@ -177,6 +182,20 @@ const PRODUCT_CHECKS = [
       'vitest',
       'run',
       'tests/multitable-form-share-manager.spec.ts',
+      '--watch=false',
+    ],
+  },
+  {
+    id: 'web-public-multitable-form',
+    label: 'Web public multitable form DingTalk runtime UI',
+    command: [
+      'pnpm',
+      '--filter',
+      '@metasheet/web',
+      'exec',
+      'vitest',
+      'run',
+      'tests/public-multitable-form.spec.ts',
       '--watch=false',
     ],
   },

--- a/scripts/ops/dingtalk-p4-regression-gate.test.mjs
+++ b/scripts/ops/dingtalk-p4-regression-gate.test.mjs
@@ -45,10 +45,11 @@ test('dingtalk-p4-regression-gate writes an ops plan without executing checks', 
     assert.equal(summary.profile, 'ops')
     assert.equal(summary.planOnly, true)
     assert.equal(summary.overallStatus, 'plan_only')
-    assert.equal(summary.totals.total, 10)
-    assert.equal(summary.totals.skipped, 10)
+    assert.equal(summary.totals.total, 11)
+    assert.equal(summary.totals.skipped, 11)
     assert.ok(summary.checks.every((check) => check.status === 'skipped'))
     assert.ok(summary.checks.some((check) => check.command.includes('dingtalk-p4-smoke-session.test.mjs')))
+    assert.ok(summary.checks.some((check) => check.command.includes('dingtalk-public-form-mobile-signoff.test.mjs')))
 
     const markdown = readFileSync(markdownPath, 'utf8')
     assert.match(markdown, /DingTalk P4 Regression Gate/)
@@ -74,12 +75,36 @@ test('dingtalk-p4-regression-gate product plan covers org destination catalog ch
     assert.equal(summary.profile, 'product')
     assert.equal(summary.planOnly, true)
     assert.equal(summary.overallStatus, 'plan_only')
-    assert.equal(summary.totals.total, 13)
+    assert.equal(summary.totals.total, 14)
     assert.ok(summary.checks.every((check) => check.status === 'skipped'))
     assert.ok(summary.checks.some((check) => check.command.includes('dingtalk-group-destination-routes.api.test.ts')))
     assert.ok(summary.checks.some((check) => check.command.includes('automation-v1.test.ts')))
+    assert.ok(summary.checks.some((check) => check.command.includes('public-multitable-form.spec.ts')))
     assert.ok(summary.checks.some((check) => check.command.includes('multitable-automation-manager.spec.ts')))
     assert.ok(summary.checks.some((check) => check.command.includes('multitable-automation-rule-editor.spec.ts')))
+  } finally {
+    rmSync(outputDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-p4-regression-gate all plan includes public form runtime and mobile signoff coverage', () => {
+  const outputDir = makeTmpDir()
+
+  try {
+    const result = runScript([
+      '--profile', 'all',
+      '--plan-only',
+      '--output-dir', outputDir,
+    ])
+
+    assert.equal(result.status, 0, result.stderr || result.stdout)
+    const summary = readJson(path.join(outputDir, 'summary.json'))
+    assert.equal(summary.profile, 'all')
+    assert.equal(summary.planOnly, true)
+    assert.equal(summary.overallStatus, 'plan_only')
+    assert.equal(summary.totals.total, 25)
+    assert.ok(summary.checks.some((check) => check.id === 'ops-mobile-signoff'))
+    assert.ok(summary.checks.some((check) => check.id === 'web-public-multitable-form'))
   } finally {
     rmSync(outputDir, { recursive: true, force: true })
   }


### PR DESCRIPTION
## Summary
- Add the public-form mobile signoff tool test to the P4 regression gate `ops` profile.
- Add the public multitable form runtime UI test to the P4 regression gate `product` profile.
- Assert the `all` plan includes both `ops-mobile-signoff` and `web-public-multitable-form`.
- Add design and verification markdown for this regression-gate coverage slice.

## Verification
- `node --test scripts/ops/dingtalk-p4-regression-gate.test.mjs`: passed, 6 tests.
- `node scripts/ops/dingtalk-p4-regression-gate.mjs --profile all --plan-only --output-dir output/dingtalk-p4-regression-gate/publicform-mobile-plan`: passed, 25 checks planned and both new check IDs present.
- `node --test scripts/ops/dingtalk-public-form-mobile-signoff.test.mjs`: passed, 15 tests.
- `../../node_modules/.bin/vitest run tests/public-multitable-form.spec.ts --watch=false` from `apps/web`: passed, 3 tests.
- `git diff --check`: passed.
- Diff secret scan for DingTalk webhook/signing secret/JWT/app-secret/public-token patterns: no matches after excluding the documented scan command itself.

## Notes
- This does not call DingTalk or the 142 staging server.
- No webhook URLs, signing secrets, access tokens, JWTs, or real public form tokens are included.