### PR TITLE
feat(formula): support power operator

### DIFF
--- a/docs/development/formula-power-operator-development-20260505.md
+++ b/docs/development/formula-power-operator-development-20260505.md
@@ -1,0 +1,65 @@
+# Formula Power Operator Development Notes
+
+Date: 2026-05-05
+Branch: `codex/formula-power-operator-20260505`
+
+## Scope
+
+This slice adds spreadsheet-style exponentiation with the `^` operator to the
+shared backend formula engine.
+
+## Problem
+
+The engine already exposed `POWER(a, b)`, but spreadsheet users commonly write
+exponentiation inline:
+
+```text
+=2^3
+```
+
+Without `^`, those formulas fell through to string-like fallback parsing or
+other incorrect behavior instead of returning a numeric result.
+
+## Implementation
+
+`FormulaEngine` now evaluates `^` with:
+
+```ts
+Math.pow(Number(left), Number(right))
+```
+
+Parser handling is intentionally split from the existing left-associative
+operator groups:
+
+- comparison, text concatenation, addition/subtraction, and
+  multiplication/division keep their existing left-associative behavior;
+- unary signs are parsed before exponentiation so `-2^2` becomes `-(2^2)`;
+- exponentiation then scans the leftmost top-level `^`, making chained powers
+  right-associative: `2^3^2` becomes `2^(3^2)`.
+
+`isUnarySign(...)` also treats `^` as an operator boundary, so formulas such as
+`2^-3` parse as `2^(-3)`.
+
+## Test Coverage
+
+Added formula-engine coverage for:
+
+- basic power: `=2 ^ 3`;
+- right-associative chaining: `=2^3^2`;
+- multiplication precedence: `=2 * 3^2`;
+- signed exponents: `=2^-3`;
+- unary sign precedence: `=-2^2`, `=(-2)^2`, `=--2^2`.
+
+## Files Changed
+
+- `packages/core-backend/src/formula/engine.ts`
+- `packages/core-backend/tests/unit/formula-engine.test.ts`
+- `docs/development/formula-power-operator-development-20260505.md`
+- `docs/development/formula-power-operator-verification-20260505.md`
+
+## Non-Goals
+
+- No full formula grammar rewrite.
+- No frontend formula editor/catalog update in this slice.
+- No changes to the existing `POWER(...)` function.
+- No database or migration changes.

