### PR TITLE
fix(multitable): allow send_email automation action in DB constraint

### DIFF
--- a/docs/development/multitable-send-email-automation-action-migration-development-20260508.md
+++ b/docs/development/multitable-send-email-automation-action-migration-development-20260508.md
@@ -1,0 +1,62 @@
+# Send Email Automation Action Constraint Migration — Development
+
+Date: 2026-05-08
+Branch: `codex/send-email-automation-action-migration-20260508`
+
+## Context
+
+The RC staging remote verification harness exposed a mainline defect, not a staging drift issue. The application layer accepts `send_email` automation actions, but the PostgreSQL `automation_rules.chk_automation_action_type` constraint was last widened before `send_email` existed.
+
+Observed failure path:
+
+1. Route parsing accepts an automation rule with `actionType='send_email'`.
+2. The service-level action allowlist includes `send_email`.
+3. Insert into `automation_rules` reaches PostgreSQL.
+4. `chk_automation_action_type` rejects the row because the constraint still excludes `send_email`.
+5. The request fails as a server error and blocks the RC automation send_email smoke.
+
+## Root Cause
+
+`feat(multitable): add send email automation action` added JavaScript/TypeScript support for the action, executor handling, and frontend wiring. It did not add a follow-up migration to widen the database CHECK constraint.
+
+The prior action widening migration, `zzzz20260419213000_add_dingtalk_person_message_automation_action.ts`, allows:
+
+- `notify`
+- `update_field`
+- `update_record`
+- `create_record`
+- `send_webhook`
+- `send_notification`
+- `send_dingtalk_group_message`
+- `send_dingtalk_person_message`
+- `lock_record`
+
+It does not include `send_email`.
+
+## Change
+
+Added `zzzz20260508120000_add_send_email_automation_action.ts`.
+
+The migration replaces `chk_automation_action_type` with a widened action list that includes `send_email` while preserving all existing legacy and DingTalk action values.
+
+The rollback path restores the previous constraint list without `send_email`.
+
+## Test Design
+
+Added `send-email-automation-action-migration.test.ts`.
+
+The test deliberately validates the migration constants against the app-level `ALL_ACTION_TYPES` list. This prevents a repeat of the same class of bug where a new action is supported by application code but not by the database constraint.
+
+The test also asserts legacy actions remain present. Those values are still accepted by `automation_rules` even though newer V1 action helpers expose a narrower typed action list.
+
+## Rollout Notes
+
+This is a bugfix-only migration. It does not change executor behavior, notification behavior, or the RC staging harness.
+
+Required deployment sequence:
+
+1. Merge this PR.
+2. Deploy the new main build to staging/142.
+3. Run migrations.
+4. Re-run `pnpm verify:multitable-rc:staging` with a valid staging admin token.
+5. Treat `7/7 pass` as the RC GO signal; any failure remains in bugfix-only mode.

