### PR TITLE
fix(formula): accept lowercase cell references

### DIFF
--- a/docs/development/formula-cell-reference-case-development-20260505.md
+++ b/docs/development/formula-cell-reference-case-development-20260505.md
@@ -1,0 +1,41 @@
+# Formula Cell Reference Case Development
+
+Date: 2026-05-05
+Branch: `codex/formula-cell-reference-case-20260505`
+
+## Scope
+
+This slice continues formula parser compatibility hardening after function names
+became case-insensitive.
+
+Function calls such as `=sum(...)` were accepted, but cell and range references
+still required uppercase column letters. Common spreadsheet input such as
+`=a1` or `=sum(a1:a3)` fell through to string parsing instead of resolving the
+cell or range.
+
+## Design
+
+`FormulaEngine.parseFormula(...)` now accepts uppercase or lowercase ASCII
+letters for cell and range references:
+
+- single cell: `A1`, `a1`, `AA1`, `aa1`;
+- range: `A1:A3`, `a1:a3`, `A1:a3`.
+
+`parseCellReference(...)` uses the same case-insensitive reference shape, and
+`columnLetterToIndex(...)` normalizes column letters to uppercase before the
+existing base-26 conversion.
+
+This keeps the DB lookup path unchanged: lowercase references map to the same
+zero-based row and column indexes as uppercase references.
+
+## Files Changed
+
+- `packages/core-backend/src/formula/engine.ts`
+- `packages/core-backend/tests/unit/formula-engine.test.ts`
+
+## Non-Goals
+
+- No support for absolute references such as `$A$1`.
+- No sheet-qualified references.
+- No R1C1 notation.
+- No frontend formula editor changes.

--- a/docs/development/formula-cell-reference-case-verification-20260505.md
+++ b/docs/development/formula-cell-reference-case-verification-20260505.md
@@ -1,0 +1,48 @@
+# Formula Cell Reference Case Verification
+
+Date: 2026-05-05
+Branch: `codex/formula-cell-reference-case-20260505`
+
+## Commands Run
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/formula-engine.test.ts \
+  tests/unit/multitable-formula-engine.test.ts \
+  --reporter=dot
+pnpm --filter @metasheet/core-backend build
+git diff --check
+```
+
+## Results
+
+Targeted formula tests:
+
+- 2 files passed;
+- 116 tests passed.
+
+Build:
+
+- `@metasheet/core-backend` TypeScript build passed.
+
+Diff hygiene:
+
+- `git diff --check` passed.
+
+## New Coverage
+
+Added regression coverage for:
+
+- `=aa1` resolving to the same column index as `AA1`;
+- `=sum(a1:a3)` resolving lowercase range references.
+
+## Non-Failing Noise
+
+The formula test suite logs an expected error for the existing invalid-function
+case. The test asserts that invalid functions return `#ERROR!`; this is not a
+regression from this slice.
+
+`pnpm install` updated plugin and CLI `node_modules` symlink metadata in the
+temporary worktree. Those generated dependency changes were reverted before
+commit.

--- a/packages/core-backend/src/formula/engine.ts
+++ b/packages/core-backend/src/formula/engine.ts
@@ -266,7 +266,7 @@ export class FormulaEngine {
     }
 
     // Check if it's a cell reference
-    const cellMatch = formula.match(/^([A-Z]+)(\d+)$/)
+    const cellMatch = formula.match(/^([A-Za-z]+)(\d+)$/)
     if (cellMatch) {
       return {
         type: 'cell',
@@ -276,7 +276,7 @@ export class FormulaEngine {
     }
 
     // Check if it's a range
-    const rangeMatch = formula.match(/^([A-Z]+\d+):([A-Z]+\d+)$/)
+    const rangeMatch = formula.match(/^([A-Za-z]+\d+):([A-Za-z]+\d+)$/)
     if (rangeMatch) {
       const start = this.parseCellReference(rangeMatch[1])
       const end = this.parseCellReference(rangeMatch[2])
@@ -672,7 +672,7 @@ export class FormulaEngine {
    * Parse cell reference string
    */
   private parseCellReference(ref: string): { row: number; col: number } {
-    const match = ref.match(/^([A-Z]+)(\d+)$/)
+    const match = ref.match(/^([A-Za-z]+)(\d+)$/)
     if (!match) throw new Error(`Invalid cell reference: ${ref}`)
 
     return {
@@ -685,7 +685,7 @@ export class FormulaEngine {
    * Convert column letter to index
    */
   private columnLetterToIndex(letter: string): number {
-    return letter
+    return letter.toUpperCase()
       .split('')
       .reduce((acc, char) => acc * 26 + char.charCodeAt(0) - 64, 0) - 1
   }

--- a/packages/core-backend/tests/unit/formula-engine.test.ts
+++ b/packages/core-backend/tests/unit/formula-engine.test.ts
@@ -321,6 +321,24 @@ describe('Formula Engine', () => {
       expect(result).toBe(42)
     })
 
+    test('Cell references should be case-insensitive', async () => {
+      const whereMock = vi.fn().mockReturnThis()
+      mockDb.selectFrom.mockReturnValue({
+        select: vi.fn().mockReturnThis(),
+        where: whereMock,
+        executeTakeFirst: vi.fn().mockResolvedValue({
+          value: '42',
+          data_type: 'number',
+          formula: null
+        })
+      })
+
+      const result = await engine.calculate('=aa1', context)
+
+      expect(result).toBe(42)
+      expect(whereMock).toHaveBeenCalledWith('column_index', '=', 26)
+    })
+
     test('Cell reference with formula', async () => {
       mockDb.selectFrom.mockReturnValue({
         select: vi.fn().mockReturnThis(),
@@ -354,6 +372,26 @@ describe('Formula Engine', () => {
       })
 
       const result = await engine.calculate('=SUM(A1:A3)', context)
+      expect(result).toBe(6)
+    })
+
+    test('Range references should be case-insensitive', async () => {
+      const cellValues = [
+        { value: '1', data_type: 'number', formula: null },
+        { value: '2', data_type: 'number', formula: null },
+        { value: '3', data_type: 'number', formula: null }
+      ]
+
+      let callIndex = 0
+      mockDb.selectFrom.mockReturnValue({
+        select: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        executeTakeFirst: vi.fn().mockImplementation(() => {
+          return Promise.resolve(cellValues[callIndex++] || null)
+        })
+      })
+
+      const result = await engine.calculate('=sum(a1:a3)', context)
       expect(result).toBe(6)
     })
   })


### PR DESCRIPTION
## Summary
- accept lowercase and mixed-case cell references in formulas
- accept lowercase and mixed-case range references
- normalize column letters to uppercase before the existing zero-based column conversion
- add design and verification docs

## Verification
- pnpm install --frozen-lockfile
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/formula-engine.test.ts tests/unit/multitable-formula-engine.test.ts --reporter=dot
- pnpm --filter @metasheet/core-backend build
- git diff --check

## Docs
- docs/development/formula-cell-reference-case-development-20260505.md
- docs/development/formula-cell-reference-case-verification-20260505.md