### PR TITLE
docs(integration): record K3 default tenant signoff

### DIFF
--- a/docs/development/integration-k3wise-default-tenant-signoff-design-20260430.md
+++ b/docs/development/integration-k3wise-default-tenant-signoff-design-20260430.md
@@ -1,0 +1,53 @@
+# K3 WISE Default Tenant Signoff Design
+
+## Context
+
+The K3 WISE internal-trial smoke reached production successfully after the
+failure-evidence fix, but the first authenticated signoff attempt was blocked
+because no tenant scope was provided:
+
+- `METASHEET_K3WISE_SMOKE_TOKEN` was not configured;
+- `METASHEET_TENANT_ID` was not configured;
+- singleton integration-tenant auto-discovery found no integration rows yet.
+
+That behavior is correct for safety. The resolver must not invent a tenant from
+empty integration state.
+
+The 142 deployment is currently a single-tenant internal trial. Existing
+MetaSheet routes commonly use `default` as the single-tenant scope, and a manual
+authenticated smoke with `tenant_id=default` passed all signoff checks.
+
+## Decision
+
+Configure GitHub repository variable:
+
+```text
+METASHEET_TENANT_ID=default
+```
+
+This makes manual K3 WISE signoff repeatable without asking an operator to type
+the tenant every time. The workflow input still overrides the variable, so
+customer-specific or future multi-tenant runs can explicitly provide another
+tenant.
+
+## Boundaries
+
+- This is a non-secret repository variable.
+- It does not configure K3 WISE credentials.
+- It does not make public-only smoke a signoff.
+- It does not make production deploy hard-fail on K3 authenticated smoke;
+  `K3_WISE_DEPLOY_SMOKE_REQUIRE_AUTH=true` remains the separate hard-gate
+  switch.
+- It does not change tenant auto-discovery rules.
+
+## Result
+
+After setting the variable, the manual workflow passed with no explicit
+`tenant_id` input. Evidence shows:
+
+- `authenticated=true`;
+- `signoff.internalTrial=pass`;
+- `auth-me.tenantId=default`;
+- `integration-route-contract=pass`;
+- all four control-plane list probes passed;
+- `staging-descriptor-contract=pass`.

--- a/docs/development/integration-k3wise-default-tenant-signoff-verification-20260430.md
+++ b/docs/development/integration-k3wise-default-tenant-signoff-verification-20260430.md
@@ -1,0 +1,89 @@
+# K3 WISE Default Tenant Signoff Verification
+
+## Repository Variable
+
+```bash
+gh variable list --repo zensgit/metasheet2 --json name,updatedAt \
+  | node -e 'let s=""; process.stdin.on("data",d=>s+=d); process.stdin.on("end",()=>{const vars=JSON.parse(s); console.log(vars.filter(v=>v.name==="METASHEET_TENANT_ID"))})'
+```
+
+Observed:
+
+```text
+METASHEET_TENANT_ID 2026-04-30T09:11:56Z
+```
+
+The value is intentionally not a secret; it is `default`.
+
+## Live Signoff Runs
+
+### Explicit Tenant Probe
+
+Workflow:
+
+```bash
+gh workflow run integration-k3wise-postdeploy-smoke.yml \
+  --repo zensgit/metasheet2 \
+  --ref main \
+  -f base_url='http://142.171.239.56:8081' \
+  -f require_auth=true \
+  -f tenant_id=default \
+  -f auto_discover_tenant=false \
+  -f timeout_ms=10000
+```
+
+Result:
+
+- Run: `https://github.com/zensgit/metasheet2/actions/runs/25157225647`
+- Status: `success`
+- Evidence: `signoff.internalTrial=pass`
+- Summary: `10 pass / 0 skipped / 0 fail`
+
+### Repository Variable Probe
+
+Workflow:
+
+```bash
+gh workflow run integration-k3wise-postdeploy-smoke.yml \
+  --repo zensgit/metasheet2 \
+  --ref main \
+  -f base_url='http://142.171.239.56:8081' \
+  -f require_auth=true \
+  -f auto_discover_tenant=false \
+  -f timeout_ms=10000
+```
+
+Result:
+
+- Run: `https://github.com/zensgit/metasheet2/actions/runs/25157307393`
+- Status: `success`
+- Artifact: `integration-k3wise-postdeploy-smoke-25157307393-1`
+- Evidence: `ok=true`
+- Evidence: `authenticated=true`
+- Evidence: `signoff.internalTrial=pass`
+- Evidence: `auth-me.tenantId=default`
+- Summary: `10 pass / 0 skipped / 0 fail`
+
+## Evidence Checks
+
+The downloaded evidence JSON for run `25157307393` contains these passing
+checks:
+
+- `api-health`
+- `integration-plugin-health`
+- `k3-wise-frontend-route`
+- `auth-me`
+- `integration-route-contract`
+- `integration-list-external-systems`
+- `integration-list-pipelines`
+- `integration-list-runs`
+- `integration-list-dead-letters`
+- `staging-descriptor-contract`
+
+## Local Documentation Check
+
+```bash
+git diff --check
+```
+
+Expected: no whitespace errors.

