### PR TITLE
fix(formula): parse signed numeric literals

### DIFF
--- a/docs/development/formula-strict-numeric-parser-development-20260505.md
+++ b/docs/development/formula-strict-numeric-parser-development-20260505.md
@@ -1,0 +1,45 @@
+# Formula Strict Numeric Parser Development
+
+Date: 2026-05-05
+Branch: `codex/formula-strict-numeric-parser-20260505`
+
+## Scope
+
+This slice continues the formula parser correctness hardening after the string
+escaping and top-level operator fixes.
+
+The parser previously scanned for `+` and `-` operators before recognizing
+complete numeric literals. That caused valid numeric literals such as `-3` and
+`1e-3` to be interpreted as binary expressions.
+
+## Design
+
+`FormulaEngine.parseFormula(...)` now recognizes complete finite numeric
+literals with `Number(...)` before top-level operator scanning. This supports:
+
+- signed literals such as `-3` and `+3`;
+- exponent literals such as `1e-3` and `1e+3`;
+- signed literals on the right side of expressions such as `5*-3`.
+
+The top-level operator scanner also skips unary `+`/`-` signs when they appear:
+
+- at the start of an expression;
+- after another operator;
+- after `(`, `[`, or `,`;
+- as an adjacent exponent sign after a numeric mantissa and `e` or `E`.
+
+This preserves normal binary expressions such as `5 - 3` while allowing signed
+numeric literals to parse correctly. It also preserves binary operators after
+identifiers ending in `E`, such as `TRUE-1`.
+
+## Files Changed
+
+- `packages/core-backend/src/formula/engine.ts`
+- `packages/core-backend/tests/unit/formula-engine.test.ts`
+
+## Non-Goals
+
+- No full grammar rewrite.
+- No operator precedence rewrite beyond existing parser behavior.
+- No frontend formula editor changes.
+- No multitable runtime or OpenAPI changes.

--- a/docs/development/formula-strict-numeric-parser-verification-20260505.md
+++ b/docs/development/formula-strict-numeric-parser-verification-20260505.md
@@ -1,0 +1,56 @@
+# Formula Strict Numeric Parser Verification
+
+Date: 2026-05-05
+Branch: `codex/formula-strict-numeric-parser-20260505`
+
+## Commands Run
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/formula-engine.test.ts \
+  tests/unit/multitable-formula-engine.test.ts \
+  --reporter=dot
+pnpm --filter @metasheet/core-backend build
+git diff --check
+```
+
+## Results
+
+Targeted formula tests:
+
+- 2 files passed;
+- 97 tests passed.
+
+Build:
+
+- `@metasheet/core-backend` TypeScript build passed.
+
+Diff hygiene:
+
+- `git diff --check` passed.
+
+## New Coverage
+
+Added regression coverage for:
+
+- `=-3`;
+- `=+3`;
+- `=1e-3`;
+- `=1e+3`;
+- `=-3+5`;
+- `=5*-3`;
+- `=5--3`;
+- `=1e-3+2`;
+- `=TRUE-1`;
+- `=FALSE+1`.
+
+## Non-Failing Noise
+
+The formula test suite logs an expected error for the existing invalid-function
+case. The test asserts that invalid functions return `#ERROR!`; this is not a
+regression from this slice.
+
+`pnpm install` updated plugin and CLI `node_modules` symlink metadata in the
+temporary worktree. Those generated dependency changes were reverted before
+commit.

--- a/packages/core-backend/src/formula/engine.ts
+++ b/packages/core-backend/src/formula/engine.ts
@@ -269,6 +269,13 @@ export class FormulaEngine {
       }
     }
 
+    // Check if it's a number before scanning operators so signed and exponent
+    // literals such as -3 and 1e-3 are not split as binary operations.
+    const strictNum = Number(formula)
+    if (formula.trim().length > 0 && Number.isFinite(strictNum)) {
+      return { type: 'number', value: strictNum }
+    }
+
     // Check for operators
     // Sort operators by length descending to match >= before >
     const operators = ['>=', '<=', '<>', '+', '-', '*', '/', '=', '>', '<']
