### PR TITLE
fix(deploy): pin frontend docker pnpm version

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,7 +1,8 @@
 FROM node:20-slim AS builder
 
 WORKDIR /app
-RUN corepack enable
+ARG PNPM_VERSION=10.16.1
+RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
 ARG VITE_ENABLE_YJS_COLLAB=false
 ENV VITE_ENABLE_YJS_COLLAB=$VITE_ENABLE_YJS_COLLAB
 

--- a/docs/development/frontend-docker-pnpm-pin-verification-20260508.md
+++ b/docs/development/frontend-docker-pnpm-pin-verification-20260508.md
@@ -1,0 +1,36 @@
+# Frontend Docker pnpm Pin Verification - 2026-05-08
+
+## Context
+
+After the backend image pin landed, the `Build and Push Docker Images` workflow advanced to the frontend image and failed for the same Corepack drift class.
+
+`Dockerfile.frontend` enabled Corepack without preparing a repository-compatible pnpm version, so the Node 20 image resolved pnpm 11 and failed before dependency installation:
+
+```text
+warn: This version of pnpm requires at least Node.js v22.13
+Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:sqlite
+Node.js v20.20.2
+```
+
+## Change
+
+`Dockerfile.frontend` now pins Corepack to `pnpm@10.16.1`, matching the backend Dockerfile and local workspace pnpm 10 line.
+
+## Verification Plan
+
+```bash
+docker build -f Dockerfile.frontend --build-arg VITE_ENABLE_YJS_COLLAB=true -t metasheet2-web:pnpm-pin-smoke .
+git diff --check
+```
+
+## Local Result
+
+`git diff --check` passed.
+
+Local Docker build could not run in this session because the Docker daemon was unavailable:
+
+```text
+failed to connect to the docker API at unix:///Users/chouhua/.docker/run/docker.sock
+```
+
+Remote GitHub Actions is therefore the authoritative verification for the image build.


### PR DESCRIPTION
## Summary

- Pins Corepack to pnpm@10.16.1 in Dockerfile.frontend.
- Fixes the second pnpm 11 / Node 20 image-build failure after the backend Dockerfile pin landed.
- Adds verification notes for the frontend image blocker.

## Verification

- git diff --check
- docker build attempted class is documented, but local Docker daemon is unavailable in this session; GitHub Actions image build is the authoritative verification.

## Deploy Readiness

After this lands, the main Build and Push Docker Images workflow should validate both backend and frontend image paths.