### PR TITLE
chore(dingtalk): harden env secret setters

### DIFF
--- a/docs/development/dingtalk-p4-env-secret-setter-hardening-development-20260429.md
+++ b/docs/development/dingtalk-p4-env-secret-setter-hardening-development-20260429.md
@@ -1,0 +1,31 @@
+# DingTalk P4 Env Secret Setter Hardening Development
+
+Date: 2026-04-29
+
+## Goal
+
+Reduce accidental secret exposure while preparing the private DingTalk P4 staging env file.
+
+## Design
+
+- Keep `--set KEY=VALUE` for non-secret DingTalk P4 keys such as allowlisted users, manual target IDs, and base URLs.
+- Reject `--set KEY=VALUE` for secret-bearing keys:
+  - `DINGTALK_P4_AUTH_TOKEN`
+  - `DINGTALK_P4_GROUP_A_WEBHOOK`
+  - `DINGTALK_P4_GROUP_B_WEBHOOK`
+  - `DINGTALK_P4_GROUP_A_SECRET`
+  - `DINGTALK_P4_GROUP_B_SECRET`
+- Require secret-bearing keys to be updated with `--set-from-env KEY`, so values do not need to be typed directly into shell history.
+- Keep existing output redaction: update logs show only `<redacted>` and character counts for secret-bearing keys.
+
+## Operator Flow
+
+```bash
+export DINGTALK_P4_GROUP_A_WEBHOOK="<private value>"
+node scripts/ops/dingtalk-p4-env-bootstrap.mjs --set-from-env DINGTALK_P4_GROUP_A_WEBHOOK
+```
+
+## Compatibility
+
+Existing private env files remain compatible. This only changes the update path for future secret writes.
+

--- a/docs/development/dingtalk-p4-env-secret-setter-hardening-verification-20260429.md
+++ b/docs/development/dingtalk-p4-env-secret-setter-hardening-verification-20260429.md
@@ -1,0 +1,25 @@
+# DingTalk P4 Env Secret Setter Hardening Verification
+
+Date: 2026-04-29
+
+## Scope
+
+Verified the `dingtalk-p4-env-bootstrap` update path for secret-bearing keys and non-secret keys.
+
+## Local Checks
+
+- `node --check scripts/ops/dingtalk-p4-env-bootstrap.mjs` passed.
+- `node --check scripts/ops/dingtalk-p4-env-bootstrap.test.mjs` passed.
+- `node --test scripts/ops/dingtalk-p4-env-bootstrap.test.mjs` passed: 9 tests, 9 passed.
+- `git diff --check` passed.
+
+## Assertions Added
+
+- Secret-bearing keys can still be written from process environment values with `--set-from-env`.
+- Update logs redact auth token and both group robot webhooks.
+- Direct `--set DINGTALK_P4_GROUP_A_WEBHOOK=...` fails before writing the private env file.
+- The failure message names the safe `--set-from-env` path and does not echo the raw webhook value.
+
+## Secret Handling
+
+The implementation and docs avoid real webhook URLs, robot secrets, bearer tokens, JWTs, SEC secrets, public tokens, or passwords. Test values remain synthetic fixtures only.

--- a/scripts/ops/dingtalk-p4-env-bootstrap.mjs
+++ b/scripts/ops/dingtalk-p4-env-bootstrap.mjs
@@ -49,7 +49,7 @@ Options:
   --output-dir <dir>        Report output dir, default ${DEFAULT_OUTPUT_ROOT}/<run-id>
   --api-base <url>          Template API base, default ${DEFAULT_API_BASE}
   --web-base <url>          Template web base, default ${DEFAULT_WEB_BASE}
-  --set <KEY=VALUE>         Safely update one known P4 env key without echoing the value
+  --set <KEY=VALUE>         Update one non-secret P4 env key without echoing the value
   --set-from-env <KEY>      Copy one known P4 env key from the current process environment
   --unset <KEY>             Clear one known P4 env key
   --force                   Allow --init to overwrite an existing env file
@@ -157,6 +157,9 @@ function parseEnvAssignment(raw) {
     throw new Error('--set expects KEY=VALUE')
   }
   const key = validateP4EnvKey(raw.slice(0, equalsIndex), '--set')
+  if (SECRET_KEYS.has(key)) {
+    throw new Error(`--set ${key} is unsafe for secret values; export ${key} and use --set-from-env ${key}`)
+  }
   return { key, value: raw.slice(equalsIndex + 1) }
 }
 

