### PR TITLE
test(multitable): harden field types smoke closeout

### DIFF
--- a/docs/development/multitable-feishu-rc-field-types-ui-smoke-design-20260507.md
+++ b/docs/development/multitable-feishu-rc-field-types-ui-smoke-design-20260507.md
@@ -49,6 +49,12 @@ The check records:
 
 The screenshot `field-types-reloaded.png` is written to the run output directory for manual review when needed.
 
+### Runner Hardening
+
+The phone href expectation is derived from the smoke value with the same digit sanitization used by the renderer. This avoids brittle hand-written `tel:` constants.
+
+The import mapping reconcile setup actively maps the target field with `ensureImportFieldMappedByColumnIndex()` before mutating field metadata. This keeps the existing reconcile smoke stable when the import preview field list grows with temporary field-type columns.
+
 ## Non-Goals
 
 - No editor interaction coverage for these fields.

--- a/docs/development/multitable-feishu-rc-field-types-ui-smoke-verification-20260507.md
+++ b/docs/development/multitable-feishu-rc-field-types-ui-smoke-verification-20260507.md
@@ -22,6 +22,13 @@ Result:
 - `node --test scripts/verify-multitable-live-smoke.test.mjs`: `1/1` pass
 - `git diff --check`: pass
 
+## Follow-up Runner Hardening
+
+Two runner-only issues were fixed after the first successful deployment of `#1379` to 8081:
+
+- Phone link assertion now derives the expected `tel:` href with the same digit sanitization as `MetaCellRenderer.vue`, instead of using a hand-written constant.
+- Import mapping reconcile now uses `ensureImportFieldMappedByColumnIndex()` so the runner actively maps the target field when the import preview does not auto-select quickly enough.
+
 ## 142 Staging Smoke
 
 ### Attempt 1 - 8081 Main Entry
@@ -43,7 +50,7 @@ Result:
 
 - Overall: blocked before runner start
 - Failure: backend not reachable at `http://142.171.239.56:8081`
-- Remote evidence: `metasheet-142` has no main app container exposing `8081`; `127.0.0.1:8081` returns connection refused from the host.
+- Remote evidence at that moment: `127.0.0.1:8081` returned connection refused from the host. Later recheck showed this was deploy-target churn, not a durable topology fact.
 
 ### Attempt 2 - 8082 Staging Entry
 
@@ -82,18 +89,90 @@ Cleanup evidence:
 - Temporary fields created before the failure were deleted by the runner cleanup path.
 - No field-type temporary fields were created on 8082 because the first `currency` create failed.
 
