### PR TITLE
test(integration): align PLM K3 route chain normalization

### DIFF
--- a/docs/development/integration-erp-plm-phase2-adapter-closeout-design-20260508.md
+++ b/docs/development/integration-erp-plm-phase2-adapter-closeout-design-20260508.md
@@ -1,0 +1,71 @@
+# ERP/PLM Phase 2 Adapter Closeout Design - 2026-05-08
+
+## Scope
+
+This closeout continues the ERP/PLM K3 WISE Phase 2 backend hardening line after
+the guard closeout recorded in #1418.
+
+This batch covers adapter/runtime safety around PLM input normalization, generic
+HTTP adapter URL/query behavior, runner write counters, connection-test
+redaction, K3 live PoC secret text rejection, and K3 SQL Server table allowlist
+separation.
+
+## Merged PRs
+
+All seven PRs were refreshed onto current `main`, waited for fresh CI, and then
+squash-merged.
+
+| PR | Merge commit | Purpose |
+|---|---|---|
+| #1387 | `832601dbf0eb20c81743e75fff8d27d108fffc9e` | Tighten PLM wrapper input normalization |
+| #1386 | `2d9fdde004cda10ef2159c81285cb64def3ed8b7` | Reject unsafe HTTP adapter relative paths |
+| #1385 | `12cbdd2dfcdfce69ecaa023c3f199cb8602654cb` | Preserve HTTP adapter pagination query guards |
+| #1383 | `3e99b83278ecc7cf93e3a19fd2e023665e5d8aff` | Guard runner target write counters |
+| #1381 | `a8d65f81126af0e8e5300d309666c6860589826b` | Redact test-connection result payloads |
+| #1382 | `621933df46e82ff4684598a54b629c248f8c8bf4` | Reject secret-bearing K3 live PoC text |
+| #1380 | `520f1f197aca757eb25ed8d1a8f85ffe84f31bab` | Split K3 SQL Server core-table and middle-table allowlists |
+
+## Cross-Batch Adjustment
+
+Combined local verification found one test expectation that became stale after
+#1387. The PLM wrapper now normalizes string identifiers, so the REST PLM -> K3
+WISE route-chain test must expect the dead-letter `sourcePayload.code` value to
+be `bad-02` instead of the pre-normalization ` bad-02 `.
+
+The runtime behavior is intentionally unchanged by this closeout PR; only the
+test assertion is aligned with the normalized source-payload contract introduced
+by #1387.
+
+## Design Outcome
+
+The integration path now has these additional protections on `main`:
+
+- PLM source records are normalized consistently before downstream cleansing and
+  dead-letter capture.
+- HTTP adapter paths reject absolute or traversal-like inputs and preserve
+  reserved pagination query parameters.
+- Pipeline-runner target-write metrics are guarded against malformed adapter
+  counter values.
+- External-system connection tests do not expose secret-like result payloads.
+- K3 live PoC preflight/evidence text rejects secret-bearing values in free-text
+  fields.
+- K3 SQL Server channel separates core-table read allowlists from middle-table
+  write targets.
+
+## Remaining Work Estimate
+
+After this batch, the open ERP/PLM/K3 queue is mostly smaller hardening PRs plus
+a separate UI/config/live-evidence group.
+
+Approximate remaining engineering work:
+
+- Backend/runtime guard drain: 2-3 more small batches.
+- K3 setup UI/config stack, including #1392: 1 focused batch after stack cleanup
+  or backend metadata-preservation patching.
+- Conflicting/live-evidence PRs: 1-2 batches, depending on conflict depth.
+- Customer live PoC: blocked on GATE packet, network reachability, credentials,
+  and test账套 behavior; usually 2-5 working days after customer data arrives.
+
+The codebase is much closer to test deployment than to final customer signoff:
+mock/offline paths are strong, while live K3/PLM signoff still depends on
+customer-provided environment facts.

