### PR TITLE
test(integration): add current ERP PLM deploy readiness gate

### DIFF
--- a/docs/development/integration-erp-plm-current-deploy-readiness-design-20260508.md
+++ b/docs/development/integration-erp-plm-current-deploy-readiness-design-20260508.md
@@ -1,0 +1,42 @@
+# Integration ERP/PLM Current Deploy Readiness Design - 2026-05-08
+
+## Context
+
+The backend and frontend Docker image builds now pin pnpm 10 and the K3 WISE setup page exposes a deploy checklist. The remaining operator problem is knowing whether the latest `main` commit is actually ready for a physical-machine internal test.
+
+Older readiness work tracked a stack of individual PR numbers. That became stale once those slices were merged or retargeted. The deploy gate now needs to look at current mainline facts instead of historical PR topology.
+
+## Change
+
+Add `scripts/ops/integration-erp-plm-deploy-readiness.mjs` and a package shortcut:
+
+```bash
+pnpm run verify:integration-erp-plm:deploy-readiness
+```
+
+The gate checks three surfaces:
+
+- GitHub Actions workflow runs for the selected `main` commit.
+- Source markers for the K3 WISE deploy checklist, offline mock PoC chain, and current postdeploy smoke.
+- Optional customer GATE JSON top-level presence.
+
+## Required Workflow Gates
+
+For the selected `main` commit, these workflows must be completed with `success`:
+
+- `Build and Push Docker Images`
+- `Plugin System Tests`
+- `Phase 5 Production Flags Guard`
+- `Deploy to Production`
+
+This makes the command answer the deployment question directly: can the current images and deployment workflow be trusted for an internal physical-machine test?
+
+## Customer Boundary
+
+The command reports internal deployment readiness separately from customer live readiness.
+
+Internal deployment can be ready without customer data. Customer live remains blocked until the GATE packet and test account/network details exist. If `--customer-gate-json` is supplied and the required top-level sections are present, the command moves customer status to `gate-packet-present-run-preflight-next`, not directly to live PASS.
+
+## Outputs
+
+The script supports text, markdown, and JSON output. Markdown output is meant to be attached to deployment handoff notes.

