### PR TITLE
fix(integration): require K3 WebAPI auth transport

### DIFF
--- a/docs/development/integration-k3wise-webapi-auth-transport-guard-design-20260506.md
+++ b/docs/development/integration-k3wise-webapi-auth-transport-guard-design-20260506.md
@@ -1,0 +1,58 @@
+# K3 WISE WebAPI Auth Transport Guard Design - 2026-05-06
+
+## Goal
+
+Make K3 WISE WebAPI connection testing fail early when the login endpoint reports business success but does not return any auth material the Node adapter can reuse for later Save-only writes.
+
+Before this guard, `login()` could return an empty auth-header object after a successful login body with no `Set-Cookie` and no session id. In that case:
+
+- `testConnection({ skipHealth: true })` could report `ok: true` with `authenticated: false`.
+- A later material/BOM Save-only run would call K3 without session headers.
+- The operator would see a misleading green connection check before hitting unauthorized write failures.
+
+## Scope
+
+Changed files:
+
+- `plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs`
+- `plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs`
+- `scripts/ops/fixtures/integration-k3wise/mock-k3-webapi-server.mjs`
+- `scripts/ops/fixtures/integration-k3wise/mock-k3-webapi-server.test.mjs`
+- `package.json`
+
+## Adapter Contract
+
+`login()` now requires one of these auth transports:
+
+- A configured `credentials.sessionId`, which is converted to the configured session header.
+- A `Set-Cookie` header from the login response.
+- A session id in the login response body, including `config.sessionIdPath`, `sessionId`, `SessionId`, or `Result.SessionId`.
+
+If the login response is otherwise successful but none of those transports are present, the adapter throws `K3WiseWebApiAdapterError` with:
+
+- `code: "K3_WISE_AUTH_TRANSPORT_MISSING"`
+- the redaction-safe login response body in details for diagnosis.
+
+`testConnection()` surfaces that as a failed connection check, so customer GATE/live PoC work stops at setup instead of failing later during Save-only writes.
+
+## Mock Fixture Tightening
+
+The in-process mock K3 server now models two extra pieces of real endpoint behavior:
+
+- Method contracts:
+  - `POST /K3API/Login`
+  - `GET /K3API/Health`
+  - `POST /K3API/Material/{Save,Submit,Audit}`
+  - `POST /K3API/BOM/{Save,Submit,Audit}`
+- Auth-transport variants:
+  - Default behavior still returns `Set-Cookie` and `sessionId`.
+  - Tests can set `includeSessionCookie: false` and `includeSessionId: false` to model a bad login response.
+
+This keeps the offline PoC mock useful without letting it hide HTTP method or session transport mistakes.
+
+## Out Of Scope
+
+- Adding a cookie jar to the adapter.
+- Supporting implicit browser-style cookie persistence in Node fetch.
+- Changing K3 business success parsing.
+- Changing live customer credentials or GATE packet shape.