--- a/docs/development/integration-erp-plm-phase2-adapter-closeout-verification-20260508.md
+++ b/docs/development/integration-erp-plm-phase2-adapter-closeout-verification-20260508.md
@@ -1,0 +1,93 @@
+# ERP/PLM Phase 2 Adapter Closeout Verification - 2026-05-08
+
+## Worktree
+
+`/private/tmp/ms2-integration-phase2-adapter-closeout`
+
+## Branch
+
+`codex/integration-phase2-adapter-closeout-20260508`
+
+## Baseline
+
+`origin/main` at `520f1f197aca757eb25ed8d1a8f85ffe84f31bab`.
+
+## Merge Verification
+
+Commands:
+
+```bash
+gh pr update-branch 1387 --repo zensgit/metasheet2
+gh pr update-branch 1386 --repo zensgit/metasheet2
+gh pr update-branch 1385 --repo zensgit/metasheet2
+gh pr update-branch 1383 --repo zensgit/metasheet2
+gh pr update-branch 1381 --repo zensgit/metasheet2
+gh pr update-branch 1382 --repo zensgit/metasheet2
+gh pr update-branch 1380 --repo zensgit/metasheet2
+
+gh pr view <number> --repo zensgit/metasheet2 --json mergeable,statusCheckRollup
+gh pr merge <number> --repo zensgit/metasheet2 --squash --admin --delete-branch
+```
+
+Results:
+
+- #1387 merged at `832601dbf0eb20c81743e75fff8d27d108fffc9e`.
+- #1386 merged at `2d9fdde004cda10ef2159c81285cb64def3ed8b7`.
+- #1385 merged at `12cbdd2dfcdfce69ecaa023c3f199cb8602654cb`.
+- #1383 merged at `3e99b83278ecc7cf93e3a19fd2e023665e5d8aff`.
+- #1381 merged at `a8d65f81126af0e8e5300d309666c6860589826b`.
+- #1382 merged at `621933df46e82ff4684598a54b629c248f8c8bf4`.
+- #1380 merged at `520f1f197aca757eb25ed8d1a8f85ffe84f31bab`.
+
+All seven PRs were `MERGEABLE` and had no failing or pending required checks at
+merge time.
+
+## Local Verification
+
+The clean closeout worktree was prepared with dependencies:
+
+```bash
+pnpm install --frozen-lockfile --ignore-scripts
+```
+
+Initial combined verification found a stale route-chain assertion:
+
+```text
+http-routes-plm-k3wise-poc FAILED
+actual: "bad-02"
+expected: " bad-02 "
+```
+
+The stale expectation came from #1387 normalizing PLM source strings before
+dead-letter capture. The test assertion was updated to expect `bad-02`, matching
+the normalized source-payload contract.
+
+Verification commands after the adjustment:
+
+```bash
+node plugins/plugin-integration-core/__tests__/http-routes-plm-k3wise-poc.test.cjs
+pnpm -F plugin-integration-core test
+node --test scripts/ops/integration-k3wise-live-poc-preflight.test.mjs
+node --test scripts/ops/integration-k3wise-live-poc-evidence.test.mjs
+node scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs
+git diff --check
+```
+
+Results:
+
+- `http-routes-plm-k3wise-poc.test.cjs`: passed.
+- `pnpm -F plugin-integration-core test`: passed all plugin-integration-core
+  suites, including HTTP adapter, PLM wrapper, transform validator, runner
+  support, payload redaction, pipeline runner, REST route-chain, K3 adapters,
+  ERP feedback, E2E writeback, staging installer, and migration SQL.
+- `integration-k3wise-live-poc-preflight.test.mjs`: 18/18 passed.
+- `integration-k3wise-live-poc-evidence.test.mjs`: 33/33 passed.
+- `run-mock-poc-demo.mjs`: PASS, including Save-only K3 mock write, SQL readonly
+  probe, core-table write rejection, and evidence PASS.
+- `git diff --check`: passed.
+
+## Residual Risk
+
+This closeout verifies adapter/runtime hardening and offline K3 PoC safety. It
+does not validate customer live PLM/K3 WISE connectivity, K3 SQL-channel setup
+UI disable persistence, or the remaining conflicting live-evidence PRs.

--- a/plugins/plugin-integration-core/__tests__/http-routes-plm-k3wise-poc.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes-plm-k3wise-poc.test.cjs
@@ -716,7 +716,7 @@ async function main() {
   })
   assertOkResponse(res, 200)
   assert.equal(res.body.data.length, 1)
-  assert.equal(res.body.data[0].sourcePayload.code, ' bad-02 ')
+  assert.equal(res.body.data[0].sourcePayload.code, 'bad-02')
   assert.equal(res.body.data[0].sourcePayload.rawPayload, '[redacted]')
   assert.equal(res.body.data[0].transformedPayload.FNumber, 'BAD-02')
   assert.equal(res.body.data[0].payloadRedacted, true)


### PR DESCRIPTION
## Summary

- Records the ERP/PLM Phase 2 adapter/runtime closeout batch.
- Documents merged PRs #1387, #1386, #1385, #1383, #1381, #1382, and #1380.
- Fixes one cross-batch test expectation: PLM source normalization now trims source payload code, so the PLM -> K3 WISE route-chain dead-letter assertion expects bad-02 instead of the old whitespace-padded value.
- Adds remaining-work estimate after this batch.

## Verification

- node plugins/plugin-integration-core/__tests__/http-routes-plm-k3wise-poc.test.cjs
- pnpm -F plugin-integration-core test
- node --test scripts/ops/integration-k3wise-live-poc-preflight.test.mjs
- node --test scripts/ops/integration-k3wise-live-poc-evidence.test.mjs
- node scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs
- git diff --check

This PR includes one test assertion update plus docs; no runtime behavior change.