+### Attempt 3 - 8081 Main After #1379 Deploy
+
+GitHub Actions run `25472158432` deployed main `e6f6547a158361042a42788701d8debef8e1d725` to 8081 successfully.
+
+Remote target evidence:
+
+- Repo: `/home/mainuser/metasheet2` at `e6f6547`
+- `IMAGE_TAG=e6f6547a158361042a42788701d8debef8e1d725`
+- `metasheet-web`: `ghcr.io/zensgit/metasheet2-web:e6f6547a158361042a42788701d8debef8e1d725`
+- `metasheet-backend`: `ghcr.io/zensgit/metasheet2-backend:e6f6547a158361042a42788701d8debef8e1d725`
+- `/api/health`: pass
+- `/api/auth/me`: pass with a short-lived admin JWT generated inside the running backend container; token value was not printed or committed.
+
+Command shape, with token redacted:
+
+```bash
+AUTH_TOKEN="<redacted>" \
+API_BASE=http://142.171.239.56:8081 \
+WEB_BASE=http://142.171.239.56:8081 \
+OUTPUT_ROOT=output/playwright/multitable-feishu-rc-field-types-smoke/20260506-192330 \
+ENSURE_PLAYWRIGHT=false \
+HEADLESS=true \
+TIMEOUT_MS=45000 \
+pnpm verify:multitable-pilot:staging
+```
+
+Result:
+
+- Overall: fail due runner assertion, not product behavior
+- Failure: `Phone cell anchor mismatch: tel:+8613800000000`
+- Finding: the frontend correctly sanitizes `+86 138 0000 0000` to `tel:+8613800000000`; the runner expected a hand-written href with one fewer `0`.
+
+### Attempt 4 - 8081 Main After Runner Hardening
+
+Command shape, with token redacted:
+
+```bash
+AUTH_TOKEN="<redacted>" \
+API_BASE=http://142.171.239.56:8081 \
+WEB_BASE=http://142.171.239.56:8081 \
+OUTPUT_ROOT=output/playwright/multitable-feishu-rc-field-types-smoke/20260506-193219 \
+ENSURE_PLAYWRIGHT=false \
+HEADLESS=true \
+TIMEOUT_MS=45000 \
+pnpm verify:multitable-pilot:staging
+```
+
+Result:
+
+- Overall: pass
+- Total checks: `159/159`
+- Report JSON: `output/playwright/multitable-feishu-rc-field-types-smoke/20260506-193219/report.json`
+- Report MD: `output/playwright/multitable-feishu-rc-field-types-smoke/20260506-193219/report.md`
+- Finished at: `2026-05-07T02:35:37.033Z`
+
+New check evidence:
+
+- `api.field-types.value-normalization`: pass
+  - Covered field types: `currency`, `percent`, `rating`, `url`, `email`, `phone`, `longText`, `multiSelect`
+  - `apiMismatches`: `[]`
+- `ui.field-types.reload-replay`: pass
+  - Initial and reloaded render both showed:
+    - currency: `¥1,234.56`
+    - percent: `37.5%`
+    - rating: `★★★★☆`
+    - url href: `https://example.com/multitable-rc`
+    - email href: `mailto:rc-field-types@example.com`
+    - phone href: `tel:+8613800000000`
+    - longText: both lines
+    - multiSelect tags: `Alpha`, `Gamma`
+
+Cleanup evidence:
+
+- Temporary imported records were deleted.
+- Temporary attachment was deleted.
+- Temporary field-type fields were deleted.
+- Existing view `filterInfo` and `config` restoration completed as part of the full smoke.
+
 ## Conclusion
 
-The runner change is locally valid, but the final 142 staging smoke cannot be marked complete until a 142 target is running a backend build that includes MF2 field types.
-
-Required next gate:
-
-1. Deploy current `main` or a verified image containing MF2 field types to the selected 142 smoke target.
-2. Re-run the same `pnpm verify:multitable-pilot:staging` command.
-3. Mark the RC TODO item complete only after `api.field-types.value-normalization` and `ui.field-types.reload-replay` pass.
+The field-type smoke item is now closed against 142 main/8081. The 8082 staging stack remains intentionally out of scope because it is still on the older `62a75f9809-itemresults` image and migration lineage.
 
 ## TODO Linkage
 
-This verification adds executable coverage for this RC TODO item, but does not close it until the staging target is upgraded and the smoke passes:
+This verification closes this RC TODO item:
 
 - `Smoke test field types: currency, percent, rating, url, email, phone, longText, multiSelect.`

--- a/docs/development/multitable-feishu-rc-todo-20260430.md
+++ b/docs/development/multitable-feishu-rc-todo-20260430.md
@@ -84,12 +84,12 @@ Do not mark an item done if:
   - Development MD: `docs/development/multitable-feishu-rc-xlsx-ui-smoke-design-20260506.md`
   - Verification MD: `docs/development/multitable-feishu-rc-xlsx-ui-smoke-verification-20260506.md`
   - Verification summary: `AUTH_TOKEN=... API_BASE=http://142.171.239.56:8081 WEB_BASE=http://142.171.239.56:8081 pnpm verify:multitable-pilot:staging` passed `130/130` checks; new `ui.xlsx.import-file` and `ui.xlsx.export-download` checks passed with a real `.xlsx` file and parsed download.
