### PR TITLE
docs(multitable): add Feishu RC audit and smoke checklist

### DIFF
--- a/docs/development/multitable-feishu-rc-audit-checklist-20260430.md
+++ b/docs/development/multitable-feishu-rc-audit-checklist-20260430.md
@@ -1,0 +1,118 @@
+# Multitable Feishu RC Audit Checklist - 2026-04-30
+
+## Scope
+
+This checklist audits the merged multitable Feishu-parity RC capability set on `origin/main@08f4ff920`.
+
+It is a local/code-and-doc audit checklist, not a staging execution report. Staging-only checks live in `docs/development/multitable-feishu-staging-smoke-checklist-20260430.md`.
+
+## Evidence Sources
+
+- `docs/development/wave-m-feishu-1-delivery-20260426.md`
+- `docs/development/wave-m-feishu-2-formula-view-gantt-development-20260429.md`
+- `docs/development/wave-m-feishu-3-longtext-field-design-20260429.md`
+- `docs/development/wave-m-feishu-3-send-email-design-20260429.md`
+- `docs/development/wave-m-feishu-3-hierarchy-view-design-20260429.md`
+- `docs/development/wave-m-feishu-4-multiselect-field-design-20260429.md`
+- `docs/development/wave-m-feishu-4-filter-builder-design-20260429.md`
+- `docs/development/wave-m-feishu-4-formula-catalog-design-20260429.md`
+- `apps/web/src/multitable/**`
+- `packages/core-backend/src/multitable/**`
+- `packages/core-backend/src/routes/univer-meta.ts`
+- `packages/openapi/src/**`
+
+## Capability Audit
+
+### Base Multitable Workflow
+
+- [ ] Base/sheet/view creation path is available in staging.
+- [ ] Grid view can create, edit, delete, sort, filter, and group records.
+- [ ] Record drawer opens from all RC view types that support selection.
+- [ ] Comments drawer still opens from record-level affordances.
+- [ ] Existing permissions still gate read/write/admin actions.
+
+### XLSX Import / Export
+
+- [x] Frontend `.xlsx`/`.xls` import path exists.
+- [x] Frontend `.xlsx` export path exists.
+- [x] `xlsx` dependency exists in `apps/web/package.json`.
+- [ ] Backend `/import-xlsx` route exists.
+  - Gap: no multitable backend route was found for `import-xlsx`.
+- [ ] Backend `/export-xlsx` route exists.
+  - Gap: no multitable backend route was found for `export-xlsx`.
+- [ ] Staging validates real Excel round-trip with a real file.
+
+### Field Types
+
+- [x] Existing core types remain present: string, number, boolean, date, formula, select, link, lookup, rollup, attachment.
+- [x] Batch-1 fields are present: currency, percent, rating, url, email, phone.
+- [x] `longText` is present.
+- [x] `multiSelect` is present.
+- [ ] System fields are present: autoNumber, createdTime, modifiedTime, createdBy, modifiedBy.
+  - Gap: these are still Phase 4 TODO items.
+- [ ] DateTime/timezone field is present.
+  - Gap: optional backlog item.
+- [ ] Barcode/location fields are present.
+  - Gap: optional backlog items.
+
+### View Types
+
+- [x] Grid, form, kanban, gallery, calendar, timeline are existing view types.
+- [x] Gantt view frontend is present.
+- [x] Hierarchy view frontend is present.
+- [ ] Gantt dependencies / critical path / drag resize are present.
+  - Gap: optional backlog item.
+- [ ] Hierarchy drag-to-reparent and server-side cycle prevention are present.
+  - Gap: optional backlog item.
+
+### View Configuration
+
+- [x] Visual filter builder exists.
+- [x] Sort/filter/group config is exposed from view management.
+- [x] Conditional formatting rules exist.
+- [x] Conditional formatting is persisted in view config.
+- [ ] Staging verifies conditional formatting reload across browser restart.
+
+### Formula
+
+- [x] Formula field editor exists.
+- [x] Field-token insertion uses stable field ids.
+- [x] Function catalog exists.
+- [x] DATEDIFF runtime alias exists.
+- [ ] Staging verifies formula save/evaluate/reload on real data.
+
+### Automation
+
+- [x] Advanced automation V1 exists.
+- [x] `send_email` action type exists.
+- [x] `send_email` UI config exists.
+- [ ] Real email provider transport is configured in staging.
+  - Gap: repository implementation reuses `NotificationService`; provider/runtime config must be verified operationally.
+
+### Collaboration / Realtime
+
+- [x] Comments, mention, unread, inbox, and presence are implemented.
+- [x] Yjs text-cell collaboration exists behind opt-in flag.
+- [ ] Long-text Yjs collaboration is enabled.
+  - Gap: explicitly out of scope for longText slice.
+- [ ] Record/cell version history exists.
+  - Gap: Phase 5 TODO.
+- [ ] Record subscription/watch notifications exist.
+  - Gap: Phase 6 TODO.
+
+### API / Contracts
+
+- [x] API token and webhook V1 exist.
+- [x] OpenAPI includes recent field enum additions.
+- [ ] OpenAPI coverage for Gantt/Hierarchy/xlsx backend routes is fully audited.
+  - Gap: Phase 3 TODO.
+
+## Audit Output Requirements
+
+The result document must classify findings as:
+
+- P0: blocks RC staging/internal trial.
+- P1: does not block first staging smoke, but blocks customer-depth trial.
+- P2: known parity/UX gap, not an RC blocker.
+
+No staging smoke item should be marked complete from this checklist alone.

