### PR TITLE
fix(multitable): keep record subscriptions best-effort

### DIFF
--- a/docs/development/multitable-record-subscription-ci-unblock-development-20260505.md
+++ b/docs/development/multitable-record-subscription-ci-unblock-development-20260505.md
@@ -1,0 +1,92 @@
+# Multitable Record Subscription CI Unblock Development
+
+Date: 2026-05-05
+Branch: `codex/multitable-record-subscriptions-fix-20260505`
+Target PR: #1290
+
+## Context
+
+PR #1290 added record-level watch subscriptions and durable watcher
+notifications. GitHub CI blocked on `test (18.x)` because existing
+`PATCH /records/:recordId` integration coverage began returning 500.
+
+The failure exposed a real production risk: watcher notification enqueue was
+awaited inside the authoritative record update transaction. A secondary
+notification failure could therefore fail or roll back an otherwise valid
+record update.
+
+Parallel review also found a privacy issue: the record subscription status
+endpoint returned every watcher subscription for a readable record, including
+other users' `userId` values. The drawer only needs the current user's watch
+state.
+
+## Changes
+
+### Post-Commit Notification Best Effort
+
+`record-subscription-service.ts` now exposes:
+
+- `NotifyRecordSubscribersInput`
+- `notifyRecordSubscribersBestEffort(...)`
+
+The strict `notifyRecordSubscribers(...)` function remains available for tests
+and callers that want failures surfaced. The new best-effort wrapper logs and
+returns `null` instead of throwing.
+
+`RecordService.patchRecord()` now:
+
+1. writes the record patch and revision inside the transaction;
+2. stores the watcher notification intent;
+3. commits the transaction;
+4. enqueues watcher notifications best-effort through the normal pool query.
+
+`RecordWriteService.patchRecords()` now follows the same pattern for batch
+patches: notification intents are collected during the transaction and flushed
+after commit.
+
+This keeps the authoritative record write path independent from the secondary
+watcher-notification side effect.
+
+### Subscription Status Privacy
+
+`GET /api/multitable/sheets/:sheetId/records/:recordId/subscriptions` now
+returns only:
+
+```json
+{
+  "subscribed": true,
+  "subscription": {
+    "id": "...",
+    "sheetId": "...",
+    "recordId": "...",
+    "userId": "current-user"
+  }
+}
+```
+
+It no longer returns `items` containing all watchers. The current frontend
+normalizer already treats `items` as optional, so no frontend behavior change is
+required for the drawer's Watch/Watching control.
+
+### Test Coverage
+
+Added a route-level privacy regression:
+
+- `packages/core-backend/tests/integration/multitable-record-subscriptions.api.test.ts`
+
+The test verifies that a readable record returns only the current user's status
+and does not execute the all-watchers listing query.
+
+Added best-effort unit coverage:
+
+- `packages/core-backend/tests/unit/record-subscription-service.test.ts`
+
+The test verifies that watcher notification enqueue failures resolve to `null`
+and log instead of throwing.
+
+## Deferred
+
+- OpenAPI source/dist contract entries remain deferred to the next contract
+  sweep, as already documented in PR #1290.
+- Notification center UI and read/mark-read APIs remain out of scope for this
+  slice.

