### PR TITLE
fix(multitable): serialize automation execution steps as jsonb

### DIFF
--- a/docs/development/multitable-automation-log-jsonb-fix-development-20260508.md
+++ b/docs/development/multitable-automation-log-jsonb-fix-development-20260508.md
@@ -1,0 +1,52 @@
+# Automation Execution Log JSONB Fix — Development
+
+Date: 2026-05-08
+Branch: `codex/automation-log-jsonb-fix-20260508`
+
+## Context
+
+After the `send_email` action CHECK constraint migration landed, the RC staging harness progressed further:
+
+1. `POST /automations` accepted `send_email`.
+2. A real `record.created` event triggered the automation executor.
+3. `AutomationLogService.record()` attempted to insert the execution log.
+4. PostgreSQL rejected the `steps` JSONB value with `22P02 invalid input syntax for type json`.
+5. Because `executeRule()` did not await or catch `logService.record()`, the rejection escaped as an unhandled async failure and restarted the backend process.
+
+## Root Cause
+
+`AutomationLogService.record()` passed `execution.steps` directly as a JavaScript array:
+
+```ts
+steps: execution.steps as unknown as Record<string, unknown>[]
+```
+
+For PostgreSQL parameters, object values are JSON-stringified by `pg`, but JavaScript arrays are treated as PostgreSQL array literals. That produces a value shaped like an array of escaped JSON object strings, not a JSONB array.
+
+The failure suffix seen on staging:
+
+```text
+... "durationMs":205}"}\n
+```
+
+matches that array-literal double-encoding path.
+
+## Change
+
+Two changes were made:
+
+1. `AutomationLogService.record()` now writes `steps` through `toJsonValue(execution.steps)`, which emits an explicit `::jsonb` cast from a JSON string.
+2. `AutomationService.executeRule()` now awaits `logService.record(execution)` and catches persistence failures, logging them instead of letting a rejected promise crash the process.
+
+This preserves the execution result contract while preventing automation log persistence from becoming a process-level failure.
+
+## Risk Notes
+
+This fix is intentionally narrow:
+
+- It does not change automation action execution.
+- It does not change notification sending.
+- It does not change the automation log schema.
+- It does make execution logging deterministic for callers because `executeRule()` now waits for the log attempt to finish.
+
+The RC staging harness should be rerun after deployment because this fix targets the exact second `automation-email` blocker.

--- a/docs/development/multitable-automation-log-jsonb-fix-verification-20260508.md
+++ b/docs/development/multitable-automation-log-jsonb-fix-verification-20260508.md
@@ -1,0 +1,51 @@
+# Automation Execution Log JSONB Fix — Verification
+
+Date: 2026-05-08
+Branch: `codex/automation-log-jsonb-fix-20260508`
+
+## Scope
+
+This verification covers the automation execution log JSONB serialization path and the unhandled log persistence rejection path.
+
+It does not claim staging/142 is green. Staging still needs redeploy and a fresh `pnpm verify:multitable-rc:staging` run after this fix lands.
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/automation-v1.test.ts \
+  --reporter=dot
+```
+
+Result: passed.
+
+Evidence:
+
+- Test files: 1 passed
+- Tests: 128 passed
+- New coverage: `record()` writes `steps` through a JSONB raw builder instead of passing the raw JS array
+- New coverage: `executeRule()` returns the execution even when log persistence rejects
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+```
+
+Result: passed.
+
+```bash
+git diff --check
+```
+
+Result: passed.
+
+## Expected Staging Recheck
+
+After merge and deployment:
+
+```bash
+AUTH_TOKEN="$(cat /tmp/metasheet-staging-admin.jwt)" \
+API_BASE="http://142.171.239.56:8081" \
+pnpm verify:multitable-rc:staging
+```
+
+Expected result: the `automation-email` check should write execution steps successfully and no longer crash/restart the backend on `AutomationLogService.record()`.

--- a/packages/core-backend/src/multitable/automation-log-service.ts
+++ b/packages/core-backend/src/multitable/automation-log-service.ts
@@ -6,6 +6,7 @@
 
 import { sql } from 'kysely'
 import { db } from '../db/db'
