### PR TITLE
chore(ops): add GitHub actions runtime readiness check

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -39,6 +39,7 @@ This folder contains GitHub Actions that validate Phase 5 SLOs against a Prometh
   - Triggers every 2 hours (`15 */2 * * *`) and via manual dispatch.
   - Restores the deploy SSH key, reapplies the on-prem Alertmanager webhook config from `ALERTMANAGER_WEBHOOK_URL`, `ALERT_WEBHOOK_URL`, `SLACK_WEBHOOK_URL`, or `ATTENDANCE_ALERT_SLACK_WEBHOOK_URL` when available, runs `scripts/ops/dingtalk-oauth-stability-check.sh` against `142.171.239.56`, and uploads JSON/log/summary artifacts.
   - Does not run the Slack drill; it is recording-only and fails the workflow when `healthy != true`.
+  - Preflight GitHub configuration with `node scripts/ops/github-actions-runtime-readiness.mjs --repo zensgit/metasheet2 --strict`.
   - Like other scheduled/manual workflows, it only becomes live after the workflow file exists on the default branch.
 
 ## Required Secrets
@@ -50,6 +51,16 @@ This folder contains GitHub Actions that validate Phase 5 SLOs against a Prometh
  - `GRAFANA_API_TOKEN` (ops deploy only, for dashboard upload).
  - `REDIS_URL` (optional: enables Redis-backed cache validation).
  - `DEPLOY_HOST`, `DEPLOY_USER`, `DEPLOY_SSH_KEY_B64` (required for `dingtalk-oauth-stability-recording-lite.yml`).
+
+## Runtime Readiness
+```bash
+node scripts/ops/github-actions-runtime-readiness.mjs --repo zensgit/metasheet2
+```
+
+This check is redaction-safe: it reads secret names and repository variable
+metadata only. It verifies that DingTalk stability has deploy SSH inputs plus
+one supported Alertmanager webhook secret, and that K3 automatic deploy smoke is
+using `METASHEET_TENANT_ID` with `K3_WISE_DEPLOY_SMOKE_REQUIRE_AUTH=true`.
 
 ## Manual Dispatch (Nightly)
 

--- a/docs/development/github-actions-runtime-readiness-design-20260505.md
+++ b/docs/development/github-actions-runtime-readiness-design-20260505.md
@@ -1,0 +1,79 @@
+# GitHub Actions Runtime Readiness Design
+
+Date: 2026-05-05
+Branch: `codex/dingtalk-alertmanager-readiness-20260505`
+
+## Problem
+
+Two runtime gates now matter for the current internal-trial path:
+
+1. K3 WISE deploy smoke must be able to run authenticated checks automatically.
+2. DingTalk OAuth Stability Recording must be able to self-heal the on-prem
+   Alertmanager webhook before it runs the remote health check.
+
+The implementation already supports both gates, but a missing GitHub
+configuration value makes failures look like workflow or app regressions. The
+latest DingTalk scheduled run showed that shape exactly:
+
+- backend health: ok
+- Alertmanager notify errors: 0
+- root filesystem usage: below gate
+- Alertmanager webhook: not configured
+- GitHub webhook secret available to self-heal: false
+
+## Change
+
+Add `scripts/ops/github-actions-runtime-readiness.mjs`.
+
+The script reads GitHub Actions configuration metadata and emits a redacted
+readiness report. It never reads or prints secret values; it only consumes the
+secret names returned by `gh secret list`.
+
+It checks:
+
+- DingTalk stability deploy secrets:
+  - `DEPLOY_HOST`
+  - `DEPLOY_USER`
+  - `DEPLOY_SSH_KEY_B64`
+- DingTalk Alertmanager webhook self-heal secret, accepting one of:
+  - `ALERTMANAGER_WEBHOOK_URL`
+  - `ALERT_WEBHOOK_URL`
+  - `SLACK_WEBHOOK_URL`
+  - `ATTENDANCE_ALERT_SLACK_WEBHOOK_URL`
+- K3 WISE deploy auth gate variables:
+  - `METASHEET_TENANT_ID`
+  - `K3_WISE_DEPLOY_SMOKE_REQUIRE_AUTH=true`
+
+## CLI
+
+```bash
+node scripts/ops/github-actions-runtime-readiness.mjs --repo zensgit/metasheet2
+node scripts/ops/github-actions-runtime-readiness.mjs --repo zensgit/metasheet2 --format markdown
+node scripts/ops/github-actions-runtime-readiness.mjs --repo zensgit/metasheet2 --format json --strict
+```
+
+Fixture mode keeps the logic testable without calling GitHub:
+
+```bash
+node scripts/ops/github-actions-runtime-readiness.mjs \
+  --secrets-json /path/to/secrets.json \
+  --variables-json /path/to/variables.json \
+  --format json \
+  --strict
+```
+
+## Operational Decision
+
+K3 WISE did not need another code change. The deploy workflow already supports
+an authenticated hard gate. This round set the repository variable:
+
+```text
+K3_WISE_DEPLOY_SMOKE_REQUIRE_AUTH=true
+```
+
+That means future automatic deploys will require K3 authenticated smoke evidence
+instead of silently accepting public-only evidence.
+
+DingTalk still needs one supported webhook secret configured in GitHub Actions.
+Until then the scheduled workflow should remain red because the on-prem
+Alertmanager webhook cannot be self-healed from GitHub.

