### PR TITLE
fix(integration): reject secret-bearing K3 preflight URLs

### DIFF
--- a/docs/development/integration-k3wise-preflight-url-secret-guard-development-20260506.md
+++ b/docs/development/integration-k3wise-preflight-url-secret-guard-development-20260506.md
@@ -1,0 +1,48 @@
+# K3 WISE Preflight URL Secret Guard Development - 2026-05-06
+
+## Context
+
+The K3 WISE live PoC preflight packet is safe to archive only when customer
+secrets remain in credential placeholders. Existing preflight redaction covered
+secret-like object keys such as `password`, `token`, and `apiKey`, but endpoint
+URLs were only checked for syntax and protocol.
+
+That left a customer-input path where values such as these could be copied into
+the generated packet and Markdown evidence:
+
+- `k3Wise.apiUrl=https://user:password@k3.example.test/K3API/`
+- `k3Wise.apiUrl=https://k3.example.test/K3API/?token=...`
+- `plm.baseUrl=https://plm.example.test/api?api_key=...`
+
+## Change
+
+`scripts/ops/integration-k3wise-live-poc-preflight.mjs` now rejects endpoint
+URLs that contain:
+
+- inline URL username or password components
+- secret-like query parameter keys matched by the existing
+  `SECRET_KEY_PATTERN`
+
+The guard is applied to:
+
+- required `k3Wise.apiUrl`
+- optional `plm.baseUrl`
+
+Non-secret query parameters are still accepted, so customer routing metadata
+such as `?tenant=demo` remains supported.
+
+## Customer Contract
+
+Credentials must be supplied through the dedicated `credentials` objects and are
+rendered as `<set-at-runtime>` placeholders in generated packets. Endpoint URLs
+must only describe the host, path, and non-secret routing parameters.
+
+The fixture README and `gate-sample.json` comment were updated to make this
+explicit before customers fill the GATE answer template.
+
+## Files
+
+- `scripts/ops/integration-k3wise-live-poc-preflight.mjs`
+- `scripts/ops/integration-k3wise-live-poc-preflight.test.mjs`
+- `scripts/ops/fixtures/integration-k3wise/gate-sample.json`
+- `scripts/ops/fixtures/integration-k3wise/README.md`

--- a/docs/development/integration-k3wise-preflight-url-secret-guard-verification-20260506.md
+++ b/docs/development/integration-k3wise-preflight-url-secret-guard-verification-20260506.md
@@ -1,0 +1,62 @@
+# K3 WISE Preflight URL Secret Guard Verification - 2026-05-06
+
+## Local Commands
+
+```bash
+node --test scripts/ops/integration-k3wise-live-poc-preflight.test.mjs
+```
+
+Result:
+
+- 17 tests passed
+- new URL secret guard cases passed
+
+```bash
+node --input-type=module -e "import { buildPacket } from './scripts/ops/integration-k3wise-live-poc-preflight.mjs'; ..."
+```
+
+Result:
+
+- `https://user:secret-pass@k3.example.test/K3API/?token=abc123` is rejected
+- error field is `k3Wise.apiUrl`
+- error message names inline username/password credentials
+
+## Coverage Added
+
+The preflight test suite now covers:
+
+- rejecting inline username/password in `k3Wise.apiUrl`
+- rejecting secret-like query params in `k3Wise.apiUrl`
+- rejecting secret-like query params in `plm.baseUrl`
+- preserving non-secret query params in `plm.baseUrl`
+
+## Full Gate
+
+```bash
+pnpm run verify:integration-k3wise:poc
+```
+
+Result:
+
+- preflight: 17 tests passed
+- evidence: 31 tests passed
+- mock PoC demo: PASS
+
+```bash
+git diff --check origin/main..HEAD
+```
+
+Result:
+
+- passed, no whitespace errors
+
+## Notes
+
+```bash
+pnpm run verify:integration-k3wise:poc
+git diff --check origin/main..HEAD
+```
+
+The full PoC script in this branch uses the current `origin/main` package
+definition, so it runs preflight + evidence + mock demo. The SQL mock contract
+test is covered by PR #1335 and is intentionally not part of this branch.

--- a/scripts/ops/fixtures/integration-k3wise/README.md
+++ b/scripts/ops/fixtures/integration-k3wise/README.md
@@ -9,7 +9,7 @@ Fixtures and mock server for the K3 WISE Live PoC chain. Used to:
 
 | File | Purpose |
 |---|---|
-| `gate-sample.json` | Customer GATE answer template. Customer copies, fills in real values (K3 version, URLs, credentials placeholders), saves outside Git. |
+| `gate-sample.json` | Customer GATE answer template. Customer copies, fills in real values (K3 version, URLs, credentials placeholders), saves outside Git. Endpoint URLs must not include inline username/password or secret-like query params; use credential fields instead. |
 | `evidence-sample.json` | Customer-side evidence template after live PoC. Customer fills in run IDs, K3 record IDs, statuses, etc. |
 | `mock-k3-webapi-server.mjs` | Minimal in-process HTTP mock for K3 WISE WebAPI: Login / Health / Material / BOM Save / Submit / Audit. NOT a full K3 simulator. |
 | `mock-sqlserver-executor.mjs` | Mock SQL executor: read-only on K3 core tables, writeable on integration middle tables, rejects writes to `t_ICItem` / `t_ICBOM`. |