--- a/docs/development/multitable-feishu-rc-audit-development-20260430.md
+++ b/docs/development/multitable-feishu-rc-audit-development-20260430.md
@@ -1,0 +1,51 @@
+# Multitable Feishu RC Audit Development - 2026-04-30
+
+## Summary
+
+Implemented Phase 1 documentation for the multitable Feishu RC closeout. This is a docs-only change that converts the merged Wave M-Feishu evidence into an executable audit and staging-smoke handoff.
+
+## Baseline
+
+- Branch: `codex/multitable-feishu-rc-audit-20260430`
+- Base: `origin/main@08f4ff920`
+- Worktree: `/tmp/ms2-feishu-rc-audit-20260430`
+
+## Development Notes
+
+- Updated `docs/development/multitable-feishu-rc-todo-20260430.md`.
+- Added `docs/development/multitable-feishu-rc-audit-checklist-20260430.md`.
+- Added `docs/development/multitable-feishu-staging-smoke-checklist-20260430.md`.
+- Added `docs/development/multitable-feishu-rc-audit-result-20260430.md`.
+- Added companion verification doc.
+
+## TODO Items Marked Complete
+
+The following items were marked complete because this PR creates durable docs evidence:
+
+- Confirm root worktree dirty state is unrelated to this RC stream.
+- Create all RC work in clean `/tmp` or `.worktrees` branches from `origin/main`.
+- Do not touch DingTalk/public-form dirty files unless explicitly required.
+- Create RC audit checklist for current merged multitable capabilities.
+- Create staging smoke checklist for manual tester.
+- Produce RC audit result MD with P0/P1/P2 defects.
+
+The staging execution items remain unchecked because no remote deployment or manual browser smoke was performed in this PR.
+
+## Audit Inputs
+
+- Wave M-Feishu delivery docs from 2026-04-26 through 2026-04-29.
+- Source grep for xlsx routes, field type unions, view type registration, send_email, system fields, record history, and subscription/watch surfaces.
+- Master TODO from #1270.
+
+## Result
+
+The audit found two P0 items:
+
+- Staging smoke still needs to be executed.
+- Backend xlsx import/export routes are still missing.
+
+It also preserved Phase 4-6 as P1 follow-up work:
+
+- System fields batch.
+- Record version history.
+- Record subscription/watch notifications.