--- a/docs/development/multitable-send-email-automation-action-migration-verification-20260508.md
+++ b/docs/development/multitable-send-email-automation-action-migration-verification-20260508.md
@@ -1,0 +1,66 @@
+# Send Email Automation Action Constraint Migration — Verification
+
+Date: 2026-05-08
+Branch: `codex/send-email-automation-action-migration-20260508`
+
+## Scope
+
+This verification covers the database CHECK constraint widening needed for `send_email` automation actions.
+
+It does not claim that staging/142 is green. Staging still needs redeploy, migration execution, and a fresh `pnpm verify:multitable-rc:staging` run after this fix lands.
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/send-email-automation-action-migration.test.ts \
+  tests/unit/automation-v1.test.ts \
+  --reporter=dot
+```
+
+Result: passed.
+
+Evidence:
+
+- Test files: 2 passed
+- Tests: 129 passed
+- New migration test: 3 passed
+- Existing automation V1 regression: 126 passed
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+```
+
+Result: passed.
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/migration-provider.test.ts \
+  tests/unit/migrations.rollback.test.ts \
+  --reporter=dot
+```
+
+Result: passed.
+
+Evidence:
+
+- Test files: 2 passed
+- Tests: 14 passed
+
+```bash
+git diff --check
+```
+
+Result: passed.
+
+## Expected Staging Recheck
+
+After merge and deployment:
+
+```bash
+AUTH_TOKEN="$(cat /tmp/metasheet-staging-admin.jwt)" \
+API_BASE="http://142.171.239.56:8081" \
+pnpm verify:multitable-rc:staging
+```
+
+Expected result: the `automation-email` check should progress past rule creation and no longer fail on `chk_automation_action_type`.

--- a/packages/core-backend/src/db/migrations/zzzz20260508120000_add_send_email_automation_action.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260508120000_add_send_email_automation_action.ts
@@ -1,0 +1,50 @@
+import { sql, type Kysely } from 'kysely'
+
+export const AUTOMATION_ACTION_TYPES_WITH_SEND_EMAIL = [
+  'notify',
+  'update_field',
+  'update_record',
+  'create_record',
+  'send_webhook',
+  'send_notification',
+  'send_email',
+  'send_dingtalk_group_message',
+  'send_dingtalk_person_message',
+  'lock_record',
+] as const
+
+export const AUTOMATION_ACTION_TYPES_BEFORE_SEND_EMAIL = [
+  'notify',
+  'update_field',
+  'update_record',
+  'create_record',
+  'send_webhook',
+  'send_notification',
+  'send_dingtalk_group_message',
+  'send_dingtalk_person_message',
+  'lock_record',
+] as const
+
+function quotedActions(actions: readonly string[]): string {
+  return actions.map((action) => `'${action}'`).join(', ')
+}
+
+async function replaceAutomationActionTypeConstraint(
+  db: Kysely<unknown>,
+  actions: readonly string[],
+): Promise<void> {
+  await sql`ALTER TABLE automation_rules DROP CONSTRAINT IF EXISTS chk_automation_action_type`.execute(db)
+  await sql.raw(`
+    ALTER TABLE automation_rules
+    ADD CONSTRAINT chk_automation_action_type
+    CHECK (action_type IN (${quotedActions(actions)}))
+  `).execute(db)
+}
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await replaceAutomationActionTypeConstraint(db, AUTOMATION_ACTION_TYPES_WITH_SEND_EMAIL)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await replaceAutomationActionTypeConstraint(db, AUTOMATION_ACTION_TYPES_BEFORE_SEND_EMAIL)
+}

--- a/packages/core-backend/tests/unit/send-email-automation-action-migration.test.ts
+++ b/packages/core-backend/tests/unit/send-email-automation-action-migration.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { ALL_ACTION_TYPES } from '../../src/multitable/automation-actions'
+import {
+  AUTOMATION_ACTION_TYPES_BEFORE_SEND_EMAIL,
+  AUTOMATION_ACTION_TYPES_WITH_SEND_EMAIL,
+} from '../../src/db/migrations/zzzz20260508120000_add_send_email_automation_action'
+
+describe('send_email automation action migration', () => {
+  it('keeps the database action constraint in sync with app-level action types', () => {
+    expect(AUTOMATION_ACTION_TYPES_WITH_SEND_EMAIL).toContain('send_email')
+
+    for (const actionType of ALL_ACTION_TYPES) {
+      expect(AUTOMATION_ACTION_TYPES_WITH_SEND_EMAIL).toContain(actionType)
+    }
+  })
+
+  it('preserves legacy action types that are still accepted by automation_rules', () => {
+    expect(AUTOMATION_ACTION_TYPES_WITH_SEND_EMAIL).toEqual([
+      'notify',
+      'update_field',
+      'update_record',
+      'create_record',
+      'send_webhook',
+      'send_notification',
+      'send_email',
+      'send_dingtalk_group_message',
+      'send_dingtalk_person_message',
+      'lock_record',
+    ])
+  })
+
+  it('rolls back only the send_email widening', () => {
+    expect(AUTOMATION_ACTION_TYPES_BEFORE_SEND_EMAIL).not.toContain('send_email')
+    expect(AUTOMATION_ACTION_TYPES_BEFORE_SEND_EMAIL).toContain('send_dingtalk_group_message')
+    expect(AUTOMATION_ACTION_TYPES_BEFORE_SEND_EMAIL).toContain('send_dingtalk_person_message')
+    expect(AUTOMATION_ACTION_TYPES_BEFORE_SEND_EMAIL).toContain('lock_record')
+  })
+})


### PR DESCRIPTION
## Summary

Fixes the RC staging blocker where `send_email` automation rules pass application validation but fail PostgreSQL insertion because `automation_rules.chk_automation_action_type` did not include `send_email`.

Changes:
- Add `zzzz20260508120000_add_send_email_automation_action.ts` to widen `chk_automation_action_type`.
- Preserve legacy action values (`notify`, `update_field`) and DingTalk action values in the constraint.
- Add a regression test that asserts the DB constraint list includes every app-level `ALL_ACTION_TYPES` value, including `send_email`.
- Add development and verification docs for the staging bugfix-only path.

## Verification

```bash
pnpm --filter @metasheet/core-backend exec vitest run \
  tests/unit/send-email-automation-action-migration.test.ts \
  tests/unit/automation-v1.test.ts \
  --reporter=dot
# Test Files 2 passed; Tests 129 passed
```

```bash
pnpm --filter @metasheet/core-backend exec tsc --noEmit
# passed
```

```bash
pnpm --filter @metasheet/core-backend exec vitest run \
  tests/unit/migration-provider.test.ts \
  tests/unit/migrations.rollback.test.ts \
  --reporter=dot
# Test Files 2 passed; Tests 14 passed
```

```bash
git diff --check
# passed
```

## Staging follow-up

After merge and deploy to 142:

```bash
AUTH_TOKEN="$(cat /tmp/metasheet-staging-admin.jwt)" \
API_BASE="http://142.171.239.56:8081" \
pnpm verify:multitable-rc:staging
```

Expected: the `automation-email` check should no longer fail on `chk_automation_action_type`.
