### PR TITLE
feat(dingtalk): summarize release readiness gates

### DIFF
--- a/docs/development/dingtalk-p4-release-readiness-gate-totals-design-20260430.md
+++ b/docs/development/dingtalk-p4-release-readiness-gate-totals-design-20260430.md
@@ -1,0 +1,25 @@
+# DingTalk P4 Release Readiness Gate Totals Design
+
+Date: 2026-04-30
+
+## Goal
+
+Make the release-readiness report answer "how many gates are already clear" without forcing operators to count rows in the gate table.
+
+## Change
+
+- Add `gateTotals` to `release-readiness-summary.json`.
+- Count `total`, `passed`, `failed`, and `skipped` gates.
+- Render the same totals near the top of `release-readiness-summary.md`.
+- Keep existing overall status behavior unchanged:
+  - any failed gate means `fail`;
+  - skipped regression planning means `manual_pending`;
+  - all passing gates means `pass`.
+
+## Operator Impact
+
+Operators can now distinguish these states immediately:
+
+- `2/2 passed, 0 failed, 0 skipped`: safe to proceed to final smoke.
+- `1/2 passed, 1 failed, 0 skipped`: fix the failed gate first.
+- `1/2 passed, 0 failed, 1 skipped`: plan-only/manual-pending state; execute the skipped gate before release.

--- a/docs/development/dingtalk-p4-release-readiness-gate-totals-verification-20260430.md
+++ b/docs/development/dingtalk-p4-release-readiness-gate-totals-verification-20260430.md
@@ -1,0 +1,36 @@
+# DingTalk P4 Release Readiness Gate Totals Verification
+
+Date: 2026-04-30
+
+## Scope
+
+Verified release-readiness gate totals in JSON and Markdown outputs.
+
+## Local Checks
+
+- `node --check scripts/ops/dingtalk-p4-release-readiness.mjs` passed.
+- `node --check scripts/ops/dingtalk-p4-release-readiness.test.mjs` passed.
+- `node --test scripts/ops/dingtalk-p4-release-readiness.test.mjs` passed: 13 tests, 13 passed.
+- `git diff --check` passed.
+
+## Assertions Added
+
+- Failing env readiness plus passing regression reports `total=2`, `passed=1`, `failed=1`, `skipped=0`.
+- Fully passing readiness reports `total=2`, `passed=2`, `failed=0`, `skipped=0`.
+- Plan-only regression reports `total=2`, `passed=1`, `failed=0`, `skipped=1`.
+- Markdown renders the same gate totals line near the top of the report.
+
+## Secret Handling
+
+No real DingTalk webhook URLs, bearer tokens, SEC secrets, JWTs, public tokens, or passwords are included in the implementation or documentation.
+
+## Current-Main Refresh - 2026-05-14
+
+Rebased the PR diff onto `origin/main@f86c35e2` after #1259 merged. The
+release-readiness checks still pass unchanged:
+
+```text
+tests 13
+pass 13
+fail 0
+```

--- a/scripts/ops/dingtalk-p4-release-readiness.mjs
+++ b/scripts/ops/dingtalk-p4-release-readiness.mjs
@@ -376,11 +376,21 @@ function computeOverallStatus(checks) {
   return 'pass'
 }
 
+function summarizeGateTotals(gates) {
+  return {
+    total: gates.length,
+    passed: gates.filter((gate) => gate.status === 'pass').length,
+    failed: gates.filter((gate) => gate.status === 'fail').length,
+    skipped: gates.filter((gate) => gate.status === 'skipped').length,
+  }
+}
+
 function renderMarkdown(summary) {
   const lines = [
     '# DingTalk P4 Release Readiness',
     '',
     `- Overall status: **${summary.overallStatus}**`,
+    `- Gate totals: **${summary.gateTotals.passed}/${summary.gateTotals.total}** passed, **${summary.gateTotals.failed}** failed, **${summary.gateTotals.skipped}** skipped`,
     `- Generated at: \`${summary.generatedAt}\``,
     `- Env file: \`${summary.p4EnvFile}\``,
     `- Regression profile: \`${summary.regressionProfile}\``,
@@ -469,6 +479,7 @@ function run(opts) {
     runEnvReadiness(opts, envDir),
     runRegressionGate(opts, regressionDir),
   ]
+  const gateTotals = summarizeGateTotals(gates)
   const readinessStatus = computeOverallStatus(gates)
   let smokeSession = {
     requested: opts.runSmokeSession,
@@ -507,6 +518,7 @@ function run(opts) {
     },
     defaultSmokeOutputDir: DEFAULT_SMOKE_OUTPUT_DIR,
     overallStatus,
+    gateTotals,
     gates,
     smokeSession,
   })

--- a/scripts/ops/dingtalk-p4-release-readiness.test.mjs
+++ b/scripts/ops/dingtalk-p4-release-readiness.test.mjs
@@ -171,6 +171,7 @@ test('dingtalk-p4-release-readiness fails when private env readiness fails even 
 
     const summary = JSON.parse(summaryText)
     assert.equal(summary.overallStatus, 'fail')
+    assert.deepEqual(summary.gateTotals, { total: 2, passed: 1, failed: 1, skipped: 0 })
     assert.equal(summary.gates.find((gate) => gate.id === 'env-readiness').status, 'fail')
     assert.equal(summary.gates.find((gate) => gate.id === 'regression-gate').status, 'pass')
     assert.ok(summary.gates.find((gate) => gate.id === 'env-readiness').details.failedChecks.includes('dingtalk_p4_auth_token'))
@@ -206,8 +207,10 @@ test('dingtalk-p4-release-readiness passes with complete env and passing regress
     assert.equal(result.status, 0, result.stderr || result.stdout)
     const summary = readSummary(outputDir)
     assert.equal(summary.overallStatus, 'pass')
+    assert.deepEqual(summary.gateTotals, { total: 2, passed: 2, failed: 0, skipped: 0 })
     assert.equal(summary.gates.every((gate) => gate.status === 'pass'), true)
     const markdown = readFileSync(path.join(outputDir, 'release-readiness-summary.md'), 'utf8')
+    assert.match(markdown, /Gate totals: \*\*2\/2\*\* passed, \*\*0\*\* failed, \*\*0\*\* skipped/)
     assert.match(markdown, /dingtalk-p4-smoke-session\.mjs/)
     assert.match(markdown, /--require-manual-targets/)
   } finally {
@@ -266,6 +269,7 @@ test('dingtalk-p4-release-readiness reports manual_pending when regression is pl
     assert.equal(result.status, 1)
     const summary = readSummary(outputDir)
     assert.equal(summary.overallStatus, 'manual_pending')
+    assert.deepEqual(summary.gateTotals, { total: 2, passed: 1, failed: 0, skipped: 1 })
     assert.equal(summary.gates.find((gate) => gate.id === 'regression-gate').status, 'skipped')
   } finally {
     rmSync(tmpDir, { recursive: true, force: true })


### PR DESCRIPTION
## Summary
- Add gateTotals to DingTalk P4 release-readiness JSON output.
- Render passed/total/failed/skipped gate counts near the top of the Markdown report.
- Add regression assertions and design/verification docs for pass, fail, and plan-only gate states.

## Verification
- node --check scripts/ops/dingtalk-p4-release-readiness.mjs
- node --check scripts/ops/dingtalk-p4-release-readiness.test.mjs
- node --test scripts/ops/dingtalk-p4-release-readiness.test.mjs
- git diff --check
- targeted secret-pattern scan on production script and docs