### PR TITLE
feat(multitable): inline name-conflict validation in Field Manager

### DIFF
--- a/apps/web/src/multitable/components/MetaFieldManager.vue
+++ b/apps/web/src/multitable/components/MetaFieldManager.vue
@@ -15,15 +15,32 @@
           <span class="meta-field-mgr__icon">{{ FIELD_ICONS[displayFieldType(field)] ?? '?' }}</span>
 
           <template v-if="editingId === field.id">
-            <input
-              class="meta-field-mgr__rename"
-              :value="editingName"
-              @input="editingName = ($event.target as HTMLInputElement).value"
-              @keydown.enter="confirmRename(field.id)"
-              @keydown.escape="cancelRename"
-            />
-            <button class="meta-field-mgr__action meta-field-mgr__action--ok" @click="confirmRename(field.id)">&#x2713;</button>
-            <button class="meta-field-mgr__action" @click="cancelRename">&#x2717;</button>
+            <div class="meta-field-mgr__rename-wrap">
+              <input
+                class="meta-field-mgr__rename"
+                :class="{ 'meta-field-mgr__rename--invalid': renameNameConflict }"
+                :value="editingName"
+                :aria-invalid="renameNameConflict"
+                :aria-describedby="renameNameConflict ? 'meta-field-mgr-rename-error' : undefined"
+                @input="editingName = ($event.target as HTMLInputElement).value"
+                @keydown.enter="confirmRename(field.id)"
+                @keydown.escape="cancelRename"
+              />
+              <span
+                v-if="renameNameConflict"
+                id="meta-field-mgr-rename-error"
+                class="meta-field-mgr__inline-error"
+                data-test="rename-conflict-error"
+                role="alert"
+              >A field named "{{ editingName.trim() }}" already exists</span>
+            </div>
+            <button
+              class="meta-field-mgr__action meta-field-mgr__action--ok"
+              :disabled="renameNameConflict"
+              :title="renameNameConflict ? 'Resolve the duplicate name to confirm' : 'Confirm rename'"
+              @click="confirmRename(field.id)"
+            >&#x2713;</button>
+            <button class="meta-field-mgr__action" title="Cancel rename" @click="cancelRename">&#x2717;</button>
           </template>
           <template v-else>
             <span class="meta-field-mgr__name" :title="field.name">{{ field.name }}</span>
@@ -331,14 +348,28 @@
           <input
             v-model="newFieldName"
             class="meta-field-mgr__input"
+            :class="{ 'meta-field-mgr__input--invalid': addNameConflict }"
             placeholder="Field name"
+            :aria-invalid="addNameConflict"
+            :aria-describedby="addNameConflict ? 'meta-field-mgr-add-error' : undefined"
             @keydown.enter="onAddField"
           />
           <select v-model="newFieldType" class="meta-field-mgr__select" @change="openNewFieldConfigIfNeeded">
             <option v-for="t in FIELD_TYPES" :key="t" :value="t">{{ t }}</option>
           </select>
-          <button class="meta-field-mgr__btn-add" :disabled="!newFieldName.trim()" @click="onAddField">+ Add</button>
+          <button
+            class="meta-field-mgr__btn-add"
+            :disabled="!newFieldName.trim() || addNameConflict"
+            @click="onAddField"
+          >+ Add</button>
         </div>
+        <div
+          v-if="addNameConflict"
+          id="meta-field-mgr-add-error"
+          class="meta-field-mgr__inline-error"
+          data-test="add-conflict-error"
+          role="alert"
+        >A field named "{{ newFieldName.trim() }}" already exists</div>
         <div v-if="newFieldTypeIsSystem" class="meta-field-mgr__hint meta-field-mgr__hint--system">
           {{ systemFieldHint(newFieldType) }}
         </div>
@@ -608,6 +639,31 @@ const fieldConfigWarningText = computed(() => {
   return fieldConfigBlockingReason.value || 'This field changed in the background. Save keeps your draft, or reload the latest settings.'
 })
 const newFieldTypeIsSystem = computed(() => isSystemFieldCreateType(newFieldType.value))
