### PR TITLE
test(multitable): add field types smoke coverage

### DIFF
--- a/docs/development/multitable-feishu-rc-field-types-ui-smoke-design-20260507.md
+++ b/docs/development/multitable-feishu-rc-field-types-ui-smoke-design-20260507.md
@@ -1,0 +1,57 @@
+# Multitable Feishu RC Field Types UI Smoke Design - 2026-05-07
+
+## Scope
+
+This slice closes the executable Feishu RC staging-smoke gap for broad field-type rendering and reload:
+
+- `Smoke test field types: currency, percent, rating, url, email, phone, longText, multiSelect.`
+
+The change is runner-only. It does not change production frontend or backend behavior.
+
+## Design
+
+The existing `scripts/verify-multitable-live-smoke.mjs` provisions a pilot sheet, imports records, patches field values through the authoritative `/api/multitable/patch` path, verifies UI hydration, and performs best-effort cleanup. This slice extends that flow after the imported record already has attachments and a linked person, before later view-manager mutations can affect grid rendering.
+
+### Temporary Field Matrix
+
+The runner now creates eight temporary fields with stable, safe values:
+
+| Field type | Property | Patched value | UI assertion |
+| --- | --- | --- | --- |
+| `currency` | `{ code: "CNY", decimals: 2 }` | `1234.56` | `¥1,234.56` |
+| `percent` | `{ decimals: 1 }` | `37.5` | `37.5%` |
+| `rating` | `{ max: 5 }` | `4` | `★★★★☆` |
+| `url` | none | `https://example.com/multitable-rc` | link text and `href` |
+| `email` | none | `rc-field-types@example.com` | link text and `mailto:` href |
+| `phone` | none | `+86 138 0000 0000` | link text and sanitized `tel:` href |
+| `longText` | none | two-line string | both lines visible |
+| `multiSelect` | `Alpha`, `Beta`, `Gamma` options | `["Alpha", "Gamma"]` | two rendered chips, ordered |
+
+All temporary fields are added to the existing cleanup set and are deleted after the smoke run.
+
+### API Normalization Check
+
+`verifyFieldTypesReloadReplay()` first fetches the patched record through the API and asserts that each field value is normalized to the expected persisted shape:
+
+- scalar values remain exact for currency, percent, rating, url, email, phone, and longText;
+- multi-select remains an ordered string array.
+
+This catches backend value coercion or validation regressions before testing frontend rendering.
+
+### UI Reload Replay Check
+
+After API validation, the runner opens the grid view, searches the imported row, and checks each field cell by `aria-label` field name. It then reloads the page and repeats the same assertions.
+
+The check records:
+
+- `api.field-types.value-normalization`
+- `ui.field-types.reload-replay`
+
+The screenshot `field-types-reloaded.png` is written to the run output directory for manual review when needed.
+
+## Non-Goals
+
+- No editor interaction coverage for these fields.
+- No invalid-value negative-path coverage.
+- No formula editor, Gantt, hierarchy, public form, or automation smoke expansion.
+- No product runtime changes.

