### PR TITLE
feat(multitable): add barcode field type

### DIFF
--- a/apps/web/src/multitable/components/MetaFieldHeader.vue
+++ b/apps/web/src/multitable/components/MetaFieldHeader.vue
@@ -29,7 +29,7 @@ import type { MetaField } from '../types'
 const FIELD_ICONS: Record<string, string> = {
   string: 'Aa', longText: '\u00B6', number: '#', boolean: '\u2611', date: '\u{1F4C5}', select: '\u25CF', multiSelect: '\u25C9',
   link: '\u21C4', person: '\u{1F464}', lookup: '\u2197', rollup: '\u03A3', formula: 'fx', attachment: '\uD83D\uDCCE',
-  currency: '\u00A4', percent: '%', rating: '\u2605', url: '\u{1F517}', email: '\u2709', phone: '\u260E',
+  currency: '\u00A4', percent: '%', rating: '\u2605', url: '\u{1F517}', email: '\u2709', phone: '\u260E', barcode: '\u25A5',
   autoNumber: '#+', createdTime: 'CT', modifiedTime: 'MT', createdBy: 'CB', modifiedBy: 'MB',
 }
 

--- a/apps/web/src/multitable/components/MetaFieldManager.vue
+++ b/apps/web/src/multitable/components/MetaFieldManager.vue
@@ -459,13 +459,13 @@ function rulesToProperty(rules: FieldValidationRule[]): Array<Record<string, unk
 const FIELD_TYPES: MetaFieldCreateType[] = [
   'string', 'longText', 'number', 'boolean', 'date', 'select', 'multiSelect', 'link', 'person',
   'formula', 'lookup', 'rollup', 'attachment',
-  'currency', 'percent', 'rating', 'url', 'email', 'phone',
+  'currency', 'percent', 'rating', 'url', 'email', 'phone', 'barcode',
   ...SYSTEM_FIELD_TYPES,
 ]
 const FIELD_ICONS: Record<string, string> = {
   string: 'Aa', longText: '\u00B6', number: '#', boolean: '\u2611', date: '\u{1F4C5}', select: '\u25CF', multiSelect: '\u25C9',
   link: '\u21C4', person: '\u{1F464}', lookup: '\u2197', rollup: '\u03A3', formula: 'fx', attachment: '\uD83D\uDCCE',
-  currency: '\u00A4', percent: '%', rating: '\u2605', url: '\u{1F517}', email: '\u2709', phone: '\u260E',
+  currency: '\u00A4', percent: '%', rating: '\u2605', url: '\u{1F517}', email: '\u2709', phone: '\u260E', barcode: '\u25A5',
   autoNumber: '#+', createdTime: 'CT', modifiedTime: 'MT', createdBy: 'CB', modifiedBy: 'MB',
 }
 

--- a/apps/web/src/multitable/components/MetaFormView.vue
+++ b/apps/web/src/multitable/components/MetaFormView.vue
@@ -51,6 +51,21 @@
             @input="formData[field.id] = ($event.target as HTMLTextAreaElement).value"
           />
           <input
+            v-else-if="field.type === 'barcode'"
+            :id="`field_${field.id}`"
+            class="meta-form-view__input"
+            :class="{ 'meta-form-view__input--error': !!fieldErrors?.[field.id] || !!validationErrors[field.id] }"
+            type="text"
+            inputmode="text"
+            placeholder="Scan or enter barcode"
+            :disabled="isFieldReadOnly(field.id)"
+            :aria-required="field.required ? 'true' : undefined"
+            :aria-invalid="(!!fieldErrors?.[field.id] || !!validationErrors[field.id]) ? 'true' : undefined"
+            :aria-describedby="(fieldErrors?.[field.id] || validationErrors[field.id]) ? `error_${field.id}` : undefined"
+            :value="textControlValue(formData[field.id])"
+            @input="formData[field.id] = ($event.target as HTMLInputElement).value"
+          />
+          <input
             v-else-if="field.type === 'number'"
             :id="`field_${field.id}`"
             class="meta-form-view__input"

--- a/apps/web/src/multitable/components/MetaRecordDrawer.vue
+++ b/apps/web/src/multitable/components/MetaRecordDrawer.vue
@@ -90,6 +90,16 @@
             @change="emit('patch', field.id, ($event.target as HTMLTextAreaElement).value)"
           />
           <input
