### PR TITLE
test(multitable): refresh sheet permission fixture queries

### DIFF
--- a/docs/development/multitable-sheet-permission-fixture-development-20260505.md
+++ b/docs/development/multitable-sheet-permission-fixture-development-20260505.md
@@ -43,6 +43,8 @@ Added generic fixture handlers for:
 - Bulk role permission lookup by role id array, bridged to the tests' existing
   single-role lookup handlers.
 - Legacy `users.permissions` fallback eligibility.
+- AutoNumber sheet advisory-lock acknowledgements for create-record paths that
+  now pass through `RecordService.createRecord()`.
 - `meta_record_revisions` insert acknowledgements.
 - Formula dependency recalculation probes with no dependent formula fields.
 - `meta_record_subscriptions` best-effort notification lookups with no

--- a/docs/development/multitable-sheet-permission-fixture-development-20260505.md
+++ b/docs/development/multitable-sheet-permission-fixture-development-20260505.md
@@ -1,0 +1,69 @@
+# Multitable Sheet Permission Fixture Refresh Development Notes
+
+Date: 2026-05-05
+Branch: `codex/multitable-permission-fixture-20260505`
+
+## Scope
+
+This change refreshes the integration-test fixture for
+`packages/core-backend/tests/integration/multitable-sheet-permissions.api.test.ts`.
+
+No production code is changed.
+
+## Problem
+
+The multitable sheet permission integration suite drifted behind the current
+runtime query surface. The runtime now routes more record writes through
+`RecordService` / `RecordWriteService` and permission candidates through the
+shared permission service. The test fixture still mocked older SQL shapes, so
+valid runtime paths failed with `Unhandled SQL in test`.
+
+The failing areas were:
+
+- Candidate eligibility now performs batch permission checks across
+  `user_permissions`, `user_roles`, role permissions, and legacy `users.permissions`.
+- Record create uses the current `created_by` parameter shape where `version` is
+  a SQL literal.
+- Patch/delete paths can lock records while returning `data` in addition to
+  ownership and version fields.
+- Record writes emit revision rows, formula dependency probes, and best-effort
+  subscriber notification queries.
+
+## Implementation
+
+The fixture-level `createMockPool()` now accepts the existing `userPermissionMap`
+so shared mock SQL can reuse each test's permission setup instead of duplicating
+candidate filtering logic in every case.
+
+Added generic fixture handlers for:
+
+- Batch user permission eligibility:
+  `user_permissions` joined through `user_roles` and `role_permissions`.
+- Admin-role eligibility lookup through `user_roles`.
+- Bulk role permission lookup by role id array, bridged to the tests' existing
+  single-role lookup handlers.
+- Legacy `users.permissions` fallback eligibility.
+- `meta_record_revisions` insert acknowledgements.
+- Formula dependency recalculation probes with no dependent formula fields.
+- `meta_record_subscriptions` best-effort notification lookups with no
+  subscribers.
+
+The write-own cases were updated to match the current record-service shapes:
+
+- Create-record fixture reads params as `[recordId, sheetId, dataJson, createdBy]`.
+- Patch fixture supports both old and current `FOR UPDATE` projections and
+  returns `data` when the runtime requests it.
+- Delete fixture supports `SELECT id, sheet_id, version, data ... FOR UPDATE`.
+
+## Parallel Review
+
+A read-only explorer independently inspected the same failures and reached the
+same conclusion: this was test fixture drift, not a product-code regression.
+The explorer specifically recommended keeping all behavior assertions unchanged,
+which this patch does.
+
+## Non-Goals
+
+- No route, service, permission, or database behavior changes.
+- No assertion relaxation.
+- No broader multitable permission refactor.

