### PR TITLE
docs(integration): record ERP PLM phase 1 closeout

### DIFF
--- a/docs/development/integration-erp-plm-phase1-closeout-design-20260507.md
+++ b/docs/development/integration-erp-plm-phase1-closeout-design-20260507.md
@@ -1,0 +1,56 @@
+# ERP/PLM Phase 1 Closeout Design - 2026-05-07
+
+## Scope
+
+This closeout implements Phase 1 from
+`docs/development/integration-erp-plm-closeout-plan-20260507.md`.
+That plan was merged as #1413 at
+`93878365fbd0d606b76adfe10d21a813926be29f`, then this batch merged the six
+Phase 1 evidence/report hardening PRs on top of the refreshed `main`.
+
+Phase 1 covers the evidence/report safety layer for the PLM -> MetaSheet
+cleanse/staging -> K3 WISE ERP path. The purpose is to make customer-facing
+diagnostic artifacts safe and stable before merging deeper runtime guardrails.
+
+## Merged PRs
+
+Merged in descending PR order after refreshing all six branches to current
+`main` and waiting for fresh CI:
+
+| PR | Merge commit | Purpose |
+|---|---|---|
+| #1405 | `33e325dc4fa2b793061c8ce892c06ffbad365df2` | Expose staging validation field details |
+| #1404 | `88c6054a1c8bb97f01a2b9a94e2212755e47ce92` | Parse bracketed/schema-qualified K3 mock SQL tables |
+| #1403 | `592daee52e2a16ecc383b7de59445bff5ee80289` | Redact K3 mock request logs |
+| #1402 | `a0f5a888c29e987dcfde449328d589a0170e5737` | Escape live PoC Markdown reports |
+| #1401 | `128c8d78ab00733130b24bac55c2c041727d8eb7` | Escape postdeploy smoke Markdown evidence |
+| #1400 | `d978543b0f7c461b3a1291e0359affb39427ee58` | Escape postdeploy summary Markdown values |
+
+## Merge Policy
+
+All six PRs were:
+
+- refreshed with `gh pr update-branch`
+- `MERGEABLE`
+- fresh green on required CI before merge
+- free of failed and pending checks at merge time
+
+Because branch protection still required review approval and these are small
+safety/test/reporting PRs, the batch used admin squash merge in the order above.
+
+## Design Outcome
+
+The evidence/report layer now has these protections on `main`:
+
+- K3 live PoC preflight and evidence Markdown escaping for table-breaking values.
+- Postdeploy smoke Markdown escaping for table-breaking values.
+- Postdeploy summary Markdown escaping for table-breaking values.
+- Mock K3 request logging redacts credential-bearing fields.
+- Mock SQL executor handles common SQL Server bracket/schema identifier forms.
+- Staging descriptor validation reports field-level details for failed checks.
+
+## Remaining Work
+
+Phase 1 is complete. The next closeout batch should start Phase 2 runtime safety
+guards from the plan, beginning with low-overlap adapter/config guard PRs before
+runner/dead-letter/idempotency guard PRs.