--- a/scripts/ops/fixtures/integration-k3wise/gate-sample.json
+++ b/scripts/ops/fixtures/integration-k3wise/gate-sample.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Customer GATE answer template. Copy this file outside Git, fill in real values, run: node scripts/ops/integration-k3wise-live-poc-preflight.mjs --input <path>. All fields below are accepted as: real boolean true/false, string 'true'/'false'/'yes'/'no'/'on'/'off', Chinese 是/否/启用/禁用, or numeric 0/1. Unknown values throw with the field name. Strings/numbers/Chinese for productId / runId are also accepted.",
+  "_comment": "Customer GATE answer template. Copy this file outside Git, fill in real values, run: node scripts/ops/integration-k3wise-live-poc-preflight.mjs --input <path>. All fields below are accepted as: real boolean true/false, string 'true'/'false'/'yes'/'no'/'on'/'off', Chinese 是/否/启用/禁用, or numeric 0/1. Unknown values throw with the field name. Strings/numbers/Chinese for productId / runId are also accepted. Do not put username/password/token/api_key values into k3Wise.apiUrl or plm.baseUrl; use credentials fields instead.",
   "tenantId": "tenant-test",
   "workspaceId": "workspace-test",
   "operator": "integration-admin",

--- a/scripts/ops/integration-k3wise-live-poc-preflight.mjs
+++ b/scripts/ops/integration-k3wise-live-poc-preflight.mjs
@@ -182,7 +182,24 @@ function validateUrl(value, field) {
   if (!['http:', 'https:'].includes(parsed.protocol)) {
     throw new LivePocPreflightError(`${field} must use http or https`, { field })
   }
+  if (parsed.username || parsed.password) {
+    throw new LivePocPreflightError(`${field} must not contain inline username or password credentials`, {
+      field,
+    })
+  }
+  const sensitiveQueryKeys = Array.from(parsed.searchParams.keys()).filter((key) => SECRET_KEY_PATTERN.test(key))
+  if (sensitiveQueryKeys.length > 0) {
+    throw new LivePocPreflightError(`${field} must not contain secret-like query parameters`, {
+      field,
+      queryKeys: sensitiveQueryKeys,
+    })
+  }
   return parsed.toString()
+}
+
+function optionalUrl(value, field) {
+  const text = optionalString(value)
+  return text ? validateUrl(text, field) : null
 }
 
 function assertNoSecretStrings(value, secrets, location = 'root') {
@@ -287,6 +304,7 @@ function normalizeGate(input) {
       field: 'bom.productId',
     })
   }
+  const plmBaseUrl = optionalUrl(plm.baseUrl, 'plm.baseUrl')
 
   const materialMappings = optionalArray(fieldMappings.material, 'fieldMappings.material')
   if (materialMappings.length === 0) {
@@ -324,7 +342,10 @@ function normalizeGate(input) {
       autoSubmit: false,
       autoAudit: false,
     },
-    plm,
+    plm: {
+      ...plm,
+      baseUrl: plmBaseUrl || undefined,
+    },
     sqlServer: {
       ...sqlServer,
       enabled: sqlEnabled,

--- a/scripts/ops/integration-k3wise-live-poc-preflight.test.mjs
+++ b/scripts/ops/integration-k3wise-live-poc-preflight.test.mjs
@@ -130,6 +130,47 @@ test('buildPacket rejects truthy Submit/Audit strings and invalid flag values', 
   )
 })
 
+test('buildPacket rejects inline credentials and secret query parameters in endpoint URLs', () => {
+  assert.throws(
+    () => buildPacket(gate({
+      k3Wise: { apiUrl: 'https://k3-user:k3-secret@k3.example.test/K3API/' },
+    })),
+    (error) => error instanceof LivePocPreflightError &&
+      error.details.field === 'k3Wise.apiUrl' &&
+      /inline username or password/.test(error.message),
+    'K3 API URL must not carry basic-auth credentials into the generated packet',
+  )
+
+  assert.throws(
+    () => buildPacket(gate({
+      k3Wise: { apiUrl: 'https://k3.example.test/K3API/?token=k3-secret-token' },
+    })),
+    (error) => error instanceof LivePocPreflightError &&
+      error.details.field === 'k3Wise.apiUrl' &&
+      error.details.queryKeys.includes('token'),
+    'K3 API URL must not carry token-like query parameters into the generated packet',
+  )
+
+  assert.throws(
+    () => buildPacket(gate({
+      plm: { baseUrl: 'https://plm.example.test/api?api_key=plm-secret-key' },
+    })),
+    (error) => error instanceof LivePocPreflightError &&
+      error.details.field === 'plm.baseUrl' &&
+      error.details.queryKeys.includes('api_key'),
+    'PLM base URL must not carry API-key-like query parameters into the generated packet',
+  )
+
+  const packet = buildPacket(gate({
+    plm: { baseUrl: 'https://plm.example.test/api?tenant=demo' },
+  }))
+  assert.equal(
+    packet.externalSystems.find((system) => system.kind === 'plm:yuantus-wrapper').config.baseUrl,
+    'https://plm.example.test/api?tenant=demo',
+    'non-secret query parameters remain available for customer routing metadata',
+  )
+})
+
 test('buildPacket requires K3 WISE auth keys before declaring preflight ready', () => {
   assert.throws(
     () => buildPacket(gate({ k3Wise: { credentials: {} } })),


### PR DESCRIPTION
## Summary
- Reject inline username/password credentials in K3 WISE and PLM endpoint URLs before generating live PoC packets
- Reject secret-like URL query keys such as token/api_key while preserving non-secret routing params
- Update K3 WISE GATE sample and fixture README so customers keep secrets in credentials fields

## Verification
- node --test scripts/ops/integration-k3wise-live-poc-preflight.test.mjs
- pnpm run verify:integration-k3wise:poc
- git diff --check origin/main..HEAD

## Docs
- docs/development/integration-k3wise-preflight-url-secret-guard-development-20260506.md
- docs/development/integration-k3wise-preflight-url-secret-guard-verification-20260506.md