+
+/**
+ * Compare field names case-insensitively after trimming. Field-name UIs
+ * across the app treat names as user-facing labels, and the friendlier
+ * default for inline conflict detection is to flag "Status" vs "status"
+ * before the user round-trips to the backend.
+ */
+function normalizeFieldName(name: string): string {
+  return name.trim().toLowerCase()
+}
+
+const addNameConflict = computed(() => {
+  const normalized = normalizeFieldName(newFieldName.value)
+  if (!normalized) return false
+  return props.fields.some((field) => normalizeFieldName(field.name) === normalized)
+})
+
+const renameNameConflict = computed(() => {
+  if (!editingId.value) return false
+  const normalized = normalizeFieldName(editingName.value)
+  if (!normalized) return false
+  return props.fields.some(
+    (field) => field.id !== editingId.value && normalizeFieldName(field.name) === normalized,
+  )
+})
 
 const validationPanelVisible = computed(() => {
   const draftType = configDraftType.value
@@ -1071,6 +1127,7 @@ function insertFormulaFunction(doc: FormulaFunctionDoc) {
 function onAddField() {
   const name = newFieldName.value.trim()
   if (!name) return
+  if (addNameConflict.value) return
   if (requiresConfig(newFieldType.value) && !newFieldConfigVisible.value) {
     openNewFieldConfigIfNeeded()
     return
@@ -1117,6 +1174,7 @@ function startRename(field: MetaField) {
 }
 
 function confirmRename(fieldId: string) {
+  if (renameNameConflict.value) return
   const name = editingName.value.trim()
   if (name && name !== props.fields.find((field) => field.id === fieldId)?.name) {
     emit('update-field', fieldId, { name })
@@ -1308,4 +1366,8 @@ onBeforeUnmount(() => {
 .meta-field-mgr__btn-delete { padding: 4px 12px; background: #f56c6c; color: #fff; border: none; border-radius: 3px; cursor: pointer; font-size: 12px; }
 .meta-field-mgr__error { color: #f56c6c; font-size: 12px; }
 .meta-field-mgr__validation { margin-top: 4px; }
+.meta-field-mgr__rename-wrap { flex: 1; display: flex; flex-direction: column; gap: 2px; }
+.meta-field-mgr__rename--invalid { border-color: #f56c6c; }
+.meta-field-mgr__input--invalid { border-color: #f56c6c; }
+.meta-field-mgr__inline-error { color: #f56c6c; font-size: 11px; margin-top: 4px; }
 </style>

--- a/apps/web/tests/multitable-field-manager.spec.ts
+++ b/apps/web/tests/multitable-field-manager.spec.ts
@@ -629,6 +629,160 @@ describe('MetaFieldManager', () => {
     app.unmount()
   })
 
+  it('blocks adding a field whose name duplicates an existing one (case-insensitive)', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const createSpy = vi.fn()
+
+    const app = createApp({
+      render() {
+        return h(MetaFieldManager, {
+          visible: true,
+          sheetId: 'sheet_1',
+          sheets: [],
+          fields: [{ id: 'fld_status', name: 'Status', type: 'string', property: {} }],
+          onCreateField: createSpy,
+        })
+      },
+    })
+
+    app.mount(container)
+    await nextTick()
+
+    const nameInput = container.querySelector('.meta-field-mgr__add-row .meta-field-mgr__input') as HTMLInputElement
+    nameInput.value = 'status'
+    nameInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await nextTick()
+
+    const inlineError = container.querySelector('[data-test="add-conflict-error"]') as HTMLElement | null
+    expect(inlineError).not.toBeNull()
+    expect(inlineError?.textContent).toContain('already exists')
+    expect(nameInput.getAttribute('aria-invalid')).toBe('true')
+
+    const addButton = (Array.from(container.querySelectorAll('.meta-field-mgr__btn-add')) as HTMLButtonElement[])
+      .find((button) => button.textContent?.includes('+ Add')) as HTMLButtonElement
+    expect(addButton.disabled).toBe(true)
+    addButton.click()
+    nameInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    await nextTick()
+    expect(createSpy).not.toHaveBeenCalled()
+
+    // Resolve the conflict by giving the new field a unique name.
+    nameInput.value = 'Priority'
+    nameInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await nextTick()
+    expect(container.querySelector('[data-test="add-conflict-error"]')).toBeNull()
+    expect(addButton.disabled).toBe(false)
+
+    addButton.click()
+    await nextTick()
+    expect(createSpy).toHaveBeenCalledWith({
+      sheetId: 'sheet_1',
+      name: 'Priority',
+      type: 'string',
+    })
+
+    app.unmount()
+  })
+
+  it('blocks renaming a field to an existing name and excludes the field itself', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const updateSpy = vi.fn()
+
+    const app = createApp({
+      render() {
+        return h(MetaFieldManager, {
+          visible: true,
+          sheetId: 'sheet_1',
+          sheets: [],
+          fields: [
+            { id: 'fld_status', name: 'Status', type: 'string', property: {} },
+            { id: 'fld_priority', name: 'Priority', type: 'string', property: {} },
+          ],
+          onUpdateField: updateSpy,
+        })
+      },
+    })
+
+    app.mount(container)
+    await nextTick()
+
+    // Open rename for the second field (Priority).
+    const renameButtons = Array.from(
+      container.querySelectorAll('.meta-field-mgr__action[title="Rename"]'),
+    ) as HTMLButtonElement[]
+    renameButtons[1].click()
+    await nextTick()
+
+    const renameInput = container.querySelector('.meta-field-mgr__rename') as HTMLInputElement
+    expect(renameInput.value).toBe('Priority')
+
+    // Try to rename Priority → Status (conflicts with first field).
+    renameInput.value = 'status'
+    renameInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await nextTick()
+
+    const inlineError = container.querySelector('[data-test="rename-conflict-error"]') as HTMLElement | null
+    expect(inlineError).not.toBeNull()
+    expect(renameInput.getAttribute('aria-invalid')).toBe('true')
+
+    const okButton = container.querySelector('.meta-field-mgr__action--ok') as HTMLButtonElement
+    expect(okButton.disabled).toBe(true)
+    renameInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    await nextTick()
+    expect(updateSpy).not.toHaveBeenCalled()
+
+    // Editing the field's own current name (Priority) must NOT flag a conflict.
+    renameInput.value = 'Priority'
+    renameInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await nextTick()
+    expect(container.querySelector('[data-test="rename-conflict-error"]')).toBeNull()
+
+    // A unique name proceeds normally.
+    renameInput.value = 'Urgency'
+    renameInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await nextTick()
+    expect(container.querySelector('[data-test="rename-conflict-error"]')).toBeNull()
+
+    const okButtonAfterFix = container.querySelector('.meta-field-mgr__action--ok') as HTMLButtonElement
+    expect(okButtonAfterFix.disabled).toBe(false)
+    okButtonAfterFix.click()
+    await nextTick()
+    expect(updateSpy).toHaveBeenCalledWith('fld_priority', { name: 'Urgency' })
+
+    app.unmount()
+  })
+
+  it('does not flag the add-row when the input is empty or whitespace', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    const app = createApp({
+      render() {
+        return h(MetaFieldManager, {
+          visible: true,
+          sheetId: 'sheet_1',
+          sheets: [],
+          fields: [{ id: 'fld_status', name: 'Status', type: 'string', property: {} }],
+        })
+      },
+    })
+
+    app.mount(container)
+    await nextTick()
+
+    const nameInput = container.querySelector('.meta-field-mgr__add-row .meta-field-mgr__input') as HTMLInputElement
+    nameInput.value = '   '
+    nameInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await nextTick()
+
+    expect(container.querySelector('[data-test="add-conflict-error"]')).toBeNull()
+    expect(nameInput.getAttribute('aria-invalid')).not.toBe('true')
+
+    app.unmount()
+  })
+
   it('emits engine-shape validation rules in the property payload on save', async () => {
     const container = document.createElement('div')
     document.body.appendChild(container)

--- a/docs/development/multitable-field-manager-ux-polish-development-verification-20260507.md
+++ b/docs/development/multitable-field-manager-ux-polish-development-verification-20260507.md
@@ -1,0 +1,113 @@
+# Multitable Field Manager UX Polish — Development Verification (2026-05-07)
+
+## Lane / scope
+- Lane D — Field UX polish
+- Branch: `codex/multitable-field-ux-polish-20260507`
+- Worktree: `/private/tmp/ms2-field-ux-polish-20260507`
+- Baseline: `8d3e5df1f feat(integration): expose dead-letter communication api (#1407)` (origin/main)
+
+## Polish chosen — and why
+
+**Inline name-conflict validation for the Add and Rename inputs in `MetaFieldManager.vue`.**
+
+Before this change the field manager silently emitted `create-field` / `update-field` even when the
+typed name duplicated another field on the sheet. The user got no inline feedback and depended on
+the backend to reject the request — which surfaces (if at all) as a generic toast far from the
+input that caused it. This is a frequent first-time experience friction (e.g. a user typing
+`status` while a `Status` field already exists).
+
+The polish:
+
+1. Renders an inline `role="alert"` message under the offending input.
+2. Disables the `+ Add` button and the rename `✓` (confirm) button while the conflict is present.
+3. Wires `aria-invalid` / `aria-describedby` on the inputs so screen readers announce the error.
+4. Hardens `onAddField` and `confirmRename` to early-return on conflict, so even Enter-keypresses
+   that bypass the disabled button don't fire stale events.
+5. Compares case-insensitively after `.trim()` — the friendlier default; a future server-side
+   uniqueness rule (today there is none in `packages/core-backend/src/multitable/`) can tighten
+   independently without UI churn. The field being renamed is excluded from its own conflict set,
+   so re-confirming the same name (or only changing case) is treated as a no-op rather than a
+   conflict.
+
+### Why not the alternatives
+
+| Candidate | Reason skipped |
+| --- | --- |
+| Esc-to-cancel / Enter-to-save in rename | Already implemented (template lines 22-23). |
+| Confirmation before delete | Already implemented (template lines 327-333). |
+| Up/down reorder | Already implemented (template lines 33-34). |
+| Auto-focus rename input | Real but tiny, hard to test richly in jsdom (would yield only 1-2 thin assertions). |
+| aria-label polish for icon-only buttons | Real a11y gap, but the test surface degenerates to attribute snapshots. Combined `title=` + the new `role="alert"` on conflicts already gets us partway. |
+
+## Files changed
+
+| Path | LOC delta |
+| --- | --- |
+| `apps/web/src/multitable/components/MetaFieldManager.vue` | +72 / −10 (net +62) |
+| `apps/web/tests/multitable-field-manager.spec.ts` | +154 / −0 |
+| **Total** | **+226 / −10** (well under the 300-LOC budget) |
+
+No other files were modified. No backend, no DingTalk, no integration-core, no autoNumber section.
+
+## Test commands & results
+
+```text
+$ pnpm --filter @metasheet/web exec vitest run tests/multitable-field-manager.spec.ts \
+    --watch=false --reporter=dot
+
+ RUN  v1.6.1 /private/tmp/ms2-field-ux-polish-20260507/apps/web
+
+ ✓ tests/multitable-field-manager.spec.ts  (17 tests) 75ms
+
+ Test Files  1 passed (1)
+      Tests  17 passed (17)
+   Start at  06:05:06
+   Duration  552ms
+```
+
+(14 pre-existing tests still green + 3 new tests for this polish.)
+
+```text
+$ pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+(no output, exit 0)
+
+$ git diff --check
+(no whitespace errors)
+```
+
+### New tests
+
+1. `blocks adding a field whose name duplicates an existing one (case-insensitive)` —
+   asserts the inline error renders, the `+ Add` button disables, both click and Enter-key
+   submission no-op, and renaming the typed value to a non-conflicting name re-enables creation.
+2. `blocks renaming a field to an existing name and excludes the field itself` — asserts that
+   typing a sibling field's name surfaces the conflict alert and disables the confirm button,
+   that the field's own current name is *not* flagged as a conflict against itself, and that a
+   unique name proceeds to emit the `update-field` payload.
+3. `does not flag the add-row when the input is empty or whitespace` — guards the empty-string
+   regression where any field would falsely trigger the conflict UI.
+
+## Known limitations
+
+- Comparison is case-insensitive after trimming. Internal whitespace (e.g. `"Status "` vs
+  `"Sta tus"`) is treated as distinct. If product later requires Unicode normalization
+  (e.g. NFC/NFKC) for CJK or accented names, the `normalizeFieldName` helper is the single
+  edit point.
+- Backend uniqueness is *not* enforced today; this is a UX-only guard. If a duplicate slips
+  in via API (or pre-existed), the manager will display the conflict alert as soon as the
+  user re-opens it for rename — which is the desired behavior (surface the latent conflict)
+  rather than a regression.
+- The inline error is announced via `role="alert"` and `aria-describedby`. Some assistive
+  tech may still require an explicit `aria-live="polite"` region; we rely on the well-known
+  alert role to keep the markup minimal.
+
+## K3 PoC Stage 1 Lock applicability
+
+- Frontend-only change. No `plugins/plugin-integration-core/*` touch.
+- No backend, migration, schema, or contract change. No new platform战线.
+- Falls under "内核打磨 permitted" — strictly improves an existing field-manager surface.
+
+## Commit
+
+- Single commit on `codex/multitable-field-ux-polish-20260507`.
+- Not pushed. No PR opened (per instructions).


### PR DESCRIPTION
## Summary

Lane D of the multitable Feishu RC three-lane plan. The Add and Rename inputs in `MetaFieldManager.vue` silently emitted `create-field` / `update-field` even when the typed name duplicated another field on the sheet, deferring failure to the backend with no inline feedback.

This PR renders an inline `role="alert"` message under the offending input, disables the `+ Add` and rename-confirm `✓` buttons while a conflict exists, sets `aria-invalid` / `aria-describedby` on inputs for screen readers, and early-returns the action handlers so Enter-key submissions cannot bypass the gate.

Comparison is case-insensitive after `trim()`. The field being renamed is excluded from its own conflict set so re-confirming the same value (or only changing case) is treated as a no-op rather than a conflict.

## K3 PoC Stage 1 Lock applicability

- Does NOT modify `plugins/plugin-integration-core/*`.
- Frontend-only UX hardening on a shipped feature (Field Manager); no platform expansion.
- No backend / OpenAPI / migration touched.
- Did not touch the autoNumber prefix/digits/start config section in MetaFieldManager (lane-D constraint).

## Files changed

- `apps/web/src/multitable/components/MetaFieldManager.vue` — +72 / −10 (net +62)
- `apps/web/tests/multitable-field-manager.spec.ts` — +154 / −0
- `docs/development/multitable-field-manager-ux-polish-development-verification-20260507.md` — new (113 lines)

## Test plan

- [x] `pnpm --filter @metasheet/web exec vitest run tests/multitable-field-manager.spec.ts --reporter=dot` → **17/17 passed** (14 pre-existing + 3 new: add-conflict gate with case-insensitive match and recovery, rename-conflict gate excluding self, whitespace-only input does not falsely flag)
- [x] `pnpm --filter @metasheet/web exec vue-tsc -b --noEmit` → passed
- [x] `git diff --check` → passed

## Known limitations

1. Comparison is case-insensitive after `trim()`; internal whitespace is treated as distinct (e.g. `"Status "` vs `"Sta tus"`). Single edit point in `normalizeFieldName` if Unicode normalization is later required.
2. Backend uniqueness is not enforced today; this is a UX-only guard. Pre-existing duplicates surface the alert when the user opens rename — desired (surfaces the issue) rather than a regression.
3. Relies on `role="alert"` rather than an explicit `aria-live` region; standard alert role should suffice for most assistive tech.

🤖 Generated with [Claude Code](https://claude.com/claude-code)