### PR TITLE
fix(multitable): align OpenAPI RC contracts

### DIFF
--- a/docs/development/multitable-feishu-rc-todo-20260430.md
+++ b/docs/development/multitable-feishu-rc-todo-20260430.md
@@ -3,6 +3,7 @@
 ## Status
 
 - Baseline: `origin/main@08f4ff920`
+- Latest RC worktree base used by Phase 3: `origin/main@751cb8439` after clean rebase.
 - Goal: Feishu-parity RC for staging and internal trial.
 - Current phase: RC audit first, then P0 gaps.
 - Rule: every completed item must be marked `[x]` and linked to PR, commit, development MD, and verification MD.
@@ -96,56 +97,56 @@ Expected docs:
 ## Phase 2 - P0 Gap: Backend XLSX Route Layer
 
 - [x] Decide backend `xlsx` dependency policy.
-  - PR: pending
-  - Merge commit: pending
+  - PR: #1275
+  - Merge commit: `5c4130913`
   - Development MD: `docs/development/multitable-xlsx-backend-routes-development-20260430.md`
   - Verification MD: `docs/development/multitable-xlsx-backend-routes-verification-20260430.md`
   - Verification summary: `xlsx` added as explicit `@metasheet/core-backend` runtime dependency; lockfile updated.
 - [x] Add backend xlsx import adapter or optional dependency seam.
-  - PR: pending
-  - Merge commit: pending
+  - PR: #1275
+  - Merge commit: `5c4130913`
   - Development MD: `docs/development/multitable-xlsx-backend-routes-development-20260430.md`
   - Verification MD: `docs/development/multitable-xlsx-backend-routes-verification-20260430.md`
   - Verification summary: `xlsx-service.ts` added with parse/build/map helpers; 5 focused unit tests pass.
 - [x] Implement `POST /api/multitable/sheets/:sheetId/import-xlsx`.
-  - PR: pending
-  - Merge commit: pending
+  - PR: #1275
+  - Merge commit: `5c4130913`
   - Development MD: `docs/development/multitable-xlsx-backend-routes-development-20260430.md`
   - Verification MD: `docs/development/multitable-xlsx-backend-routes-verification-20260430.md`
   - Verification summary: multipart route accepts `file`, optional `sheetName`, and optional JSON `mapping`.
 - [x] Implement `GET /api/multitable/sheets/:sheetId/export-xlsx`.
-  - PR: pending
-  - Merge commit: pending
+  - PR: #1275
+  - Merge commit: `5c4130913`
   - Development MD: `docs/development/multitable-xlsx-backend-routes-development-20260430.md`
   - Verification MD: `docs/development/multitable-xlsx-backend-routes-verification-20260430.md`
   - Verification summary: route returns XLSX binary with content-disposition and truncation header.
 - [x] Ensure import writes go through the authoritative record write path.
-  - PR: pending
-  - Merge commit: pending
+  - PR: #1275
+  - Merge commit: `5c4130913`
   - Development MD: `docs/development/multitable-xlsx-backend-routes-development-20260430.md`
   - Verification MD: `docs/development/multitable-xlsx-backend-routes-verification-20260430.md`
   - Verification summary: import delegates row writes to `RecordService.createRecord()`.
 - [x] Ensure export respects current sheet/view permissions.
-  - PR: pending
-  - Merge commit: pending
+  - PR: #1275
+  - Merge commit: `5c4130913`
   - Development MD: `docs/development/multitable-xlsx-backend-routes-development-20260430.md`
   - Verification MD: `docs/development/multitable-xlsx-backend-routes-verification-20260430.md`
   - Verification summary: export requires `canRead` and `canExport`; optional `viewId` is scope-checked.
 - [x] Add backend tests for import mapping, invalid file, permission denial, and export.
-  - PR: pending
-  - Merge commit: pending
+  - PR: #1275
+  - Merge commit: `5c4130913`
   - Development MD: `docs/development/multitable-xlsx-backend-routes-development-20260430.md`
   - Verification MD: `docs/development/multitable-xlsx-backend-routes-verification-20260430.md`
   - Verification summary: `multitable-xlsx-routes.test.ts` covers import mapping, invalid input, permission denial, and export.
 - [x] Update OpenAPI source and generated dist.
-  - PR: pending
-  - Merge commit: pending
+  - PR: #1275
+  - Merge commit: `5c4130913`
   - Development MD: `docs/development/multitable-xlsx-backend-routes-development-20260430.md`
   - Verification MD: `docs/development/multitable-xlsx-backend-routes-verification-20260430.md`
   - Verification summary: OpenAPI source updated and generated dist refreshed.
 - [x] Mark frontend-only xlsx limitation as closed or explicitly narrowed.
-  - PR: pending
-  - Merge commit: pending
+  - PR: #1275
+  - Merge commit: `5c4130913`
   - Development MD: `docs/development/multitable-xlsx-backend-routes-development-20260430.md`
   - Verification MD: `docs/development/multitable-xlsx-backend-routes-verification-20260430.md`
   - Verification summary: limitation narrowed to frontend not yet wired to backend routes; backend capability exists.
@@ -157,12 +158,42 @@ Expected docs:
 
 ## Phase 3 - P0 Gap: OpenAPI / Contract Cleanup
 
