### PR TITLE
fix(formula): respect operator precedence

### DIFF
--- a/docs/development/formula-operator-precedence-development-20260505.md
+++ b/docs/development/formula-operator-precedence-development-20260505.md
@@ -1,0 +1,46 @@
+# Formula Operator Precedence Development
+
+Date: 2026-05-05
+Branch: `codex/formula-left-associative-operators-20260505`
+
+## Scope
+
+This slice continues formula parser correctness hardening after string escaping,
+top-level operator tokenization, and signed numeric literal parsing.
+
+The parser previously scanned operators one token at a time in a fixed order.
+That produced two incorrect behaviors:
+
+- same-precedence arithmetic such as `5 - 3 - 1` parsed as right-associative;
+- comparisons mixed with arithmetic such as `1 + 2 > 2` could split on `+`
+  before `>`.
+
+## Design
+
+`FormulaEngine.parseFormula(...)` now scans top-level operators by precedence
+group:
+
+- comparison: `>=`, `<=`, `<>`, `=`, `>`, `<`;
+- additive: `+`, `-`;
+- multiplicative: `*`, `/`.
+
+The scanner still ignores operators inside quoted strings, function arguments,
+and array literals. Within each precedence group it keeps the rightmost
+top-level operator, which preserves left-associative evaluation through the
+existing recursive parser.
+
+Multi-character operators are matched before single-character operators and the
+scanner skips over the matched token body. This prevents `>=` from being
+overwritten by its internal `=`.
+
+## Files Changed
+
+- `packages/core-backend/src/formula/engine.ts`
+- `packages/core-backend/tests/unit/formula-engine.test.ts`
+
+## Non-Goals
+
+- No full formula grammar rewrite.
+- No parentheses grouping feature.
+- No frontend formula editor changes.
+- No multitable runtime or OpenAPI changes.

--- a/docs/development/formula-operator-precedence-verification-20260505.md
+++ b/docs/development/formula-operator-precedence-verification-20260505.md
@@ -1,0 +1,53 @@
+# Formula Operator Precedence Verification
+
+Date: 2026-05-05
+Branch: `codex/formula-left-associative-operators-20260505`
+
+## Commands Run
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/formula-engine.test.ts \
+  tests/unit/multitable-formula-engine.test.ts \
+  --reporter=dot
+pnpm --filter @metasheet/core-backend build
+git diff --check
+```
+
+## Results
+
+Targeted formula tests:
+
+- 2 files passed;
+- 100 tests passed.
+
+Build:
+
+- `@metasheet/core-backend` TypeScript build passed.
+
+## New Coverage
+
+Added regression coverage for:
+
+- `=5 - 3 - 1`;
+- `=8 / 4 / 2`;
+- `=5 + 3 - 1`;
+- `=5 * 3 / 5`;
+- `=1 + 2 > 2`;
+- `=1 + 2 = 3`;
+- `=10 / 2 <= 4 + 1`;
+- `=2 * 3 <> 7 - 1`.
+
+## First Failure Captured
+
+The first implementation matched multi-character comparison operators but then
+continued scanning inside the matched token. That let the internal `=` in `>=`
+and `<=` overwrite the previous match. The final implementation skips over the
+matched token body after a longest-token match.
+
+## Non-Failing Noise
+
+The formula test suite logs an expected error for the existing invalid-function
+case. The test asserts that invalid functions return `#ERROR!`; this is not a
+regression from this slice.

--- a/packages/core-backend/src/formula/engine.ts
+++ b/packages/core-backend/src/formula/engine.ts
@@ -276,17 +276,24 @@ export class FormulaEngine {
       return { type: 'number', value: strictNum }
     }
 