--- a/docs/operations/integration-k3wise-internal-trial-runbook.md
+++ b/docs/operations/integration-k3wise-internal-trial-runbook.md
@@ -41,6 +41,11 @@ For manual signoff, run `K3 WISE Postdeploy Smoke` with:
 - `auto_discover_tenant`: `true` only when the deployment has exactly one
   integration tenant scope.
 
+For the current 142 internal trial deployment, use tenant scope `default`.
+`METASHEET_TENANT_ID=default` is configured as a GitHub repository variable, so
+the manual workflow can be run without filling `tenant_id`; use the input only
+when intentionally testing another tenant.
+
 Token resolution order:
 
 1. `METASHEET_K3WISE_SMOKE_TOKEN` secret.
@@ -86,3 +91,19 @@ K3_WISE_DEPLOY_SMOKE_REQUIRE_AUTH=true
 Keep it unset or `false` only when the deployment is still in diagnostic mode.
 Diagnostic mode can prove the web/API surface is reachable, but cannot sign off
 the internal K3 WISE trial.
+
+## 142 Internal Trial Evidence
+
+Latest confirmed signoff run:
+
+- Workflow: `K3 WISE Postdeploy Smoke`
+- Run: `https://github.com/zensgit/metasheet2/actions/runs/25157307393`
+- Tenant source: repository variable `METASHEET_TENANT_ID=default`
+- Result: `signoff.internalTrial=pass`
+- Summary: `10 pass / 0 skipped / 0 fail`
+- Artifact: `integration-k3wise-postdeploy-smoke-25157307393-1`
+
+The run proved the deployed 142 environment can mint a temporary masked admin
+token from the deploy host, reach the K3 setup frontend route, validate the
+integration plugin route contract, list the four tenant-scoped control-plane
+collections, and validate staging descriptors.


### PR DESCRIPTION
## Summary
- document the 142 internal-trial K3 WISE signoff path using tenant scope default
- record that METASHEET_TENANT_ID=default is configured as a non-secret repo variable
- add design and verification notes for the successful authenticated smoke runs

## Verification
- gh workflow run integration-k3wise-postdeploy-smoke.yml --repo zensgit/metasheet2 --ref main -f base_url='http://142.171.239.56:8081' -f require_auth=true -f tenant_id=default -f auto_discover_tenant=false -f timeout_ms=10000
  - run: https://github.com/zensgit/metasheet2/actions/runs/25157225647
  - result: success, 10 pass / 0 skipped / 0 fail
- gh variable set METASHEET_TENANT_ID --repo zensgit/metasheet2 --body default
- gh workflow run integration-k3wise-postdeploy-smoke.yml --repo zensgit/metasheet2 --ref main -f base_url='http://142.171.239.56:8081' -f require_auth=true -f auto_discover_tenant=false -f timeout_ms=10000
  - run: https://github.com/zensgit/metasheet2/actions/runs/25157307393
  - result: success, 10 pass / 0 skipped / 0 fail
- git diff --check