### PR TITLE
fix(multitable): escape formula string references

### DIFF
--- a/docs/development/multitable-formula-string-escaping-development-20260505.md
+++ b/docs/development/multitable-formula-string-escaping-development-20260505.md
@@ -1,0 +1,41 @@
+# Multitable Formula String Escaping Development
+
+Date: 2026-05-05
+Branch: `codex/multitable-formula-string-escaping-20260505`
+
+## Scope
+
+This slice fixes the string-literal gap called out in the Feishu parity audit:
+multitable formula field references were interpolated with raw double quotes.
+Values containing quotes, backslashes, or control characters could therefore
+produce malformed formula expressions and return `#ERROR!`.
+
+## Design
+
+`MultitableFormulaEngine.evaluateField()` now converts string field values with
+`JSON.stringify(...)` before injecting them into the formula expression. This
+produces a valid quoted string literal for:
+
+- embedded double quotes;
+- backslashes;
+- newlines and other JSON-escaped control characters.
+
+The base `FormulaEngine` string parser now decodes quoted literals with
+`JSON.parse(...)` instead of returning `slice(1, -1)`. That keeps escaped
+multitable values semantically correct after parsing. Malformed quoted string
+literals now become `#ERROR!` instead of being treated as a partially escaped
+plain string.
+
+## Files Changed
+
+- `packages/core-backend/src/multitable/formula-engine.ts`
+- `packages/core-backend/src/formula/engine.ts`
+- `packages/core-backend/tests/unit/multitable-formula-engine.test.ts`
+
+## Compatibility
+
+Normal quoted formula strings keep the same behavior. The change only affects
+escaped quoted literals, where previous behavior either broke parsing or leaked
+escape backslashes into the result.
+
+No database, API, frontend, OpenAPI, or DingTalk/public-form files are touched.

--- a/docs/development/multitable-formula-string-escaping-verification-20260505.md
+++ b/docs/development/multitable-formula-string-escaping-verification-20260505.md
@@ -1,0 +1,50 @@
+# Multitable Formula String Escaping Verification
+
+Date: 2026-05-05
+Branch: `codex/multitable-formula-string-escaping-20260505`
+
+## Commands Run
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/multitable-formula-engine.test.ts \
+  tests/unit/formula-engine.test.ts \
+  --reporter=dot
+pnpm --filter @metasheet/core-backend build
+git diff --check
+```
+
+## Results
+
+Targeted formula tests:
+
+- 2 files passed;
+- 92 tests passed.
+
+Build:
+
+- `@metasheet/core-backend` TypeScript build passed.
+
+Diff hygiene:
+
+- `git diff --check` passed.
+
+## New Coverage
+
+Added regression coverage for:
+
+- formula literals with escaped quotes and backslashes;
+- malformed quoted formula literals returning `#ERROR!`;
+- multitable field references containing embedded quotes;
+- multitable field references containing backslashes and newlines.
+
+## Non-Failing Noise
+
+The formula test suite logs an expected error for the existing invalid-function
+case. The test asserts that invalid functions return `#ERROR!`; this is not a
+regression from this slice.
+
+`pnpm install` updated plugin and CLI `node_modules` symlink metadata in the
+temporary worktree. Those generated dependency changes were reverted before
+commit.

--- a/packages/core-backend/src/formula/engine.ts
+++ b/packages/core-backend/src/formula/engine.ts
@@ -307,7 +307,11 @@ export class FormulaEngine {
 
     // Check if it's a string (quoted)
     if (formula.startsWith('"') && formula.endsWith('"')) {
-      return { type: 'string', value: formula.slice(1, -1) }
+      try {
+        return { type: 'string', value: JSON.parse(formula) as string }
+      } catch {
+        return { type: 'error', value: '#ERROR!' }
+      }
     }
 
     // Check if it's an array literal (e.g. [[1, 2], [3, 4]])

--- a/packages/core-backend/src/multitable/formula-engine.ts
+++ b/packages/core-backend/src/multitable/formula-engine.ts
@@ -61,7 +61,7 @@ export class MultitableFormulaEngine {
     const resolved = expression.replace(FIELD_REF_PATTERN, (_match, fieldId: string) => {
       const value = recordData[fieldId]
       if (value === null || value === undefined) return '0'
-      if (typeof value === 'string') return `"${value}"`
+      if (typeof value === 'string') return JSON.stringify(value)
       if (typeof value === 'number') return String(value)
       if (typeof value === 'boolean') return value ? 'TRUE' : 'FALSE'
       return String(value)

--- a/packages/core-backend/tests/unit/multitable-formula-engine.test.ts
+++ b/packages/core-backend/tests/unit/multitable-formula-engine.test.ts
@@ -60,6 +60,16 @@ describe('FormulaEngine - new functions', () => {
       const result = await engine.calculate('=CONCAT("val",1)', makeContext())
       expect(result).toBe('val1')
     })
+
+    it('decodes escaped quoted string literals', async () => {
+      const result = await engine.calculate('=CONCAT("A \\"quoted\\" value","\\\\path")', makeContext())
+      expect(result).toBe('A "quoted" value\\path')
+    })
+
+    it('returns #ERROR! for malformed quoted string literals', async () => {
+      const result = await engine.calculate('=CONCAT("bad \\\\","suffix")', makeContext())
+      expect(result).toBe('#ERROR!')
+    })
   })
 
   describe('DATEDIF', () => {
@@ -158,6 +168,24 @@ describe('MultitableFormulaEngine', () => {
         sampleFields,
       )
       expect(result).toBe('Widget total')
+    })
+
+    it('escapes quoted string field references before evaluation', async () => {
+      const result = await mtEngine.evaluateField(
+        '=CONCAT({fld_name}," shipped")',
+        { fld_name: 'Widget "Pro"' },
+        sampleFields,
+      )
+      expect(result).toBe('Widget "Pro" shipped')
+    })
+
+    it('escapes backslash and newline string field references', async () => {
+      const result = await mtEngine.evaluateField(
+        '=CONCAT({fld_name}," done")',
+        { fld_name: 'C:\\temp\nline2' },
+        sampleFields,
+      )
+      expect(result).toBe('C:\\temp\nline2 done')
     })
   })
 


### PR DESCRIPTION
## Summary\n- escape multitable string field references with JSON string literals before formula evaluation\n- decode quoted formula literals with JSON.parse so escaped quotes/backslashes/newlines round-trip correctly\n- return #ERROR! for malformed quoted literals instead of accepting broken escapes\n- add design and verification notes\n\n## Verification\n- pnpm install --frozen-lockfile\n- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/multitable-formula-engine.test.ts tests/unit/formula-engine.test.ts --reporter=dot\n- pnpm --filter @metasheet/core-backend build\n- git diff --check