--- a/docs/development/multitable-sheet-permission-fixture-verification-20260505.md
+++ b/docs/development/multitable-sheet-permission-fixture-verification-20260505.md
@@ -1,0 +1,44 @@
+# Multitable Sheet Permission Fixture Refresh Verification
+
+Date: 2026-05-05
+Branch: `codex/multitable-permission-fixture-20260505`
+
+## Commands Run
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/multitable-sheet-permissions.api.test.ts --reporter=dot
+```
+
+## Results
+
+Targeted backend integration suite:
+
+```text
+Test Files  1 passed (1)
+Tests       39 passed (39)
+```
+
+The suite initially exposed missing fixture handlers for the current runtime SQL
+surface. After the fixture refresh, the same command passed without changing
+runtime code or loosening assertions.
+
+## Cleanup
+
+`pnpm install --frozen-lockfile` updated local workspace symlinks under several
+plugin/tool `node_modules` directories in the temporary worktree. Those were
+restored before staging so the PR contains only the fixture refresh and these
+development notes.
+
+## Risk
+
+Low. The patch is test-only and preserves existing assertions for:
+
+- Sheet-scoped capabilities.
+- Row-level actions.
+- Write-own create, form submit, patch, direct patch, and delete behavior.
+- Permission candidate filtering.
+- Form-share DingTalk binding/grant status.
+
+Remaining CI expectation: normal repository checks should pass because no
+production code or generated contract artifacts changed.

--- a/docs/development/multitable-sheet-permission-fixture-verification-20260505.md
+++ b/docs/development/multitable-sheet-permission-fixture-verification-20260505.md
@@ -42,3 +42,30 @@ Low. The patch is test-only and preserves existing assertions for:
 
 Remaining CI expectation: normal repository checks should pass because no
 production code or generated contract artifacts changed.
+
+## Current-Main Refresh - 2026-05-14
+
+After rebasing the PR diff onto `origin/main@b128936c`, the targeted integration
+suite exposed one additional fixture gap from the later AutoNumber rollout:
+
+```text
+Unhandled SQL in test: SELECT pg_advisory_xact_lock(hashtext($1))
+```
+
+The fixture now treats the advisory lock as a no-op acknowledgement in the mock
+pool. This preserves production behavior and keeps the patch test-only.
+
+Commands rerun after the refresh:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/multitable-sheet-permissions.api.test.ts --reporter=dot
+git diff --check origin/main..HEAD
+```
+
+Current-main rerun result:
+
+```text
+Test Files  1 passed (1)
+Tests       39 passed (39)
+```

