### PR TITLE
fix(formula): parse function calls inside expressions

### DIFF
--- a/docs/development/formula-function-expression-development-20260505.md
+++ b/docs/development/formula-function-expression-development-20260505.md
@@ -1,0 +1,67 @@
+# Formula Function Expression Development Notes
+
+Date: 2026-05-05
+Branch: `codex/formula-next-hardening-20260505`
+
+## Scope
+
+This slice hardens the shared backend formula parser so function calls can
+participate in larger expressions instead of being parsed only as whole-formula
+roots.
+
+Examples now covered:
+
+- `=SUM(1, 2) + SUM(3, 4)`
+- `=SUM(10, 5) / SUM(1, 2)`
+- `=(SUM(1, 2) + 3) * 2`
+- `=SUM(1, 2) = SUM(3)`
+
+## Problem
+
+The parser previously used a greedy function-call regular expression:
+
+```ts
+/^([A-Za-z][A-Za-z0-9_]*)\((.*)\)$/
+```
+
+That worked for formulas where the entire expression was a single function
+call, but it was too broad. Expressions such as `SUM(1)+SUM(2)` start with a
+function-like prefix and end with `)`, so the regex swallowed the full string as
+one `SUM(...)` call before operator parsing had a chance to split the top-level
+`+`.
+
+The result was incorrect parsing for common spreadsheet expressions that mix
+functions with arithmetic or comparison operators.
+
+## Implementation
+
+`FormulaEngine.parseFormula(...)` now delegates function recognition to
+`parseFunctionCall(...)`.
+
+The helper:
+
+- recognizes a function call only when the matching closing parenthesis closes
+  at the final character of the current expression;
+- tracks nested parentheses and quoted strings;
+- returns `null` when a function-like prefix is only part of a larger
+  expression, allowing the existing top-level operator parser to handle it;
+- returns a malformed signal for unclosed function-like expressions so existing
+  bad-input behavior remains `#ERROR!`.
+
+`parseFormula(...)` also trims the current expression before parsing. This keeps
+operator-recursive parsing stable when the left or right side has harmless outer
+whitespace.
+
+## Files Changed
+
+- `packages/core-backend/src/formula/engine.ts`
+- `packages/core-backend/tests/unit/formula-engine.test.ts`
+- `docs/development/formula-function-expression-development-20260505.md`
+- `docs/development/formula-function-expression-verification-20260505.md`
+
+## Non-Goals
+
+- No full formula grammar rewrite.
+- No frontend formula editor changes.
+- No new spreadsheet functions.
+- No DB or migration changes.

--- a/docs/development/formula-function-expression-verification-20260505.md
+++ b/docs/development/formula-function-expression-verification-20260505.md
@@ -1,0 +1,60 @@
+# Formula Function Expression Verification Notes
+
+Date: 2026-05-05
+Branch: `codex/formula-next-hardening-20260505`
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/formula-engine.test.ts \
+  tests/unit/multitable-formula-engine.test.ts \
+  --reporter=dot
+pnpm --filter @metasheet/core-backend build
+git diff --check
+```
+
+## Results
+
+Focused formula regression:
+
+```text
+Test Files  2 passed (2)
+Tests       118 passed (118)
+```
+
+Backend build:
+
+```text
+EXIT 0
+```
+
+Diff whitespace check:
+
+```text
+EXIT 0
+```
+
+## New Coverage
+
+Added formula-engine coverage for:
+
+- function calls on both sides of arithmetic: `SUM(...) + SUM(...)`;
+- function calls inside division: `SUM(...) / SUM(...)`;
+- function calls inside parenthesized arithmetic groups;
+- function calls on both sides of comparison operators.
+
+The existing malformed quoted function literal regression stayed green after the
+helper was changed to return `#ERROR!` for unclosed function-like expressions.
+
+## Expected Noise
+
+The targeted formula run logs:
+
+- Vite CJS API deprecation warning from the existing test stack;
+- `DATABASE_URL not set` warning from backend pool initialization;
+- expected invalid-function error log from the existing `NONEXISTENT(...)`
+  test.
+
+Those are pre-existing test-suite noises and do not indicate this slice failed.