-- [ ] Audit OpenAPI coverage for new field types.
-- [ ] Audit OpenAPI coverage for new view types: `gantt`, `hierarchy`.
-- [ ] Audit OpenAPI coverage for xlsx routes after Phase 2.
-- [ ] Regenerate and commit OpenAPI dist artifacts.
-- [ ] Run OpenAPI contract guard.
-- [ ] Add a verification doc listing schema additions and generated outputs.
+- [x] Audit OpenAPI coverage for new field types.
+  - PR: #1277
+  - Merge commit: pending
+  - Development MD: `docs/development/multitable-openapi-rc-contract-cleanup-development-20260430.md`
+  - Verification MD: `docs/development/multitable-openapi-rc-contract-cleanup-verification-20260430.md`
+  - Verification summary: `MultitableFieldType` now centralizes all runtime field types including `currency`, `percent`, `rating`, `url`, `email`, and `phone`.
+- [x] Audit OpenAPI coverage for new view types: `gantt`, `hierarchy`.
+  - PR: #1277
+  - Merge commit: pending
+  - Development MD: `docs/development/multitable-openapi-rc-contract-cleanup-development-20260430.md`
+  - Verification MD: `docs/development/multitable-openapi-rc-contract-cleanup-verification-20260430.md`
+  - Verification summary: `MultitableViewType` now enumerates `grid`, `form`, `kanban`, `gallery`, `calendar`, `timeline`, `gantt`, and `hierarchy`.
+- [x] Audit OpenAPI coverage for xlsx routes after Phase 2.
+  - PR: #1277
+  - Merge commit: pending
+  - Development MD: `docs/development/multitable-openapi-rc-contract-cleanup-development-20260430.md`
+  - Verification MD: `docs/development/multitable-openapi-rc-contract-cleanup-verification-20260430.md`
+  - Verification summary: parity guard checks import/export route presence and export response headers including `Content-Disposition`.
+- [x] Regenerate and commit OpenAPI dist artifacts.
+  - PR: #1277
+  - Merge commit: pending
+  - Development MD: `docs/development/multitable-openapi-rc-contract-cleanup-development-20260430.md`
+  - Verification MD: `docs/development/multitable-openapi-rc-contract-cleanup-verification-20260430.md`
+  - Verification summary: `packages/openapi/dist/{combined.openapi.yml,openapi.json,openapi.yaml}` regenerated.
+- [x] Run OpenAPI contract guard.
+  - PR: #1277
+  - Merge commit: pending
+  - Development MD: `docs/development/multitable-openapi-rc-contract-cleanup-development-20260430.md`
+  - Verification MD: `docs/development/multitable-openapi-rc-contract-cleanup-verification-20260430.md`
+  - Verification summary: `node --test scripts/ops/multitable-openapi-parity.test.mjs` passes.
+- [x] Add a verification doc listing schema additions and generated outputs.
+  - PR: #1277
+  - Merge commit: pending
+  - Development MD: `docs/development/multitable-openapi-rc-contract-cleanup-development-20260430.md`
+  - Verification MD: `docs/development/multitable-openapi-rc-contract-cleanup-verification-20260430.md`
+  - Verification summary: this Phase 3 dev/verification pair records implementation scope and validation commands.
 
 Expected docs:
 

