### PR TITLE
feat(multitable): enforce self-table Gantt dependencies

### DIFF
--- a/apps/web/src/multitable/components/MetaGanttView.vue
+++ b/apps/web/src/multitable/components/MetaGanttView.vue
@@ -147,9 +147,10 @@
 import { computed, onBeforeUnmount, ref, watch } from 'vue'
 import type { LinkedRecordSummary, MetaAttachment, MetaField, MetaGanttViewConfig, MetaRecord } from '../types'
 import { formatFieldDisplay } from '../utils/field-display'
-import { resolveGanttViewConfig } from '../utils/view-config'
+import { isSelfTableLinkField, resolveGanttViewConfig } from '../utils/view-config'
 
 const props = defineProps<{
+  sheetId?: string
   rows: MetaRecord[]
   fields: MetaField[]
   loading: boolean
@@ -201,7 +202,7 @@ const resizeState = ref<{
 } | null>(null)
 
 const resolvedConfig = computed<Required<MetaGanttViewConfig>>(() =>
-  resolveGanttViewConfig(props.fields, props.viewConfig, props.groupInfo),
+  resolveGanttViewConfig(props.fields, props.viewConfig, props.groupInfo, props.sheetId),
 )
 
 watch(
@@ -225,7 +226,7 @@ const dateFields = computed(() => props.fields.filter((field) => field.type === 
 const titleFields = computed(() => props.fields)
 const numericFields = computed(() => props.fields.filter((field) => ['number', 'percent', 'currency', 'rating'].includes(field.type)))
 const groupableFields = computed(() => props.fields.filter((field) => ['select', 'string', 'boolean', 'date', 'dateTime'].includes(field.type)))
-const dependencyFields = computed(() => props.fields.filter((field) => field.type === 'link'))
+const dependencyFields = computed(() => props.fields.filter((field) => isSelfTableLinkField(field, props.sheetId)))
 const canResizeTasks = computed(() => Boolean(props.canEdit && startFieldId.value && endFieldId.value && startFieldId.value !== endFieldId.value))
 
 function parseDate(value: unknown): Date | null {

--- a/apps/web/src/multitable/components/MetaViewManager.vue
+++ b/apps/web/src/multitable/components/MetaViewManager.vue
@@ -445,6 +445,7 @@ import {
   type SortRule,
 } from '../composables/useMultitableGrid'
 import {
+  isSelfTableLinkField,
   resolveCalendarViewConfig,
   resolveGanttViewConfig,
   resolveGalleryViewConfig,
@@ -563,7 +564,7 @@ const dateLikeFields = computed(() => props.fields.filter((field) => field.type 
 const numericFields = computed(() => props.fields.filter((field) => ['number', 'currency', 'percent', 'rating'].includes(field.type)))
 const selectFields = computed(() => props.fields.filter((field) => field.type === 'select'))
 const linkFields = computed(() => props.fields.filter((field) => field.type === 'link'))
-const dependencyFields = computed(() => props.fields.filter((field) => field.type === 'link'))
+const dependencyFields = computed(() => props.fields.filter((field) => isSelfTableLinkField(field, props.sheetId)))
 const stringFields = computed(() => props.fields.filter((field) => ['string', 'formula', 'lookup'].includes(field.type)))
 const groupableFields = computed(() => props.fields.filter((field) => ['select', 'string', 'boolean', 'number', 'date', 'dateTime'].includes(field.type)))
 const validFieldIds = computed(() => new Set(props.fields.map((field) => field.id)))
@@ -932,7 +933,7 @@ function hydrateExistingViewConfig(view: MetaView, options?: { liveRefreshText?:
   } else if (view.type === 'timeline') {
     Object.assign(timelineDraft, resolveTimelineViewConfig(props.fields, view.config))
   } else if (view.type === 'gantt') {
-    Object.assign(ganttDraft, resolveGanttViewConfig(props.fields, view.config, view.groupInfo))
+    Object.assign(ganttDraft, resolveGanttViewConfig(props.fields, view.config, view.groupInfo, props.sheetId))
   } else if (view.type === 'kanban') {
     Object.assign(kanbanDraft, resolveKanbanViewConfig(props.fields, view.config, view.groupInfo))
   } else if (view.type === 'hierarchy') {

--- a/apps/web/src/multitable/utils/view-config.ts
+++ b/apps/web/src/multitable/utils/view-config.ts
@@ -41,6 +41,17 @@ function firstNonMatchingFieldId(fields: MetaField[], excludedIds: Array<string 
   return firstFieldId(candidates, types)
 }
 
+export function isSelfTableLinkField(field: MetaField, sheetId?: string | null): boolean {
+  if (field.type !== 'link') return false
+  const currentSheetId = typeof sheetId === 'string' ? sheetId.trim() : ''
+  if (!currentSheetId) return true
+  const property = field.property ?? {}
+  const foreignSheetId = typeof (property.foreignSheetId ?? property.foreignDatasheetId ?? property.datasheetId) === 'string'
+    ? String(property.foreignSheetId ?? property.foreignDatasheetId ?? property.datasheetId).trim()
+    : ''
+  return foreignSheetId === currentSheetId
+}
+
 export function resolveGalleryViewConfig(
   fields: MetaField[],
   raw?: Record<string, unknown> | null,
@@ -126,12 +137,12 @@ export function resolveGanttViewConfig(
   fields: MetaField[],
   raw?: Record<string, unknown> | null,
   groupInfo?: Record<string, unknown> | null,
+  sheetId?: string | null,
 ): Required<MetaGanttViewConfig> {
   const dateFieldTypes = ['date', 'dateTime']
-  const dependencyFieldTypes = ['link']
   const configuredDependencyFieldId = stringOrNull(raw?.dependencyFieldId)
   const dependencyFieldId = configuredDependencyFieldId
-    && fields.some((field) => field.id === configuredDependencyFieldId && dependencyFieldTypes.includes(field.type))
+    && fields.some((field) => field.id === configuredDependencyFieldId && isSelfTableLinkField(field, sheetId))
     ? configuredDependencyFieldId
     : null
   const startFieldId = stringOrNull(raw?.startFieldId) ?? firstFieldId(fields, dateFieldTypes)

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -201,6 +201,7 @@
         />
         <MetaGanttView
           v-else-if="activeViewType === 'gantt'"
+          :sheet-id="workbench.activeSheetId.value"
           :rows="grid.rows.value" :fields="scopedAllFields" :loading="grid.loading.value"
           :view-config="workbench.activeView.value?.config"
           :group-info="workbench.activeView.value?.groupInfo"

--- a/apps/web/tests/multitable-gantt-view.spec.ts
+++ b/apps/web/tests/multitable-gantt-view.spec.ts
@@ -34,15 +34,17 @@ describe('MetaGanttView', () => {
       { id: 'fld_name', name: 'Name', type: 'string' as const },
       { id: 'fld_start', name: 'Start', type: 'dateTime' as const },
       { id: 'fld_end', name: 'End', type: 'dateTime' as const },
-      { id: 'fld_deps', name: 'Depends on', type: 'link' as const },
+      { id: 'fld_deps', name: 'Depends on', type: 'link' as const, property: { foreignSheetId: 'sheet_1' } },
+      { id: 'fld_external', name: 'External', type: 'link' as const, property: { foreignSheetId: 'sheet_2' } },
       { id: 'fld_status', name: 'Status', type: 'select' as const },
     ]
 
-    expect(resolveGanttViewConfig(fields, { dependencyFieldId: 'fld_deps' })).toEqual(expect.objectContaining({
+    expect(resolveGanttViewConfig(fields, { dependencyFieldId: 'fld_deps' }, null, 'sheet_1')).toEqual(expect.objectContaining({
       startFieldId: 'fld_start',
       endFieldId: 'fld_end',
       dependencyFieldId: 'fld_deps',
     }))
+    expect(resolveGanttViewConfig(fields, { dependencyFieldId: 'fld_external' }, null, 'sheet_1').dependencyFieldId).toBeNull()
     expect(resolveGanttViewConfig(fields, { dependencyFieldId: 'fld_status' }).dependencyFieldId).toBeNull()
   })
 
@@ -310,31 +312,33 @@ describe('MetaGanttView', () => {
     const fields = [
       { id: 'fld_start', name: 'Start', type: 'date' as const },
       { id: 'fld_end', name: 'End', type: 'date' as const },
-      { id: 'fld_link', name: 'Depends on', type: 'link' as const },
+      { id: 'fld_link', name: 'Depends on', type: 'link' as const, property: { foreignSheetId: 'sheet_1' } },
       { id: 'fld_multi', name: 'Tags', type: 'multiSelect' as const },
       { id: 'fld_string', name: 'Notes', type: 'string' as const },
       { id: 'fld_select', name: 'Status', type: 'select' as const },
     ]
 
-    expect(resolveGanttViewConfig(fields, { dependencyFieldId: 'fld_link' }).dependencyFieldId).toBe('fld_link')
+    expect(resolveGanttViewConfig(fields, { dependencyFieldId: 'fld_link' }, null, 'sheet_1').dependencyFieldId).toBe('fld_link')
     expect(resolveGanttViewConfig(fields, { dependencyFieldId: 'fld_multi' }).dependencyFieldId).toBeNull()
     expect(resolveGanttViewConfig(fields, { dependencyFieldId: 'fld_string' }).dependencyFieldId).toBeNull()
     expect(resolveGanttViewConfig(fields, { dependencyFieldId: 'fld_select' }).dependencyFieldId).toBeNull()
   })
 
-  it('only lists link fields in the dependency dropdown', async () => {
+  it('only lists self-table link fields in the dependency dropdown', async () => {
     const container = document.createElement('div')
     document.body.appendChild(container)
 
     const app = createApp({
       render() {
         return h(MetaGanttView, {
+          sheetId: 'sheet_1',
           loading: false,
           fields: [
             { id: 'fld_name', name: 'Name', type: 'string' },
             { id: 'fld_start', name: 'Start', type: 'date' },
             { id: 'fld_end', name: 'End', type: 'date' },
-            { id: 'fld_deps', name: 'Depends on', type: 'link' },
+            { id: 'fld_deps', name: 'Depends on', type: 'link', property: { foreignSheetId: 'sheet_1' } },
+            { id: 'fld_external', name: 'External deps', type: 'link', property: { foreignSheetId: 'sheet_2' } },
             { id: 'fld_tags', name: 'Tags', type: 'multiSelect' },
             { id: 'fld_notes', name: 'Notes', type: 'string' },
           ],
@@ -352,6 +356,7 @@ describe('MetaGanttView', () => {
     const optionLabels = Array.from(dependencySelect.options).map((opt) => opt.textContent?.trim())
 
     expect(optionLabels).toContain('Depends on')
+    expect(optionLabels).not.toContain('External deps')
     expect(optionLabels).not.toContain('Tags')
     expect(optionLabels).not.toContain('Notes')
 

--- a/apps/web/tests/multitable-view-manager.spec.ts
+++ b/apps/web/tests/multitable-view-manager.spec.ts
@@ -86,7 +86,8 @@ describe('MetaViewManager', () => {
             { id: 'fld_name', name: 'Name', type: 'string' },
             { id: 'fld_start', name: 'Start', type: 'date' },
             { id: 'fld_end', name: 'End', type: 'date' },
-            { id: 'fld_deps', name: 'Depends on', type: 'link' },
+            { id: 'fld_deps', name: 'Depends on', type: 'link', property: { foreignSheetId: 'sheet_1' } },
+            { id: 'fld_external', name: 'External deps', type: 'link', property: { foreignSheetId: 'sheet_2' } },
             { id: 'fld_tags', name: 'Tags', type: 'multiSelect' },
             { id: 'fld_notes', name: 'Notes', type: 'string' },
             { id: 'fld_status', name: 'Status', type: 'select' },
@@ -113,6 +114,7 @@ describe('MetaViewManager', () => {
 
     const selects = Array.from(container.querySelectorAll('.meta-view-mgr__config select')) as HTMLSelectElement[]
     expect(Array.from(selects[5].options).map((option) => option.value)).toEqual(['', 'fld_deps'])
+    expect(Array.from(selects[5].options).map((option) => option.textContent?.trim())).not.toContain('External deps')
     selects[5].value = 'fld_deps'
     selects[5].dispatchEvent(new Event('change', { bubbles: true }))
     await nextTick()

--- a/apps/web/tests/multitable-workbench-view.spec.ts
+++ b/apps/web/tests/multitable-workbench-view.spec.ts
@@ -699,11 +699,13 @@ vi.mock('../src/multitable/components/MetaGanttView.vue', () => ({
   default: defineComponent({
     name: 'MetaGanttView',
     props: {
+      sheetId: { type: String, default: '' },
       canEdit: { type: Boolean, default: false },
     },
     emits: ['patch-dates'],
     render() {
       return h('div', {
+        'data-gantt-sheet-id': this.$props.sheetId,
         'data-gantt-can-edit': String(this.$props.canEdit),
       }, [
         h(
@@ -1796,6 +1798,7 @@ describe('MultitableWorkbench view wiring', () => {
     workbenchMock.activeViewId.value = 'view_gantt'
     await flushUi()
 
+    expect(container!.querySelector('[data-gantt-sheet-id]')?.getAttribute('data-gantt-sheet-id')).toBe('sheet_orders')
     expect(container!.querySelector('[data-gantt-can-edit]')?.getAttribute('data-gantt-can-edit')).toBe('false')
 
     workbenchMock.activeViewId.value = 'view_hierarchy'

--- a/docs/development/multitable-gantt-self-table-dependency-design-20260507.md
+++ b/docs/development/multitable-gantt-self-table-dependency-design-20260507.md
@@ -1,0 +1,52 @@
+# Multitable Gantt Self-Table Dependency Field · Design
+
+> Date: 2026-05-07
+> Scope: Gantt dependency field tightening follow-up after PR #1409
+> Branch: `codex/multitable-gantt-self-table-dependency-20260507`
+
+## Context
+
+PR #1409 narrowed Gantt dependency fields from `link | multiSelect | string` to `link`, but the original Feishu parity plan required `dependencyFieldId` to be a self-table link field. A cross-table link is still a link, but it cannot reliably draw arrows in the current Gantt view because the rendered task set only contains records from the active sheet.
+
+## Design
+
+This follow-up applies the same self-table constraint in three places:
+
+1. Frontend config normalization
+   - `resolveGanttViewConfig()` now accepts an optional `sheetId`.
+   - A configured dependency field is kept only when it is a link whose `property.foreignSheetId` (or compatible aliases) equals the active sheet id.
+   - Without a sheet id, the function keeps the old link-only behavior for existing isolated unit tests and non-render callers.
+
+2. Frontend selectable fields
+   - `MetaGanttView` receives `sheetId` from `MultitableWorkbench` and only lists self-table link fields in the dependency dropdown.
+   - `MetaViewManager` already has `sheetId`; its Gantt dependency dropdown now uses the same helper.
+
+3. Backend write guard
+   - `POST /api/multitable/views` and `PATCH /api/multitable/views/:viewId` validate Gantt `config.dependencyFieldId` before persisting.
+   - The guard reads the field from `meta_fields` for the target sheet and requires:
+     - `type === 'link'`
+     - `property.foreignSheetId === view.sheet_id`
+   - Invalid configs return `400 VALIDATION_ERROR`.
+
+## Key Decision
+
+The canonical target sheet property remains `foreignSheetId`; aliases `foreignDatasheetId` and `datasheetId` are supported where the existing field-codec path already normalizes them.
+
+## Out Of Scope
+
+- No generic view-config schema framework is introduced.
+- No backend validation is added for every Gantt config property.
+- No Hierarchy drag-to-reparent work is included.
+- No migration is required; stale stored configs are scrubbed by frontend normalization and rejected on the next explicit Gantt config save.
+
+## Files
+
+- `apps/web/src/multitable/utils/view-config.ts`
+- `apps/web/src/multitable/components/MetaGanttView.vue`
+- `apps/web/src/multitable/components/MetaViewManager.vue`
+- `apps/web/src/multitable/views/MultitableWorkbench.vue`
+- `packages/core-backend/src/routes/univer-meta.ts`
+- `apps/web/tests/multitable-gantt-view.spec.ts`
+- `apps/web/tests/multitable-view-manager.spec.ts`
+- `apps/web/tests/multitable-workbench-view.spec.ts`
+- `packages/core-backend/tests/integration/multitable-view-config.api.test.ts`

--- a/docs/development/multitable-gantt-self-table-dependency-verification-20260507.md
+++ b/docs/development/multitable-gantt-self-table-dependency-verification-20260507.md
@@ -1,0 +1,70 @@
+# Multitable Gantt Self-Table Dependency Field · Verification
+
+> Date: 2026-05-07
+> Branch: `codex/multitable-gantt-self-table-dependency-20260507`
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/web exec vitest run \
+  tests/multitable-gantt-view.spec.ts \
+  tests/multitable-view-manager.spec.ts \
+  tests/multitable-workbench-view.spec.ts \
+  --watch=false --reporter=dot
+pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
+  tests/integration/multitable-view-config.api.test.ts \
+  --reporter=dot
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+pnpm --filter @metasheet/core-backend build
+git diff --check
+```
+
+## Results
+
+Frontend focused tests:
+
+```text
+Test Files  3 passed (3)
+Tests       76 passed (76)
+```
+
+Backend view-config integration test:
+
+```text
+Test Files  1 passed (1)
+Tests       7 passed (7)
+```
+
+Type/build gates:
+
+```text
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+passed
+
+pnpm --filter @metasheet/core-backend build
+passed
+
+git diff --check
+passed
+```
+
+## Coverage Added
+
+- `resolveGanttViewConfig()` keeps self-table link dependency fields and drops cross-table link dependency fields when `sheetId` is provided.
+- `MetaGanttView` dependency dropdown lists self-table links only.
+- `MetaViewManager` Gantt dependency dropdown lists self-table links only.
+- `MultitableWorkbench` passes active sheet id into `MetaGanttView`.
+- Backend rejects `PATCH /views/:viewId` with a cross-table Gantt dependency field.
+- Backend allows `PATCH /views/:viewId` with a self-table Gantt dependency field.
+- Backend rejects `POST /views` when a new Gantt config references a non-self-table dependency field.
+
+## Notes
+
+The default backend vitest config excludes integration tests, so the backend route test must be run with `vitest.integration.config.ts`.
+
+`pnpm install --frozen-lockfile` rewrote plugin and CLI `node_modules` symlinks in the worktree. Those install artifacts were reverted with:
+
+```bash
+git checkout -- plugins/ tools/
+```

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -2899,6 +2899,42 @@ class ValidationError extends Error {
   }
 }
 
+function stringFromRecord(value: Record<string, unknown>, keys: string[]): string {
+  for (const key of keys) {
+    const raw = value[key]
+    if (typeof raw === 'string' && raw.trim()) return raw.trim()
+  }
+  return ''
+}
+
+async function validateGanttDependencyConfig(
+  query: QueryFn,
+  sheetId: string,
+  viewType: string,
+  config: Record<string, unknown>,
+): Promise<string | null> {
+  if (viewType !== 'gantt') return null
+  const dependencyFieldId = typeof config.dependencyFieldId === 'string' ? config.dependencyFieldId.trim() : ''
+  if (!dependencyFieldId) return null
+
+  const fieldRes = await query(
+    'SELECT id, name, type, property, "order" FROM meta_fields WHERE sheet_id = $1 AND id = $2',
+    [sheetId, dependencyFieldId],
+  )
+  const fieldRow = (fieldRes.rows as any[])[0]
+  if (!fieldRow) {
+    return `Gantt dependency field must be a self-table link field: ${dependencyFieldId}`
+  }
+
+  const field = serializeFieldRow(fieldRow)
+  const foreignSheetId = stringFromRecord(field.property ?? {}, ['foreignSheetId', 'foreignDatasheetId', 'datasheetId'])
+  if (field.type !== 'link' || foreignSheetId !== sheetId) {
+    return `Gantt dependency field must be a self-table link field: ${dependencyFieldId}`
+  }
+
+  return null
+}
+
 class PermissionError extends Error {
   constructor(public message: string) {
     super(message)
@@ -4709,6 +4745,10 @@ export function univerMetaRouter(): Router {
       if (incomingRules !== undefined) {
         incomingConfig.conditionalFormattingRules = sanitizeConditionalFormattingRules(incomingRules)
       }
+      const ganttConfigError = await validateGanttDependencyConfig(pool.query.bind(pool), sheetId, type, incomingConfig)
+      if (ganttConfigError) {
+        return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: ganttConfigError } })
+      }
 
       await pool.query(
         `INSERT INTO meta_views (id, sheet_id, name, type, filter_info, sort_info, group_info, hidden_field_ids, config)
@@ -4802,6 +4842,17 @@ export function univerMetaRouter(): Router {
       if (incomingRules !== undefined) {
         ;(nextConfig as Record<string, unknown>).conditionalFormattingRules =
           sanitizeConditionalFormattingRules(incomingRules)
+      }
+      if (parsed.data.config !== undefined || parsed.data.type !== undefined) {
+        const ganttConfigError = await validateGanttDependencyConfig(
+          pool.query.bind(pool),
+          String(row.sheet_id),
+          nextType,
+          nextConfig as Record<string, unknown>,
+        )
+        if (ganttConfigError) {
+          return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: ganttConfigError } })
+        }
       }
 
       await pool.query(

--- a/packages/core-backend/tests/integration/multitable-view-config.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-view-config.api.test.ts
@@ -182,6 +182,189 @@ describe('Multitable view config API', () => {
     }))
   })
 
+  test('rejects Gantt dependency config when dependency field links to another sheet', async () => {
+    const { app, mockPool } = await createApp({
+      tokenPerms: ['multitable:write'],
+      queryHandler: async (sql, params) => {
+        if (sql.includes('SELECT sp.sheet_id, sp.perm_code, sp.subject_type')) {
+          expect(params).toEqual(['user_multitable_1', ['sheet_ops']])
+          return { rows: [] }
+        }
+        if (sql.includes('SELECT id, sheet_id, name, type, filter_info, sort_info, group_info, hidden_field_ids, config FROM meta_views WHERE id = $1')) {
+          expect(params).toEqual(['view_gantt'])
+          return {
+            rows: [{
+              id: 'view_gantt',
+              sheet_id: 'sheet_ops',
+              name: 'Gantt',
+              type: 'gantt',
+              filter_info: {},
+              sort_info: {},
+              group_info: {},
+              hidden_field_ids: [],
+              config: {},
+            }],
+          }
+        }
+        if (sql.includes('SELECT id, name, type, property, "order" FROM meta_fields WHERE sheet_id = $1 AND id = $2')) {
+          expect(params).toEqual(['sheet_ops', 'fld_cross_sheet'])
+          return {
+            rows: [{
+              id: 'fld_cross_sheet',
+              name: 'External dependency',
+              type: 'link',
+              property: { foreignSheetId: 'sheet_other' },
+              order: 3,
+            }],
+          }
+        }
+        if (sql.includes('UPDATE meta_views')) {
+          throw new Error('UPDATE should not run for invalid Gantt dependency config')
+        }
+        throw new Error(`Unhandled SQL in test: ${sql}`)
+      },
+    })
+
+    const response = await request(app)
+      .patch('/api/multitable/views/view_gantt')
+      .send({
+        config: {
+          startFieldId: 'fld_start',
+          endFieldId: 'fld_end',
+          dependencyFieldId: 'fld_cross_sheet',
+        },
+      })
+      .expect(400)
+
+    expect(response.body.ok).toBe(false)
+    expect(response.body.error).toMatchObject({
+      code: 'VALIDATION_ERROR',
+      message: 'Gantt dependency field must be a self-table link field: fld_cross_sheet',
+    })
+    expect(mockPool.query).not.toHaveBeenCalledWith(expect.stringContaining('UPDATE meta_views'), expect.anything())
+  })
+
+  test('allows Gantt dependency config when dependency field links to the same sheet', async () => {
+    let updateParams: unknown[] | undefined
+
+    const { app } = await createApp({
+      tokenPerms: ['multitable:write'],
+      queryHandler: async (sql, params) => {
+        if (sql.includes('SELECT sp.sheet_id, sp.perm_code, sp.subject_type')) {
+          expect(params).toEqual(['user_multitable_1', ['sheet_ops']])
+          return { rows: [] }
+        }
+        if (sql.includes('SELECT id, sheet_id, name, type, filter_info, sort_info, group_info, hidden_field_ids, config FROM meta_views WHERE id = $1')) {
+          expect(params).toEqual(['view_gantt'])
+          return {
+            rows: [{
+              id: 'view_gantt',
+              sheet_id: 'sheet_ops',
+              name: 'Gantt',
+              type: 'gantt',
+              filter_info: {},
+              sort_info: {},
+              group_info: {},
+              hidden_field_ids: [],
+              config: {},
+            }],
+          }
+        }
+        if (sql.includes('SELECT id, name, type, property, "order" FROM meta_fields WHERE sheet_id = $1 AND id = $2')) {
+          expect(params).toEqual(['sheet_ops', 'fld_deps'])
+          return {
+            rows: [{
+              id: 'fld_deps',
+              name: 'Dependencies',
+              type: 'link',
+              property: { foreignSheetId: 'sheet_ops' },
+              order: 3,
+            }],
+          }
+        }
+        if (sql.includes('UPDATE meta_views')) {
+          updateParams = params
+          return { rows: [], rowCount: 1 }
+        }
+        throw new Error(`Unhandled SQL in test: ${sql}`)
+      },
+    })
+
+    const response = await request(app)
+      .patch('/api/multitable/views/view_gantt')
+      .send({
+        config: {
+          startFieldId: 'fld_start',
+          endFieldId: 'fld_end',
+          dependencyFieldId: 'fld_deps',
+        },
+      })
+      .expect(200)
+
+    expect(response.body.ok).toBe(true)
+    expect(response.body.data.view.config).toMatchObject({
+      startFieldId: 'fld_start',
+      endFieldId: 'fld_end',
+      dependencyFieldId: 'fld_deps',
+    })
+    expect(updateParams?.[7]).toBe(JSON.stringify({
+      startFieldId: 'fld_start',
+      endFieldId: 'fld_end',
+      dependencyFieldId: 'fld_deps',
+    }))
+  })
+
+  test('rejects Gantt dependency config on view creation when dependency field is not self-table', async () => {
+    const { app, mockPool } = await createApp({
+      tokenPerms: ['multitable:write'],
+      queryHandler: async (sql, params) => {
+        if (sql.includes('SELECT sp.sheet_id, sp.perm_code, sp.subject_type')) {
+          expect(params).toEqual(['user_multitable_1', ['sheet_ops']])
+          return { rows: [] }
+        }
+        if (sql.includes('SELECT id FROM meta_sheets WHERE id = $1')) {
+          expect(params).toEqual(['sheet_ops'])
+          return { rows: [{ id: 'sheet_ops' }] }
+        }
+        if (sql.includes('SELECT id, name, type, property, "order" FROM meta_fields WHERE sheet_id = $1 AND id = $2')) {
+          expect(params).toEqual(['sheet_ops', 'fld_notes'])
+          return {
+            rows: [{
+              id: 'fld_notes',
+              name: 'Notes',
+              type: 'string',
+              property: {},
+              order: 3,
+            }],
+          }
+        }
+        if (sql.includes('INSERT INTO meta_views')) {
+          throw new Error('INSERT should not run for invalid Gantt dependency config')
+        }
+        throw new Error(`Unhandled SQL in test: ${sql}`)
+      },
+    })
+
+    const response = await request(app)
+      .post('/api/multitable/views')
+      .send({
+        sheetId: 'sheet_ops',
+        name: 'Gantt',
+        type: 'gantt',
+        config: {
+          dependencyFieldId: 'fld_notes',
+        },
+      })
+      .expect(400)
+
+    expect(response.body.ok).toBe(false)
+    expect(response.body.error).toMatchObject({
+      code: 'VALIDATION_ERROR',
+      message: 'Gantt dependency field must be a self-table link field: fld_notes',
+    })
+    expect(mockPool.query).not.toHaveBeenCalledWith(expect.stringContaining('INSERT INTO meta_views'), expect.anything())
+  })
+
   test('deletes a view by id through DELETE /views/:viewId', async () => {
     const { app } = await createApp({
       tokenPerms: ['multitable:write'],


### PR DESCRIPTION
## Summary\n\n- enforce Gantt dependency fields as self-table links in frontend normalization/dropdowns\n- pass active sheet id into MetaGanttView so cross-table links are hidden\n- reject invalid Gantt dependencyFieldId in POST/PATCH view config writes\n- add design and verification docs\n\n## Verification\n\n- pnpm --filter @metasheet/web exec vitest run tests/multitable-gantt-view.spec.ts tests/multitable-view-manager.spec.ts tests/multitable-workbench-view.spec.ts --watch=false --reporter=dot\n- pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/multitable-view-config.api.test.ts --reporter=dot\n- pnpm --filter @metasheet/web exec vue-tsc -b --noEmit\n- pnpm --filter @metasheet/core-backend build\n- git diff --check\n\n## Docs\n\n- docs/development/multitable-gantt-self-table-dependency-design-20260507.md\n- docs/development/multitable-gantt-self-table-dependency-verification-20260507.md\n\n## K3 PoC Stage 1 Lock\n\nThis PR does not touch plugins/plugin-integration-core/* or any K3 PoC runtime path. It is a multitable Gantt parity hardening follow-up to PR #1409.