### PR TITLE
chore(dingtalk): support container-env release gate

### DIFF
--- a/docs/development/dingtalk-work-notification-release-gate-container-env-design-20260508.md
+++ b/docs/development/dingtalk-work-notification-release-gate-container-env-design-20260508.md
@@ -1,0 +1,76 @@
+# DingTalk Work Notification Release Gate — Container Env Skip Option Design (2026-05-08)
+
+## Background
+
+After PR #1430 merged, host-side runs of `scripts/ops/dingtalk-work-notification-release-gate.mjs` on 142 reported `ENV_STATUS_BLOCKED` for app key and app secret even though the backend runtime admin API correctly considered the work-notification channel available except for Agent ID.
+
+Reason: on 142 the real DingTalk runtime envs (`DINGTALK_APP_KEY`, `DINGTALK_APP_SECRET`) live inside the backend container's process environment — injected at container start from a private secrets bundle — and are not present in `/home/mainuser/metasheet2/.env`. The host-side env-status helper only inspects host env files, so it cannot see container-side envs and falsely flags them as missing.
+
+Two truths coexist on 142:
+
+- Host env-status helper: `blocked` (host env file does not contain app key / app secret).
+- Backend admin runtime API: `available=false` only because `agent_id` is unset.
+
+The previous override path in the release gate (`runtimeStatusOverridesEnvStatus`) only kicks in when the runtime API reports `available=true`. While the Agent ID is still missing, that override cannot fire, so ops were getting an extra noisy `ENV_STATUS_BLOCKED` failure code that does not reflect the real production state.
+
+## Goal
+
+Give ops a redaction-safe way to opt out of the host env-status check when they know the runtime envs live in the backend container, while keeping every other check (health, auth, admin runtime status) intact and the default behavior unchanged.
+
+## Non-Goals
+
+- Do not read `.env`, `.secrets`, token, webhook, recipient, or remote server files.
+- Do not change how the env-status helper itself works.
+- Do not auto-detect the container-env case; this stays explicit because it is an ops decision.
+
+## Change
+
+Add a `--skip-env-status` flag to `scripts/ops/dingtalk-work-notification-release-gate.mjs`.
+
+When the flag is set:
+
+- The env-status helper subprocess is not invoked.
+- No `env-status.json` / `env-status.md` artifact is produced.
+- The summary records `envStatus.skipped=true`, `envStatus.overallStatus="not_applicable"`, and `envStatus.reason="skip_env_status_flag"`.
+- `ENV_STATUS_BLOCKED` and `ENV_STATUS_HELPER_FAILED` are suppressed because both depend on `envStatus.skipped===false`.
+- Health, auth, and admin runtime workNotification checks run unchanged, so a missing Agent ID still produces `WORK_NOTIFICATION_UNAVAILABLE`.
+
+When the flag is not set, behavior is identical to today.
+
+### JSON shape
+
+The change is additive:
+
+- `summary.skipEnvStatus`: boolean.
+- `summary.envStatus.skipped`: boolean (also added to the non-skipped path so the shape is consistent for downstream consumers).
+- `summary.envStatus.overallStatus`: stays a string. In the skipped path it is `"not_applicable"`.
+
+### Markdown rendering
+
+Adds an `Env Status Skipped: \`true\`` header line and renders the env-status check value as `skipped` in the Checks section. The Evidence section omits env-status JSON / MD paths in the skipped path.
+
+## Security
+
+The flag is purely a control-flow toggle:
+
+- No new file IO. The script still does not read `.env`, `.secrets`, token, webhook, or remote server files.
+- No new logging. Bearer token, webhook, robot `SEC` secret, JWT, and access-token redaction paths are unchanged.
+- `--skip-env-status` is independent of `--skip-admin-api`. Combining the two requires no token, but downgrades the gate to a pure health check; ops should only use that combination intentionally.
+
+## 142 Usage
+
+```bash
+node /tmp/dingtalk-work-notification-release-gate.mjs \
+  --status-helper /tmp/dingtalk-work-notification-env-status.mjs \
+  --api-base http://127.0.0.1:8900 \
+  --auth-token-file /tmp/metasheet-142-admin-2h-20260508.jwt \
+  --user-id b928b8d9-8881-43d7-a712-842b28870494 \
+  --skip-env-status \
+  --allow-blocked \
+  --output-json /tmp/dingtalk-work-notification-release-gate/summary.json \
+  --output-md /tmp/dingtalk-work-notification-release-gate/summary.md
+```
+
+Expected before Agent ID is configured: `status=blocked`, single failure `WORK_NOTIFICATION_UNAVAILABLE` (`unavailableReason=missing_agent_id`).
+
+After Agent ID is configured: rerun the same command without `--allow-blocked`. Expected status: `pass`.