--- a/docs/development/multitable-openapi-rc-contract-cleanup-development-20260430.md
+++ b/docs/development/multitable-openapi-rc-contract-cleanup-development-20260430.md
@@ -1,0 +1,121 @@
+# Multitable OpenAPI RC Contract Cleanup - Development - 2026-04-30
+
+## Context
+
+Phase 3 closes the Feishu RC contract drift found after the XLSX backend route merge. The goal is to make OpenAPI, generated dist artifacts, and backend runtime validation agree on the multitable field/view surface before staging RC smoke.
+
+Base:
+
+- Worktree: `/tmp/ms2-openapi-rc-contract-20260430`
+- Branch: `codex/multitable-openapi-rc-contract-cleanup-20260430`
+- Base commit: `origin/main@751cb8439` after clean rebase
+- Preceding dependency: `#1275` XLSX backend routes merged at `5c4130913`
+
+## Changes
+
+### Field Type Contract
+
+Added a shared `MultitableFieldType` schema in `packages/openapi/src/base.yml` and pointed create/update field request schemas at it.
+
+The enum now covers the runtime field surface:
+
+- `string`
+- `number`
+- `boolean`
+- `date`
+- `formula`
+- `select`
+- `multiSelect`
+- `link`
+- `lookup`
+- `rollup`
+- `attachment`
+- `currency`
+- `percent`
+- `rating`
+- `url`
+- `email`
+- `phone`
+- `longText`
+
+Backend Zod validation in `packages/core-backend/src/routes/univer-meta.ts` now uses the same widened field type set for create/update field routes. This prevents OpenAPI from advertising types that the route layer rejects, and prevents MF2 field types from being treated as frontend-only.
+
+`mapFieldType()` also now preserves the batch1 field types instead of falling back to `string`. The focused integration test caught this as a real response-shape bug after Zod accepted `currency` but `serializeFieldRow()` returned `type: "string"`.
+
+### View Type Contract
+
+Added a shared `MultitableViewType` schema and pointed view response/create/update contracts at it.
+
+The enum now covers:
+
+- `grid`
+- `form`
+- `kanban`
+- `gallery`
+- `calendar`
+- `timeline`
+- `gantt`
+- `hierarchy`
+
+This makes Gantt and Hierarchy explicit API-level contracts instead of unconstrained strings.
+
+### XLSX Route Audit
+
+Confirmed Phase 2 XLSX routes are present in OpenAPI:
+
+- `POST /api/multitable/sheets/{sheetId}/import-xlsx`
+- `GET /api/multitable/sheets/{sheetId}/export-xlsx`
+
+Added the `Content-Disposition` response header to the export contract so the OpenAPI source documents the binary filename behavior already implemented by the backend.
+
+### Guardrail
+
+Extended `scripts/ops/multitable-openapi-parity.test.mjs` to assert:
+
+- Field type enum exactly matches the RC runtime surface.
+- View type enum exactly matches the RC view surface.
+- Create/update field route schemas use `MultitableFieldType`.
+- Create/update view route schemas use `MultitableViewType`.
+- XLSX import/export routes exist.
+- XLSX export documents truncation and content-disposition headers.
+
+### Generated Artifacts
+
+Regenerated:
+
+- `packages/openapi/dist/combined.openapi.yml`
+- `packages/openapi/dist/openapi.json`
+- `packages/openapi/dist/openapi.yaml`
+
+## Scope Control
+
+In scope:
+
+- OpenAPI schema cleanup.
+- Generated OpenAPI dist refresh.
+- Backend field type validation parity.
+- Backend field response serialization parity for batch1 field types.
+- Focused integration/parity tests.
+- TODO status update for Phase 2 merge and Phase 3 completion.
+
+Out of scope:
+
+- Frontend UI changes.
+- New field implementations.
+- New view implementations.
+- Staging smoke execution.
+- System fields, record history, subscriptions.
+
+## Files Changed
+
+- `packages/openapi/src/base.yml`
+- `packages/openapi/src/paths/multitable.yml`
+- `packages/openapi/dist/combined.openapi.yml`
+- `packages/openapi/dist/openapi.json`
+- `packages/openapi/dist/openapi.yaml`
+- `packages/core-backend/src/routes/univer-meta.ts`
+- `packages/core-backend/tests/integration/multitable-context.api.test.ts`
+- `scripts/ops/multitable-openapi-parity.test.mjs`
+- `docs/development/multitable-feishu-rc-todo-20260430.md`
+- `docs/development/multitable-openapi-rc-contract-cleanup-development-20260430.md`
+- `docs/development/multitable-openapi-rc-contract-cleanup-verification-20260430.md`

--- a/docs/development/multitable-openapi-rc-contract-cleanup-verification-20260430.md
+++ b/docs/development/multitable-openapi-rc-contract-cleanup-verification-20260430.md
@@ -1,0 +1,105 @@
+# Multitable OpenAPI RC Contract Cleanup - Verification - 2026-04-30
+
+## Environment
+
+- Worktree: `/tmp/ms2-openapi-rc-contract-20260430`
+- Branch: `codex/multitable-openapi-rc-contract-cleanup-20260430`
+- Base commit: `origin/main@751cb8439` after clean rebase
+- Node: `v24.14.1`
+- pnpm: `10.33.0`
+
+The worktree required `pnpm install --ignore-scripts` before OpenAPI generation because `/tmp` worktrees do not share the root checkout dependency resolution path. Plugin/tool node_modules symlink churn from that install was reverted before commit.
+
+## Commands Run
+
+```bash
+pnpm install --ignore-scripts
+pnpm exec tsx packages/openapi/tools/build.ts
+pnpm exec tsx packages/openapi/tools/validate.ts
+node --test scripts/ops/multitable-openapi-parity.test.mjs
+pnpm run verify:multitable-openapi:parity
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/multitable-context.api.test.ts --reporter=dot
+git diff --check
+```
+
+## Results
+
+### OpenAPI Build
+
+```text
+Built OpenAPI to dist with parts: [
+  'admin-plugins.yml',
+  'approvals.yml',
+  'attendance.yml',
+  'audit.yml',
+  'auth.yml',
+  'comments.yml',
+  'data-sources.yml',
+  'multitable.yml',
+  'permissions.yml',
+  'plm-workbench.yml',
+  'roles.yml',
+  'spreadsheet-permissions.yml',
+  'spreadsheets.yml',
+  'views.yml',
+  'workflow-designer.yml',
+  'workflow.yml'
+]
+```
+
+### OpenAPI Parity Guard
+
+```text
+OpenAPI security validation passed
+
+> metasheet-v2@2.5.0 verify:multitable-openapi:parity /private/tmp/ms2-openapi-rc-contract-20260430
+> pnpm exec tsx packages/openapi/tools/build.ts && node --test scripts/ops/multitable-openapi-parity.test.mjs
+
+✔ multitable openapi stays aligned with runtime contracts (0.64175ms)
+ℹ tests 1
+ℹ suites 0
+ℹ pass 1
+ℹ fail 0
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 42.279541
+```
+
+### Backend Runtime Contract
+
+```text
+> @metasheet/core-backend@2.5.0 build /private/tmp/ms2-openapi-rc-contract-20260430/packages/core-backend
+> tsc
+```
+
+```text
+✓ tests/integration/multitable-context.api.test.ts  (15 tests) 657ms
+
+Test Files  1 passed (1)
+     Tests  15 passed (15)
+```
+
+### Whitespace
+
+```text
+git diff --check
+# clean
+```
+
+## Assertions Covered
+
+- `MultitableFieldType` includes all 18 RC field types, including MF2 additions: `currency`, `percent`, `rating`, `url`, `email`, `phone`.
+- `MultitableViewType` includes all 8 RC view types, including `gantt` and `hierarchy`.
+- Field create/update request schemas reference `MultitableFieldType`.
+- View create/update request schemas reference `MultitableViewType`.
+- XLSX import/export paths exist in generated OpenAPI.
+- XLSX export documents both `X-MetaSheet-XLSX-Truncated` and `Content-Disposition`.
+- Backend create/update field routes accept MF2 field types.
+- Backend field response serialization preserves batch1 field types instead of mapping them to `string`.
+
+## Notes
+
+- Phase 2 XLSX TODO entries were updated to point at merged PR `#1275` and merge commit `5c4130913`.
+- Phase 3 TODO entries are marked complete for this PR, with merge fields left pending until the PR lands.

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -164,6 +164,27 @@ export function setYjsInvalidatorForRoutes(invalidator: YjsInvalidator | null): 
   yjsInvalidator = invalidator
 }
 
