### PR TITLE
docs(openapi): align multitable context permission schemas

### DIFF
--- a/docs/development/multitable-context-permission-openapi-development-20260505.md
+++ b/docs/development/multitable-context-permission-openapi-development-20260505.md
@@ -1,0 +1,65 @@
+# Multitable Context Permission OpenAPI Development - 2026-05-05
+
+## Scope
+
+This slice aligns the remaining multitable context OpenAPI schemas with the
+permission-aware runtime responses now returned by the backend.
+
+It follows the same cleanup direction as the record drawer contract update:
+document the fields the routes actually emit, and stop advertising older
+`fieldCapabilities` / `dependencyGraph` fields where those routes no longer
+return them.
+
+## Runtime Surfaces Checked
+
+- `GET /api/multitable/context`
+- `GET /api/multitable/view`
+- `GET /api/multitable/form-context`
+
+## Changes
+
+- Added `MultitableScopedPermissions` for the shared permission payload used in
+  `MultitableViewMeta.permissions`.
+- Added `member-group` to `MultitableSheetPermissionSubjectType`, matching the
+  runtime/frontend sheet-permission subject contract.
+- Extended `MultitableViewMeta` with:
+  - `capabilityOrigin`
+  - `permissions`
+- Extended `MultitableContext` with:
+  - `capabilityOrigin`
+  - `fieldPermissions`
+  - `viewPermissions`
+- Extended `MultitableFormContext` with:
+  - `capabilityOrigin`
+  - `fieldPermissions`
+  - `viewPermissions`
+  - `rowActions`
+- Removed stale `fieldCapabilities` / `dependencyGraph` properties from:
+  - `MultitableViewData`
+  - `MultitableFormContext`
+- Removed stale `fieldCapabilities` from `MultitableContext`.
+- Regenerated `packages/openapi/dist/*`.
+- Added parity assertions in `scripts/ops/multitable-openapi-parity.test.mjs`.
+
+## Why This Is OpenAPI-only
+
+The backend and frontend types were already permission-aware:
+
+- the context route returns `capabilityOrigin`, `fieldPermissions`, and
+  `viewPermissions`;
+- the view route nests permission information under `data.meta`;
+- the form-context route returns field permissions and conditionally returns
+  capability origin, view permissions, and row actions;
+- `apps/web/src/multitable/types.ts` already models these fields.
+
+The stale part was the published OpenAPI contract and its generated dist files.
+
+## Compatibility Notes
+
+- `MultitableFormContext.capabilityOrigin` is optional because public form access
+  intentionally omits host-user capability origin.
+- `MultitableFormContext.rowActions` is optional because create-form context does
+  not include an existing record.
+- `MultitableViewMeta` remains optional on `MultitableViewData`, matching the
+  existing schema shape, but now describes the permission fields present when
+  meta is emitted.

