### PR TITLE
test(integration): add ERP PLM deploy readiness gate

### DIFF
--- a/docs/development/integration-erp-plm-deploy-readiness-design-20260507.md
+++ b/docs/development/integration-erp-plm-deploy-readiness-design-20260507.md
@@ -1,0 +1,54 @@
+# Integration ERP/PLM Deploy Readiness Design - 2026-05-07
+
+## Context
+
+The PLM -> MetaSheet cleanse -> K3 WISE work has enough backend and UI slices to start internal staging tests, but the current implementation is spread across many small PRs and one UI stack:
+
+- Mainline hardening PRs against `main`.
+- K3 WISE setup UI stack: `#1305 -> #1364 -> #1392`.
+- Existing local gates: offline K3 WISE PoC, plugin integration-core tests, K3 setup helper tests, frontend build.
+
+Without a single readiness check, staging prep becomes a manual spreadsheet exercise and it is easy to deploy an incomplete stack.
+
+## Change
+
+Add `scripts/ops/integration-erp-plm-deploy-readiness.mjs`.
+
+The script:
+
+- Checks required mainline hardening PRs are present, open, based on `main`, clean, and have no failed/pending checks.
+- Checks the K3 WISE UI stack is continuous from `main` through `#1305`, `#1364`, and `#1392`.
+- Emits text, markdown, or JSON reports.
+- Supports offline `--input-json` fixtures for deterministic tests.
+- Supports `--require-approvals` for stricter release governance, but does not require approval by default because internal staging can run before human approval if CI is clean.
+- Treats `mergeStateStatus=BLOCKED` as an approval/branch-protection warning by default, not a code-readiness failure; `BEHIND`, `DIRTY`, failed checks, and pending checks still block internal staging.
+
+Package shortcut:
+
+```bash
+pnpm run verify:integration-erp-plm:deploy-readiness
+```
+
+## Scope
+
+This is an ops/readiness gate only. It does not merge PRs, deploy services, access customer credentials, or call real PLM/K3 WISE systems.
+
+## Internal Staging Definition
+
+The script reports `candidate-ready` only when:
+
+1. Required mainline hardening PRs are clean.
+2. The K3 WISE UI stack is continuous and clean.
+
+After that, the composed staging branch still needs local gates:
+
+```bash
+pnpm run verify:integration-k3wise:poc
+pnpm -F plugin-integration-core test
+pnpm --filter @metasheet/web exec vitest run tests/k3WiseSetup.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+```
+
+## Customer Live Definition
+
+Customer live remains blocked until the customer GATE answers, test account set, network route, and rollback plan exist. The script makes that explicit with `customerLive=blocked-until-customer-gate-and-test-account`.

--- a/docs/development/integration-erp-plm-deploy-readiness-verification-20260507.md
+++ b/docs/development/integration-erp-plm-deploy-readiness-verification-20260507.md
@@ -1,0 +1,38 @@
+# Integration ERP/PLM Deploy Readiness Verification - 2026-05-07
+
+## Verification Plan
+
+1. Run deterministic unit tests for the readiness evaluator.
+2. Run the live GitHub readiness command.
+3. Render a markdown readiness report into `artifacts/`.
+
+## Commands
+
+```bash
+node --test scripts/ops/integration-erp-plm-deploy-readiness.test.mjs
+pnpm run verify:integration-erp-plm:deploy-readiness -- --format text
+pnpm run verify:integration-erp-plm:deploy-readiness -- --format markdown --output artifacts/integration-erp-plm-deploy-readiness.md
+```
+
+## Expected Result
+
+- Unit tests pass.
+- Live readiness command returns pass when the required PRs are clean.
+- Markdown report includes mainline hardening, K3 WISE UI stack, and local gates.
+
+## Result
+
+Completed locally on 2026-05-07.
+
+- `node --test scripts/ops/integration-erp-plm-deploy-readiness.test.mjs` passed: 8 tests.
+- `pnpm run verify:integration-erp-plm:deploy-readiness -- --format text` returned FAIL by design against live GitHub state because several required PRs are `BEHIND`.
+- `pnpm run verify:integration-erp-plm:deploy-readiness -- --format markdown --output artifacts/integration-erp-plm-deploy-readiness.md` rendered a markdown report.
+
+Live readiness result at verification time:
+
+- Mainline PASS: `#1391`, `#1390`, `#1389`, `#1388`.
+- Mainline blocked by stale base: `#1387`, `#1386`, `#1385`, `#1383`, `#1382`, `#1381`, `#1380`.
+- UI stack blocked by stale base: `#1305`.
+- UI stack continuity PASS: `#1364`, `#1392`.
+
+This means internal staging is not yet candidate-ready until stale PR bases are updated/re-run or a composed staging branch is built and verified with the listed local gates.

