### PR TITLE
fix(formula): parse parenthesized expressions

### DIFF
--- a/docs/development/formula-parenthesized-expressions-development-20260505.md
+++ b/docs/development/formula-parenthesized-expressions-development-20260505.md
@@ -1,0 +1,63 @@
+# Formula Parenthesized Expressions Development Notes
+
+Date: 2026-05-05
+Branch: `codex/formula-parenthesized-expressions-20260505`
+
+## Scope
+
+This slice adds grouped-expression support to the shared backend formula parser.
+It applies to both classic formula engine usage and multitable formula fields
+because `MultitableFormulaEngine` delegates resolved expressions to
+`FormulaEngine`.
+
+## Problem
+
+Recent formula fixes on `main` corrected string escaping, top-level operator
+tokenization, signed numeric literals, and operator precedence. One common
+spreadsheet syntax gap remained: parenthesized grouping.
+
+Examples that users naturally write:
+
+- `=(1 + 2) * 3`
+- `=10 / (2 + 3)`
+- `=({fld_price}+{fld_fee})*{fld_qty}`
+
+Without grouped-expression parsing, the parser can treat a parenthesized segment
+such as `(1 + 2)` as a string-like fallback instead of recursively evaluating the
+inner expression.
+
+## Implementation
+
+`packages/core-backend/src/formula/engine.ts` now recognizes expressions fully
+wrapped by one balanced outer pair of parentheses and recursively parses the
+inner expression before operator splitting.
+
+The helper intentionally stays narrow:
+
+- It only strips when the first `(` and final `)` wrap the whole expression.
+- It tracks quote state so parentheses inside strings are ignored.
+- It preserves the precedence and left-associativity logic from the prior
+  `fix(formula): respect operator precedence` change.
+- It does not attempt a full formula grammar rewrite.
+
+## Test Coverage
+
+Added direct formula engine coverage for:
+
+- Arithmetic groups: `=(1 + 2) * 3`, `=10 / (2 + 3)`,
+  `=((1 + 2) * (4 - 1))`.
+- Comparison groups: `=(1 + 2) > 2`, `=(1 + 2) = (5 - 2)`.
+
+Added multitable coverage for:
+
+- Field-reference grouping: `=({fld_price}+{fld_fee})*{fld_qty}`.
+
+Existing multitable tests also keep coverage for function arguments such as
+`=SUM((1+2),3)`.
+
+## Non-Goals
+
+- No formula grammar rewrite.
+- No new spreadsheet functions.
+- No frontend formula editor changes.
+- No database or migration changes.

