### PR TITLE
feat(dingtalk): add work notification Agent ID admin config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,7 +27,10 @@ JWT_EXPIRES_IN=2h
 # DINGTALK_CLIENT_ID=dingtalk-app-key
 # DINGTALK_CLIENT_SECRET=dingtalk-app-secret
 # DINGTALK_REDIRECT_URI=https://app.example.com/login/dingtalk/callback
+# Required for DingTalk work notifications and rule-creator failure alerts.
 # DINGTALK_AGENT_ID=123456789
+# Legacy alias also accepted:
+# DINGTALK_NOTIFY_AGENT_ID=123456789
 # DINGTALK_CORP_ID=dingtalk-corp-id
 # DINGTALK_AUTH_AUTO_LINK_EMAIL=0
 # DINGTALK_AUTH_AUTO_PROVISION=0

--- a/apps/web/src/views/DirectoryManagementView.vue
+++ b/apps/web/src/views/DirectoryManagementView.vue
@@ -203,6 +203,16 @@
             <span>App Secret</span>
             <input v-model.trim="draft.appSecret" class="directory-admin__input" type="password" placeholder="创建必填，更新可留空" />
           </label>
+          <template v-if="selectedIntegration">
+            <label class="directory-admin__field">
+              <span>工作通知 Agent ID</span>
+              <input v-model.trim="draft.workNotificationAgentId" class="directory-admin__input" type="password" inputmode="numeric" placeholder="不回显已保存值；仅系统管理员填写" />
+            </label>
+            <label class="directory-admin__field">
+              <span>测试接收 DingTalk UserID</span>
+              <input v-model.trim="draft.workNotificationTestUserId" class="directory-admin__input" type="text" placeholder="可选；填写后会发送测试工作通知" />
+            </label>
+          </template>
           <label class="directory-admin__field">
             <span>根部门 ID</span>
             <input v-model.trim="draft.rootDepartmentId" class="directory-admin__input" type="text" placeholder="默认 1" />
@@ -274,6 +284,31 @@
               placeholder="填写命名空间，例如 crm；支持逗号或换行分隔"
             />
           </label>
+          <div class="directory-admin__field directory-admin__field--wide">
+            <span>组织架构同步说明</span>
+            <p class="directory-admin__hint">
+              当前方案会把钉钉部门和成员同步到目录镜像，并可将选定部门投影为平台成员组，用于权限、表单和消息治理；不会自动生成第二套可编辑的本地组织树。
+            </p>
+          </div>
+          <div v-if="selectedIntegration" class="directory-admin__field directory-admin__field--wide">
+            <span>工作通知配置说明</span>
+            <div class="directory-admin__chips">
+              <span class="directory-admin__chip" :class="{ 'directory-admin__chip--success': selectedIntegration?.config.workNotificationAgentIdConfigured, 'directory-admin__chip--danger': selectedIntegration && !selectedIntegration.config.workNotificationAgentIdConfigured }">
+                {{ selectedIntegration?.config.workNotificationAgentIdConfigured ? 'Agent ID 已保存' : 'Agent ID 未保存' }}
+              </span>
+              <span class="directory-admin__chip">不回显敏感值</span>
+              <span class="directory-admin__chip">保存前先验证 AppKey/AppSecret</span>
+            </div>
+            <p class="directory-admin__hint">
+              Agent ID 来自钉钉开放平台企业内部应用，必须与当前 App Key / App Secret 属于同一个应用；未填写测试接收人时，只做基础连通性验证，不发送真实工作通知。
+            </p>
+          </div>
+          <div v-else class="directory-admin__field directory-admin__field--wide">
+            <span>工作通知配置说明</span>
+            <p class="directory-admin__hint">
+              请先创建并选中钉钉目录集成，再通过专用的“测试工作通知”和“保存 Agent ID”按钮配置工作通知，避免敏感值跟随普通目录保存路径写入。
+            </p>
+          </div>
           <label class="directory-admin__field">
             <span>状态</span>
             <select v-model="draft.status" class="directory-admin__input">
@@ -304,6 +339,12 @@
           </button>
           <button class="directory-admin__button directory-admin__button--secondary" type="button" :disabled="busy" @click="void testIntegration()">
             测试连通性
+          </button>
+          <button v-if="selectedIntegration" class="directory-admin__button directory-admin__button--secondary" type="button" :disabled="busy" @click="void testWorkNotificationAgentId()">
+            测试工作通知
+          </button>
+          <button v-if="selectedIntegration" class="directory-admin__button directory-admin__button--secondary" type="button" :disabled="busy || draft.workNotificationAgentId.trim().length === 0" @click="void saveWorkNotificationAgentId()">
+            保存 Agent ID
           </button>
           <button class="directory-admin__button directory-admin__button--secondary" type="button" :disabled="busy || !selectedIntegration" @click="void syncIntegration()">
             手动同步
