### PR TITLE
docs(multitable): add yjs realtime contract guard

### DIFF
--- a/docs/api/multitable-yjs-events.asyncapi.json
+++ b/docs/api/multitable-yjs-events.asyncapi.json
@@ -1,0 +1,254 @@
+{
+  "asyncapi": "2.6.0",
+  "info": {
+    "title": "MetaSheet Multitable Yjs Realtime Events",
+    "version": "1.0.0",
+    "description": "Socket.IO contract for record-scoped Yjs collaboration on the /yjs namespace."
+  },
+  "servers": {
+    "yjs": {
+      "url": "/yjs",
+      "protocol": "socket.io",
+      "security": [
+        {
+          "jwtAuth": []
+        }
+      ],
+      "description": "Socket.IO namespace mounted by YjsWebSocketAdapter. Clients authenticate with handshake auth.token."
+    }
+  },
+  "channels": {
+    "/yjs": {
+      "bindings": {
+        "socketio": {
+          "namespace": "/yjs"
+        }
+      },
+      "publish": {
+        "summary": "Client-to-server Yjs events.",
+        "message": {
+          "oneOf": [
+            {
+              "$ref": "#/components/messages/YjsSubscribe"
+            },
+            {
+              "$ref": "#/components/messages/YjsClientMessage"
+            },
+            {
+              "$ref": "#/components/messages/YjsClientUpdate"
+            },
+            {
+              "$ref": "#/components/messages/YjsClientPresence"
+            },
+            {
+              "$ref": "#/components/messages/YjsUnsubscribe"
+            }
+          ]
+        }
+      },
+      "subscribe": {
+        "summary": "Server-to-client Yjs events.",
+        "message": {
+          "oneOf": [
+            {
+              "$ref": "#/components/messages/YjsServerMessage"
+            },
+            {
+              "$ref": "#/components/messages/YjsServerUpdate"
+            },
+            {
+              "$ref": "#/components/messages/YjsPresence"
+            },
+            {
+              "$ref": "#/components/messages/YjsError"
+            },
+            {
+              "$ref": "#/components/messages/YjsInvalidated"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "jwtAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT",
+        "description": "Passed as Socket.IO handshake auth.token."
+      }
+    },
+    "messages": {
+      "YjsSubscribe": {
+        "name": "yjs:subscribe",
+        "payload": {
+          "$ref": "#/components/schemas/RecordRef"
+        }
+      },
+      "YjsUnsubscribe": {
+        "name": "yjs:unsubscribe",
+        "payload": {
+          "$ref": "#/components/schemas/RecordRef"
+        }
+      },
+      "YjsClientMessage": {
+        "name": "yjs:message",
+        "payload": {
+          "$ref": "#/components/schemas/YjsBinaryMessage"
+        }
+      },
+      "YjsServerMessage": {
+        "name": "yjs:message",
+        "payload": {
+          "$ref": "#/components/schemas/YjsBinaryMessage"
+        }
+      },
+      "YjsClientUpdate": {
+        "name": "yjs:update",
+        "payload": {
+          "$ref": "#/components/schemas/YjsBinaryMessage"
+        }
+      },
+      "YjsServerUpdate": {
+        "name": "yjs:update",
+        "payload": {
+          "$ref": "#/components/schemas/YjsBinaryMessage"
+        }
+      },
+      "YjsClientPresence": {
+        "name": "yjs:presence",
+        "payload": {
+          "$ref": "#/components/schemas/YjsPresenceUpdate"
+        }
+      },
+      "YjsPresence": {
+        "name": "yjs:presence",
+        "payload": {
+          "$ref": "#/components/schemas/YjsPresenceSnapshot"
+        }
+      },
+      "YjsError": {
+        "name": "yjs:error",
+        "payload": {
+          "$ref": "#/components/schemas/YjsError"
+        }
+      },
+      "YjsInvalidated": {
+        "name": "yjs:invalidated",
+        "payload": {
+          "$ref": "#/components/schemas/YjsInvalidated"
+        }
+      }
+    },
+    "schemas": {
+      "RecordRef": {
+        "type": "object",
+        "required": ["recordId"],
+        "properties": {
+          "recordId": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      },
+      "YjsBinaryMessage": {
+        "type": "object",
+        "required": ["recordId", "data"],
+        "properties": {
+          "recordId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 255
+            }
+          }
+        }
+      },
+      "YjsPresenceUpdate": {
+        "type": "object",
+        "required": ["recordId"],
+        "properties": {
+          "recordId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "fieldId": {
+            "type": ["string", "null"]
+          }
+        }
+      },
+      "YjsPresenceUser": {
+        "type": "object",
+        "required": ["id", "fieldIds"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "fieldIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "YjsPresenceSnapshot": {
+        "type": "object",
+        "required": ["recordId", "activeCount", "users"],
+        "properties": {
+          "recordId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "activeCount": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "users": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/YjsPresenceUser"
+            }
+          }
+        }
+      },
+      "YjsError": {
+        "type": "object",
+        "required": ["recordId", "code", "message"],
+        "properties": {
+          "recordId": {
+            "type": "string"
+          },
+          "code": {
+            "type": "string",
+            "enum": ["UNAUTHENTICATED", "NOT_FOUND", "FORBIDDEN"]
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      },
+      "YjsInvalidated": {
+        "type": "object",
+        "required": ["recordId", "reason"],
+        "properties": {
+          "recordId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "reason": {
+            "type": "string",
+            "enum": ["rest-write"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/development/multitable-yjs-contract-development-20260505.md
+++ b/docs/development/multitable-yjs-contract-development-20260505.md
@@ -1,0 +1,42 @@
+# Multitable Yjs Contract Development
+
+- Date: 2026-05-05
+- Branch: `codex/multitable-yjs-contract-20260505`
+- Scope: realtime contract documentation and parity guard for `/yjs`
+
+## Context
+
+The multitable REST contract is covered by OpenAPI, but the record-level Yjs collaboration channel uses Socket.IO on the `/yjs` namespace. That event surface was documented in design notes and tests, but it did not have a small machine-readable contract artifact or a release gate that catches accidental event-name drift.
+
+This is intentionally separate from OpenAPI because the API is event-based:
+
+- Socket.IO namespace: `/yjs`
+- Handshake auth: `auth.token` JWT
+- Client events: `yjs:subscribe`, `yjs:message`, `yjs:update`, `yjs:presence`, `yjs:unsubscribe`
+- Server events: `yjs:message`, `yjs:update`, `yjs:presence`, `yjs:error`, `yjs:invalidated`
+
+## Implementation
+
+Added `docs/api/multitable-yjs-events.asyncapi.json` as a compact AsyncAPI-style contract for the Socket.IO namespace.
+
+Added `scripts/ops/multitable-yjs-contract-parity.test.mjs`, a dependency-free Node test that checks:
+
+- the contract declares `/yjs` as a Socket.IO namespace;
+- client and server event names match the backend adapter;
+- frontend `useYjsDocument` connects to `/yjs`, emits client events, and handles server events;
+- the error-code set stays `UNAUTHENTICATED`, `NOT_FOUND`, `FORBIDDEN`;
+- `yjs:invalidated` preserves the `rest-write` reason;
+- presence payloads keep `recordId`, `activeCount`, and `users`.
+
+Added root script:
+
+```bash
+pnpm verify:multitable-yjs:contract
+```
+
+## Non-goals
+
+- No runtime behavior changes.
+- No OpenAPI changes; this is not an HTTP contract.
+- No generated SDK changes.
+

--- a/docs/development/multitable-yjs-contract-verification-20260505.md
+++ b/docs/development/multitable-yjs-contract-verification-20260505.md
@@ -1,0 +1,38 @@
+# Multitable Yjs Contract Verification
+
+- Date: 2026-05-05
+- Branch: `codex/multitable-yjs-contract-20260505`
+
+## Verification Plan
+
+1. Run the new Yjs contract parity gate.
+2. Run the existing backend Yjs socket unit tests.
+3. Run the existing frontend Yjs composable tests.
+4. Check formatting/whitespace with `git diff --check`.
+
+## Commands
+
+```bash
+pnpm verify:multitable-yjs:contract
+pnpm --filter @metasheet/core-backend exec vitest --config vitest.config.ts run tests/unit/yjs-awareness.test.ts tests/unit/yjs-hardening.test.ts --reporter=dot
+pnpm --filter @metasheet/web exec vitest run tests/yjs-awareness-presence.spec.ts tests/yjs-document-invalidation.spec.ts tests/multitable-yjs-cell-binding.spec.ts --reporter=dot
+git diff --check
+```
+
+## Results
+
+| Gate | Result |
+| --- | --- |
+| `pnpm verify:multitable-yjs:contract` | PASS, 2 tests |
+| Backend focused Yjs tests | PASS, 2 files / 10 tests |
+| Frontend focused Yjs tests | PASS, 3 files / 10 tests |
+
+The frontend Vitest run emitted the existing `WebSocket server error: Port is already in use` warning, but exited successfully.
+
+## Expected Coverage
+
+- Contract event names match backend `YjsWebSocketAdapter`.
+- Contract event names match frontend `useYjsDocument`.
+- Auth and permission errors remain documented and guarded.
+- REST-write invalidation stays `reason: "rest-write"`.
+- Existing backend and frontend Yjs behavior tests keep passing.

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "verify:multitable-pilot:release-gate:staging": "RUN_MODE=staging bash scripts/ops/multitable-pilot-release-gate.sh",
     "verify:multitable-pilot:release-gate:test": "node --test scripts/ops/multitable-pilot-release-gate.test.mjs",
     "verify:multitable-openapi:parity": "pnpm exec tsx packages/openapi/tools/build.ts && node --test scripts/ops/multitable-openapi-parity.test.mjs",
+    "verify:multitable-yjs:contract": "node --test scripts/ops/multitable-yjs-contract-parity.test.mjs",
     "prepare:multitable-pilot:handoff": "node scripts/ops/multitable-pilot-handoff.mjs",
     "prepare:multitable-pilot:handoff:release-bound": "bash scripts/ops/multitable-pilot-handoff-release-bound.sh",
     "prepare:multitable-pilot:handoff:staging:release-bound": "RUN_MODE=staging bash scripts/ops/multitable-pilot-handoff-release-bound.sh",

--- a/scripts/ops/multitable-yjs-contract-parity.test.mjs
+++ b/scripts/ops/multitable-yjs-contract-parity.test.mjs
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+
+const rootDir = path.resolve(import.meta.dirname, '../..')
+const contractPath = path.join(rootDir, 'docs/api/multitable-yjs-events.asyncapi.json')
+const backendPath = path.join(rootDir, 'packages/core-backend/src/collab/yjs-websocket-adapter.ts')
+const frontendPath = path.join(rootDir, 'apps/web/src/multitable/composables/useYjsDocument.ts')
+
+const contract = JSON.parse(readFileSync(contractPath, 'utf8'))
+const backend = readFileSync(backendPath, 'utf8')
+const frontend = readFileSync(frontendPath, 'utf8')
+
+const clientEvents = [
+  'yjs:subscribe',
+  'yjs:message',
+  'yjs:update',
+  'yjs:presence',
+  'yjs:unsubscribe',
+]
+
+const serverEvents = [
+  'yjs:message',
+  'yjs:update',
+  'yjs:presence',
+  'yjs:error',
+  'yjs:invalidated',
+]
+
+function collectMessageNames(operation) {
+  return operation.message.oneOf
+    .map((entry) => entry.$ref.replace('#/components/messages/', ''))
+    .map((messageKey) => contract.components.messages[messageKey]?.name)
+    .filter(Boolean)
+}
+
+test('multitable yjs AsyncAPI contract stays aligned with runtime event names', () => {
+  assert.equal(contract.asyncapi, '2.6.0')
+  assert.equal(contract.servers.yjs.url, '/yjs')
+  assert.equal(contract.servers.yjs.protocol, 'socket.io')
+
+  const channel = contract.channels['/yjs']
+  assert.ok(channel, 'missing /yjs channel')
+  assert.equal(channel.bindings.socketio.namespace, '/yjs')
+
+  assert.deepEqual(collectMessageNames(channel.publish), clientEvents)
+  assert.deepEqual(collectMessageNames(channel.subscribe), serverEvents)
+
+  for (const eventName of clientEvents) {
+    assert.match(backend, new RegExp(`socket\\.on\\(\\s*['"]${eventName.replace(':', '\\:')}['"]`), `backend does not listen for ${eventName}`)
+  }
+
+  for (const eventName of serverEvents) {
+    assert.match(backend, new RegExp(`\\.emit\\(\\s*['"]${eventName.replace(':', '\\:')}['"]`), `backend does not emit ${eventName}`)
+  }
+
+  assert.match(frontend, /socketIO\('\/yjs'/, 'frontend does not connect to /yjs namespace')
+  for (const eventName of clientEvents) {
+    assert.match(frontend, new RegExp(`\\.emit\\(\\s*['"]${eventName.replace(':', '\\:')}['"]`), `frontend does not emit ${eventName}`)
+  }
+  for (const eventName of serverEvents) {
+    assert.match(frontend, new RegExp(`socket\\.on\\(\\s*['"]${eventName.replace(':', '\\:')}['"]`), `frontend does not handle ${eventName}`)
+  }
+})
+
+test('multitable yjs contract preserves auth, permission, and invalidation semantics', () => {
+  const errorCodeEnum = contract.components.schemas.YjsError.properties.code.enum
+  assert.deepEqual(errorCodeEnum, ['UNAUTHENTICATED', 'NOT_FOUND', 'FORBIDDEN'])
+  assert.deepEqual(contract.components.schemas.YjsInvalidated.properties.reason.enum, ['rest-write'])
+
+  assert.match(backend, /UNAUTHENTICATED: token required/, 'missing handshake token-required rejection')
+  assert.match(backend, /UNAUTHENTICATED: invalid token/, 'missing handshake invalid-token rejection')
+  assert.match(backend, /code: 'NOT_FOUND', message: 'Record not found'/, 'missing record not-found error')
+  assert.match(backend, /code: 'FORBIDDEN', message: 'No read access'/, 'missing read access error')
+  assert.match(backend, /code: 'FORBIDDEN', message: 'No write access'/, 'missing write access error')
+  assert.match(backend, /code: 'FORBIDDEN', message: 'Not subscribed'/, 'missing not-subscribed error')
+  assert.match(backend, /reason: 'rest-write'/, 'missing rest-write invalidation reason')
+
+  assert.equal(
+    contract.components.schemas.YjsPresenceSnapshot.required.join(','),
+    'recordId,activeCount,users',
+  )
+  assert.equal(
+    contract.components.schemas.YjsPresenceUser.required.join(','),
+    'id,fieldIds',
+  )
+})


### PR DESCRIPTION
## Summary

Add a small machine-readable contract and parity guard for the multitable `/yjs` Socket.IO namespace. This keeps the realtime event contract separate from REST OpenAPI.

- Add `docs/api/multitable-yjs-events.asyncapi.json` for client/server event payloads.
- Add `scripts/ops/multitable-yjs-contract-parity.test.mjs` to statically guard event names, auth/permission error codes, presence payload shape, and `rest-write` invalidation semantics.
- Add `pnpm verify:multitable-yjs:contract`.
- Add development and verification notes.

## Verification

- `pnpm verify:multitable-yjs:contract` — passed, 2 tests.
- `pnpm --filter @metasheet/core-backend exec vitest --config vitest.config.ts run tests/unit/yjs-awareness.test.ts tests/unit/yjs-hardening.test.ts --reporter=dot` — passed, 2 files / 10 tests.
- `pnpm --filter @metasheet/web exec vitest run tests/yjs-awareness-presence.spec.ts tests/yjs-document-invalidation.spec.ts tests/multitable-yjs-cell-binding.spec.ts --reporter=dot` — passed, 3 files / 10 tests.
- `git diff --check` — passed.

## Notes

Frontend Vitest emitted the existing `WebSocket server error: Port is already in use` warning, but all tests exited successfully.

This PR does not change runtime behavior.