--- a/docs/development/dingtalk-work-notification-release-gate-container-env-verification-20260508.md
+++ b/docs/development/dingtalk-work-notification-release-gate-container-env-verification-20260508.md
@@ -1,0 +1,94 @@
+# DingTalk Work Notification Release Gate — Container Env Skip Option Verification (2026-05-08)
+
+## Summary
+
+Added `--skip-env-status` to `scripts/ops/dingtalk-work-notification-release-gate.mjs`. Default behavior is unchanged. With the flag set, the host env-status helper is not invoked and no `ENV_STATUS_BLOCKED` failure is emitted; backend health, admin auth, and admin runtime workNotification status continue to run.
+
+## Files Changed
+
+- `scripts/ops/dingtalk-work-notification-release-gate.mjs` — new `--skip-env-status` flag, `buildSkippedEnvStatus` helper, summary fields `skipEnvStatus` / `envStatus.skipped`, markdown rendering update.
+- `scripts/ops/dingtalk-work-notification-release-gate.test.mjs` — two new tests covering the skip path (pass and runtime-blocked branches).
+- `docs/development/dingtalk-work-notification-release-gate-container-env-design-20260508.md` — design rationale.
+- `docs/development/dingtalk-work-notification-release-gate-container-env-verification-20260508.md` — this file.
+
+## Local Verification
+
+Syntax check:
+
+```bash
+node --check scripts/ops/dingtalk-work-notification-release-gate.mjs
+```
+
+Result: passed.
+
+Targeted unit tests:
+
+```bash
+node --test scripts/ops/dingtalk-work-notification-release-gate.test.mjs
+```
+
+Result: 7 tests passed (4 existing + 2 new + the existing `--skip-admin-api` case retained).
+
+New cases covered:
+
+- `--skip-env-status` plus healthy backend, valid admin token, and `workNotification.available=true` returns `pass` with empty failures, `envStatus.skipped=true`, `envStatus.overallStatus="not_applicable"`, and no env-status helper artifact written.
+- `--skip-env-status` plus healthy backend with `workNotification.unavailableReason=missing_agent_id` returns `blocked` with exactly one failure code, `WORK_NOTIFICATION_UNAVAILABLE`, demonstrating that the runtime check is not weakened by skipping the host env probe.
+
+Markdown assertions:
+
+- Header line `Env Status Skipped: \`true\`` is rendered.
+- Checks section renders `Env Status: \`skipped\``.
+
+## Security Posture
+
+- The local development and unit-test path did not read `.env`, `.secrets`, token, webhook, recipient, or remote server files.
+- The live 142 verification reused a short-lived admin token file as the authenticated input to the helper. The token value was not printed, copied into Git, or included in this report.
+- No secret-shaped values appear in the new code, tests, or docs. The existing redaction paths (DingTalk robot webhook, `access_token`, `SEC...`, `eyJ...` JWT, `Bearer ...`) are unchanged and still applied to all summaries.
+- The new flag is a pure control-flow toggle; it does not introduce any new IO.
+
+## 142 Live Verification
+
+Post-merge production deployment was already running `a61b3c64b23c94137db10bce7ce166181c25d9e2` on 142 with backend `/api/health=200` and web `200`.
+
+The updated release-gate script was copied to `/tmp` on 142 and executed with `--skip-env-status`, `--allow-blocked`, the local backend API, and a short-lived admin token file. Result:
+
+```json
+{
+  "status": "blocked",
+  "skipEnvStatus": true,
+  "envStatus": {
+    "skipped": true,
+    "overallStatus": "not_applicable"
+  },
+  "failures": [
+    {
+      "code": "WORK_NOTIFICATION_UNAVAILABLE",
+      "detail": {
+        "unavailableReason": "missing_agent_id"
+      }
+    }
+  ]
+}
+```
+
+This proves the new flag removes the host `.env` false block while preserving the real runtime blocker: the production DingTalk work-notification Agent ID is still missing.
+
+## 142 Usage Note
+
+Recommended sequence on 142 while the real Agent ID is still missing:
+
+```bash
+node /tmp/dingtalk-work-notification-release-gate.mjs \
+  --status-helper /tmp/dingtalk-work-notification-env-status.mjs \
+  --api-base http://127.0.0.1:8900 \
+  --auth-token-file /tmp/metasheet-142-admin-2h-20260508.jwt \
+  --user-id b928b8d9-8881-43d7-a712-842b28870494 \
+  --skip-env-status \
+  --allow-blocked \
+  --output-json /tmp/dingtalk-work-notification-release-gate/summary.json \
+  --output-md /tmp/dingtalk-work-notification-release-gate/summary.md
+```
+
+Expected: `status=blocked`, single failure `WORK_NOTIFICATION_UNAVAILABLE` with `unavailableReason=missing_agent_id`. After Agent ID is configured, rerun without `--allow-blocked`; expected `status=pass`.
+
+The previous (host-env) invocation still works for environments where the host `.env` is the source of truth. The new flag is opt-in and exists specifically for container-env deployments like 142.

