### PR TITLE
feat(multitable): add record subscriptions

### DIFF
--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -12,6 +12,9 @@ import type {
   MetaRecord,
   MetaRecordContext,
   MetaRecordRevision,
+  MetaRecordSubscription,
+  MetaRecordSubscriptionNotification,
+  MetaRecordSubscriptionStatus,
   MetaFormContext,
   PatchResult,
   FormSubmitResult,
@@ -600,6 +603,71 @@ function normalizeRecordHistoryEntries(
     : []
 }
 
+function normalizeRecordSubscription(payload: Partial<MetaRecordSubscription> | null | undefined): MetaRecordSubscription | null {
+  const id = typeof payload?.id === 'string' ? payload.id : ''
+  const sheetId = typeof payload?.sheetId === 'string' ? payload.sheetId : ''
+  const recordId = typeof payload?.recordId === 'string' ? payload.recordId : ''
+  const userId = typeof payload?.userId === 'string' ? payload.userId : ''
+  if (!id || !sheetId || !recordId || !userId) return null
+  return {
+    id,
+    sheetId,
+    recordId,
+    userId,
+    createdAt: typeof payload?.createdAt === 'string' ? payload.createdAt : '',
+    updatedAt: typeof payload?.updatedAt === 'string' ? payload.updatedAt : '',
+  }
+}
+
+function normalizeRecordSubscriptionStatus(
+  payload: { subscribed?: boolean; subscription?: Partial<MetaRecordSubscription> | null; items?: Array<Partial<MetaRecordSubscription>> } | null | undefined,
+): MetaRecordSubscriptionStatus {
+  const subscription = normalizeRecordSubscription(payload?.subscription ?? null)
+  const items = Array.isArray(payload?.items)
+    ? payload.items
+      .map((item) => normalizeRecordSubscription(item))
+      .filter((item): item is MetaRecordSubscription => !!item)
+    : []
+  return {
+    subscribed: payload?.subscribed === true || !!subscription,
+    subscription,
+    items,
+  }
+}
+
+function normalizeRecordSubscriptionNotification(
+  payload: Partial<MetaRecordSubscriptionNotification> | null | undefined,
+): MetaRecordSubscriptionNotification | null {
+  const id = typeof payload?.id === 'string' ? payload.id : ''
+  const sheetId = typeof payload?.sheetId === 'string' ? payload.sheetId : ''
+  const recordId = typeof payload?.recordId === 'string' ? payload.recordId : ''
+  const userId = typeof payload?.userId === 'string' ? payload.userId : ''
+  const eventType = payload?.eventType === 'comment.created' ? 'comment.created' : payload?.eventType === 'record.updated' ? 'record.updated' : null
+  if (!id || !sheetId || !recordId || !userId || !eventType) return null
+  return {
+    id,
+    sheetId,
+    recordId,
+    userId,
+    eventType,
+    actorId: typeof payload?.actorId === 'string' ? payload.actorId : null,
+    revisionId: typeof payload?.revisionId === 'string' ? payload.revisionId : null,
+    commentId: typeof payload?.commentId === 'string' ? payload.commentId : null,
+    createdAt: typeof payload?.createdAt === 'string' ? payload.createdAt : '',
+    readAt: typeof payload?.readAt === 'string' ? payload.readAt : null,
+  }
+}
+
+function normalizeRecordSubscriptionNotifications(
+  payload: { items?: Array<Partial<MetaRecordSubscriptionNotification>> } | null | undefined,
+): MetaRecordSubscriptionNotification[] {
+  return Array.isArray(payload?.items)
+    ? payload.items
+      .map((item) => normalizeRecordSubscriptionNotification(item))
+      .filter((item): item is MetaRecordSubscriptionNotification => !!item)
+    : []
+}
+
 function normalizeCommentsParams(params: { containerId: string; targetId: string; targetFieldId?: string | null } | MetaCommentsScope) {
   if ('containerType' in params) {
     return {
@@ -890,6 +958,38 @@ export class MultitableApiClient {
     )
     const data = await parseJson<{ items?: Array<Partial<MetaRecordRevision>> }>(res)
     return normalizeRecordHistoryEntries(data)
+  }
+
+  async getRecordSubscriptionStatus(sheetId: string, recordId: string): Promise<MetaRecordSubscriptionStatus> {
+    const res = await this.fetch(
+      `/api/multitable/sheets/${encodeURIComponent(sheetId)}/records/${encodeURIComponent(recordId)}/subscriptions`,
+    )
+    const data = await parseJson<{ subscribed?: boolean; subscription?: Partial<MetaRecordSubscription> | null; items?: Array<Partial<MetaRecordSubscription>> }>(res)
+    return normalizeRecordSubscriptionStatus(data)
+  }
+
+  async subscribeRecord(sheetId: string, recordId: string): Promise<MetaRecordSubscriptionStatus> {
+    const res = await this.fetch(
+      `/api/multitable/sheets/${encodeURIComponent(sheetId)}/records/${encodeURIComponent(recordId)}/subscriptions/me`,
+      { method: 'PUT' },
+    )
+    const data = await parseJson<{ subscribed?: boolean; subscription?: Partial<MetaRecordSubscription> | null }>(res)
+    return normalizeRecordSubscriptionStatus(data)
+  }
+
+  async unsubscribeRecord(sheetId: string, recordId: string): Promise<MetaRecordSubscriptionStatus> {
+    const res = await this.fetch(
+      `/api/multitable/sheets/${encodeURIComponent(sheetId)}/records/${encodeURIComponent(recordId)}/subscriptions/me`,
+      { method: 'DELETE' },
+    )
+    const data = await parseJson<{ subscribed?: boolean; subscription?: Partial<MetaRecordSubscription> | null }>(res)
+    return normalizeRecordSubscriptionStatus(data)
+  }
+
+  async listRecordSubscriptionNotifications(params?: { sheetId?: string; recordId?: string; limit?: number; offset?: number }): Promise<MetaRecordSubscriptionNotification[]> {
+    const res = await this.fetch(`/api/multitable/record-subscription-notifications${qs(params ?? {})}`)
+    const data = await parseJson<{ items?: Array<Partial<MetaRecordSubscriptionNotification>> }>(res)
+    return normalizeRecordSubscriptionNotifications(data)
   }
 
   async createRecord(input: CreateRecordInput, opts?: { signal?: AbortSignal }): Promise<{ record: MetaRecord }> {

--- a/apps/web/src/multitable/components/MetaRecordDrawer.vue
+++ b/apps/web/src/multitable/components/MetaRecordDrawer.vue
@@ -9,6 +9,17 @@
       </div>
       <div class="meta-record-drawer__actions">
         <button
+          v-if="record && canLoadSubscription"
+          class="meta-record-drawer__btn meta-record-drawer__btn--watch"
+          :class="{ 'meta-record-drawer__btn--watching': recordSubscribed }"
+          type="button"
+          :disabled="subscriptionLoading"
+          :title="recordSubscribed ? 'Unwatch this record' : 'Watch this record'"
+          @click="toggleRecordSubscription"
+        >
+          {{ recordSubscribed ? 'Watching' : 'Watch' }}
+        </button>
+        <button
           v-if="resolvedCanComment"
           class="meta-record-drawer__btn meta-record-drawer__btn--comment"
           :class="drawerCommentButtonClass"
@@ -43,6 +54,7 @@
           @click="activeTab = 'history'"
         >History</button>
       </div>
+      <div v-if="subscriptionError" class="meta-record-drawer__watch-error">{{ subscriptionError }}</div>
       <div v-if="activeTab === 'details'" class="meta-record-drawer__fields">
       <div v-for="field in visibleFields" :key="field.id" class="meta-record-drawer__field">
         <div class="meta-record-drawer__field-header">
@@ -204,6 +216,7 @@ import type {
   MetaField,
   MetaRecord,
   MetaRecordRevision,
+  MetaRecordSubscriptionStatus,
   MetaRowActions,
 } from '../types'
 import type { MultitableApiClient } from '../api/client'
@@ -261,6 +274,10 @@ const historyItems = ref<MetaRecordRevision[]>([])
 const historyLoading = ref(false)
 const historyError = ref('')
 let historyRequestId = 0
+const recordSubscribed = ref(false)
+const subscriptionLoading = ref(false)
+const subscriptionError = ref('')
+let subscriptionRequestId = 0
 
 const attachmentActivity = ref<Record<string, 'uploading' | 'removing' | 'clearing'>>({})
 const attachmentErrors = ref<Record<string, string>>({})
@@ -272,7 +289,17 @@ watch(() => props.record, () => {
   localAttachmentSummaries.value = {}
   historyItems.value = []
   historyError.value = ''
+  recordSubscribed.value = false
+  subscriptionError.value = ''
 })
+
+watch(
+  [() => props.visible, () => props.record?.id, () => props.sheetId, () => props.apiClient],
+  () => {
+    if (props.visible) void loadRecordSubscription()
+  },
+  { immediate: true },
+)
 
 watch(
   [() => activeTab.value, () => props.visible, () => props.record?.id, () => props.sheetId, () => props.apiClient],
@@ -290,6 +317,7 @@ const currentRecordIndex = computed(() => {
 const visibleFields = computed(() => props.fields.filter((field) => props.fieldPermissions?.[field.id]?.visible !== false))
 const fieldLabelById = computed(() => new Map(props.fields.map((field) => [field.id, field.name])))
 const canLoadHistory = computed(() => !!props.apiClient && !!props.sheetId && !!props.record?.id)
+const canLoadSubscription = computed(() => !!props.apiClient && !!props.sheetId && !!props.record?.id)
 const resolvedCanComment = computed(() => props.rowActions?.canComment ?? props.canComment)
 const resolvedCanDelete = computed(() => props.rowActions?.canDelete ?? props.canDelete)
 const drawerCommentAffordance = computed(() => resolveRecordCommentAffordance(props.commentPresence))
@@ -346,6 +374,58 @@ async function loadRecordHistory() {
     historyError.value = error?.message ?? 'Failed to load history'
   } finally {
     if (requestId === historyRequestId) historyLoading.value = false
+  }
+}
+
+function applySubscriptionStatus(status: MetaRecordSubscriptionStatus) {
+  recordSubscribed.value = status.subscribed
+}
+
+async function loadRecordSubscription() {
+  const apiClient = props.apiClient
+  const sheetId = props.sheetId
+  const recordId = props.record?.id
+  if (!apiClient || !sheetId || !recordId) {
+    recordSubscribed.value = false
+    subscriptionLoading.value = false
+    subscriptionError.value = ''
+    return
+  }
+  const requestId = ++subscriptionRequestId
+  subscriptionLoading.value = true
+  subscriptionError.value = ''
+  try {
+    const status = await apiClient.getRecordSubscriptionStatus(sheetId, recordId)
+    if (requestId !== subscriptionRequestId) return
+    applySubscriptionStatus(status)
+  } catch (error: any) {
+    if (requestId !== subscriptionRequestId) return
+    recordSubscribed.value = false
+    subscriptionError.value = error?.message ?? 'Failed to load watch status'
+  } finally {
+    if (requestId === subscriptionRequestId) subscriptionLoading.value = false
+  }
+}
+
+async function toggleRecordSubscription() {
+  const apiClient = props.apiClient
+  const sheetId = props.sheetId
+  const recordId = props.record?.id
+  if (!apiClient || !sheetId || !recordId || subscriptionLoading.value) return
+  const requestId = ++subscriptionRequestId
+  subscriptionLoading.value = true
+  subscriptionError.value = ''
+  try {
+    const status = recordSubscribed.value
+      ? await apiClient.unsubscribeRecord(sheetId, recordId)
+      : await apiClient.subscribeRecord(sheetId, recordId)
+    if (requestId !== subscriptionRequestId) return
+    applySubscriptionStatus(status)
+  } catch (error: any) {
+    if (requestId !== subscriptionRequestId) return
+    subscriptionError.value = error?.message ?? 'Failed to update watch status'
+  } finally {
+    if (requestId === subscriptionRequestId) subscriptionLoading.value = false
   }
 }
 
@@ -595,6 +675,9 @@ function attachmentAllowsMultiple(field: MetaField): boolean {
 .meta-record-drawer__btn--comment.meta-record-drawer__btn--comment--active { border-color: #f59e0b; background: #fff7ed; color: #b45309; }
 .meta-record-drawer__btn--comment.meta-record-drawer__btn--comment--idle { border-color: #d8e1ee; background: #fff; color: #64748b; }
 .meta-record-drawer__btn--danger { color: #f56c6c; border-color: #f56c6c; }
+.meta-record-drawer__btn--watch { border-color: #bfdbfe; color: #1d4ed8; background: #eff6ff; }
+.meta-record-drawer__btn--watching { border-color: #0f766e; color: #0f766e; background: #ecfdf5; }
+.meta-record-drawer__btn:disabled { opacity: 0.55; cursor: not-allowed; }
 .meta-record-drawer__close { border: none; background: none; font-size: 20px; cursor: pointer; color: #999; }
 .meta-record-drawer__nav { display: flex; align-items: center; gap: 4px; margin-right: auto; margin-left: 8px; }
 .meta-record-drawer__nav-btn { width: 24px; height: 24px; border: 1px solid #ddd; border-radius: 3px; background: #fff; cursor: pointer; font-size: 14px; display: flex; align-items: center; justify-content: center; }
@@ -605,6 +688,7 @@ function attachmentAllowsMultiple(field: MetaField): boolean {
 .meta-record-drawer__tabs { display: inline-flex; gap: 4px; padding: 3px; margin-bottom: 14px; border: 1px solid #e5e7eb; border-radius: 999px; background: #f8fafc; }
 .meta-record-drawer__tab { min-width: 76px; padding: 5px 12px; border: none; border-radius: 999px; background: transparent; color: #64748b; cursor: pointer; font-size: 12px; font-weight: 600; }
 .meta-record-drawer__tab--active { background: #111827; color: #fff; box-shadow: 0 2px 8px rgba(15, 23, 42, 0.16); }
+.meta-record-drawer__watch-error { margin: -4px 0 12px; color: #b91c1c; font-size: 12px; }
 .meta-record-drawer__field { margin-bottom: 14px; }
 .meta-record-drawer__field-header { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-bottom: 4px; }
 .meta-record-drawer__label { display: block; font-size: 12px; color: #999; }

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -214,6 +214,36 @@ export interface MetaRecordRevision {
   createdAt: string
 }
 
+export interface MetaRecordSubscription {
+  id: string
+  sheetId: string
+  recordId: string
+  userId: string
+  createdAt: string
+  updatedAt: string
+}
+
+export interface MetaRecordSubscriptionStatus {
+  subscribed: boolean
+  subscription: MetaRecordSubscription | null
+  items?: MetaRecordSubscription[]
+}
+
+export type MetaRecordSubscriptionNotificationType = 'record.updated' | 'comment.created'
+
+export interface MetaRecordSubscriptionNotification {
+  id: string
+  sheetId: string
+  recordId: string
+  userId: string
+  eventType: MetaRecordSubscriptionNotificationType
+  actorId: string | null
+  revisionId: string | null
+  commentId: string | null
+  createdAt: string
+  readAt: string | null
+}
+
 // --- Form context (GET /api/multitable/form-context) ---
 export interface MetaFormContext {
   mode: 'form'

--- a/apps/web/tests/multitable-client.spec.ts
+++ b/apps/web/tests/multitable-client.spec.ts
@@ -570,6 +570,94 @@ describe('MultitableApiClient', () => {
     expect(fetchFn).toHaveBeenCalledWith('/api/multitable/sheets/sheet%20history/records/rec%20history/history?limit=25')
   })
 
+  it('loads and toggles record subscription status', async () => {
+    const fetchFn = vi.fn(async (input: string, init?: RequestInit) => {
+      if (input === '/api/multitable/sheets/sheet%201/records/rec%201/subscriptions') {
+        return new Response(JSON.stringify({
+          ok: true,
+          data: {
+            subscribed: false,
+            subscription: null,
+            items: [],
+          },
+        }), { status: 200 })
+      }
+      if (input === '/api/multitable/sheets/sheet%201/records/rec%201/subscriptions/me' && init?.method === 'PUT') {
+        return new Response(JSON.stringify({
+          ok: true,
+          data: {
+            subscribed: true,
+            subscription: {
+              id: 'sub_1',
+              sheetId: 'sheet 1',
+              recordId: 'rec 1',
+              userId: 'user_1',
+              createdAt: '2026-05-05T00:00:00.000Z',
+              updatedAt: '2026-05-05T00:00:00.000Z',
+            },
+          },
+        }), { status: 200 })
+      }
+      if (input === '/api/multitable/sheets/sheet%201/records/rec%201/subscriptions/me' && init?.method === 'DELETE') {
+        return new Response(JSON.stringify({
+          ok: true,
+          data: {
+            subscribed: false,
+            subscription: null,
+          },
+        }), { status: 200 })
+      }
+      throw new Error(`Unexpected request: ${input}`)
+    })
+    const client = new MultitableApiClient({ fetchFn })
+
+    await expect(client.getRecordSubscriptionStatus('sheet 1', 'rec 1')).resolves.toEqual({
+      subscribed: false,
+      subscription: null,
+      items: [],
+    })
+    await expect(client.subscribeRecord('sheet 1', 'rec 1')).resolves.toEqual({
+      subscribed: true,
+      subscription: expect.objectContaining({ id: 'sub_1', userId: 'user_1' }),
+      items: [],
+    })
+    await expect(client.unsubscribeRecord('sheet 1', 'rec 1')).resolves.toEqual({
+      subscribed: false,
+      subscription: null,
+      items: [],
+    })
+  })
+
+  it('loads record subscription notifications', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      ok: true,
+      data: {
+        items: [{
+          id: 'note_1',
+          sheetId: 'sheet_1',
+          recordId: 'rec_1',
+          userId: 'user_1',
+          eventType: 'comment.created',
+          actorId: 'user_2',
+          revisionId: null,
+          commentId: 'cmt_1',
+          createdAt: '2026-05-05T00:00:00.000Z',
+          readAt: null,
+        }],
+      },
+    }), { status: 200 }))
+    const client = new MultitableApiClient({ fetchFn })
+
+    await expect(client.listRecordSubscriptionNotifications({ sheetId: 'sheet_1', recordId: 'rec_1', limit: 10 })).resolves.toEqual([
+      expect.objectContaining({
+        id: 'note_1',
+        eventType: 'comment.created',
+        commentId: 'cmt_1',
+      }),
+    ])
+    expect(fetchFn).toHaveBeenCalledWith('/api/multitable/record-subscription-notifications?sheetId=sheet_1&recordId=rec_1&limit=10')
+  })
+
   it('parses Retry-After seconds and http-date values', () => {
     expect(parseRetryAfterMs('2')).toBe(2000)
     expect(parseRetryAfterMs('Wed, 25 Mar 2026 12:00:05 GMT')).toBe(5000)

--- a/apps/web/tests/multitable-record-drawer.spec.ts
+++ b/apps/web/tests/multitable-record-drawer.spec.ts
@@ -197,6 +197,77 @@ describe('MetaRecordDrawer', () => {
     container.remove()
   })
 
+  it('loads and toggles record watch state', async () => {
+    const getRecordSubscriptionStatus = vi.fn().mockResolvedValue({
+      subscribed: false,
+      subscription: null,
+      items: [],
+    })
+    const subscribeRecord = vi.fn().mockResolvedValue({
+      subscribed: true,
+      subscription: {
+        id: 'sub_1',
+        sheetId: 'sheet_orders',
+        recordId: 'rec_watch_1',
+        userId: 'user_1',
+        createdAt: '2026-05-05T00:00:00.000Z',
+        updatedAt: '2026-05-05T00:00:00.000Z',
+      },
+    })
+    const unsubscribeRecord = vi.fn().mockResolvedValue({
+      subscribed: false,
+      subscription: null,
+    })
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    const app = createApp({
+      render() {
+        return h(MetaRecordDrawer, {
+          visible: true,
+          record: {
+            id: 'rec_watch_1',
+            version: 1,
+            data: { fld_title: 'Alpha' },
+          },
+          fields: [{ id: 'fld_title', name: 'Title', type: 'string' }],
+          canEdit: true,
+          canComment: false,
+          canDelete: false,
+          sheetId: 'sheet_orders',
+          apiClient: {
+            getRecordSubscriptionStatus,
+            subscribeRecord,
+            unsubscribeRecord,
+          } as any,
+        })
+      },
+    })
+
+    app.mount(container)
+    await flushUi()
+
+    const watchButton = Array.from(container.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('Watch'),
+    ) as HTMLButtonElement | undefined
+    expect(getRecordSubscriptionStatus).toHaveBeenCalledWith('sheet_orders', 'rec_watch_1')
+    expect(watchButton?.textContent).toContain('Watch')
+
+    watchButton?.click()
+    await flushUi()
+    expect(subscribeRecord).toHaveBeenCalledWith('sheet_orders', 'rec_watch_1')
+    expect(container.textContent).toContain('Watching')
+
+    ;(Array.from(container.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('Watching'),
+    ) as HTMLButtonElement | undefined)?.click()
+    await flushUi()
+    expect(unsubscribeRecord).toHaveBeenCalledWith('sheet_orders', 'rec_watch_1')
+
+    app.unmount()
+    container.remove()
+  })
+
   it('honors scoped row actions and exposes the workflow entry', async () => {
     const toggleCommentsSpy = vi.fn()
     const openAutomationSpy = vi.fn()

--- a/docs/development/multitable-feishu-rc-todo-20260430.md
+++ b/docs/development/multitable-feishu-rc-todo-20260430.md
@@ -317,12 +317,42 @@ Expected docs:
 
 ## Phase 6 - P1 Gap: Record Subscription Notifications
 
-- [ ] Add record subscription table or reuse existing notification model if already sufficient.
-- [ ] Add subscribe/unsubscribe/list APIs.
-- [ ] Add record drawer watch/unwatch control.
-- [ ] Notify watchers on record update and comment events.
-- [ ] Do not notify the actor for their own write by default.
-- [ ] Add tests for subscribe, unsubscribe, update notification, comment notification, and self-notification suppression.
+- [x] Add record subscription table or reuse existing notification model if already sufficient.
+  - PR: local branch `codex/multitable-record-subscriptions-20260505`
+  - Merge commit: pending
+  - Development MD: `docs/development/multitable-record-subscription-development-20260503.md`
+  - Verification MD: `docs/development/multitable-record-subscription-verification-20260503.md`
+  - Verification summary: migration adds `meta_record_subscriptions` and durable `meta_record_subscription_notifications`.
+- [x] Add subscribe/unsubscribe/list APIs.
+  - PR: local branch `codex/multitable-record-subscriptions-20260505`
+  - Merge commit: pending
+  - Development MD: `docs/development/multitable-record-subscription-development-20260503.md`
+  - Verification MD: `docs/development/multitable-record-subscription-verification-20260503.md`
+  - Verification summary: record-scoped subscription status/list, subscribe, unsubscribe, and current-user notification list APIs added with auth/read checks.
+- [x] Add record drawer watch/unwatch control.
+  - PR: local branch `codex/multitable-record-subscriptions-20260505`
+  - Merge commit: pending
+  - Development MD: `docs/development/multitable-record-subscription-development-20260503.md`
+  - Verification MD: `docs/development/multitable-record-subscription-verification-20260503.md`
+  - Verification summary: drawer loads watch state and toggles Watch/Watching through `MultitableApiClient`.
+- [x] Notify watchers on record update and comment events.
+  - PR: local branch `codex/multitable-record-subscriptions-20260505`
+  - Merge commit: pending
+  - Development MD: `docs/development/multitable-record-subscription-development-20260503.md`
+  - Verification MD: `docs/development/multitable-record-subscription-verification-20260503.md`
+  - Verification summary: `RecordService.patchRecord()`, `RecordWriteService.patchRecords()`, and `CommentService.createComment()` enqueue watcher notifications.
+- [x] Do not notify the actor for their own write by default.
+  - PR: local branch `codex/multitable-record-subscriptions-20260505`
+  - Merge commit: pending
+  - Development MD: `docs/development/multitable-record-subscription-development-20260503.md`
+  - Verification MD: `docs/development/multitable-record-subscription-verification-20260503.md`
+  - Verification summary: subscriber lookup filters `user_id <> actorId` when actor is present.
+- [x] Add tests for subscribe, unsubscribe, update notification, comment notification, and self-notification suppression.
+  - PR: local branch `codex/multitable-record-subscriptions-20260505`
+  - Merge commit: pending
+  - Development MD: `docs/development/multitable-record-subscription-development-20260503.md`
+  - Verification MD: `docs/development/multitable-record-subscription-verification-20260503.md`
+  - Verification summary: focused backend service/write/comment tests and frontend client/drawer tests pass.
 
 Expected docs:
 

--- a/docs/development/multitable-record-subscription-development-20260503.md
+++ b/docs/development/multitable-record-subscription-development-20260503.md
@@ -1,0 +1,82 @@
+# Multitable Record Subscription Notifications Development
+
+Date: 2026-05-05
+Branch: `codex/multitable-record-subscriptions-20260505`
+Base: `origin/main@390a95ff1`
+
+## Scope
+
+Phase 6 closes the P1 gap for record-level watch/notification behavior:
+
+- users can watch/unwatch a record from the record drawer;
+- backend persists record subscriptions separately from comment mentions;
+- record updates and comment creation enqueue durable notifications for watchers;
+- the actor is excluded from watcher notifications by default.
+
+Out of scope:
+
+- global notification center UI;
+- push/WebSocket delivery for watcher notifications;
+- notification read/mark-read APIs;
+- email/DingTalk delivery.
+
+## Backend Design
+
+Added `meta_record_subscriptions` for the watch relationship:
+
+- unique `(sheet_id, record_id, user_id)`;
+- idempotent subscribe via upsert;
+- unsubscribe via delete;
+- list/status APIs are record-scoped and read-gated.
+
+Added `meta_record_subscription_notifications` for durable watcher events:
+
+- event types: `record.updated`, `comment.created`;
+- stores `actor_id`, optional `revision_id`, optional `comment_id`;
+- current-user notification list supports optional `sheetId`/`recordId` filters.
+
+The service layer lives in `packages/core-backend/src/multitable/record-subscription-service.ts`.
+
+## Write Path Wiring
+
+Record update notifications are written from the authoritative mutation paths:
+
+- `RecordService.patchRecord()` for single-record REST patch;
+- `RecordWriteService.patchRecords()` for batch REST/Yjs-authoritative patch;
+- `CommentService.createComment()` for record/field comment creation.
+
+`recordRecordRevision()` now returns the inserted revision id so watcher notifications can point at the exact revision that triggered the event. Existing callers that do not need the id continue to ignore the returned value.
+
+The actor suppression rule is centralized in `notifyRecordSubscribers(...)`: when `actorId` is present, the subscriber lookup filters out that user.
+
+## API Design
+
+Added record-scoped APIs under `/api/multitable`:
+
+- `GET /sheets/:sheetId/records/:recordId/subscriptions`
+- `PUT /sheets/:sheetId/records/:recordId/subscriptions/me`
+- `DELETE /sheets/:sheetId/records/:recordId/subscriptions/me`
+- `GET /record-subscription-notifications`
+
+Record-scoped APIs reuse the same read gate as record history:
+
+- record must exist in the requested sheet;
+- requester must be authenticated;
+- requester must have sheet read;
+- record-level read restrictions are honored when record permission assignments exist.
+
+## Frontend Design
+
+`MultitableApiClient` now exposes:
+
+- `getRecordSubscriptionStatus(sheetId, recordId)`;
+- `subscribeRecord(sheetId, recordId)`;
+- `unsubscribeRecord(sheetId, recordId)`;
+- `listRecordSubscriptionNotifications(...)`.
+
+`MetaRecordDrawer` now loads watch state when opened or when the selected record changes. The header shows `Watch` or `Watching`, and toggles through the new API methods. A stale-request guard prevents late responses for a prior record from overwriting the active record's watch state.
+
+## Deferred
+
+- OpenAPI route documentation is deferred to the next contract sweep because the runtime API is behind focused backend/frontend tests in this slice.
+- Notification center consumption and read-state management are deferred; this slice only creates durable notification rows and drawer watch controls.

--- a/docs/development/multitable-record-subscription-verification-20260503.md
+++ b/docs/development/multitable-record-subscription-verification-20260503.md
@@ -1,0 +1,71 @@
+# Multitable Record Subscription Notifications Verification
+
+Date: 2026-05-05
+Branch: `codex/multitable-record-subscriptions-20260505`
+
+## Commands Run
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/record-subscription-service.test.ts \
+  tests/unit/record-service.test.ts \
+  tests/unit/record-write-service.test.ts \
+  tests/unit/comment-service.test.ts \
+  --reporter=dot
+pnpm --filter @metasheet/web exec vitest run \
+  tests/multitable-record-drawer.spec.ts \
+  tests/multitable-client.spec.ts \
+  --reporter=dot
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+```
+
+## Results
+
+Backend focused tests:
+
+- 4 files passed;
+- 103 tests passed.
+
+Frontend focused tests:
+
+- 2 files passed;
+- 31 tests passed.
+
+Type/build gates:
+
+- `@metasheet/core-backend` TypeScript build passed;
+- `@metasheet/web` `vue-tsc -b --noEmit` passed.
+
+## Coverage Notes
+
+Backend coverage includes:
+
+- subscription upsert;
+- unsubscribe;
+- list/status;
+- watcher notification enqueue;
+- actor suppression through `user_id <> actorId`;
+- single-record patch notification;
+- batch patch notification;
+- comment-created notification.
+
+Frontend coverage includes:
+
+- client URL encoding and status normalization;
+- subscribe/unsubscribe methods;
+- notification list normalization;
+- drawer watch-state loading;
+- drawer Watch/Watching toggle.
+
+## Non-Failing Noise
+
+`RecordWriteService` tests intentionally log post-commit hook failures in existing test cases that assert failed hooks do not fail the write.
+
+Frontend Vitest printed `WebSocket server error: Port is already in use`; tests still completed successfully.
+
+## Follow-Up
+
+- Add OpenAPI source/dist entries for the new subscription APIs in a contract sweep.
+- Add notification center UI and read/mark-read APIs if product wants watcher notifications surfaced outside the record drawer.

--- a/docs/development/multitable-record-subscription-verification-20260503.md
+++ b/docs/development/multitable-record-subscription-verification-20260503.md
@@ -13,6 +13,9 @@ pnpm --filter @metasheet/core-backend exec vitest run \
   tests/unit/record-write-service.test.ts \
   tests/unit/comment-service.test.ts \
   --reporter=dot
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/integration/multitable-record-patch.api.test.ts \
+  --reporter=dot
 pnpm --filter @metasheet/web exec vitest run \
   tests/multitable-record-drawer.spec.ts \
   tests/multitable-client.spec.ts \
@@ -32,6 +35,11 @@ Frontend focused tests:
 
 - 2 files passed;
 - 31 tests passed.
+
+Record patch integration regression:
+
+- 1 file passed;
+- 6 tests passed.
 
 Type/build gates:
 
@@ -64,6 +72,10 @@ Frontend coverage includes:
 `RecordWriteService` tests intentionally log post-commit hook failures in existing test cases that assert failed hooks do not fail the write.
 
 Frontend Vitest printed `WebSocket server error: Port is already in use`; tests still completed successfully.
+
+## CI Follow-Up
+
+PR #1290 initially failed `test (18.x)` in `tests/integration/multitable-record-patch.api.test.ts` because the mocked SQL fixture did not know about the new `meta_record_subscriptions` lookup and notification insert. The route returned 500 only in the test harness. The fixture now returns empty watcher rows for those legacy route extraction scenarios, and the targeted integration file passes locally.
 
 ## Follow-Up
 

--- a/packages/core-backend/src/db/migrations/zzzz20260505103000_create_meta_record_subscriptions.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260505103000_create_meta_record_subscriptions.ts
@@ -1,0 +1,61 @@
+import { sql, type Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`CREATE EXTENSION IF NOT EXISTS pgcrypto`.execute(db)
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS meta_record_subscriptions (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      sheet_id text NOT NULL,
+      record_id text NOT NULL,
+      user_id text NOT NULL,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now(),
+      UNIQUE (sheet_id, record_id, user_id)
+    )
+  `.execute(db)
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS meta_record_subscription_notifications (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      sheet_id text NOT NULL,
+      record_id text NOT NULL,
+      user_id text NOT NULL,
+      event_type text NOT NULL CHECK (event_type IN ('record.updated', 'comment.created')),
+      actor_id text,
+      revision_id uuid,
+      comment_id text,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      read_at timestamptz
+    )
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_meta_record_subscriptions_record
+    ON meta_record_subscriptions(sheet_id, record_id)
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_meta_record_subscriptions_user
+    ON meta_record_subscriptions(user_id, updated_at DESC)
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_meta_record_subscription_notifications_user
+    ON meta_record_subscription_notifications(user_id, created_at DESC)
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_meta_record_subscription_notifications_record
+    ON meta_record_subscription_notifications(sheet_id, record_id, created_at DESC)
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP INDEX IF EXISTS idx_meta_record_subscription_notifications_record`.execute(db)
+  await sql`DROP INDEX IF EXISTS idx_meta_record_subscription_notifications_user`.execute(db)
+  await sql`DROP INDEX IF EXISTS idx_meta_record_subscriptions_user`.execute(db)
+  await sql`DROP INDEX IF EXISTS idx_meta_record_subscriptions_record`.execute(db)
+  await sql`DROP TABLE IF EXISTS meta_record_subscription_notifications`.execute(db)
+  await sql`DROP TABLE IF EXISTS meta_record_subscriptions`.execute(db)
+}

--- a/packages/core-backend/src/multitable/record-history-service.ts
+++ b/packages/core-backend/src/multitable/record-history-service.ts
@@ -35,7 +35,8 @@ export interface RecordRevisionEntry {
   createdAt: string
 }
 
-export async function recordRecordRevision(query: QueryFn, input: RecordRevisionInput): Promise<void> {
+export async function recordRecordRevision(query: QueryFn, input: RecordRevisionInput): Promise<string> {
+  const id = randomUUID()
   const changedFieldIds = Array.from(new Set((input.changedFieldIds ?? []).filter(Boolean)))
   await query(
     `INSERT INTO meta_record_revisions (
@@ -49,10 +50,10 @@ export async function recordRecordRevision(query: QueryFn, input: RecordRevision
        changed_field_ids,
        patch,
        snapshot
-     )
+    )
      VALUES ($1::uuid, $2, $3, $4, $5, $6, $7, $8::text[], $9::jsonb, $10::jsonb)`,
     [
-      randomUUID(),
+      id,
       input.sheetId,
       input.recordId,
       input.version,
@@ -64,6 +65,7 @@ export async function recordRecordRevision(query: QueryFn, input: RecordRevision
       input.snapshot === undefined ? null : JSON.stringify(input.snapshot),
     ],
   )
+  return id
 }
 
 export async function listRecordRevisions(

--- a/packages/core-backend/src/multitable/record-service.ts
+++ b/packages/core-backend/src/multitable/record-service.ts
@@ -28,6 +28,7 @@ import {
 import { isFieldAlwaysReadOnly, isFieldPermissionHidden } from './permission-derivation'
 import { publishMultitableSheetRealtime } from './realtime-publish'
 import { recordRecordRevision } from './record-history-service'
+import { notifyRecordSubscribers } from './record-subscription-service'
 import { ensureRecordWriteAllowed, type AccessInfo, type SheetPermissionScope } from './sheet-capabilities'
 
 export type QueryFn = (
@@ -817,7 +818,7 @@ export class RecordService {
           [JSON.stringify(patch), recordId, sheetId, patchActorId],
         )
         nextVersion = Number((updateRes.rows[0] as { version?: unknown } | undefined)?.version ?? serverVersion)
-        await recordRecordRevision(query, {
+        const revisionId = await recordRecordRevision(query, {
           sheetId,
           recordId,
           version: nextVersion,
@@ -827,6 +828,13 @@ export class RecordService {
           changedFieldIds: Object.keys(patch),
           patch,
           snapshot: { ...previousData, ...patch },
+        })
+        await notifyRecordSubscribers(query, {
+          sheetId,
+          recordId,
+          eventType: 'record.updated',
+          actorId: patchActorId,
+          revisionId,
         })
       } else {
         nextVersion = serverVersion

--- a/packages/core-backend/src/multitable/record-subscription-service.ts
+++ b/packages/core-backend/src/multitable/record-subscription-service.ts
@@ -1,0 +1,279 @@
+import { randomUUID } from 'crypto'
+import { sql, type Kysely } from 'kysely'
+
+export type QueryFn = (
+  sql: string,
+  params?: unknown[],
+) => Promise<{ rows: unknown[]; rowCount?: number | null }>
+
+export type RecordSubscriptionEventType = 'record.updated' | 'comment.created'
+
+export interface RecordSubscription {
+  id: string
+  sheetId: string
+  recordId: string
+  userId: string
+  createdAt: string
+  updatedAt: string
+}
+
+export interface RecordSubscriptionNotification {
+  id: string
+  sheetId: string
+  recordId: string
+  userId: string
+  eventType: RecordSubscriptionEventType
+  actorId: string | null
+  revisionId: string | null
+  commentId: string | null
+  createdAt: string
+  readAt: string | null
+}
+
+export async function subscribeRecord(
+  query: QueryFn,
+  input: { sheetId: string; recordId: string; userId: string },
+): Promise<RecordSubscription> {
+  const result = await query(
+    `INSERT INTO meta_record_subscriptions (id, sheet_id, record_id, user_id, created_at, updated_at)
+     VALUES ($1::uuid, $2, $3, $4, now(), now())
+     ON CONFLICT (sheet_id, record_id, user_id)
+     DO UPDATE SET updated_at = now()
+     RETURNING id, sheet_id, record_id, user_id, created_at, updated_at`,
+    [randomUUID(), input.sheetId, input.recordId, input.userId],
+  )
+  return serializeSubscription((result.rows as Array<Record<string, unknown>>)[0])
+}
+
+export async function unsubscribeRecord(
+  query: QueryFn,
+  input: { sheetId: string; recordId: string; userId: string },
+): Promise<boolean> {
+  const result = await query(
+    `DELETE FROM meta_record_subscriptions
+     WHERE sheet_id = $1 AND record_id = $2 AND user_id = $3`,
+    [input.sheetId, input.recordId, input.userId],
+  )
+  return Number(result.rowCount ?? 0) > 0
+}
+
+export async function listRecordSubscriptions(
+  query: QueryFn,
+  input: { sheetId: string; recordId: string },
+): Promise<RecordSubscription[]> {
+  const result = await query(
+    `SELECT id, sheet_id, record_id, user_id, created_at, updated_at
+     FROM meta_record_subscriptions
+     WHERE sheet_id = $1 AND record_id = $2
+     ORDER BY updated_at DESC, user_id ASC`,
+    [input.sheetId, input.recordId],
+  )
+  return (result.rows as Array<Record<string, unknown>>).map(serializeSubscription)
+}
+
+export async function getRecordSubscriptionStatus(
+  query: QueryFn,
+  input: { sheetId: string; recordId: string; userId: string },
+): Promise<{ subscribed: boolean; subscription: RecordSubscription | null }> {
+  const result = await query(
+    `SELECT id, sheet_id, record_id, user_id, created_at, updated_at
+     FROM meta_record_subscriptions
+     WHERE sheet_id = $1 AND record_id = $2 AND user_id = $3`,
+    [input.sheetId, input.recordId, input.userId],
+  )
+  const row = (result.rows as Array<Record<string, unknown>>)[0]
+  return {
+    subscribed: !!row,
+    subscription: row ? serializeSubscription(row) : null,
+  }
+}
+
+export async function notifyRecordSubscribers(
+  query: QueryFn,
+  input: {
+    sheetId: string
+    recordId: string
+    eventType: RecordSubscriptionEventType
+    actorId?: string | null
+    revisionId?: string | null
+    commentId?: string | null
+  },
+): Promise<{ inserted: number; userIds: string[] }> {
+  const subscriptions = await query(
+    `SELECT user_id
+     FROM meta_record_subscriptions
+     WHERE sheet_id = $1 AND record_id = $2
+       AND ($3::text IS NULL OR user_id <> $3::text)
+     ORDER BY user_id ASC`,
+    [input.sheetId, input.recordId, input.actorId ?? null],
+  )
+  const userIds = (subscriptions.rows as Array<Record<string, unknown>>)
+    .map((row) => (typeof row.user_id === 'string' ? row.user_id : ''))
+    .filter((userId) => userId.length > 0)
+
+  if (userIds.length === 0) return { inserted: 0, userIds: [] }
+
+  const values = userIds.map((userId) => ({
+    id: randomUUID(),
+    sheetId: input.sheetId,
+    recordId: input.recordId,
+    userId,
+    eventType: input.eventType,
+    actorId: input.actorId ?? null,
+    revisionId: input.revisionId ?? null,
+    commentId: input.commentId ?? null,
+  }))
+
+  await query(
+    `INSERT INTO meta_record_subscription_notifications (
+       id,
+       sheet_id,
+       record_id,
+       user_id,
+       event_type,
+       actor_id,
+       revision_id,
+       comment_id
+     )
+     SELECT
+       item.id::uuid,
+       item.sheet_id,
+       item.record_id,
+       item.user_id,
+       item.event_type,
+       item.actor_id,
+       item.revision_id::uuid,
+       item.comment_id
+     FROM jsonb_to_recordset($1::jsonb) AS item(
+       id text,
+       sheet_id text,
+       record_id text,
+       user_id text,
+       event_type text,
+       actor_id text,
+       revision_id text,
+       comment_id text
+     )`,
+    [JSON.stringify(values.map((item) => ({
+      id: item.id,
+      sheet_id: item.sheetId,
+      record_id: item.recordId,
+      user_id: item.userId,
+      event_type: item.eventType,
+      actor_id: item.actorId,
+      revision_id: item.revisionId,
+      comment_id: item.commentId,
+    })))],
+  )
+
+  return { inserted: userIds.length, userIds }
+}
+
+export async function notifyRecordSubscribersWithKysely(
+  db: Kysely<any>,
+  input: {
+    sheetId: string
+    recordId: string
+    eventType: RecordSubscriptionEventType
+    actorId?: string | null
+    revisionId?: string | null
+    commentId?: string | null
+  },
+): Promise<{ inserted: number; userIds: string[] }> {
+  const subscriptionRows = await sql<{ user_id: string }>`
+    SELECT user_id
+    FROM meta_record_subscriptions
+    WHERE sheet_id = ${input.sheetId}
+      AND record_id = ${input.recordId}
+      AND (${input.actorId ?? null}::text IS NULL OR user_id <> ${input.actorId ?? null}::text)
+    ORDER BY user_id ASC
+  `.execute(db)
+
+  const userIds = subscriptionRows.rows
+    .map((row) => (typeof row.user_id === 'string' ? row.user_id : ''))
+    .filter((userId) => userId.length > 0)
+
+  if (userIds.length === 0) return { inserted: 0, userIds: [] }
+
+  await sql`
+    INSERT INTO meta_record_subscription_notifications (
+      id,
+      sheet_id,
+      record_id,
+      user_id,
+      event_type,
+      actor_id,
+      revision_id,
+      comment_id
+    )
+    SELECT
+      gen_random_uuid(),
+      ${input.sheetId},
+      ${input.recordId},
+      user_id,
+      ${input.eventType},
+      ${input.actorId ?? null},
+      ${input.revisionId ?? null}::uuid,
+      ${input.commentId ?? null}
+    FROM unnest(${userIds}::text[]) AS user_id
+  `.execute(db)
+
+  return { inserted: userIds.length, userIds }
+}
+
+export async function listRecordSubscriptionNotifications(
+  query: QueryFn,
+  input: { userId: string; sheetId?: string; recordId?: string; limit?: number; offset?: number },
+): Promise<RecordSubscriptionNotification[]> {
+  const limit = Math.min(Math.max(Number(input.limit ?? 50), 1), 100)
+  const offset = Math.max(Number(input.offset ?? 0), 0)
+  const params: unknown[] = [input.userId, limit, offset]
+  const filters: string[] = ['user_id = $1']
+  if (input.sheetId) {
+    params.push(input.sheetId)
+    filters.push(`sheet_id = $${params.length}`)
+  }
+  if (input.recordId) {
+    params.push(input.recordId)
+    filters.push(`record_id = $${params.length}`)
+  }
+  const result = await query(
+    `SELECT id, sheet_id, record_id, user_id, event_type, actor_id, revision_id, comment_id, created_at, read_at
+     FROM meta_record_subscription_notifications
+     WHERE ${filters.join(' AND ')}
+     ORDER BY created_at DESC, id DESC
+     LIMIT $2 OFFSET $3`,
+    params,
+  )
+  return (result.rows as Array<Record<string, unknown>>).map(serializeNotification)
+}
+
+function serializeSubscription(row: Record<string, unknown>): RecordSubscription {
+  return {
+    id: String(row.id),
+    sheetId: String(row.sheet_id),
+    recordId: String(row.record_id),
+    userId: String(row.user_id),
+    createdAt: serializeTime(row.created_at),
+    updatedAt: serializeTime(row.updated_at),
+  }
+}
+
+function serializeNotification(row: Record<string, unknown>): RecordSubscriptionNotification {
+  return {
+    id: String(row.id),
+    sheetId: String(row.sheet_id),
+    recordId: String(row.record_id),
+    userId: String(row.user_id),
+    eventType: row.event_type === 'comment.created' ? 'comment.created' : 'record.updated',
+    actorId: typeof row.actor_id === 'string' ? row.actor_id : null,
+    revisionId: typeof row.revision_id === 'string' ? row.revision_id : null,
+    commentId: typeof row.comment_id === 'string' ? row.comment_id : null,
+    createdAt: serializeTime(row.created_at),
+    readAt: row.read_at === null || row.read_at === undefined ? null : serializeTime(row.read_at),
+  }
+}
+
+function serializeTime(value: unknown): string {
+  return value instanceof Date ? value.toISOString() : String(value ?? '')
+}

--- a/packages/core-backend/src/multitable/record-write-service.ts
+++ b/packages/core-backend/src/multitable/record-write-service.ts
@@ -24,6 +24,7 @@ import {
 } from './post-commit-hooks'
 import { BATCH1_FIELD_TYPES, coerceBatch1Value, normalizeMultiSelectValue, validateLongTextValue } from './field-codecs'
 import { recordRecordRevision } from './record-history-service'
+import { notifyRecordSubscribers } from './record-subscription-service'
 
 // ---------------------------------------------------------------------------
 // Shared types (mirrors the ones in univer-meta.ts to avoid coupling)
@@ -603,7 +604,7 @@ export class RecordWriteService {
           throw new RecordNotFoundError(`Record not found: ${recordId}`)
         }
         const nextVersion = Number((updateRes.rows[0] as any).version)
-        await recordRecordRevision(query, {
+        const revisionId = await recordRecordRevision(query, {
           sheetId,
           recordId,
           version: nextVersion,
@@ -613,6 +614,13 @@ export class RecordWriteService {
           changedFieldIds: Object.keys(patch),
           patch,
           snapshot: { ...previousData, ...patch },
+        })
+        await notifyRecordSubscribers(query, {
+          sheetId,
+          recordId,
+          eventType: 'record.updated',
+          actorId,
+          revisionId,
         })
 
         // Sync link table

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -135,6 +135,13 @@ import {
 } from '../multitable/post-commit-hooks'
 import { listRecordRevisions } from '../multitable/record-history-service'
 import {
+  getRecordSubscriptionStatus,
+  listRecordSubscriptionNotifications,
+  listRecordSubscriptions,
+  subscribeRecord,
+  unsubscribeRecord,
+} from '../multitable/record-subscription-service'
+import {
   CONDITIONAL_FORMATTING_RULE_LIMIT,
   sanitizeConditionalFormattingRules,
 } from '../multitable/conditional-formatting-service'
@@ -1951,6 +1958,50 @@ function sendForbidden(res: Response, message = 'Insufficient permissions') {
   return res.status(403).json({ ok: false, error: { code: 'FORBIDDEN', message } })
 }
 
+async function requireRecordReadable(
+  req: Request,
+  query: QueryFn,
+  sheetId: string,
+  recordId: string,
+): Promise<{ access: ResolvedRequestAccess } | { status: number; body: unknown }> {
+  const recordCheck = await query(
+    'SELECT id, sheet_id FROM meta_records WHERE id = $1 AND sheet_id = $2',
+    [recordId, sheetId],
+  )
+  if (recordCheck.rows.length === 0) {
+    return {
+      status: 404,
+      body: { ok: false, error: { code: 'NOT_FOUND', message: `Record not found: ${recordId}` } },
+    }
+  }
+
+  const { access, capabilities } = await resolveSheetReadableCapabilities(req, query, sheetId)
+  if (!access.userId) {
+    return { status: 401, body: { error: 'Authentication required' } }
+  }
+  if (!capabilities.canRead) {
+    return {
+      status: 403,
+      body: { ok: false, error: { code: 'FORBIDDEN', message: 'Insufficient permissions' } },
+    }
+  }
+
+  if (!access.isAdminRole) {
+    const hasRecordPerms = await hasRecordPermissionAssignments(query, sheetId)
+    if (hasRecordPerms) {
+      const recordScopeMap = await loadRecordPermissionScopeMap(query, sheetId, [recordId], access.userId)
+      if (recordScopeMap.size > 0 && !deriveRecordPermissions(recordId, capabilities, recordScopeMap).canRead) {
+        return {
+          status: 403,
+          body: { ok: false, error: { code: 'FORBIDDEN', message: 'Insufficient permissions' } },
+        }
+      }
+    }
+  }
+
+  return { access }
+}
+
 type FieldMutationGuard = {
   type: UniverMetaField['type']
   options?: string[]
@@ -3677,6 +3728,124 @@ export function univerMetaRouter(): Router {
       if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
       console.error('[univer-meta] list record history failed:', err)
       return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to list record history' } })
+    }
+  })
+
+  router.get('/sheets/:sheetId/records/:recordId/subscriptions', async (req: Request, res: Response) => {
+    const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId.trim() : ''
+    const recordId = typeof req.params.recordId === 'string' ? req.params.recordId.trim() : ''
+    if (!sheetId || !recordId) {
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId and recordId are required' } })
+    }
+
+    try {
+      const pool = poolManager.get()
+      const readable = await requireRecordReadable(req, pool.query.bind(pool), sheetId, recordId)
+      if ('status' in readable) return res.status(readable.status).json(readable.body)
+
+      const [items, status] = await Promise.all([
+        listRecordSubscriptions(pool.query.bind(pool), { sheetId, recordId }),
+        getRecordSubscriptionStatus(pool.query.bind(pool), { sheetId, recordId, userId: readable.access.userId }),
+      ])
+      return res.json({
+        ok: true,
+        data: {
+          items,
+          subscribed: status.subscribed,
+          subscription: status.subscription,
+        },
+      })
+    } catch (err) {
+      if (isUndefinedTableError(err, 'meta_record_subscriptions')) {
+        return res.json({ ok: true, data: { items: [], subscribed: false, subscription: null } })
+      }
+      const hint = getDbNotReadyMessage(err)
+      if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
+      console.error('[univer-meta] list record subscriptions failed:', err)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to list record subscriptions' } })
+    }
+  })
+
+  router.put('/sheets/:sheetId/records/:recordId/subscriptions/me', async (req: Request, res: Response) => {
+    const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId.trim() : ''
+    const recordId = typeof req.params.recordId === 'string' ? req.params.recordId.trim() : ''
+    if (!sheetId || !recordId) {
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId and recordId are required' } })
+    }
+
+    try {
+      const pool = poolManager.get()
+      const readable = await requireRecordReadable(req, pool.query.bind(pool), sheetId, recordId)
+      if ('status' in readable) return res.status(readable.status).json(readable.body)
+
+      const subscription = await subscribeRecord(pool.query.bind(pool), {
+        sheetId,
+        recordId,
+        userId: readable.access.userId,
+      })
+      return res.json({ ok: true, data: { subscribed: true, subscription } })
+    } catch (err) {
+      const hint = getDbNotReadyMessage(err)
+      if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
+      console.error('[univer-meta] subscribe record failed:', err)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to subscribe record' } })
+    }
+  })
+
+  router.delete('/sheets/:sheetId/records/:recordId/subscriptions/me', async (req: Request, res: Response) => {
+    const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId.trim() : ''
+    const recordId = typeof req.params.recordId === 'string' ? req.params.recordId.trim() : ''
+    if (!sheetId || !recordId) {
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId and recordId are required' } })
+    }
+
+    try {
+      const pool = poolManager.get()
+      const readable = await requireRecordReadable(req, pool.query.bind(pool), sheetId, recordId)
+      if ('status' in readable) return res.status(readable.status).json(readable.body)
+
+      await unsubscribeRecord(pool.query.bind(pool), {
+        sheetId,
+        recordId,
+        userId: readable.access.userId,
+      })
+      return res.json({ ok: true, data: { subscribed: false, subscription: null } })
+    } catch (err) {
+      const hint = getDbNotReadyMessage(err)
+      if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
+      console.error('[univer-meta] unsubscribe record failed:', err)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to unsubscribe record' } })
+    }
+  })
+
+  router.get('/record-subscription-notifications', async (req: Request, res: Response) => {
+    const limitParam = typeof req.query.limit === 'string' ? Number.parseInt(req.query.limit, 10) : 50
+    const offsetParam = typeof req.query.offset === 'string' ? Number.parseInt(req.query.offset, 10) : 0
+    const limit = Number.isFinite(limitParam) ? Math.min(Math.max(limitParam, 1), 100) : 50
+    const offset = Number.isFinite(offsetParam) ? Math.max(offsetParam, 0) : 0
+    const sheetId = typeof req.query.sheetId === 'string' && req.query.sheetId.trim() ? req.query.sheetId.trim() : undefined
+    const recordId = typeof req.query.recordId === 'string' && req.query.recordId.trim() ? req.query.recordId.trim() : undefined
+
+    try {
+      const pool = poolManager.get()
+      const access = await resolveRequestAccess(req)
+      if (!access.userId) return res.status(401).json({ error: 'Authentication required' })
+      const items = await listRecordSubscriptionNotifications(pool.query.bind(pool), {
+        userId: access.userId,
+        sheetId,
+        recordId,
+        limit,
+        offset,
+      })
+      return res.json({ ok: true, data: { items, limit, offset } })
+    } catch (err) {
+      if (isUndefinedTableError(err, 'meta_record_subscription_notifications')) {
+        return res.json({ ok: true, data: { items: [], limit, offset } })
+      }
+      const hint = getDbNotReadyMessage(err)
+      if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
+      console.error('[univer-meta] list record subscription notifications failed:', err)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to list record subscription notifications' } })
     }
   })
 

--- a/packages/core-backend/src/services/CommentService.ts
+++ b/packages/core-backend/src/services/CommentService.ts
@@ -13,6 +13,7 @@ import type { CollabService } from './CollabService'
 import { db } from '../db/db'
 import { nowTimestamp } from '../db/type-helpers'
 import { buildCommentInboxRoom, buildCommentRecordRoom, buildCommentSheetRoom } from './commentRooms'
+import { notifyRecordSubscribersWithKysely } from '../multitable/record-subscription-service'
 
 export class CommentValidationError extends Error {
   constructor(message: string) {
@@ -295,6 +296,17 @@ export class CommentService {
       if (mentionUserId && mentionUserId !== data.authorId) {
         this.collabService.sendTo(mentionUserId, 'comment:mention', createdPayload)
       }
+    }
+    try {
+      await notifyRecordSubscribersWithKysely(db, {
+        sheetId: data.spreadsheetId,
+        recordId: data.rowId,
+        eventType: 'comment.created',
+        actorId: data.authorId,
+        commentId: comment.id,
+      })
+    } catch (error) {
+      this.logger.warn('Failed to notify record subscribers for comment', error as Error)
     }
 
     return comment

--- a/packages/core-backend/tests/integration/multitable-record-patch.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-record-patch.api.test.ts
@@ -124,6 +124,12 @@ describe('Multitable PATCH /records/:recordId (record-service extraction)', () =
         if (sql.includes('INSERT INTO meta_record_revisions')) {
           return { rows: [], rowCount: 1 }
         }
+        if (sql.includes('FROM meta_record_subscriptions')) {
+          return { rows: [] }
+        }
+        if (sql.includes('INSERT INTO meta_record_subscription_notifications')) {
+          return { rows: [], rowCount: 0 }
+        }
         if (
           sql.includes('FROM meta_records WHERE id = $1 AND sheet_id = $2') &&
           sql.includes('SELECT id, version, data')
@@ -331,6 +337,12 @@ describe('Multitable PATCH /records/:recordId (record-service extraction)', () =
         if (sql.includes('INSERT INTO meta_record_revisions')) {
           return { rows: [], rowCount: 1 }
         }
+        if (sql.includes('FROM meta_record_subscriptions')) {
+          return { rows: [] }
+        }
+        if (sql.includes('INSERT INTO meta_record_subscription_notifications')) {
+          return { rows: [], rowCount: 0 }
+        }
         if (sql.includes('SELECT foreign_record_id FROM meta_links WHERE field_id = $1 AND record_id = $2')) {
           return { rows: [{ foreign_record_id: 'rec_c1' }, { foreign_record_id: 'rec_c2' }] }
         }
@@ -435,6 +447,12 @@ describe('Multitable PATCH /records/:recordId (record-service extraction)', () =
         }
         if (sql.includes('INSERT INTO meta_record_revisions')) {
           return { rows: [], rowCount: 1 }
+        }
+        if (sql.includes('FROM meta_record_subscriptions')) {
+          return { rows: [] }
+        }
+        if (sql.includes('INSERT INTO meta_record_subscription_notifications')) {
+          return { rows: [], rowCount: 0 }
         }
         if (
           sql.includes('FROM meta_records WHERE id = $1 AND sheet_id = $2') &&

--- a/packages/core-backend/tests/unit/comment-service.test.ts
+++ b/packages/core-backend/tests/unit/comment-service.test.ts
@@ -89,6 +89,11 @@ const mockLogger: ILogger = {
   debug: vi.fn(),
 }
 
+const mockNotifyRecordSubscribersWithKysely = vi.fn()
+vi.mock('../../src/multitable/record-subscription-service', () => ({
+  notifyRecordSubscribersWithKysely: (...args: unknown[]) => mockNotifyRecordSubscribersWithKysely(...args),
+}))
+
 // ── Import SUT after mocks ──────────────────────────────────────────────────
 
 import { CommentService, CommentValidationError, CommentNotFoundError, CommentAccessError, CommentConflictError } from '../../src/services/CommentService'
@@ -149,6 +154,7 @@ describe('CommentService', () => {
     // Clear result queues
     queueExec.length = 0
     queueTakeFirst.length = 0
+    mockNotifyRecordSubscribersWithKysely.mockResolvedValue({ inserted: 0, userIds: [] })
     service = new CommentService(
       mockCollabService as unknown as CollabService,
       mockLogger,
@@ -179,6 +185,31 @@ describe('CommentService', () => {
       })
 
       expect(comment.mentions).toEqual(['user-123'])
+    })
+
+    it('notifies record watchers for new comments and suppresses the author in the notifier', async () => {
+      pushExec([]) // insert
+      pushTakeFirst(makeCommentRow({
+        id: 'cmt_watch',
+        spreadsheet_id: 'sheet-1',
+        row_id: 'row-1',
+      }))
+      pushExec([]) // markCommentRead
+
+      await service.createComment({
+        spreadsheetId: 'sheet-1',
+        rowId: 'row-1',
+        content: 'Watcher update',
+        authorId: 'user-author',
+      })
+
+      expect(mockNotifyRecordSubscribersWithKysely).toHaveBeenCalledWith(expect.anything(), {
+        sheetId: 'sheet-1',
+        recordId: 'row-1',
+        eventType: 'comment.created',
+        actorId: 'user-author',
+        commentId: 'cmt_watch',
+      })
     })
 
     it('handles multiple mentions in one content string', async () => {

--- a/packages/core-backend/tests/unit/record-service.test.ts
+++ b/packages/core-backend/tests/unit/record-service.test.ts
@@ -63,6 +63,12 @@ function createMockPool(
     if (sql.includes('INSERT INTO meta_record_revisions')) {
       return responses.INSERT_REVISION ?? { rows: [], rowCount: 1 }
     }
+    if (sql.includes('FROM meta_record_subscriptions')) {
+      return responses.SELECT_RECORD_SUBSCRIPTIONS ?? { rows: [] }
+    }
+    if (sql.includes('INSERT INTO meta_record_subscription_notifications')) {
+      return responses.INSERT_RECORD_SUBSCRIPTION_NOTIFICATIONS ?? { rows: [], rowCount: 1 }
+    }
     if (sql.includes('INSERT INTO meta_links')) {
       return responses.INSERT_LINK ?? { rows: [], rowCount: 1 }
     }
@@ -284,6 +290,35 @@ describe('RecordService', () => {
         [],
         JSON.stringify({}),
         JSON.stringify({ fld_title: 'Before' }),
+      ]),
+    )
+  })
+
+  it('notifies record subscribers after a successful single-record patch and suppresses the actor', async () => {
+    pool = createMockPool({
+      SELECT_RECORD_SUBSCRIPTIONS: {
+        rows: [{ user_id: 'watcher_1' }],
+      },
+    })
+    const service = new RecordService(pool, eventBus as any)
+
+    await service.patchRecord({
+      recordId: 'rec_existing',
+      sheetId: 'sheet_ops',
+      data: { fld_title: 'After' },
+      actorId: 'user_editor',
+      access: { userId: 'user_editor', permissions: [], isAdminRole: false },
+      capabilities: fullCapabilities,
+    })
+
+    expect(pool.queryMock).toHaveBeenCalledWith(
+      expect.stringContaining('FROM meta_record_subscriptions'),
+      ['sheet_ops', 'rec_existing', 'user_editor'],
+    )
+    expect(pool.queryMock).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO meta_record_subscription_notifications'),
+      expect.arrayContaining([
+        expect.stringContaining('"user_id":"watcher_1"'),
       ]),
     )
   })

--- a/packages/core-backend/tests/unit/record-subscription-service.test.ts
+++ b/packages/core-backend/tests/unit/record-subscription-service.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  getRecordSubscriptionStatus,
+  listRecordSubscriptionNotifications,
+  listRecordSubscriptions,
+  notifyRecordSubscribers,
+  subscribeRecord,
+  unsubscribeRecord,
+} from '../../src/multitable/record-subscription-service'
+
+describe('record-subscription-service', () => {
+  it('upserts record subscriptions', async () => {
+    const query = vi.fn().mockResolvedValue({
+      rows: [{
+        id: 'sub_1',
+        sheet_id: 'sheet_1',
+        record_id: 'rec_1',
+        user_id: 'user_1',
+        created_at: '2026-05-05T00:00:00.000Z',
+        updated_at: '2026-05-05T00:00:00.000Z',
+      }],
+    })
+
+    const subscription = await subscribeRecord(query, {
+      sheetId: 'sheet_1',
+      recordId: 'rec_1',
+      userId: 'user_1',
+    })
+
+    expect(subscription).toEqual(expect.objectContaining({
+      id: 'sub_1',
+      sheetId: 'sheet_1',
+      recordId: 'rec_1',
+      userId: 'user_1',
+    }))
+    expect(query).toHaveBeenCalledWith(
+      expect.stringContaining('ON CONFLICT (sheet_id, record_id, user_id)'),
+      [expect.any(String), 'sheet_1', 'rec_1', 'user_1'],
+    )
+  })
+
+  it('deletes current user subscription', async () => {
+    const query = vi.fn().mockResolvedValue({ rows: [], rowCount: 1 })
+
+    await expect(unsubscribeRecord(query, {
+      sheetId: 'sheet_1',
+      recordId: 'rec_1',
+      userId: 'user_1',
+    })).resolves.toBe(true)
+  })
+
+  it('lists subscriptions and current user status', async () => {
+    const row = {
+      id: 'sub_1',
+      sheet_id: 'sheet_1',
+      record_id: 'rec_1',
+      user_id: 'user_1',
+      created_at: new Date('2026-05-05T00:00:00.000Z'),
+      updated_at: new Date('2026-05-05T00:00:00.000Z'),
+    }
+    const query = vi.fn()
+      .mockResolvedValueOnce({ rows: [row] })
+      .mockResolvedValueOnce({ rows: [row] })
+
+    await expect(listRecordSubscriptions(query, {
+      sheetId: 'sheet_1',
+      recordId: 'rec_1',
+    })).resolves.toHaveLength(1)
+    await expect(getRecordSubscriptionStatus(query, {
+      sheetId: 'sheet_1',
+      recordId: 'rec_1',
+      userId: 'user_1',
+    })).resolves.toEqual({
+      subscribed: true,
+      subscription: expect.objectContaining({ userId: 'user_1' }),
+    })
+  })
+
+  it('notifies watchers while suppressing the actor', async () => {
+    const query = vi.fn()
+      .mockResolvedValueOnce({ rows: [{ user_id: 'watcher_1' }, { user_id: 'watcher_2' }] })
+      .mockResolvedValueOnce({ rows: [], rowCount: 2 })
+
+    const result = await notifyRecordSubscribers(query, {
+      sheetId: 'sheet_1',
+      recordId: 'rec_1',
+      eventType: 'record.updated',
+      actorId: 'actor_1',
+      revisionId: '11111111-1111-1111-1111-111111111111',
+    })
+
+    expect(result).toEqual({ inserted: 2, userIds: ['watcher_1', 'watcher_2'] })
+    expect(query).toHaveBeenNthCalledWith(1, expect.stringContaining('user_id <> $3::text'), [
+      'sheet_1',
+      'rec_1',
+      'actor_1',
+    ])
+    expect(query).toHaveBeenNthCalledWith(2, expect.stringContaining('INSERT INTO meta_record_subscription_notifications'), [
+      expect.stringContaining('"event_type":"record.updated"'),
+    ])
+  })
+
+  it('lists current user record subscription notifications', async () => {
+    const query = vi.fn().mockResolvedValue({
+      rows: [{
+        id: 'note_1',
+        sheet_id: 'sheet_1',
+        record_id: 'rec_1',
+        user_id: 'user_1',
+        event_type: 'comment.created',
+        actor_id: 'actor_1',
+        revision_id: null,
+        comment_id: 'cmt_1',
+        created_at: '2026-05-05T00:00:00.000Z',
+        read_at: null,
+      }],
+    })
+
+    await expect(listRecordSubscriptionNotifications(query, {
+      userId: 'user_1',
+      sheetId: 'sheet_1',
+      recordId: 'rec_1',
+    })).resolves.toEqual([
+      expect.objectContaining({
+        id: 'note_1',
+        eventType: 'comment.created',
+        commentId: 'cmt_1',
+      }),
+    ])
+  })
+})

--- a/packages/core-backend/tests/unit/record-write-service.test.ts
+++ b/packages/core-backend/tests/unit/record-write-service.test.ts
@@ -75,6 +75,12 @@ function createMockPool(queryResponses: Record<string, { rows: unknown[] }> = {}
     if (sql.includes('INSERT INTO meta_record_revisions')) {
       return queryResponses['INSERT_REVISION'] ?? { rows: [], rowCount: 1 }
     }
+    if (sql.includes('FROM meta_record_subscriptions')) {
+      return queryResponses['SELECT_RECORD_SUBSCRIPTIONS'] ?? { rows: [] }
+    }
+    if (sql.includes('INSERT INTO meta_record_subscription_notifications')) {
+      return queryResponses['INSERT_RECORD_SUBSCRIPTION_NOTIFICATIONS'] ?? { rows: [], rowCount: 1 }
+    }
     if (sql.includes('SELECT id, version, data FROM meta_records')) {
       return queryResponses['SELECT_UPDATED'] ?? defaultQueryResponse
     }
@@ -207,6 +213,26 @@ describe('RecordWriteService', () => {
         kind: 'record-updated',
         recordIds: ['rec1'],
       }),
+    )
+  })
+
+  it('creates subscriber notifications for each updated record and skips the actor', async () => {
+    pool = createMockPool({
+      SELECT_RECORD_SUBSCRIPTIONS: { rows: [{ user_id: 'watcher_2' }] },
+    })
+    const service = new RecordWriteService(pool, eventBus as any, helpers)
+
+    await service.patchRecords(buildTestInput({ actorId: 'user_editor' }))
+
+    expect(pool.query).toHaveBeenCalledWith(
+      expect.stringContaining('FROM meta_record_subscriptions'),
+      ['sheet1', 'rec1', 'user_editor'],
+    )
+    expect(pool.query).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO meta_record_subscription_notifications'),
+      expect.arrayContaining([
+        expect.stringContaining('"user_id":"watcher_2"'),
+      ]),
     )
   })
 


### PR DESCRIPTION
## Summary
- add record subscription and durable watcher notification tables
- add record-scoped subscribe/unsubscribe/status APIs plus current-user notification listing
- enqueue watcher notifications from record patch and comment creation paths while suppressing the actor
- add drawer Watch/Watching control and typed API client methods
- mark Phase 6 TODO complete with development/verification docs

## Verification
- pnpm install --frozen-lockfile
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/record-subscription-service.test.ts tests/unit/record-service.test.ts tests/unit/record-write-service.test.ts tests/unit/comment-service.test.ts --reporter=dot
- pnpm --filter @metasheet/web exec vitest run tests/multitable-record-drawer.spec.ts tests/multitable-client.spec.ts --reporter=dot
- pnpm --filter @metasheet/core-backend build
- pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
- git diff --check origin/main..HEAD

## Docs
- docs/development/multitable-record-subscription-development-20260503.md
- docs/development/multitable-record-subscription-verification-20260503.md

## Deferred
- OpenAPI source/dist entries for these APIs should be added in the next contract sweep.
- Notification center UI and notification read/mark-read APIs are intentionally out of scope for this slice.