### PR TITLE
feat(multitable): add gantt dependency arrows

### DIFF
--- a/apps/web/src/multitable/components/MetaGanttView.vue
+++ b/apps/web/src/multitable/components/MetaGanttView.vue
@@ -39,6 +39,13 @@
           </select>
         </label>
         <label class="meta-gantt__control">
+          Dependencies
+          <select :value="dependencyFieldId" @change="onConfigChange('dependencyFieldId', ($event.target as HTMLSelectElement).value || null)">
+            <option value="">none</option>
+            <option v-for="field in dependencyFields" :key="field.id" :value="field.id">{{ field.name }}</option>
+          </select>
+        </label>
+        <label class="meta-gantt__control">
           Zoom
           <select :value="zoom" @change="onConfigChange('zoom', ($event.target as HTMLSelectElement).value)">
             <option value="day">Day</option>
@@ -77,6 +84,15 @@
               <small>{{ task.startDate }} to {{ task.endDate }}</small>
             </span>
             <span class="meta-gantt__bar-area">
+              <span
+                v-for="dependency in dependencyLinksFor(task)"
+                :key="dependency.id"
+                class="meta-gantt__dependency-arrow"
+                :class="{ 'meta-gantt__dependency-arrow--backward': dependency.backward }"
+                :style="{ left: dependency.left + '%', width: dependency.width + '%' }"
+                :title="dependency.label"
+                aria-hidden="true"
+              ></span>
               <span
                 class="meta-gantt__bar"
                 :style="{ left: task.left + '%', width: task.width + '%' }"
@@ -135,6 +151,7 @@ const endFieldId = ref('')
 const titleFieldId = ref('')
 const progressFieldId = ref('')
 const groupFieldId = ref('')
+const dependencyFieldId = ref('')
 const zoom = ref<'day' | 'week' | 'month'>('week')
 const selectedRecordId = ref<string | null>(null)
 const pendingConfigKey = ref<string | null>(null)
@@ -153,6 +170,7 @@ watch(
     titleFieldId.value = config.titleFieldId ?? ''
     progressFieldId.value = config.progressFieldId ?? ''
     groupFieldId.value = config.groupFieldId ?? ''
+    dependencyFieldId.value = config.dependencyFieldId ?? ''
     zoom.value = config.zoom
     if (pendingConfigKey.value === key) pendingConfigKey.value = null
   },
