### PR TITLE
docs(openapi): cover multitable record subscriptions

### DIFF
--- a/docs/development/multitable-record-subscription-openapi-development-20260505.md
+++ b/docs/development/multitable-record-subscription-openapi-development-20260505.md
@@ -1,0 +1,36 @@
+# Multitable Record Subscription OpenAPI Development
+
+- Date: 2026-05-05
+- Branch: `codex/multitable-record-subscriptions-openapi-20260505`
+- Scope: contract-only follow-up for record subscription endpoints
+
+## Context
+
+Record subscriptions already had backend routes and frontend client methods:
+
+- `GET /api/multitable/sheets/:sheetId/records/:recordId/subscriptions`
+- `PUT /api/multitable/sheets/:sheetId/records/:recordId/subscriptions/me`
+- `DELETE /api/multitable/sheets/:sheetId/records/:recordId/subscriptions/me`
+- `GET /api/multitable/record-subscription-notifications`
+
+The OpenAPI source did not describe those endpoints, so generated API artifacts and the multitable parity gate could drift behind runtime behavior.
+
+## Implementation
+
+Updated `packages/openapi/src/base.yml` with:
+
+- `MultitableRecordSubscription`
+- `MultitableRecordSubscriptionStatus`
+- `MultitableRecordSubscriptionNotificationType`
+- `MultitableRecordSubscriptionNotification`
+
+Updated `packages/openapi/src/paths/multitable.yml` with the four subscription endpoints and their path/query parameters, authentication requirements, success payloads, and common error responses.
+
+Updated `scripts/ops/multitable-openapi-parity.test.mjs` so the contract gate now fails if these paths or response schema refs disappear.
+
+Generated OpenAPI dist artifacts with `packages/openapi/tools/build.ts`.
+
+## Compatibility Notes
+
+The status schema keeps optional `items` for compatibility with the current runtime shape, but marks it as legacy. The intended client contract is `subscribed` plus `subscription` for the current user, which also matches the privacy hardening follow-up in PR #1291.
+

--- a/docs/development/multitable-record-subscription-openapi-verification-20260505.md
+++ b/docs/development/multitable-record-subscription-openapi-verification-20260505.md
@@ -1,0 +1,36 @@
+# Multitable Record Subscription OpenAPI Verification
+
+- Date: 2026-05-05
+- Branch: `codex/multitable-record-subscriptions-openapi-20260505`
+
+## Verification Plan
+
+1. Build combined OpenAPI artifacts from source.
+2. Run the multitable OpenAPI parity gate.
+3. Validate the generated OpenAPI document.
+4. Check for whitespace errors.
+
+## Commands
+
+```bash
+pnpm exec tsx packages/openapi/tools/build.ts
+node --test scripts/ops/multitable-openapi-parity.test.mjs
+pnpm exec tsx packages/openapi/tools/validate.ts packages/openapi/dist/openapi.yaml
+git diff --check
+```
+
+## Results
+
+| Gate | Result |
+| --- | --- |
+| `pnpm exec tsx packages/openapi/tools/build.ts` | PASS |
+| `node --test scripts/ops/multitable-openapi-parity.test.mjs` | PASS, 1 test |
+| `pnpm exec tsx packages/openapi/tools/validate.ts packages/openapi/dist/openapi.yaml` | PASS |
+
+## Coverage
+
+- The four record subscription paths exist in generated `openapi.json`.
+- Status, subscribe, and unsubscribe responses all reference `MultitableRecordSubscriptionStatus`.
+- Notification list items reference `MultitableRecordSubscriptionNotification`.
+- Subscription notification `eventType` is constrained by `MultitableRecordSubscriptionNotificationType`.
+- Existing multitable field/view enum parity checks continue to pass.

--- a/packages/openapi/dist/combined.openapi.yml
+++ b/packages/openapi/dist/combined.openapi.yml
@@ -1666,6 +1666,96 @@ components:
         data:
           type: object
           additionalProperties: true
