### PR TITLE
test(integration): align K3 SQL mock with channel contract

### DIFF
--- a/docs/development/integration-k3wise-sqlmock-channel-contract-development-20260506.md
+++ b/docs/development/integration-k3wise-sqlmock-channel-contract-development-20260506.md
@@ -1,0 +1,54 @@
+# K3 WISE SQL Mock Channel Contract Development
+
+Date: 2026-05-06
+
+## Context
+
+The K3 WISE fixture mock chain is meant to prove the offline PoC wiring before a
+customer run. The SQL Server mock claimed to be compatible with the real K3 WISE
+SQL Server channel, but only implemented low-level `query()` and `exec()` probe
+methods.
+
+The real channel uses:
+
+- `queryExecutor.select()` for read operations.
+- `queryExecutor.insertMany()` for middle-table upsert operations.
+
+Because `run-mock-poc-demo.mjs` called the mock directly, the demo could pass
+without exercising the real SQL channel read/upsert contract.
+
+## Implementation
+
+The SQL mock now implements:
+
+- `select({ table, columns, limit, cursor, filters, orderBy, watermark, options, system })`
+- `insertMany({ table, records, keyFields, mode, options, system })`
+
+Legacy `query()` and `exec()` remain for focused safety probes.
+
+The demo now calls `sqlChannel.read()` and `sqlChannel.upsert()` before running
+the raw core-table write rejection probe.
+
+## Safety Hardening
+
+The mock parser was tightened so PoC safety checks catch more SQL Server shapes:
+
+- `WITH ... DELETE/UPDATE/INSERT/MERGE/...` is treated as a write, not read.
+- `MERGE INTO [dbo].[t_ICItem] ...` is rejected as a K3 core-table write.
+- unsupported operations such as `EXEC ...` are rejected instead of being logged
+  as null-table writes.
+- bracket-qualified `[dbo].[t_ICItem]` reads resolve to the canned K3 core table.
+
+## Files Changed
+
+- `package.json`
+- `scripts/ops/fixtures/integration-k3wise/mock-sqlserver-executor.mjs`
+- `scripts/ops/fixtures/integration-k3wise/mock-sqlserver-executor.test.mjs`
+- `scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs`
+- `scripts/ops/fixtures/integration-k3wise/README.md`
+
+## CI Integration
+
+`verify:integration-k3wise:poc` now runs the SQL mock contract test before the
+mock end-to-end demo. The GitHub `K3 WISE offline PoC` workflow already invokes
+that package script.

--- a/docs/development/integration-k3wise-sqlmock-channel-contract-verification-20260506.md
+++ b/docs/development/integration-k3wise-sqlmock-channel-contract-verification-20260506.md
@@ -1,0 +1,62 @@
+# K3 WISE SQL Mock Channel Contract Verification
+
+Date: 2026-05-06
+
+## Local Verification
+
+Command:
+
+```bash
+node --test scripts/ops/fixtures/integration-k3wise/mock-sqlserver-executor.test.mjs
+```
+
+Result:
+
+- `8/8` tests passed.
+
+Command:
+
+```bash
+node scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs
+```
+
+Result:
+
+- Mock K3 WebAPI Save-only flow passed.
+- SQL channel `read()` returned one canned K3 core-table row.
+- SQL channel `upsert()` wrote one integration middle-table row.
+- Raw SQL safety probe rejected `INSERT` into `t_ICItem`.
+- Evidence compiler returned `PASS`.
+
+Command:
+
+```bash
+pnpm run verify:integration-k3wise:poc
+```
+
+Result:
+
+- Preflight tests passed: `16/16`.
+- Live evidence tests passed: `31/31`.
+- SQL mock contract tests passed: `8/8`.
+- Mock PoC chain completed with `K3 WISE PoC mock chain verified end-to-end (PASS)`.
+
+Command:
+
+```bash
+git diff --check -- package.json scripts/ops/fixtures/integration-k3wise/mock-sqlserver-executor.mjs scripts/ops/fixtures/integration-k3wise/mock-sqlserver-executor.test.mjs scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs scripts/ops/fixtures/integration-k3wise/README.md docs/development/integration-k3wise-sqlmock-channel-contract-development-20260506.md docs/development/integration-k3wise-sqlmock-channel-contract-verification-20260506.md
+```
+
+Result:
+
+- Passed with no whitespace errors.
+
+## Coverage
+
+- real channel `read()` succeeds through mock `select()`;
+- real channel `upsert()` succeeds through mock `insertMany()`;
+- direct K3 core-table upsert remains rejected;
+- CTE-wrapped write is rejected through `query()`;
+- `MERGE` into K3 core tables is rejected;
+- unsupported SQL operations are rejected;
+- mock PoC demo still reaches PASS after using channel-level SQL probes.

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "profile:multitable-grid:local": "RUNNER_SCRIPT=scripts/profile-multitable-grid.mjs RUN_LABEL=multitable-grid-profile bash scripts/ops/multitable-pilot-local.sh",
     "profile:multitable-grid:staging": "RUNNER_SCRIPT=scripts/profile-multitable-grid.mjs RUN_LABEL=multitable-grid-profile-staging RUN_MODE=staging RUNNER_REPORT_BASENAME=staging-report AUTO_START_SERVICES=false REQUIRE_RUNNING_SERVICES=true bash scripts/ops/multitable-pilot-local.sh",
     "verify:multitable-grid-profile:summary": "node scripts/ops/multitable-grid-profile-summary.mjs",
