### PR TITLE
ci(attendance): sweep remote summary pipefail caps

### DIFF
--- a/.github/workflows/attendance-remote-env-reconcile-prod.yml
+++ b/.github/workflows/attendance-remote-env-reconcile-prod.yml
@@ -245,15 +245,16 @@ jobs:
           if [[ -f "$reconcile_log" ]]; then
             block="$(
               awk '
-                /^=== ENV RECONCILE START ===$/ { printing=1; next }
+                /^=== ENV RECONCILE START ===$/ { printing=1; total=0; next }
                 /^=== ENV RECONCILE END ===$/ { printing=0; after=1; next }
-                printing { print; next }
-                after {
+                printing && total < 120 { print; total++; next }
+                after && total < 120 {
                   print
+                  total++
                   count++
                   if (count >= 20) exit
                 }
-              ' "$reconcile_log" | head -n 120
+              ' "$reconcile_log"
             )"
             echo "" >> "$GITHUB_STEP_SUMMARY"
             echo '```' >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/attendance-remote-upload-cleanup-prod.yml
+++ b/.github/workflows/attendance-remote-upload-cleanup-prod.yml
@@ -236,15 +236,16 @@ jobs:
           if [[ -f "$cleanup_log" ]]; then
             block="$(
               awk '
-                /^=== UPLOAD CLEANUP START ===$/ { printing=1; next }
+                /^=== UPLOAD CLEANUP START ===$/ { printing=1; total=0; next }
                 /^=== UPLOAD CLEANUP END ===$/ { printing=0; after=1; next }
-                printing { print; next }
-                after {
+                printing && total < 120 { print; total++; next }
+                after && total < 120 {
                   print
+                  total++
                   count++
                   if (count >= 20) exit
                 }
-              ' "$cleanup_log" | head -n 120
+              ' "$cleanup_log"
             )"
             echo "" >> "$GITHUB_STEP_SUMMARY"
             echo '```' >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -467,10 +467,10 @@ jobs:
           else
             preflight_block="$(
               awk '
-                /^=== ATTENDANCE PREFLIGHT START ===$/ { printing=1; next }
+                /^=== ATTENDANCE PREFLIGHT START ===$/ { printing=1; count=0; next }
                 /^=== ATTENDANCE PREFLIGHT END ===$/ { printing=0 }
-                printing { print }
-              ' "$deploy_log" | head -n 120
+                printing && count < 120 { print; count++ }
+              ' "$deploy_log"
             )"
 
             if [[ -z "${preflight_block}" ]]; then
@@ -507,11 +507,11 @@ jobs:
               local start="$1"
               local end="$2"
               local max_lines="$3"
-              awk -v start="$start" -v end="$end" '
-                $0 == start { printing=1; next }
+              awk -v start="$start" -v end="$end" -v max_lines="$max_lines" '
+                $0 == start { printing=1; count=0; next }
                 $0 == end { printing=0 }
-                printing { print }
-              ' "$deploy_log" | head -n "$max_lines"
+                printing && count < max_lines { print; count++ }
+              ' "$deploy_log"
             }
 
             deploy_stage="UNKNOWN"

--- a/docs/development/remote-summary-pipefail-sweep-design-20260430.md
+++ b/docs/development/remote-summary-pipefail-sweep-design-20260430.md
@@ -1,0 +1,68 @@
+# Remote Summary Pipefail Sweep Design - 2026-04-30
+
+## Context
+
+The production Docker GC maintenance workflow exposed a false-red pattern:
+remote work completed successfully, but the local GitHub summary step failed
+with exit code `141` because the summary renderer used `awk ... | head` under
+`set -euo pipefail`.
+
+PR `#1262` fixed that single Docker GC summary. A follow-up scan found the same
+summary-rendering shape still present in:
+
+- `.github/workflows/docker-build.yml`
+- `.github/workflows/attendance-remote-env-reconcile-prod.yml`
+- `.github/workflows/attendance-remote-upload-cleanup-prod.yml`
+
+These are operator-facing workflows where a false red wastes time and can hide
+the real signal.
+
+## Design
+
+Keep the fix scoped to summary rendering only:
+
+- no remote SSH command changes.
+- no deploy, reconcile, cleanup, or final gate semantic changes.
+- no threshold or artifact contract changes.
+- replace `awk ... | head -n 120` with a single `awk` program that enforces the
+  line cap internally.
+
+For simple bounded blocks:
+
+```bash
+awk '
+  /^=== START ===$/ { printing=1; count=0; next }
+  /^=== END ===$/ { printing=0 }
+  printing && count < 120 { print; count++ }
+' "$log_file"
+```
+
+For workflows that include a small post-block tail after the end marker:
+
+```bash
+awk '
+  /^=== START ===$/ { printing=1; total=0; next }
+  /^=== END ===$/ { printing=0; after=1; next }
+  printing && total < 120 { print; total++; next }
+  after && total < 120 {
+    print
+    total++
+    count++
+    if (count >= 20) exit
+  }
+' "$log_file"
+```
+
+## Files
+
+- `.github/workflows/docker-build.yml`
+- `.github/workflows/attendance-remote-env-reconcile-prod.yml`
+- `.github/workflows/attendance-remote-upload-cleanup-prod.yml`
+- `scripts/ops/remote-summary-pipefail-contract.test.mjs`
+
+## Non-Goals
+
+- Do not change Docker deploy behavior.
+- Do not change K3 WISE smoke behavior.
+- Do not change attendance env reconcile or upload cleanup remote logic.
+- Do not touch production secrets or remote host state.

