### PR TITLE
fix(integration): persist disabled K3 SQL channel

### DIFF
--- a/apps/web/src/services/integration/k3WiseSetup.ts
+++ b/apps/web/src/services/integration/k3WiseSetup.ts
@@ -1053,6 +1053,21 @@ export function buildK3WiseSetupPayloads(form: K3WiseSetupForm): K3WiseSetupPayl
   }
 
   if (!form.sqlEnabled) {
+    const sqlSystemId = optionalString(form.sqlSystemId)
+    if (sqlSystemId) {
+      return {
+        webApi,
+        sqlServer: {
+          tenantId: trim(form.tenantId),
+          workspaceId,
+          id: sqlSystemId,
+          name: optionalString(form.sqlName) ?? 'K3 WISE SQL Server',
+          kind: SQLSERVER_KIND,
+          role: 'bidirectional',
+          status: 'inactive',
+        },
+      }
+    }
     return { webApi, sqlServer: null }
   }
 

--- a/apps/web/tests/k3WiseSetup.spec.ts
+++ b/apps/web/tests/k3WiseSetup.spec.ts
@@ -99,6 +99,57 @@ describe('K3 WISE setup helpers', () => {
     expect(payloads.webApi).not.toHaveProperty('credentials')
   })
 
+  it('persists disabling an existing SQL Server channel without clearing stored config', () => {
+    const form = createDefaultK3WiseSetupForm()
+    Object.assign(form, {
+      tenantId: 'tenant_1',
+      workspaceId: 'workspace_1',
+      webApiSystemId: 'webapi_1',
+      webApiHasCredentials: true,
+      version: 'K3 WISE 15.x test',
+      baseUrl: 'https://k3.example.test/K3API/',
+      acctId: '',
+      username: '',
+      password: '',
+      sqlEnabled: false,
+      sqlSystemId: 'sql_1',
+      sqlName: 'K3 WISE SQL Server',
+      sqlHasCredentials: true,
+    })
+
+    expect(validateK3WiseSetupForm(form)).toEqual([])
+    const payloads = buildK3WiseSetupPayloads(form)
+
+    expect(payloads.sqlServer).toEqual({
+      tenantId: 'tenant_1',
+      workspaceId: 'workspace_1',
+      id: 'sql_1',
+      name: 'K3 WISE SQL Server',
+      kind: 'erp:k3-wise-sqlserver',
+      role: 'bidirectional',
+      status: 'inactive',
+    })
+  })
+
+  it('does not create a SQL Server system when disabled and no prior system exists', () => {
+    const form = createDefaultK3WiseSetupForm()
+    Object.assign(form, {
+      tenantId: 'tenant_1',
+      webApiSystemId: 'webapi_1',
+      webApiHasCredentials: true,
+      version: 'K3 WISE 15.x test',
+      baseUrl: 'https://k3.example.test/K3API/',
+      acctId: '',
+      username: '',
+      password: '',
+      sqlEnabled: false,
+      sqlSystemId: '',
+    })
+
+    expect(validateK3WiseSetupForm(form)).toEqual([])
+    expect(buildK3WiseSetupPayloads(form).sqlServer).toBeNull()
+  })
+
   it('loads public external-system config without exposing credentials', () => {
     const form = createDefaultK3WiseSetupForm()
     const system: IntegrationExternalSystem = {

--- a/docs/development/k3wise-sql-disable-persist-design-20260507.md
+++ b/docs/development/k3wise-sql-disable-persist-design-20260507.md
@@ -1,0 +1,21 @@
+# K3 WISE SQL Disable Persist Design - 2026-05-07
+
+## Context
+
+The K3 WISE setup page lets operators disable the SQL Server channel. Before this change, `buildK3WiseSetupPayloads()` returned `sqlServer: null` whenever `sqlEnabled` was false.
+
+That is correct for a brand-new setup with no SQL Server external system. It is wrong for an existing setup: saving the form after switching SQL off did not persist any state change to the registry, so the existing `erp:k3-wise-sqlserver` row could remain `active`.
+
+## Change
+
+- If SQL is disabled and no `sqlSystemId` exists, keep returning `sqlServer: null`.
+- If SQL is disabled and `sqlSystemId` exists, return a minimal SQL Server payload with `status: inactive`.
+- The inactive payload deliberately omits `config`, `credentials`, and `capabilities` so the backend preserves existing connection details without exposing or clearing secrets.
+
+## Scope
+
+This is a helper-level fix on top of the K3 WISE setup UI stack. The existing save flow already upserts `payloads.sqlServer` when it is present, so no view change is required.
+
+## Impact
+
+Operators can turn off an existing SQL Server channel from the UI and have that choice reflected in `integration_external_systems`.

--- a/docs/development/k3wise-sql-disable-persist-verification-20260507.md
+++ b/docs/development/k3wise-sql-disable-persist-verification-20260507.md
@@ -1,0 +1,27 @@
+# K3 WISE SQL Disable Persist Verification - 2026-05-07
+
+## Verification Plan
+
+1. Run the focused K3 WISE setup helper tests.
+2. Confirm SQL disabled with an existing system emits an inactive update payload.
+3. Confirm SQL disabled without an existing system still emits `null`.
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/k3WiseSetup.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+```
+
+## Expected Result
+
+- Existing SQL system disabled -> minimal `erp:k3-wise-sqlserver` payload with `status: inactive`.
+- New setup with SQL disabled -> `sqlServer: null`.
+- Existing helper behavior remains green.
+
+## Result
+
+Passed locally on 2026-05-07.
+
+- `pnpm --filter @metasheet/web exec vitest run tests/k3WiseSetup.spec.ts --watch=false` passed: 1 test file, 30 tests.
+- `pnpm --filter @metasheet/web build` passed.


### PR DESCRIPTION
## Summary
- when an existing K3 WISE SQL Server channel is switched off, emit a minimal inactive external-system payload
- keep disabled-without-existing-system behavior as `sqlServer: null`
- add design and verification docs

## Verification
- pnpm --filter @metasheet/web exec vitest run tests/k3WiseSetup.spec.ts --watch=false
- pnpm --filter @metasheet/web build

## Stacking
Stacked on #1364 / `codex/k3wise-gate-middle-table-validation-20260506`, which is stacked on #1305 K3 WISE setup UI.