--- a/scripts/ops/dingtalk-p4-env-bootstrap.test.mjs
+++ b/scripts/ops/dingtalk-p4-env-bootstrap.test.mjs
@@ -249,10 +249,10 @@ test('dingtalk-p4-env-bootstrap safely updates private env values without leakin
       envFile,
       '--set-from-env',
       'DINGTALK_P4_AUTH_TOKEN',
-      '--set',
-      'DINGTALK_P4_GROUP_A_WEBHOOK=https://oapi.dingtalk.com/robot/send?access_token=robot-secret-a',
-      '--set',
-      'DINGTALK_P4_GROUP_B_WEBHOOK=https://oapi.dingtalk.com/robot/send?access_token=robot-secret-b',
+      '--set-from-env',
+      'DINGTALK_P4_GROUP_A_WEBHOOK',
+      '--set-from-env',
+      'DINGTALK_P4_GROUP_B_WEBHOOK',
       '--set',
       'DINGTALK_P4_ALLOWED_USER_IDS=user_authorized,user_secondary',
       '--set',
@@ -263,12 +263,17 @@ test('dingtalk-p4-env-bootstrap safely updates private env values without leakin
       'DINGTALK_P4_NO_EMAIL_DINGTALK_EXTERNAL_ID=dt_no_email_001',
     ], {
       DINGTALK_P4_AUTH_TOKEN: 'secret-admin-token',
+      DINGTALK_P4_GROUP_A_WEBHOOK: 'https://oapi.dingtalk.com/robot/send?access_token=robot-secret-a',
+      DINGTALK_P4_GROUP_B_WEBHOOK: 'https://oapi.dingtalk.com/robot/send?access_token=robot-secret-b',
     })
 
     assert.equal(update.status, 0, update.stderr || update.stdout)
     assert.doesNotMatch(update.stdout, /secret-admin-token/)
     assert.doesNotMatch(update.stdout, /robot-secret-a/)
+    assert.doesNotMatch(update.stdout, /robot-secret-b/)
     assert.match(update.stdout, /DINGTALK_P4_AUTH_TOKEN: <redacted>/)
+    assert.match(update.stdout, /DINGTALK_P4_GROUP_A_WEBHOOK: <redacted>/)
+    assert.match(update.stdout, /DINGTALK_P4_GROUP_B_WEBHOOK: <redacted>/)
     assert.match(update.stdout, /DINGTALK_P4_ALLOWED_USER_IDS: 2 entries/)
     if (process.platform !== 'win32') {
       assert.equal(statSync(envFile).mode & 0o777, 0o600)
@@ -298,6 +303,17 @@ test('dingtalk-p4-env-bootstrap rejects unsafe update keys and missing source en
     const unknown = runScript(['--p4-env-file', envFile, '--set', 'UNKNOWN=value'])
     assert.equal(unknown.status, 1)
     assert.match(unknown.stderr, /only supports known DingTalk P4 env keys/)
+
+    const unsafeSecret = runScript([
+      '--p4-env-file',
+      envFile,
+      '--set',
+      'DINGTALK_P4_GROUP_A_WEBHOOK=https://oapi.dingtalk.com/robot/send?access_token=robot-secret-a',
+    ])
+    assert.equal(unsafeSecret.status, 1)
+    assert.match(unsafeSecret.stderr, /use --set-from-env DINGTALK_P4_GROUP_A_WEBHOOK/)
+    assert.doesNotMatch(unsafeSecret.stderr, /robot-secret-a/)
+    assert.doesNotMatch(readFileSync(envFile, 'utf8'), /robot-secret-a/)
 
     const missing = runScript([
       '--p4-env-file',


### PR DESCRIPTION
## Summary
- Block direct --set KEY=VALUE usage for DingTalk P4 secret-bearing env keys.
- Require --set-from-env for auth token, robot webhooks, and SEC secrets.
- Add regression coverage and design/verification notes for the safer update flow.

## Verification
- node --check scripts/ops/dingtalk-p4-env-bootstrap.mjs
- node --check scripts/ops/dingtalk-p4-env-bootstrap.test.mjs
- node --test scripts/ops/dingtalk-p4-env-bootstrap.test.mjs
- git diff --check
- targeted secret-pattern scan on production script and docs