### PR TITLE
feat(integration): expose dead-letter communication api

### DIFF
--- a/docs/development/integration-core-dead-letter-communication-api-design-20260507.md
+++ b/docs/development/integration-core-dead-letter-communication-api-design-20260507.md
@@ -1,0 +1,65 @@
+# Integration Core Dead-Letter Communication API Design - 2026-05-07
+
+## Context
+
+`plugin-integration-core` already exposes dead-letter list and replay workflows
+over REST:
+
+- `GET /api/integration/dead-letters`
+- `POST /api/integration/dead-letters/:id/replay`
+
+The cross-plugin communication namespace still stopped at external systems,
+pipelines, runner, and staging operations. That left a gap for future packaged
+integration UI plugins: they could launch runs through `integration-core`, but
+could not inspect or replay failed records without using the HTTP route layer.
+
+## Scope
+
+This slice adds a narrow communication surface in
+`plugins/plugin-integration-core/index.cjs`:
+
+- `listDeadLetters(input)`
+- `getDeadLetter(input)`
+- `replayDeadLetter(input)`
+
+It also extends `getStatus()` with:
+
+- `deadLetters`
+- `deadLetterReplay`
+
+## Security Contract
+
+Dead-letter records can contain PLM or ERP business payloads. The communication
+namespace is plugin-to-plugin, not per-user HTTP, so the default contract is
+metadata-first:
+
+- `listDeadLetters()` strips `sourcePayload` and `transformedPayload`.
+- `getDeadLetter()` strips `sourcePayload` and `transformedPayload`.
+- `replayDeadLetter()` delegates to the runner, then strips payload fields from
+  the returned `deadLetter` object.
+- All returned dead-letter records include `payloadRedacted: true`.
+
+The underlying `dead-letter.cjs` validators still own tenant/workspace/id input
+validation. The communication layer only adds initialization checks and output
+redaction.
+
+## Non-Goals
+
+- No HTTP route changes.
+- No new database tables or migrations.
+- No change to runner replay behavior or dead-letter persistence semantics.
+- No payload opt-in flag in the communication namespace. Any plugin that truly
+  needs payload inspection should go through a separately reviewed contract.
+
+## Files Changed
+
+- `plugins/plugin-integration-core/index.cjs`
+- `plugins/plugin-integration-core/__tests__/plugin-runtime-smoke.test.cjs`
+- `docs/development/integration-core-dead-letter-communication-api-design-20260507.md`
+- `docs/development/integration-core-dead-letter-communication-api-verification-20260507.md`
+
+## Expected Impact
+
+This is a small control-plane completion slice. It improves readiness for an
+independent integration UI/plugin package while keeping payload exposure tighter
+than the existing internal store object.

--- a/docs/development/integration-core-dead-letter-communication-api-verification-20260507.md
+++ b/docs/development/integration-core-dead-letter-communication-api-verification-20260507.md
@@ -1,0 +1,54 @@
+# Integration Core Dead-Letter Communication API Verification - 2026-05-07
+
+## Local Verification
+
+Worktree:
+
+`/private/tmp/ms2-deadletter-comm-api`
+
+Branch:
+
+`codex/integration-deadletter-comm-api-20260507`
+
+Baseline:
+
+`origin/main` at `d921c93e7f5500f0ad83edc92b153b0da97d93f4`
+
+Commands:
+
+```bash
+node plugins/plugin-integration-core/__tests__/plugin-runtime-smoke.test.cjs
+pnpm install --frozen-lockfile
+pnpm -F plugin-integration-core test
+pnpm validate:plugins
+git diff --check
+```
+
+Results:
+
+- `plugin-runtime-smoke`: passed.
+- `pnpm install --frozen-lockfile`: passed; lockfile unchanged.
+- `pnpm -F plugin-integration-core test`: passed.
+- `pnpm validate:plugins`: 13/13 valid, 0 errors.
+- `git diff --check`: passed.
+
+## Regression Coverage
+
+Updated `plugin-runtime-smoke.test.cjs` to verify:
+
+- communication `getStatus()` reports dead-letter store readiness.
+- communication `getStatus()` reports dead-letter replay readiness.
+- communication API exposes `listDeadLetters`.
+- communication API exposes `getDeadLetter`.
+- communication API exposes `replayDeadLetter`.
+- `listDeadLetters()` returns dead-letter metadata.
+- `listDeadLetters()` omits `sourcePayload` and `transformedPayload`.
+- `getDeadLetter()` returns a single redacted dead-letter record.
+- returned dead-letter records include `payloadRedacted: true`.
+
+## Environment Note
+
+The first full plugin test attempt stopped before business assertions because
+the temporary worktree did not yet have local `node_modules`, so `node --import
+tsx` could not resolve `tsx`. After `pnpm install --frozen-lockfile`, the same
+test command completed successfully.

