### PR TITLE
chore(ops): add DingTalk webhook secret setup helper

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -62,6 +62,10 @@ metadata only. It verifies that DingTalk stability has deploy SSH inputs plus
 one supported Alertmanager webhook secret, and that K3 automatic deploy smoke is
 using `METASHEET_TENANT_ID` with `K3_WISE_DEPLOY_SMOKE_REQUIRE_AUTH=true`.
 
+To configure the DingTalk Alertmanager webhook secret without printing the URL,
+use `scripts/ops/set-dingtalk-alertmanager-webhook-secret.mjs`. See
+`docs/operations/dingtalk-alertmanager-webhook-secret-runbook.md`.
+
 ## Manual Dispatch (Nightly)
 
 1. Actions → Phase 5 Nightly Validation (Regression) → Run workflow.

--- a/docs/development/dingtalk-alertmanager-webhook-secret-ops-design-20260505.md
+++ b/docs/development/dingtalk-alertmanager-webhook-secret-ops-design-20260505.md
@@ -1,0 +1,68 @@
+# DingTalk Alertmanager Webhook Secret Ops Design
+
+Date: 2026-05-05
+Branch: `codex/dingtalk-webhook-secret-ops-20260505`
+
+## Problem
+
+The latest manual workflow run on `main` confirmed the runtime failure is not a
+DingTalk OAuth app regression:
+
+```text
+run: 25352338855
+head: 390a95ff16eb1b02cf3a5f938e7bbcba0e7e524c
+backend health: ok
+Alertmanager notify errors: 0
+root filesystem: below gate
+webhookConfig.configured: false
+webhook self-heal secret available: false
+```
+
+Without a real Slack webhook URL, code cannot self-heal the remote
+Alertmanager config. The remaining useful work is to make the operator path
+safe and repeatable.
+
+## Change
+
+Add `scripts/ops/set-dingtalk-alertmanager-webhook-secret.mjs`.
+
+Properties:
+
+- accepts only the secret names consumed by
+  `dingtalk-oauth-stability-recording-lite.yml`;
+- reads the webhook URL from stdin or an environment variable;
+- validates that the value is an HTTPS Slack incoming webhook under
+  `hooks.slack.com`, matching the stability gate;
+- writes the GitHub Actions repository secret through `gh secret set` via stdin;
+- prints only redacted metadata: secret name, repo, host, and path length.
+
+Also update `scripts/observe-24h.sh` so startup logs no longer print the
+`ALERT_WEBHOOK_URL` value. It now prints only `configured` or `disabled`.
+
+## Non-Goals
+
+- Do not store webhook URLs in tracked docs.
+- Do not make the stability workflow pass when the webhook is missing.
+- Do not accept DingTalk webhook URLs for this Alertmanager gate; the current
+  health check explicitly expects `hooks.slack.com`.
+
+## Operator Flow
+
+```bash
+printf '%s' "$ALERTMANAGER_WEBHOOK_URL" \
+  | node scripts/ops/set-dingtalk-alertmanager-webhook-secret.mjs \
+      --repo zensgit/metasheet2 \
+      --stdin
+
+node scripts/ops/github-actions-runtime-readiness.mjs \
+  --repo zensgit/metasheet2 \
+  --strict
+
+gh workflow run dingtalk-oauth-stability-recording-lite.yml \
+  --repo zensgit/metasheet2 \
+  --ref main
+```
+
+The first successful scheduled or manual workflow after the secret is configured
+will reapply the remote `alertmanager.onprem.env` file and then run the same
+stability checks.

