### PR TITLE
feat(multitable): add auto number system field

### DIFF
--- a/apps/web/src/multitable/components/MetaFieldHeader.vue
+++ b/apps/web/src/multitable/components/MetaFieldHeader.vue
@@ -30,7 +30,7 @@ const FIELD_ICONS: Record<string, string> = {
   string: 'Aa', longText: '\u00B6', number: '#', boolean: '\u2611', date: '\u{1F4C5}', select: '\u25CF', multiSelect: '\u25C9',
   link: '\u21C4', person: '\u{1F464}', lookup: '\u2197', rollup: '\u03A3', formula: 'fx', attachment: '\uD83D\uDCCE',
   currency: '\u00A4', percent: '%', rating: '\u2605', url: '\u{1F517}', email: '\u2709', phone: '\u260E',
-  createdTime: 'CT', modifiedTime: 'MT', createdBy: 'CB', modifiedBy: 'MB',
+  autoNumber: '#+', createdTime: 'CT', modifiedTime: 'MT', createdBy: 'CB', modifiedBy: 'MB',
 }
 
 const props = defineProps<{

--- a/apps/web/src/multitable/components/MetaFieldManager.vue
+++ b/apps/web/src/multitable/components/MetaFieldManager.vue
@@ -440,7 +440,7 @@ const FIELD_ICONS: Record<string, string> = {
   string: 'Aa', longText: '\u00B6', number: '#', boolean: '\u2611', date: '\u{1F4C5}', select: '\u25CF', multiSelect: '\u25C9',
   link: '\u21C4', person: '\u{1F464}', lookup: '\u2197', rollup: '\u03A3', formula: 'fx', attachment: '\uD83D\uDCCE',
   currency: '\u00A4', percent: '%', rating: '\u2605', url: '\u{1F517}', email: '\u2709', phone: '\u260E',
-  createdTime: 'CT', modifiedTime: 'MT', createdBy: 'CB', modifiedBy: 'MB',
+  autoNumber: '#+', createdTime: 'CT', modifiedTime: 'MT', createdBy: 'CB', modifiedBy: 'MB',
 }
 
 const props = defineProps<{

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -22,6 +22,7 @@ export type MetaFieldType =
   | 'email'
   | 'phone'
   | 'longText'
+  | 'autoNumber'
   | 'createdTime'
   | 'modifiedTime'
   | 'createdBy'

--- a/apps/web/src/multitable/utils/system-fields.ts
+++ b/apps/web/src/multitable/utils/system-fields.ts
@@ -1,6 +1,7 @@
 import type { MetaField, MetaFieldCreateType, MetaFieldType } from '../types'
 
 export const SYSTEM_FIELD_TYPES = [
+  'autoNumber',
   'createdTime',
   'modifiedTime',
   'createdBy',
@@ -27,6 +28,8 @@ export function systemFieldHint(type: MetaFieldCreateType | string | null | unde
   switch (type) {
     case 'createdTime':
       return 'Created time is generated from the record creation timestamp and is read-only.'
+    case 'autoNumber':
+      return 'Auto number is generated when a record is created and is read-only.'
     case 'modifiedTime':
       return 'Modified time is generated from the last record update timestamp and is read-only.'
     case 'createdBy':

--- a/apps/web/tests/multitable-system-fields.spec.ts
+++ b/apps/web/tests/multitable-system-fields.spec.ts
@@ -155,6 +155,7 @@ describe('multitable system fields', () => {
       'modifiedTime',
       'createdBy',
       'modifiedBy',
+      'autoNumber',
     ]))
 
     nameInput.value = 'Created at'
@@ -174,6 +175,52 @@ describe('multitable system fields', () => {
       sheetId: 'sheet_1',
       name: 'Created at',
       type: 'createdTime',
+    })
+
+    app.unmount()
+    container.remove()
+  })
+
+  it('creates autoNumber fields as read-only system fields', async () => {
+    const createSpy = vi.fn()
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    const app = createApp({
+      render() {
+        return h(MetaFieldManager, {
+          visible: true,
+          sheetId: 'sheet_1',
+          sheets: [],
+          fields: [],
+          onCreateField: createSpy,
+        })
+      },
+    })
+
+    app.mount(container)
+    await flushUi()
+
+    const nameInput = container.querySelector('.meta-field-mgr__add-row .meta-field-mgr__input') as HTMLInputElement
+    const typeSelect = container.querySelector('.meta-field-mgr__add-row .meta-field-mgr__select') as HTMLSelectElement
+
+    nameInput.value = 'No.'
+    nameInput.dispatchEvent(new Event('input', { bubbles: true }))
+    typeSelect.value = 'autoNumber'
+    typeSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+
+    expect(container.textContent).toContain('Auto number is generated')
+
+    ;(Array.from(container.querySelectorAll('.meta-field-mgr__btn-add')) as HTMLButtonElement[])
+      .find((button) => button.textContent?.includes('+ Add'))
+      ?.click()
+    await flushUi()
+
+    expect(createSpy).toHaveBeenCalledWith({
+      sheetId: 'sheet_1',
+      name: 'No.',
+      type: 'autoNumber',
     })
 
     app.unmount()

--- a/docs/development/multitable-auto-number-system-field-design-20260505.md
+++ b/docs/development/multitable-auto-number-system-field-design-20260505.md
@@ -1,0 +1,42 @@
+# Multitable Auto Number System Field Design - 2026-05-05
+
+## Context
+
+`docs/development/multitable-feishu-rc-todo-20260430.md` still had one unchecked Phase 4 system-field item:
+
+- `autoNumber` was blocked because a row-index placeholder would not be stable.
+
+This slice removes that blocker by adding a persistent per-field sequence. It does not implement display formatting such as prefix, padding, or reset policies.
+
+## Design
+
+`autoNumber` is treated as a readonly system field:
+
+- Field type is accepted by backend route normalization, OpenAPI, and frontend field manager types.
+- Client-supplied values are rejected on create/patch through the same readonly field guards used by formula/system fields.
+- Values are generated only during record creation.
+
+Persistent allocation uses a new table:
+
+- `meta_field_auto_number_sequences(field_id primary key, sheet_id, next_value, created_at, updated_at)`
+- `field_id` and `sheet_id` cascade with `meta_fields`/`meta_sheets`.
+- Allocation is transactional:
+  - first create for a field inserts `next_value = startAt + 1`
+  - later creates atomically increment `next_value`
+  - returned value is `next_value - 1`
+
+Creation paths covered:
+
+- `RecordService.createRecord()` allocates auto numbers inside the same transaction before inserting `meta_records`.
+- Public form direct create path in `univer-meta.ts` also allocates inside its transaction before insert.
+
+Field lifecycle behavior:
+
+- Deleting an `autoNumber` field deletes its sequence explicitly; the FK also cascades.
+- Changing an `autoNumber` field to another type deletes the old sequence row.
+
+## Deferred
+
+- Formatting (`prefix`, `suffix`, min digits) is intentionally deferred.
+- Reset policies are intentionally deferred.
+- Existing rows are not backfilled when adding an `autoNumber` field to a sheet with records.

--- a/docs/development/multitable-auto-number-system-field-verification-20260505.md
+++ b/docs/development/multitable-auto-number-system-field-verification-20260505.md
@@ -1,0 +1,27 @@
+# Multitable Auto Number System Field Verification - 2026-05-05
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm exec tsx packages/openapi/tools/build.ts
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/record-service.test.ts --reporter=dot
+pnpm --filter @metasheet/web exec vitest run tests/multitable-system-fields.spec.ts --watch=false --reporter=dot
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+node --test scripts/ops/multitable-openapi-parity.test.mjs
+```
+
+## Results
+
+- Backend focused unit: `record-service.test.ts` passed, `16/16`.
+- Frontend focused unit: `multitable-system-fields.spec.ts` passed, `6/6`.
+- Backend build: passed.
+- Frontend type-check: passed.
+- OpenAPI parity guard: passed.
+
+## Notes
+
+- The isolated worktree initially lacked `vitest` and `tsx`; `pnpm install --frozen-lockfile` restored workspace tool links without changing the lockfile.
+- The frontend Vitest run printed `WebSocket server error: Port is already in use`; the test process still completed successfully. This is local test-server noise, not a failing assertion.
+- `pnpm install` produced plugin/tool `node_modules` symlink noise; those paths were restored with `git restore plugins tools` before final diff review.

--- a/packages/core-backend/src/db/migrations/zzzz20260505110000_create_meta_field_auto_number_sequences.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260505110000_create_meta_field_auto_number_sequences.ts
@@ -1,0 +1,24 @@
+import { sql, type Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    CREATE TABLE IF NOT EXISTS meta_field_auto_number_sequences (
+      field_id text PRIMARY KEY REFERENCES meta_fields(id) ON DELETE CASCADE,
+      sheet_id text NOT NULL REFERENCES meta_sheets(id) ON DELETE CASCADE,
+      next_value bigint NOT NULL DEFAULT 1,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now(),
+      CHECK (next_value >= 1)
+    )
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_meta_field_auto_number_sequences_sheet
+    ON meta_field_auto_number_sequences(sheet_id)
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP INDEX IF EXISTS idx_meta_field_auto_number_sequences_sheet`.execute(db)
+  await sql`DROP TABLE IF EXISTS meta_field_auto_number_sequences`.execute(db)
+}

--- a/packages/core-backend/src/db/types.ts
+++ b/packages/core-backend/src/db/types.ts
@@ -96,6 +96,7 @@ export interface Database {
   // Meta tables
   meta_sheets: MetaSheetsTable
   meta_fields: MetaFieldsTable
+  meta_field_auto_number_sequences: MetaFieldAutoNumberSequencesTable
   meta_views: MetaViewsTable
   meta_records: MetaRecordsTable
   meta_links: MetaLinksTable
@@ -626,6 +627,14 @@ export interface MetaFieldsTable {
   type: string
   property: JSONColumnType<Record<string, unknown> | null>
   order: number
+  created_at: CreatedAt
+  updated_at: UpdatedAt
+}
+
+export interface MetaFieldAutoNumberSequencesTable {
+  field_id: string
+  sheet_id: string
+  next_value: number
   created_at: CreatedAt
   updated_at: UpdatedAt
 }

--- a/packages/core-backend/src/multitable/auto-number-service.ts
+++ b/packages/core-backend/src/multitable/auto-number-service.ts
@@ -1,0 +1,39 @@
+import { normalizeJson, type MultitableField } from './field-codecs'
+
+export type AutoNumberQuery = (
+  sql: string,
+  params?: unknown[],
+) => Promise<{ rows: unknown[]; rowCount?: number | null }>
+
+function resolveStartAt(property: unknown): number {
+  const obj = normalizeJson(property)
+  const raw = typeof obj.startAt === 'number' ? obj.startAt : Number(obj.startAt)
+  if (!Number.isFinite(raw) || raw < 1) return 1
+  return Math.floor(raw)
+}
+
+export async function allocateAutoNumberValues(
+  query: AutoNumberQuery,
+  sheetId: string,
+  fields: Array<Pick<MultitableField, 'id' | 'type' | 'property'>>,
+): Promise<Record<string, number>> {
+  const autoNumberFields = fields.filter((field) => field.type === 'autoNumber')
+  if (autoNumberFields.length === 0) return {}
+
+  const values: Record<string, number> = {}
+  for (const field of autoNumberFields) {
+    const startAt = resolveStartAt(field.property)
+    const result = await query(
+      `INSERT INTO meta_field_auto_number_sequences (field_id, sheet_id, next_value)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (field_id)
+       DO UPDATE SET next_value = meta_field_auto_number_sequences.next_value + 1,
+                     updated_at = now()
+       RETURNING next_value - 1 AS value`,
+      [field.id, sheetId, startAt + 1],
+    )
+    const value = Number((result.rows[0] as { value?: unknown } | undefined)?.value ?? startAt)
+    values[field.id] = value
+  }
+  return values
+}

--- a/packages/core-backend/src/multitable/field-codecs.ts
+++ b/packages/core-backend/src/multitable/field-codecs.ts
@@ -19,6 +19,7 @@ export type MultitableFieldType =
   | 'email'
   | 'phone'
   | 'longText'
+  | 'autoNumber'
   | 'createdTime'
   | 'modifiedTime'
   | 'createdBy'
@@ -97,6 +98,13 @@ export function mapFieldType(type: string): MultitableFieldType | string {
   if (normalized === 'url') return 'url'
   if (normalized === 'email') return 'email'
   if (normalized === 'phone') return 'phone'
+  if (
+    normalized === 'autonumber' ||
+    normalized === 'auto_number' ||
+    normalized === 'auto-number'
+  ) {
+    return 'autoNumber'
+  }
   if (normalized === 'createdtime' || normalized === 'created_time' || normalized === 'created-time') {
     return 'createdTime'
   }
@@ -305,6 +313,14 @@ export function sanitizeFieldProperty(
     return obj
   }
 
+  if (type === 'autoNumber') {
+    const startAtRaw = typeof obj.startAt === 'number' ? obj.startAt : Number(obj.startAt)
+    const startAt = Number.isFinite(startAtRaw) && startAtRaw > 0
+      ? Math.floor(startAtRaw)
+      : 1
+    return { ...obj, startAt, readOnly: true }
+  }
+
   if (SYSTEM_FIELD_TYPES.has(type)) {
     return { ...obj, readOnly: true }
   }
@@ -508,6 +524,7 @@ export const BATCH1_FIELD_TYPES: ReadonlySet<string> = new Set([
 ])
 
 export const SYSTEM_FIELD_TYPES: ReadonlySet<string> = new Set([
+  'autoNumber',
   'createdTime',
   'modifiedTime',
   'createdBy',

--- a/packages/core-backend/src/multitable/record-service.ts
+++ b/packages/core-backend/src/multitable/record-service.ts
@@ -16,6 +16,7 @@ import {
   validateLongTextValue,
   type MultitableField,
 } from './field-codecs'
+import { allocateAutoNumberValues } from './auto-number-service'
 import { getDefaultValidationRules, validateRecord } from './field-validation-engine'
 import type { FieldValidationConfig } from './field-validation'
 import { loadFieldsForSheet } from './loaders'
@@ -211,6 +212,17 @@ function mapFieldType(type: string): UniverMetaField['type'] {
   if (normalized === 'lookup') return 'lookup'
   if (normalized === 'rollup') return 'rollup'
   if (normalized === 'attachment') return 'attachment'
+  if (normalized === 'currency') return 'currency'
+  if (normalized === 'percent') return 'percent'
+  if (normalized === 'rating') return 'rating'
+  if (normalized === 'url') return 'url'
+  if (normalized === 'email') return 'email'
+  if (normalized === 'phone') return 'phone'
+  if (normalized === 'autonumber' || normalized === 'auto_number' || normalized === 'auto-number') return 'autoNumber'
+  if (normalized === 'createdtime' || normalized === 'created_time' || normalized === 'created-time') return 'createdTime'
+  if (normalized === 'modifiedtime' || normalized === 'modified_time' || normalized === 'modified-time') return 'modifiedTime'
+  if (normalized === 'createdby' || normalized === 'created_by' || normalized === 'created-by') return 'createdBy'
+  if (normalized === 'modifiedby' || normalized === 'modified_by' || normalized === 'modified-by') return 'modifiedBy'
   if (
     normalized === 'longtext' ||
     normalized === 'long_text' ||
@@ -290,7 +302,12 @@ function buildCreateFieldGuardMap(rows: unknown[]): Map<string, CreateFieldGuard
       continue
     }
 
-    if (BATCH1_FIELD_TYPES.has(type)) {
+  if (BATCH1_FIELD_TYPES.has(type)) {
+      guards.set(fieldId, { type, property: normalizeJson(row.property) })
+      continue
+    }
+
+    if (type === 'autoNumber') {
       guards.set(fieldId, { type, property: normalizeJson(row.property) })
       continue
     }
@@ -389,7 +406,7 @@ export class RecordService {
         throw new RecordValidationError(`Unknown fieldId: ${fieldId}`)
       }
 
-      if (field.type === 'lookup' || field.type === 'rollup') {
+      if (isFieldAlwaysReadOnly(field)) {
         throw new RecordFieldForbiddenError(`Field is readonly: ${fieldId}`, fieldId)
       }
 
@@ -505,6 +522,11 @@ export class RecordService {
 
     const recordId = `rec_${randomUUID()}`
     const recordRes = await this.pool.transaction(async ({ query }) => {
+      Object.assign(patch, await allocateAutoNumberValues(query, sheetId, Array.from(fieldById, ([id, field]) => ({
+        id,
+        type: field.type,
+        property: field.property,
+      }))))
       const inserted = await query(
         `INSERT INTO meta_records (id, sheet_id, data, version, created_by, modified_by)
          VALUES ($1, $2, $3::jsonb, 1, $4, $4)

--- a/packages/core-backend/src/multitable/record-write-service.ts
+++ b/packages/core-backend/src/multitable/record-write-service.ts
@@ -65,6 +65,7 @@ export type UniverMetaField = {
     | 'email'
     | 'phone'
     | 'longText'
+    | 'autoNumber'
     | 'createdTime'
     | 'modifiedTime'
     | 'createdBy'

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -129,6 +129,7 @@ import {
   RecordValidationFailedError as RecordCreateValidationFailedError,
   RecordPatchFieldValidationError as RecordServicePatchFieldValidationError,
 } from '../multitable/record-service'
+import { allocateAutoNumberValues } from '../multitable/auto-number-service'
 import {
   createYjsInvalidationPostCommitHook,
   type YjsInvalidator,
@@ -190,6 +191,7 @@ const MULTITABLE_FIELD_TYPES = [
   'email',
   'phone',
   'longText',
+  'autoNumber',
   'createdTime',
   'modifiedTime',
   'createdBy',
@@ -218,6 +220,7 @@ type UniverMetaField = {
     | 'email'
     | 'phone'
     | 'longText'
+    | 'autoNumber'
     | 'createdTime'
     | 'modifiedTime'
     | 'createdBy'
@@ -1054,6 +1057,7 @@ function mapFieldType(type: string): UniverMetaField['type'] {
   if (normalized === 'rollup') return 'rollup'
   if (normalized === 'attachment') return 'attachment'
   if (BATCH1_FIELD_TYPES.has(normalized as any)) return normalized as UniverMetaField['type']
+  if (normalized === 'autonumber' || normalized === 'auto_number' || normalized === 'auto-number') return 'autoNumber'
   if (normalized === 'createdtime' || normalized === 'created_time' || normalized === 'created-time') {
     return 'createdTime'
   }
@@ -1288,6 +1292,12 @@ function sanitizeFieldProperty(type: UniverMetaField['type'], property: unknown)
       ...(Number.isFinite(maxFiles) && maxFiles > 0 ? { maxFiles: Math.round(maxFiles) } : {}),
       acceptedMimeTypes: sanitizeStringArray(obj.acceptedMimeTypes),
     }
+  }
+
+  if (type === 'autoNumber') {
+    const startAtRaw = typeof obj.startAt === 'number' ? obj.startAt : Number(obj.startAt)
+    const startAt = Number.isFinite(startAtRaw) && startAtRaw > 0 ? Math.floor(startAtRaw) : 1
+    return { ...obj, startAt, readOnly: true }
   }
 
   if (type === 'createdTime' || type === 'modifiedTime' || type === 'createdBy' || type === 'modifiedBy') {
@@ -4275,6 +4285,7 @@ export function univerMetaRouter(): Router {
         const row = (existing as any).rows[0]
         sheetId = String(row.sheet_id)
         const currentOrder = Number(row.order ?? 0)
+        const currentType = mapFieldType(String(row.type))
 
         const nextName = typeof parsed.data.name === 'string' ? parsed.data.name.trim() : String(row.name)
         const nextType = (parsed.data.type ?? mapFieldType(String(row.type))) as UniverMetaField['type']
@@ -4314,6 +4325,10 @@ export function univerMetaRouter(): Router {
         )
         const updatedRow = (update as any).rows?.[0]
         if (!updatedRow) throw new Error('Update returned no rows')
+
+        if (currentType === 'autoNumber' && nextType !== 'autoNumber') {
+          await query('DELETE FROM meta_field_auto_number_sequences WHERE field_id = $1', [fieldId])
+        }
 
         // Track formula dependencies on update
         if (nextType === 'formula' && nextProperty?.expression) {
@@ -4388,6 +4403,7 @@ export function univerMetaRouter(): Router {
         const order = Number(row.order ?? 0)
 
         await query('DELETE FROM meta_fields WHERE id = $1', [fieldId])
+        await query('DELETE FROM meta_field_auto_number_sequences WHERE field_id = $1', [fieldId])
 
         try {
           await query('DELETE FROM meta_links WHERE field_id = $1', [fieldId])
@@ -6166,6 +6182,8 @@ export function univerMetaRouter(): Router {
           }
           return
         }
+
+        Object.assign(patch, await allocateAutoNumberValues(query, view.sheetId, fields))
 
         const insertRes = await query(
           `INSERT INTO meta_records (id, sheet_id, data, version, created_by, modified_by)

--- a/packages/core-backend/tests/unit/record-service.test.ts
+++ b/packages/core-backend/tests/unit/record-service.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   RecordNotFoundError,
+  RecordFieldForbiddenError,
   RecordPatchFieldValidationError,
   RecordPermissionError,
   RecordService,
@@ -68,6 +69,9 @@ function createMockPool(
     }
     if (sql.includes('INSERT INTO meta_record_subscription_notifications')) {
       return responses.INSERT_RECORD_SUBSCRIPTION_NOTIFICATIONS ?? { rows: [], rowCount: 1 }
+    }
+    if (sql.includes('INSERT INTO meta_field_auto_number_sequences')) {
+      return responses.ALLOCATE_AUTO_NUMBER ?? { rows: [{ value: 1 }], rowCount: 1 }
     }
     if (sql.includes('INSERT INTO meta_links')) {
       return responses.INSERT_LINK ?? { rows: [], rowCount: 1 }
@@ -198,6 +202,52 @@ describe('RecordService', () => {
       expect.stringContaining('INSERT INTO meta_records'),
       [expect.any(String), 'sheet_ops', JSON.stringify({ fld_tags: ['Urgent', 'VIP'] }), 'user_1'],
     )
+  })
+
+  it('allocates readonly autoNumber values during create', async () => {
+    pool = createMockPool({
+      SELECT_FIELDS: {
+        rows: [
+          { id: 'fld_seq', name: 'No.', type: 'autoNumber', property: { startAt: 10 } },
+          { id: 'fld_title', name: 'Title', type: 'string', property: {} },
+        ],
+      },
+      ALLOCATE_AUTO_NUMBER: { rows: [{ value: 10 }] },
+    })
+    const service = new RecordService(pool, eventBus as any)
+
+    const result = await service.createRecord({
+      sheetId: 'sheet_ops',
+      data: { fld_title: 'Alpha' },
+      actorId: 'user_1',
+      capabilities: fullCapabilities,
+    })
+
+    expect(result.data).toEqual({ fld_title: 'Alpha', fld_seq: 10 })
+    expect(pool.queryMock).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO meta_field_auto_number_sequences'),
+      ['fld_seq', 'sheet_ops', 11],
+    )
+    expect(pool.queryMock).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO meta_records'),
+      [expect.any(String), 'sheet_ops', JSON.stringify({ fld_title: 'Alpha', fld_seq: 10 }), 'user_1'],
+    )
+  })
+
+  it('rejects client-supplied autoNumber values during create', async () => {
+    pool = createMockPool({
+      SELECT_FIELDS: {
+        rows: [{ id: 'fld_seq', name: 'No.', type: 'autoNumber', property: {} }],
+      },
+    })
+    const service = new RecordService(pool, eventBus as any)
+
+    await expect(service.createRecord({
+      sheetId: 'sheet_ops',
+      data: { fld_seq: 99 },
+      actorId: 'user_1',
+      capabilities: fullCapabilities,
+    })).rejects.toThrow(RecordFieldForbiddenError)
   })
 
   it('rejects create when a linked target record is missing', async () => {

--- a/packages/openapi/dist/combined.openapi.yml
+++ b/packages/openapi/dist/combined.openapi.yml
@@ -1599,6 +1599,7 @@ components:
         - email
         - phone
         - longText
+        - autoNumber
         - createdTime
         - modifiedTime
         - createdBy

--- a/packages/openapi/dist/openapi.json
+++ b/packages/openapi/dist/openapi.json
@@ -2295,6 +2295,7 @@
           "email",
           "phone",
           "longText",
+          "autoNumber",
           "createdTime",
           "modifiedTime",
           "createdBy",

--- a/packages/openapi/dist/openapi.yaml
+++ b/packages/openapi/dist/openapi.yaml
@@ -1599,6 +1599,7 @@ components:
         - email
         - phone
         - longText
+        - autoNumber
         - createdTime
         - modifiedTime
         - createdBy

--- a/packages/openapi/src/base.yml
+++ b/packages/openapi/src/base.yml
@@ -1542,6 +1542,7 @@ components:
         - email
         - phone
         - longText
+        - autoNumber
         - createdTime
         - modifiedTime
         - createdBy

--- a/scripts/ops/multitable-openapi-parity.test.mjs
+++ b/scripts/ops/multitable-openapi-parity.test.mjs
@@ -26,6 +26,7 @@ const expectedFieldTypes = [
   'email',
   'phone',
   'longText',
+  'autoNumber',
   'createdTime',
   'modifiedTime',
   'createdBy',


### PR DESCRIPTION
## Summary
- Add persistent per-field auto-number sequences for multitable records.
- Treat autoNumber as a readonly system field across backend guards, frontend field manager, and OpenAPI.
- Allocate auto numbers inside record-create transactions, including the public-form direct-create path.

## Verification
- pnpm install --frozen-lockfile
- pnpm exec tsx packages/openapi/tools/build.ts
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/record-service.test.ts --reporter=dot
- pnpm --filter @metasheet/web exec vitest run tests/multitable-system-fields.spec.ts --watch=false --reporter=dot
- pnpm --filter @metasheet/core-backend build
- pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
- node --test scripts/ops/multitable-openapi-parity.test.mjs
- git diff --check HEAD~1..HEAD

## Docs
- docs/development/multitable-auto-number-system-field-design-20260505.md
- docs/development/multitable-auto-number-system-field-verification-20260505.md

## Deferred
- Prefix/padding/reset formatting.
- Backfill for pre-existing records when adding autoNumber to an existing sheet.
