### PR TITLE
fix(integration): clarify disabled SQL preflight mode

### DIFF
--- a/docs/development/integration-core-k3wise-preflight-disabled-mode-guidance-design-20260505.md
+++ b/docs/development/integration-core-k3wise-preflight-disabled-mode-guidance-design-20260505.md
@@ -45,6 +45,8 @@ The error details include:
 
 This keeps machine-readable diagnostics stable while giving operators a direct remediation path.
 
+The operator-facing runbook also records the same message in the K3 WISE quick lookup table, so the person receiving a failed preflight run can map the exact error to the right GATE JSON edit without reading the script.
+
 ## Boundary
 
 This does not change SQL Server channel safety behavior. It only improves the preflight guidance for an already-rejected packet shape.

--- a/docs/development/integration-core-k3wise-preflight-disabled-mode-guidance-design-20260505.md
+++ b/docs/development/integration-core-k3wise-preflight-disabled-mode-guidance-design-20260505.md
@@ -1,0 +1,50 @@
+# K3 WISE Preflight Disabled SQL Mode Guidance Design - 2026-05-05
+
+## Scope
+
+This slice tightens the customer GATE preflight error for one ambiguous SQL Server configuration:
+
+```json
+{
+  "sqlServer": {
+    "enabled": true,
+    "mode": "disabled"
+  }
+}
+```
+
+Before this change, the preflight rejected the packet with the generic mode message:
+
+`sqlServer.mode must be readonly, middle-table, or stored-procedure`
+
+That was technically correct but not actionable enough for customer-filled GATE JSON. If the operator wants to disable SQL Server, the correct field is `sqlServer.enabled=false`, not `mode=disabled` while the channel is enabled.
+
+## Design
+
+`scripts/ops/integration-k3wise-live-poc-preflight.mjs` keeps the existing semantics:
+
+- `enabled=false` with no explicit mode still normalizes to `disabled`.
+- `enabled=true` with no explicit mode still defaults to `readonly`.
+- `enabled=true` with valid modes still accepts `readonly`, `middle-table`, and `stored-procedure`.
+- unknown modes still use the generic mode validation error.
+
+The only new branch is:
+
+- `mode=disabled` and `enabled=true` throws a targeted `LivePocPreflightError`.
+
+The new message is:
+
+`sqlServer.mode=disabled requires sqlServer.enabled=false; set enabled=false or choose readonly, middle-table, or stored-procedure`
+
+The error details include:
+
+- `field: "sqlServer.mode"`
+- `mode`
+- `sqlServerEnabled: true`
+- `acceptedModes`
+
+This keeps machine-readable diagnostics stable while giving operators a direct remediation path.
+
+## Boundary
+
+This does not change SQL Server channel safety behavior. It only improves the preflight guidance for an already-rejected packet shape.

--- a/docs/development/integration-core-k3wise-preflight-disabled-mode-guidance-verification-20260505.md
+++ b/docs/development/integration-core-k3wise-preflight-disabled-mode-guidance-verification-20260505.md
@@ -47,6 +47,12 @@ All planned commands passed:
 - `git diff --check`
   - passed.
 
+Runbook lookup coverage was also added:
+
+- `packages/core-backend/claudedocs/integration-plm-k3wise-mvp.md`
+  - §9.8 now maps the exact `sqlServer.mode=disabled requires sqlServer.enabled=false` error to the operator fix.
+  - The fix says to set `sqlServer.enabled=false` when disabling the channel, or choose `readonly`, `middle-table`, or `stored-procedure` when enabling it.
+
 ## Not Covered
 
 - Real customer SQL Server connectivity.

