### PR TITLE
fix(integration): block inconsistent K3 signoff summaries

### DIFF
--- a/docs/development/integration-k3wise-summary-signoff-consistency-development-20260506.md
+++ b/docs/development/integration-k3wise-summary-signoff-consistency-development-20260506.md
@@ -1,0 +1,41 @@
+# K3 WISE Summary Signoff Consistency Development
+
+Date: 2026-05-06
+
+## Context
+
+`integration-k3wise-postdeploy-summary.mjs` renders the GitHub Step Summary for
+K3 WISE postdeploy smoke evidence. Before this slice, the renderer trusted
+`signoff.internalTrial="pass"` directly. A stale or hand-edited evidence file
+could therefore display `Internal trial signoff: PASS` even when the same JSON
+also had `ok=false`, `authenticated=false`, or `summary.fail>0`.
+
+The machine gate remains separate, but the human-facing summary should not show
+a contradictory PASS.
+
+## Change
+
+Added a consistency check inside `inferInternalTrialSignoff()`:
+
+- explicit `signoff.internalTrial="pass"` still passes only when:
+  - `ok === true`
+  - `authenticated === true`
+  - `summary.fail === 0`
+- inferred PASS from old evidence without a `signoff` block also requires
+  `summary.fail === 0`
+- inconsistent evidence renders `Internal trial signoff: BLOCKED` with a direct
+  reason that names the contradictory field
+
+This keeps the renderer non-fatal: it still exits `0` and renders the rest of
+the evidence, but the signoff line can no longer mislead an operator.
+
+## Scope
+
+Changed files:
+
+- `scripts/ops/integration-k3wise-postdeploy-summary.mjs`
+- `scripts/ops/integration-k3wise-postdeploy-summary.test.mjs`
+- this development note
+- companion verification note
+This does not touch the open K3 setup UI, live preflight, fixture/evidence, or
+signoff-gate PR files.

--- a/docs/development/integration-k3wise-summary-signoff-consistency-verification-20260506.md
+++ b/docs/development/integration-k3wise-summary-signoff-consistency-verification-20260506.md
@@ -1,0 +1,29 @@
+# K3 WISE Summary Signoff Consistency Verification
+
+Date: 2026-05-06
+
+## Commands
+
+```bash
+node --test scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
+node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
+git diff --check -- scripts/ops/integration-k3wise-postdeploy-summary.mjs scripts/ops/integration-k3wise-postdeploy-summary.test.mjs docs/development/integration-k3wise-summary-signoff-consistency-development-20260506.md docs/development/integration-k3wise-summary-signoff-consistency-verification-20260506.md
+```
+
+## Coverage
+
+The added regression tests cover:
+
+- explicit `signoff.internalTrial="pass"` with `ok=false` renders BLOCKED
+- explicit pass with `authenticated=false` renders BLOCKED
+- explicit pass with `summary.fail=1` renders BLOCKED
+- inferred authenticated pass with `summary.fail=1` renders BLOCKED
+
+## Result
+
+Passed locally:
+
+- `integration-k3wise-postdeploy-summary.test.mjs`: 13/13 passed.
+- `integration-k3wise-postdeploy-smoke.test.mjs` +
+  `integration-k3wise-postdeploy-summary.test.mjs`: 25/25 passed.
+- `git diff --check`: passed.

--- a/scripts/ops/integration-k3wise-postdeploy-summary.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-summary.mjs
@@ -86,14 +86,40 @@ function renderMissingSummary(inputPath, { requireAuthSignoff = false } = {}) {
   return lines.join('\n')
 }
 