-    // Check for operators
-    // Sort operators by length descending to match >= before >
-    const operators = ['>=', '<=', '<>', '+', '-', '*', '/', '=', '>', '<']
-    for (const op of operators) {
-      const operatorIndex = this.findTopLevelOperator(formula, op)
-      if (operatorIndex >= 0) {
+    // Check for operators from lowest to highest precedence. Operators in the
+    // same precedence group are left-associative, so split on the rightmost
+    // top-level operator to recursively keep the left side grouped first.
+    const operatorGroups = [
+      ['>=', '<=', '<>', '=', '>', '<'],
+      ['+', '-'],
+      ['*', '/']
+    ]
+    for (const operators of operatorGroups) {
+      const operatorMatch = this.findTopLevelOperator(formula, operators)
+      if (operatorMatch) {
         return {
           type: 'operator',
-          operator: op,
-          left: this.parseFormula(formula.slice(0, operatorIndex).trim()),
-          right: this.parseFormula(formula.slice(operatorIndex + op.length).trim())
+          operator: operatorMatch.operator,
+          left: this.parseFormula(formula.slice(0, operatorMatch.index).trim()),
+          right: this.parseFormula(
+            formula.slice(operatorMatch.index + operatorMatch.operator.length).trim()
+          )
         }
       }
     }
@@ -334,11 +341,13 @@ export class FormulaEngine {
   /**
    * Find an operator that is not inside quoted strings, function arguments, or arrays.
    */
-  private findTopLevelOperator(formula: string, operator: string): number {
+  private findTopLevelOperator(formula: string, operators: string[]): { index: number; operator: string } | null {
     let depth = 0
     let inQuotes = false
+    let match: { index: number; operator: string } | null = null
+    const sortedOperators = [...operators].sort((a, b) => b.length - a.length)
 
-    for (let i = 0; i <= formula.length - operator.length; i++) {
+    for (let i = 0; i < formula.length; i++) {
       const char = formula[i]
 
       if (char === '"' && (i === 0 || formula[i - 1] !== '\\')) {
@@ -357,15 +366,21 @@ export class FormulaEngine {
         continue
       }
 
-      if (depth === 0 && formula.startsWith(operator, i)) {
-        if ((operator === '+' || operator === '-') && this.isUnarySign(formula, i)) {
-          continue
+      if (depth === 0) {
+        for (const operator of sortedOperators) {
+          if (formula.startsWith(operator, i)) {
+            if ((operator === '+' || operator === '-') && this.isUnarySign(formula, i)) {
+              continue
+            }
+            match = { index: i, operator }
+            i += operator.length - 1
+            break
+          }
         }
-        return i
       }
     }
 
-    return -1
+    return match
   }
 
   private isUnarySign(formula: string, index: number): boolean {

--- a/packages/core-backend/tests/unit/formula-engine.test.ts
+++ b/packages/core-backend/tests/unit/formula-engine.test.ts
@@ -244,6 +244,20 @@ describe('Formula Engine', () => {
       expect(await engine.calculate('=6 / 3', context)).toBe(2)
     })
 
+    test('Same-precedence arithmetic operators are left-associative', async () => {
+      expect(await engine.calculate('=5 - 3 - 1', context)).toBe(1)
+      expect(await engine.calculate('=8 / 4 / 2', context)).toBe(1)
+      expect(await engine.calculate('=5 + 3 - 1', context)).toBe(7)
+      expect(await engine.calculate('=5 * 3 / 5', context)).toBe(3)
+    })
+
+    test('Comparison operators have lower precedence than arithmetic', async () => {
+      expect(await engine.calculate('=1 + 2 > 2', context)).toBe(true)
+      expect(await engine.calculate('=1 + 2 = 3', context)).toBe(true)
+      expect(await engine.calculate('=10 / 2 <= 4 + 1', context)).toBe(true)
+      expect(await engine.calculate('=2 * 3 <> 7 - 1', context)).toBe(false)
+    })
+
     test('Division by zero', async () => {
       expect(await engine.calculate('=5 / 0', context)).toBe('#DIV/0!')
     })


### PR DESCRIPTION
## Summary
- parse formulas by operator precedence groups: comparison, additive, multiplicative
- preserve left-associative evaluation by splitting on the rightmost top-level operator in each group
- keep longest-token matching for >=, <=, and <> so internal single-character operators do not overwrite the match
- add regression coverage plus design and verification docs

## Verification
- pnpm install --frozen-lockfile
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/formula-engine.test.ts tests/unit/multitable-formula-engine.test.ts --reporter=dot
- pnpm --filter @metasheet/core-backend build
- git diff --check

## Docs
- docs/development/formula-operator-precedence-development-20260505.md
- docs/development/formula-operator-precedence-verification-20260505.md