--- a/docs/development/github-actions-runtime-readiness-verification-20260505.md
+++ b/docs/development/github-actions-runtime-readiness-verification-20260505.md
@@ -1,0 +1,120 @@
+# GitHub Actions Runtime Readiness Verification
+
+Date: 2026-05-05
+Branch: `codex/dingtalk-alertmanager-readiness-20260505`
+
+## Static and Unit Verification
+
+```bash
+node --test scripts/ops/github-actions-runtime-readiness.test.mjs
+```
+
+Result:
+
+```text
+pass 4
+fail 0
+```
+
+Coverage:
+
+- readiness passes when deploy secrets, a supported webhook secret, and K3
+  variables are configured.
+- readiness fails with a direct next action when no webhook self-heal secret is
+  configured.
+- readiness fails when `K3_WISE_DEPLOY_SMOKE_REQUIRE_AUTH` is missing or false.
+- fixture mode does not leak accidental secret values into JSON output.
+
+## Live GitHub Configuration Readiness
+
+Command:
+
+```bash
+node scripts/ops/github-actions-runtime-readiness.mjs \
+  --repo zensgit/metasheet2 \
+  --format markdown \
+  --output /private/tmp/ms2-github-actions-runtime-readiness-20260505.md
+```
+
+Observed summary:
+
+```text
+Overall: FAIL
+dingtalkDeploySecrets: PASS
+dingtalkWebhookSelfHeal: FAIL
+k3DeployAuthGate: PASS
+```
+
+Meaning:
+
+- `DEPLOY_HOST`, `DEPLOY_USER`, and `DEPLOY_SSH_KEY_B64` are present.
+- `METASHEET_TENANT_ID` is present.
+- `K3_WISE_DEPLOY_SMOKE_REQUIRE_AUTH=true` is present.
+- None of the supported Alertmanager webhook secrets are present:
+  `ALERTMANAGER_WEBHOOK_URL`, `ALERT_WEBHOOK_URL`, `SLACK_WEBHOOK_URL`, or
+  `ATTENDANCE_ALERT_SLACK_WEBHOOK_URL`.
+
+## Latest Failing DingTalk Artifact
+
+Downloaded artifact:
+
+```text
+run: 25347288854
+workflow: DingTalk OAuth Stability Recording (Lite)
+summary: /private/tmp/ms2-dingtalk-stability-25347288854/dingtalk-oauth-stability-recording-lite-25347288854-1/summary.md
+```
+
+Relevant artifact facts:
+
+```text
+Overall: FAIL
+Stability rc: 0
+Healthy: false
+Webhook self-heal secret available: false
+Health: status=ok plugins=13 ok=True
+Webhook: configured=False host=
+Alertmanager: activeAlerts=0 notifyErrors=0
+Storage: rootUse=50% maxUse=95%
+```
+
+Failure reasons:
+
+```text
+Alertmanager webhook is not configured
+No supported GitHub webhook secret was available for Alertmanager self-heal
+```
+
+## K3 Deploy Gate Configuration
+
+Command:
+
+```bash
+gh variable set K3_WISE_DEPLOY_SMOKE_REQUIRE_AUTH \
+  --repo zensgit/metasheet2 \
+  --body true
+```
+
+Verification:
+
+```text
+K3_WISE_DEPLOY_SMOKE_REQUIRE_AUTH true 2026-05-05T00:16:44Z
+METASHEET_TENANT_ID default 2026-04-30T09:11:56Z
+```
+
+## Remaining Live Action
+
+Configure one GitHub Actions secret for DingTalk Alertmanager self-heal:
+
+```text
+ALERTMANAGER_WEBHOOK_URL
+```
+
+The compatible fallback names are:
+
+```text
+ALERT_WEBHOOK_URL
+SLACK_WEBHOOK_URL
+ATTENDANCE_ALERT_SLACK_WEBHOOK_URL
+```
+
+Do not put the webhook URL into tracked docs or chat output.