--- a/docs/development/formula-parenthesized-expressions-verification-20260505.md
+++ b/docs/development/formula-parenthesized-expressions-verification-20260505.md
@@ -1,0 +1,46 @@
+# Formula Parenthesized Expressions Verification
+
+Date: 2026-05-05
+Branch: `codex/formula-parenthesized-expressions-20260505`
+
+## Commands Run
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/formula-engine.test.ts tests/unit/multitable-formula-engine.test.ts --reporter=dot
+pnpm --filter @metasheet/core-backend build
+```
+
+## Results
+
+Targeted unit tests:
+
+```text
+Test Files  2 passed (2)
+Tests       107 passed (107)
+```
+
+Backend build:
+
+```text
+@metasheet/core-backend build
+tsc
+```
+
+The formula unit run logs one existing expected error-path message for the
+`NONEXISTENT(...)` invalid-function test and one `DATABASE_URL not set` warning
+from the test bootstrap. Both are pre-existing test behavior; the suite exits
+successfully.
+
+## Rebase Note
+
+This branch was rebased after PR #1301 (`fix(formula): respect operator
+precedence`) merged into `main`. The final parser keeps #1301's
+lowest-to-highest precedence scan and adds the grouped-expression unwrap before
+that scan.
+
+## Cleanup
+
+`pnpm install --frozen-lockfile` recreated local workspace dependency symlinks in
+the temporary worktree. Those generated `node_modules` changes were restored and
+are not part of the patch.

--- a/packages/core-backend/src/formula/engine.ts
+++ b/packages/core-backend/src/formula/engine.ts
@@ -276,6 +276,10 @@ export class FormulaEngine {
       return { type: 'number', value: strictNum }
     }
 
+    if (this.isWrappedExpression(formula)) {
+      return this.parseFormula(formula.slice(1, -1).trim())
+    }
+
     // Check for operators from lowest to highest precedence. Operators in the
     // same precedence group are left-associative, so split on the rightmost
     // top-level operator to recursively keep the left side grouped first.
@@ -397,6 +401,36 @@ export class FormulaEngine {
       return exponentIsAdjacent && (/\d/.test(mantissaTail) || mantissaTail === '.')
     }
     return ['+', '-', '*', '/', '=', '>', '<', '(', '[', ','].includes(previous)
+  }
+
+  private isWrappedExpression(formula: string): boolean {
+    if (!formula.startsWith('(') || !formula.endsWith(')')) return false
+
+    let depth = 0
+    let inQuotes = false
+
+    for (let i = 0; i < formula.length; i++) {
+      const char = formula[i]
+
+      if (char === '"' && (i === 0 || formula[i - 1] !== '\\')) {
+        inQuotes = !inQuotes
+        continue
+      }
+
+      if (inQuotes) continue
+
+      if (char === '(') {
+        depth++
+        continue
+      }
+
+      if (char === ')') {
+        depth--
+        if (depth === 0 && i < formula.length - 1) return false
+      }
+    }
+
+    return depth === 0 && !inQuotes
   }
 
   /**

--- a/packages/core-backend/tests/unit/formula-engine.test.ts
+++ b/packages/core-backend/tests/unit/formula-engine.test.ts
@@ -258,6 +258,17 @@ describe('Formula Engine', () => {
       expect(await engine.calculate('=2 * 3 <> 7 - 1', context)).toBe(false)
     })
 
+    test('Parenthesized arithmetic groups', async () => {
+      expect(await engine.calculate('=(1 + 2) * 3', context)).toBe(9)
+      expect(await engine.calculate('=10 / (2 + 3)', context)).toBe(2)
+      expect(await engine.calculate('=((1 + 2) * (4 - 1))', context)).toBe(9)
+    })
+
+    test('Parenthesized comparison groups', async () => {
+      expect(await engine.calculate('=(1 + 2) > 2', context)).toBe(true)
+      expect(await engine.calculate('=(1 + 2) = (5 - 2)', context)).toBe(true)
+    })
+
     test('Division by zero', async () => {
       expect(await engine.calculate('=5 / 0', context)).toBe('#DIV/0!')
     })

--- a/packages/core-backend/tests/unit/multitable-formula-engine.test.ts
+++ b/packages/core-backend/tests/unit/multitable-formula-engine.test.ts
@@ -87,6 +87,28 @@ describe('FormulaEngine - new functions', () => {
     })
   })
 
+  describe('parenthesized expressions', () => {
+    it('evaluates arithmetic groups inside formulas', async () => {
+      const result = await engine.calculate('=(1+2)*3', makeContext())
+      expect(result).toBe(9)
+    })
+
+    it('evaluates nested arithmetic groups', async () => {
+      const result = await engine.calculate('=((1+2)*(4-1))', makeContext())
+      expect(result).toBe(9)
+    })
+
+    it('evaluates parenthesized function arguments', async () => {
+      const result = await engine.calculate('=SUM((1+2),3)', makeContext())
+      expect(result).toBe(6)
+    })
+
+    it('does not strip partial leading parentheses', async () => {
+      const result = await engine.calculate('=(1+2)+(3+4)', makeContext())
+      expect(result).toBe(10)
+    })
+  })
+
   describe('DATEDIF', () => {
     it('calculates days between dates', async () => {
       const result = await engine.calculate('=DATEDIF("2024-01-01","2024-01-31","D")', makeContext())
@@ -140,6 +162,7 @@ describe('MultitableFormulaEngine', () => {
 
   const sampleFields: MultitableField[] = [
     { id: 'fld_price', name: 'Price', type: 'number' },
+    { id: 'fld_fee', name: 'Fee', type: 'number' },
     { id: 'fld_qty', name: 'Quantity', type: 'number' },
     { id: 'fld_total', name: 'Total', type: 'formula', property: { expression: '={fld_price}*{fld_qty}' } },
     { id: 'fld_name', name: 'Name', type: 'string' },
@@ -174,6 +197,15 @@ describe('MultitableFormulaEngine', () => {
         sampleFields,
       )
       expect(result).toBe(50)
+    })
+
+    it('evaluates parenthesized field reference groups', async () => {
+      const result = await mtEngine.evaluateField(
+        '=({fld_price}+{fld_fee})*{fld_qty}',
+        { fld_price: 10, fld_fee: 2, fld_qty: 5 },
+        sampleFields,
+      )
+      expect(result).toBe(60)
     })
 
     it('handles string field references', async () => {


### PR DESCRIPTION
## Summary
- add balanced outer-parentheses parsing to the shared backend FormulaEngine
- preserve the existing operator precedence / left-associativity behavior from #1301
- cover grouped arithmetic, grouped comparisons, grouped function arguments, and multitable field-reference formulas

## Verification
- pnpm install --frozen-lockfile
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/formula-engine.test.ts tests/unit/multitable-formula-engine.test.ts --reporter=dot
- pnpm --filter @metasheet/core-backend build
- git diff --cached --check

## Docs
- docs/development/formula-parenthesized-expressions-development-20260505.md
- docs/development/formula-parenthesized-expressions-verification-20260505.md