### PR TITLE
fix(integration): hydrate saved K3 setup booleans

### DIFF
--- a/apps/web/src/services/integration/k3WiseSetup.ts
+++ b/apps/web/src/services/integration/k3WiseSetup.ts
@@ -253,6 +253,23 @@ function parseOptionalPositiveInteger(value: string): number | undefined {
   return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined
 }
 
+const BOOLEAN_TRUE_TEXT = new Set(['true', '1', 'yes', 'y', 'on', 'enable', 'enabled', '是', '启用', '开启'])
+const BOOLEAN_FALSE_TEXT = new Set(['false', '0', 'no', 'n', 'off', 'disable', 'disabled', '否', '禁用', '关闭'])
+
+function normalizeSavedBoolean(value: unknown): boolean {
+  if (value === true || value === false) return value
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    if (value === 1) return true
+    if (value === 0) return false
+  }
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase()
+    if (BOOLEAN_TRUE_TEXT.has(normalized)) return true
+    if (BOOLEAN_FALSE_TEXT.has(normalized)) return false
+  }
+  return false
+}
+
 function assertRelativePath(value: string, field: keyof K3WiseSetupForm, issues: K3WiseSetupValidationIssue[]): void {
   const normalized = trim(value)
   if (!normalized) {
@@ -815,8 +832,8 @@ export function applyExternalSystemToForm(form: K3WiseSetupForm, system: Integra
     next.healthPath = typeof config.healthPath === 'string' ? config.healthPath : next.healthPath
     next.lcid = config.lcid === undefined ? next.lcid : String(config.lcid)
     next.timeoutMs = config.timeoutMs === undefined ? next.timeoutMs : String(config.timeoutMs)
-    next.autoSubmit = config.autoSubmit === true
-    next.autoAudit = config.autoAudit === true
+    next.autoSubmit = normalizeSavedBoolean(config.autoSubmit)
+    next.autoAudit = normalizeSavedBoolean(config.autoAudit)
     next.materialSavePath = typeof material.savePath === 'string' ? material.savePath : next.materialSavePath
     next.materialSubmitPath = typeof material.submitPath === 'string' ? material.submitPath : next.materialSubmitPath
     next.materialAuditPath = typeof material.auditPath === 'string' ? material.auditPath : next.materialAuditPath

--- a/apps/web/tests/k3WiseSetup.spec.ts
+++ b/apps/web/tests/k3WiseSetup.spec.ts
@@ -124,6 +124,60 @@ describe('K3 WISE setup helpers', () => {
     expect(next.password).toBe('')
   })
 
+  it('normalizes saved K3 WISE auto-submit flags from string, numeric, and Chinese variants', () => {
+    const form = createDefaultK3WiseSetupForm()
+    Object.assign(form, {
+      autoSubmit: false,
+      autoAudit: true,
+    })
+    const system: IntegrationExternalSystem = {
+      id: 'sys_1',
+      tenantId: 'tenant_1',
+      workspaceId: null,
+      name: 'K3 loaded',
+      kind: 'erp:k3-wise-webapi',
+      role: 'target',
+      status: 'active',
+      config: {
+        autoSubmit: '是',
+        autoAudit: 0,
+      },
+      capabilities: {},
+    }
+
+    const next = applyExternalSystemToForm(form, system)
+
+    expect(next.autoSubmit).toBe(true)
+    expect(next.autoAudit).toBe(false)
+  })
+
+  it('clears K3 WISE auto-submit flags when saved config contains unknown values', () => {
+    const form = createDefaultK3WiseSetupForm()
+    Object.assign(form, {
+      autoSubmit: true,
+      autoAudit: false,
+    })
+    const system: IntegrationExternalSystem = {
+      id: 'sys_1',
+      tenantId: 'tenant_1',
+      workspaceId: null,
+      name: 'K3 loaded',
+      kind: 'erp:k3-wise-webapi',
+      role: 'target',
+      status: 'active',
+      config: {
+        autoSubmit: 'maybe',
+        autoAudit: {},
+      },
+      capabilities: {},
+    }
+
+    const next = applyExternalSystemToForm(form, system)
+
+    expect(next.autoSubmit).toBe(false)
+    expect(next.autoAudit).toBe(false)
+  })
+
   it('validates absolute endpoint paths and incomplete credential replacement', () => {
     const form = createDefaultK3WiseSetupForm()
     Object.assign(form, {

--- a/docs/development/integration-k3wise-setup-bool-hydration-development-20260506.md
+++ b/docs/development/integration-k3wise-setup-bool-hydration-development-20260506.md
@@ -1,0 +1,49 @@
+# K3 WISE Setup Boolean Hydration Development - 2026-05-06
+
+## Context
+
+The K3 WISE setup page hydrates saved external-system config back into the
+operator form. Backend and script-side K3 WISE hardening already accept boolean
+variants such as `"true"`, `"false"`, numeric `0`/`1`, and common Chinese
+operator inputs.
+
+The setup form only restored `autoSubmit` and `autoAudit` when the saved value
+was the literal boolean `true`. Saved config imported from older rows, fixtures,
+or hand-edited JSON could contain `"true"`, `1`, or `是`; the page would display
+those as unchecked.
+
+## Change
+
+`apps/web/src/services/integration/k3WiseSetup.ts` now normalizes saved
+`autoSubmit` / `autoAudit` values when applying an external system to the setup
+form.
+
+Accepted true variants:
+
+- `true`
+- `1`
+- `"true"`, `"1"`, `"yes"`, `"y"`, `"on"`, `"enable"`, `"enabled"`
+- `"是"`, `"启用"`, `"开启"`
+
+Accepted false variants:
+
+- `false`
+- `0`
+- `"false"`, `"0"`, `"no"`, `"n"`, `"off"`, `"disable"`, `"disabled"`
+- `"否"`, `"禁用"`, `"关闭"`
+
+Unknown, missing, object, array, and non-`0/1` numeric values hydrate to
+`false`. This keeps the UI safety-biased and prevents a truthy checkbox from a
+previously selected system leaking into the newly loaded system.
+
+## Files
+
+- `apps/web/src/services/integration/k3WiseSetup.ts`
+- `apps/web/tests/k3WiseSetup.spec.ts`
+
+## Non-Goals
+
+- This does not change how new K3 WISE setup payloads are saved.
+- This does not make the test button evaluate unsaved draft fields. The current
+  API still tests the persisted external-system row; that is tracked as a
+  separate UX/contract hardening candidate.

--- a/docs/development/integration-k3wise-setup-bool-hydration-verification-20260506.md
+++ b/docs/development/integration-k3wise-setup-bool-hydration-verification-20260506.md
@@ -1,0 +1,34 @@
+# K3 WISE Setup Boolean Hydration Verification - 2026-05-06
+
+## Scope
+
+This verifies that the K3 WISE setup helper accurately hydrates saved
+`autoSubmit` / `autoAudit` variants into the frontend form.
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/web exec vitest run --watch=false tests/k3WiseSetup.spec.ts
+```
+
+Result: pass.
+
+```text
+Test Files  1 passed (1)
+Tests       21 passed (21)
+```
+
+## Coverage Added
+
+- Saved `autoSubmit: "是"` hydrates to checked.
+- Saved `autoAudit: 0` hydrates to unchecked.
+- Unknown values such as `"maybe"` and objects hydrate to unchecked, even when
+  the previous form value was checked.
+
+## Environment Note
+
+The temporary worktree initially had no local `node_modules`, so the first
+Vitest attempt could not resolve the workspace test runner. A local
+`pnpm install --frozen-lockfile --offline` in `/private/tmp` created dependency
+links from the existing store; dependency-link side effects were reverted before
+authoring the PR.


### PR DESCRIPTION
## Summary

- Normalize saved K3 WISE `autoSubmit` / `autoAudit` values when hydrating external-system config into the setup page.
- Accept backend-compatible variants such as `"true"`, `1`, and Chinese operator values like `是` / `否`.
- Default unknown or malformed saved values to unchecked so a previous system's enabled flag cannot leak into the currently selected system.

## Verification

- `pnpm --filter @metasheet/web exec vitest run --watch=false tests/k3WiseSetup.spec.ts`
- `pnpm --filter @metasheet/web type-check`
- `git diff --check`

## Docs

- `docs/development/integration-k3wise-setup-bool-hydration-development-20260506.md`
- `docs/development/integration-k3wise-setup-bool-hydration-verification-20260506.md`