--- a/docs/development/integration-erp-plm-phase1-closeout-verification-20260507.md
+++ b/docs/development/integration-erp-plm-phase1-closeout-verification-20260507.md
@@ -1,0 +1,77 @@
+# ERP/PLM Phase 1 Closeout Verification - 2026-05-07
+
+## Worktree
+
+`/private/tmp/ms2-integration-phase1-closeout`
+
+## Branch
+
+`codex/integration-phase1-closeout-20260507`
+
+## Baseline
+
+`origin/main` at `d978543b0f7c461b3a1291e0359affb39427ee58`
+
+## Merge Verification
+
+Commands:
+
+```bash
+gh pr merge 1413 --repo zensgit/metasheet2 --squash --admin --delete-branch
+
+gh pr update-branch 1405 --repo zensgit/metasheet2
+gh pr update-branch 1404 --repo zensgit/metasheet2
+gh pr update-branch 1403 --repo zensgit/metasheet2
+gh pr update-branch 1402 --repo zensgit/metasheet2
+gh pr update-branch 1401 --repo zensgit/metasheet2
+gh pr update-branch 1400 --repo zensgit/metasheet2
+
+gh pr view <number> --repo zensgit/metasheet2 --json mergeable,reviewDecision,statusCheckRollup
+gh pr merge <number> --repo zensgit/metasheet2 --squash --admin --delete-branch
+```
+
+Results:
+
+- #1413 merged at `93878365fbd0d606b76adfe10d21a813926be29f`.
+- #1405 merged at `33e325dc4fa2b793061c8ce892c06ffbad365df2`.
+- #1404 merged at `88c6054a1c8bb97f01a2b9a94e2212755e47ce92`.
+- #1403 merged at `592daee52e2a16ecc383b7de59445bff5ee80289`.
+- #1402 merged at `a0f5a888c29e987dcfde449328d589a0170e5737`.
+- #1401 merged at `128c8d78ab00733130b24bac55c2c041727d8eb7`.
+- #1400 merged at `d978543b0f7c461b3a1291e0359affb39427ee58`.
+
+## Batch Verification
+
+Commands:
+
+```bash
+node --test scripts/ops/integration-k3wise-live-poc-evidence.test.mjs
+node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
+node --test scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
+node scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs
+node plugins/plugin-integration-core/__tests__/staging-installer.test.cjs
+node --test scripts/ops/fixtures/integration-k3wise/mock-sqlserver-executor.test.mjs
+node --test scripts/ops/fixtures/integration-k3wise/mock-k3-webapi-server.test.mjs
+node --test scripts/ops/integration-k3wise-live-poc-preflight.test.mjs
+git diff --check
+```
+
+Results:
+
+- `integration-k3wise-live-poc-evidence.test.mjs`: 32/32 passed.
+- `integration-k3wise-postdeploy-smoke.test.mjs`: 13/13 passed.
+- `integration-k3wise-postdeploy-summary.test.mjs`: 10/10 passed.
+- `run-mock-poc-demo.mjs`: PASS, including Save-only K3 mock write, SQL readonly
+  probe, core-table write rejection, and evidence PASS.
+- `staging-installer.test.cjs`: all 7 assertions passed.
+- `mock-sqlserver-executor.test.mjs`: 5/5 passed.
+- `mock-k3-webapi-server.test.mjs`: 2/2 passed.
+- `integration-k3wise-live-poc-preflight.test.mjs`: 17/17 passed.
+- `git diff --check`: passed.
+
+## Residual Risk
+
+Phase 1 verifies customer-facing evidence/report safety and mock/staging support.
+It does not prove customer live K3 WISE connectivity. Live connectivity still
+depends on the customer GATE packet, network path, test account set, and K3/PLM
+credentials.


### PR DESCRIPTION
## Summary

- Records the merged ERP/PLM Phase 1 evidence/report safety closeout.
- Links the closeout plan merge (#1413) with the Phase 1 safety PR batch (#1405, #1404, #1403, #1402, #1401, #1400).
- Adds verification evidence for K3 WISE live PoC evidence, postdeploy smoke/summary, mock PoC demo, staging installer, mock SQL/K3 fixtures, preflight, and diff checks.

## Verification

- node --test scripts/ops/integration-k3wise-live-poc-evidence.test.mjs
- node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
- node --test scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
- node scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs
- node plugins/plugin-integration-core/__tests__/staging-installer.test.cjs
- node --test scripts/ops/fixtures/integration-k3wise/mock-sqlserver-executor.test.mjs
- node --test scripts/ops/fixtures/integration-k3wise/mock-k3-webapi-server.test.mjs
- node --test scripts/ops/integration-k3wise-live-poc-preflight.test.mjs
- git diff --check

Docs-only PR; no runtime code changes.