@@ -163,6 +181,7 @@ const dateFields = computed(() => props.fields.filter((field) => field.type === 
 const titleFields = computed(() => props.fields)
 const numericFields = computed(() => props.fields.filter((field) => ['number', 'percent', 'currency', 'rating'].includes(field.type)))
 const groupableFields = computed(() => props.fields.filter((field) => ['select', 'string', 'boolean', 'date', 'dateTime'].includes(field.type)))
+const dependencyFields = computed(() => props.fields.filter((field) => ['link', 'multiSelect', 'string'].includes(field.type)))
 
 function parseDate(value: unknown): Date | null {
   if (!value) return null
@@ -207,7 +226,17 @@ const timeRange = computed(() => {
   return { min: min - pad, max: max + pad }
 })
 
-const scheduledTasks = computed(() => {
+type ScheduledTask = {
+  record: MetaRecord
+  startDate: string
+  endDate: string
+  left: number
+  width: number
+  progress: number
+  dependencyIds: string[]
+}
+
+const scheduledTasks = computed<ScheduledTask[]>(() => {
   if (!startFieldId.value || !endFieldId.value) return []
   const { min, max } = timeRange.value
   const range = max - min || 1
@@ -225,6 +254,7 @@ const scheduledTasks = computed(() => {
         left: Math.max(0, left),
         width: Math.min(100 - Math.max(0, left), width),
         progress: progressValue(record),
+        dependencyIds: dependencyIdsFor(record),
       }
     })
     .filter((item): item is NonNullable<typeof item> => item !== null)
@@ -246,6 +276,56 @@ const groupedSections = computed(() => {
   }
   return [...buckets.values()]
 })
+
+const scheduledTaskById = computed(() => new Map(scheduledTasks.value.map((task) => [task.record.id, task])))
+
+const dependencyLinksByRecordId = computed(() => {
+  const byId = scheduledTaskById.value
+  const links = new Map<string, Array<{ id: string; left: number; width: number; backward: boolean; label: string }>>()
+  for (const task of scheduledTasks.value) {
+    const taskLinks = task.dependencyIds
+      .map((dependencyId) => {
+        const dependency = byId.get(dependencyId)
+        if (!dependency || dependency.record.id === task.record.id) return null
+        const dependencyEnd = dependency.left + dependency.width
+        const forward = dependencyEnd <= task.left
+        const left = Math.max(0, Math.min(forward ? dependencyEnd : task.left, forward ? task.left : dependencyEnd))
+        const right = Math.min(100, Math.max(forward ? dependencyEnd : task.left, forward ? task.left : dependencyEnd))
+        return {
+          id: dependency.record.id,
+          left,
+          width: Math.max(1, right - left),
+          backward: !forward,
+          label: `${displayTitle(dependency.record)} \u2192 ${displayTitle(task.record)}`,
+        }
+      })
+      .filter((item): item is NonNullable<typeof item> => item !== null)
+    if (taskLinks.length) links.set(task.record.id, taskLinks)
+  }
+  return links
+})
+
+function normalizeDependencyIds(value: unknown): string[] {
+  const rawValues = Array.isArray(value)
+    ? value
+    : typeof value === 'string'
+      ? value.split(/[,;\n]/)
+      : value === null || value === undefined || value === ''
+        ? []
+        : [value]
+  return [...new Set(rawValues
+    .map((item) => String(item).trim())
+    .filter((item) => item.length > 0))]
+}
+
+function dependencyIdsFor(record: MetaRecord): string[] {
+  if (!dependencyFieldId.value) return []
+  return normalizeDependencyIds(record.data[dependencyFieldId.value])
+}
+
+function dependencyLinksFor(task: ScheduledTask) {
+  return dependencyLinksByRecordId.value.get(task.record.id) ?? []
+}
 
 const axisTicks = computed(() => {
   const { min, max } = timeRange.value
@@ -272,6 +352,7 @@ function currentConfig(): Required<MetaGanttViewConfig> {
     titleFieldId: titleFieldId.value || null,
     progressFieldId: progressFieldId.value || null,
     groupFieldId: groupFieldId.value || null,
+    dependencyFieldId: dependencyFieldId.value || null,
     zoom: zoom.value,
   }
 }
@@ -283,6 +364,7 @@ function onConfigChange(key: keyof Required<MetaGanttViewConfig>, value: unknown
   titleFieldId.value = next.titleFieldId ?? ''
   progressFieldId.value = next.progressFieldId ?? ''
   groupFieldId.value = next.groupFieldId ?? ''
+  dependencyFieldId.value = next.dependencyFieldId ?? ''
   zoom.value = next.zoom
   pendingConfigKey.value = JSON.stringify(next)
   emit('update-view-config', {
@@ -324,9 +406,13 @@ function onQuickCreate() {
 .meta-gantt__group { padding: 7px 12px; border-bottom: 1px solid #e2e8f0; background: #eef2ff; color: #3730a3; font-size: 12px; font-weight: 600; }
 .meta-gantt__row { display: grid; grid-template-columns: 260px 1fr; min-height: 52px; border: 0; border-bottom: 1px solid #e2e8f0; background: #fff; color: inherit; cursor: pointer; }
 .meta-gantt__row:hover, .meta-gantt__row--selected { background: #eff6ff; }
-.meta-gantt__bar-area { position: relative; margin: 12px 16px; border-radius: 999px; background: linear-gradient(90deg, rgba(203,213,225,.28) 1px, transparent 1px); background-size: 8.333% 100%; }
-.meta-gantt__bar { position: absolute; top: 7px; height: 16px; min-width: 6px; overflow: hidden; border-radius: 999px; background: #93c5fd; box-shadow: 0 4px 10px rgba(37,99,235,.18); }
+.meta-gantt__bar-area { position: relative; display: block; min-height: 40px; margin: 6px 16px; border-radius: 999px; background: linear-gradient(90deg, rgba(203,213,225,.28) 1px, transparent 1px); background-size: 8.333% 100%; }
+.meta-gantt__bar { position: absolute; top: 12px; height: 16px; min-width: 6px; overflow: hidden; border-radius: 999px; background: #93c5fd; box-shadow: 0 4px 10px rgba(37,99,235,.18); z-index: 2; }
 .meta-gantt__bar-progress { display: block; height: 100%; border-radius: inherit; background: #2563eb; }
+.meta-gantt__dependency-arrow { position: absolute; top: 20px; height: 0; border-top: 2px solid #f97316; z-index: 1; pointer-events: none; }
+.meta-gantt__dependency-arrow::after { content: ''; position: absolute; right: -1px; top: -5px; border-style: solid; border-width: 5px 0 5px 7px; border-color: transparent transparent transparent #f97316; }
+.meta-gantt__dependency-arrow--backward { border-top-style: dashed; opacity: 0.85; }
+.meta-gantt__dependency-arrow--backward::after { left: -1px; right: auto; border-width: 5px 7px 5px 0; border-color: transparent #f97316 transparent transparent; }
 .meta-gantt__unscheduled { margin: 16px; padding: 12px; border: 1px solid #e2e8f0; border-radius: 8px; background: #fff; }
 .meta-gantt__unscheduled-row { display: block; width: 100%; margin-top: 6px; padding: 6px 8px; border: 1px solid #e2e8f0; border-radius: 6px; background: #f8fafc; text-align: left; cursor: pointer; }
 </style>

--- a/apps/web/src/multitable/components/MetaViewManager.vue
+++ b/apps/web/src/multitable/components/MetaViewManager.vue
@@ -215,6 +215,15 @@
               </select>
             </label>
             <label class="meta-view-mgr__field">
+              <span>Dependency field</span>
+              <select v-model="ganttDraft.dependencyFieldId" class="meta-view-mgr__select">
+                <option value="">None</option>
+                <option v-for="field in dependencyFields" :key="field.id" :value="field.id">{{ field.name }}</option>
+              </select>
+            </label>
+          </div>
+          <div class="meta-view-mgr__grid">
+            <label class="meta-view-mgr__field">
               <span>Zoom</span>
               <select v-model="ganttDraft.zoom" class="meta-view-mgr__select">
                 <option value="day">day</option>
@@ -516,6 +525,7 @@ const ganttDraft = reactive<Required<MetaGanttViewConfig>>({
   titleFieldId: null,
   progressFieldId: null,
   groupFieldId: null,
+  dependencyFieldId: null,
   zoom: 'week',
 })
 const hierarchyDraft = reactive<Required<MetaHierarchyViewConfig>>({
@@ -553,6 +563,7 @@ const dateLikeFields = computed(() => props.fields.filter((field) => field.type 
 const numericFields = computed(() => props.fields.filter((field) => ['number', 'currency', 'percent', 'rating'].includes(field.type)))
 const selectFields = computed(() => props.fields.filter((field) => field.type === 'select'))
 const linkFields = computed(() => props.fields.filter((field) => field.type === 'link'))
+const dependencyFields = computed(() => props.fields.filter((field) => ['link', 'multiSelect', 'string'].includes(field.type)))
 const stringFields = computed(() => props.fields.filter((field) => ['string', 'formula', 'lookup'].includes(field.type)))
 const groupableFields = computed(() => props.fields.filter((field) => ['select', 'string', 'boolean', 'number', 'date', 'dateTime'].includes(field.type)))
 const validFieldIds = computed(() => new Set(props.fields.map((field) => field.id)))
@@ -562,6 +573,7 @@ const validDateFieldIds = computed(() => new Set(dateFields.value.map((field) =>
 const validDateLikeFieldIds = computed(() => new Set(dateLikeFields.value.map((field) => field.id)))
 const validSelectFieldIds = computed(() => new Set(selectFields.value.map((field) => field.id)))
 const validLinkFieldIds = computed(() => new Set(linkFields.value.map((field) => field.id)))
+const validDependencyFieldIds = computed(() => new Set(dependencyFields.value.map((field) => field.id)))
 const validGroupableFieldIds = computed(() => new Set(groupableFields.value.map((field) => field.id)))
 
 const viewConfigBlockingReason = computed(() => {
@@ -619,6 +631,9 @@ const viewConfigBlockingReason = computed(() => {
     }
     if (ganttDraft.groupFieldId && !validGroupableFieldIds.value.has(ganttDraft.groupFieldId)) {
       return 'The selected Gantt group field is no longer groupable. Reload latest before saving.'
+    }
+    if (ganttDraft.dependencyFieldId && !validDependencyFieldIds.value.has(ganttDraft.dependencyFieldId)) {
+      return 'The selected dependency field is no longer supported. Reload latest before saving.'
     }
   }
 
@@ -688,6 +703,7 @@ function resetConfigDrafts() {
     titleFieldId: null,
     progressFieldId: null,
     groupFieldId: null,
+    dependencyFieldId: null,
     zoom: 'week',
   } satisfies Required<MetaGanttViewConfig>)
   Object.assign(hierarchyDraft, {
@@ -862,6 +878,7 @@ function serializeViewDraft(type: MetaView['type'] | null): string {
       titleFieldId: ganttDraft.titleFieldId,
       progressFieldId: ganttDraft.progressFieldId,
       groupFieldId: ganttDraft.groupFieldId,
+      dependencyFieldId: ganttDraft.dependencyFieldId,
       zoom: ganttDraft.zoom,
       ...serializeCommonViewDraft(type),
     })
@@ -1126,6 +1143,7 @@ function saveConfig() {
         titleFieldId: ganttDraft.titleFieldId && validFieldIds.value.has(ganttDraft.titleFieldId) ? ganttDraft.titleFieldId : null,
         progressFieldId: ganttDraft.progressFieldId && numericFields.value.some((field) => field.id === ganttDraft.progressFieldId) ? ganttDraft.progressFieldId : null,
         groupFieldId: ganttDraft.groupFieldId && validGroupableFieldIds.value.has(ganttDraft.groupFieldId) ? ganttDraft.groupFieldId : null,
+        dependencyFieldId: ganttDraft.dependencyFieldId && validDependencyFieldIds.value.has(ganttDraft.dependencyFieldId) ? ganttDraft.dependencyFieldId : null,
         zoom: ganttDraft.zoom,
       }),
     })

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -638,6 +638,7 @@ export interface MetaGanttViewConfig {
   titleFieldId?: string | null
   progressFieldId?: string | null
   groupFieldId?: string | null
+  dependencyFieldId?: string | null
   zoom?: 'day' | 'week' | 'month'
 }
 

--- a/apps/web/src/multitable/utils/view-config.ts
+++ b/apps/web/src/multitable/utils/view-config.ts
@@ -109,9 +109,10 @@ export function resolveTimelineViewConfig(
   fields: MetaField[],
   raw?: Record<string, unknown> | null,
 ): Required<MetaTimelineViewConfig> {
-  const startFieldId = stringOrNull(raw?.startFieldId) ?? firstFieldId(fields, ['date'])
+  const dateFieldTypes = ['date', 'dateTime']
+  const startFieldId = stringOrNull(raw?.startFieldId) ?? firstFieldId(fields, dateFieldTypes)
   const endFieldId = stringOrNull(raw?.endFieldId)
-    ?? firstNonMatchingFieldId(fields, [startFieldId], ['date'])
+    ?? firstNonMatchingFieldId(fields, [startFieldId], dateFieldTypes)
     ?? startFieldId
   return {
     startFieldId,
@@ -126,9 +127,16 @@ export function resolveGanttViewConfig(
   raw?: Record<string, unknown> | null,
   groupInfo?: Record<string, unknown> | null,
 ): Required<MetaGanttViewConfig> {
-  const startFieldId = stringOrNull(raw?.startFieldId) ?? firstFieldId(fields, ['date'])
+  const dateFieldTypes = ['date', 'dateTime']
+  const dependencyFieldTypes = ['link', 'multiSelect', 'string']
+  const configuredDependencyFieldId = stringOrNull(raw?.dependencyFieldId)
+  const dependencyFieldId = configuredDependencyFieldId
+    && fields.some((field) => field.id === configuredDependencyFieldId && dependencyFieldTypes.includes(field.type))
+    ? configuredDependencyFieldId
+    : null
+  const startFieldId = stringOrNull(raw?.startFieldId) ?? firstFieldId(fields, dateFieldTypes)
   const endFieldId = stringOrNull(raw?.endFieldId)
-    ?? firstNonMatchingFieldId(fields, [startFieldId], ['date'])
+    ?? firstNonMatchingFieldId(fields, [startFieldId], dateFieldTypes)
     ?? startFieldId
   return {
     startFieldId,
@@ -136,6 +144,7 @@ export function resolveGanttViewConfig(
     titleFieldId: stringOrNull(raw?.titleFieldId) ?? firstNonMatchingFieldId(fields, [startFieldId, endFieldId], ['string']) ?? firstFieldId(fields),
     progressFieldId: stringOrNull(raw?.progressFieldId) ?? firstNonMatchingFieldId(fields, [startFieldId, endFieldId], ['number', 'percent']),
     groupFieldId: stringOrNull(raw?.groupFieldId) ?? stringOrNull(groupInfo?.fieldId),
+    dependencyFieldId,
     zoom: raw?.zoom === 'day' || raw?.zoom === 'month' ? raw.zoom : 'week',
   }
 }

--- a/apps/web/tests/multitable-gantt-view.spec.ts
+++ b/apps/web/tests/multitable-gantt-view.spec.ts
@@ -24,8 +24,26 @@ describe('MetaGanttView', () => {
       titleFieldId: 'fld_name',
       progressFieldId: 'fld_progress',
       groupFieldId: null,
+      dependencyFieldId: null,
       zoom: 'week',
     })
+  })
+
+  it('resolves and validates dependency field config', () => {
+    const fields = [
+      { id: 'fld_name', name: 'Name', type: 'string' as const },
+      { id: 'fld_start', name: 'Start', type: 'dateTime' as const },
+      { id: 'fld_end', name: 'End', type: 'dateTime' as const },
+      { id: 'fld_deps', name: 'Depends on', type: 'link' as const },
+      { id: 'fld_status', name: 'Status', type: 'select' as const },
+    ]
+
+    expect(resolveGanttViewConfig(fields, { dependencyFieldId: 'fld_deps' })).toEqual(expect.objectContaining({
+      startFieldId: 'fld_start',
+      endFieldId: 'fld_end',
+      dependencyFieldId: 'fld_deps',
+    }))
+    expect(resolveGanttViewConfig(fields, { dependencyFieldId: 'fld_status' }).dependencyFieldId).toBeNull()
   })
 
   it('renders grouped task bars and emits record selection', async () => {
@@ -82,6 +100,62 @@ describe('MetaGanttView', () => {
     await nextTick()
 
     expect(selectSpy).toHaveBeenCalledWith('rec_1')
+
+    app.unmount()
+  })
+
+  it('renders dependency arrows from the configured dependency field', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    const app = createApp({
+      render() {
+        return h(MetaGanttView, {
+          loading: false,
+          fields: [
+            { id: 'fld_name', name: 'Name', type: 'string' },
+            { id: 'fld_start', name: 'Start', type: 'date' },
+            { id: 'fld_end', name: 'End', type: 'date' },
+            { id: 'fld_deps', name: 'Depends on', type: 'link' },
+          ],
+          rows: [
+            {
+              id: 'rec_design',
+              version: 1,
+              data: {
+                fld_name: 'Design',
+                fld_start: '2026-04-01',
+                fld_end: '2026-04-03',
+              },
+            },
+            {
+              id: 'rec_build',
+              version: 1,
+              data: {
+                fld_name: 'Build',
+                fld_start: '2026-04-05',
+                fld_end: '2026-04-09',
+                fld_deps: ['rec_design'],
+              },
+            },
+          ],
+          viewConfig: {
+            startFieldId: 'fld_start',
+            endFieldId: 'fld_end',
+            titleFieldId: 'fld_name',
+            dependencyFieldId: 'fld_deps',
+          },
+        })
+      },
+    })
+
+    app.mount(container)
+    await nextTick()
+
+    const arrow = container.querySelector('.meta-gantt__dependency-arrow') as HTMLElement | null
+    expect(arrow).not.toBeNull()
+    expect(arrow?.getAttribute('title')).toBe('Design \u2192 Build')
+    expect(arrow?.getAttribute('style')).toContain('width:')
 
     app.unmount()
   })

--- a/apps/web/tests/multitable-view-manager.spec.ts
+++ b/apps/web/tests/multitable-view-manager.spec.ts
@@ -71,6 +71,70 @@ describe('MetaViewManager', () => {
     app.unmount()
   })
 
+  it('emits persisted Gantt dependency field config when saving view settings', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const updateSpy = vi.fn()
+
+    const app = createApp({
+      render() {
+        return h(MetaViewManager, {
+          visible: true,
+          sheetId: 'sheet_1',
+          activeViewId: 'view_gantt',
+          fields: [
+            { id: 'fld_name', name: 'Name', type: 'string' },
+            { id: 'fld_start', name: 'Start', type: 'date' },
+            { id: 'fld_end', name: 'End', type: 'date' },
+            { id: 'fld_deps', name: 'Depends on', type: 'link' },
+            { id: 'fld_status', name: 'Status', type: 'select' },
+          ],
+          views: [
+            {
+              id: 'view_gantt',
+              sheetId: 'sheet_1',
+              name: 'Gantt',
+              type: 'gantt',
+              config: { startFieldId: 'fld_start', endFieldId: 'fld_end', titleFieldId: 'fld_name', zoom: 'week' },
+            },
+          ],
+          onUpdateView: updateSpy,
+        })
+      },
+    })
+
+    app.mount(container)
+    await nextTick()
+
+    ;(container.querySelector('.meta-view-mgr__action[title="Configure"]') as HTMLButtonElement | null)?.click()
+    await nextTick()
+
+    const selects = Array.from(container.querySelectorAll('.meta-view-mgr__config select')) as HTMLSelectElement[]
+    expect(selects.map((select) => Array.from(select.options).map((option) => option.value))).toContainEqual(['', 'fld_name', 'fld_deps'])
+    selects[5].value = 'fld_deps'
+    selects[5].dispatchEvent(new Event('change', { bubbles: true }))
+    await nextTick()
+
+    ;(Array.from(container.querySelectorAll('.meta-view-mgr__btn-add')) as HTMLButtonElement[])
+      .find((button) => button.textContent?.includes('Save view settings'))
+      ?.click()
+    await nextTick()
+
+    expect(updateSpy).toHaveBeenCalledWith('view_gantt', {
+      config: {
+        startFieldId: 'fld_start',
+        endFieldId: 'fld_end',
+        titleFieldId: 'fld_name',
+        progressFieldId: null,
+        groupFieldId: null,
+        dependencyFieldId: 'fld_deps',
+        zoom: 'week',
+      },
+    })
+
+    app.unmount()
+  })
+
   it('emits persisted hierarchy config when saving view settings', async () => {
     const container = document.createElement('div')
     document.body.appendChild(container)

--- a/docs/development/multitable-gantt-dependencies-design-20260506.md
+++ b/docs/development/multitable-gantt-dependencies-design-20260506.md
@@ -1,0 +1,56 @@
+# Multitable Gantt Dependencies Design - 2026-05-06
+
+## Scope
+
+This slice adds an opt-in dependency display to the built-in multitable Gantt view. It is frontend-only and does not change record storage, backend schemas, migrations, or REST contracts.
+
+## Goals
+
+- Let a Gantt view persist a dependency field through `MetaGanttViewConfig.dependencyFieldId`.
+- Let users choose the dependency field from the view manager and inline Gantt toolbar.
+- Render lightweight dependency arrows between scheduled rows when the configured field references another record in the current result set.
+- Keep the feature disabled by default so existing text or select-like data is not reinterpreted as dependencies.
+
+## Data Contract
+
+`MetaGanttViewConfig` now includes:
+
+```ts
+dependencyFieldId?: string | null
+```
+
+Supported field types are:
+
+- `link`: primary intended source; values are treated as linked record ids.
+- `multiSelect`: accepted for teams that model dependency ids as controlled options.
+- `string`: accepted for comma, semicolon, or newline separated record ids.
+
+Invalid or stale `dependencyFieldId` values resolve to `null`. This mirrors the existing view-config hardening pattern and avoids saving unsupported field references.
+
+## Frontend Behavior
+
+- `resolveGanttViewConfig()` validates `dependencyFieldId` against current fields.
+- `MetaViewManager` exposes a "Dependency field" selector in Gantt configuration and blocks saving if the chosen dependency field disappears or becomes unsupported.
+- `MetaGanttView` exposes the same selector in the toolbar and emits `update-view-config` with the persisted config.
+- The Gantt renderer computes dependencies only among currently scheduled rows. Missing, unscheduled, or self-references are ignored.
+- Arrows are row-local visual hints rendered inside the dependent task row. Forward dependencies render solid orange arrows; backward dependencies render dashed arrows.
+
+## Non-Goals
+
+- No backend dependency model or validation.
+- No cross-row SVG routing, collision avoidance, or critical-path layout.
+- No automatic dependency inference from existing text fields.
+- No scheduling semantics such as auto-shifting dependent tasks.
+- No dependency editing UI beyond selecting the source field.
+
+## Implementation Notes
+
+- Date-like handling remains aligned with the recent DateTime field work: Gantt defaults and selectors accept `date` and `dateTime` fields.
+- String dependency parsing uses comma, semicolon, or newline delimiters. Whitespace-only values are ignored and duplicate ids are de-duplicated.
+- Rendering stays component-local and does not require new shared state or Pinia stores.
+
+## Follow-Ups
+
+- Add a dedicated dependency field type or structured dependency editor if users need stable dependency authoring rather than record-id entry.
+- Add full cross-row dependency routing after real internal usage shows this lightweight hint is insufficient.
+- Add backend validation only if dependencies become authoritative scheduling data.

--- a/docs/development/multitable-gantt-dependencies-verification-20260506.md
+++ b/docs/development/multitable-gantt-dependencies-verification-20260506.md
@@ -1,0 +1,50 @@
+# Multitable Gantt Dependencies Verification - 2026-05-06
+
+## Summary
+
+The Gantt dependencies slice was verified with focused frontend tests, frontend type checking, and whitespace checks. The change is frontend-only, so no backend migration or API test is required.
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+Result: pass. The worktree had no linked dependencies before verification, so install was needed to run Vitest and Vue type checking.
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-gantt-view.spec.ts tests/multitable-view-manager.spec.ts --watch=false --reporter=dot
+```
+
+Result: pass.
+
+```text
+Test Files  2 passed (2)
+Tests       20 passed (20)
+```
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+```
+
+Result: pass.
+
+```bash
+git diff --check -- apps/web/src/multitable/components/MetaGanttView.vue apps/web/src/multitable/components/MetaViewManager.vue apps/web/src/multitable/types.ts apps/web/src/multitable/utils/view-config.ts apps/web/tests/multitable-gantt-view.spec.ts apps/web/tests/multitable-view-manager.spec.ts
+```
+
+Result: pass.
+
+## Coverage Added
+
+- `resolveGanttViewConfig()` returns `dependencyFieldId: null` by default.
+- `resolveGanttViewConfig()` accepts valid dependency fields and rejects unsupported field types.
+- `MetaGanttView` renders a dependency arrow when the configured dependency field references another scheduled record.
+- `MetaViewManager` persists a selected dependency field through Gantt view settings.
+- Existing grouped Gantt rendering and toolbar config emission remain covered.
+
+## Notes
+
+- `pnpm install --frozen-lockfile` modified plugin and CLI `node_modules` symlink entries in the worktree. These are dependency-link noise only and are not part of the committed slice.
+- The renderer intentionally ignores dependencies that point to records outside the current scheduled result set.
+- This verification did not include browser visual QA; the behavior is covered at component DOM level.


### PR DESCRIPTION
## Summary
- add opt-in Gantt dependency field config and validation
- render row-local dependency arrows for scheduled records referenced by link/multiSelect/string fields
- expose dependency field selectors in the Gantt toolbar and view settings modal
- document the frontend-only design and verification evidence

## Verification
- pnpm install --frozen-lockfile
- pnpm --filter @metasheet/web exec vitest run tests/multitable-gantt-view.spec.ts tests/multitable-view-manager.spec.ts --watch=false --reporter=dot
- pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
- git diff --check -- apps/web/src/multitable/components/MetaGanttView.vue apps/web/src/multitable/components/MetaViewManager.vue apps/web/src/multitable/types.ts apps/web/src/multitable/utils/view-config.ts apps/web/tests/multitable-gantt-view.spec.ts apps/web/tests/multitable-view-manager.spec.ts

## Docs
- docs/development/multitable-gantt-dependencies-design-20260506.md
- docs/development/multitable-gantt-dependencies-verification-20260506.md