### PR TITLE
fix(integration): gate K3 smoke signoff on operator permissions

### DIFF
--- a/docs/development/integration-k3wise-postdeploy-operator-permission-development-20260506.md
+++ b/docs/development/integration-k3wise-postdeploy-operator-permission-development-20260506.md
@@ -1,0 +1,52 @@
+# K3 WISE Postdeploy Operator Permission Gate Development
+
+Date: 2026-05-06
+
+## Context
+
+The postdeploy smoke already verifies public health, the K3 WISE frontend route,
+authenticated integration route registration, read-only list probes, and staging
+descriptor contracts.
+
+That was enough to prove the token can read the integration control plane, but
+not enough to prove the operator can run the live PoC flow. The live flow needs
+write-capable integration access for setup, external-system connection tests,
+pipeline dry-run/run, staging install, and dead-letter replay.
+
+## Backend Permission Contract
+
+The integration plugin route guard accepts:
+
+- `role:admin` or `integration:admin` for every integration action.
+- `integration:read` or `integration:write` for read actions.
+- `integration:write` for write actions, unless the user is admin.
+
+The mutating K3 PoC routes therefore require at least one of:
+
+- `role:admin`
+- `integration:admin`
+- `integration:write`
+
+## Implementation
+
+The smoke now adds an `operator-permission` check after `/api/auth/me` succeeds.
+The check is intentionally read-only:
+
+1. Call `/api/auth/me` with the supplied bearer token.
+2. Extract claims from `data.user`, plus legacy-compatible top-level shapes.
+3. Normalize `role`, `roles`, `permissions`, and `perms` into comparable claims.
+4. Pass only when one live-operator claim is present.
+5. Fail the smoke and block internal-trial signoff for read-only tokens.
+
+No write requests are issued by this gate.
+
+## Files Changed
+
+- `scripts/ops/integration-k3wise-postdeploy-smoke.mjs`
+- `scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs`
+
+## Stacking Note
+
+This branch is stacked on PR #1330 because both slices touch the same smoke
+script. After #1330 merges, this branch should be rebased onto `main` before
+final merge.

--- a/docs/development/integration-k3wise-postdeploy-operator-permission-verification-20260506.md
+++ b/docs/development/integration-k3wise-postdeploy-operator-permission-verification-20260506.md
@@ -1,0 +1,52 @@
+# K3 WISE Postdeploy Operator Permission Gate Verification
+
+Date: 2026-05-06
+
+## Local Verification
+
+Command:
+
+```bash
+node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
+```
+
+Result:
+
+- `16/16` tests passed.
+
+Covered cases:
+
+- Admin role passes the operator gate.
+- `integration:write` passes the operator gate.
+- `integration:admin` passes the operator gate.
+- `integration:read` alone fails the operator gate.
+- Read-only token still allows read-route contract checks, but blocks
+  `signoff.internalTrial`.
+- Token strings remain redacted from stdout, stderr, and evidence JSON.
+
+## Extended Verification
+
+Command:
+
+```bash
+node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
+```
+
+Result:
+
+- `25/25` tests passed.
+
+Command:
+
+```bash
+git diff --check -- scripts/ops/integration-k3wise-postdeploy-smoke.mjs scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs docs/development/integration-k3wise-postdeploy-operator-permission-development-20260506.md docs/development/integration-k3wise-postdeploy-operator-permission-verification-20260506.md
+```
+
+Result:
+
+- Passed with no whitespace errors.
+
+## Remote Verification
+
+- GitHub CI should run after the stacked branch is pushed.
+- PR remains blocked on review until the normal review or admin-merge decision.

--- a/scripts/ops/integration-k3wise-postdeploy-smoke.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-smoke.mjs
@@ -34,6 +34,11 @@ const CONTROL_PLANE_LIST_PROBES = [
   ['integration-list-runs', '/api/integration/runs'],
   ['integration-list-dead-letters', '/api/integration/dead-letters'],
 ]