--- a/plugins/plugin-integration-core/__tests__/plugin-runtime-smoke.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/plugin-runtime-smoke.test.cjs
@@ -27,6 +27,23 @@ function createMockContext() {
   const registeredNamespaces = new Map()
   const logs = []
   const databaseCalls = []
+  const deadLetterRow = {
+    id: 'dl_1',
+    tenant_id: 'tenant_1',
+    workspace_id: null,
+    run_id: 'run_1',
+    pipeline_id: 'pipe_1',
+    idempotency_key: 'idem_1',
+    source_payload: { FNumber: 'MAT-001', password: 'secret' },
+    transformed_payload: { FNumber: 'MAT-001', token: 'secret' },
+    error_code: 'VALIDATION_FAILED',
+    error_message: 'field FName is required',
+    retry_count: 0,
+    status: 'open',
+    last_replay_run_id: null,
+    created_at: '2026-05-07T00:00:00.000Z',
+    updated_at: '2026-05-07T00:00:00.000Z',
+  }
 
   return {
     context: {
@@ -42,6 +59,9 @@ function createMockContext() {
         database: {
           async query(sql, params) {
             databaseCalls.push({ sql, params })
+            if (String(sql).includes('FROM "integration_dead_letters"')) {
+              return [deadLetterRow]
+            }
             return []
           },
         },
@@ -144,6 +164,8 @@ async function main() {
   assert.ok(statusResult.adapters.includes('http'), 'status reports http adapter')
   assert.ok(statusResult.adapters.includes('erp:k3-wise-webapi'), 'status reports K3 WISE WebAPI adapter')
   assert.ok(statusResult.adapters.includes('erp:k3-wise-sqlserver'), 'status reports K3 WISE SQL Server adapter')
+  assert.equal(statusResult.deadLetters, true, 'status reports dead-letter store')
+  assert.equal(statusResult.deadLetterReplay, true, 'status reports dead-letter replay')
 
   // --- 5b. Comm API exposes registry methods ----------------------------
   assert.equal(typeof commApi.upsertExternalSystem, 'function', 'comm api exposes upsertExternalSystem')
@@ -151,6 +173,30 @@ async function main() {
   assert.equal(typeof commApi.listExternalSystems, 'function', 'comm api exposes listExternalSystems')
   assert.equal(typeof commApi.listAdapterKinds, 'function', 'comm api exposes listAdapterKinds')
   assert.deepEqual(await commApi.listAdapterKinds(), statusResult.adapters, 'comm api adapter kinds match status')
+
+  // --- 5c. Comm API exposes redacted dead-letter control methods ---------
+  assert.equal(typeof commApi.listDeadLetters, 'function', 'comm api exposes listDeadLetters')
+  assert.equal(typeof commApi.getDeadLetter, 'function', 'comm api exposes getDeadLetter')
+  assert.equal(typeof commApi.replayDeadLetter, 'function', 'comm api exposes replayDeadLetter')
+  const deadLetters = await commApi.listDeadLetters({
+    tenantId: 'tenant_1',
+    workspaceId: null,
+    status: 'open',
+  })
+  assert.equal(deadLetters.length, 1, 'comm api lists dead letters')
+  assert.equal(deadLetters[0].id, 'dl_1', 'comm api maps dead-letter id')
+  assert.equal(deadLetters[0].payloadRedacted, true, 'comm api marks dead-letter payload redacted')
+  assert.equal('sourcePayload' in deadLetters[0], false, 'comm api does not expose sourcePayload by default')
+  assert.equal('transformedPayload' in deadLetters[0], false, 'comm api does not expose transformedPayload by default')
+  const deadLetter = await commApi.getDeadLetter({
+    tenantId: 'tenant_1',
+    workspaceId: null,
+    id: 'dl_1',
+  })
+  assert.equal(deadLetter.id, 'dl_1', 'comm api gets a single dead letter')
+  assert.equal(deadLetter.payloadRedacted, true, 'comm api redacts single dead-letter payload')
+  assert.equal('sourcePayload' in deadLetter, false, 'comm api single dead-letter omits sourcePayload')
+  assert.equal('transformedPayload' in deadLetter, false, 'comm api single dead-letter omits transformedPayload')
 
   // --- 6. Activation logged --------------------------------------------
   const hasActivationLog = inspect.logs.some(

--- a/plugins/plugin-integration-core/index.cjs
+++ b/plugins/plugin-integration-core/index.cjs
@@ -55,9 +55,31 @@ function buildHealthPayload() {
   }
 }
 
+function requireInitialized(service, message) {
+  if (!service) throw new Error(message)
+  return service
+}
+
+function redactDeadLetterForCommunication(deadLetter) {
+  if (!deadLetter || typeof deadLetter !== 'object') return deadLetter
+  const { sourcePayload: _sourcePayload, transformedPayload: _transformedPayload, ...safe } = deadLetter
+  return {
+    ...safe,
+    payloadRedacted: true,
+  }
+}
+
+function redactReplayResultForCommunication(result) {
+  if (!result || typeof result !== 'object') return result
+  return {
+    ...result,
+    deadLetter: redactDeadLetterForCommunication(result.deadLetter),
+  }
+}
+
 function buildCommunicationApi() {
   return {
-    // M0/M1 seam. Later slices will add pipeline-runner / dead-letter replay.
+    // Cross-plugin control seam for the integration plugin family.
     async ping() {
       return { ok: true, plugin: PLUGIN_ID, ts: Date.now() }
     },
@@ -75,60 +97,69 @@ function buildCommunicationApi() {
         pipelines: Boolean(pipelineRegistry),
         runner: Boolean(pipelineRunner),
         erpFeedback: Boolean(erpFeedbackWriter),
+        deadLetters: Boolean(deadLetterStore),
+        deadLetterReplay: Boolean(pipelineRunner && typeof pipelineRunner.replayDeadLetter === 'function'),
         staging: Boolean(stagingInstaller),
       }
     },
     async upsertExternalSystem(input) {
-      if (!externalSystemRegistry) throw new Error('external system registry is not initialized')
-      return externalSystemRegistry.upsertExternalSystem(input)
+      return requireInitialized(externalSystemRegistry, 'external system registry is not initialized')
+        .upsertExternalSystem(input)
     },
     async getExternalSystem(input) {
-      if (!externalSystemRegistry) throw new Error('external system registry is not initialized')
-      return externalSystemRegistry.getExternalSystem(input)
+      return requireInitialized(externalSystemRegistry, 'external system registry is not initialized')
+        .getExternalSystem(input)
     },
     async listExternalSystems(input) {
-      if (!externalSystemRegistry) throw new Error('external system registry is not initialized')
-      return externalSystemRegistry.listExternalSystems(input)
+      return requireInitialized(externalSystemRegistry, 'external system registry is not initialized')
+        .listExternalSystems(input)
     },
     async listAdapterKinds() {
-      if (!adapterRegistry) throw new Error('adapter registry is not initialized')
-      return adapterRegistry.listAdapterKinds()
+      return requireInitialized(adapterRegistry, 'adapter registry is not initialized').listAdapterKinds()
     },
     async upsertPipeline(input) {
-      if (!pipelineRegistry) throw new Error('pipeline registry is not initialized')
-      return pipelineRegistry.upsertPipeline(input)
+      return requireInitialized(pipelineRegistry, 'pipeline registry is not initialized').upsertPipeline(input)
     },
     async getPipeline(input) {
-      if (!pipelineRegistry) throw new Error('pipeline registry is not initialized')
-      return pipelineRegistry.getPipeline(input)
+      return requireInitialized(pipelineRegistry, 'pipeline registry is not initialized').getPipeline(input)
     },
     async listPipelines(input) {
-      if (!pipelineRegistry) throw new Error('pipeline registry is not initialized')
-      return pipelineRegistry.listPipelines(input)
+      return requireInitialized(pipelineRegistry, 'pipeline registry is not initialized').listPipelines(input)
     },
     async createPipelineRun(input) {
-      if (!pipelineRegistry) throw new Error('pipeline registry is not initialized')
-      return pipelineRegistry.createPipelineRun(input)
+      return requireInitialized(pipelineRegistry, 'pipeline registry is not initialized').createPipelineRun(input)
     },
     async updatePipelineRun(input) {
-      if (!pipelineRegistry) throw new Error('pipeline registry is not initialized')
-      return pipelineRegistry.updatePipelineRun(input)
+      return requireInitialized(pipelineRegistry, 'pipeline registry is not initialized').updatePipelineRun(input)
     },
     async listPipelineRuns(input) {
-      if (!pipelineRegistry) throw new Error('pipeline registry is not initialized')
-      return pipelineRegistry.listPipelineRuns(input)
+      return requireInitialized(pipelineRegistry, 'pipeline registry is not initialized').listPipelineRuns(input)
     },
     async runPipeline(input) {
-      if (!pipelineRunner) throw new Error('pipeline runner is not initialized')
-      return pipelineRunner.runPipeline(input)
+      return requireInitialized(pipelineRunner, 'pipeline runner is not initialized').runPipeline(input)
+    },
+    async listDeadLetters(input) {
+      const rows = await requireInitialized(deadLetterStore, 'dead-letter store is not initialized')
+        .listDeadLetters(input)
+      return rows.map(redactDeadLetterForCommunication)
+    },
+    async getDeadLetter(input) {
+      const deadLetter = await requireInitialized(deadLetterStore, 'dead-letter store is not initialized')
+        .getDeadLetter(input)
+      return redactDeadLetterForCommunication(deadLetter)
+    },
+    async replayDeadLetter(input) {
+      const runner = requireInitialized(pipelineRunner, 'pipeline runner is not initialized')
+      if (typeof runner.replayDeadLetter !== 'function') {
+        throw new Error('dead-letter replay is not implemented')
+      }
+      return redactReplayResultForCommunication(await runner.replayDeadLetter(input))
     },
     async listStagingDescriptors() {
-      if (!stagingInstaller) throw new Error('staging installer is not initialized')
-      return stagingInstaller.listStagingDescriptors()
+      return requireInitialized(stagingInstaller, 'staging installer is not initialized').listStagingDescriptors()
     },
     async installStaging(input) {
-      if (!stagingInstaller) throw new Error('staging installer is not initialized')
-      return stagingInstaller.installStaging(input)
+      return requireInitialized(stagingInstaller, 'staging installer is not initialized').installStaging(input)
     },
   }
 }


### PR DESCRIPTION
## Summary

Adds a small cross-plugin communication control surface for integration dead letters:

- `listDeadLetters(input)`
- `getDeadLetter(input)`
- `replayDeadLetter(input)`
- `getStatus().deadLetters`
- `getStatus().deadLetterReplay`

The list/get communication methods return dead-letter metadata only and strip `sourcePayload` / `transformedPayload` by default. Replay delegates to the existing runner and redacts the returned `deadLetter` object as well.

## Why

HTTP already supports dead-letter list/replay, but the `integration-core` communication namespace still stopped at systems, pipelines, runner, and staging. Future packaged integration UI/plugins need the same cleanup workflow without reaching around the plugin boundary.

## Docs

- `docs/development/integration-core-dead-letter-communication-api-design-20260507.md`
- `docs/development/integration-core-dead-letter-communication-api-verification-20260507.md`

## Verification

```bash
node plugins/plugin-integration-core/__tests__/plugin-runtime-smoke.test.cjs
pnpm install --frozen-lockfile
pnpm -F plugin-integration-core test
pnpm validate:plugins
git diff --check
```

Results:

- `plugin-runtime-smoke`: passed
- `pnpm install --frozen-lockfile`: passed; lockfile unchanged
- `pnpm -F plugin-integration-core test`: passed
- `pnpm validate:plugins`: 13/13 valid, 0 errors
- `git diff --check`: passed