--- a/docs/development/integration-k3wise-webapi-auth-transport-guard-verification-20260506.md
+++ b/docs/development/integration-k3wise-webapi-auth-transport-guard-verification-20260506.md
@@ -1,0 +1,92 @@
+# K3 WISE WebAPI Auth Transport Guard Verification - 2026-05-06
+
+## Scope
+
+Verified that the K3 WISE WebAPI adapter no longer treats a login response as usable unless the response provides reusable auth material for later K3 Save-only calls.
+
+Changed files:
+
+- `plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs`
+- `plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs`
+- `scripts/ops/fixtures/integration-k3wise/mock-k3-webapi-server.mjs`
+- `scripts/ops/fixtures/integration-k3wise/mock-k3-webapi-server.test.mjs`
+- `package.json`
+- `docs/development/integration-k3wise-webapi-auth-transport-guard-design-20260506.md`
+- `docs/development/integration-k3wise-webapi-auth-transport-guard-verification-20260506.md`
+
+## Checks
+
+### Focused Adapter Test
+
+Command:
+
+```bash
+pnpm --dir plugins/plugin-integration-core run test:k3-wise-adapters
+```
+
+Expected result:
+
+```text
+k3-wise-adapters: WebAPI, SQL Server channel, and auto-flag coercion tests passed
+```
+
+Coverage added:
+
+- Successful login without `Set-Cookie` or session id returns a failed connection check.
+- The failure code is `K3_WISE_AUTH_TRANSPORT_MISSING`.
+- The adapter stops at login and does not continue to health checks after missing auth transport.
+
+### Mock K3 WebAPI Contract Test
+
+Command:
+
+```bash
+node --test scripts/ops/fixtures/integration-k3wise/mock-k3-webapi-server.test.mjs
+```
+
+Expected result:
+
+```text
+3 tests pass
+```
+
+Coverage added:
+
+- Happy-path login, health, and material Save endpoints still work.
+- Login/Save/Submit/Audit endpoints reject non-POST calls with `405` and `Allow: POST`.
+- Health rejects non-GET calls with `405` and `Allow: GET`.
+- The mock can model a business-success login response with no cookie and no session id.
+
+### Full Offline K3 PoC Chain
+
+Command:
+
+```bash
+pnpm run verify:integration-k3wise:poc
+```
+
+Expected result:
+
+```text
+K3 WISE PoC mock chain verified end-to-end (PASS)
+```
+
+This command now includes the mock K3 WebAPI contract test before running the end-to-end mock PoC demo.
+
+### Diff Hygiene
+
+Command:
+
+```bash
+git diff --check
+```
+
+Expected result:
+
+```text
+passed
+```
+
+## Live Validation
+
+This is an offline adapter and fixture contract hardening. It does not require live K3 WISE access. During live customer PoC, a K3 endpoint that reports login success but does not provide `Set-Cookie` or a configured session id will now fail during connection testing with a direct operator-readable code.

--- a/docs/development/integration-k3wise-webapi-relative-path-guard-development-20260507.md
+++ b/docs/development/integration-k3wise-webapi-relative-path-guard-development-20260507.md
@@ -1,0 +1,55 @@
+# K3 WISE WebAPI Relative Path Guard Development
+
+## Context
+
+The K3 WISE WebAPI adapter joins configured endpoint paths with
+`config.baseUrl` through `new URL(path, baseUrl)`. The existing path guard only
+rejected explicit `http://` and `https://` paths.
+
+That left two URL forms that Node normalizes away from the configured K3 host:
+
+- protocol-relative paths, for example `//evil.example.test/K3API/Login`;
+- backslash-prefixed paths, for example `\\evil.example.test\K3API\Login`.
+
+Both can resolve to a host outside `config.baseUrl`, which is not acceptable for
+K3 login, save, submit, or audit calls.
+
+The same URL construction path also treated endpoint paths as root-relative.
+For a customer packet shaped like `baseUrl: https://k3.example.test/K3API` and
+`loginPath: /login`, `new URL('/login', baseUrl)` drops the `/K3API` context.
+
+## Change
+
+`assertRelativePath()` now rejects:
+
+- any leading URL scheme such as `http:`, `https:`, or `k3api:`;
+- protocol-relative paths beginning with `//`;
+- any path containing a backslash.
+
+Normal K3 relative paths are unchanged:
+
+- `/K3API/Login`
+- `K3API/Login`
+- `/K3API/Foo:Bar`
+
+Request construction now uses a K3 adapter-local join helper that preserves a
+context path on `baseUrl` while avoiding duplicate prefixes. That keeps both
+forms valid:
+
+- `baseUrl=https://k3.example.test`, `loginPath=/K3API/Login`
+- `baseUrl=https://k3.example.test/K3API`, `loginPath=/login`
+
+The test coverage adds adapter-construction assertions for protocol-relative and
+backslash-normalized login paths, plus a live mock fetch assertion for baseUrl
+context-path preservation. The patch is intentionally stacked on PR #1352
+because that PR already owns the K3 WebAPI adapter auth transport changes.
+
+## Scope
+
+Changed files:
+
+- `plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs`
+- `plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs`
+
+No workflow, database, frontend, REST route, run-log, or external-system
+registry code is changed.