--- a/docs/development/formula-power-operator-verification-20260505.md
+++ b/docs/development/formula-power-operator-verification-20260505.md
@@ -1,0 +1,57 @@
+# Formula Power Operator Verification Notes
+
+Date: 2026-05-05
+Branch: `codex/formula-power-operator-20260505`
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/formula-engine.test.ts \
+  tests/unit/multitable-formula-engine.test.ts \
+  --reporter=dot
+pnpm --filter @metasheet/core-backend build
+git diff --check
+```
+
+## Results
+
+Focused formula regression:
+
+```text
+Test Files  2 passed (2)
+Tests       123 passed (123)
+```
+
+Backend build:
+
+```text
+EXIT 0
+```
+
+Diff whitespace check:
+
+```text
+EXIT 0
+```
+
+## New Coverage
+
+The added tests verify:
+
+- `=2 ^ 3` returns `8`;
+- `=2^3^2` returns `512`;
+- `=2 * 3^2` returns `18`;
+- `=2^-3` returns `0.125`;
+- `=-2^2` returns `-4`;
+- `=(-2)^2` returns `4`;
+- `=--2^2` returns `4`.
+
+## Expected Noise
+
+The targeted formula run logs existing suite noise:
+
+- Vite CJS API deprecation warning;
+- `DATABASE_URL not set` warning from backend pool initialization;
+- expected invalid-function error log from the `NONEXISTENT(...)` test.

--- a/packages/core-backend/src/formula/engine.ts
+++ b/packages/core-backend/src/formula/engine.ts
@@ -302,9 +302,9 @@ export class FormulaEngine {
       return this.parseFormula(formula.slice(1, -1).trim())
     }
 
-    // Check for operators from lowest to highest precedence. Operators in the
-    // same precedence group are left-associative, so split on the rightmost
-    // top-level operator to recursively keep the left side grouped first.
+    // Check for left-associative operators from lowest to highest precedence.
+    // Split on the rightmost top-level operator to recursively keep the left
+    // side grouped first.
     const operatorGroups = [
       ['>=', '<=', '<>', '=', '>', '<'],
       ['&'],
@@ -328,6 +328,20 @@ export class FormulaEngine {
     const unaryExpression = this.parseUnaryExpression(formula)
     if (unaryExpression) {
       return unaryExpression
+    }
+
+    // Exponentiation is right-associative and binds tighter than unary signs,
+    // so parse it after unary handling and split on the leftmost top-level ^.
+    const exponentMatch = this.findTopLevelOperator(formula, ['^'], 'right')
+    if (exponentMatch) {
+      return {
+        type: 'operator',
+        operator: exponentMatch.operator,
+        left: this.parseFormula(formula.slice(0, exponentMatch.index).trim()),
+        right: this.parseFormula(
+          formula.slice(exponentMatch.index + exponentMatch.operator.length).trim()
+        )
+      }
     }
 
     // Check if it's a boolean
@@ -414,7 +428,11 @@ export class FormulaEngine {
   /**
    * Find an operator that is not inside quoted strings, function arguments, or arrays.
    */
-  private findTopLevelOperator(formula: string, operators: string[]): { index: number; operator: string } | null {
+  private findTopLevelOperator(
+    formula: string,
+    operators: string[],
+    associativity: 'left' | 'right' = 'left'
+  ): { index: number; operator: string } | null {
     let depth = 0
     let inQuotes = false
     let match: { index: number; operator: string } | null = null
@@ -445,6 +463,9 @@ export class FormulaEngine {
             if ((operator === '+' || operator === '-') && this.isUnarySign(formula, i)) {
               continue
             }
+            if (associativity === 'right') {
+              return { index: i, operator }
+            }
             match = { index: i, operator }
             i += operator.length - 1
             break
@@ -469,7 +490,7 @@ export class FormulaEngine {
       const mantissaTail = formula[previousIndex - 1]
       return exponentIsAdjacent && (/\d/.test(mantissaTail) || mantissaTail === '.')
     }
-    return ['+', '-', '*', '/', '=', '>', '<', '(', '[', ','].includes(previous)
+    return ['+', '-', '*', '/', '^', '=', '>', '<', '(', '[', ','].includes(previous)
   }
 
   private parseUnaryExpression(formula: string): UnaryNode | null {
@@ -623,6 +644,7 @@ export class FormulaEngine {
       case '-': return (left as number) - (right as number)
       case '*': return (left as number) * (right as number)
       case '/': return right === 0 ? '#DIV/0!' : (left as number) / (right as number)
+      case '^': return Math.pow(Number(left), Number(right))
       case '=': return left === right
       case '>': return (left as number) > (right as number)
       case '<': return (left as number) < (right as number)

--- a/packages/core-backend/tests/unit/formula-engine.test.ts
+++ b/packages/core-backend/tests/unit/formula-engine.test.ts
@@ -271,6 +271,19 @@ describe('Formula Engine', () => {
       expect(await engine.calculate('=1 + 2 & " items"', context)).toBe('3 items')
     })
 
+    test('Power operator', async () => {
+      expect(await engine.calculate('=2 ^ 3', context)).toBe(8)
+      expect(await engine.calculate('=2^3^2', context)).toBe(512)
+      expect(await engine.calculate('=2 * 3^2', context)).toBe(18)
+      expect(await engine.calculate('=2^-3', context)).toBe(0.125)
+    })
+
+    test('Power operator binds tighter than unary signs', async () => {
+      expect(await engine.calculate('=-2^2', context)).toBe(-4)
+      expect(await engine.calculate('=(-2)^2', context)).toBe(4)
+      expect(await engine.calculate('=--2^2', context)).toBe(4)
+    })
+
     test('Same-precedence arithmetic operators are left-associative', async () => {
       expect(await engine.calculate('=5 - 3 - 1', context)).toBe(1)
       expect(await engine.calculate('=8 / 4 / 2', context)).toBe(1)


### PR DESCRIPTION
## Summary
- add spreadsheet-style exponentiation with the ^ operator
- make chained powers right-associative and preserve spreadsheet unary precedence
- support signed exponents such as 2^-3
- add design and verification MDs

## Verification
- pnpm install --frozen-lockfile
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/formula-engine.test.ts tests/unit/multitable-formula-engine.test.ts --reporter=dot
- pnpm --filter @metasheet/core-backend build
- git diff --check

## Docs
- docs/development/formula-power-operator-development-20260505.md
- docs/development/formula-power-operator-verification-20260505.md