### PR TITLE
fix(formula): coerce plus operands numerically

### DIFF
--- a/docs/development/formula-numeric-plus-development-20260505.md
+++ b/docs/development/formula-numeric-plus-development-20260505.md
@@ -1,0 +1,62 @@
+# Formula Numeric Plus Development Notes
+
+Date: 2026-05-05
+Branch: `codex/formula-numeric-plus-20260505`
+
+## Scope
+
+This slice aligns the formula engine's `+` operator with spreadsheet numeric
+addition semantics.
+
+## Problem
+
+The formula engine evaluated `+` with raw JavaScript addition:
+
+```ts
+(left as number) + (right as number)
+```
+
+The TypeScript cast does not coerce at runtime. If either operand is a string,
+JavaScript performs string concatenation. That means formulas such as:
+
+```text
+="1" + 2
+```
+
+returned `"12"` instead of `3`.
+
+Other arithmetic operators already use JavaScript numeric coercion implicitly,
+so `+` was the only arithmetic operator with string-concatenation behavior.
+
+## Implementation
+
+`FormulaEngine.evaluateOperator(...)` now evaluates `+` as:
+
+```ts
+Number(left) + Number(right)
+```
+
+This keeps the existing return type and keeps invalid numeric inputs in the same
+JavaScript numeric-conversion family as unary `+` / unary `-`.
+
+## Test Coverage
+
+Added direct formula-engine coverage for:
+
+- string numeric operand addition: `="1" + 2`;
+- boolean numeric coercion: `=TRUE + 1`;
+- function result plus string numeric operand: `=SUM(1, 2) + "4"`.
+
+## Files Changed
+
+- `packages/core-backend/src/formula/engine.ts`
+- `packages/core-backend/tests/unit/formula-engine.test.ts`
+- `docs/development/formula-numeric-plus-development-20260505.md`
+- `docs/development/formula-numeric-plus-verification-20260505.md`
+
+## Non-Goals
+
+- No text-concatenation operator support.
+- No full formula type-system rewrite.
+- No frontend formula editor changes.
+- No database or migration changes.

--- a/docs/development/formula-numeric-plus-verification-20260505.md
+++ b/docs/development/formula-numeric-plus-verification-20260505.md
@@ -1,0 +1,54 @@
+# Formula Numeric Plus Verification Notes
+
+Date: 2026-05-05
+Branch: `codex/formula-numeric-plus-20260505`
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/formula-engine.test.ts \
+  tests/unit/multitable-formula-engine.test.ts \
+  --reporter=dot
+pnpm --filter @metasheet/core-backend build
+git diff --check
+```
+
+## Results
+
+Focused formula regression:
+
+```text
+Test Files  2 passed (2)
+Tests       119 passed (119)
+```
+
+Backend build:
+
+```text
+EXIT 0
+```
+
+Diff whitespace check:
+
+```text
+EXIT 0
+```
+
+## New Coverage
+
+The added test verifies that `+` performs numeric addition rather than
+JavaScript string concatenation for:
+
+- quoted numeric strings;
+- booleans;
+- function results plus quoted numeric strings.
+
+## Expected Noise
+
+The targeted formula run logs existing suite noise:
+
+- Vite CJS API deprecation warning;
+- `DATABASE_URL not set` warning from backend pool initialization;
+- expected invalid-function error log from the `NONEXISTENT(...)` test.

--- a/packages/core-backend/src/formula/engine.ts
+++ b/packages/core-backend/src/formula/engine.ts
@@ -617,7 +617,7 @@ export class FormulaEngine {
    */
   private evaluateOperator(operator: string, left: unknown, right: unknown): number | boolean | string {
     switch (operator) {
-      case '+': return (left as number) + (right as number)
+      case '+': return Number(left) + Number(right)
       case '-': return (left as number) - (right as number)
       case '*': return (left as number) * (right as number)
       case '/': return right === 0 ? '#DIV/0!' : (left as number) / (right as number)

--- a/packages/core-backend/tests/unit/formula-engine.test.ts
+++ b/packages/core-backend/tests/unit/formula-engine.test.ts
@@ -254,6 +254,12 @@ describe('Formula Engine', () => {
       expect(await engine.calculate('=6 / 3', context)).toBe(2)
     })
 
+    test('Addition coerces operands numerically instead of concatenating strings', async () => {
+      expect(await engine.calculate('="1" + 2', context)).toBe(3)
+      expect(await engine.calculate('=TRUE + 1', context)).toBe(2)
+      expect(await engine.calculate('=SUM(1, 2) + "4"', context)).toBe(7)
+    })
+
     test('Same-precedence arithmetic operators are left-associative', async () => {
       expect(await engine.calculate('=5 - 3 - 1', context)).toBe(1)
       expect(await engine.calculate('=8 / 4 / 2', context)).toBe(1)


### PR DESCRIPTION
## Summary
- make formula + use numeric addition instead of JavaScript string concatenation
- add regression coverage for quoted numeric strings, booleans, and function results
- add design and verification MDs

## Verification
- pnpm install --frozen-lockfile
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/formula-engine.test.ts tests/unit/multitable-formula-engine.test.ts --reporter=dot
- pnpm --filter @metasheet/core-backend build
- git diff --check

## Docs
- docs/development/formula-numeric-plus-development-20260505.md
- docs/development/formula-numeric-plus-verification-20260505.md