### PR TITLE
feat(multitable): harden auto number fields

### DIFF
--- a/apps/web/src/multitable/components/MetaFieldManager.vue
+++ b/apps/web/src/multitable/components/MetaFieldManager.vue
@@ -1049,7 +1049,7 @@ function currentDraftProperty(type: MetaFieldCreateType | string): Record<string
     const normalizedStart = Math.floor(start)
     return {
       prefix,
-      digits: Math.round(digits),
+      digits: Math.floor(digits),
       start: normalizedStart,
       startAt: normalizedStart,
     }

--- a/apps/web/src/multitable/components/MetaFieldManager.vue
+++ b/apps/web/src/multitable/components/MetaFieldManager.vue
@@ -290,6 +290,26 @@
           </label>
         </template>
 
+        <template v-else-if="configTargetType === 'autoNumber'">
+          <div class="meta-field-mgr__grid">
+            <label class="meta-field-mgr__field">
+              <span>Prefix</span>
+              <input v-model="autoNumberDraft.prefix" class="meta-field-mgr__input" maxlength="32" placeholder="INV-" />
+            </label>
+            <label class="meta-field-mgr__field">
+              <span>Digits</span>
+              <input v-model.number="autoNumberDraft.digits" class="meta-field-mgr__input" type="number" min="0" max="12" />
+            </label>
+            <label class="meta-field-mgr__field">
+              <span>Start at</span>
+              <input v-model.number="autoNumberDraft.start" class="meta-field-mgr__input" type="number" min="1" />
+            </label>
+          </div>
+          <div class="meta-field-mgr__hint">
+            Existing records are backfilled once when the field is created or converted.
+          </div>
+        </template>
+
         <MetaFieldValidationPanel
           v-if="configTarget && validationPanelVisible"
           class="meta-field-mgr__validation"