--- a/docs/development/multitable-feishu-rc-field-types-ui-smoke-verification-20260507.md
+++ b/docs/development/multitable-feishu-rc-field-types-ui-smoke-verification-20260507.md
@@ -1,0 +1,99 @@
+# Multitable Feishu RC Field Types UI Smoke Verification - 2026-05-07
+
+## Scope
+
+Verify the runner-only field-type smoke coverage added to `scripts/verify-multitable-live-smoke.mjs`.
+
+## Local Static Checks
+
+Run from `/private/tmp/ms2-rc-field-types-smoke-20260507`.
+
+```bash
+pnpm install --frozen-lockfile --ignore-scripts
+node --check scripts/verify-multitable-live-smoke.mjs
+node --test scripts/verify-multitable-live-smoke.test.mjs
+git diff --check
+```
+
+Result:
+
+- `pnpm install --frozen-lockfile --ignore-scripts`: pass
+- `node --check scripts/verify-multitable-live-smoke.mjs`: pass
+- `node --test scripts/verify-multitable-live-smoke.test.mjs`: `1/1` pass
+- `git diff --check`: pass
+
+## 142 Staging Smoke
+
+### Attempt 1 - 8081 Main Entry
+
+Command shape, with token redacted:
+
+```bash
+AUTH_TOKEN="<redacted>" \
+API_BASE=http://142.171.239.56:8081 \
+WEB_BASE=http://142.171.239.56:8081 \
+OUTPUT_ROOT=output/playwright/multitable-feishu-rc-field-types-smoke/20260506-184147 \
+ENSURE_PLAYWRIGHT=false \
+HEADLESS=true \
+TIMEOUT_MS=45000 \
+pnpm verify:multitable-pilot:staging
+```
+
+Result:
+
+- Overall: blocked before runner start
+- Failure: backend not reachable at `http://142.171.239.56:8081`
+- Remote evidence: `metasheet-142` has no main app container exposing `8081`; `127.0.0.1:8081` returns connection refused from the host.
+
+### Attempt 2 - 8082 Staging Entry
+
+Because `8081` is not serving the main app, a short-lived staging admin JWT was generated inside the running `metasheet-staging-backend` container using its runtime `JWT_SECRET`. The token value was not printed or committed. `/api/auth/me` validated successfully against `8082`.
+
+Command shape, with token redacted:
+
+```bash
+AUTH_TOKEN="<redacted>" \
+API_BASE=http://142.171.239.56:8082 \
+WEB_BASE=http://142.171.239.56:8082 \
+OUTPUT_ROOT=output/playwright/multitable-feishu-rc-field-types-smoke/20260506-184949 \
+ENSURE_PLAYWRIGHT=false \
+HEADLESS=true \
+TIMEOUT_MS=45000 \
+pnpm verify:multitable-pilot:staging
+```
+
+Result:
+
+- Overall: fail due target deployment drift
+- Total checks before failure: `45`
+- Failing check: `Currency PilotFlow-1778118617117`
+- Report JSON: `output/playwright/multitable-feishu-rc-field-types-smoke/20260506-184949/report.json`
+- Report MD: `output/playwright/multitable-feishu-rc-field-types-smoke/20260506-184949/report.md`
+- Remote backend image: `ghcr.io/zensgit/metasheet2-backend:62a75f9809-itemresults`
+- Failure detail: `api.multitable.create-field` returned `400 VALIDATION_ERROR`; the target backend accepts only the legacy field type enum `string | number | boolean | date | formula | select | link | lookup | rollup | attachment` and rejects `currency`.
+
+New check evidence:
+
+- `api.field-types.value-normalization`: not reached because deployed 8082 backend predates MF2 field types.
+- `ui.field-types.reload-replay`: not reached because deployed 8082 backend predates MF2 field types.
+
+Cleanup evidence:
+
+- Temporary fields created before the failure were deleted by the runner cleanup path.
+- No field-type temporary fields were created on 8082 because the first `currency` create failed.
+
+## Conclusion
+
+The runner change is locally valid, but the final 142 staging smoke cannot be marked complete until a 142 target is running a backend build that includes MF2 field types.
+
+Required next gate:
+
+1. Deploy current `main` or a verified image containing MF2 field types to the selected 142 smoke target.
+2. Re-run the same `pnpm verify:multitable-pilot:staging` command.
+3. Mark the RC TODO item complete only after `api.field-types.value-normalization` and `ui.field-types.reload-replay` pass.
+
+## TODO Linkage
+
+This verification adds executable coverage for this RC TODO item, but does not close it until the staging target is upgraded and the smoke passes:
+
+- `Smoke test field types: currency, percent, rating, url, email, phone, longText, multiSelect.`

--- a/docs/development/multitable-feishu-rc-todo-20260430.md
+++ b/docs/development/multitable-feishu-rc-todo-20260430.md
@@ -39,7 +39,7 @@ Do not mark an item done if:
   - Verification MD: `docs/development/multitable-feishu-rc-verification-20260430.md`
   - Verification summary: docs-only PR CI passed and merged.
 - [x] Confirm root worktree dirty state is unrelated to this RC stream.
-  - PR: pending
+  - PR: #1379
   - Merge commit: pending
   - Development MD: `docs/development/multitable-feishu-rc-audit-development-20260430.md`
   - Verification MD: `docs/development/multitable-feishu-rc-audit-verification-20260430.md`