--- a/packages/core-backend/src/formula/engine.ts
+++ b/packages/core-backend/src/formula/engine.ts
@@ -250,17 +250,21 @@ export class FormulaEngine {
    * Parse formula string into AST
    */
   private parseFormula(formula: string): ASTNodeUnion {
+    formula = formula.trim()
+
     // Simple tokenizer and parser (simplified for demo)
     // In production, use a proper parser like PEG.js or write a full recursive descent parser
 
     // Check if it's a function call
-    const functionMatch = formula.match(/^([A-Za-z][A-Za-z0-9_]*)\((.*)\)$/)
-    if (functionMatch) {
-      const functionName = functionMatch[1].toUpperCase()
-      const args = this.parseArguments(functionMatch[2])
+    const functionCall = this.parseFunctionCall(formula)
+    if (functionCall?.type === 'malformed') {
+      return { type: 'error', value: '#ERROR!' }
+    }
+    if (functionCall?.type === 'function') {
+      const args = this.parseArguments(functionCall.argsString)
       return {
         type: 'function',
-        name: functionName,
+        name: functionCall.name,
         arguments: args
       }
     }
@@ -363,6 +367,47 @@ export class FormulaEngine {
     }
 
     return { type: 'string', value: formula }
+  }
+
+  private parseFunctionCall(
+    formula: string
+  ): { type: 'function'; name: string; argsString: string } | { type: 'malformed' } | null {
+    const nameMatch = formula.match(/^([A-Za-z][A-Za-z0-9_]*)\s*\(/)
+    if (!nameMatch) return null
+
+    const openParenIndex = formula.indexOf('(', nameMatch[1].length)
+    let depth = 0
+    let inQuotes = false
+
+    for (let i = openParenIndex; i < formula.length; i++) {
+      const char = formula[i]
+
+      if (char === '"' && (i === 0 || formula[i - 1] !== '\\')) {
+        inQuotes = !inQuotes
+        continue
+      }
+
+      if (inQuotes) continue
+
+      if (char === '(') {
+        depth++
+        continue
+      }
+
+      if (char === ')') {
+        depth--
+        if (depth === 0) {
+          if (i !== formula.length - 1) return null
+          return {
+            type: 'function',
+            name: nameMatch[1].toUpperCase(),
+            argsString: formula.slice(openParenIndex + 1, i)
+          }
+        }
+      }
+    }
+
+    return { type: 'malformed' }
   }
 
   /**

--- a/packages/core-backend/tests/unit/formula-engine.test.ts
+++ b/packages/core-backend/tests/unit/formula-engine.test.ts
@@ -291,6 +291,17 @@ describe('Formula Engine', () => {
       expect(await engine.calculate('=+SUM(1, 2)', context)).toBe(3)
     })
 
+    test('Function calls participate in arithmetic expressions', async () => {
+      expect(await engine.calculate('=SUM(1, 2) + SUM(3, 4)', context)).toBe(10)
+      expect(await engine.calculate('=SUM(10, 5) / SUM(1, 2)', context)).toBe(5)
+      expect(await engine.calculate('=(SUM(1, 2) + 3) * 2', context)).toBe(12)
+    })
+
+    test('Function calls participate in comparison expressions', async () => {
+      expect(await engine.calculate('=SUM(1, 2) = SUM(3)', context)).toBe(true)
+      expect(await engine.calculate('=MAX(1, 5) > MIN(2, 3)', context)).toBe(true)
+    })
+
     test('Division by zero', async () => {
       expect(await engine.calculate('=5 / 0', context)).toBe('#DIV/0!')
     })


### PR DESCRIPTION
## Summary
- replace greedy whole-string function regex with balanced function-call parsing
- allow function calls to participate in arithmetic and comparison expressions
- preserve malformed function-like input as #ERROR!
- add design and verification MDs

## Verification
- pnpm install --frozen-lockfile
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/formula-engine.test.ts tests/unit/multitable-formula-engine.test.ts --reporter=dot
- pnpm --filter @metasheet/core-backend build
- git diff --check

## Docs
- docs/development/formula-function-expression-development-20260505.md
- docs/development/formula-function-expression-verification-20260505.md