### PR TITLE
feat(dingtalk): close public form governance gaps

### DIFF
--- a/apps/web/src/multitable/components/MetaFormShareManager.vue
+++ b/apps/web/src/multitable/components/MetaFormShareManager.vue
@@ -913,6 +913,22 @@ watch(candidateQuery, () => {
   color: #fff;
 }
 
+.meta-form-share__audience-card {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 10px 12px;
+  border: 1px solid #bae6fd;
+  border-radius: 10px;
+  background: #f0f9ff;
+  color: #0c4a6e;
+  font-size: 12px;
+}
+
+.meta-form-share__audience-card strong {
+  font-size: 13px;
+}
+
 .meta-form-share__hint {
   margin: 0;
   font-size: 12px;

--- a/apps/web/src/views/AdminAuditView.vue
+++ b/apps/web/src/views/AdminAuditView.vue
@@ -55,6 +55,31 @@
       {{ status }}
     </p>
 
+    <section class="admin-audit__scenes">
+      <article
+        v-for="scene in auditScenes"
+        :key="scene.key"
+        class="admin-audit__scene-card"
+        :class="{ 'admin-audit__scene-card--active': activeSceneKey === scene.key }"
+      >
+        <div class="admin-audit__scene-copy">
+          <span class="admin-audit__scene-kicker">{{ scene.kicker }}</span>
+          <h2>{{ scene.title }}</h2>
+          <p>{{ scene.description }}</p>
+        </div>
+        <div class="admin-audit__scene-actions">
+          <button
+            class="admin-audit__button"
+            type="button"
+            :disabled="activityLoading || activeSceneKey === scene.key"
+            @click="void applyAuditScene(scene.key)"
+          >
+            {{ activeSceneKey === scene.key ? '当前场景已应用' : scene.cta }}
+          </button>
+        </div>
+      </article>
+    </section>
+
     <section class="admin-audit__summary">
       <article class="admin-audit__summary-card">
         <span class="admin-audit__summary-label">审计日志总数</span>
@@ -158,8 +183,11 @@ type AdminAuditLogItem = {
   latency_ms: number | null
 }
 
+type AuditSceneKey = 'dingtalk-governance' | 'dingtalk-governance-recent'
+
 const resourceTypeOptions = [
   { value: 'user', label: '用户' },
+  { value: 'user-auth-grant', label: '钉钉登录授权' },
   { value: 'user-role', label: '用户角色' },
   { value: 'user-invite', label: '用户邀请' },
   { value: 'permission', label: '直接权限' },
@@ -185,6 +213,45 @@ const activityTotal = ref(0)
 const pageSize = 20
 
 const activityTotalPages = computed(() => Math.max(1, Math.ceil(activityTotal.value / pageSize)))
+const auditScenes = [
+  {
+    key: 'dingtalk-governance',
+    kicker: '治理场景',
+    title: '钉钉治理动作',
+    description: '一键切到钉钉登录授权撤销审计，适合排查缺 OpenID 收口、批量关闭钉钉扫码和后续责任追踪。',
+    cta: '打开钉钉治理审计',
+  },
+  {
+    key: 'dingtalk-governance-recent',
+    kicker: '巡检场景',
+    title: '最近 7 天收口结果',
+    description: '聚焦最近 7 天的钉钉登录授权撤销记录，适合日常巡检最近关闭钉钉扫码的治理结果。',
+    cta: '查看最近 7 天收口',
+  },
+] as const satisfies ReadonlyArray<{
+  key: AuditSceneKey
+  kicker: string
+  title: string
+  description: string
+  cta: string
+}>
+
+const activeSceneKey = computed<AuditSceneKey | ''>(() => {
+  if (
+    resourceTypeFilter.value !== 'user-auth-grant'
+    || actionFilter.value !== 'revoke'
+    || actorIdInput.value
+    || resourceIdInput.value
+  ) {
+    return ''
+  }
+  if (!fromDate.value && !toDate.value) return 'dingtalk-governance'
+  const recentRange = buildRecentDayRange(7)
+  if (fromDate.value === recentRange.fromDate && toDate.value === recentRange.toDate) {
+    return 'dingtalk-governance-recent'
+  }
+  return ''
+})
 
 const activeFilterSummary = computed(() => {
   const parts: string[] = []
@@ -200,6 +267,44 @@ const activeFilterSummary = computed(() => {
 function setStatus(message: string, tone: 'info' | 'error' = 'info'): void {
   status.value = message
   statusTone.value = tone
+}
+
+function applyFiltersFromLocation(): void {
+  if (typeof window === 'undefined') return
+  const params = new URL(window.location.href).searchParams
+  resourceIdInput.value = params.get('resourceId')?.trim() || ''
+  actorIdInput.value = params.get('actorId')?.trim() || ''
+  resourceTypeFilter.value = params.get('resourceType')?.trim() || ''
+  actionFilter.value = params.get('action')?.trim() || ''
+  const from = params.get('from')?.trim() || ''
+  const to = params.get('to')?.trim() || ''
+  fromDate.value = from ? from.slice(0, 10) : ''
+  toDate.value = to ? to.slice(0, 10) : ''
+}
+
+function formatDateInput(date: Date): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+function buildRecentDayRange(days: number): { fromDate: string; toDate: string } {
+  const end = new Date()
+  const start = new Date(end)
+  start.setDate(start.getDate() - Math.max(0, days - 1))
+  return {
+    fromDate: formatDateInput(start),
+    toDate: formatDateInput(end),
+  }
+}
+
+function syncFiltersToLocation(): void {
+  if (typeof window === 'undefined') return
+  const params = buildQueryParams()
+  const path = window.location.pathname || '/admin/audit'
+  const url = params.toString() ? `${path}?${params.toString()}` : path
+  window.history.replaceState({}, '', url)
 }
 
 async function readJson(response: Response): Promise<Record<string, unknown>> {
@@ -292,11 +397,28 @@ function buildQueryParams(extra: Record<string, string> = {}): URLSearchParams {
   return params
 }
 
+async function applyAuditScene(scene: AuditSceneKey): Promise<void> {
+  actorIdInput.value = ''
+  resourceIdInput.value = ''
+  resourceTypeFilter.value = 'user-auth-grant'
+  actionFilter.value = 'revoke'
+  if (scene === 'dingtalk-governance-recent') {
+    const recentRange = buildRecentDayRange(7)
+    fromDate.value = recentRange.fromDate
+    toDate.value = recentRange.toDate
+  } else {
+    fromDate.value = ''
+    toDate.value = ''
+  }
+  await loadActivityLogs(1)
+}
+
 async function loadActivityLogs(page = 1): Promise<void> {
   activityLoading.value = true
   setStatus('')
   try {
     const params = buildQueryParams({ page: String(page), pageSize: String(pageSize) })
+    syncFiltersToLocation()
     const response = await apiFetch(`/api/audit-logs?${params.toString()}`)
     const payload = await readJson(response)
     if (!response.ok || payload.ok !== true) {
@@ -354,6 +476,7 @@ async function exportActivityCsv(): Promise<void> {
 }
 
 onMounted(() => {
+  applyFiltersFromLocation()
   void loadActivityLogs(1)
 })
 </script>
@@ -367,6 +490,7 @@ onMounted(() => {
 }
 
 .admin-audit__header,
+.admin-audit__scenes,
 .admin-audit__summary,
 .admin-audit__panel {
   background: #fff;
@@ -419,6 +543,46 @@ onMounted(() => {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 12px;
+}
+
+.admin-audit__scene-card {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: center;
+}
+
+.admin-audit__scene-card--active {
+  padding: 12px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, #eff6ff, #f8fafc);
+}
+
+.admin-audit__scene-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.admin-audit__scene-copy h2,
+.admin-audit__scene-copy p {
+  margin: 0;
+}
+
+.admin-audit__scene-copy p,
+.admin-audit__scene-kicker {
+  color: #6b7280;
+}
+
+.admin-audit__scene-kicker {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.admin-audit__scene-actions {
+  display: flex;
+  align-items: center;
 }
 
 .admin-audit__summary-card {
@@ -508,6 +672,7 @@ onMounted(() => {
 
 @media (max-width: 1100px) {
   .admin-audit__header,
+  .admin-audit__scene-card,
   .admin-audit__panel-head,
   .admin-audit__pagination {
     flex-direction: column;

--- a/apps/web/src/views/DirectoryManagementView.vue
+++ b/apps/web/src/views/DirectoryManagementView.vue
@@ -519,12 +519,31 @@
               </label>
               <label class="directory-admin__toggle directory-admin__toggle--compact">
                 <input
-                  :checked="readGrantToggle(item.account.id)"
+                  :checked="readAccountGrantToggle(item.account)"
+                  :disabled="!canEnableDingTalkGrant(item.account)"
                   type="checkbox"
-                  @change="onGrantToggleChange(item.account.id, $event)"
+                  @change="onGrantToggleChange(item.account, $event)"
                 />
                 <span>绑定后同时开通钉钉登录</span>
               </label>
+              <p v-if="shouldWarnMissingOpenIdForGrant(item.account)" class="directory-admin__status directory-admin__status--error">
+                openId 缺失，当前无法同时开通钉钉登录；请重新同步目录或让用户完成钉钉 OAuth 绑定后再开通。
+              </p>
+              <p v-if="shouldWarnMissingOpenIdForGrant(item.account)" class="directory-admin__hint">
+                修复建议：若该成员刚完成钉钉登录/绑定，先刷新当前成员；若刷新后仍缺失 openId，请检查钉钉目录同步返回值，再决定是否重新同步当前集成。
+              </p>
+              <div v-if="shouldWarnMissingOpenIdForGrant(item.account)" class="directory-admin__actions">
+                <button class="directory-admin__button directory-admin__button--secondary" type="button" :disabled="reviewProcessingAccountId === item.account.id" @click="void refreshSingleReviewItem(item.account.id)">
+                  刷新当前成员
+                </button>
+                <router-link
+                  v-if="item.account.localUser"
+                  class="directory-admin__button directory-admin__button--secondary"
+                  :to="buildUserManagementLocation(item.account.localUser.id, item.account)"
+                >
+                  前往用户管理
+                </router-link>
+              </div>
             </div>
             <div v-if="item.kind === 'pending_binding' && item.recommendations.length > 0" class="directory-admin__search-results">
               <button
@@ -984,6 +1003,7 @@
               <p class="directory-admin__hint"><strong>邮箱：</strong>{{ account.email || '无' }}</p>
               <p class="directory-admin__hint"><strong>手机：</strong>{{ account.mobile || '无' }}</p>
               <p class="directory-admin__hint"><strong>Corp：</strong>{{ account.corpId || '未记录' }}</p>
+              <p class="directory-admin__hint"><strong>最近目录同步：</strong>{{ formatDateTime(account.updatedAt) }}</p>
             </div>
 
             <p class="directory-admin__hint">
@@ -1012,12 +1032,31 @@
               </label>
               <label class="directory-admin__toggle directory-admin__toggle--compact">
                 <input
-                  :checked="readGrantToggle(account.id)"
+                  :checked="readAccountGrantToggle(account)"
+                  :disabled="!canEnableDingTalkGrant(account)"
                   type="checkbox"
-                  @change="onGrantToggleChange(account.id, $event)"
+                  @change="onGrantToggleChange(account, $event)"
                 />
                 <span>绑定后同时开通钉钉登录</span>
               </label>
+              <p v-if="shouldWarnMissingOpenIdForGrant(account)" class="directory-admin__status directory-admin__status--error">
+                openId 缺失，当前无法同时开通钉钉登录；请重新同步目录或让用户完成钉钉 OAuth 绑定后再开通。
+              </p>
+              <p v-if="shouldWarnMissingOpenIdForGrant(account)" class="directory-admin__hint">
+                修复建议：若该成员刚完成钉钉登录/绑定，先刷新当前成员；若刷新后仍缺失 openId，请检查钉钉目录同步返回值，再决定是否重新同步当前集成。
+              </p>
+              <div v-if="shouldWarnMissingOpenIdForGrant(account)" class="directory-admin__actions">
+                <button class="directory-admin__button directory-admin__button--secondary" type="button" :disabled="bindingAccountId === account.id" @click="void refreshSingleAccount(account.id)">
+                  刷新当前成员
+                </button>
+                <router-link
+                  v-if="account.localUser"
+                  class="directory-admin__button directory-admin__button--secondary"
+                  :to="buildUserManagementLocation(account.localUser.id, account)"
+                >
+                  前往用户管理
+                </router-link>
+              </div>
             </div>
 
             <div class="directory-admin__actions">
@@ -1717,7 +1756,7 @@ const selectedRecommendedReviewBindEntries = computed(() => (
     .map((item) => ({
       accountId: item.account.id,
       localUserRef: item.recommendations[0].localUser.id,
-      enableDingTalkGrant: readGrantToggle(item.account.id),
+      enableDingTalkGrant: readAccountGrantToggle(item.account),
     }))
 ))
 const selectedReviewBindEntries = computed(() => (
@@ -1726,7 +1765,7 @@ const selectedReviewBindEntries = computed(() => (
     .map((item) => ({
       accountId: item.account.id,
       localUserRef: readBindingDraft(item.account).trim(),
-      enableDingTalkGrant: readGrantToggle(item.account.id),
+      enableDingTalkGrant: readAccountGrantToggle(item.account),
     }))
     .filter((item) => item.localUserRef.length > 0)
 ))
@@ -2257,13 +2296,30 @@ function readGrantToggle(accountId: string): boolean {
   return grantToggles[accountId] ?? true
 }
 
+function canEnableDingTalkGrant(account: Partial<Pick<DirectoryAccount, 'corpId' | 'openId'>>): boolean {
+  return !((account.corpId?.trim() ?? '').length > 0 && (account.openId?.trim() ?? '').length === 0)
+}
+
+function readAccountGrantToggle(account: DirectoryAccount): boolean {
+  return canEnableDingTalkGrant(account) && readGrantToggle(account.id)
+}
+
+function shouldWarnMissingOpenIdForGrant(account: Partial<Pick<DirectoryAccount, 'corpId' | 'openId'>>): boolean {
+  return !canEnableDingTalkGrant(account)
+}
+
 function updateGrantToggle(accountId: string, value: boolean) {
   grantToggles[accountId] = value
 }
 
-function onGrantToggleChange(accountId: string, event: Event) {
+function onGrantToggleChange(account: DirectoryAccount, event: Event) {
   const target = event.target
-  updateGrantToggle(accountId, target instanceof HTMLInputElement ? target.checked : true)
+  if (!canEnableDingTalkGrant(account)) {
+    updateGrantToggle(account.id, false)
+    setStatus(`目录成员 ${account.name} 缺少 openId，暂不能开通钉钉登录；请重新同步目录或完成钉钉 OAuth 绑定`, 'error')
+    return
+  }
+  updateGrantToggle(account.id, target instanceof HTMLInputElement ? target.checked : true)
 }
 
 function clearBindingSearch(accountId: string) {
@@ -2849,7 +2905,7 @@ async function bindAccount(account: DirectoryAccount) {
       method: 'POST',
       body: JSON.stringify({
         localUserRef: readBindingDraft(account).trim(),
-        enableDingTalkGrant: readGrantToggle(account.id),
+        enableDingTalkGrant: readAccountGrantToggle(account),
       }),
     })
     const body = await readJson(response)
@@ -3029,13 +3085,15 @@ async function handleDirectoryNavigationChange(): Promise<void> {
   ])
 }
 
-function buildUserManagementLocation(userId: string, account: Pick<DirectoryAccount, 'id' | 'integrationId'>): string {
-  const params = new URLSearchParams({
-    userId,
-    source: 'directory-sync',
-    integrationId: account.integrationId,
-    accountId: account.id,
-  })
+function buildUserManagementLocation(userId: string, account: Pick<DirectoryAccount, 'id' | 'integrationId'> & Partial<Pick<DirectoryAccount, 'corpId' | 'openId'>>): string {
+  const params = new URLSearchParams()
+  params.set('userId', userId)
+  params.set('source', 'directory-sync')
+  params.set('integrationId', account.integrationId)
+  params.set('accountId', account.id)
+  if (shouldWarnMissingOpenIdForGrant(account)) {
+    params.set('filter', 'dingtalk-openid-missing')
+  }
   return `/admin/users?${params.toString()}`
 }
 
@@ -3138,7 +3196,7 @@ async function handleReviewBind(item: DirectoryReviewItem) {
     await submitReviewBindings([{
       accountId: item.account.id,
       localUserRef: readBindingDraft(item.account).trim(),
-      enableDingTalkGrant: readGrantToggle(item.account.id),
+      enableDingTalkGrant: readAccountGrantToggle(item.account),
     }], `待处理成员 ${item.account.name} 已完成快速绑定`, '快速绑定失败')
   } finally {
     reviewProcessingAccountId.value = ''
@@ -3194,7 +3252,7 @@ async function backfillUserMobileAndBindReviewItem(item: DirectoryReviewItem) {
     await submitReviewBindings([{
       accountId: item.account.id,
       localUserRef: selectedUser.id,
-      enableDingTalkGrant: readGrantToggle(item.account.id),
+      enableDingTalkGrant: readAccountGrantToggle(item.account),
     }], `待处理成员 ${item.account.name} 已回填手机号并完成绑定`, '回填手机号并绑定失败')
   } catch (error) {
     setStatus(error instanceof Error ? error.message : '回填手机号并绑定失败', 'error')
@@ -3228,7 +3286,7 @@ async function createAndBindDirectoryAccountUser(account: DirectoryAccount, cont
         email: nextDraft.email || undefined,
         username: nextDraft.username || undefined,
         mobile: nextDraft.mobile || undefined,
-        enableDingTalkGrant: readGrantToggle(account.id),
+        enableDingTalkGrant: readAccountGrantToggle(account),
       }),
     })
     const body = await readJson(response)
@@ -3310,7 +3368,7 @@ async function confirmRecommendedReviewBinding(item: DirectoryReviewItem) {
     await submitReviewBindings([{
       accountId: item.account.id,
       localUserRef: recommendation.localUser.id,
-      enableDingTalkGrant: readGrantToggle(item.account.id),
+      enableDingTalkGrant: readAccountGrantToggle(item.account),
     }], `待处理成员 ${item.account.name} 已确认推荐绑定`, '确认推荐绑定失败')
   } finally {
     reviewProcessingAccountId.value = ''

--- a/apps/web/src/views/ForcePasswordChangeView.vue
+++ b/apps/web/src/views/ForcePasswordChangeView.vue
@@ -33,10 +33,14 @@
           />
         </label>
 
-        <button class="force-password-submit" type="submit" :disabled="submitting">
+        <button class="force-password-submit" type="submit" :disabled="submitting || loggingOut">
           {{ submitting ? (isZh ? '提交中...' : 'Submitting...') : (isZh ? '保存并继续' : 'Save and continue') }}
         </button>
       </form>
+
+      <button class="force-password-logout" type="button" :disabled="submitting || loggingOut" @click="void logout()">
+        {{ loggingOut ? (isZh ? '退出中...' : 'Signing out...') : (isZh ? '退出登录' : 'Sign out') }}
+      </button>
 
       <p v-if="error" class="force-password-error">{{ error }}</p>
     </div>
@@ -66,6 +70,7 @@ const { loadProductFeatures, resolveHomePath } = useFeatureFlags()
 const password = ref('')
 const confirmPassword = ref('')
 const submitting = ref(false)
+const loggingOut = ref(false)
 const error = ref('')
 const accountEmail = ref('')
 
@@ -101,7 +106,7 @@ async function ensureEligibleSession(): Promise<boolean> {
 }
 
 async function submit(): Promise<void> {
-  if (submitting.value) return
+  if (submitting.value || loggingOut.value) return
   error.value = ''
 
   if (!password.value || !confirmPassword.value) {
@@ -150,6 +155,29 @@ async function submit(): Promise<void> {
       : (isZh.value ? '修改密码失败，请稍后重试。' : 'Failed to change password. Please try again.')
   } finally {
     submitting.value = false
+  }
+}
+
+async function logout(): Promise<void> {
+  if (loggingOut.value) return
+  loggingOut.value = true
+  error.value = ''
+
+  try {
+    await apiFetch('/api/auth/logout', {
+      method: 'POST',
+      suppressUnauthorizedRedirect: true,
+    })
+  } catch {
+    // Local session cleanup below is still the source of truth for account switching.
+  }
+
+  auth.clearToken()
+  clearStoredAuthState()
+  try {
+    await router.replace(ROUTE_PATHS.LOGIN)
+  } finally {
+    loggingOut.value = false
   }
 }
 
@@ -227,6 +255,27 @@ onMounted(() => {
 }
 
 .force-password-submit:disabled {
+  opacity: 0.7;
+  cursor: wait;
+}
+
+.force-password-logout {
+  border: 1px solid #cbd5e1;
+  border-radius: 10px;
+  padding: 10px 14px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #334155;
+  background: #fff;
+  cursor: pointer;
+}
+
+.force-password-logout:hover:not(:disabled) {
+  border-color: #94a3b8;
+  background: #f8fafc;
+}
+
+.force-password-logout:disabled {
   opacity: 0.7;
   cursor: wait;
 }

--- a/apps/web/src/views/UserManagementView.vue
+++ b/apps/web/src/views/UserManagementView.vue
@@ -30,6 +30,20 @@
     <p v-if="status" class="user-admin__status" :class="{ 'user-admin__status--error': statusTone === 'error' }">
       {{ status }}
     </p>
+    <section
+      v-if="hasDirectorySyncNavigation"
+      class="user-admin__status user-admin__source-banner"
+      :class="{ 'user-admin__status--error': userNavigation.directoryFailure }"
+    >
+      <strong>{{ userNavigation.directoryFailure ? '目录定位未完成' : '目录同步回跳' }}</strong>
+      <p>{{ directoryNavigationNotice }}</p>
+      <p v-if="directoryNavigationTargetLabel">{{ directoryNavigationTargetLabel }}</p>
+      <div v-if="directoryReturnLocation" class="user-admin__source-actions">
+        <router-link class="user-admin__button user-admin__button--secondary user-admin__button-link" :to="directoryReturnLocation">
+          返回目录同步
+        </router-link>
+      </div>
+    </section>
     <section class="user-admin__panel user-admin__panel--create">
       <div class="user-admin__section-head">
         <div>
@@ -156,6 +170,54 @@
             <strong>{{ governanceSummary.directoryLinked }}</strong>
             <small>目录已链接</small>
           </span>
+          <router-link class="user-admin__metric user-admin__metric-link" :to="buildMissingOpenIdUserManagementLocation()">
+            <strong>{{ governanceSummary.dingtalkOpenIdMissing }}</strong>
+            <small>缺 OpenID</small>
+          </router-link>
+          <router-link class="user-admin__metric user-admin__metric-link" :to="buildRecentDingTalkGovernanceAuditLocation()">
+            <strong>{{ governanceSummary.dingtalkOpenIdGoverned }}</strong>
+            <small>已收口</small>
+          </router-link>
+          <router-link class="user-admin__metric user-admin__metric-link" :to="buildDingTalkGovernanceAuditLocation()">
+            <strong>{{ governanceSummary.dingtalkOpenIdPending }}</strong>
+            <small>待收口</small>
+          </router-link>
+        </div>
+        <div class="user-admin__section-head user-admin__section-head--workbench">
+          <div>
+            <h3>治理工作台</h3>
+            <p class="user-admin__hint">把筛查、目录修复和审计复盘入口放到同一个工作台，便于值班和日常收口。</p>
+          </div>
+          <div class="user-admin__role-actions">
+            <button class="user-admin__button user-admin__button--secondary" type="button" @click="exportGovernanceDailySummary()">
+              导出治理日报摘要
+            </button>
+            <button class="user-admin__button user-admin__button--secondary" type="button" @click="exportGovernanceLiveValidationChecklist()">
+              导出联调检查单
+            </button>
+            <button class="user-admin__button user-admin__button--secondary" type="button" @click="exportGovernanceValidationResultTemplate()">
+              导出联调结果模板
+            </button>
+            <button class="user-admin__button user-admin__button--secondary" type="button" @click="exportGovernanceExecutionPackageIndex()">
+              导出联调执行包索引
+            </button>
+            <button class="user-admin__button user-admin__button--secondary" type="button" @click="exportGovernanceFullValidationPackage()">
+              导出完整联调包
+            </button>
+          </div>
+        </div>
+        <div class="user-admin__workbench">
+          <router-link
+            v-for="card in governanceWorkbenchCards"
+            :key="card.title"
+            class="user-admin__workbench-card"
+            :to="card.to"
+          >
+            <span class="user-admin__workbench-kicker">{{ card.kicker }}</span>
+            <strong>{{ card.title }}</strong>
+            <small>{{ card.description }}</small>
+            <span class="user-admin__workbench-note">{{ card.note }}</span>
+          </router-link>
         </div>
         <div class="user-admin__filters" role="group" aria-label="成员治理筛选">
           <button
@@ -174,6 +236,12 @@
             <strong>批量操作</strong>
             <p class="user-admin__hint">
               已选择 {{ selectedUserIds.length }} / {{ visibleUsers.length }} 个当前筛选结果。
+            </p>
+            <p v-if="screeningUsersMissingOpenId.length > 0" class="user-admin__hint">
+              当前筛选结果中有 {{ screeningUsersMissingOpenId.length }} 个缺 OpenID 用户，可直接导出治理清单。
+            </p>
+            <p v-if="screeningUsersMissingOpenIdWithGrant.length > 0" class="user-admin__hint">
+              其中 {{ screeningUsersMissingOpenIdWithGrant.length }} 个仍开通钉钉扫码，可直接批量关闭以降低误用风险。
             </p>
           </div>
           <div class="user-admin__bulk-group">
@@ -210,6 +278,15 @@
             <button class="user-admin__button user-admin__button--secondary" type="button" :disabled="loading || bulkBusy || selectedUserIds.length === 0" @click="void bulkUpdateDingTalkGrants(false)">
               批量关闭钉钉扫码
             </button>
+            <button class="user-admin__button user-admin__button--secondary" type="button" :disabled="screeningUsersMissingOpenIdWithGrant.length === 0" @click="void bulkDisableMissingOpenIdDingTalkGrants()">
+              批量关闭缺 OpenID 钉钉扫码
+            </button>
+            <button class="user-admin__button user-admin__button--secondary" type="button" :disabled="screeningUsersMissingOpenId.length === 0" @click="exportMissingOpenIdCsv()">
+              导出缺 OpenID 清单
+            </button>
+            <router-link class="user-admin__button user-admin__button--secondary" :to="buildDingTalkGovernanceAuditLocation()">
+              查看钉钉治理审计
+            </router-link>
           </div>
         </div>
         <div v-if="visibleUsers.length === 0" class="user-admin__empty">暂无用户数据</div>
@@ -241,6 +318,9 @@
               <span class="user-admin__row-badge" :class="{ 'user-admin__row-badge--success': user.directoryLinked === true, 'user-admin__row-badge--danger': user.directoryLinked !== true }">
                 {{ user.directoryLinked === true ? '目录已链接' : '目录未链接' }}
               </span>
+              <span v-if="user.dingtalkOpenIdMissing" class="user-admin__row-badge user-admin__row-badge--danger">
+                缺 OpenID
+              </span>
               <span v-if="user.platformAdminEnabled" class="user-admin__row-badge user-admin__row-badge--accent">
                 平台管理员
               </span>
@@ -252,6 +332,9 @@
               </span>
             </div>
           </button>
+          <p v-if="user.dingtalkOpenIdMissing" class="user-admin__hint">
+            {{ readMissingOpenIdGovernanceHint(user) }}
+          </p>
         </article>
       </aside>
 
@@ -471,14 +554,35 @@
             <p v-if="dingtalkAccess?.server?.allowedCorpIds?.length" class="user-admin__hint">
               允许企业：{{ dingtalkAccess.server.allowedCorpIds.join('、') }}
             </p>
+            <div v-if="dingtalkAccess" class="user-admin__create-grid">
+              <div class="user-admin__hint"><strong>身份 corpId：</strong>{{ dingtalkAccess.identity.corpId || dingtalkAccess.server?.corpId || '未记录' }}</div>
+              <div class="user-admin__hint"><strong>Union ID：</strong>{{ dingtalkAccess.identity.unionId || '未记录' }}</div>
+              <div class="user-admin__hint"><strong>Open ID：</strong>{{ dingtalkAccess.identity.openId || '未记录' }}</div>
+              <div class="user-admin__hint"><strong>最近钉钉登录：</strong>{{ formatDate(dingtalkAccess.identity.lastLoginAt) }}</div>
+              <div class="user-admin__hint"><strong>最近目录同步：</strong>{{ formatDirectorySyncAt(memberAdmission) }}</div>
+              <div class="user-admin__hint"><strong>钉钉身份更新时间：</strong>{{ formatDate(dingtalkAccess.identity.updatedAt) }}</div>
+            </div>
             <p v-if="dingtalkAccess?.identity.lastLoginAt" class="user-admin__hint">
               最近钉钉登录：{{ formatDate(dingtalkAccess.identity.lastLoginAt) }}
+            </p>
+            <p v-if="shouldWarnMissingDingTalkOpenId(dingtalkAccess)" class="user-admin__warning">
+              当前钉钉身份缺少 openId，暂不能开通钉钉扫码；请重新同步目录或让用户完成一次钉钉 OAuth 绑定。
+            </p>
+            <p v-if="shouldWarnMissingDingTalkOpenId(dingtalkAccess)" class="user-admin__hint">
+              修复建议：先回到目录同步查看该成员是否已补齐 openId；如果目录仍未返回，请让用户先完成一次钉钉 OAuth 绑定；确认 openId 已补齐后刷新本页，再开通钉钉扫码。
             </p>
             <p v-if="dingtalkAccess?.grant.updatedAt" class="user-admin__hint">
               开通状态更新时间：{{ formatDate(dingtalkAccess.grant.updatedAt) }}
             </p>
             <div class="user-admin__role-actions">
-              <button class="user-admin__button" type="button" :disabled="busy || loadingDingTalk || dingtalkAccess?.grant.enabled === true" @click="void updateDingTalkGrant(true)">
+              <router-link
+                v-if="shouldWarnMissingDingTalkOpenId(dingtalkAccess) && access && readPrimaryDingTalkDirectoryMembership(memberAdmission)"
+                class="user-admin__button user-admin__button--secondary"
+                :to="buildDirectoryManagementLocation(access.user.id, readPrimaryDingTalkDirectoryMembership(memberAdmission)!)"
+              >
+                前往目录成员
+              </router-link>
+              <button class="user-admin__button" type="button" :disabled="busy || loadingDingTalk || dingtalkAccess?.grant.enabled === true || !canEnableDingTalkGrant(dingtalkAccess)" @click="void updateDingTalkGrant(true)">
                 开通钉钉扫码
               </button>
               <button class="user-admin__button user-admin__button--secondary" type="button" :disabled="busy || loadingDingTalk || dingtalkAccess?.grant.enabled !== true" @click="void updateDingTalkGrant(false)">
@@ -604,7 +708,15 @@ type ManagedUser = {
   platformAdminEnabled?: boolean
   attendanceAdminEnabled?: boolean
   dingtalkLoginEnabled?: boolean
+  dingtalkGrantUpdatedAt?: string | null
+  dingtalkGrantUpdatedBy?: string | null
   directoryLinked?: boolean
+  dingtalkIdentityExists?: boolean
+  dingtalkHasUnionId?: boolean
+  dingtalkHasOpenId?: boolean
+  dingtalkOpenIdMissing?: boolean
+  dingtalkCorpId?: string | null
+  lastDirectorySyncAt?: string | null
   businessRoleCount?: number
 }
 
@@ -649,6 +761,10 @@ type DingTalkAccess = {
   identity: {
     exists: boolean
     corpId: string | null
+    unionId: string | null
+    openId: string | null
+    hasUnionId: boolean
+    hasOpenId: boolean
     lastLoginAt: string | null
     createdAt: string | null
     updatedAt: string | null
@@ -763,9 +879,17 @@ type UserSessionRecord = {
   userAgent: string | null
 }
 
+type UserListFilter = 'all' | 'account-disabled' | 'dingtalk-disabled' | 'directory-unlinked' | 'dingtalk-openid-missing' | 'platform-admin'
+
+const USER_LIST_FILTER_VALUES: UserListFilter[] = ['all', 'account-disabled', 'dingtalk-disabled', 'directory-unlinked', 'dingtalk-openid-missing', 'platform-admin']
+
 type InitialUserNavigation = {
   userId: string
   source: string
+  filter: UserListFilter
+  integrationId: string
+  accountId: string
+  directoryFailure: string
 }
 
 const { hasAdminAccess } = useAuth()
@@ -783,7 +907,7 @@ const statusTone = ref<'info' | 'error'>('info')
 const search = ref('')
 const users = ref<ManagedUser[]>([])
 const selectedUserIds = ref<string[]>([])
-const userListFilter = ref<'all' | 'account-disabled' | 'dingtalk-disabled' | 'directory-unlinked' | 'platform-admin'>('all')
+const userListFilter = ref<UserListFilter>(readInitialUserNavigation().filter)
 const roleCatalog = ref<RoleCatalogItem[]>([])
 const accessPresets = ref<AccessPreset[]>([])
 const presetModeFilter = ref<'' | 'platform' | 'attendance' | 'plm-workbench'>('')
@@ -820,22 +944,70 @@ const governanceSummary = computed(() => ({
   accountEnabled: users.value.filter((user) => user.is_active).length,
   dingtalkEnabled: users.value.filter((user) => user.dingtalkLoginEnabled !== false).length,
   directoryLinked: users.value.filter((user) => user.directoryLinked === true).length,
+  dingtalkOpenIdMissing: users.value.filter((user) => user.dingtalkOpenIdMissing === true).length,
+  dingtalkOpenIdGoverned: users.value.filter((user) => user.dingtalkOpenIdMissing === true && user.dingtalkLoginEnabled === false).length,
+  dingtalkOpenIdPending: users.value.filter((user) => user.dingtalkOpenIdMissing === true && user.dingtalkLoginEnabled !== false).length,
 }))
+const governanceWorkbenchCards = computed(() => {
+  const pendingToday = users.value.filter((user) => (
+    user.dingtalkOpenIdMissing === true
+    && user.dingtalkLoginEnabled !== false
+  )).length
+  const directoryRepairCount = users.value.filter((user) => (
+    user.dingtalkOpenIdMissing === true
+    && user.directoryLinked === true
+  )).length
+  const governedRecent = users.value.filter((user) => (
+    user.dingtalkOpenIdMissing === true
+    && user.dingtalkLoginEnabled === false
+    && isWithinRecentDays(user.dingtalkGrantUpdatedAt, 7)
+  )).length
+
+  return [
+    {
+      kicker: '治理清单',
+      title: '缺 OpenID 成员',
+      description: '直接进入当前缺 OpenID 用户筛选，适合先做名单筛查和批量收口。',
+      note: pendingToday > 0 ? `今日优先处理 ${pendingToday} 个待收口成员` : '当前没有待收口成员需要优先处理',
+      to: buildMissingOpenIdUserManagementLocation(),
+    },
+    {
+      kicker: '目录修复',
+      title: '目录同步修复入口',
+      description: '跳到目录同步页，继续刷新目录成员、补齐 openId 或回看目录绑定状态。',
+      note: directoryRepairCount > 0 ? `${directoryRepairCount} 个成员可先回目录同步继续补齐 openId` : '当前没有需要回目录同步补齐的成员',
+      to: buildDirectoryMissingOpenIdWorkbenchLocation(),
+    },
+    {
+      kicker: '审计复盘',
+      title: '最近 7 天收口审计',
+      description: '查看最近 7 天钉钉扫码关闭记录，适合巡检治理结果和责任追踪。',
+      note: governedRecent > 0 ? `最近 7 天已收口 ${governedRecent} 个成员，可直接复盘处理动作` : '最近 7 天暂无新的收口记录',
+      to: buildRecentDingTalkGovernanceAuditLocation(),
+    },
+  ]
+})
 const visibleUsers = computed(() => {
   return users.value.filter((user) => {
     if (userListFilter.value === 'account-disabled') return !user.is_active
     if (userListFilter.value === 'dingtalk-disabled') return user.dingtalkLoginEnabled === false
     if (userListFilter.value === 'directory-unlinked') return user.directoryLinked !== true
+    if (userListFilter.value === 'dingtalk-openid-missing') return user.dingtalkOpenIdMissing === true
     if (userListFilter.value === 'platform-admin') return user.platformAdminEnabled === true
     return true
   })
 })
+const screeningUsersMissingOpenId = computed(() => visibleUsers.value.filter((user) => user.dingtalkOpenIdMissing === true))
+const screeningUsersMissingOpenIdWithGrant = computed(() => (
+  screeningUsersMissingOpenId.value.filter((user) => user.dingtalkLoginEnabled === true)
+))
 const selectedUserIdSet = computed(() => new Set(selectedUserIds.value))
 const userFilterOptions = [
   { value: 'all', label: '全部' },
   { value: 'account-disabled', label: '账号停用' },
   { value: 'dingtalk-disabled', label: '钉钉停用' },
   { value: 'directory-unlinked', label: '目录未链接' },
+  { value: 'dingtalk-openid-missing', label: '缺 OpenID' },
   { value: 'platform-admin', label: '平台管理员' },
 ] as const
 const hasPlatformAdminAccess = computed(() => {
@@ -863,6 +1035,361 @@ function formatManagedUserLabel(user: ManagedUser | null | undefined): string {
   if (!user) return ''
   return user.name || formatManagedUserIdentifier(user)
 }
+
+function isWithinRecentDays(value: string | null | undefined, days: number): boolean {
+  if (!value) return false
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return false
+  const now = new Date()
+  const threshold = new Date(now)
+  threshold.setDate(now.getDate() - Math.max(0, days - 1))
+  threshold.setHours(0, 0, 0, 0)
+  return date.getTime() >= threshold.getTime()
+}
+
+function readMissingOpenIdGovernanceHint(user: ManagedUser): string {
+  const parts = [`corpId ${user.dingtalkCorpId || '未记录'}`]
+  if (user.lastDirectorySyncAt) {
+    parts.push(`最近目录同步 ${formatDate(user.lastDirectorySyncAt)}`)
+  }
+  if (user.dingtalkLoginEnabled === false && user.dingtalkGrantUpdatedAt) {
+    const actor = user.dingtalkGrantUpdatedBy ? ` · 处理人 ${user.dingtalkGrantUpdatedBy}` : ''
+    parts.push(`最近关闭钉钉扫码 ${formatDate(user.dingtalkGrantUpdatedAt)}${actor}`)
+  }
+  return parts.join(' · ')
+}
+
+function escapeCsvValue(value: unknown): string {
+  const text = String(value ?? '')
+  if (!/[",\n]/.test(text)) return text
+  return `"${text.replaceAll('"', '""')}"`
+}
+
+function downloadText(filename: string, text: string, mimeType: string): void {
+  if (typeof window === 'undefined' || typeof document === 'undefined' || typeof URL.createObjectURL !== 'function') {
+    throw new Error('当前环境不支持文件导出')
+  }
+  const blob = new Blob([`\ufeff${text}`], { type: mimeType })
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = filename
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+  URL.revokeObjectURL(url)
+}
+
+function exportMissingOpenIdCsv(): void {
+  if (screeningUsersMissingOpenId.value.length === 0) {
+    setStatus('当前筛选结果中没有缺 OpenID 用户可导出', 'error')
+    return
+  }
+
+  const header = ['userId', 'name', 'account', 'role', 'dingtalkCorpId', 'directoryLinked', 'lastDirectorySyncAt']
+  const rows = screeningUsersMissingOpenId.value.map((user) => ([
+    user.id,
+    user.name || '',
+    formatManagedUserIdentifier(user),
+    user.role,
+    user.dingtalkCorpId || '',
+    user.directoryLinked === true ? 'linked' : 'unlinked',
+    user.lastDirectorySyncAt || '',
+  ].map(escapeCsvValue).join(',')))
+  downloadText(
+    `dingtalk-missing-openid-users-${new Date().toISOString().slice(0, 10)}.csv`,
+    [header.join(','), ...rows].join('\n'),
+    'text/csv;charset=utf-8',
+  )
+  setStatus(`已导出 ${screeningUsersMissingOpenId.value.length} 个缺 OpenID 用户的治理清单`)
+}
+
+function exportGovernanceDailySummary(): void {
+  const today = formatDateInput(new Date())
+  const lines = [
+    `# DingTalk 治理日报摘要`,
+    '',
+    `日期：${today}`,
+    '',
+    `## 核心统计`,
+    `- 缺 OpenID：${governanceSummary.value.dingtalkOpenIdMissing}`,
+    `- 待收口：${governanceSummary.value.dingtalkOpenIdPending}`,
+    `- 已收口：${governanceSummary.value.dingtalkOpenIdGoverned}`,
+    `- 目录已链接：${governanceSummary.value.directoryLinked}`,
+    '',
+    `## 当前建议`,
+    ...governanceWorkbenchCards.value.map((card) => `- ${card.title}：${card.note}`),
+    '',
+    `## 工作台入口`,
+    ...governanceWorkbenchCards.value.map((card) => `- ${card.title}：${card.to}`),
+  ]
+  downloadText(
+    `dingtalk-governance-daily-summary-${today}.md`,
+    lines.join('\n'),
+    'text/markdown;charset=utf-8',
+  )
+  setStatus('已导出 DingTalk 治理日报摘要')
+}
+
+function exportGovernanceLiveValidationChecklist(): void {
+  const today = formatDateInput(new Date())
+  const lines = [
+    '# DingTalk 治理联调检查单',
+    '',
+    `日期：${today}`,
+    '',
+    '## 当前基线',
+    `- 缺 OpenID：${governanceSummary.value.dingtalkOpenIdMissing}`,
+    `- 待收口：${governanceSummary.value.dingtalkOpenIdPending}`,
+    `- 已收口：${governanceSummary.value.dingtalkOpenIdGoverned}`,
+    '',
+    '## 联调步骤',
+    '- 1. 打开缺 OpenID 成员清单，确认待收口成员列表与当前预期一致。',
+    `  入口：${buildMissingOpenIdUserManagementLocation()}`,
+    '- 2. 随机抽取至少 1 个目录已链接但缺 openId 的成员，跳到目录同步页，刷新目录成员并确认是否补齐 openId。',
+    `  入口：${buildDirectoryMissingOpenIdWorkbenchLocation()}`,
+    '- 3. 对仍缺 openId 且已开通钉钉扫码的成员，执行批量关闭，确认治理统计从“待收口”转到“已收口”。',
+    '- 4. 打开最近 7 天收口审计，确认最近治理动作、处理时间和处理人可追溯。',
+    `  入口：${buildRecentDingTalkGovernanceAuditLocation()}`,
+    '- 5. 在真实钉钉账号上验证：已修复成员可正常钉钉登录；未修复成员仍被正确阻止。',
+    '- 6. 导出治理日报摘要，归档当天治理结果。',
+    '',
+    '## 当前建议',
+    ...governanceWorkbenchCards.value.map((card) => `- ${card.title}：${card.note}`),
+  ]
+  downloadText(
+    `dingtalk-governance-live-validation-checklist-${today}.md`,
+    lines.join('\n'),
+    'text/markdown;charset=utf-8',
+  )
+  setStatus('已导出 DingTalk 联调检查单')
+}
+
+function exportGovernanceValidationResultTemplate(): void {
+  const today = formatDateInput(new Date())
+  const lines = [
+    '# DingTalk 治理联调结果回填模板',
+    '',
+    `日期：${today}`,
+    '',
+    '## 联调环境',
+    '- 环境：142 / staging / other',
+    '- 执行人：',
+    '- 协同人：',
+    '- 执行时间：',
+    '',
+    '## 执行前基线',
+    `- 缺 OpenID：${governanceSummary.value.dingtalkOpenIdMissing}`,
+    `- 待收口：${governanceSummary.value.dingtalkOpenIdPending}`,
+    `- 已收口：${governanceSummary.value.dingtalkOpenIdGoverned}`,
+    '',
+    '## 结果回填',
+    '- [ ] 缺 OpenID 成员清单与预期一致',
+    '  - 实际结果：',
+    `  - 入口：${buildMissingOpenIdUserManagementLocation()}`,
+    '- [ ] 目录同步可补齐 openId / 或确认仍缺失原因',
+    '  - 实际结果：',
+    `  - 入口：${buildDirectoryMissingOpenIdWorkbenchLocation()}`,
+    '- [ ] 批量关闭缺 OpenID 钉钉扫码后，待收口数量正确变化',
+    '  - 实际结果：',
+    '- [ ] 最近 7 天收口审计可看到时间、处理人和动作',
+    '  - 实际结果：',
+    `  - 入口：${buildRecentDingTalkGovernanceAuditLocation()}`,
+    '- [ ] 真实钉钉账号验证通过',
+    '  - 已修复成员：',
+    '  - 未修复成员：',
+    '',
+    '## 异常记录',
+    '- 账号 / 现象 / 初步判断：',
+    '- 日志或截图位置：',
+    '',
+    '## 执行后结论',
+    '- 是否可继续放量：',
+    '- 是否需要继续修复：',
+    '- 下一步负责人：',
+    '',
+    '## 当前建议',
+    ...governanceWorkbenchCards.value.map((card) => `- ${card.title}：${card.note}`),
+  ]
+  downloadText(
+    `dingtalk-governance-validation-result-template-${today}.md`,
+    lines.join('\n'),
+    'text/markdown;charset=utf-8',
+  )
+  setStatus('已导出 DingTalk 联调结果模板')
+}
+
+function exportGovernanceExecutionPackageIndex(): void {
+  const today = formatDateInput(new Date())
+  const dailySummaryFile = `dingtalk-governance-daily-summary-${today}.md`
+  const checklistFile = `dingtalk-governance-live-validation-checklist-${today}.md`
+  const resultTemplateFile = `dingtalk-governance-validation-result-template-${today}.md`
+  const lines = [
+    '# DingTalk 治理联调执行包索引',
+    '',
+    `日期：${today}`,
+    '',
+    '## 推荐执行顺序',
+    '1. 导出治理日报摘要',
+    `   - 文件：${dailySummaryFile}`,
+    '2. 导出联调检查单',
+    `   - 文件：${checklistFile}`,
+    '3. 执行真实联调',
+    `   - 缺 OpenID 成员入口：${buildMissingOpenIdUserManagementLocation()}`,
+    `   - 目录同步修复入口：${buildDirectoryMissingOpenIdWorkbenchLocation()}`,
+    `   - 最近 7 天收口审计：${buildRecentDingTalkGovernanceAuditLocation()}`,
+    '4. 导出联调结果模板',
+    `   - 文件：${resultTemplateFile}`,
+    '5. 回填并归档结果',
+    '   - 建议归档日报、检查单、结果模板和异常截图 / 日志位置。',
+    '',
+    '## 当前基线',
+    `- 缺 OpenID：${governanceSummary.value.dingtalkOpenIdMissing}`,
+    `- 待收口：${governanceSummary.value.dingtalkOpenIdPending}`,
+    `- 已收口：${governanceSummary.value.dingtalkOpenIdGoverned}`,
+    `- 目录已链接：${governanceSummary.value.directoryLinked}`,
+    '',
+    '## 导出文件清单',
+    `- ${dailySummaryFile}`,
+    `- ${checklistFile}`,
+    `- ${resultTemplateFile}`,
+    '',
+    '## 工作台入口',
+    ...governanceWorkbenchCards.value.map((card) => `- ${card.title}：${card.to}`),
+    '',
+    '## 当前建议',
+    ...governanceWorkbenchCards.value.map((card) => `- ${card.title}：${card.note}`),
+  ]
+  downloadText(
+    `dingtalk-governance-execution-package-index-${today}.md`,
+    lines.join('\n'),
+    'text/markdown;charset=utf-8',
+  )
+  setStatus('已导出 DingTalk 联调执行包索引')
+}
+
+function exportGovernanceFullValidationPackage(): void {
+  const today = formatDateInput(new Date())
+  const lines = [
+    '# DingTalk 治理完整联调包',
+    '',
+    `日期：${today}`,
+    '',
+    '## 包内目录',
+    '- 治理日报摘要',
+    '- 联调检查单',
+    '- 联调结果回填模板',
+    '- 工作台入口与当前建议',
+    '',
+    '## 当前基线',
+    `- 缺 OpenID：${governanceSummary.value.dingtalkOpenIdMissing}`,
+    `- 待收口：${governanceSummary.value.dingtalkOpenIdPending}`,
+    `- 已收口：${governanceSummary.value.dingtalkOpenIdGoverned}`,
+    `- 目录已链接：${governanceSummary.value.directoryLinked}`,
+    '',
+    '## 推荐执行顺序',
+    '1. 先看治理日报摘要，确认当天缺 OpenID、待收口、已收口数量。',
+    '2. 按联调检查单执行缺 OpenID 清单、目录同步修复、批量关闭和审计复盘。',
+    '3. 用真实钉钉账号验证已修复成员和未修复成员的登录结果。',
+    '4. 在结果回填模板中记录执行结论、异常和下一步负责人。',
+    '5. 归档本完整包以及必要的日志或截图位置。',
+    '',
+    '## 治理日报摘要',
+    `- 缺 OpenID：${governanceSummary.value.dingtalkOpenIdMissing}`,
+    `- 待收口：${governanceSummary.value.dingtalkOpenIdPending}`,
+    `- 已收口：${governanceSummary.value.dingtalkOpenIdGoverned}`,
+    `- 目录已链接：${governanceSummary.value.directoryLinked}`,
+    '',
+    '## 联调检查单',
+    '- [ ] 缺 OpenID 成员清单与预期一致',
+    `  - 入口：${buildMissingOpenIdUserManagementLocation()}`,
+    '- [ ] 目录同步页可用于补齐 openId 或确认仍缺失原因',
+    `  - 入口：${buildDirectoryMissingOpenIdWorkbenchLocation()}`,
+    '- [ ] 批量关闭缺 OpenID 钉钉扫码后，待收口和已收口统计变化正确',
+    '- [ ] 最近 7 天收口审计可看到动作、处理时间和处理人',
+    `  - 入口：${buildRecentDingTalkGovernanceAuditLocation()}`,
+    '- [ ] 真实钉钉账号验证通过',
+    '  - 已修复成员：',
+    '  - 未修复成员：',
+    '',
+    '## 联调结果回填模板',
+    '- 环境：142 / staging / other',
+    '- 执行人：',
+    '- 协同人：',
+    '- 执行时间：',
+    '- 实际结果：',
+    '- 异常记录：',
+    '- 是否可继续放量：',
+    '- 是否需要继续修复：',
+    '- 下一步负责人：',
+    '',
+    '## 工作台入口',
+    ...governanceWorkbenchCards.value.map((card) => `- ${card.title}：${card.to}`),
+    '',
+    '## 当前建议',
+    ...governanceWorkbenchCards.value.map((card) => `- ${card.title}：${card.note}`),
+  ]
+  downloadText(
+    `dingtalk-governance-full-validation-package-${today}.md`,
+    lines.join('\n'),
+    'text/markdown;charset=utf-8',
+  )
+  setStatus('已导出 DingTalk 完整联调包')
+}
+
+function buildDingTalkGovernanceAuditLocation(): string {
+  const params = new URLSearchParams({
+    resourceType: 'user-auth-grant',
+    action: 'revoke',
+  })
+  return `/admin/audit?${params.toString()}`
+}
+
+function buildMissingOpenIdUserManagementLocation(): string {
+  const params = new URLSearchParams({
+    filter: 'dingtalk-openid-missing',
+    source: 'dingtalk-governance',
+  })
+  return `/admin/users?${params.toString()}`
+}
+
+function buildDirectoryMissingOpenIdWorkbenchLocation(): string {
+  const params = new URLSearchParams({
+    source: 'dingtalk-governance',
+  })
+  return `/admin/directory?${params.toString()}`
+}
+
+function formatDateInput(date: Date): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+function buildRecentDingTalkGovernanceAuditLocation(): string {
+  const end = new Date()
+  const start = new Date(end)
+  start.setDate(start.getDate() - 6)
+  const params = new URLSearchParams({
+    resourceType: 'user-auth-grant',
+    action: 'revoke',
+    from: `${formatDateInput(start)}T00:00:00.000Z`,
+    to: `${formatDateInput(end)}T23:59:59.999Z`,
+  })
+  return `/admin/audit?${params.toString()}`
+}
+
+watch(userListFilter, (nextFilter) => {
+  if (userNavigation.value.filter === nextFilter) return
+  const nextNavigation: InitialUserNavigation = {
+    ...userNavigation.value,
+    filter: nextFilter,
+  }
+  userNavigation.value = nextNavigation
+  replaceUserNavigation(nextNavigation)
+})
+
 const namespaceOptions = computed(() => {
   const namespaces: string[] = []
   const append = (namespace: string): void => {
@@ -885,20 +1412,45 @@ const namespaceOptions = computed(() => {
   return namespaces
 })
 const userNavigation = ref(readInitialUserNavigation())
+const hasDirectorySyncNavigation = computed(() => userNavigation.value.source === 'directory-sync')
+const directoryReturnLocation = computed(() => buildDirectoryReturnLocation(userNavigation.value))
+const directoryNavigationTargetLabel = computed(() => {
+  const integrationId = userNavigation.value.integrationId.trim()
+  const accountId = userNavigation.value.accountId.trim()
+  if (!integrationId && !accountId) return ''
+  return `目标集成：${integrationId || '未指定'} · 目标成员：${accountId || '未指定'}`
+})
+const directoryNavigationNotice = computed(() => {
+  if (!hasDirectorySyncNavigation.value) return ''
+  const failureMessage = readDirectoryFailureMessage(userNavigation.value.directoryFailure)
+  if (failureMessage) {
+    return `从目录同步返回用户管理，但定位未完成：${failureMessage}。请确认目录集成或成员是否仍存在。`
+  }
+  return '已从目录同步返回用户管理，可继续查看用户授权、钉钉身份和 openId 治理状态。'
+})
 
 function setStatus(message: string, tone: 'info' | 'error' = 'info'): void {
   status.value = message
   statusTone.value = tone
 }
 
+function normalizeUserListFilter(value: string | null | undefined): UserListFilter {
+  const candidate = String(value || '').trim()
+  return USER_LIST_FILTER_VALUES.includes(candidate as UserListFilter) ? candidate as UserListFilter : 'all'
+}
+
 function readInitialUserNavigation(): InitialUserNavigation {
   if (typeof window === 'undefined') {
-    return { userId: '', source: '' }
+    return { userId: '', source: '', filter: 'all', integrationId: '', accountId: '', directoryFailure: '' }
   }
   const params = new URL(window.location.href).searchParams
   return {
     userId: params.get('userId')?.trim() || '',
     source: params.get('source')?.trim() || '',
+    filter: normalizeUserListFilter(params.get('filter')),
+    integrationId: params.get('integrationId')?.trim() || '',
+    accountId: params.get('accountId')?.trim() || '',
+    directoryFailure: params.get('directoryFailure')?.trim() || '',
   }
 }
 
@@ -906,6 +1458,10 @@ function buildUserNavigationKey(navigation: InitialUserNavigation): string {
   return [
     navigation.userId.trim(),
     navigation.source.trim(),
+    navigation.filter,
+    navigation.integrationId.trim(),
+    navigation.accountId.trim(),
+    navigation.directoryFailure.trim(),
   ].join('|')
 }
 
@@ -915,8 +1471,29 @@ function buildUserLocation(navigation: InitialUserNavigation): string {
   const params = new URLSearchParams()
   if (navigation.userId.trim().length > 0) params.set('userId', navigation.userId.trim())
   if (navigation.source.trim().length > 0) params.set('source', navigation.source.trim())
+  if (navigation.directoryFailure.trim().length > 0) params.set('directoryFailure', navigation.directoryFailure.trim())
+  if (navigation.integrationId.trim().length > 0) params.set('integrationId', navigation.integrationId.trim())
+  if (navigation.accountId.trim().length > 0) params.set('accountId', navigation.accountId.trim())
+  if (navigation.filter !== 'all') params.set('filter', navigation.filter)
   const search = params.toString()
   return `${url.pathname}${search ? `?${search}` : ''}${url.hash}`
+}
+
+function buildDirectoryReturnLocation(navigation: InitialUserNavigation): string {
+  if (navigation.source !== 'directory-sync') return ''
+  const params = new URLSearchParams()
+  if (navigation.integrationId.trim().length > 0) params.set('integrationId', navigation.integrationId.trim())
+  if (navigation.accountId.trim().length > 0) params.set('accountId', navigation.accountId.trim())
+  params.set('source', 'user-management')
+  if (navigation.userId.trim().length > 0) params.set('userId', navigation.userId.trim())
+  return `/admin/directory?${params.toString()}`
+}
+
+function readDirectoryFailureMessage(value: string): string {
+  if (value === 'missing_integration') return '未找到目标目录集成'
+  if (value === 'missing_account') return '未找到目标目录成员'
+  if (value.trim().length > 0) return value.trim()
+  return ''
 }
 
 function replaceUserNavigation(navigation: InitialUserNavigation): void {
@@ -929,6 +1506,7 @@ function syncUserNavigationFromLocation(): boolean {
   const currentKey = buildUserNavigationKey(userNavigation.value)
   const nextKey = buildUserNavigationKey(next)
   userNavigation.value = next
+  userListFilter.value = next.filter
   return currentKey !== nextKey
 }
 
@@ -999,6 +1577,39 @@ function readDingTalkServerStatus(accessValue: DingTalkAccess | null): string {
     return '服务端钉钉登录暂不可用'
   }
   return '服务端钉钉登录可用'
+}
+
+function canEnableDingTalkGrant(accessValue: DingTalkAccess | null): boolean {
+  if (!accessValue) return false
+  if (!accessValue.identity.exists) return true
+  if (!accessValue.server?.corpId) return true
+  return accessValue.identity.hasOpenId
+}
+
+function shouldWarnMissingDingTalkOpenId(accessValue: DingTalkAccess | null): boolean {
+  if (!accessValue?.identity.exists) return false
+  if (!accessValue.server?.corpId) return false
+  return !accessValue.identity.hasOpenId
+}
+
+function readPrimaryDingTalkDirectoryMembership(admissionValue: MemberAdmission | null): MemberDirectoryMembership | null {
+  const membership = admissionValue?.directoryMemberships.find((item) => item.provider === 'dingtalk')
+  return membership ?? null
+}
+
+function formatDirectorySyncAt(admissionValue: MemberAdmission | null): string {
+  const membership = readPrimaryDingTalkDirectoryMembership(admissionValue)
+  return formatDate(membership?.accountUpdatedAt)
+}
+
+function buildDirectoryManagementLocation(userId: string, membership: Pick<MemberDirectoryMembership, 'integrationId' | 'directoryAccountId'>): string {
+  const params = new URLSearchParams({
+    integrationId: membership.integrationId,
+    accountId: membership.directoryAccountId,
+    source: 'user-management',
+    userId,
+  })
+  return `/admin/directory?${params.toString()}`
 }
 
 function normalizeNamespaceAdmissions(value: unknown): NamespaceAdmission[] {
@@ -1073,7 +1684,15 @@ async function loadUsers(): Promise<void> {
           platformAdminEnabled: item.platformAdminEnabled ?? (item.role === 'admin' || item.is_admin),
           attendanceAdminEnabled: item.attendanceAdminEnabled ?? false,
           dingtalkLoginEnabled: item.dingtalkLoginEnabled ?? false,
+          dingtalkGrantUpdatedAt: item.dingtalkGrantUpdatedAt ?? null,
+          dingtalkGrantUpdatedBy: item.dingtalkGrantUpdatedBy ?? null,
           directoryLinked: item.directoryLinked ?? false,
+          dingtalkIdentityExists: item.dingtalkIdentityExists ?? false,
+          dingtalkHasUnionId: item.dingtalkHasUnionId ?? false,
+          dingtalkHasOpenId: item.dingtalkHasOpenId ?? false,
+          dingtalkOpenIdMissing: item.dingtalkOpenIdMissing ?? false,
+          dingtalkCorpId: item.dingtalkCorpId ?? null,
+          lastDirectorySyncAt: item.lastDirectorySyncAt ?? null,
           businessRoleCount: item.businessRoleCount ?? 0,
         }))
       : []
@@ -1351,6 +1970,10 @@ async function updateNamespaceAdmission(admission: NamespaceAdmission, enabled: 
 
 async function updateDingTalkGrant(enabled: boolean): Promise<void> {
   if (!access.value) return
+  if (enabled && !canEnableDingTalkGrant(dingtalkAccess.value)) {
+    setStatus('当前钉钉身份缺少 openId，暂不能开通钉钉扫码；请重新同步目录或让用户完成一次钉钉 OAuth 绑定。', 'error')
+    return
+  }
   busy.value = true
   try {
     const response = await apiFetch(`/api/admin/users/${encodeURIComponent(access.value.user.id)}/dingtalk-grant`, {
@@ -1405,6 +2028,42 @@ async function bulkUpdateDingTalkGrants(enabled: boolean): Promise<void> {
     setStatus(enabled ? `已批量开通 ${userIds.length} 个用户的钉钉扫码` : `已批量关闭 ${userIds.length} 个用户的钉钉扫码`)
   } catch (error) {
     setStatus(error instanceof Error ? error.message : '批量更新钉钉扫码失败', 'error')
+  } finally {
+    bulkBusy.value = false
+  }
+}
+
+async function bulkDisableMissingOpenIdDingTalkGrants(): Promise<void> {
+  const userIds = screeningUsersMissingOpenIdWithGrant.value.map((user) => user.id)
+  if (userIds.length === 0) {
+    setStatus('当前筛选结果中没有已开通钉钉扫码的缺 OpenID 用户', 'error')
+    return
+  }
+
+  bulkBusy.value = true
+  try {
+    const response = await apiFetch('/api/admin/users/dingtalk-grants/bulk', {
+      method: 'POST',
+      body: JSON.stringify({
+        userIds,
+        enabled: false,
+      }),
+    })
+    const payload = await readJson(response)
+    if (!response.ok || payload.ok !== true) {
+      throw new Error(String((payload.error as Record<string, unknown> | undefined)?.message || '批量关闭缺 OpenID 钉钉扫码失败'))
+    }
+
+    await loadUsers()
+    if (selectedUserId.value && userIds.includes(selectedUserId.value)) {
+      await Promise.all([
+        loadDingTalkAccess(selectedUserId.value),
+        loadMemberAdmission(selectedUserId.value),
+      ])
+    }
+    setStatus(`已批量关闭 ${userIds.length} 个缺 OpenID 用户的钉钉扫码`)
+  } catch (error) {
+    setStatus(error instanceof Error ? error.message : '批量关闭缺 OpenID 钉钉扫码失败', 'error')
   } finally {
     bulkBusy.value = false
   }
@@ -1958,6 +2617,10 @@ onUnmounted(() => {
   gap: 12px;
 }
 
+.user-admin__section-head--workbench {
+  margin-top: 4px;
+}
+
 .user-admin__panel--detail {
   gap: 16px;
 }
@@ -1968,6 +2631,12 @@ onUnmounted(() => {
   gap: 8px;
 }
 
+.user-admin__workbench {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
 .user-admin__metric {
   display: grid;
   gap: 4px;
@@ -1975,6 +2644,55 @@ onUnmounted(() => {
   border: 1px solid #e5e7eb;
   border-radius: 10px;
   background: #f8fafc;
+}
+
+.user-admin__metric-link {
+  color: inherit;
+  text-decoration: none;
+  transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.user-admin__metric-link:hover {
+  border-color: #93c5fd;
+  background: #eff6ff;
+}
+
+.user-admin__workbench-card {
+  display: grid;
+  gap: 6px;
+  padding: 12px 14px;
+  border: 1px solid #dbeafe;
+  border-radius: 12px;
+  background: linear-gradient(135deg, #f8fbff, #eff6ff);
+  color: inherit;
+  text-decoration: none;
+  transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.user-admin__workbench-card:hover {
+  border-color: #60a5fa;
+  transform: translateY(-1px);
+}
+
+.user-admin__workbench-card strong {
+  color: #111827;
+}
+
+.user-admin__workbench-card small,
+.user-admin__workbench-kicker {
+  color: #6b7280;
+}
+
+.user-admin__workbench-note {
+  color: #1d4ed8;
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.user-admin__workbench-kicker {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
 }
 
 .user-admin__metric strong {
@@ -2203,7 +2921,9 @@ onUnmounted(() => {
     grid-template-columns: 1fr;
   }
 
-  .user-admin__create-grid {
+  .user-admin__create-grid,
+  .user-admin__summary,
+  .user-admin__workbench {
     grid-template-columns: 1fr;
   }
 

--- a/apps/web/tests/ForcePasswordChangeView.spec.ts
+++ b/apps/web/tests/ForcePasswordChangeView.spec.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   loadProductFeatures: vi.fn().mockResolvedValue(undefined),
   resolveHomePath: vi.fn(() => '/attendance'),
   apiFetch: vi.fn(),
+  clearStoredAuthState: vi.fn(),
 }))
 
 vi.mock('vue-router', () => ({
@@ -26,7 +27,7 @@ vi.mock('../src/utils/api', async () => {
   return {
     ...actual,
     apiFetch: mocks.apiFetch,
-    clearStoredAuthState: vi.fn(),
+    clearStoredAuthState: mocks.clearStoredAuthState,
   }
 })
 
@@ -37,14 +38,55 @@ async function flushUi(cycles = 4): Promise<void> {
   }
 }
 
+function createMemoryStorage(): Storage {
+  const store = new Map<string, string>()
+  return {
+    get length() {
+      return store.size
+    },
+    clear: () => store.clear(),
+    getItem: (key: string) => store.get(key) ?? null,
+    key: (index: number) => Array.from(store.keys())[index] ?? null,
+    removeItem: (key: string) => {
+      store.delete(key)
+    },
+    setItem: (key: string, value: string) => {
+      store.set(key, String(value))
+    },
+  } as Storage
+}
+
+function installMemoryStorage(storage: Storage): void {
+  Object.defineProperty(globalThis, 'localStorage', { value: storage, configurable: true })
+  Object.defineProperty(window, 'localStorage', { value: storage, configurable: true })
+}
+
+function resetAuthStorage(): void {
+  const keys = [
+    'auth_token',
+    'jwt',
+    'devToken',
+    'metasheet_locale',
+    'metasheet_features',
+    'metasheet_product_mode',
+    'user_permissions',
+    'user_roles',
+  ]
+  for (const key of keys) {
+    window.localStorage.removeItem(key)
+  }
+}
+
 describe('ForcePasswordChangeView', () => {
   let app: VueApp<Element> | null = null
   let container: HTMLDivElement | null = null
   let ForcePasswordChangeViewComponent: Component
   const originalFetch = globalThis.fetch
+  const originalLocalStorage = globalThis.localStorage
 
   beforeEach(async () => {
-    window.localStorage.clear()
+    installMemoryStorage(createMemoryStorage())
+    resetAuthStorage()
     window.localStorage.setItem('auth_token', 'forced-token')
     window.localStorage.setItem('metasheet_locale', 'zh-CN')
     vi.clearAllMocks()
@@ -103,6 +145,7 @@ describe('ForcePasswordChangeView', () => {
     app = null
     container = null
     globalThis.fetch = originalFetch
+    installMemoryStorage(originalLocalStorage)
   })
 
   it('changes the password and redirects back to the resolved home path', async () => {
@@ -137,5 +180,31 @@ describe('ForcePasswordChangeView', () => {
     expect(window.localStorage.getItem('auth_token')).toBe('fresh-token')
     expect(mocks.loadProductFeatures).toHaveBeenCalledWith(true, { skipSessionProbe: true })
     expect(mocks.routerReplace).toHaveBeenCalledWith('/attendance')
+  })
+
+  it('allows signing out from the forced password change page', async () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+
+    app = createApp(ForcePasswordChangeViewComponent)
+    app.mount(container)
+    await flushUi(6)
+
+    const logoutButton = container.querySelector('.force-password-logout') as HTMLButtonElement | null
+    expect(logoutButton?.textContent).toContain('退出登录')
+
+    logoutButton?.click()
+    await flushUi(8)
+
+    expect(mocks.apiFetch).toHaveBeenCalledWith(
+      '/api/auth/logout',
+      expect.objectContaining({
+        method: 'POST',
+        suppressUnauthorizedRedirect: true,
+      }),
+    )
+    expect(window.localStorage.getItem('auth_token')).toBeNull()
+    expect(mocks.clearStoredAuthState).toHaveBeenCalled()
+    expect(mocks.routerReplace).toHaveBeenCalledWith('/login')
   })
 })

--- a/apps/web/tests/adminAuditView.spec.ts
+++ b/apps/web/tests/adminAuditView.spec.ts
@@ -33,7 +33,12 @@ function createJsonResponse(payload: unknown, status = 200) {
 function registerRouterLink(app: App<Element>): void {
   app.component('RouterLink', {
     props: ['to'],
-    template: '<a><slot /></a>',
+    computed: {
+      resolvedHref(): string {
+        return typeof this.to === 'string' ? this.to : String(this.to || '')
+      },
+    },
+    template: '<a :href="resolvedHref"><slot /></a>',
   })
 }
 
@@ -87,6 +92,8 @@ describe('AdminAuditView', () => {
   const originalRevokeObjectURL = globalThis.URL.revokeObjectURL
 
   beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-05T08:00:00.000Z'))
     apiFetchMock.mockReset()
     container = document.createElement('div')
     document.body.appendChild(container)
@@ -99,6 +106,8 @@ describe('AdminAuditView', () => {
     if (container) container.remove()
     app = null
     container = null
+    window.history.replaceState({}, '', '/')
+    vi.useRealTimers()
     globalThis.URL.createObjectURL = originalCreateObjectURL
     globalThis.URL.revokeObjectURL = originalRevokeObjectURL
   })
@@ -239,5 +248,97 @@ describe('AdminAuditView', () => {
     expect(options?.method).toBe('GET')
 
     expect(container?.textContent).toContain('审计日志 CSV 已导出')
+  })
+
+  it('prefills filters from the audit deep link query string', async () => {
+    window.history.replaceState({}, '', '/admin/audit?resourceType=user-auth-grant&action=revoke')
+    apiFetchMock.mockResolvedValueOnce(createJsonResponse(createListPayload([createLogItem({
+      action: 'revoke',
+      resource_type: 'user-auth-grant',
+      resource_id: 'user-2:dingtalk',
+    })], { total: 1 })))
+
+    app = createApp(AdminAuditView)
+    registerRouterLink(app)
+    app.mount(container!)
+    await flushUi()
+
+    const resourceSelect = container?.querySelectorAll('select')[0] as HTMLSelectElement
+    const actionSelect = container?.querySelectorAll('select')[1] as HTMLSelectElement
+    expect(resourceSelect.value).toBe('user-auth-grant')
+    expect(actionSelect.value).toBe('revoke')
+
+    const url = getLastFetchUrl()
+    expect(url).toContain('resourceType=user-auth-grant')
+    expect(url).toContain('action=revoke')
+    expect(container?.textContent).toContain('当前场景已应用')
+  })
+
+  it('applies the DingTalk governance scene card and syncs the URL', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse(createListPayload([createLogItem()], { total: 1 })))
+      .mockResolvedValueOnce(createJsonResponse(createListPayload([createLogItem({
+        action: 'revoke',
+        resource_type: 'user-auth-grant',
+        resource_id: 'user-3:dingtalk',
+      })], { total: 1 })))
+
+    app = createApp(AdminAuditView)
+    registerRouterLink(app)
+    app.mount(container!)
+    await flushUi()
+
+    const sceneButton = findButtonByText(container!, '打开钉钉治理审计')
+    expect(sceneButton).toBeTruthy()
+    sceneButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+
+    const resourceSelect = container?.querySelectorAll('select')[0] as HTMLSelectElement
+    const actionSelect = container?.querySelectorAll('select')[1] as HTMLSelectElement
+    expect(resourceSelect.value).toBe('user-auth-grant')
+    expect(actionSelect.value).toBe('revoke')
+
+    const url = getLastFetchUrl()
+    expect(url).toContain('resourceType=user-auth-grant')
+    expect(url).toContain('action=revoke')
+    expect(window.location.search).toBe('?resourceType=user-auth-grant&action=revoke')
+    expect(container?.textContent).toContain('当前场景已应用')
+  })
+
+  it('applies the recent DingTalk governance scene with a 7 day date range', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse(createListPayload([createLogItem()], { total: 1 })))
+      .mockResolvedValueOnce(createJsonResponse(createListPayload([createLogItem({
+        action: 'revoke',
+        resource_type: 'user-auth-grant',
+        resource_id: 'user-7:dingtalk',
+      })], { total: 1 })))
+
+    app = createApp(AdminAuditView)
+    registerRouterLink(app)
+    app.mount(container!)
+    await flushUi()
+
+    const sceneButton = findButtonByText(container!, '查看最近 7 天收口')
+    expect(sceneButton).toBeTruthy()
+    sceneButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+
+    const resourceSelect = container?.querySelectorAll('select')[0] as HTMLSelectElement
+    const actionSelect = container?.querySelectorAll('select')[1] as HTMLSelectElement
+    const dateInputs = container?.querySelectorAll('input[type="date"]') as NodeListOf<HTMLInputElement>
+    expect(resourceSelect.value).toBe('user-auth-grant')
+    expect(actionSelect.value).toBe('revoke')
+    expect(dateInputs[0]?.value).toBe('2026-04-29')
+    expect(dateInputs[1]?.value).toBe('2026-05-05')
+
+    const url = getLastFetchUrl()
+    expect(url).toContain('resourceType=user-auth-grant')
+    expect(url).toContain('action=revoke')
+    expect(url).toContain('from=2026-04-29T00%3A00%3A00.000Z')
+    expect(url).toContain('to=2026-05-05T23%3A59%3A59.999Z')
+    expect(window.location.search).toBe('?resourceType=user-auth-grant&action=revoke&from=2026-04-29T00%3A00%3A00.000Z&to=2026-05-05T23%3A59%3A59.999Z')
+    expect(container?.textContent).toContain('最近 7 天收口结果')
+    expect(container?.textContent).toContain('当前场景已应用')
   })
 })

--- a/apps/web/tests/directoryManagementView.spec.ts
+++ b/apps/web/tests/directoryManagementView.spec.ts
@@ -88,7 +88,7 @@ function createAccount(overrides: Record<string, unknown> = {}) {
     corpId: 'dingcorp',
     externalUserId: '0447654442691174',
     unionId: 'union-1',
-    openId: null,
+    openId: 'open-1',
     externalKey: 'union-1',
     name: '林岚',
     email: null,
@@ -340,7 +340,168 @@ describe('DirectoryManagementView', () => {
     expect(container?.textContent).toContain('最近告警')
     expect(container?.textContent).toContain('Union ID')
     expect(container?.textContent).toContain('0447654442691174')
+    expect(container?.textContent).toContain('最近目录同步')
     expect(container?.textContent).toContain('第 1 / 3 页')
+  })
+
+  it('warns and disables DingTalk grant toggles when a directory account is missing openId', async () => {
+    const missingOpenIdAccount = createAccount({
+      openId: null,
+      localUser: {
+        id: 'user-1',
+        email: 'alpha@example.com',
+        username: 'alpha',
+        name: 'Alpha',
+      },
+    })
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration()],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: { items: [] },
+      }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createScheduleSnapshotPayload(),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAlertListPayload([]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([
+          {
+            kind: 'pending_binding',
+            reason: '目录成员尚未绑定本地用户。',
+            account: missingOpenIdAccount,
+            flags: {
+              missingUnionId: false,
+              missingOpenId: true,
+            },
+            actionable: {
+              canBatchUnbind: false,
+              canConfirmRecommendation: true,
+            },
+          },
+        ]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([missingOpenIdAccount]),
+      ))
+
+    app = createApp(DirectoryManagementView)
+    registerRouterLink(app, true)
+    app.mount(container!)
+    await flushUi()
+
+    expect(container?.textContent).toContain('openId 缺失，当前无法同时开通钉钉登录')
+    expect(container?.textContent).toContain('修复建议：若该成员刚完成钉钉登录/绑定，先刷新当前成员')
+    const refreshButtons = Array.from(container!.querySelectorAll('button')).filter((button) => button.textContent?.includes('刷新当前成员'))
+    expect(refreshButtons.length).toBeGreaterThanOrEqual(2)
+    const userLinks = Array.from(container!.querySelectorAll('a')).filter((link) => link.textContent?.includes('前往用户管理'))
+    expect(userLinks.length).toBeGreaterThanOrEqual(1)
+    expect(userLinks[0]?.getAttribute('href')).toBe('/admin/users?userId=user-1&source=directory-sync&integrationId=dir-1&accountId=account-1&filter=dingtalk-openid-missing')
+    const grantLabels = Array.from(container!.querySelectorAll('label.directory-admin__toggle'))
+      .filter((label) => label.textContent?.includes('绑定后同时开通钉钉登录'))
+    expect(grantLabels.length).toBeGreaterThanOrEqual(2)
+    for (const label of grantLabels) {
+      const input = label.querySelector('input[type="checkbox"]') as HTMLInputElement | null
+      expect(input?.disabled).toBe(true)
+      expect(input?.checked).toBe(false)
+    }
+  })
+
+  it('binds an openId-missing account without enabling DingTalk grant', async () => {
+    const missingOpenIdAccount = createAccount({ openId: null })
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration()],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: { items: [] },
+      }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createScheduleSnapshotPayload(),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAlertListPayload([]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([missingOpenIdAccount]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          account: createAccount({
+            openId: null,
+            linkStatus: 'linked',
+            matchStrategy: 'manual_admin',
+            localUser: {
+              id: 'user-1',
+              email: 'alpha@example.com',
+              name: 'Alpha',
+            },
+          }),
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: { items: [createIntegration()] },
+      }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([createAccount({
+          openId: null,
+          linkStatus: 'linked',
+          matchStrategy: 'manual_admin',
+          localUser: {
+            id: 'user-1',
+            email: 'alpha@example.com',
+            name: 'Alpha',
+          },
+        })]),
+      ))
+
+    app = createApp(DirectoryManagementView)
+    registerRouterLink(app)
+    app.mount(container!)
+    await flushUi()
+
+    const accountsSection = findAccountsSection(container!)
+    const bindInput = accountsSection.querySelector('input[placeholder="例如 user-123 或 alpha@example.com"]') as HTMLInputElement | null
+    expect(bindInput).toBeTruthy()
+    bindInput!.value = 'alpha@example.com'
+    bindInput!.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi(2)
+
+    const bindButton = Array.from(accountsSection.querySelectorAll('button'))
+      .find((button) => button.textContent?.includes('绑定用户'))
+    expect(bindButton).toBeTruthy()
+    bindButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(10)
+
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      '/api/admin/directory/accounts/account-1/bind',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          localUserRef: 'alpha@example.com',
+          enableDingTalkGrant: false,
+        }),
+      }),
+    )
   })
 
   it('posts manual sync and refreshes the selected integration', async () => {

--- a/apps/web/tests/userManagementView.spec.ts
+++ b/apps/web/tests/userManagementView.spec.ts
@@ -99,7 +99,14 @@ type UserFixture = {
   role: string
   is_active: boolean
   grantEnabled: boolean
+  dingtalkGrantUpdatedAt?: string | null
+  dingtalkGrantUpdatedBy?: string | null
   directoryLinked: boolean
+  dingtalkIdentityExists?: boolean
+  hasOpenId: boolean
+  hasUnionId: boolean
+  dingtalkCorpId?: string | null
+  lastDirectorySyncAt?: string | null
   namespaceAdmissions: Array<{
     namespace: string
     enabled: boolean
@@ -120,7 +127,14 @@ function createApiState(): UserFixture[] {
       role: 'user',
       is_active: true,
       grantEnabled: true,
+      dingtalkGrantUpdatedAt: '2026-04-09T00:00:00.000Z',
+      dingtalkGrantUpdatedBy: 'Admin One',
       directoryLinked: true,
+      dingtalkIdentityExists: true,
+      hasOpenId: true,
+      hasUnionId: true,
+      dingtalkCorpId: 'dingcorp',
+      lastDirectorySyncAt: '2026-04-09T00:00:00.000Z',
       namespaceAdmissions: [
         {
           namespace: 'crm',
@@ -140,7 +154,14 @@ function createApiState(): UserFixture[] {
       role: 'user',
       is_active: true,
       grantEnabled: false,
+      dingtalkGrantUpdatedAt: '2026-04-09T00:00:00.000Z',
+      dingtalkGrantUpdatedBy: 'Admin One',
       directoryLinked: false,
+      dingtalkIdentityExists: true,
+      hasOpenId: true,
+      hasUnionId: true,
+      dingtalkCorpId: 'dingcorp',
+      lastDirectorySyncAt: null,
       namespaceAdmissions: [
         {
           namespace: 'crm',
@@ -160,7 +181,14 @@ function createApiState(): UserFixture[] {
       role: 'user',
       is_active: false,
       grantEnabled: true,
+      dingtalkGrantUpdatedAt: '2026-04-09T00:00:00.000Z',
+      dingtalkGrantUpdatedBy: 'Admin One',
       directoryLinked: false,
+      dingtalkIdentityExists: true,
+      hasOpenId: true,
+      hasUnionId: true,
+      dingtalkCorpId: 'dingcorp',
+      lastDirectorySyncAt: null,
       namespaceAdmissions: [
         {
           namespace: 'crm',
@@ -180,7 +208,14 @@ function createApiState(): UserFixture[] {
       role: 'admin',
       is_active: true,
       grantEnabled: false,
+      dingtalkGrantUpdatedAt: '2026-04-09T00:00:00.000Z',
+      dingtalkGrantUpdatedBy: 'Admin One',
       directoryLinked: false,
+      dingtalkIdentityExists: true,
+      hasOpenId: true,
+      hasUnionId: true,
+      dingtalkCorpId: 'dingcorp',
+      lastDirectorySyncAt: null,
       namespaceAdmissions: [
         {
           namespace: 'crm',
@@ -230,7 +265,15 @@ function createApiImplementation(
       platformAdminEnabled: user.role === 'admin',
       attendanceAdminEnabled: false,
       dingtalkLoginEnabled: user.grantEnabled,
+      dingtalkGrantUpdatedAt: user.dingtalkGrantUpdatedAt ?? '2026-04-09T00:00:00.000Z',
+      dingtalkGrantUpdatedBy: user.dingtalkGrantUpdatedBy ?? 'Admin One',
       directoryLinked: user.directoryLinked,
+      dingtalkIdentityExists: user.dingtalkIdentityExists !== false,
+      dingtalkHasUnionId: user.hasUnionId,
+      dingtalkHasOpenId: user.hasOpenId,
+      dingtalkOpenIdMissing: (user.dingtalkIdentityExists !== false) && Boolean((user.dingtalkCorpId ?? 'dingcorp')) && !user.hasOpenId,
+      dingtalkCorpId: user.dingtalkCorpId ?? 'dingcorp',
+      lastDirectorySyncAt: user.lastDirectorySyncAt ?? null,
       businessRoleCount: 1,
     })
 
@@ -264,6 +307,10 @@ function createApiImplementation(
       identity: {
         exists: true,
         corpId: 'dingcorp',
+        unionId: user.hasUnionId ? `${user.id}-union` : null,
+        openId: user.hasOpenId ? `${user.id}-open` : null,
+        hasUnionId: user.hasUnionId,
+        hasOpenId: user.hasOpenId,
         lastLoginAt: '2026-04-09T00:00:00.000Z',
         createdAt: '2026-04-09T00:00:00.000Z',
         updatedAt: '2026-04-09T00:00:00.000Z',
@@ -403,6 +450,8 @@ function createApiImplementation(
       for (const user of state) {
         if (userIds.includes(user.id)) {
           user.grantEnabled = enabled
+          user.dingtalkGrantUpdatedAt = '2026-04-10T00:00:00.000Z'
+          user.dingtalkGrantUpdatedBy = 'Admin One'
         }
       }
       return createJsonResponse({
@@ -411,6 +460,18 @@ function createApiImplementation(
           userIds,
           enabled,
         },
+      })
+    }
+
+    const dingtalkGrantMatch = pathname.match(/^\/api\/admin\/users\/([^/]+)\/dingtalk-grant$/)
+    if (dingtalkGrantMatch) {
+      const user = findUserById(decodeURIComponent(dingtalkGrantMatch[1]))
+      const rawBody = typeof init?.body === 'string' ? init.body : ''
+      const parsed = rawBody ? JSON.parse(rawBody) as { enabled?: unknown } : {}
+      user.grantEnabled = parsed.enabled === true
+      return createJsonResponse({
+        ok: true,
+        data: buildDingTalkAccessPayload(user),
       })
     }
 
@@ -543,11 +604,35 @@ describe('UserManagementView', () => {
   let app: App<Element> | null = null
   let container: HTMLDivElement | null = null
   let callLog: string[] = []
+  const OriginalBlob = Blob
+  const originalCreateObjectURL = URL.createObjectURL
+  const originalRevokeObjectURL = URL.revokeObjectURL
+  let createObjectURLMock: ReturnType<typeof vi.fn>
+  let revokeObjectURLMock: ReturnType<typeof vi.fn>
+  let clickedAnchors: Array<{ href: string; download: string }> = []
+  let createdBlobParts: string[] = []
 
   beforeEach(() => {
     apiFetchMock.mockReset()
     callLog = []
     apiFetchMock.mockImplementation(createApiImplementation(callLog))
+    createObjectURLMock = vi.fn(() => 'blob:user-management-export')
+    revokeObjectURLMock = vi.fn()
+    clickedAnchors = []
+    createdBlobParts = []
+    globalThis.Blob = class TestBlob extends OriginalBlob {
+      constructor(parts?: BlobPart[], options?: BlobPropertyBag) {
+        createdBlobParts = Array.isArray(parts) ? parts.map((part) => String(part)) : []
+        super(parts, options)
+      }
+    } as typeof Blob
+    Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: createObjectURLMock })
+    Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: revokeObjectURLMock })
+    const originalClick = HTMLAnchorElement.prototype.click
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function click(this: HTMLAnchorElement) {
+      clickedAnchors.push({ href: this.href, download: this.download })
+      return originalClick.call(this)
+    })
     container = document.createElement('div')
     document.body.appendChild(container)
   })
@@ -558,6 +643,10 @@ describe('UserManagementView', () => {
     window.history.replaceState({}, '', '/')
     app = null
     container = null
+    vi.restoreAllMocks()
+    globalThis.Blob = OriginalBlob
+    Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: originalCreateObjectURL })
+    Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: originalRevokeObjectURL })
   })
 
   it('distinguishes DingTalk login from plugin usage and can open namespace admission', async () => {
@@ -574,6 +663,10 @@ describe('UserManagementView', () => {
     expect(container?.textContent).toContain('服务端已启用钉钉登录')
     expect(container?.textContent).toContain('服务端钉钉登录可用')
     expect(container?.textContent).toContain('允许企业：dingcorp、dingcorp-2')
+    expect(container?.textContent).toContain('身份 corpId：dingcorp')
+    expect(container?.textContent).toContain('Union ID：user-1-union')
+    expect(container?.textContent).toContain('Open ID：user-1-open')
+    expect(container?.textContent).toContain('最近目录同步：')
     expect(container?.textContent).toContain('已开通钉钉扫码')
     expect(container?.textContent).toContain('插件使用未开通')
     expect(container?.textContent).toContain('当前不可用')
@@ -666,6 +759,451 @@ describe('UserManagementView', () => {
     await flushUi()
     expect(container?.textContent).toContain('已批量关闭 4 个用户的钉钉扫码')
     expect(container?.textContent).toContain('未开通钉钉登录')
+  })
+
+  it('warns and disables enabling DingTalk grant when the identity is missing openId', async () => {
+    const state = createApiState()
+    state[1].hasOpenId = false
+    state[1].directoryLinked = true
+    state[1].lastDirectorySyncAt = '2026-04-10T00:00:00.000Z'
+    app = createApp(UserManagementView)
+    registerRouterLink(app, true)
+    apiFetchMock.mockImplementation(createApiImplementation(callLog, state))
+    app.mount(container!)
+    await flushUi(20)
+
+    const bravoRow = findUserRow(container!, 'Bravo')
+    const bravoDetailButton = Array.from(bravoRow.querySelectorAll('button')).find((candidate) => candidate.textContent?.includes('Bravo'))
+    if (!(bravoDetailButton instanceof HTMLButtonElement)) {
+      throw new Error('Bravo detail button not found')
+    }
+    bravoDetailButton.click()
+    await waitForCondition(() => callLog.includes('/api/admin/users/user-2/dingtalk-access'))
+
+    expect(container?.textContent).toContain('当前钉钉身份缺少 openId')
+    expect(container?.textContent).toContain('Union ID：user-2-union')
+    expect(container?.textContent).toContain('Open ID：未记录')
+    expect(container?.textContent).toContain('最近目录同步：')
+    expect(container?.textContent).toContain('修复建议：先回到目录同步查看该成员是否已补齐 openId')
+    const enableButton = findButtonByText(container!, '开通钉钉扫码')
+    expect(enableButton.disabled).toBe(true)
+    const directoryLink = Array.from(container!.querySelectorAll('a')).find((candidate) => candidate.textContent?.includes('前往目录成员'))
+    expect(directoryLink?.getAttribute('href')).toBe('/admin/directory?integrationId=ding-1&accountId=user-2-directory&source=user-management&userId=user-2')
+    expect(apiFetchMock.mock.calls.some((args) => String(args[0]) === '/api/admin/users/user-2/dingtalk-grant')).toBe(false)
+  })
+
+  it('filters the list to users missing DingTalk openId', async () => {
+    const state = createApiState()
+    state[1].hasOpenId = false
+    state[1].directoryLinked = true
+    state[1].lastDirectorySyncAt = '2026-04-10T00:00:00.000Z'
+    app = createApp(UserManagementView)
+    registerRouterLink(app)
+    apiFetchMock.mockImplementation(createApiImplementation(callLog, state))
+    app.mount(container!)
+    await flushUi(20)
+
+    expect(container?.textContent).toContain('缺 OpenID')
+    const filterButton = findButtonByText(container!, '缺 OpenID')
+    filterButton.click()
+    await flushUi()
+
+    const userRows = Array.from(container!.querySelectorAll('.user-admin__user')).map((row) => row.textContent || '')
+    expect(userRows.some((text) => text.includes('Bravo'))).toBe(true)
+    expect(userRows.some((text) => text.includes('Alpha'))).toBe(false)
+    expect(container?.textContent).toContain('corpId dingcorp')
+    expect(container?.textContent).toContain('最近目录同步')
+  })
+
+  it('exports the current missing-openid screening list as CSV', async () => {
+    const state = createApiState()
+    state[1].hasOpenId = false
+    state[1].directoryLinked = true
+    state[1].lastDirectorySyncAt = '2026-04-10T00:00:00.000Z'
+    app = createApp(UserManagementView)
+    registerRouterLink(app)
+    apiFetchMock.mockImplementation(createApiImplementation(callLog, state))
+    app.mount(container!)
+    await flushUi(20)
+
+    const exportButton = findButtonByText(container!, '导出缺 OpenID 清单')
+    expect(exportButton.disabled).toBe(false)
+    exportButton.click()
+    await flushUi()
+
+    expect(createObjectURLMock).toHaveBeenCalledTimes(1)
+    const exportedBlob = createObjectURLMock.mock.calls[0]?.[0] as Blob
+    expect(exportedBlob).toBeInstanceOf(Blob)
+    const exportedText = createdBlobParts.join('')
+    expect(exportedText).toContain('userId,name,account,role,dingtalkCorpId,directoryLinked,lastDirectorySyncAt')
+    expect(exportedText).toContain('user-2,Bravo,bravo@example.com,user,dingcorp,linked,2026-04-10T00:00:00.000Z')
+    expect(clickedAnchors[0]?.download).toContain('dingtalk-missing-openid-users-')
+    expect(container?.textContent).toContain('已导出 1 个缺 OpenID 用户的治理清单')
+    expect(revokeObjectURLMock).toHaveBeenCalledWith('blob:user-management-export')
+  })
+
+  it('exports the governance daily summary with counts, suggestions, and workbench links', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-05T08:00:00.000Z'))
+    try {
+      const state = createApiState()
+      state[1].hasOpenId = false
+      state[1].directoryLinked = true
+      state[1].grantEnabled = false
+      state[1].dingtalkGrantUpdatedAt = '2026-05-04T08:00:00.000Z'
+      app = createApp(UserManagementView)
+      registerRouterLink(app, true)
+      apiFetchMock.mockImplementation(createApiImplementation(callLog, state))
+      app.mount(container!)
+      await flushUi(20)
+
+      const exportButton = findButtonByText(container!, '导出治理日报摘要')
+      exportButton.click()
+      await flushUi()
+
+      expect(createObjectURLMock).toHaveBeenCalledTimes(1)
+      const exportedText = createdBlobParts.join('')
+      expect(exportedText).toContain('# DingTalk 治理日报摘要')
+      expect(exportedText).toContain('日期：2026-05-05')
+      expect(exportedText).toContain('- 缺 OpenID：1')
+      expect(exportedText).toContain('- 待收口：0')
+      expect(exportedText).toContain('- 已收口：1')
+      expect(exportedText).toContain('缺 OpenID 成员：当前没有待收口成员需要优先处理')
+      expect(exportedText).toContain('目录同步修复入口：1 个成员可先回目录同步继续补齐 openId')
+      expect(exportedText).toContain('最近 7 天收口审计：最近 7 天已收口 1 个成员，可直接复盘处理动作')
+      expect(exportedText).toContain('/admin/users?filter=dingtalk-openid-missing&source=dingtalk-governance')
+      expect(exportedText).toContain('/admin/directory?source=dingtalk-governance')
+      expect(exportedText).toContain('/admin/audit?resourceType=user-auth-grant&action=revoke&from=2026-04-29T00%3A00%3A00.000Z&to=2026-05-05T23%3A59%3A59.999Z')
+      expect(clickedAnchors[0]?.download).toBe('dingtalk-governance-daily-summary-2026-05-05.md')
+      expect(container?.textContent).toContain('已导出 DingTalk 治理日报摘要')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('exports the live validation checklist with baseline, steps, and workbench links', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-05T08:00:00.000Z'))
+    try {
+      const state = createApiState()
+      state[1].hasOpenId = false
+      state[1].directoryLinked = true
+      state[1].grantEnabled = false
+      state[1].dingtalkGrantUpdatedAt = '2026-05-04T08:00:00.000Z'
+      app = createApp(UserManagementView)
+      registerRouterLink(app, true)
+      apiFetchMock.mockImplementation(createApiImplementation(callLog, state))
+      app.mount(container!)
+      await flushUi(20)
+
+      const exportButton = findButtonByText(container!, '导出联调检查单')
+      exportButton.click()
+      await flushUi()
+
+      expect(createObjectURLMock).toHaveBeenCalledTimes(1)
+      const exportedText = createdBlobParts.join('')
+      expect(exportedText).toContain('# DingTalk 治理联调检查单')
+      expect(exportedText).toContain('日期：2026-05-05')
+      expect(exportedText).toContain('- 缺 OpenID：1')
+      expect(exportedText).toContain('- 待收口：0')
+      expect(exportedText).toContain('- 已收口：1')
+      expect(exportedText).toContain('## 联调步骤')
+      expect(exportedText).toContain('打开缺 OpenID 成员清单')
+      expect(exportedText).toContain('跳到目录同步页，刷新目录成员并确认是否补齐 openId')
+      expect(exportedText).toContain('打开最近 7 天收口审计')
+      expect(exportedText).toContain('/admin/users?filter=dingtalk-openid-missing&source=dingtalk-governance')
+      expect(exportedText).toContain('/admin/directory?source=dingtalk-governance')
+      expect(exportedText).toContain('/admin/audit?resourceType=user-auth-grant&action=revoke&from=2026-04-29T00%3A00%3A00.000Z&to=2026-05-05T23%3A59%3A59.999Z')
+      expect(clickedAnchors[0]?.download).toBe('dingtalk-governance-live-validation-checklist-2026-05-05.md')
+      expect(container?.textContent).toContain('已导出 DingTalk 联调检查单')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('exports the validation result template with baseline, fill-in sections, and workbench links', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-05T08:00:00.000Z'))
+    try {
+      const state = createApiState()
+      state[1].hasOpenId = false
+      state[1].directoryLinked = true
+      state[1].grantEnabled = false
+      state[1].dingtalkGrantUpdatedAt = '2026-05-04T08:00:00.000Z'
+      app = createApp(UserManagementView)
+      registerRouterLink(app, true)
+      apiFetchMock.mockImplementation(createApiImplementation(callLog, state))
+      app.mount(container!)
+      await flushUi(20)
+
+      const exportButton = findButtonByText(container!, '导出联调结果模板')
+      exportButton.click()
+      await flushUi()
+
+      expect(createObjectURLMock).toHaveBeenCalledTimes(1)
+      const exportedText = createdBlobParts.join('')
+      expect(exportedText).toContain('# DingTalk 治理联调结果回填模板')
+      expect(exportedText).toContain('日期：2026-05-05')
+      expect(exportedText).toContain('## 联调环境')
+      expect(exportedText).toContain('- 缺 OpenID：1')
+      expect(exportedText).toContain('- 待收口：0')
+      expect(exportedText).toContain('- 已收口：1')
+      expect(exportedText).toContain('## 结果回填')
+      expect(exportedText).toContain('缺 OpenID 成员清单与预期一致')
+      expect(exportedText).toContain('目录同步可补齐 openId / 或确认仍缺失原因')
+      expect(exportedText).toContain('最近 7 天收口审计可看到时间、处理人和动作')
+      expect(exportedText).toContain('## 执行后结论')
+      expect(exportedText).toContain('/admin/users?filter=dingtalk-openid-missing&source=dingtalk-governance')
+      expect(exportedText).toContain('/admin/directory?source=dingtalk-governance')
+      expect(exportedText).toContain('/admin/audit?resourceType=user-auth-grant&action=revoke&from=2026-04-29T00%3A00%3A00.000Z&to=2026-05-05T23%3A59%3A59.999Z')
+      expect(clickedAnchors[0]?.download).toBe('dingtalk-governance-validation-result-template-2026-05-05.md')
+      expect(container?.textContent).toContain('已导出 DingTalk 联调结果模板')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('exports the governance execution package index with ordered artifacts and workbench links', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-05T08:00:00.000Z'))
+    try {
+      const state = createApiState()
+      state[1].hasOpenId = false
+      state[1].directoryLinked = true
+      state[1].grantEnabled = false
+      state[1].dingtalkGrantUpdatedAt = '2026-05-04T08:00:00.000Z'
+      app = createApp(UserManagementView)
+      registerRouterLink(app, true)
+      apiFetchMock.mockImplementation(createApiImplementation(callLog, state))
+      app.mount(container!)
+      await flushUi(20)
+
+      const exportButton = findButtonByText(container!, '导出联调执行包索引')
+      exportButton.click()
+      await flushUi()
+
+      expect(createObjectURLMock).toHaveBeenCalledTimes(1)
+      const exportedText = createdBlobParts.join('')
+      expect(exportedText).toContain('# DingTalk 治理联调执行包索引')
+      expect(exportedText).toContain('日期：2026-05-05')
+      expect(exportedText).toContain('## 推荐执行顺序')
+      expect(exportedText).toContain('1. 导出治理日报摘要')
+      expect(exportedText).toContain('2. 导出联调检查单')
+      expect(exportedText).toContain('3. 执行真实联调')
+      expect(exportedText).toContain('4. 导出联调结果模板')
+      expect(exportedText).toContain('5. 回填并归档结果')
+      expect(exportedText).toContain('dingtalk-governance-daily-summary-2026-05-05.md')
+      expect(exportedText).toContain('dingtalk-governance-live-validation-checklist-2026-05-05.md')
+      expect(exportedText).toContain('dingtalk-governance-validation-result-template-2026-05-05.md')
+      expect(exportedText).toContain('/admin/users?filter=dingtalk-openid-missing&source=dingtalk-governance')
+      expect(exportedText).toContain('/admin/directory?source=dingtalk-governance')
+      expect(exportedText).toContain('/admin/audit?resourceType=user-auth-grant&action=revoke&from=2026-04-29T00%3A00%3A00.000Z&to=2026-05-05T23%3A59%3A59.999Z')
+      expect(clickedAnchors[0]?.download).toBe('dingtalk-governance-execution-package-index-2026-05-05.md')
+      expect(container?.textContent).toContain('已导出 DingTalk 联调执行包索引')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('exports the full governance validation package as one markdown handoff file', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-05T08:00:00.000Z'))
+    try {
+      const state = createApiState()
+      state[1].hasOpenId = false
+      state[1].directoryLinked = true
+      state[1].grantEnabled = false
+      state[1].dingtalkGrantUpdatedAt = '2026-05-04T08:00:00.000Z'
+      app = createApp(UserManagementView)
+      registerRouterLink(app, true)
+      apiFetchMock.mockImplementation(createApiImplementation(callLog, state))
+      app.mount(container!)
+      await flushUi(20)
+
+      const exportButton = findButtonByText(container!, '导出完整联调包')
+      exportButton.click()
+      await flushUi()
+
+      expect(createObjectURLMock).toHaveBeenCalledTimes(1)
+      const exportedText = createdBlobParts.join('')
+      expect(exportedText).toContain('# DingTalk 治理完整联调包')
+      expect(exportedText).toContain('日期：2026-05-05')
+      expect(exportedText).toContain('## 包内目录')
+      expect(exportedText).toContain('## 当前基线')
+      expect(exportedText).toContain('- 缺 OpenID：1')
+      expect(exportedText).toContain('- 待收口：0')
+      expect(exportedText).toContain('- 已收口：1')
+      expect(exportedText).toContain('## 推荐执行顺序')
+      expect(exportedText).toContain('## 治理日报摘要')
+      expect(exportedText).toContain('## 联调检查单')
+      expect(exportedText).toContain('## 联调结果回填模板')
+      expect(exportedText).toContain('/admin/users?filter=dingtalk-openid-missing&source=dingtalk-governance')
+      expect(exportedText).toContain('/admin/directory?source=dingtalk-governance')
+      expect(exportedText).toContain('/admin/audit?resourceType=user-auth-grant&action=revoke&from=2026-04-29T00%3A00%3A00.000Z&to=2026-05-05T23%3A59%3A59.999Z')
+      expect(clickedAnchors[0]?.download).toBe('dingtalk-governance-full-validation-package-2026-05-05.md')
+      expect(container?.textContent).toContain('已导出 DingTalk 完整联调包')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('links the screening view to the DingTalk governance audit shortcut', async () => {
+    const state = createApiState()
+    state[1].hasOpenId = false
+    app = createApp(UserManagementView)
+    registerRouterLink(app, true)
+    apiFetchMock.mockImplementation(createApiImplementation(callLog, state))
+    app.mount(container!)
+    await flushUi(20)
+
+    const auditLink = Array.from(container!.querySelectorAll('a')).find((candidate) => candidate.textContent?.includes('查看钉钉治理审计'))
+    expect(auditLink?.getAttribute('href')).toBe('/admin/audit?resourceType=user-auth-grant&action=revoke')
+  })
+
+  it('shows a governance workbench with fixed quick links', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-05T08:00:00.000Z'))
+    try {
+      const state = createApiState()
+      state[1].hasOpenId = false
+      state[1].directoryLinked = true
+      state[1].grantEnabled = false
+      state[1].dingtalkGrantUpdatedAt = '2026-05-04T08:00:00.000Z'
+      app = createApp(UserManagementView)
+      registerRouterLink(app, true)
+      apiFetchMock.mockImplementation(createApiImplementation(callLog, state))
+      app.mount(container!)
+      await flushUi(20)
+
+      const missingUsersLink = Array.from(container!.querySelectorAll('a')).find((candidate) => candidate.textContent?.includes('缺 OpenID 成员'))
+      const directoryLink = Array.from(container!.querySelectorAll('a')).find((candidate) => candidate.textContent?.includes('目录同步修复入口'))
+      const recentAuditLink = Array.from(container!.querySelectorAll('a')).find((candidate) => candidate.textContent?.includes('最近 7 天收口审计'))
+
+      expect(missingUsersLink?.getAttribute('href')).toBe('/admin/users?filter=dingtalk-openid-missing&source=dingtalk-governance')
+      expect(directoryLink?.getAttribute('href')).toBe('/admin/directory?source=dingtalk-governance')
+      expect(recentAuditLink?.getAttribute('href')).toBe('/admin/audit?resourceType=user-auth-grant&action=revoke&from=2026-04-29T00%3A00%3A00.000Z&to=2026-05-05T23%3A59%3A59.999Z')
+      expect(container?.textContent).toContain('当前没有待收口成员需要优先处理')
+      expect(container?.textContent).toContain('1 个成员可先回目录同步继续补齐 openId')
+      expect(container?.textContent).toContain('最近 7 天已收口 1 个成员，可直接复盘处理动作')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('links the pending governance summary metric to the DingTalk governance audit shortcut', async () => {
+    const state = createApiState()
+    state[1].hasOpenId = false
+    app = createApp(UserManagementView)
+    registerRouterLink(app, true)
+    apiFetchMock.mockImplementation(createApiImplementation(callLog, state))
+    app.mount(container!)
+    await flushUi(20)
+
+    const pendingLink = Array.from(container!.querySelectorAll('a')).find((candidate) => candidate.textContent?.includes('待收口'))
+    expect(pendingLink?.getAttribute('href')).toBe('/admin/audit?resourceType=user-auth-grant&action=revoke')
+  })
+
+  it('links the missing-openid summary metric to a shareable filtered user-management view', async () => {
+    const state = createApiState()
+    state[1].hasOpenId = false
+    app = createApp(UserManagementView)
+    registerRouterLink(app, true)
+    apiFetchMock.mockImplementation(createApiImplementation(callLog, state))
+    app.mount(container!)
+    await flushUi(20)
+
+    const missingLink = Array.from(container!.querySelectorAll('a')).find((candidate) => candidate.textContent?.includes('缺 OpenID'))
+    expect(missingLink?.getAttribute('href')).toBe('/admin/users?filter=dingtalk-openid-missing&source=dingtalk-governance')
+  })
+
+  it('links the governed summary metric to the recent 7 day DingTalk governance audit shortcut', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-05T08:00:00.000Z'))
+    try {
+      const state = createApiState()
+      state[1].hasOpenId = false
+      state[1].grantEnabled = false
+      app = createApp(UserManagementView)
+      registerRouterLink(app, true)
+      apiFetchMock.mockImplementation(createApiImplementation(callLog, state))
+      app.mount(container!)
+      await flushUi(20)
+
+      const governedLink = Array.from(container!.querySelectorAll('a')).find((candidate) => candidate.textContent?.includes('已收口'))
+      expect(governedLink?.getAttribute('href')).toBe('/admin/audit?resourceType=user-auth-grant&action=revoke&from=2026-04-29T00%3A00%3A00.000Z&to=2026-05-05T23%3A59%3A59.999Z')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('applies the missing-openid filter from a deep link on first load', async () => {
+    window.history.replaceState({}, '', '/admin/users?filter=dingtalk-openid-missing&source=dingtalk-governance')
+    const state = createApiState()
+    state[1].hasOpenId = false
+    app = createApp(UserManagementView)
+    registerRouterLink(app, true)
+    apiFetchMock.mockImplementation(createApiImplementation(callLog, state))
+    app.mount(container!)
+    await flushUi(20)
+
+    const rows = Array.from(container!.querySelectorAll('.user-admin__user'))
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.textContent).toContain('Bravo')
+  })
+
+  it('syncs the missing-openid filter back to the URL when selected in-page', async () => {
+    const state = createApiState()
+    state[1].hasOpenId = false
+    app = createApp(UserManagementView)
+    registerRouterLink(app, true)
+    apiFetchMock.mockImplementation(createApiImplementation(callLog, state))
+    app.mount(container!)
+    await flushUi(20)
+
+    findButtonByText(container!, '缺 OpenID').click()
+    await flushUi()
+
+    expect(window.location.search).toBe('?filter=dingtalk-openid-missing')
+    const rows = Array.from(container!.querySelectorAll('.user-admin__user'))
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.textContent).toContain('Bravo')
+  })
+
+  it('bulk disables dingtalk grant for the current missing-openid screening list', async () => {
+    const state = createApiState()
+    state[1].hasOpenId = false
+    state[1].directoryLinked = true
+    state[1].grantEnabled = true
+    state[1].lastDirectorySyncAt = '2026-04-10T00:00:00.000Z'
+    app = createApp(UserManagementView)
+    registerRouterLink(app)
+    apiFetchMock.mockImplementation(createApiImplementation(callLog, state))
+    app.mount(container!)
+    await flushUi(20)
+
+    expect(container?.textContent).toContain('1缺 OpenID')
+    expect(container?.textContent).toContain('0已收口')
+    expect(container?.textContent).toContain('1待收口')
+
+    findButtonByText(container!, '缺 OpenID').click()
+    await flushUi()
+
+    const actionButton = findButtonByText(container!, '批量关闭缺 OpenID 钉钉扫码')
+    expect(actionButton.disabled).toBe(false)
+    actionButton.click()
+    await waitForCondition(() => apiFetchMock.mock.calls.filter((args) => String(args[0]) === '/api/admin/users/dingtalk-grants/bulk').length >= 1)
+
+    const bulkCall = apiFetchMock.mock.calls.find((args) => String(args[0]) === '/api/admin/users/dingtalk-grants/bulk')
+    expect(JSON.parse(String((bulkCall?.[1] as RequestInit | undefined)?.body))).toEqual({
+      userIds: ['user-2'],
+      enabled: false,
+    })
+    await flushUi()
+    expect(container?.textContent).toContain('已批量关闭 1 个缺 OpenID 用户的钉钉扫码')
+    expect(container?.textContent).toContain('最近关闭钉钉扫码')
+    expect(container?.textContent).toContain('处理人 Admin One')
+    expect(container?.textContent).toContain('1已收口')
+    expect(container?.textContent).toContain('0待收口')
   })
 
   it('can batch update plugin usage with namespace selection and refresh the current detail user', async () => {

--- a/docs/development/dingtalk-diagnostic-fields-development-verification-20260505.md
+++ b/docs/development/dingtalk-diagnostic-fields-development-verification-20260505.md
@@ -1,0 +1,77 @@
+# DingTalk Diagnostic Fields - Development And Verification
+
+Date: 2026-05-05
+
+## Background
+
+The previous slices already solved two different problems:
+
+- prevent admins from enabling DingTalk login when `openId` is missing
+- provide repair guidance and safe next actions
+
+What was still missing was a compact diagnostic view for administrators. They could see that something was blocked, but not the key identity fields and timestamps in one place.
+
+## Development
+
+Changed files:
+
+- `packages/core-backend/src/routes/admin-users.ts`
+- `packages/core-backend/tests/unit/admin-users-routes.test.ts`
+- `apps/web/src/views/UserManagementView.vue`
+- `apps/web/src/views/DirectoryManagementView.vue`
+- `apps/web/tests/userManagementView.spec.ts`
+- `apps/web/tests/directoryManagementView.spec.ts`
+
+Backend changes:
+
+- Extended the user-management DingTalk access snapshot to return the raw identity values:
+  - `identity.unionId`
+  - `identity.openId`
+- Existing booleans remain:
+  - `identity.hasUnionId`
+  - `identity.hasOpenId`
+
+Frontend changes:
+
+- User management DingTalk section now shows a compact diagnostic grid with:
+  - identity corpId
+  - unionId
+  - openId
+  - last DingTalk login
+  - last directory sync
+  - DingTalk identity updatedAt
+- Directory management account cards now explicitly show:
+  - last directory sync
+
+## Verification
+
+Commands run:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/admin-users-routes.test.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/userManagementView.spec.ts tests/directoryManagementView.spec.ts --watch=false
+git diff --check
+```
+
+Results:
+
+- Backend: 1 test file passed, 61 tests passed.
+- Frontend: targeted user-management and directory-management test files passed.
+- `git diff --check`: passed.
+
+Coverage added:
+
+- Backend snapshot now exposes raw `unionId/openId` values.
+- User management page renders readable DingTalk diagnostics for both healthy and missing-`openId` identities.
+- Directory management account cards render the latest directory sync timestamp.
+
+## Outcome
+
+Admins now have the minimum useful DingTalk diagnosis set in the UI:
+
+- which identity values exist
+- whether the missing field is really `openId`
+- when the user last logged in via DingTalk
+- when the directory data was last refreshed
+
+That makes the repair workflow much easier to follow without going back to database inspection.

--- a/docs/development/dingtalk-directory-openid-grant-guard-development-verification-20260505.md
+++ b/docs/development/dingtalk-directory-openid-grant-guard-development-verification-20260505.md
@@ -1,0 +1,69 @@
+# DingTalk Directory OpenId Grant Guard - Development And Verification
+
+Date: 2026-05-05
+
+## Background
+
+Account 3 exposed a gap in the DingTalk directory import/manual pre-bind flow:
+
+- Directory sync can store a member with `unionId` but without `openId`.
+- Manual bind/admission previously allowed enabling DingTalk login grant as long as either `unionId` or `openId` existed.
+- Corp-scoped DingTalk OAuth login uses `corpId + openId` as the stable identity key, so a grant-enabled user without `openId` can look fully enabled in admin screens but still fail real DingTalk login.
+
+This is a product/guardrail bug in the directory pre-bind flow. The fix keeps directory-only binding possible, but prevents silently enabling DingTalk login grant when `openId` is missing.
+
+## Development
+
+Changed files:
+
+- `packages/core-backend/src/directory/directory-sync.ts`
+- `packages/core-backend/src/routes/admin-directory.ts`
+- `packages/core-backend/tests/unit/directory-sync-bind-account.test.ts`
+- `packages/core-backend/tests/unit/admin-directory-routes.test.ts`
+- `apps/web/src/views/DirectoryManagementView.vue`
+- `apps/web/tests/directoryManagementView.spec.ts`
+
+Backend behavior:
+
+- Added a guard for corp-scoped DingTalk directory accounts: when `enableDingTalkGrant=true`, `openId` is required.
+- Preserved union-only directory pre-binding when `enableDingTalkGrant=false`.
+- Manual admission now fails before user creation if the request would enable DingTalk grant without `openId`.
+- Route error mapping returns `400` for the new `missing DingTalk openId` policy error instead of falling through to `500`.
+
+Frontend behavior:
+
+- Directory account and pending-review bind panels now show a warning when `corpId` exists but `openId` is missing.
+- The “绑定后同时开通钉钉登录” checkbox is disabled and unchecked for those accounts.
+- Bind/manual-admission payloads automatically send `enableDingTalkGrant:false` when `openId` is missing, allowing directory binding without pretending DingTalk login is ready.
+
+## Verification
+
+Commands run:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/directory-sync-bind-account.test.ts tests/unit/admin-directory-routes.test.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/directoryManagementView.spec.ts --watch=false
+git diff --check
+```
+
+Results:
+
+- Backend: 2 test files passed, 35 tests passed.
+- Frontend: 1 test file passed, 36 tests passed.
+- `git diff --check`: passed.
+
+Coverage added:
+
+- Reject enabling DingTalk grant for corp-scoped directory accounts missing `openId`.
+- Allow union-only directory pre-bind when DingTalk grant is disabled.
+- Reject manual admission with DingTalk grant when `openId` is missing.
+- Return route-level `400` for the new policy failure.
+- UI warning and disabled grant toggle for missing-`openId` accounts.
+- Bind payload sends `enableDingTalkGrant:false` when `openId` is missing.
+
+## Remaining Operational Step
+
+For the existing account 3, this code prevents future repeats but does not invent a missing `openId`. Repair still needs one of:
+
+- A successful DingTalk OAuth bind/login to write the real `openId`.
+- A corrected DingTalk directory sync payload that includes `openId`, then rebind/re-enable grant.

--- a/docs/development/dingtalk-directory-openid-password-logout-development-verification-20260505.md
+++ b/docs/development/dingtalk-directory-openid-password-logout-development-verification-20260505.md
@@ -1,0 +1,64 @@
+# DingTalk Directory OpenId And Password Logout - Development And Verification
+
+Date: 2026-05-05
+
+## Scope
+
+This slice covers two related DingTalk public-form findings:
+
+- Explain why account 3 can be bound by DingTalk directory import but still has missing `provider_open_id`.
+- Add a safe sign-out path to the forced password-change page, so users who hit first-login password change can switch accounts without being trapped on that page.
+
+## Account 3 Diagnosis
+
+Current code shows two different identity update paths:
+
+- Directory import/review path builds the DingTalk identity key from `corpId + openId` when `openId` exists, otherwise it falls back to `unionId` or `openId`.
+- OAuth login/bind path writes `provider_open_id` from the real DingTalk OAuth profile after a successful DingTalk authorization callback.
+
+So account 3 is not caused by the public-form auth gate or password-change logic. It is a directory-import pre-bind case where the directory source did not provide a usable `openId`, and the user has not completed a successful OAuth login to backfill it. Deleting and re-importing only fixes it if the next DingTalk directory sync payload includes `openId`; otherwise the record will be re-created with the same gap.
+
+Recommended follow-up:
+
+- Keep the current strict matching logic; do not synthesize or guess `openId`.
+- Add an admin-facing warning for DingTalk directory users whose local identity has `unionId` but missing `openId`.
+- If we need to repair account 3, prefer a real DingTalk OAuth bind/login or a directory sync refresh that returns `openId`, then verify the identity row.
+
+## Development
+
+Changed files:
+
+- `apps/web/src/views/ForcePasswordChangeView.vue`
+- `apps/web/tests/ForcePasswordChangeView.spec.ts`
+
+Implemented behavior:
+
+- Added a secondary `退出登录 / Sign out` button on the forced password-change page.
+- Clicking it calls `/api/auth/logout` with `suppressUnauthorizedRedirect`.
+- Local auth state is cleared even if the logout request fails.
+- User is redirected to `/login`.
+- Submit and logout buttons are mutually disabled while either action is in progress.
+
+## Verification
+
+Commands run:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/ForcePasswordChangeView.spec.ts --watch=false
+git diff --check
+```
+
+Results:
+
+- `ForcePasswordChangeView.spec.ts`: 2 tests passed.
+- `git diff --check`: passed.
+
+Coverage added:
+
+- Existing password-change happy path still passes.
+- New logout path verifies `/api/auth/logout` call, local token cleanup, auth-state cleanup hook, and redirect to `/login`.
+
+## Remaining Work
+
+- Durable repair for account 3 still needs a real source of `openId`: successful OAuth login/bind or a directory sync payload that contains it.
+- If the business wants directory import to self-diagnose this earlier, add an admin UI badge such as `DingTalk OpenId missing; OAuth bind required`.

--- a/docs/development/dingtalk-directory-to-user-missing-openid-deeplink-development-verification-20260505.md
+++ b/docs/development/dingtalk-directory-to-user-missing-openid-deeplink-development-verification-20260505.md
@@ -1,0 +1,57 @@
+# DingTalk 目录页到用户管理缺 OpenID Deep Link 开发及验证
+
+日期：2026-05-05
+
+## 开发目标
+
+让目录同步页在 `openId` 缺失场景下跳回用户管理时，自动落到同一个治理筛选上下文，而不是只定位到单个用户。
+
+## 本次改动
+
+### 1. 目录页“前往用户管理”在缺 OpenID 场景下追加筛选参数
+
+文件：
+- `apps/web/src/views/DirectoryManagementView.vue`
+
+改动：
+- 调整 `buildUserManagementLocation()`
+- 原本目录页回跳用户管理只带：
+  - `userId`
+  - `source=directory-sync`
+  - `integrationId`
+  - `accountId`
+- 现在如果目录成员满足 `openId` 缺失且属于钉钉 grant 风险场景，会额外带上：
+  - `filter=dingtalk-openid-missing`
+
+这样管理员从目录页进入用户管理后，会直接落到“缺 OpenID”治理视图，而不是回到全量用户列表。
+
+## 验证
+
+### 自动化测试
+
+执行：
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/directoryManagementView.spec.ts --watch=false
+git diff --check
+```
+
+结果：
+- `tests/directoryManagementView.spec.ts` 36/36 通过
+- `git diff --check` 通过
+
+### 本次新增覆盖
+
+文件：
+- `apps/web/tests/directoryManagementView.spec.ts`
+
+新增验证：
+- 当目录成员缺 `openId` 且页面出现“前往用户管理”按钮时，链接为：
+  - `/admin/users?userId=...&source=directory-sync&integrationId=...&accountId=...&filter=dingtalk-openid-missing`
+- 其余已有“前往用户管理”链接回归测试继续通过，说明普通目录回跳未被破坏。
+
+## 产出文件
+
+- `apps/web/src/views/DirectoryManagementView.vue`
+- `apps/web/tests/directoryManagementView.spec.ts`
+- `docs/development/dingtalk-directory-to-user-missing-openid-deeplink-development-verification-20260505.md`

--- a/docs/development/dingtalk-governance-audit-scene-card-development-verification-20260505.md
+++ b/docs/development/dingtalk-governance-audit-scene-card-development-verification-20260505.md
@@ -1,0 +1,68 @@
+# DingTalk 治理审计场景卡开发及验证
+
+日期：2026-05-05
+
+## 开发目标
+
+在管理审计页提供一个不依赖用户管理页跳转的钉钉治理快捷入口，让管理员可以直接进入 `user-auth-grant + revoke` 审计场景。
+
+## 本次改动
+
+### 1. 审计页增加治理场景卡
+
+文件：
+- `apps/web/src/views/AdminAuditView.vue`
+
+改动：
+- 在审计页顶部新增“钉钉治理动作”场景卡。
+- 点击后自动切换为：
+  - `resourceType=user-auth-grant`
+  - `action=revoke`
+- 切换时清空 `actorId/resourceId/from/to`，避免旧筛选条件污染治理视角。
+- 当当前筛选已经等于该治理场景时，按钮显示为“当前场景已应用”。
+
+### 2. 增加 URL 同步
+
+文件：
+- `apps/web/src/views/AdminAuditView.vue`
+
+改动：
+- 新增筛选到地址栏的同步逻辑。
+- 场景卡点击后，地址栏会稳定反映为：
+  - `/admin/audit?resourceType=user-auth-grant&action=revoke`
+- 这样管理员可以直接刷新、复制链接或再次进入该治理场景。
+
+## 验证
+
+### 自动化测试
+
+执行：
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/adminAuditView.spec.ts --watch=false
+git diff --check
+```
+
+结果：
+- `tests/adminAuditView.spec.ts` 7/7 通过
+- `git diff --check` 通过
+
+### 本次新增测试覆盖
+
+文件：
+- `apps/web/tests/adminAuditView.spec.ts`
+
+覆盖点：
+- deep link 进入 `resourceType=user-auth-grant&action=revoke` 时，审计页会自动进入钉钉治理场景。
+- 点击“打开钉钉治理审计”后：
+  - 资源筛选变为 `user-auth-grant`
+  - 动作筛选变为 `revoke`
+  - 请求 URL 带上对应 query
+  - 地址栏同步为治理场景链接
+  - 页面显示“当前场景已应用”
+
+## 产出文件
+
+- `apps/web/src/views/AdminAuditView.vue`
+- `apps/web/tests/adminAuditView.spec.ts`
+- `docs/development/dingtalk-governance-audit-scene-card-development-verification-20260505.md`

--- a/docs/development/dingtalk-governance-audit-scene-presets-development-verification-20260505.md
+++ b/docs/development/dingtalk-governance-audit-scene-presets-development-verification-20260505.md
@@ -1,0 +1,85 @@
+# DingTalk 治理审计场景预设开发及验证
+
+日期：2026-05-05
+
+## 开发目标
+
+在管理审计页把钉钉治理相关审计从“单一 deep link”升级为可直接操作的场景预设，便于管理员快速切换：
+
+- 全量钉钉治理动作
+- 最近 7 天收口结果
+
+## 本次改动
+
+### 1. 审计页场景卡升级为双场景
+
+文件：
+- `apps/web/src/views/AdminAuditView.vue`
+
+改动：
+- 将原有单张“钉钉治理动作”卡升级为场景列表。
+- 新增两个可直接应用的审计场景：
+  - `钉钉治理动作`
+    - `resourceType=user-auth-grant`
+    - `action=revoke`
+  - `最近 7 天收口结果`
+    - `resourceType=user-auth-grant`
+    - `action=revoke`
+    - 自动带入最近 7 天的 `from/to`
+
+### 2. 增加场景激活识别
+
+文件：
+- `apps/web/src/views/AdminAuditView.vue`
+
+改动：
+- 增加 `activeSceneKey` 识别逻辑：
+  - 没有附加日期范围时，识别为“钉钉治理动作”
+  - 日期范围等于最近 7 天时，识别为“最近 7 天收口结果”
+- 当前已命中的场景会显示“当前场景已应用”。
+
+### 3. 保持 URL 可复制与可重进
+
+文件：
+- `apps/web/src/views/AdminAuditView.vue`
+
+改动：
+- 场景切换后继续同步 query 到地址栏。
+- “最近 7 天收口结果”会把日期范围一并写入 URL，便于值班巡检时复制、刷新和回访。
+
+## 验证
+
+### 自动化测试
+
+执行：
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/adminAuditView.spec.ts --watch=false
+git diff --check
+```
+
+结果：
+- `tests/adminAuditView.spec.ts` 8/8 通过
+- `git diff --check` 通过
+
+### 本次新增覆盖
+
+文件：
+- `apps/web/tests/adminAuditView.spec.ts`
+
+新增验证：
+- deep link 进入 `resourceType=user-auth-grant&action=revoke` 时，会自动识别为当前钉钉治理场景。
+- 点击“打开钉钉治理审计”后：
+  - 自动切换到钉钉治理场景
+  - 地址栏同步为治理 query
+- 点击“查看最近 7 天收口”后：
+  - 自动切换到 `user-auth-grant + revoke`
+  - 日期输入框填充最近 7 天
+  - 请求 URL 带上对应 `from/to`
+  - 地址栏同步为最近 7 天治理 query
+
+## 产出文件
+
+- `apps/web/src/views/AdminAuditView.vue`
+- `apps/web/tests/adminAuditView.spec.ts`
+- `docs/development/dingtalk-governance-audit-scene-presets-development-verification-20260505.md`

--- a/docs/development/dingtalk-governance-audit-shortcut-development-verification-20260505.md
+++ b/docs/development/dingtalk-governance-audit-shortcut-development-verification-20260505.md
@@ -1,0 +1,50 @@
+# DingTalk Governance Audit Shortcut - Development And Verification
+
+Date: 2026-05-05
+
+## Background
+
+The governance workflow in user management now supports screening, export, bulk closure, and result feedback.
+
+The next useful addition is a direct path into audit review, so admins can quickly inspect the underlying治理 actions without manually rebuilding filters on the audit page.
+
+## Development
+
+Changed files:
+
+- `apps/web/src/views/UserManagementView.vue`
+- `apps/web/src/views/AdminAuditView.vue`
+- `apps/web/tests/userManagementView.spec.ts`
+- `apps/web/tests/adminAuditView.spec.ts`
+
+Frontend changes:
+
+- Added `查看钉钉治理审计` shortcut in the user-management governance action bar.
+- Shortcut targets:
+  - `/admin/audit?resourceType=user-auth-grant&action=revoke`
+- Updated the audit page to:
+  - support `user-auth-grant` in the resource type selector
+  - prefill filters from URL query params on mount
+
+## Verification
+
+Commands run:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/userManagementView.spec.ts tests/adminAuditView.spec.ts --watch=false
+git diff --check
+```
+
+Results:
+
+- Frontend: targeted user-management and admin-audit tests passed.
+- `git diff --check`: passed.
+
+Coverage added:
+
+- User-management governance area renders the audit shortcut link with the expected deep link.
+- Audit page hydrates filters from the deep link and issues the filtered audit request automatically.
+
+## Outcome
+
+Admins can now move directly from the DingTalk治理 list to the matching audit slice without manually rebuilding filters.

--- a/docs/development/dingtalk-governance-daily-summary-export-development-verification-20260505.md
+++ b/docs/development/dingtalk-governance-daily-summary-export-development-verification-20260505.md
@@ -1,0 +1,83 @@
+# DingTalk 治理日报摘要导出开发及验证
+
+日期：2026-05-05
+
+## 开发目标
+
+在现有治理工作台基础上补一个可直接导出的日报摘要，方便把当天治理情况同步给运营、值班和协作同事，而不必手工整理统计和链接。
+
+## 本次改动
+
+### 1. 工作台新增“导出治理日报摘要”动作
+
+文件：
+- `apps/web/src/views/UserManagementView.vue`
+
+改动：
+- 在治理工作台标题区新增 `导出治理日报摘要` 按钮。
+- 导出文件格式为 Markdown：
+  - `dingtalk-governance-daily-summary-YYYY-MM-DD.md`
+
+### 2. 新增治理日报导出内容
+
+文件：
+- `apps/web/src/views/UserManagementView.vue`
+
+改动：
+- 新增 `exportGovernanceDailySummary()`
+- 导出内容包含：
+  - 日期
+  - 核心统计
+    - 缺 OpenID
+    - 待收口
+    - 已收口
+    - 目录已链接
+  - 当前建议
+    - 基于工作台 3 张卡当前实时 note 生成
+  - 工作台入口
+    - 缺 OpenID 筛查 deep link
+    - 目录修复 deep link
+    - 最近 7 天审计 deep link
+
+### 3. 标题区样式微调
+
+文件：
+- `apps/web/src/views/UserManagementView.vue`
+
+改动：
+- 新增 `user-admin__section-head--workbench`
+- 让工作台标题、提示文案和导出按钮更稳定地排布在一起。
+
+## 验证
+
+### 自动化测试
+
+执行：
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/userManagementView.spec.ts --watch=false
+git diff --check
+```
+
+结果：
+- `tests/userManagementView.spec.ts` 23/23 通过
+- `git diff --check` 通过
+
+### 本次新增覆盖
+
+文件：
+- `apps/web/tests/userManagementView.spec.ts`
+
+新增验证：
+- 点击 `导出治理日报摘要` 后：
+  - 会生成 `dingtalk-governance-daily-summary-2026-05-05.md`
+  - 内容包含核心统计
+  - 内容包含当前建议
+  - 内容包含 3 个工作台 deep link
+  - 页面显示成功提示 `已导出 DingTalk 治理日报摘要`
+
+## 产出文件
+
+- `apps/web/src/views/UserManagementView.vue`
+- `apps/web/tests/userManagementView.spec.ts`
+- `docs/development/dingtalk-governance-daily-summary-export-development-verification-20260505.md`

--- a/docs/development/dingtalk-governance-execution-package-index-export-development-verification-20260505.md
+++ b/docs/development/dingtalk-governance-execution-package-index-export-development-verification-20260505.md
@@ -1,0 +1,88 @@
+# DingTalk 联调执行包索引导出开发及验证
+
+日期：2026-05-05
+
+## 开发目标
+
+在治理工作台里补一份联调执行包索引，把日报摘要、联调检查单、真实联调入口、结果回填模板串成固定顺序。这样 142 或其他真实环境验证时，可以先导出索引，再按索引逐项执行和归档。
+
+## 本次改动
+
+### 1. 工作台标题区新增“导出联调执行包索引”
+
+文件：
+- `apps/web/src/views/UserManagementView.vue`
+
+改动：
+- 在治理工作台导出按钮组中新增：
+  - `导出联调执行包索引`
+
+当前导出按钮分工为：
+- `导出治理日报摘要`
+- `导出联调检查单`
+- `导出联调结果模板`
+- `导出联调执行包索引`
+
+### 2. 新增联调执行包索引 Markdown
+
+文件：
+- `apps/web/src/views/UserManagementView.vue`
+
+改动：
+- 新增 `exportGovernanceExecutionPackageIndex()`
+- 导出文件格式为 Markdown：
+  - `dingtalk-governance-execution-package-index-YYYY-MM-DD.md`
+- 索引内容包含：
+  - 推荐执行顺序
+    - 导出治理日报摘要
+    - 导出联调检查单
+    - 执行真实联调
+    - 导出联调结果模板
+    - 回填并归档结果
+  - 当前治理基线
+    - 缺 OpenID / 待收口 / 已收口 / 目录已链接
+  - 导出文件清单
+    - `dingtalk-governance-daily-summary-YYYY-MM-DD.md`
+    - `dingtalk-governance-live-validation-checklist-YYYY-MM-DD.md`
+    - `dingtalk-governance-validation-result-template-YYYY-MM-DD.md`
+  - 工作台入口
+    - 缺 OpenID 成员
+    - 目录同步修复
+    - 最近 7 天收口审计
+  - 当前建议
+    - 复用治理工作台卡片实时 note
+
+## 验证
+
+### 自动化测试
+
+执行：
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/userManagementView.spec.ts --watch=false
+git diff --check
+```
+
+结果：
+- `tests/userManagementView.spec.ts` 26/26 通过
+- `git diff --check` 通过
+
+### 本次新增覆盖
+
+文件：
+- `apps/web/tests/userManagementView.spec.ts`
+
+新增验证：
+- 点击 `导出联调执行包索引` 后：
+  - 生成 `dingtalk-governance-execution-package-index-2026-05-05.md`
+  - 内容包含 `DingTalk 治理联调执行包索引`
+  - 内容包含 5 步推荐执行顺序
+  - 内容包含 3 个联调产物文件名
+  - 内容包含缺 OpenID 成员、目录同步修复、最近 7 天收口审计 3 个 deep link
+  - 页面显示成功提示 `已导出 DingTalk 联调执行包索引`
+
+## 产出文件
+
+- `apps/web/src/views/UserManagementView.vue`
+- `apps/web/tests/userManagementView.spec.ts`
+- `docs/development/dingtalk-governance-execution-package-index-export-development-verification-20260505.md`

--- a/docs/development/dingtalk-governance-full-validation-package-export-development-verification-20260505.md
+++ b/docs/development/dingtalk-governance-full-validation-package-export-development-verification-20260505.md
@@ -1,0 +1,95 @@
+# DingTalk 完整联调包导出开发及验证
+
+日期：2026-05-05
+
+## 开发目标
+
+在治理工作台里补一个单文件完整联调包导出，把治理日报摘要、联调检查单、结果回填模板、工作台入口和当前建议放到同一份 Markdown。这样 142 真实联调时不必手动拼接多份导出文件，适合快速执行、回填和归档。
+
+## 本次改动
+
+### 1. 工作台标题区新增“导出完整联调包”
+
+文件：
+- `apps/web/src/views/UserManagementView.vue`
+
+改动：
+- 在治理工作台导出按钮组中新增：
+  - `导出完整联调包`
+
+当前导出按钮分工为：
+- `导出治理日报摘要`
+- `导出联调检查单`
+- `导出联调结果模板`
+- `导出联调执行包索引`
+- `导出完整联调包`
+
+### 2. 新增完整联调包 Markdown
+
+文件：
+- `apps/web/src/views/UserManagementView.vue`
+
+改动：
+- 新增 `exportGovernanceFullValidationPackage()`
+- 导出文件格式为 Markdown：
+  - `dingtalk-governance-full-validation-package-YYYY-MM-DD.md`
+- 完整包内容包含：
+  - 包内目录
+  - 当前治理基线
+    - 缺 OpenID / 待收口 / 已收口 / 目录已链接
+  - 推荐执行顺序
+  - 治理日报摘要
+  - 联调检查单
+  - 联调结果回填模板
+  - 工作台入口
+    - 缺 OpenID 成员
+    - 目录同步修复
+    - 最近 7 天收口审计
+  - 当前建议
+    - 复用治理工作台卡片实时 note
+
+## 验证
+
+### 自动化测试
+
+执行：
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/userManagementView.spec.ts --watch=false
+git diff --check -- apps/web/src/views/UserManagementView.vue apps/web/tests/userManagementView.spec.ts docs/development/dingtalk-governance-full-validation-package-export-development-verification-20260505.md
+```
+
+结果：
+- `tests/userManagementView.spec.ts` 27/27 通过
+- 本轮文件 targeted `git diff --check` 通过
+
+说明：
+- 全量 `git diff --check` 当前会被工作树中既有未合并文件阻塞，示例包括：
+  - `apps/web/tests/multitable-form-share-manager.spec.ts`
+  - `packages/core-backend/tests/integration/public-form-flow.test.ts`
+  - `packages/core-backend/tests/unit/jwt-middleware.test.ts`
+- 这些文件不属于本轮完整联调包导出改动范围，本轮未修改。
+
+### 本次新增覆盖
+
+文件：
+- `apps/web/tests/userManagementView.spec.ts`
+
+新增验证：
+- 点击 `导出完整联调包` 后：
+  - 生成 `dingtalk-governance-full-validation-package-2026-05-05.md`
+  - 内容包含 `DingTalk 治理完整联调包`
+  - 内容包含包内目录
+  - 内容包含当前基线
+  - 内容包含推荐执行顺序
+  - 内容包含治理日报摘要
+  - 内容包含联调检查单
+  - 内容包含联调结果回填模板
+  - 内容包含缺 OpenID 成员、目录同步修复、最近 7 天收口审计 3 个 deep link
+  - 页面显示成功提示 `已导出 DingTalk 完整联调包`
+
+## 产出文件
+
+- `apps/web/src/views/UserManagementView.vue`
+- `apps/web/tests/userManagementView.spec.ts`
+- `docs/development/dingtalk-governance-full-validation-package-export-development-verification-20260505.md`

--- a/docs/development/dingtalk-governance-live-validation-checklist-export-development-verification-20260505.md
+++ b/docs/development/dingtalk-governance-live-validation-checklist-export-development-verification-20260505.md
@@ -1,0 +1,79 @@
+# DingTalk 治理联调检查单导出开发及验证
+
+日期：2026-05-05
+
+## 开发目标
+
+在治理工作台里补一个更偏部署后联调的导出物，让真实数据验证可以按统一步骤执行，而不是靠口头交接或手工整理。
+
+## 本次改动
+
+### 1. 工作台标题区新增“导出联调检查单”
+
+文件：
+- `apps/web/src/views/UserManagementView.vue`
+
+改动：
+- 在治理工作台标题区新增 `导出联调检查单` 按钮。
+- 与现有 `导出治理日报摘要` 并排保留，分别服务于：
+  - 结果沉淀
+  - 真实数据联调
+
+### 2. 新增联调检查单导出内容
+
+文件：
+- `apps/web/src/views/UserManagementView.vue`
+
+改动：
+- 新增 `exportGovernanceLiveValidationChecklist()`
+- 导出文件格式为 Markdown：
+  - `dingtalk-governance-live-validation-checklist-YYYY-MM-DD.md`
+- 导出内容包含：
+  - 当前基线统计
+    - 缺 OpenID
+    - 待收口
+    - 已收口
+  - 联调步骤
+    - 缺 OpenID 成员清单核对
+    - 目录同步补齐 openId
+    - 批量关闭钉钉扫码
+    - 最近 7 天收口审计复盘
+    - 真实钉钉账号登录验证
+    - 导出日报归档
+  - 当前建议
+    - 直接复用工作台 3 张卡当前实时 note
+  - 3 个工作台 deep link
+
+## 验证
+
+### 自动化测试
+
+执行：
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/userManagementView.spec.ts --watch=false
+git diff --check
+```
+
+结果：
+- `tests/userManagementView.spec.ts` 24/24 通过
+- `git diff --check` 通过
+
+### 本次新增覆盖
+
+文件：
+- `apps/web/tests/userManagementView.spec.ts`
+
+新增验证：
+- 点击 `导出联调检查单` 后：
+  - 生成 `dingtalk-governance-live-validation-checklist-2026-05-05.md`
+  - 内容包含当前基线统计
+  - 内容包含联调步骤
+  - 内容包含 3 个工作台 deep link
+  - 页面显示成功提示 `已导出 DingTalk 联调检查单`
+
+## 产出文件
+
+- `apps/web/src/views/UserManagementView.vue`
+- `apps/web/tests/userManagementView.spec.ts`
+- `docs/development/dingtalk-governance-live-validation-checklist-export-development-verification-20260505.md`

--- a/docs/development/dingtalk-governance-summary-audit-links-development-verification-20260505.md
+++ b/docs/development/dingtalk-governance-summary-audit-links-development-verification-20260505.md
@@ -1,0 +1,72 @@
+# DingTalk 治理统计到审计场景快捷入口开发及验证
+
+日期：2026-05-05
+
+## 开发目标
+
+把用户管理页里的 DingTalk 治理统计直接接到审计页场景，减少管理员从“看到待收口数量”到“进入审计定位动作”的跳转成本。
+
+## 本次改动
+
+### 1. 用户管理页 summary 卡片增加快捷入口
+
+文件：
+- `apps/web/src/views/UserManagementView.vue`
+
+改动：
+- 将治理 summary 中两项指标改为可点击入口：
+  - `待收口`
+    - 跳转到全量钉钉治理审计：
+    - `/admin/audit?resourceType=user-auth-grant&action=revoke`
+  - `已收口`
+    - 跳转到最近 7 天收口审计：
+    - `/admin/audit?resourceType=user-auth-grant&action=revoke&from=...&to=...`
+
+### 2. 新增最近 7 天治理审计链接构造
+
+文件：
+- `apps/web/src/views/UserManagementView.vue`
+
+改动：
+- 增加 `buildRecentDingTalkGovernanceAuditLocation()`
+- 自动生成最近 7 天的 `from/to` 审计区间，和审计页新增的“最近 7 天收口结果”场景保持一致。
+
+### 3. summary 卡片交互样式补齐
+
+文件：
+- `apps/web/src/views/UserManagementView.vue`
+
+改动：
+- 新增 `user-admin__metric-link`
+- 让“已收口/待收口”在视觉上保持 summary 卡片形态，并增加 hover 高亮，避免像普通文本链接。
+
+## 验证
+
+### 自动化测试
+
+执行：
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/userManagementView.spec.ts --watch=false
+git diff --check
+```
+
+结果：
+- `tests/userManagementView.spec.ts` 18/18 通过
+- `git diff --check` 通过
+
+### 本次新增覆盖
+
+文件：
+- `apps/web/tests/userManagementView.spec.ts`
+
+新增验证：
+- `待收口` summary 指标会跳到全量钉钉治理审计。
+- `已收口` summary 指标会跳到最近 7 天治理审计，并带上固定 `from/to` query。
+- 原有“查看钉钉治理审计”入口仍保持不变。
+
+## 产出文件
+
+- `apps/web/src/views/UserManagementView.vue`
+- `apps/web/tests/userManagementView.spec.ts`
+- `docs/development/dingtalk-governance-summary-audit-links-development-verification-20260505.md`

--- a/docs/development/dingtalk-governance-validation-result-template-export-development-verification-20260505.md
+++ b/docs/development/dingtalk-governance-validation-result-template-export-development-verification-20260505.md
@@ -1,0 +1,84 @@
+# DingTalk 联调结果回填模板导出开发及验证
+
+日期：2026-05-05
+
+## 开发目标
+
+在治理工作台里补一份联调执行后的统一回填模板，让 142 等真实环境联调完成后，结果可以按统一结构沉淀，而不是散落在聊天或临时备注里。
+
+## 本次改动
+
+### 1. 工作台标题区新增“导出联调结果模板”
+
+文件：
+- `apps/web/src/views/UserManagementView.vue`
+
+改动：
+- 在现有工作台标题区的导出按钮组中新增：
+  - `导出联调结果模板`
+
+当前导出按钮分工为：
+- `导出治理日报摘要`
+- `导出联调检查单`
+- `导出联调结果模板`
+
+### 2. 新增联调结果模板导出内容
+
+文件：
+- `apps/web/src/views/UserManagementView.vue`
+
+改动：
+- 新增 `exportGovernanceValidationResultTemplate()`
+- 导出文件格式为 Markdown：
+  - `dingtalk-governance-validation-result-template-YYYY-MM-DD.md`
+- 模板内容包含：
+  - 联调环境
+    - 环境 / 执行人 / 协同人 / 执行时间
+  - 执行前基线
+    - 缺 OpenID / 待收口 / 已收口
+  - 结果回填
+    - 缺 OpenID 清单是否一致
+    - 目录同步是否补齐 openId
+    - 批量关闭钉钉扫码后统计是否变化
+    - 最近 7 天审计是否可追溯
+    - 真实钉钉账号验证结果
+  - 异常记录
+  - 执行后结论
+  - 当前建议
+    - 继续复用工作台 3 张卡的实时 note
+
+## 验证
+
+### 自动化测试
+
+执行：
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/userManagementView.spec.ts --watch=false
+git diff --check
+```
+
+结果：
+- `tests/userManagementView.spec.ts` 25/25 通过
+- `git diff --check` 通过
+
+### 本次新增覆盖
+
+文件：
+- `apps/web/tests/userManagementView.spec.ts`
+
+新增验证：
+- 点击 `导出联调结果模板` 后：
+  - 生成 `dingtalk-governance-validation-result-template-2026-05-05.md`
+  - 内容包含联调环境
+  - 内容包含执行前基线
+  - 内容包含结果回填区
+  - 内容包含执行后结论
+  - 内容包含 3 个工作台 deep link
+  - 页面显示成功提示 `已导出 DingTalk 联调结果模板`
+
+## 产出文件
+
+- `apps/web/src/views/UserManagementView.vue`
+- `apps/web/tests/userManagementView.spec.ts`
+- `docs/development/dingtalk-governance-validation-result-template-export-development-verification-20260505.md`

--- a/docs/development/dingtalk-governance-workbench-development-verification-20260505.md
+++ b/docs/development/dingtalk-governance-workbench-development-verification-20260505.md
@@ -1,0 +1,76 @@
+# DingTalk 治理工作台入口开发及验证
+
+日期：2026-05-05
+
+## 开发目标
+
+将用户管理页、目录同步页、审计页三边已经打通的治理 deep link 聚合成固定快捷入口，降低管理员在不同页面之间来回找入口的成本。
+
+## 本次改动
+
+### 1. 用户管理页新增治理工作台
+
+文件：
+- `apps/web/src/views/UserManagementView.vue`
+
+改动：
+- 在用户列表 summary 下新增固定的“治理工作台”快捷卡区域。
+- 当前包含 3 张卡：
+  - `缺 OpenID 成员`
+    - `/admin/users?filter=dingtalk-openid-missing&source=dingtalk-governance`
+  - `目录同步修复入口`
+    - `/admin/directory?source=dingtalk-governance`
+  - `最近 7 天收口审计`
+    - `/admin/audit?resourceType=user-auth-grant&action=revoke&from=...&to=...`
+
+### 2. 增加目录修复入口链接构造
+
+文件：
+- `apps/web/src/views/UserManagementView.vue`
+
+改动：
+- 新增 `buildDirectoryMissingOpenIdWorkbenchLocation()`
+- 统一从用户管理页跳往目录同步治理入口的链接格式。
+
+### 3. 工作台样式补齐
+
+文件：
+- `apps/web/src/views/UserManagementView.vue`
+
+改动：
+- 新增工作台卡片样式：
+  - `user-admin__workbench`
+  - `user-admin__workbench-card`
+  - `user-admin__workbench-kicker`
+- 移动端下会自动折成单列，避免入口区过挤。
+
+## 验证
+
+### 自动化测试
+
+执行：
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/userManagementView.spec.ts --watch=false
+git diff --check
+```
+
+结果：
+- `tests/userManagementView.spec.ts` 22/22 通过
+- `git diff --check` 通过
+
+### 本次新增覆盖
+
+文件：
+- `apps/web/tests/userManagementView.spec.ts`
+
+新增验证：
+- 工作台中的 `缺 OpenID 成员` 链接会指向用户管理缺 OpenID deep link。
+- `目录同步修复入口` 会指向目录同步治理入口。
+- `最近 7 天收口审计` 会指向最近 7 天的治理审计视图。
+
+## 产出文件
+
+- `apps/web/src/views/UserManagementView.vue`
+- `apps/web/tests/userManagementView.spec.ts`
+- `docs/development/dingtalk-governance-workbench-development-verification-20260505.md`

--- a/docs/development/dingtalk-governance-workbench-operational-hints-development-verification-20260505.md
+++ b/docs/development/dingtalk-governance-workbench-operational-hints-development-verification-20260505.md
@@ -1,0 +1,84 @@
+# DingTalk 治理工作台运营提示开发及验证
+
+日期：2026-05-05
+
+## 开发目标
+
+在现有治理工作台 3 张快捷卡上补充实时运营提示，让管理员一进入页面就能判断：
+
+- 今天先点哪张卡
+- 目录修复是否还有积压
+- 最近 7 天是否已有治理收口可复盘
+
+## 本次改动
+
+### 1. 工作台卡片改为带运营提示的动态卡
+
+文件：
+- `apps/web/src/views/UserManagementView.vue`
+
+改动：
+- 新增 `governanceWorkbenchCards` 计算属性。
+- 3 张卡保持原有 deep link 不变，但每张卡新增实时提示：
+  - `缺 OpenID 成员`
+    - `今日优先处理 N 个待收口成员`
+    - 或 `当前没有待收口成员需要优先处理`
+  - `目录同步修复入口`
+    - `N 个成员可先回目录同步继续补齐 openId`
+    - 或 `当前没有需要回目录同步补齐的成员`
+  - `最近 7 天收口审计`
+    - `最近 7 天已收口 N 个成员，可直接复盘处理动作`
+    - 或 `最近 7 天暂无新的收口记录`
+
+### 2. 增加最近 N 天治理判断辅助函数
+
+文件：
+- `apps/web/src/views/UserManagementView.vue`
+
+改动：
+- 新增 `isWithinRecentDays()`，用于识别最近 7 天的钉钉扫码关闭记录。
+- 工作台“最近 7 天收口审计”提示基于这个判断生成。
+
+### 3. 工作台提示样式补齐
+
+文件：
+- `apps/web/src/views/UserManagementView.vue`
+
+改动：
+- 新增 `user-admin__workbench-note` 样式。
+- 将运营提示和描述文案在视觉上区分开，更像“当前建议动作”。
+
+## 验证
+
+### 自动化测试
+
+执行：
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/userManagementView.spec.ts --watch=false
+git diff --check
+```
+
+结果：
+- `tests/userManagementView.spec.ts` 22/22 通过
+- `git diff --check` 通过
+
+### 本次新增覆盖
+
+文件：
+- `apps/web/tests/userManagementView.spec.ts`
+
+新增验证：
+- 工作台 3 张卡的 deep link 继续保持正确。
+- 当 fixture 数据显示：
+  - 当前无待收口成员
+  - 有 1 个目录已链接但缺 openId 成员
+  - 最近 7 天有 1 个已收口成员
+  
+  页面会分别显示对应的运营提示文案。
+
+## 产出文件
+
+- `apps/web/src/views/UserManagementView.vue`
+- `apps/web/tests/userManagementView.spec.ts`
+- `docs/development/dingtalk-governance-workbench-operational-hints-development-verification-20260505.md`

--- a/docs/development/dingtalk-missing-openid-deeplink-development-verification-20260505.md
+++ b/docs/development/dingtalk-missing-openid-deeplink-development-verification-20260505.md
@@ -1,0 +1,71 @@
+# DingTalk 缺 OpenID 筛选 Deep Link 开发及验证
+
+日期：2026-05-05
+
+## 开发目标
+
+把用户管理页的 `缺 OpenID` 治理筛选做成可直接分享和复用的 deep link，让用户管理、目录同步、审计治理三边的入口能够围绕同一个问题视角联动。
+
+## 本次改动
+
+### 1. 缺 OpenID summary 卡片改为 deep link 入口
+
+文件：
+- `apps/web/src/views/UserManagementView.vue`
+
+改动：
+- 将顶部 summary 中的 `缺 OpenID` 指标改成可点击卡片。
+- 链接目标为：
+  - `/admin/users?filter=dingtalk-openid-missing&source=dingtalk-governance`
+
+### 2. 用户管理页支持从 URL 回填筛选
+
+文件：
+- `apps/web/src/views/UserManagementView.vue`
+
+改动：
+- 扩展用户管理页导航状态，支持解析和持久化 `filter` 参数。
+- 新增 `normalizeUserListFilter()`，只接受受支持的筛选值。
+- 首次加载 `/admin/users?filter=dingtalk-openid-missing` 时，会直接进入“缺 OpenID”筛选视图。
+
+### 3. 页内切换筛选时同步回 URL
+
+文件：
+- `apps/web/src/views/UserManagementView.vue`
+
+改动：
+- 监听 `userListFilter` 变化。
+- 当管理员在页面内点击“缺 OpenID”等筛选按钮时，地址栏会同步更新 query。
+- 这样当前治理视角可以直接复制给其他管理员使用。
+
+## 验证
+
+### 自动化测试
+
+执行：
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/userManagementView.spec.ts --watch=false
+git diff --check
+```
+
+结果：
+- `tests/userManagementView.spec.ts` 21/21 通过
+- `git diff --check` 通过
+
+### 本次新增覆盖
+
+文件：
+- `apps/web/tests/userManagementView.spec.ts`
+
+新增验证：
+- `缺 OpenID` summary 卡片链接到可分享的 deep link。
+- 首次打开 `/admin/users?filter=dingtalk-openid-missing&source=dingtalk-governance` 时，会直接只显示缺 OpenID 用户。
+- 在页内点击 `缺 OpenID` 筛选按钮后，地址栏会同步更新为：
+  - `?filter=dingtalk-openid-missing`
+
+## 产出文件
+
+- `apps/web/src/views/UserManagementView.vue`
+- `apps/web/tests/userManagementView.spec.ts`
+- `docs/development/dingtalk-missing-openid-deeplink-development-verification-20260505.md`

--- a/docs/development/dingtalk-openid-bulk-disable-development-verification-20260505.md
+++ b/docs/development/dingtalk-openid-bulk-disable-development-verification-20260505.md
@@ -1,0 +1,62 @@
+# DingTalk OpenId Bulk Disable - Development And Verification
+
+Date: 2026-05-05
+
+## Background
+
+After adding screening and CSV export, admins could identify and export missing-`openId` users, but still had to manually select them before revoking DingTalk login access.
+
+The next smallest useful action is a dedicated治理按钮 that targets the currently visible missing-`openId` users whose DingTalk grant is still enabled.
+
+## Development
+
+Changed files:
+
+- `apps/web/src/views/UserManagementView.vue`
+- `apps/web/tests/userManagementView.spec.ts`
+
+Frontend behavior:
+
+- Added a computed subset for:
+  - current visible users missing `openId`
+  - and still grant-enabled
+- Added a new bulk action button:
+  - `批量关闭缺 OpenID 钉钉扫码`
+- Action behavior:
+  - posts to `/api/admin/users/dingtalk-grants/bulk`
+  - only includes currently visible missing-`openId` users with grant enabled
+  - refreshes user list after success
+  - refreshes current detail user DingTalk/member-admission state when needed
+  - reports a dedicated success status
+
+## Verification
+
+Commands run:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/userManagementView.spec.ts --watch=false
+git diff --check
+```
+
+Results:
+
+- Frontend: targeted user-management tests passed.
+- `git diff --check`: passed.
+
+Coverage added:
+
+- Dedicated bulk-disable action becomes available for visible missing-`openId` users with grant enabled.
+- Action sends the expected bulk revoke payload.
+- UI reports the expected治理 success message.
+
+## Outcome
+
+The missing-`openId`治理 path now supports:
+
+- screen
+- diagnose
+- guide repair
+- export list
+- bulk revoke risky DingTalk access
+
+This reduces the operational window where incomplete DingTalk identities still retain login access.

--- a/docs/development/dingtalk-openid-governance-feedback-development-verification-20260505.md
+++ b/docs/development/dingtalk-openid-governance-feedback-development-verification-20260505.md
@@ -1,0 +1,64 @@
+# DingTalk OpenId Governance Feedback - Development And Verification
+
+Date: 2026-05-05
+
+## Background
+
+After screening, export, and bulk revoke were available, the remaining usability gap was post-action visibility.
+
+Admins could close DingTalk access for missing-`openId` users, but the list did not clearly show which risky users had already been governed and when that happened.
+
+## Development
+
+Changed files:
+
+- `packages/core-backend/src/routes/admin-users.ts`
+- `packages/core-backend/tests/unit/admin-users-routes.test.ts`
+- `apps/web/src/views/UserManagementView.vue`
+- `apps/web/tests/userManagementView.spec.ts`
+
+Backend changes:
+
+- Enriched user-list DingTalk signals with:
+  - `dingtalkGrantUpdatedAt`
+- The list now returns both current DingTalk grant status and its latest update timestamp for the current page.
+
+Frontend changes:
+
+- Added a row-level governance hint for missing-`openId` users.
+- The hint now shows:
+  - corpId
+  - last directory sync
+  - last DingTalk grant close time when the grant is already disabled
+- This makes治理结果 visible directly in the screening list after bulk closure.
+
+## Verification
+
+Commands run:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/admin-users-routes.test.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/userManagementView.spec.ts --watch=false
+git diff --check
+```
+
+Results:
+
+- Backend: targeted admin-users route tests passed.
+- Frontend: targeted user-management tests passed.
+- `git diff --check`: passed.
+
+Coverage added:
+
+- User list API returns `dingtalkGrantUpdatedAt`.
+- User-management screening list shows recent治理 feedback after bulk closure.
+
+## Outcome
+
+Admins can now distinguish:
+
+- risky users still needing action
+- risky users already governed
+- when DingTalk access was last closed
+
+This reduces repeated operations and makes handoff/review easier.

--- a/docs/development/dingtalk-openid-governance-owner-development-verification-20260505.md
+++ b/docs/development/dingtalk-openid-governance-owner-development-verification-20260505.md
@@ -1,0 +1,59 @@
+# DingTalk OpenId Governance Owner Feedback - Development And Verification
+
+Date: 2026-05-05
+
+## Background
+
+The previous治理 feedback slice already showed when a missing-`openId` user's DingTalk access was last closed.
+
+The remaining gap was ownership visibility. For handoff and audit purposes, admins also need to know who performed the latest治理 action.
+
+## Development
+
+Changed files:
+
+- `packages/core-backend/src/routes/admin-users.ts`
+- `packages/core-backend/tests/unit/admin-users-routes.test.ts`
+- `apps/web/src/views/UserManagementView.vue`
+- `apps/web/tests/userManagementView.spec.ts`
+
+Backend changes:
+
+- Extended user-list DingTalk governance signals with:
+  - `dingtalkGrantUpdatedBy`
+- The user list now resolves the latest grant updater from `user_external_auth_grants.granted_by`, preferring operator name, then email, then id.
+
+Frontend changes:
+
+- Missing-`openId` governance hint now includes operator information when DingTalk access has already been closed:
+  - `最近关闭钉钉扫码 <time> · 处理人 <name>`
+
+## Verification
+
+Commands run:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/admin-users-routes.test.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/userManagementView.spec.ts --watch=false
+git diff --check
+```
+
+Results:
+
+- Backend: targeted admin-users route tests passed.
+- Frontend: targeted user-management tests passed.
+- `git diff --check`: passed.
+
+Coverage added:
+
+- User list API returns the latest治理 operator label.
+- User-management missing-`openId` governance hint renders both close time and operator after bulk closure.
+
+## Outcome
+
+The治理 result feedback now answers both:
+
+- when was this risky DingTalk account handled
+- who handled it
+
+That makes follow-up and audit much easier without leaving the user list.

--- a/docs/development/dingtalk-openid-governance-summary-development-verification-20260505.md
+++ b/docs/development/dingtalk-openid-governance-summary-development-verification-20260505.md
@@ -1,0 +1,57 @@
+# DingTalk OpenId Governance Summary - Development And Verification
+
+Date: 2026-05-05
+
+## Background
+
+After screening, export, bulk closure, and row-level feedback were added, admins could operate the治理 workflow end to end.
+
+The next useful refinement is a compact summary panel that shows current治理 volume at a glance:
+
+- total missing `openId`
+- already governed
+- still pending governance
+
+## Development
+
+Changed files:
+
+- `apps/web/src/views/UserManagementView.vue`
+- `apps/web/tests/userManagementView.spec.ts`
+
+Frontend changes:
+
+- Extended `governanceSummary` with:
+  - `dingtalkOpenIdGoverned`
+  - `dingtalkOpenIdPending`
+- Added two new summary metrics in the user-management governance summary bar:
+  - `已收口`
+  - `待收口`
+- Values update live after the existing bulk closure action refreshes the user list.
+
+## Verification
+
+Commands run:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/userManagementView.spec.ts --watch=false
+git diff --check
+```
+
+Results:
+
+- Frontend: targeted user-management tests passed.
+- `git diff --check`: passed.
+
+Coverage added:
+
+- Summary reflects missing-`openId` population before治理.
+- Summary flips from pending to governed after bulk disabling DingTalk access for the affected user set.
+
+## Outcome
+
+Admins can now use the top summary bar as a lightweight巡检 panel:
+
+- how many risky accounts exist
+- how many have already been收口
+- how many still need action

--- a/docs/development/dingtalk-openid-repair-guidance-development-verification-20260505.md
+++ b/docs/development/dingtalk-openid-repair-guidance-development-verification-20260505.md
@@ -1,0 +1,65 @@
+# DingTalk OpenId Repair Guidance - Development And Verification
+
+Date: 2026-05-05
+
+## Background
+
+The previous two slices already blocked new bad states:
+
+- Directory bind/admission can no longer silently enable DingTalk grant when `openId` is missing.
+- User management can no longer re-enable DingTalk grant for a corp-scoped identity missing `openId`.
+
+What was still missing was a practical repair path for administrators handling existing incomplete identities. Admin pages showed the restriction, but not the next safe action.
+
+## Development
+
+Changed files:
+
+- `apps/web/src/views/UserManagementView.vue`
+- `apps/web/src/views/DirectoryManagementView.vue`
+- `apps/web/tests/userManagementView.spec.ts`
+- `apps/web/tests/directoryManagementView.spec.ts`
+
+User management changes:
+
+- Added a repair guidance hint when the current DingTalk identity exists but is missing `openId`.
+- Added a direct link back to the matching directory member when a DingTalk directory membership is known.
+- Reused existing refresh flow so admins can refresh DingTalk state after directory resync or a real DingTalk OAuth bind.
+
+Directory management changes:
+
+- For review items and account cards with missing `openId`, added an explicit repair suggestion:
+  - refresh the current member after a real DingTalk login/bind
+  - if still missing, inspect directory sync payload/permissions before deciding on a broader resync
+- Added local action buttons:
+  - `刷新当前成员`
+  - `前往用户管理` when the local user already exists
+
+## Verification
+
+Commands run:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/userManagementView.spec.ts tests/directoryManagementView.spec.ts --watch=false
+git diff --check
+```
+
+Results:
+
+- Frontend: targeted user-management and directory-management test files passed.
+- `git diff --check`: passed.
+
+Coverage added:
+
+- User detail page renders repair guidance and a directory-member jump link for missing-`openId` identities.
+- Directory review/account cards render repair guidance and local repair actions for missing-`openId` members.
+
+## Outcome
+
+Administrators now see a consistent DingTalk repair story across both major admin surfaces:
+
+- why grant enable is blocked
+- where to continue diagnosis
+- what safe next action to try first
+
+This does not fabricate `openId`, but it turns the current “blocked state” into an actionable repair workflow.

--- a/docs/development/dingtalk-openid-screening-export-development-verification-20260505.md
+++ b/docs/development/dingtalk-openid-screening-export-development-verification-20260505.md
@@ -1,0 +1,54 @@
+# DingTalk OpenId Screening Export - Development And Verification
+
+Date: 2026-05-05
+
+## Background
+
+After adding the `缺 OpenID` screening view, administrators could identify affected users in the list, but still had to copy the results manually for follow-up.
+
+The next useful slice is a lightweight export action based on the current screening result, so operations can hand off or track a治理清单 without extra querying.
+
+## Development
+
+Changed files:
+
+- `apps/web/src/views/UserManagementView.vue`
+- `apps/web/tests/userManagementView.spec.ts`
+
+Frontend behavior:
+
+- Added `导出缺 OpenID 清单` button to the user-management bulk action bar.
+- Export scope is the current visible screening result intersected with users missing DingTalk `openId`.
+- Exported CSV columns:
+  - `userId`
+  - `name`
+  - `account`
+  - `role`
+  - `dingtalkCorpId`
+  - `directoryLinked`
+  - `lastDirectorySyncAt`
+- Added success status feedback after export completes.
+
+## Verification
+
+Commands run:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/userManagementView.spec.ts --watch=false
+git diff --check
+```
+
+Results:
+
+- Frontend: targeted user-management tests passed.
+- `git diff --check`: passed.
+
+Coverage added:
+
+- Export button enabled when current view contains missing-`openId` users.
+- Export creates a CSV blob with the expected header and row payload.
+- Export reports a success status after download preparation.
+
+## Outcome
+
+Admins can now move directly from screening to action by exporting the current missing-`openId` governance list as CSV.

--- a/docs/development/dingtalk-openid-screening-view-development-verification-20260505.md
+++ b/docs/development/dingtalk-openid-screening-view-development-verification-20260505.md
@@ -1,0 +1,68 @@
+# DingTalk OpenId Screening View - Development And Verification
+
+Date: 2026-05-05
+
+## Background
+
+The previous slices added:
+
+- grant guardrails
+- repair guidance
+- per-user diagnostics
+
+The remaining operational gap was scale. Admins still had to open users one by one to find DingTalk-linked accounts missing `openId`.
+
+## Development
+
+Changed files:
+
+- `packages/core-backend/src/routes/admin-users.ts`
+- `packages/core-backend/tests/unit/admin-users-routes.test.ts`
+- `apps/web/src/views/UserManagementView.vue`
+- `apps/web/tests/userManagementView.spec.ts`
+
+Backend changes:
+
+- Enriched `/api/admin/users` list items with DingTalk governance signals for the current page:
+  - `dingtalkIdentityExists`
+  - `dingtalkHasUnionId`
+  - `dingtalkHasOpenId`
+  - `dingtalkOpenIdMissing`
+  - `dingtalkCorpId`
+  - `lastDirectorySyncAt`
+- Reused batched lookups so the UI can screen the current page without loading per-user detail first.
+
+Frontend changes:
+
+- Added a new user-list governance filter: `缺 OpenID`
+- Added a summary metric: `缺 OpenID`
+- Added a danger badge on affected rows: `缺 OpenID`
+- Added a quick row hint for affected users:
+  - corpId
+  - last directory sync
+
+## Verification
+
+Commands run:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/admin-users-routes.test.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/userManagementView.spec.ts --watch=false
+git diff --check
+```
+
+Results:
+
+- Backend: targeted admin-users route tests passed.
+- Frontend: targeted user-management tests passed.
+- `git diff --check`: passed.
+
+Coverage added:
+
+- User list API returns DingTalk screening signals.
+- User management list renders the new screening metric and row badge.
+- `缺 OpenID` filter isolates the affected users in the management list.
+
+## Outcome
+
+Admins can now do first-pass DingTalk risk screening directly from the user list, without opening each user detail page first.

--- a/docs/development/dingtalk-p4-governance-closeout-development-verification-20260505.md
+++ b/docs/development/dingtalk-p4-governance-closeout-development-verification-20260505.md
@@ -1,0 +1,194 @@
+# DingTalk P4 Governance Closeout Development And Verification - 2026-05-05
+
+## Scope
+
+This closeout consolidates the current DingTalk public-form and OpenID governance work into one mergeable package.
+
+Included areas:
+
+- DingTalk public-form optional-auth recovery.
+- Public-form audience clarity for DingTalk and DingTalk-granted forms.
+- Directory/user-management guardrails for missing `openId`.
+- User-management governance workbench, screening, CSV/Markdown exports, and bulk grant closure.
+- Admin audit deep links and scene presets for DingTalk governance actions.
+- Forced password-change sign-out escape hatch for account switching.
+
+Excluded areas:
+
+- No secret, token, webhook, or live public-form token is recorded.
+- No schema migration is introduced.
+- No staging deployment is performed by this code slice.
+
+## Design Summary
+
+### Public Form Auth Recovery
+
+Public-form routes intentionally use optional authentication. A stale or expired local bearer token must not block anonymous or DingTalk re-authenticated form access.
+
+The JWT middleware now allows public-form requests with `publicToken` to continue when optional auth hydration fails. It also avoids applying local `must_change_password` blocking to DingTalk-protected public-form access, because that flow is governed by DingTalk identity, grant, and form allowlist policy.
+
+### DingTalk Login Policy Errors
+
+Strict DingTalk grant denials now return policy-shaped errors instead of generic auth failures. This gives public-form and OAuth callers a stable `403` policy failure for cases such as:
+
+- grant required but absent
+- DingTalk account not linked to an enabled local user
+
+### Missing OpenID Guardrails
+
+Corp-scoped DingTalk login depends on `corpId + openId`. A directory or user-management flow may still have `unionId`, but enabling DingTalk login grant without `openId` creates a misleading state: the UI appears enabled while real DingTalk login can fail.
+
+The closeout applies the guard in three places:
+
+- directory bind
+- manual directory admission
+- user-management single and bulk DingTalk grant enable
+
+Directory-only binding remains allowed when DingTalk grant is not being enabled.
+
+### Governance Workbench
+
+User management now provides an operational surface for the missing-OpenID workflow:
+
+- summary counts for missing, governed, and pending accounts
+- `缺 OpenID` screening filter
+- row-level risk and closure feedback
+- CSV export for the current risk list
+- bulk close for missing-OpenID users that still have DingTalk grant enabled
+- Markdown exports for daily summary, validation checklist, result template, and execution package index
+- direct links to directory repair and audit review
+
+### Audit Scene Presets
+
+Admin audit now supports DingTalk governance shortcuts:
+
+- `resourceType=user-auth-grant`
+- `action=revoke`
+- optional recent 7-day range
+
+The audit page hydrates filters from URL query params and keeps the URL synchronized after applying scene presets.
+
+## Verification Plan
+
+Run focused tests matching the touched surfaces:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/jwt-middleware.test.ts \
+  tests/unit/dingtalk-oauth-login-gates.test.ts \
+  tests/unit/directory-sync-bind-account.test.ts \
+  tests/unit/admin-directory-routes.test.ts \
+  tests/unit/admin-users-routes.test.ts \
+  tests/integration/public-form-flow.test.ts \
+  --watch=false
+
+pnpm --filter @metasheet/web exec vitest run \
+  tests/ForcePasswordChangeView.spec.ts \
+  tests/adminAuditView.spec.ts \
+  tests/directoryManagementView.spec.ts \
+  tests/multitable-embed-route.spec.ts \
+  tests/multitable-form-share-manager.spec.ts \
+  tests/public-multitable-form.spec.ts \
+  tests/userManagementView.spec.ts \
+  --watch=false
+
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+git diff --check
+```
+
+## Verification Results
+
+### Backend Targeted Tests
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/jwt-middleware.test.ts \
+  tests/unit/dingtalk-oauth-login-gates.test.ts \
+  tests/unit/directory-sync-bind-account.test.ts \
+  tests/unit/admin-directory-routes.test.ts \
+  tests/unit/admin-users-routes.test.ts \
+  tests/integration/public-form-flow.test.ts \
+  --watch=false
+```
+
+Result:
+
+```text
+Test Files  6 passed (6)
+Tests       137 passed (137)
+```
+
+### Frontend Targeted Tests
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/ForcePasswordChangeView.spec.ts \
+  tests/adminAuditView.spec.ts \
+  tests/directoryManagementView.spec.ts \
+  tests/multitable-embed-route.spec.ts \
+  tests/multitable-form-share-manager.spec.ts \
+  tests/public-multitable-form.spec.ts \
+  tests/userManagementView.spec.ts \
+  --watch=false
+```
+
+Result:
+
+```text
+Test Files  7 passed (7)
+Tests       97 passed (97)
+```
+
+Notes:
+
+- The web Vitest run emitted the existing jsdom `Not implemented: navigation to another Document` stderr in navigation-oriented tests.
+- The web Vitest run also emitted a WebSocket port-in-use warning before execution.
+- Both were non-fatal; the command exited 0.
+
+### Type Checks
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+```
+
+Result: both exit 0.
+
+During verification, `vue-tsc` caught a DirectoryManagement helper type mismatch where a manual-admission result only had `accountId/integrationId`. The fix widened the local helper input type to optional `corpId/openId`, preserving runtime behavior while matching the actual call sites.
+
+### Package Builds
+
+```bash
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/web build
+```
+
+Result: both exit 0.
+
+Notes:
+
+- After rebasing onto `origin/main`, the first backend build failed because the local dependency links had not yet picked up the mainline `xlsx` dependency used by `univer-meta.ts`. Running `pnpm install --frozen-lockfile` refreshed the workspace links, and the backend build then passed.
+- The web build emitted existing Vite warnings about `WorkflowDesigner.vue` mixed static/dynamic imports and large chunks.
+- No build failure was observed.
+
+### Rebase Notes
+
+The branch was rebased onto `origin/main` after formula-editor PRs landed.
+
+Conflicts resolved:
+
+- `apps/web/tests/multitable-form-share-manager.spec.ts`: kept mainline matrix/status coverage and this branch's DingTalk status assertions.
+- `packages/core-backend/tests/integration/public-form-flow.test.ts`: kept the stricter `dingtalkPersonDeliveryAvailable` assertion.
+- `packages/core-backend/tests/unit/jwt-middleware.test.ts`: kept context, submit, stale-token, and missing-public-token coverage.
+- `docs/development/dingtalk-public-form-password-change-*`: normalized duplicate add/add docs into a single merged wording.
+
+Two unrelated untracked `integration-core-stale-run-besteffort-*` docs blocked checkout because main already has files with the same names. They were copied to `/tmp/metasheet2-untracked-backup-20260505/` before being moved aside locally; they are not part of this PR.
+
+### Patch Hygiene
+
+```bash
+git diff --check
+```
+
+Result: clean.

--- a/docs/development/dingtalk-p4-public-form-closeout-development-verification-20260505.md
+++ b/docs/development/dingtalk-p4-public-form-closeout-development-verification-20260505.md
@@ -1,0 +1,159 @@
+# DingTalk P4 Public Form Closeout Development And Verification - 2026-05-05
+
+## Scope
+
+This document closes the current DingTalk public-form slice on the 142 deployment:
+
+- Recover DingTalk public-form access when a browser carries an expired local MetaSheet JWT.
+- Return policy-level DingTalk OAuth errors instead of generic authentication failures.
+- Confirm direct-user and platform-member-group allowlists for `dingtalk_granted` public forms.
+- Record the current three-account test interpretation and remaining deployment risk.
+
+No public form token, DingTalk webhook, DingTalk secret, or JWT value is recorded here.
+
+## Development Summary
+
+### Public Form Auth Recovery
+
+Changed the backend public-form optional auth behavior:
+
+- Public-form routes still optionally hydrate `req.user` when a valid bearer token is present.
+- If the bearer token is expired or invalid and the request is a public-form request with `publicToken`, the middleware now continues without `req.user`.
+- The public-form policy layer then returns the correct business response, such as `DINGTALK_AUTH_REQUIRED`, instead of the JWT middleware returning `Invalid token`.
+
+Changed DingTalk strict-grant denials:
+
+- Unlinked or not-enabled DingTalk users in strict grant mode now throw `DingTalkLoginPolicyError`.
+- The auth callback returns a policy response instead of a generic `DingTalk authentication failed`.
+
+Related source files:
+
+- `packages/core-backend/src/auth/jwt-middleware.ts`
+- `packages/core-backend/src/auth/dingtalk-oauth.ts`
+- `packages/core-backend/tests/unit/jwt-middleware.test.ts`
+- `packages/core-backend/tests/unit/dingtalk-oauth-login-gates.test.ts`
+
+### Access Matrix Behavior
+
+The intended matrix for DingTalk public forms is:
+
+| Access mode | Anonymous | DingTalk-bound user | DingTalk grant required | Allowlist support |
+| --- | --- | --- | --- | --- |
+| `public` | Allowed | Allowed | No | Not allowed with allowlists |
+| `dingtalk` | Denied until DingTalk login | Allowed if bound | No | Direct users and member groups |
+| `dingtalk_granted` | Denied until DingTalk login | Allowed if bound and grant enabled | Yes | Direct users and member groups |
+
+Important password behavior:
+
+- Normal platform pages still enforce `must_change_password`.
+- DingTalk-protected public-form access can proceed for a user with `must_change_password=true`; the form policy is based on DingTalk binding/grant/allowlist, not ordinary platform password-change gating.
+
+### 142 Member Group Allowlist Setup
+
+On 2026-05-05, the latest P4 protected form on 142 was configured with:
+
+- Access mode: `dingtalk_granted`
+- Direct allowed users: `1`
+- Allowed member groups: `1`
+
+Temporary group:
+
+- Name: `P4 DingTalk Form Allowed Test`
+- Member: account 2, `王松松 / wss142`
+
+Backup:
+
+- Previous form config backup on 142: `/tmp/metasheet-p4-member-group-allowlist-backup-20260505T003933Z.json`
+
+Implementation note:
+
+- The first probe after direct DB update still denied account 2 because the backend `metaViewConfigCache` had the old `allowed_groups=0` config.
+- Restarting only `metasheet-backend` refreshed the cache and made the member-group allowlist effective.
+
+## Three-Account Status
+
+| Account | Current state | Expected result |
+| --- | --- | --- |
+| Account 1, `zhouhua@china-yaguang.com` | DingTalk-bound, grant enabled, direct allowlist user, no forced password change | Fully normal; can access the form |
+| Account 2, `王松松 / wss142` | DingTalk-bound, grant enabled, `must_change_password=true`, member of temporary allowed group | Ordinary platform pages require password change; DingTalk public form can access through the allowed member group |
+| Account 3, `P4 Unauthorized Target / p4unauth142` | DingTalk identity exists but is not in the current form allowlist; live client may still hit unlinked/mismatched DingTalk identity path | Must not access the form; expected denial is either not linked to an enabled local user or `DINGTALK_FORM_NOT_ALLOWED` depending on which DingTalk identity is used |
+
+## Verification
+
+### Automated Source Checks
+
+Commands run:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/jwt-middleware.test.ts tests/unit/dingtalk-oauth-login-gates.test.ts tests/unit/auth-login-routes.test.ts --watch=false
+git diff --check
+```
+
+Result:
+
+- Backend targeted tests passed: 53 tests.
+- `git diff --check` passed.
+
+### Live 142 Auth Recovery Probe
+
+Live probe used a real active public-form config and an intentionally invalid bearer token.
+
+Result:
+
+```text
+active_public_form=1
+http_status=401
+result=dingtalk_auth_required
+```
+
+Interpretation:
+
+- The request was no longer blocked by JWT middleware as `Invalid token`.
+- It reached the DingTalk public-form policy and returned the expected `DINGTALK_AUTH_REQUIRED`.
+
+### Live 142 Member Group Allowlist Probe
+
+After adding account 2 to the temporary allowed group and restarting `metasheet-backend`, short-lived server-signed tokens were used only for policy probing. Token values were not printed or stored.
+
+| Scenario | Result |
+| --- | --- |
+| Anonymous request | `401 DINGTALK_AUTH_REQUIRED` |
+| Account 1 direct allowlist user | `200 OK` |
+| Account 2 member-group user | `200 OK` |
+| Account 3 not in allowlist | `403 DINGTALK_FORM_NOT_ALLOWED` |
+
+### Current 142 Health
+
+Current backend health after the latest restart:
+
+```text
+status=ok
+success=true
+plugins.total=13
+plugins.active=13
+dbPool.waiting=0
+```
+
+Current P4 form allowlist state:
+
+```text
+allowed_users=1
+allowed_groups=1
+temporary_group_members=1
+```
+
+## Remaining Items
+
+- Manual client evidence: account 2 should open the current DingTalk form link and confirm the previous "not in authorized user group" message is gone.
+- Manual client evidence: account 3 should still fail and must not gain access.
+- Release hardening: 142 currently includes runtime/container hot patches. Replace them with a normal backend image build and deployment so the fixes survive the next rollout.
+- Operational cleanup: decide whether `P4 DingTalk Form Allowed Test` should become a real production group or be removed after verification.
+
+## Related Evidence Docs
+
+- `docs/development/dingtalk-public-form-access-matrix-design-20260428.md`
+- `docs/development/dingtalk-public-form-access-matrix-verification-20260428.md`
+- `docs/development/dingtalk-public-form-auth-recovery-design-20260430.md`
+- `docs/development/dingtalk-public-form-auth-recovery-verification-20260430.md`
+- `docs/development/dingtalk-public-form-member-group-allowlist-verification-20260505.md`
+

--- a/docs/development/dingtalk-public-form-access-matrix-design-20260428.md
+++ b/docs/development/dingtalk-public-form-access-matrix-design-20260428.md
@@ -1,0 +1,59 @@
+# DingTalk Public Form Access Matrix Design
+
+- Date: 2026-04-28
+- Scope: public multitable form sharing, DingTalk protected access, local allowlists
+
+## Product Rule
+
+Public form sharing now has three effective audience modes:
+
+| Scenario | Access mode | Local allowlist | Required identity | Fill behavior |
+| --- | --- | --- | --- | --- |
+| 1. Fully public anonymous fill | `public` | Not allowed | None | Anyone with the link can open and submit. |
+| 2. User login required | `dingtalk` | Empty | DingTalk-bound local user | Anonymous visitors launch DingTalk sign-in. Bound users can fill. Unbound users see a binding-required message. |
+| 2.1 User not DingTalk-bound | `dingtalk` | Empty | Missing binding | Rejected with `DINGTALK_BIND_REQUIRED`. |
+| 2.2 User DingTalk-bound | `dingtalk` | Empty | Binding present | Allowed. |
+| 3. Selected users or groups fill | `dingtalk` or `dingtalk_granted` | Non-empty users/groups | DingTalk-bound selected user, or selected group member | Users outside the local allowlist are rejected. |
+| 3.1 Selected user not DingTalk-bound | `dingtalk` or `dingtalk_granted` | User/group selected | Missing binding | Rejected with `DINGTALK_BIND_REQUIRED`. |
+| 3.2 Selected user DingTalk-bound | `dingtalk` | User/group selected | Binding present | Allowed. |
+| 3.2 Selected user DingTalk-bound and authorization required | `dingtalk_granted` | User/group selected | Binding and enabled DingTalk grant | Allowed only when grant is enabled; otherwise `DINGTALK_GRANT_REQUIRED`. |
+
+## Password-Change Rule
+
+Users created from platform management or directory sync may have `must_change_password = true` until their first local-password login.
+
+That flag should not block the DingTalk public-form filling path when the user authenticates through DingTalk. The form flow is an external-auth, narrow-scoped filling session, not full local account access. Therefore:
+
+- Public-form requests with a valid public token can optionally hydrate that user and continue DingTalk binding/grant/allowlist checks.
+- Normal authenticated app routes still return `PASSWORD_CHANGE_REQUIRED` and route the user to `/force-password-change`.
+- Local password login and platform-wide navigation still require first password change.
+
+## Implementation
+
+Backend:
+
+- Public form allowlist summaries now include DingTalk status fields for allowed local users:
+  - `dingtalkBound`
+  - `dingtalkGrantEnabled`
+  - `dingtalkPersonDeliveryAvailable`
+- Existing access checks remain the source of truth:
+  - `public` bypasses DingTalk user checks.
+  - `dingtalk` requires a DingTalk binding.
+  - `dingtalk_granted` requires binding plus enabled DingTalk form authorization.
+  - Non-empty `allowedUserIds` or `allowedMemberGroupIds` narrows access after DingTalk checks.
+
+Frontend:
+
+- The form-share dialog shows an explicit audience rule card:
+  - Fully public anonymous form
+  - All DingTalk-bound users
+  - All authorized DingTalk users
+  - Selected DingTalk-bound users
+  - Selected authorized DingTalk users
+- Allowed users and search candidates show their DingTalk status so operators can identify 3.1 and 3.2 before sharing.
+- Member groups show that members are checked individually.
+
+## Operational Guidance
+
+For the user case described on 2026-04-28: a DingTalk user imported by platform management but not yet locally password-changed should be able to fill a DingTalk-protected public form after DingTalk sign-in, as long as they pass the binding/grant/allowlist rule. They should only be forced to change password when entering the main platform app or using local password login.
+

--- a/docs/development/dingtalk-public-form-access-matrix-verification-20260428.md
+++ b/docs/development/dingtalk-public-form-access-matrix-verification-20260428.md
@@ -1,0 +1,65 @@
+# DingTalk Public Form Access Matrix Verification
+
+- Date: 2026-04-28
+- Scope: access matrix, DingTalk binding/grant status display, password-change guard
+
+## Commands
+
+Passed:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/integration/public-form-flow.test.ts tests/unit/jwt-middleware.test.ts --watch=false
+```
+
+Result:
+
+- 2 test files passed
+- 33 tests passed
+
+Passed:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-form-share-manager.spec.ts tests/public-multitable-form.spec.ts tests/multitable-embed-route.spec.ts tests/multitable-phase4.spec.ts --watch=false
+```
+
+Result:
+
+- 4 test files passed
+- 33 tests passed
+- Sandbox printed a non-gating Vite HMR socket `EPERM` warning and jsdom navigation warning; exit code was 0.
+
+Passed:
+
+```bash
+pnpm --filter @metasheet/core-backend build
+```
+
+Passed:
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result:
+
+- Build passed.
+- Vite printed existing large-chunk warnings.
+
+Passed:
+
+```bash
+git diff --check
+```
+
+## Coverage
+
+- Public anonymous token context and submit still pass.
+- Anonymous visitor on DingTalk-protected form gets `DINGTALK_AUTH_REQUIRED`.
+- DingTalk-bound user can open `dingtalk` forms.
+- Bound user without enabled grant is rejected by `dingtalk_granted` forms.
+- Bound user outside local allowlist gets `DINGTALK_FORM_NOT_ALLOWED`.
+- Bound user in allowed member group can open the form.
+- Allowed-user share config returns DingTalk binding and grant status.
+- The form-share UI displays the selected audience rule and per-user DingTalk status.
+- Public-form optional auth allows `must_change_password` users to continue the DingTalk form path while normal app APIs still enforce password change.
+

--- a/docs/development/dingtalk-public-form-auth-recovery-design-20260430.md
+++ b/docs/development/dingtalk-public-form-auth-recovery-design-20260430.md
@@ -1,0 +1,43 @@
+# DingTalk Public Form Auth Recovery Design - 2026-04-30
+
+## Context
+
+Two live DingTalk public-form symptoms were observed on the 142 deployment:
+
+- A previously bound account opened a DingTalk public-form link and saw `Invalid token`.
+- Another account clicked DingTalk sign-in and saw the generic `DingTalk authentication failed` message.
+
+Backend logs showed two separate causes:
+
+- The first flow carried an expired local MetaSheet JWT from browser storage. The public-form route uses optional auth, but the optional middleware still rejected stale bearer tokens before the form access policy could run.
+- The second flow reached DingTalk OAuth callback, but strict DingTalk grant mode rejected the DingTalk account because it was not linked to an enabled local user. That strict-grant denial was thrown as a generic `Error`, so the route mapped it to a generic 500-style authentication failure.
+
+## Design
+
+### Public Form Optional Auth
+
+Public-form access is already identified by `isPublicFormAuthBypass(req)` for:
+
+- `GET /api/multitable/form-context?publicToken=...`
+- `POST /api/multitable/views/:viewId/submit` with `publicToken`
+
+For those routes, bearer auth is optional. A valid bearer token should still hydrate `req.user`, but an invalid or expired bearer token must not block the request. The request should continue unauthenticated so the public-form policy can decide the next step:
+
+- anonymous public form: allow if the public token and form policy allow it
+- DingTalk-protected public form: return `DINGTALK_AUTH_REQUIRED`
+- allowlist-protected form: return the existing policy denial
+
+### DingTalk Strict Grant Denials
+
+Strict DingTalk grant mode is a policy decision, not a server failure. These cases now throw `DingTalkLoginPolicyError`:
+
+- linked identity exists, but no enabled DingTalk grant is present
+- email auto-link finds a local user, but no enabled DingTalk grant is present
+- no linked/enabled local user exists while `DINGTALK_AUTH_REQUIRE_GRANT=1`
+
+The auth route already maps `DingTalkLoginPolicyError` to its configured status and message, so the callback now returns a 403 policy response instead of a generic authentication failure.
+
+## Operational Note
+
+The 142 backend was hot-patched after source changes were made locally. The hot patch is suitable for immediate live retest, but it should still be replaced by a normal image build/deploy so the fix survives the next container rollout.
+

--- a/docs/development/dingtalk-public-form-auth-recovery-verification-20260430.md
+++ b/docs/development/dingtalk-public-form-auth-recovery-verification-20260430.md
@@ -1,0 +1,62 @@
+# DingTalk Public Form Auth Recovery Verification - 2026-04-30
+
+## Source Verification
+
+Commands run from `/Users/chouhua/Downloads/Github/metasheet2`:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/jwt-middleware.test.ts tests/unit/dingtalk-oauth-login-gates.test.ts tests/unit/auth-login-routes.test.ts --watch=false
+git diff --check
+```
+
+Result:
+
+- `tests/unit/jwt-middleware.test.ts`: passed
+- `tests/unit/dingtalk-oauth-login-gates.test.ts`: passed
+- `tests/unit/auth-login-routes.test.ts`: passed
+- total targeted tests: 53 passed
+- `git diff --check`: passed
+
+## Live 142 Verification
+
+Backend log evidence before the fix:
+
+- Multiple public-form requests showed `jwt expired`, matching the `Invalid token` report.
+- DingTalk callback requests reached the backend and failed with `DingTalk account is not linked to an enabled local user`, matching the second account's sign-in failure.
+
+142 hot-patch actions:
+
+- Backed up container files under `/tmp/metasheet142-hotpatch-20260430-auth/` on 142.
+- Patched the running `metasheet-backend` compiled auth files.
+- Restarted only `metasheet-backend`.
+
+Health check after restart:
+
+```text
+status=ok
+success=true
+plugins=13
+plugins.active=13
+dbPool.waiting=0
+```
+
+Public-form stale-token probe:
+
+```text
+active_public_form=1
+http_status=401
+result=dingtalk_auth_required
+```
+
+Interpretation:
+
+- The request used a real active public-form token plus an intentionally invalid bearer token.
+- The response was no longer the JWT middleware's `Invalid token`.
+- The request reached the public-form DingTalk policy and returned `DINGTALK_AUTH_REQUIRED`, which is the expected re-auth path for a DingTalk-protected form.
+
+## Remaining Manual Retest
+
+- Previously bound account: reopen the DingTalk public-form link. Expected behavior is DingTalk re-auth or form access, not immediate `Invalid token`.
+- Unlinked account: click DingTalk sign-in. Expected behavior is a 403 policy message indicating the account is not linked/enabled, unless the admin binds the user and enables the DingTalk grant first.
+- Durable deploy: replace the 142 hot patch with the next normal backend image deployment.
+

--- a/docs/development/dingtalk-public-form-member-group-allowlist-verification-20260505.md
+++ b/docs/development/dingtalk-public-form-member-group-allowlist-verification-20260505.md
@@ -1,0 +1,73 @@
+# DingTalk Public Form Member Group Allowlist Verification - 2026-05-05
+
+## Goal
+
+Verify the DingTalk public-form allowlist path that grants access through a platform member group, not only through direct `allowedUserIds`.
+
+## Live 142 Setup
+
+Target:
+
+- Deployment: `142.171.239.56`
+- Form view: latest DingTalk P4 protected form
+- Access mode: `dingtalk_granted`
+- Direct allowed users: `1`
+- Allowed member groups: `1`
+
+Temporary member group:
+
+- Name: `P4 DingTalk Form Allowed Test`
+- Member: account 2, `王松松 / wss142`
+- Created for this verification only.
+
+Safety:
+
+- The previous form config was backed up on 142 at `/tmp/metasheet-p4-member-group-allowlist-backup-20260505T003933Z.json`.
+- No public form token, JWT, webhook, or DingTalk secret is recorded in this document.
+
+## Implementation Notes
+
+The first probe after direct DB update still denied account 2. Data inspection showed the membership row and allowlist config were correct, so the mismatch was caused by the backend view-config cache retaining the previous `allowed_groups=0` state.
+
+Action taken:
+
+- Restarted only `metasheet-backend` to clear the in-memory `metaViewConfigCache`.
+- Health check passed after restart.
+
+Health summary:
+
+```text
+status=ok
+success=true
+plugins.total=13
+plugins.active=13
+dbPool.waiting=0
+```
+
+## Probe Results
+
+The probes used short-lived server-signed JWTs to simulate the post-DingTalk-auth public-form policy check. Tokens were not printed or stored.
+
+| Scenario | Expected | Actual |
+| --- | --- | --- |
+| Anonymous request | Requires DingTalk auth | `401 DINGTALK_AUTH_REQUIRED` |
+| Account 1 direct allowlist user | Allowed | `200 OK` |
+| Account 2 member-group user | Allowed through group | `200 OK` |
+| Account 3 not in allowlist | Denied by allowlist | `403 DINGTALK_FORM_NOT_ALLOWED` |
+
+## Conclusion
+
+The member-group allowlist path works on 142 after the backend cache is refreshed. Account 2 can be granted access through a platform member group even though ordinary platform navigation still requires password change.
+
+## Manual Follow-Up
+
+Use account 2 in DingTalk to open the current P4 public-form link. Expected result:
+
+- It should no longer show "not in authorized user group".
+- It should enter the form flow because the user is now in the allowed member group.
+
+Use account 3 to open the same link. Expected result:
+
+- It should still fail before or at authorization, depending on whether the DingTalk identity is linked.
+- It must not gain access through the temporary group.
+

--- a/docs/development/dingtalk-public-form-password-change-design-20260428.md
+++ b/docs/development/dingtalk-public-form-password-change-design-20260428.md
@@ -16,7 +16,7 @@ The public form endpoints intentionally use optional JWT auth:
 
 Those endpoints must allow both anonymous public forms and DingTalk-protected forms. For DingTalk-protected forms, a bearer token carries the local user identity bound to a DingTalk account.
 
-The bug was that optional auth reused the normal password-change guard. If a DingTalk-bound local user had `must_change_password = true`, `hydrateAuthenticatedUser()` returned `403 PASSWORD_CHANGE_REQUIRED` before public-form DingTalk access rules could run.
+The bug was that optional auth reused the normal password-change guard. If a DingTalk-bound local user had `must_change_password = true`, `hydrateAuthenticatedUser()` returned `403 PASSWORD_CHANGE_REQUIRED` before public-form DingTalk access rules could run. The frontend already suppressed global redirects for public-form requests, so it displayed the backend message in-place.
 
 The public form route also did not opt out of shell bootstrap, so unrelated product-feature loading could run on a public route.
 

--- a/docs/development/dingtalk-public-form-password-change-verification-20260428.md
+++ b/docs/development/dingtalk-public-form-password-change-verification-20260428.md
@@ -22,8 +22,6 @@ git diff --check
 
 ## Results
 
-Executed in `/tmp/ms2-dingtalk-public-form-password-change` on branch `codex/dingtalk-public-form-password-change-20260428`.
-
 Backend JWT middleware unit test:
 
 ```text
@@ -57,5 +55,5 @@ git diff --check
 
 ## Non-Gating Observations
 
-- The frontend Vitest run printed a Vite websocket `Port is already in use` warning and a jsdom navigation warning from the DingTalk redirect test. Exit code was 0.
+- The frontend Vitest run printed Vite websocket/socket warnings and a jsdom navigation warning from DingTalk redirect tests. Exit code was 0.
 - The frontend production build printed existing dynamic-import and large-chunk warnings. Exit code was 0.

--- a/docs/development/dingtalk-user-management-openid-grant-guard-development-verification-20260505.md
+++ b/docs/development/dingtalk-user-management-openid-grant-guard-development-verification-20260505.md
@@ -1,0 +1,72 @@
+# DingTalk User Management OpenId Grant Guard - Development And Verification
+
+Date: 2026-05-05
+
+## Background
+
+The previous fix closed the gap in directory bind/admission flows, but `UserManagement` still had two grant entry points that could bypass that policy:
+
+- Single-user grant toggle in the user detail panel.
+- Bulk DingTalk grant update from the user list.
+
+That meant an admin could still enable DingTalk login for a corp-scoped identity missing `openId`, even though real DingTalk login would remain unreliable or fail.
+
+## Development
+
+Changed files:
+
+- `packages/core-backend/src/routes/admin-users.ts`
+- `packages/core-backend/tests/unit/admin-users-routes.test.ts`
+- `apps/web/src/views/UserManagementView.vue`
+- `apps/web/tests/userManagementView.spec.ts`
+
+Backend behavior:
+
+- Extended DingTalk identity snapshot payload with:
+  - `hasOpenId`
+  - `hasUnionId`
+- Added a guard before enabling DingTalk grant:
+  - if the user already has a corp-scoped DingTalk identity and `provider_open_id` is missing, enabling grant is rejected.
+- Applied the guard to:
+  - `PATCH /api/admin/users/:userId/dingtalk-grant`
+  - `POST /api/admin/users/dingtalk-grants/bulk`
+- Route policy failures now return `400 DINGTALK_OPEN_ID_REQUIRED` instead of a generic `500`.
+
+Frontend behavior:
+
+- User detail page now warns when the current DingTalk identity is corp-scoped but missing `openId`.
+- “开通钉钉扫码” is disabled in that state.
+- The click handler also blocks locally and shows a clear error message, preventing accidental requests if UI state lags.
+
+## Verification
+
+Commands run:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/admin-users-routes.test.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/userManagementView.spec.ts --watch=false
+git diff --check
+```
+
+Results:
+
+- Backend: 1 test file passed, 61 tests passed.
+- Frontend: 1 test file passed, 12 tests passed.
+- `git diff --check`: passed.
+
+Coverage added:
+
+- Reject single-user DingTalk grant enable when bound identity is missing `openId`.
+- Reject bulk DingTalk grant enable when any selected bound identity is missing `openId`.
+- Preserve existing revoke behavior and success paths.
+- Render warning and disable enable button in the user detail page for missing-`openId` identities.
+
+## Outcome
+
+The DingTalk `openId` guard is now consistent across:
+
+- Directory bind/admission
+- User detail grant enable
+- Bulk grant enable
+
+This does not repair already incomplete identity data by itself, but it prevents admins from reintroducing the same broken state through other management surfaces.

--- a/packages/core-backend/src/auth/dingtalk-oauth.ts
+++ b/packages/core-backend/src/auth/dingtalk-oauth.ts
@@ -586,7 +586,10 @@ async function resolveLocalUser(dtUser: DingTalkUserInfo): Promise<{ localUser: 
     assertLocalUserLoginAllowed(identityUser)
     const grantEnabled = await readGrantEnabled(identityUser.id)
     if (requireGrant && grantEnabled !== true) {
-      throw new Error('DingTalk login is not enabled for this user')
+      throw createPolicyError('DingTalk login is not enabled for this user', {
+        statusCode: 403,
+        code: 'grant_required',
+      })
     }
     if (grantEnabled === false) {
       throw createPolicyError(DINGTALK_LOGIN_DISABLED_ERROR, {
@@ -604,7 +607,10 @@ async function resolveLocalUser(dtUser: DingTalkUserInfo): Promise<{ localUser: 
       assertLocalUserLoginAllowed(emailUser)
       const grantEnabled = await readGrantEnabled(emailUser.id)
       if (requireGrant && grantEnabled !== true) {
-        throw new Error('DingTalk login is not enabled for this user')
+        throw createPolicyError('DingTalk login is not enabled for this user', {
+          statusCode: 403,
+          code: 'grant_required',
+        })
       }
       if (grantEnabled === false) {
         throw createPolicyError(DINGTALK_LOGIN_DISABLED_ERROR, {
@@ -621,10 +627,14 @@ async function resolveLocalUser(dtUser: DingTalkUserInfo): Promise<{ localUser: 
   }
 
   if (requireGrant) {
-    throw new Error(
+    throw createPolicyError(
       dtUser.email
         ? `DingTalk account ${dtUser.email} is not linked to an enabled local user`
         : 'DingTalk account is not linked to an enabled local user',
+      {
+        statusCode: 403,
+        code: 'unlinked_enabled_local_user',
+      },
     )
   }
 

--- a/packages/core-backend/src/auth/jwt-middleware.ts
+++ b/packages/core-backend/src/auth/jwt-middleware.ts
@@ -135,6 +135,11 @@ export async function optionalJwtAuthMiddleware(req: Request, res: Response, nex
 
   const result = await hydrateAuthenticatedUser(req, token)
   if (isHydrateFailure(result)) {
+    if (isPublicFormAuthBypass(req)) {
+      // Public-form auth is optional. A stale local browser token should not
+      // block anonymous or DingTalk re-authenticated form access.
+      return next()
+    }
     if (result.metricReason) {
       metrics.jwtAuthFail.inc({ reason: result.metricReason })
       metrics.authFailures.inc()

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -32,6 +32,8 @@ const DEFAULT_ROOT_DEPARTMENT_ID = '1'
 const DEFAULT_PAGE_SIZE = 50
 const DEFAULT_ADMISSION_MODE = 'manual_only'
 const DEFAULT_MEMBER_GROUP_SYNC_MODE = 'disabled'
+const DINGTALK_OPEN_ID_REQUIRED_FOR_GRANT_ERROR =
+  'Directory account is missing DingTalk openId and cannot enable DingTalk login grant; resync DingTalk directory or complete DingTalk OAuth binding first'
 
 type JsonRecord = Record<string, unknown>
 export type DirectoryAdmissionMode = 'manual_only' | 'auto_for_scoped_departments'
@@ -1075,6 +1077,16 @@ function buildDingTalkIdentityExternalKey(corpId: string | null | undefined, ope
   }
 
   return normalizedUnionId || normalizedOpenId
+}
+
+function assertDirectoryAccountCanEnableDingTalkGrant(
+  account: Pick<DirectoryBindingTargetAccountRow, 'corp_id' | 'open_id'>,
+  enableDingTalkGrant: boolean,
+): void {
+  if (!enableDingTalkGrant) return
+  if (!normalizeText(account.corp_id)) return
+  if (normalizeText(account.open_id)) return
+  throw new Error(DINGTALK_OPEN_ID_REQUIRED_FOR_GRANT_ERROR)
 }
 
 function buildRecommendationScore(reasons: DirectoryBindingRecommendationReason[]): number {
@@ -2861,6 +2873,7 @@ async function applyDirectoryAccountBindInTransaction(
   if (!identityExternalKey) {
     throw new Error('Directory account is missing DingTalk openId/unionId and cannot be pre-bound for DingTalk login')
   }
+  assertDirectoryAccountCanEnableDingTalkGrant(account, enableDingTalkGrant)
 
   const profile = JSON.stringify({
     source: 'directory_admin_bind',
@@ -3534,6 +3547,7 @@ export async function bindDirectoryAccount(
   if (!buildDingTalkIdentityExternalKey(account.corp_id, account.open_id, account.union_id)) {
     throw new Error('Directory account is missing DingTalk openId/unionId and cannot be pre-bound for DingTalk login')
   }
+  assertDirectoryAccountCanEnableDingTalkGrant(account, enableDingTalkGrant)
 
   const localUser = await resolveDirectoryBindingUser(normalizedLocalUserRef)
   if (!localUser) throw new Error('Local user not found')
@@ -3604,6 +3618,7 @@ export async function admitDirectoryAccountUser(
   if (!buildDingTalkIdentityExternalKey(account.corp_id, account.open_id, account.union_id)) {
     throw new Error('Directory account is missing DingTalk openId/unionId and cannot be pre-bound for DingTalk login')
   }
+  assertDirectoryAccountCanEnableDingTalkGrant(account, enableDingTalkGrant)
 
   const passwordHash = await bcrypt.hash(generatedPassword, getBcryptSaltRounds())
   let userId = ''

--- a/packages/core-backend/src/routes/admin-directory.ts
+++ b/packages/core-backend/src/routes/admin-directory.ts
@@ -353,7 +353,7 @@ export function adminDirectoryRouter(): Router {
         ? 404
         : /already bound|already linked/i.test(message)
           ? 409
-          : /required|cannot be pre-bound/i.test(message)
+          : /required|cannot be pre-bound|missing DingTalk openId/i.test(message)
             ? 400
             : 500
       jsonError(res, statusCode, 'DIRECTORY_BIND_FAILED', message)
@@ -432,7 +432,7 @@ export function adminDirectoryRouter(): Router {
         ? 404
         : /already exists|already bound|already linked/i.test(message)
           ? 409
-          : /required|invalid|password|cannot be pre-bound/i.test(message)
+          : /required|invalid|password|cannot be pre-bound|missing DingTalk openId/i.test(message)
             ? 400
             : 500
       jsonError(res, statusCode, 'DIRECTORY_ADMISSION_FAILED', message)
@@ -485,7 +485,7 @@ export function adminDirectoryRouter(): Router {
         ? 404
         : /already bound|already linked/i.test(message)
           ? 409
-          : /required|cannot be pre-bound/i.test(message)
+          : /required|cannot be pre-bound|missing DingTalk openId/i.test(message)
             ? 400
             : 500
       jsonError(res, statusCode, 'DIRECTORY_BATCH_BIND_FAILED', message)

--- a/packages/core-backend/src/routes/admin-users.ts
+++ b/packages/core-backend/src/routes/admin-users.ts
@@ -97,17 +97,36 @@ type AdminInviteLedgerRow = {
 }
 
 type AdminDingTalkGrantRow = {
+  user_id?: string
   enabled: boolean
   granted_by: string | null
+  granted_by_name?: string | null
+  granted_by_email?: string | null
   created_at: string
   updated_at: string
 }
 
 type AdminDingTalkIdentityRow = {
+  local_user_id?: string
   corp_id: string | null
+  provider_union_id: string | null
+  provider_open_id: string | null
   last_login_at: string | null
   created_at: string
   updated_at: string
+}
+
+type AdminUserListSignals = {
+  dingtalkLoginEnabled: boolean
+  dingtalkGrantUpdatedAt: string | null
+  dingtalkGrantUpdatedBy: string | null
+  directoryLinked: boolean
+  dingtalkIdentityExists: boolean
+  dingtalkHasUnionId: boolean
+  dingtalkHasOpenId: boolean
+  dingtalkOpenIdMissing: boolean
+  dingtalkCorpId: string | null
+  lastDirectorySyncAt: string | null
 }
 
 type DirectoryMembershipRow = {
@@ -249,6 +268,8 @@ type CreateUserRequestBody = {
 
 const ADMIN_AUDIT_RESOURCE_TYPES = ['user', 'user-role', 'user-auth-grant', 'user-namespace-admission', 'user-password', 'user-session', 'user-invite', 'role', 'permission', 'permission-template', 'delegated-admin-scope', 'delegated-admin-scope-template', 'platform-member-group', 'delegated-admin-group-scope'] as const
 const DINGTALK_PROVIDER = 'dingtalk'
+const DINGTALK_OPEN_ID_REQUIRED_FOR_GRANT_ERROR =
+  'Directory account is missing DingTalk openId and cannot enable DingTalk login grant; resync DingTalk directory or complete DingTalk OAuth binding first'
 const PLATFORM_ADMIN_ROLE_ID = 'admin'
 const ATTENDANCE_ROLE_IDS = new Set(['attendance_employee', 'attendance_approver', 'attendance_admin'])
 
@@ -429,7 +450,7 @@ async function fetchDingTalkAccessSnapshot(userId: string) {
       [DINGTALK_PROVIDER, userId],
     ),
     query<AdminDingTalkIdentityRow>(
-      `SELECT corp_id, last_login_at, created_at, updated_at
+      `SELECT corp_id, provider_union_id, provider_open_id, last_login_at, created_at, updated_at
        FROM user_external_identities
        WHERE provider = $1 AND local_user_id = $2
        ORDER BY updated_at DESC
@@ -472,11 +493,124 @@ async function fetchDingTalkAccessSnapshot(userId: string) {
     identity: {
       exists: identity !== null,
       corpId: identity?.corp_id ?? null,
+      unionId: identity?.provider_union_id ?? null,
+      openId: identity?.provider_open_id ?? null,
+      hasUnionId: Boolean(identity?.provider_union_id),
+      hasOpenId: Boolean(identity?.provider_open_id),
       lastLoginAt: identity?.last_login_at ?? null,
       createdAt: identity?.created_at ?? null,
       updatedAt: identity?.updated_at ?? null,
     },
   }
+}
+
+async function assertUsersCanEnableDingTalkGrant(userIds: string[]): Promise<void> {
+  if (userIds.length === 0) return
+
+  const identityResult = await query<{
+    local_user_id: string
+    corp_id: string | null
+    provider_open_id: string | null
+  }>(
+    `SELECT local_user_id, corp_id, provider_open_id
+     FROM user_external_identities
+     WHERE provider = $1
+       AND local_user_id = ANY($2::text[])`,
+    [DINGTALK_PROVIDER, userIds],
+  )
+
+  const blockedUserIds = new Set<string>()
+  for (const row of identityResult.rows) {
+    if (row.corp_id && !row.provider_open_id) {
+      blockedUserIds.add(row.local_user_id)
+    }
+  }
+
+  if (blockedUserIds.size > 0) {
+    throw new Error(`${DINGTALK_OPEN_ID_REQUIRED_FOR_GRANT_ERROR} (userIds: ${Array.from(blockedUserIds).sort().join(', ')})`)
+  }
+}
+
+async function fetchAdminUserListSignals(userIds: string[]): Promise<Map<string, AdminUserListSignals>> {
+  const signalMap = new Map<string, AdminUserListSignals>()
+  if (userIds.length === 0) return signalMap
+
+  const [grantResult, directoryResult, identityResult] = await Promise.all([
+    query<Required<Pick<AdminDingTalkGrantRow, 'user_id' | 'enabled' | 'granted_by' | 'created_at' | 'updated_at'>> & {
+      granted_by_name: string | null
+      granted_by_email: string | null
+    }>(
+      `SELECT
+          g.local_user_id AS user_id,
+          g.enabled,
+          g.granted_by,
+          g.created_at,
+          g.updated_at,
+          u.name AS granted_by_name,
+          u.email AS granted_by_email
+       FROM user_external_auth_grants g
+       LEFT JOIN users u ON u.id = g.granted_by
+       WHERE provider = $1
+         AND local_user_id = ANY($2::text[])`,
+      [DINGTALK_PROVIDER, userIds],
+    ),
+    query<{ user_id: string, last_directory_sync_at: string | null }>(
+      `SELECT
+          l.local_user_id AS user_id,
+          MAX(a.updated_at) AS last_directory_sync_at
+       FROM directory_account_links l
+       JOIN directory_accounts a ON a.id = l.directory_account_id
+       WHERE l.link_status = 'linked'
+         AND l.local_user_id = ANY($1::text[])
+       GROUP BY l.local_user_id`,
+      [userIds],
+    ),
+    query<Required<Pick<AdminDingTalkIdentityRow, 'local_user_id' | 'corp_id' | 'provider_union_id' | 'provider_open_id'>> & {
+      last_login_at: string | null
+      created_at: string
+      updated_at: string
+    }>(
+      `SELECT DISTINCT ON (local_user_id)
+          local_user_id,
+          corp_id,
+          provider_union_id,
+          provider_open_id,
+          last_login_at,
+          created_at,
+          updated_at
+       FROM user_external_identities
+       WHERE provider = $1
+         AND local_user_id = ANY($2::text[])
+       ORDER BY local_user_id, updated_at DESC`,
+      [DINGTALK_PROVIDER, userIds],
+    ),
+  ])
+
+  const grantMap = new Map(grantResult.rows.map((row) => [row.user_id, row]))
+  const directoryMap = new Map(directoryResult.rows.map((row) => [row.user_id, row.last_directory_sync_at ?? null]))
+  const identityMap = new Map(identityResult.rows.map((row) => [row.local_user_id, row]))
+
+  for (const userId of userIds) {
+    const grant = grantMap.get(userId)
+    const identity = identityMap.get(userId)
+    const hasUnionId = Boolean(identity?.provider_union_id)
+    const hasOpenId = Boolean(identity?.provider_open_id)
+    const corpId = identity?.corp_id ?? null
+    signalMap.set(userId, {
+      dingtalkLoginEnabled: grant?.enabled === true,
+      dingtalkGrantUpdatedAt: grant?.updated_at ?? null,
+      dingtalkGrantUpdatedBy: grant?.granted_by_name ?? grant?.granted_by_email ?? grant?.granted_by ?? null,
+      directoryLinked: directoryMap.has(userId),
+      dingtalkIdentityExists: Boolean(identity),
+      dingtalkHasUnionId: hasUnionId,
+      dingtalkHasOpenId: hasOpenId,
+      dingtalkOpenIdMissing: Boolean(identity && corpId && !hasOpenId),
+      dingtalkCorpId: corpId,
+      lastDirectorySyncAt: directoryMap.get(userId) ?? null,
+    })
+  }
+
+  return signalMap
 }
 
 function normalizeUserIdList(value: unknown): string[] {
@@ -2513,8 +2647,25 @@ export function adminUsersRouter(): Router {
         }
       }
 
+      const userSignals = await fetchAdminUserListSignals(items.map((row) => row.id))
+
       return jsonOk(res, {
-        items,
+        items: items.map((row) => {
+          const signals = userSignals.get(row.id)
+          return {
+            ...row,
+            dingtalkLoginEnabled: signals?.dingtalkLoginEnabled ?? false,
+            dingtalkGrantUpdatedAt: signals?.dingtalkGrantUpdatedAt ?? null,
+            dingtalkGrantUpdatedBy: signals?.dingtalkGrantUpdatedBy ?? null,
+            directoryLinked: signals?.directoryLinked ?? false,
+            dingtalkIdentityExists: signals?.dingtalkIdentityExists ?? false,
+            dingtalkHasUnionId: signals?.dingtalkHasUnionId ?? false,
+            dingtalkHasOpenId: signals?.dingtalkHasOpenId ?? false,
+            dingtalkOpenIdMissing: signals?.dingtalkOpenIdMissing ?? false,
+            dingtalkCorpId: signals?.dingtalkCorpId ?? null,
+            lastDirectorySyncAt: signals?.lastDirectorySyncAt ?? null,
+          }
+        }),
         page,
         pageSize,
         total,
@@ -3272,6 +3423,7 @@ export function adminUsersRouter(): Router {
 
       const profile = await fetchUserProfile(userId)
       if (!profile) return jsonError(res, 404, 'NOT_FOUND', 'User not found')
+      if (enabled) await assertUsersCanEnableDingTalkGrant([userId])
 
       await upsertDingTalkGrants([userId], enabled, adminUserId)
 
@@ -3295,7 +3447,11 @@ export function adminUsersRouter(): Router {
         ...(await fetchDingTalkAccessSnapshot(userId)),
       })
     } catch (error) {
-      return jsonError(res, 500, 'DINGTALK_GRANT_UPDATE_FAILED', (error as Error)?.message || 'Failed to update DingTalk access')
+      const message = (error as Error)?.message || 'Failed to update DingTalk access'
+      if (message.includes('missing DingTalk openId')) {
+        return jsonError(res, 400, 'DINGTALK_OPEN_ID_REQUIRED', message)
+      }
+      return jsonError(res, 500, 'DINGTALK_GRANT_UPDATE_FAILED', message)
     }
   })
 
@@ -3320,6 +3476,7 @@ export function adminUsersRouter(): Router {
       if (missingUserIds.length > 0) {
         return jsonError(res, 404, 'USERS_NOT_FOUND', 'One or more users were not found', { missingUserIds })
       }
+      if (enabled) await assertUsersCanEnableDingTalkGrant(userIds)
 
       await upsertDingTalkGrants(userIds, enabled, adminUserId)
 
@@ -3346,7 +3503,11 @@ export function adminUsersRouter(): Router {
         userIds,
       })
     } catch (error) {
-      return jsonError(res, 500, 'DINGTALK_BULK_GRANT_UPDATE_FAILED', (error as Error)?.message || 'Failed to update DingTalk access in bulk')
+      const message = (error as Error)?.message || 'Failed to update DingTalk access in bulk'
+      if (message.includes('missing DingTalk openId')) {
+        return jsonError(res, 400, 'DINGTALK_OPEN_ID_REQUIRED', message)
+      }
+      return jsonError(res, 500, 'DINGTALK_BULK_GRANT_UPDATE_FAILED', message)
     }
   })
 

--- a/packages/core-backend/tests/integration/public-form-flow.test.ts
+++ b/packages/core-backend/tests/integration/public-form-flow.test.ts
@@ -474,6 +474,11 @@ describe('Public form flow', () => {
       .expect(200)
 
     expect(patchResponse.body.data.allowedUserIds).toEqual(['user_2'])
+    expect(patchResponse.body.data.allowedUsers[0]).toMatchObject({
+      dingtalkBound: true,
+      dingtalkGrantEnabled: false,
+      dingtalkPersonDeliveryAvailable: true,
+    })
     expect(patchResponse.body.data.allowedMemberGroupIds).toEqual(['group_2'])
     expect(storedConfig.publicForm.allowedUserIds).toEqual(['user_2'])
     expect(storedConfig.publicForm.allowedMemberGroupIds).toEqual(['group_2'])

--- a/packages/core-backend/tests/unit/admin-directory-routes.test.ts
+++ b/packages/core-backend/tests/unit/admin-directory-routes.test.ts
@@ -623,6 +623,29 @@ describe('adminDirectoryRouter', () => {
     }))
   })
 
+  it('returns 400 when a directory bind would enable DingTalk grant without openId', async () => {
+    directoryMocks.bindDirectoryAccount.mockRejectedValue(
+      new Error('Directory account is missing DingTalk openId and cannot enable DingTalk login grant; resync DingTalk directory or complete DingTalk OAuth binding first'),
+    )
+
+    const response = await invokeRoute('post', '/accounts/:accountId/bind', {
+      params: { accountId: 'account-1' },
+      body: {
+        localUserRef: 'alpha@example.com',
+        enableDingTalkGrant: true,
+      },
+      user: { id: 'admin-1', role: 'admin' },
+    })
+
+    expect(response.statusCode).toBe(400)
+    expect(response.body).toMatchObject({
+      ok: false,
+      error: {
+        code: 'DIRECTORY_BIND_FAILED',
+      },
+    })
+  })
+
   it('creates a local user and binds the directory account through manual admission', async () => {
     directoryMocks.admitDirectoryAccountUser.mockResolvedValue({
       account: {
@@ -686,6 +709,30 @@ describe('adminDirectoryRouter', () => {
         },
         temporaryPassword: 'Temp#123456',
         inviteToken: 'invite-token-fixed',
+      },
+    })
+  })
+
+  it('returns 400 when manual admission would enable DingTalk grant without openId', async () => {
+    directoryMocks.admitDirectoryAccountUser.mockRejectedValue(
+      new Error('Directory account is missing DingTalk openId and cannot enable DingTalk login grant; resync DingTalk directory or complete DingTalk OAuth binding first'),
+    )
+
+    const response = await invokeRoute('post', '/accounts/:accountId/admit-user', {
+      params: { accountId: 'account-1' },
+      body: {
+        name: '李青',
+        username: 'liqing',
+        enableDingTalkGrant: true,
+      },
+      user: { id: 'admin-1', role: 'admin' },
+    })
+
+    expect(response.statusCode).toBe(400)
+    expect(response.body).toMatchObject({
+      ok: false,
+      error: {
+        code: 'DIRECTORY_ADMISSION_FAILED',
       },
     })
   })

--- a/packages/core-backend/tests/unit/admin-users-routes.test.ts
+++ b/packages/core-backend/tests/unit/admin-users-routes.test.ts
@@ -249,6 +249,31 @@ describe('admin-users routes', () => {
           },
         ],
       })
+      .mockResolvedValueOnce({
+        rows: [{
+          user_id: 'user-1',
+          enabled: true,
+          granted_by: 'admin-1',
+          granted_by_name: 'Admin One',
+          granted_by_email: 'admin@example.com',
+          created_at: '2026-03-12T00:00:00.000Z',
+          updated_at: '2026-03-13T00:05:00.000Z',
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{ user_id: 'user-1', last_directory_sync_at: '2026-03-13T00:00:00.000Z' }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          local_user_id: 'user-1',
+          corp_id: 'ding-corp',
+          provider_union_id: 'union-1',
+          provider_open_id: null,
+          last_login_at: '2026-03-13T00:00:00.000Z',
+          created_at: '2026-03-12T00:00:00.000Z',
+          updated_at: '2026-03-13T00:00:00.000Z',
+        }],
+      })
 
     const response = await invokeRoute('get', '/api/admin/users', {
       query: { q: 'alpha', page: '1', pageSize: '20' },
@@ -268,6 +293,16 @@ describe('admin-users routes', () => {
       id: 'user-1',
       email: 'alpha@example.com',
       mobile: '13800138000',
+      dingtalkLoginEnabled: true,
+      dingtalkGrantUpdatedAt: '2026-03-13T00:05:00.000Z',
+      dingtalkGrantUpdatedBy: 'Admin One',
+      directoryLinked: true,
+      dingtalkIdentityExists: true,
+      dingtalkHasUnionId: true,
+      dingtalkHasOpenId: false,
+      dingtalkOpenIdMissing: true,
+      dingtalkCorpId: 'ding-corp',
+      lastDirectorySyncAt: '2026-03-13T00:00:00.000Z',
     })
   })
 
@@ -307,13 +342,16 @@ describe('admin-users routes', () => {
           },
         ],
       })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
 
     const response = await invokeRoute('get', '/api/admin/users', {
       query: { userId: 'user-pinned', page: '1', pageSize: '1' },
     })
 
     expect(response.statusCode).toBe(200)
-    expect(pgMocks.query).toHaveBeenCalledTimes(3)
+    expect(pgMocks.query).toHaveBeenCalledTimes(6)
     const items = (response.body as Record<string, any>).data.items
     expect(items[0].id).toBe('user-pinned')
     expect(items.map((row: Record<string, unknown>) => row.id)).toEqual(['user-pinned'])
@@ -354,13 +392,16 @@ describe('admin-users routes', () => {
           },
         ],
       })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
 
     const response = await invokeRoute('get', '/api/admin/users', {
       query: { userId: 'user-a' },
     })
 
     expect(response.statusCode).toBe(200)
-    expect(pgMocks.query).toHaveBeenCalledTimes(2)
+    expect(pgMocks.query).toHaveBeenCalledTimes(5)
     expect((response.body as Record<string, any>).data.items.map((row: Record<string, unknown>) => row.id)).toEqual(['user-a', 'user-b'])
     expect((response.body as Record<string, any>).data.pinUserIncluded).toBe(true)
   })
@@ -671,6 +712,8 @@ describe('admin-users routes', () => {
       .mockResolvedValueOnce({
         rows: [{
           corp_id: 'ding-corp',
+          provider_union_id: 'union-1',
+          provider_open_id: 'open-1',
           last_login_at: '2026-03-13T00:00:00.000Z',
           created_at: '2026-03-12T00:00:00.000Z',
           updated_at: '2026-03-13T00:00:00.000Z',
@@ -706,7 +749,14 @@ describe('admin-users routes', () => {
         linkedCount: 2,
       },
       grant: { exists: true, enabled: true },
-      identity: { exists: true, corpId: 'ding-corp' },
+      identity: {
+        exists: true,
+        corpId: 'ding-corp',
+        unionId: 'union-1',
+        openId: 'open-1',
+        hasUnionId: true,
+        hasOpenId: true,
+      },
     })
   })
 
@@ -777,6 +827,8 @@ describe('admin-users routes', () => {
       .mockResolvedValueOnce({
         rows: [{
           corp_id: 'ding-corp',
+          provider_union_id: 'union-1',
+          provider_open_id: 'open-1',
           last_login_at: '2026-03-13T00:00:00.000Z',
           created_at: '2026-03-12T00:00:00.000Z',
           updated_at: '2026-03-13T00:00:00.000Z',
@@ -805,7 +857,14 @@ describe('admin-users routes', () => {
       ],
       dingtalk: {
         grant: { exists: true, enabled: true },
-        identity: { exists: true, corpId: 'ding-corp' },
+        identity: {
+          exists: true,
+          corpId: 'ding-corp',
+          unionId: 'union-1',
+          openId: 'open-1',
+          hasUnionId: true,
+          hasOpenId: true,
+        },
       },
       namespaceAdmissions: [
         expect.objectContaining({
@@ -2018,6 +2077,7 @@ describe('admin-users routes', () => {
         }],
       })
       .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({
         rows: [{
           enabled: true,
@@ -2044,6 +2104,42 @@ describe('admin-users routes', () => {
       resourceType: 'user-auth-grant',
       resourceId: 'user-1:dingtalk',
     }))
+  })
+
+  it('rejects enabling dingtalk grant when bound identity is missing openId', async () => {
+    rbacMocks.isAdmin.mockResolvedValue(true)
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'user-1',
+          email: 'alpha@example.com',
+          name: 'Alpha',
+          role: 'user',
+          is_active: true,
+          is_admin: false,
+          last_login_at: null,
+          created_at: '2026-03-12T00:00:00.000Z',
+          updated_at: '2026-03-12T00:00:00.000Z',
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          local_user_id: 'user-1',
+          corp_id: 'dingcorp',
+          provider_open_id: null,
+        }],
+      })
+
+    const response = await invokeRoute('patch', '/api/admin/users/:userId/dingtalk-grant', {
+      params: { userId: 'user-1' },
+      body: { enabled: true },
+    })
+
+    expect(response.statusCode).toBe(400)
+    expect((response.body as Record<string, any>).error.code).toBe('DINGTALK_OPEN_ID_REQUIRED')
+    expect(String((response.body as Record<string, any>).error.message || '')).toContain('missing DingTalk openId')
+    expect(String(pgMocks.query.mock.calls[1]?.[0] || '')).toContain('provider_open_id')
+    expect(auditMocks.auditLog).not.toHaveBeenCalled()
   })
 
   it('updates dingtalk grants in bulk and records an audit entry per user', async () => {
@@ -2093,6 +2189,39 @@ describe('admin-users routes', () => {
         selectionSize: 2,
       }),
     }))
+  })
+
+  it('rejects bulk enabling dingtalk grants when one identity is missing openId', async () => {
+    rbacMocks.isAdmin.mockResolvedValue(true)
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [
+          { id: 'user-1' },
+          { id: 'user-2' },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            local_user_id: 'user-2',
+            corp_id: 'dingcorp',
+            provider_open_id: null,
+          },
+        ],
+      })
+
+    const response = await invokeRoute('post', '/api/admin/users/dingtalk-grants/bulk', {
+      body: {
+        userIds: ['user-1', 'user-2'],
+        enabled: true,
+      },
+    })
+
+    expect(response.statusCode).toBe(400)
+    expect((response.body as Record<string, any>).error.code).toBe('DINGTALK_OPEN_ID_REQUIRED')
+    expect(String((response.body as Record<string, any>).error.message || '')).toContain('user-2')
+    expect(String(pgMocks.query.mock.calls[1]?.[0] || '')).toContain('provider_open_id')
+    expect(auditMocks.auditLog).not.toHaveBeenCalled()
   })
 
   it('assigns a role and invalidates cached permissions', async () => {

--- a/packages/core-backend/tests/unit/dingtalk-oauth-login-gates.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-oauth-login-gates.test.ts
@@ -91,7 +91,12 @@ describe('dingtalk oauth login gates', () => {
       })
       .mockResolvedValueOnce({ rows: [] })
 
-    await expect(exchangeCodeForUser('code-1')).rejects.toThrow('DingTalk login is not enabled for this user')
+    await expect(exchangeCodeForUser('code-1')).rejects.toMatchObject({
+      name: 'DingTalkLoginPolicyError',
+      statusCode: 403,
+      code: 'grant_required',
+      message: 'DingTalk login is not enabled for this user',
+    })
   })
 
   it('allows email-linked login when strict grant mode is enabled and grant is present', async () => {
@@ -135,7 +140,12 @@ describe('dingtalk oauth login gates', () => {
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] })
 
-    await expect(exchangeCodeForUser('code-3')).rejects.toThrow('DingTalk account beta@example.com is not linked to an enabled local user')
+    await expect(exchangeCodeForUser('code-3')).rejects.toMatchObject({
+      name: 'DingTalkLoginPolicyError',
+      statusCode: 403,
+      code: 'unlinked_enabled_local_user',
+      message: 'DingTalk account beta@example.com is not linked to an enabled local user',
+    })
   })
 
   it('reports runtime status with grant mode and allowlist details', () => {

--- a/packages/core-backend/tests/unit/directory-sync-bind-account.test.ts
+++ b/packages/core-backend/tests/unit/directory-sync-bind-account.test.ts
@@ -189,6 +189,126 @@ describe('bindDirectoryAccount', () => {
     expect(pgMocks.transaction).not.toHaveBeenCalled()
   })
 
+  it('rejects enabling DingTalk grant when a corp-scoped directory account is missing openId', async () => {
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'account-1',
+          integration_id: 'dir-1',
+          provider: 'dingtalk',
+          corp_id: 'dingcorp',
+          external_user_id: '0447654442691174',
+          union_id: 'union-1',
+          open_id: null,
+          external_key: 'union-1',
+          name: '林岚',
+          email: null,
+          mobile: '13900001234',
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          local_user_id: null,
+          local_user_email: null,
+          local_user_name: null,
+        }],
+      })
+
+    await expect(bindDirectoryAccount('account-1', {
+      localUserRef: 'alpha@example.com',
+      adminUserId: 'admin-1',
+      enableDingTalkGrant: true,
+    })).rejects.toThrow('missing DingTalk openId')
+
+    expect(pgMocks.transaction).not.toHaveBeenCalled()
+  })
+
+  it('allows union-only pre-binding when DingTalk grant is disabled', async () => {
+    const clientQuery = vi.fn().mockResolvedValue({ rows: [] })
+    pgMocks.transaction.mockImplementation(async (handler) => handler({ query: clientQuery }))
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'account-1',
+          integration_id: 'dir-1',
+          provider: 'dingtalk',
+          corp_id: 'dingcorp',
+          external_user_id: '0447654442691174',
+          union_id: 'union-1',
+          open_id: null,
+          external_key: 'union-1',
+          name: '林岚',
+          email: null,
+          mobile: '13900001234',
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          local_user_id: null,
+          local_user_email: null,
+          local_user_name: null,
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'user-1',
+          email: 'alpha@example.com',
+          name: 'Alpha',
+          role: 'user',
+          is_active: true,
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          integration_id: 'dir-1',
+          provider: 'dingtalk',
+          corp_id: 'dingcorp',
+          directory_account_id: 'account-1',
+          external_user_id: '0447654442691174',
+          union_id: 'union-1',
+          open_id: null,
+          external_key: 'union-1',
+          account_name: '林岚',
+          account_email: null,
+          account_mobile: '13900001234',
+          account_is_active: true,
+          account_updated_at: '2026-04-11T08:00:00.000Z',
+          link_status: 'linked',
+          match_strategy: 'manual_admin',
+          reviewed_by: 'admin-1',
+          review_note: null,
+          link_updated_at: '2026-04-11T08:00:00.000Z',
+          local_user_id: 'user-1',
+          local_user_email: 'alpha@example.com',
+          local_user_name: 'Alpha',
+          department_paths: ['DingTalk CN'],
+        }],
+      })
+
+    const result = await bindDirectoryAccount('account-1', {
+      localUserRef: 'alpha@example.com',
+      adminUserId: 'admin-1',
+      enableDingTalkGrant: false,
+    })
+
+    expect(clientQuery).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO user_external_identities'),
+      expect.arrayContaining([
+        'dingtalk',
+        'union-1',
+        'union-1',
+        null,
+        'dingcorp',
+        'user-1',
+      ]),
+    )
+    expect(clientQuery).not.toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO user_external_auth_grants'),
+      expect.anything(),
+    )
+    expect(result.account.localUser?.id).toBe('user-1')
+  })
+
   it('fails closed when a mobile binding reference matches multiple local users', async () => {
     pgMocks.query
       .mockResolvedValueOnce({
@@ -579,6 +699,43 @@ describe('bindDirectoryAccount', () => {
     })
     expect(inviteLedgerMocks.recordInvite).not.toHaveBeenCalled()
     expect(inviteTokenMocks.issueInviteToken).not.toHaveBeenCalled()
+  })
+
+  it('rejects manual admission with DingTalk grant when the directory account is missing openId', async () => {
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'account-admit-3',
+          integration_id: 'dir-1',
+          provider: 'dingtalk',
+          corp_id: 'dingcorp',
+          external_user_id: '0447654442691199',
+          union_id: 'union-3',
+          open_id: null,
+          external_key: 'union-3',
+          name: '王松松',
+          email: null,
+          mobile: '13900007890',
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          local_user_id: null,
+          local_user_email: null,
+          local_user_username: null,
+          local_user_name: null,
+        }],
+      })
+
+    await expect(admitDirectoryAccountUser('account-admit-3', {
+      adminUserId: 'admin-1',
+      name: '王松松',
+      username: 'wss142',
+      mobile: '13900007890',
+      enableDingTalkGrant: true,
+    })).rejects.toThrow('missing DingTalk openId')
+
+    expect(pgMocks.transaction).not.toHaveBeenCalled()
   })
 
   it('removes the bound identity, optionally disables grant, and resets the link on unbind', async () => {

--- a/packages/core-backend/tests/unit/jwt-middleware.test.ts
+++ b/packages/core-backend/tests/unit/jwt-middleware.test.ts
@@ -336,6 +336,36 @@ describe('jwt auth middleware', () => {
     expect(next).not.toHaveBeenCalled()
   })
 
+  it('ignores stale bearer tokens on public form routes so DingTalk re-auth can start', async () => {
+    metricsMocks.jwtAuthFail.inc.mockClear()
+    metricsMocks.authFailures.inc.mockClear()
+    const expiredError = new Error('jwt expired')
+    expiredError.name = 'TokenExpiredError'
+    authServiceMocks.verifyToken.mockRejectedValue(expiredError)
+
+    const req = {
+      method: 'GET',
+      path: '/api/multitable/form-context',
+      query: { publicToken: 'pub_123' },
+      headers: {
+        authorization: 'Bearer expired-public-form-token',
+      },
+    } as unknown as Request
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn().mockReturnThis(),
+    } as unknown as Response
+    const next = vi.fn() as NextFunction
+
+    await optionalJwtAuthMiddleware(req, res, next)
+
+    expect(req.user).toBeUndefined()
+    expect(res.status).not.toHaveBeenCalled()
+    expect(metricsMocks.jwtAuthFail.inc).not.toHaveBeenCalled()
+    expect(metricsMocks.authFailures.inc).not.toHaveBeenCalled()
+    expect(next).toHaveBeenCalledTimes(1)
+  })
+
   it('optional public form auth bypass does not fail when no bearer token is present', async () => {
     authServiceMocks.verifyToken.mockReset()
     const req = {


### PR DESCRIPTION
## Summary
- recover DingTalk public-form optional auth when local bearer tokens are stale or must-change-password users access protected forms
- add missing-openId guardrails across directory bind/admission and user-management DingTalk grant enable paths
- add governance workbench, audit presets, exports, diagnostics, and form-share audience status copy
- document the consolidated P4 governance closeout and slice-level verification notes

## Verification
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/jwt-middleware.test.ts tests/unit/dingtalk-oauth-login-gates.test.ts tests/unit/directory-sync-bind-account.test.ts tests/unit/admin-directory-routes.test.ts tests/unit/admin-users-routes.test.ts tests/integration/public-form-flow.test.ts --watch=false
- pnpm --filter @metasheet/web exec vitest run tests/ForcePasswordChangeView.spec.ts tests/adminAuditView.spec.ts tests/directoryManagementView.spec.ts tests/multitable-embed-route.spec.ts tests/multitable-form-share-manager.spec.ts tests/public-multitable-form.spec.ts tests/userManagementView.spec.ts --watch=false
- pnpm --filter @metasheet/core-backend build
- pnpm --filter @metasheet/web build
- git diff --check

## Notes
- web Vitest prints non-fatal jsdom navigation and WebSocket port warnings in existing route/navigation tests
- web build prints existing Vite dynamic-import and chunk-size warnings
- unrelated local untracked integration/staging docs and .claude are intentionally excluded