### PR TITLE
feat(dingtalk): summarize preflight check totals

### DIFF
--- a/docs/development/dingtalk-p4-smoke-preflight-totals-design-20260429.md
+++ b/docs/development/dingtalk-p4-smoke-preflight-totals-design-20260429.md
@@ -1,0 +1,18 @@
+# DingTalk P4 Smoke Preflight Totals Design
+
+Date: 2026-04-29
+
+## Goal
+
+Make the DingTalk P4 smoke preflight output easier to triage by exposing a direct check-count summary before operators run the remote smoke and manual evidence steps.
+
+## Change
+
+- Add a `totals` object to `preflight-summary.json` with `total`, `passed`, `failed`, and `skipped` counts.
+- Render the same counts in `preflight-summary.md` immediately under `Overall status`.
+- Keep the overall pass/fail semantics unchanged: only `fail` checks fail the preflight; `skipped` checks remain visible follow-up work.
+- Preserve existing redaction behavior for bearer tokens, robot webhooks, SEC secrets, JWTs, public tokens, timestamps, signatures, and passwords.
+
+## Operator Impact
+
+The preflight report now answers "how much is left" without requiring manual row counting. A report such as `7/11 passed, 1 failed, 3 skipped` means the blocking item must be fixed before remote smoke, while skipped items are still explicit release follow-up evidence.

--- a/docs/development/dingtalk-p4-smoke-preflight-totals-verification-20260429.md
+++ b/docs/development/dingtalk-p4-smoke-preflight-totals-verification-20260429.md
@@ -1,0 +1,24 @@
+# DingTalk P4 Smoke Preflight Totals Verification
+
+Date: 2026-04-29
+
+## Scope
+
+Verified the `dingtalk-p4-smoke-preflight` totals summary for JSON and Markdown outputs.
+
+## Local Checks
+
+- `node --check scripts/ops/dingtalk-p4-smoke-preflight.mjs` passed.
+- `node --check scripts/ops/dingtalk-p4-smoke-preflight.test.mjs` passed.
+- `node --test scripts/ops/dingtalk-p4-smoke-preflight.test.mjs` passed: 9 tests, 9 passed.
+- `git diff --check` passed.
+
+## Assertions Added
+
+- Fully valid input produces `total=11`, `passed=11`, `failed=0`, `skipped=0`.
+- Missing required manual targets with `--skip-api` produces `total=11`, `passed=7`, `failed=1`, `skipped=3`.
+- Markdown includes the same totals line shown near the top of the report.
+
+## Secret Handling
+
+The changed script and documentation do not include real DingTalk webhook URLs, robot secrets, bearer tokens, JWTs, SEC secrets, public tokens, or passwords.

--- a/scripts/ops/dingtalk-p4-smoke-preflight.mjs
+++ b/scripts/ops/dingtalk-p4-smoke-preflight.mjs
@@ -312,6 +312,15 @@ function hasFailure(summary) {
   return summary.checks.some((check) => check.status === 'fail')
 }
 
+function summarizeChecks(checks) {
+  return {
+    total: checks.length,
+    passed: checks.filter((check) => check.status === 'pass').length,
+    failed: checks.filter((check) => check.status === 'fail').length,
+    skipped: checks.filter((check) => check.status === 'skipped').length,
+  }
+}
+
 function validateBaseUrls(opts, summary) {
   try {
     opts.apiBase = normalizeUrl(opts.apiBase)
@@ -613,6 +622,8 @@ Generated at: ${summary.generatedAt}
 
 Overall status: **${summary.overallStatus}**
 
+Check totals: **${summary.totals.passed}/${summary.totals.total}** passed, **${summary.totals.failed}** failed, **${summary.totals.skipped}** skipped.
+
 ## Checks
 
 | ID | Check | Status | Notes |
@@ -660,6 +671,12 @@ async function runPreflight(opts) {
       manualTargets: {},
     },
     checks: [],
+    totals: {
+      total: 0,
+      passed: 0,
+      failed: 0,
+      skipped: 0,
+    },
     overallStatus: 'fail',
   }
 
@@ -686,6 +703,7 @@ async function runPreflight(opts) {
     personUserCount: opts.personUserIds.length,
     manualTargets: manualTargets(opts),
   }
+  summary.totals = summarizeChecks(summary.checks)
   summary.overallStatus = hasFailure(summary) ? 'fail' : 'pass'
 
   const outputDir = opts.outputDir ?? path.resolve(process.cwd(), DEFAULT_OUTPUT_ROOT, runId)

--- a/scripts/ops/dingtalk-p4-smoke-preflight.test.mjs
+++ b/scripts/ops/dingtalk-p4-smoke-preflight.test.mjs
@@ -153,6 +153,9 @@ test('dingtalk-p4-smoke-preflight passes with valid inputs and redacts secrets',
 
     const summary = JSON.parse(summaryText)
     assert.equal(summary.overallStatus, 'pass')
+    assert.deepEqual(summary.totals, { total: 11, passed: 11, failed: 0, skipped: 0 })
+    const summaryMarkdown = readFileSync(path.join(outputDir, 'preflight-summary.md'), 'utf8')
+    assert.match(summaryMarkdown, /Check totals: \*\*11\/11\*\* passed, \*\*0\*\* failed, \*\*0\*\* skipped\./)
     const byId = new Map(summary.checks.map((check) => [check.id, check]))
     assert.equal(byId.get('local-tools-present').status, 'pass')
     assert.equal(byId.get('api-health').status, 'pass')
@@ -286,6 +289,7 @@ test('dingtalk-p4-smoke-preflight can require manual target identities', () => {
     const summary = JSON.parse(readFileSync(path.join(outputDir, 'preflight-summary.json'), 'utf8'))
     const check = summary.checks.find((entry) => entry.id === 'manual-targets-declared')
     assert.equal(summary.overallStatus, 'fail')
+    assert.deepEqual(summary.totals, { total: 11, passed: 7, failed: 1, skipped: 3 })
     assert.equal(check.status, 'fail')
     assert.deepEqual(check.details.missing, ['unauthorized user', 'no-email DingTalk external id'])
   } finally {


### PR DESCRIPTION
## Summary
- Add JSON totals for DingTalk P4 smoke preflight checks.
- Render passed/total/failed/skipped counts in the preflight Markdown report.
- Add regression coverage and design/verification notes for operator triage.

## Verification
- node --check scripts/ops/dingtalk-p4-smoke-preflight.mjs
- node --check scripts/ops/dingtalk-p4-smoke-preflight.test.mjs
- node --test scripts/ops/dingtalk-p4-smoke-preflight.test.mjs
- git diff --check
- targeted secret-pattern scan on production script and docs, excluding documented placeholders