+    MultitableRecordSubscription:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        sheetId:
+          type: string
+        recordId:
+          type: string
+        userId:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - sheetId
+        - recordId
+        - userId
+        - createdAt
+        - updatedAt
+    MultitableRecordSubscriptionStatus:
+      type: object
+      properties:
+        subscribed:
+          type: boolean
+        subscription:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/MultitableRecordSubscription'
+        items:
+          type: array
+          description: >-
+            Legacy watcher list emitted by older runtimes. Clients should rely
+            on `subscribed` and `subscription` for the current user.
+          items:
+            $ref: '#/components/schemas/MultitableRecordSubscription'
+      required:
+        - subscribed
+        - subscription
+    MultitableRecordSubscriptionNotificationType:
+      type: string
+      enum:
+        - record.updated
+        - comment.created
+    MultitableRecordSubscriptionNotification:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        sheetId:
+          type: string
+        recordId:
+          type: string
+        userId:
+          type: string
+        eventType:
+          $ref: '#/components/schemas/MultitableRecordSubscriptionNotificationType'
+        actorId:
+          type: string
+          nullable: true
+        revisionId:
+          type: string
+          nullable: true
+        commentId:
+          type: string
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        readAt:
+          type: string
+          format: date-time
+          nullable: true
+      required:
+        - id
+        - sheetId
+        - recordId
+        - userId
+        - eventType
+        - actorId
+        - revisionId
+        - commentId
+        - createdAt
+        - readAt
     MultitableXlsxImportResponse:
       type: object
       properties:
@@ -11458,6 +11548,174 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
+  /api/multitable/sheets/{sheetId}/records/{recordId}/subscriptions:
+    get:
+      summary: Load current user's subscription status for a record
+      description: >-
+        Returns whether the authenticated user is subscribed to a record. Older
+        runtimes may also include a legacy `items` watcher list; clients should
+        use `subscribed` and `subscription`.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: sheetId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: recordId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Current user's subscription status
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    $ref: '#/components/schemas/MultitableRecordSubscriptionStatus'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /api/multitable/sheets/{sheetId}/records/{recordId}/subscriptions/me:
+    put:
+      summary: Subscribe the current user to a record
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: sheetId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: recordId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Subscribed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    $ref: '#/components/schemas/MultitableRecordSubscriptionStatus'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    delete:
+      summary: Unsubscribe the current user from a record
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: sheetId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: recordId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Unsubscribed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    $ref: '#/components/schemas/MultitableRecordSubscriptionStatus'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /api/multitable/record-subscription-notifications:
+    get:
+      summary: List current user's record subscription notifications
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: sheetId
+          schema:
+            type: string
+        - in: query
+          name: recordId
+          schema:
+            type: string
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 50
+        - in: query
+          name: offset
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+      responses:
+        '200':
+          description: Current user's notifications
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          $ref: >-
+                            #/components/schemas/MultitableRecordSubscriptionNotification
+                      limit:
+                        type: integer
+                      offset:
+                        type: integer
+                    required:
+                      - items
+                      - limit
+                      - offset
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
   /api/multitable/sheets/{sheetId}/permissions/{subjectType}/{subjectId}:
     put:
       summary: Set a sheet access level for a person or role

--- a/packages/openapi/dist/openapi.json
+++ b/packages/openapi/dist/openapi.json
@@ -2394,6 +2394,128 @@
           }
         }
       },
