### PR TITLE
test(integration): add K3 WISE signoff evidence gate

### DIFF
--- a/.github/workflows/integration-k3wise-postdeploy-smoke.yml
+++ b/.github/workflows/integration-k3wise-postdeploy-smoke.yml
@@ -127,6 +127,8 @@ jobs:
 
       - name: Fail when K3 WISE smoke failed
         if: always()
+        env:
+          REQUIRE_AUTH: ${{ github.event.inputs.require_auth || 'true' }}
         run: |
           token_rc="${{ steps.token_resolve.outputs.token_resolve_rc }}"
           rc="${{ steps.smoke.outputs.smoke_rc }}"
@@ -145,4 +147,8 @@ jobs:
           if [[ "$rc" != "0" ]]; then
             echo "K3 WISE postdeploy smoke failed: rc=$rc" >&2
             exit 1
+          fi
+          if [[ "$REQUIRE_AUTH" == "true" ]]; then
+            node scripts/ops/integration-k3wise-signoff-gate.mjs \
+              --input output/integration-k3wise-postdeploy-smoke/manual/integration-k3wise-postdeploy-smoke.json
           fi

--- a/docs/development/integration-k3wise-signoff-gate-development-20260506.md
+++ b/docs/development/integration-k3wise-signoff-gate-development-20260506.md
@@ -1,0 +1,63 @@
+# K3 WISE Signoff Gate Development
+
+Date: 2026-05-06
+
+## Context
+
+The K3 WISE postdeploy smoke already writes diagnostic evidence and the summary
+renderer can display `Internal trial signoff: PASS` or `BLOCKED`. The remaining
+gap was a machine-readable gate that can be run against a downloaded or
+workflow-produced `integration-k3wise-postdeploy-smoke.json` file.
+
+The gate is deliberately separate from the renderer:
+
+- `integration-k3wise-postdeploy-summary.mjs` stays presentation-oriented.
+- `integration-k3wise-signoff-gate.mjs` exits non-zero when evidence is not
+  sufficient for internal-trial signoff.
+
+## Implementation
+
+Added `scripts/ops/integration-k3wise-signoff-gate.mjs`.
+
+The script accepts:
+
+```bash
+node scripts/ops/integration-k3wise-signoff-gate.mjs --input <evidence.json>
+```
+
+It requires all of the following:
+
+- `ok === true`
+- `authenticated === true`
+- `signoff.internalTrial === "pass"`
+- `summary.fail === 0`
+- required checks are present and passing:
+  - `auth-me`
+  - `integration-route-contract`
+  - `integration-list-external-systems`
+  - `integration-list-pipelines`
+  - `integration-list-runs`
+  - `integration-list-dead-letters`
+  - `staging-descriptor-contract`
+
+The script prints a small JSON result and returns:
+
+- exit `0` for `PASS`
+- exit `1` for `BLOCKED` or invalid/missing evidence
+
+The manual `K3 WISE Postdeploy Smoke` workflow now invokes this gate in the
+final step when `require_auth=true`. Public diagnostic runs with
+`require_auth=false` still skip the signoff gate and remain useful for basic
+deployment smoke.
+
+## Scope Control
+
+This slice does not change:
+
+- the K3 WISE setup UI
+- live PoC preflight behavior
+- live PoC evidence fixtures
+- `package.json`
+- customer GATE requirements
+
+That keeps it independent from the currently open K3 WISE PRs.

