### PR TITLE
feat(multitable): add hierarchy drag reparent

### DIFF
--- a/apps/web/src/multitable/components/MetaHierarchyView.vue
+++ b/apps/web/src/multitable/components/MetaHierarchyView.vue
@@ -44,6 +44,16 @@
       <div v-if="treeDiagnostics.length" class="meta-hierarchy__notice" role="status">
         {{ treeDiagnostics.join(' ') }}
       </div>
+      <div
+        v-if="canEdit && draggingRecordId"
+        class="meta-hierarchy__root-drop"
+        role="button"
+        tabindex="0"
+        @dragover.prevent
+        @drop.prevent="onDropToRoot"
+      >
+        Drop here to move to root
+      </div>
       <ul v-if="visibleRoots.length" class="meta-hierarchy__list meta-hierarchy__list--root">
         <HierarchyNode
           v-for="node in visibleRoots"
@@ -52,12 +62,17 @@
           :expanded-ids="expandedIds"
           :title-for-row="titleForRow"
           :can-create="canCreate"
+          :can-edit="canEdit"
           :can-comment="canComment"
+          :dragging-record-id="draggingRecordId"
           :comment-presence="commentPresence"
           @toggle="toggleNode"
           @select-record="emitSelectRecord"
           @open-comments="emitOpenComments"
           @create-child="createChild"
+          @drag-start-record="onDragStartRecord"
+          @drag-end-record="onDragEndRecord"
+          @drop-record="onDropRecord"
         />
       </ul>
       <div v-else class="meta-hierarchy__empty">No records match this hierarchy view.</div>