+const MULTITABLE_FIELD_TYPES = [
+  'string',
+  'number',
+  'boolean',
+  'date',
+  'formula',
+  'select',
+  'multiSelect',
+  'link',
+  'lookup',
+  'rollup',
+  'attachment',
+  'currency',
+  'percent',
+  'rating',
+  'url',
+  'email',
+  'phone',
+  'longText',
+] as const
+
 type UniverMetaField = {
   id: string
   name: string
@@ -1017,6 +1038,7 @@ function mapFieldType(type: string): UniverMetaField['type'] {
   if (normalized === 'lookup') return 'lookup'
   if (normalized === 'rollup') return 'rollup'
   if (normalized === 'attachment') return 'attachment'
+  if (BATCH1_FIELD_TYPES.has(normalized as any)) return normalized as UniverMetaField['type']
   if (
     normalized === 'longtext' ||
     normalized === 'long_text' ||
@@ -3722,7 +3744,7 @@ export function univerMetaRouter(): Router {
       id: z.string().min(1).max(50).optional(),
       sheetId: z.string().min(1).max(50),
       name: z.string().min(1).max(255),
-      type: z.enum(['string', 'number', 'boolean', 'date', 'formula', 'select', 'multiSelect', 'link', 'lookup', 'rollup', 'attachment', 'longText']).default('string'),
+      type: z.enum(MULTITABLE_FIELD_TYPES).default('string'),
       property: z.record(z.unknown()).optional(),
       order: z.number().int().nonnegative().optional(),
     })
@@ -3978,7 +4000,7 @@ export function univerMetaRouter(): Router {
 
     const schema = z.object({
       name: z.string().min(1).max(255).optional(),
-      type: z.enum(['string', 'number', 'boolean', 'date', 'formula', 'select', 'multiSelect', 'link', 'lookup', 'rollup', 'attachment', 'longText']).optional(),
+      type: z.enum(MULTITABLE_FIELD_TYPES).optional(),
       property: z.record(z.unknown()).optional(),
       order: z.number().int().nonnegative().optional(),
     }).refine((v) => Object.keys(v).length > 0, { message: 'At least one field must be updated' })

--- a/packages/core-backend/tests/integration/multitable-context.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-context.api.test.ts
@@ -935,4 +935,128 @@ describe('Multitable context API', () => {
       order: 3,
     })
   })
+
+  test('accepts MF2 field types in create and update multitable field contracts', async () => {
+    const { app } = await createApp({
+      tokenPerms: ['multitable:write'],
+      queryHandler: async (sql, params) => {
+        if (sql.includes('SELECT id FROM meta_sheets WHERE id = $1')) {
+          expect(params).toEqual(['sheet_ops'])
+          return { rows: [{ id: 'sheet_ops' }] }
+        }
+        if (sql.includes('SELECT COALESCE(MAX("order"), -1) AS max_order FROM meta_fields')) {
+          expect(params).toEqual(['sheet_ops'])
+          return { rows: [{ max_order: 3 }] }
+        }
+        if (sql.includes('INSERT INTO meta_fields')) {
+          expect(params).toEqual([
+            'fld_amount',
+            'sheet_ops',
+            'Amount',
+            'currency',
+            '{"code":"usd","decimals":2}',
+            4,
+          ])
+          return {
+            rows: [{
+              id: 'fld_amount',
+              name: 'Amount',
+              type: 'currency',
+              property: { code: 'usd', decimals: 2 },
+              order: 4,
+            }],
+          }
+        }
+        if (sql.includes('SELECT id, name, type, property, "order" FROM meta_fields WHERE id = $1')) {
+          if (params?.[0] === 'fld_amount') {
+            return {
+              rows: [{
+                id: 'fld_amount',
+                name: 'Amount',
+                type: 'currency',
+                property: { code: 'usd', decimals: 2 },
+                order: 4,
+              }],
+            }
+          }
+          throw new Error(`Unexpected field lookup params: ${JSON.stringify(params)}`)
+        }
+        if (sql.includes('SELECT id, sheet_id FROM meta_fields WHERE id = $1')) {
+          if (params?.[0] === 'fld_amount') {
+            return { rows: [{ id: 'fld_amount', sheet_id: 'sheet_ops' }] }
+          }
+          throw new Error(`Unexpected field lookup params: ${JSON.stringify(params)}`)
+        }
+        if (sql.includes('SELECT id, sheet_id, name, type, property, "order" FROM meta_fields WHERE id = $1')) {
+          if (params?.[0] === 'fld_amount') {
+            return {
+              rows: [{
+                id: 'fld_amount',
+                sheet_id: 'sheet_ops',
+                name: 'Amount',
+                type: 'currency',
+                property: { code: 'usd', decimals: 2 },
+                order: 4,
+              }],
+            }
+          }
+          throw new Error(`Unexpected field lookup params: ${JSON.stringify(params)}`)
+        }
+        if (sql.includes('UPDATE meta_fields') && sql.includes('SET name = $2, type = $3, property = $4::jsonb, "order" = $5')) {
+          expect(params).toEqual([
+            'fld_amount',
+            'Amount',
+            'email',
+            '{}',
+            4,
+          ])
+          return {
+            rows: [{
+              id: 'fld_amount',
+              name: 'Amount',
+              type: 'email',
+              property: {},
+              order: 4,
+            }],
+          }
+        }
+        throw new Error(`Unhandled SQL in test: ${sql}`)
+      },
+    })
+
+    const createResponse = await request(app)
+      .post('/api/multitable/fields')
+      .send({
+        id: 'fld_amount',
+        sheetId: 'sheet_ops',
+        name: 'Amount',
+        type: 'currency',
+        property: { code: 'usd', decimals: 2 },
+      })
+      .expect(201)
+
+    expect(createResponse.body.data.field).toMatchObject({
+      id: 'fld_amount',
+      name: 'Amount',
+      type: 'currency',
+      property: { code: 'usd', decimals: 2 },
+      order: 4,
+    })
+
+    const updateResponse = await request(app)
+      .patch('/api/multitable/fields/fld_amount')
+      .send({
+        type: 'email',
+        property: {},
+      })
+      .expect(200)
+
+    expect(updateResponse.body.data.field).toMatchObject({
+      id: 'fld_amount',
+      name: 'Amount',
+      type: 'email',
+      property: {},
+      order: 4,
+    })
+  })
 })

