### PR TITLE
fix(integration): include runtime metadata in ping

### DIFF
--- a/docs/development/integration-core-ping-runtime-metadata-design-20260507.md
+++ b/docs/development/integration-core-ping-runtime-metadata-design-20260507.md
@@ -1,0 +1,44 @@
+# Integration Core Ping Runtime Metadata Design - 2026-05-07
+
+## Context
+
+After the runtime status refresh, `GET /api/integration/health` and
+`communication.call('integration-core', 'getStatus')` report the current
+integration-core version and phase. The lightweight communication `ping()`
+method still returned only `ok`, `plugin`, and `ts`.
+
+That made plugin startup probes choose between:
+
+- using `ping()` and losing version/phase context, or
+- calling full `getStatus()` just to confirm runtime identity.
+
+## Change
+
+`ping()` now returns:
+
+```json
+{
+  "ok": true,
+  "plugin": "plugin-integration-core",
+  "version": "0.1.0",
+  "phase": "integration-core-mvp",
+  "ts": 1234567890
+}
+```
+
+The method remains intentionally lightweight. It does not include the full
+capability object because `getStatus()` is still the readiness and diagnostics
+surface.
+
+## Compatibility
+
+This is additive. Existing callers that only check `ok`, `plugin`, or `ts`
+continue to work.
+
+## Files Changed
+
+- `plugins/plugin-integration-core/index.cjs`
+- `plugins/plugin-integration-core/__tests__/plugin-runtime-smoke.test.cjs`
+- `plugins/plugin-integration-core/__tests__/host-loader-smoke.test.mjs`
+- `docs/development/integration-core-ping-runtime-metadata-design-20260507.md`
+- `docs/development/integration-core-ping-runtime-metadata-verification-20260507.md`

--- a/docs/development/integration-core-ping-runtime-metadata-verification-20260507.md
+++ b/docs/development/integration-core-ping-runtime-metadata-verification-20260507.md
@@ -1,0 +1,51 @@
+# Integration Core Ping Runtime Metadata Verification - 2026-05-07
+
+## Local Verification
+
+Worktree:
+
+`/private/tmp/ms2-http-status-capabilities`
+
+Branch:
+
+`codex/integration-http-status-capabilities-20260507`
+
+Baseline:
+
+`origin/main` at `02cee56861e18c88f67a3b49366cc29e2b6e3ffd`
+
+Commands:
+
+```bash
+node plugins/plugin-integration-core/__tests__/plugin-runtime-smoke.test.cjs
+pnpm install --frozen-lockfile
+node --import tsx plugins/plugin-integration-core/__tests__/host-loader-smoke.test.mjs
+pnpm -F plugin-integration-core test
+pnpm validate:plugins
+git diff --check
+```
+
+Results:
+
+- `plugin-runtime-smoke`: passed.
+- `pnpm install --frozen-lockfile`: passed; lockfile unchanged.
+- `host-loader-smoke`: passed.
+- `pnpm -F plugin-integration-core test`: passed.
+- `pnpm validate:plugins`: 13/13 valid, 0 errors.
+- `git diff --check`: passed.
+
+## Regression Coverage
+
+Updated `plugin-runtime-smoke.test.cjs` to verify:
+
+- communication `ping().version` follows `plugin.json`.
+- communication `ping().phase` is `integration-core-mvp`.
+
+Updated `host-loader-smoke.test.mjs` to verify the same metadata through the
+real `PluginLoader` activation path.
+
+## Environment Note
+
+The temporary worktree initially lacked local `node_modules`, so tests that load
+`tsx` could not start. After `pnpm install --frozen-lockfile`, the host-loader
+and full plugin test commands completed successfully.

--- a/plugins/plugin-integration-core/__tests__/host-loader-smoke.test.mjs
+++ b/plugins/plugin-integration-core/__tests__/host-loader-smoke.test.mjs
@@ -115,6 +115,8 @@ async function main() {
   const ping = await host.context.communication.call('integration-core', 'ping')
   assert.equal(ping.ok, true)
   assert.equal(ping.plugin, 'plugin-integration-core')
+  assert.equal(ping.version, '0.1.0')
+  assert.equal(ping.phase, 'integration-core-mvp')
 
   const status = await host.context.communication.call('integration-core', 'getStatus')
   assert.equal(status.plugin, 'plugin-integration-core')

--- a/plugins/plugin-integration-core/__tests__/plugin-runtime-smoke.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/plugin-runtime-smoke.test.cjs
@@ -158,6 +158,8 @@ async function main() {
   // --- 5. Comm API returns expected shape ------------------------------
   const pingResult = await commApi.ping()
   assert.equal(pingResult.ok, true, 'ping.ok')
+  assert.equal(pingResult.version, manifest.version, 'ping.version follows manifest')
+  assert.equal(pingResult.phase, 'integration-core-mvp', 'ping.phase')
   const statusResult = await commApi.getStatus()
   assert.equal(statusResult.plugin, 'plugin-integration-core', 'status.plugin')
   assert.equal(statusResult.version, manifest.version, 'status.version follows manifest')

--- a/plugins/plugin-integration-core/index.cjs
+++ b/plugins/plugin-integration-core/index.cjs
@@ -100,7 +100,13 @@ function buildCommunicationApi() {
   return {
     // Cross-plugin control seam for the integration plugin family.
     async ping() {
-      return { ok: true, plugin: PLUGIN_ID, ts: Date.now() }
+      return {
+        ok: true,
+        plugin: PLUGIN_ID,
+        version: PLUGIN_VERSION,
+        phase: PLUGIN_PHASE,
+        ts: Date.now(),
+      }
     },
     async getStatus() {
       const capabilities = buildCapabilityStatus()


### PR DESCRIPTION
## Summary

Adds runtime identity metadata to the lightweight `integration-core` communication ping:

- `version` follows `plugin.json`
- `phase` reports `integration-core-mvp`

This keeps `ping()` lightweight while letting plugin startup probes confirm runtime identity without calling full `getStatus()`.

## Docs

- `docs/development/integration-core-ping-runtime-metadata-design-20260507.md`
- `docs/development/integration-core-ping-runtime-metadata-verification-20260507.md`

## Verification

```bash
node plugins/plugin-integration-core/__tests__/plugin-runtime-smoke.test.cjs
pnpm install --frozen-lockfile
node --import tsx plugins/plugin-integration-core/__tests__/host-loader-smoke.test.mjs
pnpm -F plugin-integration-core test
pnpm validate:plugins
git diff --check
```

After rebasing onto latest `origin/main`, reran:

```bash
node plugins/plugin-integration-core/__tests__/plugin-runtime-smoke.test.cjs && node --import tsx plugins/plugin-integration-core/__tests__/host-loader-smoke.test.mjs
git diff --check origin/main...HEAD
```
