### PR TITLE
feat(formula): support percent postfix operator

### DIFF
--- a/docs/development/formula-percent-operator-development-20260505.md
+++ b/docs/development/formula-percent-operator-development-20260505.md
@@ -1,0 +1,67 @@
+# Formula Percent Operator Development Notes
+
+Date: 2026-05-05
+Branch: `codex/formula-percent-operator-20260505`
+
+## Scope
+
+This slice adds spreadsheet-style postfix percent support to the shared backend
+formula engine.
+
+## Problem
+
+Spreadsheet users commonly write percentages directly in formulas:
+
+```text
+=50%
+=200 * 10%
+```
+
+Before this slice, the formula parser had no postfix percent syntax. Users had
+to write decimal equivalents such as `0.5` or `0.1`, which is less natural and
+does not match Excel/Feishu-style formula entry.
+
+## Implementation
+
+`FormulaEngine` now has a `percent` AST node. During parsing, the engine detects
+a trailing top-level `%` that is:
+
+- at the end of the current expression after trimming whitespace;
+- not inside quoted strings;
+- not inside parentheses or array brackets;
+- backed by a non-empty operand.
+
+Evaluation converts the operand with `Number(value) / 100`.
+
+This keeps `%` as a high-precedence postfix operator while preserving lower
+precedence binary parsing. Examples:
+
+- `=1 + 10%` parses as `1 + (10%)`;
+- `=200 * 10%` parses as `200 * (10%)`;
+- `=-50%` parses as `-(50%)`;
+- `="50%"` remains a string literal.
+
+## Test Coverage
+
+Added formula-engine coverage for:
+
+- standalone percent values;
+- multiplication and addition with percent operands;
+- unary negative percent;
+- percent as an exponent operand;
+- parenthesized percent power;
+- string literals ending in `%`.
+
+## Files Changed
+
+- `packages/core-backend/src/formula/engine.ts`
+- `packages/core-backend/tests/unit/formula-engine.test.ts`
+- `docs/development/formula-percent-operator-development-20260505.md`
+- `docs/development/formula-percent-operator-verification-20260505.md`
+
+## Non-Goals
+
+- No percentage formatting or display-layer changes.
+- No frontend formula editor/catalog update in this slice.
+- No full formula grammar rewrite.
+- No database or migration changes.

