### PR TITLE
docs(formula): document supported operators in editor

### DIFF
--- a/apps/web/src/multitable/components/MetaFieldManager.vue
+++ b/apps/web/src/multitable/components/MetaFieldManager.vue
@@ -170,12 +170,12 @@
             </div>
           </div>
           <div class="meta-field-mgr__field">
-            <span>Function reference</span>
+            <span>Formula reference</span>
             <div class="meta-field-mgr__formula-toolbar">
               <input
                 v-model="formulaFunctionSearch"
                 class="meta-field-mgr__input"
-                placeholder="Search SUM, IF, TODAY..."
+                placeholder="Search SUM, IF, %, ^, &..."
               />
               <select v-model="formulaFunctionCategory" class="meta-field-mgr__select">
                 <option value="all">All categories</option>

--- a/apps/web/src/multitable/utils/formula-docs.ts
+++ b/apps/web/src/multitable/utils/formula-docs.ts
@@ -3,6 +3,7 @@ import type { MetaField } from '../types'
 export type FormulaFunctionCategory =
   | 'aggregate'
   | 'math'
+  | 'operator'
   | 'logic'
   | 'text'
   | 'date'
@@ -39,6 +40,7 @@ export interface FormulaDiagnostic {
 export const FORMULA_FUNCTION_CATEGORIES: FormulaFunctionCategoryDoc[] = [
   { id: 'aggregate', label: 'Aggregate', description: 'Summarize numeric or non-empty values.' },
   { id: 'math', label: 'Math', description: 'Round, transform, and compare numbers.' },
+  { id: 'operator', label: 'Operators', description: 'Combine values with spreadsheet operators.' },
   { id: 'logic', label: 'Logic', description: 'Branch and combine conditions.' },
   { id: 'text', label: 'Text', description: 'Join, slice, and normalize text.' },
   { id: 'date', label: 'Date', description: 'Create or extract date values.' },
@@ -110,6 +112,70 @@ export const FORMULA_FUNCTION_DOCS: FormulaFunctionDoc[] = [
     description: 'Returns the absolute value of a number.',
     example: '=ABS({fld_delta})',
     insertText: 'ABS()',
+  },
+  {
+    name: 'ADD',
+    signature: 'left + right',
+    category: 'operator',
+    description: 'Adds two numeric values. Text numbers are coerced to numbers.',
+    example: '={fld_price} + {fld_tax}',
+    insertText: '+',
+  },
+  {
+    name: 'SUBTRACT',
+    signature: 'left - right',
+    category: 'operator',
+    description: 'Subtracts the right numeric value from the left value.',
+    example: '={fld_budget} - {fld_actual}',
+    insertText: '-',
+  },
+  {
+    name: 'MULTIPLY',
+    signature: 'left * right',
+    category: 'operator',
+    description: 'Multiplies two numeric values.',
+    example: '={fld_qty} * {fld_price}',
+    insertText: '*',
+  },
+  {
+    name: 'DIVIDE',
+    signature: 'left / right',
+    category: 'operator',
+    description: 'Divides the left numeric value by the right value.',
+    example: '={fld_total} / {fld_count}',
+    insertText: '/',
+  },
+  {
+    name: 'POWER_OPERATOR',
+    signature: 'left ^ right',
+    category: 'operator',
+    description: 'Raises the left numeric value to the power of the right value.',
+    example: '={fld_base} ^ 2',
+    insertText: '^',
+  },
+  {
+    name: 'PERCENT_OPERATOR',
+    signature: 'value%',
+    category: 'operator',
+    description: 'Converts a number to a percentage value, for example 50% becomes 0.5.',
+    example: '={fld_price} * 10%',
+    insertText: '10%',
+  },
+  {
+    name: 'CONCAT_OPERATOR',
+    signature: 'left & right',
+    category: 'operator',
+    description: 'Concatenates values as text.',
+    example: '={fld_first_name} & " " & {fld_last_name}',
+    insertText: '&',
+  },
+  {
+    name: 'COMPARISON',
+    signature: '=, <>, >, >=, <, <=',
+    category: 'operator',
+    description: 'Compares two values and returns TRUE or FALSE.',
+    example: '={fld_amount} >= 1000',
+    insertText: '>=',
   },
   {
     name: 'IF',

--- a/apps/web/tests/multitable-formula-editor.spec.ts
+++ b/apps/web/tests/multitable-formula-editor.spec.ts
@@ -49,6 +49,24 @@ describe('multitable formula editor', () => {
     expect(buildFormulaFieldTokenInsertion('=SUM()', 'fld_tax')).toBe('=SUM() {fld_tax}')
   })
 
+  it('documents recently supported formula operators', () => {
+    const operatorSections = getFormulaFunctionCatalog('', 'operator')
+    expect(operatorSections).toHaveLength(1)
+    expect(operatorSections[0].functions.map((doc) => doc.signature)).toEqual(expect.arrayContaining([
+      'left + right',
+      'left ^ right',
+      'value%',
+      'left & right',
+      '=, <>, >, >=, <, <=',
+    ]))
+
+    expect(searchFormulaFunctionDocs('%').map((doc) => doc.name)).toContain('PERCENT_OPERATOR')
+
+    const percentDoc = operatorSections[0].functions.find((doc) => doc.name === 'PERCENT_OPERATOR')
+    expect(percentDoc).toBeTruthy()
+    expect(buildFormulaFunctionInsertion('={fld_price} *', percentDoc!)).toBe('={fld_price} * 10%')
+  })
+
   it('inserts backend-compatible field id tokens from field chips', async () => {
     const container = document.createElement('div')
     document.body.appendChild(container)
@@ -137,6 +155,43 @@ describe('multitable formula editor', () => {
 
     const textarea = container.querySelector('.meta-field-mgr__textarea') as HTMLTextAreaElement
     expect(textarea.value).toBe('=ROUND(, 2)')
+
+    app.unmount()
+  })
+
+  it('renders the operator reference category in the formula panel', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    const app = createApp({
+      render() {
+        return h(MetaFieldManager, {
+          visible: true,
+          sheetId: 'sheet_1',
+          sheets: [],
+          fields: [
+            { id: 'fld_price', name: 'Price', type: 'number' },
+            { id: 'fld_total', name: 'Total', type: 'formula', property: { expression: '={fld_price}' } },
+          ],
+        })
+      },
+    })
+
+    app.mount(container)
+    await nextTick()
+
+    const configureButtons = Array.from(container.querySelectorAll('.meta-field-mgr__action[title="Configure"]')) as HTMLButtonElement[]
+    configureButtons[1]?.click()
+    await nextTick()
+
+    const categorySelect = container.querySelector('.meta-field-mgr__formula-toolbar .meta-field-mgr__select') as HTMLSelectElement
+    categorySelect.value = 'operator'
+    categorySelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await nextTick()
+
+    expect(container.textContent).toContain('Operators')
+    expect(container.textContent).toContain('value%')
+    expect(container.textContent).toContain('left ^ right')
 
     app.unmount()
   })

--- a/docs/development/formula-operator-reference-development-20260505.md
+++ b/docs/development/formula-operator-reference-development-20260505.md
@@ -1,0 +1,66 @@
+# Formula Operator Reference Development Notes
+
+Date: 2026-05-05
+Branch: `codex/formula-operator-reference-20260505`
+
+## Scope
+
+This slice aligns the multitable formula editor reference panel with the
+backend formula operator support recently added on `main`.
+
+## Problem
+
+The formula field configuration panel already exposes a searchable reference
+catalog, but the catalog only listed functions. The backend formula engine now
+supports spreadsheet-style operators such as:
+
+- numeric arithmetic: `+`, `-`, `*`, `/`
+- exponentiation: `^`
+- postfix percent: `%`
+- text concatenation: `&`
+- comparisons: `=`, `<>`, `>`, `>=`, `<`, `<=`
+
+Without operator docs in the editor, users can discover `SUM` and `IF`, but
+not the spreadsheet operators that are needed for common formulas like:
+
+```text
+={fld_price} * 10%
+={fld_first_name} & " " & {fld_last_name}
+={fld_base} ^ 2
+```
+
+## Implementation
+
+`apps/web/src/multitable/utils/formula-docs.ts` now adds an `operator` category
+to the formula catalog.
+
+The new category documents:
+
+- `left + right`
+- `left - right`
+- `left * right`
+- `left / right`
+- `left ^ right`
+- `value%`
+- `left & right`
+- comparison operators
+
+`MetaFieldManager.vue` changes the section label from `Function reference` to
+`Formula reference` and updates the search placeholder so operators are clearly
+discoverable from the same field configuration panel.
+
+## Tests
+
+Added frontend coverage for:
+
+- operator catalog section construction;
+- percent operator search by `%`;
+- insertion text for the percent operator helper;
+- rendered operator category in the formula configuration panel.
+
+## Non-Goals
+
+- No backend parser or evaluator changes.
+- No CodeMirror or full syntax-highlighting editor.
+- No natural-language formula generation.
+- No changes to formula field persistence.

--- a/docs/development/formula-operator-reference-verification-20260505.md
+++ b/docs/development/formula-operator-reference-verification-20260505.md
@@ -1,0 +1,50 @@
+# Formula Operator Reference Verification
+
+Date: 2026-05-05
+Branch: `codex/formula-operator-reference-20260505`
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-formula-editor.spec.ts --reporter=dot
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+git diff --check
+```
+
+## Expected Coverage
+
+The targeted frontend test verifies:
+
+- formula reference search still finds existing functions;
+- field token insertion still saves stable `{fld_xxx}` references;
+- formula expressions with unknown field references are still blocked;
+- the new `Operators` category exposes `+`, `^`, `%`, `&`, and comparisons;
+- `%` is searchable and inserts a usable `10%` snippet;
+- the formula field manager renders the operator category.
+
+## Results
+
+All local gates passed.
+
+```text
+pnpm --filter @metasheet/web exec vitest run tests/multitable-formula-editor.spec.ts --reporter=dot
+Test Files  1 passed (1)
+Tests       7 passed (7)
+
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+Exit code   0
+
+git diff --check
+Exit code   0
+```
+
+## Notes
+
+`pnpm install --frozen-lockfile` was required in the clean `/tmp` worktree
+because workspace executables were not linked there yet. It produced the known
+plugin/tool `node_modules` symlink noise; those paths were reverted before
+commit with:
+
+```bash
+git checkout -- plugins tools
+```


### PR DESCRIPTION
## Summary
- Add an Operators category to the multitable formula reference catalog
- Document arithmetic, power, postfix percent, text concatenation, and comparison operators
- Rename the field-manager section to Formula reference and update the search placeholder

## Verification
- pnpm --filter @metasheet/web exec vitest run tests/multitable-formula-editor.spec.ts --reporter=dot
- pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
- git diff --check

## Docs
- docs/development/formula-operator-reference-development-20260505.md
- docs/development/formula-operator-reference-verification-20260505.md