--- a/docs/development/multitable-context-permission-openapi-verification-20260505.md
+++ b/docs/development/multitable-context-permission-openapi-verification-20260505.md
@@ -1,0 +1,61 @@
+# Multitable Context Permission OpenAPI Verification - 2026-05-05
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm verify:multitable-openapi:parity
+pnpm exec tsx packages/openapi/tools/validate.ts packages/openapi/dist/openapi.yaml
+pnpm --filter @metasheet/web exec vitest run \
+  tests/multitable-client.spec.ts \
+  tests/multitable-scoped-permissions.spec.ts \
+  tests/multitable-form-share-manager.spec.ts \
+  --watch=false
+git diff --check
+```
+
+## Results
+
+| Check | Result | Notes |
+| --- | --- | --- |
+| `pnpm install --frozen-lockfile` | PASS | Installed dependencies in the temporary worktree. |
+| `pnpm verify:multitable-openapi:parity` | PASS | Rebuilt OpenAPI dist and passed the multitable parity test. |
+| `pnpm exec tsx packages/openapi/tools/validate.ts packages/openapi/dist/openapi.yaml` | PASS | OpenAPI security validation passed. |
+| frontend multitable permission/client specs | PASS | 3 files / 42 tests passed. |
+| `git diff --check` | PASS | No whitespace errors. |
+
+## Parity Assertions Added
+
+- `MultitableViewData.meta` still references `MultitableViewMeta`.
+- `MultitableSheetPermissionSubjectType` includes `member-group`.
+- `MultitableViewMeta.capabilityOrigin` references
+  `MultitableCapabilityOrigin`.
+- `MultitableViewMeta.permissions` references `MultitableScopedPermissions`.
+- `MultitableScopedPermissions` documents field permissions, view permissions,
+  default row actions, and per-record row-action overrides.
+- `MultitableContext` documents runtime `capabilityOrigin`,
+  `fieldPermissions`, and `viewPermissions`.
+- `MultitableFormContext` documents runtime `capabilityOrigin`,
+  `fieldPermissions`, `viewPermissions`, and `rowActions`.
+- Stale `fieldCapabilities` / `dependencyGraph` are rejected on view and form
+  context schemas where the runtime no longer emits them.
+
+## Local Worktree Notes
+
+`pnpm install --frozen-lockfile` produced the usual plugin/tool `node_modules`
+symlink modifications in this isolated worktree. Those generated dependency
+changes were restored before commit and are not part of the patch.
+
+An extra backend integration probe was also attempted:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest \
+  --config vitest.integration.config.ts \
+  run tests/integration/multitable-sheet-permissions.api.test.ts \
+  --reporter=dot
+```
+
+It failed locally with existing fixture drift (`Unhandled SQL in test` for
+record-service and permission-candidate queries). This slice does not change
+runtime code, so the failure is recorded as a pre-existing local integration
+fixture blocker rather than a regression from the OpenAPI contract update.

--- a/packages/openapi/dist/combined.openapi.yml
+++ b/packages/openapi/dist/combined.openapi.yml
@@ -2011,6 +2011,10 @@ components:
           type: array
           items:
             type: string
+        capabilityOrigin:
+          $ref: '#/components/schemas/MultitableCapabilityOrigin'
+        permissions:
+          $ref: '#/components/schemas/MultitableScopedPermissions'
     MultitableCapabilities:
       type: object
       properties:
@@ -2057,6 +2061,7 @@ components:
       enum:
         - user
         - role
+        - member-group
     MultitableSheetPermissionEntry:
       type: object
       properties:
@@ -2189,6 +2194,19 @@ components:
         - canEdit
         - canDelete
         - canComment
+    MultitableScopedPermissions:
+      type: object
+      properties:
+        fieldPermissions:
+          $ref: '#/components/schemas/MultitableFieldPermissions'
+        viewPermissions:
+          $ref: '#/components/schemas/MultitableViewPermissions'
+        rowActions:
+          $ref: '#/components/schemas/MultitableRowActions'
+        rowActionOverrides:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/MultitableRowActions'
     MultitableDependencyNode:
       type: object
       properties:
@@ -2317,10 +2335,19 @@ components:
             $ref: '#/components/schemas/MultitableView'
         capabilities:
           $ref: '#/components/schemas/MultitableCapabilities'
-        fieldCapabilities:
-          allOf:
-            - $ref: '#/components/schemas/MultitableFieldCapabilities'
-          nullable: true
+        capabilityOrigin:
+          $ref: '#/components/schemas/MultitableCapabilityOrigin'
+        fieldPermissions:
+          $ref: '#/components/schemas/MultitableFieldPermissions'
+        viewPermissions:
+          $ref: '#/components/schemas/MultitableViewPermissions'
+      required:
+        - sheets
+        - views
+        - capabilities
+        - capabilityOrigin
+        - fieldPermissions
+        - viewPermissions
     MultitableViewData:
       type: object
       properties:
