### PR TITLE
fix(deploy): pin backend docker pnpm version

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -1,7 +1,8 @@
 FROM node:20-slim AS builder
 
 WORKDIR /app
-RUN corepack enable
+ARG PNPM_VERSION=10.16.1
+RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY tsconfig.json ./
@@ -17,7 +18,8 @@ RUN pnpm --filter @metasheet/core-backend build
 FROM node:20-slim AS runner
 
 WORKDIR /app
-RUN corepack enable
+ARG PNPM_VERSION=10.16.1
+RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
 ENV NODE_ENV=production
 ENV HOST=0.0.0.0
 ENV PORT=8900

--- a/docs/development/backend-docker-pnpm-pin-verification-20260508.md
+++ b/docs/development/backend-docker-pnpm-pin-verification-20260508.md
@@ -1,0 +1,40 @@
+# Backend Docker pnpm Pin Verification - 2026-05-08
+
+## Context
+
+The `Build and Push Docker Images` workflow failed on `main` after Corepack resolved pnpm 11 inside the `node:20-slim` backend image.
+
+pnpm 11 requires a newer Node runtime and attempts to load `node:sqlite`, which is unavailable in Node 20. The backend image failed before dependency installation:
+
+```text
+warn: This version of pnpm requires at least Node.js v22.13
+Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:sqlite
+Node.js v20.20.2
+```
+
+## Change
+
+`Dockerfile.backend` now pins Corepack to `pnpm@10.16.1` in both build and runner stages.
+
+This matches the repository's known working pnpm 10 line and prevents Corepack from floating to a future pnpm release that is incompatible with the Node 20 image.
+
+## Verification Plan
+
+```bash
+docker build -f Dockerfile.backend -t metasheet2-backend:pnpm-pin-smoke .
+git diff --check
+```
+
+The GitHub `Build and Push Docker Images` workflow should also be green after this branch merges.
+
+## Local Result
+
+`git diff --check` passed.
+
+Local Docker build could not run in this session because the Docker daemon was unavailable:
+
+```text
+failed to connect to the docker API at unix:///Users/chouhua/.docker/run/docker.sock
+```
+
+Remote GitHub Actions is therefore the authoritative verification for the image build.


### PR DESCRIPTION
## Summary

- Pins Corepack to pnpm@10.16.1 in both backend Dockerfile stages.
- Prevents Node 20 backend image builds from floating to pnpm 11, which requires newer Node and fails on node:sqlite.
- Adds verification notes for the deployment blocker.

## Verification

- git diff --check
- docker build attempted locally, but Docker daemon was unavailable in this session; GitHub Actions image build is the authoritative verification.

## Deploy Readiness

This PR should make the Docker image deployment path convenient again once Build and Push Docker Images is green.