--- a/docs/development/integration-erp-plm-smoke-command-index-20260507.md
+++ b/docs/development/integration-erp-plm-smoke-command-index-20260507.md
@@ -1,0 +1,41 @@
+# Integration ERP/PLM Smoke Command Index - 2026-05-07
+
+This page keeps the K3 WISE / PLM test commands in one place so internal staging and customer PoC are not mixed up.
+
+## Internal Readiness
+
+| Command | Writes Files | Calls Customer PLM/K3 | PASS Means |
+|---|---:|---:|---|
+| `pnpm run verify:integration-erp-plm:deploy-readiness` | no, unless `--output` is set | no | Required PRs are clean enough to compose an internal staging candidate |
+| `pnpm run verify:integration-k3wise:poc` | no | no | Offline preflight/evidence/mock K3 chain is healthy |
+| `pnpm -F plugin-integration-core test` | no | no | Plugin runtime, adapters, runner, dead-letter, feedback, and migration structure pass |
+| `pnpm --filter @metasheet/web exec vitest run tests/k3WiseSetup.spec.ts --watch=false` | no | no | K3 setup helper payloads and GATE JSON helpers pass |
+| `pnpm --filter @metasheet/web build` | `apps/web/dist` | no | Frontend compiles with the K3 setup UI |
+
+## Live PoC Packet Preparation
+
+| Command | Writes Files | Calls Customer PLM/K3 | PASS Means |
+|---|---:|---:|---|
+| `node scripts/ops/integration-k3wise-live-poc-preflight.mjs --input <gate.json> --out-dir artifacts/integration-live-poc` | yes | no | Customer GATE answers are complete, non-production, Save-only, and redaction-safe |
+| `node scripts/ops/integration-k3wise-live-poc-evidence.mjs --packet <packet.json> --evidence <evidence.json> --out-dir artifacts/integration-live-poc/evidence` | yes | no | Filled live evidence is PASS/PARTIAL/FAIL with secret checks |
+
+## Postdeploy Smoke
+
+| Command | Writes Files | Calls Customer PLM/K3 | PASS Means |
+|---|---:|---:|---|
+| `node scripts/ops/integration-k3wise-postdeploy-smoke.mjs --base-url "$METASHEET_BASE_URL" --token-file "$METASHEET_AUTH_TOKEN_FILE" --tenant-id "$METASHEET_TENANT_ID" --require-auth --out-dir <dir>` | yes | no | Deployed MetaSheet can serve health, auth, integration control-plane, K3 setup route, and staging descriptor contract |
+| `node scripts/ops/integration-k3wise-postdeploy-summary.mjs --input <smoke.json> --require-auth-signoff` | yes | no | Converts smoke JSON into an internal-trial signoff summary |
+
+## Customer Live Boundary
+
+None of the commands above proves customer PLM/K3 connectivity until the customer provides:
+
+- K3 WISE version and test account set.
+- K3 WebAPI/K3API URL and network route.
+- PLM access method and sample material/BOM data.
+- Field mapping list for material and BOM.
+- SQL Server access scope and middle-table/stored-procedure decision.
+- Save/Submit/Audit policy.
+- Rollback owner and test-data cleanup SOP.
+
+Until then, the correct status is: internal staging can be prepared, customer live is blocked.

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "profile:multitable-grid:staging": "RUNNER_SCRIPT=scripts/profile-multitable-grid.mjs RUN_LABEL=multitable-grid-profile-staging RUN_MODE=staging RUNNER_REPORT_BASENAME=staging-report AUTO_START_SERVICES=false REQUIRE_RUNNING_SERVICES=true bash scripts/ops/multitable-pilot-local.sh",
     "verify:multitable-grid-profile:summary": "node scripts/ops/multitable-grid-profile-summary.mjs",
     "verify:integration-k3wise:poc": "node --test scripts/ops/integration-k3wise-live-poc-preflight.test.mjs && node --test scripts/ops/integration-k3wise-live-poc-evidence.test.mjs && node scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs",