-    "verify:integration-k3wise:poc": "node --test scripts/ops/integration-k3wise-live-poc-preflight.test.mjs && node --test scripts/ops/integration-k3wise-live-poc-evidence.test.mjs && node scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs",
+    "verify:integration-k3wise:poc": "node --test scripts/ops/integration-k3wise-live-poc-preflight.test.mjs && node --test scripts/ops/integration-k3wise-live-poc-evidence.test.mjs && node --test scripts/ops/fixtures/integration-k3wise/mock-sqlserver-executor.test.mjs && node scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs",
     "phase5:run-all": "bash scripts/phase5-run-all.sh",
     "build": "pnpm -r build",
     "test": "pnpm -r test",

--- a/scripts/ops/fixtures/integration-k3wise/README.md
+++ b/scripts/ops/fixtures/integration-k3wise/README.md
@@ -12,14 +12,16 @@ Fixtures and mock server for the K3 WISE Live PoC chain. Used to:
 | `gate-sample.json` | Customer GATE answer template. Customer copies, fills in real values (K3 version, URLs, credentials placeholders), saves outside Git. |
 | `evidence-sample.json` | Customer-side evidence template after live PoC. Customer fills in run IDs, K3 record IDs, statuses, etc. |
 | `mock-k3-webapi-server.mjs` | Minimal in-process HTTP mock for K3 WISE WebAPI: Login / Health / Material / BOM Save / Submit / Audit. NOT a full K3 simulator. |
-| `mock-sqlserver-executor.mjs` | Mock SQL executor: read-only on K3 core tables, writeable on integration middle tables, rejects writes to `t_ICItem` / `t_ICBOM`. |
-| `run-mock-poc-demo.mjs` | End-to-end smoke: loads gate sample → preflight → spins up mock K3 → adapter Save-only → SQL channel readonly probe → evidence compile → asserts PASS. |
+| `mock-sqlserver-executor.mjs` | Mock SQL executor: implements the real K3 SQL channel `select()` / `insertMany()` contract, keeps legacy `query()` / `exec()` probes, and rejects core-table writes. |
+| `mock-sqlserver-executor.test.mjs` | Contract test for SQL mock safety parsing and real channel compatibility, including CTE-wrapped writes, `MERGE`, and bracket-qualified K3 core tables. |
+| `run-mock-poc-demo.mjs` | End-to-end smoke: loads gate sample → preflight → spins up mock K3 → adapter Save-only → SQL channel read/upsert probes → evidence compile → asserts PASS. |
 
 ## Local verification
 
 From repo root:
 
 ```bash
+node --test scripts/ops/fixtures/integration-k3wise/mock-sqlserver-executor.test.mjs
 node scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs
 ```
 