--- a/docs/development/multitable-feishu-rc-audit-result-20260430.md
+++ b/docs/development/multitable-feishu-rc-audit-result-20260430.md
@@ -1,0 +1,160 @@
+# Multitable Feishu RC Audit Result - 2026-04-30
+
+## Baseline
+
+- Audited baseline: `origin/main@08f4ff920`
+- Audit type: code/docs/static evidence audit.
+- Staging status: not executed in this PR.
+
+## Executive Result
+
+The merged multitable Feishu-parity line is ready to enter staging smoke, but not yet ready to call RC complete.
+
+RC-blocking uncertainty is concentrated in operational/staging evidence, not in local source completeness. The largest functional gap remains backend xlsx import/export routes. The deepest customer-trial gaps remain system fields, record version history, and record subscription/watch notifications.
+
+## P0 Findings
+
+### P0-1 - Staging smoke has not been executed
+
+Evidence:
+
+- The TODO had no completed staging smoke items before this PR.
+- This PR creates the smoke checklist but does not deploy or click through staging.
+
+Impact:
+
+- Cannot claim RC readiness until staging confirms core flows.
+
+Next action:
+
+- Run `docs/development/multitable-feishu-staging-smoke-checklist-20260430.md` against the target staging server and update the master TODO with evidence.
+
+### P0-2 - Backend xlsx import/export routes are still missing
+
+Evidence:
+
+- `apps/web/package.json` has `xlsx`.
+- Frontend has `MetaImportModal` xlsx parsing and `onExportXlsx`.
+- No multitable backend `import-xlsx` / `export-xlsx` routes were found under `packages/core-backend/src`.
+
+Impact:
+
+- Browser-based xlsx works for normal files, but server-side import/export APIs and larger operational workflows remain unavailable.
+
+Next action:
+
+- Execute Phase 2: Backend XLSX Route Layer.
+
+## P1 Findings
+
+### P1-1 - System fields batch is still missing
+
+Missing field types:
+
+- `autoNumber`
+- `createdTime`
+- `modifiedTime`
+- `createdBy`
+- `modifiedBy`
+
+Impact:
+
+- Customer-depth trials for CRM/ERP style tables will ask for stable row identifiers and audit metadata fields.
+
+Next action:
+
+- Execute Phase 4.
+
+### P1-2 - Record/cell version history is still missing
+
+Evidence:
+
+- Existing record `version` is used for optimistic locking, not historical browsing.
+- No RC record revision UI/API was found.
+
+Impact:
+
+- Data trust and audit use cases are weaker than Feishu-style history expectations.
+
+Next action:
+
+- Execute Phase 5.
+
+### P1-3 - Record subscription/watch notifications are still missing
+
+Evidence:
+
+- Existing subscription hits are platform/event/notification internals.
+- No user-facing record watch/unwatch feature was found in multitable UI/API.
+
+Impact:
+
+- Users cannot follow important records and receive update/comment notifications.
+
+Next action:
+
+- Execute Phase 6.
+
+### P1-4 - Real `send_email` delivery depends on staging provider configuration
+
+Evidence:
+
+- `send_email` action exists and reuses `NotificationService`.
+- The design explicitly leaves real provider wiring outside the feature PR.
+
+Impact:
+
+- Rule save/execution path may work while real email delivery is not operational.
+
+Next action:
+
+- Smoke with staging provider. If no provider is configured, classify as ops blocker, not product code blocker.
+
+## P2 Findings
+
+### P2-1 - Gantt deep project features remain out of scope
+
+Missing:
+
+- Dependency arrows
+- Critical path
+- Drag resize
+
+Impact:
+
+- Basic Gantt visualization exists; advanced project management parity is deferred.
+
+### P2-2 - Hierarchy deep editing remains out of scope
+
+Missing:
+
+- Drag-to-reparent
+- Server-side cycle prevention
+
+Impact:
+
+- Basic tree view exists; advanced tree editing remains deferred.
+
+### P2-3 - Optional field parity remains
+
+Missing:
+
+- DateTime/timezone
+- Number formatting
+- Barcode
+- Location
+- Native person field migration
+
+Impact:
+
+- Useful for deeper Feishu parity, but not RC blockers.
+
+## Current Recommendation
+
+Proceed in this order:
+
+1. Run staging smoke from the new checklist.
+2. Fix any P0 smoke failures immediately.
+3. Start Phase 2 backend xlsx routes.
+4. Run Phase 3 OpenAPI/contract cleanup after xlsx route shape is known.
+5. Then decide whether to start Phase 4 system fields before customer trial.

