### PR TITLE
fix(formula): tokenize top-level operators

### DIFF
--- a/docs/development/formula-top-level-operator-tokenizer-development-20260505.md
+++ b/docs/development/formula-top-level-operator-tokenizer-development-20260505.md
@@ -1,0 +1,46 @@
+# Formula Top-Level Operator Tokenizer Development
+
+Date: 2026-05-05
+Branch: `codex/formula-operator-tokenizer-20260505`
+
+## Scope
+
+This slice hardens the formula parser after the multitable string escaping fix.
+The prior parser found binary operators with `formula.split(op)`, so quoted
+string literals containing operator characters could be interpreted as formula
+operators.
+
+Examples that should stay literal:
+
+- `"A+B"`
+- `"A=B"`
+- `"a>b"`
+
+## Design
+
+`FormulaEngine.parseFormula(...)` now resolves binary operators through
+`findTopLevelOperator(...)`.
+
+The helper scans the expression once for each operator and ignores operator
+text while inside:
+
+- quoted string literals;
+- escaped quote sequences;
+- parenthesized function arguments;
+- array literals.
+
+This preserves the existing parser shape and operator ordering while removing
+the unsafe global split behavior. The change intentionally does not rewrite
+formula precedence or introduce a new parser grammar.
+
+## Files Changed
+
+- `packages/core-backend/src/formula/engine.ts`
+- `packages/core-backend/tests/unit/multitable-formula-engine.test.ts`
+
+## Non-Goals
+
+- No formula precedence rewrite.
+- No support for new formula functions.
+- No frontend formula editor work.
+- No OpenAPI or database changes.

--- a/docs/development/formula-top-level-operator-tokenizer-verification-20260505.md
+++ b/docs/development/formula-top-level-operator-tokenizer-verification-20260505.md
@@ -1,0 +1,51 @@
+# Formula Top-Level Operator Tokenizer Verification
+
+Date: 2026-05-05
+Branch: `codex/formula-operator-tokenizer-20260505`
+
+## Commands Run
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/multitable-formula-engine.test.ts \
+  tests/unit/formula-engine.test.ts \
+  --reporter=dot
+pnpm --filter @metasheet/core-backend build
+git diff --check
+```
+
+## Results
+
+Targeted formula tests:
+
+- 2 files passed;
+- 95 tests passed.
+
+Build:
+
+- `@metasheet/core-backend` TypeScript build passed.
+
+Diff hygiene:
+
+- `git diff --check` passed.
+
+## New Coverage
+
+Added regression coverage for:
+
+- `="A+B"` staying a string literal;
+- `="A=B"` staying a string literal;
+- `"A=B"="A=B"` evaluating as a top-level comparison;
+- `IF("a>b"="a>b","ok","bad")` preserving operators inside nested arguments;
+- multitable string field references containing operator characters.
+
+## Non-Failing Noise
+
+The formula test suite logs an expected error for the existing invalid-function
+case. The test asserts that invalid functions return `#ERROR!`; this is not a
+regression from this slice.
+
+`pnpm install` updated plugin and CLI `node_modules` symlink metadata in the
+temporary worktree. Those generated dependency changes were reverted before
+commit.

--- a/packages/core-backend/src/formula/engine.ts
+++ b/packages/core-backend/src/formula/engine.ts
@@ -273,13 +273,13 @@ export class FormulaEngine {
     // Sort operators by length descending to match >= before >
     const operators = ['>=', '<=', '<>', '+', '-', '*', '/', '=', '>', '<']
     for (const op of operators) {
-      const parts = formula.split(op)
-      if (parts.length === 2) {
+      const operatorIndex = this.findTopLevelOperator(formula, op)
+      if (operatorIndex >= 0) {
         return {
           type: 'operator',
           operator: op,
-          left: this.parseFormula(parts[0].trim()),
-          right: this.parseFormula(parts[1].trim())
+          left: this.parseFormula(formula.slice(0, operatorIndex).trim()),
+          right: this.parseFormula(formula.slice(operatorIndex + op.length).trim())
         }
       }
     }
@@ -338,6 +338,40 @@ export class FormulaEngine {
     }
 
     return { type: 'string', value: formula }
+  }
+
+  /**
+   * Find an operator that is not inside quoted strings, function arguments, or arrays.
+   */
+  private findTopLevelOperator(formula: string, operator: string): number {
+    let depth = 0
+    let inQuotes = false
+
+    for (let i = 0; i <= formula.length - operator.length; i++) {
+      const char = formula[i]
+
+      if (char === '"' && (i === 0 || formula[i - 1] !== '\\')) {
+        inQuotes = !inQuotes
+        continue
+      }
+
+      if (inQuotes) continue
+
+      if (char === '(' || char === '[') {
+        depth++
+        continue
+      }
+      if (char === ')' || char === ']') {
+        depth--
+        continue
+      }
+
+      if (depth === 0 && formula.startsWith(operator, i)) {
+        return i
+      }
+    }
+
+    return -1
   }
 
   /**

--- a/packages/core-backend/tests/unit/multitable-formula-engine.test.ts
+++ b/packages/core-backend/tests/unit/multitable-formula-engine.test.ts
@@ -70,6 +70,21 @@ describe('FormulaEngine - new functions', () => {
       const result = await engine.calculate('=CONCAT("bad \\\\","suffix")', makeContext())
       expect(result).toBe('#ERROR!')
     })
+
+    it('does not split operators inside quoted string literals', async () => {
+      const plusResult = await engine.calculate('="A+B"', makeContext())
+      const equalsResult = await engine.calculate('="A=B"', makeContext())
+      const comparisonResult = await engine.calculate('="A=B"="A=B"', makeContext())
+
+      expect(plusResult).toBe('A+B')
+      expect(equalsResult).toBe('A=B')
+      expect(comparisonResult).toBe(true)
+    })
+
+    it('does not split operators inside nested function arguments', async () => {
+      const result = await engine.calculate('=IF("a>b"="a>b","ok","bad")', makeContext())
+      expect(result).toBe('ok')
+    })
   })
 
   describe('DATEDIF', () => {
@@ -186,6 +201,15 @@ describe('MultitableFormulaEngine', () => {
         sampleFields,
       )
       expect(result).toBe('C:\\temp\nline2 done')
+    })
+
+    it('does not split operators inside string field references', async () => {
+      const result = await mtEngine.evaluateField(
+        '={fld_name}="A+B=C"',
+        { fld_name: 'A+B=C' },
+        sampleFields,
+      )
+      expect(result).toBe(true)
     })
   })
 


### PR DESCRIPTION
## Summary\n- replace formula-wide operator split with top-level operator scanning\n- ignore operators inside quoted strings, escaped quotes, function arguments, and arrays\n- add regressions for quoted literals and multitable field references containing operator characters\n- add design and verification docs\n\n## Verification\n- pnpm install --frozen-lockfile\n- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/multitable-formula-engine.test.ts tests/unit/formula-engine.test.ts --reporter=dot\n- pnpm --filter @metasheet/core-backend build\n- git diff --check