### PR TITLE
fix(integration): reject secret-bearing K3 smoke base URLs

### DIFF
--- a/docs/development/k3wise-postdeploy-url-secret-guard-development-20260507.md
+++ b/docs/development/k3wise-postdeploy-url-secret-guard-development-20260507.md
@@ -1,0 +1,30 @@
+# K3 WISE Postdeploy URL Secret Guard Development - 2026-05-07
+
+## Context
+
+`integration-k3wise-postdeploy-smoke.mjs` writes the tested base URL into stdout, JSON evidence, Markdown evidence, and GitHub summary output. The smoke script already avoids printing bearer tokens, but an operator could still paste a base URL that contains username/password material, query parameters such as `access_token`, or a fragment.
+
+That would make otherwise safe postdeploy evidence carry URL-secret material.
+
+## Design
+
+- Reject `--base-url` values that contain username or password material.
+- Reject `--base-url` values that contain query parameters.
+- Reject `--base-url` values that contain a fragment.
+- Keep error details actionable by returning the field name and query keys, not query values.
+- Redact legacy evidence display in `integration-k3wise-postdeploy-summary.mjs` so old JSON with unsafe `baseUrl` does not leak into GitHub summaries.
+
+## Files Changed
+
+- `scripts/ops/integration-k3wise-postdeploy-smoke.mjs`
+- `scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs`
+- `scripts/ops/integration-k3wise-postdeploy-summary.mjs`
+- `scripts/ops/integration-k3wise-postdeploy-summary.test.mjs`
+
+## Behavior
+
+- Clean `http://` and `https://` base URLs still work.
+- Base URLs with credentials fail before any request is made.
+- Base URLs with query strings fail before any request is made.
+- Summary rendering strips credentials and redacts query/fragment display for old evidence files.
+

--- a/docs/development/k3wise-postdeploy-url-secret-guard-verification-20260507.md
+++ b/docs/development/k3wise-postdeploy-url-secret-guard-verification-20260507.md
@@ -1,0 +1,26 @@
+# K3 WISE Postdeploy URL Secret Guard Verification - 2026-05-07
+
+## Commands
+
+```bash
+node --check scripts/ops/integration-k3wise-postdeploy-smoke.mjs
+node --check scripts/ops/integration-k3wise-postdeploy-summary.mjs
+node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
+git diff --check
+```
+
+## Result
+
+- Postdeploy smoke + summary tests: 24/24 passed.
+- `git diff --check`: passed.
+
+## Coverage Added
+
+- Reject base URLs with username/password material without echoing those values.
+- Reject base URLs with query strings without echoing query values.
+- Redact unsafe base URL material when rendering existing smoke evidence into summaries.
+
+## Residual Risk
+
+The smoke script now rejects all query parameters, including non-secret query parameters. That is intentional for this operator-facing deployment probe: the base URL should identify the app origin only, and API paths add their own query strings.
+

--- a/scripts/ops/integration-k3wise-postdeploy-smoke.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-smoke.mjs
@@ -219,10 +219,26 @@ function normalizeBaseUrl(value) {
   try {
     url = new URL(value)
   } catch {
-    throw new K3WisePostdeploySmokeError('--base-url must be a valid URL', { baseUrl: value })
+    throw new K3WisePostdeploySmokeError('--base-url must be a valid URL', { field: '--base-url' })
   }
   if (url.protocol !== 'http:' && url.protocol !== 'https:') {
-    throw new K3WisePostdeploySmokeError('--base-url must use http or https', { baseUrl: value })
+    throw new K3WisePostdeploySmokeError('--base-url must use http or https', { field: '--base-url' })
+  }
+  if (url.username || url.password) {
+    throw new K3WisePostdeploySmokeError('--base-url must not include username or password material', {
+      field: '--base-url',
+    })
+  }
+  if (url.search) {
+    throw new K3WisePostdeploySmokeError('--base-url must not include query parameters', {
+      field: '--base-url',
+      queryKeys: Array.from(url.searchParams.keys()).slice(0, 20),
+    })
+  }
+  if (url.hash) {
+    throw new K3WisePostdeploySmokeError('--base-url must not include a fragment', {
+      field: '--base-url',
+    })
   }
   return url.toString().replace(/\/+$/, '')
 }

--- a/scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
@@ -403,6 +403,43 @@ test('authenticated postdeploy smoke validates route and staging contracts witho
   }
 })
 
