### PR TITLE
chore(multitable): add Feishu RC API smoke gate

### DIFF
--- a/docs/development/multitable-feishu-rc-api-smoke-design-20260506.md
+++ b/docs/development/multitable-feishu-rc-api-smoke-design-20260506.md
@@ -1,0 +1,94 @@
+# Multitable Feishu RC API Smoke Design - 2026-05-06
+
+## Status
+
+- Branch: `codex/multitable-rc-staging-api-smoke-20260506`
+- Scope: add an executable API-layer staging smoke helper for the Feishu-parity RC checklist.
+- Non-goal: replace browser/manual verification for XLSX UI, formula editor, filter builder UI, Gantt, hierarchy, and visual styling.
+
+## Problem
+
+The RC staging checklist is intentionally manual. That is correct for UI coverage, but it leaves every deploy with the same repeatable API questions:
+
+- Is staging running and reachable?
+- Is the tester token valid?
+- Are multitable templates present?
+- Can the backend create the Feishu-parity field types and persist values?
+- Does record patch still go through expected-version write semantics?
+- Does conditional formatting config persist through the view API?
+- Does public form sharing still allow unauthenticated submit with a valid public token?
+
+Those checks should be executable before a human spends 30-60 minutes on browser smoke.
+
+## Implementation
+
+Added `scripts/ops/multitable-feishu-rc-api-smoke.mjs`.
+
+The script uses only Node built-ins plus the existing `scripts/multitable-auth.mjs` token helper. It writes:
+
+- `report.json`
+- `report.md`
+
+Default output path:
+
+```bash
+output/multitable-feishu-rc-api-smoke/<timestamp>/
+```
+
+## Safety Gates
+
+The runner refuses to run unless all required staging-safety inputs are present:
+
+- `API_BASE` or `BASE_URL`
+- `AUTH_TOKEN` or `TOKEN`, unless `ALLOW_DEV_TOKEN=1`
+- `CONFIRM_WRITE=1`
+- either `SMOKE_SHEET_ID` or `ALLOW_INSTALL=1`
+
+`ALLOW_INSTALL=1` installs the `project-tracker` template into a unique base and runs the smoke against that isolated sheet. If `SMOKE_SHEET_ID` is provided, the script uses that sheet instead.
+
+The script records token source only. It never writes bearer tokens or public form tokens to the JSON or Markdown report.
+
+## Covered Checks
+
+- `api.health`: probes `/api/health`, then `/health` fallback.
+- `api.auth.me`: validates the bearer token against `/api/auth/me`.
+- `api.integration-staging.descriptors`: optional probe for integration-core staging descriptors; unavailable plugin is reported as skipped, not failed.
+- `api.templates.list`: verifies the target template exists.
+- `api.templates.install` or `api.context.smoke-sheet`: resolves a writable sheet.
+- `api.fields.batch-types`: creates currency, percent, rating, URL, email, phone, barcode, location, dateTime, and multiSelect fields.
+- `api.records.create`: writes one record with representative values for all created field types.
+- `api.records.patch.expected-version`: patches the record with `expectedVersion`.
+- `api.views.conditional-formatting`: creates a grid view with a persisted conditional formatting rule.
+- `api.public-form.submit`: creates a public form view, enables public share, loads form context, and submits an unauthenticated record.
+
+## Deferred Manual Coverage
+
+These remain in the manual staging checklist:
+
+- XLSX import/export through the browser modal and toolbar.
+- Formula editor token insertion, function catalog, and diagnostics.
+- Filter builder typed controls.
+- Gantt and hierarchy view rendering/interaction.
+- Visual conditional-formatting behavior after reload.
+- Automation `send_email` delivery/provider behavior.
+
+## Staging Command
+
+```bash
+API_BASE="https://staging.example.com" \
+AUTH_TOKEN="<redacted>" \
+CONFIRM_WRITE=1 \
+ALLOW_INSTALL=1 \
+EXPECTED_COMMIT="<deployed-main-sha>" \
+pnpm verify:multitable-feishu-rc:api-smoke
+```
+
+For an existing scratch sheet:
+
+```bash
+API_BASE="https://staging.example.com" \
+AUTH_TOKEN="<redacted>" \
+CONFIRM_WRITE=1 \
+SMOKE_SHEET_ID="sheet_xxx" \
+pnpm verify:multitable-feishu-rc:api-smoke
+```