--- a/scripts/ops/dingtalk-work-notification-release-gate.mjs
+++ b/scripts/ops/dingtalk-work-notification-release-gate.mjs
@@ -32,6 +32,10 @@ Options:
   --output-md <file>             Output Markdown path, default ${DEFAULT_OUTPUT_DIR}/summary.md
   --timeout-ms <ms>              HTTP timeout, default 10000
   --skip-admin-api               Only run env-status and health checks
+  --skip-env-status              Skip the env-status helper; record env as
+                                 skipped without producing ENV_STATUS_BLOCKED.
+                                 Useful when the real runtime envs live inside
+                                 the backend container and not in a host .env.
   --allow-blocked                Exit 0 even when the gate is blocked
   --help                         Show this help
 `)
@@ -63,6 +67,7 @@ function parseArgs(argv) {
     outputMd: path.resolve(process.cwd(), DEFAULT_OUTPUT_DIR, 'summary.md'),
     timeoutMs: 10_000,
     skipAdminApi: false,
+    skipEnvStatus: false,
     allowBlocked: false,
   }
 
@@ -107,6 +112,9 @@ function parseArgs(argv) {
         break
       case '--skip-admin-api':
         opts.skipAdminApi = true
+        break
+      case '--skip-env-status':
+        opts.skipEnvStatus = true
         break
       case '--allow-blocked':
         opts.allowBlocked = true
@@ -168,6 +176,22 @@ function addFailure(failures, code, message, detail = {}) {
   failures.push({ code, message, detail: redactDeep(detail) })
 }
 
+function buildSkippedEnvStatus() {
+  return {
+    skipped: true,
+    reason: 'skip_env_status_flag',
+    command: '',
+    exitCode: 0,
+    stdoutLength: 0,
+    stderrLength: 0,
+    outputJson: '',
+    outputMd: '',
+    overallStatus: 'not_applicable',
+    missingInputs: [],
+    requirements: {},
+  }
+}
+
 function runEnvStatus(opts) {
   const statusOutputJson = path.join(path.dirname(opts.outputJson), 'env-status.json')
   const statusOutputMd = path.join(path.dirname(opts.outputMd), 'env-status.md')
@@ -190,6 +214,7 @@ function runEnvStatus(opts) {
     }
   }
   return {
+    skipped: false,
     command: [
       'node',
       relativePath(opts.statusHelper),
@@ -281,11 +306,11 @@ function readWorkNotificationResult(result) {
 
 async function runGate(opts) {
   const failures = []
-  const envStatus = runEnvStatus(opts)
-  if (envStatus.exitCode !== 0) {
+  const envStatus = opts.skipEnvStatus ? buildSkippedEnvStatus() : runEnvStatus(opts)
+  if (!envStatus.skipped && envStatus.exitCode !== 0) {
     addFailure(failures, 'ENV_STATUS_HELPER_FAILED', 'Env status helper failed', { exitCode: envStatus.exitCode })
   }
-  const envStatusBlocked = envStatus.overallStatus !== 'ready'
+  const envStatusBlocked = !envStatus.skipped && envStatus.overallStatus !== 'ready'
 
   const healthResult = readHealthResult(await fetchJson(opts, '/api/health'))
   if (!healthResult.ok) {
@@ -334,6 +359,7 @@ async function runGate(opts) {
     authTokenFile: opts.authTokenFile ? relativePath(opts.authTokenFile) : '',
     userId: opts.userId || '',
     skipAdminApi: opts.skipAdminApi,
+    skipEnvStatus: opts.skipEnvStatus,
     envStatus,
     health: healthResult,
     auth,
@@ -365,10 +391,11 @@ function renderMarkdown(summary) {
     `- API Base: \`${summary.apiBase}\``,
     `- Env Files: ${summary.envFiles.length ? summary.envFiles.map((file) => `\`${file}\``).join(', ') : '`<none>`'}`,
     `- Admin API Skipped: \`${summary.skipAdminApi}\``,