+test('postdeploy smoke rejects base URLs with credential or query material without leaking values', async () => {
+  const outDir = makeTmpDir()
+  try {
+    const result = await runScript([
+      '--base-url', 'https://operator:base-url-password@example.test?access_token=base-url-token',
+      '--out-dir', outDir,
+    ])
+
+    assert.equal(result.status, 1)
+    assert.equal(result.stdout, '')
+    assert.match(result.stderr, /--base-url must not include username or password material/)
+    assert.equal(result.stderr.includes('base-url-password'), false)
+    assert.equal(result.stderr.includes('base-url-token'), false)
+    assert.equal(result.stderr.includes('operator'), false)
+  } finally {
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('postdeploy smoke rejects base URL query strings without leaking query values', async () => {
+  const outDir = makeTmpDir()
+  try {
+    const result = await runScript([
+      '--base-url', 'https://example.test/app?access_token=base-url-token',
+      '--out-dir', outDir,
+    ])
+
+    assert.equal(result.status, 1)
+    assert.equal(result.stdout, '')
+    assert.match(result.stderr, /--base-url must not include query parameters/)
+    assert.match(result.stderr, /access_token/)
+    assert.equal(result.stderr.includes('base-url-token'), false)
+  } finally {
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
 test('authenticated postdeploy smoke uses explicit tenant scope for control-plane list probes', async () => {
   const fake = createFakeServer()
   const baseUrl = await fake.listen()

--- a/scripts/ops/integration-k3wise-postdeploy-summary.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-summary.mjs
@@ -11,6 +11,26 @@ class K3WisePostdeploySummaryError extends Error {
   }
 }
 
+const TOKEN_PATTERN = /([A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{16,}|Bearer\s+[A-Za-z0-9._-]{16,})/g
+
+function redactText(value) {
+  return String(value).replace(TOKEN_PATTERN, '<redacted-token>')
+}
+
+function redactBaseUrlForDisplay(value) {
+  const text = String(value || '').trim()
+  if (!text) return 'unknown'
+  try {
+    const parsed = new URL(text)
+    let display = `${parsed.protocol}//${parsed.host}${parsed.pathname}`
+    if (parsed.search) display += '?<redacted-query>'
+    if (parsed.hash) display += '#<redacted-fragment>'
+    return redactText(display)
+  } catch {
+    return redactText(text)
+  }
+}
+
 function printHelp() {
   console.log(`Usage: node scripts/ops/integration-k3wise-postdeploy-summary.mjs --input <path> [options]
 
@@ -147,7 +167,7 @@ function renderEvidenceSummary(evidence, options = {}) {
   const lines = [
     ...renderSignoffLines(evidence, options),
     `- Status: **${status}**`,
-    `- Base URL: \`${evidence?.baseUrl || 'unknown'}\``,
+    `- Base URL: \`${redactBaseUrlForDisplay(evidence?.baseUrl)}\``,
     `- Authenticated checks: \`${evidence?.authenticated ? 'yes' : 'no'}\``,
     `- Summary: \`${Number(summary.pass || 0)} pass / ${Number(summary.skipped || 0)} skipped / ${Number(summary.fail || 0)} fail\``,
     '- Checks:',
@@ -215,6 +235,7 @@ export {
   formatDetailValue,
   inferInternalTrialSignoff,
   parseArgs,
+  redactBaseUrlForDisplay,
   renderEvidenceSummary,
   renderMissingSummary,
   renderSignoffLines,

--- a/scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
@@ -129,6 +129,33 @@ test('renders passing internal signoff for authenticated smoke evidence', async 
   }
 })
 
+test('redacts credential and query material from evidence base URL summary output', async () => {
+  const outDir = makeTmpDir()
+  const evidencePath = path.join(outDir, 'evidence.json')
+  try {
+    writeFileSync(evidencePath, `${JSON.stringify({
+      ok: true,
+      baseUrl: 'https://operator:base-url-password@example.test/app?access_token=base-url-token#frag-secret',
+      authenticated: true,
+      summary: { pass: 1, skipped: 0, fail: 0 },
+      checks: [
+        { id: 'api-health', status: 'pass' },
+      ],
+    })}\n`)
+
+    const result = await runScript(['--input', evidencePath])
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stdout, /Base URL: `https:\/\/example\.test\/app\?<redacted-query>#<redacted-fragment>`/)
+    assert.equal(result.stdout.includes('operator'), false)
+    assert.equal(result.stdout.includes('base-url-password'), false)
+    assert.equal(result.stdout.includes('base-url-token'), false)
+    assert.equal(result.stdout.includes('frag-secret'), false)
+  } finally {
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
 test('renders fail summary without failing the summary renderer', async () => {
   const outDir = makeTmpDir()
   const evidencePath = path.join(outDir, 'evidence.json')


### PR DESCRIPTION
## Summary
- reject K3 postdeploy smoke base URLs containing username/password, query strings, or fragments
- avoid echoing unsafe base URL material in parse errors
- redact unsafe base URL material when rendering legacy smoke evidence summaries
- add development and verification notes

## Verification
- node --check scripts/ops/integration-k3wise-postdeploy-smoke.mjs
- node --check scripts/ops/integration-k3wise-postdeploy-summary.mjs
- node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
- git diff --check

## Docs
- docs/development/k3wise-postdeploy-url-secret-guard-development-20260507.md
- docs/development/k3wise-postdeploy-url-secret-guard-verification-20260507.md