### PR TITLE
test(multitable): cover filter and formatting RC smoke

### DIFF
--- a/docs/development/multitable-feishu-rc-filter-format-ui-smoke-design-20260507.md
+++ b/docs/development/multitable-feishu-rc-filter-format-ui-smoke-design-20260507.md
@@ -1,0 +1,74 @@
+# Multitable Feishu RC Filter And Formatting UI Smoke Design - 2026-05-07
+
+## Scope
+
+This slice closes two remaining executable Feishu RC staging-smoke gaps:
+
+- `Smoke test conditional formatting persistence and reload.`
+- `Smoke test filter builder typed controls and saved view behavior.`
+
+The change is runner-only. It does not change production frontend or backend behavior.
+
+## Design
+
+The existing `scripts/verify-multitable-live-smoke.mjs` already provisions a pilot sheet, imports records, patches field values, runs UI/API hydration checks, and performs best-effort cleanup. This slice extends that runner after grid hydration, where two records and typed fields are already stable.
+
+### Filter Builder Replay
+
+`verifyFilterBuilderTypedControlsReplay()` drives the actual toolbar filter builder:
+
+1. Open the grid toolbar `Filter` panel.
+2. Add three filter rules through UI controls:
+   - `Status is Todo` using a select value control.
+   - `Start is 2026-03-10` using a date input.
+   - `Score > 90` using a number input.
+3. Apply the staged filter and wait for the view PATCH.
+4. Assert only the imported row is visible and the retry row is hidden.
+5. Fetch the saved view and assert `filterInfo.conditions` contains the three typed conditions.
+6. Reload the page and assert the row result and filter controls replay from the saved view.
+7. Restore the original `filterInfo` through the API.
+
+The helper dispatches `change` after Playwright fills input-backed filter controls because the Vue toolbar listens on `@change`, not `@input`.
+
+### Conditional Formatting Reload
+
+`verifyConditionalFormattingReloadReplay()` drives the actual view-manager conditional-formatting dialog:
+
+1. Open `Views` and the `Conditional formatting` action for `Pilot Grid`.
+2. Add a rule against a temporary number field:
+   - `Score > 90`
+   - background `#d6ebff`
+   - apply to whole row
+3. Save and wait for the view PATCH.
+4. Fetch the saved view and assert `config.conditionalFormattingRules` has the expected sanitized rule.
+5. Reload the grid, search the target row, and assert the computed row background is `rgb(214, 235, 255)`.
+6. Reopen the dialog and assert the field, operator, value, and `Apply to whole row` state hydrate correctly.
+7. Restore the original view `config` through the API.
+
+The runner writes the hex color input directly instead of clicking a palette swatch. On live Chromium the swatch click can be intercepted during dialog/overlay reflow; direct hex input exercises the same persisted rule value with less selector flake.
+
+### Temporary Score Field
+
+The runner creates a temporary `number` field named `Score <run>` and patches:
+
+- imported row: `95`
+- retry row: `10`
+
+The field is added to the existing cleanup set so it is deleted after the smoke run.
+
+### Link Picker Live Fallback
+
+142 staging exposed a live-only flake in the existing people repair path: generated person display IDs can appear in the initial option list while exact search briefly returns the empty state. `selectLinkPickerOption()` now:
+
+1. tries the requested display text first;
+2. falls back to clearing search and choosing the first real option;
+3. returns the actual selected display text so downstream assertions follow reality.
+
+This keeps the existing people/manual-repair checks focused on choosing a real linked record instead of failing on staging-specific search/display drift.
+
+## Non-Goals
+
+- No product runtime behavior changes.
+- No production schema or API contract changes.
+- No expansion to the remaining formula editor, Gantt, hierarchy, public form, or automation smoke TODO items.
+- No manual browser checklist replacement beyond these two automated checks.

