### PR TITLE
feat(multitable): accept native person field requests

### DIFF
--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -13,6 +13,7 @@ export type MetaFieldType =
   | 'select'
   | 'multiSelect'
   | 'link'
+  | 'person'
   | 'lookup'
   | 'rollup'
   | 'attachment'
@@ -31,7 +32,7 @@ export type MetaFieldType =
   | 'createdBy'
   | 'modifiedBy'
 
-export type MetaFieldCreateType = MetaFieldType | 'person'
+export type MetaFieldCreateType = MetaFieldType
 
 export type RowDensity = 'compact' | 'normal' | 'expanded'
 

--- a/apps/web/src/multitable/utils/link-fields.ts
+++ b/apps/web/src/multitable/utils/link-fields.ts
@@ -1,11 +1,11 @@
 import type { MetaField } from '../types'
 
 export function isLinkField(field?: MetaField | null): boolean {
-  return field?.type === 'link'
+  return field?.type === 'link' || field?.type === 'person'
 }
 
 export function isPersonField(field?: MetaField | null): boolean {
-  return isLinkField(field) && field?.property?.refKind === 'user'
+  return field?.type === 'person' || (isLinkField(field) && field?.property?.refKind === 'user')
 }
 
 function linkEntityLabel(field?: MetaField | null, count?: number): string {

--- a/docs/development/multitable-person-field-migration-design-20260506.md
+++ b/docs/development/multitable-person-field-migration-design-20260506.md
@@ -1,0 +1,53 @@
+# Multitable Native Person Field Migration Design - 2026-05-06
+
+## Goal
+
+Close the Phase 7 "Native person field migration" backlog item without destabilising the existing record/link stack.
+
+Before this slice, the frontend treated `person` as a create-only pseudo type:
+
+1. call `/api/multitable/person-fields/prepare`;
+2. receive a system People sheet preset;
+3. create a normal `link` field with `property.refKind = "user"`.
+
+That works, but API callers that send `type: "person"` directly still hit the route enum and fail before the authoritative field creation path.
+
+## Design
+
+This slice makes `person` a native API input type while keeping storage compatible:
+
+- `POST /api/multitable/fields` accepts `type: "person"`.
+- `PATCH /api/multitable/fields/:fieldId` accepts `type: "person"`.
+- The route provisions or reuses the hidden system People sheet inside the same DB transaction.
+- The field is persisted as `type = "link"` with `property.refKind = "user"` and `foreignSheetId` pointing at the system People sheet.
+- Caller-supplied `foreignSheetId` is ignored for native person requests; only `limitSingleRecord` is accepted as a user-controlled person option.
+
+Keeping storage as `link` is deliberate. Existing paths already understand link fields:
+
+- record write validation and link mutation;
+- link summaries and display maps;
+- import people lookup repair;
+- Yjs and REST write invalidation;
+- grid/drawer/form/link picker rendering.
+
+The migration therefore removes the API contract gap without forcing a risky storage rewrite.
+
+## Contract Updates
+
+- `MultitableFieldType` now includes `person` in OpenAPI.
+- The OpenAPI parity guard expects `person`.
+- Frontend field typings now include `person`.
+- `isLinkField()` treats both `link` and `person` as link-like, and `isPersonField()` treats `type: "person"` or legacy `link + refKind=user` as a person field.
+
+## Compatibility
+
+- Existing `link + refKind=user` fields continue to render and behave as person fields.
+- Existing direct prepare + create flows keep working.
+- If a future or legacy row is found with raw DB `type = "person"`, backend type mapping now coerces it to `link` instead of falling back to `string`.
+
+## Non-Goals
+
+- No DB data migration is required.
+- No new People sheet schema beyond the existing `User ID`, `Name`, `Email`, `Avatar URL` preset.
+- No frontend workflow rewrite; the existing prepared-link workflow remains valid.
+- No person-specific record value storage; values remain linked record ids.

--- a/docs/development/multitable-person-field-migration-verification-20260506.md
+++ b/docs/development/multitable-person-field-migration-verification-20260506.md
@@ -1,0 +1,44 @@
+# Multitable Native Person Field Migration Verification - 2026-05-06
+
+## Scope
+
+Focused verification for accepting native `type: "person"` field create/update requests while persisting storage-compatible `link + refKind=user` fields.
+
+## Commands Run
+
+```bash
+pnpm install --frozen-lockfile
+pnpm exec tsx packages/openapi/tools/build.ts
+pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/multitable-context.api.test.ts --reporter=dot
+pnpm --filter @metasheet/web exec vitest run tests/multitable-client.spec.ts tests/multitable-workbench-view.spec.ts --watch=false --reporter=dot
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+pnpm verify:multitable-openapi:parity
+```
+
+## Results
+
+- `packages/core-backend/tests/integration/multitable-context.api.test.ts`: 17/17 passed.
+- `apps/web/tests/multitable-client.spec.ts` + `apps/web/tests/multitable-workbench-view.spec.ts`: 69/69 passed.
+- `@metasheet/core-backend build`: passed.
+- `@metasheet/web vue-tsc`: passed.
+- `verify:multitable-openapi:parity`: passed.
+
+## Added Coverage
+
+- Creating a field with `type: "person"` provisions the system People sheet and persists the field as `type: "link"`.
+- Native person create ignores a spoofed `foreignSheetId` and uses the provisioned system People sheet.
+- Updating an existing field with `type: "person"` converts it to the same storage-compatible link field shape.
+- The `limitSingleRecord` option is preserved for native person create/update.
+
+## Notes
+
+The first attempted backend integration command used the default unit Vitest config and was excluded by repository settings:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/integration/multitable-context.api.test.ts --reporter=dot
+```
+
+It was rerun with `vitest.integration.config.ts`, which is the correct integration-test config for this file.
+
+`pnpm install --frozen-lockfile` created local dependency-link noise under `plugins/` and `tools/cli/`; those paths were restored before commit.

--- a/packages/core-backend/src/multitable/field-codecs.ts
+++ b/packages/core-backend/src/multitable/field-codecs.ts
@@ -100,6 +100,7 @@ export function mapFieldType(type: string): MultitableFieldType | string {
     return 'multiSelect'
   }
   if (normalized === 'link') return 'link'
+  if (normalized === 'person') return 'link'
   if (normalized === 'lookup') return 'lookup'
   if (normalized === 'rollup') return 'rollup'
   if (normalized === 'attachment') return 'attachment'

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -201,6 +201,13 @@ const MULTITABLE_FIELD_TYPES = [
   'modifiedBy',
 ] as const
 
+const MULTITABLE_FIELD_INPUT_TYPES = [
+  ...MULTITABLE_FIELD_TYPES,
+  'person',
+] as const
+
+type MultitableFieldInputType = (typeof MULTITABLE_FIELD_INPUT_TYPES)[number]
+
 type UniverMetaField = {
   id: string
   name: string
@@ -1067,6 +1074,7 @@ function mapFieldType(type: string): UniverMetaField['type'] {
     return 'multiSelect'
   }
   if (normalized === 'link') return 'link'
+  if (normalized === 'person') return 'link'
   if (normalized === 'lookup') return 'lookup'
   if (normalized === 'rollup') return 'rollup'
   if (normalized === 'attachment') return 'attachment'
@@ -2481,6 +2489,37 @@ async function ensurePeopleSheetPreset(query: QueryFn, baseId: string): Promise<
       limitSingleRecord: true,
       refKind: 'user',
     },
+  }
+}
+
+async function normalizeFieldWriteInput(
+  query: QueryFn,
+  sheetId: string,
+  requestedType: MultitableFieldInputType | UniverMetaField['type'],
+  rawProperty: unknown,
+): Promise<{ type: UniverMetaField['type']; property: Record<string, unknown> }> {
+  if (requestedType !== 'person') {
+    return {
+      type: requestedType as UniverMetaField['type'],
+      property: sanitizeFieldProperty(requestedType as UniverMetaField['type'], rawProperty),
+    }
+  }
+
+  const sourceSheet = await loadSheetRow(query, sheetId)
+  if (!sourceSheet) throw new NotFoundError(`Sheet not found: ${sheetId}`)
+
+  const baseId = sourceSheet.baseId ?? await ensureLegacyBase(query)
+  const preset = await ensurePeopleSheetPreset(query, baseId)
+  const obj = normalizeJson(rawProperty)
+  const limitSingleRecord = obj.limitSingleRecord !== false
+
+  return {
+    type: 'link',
+    property: sanitizeFieldProperty('link', {
+      ...preset.fieldProperty,
+      limitSingleRecord,
+      refKind: 'user',
+    }),
   }
 }
 
@@ -4030,7 +4069,7 @@ export function univerMetaRouter(): Router {
       id: z.string().min(1).max(50).optional(),
       sheetId: z.string().min(1).max(50),
       name: z.string().min(1).max(255),
-      type: z.enum(MULTITABLE_FIELD_TYPES).default('string'),
+      type: z.enum(MULTITABLE_FIELD_INPUT_TYPES).default('string'),
       property: z.record(z.unknown()).optional(),
       order: z.number().int().nonnegative().optional(),
     })
@@ -4043,8 +4082,8 @@ export function univerMetaRouter(): Router {
     const sheetId = parsed.data.sheetId
     const fieldId = parsed.data.id ?? buildId('fld').slice(0, 50)
     const name = parsed.data.name.trim()
-    const type = parsed.data.type
-    const property = sanitizeFieldProperty(type, parsed.data.property ?? {})
+    const requestedType = parsed.data.type
+    const rawProperty = parsed.data.property ?? {}
     const desiredOrder = parsed.data.order
 
     try {
@@ -4056,6 +4095,12 @@ export function univerMetaRouter(): Router {
       const { capabilities } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
       if (!capabilities.canManageFields) return sendForbidden(res)
       await pool.transaction(async ({ query }) => {
+        const { type, property } = await normalizeFieldWriteInput(
+          query as unknown as QueryFn,
+          sheetId,
+          requestedType,
+          rawProperty,
+        )
         const configError = await validateLookupRollupConfig(req, query, sheetId, type, property)
         if (configError) {
           throw new ValidationError(configError)
@@ -4286,7 +4331,7 @@ export function univerMetaRouter(): Router {
 
     const schema = z.object({
       name: z.string().min(1).max(255).optional(),
-      type: z.enum(MULTITABLE_FIELD_TYPES).optional(),
+      type: z.enum(MULTITABLE_FIELD_INPUT_TYPES).optional(),
       property: z.record(z.unknown()).optional(),
       order: z.number().int().nonnegative().optional(),
     }).refine((v) => Object.keys(v).length > 0, { message: 'At least one field must be updated' })
@@ -4320,9 +4365,11 @@ export function univerMetaRouter(): Router {
         const currentType = mapFieldType(String(row.type))
 
         const nextName = typeof parsed.data.name === 'string' ? parsed.data.name.trim() : String(row.name)
-        const nextType = (parsed.data.type ?? mapFieldType(String(row.type))) as UniverMetaField['type']
-        const nextProperty = sanitizeFieldProperty(
-          nextType,
+        const requestedType = parsed.data.type ?? mapFieldType(String(row.type))
+        const { type: nextType, property: nextProperty } = await normalizeFieldWriteInput(
+          query as unknown as QueryFn,
+          sheetId,
+          requestedType,
           typeof parsed.data.property !== 'undefined' ? parsed.data.property : row.property,
         )
         const desiredOrder = parsed.data.order

--- a/packages/core-backend/tests/integration/multitable-context.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-context.api.test.ts
@@ -814,6 +814,228 @@ describe('Multitable context API', () => {
     })
   })
 
+  test('creates native person field requests as system people link fields', async () => {
+    let peopleSheetId = ''
+
+    const { app } = await createApp({
+      tokenPerms: ['multitable:write'],
+      queryHandler: async (sql, params) => {
+        if (sql.includes('SELECT id FROM meta_sheets WHERE id = $1')) {
+          expect(params).toEqual(['sheet_ops'])
+          return { rows: [{ id: 'sheet_ops' }] }
+        }
+        if (sql.includes('SELECT id, base_id, name, description FROM meta_sheets WHERE id = $1')) {
+          expect(params).toEqual(['sheet_ops'])
+          return { rows: [{ id: 'sheet_ops', base_id: 'base_ops', name: 'Orders', description: null }] }
+        }
+        if (sql.includes('FROM meta_sheets') && sql.includes('WHERE base_id = $1')) {
+          expect(params).toEqual(['base_ops'])
+          return { rows: [{ id: 'sheet_ops', base_id: 'base_ops', name: 'Orders', description: null }] }
+        }
+        if (sql.includes('INSERT INTO meta_sheets')) {
+          peopleSheetId = String(params?.[0] ?? '')
+          expect(params).toEqual([
+            expect.any(String),
+            'base_ops',
+            'People',
+            '__metasheet_system:people__',
+          ])
+          return { rows: [], rowCount: 1 }
+        }
+        if (sql.includes('SELECT id, name, type, "order" FROM meta_fields WHERE sheet_id = $1')) {
+          expect(params).toEqual([peopleSheetId])
+          return { rows: [] }
+        }
+        if (sql.includes('INSERT INTO meta_fields') && params?.[1] === peopleSheetId) {
+          return { rows: [], rowCount: 1 }
+        }
+        if (sql.includes('SELECT id, email, name, avatar_url') && sql.includes('FROM users')) {
+          return { rows: [] }
+        }
+        if (sql.includes('SELECT COALESCE(MAX("order"), -1) AS max_order FROM meta_fields')) {
+          expect(params).toEqual(['sheet_ops'])
+          return { rows: [{ max_order: 4 }] }
+        }
+        if (sql.includes('INSERT INTO meta_fields')) {
+          expect(params).toEqual([
+            'fld_owner',
+            'sheet_ops',
+            'Owner',
+            'link',
+            JSON.stringify({
+              foreignSheetId: peopleSheetId,
+              limitSingleRecord: false,
+              refKind: 'user',
+              foreignDatasheetId: peopleSheetId,
+            }),
+            5,
+          ])
+          return {
+            rows: [{
+              id: 'fld_owner',
+              name: 'Owner',
+              type: 'link',
+              property: {
+                foreignSheetId: peopleSheetId,
+                limitSingleRecord: false,
+                refKind: 'user',
+                foreignDatasheetId: peopleSheetId,
+              },
+              order: 5,
+            }],
+          }
+        }
+        if (sql.includes('SELECT id, name, type, property, "order" FROM meta_fields WHERE id = $1')) {
+          expect(params).toEqual(['fld_owner'])
+          return {
+            rows: [{
+              id: 'fld_owner',
+              name: 'Owner',
+              type: 'link',
+              property: {
+                foreignSheetId: peopleSheetId,
+                limitSingleRecord: false,
+                refKind: 'user',
+                foreignDatasheetId: peopleSheetId,
+              },
+              order: 5,
+            }],
+          }
+        }
+        throw new Error(`Unhandled SQL in test: ${sql}`)
+      },
+    })
+
+    const response = await request(app)
+      .post('/api/multitable/fields')
+      .send({
+        id: 'fld_owner',
+        sheetId: 'sheet_ops',
+        name: 'Owner',
+        type: 'person',
+        property: {
+          limitSingleRecord: false,
+          foreignSheetId: 'sheet_spoofed',
+        },
+      })
+      .expect(201)
+
+    expect(response.body.data.field).toMatchObject({
+      id: 'fld_owner',
+      name: 'Owner',
+      type: 'link',
+      order: 5,
+      property: {
+        foreignSheetId: peopleSheetId,
+        limitSingleRecord: false,
+        refKind: 'user',
+        foreignDatasheetId: peopleSheetId,
+      },
+    })
+  })
+
+  test('updates native person field requests into system people link fields', async () => {
+    let peopleSheetId = ''
+
+    const { app } = await createApp({
+      tokenPerms: ['multitable:write'],
+      queryHandler: async (sql, params) => {
+        if (sql.includes('SELECT id, sheet_id FROM meta_fields WHERE id = $1')) {
+          expect(params).toEqual(['fld_assignee'])
+          return { rows: [{ id: 'fld_assignee', sheet_id: 'sheet_ops' }] }
+        }
+        if (sql.includes('SELECT id, sheet_id, name, type, property, "order" FROM meta_fields WHERE id = $1')) {
+          expect(params).toEqual(['fld_assignee'])
+          return {
+            rows: [{
+              id: 'fld_assignee',
+              sheet_id: 'sheet_ops',
+              name: 'Assignee',
+              type: 'string',
+              property: {},
+              order: 2,
+            }],
+          }
+        }
+        if (sql.includes('SELECT id, base_id, name, description FROM meta_sheets WHERE id = $1')) {
+          expect(params).toEqual(['sheet_ops'])
+          return { rows: [{ id: 'sheet_ops', base_id: 'base_ops', name: 'Orders', description: null }] }
+        }
+        if (sql.includes('FROM meta_sheets') && sql.includes('WHERE base_id = $1')) {
+          expect(params).toEqual(['base_ops'])
+          return { rows: [{ id: 'sheet_ops', base_id: 'base_ops', name: 'Orders', description: null }] }
+        }
+        if (sql.includes('INSERT INTO meta_sheets')) {
+          peopleSheetId = String(params?.[0] ?? '')
+          return { rows: [], rowCount: 1 }
+        }
+        if (sql.includes('SELECT id, name, type, "order" FROM meta_fields WHERE sheet_id = $1')) {
+          expect(params).toEqual([peopleSheetId])
+          return { rows: [] }
+        }
+        if (sql.includes('INSERT INTO meta_fields') && params?.[1] === peopleSheetId) {
+          return { rows: [], rowCount: 1 }
+        }
+        if (sql.includes('SELECT id, email, name, avatar_url') && sql.includes('FROM users')) {
+          return { rows: [] }
+        }
+        if (sql.includes('UPDATE meta_fields') && sql.includes('SET name = $2, type = $3, property = $4::jsonb, "order" = $5')) {
+          expect(params).toEqual([
+            'fld_assignee',
+            'Assignee',
+            'link',
+            JSON.stringify({
+              foreignSheetId: peopleSheetId,
+              limitSingleRecord: true,
+              refKind: 'user',
+              foreignDatasheetId: peopleSheetId,
+            }),
+            2,
+          ])
+          return {
+            rows: [{
+              id: 'fld_assignee',
+              name: 'Assignee',
+              type: 'link',
+              property: {
+                foreignSheetId: peopleSheetId,
+                limitSingleRecord: true,
+                refKind: 'user',
+                foreignDatasheetId: peopleSheetId,
+              },
+              order: 2,
+            }],
+          }
+        }
+        throw new Error(`Unhandled SQL in test: ${sql}`)
+      },
+    })
+
+    const response = await request(app)
+      .patch('/api/multitable/fields/fld_assignee')
+      .send({
+        type: 'person',
+        property: {
+          foreignSheetId: 'sheet_spoofed',
+          limitSingleRecord: true,
+        },
+      })
+      .expect(200)
+
+    expect(response.body.data.field).toMatchObject({
+      id: 'fld_assignee',
+      name: 'Assignee',
+      type: 'link',
+      order: 2,
+      property: {
+        foreignSheetId: peopleSheetId,
+        limitSingleRecord: true,
+        refKind: 'user',
+        foreignDatasheetId: peopleSheetId,
+      },
+    })
+  })
+
   test('accepts date fields in create and update multitable field contracts', async () => {
     const { app } = await createApp({
       tokenPerms: ['multitable:write'],

--- a/packages/openapi/dist/combined.openapi.yml
+++ b/packages/openapi/dist/combined.openapi.yml
@@ -1590,6 +1590,7 @@ components:
         - select
         - multiSelect
         - link
+        - person
         - lookup
         - rollup
         - attachment

--- a/packages/openapi/dist/openapi.json
+++ b/packages/openapi/dist/openapi.json
@@ -2286,6 +2286,7 @@
           "select",
           "multiSelect",
           "link",
+          "person",
           "lookup",
           "rollup",
           "attachment",

--- a/packages/openapi/dist/openapi.yaml
+++ b/packages/openapi/dist/openapi.yaml
@@ -1590,6 +1590,7 @@ components:
         - select
         - multiSelect
         - link
+        - person
         - lookup
         - rollup
         - attachment

--- a/packages/openapi/src/base.yml
+++ b/packages/openapi/src/base.yml
@@ -1533,6 +1533,7 @@ components:
         - select
         - multiSelect
         - link
+        - person
         - lookup
         - rollup
         - attachment

--- a/scripts/ops/multitable-openapi-parity.test.mjs
+++ b/scripts/ops/multitable-openapi-parity.test.mjs
@@ -17,6 +17,7 @@ const expectedFieldTypes = [
   'select',
   'multiSelect',
   'link',
+  'person',
   'lookup',
   'rollup',
   'attachment',


### PR DESCRIPTION
## Summary
- accept `type: person` in multitable field create/update requests
- provision/reuse the system People sheet transactionally and persist storage-compatible `link + refKind=user` fields
- update OpenAPI field type parity, frontend field typing, and focused integration coverage
- add design and verification docs

## Verification
- pnpm install --frozen-lockfile
- pnpm exec tsx packages/openapi/tools/build.ts
- pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/multitable-context.api.test.ts --reporter=dot
- pnpm --filter @metasheet/web exec vitest run tests/multitable-client.spec.ts tests/multitable-workbench-view.spec.ts --watch=false --reporter=dot
- pnpm --filter @metasheet/core-backend build
- pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
- pnpm verify:multitable-openapi:parity
- git diff --check