### PR TITLE
fix(multitable): prevent hierarchy parent cycles

### DIFF
--- a/docs/development/multitable-hierarchy-cycle-guard-design-20260506.md
+++ b/docs/development/multitable-hierarchy-cycle-guard-design-20260506.md
@@ -1,0 +1,63 @@
+# Multitable Hierarchy Cycle Guard Design - 2026-05-06
+
+## Scope
+
+This slice completes the Phase 7 optional backlog item "Hierarchy server-side cycle prevention".
+
+Implemented:
+
+- A shared backend guard in `packages/core-backend/src/multitable/hierarchy-cycle-guard.ts`.
+- Cycle prevention in `RecordWriteService.patchRecords()`, the authoritative batch write seam used by Workbench and Yjs bridge.
+- Cycle prevention in `RecordService.patchRecord()`, the legacy single-record PATCH seam used by `/api/multitable/records/:recordId`.
+- Field order alignment for hierarchy auto-parent fallback in the REST batch patch route and Yjs bridge write-input builder.
+
+Not implemented:
+
+- Global repair of already-corrupted hierarchy data.
+- Multi-parent hierarchy semantics. The guard checks every submitted parent id, but the product hierarchy UI remains a single-parent model.
+- Frontend changes. The previous drag-to-reparent slice already added UX guards; this slice is backend authoritative validation.
+
+## Guard Contract
+
+The guard only applies when all conditions are true:
+
+- the changed field is a `link` field
+- the link field targets the same sheet (`foreignSheetId === sheetId`)
+- at least one hierarchy view exists on the sheet
+- the changed link field is the configured `parentFieldId` for that hierarchy view
+- if a hierarchy view has no valid `parentFieldId`, the guard uses the first link field by field order, matching `resolveHierarchyViewConfig()` on the frontend
+
+This avoids blocking arbitrary same-sheet relationship fields that are not used as hierarchy parent fields.
+
+## Cycle Detection
+
+For each hierarchy parent update, the backend walks the proposed parent chain:
+
+1. Start from each submitted parent id.
+2. If any parent id equals the moving record id, reject.
+3. Read the parent record's current parent ids using `SELECT data ... FOR UPDATE`.
+4. Continue walking upward until the chain ends, an unrelated existing cycle repeats, or the moving record is reached.
+
+The guard also considers same-request batch overrides from `RecordWriteService.patchRecords()`. That closes cases where a batch update would be acyclic per individual old DB rows but cyclic after applying all submitted parent changes.
+
+## Error Shape
+
+The shared module raises `HierarchyCycleError` with code `HIERARCHY_CYCLE`.
+
+Each service maps it into that service's existing validation error class:
+
+- `RecordWriteService` -> `RecordValidationError(code='HIERARCHY_CYCLE')`
+- `RecordService` -> `RecordValidationError(code='HIERARCHY_CYCLE')`
+
+Existing route error mapping then returns a 400 validation response instead of a 500.
+
+## Files
+
+- `packages/core-backend/src/multitable/hierarchy-cycle-guard.ts`
+- `packages/core-backend/src/multitable/record-write-service.ts`
+- `packages/core-backend/src/multitable/record-service.ts`
+- `packages/core-backend/src/routes/univer-meta.ts`
+- `packages/core-backend/src/index.ts`
+- `packages/core-backend/tests/unit/record-write-service.test.ts`
+- `packages/core-backend/tests/unit/record-service.test.ts`
+