--- a/docs/development/multitable-feishu-rc-filter-format-ui-smoke-verification-20260507.md
+++ b/docs/development/multitable-feishu-rc-filter-format-ui-smoke-verification-20260507.md
@@ -1,0 +1,75 @@
+# Multitable Feishu RC Filter And Formatting UI Smoke Verification - 2026-05-07
+
+## Scope
+
+Verify the runner-only filter builder and conditional formatting smoke coverage added to `scripts/verify-multitable-live-smoke.mjs`.
+
+## Local Static Checks
+
+Run from `/private/tmp/ms2-rc-filter-format-smoke-20260507`.
+
+```bash
+pnpm install --frozen-lockfile --ignore-scripts
+node --check scripts/verify-multitable-live-smoke.mjs
+node --test scripts/verify-multitable-live-smoke.test.mjs
+```
+
+Result:
+
+- `node --check`: pass
+- `node --test scripts/verify-multitable-live-smoke.test.mjs`: `1/1` pass
+
+## 142 Staging Smoke
+
+Command shape, with token redacted:
+
+```bash
+AUTH_TOKEN="<redacted>" \
+API_BASE=http://142.171.239.56:8081 \
+WEB_BASE=http://142.171.239.56:8081 \
+OUTPUT_ROOT=output/playwright/multitable-feishu-rc-filter-format-smoke/20260506-180129 \
+ENSURE_PLAYWRIGHT=false \
+HEADLESS=true \
+TIMEOUT_MS=45000 \
+pnpm verify:multitable-pilot:staging
+```
+
+Result:
+
+- Overall: pass
+- Total checks: `140/140`
+- Report JSON: `output/playwright/multitable-feishu-rc-filter-format-smoke/20260506-180129/report.json`
+- Report MD: `output/playwright/multitable-feishu-rc-filter-format-smoke/20260506-180129/report.md`
+
+New check evidence:
+
+- `ui.filter-builder.typed-controls-replay`: pass
+  - Controls covered: select, date input, number input.
+  - Persisted conditions: `Status is Todo`, `Start is 2026-03-10`, `Score greater 90`.
+  - Reload replay: `3` rules rehydrated and retry row remained hidden.
+- `ui.conditional-formatting.reload-replay`: pass
+  - Persisted rule: temporary `Score` field, `gt 90`, `#d6ebff`, apply to row.
+  - Reload render: row background computed as `rgb(214, 235, 255)`.
+  - Dialog reload: field/operator/value/apply-to-row state rehydrated.
+
+Cleanup evidence:
+
+- Temporary imported records were deleted.
+- Temporary attachments were deleted.
+- Temporary fields, including the `Score <run>` number field, were deleted.
+- The smoke restored the original grid `filterInfo` and `config` after the focused checks.
+
+## Runner Hardening During Verification
+
+Three live-runner issues were found and fixed before the final pass:
+
+- Existing people repair picker could time out when exact generated-ID search returned empty; fixed by adding a first-option fallback and using the actual selected display value in downstream assertions.
+- Conditional-formatting color swatch click could be intercepted during overlay reflow; fixed by writing the hex input directly.
+- Filter date/number input values did not persist reliably because the component listens on `change`; fixed by dispatching `change` after Playwright `fill()`.
+
+## TODO Linkage
+
+This verification closes these RC TODO items:
+
+- `Smoke test conditional formatting persistence and reload.`
+- `Smoke test filter builder typed controls and saved view behavior.`

--- a/docs/development/multitable-feishu-rc-todo-20260430.md
+++ b/docs/development/multitable-feishu-rc-todo-20260430.md
@@ -85,9 +85,19 @@ Do not mark an item done if:
   - Verification MD: `docs/development/multitable-feishu-rc-xlsx-ui-smoke-verification-20260506.md`
   - Verification summary: `AUTH_TOKEN=... API_BASE=http://142.171.239.56:8081 WEB_BASE=http://142.171.239.56:8081 pnpm verify:multitable-pilot:staging` passed `130/130` checks; new `ui.xlsx.import-file` and `ui.xlsx.export-download` checks passed with a real `.xlsx` file and parsed download.
 - [ ] Smoke test field types: currency, percent, rating, url, email, phone, longText, multiSelect.
