### PR TITLE
test(multitable): add xlsx UI smoke coverage

### DIFF
--- a/docs/development/multitable-feishu-rc-todo-20260430.md
+++ b/docs/development/multitable-feishu-rc-todo-20260430.md
@@ -78,7 +78,12 @@ Do not mark an item done if:
   - Verification MD: `docs/development/multitable-feishu-rc-142-postdeploy-verification-20260506.md`
   - Verification summary: GitHub Actions run `25435548148` deployed `9464b628479cdff1769c864de05f5ec5b6bf7d94` to 142 after rerunning a transient GHCR `unknown blob` failure; postdeploy health/API probes passed.
 - [ ] Smoke test basic multitable sheet lifecycle: create base, sheet, view, fields, records.
-- [ ] Smoke test xlsx frontend import/export with a real file.
+- [x] Smoke test xlsx frontend import/export with a real file.
+  - PR: pending
+  - Merge commit: pending
+  - Development MD: `docs/development/multitable-feishu-rc-xlsx-ui-smoke-design-20260506.md`
+  - Verification MD: `docs/development/multitable-feishu-rc-xlsx-ui-smoke-verification-20260506.md`
+  - Verification summary: `AUTH_TOKEN=... API_BASE=http://142.171.239.56:8081 WEB_BASE=http://142.171.239.56:8081 pnpm verify:multitable-pilot:staging` passed `130/130` checks; new `ui.xlsx.import-file` and `ui.xlsx.export-download` checks passed with a real `.xlsx` file and parsed download.
 - [ ] Smoke test field types: currency, percent, rating, url, email, phone, longText, multiSelect.
 - [ ] Smoke test conditional formatting persistence and reload.
 - [ ] Smoke test formula editor: field token insertion, function insertion, diagnostics.

--- a/docs/development/multitable-feishu-rc-xlsx-ui-smoke-design-20260506.md
+++ b/docs/development/multitable-feishu-rc-xlsx-ui-smoke-design-20260506.md
@@ -1,0 +1,56 @@
+# Multitable Feishu RC XLSX UI Smoke Design - 2026-05-06
+
+## Scope
+
+This slice turns the remaining Phase 1 XLSX frontend smoke item into executable evidence inside the existing multitable pilot Playwright runner.
+
+Target TODO item:
+
+- `Smoke test xlsx frontend import/export with a real file.`
+
+The change is runner-only. It does not change production frontend or backend behavior.
+
+## Design
+
+The existing `scripts/verify-multitable-live-smoke.mjs` already exercises CSV import, mapping reconciliation, retry, attachment upload, comments, view replay, and cleanup. This slice extends that runner with a real XLSX round trip:
+
+1. Generate a real `pilot-import.xlsx` fixture under the run output directory.
+2. Open the existing grid view and click `Import records`.
+3. Select the `.xlsx` file through the real file input.
+4. Wait for the XLSX-specific behavior: the UI parses the file and moves directly to the mapping preview step.
+5. Explicitly map the first column to the pilot title field.
+6. Import one record.
+7. Verify API/search hydration for the imported row.
+8. Click the real `Export Excel` toolbar button.
+9. Capture the Playwright download.
+10. Parse the downloaded `.xlsx` and assert that it contains both the `Title` header and the imported row title.
+
+## Implementation Notes
+
+The runner resolves `xlsx` from workspace package paths using `createRequire(...).resolve(...)` because `xlsx` is a workspace package dependency rather than a root package dependency in all execution contexts.
+
+The runner records two new checks:
+
+- `ui.xlsx.import-file`
+- `ui.xlsx.export-download`
+
+It also records `xlsxImportRecordId` in report metadata and adds the imported record to the existing best-effort cleanup map before later smoke steps continue.
+
+## Rejected Approach
+
+The first implementation tried to click the `Preview` button after selecting the XLSX file, mirroring the CSV/TSV flow. That was wrong for current UI semantics: XLSX selection is parsed asynchronously and moves directly into the preview/mapping step. The final runner waits for `1 record(s) detected. Map columns to fields:` instead.
+
+## Non-Goals
+
+This slice does not close the remaining Phase 1 manual items:
+
+- broad field type UI smoke
+- conditional formatting reload
+- formula editor
+- filter builder
+- Gantt view
+- Hierarchy view
+- public form submit
+- automation `send_email`
+
+Those should remain separate slices to keep failure signals isolated.

