### PR TITLE
feat(multitable): add number display formatting

### DIFF
--- a/apps/web/src/multitable/components/MetaFieldManager.vue
+++ b/apps/web/src/multitable/components/MetaFieldManager.vue
@@ -226,6 +226,31 @@
           </div>
         </template>
 
+        <template v-else-if="configTargetType === 'number'">
+          <div class="meta-field-mgr__grid">
+            <label class="meta-field-mgr__field">
+              <span>Decimals</span>
+              <input
+                class="meta-field-mgr__input"
+                type="number"
+                min="0"
+                max="6"
+                placeholder="Preserve"
+                :value="numberDraft.decimals ?? ''"
+                @input="onNumberDecimalsInput"
+              />
+            </label>
+            <label class="meta-field-mgr__field">
+              <span>Unit</span>
+              <input v-model="numberDraft.unit" class="meta-field-mgr__input" maxlength="24" placeholder="kg, hours, pcs..." />
+            </label>
+          </div>
+          <label class="meta-field-mgr__toggle">
+            <input v-model="numberDraft.thousands" type="checkbox" />
+            <span>Use thousands separators</span>
+          </label>
+        </template>
+
         <template v-else-if="configTargetType === 'currency'">
           <div class="meta-field-mgr__grid">
             <label class="meta-field-mgr__field">
