### PR TITLE
feat(multitable): wire system fields frontend

### DIFF
--- a/apps/web/src/multitable/components/MetaFieldHeader.vue
+++ b/apps/web/src/multitable/components/MetaFieldHeader.vue
@@ -27,8 +27,10 @@ import { ref, computed } from 'vue'
 import type { MetaField } from '../types'
 
 const FIELD_ICONS: Record<string, string> = {
-  string: 'Aa', number: '#', boolean: '\u2611', date: '\u{1F4C5}', select: '\u25CF', multiSelect: '\u25C9',
-  link: '\u21C4', lookup: '\u2197', rollup: '\u03A3', formula: 'fx',
+  string: 'Aa', longText: '\u00B6', number: '#', boolean: '\u2611', date: '\u{1F4C5}', select: '\u25CF', multiSelect: '\u25C9',
+  link: '\u21C4', person: '\u{1F464}', lookup: '\u2197', rollup: '\u03A3', formula: 'fx', attachment: '\uD83D\uDCCE',
+  currency: '\u00A4', percent: '%', rating: '\u2605', url: '\u{1F517}', email: '\u2709', phone: '\u260E',
+  createdTime: 'CT', modifiedTime: 'MT', createdBy: 'CB', modifiedBy: 'MB',
 }
 
 const props = defineProps<{

--- a/apps/web/src/multitable/components/MetaFieldManager.vue
+++ b/apps/web/src/multitable/components/MetaFieldManager.vue
@@ -294,6 +294,9 @@
           </select>
           <button class="meta-field-mgr__btn-add" :disabled="!newFieldName.trim()" @click="onAddField">+ Add</button>
         </div>
+        <div v-if="newFieldTypeIsSystem" class="meta-field-mgr__hint meta-field-mgr__hint--system">
+          {{ systemFieldHint(newFieldType) }}
+        </div>
       </div>
 
       <div v-if="deleteTarget" class="meta-field-mgr__confirm">
@@ -332,6 +335,11 @@ import {
   resolveRollupFieldProperty,
   resolveSelectFieldOptions,
 } from '../utils/field-config'
+import {
+  SYSTEM_FIELD_TYPES,
+  isSystemFieldCreateType,
+  systemFieldHint,
+} from '../utils/system-fields'
 import MetaFieldValidationPanel from './MetaFieldValidationPanel.vue'
 
 /** Field types where the validation panel is configurable. */
@@ -426,11 +434,13 @@ const FIELD_TYPES: MetaFieldCreateType[] = [
   'string', 'longText', 'number', 'boolean', 'date', 'select', 'multiSelect', 'link', 'person',
   'formula', 'lookup', 'rollup', 'attachment',
   'currency', 'percent', 'rating', 'url', 'email', 'phone',
+  ...SYSTEM_FIELD_TYPES,
 ]
 const FIELD_ICONS: Record<string, string> = {
   string: 'Aa', longText: '\u00B6', number: '#', boolean: '\u2611', date: '\u{1F4C5}', select: '\u25CF', multiSelect: '\u25C9',
   link: '\u21C4', person: '\u{1F464}', lookup: '\u2197', rollup: '\u03A3', formula: 'fx', attachment: '\uD83D\uDCCE',
   currency: '\u00A4', percent: '%', rating: '\u2605', url: '\u{1F517}', email: '\u2709', phone: '\u260E',
+  createdTime: 'CT', modifiedTime: 'MT', createdBy: 'CB', modifiedBy: 'MB',
 }
 
 const props = defineProps<{
@@ -540,6 +550,7 @@ const fieldConfigBlockingReason = computed(() => {
 const fieldConfigWarningText = computed(() => {
   return fieldConfigBlockingReason.value || 'This field changed in the background. Save keeps your draft, or reload the latest settings.'
 })
+const newFieldTypeIsSystem = computed(() => isSystemFieldCreateType(newFieldType.value))
 
 const validationPanelVisible = computed(() => {
   const draftType = configDraftType.value

--- a/apps/web/src/multitable/components/MetaFormView.vue
+++ b/apps/web/src/multitable/components/MetaFormView.vue
@@ -204,7 +204,7 @@
             :value="formData[field.id] ?? ''"
             @input="formData[field.id] = ($event.target as HTMLInputElement).value"
           />
-          <span v-else class="meta-form-view__readonly-val">{{ record?.data[field.id] ?? '—' }}</span>
+          <span v-else class="meta-form-view__readonly-val">{{ readonlyFieldDisplay(field) }}</span>
           <div v-if="field.type === 'link' && linkPreview(field.id)" class="meta-form-view__link-summary">{{ linkPreview(field.id) }}</div>
           <div v-if="fieldErrors?.[field.id] || validationErrors[field.id]" :id="`error_${field.id}`" class="meta-form-view__field-error">{{ fieldErrors?.[field.id] || validationErrors[field.id] }}</div>
         </div>
@@ -246,6 +246,8 @@ import {
   validateAttachmentSelection,
 } from '../utils/field-config'
 import { linkActionLabel } from '../utils/link-fields'
+import { formatFieldDisplay } from '../utils/field-display'
+import { isSystemField } from '../utils/system-fields'
 
 const props = defineProps<{
   fields: MetaField[]
@@ -286,7 +288,8 @@ const editableFields = computed(() => {
 })
 
 function isFieldReadOnly(fieldId: string): boolean {
-  return !!props.readOnly || props.fieldPermissions?.[fieldId]?.readOnly === true || props.rowActions?.canEdit === false
+  const field = props.fields.find((item) => item.id === fieldId) ?? null
+  return !!props.readOnly || props.fieldPermissions?.[fieldId]?.readOnly === true || props.rowActions?.canEdit === false || isSystemField(field)
 }
 
 const hasUnsavedChanges = computed(() => {
@@ -360,7 +363,7 @@ function validate(): boolean {
 
 function onSubmit() {
   if (!validate()) return
-  emit('submit', { ...formData })
+  emit('submit', buildSubmitPayload())
 }
 
 function resetForm() {
@@ -403,6 +406,22 @@ function linkSummaryCount(fieldId: string): number {
   if (summaries.length) return summaries.length
   const raw = formData[fieldId] ?? props.record?.data[fieldId]
   return Array.isArray(raw) ? raw.length : raw ? 1 : 0
+}
+
+function readonlyFieldDisplay(field: MetaField): string {
+  return formatFieldDisplay({
+    field,
+    value: formData[field.id] ?? props.record?.data[field.id],
+    linkSummaries: props.linkSummariesByField?.[field.id],
+    attachmentSummaries: props.attachmentSummariesByField?.[field.id],
+  })
+}
+
+function buildSubmitPayload(): Record<string, unknown> {
+  const systemFieldIds = new Set(props.fields.filter((field) => isSystemField(field)).map((field) => field.id))
+  return Object.fromEntries(
+    Object.entries(formData).filter(([fieldId]) => !systemFieldIds.has(fieldId)),
+  )
 }
 
 function attachmentList(fieldId: string): string[] {

--- a/apps/web/src/multitable/components/MetaGridTable.vue
+++ b/apps/web/src/multitable/components/MetaGridTable.vue
@@ -267,6 +267,7 @@ import {
   resolveFieldCommentAffordance,
   resolveRecordCommentAffordance,
 } from '../utils/comment-affordance'
+import { isSystemField } from '../utils/system-fields'
 
 const EDITABLE = new Set(['string', 'number', 'boolean', 'date', 'select', 'link', 'attachment'])
 
@@ -435,7 +436,7 @@ function resolveRowActions(recordId: string): MetaRowActions {
   }
 }
 const isEditable = (recordId: string, f: MetaField) =>
-  resolveRowActions(recordId).canEdit && EDITABLE.has(f.type) && !props.fieldReadOnlyIds?.includes(f.id)
+  resolveRowActions(recordId).canEdit && EDITABLE.has(f.type) && !isSystemField(f) && !props.fieldReadOnlyIds?.includes(f.id)
 const isEditing = (rid: string, fid: string) => editCell.value?.recordId === rid && editCell.value?.fieldId === fid
 
 function cellStyle(rid: string, fid: string) {

--- a/apps/web/src/multitable/components/MetaRecordDrawer.vue
+++ b/apps/web/src/multitable/components/MetaRecordDrawer.vue
@@ -132,7 +132,7 @@
             </div>
             <div v-if="attachmentErrors[field.id]" class="meta-record-drawer__error">{{ attachmentErrors[field.id] }}</div>
           </div>
-          <span v-else class="meta-record-drawer__text">{{ formatValue(record.data[field.id]) }}</span>
+          <span v-else class="meta-record-drawer__text">{{ formatValue(field, record.data[field.id]) }}</span>
           <div v-if="field.type === 'link' && linkPreview(field.id)" class="meta-record-drawer__link-summary">{{ linkPreview(field.id) }}</div>
         </div>
       </div>
@@ -175,6 +175,8 @@ import {
 } from '../utils/comment-affordance'
 import { attachmentAcceptAttr, resolveAttachmentFieldProperty, shouldReplaceAttachmentSelection, validateAttachmentSelection } from '../utils/field-config'
 import { linkActionLabel } from '../utils/link-fields'
+import { formatFieldDisplay } from '../utils/field-display'
+import { isSystemField } from '../utils/system-fields'
 
 const props = withDefaults(defineProps<{
   visible: boolean
@@ -236,7 +238,11 @@ const drawerCommentButtonClass = computed(() =>
 )
 
 function canEditField(fieldId: string): boolean {
-  return props.canEdit && props.rowActions?.canEdit !== false && props.fieldPermissions?.[fieldId]?.readOnly !== true
+  const field = props.fields.find((item) => item.id === fieldId) ?? null
+  return props.canEdit
+    && props.rowActions?.canEdit !== false
+    && props.fieldPermissions?.[fieldId]?.readOnly !== true
+    && !isSystemField(field)
 }
 
 function recordFieldAffordance(fieldId: string) {
@@ -257,10 +263,13 @@ function navigateNext() {
   if (idx >= 0 && idx < props.recordIds.length - 1) emit('navigate', props.recordIds[idx + 1])
 }
 
-function formatValue(v: unknown): string {
-  if (v === null || v === undefined) return '—'
-  if (Array.isArray(v)) return v.join(', ')
-  return String(v)
+function formatValue(field: MetaField, v: unknown): string {
+  return formatFieldDisplay({
+    field,
+    value: v,
+    linkSummaries: props.linkSummariesByField?.[field.id],
+    attachmentSummaries: props.attachmentSummariesByField?.[field.id],
+  })
 }
 
 function textControlValue(value: unknown): string {

--- a/apps/web/src/multitable/components/cells/MetaCellEditor.vue
+++ b/apps/web/src/multitable/components/cells/MetaCellEditor.vue
@@ -223,7 +223,7 @@
     </div>
 
     <!-- readonly fallback -->
-    <span v-else class="meta-cell-editor__readonly">{{ modelValue ?? '' }}</span>
+    <span v-else class="meta-cell-editor__readonly">{{ readonlyDisplayValue }}</span>
   </div>
 </template>
 
@@ -242,6 +242,7 @@ import {
   validateAttachmentSelection,
 } from '../../utils/field-config'
 import { linkActionLabel as formatLinkActionLabel } from '../../utils/link-fields'
+import { formatFieldDisplay } from '../../utils/field-display'
 import { useYjsCellBinding, type YjsCellBinding } from '../../composables/useYjsCellBinding'
 
 const props = defineProps<{
@@ -281,6 +282,14 @@ const emit = defineEmits<{
    */
   (e: 'yjs-commit'): void
 }>()
+
+const readonlyDisplayValue = computed(() =>
+  formatFieldDisplay({
+    field: props.field,
+    value: props.modelValue,
+    attachmentSummaries: props.attachmentSummaries,
+  }),
+)
 
 function textControlValue(value: unknown): string {
   return value === null || value === undefined ? '' : String(value)

--- a/apps/web/src/multitable/components/cells/MetaCellRenderer.vue
+++ b/apps/web/src/multitable/components/cells/MetaCellRenderer.vue
@@ -13,6 +13,11 @@
       <span class="meta-cell-renderer__date">{{ dateDisplay }}</span>
     </template>
 
+    <!-- system fields -->
+    <template v-else-if="isSystemField">
+      <span class="meta-cell-renderer__system" :title="displayValue">{{ displayValue }}</span>
+    </template>
+
     <!-- number -->
     <template v-else-if="field.type === 'number'">{{ displayValue }}</template>
 
@@ -102,6 +107,7 @@ import type { MetaAttachment, MetaField, LinkedRecordSummary } from '../../types
 import MetaAttachmentList from '../MetaAttachmentList.vue'
 import { isPersonField } from '../../utils/link-fields'
 import { formatFieldDisplay } from '../../utils/field-display'
+import { isSystemFieldType } from '../../utils/system-fields'
 
 const props = defineProps<{ field: MetaField; value: unknown; linkSummaries?: LinkedRecordSummary[]; attachmentSummaries?: MetaAttachment[] }>()
 
@@ -113,6 +119,7 @@ const displayValue = computed(() => {
     attachmentSummaries: props.attachmentSummaries,
   })
 })
+const isSystemField = computed(() => isSystemFieldType(props.field.type))
 
 const dateDisplay = computed(() => {
   const v = props.value
@@ -232,6 +239,11 @@ const conditionalClass = computed(() => {
   color: #227447;
 }
 .meta-cell-renderer__date { color: #606266; }
+.meta-cell-renderer__system {
+  color: #64748b;
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: 'tnum';
+}
 .meta-cell-renderer--empty { color: #ccc; }
 .meta-cell-renderer--positive { color: #67c23a; }
 .meta-cell-renderer--negative { color: #f56c6c; }

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -22,6 +22,10 @@ export type MetaFieldType =
   | 'email'
   | 'phone'
   | 'longText'
+  | 'createdTime'
+  | 'modifiedTime'
+  | 'createdBy'
+  | 'modifiedBy'
 
 export type MetaFieldCreateType = MetaFieldType | 'person'
 

--- a/apps/web/src/multitable/utils/field-display.ts
+++ b/apps/web/src/multitable/utils/field-display.ts
@@ -6,12 +6,26 @@ import {
   resolvePercentFieldProperty,
   resolveRatingFieldProperty,
 } from './field-config'
+import { isSystemFieldType } from './system-fields'
 
 function formatDate(value: unknown): string {
   if (value === null || value === undefined || value === '') return '—'
   const date = new Date(String(value))
   if (Number.isNaN(date.getTime())) return String(value)
   return date.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
+}
+
+function formatDateTime(value: unknown): string {
+  if (value === null || value === undefined || value === '') return '—'
+  const date = new Date(String(value))
+  if (Number.isNaN(date.getTime())) return String(value)
+  return date.toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
 }
 
 function summarizeLinkCount(field: MetaField, count: number): string {
@@ -35,6 +49,8 @@ export function formatFieldDisplay(params: {
   if (value === null || value === undefined || value === '') return '—'
 
   if (field.type === 'date') return formatDate(value)
+  if (field.type === 'createdTime' || field.type === 'modifiedTime') return formatDateTime(value)
+  if (isSystemFieldType(field.type)) return String(value)
   if (field.type === 'boolean') return value ? 'Yes' : 'No'
 
   if (field.type === 'currency') {

--- a/apps/web/src/multitable/utils/system-fields.ts
+++ b/apps/web/src/multitable/utils/system-fields.ts
@@ -1,0 +1,39 @@
+import type { MetaField, MetaFieldCreateType, MetaFieldType } from '../types'
+
+export const SYSTEM_FIELD_TYPES = [
+  'createdTime',
+  'modifiedTime',
+  'createdBy',
+  'modifiedBy',
+] as const satisfies readonly MetaFieldType[]
+
+export type SystemFieldType = typeof SYSTEM_FIELD_TYPES[number]
+
+const SYSTEM_FIELD_TYPE_SET = new Set<string>(SYSTEM_FIELD_TYPES)
+
+export function isSystemFieldType(type: string | null | undefined): type is SystemFieldType {
+  return typeof type === 'string' && SYSTEM_FIELD_TYPE_SET.has(type)
+}
+
+export function isSystemField(field: Pick<MetaField, 'type'> | null | undefined): boolean {
+  return isSystemFieldType(field?.type)
+}
+
+export function isSystemFieldCreateType(type: MetaFieldCreateType | string | null | undefined): type is SystemFieldType {
+  return isSystemFieldType(type)
+}
+
+export function systemFieldHint(type: MetaFieldCreateType | string | null | undefined): string {
+  switch (type) {
+    case 'createdTime':
+      return 'Created time is generated from the record creation timestamp and is read-only.'
+    case 'modifiedTime':
+      return 'Modified time is generated from the last record update timestamp and is read-only.'
+    case 'createdBy':
+      return 'Created by is generated from the record creator and is read-only.'
+    case 'modifiedBy':
+      return 'Modified by is generated from the last modifying actor and is read-only.'
+    default:
+      return 'System fields are generated from record metadata and are read-only.'
+  }
+}

--- a/apps/web/tests/multitable-form-view.spec.ts
+++ b/apps/web/tests/multitable-form-view.spec.ts
@@ -104,6 +104,56 @@ describe('MetaFormView attachment flow', () => {
     container.remove()
   })
 
+  it('omits readonly system fields from submit payloads', async () => {
+    const submitSpy = vi.fn()
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    const app = createApp({
+      render() {
+        return h(MetaFormView, {
+          fields: [
+            { id: 'fld_title', name: 'Title', type: 'string' },
+            { id: 'fld_created_at', name: 'Created at', type: 'createdTime' },
+          ],
+          record: {
+            id: 'rec_1',
+            version: 1,
+            data: {
+              fld_title: 'Draft',
+              fld_created_at: '2026-04-30T08:15:00.000Z',
+            },
+          },
+          loading: false,
+          readOnly: false,
+          onSubmit: submitSpy,
+          onOpenLinkPicker: vi.fn(),
+        })
+      },
+    })
+
+    app.mount(container)
+    await flushUi()
+
+    expect(container.querySelector('#field_fld_created_at')).toBeNull()
+    expect(container.textContent).toContain('2026')
+
+    const titleInput = container.querySelector('#field_fld_title') as HTMLInputElement | null
+    titleInput!.value = 'Revised'
+    titleInput!.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+
+    container.querySelector('form')?.dispatchEvent(new Event('submit'))
+    await flushUi()
+
+    expect(submitSpy).toHaveBeenCalledWith({
+      fld_title: 'Revised',
+    })
+
+    app.unmount()
+    container.remove()
+  })
+
   it('emits dirty state while the form has unsaved edits', async () => {
     const dirtySpy = vi.fn()
     const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)

--- a/apps/web/tests/multitable-system-fields.spec.ts
+++ b/apps/web/tests/multitable-system-fields.spec.ts
@@ -1,0 +1,182 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick } from 'vue'
+import MetaCellEditor from '../src/multitable/components/cells/MetaCellEditor.vue'
+import MetaCellRenderer from '../src/multitable/components/cells/MetaCellRenderer.vue'
+import MetaFieldManager from '../src/multitable/components/MetaFieldManager.vue'
+import MetaGridTable from '../src/multitable/components/MetaGridTable.vue'
+import { formatFieldDisplay } from '../src/multitable/utils/field-display'
+
+async function flushUi(cycles = 4) {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+describe('multitable system fields', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  it('formats system time and actor fields through the shared display formatter', () => {
+    const createdTime = formatFieldDisplay({
+      field: { id: 'fld_created_at', name: 'Created at', type: 'createdTime' },
+      value: '2026-04-30T08:15:00.000Z',
+    })
+    const createdBy = formatFieldDisplay({
+      field: { id: 'fld_created_by', name: 'Created by', type: 'createdBy' },
+      value: 'user_1',
+    })
+
+    expect(createdTime).toContain('2026')
+    expect(createdTime).not.toBe('2026-04-30T08:15:00.000Z')
+    expect(createdBy).toBe('user_1')
+  })
+
+  it('renders system fields with the system cell branch', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    const app = createApp({
+      render() {
+        return h(MetaCellRenderer, {
+          field: { id: 'fld_modified_at', name: 'Modified at', type: 'modifiedTime' },
+          value: '2026-04-30T09:00:00.000Z',
+        })
+      },
+    })
+
+    app.mount(container)
+    await flushUi()
+
+    const systemValue = container.querySelector('.meta-cell-renderer__system')
+    expect(systemValue).not.toBeNull()
+    expect(systemValue?.textContent).toContain('2026')
+
+    app.unmount()
+    container.remove()
+  })
+
+  it('keeps system fields readonly even if the cell editor is mounted directly', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    const app = createApp({
+      render() {
+        return h(MetaCellEditor, {
+          field: { id: 'fld_created_at', name: 'Created at', type: 'createdTime' },
+          modelValue: '2026-04-30T08:15:00.000Z',
+        })
+      },
+    })
+
+    app.mount(container)
+    await flushUi()
+
+    expect(container.querySelector('input, textarea, select, button')).toBeNull()
+    expect(container.querySelector('.meta-cell-editor__readonly')?.textContent).toContain('2026')
+
+    app.unmount()
+    container.remove()
+  })
+
+  it('does not enter grid edit mode for system fields', async () => {
+    const patchSpy = vi.fn()
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    const app = createApp({
+      render() {
+        return h(MetaGridTable, {
+          rows: [
+            {
+              id: 'rec_1',
+              version: 3,
+              data: {
+                fld_created_at: '2026-04-30T08:15:00.000Z',
+              },
+            },
+          ],
+          visibleFields: [
+            { id: 'fld_created_at', name: 'Created at', type: 'createdTime' },
+          ],
+          sortRules: [],
+          loading: false,
+          currentPage: 1,
+          totalPages: 1,
+          startIndex: 0,
+          canEdit: true,
+          onPatchCell: patchSpy,
+        })
+      },
+    })
+
+    app.mount(container)
+    await flushUi()
+
+    const cell = container.querySelector('td[aria-label="Created at"]') as HTMLTableCellElement | null
+    expect(cell).not.toBeNull()
+    cell!.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }))
+    await flushUi()
+
+    expect(container.querySelector('.meta-cell-editor')).toBeNull()
+    expect(container.querySelector('.meta-cell-renderer__system')?.textContent).toContain('2026')
+    expect(patchSpy).not.toHaveBeenCalled()
+
+    app.unmount()
+    container.remove()
+  })
+
+  it('creates system fields from the field manager without configurable property', async () => {
+    const createSpy = vi.fn()
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    const app = createApp({
+      render() {
+        return h(MetaFieldManager, {
+          visible: true,
+          sheetId: 'sheet_1',
+          sheets: [],
+          fields: [],
+          onCreateField: createSpy,
+        })
+      },
+    })
+
+    app.mount(container)
+    await flushUi()
+
+    const nameInput = container.querySelector('.meta-field-mgr__add-row .meta-field-mgr__input') as HTMLInputElement
+    const typeSelect = container.querySelector('.meta-field-mgr__add-row .meta-field-mgr__select') as HTMLSelectElement
+    expect(Array.from(typeSelect.options).map((option) => option.value)).toEqual(expect.arrayContaining([
+      'createdTime',
+      'modifiedTime',
+      'createdBy',
+      'modifiedBy',
+    ]))
+
+    nameInput.value = 'Created at'
+    nameInput.dispatchEvent(new Event('input', { bubbles: true }))
+    typeSelect.value = 'createdTime'
+    typeSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+
+    expect(container.textContent).toContain('Created time is generated')
+
+    ;(Array.from(container.querySelectorAll('.meta-field-mgr__btn-add')) as HTMLButtonElement[])
+      .find((button) => button.textContent?.includes('+ Add'))
+      ?.click()
+    await flushUi()
+
+    expect(createSpy).toHaveBeenCalledWith({
+      sheetId: 'sheet_1',
+      name: 'Created at',
+      type: 'createdTime',
+    })
+
+    app.unmount()
+    container.remove()
+  })
+})

--- a/docs/development/multitable-feishu-rc-todo-20260430.md
+++ b/docs/development/multitable-feishu-rc-todo-20260430.md
@@ -234,11 +234,23 @@ Expected docs:
   - Development MD: `docs/development/multitable-system-fields-backend-development-20260430.md`
   - Verification MD: `docs/development/multitable-system-fields-backend-verification-20260430.md`
   - Verification summary: `isFieldAlwaysReadOnly()` treats system field types as readonly, reusing existing write guards.
-- [ ] Add frontend renderer/editor behavior: render-only for readonly system fields.
-- [ ] Add field manager support for creating/configuring allowed system fields.
-- [ ] Add tests for create, patch rejection, render, sorting/filtering where applicable.
+- [x] Add frontend renderer/editor behavior: render-only for readonly system fields.
+  - PR: pending
+  - Merge commit: pending
+  - Development MD: `docs/development/multitable-system-fields-frontend-development-20260430.md`
+  - Verification MD: `docs/development/multitable-system-fields-frontend-verification-20260430.md`
+  - Verification summary: grid, cell editor, record drawer, and form view treat system fields as formatted read-only values.
+- [x] Add field manager support for creating/configuring allowed system fields.
+  - PR: pending
+  - Merge commit: pending
+  - Development MD: `docs/development/multitable-system-fields-frontend-development-20260430.md`
+  - Verification MD: `docs/development/multitable-system-fields-frontend-verification-20260430.md`
+  - Verification summary: field manager exposes `createdTime`, `modifiedTime`, `createdBy`, and `modifiedBy` as createable no-config fields.
+- [x] Add tests for create, patch rejection, render, sorting/filtering where applicable.
   - Partial: backend tests cover metadata projection and actor persistence in `docs/development/multitable-system-fields-backend-verification-20260430.md`.
-  - Remaining: frontend render/editor tests and sorting/filtering behavior tests after the UI slice.
+  - Development MD: `docs/development/multitable-system-fields-frontend-development-20260430.md`
+  - Verification MD: `docs/development/multitable-system-fields-frontend-verification-20260430.md`
+  - Verification summary: frontend tests cover field-manager create payloads, renderer/editor readonly behavior, and grid no-edit behavior; backend tests continue to cover patch rejection.
 - [x] Update OpenAPI source and generated dist.
   - PR: #1280
   - Merge commit: c45da32c1
@@ -248,8 +260,10 @@ Expected docs:
 
 Expected docs:
 
-- `docs/development/multitable-system-fields-batch-development-20260501.md`
-- `docs/development/multitable-system-fields-batch-verification-20260501.md`
+- `docs/development/multitable-system-fields-backend-development-20260430.md`
+- `docs/development/multitable-system-fields-backend-verification-20260430.md`
+- `docs/development/multitable-system-fields-frontend-development-20260430.md`
+- `docs/development/multitable-system-fields-frontend-verification-20260430.md`
 
 ## Phase 5 - P1 Gap: Record Version History
 

--- a/docs/development/multitable-system-fields-frontend-development-20260430.md
+++ b/docs/development/multitable-system-fields-frontend-development-20260430.md
@@ -1,0 +1,85 @@
+# Multitable System Fields Frontend Development - 2026-04-30
+
+## Scope
+
+This slice closes the frontend half of Phase 4 system fields after the backend seam in PR #1280.
+
+Implemented field types:
+
+- `createdTime`
+- `modifiedTime`
+- `createdBy`
+- `modifiedBy`
+
+Out of scope:
+
+- `autoNumber`; still deferred until persistent sequence allocation exists.
+- User display-name resolution for `createdBy` / `modifiedBy`; the UI displays the backend-projected actor id for now.
+
+## Design
+
+### Shared Type and Helper
+
+Added the four system field types to `MetaFieldType`.
+
+Added `apps/web/src/multitable/utils/system-fields.ts` as the single frontend helper for:
+
+- system field type detection,
+- system field create-type detection,
+- readonly field-manager hint text.
+
+This keeps edit guards consistent across grid, record drawer, form view, and field manager.
+
+### Display Formatting
+
+`formatFieldDisplay()` now treats:
+
+- `createdTime` and `modifiedTime` as datetime display values,
+- `createdBy` and `modifiedBy` as actor-id display values.
+
+Invalid datetime strings intentionally fall back to raw display, matching the existing `date` behavior.
+
+### Readonly Surfaces
+
+System fields are explicitly read-only on the frontend:
+
+- `MetaGridTable` refuses edit mode for system fields even when `canEdit=true`.
+- `MetaCellEditor` direct mounts fall through to a formatted readonly span.
+- `MetaRecordDrawer` excludes system fields from editable branch conditions.
+- `MetaFormView` treats system fields as read-only and uses shared display formatting in the fallback path.
+- `MetaFormView` omits system fields from submit payloads so an update to another field does not resend generated metadata and trip backend readonly validation.
+
+Backend remains authoritative; this frontend guard only prevents avoidable UI writes before they hit the server.
+
+### Field Manager
+
+`MetaFieldManager` now exposes the four allowed system field types in the create dropdown.
+
+They do not open a config panel and emit create payloads without `property`, because their values are generated from record metadata.
+
+The add form shows a system-field hint so users know the created field is read-only.
+
+### Icons
+
+`MetaFieldHeader` and `MetaFieldManager` now include icons for system fields. `MetaFieldHeader` also received missing icons for several existing advanced field types so those columns no longer fall back to `?`.
+
+## Files Changed
+
+- `apps/web/src/multitable/types.ts`
+- `apps/web/src/multitable/utils/system-fields.ts`
+- `apps/web/src/multitable/utils/field-display.ts`
+- `apps/web/src/multitable/components/cells/MetaCellRenderer.vue`
+- `apps/web/src/multitable/components/cells/MetaCellEditor.vue`
+- `apps/web/src/multitable/components/MetaGridTable.vue`
+- `apps/web/src/multitable/components/MetaRecordDrawer.vue`
+- `apps/web/src/multitable/components/MetaFormView.vue`
+- `apps/web/src/multitable/components/MetaFieldManager.vue`
+- `apps/web/src/multitable/components/MetaFieldHeader.vue`
+- `apps/web/tests/multitable-system-fields.spec.ts`
+- `apps/web/tests/multitable-form-view.spec.ts`
+- `docs/development/multitable-feishu-rc-todo-20260430.md`
+
+## Residual Follow-ups
+
+- Add display-name resolution for actor ids once user-directory lookup is available in the multitable view payload.
+- Revisit `autoNumber` after backend sequence allocation is designed.

--- a/docs/development/multitable-system-fields-frontend-verification-20260430.md
+++ b/docs/development/multitable-system-fields-frontend-verification-20260430.md
@@ -1,0 +1,90 @@
+# Multitable System Fields Frontend Verification - 2026-04-30
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/multitable-system-fields.spec.ts \
+  tests/multitable-field-manager.spec.ts \
+  tests/multitable-record-drawer.spec.ts \
+  tests/multitable-form-view.spec.ts \
+  --reporter=dot
+```
+
+Result:
+
+```text
+Test Files  4 passed (4)
+Tests       34 passed (34)
+```
+
+Note: Vitest printed `WebSocket server error: Port is already in use`; the test process still exited `0` and all targeted tests passed.
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+```
+
+Result: exit `0`.
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/multitable-grid-link-renderer.spec.ts \
+  tests/multitable-multiselect-field.spec.ts \
+  --reporter=dot
+```
+
+Result:
+
+```text
+Test Files  2 passed (2)
+Tests       10 passed (10)
+```
+
+```bash
+git diff --check
+```
+
+Result: clean.
+
+## Coverage
+
+### New Tests
+
+`apps/web/tests/multitable-system-fields.spec.ts`
+
+- `formatFieldDisplay()` formats `createdTime` as datetime and keeps `createdBy` as actor id.
+- `MetaCellRenderer` uses a dedicated system-field branch.
+- `MetaCellEditor` direct-mount fallback is read-only and formatted.
+- `MetaGridTable` does not enter edit mode for a system field even with `canEdit=true`.
+- `MetaFieldManager` lists all four system field types and emits a create payload without `property`.
+
+### Regression Tests
+
+`apps/web/tests/multitable-field-manager.spec.ts`
+
+- Existing field-manager configuration behavior remains green.
+- New system-field create option does not regress select/multiSelect/link/attachment validation flows.
+
+`apps/web/tests/multitable-record-drawer.spec.ts`
+
+- Drawer editable and read-only branches remain green after system-field edit guard changes.
+
+`apps/web/tests/multitable-form-view.spec.ts`
+
+- Form view display and attachment regressions remain green.
+- System fields are displayed read-only and omitted from submit payloads.
+
+## Manual Verification Notes
+
+Recommended staging smoke after deploy:
+
+1. Create a multitable field with type `createdTime`.
+2. Create a record.
+3. Confirm the created-time value appears in grid, row expansion, record drawer, and form/detail view.
+4. Double-click the created-time cell and confirm no editor opens.
+5. Repeat for `modifiedTime`, `createdBy`, and `modifiedBy`.
+
+## Known Limits
+
+- Actor fields display raw user ids until a user display-name map is wired into the multitable view payload.
+- `autoNumber` remains intentionally unshipped.


### PR DESCRIPTION
## Summary

- add frontend system field types for `createdTime`, `modifiedTime`, `createdBy`, and `modifiedBy`
- render system fields with shared display formatting and block edit mode in grid, cell editor, drawer, and form view
- expose allowed system fields in the field manager as no-config create options with read-only hints
- prevent form submit payloads from resending generated system metadata
- add design/verification docs and close the Phase 4 frontend TODO items

## Verification

- `pnpm --filter @metasheet/web exec vitest run tests/multitable-system-fields.spec.ts tests/multitable-field-manager.spec.ts tests/multitable-record-drawer.spec.ts tests/multitable-form-view.spec.ts --reporter=dot` → 34/34 passed
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-grid-link-renderer.spec.ts tests/multitable-multiselect-field.spec.ts --reporter=dot` → 10/10 passed
- `pnpm --filter @metasheet/web exec vue-tsc -b --noEmit` → exit 0
- `git diff --check origin/main..HEAD` → clean

Note: Vitest printed `WebSocket server error: Port is already in use`; all targeted suites exited 0.

## Docs

- `docs/development/multitable-system-fields-frontend-development-20260430.md`
- `docs/development/multitable-system-fields-frontend-verification-20260430.md`