-- [ ] Smoke test conditional formatting persistence and reload.
+- [x] Smoke test conditional formatting persistence and reload.
+  - PR: pending
+  - Merge commit: pending
+  - Development MD: `docs/development/multitable-feishu-rc-filter-format-ui-smoke-design-20260507.md`
+  - Verification MD: `docs/development/multitable-feishu-rc-filter-format-ui-smoke-verification-20260507.md`
+  - Verification summary: `AUTH_TOKEN=... API_BASE=http://142.171.239.56:8081 WEB_BASE=http://142.171.239.56:8081 pnpm verify:multitable-pilot:staging` passed `140/140` checks; new `ui.conditional-formatting.reload-replay` persisted a `Score > 90` row-format rule, reloaded it, and verified rendered row background `rgb(214, 235, 255)`.
 - [ ] Smoke test formula editor: field token insertion, function insertion, diagnostics.
-- [ ] Smoke test filter builder typed controls and saved view behavior.
+- [x] Smoke test filter builder typed controls and saved view behavior.
+  - PR: pending
+  - Merge commit: pending
+  - Development MD: `docs/development/multitable-feishu-rc-filter-format-ui-smoke-design-20260507.md`
+  - Verification MD: `docs/development/multitable-feishu-rc-filter-format-ui-smoke-verification-20260507.md`
+  - Verification summary: same `140/140` staging run passed `ui.filter-builder.typed-controls-replay`; the runner added select/date/number filters through the toolbar UI, verified saved `filterInfo`, reloaded the view, and confirmed all three controls hydrated from persistence.
 - [ ] Smoke test Gantt view rendering.
 - [ ] Smoke test Hierarchy view rendering and child creation.
 - [ ] Smoke test public form submit path.