--- a/packages/openapi/dist/combined.openapi.yml
+++ b/packages/openapi/dist/combined.openapi.yml
@@ -1567,6 +1567,38 @@ components:
         description:
           type: string
           nullable: true
+    MultitableViewType:
+      type: string
+      enum:
+        - grid
+        - form
+        - kanban
+        - gallery
+        - calendar
+        - timeline
+        - gantt
+        - hierarchy
+    MultitableFieldType:
+      type: string
+      enum:
+        - string
+        - number
+        - boolean
+        - date
+        - formula
+        - select
+        - multiSelect
+        - link
+        - lookup
+        - rollup
+        - attachment
+        - currency
+        - percent
+        - rating
+        - url
+        - email
+        - phone
+        - longText
     MultitableView:
       type: object
       properties:
@@ -1577,7 +1609,7 @@ components:
         name:
           type: string
         type:
-          type: string
+          $ref: '#/components/schemas/MultitableViewType'
         filterInfo:
           type: object
           additionalProperties: true
@@ -1602,20 +1634,7 @@ components:
         name:
           type: string
         type:
-          type: string
-          enum:
-            - string
-            - number
-            - boolean
-            - date
-            - formula
-            - select
-            - multiSelect
-            - link
-            - lookup
-            - rollup
-            - attachment
-            - longText
+          $ref: '#/components/schemas/MultitableFieldType'
         property:
           type: object
           additionalProperties: true
@@ -11177,6 +11196,10 @@ paths:
                   - 'true'
                   - 'false'
               description: Whether the export hit the server-side row cap.
+            Content-Disposition:
+              schema:
+                type: string
+              description: Attachment filename header.
           content:
             application/vnd.openxmlformats-officedocument.spreadsheetml.sheet:
               schema:
@@ -11459,20 +11482,7 @@ paths:
                 name:
                   type: string
                 type:
-                  type: string
-                  enum:
-                    - string
-                    - number
-                    - boolean
-                    - date
-                    - formula
-                    - select
-                    - multiSelect
-                    - link
-                    - lookup
-                    - rollup
-                    - attachment
-                    - longText
+                  $ref: '#/components/schemas/MultitableFieldType'
                 property:
                   type: object
                   additionalProperties: true
@@ -11533,20 +11543,7 @@ paths:
                 name:
                   type: string
                 type:
-                  type: string
-                  enum:
-                    - string
-                    - number
-                    - boolean
-                    - date
-                    - formula
-                    - select
-                    - multiSelect
-                    - link
-                    - lookup
-                    - rollup
-                    - attachment
-                    - longText
+                  $ref: '#/components/schemas/MultitableFieldType'
                 property:
                   type: object
                   additionalProperties: true
@@ -11674,7 +11671,7 @@ paths:
                 name:
                   type: string
                 type:
