### PR TITLE
feat(multitable): add template library v1

### DIFF
--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -55,8 +55,11 @@ import type {
   DashboardUpdateInput,
   FormShareConfig,
   FormShareConfigUpdate,
+  InstallTemplateInput,
+  InstallTemplateResult,
   ApiToken,
   ApiTokenCreateResult,
+  MetaTemplate,
   Webhook,
   WebhookCreateInput,
   WebhookDelivery,
@@ -698,6 +701,20 @@ export class MultitableApiClient {
 
   async createBase(input: CreateBaseInput): Promise<{ base: MetaBase }> {
     const res = await this.fetch('/api/multitable/bases', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    })
+    return parseJson(res)
+  }
+
+  async listTemplates(): Promise<{ templates: MetaTemplate[] }> {
+    const res = await this.fetch('/api/multitable/templates')
+    return parseJson(res)
+  }
+
+  async installTemplate(templateId: string, input: InstallTemplateInput = {}): Promise<InstallTemplateResult> {
+    const res = await this.fetch(`/api/multitable/templates/${encodeURIComponent(templateId)}/install`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(input),

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -491,6 +491,59 @@ export interface RecordSummaryPage {
   page: MetaPage
 }
 
+// --- Template library ---
+export interface MetaTemplateField {
+  id: string
+  name: string
+  type: MetaFieldType
+  order?: number
+  options?: string[]
+  property?: Record<string, unknown>
+  description?: string
+}
+
+export interface MetaTemplateView {
+  id: string
+  name: string
+  type: string
+  groupByFieldId?: string
+  dateFieldId?: string
+  titleFieldId?: string
+  hiddenFieldIds?: string[]
+  config?: Record<string, unknown>
+}
+
+export interface MetaTemplateSheet {
+  id: string
+  name: string
+  description?: string | null
+  fields: MetaTemplateField[]
+  views: MetaTemplateView[]
+}
+
+export interface MetaTemplate {
+  id: string
+  name: string
+  description: string
+  category: string
+  icon: string
+  color: string
+  sheets: MetaTemplateSheet[]
+}
+
+export interface InstallTemplateInput {
+  baseName?: string
+  workspaceId?: string
+}
+
+export interface InstallTemplateResult {
+  template: MetaTemplate
+  base: MetaBase
+  sheets: MetaSheet[]
+  fields: MetaField[]
+  views: MetaView[]
+}
+
 // --- Input types ---
 export interface CreateBaseInput {
   id?: string

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -49,9 +49,39 @@
       <button v-if="caps.canManageViews.value && canConfigureCurrentView" class="mt-workbench__mgr-btn" @click="showViewManager = true">&#x2630; Views</button>
       <button v-if="caps.canManageAutomation.value" class="mt-workbench__mgr-btn" @click="openWorkflowDesigner()">&#x2699; Workflow</button>
       <button v-if="caps.canManageAutomation.value" class="mt-workbench__mgr-btn" @click="showAutomationManager = true">&#x26A1; Automations</button>
+      <button v-if="canCreateBasesAndSheets" class="mt-workbench__mgr-btn" data-action="open-template-library" @click="openTemplateLibrary">&#x1F5C2; Templates</button>
       <button class="mt-workbench__mgr-btn" :class="{ 'mt-workbench__mgr-btn--active': showDashboardView }" @click="showDashboardView = !showDashboardView" data-action="toggle-dashboard">&#x1F4CA; Dashboard</button>
       <button v-if="activeViewType === 'form'" class="mt-workbench__mgr-btn" @click="showFormShareManager = true">&#x1F517; Share Form</button>
       <button class="mt-workbench__mgr-btn" @click="showApiTokenManager = true">&#x1F511; API &amp; Webhooks</button>
+    </div>
+    <div v-if="showTemplateLibrary" class="mt-template-library" data-testid="multitable-template-library">
+      <div class="mt-template-library__header">
+        <div>
+          <strong>Template Library</strong>
+          <span>Start a new base from a built-in workspace pattern.</span>
+        </div>
+        <button class="mt-template-library__close" @click="showTemplateLibrary = false">&times;</button>
+      </div>
+      <div v-if="templateLibraryLoading" class="mt-template-library__state">Loading templates...</div>
+      <div v-else-if="templateLibraryError" class="mt-template-library__state mt-template-library__state--error">{{ templateLibraryError }}</div>
+      <div v-else class="mt-template-library__grid">
+        <article v-for="template in templates" :key="template.id" class="mt-template-library__card" :style="{ borderColor: template.color }">
+          <div class="mt-template-library__card-top">
+            <span class="mt-template-library__icon" :style="{ backgroundColor: template.color }">{{ template.icon }}</span>
+            <span class="mt-template-library__category">{{ template.category }}</span>
+          </div>
+          <h3>{{ template.name }}</h3>
+          <p>{{ template.description }}</p>
+          <small>{{ template.sheets.length }} sheet{{ template.sheets.length === 1 ? '' : 's' }} · {{ template.sheets[0]?.fields.length ?? 0 }} fields</small>
+          <button
+            class="mt-template-library__install"
+            :disabled="installingTemplateId === template.id"
+            @click="onInstallTemplate(template)"
+          >
+            {{ installingTemplateId === template.id ? 'Installing...' : 'Use template' }}
+          </button>
+        </article>
+      </div>
     </div>
     <div
       v-if="capabilityOriginNotice"
@@ -357,6 +387,7 @@ import type {
   MetaViewPermission,
   MetaFieldPermissionEntry,
   MetaViewPermissionEntry,
+  MetaTemplate,
   RowDensity,
 } from '../types'
 import type { MultitableRole } from '../composables/useMultitableCapabilities'
@@ -445,6 +476,7 @@ const showFieldManager = ref(false)
 const showPermissionManager = ref(false)
 const showAutomationManager = ref(false)
 const showDashboardView = ref(false)
+const showTemplateLibrary = ref(false)
 const showFormShareManager = ref(false)
 const showApiTokenManager = ref(false)
 const fieldPermissionEntries = ref<MetaFieldPermissionEntry[]>([])
@@ -458,6 +490,10 @@ const currentUserId = ref<string | null>(null)
 const commentMentionSuggestions = ref<MetaCommentMentionSuggestion[]>([])
 const commentMentionSuggestionsLoadedForSheetId = ref<string | null>(null)
 const searchText = ref('')
+const templates = ref<MetaTemplate[]>([])
+const templateLibraryLoading = ref(false)
+const templateLibraryError = ref<string | null>(null)
+const installingTemplateId = ref<string | null>(null)
 const showShortcuts = ref(false)
 const showImportModal = ref(false)
 const importSubmitting = ref(false)
@@ -1983,6 +2019,60 @@ async function onCreateBase(name: string) {
   } catch (e: any) { showError(e.message ?? 'Failed to create base') }
 }
 
+async function loadTemplateLibrary() {
+  templateLibraryLoading.value = true
+  templateLibraryError.value = null
+  try {
+    const data = await workbench.client.listTemplates()
+    templates.value = data.templates ?? []
+  } catch (e: any) {
+    templateLibraryError.value = e.message ?? 'Failed to load templates'
+  } finally {
+    templateLibraryLoading.value = false
+  }
+}
+
+async function openTemplateLibrary() {
+  if (!canCreateBasesAndSheets.value) {
+    showError('Template installation requires multitable write access.')
+    return
+  }
+  showTemplateLibrary.value = true
+  if (templates.value.length === 0 && !templateLibraryLoading.value) {
+    await loadTemplateLibrary()
+  }
+}
+
+async function onInstallTemplate(template: MetaTemplate) {
+  if (!canCreateBasesAndSheets.value) {
+    showError('Template installation requires multitable write access.')
+    return
+  }
+  if (!confirmDiscardContextChanges()) return
+  installingTemplateId.value = template.id
+  try {
+    const result = await workbench.client.installTemplate(template.id)
+    if (!bases.value.some((base) => base.id === result.base.id)) {
+      bases.value.push(result.base)
+    }
+    const ok = await workbench.syncExternalContext({
+      baseId: result.base.id,
+      sheetId: result.sheets[0]?.id,
+      viewId: result.views[0]?.id,
+    })
+    if (!ok) {
+      showError(workbench.error.value ?? 'Installed template but failed to refresh workbench context')
+      return
+    }
+    showTemplateLibrary.value = false
+    showSuccess(`Installed ${result.template.name}`)
+  } catch (e: any) {
+    showError(e.message ?? 'Failed to install template')
+  } finally {
+    installingTemplateId.value = null
+  }
+}
+
 // --- Print ---
 function onPrint() { window.print() }
 
@@ -2757,6 +2847,39 @@ defineExpose({
 .mt-workbench__mgr-btn--attention { border-color: #f59e0b; color: #92400e; background: #fffbeb; }
 .mt-workbench__mgr-badge { display: inline-flex; align-items: center; justify-content: center; min-width: 18px; height: 18px; margin-left: 6px; padding: 0 6px; border-radius: 999px; background: #f59e0b; color: #fff; font-size: 11px; font-weight: 600; }
 .mt-workbench__base-bar { padding: 8px 16px 0; border-bottom: 1px solid #f0f0f0; }
+.mt-template-library {
+  margin: 8px 16px 0;
+  padding: 14px;
+  border: 1px solid #dbeafe;
+  border-radius: 14px;
+  background: linear-gradient(135deg, #f8fbff 0%, #eef6ff 100%);
+  box-shadow: 0 10px 24px rgba(37, 99, 235, .08);
+}
+.mt-template-library__header { display: flex; justify-content: space-between; gap: 12px; align-items: flex-start; margin-bottom: 12px; }
+.mt-template-library__header div { display: flex; flex-direction: column; gap: 3px; }
+.mt-template-library__header strong { font-size: 14px; color: #0f172a; }
+.mt-template-library__header span { font-size: 12px; color: #64748b; }
+.mt-template-library__close { border: none; background: transparent; color: #64748b; font-size: 20px; line-height: 1; cursor: pointer; }
+.mt-template-library__state { padding: 12px; border-radius: 10px; background: #fff; color: #475569; font-size: 12px; }
+.mt-template-library__state--error { color: #b91c1c; background: #fef2f2; }
+.mt-template-library__grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 12px; }
+.mt-template-library__card {
+  padding: 12px;
+  border: 1px solid;
+  border-radius: 12px;
+  background: rgba(255,255,255,.92);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.mt-template-library__card-top { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.mt-template-library__icon { min-width: 36px; height: 24px; padding: 0 8px; border-radius: 999px; display: inline-flex; align-items: center; justify-content: center; color: #fff; font-size: 11px; font-weight: 600; text-transform: uppercase; }
+.mt-template-library__category { color: #64748b; font-size: 11px; }
+.mt-template-library__card h3 { margin: 0; color: #111827; font-size: 14px; }
+.mt-template-library__card p { margin: 0; min-height: 36px; color: #475569; font-size: 12px; line-height: 1.5; }
+.mt-template-library__card small { color: #64748b; font-size: 11px; }
+.mt-template-library__install { margin-top: auto; padding: 7px 10px; border: 1px solid #2563eb; border-radius: 8px; background: #2563eb; color: #fff; cursor: pointer; font-size: 12px; }
+.mt-template-library__install:disabled { opacity: .7; cursor: wait; }
 .mt-workbench__shortcuts-overlay { position: fixed; inset: 0; z-index: 100; background: rgba(0,0,0,.3); display: flex; align-items: center; justify-content: center; }
 .mt-workbench__shortcuts { background: #fff; border-radius: 8px; padding: 20px 24px; min-width: 320px; box-shadow: 0 8px 24px rgba(0,0,0,.15); }
 .mt-workbench__shortcuts-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 16px; font-size: 15px; }
@@ -2765,7 +2888,7 @@ defineExpose({
 .mt-workbench__shortcut { display: flex; align-items: center; gap: 12px; font-size: 13px; }
 .mt-workbench__shortcut kbd { background: #f0f0f0; border: 1px solid #ddd; border-radius: 3px; padding: 2px 8px; font-family: monospace; font-size: 12px; min-width: 80px; text-align: center; }
 @media print {
-  .mt-workbench__base-bar, .mt-workbench__actions, .mt-workbench__shortcuts-overlay { display: none !important; }
+  .mt-workbench__base-bar, .mt-workbench__actions, .mt-workbench__shortcuts-overlay, .mt-template-library { display: none !important; }
   .mt-workbench__content { overflow: visible !important; }
   .mt-workbench__main { overflow: visible !important; }
 }

--- a/apps/web/tests/multitable-phase3.spec.ts
+++ b/apps/web/tests/multitable-phase3.spec.ts
@@ -135,6 +135,39 @@ describe('base management API', () => {
     expect(result.base.name).toBe('New Base')
   })
 
+  it('listTemplates calls the template catalog endpoint', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        ok: true,
+        data: { templates: [{ id: 'project-tracker', name: 'Project Tracker', description: '', category: 'Project management', icon: 'kanban', color: '#2563eb', sheets: [] }] },
+      }), { status: 200 }),
+    )
+    const client = mockClientWithFn(fetchFn)
+    const result = await client.listTemplates()
+    expect(result.templates[0].id).toBe('project-tracker')
+    expect(fetchFn).toHaveBeenCalledWith('/api/multitable/templates')
+  })
+
+  it('installTemplate calls the template install endpoint', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({
+        ok: true,
+        data: {
+          template: { id: 'project-tracker', name: 'Project Tracker', description: '', category: 'Project management', icon: 'kanban', color: '#2563eb', sheets: [] },
+          base: { id: 'base_new', name: 'Project Tracker' },
+          sheets: [],
+          fields: [],
+          views: [],
+        },
+      }), { status: 201 }),
+    )
+    const client = mockClientWithFn(fetchFn)
+    const result = await client.installTemplate('project-tracker', { baseName: 'Launch Base' })
+    expect(result.base.id).toBe('base_new')
+    expect(fetchFn).toHaveBeenCalledWith('/api/multitable/templates/project-tracker/install', expect.objectContaining({ method: 'POST' }))
+    expect(JSON.parse(fetchFn.mock.calls[0][1].body).baseName).toBe('Launch Base')
+  })
+
   it('loadContext calls correct endpoint with params', async () => {
     const fetchFn = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({

--- a/docs/development/multitable-template-library-v1-design-20260506.md
+++ b/docs/development/multitable-template-library-v1-design-20260506.md
@@ -1,0 +1,101 @@
+# Multitable Template Library V1 Design - 2026-05-06
+
+## Goal
+
+Close the Phase 7 Feishu-parity backlog item `Template library V1` with a small, durable slice:
+
+- list built-in multitable templates;
+- install a selected template as a new base;
+- expose a minimal Workbench entry for users with multitable write access;
+- keep installation atomic so users never see a half-created template.
+
+## Scope
+
+Implemented:
+
+- `GET /api/multitable/templates`
+- `POST /api/multitable/templates/:templateId/install`
+- Static checked-in template catalog with:
+  - `project-tracker`
+  - `sales-crm`
+  - `issue-tracker`
+- Atomic install pipeline:
+  - create `meta_bases`;
+  - create template sheets;
+  - create template fields;
+  - create template views with field-id remapping for kanban/calendar/timeline config.
+- Frontend API client methods:
+  - `listTemplates()`
+  - `installTemplate(templateId, input)`
+- Workbench `Templates` panel that installs a template and switches to the new base.
+- OpenAPI source and generated dist updates.
+- Focused backend/frontend tests and OpenAPI parity guard.
+
+Not implemented in V1:
+
+- user-authored template persistence;
+- template marketplace/search/rating;
+- installing into an existing base;
+- sample records;
+- cross-sheet linked template graphs.
+
+## Design Decisions
+
+### Static Catalog First
+
+Templates live in `packages/core-backend/src/multitable/template-library.ts`.
+
+Reason: V1 needs a reliable product entry point, not a new authoring subsystem. A checked-in catalog avoids migrations, permission rules for template ownership, and extra admin UI.
+
+### Install Creates A New Base
+
+The install route creates a new base and installs sheets/fields/views inside one backend transaction.
+
+Reason: creating a new base mirrors the expected template-library flow and avoids partial frontend orchestration such as `createBase -> createSheet -> createFields -> createViews`.
+
+### Provisioning Helpers Are Reused
+
+The service reuses:
+
+- `createSheet()`
+- `ensureFields()`
+- `createView()`
+
+Reason: existing provisioning helpers already normalize field property JSON, select options, and view config persistence.
+
+### Stable Child IDs Under Random Base IDs
+
+The route generates a fresh base ID. Template sheet, field, and view IDs are stable hashes under that base ID.
+
+Reason: repeated installs produce distinct bases, while each installed base has deterministic internal references for field-id remapping.
+
+### Permission Model
+
+Catalog list requires `multitable:read`.
+
+Install requires `multitable:write`, and installed base ownership is assigned to the authenticated user.
+
+Reason: this matches current base creation semantics without introducing a separate template permission model.
+
+## Files Changed
+
+- `packages/core-backend/src/multitable/template-library.ts`
+- `packages/core-backend/src/routes/univer-meta.ts`
+- `packages/core-backend/tests/unit/multitable-template-library.test.ts`
+- `packages/core-backend/tests/integration/multitable-context.api.test.ts`
+- `apps/web/src/multitable/api/client.ts`
+- `apps/web/src/multitable/types.ts`
+- `apps/web/src/multitable/views/MultitableWorkbench.vue`
+- `apps/web/tests/multitable-phase3.spec.ts`
+- `packages/openapi/src/base.yml`
+- `packages/openapi/src/paths/multitable.yml`
+- `packages/openapi/dist/combined.openapi.yml`
+- `packages/openapi/dist/openapi.json`
+- `packages/openapi/dist/openapi.yaml`
+- `scripts/ops/multitable-openapi-parity.test.mjs`
+
+## Follow-Ups
+
+- Add a richer template gallery route if the number of built-in templates grows.
+- Add sample record seeding after record templates have a validated owner/source/audit strategy.
+- Add install-into-existing-base only after product decides how conflicts and sheet ownership should behave.

--- a/docs/development/multitable-template-library-v1-verification-20260506.md
+++ b/docs/development/multitable-template-library-v1-verification-20260506.md
@@ -1,0 +1,100 @@
+# Multitable Template Library V1 Verification - 2026-05-06
+
+## Environment
+
+- Worktree: `/private/tmp/ms2-template-library-v1-20260506`
+- Branch: `codex/multitable-template-library-v1-20260506`
+- Base: `origin/main@8ceee6fa0`
+- Note: root checkout had unrelated DingTalk/public-form dirty files; this slice was developed in a clean worktree.
+
+## Commands Run
+
+### Backend Unit
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/multitable-template-library.test.ts \
+  --reporter=dot
+```
+
+Result:
+
+- 1 file passed
+- 4 tests passed
+
+### Backend Route Integration
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest \
+  --config vitest.integration.config.ts \
+  run tests/integration/multitable-context.api.test.ts \
+  --reporter=dot
+```
+
+Result:
+
+- 1 file passed
+- 19 tests passed
+
+### Frontend API Regression
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/multitable-phase3.spec.ts \
+  --reporter=dot
+```
+
+Result:
+
+- 1 file passed
+- 17 tests passed
+- Warning observed: `WebSocket server error: Port is already in use`
+- The warning did not fail the suite.
+
+### Backend Type Check
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+```
+
+Result: passed.
+
+### Frontend Type Check
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+```
+
+Result: passed.
+
+### OpenAPI Parity
+
+```bash
+pnpm verify:multitable-openapi:parity
+```
+
+Result:
+
+- OpenAPI dist rebuilt from source.
+- `multitable openapi stays aligned with runtime contracts` passed.
+
+### Whitespace Guard
+
+```bash
+git diff --check
+```
+
+Result: passed.
+
+## Coverage Notes
+
+- Unit tests verify static catalog defensive copies, template install, field option normalization, field-id remapped view config, unknown template rejection, and base conflict rejection.
+- Integration tests verify route-level template catalog listing and transaction-bound install through `/api/multitable/templates/:templateId/install`.
+- Frontend tests verify `MultitableApiClient.listTemplates()` and `installTemplate()` request shapes.
+- Type checks cover the Workbench template panel wiring.
+
+## Known Limits
+
+- No manual browser smoke was run in this worktree.
+- No sample records are created by V1 templates.
+- Templates cannot yet be installed into an existing base.

--- a/packages/core-backend/src/multitable/template-library.ts
+++ b/packages/core-backend/src/multitable/template-library.ts
@@ -1,0 +1,327 @@
+import { createHash, randomUUID } from 'crypto'
+
+import {
+  createSheet,
+  createView,
+  ensureFields,
+  type MultitableProvisioningField,
+  type MultitableProvisioningFieldDescriptor,
+  type MultitableProvisioningQueryFn,
+  type MultitableProvisioningSheet,
+  type MultitableProvisioningView,
+} from './provisioning'
+
+export type MultitableTemplateField = MultitableProvisioningFieldDescriptor & {
+  description?: string
+}
+
+export type MultitableTemplateView = {
+  id: string
+  name: string
+  type: string
+  groupByFieldId?: string
+  dateFieldId?: string
+  titleFieldId?: string
+  hiddenFieldIds?: string[]
+  config?: Record<string, unknown>
+}
+
+export type MultitableTemplateSheet = {
+  id: string
+  name: string
+  description?: string | null
+  fields: MultitableTemplateField[]
+  views: MultitableTemplateView[]
+}
+
+export type MultitableTemplate = {
+  id: string
+  name: string
+  description: string
+  category: string
+  icon: string
+  color: string
+  sheets: MultitableTemplateSheet[]
+}
+
+export type MultitableTemplateBase = {
+  id: string
+  name: string
+  icon: string | null
+  color: string | null
+  ownerId: string | null
+  workspaceId: string | null
+}
+
+export type InstallMultitableTemplateInput = {
+  query: MultitableProvisioningQueryFn
+  templateId: string
+  baseId?: string
+  baseName?: string
+  ownerId?: string | null
+  workspaceId?: string | null
+  idGenerator?: (prefix: string) => string
+}
+
+export type InstallMultitableTemplateResult = {
+  template: MultitableTemplate
+  base: MultitableTemplateBase
+  sheets: MultitableProvisioningSheet[]
+  fields: MultitableProvisioningField[]
+  views: MultitableProvisioningView[]
+}
+
+export class MultitableTemplateNotFoundError extends Error {
+  constructor(templateId: string) {
+    super(`Template not found: ${templateId}`)
+    this.name = 'MultitableTemplateNotFoundError'
+  }
+}
+
+export class MultitableTemplateConflictError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'MultitableTemplateConflictError'
+  }
+}
+
+const TEMPLATE_LIBRARY: MultitableTemplate[] = [
+  {
+    id: 'project-tracker',
+    name: 'Project Tracker',
+    description: 'Track owners, priorities, due dates, status, and execution notes.',
+    category: 'Project management',
+    icon: 'kanban',
+    color: '#2563eb',
+    sheets: [
+      {
+        id: 'tasks',
+        name: 'Tasks',
+        description: 'Project task pipeline',
+        fields: [
+          { id: 'task', name: 'Task', type: 'string', order: 0 },
+          { id: 'status', name: 'Status', type: 'select', order: 1, options: ['Not started', 'In progress', 'Blocked', 'Done'] },
+          { id: 'owner', name: 'Owner', type: 'string', order: 2 },
+          { id: 'priority', name: 'Priority', type: 'select', order: 3, options: ['P0', 'P1', 'P2'] },
+          { id: 'dueDate', name: 'Due Date', type: 'date', order: 4 },
+          { id: 'notes', name: 'Notes', type: 'longText', order: 5 },
+        ],
+        views: [
+          { id: 'grid', name: 'All Tasks', type: 'grid' },
+          { id: 'kanban', name: 'By Status', type: 'kanban', groupByFieldId: 'status' },
+          { id: 'calendar', name: 'Due Calendar', type: 'calendar', dateFieldId: 'dueDate', titleFieldId: 'task' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'sales-crm',
+    name: 'Sales CRM',
+    description: 'Manage accounts, contacts, stage, deal value, and next action.',
+    category: 'Sales',
+    icon: 'pipeline',
+    color: '#16a34a',
+    sheets: [
+      {
+        id: 'deals',
+        name: 'Deals',
+        description: 'Opportunity pipeline',
+        fields: [
+          { id: 'account', name: 'Account', type: 'string', order: 0 },
+          { id: 'contact', name: 'Contact', type: 'string', order: 1 },
+          { id: 'stage', name: 'Stage', type: 'select', order: 2, options: ['Lead', 'Qualified', 'Proposal', 'Negotiation', 'Won', 'Lost'] },
+          { id: 'value', name: 'Deal Value', type: 'number', order: 3 },
+          { id: 'closeDate', name: 'Close Date', type: 'date', order: 4 },
+          { id: 'nextAction', name: 'Next Action', type: 'longText', order: 5 },
+        ],
+        views: [
+          { id: 'grid', name: 'All Deals', type: 'grid' },
+          { id: 'pipeline', name: 'Pipeline', type: 'kanban', groupByFieldId: 'stage' },
+          { id: 'calendar', name: 'Close Calendar', type: 'calendar', dateFieldId: 'closeDate', titleFieldId: 'account' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'issue-tracker',
+    name: 'Issue Tracker',
+    description: 'Capture bugs, severity, assignee, due date, and reproduction notes.',
+    category: 'Engineering',
+    icon: 'bug',
+    color: '#dc2626',
+    sheets: [
+      {
+        id: 'issues',
+        name: 'Issues',
+        description: 'Bug and issue triage',
+        fields: [
+          { id: 'issue', name: 'Issue', type: 'string', order: 0 },
+          { id: 'severity', name: 'Severity', type: 'select', order: 1, options: ['Critical', 'High', 'Medium', 'Low'] },
+          { id: 'status', name: 'Status', type: 'select', order: 2, options: ['Open', 'Triaged', 'In progress', 'Resolved'] },
+          { id: 'assignee', name: 'Assignee', type: 'string', order: 3 },
+          { id: 'dueDate', name: 'Due Date', type: 'date', order: 4 },
+          { id: 'reproSteps', name: 'Repro Steps', type: 'longText', order: 5 },
+        ],
+        views: [
+          { id: 'grid', name: 'All Issues', type: 'grid' },
+          { id: 'severity', name: 'By Severity', type: 'kanban', groupByFieldId: 'severity' },
+          { id: 'timeline', name: 'Due Timeline', type: 'timeline', dateFieldId: 'dueDate', titleFieldId: 'issue' },
+        ],
+      },
+    ],
+  },
+]
+
+function normalizeTemplate(template: MultitableTemplate): MultitableTemplate {
+  return {
+    ...template,
+    sheets: template.sheets.map((sheet) => ({
+      ...sheet,
+      fields: sheet.fields.map((field) => ({ ...field, property: { ...(field.property ?? {}) } })),
+      views: sheet.views.map((view) => ({ ...view, config: { ...(view.config ?? {}) } })),
+    })),
+  }
+}
+
+function generatedId(prefix: string): string {
+  return `${prefix}_${randomUUID().replace(/-/g, '').slice(0, 24)}`.slice(0, 50)
+}
+
+function stableChildId(prefix: string, ...parts: string[]): string {
+  const digest = createHash('sha1')
+    .update(parts.join(':'))
+    .digest('hex')
+    .slice(0, 24)
+  return `${prefix}_${digest}`.slice(0, 50)
+}
+
+function normalizeBaseRow(row: Record<string, unknown>): MultitableTemplateBase {
+  return {
+    id: String(row.id),
+    name: String(row.name),
+    icon: typeof row.icon === 'string' ? row.icon : null,
+    color: typeof row.color === 'string' ? row.color : null,
+    ownerId: typeof row.owner_id === 'string' ? row.owner_id : null,
+    workspaceId: typeof row.workspace_id === 'string' ? row.workspace_id : null,
+  }
+}
+
+function mapFieldIds(sheetId: string, templateId: string, sheet: MultitableTemplateSheet): Record<string, string> {
+  const next: Record<string, string> = {}
+  for (const field of sheet.fields) {
+    next[field.id] = stableChildId('fld', templateId, sheetId, field.id)
+  }
+  return next
+}
+
+function buildViewConfig(view: MultitableTemplateView, fieldIds: Record<string, string>): Record<string, unknown> {
+  const config = { ...(view.config ?? {}) }
+  if (view.dateFieldId) config.dateFieldId = fieldIds[view.dateFieldId]
+  if (view.titleFieldId) config.titleFieldId = fieldIds[view.titleFieldId]
+  return config
+}
+
+function buildGroupInfo(view: MultitableTemplateView, fieldIds: Record<string, string>): Record<string, unknown> {
+  if (!view.groupByFieldId) return {}
+  return { fieldId: fieldIds[view.groupByFieldId] }
+}
+
+export function listMultitableTemplates(): MultitableTemplate[] {
+  return TEMPLATE_LIBRARY.map(normalizeTemplate)
+}
+
+export function getMultitableTemplate(templateId: string): MultitableTemplate | null {
+  const template = TEMPLATE_LIBRARY.find((item) => item.id === templateId)
+  return template ? normalizeTemplate(template) : null
+}
+
+export async function installMultitableTemplate(
+  input: InstallMultitableTemplateInput,
+): Promise<InstallMultitableTemplateResult> {
+  const template = getMultitableTemplate(input.templateId)
+  if (!template) {
+    throw new MultitableTemplateNotFoundError(input.templateId)
+  }
+
+  const makeId = input.idGenerator ?? generatedId
+  const baseId = (input.baseId?.trim() || makeId('base')).slice(0, 50)
+  const baseName = (input.baseName?.trim() || template.name).slice(0, 255)
+  const baseInsert = await input.query(
+    `INSERT INTO meta_bases (id, name, icon, color, owner_id, workspace_id)
+     VALUES ($1, $2, $3, $4, $5, $6)
+     ON CONFLICT (id) DO NOTHING
+     RETURNING id, name, icon, color, owner_id, workspace_id`,
+    [baseId, baseName, template.icon, template.color, input.ownerId ?? null, input.workspaceId ?? null],
+  )
+  if ((baseInsert.rowCount ?? 0) === 0) {
+    throw new MultitableTemplateConflictError(`Base already exists: ${baseId}`)
+  }
+
+  const base = normalizeBaseRow((baseInsert.rows as Record<string, unknown>[])[0] ?? {
+    id: baseId,
+    name: baseName,
+    icon: template.icon,
+    color: template.color,
+    owner_id: input.ownerId ?? null,
+    workspace_id: input.workspaceId ?? null,
+  })
+
+  const sheets: MultitableProvisioningSheet[] = []
+  const fields: MultitableProvisioningField[] = []
+  const views: MultitableProvisioningView[] = []
+
+  for (const templateSheet of template.sheets) {
+    const sheetId = stableChildId('sheet', baseId, template.id, templateSheet.id)
+    const sheetResult = await createSheet({
+      query: input.query,
+      sheetId,
+      baseId,
+      name: templateSheet.name,
+      description: templateSheet.description ?? null,
+    })
+    if (!sheetResult.created || !sheetResult.sheet) {
+      throw new MultitableTemplateConflictError(`Sheet already exists: ${sheetId}`)
+    }
+    sheets.push(sheetResult.sheet)
+
+    const fieldIds = mapFieldIds(sheetId, template.id, templateSheet)
+    const installedFields = await ensureFields({
+      query: input.query,
+      sheetId,
+      fields: templateSheet.fields.map((field) => ({
+        ...field,
+        id: fieldIds[field.id],
+      })),
+    })
+    fields.push(...installedFields)
+
+    for (const templateView of templateSheet.views) {
+      const viewId = stableChildId('view', sheetId, template.id, templateSheet.id, templateView.id)
+      const hiddenFieldIds = (templateView.hiddenFieldIds ?? [])
+        .map((fieldId) => fieldIds[fieldId])
+        .filter((fieldId): fieldId is string => typeof fieldId === 'string' && fieldId.length > 0)
+      const viewResult = await createView({
+        query: input.query,
+        viewId,
+        sheetId,
+        name: templateView.name,
+        type: templateView.type,
+        groupInfo: buildGroupInfo(templateView, fieldIds),
+        hiddenFieldIds,
+        config: buildViewConfig(templateView, fieldIds),
+      })
+      if (!viewResult.created || !viewResult.view) {
+        throw new MultitableTemplateConflictError(`View already exists: ${viewId}`)
+      }
+      views.push(viewResult.view)
+    }
+  }
+
+  return {
+    template,
+    base,
+    sheets,
+    fields,
+    views,
+  }
+}

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -67,6 +67,12 @@ import {
 } from '../multitable/loaders'
 import { ensureLegacyBase as ensureLegacyBaseShared } from '../multitable/provisioning'
 import {
+  MultitableTemplateConflictError,
+  MultitableTemplateNotFoundError,
+  installMultitableTemplate,
+  listMultitableTemplates,
+} from '../multitable/template-library'
+import {
   queryRecordsWithCursor,
   buildRecordsCacheKey,
   type CursorPaginatedResult,
@@ -2989,6 +2995,57 @@ export function univerMetaRouter(): Router {
       if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
       console.error('[univer-meta] create base failed:', err)
       return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to create base' } })
+    }
+  })
+
+  router.get('/templates', rbacGuard('multitable', 'read'), async (_req: Request, res: Response) => {
+    return res.json({ ok: true, data: { templates: listMultitableTemplates() } })
+  })
+
+  router.post('/templates/:templateId/install', rbacGuard('multitable', 'write'), async (req: Request, res: Response) => {
+    const schema = z.object({
+      baseName: z.string().min(1).max(255).optional(),
+      workspaceId: z.string().min(1).max(100).optional(),
+    })
+
+    const parsed = schema.safeParse(req.body ?? {})
+    if (!parsed.success) {
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
+    }
+
+    const templateId = typeof req.params.templateId === 'string' ? req.params.templateId.trim() : ''
+    if (!templateId) {
+      return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'templateId is required' } })
+    }
+
+    try {
+      const pool = poolManager.get()
+      const access = await resolveRequestAccess(req)
+      if (!access.userId) {
+        return res.status(401).json({ ok: false, error: { code: 'UNAUTHENTICATED', message: 'Authentication required' } })
+      }
+
+      const result = await pool.transaction(async ({ query }) => installMultitableTemplate({
+        query: query as unknown as QueryFn,
+        templateId,
+        baseName: parsed.data.baseName,
+        ownerId: access.userId,
+        workspaceId: parsed.data.workspaceId ?? null,
+        idGenerator: (prefix) => buildId(prefix).slice(0, 50),
+      }))
+
+      return res.status(201).json({ ok: true, data: result })
+    } catch (err) {
+      if (err instanceof MultitableTemplateNotFoundError) {
+        return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: err.message } })
+      }
+      if (err instanceof MultitableTemplateConflictError) {
+        return res.status(409).json({ ok: false, error: { code: 'CONFLICT', message: err.message } })
+      }
+      const hint = getDbNotReadyMessage(err)
+      if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
+      console.error('[univer-meta] install multitable template failed:', err)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to install template' } })
     }
   })
 

--- a/packages/core-backend/tests/integration/multitable-context.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-context.api.test.ts
@@ -543,6 +543,110 @@ describe('Multitable context API', () => {
     expect(mockPool.transaction).toHaveBeenCalledTimes(1)
   })
 
+  test('lists the built-in multitable template catalog', async () => {
+    const { app } = await createApp({
+      tokenPerms: ['multitable:read'],
+      queryHandler: async () => ({ rows: [], rowCount: 0 }),
+    })
+
+    const response = await request(app)
+      .get('/api/multitable/templates')
+      .expect(200)
+
+    expect(response.body.ok).toBe(true)
+    expect(response.body.data.templates.map((template: any) => template.id)).toEqual([
+      'project-tracker',
+      'sales-crm',
+      'issue-tracker',
+    ])
+  })
+
+  test('installs a built-in template as a new base in one transaction', async () => {
+    const bases: any[] = []
+    const sheets: any[] = []
+    const fields: any[] = []
+    const views: any[] = []
+    const { app, mockPool } = await createApp({
+      tokenPerms: ['multitable:write'],
+      queryHandler: async (sql, params = []) => {
+        const normalized = sql.replace(/\s+/g, ' ').trim()
+        if (normalized.startsWith('INSERT INTO meta_bases')) {
+          const [id, name, icon, color, ownerId, workspaceId] = params as [string, string, string, string, string | null, string | null]
+          const base = { id, name, icon, color, owner_id: ownerId, workspace_id: workspaceId }
+          bases.push(base)
+          return { rows: [base], rowCount: 1 }
+        }
+        if (normalized.startsWith('INSERT INTO meta_sheets')) {
+          const [id, baseId, name, description] = params as [string, string, string, string | null]
+          sheets.push({ id, base_id: baseId, name, description })
+          return { rows: [], rowCount: 1 }
+        }
+        if (normalized.includes('FROM meta_sheets') && normalized.includes('WHERE id = $1')) {
+          const [sheetId] = params as [string]
+          return { rows: sheets.filter((sheet) => sheet.id === sheetId) }
+        }
+        if (normalized.startsWith('INSERT INTO meta_fields')) {
+          const [id, sheetId, name, type, propertyJson, order] = params as [string, string, string, string, string, number]
+          fields.push({ id, sheet_id: sheetId, name, type, property: JSON.parse(propertyJson), order })
+          return { rows: [], rowCount: 1 }
+        }
+        if (normalized.includes('FROM meta_fields') && normalized.includes('id = ANY($2::text[])')) {
+          const [sheetId, ids] = params as [string, string[]]
+          const idSet = new Set(ids)
+          return {
+            rows: fields
+              .filter((field) => field.sheet_id === sheetId && idSet.has(field.id))
+              .sort((a, b) => a.order - b.order),
+          }
+        }
+        if (normalized.startsWith('INSERT INTO meta_views')) {
+          const [id, sheetId, name, type, filterInfoJson, sortInfoJson, groupInfoJson, hiddenFieldIdsJson, configJson] = params as [
+            string,
+            string,
+            string,
+            string,
+            string,
+            string,
+            string,
+            string,
+            string,
+          ]
+          views.push({
+            id,
+            sheet_id: sheetId,
+            name,
+            type,
+            filter_info: JSON.parse(filterInfoJson),
+            sort_info: JSON.parse(sortInfoJson),
+            group_info: JSON.parse(groupInfoJson),
+            hidden_field_ids: JSON.parse(hiddenFieldIdsJson),
+            config: JSON.parse(configJson),
+          })
+          return { rows: [], rowCount: 1 }
+        }
+        if (normalized.includes('FROM meta_views') && normalized.includes('WHERE id = $1')) {
+          const [viewId] = params as [string]
+          return { rows: views.filter((view) => view.id === viewId) }
+        }
+        throw new Error(`Unhandled SQL in test: ${sql}`)
+      },
+    })
+
+    const response = await request(app)
+      .post('/api/multitable/templates/project-tracker/install')
+      .send({ baseName: 'Launch Base' })
+      .expect(201)
+
+    expect(response.body.ok).toBe(true)
+    expect(response.body.data.base.name).toBe('Launch Base')
+    expect(response.body.data.template.id).toBe('project-tracker')
+    expect(response.body.data.sheets).toHaveLength(1)
+    expect(response.body.data.fields).toHaveLength(6)
+    expect(response.body.data.views.map((view: any) => view.type)).toEqual(['grid', 'kanban', 'calendar'])
+    expect(bases[0].owner_id).toBe('user_multitable_1')
+    expect(mockPool.transaction).toHaveBeenCalledTimes(1)
+  })
+
   test('allows create sheet under an owned base without global multitable write', async () => {
     const { app, mockPool } = await createApp({
       tokenPerms: [],

--- a/packages/core-backend/tests/unit/multitable-template-library.test.ts
+++ b/packages/core-backend/tests/unit/multitable-template-library.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  MultitableTemplateConflictError,
+  MultitableTemplateNotFoundError,
+  installMultitableTemplate,
+  listMultitableTemplates,
+  type MultitableTemplateBase,
+} from '../../src/multitable/template-library'
+import type { MultitableProvisioningQueryFn } from '../../src/multitable/provisioning'
+
+type FakeSheet = {
+  id: string
+  base_id: string
+  name: string
+  description: string | null
+}
+
+type FakeField = {
+  id: string
+  sheet_id: string
+  name: string
+  type: string
+  property: Record<string, unknown>
+  order: number
+}
+
+type FakeView = {
+  id: string
+  sheet_id: string
+  name: string
+  type: string
+  filter_info: Record<string, unknown>
+  sort_info: Record<string, unknown>
+  group_info: Record<string, unknown>
+  hidden_field_ids: string[]
+  config: Record<string, unknown>
+}
+
+function createQuery(seed?: { bases?: MultitableTemplateBase[] }): {
+  query: MultitableProvisioningQueryFn
+  bases: MultitableTemplateBase[]
+  sheets: FakeSheet[]
+  fields: FakeField[]
+  views: FakeView[]
+} {
+  const bases = [...(seed?.bases ?? [])]
+  const sheets: FakeSheet[] = []
+  const fields: FakeField[] = []
+  const views: FakeView[] = []
+
+  const query: MultitableProvisioningQueryFn = async (sql, params = []) => {
+    const normalized = sql.replace(/\s+/g, ' ').trim()
+
+    if (normalized.startsWith('INSERT INTO meta_bases')) {
+      const [id, name, icon, color, ownerId, workspaceId] = params as [string, string, string, string, string | null, string | null]
+      if (bases.some((base) => base.id === id)) {
+        return { rows: [], rowCount: 0 }
+      }
+      const base = {
+        id,
+        name,
+        icon,
+        color,
+        ownerId,
+        workspaceId,
+      }
+      bases.push(base)
+      return {
+        rows: [{
+          id: base.id,
+          name: base.name,
+          icon: base.icon,
+          color: base.color,
+          owner_id: base.ownerId,
+          workspace_id: base.workspaceId,
+        }],
+        rowCount: 1,
+      }
+    }
+
+    if (normalized.startsWith('INSERT INTO meta_sheets')) {
+      const [id, baseId, name, description] = params as [string, string, string, string | null]
+      if (sheets.some((sheet) => sheet.id === id)) {
+        return { rows: [], rowCount: 0 }
+      }
+      sheets.push({ id, base_id: baseId, name, description })
+      return { rows: [], rowCount: 1 }
+    }
+
+    if (normalized.includes('FROM meta_sheets') && normalized.includes('WHERE id = $1')) {
+      const [sheetId] = params as [string]
+      return { rows: sheets.filter((sheet) => sheet.id === sheetId) }
+    }
+
+    if (normalized.startsWith('INSERT INTO meta_fields')) {
+      const [id, sheetId, name, type, propertyJson, order] = params as [
+        string,
+        string,
+        string,
+        string,
+        string,
+        number,
+      ]
+      const next = {
+        id,
+        sheet_id: sheetId,
+        name,
+        type,
+        property: JSON.parse(propertyJson),
+        order,
+      }
+      const existing = fields.find((field) => field.id === id)
+      if (existing) Object.assign(existing, next)
+      else fields.push(next)
+      return { rows: [], rowCount: 1 }
+    }
+
+    if (normalized.includes('FROM meta_fields') && normalized.includes('id = ANY($2::text[])')) {
+      const [sheetId, ids] = params as [string, string[]]
+      const idSet = new Set(ids)
+      return {
+        rows: fields
+          .filter((field) => field.sheet_id === sheetId && idSet.has(field.id))
+          .sort((a, b) => a.order - b.order || a.id.localeCompare(b.id)),
+      }
+    }
+
+    if (normalized.startsWith('INSERT INTO meta_views')) {
+      const [id, sheetId, name, type, filterInfoJson, sortInfoJson, groupInfoJson, hiddenFieldIdsJson, configJson] = params as [
+        string,
+        string,
+        string,
+        string,
+        string,
+        string,
+        string,
+        string,
+        string,
+      ]
+      if (views.some((view) => view.id === id)) {
+        return { rows: [], rowCount: 0 }
+      }
+      views.push({
+        id,
+        sheet_id: sheetId,
+        name,
+        type,
+        filter_info: JSON.parse(filterInfoJson),
+        sort_info: JSON.parse(sortInfoJson),
+        group_info: JSON.parse(groupInfoJson),
+        hidden_field_ids: JSON.parse(hiddenFieldIdsJson),
+        config: JSON.parse(configJson),
+      })
+      return { rows: [], rowCount: 1 }
+    }
+
+    if (normalized.includes('FROM meta_views') && normalized.includes('WHERE id = $1')) {
+      const [viewId] = params as [string]
+      return { rows: views.filter((view) => view.id === viewId) }
+    }
+
+    throw new Error(`Unhandled SQL in test: ${normalized}`)
+  }
+
+  return { query, bases, sheets, fields, views }
+}
+
+describe('multitable template library', () => {
+  it('lists built-in templates defensively', () => {
+    const first = listMultitableTemplates()
+    const second = listMultitableTemplates()
+
+    expect(first.map((template) => template.id)).toEqual([
+      'project-tracker',
+      'sales-crm',
+      'issue-tracker',
+    ])
+    first[0].sheets[0].fields[0].name = 'mutated'
+    expect(second[0].sheets[0].fields[0].name).toBe('Task')
+  })
+
+  it('installs a template as one base with mapped fields and views', async () => {
+    const { query, bases, sheets, fields, views } = createQuery()
+
+    const result = await installMultitableTemplate({
+      query,
+      templateId: 'project-tracker',
+      baseName: 'Launch Plan',
+      ownerId: 'user_1',
+      idGenerator: (prefix) => `${prefix}_fixed`,
+    })
+
+    expect(result.base).toMatchObject({
+      id: 'base_fixed',
+      name: 'Launch Plan',
+      ownerId: 'user_1',
+    })
+    expect(bases).toHaveLength(1)
+    expect(sheets).toHaveLength(1)
+    expect(fields.map((field) => field.name)).toEqual([
+      'Task',
+      'Status',
+      'Owner',
+      'Priority',
+      'Due Date',
+      'Notes',
+    ])
+    const statusField = fields.find((field) => field.name === 'Status')
+    expect(statusField?.property.options).toEqual([
+      { value: 'Not started' },
+      { value: 'In progress' },
+      { value: 'Blocked' },
+      { value: 'Done' },
+    ])
+    const kanban = views.find((view) => view.type === 'kanban')
+    expect(kanban?.group_info).toEqual({ fieldId: statusField?.id })
+    const dueDateField = fields.find((field) => field.name === 'Due Date')
+    const calendar = views.find((view) => view.type === 'calendar')
+    expect(calendar?.config).toEqual(expect.objectContaining({ dateFieldId: dueDateField?.id }))
+    expect(result.sheets[0].baseId).toBe('base_fixed')
+    expect(result.views).toHaveLength(3)
+  })
+
+  it('rejects unknown templates', async () => {
+    const { query } = createQuery()
+
+    await expect(installMultitableTemplate({
+      query,
+      templateId: 'missing',
+    })).rejects.toBeInstanceOf(MultitableTemplateNotFoundError)
+  })
+
+  it('rejects base id conflicts before creating sheets', async () => {
+    const { query, sheets } = createQuery({
+      bases: [{ id: 'base_fixed', name: 'Existing', icon: null, color: null, ownerId: null, workspaceId: null }],
+    })
+
+    await expect(installMultitableTemplate({
+      query,
+      templateId: 'sales-crm',
+      idGenerator: (prefix) => `${prefix}_fixed`,
+    })).rejects.toBeInstanceOf(MultitableTemplateConflictError)
+    expect(sheets).toHaveLength(0)
+  })
+})

--- a/packages/openapi/dist/combined.openapi.yml
+++ b/packages/openapi/dist/combined.openapi.yml
@@ -1567,6 +1567,131 @@ components:
         description:
           type: string
           nullable: true
+    MultitableTemplateField:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        type:
+          $ref: '#/components/schemas/MultitableFieldType'
+        order:
+          type: integer
+        options:
+          type: array
+          items:
+            type: string
+        property:
+          type: object
+          additionalProperties: true
+        description:
+          type: string
+      required:
+        - id
+        - name
+        - type
+    MultitableTemplateView:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        type:
+          $ref: '#/components/schemas/MultitableViewType'
+        groupByFieldId:
+          type: string
+        dateFieldId:
+          type: string
+        titleFieldId:
+          type: string
+        hiddenFieldIds:
+          type: array
+          items:
+            type: string
+        config:
+          type: object
+          additionalProperties: true
+      required:
+        - id
+        - name
+        - type
+    MultitableTemplateSheet:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+        fields:
+          type: array
+          items:
+            $ref: '#/components/schemas/MultitableTemplateField'
+        views:
+          type: array
+          items:
+            $ref: '#/components/schemas/MultitableTemplateView'
+      required:
+        - id
+        - name
+        - fields
+        - views
+    MultitableTemplate:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        category:
+          type: string
+        icon:
+          type: string
+        color:
+          type: string
+        sheets:
+          type: array
+          items:
+            $ref: '#/components/schemas/MultitableTemplateSheet'
+      required:
+        - id
+        - name
+        - description
+        - category
+        - icon
+        - color
+        - sheets
+    MultitableTemplateInstallResult:
+      type: object
+      properties:
+        template:
+          $ref: '#/components/schemas/MultitableTemplate'
+        base:
+          $ref: '#/components/schemas/MultitableBase'
+        sheets:
+          type: array
+          items:
+            $ref: '#/components/schemas/MultitableSheet'
+        fields:
+          type: array
+          items:
+            $ref: '#/components/schemas/MultitableField'
+        views:
+          type: array
+          items:
+            $ref: '#/components/schemas/MultitableView'
+      required:
+        - template
+        - base
+        - sheets
+        - fields
+        - views
     MultitableViewType:
       type: string
       enum:
@@ -11239,6 +11364,76 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
+  /api/multitable/templates:
+    get:
+      summary: List built-in multitable templates
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      templates:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/MultitableTemplate'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+  /api/multitable/templates/{templateId}/install:
+    post:
+      summary: Install a built-in multitable template as a new base
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: templateId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                baseName:
+                  type: string
+                workspaceId:
+                  type: string
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    $ref: '#/components/schemas/MultitableTemplateInstallResult'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
   /api/multitable/context:
     get:
       summary: Load multitable workbench context

--- a/packages/openapi/dist/openapi.json
+++ b/packages/openapi/dist/openapi.json
@@ -2261,6 +2261,186 @@
           }
         }
       },
+      "MultitableTemplateField": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "$ref": "#/components/schemas/MultitableFieldType"
+          },
+          "order": {
+            "type": "integer"
+          },
+          "options": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "property": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "type"
+        ]
+      },
+      "MultitableTemplateView": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "$ref": "#/components/schemas/MultitableViewType"
+          },
+          "groupByFieldId": {
+            "type": "string"
+          },
+          "dateFieldId": {
+            "type": "string"
+          },
+          "titleFieldId": {
+            "type": "string"
+          },
+          "hiddenFieldIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "config": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "type"
+        ]
+      },
+      "MultitableTemplateSheet": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MultitableTemplateField"
+            }
+          },
+          "views": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MultitableTemplateView"
+            }
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "fields",
+          "views"
+        ]
+      },
+      "MultitableTemplate": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "category": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "string"
+          },
+          "color": {
+            "type": "string"
+          },
+          "sheets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MultitableTemplateSheet"
+            }
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "description",
+          "category",
+          "icon",
+          "color",
+          "sheets"
+        ]
+      },
+      "MultitableTemplateInstallResult": {
+        "type": "object",
+        "properties": {
+          "template": {
+            "$ref": "#/components/schemas/MultitableTemplate"
+          },
+          "base": {
+            "$ref": "#/components/schemas/MultitableBase"
+          },
+          "sheets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MultitableSheet"
+            }
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MultitableField"
+            }
+          },
+          "views": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MultitableView"
+            }
+          }
+        },
+        "required": [
+          "template",
+          "base",
+          "sheets",
+          "fields",
+          "views"
+        ]
+      },
       "MultitableViewType": {
         "type": "string",
         "enum": [
@@ -17239,6 +17419,123 @@
           },
           "403": {
             "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/api/multitable/templates": {
+      "get": {
+        "summary": "List built-in multitable templates",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "templates": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/MultitableTemplate"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        }
+      }
+    },
+    "/api/multitable/templates/{templateId}/install": {
+      "post": {
+        "summary": "Install a built-in multitable template as a new base",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "templateId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "baseName": {
+                    "type": "string"
+                  },
+                  "workspaceId": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/MultitableTemplateInstallResult"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
           }
         }
       }

--- a/packages/openapi/dist/openapi.yaml
+++ b/packages/openapi/dist/openapi.yaml
@@ -1567,6 +1567,131 @@ components:
         description:
           type: string
           nullable: true
+    MultitableTemplateField:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        type:
+          $ref: '#/components/schemas/MultitableFieldType'
+        order:
+          type: integer
+        options:
+          type: array
+          items:
+            type: string
+        property:
+          type: object
+          additionalProperties: true
+        description:
+          type: string
+      required:
+        - id
+        - name
+        - type
+    MultitableTemplateView:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        type:
+          $ref: '#/components/schemas/MultitableViewType'
+        groupByFieldId:
+          type: string
+        dateFieldId:
+          type: string
+        titleFieldId:
+          type: string
+        hiddenFieldIds:
+          type: array
+          items:
+            type: string
+        config:
+          type: object
+          additionalProperties: true
+      required:
+        - id
+        - name
+        - type
+    MultitableTemplateSheet:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+        fields:
+          type: array
+          items:
+            $ref: '#/components/schemas/MultitableTemplateField'
+        views:
+          type: array
+          items:
+            $ref: '#/components/schemas/MultitableTemplateView'
+      required:
+        - id
+        - name
+        - fields
+        - views
+    MultitableTemplate:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        category:
+          type: string
+        icon:
+          type: string
+        color:
+          type: string
+        sheets:
+          type: array
+          items:
+            $ref: '#/components/schemas/MultitableTemplateSheet'
+      required:
+        - id
+        - name
+        - description
+        - category
+        - icon
+        - color
+        - sheets
+    MultitableTemplateInstallResult:
+      type: object
+      properties:
+        template:
+          $ref: '#/components/schemas/MultitableTemplate'
+        base:
+          $ref: '#/components/schemas/MultitableBase'
+        sheets:
+          type: array
+          items:
+            $ref: '#/components/schemas/MultitableSheet'
+        fields:
+          type: array
+          items:
+            $ref: '#/components/schemas/MultitableField'
+        views:
+          type: array
+          items:
+            $ref: '#/components/schemas/MultitableView'
+      required:
+        - template
+        - base
+        - sheets
+        - fields
+        - views
     MultitableViewType:
       type: string
       enum:
@@ -11239,6 +11364,76 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
+  /api/multitable/templates:
+    get:
+      summary: List built-in multitable templates
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      templates:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/MultitableTemplate'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+  /api/multitable/templates/{templateId}/install:
+    post:
+      summary: Install a built-in multitable template as a new base
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: templateId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                baseName:
+                  type: string
+                workspaceId:
+                  type: string
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    $ref: '#/components/schemas/MultitableTemplateInstallResult'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
   /api/multitable/context:
     get:
       summary: Load multitable workbench context

--- a/packages/openapi/src/base.yml
+++ b/packages/openapi/src/base.yml
@@ -1510,6 +1510,131 @@ components:
         description:
           type: string
           nullable: true
+    MultitableTemplateField:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        type:
+          $ref: '#/components/schemas/MultitableFieldType'
+        order:
+          type: integer
+        options:
+          type: array
+          items:
+            type: string
+        property:
+          type: object
+          additionalProperties: true
+        description:
+          type: string
+      required:
+        - id
+        - name
+        - type
+    MultitableTemplateView:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        type:
+          $ref: '#/components/schemas/MultitableViewType'
+        groupByFieldId:
+          type: string
+        dateFieldId:
+          type: string
+        titleFieldId:
+          type: string
+        hiddenFieldIds:
+          type: array
+          items:
+            type: string
+        config:
+          type: object
+          additionalProperties: true
+      required:
+        - id
+        - name
+        - type
+    MultitableTemplateSheet:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+        fields:
+          type: array
+          items:
+            $ref: '#/components/schemas/MultitableTemplateField'
+        views:
+          type: array
+          items:
+            $ref: '#/components/schemas/MultitableTemplateView'
+      required:
+        - id
+        - name
+        - fields
+        - views
+    MultitableTemplate:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        category:
+          type: string
+        icon:
+          type: string
+        color:
+          type: string
+        sheets:
+          type: array
+          items:
+            $ref: '#/components/schemas/MultitableTemplateSheet'
+      required:
+        - id
+        - name
+        - description
+        - category
+        - icon
+        - color
+        - sheets
+    MultitableTemplateInstallResult:
+      type: object
+      properties:
+        template:
+          $ref: '#/components/schemas/MultitableTemplate'
+        base:
+          $ref: '#/components/schemas/MultitableBase'
+        sheets:
+          type: array
+          items:
+            $ref: '#/components/schemas/MultitableSheet'
+        fields:
+          type: array
+          items:
+            $ref: '#/components/schemas/MultitableField'
+        views:
+          type: array
+          items:
+            $ref: '#/components/schemas/MultitableView'
+      required:
+        - template
+        - base
+        - sheets
+        - fields
+        - views
     MultitableViewType:
       type: string
       enum:

--- a/packages/openapi/src/paths/multitable.yml
+++ b/packages/openapi/src/paths/multitable.yml
@@ -57,6 +57,66 @@ paths:
         '400': { $ref: '#/components/responses/ValidationError' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
+  /api/multitable/templates:
+    get:
+      summary: List built-in multitable templates
+      security: [ { bearerAuth: [] } ]
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      templates:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/MultitableTemplate'
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+  /api/multitable/templates/{templateId}/install:
+    post:
+      summary: Install a built-in multitable template as a new base
+      security: [ { bearerAuth: [] } ]
+      parameters:
+        - in: path
+          name: templateId
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                baseName:
+                  type: string
+                workspaceId:
+                  type: string
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    $ref: '#/components/schemas/MultitableTemplateInstallResult'
+        '400': { $ref: '#/components/responses/ValidationError' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '403': { $ref: '#/components/responses/Forbidden' }
+        '404': { $ref: '#/components/responses/NotFound' }
+        '409': { $ref: '#/components/responses/Conflict' }
   /api/multitable/context:
     get:
       summary: Load multitable workbench context

--- a/scripts/ops/multitable-openapi-parity.test.mjs
+++ b/scripts/ops/multitable-openapi-parity.test.mjs
@@ -53,6 +53,8 @@ test('multitable openapi stays aligned with runtime contracts', () => {
   const schemas = openapi.components?.schemas ?? {}
 
   assert.ok(paths['/api/multitable/person-fields/prepare']?.post, 'missing person-field prepare endpoint')
+  assert.ok(paths['/api/multitable/templates']?.get, 'missing template catalog endpoint')
+  assert.ok(paths['/api/multitable/templates/{templateId}/install']?.post, 'missing template install endpoint')
   assert.ok(paths['/api/multitable/sheets/{sheetId}']?.delete, 'missing sheet delete endpoint')
   assert.ok(paths['/api/multitable/records/{recordId}']?.patch, 'missing single-record patch endpoint')
   assert.ok(paths['/api/multitable/sheets/{sheetId}/import-xlsx']?.post, 'missing xlsx import endpoint')
@@ -76,6 +78,22 @@ test('multitable openapi stays aligned with runtime contracts', () => {
 
   assert.deepEqual(schemas.MultitableFieldType?.enum, expectedFieldTypes)
   assert.deepEqual(schemas.MultitableViewType?.enum, expectedViewTypes)
+  assert.equal(
+    paths['/api/multitable/templates']?.get?.responses?.['200']?.content?.['application/json']?.schema?.properties?.data?.properties?.templates?.items?.$ref,
+    '#/components/schemas/MultitableTemplate',
+  )
+  assert.equal(
+    paths['/api/multitable/templates/{templateId}/install']?.post?.responses?.['201']?.content?.['application/json']?.schema?.properties?.data?.$ref,
+    '#/components/schemas/MultitableTemplateInstallResult',
+  )
+  assert.equal(
+    schemas.MultitableTemplateField?.properties?.type?.$ref,
+    '#/components/schemas/MultitableFieldType',
+  )
+  assert.equal(
+    schemas.MultitableTemplateView?.properties?.type?.$ref,
+    '#/components/schemas/MultitableViewType',
+  )
   assert.equal(
     paths['/api/multitable/fields']?.post?.requestBody?.content?.['application/json']?.schema?.properties?.type?.$ref,
     '#/components/schemas/MultitableFieldType',


### PR DESCRIPTION
## Summary
- add a static multitable template catalog with Project Tracker, Sales CRM, and Issue Tracker
- add GET /api/multitable/templates and POST /api/multitable/templates/:templateId/install
- wire a minimal Workbench Templates panel plus typed API client methods
- update OpenAPI source/dist and parity guard

## Verification
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/multitable-template-library.test.ts --reporter=dot
- pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/multitable-context.api.test.ts --reporter=dot
- pnpm --filter @metasheet/web exec vitest run tests/multitable-phase3.spec.ts --reporter=dot
- pnpm --filter @metasheet/core-backend exec tsc --noEmit
- pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
- pnpm verify:multitable-openapi:parity
- git diff --check

## Docs
- docs/development/multitable-template-library-v1-design-20260506.md
- docs/development/multitable-template-library-v1-verification-20260506.md