### PR TITLE
test(integration): validate K3 staging field details

### DIFF
--- a/apps/web/src/services/integration/k3WiseSetup.ts
+++ b/apps/web/src/services/integration/k3WiseSetup.ts
@@ -106,6 +106,12 @@ export interface IntegrationStagingDescriptor {
   id: string
   name: string
   fields: string[]
+  fieldDetails?: Array<{
+    id: string
+    name: string
+    type: string
+    options?: string[]
+  }>
 }
 
 export interface IntegrationStagingInstallResult {

--- a/docs/development/integration-k3wise-staging-field-detail-contract-design-20260429.md
+++ b/docs/development/integration-k3wise-staging-field-detail-contract-design-20260429.md
@@ -1,0 +1,111 @@
+# K3 WISE Staging Field Detail Contract Design - 2026-04-29
+
+## Context
+
+PR `#1252` made the K3 WISE postdeploy smoke verify that the five integration
+staging descriptors expose all required field IDs. That closed the largest
+false-positive gap: a deployment could no longer pass while omitting
+`standard_materials.erpSyncStatus` or `integration_exceptions.errorMessage`.
+
+One residual risk remained. A field ID could exist with the wrong multitable
+type or an incomplete `select` option set. That would still break the operator
+workflow because status fields such as material lifecycle, ERP sync state,
+exception queue state, and run mode rely on exact select choices.
+
+## Design
+
+The integration plugin keeps the existing descriptor response contract:
+
+```json
+{
+  "id": "standard_materials",
+  "name": "Standard Materials",
+  "fields": ["code", "name", "status"]
+}
+```
+
+It now adds an additive `fieldDetails` array:
+
+```json
+{
+  "fieldDetails": [
+    { "id": "code", "name": "Material Code", "type": "string" },
+    {
+      "id": "status",
+      "name": "Status",
+      "type": "select",
+      "options": ["draft", "active", "obsolete"]
+    }
+  ]
+}
+```
+
+This avoids breaking existing consumers that expect `fields: string[]` while
+giving postdeploy smoke enough detail to validate the real staging contract.
+
+The exposed detail intentionally includes only:
+
+- `id`
+- `name`
+- `type`
+- `options` for select fields
+
+It does not expose `property.validation` yet. Required-field validation remains
+an internal provisioning concern until a user-facing contract needs it.
+
+## Postdeploy Guard
+
+`scripts/ops/integration-k3wise-postdeploy-smoke.mjs` now validates:
+
+- all required descriptor IDs.
+- all required field IDs.
+- each required field type.
+- required select options for status/mode fields.
+
+The validator remains tolerant of future rich `fields` responses. It can read
+field details from either:
+
+- `fieldDetails: [{ id, type, options }]`
+- `fields: [{ id, type, options }]`
+
+The plugin currently uses the safer additive `fieldDetails` shape.
+
+## Failure Evidence
+
+Descriptor failures now include two detail groups:
+
+```json
+{
+  "missingFields": {
+    "standard_materials": ["erpSyncStatus"]
+  },
+  "invalidFields": {
+    "standard_materials": {
+      "status": [
+        "expected type select but got string",
+        "missing options: active, obsolete"
+      ]
+    }
+  }
+}
+```
+
+The GitHub summary renderer prints `invalidFields` alongside existing
+`missingAdapters`, `missingRoutes`, and `missingFields` details.
+
+## Files
+
+- `plugins/plugin-integration-core/lib/staging-installer.cjs`
+- `plugins/plugin-integration-core/__tests__/staging-installer.test.cjs`
+- `plugins/plugin-integration-core/__tests__/http-routes.test.cjs`
+- `apps/web/src/services/integration/k3WiseSetup.ts`
+- `scripts/ops/integration-k3wise-postdeploy-smoke.mjs`
+- `scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs`
+- `scripts/ops/integration-k3wise-postdeploy-summary.mjs`
+- `scripts/ops/integration-k3wise-postdeploy-summary.test.mjs`
+
+## Compatibility
+
+This is an additive API change. Existing callers that render or compare
+`descriptor.fields` continue to receive the same string array. New callers can
+use `descriptor.fieldDetails` when they need field type or option metadata.

--- a/docs/development/integration-k3wise-staging-field-detail-contract-verification-20260429.md
+++ b/docs/development/integration-k3wise-staging-field-detail-contract-verification-20260429.md
@@ -1,0 +1,62 @@
+# K3 WISE Staging Field Detail Contract Verification - 2026-04-29
+
+## Local Verification
+
+Worktree:
+
+`/tmp/ms2-k3wise-staging-field-detail-20260429`
+
+Branch:
+
+`codex/k3wise-staging-field-detail-20260429`
+
+Baseline:
+
+`origin/main` at `a01d152bd0a6ede04cc022e75505e011ded94fad`
+
+Commands:
+
+```bash
+node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
+node --test scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
+node --test scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs
+node plugins/plugin-integration-core/__tests__/staging-installer.test.cjs
+node plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+pnpm --filter @metasheet/web exec vue-tsc --noEmit --project apps/web/tsconfig.app.json --skipLibCheck
+git diff --check
+```
+
+Results:
+
+- `integration-k3wise-postdeploy-smoke.test.mjs`: 12/12 passed.
+- `integration-k3wise-postdeploy-summary.test.mjs`: 6/6 passed.
+- `integration-k3wise-postdeploy-workflow-contract.test.mjs`: 2/2 passed.
+- `staging-installer.test.cjs`: passed.
+- `http-routes.test.cjs`: passed.
+- `pnpm --filter @metasheet/web type-check`: passed.
+- `git diff --check`: passed.
+
+## Regression Coverage
+
+Added coverage:
+
+- authenticated smoke success reports `fieldDetailsChecked` for every required
+  staging field.
+- wrong `standard_materials.status` type fails
+  `staging-descriptor-contract`.
+- incomplete `standard_materials.status` select options fail with exact missing
+  option names.
+- evidence includes nested `details.invalidFields`.
+- summary renderer prints `invalidFields`.
+- plugin descriptor summary keeps existing `fields: string[]`.
+- plugin descriptor summary exposes `fieldDetails` with select options.
+- route test confirms the new metadata is not stripped by the HTTP layer.
+- frontend service type accepts the additive field-detail contract.
+
+## Residual Risk
+
+The postdeploy smoke validates only fields that are required by the K3 WISE
+PoC staging contract. It does not try to prove every descriptor field property
+that multitable provisioning supports. That keeps the guard focused on the
+customer-runnable PLM-to-K3 workflow instead of turning it into a broad schema
+snapshot test.

--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -201,7 +201,15 @@ function createMockServices(overrides = {}) {
       listStagingDescriptors() {
         calls.push(['listStagingDescriptors'])
         return [
-          { id: 'standard_materials', name: 'Standard Materials', fields: ['code', 'name'] },
+          {
+            id: 'standard_materials',
+            name: 'Standard Materials',
+            fields: ['code', 'name'],
+            fieldDetails: [
+              { id: 'code', name: 'Material Code', type: 'string' },
+              { id: 'name', name: 'Material Name', type: 'string' },
+            ],
+          },
           { id: 'bom_cleanse', name: 'BOM Cleanse', fields: ['parentCode', 'childCode'] },
         ]
       },
@@ -633,6 +641,11 @@ async function testStagingRoutes() {
   })
   assertOkResponse(res, 200)
   assert.deepEqual(res.body.data.map((item) => item.id), ['standard_materials', 'bom_cleanse'])
+  assert.deepEqual(res.body.data[0].fieldDetails[0], {
+    id: 'code',
+    name: 'Material Code',
+    type: 'string',
+  })
   assert.equal(findCalls(calls, 'listStagingDescriptors').length, 1)
 
   res = await invoke(routes, 'POST', '/api/integration/staging/install', {

--- a/plugins/plugin-integration-core/__tests__/staging-installer.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/staging-installer.test.cjs
@@ -95,6 +95,13 @@ async function main() {
   const summary = listStagingDescriptors()
   assert.equal(summary.length, 5)
   assert.equal(typeof summary[0].fields[0], 'string')
+  assert.equal(summary[0].fieldDetails[0].id, 'sourceSystemId')
+  assert.equal(summary[0].fieldDetails[0].name, 'Source System')
+  assert.equal(summary[0].fieldDetails[0].type, 'string')
+  const standardMaterialsSummary = summary.find((d) => d.id === 'standard_materials')
+  const statusFieldSummary = standardMaterialsSummary.fieldDetails.find((f) => f.id === 'status')
+  assert.deepEqual(statusFieldSummary.options, ['draft', 'active', 'obsolete'])
+  assert.equal(statusFieldSummary.required, undefined, 'field details do not re-expose authoring-only required')
 
   // --- 1b. Required fields materialize into property.validation --------
   // Raw authored fields use `required: true`; the materialized descriptor

--- a/plugins/plugin-integration-core/lib/staging-installer.cjs
+++ b/plugins/plugin-integration-core/lib/staging-installer.cjs
@@ -207,11 +207,24 @@ async function installStaging({ context, projectId, baseId = null, logger } = {}
   return { sheetIds: result, warnings }
 }
 
+function summarizeField(field) {
+  const summary = {
+    id: field.id,
+    name: field.name,
+    type: field.type,
+  }
+  if (Array.isArray(field.options) && field.options.length > 0) {
+    summary.options = field.options.slice()
+  }
+  return summary
+}
+
 function listStagingDescriptors() {
   return STAGING_DESCRIPTORS.map((d) => ({
     id: d.id,
     name: d.name,
     fields: d.fields.map((f) => f.id),
+    fieldDetails: d.fields.map(summarizeField),
   }))
 }
 
@@ -223,6 +236,7 @@ module.exports = {
     isProvisioningAvailable,
     materializeField,
     materializeDescriptor,
+    summarizeField,
     RAW_DESCRIPTORS,
   },
 }

--- a/scripts/ops/integration-k3wise-postdeploy-smoke.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-smoke.mjs
@@ -41,69 +41,69 @@ const REQUIRED_STAGING_DESCRIPTORS = [
   'integration_exceptions',
   'integration_run_log',
 ]
-const REQUIRED_STAGING_FIELDS = {
-  plm_raw_items: [
-    'sourceSystemId',
-    'objectType',
-    'sourceId',
-    'revision',
-    'code',
-    'name',
-    'rawPayload',
-    'fetchedAt',
-    'pipelineRunId',
-  ],
-  standard_materials: [
-    'code',
-    'name',
-    'uom',
-    'category',
-    'status',
-    'erpSyncStatus',
-    'erpExternalId',
-    'erpBillNo',
-    'erpResponseCode',
-    'erpResponseMessage',
-    'lastSyncedAt',
-  ],
-  bom_cleanse: [
-    'parentCode',
-    'childCode',
-    'quantity',
-    'uom',
-    'sequence',
-    'revision',
-    'validFrom',
-    'validTo',
-    'status',
-  ],
-  integration_exceptions: [
-    'pipelineId',
-    'runId',
-    'idempotencyKey',
-    'errorCode',
-    'errorMessage',
-    'sourcePayload',
-    'transformedPayload',
-    'status',
-    'assignee',
-    'note',
-  ],
-  integration_run_log: [
-    'pipelineId',
-    'runId',
-    'mode',
-    'triggeredBy',
-    'status',
-    'rowsRead',
-    'rowsCleaned',
-    'rowsWritten',
-    'rowsFailed',
-    'durationMs',
-    'startedAt',
-    'finishedAt',
-    'errorSummary',
-  ],
+const REQUIRED_STAGING_FIELD_DETAILS = {
+  plm_raw_items: {
+    sourceSystemId: { type: 'string' },
+    objectType: { type: 'string' },
+    sourceId: { type: 'string' },
+    revision: { type: 'string' },
+    code: { type: 'string' },
+    name: { type: 'string' },
+    rawPayload: { type: 'string' },
+    fetchedAt: { type: 'date' },
+    pipelineRunId: { type: 'string' },
+  },
+  standard_materials: {
+    code: { type: 'string' },
+    name: { type: 'string' },
+    uom: { type: 'string' },
+    category: { type: 'string' },
+    status: { type: 'select', options: ['draft', 'active', 'obsolete'] },
+    erpSyncStatus: { type: 'select', options: ['pending', 'synced', 'failed'] },
+    erpExternalId: { type: 'string' },
+    erpBillNo: { type: 'string' },
+    erpResponseCode: { type: 'string' },
+    erpResponseMessage: { type: 'string' },
+    lastSyncedAt: { type: 'date' },
+  },
+  bom_cleanse: {
+    parentCode: { type: 'string' },
+    childCode: { type: 'string' },
+    quantity: { type: 'number' },
+    uom: { type: 'string' },
+    sequence: { type: 'number' },
+    revision: { type: 'string' },
+    validFrom: { type: 'date' },
+    validTo: { type: 'date' },
+    status: { type: 'select', options: ['draft', 'active', 'obsolete'] },
+  },
+  integration_exceptions: {
+    pipelineId: { type: 'string' },
+    runId: { type: 'string' },
+    idempotencyKey: { type: 'string' },
+    errorCode: { type: 'string' },
+    errorMessage: { type: 'string' },
+    sourcePayload: { type: 'string' },
+    transformedPayload: { type: 'string' },
+    status: { type: 'select', options: ['open', 'in_review', 'replayed', 'discarded'] },
+    assignee: { type: 'string' },
+    note: { type: 'string' },
+  },
+  integration_run_log: {
+    pipelineId: { type: 'string' },
+    runId: { type: 'string' },
+    mode: { type: 'select', options: ['incremental', 'full', 'manual', 'replay'] },
+    triggeredBy: { type: 'string' },
+    status: { type: 'select', options: ['pending', 'running', 'succeeded', 'partial', 'failed', 'cancelled'] },
+    rowsRead: { type: 'number' },
+    rowsCleaned: { type: 'number' },
+    rowsWritten: { type: 'number' },
+    rowsFailed: { type: 'number' },
+    durationMs: { type: 'number' },
+    startedAt: { type: 'date' },
+    finishedAt: { type: 'date' },
+    errorSummary: { type: 'string' },
+  },
 }
 const TOKEN_PATTERN = /([A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{16,}|Bearer\s+[A-Za-z0-9._-]{16,})/g
 
@@ -353,6 +353,35 @@ function assertStatusRoutes(statusBody) {
   return { adapters, adaptersChecked: REQUIRED_ADAPTERS.length, routesChecked: REQUIRED_ROUTES.length }
 }
 
+function collectDescriptorFields(descriptor) {
+  const fieldIds = new Set()
+  const fieldDetailsById = new Map()
+
+  const collect = (field, detailSource) => {
+    if (typeof field === 'string') {
+      fieldIds.add(field)
+      return
+    }
+    if (!field || typeof field !== 'object' || typeof field.id !== 'string' || !field.id) return
+    fieldIds.add(field.id)
+    if (detailSource) fieldDetailsById.set(field.id, field)
+  }
+
+  if (Array.isArray(descriptor.fields)) {
+    for (const field of descriptor.fields) collect(field, typeof field === 'object')
+  }
+  if (Array.isArray(descriptor.fieldDetails)) {
+    for (const field of descriptor.fieldDetails) collect(field, true)
+  }
+  return { fieldIds, fieldDetailsById }
+}
+
+function addInvalidField(invalidFields, descriptorId, fieldId, message) {
+  if (!invalidFields[descriptorId]) invalidFields[descriptorId] = {}
+  if (!invalidFields[descriptorId][fieldId]) invalidFields[descriptorId][fieldId] = []
+  invalidFields[descriptorId][fieldId].push(message)
+}
+
 function assertStagingDescriptors(body) {
   const data = body && body.data ? body.data : body
   if (!Array.isArray(data)) {
@@ -369,34 +398,48 @@ function assertStagingDescriptors(body) {
     }
   }
   const missingFields = {}
+  const invalidFields = {}
   let fieldsChecked = 0
+  let fieldDetailsChecked = 0
   for (const id of REQUIRED_STAGING_DESCRIPTORS) {
     const descriptor = descriptorsById.get(id)
-    const fieldIds = new Set(
-      Array.isArray(descriptor.fields)
-        ? descriptor.fields
-          .map((field) => {
-            if (typeof field === 'string') return field
-            if (field && typeof field.id === 'string') return field.id
-            return ''
-          })
-          .filter(Boolean)
-        : [],
-    )
-    const requiredFields = REQUIRED_STAGING_FIELDS[id] || []
+    const { fieldIds, fieldDetailsById } = collectDescriptorFields(descriptor)
+    const requiredFieldDetails = REQUIRED_STAGING_FIELD_DETAILS[id] || {}
+    const requiredFields = Object.keys(requiredFieldDetails)
     fieldsChecked += requiredFields.length
     const missing = requiredFields.filter((fieldId) => !fieldIds.has(fieldId))
     if (missing.length > 0) missingFields[id] = missing
+
+    for (const [fieldId, expected] of Object.entries(requiredFieldDetails)) {
+      const detail = fieldDetailsById.get(fieldId)
+      if (!detail) {
+        addInvalidField(invalidFields, id, fieldId, 'missing field detail')
+        continue
+      }
+      fieldDetailsChecked += 1
+      if (detail.type !== expected.type) {
+        addInvalidField(invalidFields, id, fieldId, `expected type ${expected.type} but got ${detail.type || 'missing'}`)
+      }
+      if (Array.isArray(expected.options)) {
+        const actualOptions = Array.isArray(detail.options) ? new Set(detail.options.map(String)) : new Set()
+        const missingOptions = expected.options.filter((option) => !actualOptions.has(option))
+        if (missingOptions.length > 0) {
+          addInvalidField(invalidFields, id, fieldId, `missing options: ${missingOptions.join(', ')}`)
+        }
+      }
+    }
   }
-  if (Object.keys(missingFields).length > 0) {
-    throw new K3WisePostdeploySmokeError('staging descriptors are missing required fields', {
+  if (Object.keys(missingFields).length > 0 || Object.keys(invalidFields).length > 0) {
+    throw new K3WisePostdeploySmokeError('staging descriptors do not match required field contract', {
       missingFields,
+      invalidFields,
     })
   }
   return {
     descriptors: ids,
     descriptorsChecked: REQUIRED_STAGING_DESCRIPTORS.length,
     fieldsChecked,
+    fieldDetailsChecked,
   }
 }
 

--- a/scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
@@ -32,76 +32,85 @@ const DEFAULT_ROUTES = [
   ['GET', '/api/integration/staging/descriptors'],
   ['POST', '/api/integration/staging/install'],
 ]
-const DEFAULT_STAGING_FIELDS = {
-  plm_raw_items: [
-    'sourceSystemId',
-    'objectType',
-    'sourceId',
-    'revision',
-    'code',
-    'name',
-    'rawPayload',
-    'fetchedAt',
-    'pipelineRunId',
-  ],
-  standard_materials: [
-    'code',
-    'name',
-    'uom',
-    'category',
-    'status',
-    'erpSyncStatus',
-    'erpExternalId',
-    'erpBillNo',
-    'erpResponseCode',
-    'erpResponseMessage',
-    'lastSyncedAt',
-  ],
-  bom_cleanse: [
-    'parentCode',
-    'childCode',
-    'quantity',
-    'uom',
-    'sequence',
-    'revision',
-    'validFrom',
-    'validTo',
-    'status',
-  ],
-  integration_exceptions: [
-    'pipelineId',
-    'runId',
-    'idempotencyKey',
-    'errorCode',
-    'errorMessage',
-    'sourcePayload',
-    'transformedPayload',
-    'status',
-    'assignee',
-    'note',
-  ],
-  integration_run_log: [
-    'pipelineId',
-    'runId',
-    'mode',
-    'triggeredBy',
-    'status',
-    'rowsRead',
-    'rowsCleaned',
-    'rowsWritten',
-    'rowsFailed',
-    'durationMs',
-    'startedAt',
-    'finishedAt',
-    'errorSummary',
-  ],
+const DEFAULT_STAGING_FIELD_DETAILS = {
+  plm_raw_items: {
+    sourceSystemId: { type: 'string' },
+    objectType: { type: 'string' },
+    sourceId: { type: 'string' },
+    revision: { type: 'string' },
+    code: { type: 'string' },
+    name: { type: 'string' },
+    rawPayload: { type: 'string' },
+    fetchedAt: { type: 'date' },
+    pipelineRunId: { type: 'string' },
+  },
+  standard_materials: {
+    code: { type: 'string' },
+    name: { type: 'string' },
+    uom: { type: 'string' },
+    category: { type: 'string' },
+    status: { type: 'select', options: ['draft', 'active', 'obsolete'] },
+    erpSyncStatus: { type: 'select', options: ['pending', 'synced', 'failed'] },
+    erpExternalId: { type: 'string' },
+    erpBillNo: { type: 'string' },
+    erpResponseCode: { type: 'string' },
+    erpResponseMessage: { type: 'string' },
+    lastSyncedAt: { type: 'date' },
+  },
+  bom_cleanse: {
+    parentCode: { type: 'string' },
+    childCode: { type: 'string' },
+    quantity: { type: 'number' },
+    uom: { type: 'string' },
+    sequence: { type: 'number' },
+    revision: { type: 'string' },
+    validFrom: { type: 'date' },
+    validTo: { type: 'date' },
+    status: { type: 'select', options: ['draft', 'active', 'obsolete'] },
+  },
+  integration_exceptions: {
+    pipelineId: { type: 'string' },
+    runId: { type: 'string' },
+    idempotencyKey: { type: 'string' },
+    errorCode: { type: 'string' },
+    errorMessage: { type: 'string' },
+    sourcePayload: { type: 'string' },
+    transformedPayload: { type: 'string' },
+    status: { type: 'select', options: ['open', 'in_review', 'replayed', 'discarded'] },
+    assignee: { type: 'string' },
+    note: { type: 'string' },
+  },
+  integration_run_log: {
+    pipelineId: { type: 'string' },
+    runId: { type: 'string' },
+    mode: { type: 'select', options: ['incremental', 'full', 'manual', 'replay'] },
+    triggeredBy: { type: 'string' },
+    status: { type: 'select', options: ['pending', 'running', 'succeeded', 'partial', 'failed', 'cancelled'] },
+    rowsRead: { type: 'number' },
+    rowsCleaned: { type: 'number' },
+    rowsWritten: { type: 'number' },
+    rowsFailed: { type: 'number' },
+    durationMs: { type: 'number' },
+    startedAt: { type: 'date' },
+    finishedAt: { type: 'date' },
+    errorSummary: { type: 'string' },
+  },
+}
+const DEFAULT_STAGING_FIELDS = Object.fromEntries(
+  Object.entries(DEFAULT_STAGING_FIELD_DETAILS).map(([descriptorId, fields]) => [descriptorId, Object.keys(fields)]),
+)
+function makeFieldDetails(descriptorId) {
+  return Object.entries(DEFAULT_STAGING_FIELD_DETAILS[descriptorId]).map(([id, detail]) => ({
+    id,
+    ...detail,
+  }))
 }
 const DEFAULT_STAGING_DESCRIPTORS = [
-  { id: 'plm_raw_items', name: 'PLM Raw Items', fields: DEFAULT_STAGING_FIELDS.plm_raw_items },
-  { id: 'standard_materials', name: 'Standard Materials', fields: DEFAULT_STAGING_FIELDS.standard_materials },
-  { id: 'bom_cleanse', name: 'BOM Cleanse', fields: DEFAULT_STAGING_FIELDS.bom_cleanse },
-  { id: 'integration_exceptions', name: 'Integration Exceptions', fields: DEFAULT_STAGING_FIELDS.integration_exceptions },
-  { id: 'integration_run_log', name: 'Integration Run Log', fields: DEFAULT_STAGING_FIELDS.integration_run_log },
+  { id: 'plm_raw_items', name: 'PLM Raw Items', fields: DEFAULT_STAGING_FIELDS.plm_raw_items, fieldDetails: makeFieldDetails('plm_raw_items') },
+  { id: 'standard_materials', name: 'Standard Materials', fields: DEFAULT_STAGING_FIELDS.standard_materials, fieldDetails: makeFieldDetails('standard_materials') },
+  { id: 'bom_cleanse', name: 'BOM Cleanse', fields: DEFAULT_STAGING_FIELDS.bom_cleanse, fieldDetails: makeFieldDetails('bom_cleanse') },
+  { id: 'integration_exceptions', name: 'Integration Exceptions', fields: DEFAULT_STAGING_FIELDS.integration_exceptions, fieldDetails: makeFieldDetails('integration_exceptions') },
+  { id: 'integration_run_log', name: 'Integration Run Log', fields: DEFAULT_STAGING_FIELDS.integration_run_log, fieldDetails: makeFieldDetails('integration_run_log') },
 ]
 
 function makeTmpDir() {
@@ -365,6 +374,7 @@ test('authenticated postdeploy smoke validates route and staging contracts witho
       stagingCheck.fieldsChecked,
       Object.values(DEFAULT_STAGING_FIELDS).reduce((sum, fields) => sum + fields.length, 0),
     )
+    assert.equal(stagingCheck.fieldDetailsChecked, stagingCheck.fieldsChecked)
     assert.ok(fake.requests.some((request) => request.pathname === '/api/auth/me' && request.authorization === 'Bearer test.jwt.token'))
     assert.ok(fake.requests.some((request) => request.pathname === '/api/integration/external-systems'))
     assert.ok(fake.requests.some((request) => request.pathname === '/api/integration/pipelines'))
@@ -571,6 +581,7 @@ test('authenticated postdeploy smoke fails when a required staging descriptor fi
       return {
         ...descriptor,
         fields: descriptor.fields.filter((fieldId) => fieldId !== 'erpSyncStatus'),
+        fieldDetails: descriptor.fieldDetails.filter((field) => field.id !== 'erpSyncStatus'),
       }
     }),
   })
@@ -588,9 +599,50 @@ test('authenticated postdeploy smoke fails when a required staging descriptor fi
     const evidence = JSON.parse(readFileSync(path.join(outDir, 'integration-k3wise-postdeploy-smoke.json'), 'utf8'))
     const stagingCheck = evidence.checks.find((check) => check.id === 'staging-descriptor-contract')
     assert.equal(stagingCheck.status, 'fail')
-    assert.match(stagingCheck.error, /missing required fields/)
+    assert.match(stagingCheck.error, /required field contract/)
     assert.deepEqual(stagingCheck.details.missingFields, {
       standard_materials: ['erpSyncStatus'],
+    })
+  } finally {
+    await fake.close()
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('authenticated postdeploy smoke fails when a required staging field detail is wrong', async () => {
+  const fake = createFakeServer({
+    stagingDescriptors: DEFAULT_STAGING_DESCRIPTORS.map((descriptor) => {
+      if (descriptor.id !== 'standard_materials') return descriptor
+      return {
+        ...descriptor,
+        fieldDetails: descriptor.fieldDetails.map((field) => {
+          if (field.id !== 'status') return field
+          return { ...field, type: 'string', options: ['draft'] }
+        }),
+      }
+    }),
+  })
+  const baseUrl = await fake.listen()
+  const outDir = makeTmpDir()
+  try {
+    const result = await runScript([
+      '--base-url', baseUrl,
+      '--auth-token', 'test.jwt.token',
+      '--require-auth',
+      '--out-dir', outDir,
+    ])
+
+    assert.equal(result.status, 1)
+    const evidence = JSON.parse(readFileSync(path.join(outDir, 'integration-k3wise-postdeploy-smoke.json'), 'utf8'))
+    const stagingCheck = evidence.checks.find((check) => check.id === 'staging-descriptor-contract')
+    assert.equal(stagingCheck.status, 'fail')
+    assert.deepEqual(stagingCheck.details.invalidFields, {
+      standard_materials: {
+        status: [
+          'expected type select but got string',
+          'missing options: active, obsolete',
+        ],
+      },
     })
   } finally {
     await fake.close()

--- a/scripts/ops/integration-k3wise-postdeploy-summary.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-summary.mjs
@@ -90,7 +90,7 @@ function formatDetailValue(value) {
 function summarizeCheckDetails(check) {
   const details = check && check.details && typeof check.details === 'object' ? check.details : {}
   const lines = []
-  for (const key of ['missingAdapters', 'missingRoutes', 'missingFields']) {
+  for (const key of ['missingAdapters', 'missingRoutes', 'missingFields', 'invalidFields']) {
     const value = details[key]
     const hasValue = Array.isArray(value)
       ? value.length > 0

--- a/scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
@@ -122,6 +122,14 @@ test('renders staging missing field details for failed descriptor checks', async
               standard_materials: ['erpSyncStatus'],
               integration_exceptions: ['errorMessage', 'status'],
             },
+            invalidFields: {
+              standard_materials: {
+                status: [
+                  'expected type select but got string',
+                  'missing options: active, obsolete',
+                ],
+              },
+            },
           },
         },
       ],
@@ -133,6 +141,7 @@ test('renders staging missing field details for failed descriptor checks', async
     assert.match(result.stdout, /`staging-descriptor-contract`: `fail`/)
     assert.match(result.stdout, /missingFields: standard_materials: `erpSyncStatus`/)
     assert.match(result.stdout, /integration_exceptions: `errorMessage`, `status`/)
+    assert.match(result.stdout, /invalidFields: standard_materials: status: `expected type select but got string`, `missing options: active, obsolete`/)
   } finally {
     rmSync(outDir, { recursive: true, force: true })
   }


### PR DESCRIPTION
## Summary

- keep staging descriptor `fields: string[]` compatible and add additive `fieldDetails` metadata with `id/name/type/options`
- harden K3 WISE postdeploy smoke to validate required staging field types and select options, not just field IDs
- render `invalidFields` in the postdeploy summary and sync the frontend staging descriptor type
- add design and verification docs for the field-detail contract

## Verification

- `node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs`
- `node --test scripts/ops/integration-k3wise-postdeploy-summary.test.mjs`
- `node --test scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs`
- `node plugins/plugin-integration-core/__tests__/staging-installer.test.cjs`
- `node plugins/plugin-integration-core/__tests__/http-routes.test.cjs`
- `pnpm --filter @metasheet/web type-check`
- `git diff --check`

## Docs

- `docs/development/integration-k3wise-staging-field-detail-contract-design-20260429.md`
- `docs/development/integration-k3wise-staging-field-detail-contract-verification-20260429.md`
