### PR TITLE
docs(multitable): mark gantt dependencies item complete

### DIFF
--- a/docs/development/multitable-feishu-rc-todo-20260430.md
+++ b/docs/development/multitable-feishu-rc-todo-20260430.md
@@ -367,7 +367,12 @@ Expected docs:
 
 These are not RC blockers.
 
-- [ ] Gantt dependencies and dependency arrows.
+- [x] Gantt dependencies and dependency arrows.
+  - PR: #1340
+  - Merge commit: `d8bbab3ca2beda2a29a8330cfaa1a4fe624b9ece`
+  - Development MD: `docs/development/multitable-gantt-dependencies-design-20260506.md`
+  - Verification MD: `docs/development/multitable-gantt-dependencies-verification-20260506.md`
+  - Verification summary: focused Gantt/ViewManager frontend tests, Vue type-check, whitespace guard, and CI passed; Strict E2E was expected skip.
 - [ ] Gantt drag resize.
 - [ ] Hierarchy drag-to-reparent.
 - [ ] Hierarchy server-side cycle prevention.


### PR DESCRIPTION
## Summary
- mark the Phase 7 Gantt dependencies item complete in the multitable Feishu RC TODO
- record PR #1340, merge commit, design doc, verification doc, and verification summary

## Verification
- git diff --check docs/development/multitable-feishu-rc-todo-20260430.md