--- a/docs/development/multitable-feishu-rc-xlsx-ui-smoke-verification-20260506.md
+++ b/docs/development/multitable-feishu-rc-xlsx-ui-smoke-verification-20260506.md
@@ -1,0 +1,86 @@
+# Multitable Feishu RC XLSX UI Smoke Verification - 2026-05-06
+
+## Summary
+
+Result: PASS.
+
+The existing Playwright staging smoke now covers a real XLSX UI import/export round trip. The final 142 run passed `130/130` checks with no failures.
+
+## Local Gates
+
+Commands:
+
+```bash
+node --check scripts/verify-multitable-live-smoke.mjs
+node --test scripts/verify-multitable-live-smoke.test.mjs scripts/ops/multitable-pilot-staging.test.mjs
+```
+
+Result:
+
+- `node --check`: pass
+- `node --test`: 2/2 pass
+
+## 142 Staging Verification
+
+Command:
+
+```bash
+AUTH_TOKEN="$(cat /tmp/metasheet-142-main-admin-72h.jwt)" \
+API_BASE="http://142.171.239.56:8081" \
+WEB_BASE="http://142.171.239.56:8081" \
+OUTPUT_ROOT="output/playwright/multitable-feishu-rc-142-xlsx-ui-smoke/$(date +%Y%m%d-%H%M%S)" \
+HEADLESS=true \
+ENSURE_PLAYWRIGHT=false \
+TIMEOUT_MS=45000 \
+pnpm verify:multitable-pilot:staging
+```
+
+The token value was not printed or committed.
+
+Final report:
+
+- Directory: `/private/tmp/ms2-rc-smoke-next-20260506/output/playwright/multitable-feishu-rc-142-xlsx-ui-smoke/20260506-171537`
+- JSON: `report.json`
+- Markdown: `report.md`
+- Overall: PASS
+- Total checks: `130`
+- Failing checks: none
+- Started: `2026-05-07T00:15:37.951Z`
+- Finished: `2026-05-07T00:17:10.107Z`
+
+XLSX checks:
+
+| Check | Result | Evidence |
+| --- | --- | --- |
+| `ui.xlsx.import-file` | PASS | Imported row `PilotFlow-1778112942622 xlsx import` hydrated via API/search as `rec_bb60e88a-7f40-4509-90dd-e4e6b931c807`. |
+| `ui.xlsx.export-download` | PASS | Downloaded `sheet_multitable_pilot_smoke.xlsx`, size `20373` bytes, parsed `2` rows, contained the imported title. |
+
+## Runner Fixes During Verification
+
+Two runner issues were found and fixed before the final pass:
+
+- The runner initially clicked `Preview` immediately after `setInputFiles(...)`; XLSX file reading is asynchronous, so the button could still be disabled.
+- After adding an enabled wait, the runner still timed out because XLSX files do not use the CSV Preview flow. Current UI semantics parse XLSX and navigate directly to preview/mapping. The final runner waits for the mapping preview text instead.
+
+## Artifact Policy
+
+The generated XLSX input, downloaded XLSX output, screenshots, and runner reports remain local artifacts under `output/playwright/...`. They are intentionally not committed.
+
+Committed evidence is limited to:
+
+- runner code
+- this design/verification pair
+- the RC TODO update
+
+## Remaining Manual Coverage
+
+This closes the XLSX UI import/export smoke item only. Remaining Phase 1 manual/executable coverage:
+
+- field types: currency, percent, rating, url, email, phone, longText, multiSelect
+- conditional formatting persistence and reload
+- formula editor
+- filter builder
+- Gantt view
+- Hierarchy view
+- public form submit
+- automation `send_email`

--- a/scripts/verify-multitable-live-smoke.mjs
+++ b/scripts/verify-multitable-live-smoke.mjs
@@ -1,9 +1,11 @@
 import fs from 'fs'
 import path from 'path'
-import { fileURLToPath } from 'url'
+import { createRequire } from 'module'
+import { fileURLToPath, pathToFileURL } from 'url'
 import { chromium } from '@playwright/test'
 import { resolveMultitableAuthToken } from './multitable-auth.mjs'
 
+const require = createRequire(import.meta.url)
 const apiBase = process.env.API_BASE || 'http://127.0.0.1:7778'
 const webBase = process.env.WEB_BASE || 'http://127.0.0.1:8899'
 const outputDir = process.env.OUTPUT_DIR || 'output/playwright/multitable-live-smoke'