--- a/docs/development/integration-core-k3wise-preflight-disabled-mode-guidance-verification-20260505.md
+++ b/docs/development/integration-core-k3wise-preflight-disabled-mode-guidance-verification-20260505.md
@@ -1,0 +1,54 @@
+# K3 WISE Preflight Disabled SQL Mode Guidance Verification - 2026-05-05
+
+## Worktree
+
+`/private/tmp/ms2-k3wise-disabled-mode-20260505`
+
+Branch:
+
+`codex/k3wise-preflight-disabled-mode-20260505`
+
+Baseline:
+
+`origin/main` at worktree creation.
+
+## Verification Plan
+
+Run the focused preflight test suite and the existing K3 WISE offline PoC chain:
+
+```bash
+node --test scripts/ops/integration-k3wise-live-poc-preflight.test.mjs
+pnpm run verify:integration-k3wise:poc
+git diff --check
+```
+
+## Coverage Added
+
+- `sqlServer.enabled=true` and `sqlServer.mode=disabled` now throws a targeted `LivePocPreflightError`.
+- The assertion checks the operator-facing remediation text:
+  - set `sqlServer.enabled=false`, or
+  - choose `readonly`, `middle-table`, or `stored-procedure`.
+- The assertion also checks machine-readable details:
+  - `field === "sqlServer.mode"`
+  - `sqlServerEnabled === true`
+  - `acceptedModes` includes `readonly`.
+
+## Results
+
+All planned commands passed:
+
+- `node --test scripts/ops/integration-k3wise-live-poc-preflight.test.mjs`
+  - 17/17 passed.
+  - New coverage: `buildPacket explains disabled SQL mode requires sqlServer.enabled=false`.
+- `pnpm run verify:integration-k3wise:poc`
+  - preflight tests: 17/17 passed.
+  - evidence tests: 31/31 passed.
+  - mock PoC demo ended with `K3 WISE PoC mock chain verified end-to-end (PASS)`.
+- `git diff --check`
+  - passed.
+
+## Not Covered
+
+- Real customer SQL Server connectivity.
+- Real K3 WISE connectivity.
+- Any UI copy change; #1305 owns the setup UI surface.

--- a/packages/core-backend/claudedocs/integration-plm-k3wise-mvp.md
+++ b/packages/core-backend/claudedocs/integration-plm-k3wise-mvp.md
@@ -629,13 +629,14 @@ node scripts/ops/integration-k3wise-postdeploy-smoke.mjs \
 
 ### 9.8 错误处理快查表
 
-下表覆盖客户/操作员最可能遇到的 7 类错误，按"看到这条信息→怎么办"组织：
+下表覆盖客户/操作员最可能遇到的错误，按"看到这条信息→怎么办"组织：
 
 | 错误信号 | 典型场景 | 怎么办 |
 |---|---|---|
 | `LivePocPreflightError: <field> must be a boolean, 0/1, or boolean-like string` | GATE 答卷写了 `autoSubmit: "maybe"` 或类似无效值 | 改成允许的写法（`true/false/是/否/0/1/...`）后重跑 preflight |
 | `LivePocPreflightError: M2 live PoC packet is Save-only: autoSubmit and autoAudit must be false` | GATE 答卷写了 `autoSubmit: true` | M2 PoC 强制 Save-only。等过 PoC 后再单独申请开 auto-submit。改回 `false` 重跑 |
 | `LivePocPreflightError: SQL Server channel may not write K3 core business tables in live PoC` | `sqlServer.allowedTables` 含 `t_ICItem` / `t_ICBOM` 且 `mode != readonly` | 把 mode 改回 `readonly`，或把 allowedTables 限制到中间表 |
+| `LivePocPreflightError: sqlServer.mode=disabled requires sqlServer.enabled=false` | 想关闭 SQL Server 通道时只写了 `sqlServer.mode: "disabled"`，但 `sqlServer.enabled` 仍是 `true` | 真正关闭通道请设 `sqlServer.enabled=false`；如果要启用通道，只能选择 `readonly` / `middle-table` / `stored-procedure` |
 | `LivePocPreflightError: K3 WISE live PoC must target a non-production test environment` | `k3Wise.environment` 写成 `production` / `prod` | 改成 `test` / `uat` / `staging` 等非生产环境标识 |
 | `LivePocEvidenceError: evidence contains unredacted secret-like fields` | evidence JSON 里残留了真密码 / token / sessionId | 把 secret-like key 的值替换成 `<redacted>` 或空字符串后重跑 |
 | `SAVE_ONLY_VIOLATED` (evidence 报告 issues) | evidence 中 `materialSaveOnly.autoSubmit` 或 `autoAudit` 是 truthy（含字符串/数字/中文） | 客户 K3 实际跑时确实开了自动审核——按 GATE 答卷 Save-only 约定重新跑客户侧 K3 测试，或回流 M2 adapter 硬化 |

