### PR TITLE
fix(integration): refresh runtime status metadata

### DIFF
--- a/docs/development/integration-core-runtime-status-refresh-design-20260507.md
+++ b/docs/development/integration-core-runtime-status-refresh-design-20260507.md
@@ -1,0 +1,70 @@
+# Integration Core Runtime Status Refresh Design - 2026-05-07
+
+## Context
+
+`plugin-integration-core` has moved beyond the original M0 runtime spike. The
+runtime now wires:
+
+- external system registry
+- adapter registry
+- pipeline registry
+- pipeline runner
+- ERP feedback writer
+- staging installer
+- dead-letter list and replay control surface
+
+The health route and communication `getStatus()` payload still reported
+`M0-spike`, which is stale and misleading for deployment checks, future frontend
+plugins, and operations scripts.
+
+## Change
+
+This slice refreshes the runtime metadata in
+`plugins/plugin-integration-core/index.cjs`:
+
+- derive `version` from `plugin.json` instead of a hard-coded string.
+- replace the stale `M0-spike` marker with `integration-core-mvp`.
+- add `phase` to both health and communication status responses.
+- add a shared `capabilities` object to both health and communication status.
+- keep the existing flat readiness fields on `getStatus()` for compatibility.
+
+## Response Shape
+
+`GET /api/integration/health` now reports:
+
+```json
+{
+  "ok": true,
+  "plugin": "plugin-integration-core",
+  "version": "0.1.0",
+  "phase": "integration-core-mvp",
+  "milestone": "integration-core-mvp",
+  "capabilities": {
+    "externalSystems": true,
+    "adapters": ["http", "plm:yuantus-wrapper", "erp:k3-wise-webapi", "erp:k3-wise-sqlserver"],
+    "pipelines": true,
+    "runner": true,
+    "erpFeedback": true,
+    "deadLetters": true,
+    "deadLetterReplay": true,
+    "staging": true
+  }
+}
+```
+
+`communication.call('integration-core', 'getStatus')` returns the same phase and
+capability object while preserving the previous top-level readiness fields.
+
+## Compatibility
+
+No field was removed. The existing `milestone` key remains present, but now
+matches the current runtime phase. Consumers that already read flat booleans
+such as `runner`, `staging`, or `deadLetterReplay` continue to work.
+
+## Files Changed
+
+- `plugins/plugin-integration-core/index.cjs`
+- `plugins/plugin-integration-core/__tests__/plugin-runtime-smoke.test.cjs`
+- `plugins/plugin-integration-core/__tests__/host-loader-smoke.test.mjs`
+- `docs/development/integration-core-runtime-status-refresh-design-20260507.md`
+- `docs/development/integration-core-runtime-status-refresh-verification-20260507.md`

--- a/docs/development/integration-core-runtime-status-refresh-verification-20260507.md
+++ b/docs/development/integration-core-runtime-status-refresh-verification-20260507.md
@@ -1,0 +1,57 @@
+# Integration Core Runtime Status Refresh Verification - 2026-05-07
+
+## Local Verification
+
+Worktree:
+
+`/private/tmp/ms2-comm-status-refresh`
+
+Branch:
+
+`codex/integration-comm-status-refresh-20260507`
+
+Baseline:
+
+`origin/main` at `8d3e5df1f5b7b4f7f4673e82d0c0eb0f9da790ec`
+
+Commands:
+
+```bash
+node plugins/plugin-integration-core/__tests__/plugin-runtime-smoke.test.cjs
+pnpm install --frozen-lockfile
+node --import tsx plugins/plugin-integration-core/__tests__/host-loader-smoke.test.mjs
+pnpm -F plugin-integration-core test
+pnpm validate:plugins
+git diff --check
+```
+
+Results:
+
+- `plugin-runtime-smoke`: passed.
+- `pnpm install --frozen-lockfile`: passed; lockfile unchanged.
+- `host-loader-smoke`: passed.
+- `pnpm -F plugin-integration-core test`: passed.
+- `pnpm validate:plugins`: 13/13 valid, 0 errors.
+- `git diff --check`: passed.
+
+## Regression Coverage
+
+Updated `plugin-runtime-smoke.test.cjs` to verify:
+
+- health `version` follows `plugin.json`.
+- health `phase` and `milestone` are `integration-core-mvp`.
+- health `capabilities` reports registry, runner, and dead-letter replay
+  readiness.
+- communication `getStatus()` version follows `plugin.json`.
+- communication `getStatus()` phase and milestone are `integration-core-mvp`.
+- communication `getStatus().capabilities` mirrors the existing flat readiness
+  fields.
+
+Updated `host-loader-smoke.test.mjs` to verify the same phase and capability
+fields through the real `PluginLoader` activation path.
+
+## Environment Note
+
+The temporary worktree initially lacked local `node_modules`, so tests that load
+`tsx` could not start. After `pnpm install --frozen-lockfile`, the host-loader
+and full plugin test commands completed successfully.