--- a/docs/development/remote-summary-pipefail-sweep-verification-20260430.md
+++ b/docs/development/remote-summary-pipefail-sweep-verification-20260430.md
@@ -1,0 +1,55 @@
+# Remote Summary Pipefail Sweep Verification - 2026-04-30
+
+## Local Verification
+
+Worktree:
+
+`/tmp/ms2-remote-summary-pipefail-sweep-20260430`
+
+Branch:
+
+`codex/remote-summary-pipefail-sweep-20260430`
+
+Baseline:
+
+`origin/main` at `a06e5099362e5e0e032c1a4569b64e854ceedb47`
+
+Commands:
+
+```bash
+node --test scripts/ops/remote-summary-pipefail-contract.test.mjs
+rg -n "\\| head -n 120|\\| head -n \\\"\\$max_lines\\\"" \
+  .github/workflows/docker-build.yml \
+  .github/workflows/attendance-remote-docker-gc-prod.yml \
+  .github/workflows/attendance-remote-env-reconcile-prod.yml \
+  .github/workflows/attendance-remote-upload-cleanup-prod.yml
+ruby -e 'require "yaml"; %w[
+  .github/workflows/docker-build.yml
+  .github/workflows/attendance-remote-env-reconcile-prod.yml
+  .github/workflows/attendance-remote-upload-cleanup-prod.yml
+].each { |p| YAML.load_file(p) }; puts "workflow yaml ok"'
+git diff --check
+```
+
+Results:
+
+- `remote-summary-pipefail-contract.test.mjs`: passed.
+- `rg ...`: no matches for the pipefail-sensitive summary shapes.
+- workflow YAML parse: passed.
+- `git diff --check`: passed.
+
+## Regression Coverage
+
+The new contract test checks that:
+
+- deploy preflight summary no longer pipes into `head -n 120`.
+- deploy stage extraction no longer pipes into `head -n "$max_lines"`.
+- env reconcile and upload cleanup summaries preserve the `120` total-line cap
+  plus their existing post-block tail behavior without an external `head`.
+- the already-fixed Docker GC workflow stays protected.
+
+## Residual Risk
+
+This only prevents summary false reds. If deploy, env reconcile, upload cleanup,
+or Docker GC remote work returns non-zero, their workflows should still fail via
+the existing final gate outputs.

--- a/scripts/ops/remote-summary-pipefail-contract.test.mjs
+++ b/scripts/ops/remote-summary-pipefail-contract.test.mjs
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+
+function readWorkflow(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), 'utf8')
+}
+
+test('remote workflow summaries cap awk snippets without pipefail-sensitive head pipelines', () => {
+  const targets = [
+    '.github/workflows/docker-build.yml',
+    '.github/workflows/attendance-remote-docker-gc-prod.yml',
+    '.github/workflows/attendance-remote-env-reconcile-prod.yml',
+    '.github/workflows/attendance-remote-upload-cleanup-prod.yml',
+  ]
+
+  for (const target of targets) {
+    const raw = readWorkflow(target)
+    assert.ok(!raw.includes('| head -n 120'), `${target} must not pipe awk snippets into head -n 120`)
+  }
+
+  const dockerBuild = readWorkflow('.github/workflows/docker-build.yml')
+  assert.ok(!dockerBuild.includes('| head -n "$max_lines"'))
+  assert.ok(dockerBuild.includes('printing && count < 120 { print; count++ }'))
+  assert.ok(dockerBuild.includes('printing && count < max_lines { print; count++ }'))
+
+  const envReconcile = readWorkflow('.github/workflows/attendance-remote-env-reconcile-prod.yml')
+  assert.ok(envReconcile.includes('printing && total < 120 { print; total++; next }'))
+  assert.ok(envReconcile.includes('after && total < 120 {'))
+
+  const uploadCleanup = readWorkflow('.github/workflows/attendance-remote-upload-cleanup-prod.yml')
+  assert.ok(uploadCleanup.includes('printing && total < 120 { print; total++; next }'))
+  assert.ok(uploadCleanup.includes('after && total < 120 {'))
+})


### PR DESCRIPTION
## Summary
- remove remaining pipefail-sensitive `awk ... | head` summary snippets from docker deploy, env reconcile, and upload cleanup workflows
- keep the line caps inside awk so remote command semantics and final gates stay unchanged
- add a small contract test plus design/verification notes

## Verification
- node --test scripts/ops/remote-summary-pipefail-contract.test.mjs
- rg -n "\| head -n 120|\| head -n \"\\"" .github/workflows/docker-build.yml .github/workflows/attendance-remote-docker-gc-prod.yml .github/workflows/attendance-remote-env-reconcile-prod.yml .github/workflows/attendance-remote-upload-cleanup-prod.yml (no matches)
- ruby -e 'require "yaml"; %w[.github/workflows/docker-build.yml .github/workflows/attendance-remote-env-reconcile-prod.yml .github/workflows/attendance-remote-upload-cleanup-prod.yml].each { |p| YAML.load_file(p) }; puts "workflow yaml ok"'
- git diff --check

## Context
This follows the Docker GC false-red incident where remote maintenance succeeded but summary rendering failed with exit 141 under `set -euo pipefail`.