--- a/docs/development/formula-percent-operator-verification-20260505.md
+++ b/docs/development/formula-percent-operator-verification-20260505.md
@@ -1,0 +1,57 @@
+# Formula Percent Operator Verification Notes
+
+Date: 2026-05-05
+Branch: `codex/formula-percent-operator-20260505`
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/formula-engine.test.ts \
+  tests/unit/multitable-formula-engine.test.ts \
+  --reporter=dot
+pnpm --filter @metasheet/core-backend build
+git diff --check
+```
+
+## Results
+
+Focused formula regression:
+
+```text
+Test Files  2 passed (2)
+Tests       125 passed (125)
+```
+
+Backend build:
+
+```text
+EXIT 0
+```
+
+Diff whitespace check:
+
+```text
+EXIT 0
+```
+
+## New Coverage
+
+The added tests verify:
+
+- `=50%` returns `0.5`;
+- `=200 * 10%` returns `20`;
+- `=1 + 10%` returns `1.1`;
+- `=-50%` returns `-0.5`;
+- `=2^3%` returns approximately `1.021012`;
+- `=(50%)^2` returns `0.25`;
+- `="50%"` remains the string `50%`.
+
+## Expected Noise
+
+The targeted formula run logs existing suite noise:
+
+- Vite CJS API deprecation warning;
+- `DATABASE_URL not set` warning from backend pool initialization;
+- expected invalid-function error log from the `NONEXISTENT(...)` test.

--- a/packages/core-backend/src/formula/engine.ts
+++ b/packages/core-backend/src/formula/engine.ts
@@ -41,6 +41,7 @@ export interface ASTNode {
     | 'function'
     | 'operator'
     | 'unary'
+    | 'percent'
 }
 
 export interface NumberNode extends ASTNode {
@@ -104,6 +105,11 @@ export interface UnaryNode extends ASTNode {
   operand: ASTNodeUnion
 }
 
+export interface PercentNode extends ASTNode {
+  type: 'percent'
+  operand: ASTNodeUnion
+}
+
 export type ASTNodeUnion =
   | NumberNode
   | BooleanNode
@@ -116,6 +122,7 @@ export type ASTNodeUnion =
   | FunctionNode
   | OperatorNode
   | UnaryNode
+  | PercentNode
 
 // Function type for spreadsheet functions
 type SpreadsheetFunction = (...args: unknown[]) => unknown
@@ -344,6 +351,14 @@ export class FormulaEngine {
       }
     }
 
+    const percentIndex = this.findTrailingTopLevelPercent(formula)
+    if (percentIndex !== null) {
+      return {
+        type: 'percent',
+        operand: this.parseFormula(formula.slice(0, percentIndex).trim())
+      }
+    }
+
     // Check if it's a boolean
     if (formula.toUpperCase() === 'TRUE') return { type: 'boolean', value: true }
     if (formula.toUpperCase() === 'FALSE') return { type: 'boolean', value: false }
@@ -423,6 +438,41 @@ export class FormulaEngine {
     }
 
     return { type: 'malformed' }
+  }
+
+  private findTrailingTopLevelPercent(formula: string): number | null {
+    const trimmed = formula.trimEnd()
+    if (!trimmed.endsWith('%')) return null
+
+    let depth = 0
+    let inQuotes = false
+
+    for (let i = 0; i < trimmed.length; i++) {
+      const char = trimmed[i]
+
+      if (char === '"' && (i === 0 || trimmed[i - 1] !== '\\')) {
+        inQuotes = !inQuotes
+        continue
+      }
+
+      if (inQuotes) continue
+
+      if (char === '(' || char === '[') {
+        depth++
+        continue
+      }
+
+      if (char === ')' || char === ']') {
+        depth--
+        continue
+      }
+
+      if (char === '%' && depth === 0 && i === trimmed.length - 1) {
+        return trimmed.slice(0, i).trim().length > 0 ? i : null
+      }
+    }
+
+    return null
   }
 
   /**
@@ -627,6 +677,11 @@ export class FormulaEngine {
         const value = await this.evaluateAST(node.operand, context)
         const numericValue = Number(value)
         return node.operator === '-' ? -numericValue : numericValue
+      }
+
+      case 'percent': {
+        const value = await this.evaluateAST(node.operand, context)
+        return Number(value) / 100
       }
 
       default:

--- a/packages/core-backend/tests/unit/formula-engine.test.ts
+++ b/packages/core-backend/tests/unit/formula-engine.test.ts
@@ -284,6 +284,19 @@ describe('Formula Engine', () => {
       expect(await engine.calculate('=--2^2', context)).toBe(4)
     })
 
+    test('Percent postfix operator', async () => {
+      expect(await engine.calculate('=50%', context)).toBe(0.5)
+      expect(await engine.calculate('=200 * 10%', context)).toBe(20)
+      expect(await engine.calculate('=1 + 10%', context)).toBe(1.1)
+      expect(await engine.calculate('=-50%', context)).toBe(-0.5)
+    })
+
+    test('Percent postfix works with power and preserves string literals', async () => {
+      expect(await engine.calculate('=2^3%', context)).toBeCloseTo(1.021012, 6)
+      expect(await engine.calculate('=(50%)^2', context)).toBe(0.25)
+      expect(await engine.calculate('="50%"', context)).toBe('50%')
+    })
+
     test('Same-precedence arithmetic operators are left-associative', async () => {
       expect(await engine.calculate('=5 - 3 - 1', context)).toBe(1)
       expect(await engine.calculate('=8 / 4 / 2', context)).toBe(1)


### PR DESCRIPTION
## Summary
- add spreadsheet-style postfix percent operator
- keep percent high-precedence while preserving string literals ending in %
- add regression coverage for arithmetic, power, unary negative, and string-literal cases
- add design and verification MDs

## Verification
- pnpm install --frozen-lockfile
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/formula-engine.test.ts tests/unit/multitable-formula-engine.test.ts --reporter=dot
- pnpm --filter @metasheet/core-backend build
- git diff --check

## Docs
- docs/development/formula-percent-operator-development-20260505.md
- docs/development/formula-percent-operator-verification-20260505.md