+            v-else-if="canEditField(field.id) && field.type === 'barcode'"
+            :id="`drawer_field_${field.id}`"
+            class="meta-record-drawer__input"
+            type="text"
+            inputmode="text"
+            placeholder="Scan or enter barcode"
+            :value="textControlValue(record.data[field.id])"
+            @change="emit('patch', field.id, ($event.target as HTMLInputElement).value)"
+          />
+          <input
             v-else-if="canEditField(field.id) && field.type === 'number'"
             :id="`drawer_field_${field.id}`"
             class="meta-record-drawer__input"

--- a/apps/web/src/multitable/components/cells/MetaCellEditor.vue
+++ b/apps/web/src/multitable/components/cells/MetaCellEditor.vue
@@ -54,6 +54,20 @@
       @keydown.escape="emit('cancel')"
     />
 
+    <!-- barcode: text-backed field; scanner/image generation is out of scope. -->
+    <input
+      v-else-if="field.type === 'barcode'"
+      ref="inputRef"
+      class="meta-cell-editor__input"
+      type="text"
+      inputmode="text"
+      placeholder="Scan or enter barcode"
+      :value="textControlValue(modelValue)"
+      @input="emit('update:modelValue', ($event.target as HTMLInputElement).value)"
+      @keydown.enter="emit('confirm')"
+      @keydown.escape="emit('cancel')"
+    />
+
     <!-- number -->
     <input
       v-else-if="field.type === 'number'"

--- a/apps/web/src/multitable/components/cells/MetaCellRenderer.vue
+++ b/apps/web/src/multitable/components/cells/MetaCellRenderer.vue
@@ -21,6 +21,11 @@
     <!-- number -->
     <template v-else-if="field.type === 'number'">{{ displayValue }}</template>
 
+    <!-- barcode -->
+    <template v-else-if="field.type === 'barcode'">
+      <code class="meta-cell-renderer__barcode">{{ displayValue }}</code>
+    </template>
+
     <!-- boolean -->
     <template v-else-if="field.type === 'boolean'">
       <span class="meta-cell-renderer__bool">{{ value ? '\u2611' : '\u2610' }}</span>