+      "MultitableRecordSubscription": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "sheetId": {
+            "type": "string"
+          },
+          "recordId": {
+            "type": "string"
+          },
+          "userId": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "sheetId",
+          "recordId",
+          "userId",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "MultitableRecordSubscriptionStatus": {
+        "type": "object",
+        "properties": {
+          "subscribed": {
+            "type": "boolean"
+          },
+          "subscription": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MultitableRecordSubscription"
+              }
+            ]
+          },
+          "items": {
+            "type": "array",
+            "description": "Legacy watcher list emitted by older runtimes. Clients should rely on `subscribed` and `subscription` for the current user.",
+            "items": {
+              "$ref": "#/components/schemas/MultitableRecordSubscription"
+            }
+          }
+        },
+        "required": [
+          "subscribed",
+          "subscription"
+        ]
+      },
+      "MultitableRecordSubscriptionNotificationType": {
+        "type": "string",
+        "enum": [
+          "record.updated",
+          "comment.created"
+        ]
+      },
+      "MultitableRecordSubscriptionNotification": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "sheetId": {
+            "type": "string"
+          },
+          "recordId": {
+            "type": "string"
+          },
+          "userId": {
+            "type": "string"
+          },
+          "eventType": {
+            "$ref": "#/components/schemas/MultitableRecordSubscriptionNotificationType"
+          },
+          "actorId": {
+            "type": "string",
+            "nullable": true
+          },
+          "revisionId": {
+            "type": "string",
+            "nullable": true
+          },
+          "commentId": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "readAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          }
+        },
+        "required": [
+          "id",
+          "sheetId",
+          "recordId",
+          "userId",
+          "eventType",
+          "actorId",
+          "revisionId",
+          "commentId",
+          "createdAt",
+          "readAt"
+        ]
+      },
       "MultitableXlsxImportResponse": {
         "type": "object",
         "properties": {
@@ -17650,6 +17772,275 @@
           },
           "404": {
             "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/api/multitable/sheets/{sheetId}/records/{recordId}/subscriptions": {
+      "get": {
+        "summary": "Load current user's subscription status for a record",
+        "description": "Returns whether the authenticated user is subscribed to a record. Older runtimes may also include a legacy `items` watcher list; clients should use `subscribed` and `subscription`.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "sheetId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "recordId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Current user's subscription status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/MultitableRecordSubscriptionStatus"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/api/multitable/sheets/{sheetId}/records/{recordId}/subscriptions/me": {
+      "put": {
+        "summary": "Subscribe the current user to a record",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "sheetId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "recordId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Subscribed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/MultitableRecordSubscriptionStatus"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Unsubscribe the current user from a record",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "sheetId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "recordId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Unsubscribed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/MultitableRecordSubscriptionStatus"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/api/multitable/record-subscription-notifications": {
+      "get": {
+        "summary": "List current user's record subscription notifications",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "sheetId",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "recordId",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 50
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Current user's notifications",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/MultitableRecordSubscriptionNotification"
+                          }
+                        },
+                        "limit": {
+                          "type": "integer"
+                        },
+                        "offset": {
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "items",
+                        "limit",
+                        "offset"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
           }
         }
       }

--- a/packages/openapi/dist/openapi.yaml
+++ b/packages/openapi/dist/openapi.yaml
@@ -1666,6 +1666,96 @@ components:
         data:
           type: object
           additionalProperties: true
+    MultitableRecordSubscription:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        sheetId:
+          type: string
+        recordId:
+          type: string
+        userId:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - sheetId
+        - recordId
+        - userId
+        - createdAt
+        - updatedAt
+    MultitableRecordSubscriptionStatus:
+      type: object
+      properties:
+        subscribed:
+          type: boolean
+        subscription:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/MultitableRecordSubscription'
+        items:
+          type: array
+          description: >-
+            Legacy watcher list emitted by older runtimes. Clients should rely
+            on `subscribed` and `subscription` for the current user.
+          items:
+            $ref: '#/components/schemas/MultitableRecordSubscription'
+      required:
+        - subscribed
+        - subscription
+    MultitableRecordSubscriptionNotificationType:
+      type: string
+      enum:
+        - record.updated
+        - comment.created
+    MultitableRecordSubscriptionNotification:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        sheetId:
+          type: string
+        recordId:
+          type: string
+        userId:
+          type: string
+        eventType:
+          $ref: '#/components/schemas/MultitableRecordSubscriptionNotificationType'
+        actorId:
+          type: string
+          nullable: true
+        revisionId:
+          type: string
+          nullable: true
+        commentId:
+          type: string
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        readAt:
+          type: string
+          format: date-time
+          nullable: true
+      required:
+        - id
+        - sheetId
+        - recordId
+        - userId
+        - eventType
+        - actorId
+        - revisionId
+        - commentId
+        - createdAt
+        - readAt
     MultitableXlsxImportResponse:
       type: object
       properties:
@@ -11458,6 +11548,174 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
+  /api/multitable/sheets/{sheetId}/records/{recordId}/subscriptions:
+    get:
+      summary: Load current user's subscription status for a record
+      description: >-
+        Returns whether the authenticated user is subscribed to a record. Older
+        runtimes may also include a legacy `items` watcher list; clients should
+        use `subscribed` and `subscription`.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: sheetId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: recordId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Current user's subscription status
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    $ref: '#/components/schemas/MultitableRecordSubscriptionStatus'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /api/multitable/sheets/{sheetId}/records/{recordId}/subscriptions/me:
+    put:
+      summary: Subscribe the current user to a record
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: sheetId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: recordId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Subscribed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    $ref: '#/components/schemas/MultitableRecordSubscriptionStatus'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    delete:
+      summary: Unsubscribe the current user from a record
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: sheetId
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: recordId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Unsubscribed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    $ref: '#/components/schemas/MultitableRecordSubscriptionStatus'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /api/multitable/record-subscription-notifications:
+    get:
+      summary: List current user's record subscription notifications
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: sheetId
+          schema:
+            type: string
+        - in: query
+          name: recordId
+          schema:
+            type: string
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 50
+        - in: query
+          name: offset
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+      responses:
+        '200':
+          description: Current user's notifications
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          $ref: >-
+                            #/components/schemas/MultitableRecordSubscriptionNotification
+                      limit:
+                        type: integer
+                      offset:
+                        type: integer
+                    required:
+                      - items
+                      - limit
+                      - offset
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
   /api/multitable/sheets/{sheetId}/permissions/{subjectType}/{subjectId}:
     put:
       summary: Set a sheet access level for a person or role

--- a/packages/openapi/src/base.yml
+++ b/packages/openapi/src/base.yml
@@ -1609,6 +1609,94 @@ components:
         data:
           type: object
           additionalProperties: true
+    MultitableRecordSubscription:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        sheetId:
+          type: string
+        recordId:
+          type: string
+        userId:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - sheetId
+        - recordId
+        - userId
+        - createdAt
+        - updatedAt
+    MultitableRecordSubscriptionStatus:
+      type: object
+      properties:
+        subscribed:
+          type: boolean
+        subscription:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/MultitableRecordSubscription'
+        items:
+          type: array
+          description: Legacy watcher list emitted by older runtimes. Clients should rely on `subscribed` and `subscription` for the current user.
+          items:
+            $ref: '#/components/schemas/MultitableRecordSubscription'
+      required:
+        - subscribed
+        - subscription
+    MultitableRecordSubscriptionNotificationType:
+      type: string
+      enum:
+        - record.updated
+        - comment.created
+    MultitableRecordSubscriptionNotification:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        sheetId:
+          type: string
+        recordId:
+          type: string
+        userId:
+          type: string
+        eventType:
+          $ref: '#/components/schemas/MultitableRecordSubscriptionNotificationType'
+        actorId:
+          type: string
+          nullable: true
+        revisionId:
+          type: string
+          nullable: true
+        commentId:
+          type: string
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        readAt:
+          type: string
+          format: date-time
+          nullable: true
+      required:
+        - id
+        - sheetId
+        - recordId
+        - userId
+        - eventType
+        - actorId
+        - revisionId
+        - commentId
+        - createdAt
+        - readAt
     MultitableXlsxImportResponse:
       type: object
       properties:

--- a/packages/openapi/src/paths/multitable.yml
+++ b/packages/openapi/src/paths/multitable.yml
@@ -368,6 +368,134 @@ paths:
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
         '404': { $ref: '#/components/responses/NotFound' }
+  /api/multitable/sheets/{sheetId}/records/{recordId}/subscriptions:
+    get:
+      summary: Load current user's subscription status for a record
+      description: Returns whether the authenticated user is subscribed to a record. Older runtimes may also include a legacy `items` watcher list; clients should use `subscribed` and `subscription`.
+      security: [ { bearerAuth: [] } ]
+      parameters:
+        - in: path
+          name: sheetId
+          required: true
+          schema: { type: string }
+        - in: path
+          name: recordId
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Current user's subscription status
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    $ref: '#/components/schemas/MultitableRecordSubscriptionStatus'
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+  /api/multitable/sheets/{sheetId}/records/{recordId}/subscriptions/me:
+    put:
+      summary: Subscribe the current user to a record
+      security: [ { bearerAuth: [] } ]
+      parameters:
+        - in: path
+          name: sheetId
+          required: true
+          schema: { type: string }
+        - in: path
+          name: recordId
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Subscribed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    $ref: '#/components/schemas/MultitableRecordSubscriptionStatus'
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+    delete:
+      summary: Unsubscribe the current user from a record
+      security: [ { bearerAuth: [] } ]
+      parameters:
+        - in: path
+          name: sheetId
+          required: true
+          schema: { type: string }
+        - in: path
+          name: recordId
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Unsubscribed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    $ref: '#/components/schemas/MultitableRecordSubscriptionStatus'
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+  /api/multitable/record-subscription-notifications:
+    get:
+      summary: List current user's record subscription notifications
+      security: [ { bearerAuth: [] } ]
+      parameters:
+        - in: query
+          name: sheetId
+          schema: { type: string }
+        - in: query
+          name: recordId
+          schema: { type: string }
+        - in: query
+          name: limit
+          schema: { type: integer, minimum: 1, maximum: 100, default: 50 }
+        - in: query
+          name: offset
+          schema: { type: integer, minimum: 0, default: 0 }
+      responses:
+        '200':
+          description: Current user's notifications
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/MultitableRecordSubscriptionNotification'
+                      limit:
+                        type: integer
+                      offset:
+                        type: integer
+                    required: [items, limit, offset]
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
   /api/multitable/sheets/{sheetId}/permissions/{subjectType}/{subjectId}:
     put:
       summary: Set a sheet access level for a person or role

--- a/scripts/ops/multitable-openapi-parity.test.mjs
+++ b/scripts/ops/multitable-openapi-parity.test.mjs
@@ -52,6 +52,22 @@ test('multitable openapi stays aligned with runtime contracts', () => {
   assert.ok(paths['/api/multitable/records/{recordId}']?.patch, 'missing single-record patch endpoint')
   assert.ok(paths['/api/multitable/sheets/{sheetId}/import-xlsx']?.post, 'missing xlsx import endpoint')
   assert.ok(paths['/api/multitable/sheets/{sheetId}/export-xlsx']?.get, 'missing xlsx export endpoint')
+  assert.ok(
+    paths['/api/multitable/sheets/{sheetId}/records/{recordId}/subscriptions']?.get,
+    'missing record subscription status endpoint',
+  )
+  assert.ok(
+    paths['/api/multitable/sheets/{sheetId}/records/{recordId}/subscriptions/me']?.put,
+    'missing current-user record subscribe endpoint',
+  )
+  assert.ok(
+    paths['/api/multitable/sheets/{sheetId}/records/{recordId}/subscriptions/me']?.delete,
+    'missing current-user record unsubscribe endpoint',
+  )
+  assert.ok(
+    paths['/api/multitable/record-subscription-notifications']?.get,
+    'missing record subscription notification list endpoint',
+  )
 
   assert.deepEqual(schemas.MultitableFieldType?.enum, expectedFieldTypes)
   assert.deepEqual(schemas.MultitableViewType?.enum, expectedViewTypes)
@@ -119,9 +135,33 @@ test('multitable openapi stays aligned with runtime contracts', () => {
     paths['/api/multitable/patch']?.post?.responses?.['200']?.content?.['application/json']?.schema?.properties?.data?.$ref,
     '#/components/schemas/MultitablePatchResult',
   )
+  assert.equal(
+    paths['/api/multitable/sheets/{sheetId}/records/{recordId}/subscriptions']?.get?.responses?.['200']?.content?.['application/json']?.schema?.properties?.data?.$ref,
+    '#/components/schemas/MultitableRecordSubscriptionStatus',
+  )
+  assert.equal(
+    paths['/api/multitable/sheets/{sheetId}/records/{recordId}/subscriptions/me']?.put?.responses?.['200']?.content?.['application/json']?.schema?.properties?.data?.$ref,
+    '#/components/schemas/MultitableRecordSubscriptionStatus',
+  )
+  assert.equal(
+    paths['/api/multitable/sheets/{sheetId}/records/{recordId}/subscriptions/me']?.delete?.responses?.['200']?.content?.['application/json']?.schema?.properties?.data?.$ref,
+    '#/components/schemas/MultitableRecordSubscriptionStatus',
+  )
+  assert.equal(
+    paths['/api/multitable/record-subscription-notifications']?.get?.responses?.['200']?.content?.['application/json']?.schema?.properties?.data?.properties?.items?.items?.$ref,
+    '#/components/schemas/MultitableRecordSubscriptionNotification',
+  )
 
   assert.equal(schemas.MultitableView?.properties?.type?.$ref, '#/components/schemas/MultitableViewType')
   assert.equal(schemas.MultitableField?.properties?.type?.$ref, '#/components/schemas/MultitableFieldType')
+  assert.equal(
+    schemas.MultitableRecordSubscriptionStatus?.properties?.subscription?.allOf?.[0]?.$ref,
+    '#/components/schemas/MultitableRecordSubscription',
+  )
+  assert.equal(
+    schemas.MultitableRecordSubscriptionNotification?.properties?.eventType?.$ref,
+    '#/components/schemas/MultitableRecordSubscriptionNotificationType',
+  )
   assert.equal(schemas.MultitableView?.properties?.config?.type, 'object')
   assert.equal(schemas.MultitableField?.properties?.options?.items?.properties?.value?.type, 'string')
   assert.equal(


### PR DESCRIPTION
## Summary

Contract-only follow-up for the multitable record subscription runtime surface.

- Document record subscription status, subscribe, unsubscribe, and notification list endpoints in OpenAPI.
- Add subscription and notification schemas to `packages/openapi/src/base.yml`.
- Regenerate OpenAPI dist artifacts.
- Extend the multitable OpenAPI parity gate so future route/schema drift is caught.
- Add development and verification notes.

## Verification

- `pnpm verify:multitable-openapi:parity` — passed.
- `pnpm exec tsx packages/openapi/tools/validate.ts packages/openapi/dist/openapi.yaml` — passed.
- `git diff --check` — passed.

## Notes

This PR intentionally keeps the REST subscription contract separate from the adjacent Socket.IO `/yjs` realtime contract. A read-only parallel audit found that `/yjs` would be better handled by AsyncAPI or a separate vendor-extension pass rather than mixing it into this OpenAPI-only slice.