### PR TITLE
feat(dingtalk): expose final input blocked count

### DIFF
--- a/docs/development/dingtalk-p4-final-input-blocked-count-design-20260429.md
+++ b/docs/development/dingtalk-p4-final-input-blocked-count-design-20260429.md
@@ -1,0 +1,32 @@
+# DingTalk P4 Final Input Blocked Count Design
+
+- Date: 2026-04-29
+- Branch: `codex/dingtalk-final-input-blocked-count-20260429`
+- Base: `origin/main` at `9b49c5333`
+- Scope: make the P4 final-input offline status report expose an explicit blocked-input count
+
+## Goal
+
+The existing final-input checker already reports `overallStatus` and `missingInputs[]`, but operators and downstream handoff docs have to infer the blocker count from array length. This slice adds a direct count so the current blocker volume can be copied into status updates without changing existing parsing contracts.
+
+## Design
+
+- Add top-level `blockedInputCount` to `scripts/ops/dingtalk-p4-final-input-status.mjs`.
+- Set `blockedInputCount` from `missingInputs.length` after all checks are evaluated.
+- Keep `schemaVersion: 1` because this is a backward-compatible additive field.
+- Keep `overallStatus`, `checks[]`, `missingInputs[]`, and `nextCommands[]` unchanged.
+- Render `Blocked Input Count` near `Overall Status` in the generated Markdown summary.
+- Keep all redaction behavior unchanged; the count does not expose token, webhook, robot secret, or private target values.
+
+## Compatibility
+
+- Existing consumers that read `missingInputs[]` continue to work.
+- New consumers can read `blockedInputCount` directly.
+- No network, 142 server, DingTalk, or database call is added.
+
+## Test Coverage
+
+- Blocked fixture asserts `blockedInputCount === missingInputs.length`.
+- Ready fixture asserts `blockedInputCount === 0`.
+- Markdown fixture asserts the rendered count is present.
+- Existing redaction and non-zero blocked exit behavior remains covered.

--- a/docs/development/dingtalk-p4-final-input-blocked-count-verification-20260429.md
+++ b/docs/development/dingtalk-p4-final-input-blocked-count-verification-20260429.md
@@ -1,0 +1,52 @@
+# DingTalk P4 Final Input Blocked Count Verification
+
+- Date: 2026-04-29
+- Branch: `codex/dingtalk-final-input-blocked-count-20260429`
+- Result: pass
+
+## Commands
+
+```bash
+node --check scripts/ops/dingtalk-p4-final-input-status.mjs
+node --check scripts/ops/dingtalk-p4-final-input-status.test.mjs
+node --test scripts/ops/dingtalk-p4-final-input-status.test.mjs
+```
+
+Synthetic CLI snapshot:
+
+```bash
+node scripts/ops/dingtalk-p4-final-input-status.mjs \
+  --env-file "$TMP_ENV" \
+  --output-json "$TMP_OUT/summary.json" \
+  --output-md "$TMP_OUT/summary.md" \
+  --allow-blocked
+node -e 'assert blockedInputCount matches missingInputs length and Markdown count'
+```
+
+Repository hygiene:
+
+```bash
+git diff --check
+git diff origin/main...HEAD -- \
+  scripts/ops/dingtalk-p4-final-input-status.mjs \
+  scripts/ops/dingtalk-p4-final-input-status.test.mjs \
+  docs/development/dingtalk-p4-final-input-blocked-count-design-20260429.md \
+  docs/development/dingtalk-p4-final-input-blocked-count-verification-20260429.md \
+  | rg -v "rg -n" \
+  | rg -n "(access_token=[A-Za-z0-9]|SEC[0-9a-fA-F]{8,}|Authorization:|Bearer [A-Za-z0-9._-]{20,}|https://oapi\\.dingtalk\\.com/robot/send|JWT_SECRET|DINGTALK_APP_SECRET|publicToken=[A-Za-z0-9._~+/=-]{12,})"
+```
+
+## Actual Results
+
+- Syntax check passed for the script.
+- Syntax check passed for the test file.
+- Node test runner passed 5/5 tests.
+- Synthetic blocked snapshot returned `blockedInputCount=6`.
+- Synthetic Markdown contained the same `Blocked Input Count` value.
+- No real webhook URL, robot signing secret, app token, public form token, or temporary password is stored in this document.
+
+## Non-Run Items
+
+- Real 142 release-readiness was not run from this slice.
+- Real DingTalk smoke was not started.
+- Private env outputs were not committed.

