### PR TITLE
ci(observability): avoid pipefail head in metric extraction

### DIFF
--- a/.github/workflows/observability-e2e.yml
+++ b/.github/workflows/observability-e2e.yml
@@ -223,9 +223,9 @@ jobs:
       - name: Assert RBAC metrics activity (relaxed)
         run: |
           # Extract numeric values only (skip HELP/TYPE lines)
-          HITS=$(awk '/^rbac_perm_cache_hits_total [0-9]/{print $2}' /tmp/metrics.txt | head -1)
+          HITS=$(awk '/^rbac_perm_cache_hits_total [0-9]/{print $2; exit}' /tmp/metrics.txt)
           # Note: The metric name is rbac_perm_cache_miss_total (no 's'), not misses
-          MISS=$(awk '/^rbac_perm_cache_miss_total [0-9]/{print $2}' /tmp/metrics.txt | head -1)
+          MISS=$(awk '/^rbac_perm_cache_miss_total [0-9]/{print $2; exit}' /tmp/metrics.txt)
 
           HITS=${HITS:-0}
           MISS=${MISS:-0}
@@ -250,8 +250,8 @@ jobs:
 
       - name: Validate RealShare presence (non-blocking)
         run: |
-          REAL=$(awk '/rbac_perm_queries_real_total/{print $2}' /tmp/metrics.txt | head -1)
-          SYN=$(awk '/rbac_perm_queries_synth_total/{print $2}' /tmp/metrics.txt | head -1)
+          REAL=$(awk '/rbac_perm_queries_real_total/{print $2; exit}' /tmp/metrics.txt)
+          SYN=$(awk '/rbac_perm_queries_synth_total/{print $2; exit}' /tmp/metrics.txt)
           if [ -z "$REAL" ] || [ -z "$SYN" ]; then
             echo '::warning::RealShare counters absent'; exit 0; fi
           TOTAL=$((REAL + SYN))

--- a/.github/workflows/observability-strict.yml
+++ b/.github/workflows/observability-strict.yml
@@ -460,8 +460,8 @@ jobs:
 
       - name: Validate RealShare presence (non-blocking)
         run: |
-          REAL=$(awk '/rbac_perm_queries_real_total/{print $2}' metrics.txt | head -1)
-          SYN=$(awk '/rbac_perm_queries_synth_total/{print $2}' metrics.txt | head -1)
+          REAL=$(awk '/rbac_perm_queries_real_total/{print $2; exit}' metrics.txt)
+          SYN=$(awk '/rbac_perm_queries_synth_total/{print $2; exit}' metrics.txt)
           if [ -z "$REAL" ] || [ -z "$SYN" ]; then
             echo '::warning::RealShare counters absent'; exit 0; fi
           TOTAL=$((REAL + SYN))
@@ -520,8 +520,8 @@ jobs:
       - name: Assert STRICT cache performance
         run: |
           # Cache hit rate must be > 60% in strict mode
-          HITS=$(awk '/^rbac_perm_cache_hits_total\{[^}]*\} [0-9]+$/ {print $NF}' metrics.txt | head -1)
-          MISSES=$(awk '/^rbac_perm_cache_misses_total\{[^}]*\} [0-9]+$/ {print $NF}' metrics.txt | head -1)
+          HITS=$(awk '/^rbac_perm_cache_hits_total\{[^}]*\} [0-9]+$/ {print $NF; exit}' metrics.txt)
+          MISSES=$(awk '/^rbac_perm_cache_misses_total\{[^}]*\} [0-9]+$/ {print $NF; exit}' metrics.txt)
 
           echo "Cache hits: ${HITS:-0}"
           echo "Cache misses: ${MISSES:-0}"
@@ -545,7 +545,7 @@ jobs:
         run: |
           # Check approval metrics
           SUCCESS=$(awk '/^metasheet_approval_actions_total\{[^}]*result="success"[^}]*\} [0-9]+$/{sum+=$NF} END{print (sum==""?0:sum)}' metrics.txt)
-          CONFLICT=$(awk '/^metasheet_approval_conflict_total\{[^}]*\} [0-9]+$/{print $NF}' metrics.txt | head -1)
+          CONFLICT=$(awk '/^metasheet_approval_conflict_total\{[^}]*\} [0-9]+$/{print $NF; exit}' metrics.txt)
 
           echo "Successful approvals: ${SUCCESS:-0}"
           echo "Approval conflicts: ${CONFLICT:-0}"