--- a/docs/development/multitable-feishu-rc-audit-verification-20260430.md
+++ b/docs/development/multitable-feishu-rc-audit-verification-20260430.md
@@ -1,0 +1,36 @@
+# Multitable Feishu RC Audit Verification - 2026-04-30
+
+## Scope
+
+Verify the Phase 1 RC audit docs. This PR changes docs only. No source code, migrations, OpenAPI dist, package manifests, or runtime behavior were changed.
+
+## Commands
+
+Run from `/tmp/ms2-feishu-rc-audit-20260430`.
+
+```bash
+git status --short
+git diff --check
+rg -n "P0|P1|P2|Backend xlsx|System fields|Record/cell version history|Record subscription" docs/development/multitable-feishu-rc-audit-result-20260430.md
+rg -n "Smoke 1|Smoke 2|Smoke 3|Smoke 4|Smoke 5|Smoke 6|Smoke 7|Smoke 8|Smoke 9|Smoke 10" docs/development/multitable-feishu-staging-smoke-checklist-20260430.md
+rg -n "RC audit checklist|staging smoke checklist|audit result" docs/development/multitable-feishu-rc-todo-20260430.md
+rg -n "No source code|docs-only|runtime behavior" docs/development/multitable-feishu-rc-audit-verification-20260430.md
+```
+
+## Expected Results
+
+- `git status --short` shows only docs changes.
+- `git diff --check` exits 0.
+- Audit result grep finds P0/P1/P2 classifications and known gaps.
+- Smoke checklist grep finds all ten smoke sections.
+- TODO grep confirms completed Phase 1 doc items are linked.
+- Verification grep confirms docs-only scope.
+
+## Local Result
+
+- `git status --short`: showed one modified TODO doc and five new Phase 1 docs, all under `docs/development`.
+- `git diff --check`: exited 0.
+- Audit result grep: found P0/P1/P2 classifications and known gaps.
+- Smoke checklist grep: found Smoke 1 through Smoke 10.
+- TODO grep: confirmed completed Phase 1 doc items are linked.
+- Verification grep: confirmed docs-only scope.

--- a/docs/development/multitable-feishu-rc-todo-20260430.md
+++ b/docs/development/multitable-feishu-rc-todo-20260430.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-- Baseline: `origin/main@0e059ce99`
+- Baseline: `origin/main@08f4ff920`
 - Goal: Feishu-parity RC for staging and internal trial.
 - Current phase: RC audit first, then P0 gaps.
 - Rule: every completed item must be marked `[x]` and linked to PR, commit, development MD, and verification MD.
@@ -32,19 +32,44 @@ Do not mark an item done if:
 ## Phase 0 - Worktree Hygiene
 
 - [x] Create this master TODO MD and companion development/verification MDs.
-  - PR: pending
-  - Merge commit: pending
+  - PR: #1270
+  - Merge commit: `08f4ff920`
   - Development MD: `docs/development/multitable-feishu-rc-development-20260430.md`
   - Verification MD: `docs/development/multitable-feishu-rc-verification-20260430.md`
-  - Verification summary: docs-only local validation pending PR CI.
-- [ ] Confirm root worktree dirty state is unrelated to this RC stream.
-- [ ] Create all RC work in clean `/tmp` or `.worktrees` branches from `origin/main`.
-- [ ] Do not touch DingTalk/public-form dirty files unless the task explicitly requires it.
+  - Verification summary: docs-only PR CI passed and merged.
+- [x] Confirm root worktree dirty state is unrelated to this RC stream.
+  - PR: pending
+  - Merge commit: pending
+  - Development MD: `docs/development/multitable-feishu-rc-audit-development-20260430.md`
+  - Verification MD: `docs/development/multitable-feishu-rc-audit-verification-20260430.md`
+  - Verification summary: root status reviewed; dirty files are public-form/DingTalk/docs paths outside this RC audit worktree.
+- [x] Create all RC work in clean `/tmp` or `.worktrees` branches from `origin/main`.
+  - PR: pending
+  - Merge commit: pending
+  - Development MD: `docs/development/multitable-feishu-rc-audit-development-20260430.md`
+  - Verification MD: `docs/development/multitable-feishu-rc-audit-verification-20260430.md`
+  - Verification summary: Phase 1 worktree created at `/tmp/ms2-feishu-rc-audit-20260430` from `origin/main@08f4ff920`.
+- [x] Do not touch DingTalk/public-form dirty files unless the task explicitly requires it.
+  - PR: pending
+  - Merge commit: pending
+  - Development MD: `docs/development/multitable-feishu-rc-audit-development-20260430.md`
+  - Verification MD: `docs/development/multitable-feishu-rc-audit-verification-20260430.md`
+  - Verification summary: Phase 1 changes are docs-only under `docs/development`.
 
 ## Phase 1 - RC Audit + Staging Smoke
 
