### PR TITLE
test(integration): guard K3 live PoC evidence fixtures

### DIFF
--- a/docs/development/integration-k3wise-fixture-contract-and-dryrun-gate-development-20260505.md
+++ b/docs/development/integration-k3wise-fixture-contract-and-dryrun-gate-development-20260505.md
@@ -1,0 +1,49 @@
+# K3 WISE Fixture Contract And Dry-Run Gate Development - 2026-05-05
+
+## Scope
+
+This slice keeps the customer-facing K3 WISE Live PoC handoff templates and evidence compiler aligned before customer GATE answers arrive.
+
+It deliberately avoids the open K3 PR surfaces:
+
+- #1305 K3 WISE setup UI files are untouched.
+- #1316 preflight disabled-mode files are untouched.
+
+## Changes
+
+### 1. Fixture contract test
+
+Added `scripts/ops/fixtures/integration-k3wise/fixture-contract.test.mjs`.
+
+The test validates that:
+
+- `gate-sample.json`, after removing `_comment`, stays equivalent to `sampleGate()`.
+- `evidence-sample.json`, after removing `_comment`, stays equivalent to `sampleEvidence()`.
+- the gate fixture builds a Save-only preflight packet with three external systems and two pipelines.
+- the evidence fixture compiles against that packet with `decision=PASS` and zero issues.
+- placeholder credential values from the customer template do not leak into the generated preflight packet.
+
+This catches a common drift class: a developer updates the CLI sample but forgets the copy-and-edit fixture, or vice versa.
+
+### 2. Material dry-run evidence gate
+
+`scripts/ops/integration-k3wise-live-poc-evidence.mjs` now validates `materialDryRun` when its status is `pass`:
+
+- `runId` is required.
+- `rowsPreviewed` must be an integer from `1..3`.
+
+The rule mirrors the existing Save-only write row-count gate. A passed dry-run without proof is now a failed evidence package instead of a false green signoff.
+
+If `materialDryRun.status` is not `pass`, the dry-run proof checks are skipped and the phase status continues to drive the overall decision.
+
+### 3. CI entrypoint
+
+`pnpm run verify:integration-k3wise:poc` now includes the fixture contract test between the preflight/evidence unit tests and the mock PoC demo.
+
+## Files
+
+- `package.json`
+- `scripts/ops/integration-k3wise-live-poc-evidence.mjs`
+- `scripts/ops/integration-k3wise-live-poc-evidence.test.mjs`
+- `scripts/ops/fixtures/integration-k3wise/README.md`
+- `scripts/ops/fixtures/integration-k3wise/fixture-contract.test.mjs`

--- a/docs/development/integration-k3wise-fixture-contract-and-dryrun-gate-verification-20260505.md
+++ b/docs/development/integration-k3wise-fixture-contract-and-dryrun-gate-verification-20260505.md
@@ -1,0 +1,55 @@
+# K3 WISE Fixture Contract And Dry-Run Gate Verification - 2026-05-05
+
+## Worktree
+
+`/private/tmp/ms2-k3wise-fixture-contract-20260505`
+
+Branch:
+
+`codex/k3wise-fixture-contract-20260505`
+
+Baseline:
+
+`origin/main` at `3bbfc0504`.
+
+## Verification Plan
+
+Run the focused evidence and fixture tests, then the full offline K3 WISE PoC gate:
+
+```bash
+node --test scripts/ops/integration-k3wise-live-poc-evidence.test.mjs
+node --test scripts/ops/fixtures/integration-k3wise/fixture-contract.test.mjs
+pnpm run verify:integration-k3wise:poc
+git diff --check
+```
+
+## Expected Coverage
+
+- Evidence compiler rejects a passed `materialDryRun` without `runId`.
+- Evidence compiler rejects passed `materialDryRun.rowsPreviewed` outside `1..3`.
+- Numeric-string `rowsPreviewed` stays accepted for spreadsheet-export style input.
+- Blocked/non-pass dry-run phases do not produce row-count proof failures.
+- `gate-sample.json` and `evidence-sample.json` stay contract-equivalent to exported CLI samples.
+- The fixture pair still compiles into a PASS evidence report.
+
+## Results
+
+All planned commands passed:
+
+- `node --test scripts/ops/integration-k3wise-live-poc-evidence.test.mjs`
+  - 35/35 passed.
+  - Added material dry-run proof coverage:
+    - missing `runId` fails.
+    - `rowsPreviewed` outside `1..3` fails.
+    - numeric-string `rowsPreviewed` is accepted.
+    - blocked/non-pass dry-run skips proof checks and remains `PARTIAL`.
+- `node --test scripts/ops/fixtures/integration-k3wise/fixture-contract.test.mjs`
+  - 2/2 passed.
+  - `gate-sample.json` and `evidence-sample.json` match their exported CLI sample contracts after stripping `_comment`.
+- `pnpm run verify:integration-k3wise:poc`
+  - preflight tests: 16/16 passed.
+  - evidence tests: 35/35 passed.
+  - fixture contract tests: 2/2 passed.
+  - mock PoC demo ended with `K3 WISE PoC mock chain verified end-to-end (PASS)`.
+- `git diff --check`
+  - passed.