--- a/docs/development/dingtalk-alertmanager-webhook-secret-ops-verification-20260505.md
+++ b/docs/development/dingtalk-alertmanager-webhook-secret-ops-verification-20260505.md
@@ -1,0 +1,99 @@
+# DingTalk Alertmanager Webhook Secret Ops Verification
+
+Date: 2026-05-05
+Branch: `codex/dingtalk-webhook-secret-ops-20260505`
+
+## Live Workflow Test
+
+Manual run:
+
+```text
+run: 25352338855
+workflow: DingTalk OAuth Stability Recording (Lite)
+event: workflow_dispatch
+head: 390a95ff16eb1b02cf3a5f938e7bbcba0e7e524c
+url: https://github.com/zensgit/metasheet2/actions/runs/25352338855
+```
+
+Result:
+
+```text
+conclusion: failure
+failed step: Fail if stability check is unhealthy
+```
+
+Artifact summary:
+
+```text
+Overall: FAIL
+Stability rc: 0
+Healthy: false
+Webhook self-heal secret available: false
+Health: status=ok plugins=13 ok=True
+Webhook: configured=False host=
+Alertmanager: activeAlerts=0 notifyErrors=0
+Storage: rootUse=52% maxUse=95%
+```
+
+Failure reasons:
+
+```text
+Alertmanager webhook is not configured
+No supported GitHub webhook secret was available for Alertmanager self-heal
+```
+
+## Current Runtime Readiness
+
+Command:
+
+```bash
+node scripts/ops/github-actions-runtime-readiness.mjs \
+  --repo zensgit/metasheet2 \
+  --format markdown
+```
+
+Observed:
+
+```text
+dingtalkDeploySecrets: PASS
+dingtalkWebhookSelfHeal: FAIL
+k3DeployAuthGate: PASS
+```
+
+Meaning:
+
+- deploy SSH configuration exists;
+- K3 automatic deploy authenticated smoke gating is enabled;
+- no supported webhook secret is present yet.
+
+## Unit Verification
+
+```bash
+node --test \
+  scripts/ops/set-dingtalk-alertmanager-webhook-secret.test.mjs \
+  scripts/ops/github-actions-runtime-readiness.test.mjs
+```
+
+Expected coverage:
+
+- supported secret names are accepted;
+- unsupported DingTalk webhook secret name is rejected for this Slack-hosted
+  Alertmanager gate;
+- non-`hooks.slack.com` URLs are rejected;
+- dry-run output does not leak the webhook path or secret suffix.
+
+## Redaction Check
+
+`scripts/observe-24h.sh` startup output now prints:
+
+```text
+Webhook: configured
+```
+
+or:
+
+```text
+Webhook: disabled
+```
+
+It no longer prints the actual `ALERT_WEBHOOK_URL`.

--- a/docs/operations/dingtalk-alertmanager-webhook-secret-runbook.md
+++ b/docs/operations/dingtalk-alertmanager-webhook-secret-runbook.md
@@ -1,0 +1,101 @@
+# DingTalk Alertmanager Webhook Secret Runbook
+
+Date: 2026-05-05
+
+## Current Gate
+
+`DingTalk OAuth Stability Recording (Lite)` is healthy only when:
+
+- the backend health endpoint is ok;
+- the on-prem Alertmanager webhook config is present;
+- the webhook host is `hooks.slack.com`;
+- Alertmanager has no notify errors in the current log window;
+- the remote root filesystem is below the configured usage gate.
+
+If the workflow reports `No supported GitHub webhook secret was available for
+Alertmanager self-heal`, code cannot infer or recreate the webhook URL. A real
+Slack incoming webhook URL must be provided as a GitHub Actions repository
+secret.
+
+## Supported Secret Names
+
+Preferred:
+
+```text
+ALERTMANAGER_WEBHOOK_URL
+```
+
+Compatible fallback names:
+
+```text
+ALERT_WEBHOOK_URL
+SLACK_WEBHOOK_URL
+ATTENDANCE_ALERT_SLACK_WEBHOOK_URL
+```
+
+`ATTENDANCE_ALERT_DINGTALK_WEBHOOK_URL` is not used by this stability workflow
+because the current Alertmanager health gate expects `hooks.slack.com`.
+
+## Safe CLI Setup
+
+Do not paste webhook URLs into shell history or tracked docs.
+
+Preferred stdin flow:
+
+```bash
+printf '%s' "$ALERTMANAGER_WEBHOOK_URL" \
+  | node scripts/ops/set-dingtalk-alertmanager-webhook-secret.mjs \
+      --repo zensgit/metasheet2 \
+      --stdin
+```
+
+Environment-variable flow:
+
+```bash
+node scripts/ops/set-dingtalk-alertmanager-webhook-secret.mjs \
+  --repo zensgit/metasheet2 \
+  --from-env ALERTMANAGER_WEBHOOK_URL
+```
+
+Validation-only rehearsal:
+
+```bash
+printf '%s' "$ALERTMANAGER_WEBHOOK_URL" \
+  | node scripts/ops/set-dingtalk-alertmanager-webhook-secret.mjs \
+      --repo zensgit/metasheet2 \
+      --stdin \
+      --dry-run
+```
+
+The script prints only the secret name, repository, host, and path length. It
+does not print the webhook path or full URL.
+
+## After Setting the Secret
+
+1. Verify repository configuration:
+
+   ```bash
+   node scripts/ops/github-actions-runtime-readiness.mjs \
+     --repo zensgit/metasheet2 \
+     --strict
+   ```
+
+2. Trigger the recording workflow:
+
+   ```bash
+   gh workflow run dingtalk-oauth-stability-recording-lite.yml \
+     --repo zensgit/metasheet2 \
+     --ref main
+   ```
+
+3. Check the artifact summary. Expected transition:
+
+   ```text
+   Webhook self-heal secret available: true
+   Webhook: configured=True host=hooks.slack.com
+   Overall: PASS
+   ```
+
+If the secret is present but the workflow still fails, inspect the artifact
+failure reasons before retrying. Do not rotate the secret unless the artifact
+indicates host drift or notify errors after self-heal.

