### PR TITLE
fix(formula): accept case-insensitive function names

### DIFF
--- a/docs/development/formula-case-insensitive-functions-development-20260505.md
+++ b/docs/development/formula-case-insensitive-functions-development-20260505.md
@@ -1,0 +1,57 @@
+# Formula Case-Insensitive Functions Development Notes
+
+Date: 2026-05-05
+Branch: `codex/formula-case-insensitive-functions-20260505`
+
+## Scope
+
+This change makes backend formula function names case-insensitive. It applies to
+both classic `FormulaEngine` formulas and multitable formula fields because
+multitable formulas delegate to the same shared engine after resolving field
+references.
+
+## Problem
+
+The formula engine registers built-in functions with uppercase names such as
+`SUM`, `CONCAT`, and `DATEDIF`, while the parser only recognized function calls
+matching uppercase tokens:
+
+```ts
+/^([A-Z]+)\((.*)\)$/
+```
+
+That meant common user-entered formulas like `=sum(1,2)` or
+`=concat("a","b")` were not parsed as function calls. They fell through to the
+plain-string fallback and returned literal text instead of calculated values.
+
+## Implementation
+
+`packages/core-backend/src/formula/engine.ts` now:
+
+- recognizes function tokens beginning with a letter and followed by letters,
+  digits, or underscores;
+- normalizes the parsed function name to uppercase before storing it in the AST;
+- keeps the existing function registry unchanged.
+
+The parser still rejects unknown function names through the existing
+`Unknown function` error path.
+
+## Test Coverage
+
+Added direct formula engine coverage for:
+
+- `=sum(1, 2, 3)` -> `6`
+- `=CoUnT(1, 2, "", 4)` -> `3`
+- `=concatenate("Hello", " ", "World")` -> `Hello World`
+- `=LoWeR("HELLO")` -> `hello`
+
+Added multitable coverage for:
+
+- `=concat({fld_name}," x")` after field-reference resolution.
+
+## Non-Goals
+
+- No new formula functions.
+- No changes to function implementations.
+- No frontend formula editor changes.
+- No parser grammar rewrite beyond function-token recognition.

--- a/docs/development/formula-case-insensitive-functions-verification-20260505.md
+++ b/docs/development/formula-case-insensitive-functions-verification-20260505.md
@@ -1,0 +1,63 @@
+# Formula Case-Insensitive Functions Verification
+
+Date: 2026-05-05
+Branch: `codex/formula-case-insensitive-functions-20260505`
+
+## Commands Run
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/core-backend exec tsx -e "import { FormulaEngine } from './src/formula/engine'; void (async () => { const engine = new FormulaEngine({ db: undefined as any }); const context = { sheetId: 's', spreadsheetId: 'p', currentCell: { row: 0, col: 0 }, cache: new Map() }; console.log(await engine.calculate('=sum(1,2)', context as any)); console.log(await engine.calculate('=concat(\"a\",\"b\")', context as any)); })();"
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/formula-engine.test.ts tests/unit/multitable-formula-engine.test.ts --reporter=dot
+pnpm --filter @metasheet/core-backend build
+```
+
+## Results
+
+Manual formula probe after the fix:
+
+```text
+3
+ab
+```
+
+Targeted unit tests after rebasing onto `origin/main@cacc0aa6`:
+
+```text
+Test Files  2 passed (2)
+Tests       114 passed (114)
+```
+
+Backend build:
+
+```text
+@metasheet/core-backend build
+tsc
+```
+
+Diff hygiene:
+
+```text
+git diff --check
+```
+
+The targeted test run logs the existing invalid-function error-path message for
+`NONEXISTENT(...)` and a `DATABASE_URL not set` bootstrap warning. Both are
+pre-existing test behavior; the suite exits successfully.
+
+## Pre-Fix Probe
+
+The same manual probe was run before the code change. It returned literal text:
+
+```text
+sum(1,2)
+concat("a","b")
+```
+
+That confirmed the parser was not treating lowercase function names as calls.
+
+## Cleanup
+
+`pnpm install --frozen-lockfile` recreated local workspace dependency symlinks in
+the temporary worktree. Those generated `node_modules` changes were restored and
+are not part of the patch.

--- a/packages/core-backend/src/formula/engine.ts
+++ b/packages/core-backend/src/formula/engine.ts
@@ -254,9 +254,9 @@ export class FormulaEngine {
     // In production, use a proper parser like PEG.js or write a full recursive descent parser
 
     // Check if it's a function call
-    const functionMatch = formula.match(/^([A-Z]+)\((.*)\)$/)
+    const functionMatch = formula.match(/^([A-Za-z][A-Za-z0-9_]*)\((.*)\)$/)
     if (functionMatch) {
-      const functionName = functionMatch[1]
+      const functionName = functionMatch[1].toUpperCase()
       const args = this.parseArguments(functionMatch[2])
       return {
         type: 'function',

--- a/packages/core-backend/tests/unit/formula-engine.test.ts
+++ b/packages/core-backend/tests/unit/formula-engine.test.ts
@@ -39,6 +39,11 @@ describe('Formula Engine', () => {
         expect(result).toBe(15)
       })
 
+      test('Function names should be case-insensitive', async () => {
+        expect(await engine.calculate('=sum(1, 2, 3)', context)).toBe(6)
+        expect(await engine.calculate('=CoUnT(1, 2, "", 4)', context)).toBe(3)
+      })
+
       test('SUM with nested arrays', async () => {
         const result = await engine.calculate('=SUM([[1, 2], [3, 4]])', context)
         expect(result).toBe(10)
@@ -91,6 +96,11 @@ describe('Formula Engine', () => {
       test('CONCATENATE function', async () => {
         const result = await engine.calculate('=CONCATENATE("Hello", " ", "World")', context)
         expect(result).toBe('Hello World')
+      })
+
+      test('Text function names should be case-insensitive', async () => {
+        expect(await engine.calculate('=concatenate("Hello", " ", "World")', context)).toBe('Hello World')
+        expect(await engine.calculate('=LoWeR("HELLO")', context)).toBe('hello')
       })
 
       test('LEFT function', async () => {

--- a/packages/core-backend/tests/unit/multitable-formula-engine.test.ts
+++ b/packages/core-backend/tests/unit/multitable-formula-engine.test.ts
@@ -235,6 +235,15 @@ describe('MultitableFormulaEngine', () => {
       expect(result).toBe('Widget total')
     })
 
+    it('handles lowercase function names after resolving field references', async () => {
+      const result = await mtEngine.evaluateField(
+        '=concat({fld_name}," x")',
+        { fld_name: 'Widget' },
+        sampleFields,
+      )
+      expect(result).toBe('Widget x')
+    })
+
     it('escapes quoted string field references before evaluation', async () => {
       const result = await mtEngine.evaluateField(
         '=CONCAT({fld_name}," shipped")',


### PR DESCRIPTION
## Summary
- parse formula function names case-insensitively and normalize them to uppercase for existing registry lookup
- keep unknown-function handling unchanged
- cover lowercase/mixed-case math, text, and multitable formula usage

## Verification
- pnpm install --frozen-lockfile
- pre-fix/probe command confirmed lowercase function names returned literal text; post-fix probe returns calculated values
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/formula-engine.test.ts tests/unit/multitable-formula-engine.test.ts --reporter=dot
- pnpm --filter @metasheet/core-backend build
- git diff --check

## Docs
- docs/development/formula-case-insensitive-functions-development-20260505.md
- docs/development/formula-case-insensitive-functions-verification-20260505.md