-- [ ] Create RC audit checklist for current merged multitable capabilities.
-- [ ] Create staging smoke checklist for manual tester.
+- [x] Create RC audit checklist for current merged multitable capabilities.
+  - PR: pending
+  - Merge commit: pending
+  - Development MD: `docs/development/multitable-feishu-rc-audit-development-20260430.md`
+  - Verification MD: `docs/development/multitable-feishu-rc-audit-verification-20260430.md`
+  - Verification summary: checklist added at `docs/development/multitable-feishu-rc-audit-checklist-20260430.md`.
+- [x] Create staging smoke checklist for manual tester.
+  - PR: pending
+  - Merge commit: pending
+  - Development MD: `docs/development/multitable-feishu-rc-audit-development-20260430.md`
+  - Verification MD: `docs/development/multitable-feishu-rc-audit-verification-20260430.md`
+  - Verification summary: checklist added at `docs/development/multitable-feishu-staging-smoke-checklist-20260430.md`.
 - [ ] Verify staging deployment target version and document exact commit.
 - [ ] Smoke test basic multitable sheet lifecycle: create base, sheet, view, fields, records.
 - [ ] Smoke test xlsx frontend import/export with a real file.
@@ -56,7 +81,12 @@ Do not mark an item done if:
 - [ ] Smoke test Hierarchy view rendering and child creation.
 - [ ] Smoke test public form submit path.
 - [ ] Smoke test automation send_email save/execute path.
-- [ ] Produce RC audit result MD with P0/P1/P2 defects.
+- [x] Produce RC audit result MD with P0/P1/P2 defects.
+  - PR: pending
+  - Merge commit: pending
+  - Development MD: `docs/development/multitable-feishu-rc-audit-development-20260430.md`
+  - Verification MD: `docs/development/multitable-feishu-rc-audit-verification-20260430.md`
+  - Verification summary: result added at `docs/development/multitable-feishu-rc-audit-result-20260430.md`; staging-only smoke items remain unchecked.
 
 Expected docs:
 

