### PR TITLE
feat(dingtalk): break down smoke todo progress

### DIFF
--- a/docs/development/dingtalk-p4-smoke-status-todo-breakdown-design-20260429.md
+++ b/docs/development/dingtalk-p4-smoke-status-todo-breakdown-design-20260429.md
@@ -1,0 +1,31 @@
+# DingTalk P4 Smoke Status TODO Breakdown Design
+
+- Date: 2026-04-29
+- Branch: `codex/dingtalk-smoke-status-todo-breakdown-20260429`
+- Base: `origin/main` at `54b08b3b6`
+- Scope: make generated remote-smoke status/TODO reports show manual-evidence and automated-check remaining work separately
+
+## Goal
+
+The generated P4 smoke status already reports aggregate remote-smoke progress, but operators still need to inspect every row to answer how much of the remaining work requires real DingTalk client/admin evidence versus rerunning automated/API bootstrap checks. This slice adds a direct breakdown so the next operator can prioritize manual phone/client work without guessing.
+
+## Design
+
+- Keep the existing `remoteSmokeTodos.total`, `completed`, `remaining`, and `items[]` contract unchanged.
+- Add `remoteSmokeTodos.manualEvidence` with `total`, `completed`, and `remaining`.
+- Add `remoteSmokeTodos.automatedChecks` with `total`, `completed`, and `remaining`.
+- Render the same breakdown in both generated status Markdown and executable TODO Markdown.
+- Treat each required check's existing `manual` flag as the source of truth.
+- Preserve all redaction behavior; the new fields are numeric counts only.
+
+## Compatibility
+
+- Existing JSON consumers can keep reading the aggregate progress and `items[]`.
+- New handoff/status consumers can read the manual-vs-automated breakdown directly.
+- No network, DingTalk, 142 server, database, or browser call is added.
+
+## Operator Impact
+
+- If `manualEvidence.remaining > 0`, real DingTalk client/admin evidence is still required.
+- If `automatedChecks.remaining > 0`, the next action is rerun/inspect API bootstrap or delivery-history evidence.
+- If both are `0` and aggregate `remaining` is `0`, the flow can proceed toward final closeout/handoff gates.

--- a/docs/development/dingtalk-p4-smoke-status-todo-breakdown-verification-20260429.md
+++ b/docs/development/dingtalk-p4-smoke-status-todo-breakdown-verification-20260429.md
@@ -1,0 +1,39 @@
+# DingTalk P4 Smoke Status TODO Breakdown Verification
+
+- Date: 2026-04-29
+- Branch: `codex/dingtalk-smoke-status-todo-breakdown-20260429`
+- Result: pass for local script/test coverage
+
+## Commands
+
+```bash
+node --check scripts/ops/dingtalk-p4-smoke-status.mjs
+node --check scripts/ops/dingtalk-p4-smoke-status.test.mjs
+node --test scripts/ops/dingtalk-p4-smoke-status.test.mjs
+git diff --check
+git diff origin/main...HEAD -- \
+  scripts/ops/dingtalk-p4-smoke-status.mjs \
+  scripts/ops/dingtalk-p4-smoke-status.test.mjs \
+  docs/development/dingtalk-p4-smoke-status-todo-breakdown-design-20260429.md \
+  docs/development/dingtalk-p4-smoke-status-todo-breakdown-verification-20260429.md \
+  | rg -v "rg -n" \
+  | rg -n "(access_token=[A-Za-z0-9]|SEC[0-9a-fA-F]{8,}|Authorization:|Bearer [A-Za-z0-9._-]{20,}|https://oapi\\.dingtalk\\.com/robot/send|JWT_SECRET|DINGTALK_APP_SECRET|publicToken=[A-Za-z0-9._~+/=-]{12,})"
+```
+
+## Actual Results
+
+- Script syntax check passed.
+- Test-file syntax check passed.
+- Node test runner passed 12/12 tests.
+- The bootstrap manual-pending fixture now asserts:
+  - `remoteSmokeTodos.manualEvidence = { total: 4, completed: 3, remaining: 1 }`
+  - `remoteSmokeTodos.automatedChecks = { total: 4, completed: 4, remaining: 0 }`
+- Generated status Markdown and TODO Markdown both include the manual-evidence and automated/API progress lines.
+- `git diff --check` passed.
+- Changed-file secret-pattern scan had no matches.
+
+## Non-Run Items
+
+- Real 142 remote smoke was not started.
+- Real DingTalk client/admin evidence was not collected.
+- No private env, webhook URL, robot signing secret, JWT, public form token, temporary password, or screenshot artifact was committed.

--- a/scripts/ops/dingtalk-p4-smoke-status.mjs
+++ b/scripts/ops/dingtalk-p4-smoke-status.mjs
@@ -683,11 +683,23 @@ function buildRemoteSmokeTodos(requiredChecks, opts) {
       evidenceRecordCommand: completed ? '' : evidenceRecordCommandForCheck(opts, check),
     }
   })
+  const manualItems = items.filter((item) => item.manual)
+  const automatedItems = items.filter((item) => !item.manual)
 
   return {
     total: items.length,
     completed: items.filter((item) => item.completed).length,
     remaining: items.filter((item) => !item.completed).length,
+    manualEvidence: {
+      total: manualItems.length,
+      completed: manualItems.filter((item) => item.completed).length,
+      remaining: manualItems.filter((item) => !item.completed).length,
+    },
+    automatedChecks: {
+      total: automatedItems.length,
+      completed: automatedItems.filter((item) => item.completed).length,
+      remaining: automatedItems.filter((item) => !item.completed).length,
+    },
     items,
   }
 }
