### PR TITLE
fix(dingtalk): catch spaced secret assignments in evidence

### DIFF
--- a/docs/development/dingtalk-p4-evidence-secret-assignment-spaces-design-20260430.md
+++ b/docs/development/dingtalk-p4-evidence-secret-assignment-spaces-design-20260430.md
@@ -1,0 +1,23 @@
+# DingTalk P4 Evidence Secret Assignment Spaces Design
+
+Date: 2026-04-30
+
+## Goal
+
+Prevent manual evidence records and text artifacts from accepting DingTalk secret assignments that include spaces around the equals sign.
+
+## Change
+
+- Align `dingtalk-p4-evidence-record` secret scanning with the strict evidence compiler's assignment shape.
+- Detect these forms in summaries, notes, blocked reasons, admin fields, artifact refs, and text artifacts:
+  - `client_secret=value`
+  - `client_secret = value`
+  - `DINGTALK_CLIENT_SECRET = value`
+  - `DINGTALK_STATE_SECRET = value`
+- Keep placeholder-safe values allowed for docs and templates, including `<redacted>`, `replace-me`, environment references, and empty assignments.
+- Extend redaction to preserve the assignment prefix while replacing the value with `<redacted>`.
+
+## Operator Impact
+
+If an operator accidentally pastes a DingTalk app secret into a manual evidence summary or artifact, the recorder fails before writing `workspace/evidence.json`. The error names the offending pattern without echoing the raw secret value.
+

--- a/docs/development/dingtalk-p4-evidence-secret-assignment-spaces-verification-20260430.md
+++ b/docs/development/dingtalk-p4-evidence-secret-assignment-spaces-verification-20260430.md
@@ -1,0 +1,25 @@
+# DingTalk P4 Evidence Secret Assignment Spaces Verification
+
+Date: 2026-04-30
+
+## Scope
+
+Verified secret-assignment blocking for `dingtalk-p4-evidence-record`.
+
+## Local Checks
+
+- `node --check scripts/ops/dingtalk-p4-evidence-record.mjs` passed.
+- `node --check scripts/ops/dingtalk-p4-evidence-record.test.mjs` passed.
+- `node --test scripts/ops/dingtalk-p4-evidence-record.test.mjs` passed: 27 tests, 27 passed.
+- `git diff --check` passed.
+
+## Assertions Added
+
+- Summary input with `DINGTALK_CLIENT_SECRET = value` is rejected.
+- Text artifact content with `client_secret = value` is rejected.
+- Existing no-space secret assignment tests still reject the same class under the unified `dingtalk_secret_assignment` pattern.
+- Error output does not echo the raw synthetic secret value.
+
+## Secret Handling
+
+The implementation and docs do not include real webhook URLs, robot secrets, bearer tokens, JWTs, SEC secrets, public tokens, or passwords. Test values are synthetic fixtures only.

