### PR TITLE
feat(multitable): add system field backend seam

### DIFF
--- a/docs/development/multitable-feishu-rc-todo-20260430.md
+++ b/docs/development/multitable-feishu-rc-todo-20260430.md
@@ -203,15 +203,48 @@ Expected docs:
 ## Phase 4 - P0/P1 Gap: System Fields Batch
 
 - [ ] Add `autoNumber` field type.
-- [ ] Add `createdTime` field type mapped to record `created_at`.
-- [ ] Add `modifiedTime` field type mapped to record `updated_at`.
-- [ ] Add `createdBy` field type mapped to record `created_by`.
-- [ ] Add `modifiedBy` storage if missing, then expose `modifiedBy`.
-- [ ] Make all system fields readonly from normal patch/create payloads.
+  - Blocked: not included in backend seam slice because stable auto-number requires persistent sequence allocation; do not ship a row-index placeholder.
+- [x] Add `createdTime` field type mapped to record `created_at`.
+  - PR: #1280
+  - Merge commit: pending
+  - Development MD: `docs/development/multitable-system-fields-backend-development-20260430.md`
+  - Verification MD: `docs/development/multitable-system-fields-backend-verification-20260430.md`
+  - Verification summary: query service injects `createdTime` from `meta_records.created_at`.
+- [x] Add `modifiedTime` field type mapped to record `updated_at`.
+  - PR: #1280
+  - Merge commit: pending
+  - Development MD: `docs/development/multitable-system-fields-backend-development-20260430.md`
+  - Verification MD: `docs/development/multitable-system-fields-backend-verification-20260430.md`
+  - Verification summary: query service injects `modifiedTime` from `meta_records.updated_at`.
+- [x] Add `createdBy` field type mapped to record `created_by`.
+  - PR: #1280
+  - Merge commit: pending
+  - Development MD: `docs/development/multitable-system-fields-backend-development-20260430.md`
+  - Verification MD: `docs/development/multitable-system-fields-backend-verification-20260430.md`
+  - Verification summary: query service injects `createdBy` from `meta_records.created_by`.
+- [x] Add `modifiedBy` storage if missing, then expose `modifiedBy`.
+  - PR: #1280
+  - Merge commit: pending
+  - Development MD: `docs/development/multitable-system-fields-backend-development-20260430.md`
+  - Verification MD: `docs/development/multitable-system-fields-backend-verification-20260430.md`
+  - Verification summary: migration adds `meta_records.modified_by`; record write paths set it from the actor and query service injects `modifiedBy`.
+- [x] Make all system fields readonly from normal patch/create payloads.
+  - PR: #1280
+  - Merge commit: pending
+  - Development MD: `docs/development/multitable-system-fields-backend-development-20260430.md`
+  - Verification MD: `docs/development/multitable-system-fields-backend-verification-20260430.md`
+  - Verification summary: `isFieldAlwaysReadOnly()` treats system field types as readonly, reusing existing write guards.
 - [ ] Add frontend renderer/editor behavior: render-only for readonly system fields.
 - [ ] Add field manager support for creating/configuring allowed system fields.
 - [ ] Add tests for create, patch rejection, render, sorting/filtering where applicable.
-- [ ] Update OpenAPI source and generated dist.
+  - Partial: backend tests cover metadata projection and actor persistence in `docs/development/multitable-system-fields-backend-verification-20260430.md`.
+  - Remaining: frontend render/editor tests and sorting/filtering behavior tests after the UI slice.
+- [x] Update OpenAPI source and generated dist.
+  - PR: #1280
+  - Merge commit: pending
+  - Development MD: `docs/development/multitable-system-fields-backend-development-20260430.md`
+  - Verification MD: `docs/development/multitable-system-fields-backend-verification-20260430.md`
+  - Verification summary: OpenAPI field type enum and generated dist now include system field types.
 
 Expected docs:
 