--- a/scripts/ops/fixtures/integration-k3wise/mock-sqlserver-executor.mjs
+++ b/scripts/ops/fixtures/integration-k3wise/mock-sqlserver-executor.mjs
@@ -20,18 +20,39 @@ const K3_CORE_TABLES = new Set([
   't_measureunit',
   't_organization',
 ])
+const WRITE_OPERATIONS = new Set(['insert', 'update', 'delete', 'merge'])
 
 function tableNameFromSql(sql) {
-  const match = sql.match(/(?:from|into|update|table)\s+(?:dbo\.)?["[]?([a-z_][a-z0-9_]*)["\]]?/i)
+  const match = sql.match(
+    /(?:from|into|update|table|merge(?:\s+into)?)\s+(?:(?:dbo|\[dbo\]|"dbo")\s*\.\s*)?["[]?([a-z_][a-z0-9_]*)["\]]?/i,
+  )
   return match ? match[1].toLowerCase() : null
+}
+
+function normalizeTableName(table) {
+  return String(table || '')
+    .trim()
+    .replace(/["\[\]]/g, '')
+    .split('.')
+    .pop()
+    .toLowerCase()
+}
+
+function hasMutatingCte(sql) {
+  return /\b(?:INSERT\s+INTO|UPDATE|DELETE\s+FROM|MERGE(?:\s+INTO)?|TRUNCATE\s+TABLE|ALTER\s+TABLE|DROP\s+TABLE|CREATE\s+TABLE)\b/i.test(sql)
 }
 
 function operationFromSql(sql) {
   const trimmed = sql.trim().toUpperCase()
-  if (trimmed.startsWith('SELECT') || trimmed.startsWith('WITH')) return 'read'
+  if (trimmed.startsWith('SELECT')) return 'read'
+  if (trimmed.startsWith('WITH')) return hasMutatingCte(sql) ? 'cte-write' : 'read'
   if (trimmed.startsWith('INSERT')) return 'insert'
   if (trimmed.startsWith('UPDATE')) return 'update'
   if (trimmed.startsWith('DELETE')) return 'delete'
+  if (trimmed.startsWith('MERGE')) return 'merge'
+  if (trimmed.startsWith('TRUNCATE') || trimmed.startsWith('ALTER') || trimmed.startsWith('DROP') || trimmed.startsWith('CREATE')) {
+    return 'schema'
+  }
   return 'unknown'
 }
 
@@ -58,12 +79,37 @@ export function createMockSqlServerExecutor({
       const rows = cannedReadResults[table] || []
       return { rows }
     },
+    async select({ table, columns, limit, cursor, filters, orderBy, watermark, options, system } = {}) {
+      const normalizedTable = normalizeTableName(table)
+      queryLog.push({
+        op: 'select',
+        table: normalizedTable,
+        columns,
+        limit,
+        cursor,
+        filters,
+        orderBy,
+        watermark,
+        options,
+        systemId: system && system.id,
+      })
+      const rows = cannedReadResults[normalizedTable] || []
+      const boundedRows = Number.isInteger(limit) && limit >= 0 ? rows.slice(0, limit) : rows
+      return {
+        records: boundedRows,
+        nextCursor: null,
+        done: true,
+      }
+    },
     async exec({ sql, params = [] } = {}) {
       const op = operationFromSql(sql)
       const table = tableNameFromSql(sql)
       queryLog.push({ sql, params, op, table })
       if (op === 'read') {
         throw new Error(`mock SQL: exec() rejects read operation; use query() instead`)
+      }
+      if (!WRITE_OPERATIONS.has(op)) {
+        throw new Error(`mock SQL safety: unsupported operation "${op}" on ${table || sql.slice(0, 60)} is forbidden in PoC`)
       }
       if (table && K3_CORE_TABLES.has(table)) {
         throw new Error(`mock SQL safety: ${op.toUpperCase()} on K3 core table ${table} is forbidden in PoC`)
@@ -75,6 +121,37 @@ export function createMockSqlServerExecutor({
       list.push({ sql, params })
       writes.set(table, list)
       return { rowsAffected: 1 }
+    },
+    async insertMany({ table, records = [], keyFields = [], mode, options, system } = {}) {
+      const normalizedTable = normalizeTableName(table)
+      queryLog.push({
+        op: 'insertMany',
+        table: normalizedTable,
+        records,
+        keyFields,
+        mode,
+        options,
+        systemId: system && system.id,
+      })
+      if (K3_CORE_TABLES.has(normalizedTable)) {
+        throw new Error(`mock SQL safety: INSERTMANY on K3 core table ${normalizedTable} is forbidden in PoC`)
+      }
+      if (!normalizedTable.startsWith(middleTablePrefix)) {
+        throw new Error(`mock SQL safety: INSERTMANY on non-middle table ${normalizedTable} is forbidden (prefix must be "${middleTablePrefix}")`)
+      }
+      const list = writes.get(normalizedTable) || []
+      for (const record of records) list.push({ record, keyFields, mode, options })
+      writes.set(normalizedTable, list)
+      return {
+        written: records.length,
+        failed: 0,
+        errors: [],
+        results: records.map((record, index) => ({
+          index,
+          status: 'written',
+          key: keyFields.length > 0 ? record[keyFields[0]] : undefined,
+        })),
+      }
     },
   }
 }

--- a/scripts/ops/fixtures/integration-k3wise/mock-sqlserver-executor.test.mjs
+++ b/scripts/ops/fixtures/integration-k3wise/mock-sqlserver-executor.test.mjs
@@ -1,0 +1,161 @@
+import assert from 'node:assert/strict'
+import { createRequire } from 'node:module'
+import test from 'node:test'
+
+import { createMockSqlServerExecutor } from './mock-sqlserver-executor.mjs'
+
+const require = createRequire(import.meta.url)
+const { createK3WiseSqlServerChannel } = require('../../../../plugins/plugin-integration-core/lib/adapters/k3-wise-sqlserver-channel.cjs')
+
+function createExecutor() {
+  return createMockSqlServerExecutor({
+    cannedReadResults: {
+      t_icitem: [{ FItemID: 1001, FNumber: 'MAT-EXISTING', FName: 'Existing material' }],
+    },
+  })
+}
+
+function createChannel(executor = createExecutor()) {
+  return createK3WiseSqlServerChannel({
+    system: {
+      id: 'mock-sql',
+      name: 'Mock K3 SQL',
+      kind: 'erp:k3-wise-sqlserver',
+      role: 'bidirectional',
+      config: {
+        allowedTables: ['t_ICItem', 'dbo.integration_material_stage'],
+        objects: {
+          material_stage: {
+            table: 'dbo.integration_material_stage',
+            operations: ['upsert'],
+            writeMode: 'middle-table',
+            keyField: 'FNumber',
+            schema: [{ name: 'FNumber', type: 'string', required: true }],
+          },
+        },
+      },
+    },
+    queryExecutor: executor,
+  })
+}
+
+test('mock SQL executor satisfies real channel read contract', async () => {
+  const executor = createExecutor()
+  const channel = createChannel(executor)
+  const result = await channel.read({ object: 'material', limit: 1 })
+
+  assert.equal(result.records.length, 1)
+  assert.equal(result.records[0].FNumber, 'MAT-EXISTING')
+  assert.equal(result.metadata.table, 't_ICItem')
+  assert.equal(executor.queryLog[0].op, 'select')
+  assert.equal(executor.queryLog[0].table, 't_icitem')
+})
+
+test('mock SQL executor satisfies real channel middle-table upsert contract', async () => {
+  const executor = createExecutor()
+  const channel = createChannel(executor)
+  const result = await channel.upsert({
+    object: 'material_stage',
+    records: [{ FNumber: 'MAT-MOCK-001', FName: 'Mock material' }],
+    keyFields: ['FNumber'],
+  })
+
+  assert.equal(result.written, 1)
+  assert.equal(result.failed, 0)
+  assert.equal(result.metadata.table, 'dbo.integration_material_stage')
+  assert.equal(executor.writes.get('integration_material_stage').length, 1)
+  assert.deepEqual(executor.writes.get('integration_material_stage')[0].record, {
+    FNumber: 'MAT-MOCK-001',
+    FName: 'Mock material',
+  })
+})
+
+test('real channel still rejects direct K3 core table upsert before executor write', async () => {
+  const executor = createExecutor()
+  const channel = createK3WiseSqlServerChannel({
+    system: {
+      id: 'mock-sql',
+      name: 'Mock K3 SQL',
+      kind: 'erp:k3-wise-sqlserver',
+      role: 'bidirectional',
+      config: {
+        allowedTables: ['t_ICItem'],
+        objects: {
+          material_write: {
+            table: 't_ICItem',
+            operations: ['upsert'],
+            keyField: 'FNumber',
+          },
+        },
+      },
+    },
+    queryExecutor: executor,
+  })
+
+  await assert.rejects(
+    channel.upsert({
+      object: 'material_write',
+      records: [{ FNumber: 'MAT-FORBIDDEN' }],
+      keyFields: ['FNumber'],
+    }),
+    /only writes to configured middle tables/,
+  )
+  assert.equal(executor.writes.size, 0)
+})
+
+test('mock SQL executor allows read-only CTE queries against K3 core tables', async () => {
+  const executor = createExecutor()
+  const result = await executor.query({
+    sql: 'WITH existing AS (SELECT FItemID, FNumber FROM [dbo].[t_ICItem]) SELECT * FROM existing WHERE FNumber = ?',
+    params: ['MAT-EXISTING'],
+  })
+
+  assert.equal(result.rows.length, 1)
+  assert.equal(executor.queryLog[0].op, 'read')
+  assert.equal(executor.queryLog[0].table, 't_icitem')
+})
+
+test('mock SQL executor rejects CTE-wrapped mutating queries through query()', async () => {
+  const executor = createExecutor()
+
+  await assert.rejects(
+    executor.query({
+      sql: 'WITH doomed AS (SELECT FItemID FROM dbo.t_ICItem) DELETE FROM doomed WHERE FItemID = ?',
+      params: [1001],
+    }),
+    /query\(\) rejects non-read operation "cte-write" on t_icitem/,
+  )
+})
+
+test('mock SQL executor rejects MERGE into K3 core tables', async () => {
+  const executor = createExecutor()
+
+  await assert.rejects(
+    executor.exec({
+      sql: 'MERGE INTO [dbo].[t_ICItem] AS target USING dbo.integration_material_stage AS source ON target.FNumber = source.FNumber WHEN MATCHED THEN UPDATE SET FName = source.FName;',
+    }),
+    /MERGE on K3 core table t_icitem is forbidden in PoC/,
+  )
+})
+
+test('mock SQL executor rejects unsupported operations instead of logging null-table writes', async () => {
+  const executor = createExecutor()
+
+  await assert.rejects(
+    executor.exec({ sql: 'EXEC dbo.SomeUnsafeProcedure' }),
+    /unsupported operation "unknown".*forbidden in PoC/,
+  )
+  assert.equal(executor.writes.size, 0)
+})
+
+test('mock SQL executor still allows writes to integration middle tables', async () => {
+  const executor = createExecutor()
+
+  const result = await executor.exec({
+    sql: 'INSERT INTO dbo.integration_material_stage (FNumber, FName) VALUES (?, ?)',
+    params: ['MAT-MOCK-001', 'Mock material'],
+  })
+
+  assert.equal(result.rowsAffected, 1)
+  assert.equal(executor.writes.get('integration_material_stage').length, 1)
+})

--- a/scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs
+++ b/scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs
@@ -90,7 +90,7 @@ async function main() {
         kind: 'erp:k3-wise-sqlserver',
         role: 'bidirectional',
         config: {
-          allowedTables: ['dbo.t_ICItem', 'dbo.integration_material_stage'],
+        allowedTables: ['t_ICItem', 'dbo.t_ICItem', 'dbo.integration_material_stage'],
           objects: {
             material_stage: {
               table: 'dbo.integration_material_stage',
@@ -128,13 +128,24 @@ async function main() {
     assert(auditCalls.length === 0, `expected 0 Audit calls (Save-only), got ${auditCalls.length}`)
     console.log(`✓ step 6: K3 Save-only upsert wrote 2 records, 0 Submit, 0 Audit (PoC safety preserved)`)
 
-    // 7. SQL channel readonly probe + safety check
+    // 7. SQL channel contract probes + safety check
     try {
-      sqlReadResult = await mockSql.query({ sql: 'SELECT FItemID, FNumber, FName FROM dbo.t_ICItem WHERE FNumber = ?', params: ['MAT-EXISTING'] })
-      assert(sqlReadResult.rows.length === 1, 'mock SQL readonly probe should return 1 row')
-      console.log(`✓ step 7a: SQL readonly probe returned ${sqlReadResult.rows.length} row from t_ICItem`)
+      sqlReadResult = await sqlChannel.read({ object: 'material', limit: 1 })
+      assert(sqlReadResult.records.length === 1, 'SQL channel readonly probe should return 1 row')
+      console.log(`✓ step 7a: SQL channel readonly probe returned ${sqlReadResult.records.length} row from t_ICItem`)
     } catch (error) {
-      throw new Error(`SQL readonly probe failed: ${error.message}`)
+      throw new Error(`SQL channel readonly probe failed: ${error.message}`)
+    }
+    try {
+      const middleWriteResult = await sqlChannel.upsert({
+        object: 'material_stage',
+        records: [{ FNumber: 'MAT-STAGE-001', FName: 'Mock staged material' }],
+        keyFields: ['FNumber'],
+      })
+      assert(middleWriteResult.written === 1, `expected 1 SQL middle-table write, got ${middleWriteResult.written}`)
+      console.log('✓ step 7b: SQL channel middle-table upsert wrote 1 integration row')
+    } catch (error) {
+      throw new Error(`SQL channel middle-table upsert failed: ${error.message}`)
     }
     try {
       await mockSql.exec({ sql: 'INSERT INTO dbo.t_ICItem (FNumber, FName) VALUES (?, ?)', params: ['MAT-FORBIDDEN', 'should be blocked'] })
@@ -143,7 +154,7 @@ async function main() {
       sqlWriteRejected = /core table/.test(error.message)
     }
     assert(sqlWriteRejected, 'SQL safety: write to t_ICItem must be rejected')
-    console.log('✓ step 7b: SQL safety guard rejected INSERT into t_ICItem (core table)')
+    console.log('✓ step 7c: SQL safety guard rejected INSERT into t_ICItem (core table)')
 
     // 8-9. Compose evidence + run compiler
     const evidence = {


### PR DESCRIPTION
## Summary
- make the K3 WISE SQL Server mock implement the real channel queryExecutor.select() and insertMany() contract
- update the mock PoC demo to exercise sqlChannel.read() and sqlChannel.upsert() instead of bypassing the channel with raw mock query/exec probes
- harden SQL mock safety parsing for CTE-wrapped writes, MERGE, bracket-qualified dbo tables, and unsupported operations
- wire the new SQL mock contract test into verify:integration-k3wise:poc so the K3 WISE offline PoC workflow catches this class of regression
- add development and verification notes

## Verification
- node --test scripts/ops/fixtures/integration-k3wise/mock-sqlserver-executor.test.mjs
- node scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs
- pnpm run verify:integration-k3wise:poc
- git diff --check HEAD~1..HEAD

## Notes
- prepared in /private/tmp worktree; root DingTalk edits were left untouched
- based directly on latest main, not stacked on the existing smoke/evidence PRs