### PR TITLE
fix(formula): validate editor function arguments

### DIFF
--- a/apps/web/src/multitable/utils/formula-docs.ts
+++ b/apps/web/src/multitable/utils/formula-docs.ts
@@ -17,6 +17,8 @@ export interface FormulaFunctionDoc {
   description: string
   example: string
   insertText?: string
+  minArgs?: number
+  maxArgs?: number
 }
 
 export interface FormulaFunctionCategoryDoc {
@@ -486,6 +488,57 @@ export const FORMULA_FUNCTION_DOCS: FormulaFunctionDoc[] = [
 const FUNCTION_CALL_PATTERN = /\b([A-Z][A-Z0-9_]*)\s*\(/g
 const FIELD_REF_PATTERN = /\{([^{}]+)\}/g
 const TRAILING_BINARY_OPERATOR_PATTERN = /(?:>=|<=|<>|[+\-*/^&=><])$/
+const IDENTIFIER_START_PATTERN = /[A-Za-z_]/
+const IDENTIFIER_PART_PATTERN = /[A-Za-z0-9_]/
+
+const FORMULA_FUNCTION_ARITY: Record<string, Pick<FormulaFunctionDoc, 'minArgs' | 'maxArgs'>> = {
+  ABS: { minArgs: 1, maxArgs: 1 },
+  AND: { minArgs: 1 },
+  AVERAGE: { minArgs: 1 },
+  CEILING: { minArgs: 1, maxArgs: 1 },
+  CONCAT: { minArgs: 1 },
+  CONCATENATE: { minArgs: 1 },
+  COUNT: { minArgs: 1 },
+  COUNTA: { minArgs: 1 },
+  DATE: { minArgs: 3, maxArgs: 3 },
+  DATEDIF: { minArgs: 3, maxArgs: 3 },
+  DATEDIFF: { minArgs: 2, maxArgs: 2 },
+  DAY: { minArgs: 1, maxArgs: 1 },
+  FALSE: { minArgs: 0, maxArgs: 0 },
+  FLOOR: { minArgs: 1, maxArgs: 1 },
+  HLOOKUP: { minArgs: 3, maxArgs: 4 },
+  IF: { minArgs: 3, maxArgs: 3 },
+  INDEX: { minArgs: 2, maxArgs: 3 },
+  LEFT: { minArgs: 2, maxArgs: 2 },
+  LEN: { minArgs: 1, maxArgs: 1 },
+  LOWER: { minArgs: 1, maxArgs: 1 },
+  MATCH: { minArgs: 2, maxArgs: 3 },
+  MAX: { minArgs: 1 },
+  MEDIAN: { minArgs: 1 },
+  MID: { minArgs: 3, maxArgs: 3 },
+  MIN: { minArgs: 1 },
+  MOD: { minArgs: 2, maxArgs: 2 },
+  MODE: { minArgs: 1 },
+  MONTH: { minArgs: 1, maxArgs: 1 },
+  NOT: { minArgs: 1, maxArgs: 1 },
+  NOW: { minArgs: 0, maxArgs: 0 },
+  OR: { minArgs: 1 },
+  POWER: { minArgs: 2, maxArgs: 2 },
+  RIGHT: { minArgs: 2, maxArgs: 2 },
+  ROUND: { minArgs: 1, maxArgs: 2 },
+  SQRT: { minArgs: 1, maxArgs: 1 },
+  STDEV: { minArgs: 1 },
+  SUBSTITUTE: { minArgs: 3, maxArgs: 3 },
+  SUM: { minArgs: 1 },
+  SWITCH: { minArgs: 3 },
+  TODAY: { minArgs: 0, maxArgs: 0 },
+  TRIM: { minArgs: 1, maxArgs: 1 },
+  TRUE: { minArgs: 0, maxArgs: 0 },
+  UPPER: { minArgs: 1, maxArgs: 1 },
+  VAR: { minArgs: 1 },
+  VLOOKUP: { minArgs: 3, maxArgs: 4 },
+  YEAR: { minArgs: 1, maxArgs: 1 },
+}
 
 export function searchFormulaFunctionDocs(query: string): FormulaFunctionDoc[] {
   const normalized = query.trim().toUpperCase()
@@ -639,6 +692,226 @@ function getFormulaSyntaxDiagnostics(expression: string): FormulaDiagnostic[] {
   return diagnostics
 }
 
+interface ParsedFormulaFunctionCall {
+  name: string
+  args: string[]
+}
+
+function findClosingParenthesis(expression: string, openIndex: number): number | null {
+  let depth = 0
+  let inQuotes = false
+  let escaped = false
+
+  for (let i = openIndex; i < expression.length; i++) {
+    const char = expression[i]
+
+    if (inQuotes) {
+      if (escaped) {
+        escaped = false
+        continue
+      }
+      if (char === '\\') {
+        escaped = true
+        continue
+      }
+      if (char === '"') {
+        inQuotes = false
+      }
+      continue
+    }
+
+    if (char === '"') {
+      inQuotes = true
+      continue
+    }
+    if (char === '(') {
+      depth++
+      continue
+    }
+    if (char === ')') {
+      depth--
+      if (depth === 0) return i
+    }
+  }
+
+  return null
+}
+
+function splitFormulaArguments(source: string): string[] {
+  if (!source.trim()) return []
+
+  const args: string[] = []
+  let current = ''
+  let parenthesesDepth = 0
+  let bracketDepth = 0
+  let braceDepth = 0
+  let inQuotes = false
+  let escaped = false
+
+  for (let i = 0; i < source.length; i++) {
+    const char = source[i]
+
+    if (inQuotes) {
+      current += char
+      if (escaped) {
+        escaped = false
+        continue
+      }
+      if (char === '\\') {
+        escaped = true
+        continue
+      }
+      if (char === '"') {
+        inQuotes = false
+      }
+      continue
+    }
+
+    if (char === '"') {
+      inQuotes = true
+      current += char
+      continue
+    }
+    if (char === '(') {
+      parenthesesDepth++
+      current += char
+      continue
+    }
+    if (char === ')') {
+      parenthesesDepth = Math.max(0, parenthesesDepth - 1)
+      current += char
+      continue
+    }
+    if (char === '[') {
+      bracketDepth++
+      current += char
+      continue
+    }
+    if (char === ']') {
+      bracketDepth = Math.max(0, bracketDepth - 1)
+      current += char
+      continue
+    }
+    if (char === '{') {
+      braceDepth++
+      current += char
+      continue
+    }
+    if (char === '}') {
+      braceDepth = Math.max(0, braceDepth - 1)
+      current += char
+      continue
+    }
+
+    if (char === ',' && parenthesesDepth === 0 && bracketDepth === 0 && braceDepth === 0) {
+      args.push(current.trim())
+      current = ''
+      continue
+    }
+
+    current += char
+  }
+
+  args.push(current.trim())
+  return args
+}
+
+function collectFormulaFunctionCalls(expression: string): ParsedFormulaFunctionCall[] {
+  const calls: ParsedFormulaFunctionCall[] = []
+  let inQuotes = false
+  let escaped = false
+
+  for (let i = 0; i < expression.length; i++) {
+    const char = expression[i]
+
+    if (inQuotes) {
+      if (escaped) {
+        escaped = false
+        continue
+      }
+      if (char === '\\') {
+        escaped = true
+        continue
+      }
+      if (char === '"') {
+        inQuotes = false
+      }
+      continue
+    }
+
+    if (char === '"') {
+      inQuotes = true
+      continue
+    }
+
+    if (!IDENTIFIER_START_PATTERN.test(char)) continue
+
+    const start = i
+    i++
+    while (i < expression.length && IDENTIFIER_PART_PATTERN.test(expression[i] ?? '')) {
+      i++
+    }
+
+    const rawName = expression.slice(start, i)
+    let cursor = i
+    while (cursor < expression.length && /\s/.test(expression[cursor] ?? '')) {
+      cursor++
+    }
+    if (expression[cursor] !== '(') {
+      i--
+      continue
+    }
+
+    const closeIndex = findClosingParenthesis(expression, cursor)
+    if (closeIndex === null) {
+      i--
+      continue
+    }
+
+    const argsSource = expression.slice(cursor + 1, closeIndex)
+    const args = splitFormulaArguments(argsSource)
+    calls.push({ name: rawName.toUpperCase(), args })
+    calls.push(...collectFormulaFunctionCalls(argsSource))
+    i = closeIndex
+  }
+
+  return calls
+}
+
+function getFormulaFunctionArgumentDiagnostics(expression: string): FormulaDiagnostic[] {
+  const diagnostics: FormulaDiagnostic[] = []
+  const knownFunctions = new Set(FORMULA_FUNCTION_DOCS.map((doc) => doc.name))
+  for (const call of collectFormulaFunctionCalls(expression)) {
+    if (!knownFunctions.has(call.name)) continue
+
+    const emptyArgument = call.args.some((arg) => !arg)
+    if (emptyArgument) {
+      diagnostics.push({ severity: 'error', message: `${call.name} has an empty argument.` })
+      continue
+    }
+
+    const arity = FORMULA_FUNCTION_ARITY[call.name]
+    if (!arity) continue
+
+    if (typeof arity.minArgs === 'number' && call.args.length < arity.minArgs) {
+      diagnostics.push({
+        severity: 'error',
+        message: `${call.name} expects at least ${arity.minArgs} argument${arity.minArgs === 1 ? '' : 's'}.`,
+      })
+      continue
+    }
+
+    if (typeof arity.maxArgs === 'number' && call.args.length > arity.maxArgs) {
+      diagnostics.push({
+        severity: 'error',
+        message: `${call.name} expects at most ${arity.maxArgs} argument${arity.maxArgs === 1 ? '' : 's'}.`,
+      })
+    }
+  }
+
+  return diagnostics
+}
+
 export function validateFormulaExpression(expression: string, fields: MetaField[]): FormulaDiagnostic[] {
   const diagnostics: FormulaDiagnostic[] = []
   const trimmed = expression.trim()
@@ -648,6 +921,7 @@ export function validateFormulaExpression(expression: string, fields: MetaField[
   }
 
   diagnostics.push(...getFormulaSyntaxDiagnostics(trimmed))
+  diagnostics.push(...getFormulaFunctionArgumentDiagnostics(trimmed))
 
   const fieldIds = new Set(fields.map((field) => field.id))
   const fieldNames = new Set(fields.map((field) => field.name))

--- a/apps/web/tests/multitable-formula-editor.spec.ts
+++ b/apps/web/tests/multitable-formula-editor.spec.ts
@@ -59,6 +59,39 @@ describe('multitable formula editor', () => {
     })
   })
 
+  it('reports incomplete formula function arguments before save', () => {
+    const fields = [
+      { id: 'fld_price', name: 'Price', type: 'number' },
+      { id: 'fld_start', name: 'Start', type: 'date' },
+      { id: 'fld_end', name: 'End', type: 'date' },
+    ]
+
+    expect(validateFormulaExpression('=IF({fld_price} > 0, "ok")', fields)).toContainEqual({
+      severity: 'error',
+      message: 'IF expects at least 3 arguments.',
+    })
+    expect(validateFormulaExpression('=ROUND({fld_price}, 2, 3)', fields)).toContainEqual({
+      severity: 'error',
+      message: 'ROUND expects at most 2 arguments.',
+    })
+    expect(validateFormulaExpression('=ROUND(, 2)', fields)).toContainEqual({
+      severity: 'error',
+      message: 'ROUND has an empty argument.',
+    })
+    expect(validateFormulaExpression('=DATEDIF({fld_start}, {fld_end})', fields)).toContainEqual({
+      severity: 'error',
+      message: 'DATEDIF expects at least 3 arguments.',
+    })
+    expect(validateFormulaExpression('=TODAY(1)', fields)).toContainEqual({
+      severity: 'error',
+      message: 'TODAY expects at most 0 arguments.',
+    })
+
+    expect(validateFormulaExpression('=ROUND({fld_price}, 2)', fields).filter((diagnostic) =>
+      diagnostic.severity === 'error'
+    )).toEqual([])
+  })
+
   it('builds categorized function catalog sections and insertion text', () => {
     const mathSections = getFormulaFunctionCatalog('round', 'math')
     expect(mathSections).toHaveLength(1)

--- a/docs/development/formula-function-arity-diagnostics-development-20260505.md
+++ b/docs/development/formula-function-arity-diagnostics-development-20260505.md
@@ -1,0 +1,48 @@
+# Formula Function Arity Diagnostics Development - 2026-05-05
+
+## Scope
+
+This slice tightens the multitable formula editor before-save diagnostics for documented functions.
+
+It does not change backend formula evaluation, formula persistence, or the existing unknown-function warning behavior.
+
+## Problem
+
+The editor already catches structural syntax problems such as unclosed quotes and unbalanced delimiters, but it still allowed obvious incomplete function calls:
+
+- `IF(condition, value_if_true)` could be saved even though the backend function expects a false branch.
+- `ROUND(value, digits, extra)` could be saved even though the backend only accepts up to two arguments.
+- Snippet placeholders such as `ROUND(, 2)` were syntactically balanced but semantically incomplete.
+
+These failures were deferred by the previous formula diagnostics slice as "semantic validation of function argument counts".
+
+## Design
+
+The implementation adds editor-local function arity metadata and a quote-aware parser in `apps/web/src/multitable/utils/formula-docs.ts`.
+
+Key decisions:
+
+- Validation only applies to documented backend-compatible functions.
+- Unknown functions still use the existing documentation warning path.
+- Operator pseudo-docs are not validated as function calls.
+- `ROUND` is treated as `1..2` because the backend defaults digits to zero.
+- Lookup helpers with optional flags use bounded ranges, for example `VLOOKUP` and `HLOOKUP` are `3..4`.
+- Zero-argument helpers such as `TODAY()` and `NOW()` reject provided arguments.
+- Empty arguments are reported directly, so snippet placeholders disable save until the user fills them.
+
+The parser scans function calls with quote and nested-delimiter awareness, then splits arguments only on top-level commas. Nested calls are recursively collected so expressions such as `IF(AND(...), ..., ...)` are validated at every documented function boundary.
+
+## Files Changed
+
+- `apps/web/src/multitable/utils/formula-docs.ts`
+- `apps/web/tests/multitable-formula-editor.spec.ts`
+
+## Expected Behavior
+
+- `=IF({fld_price} > 0, "ok")` reports `IF expects at least 3 arguments.`
+- `=ROUND({fld_price}, 2, 3)` reports `ROUND expects at most 2 arguments.`
+- `=ROUND(, 2)` reports `ROUND has an empty argument.`
+- `=DATEDIF({fld_start}, {fld_end})` reports `DATEDIF expects at least 3 arguments.`
+- `=TODAY(1)` reports `TODAY expects at most 0 arguments.`
+- `=ROUND({fld_price}, 2)` remains valid.
+

--- a/docs/development/formula-function-arity-diagnostics-verification-20260505.md
+++ b/docs/development/formula-function-arity-diagnostics-verification-20260505.md
@@ -1,0 +1,59 @@
+# Formula Function Arity Diagnostics Verification - 2026-05-05
+
+## Verification Plan
+
+Run focused frontend checks from a clean worktree:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-formula-editor.spec.ts --reporter=dot
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+git diff --check
+```
+
+## Results
+
+### Dependency Setup
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+Result: completed successfully. `pnpm` emitted the expected ignored-build-scripts warning. The install rewrote plugin/tool dependency symlinks, which were restored before commit with `git restore plugins tools`.
+
+### Focused Formula Editor Spec
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-formula-editor.spec.ts --reporter=dot
+```
+
+Result:
+
+```text
+Test Files  1 passed (1)
+Tests       10 passed (10)
+```
+
+### Frontend Type Check
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+```
+
+Result: exit 0.
+
+### Patch Hygiene
+
+```bash
+git diff --check
+```
+
+Result: clean.
+
+## Coverage Notes
+
+The new spec covers:
+
+- Too few required arguments: `IF(...)`, `DATEDIF(...)`.
+- Too many bounded arguments: `ROUND(...)`, `TODAY(...)`.
+- Empty snippet placeholders: `ROUND(, 2)`.
+- A valid bounded call: `ROUND({fld_price}, 2)`.


### PR DESCRIPTION
## Summary
- add frontend formula editor arity diagnostics for documented functions
- catch empty snippet placeholders and too few/too many function arguments before save
- document the design and verification evidence

## Verification
- pnpm --filter @metasheet/web exec vitest run tests/multitable-formula-editor.spec.ts --reporter=dot
- pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
- git diff --check

## Docs
- docs/development/formula-function-arity-diagnostics-development-20260505.md
- docs/development/formula-function-arity-diagnostics-verification-20260505.md