### PR TITLE
docs(openapi): align multitable record context schema

### DIFF
--- a/docs/development/multitable-record-context-openapi-development-20260505.md
+++ b/docs/development/multitable-record-context-openapi-development-20260505.md
@@ -1,0 +1,106 @@
+# Multitable Record Context OpenAPI Contract Development - 2026-05-05
+
+## Context
+
+`GET /api/multitable/records/{recordId}` is the record drawer context endpoint.
+The runtime response in `packages/core-backend/src/routes/univer-meta.ts`
+already returns the permission-aware record context used by the web client:
+
+- `capabilityOrigin`
+- `fieldPermissions`
+- `viewPermissions` when a view is resolved
+- `rowActions`
+- `capabilities.canManageSheetAccess`
+- `capabilities.canExport`
+
+The OpenAPI schema still described an older shape with `fieldCapabilities` and
+`dependencyGraph`, and it omitted the current permission/row-action fields.
+That made generated SDK users and contract readers see a stale record drawer
+contract.
+
+This PR is intentionally stacked on top of PR #1293 because PR #1293 already
+owns the multitable OpenAPI source, generated dist files, and parity test block.
+Stacking avoids duplicate generated-file conflicts while #1293 is open.
+
+## Changes
+
+- Updated `MultitableCapabilities` with `canManageSheetAccess` and `canExport`.
+- Added schemas for:
+  - `MultitableCapabilityOrigin`
+  - `MultitableFieldPermission`
+  - `MultitableFieldPermissions`
+  - `MultitableViewPermission`
+  - `MultitableViewPermissions`
+  - `MultitableRowActions`
+- Updated `MultitableRecordContext` to document the runtime fields:
+  - `capabilityOrigin`
+  - `fieldPermissions`
+  - `viewPermissions`
+  - `rowActions`
+- Removed stale `fieldCapabilities` and `dependencyGraph` from
+  `MultitableRecordContext`.
+- Extended `scripts/ops/multitable-openapi-parity.test.mjs` so the runtime
+  record-context fields cannot drift silently again.
+- Regenerated `packages/openapi/dist/*`.
+
+## Runtime Contract
+
+The documented record context now matches the current route shape:
+
+```json
+{
+  "sheet": {},
+  "view": {},
+  "fields": [],
+  "record": {},
+  "capabilities": {
+    "canRead": true,
+    "canCreateRecord": true,
+    "canEditRecord": true,
+    "canDeleteRecord": true,
+    "canManageFields": true,
+    "canManageSheetAccess": true,
+    "canManageViews": true,
+    "canComment": true,
+    "canManageAutomation": true,
+    "canExport": true
+  },
+  "capabilityOrigin": {
+    "source": "sheet-grant",
+    "hasSheetAssignments": true
+  },
+  "fieldPermissions": {
+    "fld_name": {
+      "visible": true,
+      "readOnly": false
+    }
+  },
+  "viewPermissions": {
+    "view_grid": {
+      "canAccess": true,
+      "canConfigure": false,
+      "canDelete": false
+    }
+  },
+  "rowActions": {
+    "canEdit": true,
+    "canDelete": false,
+    "canComment": true
+  },
+  "commentsScope": {},
+  "linkSummaries": {},
+  "attachmentSummaries": {}
+}
+```
+
+`view` and `viewPermissions` remain conditional because the endpoint only emits
+them when `viewId` resolves. `attachmentSummaries` remains conditional because it
+is emitted only when visible attachment fields are present.
+
+## Non-goals
+
+- No backend route behavior changed.
+- No frontend type behavior changed; `apps/web/src/multitable/types.ts` was
+  already aligned with the runtime shape.
+- No attempt was made to move dependency graph or field-capability support into
+  the record drawer response. They are not currently returned by the route.

