### PR TITLE
fix(integration): block stale K3 setup connection tests

### DIFF
--- a/apps/web/src/services/integration/k3WiseSetup.ts
+++ b/apps/web/src/services/integration/k3WiseSetup.ts
@@ -253,6 +253,64 @@ function parseOptionalPositiveInteger(value: string): number | undefined {
   return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined
 }
 
+function fingerprintJson(value: Record<string, unknown>): string {
+  return JSON.stringify(value)
+}
+
+function normalizeListFingerprint(value: string): string[] {
+  return splitList(value)
+}
+
+function hasWebApiCredentialDraft(form: K3WiseSetupForm): boolean {
+  return Boolean(trim(form.username) || trim(form.acctId) || trim(form.password))
+}
+
+function hasSqlCredentialDraft(form: K3WiseSetupForm): boolean {
+  return Boolean(trim(form.sqlUsername) || trim(form.sqlPassword))
+}
+
+export function buildK3WiseWebApiConnectionFingerprint(form: K3WiseSetupForm): string {
+  return fingerprintJson({
+    tenantId: trim(form.tenantId),
+    workspaceId: trim(form.workspaceId),
+    systemId: trim(form.webApiSystemId),
+    hasCredentials: form.webApiHasCredentials === true,
+    credentialDraftTouched: hasWebApiCredentialDraft(form),
+    version: trim(form.version),
+    environment: form.environment,
+    baseUrl: trim(form.baseUrl),
+    loginPath: trim(form.loginPath),
+    healthPath: trim(form.healthPath),
+    lcid: trim(form.lcid),
+    timeoutMs: trim(form.timeoutMs),
+  })
+}
+
+export function buildK3WiseSqlConnectionFingerprint(form: K3WiseSetupForm): string {
+  return fingerprintJson({
+    tenantId: trim(form.tenantId),
+    workspaceId: trim(form.workspaceId),
+    enabled: form.sqlEnabled === true,
+    systemId: trim(form.sqlSystemId),
+    hasCredentials: form.sqlHasCredentials === true,
+    credentialDraftTouched: hasSqlCredentialDraft(form),
+    mode: form.sqlMode,
+    server: trim(form.sqlServer),
+    database: trim(form.sqlDatabase),
+    allowedTables: normalizeListFingerprint(form.sqlAllowedTables),
+    middleTables: normalizeListFingerprint(form.sqlMiddleTables),
+    storedProcedures: normalizeListFingerprint(form.sqlStoredProcedures),
+  })
+}
+
+export function buildK3WiseWebApiSystemConnectionFingerprint(system: IntegrationExternalSystem): string {
+  return buildK3WiseWebApiConnectionFingerprint(applyExternalSystemToForm(createDefaultK3WiseSetupForm(), system))
+}
+
+export function buildK3WiseSqlSystemConnectionFingerprint(system: IntegrationExternalSystem): string {
+  return buildK3WiseSqlConnectionFingerprint(applyExternalSystemToForm(createDefaultK3WiseSetupForm(), system))
+}
+
 function assertRelativePath(value: string, field: keyof K3WiseSetupForm, issues: K3WiseSetupValidationIssue[]): void {
   const normalized = trim(value)
   if (!normalized) {
@@ -805,6 +863,9 @@ export function applyExternalSystemToForm(form: K3WiseSetupForm, system: Integra
     const bom = objects.bom || {}
     next.webApiSystemId = system.id
     next.webApiHasCredentials = system.hasCredentials === true
+    next.acctId = ''
+    next.username = ''
+    next.password = ''
     next.tenantId = system.tenantId || next.tenantId
     next.workspaceId = system.workspaceId || ''
     next.webApiName = system.name
@@ -812,7 +873,7 @@ export function applyExternalSystemToForm(form: K3WiseSetupForm, system: Integra
     next.environment = typeof config.environment === 'string' ? config.environment as K3WiseSetupForm['environment'] : next.environment
     next.baseUrl = typeof config.baseUrl === 'string' ? config.baseUrl : next.baseUrl
     next.loginPath = typeof config.loginPath === 'string' ? config.loginPath : next.loginPath
-    next.healthPath = typeof config.healthPath === 'string' ? config.healthPath : next.healthPath
+    next.healthPath = typeof config.healthPath === 'string' ? config.healthPath : ''
     next.lcid = config.lcid === undefined ? next.lcid : String(config.lcid)
     next.timeoutMs = config.timeoutMs === undefined ? next.timeoutMs : String(config.timeoutMs)
     next.autoSubmit = config.autoSubmit === true
@@ -829,6 +890,8 @@ export function applyExternalSystemToForm(form: K3WiseSetupForm, system: Integra
     next.sqlEnabled = true
     next.sqlSystemId = system.id
     next.sqlHasCredentials = system.hasCredentials === true
+    next.sqlUsername = ''
+    next.sqlPassword = ''
     next.tenantId = system.tenantId || next.tenantId
     next.workspaceId = system.workspaceId || ''
     next.sqlName = system.name

--- a/apps/web/src/views/IntegrationK3WiseSetupView.vue
+++ b/apps/web/src/views/IntegrationK3WiseSetupView.vue
@@ -47,12 +47,14 @@
           <div class="k3-setup__panel-head">
             <h2>连接测试</h2>
           </div>
-          <button class="k3-setup__btn k3-setup__btn--full" type="button" :disabled="testingWebApi || !form.webApiSystemId" @click="testWebApi">
+          <button class="k3-setup__btn k3-setup__btn--full" type="button" :disabled="webApiTestDisabled" @click="testWebApi">
             {{ testingWebApi ? '测试中' : '测试 WebAPI' }}
           </button>
-          <button class="k3-setup__btn k3-setup__btn--full" type="button" :disabled="testingSql || !form.sqlSystemId" @click="testSqlServer">
+          <p v-if="hasUnsavedWebApiConnectionDraft" class="k3-setup__hint">WebAPI 连接配置有未保存改动，请先保存再测试。</p>
+          <button class="k3-setup__btn k3-setup__btn--full" type="button" :disabled="sqlTestDisabled" @click="testSqlServer">
             {{ testingSql ? '测试中' : '测试 SQL Server' }}
           </button>
+          <p v-if="hasUnsavedSqlConnectionDraft" class="k3-setup__hint">SQL Server 通道配置有未保存改动，请先保存再测试。</p>
           <pre v-if="testResult" class="k3-setup__test-result">{{ testResult }}</pre>
         </div>
 
@@ -497,6 +499,10 @@ import {
   K3_WISE_SQLSERVER_KIND,
   K3_WISE_WEBAPI_KIND,
   applyExternalSystemToForm,
+  buildK3WiseSqlConnectionFingerprint,
+  buildK3WiseSqlSystemConnectionFingerprint,
+  buildK3WiseWebApiConnectionFingerprint,
+  buildK3WiseWebApiSystemConnectionFingerprint,
   buildK3WisePipelineObservationQuery,
   buildK3WisePipelinePayloads,
   buildK3WisePipelineRunPayload,
@@ -558,6 +564,20 @@ const materialRunIssues = computed(() => validateK3WisePipelineRunForm(form, 'ma
 const bomRunIssues = computed(() => validateK3WisePipelineRunForm(form, 'bom'))
 const observationSummary = computed(() => `${pipelineRuns.value.length} runs / ${deadLetters.value.length} open`)
 const stagingDescriptorLabel = computed(() => stagingDescriptors.value.length > 0 ? `${stagingDescriptors.value.length} descriptors` : 'not loaded')
+const selectedWebApiSystem = computed(() => webApiSystems.value.find((system) => system.id === form.webApiSystemId) ?? null)
+const selectedSqlSystem = computed(() => sqlSystems.value.find((system) => system.id === form.sqlSystemId) ?? null)
+const hasUnsavedWebApiConnectionDraft = computed(() => {
+  const system = selectedWebApiSystem.value
+  if (!system) return Boolean(form.webApiSystemId)
+  return buildK3WiseWebApiConnectionFingerprint(form) !== buildK3WiseWebApiSystemConnectionFingerprint(system)
+})
+const hasUnsavedSqlConnectionDraft = computed(() => {
+  const system = selectedSqlSystem.value
+  if (!system) return Boolean(form.sqlSystemId)
+  return buildK3WiseSqlConnectionFingerprint(form) !== buildK3WiseSqlSystemConnectionFingerprint(system)
+})
+const webApiTestDisabled = computed(() => Boolean(testingWebApi.value || !form.webApiSystemId || hasUnsavedWebApiConnectionDraft.value))
+const sqlTestDisabled = computed(() => Boolean(testingSql.value || !form.sqlSystemId || hasUnsavedSqlConnectionDraft.value))
 
 function setStatus(message: string, kind: 'info' | 'success' | 'error' = 'info'): void {
   statusMessage.value = message
@@ -616,10 +636,15 @@ async function saveConfiguration(): Promise<void> {
     const webApi = await upsertIntegrationSystem(payloads.webApi)
     form.webApiSystemId = webApi.id
     form.webApiHasCredentials = webApi.hasCredentials === true
+    form.acctId = ''
+    form.username = ''
+    form.password = ''
     if (payloads.sqlServer) {
       const sql = await upsertIntegrationSystem(payloads.sqlServer)
       form.sqlSystemId = sql.id
       form.sqlHasCredentials = sql.hasCredentials === true
+      form.sqlUsername = ''
+      form.sqlPassword = ''
     }
     await loadSystems()
     setStatus('K3 WISE 对接配置已保存', 'success')
@@ -631,7 +656,7 @@ async function saveConfiguration(): Promise<void> {
 }
 
 async function testWebApi(): Promise<void> {
-  if (!form.webApiSystemId) return
+  if (!form.webApiSystemId || hasUnsavedWebApiConnectionDraft.value) return
   testingWebApi.value = true
   testResult.value = ''
   try {
@@ -647,7 +672,7 @@ async function testWebApi(): Promise<void> {
 }
 
 async function testSqlServer(): Promise<void> {
-  if (!form.sqlSystemId) return
+  if (!form.sqlSystemId || hasUnsavedSqlConnectionDraft.value) return
   testingSql.value = true
   testResult.value = ''
   try {
@@ -1024,6 +1049,13 @@ onMounted(() => {
 
 .k3-setup__empty {
   color: #64748b;
+}
+
+.k3-setup__hint {
+  margin: 6px 0 0;
+  color: #9a3412;
+  font-size: 12px;
+  line-height: 1.4;
 }
 
 .k3-setup__records {

--- a/apps/web/tests/k3WiseSetup.spec.ts
+++ b/apps/web/tests/k3WiseSetup.spec.ts
@@ -2,6 +2,10 @@ import { describe, expect, it } from 'vitest'
 import { readFile } from 'node:fs/promises'
 import {
   applyExternalSystemToForm,
+  buildK3WiseSqlConnectionFingerprint,
+  buildK3WiseSqlSystemConnectionFingerprint,
+  buildK3WiseWebApiConnectionFingerprint,
+  buildK3WiseWebApiSystemConnectionFingerprint,
   buildK3WisePipelineObservationQuery,
   buildK3WisePipelinePayloads,
   buildK3WisePipelineRunPayload,
@@ -94,6 +98,11 @@ describe('K3 WISE setup helpers', () => {
 
   it('loads public external-system config without exposing credentials', () => {
     const form = createDefaultK3WiseSetupForm()
+    Object.assign(form, {
+      acctId: 'draft-acct',
+      username: 'draft-user',
+      password: 'draft-password',
+    })
     const system: IntegrationExternalSystem = {
       id: 'sys_1',
       tenantId: 'tenant_1',
@@ -121,7 +130,107 @@ describe('K3 WISE setup helpers', () => {
     expect(next.webApiSystemId).toBe('sys_1')
     expect(next.webApiHasCredentials).toBe(true)
     expect(next.baseUrl).toBe('https://k3.example.test/')
+    expect(next.healthPath).toBe('')
+    expect(next.acctId).toBe('')
+    expect(next.username).toBe('')
     expect(next.password).toBe('')
+  })
+
+  it('tracks unsaved WebAPI connection drafts without reacting to pipeline-only edits', () => {
+    const form = createDefaultK3WiseSetupForm()
+    const system: IntegrationExternalSystem = {
+      id: 'sys_1',
+      tenantId: 'tenant_1',
+      workspaceId: 'workspace_1',
+      name: 'K3 loaded',
+      kind: 'erp:k3-wise-webapi',
+      role: 'target',
+      status: 'active',
+      hasCredentials: true,
+      config: {
+        version: 'K3 WISE 15.x',
+        environment: 'uat',
+        baseUrl: 'https://k3.example.test/',
+        loginPath: '/login',
+        healthPath: '/health',
+        lcid: 2052,
+        timeoutMs: 30000,
+      },
+      capabilities: {},
+    }
+    const loaded = applyExternalSystemToForm(form, system)
+    const savedFingerprint = buildK3WiseWebApiSystemConnectionFingerprint(system)
+
+    expect(buildK3WiseWebApiConnectionFingerprint(loaded)).toBe(savedFingerprint)
+
+    loaded.projectId = 'project_1'
+    loaded.materialPipelineId = 'pipe_material'
+    loaded.pipelineCursor = 'cursor_1'
+    loaded.allowLivePipelineRun = true
+    expect(buildK3WiseWebApiConnectionFingerprint(loaded)).toBe(savedFingerprint)
+
+    loaded.baseUrl = 'https://k3-new.example.test/'
+    expect(buildK3WiseWebApiConnectionFingerprint(loaded)).not.toBe(savedFingerprint)
+
+    loaded.baseUrl = 'https://k3.example.test/'
+    loaded.username = 'replacement-user'
+    expect(buildK3WiseWebApiConnectionFingerprint(loaded)).not.toBe(savedFingerprint)
+  })
+
+  it('tracks unsaved SQL Server connection drafts without reacting to pipeline-only edits', () => {
+    const form = createDefaultK3WiseSetupForm()
+    form.sqlUsername = 'draft-user'
+    form.sqlPassword = 'draft-password'
+    const system: IntegrationExternalSystem = {
+      id: 'sql_1',
+      tenantId: 'tenant_1',
+      workspaceId: 'workspace_1',
+      name: 'K3 SQL loaded',
+      kind: 'erp:k3-wise-sqlserver',
+      role: 'bidirectional',
+      status: 'active',
+      hasCredentials: true,
+      config: {
+        mode: 'readonly',
+        server: '10.0.0.10',
+        database: 'AIS_TEST',
+        allowedTables: ['dbo.t_ICItem', 'dbo.t_ICBOM'],
+        middleTables: ['dbo.integration_material_stage'],
+        storedProcedures: ['dbo.usp_integration_material'],
+      },
+      capabilities: {},
+    }
+    const loaded = applyExternalSystemToForm(form, system)
+    const savedFingerprint = buildK3WiseSqlSystemConnectionFingerprint(system)
+
+    expect(loaded.sqlUsername).toBe('')
+    expect(loaded.sqlPassword).toBe('')
+    expect(buildK3WiseSqlConnectionFingerprint(loaded)).toBe(savedFingerprint)
+
+    loaded.projectId = 'project_1'
+    loaded.bomPipelineId = 'pipe_bom'
+    loaded.pipelineCursor = 'cursor_1'
+    expect(buildK3WiseSqlConnectionFingerprint(loaded)).toBe(savedFingerprint)
+
+    loaded.sqlServer = '10.0.0.11'
+    expect(buildK3WiseSqlConnectionFingerprint(loaded)).not.toBe(savedFingerprint)
+
+    loaded.sqlServer = '10.0.0.10'
+    loaded.sqlPassword = 'replacement-password'
+    expect(buildK3WiseSqlConnectionFingerprint(loaded)).not.toBe(savedFingerprint)
+  })
+
+  it('keeps K3 setup connection test controls behind saved-draft fingerprints', async () => {
+    const source = await readFile('src/views/IntegrationK3WiseSetupView.vue', 'utf8')
+
+    expect(source).toContain(':disabled="webApiTestDisabled"')
+    expect(source).toContain(':disabled="sqlTestDisabled"')
+    expect(source).toContain('hasUnsavedWebApiConnectionDraft')
+    expect(source).toContain('hasUnsavedSqlConnectionDraft')
+    expect(source).toContain('if (!system) return Boolean(form.webApiSystemId)')
+    expect(source).toContain('if (!system) return Boolean(form.sqlSystemId)')
+    expect(source).toContain('if (!form.webApiSystemId || hasUnsavedWebApiConnectionDraft.value) return')
+    expect(source).toContain('if (!form.sqlSystemId || hasUnsavedSqlConnectionDraft.value) return')
   })
 
   it('validates absolute endpoint paths and incomplete credential replacement', () => {

--- a/docs/development/integration-k3wise-test-unsaved-draft-guard-development-20260506.md
+++ b/docs/development/integration-k3wise-test-unsaved-draft-guard-development-20260506.md
@@ -1,0 +1,69 @@
+# K3 WISE Saved-Draft Test Guard Development - 2026-05-06
+
+## Goal
+
+Prevent the `/integrations/k3-wise` setup page from testing stale saved K3 WISE connection records after an operator edits connection fields locally but has not saved them yet.
+
+The backend `POST /api/integration/external-systems/:id/test` route tests the persisted external system identified by `:id`. It does not accept replacement connection config or credentials from the request body. The UI therefore must make that contract explicit: if the visible WebAPI or SQL Server connection draft no longer matches the selected saved system, connection testing is disabled until the operator saves.
+
+## Scope
+
+Changed files:
+
+- `apps/web/src/services/integration/k3WiseSetup.ts`
+- `apps/web/src/views/IntegrationK3WiseSetupView.vue`
+- `apps/web/tests/k3WiseSetup.spec.ts`
+- `plugins/plugin-integration-core/__tests__/http-routes.test.cjs`
+
+## Frontend Design
+
+The setup helper now exposes saved-connection fingerprints for WebAPI and SQL Server configuration:
+
+- `buildK3WiseWebApiConnectionFingerprint(form)`
+- `buildK3WiseSqlConnectionFingerprint(form)`
+- `buildK3WiseWebApiSystemConnectionFingerprint(system)`
+- `buildK3WiseSqlSystemConnectionFingerprint(system)`
+
+The fingerprints include only fields that affect connection testing:
+
+- Scope: tenant, workspace, selected system id.
+- WebAPI transport: version, environment, base URL, login path, health path, LCID, timeout.
+- SQL Server channel: enabled flag, mode, server, database, allowed tables, middle tables, stored procedures.
+- Credential state: saved `hasCredentials` plus a boolean `credentialDraftTouched`.
+
+Credential values are intentionally excluded from the fingerprint. The page only needs to know whether a replacement credential draft exists; it must not serialize secret values into comparison snapshots.
+
+The setup view compares the current form fingerprint with the selected saved system fingerprint:
+
+- `hasUnsavedWebApiConnectionDraft`
+- `hasUnsavedSqlConnectionDraft`
+- `webApiTestDisabled`
+- `sqlTestDisabled`
+
+When a draft is dirty, the matching test button is disabled and the view shows a short inline hint telling the operator to save before testing. Handler-level guards mirror the disabled state so keyboard/scripted invocation cannot call the stale saved-system test path.
+
+If a form still holds a saved system id but the refreshed saved-system list no longer contains that id, the page treats the draft as stale and disables testing. This covers tenant/workspace switching and deleted/inaccessible systems.
+
+After a successful save, the page clears WebAPI and SQL Server credential replacement fields before refreshing saved systems. This keeps the visible form out of a permanently dirty state after credentials are saved, without echoing secrets back into the browser.
+
+Loading a saved WebAPI or SQL Server system also clears credential draft fields. Optional WebAPI `healthPath` reloads as blank when the saved config omits it, preserving the operator's "skip health check" choice instead of reintroducing the default path.
+
+## Backend Contract Pin
+
+`http-routes.test.cjs` now includes a route-level test for the saved-system-only contract:
+
+- `getExternalSystemForAdapter()` returns `ExternalSystemNotFoundError`.
+- The request body includes a full unsaved K3 draft with config and credentials.
+- The route returns `404`.
+- No adapter is created.
+- No connection test runs.
+- No external system upsert occurs.
+
+This prevents future changes from accidentally making `/external-systems/:id/test` consume or persist unsaved request-body drafts.
+
+## Out Of Scope
+
+- Adding an unsaved-draft "test without save" backend endpoint.
+- Returning saved credential values to the frontend.
+- Changing adapter connection semantics.
+- Treating pipeline-only edits as connection-test blockers.

--- a/docs/development/integration-k3wise-test-unsaved-draft-guard-verification-20260506.md
+++ b/docs/development/integration-k3wise-test-unsaved-draft-guard-verification-20260506.md
@@ -1,0 +1,94 @@
+# K3 WISE Saved-Draft Test Guard Verification - 2026-05-06
+
+## Scope
+
+Verified that the K3 WISE setup page does not allow connection tests against stale persisted WebAPI or SQL Server systems after local unsaved connection edits.
+
+Changed files:
+
+- `apps/web/src/services/integration/k3WiseSetup.ts`
+- `apps/web/src/views/IntegrationK3WiseSetupView.vue`
+- `apps/web/tests/k3WiseSetup.spec.ts`
+- `plugins/plugin-integration-core/__tests__/http-routes.test.cjs`
+- `docs/development/integration-k3wise-test-unsaved-draft-guard-development-20260506.md`
+- `docs/development/integration-k3wise-test-unsaved-draft-guard-verification-20260506.md`
+
+## Checks
+
+### Backend Route Contract
+
+Command:
+
+```bash
+node --test plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+```
+
+Result:
+
+```text
+http-routes: REST auth/list/upsert/run/dry-run/staging/replay tests passed
+```
+
+Coverage added:
+
+- A missing external system returns `404`.
+- The test route ignores unsaved draft config and credentials in the request body.
+- No adapter is instantiated for a missing saved system.
+- No connection test or status upsert runs.
+
+### Focused Frontend Helper Test
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run --watch=false tests/k3WiseSetup.spec.ts
+```
+
+Expected result:
+
+```text
+tests/k3WiseSetup.spec.ts: 22 tests passed
+```
+
+Coverage added:
+
+- WebAPI saved/draft fingerprints are equal after loading a saved system.
+- Pipeline-only edits do not block connection testing.
+- WebAPI transport edits and credential replacement drafts block testing.
+- SQL Server saved/draft fingerprints are equal after loading a saved system.
+- SQL channel edits and credential replacement drafts block testing.
+- Loading a saved system clears credential draft fields.
+- Missing selected saved systems are treated as stale.
+- Empty saved `healthPath` stays empty instead of falling back to the default health endpoint.
+
+### Frontend Type Check
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web type-check
+```
+
+Result:
+
+```text
+passed
+```
+
+### Diff Hygiene
+
+Command:
+
+```bash
+git diff --check
+```
+
+Expected result:
+
+```text
+passed
+```
+
+## Live Validation
+
+This change does not require live K3 WISE access. It guards the operator setup page and pins the plugin route contract locally. Live ERP validation remains dependent on the customer GATE packet and saved external-system credentials.

--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -495,6 +495,53 @@ async function testExternalSystemTestPersistsFailureAndPreservesInactive() {
   assert.equal(inactiveUpdate.lastError, null)
 }
 
+async function testExternalSystemTestRequiresSavedSystem() {
+  const { calls, services } = createMockServices({
+    externalSystemRegistry: {
+      async getExternalSystemForAdapter(input) {
+        calls.push(['getExternalSystemForAdapter', input])
+        const error = new Error('external system not found')
+        error.name = 'ExternalSystemNotFoundError'
+        throw error
+      },
+    },
+    adapterRegistry: {
+      createAdapter(input) {
+        calls.push(['createAdapter', input])
+        return {
+          async testConnection() {
+            calls.push(['testConnection'])
+            return { ok: true, status: 200 }
+          },
+        }
+      },
+    },
+  })
+  const { routes } = mountRoutes(services)
+
+  const res = await invoke(routes, 'POST', '/api/integration/external-systems/:id/test', {
+    user: WRITE_USER,
+    params: { id: 'missing_sys' },
+    query: { workspaceId: 'workspace_1' },
+    body: {
+      name: 'Unsaved K3 draft',
+      kind: 'erp:k3-wise-webapi',
+      config: { baseUrl: 'https://draft.example.test/K3API/' },
+      credentials: { username: 'draft-user', password: 'draft-password', acctId: 'AIS_DRAFT' },
+    },
+  })
+
+  assertErrorResponse(res, [404])
+  assert.deepEqual(findCall(calls, 'getExternalSystemForAdapter')[1], {
+    id: 'missing_sys',
+    tenantId: 'tenant_1',
+    workspaceId: 'workspace_1',
+  })
+  assert.equal(findCalls(calls, 'createAdapter').length, 0, 'missing systems do not instantiate adapters')
+  assert.equal(findCalls(calls, 'testConnection').length, 0, 'missing systems do not run connection tests')
+  assert.equal(findCalls(calls, 'upsertExternalSystem').length, 0, 'request body drafts are not persisted by test route')
+}
+
 async function testPipelineRoutes() {
   const { calls, services } = createMockServices()
   const { routes } = mountRoutes(services)
@@ -1094,6 +1141,7 @@ async function main() {
   await testUnauthenticatedWriteRequestIsRejected()
   await testExternalSystemRoutes()
   await testExternalSystemTestPersistsFailureAndPreservesInactive()
+  await testExternalSystemTestRequiresSavedSystem()
   await testPipelineRoutes()
   await testStagingRoutes()
   await testRunAndDeadLetterRoutes()


### PR DESCRIPTION
## Summary

- Block K3 WISE WebAPI and SQL Server connection tests when the visible setup form has unsaved connection changes.
- Add saved/draft fingerprints that compare only connection-relevant fields and credential-draft presence, never secret values.
- Clear credential replacement fields after save/load and preserve an intentionally blank healthPath.
- Pin the backend route contract: /external-systems/:id/test only tests persisted systems and ignores unsaved request-body drafts.

## Design / Verification Docs

- docs/development/integration-k3wise-test-unsaved-draft-guard-development-20260506.md
- docs/development/integration-k3wise-test-unsaved-draft-guard-verification-20260506.md

## Verification

- node --test plugins/plugin-integration-core/__tests__/http-routes.test.cjs
- pnpm --filter @metasheet/web exec vitest run --watch=false tests/k3WiseSetup.spec.ts
- pnpm --filter @metasheet/web type-check
- git diff --check

## Notes

- This PR may need a base update if #1344 merges first because both touch apps/web/src/services/integration/k3WiseSetup.ts.