--- a/docs/development/integration-k3wise-live-poc-evidence-secret-container-development-20260506.md
+++ b/docs/development/integration-k3wise-live-poc-evidence-secret-container-development-20260506.md
@@ -1,0 +1,52 @@
+# K3 WISE Live PoC Evidence Secret Container Development
+
+Date: 2026-05-06
+
+## Context
+
+The live PoC evidence compiler rejects customer evidence packets that contain
+unredacted secret-like fields before it writes the JSON and Markdown report.
+
+Before this change, the leak scanner only rejected direct string values under a
+secret-like key, such as `sessionToken: "..."`. It did not reject secret-like
+containers such as:
+
+- `credentials: { value: "..." }`
+- `authorization: ["Bearer ..."]`
+
+That created a narrow but real safety gap for hand-edited customer evidence.
+
+## Implementation
+
+The leak scanner now recursively checks every string value beneath a secret-like
+key. Safe placeholders remain allowed:
+
+- empty string
+- `<redacted>`
+- `<set-at-runtime>`
+- `redacted`
+- `***`
+
+Schema metadata keys such as `requiredCredentialKeys` are explicitly excluded
+from value scanning, because those values are field names rather than secrets.
+
+## SQL Optional Phase Decision
+
+This slice also closes a live readiness false-positive found during parallel
+inspection: when the preflight packet includes the K3 SQL Server channel,
+`sqlConnection` is optional, but an explicit `fail` status must still fail the
+report. Optional means it may be `skipped`; it does not mean a failed SQL channel
+can produce an overall `PASS`.
+
+`determineDecision()` now treats any phase with `status === "fail"` as a report
+failure.
+
+## Files Changed
+
+- `scripts/ops/integration-k3wise-live-poc-evidence.mjs`
+- `scripts/ops/integration-k3wise-live-poc-evidence.test.mjs`
+
+## Stacking Note
+
+This branch is stacked on PR #1320 because #1320 already owns the live PoC
+evidence fixture contract work and touches the same evidence script.

--- a/docs/development/integration-k3wise-live-poc-evidence-secret-container-verification-20260506.md
+++ b/docs/development/integration-k3wise-live-poc-evidence-secret-container-verification-20260506.md
@@ -1,0 +1,59 @@
+# K3 WISE Live PoC Evidence Secret Container Verification
+
+Date: 2026-05-06
+
+## Local Verification
+
+Command:
+
+```bash
+node --test scripts/ops/integration-k3wise-live-poc-evidence.test.mjs
+```
+
+Result:
+
+- `40/40` tests passed.
+
+Covered cases:
+
+- Nested `credentials.value` is rejected as a secret leak.
+- Array `authorization[0]` is rejected as a secret leak.
+- Nested safe placeholders are accepted.
+- `requiredCredentialKeys` metadata is not treated as a secret value.
+- Optional `sqlConnection: skipped` can still pass.
+- Optional `sqlConnection: fail` forces report `FAIL`.
+
+## Extended Verification
+
+Command:
+
+```bash
+node --test scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
+```
+
+Result:
+
+- `9/9` tests passed.
+
+Command:
+
+```bash
+pnpm run verify:integration-k3wise:poc
+```
+
+Result:
+
+- Preflight tests passed.
+- Live PoC evidence tests passed.
+- Fixture contract tests passed.
+- Mock PoC chain completed with `K3 WISE PoC mock chain verified end-to-end (PASS)`.
+
+Command:
+
+```bash
+git diff --check -- scripts/ops/integration-k3wise-live-poc-evidence.mjs scripts/ops/integration-k3wise-live-poc-evidence.test.mjs docs/development/integration-k3wise-live-poc-evidence-secret-container-development-20260506.md docs/development/integration-k3wise-live-poc-evidence-secret-container-verification-20260506.md
+```
+
+Result:
+
+- Passed with no whitespace errors.

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "profile:multitable-grid:local": "RUNNER_SCRIPT=scripts/profile-multitable-grid.mjs RUN_LABEL=multitable-grid-profile bash scripts/ops/multitable-pilot-local.sh",
     "profile:multitable-grid:staging": "RUNNER_SCRIPT=scripts/profile-multitable-grid.mjs RUN_LABEL=multitable-grid-profile-staging RUN_MODE=staging RUNNER_REPORT_BASENAME=staging-report AUTO_START_SERVICES=false REQUIRE_RUNNING_SERVICES=true bash scripts/ops/multitable-pilot-local.sh",
     "verify:multitable-grid-profile:summary": "node scripts/ops/multitable-grid-profile-summary.mjs",