--- a/docs/development/integration-k3wise-webapi-relative-path-guard-verification-20260507.md
+++ b/docs/development/integration-k3wise-webapi-relative-path-guard-verification-20260507.md
@@ -1,0 +1,36 @@
+# K3 WISE WebAPI Relative Path Guard Verification
+
+## Commands
+
+```bash
+node plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
+git diff --check
+```
+
+## Local Result
+
+- `node plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs`:
+  passed.
+- `git diff --check`: passed.
+
+## Covered Cases
+
+The updated adapter test verifies:
+
+- the existing K3 WebAPI login, health, save, submit, and audit flow still works;
+- non-HTTP base URLs are still rejected;
+- protocol-relative `loginPath` values such as
+  `//evil.example.test/K3API/Login` are rejected before any request is made;
+- backslash-normalized `loginPath` values such as
+  `\\evil.example.test\K3API\Login` are rejected before any request is made;
+- `baseUrl` context paths are preserved, so
+  `baseUrl=https://k3.example.test/K3API`, `loginPath=/login`, and
+  `healthPath=/health` call `/K3API/login` and `/K3API/health`;
+- SQL Server channel and K3 WebAPI auto flag coercion coverage in the same test
+  file still passes.
+
+## Residual Risk
+
+This is a configuration validation hardening slice. It does not contact a real
+K3 WISE WebAPI endpoint. The risk being tested is URL construction, so the unit
+test exercises the adapter boundary directly with a mock fetch implementation.

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "profile:multitable-grid:local": "RUNNER_SCRIPT=scripts/profile-multitable-grid.mjs RUN_LABEL=multitable-grid-profile bash scripts/ops/multitable-pilot-local.sh",
     "profile:multitable-grid:staging": "RUNNER_SCRIPT=scripts/profile-multitable-grid.mjs RUN_LABEL=multitable-grid-profile-staging RUN_MODE=staging RUNNER_REPORT_BASENAME=staging-report AUTO_START_SERVICES=false REQUIRE_RUNNING_SERVICES=true bash scripts/ops/multitable-pilot-local.sh",
     "verify:multitable-grid-profile:summary": "node scripts/ops/multitable-grid-profile-summary.mjs",
-    "verify:integration-k3wise:poc": "node --test scripts/ops/integration-k3wise-live-poc-preflight.test.mjs && node --test scripts/ops/integration-k3wise-live-poc-evidence.test.mjs && node scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs",
+    "verify:integration-k3wise:poc": "node --test scripts/ops/integration-k3wise-live-poc-preflight.test.mjs && node --test scripts/ops/integration-k3wise-live-poc-evidence.test.mjs && node --test scripts/ops/fixtures/integration-k3wise/mock-k3-webapi-server.test.mjs && node scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs",
     "phase5:run-all": "bash scripts/phase5-run-all.sh",
     "build": "pnpm -r build",
     "test": "pnpm -r test",

--- a/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
@@ -231,6 +231,31 @@ async function testK3WebApiAdapter() {
     'missing auth transport fails at login and does not continue to health checks',
   )
 
+  const contextPathCalls = []
+  const contextPathAdapter = createK3WiseWebApiAdapter({
+    system: createK3WebApiSystem({
+      config: {
+        baseUrl: 'https://k3.example.test/K3API',
+        loginPath: '/login',
+        healthPath: '/health',
+      },
+    }),
+    fetchImpl: async (url) => {
+      const parsed = new URL(url)
+      contextPathCalls.push(parsed.pathname)
+      if (parsed.pathname === '/K3API/login') {
+        return jsonResponse(200, { success: true, sessionId: 'k3-context-session' })
+      }
+      if (parsed.pathname === '/K3API/health') {
+        return jsonResponse(200, { ok: true })
+      }
+      return jsonResponse(404, { success: false, message: 'not found' })
+    },
+  })
+  const contextPathStatus = await contextPathAdapter.testConnection()
+  assert.equal(contextPathStatus.ok, true, 'baseUrl context path is preserved for relative K3 paths')
+  assert.deepEqual(contextPathCalls, ['/K3API/login', '/K3API/health'])
+
   assert.equal(webApiInternals.businessSuccess({ success: true }, {}), true)
   assert.equal(webApiInternals.businessSuccess({ Result: { ResponseStatus: { IsSuccess: true } } }, {}), true)
   assert.equal(webApiInternals.businessSuccess({ Result: { ResponseStatus: { IsSuccess: false } } }, {}), false)
