### PR TITLE
ci(attendance): avoid pipefail false red in docker GC summary

### DIFF
--- a/.github/workflows/attendance-remote-docker-gc-prod.yml
+++ b/.github/workflows/attendance-remote-docker-gc-prod.yml
@@ -184,10 +184,10 @@ jobs:
           else
             block="$(
               awk '
-                /^=== DOCKER GC START ===$/ { printing=1; next }
+                /^=== DOCKER GC START ===$/ { printing=1; count=0; next }
                 /^=== DOCKER GC END ===$/ { printing=0 }
-                printing { print }
-              ' "$gc_log" | head -n 120
+                printing && count < 120 { print; count++ }
+              ' "$gc_log"
             )"
             echo "" >> "$GITHUB_STEP_SUMMARY"
             echo '```' >> "$GITHUB_STEP_SUMMARY"

--- a/docs/development/attendance-remote-docker-gc-summary-pipefail-design-20260429.md
+++ b/docs/development/attendance-remote-docker-gc-summary-pipefail-design-20260429.md
@@ -1,0 +1,46 @@
+# Attendance Remote Docker GC Summary Pipefail Design - 2026-04-29
+
+## Context
+
+`Attendance Remote Docker GC (Prod)` successfully reclaimed deploy-host disk
+space after the root filesystem reached 100% usage. The remote GC step returned
+`gc_rc=0` and reclaimed `37.31GB`, lowering `/` from 100% to 41%.
+
+The workflow still ended red because the local summary step used this shape:
+
+```bash
+awk '...' "$gc_log" | head -n 120
+```
+
+With `set -euo pipefail`, `head` can exit after consuming the requested lines
+and leave `awk` with `SIGPIPE` (`141`). That makes a successful maintenance run
+look failed.
+
+## Design
+
+Keep the change summary-only:
+
+- do not change SSH, Docker prune, artifact upload, or final `gc_rc` semantics.
+- remove the pipe to `head` from the summary snippet extraction.
+- enforce the 120-line cap inside the single `awk` program.
+
+The new extraction is:
+
+```bash
+awk '
+  /^=== DOCKER GC START ===$/ { printing=1; count=0; next }
+  /^=== DOCKER GC END ===$/ { printing=0 }
+  printing && count < 120 { print; count++ }
+' "$gc_log"
+```
+
+## Files
+
+- `.github/workflows/attendance-remote-docker-gc-prod.yml`
+- `scripts/ops/attendance-remote-docker-gc-workflow-contract.test.mjs`
+
+## Non-Goals
+
+- No change to which Docker resources are pruned.
+- No change to deploy workflow behavior.
+- No change to storage thresholds or runbook links.

--- a/docs/development/attendance-remote-docker-gc-summary-pipefail-verification-20260429.md
+++ b/docs/development/attendance-remote-docker-gc-summary-pipefail-verification-20260429.md
@@ -1,0 +1,56 @@
+# Attendance Remote Docker GC Summary Pipefail Verification - 2026-04-29
+
+## Local Verification
+
+Worktree:
+
+`/tmp/ms2-remote-gc-summary-fix-20260429`
+
+Branch:
+
+`codex/remote-gc-summary-pipefail-20260429`
+
+Baseline:
+
+`origin/main` at `54b08b3b6cb6cc6c40aca89f0b38d35be30fd38b`
+
+Commands:
+
+```bash
+node --test scripts/ops/attendance-remote-docker-gc-workflow-contract.test.mjs
+rg -n "\\| head -n 120" .github/workflows/attendance-remote-docker-gc-prod.yml
+ruby -e 'require "yaml"; YAML.load_file(".github/workflows/attendance-remote-docker-gc-prod.yml"); puts "workflow yaml ok"'
+git diff --check
+```
+
+Results:
+
+- `attendance-remote-docker-gc-workflow-contract.test.mjs`: passed.
+- `rg -n "\\| head -n 120" ...`: no matches.
+- workflow YAML parse: passed.
+- `git diff --check`: passed.
+
+## Live Evidence
+
+Run:
+
+`25117998840`
+
+Observed behavior before this fix:
+
+- remote GC step completed with `GC_RC=0`.
+- Docker reclaimed `37.31GB`.
+- `/dev/vda2` changed from `77G used 74G avail 0 use 100%` to
+  `77G used 30G avail 44G use 41%`.
+- summary step failed with exit code `141`.
+
+## Regression Coverage
+
+The new contract test locks the summary renderer away from the
+pipefail-sensitive `awk ... | head -n 120` shape while preserving the 120-line
+cap.
+
+## Residual Risk
+
+This only fixes a false-negative summary failure. If remote Docker GC itself
+returns non-zero, the workflow still fails through the existing `gc_rc` gate.

--- a/scripts/ops/attendance-remote-docker-gc-workflow-contract.test.mjs
+++ b/scripts/ops/attendance-remote-docker-gc-workflow-contract.test.mjs
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const workflowPath = path.join(repoRoot, '.github', 'workflows', 'attendance-remote-docker-gc-prod.yml')
+
+test('remote Docker GC summary caps snippets without pipefail-sensitive head pipeline', () => {
+  const raw = readFileSync(workflowPath, 'utf8')
+
+  assert.ok(raw.includes('name: Attendance Remote Docker GC (Prod)'))
+  assert.ok(raw.includes('set -euo pipefail'))
+  assert.ok(raw.includes('^=== DOCKER GC START ===$'))
+  assert.ok(raw.includes('printing && count < 120 { print; count++ }'))
+  assert.ok(!raw.includes("' \"$gc_log\" | head -n 120"))
+})


### PR DESCRIPTION
## Summary
- move the Docker GC summary line cap into awk instead of piping awk into head
- add a workflow contract test so successful GC cannot be marked red by SIGPIPE 141 in summary rendering
- document the live evidence from run 25117998840, where remote GC reclaimed 37.31GB but the summary step failed

## Verification
- node --test scripts/ops/attendance-remote-docker-gc-workflow-contract.test.mjs
- rg -n "\| head -n 120" .github/workflows/attendance-remote-docker-gc-prod.yml (no matches)
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/attendance-remote-docker-gc-prod.yml"); puts "workflow yaml ok"'
- git diff --check