--- a/packages/core-backend/tests/integration/multitable-sheet-permissions.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-sheet-permissions.api.test.ts
@@ -9,7 +9,10 @@ type QueryResult = {
 
 type QueryHandler = (sql: string, params?: unknown[]) => QueryResult | Promise<QueryResult>
 
-function createMockPool(queryHandler: QueryHandler) {
+function createMockPool(
+  queryHandler: QueryHandler,
+  userPermissionMap: Record<string, string[]> = {},
+) {
   const query = vi.fn(async (sql: string, params?: unknown[]) => {
     if (
       sql.includes('FROM meta_view_permissions')
@@ -24,6 +27,53 @@ function createMockPool(queryHandler: QueryHandler) {
       return { rows: [], rowCount: 0 }
     }
     if (sql.includes('FROM record_permissions') && !sql.includes('FROM record_permissions rp')) return { rows: [], rowCount: 0 }
+    if (
+      sql.includes('FROM user_permissions up')
+      && sql.includes('JOIN role_permissions rp ON rp.role_id = ur.role_id')
+      && sql.includes('WHERE up.user_id = ANY($1::text[])')
+    ) {
+      const userIds = Array.isArray(params?.[0]) ? params[0].map(String) : []
+      return {
+        rows: userIds.flatMap((userId) =>
+          (userPermissionMap[userId] ?? []).map((permissionCode) => ({
+            user_id: userId,
+            permission_code: permissionCode,
+          })),
+        ),
+      }
+    }
+    if (sql.includes('FROM user_roles') && sql.includes('WHERE user_id = ANY($1::text[])') && sql.includes('role_id = $2')) {
+      return { rows: [], rowCount: 0 }
+    }
+    if (sql.includes('SELECT role_id, permission_code FROM role_permissions WHERE role_id = ANY($1::text[])')) {
+      const roleIds = Array.isArray(params?.[0]) ? params[0].map(String) : []
+      const rows: Array<{ role_id: string; permission_code: string }> = []
+      for (const roleId of roleIds) {
+        const result = await queryHandler('SELECT permission_code FROM role_permissions WHERE role_id = $1', [roleId])
+        for (const row of result.rows) {
+          if (typeof row.permission_code === 'string') rows.push({ role_id: roleId, permission_code: row.permission_code })
+        }
+      }
+      return { rows }
+    }
+    if (sql.includes('INSERT INTO meta_record_revisions')) {
+      return { rows: [], rowCount: 1 }
+    }
+    if (sql.includes('SELECT DISTINCT field_id FROM formula_dependencies')) {
+      return { rows: [], rowCount: 0 }
+    }
+    if (sql.includes('FROM meta_record_subscriptions')) {
+      return { rows: [], rowCount: 0 }
+    }
+    if (sql.includes('SELECT id, permissions') && sql.includes('FROM users') && sql.includes('WHERE id = ANY($1::text[])')) {
+      const userIds = Array.isArray(params?.[0]) ? params[0].map(String) : []
+      return {
+        rows: userIds.map((userId) => ({
+          id: userId,
+          permissions: userPermissionMap[userId] ?? [],
+        })),
+      }
+    }
     return queryHandler(sql, params)
   })
   const transaction = vi.fn(async (fn: (client: { query: typeof query }) => Promise<unknown>) => fn({ query }))
@@ -49,7 +99,7 @@ async function createApp(args: {
 
   const { poolManager } = await import('../../src/integration/db/connection-pool')
   const { univerMetaRouter } = await import('../../src/routes/univer-meta')
-  const mockPool = createMockPool(args.queryHandler)
+  const mockPool = createMockPool(args.queryHandler, args.userPermissionMap)
   vi.spyOn(poolManager, 'get').mockReturnValue(mockPool as any)
 
   const app = express()
@@ -696,12 +746,16 @@ describe('Multitable sheet-scoped permissions API', () => {
             rows: [{ id: 'fld_name', name: 'Name', type: 'string', property: {}, order: 1 }],
           }
         }
-        if (sql.includes('SELECT id, version, created_by FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE')) {
+        if (
+          sql.includes('SELECT id, version, data, created_by FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE')
+          || sql.includes('SELECT id, version, created_by FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE')
+        ) {
           const recordId = String(params?.[0] ?? '')
           return {
             rows: [{
               id: recordId,
               version: recordId === 'rec_owned' ? 3 : 4,
+              data: { fld_name: recordId === 'rec_owned' ? 'Mine' : 'Theirs' },
               created_by: recordId === 'rec_owned' ? 'user_sheet_acl_1' : 'user_sheet_acl_2',
             }],
           }
@@ -805,8 +859,9 @@ describe('Multitable sheet-scoped permissions API', () => {
             rows: [{ id: 'fld_name', name: 'Name', type: 'string', property: {} }],
           }
         }
-        if (sql.includes('INSERT INTO meta_records (id, sheet_id, data, version, created_by)')) {
-          const [recordId, sheetId, dataJson, _version, createdBy] = params as [string, string, string, number, string]
+        if (sql.includes('INSERT INTO meta_records (id, sheet_id, data, version, created_by')) {
+          const [recordId, sheetId, dataJson] = params as [string, string, string]
+          const createdBy = String(params?.[3] ?? '')
           const next = {
             id: recordId,
             sheetId,
@@ -825,20 +880,26 @@ describe('Multitable sheet-scoped permissions API', () => {
             rows: row ? [{ id: row.id, version: row.version, data: row.data }] : [],
           }
         }
-        if (sql.includes('SELECT id, version, created_by FROM meta_records WHERE sheet_id = $1 AND id = $2 FOR UPDATE')) {
+        if (
+          sql.includes('SELECT id, version, data, created_by FROM meta_records WHERE sheet_id = $1 AND id = $2 FOR UPDATE')
+          || sql.includes('SELECT id, version, created_by FROM meta_records WHERE sheet_id = $1 AND id = $2 FOR UPDATE')
+        ) {
           expect(params?.[0]).toEqual('sheet_ops')
           const recordId = String(params?.[1] ?? '')
           const row = records.get(recordId)
           return {
-            rows: row ? [{ id: row.id, version: row.version, created_by: row.createdBy }] : [],
+            rows: row ? [{ id: row.id, version: row.version, data: row.data, created_by: row.createdBy }] : [],
           }
         }
-        if (sql.includes('SELECT id, version, created_by FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE')) {
+        if (
+          sql.includes('SELECT id, version, data, created_by FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE')
+          || sql.includes('SELECT id, version, created_by FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE')
+        ) {
           expect(params?.[1]).toEqual('sheet_ops')
           const recordId = String(params?.[0] ?? '')
           const row = records.get(recordId)
           return {
-            rows: row ? [{ id: row.id, version: row.version, created_by: row.createdBy }] : [],
+            rows: row ? [{ id: row.id, version: row.version, data: row.data, created_by: row.createdBy }] : [],
           }
         }
         if (sql.includes('UPDATE meta_records') && sql.includes('WHERE sheet_id = $2 AND id = $3')) {
@@ -879,11 +940,14 @@ describe('Multitable sheet-scoped permissions API', () => {
             rows: row ? [{ id: row.id, sheet_id: row.sheetId }] : [],
           }
         }
-        if (sql.includes('SELECT id, sheet_id, version FROM meta_records WHERE id = $1 FOR UPDATE')) {
+        if (
+          sql.includes('SELECT id, sheet_id, version, data FROM meta_records WHERE id = $1 FOR UPDATE')
+          || sql.includes('SELECT id, sheet_id, version FROM meta_records WHERE id = $1 FOR UPDATE')
+        ) {
           expect(params).toEqual(['rec_owned'])
           const row = records.get('rec_owned')
           return {
-            rows: row ? [{ id: row.id, sheet_id: row.sheetId, version: row.version }] : [],
+            rows: row ? [{ id: row.id, sheet_id: row.sheetId, version: row.version, data: row.data }] : [],
           }
         }
         if (sql.includes('DELETE FROM meta_links WHERE record_id = $1 OR foreign_record_id = $1')) {

--- a/packages/core-backend/tests/integration/multitable-sheet-permissions.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-sheet-permissions.api.test.ts
@@ -27,6 +27,9 @@ function createMockPool(
       return { rows: [], rowCount: 0 }
     }
     if (sql.includes('FROM record_permissions') && !sql.includes('FROM record_permissions rp')) return { rows: [], rowCount: 0 }
+    if (sql.includes('SELECT pg_advisory_xact_lock(hashtext($1))')) {
+      return { rows: [], rowCount: 1 }
+    }
     if (
       sql.includes('FROM user_permissions up')
       && sql.includes('JOIN role_permissions rp ON rp.role_id = ur.role_id')


### PR DESCRIPTION
## Summary
- refresh the multitable sheet permission integration-test fixture for current RecordService / RecordWriteService SQL shapes
- add shared mock coverage for candidate eligibility, role permission batches, record revisions, formula dependency probes, and record subscription lookups
- keep all existing behavior assertions unchanged; no runtime code changes

## Verification
- pnpm install --frozen-lockfile
- pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/multitable-sheet-permissions.api.test.ts --reporter=dot
- git diff --check HEAD~1..HEAD

## Notes
- Development notes: docs/development/multitable-sheet-permission-fixture-development-20260505.md
- Verification notes: docs/development/multitable-sheet-permission-fixture-verification-20260505.md