@@ -248,6 +273,42 @@ async function testK3WebApiAdapter() {
     }
   })()
   assert.ok(invalidBaseUrl instanceof AdapterValidationError, 'non-http K3 baseUrl rejected')
+
+  const protocolRelativeLoginPath = (() => {
+    try {
+      createK3WiseWebApiAdapter({
+        system: createK3WebApiSystem({
+          config: {
+            baseUrl: 'https://k3.example.test',
+            loginPath: '//evil.example.test/K3API/Login',
+          },
+        }),
+        fetchImpl,
+      })
+      return null
+    } catch (error) {
+      return error
+    }
+  })()
+  assert.ok(protocolRelativeLoginPath instanceof AdapterValidationError, 'protocol-relative K3 paths are rejected')
+
+  const backslashLoginPath = (() => {
+    try {
+      createK3WiseWebApiAdapter({
+        system: createK3WebApiSystem({
+          config: {
+            baseUrl: 'https://k3.example.test',
+            loginPath: '\\\\evil.example.test\\K3API\\Login',
+          },
+        }),
+        fetchImpl,
+      })
+      return null
+    } catch (error) {
+      return error
+    }
+  })()
+  assert.ok(backslashLoginPath instanceof AdapterValidationError, 'backslash-normalized K3 paths are rejected')
 
   assert.equal(K3WiseWebApiAdapterError.name, 'K3WiseWebApiAdapterError')
 }

--- a/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
@@ -209,6 +209,28 @@ async function testK3WebApiAdapter() {
   assert.equal(missingAcctIdStatus.code, 'K3_WISE_CREDENTIALS_MISSING')
   assert.match(missingAcctIdStatus.message, /acctId/)
 
+  const loginWithoutAuthTransportCalls = []
+  const loginWithoutAuthTransport = createK3WiseWebApiAdapter({
+    system: createK3WebApiSystem(),
+    fetchImpl: async (url, options = {}) => {
+      const parsed = new URL(url)
+      loginWithoutAuthTransportCalls.push({ pathname: parsed.pathname, options })
+      if (parsed.pathname === '/K3API/Login') {
+        return jsonResponse(200, { success: true })
+      }
+      return jsonResponse(200, { ok: true })
+    },
+  })
+  const missingAuthTransportStatus = await loginWithoutAuthTransport.testConnection({ skipHealth: true })
+  assert.equal(missingAuthTransportStatus.ok, false)
+  assert.equal(missingAuthTransportStatus.code, 'K3_WISE_AUTH_TRANSPORT_MISSING')
+  assert.match(missingAuthTransportStatus.message, /session cookie or session id/)
+  assert.deepEqual(
+    loginWithoutAuthTransportCalls.map((call) => call.pathname),
+    ['/K3API/Login'],
+    'missing auth transport fails at login and does not continue to health checks',
+  )
+
   assert.equal(webApiInternals.businessSuccess({ success: true }, {}), true)
   assert.equal(webApiInternals.businessSuccess({ Result: { ResponseStatus: { IsSuccess: true } } }, {}), true)
   assert.equal(webApiInternals.businessSuccess({ Result: { ResponseStatus: { IsSuccess: false } } }, {}), false)

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
@@ -419,6 +419,12 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
     )
     if (cookie) authHeaders.Cookie = cookie
     if (sessionId) authHeaders[config.sessionHeader || 'X-K3-Session'] = String(sessionId)
