### PR TITLE
test(multitable): add RC staging remote verification harness

### DIFF
--- a/docs/development/multitable-rc-staging-smoke-development-20260507.md
+++ b/docs/development/multitable-rc-staging-smoke-development-20260507.md
@@ -17,7 +17,7 @@ For the RC closeout we need an automated, browser-free, fail-loud harness agains
 
 - New script `scripts/verify-multitable-rc-staging-smoke.mjs` (~510 LOC) covering seven checks against any deployed multitable backend reachable at `${API_BASE}` with an admin Bearer token at `${AUTH_TOKEN}`:
   1. `lifecycle` — base/sheet/field/view/record + GET records readback
-  2. `public-form` — admin enables `accessMode: 'public'`, anonymous `POST /views/:viewId/submit` with the issued `publicToken`, admin verifies persisted record; plus a stale-token negative
+  2. `public-form` — admin enables `accessMode: 'public'`, anonymous `POST /views/:viewId/submit` with the issued `publicToken`, admin verifies persisted record; then regenerates the token and asserts the old token returns 401 while the new token can submit and persist a second record
   3. `hierarchy` — self-table single-value link parent + PATCH self-parent → 400 + `error.code === 'HIERARCHY_CYCLE'`
   4. `gantt-config` — gantt view PATCH with non-link `dependencyFieldId` → 400 + `VALIDATION_ERROR` + message contains `self-table link field`
   5. `formula` — formula field with `={A.id}+{B.id}` expression + GET fields verifies persisted property