--- a/docs/development/multitable-feishu-staging-smoke-checklist-20260430.md
+++ b/docs/development/multitable-feishu-staging-smoke-checklist-20260430.md
@@ -1,0 +1,135 @@
+# Multitable Feishu RC Staging Smoke Checklist - 2026-04-30
+
+## Preconditions
+
+- [ ] Staging is deployed from `origin/main >= 08f4ff920`.
+- [ ] Tester has an admin account for the test base.
+- [ ] Test base contains at least one sheet with 20+ records.
+- [ ] Browser console and backend logs are available to capture failures.
+- [ ] A real `.xlsx` fixture is available with text, number, date, select-like, and empty cells.
+- [ ] If email smoke is required, staging has an operational email provider configured.
+
+Record exact staging evidence:
+
+- Staging URL:
+- Deployed commit:
+- Tester:
+- Test base id:
+- Test sheet id:
+- Browser:
+- Backend log source:
+
+## Smoke 1 - Basic Sheet Lifecycle
+
+- [ ] Create a base.
+- [ ] Create a sheet.
+- [ ] Create grid, form, kanban, gallery, calendar, timeline, gantt, and hierarchy views.
+- [ ] Add a normal text field and one record.
+- [ ] Edit the record in grid.
+- [ ] Open record drawer.
+- [ ] Add a comment.
+- [ ] Refresh browser and confirm record/comment persist.
+
+## Smoke 2 - XLSX Import / Export
+
+- [ ] Import `.xlsx` from `MetaImportModal`.
+- [ ] Confirm column mapping screen appears.
+- [ ] Confirm record count after import matches expected row count.
+- [ ] Confirm imported dates and numbers preserve usable values.
+- [ ] Export `.xlsx` from toolbar.
+- [ ] Reopen exported file in Excel or WPS.
+- [ ] Re-import exported file into a scratch sheet and compare row/field count.
+- [ ] Record whether backend xlsx routes are unavailable or not used.
+
+## Smoke 3 - Field Types
+
+- [ ] Create currency field and save `1234.56`.
+- [ ] Create percent field and save `0.255`.
+- [ ] Create rating field and save a 3-star value.
+- [ ] Create url field and save `https://example.com`.
+- [ ] Create email field and save `user@example.com`.
+- [ ] Create phone field and save `+86 138 1234 5678`.
+- [ ] Create longText field and save multiline content.
+- [ ] Create multiSelect field with at least three options and save two selected options.
+- [ ] Refresh page and verify all values persist.
+- [ ] Verify invalid url/email/phone values are rejected.
+
+## Smoke 4 - Conditional Formatting
+
+- [ ] Add number rule: value `> 100`, red background.
+- [ ] Add select or multiSelect rule: contains selected option, green background.
+- [ ] Add text rule: contains `urgent`, apply to row.
+- [ ] Reorder rules and confirm first-match behavior.
+- [ ] Disable a rule and confirm style is removed.
+- [ ] Refresh page and confirm rules persist.
+
+## Smoke 5 - Formula Editor
+
+- [ ] Create formula field.
+- [ ] Insert a field token from the UI.
+- [ ] Insert a function from the catalog.
+- [ ] Save a valid formula.
+- [ ] Confirm evaluated value appears in grid.
+- [ ] Try an unknown field token and confirm diagnostics block or warn as designed.
+- [ ] Refresh page and confirm formula expression persists.
+
+## Smoke 6 - Filter Builder / View Config
+
+- [ ] Add text contains filter.
+- [ ] Add number comparison filter.
+- [ ] Add boolean true/false filter.
+- [ ] Add select or multiSelect option-backed filter.
+- [ ] Use `isEmpty` or `isNotEmpty` and confirm no value input is required.
+- [ ] Save filter config to view.
+- [ ] Refresh page and confirm filter persists.
+
+## Smoke 7 - Gantt View
+
+- [ ] Configure start date field.
+- [ ] Configure end date field.
+- [ ] Configure title field.
+- [ ] Configure progress field.
+- [ ] Confirm scheduled records render as bars.
+- [ ] Confirm records missing dates appear in unscheduled/placeholder area.
+- [ ] Select a Gantt row and confirm record drawer opens.
+
+## Smoke 8 - Hierarchy View
+
+- [ ] Configure parent link field.
+- [ ] Configure title field.
+- [ ] Create a root record.
+- [ ] Create a child record using `+ Child`.
+- [ ] Confirm tree expands/collapses.
+- [ ] Confirm orphan handling matches selected mode.
+- [ ] Select a tree node and confirm record drawer opens.
+
+## Smoke 9 - Public Form
+
+- [ ] Enable public form share.
+- [ ] Open public form URL in an unauthenticated/incognito browser.
+- [ ] Submit a valid record.
+- [ ] Confirm success page appears.
+- [ ] Confirm submitted record appears in authenticated sheet.
+- [ ] Submit invalid field data and confirm validation error appears.
+
+## Smoke 10 - Automation `send_email`
+
+- [ ] Create automation rule with `send_email` action.
+- [ ] Configure recipients, subject template, and body template.
+- [ ] Save rule.
+- [ ] Trigger rule with a record event.
+- [ ] Confirm automation log records success or a clear provider/config failure.
+- [ ] If provider is configured, confirm email delivery.
+
+## Failure Capture Template
+
+For every failed smoke item, record:
+
+- Smoke item:
+- Sheet/view/record id:
+- Expected:
+- Actual:
+- Browser console:
+- Backend log excerpt:
+- Screenshot or artifact path:
+- Severity: P0/P1/P2


### PR DESCRIPTION
## Summary
- Add Phase 1 RC audit checklist for merged multitable Feishu-parity capabilities.
- Add staging smoke checklist with ten manual smoke sections.
- Add RC audit result with P0/P1/P2 findings.
- Update the master RC TODO to mark only docs/audit items completed; staging execution remains unchecked.

## Verification
- `git status --short` showed only docs changes.
- `git diff --check` exited 0.
- `rg` checks confirmed P0/P1/P2 findings, Smoke 1-10 sections, TODO links, and docs-only scope.

## Notes
- Docs-only. No source code, migrations, OpenAPI dist, package manifests, or runtime behavior changed.
- P0 findings intentionally include missing staging smoke evidence and missing backend xlsx routes.