@@ -2338,14 +2365,6 @@ components:
           $ref: '#/components/schemas/MultitableViewLinkSummaries'
         attachmentSummaries:
           $ref: '#/components/schemas/MultitableViewAttachmentSummaries'
-        fieldCapabilities:
-          allOf:
-            - $ref: '#/components/schemas/MultitableFieldCapabilities'
-          nullable: true
-        dependencyGraph:
-          allOf:
-            - $ref: '#/components/schemas/MultitableDependencyGraph'
-          nullable: true
         view:
           allOf:
             - $ref: '#/components/schemas/MultitableView'
@@ -2422,14 +2441,14 @@ components:
             $ref: '#/components/schemas/MultitableField'
         capabilities:
           $ref: '#/components/schemas/MultitableCapabilities'
-        fieldCapabilities:
-          allOf:
-            - $ref: '#/components/schemas/MultitableFieldCapabilities'
-          nullable: true
-        dependencyGraph:
-          allOf:
-            - $ref: '#/components/schemas/MultitableDependencyGraph'
-          nullable: true
+        capabilityOrigin:
+          $ref: '#/components/schemas/MultitableCapabilityOrigin'
+        fieldPermissions:
+          $ref: '#/components/schemas/MultitableFieldPermissions'
+        viewPermissions:
+          $ref: '#/components/schemas/MultitableViewPermissions'
+        rowActions:
+          $ref: '#/components/schemas/MultitableRowActions'
         record:
           allOf:
             - $ref: '#/components/schemas/MultitableRecord'
@@ -2447,6 +2466,7 @@ components:
         - sheet
         - fields
         - capabilities
+        - fieldPermissions
     MultitablePersonFieldPrepareResult:
       type: object
       properties:

--- a/packages/openapi/dist/openapi.json
+++ b/packages/openapi/dist/openapi.json
@@ -2882,6 +2882,12 @@
             "items": {
               "type": "string"
             }
+          },
+          "capabilityOrigin": {
+            "$ref": "#/components/schemas/MultitableCapabilityOrigin"
+          },
+          "permissions": {
+            "$ref": "#/components/schemas/MultitableScopedPermissions"
           }
         }
       },
@@ -2945,7 +2951,8 @@
         "type": "string",
         "enum": [
           "user",
-          "role"
+          "role",
+          "member-group"
         ]
       },
       "MultitableSheetPermissionEntry": {
@@ -3140,6 +3147,26 @@
           "canComment"
         ]
       },
+      "MultitableScopedPermissions": {
+        "type": "object",
+        "properties": {
+          "fieldPermissions": {
+            "$ref": "#/components/schemas/MultitableFieldPermissions"
+          },
+          "viewPermissions": {
+            "$ref": "#/components/schemas/MultitableViewPermissions"
+          },
+          "rowActions": {
+            "$ref": "#/components/schemas/MultitableRowActions"
+          },
+          "rowActionOverrides": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/MultitableRowActions"
+            }
+          }
+        }
+      },
       "MultitableDependencyNode": {
         "type": "object",
         "properties": {
@@ -3324,15 +3351,24 @@
           "capabilities": {
             "$ref": "#/components/schemas/MultitableCapabilities"
           },
-          "fieldCapabilities": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/MultitableFieldCapabilities"
-              }
-            ],
-            "nullable": true
+          "capabilityOrigin": {
+            "$ref": "#/components/schemas/MultitableCapabilityOrigin"
+          },
+          "fieldPermissions": {
+            "$ref": "#/components/schemas/MultitableFieldPermissions"
+          },
+          "viewPermissions": {
+            "$ref": "#/components/schemas/MultitableViewPermissions"
           }