@@ -288,22 +295,6 @@ export class FormulaEngine {
     if (formula.toUpperCase() === 'TRUE') return { type: 'boolean', value: true }
     if (formula.toUpperCase() === 'FALSE') return { type: 'boolean', value: false }
     if (formula.toUpperCase() === 'NULL') return { type: 'null', value: null }
-
-    // Check if it's a number
-    const num = parseFloat(formula)
-    if (!isNaN(num) && isFinite(num) && !formula.includes(' ')) {
-       // Only treat as number if it parses fully and doesn't contain spaces (to avoid "5 + 3" -> 5)
-       // Actually parseFloat("5 + 3") is 5.
-       // We want to avoid treating "5 + 3" as number 5.
-       // If the string contains spaces and parses as number, it might be partial match.
-       // But " 5 " is valid number.
-       // "5 + 3" is NOT a valid number representation in strict sense.
-       // Number() constructor is stricter than parseFloat.
-       const strictNum = Number(formula)
-       if (!isNaN(strictNum)) {
-         return { type: 'number', value: strictNum }
-       }
-    }
 
     // Check if it's a string (quoted)
     if (formula.startsWith('"') && formula.endsWith('"')) {
@@ -367,11 +358,30 @@ export class FormulaEngine {
       }
 
       if (depth === 0 && formula.startsWith(operator, i)) {
+        if ((operator === '+' || operator === '-') && this.isUnarySign(formula, i)) {
+          continue
+        }
         return i
       }
     }
 
     return -1
+  }
+
+  private isUnarySign(formula: string, index: number): boolean {
+    let previousIndex = index - 1
+    while (previousIndex >= 0 && /\s/.test(formula[previousIndex])) {
+      previousIndex--
+    }
+
+    if (previousIndex < 0) return true
+    const previous = formula[previousIndex]
+    if (previous === 'e' || previous === 'E') {
+      const exponentIsAdjacent = previousIndex === index - 1
+      const mantissaTail = formula[previousIndex - 1]
+      return exponentIsAdjacent && (/\d/.test(mantissaTail) || mantissaTail === '.')
+    }
+    return ['+', '-', '*', '/', '=', '>', '<', '(', '[', ','].includes(previous)
   }
 
   /**

--- a/packages/core-backend/tests/unit/formula-engine.test.ts
+++ b/packages/core-backend/tests/unit/formula-engine.test.ts
@@ -218,6 +218,25 @@ describe('Formula Engine', () => {
   })
 
   describe('Operators', () => {
+    test('Signed and exponent numeric literals', async () => {
+      expect(await engine.calculate('=-3', context)).toBe(-3)
+      expect(await engine.calculate('=+3', context)).toBe(3)
+      expect(await engine.calculate('=1e-3', context)).toBe(0.001)
+      expect(await engine.calculate('=1e+3', context)).toBe(1000)
+    })
+
+    test('Signed numeric literals inside arithmetic expressions', async () => {
+      expect(await engine.calculate('=-3+5', context)).toBe(2)
+      expect(await engine.calculate('=5*-3', context)).toBe(-15)
+      expect(await engine.calculate('=5--3', context)).toBe(8)
+      expect(await engine.calculate('=1e-3+2', context)).toBe(2.001)
+    })
+
+    test('Binary signs after identifiers ending in E remain operators', async () => {
+      expect(await engine.calculate('=TRUE-1', context)).toBe(0)
+      expect(await engine.calculate('=FALSE+1', context)).toBe(1)
+    })
+
     test('Arithmetic operators', async () => {
       expect(await engine.calculate('=5 + 3', context)).toBe(8)
       expect(await engine.calculate('=5 - 3', context)).toBe(2)


### PR DESCRIPTION
## Summary
- parse complete finite numeric literals before binary operator scanning
- skip unary +/- and adjacent exponent signs when finding top-level operators
- add regressions for signed/exponent literals and identifier-ending-in-E binary operators
- add design and verification docs

## Verification
- pnpm install --frozen-lockfile
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/formula-engine.test.ts tests/unit/multitable-formula-engine.test.ts --reporter=dot
- pnpm --filter @metasheet/core-backend build
- git diff --check

## Docs
- docs/development/formula-strict-numeric-parser-development-20260505.md
- docs/development/formula-strict-numeric-parser-verification-20260505.md