+function countSummaryFailures(evidence) {
+  const failCount = Number(evidence?.summary?.fail ?? 0)
+  return Number.isFinite(failCount) ? failCount : 0
+}
+
+function getAuthenticatedPassBlockers(evidence) {
+  const blockers = []
+  if (evidence?.ok !== true) {
+    blockers.push('top-level ok is not true')
+  }
+  if (evidence?.authenticated !== true) {
+    blockers.push('authenticated checks did not run')
+  }
+  if (countSummaryFailures(evidence) !== 0) {
+    blockers.push('summary.fail is not 0')
+  }
+  return blockers
+}
+
 function inferInternalTrialSignoff(evidence) {
   if (evidence?.signoff?.internalTrial === 'pass') {
+    const blockers = getAuthenticatedPassBlockers(evidence)
+    if (blockers.length > 0) {
+      return {
+        status: 'BLOCKED',
+        reason: `authenticated signoff evidence is inconsistent: ${blockers.join('; ')}`,
+      }
+    }
     return { status: 'PASS', reason: evidence.signoff.reason || 'authenticated smoke passed' }
   }
   if (evidence?.signoff?.internalTrial === 'blocked') {
     return { status: 'BLOCKED', reason: evidence.signoff.reason || 'authenticated smoke did not pass' }
   }
-  if (evidence?.ok && evidence?.authenticated) {
+  if (evidence?.ok && evidence?.authenticated && countSummaryFailures(evidence) === 0) {
     return { status: 'PASS', reason: 'authenticated smoke passed' }
   }
   if (!evidence?.authenticated) {
@@ -212,7 +238,9 @@ if (entryPath && import.meta.url === entryPath) {
 
 export {
   K3WisePostdeploySummaryError,
+  countSummaryFailures,
   formatDetailValue,
+  getAuthenticatedPassBlockers,
   inferInternalTrialSignoff,
   parseArgs,
   renderEvidenceSummary,

--- a/scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
@@ -129,6 +129,123 @@ test('renders passing internal signoff for authenticated smoke evidence', async 
   }
 })
 
+test('blocks explicit pass when signoff evidence says top-level ok is false', async () => {
+  const outDir = makeTmpDir()
+  const evidencePath = path.join(outDir, 'evidence.json')
+  try {
+    writeFileSync(evidencePath, `${JSON.stringify({
+      ok: false,
+      baseUrl: 'http://127.0.0.1:8081',
+      authenticated: true,
+      signoff: {
+        internalTrial: 'pass',
+        reason: 'authenticated smoke passed',
+      },
+      summary: { pass: 8, skipped: 0, fail: 0 },
+      checks: [
+        { id: 'api-health', status: 'pass' },
+        { id: 'auth-me', status: 'pass' },
+      ],
+    })}\n`)
+
+    const result = await runScript(['--input', evidencePath, '--require-auth-signoff'])
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stdout, /Internal trial signoff: \*\*BLOCKED\*\*/)
+    assert.match(result.stdout, /authenticated signoff evidence is inconsistent: top-level ok is not true/)
+    assert.match(result.stdout, /Status: \*\*FAIL\*\*/)
+  } finally {
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('blocks explicit pass when signoff evidence is not authenticated', async () => {
+  const outDir = makeTmpDir()
+  const evidencePath = path.join(outDir, 'evidence.json')
+  try {
+    writeFileSync(evidencePath, `${JSON.stringify({
+      ok: true,
+      baseUrl: 'http://127.0.0.1:8081',
+      authenticated: false,
+      signoff: {
+        internalTrial: 'pass',
+        reason: 'authenticated smoke passed',
+      },
+      summary: { pass: 8, skipped: 0, fail: 0 },
+      checks: [
+        { id: 'api-health', status: 'pass' },
+        { id: 'auth-me', status: 'pass' },
+      ],
+    })}\n`)
+
+    const result = await runScript(['--input', evidencePath, '--require-auth-signoff'])
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stdout, /Internal trial signoff: \*\*BLOCKED\*\*/)
+    assert.match(result.stdout, /authenticated signoff evidence is inconsistent: authenticated checks did not run/)
+    assert.match(result.stdout, /Authenticated checks: `no`/)
+  } finally {
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('blocks explicit pass when signoff evidence has failed checks', async () => {
+  const outDir = makeTmpDir()
+  const evidencePath = path.join(outDir, 'evidence.json')
+  try {
+    writeFileSync(evidencePath, `${JSON.stringify({
+      ok: true,
+      baseUrl: 'http://127.0.0.1:8081',
+      authenticated: true,
+      signoff: {
+        internalTrial: 'pass',
+        reason: 'authenticated smoke passed',
+      },
+      summary: { pass: 8, skipped: 0, fail: 1 },
+      checks: [
+        { id: 'api-health', status: 'pass' },
+        { id: 'auth-me', status: 'pass' },
+        { id: 'integration-route-contract', status: 'fail' },
+      ],
+    })}\n`)
+
+    const result = await runScript(['--input', evidencePath, '--require-auth-signoff'])
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stdout, /Internal trial signoff: \*\*BLOCKED\*\*/)
+    assert.match(result.stdout, /authenticated signoff evidence is inconsistent: summary\.fail is not 0/)
+    assert.match(result.stdout, /Summary: `8 pass \/ 0 skipped \/ 1 fail`/)
+  } finally {
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('blocks inferred pass when authenticated evidence has failed checks', async () => {
+  const outDir = makeTmpDir()
+  const evidencePath = path.join(outDir, 'evidence.json')
+  try {
+    writeFileSync(evidencePath, `${JSON.stringify({
+      ok: true,
+      baseUrl: 'http://127.0.0.1:8081',
+      authenticated: true,
+      summary: { pass: 8, skipped: 0, fail: 1 },
+      checks: [
+        { id: 'api-health', status: 'pass' },
+        { id: 'auth-me', status: 'pass' },
+        { id: 'integration-route-contract', status: 'fail' },
+      ],
+    })}\n`)
+
+    const result = await runScript(['--input', evidencePath, '--require-auth-signoff'])
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stdout, /Internal trial signoff: \*\*BLOCKED\*\*/)
+    assert.match(result.stdout, /Signoff reason: one or more smoke checks failed/)
+  } finally {
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
 test('renders fail summary without failing the summary renderer', async () => {
   const outDir = makeTmpDir()
   const evidencePath = path.join(outDir, 'evidence.json')


### PR DESCRIPTION
## Summary

Hardens the human-facing K3 WISE postdeploy summary so it no longer renders `Internal trial signoff: PASS` for contradictory evidence.

- explicit `signoff.internalTrial="pass"` now still requires `ok=true`, `authenticated=true`, and `summary.fail=0`
- inferred PASS from older evidence without a `signoff` block also requires `summary.fail=0`
- inconsistent evidence keeps the renderer non-fatal but renders signoff as `BLOCKED` with a direct reason
- adds development and verification notes

## Why

The separate signoff gate can fail machine checks, but operators also read GitHub Step Summary. A stale or hand-edited evidence file should not visually show PASS when the same JSON says the smoke failed, skipped auth, or has failed checks.

## Verification

```bash
node --test scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
git diff --check -- scripts/ops/integration-k3wise-postdeploy-summary.mjs scripts/ops/integration-k3wise-postdeploy-summary.test.mjs docs/development/integration-k3wise-summary-signoff-consistency-development-20260506.md docs/development/integration-k3wise-summary-signoff-consistency-verification-20260506.md
```

Local result: summary tests 13/13 pass; postdeploy smoke+summary chain 25/25 pass; diff check passes.