--- a/docs/verification-index.md
+++ b/docs/verification-index.md
@@ -32,6 +32,16 @@ Entry points:
   - Verification: `docs/development/github-actions-runtime-readiness-verification-20260505.md`
   - Notes: checks required GitHub secret names and repo variables without reading or printing secret values.
 
+## 2026-05-05 DingTalk Alertmanager Webhook Secret Ops
+
+- Safe operator path for DingTalk Alertmanager webhook secret setup:
+  - Script: `scripts/ops/set-dingtalk-alertmanager-webhook-secret.mjs`
+  - Tests: `scripts/ops/set-dingtalk-alertmanager-webhook-secret.test.mjs`
+  - Runbook: `docs/operations/dingtalk-alertmanager-webhook-secret-runbook.md`
+  - Design: `docs/development/dingtalk-alertmanager-webhook-secret-ops-design-20260505.md`
+  - Verification: `docs/development/dingtalk-alertmanager-webhook-secret-ops-verification-20260505.md`
+  - Notes: reads the webhook from stdin/env, writes through `gh secret set`, and prints only redacted metadata.
+
 ## 2026-04-07 Multitable Staging Profile Baseline
 
 - Multitable staging profile threshold follow-up:

--- a/scripts/observe-24h.sh
+++ b/scripts/observe-24h.sh
@@ -41,6 +41,11 @@ REPORT_DIR="claudedocs"
 ALERT_WEBHOOK_URL=${ALERT_WEBHOOK_URL:-""}  # Slack/Webhook for CRIT alerts
 HOOK_CRIT_CMD=${HOOK_CRIT_CMD:-""}          # Custom command on CRIT
 CREATE_GH_ISSUE=${CREATE_GH_ISSUE:-"false"} # Auto-create GitHub issues
+if [ -n "$ALERT_WEBHOOK_URL" ]; then
+  ALERT_WEBHOOK_STATUS="configured"
+else
+  ALERT_WEBHOOK_STATUS="disabled"
+fi
 
 # Cold start exemption and smoothing
 COLD_START_SAMPLES=1                        # Skip alerts for first N samples
@@ -78,7 +83,7 @@ echo "  - Cold Start Exemption: First ${COLD_START_SAMPLES} samples"
 echo "  - P99 Smoothing: Median of last ${SMOOTHING_WINDOW} samples"
 echo ""
 echo "🔔 Alert Hooks:"
-echo "  - Webhook: ${ALERT_WEBHOOK_URL:-disabled}"
+echo "  - Webhook: ${ALERT_WEBHOOK_STATUS}"
 echo "  - Custom CMD: ${HOOK_CRIT_CMD:-disabled}"
 echo "  - GitHub Issues: ${CREATE_GH_ISSUE}"
 echo ""

