### PR TITLE
feat(integration): show K3 deploy readiness checklist

### DIFF
--- a/apps/web/src/services/integration/k3WiseSetup.ts
+++ b/apps/web/src/services/integration/k3WiseSetup.ts
@@ -211,6 +211,27 @@ export interface K3WiseSetupValidationIssue {
   message: string
 }
 
+export type K3WiseDeployGateStatus = 'ready' | 'missing' | 'warning' | 'external'
+
+export interface K3WiseDeployGateItem {
+  id: string
+  label: string
+  status: K3WiseDeployGateStatus
+  message: string
+  field?: keyof K3WiseSetupForm
+}
+
+export interface K3WiseDeployGateSummary {
+  ready: number
+  missing: number
+  warning: number
+  external: number
+  canSaveConfiguration: boolean
+  canCreatePipelines: boolean
+  canRunDryRun: boolean
+  canRunLive: boolean
+}
+
 const WEBAPI_KIND = 'erp:k3-wise-webapi'
 const SQLSERVER_KIND = 'erp:k3-wise-sqlserver'
 
@@ -448,6 +469,179 @@ export function validateK3WisePipelineObservationForm(
     })
   }
   return issues
+}
+
+function gateItem(
+  id: string,
+  label: string,
+  status: K3WiseDeployGateStatus,
+  message: string,
+  field?: keyof K3WiseSetupForm,
+): K3WiseDeployGateItem {
+  return field ? { id, label, status, message, field } : { id, label, status, message }
+}
+
+export function buildK3WiseDeployGateChecklist(form: K3WiseSetupForm): K3WiseDeployGateItem[] {
+  const webApiCredentialTouched = Boolean(trim(form.username) || trim(form.password) || trim(form.acctId))
+  const webApiCredentialsReady = form.webApiHasCredentials && !webApiCredentialTouched
+    ? true
+    : Boolean(trim(form.acctId) && trim(form.username) && trim(form.password))
+  const webApiConfigReady = Boolean(trim(form.tenantId) && trim(form.version) && trim(form.baseUrl) && trim(form.loginPath))
+  const stagingReady = Boolean(trim(form.tenantId) && trim(form.projectId))
+  const pipelineTemplateReady = Boolean(trim(form.sourceSystemId) && trim(form.webApiSystemId) && trim(form.materialStagingObjectId) && trim(form.bomStagingObjectId))
+  const materialDryRunReady = Boolean(trim(form.materialPipelineId))
+  const bomDryRunReady = Boolean(trim(form.bomPipelineId))
+  const sqlAllowedTables = splitList(form.sqlAllowedTables)
+  const sqlMiddleTables = splitList(form.sqlMiddleTables)
+  const sqlStoredProcedures = splitList(form.sqlStoredProcedures)
+
+  const items: K3WiseDeployGateItem[] = [
+    gateItem(
+      'tenant-scope',
+      '租户作用域',
+      trim(form.tenantId) ? 'ready' : 'missing',
+      trim(form.tenantId)
+        ? 'Tenant 已可用于保存 K3 WISE 外部系统配置'
+        : '部署后可在页面填写 tenantId；缺 tenantId 时不能保存配置',
+      'tenantId',
+    ),
+    gateItem(
+      'webapi',
+      'K3 WISE WebAPI',
+      webApiConfigReady ? 'ready' : 'missing',
+      webApiConfigReady
+        ? '版本、环境、Base URL 和接口路径已具备'
+        : '部署后可在页面填写 K3 WISE 版本、环境、WebAPI Base URL 和相对接口路径',
+      webApiConfigReady ? undefined : 'baseUrl',
+    ),
+    gateItem(
+      'webapi-credentials',
+      'WebAPI 账套与凭据',
+      webApiCredentialsReady ? 'ready' : 'missing',
+      webApiCredentialsReady
+        ? form.webApiHasCredentials && !webApiCredentialTouched
+          ? '已保存凭据会保留，页面不会回显密码'
+          : 'Acct ID、用户名和密码已可用于保存或替换凭据'
+        : '部署后可在页面填写 acctId、用户名和密码；密码只会提交保存，不会回显',
+      webApiCredentialsReady ? undefined : 'acctId',
+    ),
+    gateItem(
+      'submit-audit-policy',
+      'Submit / Audit 策略',
+      form.environment === 'production' && (form.autoSubmit || form.autoAudit) ? 'missing' : 'ready',
+      form.environment === 'production' && (form.autoSubmit || form.autoAudit)
+        ? '生产环境自动 Submit/Audit 需要单独审批策略；当前页面会阻止保存'
+        : form.autoSubmit || form.autoAudit
+          ? '非生产环境可保存自动 Submit/Audit 策略'
+          : '当前为 save-only 策略，可先做低风险联调',
+      'autoSubmit',
+    ),
+    gateItem(
+      'sql-channel',
+      'SQL Server 通道',
+      form.sqlEnabled
+        ? trim(form.sqlServer) && trim(form.sqlDatabase) && sqlAllowedTables.length > 0
+          ? 'ready'
+          : 'missing'
+        : 'warning',
+      form.sqlEnabled
+        ? trim(form.sqlServer) && trim(form.sqlDatabase) && sqlAllowedTables.length > 0
+          ? 'SQL Server 主机、数据库和读取白名单已填写'
+          : '启用 SQL Server 后必须填写 Server、Database 和允许读取表'
+        : '可先做 WebAPI-only / dry-run；读取 K3 表或中间表回写前需启用并填写 SQL 通道',
+      form.sqlEnabled ? 'sqlServer' : 'sqlEnabled',
+    ),
+    gateItem(
+      'sql-write-path',
+      'SQL 写入边界',
+      !form.sqlEnabled || form.sqlMode === 'readonly'
+        ? 'ready'
+        : form.sqlMode === 'middle-table'
+          ? sqlMiddleTables.length > 0 ? 'ready' : 'missing'
+          : sqlStoredProcedures.length > 0 ? 'ready' : 'missing',
+      !form.sqlEnabled || form.sqlMode === 'readonly'
+        ? '当前不会通过 SQL 通道写入 K3'
+        : form.sqlMode === 'middle-table'
+          ? sqlMiddleTables.length > 0
+            ? 'middle-table 模式已有中间表写入目标'
+            : 'middle-table 模式必须填写中间表，避免误把 K3 核心表当写入目标'
+          : sqlStoredProcedures.length > 0
+            ? 'stored-procedure 模式已有可调用存储过程'
+            : 'stored-procedure 模式必须填写允许调用的存储过程',
+      form.sqlMode === 'middle-table' ? 'sqlMiddleTables' : 'sqlStoredProcedures',
+    ),
+    gateItem(
+      'plm-source',
+      'PLM Source System',
+      trim(form.sourceSystemId) ? 'ready' : 'external',
+      trim(form.sourceSystemId)
+        ? '已选择或粘贴 PLM source system ID，可创建清洗 pipeline'
+        : '当前页面只粘贴 sourceSystemId；第三方 PLM 连接本身仍需先通过 integration API/种子/后续 PLM UI 创建',
+      'sourceSystemId',
+    ),
+    gateItem(
+      'staging',
+      'Staging 多维表',
+      stagingReady ? 'ready' : 'missing',
+      stagingReady
+        ? '可在页面安装或确认 staging 多维表'
+        : '部署后可在页面填写 projectId，再点击安装 staging 多维表',
+      stagingReady ? undefined : 'projectId',
+    ),
+    gateItem(
+      'pipeline-template',
+      '清洗 Pipeline 模板',
+      pipelineTemplateReady ? 'ready' : 'missing',
+      pipelineTemplateReady
+        ? 'PLM source、K3 target 和 staging 对象已具备，可创建 draft pipeline'
+        : '需先保存 K3 WebAPI、准备 PLM source system，并选择物料/BOM staging 对象',
+      pipelineTemplateReady ? undefined : 'sourceSystemId',
+    ),
+    gateItem(
+      'pipeline-dry-run',
+      'Pipeline Dry-run',
+      materialDryRunReady && bomDryRunReady ? 'ready' : 'missing',
+      materialDryRunReady && bomDryRunReady
+        ? '物料与 BOM pipeline ID 已具备，可在页面发起 dry-run'
+        : '创建 pipeline 后页面会回填 pipeline ID；缺 ID 时不能 dry-run',
+      materialDryRunReady ? 'bomPipelineId' : 'materialPipelineId',
+    ),
+    gateItem(
+      'pipeline-live-run',
+      'Pipeline 真实执行',
+      form.allowLivePipelineRun ? 'warning' : 'ready',
+      form.allowLivePipelineRun
+        ? '已允许真实执行；实体机测试前需确认客户账套、回滚人与审批策略'
+        : '默认只允许 dry-run；真实执行需显式勾选',
+      'allowLivePipelineRun',
+    ),
+  ]
+
+  return items
+}
+
+export function summarizeK3WiseDeployGateChecklist(items: K3WiseDeployGateItem[]): K3WiseDeployGateSummary {
+  const summary = items.reduce(
+    (acc, item) => {
+      acc[item.status] += 1
+      return acc
+    },
+    { ready: 0, missing: 0, warning: 0, external: 0 },
+  )
+  const getStatus = (id: string): K3WiseDeployGateStatus | undefined => items.find((item) => item.id === id)?.status
+  const canSaveConfiguration = ['tenant-scope', 'webapi', 'webapi-credentials', 'submit-audit-policy', 'sql-channel', 'sql-write-path']
+    .every((id) => getStatus(id) === 'ready' || getStatus(id) === 'warning')
+  const canCreatePipelines = canSaveConfiguration && ['plm-source', 'staging', 'pipeline-template']
+    .every((id) => getStatus(id) === 'ready')
+  const canRunDryRun = canCreatePipelines && getStatus('pipeline-dry-run') === 'ready'
+  const canRunLive = canRunDryRun && getStatus('pipeline-live-run') === 'warning'
+  return {
+    ...summary,
+    canSaveConfiguration,
+    canCreatePipelines,
+    canRunDryRun,
+    canRunLive,
+  }
 }
 
 export function buildK3WiseStagingInstallPayload(form: K3WiseSetupForm): K3WiseStagingInstallPayload {

--- a/apps/web/src/views/IntegrationK3WiseSetupView.vue
+++ b/apps/web/src/views/IntegrationK3WiseSetupView.vue
@@ -22,6 +22,28 @@
       <aside class="k3-setup__rail">
         <div class="k3-setup__panel">
           <div class="k3-setup__panel-head">
+            <h2>部署测试准备</h2>
+            <span>{{ deployGateSummary.ready }}/{{ deployGateChecklist.length }} ready</span>
+          </div>
+          <div class="k3-setup__gate-summary">
+            <span class="k3-setup__badge" data-status="succeeded">ready {{ deployGateSummary.ready }}</span>
+            <span v-if="deployGateSummary.missing" class="k3-setup__badge" data-status="failed">missing {{ deployGateSummary.missing }}</span>
+            <span v-if="deployGateSummary.external" class="k3-setup__badge" data-status="open">external {{ deployGateSummary.external }}</span>
+            <span v-if="deployGateSummary.warning" class="k3-setup__badge" data-status="partial">warning {{ deployGateSummary.warning }}</span>
+          </div>
+          <div class="k3-setup__gate-list">
+            <div v-for="item in deployGateChecklist" :key="item.id" class="k3-setup__gate-item">
+              <div class="k3-setup__record-main">
+                <strong>{{ item.label }}</strong>
+                <span class="k3-setup__badge" :data-status="formatDeployGateStatus(item.status)">{{ item.status }}</span>
+              </div>
+              <small>{{ item.message }}</small>
+            </div>
+          </div>
+        </div>
+
+        <div class="k3-setup__panel">
+          <div class="k3-setup__panel-head">
             <h2>已保存系统</h2>
             <span>{{ webApiSystems.length + sqlSystems.length }}</span>
           </div>
@@ -497,6 +519,7 @@ import {
   K3_WISE_SQLSERVER_KIND,
   K3_WISE_WEBAPI_KIND,
   applyExternalSystemToForm,
+  buildK3WiseDeployGateChecklist,
   buildK3WisePipelineObservationQuery,
   buildK3WisePipelinePayloads,
   buildK3WisePipelineRunPayload,
@@ -512,6 +535,7 @@ import {
   listIntegrationStagingDescriptors,
   listIntegrationSystems,
   runIntegrationPipeline,
+  summarizeK3WiseDeployGateChecklist,
   testIntegrationSystem,
   upsertIntegrationPipeline,
   upsertIntegrationSystem,
@@ -556,6 +580,8 @@ const stagingIssues = computed(() => validateK3WiseStagingInstallForm(form))
 const pipelineIssues = computed(() => validateK3WisePipelineTemplateForm(form, stagingDescriptors.value))
 const materialRunIssues = computed(() => validateK3WisePipelineRunForm(form, 'material'))
 const bomRunIssues = computed(() => validateK3WisePipelineRunForm(form, 'bom'))
+const deployGateChecklist = computed(() => buildK3WiseDeployGateChecklist(form))
+const deployGateSummary = computed(() => summarizeK3WiseDeployGateChecklist(deployGateChecklist.value))
 const observationSummary = computed(() => `${pipelineRuns.value.length} runs / ${deadLetters.value.length} open`)
 const stagingDescriptorLabel = computed(() => stagingDescriptors.value.length > 0 ? `${stagingDescriptors.value.length} descriptors` : 'not loaded')
 
@@ -577,6 +603,13 @@ function formatTimestamp(value: string): string {
 
 function formatRunMetrics(run: IntegrationPipelineRun): string {
   return `read ${run.rowsRead} / clean ${run.rowsCleaned} / write ${run.rowsWritten} / failed ${run.rowsFailed}`
+}
+
+function formatDeployGateStatus(status: string): string {
+  if (status === 'ready') return 'succeeded'
+  if (status === 'missing') return 'failed'
+  if (status === 'warning') return 'partial'
+  return 'open'
 }
 
 function loadSystemIntoForm(system: IntegrationExternalSystem): void {
@@ -1038,6 +1071,39 @@ onMounted(() => {
   flex-direction: column;
   gap: 8px;
   margin-top: 10px;
+}
+
+.k3-setup__gate-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.k3-setup__gate-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-height: 420px;
+  overflow: auto;
+}
+
+.k3-setup__gate-item {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  padding: 10px;
+  background: #f8fafc;
+}
+
+.k3-setup__gate-item small {
+  color: #64748b;
+  font-size: 12px;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
 }
 
 .k3-setup__descriptor {

--- a/apps/web/tests/k3WiseSetup.spec.ts
+++ b/apps/web/tests/k3WiseSetup.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { readFile } from 'node:fs/promises'
 import {
   applyExternalSystemToForm,
+  buildK3WiseDeployGateChecklist,
   buildK3WisePipelineObservationQuery,
   buildK3WisePipelinePayloads,
   buildK3WisePipelineRunPayload,
@@ -12,6 +13,7 @@ import {
   getIntegrationStagingFieldCount,
   getK3WisePipelineId,
   splitList,
+  summarizeK3WiseDeployGateChecklist,
   validateK3WisePipelineObservationForm,
   validateK3WisePipelineTemplateForm,
   validateK3WisePipelineRunForm,
@@ -424,5 +426,88 @@ describe('K3 WISE setup helpers', () => {
     expect(messages).toContain('tenantId is required')
     expect(messages).toContain('BOM pipeline ID is required before loading run history')
     expect(() => buildK3WisePipelineObservationQuery(form, 'bom')).toThrow('tenantId is required')
+  })
+
+  it('summarizes deploy readiness fields that can be filled after deployment', () => {
+    const form = createDefaultK3WiseSetupForm()
+    Object.assign(form, {
+      tenantId: 'tenant_1',
+      version: 'K3 WISE 15.x test',
+      baseUrl: 'https://k3.example.test/K3API/',
+      acctId: 'AIS_TEST',
+      username: 'k3-user',
+      password: 'secret',
+    })
+
+    const checklist = buildK3WiseDeployGateChecklist(form)
+    const summary = summarizeK3WiseDeployGateChecklist(checklist)
+    const byId = Object.fromEntries(checklist.map((item) => [item.id, item]))
+
+    expect(byId.webapi?.status).toBe('ready')
+    expect(byId['webapi-credentials']?.status).toBe('ready')
+    expect(byId['sql-channel']?.status).toBe('warning')
+    expect(byId['plm-source']?.status).toBe('external')
+    expect(byId.staging?.status).toBe('missing')
+    expect(summary).toMatchObject({
+      external: 1,
+      canSaveConfiguration: true,
+      canCreatePipelines: false,
+      canRunDryRun: false,
+      canRunLive: false,
+    })
+  })
+
+  it('marks internal dry-run ready only after source, target, staging, and pipeline ids exist', () => {
+    const form = createDefaultK3WiseSetupForm()
+    Object.assign(form, {
+      tenantId: 'tenant_1',
+      workspaceId: 'workspace_1',
+      projectId: 'project_1',
+      webApiSystemId: 'k3_1',
+      webApiHasCredentials: true,
+      version: 'K3 WISE 15.x test',
+      baseUrl: 'https://k3.example.test/K3API/',
+      sourceSystemId: 'plm_1',
+      materialPipelineId: 'pipe_material',
+      bomPipelineId: 'pipe_bom',
+    })
+
+    const checklist = buildK3WiseDeployGateChecklist(form)
+    const summary = summarizeK3WiseDeployGateChecklist(checklist)
+    const byId = Object.fromEntries(checklist.map((item) => [item.id, item]))
+
+    expect(byId['pipeline-template']?.status).toBe('ready')
+    expect(byId['pipeline-dry-run']?.status).toBe('ready')
+    expect(byId['pipeline-live-run']?.status).toBe('ready')
+    expect(summary.canSaveConfiguration).toBe(true)
+    expect(summary.canCreatePipelines).toBe(true)
+    expect(summary.canRunDryRun).toBe(true)
+    expect(summary.canRunLive).toBe(false)
+  })
+
+  it('requires an explicit live-run opt-in before deploy checklist allows real pipeline execution', () => {
+    const form = createDefaultK3WiseSetupForm()
+    Object.assign(form, {
+      tenantId: 'tenant_1',
+      projectId: 'project_1',
+      webApiSystemId: 'k3_1',
+      webApiHasCredentials: true,
+      version: 'K3 WISE 15.x test',
+      baseUrl: 'https://k3.example.test/K3API/',
+      sourceSystemId: 'plm_1',
+      materialPipelineId: 'pipe_material',
+      bomPipelineId: 'pipe_bom',
+      allowLivePipelineRun: true,
+    })
+
+    const checklist = buildK3WiseDeployGateChecklist(form)
+    const summary = summarizeK3WiseDeployGateChecklist(checklist)
+    const liveRun = checklist.find((item) => item.id === 'pipeline-live-run')
+
+    expect(liveRun).toMatchObject({
+      status: 'warning',
+      field: 'allowLivePipelineRun',
+    })
+    expect(summary.canRunLive).toBe(true)
   })
 })

--- a/docs/development/integration-k3wise-frontend-deploy-gate-design-20260506.md
+++ b/docs/development/integration-k3wise-frontend-deploy-gate-design-20260506.md
@@ -1,0 +1,69 @@
+# K3 WISE Frontend Deploy Gate - Design
+
+Date: 2026-05-06
+Branch: `codex/erp-plm-deploy-gate-frontend-readiness-20260506`
+
+## Goal
+
+Make the K3 WISE setup page answer a practical operator question:
+
+> After deploying MetaSheet to a physical machine, which K3 WISE / ERP-PLM PoC fields can I fill in the frontend, and which items still require customer GATE input or backend/API preparation?
+
+## Scope
+
+Files changed:
+
+- `apps/web/src/services/integration/k3WiseSetup.ts`
+- `apps/web/src/views/IntegrationK3WiseSetupView.vue`
+- `apps/web/tests/k3WiseSetup.spec.ts`
+
+## Design
+
+The setup helper now exposes a pure readiness model:
+
+- `buildK3WiseDeployGateChecklist(form)`
+- `summarizeK3WiseDeployGateChecklist(items)`
+
+The checklist is intentionally frontend-only and does not call the network. It classifies the current form into four statuses:
+
+- `ready`: the page already has enough information for that step.
+- `missing`: the operator can fill this on the deployed page before continuing.
+- `warning`: the step is allowed, but needs operator attention.
+- `external`: the page can reference the value, but cannot create it by itself.
+
+The page renders this checklist in the left rail above saved systems. It gives immediate feedback for:
+
+- tenant/project scope;
+- tenant-only configuration save readiness;
+- project-scoped staging installation readiness;
+- K3 WISE WebAPI endpoint and credentials;
+- save-only versus Submit/Audit policy;
+- SQL Server read channel and write boundary;
+- PLM source system readiness;
+- staging multitable installation readiness;
+- pipeline template, dry-run, and live-run readiness.
+
+## Important Boundary
+
+Deploying the app lets an operator fill many K3 WISE fields directly in the frontend:
+
+- K3 WISE version/environment/base URL;
+- acctId, username, password;
+- Save/Submit/Audit paths;
+- optional SQL Server channel fields;
+- project/base/staging/pipeline fields;
+- dry-run/live-run toggles.
+
+It does **not** remove the customer GATE dependency. These still need customer input or backend/API/script preparation:
+
+- third-party PLM source external system creation;
+- complete customer field mapping and dictionary rules;
+- rollback/evidence owner and signoff;
+- SQL Server executor/proxy for real SQL connectivity;
+- live K3/PLM connectivity credentials and network allowlist.
+
+This keeps the UI honest: internal deployment smoke and frontend setup can proceed before the customer answers, but true live PoC PASS still waits for the customer GATE packet.
+
+## Why This Slice
+
+The backend/mock PoC path already has control-plane and postdeploy smoke scripts. The practical gap was operator visibility on the deployed page. This change lowers deployment-test friction without inventing vendor abstraction or pretending the customer GATE is solved.

--- a/docs/development/integration-k3wise-frontend-deploy-gate-verification-20260506.md
+++ b/docs/development/integration-k3wise-frontend-deploy-gate-verification-20260506.md
@@ -1,0 +1,65 @@
+# K3 WISE Frontend Deploy Gate - Verification
+
+Date: 2026-05-06
+Branch: `codex/erp-plm-deploy-gate-frontend-readiness-20260506`
+
+## Verification Plan
+
+Run the focused frontend helper tests, then build the web app:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/k3WiseSetup.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+## Expected Coverage
+
+- Existing K3 WISE WebAPI, SQL Server, staging, pipeline, dry-run, and observation payload tests remain green.
+- The new deploy checklist marks fields that can be filled after deployment as `missing` rather than external blockers.
+- PLM source creation is marked `external` when only a source system ID can be pasted.
+- Internal dry-run readiness only becomes true after source, target, staging, and pipeline IDs exist.
+- Live pipeline execution remains disabled until the operator explicitly enables it.
+
+## Results
+
+### Focused Helper Tests
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/k3WiseSetup.spec.ts --watch=false
+```
+
+Result: passed, 22/22 tests.
+
+### Frontend Build
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result: passed.
+
+Vite printed existing warnings for `WorkflowDesigner.vue` being both dynamically and statically imported, plus chunk-size warnings for large bundles. The command exited 0.
+
+### Diff Check
+
+```bash
+git diff --check
+```
+
+Result: passed.
+
+## Deployment Test Interpretation
+
+If these checks pass, the frontend is ready for an internal physical-machine setup test:
+
+1. Deploy the app.
+2. Open `/integrations/k3-wise` with a user that has `integration:write`.
+3. Fill K3 WISE WebAPI and optional SQL Server fields.
+4. Save configuration and run connection tests.
+5. Install staging multitables.
+6. Paste or seed a PLM source system ID.
+7. Create draft pipelines.
+8. Run dry-run first.
+
+Customer live PoC remains blocked until the customer GATE JSON/evidence inputs are available.


### PR DESCRIPTION
## Summary
- add a frontend-only K3 WISE deploy readiness checklist on the setup page
- distinguish fields operators can fill after deployment from external customer GATE / PLM source blockers
- add helper summary flags for save, pipeline creation, dry-run, and live-run readiness
- document design and verification results

## Verification
- pnpm --filter @metasheet/web exec vitest run tests/k3WiseSetup.spec.ts --watch=false
- pnpm --filter @metasheet/web build
- git diff --check

## Notes
This does not remove the customer GATE dependency. It makes the deployed setup page explicit about which fields can be filled in the frontend and which items still need customer/API/script preparation.