+const LIVE_OPERATOR_CLAIMS = [
+  'role:admin',
+  'integration:admin',
+  'integration:write',
+]
 const REQUIRED_STAGING_DESCRIPTORS = [
   'plm_raw_items',
   'standard_materials',
@@ -477,6 +482,51 @@ function extractTenantId(authBody) {
   return ''
 }
 
+function resolveAuthUser(authBody) {
+  return authBody?.user || authBody?.data?.user || authBody?.data || {}
+}
+
+function addStringClaims(claims, values) {
+  if (!Array.isArray(values)) return
+  for (const value of values) {
+    const claim = String(value ?? '').trim()
+    if (claim) claims.add(claim)
+  }
+}
+
+function collectAuthClaims(authBody) {
+  const user = resolveAuthUser(authBody)
+  const claims = new Set()
+  for (const source of [authBody, authBody?.data, user]) {
+    if (!source || typeof source !== 'object') continue
+    addStringClaims(claims, source.permissions)
+    addStringClaims(claims, source.perms)
+    if (typeof source.role === 'string' && source.role.trim()) claims.add(`role:${source.role.trim()}`)
+    if (Array.isArray(source.roles)) {
+      for (const role of source.roles) {
+        const normalized = String(role ?? '').trim()
+        if (normalized) claims.add(`role:${normalized}`)
+      }
+    }
+  }
+  return Array.from(claims).sort()
+}
+
+function assertLiveOperatorClaims(authBody) {
+  const claims = collectAuthClaims(authBody)
+  const matchedClaims = LIVE_OPERATOR_CLAIMS.filter((claim) => claims.includes(claim))
+  if (matchedClaims.length === 0) {
+    throw new K3WisePostdeploySmokeError('auth token lacks K3 WISE live-operator permissions', {
+      requiredAnyOf: LIVE_OPERATOR_CLAIMS,
+      observedClaims: claims,
+    })
+  }
+  return {
+    requiredAnyOf: LIVE_OPERATOR_CLAIMS,
+    matchedClaims,
+  }
+}
+
 async function runSmoke(opts) {
   const checks = []
   const resolvedToken = await resolveToken(opts)
@@ -541,9 +591,11 @@ async function runSmoke(opts) {
     checks.push(skipped)
   } else {
     let tenantId = opts.tenantId
+    let authBody = null
     try {
       const me = await requestJson(opts.baseUrl, '/api/auth/me', { token, timeoutMs: opts.timeoutMs })
-      const user = me.body?.user || me.body?.data?.user || me.body?.data || {}
+      authBody = me.body
+      const user = resolveAuthUser(authBody)
       tenantId = tenantId || extractTenantId(me.body)
       checks.push(result('auth-me', 'pass', {
         userId: user.id || user.userId || null,
@@ -552,6 +604,14 @@ async function runSmoke(opts) {
       }))
     } catch (error) {
       checks.push(failResult('auth-me', error))
+    }
+
+    if (authBody) {
+      try {
+        checks.push(result('operator-permission', 'pass', assertLiveOperatorClaims(authBody)))
+      } catch (error) {
+        checks.push(failResult('operator-permission', error))
+      }
     }
 
     try {
@@ -681,8 +741,10 @@ if (entryPath && import.meta.url === entryPath) {
 
 export {
   K3WisePostdeploySmokeError,
+  assertLiveOperatorClaims,
   assertStagingDescriptors,
   assertStatusRoutes,
+  collectAuthClaims,
   parseArgs,
   resolveToken,
   renderMarkdown,

--- a/scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
@@ -209,7 +209,17 @@ function createFakeServer(options = {}) {
         sendJson(res, 401, { ok: false, error: { message: 'bad token' } })
         return
       }
-      sendJson(res, 200, { success: true, user: { id: 'admin_1', role: 'admin', tenantId: 'tenant-smoke' } })
+      sendJson(res, 200, {
+        success: true,
+        data: {
+          user: options.authUser || {
+            id: 'admin_1',
+            role: 'admin',
+            permissions: [],
+            tenantId: 'tenant-smoke',
+          },
+        },
+      })
       return
     }
 
@@ -372,6 +382,9 @@ test('authenticated postdeploy smoke validates route and staging contracts witho
       reason: 'authenticated smoke passed',
     })
     assert.equal(evidence.summary.fail, 0)
+    const operatorCheck = evidence.checks.find((check) => check.id === 'operator-permission')
+    assert.equal(operatorCheck.status, 'pass')
+    assert.deepEqual(operatorCheck.matchedClaims, ['role:admin'])
     const routeCheck = evidence.checks.find((check) => check.id === 'integration-route-contract')
     assert.equal(routeCheck.status, 'pass')
     assert.equal(routeCheck.routesChecked, DEFAULT_ROUTES.length)
@@ -397,6 +410,119 @@ test('authenticated postdeploy smoke validates route and staging contracts witho
     assert.ok(fake.requests.some((request) => request.pathname === '/api/integration/pipelines'))
     assert.ok(fake.requests.some((request) => request.pathname === '/api/integration/runs'))
     assert.ok(fake.requests.some((request) => request.pathname === '/api/integration/dead-letters'))
+  } finally {
+    await fake.close()
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('authenticated postdeploy smoke passes operator gate for integration:write permission', async () => {
+  const fake = createFakeServer({
+    authUser: {
+      id: 'operator_1',
+      role: 'user',
+      permissions: ['integration:read', 'integration:write'],
+      tenantId: 'tenant-smoke',
+    },
+  })
+  const baseUrl = await fake.listen()
+  const outDir = makeTmpDir()
+  try {
+    const result = await runScript([
+      '--base-url', baseUrl,
+      '--auth-token', 'test.jwt.token',
+      '--require-auth',
+      '--out-dir', outDir,
+    ])
+
+    assert.equal(result.status, 0, result.stderr)
+    const evidence = JSON.parse(readFileSync(path.join(outDir, 'integration-k3wise-postdeploy-smoke.json'), 'utf8'))
+    const operatorCheck = evidence.checks.find((check) => check.id === 'operator-permission')
+    assert.equal(operatorCheck.status, 'pass')
+    assert.deepEqual(operatorCheck.matchedClaims, ['integration:write'])
+    assert.deepEqual(evidence.signoff, {
+      internalTrial: 'pass',
+      reason: 'authenticated smoke passed',
+    })
+  } finally {
+    await fake.close()
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('authenticated postdeploy smoke passes operator gate for integration:admin permission', async () => {
+  const fake = createFakeServer({
+    authUser: {
+      id: 'integration_admin_1',
+      role: 'user',
+      permissions: ['integration:admin'],
+      tenantId: 'tenant-smoke',
+    },
+  })
+  const baseUrl = await fake.listen()
+  const outDir = makeTmpDir()
+  try {
+    const result = await runScript([
+      '--base-url', baseUrl,
+      '--auth-token', 'test.jwt.token',
+      '--require-auth',
+      '--out-dir', outDir,
+    ])
+
+    assert.equal(result.status, 0, result.stderr)
+    const evidence = JSON.parse(readFileSync(path.join(outDir, 'integration-k3wise-postdeploy-smoke.json'), 'utf8'))
+    const operatorCheck = evidence.checks.find((check) => check.id === 'operator-permission')
+    assert.equal(operatorCheck.status, 'pass')
+    assert.deepEqual(operatorCheck.matchedClaims, ['integration:admin'])
+    assert.deepEqual(evidence.signoff, {
+      internalTrial: 'pass',
+      reason: 'authenticated smoke passed',
+    })
+  } finally {
+    await fake.close()
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('authenticated postdeploy smoke blocks internal trial signoff for read-only operator token', async () => {
+  const fake = createFakeServer({
+    authUser: {
+      id: 'readonly_1',
+      role: 'user',
+      permissions: ['integration:read'],
+      tenantId: 'tenant-smoke',
+    },
+  })
+  const baseUrl = await fake.listen()
+  const outDir = makeTmpDir()
+  try {
+    const result = await runScript([
+      '--base-url', baseUrl,
+      '--auth-token', 'test.jwt.token',
+      '--require-auth',
+      '--out-dir', outDir,
+    ])
+
+    assert.equal(result.status, 1)
+    assert.equal(result.stdout.includes('test.jwt.token'), false)
+    assert.equal(result.stderr.includes('test.jwt.token'), false)
+    const evidenceText = readFileSync(path.join(outDir, 'integration-k3wise-postdeploy-smoke.json'), 'utf8')
+    assert.equal(evidenceText.includes('test.jwt.token'), false)
+    const evidence = JSON.parse(evidenceText)
+    const operatorCheck = evidence.checks.find((check) => check.id === 'operator-permission')
+    assert.equal(operatorCheck.status, 'fail')
+    assert.match(operatorCheck.error, /lacks K3 WISE live-operator permissions/)
+    assert.deepEqual(operatorCheck.details.requiredAnyOf, [
+      'role:admin',
+      'integration:admin',
+      'integration:write',
+    ])
+    assert.deepEqual(operatorCheck.details.observedClaims, ['integration:read', 'role:user'])
+    assert.equal(evidence.checks.find((check) => check.id === 'integration-route-contract').status, 'pass')
+    assert.deepEqual(evidence.signoff, {
+      internalTrial: 'blocked',
+      reason: 'one or more smoke checks failed',
+    })
   } finally {
     await fake.close()
     rmSync(outDir, { recursive: true, force: true })


### PR DESCRIPTION
## Summary
- add a read-only operator-permission check to K3 WISE postdeploy smoke after /api/auth/me succeeds
- block internal-trial signoff when the token only has read access, while keeping route/staging diagnostics running
- accept the same live-operator claims used by integration write routes: role:admin, integration:admin, or integration:write
- add development and verification notes for the permission gate

## Verification
- node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
- node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
- git diff --check -- scripts/ops/integration-k3wise-postdeploy-smoke.mjs scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs docs/development/integration-k3wise-postdeploy-operator-permission-development-20260506.md docs/development/integration-k3wise-postdeploy-operator-permission-verification-20260506.md

## Stacking
- stacked on #1330 because both slices touch scripts/ops/integration-k3wise-postdeploy-smoke.mjs
- after #1330 merges, retarget/rebase this PR onto main before final merge