### PR TITLE
feat(multitable): add location field type

### DIFF
--- a/apps/web/src/multitable/components/MetaFieldHeader.vue
+++ b/apps/web/src/multitable/components/MetaFieldHeader.vue
@@ -29,7 +29,7 @@ import type { MetaField } from '../types'
 const FIELD_ICONS: Record<string, string> = {
   string: 'Aa', longText: '\u00B6', number: '#', boolean: '\u2611', date: '\u{1F4C5}', select: '\u25CF', multiSelect: '\u25C9',
   link: '\u21C4', person: '\u{1F464}', lookup: '\u2197', rollup: '\u03A3', formula: 'fx', attachment: '\uD83D\uDCCE',
-  currency: '\u00A4', percent: '%', rating: '\u2605', url: '\u{1F517}', email: '\u2709', phone: '\u260E', barcode: '\u25A5',
+  currency: '\u00A4', percent: '%', rating: '\u2605', url: '\u{1F517}', email: '\u2709', phone: '\u260E', barcode: '\u25A5', location: '\u{1F4CD}',
   autoNumber: '#+', createdTime: 'CT', modifiedTime: 'MT', createdBy: 'CB', modifiedBy: 'MB',
 }
 

--- a/apps/web/src/multitable/components/MetaFieldManager.vue
+++ b/apps/web/src/multitable/components/MetaFieldManager.vue
@@ -459,13 +459,13 @@ function rulesToProperty(rules: FieldValidationRule[]): Array<Record<string, unk
 const FIELD_TYPES: MetaFieldCreateType[] = [
   'string', 'longText', 'number', 'boolean', 'date', 'select', 'multiSelect', 'link', 'person',
   'formula', 'lookup', 'rollup', 'attachment',
-  'currency', 'percent', 'rating', 'url', 'email', 'phone', 'barcode',
+  'currency', 'percent', 'rating', 'url', 'email', 'phone', 'barcode', 'location',
   ...SYSTEM_FIELD_TYPES,
 ]
 const FIELD_ICONS: Record<string, string> = {
   string: 'Aa', longText: '\u00B6', number: '#', boolean: '\u2611', date: '\u{1F4C5}', select: '\u25CF', multiSelect: '\u25C9',
   link: '\u21C4', person: '\u{1F464}', lookup: '\u2197', rollup: '\u03A3', formula: 'fx', attachment: '\uD83D\uDCCE',
-  currency: '\u00A4', percent: '%', rating: '\u2605', url: '\u{1F517}', email: '\u2709', phone: '\u260E', barcode: '\u25A5',
+  currency: '\u00A4', percent: '%', rating: '\u2605', url: '\u{1F517}', email: '\u2709', phone: '\u260E', barcode: '\u25A5', location: '\u{1F4CD}',
   autoNumber: '#+', createdTime: 'CT', modifiedTime: 'MT', createdBy: 'CB', modifiedBy: 'MB',
 }
 

--- a/apps/web/src/multitable/components/MetaFormView.vue
+++ b/apps/web/src/multitable/components/MetaFormView.vue
@@ -66,6 +66,20 @@
             @input="formData[field.id] = ($event.target as HTMLInputElement).value"
           />
           <input
+            v-else-if="field.type === 'location'"
+            :id="`field_${field.id}`"
+            class="meta-form-view__input"
+            :class="{ 'meta-form-view__input--error': !!fieldErrors?.[field.id] || !!validationErrors[field.id] }"
+            type="text"
+            placeholder="Enter address"
+            :disabled="isFieldReadOnly(field.id)"
+            :aria-required="field.required ? 'true' : undefined"
+            :aria-invalid="(!!fieldErrors?.[field.id] || !!validationErrors[field.id]) ? 'true' : undefined"
+            :aria-describedby="(fieldErrors?.[field.id] || validationErrors[field.id]) ? `error_${field.id}` : undefined"
+            :value="locationAddressValue(formData[field.id])"
+            @input="formData[field.id] = locationValueFromAddress(($event.target as HTMLInputElement).value)"
+          />
+          <input
             v-else-if="field.type === 'number'"
             :id="`field_${field.id}`"
             class="meta-form-view__input"
@@ -261,7 +275,7 @@ import {
   validateAttachmentSelection,
 } from '../utils/field-config'
 import { linkActionLabel } from '../utils/link-fields'
