### PR TITLE
fix(integration): guard K3 summary auth signoff

### DIFF
--- a/docs/development/integration-k3wise-summary-auth-signoff-guard-development-20260506.md
+++ b/docs/development/integration-k3wise-summary-auth-signoff-guard-development-20260506.md
@@ -1,0 +1,46 @@
+# K3 WISE Summary Auth Signoff Guard Development - 2026-05-06
+
+## Context
+
+`integration-k3wise-postdeploy-summary.mjs` renders the GitHub Step Summary for
+K3 WISE postdeploy smoke evidence. With `--require-auth-signoff`, operators use
+that summary as the internal-trial signoff surface.
+
+The runbook requires all authenticated signoff evidence to satisfy:
+
+- `ok=true`
+- `authenticated=true`
+- `signoff.internalTrial=pass`
+
+The summary renderer trusted an explicit `signoff.internalTrial=pass` before
+checking `ok` and `authenticated`. A stale, hand-edited, or older contradictory
+evidence artifact could therefore display internal trial `PASS` even when
+authenticated checks did not run or the smoke itself failed.
+
+## Change
+
+`inferInternalTrialSignoff()` now accepts explicit
+`signoff.internalTrial=pass` only when the evidence also has:
+
+- `ok === true`
+- `authenticated === true`
+
+Contradictory evidence is rendered as blocked:
+
+- `authenticated !== true` -> `authenticated checks did not run`
+- `ok !== true` -> `one or more smoke checks failed`
+
+This keeps the summary renderer aligned with the internal trial runbook and the
+smoke generator's intended signoff contract.
+
+## Files
+
+- `scripts/ops/integration-k3wise-postdeploy-summary.mjs`
+- `scripts/ops/integration-k3wise-postdeploy-summary.test.mjs`
+
+## Non-Goals
+
+- This does not change smoke evidence generation.
+- This does not fail the summary renderer process. The renderer still exits
+  successfully after displaying a blocked signoff, so deploy summaries remain
+  available for diagnosis.

--- a/docs/development/integration-k3wise-summary-auth-signoff-guard-verification-20260506.md
+++ b/docs/development/integration-k3wise-summary-auth-signoff-guard-verification-20260506.md
@@ -1,0 +1,34 @@
+# K3 WISE Summary Auth Signoff Guard Verification - 2026-05-06
+
+## Scope
+
+This verifies that K3 WISE postdeploy summary rendering cannot display internal
+trial `PASS` from contradictory evidence.
+
+## Commands
+
+```bash
+node --test scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
+```
+
+Result: pass.
+
+```text
+tests 11
+pass 11
+fail 0
+```
+
+## Coverage Added
+
+- `signoff.internalTrial=pass` with `authenticated=false` renders
+  `Internal trial signoff: BLOCKED`.
+- `signoff.internalTrial=pass` with `ok=false` renders
+  `Internal trial signoff: BLOCKED`.
+- Valid authenticated PASS evidence still renders PASS.
+
+## Expected Operator Behavior
+
+When the evidence is contradictory, GitHub Step Summary remains readable but
+cannot be used as internal-trial approval. Operators must rerun the authenticated
+postdeploy smoke and preserve the fresh evidence artifact.

--- a/scripts/ops/integration-k3wise-postdeploy-summary.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-summary.mjs
@@ -88,6 +88,12 @@ function renderMissingSummary(inputPath, { requireAuthSignoff = false } = {}) {
 
 function inferInternalTrialSignoff(evidence) {
   if (evidence?.signoff?.internalTrial === 'pass') {
+    if (!evidence?.ok) {
+      return { status: 'BLOCKED', reason: 'one or more smoke checks failed' }
+    }
+    if (!evidence?.authenticated) {
+      return { status: 'BLOCKED', reason: 'authenticated checks did not run' }
+    }
     return { status: 'PASS', reason: evidence.signoff.reason || 'authenticated smoke passed' }
   }
   if (evidence?.signoff?.internalTrial === 'blocked') {

--- a/scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
@@ -129,6 +129,66 @@ test('renders passing internal signoff for authenticated smoke evidence', async 
   }
 })
 
+test('blocks contradictory explicit pass signoff when authenticated checks did not run', async () => {
+  const outDir = makeTmpDir()
+  const evidencePath = path.join(outDir, 'evidence.json')
+  try {
+    writeFileSync(evidencePath, `${JSON.stringify({
+      ok: true,
+      baseUrl: 'http://127.0.0.1:8081',
+      authenticated: false,
+      signoff: {
+        internalTrial: 'pass',
+        reason: 'authenticated smoke passed',
+      },
+      summary: { pass: 3, skipped: 1, fail: 0 },
+      checks: [
+        { id: 'api-health', status: 'pass' },
+        { id: 'authenticated-integration-contract', status: 'skipped' },
+      ],
+    })}\n`)
+
+    const result = await runScript(['--input', evidencePath, '--require-auth-signoff'])
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stdout, /Internal trial signoff: \*\*BLOCKED\*\*/)
+    assert.match(result.stdout, /Signoff reason: authenticated checks did not run/)
+    assert.doesNotMatch(result.stdout, /Internal trial signoff: \*\*PASS\*\*/)
+  } finally {
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('blocks contradictory explicit pass signoff when smoke status failed', async () => {
+  const outDir = makeTmpDir()
+  const evidencePath = path.join(outDir, 'evidence.json')
+  try {
+    writeFileSync(evidencePath, `${JSON.stringify({
+      ok: false,
+      baseUrl: 'http://127.0.0.1:8081',
+      authenticated: true,
+      signoff: {
+        internalTrial: 'pass',
+        reason: 'authenticated smoke passed',
+      },
+      summary: { pass: 3, skipped: 0, fail: 1 },
+      checks: [
+        { id: 'auth-me', status: 'pass' },
+        { id: 'integration-route-contract', status: 'fail' },
+      ],
+    })}\n`)
+
+    const result = await runScript(['--input', evidencePath, '--require-auth-signoff'])
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stdout, /Internal trial signoff: \*\*BLOCKED\*\*/)
+    assert.match(result.stdout, /Signoff reason: one or more smoke checks failed/)
+    assert.doesNotMatch(result.stdout, /Internal trial signoff: \*\*PASS\*\*/)
+  } finally {
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
 test('renders fail summary without failing the summary renderer', async () => {
   const outDir = makeTmpDir()
   const evidencePath = path.join(outDir, 'evidence.json')


### PR DESCRIPTION
## Summary

- Require K3 WISE summary-rendered internal trial PASS to have both `ok=true` and `authenticated=true`.
- Treat contradictory explicit `signoff.internalTrial=pass` evidence as blocked if authenticated checks did not run or the smoke failed.
- Add regression tests and development/verification docs for the summary signoff guard.

## Verification

- `node --test scripts/ops/integration-k3wise-postdeploy-summary.test.mjs`
- `git diff --check`

## Docs

- `docs/development/integration-k3wise-summary-auth-signoff-guard-development-20260506.md`
- `docs/development/integration-k3wise-summary-auth-signoff-guard-verification-20260506.md`