--- a/scripts/ops/dingtalk-p4-final-input-status.mjs
+++ b/scripts/ops/dingtalk-p4-final-input-status.mjs
@@ -206,6 +206,7 @@ function buildSummary(opts, values) {
     },
     checks: [],
     missingInputs: [],
+    blockedInputCount: 0,
     nextCommands: [],
   }
 
@@ -270,6 +271,7 @@ function buildSummary(opts, values) {
       label: check.label,
       remediation: check.remediation,
     }))
+  summary.blockedInputCount = summary.missingInputs.length
   summary.overallStatus = summary.missingInputs.length === 0 ? 'ready' : 'blocked'
   summary.nextCommands = buildNextCommands(opts.envFile, summary.overallStatus)
   return summary
@@ -296,6 +298,7 @@ function renderMarkdown(summary) {
     `- Generated At: ${summary.generatedAt}`,
     `- Env File: \`${summary.envFile}\``,
     `- Overall Status: \`${summary.overallStatus}\``,
+    `- Blocked Input Count: \`${summary.blockedInputCount}\``,
     '',
     '## Redacted Environment',
     '',

--- a/scripts/ops/dingtalk-p4-final-input-status.test.mjs
+++ b/scripts/ops/dingtalk-p4-final-input-status.test.mjs
@@ -65,6 +65,7 @@ test('dingtalk-p4-final-input-status reports blocked final inputs without leakin
 
     const summary = JSON.parse(summaryText)
     assert.equal(summary.overallStatus, 'blocked')
+    assert.equal(summary.blockedInputCount, summary.missingInputs.length)
     assert.equal(summary.environment.authTokenPresent, true)
     assert.match(summary.environment.groupAWebhook, /^https:\/\/oapi\.dingtalk\.com\/robot\/send\?<redacted>; \d+ chars$/)
     assert.ok(summary.missingInputs.some((item) => item.id === 'group-b-webhook-present'))
@@ -73,6 +74,7 @@ test('dingtalk-p4-final-input-status reports blocked final inputs without leakin
 
     const markdown = readFileSync(outputMd, 'utf8')
     assert.match(markdown, /Overall Status: `blocked`/)
+    assert.match(markdown, new RegExp(`Blocked Input Count: \`${summary.blockedInputCount}\``))
     assert.doesNotMatch(markdown, /robot-secret-a|secret-admin-token/)
   } finally {
     rmSync(tmpDir, { recursive: true, force: true })
@@ -110,6 +112,7 @@ test('dingtalk-p4-final-input-status passes complete final inputs', () => {
     const summary = readJson(outputJson)
     assert.equal(summary.overallStatus, 'ready')
     assert.equal(summary.missingInputs.length, 0)
+    assert.equal(summary.blockedInputCount, 0)
     assert.equal(summary.checks.every((check) => check.status === 'pass'), true)
     assert.equal(summary.nextCommands.some((command) => command.includes('--run-smoke-session')), true)
     assert.doesNotMatch(readFileSync(outputMd, 'utf8'), /robot-secret|secret-admin-token/)


### PR DESCRIPTION
## Summary
- add top-level `blockedInputCount` to the DingTalk P4 final-input status JSON
- render the same count in the generated Markdown summary
- add blocked/ready regression assertions plus design and verification docs

## Verification
- `node --check scripts/ops/dingtalk-p4-final-input-status.mjs`
- `node --check scripts/ops/dingtalk-p4-final-input-status.test.mjs`
- `node --test scripts/ops/dingtalk-p4-final-input-status.test.mjs`
- synthetic CLI snapshot verified `blockedInputCount === missingInputs.length` and Markdown count rendering
- `git diff --check`
- changed-file secret-pattern scan: no matches