--- a/docs/verification-index.md
+++ b/docs/verification-index.md
@@ -23,6 +23,15 @@ Entry points:
   - Verification: `docs/development/github-stability-summary-polish-verification-20260406.md`
   - Notes: adds machine-readable `summary.json`, failure reasons, and next actions while keeping GitHub in passive recording mode.
 
+## 2026-05-05 GitHub Actions Runtime Readiness
+
+- Runtime readiness for K3 deploy auth and DingTalk Alertmanager self-heal:
+  - Script: `scripts/ops/github-actions-runtime-readiness.mjs`
+  - Tests: `scripts/ops/github-actions-runtime-readiness.test.mjs`
+  - Design: `docs/development/github-actions-runtime-readiness-design-20260505.md`
+  - Verification: `docs/development/github-actions-runtime-readiness-verification-20260505.md`
+  - Notes: checks required GitHub secret names and repo variables without reading or printing secret values.
+
 ## 2026-04-07 Multitable Staging Profile Baseline
 
 - Multitable staging profile threshold follow-up:

--- a/scripts/ops/github-actions-runtime-readiness.mjs
+++ b/scripts/ops/github-actions-runtime-readiness.mjs
@@ -1,0 +1,272 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process'
+import { readFileSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+export const REQUIRED_DINGTALK_DEPLOY_SECRETS = [
+  'DEPLOY_HOST',
+  'DEPLOY_USER',
+  'DEPLOY_SSH_KEY_B64',
+]
+
+export const SUPPORTED_DINGTALK_WEBHOOK_SECRETS = [
+  'ALERTMANAGER_WEBHOOK_URL',
+  'ALERT_WEBHOOK_URL',
+  'SLACK_WEBHOOK_URL',
+  'ATTENDANCE_ALERT_SLACK_WEBHOOK_URL',
+]
+
+export const REQUIRED_K3_VARIABLES = [
+  'METASHEET_TENANT_ID',
+  'K3_WISE_DEPLOY_SMOKE_REQUIRE_AUTH',
+]
+
+export function parseArgs(argv) {
+  const config = {
+    repo: process.env.GITHUB_REPOSITORY || 'zensgit/metasheet2',
+    format: 'text',
+    output: null,
+    secretsJson: null,
+    variablesJson: null,
+    strict: false,
+    help: false,
+  }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === '--repo') {
+      config.repo = requireValue(argv, index, arg)
+      index += 1
+    } else if (arg === '--format') {
+      config.format = requireValue(argv, index, arg)
+      index += 1
+    } else if (arg === '--output') {
+      config.output = requireValue(argv, index, arg)
+      index += 1
+    } else if (arg === '--secrets-json') {
+      config.secretsJson = requireValue(argv, index, arg)
+      index += 1
+    } else if (arg === '--variables-json') {
+      config.variablesJson = requireValue(argv, index, arg)
+      index += 1
+    } else if (arg === '--strict') {
+      config.strict = true
+    } else if (arg === '--help' || arg === '-h') {
+      config.help = true
+    } else {
+      throw new Error(`Unknown argument: ${arg}`)
+    }
+  }
+
+  if (!['json', 'markdown', 'text'].includes(config.format)) {
+    throw new Error('--format must be one of: text, markdown, json')
+  }
+
+  return config
+}
+
+function requireValue(argv, index, arg) {
+  const value = argv[index + 1]
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${arg} requires a value`)
+  }
+  return value
+}
+
+function readJsonFile(filePath) {
+  return JSON.parse(readFileSync(filePath, 'utf8'))
+}
+
+function runGhJson(args) {
+  const result = spawnSync('gh', args, { encoding: 'utf8' })
+  if (result.status !== 0) {
+    throw new Error(`gh ${args.join(' ')} failed: ${result.stderr || result.stdout}`)
+  }
+  return JSON.parse(result.stdout || '[]')
+}
+
+function normalizeNamedRows(rows) {
+  if (!Array.isArray(rows)) return []
+  return rows
+    .map((row) => ({
+      name: String(row?.name || ''),
+      updatedAt: row?.updatedAt || '',
+      value: row?.value,
+    }))
+    .filter((row) => row.name)
+}
+
+export function evaluateReadiness({ secrets, variables, repo, checkedAt = new Date().toISOString() }) {
+  const secretRows = normalizeNamedRows(secrets)
+  const variableRows = normalizeNamedRows(variables)
+  const secretNames = new Set(secretRows.map((secret) => secret.name))
+  const variableByName = new Map(variableRows.map((variable) => [variable.name, variable]))
+
+  const missingDeploySecrets = REQUIRED_DINGTALK_DEPLOY_SECRETS.filter((name) => !secretNames.has(name))
+  const presentWebhookSecrets = SUPPORTED_DINGTALK_WEBHOOK_SECRETS.filter((name) => secretNames.has(name))
+  const missingK3Variables = REQUIRED_K3_VARIABLES.filter((name) => !variableByName.has(name))
+  const k3HardGateValue = String(variableByName.get('K3_WISE_DEPLOY_SMOKE_REQUIRE_AUTH')?.value || '').toLowerCase()
+  const k3HardGateEnabled = ['1', 'true', 'yes', 'on'].includes(k3HardGateValue)
+
+  const checks = {
+    dingtalkDeploySecrets: {
+      ok: missingDeploySecrets.length === 0,
+      required: REQUIRED_DINGTALK_DEPLOY_SECRETS,
+      present: REQUIRED_DINGTALK_DEPLOY_SECRETS.filter((name) => secretNames.has(name)),
+      missing: missingDeploySecrets,
+    },
+    dingtalkWebhookSelfHeal: {
+      ok: presentWebhookSecrets.length > 0,
+      supported: SUPPORTED_DINGTALK_WEBHOOK_SECRETS,
+      present: presentWebhookSecrets,
+      missing: SUPPORTED_DINGTALK_WEBHOOK_SECRETS.filter((name) => !secretNames.has(name)),
+    },
+    k3DeployAuthGate: {
+      ok: missingK3Variables.length === 0 && k3HardGateEnabled,
+      requiredVariables: REQUIRED_K3_VARIABLES,
+      presentVariables: REQUIRED_K3_VARIABLES.filter((name) => variableByName.has(name)),
+      missingVariables: missingK3Variables,
+      requireAuthEnabled: k3HardGateEnabled,
+      tenantConfigured: variableByName.has('METASHEET_TENANT_ID'),
+    },
+  }
+
+  const nextActions = []
+  if (!checks.dingtalkDeploySecrets.ok) {
+    nextActions.push(`Configure missing DingTalk stability deploy secrets: ${missingDeploySecrets.join(', ')}.`)
+  }
+  if (!checks.dingtalkWebhookSelfHeal.ok) {
+    nextActions.push(
+      `Configure one supported webhook secret for DingTalk Alertmanager self-heal: ${SUPPORTED_DINGTALK_WEBHOOK_SECRETS.join(', ')}.`,
+    )
+  }
+  if (missingK3Variables.includes('METASHEET_TENANT_ID')) {
+    nextActions.push('Set repository variable METASHEET_TENANT_ID for K3 authenticated smoke tenant scope.')
+  }
+  if (missingK3Variables.includes('K3_WISE_DEPLOY_SMOKE_REQUIRE_AUTH') || !k3HardGateEnabled) {
+    nextActions.push('Set repository variable K3_WISE_DEPLOY_SMOKE_REQUIRE_AUTH=true for automatic deploy authenticated smoke gating.')
+  }
+  if (nextActions.length === 0) {
+    nextActions.push('GitHub Actions runtime configuration is ready for K3 deploy auth gating and DingTalk stability self-heal.')
+  }
+
+  const ok = Object.values(checks).every((check) => check.ok)
+  return {
+    status: ok ? 'PASS' : 'FAIL',
+    ok,
+    repo,
+    checkedAt,
+    checks,
+    nextActions,
+  }
+}
+
+function loadInputs(config) {
+  const secrets = config.secretsJson
+    ? readJsonFile(config.secretsJson)
+    : runGhJson(['secret', 'list', '--repo', config.repo, '--json', 'name,updatedAt'])
+  const variables = config.variablesJson
+    ? readJsonFile(config.variablesJson)
+    : runGhJson(['variable', 'list', '--repo', config.repo, '--json', 'name,value,updatedAt'])
+  return { secrets, variables }
+}
+
+export function renderText(summary) {
+  const lines = [
+    `GitHub Actions runtime readiness: ${summary.status}`,
+    `Repo: ${summary.repo}`,
+    `Checked at: ${summary.checkedAt}`,
+    '',
+  ]
+
+  for (const [name, check] of Object.entries(summary.checks)) {
+    lines.push(`- ${name}: ${check.ok ? 'PASS' : 'FAIL'}`)
+    if (check.missing?.length) lines.push(`  missing: ${check.missing.join(', ')}`)
+    if (check.missingVariables?.length) lines.push(`  missing variables: ${check.missingVariables.join(', ')}`)
+    if (name === 'dingtalkWebhookSelfHeal') {
+      lines.push(`  present supported webhook secrets: ${check.present.length ? check.present.join(', ') : 'none'}`)
+    }
+    if (name === 'k3DeployAuthGate') {
+      lines.push(`  require auth enabled: ${check.requireAuthEnabled}`)
+      lines.push(`  tenant configured: ${check.tenantConfigured}`)
+    }
+  }
+
+  lines.push('', 'Next actions:')
+  for (const action of summary.nextActions) lines.push(`- ${action}`)
+  return `${lines.join('\n')}\n`
+}
+
+export function renderMarkdown(summary) {
+  const lines = [
+    '# GitHub Actions Runtime Readiness',
+    '',
+    `- Overall: **${summary.status}**`,
+    `- Repo: \`${summary.repo}\``,
+    `- Checked at: \`${summary.checkedAt}\``,
+    '',
+    '## Checks',
+    '',
+  ]
+  for (const [name, check] of Object.entries(summary.checks)) {
+    lines.push(`- \`${name}\`: **${check.ok ? 'PASS' : 'FAIL'}**`)
+    if (check.missing?.length) lines.push(`  - Missing: \`${check.missing.join('`, `')}\``)
+    if (check.missingVariables?.length) lines.push(`  - Missing variables: \`${check.missingVariables.join('`, `')}\``)
+    if (name === 'dingtalkWebhookSelfHeal') {
+      lines.push(`  - Present supported webhook secrets: \`${check.present.length ? check.present.join('`, `') : 'none'}\``)
+    }
+    if (name === 'k3DeployAuthGate') {
+      lines.push(`  - Require auth enabled: \`${check.requireAuthEnabled}\``)
+      lines.push(`  - Tenant configured: \`${check.tenantConfigured}\``)
+    }
+  }
+  lines.push('', '## Next Actions', '')
+  for (const action of summary.nextActions) lines.push(`- ${action}`)
+  return `${lines.join('\n')}\n`
+}
+
+function render(summary, format) {
+  if (format === 'json') return `${JSON.stringify(summary, null, 2)}\n`
+  if (format === 'markdown') return renderMarkdown(summary)
+  return renderText(summary)
+}
+
+function printHelp() {
+  console.log(`usage: github-actions-runtime-readiness.mjs [options]
+
+Options:
+  --repo <owner/name>          GitHub repository (default: GITHUB_REPOSITORY or zensgit/metasheet2)
+  --format <text|markdown|json>
+  --output <path>             Write rendered readiness output to a file
+  --secrets-json <path>       Use fixture JSON instead of gh secret list
+  --variables-json <path>     Use fixture JSON instead of gh variable list
+  --strict                    Exit non-zero when readiness is FAIL
+`)
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const config = parseArgs(argv)
+  if (config.help) {
+    printHelp()
+    return 0
+  }
+  const { secrets, variables } = loadInputs(config)
+  const summary = evaluateReadiness({ secrets, variables, repo: config.repo })
+  const rendered = render(summary, config.format)
+  if (config.output) {
+    writeFileSync(config.output, rendered)
+  } else {
+    process.stdout.write(rendered)
+  }
+  return config.strict && !summary.ok ? 1 : 0
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    process.exitCode = main()
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exitCode = 1
+  }
+}