--- a/docs/development/integration-erp-plm-current-deploy-readiness-verification-20260508.md
+++ b/docs/development/integration-erp-plm-current-deploy-readiness-verification-20260508.md
@@ -1,0 +1,93 @@
+# Integration ERP/PLM Current Deploy Readiness Verification - 2026-05-08
+
+## Verification Plan
+
+Run deterministic unit tests, render an offline markdown report, and run the live GitHub readiness command against `main`.
+
+## Commands
+
+```bash
+node --test scripts/ops/integration-erp-plm-deploy-readiness.test.mjs
+pnpm run verify:integration-erp-plm:deploy-readiness -- --head-sha <main-sha> --format markdown --output artifacts/integration-erp-plm-deploy-readiness.md
+git diff --check
+```
+
+## Expected Result
+
+- Unit tests pass.
+- Offline fixture mode can produce PASS without calling GitHub.
+- Live mode returns PASS only after the required workflows for the selected `main` SHA complete successfully.
+- Customer live remains blocked unless a customer GATE JSON packet is supplied.
+
+## Local Result
+
+Completed on 2026-05-08.
+
+### Unit Tests
+
+```bash
+node --test scripts/ops/integration-erp-plm-deploy-readiness.test.mjs
+```
+
+Result: passed, 8/8 tests.
+
+Covered cases:
+
+- option parsing, including the `pnpm run ... -- --flag` separator;
+- required workflow PASS for the selected head SHA;
+- failed, pending, and missing workflow gates;
+- source marker failures;
+- customer GATE JSON top-level detection;
+- markdown report rendering and offline fixture mode.
+
+### Live Main Readiness
+
+Command:
+
+```bash
+pnpm run verify:integration-erp-plm:deploy-readiness -- --head-sha 3ce20f59a251e113cc88c5e20fc787de2cfce422 --format markdown --output artifacts/integration-erp-plm-deploy-readiness.md
+```
+
+Result: passed.
+
+The generated report returned:
+
+- Overall: `PASS`
+- Internal deployment: `ready-for-physical-machine-test`
+- Customer live: `blocked-until-customer-gate-and-test-account`
+
+Workflow gates for `3ce20f59a251e113cc88c5e20fc787de2cfce422`:
+
+- `Build and Push Docker Images`: PASS
+- `Plugin System Tests`: PASS
+- `Phase 5 Production Flags Guard`: PASS
+- `Deploy to Production`: PASS
+
+Source gates:
+
+- K3 setup deploy checklist helper: PASS
+- K3 setup deploy checklist view: PASS
+- K3 offline mock PoC chain: PASS
+- K3 postdeploy smoke script: PASS
+
+### Offline K3 WISE PoC
+
+Command:
+
+```bash
+pnpm run verify:integration-k3wise:poc
+```
+
+Result: passed.
+
+- Preflight tests: 18/18 passed.
+- Evidence tests: 33/33 passed.
+- Mock PLM/K3 WISE chain completed end-to-end with PASS.
+
+### Diff Check
+
+```bash
+git diff --check
+```
+
+Result: passed.

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "profile:multitable-grid:local": "RUNNER_SCRIPT=scripts/profile-multitable-grid.mjs RUN_LABEL=multitable-grid-profile bash scripts/ops/multitable-pilot-local.sh",
     "profile:multitable-grid:staging": "RUNNER_SCRIPT=scripts/profile-multitable-grid.mjs RUN_LABEL=multitable-grid-profile-staging RUN_MODE=staging RUNNER_REPORT_BASENAME=staging-report AUTO_START_SERVICES=false REQUIRE_RUNNING_SERVICES=true bash scripts/ops/multitable-pilot-local.sh",
     "verify:multitable-grid-profile:summary": "node scripts/ops/multitable-grid-profile-summary.mjs",
+    "verify:integration-erp-plm:deploy-readiness": "node scripts/ops/integration-erp-plm-deploy-readiness.mjs",
     "verify:integration-k3wise:poc": "node --test scripts/ops/integration-k3wise-live-poc-preflight.test.mjs && node --test scripts/ops/integration-k3wise-live-poc-evidence.test.mjs && node scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs",
     "verify:integration-k3wise:postdeploy-env-check": "node --test scripts/ops/integration-k3wise-postdeploy-env-check.test.mjs",
     "phase5:run-all": "bash scripts/phase5-run-all.sh",