-    "verify:integration-k3wise:poc": "node --test scripts/ops/integration-k3wise-live-poc-preflight.test.mjs && node --test scripts/ops/integration-k3wise-live-poc-evidence.test.mjs && node scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs",
+    "verify:integration-k3wise:poc": "node --test scripts/ops/integration-k3wise-live-poc-preflight.test.mjs && node --test scripts/ops/integration-k3wise-live-poc-evidence.test.mjs && node --test scripts/ops/fixtures/integration-k3wise/fixture-contract.test.mjs && node scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs",
     "phase5:run-all": "bash scripts/phase5-run-all.sh",
     "build": "pnpm -r build",
     "test": "pnpm -r test",

--- a/scripts/ops/fixtures/integration-k3wise/README.md
+++ b/scripts/ops/fixtures/integration-k3wise/README.md
@@ -13,6 +13,7 @@ Fixtures and mock server for the K3 WISE Live PoC chain. Used to:
 | `evidence-sample.json` | Customer-side evidence template after live PoC. Customer fills in run IDs, K3 record IDs, statuses, etc. |
 | `mock-k3-webapi-server.mjs` | Minimal in-process HTTP mock for K3 WISE WebAPI: Login / Health / Material / BOM Save / Submit / Audit. NOT a full K3 simulator. |
 | `mock-sqlserver-executor.mjs` | Mock SQL executor: read-only on K3 core tables, writeable on integration middle tables, rejects writes to `t_ICItem` / `t_ICBOM`. |
+| `fixture-contract.test.mjs` | Contract test proving the copy-and-edit JSON templates still match the exported CLI samples and compile into PASS preflight/evidence results. |
 | `run-mock-poc-demo.mjs` | End-to-end smoke: loads gate sample → preflight → spins up mock K3 → adapter Save-only → SQL channel readonly probe → evidence compile → asserts PASS. |
 
 ## Local verification
@@ -20,6 +21,7 @@ Fixtures and mock server for the K3 WISE Live PoC chain. Used to:
 From repo root:
 
 ```bash
+node --test scripts/ops/fixtures/integration-k3wise/fixture-contract.test.mjs
 node scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs
 ```
 