--- a/docs/development/multitable-record-subscription-ci-unblock-verification-20260505.md
+++ b/docs/development/multitable-record-subscription-ci-unblock-verification-20260505.md
@@ -1,0 +1,101 @@
+# Multitable Record Subscription CI Unblock Verification
+
+Date: 2026-05-05
+Branch: `codex/multitable-record-subscriptions-fix-20260505`
+Target PR: #1290
+
+## CI Failure Reproduced
+
+GitHub CI for PR #1290 failed in `test (18.x)`:
+
+- `tests/integration/multitable-record-patch.api.test.ts`
+- 3 existing PATCH cases returned `500 Internal Server Error` instead of 200.
+
+Root cause: watcher notification enqueue queried
+`meta_record_subscriptions` inside the record update transaction. The existing
+PATCH integration fixtures did not include that secondary table, which surfaced
+the same production risk that deploy skew or notification table failure could
+break core record writes.
+
+## Commands Run
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+Focused backend regression and subscription coverage:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest --config vitest.config.ts run \
+  tests/integration/multitable-record-patch.api.test.ts \
+  tests/integration/multitable-record-subscriptions.api.test.ts \
+  tests/unit/record-subscription-service.test.ts \
+  tests/unit/record-service.test.ts \
+  tests/unit/record-write-service.test.ts \
+  tests/unit/comment-service.test.ts \
+  --reporter=dot
+```
+
+Result:
+
+- 6 files passed
+- 111 tests passed
+
+Frontend focused coverage:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/multitable-record-drawer.spec.ts \
+  tests/multitable-client.spec.ts \
+  --reporter=dot
+```
+
+Result:
+
+- 2 files passed
+- 31 tests passed
+
+Build/type gates:
+
+```bash
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+git diff --check
+```
+
+Result:
+
+- backend TypeScript build passed
+- web `vue-tsc` passed
+- whitespace check passed
+
+Full backend CI-style suite:
+
+```bash
+CI=true pnpm --filter @metasheet/core-backend test
+```
+
+Result:
+
+- 210 files passed
+- 9 files skipped
+- 2831 tests passed
+- 47 tests skipped
+
+## Notes
+
+- Existing `RecordWriteService` post-commit hook tests intentionally log failed
+  hook errors while asserting the write still succeeds.
+- Full backend tests log expected degraded-mode database errors when
+  environment-local tests initialize workflow services without a local
+  PostgreSQL database named after the OS user; the suite still exits 0.
+- Frontend Vitest printed `WebSocket server error: Port is already in use`;
+  both frontend test files still passed.
+
+## Acceptance
+
+- Core PATCH route no longer fails when watcher notification enqueue is absent
+  or unavailable.
+- Watcher notification enqueue remains durable when available.
+- Ordinary record readers can no longer enumerate all watchers for a record.
+- Existing drawer watch behavior is preserved.

--- a/packages/core-backend/src/multitable/record-service.ts
+++ b/packages/core-backend/src/multitable/record-service.ts
@@ -28,7 +28,10 @@ import {
 import { isFieldAlwaysReadOnly, isFieldPermissionHidden } from './permission-derivation'
 import { publishMultitableSheetRealtime } from './realtime-publish'
 import { recordRecordRevision } from './record-history-service'
-import { notifyRecordSubscribers } from './record-subscription-service'
+import {
+  notifyRecordSubscribersBestEffort,
+  type NotifyRecordSubscribersInput,
+} from './record-subscription-service'
 import { ensureRecordWriteAllowed, type AccessInfo, type SheetPermissionScope } from './sheet-capabilities'
 
 export type QueryFn = (
@@ -784,6 +787,7 @@ export class RecordService {
     }
 
     let nextVersion = 1
+    let pendingSubscriberNotification: NotifyRecordSubscribersInput | null = null
     await this.pool.transaction(async ({ query }) => {
       const currentRes = await query(
         'SELECT id, version, data, created_by FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE',
@@ -829,13 +833,13 @@ export class RecordService {
           patch,
           snapshot: { ...previousData, ...patch },
         })
-        await notifyRecordSubscribers(query, {
+        pendingSubscriberNotification = {
           sheetId,
           recordId,
           eventType: 'record.updated',
           actorId: patchActorId,
           revisionId,
-        })
+        }
       } else {
         nextVersion = serverVersion
       }
@@ -870,6 +874,14 @@ export class RecordService {
         }
       }
     })