--- a/scripts/ops/dingtalk-p4-evidence-record.mjs
+++ b/scripts/ops/dingtalk-p4-evidence-record.mjs
@@ -50,8 +50,8 @@ const SECRET_PATTERNS = [
     regex: /\bpublicToken=(?!<redacted>|\$)[A-Za-z0-9._~+/=-]{12,}/i,
   },
   {
-    name: 'client_secret',
-    regex: /(?:^|[\s"'`&?])(?:client_secret|DINGTALK_CLIENT_SECRET|DINGTALK_STATE_SECRET)=(?!<redacted>|\$|\{)[^\s&"'`<>]{8,}/i,
+    name: 'dingtalk_secret_assignment',
+    regex: /\b(?:client_secret|DINGTALK_CLIENT_SECRET|DINGTALK_STATE_SECRET)\s*=\s*(?!<redacted>|replace-me|\$|\{|\s|$)[^\s&"'`<>]{8,}/i,
   },
 ]
 
@@ -318,7 +318,7 @@ function redactString(value) {
   return String(value ?? '')
     .replace(/(access_token=)[^&\s)]+/gi, '$1<redacted>')
     .replace(/(publicToken=)[^&\s)]+/gi, '$1<redacted>')
-    .replace(/((?:client_secret|DINGTALK_CLIENT_SECRET|DINGTALK_STATE_SECRET)=)[^&\s)"'`<>]+/gi, '$1<redacted>')
+    .replace(/\b((?:client_secret|DINGTALK_CLIENT_SECRET|DINGTALK_STATE_SECRET)\s*=\s*)[^&\s)"'`<>]+/gi, '$1<redacted>')
     .replace(/([?&](?:sign|timestamp)=)[^&\s)]+/gi, '$1<redacted>')
     .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]+/gi, 'Bearer <redacted>')
     .replace(/\bSEC[A-Za-z0-9+/=_-]{8,}\b/g, 'SEC<redacted>')

--- a/scripts/ops/dingtalk-p4-evidence-record.test.mjs
+++ b/scripts/ops/dingtalk-p4-evidence-record.test.mjs
@@ -934,7 +934,40 @@ test('dingtalk-p4-evidence-record rejects client_secret summary input', () => {
     ])
 
     assert.equal(result.status, 1)
-    assert.match(result.stderr, /--summary contains secret-like value: client_secret/)
+    assert.match(result.stderr, /--summary contains secret-like value: dingtalk_secret_assignment/)
+    assert.doesNotMatch(result.stderr, /abcdefghijklmnopqrstuvwxyz123456/)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-p4-evidence-record rejects spaced client secret summary input', () => {
+  const tmpDir = makeTmpDir()
+  const sessionDir = path.join(tmpDir, 'session')
+
+  try {
+    writeEvidence(sessionDir)
+    const artifactRef = writeArtifact(sessionDir, 'authorized-user-submit')
+
+    const result = runScript([
+      '--session-dir',
+      sessionDir,
+      '--check-id',
+      'authorized-user-submit',
+      '--status',
+      'pass',
+      '--source',
+      'manual-client',
+      '--operator',
+      'qa',
+      '--summary',
+      'DINGTALK_CLIENT_SECRET = abcdefghijklmnopqrstuvwxyz123456',
+      '--artifact',
+      artifactRef,
+    ])
+
+    assert.equal(result.status, 1)
+    assert.match(result.stderr, /--summary contains secret-like value: dingtalk_secret_assignment/)
     assert.doesNotMatch(result.stderr, /abcdefghijklmnopqrstuvwxyz123456/)
   } finally {
     rmSync(tmpDir, { recursive: true, force: true })
@@ -1010,7 +1043,45 @@ test('dingtalk-p4-evidence-record rejects client_secret text artifacts', () => {
     ])
 
     assert.equal(result.status, 1)
-    assert.match(result.stderr, /artifact .* contains secret-like value: client_secret/)
+    assert.match(result.stderr, /artifact .* contains secret-like value: dingtalk_secret_assignment/)
+    assert.doesNotMatch(result.stderr, /abcdefghijklmnopqrstuvwxyz123456/)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-p4-evidence-record rejects spaced client secret text artifacts', () => {
+  const tmpDir = makeTmpDir()
+  const sessionDir = path.join(tmpDir, 'session')
+
+  try {
+    writeEvidence(sessionDir)
+    const artifactRef = writeArtifact(
+      sessionDir,
+      'authorized-user-submit',
+      'leak.txt',
+      'client_secret = abcdefghijklmnopqrstuvwxyz123456\n',
+    )
+
+    const result = runScript([
+      '--session-dir',
+      sessionDir,
+      '--check-id',
+      'authorized-user-submit',
+      '--status',
+      'pass',
+      '--source',
+      'manual-client',
+      '--operator',
+      'qa',
+      '--summary',
+      'Allowed user submit proof.',
+      '--artifact',
+      artifactRef,
+    ])
+
+    assert.equal(result.status, 1)
+    assert.match(result.stderr, /artifact .* contains secret-like value: dingtalk_secret_assignment/)
     assert.doesNotMatch(result.stderr, /abcdefghijklmnopqrstuvwxyz123456/)
   } finally {
     rmSync(tmpDir, { recursive: true, force: true })


### PR DESCRIPTION
## Summary
- Align evidence recorder secret assignment scanning with the strict compiler shape.
- Reject client_secret / DINGTALK_CLIENT_SECRET / DINGTALK_STATE_SECRET assignments with optional spaces around =.
- Add regression coverage and design/verification notes for summary and text artifact inputs.

## Verification
- node --check scripts/ops/dingtalk-p4-evidence-record.mjs
- node --check scripts/ops/dingtalk-p4-evidence-record.test.mjs
- node --test scripts/ops/dingtalk-p4-evidence-record.test.mjs
- git diff --check
- targeted secret-pattern scan on production script and docs