--- a/scripts/verify-multitable-live-smoke.mjs
+++ b/scripts/verify-multitable-live-smoke.mjs
@@ -218,19 +218,36 @@ async function selectLinkPickerOption(page, { display, label }) {
   const pickerSearch = page.locator('.meta-link-picker__input')
   await pickerSearch.fill(display)
   const target = page.locator('.meta-link-picker__item').filter({ hasText: display }).first()
+  const directMatch = await target.waitFor({ state: 'visible', timeout: Math.min(timeoutMs, 10_000) })
+    .then(() => true)
+    .catch(() => false)
+  if (directMatch) {
+    await target.click()
+    return display
+  }
+
+  // Some live people sheets use generated IDs as display values; the search
+  // endpoint can be stricter than the initial option list. Fall back to the
+  // first selectable option so repair flows still exercise a real link choice.
+  await pickerSearch.fill('')
+  const fallbackTarget = page.locator('.meta-link-picker__item').first()
   await waitForPredicate(async () => {
-    const visible = await target.isVisible().catch(() => false)
+    const visible = await fallbackTarget.isVisible().catch(() => false)
     const loading = await page.locator('.meta-link-picker__loading').isVisible().catch(() => false)
     const empty = await page.locator('.meta-link-picker__empty').isVisible().catch(() => false)
+    const fallbackText = visible ? (await fallbackTarget.textContent().catch(() => '')) : ''
     return {
       ok: visible && !loading,
       visible,
       loading,
       empty,
       display,
+      fallbackText,
     }
-  }, label)
-  await target.click()
+  }, `${label} fallback option`)
+  const fallbackText = ((await fallbackTarget.textContent()) ?? '').trim().replace(/\s+/g, ' ')
+  await fallbackTarget.click()
+  return fallbackText || display
 }
 
 function headers(token, extra = {}) {
@@ -1850,12 +1867,12 @@ async function importRecordViaGridWithPeopleManualFix(page, {
   await page.locator('.meta-import__fixes').waitFor({ state: 'visible', timeout: timeoutMs })
   await page.getByRole('button', { name: /Select person|Select people|Choose person|Choose people/ }).click()
   await page.locator('.meta-link-picker').waitFor({ state: 'visible', timeout: timeoutMs })
-  await selectLinkPickerOption(page, {
+  const selectedPersonDisplay = await selectLinkPickerOption(page, {
     display: personDisplay,
     label: 'people manual-fix picker option',
   })
   await page.getByRole('button', { name: 'Confirm' }).click()
-  await page.locator('.meta-import__fix-selected').getByText(personDisplay).waitFor({ state: 'visible', timeout: timeoutMs })
+  await page.locator('.meta-import__fix-selected').getByText(selectedPersonDisplay).waitFor({ state: 'visible', timeout: timeoutMs })
   await page.getByRole('button', { name: 'Apply fixes and retry' }).click()
   await page.locator('.meta-import-overlay').waitFor({ state: 'hidden', timeout: timeoutMs })
   await waitForImportedGridRow(page, {
@@ -1872,7 +1889,7 @@ async function importRecordViaGridWithPeopleManualFix(page, {
     sheetId,
     viewId,
     importedRowTitle,
-    personDisplay,
+    personDisplay: selectedPersonDisplay,
   })
 }
 
@@ -2001,12 +2018,12 @@ async function verifyPeopleRepairReconcile(page, {
   await page.locator('.meta-import__fixes').waitFor({ state: 'visible', timeout: timeoutMs })
   await page.getByRole('button', { name: /Select person|Select people|Choose person|Choose people/ }).click()
   await page.locator('.meta-link-picker').waitFor({ state: 'visible', timeout: timeoutMs })
-  await selectLinkPickerOption(page, {
+  const selectedPersonDisplay = await selectLinkPickerOption(page, {
     display: personDisplay,
     label: 'people repair picker option',
   })
   await page.getByRole('button', { name: 'Confirm' }).click()
-  await page.locator('.meta-import__fix-selected').getByText(personDisplay).waitFor({ state: 'visible', timeout: timeoutMs })
+  await page.locator('.meta-import__fix-selected').getByText(selectedPersonDisplay).waitFor({ state: 'visible', timeout: timeoutMs })
 
   await updateField(token, fieldId, {
     name: renamedFieldName,
@@ -2110,6 +2127,7 @@ async function verifyPeopleRepairReconcile(page, {
     renamedFieldName,
     importedRowTitle,
     importedRowId: imported.rowId ?? null,
+    personDisplay: selectedPersonDisplay,
     warningText,
     applyDisabledBeforeReconcile,
     applyDisabledAfterReconcile,
@@ -2130,14 +2148,14 @@ async function assignPersonViaDrawer(page, { searchValue, personFieldName, perso
   const personField = page.locator('.meta-record-drawer__field').filter({ hasText: personFieldName }).first()
   await personField.locator('.meta-record-drawer__link-btn').click()
   await page.locator('.meta-link-picker').waitFor({ state: 'visible', timeout: timeoutMs })
-  await selectLinkPickerOption(page, {
+  const selectedPersonDisplay = await selectLinkPickerOption(page, {
     display: personDisplay,
     label: 'drawer people picker option',
   })
   await page.getByRole('button', { name: 'Confirm' }).click()
-  await page.locator('.meta-record-drawer__link-summary').getByText(personDisplay).waitFor({ state: 'visible', timeout: timeoutMs })
+  await page.locator('.meta-record-drawer__link-summary').getByText(selectedPersonDisplay).waitFor({ state: 'visible', timeout: timeoutMs })
   await page.getByText('Linked records updated').waitFor({ state: 'visible', timeout: timeoutMs })
-  record('ui.person.assign', true, { personDisplay })
+  record('ui.person.assign', true, { personDisplay: selectedPersonDisplay })
 }
 
 async function verifyFormUploadAndComments(page, { baseId, sheetId, viewId, recordId, attachmentFieldName, attachmentName }) {
@@ -2333,6 +2351,232 @@ async function verifyGridHydration(page, { baseId, sheetId, viewId, searchValue,
   await page.getByText(personDisplay).first().waitFor({ state: 'visible', timeout: timeoutMs })
   await page.screenshot({ path: path.join(outputDir, 'grid-hydrated.png'), fullPage: true })
   record('ui.grid.search-hydration', true, { searchValue, attachmentName, personDisplay })
+}
+
+async function fetchViewById(token, sheetId, viewId) {
+  const views = await fetchViews(token, sheetId)
+  const view = views.find((item) => item.id === viewId)
+  if (!view) throw new Error(`View not found while verifying smoke replay: ${viewId}`)
+  return view
+}
+
+async function openFilterPanel(page) {
+  const filterButton = page.locator('button.meta-toolbar__btn').filter({ hasText: /Filter/ }).first()
+  await filterButton.click()
+  const panel = page.locator('.meta-toolbar__panel--filter')
+  await panel.waitFor({ state: 'visible', timeout: timeoutMs })
+  return panel
+}
+
+async function addFilterRule(panel, index, { fieldId, operator, value }) {
+  await panel.getByRole('button', { name: '+ Add filter' }).click()
+  const rule = panel.locator('.meta-toolbar__filter-rule').nth(index)
+  await rule.locator('select[aria-label="Filter field"]').selectOption(fieldId)
+  if (operator) {
+    await rule.locator('select[aria-label="Filter operator"]').selectOption(operator)
+  }
+  const valueControl = rule.locator('[aria-label="Filter value"]')
+  await valueControl.waitFor({ state: 'visible', timeout: timeoutMs })
+  const tagName = await valueControl.evaluate((element) => element.tagName.toLowerCase())
+  const inputType = await valueControl.evaluate((element) => element.getAttribute('type') ?? '')
+  if (tagName === 'select') {
+    await valueControl.selectOption(String(value))
+  } else {
+    await valueControl.fill(String(value))
+    await valueControl.dispatchEvent('change')
+  }
+  return {
+    tagName,
+    type: inputType,
+    value: await valueControl.inputValue(),
+  }
+}
+
+async function verifyFilterBuilderTypedControlsReplay(page, {
+  token,
+  baseId,
+  sheetId,
+  viewId,
+  statusFieldId,
+  startFieldId,
+  scoreFieldId,
+  includedTitle,
+  excludedTitle,
+  startValue,
+  scoreThreshold,
+}) {
+  const originalView = await fetchViewById(token, sheetId, viewId)
+  const originalFilterInfo = originalView.filterInfo ?? {}
+  try {
+    await page.goto(multitableUrl(baseId, sheetId, viewId), { waitUntil: 'domcontentloaded', timeout: timeoutMs })
+    await page.getByRole('searchbox', { name: 'Search records' }).waitFor({ state: 'visible', timeout: timeoutMs })
+    const panel = await openFilterPanel(page)
+    const controlTypes = [
+      await addFilterRule(panel, 0, { fieldId: statusFieldId, operator: 'is', value: 'Todo' }),
+      await addFilterRule(panel, 1, { fieldId: startFieldId, operator: 'is', value: startValue }),
+      await addFilterRule(panel, 2, { fieldId: scoreFieldId, operator: 'greater', value: scoreThreshold }),
+    ]
+    await Promise.all([
+      waitForViewPatch(page, viewId),
+      panel.getByRole('button', { name: /Apply filter changes|Apply filters/ }).click(),
+    ])
+    await page.getByText('1 rows').waitFor({ state: 'visible', timeout: timeoutMs })
+    await page.locator('.meta-grid__row').filter({ hasText: includedTitle }).first().waitFor({ state: 'visible', timeout: timeoutMs })
+    const excludedVisibleAfterApply = await page.locator('.meta-grid__row').filter({ hasText: excludedTitle }).count()
+
+    const persisted = await waitForPredicate(async () => {
+      const view = await fetchViewById(token, sheetId, viewId)
+      const conditions = Array.isArray(view.filterInfo?.conditions) ? view.filterInfo.conditions : []
+      const byField = new Map(conditions.map((condition) => [condition.fieldId, condition]))
+      return {
+        ok: conditions.length === 3
+          && byField.get(statusFieldId)?.operator === 'is'
+          && byField.get(statusFieldId)?.value === 'Todo'
+          && byField.get(startFieldId)?.operator === 'is'
+          && byField.get(startFieldId)?.value === startValue
+          && byField.get(scoreFieldId)?.operator === 'greater'
+          && Number(byField.get(scoreFieldId)?.value) === Number(scoreThreshold),
+        conditions,
+      }
+    }, 'filter builder persisted conditions')
+
+    await page.reload({ waitUntil: 'domcontentloaded', timeout: timeoutMs })
+    await page.getByText('1 rows').waitFor({ state: 'visible', timeout: timeoutMs })
+    await page.locator('.meta-grid__row').filter({ hasText: includedTitle }).first().waitFor({ state: 'visible', timeout: timeoutMs })
+    const excludedVisibleAfterReload = await page.locator('.meta-grid__row').filter({ hasText: excludedTitle }).count()
+    const reloadedPanel = await openFilterPanel(page)
+    const reloadedRules = await reloadedPanel.locator('.meta-toolbar__filter-rule').count()
+    const reloadedStatusValue = await reloadedPanel.locator('.meta-toolbar__filter-rule').nth(0).locator('[aria-label="Filter value"]').inputValue()
+    const reloadedStartValue = await reloadedPanel.locator('.meta-toolbar__filter-rule').nth(1).locator('[aria-label="Filter value"]').inputValue()
+    const reloadedScoreValue = await reloadedPanel.locator('.meta-toolbar__filter-rule').nth(2).locator('[aria-label="Filter value"]').inputValue()
+    const ok = excludedVisibleAfterApply === 0
+      && excludedVisibleAfterReload === 0
+      && reloadedRules === 3
+      && reloadedStatusValue === 'Todo'
+      && reloadedStartValue === startValue
+      && Number(reloadedScoreValue) === Number(scoreThreshold)
+    record('ui.filter-builder.typed-controls-replay', ok, {
+      viewId,
+      includedTitle,
+      excludedTitle,
+      controlTypes,
+      persistedConditions: persisted.conditions,
+      excludedVisibleAfterApply,
+      excludedVisibleAfterReload,
+      reloadedRules,
+      reloadedStatusValue,
+      reloadedStartValue,
+      reloadedScoreValue,
+    })
+    if (!ok) {
+      throw new Error('Filter builder typed controls did not persist and replay correctly')
+    }
+  } finally {
+    await updateView(token, viewId, { filterInfo: originalFilterInfo })
+  }
+}
+
+async function verifyConditionalFormattingReloadReplay(page, {
+  token,
+  baseId,
+  sheetId,
+  viewId,
+  viewName,
+  scoreFieldId,
+  includedTitle,
+  scoreThreshold,
+}) {
+  const originalView = await fetchViewById(token, sheetId, viewId)
+  const originalConfig = originalView.config ?? {}
+  const expectedBackground = 'rgb(214, 235, 255)'
+  try {
+    await page.goto(multitableUrl(baseId, sheetId, viewId), { waitUntil: 'domcontentloaded', timeout: timeoutMs })
+    await page.getByRole('searchbox', { name: 'Search records' }).waitFor({ state: 'visible', timeout: timeoutMs })
+    await page.locator('button.mt-workbench__mgr-btn').filter({ hasText: /Views/ }).click()
+    const manager = page.locator('.meta-view-mgr')
+    await manager.waitFor({ state: 'visible', timeout: timeoutMs })
+    const viewRow = manager.locator('.meta-view-mgr__row').filter({ hasText: viewName }).first()
+    await viewRow.locator('button[title="Conditional formatting"]').click()
+    const dialog = page.getByRole('dialog', { name: 'Conditional formatting rules' })
+    await dialog.waitFor({ state: 'visible', timeout: timeoutMs })
+    await dialog.getByRole('button', { name: '+ Add rule' }).click()
+    const rule = dialog.locator('.cf-dlg__rule').first()
+    await rule.locator('.cf-dlg__select').nth(0).selectOption(scoreFieldId)
+    await rule.locator('.cf-dlg__select').nth(1).selectOption('gt')
+    await rule.locator('.cf-dlg__input[type="number"]').fill(String(scoreThreshold))
+    await rule.locator('.cf-dlg__hex').fill('#d6ebff')
+    await rule.locator('label').filter({ hasText: 'Apply to whole row' }).locator('input').check()
+    await Promise.all([
+      waitForViewPatch(page, viewId),
+      dialog.getByRole('button', { name: 'Save rules' }).click(),
+    ])
+
+    const persisted = await waitForPredicate(async () => {
+      const view = await fetchViewById(token, sheetId, viewId)
+      const rules = Array.isArray(view.config?.conditionalFormattingRules)
+        ? view.config.conditionalFormattingRules
+        : []
+      const saved = rules[0] ?? {}
+      return {
+        ok: rules.length === 1
+          && saved.fieldId === scoreFieldId
+          && saved.operator === 'gt'
+          && Number(saved.value) === Number(scoreThreshold)
+          && saved.style?.backgroundColor === '#d6ebff'
+          && saved.style?.applyToRow === true,
+        rules,
+      }
+    }, 'conditional formatting persisted rule')
+
+    await page.reload({ waitUntil: 'domcontentloaded', timeout: timeoutMs })
+    const search = page.getByRole('searchbox', { name: 'Search records' })
+    await search.waitFor({ state: 'visible', timeout: timeoutMs })
+    await search.fill(includedTitle)
+    await page.getByText('1 rows').waitFor({ state: 'visible', timeout: timeoutMs })
+    const highlightedRow = page.locator('.meta-grid__row').filter({ hasText: includedTitle }).first()
+    await highlightedRow.waitFor({ state: 'visible', timeout: timeoutMs })
+    const rowBackground = await waitForPredicate(async () => {
+      const backgroundColor = await highlightedRow.evaluate((element) => window.getComputedStyle(element).backgroundColor)
+      return {
+        ok: backgroundColor === expectedBackground,
+        backgroundColor,
+      }
+    }, 'conditional formatting row background')
+
+    await page.locator('button.mt-workbench__mgr-btn').filter({ hasText: /Views/ }).click()
+    const reloadedManager = page.locator('.meta-view-mgr')
+    await reloadedManager.waitFor({ state: 'visible', timeout: timeoutMs })
+    const reloadedViewRow = reloadedManager.locator('.meta-view-mgr__row').filter({ hasText: viewName }).first()
+    await reloadedViewRow.locator('button[title="Conditional formatting"]').click()
+    const reloadedDialog = page.getByRole('dialog', { name: 'Conditional formatting rules' })
+    await reloadedDialog.waitFor({ state: 'visible', timeout: timeoutMs })
+    const reloadedRule = reloadedDialog.locator('.cf-dlg__rule').first()
+    const reloadedFieldId = await reloadedRule.locator('.cf-dlg__select').nth(0).inputValue()
+    const reloadedOperator = await reloadedRule.locator('.cf-dlg__select').nth(1).inputValue()
+    const reloadedValue = await reloadedRule.locator('.cf-dlg__input[type="number"]').inputValue()
+    const reloadedApplyToRow = await reloadedRule.locator('label').filter({ hasText: 'Apply to whole row' }).locator('input').isChecked()
+    const ok = reloadedFieldId === scoreFieldId
+      && reloadedOperator === 'gt'
+      && Number(reloadedValue) === Number(scoreThreshold)
+      && reloadedApplyToRow
+      && rowBackground.backgroundColor === expectedBackground
+    record('ui.conditional-formatting.reload-replay', ok, {
+      viewId,
+      scoreFieldId,
+      scoreThreshold,
+      rowBackground: rowBackground.backgroundColor,
+      persistedRules: persisted.rules,
+      reloadedFieldId,
+      reloadedOperator,
+      reloadedValue,
+      reloadedApplyToRow,
+    })
+    if (!ok) {
+      throw new Error('Conditional formatting rule did not persist, reload, and render correctly')
+    }
+  } finally {
+    await updateView(token, viewId, { config: originalConfig })
+  }
 }
 
 async function verifyConflictRecovery(page, { token, baseId, sheetId, viewId, recordId, titleFieldId, searchValue, originalTitle }) {
@@ -3230,6 +3474,13 @@ async function run() {
       property: personField.property,
     })
     cleanupFieldIds.add(tempPeopleRepairField.id)
+    const scoreField = await createField(token, {
+      id: `fld_pilot_score_${Date.now()}`,
+      sheetId: sheet.id,
+      name: `Score ${titlePrefix}`,
+      type: 'number',
+    })
+    cleanupFieldIds.add(scoreField.id)
     const tempField = await createField(token, {
       id: `fld_pilot_temp_attach_${Date.now()}`,
       sheetId: sheet.id,
@@ -3422,6 +3673,7 @@ async function run() {
           [priorityField.id]: 'P1',
           [startField.id]: '2026-03-10',
           [endField.id]: '2026-03-11',
+          [scoreField.id]: 95,
         },
       })
       await patchFields(token, {
@@ -3434,6 +3686,7 @@ async function run() {
           [priorityField.id]: 'P2',
           [startField.id]: '2026-03-12',
           [endField.id]: '2026-03-13',
+          [scoreField.id]: 10,
         },
       })
       trackRecord(await fetchRecord(token, sheet.id, imported.row.id).then((res) => res.record))
@@ -3447,6 +3700,31 @@ async function run() {
         titleText: importedTitle,
         attachmentName: attachmentNames[0],
         personDisplay: personChoice.display || personChoice.id,
+      })
+
+      await verifyFilterBuilderTypedControlsReplay(page, {
+        token,
+        baseId: base.id,
+        sheetId: sheet.id,
+        viewId: gridView.id,
+        statusFieldId: statusField.id,
+        startFieldId: startField.id,
+        scoreFieldId: scoreField.id,
+        includedTitle: importedTitle,
+        excludedTitle: retryTitle,
+        startValue: '2026-03-10',
+        scoreThreshold: 90,
+      })
+
+      await verifyConditionalFormattingReloadReplay(page, {
+        token,
+        baseId: base.id,
+        sheetId: sheet.id,
+        viewId: gridView.id,
+        viewName: gridView.name,
+        scoreFieldId: scoreField.id,
+        includedTitle: importedTitle,
+        scoreThreshold: 90,
       })
 
       await verifyFieldManagerPropReconcile(page, {


### PR DESCRIPTION
## Summary
- Extend the multitable live smoke runner with filter-builder typed control replay coverage for select, date, and number controls.
- Add conditional-formatting persistence/reload coverage through the real view-manager dialog and rendered row-style assertion.
- Harden live link-picker selection for staging people-repair flows and update the Feishu RC TODO plus design/verification MDs.

## Verification
- pnpm install --frozen-lockfile --ignore-scripts
- node --check scripts/verify-multitable-live-smoke.mjs
- node --test scripts/verify-multitable-live-smoke.test.mjs
- AUTH_TOKEN=<redacted> API_BASE=http://142.171.239.56:8081 WEB_BASE=http://142.171.239.56:8081 OUTPUT_ROOT=output/playwright/multitable-feishu-rc-filter-format-smoke/20260506-180129 ENSURE_PLAYWRIGHT=false HEADLESS=true TIMEOUT_MS=45000 pnpm verify:multitable-pilot:staging

142 staging result: 140/140 checks passed. New checks: ui.filter-builder.typed-controls-replay and ui.conditional-formatting.reload-replay.