--- a/scripts/ops/fixtures/integration-k3wise/fixture-contract.test.mjs
+++ b/scripts/ops/fixtures/integration-k3wise/fixture-contract.test.mjs
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import test from 'node:test'
+
+import {
+  buildPacket,
+  sampleGate,
+} from '../../integration-k3wise-live-poc-preflight.mjs'
+import {
+  buildEvidenceReport,
+  sampleEvidence,
+} from '../../integration-k3wise-live-poc-evidence.mjs'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const gateFixturePath = path.join(__dirname, 'gate-sample.json')
+const evidenceFixturePath = path.join(__dirname, 'evidence-sample.json')
+
+async function readJson(filePath) {
+  return JSON.parse(await readFile(filePath, 'utf8'))
+}
+
+function stripTemplateComments(value) {
+  if (Array.isArray(value)) return value.map(stripTemplateComments)
+  if (!value || typeof value !== 'object') return value
+
+  const result = {}
+  for (const [key, child] of Object.entries(value)) {
+    if (key === '_comment') continue
+    result[key] = stripTemplateComments(child)
+  }
+  return result
+}
+
+test('gate-sample.json stays equivalent to the exported preflight sample', async () => {
+  const gateFixture = await readJson(gateFixturePath)
+  assert.deepEqual(stripTemplateComments(gateFixture), sampleGate())
+
+  const packet = buildPacket(gateFixture, { generatedAt: '2026-05-05T00:00:00.000Z' })
+  assert.equal(packet.status, 'preflight-ready')
+  assert.equal(packet.safety.saveOnly, true)
+  assert.equal(packet.safety.autoSubmit, false)
+  assert.equal(packet.safety.autoAudit, false)
+  assert.equal(packet.externalSystems.length, 3)
+  assert.equal(packet.pipelines.length, 2)
+  assert.equal(JSON.stringify(packet).includes('<fill-outside-git>'), false)
+})
+
+test('evidence-sample.json stays equivalent to the exported evidence sample', async () => {
+  const gateFixture = await readJson(gateFixturePath)
+  const evidenceFixture = await readJson(evidenceFixturePath)
+  assert.deepEqual(stripTemplateComments(evidenceFixture), sampleEvidence())
+
+  const packet = buildPacket(gateFixture, { generatedAt: '2026-05-05T00:00:00.000Z' })
+  const report = buildEvidenceReport(packet, evidenceFixture, { generatedAt: '2026-05-05T01:00:00.000Z' })
+  assert.equal(report.decision, 'PASS')
+  assert.equal(report.issues.length, 0)
+  assert.equal(report.scope.bomRequired, true)
+  assert.equal(report.scope.sqlChannelExpected, true)
+})

--- a/scripts/ops/integration-k3wise-live-poc-evidence.mjs
+++ b/scripts/ops/integration-k3wise-live-poc-evidence.mjs
@@ -184,6 +184,20 @@ function addIssue(issues, severity, code, message, phaseId = null) {
   issues.push({ severity, code, message, phaseId })
 }
 