-import { formatFieldDisplay } from '../utils/field-display'
+import { formatFieldDisplay, locationAddressValue, locationValueFromAddress } from '../utils/field-display'
 import { isSystemField } from '../utils/system-fields'
 
 const props = defineProps<{

--- a/apps/web/src/multitable/components/MetaRecordDrawer.vue
+++ b/apps/web/src/multitable/components/MetaRecordDrawer.vue
@@ -100,6 +100,15 @@
             @change="emit('patch', field.id, ($event.target as HTMLInputElement).value)"
           />
           <input
+            v-else-if="canEditField(field.id) && field.type === 'location'"
+            :id="`drawer_field_${field.id}`"
+            class="meta-record-drawer__input"
+            type="text"
+            placeholder="Enter address"
+            :value="locationAddressValue(record.data[field.id])"
+            @change="emit('patch', field.id, locationValueFromAddress(($event.target as HTMLInputElement).value))"
+          />
+          <input
             v-else-if="canEditField(field.id) && field.type === 'number'"
             :id="`drawer_field_${field.id}`"
             class="meta-record-drawer__input"
@@ -241,7 +250,7 @@ import {
 } from '../utils/comment-affordance'
 import { attachmentAcceptAttr, resolveAttachmentFieldProperty, shouldReplaceAttachmentSelection, validateAttachmentSelection } from '../utils/field-config'
 import { linkActionLabel } from '../utils/link-fields'
-import { formatFieldDisplay } from '../utils/field-display'
+import { formatFieldDisplay, locationAddressValue, locationValueFromAddress } from '../utils/field-display'
 import { isSystemField } from '../utils/system-fields'
 
 const props = withDefaults(defineProps<{

--- a/apps/web/src/multitable/components/cells/MetaCellEditor.vue
+++ b/apps/web/src/multitable/components/cells/MetaCellEditor.vue
@@ -68,6 +68,19 @@
       @keydown.escape="emit('cancel')"
     />
 
+    <!-- location: address-only editor; coordinates can still be supplied through API. -->
+    <input
+      v-else-if="field.type === 'location'"
+      ref="inputRef"
+      class="meta-cell-editor__input"
+      type="text"
+      placeholder="Enter address"
+      :value="locationAddressValue(modelValue)"
+      @input="emit('update:modelValue', locationValueFromAddress(($event.target as HTMLInputElement).value))"
+      @keydown.enter="emit('confirm')"
+      @keydown.escape="emit('cancel')"
+    />
+
     <!-- number -->
     <input
       v-else-if="field.type === 'number'"
@@ -258,7 +271,7 @@ import {
   validateAttachmentSelection,
 } from '../../utils/field-config'
 import { linkActionLabel as formatLinkActionLabel } from '../../utils/link-fields'
-import { formatFieldDisplay } from '../../utils/field-display'
+import { formatFieldDisplay, locationAddressValue, locationValueFromAddress } from '../../utils/field-display'
 import { useYjsCellBinding, type YjsCellBinding } from '../../composables/useYjsCellBinding'
 
 const props = defineProps<{

--- a/apps/web/src/multitable/components/cells/MetaCellRenderer.vue
+++ b/apps/web/src/multitable/components/cells/MetaCellRenderer.vue
@@ -26,6 +26,11 @@
       <code class="meta-cell-renderer__barcode">{{ displayValue }}</code>
     </template>
 
+    <!-- location -->
+    <template v-else-if="field.type === 'location'">
+      <span class="meta-cell-renderer__location" :title="displayValue">{{ displayValue }}</span>
+    </template>
+
     <!-- boolean -->
     <template v-else-if="field.type === 'boolean'">
       <span class="meta-cell-renderer__bool">{{ value ? '\u2611' : '\u2610' }}</span>
@@ -268,6 +273,16 @@ const conditionalClass = computed(() => {
   border-radius: 4px;
   padding: 1px 5px;
   color: #334155;
+}
+.meta-cell-renderer__location {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: #0f766e;
+}
+.meta-cell-renderer__location::before {
+  content: '\1F4CD';
+  font-size: 12px;
 }
 .meta-cell-renderer__url,
 .meta-cell-renderer__email,

--- a/apps/web/src/multitable/composables/useMultitableGrid.ts
+++ b/apps/web/src/multitable/composables/useMultitableGrid.ts
@@ -110,6 +110,14 @@ export const FILTER_OPERATORS_BY_TYPE: Record<string, Array<{ value: string; lab
     { value: 'isEmpty', label: 'is empty' },
     { value: 'isNotEmpty', label: 'is not empty' },
   ],
+  location: [
+    { value: 'is', label: 'is' },
+    { value: 'isNot', label: 'is not' },
+    { value: 'contains', label: 'contains' },
+    { value: 'doesNotContain', label: 'does not contain' },
+    { value: 'isEmpty', label: 'is empty' },
+    { value: 'isNotEmpty', label: 'is not empty' },
+  ],
   number: [
     { value: 'is', label: '=' },
     { value: 'isNot', label: '\u2260' },

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -22,6 +22,7 @@ export type MetaFieldType =
   | 'email'
   | 'phone'
   | 'barcode'
+  | 'location'
   | 'longText'
   | 'autoNumber'
   | 'createdTime'

--- a/apps/web/src/multitable/utils/field-config.ts
+++ b/apps/web/src/multitable/utils/field-config.ts
@@ -33,7 +33,7 @@ export type NormalizedAttachmentFieldProperty = {
   acceptedMimeTypes: string[]
 }
 
-// MF2 batch-1 field types (currency / percent / rating / url / email / phone).
+// MF2 batch-1 field types (currency / percent / rating / url / email / phone / barcode / location).
 export type NormalizedCurrencyFieldProperty = {
   code: string
   decimals: number

--- a/apps/web/src/multitable/utils/field-display.ts
+++ b/apps/web/src/multitable/utils/field-display.ts
@@ -40,6 +40,29 @@ function summarizeAttachmentCount(count: number): string {
   return count === 1 ? '1 attachment' : `${count} attachments`
 }
 
+export function locationAddressValue(value: unknown): string {
+  if (value === null || value === undefined || value === '') return ''
+  if (typeof value === 'string' || typeof value === 'number') return String(value)
+  if (typeof value === 'object' && !Array.isArray(value)) {
+    const obj = value as Record<string, unknown>
+    const rawAddress = obj.address ?? obj.name ?? obj.fullAddress
+    if (rawAddress !== null && rawAddress !== undefined && String(rawAddress).trim().length > 0) {
+      return String(rawAddress)
+    }
+    const latitude = obj.latitude ?? obj.lat
+    const longitude = obj.longitude ?? obj.lng ?? obj.lon
+    if (latitude !== null && latitude !== undefined && longitude !== null && longitude !== undefined) {
+      return `${latitude}, ${longitude}`
+    }
+  }
+  return String(value)
+}
+
+export function locationValueFromAddress(address: string): { address: string } | null {
+  const trimmed = address.trim()
+  return trimmed ? { address: trimmed } : null
+}
+
 export function formatFieldDisplay(params: {
   field: MetaField
   value: unknown
@@ -80,6 +103,11 @@ export function formatFieldDisplay(params: {
     const { max } = resolveRatingFieldProperty(field.property)
     const filled = Math.max(0, Math.min(max, Math.round(num)))
     return `${'★'.repeat(filled)}${'☆'.repeat(max - filled)}`
+  }
+
+  if (field.type === 'location') {
+    const location = locationAddressValue(value).trim()
+    return location.length > 0 ? location : '—'
   }
 
   if (field.type === 'select' || field.type === 'multiSelect') {

--- a/apps/web/tests/multitable-location-field.spec.ts
+++ b/apps/web/tests/multitable-location-field.spec.ts
@@ -1,0 +1,210 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick } from 'vue'
+import MetaCellEditor from '../src/multitable/components/cells/MetaCellEditor.vue'
+import MetaCellRenderer from '../src/multitable/components/cells/MetaCellRenderer.vue'
+import MetaFieldManager from '../src/multitable/components/MetaFieldManager.vue'
+import MetaFormView from '../src/multitable/components/MetaFormView.vue'
+import MetaRecordDrawer from '../src/multitable/components/MetaRecordDrawer.vue'
+import { formatFieldDisplay, locationAddressValue, locationValueFromAddress } from '../src/multitable/utils/field-display'
+
+async function flushUi(cycles = 3) {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+describe('location field UI', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  it('formats location values from address strings, objects, and coordinates', () => {
+    const field = { id: 'fld_location', name: 'Location', type: 'location' as const }
+    expect(formatFieldDisplay({ field, value: 'Shanghai Tower' })).toBe('Shanghai Tower')
+    expect(formatFieldDisplay({ field, value: { address: 'Shanghai Tower', latitude: 31.2335, longitude: 121.5055 } })).toBe('Shanghai Tower')
+    expect(formatFieldDisplay({ field, value: { latitude: 31.2335, longitude: 121.5055 } })).toBe('31.2335, 121.5055')
+    expect(locationAddressValue({ lat: 31.2335, lng: 121.5055 })).toBe('31.2335, 121.5055')
+    expect(locationValueFromAddress('  Shanghai Tower  ')).toEqual({ address: 'Shanghai Tower' })
+    expect(locationValueFromAddress('   ')).toBeNull()
+  })
+
+  it('renders location values with a location-specific class', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    const app = createApp({
+      render() {
+        return h(MetaCellRenderer, {
+          field: { id: 'fld_location', name: 'Location', type: 'location' },
+          value: { address: 'Shanghai Tower', latitude: 31.2335, longitude: 121.5055 },
+        })
+      },
+    })
+
+    app.mount(container)
+    await flushUi()
+
+    const value = container.querySelector('.meta-cell-renderer__location') as HTMLElement | null
+    expect(value).not.toBeNull()
+    expect(value?.textContent).toBe('Shanghai Tower')
+
+    app.unmount()
+    container.remove()
+  })
+
+  it('uses an address-backed cell editor for location values', async () => {
+    const updateSpy = vi.fn()
+    const confirmSpy = vi.fn()
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    const app = createApp({
+      render() {
+        return h(MetaCellEditor, {
+          field: { id: 'fld_location', name: 'Location', type: 'location' },
+          modelValue: { address: 'Old Address', latitude: 31.2335, longitude: 121.5055 },
+          'onUpdate:modelValue': updateSpy,
+          onConfirm: confirmSpy,
+          onCancel: vi.fn(),
+          onOpenLinkPicker: vi.fn(),
+        })
+      },
+    })
+
+    app.mount(container)
+    await flushUi()
+
+    const input = container.querySelector('input[placeholder="Enter address"]') as HTMLInputElement | null
+    expect(input?.type).toBe('text')
+    expect(input?.value).toBe('Old Address')
+    input!.value = 'New Address'
+    input!.dispatchEvent(new Event('input', { bubbles: true }))
+    input!.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    await flushUi()
+
+    expect(updateSpy).toHaveBeenCalledWith({ address: 'New Address' })
+    expect(confirmSpy).toHaveBeenCalledTimes(1)
+
+    app.unmount()
+    container.remove()
+  })
+
+  it('creates location fields from the field manager without configurable property', async () => {
+    const createSpy = vi.fn()
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    const app = createApp({
+      render() {
+        return h(MetaFieldManager, {
+          visible: true,
+          sheetId: 'sheet_1',
+          sheets: [],
+          fields: [],
+          onCreateField: createSpy,
+        })
+      },
+    })
+
+    app.mount(container)
+    await flushUi()
+
+    const nameInput = container.querySelector('.meta-field-mgr__add-row .meta-field-mgr__input') as HTMLInputElement
+    const typeSelect = container.querySelector('.meta-field-mgr__add-row .meta-field-mgr__select') as HTMLSelectElement
+    expect(Array.from(typeSelect.options).map((option) => option.value)).toContain('location')
+
+    nameInput.value = 'Location'
+    nameInput.dispatchEvent(new Event('input', { bubbles: true }))
+    typeSelect.value = 'location'
+    typeSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+
+    ;(Array.from(container.querySelectorAll('.meta-field-mgr__btn-add')) as HTMLButtonElement[])
+      .find((button) => button.textContent?.includes('+ Add'))
+      ?.click()
+    await flushUi()
+
+    expect(createSpy).toHaveBeenCalledWith({
+      sheetId: 'sheet_1',
+      name: 'Location',
+      type: 'location',
+    })
+
+    app.unmount()
+    container.remove()
+  })
+
+  it('submits location values from form view', async () => {
+    const submitSpy = vi.fn()
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    const app = createApp({
+      render() {
+        return h(MetaFormView, {
+          fields: [{ id: 'fld_location', name: 'Location', type: 'location' }],
+          record: { id: 'rec_1', version: 1, data: { fld_location: { address: 'Old Address' } } },
+          loading: false,
+          readOnly: false,
+          onSubmit: submitSpy,
+          onOpenLinkPicker: vi.fn(),
+        })
+      },
+    })
+
+    app.mount(container)
+    await flushUi()
+
+    const input = container.querySelector('#field_fld_location') as HTMLInputElement | null
+    expect(input?.placeholder).toBe('Enter address')
+    expect(input?.value).toBe('Old Address')
+    input!.value = 'New Address'
+    input!.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+    container.querySelector('form')?.dispatchEvent(new Event('submit'))
+    await flushUi()
+
+    expect(submitSpy).toHaveBeenCalledWith({ fld_location: { address: 'New Address' } })
+
+    app.unmount()
+    container.remove()
+  })
+
+  it('patches location values from the record drawer', async () => {
+    const patchSpy = vi.fn()
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    const app = createApp({
+      render() {
+        return h(MetaRecordDrawer, {
+          visible: true,
+          record: { id: 'rec_1', version: 1, data: { fld_location: { address: 'Old Address' } } },
+          fields: [{ id: 'fld_location', name: 'Location', type: 'location' }],
+          canEdit: true,
+          canComment: false,
+          canDelete: false,
+          onPatch: patchSpy,
+        })
+      },
+    })
+
+    app.mount(container)
+    await flushUi()
+
+    const input = container.querySelector('#drawer_field_fld_location') as HTMLInputElement | null
+    expect(input?.placeholder).toBe('Enter address')
+    expect(input?.value).toBe('Old Address')
+    input!.value = 'Drawer Address'
+    input!.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+
+    expect(patchSpy).toHaveBeenCalledWith('fld_location', { address: 'Drawer Address' })
+
+    app.unmount()
+    container.remove()
+  })
+})
+

--- a/docs/development/multitable-location-field-design-20260506.md
+++ b/docs/development/multitable-location-field-design-20260506.md
@@ -1,0 +1,79 @@
+# Multitable Location Field Design - 2026-05-06
+
+## Context
+
+`docs/development/multitable-feishu-rc-todo-20260430.md` keeps `Location field` as a remaining optional Feishu-parity item. The previous `number` and `barcode` slices established the pattern for adding small, first-class field types across backend codecs, frontend editors/renderers, OpenAPI, and focused verification.
+
+## Goals
+
+- Add a first-class `location` multitable field type.
+- Persist location values as a structured JSON object in record `data`.
+- Accept both address-only input and optional coordinates through API write paths.
+- Provide basic frontend creation, rendering, cell editing, form editing, record drawer editing, and filtering.
+- Keep the slice dependency-free and safe for RC use.
+
+## Non-Goals
+
+- No map picker.
+- No browser geolocation prompt.
+- No reverse geocoding or address normalization through external services.
+- No distance/radius filter operators.
+- No export-specific location formatting.
+
+## Value Contract
+
+Canonical persisted shape:
+
+```json
+{
+  "address": "Shanghai Tower",
+  "latitude": 31.2335,
+  "longitude": 121.5055
+}
+```
+
+Rules:
+
+- Empty input becomes `null`.
+- A string or number is treated as an address and normalized to `{ "address": "..." }`.
+- An object may use `address`, `name`, or `fullAddress` as the address source.
+- Coordinates may use `latitude`/`longitude` or aliases `lat`/`lng`/`lon`.
+- Coordinates must be provided together.
+- Latitude must be in `[-90, 90]`; longitude must be in `[-180, 180]`.
+- Address text is trimmed and capped at 512 characters.
+- Coordinate-only objects are allowed and display as `latitude, longitude`.
+
+## Implementation
+
+- Backend field codecs: `packages/core-backend/src/multitable/field-codecs.ts`
+  - Adds `location` to `MultitableFieldType` and `BATCH1_FIELD_TYPES`.
+  - Maps aliases: `geo`, `geolocation`, `geo_location`, and `geo-location`.
+  - Adds `validateLocationValue()` for address/coordinate normalization.
+- Backend write surfaces:
+  - `packages/core-backend/src/routes/univer-meta.ts`
+  - `packages/core-backend/src/multitable/record-service.ts`
+  - `packages/core-backend/src/multitable/record-write-service.ts`
+  - These paths reuse existing batch field coercion, so direct route, public form, record service, and `RecordWriteService` writes share the same semantics.
+- Frontend type and UI:
+  - `apps/web/src/multitable/types.ts` adds `location`.
+  - `MetaFieldManager.vue` and `MetaFieldHeader.vue` expose the field type and map-pin icon.
+  - `MetaCellRenderer.vue` displays a pin-prefixed location label.
+  - `MetaCellEditor.vue`, `MetaFormView.vue`, and `MetaRecordDrawer.vue` provide address-only text inputs.
+  - `useMultitableGrid.ts` gives `location` string-like filter operators for address matching.
+  - `field-display.ts` centralizes display and address-input helpers.
+- OpenAPI:
+  - `packages/openapi/src/base.yml` adds `location` to `MultitableFieldType`.
+  - Generated `packages/openapi/dist/*` was refreshed.
+  - `scripts/ops/multitable-openapi-parity.test.mjs` now checks `location`.
+
+## Compatibility
+
+No migration is required. Existing records are unaffected. Unknown clients that read a location field will receive a JSON value in the existing record `data` object; updated clients should use the OpenAPI enum to treat `location` as first-class.
+
+## Deferred
+
+- Map picker and browser geolocation.
+- Reverse geocoding and coordinate lookup.
+- Distance-based filtering.
+- Location-specific XLSX/CSV formatting.
+

--- a/docs/development/multitable-location-field-verification-20260506.md
+++ b/docs/development/multitable-location-field-verification-20260506.md
@@ -1,0 +1,114 @@
+# Multitable Location Field Verification - 2026-05-06
+
+## Scope
+
+Verifies the `location` field slice:
+
+- Backend type mapping and write coercion.
+- Backend default validation behavior.
+- Frontend display helpers, field creation, rendering, editing, form submit, and drawer patching.
+- OpenAPI generation and runtime parity.
+- Build/type/diff gates.
+
+## Commands
+
+### Dependency Bootstrap
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+Result: passed. `pnpm` relinked tracked plugin/tool `node_modules` shims in this worktree; those generated path changes were reverted before commit.
+
+### OpenAPI Generation
+
+```bash
+pnpm exec tsx packages/openapi/tools/build.ts
+```
+
+Result: passed. `packages/openapi/dist/combined.openapi.yml`, `openapi.json`, and `openapi.yaml` were regenerated with `location` in `MultitableFieldType`.
+
+### Backend Focused Tests
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/multitable-field-types-batch1.test.ts tests/unit/field-validation.test.ts --reporter=dot
+```
+
+Result: passed.
+
+```text
+Test Files  2 passed (2)
+Tests       145 passed (145)
+```
+
+### Frontend Focused Tests
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-location-field.spec.ts tests/multitable-field-manager.spec.ts --watch=false --reporter=dot
+```
+
+Result: passed.
+
+```text
+Test Files  2 passed (2)
+Tests       20 passed (20)
+```
+
+Note: local Vitest printed `WebSocket server error: Port is already in use`; the test process still exited `0`. This is the known web test harness port warning.
+
+### Backend Build
+
+```bash
+pnpm --filter @metasheet/core-backend build
+```
+
+Result: passed.
+
+### Frontend Type Check
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+```
+
+Result: passed.
+
+### OpenAPI Runtime Parity
+
+```bash
+node --test scripts/ops/multitable-openapi-parity.test.mjs
+```
+
+Result: passed.
+
+```text
+tests 1
+pass  1
+fail  0
+```
+
+### Whitespace Guard
+
+```bash
+git diff --check
+```
+
+Result: passed.
+
+## Assertions Covered
+
+- `mapFieldType()` recognizes `location`, `geo`, `geolocation`, `geo_location`, and `geo-location`.
+- `BATCH1_FIELD_TYPES` includes `location`.
+- `validateLocationValue()` trims string addresses, normalizes structured values, accepts coordinate aliases, allows coordinate-only values, returns `null` for empty input, and rejects invalid shapes, partial coordinates, out-of-range coordinates, and addresses longer than 512 characters.
+- `coerceBatch1Value('location', ...)` dispatches through location coercion.
+- `getDefaultValidationRules('location')` returns no default rule because structured shape is enforced in write coercion.
+- Frontend display helpers render address objects and coordinate-only objects.
+- Field manager can create a `location` field without extra property.
+- Cell renderer displays a location-specific value.
+- Cell editor, form view, and record drawer submit `{ address }` values from address text inputs.
+- OpenAPI generated enum and parity test include `location`.
+
+## Deferred
+
+- Manual staging verification in the RC smoke checklist.
+- Map picker, browser geolocation, reverse geocoding, and distance filtering.
+

--- a/packages/core-backend/src/multitable/contracts.ts
+++ b/packages/core-backend/src/multitable/contracts.ts
@@ -11,6 +11,7 @@ export type MultitableProvisioningFieldType =
   | 'rollup'
   | 'attachment'
   | 'barcode'
+  | 'location'
   | 'longText'
 
 export interface MultitableProvisioningFieldDescriptor {

--- a/packages/core-backend/src/multitable/field-codecs.ts
+++ b/packages/core-backend/src/multitable/field-codecs.ts
@@ -19,6 +19,7 @@ export type MultitableFieldType =
   | 'email'
   | 'phone'
   | 'barcode'
+  | 'location'
   | 'longText'
   | 'autoNumber'
   | 'createdTime'
@@ -100,6 +101,15 @@ export function mapFieldType(type: string): MultitableFieldType | string {
   if (normalized === 'email') return 'email'
   if (normalized === 'phone') return 'phone'
   if (normalized === 'barcode' || normalized === 'bar_code' || normalized === 'bar-code') return 'barcode'
+  if (
+    normalized === 'location' ||
+    normalized === 'geo' ||
+    normalized === 'geolocation' ||
+    normalized === 'geo_location' ||
+    normalized === 'geo-location'
+  ) {
+    return 'location'
+  }
   if (
     normalized === 'autonumber' ||
     normalized === 'auto_number' ||
@@ -328,7 +338,7 @@ export function sanitizeFieldProperty(
     return { ...obj, max }
   }
 
-  if (type === 'url' || type === 'email' || type === 'phone' || type === 'barcode' || type === 'longText') {
+  if (type === 'url' || type === 'email' || type === 'phone' || type === 'barcode' || type === 'location' || type === 'longText') {
     return obj
   }
 
@@ -368,7 +378,7 @@ export function serializeFieldRow(row: any): MultitableField {
 }
 
 // ---------------------------------------------------------------------------
-// MF2 field-types batch 1: currency / percent / rating / url / email / phone / barcode
+// MF2 field-types batch 1: currency / percent / rating / url / email / phone / barcode / location
 // ---------------------------------------------------------------------------
 //
 // Validation regex chosen to match Feishu's lenient client-side checks and
@@ -492,6 +502,65 @@ export function validateBarcodeValue(value: unknown, fieldId: string): string | 
   return trimmed
 }
 
+export type LocationValue = {
+  address: string
+  latitude?: number
+  longitude?: number
+}
+
+function coerceLocationCoordinate(
+  value: unknown,
+  label: 'latitude' | 'longitude',
+  fieldId: string,
+  min: number,
+  max: number,
+): number | undefined {
+  if (value === null || value === undefined || value === '') return undefined
+  const num = typeof value === 'number' ? value : Number(value)
+  if (!Number.isFinite(num)) {
+    throw new Error(`Location ${label} must be a finite number for ${fieldId}`)
+  }
+  if (num < min || num > max) {
+    throw new Error(`Location ${label} must be between ${min} and ${max} for ${fieldId}`)
+  }
+  return num
+}
+
+export function validateLocationValue(value: unknown, fieldId: string): LocationValue | null {
+  if (value === null || value === undefined || value === '') return null
+  if (typeof value === 'string' || typeof value === 'number') {
+    const address = String(value).trim()
+    if (!address) return null
+    if (address.length > 512) {
+      throw new Error(`Location address must be 512 characters or fewer for ${fieldId}`)
+    }
+    return { address }
+  }
+  if (!isPlainObject(value)) {
+    throw new Error(`Location value must be a string or object for ${fieldId}`)
+  }
+
+  const rawAddress = value.address ?? value.name ?? value.fullAddress
+  const address = rawAddress === null || rawAddress === undefined ? '' : String(rawAddress).trim()
+  if (address.length > 512) {
+    throw new Error(`Location address must be 512 characters or fewer for ${fieldId}`)
+  }
+
+  const rawLatitude = value.latitude ?? value.lat
+  const rawLongitude = value.longitude ?? value.lng ?? value.lon
+  const latitude = coerceLocationCoordinate(rawLatitude, 'latitude', fieldId, -90, 90)
+  const longitude = coerceLocationCoordinate(rawLongitude, 'longitude', fieldId, -180, 180)
+  if ((latitude === undefined) !== (longitude === undefined)) {
+    throw new Error(`Location latitude and longitude must be provided together for ${fieldId}`)
+  }
+  if (!address && latitude === undefined) return null
+
+  return {
+    address,
+    ...(latitude !== undefined && longitude !== undefined ? { latitude, longitude } : {}),
+  }
+}
+
 export function normalizeMultiSelectValue(
   value: unknown,
   fieldId: string,
@@ -544,6 +613,7 @@ export function coerceBatch1Value(
   if (fieldType === 'email') return validateEmailValue(value, fieldId)
   if (fieldType === 'phone') return validatePhoneValue(value, fieldId)
   if (fieldType === 'barcode') return validateBarcodeValue(value, fieldId)
+  if (fieldType === 'location') return validateLocationValue(value, fieldId)
   return value
 }
 
@@ -555,6 +625,7 @@ export const BATCH1_FIELD_TYPES: ReadonlySet<string> = new Set([
   'email',
   'phone',
   'barcode',
+  'location',
 ])
 
 export const SYSTEM_FIELD_TYPES: ReadonlySet<string> = new Set([

--- a/packages/core-backend/src/multitable/field-validation-engine.ts
+++ b/packages/core-backend/src/multitable/field-validation-engine.ts
@@ -241,6 +241,8 @@ export function getDefaultValidationRules(
       return [{ type: 'maxLength', params: { value: 10000 } }]
     case 'barcode':
       return [{ type: 'maxLength', params: { value: 256 } }]
+    case 'location':
+      return []
     case 'select':
     case 'multiSelect': {
       const options = fieldProperty?.options

--- a/packages/core-backend/src/multitable/record-service.ts
+++ b/packages/core-backend/src/multitable/record-service.ts
@@ -219,6 +219,15 @@ function mapFieldType(type: string): UniverMetaField['type'] {
   if (normalized === 'email') return 'email'
   if (normalized === 'phone') return 'phone'
   if (normalized === 'barcode' || normalized === 'bar_code' || normalized === 'bar-code') return 'barcode'
+  if (
+    normalized === 'location' ||
+    normalized === 'geo' ||
+    normalized === 'geolocation' ||
+    normalized === 'geo_location' ||
+    normalized === 'geo-location'
+  ) {
+    return 'location'
+  }
   if (normalized === 'autonumber' || normalized === 'auto_number' || normalized === 'auto-number') return 'autoNumber'
   if (normalized === 'createdtime' || normalized === 'created_time' || normalized === 'created-time') return 'createdTime'
   if (normalized === 'modifiedtime' || normalized === 'modified_time' || normalized === 'modified-time') return 'modifiedTime'

--- a/packages/core-backend/src/multitable/record-write-service.ts
+++ b/packages/core-backend/src/multitable/record-write-service.ts
@@ -65,6 +65,7 @@ export type UniverMetaField = {
     | 'email'
     | 'phone'
     | 'barcode'
+    | 'location'
     | 'longText'
     | 'autoNumber'
     | 'createdTime'

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -191,6 +191,7 @@ const MULTITABLE_FIELD_TYPES = [
   'email',
   'phone',
   'barcode',
+  'location',
   'longText',
   'autoNumber',
   'createdTime',
@@ -221,6 +222,7 @@ type UniverMetaField = {
     | 'email'
     | 'phone'
     | 'barcode'
+    | 'location'
     | 'longText'
     | 'autoNumber'
     | 'createdTime'

--- a/packages/core-backend/tests/unit/field-validation.test.ts
+++ b/packages/core-backend/tests/unit/field-validation.test.ts
@@ -435,6 +435,10 @@ describe('getDefaultValidationRules', () => {
     expect(errors('barcode', 'x'.repeat(257), rules)).toHaveLength(1)
   })
 
+  test('location type returns empty defaults because write coercion validates structured shape', () => {
+    expect(getDefaultValidationRules('location')).toHaveLength(0)
+  })
+
   test('select type returns enum from options', () => {
     const rules = getDefaultValidationRules('select', {
       options: [{ value: 'red' }, { value: 'blue' }],

--- a/packages/core-backend/tests/unit/multitable-field-types-batch1.test.ts
+++ b/packages/core-backend/tests/unit/multitable-field-types-batch1.test.ts
@@ -1,5 +1,5 @@
 /**
- * MF2/MF3 field types — currency / percent / rating / url / email / phone / barcode / longText.
+ * MF2/MF3 field types — currency / percent / rating / url / email / phone / barcode / location / longText.
  *
  * Covers:
  *   - mapFieldType: each new type is recognised (not falling through to 'string').
@@ -26,6 +26,7 @@ import {
   serializeFieldRow,
   validateEmailValue,
   validateBarcodeValue,
+  validateLocationValue,
   validateLongTextValue,
   validatePhoneValue,
   validateUrlValue,
@@ -40,6 +41,7 @@ describe('mapFieldType — MF2 batch-1', () => {
     expect(mapFieldType('email')).toBe('email')
     expect(mapFieldType('phone')).toBe('phone')
     expect(mapFieldType('barcode')).toBe('barcode')
+    expect(mapFieldType('location')).toBe('location')
   })
 
   it('is case-insensitive and trims whitespace', () => {
@@ -67,9 +69,15 @@ describe('mapFieldType — MF2 batch-1', () => {
     expect(mapFieldType('multi_line_text')).toBe('longText')
   })
 
+  it('recognises location aliases without falling back to string', () => {
+    expect(mapFieldType('geo')).toBe('location')
+    expect(mapFieldType('geo_location')).toBe('location')
+    expect(mapFieldType('geo-location')).toBe('location')
+  })
+
   it('exposes BATCH1_FIELD_TYPES set with normalized runtime types', () => {
     expect(Array.from(BATCH1_FIELD_TYPES).sort()).toEqual([
-      'barcode', 'currency', 'email', 'percent', 'phone', 'rating', 'url',
+      'barcode', 'currency', 'email', 'location', 'percent', 'phone', 'rating', 'url',
     ])
   })
 })
@@ -162,12 +170,13 @@ describe('sanitizeFieldProperty — rating', () => {
   })
 })
 
-describe('sanitizeFieldProperty — url / email / phone / barcode', () => {
+describe('sanitizeFieldProperty — url / email / phone / barcode / location', () => {
   it('returns the property object unchanged (no required options)', () => {
     expect(sanitizeFieldProperty('url', {})).toEqual({})
     expect(sanitizeFieldProperty('email', {})).toEqual({})
     expect(sanitizeFieldProperty('phone', {})).toEqual({})
     expect(sanitizeFieldProperty('barcode', {})).toEqual({})
+    expect(sanitizeFieldProperty('location', {})).toEqual({})
   })
 
   it('keeps custom keys for forward-compat', () => {
@@ -431,6 +440,46 @@ describe('validateBarcodeValue', () => {
   })
 })
 
+describe('validateLocationValue', () => {
+  it('normalizes string addresses', () => {
+    expect(validateLocationValue('  Shanghai Tower  ', 'fld_location')).toEqual({ address: 'Shanghai Tower' })
+  })
+
+  it('normalizes structured values and coordinate aliases', () => {
+    expect(validateLocationValue({
+      address: 'Shanghai Tower',
+      lat: '31.2335',
+      lng: 121.5055,
+    }, 'fld_location')).toEqual({
+      address: 'Shanghai Tower',
+      latitude: 31.2335,
+      longitude: 121.5055,
+    })
+  })
+
+  it('accepts coordinate-only structured values', () => {
+    expect(validateLocationValue({ latitude: 31.2335, longitude: 121.5055 }, 'fld_location')).toEqual({
+      address: '',
+      latitude: 31.2335,
+      longitude: 121.5055,
+    })
+  })
+
+  it('returns null for empty location values', () => {
+    expect(validateLocationValue(null, 'fld_location')).toBeNull()
+    expect(validateLocationValue('', 'fld_location')).toBeNull()
+    expect(validateLocationValue({}, 'fld_location')).toBeNull()
+  })
+
+  it('rejects invalid shapes, partial coordinates, out-of-range coordinates, and long addresses', () => {
+    expect(() => validateLocationValue(['Shanghai'], 'fld_location')).toThrow(/string or object/)
+    expect(() => validateLocationValue({ address: 'A', latitude: 31 }, 'fld_location')).toThrow(/provided together/)
+    expect(() => validateLocationValue({ address: 'A', latitude: 91, longitude: 0 }, 'fld_location')).toThrow(/latitude/)
+    expect(() => validateLocationValue({ address: 'A', latitude: 0, longitude: 181 }, 'fld_location')).toThrow(/longitude/)
+    expect(() => validateLocationValue('x'.repeat(513), 'fld_location')).toThrow(/512 characters/)
+  })
+})
+
 describe('coerceBatch1Value — dispatch', () => {
   it('dispatches to currency / percent / rating coercion', () => {
     expect(coerceBatch1Value('currency', { code: 'USD', decimals: 2 }, 'fld', '99.99')).toBe(99.99)
@@ -443,6 +492,7 @@ describe('coerceBatch1Value — dispatch', () => {
     expect(coerceBatch1Value('email', undefined, 'fld', 'a@b.co')).toBe('a@b.co')
     expect(coerceBatch1Value('phone', undefined, 'fld', '+86 138 0000 0000')).toBe('+86 138 0000 0000')
     expect(coerceBatch1Value('barcode', undefined, 'fld', '  6901234567890  ')).toBe('6901234567890')
+    expect(coerceBatch1Value('location', undefined, 'fld', '  Shanghai Tower  ')).toEqual({ address: 'Shanghai Tower' })
   })
 
   it('uses default rating max when property missing', () => {
@@ -467,6 +517,7 @@ describe('coerceBatch1Value — dispatch', () => {
     expect(coerceBatch1Value('email', undefined, 'fld', '')).toBeNull()
     expect(coerceBatch1Value('phone', undefined, 'fld', null)).toBeNull()
     expect(coerceBatch1Value('barcode', undefined, 'fld', '')).toBeNull()
+    expect(coerceBatch1Value('location', undefined, 'fld', '')).toBeNull()
   })
 
   it('surfaces validation errors as thrown exceptions', () => {

--- a/packages/openapi/dist/combined.openapi.yml
+++ b/packages/openapi/dist/combined.openapi.yml
@@ -1599,6 +1599,7 @@ components:
         - email
         - phone
         - barcode
+        - location
         - longText
         - autoNumber
         - createdTime

--- a/packages/openapi/dist/openapi.json
+++ b/packages/openapi/dist/openapi.json
@@ -2295,6 +2295,7 @@
           "email",
           "phone",
           "barcode",
+          "location",
           "longText",
           "autoNumber",
           "createdTime",

--- a/packages/openapi/dist/openapi.yaml
+++ b/packages/openapi/dist/openapi.yaml
@@ -1599,6 +1599,7 @@ components:
         - email
         - phone
         - barcode
+        - location
         - longText
         - autoNumber
         - createdTime

--- a/packages/openapi/src/base.yml
+++ b/packages/openapi/src/base.yml
@@ -1542,6 +1542,7 @@ components:
         - email
         - phone
         - barcode
+        - location
         - longText
         - autoNumber
         - createdTime

--- a/scripts/ops/multitable-openapi-parity.test.mjs
+++ b/scripts/ops/multitable-openapi-parity.test.mjs
@@ -26,6 +26,7 @@ const expectedFieldTypes = [
   'email',
   'phone',
   'barcode',
+  'location',
   'longText',
   'autoNumber',
   'createdTime',


### PR DESCRIPTION
## Summary
- add structured `location` multitable field type across backend codecs, write services, route constants, frontend UI, and OpenAPI
- normalize string input to `{ address }`, accept structured address plus optional latitude/longitude, and validate coordinate ranges
- add address-backed renderer/editor/form/drawer support and string-like filter operators
- document design and verification in `docs/development/multitable-location-field-{design,verification}-20260506.md`

## Non-goals
- no map picker or browser geolocation
- no reverse geocoding or external service dependency
- no distance/radius filters

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm exec tsx packages/openapi/tools/build.ts`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/multitable-field-types-batch1.test.ts tests/unit/field-validation.test.ts --reporter=dot` → 145/145 passed
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-location-field.spec.ts tests/multitable-field-manager.spec.ts --watch=false --reporter=dot` → 20/20 passed
- `pnpm --filter @metasheet/core-backend build`
- `pnpm --filter @metasheet/web exec vue-tsc -b --noEmit`
- `node --test scripts/ops/multitable-openapi-parity.test.mjs`
- `git diff --check`