### PR TITLE
fix(formula): parse unary expressions

### DIFF
--- a/docs/development/formula-unary-expression-development-20260505.md
+++ b/docs/development/formula-unary-expression-development-20260505.md
@@ -1,0 +1,42 @@
+# Formula Unary Expression Development
+
+Date: 2026-05-05
+Branch: `codex/formula-unary-expression-20260505`
+
+## Scope
+
+This slice continues formula parser correctness hardening after string escaping,
+top-level operator tokenization, strict numeric literals, operator precedence,
+and parenthesized expression parsing.
+
+Parenthesized expressions were supported, but unary signs only worked when the
+operand was a complete numeric literal such as `-3`. Expressions such as
+`-(1+2)`, `5*-(1+2)`, and `-SUM(1,2)` still fell through to string parsing.
+
+## Design
+
+The formula AST now has an explicit `unary` node:
+
+- `operator`: `+` or `-`;
+- `operand`: any existing formula AST node.
+
+`parseFormula(...)` scans binary operators before parsing unary expressions.
+This preserves existing binary behavior such as `-3+5` by splitting on the
+top-level `+` first, then parsing `-3` as the left operand.
+
+Unary parsing only applies when the sign is a true unary sign according to the
+existing `isUnarySign(...)` rules. Evaluation coerces the operand with
+`Number(...)`, matching the existing arithmetic operator behavior.
+
+## Files Changed
+
+- `packages/core-backend/src/formula/engine.ts`
+- `packages/core-backend/tests/unit/formula-engine.test.ts`
+- `packages/core-backend/tests/unit/multitable-formula-engine.test.ts`
+
+## Non-Goals
+
+- No full formula grammar rewrite.
+- No custom error typing for unary coercion failures.
+- No frontend formula editor changes.
+- No OpenAPI changes.

--- a/docs/development/formula-unary-expression-verification-20260505.md
+++ b/docs/development/formula-unary-expression-verification-20260505.md
@@ -1,0 +1,60 @@
+# Formula Unary Expression Verification
+
+Date: 2026-05-05
+Branch: `codex/formula-unary-expression-20260505`
+
+## Commands Run
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/formula-engine.test.ts \
+  tests/unit/multitable-formula-engine.test.ts \
+  --reporter=dot
+pnpm --filter @metasheet/core-backend build
+git diff --check
+```
+
+## Results
+
+Targeted formula tests:
+
+- 2 files passed;
+- 111 tests passed.
+
+Build:
+
+- `@metasheet/core-backend` TypeScript build passed.
+
+Diff hygiene:
+
+- `git diff --check` passed.
+
+## New Coverage
+
+Added regression coverage for:
+
+- `=-(1 + 2)`;
+- `=+(1 + 2)`;
+- `=5 * -(1 + 2)`;
+- `=--(1 + 2)`;
+- `=-SUM(1, 2)`;
+- `=+SUM(1, 2)`;
+- `=-({fld_price}+{fld_fee})*{fld_qty}`;
+- `=-SUM({fld_price},{fld_fee})`.
+
+## First Failure Captured
+
+The first implementation parsed unary expressions before binary operators. That
+made `-3+5` parse as `-(3+5)` and returned `-8`. The final implementation scans
+binary operators first, then parses unary signs at operand boundaries.
+
+## Non-Failing Noise
+
+The formula test suite logs an expected error for the existing invalid-function
+case. The test asserts that invalid functions return `#ERROR!`; this is not a
+regression from this slice.
+
+`pnpm install` updated plugin and CLI `node_modules` symlink metadata in the
+temporary worktree. Those generated dependency changes were reverted before
+commit.