+    "verify:integration-erp-plm:deploy-readiness": "node scripts/ops/integration-erp-plm-deploy-readiness.mjs",
     "phase5:run-all": "bash scripts/phase5-run-all.sh",
     "build": "pnpm -r build",
     "test": "pnpm -r test",

--- a/scripts/ops/integration-erp-plm-deploy-readiness.mjs
+++ b/scripts/ops/integration-erp-plm-deploy-readiness.mjs
@@ -1,0 +1,406 @@
+#!/usr/bin/env node
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+import {
+  evaluatePr,
+  readPrFromGh,
+} from './check-pr-mainline-readiness.mjs'
+import {
+  evaluateStack,
+} from './check-pr-stack-readiness.mjs'
+
+const DEFAULT_MAINLINE_PRS = [
+  { number: 1391, label: 'PLM disabled import route guard' },
+  { number: 1390, label: 'dead-letter replay mark write guard' },
+  { number: 1389, label: 'DB read where shape guard' },
+  { number: 1388, label: 'external-system update default preservation' },
+  { number: 1387, label: 'PLM input normalization' },
+  { number: 1386, label: 'HTTP adapter relative path guard' },
+  { number: 1385, label: 'HTTP adapter pagination/query guard' },
+  { number: 1383, label: 'runner target write counter guard' },
+  { number: 1382, label: 'K3 PoC secret text guard' },
+  { number: 1381, label: 'testConnection result redaction' },
+  { number: 1380, label: 'K3 SQL read/write allowlist split' },
+]
+
+const DEFAULT_UI_STACK = [
+  { number: 1305, label: 'K3 WISE GATE readiness UI' },
+  { number: 1364, label: 'K3 GATE middle-table validation' },
+  { number: 1392, label: 'K3 SQL disabled-channel persistence' },
+]
+
+const REQUIRED_LOCAL_GATES = [
+  {
+    id: 'offline-poc',
+    command: 'pnpm run verify:integration-k3wise:poc',
+    purpose: 'Run preflight tests, evidence tests, and the mock PLM/K3 WISE PoC chain.',
+  },
+  {
+    id: 'plugin-core',
+    command: 'pnpm -F plugin-integration-core test',
+    purpose: 'Verify plugin runtime, adapters, runner, dead-letter, feedback, and migration structure.',
+  },
+  {
+    id: 'k3-setup-unit',
+    command: 'pnpm --filter @metasheet/web exec vitest run tests/k3WiseSetup.spec.ts --watch=false',
+    purpose: 'Verify K3 WISE setup helper payloads and GATE form behavior.',
+  },
+  {
+    id: 'web-build',
+    command: 'pnpm --filter @metasheet/web build',
+    purpose: 'Verify the K3 WISE setup UI compiles in the frontend package.',
+  },
+]
+
+export function parseArgs(argv) {
+  const config = {
+    format: 'text',
+    inputJson: null,
+    output: null,
+    requireApprovals: false,
+    mainlineBase: 'main',
+    uiRootBase: 'main',
+  }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === '--format') {
+      config.format = requireValue(argv, index, arg)
+      index += 1
+    } else if (arg === '--input-json') {
+      config.inputJson = requireValue(argv, index, arg)
+      index += 1
+    } else if (arg === '--output') {
+      config.output = requireValue(argv, index, arg)
+      index += 1
+    } else if (arg === '--require-approvals') {
+      config.requireApprovals = true
+    } else if (arg === '--mainline-base') {
+      config.mainlineBase = requireValue(argv, index, arg)
+      index += 1
+    } else if (arg === '--ui-root-base') {
+      config.uiRootBase = requireValue(argv, index, arg)
+      index += 1
+    } else if (arg === '--help' || arg === '-h') {
+      config.help = true
+    } else {
+      throw new Error(`Unknown argument: ${arg}`)
+    }
+  }
+
+  if (!['json', 'markdown', 'text'].includes(config.format)) {
+    throw new Error('--format must be one of: text, markdown, json')
+  }
+
+  return config
+}
+
+function requireValue(argv, index, arg) {
+  const value = argv[index + 1]
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${arg} requires a value`)
+  }
+  return value
+}
+
+function attachLabel(result, label) {
+  return { ...result, label }
+}
+
+function applyInternalStagingPolicy(result, requireApprovals) {
+  if (requireApprovals || result.mergeStateStatus !== 'BLOCKED') return result
+  const blockedReason = 'mergeStateStatus is BLOCKED, expected CLEAN'
+  if (!result.reasons.includes(blockedReason)) return result
+  return {
+    ...result,
+    ok: result.reasons.length === 1,
+    reasons: result.reasons.filter((reason) => reason !== blockedReason),
+    warnings: [
+      ...result.warnings,
+      'mergeStateStatus is BLOCKED; allowed for internal staging when approval is not required',
+    ],
+  }
+}
+
+function applyApprovalPolicy(result, requireApprovals) {
+  if (!requireApprovals) return result
+  if (result.reviewDecision !== 'APPROVED') {
+    return {
+      ...result,
+      ok: false,
+      reasons: [
+        ...result.reasons,
+        `reviewDecision is ${result.reviewDecision || 'empty'}, expected APPROVED`,
+      ],
+    }
+  }
+  return result
+}
+
+export function normalizeInputPayload(payload) {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    throw new Error('Input JSON must be an object with mainlinePrs and uiStackPrs arrays')
+  }
+  return {
+    mainlinePrs: Array.isArray(payload.mainlinePrs) ? payload.mainlinePrs : [],
+    uiStackPrs: Array.isArray(payload.uiStackPrs) ? payload.uiStackPrs : [],
+  }
+}
+
+export function evaluateDeployReadiness(payload, options = {}) {
+  const requireApprovals = options.requireApprovals === true
+  const mainlineBase = options.mainlineBase ?? 'main'
+  const uiRootBase = options.uiRootBase ?? 'main'
+
+  const mainlineResults = DEFAULT_MAINLINE_PRS.map((item) => {
+    const pr = payload.mainlinePrs.find((candidate) => Number(candidate.number) === item.number)
+    if (!pr) {
+      return {
+        number: item.number,
+        title: '',
+        url: '',
+        state: '',
+        baseRefName: '',
+        headRefName: '',
+        mergeStateStatus: '',
+        reviewDecision: '',
+        ok: false,
+        label: item.label,
+        reasons: ['PR data missing'],
+        warnings: [],
+        checks: [],
+      }
+    }
+    return attachLabel(
+      applyApprovalPolicy(
+        applyInternalStagingPolicy(evaluatePr(pr, { expectedBase: mainlineBase }), requireApprovals),
+        requireApprovals,
+      ),
+      item.label,
+    )
+  })
+
+  const uiPrs = DEFAULT_UI_STACK.map((item) => payload.uiStackPrs.find((candidate) => Number(candidate.number) === item.number))
+  const missingUi = uiPrs
+    .map((pr, index) => pr ? null : DEFAULT_UI_STACK[index])
+    .filter(Boolean)
+  const stackSummary = missingUi.length > 0
+    ? {
+        ok: false,
+        rootBase: uiRootBase,
+        checkedAt: new Date().toISOString(),
+        count: DEFAULT_UI_STACK.length,
+        results: DEFAULT_UI_STACK.map((item) => ({
+          number: item.number,
+          title: '',
+          url: '',
+          state: '',
+          baseRefName: '',
+          headRefName: '',
+          mergeStateStatus: '',
+          reviewDecision: '',
+          ok: false,
+          label: item.label,
+          expectedBase: item.number === DEFAULT_UI_STACK[0].number ? uiRootBase : 'previous stack head',
+          position: DEFAULT_UI_STACK.findIndex((candidate) => candidate.number === item.number) + 1,
+          reasons: missingUi.some((missing) => missing.number === item.number) ? ['PR data missing'] : [],
+          warnings: [],
+          checks: [],
+        })),
+      }
+    : evaluateStack(uiPrs, { rootBase: uiRootBase })
+
+  const uiResults = stackSummary.results.map((result) => {
+    const item = DEFAULT_UI_STACK.find((candidate) => candidate.number === result.number)
+    return attachLabel(
+      applyApprovalPolicy(applyInternalStagingPolicy(result, requireApprovals), requireApprovals),
+      item?.label ?? '',
+    )
+  })
+  const uiOk = uiResults.every((result) => result.ok)
+  const mainlineOk = mainlineResults.every((result) => result.ok)
+
+  return {
+    ok: mainlineOk && uiOk,
+    checkedAt: new Date().toISOString(),
+    requireApprovals,
+    mainlineBase,
+    uiRootBase,
+    mainline: {
+      ok: mainlineOk,
+      required: DEFAULT_MAINLINE_PRS,
+      results: mainlineResults,
+    },
+    uiStack: {
+      ok: uiOk,
+      required: DEFAULT_UI_STACK,
+      results: uiResults,
+    },
+    localGates: REQUIRED_LOCAL_GATES,
+    deployMode: {
+      internalStaging: mainlineOk && uiOk ? 'candidate-ready' : 'blocked',
+      customerLive: 'blocked-until-customer-gate-and-test-account',
+    },
+  }
+}
+
+function readPayloadFromJson(filePath) {
+  return normalizeInputPayload(JSON.parse(readFileSync(filePath, 'utf8')))
+}
+
+function readPayloadFromGh() {
+  return {
+    mainlinePrs: DEFAULT_MAINLINE_PRS.map((item) => readPrFromGh(item.number)),
+    uiStackPrs: DEFAULT_UI_STACK.map((item) => readPrFromGh(item.number)),
+  }
+}
+
+export function renderText(summary) {
+  const lines = [
+    `ERP/PLM deploy readiness: ${summary.ok ? 'PASS' : 'FAIL'}`,
+    `Internal staging: ${summary.deployMode.internalStaging}`,
+    `Customer live: ${summary.deployMode.customerLive}`,
+    `Require approvals: ${summary.requireApprovals ? 'yes' : 'no'}`,
+    '',
+    `Mainline hardening: ${summary.mainline.ok ? 'PASS' : 'FAIL'}`,
+  ]
+
+  for (const result of summary.mainline.results) {
+    lines.push(`- #${result.number} ${result.ok ? 'PASS' : 'FAIL'} ${result.label}${result.reasons.length ? ` (${result.reasons.join('; ')})` : ''}`)
+  }
+
+  lines.push('')
+  lines.push(`K3 WISE UI stack: ${summary.uiStack.ok ? 'PASS' : 'FAIL'}`)
+  for (const result of summary.uiStack.results) {
+    lines.push(`- #${result.number} ${result.ok ? 'PASS' : 'FAIL'} ${result.label}${result.reasons.length ? ` (${result.reasons.join('; ')})` : ''}`)
+  }
+
+  lines.push('')
+  lines.push('Local gates to run on the composed staging branch:')
+  for (const gate of summary.localGates) {
+    lines.push(`- ${gate.command}`)
+  }
+
+  return `${lines.join('\n')}\n`
+}
+
+export function renderMarkdown(summary) {
+  const lines = [
+    '# ERP/PLM Deploy Readiness',
+    '',
+    `Overall: **${summary.ok ? 'PASS' : 'FAIL'}**`,
+    '',
+    `Internal staging: \`${summary.deployMode.internalStaging}\``,
+    '',
+    `Customer live: \`${summary.deployMode.customerLive}\``,
+    '',
+    `Require approvals: \`${summary.requireApprovals ? 'yes' : 'no'}\``,
+    '',
+    '## Mainline Hardening',
+    '',
+    '| PR | Label | Status | Base | Head | Reasons |',
+    '| --- | --- | --- | --- | --- | --- |',
+  ]
+
+  for (const result of summary.mainline.results) {
+    lines.push([
+      result.url ? `[#${result.number}](${result.url})` : `#${result.number}`,
+      escapePipe(result.label),
+      result.ok ? 'PASS' : 'FAIL',
+      `\`${result.baseRefName || 'unknown'}\``,
+      `\`${result.headRefName || 'unknown'}\``,
+      result.reasons.length ? result.reasons.map(escapePipe).join('<br>') : '-',
+    ].join(' | '))
+  }
+
+  lines.push('')
+  lines.push('## K3 WISE UI Stack')
+  lines.push('')
+  lines.push('| Pos | PR | Label | Status | Base | Expected Base | Head | Reasons |')
+  lines.push('| --- | --- | --- | --- | --- | --- | --- | --- |')
+  for (const result of summary.uiStack.results) {
+    lines.push([
+      result.position,
+      result.url ? `[#${result.number}](${result.url})` : `#${result.number}`,
+      escapePipe(result.label),
+      result.ok ? 'PASS' : 'FAIL',
+      `\`${result.baseRefName || 'unknown'}\``,
+      `\`${result.expectedBase || 'unknown'}\``,
+      `\`${result.headRefName || 'unknown'}\``,
+      result.reasons.length ? result.reasons.map(escapePipe).join('<br>') : '-',
+    ].join(' | '))
+  }
+
+  lines.push('')
+  lines.push('## Local Gates')
+  lines.push('')
+  for (const gate of summary.localGates) {
+    lines.push(`- \`${gate.command}\` - ${gate.purpose}`)
+  }
+  lines.push('')
+
+  return `${lines.join('\n')}`
+}
+
+function escapePipe(value) {
+  return String(value).replaceAll('|', '\\|')
+}
+
+export function renderSummary(summary, format) {
+  if (format === 'json') return `${JSON.stringify(summary, null, 2)}\n`
+  if (format === 'markdown') return renderMarkdown(summary)
+  return renderText(summary)
+}
+
+function printHelp() {
+  console.log(`Usage:
+  node scripts/ops/integration-erp-plm-deploy-readiness.mjs [options]
+
+Options:
+  --format <format>       text, markdown, or json. Default: text
+  --input-json <path>     Read offline PR payload instead of calling gh
+  --output <path>         Write rendered result to a file
+  --require-approvals     Treat non-approved PRs as blocking
+  --mainline-base <base>  Expected base for mainline hardening PRs. Default: main
+  --ui-root-base <base>   Expected base for the first UI stack PR. Default: main
+
+Input JSON shape:
+  { "mainlinePrs": [<gh pr json>], "uiStackPrs": [<gh pr json>] }
+`)
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const config = parseArgs(argv)
+  if (config.help) {
+    printHelp()
+    return 0
+  }
+
+  const payload = config.inputJson ? readPayloadFromJson(config.inputJson) : readPayloadFromGh()
+  const summary = evaluateDeployReadiness(payload, {
+    requireApprovals: config.requireApprovals,
+    mainlineBase: config.mainlineBase,
+    uiRootBase: config.uiRootBase,
+  })
+  const rendered = renderSummary(summary, config.format)
+
+  if (config.output) {
+    mkdirSync(path.dirname(config.output), { recursive: true })
+    writeFileSync(config.output, rendered, 'utf8')
+  } else {
+    process.stdout.write(rendered)
+  }
+
+  return summary.ok ? 0 : 1
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    process.exitCode = main()
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exitCode = 1
+  }
+}