@@ -50,6 +52,17 @@ function formFieldByLabel(page, fieldName) {
 
 function recordCommentsButton(page) {
   return page.locator('.meta-record-drawer__btn--comment[title="Comments"]').first()
+}
+
+async function importXlsxModule() {
+  const resolved = require.resolve('xlsx', {
+    paths: [
+      path.resolve('apps/web'),
+      path.resolve('packages/core-backend'),
+      process.cwd(),
+    ],
+  })
+  return import(pathToFileURL(resolved).href)
 }
 
 async function addAndResolveRecordComment(page) {
@@ -1588,6 +1601,116 @@ async function importRecordViaGrid(page, { baseId, sheetId, viewId, csvPath, sea
   record('ui.grid.import', true, { searchValue })
 }
 
+async function loadXlsxApi() {
+  const mod = await importXlsxModule()
+  return mod.default?.utils ? mod.default : mod
+}
+
+async function writeXlsxFixture(filePath, { sheetName, headers, rows }) {
+  const xlsx = await loadXlsxApi()
+  const worksheet = xlsx.utils.aoa_to_sheet([headers, ...rows])
+  const workbook = xlsx.utils.book_new()
+  xlsx.utils.book_append_sheet(workbook, worksheet, sheetName)
+  xlsx.writeFile(workbook, filePath)
+}
+
+async function readXlsxRows(filePath) {
+  const xlsx = await loadXlsxApi()
+  const workbook = xlsx.readFile(filePath)
+  const sheetName = workbook.SheetNames[0]
+  if (!sheetName) return []
+  return xlsx.utils.sheet_to_json(workbook.Sheets[sheetName], {
+    header: 1,
+    raw: false,
+    defval: '',
+    blankrows: false,
+  })
+}
+
+async function verifyXlsxImportExport(page, {
+  token,
+  baseId,
+  sheetId,
+  viewId,
+  titleFieldId,
+  importedRowTitle,
+  onImportedRecord,
+}) {
+  const xlsxPath = path.join(outputDir, 'pilot-import.xlsx')
+  await writeXlsxFixture(xlsxPath, {
+    sheetName: 'Import',
+    headers: ['Title'],
+    rows: [[importedRowTitle]],
+  })
+
+  await page.goto(multitableUrl(baseId, sheetId, viewId), { waitUntil: 'domcontentloaded', timeout: timeoutMs })
+  await page.getByRole('searchbox', { name: 'Search records' }).waitFor({ state: 'visible', timeout: timeoutMs })
+  await page.getByRole('button', { name: 'Import records' }).click()
+  await page.getByText('Import Records').waitFor({ state: 'visible', timeout: timeoutMs })
+  await page.locator('input.meta-import__file-input[type="file"]').setInputFiles(xlsxPath)
+  await page.getByText('1 record(s) detected. Map columns to fields:').waitFor({ state: 'visible', timeout: timeoutMs })
+  await ensureImportFieldMappedByColumnIndex(page, {
+    columnIndex: 0,
+    fieldId: titleFieldId,
+    label: 'xlsx import title mapping',
+  })
+  const importButton = page.getByRole('button', { name: /Import 1 record\(s\)/ })
+  await waitForActionButtonEnabled(importButton, 'xlsx import button enable')
+  await importButton.click()
+  await page.getByText('1 record(s) imported').waitFor({ state: 'visible', timeout: timeoutMs })
+
+  await waitForImportedGridRow(page, {
+    token,
+    baseId,
+    sheetId,
+    viewId,
+    searchValue: importedRowTitle,
+    label: 'xlsx file import',
+  })
+  const imported = await findRecordBySearch(token, sheetId, viewId, importedRowTitle)
+  const importOk = !!imported.row?.id
+  record('ui.xlsx.import-file', importOk, {
+    baseId,
+    sheetId,
+    viewId,
+    recordId: imported.row?.id ?? null,
+    title: importedRowTitle,
+  })
+  if (!importOk) {
+    throw new Error('XLSX import did not hydrate the imported row')
+  }
+  if (typeof onImportedRecord === 'function') {
+    onImportedRecord(imported.row)
+  }
+
+  const exportPromise = page.waitForEvent('download', { timeout: timeoutMs })
+  await page.getByRole('button', { name: 'Export Excel' }).click()
+  const download = await exportPromise
+  const suggestedFilename = download.suggestedFilename()
+  const exportPath = path.join(outputDir, `pilot-export-${Date.now()}.xlsx`)
+  await download.saveAs(exportPath)
+  const stats = fs.statSync(exportPath)
+  const rows = await readXlsxRows(exportPath)
+  const flattened = rows.flat().map((value) => String(value))
+  const exportOk = suggestedFilename.endsWith('.xlsx') &&
+    stats.size > 0 &&
+    flattened.includes('Title') &&
+    flattened.includes(importedRowTitle)
+  record('ui.xlsx.export-download', exportOk, {
+    suggestedFilename,
+    bytes: stats.size,
+    title: importedRowTitle,
+    rowCount: rows.length,
+    exportPath,
+  })
+  if (!exportOk) {
+    throw new Error('XLSX export did not include the imported row')
+  }
+
+  await page.screenshot({ path: path.join(outputDir, 'grid-xlsx-import-export.png'), fullPage: true })
+  return imported.row
+}
+
 async function importRecordsViaGridWithRetry(page, {
   baseId,
   sheetId,
@@ -3090,6 +3213,7 @@ async function run() {
     const retryTitle = `${titlePrefix} retry`
     const peopleRepairReconcileTitle = `${titlePrefix} people repair reconcile`
     const manualFixTitle = `${titlePrefix} manual fix`
+    const xlsxImportTitle = `${titlePrefix} xlsx import`
     const viewSubmitTitle = `${titlePrefix} view submit`
     const importDriftField = await createField(token, {
       id: `fld_pilot_import_drift_${Date.now()}`,
@@ -3210,6 +3334,10 @@ async function run() {
       cleanupRecords.set(retried.row.id, retried.row.version)
       cleanupRecords.set(peopleRepairReconcile.row.id, peopleRepairReconcile.row.version)
       cleanupRecords.set(manualFixed.row.id, manualFixed.row.version)
+      const recordId = imported.row.id
+      const trackRecord = (record) => {
+        if (record?.id) cleanupRecords.set(record.id, record.version)
+      }
       const manualFixRecord = await fetchRecord(token, sheet.id, manualFixed.row.id)
       const manualFixPeople = manualFixRecord.linkSummaries?.[personField.id] ?? []
       const manualFixOk = manualFixPeople.some((item) => item.id === personChoice.id)
@@ -3221,10 +3349,16 @@ async function run() {
       if (!manualFixOk) {
         throw new Error('Manual-fix people import did not persist selected person link')
       }
-      let recordId = imported.row.id
-      const trackRecord = (record) => {
-        if (record?.id) cleanupRecords.set(record.id, record.version)
-      }
+
+      const xlsxImported = await verifyXlsxImportExport(page, {
+        token,
+        baseId: base.id,
+        sheetId: sheet.id,
+        viewId: gridView.id,
+        titleFieldId: titleField.id,
+        importedRowTitle: xlsxImportTitle,
+        onImportedRecord: trackRecord,
+      })
 
       await assignPersonViaDrawer(page, {
         searchValue: importedTitle,
@@ -3601,6 +3735,7 @@ async function run() {
         primaryRecordId: recordId,
         retryRecordId: retried.row.id,
         manualFixRecordId: manualFixed.row.id,
+        xlsxImportRecordId: xlsxImported.id,
         viewSubmitRecordId: viewSubmit.record.id,
         embedHostGeneratedRequestId: embedHost.generatedRequestId,
         embedHostExplicitRequestId: embedHost.explicitRequestId,


### PR DESCRIPTION
## Summary

- extend the existing multitable live Playwright smoke with a real `.xlsx` UI import/export round trip
- generate `pilot-import.xlsx`, import through the real modal, verify API/search hydration, export through `Export Excel`, and parse the downloaded workbook
- update the Feishu RC TODO and add design/verification MDs

## Verification

- `node --check scripts/verify-multitable-live-smoke.mjs`
- `node --test scripts/verify-multitable-live-smoke.test.mjs scripts/ops/multitable-pilot-staging.test.mjs`
- `git diff --check`
- 142 staging: `AUTH_TOKEN=... API_BASE=http://142.171.239.56:8081 WEB_BASE=http://142.171.239.56:8081 pnpm verify:multitable-pilot:staging`
  - final report dir: `output/playwright/multitable-feishu-rc-142-xlsx-ui-smoke/20260506-171537`
  - result: `130/130` checks passed
  - new checks: `ui.xlsx.import-file`, `ui.xlsx.export-download`

## Notes

The admin JWT value was loaded from the local token file and was not printed or committed. Raw Playwright screenshots and XLSX artifacts remain local under `output/playwright/...` and are intentionally not committed.