--- a/scripts/ops/integration-k3wise-live-poc-preflight.mjs
+++ b/scripts/ops/integration-k3wise-live-poc-preflight.mjs
@@ -95,6 +95,17 @@ function normalizeSqlMode(value, sqlEnabled) {
   const key = text.toLowerCase().replace(/\s+/g, ' ')
   const normalized = SQL_MODE_ALIASES.get(key) || key
   if (normalized === 'disabled' && !sqlEnabled) return normalized
+  if (normalized === 'disabled' && sqlEnabled) {
+    throw new LivePocPreflightError(
+      'sqlServer.mode=disabled requires sqlServer.enabled=false; set enabled=false or choose readonly, middle-table, or stored-procedure',
+      {
+        field: 'sqlServer.mode',
+        mode: text,
+        sqlServerEnabled: true,
+        acceptedModes: ['readonly', 'middle-table', 'stored-procedure'],
+      },
+    )
+  }
   if (!SQL_MODES.has(normalized)) {
     throw new LivePocPreflightError('sqlServer.mode must be readonly, middle-table, or stored-procedure', {
       field: 'sqlServer.mode',

--- a/scripts/ops/integration-k3wise-live-poc-preflight.test.mjs
+++ b/scripts/ops/integration-k3wise-live-poc-preflight.test.mjs
@@ -245,6 +245,24 @@ test('buildPacket coerces sqlServer.enabled "true" string and still applies allo
   assert.equal(packet.safety.sqlServerMode, 'disabled', 'string "no" + no explicit mode disables sql server')
 })
 
+test('buildPacket explains disabled SQL mode requires sqlServer.enabled=false', () => {
+  assert.throws(
+    () => buildPacket(gate({
+      sqlServer: {
+        enabled: true,
+        mode: 'disabled',
+        allowedTables: [],
+      },
+    })),
+    (error) => error instanceof LivePocPreflightError &&
+      error.details.field === 'sqlServer.mode' &&
+      error.details.sqlServerEnabled === true &&
+      error.details.acceptedModes.includes('readonly') &&
+      /requires sqlServer\.enabled=false/.test(error.message),
+    'enabled SQL Server channel with mode=disabled must tell operators to set enabled=false instead',
+  )
+})
+
 test('buildPacket coerces sqlServer.writeCoreTables "true" string', () => {
   // Same string-truthy pattern: customer typing writeCoreTables: "true" was
   // previously read as not-true (=== true comparison), bypassing the guard.


### PR DESCRIPTION
## Summary

Clarifies the K3 WISE live PoC preflight error when a customer GATE packet sets `sqlServer.enabled=true` and `sqlServer.mode=disabled`.

Before this PR, that packet was rejected with the generic mode error. Now it tells operators to either set `sqlServer.enabled=false` or choose `readonly`, `middle-table`, or `stored-procedure`.

## Scope

- `scripts/ops/integration-k3wise-live-poc-preflight.mjs`
- `scripts/ops/integration-k3wise-live-poc-preflight.test.mjs`
- design/verification docs under `docs/development/`

This is independent from #1305 and does not touch the K3 WISE setup UI files.

## Verification

- `node --test scripts/ops/integration-k3wise-live-poc-preflight.test.mjs` -> 17/17 pass
- `pnpm run verify:integration-k3wise:poc` -> PASS; preflight 17/17, evidence 31/31, mock chain PASS
- `git diff --check` -> pass

## Notes

Customer live validation remains blocked on customer GATE answers and real K3/PLM access.