--- a/docs/development/multitable-hierarchy-cycle-guard-verification-20260506.md
+++ b/docs/development/multitable-hierarchy-cycle-guard-verification-20260506.md
@@ -1,0 +1,73 @@
+# Multitable Hierarchy Cycle Guard Verification - 2026-05-06
+
+## Environment
+
+- Worktree: `/private/tmp/ms2-hierarchy-cycle-guard-20260506`
+- Branch: `codex/multitable-hierarchy-cycle-guard-20260506`
+- Base: `origin/main@2b72e30d90ddc11214a4acb54c4877918d7af6b1`
+- Dependency setup: `pnpm install --frozen-lockfile`
+
+`pnpm install` recreated local workspace dependency symlink noise under `plugins/*/node_modules` and `tools/cli/node_modules`. Those files are not part of this feature commit.
+
+## Automated Verification
+
+### Focused backend unit tests
+
+Command:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/record-write-service.test.ts tests/unit/record-service.test.ts --reporter=dot
+```
+
+Result:
+
+```text
+Test Files  2 passed (2)
+Tests       56 passed (56)
+```
+
+Coverage added:
+
+- `RecordWriteService.patchRecords()` rejects hierarchy parent updates that would move a record under its descendant.
+- `RecordWriteService.patchRecords()` applies the same first-link fallback used by frontend hierarchy view config.
+- `RecordService.patchRecord()` rejects direct legacy single-record patches that would create a hierarchy cycle.
+
+Expected stderr:
+
+- Existing post-commit hook tests intentionally log `purge failed` and `hook failed`.
+- Existing pool manager startup warning appears when `DATABASE_URL` is unset.
+
+### Backend build
+
+Command:
+
+```bash
+pnpm --filter @metasheet/core-backend build
+```
+
+Result: exit 0.
+
+### Whitespace guard
+
+Command:
+
+```bash
+git diff --check -- packages/core-backend/src/multitable/hierarchy-cycle-guard.ts packages/core-backend/src/multitable/record-write-service.ts packages/core-backend/src/multitable/record-service.ts packages/core-backend/src/routes/univer-meta.ts packages/core-backend/src/index.ts packages/core-backend/tests/unit/record-write-service.test.ts packages/core-backend/tests/unit/record-service.test.ts
+```
+
+Result: exit 0.
+
+## Manual Verification Notes
+
+Recommended staging smoke after merge:
+
+1. Create a hierarchy view on a sheet with a same-sheet single link parent field.
+2. Build `Root -> Child`.
+3. Try to patch `Root.parent = Child` through Workbench drag-to-reparent or the REST patch API.
+4. Confirm the response is a validation failure with code `HIERARCHY_CYCLE`.
+5. Confirm normal moves, moving to root, and non-hierarchy same-sheet link fields still work.
+
+## Residual Risk
+
+The guard prevents new hierarchy cycles on the two update seams covered here. It does not repair existing corrupted records. If production data already contains cycles, a separate audit/repair command should detect and clear them explicitly.
+

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -2070,12 +2070,12 @@ export class MetaSheetServer {
               const sheetId = String((recResult.rows[0] as any).sheet_id)
 
               const fieldResult = await pool.query(
-                'SELECT id, name, type, property FROM meta_fields WHERE sheet_id = $1',
+                'SELECT id, name, type, property, "order" FROM meta_fields WHERE sheet_id = $1 ORDER BY "order" ASC, id ASC',
                 [sheetId],
               )
               const fields = (fieldResult.rows as any[]).map((f: any) => {
                 const prop = f.property && typeof f.property === 'object' ? f.property : {}
-                return { id: String(f.id), name: String(f.name), type: f.type, property: prop, options: prop.options }
+                return { id: String(f.id), name: String(f.name), type: f.type, property: prop, options: prop.options, order: Number(f.order ?? 0) }
               })
 
               // Build real field mutation guards from DB (same logic as buildFieldMutationGuardMap)

--- a/packages/core-backend/src/multitable/hierarchy-cycle-guard.ts
+++ b/packages/core-backend/src/multitable/hierarchy-cycle-guard.ts
@@ -1,0 +1,150 @@
+import { normalizeJson } from './field-codecs'
+
+export type HierarchyCycleGuardQueryFn = (
+  sql: string,
+  params?: unknown[],
+) => Promise<{ rows: unknown[]; rowCount?: number | null }>
+
+export type HierarchyCycleField = {
+  id: string
+  type: string
+  order?: number
+  property?: Record<string, unknown>
+}
+
+export type HierarchyCycleLinkGuard = {
+  type: string
+  link?: {
+    foreignSheetId: string
+    limitSingleRecord: boolean
+  } | null
+}
+
+export type HierarchyCycleChange = {
+  fieldId: string
+  value: unknown
+}
+
+export class HierarchyCycleError extends Error {
+  constructor(
+    message: string,
+    public code = 'HIERARCHY_CYCLE',
+  ) {
+    super(message)
+    this.name = 'HierarchyCycleError'
+  }
+}
+
+function stringOrNull(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null
+}
+
+function firstLinkFieldId(fields: HierarchyCycleField[]): string | null {
+  const linkField = [...fields]
+    .sort((a, b) => (a.order ?? Number.MAX_SAFE_INTEGER) - (b.order ?? Number.MAX_SAFE_INTEGER) || a.id.localeCompare(b.id))
+    .find((field) => field.type === 'link')
+  return linkField?.id ?? null
+}
+
+export function collectSameSheetLinkChangeFieldIds(input: {
+  changesByRecord: Map<string, HierarchyCycleChange[]>
+  fieldById: Map<string, HierarchyCycleLinkGuard>
+  sheetId: string
+}): Set<string> {
+  const fieldIds = new Set<string>()
+  for (const changes of input.changesByRecord.values()) {
+    for (const change of changes) {
+      const field = input.fieldById.get(change.fieldId)
+      if (field?.type === 'link' && field.link?.foreignSheetId === input.sheetId) {
+        fieldIds.add(change.fieldId)
+      }
+    }
+  }
+  return fieldIds
+}
+
+export async function loadHierarchyParentFieldIds(input: {
+  query: HierarchyCycleGuardQueryFn
+  sheetId: string
+  fields: HierarchyCycleField[]
+}): Promise<Set<string>> {
+  const linkFieldIds = new Set(input.fields.filter((field) => field.type === 'link').map((field) => field.id))
+  if (linkFieldIds.size === 0) return new Set()
+
+  const fallbackParentFieldId = firstLinkFieldId(input.fields)
+  const result = await input.query(
+    'SELECT id, config FROM meta_views WHERE sheet_id = $1 AND type = $2',
+    [input.sheetId, 'hierarchy'],
+  )
+  const parentFieldIds = new Set<string>()
+  for (const row of result.rows as Array<Record<string, unknown>>) {
+    const config = normalizeJson(row.config)
+    const configuredParentFieldId = stringOrNull(config.parentFieldId)
+    if (configuredParentFieldId && linkFieldIds.has(configuredParentFieldId)) {
+      parentFieldIds.add(configuredParentFieldId)
+      continue
+    }
+    if (fallbackParentFieldId) {
+      parentFieldIds.add(fallbackParentFieldId)
+    }
+  }
+  return parentFieldIds
+}
+
+export function buildHierarchyParentOverridesByField(input: {
+  changesByRecord: Map<string, HierarchyCycleChange[]>
+  hierarchyParentFieldIds: Set<string>
+  normalizeLinkIds: (value: unknown) => string[]
+}): Map<string, Map<string, string[]>> {
+  const overridesByField = new Map<string, Map<string, string[]>>()
+  for (const [recordId, changes] of input.changesByRecord.entries()) {
+    for (const change of changes) {
+      if (!input.hierarchyParentFieldIds.has(change.fieldId)) continue
+      const ids = input.normalizeLinkIds(change.value)
+      if (!overridesByField.has(change.fieldId)) overridesByField.set(change.fieldId, new Map())
+      overridesByField.get(change.fieldId)?.set(recordId, ids)
+    }
+  }
+  return overridesByField
+}
+
+export async function assertNoHierarchyParentCycle(input: {
+  query: HierarchyCycleGuardQueryFn
+  sheetId: string
+  recordId: string
+  fieldId: string
+  parentRecordIds: string[]
+  parentOverridesByRecord: Map<string, string[]>
+  normalizeLinkIds: (value: unknown) => string[]
+}): Promise<void> {
+  const queue = [...input.parentRecordIds]
+  const visited = new Set<string>()
+
+  while (queue.length > 0) {
+    const currentId = queue.shift()
+    if (!currentId) continue
+    if (currentId === input.recordId) {
+      throw new HierarchyCycleError(
+        `Hierarchy parent update would create a cycle for record ${input.recordId} via field ${input.fieldId}`,
+      )
+    }
+    if (visited.has(currentId)) continue
+    visited.add(currentId)
+
+    const overrideParents = input.parentOverridesByRecord.get(currentId)
+    if (overrideParents) {
+      queue.push(...overrideParents)
+      continue
+    }
+
+    const result = await input.query(
+      'SELECT data FROM meta_records WHERE sheet_id = $1 AND id = $2 FOR UPDATE',
+      [input.sheetId, currentId],
+    )
+    const row = (result.rows as Array<Record<string, unknown>>)[0]
+    if (!row) continue
+    const data = normalizeJson(row.data)
+    queue.push(...input.normalizeLinkIds(data[input.fieldId]))
+  }
+}
+

--- a/packages/core-backend/src/multitable/record-service.ts
+++ b/packages/core-backend/src/multitable/record-service.ts
@@ -16,6 +16,13 @@ import {
   validateLongTextValue,
   type MultitableField,
 } from './field-codecs'
+import {
+  HierarchyCycleError,
+  assertNoHierarchyParentCycle,
+  buildHierarchyParentOverridesByField,
+  collectSameSheetLinkChangeFieldIds,
+  loadHierarchyParentFieldIds,
+} from './hierarchy-cycle-guard'
 import { allocateAutoNumberValues } from './auto-number-service'
 import { getDefaultValidationRules, validateRecord } from './field-validation-engine'
 import type { FieldValidationConfig } from './field-validation'
@@ -826,6 +833,32 @@ export class RecordService {
       throw new RecordPatchFieldValidationError(fieldErrors)
     }
 
+    const changesByRecord = new Map<string, Array<{ fieldId: string; value: unknown }>>([
+      [recordId, Object.entries(data).map(([fieldId, value]) => ({ fieldId, value }))],
+    ])
+    const sameSheetLinkChangeFieldIds = collectSameSheetLinkChangeFieldIds({
+      changesByRecord,
+      fieldById,
+      sheetId,
+    })
+    const hierarchyParentFieldIds = sameSheetLinkChangeFieldIds.size > 0
+      ? await loadHierarchyParentFieldIds({
+          query: this.pool.query.bind(this.pool),
+          sheetId,
+          fields,
+        })
+      : new Set<string>()
+    const guardedHierarchyParentFieldIds = new Set(
+      [...sameSheetLinkChangeFieldIds].filter((fieldId) => hierarchyParentFieldIds.has(fieldId)),
+    )
+    const hierarchyParentOverridesByField = guardedHierarchyParentFieldIds.size > 0
+      ? buildHierarchyParentOverridesByField({
+          changesByRecord,
+          hierarchyParentFieldIds: guardedHierarchyParentFieldIds,
+          normalizeLinkIds,
+        })
+      : new Map<string, Map<string, string[]>>()
+
     let nextVersion = 1
     let pendingSubscriberNotification: NotifyRecordSubscribersInput | null = null
     await this.pool.transaction(async ({ query }) => {
@@ -852,6 +885,28 @@ export class RecordService {
         throw new VersionConflictError(recordId, serverVersion)
       }
       const previousData = normalizeJson(currentRow.data)
+
+      for (const [fieldId, { ids, cfg }] of linkUpdates.entries()) {
+        if (ids.length === 0 || !guardedHierarchyParentFieldIds.has(fieldId) || cfg.foreignSheetId !== sheetId) {
+          continue
+        }
+        try {
+          await assertNoHierarchyParentCycle({
+            query,
+            sheetId,
+            recordId,
+            fieldId,
+            parentRecordIds: ids,
+            parentOverridesByRecord: hierarchyParentOverridesByField.get(fieldId) ?? new Map(),
+            normalizeLinkIds,
+          })
+        } catch (error) {
+          if (error instanceof HierarchyCycleError) {
+            throw new RecordValidationError(error.message, error.code)
+          }
+          throw error
+        }
+      }
 
       if (Object.keys(patch).length > 0) {
         const updateRes = await query(

--- a/packages/core-backend/src/multitable/record-write-service.ts
+++ b/packages/core-backend/src/multitable/record-write-service.ts
@@ -23,6 +23,13 @@ import {
   type YjsInvalidator,
 } from './post-commit-hooks'
 import { BATCH1_FIELD_TYPES, coerceBatch1Value, normalizeMultiSelectValue, validateLongTextValue } from './field-codecs'
+import {
+  HierarchyCycleError,
+  assertNoHierarchyParentCycle,
+  buildHierarchyParentOverridesByField,
+  collectSameSheetLinkChangeFieldIds,
+  loadHierarchyParentFieldIds,
+} from './hierarchy-cycle-guard'
 import { recordRecordRevision } from './record-history-service'
 import {
   notifyRecordSubscribersBestEffort,
@@ -481,6 +488,28 @@ export class RecordWriteService {
     // Step 0: Validate changes (field writability + value constraints)
     // -----------------------------------------------------------------------
     await this.validateChanges({ sheetId, changesByRecord, fieldById })
+    const sameSheetLinkChangeFieldIds = collectSameSheetLinkChangeFieldIds({
+      changesByRecord,
+      fieldById,
+      sheetId,
+    })
+    const hierarchyParentFieldIds = sameSheetLinkChangeFieldIds.size > 0
+      ? await loadHierarchyParentFieldIds({
+          query: this.pool.query.bind(this.pool),
+          sheetId,
+          fields,
+        })
+      : new Set<string>()
+    const guardedHierarchyParentFieldIds = new Set(
+      [...sameSheetLinkChangeFieldIds].filter((fieldId) => hierarchyParentFieldIds.has(fieldId)),
+    )
+    const hierarchyParentOverridesByField = guardedHierarchyParentFieldIds.size > 0
+      ? buildHierarchyParentOverridesByField({
+          changesByRecord,
+          hierarchyParentFieldIds: guardedHierarchyParentFieldIds,
+          normalizeLinkIds: h.normalizeLinkIds,
+        })
+      : new Map<string, Map<string, string[]>>()
 
     // -----------------------------------------------------------------------
     // Step 1: DB transaction
@@ -585,7 +614,7 @@ export class RecordWriteService {
         if (applied === 0) continue
 
         // Validate link targets exist
-        for (const { ids, cfg } of linkUpdates.values()) {
+        for (const [fieldId, { ids, cfg }] of linkUpdates.entries()) {
           if (ids.length === 0) continue
           const exists = await query(
             'SELECT id FROM meta_records WHERE sheet_id = $1 AND id = ANY($2::text[])',
@@ -597,6 +626,24 @@ export class RecordWriteService {
             throw new RecordValidationError(
               `Linked record(s) not found in sheet ${cfg.foreignSheetId}: ${missing.join(', ')}`,
             )
+          }
+          if (guardedHierarchyParentFieldIds.has(fieldId) && cfg.foreignSheetId === sheetId) {
+            try {
+              await assertNoHierarchyParentCycle({
+                query,
+                sheetId,
+                recordId,
+                fieldId,
+                parentRecordIds: ids,
+                parentOverridesByRecord: hierarchyParentOverridesByField.get(fieldId) ?? new Map(),
+                normalizeLinkIds: h.normalizeLinkIds,
+              })
+            } catch (error) {
+              if (error instanceof HierarchyCycleError) {
+                throw new RecordValidationError(error.message, error.code)
+              }
+              throw error
+            }
           }
         }
 

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -7326,7 +7326,7 @@ export function univerMetaRouter(): Router {
       if (!capabilities.canEditRecord) return sendForbidden(res)
 
       const fieldRes = await pool.query(
-        'SELECT id, name, type, property FROM meta_fields WHERE sheet_id = $1',
+        'SELECT id, name, type, property, "order" FROM meta_fields WHERE sheet_id = $1 ORDER BY "order" ASC, id ASC',
         [sheetId],
       )
       if (fieldRes.rows.length === 0) {

--- a/packages/core-backend/tests/unit/record-service.test.ts
+++ b/packages/core-backend/tests/unit/record-service.test.ts
@@ -70,6 +70,12 @@ function createMockPool(
     if (sql.includes('INSERT INTO meta_record_subscription_notifications')) {
       return responses.INSERT_RECORD_SUBSCRIPTION_NOTIFICATIONS ?? { rows: [], rowCount: 1 }
     }
+    if (sql.includes('SELECT id, config FROM meta_views WHERE sheet_id = $1 AND type = $2')) {
+      return responses.SELECT_HIERARCHY_VIEWS ?? { rows: [] }
+    }
+    if (sql.includes('SELECT data FROM meta_records WHERE sheet_id = $1 AND id = $2 FOR UPDATE')) {
+      return responses.SELECT_HIERARCHY_PARENT_RECORD ?? { rows: [] }
+    }
     if (sql.includes('INSERT INTO meta_field_auto_number_sequences')) {
       return responses.ALLOCATE_AUTO_NUMBER ?? { rows: [{ value: 1 }], rowCount: 1 }
     }
@@ -371,6 +377,34 @@ describe('RecordService', () => {
         expect.stringContaining('"user_id":"watcher_1"'),
       ]),
     )
+  })
+
+  it('rejects direct record patches that would create a hierarchy cycle', async () => {
+    pool = createMockPool({
+      SELECT_FIELDS: {
+        rows: [
+          { id: 'fld_title', name: 'Title', type: 'string', property: {}, order: 0 },
+          { id: 'fld_parent', name: 'Parent', type: 'link', property: { foreignSheetId: 'sheet_ops', limitSingleRecord: true }, order: 1 },
+        ],
+      },
+      SELECT_LINK_TARGETS: { rows: [{ id: 'rec_child' }] },
+      SELECT_HIERARCHY_VIEWS: { rows: [{ id: 'view_hierarchy', config: { parentFieldId: 'fld_parent' } }] },
+      SELECT_PATCH_FOR_UPDATE: {
+        rows: [{ id: 'rec_root', version: 4, data: { fld_title: 'Root' }, created_by: 'user_1' }],
+      },
+      SELECT_HIERARCHY_PARENT_RECORD: { rows: [{ data: { fld_parent: ['rec_root'] } }] },
+    })
+    const service = new RecordService(pool, eventBus as any)
+
+    await expect(service.patchRecord({
+      recordId: 'rec_root',
+      sheetId: 'sheet_ops',
+      data: { fld_parent: ['rec_child'] },
+      actorId: 'user_1',
+      access: { userId: 'user_1', permissions: [], isAdminRole: false },
+      capabilities: fullCapabilities,
+    })).rejects.toMatchObject({ code: 'HIERARCHY_CYCLE' })
+    expect(pool.queryMock).not.toHaveBeenCalledWith(expect.stringContaining('UPDATE meta_records'), expect.anything())
   })
 
   it('throws VersionConflictError when delete expectedVersion does not match', async () => {

--- a/packages/core-backend/tests/unit/record-write-service.test.ts
+++ b/packages/core-backend/tests/unit/record-write-service.test.ts
@@ -81,6 +81,12 @@ function createMockPool(queryResponses: Record<string, { rows: unknown[] }> = {}
     if (sql.includes('INSERT INTO meta_record_subscription_notifications')) {
       return queryResponses['INSERT_RECORD_SUBSCRIPTION_NOTIFICATIONS'] ?? { rows: [], rowCount: 1 }
     }
+    if (sql.includes('SELECT id, config FROM meta_views WHERE sheet_id = $1 AND type = $2')) {
+      return queryResponses['SELECT_HIERARCHY_VIEWS'] ?? { rows: [] }
+    }
+    if (sql.includes('SELECT data FROM meta_records WHERE sheet_id = $1 AND id = $2 FOR UPDATE')) {
+      return queryResponses['SELECT_HIERARCHY_PARENT_RECORD'] ?? { rows: [] }
+    }
     if (sql.includes('SELECT id, version, data FROM meta_records')) {
       return queryResponses['SELECT_UPDATED'] ?? defaultQueryResponse
     }
@@ -430,6 +436,78 @@ describe('RecordWriteService', () => {
 
     const service = new RecordWriteService(linkPool, eventBus as any, linkHelpers)
     await expect(service.patchRecords(input)).rejects.toThrow(RecordValidationError)
+  })
+
+  it('rejects hierarchy parent link updates that would create a cycle', async () => {
+    const linkHelpers = createMockHelpers({
+      normalizeLinkIds: (value) => (Array.isArray(value) ? value.map(String) : []),
+      parseLinkFieldConfig: () => ({ foreignSheetId: 'sheet1', limitSingleRecord: true }),
+    })
+    const linkPool = createMockPool({
+      SELECT_FOR_UPDATE: { rows: [{ id: 'rec_root', version: 1, data: { fld_title: 'Root' }, created_by: 'user1' }] },
+      SELECT_LINK_TARGETS: { rows: [{ id: 'rec_child' }] },
+      SELECT_HIERARCHY_VIEWS: { rows: [{ id: 'view_hierarchy', config: { parentFieldId: 'fld_parent' } }] },
+      SELECT_HIERARCHY_PARENT_RECORD: { rows: [{ data: { fld_parent: ['rec_root'] } }] },
+    })
+    const fields: UniverMetaField[] = [
+      { id: 'fld_title', name: 'Title', type: 'string', order: 0 },
+      { id: 'fld_parent', name: 'Parent', type: 'link', order: 1, property: { foreignSheetId: 'sheet1', limitSingleRecord: true } },
+    ]
+    const fieldById = new Map([
+      ['fld_title', { type: 'string' as const, readOnly: false, hidden: false }],
+      ['fld_parent', { type: 'link' as const, readOnly: false, hidden: false, link: { foreignSheetId: 'sheet1', limitSingleRecord: true } }],
+    ])
+    const input = buildTestInput({
+      sheetId: 'sheet1',
+      fields,
+      visiblePropertyFields: fields,
+      visiblePropertyFieldIds: new Set(fields.map((field) => field.id)),
+      fieldById: fieldById as any,
+      changesByRecord: new Map([
+        ['rec_root', [{ fieldId: 'fld_parent', value: ['rec_child'] }]],
+      ]),
+    })
+    const service = new RecordWriteService(linkPool, eventBus as any, linkHelpers)
+
+    await expect(service.patchRecords(input)).rejects.toThrow(RecordValidationError)
+    await expect(service.patchRecords(input)).rejects.toMatchObject({ code: 'HIERARCHY_CYCLE' })
+    expect(linkPool.query).not.toHaveBeenCalledWith(expect.stringContaining('UPDATE meta_records'), expect.anything())
+  })
+
+  it('uses the first link field as the server-side hierarchy parent fallback', async () => {
+    const linkHelpers = createMockHelpers({
+      normalizeLinkIds: (value) => (Array.isArray(value) ? value.map(String) : []),
+      parseLinkFieldConfig: () => ({ foreignSheetId: 'sheet1', limitSingleRecord: true }),
+    })
+    const linkPool = createMockPool({
+      SELECT_FOR_UPDATE: { rows: [{ id: 'rec_root', version: 1, data: { fld_title: 'Root' }, created_by: 'user1' }] },
+      SELECT_LINK_TARGETS: { rows: [{ id: 'rec_child' }] },
+      SELECT_HIERARCHY_VIEWS: { rows: [{ id: 'view_hierarchy', config: {} }] },
+      SELECT_HIERARCHY_PARENT_RECORD: { rows: [{ data: { fld_parent: ['rec_root'] } }] },
+    })
+    const fields: UniverMetaField[] = [
+      { id: 'fld_title', name: 'Title', type: 'string', order: 0 },
+      { id: 'fld_parent', name: 'Parent', type: 'link', order: 1, property: { foreignSheetId: 'sheet1', limitSingleRecord: true } },
+      { id: 'fld_related', name: 'Related', type: 'link', order: 2, property: { foreignSheetId: 'sheet1' } },
+    ]
+    const fieldById = new Map([
+      ['fld_title', { type: 'string' as const, readOnly: false, hidden: false }],
+      ['fld_parent', { type: 'link' as const, readOnly: false, hidden: false, link: { foreignSheetId: 'sheet1', limitSingleRecord: true } }],
+      ['fld_related', { type: 'link' as const, readOnly: false, hidden: false, link: { foreignSheetId: 'sheet1', limitSingleRecord: false } }],
+    ])
+    const input = buildTestInput({
+      sheetId: 'sheet1',
+      fields,
+      visiblePropertyFields: fields,
+      visiblePropertyFieldIds: new Set(fields.map((field) => field.id)),
+      fieldById: fieldById as any,
+      changesByRecord: new Map([
+        ['rec_root', [{ fieldId: 'fld_parent', value: ['rec_child'] }]],
+      ]),
+    })
+    const service = new RecordWriteService(linkPool, eventBus as any, linkHelpers)
+
+    await expect(service.patchRecords(input)).rejects.toMatchObject({ code: 'HIERARCHY_CYCLE' })
   })
 
   it('should trigger computed field recalculation when lookup/rollup fields exist', async () => {


### PR DESCRIPTION
## Summary
- add a shared backend hierarchy cycle guard for same-sheet hierarchy parent link fields
- enforce the guard in both RecordWriteService.patchRecords and RecordService.patchRecord
- align field ordering in batch REST/Yjs bridge field loads so auto parent-field fallback matches the frontend

## Verification
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/record-write-service.test.ts tests/unit/record-service.test.ts --reporter=dot
- pnpm --filter @metasheet/core-backend build
- git diff --check -- packages/core-backend/src/multitable/hierarchy-cycle-guard.ts packages/core-backend/src/multitable/record-write-service.ts packages/core-backend/src/multitable/record-service.ts packages/core-backend/src/routes/univer-meta.ts packages/core-backend/src/index.ts packages/core-backend/tests/unit/record-write-service.test.ts packages/core-backend/tests/unit/record-service.test.ts docs/development/multitable-hierarchy-cycle-guard-design-20260506.md docs/development/multitable-hierarchy-cycle-guard-verification-20260506.md

## Docs
- docs/development/multitable-hierarchy-cycle-guard-design-20260506.md
- docs/development/multitable-hierarchy-cycle-guard-verification-20260506.md

## Notes
- This prevents new cycles. It does not repair existing corrupted hierarchy data.
- Non-hierarchy same-sheet link fields remain allowed.