--- a/scripts/ops/github-actions-runtime-readiness.test.mjs
+++ b/scripts/ops/github-actions-runtime-readiness.test.mjs
@@ -1,0 +1,123 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+import { evaluateReadiness } from './github-actions-runtime-readiness.mjs'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const scriptPath = path.join(repoRoot, 'scripts', 'ops', 'github-actions-runtime-readiness.mjs')
+
+function makeTmpDir() {
+  return mkdtempSync(path.join(tmpdir(), 'github-actions-runtime-readiness-'))
+}
+
+function writeFixture(dir, name, payload) {
+  const filePath = path.join(dir, name)
+  writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`)
+  return filePath
+}
+
+test('readiness passes when K3 variables and DingTalk self-heal secrets are configured', () => {
+  const result = evaluateReadiness({
+    repo: 'zensgit/metasheet2',
+    checkedAt: '2026-05-05T00:00:00.000Z',
+    secrets: [
+      { name: 'DEPLOY_HOST' },
+      { name: 'DEPLOY_USER' },
+      { name: 'DEPLOY_SSH_KEY_B64' },
+      { name: 'SLACK_WEBHOOK_URL' },
+    ],
+    variables: [
+      { name: 'METASHEET_TENANT_ID', value: 'default' },
+      { name: 'K3_WISE_DEPLOY_SMOKE_REQUIRE_AUTH', value: 'true' },
+    ],
+  })
+
+  assert.equal(result.status, 'PASS')
+  assert.equal(result.checks.dingtalkDeploySecrets.ok, true)
+  assert.equal(result.checks.dingtalkWebhookSelfHeal.ok, true)
+  assert.equal(result.checks.k3DeployAuthGate.ok, true)
+})
+
+test('readiness fails with actionable output when webhook self-heal secret is missing', () => {
+  const result = evaluateReadiness({
+    repo: 'zensgit/metasheet2',
+    checkedAt: '2026-05-05T00:00:00.000Z',
+    secrets: [
+      { name: 'DEPLOY_HOST' },
+      { name: 'DEPLOY_USER' },
+      { name: 'DEPLOY_SSH_KEY_B64' },
+    ],
+    variables: [
+      { name: 'METASHEET_TENANT_ID', value: 'default' },
+      { name: 'K3_WISE_DEPLOY_SMOKE_REQUIRE_AUTH', value: 'true' },
+    ],
+  })
+
+  assert.equal(result.status, 'FAIL')
+  assert.equal(result.checks.dingtalkDeploySecrets.ok, true)
+  assert.equal(result.checks.dingtalkWebhookSelfHeal.ok, false)
+  assert.match(result.nextActions.join('\n'), /Configure one supported webhook secret/)
+})
+
+test('readiness fails when the K3 deploy auth gate variable is absent or false', () => {
+  const result = evaluateReadiness({
+    repo: 'zensgit/metasheet2',
+    checkedAt: '2026-05-05T00:00:00.000Z',
+    secrets: [
+      { name: 'DEPLOY_HOST' },
+      { name: 'DEPLOY_USER' },
+      { name: 'DEPLOY_SSH_KEY_B64' },
+      { name: 'ALERTMANAGER_WEBHOOK_URL' },
+    ],
+    variables: [
+      { name: 'METASHEET_TENANT_ID', value: 'default' },
+      { name: 'K3_WISE_DEPLOY_SMOKE_REQUIRE_AUTH', value: 'false' },
+    ],
+  })
+
+  assert.equal(result.status, 'FAIL')
+  assert.equal(result.checks.k3DeployAuthGate.ok, false)
+  assert.equal(result.checks.k3DeployAuthGate.requireAuthEnabled, false)
+  assert.match(result.nextActions.join('\n'), /K3_WISE_DEPLOY_SMOKE_REQUIRE_AUTH=true/)
+})
+
+test('fixture mode does not leak accidental secret values', () => {
+  const dir = makeTmpDir()
+  try {
+    const secretsPath = writeFixture(dir, 'secrets.json', [
+      { name: 'DEPLOY_HOST', value: 'host-secret-value' },
+      { name: 'DEPLOY_USER', value: 'user-secret-value' },
+      { name: 'DEPLOY_SSH_KEY_B64', value: 'ssh-secret-value' },
+      { name: 'SLACK_WEBHOOK_URL', value: 'https://hooks.slack.com/services/secret-value' },
+    ])
+    const variablesPath = writeFixture(dir, 'variables.json', [
+      { name: 'METASHEET_TENANT_ID', value: 'default' },
+      { name: 'K3_WISE_DEPLOY_SMOKE_REQUIRE_AUTH', value: 'true' },
+    ])
+
+    const result = spawnSync('node', [
+      scriptPath,
+      '--repo',
+      'zensgit/metasheet2',
+      '--format',
+      'json',
+      '--secrets-json',
+      secretsPath,
+      '--variables-json',
+      variablesPath,
+      '--strict',
+    ], { encoding: 'utf8' })
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stdout, /"status": "PASS"/)
+    assert.doesNotMatch(result.stdout, /secret-value/)
+    assert.doesNotMatch(result.stdout, /hooks\.slack\.com\/services/)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary

- Adds `scripts/ops/github-actions-runtime-readiness.mjs`, a redaction-safe GitHub Actions configuration readiness check for the current K3 + DingTalk runtime gates.
- Checks DingTalk stability deploy secrets, supported Alertmanager webhook self-heal secret names, and K3 deploy auth gate repo variables.
- Documents the design and verification evidence, including the latest failing DingTalk artifact and the repo-variable change that enables K3 authenticated deploy smoke gating.

## Live configuration result

`node scripts/ops/github-actions-runtime-readiness.mjs --repo zensgit/metasheet2 --format markdown` currently reports:

- DingTalk deploy SSH secrets: PASS
- K3 deploy auth gate: PASS
- DingTalk Alertmanager webhook self-heal: FAIL

Remaining live action is to configure one supported GitHub Actions secret: `ALERTMANAGER_WEBHOOK_URL`, `ALERT_WEBHOOK_URL`, `SLACK_WEBHOOK_URL`, or `ATTENDANCE_ALERT_SLACK_WEBHOOK_URL`.

## Verification

- `node --test scripts/ops/github-actions-runtime-readiness.test.mjs scripts/ops/dingtalk-oauth-stability-workflow-contract.test.mjs scripts/ops/github-dingtalk-oauth-stability-summary.test.mjs scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs`
- `node scripts/ops/github-actions-runtime-readiness.mjs --repo zensgit/metasheet2 --format json`

## Notes

- The script only reads secret names from GitHub; it never reads or prints secret values.
- Repository variable `K3_WISE_DEPLOY_SMOKE_REQUIRE_AUTH=true` was set outside this PR so future automatic deploys require authenticated K3 smoke evidence.
