### PR TITLE
fix(formula): tighten editor syntax diagnostics

### DIFF
--- a/apps/web/src/multitable/utils/formula-docs.ts
+++ b/apps/web/src/multitable/utils/formula-docs.ts
@@ -485,6 +485,7 @@ export const FORMULA_FUNCTION_DOCS: FormulaFunctionDoc[] = [
 
 const FUNCTION_CALL_PATTERN = /\b([A-Z][A-Z0-9_]*)\s*\(/g
 const FIELD_REF_PATTERN = /\{([^{}]+)\}/g
+const TRAILING_BINARY_OPERATOR_PATTERN = /(?:>=|<=|<>|[+\-*/^&=><])$/
 
 export function searchFormulaFunctionDocs(query: string): FormulaFunctionDoc[] {
   const normalized = query.trim().toUpperCase()
@@ -547,6 +548,97 @@ export function extractFormulaFieldRefs(expression: string): string[] {
   return refs
 }
 
+function getFormulaSyntaxDiagnostics(expression: string): FormulaDiagnostic[] {
+  const diagnostics: FormulaDiagnostic[] = []
+  let parenthesesDepth = 0
+  let bracketDepth = 0
+  let braceDepth = 0
+  let inQuotes = false
+  let escaped = false
+
+  for (let i = 0; i < expression.length; i++) {
+    const char = expression[i]
+
+    if (inQuotes) {
+      if (escaped) {
+        escaped = false
+        continue
+      }
+      if (char === '\\') {
+        escaped = true
+        continue
+      }
+      if (char === '"') {
+        inQuotes = false
+      }
+      continue
+    }
+
+    if (char === '"') {
+      inQuotes = true
+      continue
+    }
+
+    if (char === '(') {
+      parenthesesDepth++
+      continue
+    }
+    if (char === ')') {
+      if (parenthesesDepth === 0) {
+        diagnostics.push({ severity: 'error', message: 'Unexpected closing parenthesis.' })
+      } else {
+        parenthesesDepth--
+      }
+      continue
+    }
+
+    if (char === '[') {
+      bracketDepth++
+      continue
+    }
+    if (char === ']') {
+      if (bracketDepth === 0) {
+        diagnostics.push({ severity: 'error', message: 'Unexpected closing array bracket.' })
+      } else {
+        bracketDepth--
+      }
+      continue
+    }
+
+    if (char === '{') {
+      braceDepth++
+      continue
+    }
+    if (char === '}') {
+      if (braceDepth === 0) {
+        diagnostics.push({ severity: 'error', message: 'Unexpected closing field-reference brace.' })
+      } else {
+        braceDepth--
+      }
+    }
+  }
+
+  if (inQuotes) {
+    diagnostics.push({ severity: 'error', message: 'Quoted string is not closed.' })
+  }
+  if (parenthesesDepth > 0) {
+    diagnostics.push({ severity: 'error', message: 'Parentheses are not balanced.' })
+  }
+  if (bracketDepth > 0) {
+    diagnostics.push({ severity: 'error', message: 'Array brackets are not balanced.' })
+  }
+  if (braceDepth > 0) {
+    diagnostics.push({ severity: 'error', message: 'Field reference braces are not balanced.' })
+  }
+
+  const withoutWhitespace = expression.trimEnd()
+  if (TRAILING_BINARY_OPERATOR_PATTERN.test(withoutWhitespace)) {
+    diagnostics.push({ severity: 'error', message: 'Formula cannot end with a binary operator.' })
+  }
+
+  return diagnostics
+}
+
 export function validateFormulaExpression(expression: string, fields: MetaField[]): FormulaDiagnostic[] {
   const diagnostics: FormulaDiagnostic[] = []
   const trimmed = expression.trim()
@@ -555,11 +647,7 @@ export function validateFormulaExpression(expression: string, fields: MetaField[
     return diagnostics
   }
 
-  const openCount = (trimmed.match(/\(/g) ?? []).length
-  const closeCount = (trimmed.match(/\)/g) ?? []).length
-  if (openCount !== closeCount) {
-    diagnostics.push({ severity: 'error', message: 'Parentheses are not balanced.' })
-  }
+  diagnostics.push(...getFormulaSyntaxDiagnostics(trimmed))
 
   const fieldIds = new Set(fields.map((field) => field.id))
   const fieldNames = new Set(fields.map((field) => field.name))

--- a/apps/web/tests/multitable-formula-editor.spec.ts
+++ b/apps/web/tests/multitable-formula-editor.spec.ts
@@ -34,6 +34,31 @@ describe('multitable formula editor', () => {
     ])).toContainEqual({ severity: 'error', message: 'Unknown field reference {fld_missing}.' })
   })
 
+  it('reports common formula syntax issues before save', () => {
+    const fields = [{ id: 'fld_price', name: 'Price', type: 'number' }]
+
+    expect(validateFormulaExpression('=CONCAT("unterminated)', fields)).toContainEqual({
+      severity: 'error',
+      message: 'Quoted string is not closed.',
+    })
+    expect(validateFormulaExpression('=SUM([1, 2)', fields)).toContainEqual({
+      severity: 'error',
+      message: 'Array brackets are not balanced.',
+    })
+    expect(validateFormulaExpression('=SUM({fld_price)', fields)).toContainEqual({
+      severity: 'error',
+      message: 'Field reference braces are not balanced.',
+    })
+    expect(validateFormulaExpression('=SUM({fld_price}) +', fields)).toContainEqual({
+      severity: 'error',
+      message: 'Formula cannot end with a binary operator.',
+    })
+    expect(validateFormulaExpression('="("', fields)).not.toContainEqual({
+      severity: 'error',
+      message: 'Parentheses are not balanced.',
+    })
+  })
+
   it('builds categorized function catalog sections and insertion text', () => {
     const mathSections = getFormulaFunctionCatalog('round', 'math')
     expect(mathSections).toHaveLength(1)

--- a/docs/development/formula-editor-diagnostics-development-20260505.md
+++ b/docs/development/formula-editor-diagnostics-development-20260505.md
@@ -1,0 +1,58 @@
+# Formula Editor Diagnostics Development Notes
+
+Date: 2026-05-05
+Branch: `codex/formula-editor-diagnostics-20260505`
+
+## Scope
+
+This slice improves the multitable formula editor's pre-save diagnostics for
+common syntax mistakes.
+
+## Problem
+
+The backend formula engine still returns a coarse `#ERROR!` for many invalid
+expressions. The frontend formula editor already blocked unknown field
+references and unbalanced parentheses, but the check was a raw character count
+and did not understand quoted strings or other delimiter types.
+
+That left avoidable save-time mistakes such as:
+
+- unclosed string literals;
+- unbalanced array brackets;
+- unbalanced `{fld_xxx}` field-reference braces;
+- formulas ending with a binary operator.
+
+## Implementation
+
+`apps/web/src/multitable/utils/formula-docs.ts` now has a small quote-aware
+syntax scanner used by `validateFormulaExpression()`.
+
+The scanner tracks:
+
+- quoted string state with escaped quote handling;
+- parentheses depth;
+- array bracket depth;
+- field-reference brace depth;
+- unexpected closing delimiters;
+- trailing binary operators.
+
+It intentionally stays shallow. It does not parse or evaluate formulas; it only
+flags syntax shapes that are clearly incomplete before the user saves the field
+configuration.
+
+## Tests
+
+`apps/web/tests/multitable-formula-editor.spec.ts` now covers:
+
+- unclosed quoted string detection;
+- unbalanced array bracket detection;
+- unbalanced field-reference brace detection;
+- trailing binary operator detection;
+- quoted parentheses not being counted as real parentheses.
+
+## Non-Goals
+
+- No backend formula error payload changes.
+- No full formula parser in the browser.
+- No CodeMirror integration or syntax highlighting.
+- No semantic validation of function argument counts.

--- a/docs/development/formula-editor-diagnostics-verification-20260505.md
+++ b/docs/development/formula-editor-diagnostics-verification-20260505.md
@@ -1,0 +1,51 @@
+# Formula Editor Diagnostics Verification
+
+Date: 2026-05-05
+Branch: `codex/formula-editor-diagnostics-20260505`
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-formula-editor.spec.ts --reporter=dot
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+git diff --check
+```
+
+## Expected Coverage
+
+The targeted test suite covers:
+
+- existing formula reference catalog search and insertion behavior;
+- backend function catalog parity guard;
+- operator reference rendering;
+- unknown field reference blocking;
+- new syntax diagnostics for unclosed quotes, unbalanced arrays, unbalanced
+  field-reference braces, trailing binary operators, and quoted delimiter
+  false positives.
+
+## Results
+
+All local gates passed.
+
+```text
+pnpm --filter @metasheet/web exec vitest run tests/multitable-formula-editor.spec.ts --reporter=dot
+Test Files  1 passed (1)
+Tests       9 passed (9)
+
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+Exit code   0
+
+git diff --check
+Exit code   0
+```
+
+## Notes
+
+`pnpm install --frozen-lockfile` was required in the clean `/tmp` worktree to
+link workspace executables before running web tests. The install produced the
+known plugin/tool `node_modules` symlink noise; those paths were reverted before
+commit with:
+
+```bash
+git checkout -- plugins tools
+```


### PR DESCRIPTION
## Summary
- Replace raw parenthesis counting with a quote-aware formula syntax scanner
- Report unclosed quoted strings, unbalanced array brackets, unbalanced field-reference braces, unexpected closing delimiters, and trailing binary operators before save
- Preserve existing function catalog, operator reference, and field reference diagnostics

## Verification
- pnpm --filter @metasheet/web exec vitest run tests/multitable-formula-editor.spec.ts --reporter=dot
- pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
- git diff --check

## Docs
- docs/development/formula-editor-diagnostics-development-20260505.md
- docs/development/formula-editor-diagnostics-verification-20260505.md