### PR TITLE
feat(multitable): add record history

### DIFF
--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -11,6 +11,7 @@ import type {
   MetaContext,
   MetaRecord,
   MetaRecordContext,
+  MetaRecordRevision,
   MetaFormContext,
   PatchResult,
   FormSubmitResult,
@@ -563,6 +564,42 @@ function normalizeRecordPermissionEntries(
     : []
 }
 
+function normalizeRecordHistoryEntry(payload: Partial<MetaRecordRevision> | null | undefined): MetaRecordRevision | null {
+  const id = typeof payload?.id === 'string' ? payload.id : ''
+  const sheetId = typeof payload?.sheetId === 'string' ? payload.sheetId : ''
+  const recordId = typeof payload?.recordId === 'string' ? payload.recordId : ''
+  const version = typeof payload?.version === 'number' && Number.isFinite(payload.version) ? payload.version : null
+  const action = payload?.action === 'create' || payload?.action === 'delete' || payload?.action === 'update'
+    ? payload.action
+    : null
+  if (!id || !sheetId || !recordId || version === null || !action) return null
+  return {
+    id,
+    sheetId,
+    recordId,
+    version,
+    action,
+    source: typeof payload?.source === 'string' ? payload.source : 'rest',
+    actorId: typeof payload?.actorId === 'string' ? payload.actorId : null,
+    changedFieldIds: Array.isArray(payload?.changedFieldIds) ? payload.changedFieldIds.map(String) : [],
+    patch: isPlainObject(payload?.patch) ? payload.patch : {},
+    snapshot: payload?.snapshot === null || payload?.snapshot === undefined
+      ? null
+      : isPlainObject(payload.snapshot) ? payload.snapshot : {},
+    createdAt: typeof payload?.createdAt === 'string' ? payload.createdAt : '',
+  }
+}
+
+function normalizeRecordHistoryEntries(
+  payload: { items?: Array<Partial<MetaRecordRevision>> } | null | undefined,
+): MetaRecordRevision[] {
+  return Array.isArray(payload?.items)
+    ? payload.items
+      .map((item) => normalizeRecordHistoryEntry(item))
+      .filter((item): item is MetaRecordRevision => !!item)
+    : []
+}
+
 function normalizeCommentsParams(params: { containerId: string; targetId: string; targetFieldId?: string | null } | MetaCommentsScope) {
   if ('containerType' in params) {
     return {
@@ -845,6 +882,14 @@ export class MultitableApiClient {
   async getRecord(recordId: string, params?: { sheetId?: string; viewId?: string }): Promise<MetaRecordContext> {
     const res = await this.fetch(`/api/multitable/records/${recordId}${qs(params ?? {})}`)
     return parseJson(res)
+  }
+
+  async listRecordHistory(sheetId: string, recordId: string, params?: { limit?: number; offset?: number }): Promise<MetaRecordRevision[]> {
+    const res = await this.fetch(
+      `/api/multitable/sheets/${encodeURIComponent(sheetId)}/records/${encodeURIComponent(recordId)}/history${qs(params ?? {})}`,
+    )
+    const data = await parseJson<{ items?: Array<Partial<MetaRecordRevision>> }>(res)
+    return normalizeRecordHistoryEntries(data)
   }
 
   async createRecord(input: CreateRecordInput, opts?: { signal?: AbortSignal }): Promise<{ record: MetaRecord }> {

--- a/apps/web/src/multitable/components/MetaRecordDrawer.vue
+++ b/apps/web/src/multitable/components/MetaRecordDrawer.vue
@@ -25,6 +25,25 @@
       </div>
     </div>
     <div v-if="record" class="meta-record-drawer__body">
+      <div class="meta-record-drawer__tabs" role="tablist" aria-label="Record drawer sections">
+        <button
+          class="meta-record-drawer__tab"
+          :class="{ 'meta-record-drawer__tab--active': activeTab === 'details' }"
+          type="button"
+          role="tab"
+          :aria-selected="activeTab === 'details'"
+          @click="activeTab = 'details'"
+        >Details</button>
+        <button
+          class="meta-record-drawer__tab"
+          :class="{ 'meta-record-drawer__tab--active': activeTab === 'history' }"
+          type="button"
+          role="tab"
+          :aria-selected="activeTab === 'history'"
+          @click="activeTab = 'history'"
+        >History</button>
+      </div>
+      <div v-if="activeTab === 'details'" class="meta-record-drawer__fields">
       <div v-for="field in visibleFields" :key="field.id" class="meta-record-drawer__field">
         <div class="meta-record-drawer__field-header">
           <label class="meta-record-drawer__label" :for="`drawer_field_${field.id}`">{{ field.name }}</label>
@@ -136,6 +155,29 @@
           <div v-if="field.type === 'link' && linkPreview(field.id)" class="meta-record-drawer__link-summary">{{ linkPreview(field.id) }}</div>
         </div>
       </div>
+      </div>
+      <div v-else class="meta-record-drawer__history">
+        <div v-if="historyLoading" class="meta-record-drawer__history-state">Loading history...</div>
+        <div v-else-if="historyError" class="meta-record-drawer__history-state meta-record-drawer__history-state--error">{{ historyError }}</div>
+        <div v-else-if="!canLoadHistory" class="meta-record-drawer__history-state">History unavailable for this record.</div>
+        <div v-else-if="historyItems.length === 0" class="meta-record-drawer__history-state">No history yet.</div>
+        <ol v-else class="meta-record-drawer__history-list">
+          <li v-for="item in historyItems" :key="item.id" class="meta-record-drawer__history-item">
+            <div class="meta-record-drawer__history-main">
+              <span class="meta-record-drawer__history-action">{{ historyActionLabel(item.action) }}</span>
+              <span class="meta-record-drawer__history-version">v{{ item.version }}</span>
+            </div>
+            <div class="meta-record-drawer__history-meta">
+              <span>{{ formatHistoryTime(item.createdAt) }}</span>
+              <span v-if="item.actorId">by {{ item.actorId }}</span>
+              <span>{{ item.source }}</span>
+            </div>
+            <div v-if="item.changedFieldIds.length" class="meta-record-drawer__history-fields">
+              {{ historyFieldLabels(item.changedFieldIds) }}
+            </div>
+          </li>
+        </ol>
+      </div>
     </div>
     <div v-else class="meta-record-drawer__empty">No record selected</div>
     <MetaRecordPermissionManager
@@ -161,6 +203,7 @@ import type {
   MetaFieldPermission,
   MetaField,
   MetaRecord,
+  MetaRecordRevision,
   MetaRowActions,
 } from '../types'
 import type { MultitableApiClient } from '../api/client'
@@ -213,6 +256,11 @@ const emit = defineEmits<{
 }>()
 
 const showRecordPermissions = ref(false)
+const activeTab = ref<'details' | 'history'>('details')
+const historyItems = ref<MetaRecordRevision[]>([])
+const historyLoading = ref(false)
+const historyError = ref('')
+let historyRequestId = 0
 
 const attachmentActivity = ref<Record<string, 'uploading' | 'removing' | 'clearing'>>({})
 const attachmentErrors = ref<Record<string, string>>({})
@@ -222,7 +270,17 @@ watch(() => props.record, () => {
   attachmentActivity.value = {}
   attachmentErrors.value = {}
   localAttachmentSummaries.value = {}
+  historyItems.value = []
+  historyError.value = ''
 })
+
+watch(
+  [() => activeTab.value, () => props.visible, () => props.record?.id, () => props.sheetId, () => props.apiClient],
+  () => {
+    if (activeTab.value === 'history') void loadRecordHistory()
+  },
+  { immediate: false },
+)
 
 const currentRecordIndex = computed(() => {
   if (!props.record || !props.recordIds.length) return -1
@@ -230,6 +288,8 @@ const currentRecordIndex = computed(() => {
 })
 
 const visibleFields = computed(() => props.fields.filter((field) => props.fieldPermissions?.[field.id]?.visible !== false))
+const fieldLabelById = computed(() => new Map(props.fields.map((field) => [field.id, field.name])))
+const canLoadHistory = computed(() => !!props.apiClient && !!props.sheetId && !!props.record?.id)
 const resolvedCanComment = computed(() => props.rowActions?.canComment ?? props.canComment)
 const resolvedCanDelete = computed(() => props.rowActions?.canDelete ?? props.canDelete)
 const drawerCommentAffordance = computed(() => resolveRecordCommentAffordance(props.commentPresence))
@@ -261,6 +321,51 @@ function navigatePrev() {
 function navigateNext() {
   const idx = currentRecordIndex.value
   if (idx >= 0 && idx < props.recordIds.length - 1) emit('navigate', props.recordIds[idx + 1])
+}
+
+async function loadRecordHistory() {
+  const apiClient = props.apiClient
+  const sheetId = props.sheetId
+  const recordId = props.record?.id
+  if (!apiClient || !sheetId || !recordId) {
+    historyItems.value = []
+    historyLoading.value = false
+    historyError.value = ''
+    return
+  }
+  const requestId = ++historyRequestId
+  historyLoading.value = true
+  historyError.value = ''
+  try {
+    const items = await apiClient.listRecordHistory(sheetId, recordId, { limit: 50 })
+    if (requestId !== historyRequestId) return
+    historyItems.value = items
+  } catch (error: any) {
+    if (requestId !== historyRequestId) return
+    historyItems.value = []
+    historyError.value = error?.message ?? 'Failed to load history'
+  } finally {
+    if (requestId === historyRequestId) historyLoading.value = false
+  }
+}
+
+function historyActionLabel(action: MetaRecordRevision['action']): string {
+  if (action === 'create') return 'Created'
+  if (action === 'delete') return 'Deleted'
+  return 'Updated'
+}
+
+function historyFieldLabels(fieldIds: string[]): string {
+  return fieldIds
+    .map((fieldId) => fieldLabelById.value.get(fieldId) ?? fieldId)
+    .join(', ')
+}
+
+function formatHistoryTime(value: string): string {
+  if (!value) return ''
+  const timestamp = Date.parse(value)
+  if (Number.isNaN(timestamp)) return value
+  return new Date(timestamp).toLocaleString()
 }
 
 function formatValue(field: MetaField, v: unknown): string {
@@ -497,6 +602,9 @@ function attachmentAllowsMultiple(field: MetaField): boolean {
 .meta-record-drawer__nav-btn:disabled { opacity: 0.35; cursor: not-allowed; }
 .meta-record-drawer__nav-pos { font-size: 11px; color: #999; min-width: 36px; text-align: center; }
 .meta-record-drawer__body { padding: 12px 16px; flex: 1; }
+.meta-record-drawer__tabs { display: inline-flex; gap: 4px; padding: 3px; margin-bottom: 14px; border: 1px solid #e5e7eb; border-radius: 999px; background: #f8fafc; }
+.meta-record-drawer__tab { min-width: 76px; padding: 5px 12px; border: none; border-radius: 999px; background: transparent; color: #64748b; cursor: pointer; font-size: 12px; font-weight: 600; }
+.meta-record-drawer__tab--active { background: #111827; color: #fff; box-shadow: 0 2px 8px rgba(15, 23, 42, 0.16); }
 .meta-record-drawer__field { margin-bottom: 14px; }
 .meta-record-drawer__field-header { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-bottom: 4px; }
 .meta-record-drawer__label { display: block; font-size: 12px; color: #999; }
@@ -523,4 +631,13 @@ function attachmentAllowsMultiple(field: MetaField): boolean {
 .meta-record-drawer__error { color: #f56c6c; font-size: 12px; }
 .meta-record-drawer__text { font-size: 13px; color: #333; white-space: pre-wrap; word-break: break-word; }
 .meta-record-drawer__empty { padding: 32px; text-align: center; color: #999; }
+.meta-record-drawer__history-state { padding: 18px 12px; border: 1px dashed #d8e1ee; border-radius: 8px; color: #64748b; font-size: 13px; text-align: center; }
+.meta-record-drawer__history-state--error { border-color: #fecaca; color: #b91c1c; background: #fef2f2; }
+.meta-record-drawer__history-list { display: flex; flex-direction: column; gap: 10px; padding: 0; margin: 0; list-style: none; }
+.meta-record-drawer__history-item { padding: 10px 12px; border: 1px solid #e5e7eb; border-radius: 10px; background: #fff; }
+.meta-record-drawer__history-main { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-bottom: 5px; }
+.meta-record-drawer__history-action { font-size: 13px; font-weight: 700; color: #111827; }
+.meta-record-drawer__history-version { font-size: 11px; font-weight: 700; color: #2563eb; background: #eff6ff; border-radius: 999px; padding: 2px 7px; }
+.meta-record-drawer__history-meta { display: flex; flex-wrap: wrap; gap: 6px; font-size: 11px; color: #64748b; }
+.meta-record-drawer__history-fields { margin-top: 8px; font-size: 12px; color: #374151; word-break: break-word; }
 </style>

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -198,6 +198,22 @@ export interface MetaRecordContext {
   attachmentSummaries?: Record<string, MetaAttachment[]>
 }
 
+export type MetaRecordRevisionAction = 'create' | 'update' | 'delete'
+
+export interface MetaRecordRevision {
+  id: string
+  sheetId: string
+  recordId: string
+  version: number
+  action: MetaRecordRevisionAction
+  source: string
+  actorId: string | null
+  changedFieldIds: string[]
+  patch: Record<string, unknown>
+  snapshot: Record<string, unknown> | null
+  createdAt: string
+}
+
 // --- Form context (GET /api/multitable/form-context) ---
 export interface MetaFormContext {
   mode: 'form'

--- a/apps/web/tests/multitable-client.spec.ts
+++ b/apps/web/tests/multitable-client.spec.ts
@@ -528,6 +528,48 @@ describe('MultitableApiClient', () => {
     }))
   })
 
+  it('loads and normalizes record history entries', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      ok: true,
+      data: {
+        items: [
+          {
+            id: 'rev_1',
+            sheetId: 'sheet history',
+            recordId: 'rec history',
+            version: 3,
+            action: 'update',
+            source: 'rest',
+            actorId: 'user_1',
+            changedFieldIds: ['fld_title'],
+            patch: { fld_title: 'Updated' },
+            snapshot: { fld_title: 'Updated' },
+            createdAt: '2026-04-30T09:00:00.000Z',
+          },
+          { id: 'bad' },
+        ],
+      },
+    }), { status: 200 }))
+    const client = new MultitableApiClient({ fetchFn })
+
+    await expect(client.listRecordHistory('sheet history', 'rec history', { limit: 25 })).resolves.toEqual([
+      {
+        id: 'rev_1',
+        sheetId: 'sheet history',
+        recordId: 'rec history',
+        version: 3,
+        action: 'update',
+        source: 'rest',
+        actorId: 'user_1',
+        changedFieldIds: ['fld_title'],
+        patch: { fld_title: 'Updated' },
+        snapshot: { fld_title: 'Updated' },
+        createdAt: '2026-04-30T09:00:00.000Z',
+      },
+    ])
+    expect(fetchFn).toHaveBeenCalledWith('/api/multitable/sheets/sheet%20history/records/rec%20history/history?limit=25')
+  })
+
   it('parses Retry-After seconds and http-date values', () => {
     expect(parseRetryAfterMs('2')).toBe(2000)
     expect(parseRetryAfterMs('Wed, 25 Mar 2026 12:00:05 GMT')).toBe(5000)

--- a/apps/web/tests/multitable-record-drawer.spec.ts
+++ b/apps/web/tests/multitable-record-drawer.spec.ts
@@ -98,6 +98,105 @@ describe('MetaRecordDrawer', () => {
     container.remove()
   })
 
+  it('loads and renders record history in the History tab', async () => {
+    const listRecordHistory = vi.fn().mockResolvedValue([
+      {
+        id: 'rev_2',
+        sheetId: 'sheet_orders',
+        recordId: 'rec_history_1',
+        version: 2,
+        action: 'update',
+        source: 'rest',
+        actorId: 'user_1',
+        changedFieldIds: ['fld_title'],
+        patch: { fld_title: 'Updated' },
+        snapshot: { fld_title: 'Updated' },
+        createdAt: '2026-04-30T09:00:00.000Z',
+      },
+    ])
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    const app = createApp({
+      render() {
+        return h(MetaRecordDrawer, {
+          visible: true,
+          record: {
+            id: 'rec_history_1',
+            version: 2,
+            data: {
+              fld_title: 'Updated',
+            },
+          },
+          fields: [
+            { id: 'fld_title', name: 'Title', type: 'string' },
+          ],
+          canEdit: true,
+          canComment: false,
+          canDelete: false,
+          sheetId: 'sheet_orders',
+          apiClient: { listRecordHistory } as any,
+        })
+      },
+    })
+
+    app.mount(container)
+    await flushUi()
+
+    ;(Array.from(container.querySelectorAll('.meta-record-drawer__tab')).find((button) =>
+      button.textContent?.includes('History'),
+    ) as HTMLButtonElement | undefined)?.click()
+    await flushUi()
+
+    expect(listRecordHistory).toHaveBeenCalledWith('sheet_orders', 'rec_history_1', { limit: 50 })
+    expect(container.textContent).toContain('Updated')
+    expect(container.textContent).toContain('v2')
+    expect(container.textContent).toContain('Title')
+    expect(container.textContent).toContain('user_1')
+
+    app.unmount()
+    container.remove()
+  })
+
+  it('shows history unavailable when no api client is provided', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    const app = createApp({
+      render() {
+        return h(MetaRecordDrawer, {
+          visible: true,
+          record: {
+            id: 'rec_history_2',
+            version: 1,
+            data: {
+              fld_title: 'Alpha',
+            },
+          },
+          fields: [
+            { id: 'fld_title', name: 'Title', type: 'string' },
+          ],
+          canEdit: true,
+          canComment: false,
+          canDelete: false,
+        })
+      },
+    })
+
+    app.mount(container)
+    await flushUi()
+
+    ;(Array.from(container.querySelectorAll('.meta-record-drawer__tab')).find((button) =>
+      button.textContent?.includes('History'),
+    ) as HTMLButtonElement | undefined)?.click()
+    await flushUi()
+
+    expect(container.textContent).toContain('History unavailable for this record.')
+
+    app.unmount()
+    container.remove()
+  })
+
   it('honors scoped row actions and exposes the workflow entry', async () => {
     const toggleCommentsSpy = vi.fn()
     const openAutomationSpy = vi.fn()

--- a/docs/development/multitable-feishu-rc-todo-20260430.md
+++ b/docs/development/multitable-feishu-rc-todo-20260430.md
@@ -235,14 +235,14 @@ Expected docs:
   - Verification MD: `docs/development/multitable-system-fields-backend-verification-20260430.md`
   - Verification summary: `isFieldAlwaysReadOnly()` treats system field types as readonly, reusing existing write guards.
 - [x] Add frontend renderer/editor behavior: render-only for readonly system fields.
-  - PR: pending
-  - Merge commit: pending
+  - PR: #1283
+  - Merge commit: `8174f26f9`
   - Development MD: `docs/development/multitable-system-fields-frontend-development-20260430.md`
   - Verification MD: `docs/development/multitable-system-fields-frontend-verification-20260430.md`
   - Verification summary: grid, cell editor, record drawer, and form view treat system fields as formatted read-only values.
 - [x] Add field manager support for creating/configuring allowed system fields.
-  - PR: pending
-  - Merge commit: pending
+  - PR: #1283
+  - Merge commit: `8174f26f9`
   - Development MD: `docs/development/multitable-system-fields-frontend-development-20260430.md`
   - Verification MD: `docs/development/multitable-system-fields-frontend-verification-20260430.md`
   - Verification summary: field manager exposes `createdTime`, `modifiedTime`, `createdBy`, and `modifiedBy` as createable no-config fields.
@@ -267,18 +267,53 @@ Expected docs:
 
 ## Phase 5 - P1 Gap: Record Version History
 
-- [ ] Add record revision persistence table.
-- [ ] Record revision after successful authoritative writes.
-- [ ] Capture actor, source, version, changed fields, and timestamp.
-- [ ] Add API to list record history.
-- [ ] Add record drawer History tab.
-- [ ] Add tests for single-field patch, multi-field patch, actor attribution, and permission denial.
-- [ ] Document retention default: no cleanup in v1.
+- [x] Add record revision persistence table.
+  - PR: local branch `codex/multitable-record-history-20260430`
+  - Merge commit: pending
+  - Development MD: `docs/development/multitable-record-history-development-20260430.md`
+  - Verification MD: `docs/development/multitable-record-history-verification-20260430.md`
+  - Verification summary: migration creates `meta_record_revisions` with revision indexes.
+- [x] Record revision after successful authoritative writes.
+  - PR: local branch `codex/multitable-record-history-20260430`
+  - Merge commit: pending
+  - Development MD: `docs/development/multitable-record-history-development-20260430.md`
+  - Verification MD: `docs/development/multitable-record-history-verification-20260430.md`
+  - Verification summary: `RecordService` create/patch/delete and `RecordWriteService.patchRecords()` persist revisions in the same transaction.
+- [x] Capture actor, source, version, changed fields, and timestamp.
+  - PR: local branch `codex/multitable-record-history-20260430`
+  - Merge commit: pending
+  - Development MD: `docs/development/multitable-record-history-development-20260430.md`
+  - Verification MD: `docs/development/multitable-record-history-verification-20260430.md`
+  - Verification summary: revision rows include actor, source, action, version, changed field ids, patch, snapshot, and server timestamp.
+- [x] Add API to list record history.
+  - PR: local branch `codex/multitable-record-history-20260430`
+  - Merge commit: pending
+  - Development MD: `docs/development/multitable-record-history-development-20260430.md`
+  - Verification MD: `docs/development/multitable-record-history-verification-20260430.md`
+  - Verification summary: `GET /api/multitable/sheets/:sheetId/records/:recordId/history` added with auth/read checks; OpenAPI source and dist regenerated.
+- [x] Add record drawer History tab.
+  - PR: local branch `codex/multitable-record-history-20260430`
+  - Merge commit: pending
+  - Development MD: `docs/development/multitable-record-history-development-20260430.md`
+  - Verification MD: `docs/development/multitable-record-history-verification-20260430.md`
+  - Verification summary: drawer adds lazy-loaded `Details` and `History` tabs.
+- [x] Add tests for single-field patch, multi-field patch, actor attribution, and permission denial.
+  - PR: local branch `codex/multitable-record-history-20260430`
+  - Merge commit: pending
+  - Development MD: `docs/development/multitable-record-history-development-20260430.md`
+  - Verification MD: `docs/development/multitable-record-history-verification-20260430.md`
+  - Verification summary: focused backend/frontend tests pass; DB route permission integration remains a documented follow-up.
+- [x] Document retention default: no cleanup in v1.
+  - PR: local branch `codex/multitable-record-history-20260430`
+  - Merge commit: pending
+  - Development MD: `docs/development/multitable-record-history-development-20260430.md`
+  - Verification MD: `docs/development/multitable-record-history-verification-20260430.md`
+  - Verification summary: retention default documented as indefinite/no cleanup in v1.
 
 Expected docs:
 
-- `docs/development/multitable-record-history-development-20260502.md`
-- `docs/development/multitable-record-history-verification-20260502.md`
+- `docs/development/multitable-record-history-development-20260430.md`
+- `docs/development/multitable-record-history-verification-20260430.md`
 
 ## Phase 6 - P1 Gap: Record Subscription Notifications
 

--- a/docs/development/multitable-record-history-development-20260430.md
+++ b/docs/development/multitable-record-history-development-20260430.md
@@ -1,0 +1,132 @@
+# Multitable Record History Development - 2026-04-30
+
+## Scope
+
+Phase 5 implements the first production record version history slice for multitable records.
+
+Included:
+
+- Persist record revisions in `meta_record_revisions`.
+- Record revisions from authoritative record writes:
+  - `RecordService.createRecord()`
+  - `RecordService.patchRecord()`
+  - `RecordService.deleteRecord()`
+  - `RecordWriteService.patchRecords()` for batch/Yjs writes.
+- Capture actor, source, version, changed field ids, patch, snapshot, and timestamp.
+- Expose `GET /api/multitable/sheets/:sheetId/records/:recordId/history`.
+- Add a History tab to the record drawer.
+- Update OpenAPI source and generated dist for the new history API.
+- Add focused backend and frontend coverage.
+
+Not included:
+
+- Diff UI or rollback UI.
+- Revision cleanup/retention jobs.
+- Deleted-record history browsing after the live record row is gone.
+- Public-form, automation, and plugin legacy direct-write paths. Those are documented follow-ups unless they are routed through `RecordService` or `RecordWriteService`.
+
+## Backend Design
+
+### Persistence
+
+Migration:
+
+- `packages/core-backend/src/db/migrations/zzzz20260430172000_create_meta_record_revisions.ts`
+
+Table:
+
+- `meta_record_revisions.id`: UUID primary key.
+- `sheet_id`, `record_id`: text identifiers, intentionally not cascading from `meta_records` so delete history can be retained.
+- `version`: server version after create/update, or the deleted version for delete.
+- `action`: `create`, `update`, or `delete`.
+- `source`: defaults to `rest`; Yjs bridge writes preserve `yjs-bridge`.
+- `actor_id`: nullable user/system actor.
+- `changed_field_ids`: changed field ids in write order.
+- `patch`: the submitted authoritative patch.
+- `snapshot`: post-write snapshot for create/update, pre-delete snapshot for delete.
+- `created_at`: server timestamp.
+
+Retention default: no cleanup in v1.
+
+### Write Path
+
+New service:
+
+- `packages/core-backend/src/multitable/record-history-service.ts`
+
+`recordRecordRevision()` inserts revision rows inside the same DB transaction as the record mutation. If revision persistence fails, the record mutation fails too. This is intentional because history is part of the authoritative write contract for this slice.
+
+`RecordWriteService.patchRecords()` uses `input.source ?? 'rest'`, so Yjs-originated writes keep their source attribution and REST writes remain the default.
+
+### Read API
+
+Route:
+
+- `GET /api/multitable/sheets/:sheetId/records/:recordId/history?limit=&offset=`
+
+Response shape:
+
+```json
+{
+  "ok": true,
+  "data": {
+    "items": [
+      {
+        "id": "...",
+        "sheetId": "...",
+        "recordId": "...",
+        "version": 2,
+        "action": "update",
+        "source": "rest",
+        "actorId": "user_1",
+        "changedFieldIds": ["fld_title"],
+        "patch": { "fld_title": "Updated" },
+        "snapshot": { "fld_title": "Updated" },
+        "createdAt": "2026-04-30T09:00:00.000Z"
+      }
+    ],
+    "limit": 50,
+    "offset": 0
+  }
+}
+```
+
+Permission model:
+
+- Requires authenticated user.
+- Requires sheet `canRead`.
+- Reuses existing record-permission scope checks when record-level assignments are present.
+- Returns an empty history list if the revision table is not migrated yet, matching the router's compatibility pattern for optional multitable tables.
+
+## Frontend Design
+
+Types:
+
+- `MetaRecordRevision`
+- `MetaRecordRevisionAction`
+
+Client:
+
+- `MultitableApiClient.listRecordHistory(sheetId, recordId, { limit, offset })`
+
+OpenAPI:
+
+- `MultitableRecordRevision` schema.
+- `GET /api/multitable/sheets/{sheetId}/records/{recordId}/history` path.
+- Generated `packages/openapi/dist/{combined.openapi.yml,openapi.json,openapi.yaml}` refreshed.
+
+Record drawer:
+
+- Adds `Details` and `History` tabs.
+- Defaults to `Details`.
+- Loads history lazily when the user opens `History`.
+- Guards stale async responses with a monotonic request id.
+- Shows loading, empty, error, and unavailable states.
+- Displays action, version, timestamp, actor, source, and changed field labels.
+
+## Follow-ups
+
+- Add integration route tests for the history endpoint with real permission fixtures.
+- Add history rows for public-form, automation, and plugin legacy direct writes, or route those writes through the shared services.
+- Add deleted-record history browsing in a future audit surface.
+- Add diff rendering and optional rollback after retention/product rules are settled.

--- a/docs/development/multitable-record-history-verification-20260430.md
+++ b/docs/development/multitable-record-history-verification-20260430.md
@@ -1,0 +1,86 @@
+# Multitable Record History Verification - 2026-04-30
+
+## Environment
+
+- Worktree: `/tmp/ms2-record-history-20260430`
+- Branch: `codex/multitable-record-history-20260430`
+- Base after rebase: `origin/main@212f9953b`
+- Dependency setup: `pnpm install --frozen-lockfile` in the temporary worktree, using the checked-in lockfile.
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/record-service.test.ts \
+  tests/unit/record-write-service.test.ts \
+  tests/integration/multitable-record-patch.api.test.ts \
+  --reporter=dot
+pnpm --filter @metasheet/web exec vitest run \
+  tests/multitable-record-drawer.spec.ts \
+  tests/multitable-client.spec.ts \
+  --reporter=dot
+pnpm exec tsx packages/openapi/tools/build.ts
+node --test scripts/ops/multitable-openapi-parity.test.mjs
+```
+
+## Results
+
+- `pnpm install --frozen-lockfile`: pass.
+- `pnpm --filter @metasheet/core-backend build`: pass.
+- `pnpm --filter @metasheet/web exec vue-tsc -b --noEmit`: pass.
+- Backend focused tests: 55/55 pass.
+- Frontend focused tests: 28/28 pass.
+- OpenAPI build: pass.
+- Multitable OpenAPI parity test: 1/1 pass.
+
+## CI Follow-up - 2026-05-05
+
+Initial PR CI failed `test (18.x)` / `test (20.x)` in `tests/integration/multitable-record-patch.api.test.ts`.
+
+Root cause:
+
+- The integration test's hand-written SQL stand-in still matched the old `SELECT id, version, created_by ... FOR UPDATE` shape.
+- The record history implementation correctly changed the locked row select to include `data` for revision snapshots.
+- The same fixture also lacked a handler for `INSERT INTO meta_record_revisions`.
+
+Fix:
+
+- Updated the integration fixture to return `data` from locked rows.
+- Added no-op `meta_record_revisions` insert handlers where the test exercises successful PATCH writes.
+
+Re-run result:
+
+- `pnpm --filter @metasheet/core-backend exec vitest run tests/integration/multitable-record-patch.api.test.ts --reporter=verbose`: 6/6 pass.
+- Full focused backend command listed above: 55/55 pass.
+
+Observed non-failing noise:
+
+- Backend tests print existing post-commit hook failure logs in tests that intentionally verify hook failures do not fail the write.
+- Frontend Vitest prints `WebSocket server error: Port is already in use`; the focused tests still pass.
+
+## Coverage
+
+Backend:
+
+- Create writes a `create` revision with actor, changed fields, patch, and snapshot.
+- Single-record patch writes an `update` revision after version increment.
+- Delete writes a `delete` revision with pre-delete snapshot.
+- Batch/Yjs shared patch path writes one revision per updated record.
+- Yjs-originated writes preserve `source = yjs-bridge`.
+- Existing version conflict and own-write denial tests still pass.
+
+Frontend:
+
+- API client encodes sheet/record ids, sends `limit`, unwraps response data, and drops malformed history items.
+- Record drawer renders `Details` and `History` tabs.
+- History tab lazy-loads revisions and displays action, version, actor, source, and field labels.
+- Drawer shows an unavailable state when no API client/sheet id is provided.
+
+## Known Limits
+
+- No cleanup job in v1. History retention is indefinite until a product retention rule exists.
+- The drawer only fetches history for live records.
+- Route integration tests with full DB permission fixtures remain a follow-up; focused unit/UI tests cover the new seams.

--- a/packages/core-backend/src/db/migrations/zzzz20260430172000_create_meta_record_revisions.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260430172000_create_meta_record_revisions.ts
@@ -1,0 +1,43 @@
+import { sql, type Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`CREATE EXTENSION IF NOT EXISTS pgcrypto`.execute(db)
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS meta_record_revisions (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      sheet_id text NOT NULL,
+      record_id text NOT NULL,
+      version integer NOT NULL,
+      action text NOT NULL CHECK (action IN ('create', 'update', 'delete')),
+      source text NOT NULL DEFAULT 'rest',
+      actor_id text,
+      changed_field_ids text[] NOT NULL DEFAULT ARRAY[]::text[],
+      patch jsonb NOT NULL DEFAULT '{}'::jsonb,
+      snapshot jsonb,
+      created_at timestamptz NOT NULL DEFAULT now()
+    )
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_meta_record_revisions_sheet_record_version
+    ON meta_record_revisions(sheet_id, record_id, version DESC)
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_meta_record_revisions_record_created_at
+    ON meta_record_revisions(record_id, created_at DESC)
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_meta_record_revisions_actor_created_at
+    ON meta_record_revisions(actor_id, created_at DESC)
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP INDEX IF EXISTS idx_meta_record_revisions_actor_created_at`.execute(db)
+  await sql`DROP INDEX IF EXISTS idx_meta_record_revisions_record_created_at`.execute(db)
+  await sql`DROP INDEX IF EXISTS idx_meta_record_revisions_sheet_record_version`.execute(db)
+  await sql`DROP TABLE IF EXISTS meta_record_revisions`.execute(db)
+}

--- a/packages/core-backend/src/multitable/record-history-service.ts
+++ b/packages/core-backend/src/multitable/record-history-service.ts
@@ -1,0 +1,128 @@
+import { randomUUID } from 'crypto'
+
+export type QueryFn = (
+  sql: string,
+  params?: unknown[],
+) => Promise<{ rows: unknown[]; rowCount?: number | null }>
+
+export type RecordRevisionAction = 'create' | 'update' | 'delete'
+
+export type RecordRevisionSource = 'rest' | 'yjs-bridge' | 'automation' | 'public-form' | 'plugin' | string
+
+export interface RecordRevisionInput {
+  sheetId: string
+  recordId: string
+  version: number
+  action: RecordRevisionAction
+  source?: RecordRevisionSource
+  actorId?: string | null
+  changedFieldIds?: string[]
+  patch?: Record<string, unknown>
+  snapshot?: Record<string, unknown> | null
+}
+
+export interface RecordRevisionEntry {
+  id: string
+  sheetId: string
+  recordId: string
+  version: number
+  action: RecordRevisionAction
+  source: string
+  actorId: string | null
+  changedFieldIds: string[]
+  patch: Record<string, unknown>
+  snapshot: Record<string, unknown> | null
+  createdAt: string
+}
+
+export async function recordRecordRevision(query: QueryFn, input: RecordRevisionInput): Promise<void> {
+  const changedFieldIds = Array.from(new Set((input.changedFieldIds ?? []).filter(Boolean)))
+  await query(
+    `INSERT INTO meta_record_revisions (
+       id,
+       sheet_id,
+       record_id,
+       version,
+       action,
+       source,
+       actor_id,
+       changed_field_ids,
+       patch,
+       snapshot
+     )
+     VALUES ($1::uuid, $2, $3, $4, $5, $6, $7, $8::text[], $9::jsonb, $10::jsonb)`,
+    [
+      randomUUID(),
+      input.sheetId,
+      input.recordId,
+      input.version,
+      input.action,
+      input.source ?? 'rest',
+      input.actorId ?? null,
+      changedFieldIds,
+      JSON.stringify(input.patch ?? {}),
+      input.snapshot === undefined ? null : JSON.stringify(input.snapshot),
+    ],
+  )
+}
+
+export async function listRecordRevisions(
+  query: QueryFn,
+  input: { sheetId: string; recordId: string; limit?: number; offset?: number },
+): Promise<RecordRevisionEntry[]> {
+  const limit = Math.min(Math.max(Number(input.limit ?? 50), 1), 100)
+  const offset = Math.max(Number(input.offset ?? 0), 0)
+  const result = await query(
+    `SELECT
+       id,
+       sheet_id,
+       record_id,
+       version,
+       action,
+       source,
+       actor_id,
+       changed_field_ids,
+       patch,
+       snapshot,
+       created_at
+     FROM meta_record_revisions
+     WHERE sheet_id = $1 AND record_id = $2
+     ORDER BY version DESC, created_at DESC
+     LIMIT $3 OFFSET $4`,
+    [input.sheetId, input.recordId, limit, offset],
+  )
+  return (result.rows as Array<Record<string, unknown>>).map(serializeRecordRevision)
+}
+
+function serializeRecordRevision(row: Record<string, unknown>): RecordRevisionEntry {
+  return {
+    id: String(row.id),
+    sheetId: String(row.sheet_id),
+    recordId: String(row.record_id),
+    version: Number(row.version ?? 0),
+    action: normalizeAction(row.action),
+    source: typeof row.source === 'string' ? row.source : 'rest',
+    actorId: typeof row.actor_id === 'string' ? row.actor_id : null,
+    changedFieldIds: Array.isArray(row.changed_field_ids) ? row.changed_field_ids.map(String) : [],
+    patch: normalizeJsonObject(row.patch),
+    snapshot: row.snapshot === null || row.snapshot === undefined ? null : normalizeJsonObject(row.snapshot),
+    createdAt: row.created_at instanceof Date ? row.created_at.toISOString() : String(row.created_at ?? ''),
+  }
+}
+
+function normalizeAction(value: unknown): RecordRevisionAction {
+  return value === 'create' || value === 'delete' ? value : 'update'
+}
+
+function normalizeJsonObject(value: unknown): Record<string, unknown> {
+  if (value && typeof value === 'object' && !Array.isArray(value)) return value as Record<string, unknown>
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value)
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) return parsed as Record<string, unknown>
+    } catch {
+      return {}
+    }
+  }
+  return {}
+}

--- a/packages/core-backend/src/multitable/record-service.ts
+++ b/packages/core-backend/src/multitable/record-service.ts
@@ -27,6 +27,7 @@ import {
 } from './post-commit-hooks'
 import { isFieldAlwaysReadOnly, isFieldPermissionHidden } from './permission-derivation'
 import { publishMultitableSheetRealtime } from './realtime-publish'
+import { recordRecordRevision } from './record-history-service'
 import { ensureRecordWriteAllowed, type AccessInfo, type SheetPermissionScope } from './sheet-capabilities'
 
 export type QueryFn = (
@@ -520,6 +521,19 @@ export class RecordService {
         }
       }
 
+      const version = Number((inserted.rows[0] as { version?: unknown } | undefined)?.version ?? 1)
+      await recordRecordRevision(query, {
+        sheetId,
+        recordId,
+        version,
+        action: 'create',
+        source: 'rest',
+        actorId,
+        changedFieldIds: Object.keys(patch),
+        patch,
+        snapshot: patch,
+      })
+
       return inserted
     })
 
@@ -579,7 +593,7 @@ export class RecordService {
 
     await this.pool.transaction(async ({ query }) => {
       const lockedRecordRes = await query(
-        'SELECT id, sheet_id, version FROM meta_records WHERE id = $1 FOR UPDATE',
+        'SELECT id, sheet_id, version, data FROM meta_records WHERE id = $1 FOR UPDATE',
         [recordId],
       )
       if (lockedRecordRes.rows.length === 0) {
@@ -591,6 +605,7 @@ export class RecordService {
       if (typeof expectedVersion === 'number' && expectedVersion !== serverVersion) {
         throw new VersionConflictError(recordId, serverVersion)
       }
+      const snapshot = normalizeJson(currentRow.data)
 
       try {
         await query(
@@ -600,6 +615,18 @@ export class RecordService {
       } catch (err) {
         if (!isUndefinedTableError(err, 'meta_links')) throw err
       }
+
+      await recordRecordRevision(query, {
+        sheetId,
+        recordId,
+        version: serverVersion,
+        action: 'delete',
+        source: 'rest',
+        actorId,
+        changedFieldIds: [],
+        patch: {},
+        snapshot,
+      })
 
       await query('DELETE FROM meta_records WHERE id = $1', [recordId])
     })
@@ -758,7 +785,7 @@ export class RecordService {
     let nextVersion = 1
     await this.pool.transaction(async ({ query }) => {
       const currentRes = await query(
-        'SELECT id, version, created_by FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE',
+        'SELECT id, version, data, created_by FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE',
         [recordId, sheetId],
       )
       if (currentRes.rows.length === 0) {
@@ -779,6 +806,7 @@ export class RecordService {
       if (typeof expectedVersion === 'number' && expectedVersion !== serverVersion) {
         throw new VersionConflictError(recordId, serverVersion)
       }
+      const previousData = normalizeJson(currentRow.data)
 
       if (Object.keys(patch).length > 0) {
         const updateRes = await query(
@@ -789,6 +817,17 @@ export class RecordService {
           [JSON.stringify(patch), recordId, sheetId, patchActorId],
         )
         nextVersion = Number((updateRes.rows[0] as { version?: unknown } | undefined)?.version ?? serverVersion)
+        await recordRecordRevision(query, {
+          sheetId,
+          recordId,
+          version: nextVersion,
+          action: 'update',
+          source: 'rest',
+          actorId: patchActorId,
+          changedFieldIds: Object.keys(patch),
+          patch,
+          snapshot: { ...previousData, ...patch },
+        })
       } else {
         nextVersion = serverVersion
       }

--- a/packages/core-backend/src/multitable/record-write-service.ts
+++ b/packages/core-backend/src/multitable/record-write-service.ts
@@ -23,6 +23,7 @@ import {
   type YjsInvalidator,
 } from './post-commit-hooks'
 import { BATCH1_FIELD_TYPES, coerceBatch1Value, normalizeMultiSelectValue, validateLongTextValue } from './field-codecs'
+import { recordRecordRevision } from './record-history-service'
 
 // ---------------------------------------------------------------------------
 // Shared types (mirrors the ones in univer-meta.ts to avoid coupling)
@@ -463,6 +464,7 @@ export class RecordWriteService {
       capabilities,
       sheetScope,
       access,
+      source,
     } = input
 
     const h = this.helpers
@@ -484,7 +486,7 @@ export class RecordWriteService {
         )[0]
 
         const recordRes = await query(
-          'SELECT id, version, created_by FROM meta_records WHERE sheet_id = $1 AND id = $2 FOR UPDATE',
+          'SELECT id, version, data, created_by FROM meta_records WHERE sheet_id = $1 AND id = $2 FOR UPDATE',
           [sheetId, recordId],
         )
         if ((recordRes.rows as any[]).length === 0) {
@@ -508,6 +510,7 @@ export class RecordWriteService {
         if (typeof expectedVersion === 'number' && expectedVersion !== serverVersion) {
           throw new VersionConflictError(recordId, serverVersion)
         }
+        const previousData = h.normalizeJson(recordRow?.data)
 
         const patch: Record<string, unknown> = {}
         const linkUpdates = new Map<string, { ids: string[]; cfg: LinkFieldConfig }>()
@@ -599,6 +602,18 @@ export class RecordWriteService {
         if ((updateRes.rows as any[]).length === 0) {
           throw new RecordNotFoundError(`Record not found: ${recordId}`)
         }
+        const nextVersion = Number((updateRes.rows[0] as any).version)
+        await recordRecordRevision(query, {
+          sheetId,
+          recordId,
+          version: nextVersion,
+          action: 'update',
+          source: source ?? 'rest',
+          actorId,
+          changedFieldIds: Object.keys(patch),
+          patch,
+          snapshot: { ...previousData, ...patch },
+        })
 
         // Sync link table
         if (linkUpdates.size > 0) {
@@ -654,7 +669,7 @@ export class RecordWriteService {
           }
         }
 
-        updated.push({ recordId, version: Number((updateRes.rows[0] as any).version) })
+        updated.push({ recordId, version: nextVersion })
       }
 
       return updated

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -133,6 +133,7 @@ import {
   createYjsInvalidationPostCommitHook,
   type YjsInvalidator,
 } from '../multitable/post-commit-hooks'
+import { listRecordRevisions } from '../multitable/record-history-service'
 import {
   CONDITIONAL_FORMATTING_RULE_LIMIT,
   sanitizeConditionalFormattingRules,
@@ -3621,6 +3622,61 @@ export function univerMetaRouter(): Router {
       if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
       console.error('[univer-meta] list record permissions failed:', err)
       return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to list record permissions' } })
+    }
+  })
+
+  router.get('/sheets/:sheetId/records/:recordId/history', async (req: Request, res: Response) => {
+    const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId.trim() : ''
+    const recordId = typeof req.params.recordId === 'string' ? req.params.recordId.trim() : ''
+    const limitParam = typeof req.query.limit === 'string' ? Number.parseInt(req.query.limit, 10) : 50
+    const offsetParam = typeof req.query.offset === 'string' ? Number.parseInt(req.query.offset, 10) : 0
+    const limit = Number.isFinite(limitParam) ? Math.min(Math.max(limitParam, 1), 100) : 50
+    const offset = Number.isFinite(offsetParam) ? Math.max(offsetParam, 0) : 0
+    if (!sheetId || !recordId) {
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId and recordId are required' } })
+    }
+
+    try {
+      const pool = poolManager.get()
+      const recordCheck = await pool.query(
+        'SELECT id, sheet_id FROM meta_records WHERE id = $1 AND sheet_id = $2',
+        [recordId, sheetId],
+      )
+      if (recordCheck.rows.length === 0) {
+        return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Record not found: ${recordId}` } })
+      }
+
+      const { access, capabilities } = await resolveSheetReadableCapabilities(req, pool.query.bind(pool), sheetId)
+      if (!access.userId) {
+        return res.status(401).json({ error: 'Authentication required' })
+      }
+      if (!capabilities.canRead) return sendForbidden(res)
+
+      if (!access.isAdminRole) {
+        const hasRecordPerms = await hasRecordPermissionAssignments(pool.query.bind(pool), sheetId)
+        if (hasRecordPerms) {
+          const recordScopeMap = await loadRecordPermissionScopeMap(
+            pool.query.bind(pool),
+            sheetId,
+            [recordId],
+            access.userId,
+          )
+          if (recordScopeMap.size > 0 && !deriveRecordPermissions(recordId, capabilities, recordScopeMap).canRead) {
+            return sendForbidden(res)
+          }
+        }
+      }
+
+      const items = await listRecordRevisions(pool.query.bind(pool), { sheetId, recordId, limit, offset })
+      return res.json({ ok: true, data: { items, limit, offset } })
+    } catch (err) {
+      if (isUndefinedTableError(err, 'meta_record_revisions')) {
+        return res.json({ ok: true, data: { items: [], limit, offset } })
+      }
+      const hint = getDbNotReadyMessage(err)
+      if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
+      console.error('[univer-meta] list record history failed:', err)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to list record history' } })
     }
   })
 

--- a/packages/core-backend/tests/integration/multitable-record-patch.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-record-patch.api.test.ts
@@ -106,10 +106,10 @@ describe('Multitable PATCH /records/:recordId (record-service extraction)', () =
         if (sql.includes('SELECT id, name, type, property, "order" FROM meta_fields WHERE sheet_id = $1')) {
           return { rows: [{ id: 'fld_title', name: 'Title', type: 'string', property: {}, order: 1 }] }
         }
-        if (sql.includes('SELECT id, version, created_by FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE')) {
+        if (sql.includes('SELECT id, version, data, created_by FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE')) {
           expect(params).toEqual(['rec_1', 'sheet_ops'])
           return {
-            rows: [{ id: 'rec_1', version: 7, created_by: 'user_patch_1' }],
+            rows: [{ id: 'rec_1', version: 7, data: { fld_title: 'Original title' }, created_by: 'user_patch_1' }],
           }
         }
         if (sql.includes('UPDATE meta_records') && sql.includes('RETURNING version')) {
@@ -120,6 +120,9 @@ describe('Multitable PATCH /records/:recordId (record-service extraction)', () =
             'user_patch_1',
           ])
           return { rows: [{ version: 8 }] }
+        }
+        if (sql.includes('INSERT INTO meta_record_revisions')) {
+          return { rows: [], rowCount: 1 }
         }
         if (
           sql.includes('FROM meta_records WHERE id = $1 AND sheet_id = $2') &&
@@ -259,8 +262,8 @@ describe('Multitable PATCH /records/:recordId (record-service extraction)', () =
         if (sql.includes('SELECT id, name, type, property, "order" FROM meta_fields WHERE sheet_id = $1')) {
           return { rows: [{ id: 'fld_title', name: 'Title', type: 'string', property: {}, order: 1 }] }
         }
-        if (sql.includes('SELECT id, version, created_by FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE')) {
-          return { rows: [{ id: 'rec_1', version: 11, created_by: 'user_patch_1' }] }
+        if (sql.includes('SELECT id, version, data, created_by FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE')) {
+          return { rows: [{ id: 'rec_1', version: 11, data: { fld_title: 'Current' }, created_by: 'user_patch_1' }] }
         }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
@@ -311,9 +314,9 @@ describe('Multitable PATCH /records/:recordId (record-service extraction)', () =
           expect(params).toEqual(['sheet_customer', ['rec_c2', 'rec_c3']])
           return { rows: [{ id: 'rec_c2' }, { id: 'rec_c3' }] }
         }
-        if (sql.includes('SELECT id, version, created_by FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE')) {
+        if (sql.includes('SELECT id, version, data, created_by FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE')) {
           return {
-            rows: [{ id: 'rec_1', version: 2, created_by: 'user_patch_1' }],
+            rows: [{ id: 'rec_1', version: 2, data: { fld_customer: ['rec_c1', 'rec_c2'] }, created_by: 'user_patch_1' }],
           }
         }
         if (sql.includes('UPDATE meta_records') && sql.includes('RETURNING version')) {
@@ -324,6 +327,9 @@ describe('Multitable PATCH /records/:recordId (record-service extraction)', () =
             'user_patch_1',
           ])
           return { rows: [{ version: 3 }] }
+        }
+        if (sql.includes('INSERT INTO meta_record_revisions')) {
+          return { rows: [], rowCount: 1 }
         }
         if (sql.includes('SELECT foreign_record_id FROM meta_links WHERE field_id = $1 AND record_id = $2')) {
           return { rows: [{ foreign_record_id: 'rec_c1' }, { foreign_record_id: 'rec_c2' }] }
@@ -414,17 +420,21 @@ describe('Multitable PATCH /records/:recordId (record-service extraction)', () =
         if (sql.includes('FROM multitable_attachments') && sql.includes('id = ANY')) {
           return { rows: [{ id: 'att_new_1', field_id: 'fld_files' }] }
         }
-        if (sql.includes('SELECT id, version, created_by FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE')) {
+        if (sql.includes('SELECT id, version, data, created_by FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE')) {
           return {
             rows: [{
               id: 'rec_1',
               version: 2,
+              data: { fld_files: ['att_old_1'] },
               created_by: 'user_patch_1',
             }],
           }
         }
         if (sql.includes('UPDATE meta_records') && sql.includes('RETURNING version')) {
           return { rows: [{ version: 3 }] }
+        }
+        if (sql.includes('INSERT INTO meta_record_revisions')) {
+          return { rows: [], rowCount: 1 }
         }
         if (
           sql.includes('FROM meta_records WHERE id = $1 AND sheet_id = $2') &&

--- a/packages/core-backend/tests/unit/record-service.test.ts
+++ b/packages/core-backend/tests/unit/record-service.test.ts
@@ -60,6 +60,9 @@ function createMockPool(
     if (sql.includes('INSERT INTO meta_records') && sql.includes('RETURNING version')) {
       return responses.INSERT_RECORD ?? { rows: [{ version: 1 }] }
     }
+    if (sql.includes('INSERT INTO meta_record_revisions')) {
+      return responses.INSERT_REVISION ?? { rows: [], rowCount: 1 }
+    }
     if (sql.includes('INSERT INTO meta_links')) {
       return responses.INSERT_LINK ?? { rows: [], rowCount: 1 }
     }
@@ -68,14 +71,14 @@ function createMockPool(
         rows: [{ id: 'rec_existing', sheet_id: 'sheet_ops', created_by: 'user_1' }],
       }
     }
-    if (sql.includes('SELECT id, sheet_id, version FROM meta_records WHERE id = $1 FOR UPDATE')) {
+    if (sql.includes('SELECT id, sheet_id, version, data FROM meta_records WHERE id = $1 FOR UPDATE')) {
       return responses.SELECT_DELETE_FOR_UPDATE ?? {
-        rows: [{ id: 'rec_existing', sheet_id: 'sheet_ops', version: 4 }],
+        rows: [{ id: 'rec_existing', sheet_id: 'sheet_ops', version: 4, data: { fld_title: 'Before' } }],
       }
     }
-    if (sql.includes('SELECT id, version, created_by FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE')) {
+    if (sql.includes('SELECT id, version, data, created_by FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE')) {
       return responses.SELECT_PATCH_FOR_UPDATE ?? {
-        rows: [{ id: 'rec_existing', version: 4, created_by: 'user_1' }],
+        rows: [{ id: 'rec_existing', version: 4, data: { fld_title: 'Before' }, created_by: 'user_1' }],
       }
     }
     if (sql.includes('UPDATE meta_records') && sql.includes('RETURNING version')) {
@@ -146,6 +149,21 @@ describe('RecordService', () => {
         recordIds: [result.recordId],
         fieldIds: ['fld_title'],
       }),
+    )
+    expect(pool.queryMock).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO meta_record_revisions'),
+      expect.arrayContaining([
+        expect.any(String),
+        'sheet_ops',
+        result.recordId,
+        1,
+        'create',
+        'rest',
+        'user_1',
+        ['fld_title'],
+        JSON.stringify({ fld_title: 'Alpha' }),
+        JSON.stringify({ fld_title: 'Alpha' }),
+      ]),
     )
   })
 
@@ -253,6 +271,21 @@ describe('RecordService', () => {
         recordIds: ['rec_existing'],
       }),
     )
+    expect(pool.queryMock).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO meta_record_revisions'),
+      expect.arrayContaining([
+        expect.any(String),
+        'sheet_ops',
+        'rec_existing',
+        4,
+        'delete',
+        'rest',
+        'user_1',
+        [],
+        JSON.stringify({}),
+        JSON.stringify({ fld_title: 'Before' }),
+      ]),
+    )
   })
 
   it('throws VersionConflictError when delete expectedVersion does not match', async () => {
@@ -353,6 +386,21 @@ describe('RecordService', () => {
     expect(pool.queryMock).toHaveBeenCalledWith(
       expect.stringContaining('UPDATE meta_records'),
       [JSON.stringify({ fld_title: 'Updated', fld_customer: ['rec_customer_2'] }), 'rec_existing', 'sheet_ops', 'user_1'],
+    )
+    expect(pool.queryMock).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO meta_record_revisions'),
+      expect.arrayContaining([
+        expect.any(String),
+        'sheet_ops',
+        'rec_existing',
+        5,
+        'update',
+        'rest',
+        'user_1',
+        ['fld_title', 'fld_customer'],
+        JSON.stringify({ fld_title: 'Updated', fld_customer: ['rec_customer_2'] }),
+        JSON.stringify({ fld_title: 'Updated', fld_customer: ['rec_customer_2'] }),
+      ]),
     )
     expect(pool.queryMock).toHaveBeenCalledWith(
       expect.stringContaining('DELETE FROM meta_links WHERE field_id = $1 AND record_id = $2 AND foreign_record_id = ANY'),

--- a/packages/core-backend/tests/unit/record-write-service.test.ts
+++ b/packages/core-backend/tests/unit/record-write-service.test.ts
@@ -66,11 +66,14 @@ function createMockPool(queryResponses: Record<string, { rows: unknown[] }> = {}
 
   const queryFn = vi.fn(async (sql: string, _params?: unknown[]) => {
     // Match SQL patterns to return the correct responses
-    if (sql.includes('SELECT id, version, created_by FROM meta_records') && sql.includes('FOR UPDATE')) {
-      return queryResponses['SELECT_FOR_UPDATE'] ?? { rows: [{ id: 'rec1', version: 1, created_by: 'user1' }] }
+    if (sql.includes('SELECT id, version, data, created_by FROM meta_records') && sql.includes('FOR UPDATE')) {
+      return queryResponses['SELECT_FOR_UPDATE'] ?? { rows: [{ id: 'rec1', version: 1, data: { fld_name: 'Before' }, created_by: 'user1' }] }
     }
     if (sql.includes('UPDATE meta_records')) {
       return queryResponses['UPDATE'] ?? { rows: [{ version: 2 }] }
+    }
+    if (sql.includes('INSERT INTO meta_record_revisions')) {
+      return queryResponses['INSERT_REVISION'] ?? { rows: [], rowCount: 1 }
     }
     if (sql.includes('SELECT id, version, data FROM meta_records')) {
       return queryResponses['SELECT_UPDATED'] ?? defaultQueryResponse
@@ -222,6 +225,39 @@ describe('RecordWriteService', () => {
       'rec1',
       'user_editor',
     ])
+  })
+
+  it('writes one record revision for each authoritative patch', async () => {
+    const service = new RecordWriteService(pool, eventBus as any, helpers)
+
+    await service.patchRecords(buildTestInput({ actorId: 'user_editor' }))
+
+    expect(pool.query).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO meta_record_revisions'),
+      expect.arrayContaining([
+        expect.any(String),
+        'sheet1',
+        'rec1',
+        2,
+        'update',
+        'rest',
+        'user_editor',
+        ['fld_name'],
+        JSON.stringify({ fld_name: 'Alice' }),
+        JSON.stringify({ fld_name: 'Alice' }),
+      ]),
+    )
+  })
+
+  it('preserves yjs-bridge as the record revision source', async () => {
+    const service = new RecordWriteService(pool, eventBus as any, helpers)
+
+    await service.patchRecords(buildTestInput({ source: 'yjs-bridge' }))
+
+    expect(pool.query).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO meta_record_revisions'),
+      expect.arrayContaining(['yjs-bridge']),
+    )
   })
 
   it('preserves longText multiline values in the shared write path', async () => {

--- a/packages/openapi/dist/combined.openapi.yml
+++ b/packages/openapi/dist/combined.openapi.yml
@@ -1782,6 +1782,54 @@ components:
       required:
         - recordId
         - version
+    MultitableRecordRevision:
+      type: object
+      properties:
+        id:
+          type: string
+        sheetId:
+          type: string
+        recordId:
+          type: string
+        version:
+          type: integer
+        action:
+          type: string
+          enum:
+            - create
+            - update
+            - delete
+        source:
+          type: string
+        actorId:
+          type: string
+          nullable: true
+        changedFieldIds:
+          type: array
+          items:
+            type: string
+        patch:
+          type: object
+          additionalProperties: true
+        snapshot:
+          type: object
+          nullable: true
+          additionalProperties: true
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - sheetId
+        - recordId
+        - version
+        - action
+        - source
+        - actorId
+        - changedFieldIds
+        - patch
+        - snapshot
+        - createdAt
     MultitableComputedRecord:
       type: object
       properties:
@@ -11340,6 +11388,68 @@ paths:
                       - total
                       - limit
                       - query
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /api/multitable/sheets/{sheetId}/records/{recordId}/history:
+    get:
+      summary: List multitable record revision history
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: sheetId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: recordId
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 50
+        - in: query
+          name: offset
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/MultitableRecordRevision'
+                      limit:
+                        type: integer
+                      offset:
+                        type: integer
+                    required:
+                      - items
+                      - limit
+                      - offset
         '400':
           $ref: '#/components/responses/ValidationError'
         '401':

--- a/packages/openapi/dist/openapi.json
+++ b/packages/openapi/dist/openapi.json
@@ -2565,6 +2565,70 @@
           "version"
         ]
       },
+      "MultitableRecordRevision": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "sheetId": {
+            "type": "string"
+          },
+          "recordId": {
+            "type": "string"
+          },
+          "version": {
+            "type": "integer"
+          },
+          "action": {
+            "type": "string",
+            "enum": [
+              "create",
+              "update",
+              "delete"
+            ]
+          },
+          "source": {
+            "type": "string"
+          },
+          "actorId": {
+            "type": "string",
+            "nullable": true
+          },
+          "changedFieldIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "patch": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "snapshot": {
+            "type": "object",
+            "nullable": true,
+            "additionalProperties": true
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "sheetId",
+          "recordId",
+          "version",
+          "action",
+          "source",
+          "actorId",
+          "changedFieldIds",
+          "patch",
+          "snapshot",
+          "createdAt"
+        ]
+      },
       "MultitableComputedRecord": {
         "type": "object",
         "properties": {
@@ -17470,6 +17534,104 @@
                         "total",
                         "limit",
                         "query"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/api/multitable/sheets/{sheetId}/records/{recordId}/history": {
+      "get": {
+        "summary": "List multitable record revision history",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "sheetId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "recordId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 50
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/MultitableRecordRevision"
+                          }
+                        },
+                        "limit": {
+                          "type": "integer"
+                        },
+                        "offset": {
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "items",
+                        "limit",
+                        "offset"
                       ]
                     }
                   }

--- a/packages/openapi/dist/openapi.yaml
+++ b/packages/openapi/dist/openapi.yaml
@@ -1782,6 +1782,54 @@ components:
       required:
         - recordId
         - version
+    MultitableRecordRevision:
+      type: object
+      properties:
+        id:
+          type: string
+        sheetId:
+          type: string
+        recordId:
+          type: string
+        version:
+          type: integer
+        action:
+          type: string
+          enum:
+            - create
+            - update
+            - delete
+        source:
+          type: string
+        actorId:
+          type: string
+          nullable: true
+        changedFieldIds:
+          type: array
+          items:
+            type: string
+        patch:
+          type: object
+          additionalProperties: true
+        snapshot:
+          type: object
+          nullable: true
+          additionalProperties: true
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - sheetId
+        - recordId
+        - version
+        - action
+        - source
+        - actorId
+        - changedFieldIds
+        - patch
+        - snapshot
+        - createdAt
     MultitableComputedRecord:
       type: object
       properties:
@@ -11340,6 +11388,68 @@ paths:
                       - total
                       - limit
                       - query
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /api/multitable/sheets/{sheetId}/records/{recordId}/history:
+    get:
+      summary: List multitable record revision history
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: sheetId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: recordId
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 50
+        - in: query
+          name: offset
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/MultitableRecordRevision'
+                      limit:
+                        type: integer
+                      offset:
+                        type: integer
+                    required:
+                      - items
+                      - limit
+                      - offset
         '400':
           $ref: '#/components/responses/ValidationError'
         '401':

--- a/packages/openapi/src/base.yml
+++ b/packages/openapi/src/base.yml
@@ -1721,6 +1721,51 @@ components:
       required:
         - recordId
         - version
+    MultitableRecordRevision:
+      type: object
+      properties:
+        id:
+          type: string
+        sheetId:
+          type: string
+        recordId:
+          type: string
+        version:
+          type: integer
+        action:
+          type: string
+          enum: [create, update, delete]
+        source:
+          type: string
+        actorId:
+          type: string
+          nullable: true
+        changedFieldIds:
+          type: array
+          items:
+            type: string
+        patch:
+          type: object
+          additionalProperties: true
+        snapshot:
+          type: object
+          nullable: true
+          additionalProperties: true
+        createdAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - sheetId
+        - recordId
+        - version
+        - action
+        - source
+        - actorId
+        - changedFieldIds
+        - patch
+        - snapshot
+        - createdAt
     MultitableComputedRecord:
       type: object
       properties:

--- a/packages/openapi/src/paths/multitable.yml
+++ b/packages/openapi/src/paths/multitable.yml
@@ -323,6 +323,51 @@ paths:
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
         '404': { $ref: '#/components/responses/NotFound' }
+  /api/multitable/sheets/{sheetId}/records/{recordId}/history:
+    get:
+      summary: List multitable record revision history
+      security: [ { bearerAuth: [] } ]
+      parameters:
+        - in: path
+          name: sheetId
+          required: true
+          schema: { type: string }
+        - in: path
+          name: recordId
+          required: true
+          schema: { type: string }
+        - in: query
+          name: limit
+          schema: { type: integer, minimum: 1, maximum: 100, default: 50 }
+        - in: query
+          name: offset
+          schema: { type: integer, minimum: 0, default: 0 }
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/MultitableRecordRevision'
+                      limit:
+                        type: integer
+                      offset:
+                        type: integer
+                    required: [items, limit, offset]
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
   /api/multitable/sheets/{sheetId}/permissions/{subjectType}/{subjectId}:
     put:
       summary: Set a sheet access level for a person or role


### PR DESCRIPTION
## Summary
- add meta_record_revisions migration and record-history service
- persist revisions from RecordService create/patch/delete and RecordWriteService batch/Yjs patch
- expose record history API, OpenAPI schema/path, and drawer History tab
- update RC TODO plus development/verification MDs

## Verification
- pnpm install --frozen-lockfile
- pnpm --filter @metasheet/core-backend build
- pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/record-service.test.ts tests/unit/record-write-service.test.ts --reporter=dot
- pnpm --filter @metasheet/web exec vitest run tests/multitable-record-drawer.spec.ts tests/multitable-client.spec.ts --reporter=dot
- pnpm exec tsx packages/openapi/tools/build.ts
- node --test scripts/ops/multitable-openapi-parity.test.mjs

## Notes
- retention default is no cleanup in v1
- route integration tests with full DB permission fixtures are documented follow-up