--- a/scripts/ops/integration-erp-plm-deploy-readiness.test.mjs
+++ b/scripts/ops/integration-erp-plm-deploy-readiness.test.mjs
@@ -1,0 +1,158 @@
+import assert from 'node:assert/strict'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+
+import {
+  evaluateDeployReadiness,
+  main,
+  parseArgs,
+  renderMarkdown,
+} from './integration-erp-plm-deploy-readiness.mjs'
+
+const MAINLINE_NUMBERS = [1391, 1390, 1389, 1388, 1387, 1386, 1385, 1383, 1382, 1381, 1380]
+const UI_STACK = [
+  { number: 1305, base: 'main', head: 'codex/erp-plm-config-workbench-20260505' },
+  { number: 1364, base: 'codex/erp-plm-config-workbench-20260505', head: 'codex/k3wise-gate-middle-table-validation-20260506' },
+  { number: 1392, base: 'codex/k3wise-gate-middle-table-validation-20260506', head: 'codex/k3wise-sql-disable-persist-20260507' },
+]
+
+function pr(number, baseRefName, headRefName, overrides = {}) {
+  return {
+    number,
+    title: `PR ${number}`,
+    state: 'OPEN',
+    baseRefName,
+    headRefName,
+    mergeStateStatus: 'CLEAN',
+    reviewDecision: '',
+    statusCheckRollup: [
+      { name: 'pr-validate', conclusion: 'SUCCESS', status: 'COMPLETED' },
+    ],
+    url: `https://github.com/zensgit/metasheet2/pull/${number}`,
+    ...overrides,
+  }
+}
+
+function cleanPayload() {
+  return {
+    mainlinePrs: MAINLINE_NUMBERS.map((number) => pr(number, 'main', `codex/pr-${number}`)),
+    uiStackPrs: UI_STACK.map((item) => pr(item.number, item.base, item.head)),
+  }
+}
+
+test('parseArgs accepts output, offline input, and approval policy', () => {
+  assert.deepEqual(parseArgs([
+    '--format',
+    'markdown',
+    '--input-json',
+    'prs.json',
+    '--output',
+    'readiness.md',
+    '--require-approvals',
+    '--mainline-base',
+    'release',
+    '--ui-root-base',
+    'staging',
+  ]), {
+    format: 'markdown',
+    inputJson: 'prs.json',
+    output: 'readiness.md',
+    requireApprovals: true,
+    mainlineBase: 'release',
+    uiRootBase: 'staging',
+  })
+})
+
+test('evaluateDeployReadiness passes clean mainline PRs and continuous UI stack', () => {
+  const summary = evaluateDeployReadiness(cleanPayload())
+
+  assert.equal(summary.ok, true)
+  assert.equal(summary.deployMode.internalStaging, 'candidate-ready')
+  assert.equal(summary.deployMode.customerLive, 'blocked-until-customer-gate-and-test-account')
+  assert.equal(summary.mainline.results.length, MAINLINE_NUMBERS.length)
+  assert.deepEqual(summary.uiStack.results.map((result) => result.expectedBase), [
+    'main',
+    'codex/erp-plm-config-workbench-20260505',
+    'codex/k3wise-gate-middle-table-validation-20260506',
+  ])
+})
+
+test('evaluateDeployReadiness fails when a required mainline PR is missing', () => {
+  const payload = cleanPayload()
+  payload.mainlinePrs = payload.mainlinePrs.filter((item) => item.number !== 1388)
+
+  const summary = evaluateDeployReadiness(payload)
+
+  assert.equal(summary.ok, false)
+  assert.equal(summary.deployMode.internalStaging, 'blocked')
+  const missing = summary.mainline.results.find((item) => item.number === 1388)
+  assert.deepEqual(missing.reasons, ['PR data missing'])
+})
+
+test('evaluateDeployReadiness fails when the UI stack continuity breaks', () => {
+  const payload = cleanPayload()
+  payload.uiStackPrs[2] = pr(1392, 'main', 'codex/k3wise-sql-disable-persist-20260507')
+
+  const summary = evaluateDeployReadiness(payload)
+
+  assert.equal(summary.ok, false)
+  const broken = summary.uiStack.results.find((item) => item.number === 1392)
+  assert.deepEqual(broken.reasons, [
+    'base is main, expected codex/k3wise-gate-middle-table-validation-20260506',
+  ])
+})
+
+test('require approvals turns review warnings into blocking reasons', () => {
+  const summary = evaluateDeployReadiness(cleanPayload(), { requireApprovals: true })
+
+  assert.equal(summary.ok, false)
+  assert.match(summary.mainline.results[0].reasons.join('\n'), /expected APPROVED/)
+})
+
+test('BLOCKED merge state is allowed for internal staging but not approval-required release', () => {
+  const payload = cleanPayload()
+  payload.mainlinePrs[0] = pr(1391, 'main', 'codex/pr-1391', { mergeStateStatus: 'BLOCKED' })
+
+  const internal = evaluateDeployReadiness(payload)
+  assert.equal(internal.ok, true)
+  assert.equal(internal.mainline.results[0].ok, true)
+  assert.match(internal.mainline.results[0].warnings.join('\n'), /allowed for internal staging/)
+
+  const release = evaluateDeployReadiness(payload, { requireApprovals: true })
+  assert.equal(release.ok, false)
+  assert.match(release.mainline.results[0].reasons.join('\n'), /BLOCKED/)
+})
+
+test('renderMarkdown includes PR sections and local gates', () => {
+  const markdown = renderMarkdown(evaluateDeployReadiness(cleanPayload()))
+
+  assert.match(markdown, /## Mainline Hardening/)
+  assert.match(markdown, /## K3 WISE UI Stack/)
+  assert.match(markdown, /pnpm run verify:integration-k3wise:poc/)
+})
+
+test('main renders markdown from offline JSON', () => {
+  const tmpDir = mkdtempSync(path.join(tmpdir(), 'erp-plm-readiness-'))
+  const input = path.join(tmpDir, 'payload.json')
+  const output = path.join(tmpDir, 'readiness.md')
+
+  try {
+    writeFileSync(input, JSON.stringify(cleanPayload(), null, 2), 'utf8')
+
+    const exitCode = main([
+      '--input-json',
+      input,
+      '--format',
+      'markdown',
+      '--output',
+      output,
+    ])
+
+    assert.equal(exitCode, 0)
+    assert.match(readFileSync(output, 'utf8'), /Overall: \*\*PASS\*\*/)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary
- add `integration-erp-plm-deploy-readiness.mjs` to evaluate ERP/PLM internal staging readiness across required mainline PRs and the K3 WISE UI stack
- add offline unit coverage for missing PRs, stale stack continuity, approval policy, and markdown output
- add a smoke command index and design/verification docs

## Verification
- node --test scripts/ops/integration-erp-plm-deploy-readiness.test.mjs
- pnpm run verify:integration-erp-plm:deploy-readiness -- --format text (expected live FAIL while stale-base PRs remain BEHIND)
- pnpm run verify:integration-erp-plm:deploy-readiness -- --format markdown --output artifacts/integration-erp-plm-deploy-readiness.md