--- a/docs/development/multitable-system-fields-backend-development-20260430.md
+++ b/docs/development/multitable-system-fields-backend-development-20260430.md
@@ -1,0 +1,113 @@
+# Multitable System Fields Backend - Development - 2026-04-30
+
+## Context
+
+This is the first Phase 4 slice from `docs/development/multitable-feishu-rc-todo-20260430.md`.
+
+The slice deliberately implements the backend seam for stable system fields before attempting frontend configuration polish. The main design decision is to avoid a fake `autoNumber` implementation: row-number style derivation is not stable under delete/import/concurrent create, so `autoNumber` remains deferred until a persistent sequence design is agreed.
+
+Base:
+
+- Worktree: `/tmp/ms2-system-fields-backend-20260430`
+- Branch: `codex/multitable-system-fields-backend-20260430`
+- Base commit: `origin/main@9d148580`
+
+## Implemented Scope
+
+### System Field Types
+
+Added backend/OpenAPI support for:
+
+- `createdTime`
+- `modifiedTime`
+- `createdBy`
+- `modifiedBy`
+
+Touched contract surfaces:
+
+- `packages/core-backend/src/multitable/field-codecs.ts`
+- `packages/core-backend/src/routes/univer-meta.ts`
+- `packages/openapi/src/base.yml`
+- `scripts/ops/multitable-openapi-parity.test.mjs`
+
+### Readonly Enforcement
+
+System fields are always readonly through `isFieldAlwaysReadOnly()`.
+
+This means the existing authoritative write guards reject user writes through:
+
+- `RecordWriteService.validateChanges()`
+- `RecordService.patchRecord()`
+- route-level field mutation guard maps built from `isFieldAlwaysReadOnly()`
+- XLSX import/export writable-field filtering through the same permission derivation helper
+
+### Metadata Projection
+
+`query-service` now selects record metadata:
+
+- `created_at`
+- `updated_at`
+- `created_by`
+- `modified_by`
+
+When a sheet has system fields, `mapRecordRow()` injects the corresponding metadata value into `record.data[field.id]`. This overwrites any forged JSON value for that system field ID in `meta_records.data`.
+
+### `modified_by` Persistence
+
+Added migration:
+
+- `packages/core-backend/src/db/migrations/zzzz20260430163000_add_meta_record_modified_by.ts`
+
+Behavior:
+
+- Adds nullable `meta_records.modified_by`.
+- Backfills `modified_by = created_by` where possible.
+- Adds `idx_meta_records_modified_by`.
+
+Write paths updated:
+
+- `RecordService.createRecord()` sets `created_by` and `modified_by` to the actor.
+- `RecordService.patchRecord()` sets `modified_by` to `actorId ?? access.userId`.
+- `RecordWriteService.patchRecords()` sets `modified_by` to the patch actor.
+- Direct public-form route update path sets `modified_by` to the request actor.
+- Attachment delete record-patch path sets `modified_by` to the request actor.
+
+### CI Contract Tightening
+
+The first PR CI run exposed three test doubles with over-specific SQL matching:
+
+- `multitable-records.test.ts` matched only `SELECT id, sheet_id, version, data FROM ...`.
+- `multitable-xlsx-routes.test.ts` matched only the pre-metadata record projection.
+- `multitable-record-patch.api.test.ts` expected the old three-parameter `UPDATE meta_records` call.
+
+Those tests now match the stable semantic SQL shape instead of the full column list, and PATCH integration assertions include the `modified_by` actor parameter.
+
+## Deferred
+
+`autoNumber` is not included in this slice.
+
+Reason: stable Feishu-like auto number needs a persistent allocation model, not a derived row index. A later slice should define field-level sequence state and create-time allocation semantics.
+
+## Files Changed
+
+- `packages/core-backend/src/db/migrations/zzzz20260430163000_add_meta_record_modified_by.ts`
+- `packages/core-backend/src/db/types.ts`
+- `packages/core-backend/src/multitable/field-codecs.ts`
+- `packages/core-backend/src/multitable/permission-derivation.ts`
+- `packages/core-backend/src/multitable/query-service.ts`
+- `packages/core-backend/src/multitable/record-service.ts`
+- `packages/core-backend/src/multitable/record-write-service.ts`
+- `packages/core-backend/src/routes/univer-meta.ts`
+- `packages/core-backend/tests/unit/multitable-query-service.test.ts`
+- `packages/core-backend/tests/unit/multitable-records.test.ts`
+- `packages/core-backend/tests/unit/record-service.test.ts`
+- `packages/core-backend/tests/unit/record-write-service.test.ts`
+- `packages/core-backend/tests/integration/multitable-record-patch.api.test.ts`
+- `packages/core-backend/tests/integration/multitable-xlsx-routes.test.ts`
+- `packages/openapi/src/base.yml`
+- `packages/openapi/dist/combined.openapi.yml`
+- `packages/openapi/dist/openapi.json`
+- `packages/openapi/dist/openapi.yaml`
+- `scripts/ops/multitable-openapi-parity.test.mjs`
+- `docs/development/multitable-system-fields-backend-development-20260430.md`
+- `docs/development/multitable-system-fields-backend-verification-20260430.md`