@@ -350,6 +370,7 @@ import {
 } from '../utils/formula-docs'
 import {
   normalizeStringArray,
+  resolveAutoNumberFieldProperty,
   resolveAttachmentFieldProperty,
   resolveCurrencyFieldProperty,
   resolveFormulaFieldProperty,
@@ -540,6 +561,11 @@ const percentDraft = reactive<{ decimals: number }>({
 const ratingDraft = reactive<{ max: number }>({
   max: 5,
 })
+const autoNumberDraft = reactive<{ prefix: string; digits: number; start: number }>({
+  prefix: '',
+  digits: 0,
+  start: 1,
+})
 const validationDraft = ref<FieldValidationRule[]>([])
 // True when the field had explicit validation rules stored OR the user
 // touched the panel. Keeps us from overwriting the engine's defaults
@@ -613,7 +639,7 @@ function onNumberDecimalsInput(event: Event) {
 function requiresConfig(type: MetaFieldCreateType): boolean {
   return [
     'select', 'multiSelect', 'link', 'person', 'lookup', 'rollup', 'formula', 'attachment',
-    'number', 'currency', 'percent', 'rating', 'longText',
+    'number', 'currency', 'percent', 'rating', 'longText', 'autoNumber',
   ].includes(type)
 }
 
@@ -646,6 +672,9 @@ function resetDrafts() {
   numberDraft.unit = ''
   percentDraft.decimals = 1
   ratingDraft.max = 5
+  autoNumberDraft.prefix = ''
+  autoNumberDraft.digits = 0
+  autoNumberDraft.start = 1
   validationDraft.value = []
   validationDraftTouched.value = false
   fieldConfigError.value = ''
@@ -715,6 +744,14 @@ function serializeFieldDraft(type: string | null): string {
   }
   if (type === 'rating') {
     return JSON.stringify({ max: ratingDraft.max })
+  }
+  if (type === 'autoNumber') {
+    return JSON.stringify({
+      prefix: autoNumberDraft.prefix.trim(),
+      digits: autoNumberDraft.digits,
+      start: autoNumberDraft.start,
+      startAt: autoNumberDraft.start,
+    })
   }
   if (type === 'string' || type === 'longText' || type === 'number') {
     return JSON.stringify({ validation })
@@ -794,6 +831,11 @@ function hydrateExistingFieldConfig(field: MetaField, options?: { liveRefreshTex
   } else if (fieldType === 'rating') {
     const property = resolveRatingFieldProperty(field.property)
     ratingDraft.max = property.max
+  } else if (fieldType === 'autoNumber') {
+    const property = resolveAutoNumberFieldProperty(field.property)
+    autoNumberDraft.prefix = property.prefix
+    autoNumberDraft.digits = property.digits
+    autoNumberDraft.start = property.start
   }
   if (VALIDATION_PANEL_TYPES.has(fieldType)) {
     const loaded = rulesFromProperty(field.property ?? null)
@@ -862,7 +904,7 @@ function openNewFieldConfigIfNeeded() {
 }
 
 function currentDraftProperty(type: MetaFieldCreateType | string): Record<string, unknown> | undefined {
-  const normalizedType = type === 'link' || type === 'select' || type === 'multiSelect' || type === 'lookup' || type === 'rollup' || type === 'formula' || type === 'attachment' || type === 'person' || type === 'number' || type === 'currency' || type === 'percent' || type === 'rating'
+  const normalizedType = type === 'link' || type === 'select' || type === 'multiSelect' || type === 'lookup' || type === 'rollup' || type === 'formula' || type === 'attachment' || type === 'person' || type === 'number' || type === 'currency' || type === 'percent' || type === 'rating' || type === 'autoNumber'
     ? type
     : null
   fieldConfigError.value = ''
@@ -987,6 +1029,30 @@ function currentDraftProperty(type: MetaFieldCreateType | string): Record<string
       return undefined
     }
     return { max: Math.round(max) }
+  }
+  if (normalizedType === 'autoNumber') {
+    const prefix = autoNumberDraft.prefix.trim()
+    if (prefix.length > 32) {
+      fieldConfigError.value = 'Auto number prefix must be 32 characters or fewer'
+      return undefined
+    }
+    const digits = Number(autoNumberDraft.digits)
+    if (!Number.isFinite(digits) || digits < 0 || digits > 12) {
+      fieldConfigError.value = 'Auto number digits must be between 0 and 12'
+      return undefined
+    }
+    const start = Number(autoNumberDraft.start)
+    if (!Number.isFinite(start) || start < 1) {
+      fieldConfigError.value = 'Auto number start must be at least 1'
+      return undefined
+    }
+    const normalizedStart = Math.floor(start)
+    return {
+      prefix,
+      digits: Math.round(digits),
+      start: normalizedStart,
+      startAt: normalizedStart,
+    }
   }
   if (type === 'string' || type === 'longText') {
     return { ...validationProperty }

--- a/apps/web/src/multitable/utils/field-config.ts
+++ b/apps/web/src/multitable/utils/field-config.ts
@@ -53,6 +53,12 @@ export type NormalizedNumberFieldProperty = {
   unit: string
 }
 
+export type NormalizedAutoNumberFieldProperty = {
+  prefix: string
+  digits: number
+  start: number
+}
+
 function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value)
     ? value as Record<string, unknown>
@@ -185,6 +191,18 @@ export function resolveNumberFieldProperty(value: unknown): NormalizedNumberFiel
     thousands: property.thousands === true,
     unit,
   }
+}
+
+export function resolveAutoNumberFieldProperty(value: unknown): NormalizedAutoNumberFieldProperty {
+  const property = asRecord(value)
+  const prefix = typeof property.prefix === 'string' ? property.prefix.trim().slice(0, 32) : ''
+  const digitsRaw = typeof property.digits === 'number' ? property.digits : Number(property.digits)
+  const digits = Number.isFinite(digitsRaw) && digitsRaw >= 0 && digitsRaw <= 12
+    ? Math.round(digitsRaw)
+    : 0
+  const startRaw = typeof property.start === 'number' ? property.start : Number(property.start ?? property.startAt)
+  const start = Number.isFinite(startRaw) && startRaw > 0 ? Math.floor(startRaw) : 1
+  return { prefix, digits, start }
 }
 
 const CURRENCY_SYMBOL_BY_CODE: Record<string, string> = {

--- a/apps/web/src/multitable/utils/field-config.ts
+++ b/apps/web/src/multitable/utils/field-config.ts
@@ -198,7 +198,7 @@ export function resolveAutoNumberFieldProperty(value: unknown): NormalizedAutoNu
   const prefix = typeof property.prefix === 'string' ? property.prefix.trim().slice(0, 32) : ''
   const digitsRaw = typeof property.digits === 'number' ? property.digits : Number(property.digits)
   const digits = Number.isFinite(digitsRaw) && digitsRaw >= 0 && digitsRaw <= 12
-    ? Math.round(digitsRaw)
+    ? Math.floor(digitsRaw)
     : 0
   const startRaw = typeof property.start === 'number' ? property.start : Number(property.start ?? property.startAt)
   const start = Number.isFinite(startRaw) && startRaw > 0 ? Math.floor(startRaw) : 1

--- a/apps/web/src/multitable/utils/field-display.ts
+++ b/apps/web/src/multitable/utils/field-display.ts
@@ -3,6 +3,7 @@ import {
   formatCurrencyValue,
   formatNumberValue,
   formatPercentValue,
+  resolveAutoNumberFieldProperty,
   resolveCurrencyFieldProperty,
   resolvePercentFieldProperty,
   resolveRatingFieldProperty,
@@ -57,6 +58,13 @@ function formatDateTime(value: unknown, timezone?: string): string {
   })
 }
 
+function formatAutoNumber(value: unknown, property: Record<string, unknown> | undefined): string {
+  const num = typeof value === 'number' ? value : Number(value)
+  if (!Number.isFinite(num)) return String(value)
+  const { prefix, digits } = resolveAutoNumberFieldProperty(property)
+  return `${prefix}${String(Math.trunc(num)).padStart(digits, '0')}`
+}
+
 function summarizeLinkCount(field: MetaField, count: number): string {
   if (count <= 0) return '—'
   if (field.property?.refKind === 'user') return count === 1 ? '1 person' : `${count} people`
@@ -103,6 +111,7 @@ export function formatFieldDisplay(params: {
   if (field.type === 'date') return formatDate(value)
   if (field.type === 'dateTime') return formatDateTime(value, resolveDateTimeTimezone(field.property))
   if (field.type === 'createdTime' || field.type === 'modifiedTime') return formatDateTime(value)
+  if (field.type === 'autoNumber') return formatAutoNumber(value, field.property)
   if (isSystemFieldType(field.type)) return String(value)
   if (field.type === 'boolean') return value ? 'Yes' : 'No'
 

--- a/apps/web/tests/multitable-system-fields.spec.ts
+++ b/apps/web/tests/multitable-system-fields.spec.ts
@@ -34,6 +34,28 @@ describe('multitable system fields', () => {
     expect(createdBy).toBe('user_1')
   })
 
+  it('formats autoNumber fields with prefix and zero padding', () => {
+    expect(formatFieldDisplay({
+      field: {
+        id: 'fld_auto',
+        name: 'No.',
+        type: 'autoNumber',
+        property: { prefix: 'INV-', digits: 4 },
+      },
+      value: 42,
+    })).toBe('INV-0042')
+
+    expect(formatFieldDisplay({
+      field: {
+        id: 'fld_auto',
+        name: 'No.',
+        type: 'autoNumber',
+        property: { prefix: '', digits: 0 },
+      },
+      value: 42,
+    })).toBe('42')
+  })
+
   it('renders system fields with the system cell branch', async () => {
     const container = document.createElement('div')
     document.body.appendChild(container)
@@ -181,7 +203,7 @@ describe('multitable system fields', () => {
     container.remove()
   })
 
-  it('creates autoNumber fields as read-only system fields', async () => {
+  it('creates autoNumber fields with generation config as read-only system fields', async () => {
     const createSpy = vi.fn()
     const container = document.createElement('div')
     document.body.appendChild(container)
@@ -212,6 +234,16 @@ describe('multitable system fields', () => {
 
     expect(container.textContent).toContain('Auto number is generated')
 
+    const configInputs = Array.from(container.querySelectorAll('.meta-field-mgr__config .meta-field-mgr__input')) as HTMLInputElement[]
+    expect(configInputs).toHaveLength(3)
+    configInputs[0].value = 'INV-'
+    configInputs[0].dispatchEvent(new Event('input', { bubbles: true }))
+    configInputs[1].value = '4'
+    configInputs[1].dispatchEvent(new Event('input', { bubbles: true }))
+    configInputs[2].value = '100'
+    configInputs[2].dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+
     ;(Array.from(container.querySelectorAll('.meta-field-mgr__btn-add')) as HTMLButtonElement[])
       .find((button) => button.textContent?.includes('+ Add'))
       ?.click()
@@ -221,6 +253,12 @@ describe('multitable system fields', () => {
       sheetId: 'sheet_1',
       name: 'No.',
       type: 'autoNumber',
+      property: {
+        prefix: 'INV-',
+        digits: 4,
+        start: 100,
+        startAt: 100,
+      },
     })
 
     app.unmount()

--- a/docs/development/multitable-auto-number-hardening-design-20260507.md
+++ b/docs/development/multitable-auto-number-hardening-design-20260507.md
@@ -83,6 +83,8 @@ New field creation backfills records missing the field key. Type conversion into
 
 The standard `RecordService.createRecord()` path now acquires the same sheet-level lock before reading fields. This prevents a create request from reading the pre-backfill schema while an `autoNumber` field is being created.
 
+The public form direct create path acquires the same lock inside its write transaction and reloads the latest fields for auto-number allocation before insert.
+
 The plugin helper path also acquires the sheet-level lock before loading fields. Callers should pass a transaction-bound query when they need the lock held across the whole write.
 
 ## Frontend Design
@@ -98,5 +100,5 @@ Display formatting is centralized in `formatFieldDisplay()`, so grid, renderer, 
 
 ## Residual Limits
 
-- Public form direct create now locks inside its write transaction, but it still loads and validates fields before that transaction. The sequence allocation itself remains atomic; the full schema-read race is best removed when public-form create is routed through `RecordService.createRecord()`.
 - XLSX import currently creates records one by one through `RecordService`; values are correct and serialized, but it does not yet reserve a single batch range for the whole import.
+- `multitable.records.createRecord()` can only hold the sheet lock across the whole write when its `query` argument is transaction-bound.

--- a/docs/development/multitable-auto-number-hardening-design-20260507.md
+++ b/docs/development/multitable-auto-number-hardening-design-20260507.md
@@ -1,0 +1,102 @@
+# Multitable Auto Number Hardening Design - 2026-05-07
+
+## Context
+
+`autoNumber` already existed on `main` from PR #1321:
+
+- `meta_field_auto_number_sequences` persists per-field counters.
+- `RecordService.createRecord()` and the public form direct create path allocate values.
+- `autoNumber` is a readonly system field and user-supplied values are rejected on the standard create path.
+
+This follow-up closes the remaining Feishu parity gaps without replacing the existing table or migration.
+
+## Scope
+
+Implemented:
+
+- Property normalization now supports `prefix`, `digits`, `start`, and the existing `startAt` alias.
+- New and converted `autoNumber` fields backfill existing records in `(created_at, id)` order.
+- Sheet-level advisory locking serializes field backfill against standard record creation.
+- Field-level advisory locking serializes sequence allocation per field.
+- The older `multitable.records.createRecord()` helper now rejects user-supplied `autoNumber` values and allocates generated values.
+- Frontend Field Manager exposes `prefix`, `digits`, and `start` controls.
+- Shared display formatting renders `prefix + zeroPad(value, digits)`.
+
+Not changed:
+
+- The existing `meta_field_auto_number_sequences` schema remains unchanged.
+- `startAt` stays supported and is still persisted for compatibility.
+- Existing sequence values are not reset when only the display property is edited.
+- Deleted numbers are not reused.
+
+## Backend Design
+
+### Property Contract
+
+The backend stores a normalized property shape:
+
+```json
+{
+  "prefix": "INV-",
+  "digits": 4,
+  "start": 100,
+  "startAt": 100,
+  "readOnly": true
+}
+```
+
+Validation rules:
+
+- `prefix`: trimmed string, max 32 characters.
+- `digits`: integer `0..12`.
+- `start/startAt`: integer `>= 1`.
+- `readOnly` is always forced to `true`.
+
+### Allocation
+
+`allocateAutoNumberRange()` uses the existing row as the counter:
+
+```sql
+INSERT INTO meta_field_auto_number_sequences (field_id, sheet_id, next_value)
+VALUES ($1, $2, $3)
+ON CONFLICT (field_id)
+DO UPDATE SET next_value = meta_field_auto_number_sequences.next_value + $4,
+              updated_at = now()
+RETURNING next_value - $4 AS start_value
+```
+
+The returned range is contiguous for that field. The single-value API delegates to the range API with `count = 1`.
+
+### Backfill
+
+`backfillAutoNumberField()`:
+
+1. Acquires a sheet-level transaction advisory lock.
+2. Acquires a field-level transaction advisory lock.
+3. Selects target records ordered by `created_at ASC, id ASC`.
+4. Writes generated integers into `meta_records.data[fieldId]` with `jsonb_set`.
+5. Initializes or advances `next_value` to the first value after the backfilled range.
+
+New field creation backfills records missing the field key. Type conversion into `autoNumber` uses `overwrite: true` so stale values from the previous type do not survive as generated IDs.
+
+### Concurrency
+
+The standard `RecordService.createRecord()` path now acquires the same sheet-level lock before reading fields. This prevents a create request from reading the pre-backfill schema while an `autoNumber` field is being created.
+
+The plugin helper path also acquires the sheet-level lock before loading fields. Callers should pass a transaction-bound query when they need the lock held across the whole write.
+
+## Frontend Design
+
+Field Manager treats `autoNumber` as configurable:
+
+- Prefix input.
+- Digits input.
+- Start-at input.
+- Readonly system hint remains visible.
+
+Display formatting is centralized in `formatFieldDisplay()`, so grid, renderer, and readonly surfaces that use the shared formatter inherit the same `INV-0042` rendering.
+
+## Residual Limits
+
+- Public form direct create now locks inside its write transaction, but it still loads and validates fields before that transaction. The sequence allocation itself remains atomic; the full schema-read race is best removed when public-form create is routed through `RecordService.createRecord()`.
+- XLSX import currently creates records one by one through `RecordService`; values are correct and serialized, but it does not yet reserve a single batch range for the whole import.

--- a/docs/development/multitable-auto-number-hardening-verification-20260507.md
+++ b/docs/development/multitable-auto-number-hardening-verification-20260507.md
@@ -32,7 +32,7 @@ pnpm verify:multitable-openapi:parity
 
 - `pnpm install --frozen-lockfile`: passed.
 - `git diff --check`: passed.
-- Backend focused tests: `3 passed`, `34/34` tests passed.
+- Backend focused tests: `3 passed`, `35/35` tests passed.
 - Frontend focused tests: `1 passed`, `7/7` tests passed.
 - Backend type-check: passed.
 - Frontend type-check: passed.

--- a/docs/development/multitable-auto-number-hardening-verification-20260507.md
+++ b/docs/development/multitable-auto-number-hardening-verification-20260507.md
@@ -1,0 +1,60 @@
+# Multitable Auto Number Hardening Verification - 2026-05-07
+
+## Environment
+
+- Worktree: `/private/tmp/ms2-autonumber-20260507`
+- Branch: `codex/multitable-autonumber-field-20260507`
+- Base: `origin/main@d921c93e7`
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+git diff --check
+
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/auto-number-service.test.ts \
+  tests/unit/record-service.test.ts \
+  tests/unit/multitable-records.test.ts \
+  --reporter=dot
+
+pnpm --filter @metasheet/web exec vitest run \
+  tests/multitable-system-fields.spec.ts \
+  --watch=false \
+  --reporter=dot
+
+pnpm --filter @metasheet/core-backend exec tsc -p tsconfig.json --noEmit
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+pnpm verify:multitable-openapi:parity
+```
+
+## Results
+
+- `pnpm install --frozen-lockfile`: passed.
+- `git diff --check`: passed.
+- Backend focused tests: `3 passed`, `34/34` tests passed.
+- Frontend focused tests: `1 passed`, `7/7` tests passed.
+- Backend type-check: passed.
+- Frontend type-check: passed.
+- Multitable OpenAPI parity: passed.
+
+## Coverage Added
+
+Backend:
+
+- `allocateAutoNumberRange()` returns contiguous ranges from the sequence row.
+- `backfillAutoNumberField()` assigns existing records in deterministic order and initializes `next_value`.
+- `RecordService.createRecord()` still allocates readonly `autoNumber` values after the new lock/refactor.
+- `multitable.records.createRecord()` now allocates `autoNumber` values.
+- `multitable.records.createRecord()` rejects client-supplied `autoNumber` values.
+
+Frontend:
+
+- `formatFieldDisplay()` renders `autoNumber` prefix and zero-padding.
+- Field Manager creates `autoNumber` with `prefix`, `digits`, `start`, and `startAt` property.
+
+## Notes
+
+- Frontend Vitest printed `WebSocket server error: Port is already in use`; the suite exited `0` and all assertions passed.
+- `pnpm install` produced plugin/tool `node_modules` symlink noise in the isolated worktree. These paths were restored with `git checkout -- plugins/ tools/` before final status review.
+- `pnpm verify:multitable-openapi:parity` regenerated OpenAPI dist in place and reported no tracked diff.

--- a/docs/development/multitable-feishu-rc-todo-20260430.md
+++ b/docs/development/multitable-feishu-rc-todo-20260430.md
@@ -257,6 +257,7 @@ Expected docs:
   - Development MD: `docs/development/multitable-auto-number-system-field-design-20260505.md`
   - Verification MD: `docs/development/multitable-auto-number-system-field-verification-20260505.md`
   - Verification summary: persistent per-field sequence table added; create paths allocate `autoNumber` values transactionally; focused backend/frontend tests, backend build, frontend type-check, OpenAPI parity, migration replay, and CI passed.
+  - 2026-05-07 follow-up hardening: `docs/development/multitable-auto-number-hardening-design-20260507.md` and `docs/development/multitable-auto-number-hardening-verification-20260507.md` add prefix/digits/start config, existing-record backfill, advisory locking, helper create-path coverage, and frontend formatting.
 - [x] Add `createdTime` field type mapped to record `created_at`.
   - PR: #1280
   - Merge commit: c45da32c1

--- a/packages/core-backend/src/multitable/auto-number-property.ts
+++ b/packages/core-backend/src/multitable/auto-number-property.ts
@@ -1,0 +1,33 @@
+export type NormalizedAutoNumberProperty = {
+  prefix: string
+  digits: number
+  start: number
+  startAt: number
+  readOnly: true
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {}
+}
+
+function finiteInteger(value: unknown, fallback: number): number {
+  const raw = typeof value === 'number' ? value : Number(value)
+  return Number.isFinite(raw) ? Math.floor(raw) : fallback
+}
+
+export function normalizeAutoNumberProperty(property: unknown): NormalizedAutoNumberProperty {
+  const obj = asRecord(property)
+  const start = Math.max(1, finiteInteger(obj.start ?? obj.startAt, 1))
+  const digits = Math.min(12, Math.max(0, finiteInteger(obj.digits, 0)))
+  const prefix = typeof obj.prefix === 'string' ? obj.prefix.trim().slice(0, 32) : ''
+  return {
+    ...obj,
+    prefix,
+    digits,
+    start,
+    startAt: start,
+    readOnly: true,
+  }
+}

--- a/packages/core-backend/src/multitable/auto-number-service.ts
+++ b/packages/core-backend/src/multitable/auto-number-service.ts
@@ -1,15 +1,53 @@
-import { normalizeJson, type MultitableField } from './field-codecs'
+import { normalizeAutoNumberProperty } from './auto-number-property'
+import type { MultitableField } from './field-codecs'
 
 export type AutoNumberQuery = (
   sql: string,
   params?: unknown[],
 ) => Promise<{ rows: unknown[]; rowCount?: number | null }>
 
-function resolveStartAt(property: unknown): number {
-  const obj = normalizeJson(property)
-  const raw = typeof obj.startAt === 'number' ? obj.startAt : Number(obj.startAt)
-  if (!Number.isFinite(raw) || raw < 1) return 1
-  return Math.floor(raw)
+function sheetLockKey(sheetId: string): string {
+  return `meta:auto-number:sheet:${sheetId}`
+}
+
+function lockKey(sheetId: string, fieldId: string): string {
+  return `meta:auto-number:${sheetId}:${fieldId}`
+}
+
+export async function acquireAutoNumberSheetWriteLock(
+  query: AutoNumberQuery,
+  sheetId: string,
+): Promise<void> {
+  await query('SELECT pg_advisory_xact_lock(hashtext($1))', [sheetLockKey(sheetId)])
+}
+
+async function acquireFieldLock(query: AutoNumberQuery, sheetId: string, fieldId: string): Promise<void> {
+  await query('SELECT pg_advisory_xact_lock(hashtext($1))', [lockKey(sheetId, fieldId)])
+}
+
+export async function allocateAutoNumberRange(
+  query: AutoNumberQuery,
+  sheetId: string,
+  field: Pick<MultitableField, 'id' | 'type' | 'property'>,
+  count: number,
+): Promise<number[]> {
+  if (field.type !== 'autoNumber' || count <= 0) return []
+  const batchSize = Math.floor(count)
+  if (!Number.isFinite(batchSize) || batchSize <= 0) return []
+
+  await acquireFieldLock(query, sheetId, field.id)
+  const config = normalizeAutoNumberProperty(field.property)
+  const result = await query(
+    `INSERT INTO meta_field_auto_number_sequences (field_id, sheet_id, next_value)
+     VALUES ($1, $2, $3)
+     ON CONFLICT (field_id)
+     DO UPDATE SET next_value = meta_field_auto_number_sequences.next_value + $4,
+                   updated_at = now()
+     RETURNING next_value - $4 AS start_value`,
+    [field.id, sheetId, config.start + batchSize, batchSize],
+  )
+  const startValue = Number((result.rows[0] as { start_value?: unknown } | undefined)?.start_value ?? config.start)
+  return Array.from({ length: batchSize }, (_, index) => startValue + index)
 }
 
 export async function allocateAutoNumberValues(
@@ -22,18 +60,61 @@ export async function allocateAutoNumberValues(
 
   const values: Record<string, number> = {}
   for (const field of autoNumberFields) {
-    const startAt = resolveStartAt(field.property)
-    const result = await query(
-      `INSERT INTO meta_field_auto_number_sequences (field_id, sheet_id, next_value)
-       VALUES ($1, $2, $3)
-       ON CONFLICT (field_id)
-       DO UPDATE SET next_value = meta_field_auto_number_sequences.next_value + 1,
-                     updated_at = now()
-       RETURNING next_value - 1 AS value`,
-      [field.id, sheetId, startAt + 1],
-    )
-    const value = Number((result.rows[0] as { value?: unknown } | undefined)?.value ?? startAt)
-    values[field.id] = value
+    const [value] = await allocateAutoNumberRange(query, sheetId, field, 1)
+    if (typeof value === 'number') values[field.id] = value
   }
   return values
+}
+
+export type BackfillAutoNumberFieldResult = {
+  assigned: number
+  nextValue: number
+}
+
+export async function backfillAutoNumberField(
+  query: AutoNumberQuery,
+  sheetId: string,
+  fieldId: string,
+  property: unknown,
+  opts?: { overwrite?: boolean },
+): Promise<BackfillAutoNumberFieldResult> {
+  const config = normalizeAutoNumberProperty(property)
+  await acquireAutoNumberSheetWriteLock(query, sheetId)
+  await acquireFieldLock(query, sheetId, fieldId)
+
+  const rows = await query(
+    `SELECT id
+     FROM meta_records
+     WHERE sheet_id = $1
+       AND ($2::boolean OR NOT (data ? $3))
+     ORDER BY created_at ASC, id ASC
+     FOR UPDATE`,
+    [sheetId, opts?.overwrite === true, fieldId],
+  )
+
+  let assigned = 0
+  for (const row of rows.rows as Array<{ id?: unknown }>) {
+    const recordId = typeof row.id === 'string' ? row.id : ''
+    if (!recordId) continue
+    const value = config.start + assigned
+    await query(
+      `UPDATE meta_records
+       SET data = jsonb_set(COALESCE(data, '{}'::jsonb), ARRAY[$1]::text[], to_jsonb($2::integer), true)
+       WHERE sheet_id = $3 AND id = $4`,
+      [fieldId, value, sheetId, recordId],
+    )
+    assigned += 1
+  }
+
+  const nextValue = config.start + assigned
+  await query(
+    `INSERT INTO meta_field_auto_number_sequences (field_id, sheet_id, next_value)
+     VALUES ($1, $2, $3)
+     ON CONFLICT (field_id)
+     DO UPDATE SET next_value = GREATEST(meta_field_auto_number_sequences.next_value, EXCLUDED.next_value),
+                   updated_at = now()`,
+    [fieldId, sheetId, nextValue],
+  )
+
+  return { assigned, nextValue }
 }

--- a/packages/core-backend/src/multitable/field-codecs.ts
+++ b/packages/core-backend/src/multitable/field-codecs.ts
@@ -1,3 +1,4 @@
+import { normalizeAutoNumberProperty } from './auto-number-property'
 import { fieldTypeRegistry } from './field-type-registry'
 
 export type MultitableFieldType =
@@ -364,11 +365,7 @@ export function sanitizeFieldProperty(
   }
 
   if (type === 'autoNumber') {
-    const startAtRaw = typeof obj.startAt === 'number' ? obj.startAt : Number(obj.startAt)
-    const startAt = Number.isFinite(startAtRaw) && startAtRaw > 0
-      ? Math.floor(startAtRaw)
-      : 1
-    return { ...obj, startAt, readOnly: true }
+    return normalizeAutoNumberProperty(obj)
   }
 
   if (SYSTEM_FIELD_TYPES.has(type)) {

--- a/packages/core-backend/src/multitable/record-service.ts
+++ b/packages/core-backend/src/multitable/record-service.ts
@@ -23,7 +23,10 @@ import {
   collectSameSheetLinkChangeFieldIds,
   loadHierarchyParentFieldIds,
 } from './hierarchy-cycle-guard'
-import { allocateAutoNumberValues } from './auto-number-service'
+import {
+  acquireAutoNumberSheetWriteLock,
+  allocateAutoNumberValues,
+} from './auto-number-service'
 import { getDefaultValidationRules, validateRecord } from './field-validation-engine'
 import type { FieldValidationConfig } from './field-validation'
 import { loadFieldsForSheet } from './loaders'
@@ -401,152 +404,154 @@ export class RecordService {
   async createRecord(input: RecordCreateInput): Promise<RecordCreateResult> {
     const { sheetId, data, actorId, capabilities } = input
 
-    const sheetRes = await this.pool.query(
-      'SELECT id FROM meta_sheets WHERE id = $1 AND deleted_at IS NULL',
-      [sheetId],
-    )
-    if (sheetRes.rows.length === 0) {
-      throw new RecordNotFoundError(`Sheet not found: ${sheetId}`)
-    }
-
     if (!capabilities.canCreateRecord) {
       throw new RecordPermissionError('Insufficient permissions')
     }
 
-    const fieldRes = await this.pool.query(
-      'SELECT id, name, type, property FROM meta_fields WHERE sheet_id = $1',
-      [sheetId],
-    )
-    if (fieldRes.rows.length === 0) {
-      throw new RecordNotFoundError(`Sheet not found: ${sheetId}`)
-    }
-
-    const fieldById = buildCreateFieldGuardMap(fieldRes.rows)
     const patch: Record<string, unknown> = {}
-    const linkUpdates = new Map<string, { ids: string[]; cfg: LinkFieldConfig }>()
+    const recordId = `rec_${randomUUID()}`
+    const recordRes = await this.pool.transaction(async ({ query }) => {
+      await acquireAutoNumberSheetWriteLock(query, sheetId)
 
-    for (const [fieldId, value] of Object.entries(data)) {
-      const field = fieldById.get(fieldId)
-      if (!field) {
-        throw new RecordValidationError(`Unknown fieldId: ${fieldId}`)
+      const sheetRes = await query(
+        'SELECT id FROM meta_sheets WHERE id = $1 AND deleted_at IS NULL',
+        [sheetId],
+      )
+      if (sheetRes.rows.length === 0) {
+        throw new RecordNotFoundError(`Sheet not found: ${sheetId}`)
       }
 
-      if (isFieldAlwaysReadOnly(field)) {
-        throw new RecordFieldForbiddenError(`Field is readonly: ${fieldId}`, fieldId)
+      const fieldRes = await query(
+        'SELECT id, name, type, property FROM meta_fields WHERE sheet_id = $1',
+        [sheetId],
+      )
+      if (fieldRes.rows.length === 0) {
+        throw new RecordNotFoundError(`Sheet not found: ${sheetId}`)
       }
 
-      if (field.type === 'select') {
-        if (typeof value !== 'string') {
-          throw new RecordValidationError(`Select value must be string: ${fieldId}`)
+      const fieldById = buildCreateFieldGuardMap(fieldRes.rows)
+      const linkUpdates = new Map<string, { ids: string[]; cfg: LinkFieldConfig }>()
+
+      for (const [fieldId, value] of Object.entries(data)) {
+        const field = fieldById.get(fieldId)
+        if (!field) {
+          throw new RecordValidationError(`Unknown fieldId: ${fieldId}`)
         }
-        const allowed = new Set(field.options ?? [])
-        if (value !== '' && !allowed.has(value)) {
-          throw new RecordValidationError(`Invalid select option for ${fieldId}: ${value}`)
+
+        if (isFieldAlwaysReadOnly(field)) {
+          throw new RecordFieldForbiddenError(`Field is readonly: ${fieldId}`, fieldId)
         }
-      }
-      if (field.type === 'multiSelect') {
-        try {
-          patch[fieldId] = normalizeMultiSelectValue(value, fieldId, field.options ?? [])
-        } catch (error) {
-          throw new RecordValidationError(error instanceof Error ? error.message : String(error))
+
+        if (field.type === 'select') {
+          if (typeof value !== 'string') {
+            throw new RecordValidationError(`Select value must be string: ${fieldId}`)
+          }
+          const allowed = new Set(field.options ?? [])
+          if (value !== '' && !allowed.has(value)) {
+            throw new RecordValidationError(`Invalid select option for ${fieldId}: ${value}`)
+          }
         }
-        continue
-      }
-
-      if (field.type === 'link') {
-        if (field.link) {
-          const ids = normalizeLinkIds(value)
-          if (field.link.limitSingleRecord && ids.length > 1) {
-            throw new RecordValidationError(`Link field only allows a single record: ${fieldId}`)
+        if (field.type === 'multiSelect') {
+          try {
+            patch[fieldId] = normalizeMultiSelectValue(value, fieldId, field.options ?? [])
+          } catch (error) {
+            throw new RecordValidationError(error instanceof Error ? error.message : String(error))
           }
-          const tooLong = ids.find((id) => id.length > 50)
-          if (tooLong) {
-            throw new RecordValidationError(`Link id too long (>50): ${tooLong}`)
-          }
-
-          if (ids.length > 0) {
-            const exists = await this.pool.query(
-              'SELECT id FROM meta_records WHERE sheet_id = $1 AND id = ANY($2::text[])',
-              [field.link.foreignSheetId, ids],
-            )
-            const found = new Set(
-              (exists.rows as Array<Record<string, unknown>>)
-                .map((row) => (typeof row.id === 'string' ? row.id : ''))
-                .filter((id) => id.length > 0),
-            )
-            const missing = ids.filter((id) => !found.has(id))
-            if (missing.length > 0) {
-              throw new RecordValidationError(
-                `Linked record(s) not found in sheet ${field.link.foreignSheetId}: ${missing.join(', ')}`,
-              )
-            }
-          }
-
-          patch[fieldId] = ids
-          linkUpdates.set(fieldId, { ids, cfg: field.link })
           continue
         }
 
-        if (typeof value !== 'string') {
-          throw new RecordValidationError(`Link value must be string: ${fieldId}`)
+        if (field.type === 'link') {
+          if (field.link) {
+            const ids = normalizeLinkIds(value)
+            if (field.link.limitSingleRecord && ids.length > 1) {
+              throw new RecordValidationError(`Link field only allows a single record: ${fieldId}`)
+            }
+            const tooLong = ids.find((id) => id.length > 50)
+            if (tooLong) {
+              throw new RecordValidationError(`Link id too long (>50): ${tooLong}`)
+            }
+
+            if (ids.length > 0) {
+              const exists = await query(
+                'SELECT id FROM meta_records WHERE sheet_id = $1 AND id = ANY($2::text[])',
+                [field.link.foreignSheetId, ids],
+              )
+              const found = new Set(
+                (exists.rows as Array<Record<string, unknown>>)
+                  .map((row) => (typeof row.id === 'string' ? row.id : ''))
+                  .filter((id) => id.length > 0),
+              )
+              const missing = ids.filter((id) => !found.has(id))
+              if (missing.length > 0) {
+                throw new RecordValidationError(
+                  `Linked record(s) not found in sheet ${field.link.foreignSheetId}: ${missing.join(', ')}`,
+                )
+              }
+            }
+
+            patch[fieldId] = ids
+            linkUpdates.set(fieldId, { ids, cfg: field.link })
+            continue
+          }
+
+          if (typeof value !== 'string') {
+            throw new RecordValidationError(`Link value must be string: ${fieldId}`)
+          }
         }
+
+        if (field.type === 'attachment') {
+          const ids = normalizeAttachmentIdsShared(value)
+          const tooLong = ids.find((id) => id.length > 100)
+          if (tooLong) {
+            throw new RecordValidationError(`Attachment id too long: ${tooLong}`)
+          }
+          const attachmentError = await ensureAttachmentIdsExistShared({
+            query,
+            sheetId,
+            fieldId,
+            attachmentIds: ids,
+          })
+          if (attachmentError) {
+            throw new RecordValidationError(attachmentError)
+          }
+          patch[fieldId] = ids
+          continue
+        }
+
+        if (field.type === 'formula') {
+          if (typeof value !== 'string') continue
+          if (value !== '' && !value.startsWith('=')) continue
+        }
+
+        if (field.type === 'longText') {
+          try {
+            patch[fieldId] = validateLongTextValue(value, fieldId)
+          } catch (error) {
+            throw new RecordValidationError(error instanceof Error ? error.message : String(error))
+          }
+          continue
+        }
+
+        if (BATCH1_FIELD_TYPES.has(field.type)) {
+          try {
+            patch[fieldId] = coerceBatch1Value(field.type, field.property, fieldId, value)
+          } catch (error) {
+            throw new RecordValidationError(error instanceof Error ? error.message : String(error))
+          }
+          continue
+        }
+
+        patch[fieldId] = value
       }
 
-      if (field.type === 'attachment') {
-        const ids = normalizeAttachmentIdsShared(value)
-        const tooLong = ids.find((id) => id.length > 100)
-        if (tooLong) {
-          throw new RecordValidationError(`Attachment id too long: ${tooLong}`)
-        }
-        const attachmentError = await ensureAttachmentIdsExistShared({
-          query: this.pool.query.bind(this.pool),
-          sheetId,
-          fieldId,
-          attachmentIds: ids,
-        })
-        if (attachmentError) {
-          throw new RecordValidationError(attachmentError)
-        }
-        patch[fieldId] = ids
-        continue
+      const directValidationResult = validateRecord(
+        buildDirectValidationFields(fieldRes.rows),
+        patch,
+      )
+      if (!directValidationResult.valid) {
+        throw new RecordValidationFailedError(directValidationResult.errors)
       }
 
-      if (field.type === 'formula') {
-        if (typeof value !== 'string') continue
-        if (value !== '' && !value.startsWith('=')) continue
-      }
-
-      if (field.type === 'longText') {
-        try {
-          patch[fieldId] = validateLongTextValue(value, fieldId)
-        } catch (error) {
-          throw new RecordValidationError(error instanceof Error ? error.message : String(error))
-        }
-        continue
-      }
-
-      if (BATCH1_FIELD_TYPES.has(field.type)) {
-        try {
-          patch[fieldId] = coerceBatch1Value(field.type, field.property, fieldId, value)
-        } catch (error) {
-          throw new RecordValidationError(error instanceof Error ? error.message : String(error))
-        }
-        continue
-      }
-
-      patch[fieldId] = value
-    }
-
-    const directValidationResult = validateRecord(
-      buildDirectValidationFields(fieldRes.rows),
-      patch,
-    )
-    if (!directValidationResult.valid) {
-      throw new RecordValidationFailedError(directValidationResult.errors)
-    }
-
-    const recordId = `rec_${randomUUID()}`
-    const recordRes = await this.pool.transaction(async ({ query }) => {
       Object.assign(patch, await allocateAutoNumberValues(query, sheetId, Array.from(fieldById, ([id, field]) => ({
         id,
         type: field.type,

--- a/packages/core-backend/src/multitable/record-service.ts
+++ b/packages/core-backend/src/multitable/record-service.ts
@@ -404,6 +404,14 @@ export class RecordService {
   async createRecord(input: RecordCreateInput): Promise<RecordCreateResult> {
     const { sheetId, data, actorId, capabilities } = input
 
+    const sheetRes = await this.pool.query(
+      'SELECT id FROM meta_sheets WHERE id = $1 AND deleted_at IS NULL',
+      [sheetId],
+    )
+    if (sheetRes.rows.length === 0) {
+      throw new RecordNotFoundError(`Sheet not found: ${sheetId}`)
+    }
+
     if (!capabilities.canCreateRecord) {
       throw new RecordPermissionError('Insufficient permissions')
     }
@@ -412,14 +420,6 @@ export class RecordService {
     const recordId = `rec_${randomUUID()}`
     const recordRes = await this.pool.transaction(async ({ query }) => {
       await acquireAutoNumberSheetWriteLock(query, sheetId)
-
-      const sheetRes = await query(
-        'SELECT id FROM meta_sheets WHERE id = $1 AND deleted_at IS NULL',
-        [sheetId],
-      )
-      if (sheetRes.rows.length === 0) {
-        throw new RecordNotFoundError(`Sheet not found: ${sheetId}`)
-      }
 
       const fieldRes = await query(
         'SELECT id, name, type, property FROM meta_fields WHERE sheet_id = $1',

--- a/packages/core-backend/src/multitable/records.ts
+++ b/packages/core-backend/src/multitable/records.ts
@@ -1,5 +1,9 @@
 import { randomUUID } from 'crypto'
 
+import {
+  acquireAutoNumberSheetWriteLock,
+  allocateAutoNumberValues,
+} from './auto-number-service'
 import { fieldTypeRegistry } from './field-type-registry'
 import { loadFieldsForSheet, loadSheetRow } from './loaders'
 import { MultitableRecordNotFoundError, MultitableRecordValidationError } from './record-errors'
@@ -232,6 +236,8 @@ function normalizeFieldValue(
         throw new MultitableRecordValidationError(`Formula must start with "=": ${field.id}`)
       }
       return value
+    case 'autoNumber':
+      throw new MultitableRecordValidationError(`Field is readonly: ${field.id}`)
     case 'lookup':
     case 'rollup':
     case 'attachment':
@@ -461,9 +467,15 @@ export async function createRecord(
   input: CreateMultitableRecordInput,
 ): Promise<CreatedMultitableRecord> {
   const query = input.query
+  await acquireAutoNumberSheetWriteLock(query, input.sheetId)
   const { fields } = await loadSheetAndFields(query, input.sheetId)
 
   const { patch, linkUpdates } = await buildNormalizedPatch(query, fields, input.data)
+  Object.assign(patch, await allocateAutoNumberValues(query, input.sheetId, fields.map((field) => ({
+    id: field.id,
+    type: field.type,
+    property: field.property,
+  }))))
 
   const recordId = `rec_${randomUUID()}`
   const inserted = await query(

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -6332,7 +6332,8 @@ export function univerMetaRouter(): Router {
           return
         }
 
-        Object.assign(patch, await allocateAutoNumberValues(query, view.sheetId, fields))
+        const latestFields = await loadFieldsForSheet(query, view.sheetId)
+        Object.assign(patch, await allocateAutoNumberValues(query, view.sheetId, latestFields))
 
         const insertRes = await query(
           `INSERT INTO meta_records (id, sheet_id, data, version, created_by, modified_by)

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -135,7 +135,12 @@ import {
   RecordValidationFailedError as RecordCreateValidationFailedError,
   RecordPatchFieldValidationError as RecordServicePatchFieldValidationError,
 } from '../multitable/record-service'
-import { allocateAutoNumberValues } from '../multitable/auto-number-service'
+import {
+  acquireAutoNumberSheetWriteLock,
+  allocateAutoNumberValues,
+  backfillAutoNumberField,
+} from '../multitable/auto-number-service'
+import { normalizeAutoNumberProperty } from '../multitable/auto-number-property'
 import {
   createYjsInvalidationPostCommitHook,
   type YjsInvalidator,
@@ -1340,9 +1345,7 @@ function sanitizeFieldProperty(type: UniverMetaField['type'], property: unknown)
   }
 
   if (type === 'autoNumber') {
-    const startAtRaw = typeof obj.startAt === 'number' ? obj.startAt : Number(obj.startAt)
-    const startAt = Number.isFinite(startAtRaw) && startAtRaw > 0 ? Math.floor(startAtRaw) : 1
-    return { ...obj, startAt, readOnly: true }
+    return normalizeAutoNumberProperty(obj)
   }
 
   if (type === 'createdTime' || type === 'modifiedTime' || type === 'createdBy' || type === 'modifiedBy') {
@@ -4186,6 +4189,10 @@ export function univerMetaRouter(): Router {
           const refs = multitableFormulaEngine.extractFieldReferences(String(property.expression))
           await syncFormulaDependencies(query, sheetId, fieldId, refs)
         }
+
+        if (type === 'autoNumber') {
+          await backfillAutoNumberField(query, sheetId, fieldId, property)
+        }
       })
 
       const fieldRes = await pool.query(
@@ -4464,6 +4471,10 @@ export function univerMetaRouter(): Router {
 
         if (currentType === 'autoNumber' && nextType !== 'autoNumber') {
           await query('DELETE FROM meta_field_auto_number_sequences WHERE field_id = $1', [fieldId])
+        }
+
+        if (currentType !== 'autoNumber' && nextType === 'autoNumber') {
+          await backfillAutoNumberField(query, sheetId, fieldId, nextProperty, { overwrite: true })
         }
 
         // Track formula dependencies on update
@@ -6257,6 +6268,8 @@ export function univerMetaRouter(): Router {
       let nextVersion = 1
 
       await pool.transaction(async ({ query }) => {
+        await acquireAutoNumberSheetWriteLock(query, view.sheetId)
+
         if (recordId) {
           const currentRes = await query(
             'SELECT id, version, created_by FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE',

--- a/packages/core-backend/tests/unit/auto-number-service.test.ts
+++ b/packages/core-backend/tests/unit/auto-number-service.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  allocateAutoNumberRange,
+  backfillAutoNumberField,
+  type AutoNumberQuery,
+} from '../../src/multitable/auto-number-service'
+
+function createQuery(rows: Array<{ id: string }> = []): {
+  query: AutoNumberQuery
+  calls: Array<{ sql: string; params: unknown[] }>
+} {
+  const calls: Array<{ sql: string; params: unknown[] }> = []
+  const query: AutoNumberQuery = async (sql, params = []) => {
+    calls.push({ sql, params })
+    const normalized = sql.replace(/\s+/g, ' ').trim()
+    if (normalized.includes('SELECT pg_advisory_xact_lock')) {
+      return { rows: [], rowCount: 1 }
+    }
+    if (normalized.startsWith('SELECT id FROM meta_records')) {
+      return { rows }
+    }
+    if (normalized.startsWith('UPDATE meta_records')) {
+      return { rows: [], rowCount: 1 }
+    }
+    if (normalized.startsWith('INSERT INTO meta_field_auto_number_sequences')) {
+      const batchSize = typeof params[3] === 'number' ? params[3] : 0
+      return {
+        rows: batchSize > 0 ? [{ start_value: 25 }] : [],
+        rowCount: 1,
+      }
+    }
+    throw new Error(`Unhandled SQL: ${sql}`)
+  }
+  return { query, calls }
+}
+
+describe('auto-number-service', () => {
+  it('allocates a contiguous range from a field sequence', async () => {
+    const { query, calls } = createQuery()
+
+    const values = await allocateAutoNumberRange(
+      query,
+      'sheet_1',
+      { id: 'fld_seq', type: 'autoNumber', property: { startAt: 10 } },
+      3,
+    )
+
+    expect(values).toEqual([25, 26, 27])
+    expect(calls[0]).toEqual({
+      sql: 'SELECT pg_advisory_xact_lock(hashtext($1))',
+      params: ['meta:auto-number:sheet_1:fld_seq'],
+    })
+    expect(calls[1].params).toEqual(['fld_seq', 'sheet_1', 13, 3])
+  })
+
+  it('backfills existing records and initializes next_value after the assigned range', async () => {
+    const { query, calls } = createQuery([{ id: 'rec_a' }, { id: 'rec_b' }])
+
+    const result = await backfillAutoNumberField(
+      query,
+      'sheet_1',
+      'fld_seq',
+      { start: 100, prefix: 'INV-', digits: 4 },
+    )
+
+    expect(result).toEqual({ assigned: 2, nextValue: 102 })
+    expect(calls[0].params).toEqual(['meta:auto-number:sheet:sheet_1'])
+    expect(calls[1].params).toEqual(['meta:auto-number:sheet_1:fld_seq'])
+    expect(calls.filter((call) => call.sql.includes('UPDATE meta_records')).map((call) => call.params)).toEqual([
+      ['fld_seq', 100, 'sheet_1', 'rec_a'],
+      ['fld_seq', 101, 'sheet_1', 'rec_b'],
+    ])
+    expect(calls.at(-1)?.params).toEqual(['fld_seq', 'sheet_1', 102])
+  })
+})

--- a/packages/core-backend/tests/unit/multitable-records.test.ts
+++ b/packages/core-backend/tests/unit/multitable-records.test.ts
@@ -124,6 +124,7 @@ function createQuery(): {
   ]
   const records: FakeRecord[] = []
   const links: FakeLink[] = []
+  const autoNumberNextByField = new Map<string, number>()
 
   const query: MultitableRecordsQueryFn = async (sql, params = []) => {
     const normalized = sql.replace(/\s+/g, ' ').trim()
@@ -131,6 +132,10 @@ function createQuery(): {
     if (normalized.includes('FROM meta_sheets') && normalized.includes('WHERE id = $1')) {
       const [sheetId] = params as [string]
       return { rows: sheets.filter((sheet) => sheet.id === sheetId) }
+    }
+
+    if (normalized.includes('SELECT pg_advisory_xact_lock')) {
+      return { rows: [], rowCount: 1 }
     }
 
     if (normalized.includes('FROM meta_fields') && normalized.includes('WHERE sheet_id = $1')) {
@@ -148,6 +153,19 @@ function createQuery(): {
       }
       records.push(record)
       return { rows: [{ version: 1 }], rowCount: 1 }
+    }
+
+    if (normalized.startsWith('INSERT INTO meta_field_auto_number_sequences')) {
+      const [fieldId, , nextValueRaw, batchSizeRaw] = params as [string, string, number, number | undefined]
+      const batchSize = typeof batchSizeRaw === 'number' ? batchSizeRaw : 1
+      const initialNextValue = Number(nextValueRaw)
+      const current = autoNumberNextByField.get(fieldId)
+      if (current === undefined) {
+        autoNumberNextByField.set(fieldId, initialNextValue)
+        return { rows: [{ start_value: initialNextValue - batchSize }], rowCount: 1 }
+      }
+      autoNumberNextByField.set(fieldId, current + batchSize)
+      return { rows: [{ start_value: current }], rowCount: 1 }
     }
 
     if (normalized.startsWith('SELECT id FROM meta_records WHERE sheet_id = $1 AND id = ANY($2::text[])')) {
@@ -350,6 +368,50 @@ describe('multitable records helper', () => {
       refundAmount: 88.5,
     })
     expect(records).toHaveLength(1)
+  })
+
+  it('allocates autoNumber values through the helper create path', async () => {
+    const { query, fields } = createQuery()
+    fields.push({
+      id: 'autoNo',
+      sheet_id: 'sheet_service_ticket',
+      name: 'Auto No',
+      type: 'autoNumber',
+      property: { startAt: 100, prefix: 'TK-', digits: 4 },
+      order: 6,
+    })
+
+    const first = await createRecord({
+      query,
+      sheetId: 'sheet_service_ticket',
+      data: { title: 'Broken compressor' },
+    })
+    const second = await createRecord({
+      query,
+      sheetId: 'sheet_service_ticket',
+      data: { title: 'Worn bearing' },
+    })
+
+    expect(first.data.autoNo).toBe(100)
+    expect(second.data.autoNo).toBe(101)
+  })
+
+  it('rejects client supplied autoNumber values through the helper create path', async () => {
+    const { query, fields } = createQuery()
+    fields.push({
+      id: 'autoNo',
+      sheet_id: 'sheet_service_ticket',
+      name: 'Auto No',
+      type: 'autoNumber',
+      property: {},
+      order: 6,
+    })
+
+    await expect(createRecord({
+      query,
+      sheetId: 'sheet_service_ticket',
+      data: { autoNo: 999 },
+    })).rejects.toBeInstanceOf(MultitableRecordValidationError)
   })
 
   it('throws when the sheet is missing', async () => {

--- a/packages/core-backend/tests/unit/record-service.test.ts
+++ b/packages/core-backend/tests/unit/record-service.test.ts
@@ -259,6 +259,23 @@ describe('RecordService', () => {
     })).rejects.toThrow(RecordFieldForbiddenError)
   })
 
+  it('preserves not-found priority for missing sheets during create', async () => {
+    pool = createMockPool({
+      SELECT_SHEET: { rows: [] },
+    })
+    const service = new RecordService(pool, eventBus as any)
+
+    await expect(service.createRecord({
+      sheetId: 'sheet_missing',
+      data: { fld_title: 'Alpha' },
+      actorId: 'user_1',
+      capabilities: {
+        ...fullCapabilities,
+        canCreateRecord: false,
+      },
+    })).rejects.toThrow(RecordNotFoundError)
+  })
+
   it('rejects create when a linked target record is missing', async () => {
     pool = createMockPool({
       SELECT_FIELDS: {

--- a/packages/core-backend/tests/unit/record-service.test.ts
+++ b/packages/core-backend/tests/unit/record-service.test.ts
@@ -76,8 +76,11 @@ function createMockPool(
     if (sql.includes('SELECT data FROM meta_records WHERE sheet_id = $1 AND id = $2 FOR UPDATE')) {
       return responses.SELECT_HIERARCHY_PARENT_RECORD ?? { rows: [] }
     }
+    if (sql.includes('SELECT pg_advisory_xact_lock')) {
+      return responses.ADVISORY_LOCK ?? { rows: [], rowCount: 1 }
+    }
     if (sql.includes('INSERT INTO meta_field_auto_number_sequences')) {
-      return responses.ALLOCATE_AUTO_NUMBER ?? { rows: [{ value: 1 }], rowCount: 1 }
+      return responses.ALLOCATE_AUTO_NUMBER ?? { rows: [{ start_value: 1 }], rowCount: 1 }
     }
     if (sql.includes('INSERT INTO meta_links')) {
       return responses.INSERT_LINK ?? { rows: [], rowCount: 1 }
@@ -218,7 +221,7 @@ describe('RecordService', () => {
           { id: 'fld_title', name: 'Title', type: 'string', property: {} },
         ],
       },
-      ALLOCATE_AUTO_NUMBER: { rows: [{ value: 10 }] },
+      ALLOCATE_AUTO_NUMBER: { rows: [{ start_value: 10 }] },
     })
     const service = new RecordService(pool, eventBus as any)
 
@@ -232,7 +235,7 @@ describe('RecordService', () => {
     expect(result.data).toEqual({ fld_title: 'Alpha', fld_seq: 10 })
     expect(pool.queryMock).toHaveBeenCalledWith(
       expect.stringContaining('INSERT INTO meta_field_auto_number_sequences'),
-      ['fld_seq', 'sheet_ops', 11],
+      ['fld_seq', 'sheet_ops', 11, 1],
     )
     expect(pool.queryMock).toHaveBeenCalledWith(
       expect.stringContaining('INSERT INTO meta_records'),


### PR DESCRIPTION
## Summary

Hardens the existing `autoNumber` system field from PR #1321. `origin/main` already has the base field type and single-value allocation; this PR closes the remaining Feishu-parity gaps:

- normalize `prefix`, `digits`, `start`, and existing `startAt` alias
- backfill existing records when an `autoNumber` field is created or a field is converted into `autoNumber`
- add sheet/field advisory locks so field backfill and standard record creation do not race
- keep the legacy `multitable.records.createRecord()` helper aligned with generated values and readonly rejection
- expose Field Manager config for prefix/digits/start
- format display values as `prefix + zeroPad(value, digits)`

## Why this is not duplicate work

`origin/main@d921c93e7` has `meta_field_auto_number_sequences` and `allocateAutoNumberValues()`, but it does not include:

- `auto-number-property.ts`
- `backfillAutoNumberField()`
- `allocateAutoNumberRange()`
- `acquireAutoNumberSheetWriteLock()`
- frontend `autoNumberDraft` config UI
- `formatAutoNumber()` display formatting
- the 2026-05-07 design/verification MD pair

Those are introduced here.

## Design notes

- Reuses the existing `meta_field_auto_number_sequences` table; no new migration.
- Keeps `startAt` for compatibility and also persists `start` for the new UI contract.
- New field creation backfills missing values; conversion into autoNumber overwrites stale old-type values.
- Deleted numbers are not reused.
- XLSX import remains correct because it goes through `RecordService.createRecord()` per row; batch range reservation is documented as a later optimization.

## Verification

```bash
pnpm install --frozen-lockfile
git diff --check
pnpm --filter @metasheet/core-backend exec vitest run tests/unit/auto-number-service.test.ts tests/unit/record-service.test.ts tests/unit/multitable-records.test.ts --reporter=dot
pnpm --filter @metasheet/web exec vitest run tests/multitable-system-fields.spec.ts --watch=false --reporter=dot
pnpm --filter @metasheet/core-backend exec tsc -p tsconfig.json --noEmit
pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
pnpm verify:multitable-openapi:parity
```

Results:

- backend focused tests: 35/35 passed
- frontend focused tests: 7/7 passed
- backend type-check passed
- frontend type-check passed
- OpenAPI parity passed

## Review follow-up

A second commit tightened two review findings:

- preserves missing-sheet `RecordNotFoundError` priority before create permission denial
- reloads latest fields inside public-form create transaction before auto-number allocation, so concurrent autoNumber field creation cannot be missed by allocation
- `git diff --check` passed

Note: frontend Vitest printed `WebSocket server error: Port is already in use`, but exited 0 and all assertions passed.
