### PR TITLE
chore(dingtalk): scan packet secret assignments

### DIFF
--- a/docs/development/dingtalk-p4-packet-secret-assignment-scan-development-20260429.md
+++ b/docs/development/dingtalk-p4-packet-secret-assignment-scan-development-20260429.md
@@ -1,0 +1,31 @@
+# DingTalk P4 Packet Secret Assignment Scan Development
+
+- Date: 2026-04-29
+- Branch: `codex/dingtalk-packet-secret-assignment-scan-20260429`
+- Base: `origin/main` at `54b08b3b6`
+- Scope: harden staging evidence packet publish validation against raw token/password assignment leaks
+
+## Goal
+
+The staging evidence packet validator already rejects common webhook, bearer, JWT, `SEC...`, DingTalk client-secret, and public form token leaks. This slice extends the same publish-time safety gate to catch copied environment/admin notes that expose raw auth token or password assignments.
+
+## Changes
+
+- Added `auth_token_assignment` secret pattern for raw `DINGTALK_P4_AUTH_TOKEN`, `ADMIN_TOKEN`, and `AUTH_TOKEN` assignments.
+- Added `password_assignment` secret pattern for raw `password`, `temp_password`, `temporary_password`, and `temporary password` assignments.
+- Kept placeholders and safe redacted forms allowed, including `<redacted>`, `replace-me`, `changeme`, `example`, `$ENV_VAR`, `{...}`, and `<...>` values.
+- Added regression coverage that writes raw token/password assignments into a packet artifact and verifies the validator fails.
+- Preserved report safety by asserting `publish-check.json` contains redacted previews only.
+
+## Compatibility
+
+- Generated exporter packets still pass.
+- Existing mobile signoff packet validation remains covered.
+- No network, 142 server, DingTalk, browser, or database call is added.
+- Existing `secretFindings[]` schema is unchanged; only new `pattern` names can appear.
+
+## Security Boundary
+
+- This is a preventive publish gate. It does not prove every possible secret string is absent.
+- The validator continues to skip large files over the existing scan byte limit and binary-looking files.
+- Human review is still required before sharing raw screenshots or evidence externally.

--- a/docs/development/dingtalk-p4-packet-secret-assignment-scan-verification-20260429.md
+++ b/docs/development/dingtalk-p4-packet-secret-assignment-scan-verification-20260429.md
@@ -1,0 +1,39 @@
+# DingTalk P4 Packet Secret Assignment Scan Verification
+
+- Date: 2026-04-29
+- Branch: `codex/dingtalk-packet-secret-assignment-scan-20260429`
+- Result: pass
+
+## Commands
+
+```bash
+node --check scripts/ops/validate-dingtalk-staging-evidence-packet.mjs
+node --check scripts/ops/validate-dingtalk-staging-evidence-packet.test.mjs
+node --test scripts/ops/validate-dingtalk-staging-evidence-packet.test.mjs
+node --test scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs scripts/ops/validate-dingtalk-staging-evidence-packet.test.mjs
+git diff --check
+git diff origin/main...HEAD -- \
+  scripts/ops/validate-dingtalk-staging-evidence-packet.mjs \
+  scripts/ops/validate-dingtalk-staging-evidence-packet.test.mjs \
+  docs/development/dingtalk-p4-packet-secret-assignment-scan-development-20260429.md \
+  docs/development/dingtalk-p4-packet-secret-assignment-scan-verification-20260429.md \
+  | rg -v "rg -n" \
+  | rg -n "(access_token=[A-Za-z0-9]|SEC[0-9a-fA-F]{8,}|Authorization:|Bearer [A-Za-z0-9._-]{20,}|https://oapi\\.dingtalk\\.com/robot/send|JWT_SECRET|DINGTALK_APP_SECRET|publicToken=[A-Za-z0-9._~+/=-]{12,})"
+```
+
+## Actual Results
+
+- Script syntax check passed.
+- Test-file syntax check passed.
+- Validator test runner passed 15/15 tests.
+- Combined exporter plus validator test runner passed.
+- New regression rejects raw auth token and password assignments inside packet artifacts.
+- `publish-check.json` regression confirms raw token/password values are not written to the report.
+- `git diff --check` passed.
+- Changed-file secret-pattern scan had no matches.
+
+## Non-Run Items
+
+- Real 142 remote smoke was not started.
+- Real DingTalk client/admin evidence was not collected.
+- No private env, webhook URL, robot signing secret, JWT, public form token, temporary password, or screenshot artifact was committed.