+
+    if (pendingSubscriberNotification) {
+      await notifyRecordSubscribersBestEffort(
+        this.pool.query.bind(this.pool),
+        pendingSubscriberNotification,
+        'record-service',
+      )
+    }
 
     if (this.postCommitHooks.length > 0) {
       const context: RecordPostCommitContext = {

--- a/packages/core-backend/src/multitable/record-subscription-service.ts
+++ b/packages/core-backend/src/multitable/record-subscription-service.ts
@@ -30,6 +30,15 @@ export interface RecordSubscriptionNotification {
   readAt: string | null
 }
 
+export interface NotifyRecordSubscribersInput {
+  sheetId: string
+  recordId: string
+  eventType: RecordSubscriptionEventType
+  actorId?: string | null
+  revisionId?: string | null
+  commentId?: string | null
+}
+
 export async function subscribeRecord(
   query: QueryFn,
   input: { sheetId: string; recordId: string; userId: string },
@@ -90,14 +99,7 @@ export async function getRecordSubscriptionStatus(
 
 export async function notifyRecordSubscribers(
   query: QueryFn,
-  input: {
-    sheetId: string
-    recordId: string
-    eventType: RecordSubscriptionEventType
-    actorId?: string | null
-    revisionId?: string | null
-    commentId?: string | null
-  },
+  input: NotifyRecordSubscribersInput,
 ): Promise<{ inserted: number; userIds: string[] }> {
   const subscriptions = await query(
     `SELECT user_id
@@ -169,16 +171,22 @@ export async function notifyRecordSubscribers(
   return { inserted: userIds.length, userIds }
 }
 
+export async function notifyRecordSubscribersBestEffort(
+  query: QueryFn,
+  input: NotifyRecordSubscribersInput,
+  context = 'record-subscription',
+): Promise<{ inserted: number; userIds: string[] } | null> {
+  try {
+    return await notifyRecordSubscribers(query, input)
+  } catch (error) {
+    console.warn(`[${context}] Failed to notify record subscribers`, error)
+    return null
+  }
+}
+
 export async function notifyRecordSubscribersWithKysely(
   db: Kysely<any>,
-  input: {
-    sheetId: string
-    recordId: string
-    eventType: RecordSubscriptionEventType
-    actorId?: string | null
-    revisionId?: string | null
-    commentId?: string | null
-  },
+  input: NotifyRecordSubscribersInput,
 ): Promise<{ inserted: number; userIds: string[] }> {
   const subscriptionRows = await sql<{ user_id: string }>`
     SELECT user_id

--- a/packages/core-backend/src/multitable/record-write-service.ts
+++ b/packages/core-backend/src/multitable/record-write-service.ts
@@ -24,7 +24,10 @@ import {
 } from './post-commit-hooks'
 import { BATCH1_FIELD_TYPES, coerceBatch1Value, normalizeMultiSelectValue, validateLongTextValue } from './field-codecs'
 import { recordRecordRevision } from './record-history-service'
-import { notifyRecordSubscribers } from './record-subscription-service'
+import {
+  notifyRecordSubscribersBestEffort,
+  type NotifyRecordSubscribersInput,
+} from './record-subscription-service'
 
 // ---------------------------------------------------------------------------
 // Shared types (mirrors the ones in univer-meta.ts to avoid coupling)
@@ -478,6 +481,7 @@ export class RecordWriteService {
     // -----------------------------------------------------------------------
     // Step 1: DB transaction
     // -----------------------------------------------------------------------
+    const pendingSubscriberNotifications: NotifyRecordSubscribersInput[] = []
     const updates = await this.pool.transaction(async ({ query }) => {
       const updated: Array<{ recordId: string; version: number }> = []
 
@@ -615,7 +619,7 @@ export class RecordWriteService {
           patch,
           snapshot: { ...previousData, ...patch },
         })
-        await notifyRecordSubscribers(query, {
+        pendingSubscriberNotifications.push({
           sheetId,
           recordId,
           eventType: 'record.updated',
@@ -684,7 +688,18 @@ export class RecordWriteService {
     })
 
     // -----------------------------------------------------------------------
-    // Step 2: Post-commit hooks (best effort, immediately after commit)
+    // Step 2: Subscriber notifications (best effort, after commit)
+    // -----------------------------------------------------------------------
+    for (const notification of pendingSubscriberNotifications) {
+      await notifyRecordSubscribersBestEffort(
+        this.pool.query.bind(this.pool),
+        notification,
+        'record-write',
+      )
+    }
+
+    // -----------------------------------------------------------------------
+    // Step 3: Post-commit hooks (best effort, immediately after commit)
     // -----------------------------------------------------------------------
     if (this.postCommitHooks.length > 0 && updates.length > 0) {
       const context: RecordPostCommitContext = {
@@ -706,7 +721,7 @@ export class RecordWriteService {
     }
 
     // -----------------------------------------------------------------------
-    // Step 3: Computed field recalculation (lookup / rollup)
+    // Step 4: Computed field recalculation (lookup / rollup)
     // -----------------------------------------------------------------------
     let computedRecords: Array<{ recordId: string; data: Record<string, unknown> }> | undefined
     let updatedRowsForSummaries: UniverMetaRecord[] = []

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -137,7 +137,6 @@ import { listRecordRevisions } from '../multitable/record-history-service'
 import {
   getRecordSubscriptionStatus,
   listRecordSubscriptionNotifications,
-  listRecordSubscriptions,
   subscribeRecord,
   unsubscribeRecord,
 } from '../multitable/record-subscription-service'
@@ -3743,21 +3742,21 @@ export function univerMetaRouter(): Router {
       const readable = await requireRecordReadable(req, pool.query.bind(pool), sheetId, recordId)
       if ('status' in readable) return res.status(readable.status).json(readable.body)
 
-      const [items, status] = await Promise.all([
-        listRecordSubscriptions(pool.query.bind(pool), { sheetId, recordId }),
-        getRecordSubscriptionStatus(pool.query.bind(pool), { sheetId, recordId, userId: readable.access.userId }),
-      ])
+      const status = await getRecordSubscriptionStatus(pool.query.bind(pool), {
+        sheetId,
+        recordId,
+        userId: readable.access.userId,
+      })
       return res.json({
         ok: true,
         data: {
-          items,
           subscribed: status.subscribed,
           subscription: status.subscription,
         },
       })
     } catch (err) {
       if (isUndefinedTableError(err, 'meta_record_subscriptions')) {
-        return res.json({ ok: true, data: { items: [], subscribed: false, subscription: null } })
+        return res.json({ ok: true, data: { subscribed: false, subscription: null } })
       }
       const hint = getDbNotReadyMessage(err)
       if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })

--- a/packages/core-backend/tests/integration/multitable-record-subscriptions.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-record-subscriptions.api.test.ts
@@ -1,0 +1,109 @@
+import express from 'express'
+import request from 'supertest'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+type QueryResult = {
+  rows: any[]
+  rowCount?: number
+}
+
+type QueryHandler = (sql: string, params?: unknown[]) => QueryResult | Promise<QueryResult>
+
+function createMockPool(queryHandler: QueryHandler) {
+  const query = vi.fn(async (sql: string, params?: unknown[]) => {
+    if (sql.includes('FROM spreadsheet_permissions')) {
+      return { rows: [], rowCount: 0 }
+    }
+    if (sql.includes('FROM record_permissions')) {
+      return { rows: [], rowCount: 0 }
+    }
+    return queryHandler(sql, params)
+  })
+  const transaction = vi.fn(async (fn: (client: { query: typeof query }) => Promise<unknown>) => fn({ query }))
+  return { query, transaction }
+}
+
+async function createApp(args: {
+  tokenPerms?: string[]
+  queryHandler: QueryHandler
+}) {
+  vi.resetModules()
+  vi.doMock('../../src/rbac/service', () => ({
+    isAdmin: vi.fn().mockResolvedValue(false),
+    userHasPermission: vi.fn().mockResolvedValue(false),
+    listUserPermissions: vi.fn().mockResolvedValue([]),
+    invalidateUserPerms: vi.fn(),
+    getPermCacheStatus: vi.fn(),
+  }))
+
+  const { poolManager } = await import('../../src/integration/db/connection-pool')
+  const { univerMetaRouter } = await import('../../src/routes/univer-meta')
+  const mockPool = createMockPool(args.queryHandler)
+  vi.spyOn(poolManager, 'get').mockReturnValue(mockPool as any)
+
+  const app = express()
+  app.use(express.json())
+  app.use((req, _res, next) => {
+    req.user = {
+      id: 'user_multitable_1',
+      roles: [],
+      perms: args.tokenPerms ?? [],
+    }
+    next()
+  })
+  app.use('/api/multitable', univerMetaRouter())
+
+  return { app, mockPool }
+}
+
+describe('Multitable record subscription routes', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.resetModules()
+  })
+
+  test('returns only the current user subscription status without enumerating watchers', async () => {
+    const { app, mockPool } = await createApp({
+      tokenPerms: ['multitable:read'],
+      queryHandler: async (sql, params) => {
+        if (sql.includes('SELECT id, sheet_id FROM meta_records WHERE id = $1 AND sheet_id = $2')) {
+          expect(params).toEqual(['rec_1', 'sheet_ops'])
+          return { rows: [{ id: 'rec_1', sheet_id: 'sheet_ops' }] }
+        }
+        if (sql.includes('FROM meta_record_subscriptions')) {
+          expect(params).toEqual(['sheet_ops', 'rec_1', 'user_multitable_1'])
+          return {
+            rows: [{
+              id: '11111111-1111-1111-1111-111111111111',
+              sheet_id: 'sheet_ops',
+              record_id: 'rec_1',
+              user_id: 'user_multitable_1',
+              created_at: '2026-05-05T00:00:00.000Z',
+              updated_at: '2026-05-05T00:00:00.000Z',
+            }],
+          }
+        }
+        throw new Error(`Unhandled SQL in test: ${sql}`)
+      },
+    })
+
+    const response = await request(app)
+      .get('/api/multitable/sheets/sheet_ops/records/rec_1/subscriptions')
+      .expect(200)
+
+    expect(response.body.data).toMatchObject({
+      subscribed: true,
+      subscription: {
+        sheetId: 'sheet_ops',
+        recordId: 'rec_1',
+        userId: 'user_multitable_1',
+      },
+    })
+    expect(response.body.data.items).toBeUndefined()
+    expect(JSON.stringify(response.body)).not.toContain('watcher_')
+    expect(mockPool.query).not.toHaveBeenCalledWith(
+      expect.stringContaining('ORDER BY updated_at DESC, user_id ASC'),
+      expect.anything(),
+    )
+  })
+})

--- a/packages/core-backend/tests/unit/record-subscription-service.test.ts
+++ b/packages/core-backend/tests/unit/record-subscription-service.test.ts
@@ -5,6 +5,7 @@ import {
   listRecordSubscriptionNotifications,
   listRecordSubscriptions,
   notifyRecordSubscribers,
+  notifyRecordSubscribersBestEffort,
   subscribeRecord,
   unsubscribeRecord,
 } from '../../src/multitable/record-subscription-service'
@@ -99,6 +100,25 @@ describe('record-subscription-service', () => {
     expect(query).toHaveBeenNthCalledWith(2, expect.stringContaining('INSERT INTO meta_record_subscription_notifications'), [
       expect.stringContaining('"event_type":"record.updated"'),
     ])
+  })
+
+  it('keeps watcher notification enqueue best-effort for write paths', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const query = vi.fn().mockRejectedValue(new Error('meta_record_subscriptions missing'))
+
+    await expect(notifyRecordSubscribersBestEffort(query, {
+      sheetId: 'sheet_1',
+      recordId: 'rec_1',
+      eventType: 'record.updated',
+      actorId: 'actor_1',
+      revisionId: '11111111-1111-1111-1111-111111111111',
+    }, 'test-record-write')).resolves.toBeNull()
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[test-record-write] Failed to notify record subscribers',
+      expect.any(Error),
+    )
+    warnSpy.mockRestore()
   })
 
   it('lists current user record subscription notifications', async () => {


### PR DESCRIPTION
## Summary

Follow-up to #1290 after it merged before the local hardening commit landed. This PR keeps the diff clean against current `main` and contains only the follow-up fixes.

- Move record-subscription notification enqueueing out of authoritative record write transactions and make it best-effort.
- Prevent the per-record subscription status endpoint from returning every watcher userId; it now returns only the current user subscription state.
- Add route-level privacy coverage and service coverage for best-effort enqueue failure.
- Add development and verification notes for the CI unblock/hardening slice.

## Verification

- `pnpm --filter @metasheet/core-backend exec vitest --config vitest.config.ts run tests/integration/multitable-record-patch.api.test.ts tests/integration/multitable-record-subscriptions.api.test.ts tests/unit/record-subscription-service.test.ts tests/unit/record-service.test.ts tests/unit/record-write-service.test.ts tests/unit/comment-service.test.ts --reporter=dot` — 6 files / 111 tests passed.
- `pnpm --filter @metasheet/core-backend build` — passed.
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-record-drawer.spec.ts tests/multitable-client.spec.ts --reporter=dot` — 2 files / 31 tests passed.
- `pnpm --filter @metasheet/web exec vue-tsc -b --noEmit` — passed.
- `git diff --check` — passed.
- Earlier CI-style backend run on the same patch before clean cherry-pick: `CI=true pnpm --filter @metasheet/core-backend test` — 210 files passed / 9 skipped; 2831 tests passed / 47 skipped.

## Docs

- `docs/development/multitable-record-subscription-ci-unblock-development-20260505.md`
- `docs/development/multitable-record-subscription-ci-unblock-verification-20260505.md`