--- a/docs/development/observability-workflow-pipefail-head-design-20260430.md
+++ b/docs/development/observability-workflow-pipefail-head-design-20260430.md
@@ -1,0 +1,61 @@
+# Observability Workflow Pipefail Head Design - 2026-04-30
+
+## Context
+
+The attendance remote workflow summary fixes removed several `awk | head` patterns that could false-red under `set -o pipefail`. A follow-up scan of the latest `origin/main` found the same pattern in the observability workflows:
+
+- `.github/workflows/observability-e2e.yml`
+- `.github/workflows/observability-strict.yml`
+
+These jobs fetch Prometheus-style metrics and extract the first matching series for RBAC cache, RealShare, and approval conflict counters.
+
+## Problem
+
+The previous extraction style was:
+
+```sh
+awk '/metric_pattern/{print $2}' metrics.txt | head -1
+```
+
+If the metrics payload contains multiple matching series, `head -1` can close the pipe after the first line. With `pipefail` enabled, the upstream `awk` may receive SIGPIPE and the step can fail even though a valid metric was found. That creates CI false negatives in observability validation.
+
+## Design
+
+Keep the existing "first matching series" semantics, but make `awk` stop itself:
+
+```sh
+awk '/metric_pattern/{print $2; exit}' metrics.txt
+```
+
+For `$NF`-based strict metrics, the same pattern is used:
+
+```sh
+awk '/metric_pattern/ {print $NF; exit}' metrics.txt
+```
+
+This avoids early pipe closure entirely, preserves shell behavior for missing metrics, and does not change threshold logic.
+
+## Scope
+
+Changed metric extraction in:
+
+- `observability-e2e.yml`
+  - `rbac_perm_cache_hits_total`
+  - `rbac_perm_cache_miss_total`
+  - `rbac_perm_queries_real_total`
+  - `rbac_perm_queries_synth_total`
+- `observability-strict.yml`
+  - `rbac_perm_queries_real_total`
+  - `rbac_perm_queries_synth_total`
+  - `rbac_perm_cache_hits_total`
+  - `rbac_perm_cache_misses_total`
+  - `metasheet_approval_conflict_total`
+
+Intentionally not changed:
+
+- Non-observability workflows.
+- Non-metric `head` usage where the surrounding command already tolerates failure or has different semantics.
+
+## Guardrail
+
+Added `scripts/ops/observability-workflow-pipefail-contract.test.mjs` to keep these observability metric extraction sites from regressing to `awk ... | head -1`.

--- a/docs/development/observability-workflow-pipefail-head-verification-20260430.md
+++ b/docs/development/observability-workflow-pipefail-head-verification-20260430.md
@@ -1,0 +1,57 @@
+# Observability Workflow Pipefail Head Verification - 2026-04-30
+
+## Local Verification
+
+From `/private/tmp/ms2-observability-pipefail-20260430`:
+
+```sh
+node --test scripts/ops/observability-workflow-pipefail-contract.test.mjs
+```
+
+Actual result:
+
+```text
+pass 1, fail 0
+```
+
+```sh
+rg -n "awk .*\\| head -1|\\| head -1" .github/workflows/observability-e2e.yml .github/workflows/observability-strict.yml
+```
+
+Actual result:
+
+```text
+no matches
+```
+
+```sh
+ruby -e 'require "yaml"; %w[.github/workflows/observability-e2e.yml .github/workflows/observability-strict.yml].each { |p| YAML.load_file(p) }; puts "workflow yaml ok"'
+```
+
+Actual result:
+
+```text
+workflow yaml ok
+```
+
+```sh
+git diff --check
+```
+
+Actual result:
+
+```text
+no output
+```
+
+## CI Verification
+
+After opening the PR, wait for GitHub checks on the branch. This is a CI-only change, so the merge gate should focus on:
+
+- workflow YAML parsing
+- repository tests triggered by `pr-validate`
+- any observability workflow validation that GitHub schedules or PR filters include
+
+## Rollback
+
+Rollback is a straight revert of the PR. The previous behavior only affected CI metric extraction and does not change runtime application code.

--- a/scripts/ops/observability-workflow-pipefail-contract.test.mjs
+++ b/scripts/ops/observability-workflow-pipefail-contract.test.mjs
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+
+function readWorkflow(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), 'utf8')
+}
+
+test('observability metric extraction avoids pipefail-sensitive awk to head pipelines', () => {
+  const targets = [
+    '.github/workflows/observability-e2e.yml',
+    '.github/workflows/observability-strict.yml',
+  ]
+
+  for (const target of targets) {
+    const raw = readWorkflow(target)
+    assert.ok(
+      !/awk [^\n]*\| head -1/.test(raw),
+      `${target} must not pipe metric extraction awk into head -1`,
+    )
+  }
+
+  const e2e = readWorkflow('.github/workflows/observability-e2e.yml')
+  assert.ok(e2e.includes('rbac_perm_cache_hits_total [0-9]/{print $2; exit}'))
+  assert.ok(e2e.includes('rbac_perm_cache_miss_total [0-9]/{print $2; exit}'))
+  assert.ok(e2e.includes('rbac_perm_queries_real_total/{print $2; exit}'))
+  assert.ok(e2e.includes('rbac_perm_queries_synth_total/{print $2; exit}'))
+
+  const strict = readWorkflow('.github/workflows/observability-strict.yml')
+  assert.ok(strict.includes('rbac_perm_queries_real_total/{print $2; exit}'))
+  assert.ok(strict.includes('rbac_perm_queries_synth_total/{print $2; exit}'))
+  assert.ok(strict.includes('rbac_perm_cache_hits_total\\{[^}]*\\} [0-9]+$/ {print $NF; exit}'))
+  assert.ok(strict.includes('rbac_perm_cache_misses_total\\{[^}]*\\} [0-9]+$/ {print $NF; exit}'))
+  assert.ok(strict.includes('metasheet_approval_conflict_total\\{[^}]*\\} [0-9]+$/{print $NF; exit}'))
+})


### PR DESCRIPTION
## Summary
- Replace observability metric extraction `awk ... | head -1` pipelines with `awk ... { print; exit }` so `set -o pipefail` cannot false-red when metrics contain multiple matching series.
- Cover RBAC cache, RealShare, and approval conflict extraction in observability E2E/strict workflows.
- Add a focused workflow contract test plus design and verification notes.

## Verification
- `node --test scripts/ops/observability-workflow-pipefail-contract.test.mjs`
- `rg -n "awk .*\\| head -1|\\| head -1" .github/workflows/observability-e2e.yml .github/workflows/observability-strict.yml` (no matches)
- `ruby -e 'require "yaml"; %w[.github/workflows/observability-e2e.yml .github/workflows/observability-strict.yml].each { |p| YAML.load_file(p) }; puts "workflow yaml ok"'`
- `git diff --check`