@@ -85,6 +85,11 @@ Do not mark an item done if:
   - Verification MD: `docs/development/multitable-feishu-rc-xlsx-ui-smoke-verification-20260506.md`
   - Verification summary: `AUTH_TOKEN=... API_BASE=http://142.171.239.56:8081 WEB_BASE=http://142.171.239.56:8081 pnpm verify:multitable-pilot:staging` passed `130/130` checks; new `ui.xlsx.import-file` and `ui.xlsx.export-download` checks passed with a real `.xlsx` file and parsed download.
 - [ ] Smoke test field types: currency, percent, rating, url, email, phone, longText, multiSelect.
+  - PR: pending
+  - Merge commit: pending
+  - Development MD: `docs/development/multitable-feishu-rc-field-types-ui-smoke-design-20260507.md`
+  - Verification MD: `docs/development/multitable-feishu-rc-field-types-ui-smoke-verification-20260507.md`
+  - Verification summary: runner coverage is implemented and local static checks pass; final staging pass is blocked because 142 `8081` is not serving the main app and 142 `8082` is running an older backend image that rejects MF2 field types at create-field validation.
 - [x] Smoke test conditional formatting persistence and reload.
   - PR: pending
   - Merge commit: pending

--- a/scripts/verify-multitable-live-smoke.mjs
+++ b/scripts/verify-multitable-live-smoke.mjs
@@ -44,6 +44,75 @@ function exactTextRegex(value) {
   return new RegExp(`^\\s*${String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*$`)
 }
 