--- a/docs/development/integration-k3wise-signoff-gate-verification-20260506.md
+++ b/docs/development/integration-k3wise-signoff-gate-verification-20260506.md
@@ -1,0 +1,36 @@
+# K3 WISE Signoff Gate Verification
+
+Date: 2026-05-06
+
+## Commands
+
+```bash
+node --test scripts/ops/integration-k3wise-signoff-gate.test.mjs
+node --test scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs
+node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs scripts/ops/integration-k3wise-postdeploy-summary.test.mjs scripts/ops/integration-k3wise-signoff-gate.test.mjs
+git diff --check -- .github/workflows/integration-k3wise-postdeploy-smoke.yml scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs scripts/ops/integration-k3wise-signoff-gate.mjs scripts/ops/integration-k3wise-signoff-gate.test.mjs docs/development/integration-k3wise-signoff-gate-development-20260506.md docs/development/integration-k3wise-signoff-gate-verification-20260506.md
+```
+
+## Expected Coverage
+
+The new test suite covers:
+
+- authenticated evidence with all required checks passes
+- public-only diagnostic smoke is blocked
+- stale explicit signoff pass with `ok=false` is blocked
+- stale explicit signoff pass with `summary.fail>0` is blocked
+- missing required checks are blocked
+- non-passing required checks are blocked
+- missing evidence fails by default
+- `--help` prints usage
+- the manual postdeploy workflow calls the signoff gate when `require_auth=true`
+
+## Result
+
+Passed locally:
+
+- `integration-k3wise-signoff-gate.test.mjs`: 8/8 passed.
+- Postdeploy chain suite (`smoke`, `summary`, `workflow-contract`, `signoff-gate`):
+  31/31 passed.
+- Workflow YAML parse: passed.
+- `git diff --check`: passed.

