### PR TITLE
feat(formula): support text concatenation operator

### DIFF
--- a/docs/development/formula-concat-operator-development-20260505.md
+++ b/docs/development/formula-concat-operator-development-20260505.md
@@ -1,0 +1,77 @@
+# Formula Concatenation Operator Development Notes
+
+Date: 2026-05-05
+Branch: `codex/formula-concat-operator-20260505`
+
+## Scope
+
+This slice adds spreadsheet-style text concatenation with the `&` operator to
+the shared backend formula engine.
+
+## Problem
+
+The previous formula-hardening slice intentionally made `+` numeric-only so
+formulas such as `="1" + 2` return `3` instead of JavaScript's `"12"`.
+
+That fixed numeric addition, but it left no operator-level way to concatenate
+text. Users coming from Excel or Feishu-style formulas expect:
+
+```text
+="Hello" & " " & "World"
+```
+
+to return `Hello World`.
+
+`CONCAT(...)` and `CONCATENATE(...)` already exist, but operator-level
+concatenation is common in spreadsheet formulas and is easier to combine with
+cell references and arithmetic.
+
+## Implementation
+
+`FormulaEngine` now includes `&` in the top-level operator scan.
+
+Precedence is intentionally spreadsheet-like:
+
+1. comparison operators split first;
+2. `&` splits after comparison and before arithmetic;
+3. `+` / `-` and `*` / `/` keep their existing precedence.
+
+Because the parser recursively splits on the lowest-precedence top-level
+operator first, this means:
+
+```text
+="Total: " & 1 + 2
+```
+
+evaluates as:
+
+```text
+"Total: " & (1 + 2)
+```
+
+and returns `Total: 3`.
+
+At evaluation time `&` uses `String(left) + String(right)`.
+
+## Test Coverage
+
+Added formula-engine coverage for:
+
+- chained text concatenation;
+- concatenation with function results;
+- concatenation inside comparison expressions;
+- arithmetic precedence around `&`.
+
+## Files Changed
+
+- `packages/core-backend/src/formula/engine.ts`
+- `packages/core-backend/tests/unit/formula-engine.test.ts`
+- `docs/development/formula-concat-operator-development-20260505.md`
+- `docs/development/formula-concat-operator-verification-20260505.md`
+
+## Non-Goals
+
+- No frontend formula editor/catalog update in this slice.
+- No full formula grammar rewrite.
+- No changes to `CONCAT` or `CONCATENATE`.
+- No database or migration changes.

--- a/docs/development/formula-concat-operator-verification-20260505.md
+++ b/docs/development/formula-concat-operator-verification-20260505.md
@@ -1,0 +1,55 @@
+# Formula Concatenation Operator Verification Notes
+
+Date: 2026-05-05
+Branch: `codex/formula-concat-operator-20260505`
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/formula-engine.test.ts \
+  tests/unit/multitable-formula-engine.test.ts \
+  --reporter=dot
+pnpm --filter @metasheet/core-backend build
+git diff --check
+```
+
+## Results
+
+Focused formula regression:
+
+```text
+Test Files  2 passed (2)
+Tests       121 passed (121)
+```
+
+Backend build:
+
+```text
+EXIT 0
+```
+
+Diff whitespace check:
+
+```text
+EXIT 0
+```
+
+## New Coverage
+
+The added tests verify:
+
+- `="Hello" & " " & "World"` returns `Hello World`;
+- `="Total: " & SUM(1, 2)` returns `Total: 3`;
+- `=("A" & "B") = "AB"` returns `true`;
+- `&` keeps lower precedence than arithmetic, so `="Total: " & 1 + 2`
+  returns `Total: 3`.
+
+## Expected Noise
+
+The targeted formula run logs existing suite noise:
+
+- Vite CJS API deprecation warning;
+- `DATABASE_URL not set` warning from backend pool initialization;
+- expected invalid-function error log from the `NONEXISTENT(...)` test.

--- a/packages/core-backend/src/formula/engine.ts
+++ b/packages/core-backend/src/formula/engine.ts
@@ -307,6 +307,7 @@ export class FormulaEngine {
     // top-level operator to recursively keep the left side grouped first.
     const operatorGroups = [
       ['>=', '<=', '<>', '=', '>', '<'],
+      ['&'],
       ['+', '-'],
       ['*', '/']
     ]
@@ -618,6 +619,7 @@ export class FormulaEngine {
   private evaluateOperator(operator: string, left: unknown, right: unknown): number | boolean | string {
     switch (operator) {
       case '+': return Number(left) + Number(right)
+      case '&': return String(left) + String(right)
       case '-': return (left as number) - (right as number)
       case '*': return (left as number) * (right as number)
       case '/': return right === 0 ? '#DIV/0!' : (left as number) / (right as number)

--- a/packages/core-backend/tests/unit/formula-engine.test.ts
+++ b/packages/core-backend/tests/unit/formula-engine.test.ts
@@ -260,6 +260,17 @@ describe('Formula Engine', () => {
       expect(await engine.calculate('=SUM(1, 2) + "4"', context)).toBe(7)
     })
 
+    test('Text concatenation operator', async () => {
+      expect(await engine.calculate('="Hello" & " " & "World"', context)).toBe('Hello World')
+      expect(await engine.calculate('="Total: " & SUM(1, 2)', context)).toBe('Total: 3')
+      expect(await engine.calculate('=("A" & "B") = "AB"', context)).toBe(true)
+    })
+
+    test('Text concatenation has lower precedence than arithmetic', async () => {
+      expect(await engine.calculate('="Total: " & 1 + 2', context)).toBe('Total: 3')
+      expect(await engine.calculate('=1 + 2 & " items"', context)).toBe('3 items')
+    })
+
     test('Same-precedence arithmetic operators are left-associative', async () => {
       expect(await engine.calculate('=5 - 3 - 1', context)).toBe(1)
       expect(await engine.calculate('=8 / 4 / 2', context)).toBe(1)


### PR DESCRIPTION
## Summary
- add spreadsheet-style text concatenation with the & operator
- keep & lower precedence than arithmetic and higher than comparison
- add regression coverage for chained text, function results, comparison, and precedence
- add design and verification MDs

## Verification
- pnpm install --frozen-lockfile
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/formula-engine.test.ts tests/unit/multitable-formula-engine.test.ts --reporter=dot
- pnpm --filter @metasheet/core-backend build
- git diff --check

## Docs
- docs/development/formula-concat-operator-development-20260505.md
- docs/development/formula-concat-operator-verification-20260505.md