+    if (Object.keys(authHeaders).length === 0) {
+      throw new K3WiseWebApiAdapterError('K3 WISE WebAPI login succeeded but did not return a session cookie or session id', {
+        code: 'K3_WISE_AUTH_TRANSPORT_MISSING',
+        body: data,
+      })
+    }
     cachedAuthHeaders = authHeaders
     return cachedAuthHeaders
   }

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
@@ -93,10 +93,29 @@ function assertRelativePath(path, field) {
     throw new AdapterValidationError(`${field} is required`, { field })
   }
   const trimmed = path.trim()
-  if (/^https?:\/\//i.test(trimmed)) {
+  const hasScheme = /^[A-Za-z][A-Za-z0-9+.-]*:/.test(trimmed)
+  const isProtocolRelative = trimmed.startsWith('//')
+  const hasBackslash = trimmed.includes('\\')
+  if (hasScheme || isProtocolRelative || hasBackslash) {
     throw new AdapterValidationError(`${field} must be relative to baseUrl`, { field })
   }
   return trimmed.startsWith('/') ? trimmed : `/${trimmed}`
+}
+
+function buildEndpointUrl(baseUrl, path) {
+  const endpointPath = assertRelativePath(path, 'path')
+  const url = new URL(baseUrl)
+  const basePath = url.pathname && url.pathname !== '/'
+    ? url.pathname.replace(/\/+$/, '')
+    : ''
+  if (basePath && endpointPath !== basePath && !endpointPath.startsWith(`${basePath}/`)) {
+    url.pathname = `${basePath}${endpointPath}`
+  } else {
+    url.pathname = endpointPath
+  }
+  url.search = ''
+  url.hash = ''
+  return url.toString()
 }
 
 function normalizeHeaders(value, field) {
@@ -326,7 +345,7 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
   }
 
   async function requestJson(path, { method = 'GET', headers, body } = {}) {
-    const url = new URL(assertRelativePath(path, 'path'), baseUrl).toString()
+    const url = buildEndpointUrl(baseUrl, path)
     const controller = typeof AbortController === 'function' ? new AbortController() : null
     const timeout = controller ? setTimeout(() => controller.abort(), timeoutMs) : null
     const requestHeaders = mergeHeaders(

--- a/scripts/ops/fixtures/integration-k3wise/mock-k3-webapi-server.mjs
+++ b/scripts/ops/fixtures/integration-k3wise/mock-k3-webapi-server.mjs
@@ -13,7 +13,12 @@
 
 import { createServer } from 'node:http'
 
-export function createMockK3WebApiServer({ logger = () => {}, knownBadFNumbers = new Set(['BAD']) } = {}) {
+export function createMockK3WebApiServer({
+  logger = () => {},
+  knownBadFNumbers = new Set(['BAD']),
+  includeSessionCookie = true,
+  includeSessionId = true,
+} = {}) {
   const calls = []
 
   async function readBody(req) {
@@ -25,11 +30,24 @@ export function createMockK3WebApiServer({ logger = () => {}, knownBadFNumbers =
     })
   }
 
-  function jsonResponse(res, status, payload) {
+  function jsonResponse(res, status, payload, { setCookie = includeSessionCookie } = {}) {
     res.statusCode = status
     res.setHeader('Content-Type', 'application/json')
-    res.setHeader('Set-Cookie', 'K3SESSION=mock-cookie-1; Path=/; HttpOnly')
+    if (setCookie) res.setHeader('Set-Cookie', 'K3SESSION=mock-cookie-1; Path=/; HttpOnly')
     res.end(JSON.stringify(payload))
+  }
+
+  function requireMethod(req, res, expectedMethod) {
+    if (req.method === expectedMethod) return true
+    res.statusCode = 405
+    res.setHeader('Content-Type', 'application/json')
+    res.setHeader('Allow', expectedMethod)
+    res.end(JSON.stringify({
+      success: false,
+      message: `mock K3 method not allowed: ${req.method} ${req.url}`,
+      expectedMethod,
+    }))
+    return false
   }
 
   const server = createServer(async (req, res) => {
@@ -46,14 +64,20 @@ export function createMockK3WebApiServer({ logger = () => {}, knownBadFNumbers =
     logger({ method: req.method, pathname, body })
 
     if (pathname === '/K3API/Login') {
-      jsonResponse(res, 200, { success: true, sessionId: 'mock-session-1' })
+      if (!requireMethod(req, res, 'POST')) return
+      jsonResponse(res, 200, {
+        success: true,
+        ...(includeSessionId ? { sessionId: 'mock-session-1' } : {}),
+      })
       return
     }
     if (pathname === '/K3API/Health') {
+      if (!requireMethod(req, res, 'GET')) return
       jsonResponse(res, 200, { ok: true })
       return
     }
     if (pathname === '/K3API/Material/Save') {
+      if (!requireMethod(req, res, 'POST')) return
       const fNumber = body?.Model?.FNumber
       if (knownBadFNumbers.has(fNumber)) {
         jsonResponse(res, 200, { success: false, message: `mock K3 rejects ${fNumber}: invalid material code` })
@@ -63,14 +87,17 @@ export function createMockK3WebApiServer({ logger = () => {}, knownBadFNumbers =
       return
     }
     if (pathname === '/K3API/Material/Submit') {
+      if (!requireMethod(req, res, 'POST')) return
       jsonResponse(res, 200, { success: true, submitted: body?.Number })
       return
     }
     if (pathname === '/K3API/Material/Audit') {
+      if (!requireMethod(req, res, 'POST')) return
       jsonResponse(res, 200, { success: true, audited: body?.Number })
       return
     }
     if (pathname === '/K3API/BOM/Save') {
+      if (!requireMethod(req, res, 'POST')) return
       const fNumber = body?.Model?.FNumber
       if (knownBadFNumbers.has(fNumber)) {
         jsonResponse(res, 200, { success: false, message: `mock K3 BOM rejects ${fNumber}` })
@@ -80,10 +107,12 @@ export function createMockK3WebApiServer({ logger = () => {}, knownBadFNumbers =
       return
     }
     if (pathname === '/K3API/BOM/Submit') {
+      if (!requireMethod(req, res, 'POST')) return
       jsonResponse(res, 200, { success: true, submitted: body?.Number })
       return
     }
     if (pathname === '/K3API/BOM/Audit') {
+      if (!requireMethod(req, res, 'POST')) return
       jsonResponse(res, 200, { success: true, audited: body?.Number })
       return
     }

--- a/scripts/ops/fixtures/integration-k3wise/mock-k3-webapi-server.test.mjs
+++ b/scripts/ops/fixtures/integration-k3wise/mock-k3-webapi-server.test.mjs
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { createMockK3WebApiServer } from './mock-k3-webapi-server.mjs'
+
+async function withMockServer(fn) {
+  const mock = createMockK3WebApiServer()
+  const baseUrl = await mock.start()
+  try {
+    await fn({ mock, baseUrl })
+  } finally {
+    await mock.stop()
+  }
+}
+
+async function fetchJson(baseUrl, pathname, options = {}) {
+  const response = await fetch(`${baseUrl}${pathname}`, options)
+  return {
+    response,
+    body: await response.json(),
+  }
+}
+
+test('mock K3 WebAPI keeps the adapter happy-path methods available', async () => {
+  await withMockServer(async ({ baseUrl }) => {
+    const login = await fetchJson(baseUrl, '/K3API/Login', {
+      method: 'POST',
+      body: JSON.stringify({ username: 'demo', password: 'demo', acctId: 'AIS_TEST' }),
+    })
+    assert.equal(login.response.status, 200)
+    assert.equal(login.body.success, true)
+    assert.equal(login.body.sessionId, 'mock-session-1')
+
+    const health = await fetchJson(baseUrl, '/K3API/Health')
+    assert.equal(health.response.status, 200)
+    assert.equal(health.body.ok, true)
+
+    const save = await fetchJson(baseUrl, '/K3API/Material/Save', {
+      method: 'POST',
+      body: JSON.stringify({ Model: { FNumber: 'MAT-METHOD-001' } }),
+    })
+    assert.equal(save.response.status, 200)
+    assert.equal(save.body.success, true)
+    assert.equal(save.body.billNo, 'MAT-METHOD-001')
+  })
+})
+
+test('mock K3 WebAPI rejects methods that real K3 endpoints would not accept', async () => {
+  await withMockServer(async ({ baseUrl, mock }) => {
+    const cases = [
+      { pathname: '/K3API/Login', method: 'GET', expectedMethod: 'POST' },
+      { pathname: '/K3API/Health', method: 'POST', expectedMethod: 'GET' },
+      { pathname: '/K3API/Material/Save', method: 'GET', expectedMethod: 'POST' },
+      { pathname: '/K3API/Material/Submit', method: 'GET', expectedMethod: 'POST' },
+      { pathname: '/K3API/Material/Audit', method: 'GET', expectedMethod: 'POST' },
+      { pathname: '/K3API/BOM/Save', method: 'GET', expectedMethod: 'POST' },
+      { pathname: '/K3API/BOM/Submit', method: 'GET', expectedMethod: 'POST' },
+      { pathname: '/K3API/BOM/Audit', method: 'GET', expectedMethod: 'POST' },
+    ]
+
+    for (const item of cases) {
+      const result = await fetchJson(baseUrl, item.pathname, { method: item.method })
+      assert.equal(result.response.status, 405, `${item.method} ${item.pathname} should be rejected`)
+      assert.equal(result.response.headers.get('allow'), item.expectedMethod)
+      assert.deepEqual(result.body, {
+        success: false,
+        message: `mock K3 method not allowed: ${item.method} ${item.pathname}`,
+        expectedMethod: item.expectedMethod,
+      })
+    }
+
+    assert.deepEqual(
+      mock.calls.map((call) => `${call.method} ${call.pathname}`),
+      cases.map((item) => `${item.method} ${item.pathname}`),
+      'rejected calls remain visible for debugging',
+    )
+  })
+})
+
+test('mock K3 WebAPI can model successful login responses without usable auth transport', async () => {
+  const mock = createMockK3WebApiServer({
+    includeSessionCookie: false,
+    includeSessionId: false,
+  })
+  const baseUrl = await mock.start()
+  try {
+    const login = await fetchJson(baseUrl, '/K3API/Login', {
+      method: 'POST',
+      body: JSON.stringify({ username: 'demo', password: 'demo', acctId: 'AIS_TEST' }),
+    })
+    assert.equal(login.response.status, 200)
+    assert.equal(login.response.headers.get('set-cookie'), null)
+    assert.deepEqual(login.body, { success: true })
+  } finally {
+    await mock.stop()
+  }
+})


### PR DESCRIPTION
## Summary

- Fail K3 WISE WebAPI login when business success does not provide reusable auth transport (`Set-Cookie` or session id).
- Add adapter regression coverage for `K3_WISE_AUTH_TRANSPORT_MISSING` so `testConnection({ skipHealth: true })` cannot return a misleading green result.
- Tighten the offline mock K3 WebAPI fixture to enforce endpoint HTTP methods and model login success without auth transport.
- Include the mock K3 WebAPI contract test in `verify:integration-k3wise:poc`.

## Design / Verification Docs

- docs/development/integration-k3wise-webapi-auth-transport-guard-design-20260506.md
- docs/development/integration-k3wise-webapi-auth-transport-guard-verification-20260506.md

## Verification

- pnpm --dir plugins/plugin-integration-core run test:k3-wise-adapters
- node --test scripts/ops/fixtures/integration-k3wise/mock-k3-webapi-server.test.mjs
- pnpm run verify:integration-k3wise:poc
- git diff --check HEAD~1..HEAD

## Notes

- Low conflict with current K3 setup/postdeploy PRs: this touches the WebAPI adapter, adapter test, and offline K3 mock fixture.