--- a/docs/development/multitable-record-context-openapi-verification-20260505.md
+++ b/docs/development/multitable-record-context-openapi-verification-20260505.md
@@ -1,0 +1,51 @@
+# Multitable Record Context OpenAPI Contract Verification - 2026-05-05
+
+## Scope
+
+Verification covered the stacked OpenAPI-only record-context update on top of
+PR #1293.
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm verify:multitable-openapi:parity
+pnpm exec tsx packages/openapi/tools/validate.ts packages/openapi/dist/openapi.yaml
+git diff --check
+```
+
+## Results
+
+| Check | Result | Notes |
+| --- | --- | --- |
+| `pnpm install --frozen-lockfile` | PASS | Installed workspace dependencies in the temporary worktree. |
+| `pnpm verify:multitable-openapi:parity` | PASS | Rebuilt OpenAPI dist and passed the multitable parity test. |
+| `pnpm exec tsx packages/openapi/tools/validate.ts packages/openapi/dist/openapi.yaml` | PASS | OpenAPI security validation passed. |
+| `git diff --check` | PASS | No whitespace errors. |
+
+## Assertions Added
+
+The parity test now checks that:
+
+- `MultitableRecordContext.capabilityOrigin` references
+  `MultitableCapabilityOrigin`.
+- `MultitableRecordContext.fieldPermissions` references
+  `MultitableFieldPermissions`.
+- `MultitableRecordContext.viewPermissions` references
+  `MultitableViewPermissions`.
+- `MultitableRecordContext.rowActions` references `MultitableRowActions`.
+- Required runtime fields include `capabilityOrigin`, `fieldPermissions`, and
+  `rowActions`.
+- Stale `fieldCapabilities` and `dependencyGraph` are not documented on
+  `MultitableRecordContext`.
+- `MultitableCapabilityOrigin.source` allows
+  `admin`, `global-rbac`, `sheet-grant`, and `sheet-scope`.
+- `MultitableCapabilities.required` includes `canManageSheetAccess` and
+  `canExport`.
+
+## Risk Notes
+
+- This is a stacked PR and should merge after PR #1293, or be rebased after
+  #1293 lands.
+- The change is OpenAPI/documentation only; runtime behavior was not modified.
+- Generated files were rebuilt from `packages/openapi/src/base.yml`.

--- a/packages/openapi/dist/combined.openapi.yml
+++ b/packages/openapi/dist/combined.openapi.yml
@@ -2024,11 +2024,15 @@ components:
           type: boolean
         canManageFields:
           type: boolean
+        canManageSheetAccess:
+          type: boolean
         canManageViews:
           type: boolean
         canComment:
           type: boolean
         canManageAutomation:
+          type: boolean
+        canExport:
           type: boolean
       required:
         - canRead
@@ -2036,9 +2040,11 @@ components:
         - canEditRecord
         - canDeleteRecord
         - canManageFields
+        - canManageSheetAccess
         - canManageViews
         - canComment
         - canManageAutomation
+        - canExport
     MultitableSheetPermissionAccessLevel:
       type: string
       enum:
@@ -2124,6 +2130,65 @@ components:
       type: object
       additionalProperties:
         $ref: '#/components/schemas/MultitableFieldCapability'
+    MultitableCapabilityOrigin:
+      type: object
+      properties:
+        source:
+          type: string
+          enum:
+            - admin
+            - global-rbac
+            - sheet-grant
+            - sheet-scope
+        hasSheetAssignments:
+          type: boolean
+      required:
+        - source
+        - hasSheetAssignments
+    MultitableFieldPermission:
+      type: object
+      properties:
+        visible:
+          type: boolean
+        readOnly:
+          type: boolean
+      required:
+        - visible
+        - readOnly
+    MultitableFieldPermissions:
+      type: object
+      additionalProperties:
+        $ref: '#/components/schemas/MultitableFieldPermission'
+    MultitableViewPermission:
+      type: object
+      properties:
+        canAccess:
+          type: boolean
+        canConfigure:
+          type: boolean
+        canDelete:
+          type: boolean
+      required:
+        - canAccess
+        - canConfigure
+        - canDelete
+    MultitableViewPermissions:
+      type: object
+      additionalProperties:
+        $ref: '#/components/schemas/MultitableViewPermission'
+    MultitableRowActions:
+      type: object
+      properties:
+        canEdit:
+          type: boolean
+        canDelete:
+          type: boolean
+        canComment:
+          type: boolean
+      required:
+        - canEdit
+        - canDelete
+        - canComment
     MultitableDependencyNode:
       type: object
       properties:
@@ -2310,14 +2375,14 @@ components:
           $ref: '#/components/schemas/MultitableRecord'
         capabilities:
           $ref: '#/components/schemas/MultitableCapabilities'
-        fieldCapabilities:
-          allOf:
-            - $ref: '#/components/schemas/MultitableFieldCapabilities'
-          nullable: true
-        dependencyGraph:
-          allOf:
-            - $ref: '#/components/schemas/MultitableDependencyGraph'
-          nullable: true
+        capabilityOrigin:
+          $ref: '#/components/schemas/MultitableCapabilityOrigin'
+        fieldPermissions:
+          $ref: '#/components/schemas/MultitableFieldPermissions'
+        viewPermissions:
+          $ref: '#/components/schemas/MultitableViewPermissions'
+        rowActions:
+          $ref: '#/components/schemas/MultitableRowActions'
         commentsScope:
           $ref: '#/components/schemas/MultitableCommentsScope'
         linkSummaries:
@@ -2329,6 +2394,9 @@ components:
         - fields
         - record
         - capabilities
+        - capabilityOrigin
+        - fieldPermissions
+        - rowActions
         - commentsScope
         - linkSummaries
     MultitableFormContext:

--- a/packages/openapi/dist/openapi.json
+++ b/packages/openapi/dist/openapi.json
@@ -2903,6 +2903,9 @@
           "canManageFields": {
             "type": "boolean"
           },
+          "canManageSheetAccess": {
+            "type": "boolean"
+          },
           "canManageViews": {
             "type": "boolean"
           },
@@ -2910,6 +2913,9 @@
             "type": "boolean"
           },
           "canManageAutomation": {
+            "type": "boolean"
+          },
+          "canExport": {
             "type": "boolean"
           }
         },
@@ -2919,9 +2925,11 @@
           "canEditRecord",
           "canDeleteRecord",
           "canManageFields",
+          "canManageSheetAccess",
           "canManageViews",
           "canComment",
-          "canManageAutomation"
+          "canManageAutomation",
+          "canExport"
         ]
       },
       "MultitableSheetPermissionAccessLevel": {
@@ -3045,6 +3053,92 @@
         "additionalProperties": {
           "$ref": "#/components/schemas/MultitableFieldCapability"
         }
+      },
+      "MultitableCapabilityOrigin": {
+        "type": "object",
+        "properties": {
+          "source": {
+            "type": "string",
+            "enum": [
+              "admin",
+              "global-rbac",
+              "sheet-grant",
+              "sheet-scope"
+            ]
+          },
+          "hasSheetAssignments": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "source",
+          "hasSheetAssignments"
+        ]
+      },
+      "MultitableFieldPermission": {
+        "type": "object",
+        "properties": {
+          "visible": {
+            "type": "boolean"
+          },
+          "readOnly": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "visible",
+          "readOnly"
+        ]
+      },
+      "MultitableFieldPermissions": {
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/components/schemas/MultitableFieldPermission"
+        }
+      },
+      "MultitableViewPermission": {
+        "type": "object",
+        "properties": {
+          "canAccess": {
+            "type": "boolean"
+          },
+          "canConfigure": {
+            "type": "boolean"
+          },
+          "canDelete": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "canAccess",
+          "canConfigure",
+          "canDelete"
+        ]
+      },
+      "MultitableViewPermissions": {
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/components/schemas/MultitableViewPermission"
+        }
+      },
+      "MultitableRowActions": {
+        "type": "object",
+        "properties": {
+          "canEdit": {
+            "type": "boolean"
+          },
+          "canDelete": {
+            "type": "boolean"
+          },
+          "canComment": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "canEdit",
+          "canDelete",
+          "canComment"
+        ]
       },
       "MultitableDependencyNode": {
         "type": "object",
@@ -3327,21 +3421,17 @@
           "capabilities": {
             "$ref": "#/components/schemas/MultitableCapabilities"
           },
-          "fieldCapabilities": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/MultitableFieldCapabilities"
-              }
-            ],
-            "nullable": true
+          "capabilityOrigin": {
+            "$ref": "#/components/schemas/MultitableCapabilityOrigin"
           },
-          "dependencyGraph": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/MultitableDependencyGraph"
-              }
-            ],
-            "nullable": true
+          "fieldPermissions": {
+            "$ref": "#/components/schemas/MultitableFieldPermissions"
+          },
+          "viewPermissions": {
+            "$ref": "#/components/schemas/MultitableViewPermissions"
+          },
+          "rowActions": {
+            "$ref": "#/components/schemas/MultitableRowActions"
           },
           "commentsScope": {
             "$ref": "#/components/schemas/MultitableCommentsScope"
@@ -3358,6 +3448,9 @@
           "fields",
           "record",
           "capabilities",
+          "capabilityOrigin",
+          "fieldPermissions",
+          "rowActions",
           "commentsScope",
           "linkSummaries"
         ]

--- a/packages/openapi/dist/openapi.yaml
+++ b/packages/openapi/dist/openapi.yaml
@@ -2024,11 +2024,15 @@ components:
           type: boolean
         canManageFields:
           type: boolean
+        canManageSheetAccess:
+          type: boolean
         canManageViews:
           type: boolean
         canComment:
           type: boolean
         canManageAutomation:
+          type: boolean
+        canExport:
           type: boolean
       required:
         - canRead
@@ -2036,9 +2040,11 @@ components:
         - canEditRecord
         - canDeleteRecord
         - canManageFields
+        - canManageSheetAccess
         - canManageViews
         - canComment
         - canManageAutomation
+        - canExport
     MultitableSheetPermissionAccessLevel:
       type: string
       enum:
@@ -2124,6 +2130,65 @@ components:
       type: object
       additionalProperties:
         $ref: '#/components/schemas/MultitableFieldCapability'
+    MultitableCapabilityOrigin:
+      type: object
+      properties:
+        source:
+          type: string
+          enum:
+            - admin
+            - global-rbac
+            - sheet-grant
+            - sheet-scope
+        hasSheetAssignments:
+          type: boolean
+      required:
+        - source
+        - hasSheetAssignments
+    MultitableFieldPermission:
+      type: object
+      properties:
+        visible:
+          type: boolean
+        readOnly:
+          type: boolean
+      required:
+        - visible
+        - readOnly
+    MultitableFieldPermissions:
+      type: object
+      additionalProperties:
+        $ref: '#/components/schemas/MultitableFieldPermission'
+    MultitableViewPermission:
+      type: object
+      properties:
+        canAccess:
+          type: boolean
+        canConfigure:
+          type: boolean
+        canDelete:
+          type: boolean
+      required:
+        - canAccess
+        - canConfigure
+        - canDelete
+    MultitableViewPermissions:
+      type: object
+      additionalProperties:
+        $ref: '#/components/schemas/MultitableViewPermission'
+    MultitableRowActions:
+      type: object
+      properties:
+        canEdit:
+          type: boolean
+        canDelete:
+          type: boolean
+        canComment:
+          type: boolean
+      required:
+        - canEdit
+        - canDelete
+        - canComment
     MultitableDependencyNode:
       type: object
       properties:
@@ -2310,14 +2375,14 @@ components:
           $ref: '#/components/schemas/MultitableRecord'
         capabilities:
           $ref: '#/components/schemas/MultitableCapabilities'
-        fieldCapabilities:
-          allOf:
-            - $ref: '#/components/schemas/MultitableFieldCapabilities'
-          nullable: true
-        dependencyGraph:
-          allOf:
-            - $ref: '#/components/schemas/MultitableDependencyGraph'
-          nullable: true
+        capabilityOrigin:
+          $ref: '#/components/schemas/MultitableCapabilityOrigin'
+        fieldPermissions:
+          $ref: '#/components/schemas/MultitableFieldPermissions'
+        viewPermissions:
+          $ref: '#/components/schemas/MultitableViewPermissions'
+        rowActions:
+          $ref: '#/components/schemas/MultitableRowActions'
         commentsScope:
           $ref: '#/components/schemas/MultitableCommentsScope'
         linkSummaries:
@@ -2329,6 +2394,9 @@ components:
         - fields
         - record
         - capabilities
+        - capabilityOrigin
+        - fieldPermissions
+        - rowActions
         - commentsScope
         - linkSummaries
     MultitableFormContext:

--- a/packages/openapi/src/base.yml
+++ b/packages/openapi/src/base.yml
@@ -1958,11 +1958,15 @@ components:
           type: boolean
         canManageFields:
           type: boolean
+        canManageSheetAccess:
+          type: boolean
         canManageViews:
           type: boolean
         canComment:
           type: boolean
         canManageAutomation:
+          type: boolean
+        canExport:
           type: boolean
       required:
         - canRead
@@ -1970,9 +1974,11 @@ components:
         - canEditRecord
         - canDeleteRecord
         - canManageFields
+        - canManageSheetAccess
         - canManageViews
         - canComment
         - canManageAutomation
+        - canExport
     MultitableSheetPermissionAccessLevel:
       type: string
       enum: [read, write, write-own, admin]
@@ -2052,6 +2058,61 @@ components:
       type: object
       additionalProperties:
         $ref: '#/components/schemas/MultitableFieldCapability'
+    MultitableCapabilityOrigin:
+      type: object
+      properties:
+        source:
+          type: string
+          enum: [admin, global-rbac, sheet-grant, sheet-scope]
+        hasSheetAssignments:
+          type: boolean
+      required:
+        - source
+        - hasSheetAssignments
+    MultitableFieldPermission:
+      type: object
+      properties:
+        visible:
+          type: boolean
+        readOnly:
+          type: boolean
+      required:
+        - visible
+        - readOnly
+    MultitableFieldPermissions:
+      type: object
+      additionalProperties:
+        $ref: '#/components/schemas/MultitableFieldPermission'
+    MultitableViewPermission:
+      type: object
+      properties:
+        canAccess:
+          type: boolean
+        canConfigure:
+          type: boolean
+        canDelete:
+          type: boolean
+      required:
+        - canAccess
+        - canConfigure
+        - canDelete
+    MultitableViewPermissions:
+      type: object
+      additionalProperties:
+        $ref: '#/components/schemas/MultitableViewPermission'
+    MultitableRowActions:
+      type: object
+      properties:
+        canEdit:
+          type: boolean
+        canDelete:
+          type: boolean
+        canComment:
+          type: boolean
+      required:
+        - canEdit
+        - canDelete
+        - canComment
     MultitableDependencyNode:
       type: object
       properties:
@@ -2225,14 +2286,14 @@ components:
           $ref: '#/components/schemas/MultitableRecord'
         capabilities:
           $ref: '#/components/schemas/MultitableCapabilities'
-        fieldCapabilities:
-          allOf:
-            - $ref: '#/components/schemas/MultitableFieldCapabilities'
-          nullable: true
-        dependencyGraph:
-          allOf:
-            - $ref: '#/components/schemas/MultitableDependencyGraph'
-          nullable: true
+        capabilityOrigin:
+          $ref: '#/components/schemas/MultitableCapabilityOrigin'
+        fieldPermissions:
+          $ref: '#/components/schemas/MultitableFieldPermissions'
+        viewPermissions:
+          $ref: '#/components/schemas/MultitableViewPermissions'
+        rowActions:
+          $ref: '#/components/schemas/MultitableRowActions'
         commentsScope:
           $ref: '#/components/schemas/MultitableCommentsScope'
         linkSummaries:
@@ -2244,6 +2305,9 @@ components:
         - fields
         - record
         - capabilities
+        - capabilityOrigin
+        - fieldPermissions
+        - rowActions
         - commentsScope
         - linkSummaries
     MultitableFormContext:

--- a/scripts/ops/multitable-openapi-parity.test.mjs
+++ b/scripts/ops/multitable-openapi-parity.test.mjs
@@ -173,6 +173,52 @@ test('multitable openapi stays aligned with runtime contracts', () => {
     '#/components/schemas/MultitableAttachmentSummaryMap',
   )
   assert.equal(
+    schemas.MultitableRecordContext?.properties?.capabilityOrigin?.$ref,
+    '#/components/schemas/MultitableCapabilityOrigin',
+  )
+  assert.equal(
+    schemas.MultitableRecordContext?.properties?.fieldPermissions?.$ref,
+    '#/components/schemas/MultitableFieldPermissions',
+  )
+  assert.equal(
+    schemas.MultitableRecordContext?.properties?.viewPermissions?.$ref,
+    '#/components/schemas/MultitableViewPermissions',
+  )
+  assert.equal(
+    schemas.MultitableRecordContext?.properties?.rowActions?.$ref,
+    '#/components/schemas/MultitableRowActions',
+  )
+  assert.ok(
+    schemas.MultitableRecordContext?.required?.includes('capabilityOrigin'),
+    'record context must document runtime capabilityOrigin',
+  )
+  assert.ok(
+    schemas.MultitableRecordContext?.required?.includes('fieldPermissions'),
+    'record context must document runtime fieldPermissions',
+  )
+  assert.ok(
+    schemas.MultitableRecordContext?.required?.includes('rowActions'),
+    'record context must document runtime rowActions',
+  )
+  assert.equal(
+    Object.hasOwn(schemas.MultitableRecordContext?.properties ?? {}, 'fieldCapabilities'),
+    false,
+    'record context should not expose stale fieldCapabilities',
+  )
+  assert.equal(
+    Object.hasOwn(schemas.MultitableRecordContext?.properties ?? {}, 'dependencyGraph'),
+    false,
+    'record context should not expose stale dependencyGraph',
+  )
+  assert.equal(
+    schemas.MultitableCapabilityOrigin?.properties?.source?.enum?.join(','),
+    'admin,global-rbac,sheet-grant,sheet-scope',
+  )
+  assert.deepEqual(
+    schemas.MultitableCapabilities?.required?.filter((key) => key === 'canManageSheetAccess' || key === 'canExport'),
+    ['canManageSheetAccess', 'canExport'],
+  )
+  assert.equal(
     schemas.MultitableFormContext?.properties?.attachmentSummaries?.$ref,
     '#/components/schemas/MultitableAttachmentSummaryMap',
   )


### PR DESCRIPTION
Stacked on #1293. This PR keeps the OpenAPI record drawer contract aligned with the current runtime response for GET /api/multitable/records/{recordId}.

What changed:
- Add MultitableCapabilityOrigin, field/view permission maps, and row actions schemas.
- Add canManageSheetAccess and canExport to MultitableCapabilities.
- Update MultitableRecordContext to document capabilityOrigin, fieldPermissions, optional viewPermissions, and rowActions.
- Remove stale fieldCapabilities/dependencyGraph from the record context schema.
- Extend scripts/ops/multitable-openapi-parity.test.mjs and regenerate packages/openapi/dist/*.
- Add development and verification notes under docs/development/.

Verification:
- pnpm install --frozen-lockfile
- pnpm verify:multitable-openapi:parity
- pnpm exec tsx packages/openapi/tools/validate.ts packages/openapi/dist/openapi.yaml
- git diff --check

Merge note: merge #1293 first, then rebase/retarget this PR to main if needed.