### PR TITLE
fix(integration): reject unsafe K3 WebAPI relative paths

### DIFF
--- a/docs/development/integration-k3wise-webapi-relative-path-guard-development-20260507.md
+++ b/docs/development/integration-k3wise-webapi-relative-path-guard-development-20260507.md
@@ -1,0 +1,55 @@
+# K3 WISE WebAPI Relative Path Guard Development
+
+## Context
+
+The K3 WISE WebAPI adapter joins configured endpoint paths with
+`config.baseUrl` through `new URL(path, baseUrl)`. The existing path guard only
+rejected explicit `http://` and `https://` paths.
+
+That left two URL forms that Node normalizes away from the configured K3 host:
+
+- protocol-relative paths, for example `//evil.example.test/K3API/Login`;
+- backslash-prefixed paths, for example `\\evil.example.test\K3API\Login`.
+
+Both can resolve to a host outside `config.baseUrl`, which is not acceptable for
+K3 login, save, submit, or audit calls.
+
+The same URL construction path also treated endpoint paths as root-relative.
+For a customer packet shaped like `baseUrl: https://k3.example.test/K3API` and
+`loginPath: /login`, `new URL('/login', baseUrl)` drops the `/K3API` context.
+
+## Change
+
+`assertRelativePath()` now rejects:
+
+- any leading URL scheme such as `http:`, `https:`, or `k3api:`;
+- protocol-relative paths beginning with `//`;
+- any path containing a backslash.
+
+Normal K3 relative paths are unchanged:
+
+- `/K3API/Login`
+- `K3API/Login`
+- `/K3API/Foo:Bar`
+
+Request construction now uses a K3 adapter-local join helper that preserves a
+context path on `baseUrl` while avoiding duplicate prefixes. That keeps both
+forms valid:
+
+- `baseUrl=https://k3.example.test`, `loginPath=/K3API/Login`
+- `baseUrl=https://k3.example.test/K3API`, `loginPath=/login`
+
+The test coverage adds adapter-construction assertions for protocol-relative and
+backslash-normalized login paths, plus a live mock fetch assertion for baseUrl
+context-path preservation. The patch is intentionally stacked on PR #1352
+because that PR already owns the K3 WebAPI adapter auth transport changes.
+
+## Scope
+
+Changed files:
+
+- `plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs`
+- `plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs`
+
+No workflow, database, frontend, REST route, run-log, or external-system
+registry code is changed.

--- a/docs/development/integration-k3wise-webapi-relative-path-guard-verification-20260507.md
+++ b/docs/development/integration-k3wise-webapi-relative-path-guard-verification-20260507.md
@@ -1,0 +1,36 @@
+# K3 WISE WebAPI Relative Path Guard Verification
+
+## Commands
+
+```bash
+node plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
+git diff --check
+```
+
+## Local Result
+
+- `node plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs`:
+  passed.
+- `git diff --check`: passed.
+
+## Covered Cases
+
+The updated adapter test verifies:
+
+- the existing K3 WebAPI login, health, save, submit, and audit flow still works;
+- non-HTTP base URLs are still rejected;
+- protocol-relative `loginPath` values such as
+  `//evil.example.test/K3API/Login` are rejected before any request is made;
+- backslash-normalized `loginPath` values such as
+  `\\evil.example.test\K3API\Login` are rejected before any request is made;
+- `baseUrl` context paths are preserved, so
+  `baseUrl=https://k3.example.test/K3API`, `loginPath=/login`, and
+  `healthPath=/health` call `/K3API/login` and `/K3API/health`;
+- SQL Server channel and K3 WebAPI auto flag coercion coverage in the same test
+  file still passes.
+
+## Residual Risk
+
+This is a configuration validation hardening slice. It does not contact a real
+K3 WISE WebAPI endpoint. The risk being tested is URL construction, so the unit
+test exercises the adapter boundary directly with a mock fetch implementation.

--- a/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
@@ -231,6 +231,31 @@ async function testK3WebApiAdapter() {
     'missing auth transport fails at login and does not continue to health checks',
   )
 