+    `- Env Status Skipped: \`${summary.skipEnvStatus === true}\``,
     '',
     '## Checks',
     '',
-    `- Env Status: \`${summary.envStatus.overallStatus || '<unknown>'}\``,
+    `- Env Status: \`${summary.envStatus.skipped ? 'skipped' : (summary.envStatus.overallStatus || '<unknown>')}\``,
     `- Runtime Status Overrides Env Status: \`${summary.runtimeStatusOverridesEnvStatus === true}\``,
     `- Health: \`${summary.health.ok}\` (status ${summary.health.status})`,
     `- Auth: \`${summary.auth.skipped ? 'skipped' : summary.auth.ok}\``,
@@ -385,8 +412,12 @@ function renderMarkdown(summary) {
   }
 
   lines.push('## Evidence', '')
-  lines.push(`- Env Status JSON: \`${summary.envStatus.outputJson}\``)
-  lines.push(`- Env Status MD: \`${summary.envStatus.outputMd}\``)
+  if (summary.envStatus.skipped) {
+    lines.push('- Env Status: `skipped`')
+  } else {
+    lines.push(`- Env Status JSON: \`${summary.envStatus.outputJson}\``)
+    lines.push(`- Env Status MD: \`${summary.envStatus.outputMd}\``)
+  }
   if (!summary.workNotification.skipped) {
     lines.push(`- Work Notification Reason: \`${summary.workNotification.unavailableReason || '<none>'}\``)
   }

--- a/scripts/ops/dingtalk-work-notification-release-gate.test.mjs
+++ b/scripts/ops/dingtalk-work-notification-release-gate.test.mjs
@@ -285,6 +285,110 @@ test('release gate redacts sensitive API error payloads', async () => {
   }
 })
 
