### PR TITLE
fix(integration): harden K3 live evidence decisions

### DIFF
--- a/docs/development/integration-k3wise-live-poc-evidence-secret-container-development-20260506.md
+++ b/docs/development/integration-k3wise-live-poc-evidence-secret-container-development-20260506.md
@@ -1,0 +1,52 @@
+# K3 WISE Live PoC Evidence Secret Container Development
+
+Date: 2026-05-06
+
+## Context
+
+The live PoC evidence compiler rejects customer evidence packets that contain
+unredacted secret-like fields before it writes the JSON and Markdown report.
+
+Before this change, the leak scanner only rejected direct string values under a
+secret-like key, such as `sessionToken: "..."`. It did not reject secret-like
+containers such as:
+
+- `credentials: { value: "..." }`
+- `authorization: ["Bearer ..."]`
+
+That created a narrow but real safety gap for hand-edited customer evidence.
+
+## Implementation
+
+The leak scanner now recursively checks every string value beneath a secret-like
+key. Safe placeholders remain allowed:
+
+- empty string
+- `<redacted>`
+- `<set-at-runtime>`
+- `redacted`
+- `***`
+
+Schema metadata keys such as `requiredCredentialKeys` are explicitly excluded
+from value scanning, because those values are field names rather than secrets.
+
+## SQL Optional Phase Decision
+
+This slice also closes a live readiness false-positive found during parallel
+inspection: when the preflight packet includes the K3 SQL Server channel,
+`sqlConnection` is optional, but an explicit `fail` status must still fail the
+report. Optional means it may be `skipped`; it does not mean a failed SQL channel
+can produce an overall `PASS`.
+
+`determineDecision()` now treats any phase with `status === "fail"` as a report
+failure.
+
+## Files Changed
+
+- `scripts/ops/integration-k3wise-live-poc-evidence.mjs`
+- `scripts/ops/integration-k3wise-live-poc-evidence.test.mjs`
+
+## Stacking Note
+
+This branch is stacked on PR #1320 because #1320 already owns the live PoC
+evidence fixture contract work and touches the same evidence script.

--- a/docs/development/integration-k3wise-live-poc-evidence-secret-container-verification-20260506.md
+++ b/docs/development/integration-k3wise-live-poc-evidence-secret-container-verification-20260506.md
@@ -1,0 +1,59 @@
+# K3 WISE Live PoC Evidence Secret Container Verification
+
+Date: 2026-05-06
+
+## Local Verification
+
+Command:
+
+```bash
+node --test scripts/ops/integration-k3wise-live-poc-evidence.test.mjs
+```
+
+Result:
+
+- `40/40` tests passed.
+
+Covered cases:
+
+- Nested `credentials.value` is rejected as a secret leak.
+- Array `authorization[0]` is rejected as a secret leak.
+- Nested safe placeholders are accepted.
+- `requiredCredentialKeys` metadata is not treated as a secret value.
+- Optional `sqlConnection: skipped` can still pass.
+- Optional `sqlConnection: fail` forces report `FAIL`.
+
+## Extended Verification
+
+Command:
+
+```bash
+node --test scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
+```
+
+Result:
+
+- `9/9` tests passed.
+
+Command:
+
+```bash
+pnpm run verify:integration-k3wise:poc
+```
+
+Result:
+
+- Preflight tests passed.
+- Live PoC evidence tests passed.
+- Fixture contract tests passed.
+- Mock PoC chain completed with `K3 WISE PoC mock chain verified end-to-end (PASS)`.
+
+Command:
+
+```bash
+git diff --check -- scripts/ops/integration-k3wise-live-poc-evidence.mjs scripts/ops/integration-k3wise-live-poc-evidence.test.mjs docs/development/integration-k3wise-live-poc-evidence-secret-container-development-20260506.md docs/development/integration-k3wise-live-poc-evidence-secret-container-verification-20260506.md
+```
+
+Result:
+
+- Passed with no whitespace errors.

--- a/scripts/ops/integration-k3wise-live-poc-evidence.mjs
+++ b/scripts/ops/integration-k3wise-live-poc-evidence.mjs
@@ -4,6 +4,7 @@ import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 
 const SECRET_KEY_PATTERN = /password|secret|token|session|credential|api[-_]?key|authorization/i
+const SECRET_METADATA_KEY_PATTERN = /^(requiredCredentialKeys|credentialKeys|credentialFieldKeys)$/i
 const SAFE_SECRET_PLACEHOLDERS = new Set(['', '<redacted>', '<set-at-runtime>', 'redacted', '***'])
 const VALID_STATUSES = new Set(['pass', 'partial', 'fail', 'skipped', 'todo', 'blocked'])
 // Customer evidence often spells phase status with localized or English
@@ -111,6 +112,25 @@ function redact(value) {
   return result
 }
 
