### PR TITLE
fix(integration): align K3 setup frontend permissions

### DIFF
--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -38,7 +38,7 @@
             <router-link v-if="canManageUsers" to="/admin/permissions" class="nav-link">{{ navLabels.permissions }}</router-link>
             <router-link v-if="canManageUsers" to="/admin/audit" class="nav-link">{{ navLabels.adminAudit }}</router-link>
             <router-link v-if="canManageUsers" to="/approvals/metrics" class="nav-link">{{ navLabels.approvalMetrics }}</router-link>
-            <router-link v-if="isAdmin" to="/integrations/k3-wise" class="nav-link">{{ navLabels.erpIntegration }}</router-link>
+            <router-link v-if="canUseIntegration" to="/integrations/k3-wise" class="nav-link">{{ navLabels.erpIntegration }}</router-link>
             <router-link v-if="isAdmin" to="/admin/plugins" class="nav-link">{{ navLabels.plugins }}</router-link>
             <router-link v-if="canUsePlm" to="/plm" class="nav-link">{{ navLabels.plm }}</router-link>
             <router-link v-if="canUsePlm" to="/plm/audit" class="nav-link">{{ navLabels.audit }}</router-link>
@@ -86,7 +86,7 @@ import { getApiBase } from './utils/api'
 const route = useRoute()
 const { navItems: pluginNavItems, fetchPlugins } = usePlugins()
 const { isAttendanceFocused, isPlmWorkbenchFocused, hasFeature, loadProductFeatures } = useFeatureFlags()