--- a/scripts/ops/integration-erp-plm-deploy-readiness.mjs
+++ b/scripts/ops/integration-erp-plm-deploy-readiness.mjs
@@ -1,0 +1,447 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+export const REQUIRED_MAIN_WORKFLOWS = [
+  {
+    id: 'docker-images',
+    workflowName: 'Build and Push Docker Images',
+    purpose: 'backend and frontend Docker images build and push for the selected main commit',
+  },
+  {
+    id: 'plugin-system-tests',
+    workflowName: 'Plugin System Tests',
+    purpose: 'plugin, K3 offline PoC, Node 18/20, and coverage checks pass on the selected main commit',
+  },
+  {
+    id: 'production-flags',
+    workflowName: 'Phase 5 Production Flags Guard',
+    purpose: 'production flag guard passes before deployment',
+  },
+  {
+    id: 'deploy-workflow',
+    workflowName: 'Deploy to Production',
+    purpose: 'repository deploy workflow accepts the selected main commit',
+  },
+]
+
+export const REQUIRED_SOURCE_MARKERS = [
+  {
+    id: 'k3-setup-deploy-checklist-service',
+    file: 'apps/web/src/services/integration/k3WiseSetup.ts',
+    marker: 'buildK3WiseDeployGateChecklist',
+    purpose: 'K3 WISE setup helper exposes deploy checklist evaluation',
+  },
+  {
+    id: 'k3-setup-deploy-checklist-view',
+    file: 'apps/web/src/views/IntegrationK3WiseSetupView.vue',
+    marker: 'deployGateChecklist',
+    purpose: 'K3 WISE setup page renders the deploy checklist',
+  },
+  {
+    id: 'k3-offline-poc-chain',
+    file: 'scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs',
+    marker: 'mock chain verified end-to-end',
+    purpose: 'offline mock PLM/K3 WISE PoC chain is present',
+  },
+  {
+    id: 'k3-postdeploy-smoke',
+    file: 'scripts/ops/integration-k3wise-postdeploy-smoke.mjs',
+    marker: 'staging-descriptor-contract',
+    purpose: 'postdeploy smoke can validate integration routes and staging descriptors',
+  },
+]
+
+export const REQUIRED_CUSTOMER_GATE_FIELDS = [
+  'tenantId',
+  'workspaceId',
+  'k3Wise',
+  'plm',
+  'rollback',
+]
+
+export function parseArgs(argv) {
+  const config = {
+    repo: process.env.GITHUB_REPOSITORY || 'zensgit/metasheet2',
+    branch: 'main',
+    headSha: '',
+    repoRoot: process.cwd(),
+    runsJson: '',
+    customerGateJson: '',
+    format: 'text',
+    output: '',
+    help: false,
+  }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === '--') {
+      continue
+    } else if (arg === '--repo') {
+      config.repo = requireValue(argv, index, arg)
+      index += 1
+    } else if (arg === '--branch') {
+      config.branch = requireValue(argv, index, arg)
+      index += 1
+    } else if (arg === '--head-sha') {
+      config.headSha = requireValue(argv, index, arg)
+      index += 1
+    } else if (arg === '--repo-root') {
+      config.repoRoot = requireValue(argv, index, arg)
+      index += 1
+    } else if (arg === '--runs-json') {
+      config.runsJson = requireValue(argv, index, arg)
+      index += 1
+    } else if (arg === '--customer-gate-json') {
+      config.customerGateJson = requireValue(argv, index, arg)
+      index += 1
+    } else if (arg === '--format') {
+      config.format = requireValue(argv, index, arg)
+      index += 1
+    } else if (arg === '--output') {
+      config.output = requireValue(argv, index, arg)
+      index += 1
+    } else if (arg === '--help' || arg === '-h') {
+      config.help = true
+    } else {
+      throw new Error(`Unknown argument: ${arg}`)
+    }
+  }
+
+  if (!['json', 'markdown', 'text'].includes(config.format)) {
+    throw new Error('--format must be one of: text, markdown, json')
+  }
+
+  return config
+}
+
+function requireValue(argv, index, arg) {
+  const value = argv[index + 1]
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${arg} requires a value`)
+  }
+  return value
+}
+
+function runCommand(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd || process.cwd(),
+    encoding: 'utf8',
+  })
+  if (result.status !== 0) {
+    throw new Error(`${command} ${args.join(' ')} failed: ${result.stderr || result.stdout}`)
+  }
+  return result.stdout.trim()
+}
+
+function readJsonFile(filePath) {
+  return JSON.parse(readFileSync(filePath, 'utf8'))
+}
+
+function normalizeRuns(value) {
+  if (Array.isArray(value)) return value
+  if (value && Array.isArray(value.runs)) return value.runs
+  if (value && Array.isArray(value.workflowRuns)) return value.workflowRuns
+  throw new Error('Runs JSON must be an array or an object with runs/workflowRuns')
+}
+
+function readRunsFromGh(config) {
+  const output = runCommand('gh', [
+    'run',
+    'list',
+    '--repo',
+    config.repo,
+    '--branch',
+    config.branch,
+    '--limit',
+    '40',
+    '--json',
+    'databaseId,workflowName,headSha,status,conclusion,url,createdAt,updatedAt',
+  ])
+  return normalizeRuns(JSON.parse(output || '[]'))
+}
+
+function resolveHeadSha(config) {
+  if (config.headSha) return config.headSha
+  try {
+    return runCommand('git', ['rev-parse', `origin/${config.branch}`], { cwd: config.repoRoot })
+  } catch {
+    return runCommand('git', ['rev-parse', 'HEAD'], { cwd: config.repoRoot })
+  }
+}
+
+function newestFirst(a, b) {
+  return String(b.createdAt || '').localeCompare(String(a.createdAt || ''))
+}
+
+function findWorkflowRun(runs, workflowName, headSha) {
+  return runs
+    .filter((run) => run.workflowName === workflowName)
+    .filter((run) => !headSha || run.headSha === headSha)
+    .sort(newestFirst)[0] || null
+}
+
+function evaluateWorkflowRun(spec, run) {
+  if (!run) {
+    return {
+      ...spec,
+      ok: false,
+      status: 'missing',
+      conclusion: '',
+      url: '',
+      reason: 'workflow run not found for selected head SHA',
+    }
+  }
+  if (run.status !== 'completed') {
+    return {
+      ...spec,
+      ok: false,
+      status: run.status || 'unknown',
+      conclusion: run.conclusion || '',
+      url: run.url || '',
+      reason: `workflow is ${run.status || 'unknown'}`,
+    }
+  }
+  if (run.conclusion !== 'success') {
+    return {
+      ...spec,
+      ok: false,
+      status: run.status,
+      conclusion: run.conclusion || '',
+      url: run.url || '',
+      reason: `workflow conclusion is ${run.conclusion || 'empty'}, expected success`,
+    }
+  }
+  return {
+    ...spec,
+    ok: true,
+    status: run.status,
+    conclusion: run.conclusion,
+    url: run.url || '',
+    reason: '',
+  }
+}
+
+export function evaluateWorkflowReadiness(runs, options = {}) {
+  const headSha = options.headSha || ''
+  const results = REQUIRED_MAIN_WORKFLOWS.map((spec) => evaluateWorkflowRun(spec, findWorkflowRun(runs, spec.workflowName, headSha)))
+  return {
+    ok: results.every((result) => result.ok),
+    headSha,
+    results,
+  }
+}
+
+export function evaluateSourceMarkers(repoRoot) {
+  const results = REQUIRED_SOURCE_MARKERS.map((spec) => {
+    const filePath = path.join(repoRoot, spec.file)
+    if (!existsSync(filePath)) {
+      return {
+        ...spec,
+        ok: false,
+        reason: 'file missing',
+      }
+    }
+    const text = readFileSync(filePath, 'utf8')
+    if (!text.includes(spec.marker)) {
+      return {
+        ...spec,
+        ok: false,
+        reason: `marker not found: ${spec.marker}`,
+      }
+    }
+    return {
+      ...spec,
+      ok: true,
+      reason: '',
+    }
+  })
+  return {
+    ok: results.every((result) => result.ok),
+    results,
+  }
+}
+
+export function evaluateCustomerGate(filePath = '') {
+  if (!filePath) {
+    return {
+      status: 'blocked',
+      ok: false,
+      provided: false,
+      missing: REQUIRED_CUSTOMER_GATE_FIELDS,
+      message: 'customer GATE JSON not provided; internal deployment can proceed, customer live PoC remains blocked',
+    }
+  }
+  const packet = readJsonFile(filePath)
+  const missing = REQUIRED_CUSTOMER_GATE_FIELDS.filter((field) => packet[field] === undefined || packet[field] === null || packet[field] === '')
+  return {
+    status: missing.length === 0 ? 'packet-present' : 'incomplete',
+    ok: missing.length === 0,
+    provided: true,
+    missing,
+    message: missing.length === 0
+      ? 'customer GATE JSON has required top-level sections; run live preflight next'
+      : `customer GATE JSON is missing: ${missing.join(', ')}`,
+  }
+}
+
+export function evaluateDeployReadiness({ runs, repoRoot, headSha, customerGateJson = '', checkedAt = new Date().toISOString() }) {
+  const workflows = evaluateWorkflowReadiness(runs, { headSha })
+  const source = evaluateSourceMarkers(repoRoot)
+  const customerGate = evaluateCustomerGate(customerGateJson)
+  const internalReady = workflows.ok && source.ok
+  return {
+    ok: internalReady,
+    checkedAt,
+    headSha,
+    workflows,
+    source,
+    customerGate,
+    deployMode: {
+      internalDeployment: internalReady ? 'ready-for-physical-machine-test' : 'blocked',
+      customerLive: customerGate.ok && internalReady ? 'gate-packet-present-run-preflight-next' : 'blocked-until-customer-gate-and-test-account',
+    },
+    localCommands: [
+      'pnpm run verify:integration-k3wise:poc',
+      'pnpm -F plugin-integration-core test',
+      'pnpm --filter @metasheet/web exec vitest run tests/k3WiseSetup.spec.ts --watch=false',
+      'pnpm --filter @metasheet/web build',
+    ],
+    postdeployCommands: [
+      'node scripts/ops/integration-k3wise-postdeploy-smoke.mjs --base-url "$METASHEET_BASE_URL" --token-file "$METASHEET_AUTH_TOKEN_FILE" --tenant-id "$METASHEET_TENANT_ID" --require-auth --out-dir artifacts/integration-k3wise-postdeploy',
+      'node scripts/ops/integration-k3wise-postdeploy-summary.mjs --input artifacts/integration-k3wise-postdeploy/integration-k3wise-postdeploy-smoke.json --require-auth-signoff',
+    ],
+  }
+}
+
+function renderStatus(ok) {
+  return ok ? 'PASS' : 'FAIL'
+}
+
+export function renderText(summary) {
+  const lines = [
+    `ERP/PLM deploy readiness: ${renderStatus(summary.ok)}`,
+    `Head SHA: ${summary.headSha}`,
+    `Internal deployment: ${summary.deployMode.internalDeployment}`,
+    `Customer live: ${summary.deployMode.customerLive}`,
+    '',
+    'Main workflow gates:',
+  ]
+  for (const item of summary.workflows.results) {
+    lines.push(`- ${item.workflowName}: ${renderStatus(item.ok)}${item.reason ? ` (${item.reason})` : ''}`)
+  }
+  lines.push('', 'Source gates:')
+  for (const item of summary.source.results) {
+    lines.push(`- ${item.id}: ${renderStatus(item.ok)}${item.reason ? ` (${item.reason})` : ''}`)
+  }
+  lines.push('', `Customer GATE: ${summary.customerGate.status}`)
+  if (summary.customerGate.missing.length > 0) lines.push(`Missing: ${summary.customerGate.missing.join(', ')}`)
+  lines.push('', 'Local commands before physical-machine smoke:')
+  for (const command of summary.localCommands) lines.push(`- ${command}`)
+  lines.push('', 'Postdeploy commands:')
+  for (const command of summary.postdeployCommands) lines.push(`- ${command}`)
+  return `${lines.join('\n')}\n`
+}
+
+export function renderMarkdown(summary) {
+  const lines = [
+    '# ERP/PLM Deploy Readiness',
+    '',
+    `Overall: **${renderStatus(summary.ok)}**`,
+    '',
+    `Head SHA: \`${summary.headSha}\``,
+    '',
+    `Internal deployment: \`${summary.deployMode.internalDeployment}\``,
+    '',
+    `Customer live: \`${summary.deployMode.customerLive}\``,
+    '',
+    '## Main Workflow Gates',
+    '',
+    '| Workflow | Status | Reason | URL |',
+    '| --- | --- | --- | --- |',
+  ]
+  for (const item of summary.workflows.results) {
+    lines.push([
+      `\`${item.workflowName}\``,
+      renderStatus(item.ok),
+      item.reason || '-',
+      item.url ? `[run](${item.url})` : '-',
+    ].join(' | '))
+  }
+  lines.push('', '## Source Gates', '', '| Gate | Status | File | Reason |', '| --- | --- | --- | --- |')
+  for (const item of summary.source.results) {
+    lines.push([
+      `\`${item.id}\``,
+      renderStatus(item.ok),
+      `\`${item.file}\``,
+      item.reason || '-',
+    ].join(' | '))
+  }
+  lines.push('', '## Customer Gate', '')
+  lines.push(`- Status: \`${summary.customerGate.status}\``)
+  lines.push(`- Message: ${summary.customerGate.message}`)
+  if (summary.customerGate.missing.length > 0) lines.push(`- Missing: \`${summary.customerGate.missing.join('`, `')}\``)
+  lines.push('', '## Local Commands', '')
+  for (const command of summary.localCommands) lines.push(`- \`${command}\``)
+  lines.push('', '## Postdeploy Commands', '')
+  for (const command of summary.postdeployCommands) lines.push(`- \`${command}\``)
+  return `${lines.join('\n')}\n`
+}
+
+export function renderSummary(summary, format) {
+  if (format === 'json') return `${JSON.stringify(summary, null, 2)}\n`
+  if (format === 'markdown') return renderMarkdown(summary)
+  return renderText(summary)
+}
+
+function printHelp() {
+  console.log(`Usage:
+  node scripts/ops/integration-erp-plm-deploy-readiness.mjs [options]
+
+Options:
+  --repo <owner/name>              GitHub repo. Default: GITHUB_REPOSITORY or zensgit/metasheet2
+  --branch <branch>                GitHub branch for workflow lookup. Default: main
+  --head-sha <sha>                 Commit SHA to check. Default: origin/<branch>, then HEAD
+  --repo-root <path>               Repo root for source marker checks. Default: cwd
+  --runs-json <path>               Offline GitHub runs JSON fixture
+  --customer-gate-json <path>      Optional customer GATE JSON packet
+  --format <text|markdown|json>    Output format. Default: text
+  --output <path>                  Write report to file
+`)
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const config = parseArgs(argv)
+  if (config.help) {
+    printHelp()
+    return 0
+  }
+  const headSha = resolveHeadSha(config)
+  const runs = config.runsJson ? normalizeRuns(readJsonFile(config.runsJson)) : readRunsFromGh(config)
+  const summary = evaluateDeployReadiness({
+    runs,
+    repoRoot: config.repoRoot,
+    headSha,
+    customerGateJson: config.customerGateJson,
+  })
+  const rendered = renderSummary(summary, config.format)
+  if (config.output) {
+    mkdirSync(path.dirname(config.output), { recursive: true })
+    writeFileSync(config.output, rendered, 'utf8')
+  } else {
+    process.stdout.write(rendered)
+  }
+  return summary.ok ? 0 : 1
+}
+
+const entryPath = process.argv[1]
+if (entryPath && import.meta.url === pathToFileURL(entryPath).href) {
+  try {
+    process.exitCode = main()
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exitCode = 1
+  }
+}