--- a/scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs
@@ -74,8 +74,11 @@ test('manual K3 WISE postdeploy smoke workflow keeps dispatch and auth contract 
   assertContains(raw, '- name: Fail when K3 WISE smoke failed', 'manual final gate')
   assertContains(raw, 'steps.token_resolve.outputs.token_resolve_rc', 'manual final gate')
   assertContains(raw, 'steps.smoke.outputs.smoke_rc', 'manual final gate')
+  assertContains(raw, "REQUIRE_AUTH: ${{ github.event.inputs.require_auth || 'true' }}", 'manual final gate')
   assertContains(raw, 'K3 WISE smoke token resolution failed', 'manual final gate')
   assertContains(raw, 'K3 WISE postdeploy smoke failed', 'manual final gate')
+  assertContains(raw, 'scripts/ops/integration-k3wise-signoff-gate.mjs', 'manual final gate')
+  assertContains(raw, '--input output/integration-k3wise-postdeploy-smoke/manual/integration-k3wise-postdeploy-smoke.json', 'manual final gate')
 })
 
 test('deploy workflow keeps K3 WISE smoke evidence wired into deploy summary and artifacts', () => {

--- a/scripts/ops/integration-k3wise-signoff-gate.mjs
+++ b/scripts/ops/integration-k3wise-signoff-gate.mjs
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const REQUIRED_PASS_CHECKS = [
+  'auth-me',
+  'integration-route-contract',
+  'integration-list-external-systems',
+  'integration-list-pipelines',
+  'integration-list-runs',
+  'integration-list-dead-letters',
+  'staging-descriptor-contract',
+]
+
+class K3WiseSignoffGateError extends Error {
+  constructor(message, details = {}) {
+    super(message)
+    this.name = 'K3WiseSignoffGateError'
+    this.details = details
+  }
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/ops/integration-k3wise-signoff-gate.mjs --input <path>
+
+Machine-checks K3 WISE postdeploy smoke evidence for internal-trial signoff.
+Public-only smoke and presentation summaries are not accepted as signoff.
+
+Required evidence:
+  ok === true
+  authenticated === true
+  signoff.internalTrial === "pass"
+  summary.fail === 0
+  required checks pass: ${REQUIRED_PASS_CHECKS.join(', ')}
+
+Options:
+  --input <path>  K3 WISE postdeploy smoke evidence JSON path
+  --help          Show this help
+`)
+}
+
+function readRequiredValue(argv, index, flag) {
+  const next = argv[index + 1]
+  if (!next || next.startsWith('--')) {
+    throw new K3WiseSignoffGateError(`${flag} requires a value`, { flag })
+  }
+  return next
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+  const opts = {
+    input: '',
+    help: false,
+  }
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    switch (arg) {
+      case '--input':
+        opts.input = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--help':
+      case '-h':
+        opts.help = true
+        break
+      default:
+        throw new K3WiseSignoffGateError(`unknown option: ${arg}`, { arg })
+    }
+  }
+
+  if (!opts.help && !opts.input) {
+    throw new K3WiseSignoffGateError('--input is required')
+  }
+
+  return opts
+}
+
+function asNonNegativeInteger(value) {
+  if (value === undefined || value === null || value === '') return null
+  const number = Number(value)
+  return Number.isInteger(number) && number >= 0 ? number : null
+}
+
+function getCheckMap(evidence) {
+  const checks = Array.isArray(evidence?.checks) ? evidence.checks : []
+  return new Map(
+    checks
+      .filter((check) => check && typeof check === 'object' && typeof check.id === 'string')
+      .map((check) => [check.id, check]),
+  )
+}
+
+function evaluateSignoffEvidence(evidence) {
+  const failures = []
+  const checkMap = getCheckMap(evidence)
+  const summaryFail = asNonNegativeInteger(evidence?.summary?.fail)
+
+  if (!evidence || typeof evidence !== 'object' || Array.isArray(evidence)) {
+    failures.push('evidence JSON must be an object')
+  }
+  if (evidence?.ok !== true) {
+    failures.push('top-level ok must be true')
+  }
+  if (evidence?.authenticated !== true) {
+    failures.push('authenticated checks must have run')
+  }
+  if (evidence?.signoff?.internalTrial !== 'pass') {
+    failures.push('signoff.internalTrial must be pass')
+  }
+  if (summaryFail !== 0) {
+    failures.push('summary.fail must be 0')
+  }
+
+  const missingChecks = []
+  const failedChecks = []
+  for (const checkId of REQUIRED_PASS_CHECKS) {
+    const check = checkMap.get(checkId)
+    if (!check) {
+      missingChecks.push(checkId)
+    } else if (check.status !== 'pass') {
+      failedChecks.push(`${checkId}:${check.status || 'unknown'}`)
+    }
+  }
+
+  if (missingChecks.length > 0) {
+    failures.push(`missing required checks: ${missingChecks.join(', ')}`)
+  }
+  if (failedChecks.length > 0) {
+    failures.push(`required checks not passing: ${failedChecks.join(', ')}`)
+  }
+
+  return {
+    ok: failures.length === 0,
+    status: failures.length === 0 ? 'PASS' : 'BLOCKED',
+    reason: failures.length === 0 ? 'authenticated postdeploy smoke satisfies internal-trial gate' : failures.join('; '),
+    requiredChecks: REQUIRED_PASS_CHECKS,
+    summary: {
+      pass: asNonNegativeInteger(evidence?.summary?.pass),
+      skipped: asNonNegativeInteger(evidence?.summary?.skipped),
+      fail: summaryFail,
+    },
+    authenticated: evidence?.authenticated === true,
+    signoff: evidence?.signoff?.internalTrial || null,
+  }
+}
+
+async function readEvidence(inputPath) {
+  const raw = await readFile(inputPath, 'utf8')
+  try {
+    return JSON.parse(raw)
+  } catch (error) {
+    throw new K3WiseSignoffGateError(`invalid evidence JSON: ${inputPath}`, {
+      cause: error && error.message ? error.message : String(error),
+    })
+  }
+}
+
+async function runCli(argv = process.argv.slice(2)) {
+  const opts = parseArgs(argv)
+  if (opts.help) {
+    printHelp()
+    return 0
+  }
+
+  const inputPath = path.resolve(opts.input)
+  const evidence = await readEvidence(inputPath)
+  const result = evaluateSignoffEvidence(evidence)
+  console.log(JSON.stringify(result, null, 2))
+  return result.ok ? 0 : 1
+}
+
+const entryPath = process.argv[1] ? pathToFileURL(path.resolve(process.argv[1])).href : null
+if (entryPath && import.meta.url === entryPath) {
+  runCli().then((code) => {
+    process.exit(code)
+  }).catch((error) => {
+    const body = error instanceof K3WiseSignoffGateError
+      ? { ok: false, code: error.name, message: error.message, details: error.details }
+      : { ok: false, code: error && error.name ? error.name : 'Error', message: error && error.message ? error.message : String(error) }
+    console.error(JSON.stringify(body, null, 2))
+    process.exit(1)
+  })
+}
+
+export {
+  K3WiseSignoffGateError,
+  REQUIRED_PASS_CHECKS,
+  evaluateSignoffEvidence,
+  parseArgs,
+  runCli,
+}

--- a/scripts/ops/integration-k3wise-signoff-gate.test.mjs
+++ b/scripts/ops/integration-k3wise-signoff-gate.test.mjs
@@ -1,0 +1,211 @@
+import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const scriptPath = path.join(repoRoot, 'scripts', 'ops', 'integration-k3wise-signoff-gate.mjs')
+const requiredPassChecks = [
+  'auth-me',
+  'integration-route-contract',
+  'integration-list-external-systems',
+  'integration-list-pipelines',
+  'integration-list-runs',
+  'integration-list-dead-letters',
+  'staging-descriptor-contract',
+]
+
+function makeTmpDir() {
+  return mkdtempSync(path.join(tmpdir(), 'integration-k3wise-signoff-gate-'))
+}
+
+function runScript(args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [scriptPath, ...args], { stdio: ['ignore', 'pipe', 'pipe'] })
+    let stdout = ''
+    let stderr = ''
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL')
+      reject(new Error(`script timed out\nstdout=${stdout}\nstderr=${stderr}`))
+    }, 10_000)
+
+    child.stdout.setEncoding('utf8')
+    child.stderr.setEncoding('utf8')
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk
+    })
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk
+    })
+    child.on('error', (error) => {
+      clearTimeout(timer)
+      reject(error)
+    })
+    child.on('close', (status) => {
+      clearTimeout(timer)
+      resolve({ status, stdout, stderr })
+    })
+  })
+}
+
+function writeEvidence(dir, overrides = {}) {
+  const evidence = {
+    ok: true,
+    generatedAt: '2026-05-06T00:00:00.000Z',
+    baseUrl: 'http://127.0.0.1:8081',
+    authenticated: true,
+    requireAuth: true,
+    signoff: {
+      internalTrial: 'pass',
+      reason: 'authenticated smoke passed',
+    },
+    checks: requiredPassChecks.map((id) => ({ id, status: 'pass' })),
+    summary: { pass: requiredPassChecks.length + 3, skipped: 0, fail: 0 },
+    ...overrides,
+  }
+  const evidencePath = path.join(dir, 'integration-k3wise-postdeploy-smoke.json')
+  writeFileSync(evidencePath, `${JSON.stringify(evidence, null, 2)}\n`)
+  return evidencePath
+}
+
+test('passes authenticated postdeploy evidence with all required checks', async () => {
+  const outDir = makeTmpDir()
+  try {
+    const evidencePath = writeEvidence(outDir)
+
+    const result = await runScript(['--input', evidencePath])
+
+    assert.equal(result.status, 0, result.stderr)
+    const body = JSON.parse(result.stdout)
+    assert.equal(body.ok, true)
+    assert.equal(body.status, 'PASS')
+    assert.equal(body.signoff, 'pass')
+    assert.equal(body.summary.fail, 0)
+  } finally {
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('blocks public-only evidence even when diagnostic smoke passed', async () => {
+  const outDir = makeTmpDir()
+  try {
+    const evidencePath = writeEvidence(outDir, {
+      authenticated: false,
+      signoff: {
+        internalTrial: 'blocked',
+        reason: 'authenticated checks did not run',
+      },
+      checks: [
+        { id: 'api-health', status: 'pass' },
+        { id: 'integration-plugin-health', status: 'pass' },
+        { id: 'k3-wise-frontend-route', status: 'pass' },
+        { id: 'authenticated-integration-contract', status: 'skipped' },
+      ],
+      summary: { pass: 3, skipped: 1, fail: 0 },
+    })
+
+    const result = await runScript(['--input', evidencePath])
+
+    assert.equal(result.status, 1)
+    const body = JSON.parse(result.stdout)
+    assert.equal(body.status, 'BLOCKED')
+    assert.match(body.reason, /authenticated checks must have run/)
+    assert.match(body.reason, /missing required checks: auth-me/)
+  } finally {
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('blocks stale explicit pass when top-level ok is false', async () => {
+  const outDir = makeTmpDir()
+  try {
+    const evidencePath = writeEvidence(outDir, {
+      ok: false,
+      summary: { pass: requiredPassChecks.length, skipped: 0, fail: 0 },
+    })
+
+    const result = await runScript(['--input', evidencePath])
+
+    assert.equal(result.status, 1)
+    assert.match(JSON.parse(result.stdout).reason, /top-level ok must be true/)
+  } finally {
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('blocks stale explicit pass when summary.fail is nonzero', async () => {
+  const outDir = makeTmpDir()
+  try {
+    const evidencePath = writeEvidence(outDir, {
+      summary: { pass: requiredPassChecks.length, skipped: 0, fail: 1 },
+    })
+
+    const result = await runScript(['--input', evidencePath])
+
+    assert.equal(result.status, 1)
+    assert.match(JSON.parse(result.stdout).reason, /summary\.fail must be 0/)
+  } finally {
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('blocks when a required check is missing', async () => {
+  const outDir = makeTmpDir()
+  try {
+    const evidencePath = writeEvidence(outDir, {
+      checks: requiredPassChecks
+        .filter((id) => id !== 'staging-descriptor-contract')
+        .map((id) => ({ id, status: 'pass' })),
+    })
+
+    const result = await runScript(['--input', evidencePath])
+
+    assert.equal(result.status, 1)
+    assert.match(JSON.parse(result.stdout).reason, /missing required checks: staging-descriptor-contract/)
+  } finally {
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('blocks when a required check is not passing', async () => {
+  const outDir = makeTmpDir()
+  try {
+    const evidencePath = writeEvidence(outDir, {
+      checks: requiredPassChecks.map((id) => ({
+        id,
+        status: id === 'integration-list-runs' ? 'fail' : 'pass',
+      })),
+    })
+
+    const result = await runScript(['--input', evidencePath])
+
+    assert.equal(result.status, 1)
+    assert.match(JSON.parse(result.stdout).reason, /required checks not passing: integration-list-runs:fail/)
+  } finally {
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('missing evidence fails by default', async () => {
+  const outDir = makeTmpDir()
+  try {
+    const result = await runScript(['--input', path.join(outDir, 'missing.json')])
+
+    assert.equal(result.status, 1)
+    assert.match(result.stderr, /ENOENT/)
+    assert.equal(result.stdout, '')
+  } finally {
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('help prints usage', async () => {
+  const result = await runScript(['--help'])
+
+  assert.equal(result.status, 0, result.stderr)
+  assert.match(result.stdout, /Usage: node scripts\/ops\/integration-k3wise-signoff-gate\.mjs/)
+  assert.match(result.stdout, /auth-me/)
+})


### PR DESCRIPTION
## Summary

Adds a machine-readable K3 WISE internal-trial signoff gate for postdeploy smoke evidence.

- adds `scripts/ops/integration-k3wise-signoff-gate.mjs`
- requires `ok=true`, `authenticated=true`, `signoff.internalTrial=pass`, `summary.fail=0`
- requires these checks to be present and passing: `auth-me`, `integration-route-contract`, the four control-plane list probes, and `staging-descriptor-contract`
- wires the manual `K3 WISE Postdeploy Smoke` workflow to run the gate when `require_auth=true`
- adds focused gate tests plus design and verification docs

## Why

The summary renderer is presentation-oriented. This PR adds a separate gate that can fail CI or an operator run when evidence is public-only, stale, malformed, or missing one of the authenticated postdeploy checks.

## Verification

```bash
node --test scripts/ops/integration-k3wise-signoff-gate.test.mjs
node --test scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs
node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs scripts/ops/integration-k3wise-postdeploy-summary.test.mjs scripts/ops/integration-k3wise-signoff-gate.test.mjs scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs
ruby -e 'require "yaml"; YAML.load_file(".github/workflows/integration-k3wise-postdeploy-smoke.yml"); puts "workflow yaml ok"'
git diff --cached --check
```

Local result: 31/31 postdeploy chain tests pass; workflow YAML parses successfully.