+function evaluateMaterialDryRun(evidence, issues) {
+  const dryRun = asObject(evidence.materialDryRun, 'evidence.materialDryRun')
+  const status = normalizeStatus(dryRun.status)
+  if (status !== 'pass') return
+
+  if (!text(dryRun.runId)) {
+    addIssue(issues, 'fail', 'MATERIAL_DRY_RUN_ID_REQUIRED', 'material dry-run evidence must include runId', 'materialDryRun')
+  }
+  const rowsPreviewed = Number(dryRun.rowsPreviewed)
+  if (!Number.isInteger(rowsPreviewed) || rowsPreviewed < 1 || rowsPreviewed > 3) {
+    addIssue(issues, 'fail', 'MATERIAL_DRY_RUN_ROW_COUNT', 'material dry-run must preview between 1 and 3 rows', 'materialDryRun')
+  }
+}
+
 function evaluatePhases(packet, evidence) {
   const connections = asObject(evidence.connections, 'evidence.connections')
   const bomRequired = hasBomPipeline(packet)
@@ -263,6 +277,7 @@ function buildEvidenceReport(packet, evidence, { generatedAt = new Date().toISOS
 
   const issues = []
   const phases = evaluatePhases(packet, evidence)
+  evaluateMaterialDryRun(evidence, issues)
   evaluateMaterialSaveOnly(evidence, issues)
   evaluateBom(packet, evidence, issues)
 

--- a/scripts/ops/integration-k3wise-live-poc-evidence.mjs
+++ b/scripts/ops/integration-k3wise-live-poc-evidence.mjs
@@ -4,6 +4,7 @@ import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 
 const SECRET_KEY_PATTERN = /password|secret|token|session|credential|api[-_]?key|authorization/i
+const SECRET_METADATA_KEY_PATTERN = /^(requiredCredentialKeys|credentialKeys|credentialFieldKeys)$/i
 const SAFE_SECRET_PLACEHOLDERS = new Set(['', '<redacted>', '<set-at-runtime>', 'redacted', '***'])
 const VALID_STATUSES = new Set(['pass', 'partial', 'fail', 'skipped', 'todo', 'blocked'])
 // Customer evidence often spells phase status with localized or English
@@ -111,6 +112,25 @@ function redact(value) {
   return result
 }
 
+function findSecretValueLeaks(value, location, leaks) {
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => findSecretValueLeaks(item, `${location}[${index}]`, leaks))
+    return leaks
+  }
+  if (isPlainObject(value)) {
+    for (const [key, child] of Object.entries(value)) {
+      findSecretValueLeaks(child, `${location}.${key}`, leaks)
+    }
+    return leaks
+  }
+  if (typeof value !== 'string') return leaks
+  const normalized = value.trim()
+  if (normalized.length >= 4 && !SAFE_SECRET_PLACEHOLDERS.has(normalized.toLowerCase())) {
+    leaks.push(location)
+  }
+  return leaks
+}
+
 function findSecretLeaks(value, location = 'root', leaks = []) {
   if (Array.isArray(value)) {
     value.forEach((item, index) => findSecretLeaks(item, `${location}[${index}]`, leaks))
@@ -119,11 +139,9 @@ function findSecretLeaks(value, location = 'root', leaks = []) {
   if (!isPlainObject(value)) return leaks
   for (const [key, child] of Object.entries(value)) {
     const childPath = `${location}.${key}`
-    if (SECRET_KEY_PATTERN.test(key) && typeof child === 'string') {
-      const normalized = child.trim()
-      if (normalized.length >= 4 && !SAFE_SECRET_PLACEHOLDERS.has(normalized.toLowerCase())) {
-        leaks.push(childPath)
-      }
+    if (SECRET_KEY_PATTERN.test(key)) {
+      if (SECRET_METADATA_KEY_PATTERN.test(key)) continue
+      findSecretValueLeaks(child, childPath, leaks)
       continue
     }
     findSecretLeaks(child, childPath, leaks)
@@ -253,7 +271,7 @@ function evaluateBom(packet, evidence, issues) {
 
 function determineDecision(phases, issues) {
   if (issues.some((issue) => issue.severity === 'fail')) return 'FAIL'
-  if (phases.some((item) => item.required && item.status === 'fail')) return 'FAIL'
+  if (phases.some((item) => item.status === 'fail')) return 'FAIL'
   if (phases.some((item) => item.status === 'blocked')) return 'PARTIAL'
   if (phases.some((item) => item.required && item.status !== 'pass')) return 'PARTIAL'
   if (issues.length > 0) return 'PARTIAL'

--- a/scripts/ops/integration-k3wise-live-poc-evidence.test.mjs
+++ b/scripts/ops/integration-k3wise-live-poc-evidence.test.mjs
@@ -40,6 +40,23 @@ test('buildEvidenceReport returns PARTIAL when a required phase is missing', () 
   assert.equal(report.phases.find((phase) => phase.id === 'customerConfirmation').status, 'todo')
 })
 
+test('buildEvidenceReport returns FAIL when optional SQL channel explicitly fails', () => {
+  const evidence = sampleEvidence()
+  evidence.connections.sqlServer.status = 'fail'
+  const report = buildEvidenceReport(packet(), evidence)
+  assert.equal(report.decision, 'FAIL')
+  assert.equal(report.phases.find((phase) => phase.id === 'sqlConnection').status, 'fail')
+  assert.equal(report.issues.length, 0)
+})
+
+test('buildEvidenceReport allows optional SQL channel to be skipped', () => {
+  const evidence = sampleEvidence()
+  evidence.connections.sqlServer.status = 'skipped'
+  const report = buildEvidenceReport(packet(), evidence)
+  assert.equal(report.decision, 'PASS')
+  assert.equal(report.phases.find((phase) => phase.id === 'sqlConnection').status, 'skipped')
+})
+
 test('buildEvidenceReport returns FAIL when Save-only row count exceeds PoC limit', () => {
   const evidence = sampleEvidence()
   evidence.materialSaveOnly.rowsWritten = 4
@@ -63,6 +80,41 @@ test('buildEvidenceReport rejects unredacted secret-like evidence fields', () =>
     () => buildEvidenceReport(packet(), evidence),
     (error) => error instanceof LivePocEvidenceError && error.details.secretLeaks.includes('evidence.connections.k3Wise.sessionToken'),
   )
+})
+
+test('buildEvidenceReport rejects nested secret-like object values', () => {
+  const evidence = sampleEvidence()
+  evidence.connections.k3Wise.credentials = {
+    value: 'live-k3-password',
+  }
+  assert.throws(
+    () => buildEvidenceReport(packet(), evidence),
+    (error) =>
+      error instanceof LivePocEvidenceError &&
+      error.details.secretLeaks.includes('evidence.connections.k3Wise.credentials.value'),
+  )
+})
+
+test('buildEvidenceReport rejects secret-like array values', () => {
+  const evidence = sampleEvidence()
+  evidence.connections.k3Wise.authorization = ['Bearer live-session-token']
+  assert.throws(
+    () => buildEvidenceReport(packet(), evidence),
+    (error) =>
+      error instanceof LivePocEvidenceError &&
+      error.details.secretLeaks.includes('evidence.connections.k3Wise.authorization[0]'),
+  )
+})
+
+test('buildEvidenceReport accepts nested secret-like placeholders', () => {
+  const evidence = sampleEvidence()
+  evidence.connections.k3Wise.credentials = {
+    password: '<redacted>',
+    token: '<set-at-runtime>',
+    notes: ['***', 'redacted'],
+  }
+  const report = buildEvidenceReport(packet(), evidence)
+  assert.equal(report.decision, 'PASS')
 })
 
 test('buildEvidenceReport requires material dry-run runId when dry-run passed', () => {

--- a/scripts/ops/integration-k3wise-live-poc-evidence.test.mjs
+++ b/scripts/ops/integration-k3wise-live-poc-evidence.test.mjs
@@ -65,6 +65,47 @@ test('buildEvidenceReport rejects unredacted secret-like evidence fields', () =>
   )
 })
 
+test('buildEvidenceReport requires material dry-run runId when dry-run passed', () => {
+  const evidence = sampleEvidence()
+  delete evidence.materialDryRun.runId
+  const report = buildEvidenceReport(packet(), evidence)
+  assert.equal(report.decision, 'FAIL')
+  assert.equal(report.issues.some((issue) => issue.code === 'MATERIAL_DRY_RUN_ID_REQUIRED'), true)
+})
+
+test('buildEvidenceReport requires material dry-run preview count to stay within PoC sample limit', () => {
+  for (const rowsPreviewed of [0, 4, '4', 'many', NaN, Infinity]) {
+    const evidence = sampleEvidence()
+    evidence.materialDryRun.rowsPreviewed = rowsPreviewed
+    const report = buildEvidenceReport(packet(), evidence)
+    assert.equal(report.decision, 'FAIL', `rowsPreviewed=${String(rowsPreviewed)} should fail`)
+    assert.equal(
+      report.issues.some((issue) => issue.code === 'MATERIAL_DRY_RUN_ROW_COUNT'),
+      true,
+      `rowsPreviewed=${String(rowsPreviewed)} should raise MATERIAL_DRY_RUN_ROW_COUNT`,
+    )
+  }
+})
+
+test('buildEvidenceReport accepts material dry-run numeric-string preview count', () => {
+  const evidence = sampleEvidence()
+  evidence.materialDryRun.runId = 123456
+  evidence.materialDryRun.rowsPreviewed = '3'
+  const report = buildEvidenceReport(packet(), evidence)
+  assert.equal(report.decision, 'PASS')
+})
+
+test('buildEvidenceReport skips material dry-run row checks when dry-run did not pass', () => {
+  const evidence = sampleEvidence()
+  evidence.materialDryRun.status = 'blocked'
+  delete evidence.materialDryRun.runId
+  evidence.materialDryRun.rowsPreviewed = 99
+  const report = buildEvidenceReport(packet(), evidence)
+  assert.equal(report.decision, 'PARTIAL')
+  assert.equal(report.issues.some((issue) => issue.code === 'MATERIAL_DRY_RUN_ID_REQUIRED'), false)
+  assert.equal(report.issues.some((issue) => issue.code === 'MATERIAL_DRY_RUN_ROW_COUNT'), false)
+})
+
 // ----- migration of bool-coercion sweep from preflight (#1168 / #1169) -----
 
 test('buildEvidenceReport returns FAIL when materialSaveOnly autoSubmit is the string "true"', () => {


### PR DESCRIPTION
## Summary

- add a K3 WISE fixture contract test for customer copy-and-edit `gate-sample.json` / `evidence-sample.json`
- validate passed material dry-run evidence with `runId` and `rowsPreviewed` in the `1..3` PoC sample range
- wire the fixture contract test into `pnpm run verify:integration-k3wise:poc`
- document the slice in development and verification MDs

## Verification

- `node --test scripts/ops/integration-k3wise-live-poc-evidence.test.mjs` — 35/35 passed
- `node --test scripts/ops/fixtures/integration-k3wise/fixture-contract.test.mjs` — 2/2 passed
- `pnpm run verify:integration-k3wise:poc` — preflight 16/16, evidence 35/35, fixture contract 2/2, mock PoC PASS
- `git diff --check` — passed

## Independence

Does not touch #1305 K3 setup UI files or #1316 preflight disabled-mode files.