### PR TITLE
fix(integration): use temp key for K3 smoke token resolver

### DIFF
--- a/docs/development/integration-k3wise-smoke-token-temp-key-design-20260506.md
+++ b/docs/development/integration-k3wise-smoke-token-temp-key-design-20260506.md
@@ -1,0 +1,38 @@
+# K3 WISE Smoke Token Temp Key Design
+
+Date: 2026-05-06
+
+## Context
+
+`resolve-k3wise-smoke-token.sh` can mint a short-lived K3 WISE postdeploy smoke
+token by SSHing into the deploy host and executing backend runtime code. Before
+this slice, the deploy SSH key decoded from `DEPLOY_SSH_KEY_B64` was written to
+the fixed path `~/.ssh/deploy_key`.
+
+That fixed path is unnecessary for this resolver and can leave secret material
+behind on reused runners or local test environments.
+
+## Change
+
+The resolver now:
+
+- decodes `DEPLOY_SSH_KEY_B64` into a per-run `mktemp` file under
+  `${TMPDIR:-/tmp}`
+- sets the key mode to `0600`
+- passes the temp path to `ssh -i`
+- registers a `trap` that removes the temp key on script exit
+
+The existing secret-token fast path is unchanged and does not create any SSH key
+file.
+
+## Scope
+
+Changed files:
+
+- `scripts/ops/resolve-k3wise-smoke-token.sh`
+- `scripts/ops/resolve-k3wise-smoke-token.test.mjs`
+- this design note
+- companion verification note
+
+No workflow files are changed, so this stays independent from the open K3 WISE
+postdeploy workflow PR.

--- a/docs/development/integration-k3wise-smoke-token-temp-key-verification-20260506.md
+++ b/docs/development/integration-k3wise-smoke-token-temp-key-verification-20260506.md
@@ -1,0 +1,33 @@
+# K3 WISE Smoke Token Temp Key Verification
+
+Date: 2026-05-06
+
+## Commands
+
+```bash
+bash -n scripts/ops/resolve-k3wise-smoke-token.sh
+node --test scripts/ops/resolve-k3wise-smoke-token.test.mjs
+node --test scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs
+node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
+node --test scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
+git diff --check -- scripts/ops/resolve-k3wise-smoke-token.sh scripts/ops/resolve-k3wise-smoke-token.test.mjs docs/development/integration-k3wise-smoke-token-temp-key-design-20260506.md docs/development/integration-k3wise-smoke-token-temp-key-verification-20260506.md
+```
+
+## Coverage
+
+The resolver tests cover:
+
+- secret-token fast path still writes to `GITHUB_ENV`
+- optional auth still skips safely when no inputs are present
+- required auth still fails when tenant or deploy SSH inputs are missing
+- deploy-host fallback uses SSH without `~/.ssh/deploy_key`
+- deploy-host fallback creates a `0600` temp key and removes it before exit
+
+## Result
+
+Passed locally:
+
+- `bash -n scripts/ops/resolve-k3wise-smoke-token.sh`: passed.
+- `resolve-k3wise-smoke-token.test.mjs`: 8/8 passed.
+- Postdeploy workflow/smoke/summary related tests: 23/23 passed.
+- `git diff --check`: passed.

--- a/scripts/ops/resolve-k3wise-smoke-token.sh
+++ b/scripts/ops/resolve-k3wise-smoke-token.sh
@@ -72,6 +72,12 @@ shell_quote() {
   printf '%q' "$1"
 }
 
+cleanup_tmp_key() {
+  if [[ -n "${tmp_ssh_key:-}" && -f "${tmp_ssh_key}" ]]; then
+    rm -f "${tmp_ssh_key}"
+  fi
+}
+
 if [[ -n "${secret_token}" ]]; then
   write_resolved_tenant "${tenant_id}" "METASHEET_TENANT_ID"
   write_token "${secret_token}" "METASHEET_K3WISE_SMOKE_TOKEN"