@@ -254,6 +259,15 @@ const conditionalClass = computed(() => {
 .meta-cell-renderer__rating {
   color: #f5a623;
   letter-spacing: 1px;
+}
+.meta-cell-renderer__barcode {
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', monospace;
+  font-size: 12px;
+  background: #f6f8fa;
+  border: 1px solid #e5e7eb;
+  border-radius: 4px;
+  padding: 1px 5px;
+  color: #334155;
 }
 .meta-cell-renderer__url,
 .meta-cell-renderer__email,

--- a/apps/web/src/multitable/composables/useMultitableGrid.ts
+++ b/apps/web/src/multitable/composables/useMultitableGrid.ts
@@ -102,6 +102,14 @@ export const FILTER_OPERATORS_BY_TYPE: Record<string, Array<{ value: string; lab
     { value: 'isEmpty', label: 'is empty' },
     { value: 'isNotEmpty', label: 'is not empty' },
   ],
+  barcode: [
+    { value: 'is', label: 'is' },
+    { value: 'isNot', label: 'is not' },
+    { value: 'contains', label: 'contains' },
+    { value: 'doesNotContain', label: 'does not contain' },
+    { value: 'isEmpty', label: 'is empty' },
+    { value: 'isNotEmpty', label: 'is not empty' },
+  ],
   number: [
     { value: 'is', label: '=' },
     { value: 'isNot', label: '\u2260' },

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -21,6 +21,7 @@ export type MetaFieldType =
   | 'url'
   | 'email'
   | 'phone'
+  | 'barcode'
   | 'longText'
   | 'autoNumber'
   | 'createdTime'

--- a/apps/web/tests/multitable-barcode-field.spec.ts
+++ b/apps/web/tests/multitable-barcode-field.spec.ts
@@ -1,0 +1,195 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick } from 'vue'
+import MetaCellEditor from '../src/multitable/components/cells/MetaCellEditor.vue'
+import MetaCellRenderer from '../src/multitable/components/cells/MetaCellRenderer.vue'
+import MetaFieldManager from '../src/multitable/components/MetaFieldManager.vue'
+import MetaFormView from '../src/multitable/components/MetaFormView.vue'
+import MetaRecordDrawer from '../src/multitable/components/MetaRecordDrawer.vue'
+
+async function flushUi(cycles = 3) {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+describe('barcode field UI', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  it('renders barcode values as copy-friendly monospace text', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    const app = createApp({
+      render() {
+        return h(MetaCellRenderer, {
+          field: { id: 'fld_barcode', name: 'Barcode', type: 'barcode' },
+          value: '6901234567890',
+        })
+      },
+    })
+
+    app.mount(container)
+    await flushUi()
+
+    const value = container.querySelector('.meta-cell-renderer__barcode') as HTMLElement | null
+    expect(value).not.toBeNull()
+    expect(value?.textContent).toBe('6901234567890')
+
+    app.unmount()
+    container.remove()
+  })
+
+  it('uses a text-backed cell editor for barcode values', async () => {
+    const updateSpy = vi.fn()
+    const confirmSpy = vi.fn()
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    const app = createApp({
+      render() {
+        return h(MetaCellEditor, {
+          field: { id: 'fld_barcode', name: 'Barcode', type: 'barcode' },
+          modelValue: '6901234567890',
+          'onUpdate:modelValue': updateSpy,
+          onConfirm: confirmSpy,
+          onCancel: vi.fn(),
+          onOpenLinkPicker: vi.fn(),
+        })
+      },
+    })
+
+    app.mount(container)
+    await flushUi()
+
+    const input = container.querySelector('input[placeholder="Scan or enter barcode"]') as HTMLInputElement | null
+    expect(input?.type).toBe('text')
+    input!.value = 'ABC-123'
+    input!.dispatchEvent(new Event('input', { bubbles: true }))
+    input!.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    await flushUi()
+
+    expect(updateSpy).toHaveBeenCalledWith('ABC-123')
+    expect(confirmSpy).toHaveBeenCalledTimes(1)
+
+    app.unmount()
+    container.remove()
+  })
+
+  it('creates barcode fields from the field manager without configurable property', async () => {
+    const createSpy = vi.fn()
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    const app = createApp({
+      render() {
+        return h(MetaFieldManager, {
+          visible: true,
+          sheetId: 'sheet_1',
+          sheets: [],
+          fields: [],
+          onCreateField: createSpy,
+        })
+      },
+    })
+
+    app.mount(container)
+    await flushUi()
+
+    const nameInput = container.querySelector('.meta-field-mgr__add-row .meta-field-mgr__input') as HTMLInputElement
+    const typeSelect = container.querySelector('.meta-field-mgr__add-row .meta-field-mgr__select') as HTMLSelectElement
+    expect(Array.from(typeSelect.options).map((option) => option.value)).toContain('barcode')
+
+    nameInput.value = 'Barcode'
+    nameInput.dispatchEvent(new Event('input', { bubbles: true }))
+    typeSelect.value = 'barcode'
+    typeSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+
+    ;(Array.from(container.querySelectorAll('.meta-field-mgr__btn-add')) as HTMLButtonElement[])
+      .find((button) => button.textContent?.includes('+ Add'))
+      ?.click()
+    await flushUi()
+
+    expect(createSpy).toHaveBeenCalledWith({
+      sheetId: 'sheet_1',
+      name: 'Barcode',
+      type: 'barcode',
+    })
+
+    app.unmount()
+    container.remove()
+  })
+
+  it('submits barcode values from form view', async () => {
+    const submitSpy = vi.fn()
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    const app = createApp({
+      render() {
+        return h(MetaFormView, {
+          fields: [{ id: 'fld_barcode', name: 'Barcode', type: 'barcode' }],
+          record: { id: 'rec_1', version: 1, data: { fld_barcode: 'OLD' } },
+          loading: false,
+          readOnly: false,
+          onSubmit: submitSpy,
+          onOpenLinkPicker: vi.fn(),
+        })
+      },
+    })
+
+    app.mount(container)
+    await flushUi()
+
+    const input = container.querySelector('#field_fld_barcode') as HTMLInputElement | null
+    expect(input?.placeholder).toBe('Scan or enter barcode')
+    input!.value = 'NEW-123'
+    input!.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+    container.querySelector('form')?.dispatchEvent(new Event('submit'))
+    await flushUi()
+
+    expect(submitSpy).toHaveBeenCalledWith({ fld_barcode: 'NEW-123' })
+
+    app.unmount()
+    container.remove()
+  })
+
+  it('patches barcode values from the record drawer', async () => {
+    const patchSpy = vi.fn()
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    const app = createApp({
+      render() {
+        return h(MetaRecordDrawer, {
+          visible: true,
+          record: { id: 'rec_1', version: 1, data: { fld_barcode: 'OLD' } },
+          fields: [{ id: 'fld_barcode', name: 'Barcode', type: 'barcode' }],
+          canEdit: true,
+          canComment: false,
+          canDelete: false,
+          onPatch: patchSpy,
+        })
+      },
+    })
+
+    app.mount(container)
+    await flushUi()
+
+    const input = container.querySelector('#drawer_field_fld_barcode') as HTMLInputElement | null
+    expect(input?.placeholder).toBe('Scan or enter barcode')
+    input!.value = 'DRAWER-123'
+    input!.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+
+    expect(patchSpy).toHaveBeenCalledWith('fld_barcode', 'DRAWER-123')
+
+    app.unmount()
+    container.remove()
+  })
+})

--- a/docs/development/multitable-barcode-field-design-20260505.md
+++ b/docs/development/multitable-barcode-field-design-20260505.md
@@ -1,0 +1,74 @@
+# Multitable Barcode Field Design - 2026-05-05
+
+## Context
+
+`docs/development/multitable-feishu-rc-todo-20260430.md` tracks `Barcode field` as a remaining Feishu-parity RC item. The existing multitable runtime already supports text-like custom field types through the shared batch-1 codec seam, but `barcode` was not recognized in backend contracts, frontend field creation, cell rendering, or OpenAPI.
+
+## Goals
+
+- Add a first-class `barcode` multitable field type across backend, frontend, and OpenAPI.
+- Store barcode values as plain text in record `data`, with deterministic trimming.
+- Accept numeric scanner payloads by converting them to strings.
+- Preserve existing write paths through `RecordWriteService`, direct route writes, public form writes, and record-service helpers.
+- Provide copy-friendly UI rendering and text-backed editing.
+
+## Non-Goals
+
+- No camera/scanner integration.
+- No barcode image generation.
+- No uniqueness constraint.
+- No checksum validation for EAN/UPC/Code128 variants.
+- No export-specific barcode formatting.
+
+## Runtime Contract
+
+`barcode` is a text-backed field type:
+
+```json
+{
+  "id": "fld_barcode",
+  "name": "Barcode",
+  "type": "barcode",
+  "property": {}
+}
+```
+
+Value coercion rules:
+
+- `null`, `undefined`, and empty string become `null`.
+- String values are trimmed.
+- Number values are converted to strings.
+- Other value types are rejected.
+- Persisted value length is capped at 256 characters.
+
+Default validation rules also cap `barcode` at 256 characters, matching backend write coercion.
+
+## Implementation
+
+- Backend field codecs: `packages/core-backend/src/multitable/field-codecs.ts`
+  - Adds `barcode` to `MultitableFieldType` and `BATCH1_FIELD_TYPES`.
+  - Maps `barcode`, `bar_code`, and `bar-code` aliases.
+  - Adds `validateBarcodeValue()` and routes `coerceBatch1Value()` through it.
+- Backend write surfaces:
+  - `packages/core-backend/src/routes/univer-meta.ts`
+  - `packages/core-backend/src/multitable/record-service.ts`
+  - `packages/core-backend/src/multitable/record-write-service.ts`
+  - These paths now recognize `barcode` and reuse the shared batch-1 coercion seam.
+- Backend validation:
+  - `packages/core-backend/src/multitable/field-validation-engine.ts`
+  - Adds default `maxLength: 256` for `barcode`.
+- Frontend type and UI:
+  - `apps/web/src/multitable/types.ts`
+  - `MetaFieldManager.vue` and `MetaFieldHeader.vue` expose the field type and icon.
+  - `MetaCellRenderer.vue` renders barcode values as monospace copy-friendly text.
+  - `MetaCellEditor.vue`, `MetaFormView.vue`, and `MetaRecordDrawer.vue` use text inputs.
+  - `useMultitableGrid.ts` gives barcode string-like filter operators.
+- OpenAPI:
+  - `packages/openapi/src/base.yml` adds `barcode` to `MultitableFieldType`.
+  - Generated `packages/openapi/dist/*` was refreshed.
+  - `scripts/ops/multitable-openapi-parity.test.mjs` now checks `barcode`.
+
+## Compatibility
+
+Existing records are unaffected. `barcode` uses the same JSON `data` storage model as other text-backed fields and does not require a migration. Clients that do not know `barcode` will still see a string-like value in record payloads, but should update their field-type enum to avoid treating the field as unknown.
+

--- a/docs/development/multitable-barcode-field-verification-20260505.md
+++ b/docs/development/multitable-barcode-field-verification-20260505.md
@@ -1,0 +1,115 @@
+# Multitable Barcode Field Verification - 2026-05-05
+
+## Scope
+
+Verifies the `barcode` field slice:
+
+- Backend type mapping and write coercion.
+- Backend default validation rule alignment.
+- Frontend field creation, rendering, editing, form submit, and drawer patching.
+- OpenAPI contract generation and parity.
+- Build/type/diff gates.
+
+## Commands
+
+### Dependency Bootstrap
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+Result: passed. `pnpm` relinked tracked plugin/tool `node_modules` shims in this worktree; those generated path changes were reverted before commit.
+
+### OpenAPI Generation
+
+```bash
+pnpm exec tsx packages/openapi/tools/build.ts
+```
+
+Result: passed. `packages/openapi/dist/combined.openapi.yml`, `openapi.json`, and `openapi.yaml` were regenerated with `barcode` in `MultitableFieldType`.
+
+### Backend Focused Tests
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/multitable-field-types-batch1.test.ts tests/unit/field-validation.test.ts --reporter=dot
+```
+
+Result: passed.
+
+```text
+Test Files  2 passed (2)
+Tests       138 passed (138)
+```
+
+### Frontend Focused Tests
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-barcode-field.spec.ts tests/multitable-field-manager.spec.ts --watch=false --reporter=dot
+```
+
+Result: passed.
+
+```text
+Test Files  2 passed (2)
+Tests       19 passed (19)
+```
+
+Note: local Vitest printed `WebSocket server error: Port is already in use`; the test process still exited `0`. This is the known web test harness port warning.
+
+### Backend Build
+
+```bash
+pnpm --filter @metasheet/core-backend build
+```
+
+Result: passed.
+
+### Frontend Type Check
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+```
+
+Result: passed.
+
+### OpenAPI Runtime Parity
+
+```bash
+node --test scripts/ops/multitable-openapi-parity.test.mjs
+```
+
+Result: passed.
+
+```text
+tests 1
+pass  1
+fail  0
+```
+
+### Whitespace Guard
+
+```bash
+git diff --check
+```
+
+Result: passed.
+
+## Assertions Covered
+
+- `mapFieldType()` recognizes `barcode`, `bar_code`, and `bar-code`.
+- `BATCH1_FIELD_TYPES` includes `barcode`.
+- `validateBarcodeValue()` trims strings, converts numbers to strings, returns `null` for empty values, rejects object/array values, and rejects values longer than 256 characters.
+- `coerceBatch1Value('barcode', ...)` dispatches through barcode coercion.
+- `getDefaultValidationRules('barcode')` returns `maxLength: 256`.
+- Frontend field manager can create a `barcode` field without extra property.
+- Cell renderer displays barcode values as monospace copy-friendly text.
+- Cell editor, form view, and record drawer submit barcode values through text inputs.
+- OpenAPI generated enum and parity test include `barcode`.
+
+## Deferred
+
+- Camera/scanner integration.
+- Barcode image rendering.
+- Barcode uniqueness or checksum validation.
+- Manual staging verification in the RC smoke checklist.
+

--- a/packages/core-backend/src/multitable/contracts.ts
+++ b/packages/core-backend/src/multitable/contracts.ts
@@ -10,6 +10,7 @@ export type MultitableProvisioningFieldType =
   | 'lookup'
   | 'rollup'
   | 'attachment'
+  | 'barcode'
   | 'longText'
 
 export interface MultitableProvisioningFieldDescriptor {

--- a/packages/core-backend/src/multitable/field-codecs.ts
+++ b/packages/core-backend/src/multitable/field-codecs.ts
@@ -18,6 +18,7 @@ export type MultitableFieldType =
   | 'url'
   | 'email'
   | 'phone'
+  | 'barcode'
   | 'longText'
   | 'autoNumber'
   | 'createdTime'
@@ -98,6 +99,7 @@ export function mapFieldType(type: string): MultitableFieldType | string {
   if (normalized === 'url') return 'url'
   if (normalized === 'email') return 'email'
   if (normalized === 'phone') return 'phone'
+  if (normalized === 'barcode' || normalized === 'bar_code' || normalized === 'bar-code') return 'barcode'
   if (
     normalized === 'autonumber' ||
     normalized === 'auto_number' ||
@@ -326,7 +328,7 @@ export function sanitizeFieldProperty(
     return { ...obj, max }
   }
 
-  if (type === 'url' || type === 'email' || type === 'phone' || type === 'longText') {
+  if (type === 'url' || type === 'email' || type === 'phone' || type === 'barcode' || type === 'longText') {
     return obj
   }
 
@@ -366,7 +368,7 @@ export function serializeFieldRow(row: any): MultitableField {
 }
 
 // ---------------------------------------------------------------------------
-// MF2 field-types batch 1: currency / percent / rating / url / email / phone
+// MF2 field-types batch 1: currency / percent / rating / url / email / phone / barcode
 // ---------------------------------------------------------------------------
 //
 // Validation regex chosen to match Feishu's lenient client-side checks and
@@ -477,6 +479,19 @@ export function validateLongTextValue(value: unknown, fieldId: string): string |
   return value
 }
 
+export function validateBarcodeValue(value: unknown, fieldId: string): string | null {
+  if (value === null || value === undefined || value === '') return null
+  if (typeof value !== 'string' && typeof value !== 'number') {
+    throw new Error(`Barcode value must be a string for ${fieldId}`)
+  }
+  const trimmed = String(value).trim()
+  if (trimmed === '') return null
+  if (trimmed.length > 256) {
+    throw new Error(`Barcode value must be 256 characters or fewer for ${fieldId}`)
+  }
+  return trimmed
+}
+
 export function normalizeMultiSelectValue(
   value: unknown,
   fieldId: string,
@@ -528,6 +543,7 @@ export function coerceBatch1Value(
   if (fieldType === 'url') return validateUrlValue(value, fieldId)
   if (fieldType === 'email') return validateEmailValue(value, fieldId)
   if (fieldType === 'phone') return validatePhoneValue(value, fieldId)
+  if (fieldType === 'barcode') return validateBarcodeValue(value, fieldId)
   return value
 }
 
@@ -538,6 +554,7 @@ export const BATCH1_FIELD_TYPES: ReadonlySet<string> = new Set([
   'url',
   'email',
   'phone',
+  'barcode',
 ])
 
 export const SYSTEM_FIELD_TYPES: ReadonlySet<string> = new Set([

--- a/packages/core-backend/src/multitable/field-validation-engine.ts
+++ b/packages/core-backend/src/multitable/field-validation-engine.ts
@@ -239,6 +239,8 @@ export function getDefaultValidationRules(
     case 'string':
     case 'longText':
       return [{ type: 'maxLength', params: { value: 10000 } }]
+    case 'barcode':
+      return [{ type: 'maxLength', params: { value: 256 } }]
     case 'select':
     case 'multiSelect': {
       const options = fieldProperty?.options

--- a/packages/core-backend/src/multitable/record-service.ts
+++ b/packages/core-backend/src/multitable/record-service.ts
@@ -218,6 +218,7 @@ function mapFieldType(type: string): UniverMetaField['type'] {
   if (normalized === 'url') return 'url'
   if (normalized === 'email') return 'email'
   if (normalized === 'phone') return 'phone'
+  if (normalized === 'barcode' || normalized === 'bar_code' || normalized === 'bar-code') return 'barcode'
   if (normalized === 'autonumber' || normalized === 'auto_number' || normalized === 'auto-number') return 'autoNumber'
   if (normalized === 'createdtime' || normalized === 'created_time' || normalized === 'created-time') return 'createdTime'
   if (normalized === 'modifiedtime' || normalized === 'modified_time' || normalized === 'modified-time') return 'modifiedTime'

--- a/packages/core-backend/src/multitable/record-write-service.ts
+++ b/packages/core-backend/src/multitable/record-write-service.ts
@@ -64,6 +64,7 @@ export type UniverMetaField = {
     | 'url'
     | 'email'
     | 'phone'
+    | 'barcode'
     | 'longText'
     | 'autoNumber'
     | 'createdTime'

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -190,6 +190,7 @@ const MULTITABLE_FIELD_TYPES = [
   'url',
   'email',
   'phone',
+  'barcode',
   'longText',
   'autoNumber',
   'createdTime',
@@ -219,6 +220,7 @@ type UniverMetaField = {
     | 'url'
     | 'email'
     | 'phone'
+    | 'barcode'
     | 'longText'
     | 'autoNumber'
     | 'createdTime'

--- a/packages/core-backend/tests/unit/field-validation.test.ts
+++ b/packages/core-backend/tests/unit/field-validation.test.ts
@@ -428,6 +428,13 @@ describe('getDefaultValidationRules', () => {
     expect((rules[0].params as any).value).toBe(10000)
   })
 
+  test('barcode type returns maxLength 256', () => {
+    const rules = getDefaultValidationRules('barcode')
+    expect(rules).toEqual([{ type: 'maxLength', params: { value: 256 } }])
+    expect(errors('barcode', 'x'.repeat(256), rules)).toHaveLength(0)
+    expect(errors('barcode', 'x'.repeat(257), rules)).toHaveLength(1)
+  })
+
   test('select type returns enum from options', () => {
     const rules = getDefaultValidationRules('select', {
       options: [{ value: 'red' }, { value: 'blue' }],

--- a/packages/core-backend/tests/unit/multitable-field-types-batch1.test.ts
+++ b/packages/core-backend/tests/unit/multitable-field-types-batch1.test.ts
@@ -1,5 +1,5 @@
 /**
- * MF2/MF3 field types — currency / percent / rating / url / email / phone / longText.
+ * MF2/MF3 field types — currency / percent / rating / url / email / phone / barcode / longText.
  *
  * Covers:
  *   - mapFieldType: each new type is recognised (not falling through to 'string').
@@ -25,6 +25,7 @@ import {
   sanitizeFieldProperty,
   serializeFieldRow,
   validateEmailValue,
+  validateBarcodeValue,
   validateLongTextValue,
   validatePhoneValue,
   validateUrlValue,
@@ -38,6 +39,7 @@ describe('mapFieldType — MF2 batch-1', () => {
     expect(mapFieldType('url')).toBe('url')
     expect(mapFieldType('email')).toBe('email')
     expect(mapFieldType('phone')).toBe('phone')
+    expect(mapFieldType('barcode')).toBe('barcode')
   })
 
   it('is case-insensitive and trims whitespace', () => {
@@ -65,9 +67,9 @@ describe('mapFieldType — MF2 batch-1', () => {
     expect(mapFieldType('multi_line_text')).toBe('longText')
   })
 
-  it('exposes BATCH1_FIELD_TYPES set with all 6 names', () => {
+  it('exposes BATCH1_FIELD_TYPES set with normalized runtime types', () => {
     expect(Array.from(BATCH1_FIELD_TYPES).sort()).toEqual([
-      'currency', 'email', 'percent', 'phone', 'rating', 'url',
+      'barcode', 'currency', 'email', 'percent', 'phone', 'rating', 'url',
     ])
   })
 })
@@ -160,11 +162,12 @@ describe('sanitizeFieldProperty — rating', () => {
   })
 })
 
-describe('sanitizeFieldProperty — url / email / phone', () => {
+describe('sanitizeFieldProperty — url / email / phone / barcode', () => {
   it('returns the property object unchanged (no required options)', () => {
     expect(sanitizeFieldProperty('url', {})).toEqual({})
     expect(sanitizeFieldProperty('email', {})).toEqual({})
     expect(sanitizeFieldProperty('phone', {})).toEqual({})
+    expect(sanitizeFieldProperty('barcode', {})).toEqual({})
   })
 
   it('keeps custom keys for forward-compat', () => {
@@ -411,6 +414,23 @@ describe('validateLongTextValue', () => {
   })
 })
 
+describe('validateBarcodeValue', () => {
+  it('trims string and numeric barcode values', () => {
+    expect(validateBarcodeValue('  6901234567890  ', 'fld_barcode')).toBe('6901234567890')
+    expect(validateBarcodeValue(1234567890, 'fld_barcode')).toBe('1234567890')
+  })
+
+  it('returns null for empty barcode values', () => {
+    expect(validateBarcodeValue(null, 'fld_barcode')).toBeNull()
+    expect(validateBarcodeValue('', 'fld_barcode')).toBeNull()
+  })
+
+  it('rejects object values and overly long strings', () => {
+    expect(() => validateBarcodeValue(['123'], 'fld_barcode')).toThrow(/Barcode value must be a string/)
+    expect(() => validateBarcodeValue('x'.repeat(257), 'fld_barcode')).toThrow(/256 characters/)
+  })
+})
+
 describe('coerceBatch1Value — dispatch', () => {
   it('dispatches to currency / percent / rating coercion', () => {
     expect(coerceBatch1Value('currency', { code: 'USD', decimals: 2 }, 'fld', '99.99')).toBe(99.99)
@@ -422,6 +442,7 @@ describe('coerceBatch1Value — dispatch', () => {
     expect(coerceBatch1Value('url', undefined, 'fld', 'https://feishu.cn')).toBe('https://feishu.cn')
     expect(coerceBatch1Value('email', undefined, 'fld', 'a@b.co')).toBe('a@b.co')
     expect(coerceBatch1Value('phone', undefined, 'fld', '+86 138 0000 0000')).toBe('+86 138 0000 0000')
+    expect(coerceBatch1Value('barcode', undefined, 'fld', '  6901234567890  ')).toBe('6901234567890')
   })
 
   it('uses default rating max when property missing', () => {
@@ -445,6 +466,7 @@ describe('coerceBatch1Value — dispatch', () => {
     expect(coerceBatch1Value('url', undefined, 'fld', null)).toBeNull()
     expect(coerceBatch1Value('email', undefined, 'fld', '')).toBeNull()
     expect(coerceBatch1Value('phone', undefined, 'fld', null)).toBeNull()
+    expect(coerceBatch1Value('barcode', undefined, 'fld', '')).toBeNull()
   })
 
   it('surfaces validation errors as thrown exceptions', () => {

--- a/packages/openapi/dist/combined.openapi.yml
+++ b/packages/openapi/dist/combined.openapi.yml
@@ -1598,6 +1598,7 @@ components:
         - url
         - email
         - phone
+        - barcode
         - longText
         - autoNumber
         - createdTime

--- a/packages/openapi/dist/openapi.json
+++ b/packages/openapi/dist/openapi.json
@@ -2294,6 +2294,7 @@
           "url",
           "email",
           "phone",
+          "barcode",
           "longText",
           "autoNumber",
           "createdTime",

--- a/packages/openapi/dist/openapi.yaml
+++ b/packages/openapi/dist/openapi.yaml
@@ -1598,6 +1598,7 @@ components:
         - url
         - email
         - phone
+        - barcode
         - longText
         - autoNumber
         - createdTime

--- a/packages/openapi/src/base.yml
+++ b/packages/openapi/src/base.yml
@@ -1541,6 +1541,7 @@ components:
         - url
         - email
         - phone
+        - barcode
         - longText
         - autoNumber
         - createdTime

--- a/scripts/ops/multitable-openapi-parity.test.mjs
+++ b/scripts/ops/multitable-openapi-parity.test.mjs
@@ -25,6 +25,7 @@ const expectedFieldTypes = [
   'url',
   'email',
   'phone',
+  'barcode',
   'longText',
   'autoNumber',
   'createdTime',


### PR DESCRIPTION
## Summary
- add text-backed `barcode` multitable field type across backend codecs, write services, route constants, frontend UI, and OpenAPI
- coerce barcode values by trimming strings, converting numeric scanner payloads to strings, and rejecting non-string/non-number values or values over 256 characters
- add copy-friendly renderer plus text editors in cells, form view, and record drawer
- document design and verification in `docs/development/multitable-barcode-field-{design,verification}-20260505.md`

## Non-goals
- no camera/scanner integration
- no barcode image rendering
- no uniqueness or checksum validation

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm exec tsx packages/openapi/tools/build.ts`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/multitable-field-types-batch1.test.ts tests/unit/field-validation.test.ts --reporter=dot` → 138/138 passed
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-barcode-field.spec.ts tests/multitable-field-manager.spec.ts --watch=false --reporter=dot` → 19/19 passed
- `pnpm --filter @metasheet/core-backend build`
- `pnpm --filter @metasheet/web exec vue-tsc -b --noEmit`
- `node --test scripts/ops/multitable-openapi-parity.test.mjs`
- `git diff --check`