-- [ ] Smoke test field types: currency, percent, rating, url, email, phone, longText, multiSelect.
-  - PR: pending
-  - Merge commit: pending
+- [x] Smoke test field types: currency, percent, rating, url, email, phone, longText, multiSelect.
+  - PR: #1379 + #1384
+  - Merge commit: `e6f6547a1` + #1384 pending
   - Development MD: `docs/development/multitable-feishu-rc-field-types-ui-smoke-design-20260507.md`
   - Verification MD: `docs/development/multitable-feishu-rc-field-types-ui-smoke-verification-20260507.md`
-  - Verification summary: runner coverage is implemented and local static checks pass; final staging pass is blocked because 142 `8081` is not serving the main app and 142 `8082` is running an older backend image that rejects MF2 field types at create-field validation.
+  - Verification summary: `AUTH_TOKEN=... API_BASE=http://142.171.239.56:8081 WEB_BASE=http://142.171.239.56:8081 pnpm verify:multitable-pilot:staging` passed `159/159` checks against main `e6f6547a158361042a42788701d8debef8e1d725`; new `api.field-types.value-normalization` and `ui.field-types.reload-replay` checks covered all 8 field types.
 - [x] Smoke test conditional formatting persistence and reload.
   - PR: pending
   - Merge commit: pending

--- a/scripts/verify-multitable-live-smoke.mjs
+++ b/scripts/verify-multitable-live-smoke.mjs
@@ -2007,10 +2007,11 @@ async function verifyImportMappingReconcile(page, {
   await page.getByRole('button', { name: 'Preview' }).click()
 
   const fieldSelect = page.locator('.meta-import__field-select').first()
-  await page.waitForFunction(({ selector, targetValue }) => {
-    const element = document.querySelector(selector)
-    return element instanceof HTMLSelectElement && element.value === targetValue
-  }, { selector: '.meta-import__field-select', targetValue: fieldId }, { timeout: timeoutMs })
+  await ensureImportFieldMappedByColumnIndex(page, {
+    columnIndex: 0,
+    fieldId,
+    label: 'import mapping reconcile initial mapping',
+  })
 
   await updateField(token, fieldId, { name: renamedFieldName })
 
@@ -2458,6 +2459,10 @@ function apiFieldValueMatches(actual, expected) {
   return actual === expected
 }
 
+function phoneHrefFor(value) {
+  return `tel:${String(value).replace(/[^+\d]/g, '')}`
+}
+
 async function assertFieldTypeGridRender(page, titleText, specs) {
   const search = page.getByRole('searchbox', { name: 'Search records' })
   await search.waitFor({ state: 'visible', timeout: timeoutMs })
@@ -2509,7 +2514,7 @@ async function assertFieldTypeGridRender(page, titleText, specs) {
     if (spec.key === 'phone') {
       const href = await cell.locator('a.meta-cell-renderer__phone').getAttribute('href')
       details[spec.key].href = href
-      if (href !== 'tel:+861380000000' || !text.includes(spec.value)) {
+      if (href !== phoneHrefFor(spec.value) || !text.includes(spec.value)) {
         throw new Error(`Phone cell anchor mismatch: ${href}`)
       }
     }


### PR DESCRIPTION
## Summary
- derive the phone `tel:` href expectation from the smoke value instead of a brittle constant
- make import mapping reconcile actively select the target field before schema mutation
- update field-type smoke docs with the successful 142 main/8081 run
- mark the field-type RC TODO closed with 159/159 staging checks

## Verification
- `node --check scripts/verify-multitable-live-smoke.mjs`
- `node --test scripts/verify-multitable-live-smoke.test.mjs`
- `git diff --check`
- `AUTH_TOKEN=<redacted> API_BASE=http://142.171.239.56:8081 WEB_BASE=http://142.171.239.56:8081 OUTPUT_ROOT=output/playwright/multitable-feishu-rc-field-types-smoke/20260506-193219 ENSURE_PLAYWRIGHT=false HEADLESS=true TIMEOUT_MS=45000 pnpm verify:multitable-pilot:staging`

142 result: PASS, 159/159 checks. New checks `api.field-types.value-normalization` and `ui.field-types.reload-replay` both passed against `e6f6547a158361042a42788701d8debef8e1d725`.