+const fieldTypeSmokeSpecs = [
+  {
+    key: 'currency',
+    idPart: 'currency',
+    label: 'Currency',
+    type: 'currency',
+    property: { code: 'CNY', decimals: 2 },
+    value: 1234.56,
+  },
+  {
+    key: 'percent',
+    idPart: 'percent',
+    label: 'Percent',
+    type: 'percent',
+    property: { decimals: 1 },
+    value: 37.5,
+  },
+  {
+    key: 'rating',
+    idPart: 'rating',
+    label: 'Rating',
+    type: 'rating',
+    property: { max: 5 },
+    value: 4,
+  },
+  {
+    key: 'url',
+    idPart: 'url',
+    label: 'URL',
+    type: 'url',
+    value: 'https://example.com/multitable-rc',
+  },
+  {
+    key: 'email',
+    idPart: 'email',
+    label: 'Email',
+    type: 'email',
+    value: 'rc-field-types@example.com',
+  },
+  {
+    key: 'phone',
+    idPart: 'phone',
+    label: 'Phone',
+    type: 'phone',
+    value: '+86 138 0000 0000',
+  },
+  {
+    key: 'longText',
+    idPart: 'long_text',
+    label: 'Long Text',
+    type: 'longText',
+    value: 'Line one field smoke\nLine two field smoke',
+  },
+  {
+    key: 'multiSelect',
+    idPart: 'multi_select',
+    label: 'Multi Select',
+    type: 'multiSelect',
+    property: {
+      options: [
+        { value: 'Alpha', color: '#3b82f6' },
+        { value: 'Beta', color: '#22c55e' },
+        { value: 'Gamma', color: '#f59e0b' },
+      ],
+    },
+    value: ['Alpha', 'Gamma'],
+  },
+]
+
 function formFieldByLabel(page, fieldName) {
   return page.locator('.meta-form-view__field').filter({
     has: page.locator('.meta-form-view__label').filter({ hasText: exactTextRegex(fieldName) }),
@@ -347,6 +416,26 @@ async function createField(token, input) {
   })
   const json = await ensureOk('api.multitable.create-field', result, { sheetId: input.sheetId, fieldId: input.id, name: input.name, type: input.type })
   return json.data.field
+}
+
+async function createFieldTypeSmokeFields(token, sheetId, titlePrefix) {
+  const stamp = Date.now()
+  const fields = []
+  for (const spec of fieldTypeSmokeSpecs) {
+    const field = await createField(token, {
+      id: `fld_pilot_${spec.idPart}_${stamp}`,
+      sheetId,
+      name: `${spec.label} ${titlePrefix}`,
+      type: spec.type,
+      ...(spec.property ? { property: spec.property } : {}),
+    })
+    fields.push({ ...spec, field })
+  }
+  return fields
+}
+
+function fieldTypeSmokePatchValues(specs) {
+  return Object.fromEntries(specs.map((spec) => [spec.field.id, spec.value]))
 }
 
 async function updateField(token, fieldId, input) {
@@ -2353,6 +2442,124 @@ async function verifyGridHydration(page, { baseId, sheetId, viewId, searchValue,
   record('ui.grid.search-hydration', true, { searchValue, attachmentName, personDisplay })
 }
 
+function fieldCell(row, fieldName) {
+  const safeName = String(fieldName).replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+  return row.locator(`.meta-grid__cell[aria-label="${safeName}"]`).first()
+}
+
+function hasSameArrayValues(actual, expected) {
+  return Array.isArray(actual)
+    && actual.length === expected.length
+    && expected.every((value, index) => actual[index] === value)
+}
+
+function apiFieldValueMatches(actual, expected) {
+  if (Array.isArray(expected)) return hasSameArrayValues(actual, expected)
+  return actual === expected
+}
+
+async function assertFieldTypeGridRender(page, titleText, specs) {
+  const search = page.getByRole('searchbox', { name: 'Search records' })
+  await search.waitFor({ state: 'visible', timeout: timeoutMs })
+  await search.fill(titleText)
+  await page.getByText('1 rows').waitFor({ state: 'visible', timeout: timeoutMs })
+  const row = page.locator('.meta-grid__row').filter({ hasText: titleText }).first()
+  await row.waitFor({ state: 'visible', timeout: timeoutMs })
+
+  const details = {}
+  for (const spec of specs) {
+    const cell = fieldCell(row, spec.field.name)
+    await cell.waitFor({ state: 'visible', timeout: timeoutMs })
+    const text = (await cell.textContent())?.trim() ?? ''
+    details[spec.key] = { text }
+
+    if (spec.key === 'currency' && !text.includes('\u00a51,234.56')) {
+      throw new Error(`Currency cell did not render expected value: ${text}`)
+    }
+    if (spec.key === 'percent' && !text.includes('37.5%')) {
+      throw new Error(`Percent cell did not render expected value: ${text}`)
+    }
+    if (spec.key === 'rating' && !text.includes('\u2605\u2605\u2605\u2605\u2606')) {
+      throw new Error(`Rating cell did not render expected value: ${text}`)
+    }
+    if (spec.key === 'longText' && (!text.includes('Line one field smoke') || !text.includes('Line two field smoke'))) {
+      throw new Error(`Long text cell did not render both lines: ${text}`)
+    }
+    if (spec.key === 'multiSelect') {
+      const tags = (await cell.locator('.meta-cell-renderer__tag').allTextContents()).map((item) => item.trim()).filter(Boolean)
+      details[spec.key].tags = tags
+      if (!hasSameArrayValues(tags, spec.value)) {
+        throw new Error(`Multi-select cell tags mismatch: ${JSON.stringify(tags)}`)
+      }
+    }
+    if (spec.key === 'url') {
+      const href = await cell.locator('a.meta-cell-renderer__url').getAttribute('href')
+      details[spec.key].href = href
+      if (href !== spec.value || !text.includes(spec.value)) {
+        throw new Error(`URL cell anchor mismatch: ${href}`)
+      }
+    }
+    if (spec.key === 'email') {
+      const href = await cell.locator('a.meta-cell-renderer__email').getAttribute('href')
+      details[spec.key].href = href
+      if (href !== `mailto:${spec.value}` || !text.includes(spec.value)) {
+        throw new Error(`Email cell anchor mismatch: ${href}`)
+      }
+    }
+    if (spec.key === 'phone') {
+      const href = await cell.locator('a.meta-cell-renderer__phone').getAttribute('href')
+      details[spec.key].href = href
+      if (href !== 'tel:+861380000000' || !text.includes(spec.value)) {
+        throw new Error(`Phone cell anchor mismatch: ${href}`)
+      }
+    }
+  }
+
+  return details
+}
+
+async function verifyFieldTypesReloadReplay(page, {
+  token,
+  baseId,
+  sheetId,
+  viewId,
+  recordId,
+  titleText,
+  specs,
+}) {
+  const persistedRecord = await fetchRecord(token, sheetId, recordId)
+  const data = persistedRecord.record?.data ?? {}
+  const apiMismatches = specs
+    .filter((spec) => !apiFieldValueMatches(data[spec.field.id], spec.value))
+    .map((spec) => ({
+      key: spec.key,
+      fieldId: spec.field.id,
+      actual: data[spec.field.id],
+      expected: spec.value,
+    }))
+  const apiOk = apiMismatches.length === 0
+  record('api.field-types.value-normalization', apiOk, {
+    recordId,
+    fieldIds: specs.map((spec) => spec.field.id),
+    apiMismatches,
+  })
+  if (!apiOk) {
+    throw new Error(`Field type API value mismatch: ${JSON.stringify(apiMismatches)}`)
+  }
+
+  await page.goto(multitableUrl(baseId, sheetId, viewId), { waitUntil: 'domcontentloaded', timeout: timeoutMs })
+  const initialRender = await assertFieldTypeGridRender(page, titleText, specs)
+  await page.reload({ waitUntil: 'domcontentloaded', timeout: timeoutMs })
+  const reloadedRender = await assertFieldTypeGridRender(page, titleText, specs)
+  await page.screenshot({ path: path.join(outputDir, 'field-types-reloaded.png'), fullPage: true })
+  record('ui.field-types.reload-replay', true, {
+    recordId,
+    fields: specs.map((spec) => ({ key: spec.key, fieldId: spec.field.id, type: spec.type })),
+    initialRender,
+    reloadedRender,
+  })
+}
+
 async function fetchViewById(token, sheetId, viewId) {
   const views = await fetchViews(token, sheetId)
   const view = views.find((item) => item.id === viewId)
@@ -3481,6 +3688,8 @@ async function run() {
       type: 'number',
     })
     cleanupFieldIds.add(scoreField.id)
+    const fieldTypeSmokeFields = await createFieldTypeSmokeFields(token, sheet.id, titlePrefix)
+    for (const spec of fieldTypeSmokeFields) cleanupFieldIds.add(spec.field.id)
     const tempField = await createField(token, {
       id: `fld_pilot_temp_attach_${Date.now()}`,
       sheetId: sheet.id,
@@ -3674,6 +3883,7 @@ async function run() {
           [startField.id]: '2026-03-10',
           [endField.id]: '2026-03-11',
           [scoreField.id]: 95,
+          ...fieldTypeSmokePatchValues(fieldTypeSmokeFields),
         },
       })
       await patchFields(token, {
@@ -3700,6 +3910,16 @@ async function run() {
         titleText: importedTitle,
         attachmentName: attachmentNames[0],
         personDisplay: personChoice.display || personChoice.id,
+      })
+
+      await verifyFieldTypesReloadReplay(page, {
+        token,
+        baseId: base.id,
+        sheetId: sheet.id,
+        viewId: gridView.id,
+        recordId,
+        titleText: importedTitle,
+        specs: fieldTypeSmokeFields,
       })
 
       await verifyFilterBuilderTypedControlsReplay(page, {


### PR DESCRIPTION
## Summary
- extend `scripts/verify-multitable-live-smoke.mjs` with eight field-type smoke checks for currency, percent, rating, url, email, phone, longText, and multiSelect
- validate API value normalization before asserting grid rendering
- reload the grid and assert rendered numeric text, links, phone href, long text, and multi-select tags
- add design/verification MDs and leave the RC TODO unchecked until a current 142 target passes the smoke

## Verification
- `pnpm install --frozen-lockfile --ignore-scripts`
- `node --check scripts/verify-multitable-live-smoke.mjs`
- `node --test scripts/verify-multitable-live-smoke.test.mjs`
- `git diff --check`

## 142 result
- `8081`: blocked before runner start; no main app container is serving the entrypoint.
- `8082`: auth token validated, but smoke fails at first field-type create because deployed backend image `ghcr.io/zensgit/metasheet2-backend:62a75f9809-itemresults` predates MF2 field types and rejects `currency`.

This PR adds executable coverage. The TODO remains open until the selected 142 smoke target is upgraded and `api.field-types.value-normalization` plus `ui.field-types.reload-replay` pass.