@@ -330,6 +355,7 @@ import {
   resolveFormulaFieldProperty,
   resolveLinkFieldProperty,
   resolveLookupFieldProperty,
+  resolveNumberFieldProperty,
   resolvePercentFieldProperty,
   resolveRatingFieldProperty,
   resolveRollupFieldProperty,
@@ -503,6 +529,11 @@ const currencyDraft = reactive<{ code: string; decimals: number }>({
   code: 'CNY',
   decimals: 2,
 })
+const numberDraft = reactive<{ decimals: number | null; thousands: boolean; unit: string }>({
+  decimals: null,
+  thousands: false,
+  unit: '',
+})
 const percentDraft = reactive<{ decimals: number }>({
   decimals: 1,
 })
@@ -574,10 +605,15 @@ function onValidationRulesChange(rules: FieldValidationRule[]) {
   validationDraftTouched.value = true
 }
 
+function onNumberDecimalsInput(event: Event) {
+  const value = (event.target as HTMLInputElement).value.trim()
+  numberDraft.decimals = value === '' ? null : Number(value)
+}
+
 function requiresConfig(type: MetaFieldCreateType): boolean {
   return [
     'select', 'multiSelect', 'link', 'person', 'lookup', 'rollup', 'formula', 'attachment',
-    'currency', 'percent', 'rating', 'longText',
+    'number', 'currency', 'percent', 'rating', 'longText',
   ].includes(type)
 }
 
@@ -605,6 +641,9 @@ function resetDrafts() {
   attachmentDraft.acceptedMimeTypesText = ''
   currencyDraft.code = 'CNY'
   currencyDraft.decimals = 2
+  numberDraft.decimals = null
+  numberDraft.thousands = false
+  numberDraft.unit = ''
   percentDraft.decimals = 1
   ratingDraft.max = 5
   validationDraft.value = []
@@ -662,6 +701,14 @@ function serializeFieldDraft(type: string | null): string {
   }
   if (type === 'currency') {
     return JSON.stringify({ code: currencyDraft.code.trim().toUpperCase(), decimals: currencyDraft.decimals })
+  }
+  if (type === 'number') {
+    return JSON.stringify({
+      decimals: numberDraft.decimals,
+      thousands: numberDraft.thousands,
+      unit: numberDraft.unit.trim(),
+      validation,
+    })
   }
   if (type === 'percent') {
     return JSON.stringify({ decimals: percentDraft.decimals })
@@ -736,6 +783,11 @@ function hydrateExistingFieldConfig(field: MetaField, options?: { liveRefreshTex
     const property = resolveCurrencyFieldProperty(field.property)
     currencyDraft.code = property.code
     currencyDraft.decimals = property.decimals
+  } else if (fieldType === 'number') {
+    const property = resolveNumberFieldProperty(field.property)
+    numberDraft.decimals = property.decimals
+    numberDraft.thousands = property.thousands
+    numberDraft.unit = property.unit
   } else if (fieldType === 'percent') {
     const property = resolvePercentFieldProperty(field.property)
     percentDraft.decimals = property.decimals
@@ -810,7 +862,7 @@ function openNewFieldConfigIfNeeded() {
 }
 
 function currentDraftProperty(type: MetaFieldCreateType | string): Record<string, unknown> | undefined {
-  const normalizedType = type === 'link' || type === 'select' || type === 'multiSelect' || type === 'lookup' || type === 'rollup' || type === 'formula' || type === 'attachment' || type === 'person' || type === 'currency' || type === 'percent' || type === 'rating'
+  const normalizedType = type === 'link' || type === 'select' || type === 'multiSelect' || type === 'lookup' || type === 'rollup' || type === 'formula' || type === 'attachment' || type === 'person' || type === 'number' || type === 'currency' || type === 'percent' || type === 'rating'
     ? type
     : null
   fieldConfigError.value = ''
@@ -901,6 +953,25 @@ function currentDraftProperty(type: MetaFieldCreateType | string): Record<string
     }
     return { code, decimals: Math.round(decimals) }
   }
+  if (normalizedType === 'number') {
+    const property: Record<string, unknown> = { ...validationProperty }
+    if (numberDraft.decimals !== null) {
+      const decimals = Number(numberDraft.decimals)
+      if (!Number.isFinite(decimals) || decimals < 0 || decimals > 6) {
+        fieldConfigError.value = 'Number decimals must be blank or between 0 and 6'
+        return undefined
+      }
+      property.decimals = Math.round(decimals)
+    }
+    property.thousands = numberDraft.thousands
+    const unit = numberDraft.unit.trim()
+    if (unit.length > 24) {
+      fieldConfigError.value = 'Number unit must be 24 characters or fewer'
+      return undefined
+    }
+    if (unit) property.unit = unit
+    return property
+  }
   if (normalizedType === 'percent') {
     const decimals = Number(percentDraft.decimals)
     if (!Number.isFinite(decimals) || decimals < 0 || decimals > 6) {
@@ -917,7 +988,7 @@ function currentDraftProperty(type: MetaFieldCreateType | string): Record<string
     }
     return { max: Math.round(max) }
   }
-  if (type === 'string' || type === 'longText' || type === 'number') {
+  if (type === 'string' || type === 'longText') {
     return { ...validationProperty }
   }
   return undefined
@@ -964,7 +1035,7 @@ function saveConfig() {
   // an empty `property: {}` would otherwise clobber existing values on
   // the server. Types with mandatory structural config (select/link/
   // lookup/rollup/formula/attachment) always have keys to persist.
-  const onlyValidationSurface = (fieldType === 'string' || fieldType === 'longText' || fieldType === 'number')
+  const onlyValidationSurface = (fieldType === 'string' || fieldType === 'longText')
   if (onlyValidationSurface && !validationDraftTouched.value) {
     closeConfig()
     return

--- a/apps/web/src/multitable/components/cells/MetaCellEditor.vue
+++ b/apps/web/src/multitable/components/cells/MetaCellEditor.vue
@@ -60,6 +60,7 @@
       ref="inputRef"
       class="meta-cell-editor__input"
       type="number"
+      :step="numericStep"
       :value="modelValue ?? ''"
       @input="onNumberInput"
       @keydown.enter="emit('confirm')"
@@ -236,6 +237,7 @@ import {
   attachmentAcceptAttr,
   resolveAttachmentFieldProperty,
   resolveCurrencyFieldProperty,
+  resolveNumberFieldProperty,
   resolvePercentFieldProperty,
   resolveRatingFieldProperty,
   shouldReplaceAttachmentSelection,
@@ -463,6 +465,10 @@ function onNumberInput(e: Event) {
 }
 
 const numericStep = computed(() => {
+  if (props.field.type === 'number') {
+    const { decimals } = resolveNumberFieldProperty(props.field.property)
+    return decimals && decimals > 0 ? `0.${'0'.repeat(decimals - 1)}1` : 'any'
+  }
   if (props.field.type === 'currency') {
     const { decimals } = resolveCurrencyFieldProperty(props.field.property)
     return decimals > 0 ? `0.${'0'.repeat(decimals - 1)}1` : '1'

--- a/apps/web/src/multitable/utils/field-config.ts
+++ b/apps/web/src/multitable/utils/field-config.ts
@@ -47,6 +47,12 @@ export type NormalizedRatingFieldProperty = {
   max: number
 }
 
+export type NormalizedNumberFieldProperty = {
+  decimals: number | null
+  thousands: boolean
+  unit: string
+}
+
 function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value)
     ? value as Record<string, unknown>
@@ -167,6 +173,20 @@ export function resolveRatingFieldProperty(value: unknown): NormalizedRatingFiel
   return { max }
 }
 
+export function resolveNumberFieldProperty(value: unknown): NormalizedNumberFieldProperty {
+  const property = asRecord(value)
+  const decimalsRaw = typeof property.decimals === 'number' ? property.decimals : Number(property.decimals)
+  const decimals = Number.isFinite(decimalsRaw) && decimalsRaw >= 0 && decimalsRaw <= 6
+    ? Math.round(decimalsRaw)
+    : null
+  const unit = typeof property.unit === 'string' ? property.unit.trim().slice(0, 24) : ''
+  return {
+    decimals,
+    thousands: property.thousands === true,
+    unit,
+  }
+}
+
 const CURRENCY_SYMBOL_BY_CODE: Record<string, string> = {
   CNY: '¥',
   USD: '$',
@@ -210,6 +230,27 @@ export function formatPercentValue(value: number, decimals: number): string {
   } catch {
     return `${value.toFixed(decimals)}%`
   }
+}
+
+function splitFixedNumber(value: number, decimals: number | null): { sign: string; integer: string; fraction: string } {
+  const raw = decimals === null ? String(value) : value.toFixed(decimals)
+  const sign = raw.startsWith('-') ? '-' : ''
+  const unsigned = sign ? raw.slice(1) : raw
+  const [integer = '0', fraction = ''] = unsigned.split('.')
+  return { sign, integer, fraction }
+}
+
+function groupThousands(integer: string): string {
+  return integer.replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+}
+
+export function formatNumberValue(value: number, property: unknown): string {
+  const { decimals, thousands, unit } = resolveNumberFieldProperty(property)
+  if (decimals === null && !thousands && !unit) return String(value)
+  const { sign, integer, fraction } = splitFixedNumber(value, decimals)
+  const whole = thousands ? groupThousands(integer) : integer
+  const numeric = fraction.length > 0 ? `${sign}${whole}.${fraction}` : `${sign}${whole}`
+  return unit ? `${numeric} ${unit}` : numeric
 }
 
 const URL_REGEX = /^https?:\/\/[^\s]+$/i

--- a/apps/web/src/multitable/utils/field-display.ts
+++ b/apps/web/src/multitable/utils/field-display.ts
@@ -1,6 +1,7 @@
 import type { LinkedRecordSummary, MetaAttachment, MetaField } from '../types'
 import {
   formatCurrencyValue,
+  formatNumberValue,
   formatPercentValue,
   resolveCurrencyFieldProperty,
   resolvePercentFieldProperty,
@@ -52,6 +53,12 @@ export function formatFieldDisplay(params: {
   if (field.type === 'createdTime' || field.type === 'modifiedTime') return formatDateTime(value)
   if (isSystemFieldType(field.type)) return String(value)
   if (field.type === 'boolean') return value ? 'Yes' : 'No'
+
+  if (field.type === 'number') {
+    const num = typeof value === 'number' ? value : Number(value)
+    if (!Number.isFinite(num)) return String(value)
+    return formatNumberValue(num, field.property)
+  }
 
   if (field.type === 'currency') {
     const num = typeof value === 'number' ? value : Number(value)

--- a/apps/web/tests/multitable-number-format.spec.ts
+++ b/apps/web/tests/multitable-number-format.spec.ts
@@ -1,0 +1,165 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick } from 'vue'
+import MetaCellEditor from '../src/multitable/components/cells/MetaCellEditor.vue'
+import MetaFieldManager from '../src/multitable/components/MetaFieldManager.vue'
+import { formatFieldDisplay } from '../src/multitable/utils/field-display'
+
+describe('multitable number format', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  it('formats number fields with decimals, thousands separators, and unit', () => {
+    expect(formatFieldDisplay({
+      field: {
+        id: 'fld_weight',
+        name: 'Weight',
+        type: 'number',
+        property: { decimals: 2, thousands: true, unit: 'kg' },
+      },
+      value: 12345.6,
+    })).toBe('12,345.60 kg')
+  })
+
+  it('preserves legacy number display when no format property is configured', () => {
+    expect(formatFieldDisplay({
+      field: { id: 'fld_raw', name: 'Raw number', type: 'number', property: {} },
+      value: 12345.678,
+    })).toBe('12345.678')
+  })
+
+  it('creates number fields with display-format property from the field manager', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const createSpy = vi.fn()
+
+    const app = createApp({
+      render() {
+        return h(MetaFieldManager, {
+          visible: true,
+          sheetId: 'sheet_1',
+          sheets: [],
+          fields: [],
+          onCreateField: createSpy,
+        })
+      },
+    })
+
+    app.mount(container)
+    await nextTick()
+
+    const nameInput = container.querySelector('.meta-field-mgr__add-row .meta-field-mgr__input') as HTMLInputElement
+    const typeSelect = container.querySelector('.meta-field-mgr__add-row .meta-field-mgr__select') as HTMLSelectElement
+    nameInput.value = 'Weight'
+    nameInput.dispatchEvent(new Event('input', { bubbles: true }))
+    typeSelect.value = 'number'
+    typeSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await nextTick()
+
+    const configInputs = Array.from(container.querySelectorAll('.meta-field-mgr__config .meta-field-mgr__input')) as HTMLInputElement[]
+    configInputs[0].value = '2'
+    configInputs[0].dispatchEvent(new Event('input', { bubbles: true }))
+    configInputs[1].value = 'kg'
+    configInputs[1].dispatchEvent(new Event('input', { bubbles: true }))
+    const thousandsCheckbox = container.querySelector('.meta-field-mgr__config input[type="checkbox"]') as HTMLInputElement
+    thousandsCheckbox.checked = true
+    thousandsCheckbox.dispatchEvent(new Event('change', { bubbles: true }))
+    await nextTick()
+
+    ;(Array.from(container.querySelectorAll('.meta-field-mgr__btn-add')) as HTMLButtonElement[])
+      .find((button) => button.textContent?.includes('+ Add'))
+      ?.click()
+    await nextTick()
+
+    expect(createSpy).toHaveBeenCalledWith({
+      sheetId: 'sheet_1',
+      name: 'Weight',
+      type: 'number',
+      property: {
+        decimals: 2,
+        thousands: true,
+        unit: 'kg',
+      },
+    })
+
+    app.unmount()
+  })
+
+  it('updates an existing number field without dropping validation rules', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const updateSpy = vi.fn()
+
+    const app = createApp({
+      render() {
+        return h(MetaFieldManager, {
+          visible: true,
+          sheetId: 'sheet_1',
+          sheets: [],
+          fields: [
+            {
+              id: 'fld_qty',
+              name: 'Quantity',
+              type: 'number',
+              property: {
+                decimals: 1,
+                validation: [{ type: 'min', params: { value: 0 } }],
+              },
+            },
+          ],
+          onUpdateField: updateSpy,
+        })
+      },
+    })
+
+    app.mount(container)
+    await nextTick()
+
+    ;(container.querySelector('.meta-field-mgr__action[title="Configure"]') as HTMLButtonElement | null)?.click()
+    await nextTick()
+
+    const configInputs = Array.from(container.querySelectorAll('.meta-field-mgr__config .meta-field-mgr__input')) as HTMLInputElement[]
+    expect(configInputs[0].value).toBe('1')
+    configInputs[0].value = '3'
+    configInputs[0].dispatchEvent(new Event('input', { bubbles: true }))
+    await nextTick()
+
+    ;(Array.from(container.querySelectorAll('.meta-field-mgr__btn-add')) as HTMLButtonElement[])
+      .find((button) => button.textContent?.includes('Save field settings'))
+      ?.click()
+    await nextTick()
+
+    expect(updateSpy).toHaveBeenCalledWith('fld_qty', {
+      property: {
+        decimals: 3,
+        thousands: false,
+        validation: [{ type: 'min', params: { value: 0 } }],
+      },
+    })
+
+    app.unmount()
+  })
+
+  it('uses the configured decimal precision as the number editor step', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    const app = createApp({
+      render() {
+        return h(MetaCellEditor, {
+          field: { id: 'fld_score', name: 'Score', type: 'number', property: { decimals: 3 } },
+          modelValue: 1.234,
+        })
+      },
+    })
+
+    app.mount(container)
+    await nextTick()
+
+    const input = container.querySelector('input[type="number"]') as HTMLInputElement
+    expect(input.step).toBe('0.001')
+
+    app.unmount()
+  })
+})

--- a/docs/development/multitable-number-format-design-20260505.md
+++ b/docs/development/multitable-number-format-design-20260505.md
@@ -1,0 +1,64 @@
+# Multitable Number Format Design - 2026-05-05
+
+## Context
+
+`docs/development/multitable-feishu-rc-todo-20260430.md` keeps `Number format: decimals, thousands, unit` as an optional Feishu-parity RC item. Existing `number` fields already store raw numeric values and can carry validation rules, but the UI had no first-class display-format property and rendered numbers with `String(value)`.
+
+## Goals
+
+- Add field-level display formatting for `number` fields: decimal precision, thousands separator, and unit suffix.
+- Preserve raw numeric storage and write validation semantics.
+- Preserve existing `number` fields that have no format property.
+- Keep number validation rules round-tripping with the new display-format keys.
+
+## Non-Goals
+
+- No locale-specific formatting selector.
+- No XLSX/CSV export formatting changes.
+- No formula/rollup result formatting changes.
+- No backend numeric coercion change for record values.
+
+## Property Contract
+
+`number` field property now accepts these display keys:
+
+```json
+{
+  "decimals": 2,
+  "thousands": true,
+  "unit": "kg",
+  "validation": []
+}
+```
+
+Rules:
+
+- `decimals` is optional. If absent or invalid, rendering preserves the raw numeric precision.
+- `decimals` is normalized to an integer in `[0, 6]`.
+- `thousands` is normalized to a boolean and defaults to `false`.
+- `unit` is trimmed and capped at 24 characters.
+- `validation` keeps the existing field-validation engine shape.
+
+## Implementation
+
+- Backend canonical sanitizer: `packages/core-backend/src/multitable/field-codecs.ts`
+  - Normalizes `number.decimals`, `number.thousands`, and `number.unit`.
+  - Leaves record values untouched.
+- Legacy route sanitizer: `packages/core-backend/src/routes/univer-meta.ts`
+  - Mirrors the same `number` property normalization for route paths still using local sanitize logic.
+- Frontend config helpers: `apps/web/src/multitable/utils/field-config.ts`
+  - Adds `resolveNumberFieldProperty()` and `formatNumberValue()`.
+  - Rendering is deterministic and avoids locale-dependent assertions.
+- Frontend display: `apps/web/src/multitable/utils/field-display.ts`
+  - Routes `number` values through the new formatter.
+  - If no display-format property is set, output remains `String(value)`.
+- Field manager: `apps/web/src/multitable/components/MetaFieldManager.vue`
+  - Adds number config UI for decimals, thousands separator, and unit.
+  - Keeps validation rules alongside display-format keys.
+- Cell editor: `apps/web/src/multitable/components/cells/MetaCellEditor.vue`
+  - Uses configured `decimals` as the numeric input step when present.
+
+## Compatibility
+
+Existing number fields without `decimals`, `thousands`, or `unit` render exactly as before. New formatting is opt-in by field property and does not convert persisted values into formatted strings.
+

--- a/docs/development/multitable-number-format-verification-20260505.md
+++ b/docs/development/multitable-number-format-verification-20260505.md
@@ -1,0 +1,103 @@
+# Multitable Number Format Verification - 2026-05-05
+
+## Scope
+
+Verifies the `number` field display-format slice:
+
+- Backend property sanitization.
+- Frontend field display formatting.
+- Field manager create/update payloads.
+- Number editor step behavior.
+- Type/build gates.
+
+## Commands
+
+### Dependency Bootstrap
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+Result: passed. `pnpm` relinked tracked plugin/tool `node_modules` shims in this worktree; those generated path changes were reverted before commit.
+
+### Backend Sanitizer Unit Test
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/multitable-field-types-batch1.test.ts --reporter=dot
+```
+
+Result: passed.
+
+```text
+Test Files  1 passed (1)
+Tests       65 passed (65)
+```
+
+### Frontend Focused Number Format Test
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-number-format.spec.ts --watch=false --reporter=dot
+```
+
+Result: passed.
+
+```text
+Test Files  1 passed (1)
+Tests       5 passed (5)
+```
+
+Note: local Vitest printed `WebSocket server error: Port is already in use`; the test process still exited `0`. This is the known web test harness port warning.
+
+### Frontend Field Manager Regression
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-field-manager.spec.ts tests/multitable-number-format.spec.ts --watch=false --reporter=dot
+```
+
+Result: passed.
+
+```text
+Test Files  2 passed (2)
+Tests       19 passed (19)
+```
+
+### Backend Build
+
+```bash
+pnpm --filter @metasheet/core-backend build
+```
+
+Result: passed.
+
+### Frontend Type Check
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+```
+
+Result: passed.
+
+### Whitespace Guard
+
+```bash
+git diff --check
+```
+
+Result: passed.
+
+## Assertions Covered
+
+- `sanitizeFieldProperty('number', ...)` preserves valid `decimals/thousands/unit` and validation rules.
+- Invalid `decimals` is dropped, `thousands` is normalized to boolean, and `unit` is trimmed/capped.
+- `formatFieldDisplay()` renders `12,345.60 kg` for a formatted number field.
+- Legacy number fields with no display-format property still render raw values, e.g. `12345.678`.
+- `MetaFieldManager` emits number field create payloads with format property.
+- Existing number field config updates preserve engine-shape validation rules.
+- `MetaCellEditor` derives number input `step` from configured decimal precision.
+
+## Deferred
+
+- Manual staging verification remains part of the RC smoke checklist.
+- XLSX/CSV formatting is not changed by this slice.
+- Locale-specific number formatting is not implemented.
+

--- a/packages/core-backend/src/multitable/field-codecs.ts
+++ b/packages/core-backend/src/multitable/field-codecs.ts
@@ -295,6 +295,23 @@ export function sanitizeFieldProperty(
     return { ...obj, code, decimals }
   }
 
+  if (type === 'number') {
+    const next: Record<string, unknown> = { ...obj }
+    if ('decimals' in obj) {
+      const decimalsRaw = typeof obj.decimals === 'number' ? obj.decimals : Number(obj.decimals)
+      if (Number.isFinite(decimalsRaw) && decimalsRaw >= 0 && decimalsRaw <= 6) {
+        next.decimals = Math.round(decimalsRaw)
+      } else {
+        delete next.decimals
+      }
+    }
+    next.thousands = obj.thousands === true
+    const unit = typeof obj.unit === 'string' ? obj.unit.trim().slice(0, 24) : ''
+    if (unit) next.unit = unit
+    else delete next.unit
+    return next
+  }
+
   if (type === 'percent') {
     const decimalsRaw = typeof obj.decimals === 'number' ? obj.decimals : Number(obj.decimals)
     const decimals = Number.isFinite(decimalsRaw) && decimalsRaw >= 0 && decimalsRaw <= 6

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -1294,6 +1294,23 @@ function sanitizeFieldProperty(type: UniverMetaField['type'], property: unknown)
     }
   }
 
+  if (type === 'number') {
+    const next: Record<string, unknown> = { ...obj }
+    if ('decimals' in obj) {
+      const decimalsRaw = typeof obj.decimals === 'number' ? obj.decimals : Number(obj.decimals)
+      if (Number.isFinite(decimalsRaw) && decimalsRaw >= 0 && decimalsRaw <= 6) {
+        next.decimals = Math.round(decimalsRaw)
+      } else {
+        delete next.decimals
+      }
+    }
+    next.thousands = obj.thousands === true
+    const unit = typeof obj.unit === 'string' ? obj.unit.trim().slice(0, 24) : ''
+    if (unit) next.unit = unit
+    else delete next.unit
+    return next
+  }
+
   if (type === 'autoNumber') {
     const startAtRaw = typeof obj.startAt === 'number' ? obj.startAt : Number(obj.startAt)
     const startAt = Number.isFinite(startAtRaw) && startAtRaw > 0 ? Math.floor(startAtRaw) : 1

--- a/packages/core-backend/tests/unit/multitable-field-types-batch1.test.ts
+++ b/packages/core-backend/tests/unit/multitable-field-types-batch1.test.ts
@@ -107,6 +107,33 @@ describe('sanitizeFieldProperty — currency', () => {
   })
 })
 
+describe('sanitizeFieldProperty — number format', () => {
+  it('preserves safe display-format options without changing validation rules', () => {
+    expect(sanitizeFieldProperty('number', {
+      decimals: '2',
+      thousands: true,
+      unit: ' kg ',
+      validation: [{ type: 'min', params: { value: 0 } }],
+    })).toEqual({
+      decimals: 2,
+      thousands: true,
+      unit: 'kg',
+      validation: [{ type: 'min', params: { value: 0 } }],
+    })
+  })
+
+  it('drops invalid decimals and trims unit length', () => {
+    expect(sanitizeFieldProperty('number', {
+      decimals: 99,
+      thousands: 'yes',
+      unit: 'abcdefghijklmnopqrstuvwxy',
+    })).toEqual({
+      thousands: false,
+      unit: 'abcdefghijklmnopqrstuvwx',
+    })
+  })
+})
+
 describe('sanitizeFieldProperty — percent', () => {
   it('round-trips valid decimals', () => {
     expect(sanitizeFieldProperty('percent', { decimals: 0 })).toEqual({ decimals: 0 })


### PR DESCRIPTION
## Summary\n- add optional number field display formatting for decimals, thousands separators, and unit suffix\n- preserve raw number storage and legacy display when no format property is configured\n- wire field manager config, display formatter, editor step, backend sanitizers, tests, and design/verification docs\n\n## Verification\n- pnpm install --frozen-lockfile\n- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/multitable-field-types-batch1.test.ts --reporter=dot\n- pnpm --filter @metasheet/web exec vitest run tests/multitable-number-format.spec.ts --watch=false --reporter=dot\n- pnpm --filter @metasheet/web exec vitest run tests/multitable-field-manager.spec.ts tests/multitable-number-format.spec.ts --watch=false --reporter=dot\n- pnpm --filter @metasheet/core-backend build\n- pnpm --filter @metasheet/web exec vue-tsc -b --noEmit\n- git diff --check\n\n## Docs\n- docs/development/multitable-number-format-design-20260505.md\n- docs/development/multitable-number-format-verification-20260505.md\n\n## Notes\n- XLSX/CSV formatting remains out of scope for this slice.\n- Existing number fields without format property still render as raw values.