--- a/scripts/ops/validate-dingtalk-staging-evidence-packet.mjs
+++ b/scripts/ops/validate-dingtalk-staging-evidence-packet.mjs
@@ -60,6 +60,14 @@ const SECRET_PATTERNS = [
     regex: /\b(?:DINGTALK_CLIENT_SECRET|DINGTALK_STATE_SECRET|client_secret)\s*=\s*(?!<redacted>|replace-me|\$|\s|$)[^\s&"'`<>]{8,}/gi,
   },
   {
+    name: 'auth_token_assignment',
+    regex: /\b(?:DINGTALK_P4_AUTH_TOKEN|ADMIN_TOKEN|AUTH_TOKEN)\s*(?:=|:)\s*["']?(?!<redacted>|redacted|replace-me|changeme|example|\$|\{|<|\s|$)[A-Za-z0-9._~+/=-]{16,}/gi,
+  },
+  {
+    name: 'password_assignment',
+    regex: /\b(?:temporary\s+password|temp(?:orary)?_?password|password)\s*(?:=|:)\s*["']?(?!<redacted>|redacted|replace-me|changeme|example|\$|\{|<|\s|$)[^\s"'`<>]{8,}/gi,
+  },
+  {
     name: 'public_form_token',
     regex: /\bpublicToken=(?!<redacted>|\$)[A-Za-z0-9._~+/=-]{12,}/gi,
   },

--- a/scripts/ops/validate-dingtalk-staging-evidence-packet.test.mjs
+++ b/scripts/ops/validate-dingtalk-staging-evidence-packet.test.mjs
@@ -482,6 +482,45 @@ test('validate-dingtalk-staging-evidence-packet rejects secret-like raw evidence
   }
 })
 
+test('validate-dingtalk-staging-evidence-packet rejects raw token and password assignments', () => {
+  const tmpDir = makeTmpDir()
+  const packetDir = path.join(tmpDir, 'packet')
+  const reportPath = path.join(tmpDir, 'publish-check.json')
+
+  try {
+    const evidenceDir = writePacket(packetDir)
+    mkdirSync(path.join(evidenceDir, 'workspace', 'artifacts', 'no-email-user-create-bind'), { recursive: true })
+    writeFileSync(
+      path.join(evidenceDir, 'workspace', 'artifacts', 'no-email-user-create-bind', 'admin-note.txt'),
+      [
+        'DINGTALK_P4_AUTH_TOKEN=token-value-0123456789abcdef',
+        'ADMIN_TOKEN: admin-token-0123456789abcdef',
+        'temporary password: PlainTempPassword123',
+        'password=<redacted>',
+        'AUTH_TOKEN=$DINGTALK_P4_AUTH_TOKEN',
+      ].join('\n'),
+      'utf8',
+    )
+
+    const result = runValidator(['--packet-dir', packetDir, '--output-json', reportPath])
+
+    assert.equal(result.status, 1)
+    assert.match(result.stderr, /auth_token_assignment/)
+    assert.match(result.stderr, /password_assignment/)
+    const reportText = readFileSync(reportPath, 'utf8')
+    assert.doesNotMatch(reportText, /token-value-0123456789abcdef/)
+    assert.doesNotMatch(reportText, /admin-token-0123456789abcdef/)
+    assert.doesNotMatch(reportText, /PlainTempPassword123/)
+    const report = JSON.parse(reportText)
+    assert.equal(report.secretFindings.some((finding) => finding.pattern === 'auth_token_assignment'), true)
+    assert.equal(report.secretFindings.some((finding) => finding.pattern === 'password_assignment'), true)
+    assert.equal(report.secretFindings.some((finding) => finding.preview.includes('token-value')), false)
+    assert.equal(report.secretFindings.some((finding) => finding.preview.includes('PlainTempPassword123')), false)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
 test('validate-dingtalk-staging-evidence-packet rejects unknown arguments', () => {
   const result = runValidator(['--unknown'])
 


### PR DESCRIPTION
## Summary
- extend DingTalk staging evidence packet publish validation to reject raw auth token assignments
- reject raw password and temporary-password assignments while allowing placeholders/redacted values
- add regression coverage and design/verification docs

## Verification
- `node --check scripts/ops/validate-dingtalk-staging-evidence-packet.mjs`
- `node --check scripts/ops/validate-dingtalk-staging-evidence-packet.test.mjs`
- `node --test scripts/ops/validate-dingtalk-staging-evidence-packet.test.mjs`
- `node --test scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs scripts/ops/validate-dingtalk-staging-evidence-packet.test.mjs`
- `git diff --check`
- changed-file secret-pattern scan: no matches