--- a/packages/core-backend/src/formula/engine.ts
+++ b/packages/core-backend/src/formula/engine.ts
@@ -29,7 +29,18 @@ export interface FormulaContext {
 
 // AST Node Types
 export interface ASTNode {
-  type: 'number' | 'boolean' | 'null' | 'array' | 'string' | 'cell' | 'range' | 'error' | 'function' | 'operator'
+  type:
+    | 'number'
+    | 'boolean'
+    | 'null'
+    | 'array'
+    | 'string'
+    | 'cell'
+    | 'range'
+    | 'error'
+    | 'function'
+    | 'operator'
+    | 'unary'
 }
 
 export interface NumberNode extends ASTNode {
@@ -87,6 +98,12 @@ export interface OperatorNode extends ASTNode {
   right: ASTNodeUnion
 }
 
+export interface UnaryNode extends ASTNode {
+  type: 'unary'
+  operator: '+' | '-'
+  operand: ASTNodeUnion
+}
+
 export type ASTNodeUnion =
   | NumberNode
   | BooleanNode
@@ -98,6 +115,7 @@ export type ASTNodeUnion =
   | ErrorNode
   | FunctionNode
   | OperatorNode
+  | UnaryNode
 
 // Function type for spreadsheet functions
 type SpreadsheetFunction = (...args: unknown[]) => unknown
@@ -302,6 +320,11 @@ export class FormulaEngine {
       }
     }
 
+    const unaryExpression = this.parseUnaryExpression(formula)
+    if (unaryExpression) {
+      return unaryExpression
+    }
+
     // Check if it's a boolean
     if (formula.toUpperCase() === 'TRUE') return { type: 'boolean', value: true }
     if (formula.toUpperCase() === 'FALSE') return { type: 'boolean', value: false }
@@ -401,6 +424,24 @@ export class FormulaEngine {
       return exponentIsAdjacent && (/\d/.test(mantissaTail) || mantissaTail === '.')
     }
     return ['+', '-', '*', '/', '=', '>', '<', '(', '[', ','].includes(previous)
+  }
+
+  private parseUnaryExpression(formula: string): UnaryNode | null {
+    const firstTokenIndex = formula.search(/\S/)
+    if (firstTokenIndex < 0) return null
+
+    const operator = formula[firstTokenIndex]
+    if (operator !== '+' && operator !== '-') return null
+    if (!this.isUnarySign(formula, firstTokenIndex)) return null
+
+    const operand = formula.slice(firstTokenIndex + 1).trim()
+    if (operand.length === 0) return null
+
+    return {
+      type: 'unary',
+      operator,
+      operand: this.parseFormula(operand),
+    }
   }
 
   private isWrappedExpression(formula: string): boolean {
@@ -513,6 +554,12 @@ export class FormulaEngine {
         const left = await this.evaluateAST(node.left, context)
         const right = await this.evaluateAST(node.right, context)
         return this.evaluateOperator(node.operator, left, right)
+      }
+
+      case 'unary': {
+        const value = await this.evaluateAST(node.operand, context)
+        const numericValue = Number(value)
+        return node.operator === '-' ? -numericValue : numericValue
       }
 
       default:

--- a/packages/core-backend/tests/unit/formula-engine.test.ts
+++ b/packages/core-backend/tests/unit/formula-engine.test.ts
@@ -269,6 +269,18 @@ describe('Formula Engine', () => {
       expect(await engine.calculate('=(1 + 2) = (5 - 2)', context)).toBe(true)
     })
 
+    test('Unary signs apply to grouped expressions', async () => {
+      expect(await engine.calculate('=-(1 + 2)', context)).toBe(-3)
+      expect(await engine.calculate('=+(1 + 2)', context)).toBe(3)
+      expect(await engine.calculate('=5 * -(1 + 2)', context)).toBe(-15)
+      expect(await engine.calculate('=--(1 + 2)', context)).toBe(3)
+    })
+
+    test('Unary signs apply to function results', async () => {
+      expect(await engine.calculate('=-SUM(1, 2)', context)).toBe(-3)
+      expect(await engine.calculate('=+SUM(1, 2)', context)).toBe(3)
+    })
+
     test('Division by zero', async () => {
       expect(await engine.calculate('=5 / 0', context)).toBe('#DIV/0!')
     })

--- a/packages/core-backend/tests/unit/multitable-formula-engine.test.ts
+++ b/packages/core-backend/tests/unit/multitable-formula-engine.test.ts
@@ -208,6 +208,24 @@ describe('MultitableFormulaEngine', () => {
       expect(result).toBe(60)
     })
 
+    it('evaluates unary signs for grouped field reference expressions', async () => {
+      const result = await mtEngine.evaluateField(
+        '=-({fld_price}+{fld_fee})*{fld_qty}',
+        { fld_price: 10, fld_fee: 2, fld_qty: 5 },
+        sampleFields,
+      )
+      expect(result).toBe(-60)
+    })
+
+    it('evaluates unary signs for function results', async () => {
+      const result = await mtEngine.evaluateField(
+        '=-SUM({fld_price},{fld_fee})',
+        { fld_price: 10, fld_fee: 2 },
+        sampleFields,
+      )
+      expect(result).toBe(-12)
+    })
+
     it('handles string field references', async () => {
       const result = await mtEngine.evaluateField(
         '=CONCAT({fld_name}," total")',


### PR DESCRIPTION
## Summary
- add an explicit unary AST node for leading + and - expressions
- parse unary signs after binary operator scanning so existing cases like -3+5 remain correct
- support unary signs for grouped expressions, function results, and multitable field-reference expressions
- add design and verification docs

## Verification
- pnpm install --frozen-lockfile
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/formula-engine.test.ts tests/unit/multitable-formula-engine.test.ts --reporter=dot
- pnpm --filter @metasheet/core-backend build
- git diff --check

## Docs
- docs/development/formula-unary-expression-development-20260505.md
- docs/development/formula-unary-expression-verification-20260505.md