### PR TITLE
feat(multitable): add gantt drag resize

### DIFF
--- a/apps/web/src/multitable/components/MetaGanttView.vue
+++ b/apps/web/src/multitable/components/MetaGanttView.vue
@@ -76,12 +76,12 @@
             v-for="task in section.items"
             :key="task.record.id"
             class="meta-gantt__row"
-            :class="{ 'meta-gantt__row--selected': task.record.id === selectedRecordId }"
+            :class="{ 'meta-gantt__row--selected': task.record.id === selectedRecordId, 'meta-gantt__row--resizing': task.record.id === resizingRecordId }"
             @click="selectRecord(task.record.id)"
           >
             <span class="meta-gantt__task-col">
               <strong>{{ displayTitle(task.record) }}</strong>
-              <small>{{ task.startDate }} to {{ task.endDate }}</small>
+              <small>{{ displayStartDate(task) }} to {{ displayEndDate(task) }}</small>
             </span>
             <span class="meta-gantt__bar-area">
               <span
@@ -95,9 +95,29 @@
               ></span>
               <span
                 class="meta-gantt__bar"
-                :style="{ left: task.left + '%', width: task.width + '%' }"
+                :class="{ 'meta-gantt__bar--resizable': canResizeTasks }"
+                :style="barStyle(task)"
+                :title="`${displayStartDate(task)} → ${displayEndDate(task)}`"
               >
+                <span
+                  v-if="canResizeTasks"
+                  class="meta-gantt__resize-handle meta-gantt__resize-handle--start"
+                  role="separator"
+                  aria-orientation="vertical"
+                  :aria-label="`Resize start for ${displayTitle(task.record)}`"
+                  @click.stop
+                  @mousedown.stop.prevent="onResizeStart(task, 'start', $event)"
+                ></span>
                 <span class="meta-gantt__bar-progress" :style="{ width: task.progress + '%' }"></span>
+                <span
+                  v-if="canResizeTasks"
+                  class="meta-gantt__resize-handle meta-gantt__resize-handle--end"
+                  role="separator"
+                  aria-orientation="vertical"
+                  :aria-label="`Resize end for ${displayTitle(task.record)}`"
+                  @click.stop
+                  @mousedown.stop.prevent="onResizeStart(task, 'end', $event)"
+                ></span>
               </span>
             </span>
           </button>
@@ -124,7 +144,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, ref, watch } from 'vue'
 import type { LinkedRecordSummary, MetaAttachment, MetaField, MetaGanttViewConfig, MetaRecord } from '../types'
 import { formatFieldDisplay } from '../utils/field-display'
 import { resolveGanttViewConfig } from '../utils/view-config'