--- a/scripts/ops/set-dingtalk-alertmanager-webhook-secret.mjs
+++ b/scripts/ops/set-dingtalk-alertmanager-webhook-secret.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { pathToFileURL } from 'node:url'
+
+export const SUPPORTED_SECRET_NAMES = [
+  'ALERTMANAGER_WEBHOOK_URL',
+  'ALERT_WEBHOOK_URL',
+  'SLACK_WEBHOOK_URL',
+  'ATTENDANCE_ALERT_SLACK_WEBHOOK_URL',
+]
+
+export function parseArgs(argv) {
+  const config = {
+    repo: process.env.GITHUB_REPOSITORY || 'zensgit/metasheet2',
+    name: 'ALERTMANAGER_WEBHOOK_URL',
+    fromEnv: '',
+    stdin: false,
+    dryRun: false,
+    help: false,
+  }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === '--repo') {
+      config.repo = requireValue(argv, index, arg)
+      index += 1
+    } else if (arg === '--name') {
+      config.name = requireValue(argv, index, arg)
+      index += 1
+    } else if (arg === '--from-env') {
+      config.fromEnv = requireValue(argv, index, arg)
+      index += 1
+    } else if (arg === '--stdin') {
+      config.stdin = true
+    } else if (arg === '--dry-run') {
+      config.dryRun = true
+    } else if (arg === '--help' || arg === '-h') {
+      config.help = true
+    } else {
+      throw new Error(`Unknown argument: ${arg}`)
+    }
+  }
+
+  return config
+}
+
+function requireValue(argv, index, arg) {
+  const value = argv[index + 1]
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${arg} requires a value`)
+  }
+  return value
+}
+
+export function validateSecretName(name) {
+  if (!SUPPORTED_SECRET_NAMES.includes(name)) {
+    throw new Error(`Unsupported secret name: ${name}. Supported: ${SUPPORTED_SECRET_NAMES.join(', ')}`)
+  }
+}
+
+export function validateSlackWebhookUrl(value) {
+  const webhookUrl = String(value || '').trim()
+  if (!webhookUrl) {
+    throw new Error('Webhook URL is empty')
+  }
+
+  let parsed
+  try {
+    parsed = new URL(webhookUrl)
+  } catch {
+    throw new Error('Webhook URL must be a valid URL')
+  }
+
+  if (parsed.protocol !== 'https:') {
+    throw new Error('Webhook URL must use https')
+  }
+  if (parsed.hostname !== 'hooks.slack.com') {
+    throw new Error('DingTalk Alertmanager stability requires a Slack webhook host: hooks.slack.com')
+  }
+  if (!parsed.pathname || parsed.pathname === '/') {
+    throw new Error('Webhook URL path is missing')
+  }
+
+  return {
+    value: webhookUrl,
+    host: parsed.hostname,
+    pathLength: parsed.pathname.length,
+  }
+}
+
+function readWebhookValue(config) {
+  if (config.stdin) {
+    return readFileSync(0, 'utf8')
+  }
+  const envName = config.fromEnv || config.name
+  return process.env[envName] || ''
+}
+
+function setGitHubSecret({ repo, name, value }) {
+  const result = spawnSync('gh', ['secret', 'set', name, '--repo', repo], {
+    input: `${value}\n`,
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  })
+  if (result.status !== 0) {
+    throw new Error(`gh secret set failed: ${result.stderr || result.stdout}`)
+  }
+}
+
+function printHelp() {
+  console.log(`usage: set-dingtalk-alertmanager-webhook-secret.mjs [options]
+
+Options:
+  --repo <owner/name>       GitHub repository (default: GITHUB_REPOSITORY or zensgit/metasheet2)
+  --name <secret-name>      Secret name to set (default: ALERTMANAGER_WEBHOOK_URL)
+  --from-env <env-name>     Read the webhook URL from an environment variable
+  --stdin                   Read the webhook URL from stdin
+  --dry-run                 Validate only; do not call gh secret set
+
+Supported secret names:
+  ${SUPPORTED_SECRET_NAMES.join('\n  ')}
+
+Examples:
+  printf '%s' "$ALERTMANAGER_WEBHOOK_URL" | node scripts/ops/set-dingtalk-alertmanager-webhook-secret.mjs --stdin
+  node scripts/ops/set-dingtalk-alertmanager-webhook-secret.mjs --from-env ALERTMANAGER_WEBHOOK_URL
+`)
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const config = parseArgs(argv)
+  if (config.help) {
+    printHelp()
+    return 0
+  }
+
+  validateSecretName(config.name)
+  const webhook = validateSlackWebhookUrl(readWebhookValue(config))
+
+  if (!config.dryRun) {
+    setGitHubSecret({
+      repo: config.repo,
+      name: config.name,
+      value: webhook.value,
+    })
+  }
+
+  const action = config.dryRun ? 'validated' : 'configured'
+  console.log(
+    `[dingtalk-alertmanager-webhook-secret] ${action} ${config.name} for ${config.repo} ` +
+      `(host=${webhook.host} path_length=${webhook.pathLength})`,
+  )
+  return 0
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    process.exitCode = main()
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exitCode = 1
+  }
+}

--- a/scripts/ops/set-dingtalk-alertmanager-webhook-secret.test.mjs
+++ b/scripts/ops/set-dingtalk-alertmanager-webhook-secret.test.mjs
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+import {
+  parseArgs,
+  validateSecretName,
+  validateSlackWebhookUrl,
+} from './set-dingtalk-alertmanager-webhook-secret.mjs'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const scriptPath = path.join(repoRoot, 'scripts', 'ops', 'set-dingtalk-alertmanager-webhook-secret.mjs')
+
+test('parses the default GitHub secret target', () => {
+  assert.deepEqual(parseArgs([]), {
+    repo: process.env.GITHUB_REPOSITORY || 'zensgit/metasheet2',
+    name: 'ALERTMANAGER_WEBHOOK_URL',
+    fromEnv: '',
+    stdin: false,
+    dryRun: false,
+    help: false,
+  })
+})
+
+test('accepts only supported DingTalk Alertmanager webhook secret names', () => {
+  assert.doesNotThrow(() => validateSecretName('ALERTMANAGER_WEBHOOK_URL'))
+  assert.doesNotThrow(() => validateSecretName('SLACK_WEBHOOK_URL'))
+  assert.throws(
+    () => validateSecretName('ATTENDANCE_ALERT_DINGTALK_WEBHOOK_URL'),
+    /Unsupported secret name/,
+  )
+})
+
+test('validates Slack webhook URL without returning the full URL in metadata', () => {
+  const result = validateSlackWebhookUrl('https://hooks.slack.com/services/T000/B000/secret-value\n')
+
+  assert.equal(result.host, 'hooks.slack.com')
+  assert.equal(result.pathLength, '/services/T000/B000/secret-value'.length)
+  assert.equal(result.value, 'https://hooks.slack.com/services/T000/B000/secret-value')
+})
+
+test('rejects non-Slack hosts because stability check requires hooks.slack.com', () => {
+  assert.throws(
+    () => validateSlackWebhookUrl('https://example.com/webhook'),
+    /hooks\.slack\.com/,
+  )
+})
+
+test('dry-run mode does not print the secret path', () => {
+  const result = spawnSync('node', [
+    scriptPath,
+    '--stdin',
+    '--dry-run',
+    '--repo',
+    'zensgit/metasheet2',
+  ], {
+    input: 'https://hooks.slack.com/services/T000/B000/secret-value\n',
+    encoding: 'utf8',
+  })
+
+  assert.equal(result.status, 0, result.stderr)
+  assert.match(result.stdout, /validated ALERTMANAGER_WEBHOOK_URL/)
+  assert.match(result.stdout, /host=hooks\.slack\.com/)
+  assert.doesNotMatch(result.stdout, /secret-value/)
+  assert.doesNotMatch(result.stderr, /secret-value/)
+})


### PR DESCRIPTION
## Summary

- Adds `scripts/ops/set-dingtalk-alertmanager-webhook-secret.mjs`, a redaction-safe helper for configuring the DingTalk Alertmanager webhook GitHub secret from stdin or env.
- Adds a runbook plus design/verification docs for the tested failure mode: backend and Alertmanager are healthy, but webhook self-heal cannot run because no supported GitHub webhook secret exists.
- Redacts `scripts/observe-24h.sh` startup output so `ALERT_WEBHOOK_URL` is no longer printed; it now reports only `configured` or `disabled`.

## Live test evidence

Manual workflow run on latest `main`:

- Run: https://github.com/zensgit/metasheet2/actions/runs/25352338855
- Head: `390a95ff16eb1b02cf3a5f938e7bbcba0e7e524c`
- Result: failed at final unhealthy gate
- Artifact facts: backend health ok, active alerts 0, notify errors 0, root use 52%/95%, webhook configured false, webhook self-heal secret available false

Current readiness remains:

- DingTalk deploy secrets: PASS
- K3 deploy auth gate: PASS
- DingTalk webhook self-heal: FAIL until one supported webhook secret is configured

## Verification

- `node --test scripts/ops/set-dingtalk-alertmanager-webhook-secret.test.mjs scripts/ops/github-actions-runtime-readiness.test.mjs scripts/ops/dingtalk-oauth-stability-workflow-contract.test.mjs scripts/ops/github-dingtalk-oauth-stability-summary.test.mjs`
- `node scripts/ops/set-dingtalk-alertmanager-webhook-secret.mjs --stdin --dry-run --repo zensgit/metasheet2` with a dummy Slack URL; output redacts the secret path.
- `bash -n scripts/observe-24h.sh scripts/ops/set-dingtalk-onprem-alertmanager-webhook-config.sh`
- `gh secret set --help` confirms secret values are read from stdin when `--body` is not specified.

## Notes

This PR does not make the workflow pass without a real webhook URL. It provides the safe operator path for setting that value without leaking it into shell history, logs, or tracked docs.