-                  type: string
+                  $ref: '#/components/schemas/MultitableViewType'
                 filterInfo:
                   type: object
                   additionalProperties: true
@@ -11740,7 +11737,7 @@ paths:
                 name:
                   type: string
                 type:
-                  type: string
+                  $ref: '#/components/schemas/MultitableViewType'
                 filterInfo:
                   type: object
                   additionalProperties: true

--- a/packages/openapi/dist/openapi.json
+++ b/packages/openapi/dist/openapi.json
@@ -2261,6 +2261,42 @@
           }
         }
       },
+      "MultitableViewType": {
+        "type": "string",
+        "enum": [
+          "grid",
+          "form",
+          "kanban",
+          "gallery",
+          "calendar",
+          "timeline",
+          "gantt",
+          "hierarchy"
+        ]
+      },
+      "MultitableFieldType": {
+        "type": "string",
+        "enum": [
+          "string",
+          "number",
+          "boolean",
+          "date",
+          "formula",
+          "select",
+          "multiSelect",
+          "link",
+          "lookup",
+          "rollup",
+          "attachment",
+          "currency",
+          "percent",
+          "rating",
+          "url",
+          "email",
+          "phone",
+          "longText"
+        ]
+      },
       "MultitableView": {
         "type": "object",
         "properties": {
@@ -2274,7 +2310,7 @@
             "type": "string"
           },
           "type": {
-            "type": "string"
+            "$ref": "#/components/schemas/MultitableViewType"
           },
           "filterInfo": {
             "type": "object",
@@ -2310,21 +2346,7 @@
             "type": "string"
           },
           "type": {
-            "type": "string",
-            "enum": [
-              "string",
-              "number",
-              "boolean",
-              "date",
-              "formula",
-              "select",
-              "multiSelect",
-              "link",
-              "lookup",
-              "rollup",
-              "attachment",
-              "longText"
-            ]
+            "$ref": "#/components/schemas/MultitableFieldType"
           },
           "property": {
             "type": "object",
@@ -17221,6 +17243,12 @@
                   ]
                 },
                 "description": "Whether the export hit the server-side row cap."