+test('release gate can skip env status helper without producing ENV_STATUS_BLOCKED', async () => {
+  const tmpDir = makeTmpDir()
+  const tokenFile = path.join(tmpDir, 'admin.jwt')
+  const outputJson = path.join(tmpDir, 'summary.json')
+  const outputMd = path.join(tmpDir, 'summary.md')
+  const envStatusJson = path.join(tmpDir, 'env-status.json')
+  try {
+    writeFileSync(tokenFile, 'secret-admin-token\n', 'utf8')
+
+    await withServer((req, res) => {
+      if (req.url === '/api/health') return jsonResponse(res, 200, { status: 'ok', success: true })
+      if (req.url === '/api/auth/me') return jsonResponse(res, 200, { success: true, user: { role: 'admin' } })
+      if (req.url === '/api/admin/users/user-1/dingtalk-access') {
+        return jsonResponse(res, 200, {
+          workNotification: {
+            configured: true,
+            available: true,
+            requirements: {
+              appKey: { configured: true, selectedKey: 'DINGTALK_APP_KEY' },
+              appSecret: { configured: true, selectedKey: 'DINGTALK_APP_SECRET' },
+              agentId: { configured: true, selectedKey: 'DINGTALK_AGENT_ID' },
+            },
+          },
+        })
+      }
+      return jsonResponse(res, 404, { error: 'not found' })
+    }, async (apiBase) => {
+      const result = await runScript([
+        '--status-helper', statusHelperPath,
+        '--api-base', apiBase,
+        '--auth-token-file', tokenFile,
+        '--user-id', 'user-1',
+        '--skip-env-status',
+        '--output-json', outputJson,
+        '--output-md', outputMd,
+      ])
+
+      assert.equal(result.status, 0, result.stderr || result.stdout)
+      const summary = readJson(outputJson)
+      assert.equal(summary.status, 'pass')
+      assert.equal(summary.skipEnvStatus, true)
+      assert.equal(summary.envStatus.skipped, true)
+      assert.equal(summary.envStatus.overallStatus, 'not_applicable')
+      assert.equal(summary.runtimeStatusOverridesEnvStatus, false)
+      assert.deepEqual(summary.failures, [])
+      assert.equal(existsSync(envStatusJson), false, 'env-status helper artifact should not exist when skipped')
+      const markdown = readFileSync(outputMd, 'utf8')
+      assert.match(markdown, /Env Status Skipped: `true`/)
+      assert.match(markdown, /Env Status: `skipped`/)
+    })
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('release gate skip-env-status still surfaces work notification failures from runtime', async () => {
+  const tmpDir = makeTmpDir()
+  const tokenFile = path.join(tmpDir, 'admin.jwt')
+  const outputJson = path.join(tmpDir, 'summary.json')
+  const outputMd = path.join(tmpDir, 'summary.md')
+  try {
+    writeFileSync(tokenFile, 'secret-admin-token\n', 'utf8')
+
+    await withServer((req, res) => {
+      if (req.url === '/api/health') return jsonResponse(res, 200, { status: 'ok', success: true })
+      if (req.url === '/api/auth/me') return jsonResponse(res, 200, { success: true, user: { role: 'admin' } })
+      if (req.url === '/api/admin/users/user-1/dingtalk-access') {
+        return jsonResponse(res, 200, {
+          workNotification: {
+            configured: false,
+            available: false,
+            unavailableReason: 'missing_agent_id',
+            requirements: { agentId: { configured: false, selectedKey: null } },
+          },
+        })
+      }
+      return jsonResponse(res, 404, { error: 'not found' })
+    }, async (apiBase) => {
+      const result = await runScript([
+        '--status-helper', statusHelperPath,
+        '--api-base', apiBase,
+        '--auth-token-file', tokenFile,
+        '--user-id', 'user-1',
+        '--skip-env-status',
+        '--allow-blocked',
+        '--output-json', outputJson,
+        '--output-md', outputMd,
+      ])
+
+      assert.equal(result.status, 0, result.stderr || result.stdout)
+      const summary = readJson(outputJson)
+      assert.equal(summary.status, 'blocked')
+      assert.equal(summary.skipEnvStatus, true)
+      assert.equal(summary.envStatus.skipped, true)
+      assert.deepEqual(
+        summary.failures.map((failure) => failure.code).sort(),
+        ['WORK_NOTIFICATION_UNAVAILABLE'],
+      )
+    })
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
 test('release gate can skip admin API checks', async () => {
   const tmpDir = makeTmpDir()
   const envFile = path.join(tmpDir, 'app.env')


### PR DESCRIPTION
## Summary\n- add `--skip-env-status` to the DingTalk work-notification release gate for container-env deployments like 142\n- keep default host env-status behavior unchanged\n- document the 142 post-merge finding and verification path\n\n## Verification\n- `git diff --check`\n- targeted secret-shape scan over changed files\n- `node --check scripts/ops/dingtalk-work-notification-release-gate.mjs`\n- `node --test scripts/ops/dingtalk-work-notification-release-gate.test.mjs`\n- 142 live temp-script check with `--skip-env-status`: only remaining failure is `WORK_NOTIFICATION_UNAVAILABLE / missing_agent_id`\n\n## Notes\nNo real DingTalk webhook, token, SEC secret, JWT, Agent ID, or recipient value is committed or printed.