--- a/scripts/ops/integration-erp-plm-deploy-readiness.test.mjs
+++ b/scripts/ops/integration-erp-plm-deploy-readiness.test.mjs
@@ -1,0 +1,208 @@
+import assert from 'node:assert/strict'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+
+import {
+  evaluateDeployReadiness,
+  evaluateWorkflowReadiness,
+  main,
+  parseArgs,
+  renderMarkdown,
+} from './integration-erp-plm-deploy-readiness.mjs'
+
+const HEAD = 'abc123'
+
+function run(workflowName, overrides = {}) {
+  return {
+    databaseId: Math.floor(Math.random() * 100000),
+    workflowName,
+    headSha: HEAD,
+    status: 'completed',
+    conclusion: 'success',
+    url: `https://github.example/runs/${workflowName}`,
+    createdAt: '2026-05-08T00:00:00Z',
+    ...overrides,
+  }
+}
+
+function successRuns() {
+  return [
+    run('Build and Push Docker Images'),
+    run('Plugin System Tests'),
+    run('Phase 5 Production Flags Guard'),
+    run('Deploy to Production'),
+  ]
+}
+
+function makeRepoRoot() {
+  const root = mkdtempSync(path.join(tmpdir(), 'erp-plm-readiness-root-'))
+  const files = {
+    'apps/web/src/services/integration/k3WiseSetup.ts': 'export function buildK3WiseDeployGateChecklist() {}',
+    'apps/web/src/views/IntegrationK3WiseSetupView.vue': 'const deployGateChecklist = []',
+    'scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs': 'console.log("mock chain verified end-to-end")',
+    'scripts/ops/integration-k3wise-postdeploy-smoke.mjs': 'const id = "staging-descriptor-contract"',
+  }
+  for (const [file, content] of Object.entries(files)) {
+    const filePath = path.join(root, file)
+    mkdirSync(path.dirname(filePath), { recursive: true })
+    writeFileSync(filePath, content, 'utf8')
+  }
+  return root
+}
+
+test('parseArgs accepts deploy readiness options', () => {
+  assert.deepEqual(parseArgs([
+    '--',
+    '--repo',
+    'zensgit/metasheet2',
+    '--branch',
+    'main',
+    '--head-sha',
+    HEAD,
+    '--repo-root',
+    '/tmp/repo',
+    '--runs-json',
+    'runs.json',
+    '--customer-gate-json',
+    'gate.json',
+    '--format',
+    'markdown',
+    '--output',
+    'out.md',
+  ]), {
+    repo: 'zensgit/metasheet2',
+    branch: 'main',
+    headSha: HEAD,
+    repoRoot: '/tmp/repo',
+    runsJson: 'runs.json',
+    customerGateJson: 'gate.json',
+    format: 'markdown',
+    output: 'out.md',
+    help: false,
+  })
+})
+
+test('evaluateWorkflowReadiness passes required workflows for the selected head', () => {
+  const summary = evaluateWorkflowReadiness([
+    run('Build and Push Docker Images', { headSha: 'old', conclusion: 'failure', createdAt: '2026-05-07T00:00:00Z' }),
+    ...successRuns(),
+  ], { headSha: HEAD })
+
+  assert.equal(summary.ok, true)
+  assert.equal(summary.results.length, 4)
+})
+
+test('evaluateWorkflowReadiness fails missing, pending, and failed workflow gates', () => {
+  const summary = evaluateWorkflowReadiness([
+    run('Build and Push Docker Images', { conclusion: 'failure' }),
+    run('Plugin System Tests', { status: 'in_progress', conclusion: '' }),
+    run('Phase 5 Production Flags Guard'),
+  ], { headSha: HEAD })
+
+  assert.equal(summary.ok, false)
+  assert.match(summary.results.find((item) => item.id === 'docker-images').reason, /failure/)
+  assert.match(summary.results.find((item) => item.id === 'plugin-system-tests').reason, /in_progress/)
+  assert.match(summary.results.find((item) => item.id === 'deploy-workflow').reason, /not found/)
+})
+
+test('evaluateDeployReadiness passes internal deployment and keeps customer live blocked without GATE JSON', () => {
+  const repoRoot = makeRepoRoot()
+  try {
+    const summary = evaluateDeployReadiness({
+      runs: successRuns(),
+      repoRoot,
+      headSha: HEAD,
+      checkedAt: '2026-05-08T00:00:00Z',
+    })
+
+    assert.equal(summary.ok, true)
+    assert.equal(summary.deployMode.internalDeployment, 'ready-for-physical-machine-test')
+    assert.equal(summary.deployMode.customerLive, 'blocked-until-customer-gate-and-test-account')
+    assert.equal(summary.customerGate.provided, false)
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true })
+  }
+})
+
+test('evaluateDeployReadiness fails when source markers are missing', () => {
+  const repoRoot = makeRepoRoot()
+  try {
+    writeFileSync(path.join(repoRoot, 'apps/web/src/views/IntegrationK3WiseSetupView.vue'), 'no marker', 'utf8')
+    const summary = evaluateDeployReadiness({ runs: successRuns(), repoRoot, headSha: HEAD })
+
+    assert.equal(summary.ok, false)
+    assert.match(summary.source.results.find((item) => item.id === 'k3-setup-deploy-checklist-view').reason, /marker/)
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true })
+  }
+})
+
+test('customer GATE JSON moves live status to preflight-next only when required sections exist', () => {
+  const repoRoot = makeRepoRoot()
+  const tmp = mkdtempSync(path.join(tmpdir(), 'erp-plm-gate-'))
+  const gateJson = path.join(tmp, 'gate.json')
+  try {
+    writeFileSync(gateJson, JSON.stringify({
+      tenantId: 'tenant_1',
+      workspaceId: 'workspace_1',
+      k3Wise: {},
+      plm: {},
+      rollback: {},
+    }), 'utf8')
+    const summary = evaluateDeployReadiness({
+      runs: successRuns(),
+      repoRoot,
+      headSha: HEAD,
+      customerGateJson: gateJson,
+    })
+
+    assert.equal(summary.ok, true)
+    assert.equal(summary.customerGate.ok, true)
+    assert.equal(summary.deployMode.customerLive, 'gate-packet-present-run-preflight-next')
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true })
+    rmSync(tmp, { recursive: true, force: true })
+  }
+})
+
+test('renderMarkdown includes workflow, source, and postdeploy command sections', () => {
+  const repoRoot = makeRepoRoot()
+  try {
+    const markdown = renderMarkdown(evaluateDeployReadiness({ runs: successRuns(), repoRoot, headSha: HEAD }))
+    assert.match(markdown, /## Main Workflow Gates/)
+    assert.match(markdown, /## Source Gates/)
+    assert.match(markdown, /integration-k3wise-postdeploy-smoke/)
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true })
+  }
+})
+
+test('main renders markdown from offline runs JSON', () => {
+  const repoRoot = makeRepoRoot()
+  const tmp = mkdtempSync(path.join(tmpdir(), 'erp-plm-readiness-'))
+  const runsJson = path.join(tmp, 'runs.json')
+  const output = path.join(tmp, 'readiness.md')
+  try {
+    writeFileSync(runsJson, JSON.stringify(successRuns(), null, 2), 'utf8')
+    const exitCode = main([
+      '--head-sha',
+      HEAD,
+      '--repo-root',
+      repoRoot,
+      '--runs-json',
+      runsJson,
+      '--format',
+      'markdown',
+      '--output',
+      output,
+    ])
+
+    assert.equal(exitCode, 0)
+    assert.match(readFileSync(output, 'utf8'), /Overall: \*\*PASS\*\*/)
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true })
+    rmSync(tmp, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary

- Adds a current-main ERP/PLM deploy readiness gate.
- Checks selected main SHA workflow facts instead of stale historical PR stacks.
- Verifies source markers for the K3 WISE deploy checklist, mock PoC chain, and postdeploy smoke.
- Keeps internal physical-machine deployment readiness separate from customer live GATE readiness.

## Verification

- node --test scripts/ops/integration-erp-plm-deploy-readiness.test.mjs
- pnpm run verify:integration-erp-plm:deploy-readiness -- --head-sha 3ce20f59a251e113cc88c5e20fc787de2cfce422 --format markdown --output artifacts/integration-erp-plm-deploy-readiness.md
- pnpm run verify:integration-k3wise:poc
- git diff --check

Live readiness for main SHA 3ce20f59a251e113cc88c5e20fc787de2cfce422 returned PASS for internal physical-machine deployment and kept customer live blocked until GATE/test account data arrives.