-const { clearToken, getAccessSnapshot, getToken } = useAuth()
+const { clearToken, getAccessSnapshot, getToken, hasPermission } = useAuth()
 const { locale, isZh, setLocale } = useLocale()
 
 const showNav = computed(() => {
@@ -105,6 +105,10 @@ const isAdmin = computed(() => hasFeature('attendanceAdmin'))
 const canManageUsers = computed(() => {
   void route.fullPath
   return getAccessSnapshot().isAdmin
+})
+const canUseIntegration = computed(() => {
+  void route.fullPath
+  return hasPermission('integration:write')
 })
 const isLoggedIn = computed(() => {
   void route.fullPath

--- a/apps/web/src/composables/useAuth.ts
+++ b/apps/web/src/composables/useAuth.ts
@@ -410,6 +410,24 @@ export function useAuth() {
     return getAccessSnapshot().isAdmin
   }
 
+  function hasPermission(requiredPermission: string): boolean {
+    const normalized = String(requiredPermission || '').trim()
+    if (!normalized) return true
+
+    const snapshot = getAccessSnapshot()
+    if (snapshot.isAdmin || snapshot.roles.includes('admin')) return true
+
+    const permissions = snapshot.permissions
+    if (permissions.includes(normalized) || permissions.includes('*:*')) return true
+
+    const [resource, action] = normalized.split(':')
+    if (!resource || !action) return false
+    if (permissions.includes(`${resource}:*`)) return true
+    if (permissions.includes(`${resource}:admin`) && action !== 'admin') return true
+    if (action === 'read' && permissions.includes(`${resource}:write`)) return true
+    return false
+  }
+
   function getCurrentUser(): SessionUserRecord | null {
     return (extractSessionUser(sessionCache?.payload ?? null) as SessionUserRecord | null) ?? null
   }
@@ -434,6 +452,7 @@ export function useAuth() {
     buildAuthHeaders,
     getAccessSnapshot,
     hasAdminAccess,
+    hasPermission,
     getCurrentUser,
     getCurrentUserId,
   }

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -114,6 +114,11 @@ router.beforeEach(async (to, _from, next) => {
       return next(flags.resolveHomePath())
     }
 
+    const requiredPermissions = Array.isArray(to.meta?.permissions) ? to.meta.permissions : []
+    if (requiredPermissions.length > 0 && !requiredPermissions.every((permission) => auth.hasPermission(permission))) {
+      return next(flags.resolveHomePath())
+    }
+
     if (flags.isAttendanceFocused()) {
       const allowed = new Set<string>([
         '/attendance',
@@ -128,7 +133,7 @@ router.beforeEach(async (to, _from, next) => {
 
     if (typeof flags.isPlmWorkbenchFocused === 'function' && flags.isPlmWorkbenchFocused()) {
       const path = String(to.path || '')
-      const allowedPrefixes = ['/plm', '/workflows', '/approvals']
+      const allowedPrefixes = ['/plm', '/workflows', '/approvals', '/integrations']
       const allowed = allowedPrefixes.some((prefix) => path === prefix || path.startsWith(`${prefix}/`))
       if (!allowed) {
         return next('/plm')

--- a/apps/web/src/router/appRoutes.ts
+++ b/apps/web/src/router/appRoutes.ts
@@ -188,7 +188,7 @@ export const appRoutes: RouteRecordRaw[] = [
     path: '/integrations/k3-wise',
     name: AppRouteNames.INTEGRATION_K3_WISE,
     component: () => import('../views/IntegrationK3WiseSetupView.vue'),
-    meta: { title: 'K3 WISE Integration', titleZh: 'K3 WISE 对接', requiresAuth: true, requiredFeature: 'attendanceAdmin' }
+    meta: { title: 'K3 WISE Integration', titleZh: 'K3 WISE 对接', requiresAuth: true, permissions: ['integration:write'] }
   },
   {
     path: '/workflows',

--- a/apps/web/tests/k3WiseSetup.spec.ts
+++ b/apps/web/tests/k3WiseSetup.spec.ts
@@ -164,12 +164,19 @@ describe('K3 WISE setup helpers', () => {
     expect(() => buildK3WiseSetupPayloads(form)).toThrow('lcid must be a positive integer')
   })
 
-  it('keeps the K3 WISE setup route behind the same admin feature as the nav entry', async () => {
+  it('keeps the K3 WISE setup route behind integration write permission', async () => {
     const source = await readFile('src/router/appRoutes.ts', 'utf8')
+    const mainSource = await readFile('src/main.ts', 'utf8')
+    const routeStart = source.indexOf("path: '/integrations/k3-wise'")
+    const routeEnd = source.indexOf("path: '/workflows'", routeStart)
+    const routeBlock = source.slice(routeStart, routeEnd)
 
-    expect(source).toContain("path: '/integrations/k3-wise'")
-    expect(source).toContain("titleZh: 'K3 WISE 对接'")
-    expect(source).toContain("requiredFeature: 'attendanceAdmin'")
+    expect(routeBlock).toContain("path: '/integrations/k3-wise'")
+    expect(routeBlock).toContain("titleZh: 'K3 WISE 对接'")
+    expect(routeBlock).toContain("permissions: ['integration:write']")
+    expect(routeBlock).not.toContain("requiredFeature: 'attendanceAdmin'")
+    expect(mainSource).toContain('to.meta?.permissions')
+    expect(mainSource).toContain('auth.hasPermission(permission)')
   })
 
   it('splits comma and newline table lists', () => {

--- a/apps/web/tests/platform-shell-nav.spec.ts
+++ b/apps/web/tests/platform-shell-nav.spec.ts
@@ -67,6 +67,7 @@ describe('platform shell navigation', () => {
           isAdmin: false,
         }),
         getToken: () => 'session-token',
+        hasPermission: () => false,
       }),
     }))
 
@@ -106,13 +107,97 @@ describe('platform shell navigation', () => {
     ]))
     expect(links.some((link) => link.href === '/plm')).toBe(false)
     expect(links.some((link) => link.href === '/plm/audit')).toBe(false)
+    expect(links.some((link) => link.href === '/integrations/k3-wise')).toBe(false)
+  })
+
+  it('shows ERP integration navigation for integration write permission without attendance admin', async () => {
+    vi.doMock('vue-router', () => ({
+      useRoute: () => ({
+        path: '/grid',
+        fullPath: '/grid',
+        meta: { requiresAuth: true },
+      }),
+    }))
+
+    vi.doMock('../src/composables/usePlugins', () => ({
+      usePlugins: () => ({
+        navItems: ref([]),
+        fetchPlugins: vi.fn().mockResolvedValue(undefined),
+      }),
+    }))
+
+    vi.doMock('../src/stores/featureFlags', () => ({
+      useFeatureFlags: () => ({
+        loadProductFeatures: vi.fn().mockResolvedValue(undefined),
+        isAttendanceFocused: () => false,
+        isPlmWorkbenchFocused: () => false,
+        hasFeature: (feature: string) => feature === 'plm',
+      }),
+    }))
+
+    vi.doMock('../src/composables/useLocale', () => ({
+      useLocale: () => ({
+        locale: ref('zh-CN'),
+        isZh: ref(true),
+        setLocale: vi.fn(),
+      }),
+    }))
+
+    vi.doMock('../src/composables/useAuth', () => ({
+      useAuth: () => ({
+        clearToken: vi.fn(),
+        getAccessSnapshot: () => ({
+          email: 'integrator@test.local',
+          roles: ['integration_operator'],
+          permissions: ['integration:write'],
+          isAdmin: false,
+        }),
+        getToken: () => 'session-token',
+        hasPermission: (permission: string) => permission === 'integration:read' || permission === 'integration:write',
+      }),
+    }))
+
+    vi.doMock('../src/utils/api', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('../src/utils/api')>()
+      return {
+        ...actual,
+        getApiBase: () => 'http://example.test',
+      }
+    })
+
+    const { default: App } = await import('../src/App.vue')
+
+    container = document.createElement('div')
+    document.body.appendChild(container)
+
+    app = createApp(App as Component)
+    app.component('router-view', { render: () => h('div') })
+    app.component('router-link', {
+      props: ['to'],
+      render() {
+        return h('a', { href: this.$props.to }, this.$slots.default ? this.$slots.default() : [])
+      },
+    })
+
+    app.mount(container)
+    await flushUi()
+
+    const links = Array.from(container.querySelectorAll('a')).map((node) => ({
+      href: node.getAttribute('href'),
+      text: node.textContent?.trim(),
+    }))
+
+    expect(links).toEqual(expect.arrayContaining([
+      expect.objectContaining({ href: '/integrations/k3-wise', text: 'ERP 对接' }),
+    ]))
+    expect(links.some((link) => link.href === '/admin/users')).toBe(false)
   })
 
   it('keeps a dedicated approvals route in the platform shell', async () => {
     const source = await readFile(resolve(process.cwd(), 'src/router/appRoutes.ts'), 'utf8')
 
     expect(source).toContain("path: '/approvals'")
-    expect(source).toContain("import('../views/ApprovalInboxView.vue')")
+    expect(source).toContain("import('../views/approval/ApprovalCenterView.vue')")
     expect(source).toContain("titleZh: '审批中心'")
     expect(source).toContain("path: '/p/plugin-attendance/attendance'")
     expect(source).toContain("redirect: '/attendance'")

--- a/apps/web/tests/useAuth.spec.ts
+++ b/apps/web/tests/useAuth.spec.ts
@@ -105,6 +105,30 @@ describe('useAuth', () => {
     expect(hasAdminAccess()).toBe(true)
   })
 
+  it('matches integration permissions with backend-compatible hierarchy', () => {
+    store.user_permissions = JSON.stringify(['integration:write'])
+    const { hasPermission } = useAuth()
+
+    expect(hasPermission('integration:read')).toBe(true)
+    expect(hasPermission('integration:write')).toBe(true)
+    expect(hasPermission('integration:admin')).toBe(false)
+    expect(hasPermission('attendance:read')).toBe(false)
+  })
+
+  it('allows resource admin and role admin permissions through the shared helper', () => {
+    store.user_permissions = JSON.stringify(['integration:admin'])
+    const { hasPermission, clearStoredUserSnapshot } = useAuth()
+
+    expect(hasPermission('integration:read')).toBe(true)
+    expect(hasPermission('integration:write')).toBe(true)
+    expect(hasPermission('integration:admin')).toBe(true)
+
+    clearStoredUserSnapshot()
+    store.user_roles = JSON.stringify(['admin'])
+
+    expect(hasPermission('integration:write')).toBe(true)
+  })
+
   it('bootstraps session only once for the same token and reuses the cached payload', async () => {
     store.jwt = 'stable-token'
     store.tenantId = 'tenant_42'

--- a/docs/development/integration-k3wise-permission-gate-design-20260430.md
+++ b/docs/development/integration-k3wise-permission-gate-design-20260430.md
@@ -1,0 +1,72 @@
+# K3 WISE Setup Permission Gate Design - 2026-04-30
+
+## Context
+
+The K3 WISE setup page is the operator-facing entry point for external systems,
+pipeline templates, staging installation, dry runs, and live pipeline runs.
+Backend integration routes already enforce the `integration:*` permission model,
+but the frontend route and shell entry were still tied to the older
+`attendanceAdmin` feature gate.
+
+That mismatch created two bad states:
+
+- A user with `integration:write` could use the backend API but could not see or
+  open the K3 WISE setup page.
+- A user with `attendanceAdmin` but no `integration:*` permission could open the
+  page, then hit backend `403` responses on save/install/run actions.
+
+## Decision
+
+Gate the K3 WISE setup entry with `integration:write`, not `integration:read`.
+
+Reasoning:
+
+- The current page is a setup console, not a read-only dashboard.
+- The page exposes write actions including external-system upsert, credential
+  test, staging install, pipeline upsert, dry run, and run.
+- A read-only entry would require action-level UI disabling for every write
+  control. That can be added later as a dedicated read-only mode, but it is not
+  the smallest safe internal-trial fix.
+
+## Implementation
+
+Changed files:
+
+- `apps/web/src/composables/useAuth.ts`
+  - Adds `hasPermission(requiredPermission)`.
+  - Mirrors backend-compatible hierarchy:
+    - `snapshot.isAdmin` and role `admin` allow all permission checks.
+    - Exact permission and `*:*` allow the check.
+    - `resource:*` allows every action in the resource.
+    - `resource:admin` allows resource actions and exact admin checks.
+    - `resource:write` allows `resource:read`.
+
+- `apps/web/src/main.ts`
+  - Reads `to.meta.permissions`.
+  - Blocks routes when any required permission is missing.
+
+- `apps/web/src/router/appRoutes.ts`
+  - Changes `/integrations/k3-wise` from the `attendanceAdmin` feature gate to
+    `permissions: ['integration:write']`.
+
+- `apps/web/src/App.vue`
+  - Shows the ERP integration navigation entry when
+    `hasPermission('integration:write')` is true.
+
+## Non-Goals
+
+- This does not implement a read-only K3 WISE setup mode.
+- This does not change backend RBAC; it aligns frontend gating with the existing
+  backend integration route contract.
+- This does not change customer GATE requirements or K3 WISE live-connection
+  behavior.
+
+## Follow-Up
+
+For internal staging signoff, the next non-customer blocker is deployment
+evidence:
+
+- Run the K3 postdeploy smoke with authenticated checks enabled.
+- Ensure the target tenant has integration permissions seeded for the test
+  operator.
+- Treat public-only smoke as insufficient for internal trial signoff.

--- a/docs/development/integration-k3wise-permission-gate-verification-20260430.md
+++ b/docs/development/integration-k3wise-permission-gate-verification-20260430.md
@@ -1,0 +1,53 @@
+# K3 WISE Setup Permission Gate Verification - 2026-04-30
+
+## Scope
+
+This verification covers the frontend permission gate for the K3 WISE setup
+entry point.
+
+It validates:
+
+- `integration:write` can open the setup entry without `attendanceAdmin`.
+- `attendanceAdmin` alone no longer exposes the ERP integration navigation link.
+- `integration:write` implies `integration:read`.
+- `integration:admin` and role `admin` satisfy integration setup checks.
+- The route meta is enforced by the global router guard.
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile --ignore-scripts
+pnpm --filter @metasheet/web exec vitest run \
+  tests/useAuth.spec.ts \
+  tests/k3WiseSetup.spec.ts \
+  tests/platform-shell-nav.spec.ts \
+  tests/App.spec.ts \
+  --watch=false
+
+pnpm --filter @metasheet/web run lint
+pnpm --filter @metasheet/web run type-check
+```
+
+## Result
+
+```text
+Test Files  4 passed (4)
+Tests       33 passed (33)
+```
+
+Additional checks:
+
+```text
+pnpm --filter @metasheet/web run lint        PASS
+pnpm --filter @metasheet/web run type-check  PASS
+git diff --check HEAD~1..HEAD                PASS
+```
+
+## Notes
+
+- The isolated worktree did not have `node_modules`, so dependencies were
+  installed locally before running Vitest.
+- No customer K3 WISE credentials, customer tenant, SQL Server, or PLM endpoint
+  were used.
+- This is not a staging deployment signoff. Deployment signoff still requires
+  authenticated K3 WISE postdeploy smoke against the target environment.


### PR DESCRIPTION
## Summary
- align the K3 WISE setup route/nav with backend integration permissions instead of attendanceAdmin
- add a shared frontend hasPermission helper and route-meta permission guard
- document the permission-gate design and verification results

## Why
The backend integration plugin already uses integration:read/write/admin, but the frontend K3 WISE setup entry was gated by attendanceAdmin. That blocked real integration operators and allowed attendance admins into a page that would then 403 on write actions.

## Verification
- pnpm --filter @metasheet/web exec vitest run tests/useAuth.spec.ts tests/k3WiseSetup.spec.ts tests/platform-shell-nav.spec.ts tests/App.spec.ts --watch=false
- pnpm --filter @metasheet/web run lint
- pnpm --filter @metasheet/web run type-check
- git diff --check HEAD~1..HEAD

## Docs
- docs/development/integration-k3wise-permission-gate-design-20260430.md
- docs/development/integration-k3wise-permission-gate-verification-20260430.md