### PR TITLE
feat(integration): surface K3 staging descriptors in setup

### DIFF
--- a/apps/web/src/services/integration/k3WiseSetup.ts
+++ b/apps/web/src/services/integration/k3WiseSetup.ts
@@ -102,16 +102,18 @@ export interface IntegrationDeadLetter {
   updatedAt?: string | null
 }
 
+export interface IntegrationStagingFieldDetail {
+  id: string
+  name: string
+  type: string
+  options?: string[]
+}
+
 export interface IntegrationStagingDescriptor {
   id: string
   name: string
   fields: string[]
-  fieldDetails?: Array<{
-    id: string
-    name: string
-    type: string
-    options?: string[]
-  }>
+  fieldDetails?: IntegrationStagingFieldDetail[]
 }
 
 export interface IntegrationStagingInstallResult {
@@ -378,7 +380,10 @@ export function validateK3WiseSetupForm(form: K3WiseSetupForm): K3WiseSetupValid
   return issues
 }
 
-export function validateK3WisePipelineTemplateForm(form: K3WiseSetupForm): K3WiseSetupValidationIssue[] {
+export function validateK3WisePipelineTemplateForm(
+  form: K3WiseSetupForm,
+  descriptors: IntegrationStagingDescriptor[] = [],
+): K3WiseSetupValidationIssue[] {
   const issues: K3WiseSetupValidationIssue[] = []
   if (!trim(form.tenantId)) issues.push({ field: 'tenantId', message: 'tenantId is required' })
   if (!trim(form.sourceSystemId)) issues.push({ field: 'sourceSystemId', message: 'PLM source system ID is required' })
@@ -387,6 +392,15 @@ export function validateK3WisePipelineTemplateForm(form: K3WiseSetupForm): K3Wis
   if (!trim(form.bomPipelineName)) issues.push({ field: 'bomPipelineName', message: 'BOM pipeline name is required' })
   if (!trim(form.materialStagingObjectId)) issues.push({ field: 'materialStagingObjectId', message: 'Material staging object is required' })
   if (!trim(form.bomStagingObjectId)) issues.push({ field: 'bomStagingObjectId', message: 'BOM staging object is required' })
+  if (descriptors.length > 0) {
+    const descriptorIds = new Set(descriptors.map((descriptor) => descriptor.id))
+    if (trim(form.materialStagingObjectId) && !descriptorIds.has(trim(form.materialStagingObjectId))) {
+      issues.push({ field: 'materialStagingObjectId', message: 'Material staging object must match a loaded descriptor' })
+    }
+    if (trim(form.bomStagingObjectId) && !descriptorIds.has(trim(form.bomStagingObjectId))) {
+      issues.push({ field: 'bomStagingObjectId', message: 'BOM staging object must match a loaded descriptor' })
+    }
+  }
   return issues
 }
 
@@ -447,6 +461,32 @@ export function buildK3WiseStagingInstallPayload(form: K3WiseSetupForm): K3WiseS
     projectId: trim(form.projectId),
     ...(optionalString(form.baseId) ? { baseId: trim(form.baseId) } : {}),
   }