--- a/plugins/plugin-integration-core/__tests__/host-loader-smoke.test.mjs
+++ b/plugins/plugin-integration-core/__tests__/host-loader-smoke.test.mjs
@@ -107,6 +107,10 @@ async function main() {
   await healthRoute.handler({}, { json(value) { responseBody = value } })
   assert.equal(responseBody?.ok, true)
   assert.equal(responseBody?.plugin, 'plugin-integration-core')
+  assert.equal(responseBody?.phase, 'integration-core-mvp')
+  assert.equal(responseBody?.milestone, 'integration-core-mvp')
+  assert.equal(responseBody?.capabilities?.runner, true)
+  assert.equal(responseBody?.capabilities?.deadLetterReplay, true)
 
   const ping = await host.context.communication.call('integration-core', 'ping')
   assert.equal(ping.ok, true)
@@ -114,12 +118,16 @@ async function main() {
 
   const status = await host.context.communication.call('integration-core', 'getStatus')
   assert.equal(status.plugin, 'plugin-integration-core')
+  assert.equal(status.phase, 'integration-core-mvp')
+  assert.equal(status.milestone, 'integration-core-mvp')
   assert.equal(status.routesRegistered, host.routes.length)
   assert.deepEqual(status.credentialStore, { source: 'host-security', format: 'enc' })
   assert.equal(status.externalSystems, true)
   assert.ok(status.adapters.includes('http'), 'status reports http adapter')
   assert.ok(status.adapters.includes('erp:k3-wise-webapi'), 'status reports K3 WISE WebAPI adapter')
   assert.ok(status.adapters.includes('erp:k3-wise-sqlserver'), 'status reports K3 WISE SQL Server adapter')
+  assert.equal(status.capabilities?.runner, true)
+  assert.equal(status.capabilities?.deadLetterReplay, true)
   assert.equal(typeof host.namespaces.get('integration-core').upsertExternalSystem, 'function')
   assert.deepEqual(
     await host.context.communication.call('integration-core', 'listAdapterKinds'),

--- a/plugins/plugin-integration-core/__tests__/plugin-runtime-smoke.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/plugin-runtime-smoke.test.cjs
@@ -147,13 +147,22 @@ async function main() {
   const healthBody = await runMockResponse(healthRoute.handler)
   assert.equal(healthBody.ok, true, 'health.ok')
   assert.equal(healthBody.plugin, 'plugin-integration-core', 'health.plugin')
+  assert.equal(healthBody.version, manifest.version, 'health.version follows manifest')
+  assert.equal(healthBody.phase, 'integration-core-mvp', 'health.phase')
+  assert.equal(healthBody.milestone, 'integration-core-mvp', 'health.milestone')
   assert.equal(typeof healthBody.ts, 'number', 'health.ts is number')
+  assert.equal(healthBody.capabilities.externalSystems, true, 'health capabilities report external systems')
+  assert.equal(healthBody.capabilities.runner, true, 'health capabilities report runner')
+  assert.equal(healthBody.capabilities.deadLetterReplay, true, 'health capabilities report dead-letter replay')
 
   // --- 5. Comm API returns expected shape ------------------------------
   const pingResult = await commApi.ping()
   assert.equal(pingResult.ok, true, 'ping.ok')
   const statusResult = await commApi.getStatus()
   assert.equal(statusResult.plugin, 'plugin-integration-core', 'status.plugin')
+  assert.equal(statusResult.version, manifest.version, 'status.version follows manifest')
+  assert.equal(statusResult.phase, 'integration-core-mvp', 'status.phase')
+  assert.equal(statusResult.milestone, 'integration-core-mvp', 'status.milestone')
   assert.equal(statusResult.routesRegistered, inspect.routes.length, 'status.routesRegistered matches registered routes')
   assert.deepEqual(
     statusResult.credentialStore,
@@ -166,6 +175,16 @@ async function main() {
   assert.ok(statusResult.adapters.includes('erp:k3-wise-sqlserver'), 'status reports K3 WISE SQL Server adapter')
   assert.equal(statusResult.deadLetters, true, 'status reports dead-letter store')
   assert.equal(statusResult.deadLetterReplay, true, 'status reports dead-letter replay')
+  assert.deepEqual(statusResult.capabilities, {
+    externalSystems: statusResult.externalSystems,
+    adapters: statusResult.adapters,
+    pipelines: statusResult.pipelines,
+    runner: statusResult.runner,
+    erpFeedback: statusResult.erpFeedback,
+    deadLetters: statusResult.deadLetters,
+    deadLetterReplay: statusResult.deadLetterReplay,
+    staging: statusResult.staging,
+  }, 'status capabilities mirror flat readiness fields')
 
   // --- 5b. Comm API exposes registry methods ----------------------------
   assert.equal(typeof commApi.upsertExternalSystem, 'function', 'comm api exposes upsertExternalSystem')

--- a/plugins/plugin-integration-core/index.cjs
+++ b/plugins/plugin-integration-core/index.cjs
@@ -5,7 +5,7 @@
 //
 // PLM/ERP integration pipeline — system plugin MVP.
 //
-// M0 scope: minimal runtime spike. Registers a health route and a cross-plugin
+// Registers the integration health route, REST control plane, and cross-plugin
 // communication namespace so the rest of the plugin family can call into this
 // one via `context.communication.call('integration-core', ...)`.
 //
@@ -32,8 +32,11 @@ const { createErpFeedbackWriter } = require('./lib/erp-feedback.cjs')
 const { createPipelineRunner } = require('./lib/pipeline-runner.cjs')
 const { installStaging, listStagingDescriptors } = require('./lib/staging-installer.cjs')
 const { registerIntegrationRoutes } = require('./lib/http-routes.cjs')
+const manifest = require('./plugin.json')
 
 const registeredRoutes = []
+const PLUGIN_VERSION = manifest.version || '0.1.0'
+const PLUGIN_PHASE = 'integration-core-mvp'
 let activeContext = null
 let credentialStore = null
 let externalSystemRegistry = null
@@ -46,12 +49,28 @@ let erpFeedbackWriter = null
 let pipelineRunner = null
 let stagingInstaller = null
 
+function buildCapabilityStatus() {
+  return {
+    externalSystems: Boolean(externalSystemRegistry),
+    adapters: adapterRegistry ? adapterRegistry.listAdapterKinds() : [],
+    pipelines: Boolean(pipelineRegistry),
+    runner: Boolean(pipelineRunner),
+    erpFeedback: Boolean(erpFeedbackWriter),
+    deadLetters: Boolean(deadLetterStore),
+    deadLetterReplay: Boolean(pipelineRunner && typeof pipelineRunner.replayDeadLetter === 'function'),
+    staging: Boolean(stagingInstaller),
+  }
+}
+
 function buildHealthPayload() {
   return {
     ok: true,
     plugin: PLUGIN_ID,
+    version: PLUGIN_VERSION,
+    phase: PLUGIN_PHASE,
     ts: Date.now(),
-    milestone: 'M0-spike',
+    milestone: PLUGIN_PHASE,
+    capabilities: buildCapabilityStatus(),
   }
 }
 
@@ -84,22 +103,18 @@ function buildCommunicationApi() {
       return { ok: true, plugin: PLUGIN_ID, ts: Date.now() }
     },
     async getStatus() {
+      const capabilities = buildCapabilityStatus()
       return {
         plugin: PLUGIN_ID,
-        version: '0.1.0',
-        milestone: 'M0-spike',
+        version: PLUGIN_VERSION,
+        phase: PLUGIN_PHASE,
+        milestone: PLUGIN_PHASE,
         routesRegistered: registeredRoutes.length,
         credentialStore: credentialStore
           ? { source: credentialStore.source, format: credentialStore.format }
           : null,
-        externalSystems: Boolean(externalSystemRegistry),
-        adapters: adapterRegistry ? adapterRegistry.listAdapterKinds() : [],
-        pipelines: Boolean(pipelineRegistry),
-        runner: Boolean(pipelineRunner),
-        erpFeedback: Boolean(erpFeedbackWriter),
-        deadLetters: Boolean(deadLetterStore),
-        deadLetterReplay: Boolean(pipelineRunner && typeof pipelineRunner.replayDeadLetter === 'function'),
-        staging: Boolean(stagingInstaller),
+        ...capabilities,
+        capabilities,
       }
     },
     async upsertExternalSystem(input) {
@@ -235,7 +250,7 @@ module.exports = {
     // --- Cross-plugin communication --------------------------------------
     context.communication.register(COMMUNICATION_NAMESPACE, buildCommunicationApi())
 
-    logger.info(`[${PLUGIN_ID}] activated (M0 spike). routes=${registeredRoutes.length}`)
+    logger.info(`[${PLUGIN_ID}] activated (${PLUGIN_PHASE}). routes=${registeredRoutes.length}`)
   },
 
   async deactivate() {


### PR DESCRIPTION
## Summary

Refreshes `plugin-integration-core` runtime metadata now that the plugin is beyond the original M0 spike:

- derives runtime `version` from `plugin.json`
- replaces stale `M0-spike` health/status metadata with `integration-core-mvp`
- adds `phase` to health and communication `getStatus()` responses
- adds a shared `capabilities` object to health and communication status
- keeps existing flat `getStatus()` readiness fields for compatibility

## Why

Deployment checks, future integration UI plugins, and ops scripts should see the actual runtime capability surface instead of early spike metadata.

## Docs

- `docs/development/integration-core-runtime-status-refresh-design-20260507.md`
- `docs/development/integration-core-runtime-status-refresh-verification-20260507.md`

## Verification

```bash
node plugins/plugin-integration-core/__tests__/plugin-runtime-smoke.test.cjs
pnpm install --frozen-lockfile
node --import tsx plugins/plugin-integration-core/__tests__/host-loader-smoke.test.mjs
pnpm -F plugin-integration-core test
pnpm validate:plugins
git diff --check
```

Results:

- `plugin-runtime-smoke`: passed
- `pnpm install --frozen-lockfile`: passed; lockfile unchanged
- `host-loader-smoke`: passed
- `pnpm -F plugin-integration-core test`: passed
- `pnpm validate:plugins`: 13/13 valid, 0 errors
- `git diff --check`: passed
