### PR TITLE
fix(integration): validate K3 GATE middle-table writes

### DIFF
--- a/apps/web/src/services/integration/k3WiseSetup.ts
+++ b/apps/web/src/services/integration/k3WiseSetup.ts
@@ -456,8 +456,8 @@ export function validateK3WiseGateDraftForm(form: K3WiseSetupForm): K3WiseSetupV
   if (form.bomEnabled && !trim(form.bomProductId) && !trim(form.plmDefaultProductId)) {
     issues.push({ field: 'bomProductId', message: 'BOM PoC requires BOM product ID or PLM default product ID' })
   }
-  if (form.sqlEnabled && form.sqlMode !== 'readonly' && splitList(form.sqlAllowedTables).some(isK3CoreBusinessTable)) {
-    issues.push({ field: 'sqlAllowedTables', message: 'Live PoC may not write K3 WISE core business tables' })
+  if (form.sqlEnabled && form.sqlMode !== 'readonly' && splitList(form.sqlMiddleTables).some(isK3CoreBusinessTable)) {
+    issues.push({ field: 'sqlMiddleTables', message: 'Live PoC may not write K3 WISE core business tables' })
   }
   return issues
 }

--- a/apps/web/tests/k3WiseSetup.spec.ts
+++ b/apps/web/tests/k3WiseSetup.spec.ts
@@ -535,6 +535,7 @@ describe('K3 WISE setup helpers', () => {
       sqlEnabled: true,
       sqlMode: 'middle-table',
       sqlAllowedTables: 'dbo.t_ICItem',
+      sqlMiddleTables: 'dbo.t_ICItem',
       rollbackOwner: 'customer-k3-admin',
       bomEnabled: true,
       bomProductId: '',
@@ -556,6 +557,58 @@ describe('K3 WISE setup helpers', () => {
       'Live PoC GATE environment must be test, uat, or staging',
     )
     expect(() => buildK3WiseGateDraft(form)).toThrow('Live PoC GATE environment must be test, uat, or staging')
+  })
+
+  it('allows live PoC GATE drafts to read K3 core tables when writes target middle tables', () => {
+    const form = createDefaultK3WiseSetupForm()
+    Object.assign(form, {
+      tenantId: 'tenant_1',
+      workspaceId: 'workspace_1',
+      operator: 'integration-admin',
+      version: 'K3 WISE 15.x test',
+      environment: 'uat',
+      baseUrl: 'https://k3.example.test/K3API/',
+      acctId: 'AIS_TEST',
+      sqlEnabled: true,
+      sqlMode: 'middle-table',
+      sqlAllowedTables: 'dbo.t_ICItem\ndbo.t_ICBOM\ndbo.t_ICBomChild',
+      sqlMiddleTables: 'dbo.integration_material_stage\ndbo.integration_bom_stage',
+      rollbackOwner: 'customer-k3-admin',
+      rollbackStrategy: 'delete-test-records',
+      bomEnabled: true,
+      bomProductId: 'BOM-PRODUCT-001',
+    })
+
+    expect(validateK3WiseGateDraftForm(form)).toEqual([])
+    const draft = buildK3WiseGateDraft(form) as { sqlServer?: { allowedTables?: string[]; middleTables?: string[] } }
+    expect(draft.sqlServer?.allowedTables).toEqual(['dbo.t_ICItem', 'dbo.t_ICBOM', 'dbo.t_ICBomChild'])
+    expect(draft.sqlServer?.middleTables).toEqual(['dbo.integration_material_stage', 'dbo.integration_bom_stage'])
+  })
+
+  it('blocks live PoC GATE drafts when middle-table writes target K3 core business tables', () => {
+    const form = createDefaultK3WiseSetupForm()
+    Object.assign(form, {
+      tenantId: 'tenant_1',
+      workspaceId: 'workspace_1',
+      operator: 'integration-admin',
+      version: 'K3 WISE 15.x test',
+      environment: 'uat',
+      baseUrl: 'https://k3.example.test/K3API/',
+      acctId: 'AIS_TEST',
+      sqlEnabled: true,
+      sqlMode: 'middle-table',
+      sqlAllowedTables: 'dbo.t_ICItem',
+      sqlMiddleTables: 'dbo.t_ICBomChild',
+      rollbackOwner: 'customer-k3-admin',
+      rollbackStrategy: 'delete-test-records',
+      bomEnabled: true,
+      bomProductId: 'BOM-PRODUCT-001',
+    })
+
+    expect(validateK3WiseGateDraftForm(form)).toEqual([
+      { field: 'sqlMiddleTables', message: 'Live PoC may not write K3 WISE core business tables' },
+    ])
+    expect(() => buildK3WiseGateDraft(form)).toThrow('Live PoC may not write K3 WISE core business tables')
   })
 
   it('imports customer GATE JSON public fields without credential secrets', () => {

--- a/docs/development/k3wise-gate-middle-table-validation-development-20260506.md
+++ b/docs/development/k3wise-gate-middle-table-validation-development-20260506.md
@@ -1,0 +1,49 @@
+# K3 WISE GATE Middle-Table Validation - Development
+
+Date: 2026-05-06
+Branch: `codex/k3wise-gate-middle-table-validation-20260506`
+Stacked on: `codex/erp-plm-config-workbench-20260505` / PR #1305
+
+## Goal
+
+Let the K3 WISE GATE workbench generate valid customer PoC packets for the intended middle-table pattern: read K3 WISE core tables, write only integration middle tables.
+
+## Problem
+
+`validateK3WiseGateDraftForm()` blocked core K3 WISE table names from `sqlAllowedTables` whenever SQL mode was not `readonly`.
+
+That field is the read whitelist and defaults to K3 WISE core tables such as:
+
+- `t_ICItem`
+- `t_ICBOM`
+- `t_ICBomChild`
+
+The write side is represented by `sqlMiddleTables`, which is serialized into `sqlServer.middleTables` and `writeTables`. The previous validation therefore rejected a safe and expected configuration:
+
+- read `t_ICItem` / `t_ICBOM` / `t_ICBomChild`;
+- write `integration_material_stage` / `integration_bom_stage`.
+
+In the UI this would disable copy/download for the GATE JSON draft even though the packet was safe.
+
+## Implementation
+
+Files changed:
+
+- `apps/web/src/services/integration/k3WiseSetup.ts`
+- `apps/web/tests/k3WiseSetup.spec.ts`
+
+Changes:
+
+- Moved the "may not write K3 WISE core business tables" check from `sqlAllowedTables` to `sqlMiddleTables`.
+- Kept the safety intent intact: core K3 WISE tables are still forbidden as write targets.
+- Added regression coverage for:
+  - safe read-core/write-middle-table GATE drafts;
+  - unsafe middle-table writes targeting `t_ICBomChild`.
+
+## Safety
+
+This is a validation-scope correction only. It does not change the generated K3 WebAPI payload, SQL Server external system payload shape, credentials handling, or runtime adapter behavior.
+
+## Residual Risk
+
+This branch is stacked on the still-open PR #1305. It should be merged after #1305 or retargeted if #1305 is rewritten.

--- a/docs/development/k3wise-gate-middle-table-validation-verification-20260506.md
+++ b/docs/development/k3wise-gate-middle-table-validation-verification-20260506.md
@@ -1,0 +1,69 @@
+# K3 WISE GATE Middle-Table Validation - Verification
+
+Date: 2026-05-06
+Branch: `codex/k3wise-gate-middle-table-validation-20260506`
+Stacked on: `codex/erp-plm-config-workbench-20260505` / PR #1305
+
+## Verification Plan
+
+Run the focused K3 WISE setup helper and view tests, then run the frontend build and whitespace checks:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/k3WiseSetup.spec.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/k3WiseSetupView.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+## Expected Coverage
+
+- Existing K3 WISE setup helper tests remain green.
+- GATE drafts can read K3 WISE core tables while writing safe middle tables.
+- GATE drafts still fail when middle-table writes target K3 WISE core business tables.
+- Existing GATE copy/download view tests remain green.
+- Frontend build succeeds.
+- Whitespace check passes.
+
+## Results
+
+### Setup Helper Tests
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/k3WiseSetup.spec.ts --watch=false
+```
+
+Result: passed, 28/28 tests.
+
+### Setup View Tests
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/k3WiseSetupView.spec.ts --watch=false
+```
+
+Result: passed, 3/3 tests.
+
+Note: the test process printed `WebSocket server error: Port is already in use`, but exited 0 and all assertions passed. This is an environment warning from the test server port, not a failed assertion.
+
+### Frontend Build
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result: passed. Vite reported existing chunk-size warnings and a workflow designer dynamic/static import warning; the build exited 0.
+
+### Diff Check
+
+Command:
+
+```bash
+git diff --check
+```
+
+Result: passed.


### PR DESCRIPTION
## Summary
- Correct K3 WISE GATE validation so `sqlAllowedTables` remains a read whitelist.
- Move the core-business-table write guard to `sqlMiddleTables`, which is the write-side middle-table target list.
- Add regression coverage for the intended safe pattern: read `t_ICItem` / `t_ICBOM` / `t_ICBomChild`, write only integration middle tables.
- Keep the safety guard for unsafe middle-table writes targeting K3 core business tables.
- Add development and verification notes under `docs/development/`.

## Verification
- `pnpm --filter @metasheet/web exec vitest run tests/k3WiseSetup.spec.ts --watch=false`
- `pnpm --filter @metasheet/web exec vitest run tests/k3WiseSetupView.spec.ts --watch=false`
- `pnpm --filter @metasheet/web build`
- `git diff --check`
- `git diff --cached --check`

## Notes
- Stacked on #1305 (`codex/erp-plm-config-workbench-20260505`) because the GATE readiness UI is still open.
- Validation-scope correction only; no runtime adapter or credential behavior change.