--- a/docs/development/multitable-feishu-rc-api-smoke-verification-20260506.md
+++ b/docs/development/multitable-feishu-rc-api-smoke-verification-20260506.md
@@ -1,0 +1,84 @@
+# Multitable Feishu RC API Smoke Verification - 2026-05-06
+
+## Status
+
+- Branch: `codex/multitable-rc-staging-api-smoke-20260506`
+- Real staging run: not run in this development session because no staging URL/token was injected into the worktree.
+- Verification level: parser/renderer/unit coverage plus mocked HTTP end-to-end runner coverage.
+
+## Commands
+
+```bash
+node --test scripts/ops/multitable-feishu-rc-api-smoke.test.mjs
+```
+
+Result:
+
+```text
+3 tests pass
+```
+
+```bash
+node --check scripts/ops/multitable-feishu-rc-api-smoke.mjs
+node --check scripts/ops/multitable-feishu-rc-api-smoke.test.mjs
+git diff --check
+```
+
+Result:
+
+```text
+no syntax or whitespace errors
+```
+
+Also verified through the package script:
+
+```bash
+pnpm verify:multitable-feishu-rc:api-smoke:test
+```
+
+Result:
+
+```text
+3 tests pass
+```
+
+## Test Coverage
+
+`scripts/ops/multitable-feishu-rc-api-smoke.test.mjs` covers:
+
+- Required config validation for token, write confirmation, and writable target.
+- Markdown renderer behavior for failing and skipped checks.
+- Redaction safety: reports do not include bearer token strings or public form tokens.
+- Mocked HTTP end-to-end run through:
+  - health
+  - auth
+  - optional integration descriptors skip
+  - template list
+  - template install
+  - batch field creation
+  - record create
+  - record patch with expected version
+  - conditional-formatting view create
+  - public form share/context/submit
+  - report artifact writes
+
+## Real Staging Follow-up
+
+Run after staging deploy:
+
+```bash
+API_BASE="http://142.171.239.56:8081" \
+AUTH_TOKEN="$(cat /path/to/admin.jwt)" \
+CONFIRM_WRITE=1 \
+ALLOW_INSTALL=1 \
+EXPECTED_COMMIT="<deployed-main-sha>" \
+OUTPUT_DIR="output/multitable-feishu-rc-api-smoke/142-$(date +%Y%m%d-%H%M%S)" \
+pnpm verify:multitable-feishu-rc:api-smoke
+```
+
+Pass criteria:
+
+- Runner exits `0`.
+- `report.md` has `Overall: PASS`.
+- Any skipped `api.integration-staging.descriptors` is acceptable only if integration-core staging plugin is intentionally disabled.
+- Browser checklist remains required after this API smoke passes.

--- a/docs/development/multitable-feishu-rc-todo-20260430.md
+++ b/docs/development/multitable-feishu-rc-todo-20260430.md
@@ -82,6 +82,12 @@ Do not mark an item done if:
 - [ ] Smoke test Hierarchy view rendering and child creation.
 - [ ] Smoke test public form submit path.
 - [ ] Smoke test automation send_email save/execute path.
+- [x] Create executable API smoke helper for repeatable staging evidence.
+  - PR: pending
+  - Merge commit: pending
+  - Development MD: `docs/development/multitable-feishu-rc-api-smoke-design-20260506.md`
+  - Verification MD: `docs/development/multitable-feishu-rc-api-smoke-verification-20260506.md`
+  - Verification summary: `node --test scripts/ops/multitable-feishu-rc-api-smoke.test.mjs`, `node --check` for runner/test, and `git diff --check`; real staging run remains pending.
 - [x] Produce RC audit result MD with P0/P1/P2 defects.
   - PR: pending
   - Merge commit: pending

--- a/docs/development/multitable-feishu-rc-todo-20260430.md
+++ b/docs/development/multitable-feishu-rc-todo-20260430.md
@@ -83,7 +83,7 @@ Do not mark an item done if:
 - [ ] Smoke test public form submit path.
 - [ ] Smoke test automation send_email save/execute path.
 - [x] Create executable API smoke helper for repeatable staging evidence.
-  - PR: pending
+  - PR: #1359
   - Merge commit: pending
   - Development MD: `docs/development/multitable-feishu-rc-api-smoke-design-20260506.md`
   - Verification MD: `docs/development/multitable-feishu-rc-api-smoke-verification-20260506.md`

--- a/docs/development/multitable-feishu-staging-smoke-checklist-20260430.md
+++ b/docs/development/multitable-feishu-staging-smoke-checklist-20260430.md
@@ -19,6 +19,26 @@ Record exact staging evidence:
 - Browser:
 - Backend log source:
 
+## Optional API Smoke Helper
+
+Run this before manual browser smoke to collect repeatable backend/API evidence:
+
+```bash
+API_BASE="<staging-url>" \
+AUTH_TOKEN="<redacted>" \
+CONFIRM_WRITE=1 \
+ALLOW_INSTALL=1 \
+EXPECTED_COMMIT="<deployed-main-sha>" \
+pnpm verify:multitable-feishu-rc:api-smoke
+```
+
+Expected artifacts:
+
+- `output/multitable-feishu-rc-api-smoke/<timestamp>/report.json`
+- `output/multitable-feishu-rc-api-smoke/<timestamp>/report.md`
+
+This helper covers API health, auth, template availability/install, batch field creation, record create/patch, conditional-formatting persistence, and public-form submit. It does not replace the manual UI checks below.
+
 ## Smoke 1 - Basic Sheet Lifecycle
 
 - [ ] Create a base.

--- a/package.json
+++ b/package.json
@@ -57,6 +57,8 @@
     "verify:multitable-pilot:release-gate": "bash scripts/ops/multitable-pilot-release-gate.sh",
     "verify:multitable-pilot:release-gate:staging": "RUN_MODE=staging bash scripts/ops/multitable-pilot-release-gate.sh",
     "verify:multitable-pilot:release-gate:test": "node --test scripts/ops/multitable-pilot-release-gate.test.mjs",
+    "verify:multitable-feishu-rc:api-smoke": "node scripts/ops/multitable-feishu-rc-api-smoke.mjs",
+    "verify:multitable-feishu-rc:api-smoke:test": "node --test scripts/ops/multitable-feishu-rc-api-smoke.test.mjs",
     "verify:multitable-openapi:parity": "pnpm exec tsx packages/openapi/tools/build.ts && node --test scripts/ops/multitable-openapi-parity.test.mjs",
     "verify:multitable-yjs:contract": "node --test scripts/ops/multitable-yjs-contract-parity.test.mjs",
     "prepare:multitable-pilot:handoff": "node scripts/ops/multitable-pilot-handoff.mjs",