+}
+
+export function getIntegrationStagingFieldCount(descriptor: IntegrationStagingDescriptor): number {
+  return descriptor.fieldDetails?.length || descriptor.fields.length
+}
+
+export function formatIntegrationStagingDescriptorFieldSummary(descriptor: IntegrationStagingDescriptor): string {
+  const details = descriptor.fieldDetails || []
+  if (details.length === 0) return `${descriptor.fields.length} fields`
+  const selectFields = details
+    .filter((field) => field.type === 'select')
+    .map((field) => {
+      const optionCount = Array.isArray(field.options) ? field.options.length : 0
+      return `${field.id}(${optionCount})`
+    })
+  const typeCounts = details.reduce<Record<string, number>>((acc, field) => {
+    acc[field.type] = (acc[field.type] || 0) + 1
+    return acc
+  }, {})
+  const typeText = Object.entries(typeCounts)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([type, count]) => `${type}:${count}`)
+    .join(', ')
+  return selectFields.length > 0
+    ? `${details.length} fields · ${typeText} · select ${selectFields.join(', ')}`
+    : `${details.length} fields · ${typeText}`
 }
 
 export function getK3WisePipelineId(form: K3WiseSetupForm, target: K3WisePipelineTarget): string {

--- a/apps/web/src/views/IntegrationK3WiseSetupView.vue
+++ b/apps/web/src/views/IntegrationK3WiseSetupView.vue
@@ -59,8 +59,27 @@
         <div class="k3-setup__panel">
           <div class="k3-setup__panel-head">
             <h2>清洗链路</h2>
-            <span>draft</span>
+            <span>{{ stagingDescriptorLabel }}</span>
           </div>
+          <button
+            class="k3-setup__btn k3-setup__btn--full"
+            type="button"
+            :disabled="loadingStagingDescriptors"
+            @click="loadStagingDescriptors(false)"
+          >
+            {{ loadingStagingDescriptors ? '刷新中' : '刷新 Staging 契约' }}
+          </button>
+          <div v-if="stagingDescriptors.length" class="k3-setup__descriptor-list">
+            <div v-for="descriptor in stagingDescriptors" :key="descriptor.id" class="k3-setup__descriptor">
+              <div class="k3-setup__record-main">
+                <strong>{{ descriptor.name }}</strong>
+                <span class="k3-setup__badge">{{ getIntegrationStagingFieldCount(descriptor) }} fields</span>
+              </div>
+              <small>{{ descriptor.id }}</small>
+              <small>{{ formatIntegrationStagingDescriptorFieldSummary(descriptor) }}</small>
+            </div>
+          </div>
+          <div v-else class="k3-setup__empty">未加载 Staging 契约。</div>
           <button
             class="k3-setup__btn k3-setup__btn--full"
             type="button"
@@ -421,7 +440,12 @@
             </label>
             <label class="k3-setup__field">
               <span>物料 Staging 对象</span>
-              <input v-model.trim="form.materialStagingObjectId" autocomplete="off" />
+              <select v-if="stagingDescriptors.length" v-model="form.materialStagingObjectId">
+                <option v-for="descriptor in stagingDescriptors" :key="`material:${descriptor.id}`" :value="descriptor.id">
+                  {{ descriptor.id }}
+                </option>
+              </select>
+              <input v-else v-model.trim="form.materialStagingObjectId" autocomplete="off" />
             </label>
             <label class="k3-setup__field">
               <span>BOM Pipeline 名称</span>
@@ -433,7 +457,12 @@
             </label>
             <label class="k3-setup__field">
               <span>BOM Staging 对象</span>
-              <input v-model.trim="form.bomStagingObjectId" autocomplete="off" />
+              <select v-if="stagingDescriptors.length" v-model="form.bomStagingObjectId">
+                <option v-for="descriptor in stagingDescriptors" :key="`bom:${descriptor.id}`" :value="descriptor.id">
+                  {{ descriptor.id }}
+                </option>
+              </select>
+              <input v-else v-model.trim="form.bomStagingObjectId" autocomplete="off" />
             </label>
             <label class="k3-setup__field">
               <span>执行模式</span>
@@ -474,10 +503,13 @@ import {
   buildK3WiseSetupPayloads,
   buildK3WiseStagingInstallPayload,
   createDefaultK3WiseSetupForm,
+  formatIntegrationStagingDescriptorFieldSummary,
+  getIntegrationStagingFieldCount,
   getK3WisePipelineId,
   installIntegrationStaging,
   listIntegrationDeadLetters,
   listIntegrationPipelineRuns,
+  listIntegrationStagingDescriptors,
   listIntegrationSystems,
   runIntegrationPipeline,
   testIntegrationSystem,
@@ -491,6 +523,7 @@ import {
   type IntegrationDeadLetter,
   type IntegrationExternalSystem,
   type IntegrationPipelineRun,
+  type IntegrationStagingDescriptor,
   type K3WisePipelineTarget,
 } from '../services/integration/k3WiseSetup'
 
@@ -505,6 +538,7 @@ const installingStaging = ref(false)
 const creatingPipelines = ref(false)
 const runningPipeline = ref('')
 const observingPipeline = ref('')
+const loadingStagingDescriptors = ref(false)
 const observedPipelineTarget = ref<K3WisePipelineTarget>('material')
 const statusMessage = ref('')
 const statusKind = ref<'info' | 'success' | 'error'>('info')
@@ -514,14 +548,16 @@ const pipelineResult = ref('')
 const pipelineRunResult = ref('')
 const pipelineRuns = ref<IntegrationPipelineRun[]>([])
 const deadLetters = ref<IntegrationDeadLetter[]>([])
+const stagingDescriptors = ref<IntegrationStagingDescriptor[]>([])
 
 const savedSystems = computed(() => [...webApiSystems.value, ...sqlSystems.value])
 const validationIssues = computed(() => validateK3WiseSetupForm(form))
 const stagingIssues = computed(() => validateK3WiseStagingInstallForm(form))
-const pipelineIssues = computed(() => validateK3WisePipelineTemplateForm(form))
+const pipelineIssues = computed(() => validateK3WisePipelineTemplateForm(form, stagingDescriptors.value))
 const materialRunIssues = computed(() => validateK3WisePipelineRunForm(form, 'material'))
 const bomRunIssues = computed(() => validateK3WisePipelineRunForm(form, 'bom'))
 const observationSummary = computed(() => `${pipelineRuns.value.length} runs / ${deadLetters.value.length} open`)
+const stagingDescriptorLabel = computed(() => stagingDescriptors.value.length > 0 ? `${stagingDescriptors.value.length} descriptors` : 'not loaded')
 
 function setStatus(message: string, kind: 'info' | 'success' | 'error' = 'info'): void {
   statusMessage.value = message
@@ -626,6 +662,18 @@ async function testSqlServer(): Promise<void> {
   }
 }
 
+async function loadStagingDescriptors(silent = false): Promise<void> {
+  loadingStagingDescriptors.value = true
+  try {
+    stagingDescriptors.value = await listIntegrationStagingDescriptors()
+    if (!silent) setStatus('Staging 契约已刷新', 'success')
+  } catch (error) {
+    if (!silent) setStatus(formatError(error), 'error')
+  } finally {
+    loadingStagingDescriptors.value = false
+  }
+}
+
 async function installStagingTables(): Promise<void> {
   const issues = validateK3WiseStagingInstallForm(form)
   if (issues.length > 0) {
@@ -637,6 +685,7 @@ async function installStagingTables(): Promise<void> {
   try {
     const result = await installIntegrationStaging(buildK3WiseStagingInstallPayload(form))
     stagingResult.value = JSON.stringify(result, null, 2)
+    await loadStagingDescriptors(true)
     setStatus('Staging 多维表已安装或确认存在', result.warnings.length > 0 ? 'info' : 'success')
   } catch (error) {
     setStatus(formatError(error), 'error')
@@ -646,7 +695,7 @@ async function installStagingTables(): Promise<void> {
 }
 
 async function createPipelineTemplates(): Promise<void> {
-  const issues = validateK3WisePipelineTemplateForm(form)
+  const issues = validateK3WisePipelineTemplateForm(form, stagingDescriptors.value)
   if (issues.length > 0) {
     setStatus(issues[0].message, 'error')
     return
@@ -739,6 +788,7 @@ async function executePipeline(target: K3WisePipelineTarget, dryRun: boolean): P
 
 onMounted(() => {
   void loadSystems()
+  void loadStagingDescriptors(true)
 })
 </script>
 
@@ -981,6 +1031,34 @@ onMounted(() => {
   flex-direction: column;
   gap: 8px;
   margin-top: 12px;
+}
+
+.k3-setup__descriptor-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.k3-setup__descriptor {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  padding: 10px;
+  background: #f8fafc;
+}
+
+.k3-setup__descriptor strong,
+.k3-setup__descriptor small {
+  overflow-wrap: anywhere;
+}
+
+.k3-setup__descriptor small {
+  color: #64748b;
+  font-size: 12px;
 }
 
 .k3-setup__record-head,

--- a/apps/web/tests/k3WiseSetup.spec.ts
+++ b/apps/web/tests/k3WiseSetup.spec.ts
@@ -8,6 +8,8 @@ import {
   buildK3WiseSetupPayloads,
   buildK3WiseStagingInstallPayload,
   createDefaultK3WiseSetupForm,
+  formatIntegrationStagingDescriptorFieldSummary,
+  getIntegrationStagingFieldCount,
   getK3WisePipelineId,
   splitList,
   validateK3WisePipelineObservationForm,
@@ -163,7 +165,7 @@ describe('K3 WISE setup helpers', () => {
   })
 
   it('keeps the K3 WISE setup route behind the same admin feature as the nav entry', async () => {
-    const source = await readFile(new URL('../src/router/appRoutes.ts', import.meta.url), 'utf8')
+    const source = await readFile('src/router/appRoutes.ts', 'utf8')
 
     expect(source).toContain("path: '/integrations/k3-wise'")
     expect(source).toContain("titleZh: 'K3 WISE 对接'")
@@ -245,6 +247,38 @@ describe('K3 WISE setup helpers', () => {
     expect(() => buildK3WisePipelinePayloads(form)).toThrow('PLM source system ID is required')
   })
 
+  it('keeps pipeline staging object validation permissive until descriptors are loaded', () => {
+    const form = createDefaultK3WiseSetupForm()
+    Object.assign(form, {
+      tenantId: 'tenant_1',
+      sourceSystemId: 'plm_1',
+      webApiSystemId: 'k3_1',
+      materialStagingObjectId: 'custom_material_stage',
+      bomStagingObjectId: 'custom_bom_stage',
+    })
+
+    expect(validateK3WisePipelineTemplateForm(form)).toEqual([])
+  })
+
+  it('requires selected pipeline staging objects to match loaded descriptors', () => {
+    const form = createDefaultK3WiseSetupForm()
+    Object.assign(form, {
+      tenantId: 'tenant_1',
+      sourceSystemId: 'plm_1',
+      webApiSystemId: 'k3_1',
+      materialStagingObjectId: 'typo_materials',
+      bomStagingObjectId: 'bom_cleanse',
+    })
+
+    const messages = validateK3WisePipelineTemplateForm(form, [
+      { id: 'standard_materials', name: 'Standard Materials', fields: ['code'] },
+      { id: 'bom_cleanse', name: 'BOM Cleanse', fields: ['parentCode'] },
+    ]).map((issue) => issue.message)
+
+    expect(messages).toContain('Material staging object must match a loaded descriptor')
+    expect(messages).not.toContain('BOM staging object must match a loaded descriptor')
+  })
+
   it('builds staging install payloads from tenant and project scope', () => {
     const form = createDefaultK3WiseSetupForm()
     Object.assign(form, {
@@ -261,6 +295,35 @@ describe('K3 WISE setup helpers', () => {
       projectId: 'project_1',
       baseId: 'base_1',
     })
+  })
+
+  it('summarizes staging descriptor field details for the setup page preview', () => {
+    const descriptor = {
+      id: 'standard_materials',
+      name: 'Standard Materials',
+      fields: ['code', 'name', 'status'],
+      fieldDetails: [
+        { id: 'code', name: 'Material Code', type: 'string' },
+        { id: 'name', name: 'Material Name', type: 'string' },
+        { id: 'status', name: 'Status', type: 'select', options: ['draft', 'active', 'obsolete'] },
+      ],
+    }
+
+    expect(getIntegrationStagingFieldCount(descriptor)).toBe(3)
+    expect(formatIntegrationStagingDescriptorFieldSummary(descriptor)).toBe(
+      '3 fields · select:1, string:2 · select status(3)',
+    )
+  })
+
+  it('falls back to field ids when descriptor details are not available', () => {
+    const descriptor = {
+      id: 'legacy_descriptor',
+      name: 'Legacy Descriptor',
+      fields: ['code', 'name'],
+    }
+
+    expect(getIntegrationStagingFieldCount(descriptor)).toBe(2)
+    expect(formatIntegrationStagingDescriptorFieldSummary(descriptor)).toBe('2 fields')
   })
 
   it('requires project scope before staging install', () => {

--- a/docs/development/integration-k3wise-staging-descriptor-ui-design-20260429.md
+++ b/docs/development/integration-k3wise-staging-descriptor-ui-design-20260429.md
@@ -1,0 +1,59 @@
+# K3 WISE Staging Descriptor UI Guardrail Design - 2026-04-29
+
+## Context
+
+PR `#1254` exposed staging descriptor `fieldDetails` from the integration
+plugin and made postdeploy smoke validate field types and select options.
+That made the backend contract observable, but the K3 WISE setup page still
+treated pipeline feedback staging objects as free-text fields.
+
+An operator could therefore typo `standard_materials` or `bom_cleanse` and
+create draft pipelines pointing at a non-existent or stale feedback surface.
+The backend would only fail later when the pipeline attempted to write ERP
+feedback.
+
+## Design
+
+The setup page now consumes the existing read-only endpoint:
+
+`GET /api/integration/staging/descriptors`
+
+The page loads descriptors:
+
+- silently on mount, so the page can render with or without auth/route support.
+- after successful staging installation, so the preview reflects the latest
+  provisioned contract.
+- manually through `刷新 Staging 契约`.
+
+When descriptors are available:
+
+- the sidebar shows each descriptor name, logical id, field count, field type
+  breakdown, and select-option counts.
+- the material and BOM staging object fields become descriptor-backed selects.
+- pipeline-template validation rejects selected object IDs that do not match
+  the loaded descriptor set.
+
+When descriptors are unavailable:
+
+- the form keeps the previous free-text inputs.
+- validation remains permissive for custom or legacy staging object IDs.
+
+This keeps old deployments usable while turning the richer descriptor contract
+into direct setup-page guardrails when the endpoint is present.
+
+## Files
+
+- `apps/web/src/services/integration/k3WiseSetup.ts`
+- `apps/web/src/views/IntegrationK3WiseSetupView.vue`
+- `apps/web/tests/k3WiseSetup.spec.ts`
+
+## Operator Effect
+
+The K3 WISE page now answers two practical setup questions without asking the
+operator to inspect JSON:
+
+- which staging multitable objects are available.
+- which object ID will be used by material and BOM ERP feedback.
+
+The change is read-only until the operator clicks the existing install or
+pipeline creation buttons.

--- a/docs/development/integration-k3wise-staging-descriptor-ui-verification-20260429.md
+++ b/docs/development/integration-k3wise-staging-descriptor-ui-verification-20260429.md
@@ -1,0 +1,62 @@
+# K3 WISE Staging Descriptor UI Guardrail Verification - 2026-04-29
+
+## Local Verification
+
+Worktree:
+
+`/tmp/ms2-k3wise-next-20260429`
+
+Branch:
+
+`codex/k3wise-next-contract-20260429`
+
+Baseline:
+
+`origin/main` at `9b49c5333d2cfa1a2d01eeaa9e9078a60ff87763`
+
+Commands:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/k3WiseSetup.spec.ts --watch=false
+pnpm --filter @metasheet/web type-check
+node plugins/plugin-integration-core/__tests__/staging-installer.test.cjs
+node plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+git diff --check
+```
+
+Results:
+
+- `k3WiseSetup.spec.ts`: 19/19 passed.
+- `@metasheet/web type-check`: passed.
+- `staging-installer.test.cjs`: passed.
+- `http-routes.test.cjs`: passed.
+- `git diff --check`: passed.
+
+## Regression Coverage
+
+Added coverage:
+
+- descriptor field summaries render field count, type breakdown, and select
+  option counts.
+- descriptor summary falls back to legacy `fields: string[]` when
+  `fieldDetails` is absent.
+- pipeline staging object validation remains permissive before descriptors are
+  loaded.
+- pipeline staging object validation rejects typo IDs after descriptors are
+  loaded.
+
+Existing coverage preserved:
+
+- WebAPI and SQL Server setup payloads.
+- credential-preserving edits.
+- K3 numeric field validation.
+- route feature gating.
+- staging install payload validation.
+- pipeline payload, dry-run/run payload, and observation query validation.
+
+## Notes
+
+Running `pnpm install --offline --frozen-lockfile` was required in the temporary
+worktree because `node_modules` was absent. The install touched tracked
+workspace dependency links; those were restored before staging so the PR only
+contains source, test, and documentation changes.


### PR DESCRIPTION
## Summary

- load K3 integration staging descriptors in the setup page and show a compact read-only contract preview
- switch material/BOM staging object fields from free text to descriptor-backed selects when descriptors are loaded
- keep legacy/custom object IDs permissive when descriptors are unavailable
- validate selected staging object IDs against the loaded descriptor set before draft pipeline creation
- add design and verification docs for the UI guardrail

## Verification

- `pnpm --filter @metasheet/web exec vitest run tests/k3WiseSetup.spec.ts --watch=false`
- `pnpm --filter @metasheet/web type-check`
- `node plugins/plugin-integration-core/__tests__/staging-installer.test.cjs`
- `node plugins/plugin-integration-core/__tests__/http-routes.test.cjs`
- `git diff --check`

## Docs

- `docs/development/integration-k3wise-staging-descriptor-ui-design-20260429.md`
- `docs/development/integration-k3wise-staging-descriptor-ui-verification-20260429.md`