+import { toJsonValue } from '../db/type-helpers'
 import type { AutomationExecution, AutomationStepResult } from './automation-executor'
 
 export interface AutomationStats {
@@ -21,6 +22,8 @@ export class AutomationLogService {
    * Record an execution log by inserting into the database.
    */
   async record(execution: AutomationExecution): Promise<void> {
+    // node-postgres treats JS arrays as PostgreSQL array literals unless we cast explicit JSON text.
+    const stepsJsonb = toJsonValue(execution.steps) as unknown as Record<string, unknown>[]
     await db
       .insertInto('multitable_automation_executions')
       .values({
@@ -29,7 +32,7 @@ export class AutomationLogService {
         triggered_by: execution.triggeredBy,
         triggered_at: execution.triggeredAt,
         status: execution.status,
-        steps: execution.steps as unknown as Record<string, unknown>[],
+        steps: stepsJsonb,
         error: execution.error ?? null,
         duration: execution.duration ?? null,
       })

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -627,7 +627,11 @@ export class AutomationService {
    */
   async executeRule(rule: ExecutorRule, triggerEvent: unknown): Promise<AutomationExecution> {
     const execution = await this.executor.execute(rule, triggerEvent)
-    this.logService.record(execution)
+    try {
+      await this.logService.record(execution)
+    } catch (err) {
+      logger.error('Automation execution log persistence failed', err instanceof Error ? err : undefined)
+    }
     return execution
   }
 

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -10,6 +10,7 @@ import { EventBus } from '../../src/integration/events/event-bus'
 
 const _executeResults: unknown[] = []
 const _executeTakeFirstResults: unknown[] = []
+const _valuesCalls: unknown[] = []
 
 function makeChain(): Record<string, unknown> {
   const self: Record<string, unknown> = {}
@@ -22,7 +23,12 @@ function makeChain(): Record<string, unknown> {
     'leftJoin',
   ]
   for (const m of methods) {
-    self[m] = vi.fn(chainFn)
+    self[m] = m === 'values'
+      ? vi.fn((value: unknown) => {
+        _valuesCalls.push(value)
+        return self
+      })
+      : vi.fn(chainFn)
   }
   self.execute = vi.fn(async () => {
     return _executeResults.shift() ?? []
@@ -1809,6 +1815,7 @@ describe('AutomationLogService', () => {
   beforeEach(() => {
     _executeResults.length = 0
     _executeTakeFirstResults.length = 0
+    _valuesCalls.length = 0
     logService = new AutomationLogService()
   })
 
@@ -1818,6 +1825,32 @@ describe('AutomationLogService', () => {
     _executeResults.push([])
     await logService.record(exec)
     // If it didn't throw, the insert was called
+  })
+
+  it('record() casts step arrays through jsonb instead of passing a raw PostgreSQL array', async () => {
+    const exec = createExecution({
+      ruleId: 'r1',
+      steps: [
+        {
+          actionType: 'send_email',
+          status: 'success',
+          output: {
+            notificationId: 'notif_1',
+            notificationStatus: 'sent',
+            recipientCount: 2,
+          },
+          durationMs: 205,
+        },
+      ],
+    })
+
+    _executeResults.push([])
+    await logService.record(exec)
+
+    const inserted = _valuesCalls.at(-1) as Record<string, unknown>
+
+    expect(inserted.steps).not.toBe(exec.steps)
+    expect(typeof (inserted.steps as { toOperationNode?: unknown }).toOperationNode).toBe('function')
   })
 
   it('getByRule() returns mapped executions', async () => {
@@ -1976,6 +2009,7 @@ describe('AutomationService — Rule CRUD', () => {
   beforeEach(() => {
     eventBus = new EventBus()
     queryFn = vi.fn(async () => ({ rows: [], rowCount: 0 }))
+    _valuesCalls.length = 0
     const db = makeMockDb()
     service = new AutomationService(eventBus, db as never, queryFn)
   })
@@ -2114,6 +2148,19 @@ describe('AutomationService — Rule CRUD', () => {
     expect(rule).not.toBeNull()
     expect(rule!.id).toBe('atr_123')
     expect(rule!.trigger_type).toBe('record.created')
+  })
+
+  it('executeRule returns the execution even when log persistence fails', async () => {
+    const logFailure = vi.spyOn(service.logs, 'record').mockRejectedValueOnce(new Error('jsonb insert failed'))
+
+    const execution = await service.executeRule(
+      createMockRule({ actions: [] }),
+      { sheetId: 'sheet_1', recordId: 'rec_1', data: {}, _triggeredBy: 'test' },
+    )
+
+    expect(logFailure).toHaveBeenCalledOnce()
+    expect(execution.status).toBe('success')
+    expect(execution.steps).toEqual([])
   })
 
   it('getRule returns null when not found', async () => {


### PR DESCRIPTION
## Summary

Fixes the second RC staging blocker found after `send_email` rule creation started passing:

- `AutomationLogService.record()` no longer passes `execution.steps` as a raw JavaScript array to a JSONB column.
- `steps` is now written through explicit JSONB serialization/cast via `toJsonValue(execution.steps)`.
- `AutomationService.executeRule()` now awaits log persistence and catches failures, so a log write rejection cannot become an unhandled promise rejection that restarts the backend.
- Adds regression coverage for both the JSONB raw-builder path and log persistence failure isolation.
- Adds development and verification docs for this bugfix-only RC blocker.

## Verification

```bash
pnpm --filter @metasheet/core-backend exec vitest run \
  tests/unit/automation-v1.test.ts \
  --reporter=dot
# Test Files 1 passed; Tests 128 passed
```

```bash
pnpm --filter @metasheet/core-backend exec tsc --noEmit
# passed
```

```bash
git diff --check
# passed
```

## Staging follow-up

After merge and deploy to 142:

```bash
AUTH_TOKEN="$(cat /tmp/metasheet-staging-admin.jwt)" \
API_BASE="http://142.171.239.56:8081" \
pnpm verify:multitable-rc:staging
```

Expected: the `automation-email` check should write execution steps successfully and no longer crash/restart the backend on `AutomationLogService.record()`.