@@ -89,13 +95,14 @@ if [[ -z "${DEPLOY_HOST:-}" || -z "${DEPLOY_USER:-}" || -z "${DEPLOY_SSH_KEY_B64
   warn_or_fail "METASHEET_K3WISE_SMOKE_TOKEN is not set and DEPLOY_HOST/DEPLOY_USER/DEPLOY_SSH_KEY_B64 are incomplete"
 fi
 
-mkdir -p ~/.ssh
-if ! printf '%s' "${DEPLOY_SSH_KEY_B64}" | base64 -d > ~/.ssh/deploy_key; then
+tmp_ssh_key="$(mktemp "${TMPDIR:-/tmp}/k3wise-smoke-ssh-key.XXXXXX")"
+trap cleanup_tmp_key EXIT
+if ! printf '%s' "${DEPLOY_SSH_KEY_B64}" | base64 -d > "${tmp_ssh_key}"; then
   warn_or_fail "failed to decode DEPLOY_SSH_KEY_B64 for K3 WISE smoke token fallback"
 fi
-chmod 600 ~/.ssh/deploy_key
+chmod 600 "${tmp_ssh_key}"
 
-ssh_opts="-o BatchMode=yes -o ConnectTimeout=15 -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i ~/.ssh/deploy_key"
+ssh_opts="-o BatchMode=yes -o ConnectTimeout=15 -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i ${tmp_ssh_key}"
 quoted_deploy_path="$(shell_quote "${deploy_path}")"
 quoted_compose_file="$(shell_quote "${deploy_compose_file}")"
 quoted_tenant_id="$(shell_quote "${tenant_id}")"

--- a/scripts/ops/resolve-k3wise-smoke-token.test.mjs
+++ b/scripts/ops/resolve-k3wise-smoke-token.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import { spawn } from 'node:child_process'
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import test from 'node:test'
@@ -114,7 +114,67 @@ printf 'header.payload.signature\\n'
     const githubEnvText = readFileSync(githubEnv, 'utf8')
     assert.match(githubEnvText, /K3_WISE_SMOKE_TENANT_ID=tenant-auto/)
     assert.match(githubEnvText, /K3_WISE_SMOKE_TOKEN<<EOF\nheader\.payload\.signature\nEOF/)
-    assert.match(readFileSync(sshArgsPath, 'utf8'), /K3_WISE_SMOKE_TENANT_AUTO_DISCOVER=true/)
+    const sshArgs = readFileSync(sshArgsPath, 'utf8')
+    assert.match(sshArgs, /K3_WISE_SMOKE_TENANT_AUTO_DISCOVER=true/)
+    assert.doesNotMatch(sshArgs, /\.ssh\/deploy_key/)
+    assert.equal(existsSync(path.join(tmp, '.ssh', 'deploy_key')), false)
+  } finally {
+    rmSync(tmp, { recursive: true, force: true })
+  }
+})
+
+test('resolver cleans up temporary deploy SSH key after fallback execution', async () => {
+  const tmp = makeTmpDir()
+  const githubEnv = path.join(tmp, 'github-env')
+  const binDir = path.join(tmp, 'bin')
+  const sshArgsPath = path.join(tmp, 'ssh-args')
+  const sshKeyPathFile = path.join(tmp, 'ssh-key-path')
+  try {
+    mkdirSync(binDir)
+    const sshPath = path.join(binDir, 'ssh')
+    writeFileSync(sshPath, `#!/usr/bin/env bash
+printf '%s\\n' "$*" > "$FAKE_SSH_ARGS_PATH"
+while [[ "$#" -gt 0 ]]; do
+  if [[ "$1" == "-i" ]]; then
+    shift
+    printf '%s\\n' "$1" > "$FAKE_SSH_KEY_PATH"
+    if [[ ! -f "$1" ]]; then
+      echo "missing ssh key" >&2
+      exit 9
+    fi
+    mode="$(stat -f %Lp "$1" 2>/dev/null || stat -c %a "$1")"
+    if [[ "$mode" != "600" ]]; then
+      echo "bad ssh key mode: $mode" >&2
+      exit 10
+    fi
+  fi
+  shift
+done
+cat >/dev/null
+printf 'K3_WISE_SMOKE_TENANT_ID=tenant-auto\\n'
+printf 'header.payload.signature\\n'
+`)
+    chmodSync(sshPath, 0o755)
+
+    const result = await runResolver({
+      GITHUB_ENV: githubEnv,
+      HOME: tmp,
+      TMPDIR: tmp,
+      PATH: `${binDir}:${process.env.PATH || ''}`,
+      FAKE_SSH_ARGS_PATH: sshArgsPath,
+      FAKE_SSH_KEY_PATH: sshKeyPathFile,
+      K3_WISE_TOKEN_AUTO_DISCOVER_TENANT: 'true',
+      DEPLOY_HOST: 'deploy.example.test',
+      DEPLOY_USER: 'deployer',
+      DEPLOY_SSH_KEY_B64: Buffer.from('fake-key').toString('base64'),
+    })
+
+    assert.equal(result.status, 0, result.stderr)
+    const usedKeyPath = readFileSync(sshKeyPathFile, 'utf8').trim()
+    assert.match(usedKeyPath, new RegExp(`^${tmp.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}/k3wise-smoke-ssh-key\\.`))
+    assert.equal(existsSync(usedKeyPath), false)
+    assert.equal(existsSync(path.join(tmp, '.ssh', 'deploy_key')), false)
+    assert.doesNotMatch(readFileSync(sshArgsPath, 'utf8'), /\.ssh\/deploy_key/)
   } finally {
     rmSync(tmp, { recursive: true, force: true })
   }


### PR DESCRIPTION
## Summary

Hardens the K3 WISE smoke token resolver so deploy-host fallback no longer writes the decoded SSH key to a fixed `~/.ssh/deploy_key` path.

- decodes `DEPLOY_SSH_KEY_B64` into a per-run `mktemp` file
- keeps `chmod 600` before invoking SSH
- passes the temp path to `ssh -i`
- removes the temp key via `trap` on script exit
- adds tests that verify the temp key is used, mode-checked, cleaned up, and `~/.ssh/deploy_key` is not created
- adds design and verification notes

## Why

The resolver only needs the deploy key during a single fallback invocation. A fixed key path is unnecessary state and can leave secret material behind on reused runners or local test environments.

## Verification

```bash
bash -n scripts/ops/resolve-k3wise-smoke-token.sh
node --test scripts/ops/resolve-k3wise-smoke-token.test.mjs
node --test scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
git diff --check -- scripts/ops/resolve-k3wise-smoke-token.sh scripts/ops/resolve-k3wise-smoke-token.test.mjs docs/development/integration-k3wise-smoke-token-temp-key-design-20260506.md docs/development/integration-k3wise-smoke-token-temp-key-verification-20260506.md
```

Local result: resolver tests 8/8 pass; postdeploy workflow/smoke/summary related tests 23/23 pass; shell syntax and diff checks pass.