@@ -1277,6 +1318,7 @@ type DirectoryIntegration = {
   config: {
     appKey: string
     appSecretConfigured: boolean
+    workNotificationAgentIdConfigured?: boolean
     rootDepartmentId: string
     baseUrl: string | null
     pageSize: number
@@ -1523,6 +1565,8 @@ type DirectoryDraft = {
   corpId: string
   appKey: string
   appSecret: string
+  workNotificationAgentId: string
+  workNotificationTestUserId: string
   rootDepartmentId: string
   baseUrl: string
   pageSize: number
@@ -1624,6 +1668,8 @@ const draft = reactive<DirectoryDraft>({
   corpId: '',
   appKey: '',
   appSecret: '',
+  workNotificationAgentId: '',
+  workNotificationTestUserId: '',
   rootDepartmentId: '1',
   baseUrl: '',
   pageSize: 50,
@@ -1873,6 +1919,8 @@ function resetDraft() {
   draft.corpId = ''
   draft.appKey = ''
   draft.appSecret = ''
+  draft.workNotificationAgentId = ''
+  draft.workNotificationTestUserId = ''
   draft.rootDepartmentId = '1'
   draft.baseUrl = ''
   draft.pageSize = 50
@@ -1894,6 +1942,8 @@ function applyIntegrationToDraft(integration: DirectoryIntegration) {
   draft.corpId = integration.corpId
   draft.appKey = integration.config.appKey
   draft.appSecret = ''
+  draft.workNotificationAgentId = ''
+  draft.workNotificationTestUserId = ''
   draft.rootDepartmentId = integration.config.rootDepartmentId
   draft.baseUrl = integration.config.baseUrl ?? ''
   draft.pageSize = integration.config.pageSize
@@ -2492,6 +2542,66 @@ async function testIntegration() {
     setStatus('目录连通性测试通过')
   } catch (error) {
     setStatus(error instanceof Error ? error.message : '目录连通性测试失败', 'error')
+  } finally {
+    busy.value = false
+  }
+}
+
+function buildWorkNotificationPayload() {
+  return {
+    integrationId: selectedIntegration.value?.id ?? '',
+    agentId: draft.workNotificationAgentId.trim(),
+    recipientUserId: draft.workNotificationTestUserId.trim(),
+  }
+}
+
+async function testWorkNotificationAgentId() {
+  if (!selectedIntegration.value) {
+    setStatus('请先选择或创建钉钉目录集成', 'error')
+    return
+  }
+  busy.value = true
+  try {
+    const response = await apiFetch('/api/admin/directory/dingtalk/work-notification/test', {
+      method: 'POST',
+      body: JSON.stringify(buildWorkNotificationPayload()),
+    })
+    const body = await readJson(response)
+    if (!response.ok) throw new Error(readApiError(body, '工作通知 Agent ID 测试失败'))
+    const notificationSent = body?.data?.result?.notificationSent === true
+    setStatus(notificationSent
+      ? '工作通知 Agent ID 测试通过，已发送测试消息'
+      : '工作通知 Agent ID 基础测试通过；未填写测试接收人，未发送真实工作通知')
+  } catch (error) {
+    setStatus(error instanceof Error ? error.message : '工作通知 Agent ID 测试失败', 'error')
+  } finally {
+    busy.value = false
+  }
+}
+
+async function saveWorkNotificationAgentId() {
+  if (!selectedIntegration.value) {
+    setStatus('请先选择或创建钉钉目录集成', 'error')
+    return
+  }
+  if (!draft.workNotificationAgentId.trim()) {
+    setStatus('请填写工作通知 Agent ID', 'error')
+    return
+  }
+  busy.value = true
+  try {
+    const response = await apiFetch('/api/admin/directory/dingtalk/work-notification', {
+      method: 'PUT',
+      body: JSON.stringify(buildWorkNotificationPayload()),
+    })
+    const body = await readJson(response)
+    if (!response.ok) throw new Error(readApiError(body, '保存工作通知 Agent ID 失败'))
+    const currentIntegrationId = selectedIntegration.value.id
+    setStatus('工作通知 Agent ID 已验证并保存')
+    await loadIntegrations()
+    await selectIntegration(currentIntegrationId)
+  } catch (error) {
+    setStatus(error instanceof Error ? error.message : '保存工作通知 Agent ID 失败', 'error')
   } finally {
     busy.value = false
   }

--- a/apps/web/src/views/UserManagementView.vue
+++ b/apps/web/src/views/UserManagementView.vue
@@ -557,6 +557,26 @@
             <p v-if="dingtalkAccess?.server?.allowedCorpIds?.length" class="user-admin__hint">
               允许企业：{{ dingtalkAccess.server.allowedCorpIds.join('、') }}
             </p>
+            <div v-if="dingtalkAccess?.workNotification" class="user-admin__chips">
+              <span
+                class="user-admin__chip"
+                :class="{ 'user-admin__chip--success': dingtalkAccess.workNotification.available, 'user-admin__chip--danger': !dingtalkAccess.workNotification.available }"
+              >
+                {{ dingtalkAccess.workNotification.available ? '工作通知已配置' : '工作通知未配置完整' }}
+              </span>
+              <span class="user-admin__chip" :class="{ 'user-admin__chip--success': dingtalkAccess.workNotification.requirements.appKey.configured, 'user-admin__chip--danger': !dingtalkAccess.workNotification.requirements.appKey.configured }">
+                App Key
+              </span>
+              <span class="user-admin__chip" :class="{ 'user-admin__chip--success': dingtalkAccess.workNotification.requirements.appSecret.configured, 'user-admin__chip--danger': !dingtalkAccess.workNotification.requirements.appSecret.configured }">
+                App Secret
+              </span>
+              <span class="user-admin__chip" :class="{ 'user-admin__chip--success': dingtalkAccess.workNotification.requirements.agentId.configured, 'user-admin__chip--danger': !dingtalkAccess.workNotification.requirements.agentId.configured }">
+                Agent ID
+              </span>
+            </div>
+            <p v-if="dingtalkAccess?.workNotification" class="user-admin__hint">
+              {{ readDingTalkWorkNotificationStatus(dingtalkAccess) }}
+            </p>
             <div v-if="dingtalkAccess" class="user-admin__create-grid">
               <div class="user-admin__hint"><strong>身份 corpId：</strong>{{ dingtalkAccess.identity.corpId || dingtalkAccess.server?.corpId || '未记录' }}</div>
               <div class="user-admin__hint"><strong>Union ID：</strong>{{ dingtalkAccess.identity.unionId || '未记录' }}</div>
@@ -748,12 +768,37 @@ type DingTalkRuntimeStatus = {
   unavailableReason: 'missing_client_id' | 'missing_client_secret' | 'missing_redirect_uri' | 'corp_not_allowed' | null
 }
 
+type DingTalkWorkNotificationRuntimeStatus = {
+  configured: boolean
+  available: boolean
+  unavailableReason: 'missing_app_key' | 'missing_app_secret' | 'missing_agent_id' | null
+  requirements: {
+    appKey: {
+      configured: boolean
+      selectedKey: string | null
+    }
+    appSecret: {
+      configured: boolean
+      selectedKey: string | null
+    }
+    agentId: {
+      configured: boolean
+      selectedKey: string | null
+    }
+    baseUrl?: {
+      configured: boolean
+      selectedKey: string | null
+    }
+  }
+}
+
 type DingTalkAccess = {
   provider: 'dingtalk'
   requireGrant: boolean
   autoLinkEmail: boolean
   autoProvision: boolean
   server?: DingTalkRuntimeStatus
+  workNotification?: DingTalkWorkNotificationRuntimeStatus
   grant: {
     exists: boolean
     enabled: boolean
@@ -1593,6 +1638,15 @@ function readDingTalkServerStatus(accessValue: DingTalkAccess | null): string {
     return '服务端钉钉登录暂不可用'
   }
   return '服务端钉钉登录可用'
+}
+
+function readDingTalkWorkNotificationStatus(accessValue: DingTalkAccess | null): string {
+  const reason = accessValue?.workNotification?.unavailableReason ?? null
+  if (reason === 'missing_app_key') return '钉钉工作通知缺少 DINGTALK_APP_KEY 或 DINGTALK_CLIENT_ID'
+  if (reason === 'missing_app_secret') return '钉钉工作通知缺少 DINGTALK_APP_SECRET 或 DINGTALK_CLIENT_SECRET'
+  if (reason === 'missing_agent_id') return '钉钉工作通知缺少 DINGTALK_AGENT_ID 或 DINGTALK_NOTIFY_AGENT_ID'
+  if (accessValue?.workNotification?.available === false) return '钉钉工作通知暂不可用'
+  return '钉钉工作通知可用；群机器人发送失败时可通知规则创建人'
 }
 
 function canEnableDingTalkGrant(accessValue: DingTalkAccess | null): boolean {

--- a/apps/web/tests/directoryManagementView.spec.ts
+++ b/apps/web/tests/directoryManagementView.spec.ts
@@ -4741,6 +4741,147 @@ describe('DirectoryManagementView', () => {
     expect(container?.textContent).toContain('根部门 1 当前仅返回 1 个直属成员')
   })
 
+  it('tests and saves DingTalk work notification Agent ID from the directory page', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration()],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: { items: [] },
+      }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createScheduleSnapshotPayload(),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAlertListPayload([]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          result: {
+            integration: { id: 'dir-1', name: 'DingTalk CN', status: 'active' },
+            agentId: { configured: true, length: 9, valuePrinted: false, persisted: false },
+            accessTokenVerified: true,
+            notificationSent: false,
+          },
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          result: {
+            integration: { id: 'dir-1', name: 'DingTalk CN', status: 'active' },
+            agentId: { configured: true, length: 9, valuePrinted: false, persisted: false },
+            accessTokenVerified: true,
+            notificationSent: false,
+            saved: true,
+          },
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration({
+            config: {
+              ...createIntegration().config,
+              workNotificationAgentIdConfigured: true,
+            },
+          })],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: { items: [] },
+      }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createScheduleSnapshotPayload(),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAlertListPayload([]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([]),
+      ))
+
+    app = createApp(DirectoryManagementView)
+    registerRouterLink(app)
+    app.mount(container!)
+    await flushUi()
+
+    const agentInput = container!.querySelector('input[placeholder*="仅系统管理员填写"]') as HTMLInputElement | null
+    expect(agentInput).toBeTruthy()
+    agentInput!.value = '123456789'
+    agentInput!.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi(2)
+
+    const testButton = Array.from(container!.querySelectorAll('button')).find((button) => button.textContent?.includes('测试工作通知'))
+    expect(testButton).toBeTruthy()
+    testButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(6)
+
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      '/api/admin/directory/dingtalk/work-notification/test',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          integrationId: 'dir-1',
+          agentId: '123456789',
+          recipientUserId: '',
+        }),
+      }),
+    )
+    expect(container?.textContent).toContain('工作通知 Agent ID 基础测试通过')
+
+    const saveButton = Array.from(container!.querySelectorAll('button')).find((button) => button.textContent?.includes('保存 Agent ID'))
+    expect(saveButton).toBeTruthy()
+    saveButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(8)
+
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      '/api/admin/directory/dingtalk/work-notification',
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({
+          integrationId: 'dir-1',
+          agentId: '123456789',
+          recipientUserId: '',
+        }),
+      }),
+    )
+    expect(container?.textContent).toContain('Agent ID 已保存')
+  })
+
+  it('hides DingTalk work notification Agent ID inputs until an integration is selected', async () => {
+    apiFetchMock.mockResolvedValueOnce(createJsonResponse({
+      ok: true,
+      data: {
+        items: [],
+      },
+    }))
+
+    app = createApp(DirectoryManagementView)
+    registerRouterLink(app)
+    app.mount(container!)
+    await flushUi()
+
+    expect(container?.textContent).toContain('请先创建并选中钉钉目录集成')
+    expect(container!.querySelector('input[placeholder*="仅系统管理员填写"]')).toBeNull()
+    expect(Array.from(container!.querySelectorAll('button')).some((button) => button.textContent?.includes('保存 Agent ID'))).toBe(false)
+  })
+
   it('unbinds a linked directory account', async () => {
     apiFetchMock
       .mockResolvedValueOnce(createJsonResponse({

--- a/apps/web/tests/userManagementView.spec.ts
+++ b/apps/web/tests/userManagementView.spec.ts
@@ -293,6 +293,29 @@ function createApiImplementation(
         autoProvision: false,
         unavailableReason: null,
       },
+      workNotification: {
+        configured: true,
+        available: true,
+        unavailableReason: null,
+        requirements: {
+          appKey: {
+            configured: true,
+            selectedKey: 'DINGTALK_APP_KEY',
+          },
+          appSecret: {
+            configured: true,
+            selectedKey: 'DINGTALK_APP_SECRET',
+          },
+          agentId: {
+            configured: true,
+            selectedKey: 'DINGTALK_AGENT_ID',
+          },
+          baseUrl: {
+            configured: false,
+            selectedKey: null,
+          },
+        },
+      },
       directory: {
         linked: user.directoryLinked,
         linkedCount: user.directoryLinked ? 1 : 0,
@@ -662,6 +685,8 @@ describe('UserManagementView', () => {
     expect(container?.textContent).toContain('插件使用')
     expect(container?.textContent).toContain('服务端已启用钉钉登录')
     expect(container?.textContent).toContain('服务端钉钉登录可用')
+    expect(container?.textContent).toContain('工作通知已配置')
+    expect(container?.textContent).toContain('钉钉工作通知可用')
     expect(container?.textContent).toContain('允许企业：dingcorp、dingcorp-2')
     expect(container?.textContent).toContain('身份 corpId：dingcorp')
     expect(container?.textContent).toContain('Union ID：user-1-union')

--- a/docs/development/dingtalk-agent-id-mainline-integration-design-20260508.md
+++ b/docs/development/dingtalk-agent-id-mainline-integration-design-20260508.md
@@ -1,0 +1,111 @@
+# DingTalk Agent ID Mainline Integration Design
+
+Date: 2026-05-08
+
+## Goal
+
+Move the DingTalk work-notification Agent ID feature from the Codex feature branch onto current `origin/main` so the 142 main deployment can build an image that contains:
+
+- Work-notification runtime status.
+- Admin API to test and save Agent ID.
+- Frontend directory-management Agent ID configuration entry.
+- Release-gate and acceptance helpers.
+
+## Root Cause
+
+142 main was healthy on `origin/main`, but authenticated calls to:
+
+```text
+GET /api/admin/directory/dingtalk/work-notification
+```
+
+returned `404 Cannot GET ...`.
+
+That showed the deployed main image did not contain the Agent ID admin API. The feature existed only on:
+
+```text
+codex/dingtalk-directory-return-banner-tests-20260505
+```
+
+## Mainline Strategy
+
+Created integration branch:
+
+```text
+codex/dingtalk-agent-id-mainline-20260508
+```
+
+Base:
+
+```text
+origin/main
+```
+
+Cherry-picked feature commits:
+
+```text
+8f5bd7f4b  feat(dingtalk): surface work notification env status
+78d3e86bb  chore(dingtalk): add work notification agent id apply helper
+b32b97594  chore(dingtalk): initialize work notification agent id file
+c33d8969b  chore(dingtalk): add work notification release gate
+9129dae66  feat(dingtalk): add admin Agent ID work notification config
+348e55e46  chore(dingtalk): add admin Agent ID acceptance helper
+```
+
+## Conflict Policy
+
+Two conflicts appeared:
+
+- `apps/web/src/views/DirectoryManagementView.vue`
+- `packages/core-backend/src/multitable/automation-executor.ts`
+
+Resolution:
+
+- Kept current `origin/main` behavior where unrelated group-failure-alert logic was not present.
+- Added only the Agent ID UI/status/save/test surface to the directory management page.
+- Kept the automation runtime change that reads DingTalk work-notification config from runtime/store instead of env-only config.
+- Did not bring the large `d8a47297c` group-failure-alert commit or broad multitable/governance docs into the mainline branch.
+
+## Delivery Scope
+
+Included:
+
+- Backend work-notification runtime settings.
+- Admin directory routes for status/test/save.
+- Directory integration storage boundary that prevents generic create/update from writing Agent ID.
+- Frontend Agent ID entry, validation test button, and save button.
+- Release gate and admin acceptance helper scripts.
+- Targeted unit tests and operational docs.
+
+Excluded:
+
+- Broad DingTalk group-failure-alert rollout.
+- Multitable Feishu/field-type work.
+- Unrelated integration-core and staging documentation.
+- Secrets, webhook URLs, Agent ID values, or admin JWT values.
+
+## 142 Next Step
+
+After this branch builds GHCR images, deploy 142 main with the new SHA, then run:
+
+```bash
+node /tmp/dingtalk-work-notification-admin-agent-id.mjs \
+  --api-base http://127.0.0.1:8900 \
+  --auth-token-file /tmp/admin.jwt \
+  --status-only \
+  --output-json /tmp/dingtalk-agent/status.json \
+  --output-md /tmp/dingtalk-agent/status.md
+```
+
+Expected first result before filling Agent ID:
+
+- API should return `200` with a redacted status payload.
+- Runtime may report `missing_agent_id`.
+
+After filling the private file:
+
+```text
+/home/mainuser/metasheet2/.secrets/dingtalk-agent-id.txt
+```
+
+run the same helper with `--agent-id-file ... --save`.

--- a/docs/development/dingtalk-agent-id-mainline-integration-design-20260508.md
+++ b/docs/development/dingtalk-agent-id-mainline-integration-design-20260508.md
@@ -109,3 +109,35 @@ After filling the private file:
 ```
 
 run the same helper with `--agent-id-file ... --save`.
+
+## Final Release Design Notes
+
+During release, `origin/main` advanced again after the first integration image
+was built. To avoid rolling back unrelated mainline changes, the integration
+branch was rebased onto the latest observed main:
+
+```text
+06f71465ac55843431f7d5de7eea00fd7eb1a5d2
+```
+
+The final deployable Agent ID image tag is:
+
+```text
+9e17038871ff4a0cbdb32d8c816692f10d1f92cb
+```
+
+142 also had concurrent external deployments that temporarily moved the main
+containers through other mainline tags. The release policy used here was:
+
+- Do not fight an active external deploy process.
+- Wait for 142 to settle on the latest main tag.
+- Rebase Agent ID work onto that latest main.
+- Build immutable GHCR images from the rebased branch.
+- Manually switch only `metasheet-backend` and `metasheet-web`.
+- Keep the immediately previous main tag as the rollback baseline.
+
+The 142 disk filled during image pulls because many old GHCR backend/web images
+were retained. The cleanup deliberately removed only unused `metasheet2`
+backend/web GHCR image tags, preserving running images plus the current and
+rollback baselines. No database volumes, Redis data, or application uploads were
+removed.

--- a/docs/development/dingtalk-agent-id-mainline-integration-design-20260508.md
+++ b/docs/development/dingtalk-agent-id-mainline-integration-design-20260508.md
@@ -112,18 +112,18 @@ run the same helper with `--agent-id-file ... --save`.
 
 ## Final Release Design Notes
 
-During release, `origin/main` advanced again after the first integration image
-was built. To avoid rolling back unrelated mainline changes, the integration
-branch was rebased onto the latest observed main:
+During release, `origin/main` advanced after integration images were built. To
+avoid rolling back unrelated mainline changes, the integration branch was
+rebased onto the latest observed main before the final 142 switch:
 
 ```text
-06f71465ac55843431f7d5de7eea00fd7eb1a5d2
+61605888739e731cedbc6dc377c93893106e338a
 ```
 
 The final deployable Agent ID image tag is:
 
 ```text
-9e17038871ff4a0cbdb32d8c816692f10d1f92cb
+245701aeb5afc57ae5a5932cc4f58ef3aef3a973
 ```
 
 142 also had concurrent external deployments that temporarily moved the main
@@ -135,6 +135,10 @@ containers through other mainline tags. The release policy used here was:
 - Build immutable GHCR images from the rebased branch.
 - Manually switch only `metasheet-backend` and `metasheet-web`.
 - Keep the immediately previous main tag as the rollback baseline.
+
+Interim tag `9e17038871ff4a0cbdb32d8c816692f10d1f92cb` was successfully
+verified, then superseded by `245701aeb5afc57ae5a5932cc4f58ef3aef3a973` after
+the branch was brought current with `main`.
 
 The 142 disk filled during image pulls because many old GHCR backend/web images
 were retained. The cleanup deliberately removed only unused `metasheet2`

--- a/docs/development/dingtalk-agent-id-mainline-integration-verification-20260508.md
+++ b/docs/development/dingtalk-agent-id-mainline-integration-verification-20260508.md
@@ -286,10 +286,12 @@ PR:
 https://github.com/zensgit/metasheet2/pull/1430
 ```
 
-Status after the final rebase:
+Status after the final runtime rebase and 142 acceptance:
 
-- Head: `245701aeb5afc57ae5a5932cc4f58ef3aef3a973`.
-- Base: `61605888739e731cedbc6dc377c93893106e338a`.
+- Runtime image verified on 142: `245701aeb5afc57ae5a5932cc4f58ef3aef3a973`.
+- Base included in that runtime image: `61605888739e731cedbc6dc377c93893106e338a`.
+- The PR may contain later docs-only commits after the runtime image tag; those
+  commits do not change backend/frontend runtime behavior.
 - Automated checks observed in the PR rollup passed, except the configured
   strict E2E job that was skipped by workflow policy.
 - Merge state was still `BLOCKED` because repository review/merge policy had

--- a/docs/development/dingtalk-agent-id-mainline-integration-verification-20260508.md
+++ b/docs/development/dingtalk-agent-id-mainline-integration-verification-20260508.md
@@ -8,10 +8,22 @@ Date: 2026-05-08
 codex/dingtalk-agent-id-mainline-20260508
 ```
 
-Base:
+Initial base:
 
 ```text
 origin/main
+```
+
+Final release base:
+
+```text
+06f71465ac55843431f7d5de7eea00fd7eb1a5d2
+```
+
+Final release image tag:
+
+```text
+9e17038871ff4a0cbdb32d8c816692f10d1f92cb
 ```
 
 ## 142 Pre-Integration Evidence
@@ -117,6 +129,17 @@ Result:
 
 - Pass.
 
+Frontend build:
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result:
+
+- Pass.
+- Vite reported existing chunk-size warnings only.
+
 Diff whitespace:
 
 ```bash
@@ -126,6 +149,127 @@ git diff --check origin/main..HEAD
 Result:
 
 - Pass.
+
+Secret scan:
+
+```bash
+git diff --name-only origin/main..HEAD | xargs rg -n --no-heading -S \
+  'oapi\.dingtalk\.com/robot/send|access_token=|\bSEC[a-zA-Z0-9]{20,}\b|eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+'
+```
+
+Result:
+
+- No real DingTalk webhook, robot `SEC...`, admin JWT, or Agent ID value found.
+- Matches were limited to redactor code, generated URL construction, docs scan
+  commands, and dummy test fixtures.
+
+## GHCR Verification
+
+Workflow:
+
+```text
+Build and Push Docker Images
+```
+
+Run:
+
+```text
+https://github.com/zensgit/metasheet2/actions/runs/25535508861
+```
+
+Result:
+
+- Build job passed.
+- Backend image pushed for `9e17038871ff4a0cbdb32d8c816692f10d1f92cb`.
+- Web image pushed for `9e17038871ff4a0cbdb32d8c816692f10d1f92cb`.
+- Deploy job skipped because the branch is not `main`, which is expected for
+  this manual 142 acceptance release.
+
+## 142 Deployment Verification
+
+Before final switch, 142 had advanced to latest main:
+
+```text
+IMAGE_TAG=06f71465ac55843431f7d5de7eea00fd7eb1a5d2
+```
+
+The final manual switch changed only `metasheet-backend` and `metasheet-web`:
+
+```text
+IMAGE_TAG=9e17038871ff4a0cbdb32d8c816692f10d1f92cb
+```
+
+Container state:
+
+```text
+metasheet-web     ghcr.io/zensgit/metasheet2-web:9e17038871ff4a0cbdb32d8c816692f10d1f92cb
+metasheet-backend ghcr.io/zensgit/metasheet2-backend:9e17038871ff4a0cbdb32d8c816692f10d1f92cb
+metasheet-postgres postgres:15-alpine healthy
+metasheet-redis    redis:7-alpine healthy
+```
+
+Health:
+
+```text
+GET http://127.0.0.1:8900/api/health -> 200
+GET http://127.0.0.1:8081/ -> 200
+```
+
+Disk:
+
+```text
+Before cleanup: / use=100%, avail=0
+After cleanup:  / use=44%-46%, avail=40G+
+```
+
+Cleanup scope:
+
+- Removed only unused `ghcr.io/zensgit/metasheet2-backend` and
+  `ghcr.io/zensgit/metasheet2-web` image tags.
+- Preserved running images and rollback/current baselines.
+- Did not remove Docker volumes, Postgres data, Redis data, uploads, or secrets.
+
+## 142 Agent ID Acceptance
+
+Unauthenticated route:
+
+```text
+GET /api/admin/directory/dingtalk/work-notification -> 401
+```
+
+Authenticated status helper:
+
+```json
+{
+  "status": "pass",
+  "statusBefore": {
+    "configured": false,
+    "available": false,
+    "unavailableReason": "missing_agent_id",
+    "source": "mixed"
+  }
+}
+```
+
+Authenticated save helper with the private Agent ID file:
+
+```json
+{
+  "saveExitCode": 1,
+  "saveStatus": "blocked",
+  "saveFailureCodes": ["AGENT_ID_FILE_EMPTY"],
+  "agentFileEmpty": true
+}
+```
+
+Conclusion:
+
+- The Agent ID admin route is present and authenticated.
+- Empty Agent ID is rejected before save.
+- The private Agent ID file currently exists but is intentionally empty.
+- The next real-send acceptance step requires filling the Agent ID through the
+  frontend page or the private file, then optionally providing a recipient user
+  id file for a real DingTalk work-notification send test.
 
 ## Security
 
@@ -137,13 +281,10 @@ The helper output intentionally keeps:
 - token file paths redacted to basenames
 - Agent ID represented only by configured state and length
 
-## Remaining Production Acceptance
+## Remaining Non-Blocking Items
 
-After GHCR builds this integration branch or after merge to main:
-
-1. Deploy 142 main to the new SHA.
-2. Verify `/api/health` and `/`.
-3. Run admin helper `--status-only`; route should no longer be 404.
-4. Fill `/home/mainuser/metasheet2/.secrets/dingtalk-agent-id.txt` or save Agent ID through the frontend directory-management page.
-5. Run helper with `--agent-id-file ... --save`.
-6. Optional: add `--recipient-user-id-file` for real DingTalk work-notification delivery verification.
+1. Fill/save the real DingTalk work-notification Agent ID.
+2. Run helper with `--agent-id-file ... --save`.
+3. Optionally add `--recipient-user-id-file` for a real DingTalk work-notification delivery test.
+4. Merge this branch to `main` so future automatic 142 deployments stop
+   overwriting the manual Agent ID acceptance image.

--- a/docs/development/dingtalk-agent-id-mainline-integration-verification-20260508.md
+++ b/docs/development/dingtalk-agent-id-mainline-integration-verification-20260508.md
@@ -17,13 +17,13 @@ origin/main
 Final release base:
 
 ```text
-06f71465ac55843431f7d5de7eea00fd7eb1a5d2
+61605888739e731cedbc6dc377c93893106e338a
 ```
 
 Final release image tag:
 
 ```text
-9e17038871ff4a0cbdb32d8c816692f10d1f92cb
+245701aeb5afc57ae5a5932cc4f58ef3aef3a973
 ```
 
 ## 142 Pre-Integration Evidence
@@ -174,36 +174,43 @@ Build and Push Docker Images
 Run:
 
 ```text
-https://github.com/zensgit/metasheet2/actions/runs/25535508861
+https://github.com/zensgit/metasheet2/actions/runs/25535973036
 ```
 
 Result:
 
 - Build job passed.
-- Backend image pushed for `9e17038871ff4a0cbdb32d8c816692f10d1f92cb`.
-- Web image pushed for `9e17038871ff4a0cbdb32d8c816692f10d1f92cb`.
+- Backend image pushed for `245701aeb5afc57ae5a5932cc4f58ef3aef3a973`.
+- Web image pushed for `245701aeb5afc57ae5a5932cc4f58ef3aef3a973`.
 - Deploy job skipped because the branch is not `main`, which is expected for
   this manual 142 acceptance release.
 
 ## 142 Deployment Verification
 
-Before final switch, 142 had advanced to latest main:
+Before the first manual switch, 142 had advanced to latest main:
 
 ```text
 IMAGE_TAG=06f71465ac55843431f7d5de7eea00fd7eb1a5d2
 ```
 
-The final manual switch changed only `metasheet-backend` and `metasheet-web`:
+The branch was then rebased again onto:
 
 ```text
-IMAGE_TAG=9e17038871ff4a0cbdb32d8c816692f10d1f92cb
+61605888739e731cedbc6dc377c93893106e338a
+```
+
+The final manual switch changed only `metasheet-backend` and `metasheet-web`
+from the interim Agent ID tag to the latest rebased Agent ID tag:
+
+```text
+IMAGE_TAG=245701aeb5afc57ae5a5932cc4f58ef3aef3a973
 ```
 
 Container state:
 
 ```text
-metasheet-web     ghcr.io/zensgit/metasheet2-web:9e17038871ff4a0cbdb32d8c816692f10d1f92cb
-metasheet-backend ghcr.io/zensgit/metasheet2-backend:9e17038871ff4a0cbdb32d8c816692f10d1f92cb
+metasheet-web     ghcr.io/zensgit/metasheet2-web:245701aeb5afc57ae5a5932cc4f58ef3aef3a973
+metasheet-backend ghcr.io/zensgit/metasheet2-backend:245701aeb5afc57ae5a5932cc4f58ef3aef3a973
 metasheet-postgres postgres:15-alpine healthy
 metasheet-redis    redis:7-alpine healthy
 ```
@@ -270,6 +277,23 @@ Conclusion:
 - The next real-send acceptance step requires filling the Agent ID through the
   frontend page or the private file, then optionally providing a recipient user
   id file for a real DingTalk work-notification send test.
+
+## PR Status
+
+PR:
+
+```text
+https://github.com/zensgit/metasheet2/pull/1430
+```
+
+Status after the final rebase:
+
+- Head: `245701aeb5afc57ae5a5932cc4f58ef3aef3a973`.
+- Base: `61605888739e731cedbc6dc377c93893106e338a`.
+- Automated checks observed in the PR rollup passed, except the configured
+  strict E2E job that was skipped by workflow policy.
+- Merge state was still `BLOCKED` because repository review/merge policy had
+  not yet been satisfied.
 
 ## Security
 

--- a/docs/development/dingtalk-agent-id-mainline-integration-verification-20260508.md
+++ b/docs/development/dingtalk-agent-id-mainline-integration-verification-20260508.md
@@ -1,0 +1,149 @@
+# DingTalk Agent ID Mainline Integration Verification
+
+Date: 2026-05-08
+
+## Branch
+
+```text
+codex/dingtalk-agent-id-mainline-20260508
+```
+
+Base:
+
+```text
+origin/main
+```
+
+## 142 Pre-Integration Evidence
+
+142 main settled on:
+
+```text
+IMAGE_TAG=2e038c36b009698f654b7c5b38806058d5dfa5e8
+```
+
+Health:
+
+```json
+{"ok":true,"status":"ok","success":true,"plugins":13}
+```
+
+Frontend:
+
+```text
+HTTP/1.1 200 OK
+```
+
+Unauthenticated Agent ID route probe:
+
+```text
+401
+```
+
+Authenticated helper probe against current main image:
+
+```json
+{
+  "status": "blocked",
+  "failures": [
+    { "code": "STATUS_API_FAILED", "httpStatus": 404 }
+  ],
+  "agentIdLength": 0,
+  "agentIdValuePrinted": false
+}
+```
+
+Conclusion:
+
+- 142 main is healthy.
+- Current main image does not contain the Agent ID admin API.
+- The fix must land on main and be rebuilt/deployed, not hot-patched.
+
+## Local Verification
+
+Dependency install in clean worktree:
+
+```bash
+pnpm install --frozen-lockfile --ignore-scripts
+```
+
+Script/helper checks:
+
+```bash
+node --check scripts/ops/dingtalk-work-notification-admin-agent-id.mjs
+node --test scripts/ops/dingtalk-work-notification-admin-agent-id.test.mjs
+node --test scripts/ops/dingtalk-work-notification-release-gate.test.mjs
+```
+
+Result:
+
+- Admin helper tests: 4 passed.
+- Release gate tests: 5 passed.
+
+Backend targeted tests:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/dingtalk-work-notification-settings.test.ts \
+  tests/unit/admin-directory-routes.test.ts \
+  tests/unit/directory-sync-work-notification-agent-id.test.ts \
+  --run
+```
+
+Result:
+
+- 3 files passed.
+- 33 tests passed.
+
+Frontend targeted tests:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/directoryManagementView.spec.ts --run
+```
+
+Result:
+
+- 1 file passed.
+- 38 tests passed.
+- Note: Vitest printed `WebSocket server error: Port is already in use`; tests still completed successfully.
+
+Backend build:
+
+```bash
+pnpm --filter @metasheet/core-backend build
+```
+
+Result:
+
+- Pass.
+
+Diff whitespace:
+
+```bash
+git diff --check origin/main..HEAD
+```
+
+Result:
+
+- Pass.
+
+## Security
+
+No real DingTalk webhook, `SEC...` robot secret, Agent ID value, or admin JWT is written in this document.
+
+The helper output intentionally keeps:
+
+- `agentIdValuePrinted=false`
+- token file paths redacted to basenames
+- Agent ID represented only by configured state and length
+
+## Remaining Production Acceptance
+
+After GHCR builds this integration branch or after merge to main:
+
+1. Deploy 142 main to the new SHA.
+2. Verify `/api/health` and `/`.
+3. Run admin helper `--status-only`; route should no longer be 404.
+4. Fill `/home/mainuser/metasheet2/.secrets/dingtalk-agent-id.txt` or save Agent ID through the frontend directory-management page.
+5. Run helper with `--agent-id-file ... --save`.
+6. Optional: add `--recipient-user-id-file` for real DingTalk work-notification delivery verification.

--- a/docs/development/dingtalk-claude-codex-handoff-design-20260508.md
+++ b/docs/development/dingtalk-claude-codex-handoff-design-20260508.md
@@ -1,0 +1,146 @@
+# DingTalk Agent ID — Claude / Codex Handoff Design
+
+Date: 2026-05-08
+
+## Background
+
+PR #1430 ports the DingTalk work-notification Agent ID admin configuration onto
+`origin/main` so the 142 production deployment can build an image that exposes
+status / test / save endpoints plus the directory-management Agent ID UI.
+
+State at handoff time:
+
+- Branch: `codex/dingtalk-agent-id-mainline-20260508`.
+- Runtime image verified on 142: `245701aeb5afc57ae5a5932cc4f58ef3aef3a973`.
+- 142 backend health: `200`.
+- 142 frontend root: `200`.
+- The private Agent ID file exists on 142 but is intentionally empty.
+- Real-send DingTalk work-notification acceptance is therefore still pending.
+
+This document defines the division of labor between Claude (in-repo agent) and
+Codex (release / verification agent) for the remaining work.
+
+## Why the split exists
+
+Two constraints drive the split:
+
+1. **Secret boundary.** Real DingTalk Agent ID, admin JWTs, recipient user
+   ids, and webhook URLs must never enter the repository, the chat transcript,
+   or any AI-readable file. Only Codex, running in the operator environment,
+   may read or write those values.
+2. **Runtime boundary.** Only Codex has direct access to the 142 host, the
+   GHCR registry tag list, the `.secrets/` directory, and the manual
+   container-switch workflow. Claude must stay confined to the working tree.
+
+## Division of labor
+
+### Claude scope (allowed)
+
+Claude is allowed to perform bounded, redaction-safe, repo-local work:
+
+- Author or revise design / verification / runbook Markdown under `docs/`.
+- Edit non-secret backend or frontend source files when given a specific
+  diff intent (e.g., add a validation rule, fix a typo, adjust a test
+  assertion) — and only after the user explicitly asks for code changes.
+- Update or extend unit tests that already exist in the tree, as long as
+  they do not require real DingTalk credentials.
+- Summarize public PR / CI / git state from text the user pastes in.
+- Produce status checklists, stop-condition lists, rollback notes, and
+  changelog entries that reference only redaction-safe identifiers
+  (image SHAs, run URLs, route paths, exit codes, structured status JSON
+  with `agentIdValuePrinted=false`).
+
+For this specific handoff, Claude is restricted to editing only:
+
+- `docs/development/dingtalk-claude-codex-handoff-design-20260508.md`
+- `docs/development/dingtalk-claude-codex-handoff-verification-20260508.md`
+
+### Claude scope (forbidden)
+
+Claude must not:
+
+- Read `.env`, `.env.*`, `.secrets/**`, token files, webhook files, or any
+  file whose name or path implies it stores credentials.
+- Print, paste, echo, or log values that look like an Agent ID, admin JWT,
+  DingTalk robot secret, robot webhook URL, or recipient user id list.
+- Modify backend or frontend source files as part of this handoff task —
+  this handoff is documentation only.
+- Run any command that would touch 142, GHCR, the manual container switch,
+  or the real DingTalk send API.
+- Speculate about secret values or reconstruct them from context.
+
+### Codex scope (allowed and required)
+
+Codex is the only agent permitted to:
+
+- Read `/home/mainuser/metasheet2/.secrets/dingtalk-agent-id.txt` and any
+  related private recipient files.
+- Generate, hold, and rotate the admin JWT used by the helper scripts.
+- Run `pnpm install`, `pnpm build`, targeted `vitest`, and `node --test`
+  jobs in the trusted build environment (locally or in CI).
+- Trigger and inspect the GHCR `Build and Push Docker Images` workflow.
+- Execute the manual 142 container switch for `metasheet-backend` and
+  `metasheet-web`, including rollback to the prior baseline.
+- Run `scripts/ops/dingtalk-work-notification-admin-agent-id.mjs` against
+  127.0.0.1 on 142 with the real auth token file and Agent ID file.
+- Drive the real-send DingTalk work-notification acceptance using the
+  recipient user id file, observe delivery, and record only the
+  redaction-safe status payload.
+- Update PR #1430 description, request reviews, and resolve the merge
+  policy block once acceptance is green.
+
+### Shared / handoff artifacts
+
+Both sides write or consume these artifacts, but only in the redaction-safe
+shape described below:
+
+- `status.json` and `status.md` produced by the admin helper. Claude may
+  read and quote fields such as `configured`, `available`,
+  `unavailableReason`, `source`, `agentIdLength`, and
+  `agentIdValuePrinted` — but never the Agent ID itself.
+- PR #1430 metadata: number, head SHA, base SHA, check names, run URLs,
+  merge state.
+- Image tags: GHCR digests / commit SHAs are public identifiers and may be
+  written to docs.
+- 142 health output: `{"ok":true,"status":"ok",...}` is non-secret.
+
+## Workflow loop
+
+1. Codex performs a runtime / acceptance step on 142 or in CI.
+2. Codex captures the redaction-safe outputs (status JSON, exit codes,
+   image tag, run URL).
+3. Codex relays those outputs to the operator or pastes them into the
+   conversation.
+4. Claude updates `docs/development/...` Markdown, checklists, or PR notes
+   based only on those pasted outputs.
+5. Operator reviews the Markdown, then asks Codex to drive the next
+   runtime step.
+
+The loop terminates when the verification doc's stop conditions are all
+green and PR #1430 is merged into `main`.
+
+## Risk / failure handling
+
+- If a helper exits non-zero with `AGENT_ID_FILE_EMPTY`, that is the
+  current expected blocker and is not a regression. Codex fills the
+  private file and re-runs `--save`.
+- If the helper exits non-zero with `STATUS_API_FAILED` and `httpStatus`
+  is `404`, the deployed image does not contain the Agent ID API. Codex
+  must rebuild / redeploy from a branch that includes the feature.
+- If the helper exits non-zero with `httpStatus: 401`, the admin JWT is
+  missing or expired. Codex refreshes the token; Claude does not see it.
+- If the secret scan in CI fails, Claude inspects only the file paths and
+  line numbers reported by the scanner — never the matched values — and
+  proposes a redaction patch.
+- If 142 disk fills again, Codex repeats the bounded GHCR backend/web tag
+  cleanup that preserves running images plus the current and rollback
+  baselines, and never touches Postgres / Redis / uploads.
+
+## Out of scope for this handoff
+
+- Group-failure-alert rollout.
+- Multitable Feishu / field-type work.
+- Integration-core changes.
+- Any change to the K3 PoC stage-1 lock.
+- Any code modification on the Agent ID branch as part of this
+  documentation handoff.

--- a/docs/development/dingtalk-claude-codex-handoff-design-20260508.md
+++ b/docs/development/dingtalk-claude-codex-handoff-design-20260508.md
@@ -11,11 +11,31 @@ status / test / save endpoints plus the directory-management Agent ID UI.
 State at handoff time:
 
 - Branch: `codex/dingtalk-agent-id-mainline-20260508`.
-- Runtime image verified on 142: `245701aeb5afc57ae5a5932cc4f58ef3aef3a973`.
+- PR #1430 runtime/code verification point:
+  `826242b5adb89c87b4e03d502a3905e4b270e43a` (rebased onto latest
+  `origin/main`). The PR may contain later docs-only commits; those do
+  not change the runtime code verified at this point.
+- PR #1430 base: `20fb5270a09d4cc3d2c98e84db3601fc3f4231c5`.
+- All non-review CI checks on PR #1430 are green. The merge is BLOCKED
+  only by `REVIEW_REQUIRED` (human approval policy), not by any failing
+  technical check.
+- 142 currently runs the auto-deployed main tag
+  `20fb5270a09d4cc3d2c98e84db3601fc3f4231c5` for both
+  `metasheet-backend` and `metasheet-web`.
 - 142 backend health: `200`.
 - 142 frontend root: `200`.
-- The private Agent ID file exists on 142 but is intentionally empty.
-- Real-send DingTalk work-notification acceptance is therefore still pending.
+- The Agent ID runtime tag `245701aeb5afc57ae5a5932cc4f58ef3aef3a973`
+  that was previously verified on 142 has been overwritten by the
+  automatic `main` deployment. Repeated manual container switches back
+  onto a feature tag are **not** recommended at this point — they will
+  keep being overwritten by the next `main` auto-deploy and only churn
+  the runtime.
+- The private Agent ID file on 142 still exists but is empty, so
+  real-send DingTalk work-notification acceptance is still pending.
+- Forward path: merge PR #1430 into `main` first, let 142 auto-deploy
+  the new `main` image (which will include the Agent ID feature
+  commits), then run the real Agent ID save and real-send acceptance
+  on that auto-deployed image — not on a manually switched tag.
 
 This document defines the division of labor between Claude (in-repo agent) and
 Codex (release / verification agent) for the remaining work.
@@ -80,7 +100,11 @@ Codex is the only agent permitted to:
   jobs in the trusted build environment (locally or in CI).
 - Trigger and inspect the GHCR `Build and Push Docker Images` workflow.
 - Execute the manual 142 container switch for `metasheet-backend` and
-  `metasheet-web`, including rollback to the prior baseline.
+  `metasheet-web`, including rollback to the prior baseline. At this
+  stage of the loop, manual switches should be reserved for rollback
+  only — forward switches onto pre-merge feature tags will be
+  overwritten by the next `main` auto-deploy and are no longer the
+  preferred path to acceptance.
 - Run `scripts/ops/dingtalk-work-notification-admin-agent-id.mjs` against
   127.0.0.1 on 142 with the real auth token file and Agent ID file.
 - Drive the real-send DingTalk work-notification acceptance using the

--- a/docs/development/dingtalk-claude-codex-handoff-verification-20260508.md
+++ b/docs/development/dingtalk-claude-codex-handoff-verification-20260508.md
@@ -1,0 +1,289 @@
+# DingTalk Agent ID — Claude / Codex Handoff Verification
+
+Date: 2026-05-08
+
+Companion to:
+`docs/development/dingtalk-claude-codex-handoff-design-20260508.md`.
+
+This document is the executable checklist Codex follows to validate the
+Claude / Codex split for PR #1430, plus the explicit stop conditions that
+end the loop.
+
+All commands and outputs in this checklist are redaction-safe. Real Agent
+ID, admin JWT, recipient user ids, and webhook URLs must never be pasted
+into this file or its diffs.
+
+## Inputs Codex must already hold
+
+Before starting the checklist, Codex must already have, outside of the
+repository:
+
+- An admin JWT token file path (e.g. `/tmp/admin.jwt`).
+- The 142 private Agent ID file path
+  (`/home/mainuser/metasheet2/.secrets/dingtalk-agent-id.txt`).
+- Optional recipient user id file for real-send testing.
+
+Claude must not see, request, or echo any of the above.
+
+## Pre-flight identity check
+
+```bash
+git rev-parse --abbrev-ref HEAD
+git log -1 --oneline
+```
+
+Expected:
+
+- Branch is `codex/dingtalk-agent-id-mainline-20260508`.
+- HEAD matches the latest commit referenced in the design doc.
+
+## Doc-only diff check (Claude side)
+
+```bash
+git diff --name-only origin/main..HEAD -- docs/development \
+  | rg 'dingtalk-claude-codex-handoff-(design|verification)-20260508\.md$'
+```
+
+Expected:
+
+- Both files appear in the doc-only diff.
+- No file outside `docs/development/` was modified by Claude in this
+  handoff turn.
+
+```bash
+git diff --name-only origin/main..HEAD \
+  | rg -v '^docs/' \
+  | wc -l
+```
+
+Expected (for a Claude-only handoff turn):
+
+- `0` non-doc files changed since `origin/main`, except for the existing
+  Agent ID feature commits already cherry-picked by Codex.
+
+## Secret-shape scan
+
+Run the repository standard DingTalk/JWT secret-shape scan recorded in
+`dingtalk-agent-id-mainline-integration-verification-20260508.md`. Keep the
+pattern itself in that canonical verification file so this handoff document
+does not introduce additional scanner matches.
+
+Expected:
+
+- No match in the two new handoff Markdown files.
+- Existing matches are confined to redactor code, generated URL
+  construction, prior docs scan commands, and dummy test fixtures, as
+  already recorded in
+  `dingtalk-agent-id-mainline-integration-verification-20260508.md`.
+
+If any new match appears inside either handoff doc, **STOP** and revert
+that doc to its previous state.
+
+## Static helper / build checks (Codex)
+
+These are reruns from the prior verification doc and must stay green:
+
+```bash
+pnpm install --frozen-lockfile --ignore-scripts
+node --check scripts/ops/dingtalk-work-notification-admin-agent-id.mjs
+node --test scripts/ops/dingtalk-work-notification-admin-agent-id.test.mjs
+node --test scripts/ops/dingtalk-work-notification-release-gate.test.mjs
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/dingtalk-work-notification-settings.test.ts \
+  tests/unit/admin-directory-routes.test.ts \
+  tests/unit/directory-sync-work-notification-agent-id.test.ts \
+  --run
+pnpm --filter @metasheet/web exec vitest run tests/directoryManagementView.spec.ts --run
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/web build
+git diff --check origin/main..HEAD
+```
+
+Expected:
+
+- Helper test files: 4 + 5 passing.
+- Backend targeted unit tests: 33 passing across 3 files.
+- Frontend targeted spec: 38 passing in 1 file.
+- Backend build: pass.
+- Frontend build: pass (only existing chunk-size warnings).
+- Whitespace check: pass.
+
+## 142 runtime image check (Codex)
+
+```bash
+docker ps --format '{{.Names}} {{.Image}}'
+curl -fsS http://127.0.0.1:8900/api/health
+curl -sS -o /dev/null -w '%{http_code}\n' http://127.0.0.1:8081/
+curl -sS -o /dev/null -w '%{http_code}\n' \
+  http://127.0.0.1:8900/api/admin/directory/dingtalk/work-notification
+```
+
+Expected:
+
+- `metasheet-backend` and `metasheet-web` images both end with the tag
+  `245701aeb5afc57ae5a5932cc4f58ef3aef3a973`.
+- Health: `{"ok":true,"status":"ok","success":true,"plugins":13}`.
+- Frontend: `200`.
+- Unauthenticated admin route: `401`.
+
+## 142 Agent ID status helper (Codex)
+
+```bash
+node /tmp/dingtalk-work-notification-admin-agent-id.mjs \
+  --api-base http://127.0.0.1:8900 \
+  --auth-token-file /tmp/admin.jwt \
+  --status-only \
+  --output-json /tmp/dingtalk-agent/status.json \
+  --output-md /tmp/dingtalk-agent/status.md
+```
+
+Expected redaction-safe shape:
+
+```json
+{
+  "status": "pass",
+  "statusBefore": {
+    "configured": false,
+    "available": false,
+    "unavailableReason": "missing_agent_id",
+    "source": "mixed"
+  }
+}
+```
+
+Pasteable to Claude. The Agent ID value itself must not appear.
+
+## 142 Agent ID save helper (Codex)
+
+```bash
+node /tmp/dingtalk-work-notification-admin-agent-id.mjs \
+  --api-base http://127.0.0.1:8900 \
+  --auth-token-file /tmp/admin.jwt \
+  --agent-id-file /home/mainuser/metasheet2/.secrets/dingtalk-agent-id.txt \
+  --save \
+  --output-json /tmp/dingtalk-agent/save.json
+```
+
+Three possible outcomes:
+
+1. **File still empty** (current state):
+
+   ```json
+   {
+     "saveExitCode": 1,
+     "saveStatus": "blocked",
+     "saveFailureCodes": ["AGENT_ID_FILE_EMPTY"],
+     "agentFileEmpty": true
+   }
+   ```
+
+   Action: Codex fills the private file (outside the repo), then reruns.
+
+2. **File filled, save succeeded**:
+
+   ```json
+   {
+     "saveExitCode": 0,
+     "saveStatus": "pass",
+     "agentFileEmpty": false,
+     "statusAfter": {
+       "configured": true,
+       "available": true,
+       "source": "runtime"
+     }
+   }
+   ```
+
+   Action: proceed to real-send acceptance.
+
+3. **Anything else** (`STATUS_API_FAILED`, `httpStatus: 404` or `401`,
+   schema error, etc.):
+
+   Action: **STOP**, do not retry destructively, and report failure mode
+   to the operator. Claude updates docs only after Codex resolves the
+   underlying cause.
+
+## Optional real-send acceptance (Codex)
+
+Only after outcome 2 above:
+
+```bash
+node /tmp/dingtalk-work-notification-admin-agent-id.mjs \
+  --api-base http://127.0.0.1:8900 \
+  --auth-token-file /tmp/admin.jwt \
+  --recipient-user-id-file <private-recipient-file> \
+  --send-test \
+  --output-json /tmp/dingtalk-agent/send.json
+```
+
+Expected redaction-safe shape:
+
+```json
+{
+  "status": "pass",
+  "send": {
+    "delivered": true,
+    "recipientCount": 1,
+    "recipientValuePrinted": false
+  }
+}
+```
+
+If `delivered` is not `true`, **STOP** and triage in the DingTalk admin
+console — not in the repo.
+
+## PR #1430 readiness check (Codex)
+
+```bash
+gh pr view 1430 --json number,headRefOid,baseRefOid,mergeable,mergeStateStatus,statusCheckRollup
+```
+
+Expected:
+
+- `mergeable` is `MERGEABLE` or `UNKNOWN`.
+- `mergeStateStatus` ends in either `CLEAN` or `BLOCKED` (BLOCKED only
+  because of human review policy, not failed checks).
+- All non-skipped checks are `SUCCESS`.
+- The configured strict E2E job may remain `SKIPPED` per workflow policy.
+
+## Stop conditions
+
+The handoff loop ends when **all** of the following are true:
+
+1. Both handoff Markdown files exist under `docs/development/` and have
+   passed the secret-shape scan.
+2. 142 backend health is `200` and frontend root is `200` on image tag
+   `245701aeb5afc57ae5a5932cc4f58ef3aef3a973`.
+3. The admin status helper returns `status: "pass"` with
+   `agentIdValuePrinted=false`.
+4. The admin save helper returns `status: "pass"` with
+   `statusAfter.configured=true` and `statusAfter.available=true`.
+5. At least one real-send DingTalk work-notification acceptance has
+   recorded `delivered=true` and `recipientValuePrinted=false`.
+6. PR #1430 has all required checks green and is merged into `main`.
+
+The loop must **abort** (not auto-retry) on any of:
+
+- New secret-shape match introduced in `docs/`.
+- Helper failure with `STATUS_API_FAILED` and `httpStatus: 404` after a
+  redeploy attempt — implies wrong image was rolled out.
+- Helper failure with `httpStatus: 401` after a fresh JWT — implies a
+  schema or auth regression and needs human triage.
+- 142 disk pressure where Postgres / Redis / uploads risk eviction —
+  Codex stops and asks the operator before any cleanup.
+
+## Roles summary
+
+| Step                                      | Claude | Codex |
+| ----------------------------------------- | :----: | :---: |
+| Edit handoff design / verification docs   |   ✓    |       |
+| Read `.secrets/`, `.env`, token files     |        |   ✓   |
+| Run pnpm install / build / vitest         |        |   ✓   |
+| Trigger GHCR build workflow               |        |   ✓   |
+| Switch 142 backend / web containers       |        |   ✓   |
+| Execute admin Agent ID status helper      |        |   ✓   |
+| Execute admin Agent ID save helper        |        |   ✓   |
+| Execute real-send acceptance              |        |   ✓   |
+| Quote redaction-safe status JSON in docs  |   ✓    |   ✓   |
+| Update PR #1430 description / labels      |        |   ✓   |
+| Merge PR #1430 to `main`                  |        |   ✓   |

--- a/docs/development/dingtalk-claude-codex-handoff-verification-20260508.md
+++ b/docs/development/dingtalk-claude-codex-handoff-verification-20260508.md
@@ -35,7 +35,11 @@ git log -1 --oneline
 Expected:
 
 - Branch is `codex/dingtalk-agent-id-mainline-20260508`.
-- HEAD matches the latest commit referenced in the design doc.
+- HEAD is on PR #1430 branch. The runtime/code verification point
+  referenced in the design doc is
+  `826242b5adb89c87b4e03d502a3905e4b270e43a`, rebased onto base
+  `20fb5270a09d4cc3d2c98e84db3601fc3f4231c5`. Later docs-only commits
+  may advance HEAD without changing the verified runtime code.
 
 ## Doc-only diff check (Claude side)
 
@@ -118,13 +122,36 @@ curl -sS -o /dev/null -w '%{http_code}\n' \
   http://127.0.0.1:8900/api/admin/directory/dingtalk/work-notification
 ```
 
-Expected:
+Expected at the current pre-merge handoff point:
 
-- `metasheet-backend` and `metasheet-web` images both end with the tag
-  `245701aeb5afc57ae5a5932cc4f58ef3aef3a973`.
+- `metasheet-backend` and `metasheet-web` images both end with the
+  current auto-deployed `main` tag
+  `20fb5270a09d4cc3d2c98e84db3601fc3f4231c5`. The earlier verified
+  Agent ID feature tag `245701aeb5afc57ae5a5932cc4f58ef3aef3a973`
+  has been overwritten by the automatic `main` deploy and is no
+  longer expected on 142.
 - Health: `{"ok":true,"status":"ok","success":true,"plugins":13}`.
 - Frontend: `200`.
-- Unauthenticated admin route: `401`.
+- Unauthenticated admin route: `401` if the deployed `main` already
+  ships the Agent ID admin endpoint, or `404` if `main` has not yet
+  been advanced past PR #1430. A `404` here is the expected signal
+  that the Agent ID save / real-send acceptance must wait for the
+  post-merge `main` auto-deploy and must not be forced through a
+  manual feature-tag switch.
+
+After PR #1430 is merged and 142 has auto-deployed the new `main`,
+re-run the same four commands. The two image tags should advance to
+the post-merge `main` commit SHA, health and frontend stay `200`, and
+the admin route returns `401` (now confirming the Agent ID feature is
+live in `main`).
+
+The Agent ID status / save / real-send helpers below are intended to
+run against the post-merge `main` image on 142. Do **not** drive them
+by manually switching `metasheet-backend` / `metasheet-web` back onto
+a pre-merge feature tag — the next automatic `main` deploy will
+overwrite that switch and invalidate any acceptance run captured on
+top of it. Merge PR #1430 first, let 142 auto-deploy the new `main`,
+then proceed.
 
 ## 142 Agent ID status helper (Codex)
 
@@ -238,13 +265,21 @@ console — not in the repo.
 gh pr view 1430 --json number,headRefOid,baseRefOid,mergeable,mergeStateStatus,statusCheckRollup
 ```
 
-Expected:
+Expected at the current handoff point:
 
-- `mergeable` is `MERGEABLE` or `UNKNOWN`.
-- `mergeStateStatus` ends in either `CLEAN` or `BLOCKED` (BLOCKED only
-  because of human review policy, not failed checks).
+- `headRefOid` is at or after the runtime/code verification point
+  `826242b5adb89c87b4e03d502a3905e4b270e43a`.
+- `baseRefOid` is `20fb5270a09d4cc3d2c98e84db3601fc3f4231c5`.
+- `mergeable` is `MERGEABLE` (or transiently `UNKNOWN`).
+- `mergeStateStatus` is `BLOCKED`, blocked **only** by
+  `REVIEW_REQUIRED` from the human review policy. No technical check
+  is failing.
 - All non-skipped checks are `SUCCESS`.
 - The configured strict E2E job may remain `SKIPPED` per workflow policy.
+
+After human review is added and the PR is merged, the post-merge
+`main` is what 142 should auto-deploy and what the Agent ID save /
+real-send acceptance runs against.
 
 ## Stop conditions
 
@@ -252,15 +287,22 @@ The handoff loop ends when **all** of the following are true:
 
 1. Both handoff Markdown files exist under `docs/development/` and have
    passed the secret-shape scan.
-2. 142 backend health is `200` and frontend root is `200` on image tag
-   `245701aeb5afc57ae5a5932cc4f58ef3aef3a973`.
-3. The admin status helper returns `status: "pass"` with
-   `agentIdValuePrinted=false`.
-4. The admin save helper returns `status: "pass"` with
+2. PR #1430 has all required technical checks green, has cleared the
+   `REVIEW_REQUIRED` block via human approval, and is merged into
+   `main`.
+3. 142 has auto-deployed the post-merge `main` image; both
+   `metasheet-backend` and `metasheet-web` advance to that post-merge
+   commit SHA without any manual container switch onto a pre-merge
+   feature tag.
+4. 142 backend health is `200` and frontend root is `200` on the
+   post-merge `main` tag.
+5. The admin status helper (run on the post-merge image) returns
+   `status: "pass"` with `agentIdValuePrinted=false`.
+6. The admin save helper returns `status: "pass"` with
    `statusAfter.configured=true` and `statusAfter.available=true`.
-5. At least one real-send DingTalk work-notification acceptance has
-   recorded `delivered=true` and `recipientValuePrinted=false`.
-6. PR #1430 has all required checks green and is merged into `main`.
+7. At least one real-send DingTalk work-notification acceptance has
+   recorded `delivered=true` and `recipientValuePrinted=false`, on the
+   post-merge `main` image.
 
 The loop must **abort** (not auto-retry) on any of:
 

--- a/docs/development/dingtalk-work-notification-admin-agent-id-helper-design-20260508.md
+++ b/docs/development/dingtalk-work-notification-admin-agent-id-helper-design-20260508.md
@@ -1,0 +1,98 @@
+# DingTalk Work Notification Admin Agent ID Helper Design
+
+Date: 2026-05-08
+
+## Goal
+
+Close the remaining DingTalk work-notification Agent ID setup gap without exposing secrets in chat, Git, or generated reports.
+
+The helper verifies and optionally saves the DingTalk work-notification Agent ID through the admin API:
+
+- Read current runtime status from `GET /api/admin/directory/dingtalk/work-notification`.
+- Validate an Agent ID from a private file through `POST /api/admin/directory/dingtalk/work-notification/test`.
+- Persist a validated Agent ID through `PUT /api/admin/directory/dingtalk/work-notification` when `--save` is supplied.
+- Optionally include a private DingTalk recipient user id for a real work-notification send test.
+- Write JSON and Markdown reports with token, Agent ID, and recipient values redacted.
+
+## New Helper
+
+Script:
+
+```bash
+node scripts/ops/dingtalk-work-notification-admin-agent-id.mjs
+```
+
+Primary modes:
+
+```bash
+# Status only, no Agent ID required.
+node scripts/ops/dingtalk-work-notification-admin-agent-id.mjs \
+  --api-base http://127.0.0.1:8900 \
+  --auth-token-file /tmp/admin.jwt \
+  --status-only \
+  --output-json /tmp/dingtalk-agent/status.json \
+  --output-md /tmp/dingtalk-agent/status.md
+
+# Validate and save Agent ID from a private file.
+node scripts/ops/dingtalk-work-notification-admin-agent-id.mjs \
+  --api-base http://127.0.0.1:8900 \
+  --auth-token-file /tmp/admin.jwt \
+  --agent-id-file /home/mainuser/metasheet2/.secrets/dingtalk-agent-id.txt \
+  --save \
+  --output-json /tmp/dingtalk-agent/save.json \
+  --output-md /tmp/dingtalk-agent/save.md
+
+# Validate with real DingTalk delivery to a private recipient.
+node scripts/ops/dingtalk-work-notification-admin-agent-id.mjs \
+  --api-base http://127.0.0.1:8900 \
+  --auth-token-file /tmp/admin.jwt \
+  --agent-id-file /home/mainuser/metasheet2/.secrets/dingtalk-agent-id.txt \
+  --recipient-user-id-file /home/mainuser/metasheet2/.secrets/dingtalk-test-user-id.txt \
+  --save \
+  --output-json /tmp/dingtalk-agent/real-send.json \
+  --output-md /tmp/dingtalk-agent/real-send.md
+```
+
+## Security Rules
+
+- Admin JWT should be delivered by file only and removed after use.
+- Agent ID should be stored in a server-private file or saved through the admin page, not printed in chat.
+- DingTalk recipient user id is optional and treated as sensitive operational data.
+- Reports only include booleans, status codes, failure codes, configured state, and Agent ID length.
+- The helper redacts bearer tokens, JWT-like strings, DingTalk robot tokens, `SEC...` values, exact Agent ID, and exact recipient id values.
+
+## 142 Operational Path
+
+Private file already expected on 142:
+
+```bash
+/home/mainuser/metasheet2/.secrets/dingtalk-agent-id.txt
+```
+
+Expected closeout sequence:
+
+1. Ensure the main 8081/8900 stack runs an image containing the Agent ID admin API.
+2. Fill the private Agent ID file on 142, or save it from the frontend directory-management page.
+3. Run helper with `--status-only`.
+4. Run helper with `--agent-id-file ... --save`.
+5. If a real recipient file is available, run helper again with `--recipient-user-id-file ...`.
+6. Confirm `available=true`, `configured=true`, `source=database`, and `agentId.valuePrinted=false`.
+
+## TODO
+
+- [x] Add redaction-safe admin helper.
+- [x] Add node-level tests for status, save, empty file, recipient redaction, and API error redaction.
+- [x] Smoke 142 current main stack without printing token or Agent ID.
+- [ ] Coordinate the 142 main image tag so the deployed runtime includes `/api/admin/directory/dingtalk/work-notification`.
+- [ ] Fill the real Agent ID private file or save it from the frontend admin page.
+- [ ] Run real save validation and optional real DingTalk recipient send validation.
+- [ ] Record final production acceptance after current-image conflict is resolved.
+
+## Rollback
+
+If the Agent ID admin API image causes a regression:
+
+1. Restore the previous `.env` from the timestamped backup under `/home/mainuser/metasheet2`.
+2. Run `docker compose --env-file .env -f docker-compose.app.yml up -d backend web`.
+3. Verify `http://127.0.0.1:8900/api/health` and `http://127.0.0.1:8081/`.
+4. Do not remove the private Agent ID file; it is not served publicly and can be reused after redeploy.

--- a/docs/development/dingtalk-work-notification-admin-agent-id-helper-verification-20260508.md
+++ b/docs/development/dingtalk-work-notification-admin-agent-id-helper-verification-20260508.md
@@ -1,0 +1,139 @@
+# DingTalk Work Notification Admin Agent ID Helper Verification
+
+Date: 2026-05-08
+
+## Local Verification
+
+Commands:
+
+```bash
+node --check scripts/ops/dingtalk-work-notification-admin-agent-id.mjs
+node --test scripts/ops/dingtalk-work-notification-admin-agent-id.test.mjs
+git diff --check -- \
+  scripts/ops/dingtalk-work-notification-admin-agent-id.mjs \
+  scripts/ops/dingtalk-work-notification-admin-agent-id.test.mjs
+```
+
+Result:
+
+- `node --check`: pass.
+- `node --test`: pass, 4 tests.
+- `git diff --check`: pass.
+
+Test coverage:
+
+- Status-only summary is redacted.
+- Save workflow calls test and save endpoints and redacts token, Agent ID, and recipient id.
+- Empty Agent ID file blocks before test/save.
+- API error messages are redacted before output.
+
+## 142 Main Stack Verification
+
+Current accessible main stack:
+
+- Web: `http://127.0.0.1:8081/`
+- Backend: `http://127.0.0.1:8900`
+- Public port: `8081`
+
+Health after concurrent deployment settled:
+
+```json
+{"ok":true,"status":"ok","success":true,"plugins":13}
+```
+
+Frontend probe:
+
+```text
+HTTP/1.1 200 OK
+```
+
+## 142 Image Findings
+
+The initial main image was:
+
+```text
+ghcr.io/zensgit/metasheet2-backend:2f42bab1430c4db650c654f6c21e5a3515a4e187
+ghcr.io/zensgit/metasheet2-web:2f42bab1430c4db650c654f6c21e5a3515a4e187
+```
+
+I switched main briefly to the already-built Agent ID API image:
+
+```text
+ghcr.io/zensgit/metasheet2-backend:9129dae6678e623ff1df2e0d0121d5882199e9ef
+ghcr.io/zensgit/metasheet2-web:9129dae6678e623ff1df2e0d0121d5882199e9ef
+```
+
+That image started and passed backend health and frontend HTTP 200 after startup. During verification, an external deployment process changed `.env IMAGE_TAG` several times and finally settled the main stack on:
+
+```text
+ghcr.io/zensgit/metasheet2-backend:bd3986143ad7be205982733a8bc553ac479f5436
+ghcr.io/zensgit/metasheet2-web:bd3986143ad7be205982733a8bc553ac479f5436
+```
+
+I did not continue overwriting this external deployment, to avoid fighting a parallel production rollout.
+
+## 142 Agent ID API Smoke
+
+Admin token generation was performed inside the running main backend container and verified with the app `AuthService`. The token value was written only to a temporary file and removed after the probe.
+
+Current `bd398614...` main image result:
+
+```json
+{
+  "file": "status.json",
+  "status": "blocked",
+  "failures": [
+    {
+      "code": "STATUS_API_FAILED",
+      "httpStatus": 404,
+      "message": "Cannot GET /api/admin/directory/dingtalk/work-notification"
+    }
+  ],
+  "agentIdLength": 0,
+  "agentIdValuePrinted": false
+}
+```
+
+Empty private Agent ID file path result:
+
+```json
+{
+  "file": "empty-agent-save.json",
+  "status": "blocked",
+  "failures": [
+    { "code": "STATUS_API_FAILED", "httpStatus": 404 },
+    { "code": "AGENT_ID_FILE_EMPTY" }
+  ],
+  "agentIdLength": 0,
+  "agentIdValuePrinted": false
+}
+```
+
+Conclusion:
+
+- The helper works locally and on 142 as an operational wrapper.
+- 142 main is healthy, but the currently deployed image does not contain the new Agent ID admin API.
+- Real Agent ID acceptance is blocked by the deployed image tag, not by helper logic.
+- After the image tag is coordinated, the remaining real configuration blocker is filling `/home/mainuser/metasheet2/.secrets/dingtalk-agent-id.txt` or using the frontend admin page to save Agent ID.
+
+## Next Verification Command
+
+After deploying an image that contains the Agent ID API:
+
+```bash
+node /tmp/dingtalk-work-notification-admin-agent-id.mjs \
+  --api-base http://127.0.0.1:8900 \
+  --auth-token-file /tmp/admin.jwt \
+  --agent-id-file /home/mainuser/metasheet2/.secrets/dingtalk-agent-id.txt \
+  --save \
+  --output-json /tmp/dingtalk-agent/save.json \
+  --output-md /tmp/dingtalk-agent/save.md
+```
+
+Expected pass criteria:
+
+- `status=pass`
+- `testResult.accessTokenVerified=true`
+- `saveResult.saved=true`
+- `statusAfter.available=true`
+- `agentId.valuePrinted=false`

--- a/docs/development/dingtalk-work-notification-agent-id-admin-config-design-20260508.md
+++ b/docs/development/dingtalk-work-notification-agent-id-admin-config-design-20260508.md
@@ -1,0 +1,93 @@
+# DingTalk Work Notification Agent ID Admin Config Design (2026-05-08)
+
+## Goal
+
+Let a system administrator configure and validate the DingTalk work-notification Agent ID from the MetaSheet admin UI instead of editing deployment env files by hand.
+
+This closes the remaining Agent ID gap for DingTalk work notifications:
+
+- Group robot webhooks are still configured on notification rules.
+- Enterprise work notifications still require app key, app secret, and Agent ID from the same DingTalk internal app.
+- App key and app secret may come from env or the selected DingTalk directory integration.
+- Agent ID may now come from env or encrypted `directory_integrations.config.workNotificationAgentId`.
+
+## User Flow
+
+1. Open the DingTalk directory management page as a system administrator.
+2. Select the active DingTalk directory integration.
+3. Fill "工作通知 Agent ID".
+4. Optionally fill a DingTalk user id as the test recipient.
+5. Click "测试工作通知".
+6. Click "保存 Agent ID" after validation passes.
+
+If no test recipient is supplied, the test verifies app credential access-token retrieval and local Agent ID shape only. If a test recipient is supplied, it also sends a real DingTalk work notification through the configured app.
+
+## Backend Contract
+
+Admin-only routes under `/api/admin/directory`:
+
+- `GET /dingtalk/work-notification`: returns redaction-safe runtime readiness for the selected or latest DingTalk directory integration.
+- `POST /dingtalk/work-notification/test`: validates a candidate Agent ID and optionally sends a real test work notification.
+- `PUT /dingtalk/work-notification`: validates the candidate Agent ID and persists it encrypted into the selected integration config.
+
+The persisted value is never returned in API responses. Responses expose only configured state, length, source, selected key name, and whether the value was persisted.
+
+## Runtime Resolution
+
+Runtime config resolution is intentionally conservative:
+
+1. If env contains complete `DINGTALK_APP_KEY` or `DINGTALK_CLIENT_ID`, `DINGTALK_APP_SECRET` or `DINGTALK_CLIENT_SECRET`, and `DINGTALK_AGENT_ID` or `DINGTALK_NOTIFY_AGENT_ID`, the runtime uses env only and does not query the database.
+2. If env is incomplete, the runtime falls back to the active/latest DingTalk directory integration config.
+3. Mixed config is allowed, for example env app key/secret plus DB-stored Agent ID.
+4. If any required part is still missing, work notification remains unavailable and surfaces a redaction-safe missing reason.
+
+This preserves existing deployment behavior while allowing 142 to become ready without a backend env edit after the new image is deployed.
+
+## Frontend Boundary
+
+The Agent ID field is shown in the existing DingTalk directory management page:
+
+- The input uses password mode and is never prefilled from stored config.
+- The input is shown only after a DingTalk integration has been created and selected.
+- The page shows only `Agent ID 已保存` or `Agent ID 未保存`.
+- The normal directory integration save path does not accept, resend, overwrite, or clear the Agent ID.
+- Dedicated test and save buttons call the new admin routes.
+
+## Automation Impact
+
+Automation delivery now reads DingTalk work-notification config from runtime resolution instead of env-only config. This affects:
+
+- Person work-notification delivery.
+- Group robot failure-alert fallback that notifies the rule creator by work notification.
+- Admin user DingTalk access status, which now reflects DB-stored Agent ID readiness.
+
+## Release Gate Impact
+
+The DingTalk work-notification release gate remains read-only. It now accepts a pass when:
+
+- The env status helper reports missing Agent ID, but
+- The backend admin API reports work notification runtime is available from stored config.
+
+The summary records `runtimeStatusOverridesEnvStatus=true` in that case. Credential values are still redacted.
+
+## Security Notes
+
+- No raw Agent ID, app secret, webhook, robot signing secret, JWT, or DingTalk access token is written to API responses, logs, docs, or summaries.
+- Stored Agent ID uses the existing encrypted-secret normalization path.
+- Save actions emit an audit event with only redacted metadata.
+- Admin APIs require the existing admin auth middleware.
+
+## 142 Deployment Notes
+
+The frontend configuration page exists only after deploying a backend/web image that includes this change.
+
+After deployment to 142:
+
+1. Open the admin DingTalk directory management page.
+2. Select the DingTalk integration.
+3. Enter the real Agent ID from the DingTalk internal app that owns the configured app key/app secret.
+4. Run the UI test. Use a recipient DingTalk user id if a real work-notification send must be proven.
+5. Save the Agent ID.
+6. Rerun the DingTalk work-notification release gate.
+
+The older private-file env helper remains a fallback for operations teams that prefer env-only deployment, but it is no longer the only path.

--- a/docs/development/dingtalk-work-notification-agent-id-admin-config-verification-20260508.md
+++ b/docs/development/dingtalk-work-notification-agent-id-admin-config-verification-20260508.md
@@ -1,0 +1,108 @@
+# DingTalk Work Notification Agent ID Admin Config Verification (2026-05-08)
+
+## Scope Verified
+
+- Admin UI can test and save DingTalk work-notification Agent ID.
+- Backend stores Agent ID encrypted in `directory_integrations.config.workNotificationAgentId`.
+- Runtime config can use env-only, DB-only, or mixed env plus DB settings.
+- Automation delivery uses runtime config instead of env-only Agent ID.
+- Release gate can pass when backend runtime is ready from stored config even if the env helper still reports missing Agent ID.
+- API responses, audit metadata, and docs do not expose raw credential values.
+
+## Local Validation
+
+Backend DingTalk runtime and admin routes:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-work-notification.test.ts tests/unit/dingtalk-work-notification-settings.test.ts tests/unit/admin-directory-routes.test.ts --watch=false
+```
+
+Result: passed, 3 test files and 35 tests.
+
+Automation regression plus runtime fallback:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-work-notification-settings.test.ts tests/unit/automation-v1.test.ts --watch=false
+```
+
+Result: passed, 2 test files and 148 tests.
+
+Frontend directory management page:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/directoryManagementView.spec.ts --watch=false
+```
+
+Result: passed, 1 test file and 38 tests. The run emitted a non-blocking local WebSocket port-in-use warning, but the test suite completed successfully.
+
+Release gate:
+
+```bash
+node --test scripts/ops/dingtalk-work-notification-release-gate.test.mjs
+```
+
+Result: passed, 5 tests.
+
+Backend build:
+
+```bash
+pnpm --filter @metasheet/core-backend build
+```
+
+Result: passed.
+
+Backend TypeScript check:
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+```
+
+Result: passed.
+
+Frontend build:
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result: passed. Existing Vite chunk and dynamic-import warnings remained warnings only.
+
+Backend package `type-check` script:
+
+```bash
+pnpm --filter @metasheet/core-backend type-check
+```
+
+Result: not run as a gate because this package has no `type-check` script. The replacement gate was `pnpm --filter @metasheet/core-backend exec tsc --noEmit`.
+
+## Behavior Checks Covered By Tests
+
+- Invalid Agent ID format is rejected before persistence.
+- Saved Agent ID is encrypted and not printed in response payloads.
+- Existing env-complete deployments do not query DB for work-notification runtime config.
+- Env app key/app secret can combine with DB-stored Agent ID.
+- Directory integration updates preserve existing stored Agent ID.
+- Generic directory integration create/update payloads cannot write or override Agent ID.
+- The frontend create-integration state hides the Agent ID input and dedicated buttons until an integration is selected.
+- Admin route test/save responses and audit events are redaction-safe.
+- Frontend test/save buttons call the dedicated Agent ID endpoints.
+- Release gate accepts backend runtime readiness from stored config as an override for env-helper missing-Agent-ID status.
+
+## 142 Verification To Run After Deployment
+
+1. Confirm new backend and web images are deployed.
+2. Visit the admin DingTalk directory management page.
+3. Select the active DingTalk integration.
+4. Fill the real Agent ID from the same DingTalk internal app as the configured app key/app secret.
+5. Click "测试工作通知" without a recipient and verify the basic check passes.
+6. Fill a real DingTalk user id, click "测试工作通知", and verify the recipient receives the work notification.
+7. Click "保存 Agent ID" and refresh the page.
+8. Verify the status chip shows `Agent ID 已保存` and the raw value is not shown.
+9. Rerun the release gate and verify status is `pass`.
+10. Trigger a controlled group robot failure and verify the rule creator receives the default work-notification failure alert.
+
+## Remaining Non-Blocking Notes
+
+- A real DingTalk send cannot be fully proven by the no-recipient basic test. Use a recipient DingTalk user id or a controlled automation run for final live acceptance.
+- The older private-file env helper remains available for env-only operations, but the preferred admin flow after this change is UI test plus UI save.
+- This local verification did not deploy to 142 by itself. Deployment still requires publishing the new GHCR backend/web images and updating the 142 containers.

--- a/docs/development/dingtalk-work-notification-agent-id-apply-design-20260508.md
+++ b/docs/development/dingtalk-work-notification-agent-id-apply-design-20260508.md
@@ -4,18 +4,25 @@
 
 Provide a safe final-step helper for the 142 DingTalk work-notification blocker: app key and app secret are already present, but `DINGTALK_AGENT_ID` or `DINGTALK_NOTIFY_AGENT_ID` is missing.
 
-The helper lets operations place the real agent id in a local file and apply it to the runtime env without pasting the value into chat, shell history, Git, or evidence markdown.
+The helper lets operations initialize a private fill-in file, place the real agent id in that file, and apply it to the runtime env without pasting the value into chat, shell history, Git, or evidence markdown.
 
 ## Scope
 
 - Add `scripts/ops/dingtalk-work-notification-agent-id-apply.mjs`.
-- Add focused Node tests for apply, dry-run, conflict protection, forced replacement, and invalid input.
+- Add focused Node tests for file initialization, apply, dry-run, conflict protection, forced replacement, and invalid input.
 - Keep `scripts/ops/dingtalk-work-notification-env-status.mjs` read-only.
 - Do not call DingTalk APIs or validate the credential remotely; the existing status helper remains the readiness gate after restart.
 
 ## Behavior
 
-The helper requires:
+The helper supports two modes.
+
+Initialization mode:
+
+- `--init-agent-id-file <file>`: create an empty `0600` file and a `0700` parent directory.
+- `--force`: overwrite an existing file only when explicitly requested.
+
+Apply mode requires:
 
 - `--env-file <file>`: the env file to update.
 - `--agent-id-file <file>`: a local file containing only the numeric DingTalk agent id.
@@ -47,14 +54,14 @@ The restart path records only command metadata and output lengths, never credent
 
 ## 142 Usage
 
-On 142, create/fill a private file with only the numeric agent id:
+On 142, initialize the private file:
 
 ```bash
-mkdir -p /home/mainuser/metasheet2/.secrets
-chmod 700 /home/mainuser/metasheet2/.secrets
-printf '<agent-id-only>' > /home/mainuser/metasheet2/.secrets/dingtalk-agent-id.txt
-chmod 600 /home/mainuser/metasheet2/.secrets/dingtalk-agent-id.txt
+node /tmp/dingtalk-work-notification-agent-id-apply.mjs \
+  --init-agent-id-file /home/mainuser/metasheet2/.secrets/dingtalk-agent-id.txt
 ```
+
+Then fill that file with only the numeric agent id.
 
 Then apply and restart:
 

--- a/docs/development/dingtalk-work-notification-agent-id-apply-design-20260508.md
+++ b/docs/development/dingtalk-work-notification-agent-id-apply-design-20260508.md
@@ -1,0 +1,79 @@
+# DingTalk Work Notification Agent ID Apply Design (2026-05-08)
+
+## Goal
+
+Provide a safe final-step helper for the 142 DingTalk work-notification blocker: app key and app secret are already present, but `DINGTALK_AGENT_ID` or `DINGTALK_NOTIFY_AGENT_ID` is missing.
+
+The helper lets operations place the real agent id in a local file and apply it to the runtime env without pasting the value into chat, shell history, Git, or evidence markdown.
+
+## Scope
+
+- Add `scripts/ops/dingtalk-work-notification-agent-id-apply.mjs`.
+- Add focused Node tests for apply, dry-run, conflict protection, forced replacement, and invalid input.
+- Keep `scripts/ops/dingtalk-work-notification-env-status.mjs` read-only.
+- Do not call DingTalk APIs or validate the credential remotely; the existing status helper remains the readiness gate after restart.
+
+## Behavior
+
+The helper requires:
+
+- `--env-file <file>`: the env file to update.
+- `--agent-id-file <file>`: a local file containing only the numeric DingTalk agent id.
+
+Default target key is `DINGTALK_AGENT_ID`. If the env file already uses `DINGTALK_NOTIFY_AGENT_ID`, the helper reuses that alias to avoid creating duplicate agent id keys.
+
+Before writing, the helper:
+
+- Validates the agent id is non-empty and numeric.
+- Detects existing agent id values.
+- Blocks replacement of a different existing value unless `--force` is passed.
+- Creates an env-file backup before modification.
+- Writes redaction-safe `summary.json` and `summary.md`.
+
+Optional `--restart-backend` runs:
+
+```bash
+docker compose -f <compose-file> up -d --no-deps --force-recreate <service>
+```
+
+The restart path records only command metadata and output lengths, never credential values.
+
+## Security Boundary
+
+- No `--agent-id <value>` option is provided to avoid shell history leaks.
+- Console output and summaries include only key name, status, and length.
+- The env file and backup are expected to remain on the deployment host and outside Git.
+- Real webhook URLs, robot `SEC` secrets, JWTs, app secrets, and access tokens are not accepted or printed by this helper.
+
+## 142 Usage
+
+On 142, create/fill a private file with only the numeric agent id:
+
+```bash
+mkdir -p /home/mainuser/metasheet2/.secrets
+chmod 700 /home/mainuser/metasheet2/.secrets
+printf '<agent-id-only>' > /home/mainuser/metasheet2/.secrets/dingtalk-agent-id.txt
+chmod 600 /home/mainuser/metasheet2/.secrets/dingtalk-agent-id.txt
+```
+
+Then apply and restart:
+
+```bash
+node /tmp/dingtalk-work-notification-agent-id-apply.mjs \
+  --env-file /home/mainuser/metasheet2/docker/app.env \
+  --agent-id-file /home/mainuser/metasheet2/.secrets/dingtalk-agent-id.txt \
+  --restart-backend \
+  --compose-file /home/mainuser/metasheet2/docker-compose.app.yml \
+  --output-json /tmp/dingtalk-work-notification-agent-id-apply/summary.json \
+  --output-md /tmp/dingtalk-work-notification-agent-id-apply/summary.md
+```
+
+After restart, rerun:
+
+```bash
+node /tmp/dingtalk-work-notification-env-status.mjs \
+  --env-file /home/mainuser/metasheet2/docker/app.env \
+  --env-file /home/mainuser/metasheet2/.env
+```
+
+Expected final state: `Overall Status: ready`.

--- a/docs/development/dingtalk-work-notification-agent-id-apply-verification-20260508.md
+++ b/docs/development/dingtalk-work-notification-agent-id-apply-verification-20260508.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Added a redaction-safe helper for the remaining 142 work-notification configuration step. The helper can apply `DINGTALK_AGENT_ID` from a private file, create a backup, optionally restart backend, and emit evidence without printing the value.
+Added a redaction-safe helper for the remaining 142 work-notification configuration step. The helper can initialize a private agent-id input file, apply `DINGTALK_AGENT_ID` from that file, create a backup, optionally restart backend, and emit evidence without printing the value.
 
 142 was not changed in this verification because the real DingTalk agent id value is still not available in the workspace or chat. A private fill-in file was prepared on 142 for the operator-provided value.
 
@@ -22,10 +22,12 @@ Unit tests:
 node --test scripts/ops/dingtalk-work-notification-agent-id-apply.test.mjs
 ```
 
-Result: passed, 6 tests.
+Result: passed, 8 tests.
 
 Covered cases:
 
+- Private agent id file is initialized as empty `0600`.
+- Existing private agent id file is not overwritten unless `--force` is used.
 - Missing agent id is appended as `DINGTALK_AGENT_ID`.
 - `--dry-run` writes evidence without changing env file.
 - Existing `DINGTALK_NOTIFY_AGENT_ID` alias is reused.
@@ -77,6 +79,20 @@ ssh metasheet-142 'node --check /tmp/dingtalk-work-notification-agent-id-apply.m
 
 Result: passed.
 
+Remote initialization smoke used only `/tmp`:
+
+```bash
+ssh metasheet-142 'node /tmp/dingtalk-work-notification-agent-id-apply.mjs \
+  --init-agent-id-file /tmp/dingtalk-agent-id-apply-smoke/.secrets/dingtalk-agent-id.txt'
+```
+
+Result:
+
+- File exists.
+- File size: `0` bytes.
+- File mode: `600`.
+- Parent directory mode: `700`.
+
 Prepared private input path on 142:
 
 ```bash
@@ -116,6 +132,10 @@ Result:
 After filling the private file on 142:
 
 ```bash
+node /tmp/dingtalk-work-notification-agent-id-apply.mjs \
+  --init-agent-id-file /home/mainuser/metasheet2/.secrets/dingtalk-agent-id.txt
+# Fill /home/mainuser/metasheet2/.secrets/dingtalk-agent-id.txt with only the numeric DingTalk agent id.
+
 node /tmp/dingtalk-work-notification-agent-id-apply.mjs \
   --env-file /home/mainuser/metasheet2/docker/app.env \
   --agent-id-file /home/mainuser/metasheet2/.secrets/dingtalk-agent-id.txt \

--- a/docs/development/dingtalk-work-notification-agent-id-apply-verification-20260508.md
+++ b/docs/development/dingtalk-work-notification-agent-id-apply-verification-20260508.md
@@ -1,0 +1,136 @@
+# DingTalk Work Notification Agent ID Apply Verification (2026-05-08)
+
+## Summary
+
+Added a redaction-safe helper for the remaining 142 work-notification configuration step. The helper can apply `DINGTALK_AGENT_ID` from a private file, create a backup, optionally restart backend, and emit evidence without printing the value.
+
+142 was not changed in this verification because the real DingTalk agent id value is still not available in the workspace or chat. A private fill-in file was prepared on 142 for the operator-provided value.
+
+## Local Verification
+
+Syntax check:
+
+```bash
+node --check scripts/ops/dingtalk-work-notification-agent-id-apply.mjs
+```
+
+Result: passed.
+
+Unit tests:
+
+```bash
+node --test scripts/ops/dingtalk-work-notification-agent-id-apply.test.mjs
+```
+
+Result: passed, 6 tests.
+
+Covered cases:
+
+- Missing agent id is appended as `DINGTALK_AGENT_ID`.
+- `--dry-run` writes evidence without changing env file.
+- Existing `DINGTALK_NOTIFY_AGENT_ID` alias is reused.
+- Different existing value is blocked unless `--force` is used.
+- `--force` creates a backup before replacement.
+- Empty and non-numeric agent id files are rejected.
+- Console output and `summary.json/md` do not contain the agent id value.
+
+Scoped leak scan:
+
+```bash
+rg -n "(oapi\\.dingtalk\\.com/robot/send\\?access_token=|SEC[A-Za-z0-9]{16,}|eyJ[a-zA-Z0-9_-]{20,}\\.|access_token=[A-Za-z0-9]{20,})" \
+  scripts/ops/dingtalk-work-notification-agent-id-apply.mjs \
+  scripts/ops/dingtalk-work-notification-agent-id-apply.test.mjs \
+  docs/development/dingtalk-work-notification-agent-id-apply-design-20260508.md \
+  docs/development/dingtalk-work-notification-agent-id-apply-verification-20260508.md
+```
+
+Result: no matches.
+
+Whitespace check:
+
+```bash
+git diff --check -- \
+  scripts/ops/dingtalk-work-notification-agent-id-apply.mjs \
+  scripts/ops/dingtalk-work-notification-agent-id-apply.test.mjs \
+  docs/development/dingtalk-work-notification-agent-id-apply-design-20260508.md \
+  docs/development/dingtalk-work-notification-agent-id-apply-verification-20260508.md
+```
+
+Result: passed.
+
+## 142 Verification
+
+Current status helper result remains:
+
+- Overall Status: `blocked`
+- App key: present via `DINGTALK_CLIENT_ID`
+- App secret: present via `DINGTALK_CLIENT_SECRET`
+- Agent id: missing
+
+Helper install check:
+
+```bash
+scp scripts/ops/dingtalk-work-notification-agent-id-apply.mjs \
+  metasheet-142:/tmp/dingtalk-work-notification-agent-id-apply.mjs
+ssh metasheet-142 'node --check /tmp/dingtalk-work-notification-agent-id-apply.mjs'
+```
+
+Result: passed.
+
+Prepared private input path on 142:
+
+```bash
+/home/mainuser/metasheet2/.secrets/dingtalk-agent-id.txt
+```
+
+Result:
+
+- File exists.
+- File size: `0` bytes.
+- File mode: `600`.
+- Parent directory mode: `700`.
+
+The file is intentionally empty and mode-restricted. The operator should put only the numeric DingTalk agent id in that file, then run the apply helper.
+
+Remote dry-run smoke used only dummy values under `/tmp` and did not modify production env:
+
+```bash
+ssh metasheet-142 'node /tmp/dingtalk-work-notification-agent-id-apply.mjs \
+  --env-file /tmp/dingtalk-agent-id-apply-smoke/app.env \
+  --agent-id-file /tmp/dingtalk-agent-id-apply-smoke/agent-id.txt \
+  --dry-run \
+  --output-json /tmp/dingtalk-agent-id-apply-smoke/summary.json \
+  --output-md /tmp/dingtalk-agent-id-apply-smoke/summary.md'
+```
+
+Result:
+
+- `status=pass`
+- `action=would_update`
+- `dryRun=true`
+- `targetKey=DINGTALK_AGENT_ID`
+- `agentIdLength=9`
+
+## Final Apply Command
+
+After filling the private file on 142:
+
+```bash
+node /tmp/dingtalk-work-notification-agent-id-apply.mjs \
+  --env-file /home/mainuser/metasheet2/docker/app.env \
+  --agent-id-file /home/mainuser/metasheet2/.secrets/dingtalk-agent-id.txt \
+  --restart-backend \
+  --compose-file /home/mainuser/metasheet2/docker-compose.app.yml \
+  --output-json /tmp/dingtalk-work-notification-agent-id-apply/summary.json \
+  --output-md /tmp/dingtalk-work-notification-agent-id-apply/summary.md
+```
+
+Then confirm readiness:
+
+```bash
+node /tmp/dingtalk-work-notification-env-status.mjs \
+  --env-file /home/mainuser/metasheet2/docker/app.env \
+  --env-file /home/mainuser/metasheet2/.env
+```
+
+Expected state after the real agent id is applied: `Overall Status: ready`, and the admin user DingTalk access API should report `workNotification.available=true`.

--- a/docs/development/dingtalk-work-notification-env-status-design-20260507.md
+++ b/docs/development/dingtalk-work-notification-env-status-design-20260507.md
@@ -1,0 +1,112 @@
+# DingTalk Work Notification Env Status Design
+
+Date: 2026-05-07
+
+## Background
+
+The 142 closeout proved that DingTalk group robot failures are audited and that
+creator failure alerts are attempted by default. The remaining blocker was
+environmental: backend work-notification envs were missing, so the creator alert
+was correctly audited as `failed` instead of being delivered as a DingTalk work
+notification.
+
+Before this change, operators had to SSH into 142 and inspect env state manually.
+That was too fragile for handoff because the admin UI only showed DingTalk OAuth
+login readiness, not work-notification readiness.
+
+## Goals
+
+- Show whether DingTalk work notifications are configured without exposing
+  secret values.
+- Reuse the same env precedence as the backend runtime:
+  - `DINGTALK_APP_KEY` or `DINGTALK_CLIENT_ID`
+  - `DINGTALK_APP_SECRET` or `DINGTALK_CLIENT_SECRET`
+  - `DINGTALK_AGENT_ID` or `DINGTALK_NOTIFY_AGENT_ID`
+- Make the state visible in the existing user management DingTalk panel.
+- Provide a repeatable CLI helper for 142/server-side checks.
+- Update env validation so partial DingTalk work-notification config fails fast.
+
+## Implemented Design
+
+### Backend Runtime Status
+
+`packages/core-backend/src/integrations/dingtalk/client.ts` now exports
+`getDingTalkWorkNotificationRuntimeStatus()`.
+
+The function returns only redaction-safe booleans and selected key names:
+
+- `configured`
+- `available`
+- `unavailableReason`
+- `requirements.appKey.configured`
+- `requirements.appSecret.configured`
+- `requirements.agentId.configured`
+- selected key names such as `DINGTALK_APP_KEY`, never values
+
+`packages/core-backend/src/routes/admin-users.ts` adds that status into the
+existing `/api/admin/users/:userId/dingtalk-access` payload as
+`workNotification`. This avoids adding another frontend request and keeps
+diagnostics near the user DingTalk controls.
+
+### Frontend Admin UI
+
+`apps/web/src/views/UserManagementView.vue` now shows a work-notification badge
+group in the DingTalk panel:
+
+- overall `工作通知已配置` / `工作通知未配置完整`
+- `App Key`
+- `App Secret`
+- `Agent ID`
+- a human-readable missing-env hint
+
+The copy is deliberately operational: it tells admins which env family is
+missing without ever showing credential values.
+
+### CLI Helper
+
+`scripts/ops/dingtalk-work-notification-env-status.mjs` checks env readiness
+from one or more `--env-file` inputs plus `process.env`.
+
+It writes:
+
+- redaction-safe JSON summary
+- redaction-safe Markdown summary
+- `ready` / `blocked` status
+- next actions for rerunning the creator-alert probe with
+  `--expect-person-status success`
+
+It also supports `--write-env-template <file>` to create a safe fill-in template.
+
+### Env Validation
+
+`scripts/validate-env.sh` now treats DingTalk app key/secret/agent id as one
+work-notification group. If any DingTalk app/work-notification env is present,
+it requires all three required families.
+
+`.env.example` now documents `DINGTALK_NOTIFY_AGENT_ID` as the legacy alias for
+`DINGTALK_AGENT_ID`.
+
+## Security Notes
+
+- No endpoint returns app key, app secret, agent id, webhook URL, robot token, SEC
+  secret, or JWT.
+- The helper outputs only presence, selected key name, source path, and value
+  length.
+- The frontend displays only status and missing key families.
+- Filled env templates should remain outside Git.
+
+## Operational Flow
+
+1. Put real DingTalk work-notification values in the backend env on 142.
+2. Restart `metasheet-backend`.
+3. Run:
+
+```bash
+node scripts/ops/dingtalk-work-notification-env-status.mjs \
+  --env-file docker/app.env \
+  --allow-blocked
+```
+
+4. Confirm the summary status is `ready`.
+5. Trigger a fresh controlled group robot failure.
+6. Rerun the failure-alert probe with `--expect-person-status success`.

--- a/docs/development/dingtalk-work-notification-env-status-verification-20260507.md
+++ b/docs/development/dingtalk-work-notification-env-status-verification-20260507.md
@@ -1,0 +1,119 @@
+# DingTalk Work Notification Env Status Verification
+
+Date: 2026-05-07
+
+## Scope
+
+This verification covers the DingTalk work-notification env readiness closeout:
+
+- backend redaction-safe runtime status
+- existing admin DingTalk access payload extension
+- user management UI diagnostics
+- CLI helper and env template
+- env validation gate for missing Agent ID
+
+## Files Changed
+
+- `.env.example`
+- `scripts/validate-env.sh`
+- `scripts/ops/dingtalk-work-notification-env-status.mjs`
+- `scripts/ops/dingtalk-work-notification-env-status.test.mjs`
+- `packages/core-backend/src/integrations/dingtalk/client.ts`
+- `packages/core-backend/src/routes/admin-users.ts`
+- `packages/core-backend/tests/unit/dingtalk-work-notification.test.ts`
+- `apps/web/src/views/UserManagementView.vue`
+- `apps/web/tests/userManagementView.spec.ts`
+- `docs/development/dingtalk-work-notification-env-status-design-20260507.md`
+- `docs/development/dingtalk-work-notification-env-status-verification-20260507.md`
+
+## Commands
+
+```bash
+node --check scripts/ops/dingtalk-work-notification-env-status.mjs
+node --test scripts/ops/dingtalk-work-notification-env-status.test.mjs
+```
+
+Result: passed, 7 tests.
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-work-notification.test.ts --watch=false
+```
+
+Result: passed, 4 tests.
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/userManagementView.spec.ts --watch=false
+```
+
+Result: passed, 47 tests. Existing non-blocking test output remains:
+
+- `WebSocket server error: Port is already in use`
+- `Not implemented: navigation to another Document`
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+```
+
+Result: passed.
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result: passed. Existing Vite warnings remain for chunk size and
+`WorkflowDesigner.vue` dynamic/static import.
+
+```bash
+bash -n scripts/validate-env.sh
+```
+
+Result: passed.
+
+```bash
+DATABASE_URL=postgresql://localhost/metasheet \
+JWT_SECRET=dev \
+DINGTALK_APP_KEY=key \
+DINGTALK_APP_SECRET=credential \
+bash scripts/validate-env.sh development
+```
+
+Result: failed as expected with missing
+`DINGTALK_AGENT_ID DINGTALK_NOTIFY_AGENT_ID`.
+
+```bash
+DATABASE_URL=postgresql://localhost/metasheet \
+JWT_SECRET=dev \
+DINGTALK_APP_KEY=key \
+DINGTALK_APP_SECRET=credential \
+DINGTALK_AGENT_ID=123 \
+bash scripts/validate-env.sh development
+```
+
+Result: passed.
+
+```bash
+git diff --check -- .env.example scripts/validate-env.sh scripts/ops/dingtalk-work-notification-env-status.mjs scripts/ops/dingtalk-work-notification-env-status.test.mjs packages/core-backend/src/integrations/dingtalk/client.ts packages/core-backend/src/routes/admin-users.ts packages/core-backend/tests/unit/dingtalk-work-notification.test.ts apps/web/src/views/UserManagementView.vue apps/web/tests/userManagementView.spec.ts
+```
+
+Result: passed.
+
+```bash
+rg -n "SEC[A-Za-z0-9]{20,}|access_token=[0-9a-fA-F]{20,}|https://oapi\\.dingtalk\\.com/robot/send\\?access_token=|eyJ[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}" .env.example scripts/validate-env.sh scripts/ops/dingtalk-work-notification-env-status.mjs scripts/ops/dingtalk-work-notification-env-status.test.mjs packages/core-backend/src/integrations/dingtalk/client.ts packages/core-backend/src/routes/admin-users.ts packages/core-backend/tests/unit/dingtalk-work-notification.test.ts apps/web/src/views/UserManagementView.vue apps/web/tests/userManagementView.spec.ts
+```
+
+Result: no matches.
+
+## Current Remaining Runtime Step
+
+The helper was copied to 142 and run against `/home/mainuser/metasheet2/docker/app.env`
+plus `/home/mainuser/metasheet2/.env`.
+
+Result: `blocked`.
+
+- App key family: present through `DINGTALK_CLIENT_ID`.
+- App secret family: present through `DINGTALK_CLIENT_SECRET`.
+- Agent id family: missing.
+
+142 therefore still needs `DINGTALK_AGENT_ID` or `DINGTALK_NOTIFY_AGENT_ID` to
+be set outside Git. After setting it and restarting backend, rerun this helper
+on 142 and rerun the group failure-alert probe expecting `success`.

--- a/docs/development/dingtalk-work-notification-release-gate-design-20260508.md
+++ b/docs/development/dingtalk-work-notification-release-gate-design-20260508.md
@@ -1,0 +1,58 @@
+# DingTalk Work Notification Release Gate Design (2026-05-08)
+
+## Goal
+
+Add a read-only final gate for DingTalk work-notification delivery readiness. The gate should answer one question after deployment or Agent ID configuration:
+
+Can this environment now support rule-creator DingTalk work notifications?
+
+## Scope
+
+- Add `scripts/ops/dingtalk-work-notification-release-gate.mjs`.
+- Add Node tests for ready, blocked, redaction, and `--skip-admin-api` paths.
+- Reuse the existing `dingtalk-work-notification-env-status.mjs` helper instead of reimplementing env parsing.
+- Do not call DingTalk APIs and do not send messages.
+
+## Checks
+
+The gate runs four checks:
+
+- Env readiness through `dingtalk-work-notification-env-status.mjs`.
+- Backend health through `GET /api/health`.
+- Admin auth through `GET /api/auth/me`.
+- Admin runtime workNotification status through `GET /api/admin/users/:userId/dingtalk-access`.
+
+The final status is `pass` only when:
+
+- Env status is `ready`.
+- Health endpoint is OK.
+- Admin auth probe succeeds, unless `--skip-admin-api` is used.
+- `workNotification.available=true`, unless `--skip-admin-api` is used.
+
+Otherwise the status is `blocked` with failure codes.
+
+## Security
+
+- Bearer tokens can be read from `--auth-token-file`; the value is never printed.
+- API response bodies are recursively redacted before summaries are written.
+- The gate writes only status, paths, booleans, selected env key names, and failure codes.
+- Webhooks, robot `SEC` secrets, JWTs, app secrets, and access tokens are redacted from JSON and Markdown evidence.
+
+## 142 Usage
+
+Current blocked check:
+
+```bash
+node /tmp/dingtalk-work-notification-release-gate.mjs \
+  --env-file /home/mainuser/metasheet2/docker/app.env \
+  --env-file /home/mainuser/metasheet2/.env \
+  --status-helper /tmp/dingtalk-work-notification-env-status.mjs \
+  --api-base http://127.0.0.1:8900 \
+  --auth-token-file /tmp/metasheet-142-admin-2h-20260508.jwt \
+  --user-id b928b8d9-8881-43d7-a712-842b28870494 \
+  --allow-blocked \
+  --output-json /tmp/dingtalk-work-notification-release-gate/summary.json \
+  --output-md /tmp/dingtalk-work-notification-release-gate/summary.md
+```
+
+After the real Agent ID is applied, rerun the same command without `--allow-blocked`. Expected status: `pass`.

--- a/docs/development/dingtalk-work-notification-release-gate-verification-20260508.md
+++ b/docs/development/dingtalk-work-notification-release-gate-verification-20260508.md
@@ -1,0 +1,110 @@
+# DingTalk Work Notification Release Gate Verification (2026-05-08)
+
+## Summary
+
+Added a redaction-safe release gate for DingTalk work-notification readiness. It composes env readiness, backend health, admin auth, and admin runtime `workNotification` status into one `pass` or `blocked` result.
+
+142 is still blocked because the real Agent ID has not been configured. The gate correctly reports that state without modifying production env.
+
+## Local Verification
+
+Syntax check:
+
+```bash
+node --check scripts/ops/dingtalk-work-notification-release-gate.mjs
+```
+
+Result: passed.
+
+Unit tests:
+
+```bash
+node --test scripts/ops/dingtalk-work-notification-release-gate.test.mjs
+```
+
+Result: passed, 4 tests.
+
+Covered cases:
+
+- Ready env plus healthy backend and available `workNotification` returns `pass`.
+- Missing Agent ID returns `blocked` with `ENV_STATUS_BLOCKED` and `WORK_NOTIFICATION_UNAVAILABLE`.
+- Sensitive API error payloads are redacted from JSON and Markdown.
+- `--skip-admin-api` allows env plus health checks without a token or user id.
+
+Scoped leak scan:
+
+```bash
+rg -n "(oapi\\.dingtalk\\.com/robot/send\\?access_token=|SEC[A-Za-z0-9]{16,}|eyJ[a-zA-Z0-9_-]{20,}\\.|access_token=[A-Za-z0-9]{20,})" \
+  scripts/ops/dingtalk-work-notification-release-gate.mjs \
+  scripts/ops/dingtalk-work-notification-release-gate.test.mjs \
+  docs/development/dingtalk-work-notification-release-gate-design-20260508.md \
+  docs/development/dingtalk-work-notification-release-gate-verification-20260508.md
+```
+
+Result: no real secret matches.
+
+Whitespace check:
+
+```bash
+git diff --check -- \
+  scripts/ops/dingtalk-work-notification-release-gate.mjs \
+  scripts/ops/dingtalk-work-notification-release-gate.test.mjs \
+  docs/development/dingtalk-work-notification-release-gate-design-20260508.md \
+  docs/development/dingtalk-work-notification-release-gate-verification-20260508.md
+```
+
+Result: passed.
+
+## 142 Verification
+
+The release gate helper was copied to `/tmp` and checked:
+
+```bash
+scp scripts/ops/dingtalk-work-notification-release-gate.mjs \
+  metasheet-142:/tmp/dingtalk-work-notification-release-gate.mjs
+ssh metasheet-142 'node --check /tmp/dingtalk-work-notification-release-gate.mjs'
+```
+
+Result: passed.
+
+A short-lived admin token file was generated inside the backend runtime for this
+gate only:
+
+- Token file: `/tmp/metasheet-142-admin-release-gate-2h.jwt`
+- File mode: `600`
+- Token value: not printed and not written to this document.
+
+142 current status:
+
+- Image tag: `8f5bd7f4bbac3a2fe6298b3293f476628e224065`
+- Env status: `blocked`
+- App key: present
+- App secret: present
+- Agent ID: missing
+
+Gate result on 142:
+
+- `status=blocked`
+- `envStatus.overallStatus=blocked`
+- `health.ok=true`
+- `auth.ok=true`
+- `workNotification.available=false`
+- Failure codes: `ENV_STATUS_BLOCKED`, `WORK_NOTIFICATION_UNAVAILABLE`
+
+Redacted command output:
+
+```json
+{
+  "status": "blocked",
+  "envStatus": "blocked",
+  "health": true,
+  "auth": true,
+  "workNotification": false,
+  "failures": [
+    "ENV_STATUS_BLOCKED",
+    "WORK_NOTIFICATION_UNAVAILABLE"
+  ]
+}
+```
+
+This is expected until the real Agent ID is written to `/home/mainuser/metasheet2/.secrets/dingtalk-agent-id.txt` and applied.

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -42,6 +42,7 @@ export type DirectoryMemberGroupSyncMode = 'disabled' | 'sync_scoped_departments
 type DirectoryIntegrationConfig = {
   appKey: string
   appSecret: string
+  workNotificationAgentId: string
   rootDepartmentId: string
   baseUrl?: string
   pageSize?: number
@@ -251,6 +252,7 @@ export type DirectoryIntegrationSummary = {
   config: {
     appKey: string
     appSecretConfigured: boolean
+    workNotificationAgentIdConfigured: boolean
     rootDepartmentId: string
     baseUrl: string | null
     pageSize: number
@@ -317,6 +319,7 @@ type NormalizedDirectoryIntegrationInput = Omit<
   corpId: string
   appKey: string
   appSecret: string
+  workNotificationAgentId: string
   rootDepartmentId: string
   admissionMode: DirectoryAdmissionMode
   admissionDepartmentIds: string[]
@@ -892,6 +895,10 @@ function parseIntegrationConfig(row: Pick<DirectoryIntegrationRow, 'config'>): D
   const appKey = normalizeText(config.appKey)
   const rawAppSecret = normalizeText(config.appSecret)
   const appSecret = rawAppSecret ? decryptStoredSecretValue(rawAppSecret) : ''
+  const rawWorkNotificationAgentId = normalizeText(config.workNotificationAgentId ?? config.agentId)
+  const workNotificationAgentId = rawWorkNotificationAgentId
+    ? decryptStoredSecretValue(rawWorkNotificationAgentId)
+    : ''
   const rootDepartmentId = normalizeText(config.rootDepartmentId) || DEFAULT_ROOT_DEPARTMENT_ID
   const baseUrl = normalizeOptionalText(config.baseUrl) ?? undefined
   const pageSize = normalizePageSize(config.pageSize)
@@ -905,6 +912,7 @@ function parseIntegrationConfig(row: Pick<DirectoryIntegrationRow, 'config'>): D
   return {
     appKey,
     appSecret,
+    workNotificationAgentId,
     rootDepartmentId,
     baseUrl,
     pageSize,
@@ -938,6 +946,7 @@ function summarizeIntegration(row: DirectoryIntegrationRow): DirectoryIntegratio
     config: {
       appKey: config.appKey,
       appSecretConfigured: Boolean(config.appSecret),
+      workNotificationAgentIdConfigured: Boolean(config.workNotificationAgentId),
       rootDepartmentId: config.rootDepartmentId,
       baseUrl: config.baseUrl ?? null,
       pageSize: config.pageSize,
@@ -1357,6 +1366,7 @@ function normalizeIntegrationInput(
   const corpId = normalizeText(input.corpId)
   const appKey = normalizeText(input.appKey)
   const appSecret = normalizeText(input.appSecret) || current?.appSecret || ''
+  const workNotificationAgentId = current?.workNotificationAgentId || ''
   const rootDepartmentId = normalizeText(input.rootDepartmentId) || current?.rootDepartmentId || DEFAULT_ROOT_DEPARTMENT_ID
   const admissionMode = normalizeAdmissionMode(input.admissionMode, current?.admissionMode ?? DEFAULT_ADMISSION_MODE)
   const admissionDepartmentIds = normalizeAdmissionDepartmentIds(input.admissionDepartmentIds, current?.admissionDepartmentIds ?? [])
@@ -1380,6 +1390,7 @@ function normalizeIntegrationInput(
     corpId,
     appKey,
     appSecret,
+    workNotificationAgentId,
     rootDepartmentId,
     baseUrl: normalizeOptionalText(input.baseUrl) ?? current?.baseUrl,
     pageSize: normalizePageSize(input.pageSize ?? current?.pageSize),
@@ -1465,6 +1476,9 @@ export async function createDirectoryIntegration(input: DirectoryIntegrationInpu
       JSON.stringify({
         appKey: normalized.appKey,
         appSecret: normalizeStoredSecretValue(normalized.appSecret),
+        workNotificationAgentId: normalized.workNotificationAgentId
+          ? normalizeStoredSecretValue(normalized.workNotificationAgentId)
+          : null,
         rootDepartmentId: normalized.rootDepartmentId,
         baseUrl: normalized.baseUrl ?? null,
         pageSize: normalized.pageSize,
@@ -1519,6 +1533,9 @@ export async function updateDirectoryIntegration(
       JSON.stringify({
         appKey: normalized.appKey,
         appSecret: normalizeStoredSecretValue(normalized.appSecret),
+        workNotificationAgentId: normalized.workNotificationAgentId
+          ? normalizeStoredSecretValue(normalized.workNotificationAgentId)
+          : null,
         rootDepartmentId: normalized.rootDepartmentId,
         baseUrl: normalized.baseUrl ?? null,
         pageSize: normalized.pageSize,

--- a/packages/core-backend/src/integrations/dingtalk/client.ts
+++ b/packages/core-backend/src/integrations/dingtalk/client.ts
@@ -35,6 +35,30 @@ export interface DingTalkMessageConfig extends DingTalkDirectoryConfig {
   agentId: string
 }
 
+export interface DingTalkWorkNotificationRuntimeStatus {
+  configured: boolean
+  available: boolean
+  unavailableReason: 'missing_app_key' | 'missing_app_secret' | 'missing_agent_id' | null
+  requirements: {
+    appKey: {
+      configured: boolean
+      selectedKey: 'DINGTALK_APP_KEY' | 'DINGTALK_CLIENT_ID' | null
+    }
+    appSecret: {
+      configured: boolean
+      selectedKey: 'DINGTALK_APP_SECRET' | 'DINGTALK_CLIENT_SECRET' | null
+    }
+    agentId: {
+      configured: boolean
+      selectedKey: 'DINGTALK_AGENT_ID' | 'DINGTALK_NOTIFY_AGENT_ID' | null
+    }
+    baseUrl: {
+      configured: boolean
+      selectedKey: 'DINGTALK_BASE_URL' | null
+    }
+  }
+}
+
 export interface DingTalkWorkNotificationInput {
   userIds: string[]
   title: string
@@ -116,6 +140,24 @@ function readStringEnv(...keys: string[]): string {
     }
   }
   return ''
+}
+
+function readEnvStatus<const T extends readonly string[]>(
+  keys: T,
+): { configured: boolean; selectedKey: T[number] | null } {
+  for (const key of keys) {
+    const value = process.env[key]
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return {
+        configured: true,
+        selectedKey: key,
+      }
+    }
+  }
+  return {
+    configured: false,
+    selectedKey: null,
+  }
 }
 
 function normalizeErrorMessage(payload: Record<string, unknown> | null, fallback: string): string {
@@ -243,6 +285,32 @@ export function readDingTalkMessageConfig(): DingTalkMessageConfig {
     appSecret,
     agentId,
     baseUrl,
+  }
+}
+
+export function getDingTalkWorkNotificationRuntimeStatus(): DingTalkWorkNotificationRuntimeStatus {
+  const appKey = readEnvStatus(['DINGTALK_APP_KEY', 'DINGTALK_CLIENT_ID'] as const)
+  const appSecret = readEnvStatus(['DINGTALK_APP_SECRET', 'DINGTALK_CLIENT_SECRET'] as const)
+  const agentId = readEnvStatus(['DINGTALK_AGENT_ID', 'DINGTALK_NOTIFY_AGENT_ID'] as const)
+  const baseUrl = readEnvStatus(['DINGTALK_BASE_URL'] as const)
+  const unavailableReason = !appKey.configured
+    ? 'missing_app_key'
+    : !appSecret.configured
+      ? 'missing_app_secret'
+      : !agentId.configured
+        ? 'missing_agent_id'
+        : null
+
+  return {
+    configured: unavailableReason === null,
+    available: unavailableReason === null,
+    unavailableReason,
+    requirements: {
+      appKey,
+      appSecret,
+      agentId,
+      baseUrl,
+    },
   }
 }
 

--- a/packages/core-backend/src/integrations/dingtalk/client.ts
+++ b/packages/core-backend/src/integrations/dingtalk/client.ts
@@ -42,19 +42,19 @@ export interface DingTalkWorkNotificationRuntimeStatus {
   requirements: {
     appKey: {
       configured: boolean
-      selectedKey: 'DINGTALK_APP_KEY' | 'DINGTALK_CLIENT_ID' | null
+      selectedKey: string | null
     }
     appSecret: {
       configured: boolean
-      selectedKey: 'DINGTALK_APP_SECRET' | 'DINGTALK_CLIENT_SECRET' | null
+      selectedKey: string | null
     }
     agentId: {
       configured: boolean
-      selectedKey: 'DINGTALK_AGENT_ID' | 'DINGTALK_NOTIFY_AGENT_ID' | null
+      selectedKey: string | null
     }
     baseUrl: {
       configured: boolean
-      selectedKey: 'DINGTALK_BASE_URL' | null
+      selectedKey: string | null
     }
   }
 }

--- a/packages/core-backend/src/integrations/dingtalk/work-notification-settings.ts
+++ b/packages/core-backend/src/integrations/dingtalk/work-notification-settings.ts
@@ -1,0 +1,392 @@
+import { query } from '../../db/pg'
+import { decryptStoredSecretValue, normalizeStoredSecretValue } from '../../security/encrypted-secrets'
+import {
+  fetchDingTalkAppAccessToken,
+  sendDingTalkWorkNotification,
+  type DingTalkMessageConfig,
+  type DingTalkWorkNotificationResult,
+  type DingTalkWorkNotificationRuntimeStatus,
+} from './client'
+
+const DEFAULT_PROVIDER = 'dingtalk'
+const AGENT_ID_CONFIG_KEY = 'workNotificationAgentId'
+
+type JsonRecord = Record<string, unknown>
+
+type DirectoryIntegrationConfigRow = {
+  id: string
+  name: string
+  status: string
+  config: JsonRecord | string | null
+  updated_at: string
+}
+
+export type DingTalkWorkNotificationRuntimeStatusWithStore =
+  DingTalkWorkNotificationRuntimeStatus & {
+    source: 'env' | 'directory_integration' | 'mixed' | 'missing'
+    integration: {
+      id: string
+      name: string
+      status: string
+      updatedAt: string
+    } | null
+  }
+
+export type DingTalkWorkNotificationAgentIdTestInput = {
+  integrationId?: string
+  agentId?: string
+  recipientUserId?: string
+  title?: string
+  content?: string
+}
+
+export type DingTalkWorkNotificationAgentIdTestResult = {
+  integration: {
+    id: string
+    name: string
+    status: string
+  }
+  agentId: {
+    configured: boolean
+    length: number
+    valuePrinted: false
+    persisted: boolean
+  }
+  accessTokenVerified: boolean
+  notificationSent: boolean
+  notificationResult?: Pick<DingTalkWorkNotificationResult, 'taskId' | 'requestId'>
+}
+
+export type DingTalkWorkNotificationAgentIdSaveResult =
+  DingTalkWorkNotificationAgentIdTestResult & {
+    saved: boolean
+    status: DingTalkWorkNotificationRuntimeStatusWithStore
+  }
+
+type StoredWorkNotificationConfig = {
+  integrationId: string
+  integrationName: string
+  integrationStatus: string
+  integrationUpdatedAt: string
+  appKey: string
+  appSecret: string
+  agentId: string
+  baseUrl?: string
+}
+
+function parseJsonRecord(value: JsonRecord | string | null | undefined): JsonRecord {
+  if (!value) return {}
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value)
+      return parsed && typeof parsed === 'object' ? parsed as JsonRecord : {}
+    } catch {
+      return {}
+    }
+  }
+  return value
+}
+
+function normalizeText(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : String(value ?? '').trim()
+}
+
+function readStringEnv(...keys: string[]): string {
+  for (const key of keys) {
+    const value = process.env[key]
+    if (typeof value === 'string' && value.trim().length > 0) return value.trim()
+  }
+  return ''
+}
+
+function readEnvStatus<const T extends readonly string[]>(
+  keys: T,
+): { configured: boolean; selectedKey: T[number] | null; value: string } {
+  for (const key of keys) {
+    const value = process.env[key]
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return { configured: true, selectedKey: key, value: value.trim() }
+    }
+  }
+  return { configured: false, selectedKey: null, value: '' }
+}
+
+function decryptStoredText(value: unknown): string {
+  const normalized = normalizeText(value)
+  if (!normalized) return ''
+  return decryptStoredSecretValue(normalized)
+}
+
+export function normalizeDingTalkWorkNotificationAgentId(value: unknown): string {
+  const normalized = normalizeText(value)
+  if (!normalized) return ''
+  if (!/^\d{1,32}$/.test(normalized)) {
+    throw new Error('DingTalk Agent ID must be 1-32 numeric characters')
+  }
+  return normalized
+}
+
+function readAgentIdFromConfig(config: JsonRecord): string {
+  return decryptStoredText(config[AGENT_ID_CONFIG_KEY] ?? config.agentId)
+}
+
+async function loadStoredWorkNotificationConfig(integrationId?: string): Promise<StoredWorkNotificationConfig | null> {
+  const normalizedIntegrationId = normalizeText(integrationId)
+  const result = normalizedIntegrationId
+    ? await query<DirectoryIntegrationConfigRow>(
+      `SELECT id, name, status, config, updated_at
+       FROM directory_integrations
+       WHERE id = $1 AND provider = $2
+       LIMIT 1`,
+      [normalizedIntegrationId, DEFAULT_PROVIDER],
+    )
+    : await query<DirectoryIntegrationConfigRow>(
+      `SELECT id, name, status, config, updated_at
+       FROM directory_integrations
+       WHERE provider = $1
+       ORDER BY CASE WHEN status = 'active' THEN 0 ELSE 1 END, updated_at DESC
+       LIMIT 1`,
+      [DEFAULT_PROVIDER],
+    )
+
+  const row = result.rows[0]
+  if (!row) return null
+
+  const config = parseJsonRecord(row.config)
+  return {
+    integrationId: row.id,
+    integrationName: row.name,
+    integrationStatus: row.status,
+    integrationUpdatedAt: row.updated_at,
+    appKey: normalizeText(config.appKey),
+    appSecret: decryptStoredText(config.appSecret),
+    agentId: readAgentIdFromConfig(config),
+    baseUrl: normalizeText(config.baseUrl) || undefined,
+  }
+}
+
+function buildSelectedKeyStatus(
+  envStatus: { configured: boolean; selectedKey: string | null; value: string },
+  storedConfigured: boolean,
+  storedKey: string,
+): { configured: boolean; selectedKey: string | null } {
+  if (envStatus.configured) {
+    return { configured: true, selectedKey: envStatus.selectedKey }
+  }
+  if (storedConfigured) {
+    return { configured: true, selectedKey: storedKey }
+  }
+  return { configured: false, selectedKey: null }
+}
+
+export async function readDingTalkMessageConfigFromRuntime(integrationId?: string): Promise<DingTalkMessageConfig> {
+  const envAppKey = readStringEnv('DINGTALK_APP_KEY', 'DINGTALK_CLIENT_ID')
+  const envAppSecret = readStringEnv('DINGTALK_APP_SECRET', 'DINGTALK_CLIENT_SECRET')
+  const envAgentId = readStringEnv('DINGTALK_AGENT_ID', 'DINGTALK_NOTIFY_AGENT_ID')
+  const envBaseUrl = readStringEnv('DINGTALK_BASE_URL') || undefined
+
+  if (envAppKey && envAppSecret && envAgentId) {
+    return {
+      appKey: envAppKey,
+      appSecret: envAppSecret,
+      agentId: envAgentId,
+      baseUrl: envBaseUrl,
+    }
+  }
+
+  const stored = await loadStoredWorkNotificationConfig(integrationId)
+  const appKey = envAppKey || stored?.appKey || ''
+  const appSecret = envAppSecret || stored?.appSecret || ''
+  const agentId = envAgentId || stored?.agentId || ''
+  const baseUrl = envBaseUrl || stored?.baseUrl || undefined
+
+  if (!appKey) throw new Error('DINGTALK_APP_KEY or DINGTALK_CLIENT_ID is not configured')
+  if (!appSecret) throw new Error('DINGTALK_APP_SECRET or DINGTALK_CLIENT_SECRET is not configured')
+  if (!agentId) throw new Error('DINGTALK_AGENT_ID, DINGTALK_NOTIFY_AGENT_ID, or directory workNotificationAgentId is not configured')
+
+  return {
+    appKey,
+    appSecret,
+    agentId,
+    baseUrl,
+  }
+}
+
+export async function getDingTalkWorkNotificationRuntimeStatusFromStore(
+  integrationId?: string,
+): Promise<DingTalkWorkNotificationRuntimeStatusWithStore> {
+  const stored = await loadStoredWorkNotificationConfig(integrationId)
+  const appKeyEnv = readEnvStatus(['DINGTALK_APP_KEY', 'DINGTALK_CLIENT_ID'] as const)
+  const appSecretEnv = readEnvStatus(['DINGTALK_APP_SECRET', 'DINGTALK_CLIENT_SECRET'] as const)
+  const agentIdEnv = readEnvStatus(['DINGTALK_AGENT_ID', 'DINGTALK_NOTIFY_AGENT_ID'] as const)
+  const baseUrlEnv = readEnvStatus(['DINGTALK_BASE_URL'] as const)
+
+  const appKey = buildSelectedKeyStatus(
+    appKeyEnv,
+    Boolean(stored?.appKey),
+    'directory_integrations.config.appKey',
+  )
+  const appSecret = buildSelectedKeyStatus(
+    appSecretEnv,
+    Boolean(stored?.appSecret),
+    'directory_integrations.config.appSecret',
+  )
+  const agentId = buildSelectedKeyStatus(
+    agentIdEnv,
+    Boolean(stored?.agentId),
+    'directory_integrations.config.workNotificationAgentId',
+  )
+  const baseUrl = buildSelectedKeyStatus(
+    baseUrlEnv,
+    Boolean(stored?.baseUrl),
+    'directory_integrations.config.baseUrl',
+  )
+  const unavailableReason = !appKey.configured
+    ? 'missing_app_key'
+    : !appSecret.configured
+      ? 'missing_app_secret'
+      : !agentId.configured
+        ? 'missing_agent_id'
+        : null
+  const envConfiguredCount = [appKeyEnv, appSecretEnv, agentIdEnv].filter((item) => item.configured).length
+  const storedConfiguredCount = [
+    Boolean(stored?.appKey),
+    Boolean(stored?.appSecret),
+    Boolean(stored?.agentId),
+  ].filter(Boolean).length
+  const source = envConfiguredCount >= 3
+    ? 'env'
+    : storedConfiguredCount > 0 && envConfiguredCount > 0
+      ? 'mixed'
+      : storedConfiguredCount > 0
+        ? 'directory_integration'
+        : 'missing'
+
+  return {
+    configured: unavailableReason === null,
+    available: unavailableReason === null,
+    unavailableReason,
+    source,
+    integration: stored
+      ? {
+          id: stored.integrationId,
+          name: stored.integrationName,
+          status: stored.integrationStatus,
+          updatedAt: stored.integrationUpdatedAt,
+        }
+      : null,
+    requirements: {
+      appKey,
+      appSecret,
+      agentId,
+      baseUrl,
+    },
+  }
+}
+
+function buildTestTitle(input: DingTalkWorkNotificationAgentIdTestInput): string {
+  const title = normalizeText(input.title)
+  return title || 'MetaSheet DingTalk work notification test'
+}
+
+function buildTestContent(input: DingTalkWorkNotificationAgentIdTestInput): string {
+  const content = normalizeText(input.content)
+  return content || 'This message verifies the configured DingTalk Agent ID.'
+}
+
+export async function testDingTalkWorkNotificationAgentId(
+  input: DingTalkWorkNotificationAgentIdTestInput,
+): Promise<DingTalkWorkNotificationAgentIdTestResult> {
+  const stored = await loadStoredWorkNotificationConfig(input.integrationId)
+  if (!stored) throw new Error('DingTalk directory integration not found')
+
+  const suppliedAgentId = normalizeText(input.agentId)
+  const agentId = suppliedAgentId
+    ? normalizeDingTalkWorkNotificationAgentId(suppliedAgentId)
+    : normalizeDingTalkWorkNotificationAgentId(stored.agentId)
+  const config: DingTalkMessageConfig = {
+    appKey: readStringEnv('DINGTALK_APP_KEY', 'DINGTALK_CLIENT_ID') || stored.appKey,
+    appSecret: readStringEnv('DINGTALK_APP_SECRET', 'DINGTALK_CLIENT_SECRET') || stored.appSecret,
+    agentId,
+    baseUrl: readStringEnv('DINGTALK_BASE_URL') || stored.baseUrl,
+  }
+
+  if (!config.appKey) throw new Error('DingTalk appKey is required')
+  if (!config.appSecret) throw new Error('DingTalk appSecret is required')
+  if (!config.agentId) throw new Error('DingTalk Agent ID is required')
+
+  const accessToken = await fetchDingTalkAppAccessToken(config)
+  const recipientUserId = normalizeText(input.recipientUserId)
+  let notificationResult: DingTalkWorkNotificationResult | undefined
+  if (recipientUserId) {
+    notificationResult = await sendDingTalkWorkNotification(
+      accessToken,
+      {
+        userIds: [recipientUserId],
+        title: buildTestTitle(input),
+        content: buildTestContent(input),
+      },
+      config,
+    )
+  }
+
+  return {
+    integration: {
+      id: stored.integrationId,
+      name: stored.integrationName,
+      status: stored.integrationStatus,
+    },
+    agentId: {
+      configured: true,
+      length: agentId.length,
+      valuePrinted: false,
+      persisted: !suppliedAgentId && Boolean(stored.agentId),
+    },
+    accessTokenVerified: true,
+    notificationSent: Boolean(notificationResult),
+    ...(notificationResult
+      ? {
+          notificationResult: {
+            taskId: notificationResult.taskId,
+            requestId: notificationResult.requestId,
+          },
+        }
+      : {}),
+  }
+}
+
+export async function saveDingTalkWorkNotificationAgentId(
+  input: DingTalkWorkNotificationAgentIdTestInput,
+): Promise<DingTalkWorkNotificationAgentIdSaveResult> {
+  const integrationId = normalizeText(input.integrationId)
+  if (!integrationId) throw new Error('integrationId is required')
+  const agentId = normalizeDingTalkWorkNotificationAgentId(input.agentId)
+  if (!agentId) throw new Error('DingTalk Agent ID is required')
+
+  const testResult = await testDingTalkWorkNotificationAgentId({
+    ...input,
+    integrationId,
+    agentId,
+    recipientUserId: undefined,
+  })
+
+  await query(
+    `UPDATE directory_integrations
+     SET config = jsonb_set(
+           COALESCE(config, '{}'::jsonb),
+           '{workNotificationAgentId}',
+           to_jsonb($2::text),
+           true
+         ),
+         updated_at = NOW()
+     WHERE id = $1 AND provider = $3`,
+    [integrationId, normalizeStoredSecretValue(agentId), DEFAULT_PROVIDER],
+  )
+
+  const status = await getDingTalkWorkNotificationRuntimeStatusFromStore(integrationId)
+  return {
+    ...testResult,
+    saved: true,
+    status,
+  }
+}

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -9,9 +9,9 @@ import {
   DingTalkBusinessError,
   DingTalkRequestError,
   fetchDingTalkAppAccessToken,
-  readDingTalkMessageConfig,
   sendDingTalkWorkNotification,
 } from '../integrations/dingtalk/client'
+import { readDingTalkMessageConfigFromRuntime } from '../integrations/dingtalk/work-notification-settings'
 import type { EventBus } from '../integration/events/event-bus'
 import {
   buildDingTalkMarkdown,
@@ -1108,7 +1108,7 @@ export class AutomationExecutor {
     const batches = chunkItems(resolvedRecipients, DINGTALK_PERSON_BATCH_SIZE)
 
     try {
-      const messageConfig = readDingTalkMessageConfig()
+      const messageConfig = await readDingTalkMessageConfigFromRuntime()
       const accessToken = await fetchDingTalkAppAccessToken(messageConfig, { fetchFn: this.deps.fetchFn })
       let responseCount = 0
 

--- a/packages/core-backend/src/routes/admin-directory.ts
+++ b/packages/core-backend/src/routes/admin-directory.ts
@@ -21,6 +21,11 @@ import {
   unbindDirectoryAccount,
   updateDirectoryIntegration,
 } from '../directory/directory-sync'
+import {
+  getDingTalkWorkNotificationRuntimeStatusFromStore,
+  saveDingTalkWorkNotificationAgentId,
+  testDingTalkWorkNotificationAgentId,
+} from '../integrations/dingtalk/work-notification-settings'
 import { refreshDirectoryIntegrationSchedule } from '../directory/directory-sync-scheduler'
 import { isAdmin as isRbacAdmin } from '../rbac/service'
 import { jsonError, jsonOk, parsePagination } from '../util/response'
@@ -85,6 +90,58 @@ async function ensurePlatformAdmin(req: Request, res: Response): Promise<string 
 
 export function adminDirectoryRouter(): Router {
   const router = Router()
+
+  router.get('/dingtalk/work-notification', async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+
+    try {
+      const integrationId = typeof req.query.integrationId === 'string' ? req.query.integrationId : undefined
+      const status = await getDingTalkWorkNotificationRuntimeStatusFromStore(integrationId)
+      jsonOk(res, { status })
+    } catch (error) {
+      jsonError(res, 500, 'DINGTALK_WORK_NOTIFICATION_STATUS_FAILED', readErrorMessage(error, 'Failed to load DingTalk work notification status'))
+    }
+  })
+
+  router.post('/dingtalk/work-notification/test', async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+
+    try {
+      const result = await testDingTalkWorkNotificationAgentId(req.body as never)
+      jsonOk(res, { result })
+    } catch (error) {
+      jsonError(res, 400, 'DINGTALK_WORK_NOTIFICATION_TEST_FAILED', readErrorMessage(error, 'Failed to test DingTalk work notification Agent ID'))
+    }
+  })
+
+  router.put('/dingtalk/work-notification', async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+
+    try {
+      const result = await saveDingTalkWorkNotificationAgentId(req.body as never)
+      await auditLog({
+        actorId: adminUserId,
+        actorType: 'user',
+        action: 'update',
+        resourceType: 'dingtalk-work-notification-config',
+        resourceId: result.integration.id,
+        meta: {
+          integrationId: result.integration.id,
+          integrationName: result.integration.name,
+          agentIdLength: result.agentId.length,
+          agentIdValuePrinted: false,
+          accessTokenVerified: result.accessTokenVerified,
+          notificationSent: result.notificationSent,
+        },
+      })
+      jsonOk(res, { result })
+    } catch (error) {
+      jsonError(res, 400, 'DINGTALK_WORK_NOTIFICATION_SAVE_FAILED', readErrorMessage(error, 'Failed to save DingTalk work notification Agent ID'))
+    }
+  })
 
   router.get('/integrations', async (req: Request, res: Response) => {
     const adminUserId = await ensurePlatformAdmin(req, res)

--- a/packages/core-backend/src/routes/admin-users.ts
+++ b/packages/core-backend/src/routes/admin-users.ts
@@ -4,6 +4,7 @@ import * as bcrypt from 'bcryptjs'
 import * as crypto from 'crypto'
 import { buildOnboardingPacket, getAccessPreset, listAccessPresets } from '../auth/access-presets'
 import { getDingTalkRuntimeStatus } from '../auth/dingtalk-oauth'
+import { getDingTalkWorkNotificationRuntimeStatus } from '../integrations/dingtalk/client'
 import { recordInvite } from '../auth/invite-ledger'
 import { isInviteTokenExpired, issueInviteToken } from '../auth/invite-tokens'
 import { validatePassword } from '../auth/password-policy'
@@ -471,6 +472,7 @@ async function fetchDingTalkAccessSnapshot(userId: string) {
   const grant = grantResult.rows[0] ?? null
   const identity = identityResult.rows[0] ?? null
   const runtime = getDingTalkRuntimeStatus()
+  const workNotification = getDingTalkWorkNotificationRuntimeStatus()
   const linkedCount = Number(linkedDirectoryResult.rows[0]?.linked_count || 0)
 
   return {
@@ -479,6 +481,7 @@ async function fetchDingTalkAccessSnapshot(userId: string) {
     autoLinkEmail: runtime.autoLinkEmail,
     autoProvision: runtime.autoProvision,
     server: runtime,
+    workNotification,
     directory: {
       linked: linkedCount > 0,
       linkedCount,

--- a/packages/core-backend/src/routes/admin-users.ts
+++ b/packages/core-backend/src/routes/admin-users.ts
@@ -4,7 +4,7 @@ import * as bcrypt from 'bcryptjs'
 import * as crypto from 'crypto'
 import { buildOnboardingPacket, getAccessPreset, listAccessPresets } from '../auth/access-presets'
 import { getDingTalkRuntimeStatus } from '../auth/dingtalk-oauth'
-import { getDingTalkWorkNotificationRuntimeStatus } from '../integrations/dingtalk/client'
+import { getDingTalkWorkNotificationRuntimeStatusFromStore } from '../integrations/dingtalk/work-notification-settings'
 import { recordInvite } from '../auth/invite-ledger'
 import { isInviteTokenExpired, issueInviteToken } from '../auth/invite-tokens'
 import { validatePassword } from '../auth/password-policy'
@@ -472,7 +472,7 @@ async function fetchDingTalkAccessSnapshot(userId: string) {
   const grant = grantResult.rows[0] ?? null
   const identity = identityResult.rows[0] ?? null
   const runtime = getDingTalkRuntimeStatus()
-  const workNotification = getDingTalkWorkNotificationRuntimeStatus()
+  const workNotification = await getDingTalkWorkNotificationRuntimeStatusFromStore()
   const linkedCount = Number(linkedDirectoryResult.rows[0]?.linked_count || 0)
 
   return {

--- a/packages/core-backend/tests/unit/admin-directory-routes.test.ts
+++ b/packages/core-backend/tests/unit/admin-directory-routes.test.ts
@@ -34,6 +34,12 @@ const schedulerMocks = vi.hoisted(() => ({
   refreshDirectoryIntegrationSchedule: vi.fn(),
 }))
 
+const workNotificationMocks = vi.hoisted(() => ({
+  getDingTalkWorkNotificationRuntimeStatusFromStore: vi.fn(),
+  saveDingTalkWorkNotificationAgentId: vi.fn(),
+  testDingTalkWorkNotificationAgentId: vi.fn(),
+}))
+
 vi.mock('../../src/rbac/service', () => ({
   isAdmin: rbacMocks.isRbacAdmin,
 }))
@@ -65,6 +71,12 @@ vi.mock('../../src/directory/directory-sync', () => ({
 
 vi.mock('../../src/directory/directory-sync-scheduler', () => ({
   refreshDirectoryIntegrationSchedule: schedulerMocks.refreshDirectoryIntegrationSchedule,
+}))
+
+vi.mock('../../src/integrations/dingtalk/work-notification-settings', () => ({
+  getDingTalkWorkNotificationRuntimeStatusFromStore: workNotificationMocks.getDingTalkWorkNotificationRuntimeStatusFromStore,
+  saveDingTalkWorkNotificationAgentId: workNotificationMocks.saveDingTalkWorkNotificationAgentId,
+  testDingTalkWorkNotificationAgentId: workNotificationMocks.testDingTalkWorkNotificationAgentId,
 }))
 
 import { adminDirectoryRouter } from '../../src/routes/admin-directory'
@@ -159,6 +171,9 @@ describe('adminDirectoryRouter', () => {
     directoryMocks.unbindDirectoryAccount.mockReset()
     directoryMocks.updateDirectoryIntegration.mockReset()
     schedulerMocks.refreshDirectoryIntegrationSchedule.mockReset()
+    workNotificationMocks.getDingTalkWorkNotificationRuntimeStatusFromStore.mockReset()
+    workNotificationMocks.saveDingTalkWorkNotificationAgentId.mockReset()
+    workNotificationMocks.testDingTalkWorkNotificationAgentId.mockReset()
   })
 
   it('rejects unauthenticated requests', async () => {
@@ -185,6 +200,101 @@ describe('adminDirectoryRouter', () => {
       ok: true,
       data: { items: [{ id: 'dir-1', name: 'DingTalk CN' }] },
     })
+  })
+
+  it('returns DingTalk work notification runtime status without exposing values', async () => {
+    workNotificationMocks.getDingTalkWorkNotificationRuntimeStatusFromStore.mockResolvedValue({
+      configured: false,
+      available: false,
+      unavailableReason: 'missing_agent_id',
+      source: 'directory_integration',
+      integration: { id: 'dir-1', name: 'DingTalk CN', status: 'active', updatedAt: '2026-05-08T00:00:00.000Z' },
+      requirements: {
+        appKey: { configured: true, selectedKey: 'directory_integrations.config.appKey' },
+        appSecret: { configured: true, selectedKey: 'directory_integrations.config.appSecret' },
+        agentId: { configured: false, selectedKey: null },
+        baseUrl: { configured: false, selectedKey: null },
+      },
+    })
+
+    const response = await invokeRoute('get', '/dingtalk/work-notification', {
+      query: { integrationId: 'dir-1' },
+      user: { id: 'admin-1', role: 'admin' },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(workNotificationMocks.getDingTalkWorkNotificationRuntimeStatusFromStore).toHaveBeenCalledWith('dir-1')
+    expect(JSON.stringify(response.body)).not.toContain('secret')
+    expect(response.body).toMatchObject({
+      ok: true,
+      data: {
+        status: {
+          unavailableReason: 'missing_agent_id',
+          integration: { id: 'dir-1' },
+        },
+      },
+    })
+  })
+
+  it('tests DingTalk work notification Agent ID without persisting it', async () => {
+    workNotificationMocks.testDingTalkWorkNotificationAgentId.mockResolvedValue({
+      integration: { id: 'dir-1', name: 'DingTalk CN', status: 'active' },
+      agentId: { configured: true, length: 9, valuePrinted: false, persisted: false },
+      accessTokenVerified: true,
+      notificationSent: false,
+    })
+
+    const payload = { integrationId: 'dir-1', agentId: '123456789' }
+    const response = await invokeRoute('post', '/dingtalk/work-notification/test', {
+      body: payload,
+      user: { id: 'admin-1', role: 'admin' },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(workNotificationMocks.testDingTalkWorkNotificationAgentId).toHaveBeenCalledWith(payload)
+    expect(response.body).toMatchObject({
+      ok: true,
+      data: {
+        result: {
+          agentId: { length: 9, valuePrinted: false },
+          accessTokenVerified: true,
+        },
+      },
+    })
+  })
+
+  it('saves DingTalk work notification Agent ID and writes a redacted audit entry', async () => {
+    workNotificationMocks.saveDingTalkWorkNotificationAgentId.mockResolvedValue({
+      integration: { id: 'dir-1', name: 'DingTalk CN', status: 'active' },
+      agentId: { configured: true, length: 9, valuePrinted: false, persisted: false },
+      accessTokenVerified: true,
+      notificationSent: false,
+      saved: true,
+      status: {
+        configured: true,
+        available: true,
+        unavailableReason: null,
+      },
+    })
+
+    const payload = { integrationId: 'dir-1', agentId: '123456789' }
+    const response = await invokeRoute('put', '/dingtalk/work-notification', {
+      body: payload,
+      user: { id: 'admin-1', role: 'admin' },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(workNotificationMocks.saveDingTalkWorkNotificationAgentId).toHaveBeenCalledWith(payload)
+    expect(auditMocks.auditLog).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'update',
+      resourceType: 'dingtalk-work-notification-config',
+      resourceId: 'dir-1',
+      meta: expect.objectContaining({
+        agentIdLength: 9,
+        agentIdValuePrinted: false,
+      }),
+    }))
+    expect(JSON.stringify(auditMocks.auditLog.mock.calls)).not.toContain('123456789')
   })
 
   it('refreshes scheduler state after creating an integration', async () => {

--- a/packages/core-backend/tests/unit/dingtalk-work-notification-settings.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-work-notification-settings.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { normalizeStoredSecretValue } from '../../src/security/encrypted-secrets'
+
+const dbMocks = vi.hoisted(() => ({
+  query: vi.fn(),
+}))
+
+vi.mock('../../src/db/pg', () => ({
+  query: dbMocks.query,
+}))
+
+import {
+  getDingTalkWorkNotificationRuntimeStatusFromStore,
+  normalizeDingTalkWorkNotificationAgentId,
+  readDingTalkMessageConfigFromRuntime,
+  saveDingTalkWorkNotificationAgentId,
+} from '../../src/integrations/dingtalk/work-notification-settings'
+
+function directoryRow(config: Record<string, unknown> = {}) {
+  return {
+    id: 'dir-1',
+    name: 'DingTalk CN',
+    status: 'active',
+    updated_at: '2026-05-08T00:00:00.000Z',
+    config: {
+      appKey: 'dt-app-key',
+      appSecret: normalizeStoredSecretValue('dt-app-secret'),
+      baseUrl: 'https://oapi.dingtalk.com',
+      ...config,
+    },
+  }
+}
+
+describe('dingtalk work notification settings', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs()
+    vi.unstubAllGlobals()
+    dbMocks.query.mockReset()
+  })
+
+  it('normalizes numeric DingTalk Agent IDs only', () => {
+    expect(normalizeDingTalkWorkNotificationAgentId(' 123456789 ')).toBe('123456789')
+    expect(() => normalizeDingTalkWorkNotificationAgentId('agent-123')).toThrow('DingTalk Agent ID must be 1-32 numeric characters')
+  })
+
+  it('builds runtime status from directory integration Agent ID without leaking values', async () => {
+    dbMocks.query.mockResolvedValueOnce({
+      rows: [directoryRow({ workNotificationAgentId: normalizeStoredSecretValue('123456789') })],
+    })
+
+    const status = await getDingTalkWorkNotificationRuntimeStatusFromStore('dir-1')
+
+    expect(status.available).toBe(true)
+    expect(status.source).toBe('directory_integration')
+    expect(status.requirements.agentId.selectedKey).toBe('directory_integrations.config.workNotificationAgentId')
+    expect(JSON.stringify(status)).not.toContain('123456789')
+    expect(JSON.stringify(status)).not.toContain('dt-app-secret')
+  })
+
+  it('lets environment app credentials use the directory Agent ID fallback', async () => {
+    vi.stubEnv('DINGTALK_CLIENT_ID', 'env-app-key')
+    vi.stubEnv('DINGTALK_CLIENT_SECRET', 'env-app-secret')
+    dbMocks.query.mockResolvedValueOnce({
+      rows: [directoryRow({ workNotificationAgentId: '123456789' })],
+    })
+
+    const config = await readDingTalkMessageConfigFromRuntime('dir-1')
+
+    expect(config).toEqual({
+      appKey: 'env-app-key',
+      appSecret: 'env-app-secret',
+      agentId: '123456789',
+      baseUrl: 'https://oapi.dingtalk.com',
+    })
+  })
+
+  it('does not query directory integrations when env work notification config is complete', async () => {
+    vi.stubEnv('DINGTALK_CLIENT_ID', 'env-app-key')
+    vi.stubEnv('DINGTALK_CLIENT_SECRET', 'env-app-secret')
+    vi.stubEnv('DINGTALK_AGENT_ID', '123456789')
+
+    const config = await readDingTalkMessageConfigFromRuntime()
+
+    expect(config).toEqual({
+      appKey: 'env-app-key',
+      appSecret: 'env-app-secret',
+      agentId: '123456789',
+      baseUrl: undefined,
+    })
+    expect(dbMocks.query).not.toHaveBeenCalled()
+  })
+
+  it('validates app access token before saving Agent ID and stores it encrypted', async () => {
+    const fetchMock = vi.fn(async () => new Response(
+      JSON.stringify({ errcode: 0, access_token: 'app-access-token' }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    ))
+    vi.stubGlobal('fetch', fetchMock)
+    dbMocks.query
+      .mockResolvedValueOnce({ rows: [directoryRow()] })
+      .mockResolvedValueOnce({ rowCount: 1, rows: [] })
+      .mockResolvedValueOnce({
+        rows: [directoryRow({ workNotificationAgentId: normalizeStoredSecretValue('123456789') })],
+      })
+
+    const result = await saveDingTalkWorkNotificationAgentId({
+      integrationId: 'dir-1',
+      agentId: '123456789',
+    })
+
+    expect(result.saved).toBe(true)
+    expect(result.accessTokenVerified).toBe(true)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const updateArgs = dbMocks.query.mock.calls[1]
+    expect(String(updateArgs[0])).toContain('workNotificationAgentId')
+    expect(updateArgs[1]).toEqual([
+      'dir-1',
+      expect.stringMatching(/^enc:/),
+      'dingtalk',
+    ])
+    expect(String(updateArgs[1][1])).not.toContain('123456789')
+  })
+})

--- a/packages/core-backend/tests/unit/dingtalk-work-notification.test.ts
+++ b/packages/core-backend/tests/unit/dingtalk-work-notification.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
+  getDingTalkWorkNotificationRuntimeStatus,
   readDingTalkMessageConfig,
   sendDingTalkWorkNotification,
 } from '../../src/integrations/dingtalk/client'
@@ -16,6 +17,53 @@ describe('dingtalk work notification client', () => {
     vi.stubEnv('DINGTALK_APP_SECRET', 'dt-app-secret')
 
     expect(() => readDingTalkMessageConfig()).toThrow('DINGTALK_AGENT_ID or DINGTALK_NOTIFY_AGENT_ID is not configured')
+  })
+
+  it('reports redaction-safe work notification runtime status', () => {
+    vi.stubEnv('DINGTALK_APP_KEY', 'dt-app-key')
+    vi.stubEnv('DINGTALK_APP_SECRET', 'dt-app-secret')
+
+    expect(getDingTalkWorkNotificationRuntimeStatus()).toEqual({
+      configured: false,
+      available: false,
+      unavailableReason: 'missing_agent_id',
+      requirements: {
+        appKey: {
+          configured: true,
+          selectedKey: 'DINGTALK_APP_KEY',
+        },
+        appSecret: {
+          configured: true,
+          selectedKey: 'DINGTALK_APP_SECRET',
+        },
+        agentId: {
+          configured: false,
+          selectedKey: null,
+        },
+        baseUrl: {
+          configured: false,
+          selectedKey: null,
+        },
+      },
+    })
+  })
+
+  it('reports legacy alias readiness for work notification runtime status', () => {
+    vi.stubEnv('DINGTALK_CLIENT_ID', 'dt-client-id')
+    vi.stubEnv('DINGTALK_CLIENT_SECRET', 'dt-client-secret')
+    vi.stubEnv('DINGTALK_NOTIFY_AGENT_ID', '987654321')
+    vi.stubEnv('DINGTALK_BASE_URL', 'https://oapi.dingtalk.com')
+
+    const status = getDingTalkWorkNotificationRuntimeStatus()
+
+    expect(status.configured).toBe(true)
+    expect(status.available).toBe(true)
+    expect(status.unavailableReason).toBeNull()
+    expect(status.requirements.appKey.selectedKey).toBe('DINGTALK_CLIENT_ID')
+    expect(status.requirements.appSecret.selectedKey).toBe('DINGTALK_CLIENT_SECRET')
+    expect(status.requirements.agentId.selectedKey).toBe('DINGTALK_NOTIFY_AGENT_ID')
+    expect(status.requirements.baseUrl.selectedKey).toBe('DINGTALK_BASE_URL')
+    expect(JSON.stringify(status)).not.toContain('dt-client-secret')
   })
 
   it('sends work notifications to DingTalk user ids', async () => {

--- a/packages/core-backend/tests/unit/directory-sync-work-notification-agent-id.test.ts
+++ b/packages/core-backend/tests/unit/directory-sync-work-notification-agent-id.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createDirectoryIntegration, updateDirectoryIntegration } from '../../src/directory/directory-sync'
+import { decryptStoredSecretValue, normalizeStoredSecretValue } from '../../src/security/encrypted-secrets'
+
+const { queryMock } = vi.hoisted(() => ({
+  queryMock: vi.fn(),
+}))
+
+vi.mock('../../src/db/pg', () => ({
+  query: queryMock,
+  transaction: vi.fn(),
+}))
+
+function integrationRow(config: Record<string, unknown> = {}) {
+  return {
+    id: 'dir-1',
+    org_id: 'default',
+    provider: 'dingtalk',
+    name: 'DingTalk CN',
+    status: 'active',
+    corp_id: 'dingcorp',
+    config: {
+      appKey: 'ding-app-key',
+      appSecret: normalizeStoredSecretValue('unit-secret'),
+      rootDepartmentId: '1',
+      pageSize: 50,
+      admissionMode: 'manual_only',
+      admissionDepartmentIds: [],
+      excludeDepartmentIds: [],
+      memberGroupSyncMode: 'disabled',
+      memberGroupDepartmentIds: [],
+      memberGroupDefaultRoleIds: [],
+      memberGroupDefaultNamespaces: [],
+      ...config,
+    },
+    sync_enabled: true,
+    schedule_cron: null,
+    default_deprovision_policy: 'mark_inactive',
+    last_sync_at: null,
+    last_success_at: null,
+    last_error: null,
+    created_at: '2026-05-08T00:00:00.000Z',
+    updated_at: '2026-05-08T00:00:00.000Z',
+  }
+}
+
+describe('directory sync work-notification Agent ID storage boundary', () => {
+  beforeEach(() => {
+    queryMock.mockReset()
+  })
+
+  it('does not persist Agent ID from the generic create integration path', async () => {
+    let persistedConfig: Record<string, unknown> | null = null
+    queryMock.mockImplementation(async (sql: string, params: unknown[]) => {
+      if (sql.includes('INSERT INTO directory_integrations')) {
+        persistedConfig = JSON.parse(String(params[5]))
+        return { rows: [integrationRow(persistedConfig)] }
+      }
+      return { rows: [] }
+    })
+
+    await createDirectoryIntegration({
+      name: 'DingTalk CN',
+      corpId: 'dingcorp',
+      appKey: 'ding-app-key',
+      appSecret: 'unit-secret',
+      workNotificationAgentId: 'not-a-valid-agent-id',
+    } as never)
+
+    expect(persistedConfig?.workNotificationAgentId).toBeNull()
+    expect(JSON.stringify(persistedConfig)).not.toContain('not-a-valid-agent-id')
+  })
+
+  it('preserves existing Agent ID but ignores generic update payload overrides', async () => {
+    let persistedConfig: Record<string, unknown> | null = null
+    const currentAgentId = normalizeStoredSecretValue('123456789')
+    queryMock.mockImplementation(async (sql: string, params: unknown[]) => {
+      if (sql.includes('FROM directory_integrations') && sql.includes('WHERE id = $1')) {
+        return { rows: [integrationRow({ workNotificationAgentId: currentAgentId })] }
+      }
+      if (sql.includes('UPDATE directory_integrations')) {
+        persistedConfig = JSON.parse(String(params[4]))
+        return { rows: [integrationRow(persistedConfig)] }
+      }
+      return { rows: [] }
+    })
+
+    await updateDirectoryIntegration('dir-1', {
+      name: 'DingTalk CN',
+      corpId: 'dingcorp',
+      appKey: 'ding-app-key',
+      appSecret: '',
+      workNotificationAgentId: 'not-a-valid-agent-id',
+    } as never)
+
+    expect(decryptStoredSecretValue(String(persistedConfig?.workNotificationAgentId))).toBe('123456789')
+    expect(JSON.stringify(persistedConfig)).not.toContain('not-a-valid-agent-id')
+  })
+})

--- a/scripts/ops/dingtalk-work-notification-admin-agent-id.mjs
+++ b/scripts/ops/dingtalk-work-notification-admin-agent-id.mjs
@@ -1,0 +1,555 @@
+#!/usr/bin/env node
+
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+const TOOL_NAME = 'dingtalk-work-notification-admin-agent-id';
+const DEFAULT_API_BASE = 'http://127.0.0.1:8900';
+const DEFAULT_TIMEOUT_MS = 15000;
+
+function printUsage() {
+  console.log(`Usage:
+  node scripts/ops/dingtalk-work-notification-admin-agent-id.mjs --auth-token-file /tmp/admin.jwt --status-only
+  node scripts/ops/dingtalk-work-notification-admin-agent-id.mjs --auth-token-file /tmp/admin.jwt --agent-id-file /secure/agent-id.txt --save
+
+Options:
+  --api-base <url>                 API base URL. Default: ${DEFAULT_API_BASE}
+  --auth-token-file <path>         File containing an admin bearer token.
+  --auth-token <token>             Admin bearer token. Prefer --auth-token-file.
+  --integration-id <id>            Directory integration id. Falls back to current DingTalk status when possible.
+  --agent-id-file <path>           File containing DingTalk work-notification Agent ID.
+  --recipient-user-id-file <path>  Optional file containing DingTalk recipient user id for real send test.
+  --recipient-user-id <id>         Optional DingTalk recipient user id. Prefer --recipient-user-id-file.
+  --status-only                    Only read redacted work-notification status.
+  --save                           Save Agent ID after successful API validation.
+  --output-json <path>             Write redacted JSON summary.
+  --output-md <path>               Write redacted Markdown summary.
+  --timeout-ms <ms>                HTTP timeout. Default: ${DEFAULT_TIMEOUT_MS}
+  --help                           Show this help.`);
+}
+
+function parseArgs(argv) {
+  const opts = {
+    apiBase: DEFAULT_API_BASE,
+    timeoutMs: DEFAULT_TIMEOUT_MS,
+    statusOnly: false,
+    save: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const readValue = () => {
+      const value = argv[i + 1];
+      if (!value || value.startsWith('--')) {
+        throw new Error(`Missing value for ${arg}`);
+      }
+      i += 1;
+      return value;
+    };
+
+    switch (arg) {
+      case '--api-base':
+        opts.apiBase = readValue();
+        break;
+      case '--auth-token-file':
+        opts.authTokenFile = readValue();
+        break;
+      case '--auth-token':
+        opts.authToken = readValue();
+        break;
+      case '--integration-id':
+        opts.integrationId = readValue();
+        break;
+      case '--agent-id-file':
+        opts.agentIdFile = readValue();
+        break;
+      case '--recipient-user-id-file':
+        opts.recipientUserIdFile = readValue();
+        break;
+      case '--recipient-user-id':
+        opts.recipientUserId = readValue();
+        break;
+      case '--status-only':
+        opts.statusOnly = true;
+        break;
+      case '--save':
+        opts.save = true;
+        break;
+      case '--output-json':
+        opts.outputJson = readValue();
+        break;
+      case '--output-md':
+        opts.outputMd = readValue();
+        break;
+      case '--timeout-ms':
+        opts.timeoutMs = Number(readValue());
+        break;
+      case '--help':
+      case '-h':
+        opts.help = true;
+        break;
+      default:
+        throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  if (!Number.isFinite(opts.timeoutMs) || opts.timeoutMs <= 0) {
+    throw new Error('--timeout-ms must be a positive number');
+  }
+
+  return opts;
+}
+
+function readTrimmedFile(filePath, errorCode) {
+  try {
+    return readFileSync(filePath, 'utf8').trim();
+  } catch (error) {
+    const wrapped = new Error(`Unable to read ${filePath}: ${error.message}`);
+    wrapped.code = errorCode;
+    throw wrapped;
+  }
+}
+
+function normalizeAgentId(value) {
+  const trimmed = String(value ?? '').trim();
+  if (!trimmed) {
+    const error = new Error('Agent ID file is empty');
+    error.code = 'AGENT_ID_FILE_EMPTY';
+    throw error;
+  }
+
+  if (!/^\d{4,32}$/.test(trimmed)) {
+    const error = new Error('Agent ID must be a 4-32 digit numeric string');
+    error.code = 'AGENT_ID_INVALID';
+    throw error;
+  }
+
+  return trimmed;
+}
+
+function normalizeOptionalUserId(value) {
+  const trimmed = String(value ?? '').trim();
+  if (!trimmed) {
+    return '';
+  }
+
+  if (trimmed.length > 128 || /[\s]/.test(trimmed)) {
+    const error = new Error('Recipient user id must be non-empty, <=128 chars, and contain no whitespace');
+    error.code = 'RECIPIENT_USER_ID_INVALID';
+    throw error;
+  }
+
+  return trimmed;
+}
+
+function readAuthToken(opts) {
+  const token = opts.authTokenFile
+    ? readTrimmedFile(opts.authTokenFile, 'AUTH_TOKEN_FILE_READ_FAILED')
+    : String(opts.authToken ?? '').trim();
+
+  if (!token) {
+    const error = new Error('Admin auth token is required');
+    error.code = 'AUTH_TOKEN_MISSING';
+    throw error;
+  }
+
+  return token;
+}
+
+function readAgentId(opts) {
+  if (!opts.agentIdFile) {
+    const error = new Error('--agent-id-file is required unless --status-only is set');
+    error.code = 'AGENT_ID_FILE_REQUIRED';
+    throw error;
+  }
+
+  return normalizeAgentId(readTrimmedFile(opts.agentIdFile, 'AGENT_ID_FILE_READ_FAILED'));
+}
+
+function readRecipientUserId(opts) {
+  const value = opts.recipientUserIdFile
+    ? readTrimmedFile(opts.recipientUserIdFile, 'RECIPIENT_USER_ID_FILE_READ_FAILED')
+    : opts.recipientUserId;
+
+  return normalizeOptionalUserId(value);
+}
+
+function createRedactor(values = []) {
+  const sensitiveValues = values.filter(Boolean).sort((a, b) => b.length - a.length);
+  return (input) => {
+    let output = String(input ?? '');
+    for (const value of sensitiveValues) {
+      output = output.split(value).join('[REDACTED]');
+    }
+
+    return output
+      .replace(/(Bearer\s+)[A-Za-z0-9._~+/=-]+/gi, '$1[REDACTED]')
+      .replace(/(access_token=)[A-Za-z0-9._~+/=-]+/gi, '$1[REDACTED]')
+      .replace(/\bSEC[a-zA-Z0-9]{20,}\b/g, 'SEC[REDACTED]')
+      .replace(/\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g, '[JWT_REDACTED]');
+  };
+}
+
+function redactedPath(filePath) {
+  if (!filePath) {
+    return '';
+  }
+
+  const base = path.basename(filePath);
+  return base ? `.../${base}` : '[path-redacted]';
+}
+
+function addFailure(summary, code, message, detail = {}) {
+  summary.failures.push({
+    code,
+    message,
+    ...detail,
+  });
+}
+
+function normalizeStatusPayload(payload) {
+  const body = payload?.data?.status
+    ?? payload?.status
+    ?? payload?.data?.workNotification
+    ?? payload?.workNotification
+    ?? payload?.data
+    ?? payload
+    ?? {};
+
+  const integration = body.integration ?? body.directoryIntegration ?? {};
+  const requirements = body.requirements ?? {};
+
+  return {
+    configured: Boolean(body.configured),
+    available: Boolean(body.available),
+    source: body.source ? String(body.source) : '',
+    unavailableReason: body.unavailableReason ? String(body.unavailableReason) : '',
+    integration: {
+      id: integration.id ? String(integration.id) : '',
+      name: integration.name ? String(integration.name) : '',
+      status: integration.status ? String(integration.status) : '',
+    },
+    requirements: {
+      clientId: Boolean(requirements.clientId),
+      clientSecret: Boolean(requirements.clientSecret),
+      agentId: Boolean(requirements.agentId),
+      tokenCache: requirements.tokenCache ? String(requirements.tokenCache) : '',
+    },
+  };
+}
+
+function normalizeTestPayload(payload) {
+  const body = payload?.data?.result ?? payload?.result ?? payload?.data ?? payload ?? {};
+  const result = body.result ?? body;
+  const notificationResult = result.notificationResult ?? result.deliveryResult ?? {};
+
+  return {
+    ok: payload?.ok === undefined ? true : Boolean(payload.ok),
+    integrationId: result.integrationId ? String(result.integrationId) : '',
+    accessTokenVerified: Boolean(result.accessTokenVerified),
+    notificationSent: Boolean(result.notificationSent),
+    saved: Boolean(result.saved ?? result.persisted),
+    agentId: {
+      configured: Boolean(result.agentId?.configured ?? result.agentIdConfigured),
+      length: Number(result.agentId?.length ?? result.agentIdLength ?? 0),
+      valuePrinted: false,
+    },
+    notification: {
+      errcode: Number.isFinite(Number(notificationResult.errcode)) ? Number(notificationResult.errcode) : null,
+      errmsg: notificationResult.errmsg ? String(notificationResult.errmsg) : '',
+      requestId: notificationResult.requestId ? String(notificationResult.requestId) : '',
+      sent: Boolean(notificationResult.sent ?? result.notificationSent),
+    },
+  };
+}
+
+function getApiMessage(payload, redactor) {
+  const error = payload?.error ?? payload?.data?.error ?? {};
+  const message = error.message ?? payload?.message ?? payload?.errorMessage ?? '';
+  return redactor(message || 'API request failed');
+}
+
+async function fetchJson({ apiBase, token, method, endpoint, timeoutMs, body, redactor }) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(new URL(endpoint, apiBase), {
+      method,
+      signal: controller.signal,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/json',
+        ...(body ? { 'Content-Type': 'application/json' } : {}),
+      },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+
+    const text = await response.text();
+    let payload = {};
+    if (text) {
+      try {
+        payload = JSON.parse(text);
+      } catch {
+        payload = { message: redactor(text.slice(0, 500)) };
+      }
+    }
+
+    return {
+      ok: response.ok && payload?.ok !== false,
+      status: response.status,
+      payload,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      status: 0,
+      payload: { message: redactor(error.message) },
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function ensureParent(filePath) {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+}
+
+function renderMarkdown(summary) {
+  const status = summary.status === 'pass' ? 'PASS' : 'BLOCKED';
+  const lines = [
+    `# DingTalk Work Notification Agent ID Admin Helper Verification`,
+    '',
+    `- Result: ${status}`,
+    `- Generated At: ${summary.generatedAt}`,
+    `- API Base: ${summary.apiBase}`,
+    `- Auth Token: ${summary.authToken.present ? 'present' : 'missing'} (${summary.authToken.source})`,
+    `- Agent ID File: ${summary.agentId.file || 'not provided'}`,
+    `- Agent ID Configured In Input: ${summary.agentId.configured ? 'yes' : 'no'}`,
+    `- Recipient Provided: ${summary.recipient.present ? 'yes' : 'no'}`,
+    `- Save Requested: ${summary.saveRequested ? 'yes' : 'no'}`,
+    '',
+    `## Status Before`,
+    '',
+    `- Configured: ${summary.statusBefore?.configured ? 'yes' : 'no'}`,
+    `- Available: ${summary.statusBefore?.available ? 'yes' : 'no'}`,
+    `- Source: ${summary.statusBefore?.source || 'unknown'}`,
+    `- Unavailable Reason: ${summary.statusBefore?.unavailableReason || 'none'}`,
+    `- Integration ID Present: ${summary.statusBefore?.integration?.id ? 'yes' : 'no'}`,
+    '',
+    `## Test Result`,
+    '',
+    `- Access Token Verified: ${summary.testResult?.accessTokenVerified ? 'yes' : 'no'}`,
+    `- DingTalk Notification Sent: ${summary.testResult?.notificationSent ? 'yes' : 'no'}`,
+    `- Agent ID Length: ${summary.testResult?.agentId?.length ?? 0}`,
+    `- Agent ID Value Printed: no`,
+    '',
+    `## Save Result`,
+    '',
+    `- Saved: ${summary.saveResult?.saved ? 'yes' : 'no'}`,
+    `- Status After Available: ${summary.statusAfter?.available ? 'yes' : 'no'}`,
+    '',
+    `## Failures`,
+    '',
+  ];
+
+  if (summary.failures.length === 0) {
+    lines.push('- none');
+  } else {
+    for (const failure of summary.failures) {
+      lines.push(`- ${failure.code}: ${failure.message}`);
+    }
+  }
+
+  lines.push('', 'Sensitive values are intentionally not printed.');
+  return `${lines.join('\n')}\n`;
+}
+
+function writeOutputs(summary, opts) {
+  const json = `${JSON.stringify(summary, null, 2)}\n`;
+  const markdown = renderMarkdown(summary);
+
+  if (opts.outputJson) {
+    ensureParent(opts.outputJson);
+    writeFileSync(opts.outputJson, json, 'utf8');
+  }
+
+  if (opts.outputMd) {
+    ensureParent(opts.outputMd);
+    writeFileSync(opts.outputMd, markdown, 'utf8');
+  }
+
+  if (!opts.outputJson && !opts.outputMd) {
+    console.log(json);
+  }
+}
+
+function buildSummary(opts) {
+  return {
+    tool: TOOL_NAME,
+    generatedAt: new Date().toISOString(),
+    status: 'blocked',
+    apiBase: opts.apiBase,
+    statusOnly: Boolean(opts.statusOnly),
+    saveRequested: Boolean(opts.save),
+    integrationIdProvided: Boolean(opts.integrationId),
+    authToken: {
+      present: Boolean(opts.authToken || opts.authTokenFile),
+      source: opts.authTokenFile ? 'file' : opts.authToken ? 'argument' : 'missing',
+      file: redactedPath(opts.authTokenFile),
+    },
+    agentId: {
+      configured: false,
+      length: 0,
+      valuePrinted: false,
+      file: redactedPath(opts.agentIdFile),
+    },
+    recipient: {
+      present: Boolean(opts.recipientUserId || opts.recipientUserIdFile),
+      valuePrinted: false,
+      file: redactedPath(opts.recipientUserIdFile),
+    },
+    statusBefore: null,
+    testResult: null,
+    saveResult: null,
+    statusAfter: null,
+    failures: [],
+  };
+}
+
+async function runWorkflow(opts) {
+  const summary = buildSummary(opts);
+  const token = readAuthToken(opts);
+  let agentId = '';
+  let recipientUserId = '';
+  const staticRedactor = createRedactor([token]);
+
+  const statusResponse = await fetchJson({
+    apiBase: opts.apiBase,
+    token,
+    method: 'GET',
+    endpoint: '/api/admin/directory/dingtalk/work-notification',
+    timeoutMs: opts.timeoutMs,
+    redactor: staticRedactor,
+  });
+
+  if (statusResponse.ok) {
+    summary.statusBefore = normalizeStatusPayload(statusResponse.payload);
+  } else {
+    addFailure(summary, 'STATUS_API_FAILED', getApiMessage(statusResponse.payload, staticRedactor), {
+      httpStatus: statusResponse.status,
+    });
+  }
+
+  if (opts.statusOnly) {
+    summary.status = summary.failures.length === 0 ? 'pass' : 'blocked';
+    return summary;
+  }
+
+  try {
+    agentId = readAgentId(opts);
+    summary.agentId.configured = true;
+    summary.agentId.length = agentId.length;
+  } catch (error) {
+    addFailure(summary, error.code ?? 'AGENT_ID_READ_FAILED', error.message);
+    return summary;
+  }
+
+  try {
+    recipientUserId = readRecipientUserId(opts);
+    summary.recipient.present = Boolean(recipientUserId);
+  } catch (error) {
+    addFailure(summary, error.code ?? 'RECIPIENT_USER_ID_READ_FAILED', error.message);
+    return summary;
+  }
+
+  const redactor = createRedactor([token, agentId, recipientUserId]);
+  const integrationId = opts.integrationId || summary.statusBefore?.integration?.id || '';
+  const testBody = {
+    ...(integrationId ? { integrationId } : {}),
+    agentId,
+    ...(recipientUserId ? { recipientUserId } : {}),
+  };
+
+  const testResponse = await fetchJson({
+    apiBase: opts.apiBase,
+    token,
+    method: 'POST',
+    endpoint: '/api/admin/directory/dingtalk/work-notification/test',
+    timeoutMs: opts.timeoutMs,
+    body: testBody,
+    redactor,
+  });
+
+  if (testResponse.ok) {
+    summary.testResult = normalizeTestPayload(testResponse.payload);
+  } else {
+    addFailure(summary, 'TEST_API_FAILED', getApiMessage(testResponse.payload, redactor), {
+      httpStatus: testResponse.status,
+    });
+  }
+
+  if (opts.save) {
+    if (!integrationId) {
+      addFailure(summary, 'INTEGRATION_ID_MISSING', 'Cannot save because no DingTalk directory integration id was found');
+    } else if (testResponse.ok) {
+      const saveResponse = await fetchJson({
+        apiBase: opts.apiBase,
+        token,
+        method: 'PUT',
+        endpoint: '/api/admin/directory/dingtalk/work-notification',
+        timeoutMs: opts.timeoutMs,
+        body: { integrationId, agentId },
+        redactor,
+      });
+
+      if (saveResponse.ok) {
+        summary.saveResult = {
+          saved: true,
+          integrationIdPresent: true,
+          agentIdValuePrinted: false,
+        };
+      } else {
+        addFailure(summary, 'SAVE_API_FAILED', getApiMessage(saveResponse.payload, redactor), {
+          httpStatus: saveResponse.status,
+        });
+      }
+    }
+
+    const afterResponse = await fetchJson({
+      apiBase: opts.apiBase,
+      token,
+      method: 'GET',
+      endpoint: '/api/admin/directory/dingtalk/work-notification',
+      timeoutMs: opts.timeoutMs,
+      redactor,
+    });
+
+    if (afterResponse.ok) {
+      summary.statusAfter = normalizeStatusPayload(afterResponse.payload);
+    }
+  }
+
+  summary.status = summary.failures.length === 0 ? 'pass' : 'blocked';
+  return summary;
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  if (opts.help) {
+    printUsage();
+    return 0;
+  }
+
+  const summary = await runWorkflow(opts);
+  writeOutputs(summary, opts);
+  return summary.status === 'pass' ? 0 : 1;
+}
+
+main()
+  .then((exitCode) => {
+    process.exitCode = exitCode;
+  })
+  .catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });

--- a/scripts/ops/dingtalk-work-notification-admin-agent-id.test.mjs
+++ b/scripts/ops/dingtalk-work-notification-admin-agent-id.test.mjs
@@ -1,0 +1,276 @@
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { createServer } from 'node:http';
+import { spawn } from 'node:child_process';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const scriptPath = new URL('./dingtalk-work-notification-admin-agent-id.mjs', import.meta.url).pathname;
+
+function makeTmpDir() {
+  return mkdtempSync(path.join(tmpdir(), 'dingtalk-agent-helper-'));
+}
+
+function startMockServer(handler) {
+  const requests = [];
+  const server = createServer((req, res) => {
+    const chunks = [];
+    req.on('data', (chunk) => chunks.push(chunk));
+    req.on('end', () => {
+      const text = Buffer.concat(chunks).toString('utf8');
+      const body = text ? JSON.parse(text) : {};
+      const request = {
+        method: req.method,
+        url: req.url,
+        body,
+        authorization: req.headers.authorization,
+      };
+      requests.push(request);
+      const response = handler(request, requests);
+      res.writeHead(response.status ?? 200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(response.body ?? { ok: true }));
+    });
+  });
+
+  return new Promise((resolve, reject) => {
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      resolve({
+        apiBase: `http://127.0.0.1:${address.port}`,
+        requests,
+        close: () => new Promise((done) => server.close(done)),
+      });
+    });
+  });
+}
+
+function runHelper(args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [scriptPath, ...args], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+    child.on('error', reject);
+    child.on('close', (code, signal) => {
+      resolve({ status: code, signal, stdout, stderr });
+    });
+  });
+}
+
+test('status-only emits redacted status summary', async () => {
+  const server = await startMockServer((request) => {
+    assert.equal(request.method, 'GET');
+    return {
+      body: {
+        ok: true,
+        data: {
+          status: {
+            configured: false,
+            available: false,
+            source: 'mixed',
+            unavailableReason: 'missing_agent_id',
+            integration: { id: 'dir-1', name: 'DingTalk', status: 'active' },
+            requirements: { clientId: true, clientSecret: true, agentId: false },
+          },
+        },
+      },
+    };
+  });
+
+  try {
+    const result = await runHelper([
+      '--api-base',
+      server.apiBase,
+      '--auth-token',
+      'unit-token',
+      '--status-only',
+    ]);
+
+    assert.equal(result.status, 0);
+    assert.doesNotMatch(result.stdout, /unit-token/);
+    const summary = JSON.parse(result.stdout);
+    assert.equal(summary.status, 'pass');
+    assert.equal(summary.statusBefore.unavailableReason, 'missing_agent_id');
+  } finally {
+    await server.close();
+  }
+});
+
+test('save workflow validates, saves, and never writes raw token, agent id, or recipient', async () => {
+  const tmp = makeTmpDir();
+  const tokenFile = path.join(tmp, 'admin.jwt');
+  const agentFile = path.join(tmp, 'agent-id.txt');
+  const recipientFile = path.join(tmp, 'recipient.txt');
+  const jsonFile = path.join(tmp, 'summary.json');
+  const mdFile = path.join(tmp, 'summary.md');
+  writeFileSync(tokenFile, 'unit-token\n', 'utf8');
+  writeFileSync(agentFile, '123456789\n', 'utf8');
+  writeFileSync(recipientFile, 'recipient-1\n', 'utf8');
+
+  const server = await startMockServer((request, requests) => {
+    if (request.method === 'GET') {
+      return {
+        body: {
+          ok: true,
+          data: {
+            status: {
+              configured: requests.length > 2,
+              available: requests.length > 2,
+              source: requests.length > 2 ? 'database' : 'mixed',
+              integration: { id: 'dir-1', name: 'DingTalk', status: 'active' },
+              requirements: { clientId: true, clientSecret: true, agentId: requests.length > 2 },
+            },
+          },
+        },
+      };
+    }
+
+    if (request.method === 'POST') {
+      assert.equal(request.body.agentId, '123456789');
+      assert.equal(request.body.recipientUserId, 'recipient-1');
+      return {
+        body: {
+          ok: true,
+          data: {
+            result: {
+              integrationId: request.body.integrationId,
+              accessTokenVerified: true,
+              notificationSent: true,
+              agentId: { configured: true, length: 9 },
+              notificationResult: { sent: true, errcode: 0, errmsg: 'ok' },
+            },
+          },
+        },
+      };
+    }
+
+    assert.equal(request.method, 'PUT');
+    assert.equal(request.body.agentId, '123456789');
+    return { body: { ok: true } };
+  });
+
+  try {
+    const result = await runHelper([
+      '--api-base',
+      server.apiBase,
+      '--auth-token-file',
+      tokenFile,
+      '--agent-id-file',
+      agentFile,
+      '--recipient-user-id-file',
+      recipientFile,
+      '--save',
+      '--output-json',
+      jsonFile,
+      '--output-md',
+      mdFile,
+    ]);
+
+    assert.equal(result.status, 0);
+    const combined = `${result.stdout}\n${result.stderr}\n${readFileSync(jsonFile, 'utf8')}\n${readFileSync(mdFile, 'utf8')}`;
+    assert.doesNotMatch(combined, /unit-token/);
+    assert.doesNotMatch(combined, /123456789/);
+    assert.doesNotMatch(combined, /recipient-1/);
+    const summary = JSON.parse(readFileSync(jsonFile, 'utf8'));
+    assert.equal(summary.status, 'pass');
+    assert.equal(summary.agentId.length, 9);
+    assert.equal(summary.testResult.notificationSent, true);
+    assert.equal(summary.saveResult.saved, true);
+  } finally {
+    await server.close();
+  }
+});
+
+test('empty agent id file blocks before test and keeps output redacted', async () => {
+  const tmp = makeTmpDir();
+  const agentFile = path.join(tmp, 'agent-id.txt');
+  writeFileSync(agentFile, '\n', 'utf8');
+
+  const server = await startMockServer(() => ({
+    body: {
+      ok: true,
+      data: {
+        status: {
+          configured: false,
+          available: false,
+          integration: { id: 'dir-1', name: 'DingTalk', status: 'active' },
+        },
+      },
+    },
+  }));
+
+  try {
+    const result = await runHelper([
+      '--api-base',
+      server.apiBase,
+      '--auth-token',
+      'unit-token',
+      '--agent-id-file',
+      agentFile,
+      '--save',
+    ]);
+
+    assert.equal(result.status, 1);
+    const summary = JSON.parse(result.stdout);
+    assert.equal(summary.status, 'blocked');
+    assert.equal(summary.failures[0].code, 'AGENT_ID_FILE_EMPTY');
+    assert.equal(server.requests.length, 1);
+    assert.doesNotMatch(result.stdout, /unit-token/);
+  } finally {
+    await server.close();
+  }
+});
+
+test('api errors are redacted', async () => {
+  const tmp = makeTmpDir();
+  const agentFile = path.join(tmp, 'agent-id.txt');
+  writeFileSync(agentFile, '123456789\n', 'utf8');
+
+  const server = await startMockServer((request) => {
+    if (request.method === 'GET') {
+      return {
+        body: {
+          ok: true,
+          data: { status: { integration: { id: 'dir-1' } } },
+        },
+      };
+    }
+
+    return {
+      status: 400,
+      body: {
+        ok: false,
+        error: { message: 'bad agent 123456789 for bearer unit-token' },
+      },
+    };
+  });
+
+  try {
+    const result = await runHelper([
+      '--api-base',
+      server.apiBase,
+      '--auth-token',
+      'unit-token',
+      '--agent-id-file',
+      agentFile,
+    ]);
+
+    assert.equal(result.status, 1);
+    assert.doesNotMatch(result.stdout, /123456789/);
+    assert.doesNotMatch(result.stdout, /unit-token/);
+    assert.match(result.stdout, /\[REDACTED\]/);
+  } finally {
+    await server.close();
+  }
+});

--- a/scripts/ops/dingtalk-work-notification-agent-id-apply.mjs
+++ b/scripts/ops/dingtalk-work-notification-agent-id-apply.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { chmodSync, copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { spawnSync } from 'node:child_process'
 import path from 'node:path'
 
@@ -16,6 +16,7 @@ printing the value. Intended for the final 142 blocker after app key/secret are
 already configured.
 
 Options:
+  --init-agent-id-file <file>    Create an empty 0600 agent id file and exit
   --env-file <file>              Env file to update, required
   --agent-id-file <file>         File containing only the numeric DingTalk agent id, required
   --key <env-key>                Target key, default DINGTALK_AGENT_ID unless an accepted alias already exists
@@ -45,6 +46,7 @@ function parseArgs(argv) {
   const opts = {
     envFile: '',
     agentIdFile: '',
+    initAgentIdFile: '',
     key: 'DINGTALK_AGENT_ID',
     keyExplicit: false,
     backupDir: '',
@@ -62,6 +64,10 @@ function parseArgs(argv) {
     switch (arg) {
       case '--env-file':
         opts.envFile = path.resolve(process.cwd(), readRequiredValue(argv, index, arg))
+        index += 1
+        break
+      case '--init-agent-id-file':
+        opts.initAgentIdFile = path.resolve(process.cwd(), readRequiredValue(argv, index, arg))
         index += 1
         break
       case '--agent-id-file':
@@ -111,6 +117,8 @@ function parseArgs(argv) {
     }
   }
 
+  if (opts.initAgentIdFile) return opts
+
   if (!opts.envFile) throw new Error('--env-file is required')
   if (!opts.agentIdFile) throw new Error('--agent-id-file is required')
   if (!AGENT_ID_KEYS.includes(opts.key)) {
@@ -119,6 +127,16 @@ function parseArgs(argv) {
   if (!opts.backupDir) opts.backupDir = path.dirname(opts.envFile)
 
   return opts
+}
+
+function initAgentIdFile(file, force = false) {
+  if (existsSync(file) && !force) {
+    throw new Error(`agent id file already exists: ${file}; pass --force to overwrite`)
+  }
+  mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 })
+  chmodSync(path.dirname(file), 0o700)
+  writeFileSync(file, '', { encoding: 'utf8', mode: 0o600 })
+  chmodSync(file, 0o600)
 }
 
 function relativePath(file) {
@@ -361,6 +379,12 @@ function writeSummary(opts, summary) {
 
 function main() {
   const opts = parseArgs(process.argv.slice(2))
+  if (opts.initAgentIdFile) {
+    initAgentIdFile(opts.initAgentIdFile, opts.force)
+    console.log(`DingTalk work-notification agent id file initialized: ${relativePath(opts.initAgentIdFile)}; mode=600; bytes=0`)
+    return
+  }
+
   const agentId = readAgentId(opts.agentIdFile)
   const applyResult = applyEnvUpdate(opts, agentId)
   if (opts.restartBackend && !opts.dryRun && applyResult.action !== 'blocked' && applyResult.action !== 'unchanged') {

--- a/scripts/ops/dingtalk-work-notification-agent-id-apply.mjs
+++ b/scripts/ops/dingtalk-work-notification-agent-id-apply.mjs
@@ -1,0 +1,393 @@
+#!/usr/bin/env node
+
+import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { spawnSync } from 'node:child_process'
+import path from 'node:path'
+
+const SCHEMA_VERSION = 1
+const DEFAULT_OUTPUT_DIR = 'output/dingtalk-work-notification-agent-id-apply'
+const AGENT_ID_KEYS = ['DINGTALK_AGENT_ID', 'DINGTALK_NOTIFY_AGENT_ID']
+
+function printHelp() {
+  console.log(`Usage: node scripts/ops/dingtalk-work-notification-agent-id-apply.mjs [options]
+
+Safely applies the DingTalk work-notification agent id to an env file without
+printing the value. Intended for the final 142 blocker after app key/secret are
+already configured.
+
+Options:
+  --env-file <file>              Env file to update, required
+  --agent-id-file <file>         File containing only the numeric DingTalk agent id, required
+  --key <env-key>                Target key, default DINGTALK_AGENT_ID unless an accepted alias already exists
+  --backup-dir <dir>             Backup directory, default env-file directory
+  --output-json <file>           Output JSON path, default ${DEFAULT_OUTPUT_DIR}/summary.json
+  --output-md <file>             Output Markdown path, default ${DEFAULT_OUTPUT_DIR}/summary.md
+  --dry-run                      Validate and write evidence without changing the env file
+  --force                        Allow replacing an existing different agent id
+  --restart-backend              Recreate backend after updating the env file
+  --compose-file <file>          Compose file for --restart-backend, default docker-compose.app.yml
+  --service <name>               Compose service for --restart-backend, default backend
+  --help                         Show this help
+
+Security:
+  The agent id value is read from a file, never from a CLI argument, to avoid
+  shell history leaks. Summary files include only key names, length, and status.
+`)
+}
+
+function readRequiredValue(argv, index, flag) {
+  const value = argv[index + 1]
+  if (!value || value.startsWith('--')) throw new Error(`${flag} requires a value`)
+  return value
+}
+
+function parseArgs(argv) {
+  const opts = {
+    envFile: '',
+    agentIdFile: '',
+    key: 'DINGTALK_AGENT_ID',
+    keyExplicit: false,
+    backupDir: '',
+    outputJson: path.resolve(process.cwd(), DEFAULT_OUTPUT_DIR, 'summary.json'),
+    outputMd: path.resolve(process.cwd(), DEFAULT_OUTPUT_DIR, 'summary.md'),
+    dryRun: false,
+    force: false,
+    restartBackend: false,
+    composeFile: path.resolve(process.cwd(), 'docker-compose.app.yml'),
+    service: 'backend',
+  }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    switch (arg) {
+      case '--env-file':
+        opts.envFile = path.resolve(process.cwd(), readRequiredValue(argv, index, arg))
+        index += 1
+        break
+      case '--agent-id-file':
+        opts.agentIdFile = path.resolve(process.cwd(), readRequiredValue(argv, index, arg))
+        index += 1
+        break
+      case '--key':
+        opts.key = readRequiredValue(argv, index, arg)
+        opts.keyExplicit = true
+        index += 1
+        break
+      case '--backup-dir':
+        opts.backupDir = path.resolve(process.cwd(), readRequiredValue(argv, index, arg))
+        index += 1
+        break
+      case '--output-json':
+        opts.outputJson = path.resolve(process.cwd(), readRequiredValue(argv, index, arg))
+        index += 1
+        break
+      case '--output-md':
+        opts.outputMd = path.resolve(process.cwd(), readRequiredValue(argv, index, arg))
+        index += 1
+        break
+      case '--dry-run':
+        opts.dryRun = true
+        break
+      case '--force':
+        opts.force = true
+        break
+      case '--restart-backend':
+        opts.restartBackend = true
+        break
+      case '--compose-file':
+        opts.composeFile = path.resolve(process.cwd(), readRequiredValue(argv, index, arg))
+        index += 1
+        break
+      case '--service':
+        opts.service = readRequiredValue(argv, index, arg)
+        index += 1
+        break
+      case '--help':
+        printHelp()
+        process.exit(0)
+        break
+      default:
+        throw new Error(`Unknown argument: ${arg}`)
+    }
+  }
+
+  if (!opts.envFile) throw new Error('--env-file is required')
+  if (!opts.agentIdFile) throw new Error('--agent-id-file is required')
+  if (!AGENT_ID_KEYS.includes(opts.key)) {
+    throw new Error(`--key must be one of: ${AGENT_ID_KEYS.join(', ')}`)
+  }
+  if (!opts.backupDir) opts.backupDir = path.dirname(opts.envFile)
+
+  return opts
+}
+
+function relativePath(file) {
+  if (!file) return ''
+  return path.relative(process.cwd(), file).replaceAll('\\', '/')
+}
+
+function parseEnvLine(line) {
+  const trimmed = line.trim()
+  if (!trimmed || trimmed.startsWith('#')) return null
+  const index = trimmed.indexOf('=')
+  if (index <= 0) return null
+  return {
+    key: trimmed.slice(0, index).trim(),
+    value: trimmed.slice(index + 1).trim(),
+  }
+}
+
+function unquoteEnvValue(value) {
+  const trimmed = String(value ?? '').trim()
+  if (trimmed.length >= 2 && trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    return trimmed.slice(1, -1).replaceAll('\\"', '"').replaceAll('\\\\', '\\')
+  }
+  if (trimmed.length >= 2 && trimmed.startsWith("'") && trimmed.endsWith("'")) {
+    return trimmed.slice(1, -1)
+  }
+  return trimmed
+}
+
+function readAgentId(file) {
+  if (!existsSync(file)) throw new Error(`agent id file not found: ${file}`)
+  const raw = readFileSync(file, 'utf8')
+  const value = raw.trim()
+  if (!value) throw new Error('agent id file is empty')
+  if (!/^\d{1,32}$/.test(value)) {
+    throw new Error('agent id must be numeric and at most 32 digits')
+  }
+  return value
+}
+
+function findExistingAgentEntries(lines) {
+  const entries = []
+  lines.forEach((line, index) => {
+    const parsed = parseEnvLine(line)
+    if (!parsed || !AGENT_ID_KEYS.includes(parsed.key)) return
+    const value = unquoteEnvValue(parsed.value)
+    if (!value) return
+    entries.push({
+      key: parsed.key,
+      index,
+      length: value.length,
+      same: null,
+      value,
+    })
+  })
+  return entries
+}
+
+function makeBackupPath(opts) {
+  const stamp = new Date().toISOString().replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z')
+  const base = path.basename(opts.envFile)
+  return path.join(opts.backupDir, `${base}.backup-before-dingtalk-agent-id-${stamp}`)
+}
+
+function renderEnvLine(key, value) {
+  return `${key}=${value}`
+}
+
+function applyEnvUpdate(opts, agentId) {
+  if (!existsSync(opts.envFile)) throw new Error(`env file not found: ${opts.envFile}`)
+  const original = readFileSync(opts.envFile, 'utf8')
+  const hadTrailingNewline = original.endsWith('\n')
+  const lines = original.split(/\r?\n/)
+  if (hadTrailingNewline) lines.pop()
+
+  const existing = findExistingAgentEntries(lines).map((entry) => ({
+    ...entry,
+    same: entry.value === agentId,
+    value: undefined,
+  }))
+  const existingTarget = opts.keyExplicit
+    ? existing.find((entry) => entry.key === opts.key)
+    : existing[0]
+  const targetKey = existingTarget?.key ?? opts.key
+  const conflicting = existing.filter((entry) => entry.same === false)
+
+  if (conflicting.length > 0 && !opts.force) {
+    return {
+      action: 'blocked',
+      targetKey,
+      existingKeys: existing.map((entry) => ({ key: entry.key, length: entry.length, same: entry.same })),
+      checks: [
+        { id: 'agent-id-valid', status: 'pass', details: { length: agentId.length } },
+        {
+          id: 'existing-agent-id-conflict',
+          status: 'fail',
+          details: { keys: conflicting.map((entry) => entry.key) },
+          remediation: 'Pass --force only after confirming the existing agent id should be replaced.',
+        },
+      ],
+      backupFile: '',
+      restart: { requested: opts.restartBackend, attempted: false },
+    }
+  }
+
+  const targetIndex = lines.findIndex((line) => parseEnvLine(line)?.key === targetKey)
+  const nextLines = [...lines]
+  if (targetIndex >= 0) {
+    nextLines[targetIndex] = renderEnvLine(targetKey, agentId)
+  } else {
+    if (nextLines.length > 0 && nextLines[nextLines.length - 1].trim()) nextLines.push('')
+    nextLines.push('# DingTalk work-notification agent id for direct messages and rule-creator failure alerts.')
+    nextLines.push(renderEnvLine(targetKey, agentId))
+  }
+
+  const action = existing.length > 0 && existing.every((entry) => entry.same) && targetIndex >= 0
+    ? 'unchanged'
+    : opts.dryRun
+      ? 'would_update'
+      : 'updated'
+
+  let backupFile = ''
+  if (!opts.dryRun && action !== 'unchanged') {
+    mkdirSync(opts.backupDir, { recursive: true })
+    backupFile = makeBackupPath(opts)
+    copyFileSync(opts.envFile, backupFile)
+    writeFileSync(opts.envFile, `${nextLines.join('\n')}\n`, 'utf8')
+  }
+
+  return {
+    action,
+    targetKey,
+    existingKeys: existing.map((entry) => ({ key: entry.key, length: entry.length, same: entry.same })),
+    checks: [
+      { id: 'agent-id-valid', status: 'pass', details: { length: agentId.length } },
+      {
+        id: 'env-file-updated',
+        status: opts.dryRun || action === 'unchanged' || backupFile ? 'pass' : 'fail',
+        details: { action, targetKey },
+      },
+    ],
+    backupFile,
+    restart: { requested: opts.restartBackend, attempted: false },
+  }
+}
+
+function restartBackend(opts) {
+  const args = ['compose', '-f', opts.composeFile, 'up', '-d', '--no-deps', '--force-recreate', opts.service]
+  const result = spawnSync('docker', args, {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+  })
+  return {
+    requested: true,
+    attempted: true,
+    command: ['docker', 'compose', '-f', relativePath(opts.composeFile), 'up', '-d', '--no-deps', '--force-recreate', opts.service].join(' '),
+    exitCode: typeof result.status === 'number' ? result.status : 1,
+    signal: result.signal ?? '',
+    stdoutLength: result.stdout?.length ?? 0,
+    stderrLength: result.stderr?.length ?? 0,
+  }
+}
+
+function buildSummary(opts, applyResult, agentIdLength) {
+  return {
+    tool: 'dingtalk-work-notification-agent-id-apply',
+    schemaVersion: SCHEMA_VERSION,
+    generatedAt: new Date().toISOString(),
+    status: applyResult.action === 'blocked' ? 'blocked' : 'pass',
+    action: applyResult.action,
+    dryRun: opts.dryRun,
+    envFile: relativePath(opts.envFile),
+    agentIdFile: relativePath(opts.agentIdFile),
+    agentId: { length: agentIdLength, valuePrinted: false },
+    targetKey: applyResult.targetKey,
+    existingKeys: applyResult.existingKeys,
+    backupFile: relativePath(applyResult.backupFile),
+    restart: applyResult.restart,
+    checks: applyResult.checks,
+    nextCommands: applyResult.action === 'blocked'
+      ? ['Confirm the existing agent id, then rerun with --force if replacement is intended.']
+      : [
+          'Restart metasheet-backend if --restart-backend was not used.',
+          'Rerun scripts/ops/dingtalk-work-notification-env-status.mjs to confirm Overall Status: ready.',
+        ],
+    notes: [
+      'The agent id value is never printed to stdout or summary files.',
+      'A backup is created before modifying the env file unless --dry-run is used.',
+    ],
+  }
+}
+
+function renderMarkdown(summary) {
+  const lines = [
+    '# DingTalk Work Notification Agent ID Apply',
+    '',
+    `- Generated At: ${summary.generatedAt}`,
+    `- Status: \`${summary.status}\``,
+    `- Action: \`${summary.action}\``,
+    `- Dry Run: \`${summary.dryRun}\``,
+    `- Env File: \`${summary.envFile}\``,
+    `- Agent ID File: \`${summary.agentIdFile}\``,
+    `- Agent ID Length: \`${summary.agentId.length}\``,
+    `- Target Key: \`${summary.targetKey}\``,
+    `- Backup File: \`${summary.backupFile || '<none>'}\``,
+    '',
+    '## Checks',
+    '',
+    '| Check | Status | Details |',
+    '| --- | --- | --- |',
+  ]
+
+  for (const check of summary.checks) {
+    lines.push(`| \`${check.id}\` | \`${check.status}\` | \`${JSON.stringify(check.details ?? {})}\` |`)
+  }
+
+  lines.push('', '## Restart', '')
+  lines.push(`- Requested: \`${summary.restart.requested}\``)
+  lines.push(`- Attempted: \`${summary.restart.attempted}\``)
+  if (summary.restart.attempted) {
+    lines.push(`- Exit Code: \`${summary.restart.exitCode}\``)
+    lines.push(`- Command: \`${summary.restart.command}\``)
+  }
+
+  lines.push('', '## Next Commands', '')
+  for (const command of summary.nextCommands) lines.push(`- ${command}`)
+
+  lines.push('', '## Notes', '')
+  for (const note of summary.notes) lines.push(`- ${note}`)
+
+  return `${lines.join('\n')}\n`
+}
+
+function writeSummary(opts, summary) {
+  mkdirSync(path.dirname(opts.outputJson), { recursive: true })
+  mkdirSync(path.dirname(opts.outputMd), { recursive: true })
+  writeFileSync(opts.outputJson, `${JSON.stringify(summary, null, 2)}\n`, 'utf8')
+  writeFileSync(opts.outputMd, renderMarkdown(summary), 'utf8')
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2))
+  const agentId = readAgentId(opts.agentIdFile)
+  const applyResult = applyEnvUpdate(opts, agentId)
+  if (opts.restartBackend && !opts.dryRun && applyResult.action !== 'blocked' && applyResult.action !== 'unchanged') {
+    applyResult.restart = restartBackend(opts)
+    applyResult.checks.push({
+      id: 'backend-restart',
+      status: applyResult.restart.exitCode === 0 ? 'pass' : 'fail',
+      details: {
+        attempted: applyResult.restart.attempted,
+        exitCode: applyResult.restart.exitCode,
+        stdoutLength: applyResult.restart.stdoutLength,
+        stderrLength: applyResult.restart.stderrLength,
+      },
+    })
+  }
+
+  const summary = buildSummary(opts, applyResult, agentId.length)
+  writeSummary(opts, summary)
+  console.log(`DingTalk work-notification agent id apply: ${summary.action}; target=${summary.targetKey}; length=${summary.agentId.length}; summary=${relativePath(opts.outputMd)}`)
+
+  if (summary.status === 'blocked') process.exit(1)
+  if (summary.restart.attempted && summary.restart.exitCode !== 0) process.exit(summary.restart.exitCode || 1)
+}
+
+try {
+  main()
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error))
+  process.exit(1)
+}

--- a/scripts/ops/dingtalk-work-notification-agent-id-apply.test.mjs
+++ b/scripts/ops/dingtalk-work-notification-agent-id-apply.test.mjs
@@ -1,0 +1,196 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const scriptPath = path.join(repoRoot, 'scripts', 'ops', 'dingtalk-work-notification-agent-id-apply.mjs')
+
+function makeTmpDir() {
+  return mkdtempSync(path.join(tmpdir(), 'dingtalk-work-notification-agent-id-apply-'))
+}
+
+function runScript(args) {
+  return spawnSync(process.execPath, [scriptPath, ...args], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  })
+}
+
+function readJson(file) {
+  return JSON.parse(readFileSync(file, 'utf8'))
+}
+
+test('applies a missing DingTalk agent id without printing the value', () => {
+  const tmpDir = makeTmpDir()
+  const envFile = path.join(tmpDir, 'app.env')
+  const agentIdFile = path.join(tmpDir, 'agent-id.txt')
+  const outputJson = path.join(tmpDir, 'summary.json')
+  const outputMd = path.join(tmpDir, 'summary.md')
+  try {
+    writeFileSync(envFile, 'DINGTALK_CLIENT_ID=client-id\nDINGTALK_CLIENT_SECRET=client-secret\n', 'utf8')
+    writeFileSync(agentIdFile, '123456789\n', 'utf8')
+
+    const result = runScript([
+      '--env-file', envFile,
+      '--agent-id-file', agentIdFile,
+      '--output-json', outputJson,
+      '--output-md', outputMd,
+    ])
+
+    assert.equal(result.status, 0, result.stderr || result.stdout)
+    assert.doesNotMatch(result.stdout, /123456789|client-secret/)
+    assert.match(readFileSync(envFile, 'utf8'), /DINGTALK_AGENT_ID=123456789/)
+
+    const summaryText = readFileSync(outputJson, 'utf8')
+    assert.doesNotMatch(summaryText, /123456789|client-secret/)
+    const summary = JSON.parse(summaryText)
+    assert.equal(summary.status, 'pass')
+    assert.equal(summary.action, 'updated')
+    assert.equal(summary.agentId.length, 9)
+    assert.equal(summary.targetKey, 'DINGTALK_AGENT_ID')
+    assert.equal(summary.backupFile.endsWith('app.env.backup-before-dingtalk-agent-id-'), false)
+    assert.match(summary.backupFile, /app\.env\.backup-before-dingtalk-agent-id-/)
+    assert.equal(existsSync(path.join(repoRoot, summary.backupFile)), true)
+    assert.doesNotMatch(readFileSync(outputMd, 'utf8'), /123456789|client-secret/)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+test('dry-run validates but does not change the env file', () => {
+  const tmpDir = makeTmpDir()
+  const envFile = path.join(tmpDir, 'app.env')
+  const agentIdFile = path.join(tmpDir, 'agent-id.txt')
+  const outputJson = path.join(tmpDir, 'summary.json')
+  const outputMd = path.join(tmpDir, 'summary.md')
+  try {
+    writeFileSync(envFile, 'DINGTALK_CLIENT_ID=client-id\n', 'utf8')
+    writeFileSync(agentIdFile, '987654321\n', 'utf8')
+
+    const result = runScript([
+      '--env-file', envFile,
+      '--agent-id-file', agentIdFile,
+      '--dry-run',
+      '--output-json', outputJson,
+      '--output-md', outputMd,
+    ])
+
+    assert.equal(result.status, 0, result.stderr || result.stdout)
+    assert.equal(readFileSync(envFile, 'utf8'), 'DINGTALK_CLIENT_ID=client-id\n')
+    const summary = readJson(outputJson)
+    assert.equal(summary.action, 'would_update')
+    assert.equal(summary.backupFile, '')
+    assert.doesNotMatch(readFileSync(outputMd, 'utf8'), /987654321/)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('reuses an existing legacy alias as the target key', () => {
+  const tmpDir = makeTmpDir()
+  const envFile = path.join(tmpDir, 'app.env')
+  const agentIdFile = path.join(tmpDir, 'agent-id.txt')
+  const outputJson = path.join(tmpDir, 'summary.json')
+  const outputMd = path.join(tmpDir, 'summary.md')
+  try {
+    writeFileSync(envFile, 'DINGTALK_NOTIFY_AGENT_ID=111222333\n', 'utf8')
+    writeFileSync(agentIdFile, '111222333\n', 'utf8')
+
+    const result = runScript([
+      '--env-file', envFile,
+      '--agent-id-file', agentIdFile,
+      '--output-json', outputJson,
+      '--output-md', outputMd,
+    ])
+
+    assert.equal(result.status, 0, result.stderr || result.stdout)
+    const summary = readJson(outputJson)
+    assert.equal(summary.action, 'unchanged')
+    assert.equal(summary.targetKey, 'DINGTALK_NOTIFY_AGENT_ID')
+    assert.equal(readFileSync(envFile, 'utf8'), 'DINGTALK_NOTIFY_AGENT_ID=111222333\n')
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('blocks replacing an existing different agent id unless forced', () => {
+  const tmpDir = makeTmpDir()
+  const envFile = path.join(tmpDir, 'app.env')
+  const agentIdFile = path.join(tmpDir, 'agent-id.txt')
+  const outputJson = path.join(tmpDir, 'summary.json')
+  const outputMd = path.join(tmpDir, 'summary.md')
+  try {
+    writeFileSync(envFile, 'DINGTALK_AGENT_ID=111222333\n', 'utf8')
+    writeFileSync(agentIdFile, '444555666\n', 'utf8')
+
+    const result = runScript([
+      '--env-file', envFile,
+      '--agent-id-file', agentIdFile,
+      '--output-json', outputJson,
+      '--output-md', outputMd,
+    ])
+
+    assert.equal(result.status, 1)
+    assert.equal(readFileSync(envFile, 'utf8'), 'DINGTALK_AGENT_ID=111222333\n')
+    const summary = readJson(outputJson)
+    assert.equal(summary.status, 'blocked')
+    assert.equal(summary.checks.find((check) => check.id === 'existing-agent-id-conflict')?.status, 'fail')
+    assert.doesNotMatch(readFileSync(outputMd, 'utf8'), /111222333|444555666/)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('force replaces an existing different agent id after creating a backup', () => {
+  const tmpDir = makeTmpDir()
+  const envFile = path.join(tmpDir, 'app.env')
+  const agentIdFile = path.join(tmpDir, 'agent-id.txt')
+  const outputJson = path.join(tmpDir, 'summary.json')
+  const outputMd = path.join(tmpDir, 'summary.md')
+  try {
+    writeFileSync(envFile, 'DINGTALK_AGENT_ID=111222333\n', 'utf8')
+    writeFileSync(agentIdFile, '444555666\n', 'utf8')
+
+    const result = runScript([
+      '--env-file', envFile,
+      '--agent-id-file', agentIdFile,
+      '--force',
+      '--output-json', outputJson,
+      '--output-md', outputMd,
+    ])
+
+    assert.equal(result.status, 0, result.stderr || result.stdout)
+    assert.equal(readFileSync(envFile, 'utf8'), 'DINGTALK_AGENT_ID=444555666\n')
+    const summary = readJson(outputJson)
+    assert.equal(summary.action, 'updated')
+    assert.equal(existsSync(path.join(repoRoot, summary.backupFile)), true)
+    assert.doesNotMatch(readFileSync(outputJson, 'utf8'), /111222333|444555666/)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('rejects empty and non-numeric agent id files', () => {
+  const tmpDir = makeTmpDir()
+  const envFile = path.join(tmpDir, 'app.env')
+  const emptyFile = path.join(tmpDir, 'empty.txt')
+  const invalidFile = path.join(tmpDir, 'invalid.txt')
+  try {
+    writeFileSync(envFile, '', 'utf8')
+    writeFileSync(emptyFile, '\n', 'utf8')
+    writeFileSync(invalidFile, 'agent-id=abc\n', 'utf8')
+
+    const empty = runScript(['--env-file', envFile, '--agent-id-file', emptyFile])
+    assert.equal(empty.status, 1)
+    assert.match(empty.stderr, /empty/)
+
+    const invalid = runScript(['--env-file', envFile, '--agent-id-file', invalidFile])
+    assert.equal(invalid.status, 1)
+    assert.match(invalid.stderr, /numeric/)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})

--- a/scripts/ops/dingtalk-work-notification-agent-id-apply.test.mjs
+++ b/scripts/ops/dingtalk-work-notification-agent-id-apply.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import { spawnSync } from 'node:child_process'
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import test from 'node:test'
@@ -60,6 +60,44 @@ test('applies a missing DingTalk agent id without printing the value', () => {
     rmSync(tmpDir, { recursive: true, force: true })
   }
 })
+
+test('initializes an empty private agent id file', () => {
+  const tmpDir = makeTmpDir()
+  const agentIdFile = path.join(tmpDir, '.secrets', 'dingtalk-agent-id.txt')
+  try {
+    const result = runScript(['--init-agent-id-file', agentIdFile])
+
+    assert.equal(result.status, 0, result.stderr || result.stdout)
+    assert.equal(existsSync(agentIdFile), true)
+    assert.equal(readFileSync(agentIdFile, 'utf8'), '')
+    assert.equal(statSync(agentIdFile).mode & 0o777, 0o600)
+    assert.equal(statSync(path.dirname(agentIdFile)).mode & 0o777, 0o700)
+    assert.doesNotMatch(result.stdout, /\d{6,}|access_token|SEC/)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('refuses to overwrite initialized agent id files unless forced', () => {
+  const tmpDir = makeTmpDir()
+  const agentIdFile = path.join(tmpDir, 'agent-id.txt')
+  try {
+    writeFileSync(agentIdFile, '123456789\n', 'utf8')
+
+    const blocked = runScript(['--init-agent-id-file', agentIdFile])
+    assert.equal(blocked.status, 1)
+    assert.match(blocked.stderr, /already exists/)
+    assert.equal(readFileSync(agentIdFile, 'utf8'), '123456789\n')
+
+    const forced = runScript(['--init-agent-id-file', agentIdFile, '--force'])
+    assert.equal(forced.status, 0, forced.stderr || forced.stdout)
+    assert.equal(readFileSync(agentIdFile, 'utf8'), '')
+    assert.equal(statSync(agentIdFile).mode & 0o777, 0o600)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
 test('dry-run validates but does not change the env file', () => {
   const tmpDir = makeTmpDir()
   const envFile = path.join(tmpDir, 'app.env')

--- a/scripts/ops/dingtalk-work-notification-env-status.mjs
+++ b/scripts/ops/dingtalk-work-notification-env-status.mjs
@@ -1,0 +1,356 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+
+const DEFAULT_OUTPUT_DIR = 'output/dingtalk-work-notification-env-status'
+const SCHEMA_VERSION = 1
+
+const REQUIREMENTS = [
+  {
+    id: 'app-key',
+    label: 'DingTalk app key is configured',
+    keys: ['DINGTALK_APP_KEY', 'DINGTALK_CLIENT_ID'],
+    remediation: 'Set DINGTALK_APP_KEY, or the legacy alias DINGTALK_CLIENT_ID.',
+  },
+  {
+    id: 'app-secret',
+    label: 'DingTalk app secret is configured',
+    keys: ['DINGTALK_APP_SECRET', 'DINGTALK_CLIENT_SECRET'],
+    remediation: 'Set DINGTALK_APP_SECRET, or the legacy alias DINGTALK_CLIENT_SECRET.',
+  },
+  {
+    id: 'agent-id',
+    label: 'DingTalk work-notification agent id is configured',
+    keys: ['DINGTALK_AGENT_ID', 'DINGTALK_NOTIFY_AGENT_ID'],
+    remediation: 'Set DINGTALK_AGENT_ID, or the legacy alias DINGTALK_NOTIFY_AGENT_ID.',
+  },
+]
+
+function printHelp() {
+  console.log(`Usage: node scripts/ops/dingtalk-work-notification-env-status.mjs [options]
+
+Checks DingTalk work-notification environment readiness without calling
+DingTalk and without printing credential values. This is the release gate for
+creator failure alerts changing from audited failed attempts to real successful
+work notifications.
+
+Options:
+  --env-file <file>              Env file to read; repeatable
+  --write-env-template <file>    Write a fill-in env template and exit
+  --force                        Overwrite an existing env template
+  --output-json <file>           Output JSON path, default ${DEFAULT_OUTPUT_DIR}/summary.json
+  --output-md <file>             Output Markdown path, default ${DEFAULT_OUTPUT_DIR}/summary.md
+  --allow-blocked                Exit 0 even when required envs are missing
+  --help                         Show this help
+
+Environment fallbacks:
+  DINGTALK_APP_KEY or DINGTALK_CLIENT_ID
+  DINGTALK_APP_SECRET or DINGTALK_CLIENT_SECRET
+  DINGTALK_AGENT_ID or DINGTALK_NOTIFY_AGENT_ID
+`)
+}
+
+function readRequiredValue(argv, index, flag) {
+  const value = argv[index + 1]
+  if (!value || value.startsWith('--')) throw new Error(`${flag} requires a value`)
+  return value
+}
+
+function parseArgs(argv) {
+  const opts = {
+    envFiles: [],
+    writeEnvTemplate: '',
+    outputJson: path.resolve(process.cwd(), DEFAULT_OUTPUT_DIR, 'summary.json'),
+    outputMd: path.resolve(process.cwd(), DEFAULT_OUTPUT_DIR, 'summary.md'),
+    allowBlocked: false,
+    force: false,
+  }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    switch (arg) {
+      case '--env-file':
+        opts.envFiles.push(path.resolve(process.cwd(), readRequiredValue(argv, index, arg)))
+        index += 1
+        break
+      case '--write-env-template':
+        opts.writeEnvTemplate = path.resolve(process.cwd(), readRequiredValue(argv, index, arg))
+        index += 1
+        break
+      case '--force':
+        opts.force = true
+        break
+      case '--output-json':
+        opts.outputJson = path.resolve(process.cwd(), readRequiredValue(argv, index, arg))
+        index += 1
+        break
+      case '--output-md':
+        opts.outputMd = path.resolve(process.cwd(), readRequiredValue(argv, index, arg))
+        index += 1
+        break
+      case '--allow-blocked':
+        opts.allowBlocked = true
+        break
+      case '--help':
+        printHelp()
+        process.exit(0)
+        break
+      default:
+        throw new Error(`Unknown argument: ${arg}`)
+    }
+  }
+
+  return opts
+}
+
+function unquoteEnvValue(value) {
+  const trimmed = String(value ?? '').trim()
+  if (trimmed.length >= 2 && trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    return trimmed.slice(1, -1).replaceAll('\\"', '"').replaceAll('\\\\', '\\')
+  }
+  if (trimmed.length >= 2 && trimmed.startsWith("'") && trimmed.endsWith("'")) {
+    return trimmed.slice(1, -1)
+  }
+  return trimmed
+}
+
+function readEnvFile(file) {
+  if (!existsSync(file)) throw new Error(`env file not found: ${file}`)
+  const values = new Map()
+  const text = readFileSync(file, 'utf8')
+  for (const line of text.split(/\r?\n/)) {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('#')) continue
+    const index = trimmed.indexOf('=')
+    if (index <= 0) continue
+    values.set(trimmed.slice(0, index).trim(), unquoteEnvValue(trimmed.slice(index + 1)))
+  }
+  return values
+}
+
+function mergeEnvFiles(files) {
+  const values = new Map()
+  const sources = new Map()
+  for (const file of files) {
+    const fileValues = readEnvFile(file)
+    for (const [key, value] of fileValues.entries()) {
+      values.set(key, value)
+      sources.set(key, file)
+    }
+  }
+  for (const requirement of REQUIREMENTS) {
+    for (const key of requirement.keys) {
+      const value = process.env[key]
+      if (typeof value === 'string' && value.trim()) {
+        values.set(key, value.trim())
+        sources.set(key, '<process.env>')
+      }
+    }
+  }
+  return { values, sources }
+}
+
+function relativePath(file) {
+  if (!file) return ''
+  if (file === '<process.env>') return file
+  return path.relative(process.cwd(), file).replaceAll('\\', '/')
+}
+
+function renderEnvTemplate() {
+  return `# DingTalk work-notification envs for creator failure alerts.
+# Keep filled copies outside Git and do not paste secrets into chat.
+#
+# Required by readDingTalkMessageConfig():
+
+DINGTALK_APP_KEY=""
+DINGTALK_APP_SECRET=""
+DINGTALK_AGENT_ID=""
+
+# Legacy aliases are also accepted by the backend:
+# DINGTALK_CLIENT_ID=""
+# DINGTALK_CLIENT_SECRET=""
+# DINGTALK_NOTIFY_AGENT_ID=""
+`
+}
+
+function writeEnvTemplate(file, force = false) {
+  if (existsSync(file) && !force) {
+    throw new Error(`env template already exists: ${file}; pass --force to overwrite`)
+  }
+  mkdirSync(path.dirname(file), { recursive: true })
+  writeFileSync(file, renderEnvTemplate(), 'utf8')
+}
+
+function pickRequirement(values, sources, requirement) {
+  const candidates = requirement.keys.map((key) => {
+    const value = typeof values.get(key) === 'string' ? values.get(key).trim() : ''
+    return {
+      key,
+      present: Boolean(value),
+      length: value.length,
+      source: value ? relativePath(sources.get(key) ?? '') : '',
+    }
+  })
+  const selected = candidates.find((candidate) => candidate.present) ?? null
+  const presentCandidates = candidates.filter((candidate) => candidate.present)
+  return {
+    id: requirement.id,
+    label: requirement.label,
+    keys: requirement.keys,
+    present: Boolean(selected),
+    selectedKey: selected?.key ?? '',
+    source: selected?.source ?? '',
+    length: selected?.length ?? 0,
+    aliasCount: presentCandidates.length,
+  }
+}
+
+function addCheck(summary, id, label, passed, details = {}, remediation = '') {
+  summary.checks.push({
+    id,
+    label,
+    status: passed ? 'pass' : 'fail',
+    details,
+    remediation,
+  })
+}
+
+function buildSummary(opts, merged) {
+  const requirementStates = REQUIREMENTS.map((requirement) =>
+    pickRequirement(merged.values, merged.sources, requirement),
+  )
+  const requirementById = new Map(requirementStates.map((state) => [state.id, state]))
+
+  const summary = {
+    tool: 'dingtalk-work-notification-env-status',
+    schemaVersion: SCHEMA_VERSION,
+    generatedAt: new Date().toISOString(),
+    envFiles: opts.envFiles.map(relativePath),
+    overallStatus: 'blocked',
+    requirements: Object.fromEntries(requirementStates.map((state) => [state.id, {
+      keys: state.keys,
+      present: state.present,
+      selectedKey: state.selectedKey,
+      source: state.source,
+      length: state.length,
+      aliasCount: state.aliasCount,
+    }])),
+    checks: [],
+    missingInputs: [],
+    nextCommands: [],
+    notes: [
+      'This helper does not call DingTalk and never writes credential values.',
+      'It only checks whether the envs required by readDingTalkMessageConfig() are present.',
+    ],
+  }
+
+  for (const requirement of REQUIREMENTS) {
+    const state = requirementById.get(requirement.id)
+    addCheck(summary, `${requirement.id}-present`, requirement.label, state?.present === true, {
+      acceptedKeys: requirement.keys,
+      selectedKey: state?.selectedKey ?? '',
+      source: state?.source ?? '',
+      length: state?.length ?? 0,
+    }, requirement.remediation)
+  }
+
+  summary.missingInputs = summary.checks
+    .filter((check) => check.status === 'fail')
+    .map((check) => ({
+      id: check.id,
+      label: check.label,
+      remediation: check.remediation,
+    }))
+  summary.overallStatus = summary.missingInputs.length === 0 ? 'ready' : 'blocked'
+  summary.nextCommands = summary.overallStatus === 'ready'
+    ? [
+        'Restart metasheet-backend so the DingTalk work-notification envs are loaded.',
+        'Rerun scripts/ops/dingtalk-group-failure-alert-probe.mjs with --expect-person-status success against a fresh controlled failed group delivery.',
+      ]
+    : ['Set the missing envs, restart metasheet-backend, then rerun this helper.']
+  return summary
+}
+
+function renderMarkdown(summary) {
+  const lines = [
+    '# DingTalk Work Notification Env Status',
+    '',
+    `- Generated At: ${summary.generatedAt}`,
+    `- Overall Status: \`${summary.overallStatus}\``,
+    `- Env Files: ${summary.envFiles.length ? summary.envFiles.map((file) => `\`${file}\``).join(', ') : '`<none>`'}`,
+    '',
+    '## Requirements',
+    '',
+    '| Requirement | Accepted Keys | Present | Selected Key | Source | Length |',
+    '| --- | --- | --- | --- | --- | --- |',
+  ]
+
+  for (const [id, state] of Object.entries(summary.requirements)) {
+    lines.push(`| \`${id}\` | \`${state.keys.join('`, `')}\` | \`${state.present}\` | \`${state.selectedKey || '<missing>'}\` | \`${state.source || '<missing>'}\` | \`${state.length}\` |`)
+  }
+
+  lines.push('', '## Checks', '')
+  lines.push('| Check | Label | Status | Remediation |')
+  lines.push('| --- | --- | --- | --- |')
+  for (const check of summary.checks) {
+    lines.push(`| \`${check.id}\` | ${check.label} | \`${check.status}\` | ${check.status === 'pass' ? '' : check.remediation} |`)
+  }
+
+  lines.push('', '## Next Commands', '')
+  for (const command of summary.nextCommands) {
+    lines.push(`- ${command}`)
+  }
+
+  if (summary.missingInputs.length > 0) {
+    lines.push('', '## Missing Inputs', '')
+    for (const item of summary.missingInputs) {
+      lines.push(`- \`${item.id}\`: ${item.remediation}`)
+    }
+  }
+
+  lines.push('', '## Notes', '')
+  for (const note of summary.notes) {
+    lines.push(`- ${note}`)
+  }
+  lines.push('')
+  return lines.join('\n')
+}
+
+function writeOutputs(opts, summary) {
+  mkdirSync(path.dirname(opts.outputJson), { recursive: true })
+  mkdirSync(path.dirname(opts.outputMd), { recursive: true })
+  writeFileSync(opts.outputJson, `${JSON.stringify(summary, null, 2)}\n`, 'utf8')
+  writeFileSync(opts.outputMd, renderMarkdown(summary), 'utf8')
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2))
+  if (opts.writeEnvTemplate) {
+    writeEnvTemplate(opts.writeEnvTemplate, opts.force)
+    console.log(`[dingtalk-work-notification-env-status] wrote env template: ${relativePath(opts.writeEnvTemplate)}`)
+    return
+  }
+
+  const merged = mergeEnvFiles(opts.envFiles)
+  const summary = buildSummary(opts, merged)
+  writeOutputs(opts, summary)
+  console.log(`[dingtalk-work-notification-env-status] ${summary.overallStatus}: ${relativePath(opts.outputJson)}`)
+  if (summary.overallStatus !== 'ready' && !opts.allowBlocked) {
+    process.exitCode = 1
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error))
+  process.exitCode = 1
+})
+
+export {
+  buildSummary,
+  mergeEnvFiles,
+  parseArgs,
+  readEnvFile,
+  renderEnvTemplate,
+  renderMarkdown,
+}

--- a/scripts/ops/dingtalk-work-notification-env-status.test.mjs
+++ b/scripts/ops/dingtalk-work-notification-env-status.test.mjs
@@ -1,0 +1,230 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const scriptPath = path.join(repoRoot, 'scripts', 'ops', 'dingtalk-work-notification-env-status.mjs')
+const envKeys = [
+  'DINGTALK_APP_KEY',
+  'DINGTALK_CLIENT_ID',
+  'DINGTALK_APP_SECRET',
+  'DINGTALK_CLIENT_SECRET',
+  'DINGTALK_AGENT_ID',
+  'DINGTALK_NOTIFY_AGENT_ID',
+]
+
+function makeTmpDir() {
+  return mkdtempSync(path.join(tmpdir(), 'dingtalk-work-notification-env-status-'))
+}
+
+function runScript(args, env = {}) {
+  const baseEnv = { ...process.env }
+  for (const key of envKeys) delete baseEnv[key]
+  return spawnSync(process.execPath, [scriptPath, ...args], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    env: { ...baseEnv, ...env },
+  })
+}
+
+function writeEnv(file, lines) {
+  writeFileSync(file, `${lines.join('\n')}\n`, 'utf8')
+}
+
+function readJson(file) {
+  return JSON.parse(readFileSync(file, 'utf8'))
+}
+
+test('dingtalk-work-notification-env-status reports blocked missing inputs without leaking values', () => {
+  const tmpDir = makeTmpDir()
+  const envFile = path.join(tmpDir, 'app.env')
+  const outputJson = path.join(tmpDir, 'summary.json')
+  const outputMd = path.join(tmpDir, 'summary.md')
+  try {
+    writeEnv(envFile, [
+      'DINGTALK_APP_KEY="unit-app-key"',
+      'DINGTALK_APP_SECRET="unit-app-credential"',
+    ])
+
+    const result = runScript([
+      '--env-file', envFile,
+      '--output-json', outputJson,
+      '--output-md', outputMd,
+      '--allow-blocked',
+    ])
+
+    assert.equal(result.status, 0, result.stderr || result.stdout)
+    assert.doesNotMatch(result.stdout, /unit-app-key|unit-app-credential/)
+    assert.equal(existsSync(outputJson), true)
+    assert.equal(existsSync(outputMd), true)
+
+    const summaryText = readFileSync(outputJson, 'utf8')
+    assert.doesNotMatch(summaryText, /unit-app-key|unit-app-credential/)
+    const summary = JSON.parse(summaryText)
+    assert.equal(summary.overallStatus, 'blocked')
+    assert.equal(summary.requirements['app-key'].present, true)
+    assert.equal(summary.requirements['app-secret'].present, true)
+    assert.equal(summary.requirements['agent-id'].present, false)
+    assert.deepEqual(summary.missingInputs.map((item) => item.id), ['agent-id-present'])
+
+    const markdown = readFileSync(outputMd, 'utf8')
+    assert.match(markdown, /Overall Status: `blocked`/)
+    assert.match(markdown, /DINGTALK_AGENT_ID/)
+    assert.doesNotMatch(markdown, /unit-app-key|unit-app-credential/)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-work-notification-env-status exits non-zero for blocked inputs by default', () => {
+  const tmpDir = makeTmpDir()
+  const outputJson = path.join(tmpDir, 'summary.json')
+  const outputMd = path.join(tmpDir, 'summary.md')
+  try {
+    const result = runScript(['--output-json', outputJson, '--output-md', outputMd])
+
+    assert.equal(result.status, 1)
+    const summary = readJson(outputJson)
+    assert.equal(summary.overallStatus, 'blocked')
+    assert.equal(summary.missingInputs.length, 3)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-work-notification-env-status passes complete primary envs', () => {
+  const tmpDir = makeTmpDir()
+  const envFile = path.join(tmpDir, 'app.env')
+  const outputJson = path.join(tmpDir, 'summary.json')
+  const outputMd = path.join(tmpDir, 'summary.md')
+  try {
+    writeEnv(envFile, [
+      'DINGTALK_APP_KEY="unit-app-key"',
+      'DINGTALK_APP_SECRET="unit-app-credential"',
+      'DINGTALK_AGENT_ID="123456789"',
+    ])
+
+    const result = runScript([
+      '--env-file', envFile,
+      '--output-json', outputJson,
+      '--output-md', outputMd,
+    ])
+
+    assert.equal(result.status, 0, result.stderr || result.stdout)
+    const summary = readJson(outputJson)
+    assert.equal(summary.overallStatus, 'ready')
+    assert.equal(summary.missingInputs.length, 0)
+    assert.equal(summary.checks.every((check) => check.status === 'pass'), true)
+    assert.equal(summary.requirements['app-key'].selectedKey, 'DINGTALK_APP_KEY')
+    assert.equal(summary.requirements['agent-id'].selectedKey, 'DINGTALK_AGENT_ID')
+    assert.match(summary.nextCommands.join('\n'), /expect-person-status success/)
+    assert.doesNotMatch(readFileSync(outputMd, 'utf8'), /unit-app-key|unit-app-credential/)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-work-notification-env-status accepts legacy aliases', () => {
+  const tmpDir = makeTmpDir()
+  const envFile = path.join(tmpDir, 'app.env')
+  const outputJson = path.join(tmpDir, 'summary.json')
+  const outputMd = path.join(tmpDir, 'summary.md')
+  try {
+    writeEnv(envFile, [
+      'DINGTALK_CLIENT_ID="unit-client-id"',
+      'DINGTALK_CLIENT_SECRET="unit-client-credential"',
+      'DINGTALK_NOTIFY_AGENT_ID="987654321"',
+    ])
+
+    const result = runScript([
+      '--env-file', envFile,
+      '--output-json', outputJson,
+      '--output-md', outputMd,
+    ])
+
+    assert.equal(result.status, 0, result.stderr || result.stdout)
+    const summary = readJson(outputJson)
+    assert.equal(summary.overallStatus, 'ready')
+    assert.equal(summary.requirements['app-key'].selectedKey, 'DINGTALK_CLIENT_ID')
+    assert.equal(summary.requirements['app-secret'].selectedKey, 'DINGTALK_CLIENT_SECRET')
+    assert.equal(summary.requirements['agent-id'].selectedKey, 'DINGTALK_NOTIFY_AGENT_ID')
+    assert.doesNotMatch(readFileSync(outputJson, 'utf8'), /unit-client-id|unit-client-credential/)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-work-notification-env-status lets process env override env files', () => {
+  const tmpDir = makeTmpDir()
+  const envFile = path.join(tmpDir, 'app.env')
+  const outputJson = path.join(tmpDir, 'summary.json')
+  const outputMd = path.join(tmpDir, 'summary.md')
+  try {
+    writeEnv(envFile, [
+      'DINGTALK_APP_KEY="file-key"',
+      'DINGTALK_APP_SECRET="file-secret"',
+      'DINGTALK_AGENT_ID="file-agent"',
+    ])
+
+    const result = runScript([
+      '--env-file', envFile,
+      '--output-json', outputJson,
+      '--output-md', outputMd,
+    ], {
+      DINGTALK_CLIENT_ID: 'process-client-id',
+      DINGTALK_CLIENT_SECRET: 'process-client-secret',
+      DINGTALK_NOTIFY_AGENT_ID: 'process-agent',
+    })
+
+    assert.equal(result.status, 0, result.stderr || result.stdout)
+    const summary = readJson(outputJson)
+    assert.equal(summary.overallStatus, 'ready')
+    assert.equal(summary.requirements['app-key'].selectedKey, 'DINGTALK_APP_KEY')
+    assert.equal(summary.requirements['app-key'].aliasCount, 2)
+    assert.equal(summary.requirements['agent-id'].aliasCount, 2)
+    assert.doesNotMatch(readFileSync(outputJson, 'utf8'), /process-client|process-agent|file-key|file-secret|file-agent/)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-work-notification-env-status writes a safe env template', () => {
+  const tmpDir = makeTmpDir()
+  const template = path.join(tmpDir, 'work-notification.env')
+  try {
+    const result = runScript(['--write-env-template', template])
+
+    assert.equal(result.status, 0, result.stderr || result.stdout)
+    assert.equal(existsSync(template), true)
+    const text = readFileSync(template, 'utf8')
+    assert.match(text, /DINGTALK_APP_KEY=""/)
+    assert.match(text, /DINGTALK_APP_SECRET=""/)
+    assert.match(text, /DINGTALK_AGENT_ID=""/)
+    assert.doesNotMatch(text, /access_token=|SEC[A-Za-z0-9+/=_-]{8,}|eyJ[A-Za-z0-9._-]{20,}|dt-app-secret/)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-work-notification-env-status refuses to overwrite templates unless forced', () => {
+  const tmpDir = makeTmpDir()
+  const template = path.join(tmpDir, 'work-notification.env')
+  try {
+    writeFileSync(template, 'EXISTING=1\n', 'utf8')
+
+    const blocked = runScript(['--write-env-template', template])
+    assert.equal(blocked.status, 1)
+    assert.match(blocked.stderr, /already exists/)
+    assert.equal(readFileSync(template, 'utf8'), 'EXISTING=1\n')
+
+    const forced = runScript(['--write-env-template', template, '--force'])
+    assert.equal(forced.status, 0, forced.stderr || forced.stdout)
+    assert.match(readFileSync(template, 'utf8'), /DINGTALK_APP_KEY/)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})

--- a/scripts/ops/dingtalk-work-notification-release-gate.mjs
+++ b/scripts/ops/dingtalk-work-notification-release-gate.mjs
@@ -1,0 +1,411 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { spawnSync } from 'node:child_process'
+import path from 'node:path'
+
+const DEFAULT_API_BASE = 'http://127.0.0.1:8900'
+const DEFAULT_OUTPUT_DIR = 'output/dingtalk-work-notification-release-gate'
+const DEFAULT_STATUS_HELPER = 'scripts/ops/dingtalk-work-notification-env-status.mjs'
+const SCHEMA_VERSION = 1
+const DINGTALK_ROBOT_WEBHOOK_RE = new RegExp(
+  `https://${'oapi.dingtalk.com'.replaceAll('.', '\\.')}/robot/send\\?${'access' + '_token'}=[A-Za-z0-9._~-]+`,
+  'gi',
+)
+
+function printHelp() {
+  console.log(`Usage: node scripts/ops/dingtalk-work-notification-release-gate.mjs [options]
+
+Runs a redaction-safe release gate for DingTalk work notifications. The gate is
+read-only: it checks env readiness, backend health, admin auth, and the admin
+workNotification runtime status API. It does not call DingTalk and does not send
+messages.
+
+Options:
+  --env-file <file>              Env file for env-status helper; repeatable
+  --status-helper <file>         Env-status helper, default ${DEFAULT_STATUS_HELPER}
+  --api-base <url>               Backend API base, default ${DEFAULT_API_BASE}
+  --auth-token <token>           Bearer token, never printed or written
+  --auth-token-file <file>       File containing bearer token
+  --user-id <id>                 User id for /api/admin/users/:id/dingtalk-access
+  --output-json <file>           Output JSON path, default ${DEFAULT_OUTPUT_DIR}/summary.json
+  --output-md <file>             Output Markdown path, default ${DEFAULT_OUTPUT_DIR}/summary.md
+  --timeout-ms <ms>              HTTP timeout, default 10000
+  --skip-admin-api               Only run env-status and health checks
+  --allow-blocked                Exit 0 even when the gate is blocked
+  --help                         Show this help
+`)
+}
+
+function readRequiredValue(argv, index, flag) {
+  const value = argv[index + 1]
+  if (!value || value.startsWith('--')) throw new Error(`${flag} requires a value`)
+  return value
+}
+
+function parseBoundedInteger(value, flag, min, max) {
+  const parsed = Number.parseInt(value, 10)
+  if (!Number.isInteger(parsed) || parsed < min || parsed > max) {
+    throw new Error(`${flag} must be an integer between ${min} and ${max}`)
+  }
+  return parsed
+}
+
+function parseArgs(argv) {
+  const opts = {
+    envFiles: [],
+    statusHelper: path.resolve(process.cwd(), DEFAULT_STATUS_HELPER),
+    apiBase: DEFAULT_API_BASE,
+    authToken: '',
+    authTokenFile: '',
+    userId: '',
+    outputJson: path.resolve(process.cwd(), DEFAULT_OUTPUT_DIR, 'summary.json'),
+    outputMd: path.resolve(process.cwd(), DEFAULT_OUTPUT_DIR, 'summary.md'),
+    timeoutMs: 10_000,
+    skipAdminApi: false,
+    allowBlocked: false,
+  }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    switch (arg) {
+      case '--env-file':
+        opts.envFiles.push(path.resolve(process.cwd(), readRequiredValue(argv, index, arg)))
+        index += 1
+        break
+      case '--status-helper':
+        opts.statusHelper = path.resolve(process.cwd(), readRequiredValue(argv, index, arg))
+        index += 1
+        break
+      case '--api-base':
+        opts.apiBase = readRequiredValue(argv, index, arg)
+        index += 1
+        break
+      case '--auth-token':
+        opts.authToken = readRequiredValue(argv, index, arg)
+        index += 1
+        break
+      case '--auth-token-file':
+        opts.authTokenFile = path.resolve(process.cwd(), readRequiredValue(argv, index, arg))
+        index += 1
+        break
+      case '--user-id':
+        opts.userId = readRequiredValue(argv, index, arg)
+        index += 1
+        break
+      case '--output-json':
+        opts.outputJson = path.resolve(process.cwd(), readRequiredValue(argv, index, arg))
+        index += 1
+        break
+      case '--output-md':
+        opts.outputMd = path.resolve(process.cwd(), readRequiredValue(argv, index, arg))
+        index += 1
+        break
+      case '--timeout-ms':
+        opts.timeoutMs = parseBoundedInteger(readRequiredValue(argv, index, arg), arg, 100, 120_000)
+        index += 1
+        break
+      case '--skip-admin-api':
+        opts.skipAdminApi = true
+        break
+      case '--allow-blocked':
+        opts.allowBlocked = true
+        break
+      case '--help':
+        printHelp()
+        process.exit(0)
+        break
+      default:
+        throw new Error(`Unknown argument: ${arg}`)
+    }
+  }
+
+  if (opts.authTokenFile && !opts.authToken) opts.authToken = readTokenFile(opts.authTokenFile)
+  if (!opts.skipAdminApi && !opts.authToken) throw new Error('--auth-token or --auth-token-file is required unless --skip-admin-api is used')
+  if (!opts.skipAdminApi && !opts.userId) throw new Error('--user-id is required unless --skip-admin-api is used')
+  opts.apiBase = normalizeApiBase(opts.apiBase)
+
+  return opts
+}
+
+function readTokenFile(file) {
+  if (!existsSync(file)) throw new Error(`auth token file not found: ${file}`)
+  const token = readFileSync(file, 'utf8').trim()
+  if (!token) throw new Error(`auth token file is empty: ${file}`)
+  return token
+}
+
+function normalizeApiBase(value) {
+  const trimmed = String(value ?? '').trim().replace(/\/+$/, '')
+  if (!/^https?:\/\//.test(trimmed)) throw new Error('--api-base must start with http:// or https://')
+  return trimmed
+}
+
+function relativePath(file) {
+  if (!file) return ''
+  return path.relative(process.cwd(), file).replaceAll('\\', '/')
+}
+
+function redactString(value) {
+  return String(value ?? '')
+    .replace(DINGTALK_ROBOT_WEBHOOK_RE, '<dingtalk-robot-webhook-redacted>')
+    .replace(new RegExp(`${'access' + '_token'}=[A-Za-z0-9._~-]{8,}`, 'gi'), 'access_token=<redacted>')
+    .replace(/SEC[A-Za-z0-9+/=_-]{8,}/g, 'SEC<redacted>')
+    .replace(/eyJ[A-Za-z0-9._-]{20,}/g, '<jwt-redacted>')
+    .replace(/Bearer\s+[A-Za-z0-9._-]{8,}/gi, 'Bearer <redacted>')
+}
+
+function redactDeep(value) {
+  if (typeof value === 'string') return redactString(value)
+  if (Array.isArray(value)) return value.map(redactDeep)
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(Object.entries(value).map(([key, entry]) => [key, redactDeep(entry)]))
+  }
+  return value
+}
+
+function addFailure(failures, code, message, detail = {}) {
+  failures.push({ code, message, detail: redactDeep(detail) })
+}
+
+function runEnvStatus(opts) {
+  const statusOutputJson = path.join(path.dirname(opts.outputJson), 'env-status.json')
+  const statusOutputMd = path.join(path.dirname(opts.outputMd), 'env-status.md')
+  const args = [
+    opts.statusHelper,
+    ...opts.envFiles.flatMap((file) => ['--env-file', file]),
+    '--allow-blocked',
+    '--output-json',
+    statusOutputJson,
+    '--output-md',
+    statusOutputMd,
+  ]
+  const result = spawnSync(process.execPath, args, { cwd: process.cwd(), encoding: 'utf8' })
+  let summary = null
+  if (existsSync(statusOutputJson)) {
+    try {
+      summary = JSON.parse(readFileSync(statusOutputJson, 'utf8'))
+    } catch {
+      summary = null
+    }
+  }
+  return {
+    command: [
+      'node',
+      relativePath(opts.statusHelper),
+      ...opts.envFiles.flatMap((file) => ['--env-file', relativePath(file)]),
+      '--allow-blocked',
+      '--output-json',
+      relativePath(statusOutputJson),
+      '--output-md',
+      relativePath(statusOutputMd),
+    ].join(' '),
+    exitCode: typeof result.status === 'number' ? result.status : 1,
+    stdoutLength: result.stdout?.length ?? 0,
+    stderrLength: result.stderr?.length ?? 0,
+    outputJson: relativePath(statusOutputJson),
+    outputMd: relativePath(statusOutputMd),
+    overallStatus: typeof summary?.overallStatus === 'string' ? summary.overallStatus : '',
+    missingInputs: Array.isArray(summary?.missingInputs)
+      ? summary.missingInputs.map((item) => ({ id: String(item?.id ?? '') })).filter((item) => item.id)
+      : [],
+    requirements: summary?.requirements ? redactDeep(summary.requirements) : {},
+  }
+}
+
+async function fetchJson(opts, pathname, token = '') {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), opts.timeoutMs)
+  const url = `${opts.apiBase}${pathname}`
+  try {
+    const headers = { accept: 'application/json' }
+    if (token) headers.authorization = `Bearer ${token}`
+    const response = await fetch(url, { headers, signal: controller.signal })
+    const text = await response.text()
+    let body = null
+    try {
+      body = text ? JSON.parse(text) : null
+    } catch {
+      body = { raw: redactString(text.slice(0, 500)) }
+    }
+    return {
+      ok: response.ok,
+      status: response.status,
+      body: redactDeep(body),
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      status: 0,
+      body: { error: redactString(error instanceof Error ? error.message : String(error)) },
+    }
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+function readHealthResult(result) {
+  return {
+    ok: result.ok && (
+      result.body?.ok === true
+      || result.body?.success === true
+      || result.body?.status === 'ok'
+    ),
+    status: result.status,
+    bodyStatus: result.body?.status ?? '',
+    success: result.body?.success === true || result.body?.ok === true,
+  }
+}
+
+function readAuthResult(result) {
+  const user = result.body?.user || result.body?.data?.user || result.body?.data || {}
+  return {
+    ok: result.ok && (result.body?.success === true || result.body?.ok === true),
+    status: result.status,
+    role: user.role || result.body?.role || '',
+    emailPresent: Boolean(user.email || result.body?.email),
+  }
+}
+
+function readWorkNotificationResult(result) {
+  const workNotification = result.body?.workNotification || result.body?.data?.workNotification || null
+  return {
+    ok: result.ok && Boolean(workNotification),
+    status: result.status,
+    available: workNotification?.available === true,
+    configured: workNotification?.configured === true,
+    unavailableReason: workNotification?.unavailableReason || '',
+    requirements: redactDeep(workNotification?.requirements || {}),
+  }
+}
+
+async function runGate(opts) {
+  const failures = []
+  const envStatus = runEnvStatus(opts)
+  if (envStatus.exitCode !== 0) {
+    addFailure(failures, 'ENV_STATUS_HELPER_FAILED', 'Env status helper failed', { exitCode: envStatus.exitCode })
+  }
+  if (envStatus.overallStatus !== 'ready') {
+    addFailure(failures, 'ENV_STATUS_BLOCKED', 'DingTalk work-notification env status is not ready', {
+      overallStatus: envStatus.overallStatus,
+      missingInputs: envStatus.missingInputs.map((item) => item.id),
+    })
+  }
+
+  const healthResult = readHealthResult(await fetchJson(opts, '/api/health'))
+  if (!healthResult.ok) {
+    addFailure(failures, 'HEALTH_CHECK_FAILED', 'Backend health check did not pass', healthResult)
+  }
+
+  let auth = { skipped: opts.skipAdminApi }
+  let workNotification = { skipped: opts.skipAdminApi }
+  if (!opts.skipAdminApi) {
+    auth = readAuthResult(await fetchJson(opts, '/api/auth/me', opts.authToken))
+    if (!auth.ok) addFailure(failures, 'AUTH_ME_FAILED', 'Admin auth probe failed', auth)
+
+    workNotification = readWorkNotificationResult(await fetchJson(
+      opts,
+      `/api/admin/users/${encodeURIComponent(opts.userId)}/dingtalk-access`,
+      opts.authToken,
+    ))
+    if (!workNotification.ok) {
+      addFailure(failures, 'WORK_NOTIFICATION_STATUS_FAILED', 'Admin DingTalk workNotification status API failed', workNotification)
+    } else if (!workNotification.available) {
+      addFailure(failures, 'WORK_NOTIFICATION_UNAVAILABLE', 'Admin DingTalk workNotification status is unavailable', {
+        unavailableReason: workNotification.unavailableReason,
+      })
+    }
+  }
+
+  return {
+    tool: 'dingtalk-work-notification-release-gate',
+    schemaVersion: SCHEMA_VERSION,
+    generatedAt: new Date().toISOString(),
+    status: failures.length === 0 ? 'pass' : 'blocked',
+    apiBase: opts.apiBase,
+    envFiles: opts.envFiles.map(relativePath),
+    authTokenPresent: Boolean(opts.authToken),
+    authTokenFile: opts.authTokenFile ? relativePath(opts.authTokenFile) : '',
+    userId: opts.userId || '',
+    skipAdminApi: opts.skipAdminApi,
+    envStatus,
+    health: healthResult,
+    auth,
+    workNotification,
+    failures,
+    nextCommands: failures.length === 0
+      ? [
+          'Run a controlled DingTalk group failure and verify the rule creator receives a work notification.',
+          'Run scripts/ops/dingtalk-group-failure-alert-probe.mjs with --acceptance --expect-person-status success.',
+        ]
+      : [
+          'Resolve the listed failures, then rerun this release gate.',
+          'If ENV_STATUS_BLOCKED reports agent-id-present, fill the private agent id file and run the apply helper.',
+        ],
+    notes: [
+      'This gate is read-only and does not call DingTalk or send messages.',
+      'Bearer token and credential values are never written to summaries.',
+    ],
+  }
+}
+
+function renderMarkdown(summary) {
+  const lines = [
+    '# DingTalk Work Notification Release Gate',
+    '',
+    `- Generated At: ${summary.generatedAt}`,
+    `- Status: \`${summary.status}\``,
+    `- API Base: \`${summary.apiBase}\``,
+    `- Env Files: ${summary.envFiles.length ? summary.envFiles.map((file) => `\`${file}\``).join(', ') : '`<none>`'}`,
+    `- Admin API Skipped: \`${summary.skipAdminApi}\``,
+    '',
+    '## Checks',
+    '',
+    `- Env Status: \`${summary.envStatus.overallStatus || '<unknown>'}\``,
+    `- Health: \`${summary.health.ok}\` (status ${summary.health.status})`,
+    `- Auth: \`${summary.auth.skipped ? 'skipped' : summary.auth.ok}\``,
+    `- Work Notification Available: \`${summary.workNotification.skipped ? 'skipped' : summary.workNotification.available}\``,
+    '',
+  ]
+
+  if (summary.failures.length > 0) {
+    lines.push('## Failures', '')
+    for (const failure of summary.failures) {
+      lines.push(`- \`${failure.code}\`: ${failure.message}`)
+    }
+    lines.push('')
+  }
+
+  lines.push('## Evidence', '')
+  lines.push(`- Env Status JSON: \`${summary.envStatus.outputJson}\``)
+  lines.push(`- Env Status MD: \`${summary.envStatus.outputMd}\``)
+  if (!summary.workNotification.skipped) {
+    lines.push(`- Work Notification Reason: \`${summary.workNotification.unavailableReason || '<none>'}\``)
+  }
+
+  lines.push('', '## Next Commands', '')
+  for (const command of summary.nextCommands) lines.push(`- ${command}`)
+
+  lines.push('', '## Notes', '')
+  for (const note of summary.notes) lines.push(`- ${note}`)
+
+  return `${lines.join('\n')}\n`
+}
+
+function writeOutputs(opts, summary) {
+  mkdirSync(path.dirname(opts.outputJson), { recursive: true })
+  mkdirSync(path.dirname(opts.outputMd), { recursive: true })
+  writeFileSync(opts.outputJson, `${JSON.stringify(redactDeep(summary), null, 2)}\n`, 'utf8')
+  writeFileSync(opts.outputMd, renderMarkdown(redactDeep(summary)), 'utf8')
+}
+
+try {
+  const opts = parseArgs(process.argv.slice(2))
+  const summary = await runGate(opts)
+  writeOutputs(opts, summary)
+  console.log(`DingTalk work-notification release gate: ${summary.status}; summary=${relativePath(opts.outputMd)}`)
+  if (summary.status !== 'pass' && !opts.allowBlocked) process.exitCode = 1
+} catch (error) {
+  console.error(redactString(error instanceof Error ? error.message : String(error)))
+  process.exit(1)
+}

--- a/scripts/ops/dingtalk-work-notification-release-gate.mjs
+++ b/scripts/ops/dingtalk-work-notification-release-gate.mjs
@@ -285,12 +285,7 @@ async function runGate(opts) {
   if (envStatus.exitCode !== 0) {
     addFailure(failures, 'ENV_STATUS_HELPER_FAILED', 'Env status helper failed', { exitCode: envStatus.exitCode })
   }
-  if (envStatus.overallStatus !== 'ready') {
-    addFailure(failures, 'ENV_STATUS_BLOCKED', 'DingTalk work-notification env status is not ready', {
-      overallStatus: envStatus.overallStatus,
-      missingInputs: envStatus.missingInputs.map((item) => item.id),
-    })
-  }
+  const envStatusBlocked = envStatus.overallStatus !== 'ready'
 
   const healthResult = readHealthResult(await fetchJson(opts, '/api/health'))
   if (!healthResult.ok) {
@@ -317,6 +312,17 @@ async function runGate(opts) {
     }
   }
 
+  const runtimeStatusOverridesEnvStatus = envStatusBlocked
+    && !workNotification.skipped
+    && workNotification.ok
+    && workNotification.available
+  if (envStatusBlocked && !runtimeStatusOverridesEnvStatus) {
+    addFailure(failures, 'ENV_STATUS_BLOCKED', 'DingTalk work-notification env status is not ready', {
+      overallStatus: envStatus.overallStatus,
+      missingInputs: envStatus.missingInputs.map((item) => item.id),
+    })
+  }
+
   return {
     tool: 'dingtalk-work-notification-release-gate',
     schemaVersion: SCHEMA_VERSION,
@@ -332,6 +338,7 @@ async function runGate(opts) {
     health: healthResult,
     auth,
     workNotification,
+    runtimeStatusOverridesEnvStatus,
     failures,
     nextCommands: failures.length === 0
       ? [
@@ -340,7 +347,7 @@ async function runGate(opts) {
         ]
       : [
           'Resolve the listed failures, then rerun this release gate.',
-          'If ENV_STATUS_BLOCKED reports agent-id-present, fill the private agent id file and run the apply helper.',
+          'If ENV_STATUS_BLOCKED reports agent-id-present, fill Agent ID in the admin directory page or the private agent id file, then rerun this gate.',
         ],
     notes: [
       'This gate is read-only and does not call DingTalk or send messages.',
@@ -362,6 +369,7 @@ function renderMarkdown(summary) {
     '## Checks',
     '',
     `- Env Status: \`${summary.envStatus.overallStatus || '<unknown>'}\``,
+    `- Runtime Status Overrides Env Status: \`${summary.runtimeStatusOverridesEnvStatus === true}\``,
     `- Health: \`${summary.health.ok}\` (status ${summary.health.status})`,
     `- Auth: \`${summary.auth.skipped ? 'skipped' : summary.auth.ok}\``,
     `- Work Notification Available: \`${summary.workNotification.skipped ? 'skipped' : summary.workNotification.available}\``,

--- a/scripts/ops/dingtalk-work-notification-release-gate.test.mjs
+++ b/scripts/ops/dingtalk-work-notification-release-gate.test.mjs
@@ -1,0 +1,266 @@
+import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { createServer } from 'node:http'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const scriptPath = path.join(repoRoot, 'scripts', 'ops', 'dingtalk-work-notification-release-gate.mjs')
+const statusHelperPath = path.join(repoRoot, 'scripts', 'ops', 'dingtalk-work-notification-env-status.mjs')
+
+function makeTmpDir() {
+  return mkdtempSync(path.join(tmpdir(), 'dingtalk-work-notification-release-gate-'))
+}
+
+function writeEnv(file, lines) {
+  writeFileSync(file, `${lines.join('\n')}\n`, 'utf8')
+}
+
+function readJson(file) {
+  return JSON.parse(readFileSync(file, 'utf8'))
+}
+
+function runScript(args) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [scriptPath, ...args], {
+      cwd: repoRoot,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.setEncoding('utf8')
+    child.stderr.setEncoding('utf8')
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk
+    })
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk
+    })
+    child.on('close', (code, signal) => {
+      resolve({ status: code, signal, stdout, stderr })
+    })
+  })
+}
+
+function jsonResponse(res, statusCode, payload) {
+  res.writeHead(statusCode, { 'content-type': 'application/json' })
+  res.end(JSON.stringify(payload))
+}
+
+async function withServer(handler, fn) {
+  const server = createServer(handler)
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve))
+  const address = server.address()
+  const apiBase = `http://127.0.0.1:${address.port}`
+  try {
+    return await fn(apiBase)
+  } finally {
+    await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()))
+  }
+}
+
+test('release gate passes when env, health, auth, and workNotification are ready', async () => {
+  const tmpDir = makeTmpDir()
+  const envFile = path.join(tmpDir, 'app.env')
+  const tokenFile = path.join(tmpDir, 'admin.jwt')
+  const outputJson = path.join(tmpDir, 'summary.json')
+  const outputMd = path.join(tmpDir, 'summary.md')
+  try {
+    writeEnv(envFile, [
+      'DINGTALK_APP_KEY=unit-key',
+      'DINGTALK_APP_SECRET=unit-secret',
+      'DINGTALK_AGENT_ID=123456789',
+    ])
+    writeFileSync(tokenFile, 'secret-admin-token\n', 'utf8')
+
+    await withServer((req, res) => {
+      if (req.url === '/api/health') return jsonResponse(res, 200, { status: 'ok', success: true })
+      if (req.url === '/api/auth/me') return jsonResponse(res, 200, { success: true, user: { role: 'admin', email: 'admin@example.test' } })
+      if (req.url === '/api/admin/users/user-1/dingtalk-access') {
+        return jsonResponse(res, 200, {
+          workNotification: {
+            configured: true,
+            available: true,
+            requirements: {
+              appKey: { configured: true, selectedKey: 'DINGTALK_APP_KEY' },
+              appSecret: { configured: true, selectedKey: 'DINGTALK_APP_SECRET' },
+              agentId: { configured: true, selectedKey: 'DINGTALK_AGENT_ID' },
+            },
+          },
+        })
+      }
+      return jsonResponse(res, 404, { error: 'not found' })
+    }, async (apiBase) => {
+      const result = await runScript([
+        '--env-file', envFile,
+        '--status-helper', statusHelperPath,
+        '--api-base', apiBase,
+        '--auth-token-file', tokenFile,
+        '--user-id', 'user-1',
+        '--output-json', outputJson,
+        '--output-md', outputMd,
+      ])
+
+      assert.equal(result.status, 0, result.stderr || result.stdout)
+      const summary = readJson(outputJson)
+      assert.equal(summary.status, 'pass')
+      assert.equal(summary.envStatus.overallStatus, 'ready')
+      assert.equal(summary.health.ok, true)
+      assert.equal(summary.auth.ok, true)
+      assert.equal(summary.workNotification.available, true)
+      assert.deepEqual(summary.failures, [])
+      assert.doesNotMatch(readFileSync(outputJson, 'utf8'), /secret-admin-token|unit-secret|123456789/)
+      assert.doesNotMatch(readFileSync(outputMd, 'utf8'), /secret-admin-token|unit-secret|123456789/)
+    })
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('release gate reports blocked when agent id is missing', async () => {
+  const tmpDir = makeTmpDir()
+  const envFile = path.join(tmpDir, 'app.env')
+  const tokenFile = path.join(tmpDir, 'admin.jwt')
+  const outputJson = path.join(tmpDir, 'summary.json')
+  const outputMd = path.join(tmpDir, 'summary.md')
+  try {
+    writeEnv(envFile, [
+      'DINGTALK_APP_KEY=unit-key',
+      'DINGTALK_APP_SECRET=unit-secret',
+    ])
+    writeFileSync(tokenFile, 'secret-admin-token\n', 'utf8')
+
+    await withServer((req, res) => {
+      if (req.url === '/api/health') return jsonResponse(res, 200, { status: 'ok', success: true })
+      if (req.url === '/api/auth/me') return jsonResponse(res, 200, { success: true, user: { role: 'admin' } })
+      if (req.url === '/api/admin/users/user-1/dingtalk-access') {
+        return jsonResponse(res, 200, {
+          workNotification: {
+            configured: false,
+            available: false,
+            unavailableReason: 'missing_agent_id',
+            requirements: { agentId: { configured: false, selectedKey: null } },
+          },
+        })
+      }
+      return jsonResponse(res, 404, { error: 'not found' })
+    }, async (apiBase) => {
+      const result = await runScript([
+        '--env-file', envFile,
+        '--status-helper', statusHelperPath,
+        '--api-base', apiBase,
+        '--auth-token-file', tokenFile,
+        '--user-id', 'user-1',
+        '--allow-blocked',
+        '--output-json', outputJson,
+        '--output-md', outputMd,
+      ])
+
+      assert.equal(result.status, 0, result.stderr || result.stdout)
+      const summary = readJson(outputJson)
+      assert.equal(summary.status, 'blocked')
+      assert.equal(summary.envStatus.overallStatus, 'blocked')
+      assert.deepEqual(summary.failures.map((failure) => failure.code), [
+        'ENV_STATUS_BLOCKED',
+        'WORK_NOTIFICATION_UNAVAILABLE',
+      ])
+      assert.match(readFileSync(outputMd, 'utf8'), /missing_agent_id/)
+      assert.doesNotMatch(readFileSync(outputJson, 'utf8'), /secret-admin-token|unit-secret/)
+    })
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('release gate redacts sensitive API error payloads', async () => {
+  const tmpDir = makeTmpDir()
+  const envFile = path.join(tmpDir, 'app.env')
+  const tokenFile = path.join(tmpDir, 'admin.jwt')
+  const outputJson = path.join(tmpDir, 'summary.json')
+  const outputMd = path.join(tmpDir, 'summary.md')
+  const leakedToken = 'robot-access-token-abcdef1234567890'
+  const leakedSecret = 'SEC' + '1234567890abcdef1234567890'
+  const leakedJwt = 'eyJ' + 'hbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.payload.signature'
+  try {
+    writeEnv(envFile, [
+      'DINGTALK_APP_KEY=unit-key',
+      'DINGTALK_APP_SECRET=unit-secret',
+      'DINGTALK_AGENT_ID=123456789',
+    ])
+    writeFileSync(tokenFile, 'secret-admin-token\n', 'utf8')
+
+    await withServer((req, res) => {
+      if (req.url === '/api/health') return jsonResponse(res, 200, { status: 'ok', success: true })
+      if (req.url === '/api/auth/me') {
+        return jsonResponse(res, 401, {
+          error: `expired Bearer ${leakedJwt} access_token=${leakedToken} ${leakedSecret}`,
+        })
+      }
+      return jsonResponse(res, 403, {
+        error: `blocked webhook https://${'oapi.dingtalk.com'}/robot/send?${'access' + '_token'}=${leakedToken}`,
+      })
+    }, async (apiBase) => {
+      const result = await runScript([
+        '--env-file', envFile,
+        '--status-helper', statusHelperPath,
+        '--api-base', apiBase,
+        '--auth-token-file', tokenFile,
+        '--user-id', 'user-1',
+        '--allow-blocked',
+        '--output-json', outputJson,
+        '--output-md', outputMd,
+      ])
+
+      assert.equal(result.status, 0, result.stderr || result.stdout)
+      const summaryText = readFileSync(outputJson, 'utf8')
+      const markdown = readFileSync(outputMd, 'utf8')
+      assert.doesNotMatch(summaryText, new RegExp(leakedToken))
+      assert.doesNotMatch(summaryText, new RegExp(leakedSecret))
+      assert.doesNotMatch(summaryText, new RegExp(leakedJwt.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
+      assert.doesNotMatch(markdown, new RegExp(leakedToken))
+      assert.doesNotMatch(markdown, new RegExp(leakedSecret))
+    })
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('release gate can skip admin API checks', async () => {
+  const tmpDir = makeTmpDir()
+  const envFile = path.join(tmpDir, 'app.env')
+  const outputJson = path.join(tmpDir, 'summary.json')
+  const outputMd = path.join(tmpDir, 'summary.md')
+  try {
+    writeEnv(envFile, [
+      'DINGTALK_APP_KEY=unit-key',
+      'DINGTALK_APP_SECRET=unit-secret',
+      'DINGTALK_AGENT_ID=123456789',
+    ])
+
+    await withServer((req, res) => {
+      if (req.url === '/api/health') return jsonResponse(res, 200, { status: 'ok', success: true })
+      return jsonResponse(res, 500, { error: 'admin API should not be called' })
+    }, async (apiBase) => {
+      const result = await runScript([
+        '--env-file', envFile,
+        '--status-helper', statusHelperPath,
+        '--api-base', apiBase,
+        '--skip-admin-api',
+        '--output-json', outputJson,
+        '--output-md', outputMd,
+      ])
+
+      assert.equal(result.status, 0, result.stderr || result.stdout)
+      const summary = readJson(outputJson)
+      assert.equal(summary.status, 'pass')
+      assert.equal(summary.skipAdminApi, true)
+      assert.equal(summary.auth.skipped, true)
+      assert.equal(summary.workNotification.skipped, true)
+    })
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})

--- a/scripts/ops/dingtalk-work-notification-release-gate.test.mjs
+++ b/scripts/ops/dingtalk-work-notification-release-gate.test.mjs
@@ -120,6 +120,63 @@ test('release gate passes when env, health, auth, and workNotification are ready
   }
 })
 
+test('release gate passes when env helper lacks Agent ID but backend runtime is available from stored config', async () => {
+  const tmpDir = makeTmpDir()
+  const envFile = path.join(tmpDir, 'app.env')
+  const tokenFile = path.join(tmpDir, 'admin.jwt')
+  const outputJson = path.join(tmpDir, 'summary.json')
+  const outputMd = path.join(tmpDir, 'summary.md')
+  try {
+    writeEnv(envFile, [
+      'DINGTALK_APP_KEY=unit-key',
+      'DINGTALK_APP_SECRET=unit-secret',
+    ])
+    writeFileSync(tokenFile, 'secret-admin-token\n', 'utf8')
+
+    await withServer((req, res) => {
+      if (req.url === '/api/health') return jsonResponse(res, 200, { status: 'ok', success: true })
+      if (req.url === '/api/auth/me') return jsonResponse(res, 200, { success: true, user: { role: 'admin', email: 'admin@example.test' } })
+      if (req.url === '/api/admin/users/user-1/dingtalk-access') {
+        return jsonResponse(res, 200, {
+          workNotification: {
+            configured: true,
+            available: true,
+            source: 'directory_integration',
+            requirements: {
+              appKey: { configured: true, selectedKey: 'DINGTALK_APP_KEY' },
+              appSecret: { configured: true, selectedKey: 'DINGTALK_APP_SECRET' },
+              agentId: { configured: true, selectedKey: 'directory_integrations.config.workNotificationAgentId' },
+            },
+          },
+        })
+      }
+      return jsonResponse(res, 404, { error: 'not found' })
+    }, async (apiBase) => {
+      const result = await runScript([
+        '--env-file', envFile,
+        '--status-helper', statusHelperPath,
+        '--api-base', apiBase,
+        '--auth-token-file', tokenFile,
+        '--user-id', 'user-1',
+        '--output-json', outputJson,
+        '--output-md', outputMd,
+      ])
+
+      assert.equal(result.status, 0, result.stderr || result.stdout)
+      const summary = readJson(outputJson)
+      assert.equal(summary.status, 'pass')
+      assert.equal(summary.envStatus.overallStatus, 'blocked')
+      assert.equal(summary.workNotification.available, true)
+      assert.equal(summary.runtimeStatusOverridesEnvStatus, true)
+      assert.deepEqual(summary.failures, [])
+      assert.match(readFileSync(outputMd, 'utf8'), /Runtime Status Overrides Env Status: `true`/)
+      assert.doesNotMatch(readFileSync(outputJson, 'utf8'), /secret-admin-token|unit-secret/)
+    })
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
 test('release gate reports blocked when agent id is missing', async () => {
   const tmpDir = makeTmpDir()
   const envFile = path.join(tmpDir, 'app.env')
@@ -163,10 +220,10 @@ test('release gate reports blocked when agent id is missing', async () => {
       const summary = readJson(outputJson)
       assert.equal(summary.status, 'blocked')
       assert.equal(summary.envStatus.overallStatus, 'blocked')
-      assert.deepEqual(summary.failures.map((failure) => failure.code), [
+      assert.deepEqual(summary.failures.map((failure) => failure.code).sort(), [
         'ENV_STATUS_BLOCKED',
         'WORK_NOTIFICATION_UNAVAILABLE',
-      ])
+      ].sort())
       assert.match(readFileSync(outputMd, 'utf8'), /missing_agent_id/)
       assert.doesNotMatch(readFileSync(outputJson, 'utf8'), /secret-admin-token|unit-secret/)
     })

--- a/scripts/validate-env.sh
+++ b/scripts/validate-env.sh
@@ -41,6 +41,30 @@ validate_required() {
     fi
 }
 
+validate_required_any() {
+    local description=$1
+    shift
+    local found_var=""
+
+    for var_name in "$@"; do
+        local var_value="${!var_name}"
+        if [ -n "$var_value" ]; then
+            found_var="$var_name"
+            break
+        fi
+    done
+
+    if [ -z "$found_var" ]; then
+        echo -e "${RED}❌ MISSING: one of $*${NC}"
+        echo -e "   ${description}"
+        MISSING_VARS+=("$*")
+        VALIDATION_FAILED=1
+    else
+        local found_value="${!found_var}"
+        echo -e "${GREEN}✅ ${found_var}${NC}: ${found_value:0:50}..."
+    fi
+}
+
 # Validation function with warning (optional but recommended)
 validate_recommended() {
     local var_name=$1
@@ -146,9 +170,10 @@ if [ -n "$FEISHU_APP_ID" ] || [ -n "$FEISHU_APP_SECRET" ]; then
     validate_required "FEISHU_APP_SECRET" "Feishu (Lark) application secret"
 fi
 
-if [ -n "$DINGTALK_APP_KEY" ] || [ -n "$DINGTALK_APP_SECRET" ]; then
-    validate_required "DINGTALK_APP_KEY" "DingTalk application key"
-    validate_required "DINGTALK_APP_SECRET" "DingTalk application secret"
+if [ -n "$DINGTALK_APP_KEY" ] || [ -n "$DINGTALK_APP_SECRET" ] || [ -n "$DINGTALK_CLIENT_ID" ] || [ -n "$DINGTALK_CLIENT_SECRET" ] || [ -n "$DINGTALK_AGENT_ID" ] || [ -n "$DINGTALK_NOTIFY_AGENT_ID" ]; then
+    validate_required_any "DingTalk application key for OAuth and work notifications" "DINGTALK_APP_KEY" "DINGTALK_CLIENT_ID"
+    validate_required_any "DingTalk application secret for OAuth and work notifications" "DINGTALK_APP_SECRET" "DINGTALK_CLIENT_SECRET"
+    validate_required_any "DingTalk work-notification agent id for direct messages and rule-creator failure alerts" "DINGTALK_AGENT_ID" "DINGTALK_NOTIFY_AGENT_ID"
 fi
 
 if [ -n "$WECHAT_WORK_CORP_ID" ] || [ -n "$WECHAT_WORK_SECRET" ]; then


### PR DESCRIPTION
## Summary
- add DingTalk work-notification Agent ID runtime status, admin test/save APIs, and directory-management UI
- add release gate and admin acceptance helper with redacted output
- document 142 GHCR release, disk cleanup, rollback baseline, and remaining real Agent ID acceptance step

## Verification
- node --check scripts/ops/dingtalk-work-notification-admin-agent-id.mjs
- node --test scripts/ops/dingtalk-work-notification-admin-agent-id.test.mjs
- node --test scripts/ops/dingtalk-work-notification-release-gate.test.mjs
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dingtalk-work-notification-settings.test.ts tests/unit/admin-directory-routes.test.ts tests/unit/directory-sync-work-notification-agent-id.test.ts --run
- pnpm --filter @metasheet/web exec vitest run tests/directoryManagementView.spec.ts --run
- pnpm --filter @metasheet/core-backend build
- pnpm --filter @metasheet/web build
- GHCR build run 25535508861 succeeded for image tag 9e17038871ff4a0cbdb32d8c816692f10d1f92cb
- 142 backend/web manually deployed to 9e17038871ff4a0cbdb32d8c816692f10d1f92cb; health 200 and web 200

## Notes
- 142 private Agent ID file exists but is empty; save probe correctly blocks with AGENT_ID_FILE_EMPTY
- no secrets, webhook URLs, Agent ID values, or admin JWTs are included