--- a/docs/development/multitable-system-fields-backend-verification-20260430.md
+++ b/docs/development/multitable-system-fields-backend-verification-20260430.md
@@ -1,0 +1,128 @@
+# Multitable System Fields Backend - Verification - 2026-04-30
+
+## Environment
+
+- Worktree: `/tmp/ms2-system-fields-backend-20260430`
+- Branch: `codex/multitable-system-fields-backend-20260430`
+- Base commit: `origin/main@9d148580`
+- Node: `v24.14.1`
+- pnpm: `10.33.0`
+
+The `/tmp` worktree required `pnpm install --ignore-scripts` so package binaries were available. Plugin/tool node_modules symlink churn from that install was reverted before commit.
+
+## Commands Run
+
+```bash
+pnpm install --ignore-scripts
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/multitable-query-service.test.ts tests/unit/record-write-service.test.ts tests/unit/record-service.test.ts --reporter=dot
+pnpm --filter @metasheet/core-backend exec vitest run tests/integration/multitable-record-patch.api.test.ts tests/integration/multitable-xlsx-routes.test.ts tests/unit/multitable-records.test.ts --reporter=dot
+CI=1 pnpm --filter @metasheet/core-backend test
+pnpm run verify:multitable-openapi:parity
+pnpm exec tsx packages/openapi/tools/validate.ts
+git diff --check
+```
+
+## Results
+
+### Backend Build
+
+```text
+> @metasheet/core-backend@2.5.0 build /private/tmp/ms2-system-fields-backend-20260430/packages/core-backend
+> tsc
+```
+
+### Focused Unit Tests
+
+```text
+✓ tests/unit/multitable-query-service.test.ts  (5 tests) 4ms
+✓ tests/unit/record-write-service.test.ts  (34 tests) 14ms
+✓ tests/unit/record-service.test.ts  (13 tests) 8ms
+
+Test Files  3 passed (3)
+     Tests  52 passed (52)
+```
+
+Expected stderr:
+
+- Existing post-commit hook tests intentionally log simulated hook failures.
+- `DATABASE_URL not set` warning comes from existing test bootstrap behavior.
+
+### CI Failure Reproduction Tests
+
+GitHub CI initially failed `test (18.x)` / `test (20.x)` on five assertions across:
+
+- `tests/integration/multitable-record-patch.api.test.ts`
+- `tests/integration/multitable-xlsx-routes.test.ts`
+- `tests/unit/multitable-records.test.ts`
+
+Cause: test doubles matched the old exact record projection and old three-argument record update. The implementation now legitimately selects record metadata and passes `modified_by`.
+
+After tightening those tests:
+
+```text
+✓ tests/unit/multitable-records.test.ts  (13 tests) 10ms
+✓ tests/integration/multitable-xlsx-routes.test.ts  (4 tests) 306ms
+✓ tests/integration/multitable-record-patch.api.test.ts  (6 tests) 504ms
+
+Test Files  3 passed (3)
+     Tests  23 passed (23)
+```
+
+### Full Backend Test Matrix
+
+```text
+Test Files  208 passed | 9 skipped (217)
+     Tests  2819 passed | 47 skipped (2866)
+```
+
+Expected stderr:
+
+- Some lifecycle/plugin tests log intentional degraded-mode database warnings because no local `DATABASE_URL` is configured.
+- Negative-path auth/plugin tests log expected errors while asserting controlled responses.
+
+### OpenAPI Parity
+
+```text
+> metasheet-v2@2.5.0 verify:multitable-openapi:parity /private/tmp/ms2-system-fields-backend-20260430
+> pnpm exec tsx packages/openapi/tools/build.ts && node --test scripts/ops/multitable-openapi-parity.test.mjs
+
+✔ multitable openapi stays aligned with runtime contracts (0.59625ms)
+ℹ tests 1
+ℹ pass 1
+ℹ fail 0
+```
+
+### OpenAPI Security Validation
+
+```text
+OpenAPI security validation passed
+```
+
+### Whitespace
+
+```text
+git diff --check
+# clean
+```
+
+## Assertions Covered
+
+- Query service injects `createdTime`, `modifiedTime`, `createdBy`, and `modifiedBy` values from record metadata.
+- Metadata projection overrides forged JSON values for system field IDs.
+- `RecordWriteService.patchRecords()` writes `modified_by` using the actor.
+- `RecordService.createRecord()` keeps `created_by` and `modified_by` aligned at creation.
+- `RecordService.patchRecord()` writes `modified_by` using `actorId ?? access.userId`.
+- OpenAPI field type enum includes the four system field types.
+
+## CI Verification
+
+After force-pushing the CI-failure fix, GitHub CI should cover:
+
+- migration replay with `zzzz20260430163000_add_meta_record_modified_by.ts`
+- full backend unit/integration matrix
+- OpenAPI contract matrix
+
+## Deferred
+
+`autoNumber` is intentionally not claimed by this verification. It requires persistent sequence allocation and should be delivered as a follow-up slice.