@@ -134,6 +154,7 @@ const props = defineProps<{
   fields: MetaField[]
   loading: boolean
   canCreate?: boolean
+  canEdit?: boolean
   viewConfig?: Record<string, unknown> | null
   groupInfo?: Record<string, unknown> | null
   linkSummaries?: Record<string, Record<string, LinkedRecordSummary[]>>
@@ -144,6 +165,14 @@ const emit = defineEmits<{
   (e: 'select-record', recordId: string): void
   (e: 'create-record', data: Record<string, unknown>): void
   (e: 'update-view-config', input: { config: Record<string, unknown>; groupInfo?: Record<string, unknown> }): void
+  (e: 'patch-dates', payload: {
+    recordId: string
+    version: number
+    startFieldId: string
+    endFieldId: string
+    startValue: string
+    endValue: string
+  }): void
 }>()
 
 const startFieldId = ref('')
@@ -155,6 +184,21 @@ const dependencyFieldId = ref('')
 const zoom = ref<'day' | 'week' | 'month'>('week')
 const selectedRecordId = ref<string | null>(null)
 const pendingConfigKey = ref<string | null>(null)
+const resizingRecordId = ref<string | null>(null)
+
+type ResizeEdge = 'start' | 'end'
+
+const resizeState = ref<{
+  recordId: string
+  version: number
+  edge: ResizeEdge
+  axisLeft: number
+  axisWidth: number
+  originalStartMs: number
+  originalEndMs: number
+  nextStartMs: number
+  nextEndMs: number
+} | null>(null)
 
 const resolvedConfig = computed<Required<MetaGanttViewConfig>>(() =>
   resolveGanttViewConfig(props.fields, props.viewConfig, props.groupInfo),
@@ -182,6 +226,7 @@ const titleFields = computed(() => props.fields)
 const numericFields = computed(() => props.fields.filter((field) => ['number', 'percent', 'currency', 'rating'].includes(field.type)))
 const groupableFields = computed(() => props.fields.filter((field) => ['select', 'string', 'boolean', 'date', 'dateTime'].includes(field.type)))
 const dependencyFields = computed(() => props.fields.filter((field) => ['link', 'multiSelect', 'string'].includes(field.type)))
+const canResizeTasks = computed(() => Boolean(props.canEdit && startFieldId.value && endFieldId.value && startFieldId.value !== endFieldId.value))
 
 function parseDate(value: unknown): Date | null {
   if (!value) return null
@@ -223,13 +268,16 @@ const timeRange = computed(() => {
   }
   if (min === Infinity) return { min: Date.now(), max: Date.now() + 86400000 * 30 }
   const pad = (max - min) * 0.08 || 86400000
-  return { min: min - pad, max: max + pad }
+  const boundedPad = Math.max(pad, 86400000)
+  return { min: min - boundedPad, max: max + boundedPad }
 })
 
 type ScheduledTask = {
   record: MetaRecord
   startDate: string
   endDate: string
+  startMs: number
+  endMs: number
   left: number
   width: number
   progress: number
@@ -251,6 +299,8 @@ const scheduledTasks = computed<ScheduledTask[]>(() => {
         record,
         startDate: start.toISOString().slice(0, 10),
         endDate: end.toISOString().slice(0, 10),
+        startMs: start.getTime(),
+        endMs: end.getTime(),
         left: Math.max(0, left),
         width: Math.min(100 - Math.max(0, left), width),
         progress: progressValue(record),
@@ -327,6 +377,44 @@ function dependencyLinksFor(task: ScheduledTask) {
   return dependencyLinksByRecordId.value.get(task.record.id) ?? []
 }
 
+function activeTaskRange(task: ScheduledTask) {
+  if (resizeState.value?.recordId === task.record.id) {
+    return {
+      startMs: resizeState.value.nextStartMs,
+      endMs: resizeState.value.nextEndMs,
+    }
+  }
+  return {
+    startMs: task.startMs,
+    endMs: task.endMs,
+  }
+}
+
+function isoDateFromMs(timestamp: number): string {
+  return new Date(timestamp).toISOString().slice(0, 10)
+}
+
+function displayStartDate(task: ScheduledTask): string {
+  return isoDateFromMs(activeTaskRange(task).startMs)
+}
+
+function displayEndDate(task: ScheduledTask): string {
+  return isoDateFromMs(activeTaskRange(task).endMs)
+}
+
+function barStyle(task: ScheduledTask) {
+  const { min, max } = timeRange.value
+  const range = max - min || 1
+  const taskRange = activeTaskRange(task)
+  const left = ((taskRange.startMs - min) / range) * 100
+  const width = Math.max(1, ((taskRange.endMs - taskRange.startMs) / range) * 100)
+  const boundedLeft = Math.max(0, Math.min(100, left))
+  return {
+    left: boundedLeft + '%',
+    width: Math.min(100 - boundedLeft, width) + '%',
+  }
+}
+
 const axisTicks = computed(() => {
   const { min, max } = timeRange.value
   const range = max - min || 1
@@ -378,6 +466,74 @@ function selectRecord(recordId: string) {
   emit('select-record', recordId)
 }
 
+function timestampFromClientX(clientX: number): number {
+  if (!resizeState.value) return Date.now()
+  const ratio = Math.max(-0.5, Math.min(1.5, (clientX - resizeState.value.axisLeft) / resizeState.value.axisWidth))
+  const { min, max } = timeRange.value
+  return min + ratio * (max - min || 1)
+}
+
+function onResizeStart(task: ScheduledTask, edge: ResizeEdge, event: MouseEvent) {
+  if (!canResizeTasks.value) return
+  const barArea = (event.currentTarget as HTMLElement | null)?.closest('.meta-gantt__bar-area') as HTMLElement | null
+  const rect = barArea?.getBoundingClientRect()
+  if (!rect || rect.width <= 0) return
+  resizingRecordId.value = task.record.id
+  resizeState.value = {
+    recordId: task.record.id,
+    version: task.record.version,
+    edge,
+    axisLeft: rect.left,
+    axisWidth: rect.width,
+    originalStartMs: task.startMs,
+    originalEndMs: task.endMs,
+    nextStartMs: task.startMs,
+    nextEndMs: task.endMs,
+  }
+  window.addEventListener('mousemove', onResizeMove)
+  window.addEventListener('mouseup', onResizeEnd)
+}
+
+function onResizeMove(event: MouseEvent) {
+  if (!resizeState.value) return
+  const nextMs = timestampFromClientX(event.clientX)
+  if (resizeState.value.edge === 'start') {
+    resizeState.value.nextStartMs = Math.min(nextMs, resizeState.value.nextEndMs)
+  } else {
+    resizeState.value.nextEndMs = Math.max(nextMs, resizeState.value.nextStartMs)
+  }
+}
+
+function onResizeEnd() {
+  const state = resizeState.value
+  if (!state || !startFieldId.value || !endFieldId.value) {
+    cleanupResize()
+    return
+  }
+  const startValue = isoDateFromMs(state.nextStartMs)
+  const endValue = isoDateFromMs(state.nextEndMs)
+  if (startValue !== isoDateFromMs(state.originalStartMs) || endValue !== isoDateFromMs(state.originalEndMs)) {
+    emit('patch-dates', {
+      recordId: state.recordId,
+      version: state.version,
+      startFieldId: startFieldId.value,
+      endFieldId: endFieldId.value,
+      startValue,
+      endValue,
+    })
+  }
+  cleanupResize()
+}
+
+function cleanupResize() {
+  window.removeEventListener('mousemove', onResizeMove)
+  window.removeEventListener('mouseup', onResizeEnd)
+  resizingRecordId.value = null
+  resizeState.value = null
+}
+
+onBeforeUnmount(cleanupResize)
+
 function onQuickCreate() {
   const today = new Date()
   today.setHours(0, 0, 0, 0)
@@ -405,10 +561,15 @@ function onQuickCreate() {
 .meta-gantt__section { display: flex; flex-direction: column; }
 .meta-gantt__group { padding: 7px 12px; border-bottom: 1px solid #e2e8f0; background: #eef2ff; color: #3730a3; font-size: 12px; font-weight: 600; }
 .meta-gantt__row { display: grid; grid-template-columns: 260px 1fr; min-height: 52px; border: 0; border-bottom: 1px solid #e2e8f0; background: #fff; color: inherit; cursor: pointer; }
-.meta-gantt__row:hover, .meta-gantt__row--selected { background: #eff6ff; }
+.meta-gantt__row:hover, .meta-gantt__row--selected, .meta-gantt__row--resizing { background: #eff6ff; }
 .meta-gantt__bar-area { position: relative; display: block; min-height: 40px; margin: 6px 16px; border-radius: 999px; background: linear-gradient(90deg, rgba(203,213,225,.28) 1px, transparent 1px); background-size: 8.333% 100%; }
 .meta-gantt__bar { position: absolute; top: 12px; height: 16px; min-width: 6px; overflow: hidden; border-radius: 999px; background: #93c5fd; box-shadow: 0 4px 10px rgba(37,99,235,.18); z-index: 2; }
+.meta-gantt__bar--resizable { cursor: ew-resize; }
 .meta-gantt__bar-progress { display: block; height: 100%; border-radius: inherit; background: #2563eb; }
+.meta-gantt__resize-handle { position: absolute; top: 0; bottom: 0; width: 10px; z-index: 3; cursor: ew-resize; background: rgba(15,23,42,.12); opacity: 0; transition: opacity .12s ease; }
+.meta-gantt__bar:hover .meta-gantt__resize-handle, .meta-gantt__row--resizing .meta-gantt__resize-handle { opacity: 1; }
+.meta-gantt__resize-handle--start { left: 0; border-radius: 999px 0 0 999px; }
+.meta-gantt__resize-handle--end { right: 0; border-radius: 0 999px 999px 0; }
 .meta-gantt__dependency-arrow { position: absolute; top: 20px; height: 0; border-top: 2px solid #f97316; z-index: 1; pointer-events: none; }
 .meta-gantt__dependency-arrow::after { content: ''; position: absolute; right: -1px; top: -5px; border-style: solid; border-width: 5px 0 5px 7px; border-color: transparent transparent transparent #f97316; }
 .meta-gantt__dependency-arrow--backward { border-top-style: dashed; opacity: 0.85; }

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -175,8 +175,9 @@
           :view-config="workbench.activeView.value?.config"
           :group-info="workbench.activeView.value?.groupInfo"
           :link-summaries="grid.linkSummaries.value" :attachment-summaries="grid.attachmentSummaries.value"
-          :can-create="caps.canCreateRecord.value"
+          :can-create="caps.canCreateRecord.value" :can-edit="effectiveRowActions.canEdit"
           @select-record="onSelectRecord" @create-record="onKanbanCreateRecord"
+          @patch-dates="onTimelinePatchDates"
           @update-view-config="onPersistActiveViewConfig"
         />
         <MetaHierarchyView
@@ -1238,7 +1239,7 @@ async function onTimelinePatchDates(payload: {
     if (selectedRecordId.value === payload.recordId) {
       await resolveDeepLink(payload.recordId)
     }
-    showSuccess('Timeline updated')
+    showSuccess('Dates updated')
   } catch (error: any) {
     showError(error?.message ?? 'Failed to update timeline dates')
   }

--- a/apps/web/tests/multitable-gantt-view.spec.ts
+++ b/apps/web/tests/multitable-gantt-view.spec.ts
@@ -160,6 +160,113 @@ describe('MetaGanttView', () => {
     app.unmount()
   })
 
+  it('emits patch-dates when resizing a task end handle', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const patchSpy = vi.fn()
+
+    const app = createApp({
+      render() {
+        return h(MetaGanttView, {
+          loading: false,
+          canEdit: true,
+          fields: [
+            { id: 'fld_name', name: 'Name', type: 'string' },
+            { id: 'fld_start', name: 'Start', type: 'date' },
+            { id: 'fld_end', name: 'End', type: 'date' },
+          ],
+          rows: [
+            {
+              id: 'rec_build',
+              version: 7,
+              data: {
+                fld_name: 'Build',
+                fld_start: '2026-04-01',
+                fld_end: '2026-04-03',
+              },
+            },
+          ],
+          viewConfig: {
+            startFieldId: 'fld_start',
+            endFieldId: 'fld_end',
+            titleFieldId: 'fld_name',
+          },
+          onPatchDates: patchSpy,
+        })
+      },
+    })
+
+    app.mount(container)
+    await nextTick()
+
+    const barArea = container.querySelector('.meta-gantt__bar-area') as HTMLElement | null
+    const endHandle = container.querySelector('.meta-gantt__resize-handle--end') as HTMLElement | null
+    expect(barArea).not.toBeNull()
+    expect(endHandle).not.toBeNull()
+
+    Object.defineProperty(barArea!, 'getBoundingClientRect', {
+      value: () => ({ left: 0, width: 300, top: 0, height: 40, right: 300, bottom: 40 }),
+    })
+
+    endHandle?.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, clientX: 150 }))
+    window.dispatchEvent(new MouseEvent('mousemove', { bubbles: true, clientX: 300 }))
+    window.dispatchEvent(new MouseEvent('mouseup', { bubbles: true, clientX: 300 }))
+    await nextTick()
+
+    expect(patchSpy).toHaveBeenCalledWith({
+      recordId: 'rec_build',
+      version: 7,
+      startFieldId: 'fld_start',
+      endFieldId: 'fld_end',
+      startValue: '2026-04-01',
+      endValue: '2026-04-04',
+    })
+
+    app.unmount()
+  })
+
+  it('does not expose resize handles for read-only Gantt tasks', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    const app = createApp({
+      render() {
+        return h(MetaGanttView, {
+          loading: false,
+          canEdit: false,
+          fields: [
+            { id: 'fld_name', name: 'Name', type: 'string' },
+            { id: 'fld_start', name: 'Start', type: 'date' },
+            { id: 'fld_end', name: 'End', type: 'date' },
+          ],
+          rows: [
+            {
+              id: 'rec_build',
+              version: 1,
+              data: {
+                fld_name: 'Build',
+                fld_start: '2026-04-01',
+                fld_end: '2026-04-03',
+              },
+            },
+          ],
+          viewConfig: {
+            startFieldId: 'fld_start',
+            endFieldId: 'fld_end',
+            titleFieldId: 'fld_name',
+          },
+        })
+      },
+    })
+
+    app.mount(container)
+    await nextTick()
+
+    expect(container.querySelector('.meta-gantt__resize-handle')).toBeNull()
+
+    app.unmount()
+  })
+
   it('emits persisted Gantt config and groupInfo from toolbar changes', async () => {
     const container = document.createElement('div')
     document.body.appendChild(container)

--- a/apps/web/tests/multitable-workbench-view.spec.ts
+++ b/apps/web/tests/multitable-workbench-view.spec.ts
@@ -695,6 +695,36 @@ vi.mock('../src/multitable/components/MetaTimelineView.vue', () => ({
     },
   }),
 }))
+vi.mock('../src/multitable/components/MetaGanttView.vue', () => ({
+  default: defineComponent({
+    name: 'MetaGanttView',
+    props: {
+      canEdit: { type: Boolean, default: false },
+    },
+    emits: ['patch-dates'],
+    render() {
+      return h('div', {
+        'data-gantt-can-edit': String(this.$props.canEdit),
+      }, [
+        h(
+          'button',
+          {
+            'data-gantt-patch': 'true',
+            onClick: () => this.$emit('patch-dates', {
+              recordId: 'rec_1',
+              version: 4,
+              startFieldId: 'fld_start',
+              endFieldId: 'fld_end',
+              startValue: '2026-04-01',
+              endValue: '2026-04-04',
+            }),
+          },
+          'gantt-patch',
+        ),
+      ])
+    },
+  }),
+}))
 vi.mock('../src/multitable/components/MetaImportModal.vue', () => ({
   default: defineComponent({
     name: 'MetaImportModal',
@@ -1712,10 +1742,11 @@ describe('MultitableWorkbench view wiring', () => {
     expect(gridMock.loadViewData).toHaveBeenCalled()
   })
 
-  it('passes scoped row edit gating into kanban and timeline views', async () => {
+  it('passes scoped row edit gating into kanban, timeline and gantt views', async () => {
     workbenchMock.views.value = [
       { id: 'view_kanban', sheetId: 'sheet_orders', name: 'Kanban', type: 'kanban' },
       { id: 'view_timeline', sheetId: 'sheet_orders', name: 'Timeline', type: 'timeline', config: { zoom: 'week' } },
+      { id: 'view_gantt', sheetId: 'sheet_orders', name: 'Gantt', type: 'gantt', config: { zoom: 'week' } },
     ]
     gridMock.rowActions.value = {
       canEdit: false,
@@ -1732,6 +1763,11 @@ describe('MultitableWorkbench view wiring', () => {
     await flushUi()
 
     expect(container!.querySelector('[data-timeline-can-edit]')?.getAttribute('data-timeline-can-edit')).toBe('false')
+
+    workbenchMock.activeViewId.value = 'view_gantt'
+    await flushUi()
+
+    expect(container!.querySelector('[data-gantt-can-edit]')?.getAttribute('data-gantt-can-edit')).toBe('false')
   })
 
   it('patches timeline date updates through patchRecords and refreshes the active page', async () => {
@@ -1750,7 +1786,31 @@ describe('MultitableWorkbench view wiring', () => {
       ],
     })
     expect(gridMock.loadViewData).toHaveBeenCalled()
-    expect(showSuccessSpy).toHaveBeenCalledWith('Timeline updated')
+    expect(showSuccessSpy).toHaveBeenCalledWith('Dates updated')
+  })
+
+  it('patches gantt resize date updates through patchRecords and refreshes the active page', async () => {
+    workbenchMock.views.value = [
+      ...workbenchMock.views.value,
+      { id: 'view_gantt', sheetId: 'sheet_orders', name: 'Gantt', type: 'gantt', config: { zoom: 'week' } },
+    ]
+
+    mountWorkbench({ viewId: 'view_gantt' })
+    await flushUi()
+
+    container!.querySelector<HTMLButtonElement>('[data-gantt-patch="true"]')!.click()
+    await flushUi()
+
+    expect(workbenchMock.client.patchRecords).toHaveBeenCalledWith({
+      sheetId: 'sheet_orders',
+      viewId: 'view_gantt',
+      changes: [
+        { recordId: 'rec_1', fieldId: 'fld_start', value: '2026-04-01', expectedVersion: 4 },
+        { recordId: 'rec_1', fieldId: 'fld_end', value: '2026-04-04', expectedVersion: 4 },
+      ],
+    })
+    expect(gridMock.loadViewData).toHaveBeenCalled()
+    expect(showSuccessSpy).toHaveBeenCalledWith('Dates updated')
   })
 
   it('blocks timeline patch updates when scoped rowActions disallow edits', async () => {

--- a/docs/development/multitable-gantt-drag-resize-design-20260506.md
+++ b/docs/development/multitable-gantt-drag-resize-design-20260506.md
@@ -1,0 +1,58 @@
+# Multitable Gantt Drag Resize Design - 2026-05-06
+
+## Scope
+
+This slice adds interactive start/end resizing to the built-in multitable Gantt view. It is a frontend integration over the existing authoritative `patchRecords` write path and does not add backend routes, migrations, or new record semantics.
+
+## Goals
+
+- Show resize handles on Gantt task bars when the current row is editable.
+- Let users drag the left edge to update the start field and the right edge to update the end field.
+- Persist the resized dates through the same `patch-dates` payload shape already used by Timeline.
+- Reuse the existing `RecordWriteService` backed `patchRecords` path from `MultitableWorkbench`.
+- Keep read-only users from seeing resize handles or emitting writes.
+
+## Interaction Model
+
+- Resize is enabled only when:
+  - `canEdit` is true.
+  - both `startFieldId` and `endFieldId` are configured.
+  - start and end use different fields.
+- Each bar renders two edge handles with accessible separator labels.
+- Dragging updates an in-component preview for the active bar.
+- Releasing the mouse emits:
+
+```ts
+{
+  recordId: string
+  version: number
+  startFieldId: string
+  endFieldId: string
+  startValue: string
+  endValue: string
+}
+```
+
+`MultitableWorkbench` wires this to the same handler as Timeline, which sends two expected-version guarded changes through `patchRecords`.
+
+## Date Semantics
+
+- The Gantt view remains day-granularity.
+- Resized values are emitted as ISO `YYYY-MM-DD` strings.
+- Date conversion uses UTC ISO slicing to avoid local-time off-by-one regressions.
+- The Gantt axis now keeps at least one day of visual padding around the scheduled range so edge resizing has usable space even for short tasks.
+
+## Non-Goals
+
+- No whole-bar drag/move operation.
+- No dependency-aware auto-shifting.
+- No server-side scheduling model.
+- No multi-record batch resize.
+- No keyboard resize control in this slice.
+
+## Risk Controls
+
+- Resize handles are hidden for read-only rows.
+- The component does not emit if the final date range is unchanged.
+- The workbench still gates writes through `ensureCanEditRecord()`.
+- Existing optimistic conflict behavior is preserved through `expectedVersion`.

--- a/docs/development/multitable-gantt-drag-resize-verification-20260506.md
+++ b/docs/development/multitable-gantt-drag-resize-verification-20260506.md
@@ -1,0 +1,53 @@
+# Multitable Gantt Drag Resize Verification - 2026-05-06
+
+## Summary
+
+The Gantt drag-resize slice was verified with focused component tests, workbench wiring tests, Vue type checking, and whitespace checks.
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+Result: pass. The isolated worktree had no linked dependencies before verification.
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-gantt-view.spec.ts tests/multitable-workbench-view.spec.ts --watch=false --reporter=dot
+```
+
+Result: pass.
+
+```text
+Test Files  2 passed (2)
+Tests       55 passed (55)
+```
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+```
+
+Result: pass.
+
+```bash
+git diff --check -- apps/web/src/multitable/components/MetaGanttView.vue apps/web/src/multitable/views/MultitableWorkbench.vue apps/web/tests/multitable-gantt-view.spec.ts apps/web/tests/multitable-workbench-view.spec.ts
+```
+
+Result: pass.
+
+## Coverage Added
+
+- Gantt end-handle resize emits `patch-dates` with record id, version, start/end field ids, and ISO date values.
+- Read-only Gantt tasks do not expose resize handles.
+- Workbench passes scoped edit gating into Gantt.
+- Workbench routes Gantt resize updates through `patchRecords`, refreshes the active page, and reports success.
+- Existing Gantt config, grouping, dependency arrow, and Workbench Timeline patch tests remain green.
+
+## Regression Found And Fixed
+
+During test development, the first resize assertion exposed a local-time off-by-one conversion risk. The implementation now emits dates with UTC ISO slicing instead of local `setHours(0, 0, 0, 0)` normalization.
+
+## Notes
+
+- `pnpm install --frozen-lockfile` modified plugin and CLI `node_modules` symlink entries in the worktree. These are dependency-link noise only and are not part of the committed slice.
+- Browser visual QA was not run in this slice; behavior is covered at DOM-event and workbench-wiring level.


### PR DESCRIPTION
## Summary
- add left/right resize handles to editable Gantt task bars
- emit Gantt resize updates through the existing patch-dates payload and workbench patchRecords path
- hide resize affordances for read-only rows and same-field start/end configs
- document design and verification evidence

## Verification
- pnpm install --frozen-lockfile
- pnpm --filter @metasheet/web exec vitest run tests/multitable-gantt-view.spec.ts tests/multitable-workbench-view.spec.ts --watch=false --reporter=dot
- pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
- git diff --check -- apps/web/src/multitable/components/MetaGanttView.vue apps/web/src/multitable/views/MultitableWorkbench.vue apps/web/tests/multitable-gantt-view.spec.ts apps/web/tests/multitable-workbench-view.spec.ts

## Docs
- docs/development/multitable-gantt-drag-resize-design-20260506.md
- docs/development/multitable-gantt-drag-resize-verification-20260506.md