@@ -931,6 +943,10 @@ ${checkRows.join('\n')}
 
 Progress: **${summary.remoteSmokeTodos.completed}/${summary.remoteSmokeTodos.total}** complete, **${summary.remoteSmokeTodos.remaining}** remaining.
 
+Manual evidence: **${summary.remoteSmokeTodos.manualEvidence.completed}/${summary.remoteSmokeTodos.manualEvidence.total}** complete, **${summary.remoteSmokeTodos.manualEvidence.remaining}** remaining.
+
+Automated/API checks: **${summary.remoteSmokeTodos.automatedChecks.completed}/${summary.remoteSmokeTodos.automatedChecks.total}** complete, **${summary.remoteSmokeTodos.automatedChecks.remaining}** remaining.
+
 | State | Check | Status | Manual | TODO |
 | --- | --- | --- | --- | --- |
 ${todoRows.join('\n')}
@@ -1010,6 +1026,10 @@ Overall status: **${summary.overallStatus}**
 Remote smoke phase: **${summary.remoteSmokePhase}**
 
 Progress: **${summary.remoteSmokeTodos.completed}/${summary.remoteSmokeTodos.total}** complete, **${summary.remoteSmokeTodos.remaining}** remaining.
+
+Manual evidence: **${summary.remoteSmokeTodos.manualEvidence.completed}/${summary.remoteSmokeTodos.manualEvidence.total}** complete, **${summary.remoteSmokeTodos.manualEvidence.remaining}** remaining.
+
+Automated/API checks: **${summary.remoteSmokeTodos.automatedChecks.completed}/${summary.remoteSmokeTodos.automatedChecks.total}** complete, **${summary.remoteSmokeTodos.automatedChecks.remaining}** remaining.
 
 ## Current Focus
 

--- a/scripts/ops/dingtalk-p4-smoke-status.test.mjs
+++ b/scripts/ops/dingtalk-p4-smoke-status.test.mjs
@@ -176,6 +176,16 @@ test('dingtalk-p4-smoke-status reports manual pending gaps for bootstrap session
     assert.equal(summary.requiredChecks.find((check) => check.id === 'authorized-user-submit').docSection, 'Smoke 4')
     assert.equal(summary.requiredChecks.find((check) => check.id === 'authorized-user-submit').evidenceSnapshot.authorizedUserId, 'user_authorized_001')
     assert.equal(summary.remoteSmokeTodos.remaining > 0, true)
+    assert.deepEqual(summary.remoteSmokeTodos.manualEvidence, {
+      total: 4,
+      completed: 3,
+      remaining: 1,
+    })
+    assert.deepEqual(summary.remoteSmokeTodos.automatedChecks, {
+      total: 4,
+      completed: 4,
+      remaining: 0,
+    })
     assert.equal(summary.executionPlan.activePhaseId, 'client-access')
     assert.equal(summary.executionPlan.currentFocus.checkId, 'authorized-user-submit')
     assert.equal(summary.remoteSmokeTodos.items.find((item) => item.id === 'authorized-user-submit').completed, false)
@@ -187,11 +197,15 @@ test('dingtalk-p4-smoke-status reports manual pending gaps for bootstrap session
     const statusMd = readFileSync(path.join(sessionDir, 'smoke-status.md'), 'utf8')
     assert.match(statusMd, /Ordered Execution Plan/)
     assert.match(statusMd, /Remote smoke phase: \*\*manual_pending\*\*/)
+    assert.match(statusMd, /Manual evidence: \*\*3\/4\*\* complete, \*\*1\*\* remaining\./)
+    assert.match(statusMd, /Automated\/API checks: \*\*4\/4\*\* complete, \*\*0\*\* remaining\./)
     assert.match(statusMd, /Top-level Remote Smoke Steps/)
     assert.match(statusMd, /Current focus:/)
     const todoText = readFileSync(path.join(sessionDir, 'smoke-todo.md'), 'utf8')
     assert.match(todoText, /Current Focus/)
     assert.match(todoText, /Remote smoke phase: \*\*manual_pending\*\*/)
+    assert.match(todoText, /Manual evidence: \*\*3\/4\*\* complete, \*\*1\*\* remaining\./)
+    assert.match(todoText, /Automated\/API checks: \*\*4\/4\*\* complete, \*\*0\*\* remaining\./)
     assert.match(todoText, /Ordered Phase Plan/)
     assert.match(todoText, /### 3\. Validate protected form access/)
     assert.match(todoText, /evidence-record\.mjs.*refresh automatically/)


### PR DESCRIPTION
## Summary
- add manual-evidence and automated/API progress breakdowns to DingTalk P4 smoke status JSON
- render the breakdown in generated smoke status and executable TODO Markdown
- add regression assertions plus design and verification docs

## Verification
- `node --check scripts/ops/dingtalk-p4-smoke-status.mjs`
- `node --check scripts/ops/dingtalk-p4-smoke-status.test.mjs`
- `node --test scripts/ops/dingtalk-p4-smoke-status.test.mjs`
- `git diff --check`
- changed-file secret-pattern scan: no matches