--- a/packages/core-backend/src/db/migrations/zzzz20260430163000_add_meta_record_modified_by.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260430163000_add_meta_record_modified_by.ts
@@ -1,0 +1,19 @@
+import { sql, type Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`ALTER TABLE meta_records ADD COLUMN IF NOT EXISTS modified_by text`.execute(db)
+  await sql`
+    UPDATE meta_records
+    SET modified_by = created_by
+    WHERE modified_by IS NULL AND created_by IS NOT NULL
+  `.execute(db)
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_meta_records_modified_by
+    ON meta_records(modified_by)
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP INDEX IF EXISTS idx_meta_records_modified_by`.execute(db)
+  await sql`ALTER TABLE meta_records DROP COLUMN IF EXISTS modified_by`.execute(db)
+}

--- a/packages/core-backend/src/db/types.ts
+++ b/packages/core-backend/src/db/types.ts
@@ -649,6 +649,7 @@ export interface MetaRecordsTable {
   data: JSONColumnType<Record<string, unknown>>
   version: number
   created_by: string | null
+  modified_by: string | null
   created_at: CreatedAt
   updated_at: UpdatedAt
 }

--- a/packages/core-backend/src/multitable/field-codecs.ts
+++ b/packages/core-backend/src/multitable/field-codecs.ts
@@ -19,6 +19,10 @@ export type MultitableFieldType =
   | 'email'
   | 'phone'
   | 'longText'
+  | 'createdTime'
+  | 'modifiedTime'
+  | 'createdBy'
+  | 'modifiedBy'
 
 export type MultitableField = {
   id: string
@@ -93,6 +97,14 @@ export function mapFieldType(type: string): MultitableFieldType | string {
   if (normalized === 'url') return 'url'
   if (normalized === 'email') return 'email'
   if (normalized === 'phone') return 'phone'
+  if (normalized === 'createdtime' || normalized === 'created_time' || normalized === 'created-time') {
+    return 'createdTime'
+  }
+  if (normalized === 'modifiedtime' || normalized === 'modified_time' || normalized === 'modified-time') {
+    return 'modifiedTime'
+  }
+  if (normalized === 'createdby' || normalized === 'created_by' || normalized === 'created-by') return 'createdBy'
+  if (normalized === 'modifiedby' || normalized === 'modified_by' || normalized === 'modified-by') return 'modifiedBy'
   if (
     normalized === 'longtext' ||
     normalized === 'long_text' ||
@@ -293,6 +305,10 @@ export function sanitizeFieldProperty(
     return obj
   }
 
+  if (SYSTEM_FIELD_TYPES.has(type)) {
+    return { ...obj, readOnly: true }
+  }
+
   const customDef = fieldTypeRegistry.get(type)
   if (customDef) {
     return customDef.sanitizeProperty(property)
@@ -490,3 +506,14 @@ export const BATCH1_FIELD_TYPES: ReadonlySet<string> = new Set([
   'email',
   'phone',
 ])
+
+export const SYSTEM_FIELD_TYPES: ReadonlySet<string> = new Set([
+  'createdTime',
+  'modifiedTime',
+  'createdBy',
+  'modifiedBy',
+])
+
+export function isSystemFieldType(type: string): boolean {
+  return SYSTEM_FIELD_TYPES.has(type)
+}

--- a/packages/core-backend/src/multitable/permission-derivation.ts
+++ b/packages/core-backend/src/multitable/permission-derivation.ts
@@ -1,3 +1,5 @@
+import { isSystemFieldType } from './field-codecs'
+
 /**
  * Extracted permission derivation functions for testability.
  *
@@ -54,6 +56,7 @@ export type FieldLike = {
 
 export function isFieldAlwaysReadOnly(field: Pick<FieldLike, 'type' | 'property'>): boolean {
   if (field.type === 'formula' || field.type === 'lookup' || field.type === 'rollup') return true
+  if (isSystemFieldType(field.type)) return true
   const property = field.property ?? {}
   return property.readonly === true || property.readOnly === true
 }

--- a/packages/core-backend/src/multitable/query-service.ts
+++ b/packages/core-backend/src/multitable/query-service.ts
@@ -2,6 +2,7 @@ import { createHash } from 'crypto'
 
 import { loadFieldsForSheet, loadSheetRow } from './loaders'
 import { MultitableRecordNotFoundError, MultitableRecordValidationError } from './record-errors'
+import type { MultitableField } from './field-codecs'
 
 export type MultitableRecordsQueryFn = (
   sql: string,
@@ -37,6 +38,10 @@ export type LoadedMultitableRecord = {
   sheetId: string
   version: number
   data: Record<string, unknown>
+  createdBy?: string | null
+  modifiedBy?: string | null
+  createdAt?: string | null
+  updatedAt?: string | null
 }
 
 export type CursorPaginatedResult<T> = {
@@ -172,12 +177,59 @@ async function loadSheetAndFields(
   return { sheet, fields }
 }
 
-function mapRecordRow(row: any): LoadedMultitableRecord {
+function toIsoString(value: unknown): string | null {
+  if (value instanceof Date) return value.toISOString()
+  if (typeof value === 'string' && value.trim()) return value
+  return null
+}
+
+function injectSystemFieldValues(
+  data: Record<string, unknown>,
+  row: any,
+  fields: MultitableField[],
+): Record<string, unknown> {
+  const hasSystemFields = fields.some((field) =>
+    field.type === 'createdTime' ||
+    field.type === 'modifiedTime' ||
+    field.type === 'createdBy' ||
+    field.type === 'modifiedBy',
+  )
+  if (!hasSystemFields) {
+    return data
+  }
+
+  const next = { ...data }
+  const values: Record<string, unknown> = {
+    createdTime: toIsoString(row.created_at),
+    modifiedTime: toIsoString(row.updated_at),
+    createdBy: typeof row.created_by === 'string' ? row.created_by : null,
+    modifiedBy: typeof row.modified_by === 'string' ? row.modified_by : null,
+  }
+
+  for (const field of fields) {
+    if (field.type in values) {
+      next[field.id] = values[field.type]
+    }
+  }
+
+  return next
+}
+
+function mapRecordRow(row: any, fields: MultitableField[]): LoadedMultitableRecord {
+  const data = normalizeRecordData(row.data)
+  const createdBy = typeof row.created_by === 'string' ? row.created_by : null
+  const modifiedBy = typeof row.modified_by === 'string' ? row.modified_by : null
+  const createdAt = toIsoString(row.created_at)
+  const updatedAt = toIsoString(row.updated_at)
   return {
     id: String(row.id),
     sheetId: String(row.sheet_id),
     version: Number(row.version ?? 1),
-    data: normalizeRecordData(row.data),
+    data: injectSystemFieldValues(data, row, fields),
+    ...(createdBy !== null ? { createdBy } : {}),
+    ...(modifiedBy !== null ? { modifiedBy } : {}),
+    ...(createdAt !== null ? { createdAt } : {}),
+    ...(updatedAt !== null ? { updatedAt } : {}),
   }
 }
 
@@ -238,7 +290,7 @@ export async function queryRecords(
   const offsetParamIndex = offset !== undefined ? params.length : null
 
   const sqlParts = [
-    'SELECT id, sheet_id, version, data FROM meta_records',
+    'SELECT id, sheet_id, version, data, created_at, updated_at, created_by, modified_by FROM meta_records',
     `WHERE ${where.join(' AND ')}`,
     orderSql,
   ]
@@ -250,7 +302,7 @@ export async function queryRecords(
   }
 
   const recordRes = await query(sqlParts.join(' '), params)
-  return (recordRes.rows as any[]).map(mapRecordRow)
+  return (recordRes.rows as any[]).map((row) => mapRecordRow(row, fields))
 }
 
 /**
@@ -309,14 +361,14 @@ export async function queryRecordsWithCursor(
     : `ORDER BY id ${direction}`
 
   const sql = [
-    'SELECT id, sheet_id, version, data FROM meta_records',
+    'SELECT id, sheet_id, version, data, created_at, updated_at, created_by, modified_by FROM meta_records',
     `WHERE ${where.join(' AND ')}`,
     orderSql,
     `LIMIT $${fetchLimitIndex}`,
   ].join(' ')
 
   const recordRes = await query(sql, params)
-  const rows = (recordRes.rows as any[]).map(mapRecordRow)
+  const rows = (recordRes.rows as any[]).map((row) => mapRecordRow(row, fields))
 
   const hasMore = rows.length > limit
   const items = hasMore ? rows.slice(0, limit) : rows

--- a/packages/core-backend/src/multitable/record-service.ts
+++ b/packages/core-backend/src/multitable/record-service.ts
@@ -167,6 +167,7 @@ export type RecordPatchInput = {
   sheetId: string
   data: Record<string, unknown>
   expectedVersion?: number
+  actorId?: string | null
   access: AccessInfo
   capabilities: MultitableCapabilities
   sheetScope?: SheetPermissionScope
@@ -500,8 +501,8 @@ export class RecordService {
     const recordId = `rec_${randomUUID()}`
     const recordRes = await this.pool.transaction(async ({ query }) => {
       const inserted = await query(
-        `INSERT INTO meta_records (id, sheet_id, data, version, created_by)
-         VALUES ($1, $2, $3::jsonb, 1, $4)
+        `INSERT INTO meta_records (id, sheet_id, data, version, created_by, modified_by)
+         VALUES ($1, $2, $3::jsonb, 1, $4, $4)
          RETURNING version`,
         [recordId, sheetId, JSON.stringify(patch), actorId],
       )