+function findSecretValueLeaks(value, location, leaks) {
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => findSecretValueLeaks(item, `${location}[${index}]`, leaks))
+    return leaks
+  }
+  if (isPlainObject(value)) {
+    for (const [key, child] of Object.entries(value)) {
+      findSecretValueLeaks(child, `${location}.${key}`, leaks)
+    }
+    return leaks
+  }
+  if (typeof value !== 'string') return leaks
+  const normalized = value.trim()
+  if (normalized.length >= 4 && !SAFE_SECRET_PLACEHOLDERS.has(normalized.toLowerCase())) {
+    leaks.push(location)
+  }
+  return leaks
+}
+
 function findSecretLeaks(value, location = 'root', leaks = []) {
   if (Array.isArray(value)) {
     value.forEach((item, index) => findSecretLeaks(item, `${location}[${index}]`, leaks))
@@ -119,11 +139,9 @@ function findSecretLeaks(value, location = 'root', leaks = []) {
   if (!isPlainObject(value)) return leaks
   for (const [key, child] of Object.entries(value)) {
     const childPath = `${location}.${key}`
-    if (SECRET_KEY_PATTERN.test(key) && typeof child === 'string') {
-      const normalized = child.trim()
-      if (normalized.length >= 4 && !SAFE_SECRET_PLACEHOLDERS.has(normalized.toLowerCase())) {
-        leaks.push(childPath)
-      }
+    if (SECRET_KEY_PATTERN.test(key)) {
+      if (SECRET_METADATA_KEY_PATTERN.test(key)) continue
+      findSecretValueLeaks(child, childPath, leaks)
       continue
     }
     findSecretLeaks(child, childPath, leaks)
@@ -253,7 +271,7 @@ function evaluateBom(packet, evidence, issues) {
 
 function determineDecision(phases, issues) {
   if (issues.some((issue) => issue.severity === 'fail')) return 'FAIL'
-  if (phases.some((item) => item.required && item.status === 'fail')) return 'FAIL'
+  if (phases.some((item) => item.status === 'fail')) return 'FAIL'
   if (phases.some((item) => item.status === 'blocked')) return 'PARTIAL'
   if (phases.some((item) => item.required && item.status !== 'pass')) return 'PARTIAL'
   if (issues.length > 0) return 'PARTIAL'

--- a/scripts/ops/integration-k3wise-live-poc-evidence.test.mjs
+++ b/scripts/ops/integration-k3wise-live-poc-evidence.test.mjs
@@ -40,6 +40,23 @@ test('buildEvidenceReport returns PARTIAL when a required phase is missing', () 
   assert.equal(report.phases.find((phase) => phase.id === 'customerConfirmation').status, 'todo')
 })
 
+test('buildEvidenceReport returns FAIL when optional SQL channel explicitly fails', () => {
+  const evidence = sampleEvidence()
+  evidence.connections.sqlServer.status = 'fail'
+  const report = buildEvidenceReport(packet(), evidence)
+  assert.equal(report.decision, 'FAIL')
+  assert.equal(report.phases.find((phase) => phase.id === 'sqlConnection').status, 'fail')
+  assert.equal(report.issues.length, 0)
+})
+
+test('buildEvidenceReport allows optional SQL channel to be skipped', () => {
+  const evidence = sampleEvidence()
+  evidence.connections.sqlServer.status = 'skipped'
+  const report = buildEvidenceReport(packet(), evidence)
+  assert.equal(report.decision, 'PASS')
+  assert.equal(report.phases.find((phase) => phase.id === 'sqlConnection').status, 'skipped')
+})
+
 test('buildEvidenceReport returns FAIL when Save-only row count exceeds PoC limit', () => {
   const evidence = sampleEvidence()
   evidence.materialSaveOnly.rowsWritten = 4
@@ -63,6 +80,41 @@ test('buildEvidenceReport rejects unredacted secret-like evidence fields', () =>
     () => buildEvidenceReport(packet(), evidence),
     (error) => error instanceof LivePocEvidenceError && error.details.secretLeaks.includes('evidence.connections.k3Wise.sessionToken'),
   )
+})
+
+test('buildEvidenceReport rejects nested secret-like object values', () => {
+  const evidence = sampleEvidence()
+  evidence.connections.k3Wise.credentials = {
+    value: 'live-k3-password',
+  }
+  assert.throws(
+    () => buildEvidenceReport(packet(), evidence),
+    (error) =>
+      error instanceof LivePocEvidenceError &&
+      error.details.secretLeaks.includes('evidence.connections.k3Wise.credentials.value'),
+  )
+})
+
+test('buildEvidenceReport rejects secret-like array values', () => {
+  const evidence = sampleEvidence()
+  evidence.connections.k3Wise.authorization = ['Bearer live-session-token']
+  assert.throws(
+    () => buildEvidenceReport(packet(), evidence),
+    (error) =>
+      error instanceof LivePocEvidenceError &&
+      error.details.secretLeaks.includes('evidence.connections.k3Wise.authorization[0]'),
+  )
+})
+
+test('buildEvidenceReport accepts nested secret-like placeholders', () => {
+  const evidence = sampleEvidence()
+  evidence.connections.k3Wise.credentials = {
+    password: '<redacted>',
+    token: '<set-at-runtime>',
+    notes: ['***', 'redacted'],
+  }
+  const report = buildEvidenceReport(packet(), evidence)
+  assert.equal(report.decision, 'PASS')
 })
 
 test('buildEvidenceReport requires material dry-run runId when dry-run passed', () => {


### PR DESCRIPTION
## Summary
- reject nested secret-like evidence containers such as credentials.value and authorization arrays instead of only direct secret strings
- keep schema metadata such as requiredCredentialKeys out of secret-value scanning
- make an explicit failed optional phase, especially sqlConnection, fail the live PoC evidence report while still allowing optional skipped phases
- add development and verification notes for the live evidence hardening

## Verification
- node --test scripts/ops/integration-k3wise-live-poc-evidence.test.mjs
- node --test scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
- pnpm run verify:integration-k3wise:poc
- git diff --check -- scripts/ops/integration-k3wise-live-poc-evidence.mjs scripts/ops/integration-k3wise-live-poc-evidence.test.mjs docs/development/integration-k3wise-live-poc-evidence-secret-container-development-20260506.md docs/development/integration-k3wise-live-poc-evidence-secret-container-verification-20260506.md

## Stacking
- stacked on #1320 because that PR owns the K3 live PoC fixture/evidence contract surface
- after #1320 merges, retarget/rebase this PR onto main before final merge