--- a/scripts/ops/multitable-feishu-rc-api-smoke.mjs
+++ b/scripts/ops/multitable-feishu-rc-api-smoke.mjs
@@ -1,0 +1,558 @@
+#!/usr/bin/env node
+import crypto from 'node:crypto'
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { resolveMultitableAuthToken } from '../multitable-auth.mjs'
+
+const DEFAULT_TIMEOUT_MS = 15_000
+const DEFAULT_TEMPLATE_ID = 'project-tracker'
+
+const FIELD_SPECS = [
+  { key: 'currency', type: 'currency', property: { code: 'CNY', decimals: 2 }, value: 123.45 },
+  { key: 'percent', type: 'percent', property: { decimals: 2 }, value: 0.42 },
+  { key: 'rating', type: 'rating', property: { max: 5 }, value: 4 },
+  { key: 'url', type: 'url', property: {}, value: 'https://example.com/rc-smoke' },
+  { key: 'email', type: 'email', property: {}, value: 'rc-smoke@example.com' },
+  { key: 'phone', type: 'phone', property: {}, value: '+14155550123' },
+  { key: 'barcode', type: 'barcode', property: {}, value: 'RC-SMOKE-001' },
+  {
+    key: 'location',
+    type: 'location',
+    property: {},
+    value: { address: 'RC Smoke Location', latitude: 37.7749, longitude: -122.4194 },
+  },
+  { key: 'dateTime', type: 'dateTime', property: { timezone: 'UTC' }, value: '2026-05-06T12:00:00.000Z' },
+  {
+    key: 'multiSelect',
+    type: 'multiSelect',
+    property: {
+      options: [
+        { value: 'Alpha', color: '#2563eb' },
+        { value: 'Beta', color: '#16a34a' },
+        { value: 'Gamma', color: '#f97316' },
+      ],
+    },
+    value: ['Alpha', 'Beta'],
+  },
+]
+
+function timestampSlug(date = new Date()) {
+  return date.toISOString().replace(/[:.]/g, '-')
+}
+
+export function normalizeBaseUrl(value) {
+  return String(value || '').trim().replace(/\/+$/, '')
+}
+
+export function parseBoolean(value) {
+  return value === '1' || value === 'true' || value === 'TRUE' || value === 'yes'
+}
+
+function sha(value) {
+  return crypto.createHash('sha256').update(String(value || '')).digest('hex').slice(0, 12)
+}
+
+function buildDefaultOutputDir(now = new Date()) {
+  return `output/multitable-feishu-rc-api-smoke/${timestampSlug(now)}`
+}
+
+export function parseConfig(env = process.env, now = new Date()) {
+  const apiBase = normalizeBaseUrl(env.API_BASE || env.BASE_URL || env.STAGING_BASE_URL)
+  const outputDir = String(env.OUTPUT_DIR || buildDefaultOutputDir(now))
+  const timeoutMs = Number(env.TIMEOUT_MS || DEFAULT_TIMEOUT_MS)
+  return {
+    apiBase,
+    authToken: String(env.AUTH_TOKEN || env.TOKEN || '').trim(),
+    allowDevToken: parseBoolean(env.ALLOW_DEV_TOKEN),
+    confirmWrite: parseBoolean(env.CONFIRM_WRITE),
+    allowInstall: parseBoolean(env.ALLOW_INSTALL),
+    templateId: String(env.TEMPLATE_ID || DEFAULT_TEMPLATE_ID).trim(),
+    smokeSheetId: String(env.SMOKE_SHEET_ID || '').trim(),
+    expectedCommit: String(env.EXPECTED_COMMIT || env.DEPLOY_SHA || env.GIT_SHA || '').trim(),
+    outputDir,
+    reportPath: String(env.REPORT_JSON || path.join(outputDir, 'report.json')),
+    reportMdPath: String(env.REPORT_MD || path.join(outputDir, 'report.md')),
+    timeoutMs: Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : DEFAULT_TIMEOUT_MS,
+    skipPublicForm: parseBoolean(env.SKIP_PUBLIC_FORM),
+    cleanup: parseBoolean(env.CLEANUP),
+    runId: String(env.RUN_ID || `rc-api-smoke-${timestampSlug(now)}`).slice(0, 80),
+  }
+}
+
+export function validateConfig(config) {
+  const missing = []
+  if (!config.apiBase) missing.push('API_BASE or BASE_URL')
+  if (!config.authToken && !config.allowDevToken) missing.push('AUTH_TOKEN or TOKEN')
+  if (!config.confirmWrite) missing.push('CONFIRM_WRITE=1')
+  if (!config.smokeSheetId && !config.allowInstall) missing.push('SMOKE_SHEET_ID or ALLOW_INSTALL=1')
+  return missing
+}
+
+export function renderRcApiSmokeMarkdown(report) {
+  const checks = Array.isArray(report?.checks) ? report.checks : []
+  const failing = checks.filter((check) => check && check.ok === false)
+  const skipped = checks.filter((check) => check?.details?.skipped === true)
+  const lines = [
+    '# Multitable Feishu RC API Smoke',
+    '',
+    `- Overall: **${report?.ok === false ? 'FAIL' : 'PASS'}**`,
+    `- API base: \`${report?.apiBase || 'missing'}\``,
+    `- Run ID: \`${report?.runId || 'missing'}\``,
+    `- Started at: \`${report?.startedAt || 'missing'}\``,
+    `- Finished at: \`${report?.finishedAt || 'missing'}\``,
+    `- Expected commit: \`${report?.expectedCommit || 'not-set'}\``,
+    `- JSON report: \`${report?.reportPath || 'missing'}\``,
+    `- Markdown report: \`${report?.reportMdPath || 'missing'}\``,
+    '',
+    '## Checks',
+    '',
+    `- Total checks: \`${checks.length}\``,
+    failing.length
+      ? `- Failing checks: ${failing.map((check) => `\`${check.name}\``).join(', ')}`
+      : '- Failing checks: none',
+    skipped.length
+      ? `- Skipped checks: ${skipped.map((check) => `\`${check.name}\``).join(', ')}`
+      : '- Skipped checks: none',
+  ]
+
+  if (report?.metadata && Object.keys(report.metadata).length > 0) {
+    lines.push('', '## Metadata', '')
+    for (const [key, value] of Object.entries(report.metadata)) {
+      lines.push(`- ${key}: \`${String(value)}\``)
+    }
+  }
+
+  if (report?.error) {
+    lines.push('', '## Error', '', `\`${report.error}\``)
+  }
+
+  lines.push('', '## Check Results', '')
+  for (const check of checks) {
+    const suffix = check.details?.skipped === true ? ' (skipped)' : ''
+    lines.push(`- \`${check.name}\`: **${check.ok ? 'PASS' : 'FAIL'}**${suffix}`)
+    if (check.details?.reason) {
+      lines.push(`  - reason: \`${check.details.reason}\``)
+    }
+    if (check.details?.status !== undefined) {
+      lines.push(`  - status: \`${check.details.status}\``)
+    }
+  }
+
+  lines.push(
+    '',
+    '## Manual Follow-up',
+    '',
+    '- XLSX import/export UI still needs browser verification.',
+    '- Formula editor, filter builder, Gantt, hierarchy, and visual conditional formatting still need browser verification.',
+    '- This smoke intentionally covers API-contract evidence only.',
+  )
+
+  return `${lines.join('\n')}\n`
+}
+
+function writeArtifacts(report) {
+  fs.mkdirSync(path.dirname(report.reportPath), { recursive: true })
+  fs.mkdirSync(path.dirname(report.reportMdPath), { recursive: true })
+  fs.writeFileSync(report.reportPath, `${JSON.stringify(report, null, 2)}\n`)
+  fs.writeFileSync(report.reportMdPath, renderRcApiSmokeMarkdown(report))
+}
+
+function createRecorder(report) {
+  return (name, ok, details = {}) => {
+    report.checks.push({ name, ok: Boolean(ok), details })
+  }
+}
+
+async function fetchJson(url, options = {}, timeoutMs = DEFAULT_TIMEOUT_MS) {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const res = await fetch(url, { ...options, signal: controller.signal })
+    const text = await res.text()
+    let json = null
+    if (text) {
+      try {
+        json = JSON.parse(text)
+      } catch {
+        json = { raw: text }
+      }
+    }
+    return { res, json }
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+function authHeaders(token, extra = {}) {
+  return {
+    Authorization: `Bearer ${token}`,
+    ...extra,
+  }
+}
+
+async function requestJson(config, token, route, options = {}) {
+  const url = `${config.apiBase}${route}`
+  return fetchJson(url, {
+    ...options,
+    headers: {
+      ...(token ? authHeaders(token) : {}),
+      ...(options.body ? { 'Content-Type': 'application/json' } : {}),
+      ...(options.headers ?? {}),
+    },
+  }, config.timeoutMs)
+}
+
+function body(input) {
+  return JSON.stringify(input)
+}
+
+function ensureOk(name, result) {
+  if (!result.res.ok || result.json?.ok === false) {
+    const code = result.json?.error?.code || result.json?.code || 'UNKNOWN'
+    const message = result.json?.error?.message || result.json?.message || result.res.statusText
+    throw new Error(`${name} failed (${result.res.status} ${code}): ${message}`)
+  }
+  return result.json
+}
+
+async function resolveToken(config, record) {
+  if (config.authToken) {
+    record('auth.token-present', true, { source: 'AUTH_TOKEN' })
+    return config.authToken
+  }
+  if (!config.allowDevToken) {
+    throw new Error('AUTH_TOKEN/TOKEN is required unless ALLOW_DEV_TOKEN=1')
+  }
+  return resolveMultitableAuthToken({
+    apiBase: config.apiBase,
+    envToken: '',
+    fetchJson: (url) => fetchJson(url, {}, config.timeoutMs),
+    record,
+    perms: 'multitable:read,multitable:write,multitable:admin',
+    userId: 'rc-api-smoke-admin',
+    roles: 'admin',
+  })
+}
+
+async function checkHealth(config, record) {
+  const attempts = ['/api/health', '/health']
+  let last = null
+  for (const route of attempts) {
+    const result = await fetchJson(`${config.apiBase}${route}`, {}, config.timeoutMs)
+    last = result
+    if (result.res.ok) {
+      record('api.health', true, {
+        route,
+        status: result.res.status,
+        ok: result.json?.ok ?? result.json?.status ?? null,
+        pluginsSummary: result.json?.pluginsSummary ? JSON.stringify(result.json.pluginsSummary) : undefined,
+        dbPool: result.json?.dbPool ? JSON.stringify(result.json.dbPool) : undefined,
+      })
+      return
+    }
+  }
+  record('api.health', false, { status: last?.res?.status ?? 0 })
+}
+
+async function checkAuth(config, token, record, report) {
+  const result = await requestJson(config, token, '/api/auth/me')
+  const json = ensureOk('auth.me', result)
+  const user = json?.user || json?.data?.user || json?.data || {}
+  report.metadata.userHash = sha(user?.id || user?.userId || 'unknown')
+  record('api.auth.me', true, { status: result.res.status, userHash: report.metadata.userHash })
+}
+
+async function probeIntegrationDescriptors(config, token, record) {
+  const result = await requestJson(config, token, '/api/integration/staging/descriptors')
+  if (!result.res.ok) {
+    record('api.integration-staging.descriptors', true, {
+      skipped: true,
+      status: result.res.status,
+      reason: 'integration staging plugin unavailable or disabled',
+    })
+    return
+  }
+  const descriptors = result.json?.data?.descriptors || result.json?.descriptors || []
+  record('api.integration-staging.descriptors', true, {
+    status: result.res.status,
+    count: Array.isArray(descriptors) ? descriptors.length : 0,
+  })
+}
+
+async function listTemplates(config, token, record) {
+  const result = await requestJson(config, token, '/api/multitable/templates')
+  const json = ensureOk('templates.list', result)
+  const templates = json?.data?.templates || []
+  const templateIds = Array.isArray(templates) ? templates.map((item) => item?.id).filter(Boolean) : []
+  record('api.templates.list', templateIds.includes(config.templateId), {
+    status: result.res.status,
+    templateIds: templateIds.join(','),
+  })
+  if (!templateIds.includes(config.templateId)) {
+    throw new Error(`Template not available: ${config.templateId}`)
+  }
+}
+
+async function installTemplate(config, token, record, report) {
+  const baseName = `RC API Smoke ${config.runId}`.slice(0, 255)
+  const result = await requestJson(config, token, `/api/multitable/templates/${encodeURIComponent(config.templateId)}/install`, {
+    method: 'POST',
+    body: body({ baseName }),
+  })
+  const json = ensureOk('templates.install', result)
+  const data = json?.data || {}
+  const sheet = Array.isArray(data.sheets) ? data.sheets[0] : null
+  if (!data.base?.id || !sheet?.id) {
+    throw new Error('Template install response missing base/sheet ids')
+  }
+  report.metadata.baseId = data.base.id
+  report.metadata.sheetId = sheet.id
+  report.metadata.templateId = data.template?.id || config.templateId
+  record('api.templates.install', true, {
+    status: result.res.status,
+    baseId: data.base.id,
+    sheetId: sheet.id,
+  })
+  return { baseId: data.base.id, sheetId: sheet.id }
+}
+
+async function resolveWorkingSheet(config, token, record, report) {
+  if (config.smokeSheetId) {
+    const result = await requestJson(config, token, `/api/multitable/context?sheetId=${encodeURIComponent(config.smokeSheetId)}`)
+    const json = ensureOk('context.sheet', result)
+    const sheet = json?.data?.sheet || null
+    if (!sheet?.id) throw new Error(`Unable to resolve SMOKE_SHEET_ID: ${config.smokeSheetId}`)
+    report.metadata.baseId = sheet.baseId || json?.data?.base?.id || ''
+    report.metadata.sheetId = sheet.id
+    record('api.context.smoke-sheet', true, { status: result.res.status, sheetId: sheet.id })
+    return { baseId: sheet.baseId || '', sheetId: sheet.id }
+  }
+  return installTemplate(config, token, record, report)
+}
+
+async function createSmokeFields(config, token, sheetId, record) {
+  const created = {}
+  for (const spec of FIELD_SPECS) {
+    const result = await requestJson(config, token, '/api/multitable/fields', {
+      method: 'POST',
+      body: body({
+        sheetId,
+        name: `RC ${spec.key} ${config.runId}`.slice(0, 255),
+        type: spec.type,
+        property: spec.property,
+      }),
+    })
+    const json = ensureOk(`fields.create.${spec.key}`, result)
+    const field = json?.data?.field
+    if (!field?.id || field.type !== spec.type) {
+      throw new Error(`Field create response invalid for ${spec.key}`)
+    }
+    created[spec.key] = field
+  }
+  record('api.fields.batch-types', true, {
+    count: Object.keys(created).length,
+    types: FIELD_SPECS.map((spec) => spec.type).join(','),
+  })
+  return created
+}
+
+async function createRecord(config, token, sheetId, fields, record) {
+  const data = {}
+  for (const spec of FIELD_SPECS) {
+    data[fields[spec.key].id] = spec.value
+  }
+  const result = await requestJson(config, token, '/api/multitable/records', {
+    method: 'POST',
+    body: body({ sheetId, data }),
+  })
+  const json = ensureOk('records.create', result)
+  const created = json?.data?.record
+  if (!created?.id || typeof created.version !== 'number') {
+    throw new Error('Record create response missing id/version')
+  }
+  record('api.records.create', true, { status: result.res.status, recordId: created.id, version: created.version })
+  return created
+}
+
+async function patchRecord(config, token, sheetId, fields, createdRecord, record) {
+  const result = await requestJson(config, token, '/api/multitable/patch', {
+    method: 'POST',
+    body: body({
+      sheetId,
+      changes: [{
+        recordId: createdRecord.id,
+        fieldId: fields.currency.id,
+        value: 234.56,
+        expectedVersion: createdRecord.version,
+      }],
+    }),
+  })
+  const json = ensureOk('records.patch', result)
+  const updated = json?.data?.updated || []
+  const ok = Array.isArray(updated) && updated.some((item) => item?.recordId === createdRecord.id)
+  record('api.records.patch.expected-version', ok, {
+    status: result.res.status,
+    updatedCount: Array.isArray(updated) ? updated.length : 0,
+  })
+  if (!ok) throw new Error('Patch response did not include created record')
+}
+
+async function createConditionalFormattingView(config, token, sheetId, fields, record) {
+  const result = await requestJson(config, token, '/api/multitable/views', {
+    method: 'POST',
+    body: body({
+      sheetId,
+      name: `RC conditional ${config.runId}`.slice(0, 255),
+      type: 'grid',
+      config: {
+        conditionalFormattingRules: [{
+          id: `rc-rule-${sha(config.runId)}`,
+          order: 0,
+          fieldId: fields.currency.id,
+          operator: 'gt',
+          value: 100,
+          style: { backgroundColor: '#fff4cc', textColor: '#7c2d12', applyToRow: false },
+        }],
+      },
+    }),
+  })
+  const json = ensureOk('views.conditional-formatting', result)
+  const rules = json?.data?.view?.config?.conditionalFormattingRules
+  const ok = Array.isArray(rules) && rules.length === 1 && rules[0]?.fieldId === fields.currency.id
+  record('api.views.conditional-formatting', ok, { status: result.res.status, ruleCount: Array.isArray(rules) ? rules.length : 0 })
+  if (!ok) throw new Error('Conditional formatting rule was not persisted')
+}
+
+async function runPublicFormSmoke(config, token, sheetId, fields, record) {
+  if (config.skipPublicForm) {
+    record('api.public-form.submit', true, { skipped: true, reason: 'SKIP_PUBLIC_FORM=1' })
+    return
+  }
+  const viewResult = await requestJson(config, token, '/api/multitable/views', {
+    method: 'POST',
+    body: body({
+      sheetId,
+      name: `RC public form ${config.runId}`.slice(0, 255),
+      type: 'form',
+      hiddenFieldIds: [],
+      config: {},
+    }),
+  })
+  const viewJson = ensureOk('views.form.create', viewResult)
+  const viewId = viewJson?.data?.view?.id
+  if (!viewId) throw new Error('Form view create response missing id')
+
+  const shareResult = await requestJson(config, token, `/api/multitable/sheets/${encodeURIComponent(sheetId)}/views/${encodeURIComponent(viewId)}/form-share`, {
+    method: 'PATCH',
+    body: body({ enabled: true, accessMode: 'public' }),
+  })
+  const shareJson = ensureOk('form-share.enable', shareResult)
+  const publicToken = shareJson?.data?.publicToken || shareJson?.data?.publicForm?.publicToken
+  if (!publicToken) throw new Error('Public form share did not return a public token')
+
+  const contextResult = await fetchJson(
+    `${config.apiBase}/api/multitable/form-context?viewId=${encodeURIComponent(viewId)}&publicToken=${encodeURIComponent(publicToken)}`,
+    {},
+    config.timeoutMs,
+  )
+  ensureOk('form-context.public', contextResult)
+
+  const submitResult = await fetchJson(
+    `${config.apiBase}/api/multitable/views/${encodeURIComponent(viewId)}/submit?publicToken=${encodeURIComponent(publicToken)}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: body({
+        data: {
+          [fields.email.id]: 'public-submit@example.com',
+          [fields.currency.id]: 88.8,
+          [fields.rating.id]: 5,
+        },
+      }),
+    },
+    config.timeoutMs,
+  )
+  const submitJson = ensureOk('public-form.submit', submitResult)
+  record('api.public-form.submit', true, {
+    status: submitResult.res.status,
+    recordId: submitJson?.data?.record?.id || submitJson?.data?.recordId || '',
+  })
+}
+
+async function cleanupCreatedSheet(config, token, sheetId, record) {
+  if (!config.cleanup) return
+  const result = await requestJson(config, token, `/api/multitable/sheets/${encodeURIComponent(sheetId)}`, {
+    method: 'DELETE',
+  })
+  if (result.res.ok) {
+    record('api.cleanup.sheet', true, { status: result.res.status, sheetId })
+  } else {
+    record('api.cleanup.sheet', true, {
+      skipped: true,
+      status: result.res.status,
+      reason: 'cleanup failed; smoke evidence was already collected',
+    })
+  }
+}
+
+export async function runRcApiSmoke(inputConfig = parseConfig()) {
+  const config = { ...inputConfig }
+  const report = {
+    ok: false,
+    apiBase: config.apiBase,
+    runId: config.runId,
+    expectedCommit: config.expectedCommit,
+    startedAt: new Date().toISOString(),
+    finishedAt: '',
+    reportPath: config.reportPath,
+    reportMdPath: config.reportMdPath,
+    checks: [],
+    metadata: {},
+  }
+  const record = createRecorder(report)
+
+  try {
+    const missing = validateConfig(config)
+    if (missing.length > 0) {
+      throw new Error(`Missing required config: ${missing.join(', ')}`)
+    }
+
+    await checkHealth(config, record)
+    const token = await resolveToken(config, record)
+    await checkAuth(config, token, record, report)
+    await probeIntegrationDescriptors(config, token, record)
+    await listTemplates(config, token, record)
+    const { sheetId } = await resolveWorkingSheet(config, token, record, report)
+    const fields = await createSmokeFields(config, token, sheetId, record)
+    const createdRecord = await createRecord(config, token, sheetId, fields, record)
+    await patchRecord(config, token, sheetId, fields, createdRecord, record)
+    await createConditionalFormattingView(config, token, sheetId, fields, record)
+    await runPublicFormSmoke(config, token, sheetId, fields, record)
+    await cleanupCreatedSheet(config, token, sheetId, record)
+
+    report.ok = report.checks.every((check) => check.ok !== false)
+  } catch (err) {
+    report.error = err instanceof Error ? err.message : String(err)
+    report.ok = false
+  } finally {
+    report.finishedAt = new Date().toISOString()
+    writeArtifacts(report)
+  }
+
+  if (!report.ok) {
+    throw new Error(`Multitable Feishu RC API smoke failed; see ${report.reportMdPath}`)
+  }
+  return report
+}
+
+async function main() {
+  await runRcApiSmoke(parseConfig())
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    console.error(err instanceof Error ? err.message : String(err))
+    process.exitCode = 1
+  })
+}

--- a/scripts/ops/multitable-feishu-rc-api-smoke.test.mjs
+++ b/scripts/ops/multitable-feishu-rc-api-smoke.test.mjs
@@ -1,0 +1,238 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import http from 'node:http'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+
+import {
+  parseConfig,
+  renderRcApiSmokeMarkdown,
+  runRcApiSmoke,
+  validateConfig,
+} from './multitable-feishu-rc-api-smoke.mjs'
+
+function readJson(req) {
+  return new Promise((resolve, reject) => {
+    let raw = ''
+    req.on('data', (chunk) => {
+      raw += chunk
+    })
+    req.on('end', () => {
+      if (!raw) {
+        resolve({})
+        return
+      }
+      try {
+        resolve(JSON.parse(raw))
+      } catch (err) {
+        reject(err)
+      }
+    })
+  })
+}
+
+function send(res, status, json) {
+  res.writeHead(status, { 'Content-Type': 'application/json' })
+  res.end(JSON.stringify(json))
+}
+
+async function startMockServer() {
+  const calls = []
+  let fieldCounter = 0
+  let viewCounter = 0
+  let recordCounter = 0
+  const fieldsByKey = {}
+
+  const server = http.createServer(async (req, res) => {
+    const url = new URL(req.url || '/', 'http://127.0.0.1')
+    calls.push(`${req.method} ${url.pathname}`)
+
+    if (url.pathname === '/api/health') {
+      send(res, 200, { ok: true, status: 'healthy', pluginsSummary: { total: 1 }, dbPool: { total: 1 } })
+      return
+    }
+    if (url.pathname === '/api/auth/me') {
+      send(res, 200, { ok: true, data: { user: { id: 'admin', roles: ['admin'] } } })
+      return
+    }
+    if (url.pathname === '/api/integration/staging/descriptors') {
+      send(res, 404, { ok: false, error: { code: 'NOT_FOUND', message: 'plugin disabled' } })
+      return
+    }
+    if (url.pathname === '/api/multitable/templates') {
+      send(res, 200, { ok: true, data: { templates: [{ id: 'project-tracker', name: 'Project Tracker' }] } })
+      return
+    }
+    if (url.pathname === '/api/multitable/templates/project-tracker/install') {
+      send(res, 201, {
+        ok: true,
+        data: {
+          template: { id: 'project-tracker' },
+          base: { id: 'base_mock' },
+          sheets: [{ id: 'sheet_mock', baseId: 'base_mock' }],
+          fields: [],
+          views: [],
+        },
+      })
+      return
+    }
+    if (url.pathname === '/api/multitable/fields') {
+      const payload = await readJson(req)
+      fieldCounter += 1
+      const id = `fld_${fieldCounter}_${payload.type}`
+      fieldsByKey[payload.type] = id
+      send(res, 201, {
+        ok: true,
+        data: {
+          field: {
+            id,
+            sheetId: payload.sheetId,
+            name: payload.name,
+            type: payload.type,
+            property: payload.property || {},
+          },
+        },
+      })
+      return
+    }
+    if (url.pathname === '/api/multitable/records') {
+      const payload = await readJson(req)
+      recordCounter += 1
+      send(res, 200, {
+        ok: true,
+        data: {
+          record: {
+            id: `rec_${recordCounter}`,
+            version: 1,
+            data: payload.data || {},
+          },
+        },
+      })
+      return
+    }
+    if (url.pathname === '/api/multitable/patch') {
+      const payload = await readJson(req)
+      send(res, 200, {
+        ok: true,
+        data: {
+          updated: (payload.changes || []).map((change) => ({
+            recordId: change.recordId,
+            version: 2,
+            patch: { [change.fieldId]: change.value },
+          })),
+        },
+      })
+      return
+    }
+    if (url.pathname === '/api/multitable/views') {
+      const payload = await readJson(req)
+      viewCounter += 1
+      send(res, 201, {
+        ok: true,
+        data: {
+          view: {
+            id: `view_${viewCounter}`,
+            sheetId: payload.sheetId,
+            name: payload.name,
+            type: payload.type || 'grid',
+            config: payload.config || {},
+          },
+        },
+      })
+      return
+    }
+    if (/^\/api\/multitable\/sheets\/[^/]+\/views\/[^/]+\/form-share$/.test(url.pathname)) {
+      send(res, 200, {
+        ok: true,
+        data: {
+          enabled: true,
+          accessMode: 'public',
+          publicToken: 'public-token-secret',
+        },
+      })
+      return
+    }
+    if (url.pathname === '/api/multitable/form-context') {
+      send(res, 200, { ok: true, data: { mode: 'form', fields: [] } })
+      return
+    }
+    if (/^\/api\/multitable\/views\/[^/]+\/submit$/.test(url.pathname)) {
+      send(res, 200, { ok: true, data: { record: { id: 'rec_public', version: 1 } } })
+      return
+    }
+
+    send(res, 404, { ok: false, error: { code: 'NOT_FOUND', message: url.pathname } })
+  })
+
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve))
+  const address = server.address()
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    calls,
+    close: () => new Promise((resolve) => server.close(resolve)),
+  }
+}
+
+test('validateConfig requires a real token/write confirmation and a writable target', () => {
+  const config = parseConfig({
+    API_BASE: 'https://staging.example.test/',
+  })
+  assert.deepEqual(validateConfig(config), [
+    'AUTH_TOKEN or TOKEN',
+    'CONFIRM_WRITE=1',
+    'SMOKE_SHEET_ID or ALLOW_INSTALL=1',
+  ])
+})
+
+test('renderRcApiSmokeMarkdown summarizes failures without leaking token values', () => {
+  const markdown = renderRcApiSmokeMarkdown({
+    ok: false,
+    apiBase: 'https://staging.example.test',
+    runId: 'rc-api-smoke-test',
+    startedAt: '2026-05-06T00:00:00.000Z',
+    finishedAt: '2026-05-06T00:00:01.000Z',
+    expectedCommit: 'abc123',
+    reportPath: '/tmp/report.json',
+    reportMdPath: '/tmp/report.md',
+    metadata: { userHash: 'hash-only' },
+    checks: [
+      { name: 'auth.token-present', ok: true, details: { tokenHash: 'secret-hash' } },
+      { name: 'api.records.patch.expected-version', ok: false, details: { status: 409 } },
+      { name: 'api.integration-staging.descriptors', ok: true, details: { skipped: true, reason: 'disabled' } },
+    ],
+  })
+
+  assert.match(markdown, /# Multitable Feishu RC API Smoke/)
+  assert.match(markdown, /Overall: \*\*FAIL\*\*/)
+  assert.match(markdown, /Failing checks: `api\.records\.patch\.expected-version`/)
+  assert.match(markdown, /Skipped checks: `api\.integration-staging\.descriptors`/)
+  assert.doesNotMatch(markdown, /Bearer/)
+  assert.doesNotMatch(markdown, /public-token-secret/)
+})
+
+test('runRcApiSmoke executes required API checks and writes JSON/Markdown artifacts', async () => {
+  const server = await startMockServer()
+  const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'multitable-feishu-rc-api-smoke-'))
+  try {
+    const report = await runRcApiSmoke(parseConfig({
+      API_BASE: server.baseUrl,
+      AUTH_TOKEN: 'test-token',
+      CONFIRM_WRITE: '1',
+      ALLOW_INSTALL: '1',
+      RUN_ID: 'rc-api-smoke-unit',
+      OUTPUT_DIR: outputDir,
+    }))
+
+    assert.equal(report.ok, true)
+    assert.equal(report.metadata.baseId, 'base_mock')
+    assert.equal(report.metadata.sheetId, 'sheet_mock')
+    assert.ok(report.checks.some((check) => check.name === 'api.fields.batch-types' && check.ok))
+    assert.ok(report.checks.some((check) => check.name === 'api.public-form.submit' && check.ok))
+    assert.ok(server.calls.includes('POST /api/multitable/templates/project-tracker/install'))
+    assert.ok(fs.existsSync(path.join(outputDir, 'report.json')))
+    assert.ok(fs.existsSync(path.join(outputDir, 'report.md')))
+  } finally {
+    await server.close()
+  }
+})


### PR DESCRIPTION
## Summary
- add a write-confirmed Node API smoke runner for the Multitable Feishu RC staging checklist
- cover health/auth/template install, batch field creation, record create/patch, conditional-formatting persistence, and public-form submit
- add design + verification MDs and link the helper from the staging checklist/TODO

## Safety
- requires API_BASE plus AUTH_TOKEN/TOKEN by default
- refuses to write without CONFIRM_WRITE=1
- requires SMOKE_SHEET_ID or ALLOW_INSTALL=1
- does not write bearer tokens or public form tokens to JSON/Markdown reports

## Verification
- pnpm verify:multitable-feishu-rc:api-smoke:test
- node --check scripts/ops/multitable-feishu-rc-api-smoke.mjs
- node --check scripts/ops/multitable-feishu-rc-api-smoke.test.mjs
- git diff --check

Real staging run was not performed in this branch because staging URL/token were not injected.