@@ -26,6 +26,7 @@ For the RC closeout we need an automated, browser-free, fail-loud harness agains
 - New package.json script `verify:multitable-rc:staging` that invokes the harness via `node scripts/...mjs`.
 - Outputs `report.json` + `report.md` under `${OUTPUT_DIR}` (default `output/multitable-rc-staging-smoke`). Each row records pass/fail/skip + duration; failures include a stack-printable error string. Exit code 0 = all pass, 1 = at least one fail, 2 = env / fatal before any check ran.
 - Supports `SKIP=automation-email,autoNumber-backfill` env to skip specific checks (useful when the staging deployment hasn't yet caught up to the latest perf merge).
+- `API_BASE` is validated before use and rejected if it contains embedded credentials, query params, or a URL fragment. Reports include the normalized API URL, so this avoids writing secret-bearing URLs to `report.json` / `report.md`.
 
 ### Out
 

--- a/docs/development/multitable-rc-staging-smoke-development-20260507.md
+++ b/docs/development/multitable-rc-staging-smoke-development-20260507.md
@@ -1,0 +1,91 @@
+# Multitable RC Staging Smoke — Remote Verification Harness · Development
+
+> Date: 2026-05-07
+> Branch: `codex/multitable-rc-staging-smoke-20260507`
+> Base: `origin/main@20fb5270a` (after the autoNumber backfill perf merge)
+> Scope: RC validation tooling, not a feature change. Fits the bugfix-only window opened for the RC closeout.
+
+## Background
+
+The local Playwright specs at `packages/core-backend/tests/e2e/multitable-*-smoke.spec.ts` cover the six RC TODO smoke surfaces against a local dev stack and skip when servers are unreachable. They do not run against a deployed staging URL, and the existing `scripts/verify-multitable-live-smoke.mjs` (3 644 lines, Playwright + browser) does not cover the recent RC additions — a grep confirmed zero hits for `send_email`, `autoNumber`, `hierarchy` cycle guard, `dependencyFieldId`, or `publicForm` / `publicToken` / `public-form` in that file.
+
+For the RC closeout we need an automated, browser-free, fail-loud harness against the deployed staging that exercises the RC surfaces and produces a report operators can pin to a release decision. This PR adds it.
+
+## Scope
+
+### In
+
+- New script `scripts/verify-multitable-rc-staging-smoke.mjs` (~510 LOC) covering seven checks against any deployed multitable backend reachable at `${API_BASE}` with an admin Bearer token at `${AUTH_TOKEN}`:
+  1. `lifecycle` — base/sheet/field/view/record + GET records readback
+  2. `public-form` — admin enables `accessMode: 'public'`, anonymous `POST /views/:viewId/submit` with the issued `publicToken`, admin verifies persisted record; plus a stale-token negative
+  3. `hierarchy` — self-table single-value link parent + PATCH self-parent → 400 + `error.code === 'HIERARCHY_CYCLE'`
+  4. `gantt-config` — gantt view PATCH with non-link `dependencyFieldId` → 400 + `VALIDATION_ERROR` + message contains `self-table link field`
+  5. `formula` — formula field with `={A.id}+{B.id}` expression + GET fields verifies persisted property
+  6. `automation-email` — `record.created` → `send_email` rule + creating a record fires the real event chain → poll `/logs?limit=10` (default 12 s timeout, 1 s interval) → assert `execution.status === 'success'`, `step.actionType === 'send_email'`, `step.status === 'success'`, `step.output.recipientCount === 2`, `step.output.notificationStatus === 'sent'`
+  7. `autoNumber-backfill` — pre-create 3 records, then add an `autoNumber` field with `start: 1000, prefix: 'INV-', digits: 4` → assert all 3 pre-existing records receive backfilled values, raw client write returns 403 + `FIELD_READONLY`, and a post-backfill record receives `value >= start + 3`
+- New package.json script `verify:multitable-rc:staging` that invokes the harness via `node scripts/...mjs`.
+- Outputs `report.json` + `report.md` under `${OUTPUT_DIR}` (default `output/multitable-rc-staging-smoke`). Each row records pass/fail/skip + duration; failures include a stack-printable error string. Exit code 0 = all pass, 1 = at least one fail, 2 = env / fatal before any check ran.
+- Supports `SKIP=automation-email,autoNumber-backfill` env to skip specific checks (useful when the staging deployment hasn't yet caught up to the latest perf merge).
+
+### Out
+
+- Browser-driven UI clicks. The companion human-smoke pass and Codex's RC checklist exercise the click-driven flows; this harness is the API-layer net.
+- Real SMTP delivery validation. The default `EmailNotificationChannel` mocks the send and returns `notificationStatus === 'sent'`; the harness validates the wire, not actual mail receipt.
+- DingTalk-protected public form access modes. The lifecycle / public-form smokes already cover the `'public'` access mode; protected modes belong to a separate harness.
+- The legacy `verify-multitable-live-smoke.mjs`. That script is a 3 644-line Playwright harness covering different (and earlier) surfaces; this PR does not modify it.
+
+## K3 PoC Stage 1 Lock applicability
+
+- Does NOT modify `plugins/plugin-integration-core/*`.
+- Pure RC validation tooling — no user-facing feature change, no migration, no OpenAPI change. Fits the explicit "bugfix-only window for RC" framing.
+- Does NOT touch DingTalk / public-form runtime / Gantt / Hierarchy / formula / automation runtime; only consumes existing public REST endpoints.
+
+## Implementation notes
+
+### Why a dedicated script instead of extending `verify-multitable-live-smoke.mjs`
+
+That script is 3 644 lines of Playwright + browser. Adding seven HTTP-only checks to it means either (a) splitting its top-level runner to support a "no-browser" mode, or (b) leaving the new checks coupled to a Playwright dependency that the harness doesn't need. A clean separate script is small (~510 LOC), independent, and can be invoked from CI or operators without spinning up a browser.
+
+### Why `node:fetch` and not `node-fetch` or axios
+
+Node 18+ ships `fetch` in the global. The repo's CI matrix (per `package.json` engines + the existing 18.x/20.x test matrix) is comfortably above that. No new dep.
+
+### Why each check creates its own base + sheet
+
+Tests must be hermetic against staging fixture drift. Each check uses `uniqueLabel('<surface>')` with a process-wide `stamp` + per-check random suffix; collisions between concurrent runs are negligible. The fixtures persist after the run (matching the existing pilot-smoke convention) — operators can inspect them post-failure.
+
+### Why `automation-email` polls `/logs` rather than calling `/test`
+
+The user brief on the `send_email` smoke explicitly required the real event chain: a `record.created` event must drive the executor, not a synthetic `/test` invocation. The same constraint applies to staging validation. The polling window is configurable via `POLL_TIMEOUT_MS` and `POLL_INTERVAL_MS`; the defaults (12 s / 1 s) match the local Playwright spec.
+
+### Why the `autoNumber-backfill` check pre-creates records
+
+The check value-add is verifying that adding an `autoNumber` field to a sheet that already has data does the backfill. The PR #1431 perf change collapsed the N+1 UPDATE into a single window-function UPDATE; staging validation should confirm the resulting backfill is observable through the public API. Three records is enough to assert "all pre-existing records receive a value" without bloating the smoke.
+
+### Why exit codes 0 / 1 / 2 are distinct
+
+Operators wrap this in deploy gates. Distinguishing "env not configured" (exit 2) from "checks ran and failed" (exit 1) lets the gate either block the rollout (1) or surface a configuration issue (2) with different alert paths.
+
+## Files changed
+
+| File | Lines |
+|---|---|
+| `scripts/verify-multitable-rc-staging-smoke.mjs` | +new (~510) |
+| `package.json` | +1 (script entry `verify:multitable-rc:staging`) |
+| `docs/development/multitable-rc-staging-smoke-development-20260507.md` | +new |
+| `docs/development/multitable-rc-staging-smoke-verification-20260507.md` | +new |
+
+## Known limitations
+
+1. **Fixtures are not cleaned up** — matches the existing pilot-smoke convention; timestamp + random suffix prevents collisions.
+2. **Single-tenant assumption** — the script uses a single AUTH_TOKEN to act as the operator. Multi-tenant scenarios require separate runs with different tokens.
+3. **No real SMTP** — `notificationStatus === 'sent'` proves the channel returned, not that an inbox received the message.
+4. **Polling deadline of 12 s** — heavy staging load can push automation execution beyond this. The error path includes the last logs body for diagnostic context; raise `POLL_TIMEOUT_MS` if false-fails appear under load.
+5. **DingTalk-protected access modes uncovered** — accessMode `'dingtalk'` and `'dingtalk_granted'` need DingTalk corp tenant fixtures; out of scope.
+
+## Cross-references
+
+- RC TODO master: `docs/development/multitable-feishu-rc-todo-20260430.md`
+- Companion local Playwright specs: `packages/core-backend/tests/e2e/multitable-*-smoke.spec.ts`
+- Existing live-smoke harness (different scope, not modified): `scripts/verify-multitable-live-smoke.mjs`
+- Existing pilot-smoke harness (Playwright-based): `scripts/ops/multitable-pilot-staging.sh`

--- a/docs/development/multitable-rc-staging-smoke-verification-20260507.md
+++ b/docs/development/multitable-rc-staging-smoke-verification-20260507.md
@@ -1,0 +1,117 @@
+# Multitable RC Staging Smoke — Remote Verification Harness · Verification
+
+> Date: 2026-05-07
+> Companion to: `multitable-rc-staging-smoke-development-20260507.md`
+
+## Syntax check
+
+```bash
+node --check scripts/verify-multitable-rc-staging-smoke.mjs
+```
+
+Result: passes (no output / exit 0).
+
+## package.json validity
+
+```bash
+node -e "JSON.parse(require('fs').readFileSync('package.json','utf8'))"
+grep -n 'verify:multitable-rc:staging' package.json
+```
+
+Result: parses; entry registered at line 48.
+
+## Dry-run against unreachable URL (loud-failure validation)
+
+The script does not have access to a real staging cluster from this worktree, but the runtime structure is validated by pointing it at a closed local port and confirming each check fails with a clear error and the report is written.
+
+```bash
+AUTH_TOKEN=fake-token \
+API_BASE=http://127.0.0.1:1 \
+OUTPUT_DIR=/tmp/rc-smoke-fake-test \
+node scripts/verify-multitable-rc-staging-smoke.mjs
+```
+
+Result (truncated):
+
+```
+[rc-smoke] FAIL lifecycle (11ms): fetch failed
+[rc-smoke] FAIL public-form (0ms): fetch failed
+[rc-smoke] FAIL hierarchy (0ms): fetch failed
+[rc-smoke] FAIL gantt-config (0ms): fetch failed
+[rc-smoke] FAIL formula (0ms): fetch failed
+[rc-smoke] FAIL automation-email (0ms): fetch failed
+[rc-smoke] FAIL autoNumber-backfill (1ms): fetch failed
+[rc-smoke] report json: /tmp/rc-smoke-fake-test/report.json
+[rc-smoke] report md:   /tmp/rc-smoke-fake-test/report.md
+[rc-smoke] result: 0 pass / 7 fail / 0 skip / 7 total
+```
+
+`report.md` excerpt:
+
+```
+# Multitable RC Staging Smoke Report
+
+- API: `http://127.0.0.1:1`
+- Started: 2026-05-08T05:26:23.794Z
+- Finished: 2026-05-08T05:26:23.807Z
+- Total: 7 (pass=0, fail=7, skip=0)
+
+| Check | Status | Duration |
+| --- | --- | --- |
+| lifecycle | fail | 11ms |
+| public-form | fail | 0ms |
+| ...
+```
+
+Confirms:
+- All seven checks are registered and iterated
+- Errors are caught per-check (no early termination)
+- Both `report.json` and `report.md` are written
+- Exit code is non-zero on any failure (verified via `&&`-chain semantics in the dry-run)
+
+## Diff hygiene
+
+```bash
+git diff --check
+```
+
+Result: passes.
+
+## Scoped diff
+
+- `scripts/verify-multitable-rc-staging-smoke.mjs` — new harness
+- `package.json` — `verify:multitable-rc:staging` script entry
+- `docs/development/multitable-rc-staging-smoke-development-20260507.md` — new
+- `docs/development/multitable-rc-staging-smoke-verification-20260507.md` — new
+
+## Operational usage
+
+```bash
+AUTH_TOKEN=$(cat /tmp/metasheet-staging-admin.jwt) \
+API_BASE=http://142.171.239.56:8081 \
+pnpm verify:multitable-rc:staging
+```
+
+Outputs land at `output/multitable-rc-staging-smoke/{report.json,report.md}` by default. Operator pins these to the release decision artifact. For a partial run that excludes the slowest check, use:
+
+```bash
+SKIP=automation-email pnpm verify:multitable-rc:staging
+```
+
+## What is NOT validated by this PR
+
+- A real staging cluster run. The dry-run against an unreachable port proves the runtime structure; running the harness against `142` requires a fresh admin JWT that this PR does not include.
+- Real SMTP / mail receipt. `notificationStatus === 'sent'` is the channel-result contract that the spec asserts; the underlying default `EmailNotificationChannel` is a mock.
+- DingTalk-protected public-form access modes (`'dingtalk'` / `'dingtalk_granted'`).
+- UI / browser interaction layers (Codex's RC checklist + the human smoke pass cover those).
+
+## Pre-deployment checks
+
+- [x] No DingTalk / public-form runtime / `plugins/plugin-integration-core/*` files touched.
+- [x] No migration / OpenAPI / route additions.
+- [x] No new env vars beyond what operators must already know about (AUTH_TOKEN / API_BASE pattern matches the existing `verify-multitable-live-smoke.mjs`).
+- [x] Branch rebased onto `origin/main@20fb5270a` before push.
+
+## Result
+
+Script syntax-clean, package.json valid, dry-run produces clean reports + correct exit code. Ready to run against the deployed RC staging by the operator/Codex during the RC validation window.

--- a/docs/development/multitable-rc-staging-smoke-verification-20260507.md
+++ b/docs/development/multitable-rc-staging-smoke-verification-20260507.md
@@ -69,6 +69,24 @@ Confirms:
 - Both `report.json` and `report.md` are written
 - Exit code is non-zero on any failure (verified via `&&`-chain semantics in the dry-run)
 
+## Codex review hardening
+
+During review, Codex tightened two details before merge:
+
+- `lifecycle` now creates the grid view it claimed to cover and returns `viewId` in evidence. The original draft created base/sheet/field/record but not a view, which made the report over-state lifecycle coverage.
+- `public-form` now tests real token rotation rather than a hard-coded invalid token: initial token submits successfully, regenerated old token returns 401, and the new token also submits and persists a second record.
+- `API_BASE` is now parsed and rejected when it contains embedded credentials, query params, or a URL fragment, so secret-bearing URLs cannot be written into `report.json` / `report.md`.
+
+Additional syntax guard for the URL validation path:
+
+```bash
+AUTH_TOKEN=fake-token \
+API_BASE='http://user:pass@127.0.0.1:1?token=secret' \
+node scripts/verify-multitable-rc-staging-smoke.mjs
+```
+
+Result: exits 2 with `API_BASE must not contain credentials, query, or fragment`.
+
 ## Diff hygiene
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "verify:multitable-pilot:local": "bash scripts/ops/multitable-pilot-local.sh",
     "verify:multitable-pilot:local:test": "node --test scripts/ops/multitable-pilot-local.test.mjs",
     "verify:multitable-pilot:staging": "bash scripts/ops/multitable-pilot-staging.sh",
+    "verify:multitable-rc:staging": "node scripts/verify-multitable-rc-staging-smoke.mjs",
     "verify:multitable-pilot:staging:test": "node --test scripts/ops/multitable-pilot-staging.test.mjs",
     "verify:multitable-pilot:readiness": "node scripts/ops/multitable-pilot-readiness.mjs",
     "verify:multitable-pilot:readiness:test": "node --test scripts/ops/multitable-pilot-readiness.test.mjs",

--- a/scripts/verify-multitable-rc-staging-smoke.mjs
+++ b/scripts/verify-multitable-rc-staging-smoke.mjs
@@ -1,0 +1,536 @@
+#!/usr/bin/env node
+/**
+ * Multitable RC Staging Smoke — automated remote verification.
+ *
+ * Pure HTTP harness (no Playwright / no browser) covering the six
+ * RC TODO smoke surfaces against a deployed multitable backend:
+ *
+ *   1. lifecycle           — create base/sheet/field/view/record + GET records
+ *   2. public-form         — admin enable accessMode='public' + anonymous submit + admin verify persisted
+ *   3. hierarchy           — self-table link parent field + PATCH self-parent → 400 + HIERARCHY_CYCLE
+ *   4. gantt-config        — gantt view with non-link dependencyFieldId → 400 + VALIDATION_ERROR + self-table link msg
+ *   5. formula             — formula field with `={A.id}+{B.id}` expression + verify persisted property
+ *   6. automation-email    — record.created → send_email rule + create record + poll /logs ≤12s + assert step shape
+ *   7. autoNumber-backfill — autoNumber field on existing-records sheet + verify backfilled values
+ *
+ * The harness does NOT trigger real SMTP — the default
+ * EmailNotificationChannel mocks the send and returns
+ * notificationStatus='sent', so the smoke validates the wire
+ * without depending on mail infrastructure.
+ *
+ * Companion to the local Playwright specs at
+ * `packages/core-backend/tests/e2e/multitable-*-smoke.spec.ts`. The
+ * Playwright specs run against a local dev stack and skip when
+ * unreachable; this script runs against a deployed staging URL and
+ * fails-loud (non-zero exit) when checks miss.
+ *
+ * Env (all read from process.env):
+ *   API_BASE         http://host:port — required, no trailing slash
+ *   AUTH_TOKEN       Bearer token of an admin-capable user — required
+ *   OUTPUT_DIR       directory for report artifacts (default output/multitable-rc-staging-smoke)
+ *   REPORT_JSON      report.json path (default <OUTPUT_DIR>/report.json)
+ *   REPORT_MD        report.md path (default <OUTPUT_DIR>/report.md)
+ *   POLL_TIMEOUT_MS  send_email log poll timeout (default 12000)
+ *   POLL_INTERVAL_MS send_email log poll interval (default 1000)
+ *   SKIP             comma-separated check names to skip (e.g. SKIP=automation-email)
+ *
+ * Exit codes:
+ *   0 — all selected checks passed
+ *   1 — at least one check failed
+ *   2 — env / fatal error before any check ran
+ *
+ * Usage:
+ *   AUTH_TOKEN=<jwt> API_BASE=http://142.171.239.56:8081 \
+ *     node scripts/verify-multitable-rc-staging-smoke.mjs
+ */
+
+import { mkdirSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+
+const apiBase = (process.env.API_BASE || '').replace(/\/+$/, '')
+const authToken = process.env.AUTH_TOKEN || ''
+const outputDir = process.env.OUTPUT_DIR || 'output/multitable-rc-staging-smoke'
+const reportJsonPath = process.env.REPORT_JSON || path.join(outputDir, 'report.json')
+const reportMdPath = process.env.REPORT_MD || path.join(outputDir, 'report.md')
+const pollTimeoutMs = Number(process.env.POLL_TIMEOUT_MS || 12000)
+const pollIntervalMs = Number(process.env.POLL_INTERVAL_MS || 1000)
+const skipSet = new Set(
+  (process.env.SKIP || '')
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean),
+)
+
+if (!apiBase) {
+  console.error('[rc-smoke] API_BASE env is required (e.g. http://142.171.239.56:8081)')
+  process.exit(2)
+}
+if (!authToken) {
+  console.error('[rc-smoke] AUTH_TOKEN env is required (Bearer token of an admin user)')
+  process.exit(2)
+}
+
+mkdirSync(outputDir, { recursive: true })
+
+const authHeaders = {
+  Authorization: `Bearer ${authToken}`,
+  'Content-Type': 'application/json',
+}
+
+const stamp = `${Date.now()}-${Math.floor(Math.random() * 10000)}`
+const uniqueLabel = (prefix) => `rc-${prefix}-${stamp}-${Math.floor(Math.random() * 1000)}`
+
+async function authPost(path, body) {
+  const res = await fetch(`${apiBase}${path}`, {
+    method: 'POST',
+    headers: authHeaders,
+    body: JSON.stringify(body ?? {}),
+  })
+  let json = null
+  try { json = await res.json() } catch {}
+  if (!res.ok) {
+    throw new Error(`POST ${path} → ${res.status}: ${JSON.stringify(json)}`)
+  }
+  return json
+}
+
+async function authPostExpectingFailure(path, body) {
+  const res = await fetch(`${apiBase}${path}`, {
+    method: 'POST',
+    headers: authHeaders,
+    body: JSON.stringify(body ?? {}),
+  })
+  let json = null
+  try { json = await res.json() } catch {}
+  return { status: res.status, body: json }
+}
+
+async function authPatch(path, body) {
+  const res = await fetch(`${apiBase}${path}`, {
+    method: 'PATCH',
+    headers: authHeaders,
+    body: JSON.stringify(body ?? {}),
+  })
+  let json = null
+  try { json = await res.json() } catch {}
+  if (!res.ok) {
+    throw new Error(`PATCH ${path} → ${res.status}: ${JSON.stringify(json)}`)
+  }
+  return json
+}
+
+async function authPatchExpectingFailure(path, body) {
+  const res = await fetch(`${apiBase}${path}`, {
+    method: 'PATCH',
+    headers: authHeaders,
+    body: JSON.stringify(body ?? {}),
+  })
+  let json = null
+  try { json = await res.json() } catch {}
+  return { status: res.status, body: json }
+}
+
+async function authGet(path) {
+  const res = await fetch(`${apiBase}${path}`, { method: 'GET', headers: authHeaders })
+  let json = null
+  try { json = await res.json() } catch {}
+  if (!res.ok) {
+    throw new Error(`GET ${path} → ${res.status}: ${JSON.stringify(json)}`)
+  }
+  return json
+}
+
+async function anonPost(path, body) {
+  const res = await fetch(`${apiBase}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body ?? {}),
+  })
+  let json = null
+  try { json = await res.json() } catch {}
+  return { status: res.status, ok: res.ok, body: json }
+}
+
+function requireValue(value, label) {
+  if (value === undefined || value === null || value === '') {
+    throw new Error(`Expected ${label} in API response`)
+  }
+  return value
+}
+
+async function createBase(name) {
+  return requireValue((await authPost('/api/multitable/bases', { name })).data?.base, 'base')
+}
+
+async function createSheet(baseId, name) {
+  return requireValue((await authPost('/api/multitable/sheets', { baseId, name })).data?.sheet, 'sheet')
+}
+
+async function createField(sheetId, name, type, property) {
+  const body = { sheetId, name, type }
+  if (property) body.property = property
+  return requireValue((await authPost('/api/multitable/fields', body)).data?.field, `${type} field ${name}`)
+}
+
+async function createView(sheetId, name, type, config) {
+  const body = { sheetId, name }
+  if (type) body.type = type
+  if (config) body.config = config
+  return requireValue((await authPost('/api/multitable/views', body)).data?.view, `${type ?? 'grid'} view ${name}`)
+}
+
+async function createRecord(sheetId, data) {
+  return requireValue((await authPost('/api/multitable/records', { sheetId, data })).data?.record, 'record')
+}
+
+const checks = []
+
+function registerCheck(name, fn) {
+  checks.push({ name, fn })
+}
+
+// ── 1. lifecycle ────────────────────────────────────────────────────────────
+
+registerCheck('lifecycle', async () => {
+  const label = uniqueLabel('lifecycle')
+  const base = await createBase(`${label}-base`)
+  const sheet = await createSheet(base.id, `${label}-sheet`)
+  const field = await createField(sheet.id, 'Title', 'string')
+  const cellValue = `lifecycle-${stamp}`
+  const record = await createRecord(sheet.id, { [field.id]: cellValue })
+  if (record.data?.[field.id] !== cellValue) {
+    throw new Error(`Created record value mismatch: expected '${cellValue}', got '${record.data?.[field.id]}'`)
+  }
+  const recordsBody = await authGet(`/api/multitable/records?sheetId=${sheet.id}`)
+  const rows = recordsBody.data?.records ?? []
+  const persisted = rows.find((row) => row.id === record.id)
+  if (!persisted) throw new Error(`Record ${record.id} not visible via GET /records`)
+  if (persisted.data?.[field.id] !== cellValue) {
+    throw new Error(`Record value drift after read-back: '${persisted.data?.[field.id]}'`)
+  }
+  return { sheetId: sheet.id, recordId: record.id, fieldId: field.id }
+})
+
+// ── 2. public-form ──────────────────────────────────────────────────────────
+
+registerCheck('public-form', async () => {
+  const label = uniqueLabel('pf')
+  const base = await createBase(`${label}-base`)
+  const sheet = await createSheet(base.id, `${label}-sheet`)
+  const field = await createField(sheet.id, 'Title', 'string')
+  const view = await createView(sheet.id, 'Default Grid', 'grid')
+
+  const shareBody = await authPatch(
+    `/api/multitable/sheets/${sheet.id}/views/${view.id}/form-share`,
+    { enabled: true, accessMode: 'public' },
+  )
+  const publicToken = requireValue(shareBody.data?.publicToken, 'publicToken')
+
+  const submitValue = `pf-anon-${stamp}`
+  const submit = await anonPost(`/api/multitable/views/${view.id}/submit`, {
+    publicToken,
+    data: { [field.id]: submitValue },
+  })
+  if (!submit.ok) throw new Error(`Anonymous submit failed: ${submit.status} ${JSON.stringify(submit.body)}`)
+  const newRecordId = requireValue(submit.body?.data?.record?.id, 'submitted record id')
+
+  const recordsBody = await authGet(`/api/multitable/records?sheetId=${sheet.id}`)
+  const persisted = (recordsBody.data?.records ?? []).find((row) => row.id === newRecordId)
+  if (!persisted) throw new Error(`Submitted record ${newRecordId} not visible to admin`)
+  if (persisted.data?.[field.id] !== submitValue) {
+    throw new Error(`Submitted value drift: '${persisted.data?.[field.id]}'`)
+  }
+
+  // Negative: stale token must reject
+  const stale = await anonPost(`/api/multitable/views/${view.id}/submit`, {
+    publicToken: 'definitely-not-the-real-token',
+    data: { [field.id]: 'should-not-persist' },
+  })
+  if (stale.status !== 401) {
+    throw new Error(`Expected 401 for stale-token anonymous submit; got ${stale.status}`)
+  }
+  return { sheetId: sheet.id, viewId: view.id, recordId: newRecordId }
+})
+
+// ── 3. hierarchy ────────────────────────────────────────────────────────────
+
+registerCheck('hierarchy', async () => {
+  const label = uniqueLabel('h')
+  const base = await createBase(`${label}-base`)
+  const sheet = await createSheet(base.id, `${label}-sheet`)
+  const title = await createField(sheet.id, 'Title', 'string')
+  const parent = await createField(sheet.id, 'Parent', 'link', {
+    foreignSheetId: sheet.id,
+    limitSingleRecord: true,
+  })
+  await createView(sheet.id, 'Hierarchy', 'hierarchy', { parentFieldId: parent.id })
+
+  const record = await createRecord(sheet.id, { [title.id]: 'self-loop-candidate' })
+  const fail = await authPatchExpectingFailure(`/api/multitable/records/${record.id}`, {
+    sheetId: sheet.id,
+    data: { [parent.id]: [record.id] },
+  })
+  if (fail.status !== 400) {
+    throw new Error(`Self-parent PATCH expected 400, got ${fail.status}: ${JSON.stringify(fail.body)}`)
+  }
+  if (fail.body?.error?.code !== 'HIERARCHY_CYCLE') {
+    throw new Error(`Expected error.code 'HIERARCHY_CYCLE', got '${fail.body?.error?.code}'`)
+  }
+  return { sheetId: sheet.id, parentFieldId: parent.id, recordId: record.id }
+})
+
+// ── 4. gantt-config ─────────────────────────────────────────────────────────
+
+registerCheck('gantt-config', async () => {
+  const label = uniqueLabel('g')
+  const base = await createBase(`${label}-base`)
+  const sheet = await createSheet(base.id, `${label}-sheet`)
+  const title = await createField(sheet.id, 'Title', 'string')
+  const startField = await createField(sheet.id, 'Start', 'date')
+  const endField = await createField(sheet.id, 'End', 'date')
+  const view = await createView(sheet.id, 'Gantt', 'gantt', {
+    startFieldId: startField.id,
+    endFieldId: endField.id,
+    titleFieldId: title.id,
+  })
+
+  // Non-link dependencyFieldId must be rejected by validateGanttDependencyConfig.
+  const fail = await authPatchExpectingFailure(`/api/multitable/views/${view.id}`, {
+    sheetId: sheet.id,
+    type: 'gantt',
+    config: {
+      startFieldId: startField.id,
+      endFieldId: endField.id,
+      titleFieldId: title.id,
+      dependencyFieldId: title.id,
+    },
+  })
+  if (fail.status !== 400) {
+    throw new Error(`Non-link dependency PATCH expected 400, got ${fail.status}: ${JSON.stringify(fail.body)}`)
+  }
+  if (fail.body?.error?.code !== 'VALIDATION_ERROR') {
+    throw new Error(`Expected error.code 'VALIDATION_ERROR', got '${fail.body?.error?.code}'`)
+  }
+  if (typeof fail.body?.error?.message !== 'string' || !fail.body.error.message.includes('self-table link field')) {
+    throw new Error(`Expected error.message to contain 'self-table link field', got '${fail.body?.error?.message}'`)
+  }
+  return { sheetId: sheet.id, viewId: view.id }
+})
+
+// ── 5. formula ──────────────────────────────────────────────────────────────
+
+registerCheck('formula', async () => {
+  const label = uniqueLabel('f')
+  const base = await createBase(`${label}-base`)
+  const sheet = await createSheet(base.id, `${label}-sheet`)
+  const numA = await createField(sheet.id, 'A', 'number')
+  const numB = await createField(sheet.id, 'B', 'number')
+  const expression = `={${numA.id}} + {${numB.id}}`
+  const formula = await createField(sheet.id, 'Sum', 'formula', { expression })
+
+  const fieldsBody = await authGet(`/api/multitable/fields?sheetId=${sheet.id}`)
+  const fields = fieldsBody.data?.fields ?? []
+  const persisted = fields.find((f) => f.id === formula.id)
+  if (!persisted) throw new Error(`Formula field ${formula.id} not in field list`)
+  if (persisted.type !== 'formula') {
+    throw new Error(`Formula field type drift: '${persisted.type}'`)
+  }
+  if (persisted.property?.expression !== expression) {
+    throw new Error(`Formula expression drift: '${persisted.property?.expression}' vs '${expression}'`)
+  }
+  return { sheetId: sheet.id, formulaFieldId: formula.id }
+})
+
+// ── 6. automation-email ─────────────────────────────────────────────────────
+
+registerCheck('automation-email', async () => {
+  const label = uniqueLabel('ae')
+  const base = await createBase(`${label}-base`)
+  const sheet = await createSheet(base.id, `${label}-sheet`)
+  const title = await createField(sheet.id, 'Title', 'string')
+  const owner = await createField(sheet.id, 'Owner', 'string')
+
+  const recipients = ['team@test.local', 'lead@test.local']
+  const ruleEnv = await authPost(`/api/multitable/sheets/${sheet.id}/automations`, {
+    name: `${label}-rule`,
+    triggerType: 'record.created',
+    triggerConfig: {},
+    actionType: 'send_email',
+    actionConfig: {
+      recipients,
+      subjectTemplate: `[rc-staging] new record {{recordId}}`,
+      bodyTemplate: `Title={{record.${title.id}}} Owner={{record.${owner.id}}}`,
+    },
+    enabled: true,
+  })
+  const rule = requireValue(ruleEnv.data?.rule, 'rule')
+
+  await createRecord(sheet.id, { [title.id]: `rc-staging-task-${stamp}`, [owner.id]: 'Alice' })
+
+  const deadline = Date.now() + pollTimeoutMs
+  let lastBody = null
+  while (Date.now() < deadline) {
+    const res = await fetch(
+      `${apiBase}/api/multitable/sheets/${sheet.id}/automations/${rule.id}/logs?limit=10`,
+      { headers: authHeaders },
+    )
+    if (res.ok) {
+      const body = await res.json().catch(() => null)
+      lastBody = body
+      const execution = body?.executions?.[0]
+      if (execution) {
+        if (execution.status !== 'success') {
+          throw new Error(`Execution status='${execution.status}'; expected 'success'. Body: ${JSON.stringify(body)}`)
+        }
+        const step = execution.steps?.[0]
+        if (step?.actionType !== 'send_email') {
+          throw new Error(`step.actionType='${step?.actionType}'; expected 'send_email'`)
+        }
+        if (step?.status !== 'success') {
+          throw new Error(`step.status='${step?.status}'; expected 'success'`)
+        }
+        if (step?.output?.recipientCount !== recipients.length) {
+          throw new Error(`step.output.recipientCount=${step?.output?.recipientCount}; expected ${recipients.length}`)
+        }
+        if (step?.output?.notificationStatus !== 'sent') {
+          throw new Error(`step.output.notificationStatus='${step?.output?.notificationStatus}'; expected 'sent'`)
+        }
+        return { sheetId: sheet.id, ruleId: rule.id, executionId: execution.id }
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs))
+  }
+  throw new Error(`No automation execution observed within ${pollTimeoutMs}ms; last logs body: ${JSON.stringify(lastBody)}`)
+})
+
+// ── 7. autoNumber-backfill ──────────────────────────────────────────────────
+
+registerCheck('autoNumber-backfill', async () => {
+  const label = uniqueLabel('an')
+  const base = await createBase(`${label}-base`)
+  const sheet = await createSheet(base.id, `${label}-sheet`)
+  const title = await createField(sheet.id, 'Title', 'string')
+
+  // Create records BEFORE the autoNumber field, so backfill is exercised.
+  const r1 = await createRecord(sheet.id, { [title.id]: `pre-an-1-${stamp}` })
+  const r2 = await createRecord(sheet.id, { [title.id]: `pre-an-2-${stamp}` })
+  const r3 = await createRecord(sheet.id, { [title.id]: `pre-an-3-${stamp}` })
+
+  const startAt = 1000
+  const seq = await createField(sheet.id, 'No.', 'autoNumber', {
+    start: startAt,
+    prefix: 'INV-',
+    digits: 4,
+  })
+
+  const recordsBody = await authGet(`/api/multitable/records?sheetId=${sheet.id}`)
+  const rows = recordsBody.data?.records ?? []
+  const ids = [r1.id, r2.id, r3.id]
+  const values = ids.map((id) => rows.find((row) => row.id === id)?.data?.[seq.id])
+  for (const [i, value] of values.entries()) {
+    if (typeof value !== 'number' && typeof value !== 'string') {
+      throw new Error(`Backfill missing for record[${i}] ${ids[i]}; got: ${JSON.stringify(value)}`)
+    }
+  }
+
+  // Server-side raw-write rejection: client cannot supply autoNumber value.
+  const raw = await authPostExpectingFailure('/api/multitable/records', {
+    sheetId: sheet.id,
+    data: { [title.id]: 'raw-write-attempt', [seq.id]: 9999 },
+  })
+  if (raw.status !== 403) {
+    throw new Error(`Raw autoNumber write expected 403, got ${raw.status}: ${JSON.stringify(raw.body)}`)
+  }
+  if (raw.body?.error?.code !== 'FIELD_READONLY') {
+    throw new Error(`Expected error.code 'FIELD_READONLY', got '${raw.body?.error?.code}'`)
+  }
+
+  // Subsequent fresh record gets next value (after backfill consumed [startAt..startAt+2]).
+  const r4 = await createRecord(sheet.id, { [title.id]: `post-an-${stamp}` })
+  const r4Value = r4.data?.[seq.id]
+  if (typeof r4Value !== 'number') {
+    throw new Error(`New record after backfill missing autoNumber value; got: ${JSON.stringify(r4Value)}`)
+  }
+  if (r4Value < startAt + 3) {
+    throw new Error(`New record value=${r4Value} < expected >=${startAt + 3} after 3-record backfill`)
+  }
+
+  return { sheetId: sheet.id, fieldId: seq.id, backfilled: values, freshValue: r4Value }
+})
+
+// ── runner ──────────────────────────────────────────────────────────────────
+
+const startedAt = new Date().toISOString()
+const results = []
+for (const { name, fn } of checks) {
+  if (skipSet.has(name)) {
+    console.error(`[rc-smoke] SKIP ${name}`)
+    results.push({ name, status: 'skipped', durationMs: 0 })
+    continue
+  }
+  const t0 = Date.now()
+  try {
+    const evidence = await fn()
+    const durationMs = Date.now() - t0
+    console.error(`[rc-smoke] PASS ${name} (${durationMs}ms)`)
+    results.push({ name, status: 'pass', durationMs, evidence })
+  } catch (err) {
+    const durationMs = Date.now() - t0
+    const message = err instanceof Error ? err.message : String(err)
+    console.error(`[rc-smoke] FAIL ${name} (${durationMs}ms): ${message}`)
+    results.push({ name, status: 'fail', durationMs, error: message })
+  }
+}
+const finishedAt = new Date().toISOString()
+
+const passes = results.filter((r) => r.status === 'pass').length
+const fails = results.filter((r) => r.status === 'fail').length
+const skips = results.filter((r) => r.status === 'skipped').length
+
+const report = {
+  apiBase,
+  startedAt,
+  finishedAt,
+  total: results.length,
+  passes,
+  fails,
+  skips,
+  results,
+}
+
+writeFileSync(reportJsonPath, JSON.stringify(report, null, 2))
+
+const mdLines = []
+mdLines.push(`# Multitable RC Staging Smoke Report`)
+mdLines.push('')
+mdLines.push(`- API: \`${apiBase}\``)
+mdLines.push(`- Started: ${startedAt}`)
+mdLines.push(`- Finished: ${finishedAt}`)
+mdLines.push(`- Total: ${results.length} (pass=${passes}, fail=${fails}, skip=${skips})`)
+mdLines.push('')
+mdLines.push('| Check | Status | Duration |')
+mdLines.push('| --- | --- | --- |')
+for (const r of results) {
+  mdLines.push(`| ${r.name} | ${r.status} | ${r.durationMs}ms |`)
+}
+mdLines.push('')
+const failures = results.filter((r) => r.status === 'fail')
+if (failures.length > 0) {
+  mdLines.push('## Failures')
+  mdLines.push('')
+  for (const r of failures) {
+    mdLines.push(`### ${r.name}`)
+    mdLines.push('')
+    mdLines.push('```')
+    mdLines.push(r.error ?? '(unknown error)')
+    mdLines.push('```')
+    mdLines.push('')
+  }
+}
+writeFileSync(reportMdPath, mdLines.join('\n') + '\n')
+
+console.error(`[rc-smoke] report json: ${reportJsonPath}`)
+console.error(`[rc-smoke] report md:   ${reportMdPath}`)
+console.error(`[rc-smoke] result: ${passes} pass / ${fails} fail / ${skips} skip / ${results.length} total`)
+
+process.exit(fails > 0 ? 1 : 0)

--- a/scripts/verify-multitable-rc-staging-smoke.mjs
+++ b/scripts/verify-multitable-rc-staging-smoke.mjs
@@ -6,7 +6,7 @@
  * RC TODO smoke surfaces against a deployed multitable backend:
  *
  *   1. lifecycle           — create base/sheet/field/view/record + GET records
- *   2. public-form         — admin enable accessMode='public' + anonymous submit + admin verify persisted
+ *   2. public-form         — admin enable accessMode='public' + anonymous submit + token rotation
  *   3. hierarchy           — self-table link parent field + PATCH self-parent → 400 + HIERARCHY_CYCLE
  *   4. gantt-config        — gantt view with non-link dependencyFieldId → 400 + VALIDATION_ERROR + self-table link msg
  *   5. formula             — formula field with `={A.id}+{B.id}` expression + verify persisted property
@@ -47,7 +47,28 @@
 import { mkdirSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
 
-const apiBase = (process.env.API_BASE || '').replace(/\/+$/, '')
+function normalizeApiBase(rawValue) {
+  const value = (rawValue || '').trim().replace(/\/+$/, '')
+  if (!value) return ''
+  let parsed
+  try {
+    parsed = new URL(value)
+  } catch {
+    console.error('[rc-smoke] API_BASE must be an absolute http(s) URL')
+    process.exit(2)
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    console.error('[rc-smoke] API_BASE must use http or https')
+    process.exit(2)
+  }
+  if (parsed.username || parsed.password || parsed.search || parsed.hash) {
+    console.error('[rc-smoke] API_BASE must not contain credentials, query, or fragment')
+    process.exit(2)
+  }
+  return value
+}
+
+const apiBase = normalizeApiBase(process.env.API_BASE)
 const authToken = process.env.AUTH_TOKEN || ''
 const outputDir = process.env.OUTPUT_DIR || 'output/multitable-rc-staging-smoke'
 const reportJsonPath = process.env.REPORT_JSON || path.join(outputDir, 'report.json')
@@ -196,6 +217,7 @@ registerCheck('lifecycle', async () => {
   const base = await createBase(`${label}-base`)
   const sheet = await createSheet(base.id, `${label}-sheet`)
   const field = await createField(sheet.id, 'Title', 'string')
+  const view = await createView(sheet.id, 'Default Grid', 'grid')
   const cellValue = `lifecycle-${stamp}`
   const record = await createRecord(sheet.id, { [field.id]: cellValue })
   if (record.data?.[field.id] !== cellValue) {
@@ -208,7 +230,7 @@ registerCheck('lifecycle', async () => {
   if (persisted.data?.[field.id] !== cellValue) {
     throw new Error(`Record value drift after read-back: '${persisted.data?.[field.id]}'`)
   }
-  return { sheetId: sheet.id, recordId: record.id, fieldId: field.id }
+  return { sheetId: sheet.id, viewId: view.id, recordId: record.id, fieldId: field.id }
 })
 
 // ── 2. public-form ──────────────────────────────────────────────────────────
@@ -241,15 +263,41 @@ registerCheck('public-form', async () => {
     throw new Error(`Submitted value drift: '${persisted.data?.[field.id]}'`)
   }
 
-  // Negative: stale token must reject
+  const regenBody = await authPost(
+    `/api/multitable/sheets/${sheet.id}/views/${view.id}/form-share/regenerate`,
+    {},
+  )
+  const rotatedToken = requireValue(regenBody.data?.publicToken, 'rotated publicToken')
+  if (rotatedToken === publicToken) {
+    throw new Error('Regenerated publicToken matched the previous token')
+  }
+
+  // Negative: a previously-valid token must reject after regeneration.
   const stale = await anonPost(`/api/multitable/views/${view.id}/submit`, {
-    publicToken: 'definitely-not-the-real-token',
+    publicToken,
     data: { [field.id]: 'should-not-persist' },
   })
   if (stale.status !== 401) {
-    throw new Error(`Expected 401 for stale-token anonymous submit; got ${stale.status}`)
+    throw new Error(`Expected 401 for rotated stale-token anonymous submit; got ${stale.status}`)
   }
-  return { sheetId: sheet.id, viewId: view.id, recordId: newRecordId }
+
+  const rotatedValue = `pf-rotated-${stamp}`
+  const rotatedSubmit = await anonPost(`/api/multitable/views/${view.id}/submit`, {
+    publicToken: rotatedToken,
+    data: { [field.id]: rotatedValue },
+  })
+  if (!rotatedSubmit.ok) {
+    throw new Error(`Anonymous submit with rotated token failed: ${rotatedSubmit.status} ${JSON.stringify(rotatedSubmit.body)}`)
+  }
+  const rotatedRecordId = requireValue(rotatedSubmit.body?.data?.record?.id, 'rotated-token submitted record id')
+  const rotatedRecordsBody = await authGet(`/api/multitable/records?sheetId=${sheet.id}`)
+  const rotatedPersisted = (rotatedRecordsBody.data?.records ?? []).find((row) => row.id === rotatedRecordId)
+  if (!rotatedPersisted) throw new Error(`Rotated-token submitted record ${rotatedRecordId} not visible to admin`)
+  if (rotatedPersisted.data?.[field.id] !== rotatedValue) {
+    throw new Error(`Rotated-token submitted value drift: '${rotatedPersisted.data?.[field.id]}'`)
+  }
+
+  return { sheetId: sheet.id, viewId: view.id, recordId: newRecordId, rotatedRecordId }
 })
 
 // ── 3. hierarchy ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds `scripts/verify-multitable-rc-staging-smoke.mjs` — a browser-free HTTP harness that exercises the six RC TODO smoke surfaces plus the autoNumber backfill path against a deployed multitable backend. Pure RC validation tooling for the closeout window; no user-facing change.

Companion to the local Playwright specs in `packages/core-backend/tests/e2e/multitable-*-smoke.spec.ts`. The existing `scripts/verify-multitable-live-smoke.mjs` (3 644 lines, Playwright + browser) does not cover any of these RC surfaces (zero hits for `send_email` / `autoNumber` / `hierarchy` / `dependencyFieldId` / `publicForm` via grep); kept untouched here.

## Seven checks

1. **lifecycle** — base/sheet/field/view/record + GET records readback
2. **public-form** — admin enables `accessMode: 'public'`, anonymous submit with the issued `publicToken`, admin verifies persisted; stale-token negative
3. **hierarchy** — self-link parent + PATCH self-parent → 400 + `error.code === 'HIERARCHY_CYCLE'`
4. **gantt-config** — gantt view PATCH with non-link `dependencyFieldId` → 400 + `VALIDATION_ERROR` + message contains `self-table link field`
5. **formula** — formula field with `={A.id}+{B.id}` expression + GET fields verifies persisted property
6. **automation-email** — `record.created` → `send_email` rule via the real event chain (not `/test`); poll `/logs?limit=10` for up to 12 s and assert `execution.status === 'success'`, `step.actionType === 'send_email'`, `step.status === 'success'`, `step.output.recipientCount === 2`, `step.output.notificationStatus === 'sent'`
7. **autoNumber-backfill** — pre-create 3 records, then add an autoNumber field with `start: 1000, prefix: 'INV-', digits: 4`; assert all 3 pre-existing records receive backfilled values, raw client write returns 403 + `FIELD_READONLY`, and a fresh post-backfill record gets `value >= start + 3`. Validates the PR #1431 window-function backfill is observable through the public API.

Each check is isolated: failures are captured per-check (no early termination); `report.json` + `report.md` written under `${OUTPUT_DIR}` (default `output/multitable-rc-staging-smoke`). Exit code 0 = all pass, 1 = any fail, 2 = env/fatal before any check ran.

## Operational usage

```bash
AUTH_TOKEN=$(cat /tmp/metasheet-staging-admin.jwt) \
API_BASE=http://142.171.239.56:8081 \
pnpm verify:multitable-rc:staging

# Partial run (skip slowest):
SKIP=automation-email pnpm verify:multitable-rc:staging
```

## K3 PoC Stage 1 Lock applicability

- Does NOT modify `plugins/plugin-integration-core/*`.
- Pure RC validation tooling — fits the explicit "bugfix-only window for RC" framing. No migration, no OpenAPI change, no runtime change.
- Does NOT touch DingTalk / public-form / Gantt / Hierarchy / formula / automation runtime; only consumes existing public REST endpoints.

## Files changed

| File | Lines |
|---|---|
| `scripts/verify-multitable-rc-staging-smoke.mjs` | +new (~510) |
| `package.json` | +1 (`verify:multitable-rc:staging` entry) |
| `docs/development/multitable-rc-staging-smoke-development-20260507.md` | +new |
| `docs/development/multitable-rc-staging-smoke-verification-20260507.md` | +new |

Net: +745 / 0.

## Test plan

- [x] `node --check scripts/verify-multitable-rc-staging-smoke.mjs` — passes (syntax)
- [x] `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8'))"` — passes (JSON valid)
- [x] Dry-run against unreachable URL exits 1 with all 7 checks reporting `fail` and report files written:

```
[rc-smoke] FAIL lifecycle (11ms): fetch failed
[rc-smoke] FAIL public-form (0ms): fetch failed
[rc-smoke] FAIL hierarchy (0ms): fetch failed
[rc-smoke] FAIL gantt-config (0ms): fetch failed
[rc-smoke] FAIL formula (0ms): fetch failed
[rc-smoke] FAIL automation-email (0ms): fetch failed
[rc-smoke] FAIL autoNumber-backfill (1ms): fetch failed
[rc-smoke] result: 0 pass / 7 fail / 0 skip / 7 total
```

- [x] `git diff --check` — passes

## Codex hardening lessons applied (per memory checklist)

- No `any` — Node script is pure JS but uses defensive `requireValue` + explicit checks; no implicit `any` types
- No dead helpers — every helper called by at least one check
- Specific assertions — exact `error.code` / `error.message` substring matches; not status-code-only
- MD claim matches spec coverage — explicit "What is NOT validated" section
- Exit codes distinct (0 / 1 / 2) so deploy gates can route alerts correctly
- Real event chain for automation (not `/test`)
- Loud failure mode — fixtures persist + report includes last logs body for diagnostic context

## Known limitations (also captured in dev MD)

1. Fixtures not cleaned up — timestamp + random suffix prevents collisions; matches existing pilot-smoke convention.
2. No real SMTP — `notificationStatus === 'sent'` is the channel-result contract; default `EmailNotificationChannel` mocks the send.
3. `automation-email` polling deadline is 12 s — heavy staging load may need `POLL_TIMEOUT_MS` raised.
4. DingTalk-protected access modes uncovered — out of scope.
5. Has NOT been run against a real staging cluster from this PR's worktree (no admin JWT here); operator/Codex runs it during RC validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)