+  const contextPathCalls = []
+  const contextPathAdapter = createK3WiseWebApiAdapter({
+    system: createK3WebApiSystem({
+      config: {
+        baseUrl: 'https://k3.example.test/K3API',
+        loginPath: '/login',
+        healthPath: '/health',
+      },
+    }),
+    fetchImpl: async (url) => {
+      const parsed = new URL(url)
+      contextPathCalls.push(parsed.pathname)
+      if (parsed.pathname === '/K3API/login') {
+        return jsonResponse(200, { success: true, sessionId: 'k3-context-session' })
+      }
+      if (parsed.pathname === '/K3API/health') {
+        return jsonResponse(200, { ok: true })
+      }
+      return jsonResponse(404, { success: false, message: 'not found' })
+    },
+  })
+  const contextPathStatus = await contextPathAdapter.testConnection()
+  assert.equal(contextPathStatus.ok, true, 'baseUrl context path is preserved for relative K3 paths')
+  assert.deepEqual(contextPathCalls, ['/K3API/login', '/K3API/health'])
+
   assert.equal(webApiInternals.businessSuccess({ success: true }, {}), true)
   assert.equal(webApiInternals.businessSuccess({ Result: { ResponseStatus: { IsSuccess: true } } }, {}), true)
   assert.equal(webApiInternals.businessSuccess({ Result: { ResponseStatus: { IsSuccess: false } } }, {}), false)
@@ -248,6 +273,42 @@ async function testK3WebApiAdapter() {
     }
   })()
   assert.ok(invalidBaseUrl instanceof AdapterValidationError, 'non-http K3 baseUrl rejected')
+
+  const protocolRelativeLoginPath = (() => {
+    try {
+      createK3WiseWebApiAdapter({
+        system: createK3WebApiSystem({
+          config: {
+            baseUrl: 'https://k3.example.test',
+            loginPath: '//evil.example.test/K3API/Login',
+          },
+        }),
+        fetchImpl,
+      })
+      return null
+    } catch (error) {
+      return error
+    }
+  })()
+  assert.ok(protocolRelativeLoginPath instanceof AdapterValidationError, 'protocol-relative K3 paths are rejected')
+
+  const backslashLoginPath = (() => {
+    try {
+      createK3WiseWebApiAdapter({
+        system: createK3WebApiSystem({
+          config: {
+            baseUrl: 'https://k3.example.test',
+            loginPath: '\\\\evil.example.test\\K3API\\Login',
+          },
+        }),
+        fetchImpl,
+      })
+      return null
+    } catch (error) {
+      return error
+    }
+  })()
+  assert.ok(backslashLoginPath instanceof AdapterValidationError, 'backslash-normalized K3 paths are rejected')
 
   assert.equal(K3WiseWebApiAdapterError.name, 'K3WiseWebApiAdapterError')
 }

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
@@ -93,10 +93,29 @@ function assertRelativePath(path, field) {
     throw new AdapterValidationError(`${field} is required`, { field })
   }
   const trimmed = path.trim()
-  if (/^https?:\/\//i.test(trimmed)) {
+  const hasScheme = /^[A-Za-z][A-Za-z0-9+.-]*:/.test(trimmed)
+  const isProtocolRelative = trimmed.startsWith('//')
+  const hasBackslash = trimmed.includes('\\')
+  if (hasScheme || isProtocolRelative || hasBackslash) {
     throw new AdapterValidationError(`${field} must be relative to baseUrl`, { field })
   }
   return trimmed.startsWith('/') ? trimmed : `/${trimmed}`
+}
+
+function buildEndpointUrl(baseUrl, path) {
+  const endpointPath = assertRelativePath(path, 'path')
+  const url = new URL(baseUrl)
+  const basePath = url.pathname && url.pathname !== '/'
+    ? url.pathname.replace(/\/+$/, '')
+    : ''
+  if (basePath && endpointPath !== basePath && !endpointPath.startsWith(`${basePath}/`)) {
+    url.pathname = `${basePath}${endpointPath}`
+  } else {
+    url.pathname = endpointPath
+  }
+  url.search = ''
+  url.hash = ''
+  return url.toString()
 }
 
 function normalizeHeaders(value, field) {
@@ -326,7 +345,7 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
   }
 
   async function requestJson(path, { method = 'GET', headers, body } = {}) {
-    const url = new URL(assertRelativePath(path, 'path'), baseUrl).toString()
+    const url = buildEndpointUrl(baseUrl, path)
     const controller = typeof AbortController === 'function' ? new AbortController() : null
     const timeout = controller ? setTimeout(() => controller.abort(), timeoutMs) : null
     const requestHeaders = mergeHeaders(


### PR DESCRIPTION
## Summary
- reject K3 WebAPI endpoint paths with schemes, protocol-relative prefixes, or backslashes before URL construction
- preserve baseUrl context paths such as https://k3.example.test/K3API when endpoint paths are configured as /login or /health
- add adapter tests plus development and verification notes

## Verification
- pnpm --dir plugins/plugin-integration-core run test:k3-wise-adapters
- git diff --check

## Stacking
- This PR is intentionally based on #1352 / codex/k3wise-webapi-auth-transport-guard-20260506 because that PR already owns adjacent K3 WebAPI adapter auth-transport changes.
- After #1352 merges, this PR should be rebased/retargeted to main.