+              },
+              "Content-Disposition": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "Attachment filename header."
               }
             },
             "content": {
@@ -17671,21 +17699,7 @@
                     "type": "string"
                   },
                   "type": {
-                    "type": "string",
-                    "enum": [
-                      "string",
-                      "number",
-                      "boolean",
-                      "date",
-                      "formula",
-                      "select",
-                      "multiSelect",
-                      "link",
-                      "lookup",
-                      "rollup",
-                      "attachment",
-                      "longText"
-                    ]
+                    "$ref": "#/components/schemas/MultitableFieldType"
                   },
                   "property": {
                     "type": "object",
@@ -17784,21 +17798,7 @@
                     "type": "string"
                   },
                   "type": {
-                    "type": "string",
-                    "enum": [
-                      "string",
-                      "number",
-                      "boolean",
-                      "date",
-                      "formula",
-                      "select",
-                      "multiSelect",
-                      "link",
-                      "lookup",
-                      "rollup",
-                      "attachment",
-                      "longText"
-                    ]
+                    "$ref": "#/components/schemas/MultitableFieldType"
                   },
                   "property": {
                     "type": "object",
@@ -18008,7 +18008,7 @@
                     "type": "string"
                   },
                   "type": {
-                    "type": "string"
+                    "$ref": "#/components/schemas/MultitableViewType"
                   },
                   "filterInfo": {
                     "type": "object",
@@ -18112,7 +18112,7 @@
                     "type": "string"
                   },
                   "type": {
-                    "type": "string"
+                    "$ref": "#/components/schemas/MultitableViewType"
                   },
                   "filterInfo": {
                     "type": "object",

--- a/packages/openapi/dist/openapi.yaml
+++ b/packages/openapi/dist/openapi.yaml
@@ -1567,6 +1567,38 @@ components:
         description:
           type: string
           nullable: true
+    MultitableViewType:
+      type: string
+      enum:
+        - grid
+        - form
+        - kanban
+        - gallery
+        - calendar
+        - timeline
+        - gantt
+        - hierarchy
+    MultitableFieldType:
+      type: string
+      enum:
+        - string
+        - number
+        - boolean
+        - date
+        - formula
+        - select
+        - multiSelect
+        - link
+        - lookup
+        - rollup
+        - attachment
+        - currency
+        - percent
+        - rating
+        - url
+        - email
+        - phone
+        - longText
     MultitableView:
       type: object
       properties:
@@ -1577,7 +1609,7 @@ components:
         name:
           type: string
         type:
-          type: string
+          $ref: '#/components/schemas/MultitableViewType'
         filterInfo:
           type: object
           additionalProperties: true
@@ -1602,20 +1634,7 @@ components:
         name:
           type: string
         type:
-          type: string
-          enum:
-            - string
-            - number
-            - boolean
-            - date
-            - formula
-            - select
-            - multiSelect
-            - link
-            - lookup
-            - rollup
-            - attachment
-            - longText
+          $ref: '#/components/schemas/MultitableFieldType'
         property:
           type: object
           additionalProperties: true
@@ -11177,6 +11196,10 @@ paths:
                   - 'true'
                   - 'false'
               description: Whether the export hit the server-side row cap.
+            Content-Disposition:
+              schema:
+                type: string
+              description: Attachment filename header.
           content:
             application/vnd.openxmlformats-officedocument.spreadsheetml.sheet:
               schema:
@@ -11459,20 +11482,7 @@ paths:
                 name:
                   type: string
                 type:
-                  type: string
-                  enum:
-                    - string
-                    - number
-                    - boolean
-                    - date
-                    - formula
-                    - select
-                    - multiSelect
-                    - link
-                    - lookup
-                    - rollup
-                    - attachment
-                    - longText
+                  $ref: '#/components/schemas/MultitableFieldType'
                 property:
                   type: object
                   additionalProperties: true
@@ -11533,20 +11543,7 @@ paths:
                 name:
                   type: string
                 type:
-                  type: string
-                  enum:
-                    - string
-                    - number
-                    - boolean
-                    - date
-                    - formula
-                    - select
-                    - multiSelect
-                    - link
-                    - lookup
-                    - rollup
-                    - attachment
-                    - longText
+                  $ref: '#/components/schemas/MultitableFieldType'
                 property:
                   type: object
                   additionalProperties: true
@@ -11674,7 +11671,7 @@ paths:
                 name:
                   type: string
                 type:
-                  type: string
+                  $ref: '#/components/schemas/MultitableViewType'
                 filterInfo:
                   type: object
                   additionalProperties: true
@@ -11740,7 +11737,7 @@ paths:
                 name:
                   type: string
                 type:
-                  type: string
+                  $ref: '#/components/schemas/MultitableViewType'
                 filterInfo:
                   type: object
                   additionalProperties: true

--- a/packages/openapi/src/base.yml
+++ b/packages/openapi/src/base.yml
@@ -1510,6 +1510,38 @@ components:
         description:
           type: string
           nullable: true
+    MultitableViewType:
+      type: string
+      enum:
+        - grid
+        - form
+        - kanban
+        - gallery
+        - calendar
+        - timeline
+        - gantt
+        - hierarchy
+    MultitableFieldType:
+      type: string
+      enum:
+        - string
+        - number
+        - boolean
+        - date
+        - formula
+        - select
+        - multiSelect
+        - link
+        - lookup
+        - rollup
+        - attachment
+        - currency
+        - percent
+        - rating
+        - url
+        - email
+        - phone
+        - longText
     MultitableView:
       type: object
       properties:
@@ -1520,7 +1552,7 @@ components:
         name:
           type: string
         type:
-          type: string
+          $ref: '#/components/schemas/MultitableViewType'
         filterInfo:
           type: object
           additionalProperties: true
@@ -1545,20 +1577,7 @@ components:
         name:
           type: string
         type:
-          type: string
-          enum:
-            - string
-            - number
-            - boolean
-            - date
-            - formula
-            - select
-            - multiSelect
-            - link
-            - lookup
-            - rollup
-            - attachment
-            - longText
+          $ref: '#/components/schemas/MultitableFieldType'
         property:
           type: object
           additionalProperties: true

--- a/packages/openapi/src/paths/multitable.yml
+++ b/packages/openapi/src/paths/multitable.yml
@@ -208,6 +208,9 @@ paths:
             X-MetaSheet-XLSX-Truncated:
               schema: { type: string, enum: ['true', 'false'] }
               description: Whether the export hit the server-side row cap.
+            Content-Disposition:
+              schema: { type: string }
+              description: Attachment filename header.
           content:
             application/vnd.openxmlformats-officedocument.spreadsheetml.sheet:
               schema:
@@ -423,8 +426,7 @@ paths:
                 sheetId: { type: string }
                 name: { type: string }
                 type:
-                  type: string
-                  enum: [string, number, boolean, date, formula, select, multiSelect, link, lookup, rollup, attachment, longText]
+                  $ref: '#/components/schemas/MultitableFieldType'
                 property:
                   type: object
                   additionalProperties: true
@@ -474,8 +476,7 @@ paths:
               properties:
                 name: { type: string }
                 type:
-                  type: string
-                  enum: [string, number, boolean, date, formula, select, multiSelect, link, lookup, rollup, attachment, longText]
+                  $ref: '#/components/schemas/MultitableFieldType'
                 property:
                   type: object
                   additionalProperties: true
@@ -578,7 +579,8 @@ paths:
                 id: { type: string }
                 sheetId: { type: string }
                 name: { type: string }
-                type: { type: string }
+                type:
+                  $ref: '#/components/schemas/MultitableViewType'
                 filterInfo:
                   type: object
                   additionalProperties: true
@@ -632,7 +634,8 @@ paths:
               type: object
               properties:
                 name: { type: string }
-                type: { type: string }
+                type:
+                  $ref: '#/components/schemas/MultitableViewType'
                 filterInfo:
                   type: object
                   additionalProperties: true

--- a/scripts/ops/multitable-openapi-parity.test.mjs
+++ b/scripts/ops/multitable-openapi-parity.test.mjs
@@ -7,6 +7,38 @@ const rootDir = path.resolve(import.meta.dirname, '../..')
 const openapiPath = path.join(rootDir, 'packages/openapi/dist/openapi.json')
 const openapi = JSON.parse(readFileSync(openapiPath, 'utf8'))
 
+const expectedFieldTypes = [
+  'string',
+  'number',
+  'boolean',
+  'date',
+  'formula',
+  'select',
+  'multiSelect',
+  'link',
+  'lookup',
+  'rollup',
+  'attachment',
+  'currency',
+  'percent',
+  'rating',
+  'url',
+  'email',
+  'phone',
+  'longText',
+]
+
+const expectedViewTypes = [
+  'grid',
+  'form',
+  'kanban',
+  'gallery',
+  'calendar',
+  'timeline',
+  'gantt',
+  'hierarchy',
+]
+
 test('multitable openapi stays aligned with runtime contracts', () => {
   const paths = openapi.paths ?? {}
   const schemas = openapi.components?.schemas ?? {}
@@ -14,6 +46,35 @@ test('multitable openapi stays aligned with runtime contracts', () => {
   assert.ok(paths['/api/multitable/person-fields/prepare']?.post, 'missing person-field prepare endpoint')
   assert.ok(paths['/api/multitable/sheets/{sheetId}']?.delete, 'missing sheet delete endpoint')
   assert.ok(paths['/api/multitable/records/{recordId}']?.patch, 'missing single-record patch endpoint')
+  assert.ok(paths['/api/multitable/sheets/{sheetId}/import-xlsx']?.post, 'missing xlsx import endpoint')
+  assert.ok(paths['/api/multitable/sheets/{sheetId}/export-xlsx']?.get, 'missing xlsx export endpoint')
+
+  assert.deepEqual(schemas.MultitableFieldType?.enum, expectedFieldTypes)
+  assert.deepEqual(schemas.MultitableViewType?.enum, expectedViewTypes)
+  assert.equal(
+    paths['/api/multitable/fields']?.post?.requestBody?.content?.['application/json']?.schema?.properties?.type?.$ref,
+    '#/components/schemas/MultitableFieldType',
+  )
+  assert.equal(
+    paths['/api/multitable/fields/{fieldId}']?.patch?.requestBody?.content?.['application/json']?.schema?.properties?.type?.$ref,
+    '#/components/schemas/MultitableFieldType',
+  )
+  assert.equal(
+    paths['/api/multitable/views']?.post?.requestBody?.content?.['application/json']?.schema?.properties?.type?.$ref,
+    '#/components/schemas/MultitableViewType',
+  )
+  assert.equal(
+    paths['/api/multitable/views/{viewId}']?.patch?.requestBody?.content?.['application/json']?.schema?.properties?.type?.$ref,
+    '#/components/schemas/MultitableViewType',
+  )
+  assert.equal(
+    paths['/api/multitable/sheets/{sheetId}/export-xlsx']?.get?.responses?.['200']?.headers?.['X-MetaSheet-XLSX-Truncated']?.schema?.enum?.join(','),
+    'true,false',
+  )
+  assert.equal(
+    paths['/api/multitable/sheets/{sheetId}/export-xlsx']?.get?.responses?.['200']?.headers?.['Content-Disposition']?.schema?.type,
+    'string',
+  )
 
   assert.equal(
     paths['/api/multitable/view']?.get?.responses?.['200']?.content?.['application/json']?.schema?.properties?.data?.$ref,
@@ -55,6 +116,8 @@ test('multitable openapi stays aligned with runtime contracts', () => {
     '#/components/schemas/MultitablePatchResult',
   )
 
+  assert.equal(schemas.MultitableView?.properties?.type?.$ref, '#/components/schemas/MultitableViewType')
+  assert.equal(schemas.MultitableField?.properties?.type?.$ref, '#/components/schemas/MultitableFieldType')
   assert.equal(schemas.MultitableView?.properties?.config?.type, 'object')
   assert.equal(schemas.MultitableField?.properties?.options?.items?.properties?.value?.type, 'string')
   assert.equal(


### PR DESCRIPTION
## Summary

Closes Phase 3 of the Multitable Feishu RC TODO by aligning OpenAPI, generated dist artifacts, and backend runtime validation for the current multitable RC surface.

## Changes

- Add shared `MultitableFieldType` OpenAPI schema with all runtime field types, including `currency`, `percent`, `rating`, `url`, `email`, and `phone`.
- Add shared `MultitableViewType` OpenAPI schema with `grid`, `form`, `kanban`, `gallery`, `calendar`, `timeline`, `gantt`, and `hierarchy`.
- Point field/view create/update contracts at the shared schemas and regenerate OpenAPI dist files.
- Document XLSX export `Content-Disposition` response header.
- Widen backend field create/update Zod validation to the same field type set.
- Fix `mapFieldType()` so batch1 field types serialize back as their real type instead of falling back to `string`.
- Extend `scripts/ops/multitable-openapi-parity.test.mjs` and add focused integration coverage.
- Update Phase 2 TODO entries with merged `#1275` / `5c4130913`; mark Phase 3 items complete for this PR.

## Verification

- `pnpm exec tsx packages/openapi/tools/validate.ts`
- `pnpm run verify:multitable-openapi:parity`
- `pnpm --filter @metasheet/core-backend build`
- `pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/multitable-context.api.test.ts --reporter=dot`
- `git diff --check`

## Docs

- `docs/development/multitable-openapi-rc-contract-cleanup-development-20260430.md`
- `docs/development/multitable-openapi-rc-contract-cleanup-verification-20260430.md`