@@ -629,6 +630,7 @@ export class RecordService {
     if (!capabilities.canEditRecord) {
       throw new RecordPermissionError('Insufficient permissions')
     }
+    const patchActorId = input.actorId ?? access.userId ?? null
 
     const fields = await loadFieldsForSheet(this.pool.query.bind(this.pool), sheetId)
     if (fields.length === 0) {
@@ -781,10 +783,10 @@ export class RecordService {
       if (Object.keys(patch).length > 0) {
         const updateRes = await query(
           `UPDATE meta_records
-           SET data = data || $1::jsonb, updated_at = now(), version = version + 1
+           SET data = data || $1::jsonb, updated_at = now(), version = version + 1, modified_by = $4
            WHERE id = $2 AND sheet_id = $3
            RETURNING version`,
-          [JSON.stringify(patch), recordId, sheetId],
+          [JSON.stringify(patch), recordId, sheetId, patchActorId],
         )
         nextVersion = Number((updateRes.rows[0] as { version?: unknown } | undefined)?.version ?? serverVersion)
       } else {

--- a/packages/core-backend/src/multitable/record-write-service.ts
+++ b/packages/core-backend/src/multitable/record-write-service.ts
@@ -60,6 +60,10 @@ export type UniverMetaField = {
     | 'email'
     | 'phone'
     | 'longText'
+    | 'createdTime'
+    | 'modifiedTime'
+    | 'createdBy'
+    | 'modifiedBy'
   options?: Array<{ value: string; color?: string }>
   order?: number
   property?: Record<string, unknown>
@@ -587,10 +591,10 @@ export class RecordWriteService {
         // Apply patch
         const updateRes = await query(
           `UPDATE meta_records
-           SET data = data || $1::jsonb, updated_at = now(), version = version + 1
+           SET data = data || $1::jsonb, updated_at = now(), version = version + 1, modified_by = $4
            WHERE sheet_id = $2 AND id = $3
            RETURNING version`,
-          [JSON.stringify(patch), sheetId, recordId],
+          [JSON.stringify(patch), sheetId, recordId, actorId],
         )
         if ((updateRes.rows as any[]).length === 0) {
           throw new RecordNotFoundError(`Record not found: ${recordId}`)

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -183,6 +183,10 @@ const MULTITABLE_FIELD_TYPES = [
   'email',
   'phone',
   'longText',
+  'createdTime',
+  'modifiedTime',
+  'createdBy',
+  'modifiedBy',
 ] as const
 
 type UniverMetaField = {
@@ -207,6 +211,10 @@ type UniverMetaField = {
     | 'email'
     | 'phone'
     | 'longText'
+    | 'createdTime'
+    | 'modifiedTime'
+    | 'createdBy'
+    | 'modifiedBy'
   options?: Array<{ value: string; color?: string }>
   order?: number
   property?: Record<string, unknown>
@@ -1039,6 +1047,14 @@ function mapFieldType(type: string): UniverMetaField['type'] {
   if (normalized === 'rollup') return 'rollup'
   if (normalized === 'attachment') return 'attachment'
   if (BATCH1_FIELD_TYPES.has(normalized as any)) return normalized as UniverMetaField['type']
+  if (normalized === 'createdtime' || normalized === 'created_time' || normalized === 'created-time') {
+    return 'createdTime'
+  }
+  if (normalized === 'modifiedtime' || normalized === 'modified_time' || normalized === 'modified-time') {
+    return 'modifiedTime'
+  }
+  if (normalized === 'createdby' || normalized === 'created_by' || normalized === 'created-by') return 'createdBy'
+  if (normalized === 'modifiedby' || normalized === 'modified_by' || normalized === 'modified-by') return 'modifiedBy'
   if (
     normalized === 'longtext' ||
     normalized === 'long_text' ||
@@ -1265,6 +1281,10 @@ function sanitizeFieldProperty(type: UniverMetaField['type'], property: unknown)
       ...(Number.isFinite(maxFiles) && maxFiles > 0 ? { maxFiles: Math.round(maxFiles) } : {}),
       acceptedMimeTypes: sanitizeStringArray(obj.acceptedMimeTypes),
     }
+  }
+
+  if (type === 'createdTime' || type === 'modifiedTime' || type === 'createdBy' || type === 'modifiedBy') {
+    return { ...obj, readOnly: true }
   }
 
   return obj
@@ -5881,10 +5901,10 @@ export function univerMetaRouter(): Router {
           if (Object.keys(patch).length > 0) {
             const updateRes = await query(
               `UPDATE meta_records
-               SET data = data || $1::jsonb, updated_at = now(), version = version + 1
+               SET data = data || $1::jsonb, updated_at = now(), version = version + 1, modified_by = $4
                WHERE id = $2 AND sheet_id = $3
                RETURNING version`,
-              [JSON.stringify(patch), recordId, view.sheetId],
+              [JSON.stringify(patch), recordId, view.sheetId, getRequestActorId(req)],
             )
             nextVersion = Number((updateRes as any).rows[0]?.version ?? serverVersion)
           } else {
@@ -5924,8 +5944,8 @@ export function univerMetaRouter(): Router {
         }
 
         const insertRes = await query(
-          `INSERT INTO meta_records (id, sheet_id, data, version, created_by)
-           VALUES ($1, $2, $3::jsonb, 1, $4)
+          `INSERT INTO meta_records (id, sheet_id, data, version, created_by, modified_by)
+           VALUES ($1, $2, $3::jsonb, 1, $4, $4)
            RETURNING id, version`,
           [
             resultRecordId,
@@ -6138,6 +6158,7 @@ export function univerMetaRouter(): Router {
         sheetId,
         data: parsed.data.data ?? {},
         expectedVersion: parsed.data.expectedVersion,
+        actorId: getRequestActorId(req),
         access,
         capabilities,
         sheetScope,
@@ -6829,10 +6850,10 @@ export function univerMetaRouter(): Router {
             if (nextIds.length !== currentIds.length) {
               const updateRes = await query(
                 `UPDATE meta_records
-                 SET data = data || $1::jsonb, updated_at = now(), version = version + 1
+                 SET data = data || $1::jsonb, updated_at = now(), version = version + 1, modified_by = $4
                  WHERE id = $2 AND sheet_id = $3
                  RETURNING version`,
-                [JSON.stringify({ [fieldId]: nextIds }), recordId, sheetId],
+                [JSON.stringify({ [fieldId]: nextIds }), recordId, sheetId, getRequestActorId(req)],
               )
               updatedRecordRealtimeScope = {
                 sheetId,

--- a/packages/core-backend/tests/integration/multitable-record-patch.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-record-patch.api.test.ts
@@ -117,10 +117,14 @@ describe('Multitable PATCH /records/:recordId (record-service extraction)', () =
             JSON.stringify({ fld_title: 'Updated title' }),
             'rec_1',
             'sheet_ops',
+            'user_patch_1',
           ])
           return { rows: [{ version: 8 }] }
         }
-        if (sql.includes('SELECT id, version, data FROM meta_records WHERE id = $1 AND sheet_id = $2')) {
+        if (
+          sql.includes('FROM meta_records WHERE id = $1 AND sheet_id = $2') &&
+          sql.includes('SELECT id, version, data')
+        ) {
           return { rows: [{ id: 'rec_1', version: 8, data: { fld_title: 'Updated title' } }] }
         }
         throw new Error(`Unhandled SQL in test: ${sql}`)
@@ -317,6 +321,7 @@ describe('Multitable PATCH /records/:recordId (record-service extraction)', () =
             JSON.stringify({ fld_customer: ['rec_c2', 'rec_c3'] }),
             'rec_1',
             'sheet_ops',
+            'user_patch_1',
           ])
           return { rows: [{ version: 3 }] }
         }
@@ -330,7 +335,10 @@ describe('Multitable PATCH /records/:recordId (record-service extraction)', () =
         if (sql.includes('INSERT INTO meta_links')) {
           return { rows: [], rowCount: 1 }
         }
-        if (sql.includes('SELECT id, version, data FROM meta_records WHERE id = $1 AND sheet_id = $2')) {
+        if (
+          sql.includes('FROM meta_records WHERE id = $1 AND sheet_id = $2') &&
+          sql.includes('SELECT id, version, data')
+        ) {
           return { rows: [{ id: 'rec_1', version: 3, data: { fld_customer: ['rec_c2', 'rec_c3'] } }] }
         }
         if (sql.includes('SELECT field_id, record_id, foreign_record_id')) {
@@ -418,7 +426,10 @@ describe('Multitable PATCH /records/:recordId (record-service extraction)', () =
         if (sql.includes('UPDATE meta_records') && sql.includes('RETURNING version')) {
           return { rows: [{ version: 3 }] }
         }
-        if (sql.includes('SELECT id, version, data FROM meta_records WHERE id = $1 AND sheet_id = $2')) {
+        if (
+          sql.includes('FROM meta_records WHERE id = $1 AND sheet_id = $2') &&
+          sql.includes('SELECT id, version, data')
+        ) {
           return { rows: [{ id: 'rec_1', version: 3, data: { fld_files: ['att_new_1'] } }] }
         }
         throw new Error(`Unhandled SQL in test: ${sql}`)

--- a/packages/core-backend/tests/integration/multitable-xlsx-routes.test.ts
+++ b/packages/core-backend/tests/integration/multitable-xlsx-routes.test.ts
@@ -85,7 +85,10 @@ function defaultQueryHandler(records: any[] = []): QueryHandler {
       expect(params).toEqual([SHEET_ID])
       return { rows: FIELD_ROWS }
     }
-    if (sql.includes('SELECT id, sheet_id, version, data FROM meta_records')) {
+    if (
+      sql.includes('FROM meta_records') &&
+      sql.includes('SELECT id, sheet_id, version, data')
+    ) {
       expect(params?.[0]).toBe(SHEET_ID)
       return { rows: records }
     }

--- a/packages/core-backend/tests/unit/multitable-query-service.test.ts
+++ b/packages/core-backend/tests/unit/multitable-query-service.test.ts
@@ -52,6 +52,62 @@ describe('multitable query-service', () => {
     ])
   })
 
+  it('injects readonly system field values from record metadata', async () => {
+    const calls: Array<{ sql: string; params?: unknown[] }> = []
+    const query: MultitableRecordsQueryFn = async (sql, params) => {
+      calls.push({ sql, params })
+      if (sql.includes('FROM meta_sheets')) {
+        return { rows: [{ id: 'sheet_1', name: 'Tickets' }], rowCount: 1 }
+      }
+      if (sql.includes('FROM meta_fields')) {
+        return {
+          rows: [
+            { id: 'title', sheet_id: 'sheet_1', name: 'Title', type: 'string', property: {}, order: 1 },
+            { id: 'created_at_sys', sheet_id: 'sheet_1', name: 'Created At', type: 'createdTime', property: {}, order: 2 },
+            { id: 'updated_at_sys', sheet_id: 'sheet_1', name: 'Updated At', type: 'modifiedTime', property: {}, order: 3 },
+            { id: 'created_by_sys', sheet_id: 'sheet_1', name: 'Created By', type: 'createdBy', property: {}, order: 4 },
+            { id: 'modified_by_sys', sheet_id: 'sheet_1', name: 'Modified By', type: 'modifiedBy', property: {}, order: 5 },
+          ],
+          rowCount: 5,
+        }
+      }
+      return {
+        rows: [{
+          id: 'rec_1',
+          sheet_id: 'sheet_1',
+          version: 3,
+          data: { title: 'A', created_at_sys: 'client-forged' },
+          created_at: new Date('2026-04-30T01:02:03.000Z'),
+          updated_at: '2026-04-30T02:03:04.000Z',
+          created_by: 'user_creator',
+          modified_by: 'user_editor',
+        }],
+        rowCount: 1,
+      }
+    }
+
+    await expect(listRecords({ query, sheetId: 'sheet_1' })).resolves.toEqual([
+      {
+        id: 'rec_1',
+        sheetId: 'sheet_1',
+        version: 3,
+        createdAt: '2026-04-30T01:02:03.000Z',
+        updatedAt: '2026-04-30T02:03:04.000Z',
+        createdBy: 'user_creator',
+        modifiedBy: 'user_editor',
+        data: {
+          title: 'A',
+          created_at_sys: '2026-04-30T01:02:03.000Z',
+          updated_at_sys: '2026-04-30T02:03:04.000Z',
+          created_by_sys: 'user_creator',
+          modified_by_sys: 'user_editor',
+        },
+      },
+    ])
+
+    expect(calls.at(-1)?.sql).toContain('created_at, updated_at, created_by, modified_by')
+  })
+
   it('builds filter/search/order SQL without touching write helpers', async () => {
     const { query, calls } = createQuery([
       { id: 'rec_1', sheet_id: 'sheet_1', version: 1, data: JSON.stringify({ title: 'A', status: 'open' }) },

--- a/packages/core-backend/tests/unit/multitable-records.test.ts
+++ b/packages/core-backend/tests/unit/multitable-records.test.ts
@@ -160,14 +160,20 @@ function createQuery(): {
       }
     }
 
-    if (normalized.startsWith('SELECT id, sheet_id, version, data FROM meta_records WHERE id = $1 AND sheet_id = $2')) {
+    if (
+      normalized.includes('FROM meta_records WHERE id = $1 AND sheet_id = $2') &&
+      normalized.includes('SELECT id, sheet_id, version, data')
+    ) {
       const [recordId, sheetId] = params as [string, string]
       return {
         rows: records.filter((record) => record.id === recordId && record.sheet_id === sheetId),
       }
     }
 
-    if (normalized.startsWith('SELECT id, sheet_id, version, data FROM meta_records WHERE sheet_id = $1')) {
+    if (
+      normalized.includes('FROM meta_records WHERE sheet_id = $1') &&
+      normalized.includes('SELECT id, sheet_id, version, data')
+    ) {
       let filtered = records.filter((record) => record.sheet_id === String(params[0]))
 
       const whereFilters = normalized.match(/data ->(?:>|) \$(\d+)(?: = \$(\d+)| IS NULL)/g) ?? []

--- a/packages/core-backend/tests/unit/record-service.test.ts
+++ b/packages/core-backend/tests/unit/record-service.test.ts
@@ -352,7 +352,7 @@ describe('RecordService', () => {
     expect(yjsInvalidator).toHaveBeenCalledWith(['rec_existing'])
     expect(pool.queryMock).toHaveBeenCalledWith(
       expect.stringContaining('UPDATE meta_records'),
-      [JSON.stringify({ fld_title: 'Updated', fld_customer: ['rec_customer_2'] }), 'rec_existing', 'sheet_ops'],
+      [JSON.stringify({ fld_title: 'Updated', fld_customer: ['rec_customer_2'] }), 'rec_existing', 'sheet_ops', 'user_1'],
     )
     expect(pool.queryMock).toHaveBeenCalledWith(
       expect.stringContaining('DELETE FROM meta_links WHERE field_id = $1 AND record_id = $2 AND foreign_record_id = ANY'),
@@ -389,7 +389,7 @@ describe('RecordService', () => {
     expect(result.patch).toEqual({ fld_tags: ['VIP', 'Urgent'] })
     expect(pool.queryMock).toHaveBeenCalledWith(
       expect.stringContaining('UPDATE meta_records'),
-      [JSON.stringify({ fld_tags: ['VIP', 'Urgent'] }), 'rec_existing', 'sheet_ops'],
+      [JSON.stringify({ fld_tags: ['VIP', 'Urgent'] }), 'rec_existing', 'sheet_ops', 'user_1'],
     )
   })
 

--- a/packages/core-backend/tests/unit/record-write-service.test.ts
+++ b/packages/core-backend/tests/unit/record-write-service.test.ts
@@ -207,6 +207,23 @@ describe('RecordWriteService', () => {
     )
   })
 
+  it('persists modified_by with the patch actor', async () => {
+    const service = new RecordWriteService(pool, eventBus as any, helpers)
+
+    await service.patchRecords(buildTestInput({ actorId: 'user_editor' }))
+
+    const updateCall = (pool.query as any).mock.calls.find((call: unknown[]) =>
+      typeof call[0] === 'string' && call[0].includes('UPDATE meta_records'),
+    )
+    expect(updateCall[0]).toContain('modified_by = $4')
+    expect(updateCall[1]).toEqual([
+      JSON.stringify({ fld_name: 'Alice' }),
+      'sheet1',
+      'rec1',
+      'user_editor',
+    ])
+  })
+
   it('preserves longText multiline values in the shared write path', async () => {
     const service = new RecordWriteService(pool, eventBus as any, helpers)
     const fields: UniverMetaField[] = [

--- a/packages/openapi/dist/combined.openapi.yml
+++ b/packages/openapi/dist/combined.openapi.yml
@@ -1599,6 +1599,10 @@ components:
         - email
         - phone
         - longText
+        - createdTime
+        - modifiedTime
+        - createdBy
+        - modifiedBy
     MultitableView:
       type: object
       properties:

--- a/packages/openapi/dist/openapi.json
+++ b/packages/openapi/dist/openapi.json
@@ -2294,7 +2294,11 @@
           "url",
           "email",
           "phone",
-          "longText"
+          "longText",
+          "createdTime",
+          "modifiedTime",
+          "createdBy",
+          "modifiedBy"
         ]
       },
       "MultitableView": {

--- a/packages/openapi/dist/openapi.yaml
+++ b/packages/openapi/dist/openapi.yaml
@@ -1599,6 +1599,10 @@ components:
         - email
         - phone
         - longText
+        - createdTime
+        - modifiedTime
+        - createdBy
+        - modifiedBy
     MultitableView:
       type: object
       properties:

--- a/packages/openapi/src/base.yml
+++ b/packages/openapi/src/base.yml
@@ -1542,6 +1542,10 @@ components:
         - email
         - phone
         - longText
+        - createdTime
+        - modifiedTime
+        - createdBy
+        - modifiedBy
     MultitableView:
       type: object
       properties:

--- a/scripts/ops/multitable-openapi-parity.test.mjs
+++ b/scripts/ops/multitable-openapi-parity.test.mjs
@@ -26,6 +26,10 @@ const expectedFieldTypes = [
   'email',
   'phone',
   'longText',
+  'createdTime',
+  'modifiedTime',
+  'createdBy',
+  'modifiedBy',
 ]
 
 const expectedViewTypes = [


### PR DESCRIPTION
## Summary

Phase 4 backend seam for multitable system fields.

## Changes

- Add system field types: `createdTime`, `modifiedTime`, `createdBy`, `modifiedBy`.
- Treat system field types as always readonly through shared permission derivation.
- Project system field values from `meta_records` metadata into `record.data[field.id]` in query-service.
- Add `meta_records.modified_by` migration with backfill and index.
- Persist `modified_by` through RecordService, RecordWriteService, public-form update, and attachment delete record-patch paths.
- Update OpenAPI field type enum and generated dist artifacts.
- Update Phase 4 TODO with completed backend items and explicit `autoNumber` deferral.

## Verification

- `pnpm --filter @metasheet/core-backend build`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/multitable-query-service.test.ts tests/unit/record-write-service.test.ts tests/unit/record-service.test.ts --reporter=dot`
- `pnpm exec tsx packages/openapi/tools/validate.ts`
- `pnpm run verify:multitable-openapi:parity`
- `git diff --check`

## Deferred

`autoNumber` is intentionally not included. Stable Feishu-like numbering needs persistent sequence allocation; row-index derivation would be incorrect under delete/import/concurrent create.

## Docs

- `docs/development/multitable-system-fields-backend-development-20260430.md`
- `docs/development/multitable-system-fields-backend-verification-20260430.md`