-        }
+        },
+        "required": [
+          "sheets",
+          "views",
+          "capabilities",
+          "capabilityOrigin",
+          "fieldPermissions",
+          "viewPermissions"
+        ]
       },
       "MultitableViewData": {
         "type": "object",
@@ -3357,22 +3393,6 @@
           },
           "attachmentSummaries": {
             "$ref": "#/components/schemas/MultitableViewAttachmentSummaries"
-          },
-          "fieldCapabilities": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/MultitableFieldCapabilities"
-              }
-            ],
-            "nullable": true
-          },
-          "dependencyGraph": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/MultitableDependencyGraph"
-              }
-            ],
-            "nullable": true
           },
           "view": {
             "allOf": [
@@ -3490,21 +3510,17 @@
           "capabilities": {
             "$ref": "#/components/schemas/MultitableCapabilities"
           },
-          "fieldCapabilities": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/MultitableFieldCapabilities"
-              }
-            ],
-            "nullable": true
+          "capabilityOrigin": {
+            "$ref": "#/components/schemas/MultitableCapabilityOrigin"
           },
-          "dependencyGraph": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/MultitableDependencyGraph"
-              }
-            ],
-            "nullable": true
+          "fieldPermissions": {
+            "$ref": "#/components/schemas/MultitableFieldPermissions"
+          },
+          "viewPermissions": {
+            "$ref": "#/components/schemas/MultitableViewPermissions"
+          },
+          "rowActions": {
+            "$ref": "#/components/schemas/MultitableRowActions"
           },
           "record": {
             "allOf": [
@@ -3532,7 +3548,8 @@
           "submitPath",
           "sheet",
           "fields",
-          "capabilities"
+          "capabilities",
+          "fieldPermissions"
         ]
       },
       "MultitablePersonFieldPrepareResult": {

--- a/packages/openapi/dist/openapi.yaml
+++ b/packages/openapi/dist/openapi.yaml
@@ -2011,6 +2011,10 @@ components:
           type: array
           items:
             type: string
+        capabilityOrigin:
+          $ref: '#/components/schemas/MultitableCapabilityOrigin'
+        permissions:
+          $ref: '#/components/schemas/MultitableScopedPermissions'
     MultitableCapabilities:
       type: object
       properties:
@@ -2057,6 +2061,7 @@ components:
       enum:
         - user
         - role
+        - member-group
     MultitableSheetPermissionEntry:
       type: object
       properties:
@@ -2189,6 +2194,19 @@ components:
         - canEdit
         - canDelete
         - canComment
+    MultitableScopedPermissions:
+      type: object
+      properties:
+        fieldPermissions:
+          $ref: '#/components/schemas/MultitableFieldPermissions'
+        viewPermissions:
+          $ref: '#/components/schemas/MultitableViewPermissions'
+        rowActions:
+          $ref: '#/components/schemas/MultitableRowActions'
+        rowActionOverrides:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/MultitableRowActions'
     MultitableDependencyNode:
       type: object
       properties:
@@ -2317,10 +2335,19 @@ components:
             $ref: '#/components/schemas/MultitableView'
         capabilities:
           $ref: '#/components/schemas/MultitableCapabilities'
-        fieldCapabilities:
-          allOf:
-            - $ref: '#/components/schemas/MultitableFieldCapabilities'
-          nullable: true
+        capabilityOrigin:
+          $ref: '#/components/schemas/MultitableCapabilityOrigin'
+        fieldPermissions:
+          $ref: '#/components/schemas/MultitableFieldPermissions'
+        viewPermissions:
+          $ref: '#/components/schemas/MultitableViewPermissions'
+      required:
+        - sheets
+        - views
+        - capabilities
+        - capabilityOrigin
+        - fieldPermissions
+        - viewPermissions
     MultitableViewData:
       type: object
       properties:
@@ -2338,14 +2365,6 @@ components:
           $ref: '#/components/schemas/MultitableViewLinkSummaries'
         attachmentSummaries:
           $ref: '#/components/schemas/MultitableViewAttachmentSummaries'
-        fieldCapabilities:
-          allOf:
-            - $ref: '#/components/schemas/MultitableFieldCapabilities'
-          nullable: true
-        dependencyGraph:
-          allOf:
-            - $ref: '#/components/schemas/MultitableDependencyGraph'
-          nullable: true
         view:
           allOf:
             - $ref: '#/components/schemas/MultitableView'
@@ -2422,14 +2441,14 @@ components:
             $ref: '#/components/schemas/MultitableField'
         capabilities:
           $ref: '#/components/schemas/MultitableCapabilities'
-        fieldCapabilities:
-          allOf:
-            - $ref: '#/components/schemas/MultitableFieldCapabilities'
-          nullable: true
-        dependencyGraph:
-          allOf:
-            - $ref: '#/components/schemas/MultitableDependencyGraph'
-          nullable: true
+        capabilityOrigin:
+          $ref: '#/components/schemas/MultitableCapabilityOrigin'
+        fieldPermissions:
+          $ref: '#/components/schemas/MultitableFieldPermissions'
+        viewPermissions:
+          $ref: '#/components/schemas/MultitableViewPermissions'
+        rowActions:
+          $ref: '#/components/schemas/MultitableRowActions'
         record:
           allOf:
             - $ref: '#/components/schemas/MultitableRecord'
@@ -2447,6 +2466,7 @@ components:
         - sheet
         - fields
         - capabilities
+        - fieldPermissions
     MultitablePersonFieldPrepareResult:
       type: object
       properties:

--- a/packages/openapi/src/base.yml
+++ b/packages/openapi/src/base.yml
@@ -1945,6 +1945,10 @@ components:
           type: array
           items:
             type: string
+        capabilityOrigin:
+          $ref: '#/components/schemas/MultitableCapabilityOrigin'
+        permissions:
+          $ref: '#/components/schemas/MultitableScopedPermissions'
     MultitableCapabilities:
       type: object
       properties:
@@ -1984,7 +1988,7 @@ components:
       enum: [read, write, write-own, admin]
     MultitableSheetPermissionSubjectType:
       type: string
-      enum: [user, role]
+      enum: [user, role, member-group]
     MultitableSheetPermissionEntry:
       type: object
       properties:
@@ -2113,6 +2117,19 @@ components:
         - canEdit
         - canDelete
         - canComment
+    MultitableScopedPermissions:
+      type: object
+      properties:
+        fieldPermissions:
+          $ref: '#/components/schemas/MultitableFieldPermissions'
+        viewPermissions:
+          $ref: '#/components/schemas/MultitableViewPermissions'
+        rowActions:
+          $ref: '#/components/schemas/MultitableRowActions'
+        rowActionOverrides:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/MultitableRowActions'
     MultitableDependencyNode:
       type: object
       properties:
@@ -2228,10 +2245,19 @@ components:
             $ref: '#/components/schemas/MultitableView'
         capabilities:
           $ref: '#/components/schemas/MultitableCapabilities'
-        fieldCapabilities:
-          allOf:
-            - $ref: '#/components/schemas/MultitableFieldCapabilities'
-          nullable: true
+        capabilityOrigin:
+          $ref: '#/components/schemas/MultitableCapabilityOrigin'
+        fieldPermissions:
+          $ref: '#/components/schemas/MultitableFieldPermissions'
+        viewPermissions:
+          $ref: '#/components/schemas/MultitableViewPermissions'
+      required:
+        - sheets
+        - views
+        - capabilities
+        - capabilityOrigin
+        - fieldPermissions
+        - viewPermissions
     MultitableViewData:
       type: object
       properties:
@@ -2249,14 +2275,6 @@ components:
           $ref: '#/components/schemas/MultitableViewLinkSummaries'
         attachmentSummaries:
           $ref: '#/components/schemas/MultitableViewAttachmentSummaries'
-        fieldCapabilities:
-          allOf:
-            - $ref: '#/components/schemas/MultitableFieldCapabilities'
-          nullable: true
-        dependencyGraph:
-          allOf:
-            - $ref: '#/components/schemas/MultitableDependencyGraph'
-          nullable: true
         view:
           allOf:
             - $ref: '#/components/schemas/MultitableView'
@@ -2332,14 +2350,14 @@ components:
             $ref: '#/components/schemas/MultitableField'
         capabilities:
           $ref: '#/components/schemas/MultitableCapabilities'
-        fieldCapabilities:
-          allOf:
-            - $ref: '#/components/schemas/MultitableFieldCapabilities'
-          nullable: true
-        dependencyGraph:
-          allOf:
-            - $ref: '#/components/schemas/MultitableDependencyGraph'
-          nullable: true
+        capabilityOrigin:
+          $ref: '#/components/schemas/MultitableCapabilityOrigin'
+        fieldPermissions:
+          $ref: '#/components/schemas/MultitableFieldPermissions'
+        viewPermissions:
+          $ref: '#/components/schemas/MultitableViewPermissions'
+        rowActions:
+          $ref: '#/components/schemas/MultitableRowActions'
         record:
           allOf:
             - $ref: '#/components/schemas/MultitableRecord'
@@ -2357,6 +2375,7 @@ components:
         - sheet
         - fields
         - capabilities
+        - fieldPermissions
     MultitablePersonFieldPrepareResult:
       type: object
       properties:

--- a/scripts/ops/multitable-openapi-parity.test.mjs
+++ b/scripts/ops/multitable-openapi-parity.test.mjs
@@ -154,6 +154,10 @@ test('multitable openapi stays aligned with runtime contracts', () => {
 
   assert.equal(schemas.MultitableView?.properties?.type?.$ref, '#/components/schemas/MultitableViewType')
   assert.equal(schemas.MultitableField?.properties?.type?.$ref, '#/components/schemas/MultitableFieldType')
+  assert.deepEqual(
+    schemas.MultitableSheetPermissionSubjectType?.enum,
+    ['user', 'role', 'member-group'],
+  )
   assert.equal(
     schemas.MultitableRecordSubscriptionStatus?.properties?.subscription?.allOf?.[0]?.$ref,
     '#/components/schemas/MultitableRecordSubscription',
@@ -167,6 +171,69 @@ test('multitable openapi stays aligned with runtime contracts', () => {
   assert.equal(
     schemas.MultitableViewData?.properties?.attachmentSummaries?.$ref,
     '#/components/schemas/MultitableViewAttachmentSummaries',
+  )
+  assert.equal(
+    schemas.MultitableViewData?.properties?.meta?.$ref,
+    '#/components/schemas/MultitableViewMeta',
+  )
+  assert.equal(
+    schemas.MultitableViewMeta?.properties?.capabilityOrigin?.$ref,
+    '#/components/schemas/MultitableCapabilityOrigin',
+  )
+  assert.equal(
+    schemas.MultitableViewMeta?.properties?.permissions?.$ref,
+    '#/components/schemas/MultitableScopedPermissions',
+  )
+  assert.equal(
+    schemas.MultitableScopedPermissions?.properties?.fieldPermissions?.$ref,
+    '#/components/schemas/MultitableFieldPermissions',
+  )
+  assert.equal(
+    schemas.MultitableScopedPermissions?.properties?.viewPermissions?.$ref,
+    '#/components/schemas/MultitableViewPermissions',
+  )
+  assert.equal(
+    schemas.MultitableScopedPermissions?.properties?.rowActions?.$ref,
+    '#/components/schemas/MultitableRowActions',
+  )
+  assert.equal(
+    schemas.MultitableScopedPermissions?.properties?.rowActionOverrides?.additionalProperties?.$ref,
+    '#/components/schemas/MultitableRowActions',
+  )
+  assert.equal(
+    Object.hasOwn(schemas.MultitableViewData?.properties ?? {}, 'fieldCapabilities'),
+    false,
+    'view data should not expose stale fieldCapabilities',
+  )
+  assert.equal(
+    Object.hasOwn(schemas.MultitableViewData?.properties ?? {}, 'dependencyGraph'),
+    false,
+    'view data should not expose stale dependencyGraph',
+  )
+  assert.equal(
+    schemas.MultitableContext?.properties?.capabilityOrigin?.$ref,
+    '#/components/schemas/MultitableCapabilityOrigin',
+  )
+  assert.equal(
+    schemas.MultitableContext?.properties?.fieldPermissions?.$ref,
+    '#/components/schemas/MultitableFieldPermissions',
+  )
+  assert.equal(
+    schemas.MultitableContext?.properties?.viewPermissions?.$ref,
+    '#/components/schemas/MultitableViewPermissions',
+  )
+  assert.ok(
+    schemas.MultitableContext?.required?.includes('capabilityOrigin'),
+    'context must document runtime capabilityOrigin',
+  )
+  assert.ok(
+    schemas.MultitableContext?.required?.includes('fieldPermissions'),
+    'context must document runtime fieldPermissions',
+  )
+  assert.equal(
+    Object.hasOwn(schemas.MultitableContext?.properties ?? {}, 'fieldCapabilities'),
+    false,
+    'context should not expose stale fieldCapabilities',
   )
   assert.equal(
     schemas.MultitableRecordContext?.properties?.attachmentSummaries?.$ref,
@@ -221,6 +288,36 @@ test('multitable openapi stays aligned with runtime contracts', () => {
   assert.equal(
     schemas.MultitableFormContext?.properties?.attachmentSummaries?.$ref,
     '#/components/schemas/MultitableAttachmentSummaryMap',
+  )
+  assert.equal(
+    schemas.MultitableFormContext?.properties?.capabilityOrigin?.$ref,
+    '#/components/schemas/MultitableCapabilityOrigin',
+  )
+  assert.equal(
+    schemas.MultitableFormContext?.properties?.fieldPermissions?.$ref,
+    '#/components/schemas/MultitableFieldPermissions',
+  )
+  assert.equal(
+    schemas.MultitableFormContext?.properties?.viewPermissions?.$ref,
+    '#/components/schemas/MultitableViewPermissions',
+  )
+  assert.equal(
+    schemas.MultitableFormContext?.properties?.rowActions?.$ref,
+    '#/components/schemas/MultitableRowActions',
+  )
+  assert.ok(
+    schemas.MultitableFormContext?.required?.includes('fieldPermissions'),
+    'form context must document runtime fieldPermissions',
+  )
+  assert.equal(
+    Object.hasOwn(schemas.MultitableFormContext?.properties ?? {}, 'fieldCapabilities'),
+    false,
+    'form context should not expose stale fieldCapabilities',
+  )
+  assert.equal(
+    Object.hasOwn(schemas.MultitableFormContext?.properties ?? {}, 'dependencyGraph'),
+    false,
+    'form context should not expose stale dependencyGraph',
   )
   assert.equal(
     schemas.MultitableFormSubmitResult?.properties?.attachmentSummaries?.$ref,


### PR DESCRIPTION
This PR continues the multitable OpenAPI contract cleanup after #1293/#1295 by aligning context/view/form-context schemas with the permission-aware runtime response shape.

What changed:
- Add MultitableScopedPermissions for view meta permission payloads.
- Document MultitableViewMeta.capabilityOrigin and permissions.
- Document MultitableContext capabilityOrigin, fieldPermissions, and viewPermissions.
- Document MultitableFormContext capabilityOrigin, fieldPermissions, viewPermissions, and rowActions.
- Remove stale fieldCapabilities/dependencyGraph properties from view/form context schemas where runtime no longer emits them.
- Extend scripts/ops/multitable-openapi-parity.test.mjs and regenerate packages/openapi/dist/*.
- Add development and verification notes under docs/development/.

Verification:
- pnpm install --frozen-lockfile
- pnpm verify:multitable-openapi:parity
- pnpm exec tsx packages/openapi/tools/validate.ts packages/openapi/dist/openapi.yaml
- git diff --check

Runtime code is unchanged; this is OpenAPI/docs/contract coverage only.