@@ -95,6 +110,7 @@ const props = defineProps<{
   fields: MetaField[]
   loading: boolean
   canCreate?: boolean
+  canEdit?: boolean
   canComment?: boolean
   viewConfig?: Record<string, unknown> | null
   commentPresence?: Record<string, MultitableCommentPresenceSummary | undefined>
@@ -105,6 +121,7 @@ const emit = defineEmits<{
   (e: 'open-comments', recordId: string): void
   (e: 'create-record', data: Record<string, unknown>): void
   (e: 'update-view-config', input: { config: Record<string, unknown> }): void
+  (e: 'reparent-record', payload: { recordId: string; version: number; parentFieldId: string; parentRecordId: string | null }): void
 }>()
 
 const hierarchyDraft = reactive<Required<MetaHierarchyViewConfig>>({
@@ -115,6 +132,8 @@ const hierarchyDraft = reactive<Required<MetaHierarchyViewConfig>>({
 })
 const pendingConfigKey = ref<string | null>(null)
 const expandedIds = ref<Set<string>>(new Set())
+const draggingRecordId = ref<string | null>(null)
+const dragWarning = ref<string | null>(null)
 
 const hierarchyConfig = computed<Required<MetaHierarchyViewConfig>>(() =>
   resolveHierarchyViewConfig(props.fields, props.viewConfig),
@@ -147,7 +166,10 @@ const treeResult = computed<TreeResult>(() =>
   buildHierarchyTree(props.rows, hierarchyDraft.parentFieldId, hierarchyDraft.orphanMode),
 )
 const visibleRoots = computed(() => treeResult.value.roots)
-const treeDiagnostics = computed(() => treeResult.value.diagnostics)
+const treeDiagnostics = computed(() => [
+  ...(dragWarning.value ? [dragWarning.value] : []),
+  ...treeResult.value.diagnostics,
+])
 
 watch(
   [() => props.rows, () => hierarchyDraft.defaultExpandDepth, () => hierarchyDraft.parentFieldId],
@@ -212,6 +234,78 @@ function toggleNode(recordId: string) {
 function createChild(recordId: string) {
   const fieldId = hierarchyDraft.parentFieldId
   emit('create-record', fieldId ? { [fieldId]: [recordId] } : {})
+}
+
+function currentParentId(recordId: string): string | null {
+  const row = props.rows.find((item) => item.id === recordId)
+  return row && hierarchyDraft.parentFieldId ? firstParentId(row.data[hierarchyDraft.parentFieldId]) : null
+}
+
+function descendantIdsOf(recordId: string): Set<string> {
+  const childIdsByParent = new Map<string, string[]>()
+  if (!hierarchyDraft.parentFieldId) return new Set()
+  for (const row of props.rows) {
+    const parentId = firstParentId(row.data[hierarchyDraft.parentFieldId])
+    if (!parentId) continue
+    if (!childIdsByParent.has(parentId)) childIdsByParent.set(parentId, [])
+    childIdsByParent.get(parentId)?.push(row.id)
+  }
+  const descendants = new Set<string>()
+  const stack = [...(childIdsByParent.get(recordId) ?? [])]
+  while (stack.length) {
+    const childId = stack.pop()!
+    if (descendants.has(childId)) continue
+    descendants.add(childId)
+    stack.push(...(childIdsByParent.get(childId) ?? []))
+  }
+  return descendants
+}
+
+function onDragStartRecord(recordId: string): void {
+  if (!props.canEdit) return
+  draggingRecordId.value = recordId
+  dragWarning.value = null
+}
+
+function onDragEndRecord(): void {
+  draggingRecordId.value = null
+}
+
+function onDropRecord(payload: { recordId: string; parentRecordId: string | null }): void {
+  if (!props.canEdit || !hierarchyDraft.parentFieldId) return
+  const record = props.rows.find((row) => row.id === payload.recordId)
+  if (!record) return
+  if (payload.parentRecordId === payload.recordId) {
+    dragWarning.value = 'Cannot move a record under itself.'
+    draggingRecordId.value = null
+    return
+  }
+  if (payload.parentRecordId && descendantIdsOf(payload.recordId).has(payload.parentRecordId)) {
+    dragWarning.value = 'Cannot move a record under its own descendant.'
+    draggingRecordId.value = null
+    return
+  }
+  if ((currentParentId(payload.recordId) ?? null) === (payload.parentRecordId ?? null)) {
+    draggingRecordId.value = null
+    return
+  }
+  if (payload.parentRecordId) {
+    expandedIds.value = new Set([...expandedIds.value, payload.parentRecordId])
+  }
+  draggingRecordId.value = null
+  dragWarning.value = null
+  emit('reparent-record', {
+    recordId: payload.recordId,
+    version: record.version,
+    parentFieldId: hierarchyDraft.parentFieldId,
+    parentRecordId: payload.parentRecordId,
+  })
+}
+
+function onDropToRoot(): void {
+  const recordId = draggingRecordId.value
+  if (!recordId) return
+  onDropRecord({ recordId, parentRecordId: null })
 }
 
 function emitSelectRecord(recordId: string): void {
@@ -304,10 +398,12 @@ const HierarchyNode: ReturnType<typeof defineComponent> = defineComponent({
     expandedIds: { type: Object as PropType<Set<string>>, required: true },
     titleForRow: { type: Function as PropType<(row: MetaRecord) => string>, required: true },
     canCreate: { type: Boolean, default: false },
+    canEdit: { type: Boolean, default: false },
     canComment: { type: Boolean, default: false },
+    draggingRecordId: { type: String as PropType<string | null>, default: null },
     commentPresence: { type: Object as PropType<Record<string, MultitableCommentPresenceSummary | undefined> | undefined>, default: undefined },
   },
-  emits: ['toggle', 'select-record', 'open-comments', 'create-child'],
+  emits: ['toggle', 'select-record', 'open-comments', 'create-child', 'drag-start-record', 'drag-end-record', 'drop-record'],
   setup(nodeProps, { emit: nodeEmit }) {
     function rowCommentAffordance(recordId: string) {
       return resolveRecordCommentAffordance(nodeProps.commentPresence?.[recordId])
@@ -322,10 +418,35 @@ const HierarchyNode: ReturnType<typeof defineComponent> = defineComponent({
       const hasChildren = node.children.length > 0
       return h('li', { class: 'meta-hierarchy__item' }, [
         h('div', {
-          class: 'meta-hierarchy__row',
+          class: ['meta-hierarchy__row', {
+            'meta-hierarchy__row--draggable': nodeProps.canEdit,
+            'meta-hierarchy__row--drop-target': Boolean(nodeProps.canEdit && nodeProps.draggingRecordId && nodeProps.draggingRecordId !== node.record.id),
+          }],
           role: 'treeitem',
           'aria-expanded': hasChildren ? String(expanded) : undefined,
+          draggable: nodeProps.canEdit,
           style: { paddingLeft: `${node.depth * 18 + 8}px` },
+          onDragstart: (event: DragEvent) => {
+            if (!nodeProps.canEdit) return
+            event.stopPropagation()
+            event.dataTransfer?.setData('text/plain', node.record.id)
+            if (event.dataTransfer) event.dataTransfer.effectAllowed = 'move'
+            nodeEmit('drag-start-record', node.record.id)
+          },
+          onDragend: () => nodeEmit('drag-end-record'),
+          onDragover: (event: DragEvent) => {
+            if (!nodeProps.canEdit || !nodeProps.draggingRecordId || nodeProps.draggingRecordId === node.record.id) return
+            event.preventDefault()
+            if (event.dataTransfer) event.dataTransfer.dropEffect = 'move'
+          },
+          onDrop: (event: DragEvent) => {
+            if (!nodeProps.canEdit) return
+            event.preventDefault()
+            event.stopPropagation()
+            const recordId = nodeProps.draggingRecordId ?? event.dataTransfer?.getData('text/plain') ?? ''
+            if (!recordId) return
+            nodeEmit('drop-record', { recordId, parentRecordId: node.record.id })
+          },
         }, [
           h('button', {
             class: ['meta-hierarchy__toggle', { 'meta-hierarchy__toggle--empty': !hasChildren }],
@@ -363,12 +484,17 @@ const HierarchyNode: ReturnType<typeof defineComponent> = defineComponent({
               expandedIds: nodeProps.expandedIds,
               titleForRow: nodeProps.titleForRow,
               canCreate: nodeProps.canCreate,
+              canEdit: nodeProps.canEdit,
               canComment: nodeProps.canComment,
+              draggingRecordId: nodeProps.draggingRecordId,
               commentPresence: nodeProps.commentPresence,
               onToggle: (recordId: string) => nodeEmit('toggle', recordId),
               onSelectRecord: (recordId: string) => nodeEmit('select-record', recordId),
               onOpenComments: (recordId: string) => nodeEmit('open-comments', recordId),
               onCreateChild: (recordId: string) => nodeEmit('create-child', recordId),
+              onDragStartRecord: (recordId: string) => nodeEmit('drag-start-record', recordId),
+              onDragEndRecord: () => nodeEmit('drag-end-record'),
+              onDropRecord: (payload: { recordId: string; parentRecordId: string | null }) => nodeEmit('drop-record', payload),
             }),
           ))
           : null,
@@ -387,9 +513,13 @@ const HierarchyNode: ReturnType<typeof defineComponent> = defineComponent({
 .meta-hierarchy__placeholder, .meta-hierarchy__empty { margin: 24px; padding: 28px; border: 1px dashed #cbd5e1; border-radius: 10px; background: #fff; color: #64748b; text-align: center; display: flex; flex-direction: column; gap: 6px; }
 .meta-hierarchy__body { flex: 1; min-height: 0; overflow: auto; padding: 14px 16px 24px; }
 .meta-hierarchy__notice { margin-bottom: 10px; padding: 8px 10px; border: 1px solid #fde68a; border-radius: 8px; background: #fffbeb; color: #92400e; font-size: 12px; }
+.meta-hierarchy__root-drop { margin-bottom: 10px; padding: 10px 12px; border: 1px dashed #93c5fd; border-radius: 8px; background: #eff6ff; color: #1d4ed8; font-size: 12px; font-weight: 600; text-align: center; }
 .meta-hierarchy__list { margin: 0; padding: 0; list-style: none; }
 .meta-hierarchy__list--root { border: 1px solid #e2e8f0; border-radius: 10px; overflow: hidden; background: #fff; }
 .meta-hierarchy__row { display: flex; align-items: center; gap: 8px; min-height: 40px; border-bottom: 1px solid #edf2f7; }
+.meta-hierarchy__row--draggable { cursor: grab; }
+.meta-hierarchy__row--draggable:active { cursor: grabbing; }
+.meta-hierarchy__row--drop-target { background: #f0fdf4; box-shadow: inset 3px 0 0 #22c55e; }
 .meta-hierarchy__item:last-child > .meta-hierarchy__row { border-bottom: 0; }
 .meta-hierarchy__toggle { width: 24px; height: 24px; border: 0; border-radius: 6px; background: #eef2ff; color: #3730a3; cursor: pointer; }
 .meta-hierarchy__toggle--empty { background: transparent; color: #94a3b8; cursor: default; }

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -185,10 +185,12 @@
           :rows="grid.rows.value" :fields="scopedAllFields" :loading="grid.loading.value"
           :view-config="workbench.activeView.value?.config"
           :can-create="caps.canCreateRecord.value"
+          :can-edit="effectiveRowActions.canEdit"
           :can-comment="effectiveRowActions.canComment"
           :comment-presence="commentPresenceState.presenceByRecordId.value"
           @select-record="onSelectRecord" @create-record="onKanbanCreateRecord"
           @open-comments="onOpenRecordComments"
+          @reparent-record="onHierarchyReparentRecord"
           @update-view-config="onPersistActiveViewConfig"
         />
         <MetaGridTable
@@ -1242,6 +1244,35 @@ async function onTimelinePatchDates(payload: {
     showSuccess('Dates updated')
   } catch (error: any) {
     showError(error?.message ?? 'Failed to update timeline dates')
+  }
+}
+async function onHierarchyReparentRecord(payload: {
+  recordId: string
+  version: number
+  parentFieldId: string
+  parentRecordId: string | null
+}) {
+  if (!ensureCanEditRecord(payload.recordId)) return
+  try {
+    await workbench.client.patchRecords({
+      sheetId: workbench.activeSheetId.value || undefined,
+      viewId: workbench.activeViewId.value || undefined,
+      changes: [
+        {
+          recordId: payload.recordId,
+          fieldId: payload.parentFieldId,
+          value: payload.parentRecordId ? [payload.parentRecordId] : [],
+          expectedVersion: payload.version,
+        },
+      ],
+    })
+    await grid.loadViewData(grid.page.value.offset)
+    if (selectedRecordId.value === payload.recordId) {
+      await resolveDeepLink(payload.recordId)
+    }
+    showSuccess('Hierarchy updated')
+  } catch (error: any) {
+    showError(error?.message ?? 'Failed to update hierarchy parent')
   }
 }
 async function onAddRecord() {

--- a/apps/web/tests/multitable-hierarchy-view.spec.ts
+++ b/apps/web/tests/multitable-hierarchy-view.spec.ts
@@ -12,11 +12,13 @@ function mountHierarchy(props: {
   rows: MetaRecord[]
   viewConfig?: Record<string, unknown>
   canCreate?: boolean
+  canEdit?: boolean
   canComment?: boolean
   onSelectRecord?: (recordId: string) => void
   onOpenComments?: (recordId: string) => void
   onCreateRecord?: (data: Record<string, unknown>) => void
   onUpdateViewConfig?: (input: { config: Record<string, unknown> }) => void
+  onReparentRecord?: (payload: { recordId: string; version: number; parentFieldId: string; parentRecordId: string | null }) => void
 }) {
   const container = document.createElement('div')
   document.body.appendChild(container)
@@ -115,6 +117,104 @@ describe('MetaHierarchyView', () => {
         orphanMode: 'hidden',
       },
     })
+
+    unmount()
+  })
+
+  it('emits reparent updates from drag and drop interactions', async () => {
+    const reparentSpy = vi.fn()
+    const { container, unmount } = mountHierarchy({
+      rows: [
+        { id: 'rec_root', version: 1, data: { fld_title: 'Root' } },
+        { id: 'rec_child', version: 4, data: { fld_title: 'Child', fld_parent: ['rec_root'] } },
+        { id: 'rec_new_parent', version: 2, data: { fld_title: 'New Parent' } },
+      ],
+      viewConfig: { parentFieldId: 'fld_parent', titleFieldId: 'fld_title', defaultExpandDepth: 2 },
+      canEdit: true,
+      onReparentRecord: reparentSpy,
+    })
+    await nextTick()
+
+    const titleButtons = Array.from(container.querySelectorAll('.meta-hierarchy__title')) as HTMLButtonElement[]
+    const childRow = titleButtons.find((button) => button.textContent === 'Child')?.closest('.meta-hierarchy__row') as HTMLElement | null
+    const newParentRow = titleButtons.find((button) => button.textContent === 'New Parent')?.closest('.meta-hierarchy__row') as HTMLElement | null
+    expect(childRow).not.toBeNull()
+    expect(newParentRow).not.toBeNull()
+
+    childRow?.dispatchEvent(new Event('dragstart', { bubbles: true }))
+    await nextTick()
+    newParentRow?.dispatchEvent(new Event('drop', { bubbles: true }))
+    await nextTick()
+
+    expect(reparentSpy).toHaveBeenCalledWith({
+      recordId: 'rec_child',
+      version: 4,
+      parentFieldId: 'fld_parent',
+      parentRecordId: 'rec_new_parent',
+    })
+
+    unmount()
+  })
+
+  it('supports dropping a child to the root drop zone', async () => {
+    const reparentSpy = vi.fn()
+    const { container, unmount } = mountHierarchy({
+      rows: [
+        { id: 'rec_root', version: 1, data: { fld_title: 'Root' } },
+        { id: 'rec_child', version: 4, data: { fld_title: 'Child', fld_parent: ['rec_root'] } },
+      ],
+      viewConfig: { parentFieldId: 'fld_parent', titleFieldId: 'fld_title', defaultExpandDepth: 2 },
+      canEdit: true,
+      onReparentRecord: reparentSpy,
+    })
+    await nextTick()
+
+    const childRow = (Array.from(container.querySelectorAll('.meta-hierarchy__title')) as HTMLButtonElement[])
+      .find((button) => button.textContent === 'Child')
+      ?.closest('.meta-hierarchy__row') as HTMLElement | null
+    childRow?.dispatchEvent(new Event('dragstart', { bubbles: true }))
+    await nextTick()
+
+    const rootDrop = container.querySelector('.meta-hierarchy__root-drop') as HTMLElement | null
+    expect(rootDrop).not.toBeNull()
+
+    rootDrop?.dispatchEvent(new Event('drop', { bubbles: true }))
+    await nextTick()
+
+    expect(reparentSpy).toHaveBeenCalledWith({
+      recordId: 'rec_child',
+      version: 4,
+      parentFieldId: 'fld_parent',
+      parentRecordId: null,
+    })
+
+    unmount()
+  })
+
+  it('blocks dragging a parent under its own descendant', async () => {
+    const reparentSpy = vi.fn()
+    const { container, unmount } = mountHierarchy({
+      rows: [
+        { id: 'rec_root', version: 1, data: { fld_title: 'Root' } },
+        { id: 'rec_child', version: 2, data: { fld_title: 'Child', fld_parent: ['rec_root'] } },
+      ],
+      viewConfig: { parentFieldId: 'fld_parent', titleFieldId: 'fld_title', defaultExpandDepth: 2 },
+      canEdit: true,
+      onReparentRecord: reparentSpy,
+    })
+    await nextTick()
+
+    const titleButtons = Array.from(container.querySelectorAll('.meta-hierarchy__title')) as HTMLButtonElement[]
+    const rootRow = titleButtons.find((button) => button.textContent === 'Root')?.closest('.meta-hierarchy__row') as HTMLElement | null
+    const childRow = titleButtons.find((button) => button.textContent === 'Child')?.closest('.meta-hierarchy__row') as HTMLElement | null
+
+    rootRow?.dispatchEvent(new Event('dragstart', { bubbles: true }))
+    await nextTick()
+    childRow?.dispatchEvent(new Event('drop', { bubbles: true }))
+    await nextTick()
+
+    expect(reparentSpy).not.toHaveBeenCalled()
+    expect(container.textContent).toContain('Cannot move a record under its own descendant.')
 
     unmount()
   })

--- a/apps/web/tests/multitable-workbench-view.spec.ts
+++ b/apps/web/tests/multitable-workbench-view.spec.ts
@@ -725,6 +725,34 @@ vi.mock('../src/multitable/components/MetaGanttView.vue', () => ({
     },
   }),
 }))
+vi.mock('../src/multitable/components/MetaHierarchyView.vue', () => ({
+  default: defineComponent({
+    name: 'MetaHierarchyView',
+    props: {
+      canEdit: { type: Boolean, default: false },
+    },
+    emits: ['reparent-record'],
+    render() {
+      return h('div', {
+        'data-hierarchy-can-edit': String(this.$props.canEdit),
+      }, [
+        h(
+          'button',
+          {
+            'data-hierarchy-reparent': 'true',
+            onClick: () => this.$emit('reparent-record', {
+              recordId: 'rec_1',
+              version: 5,
+              parentFieldId: 'fld_parent',
+              parentRecordId: 'rec_parent',
+            }),
+          },
+          'hierarchy-reparent',
+        ),
+      ])
+    },
+  }),
+}))
 vi.mock('../src/multitable/components/MetaImportModal.vue', () => ({
   default: defineComponent({
     name: 'MetaImportModal',
@@ -1742,11 +1770,12 @@ describe('MultitableWorkbench view wiring', () => {
     expect(gridMock.loadViewData).toHaveBeenCalled()
   })
 
-  it('passes scoped row edit gating into kanban, timeline and gantt views', async () => {
+  it('passes scoped row edit gating into kanban, timeline, gantt and hierarchy views', async () => {
     workbenchMock.views.value = [
       { id: 'view_kanban', sheetId: 'sheet_orders', name: 'Kanban', type: 'kanban' },
       { id: 'view_timeline', sheetId: 'sheet_orders', name: 'Timeline', type: 'timeline', config: { zoom: 'week' } },
       { id: 'view_gantt', sheetId: 'sheet_orders', name: 'Gantt', type: 'gantt', config: { zoom: 'week' } },
+      { id: 'view_hierarchy', sheetId: 'sheet_orders', name: 'Hierarchy', type: 'hierarchy', config: { parentFieldId: 'fld_parent' } },
     ]
     gridMock.rowActions.value = {
       canEdit: false,
@@ -1768,6 +1797,11 @@ describe('MultitableWorkbench view wiring', () => {
     await flushUi()
 
     expect(container!.querySelector('[data-gantt-can-edit]')?.getAttribute('data-gantt-can-edit')).toBe('false')
+
+    workbenchMock.activeViewId.value = 'view_hierarchy'
+    await flushUi()
+
+    expect(container!.querySelector('[data-hierarchy-can-edit]')?.getAttribute('data-hierarchy-can-edit')).toBe('false')
   })
 
   it('patches timeline date updates through patchRecords and refreshes the active page', async () => {
@@ -1811,6 +1845,29 @@ describe('MultitableWorkbench view wiring', () => {
     })
     expect(gridMock.loadViewData).toHaveBeenCalled()
     expect(showSuccessSpy).toHaveBeenCalledWith('Dates updated')
+  })
+
+  it('patches hierarchy reparent updates through patchRecords and refreshes the active page', async () => {
+    workbenchMock.views.value = [
+      ...workbenchMock.views.value,
+      { id: 'view_hierarchy', sheetId: 'sheet_orders', name: 'Hierarchy', type: 'hierarchy', config: { parentFieldId: 'fld_parent' } },
+    ]
+
+    mountWorkbench({ viewId: 'view_hierarchy' })
+    await flushUi()
+
+    container!.querySelector<HTMLButtonElement>('[data-hierarchy-reparent="true"]')!.click()
+    await flushUi()
+
+    expect(workbenchMock.client.patchRecords).toHaveBeenCalledWith({
+      sheetId: 'sheet_orders',
+      viewId: 'view_hierarchy',
+      changes: [
+        { recordId: 'rec_1', fieldId: 'fld_parent', value: ['rec_parent'], expectedVersion: 5 },
+      ],
+    })
+    expect(gridMock.loadViewData).toHaveBeenCalled()
+    expect(showSuccessSpy).toHaveBeenCalledWith('Hierarchy updated')
   })
 
   it('blocks timeline patch updates when scoped rowActions disallow edits', async () => {

--- a/docs/development/multitable-hierarchy-drag-reparent-design-20260506.md
+++ b/docs/development/multitable-hierarchy-drag-reparent-design-20260506.md
@@ -1,0 +1,75 @@
+# Multitable Hierarchy Drag Reparent Design - 2026-05-06
+
+## Scope
+
+This slice implements the Phase 7 optional backlog item "Hierarchy drag-to-reparent" as a frontend-to-authoritative-write integration.
+
+Implemented:
+
+- `MetaHierarchyView` rows become draggable when the current row scope allows editing.
+- Dropping a row onto another hierarchy row emits a reparent payload with `recordId`, `version`, `parentFieldId`, and `parentRecordId`.
+- Dropping a row onto the root drop zone clears the parent link.
+- `MultitableWorkbench` handles `reparent-record` by calling `workbench.client.patchRecords()` with `expectedVersion`.
+- The active grid page reloads after a successful write, and the selected deep-link record is refreshed when needed.
+- Client-side guards reject no-op moves, self-parenting, and moving a record under one of its descendants.
+
+Not implemented in this slice:
+
+- Server-side cycle prevention. The next backlog item remains necessary because other callers can still patch the parent link field directly.
+- Multi-record drag operations.
+- Custom drag preview styling.
+
+## Write Path
+
+The hierarchy component stays presentation-focused and does not import the API client. It emits:
+
+```ts
+{
+  recordId: string
+  version: number
+  parentFieldId: string
+  parentRecordId: string | null
+}
+```
+
+`MultitableWorkbench` converts that payload to the existing record patch seam:
+
+```ts
+await workbench.client.patchRecords({
+  sheetId,
+  viewId,
+  changes: [
+    {
+      recordId,
+      fieldId: parentFieldId,
+      value: parentRecordId ? [parentRecordId] : [],
+      expectedVersion: version,
+    },
+  ],
+})
+```
+
+This keeps version conflict behavior, field validation, realtime invalidation, and backend write semantics on the same path used by grid/timeline/gantt edits.
+
+## Permissions
+
+`MultitableWorkbench` passes `effectiveRowActions.canEdit` into `MetaHierarchyView`. The component only enables drag affordances when `canEdit` is true, and the workbench handler still calls `ensureCanEditRecord(recordId)` before writing.
+
+This mirrors the existing timeline/gantt edit gating pattern and avoids relying on UI affordances as the only permission boundary.
+
+## Cycle Guard
+
+The component builds a parent-to-children index from the current page rows and rejects:
+
+- moving a record under itself
+- moving a record under one of its visible descendants
+
+This is intentionally a UX guard only. It catches common mistakes before the patch request but is not authoritative because the current page may not contain the full hierarchy and other clients can patch the parent field directly.
+
+## Files
+
+- `apps/web/src/multitable/components/MetaHierarchyView.vue`
+- `apps/web/src/multitable/views/MultitableWorkbench.vue`
+- `apps/web/tests/multitable-hierarchy-view.spec.ts`
+- `apps/web/tests/multitable-workbench-view.spec.ts`
+

--- a/docs/development/multitable-hierarchy-drag-reparent-verification-20260506.md
+++ b/docs/development/multitable-hierarchy-drag-reparent-verification-20260506.md
@@ -1,0 +1,70 @@
+# Multitable Hierarchy Drag Reparent Verification - 2026-05-06
+
+## Environment
+
+- Worktree: `/private/tmp/ms2-hierarchy-drag-reparent-20260506`
+- Branch: `codex/multitable-hierarchy-drag-reparent-20260506`
+- Base: `origin/main@922cff530be14f8f661d3105ecf9dd5139ea8ab4`
+- Dependency setup: `pnpm install --frozen-lockfile`
+
+`pnpm install` produced local dependency symlink noise under `plugins/*/node_modules` and `tools/cli/node_modules`. Those files are not part of this feature commit.
+
+## Automated Verification
+
+### Focused frontend behavior
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-hierarchy-view.spec.ts tests/multitable-workbench-view.spec.ts --watch=false --reporter=dot
+```
+
+Result:
+
+```text
+Test Files  2 passed (2)
+Tests       55 passed (55)
+```
+
+Coverage added:
+
+- drag child row onto another row emits `reparent-record`
+- drag child row to the root drop zone emits a null parent
+- dragging a parent under a visible descendant is blocked client-side
+- workbench passes scoped edit gating into Hierarchy
+- workbench converts Hierarchy reparent events into `patchRecords` calls
+
+### Frontend type check
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+```
+
+Result: exit 0.
+
+### Whitespace guard
+
+Command:
+
+```bash
+git diff --check -- apps/web/src/multitable/components/MetaHierarchyView.vue apps/web/src/multitable/views/MultitableWorkbench.vue apps/web/tests/multitable-hierarchy-view.spec.ts apps/web/tests/multitable-workbench-view.spec.ts
+```
+
+Result: exit 0.
+
+## Manual Verification Notes
+
+Recommended staging smoke after merge:
+
+1. Open a hierarchy view with an editable parent link field.
+2. Drag a child record onto another parent and confirm it moves after refresh.
+3. Drag the same child to the root drop zone and confirm the parent link clears.
+4. Use a read-only row scope and confirm drag affordances are disabled.
+5. Attempt to drag a parent under its visible child and confirm the warning appears and no write happens.
+
+## Residual Risk
+
+Server-side cycle prevention is still open. This feature prevents obvious UI mistakes, but authoritative validation must be added in a follow-up backend slice before treating hierarchy constraints as complete.
+


### PR DESCRIPTION
## Summary
- add drag-to-reparent interactions to MetaHierarchyView, including a root drop zone
- wire hierarchy reparent events through MultitableWorkbench to patchRecords with expectedVersion
- cover hierarchy drag/drop behavior and Workbench patchRecords wiring

## Verification
- pnpm --filter @metasheet/web exec vitest run tests/multitable-hierarchy-view.spec.ts tests/multitable-workbench-view.spec.ts --watch=false --reporter=dot
- pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
- git diff --check -- apps/web/src/multitable/components/MetaHierarchyView.vue apps/web/src/multitable/views/MultitableWorkbench.vue apps/web/tests/multitable-hierarchy-view.spec.ts apps/web/tests/multitable-workbench-view.spec.ts

## Docs
- docs/development/multitable-hierarchy-drag-reparent-design-20260506.md
- docs/development/multitable-hierarchy-drag-reparent-verification-20260506.md

## Note
Server-side hierarchy cycle prevention remains the next backlog item; this PR only adds client-side drag UX guards.