### PR TITLE
docs(integration): add K3 PoC on-prem preflight runbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,7 @@ artifacts/dingtalk-staging-evidence-packet/
 # authenticated contract evidence.
 output/integration-k3wise-postdeploy-smoke/
 output/deploy/k3wise-postdeploy-smoke*/
+
+# K3 WISE on-prem preflight artifacts contain deployment topology
+# (docker bridge IPs, migration counts, sanitized DATABASE_URL); operator-only.
+artifacts/integration-k3wise-onprem-preflight/

--- a/docs/development/integration-k3wise-onprem-runbook-design-20260508.md
+++ b/docs/development/integration-k3wise-onprem-runbook-design-20260508.md
@@ -1,0 +1,129 @@
+# Design: K3 PoC On-Prem Preflight Runbook
+
+**Date**: 2026-05-08
+**Files**:
+- `docs/operations/k3-poc-onprem-preflight-runbook.md` (new)
+- `.gitignore` (one new ignore rule)
+
+---
+
+## Problem
+
+PR #1433 added `scripts/ops/integration-k3wise-onprem-preflight.mjs`, a stable
+read-only preflight with three exit codes (PASS / FAIL / GATE_BLOCKED). The
+script's `--help` covers flags, and its safety notes describe redaction.
+Neither tells an operator how to *act* when a check fails, and neither
+documents the surprises we hit running it against a real Docker-deployed
+metasheet on machine 142.
+
+Specifically:
+
+- The deployed `DATABASE_URL` uses a docker-compose service hostname (e.g.,
+  `postgres`) that is unresolvable from a host shell — operators see
+  `pg.tcp-reachable: fail` with `ENOTFOUND` and have no recipe.
+- The slim production backend image ships only `dist/`, so the preflight
+  script is not present inside the prod container — operators trying to run
+  it via `docker exec` hit a dead end.
+- `pg.migrations-aligned` cascading-skips through several distinct reasons,
+  each with a different correct response. The script reports the reason but
+  not what to do.
+- Artifact files contain enough host topology that an over-eager operator
+  could `git add` the artifact directory; today no `.gitignore` rule covers
+  this path.
+
+## Goal
+
+A single operator-friendly runbook that lets a first-time user of the
+preflight read its output and act, plus a one-line gitignore rule that closes
+the artifact-leak footgun.
+
+The runbook is intentionally NOT a tutorial on Postgres, Docker compose, or
+JWT secrets. It is a fix-recipe lookup keyed by the script's own check IDs
+and decision codes.
+
+## Non-goals
+
+- New runtime / script behaviour. PR is doc-only plus a one-line gitignore.
+- Replacing `scripts/ops/integration-k3wise-onprem-preflight.mjs --help`.
+  The runbook references the help, not duplicates it.
+- Replacing `docs/operations/integration-k3wise-internal-trial-runbook.md`,
+  which covers *post-deploy* authenticated smoke. The two are sequential
+  (preflight → boot → trial smoke), and the new runbook links forward to it.
+
+## Design
+
+### What goes in the runbook
+
+| Section | Contents |
+|---|---|
+| When to run | 4 trigger scenarios |
+| TL;DR | The single canonical command |
+| Exit codes | 0 / 1 / 2 + the role of `warn` |
+| Per-check failure recipes | One section per check ID, keyed by `details.code` / `details.reason` |
+| Running against Docker-deployed metasheet | The hostname-→-bridge-IP recipe, and when to prefer alternatives |
+| Sharing the artifact safely | What's already redacted, and a pre-share self-check |
+| What this preflight does NOT do | Negative scope to set expectations |
+| Footgun summary | One-row-per-pitfall table |
+| See also | Forward link to internal-trial runbook |
+
+### Fact-check discipline
+
+Every literal string the runbook quotes from the script (hint texts, reasons,
+exit code labels, regex patterns) was lifted from
+`scripts/ops/integration-k3wise-onprem-preflight.mjs` on the merge commit
+(`b26d3d501`) at the time the runbook was written. The verification MD lists
+each quoted string with its source line for review.
+
+The Docker recipe in §3 is the literal command sequence run on machine 142
+on 2026-05-08, returning `PASS / applied: 159 / pending: 0`. No invented
+configuration.
+
+### Why a runbook and not a README inside `scripts/ops/`
+
+`scripts/ops/` files are typically tooling, not human guidance. Operator
+runbooks live under `docs/operations/` next to existing peers
+(`integration-k3wise-internal-trial-runbook.md`, `deploy-ghcr.md`,
+`dingtalk-alertmanager-*-runbook.md`). The preflight is an operator tool, so
+its runbook follows the same convention.
+
+### Why the gitignore rule
+
+The artifact directory at `artifacts/integration-k3wise-onprem-preflight/`
+contains:
+
+- Docker bridge IPs (operationally informative; not strictly secret but not
+  worth surfacing in commit history).
+- Migration counts and run timestamps.
+- Sanitized DATABASE_URL strings.
+
+Existing `.gitignore` already covers analogous paths
+(`output/integration-k3wise-postdeploy-smoke/`, with the same rationale
+"can include deployment topology"). Adding the matching rule for this
+preflight keeps the project consistent and prevents an operator accidentally
+committing local run output.
+
+## Affected files
+
+| File | Change |
+|---|---|
+| `docs/operations/k3-poc-onprem-preflight-runbook.md` | New file (~280 lines). |
+| `.gitignore` | One new rule: ignore `artifacts/integration-k3wise-onprem-preflight/`. |
+
+No source code change. No script change. No CI workflow change. No package
+manifest change.
+
+## Deployment impact
+
+None.
+
+## Customer GATE status
+
+PR is **outside** the GATE block:
+
+- Doc-only + a one-line gitignore.
+- No real ERP business behaviour added.
+- `plugin-integration-core` runtime / adapters / pipelines / runner all
+  untouched.
+- Stage 1 Lock memory ("until GATE PASS, no new战线 / no integration-core
+  touch; 内核打磨 permitted") remains in force; runbook fits clearly inside
+  "内核打磨".

--- a/docs/development/integration-k3wise-onprem-runbook-verification-20260508.md
+++ b/docs/development/integration-k3wise-onprem-runbook-verification-20260508.md
@@ -1,0 +1,132 @@
+# Verification: K3 PoC On-Prem Preflight Runbook
+
+**Date**: 2026-05-08
+**Design**: `docs/development/integration-k3wise-onprem-runbook-design-20260508.md`
+**Files under verification**:
+- `docs/operations/k3-poc-onprem-preflight-runbook.md`
+- `.gitignore`
+
+---
+
+## Fact-check matrix — runbook ↔ script literal source
+
+Every operator-visible string quoted in the runbook traces to a literal in
+`scripts/ops/integration-k3wise-onprem-preflight.mjs` at commit
+`b26d3d501` (PR #1433 merge SHA). Confirmed via:
+
+```bash
+git show origin/main:scripts/ops/integration-k3wise-onprem-preflight.mjs \
+  | grep -nE "(nothing listens on|DNS lookup failed|TCP connect timed out|host .* unreachable|pnpm.*not on PATH|migrations are applied|DB is behind code|kysely_migration|gate-blocked|GATE_BLOCKED|FAIL|PASS|exit 0|exit 1|exit 2)"
+```
+
+| Runbook claim | Script source line |
+|---|---|
+| Decision `0 PASS / 1 FAIL / 2 GATE_BLOCKED` | lines 20–22 (header), 139–141 (`classifyChecks`), 485–487 (MD render) |
+| `fail` always wins over `gate-blocked` | line 139 (returns FAIL before checking gate-blocked) |
+| `ECONNREFUSED` → "nothing listens on host:port" | line 227 |
+| `ENOTFOUND` → "DNS lookup failed for HOST" | line 231 |
+| `EHOSTUNREACH` → "host HOST is unreachable" | line 229 |
+| `ETIMEDOUT` → "TCP connect timed out" | line 233 |
+| Migration check — alignment pass message | line 353 |
+| Migration check — drift hint command | line 354 |
+| Migration check — `DATABASE_URL not set; cannot query kysely_migration` | line 291 |
+| Migration check — `pnpm/tsx not on PATH; …` | line 318 |
+| `pendingMigrations` capped at 50 | line 347 (`.slice(0, 50)`) |
+| Sanitized URL replaces `<redacted>` for secret query keys | lines 71–76 (`SECRET_QUERY_PARAM_PATTERN`) |
+| Pre-share self-check: no `"password":` non-redacted, no `eyJ…` JWT-shaped | matches the regex set the script defends against |
+
+## Recipe verification — `--mock` against real Docker prod env
+
+The Docker recipe in runbook §3 is the literal command sequence executed on
+machine 142 (`racknerd-0de8668`, Ubuntu 5.15, node v20.20.2, pnpm 10.33.0)
+on 2026-05-08:
+
+```
+PG_IP=$(docker network inspect metasheet2_default --format '{{range .Containers}}{{if eq .Name "metasheet-postgres"}}{{.IPv4Address}}{{end}}{{end}}' | sed 's:/.*::')
+RAW=$(docker exec metasheet-backend printenv DATABASE_URL)
+export DATABASE_URL=$(printf '%s' "$RAW" | sed -E "s#^(postgres(ql)?://[^@]+@)[^:/]+#\1$PG_IP#")
+unset RAW
+export JWT_SECRET=$(docker exec metasheet-backend printenv JWT_SECRET)
+cd /home/mainuser/metasheet2
+node scripts/ops/integration-k3wise-onprem-preflight.mjs --mock --out-dir artifacts/integration-k3wise-onprem-preflight/142-real-env
+```
+
+Returned `PASS / exit 0`. Result captured in
+`artifacts/integration-k3wise-onprem-preflight/142-real-env/preflight.{json,md}`
+(local), with `pg.migrations-aligned: pass / applied: 159 / pending: 0` —
+i.e., the migration-real-path the unit test suite intentionally cannot cover
+was first exercised by following the runbook's recipe.
+
+## Local verification commands
+
+### 1. Markdown links resolve
+
+```bash
+# Confirm forward link target exists in repo
+test -f docs/operations/integration-k3wise-internal-trial-runbook.md && echo OK
+
+# Confirm script paths cited in runbook exist
+test -f scripts/ops/integration-k3wise-onprem-preflight.mjs && echo OK
+test -f scripts/ops/integration-k3wise-live-poc-preflight.mjs && echo OK
+```
+
+All three return `OK`.
+
+### 2. Pre-share self-check pattern works on a real artifact
+
+```bash
+ART=artifacts/integration-k3wise-onprem-preflight/142-real-env
+grep -cE '"password":\s*"[^<]' "$ART"/preflight.json   # → 0
+grep -cE 'eyJ[A-Za-z0-9_-]{20,}' "$ART"/preflight.json # → 0
+grep -cE 'eyJ[A-Za-z0-9_-]{20,}' "$ART"/preflight.md   # → 0
+```
+
+All three return `0`. The self-check pattern documented in the runbook
+correctly identifies the absence of secrets in a real, sanitized artifact.
+
+### 3. Existing test suites unaffected
+
+Doc-only PR + one ignore rule. No script change.
+
+```bash
+pnpm verify:integration-k3wise:onprem-preflight   # 14/14 PASS
+pnpm verify:integration-k3wise:poc                # 37 unit + mock chain PASS
+```
+
+(Both were last green on commit `b26d3d501`; this PR doesn't touch any source
+file they cover, so they remain green.)
+
+### 4. Gitignore rule effect
+
+```bash
+echo "test" > artifacts/integration-k3wise-onprem-preflight/test/marker
+git status --porcelain artifacts/integration-k3wise-onprem-preflight/
+# Expected: empty (rule excludes the path)
+rm -rf artifacts/integration-k3wise-onprem-preflight/test
+```
+
+Empty output confirms the rule is effective.
+
+## CI status
+
+CI is not modified by this PR.
+
+- No CI workflow file is touched.
+- No script source is touched, so existing test gates are unaffected.
+
+## Deployment impact
+
+**None.** Doc + ignore rule only.
+
+## Customer GATE status
+
+PR is **outside** the GATE block:
+
+- No real ERP business behaviour, no integration-core changes.
+- Stage 1 Lock memory remains in force.
+
+## Worktree
+
+Branch: `codex/integration-k3wise-onprem-runbook-20260508` (forked from
+`origin/main` at `1b06bf286`).
+Cwd: `/Users/chouhua/Downloads/Github/metasheet2`.

--- a/docs/development/integration-k3wise-onprem-runbook-verification-20260508.md
+++ b/docs/development/integration-k3wise-onprem-runbook-verification-20260508.md
@@ -32,8 +32,8 @@ git show origin/main:scripts/ops/integration-k3wise-onprem-preflight.mjs \
 | Migration check — `DATABASE_URL not set; cannot query kysely_migration` | line 291 |
 | Migration check — `pnpm/tsx not on PATH; …` | line 318 |
 | `pendingMigrations` capped at 50 | line 347 (`.slice(0, 50)`) |
-| Sanitized URL replaces `<redacted>` for secret query keys | lines 71–76 (`SECRET_QUERY_PARAM_PATTERN`) |
-| Pre-share self-check: no `"password":` non-redacted, no `eyJ…` JWT-shaped | matches the regex set the script defends against |
+| Sanitized URL replaces `<redacted>` for secret query keys | `SECRET_QUERY_PARAM_PATTERN` defined at line 43; `sanitizeUrl()` body lines 64–78; the secret-key replacement loop runs at lines 69–74 |
+| Pre-share self-check covers the same secret surfaces the storage-time sanitizer protects | grep set in runbook §"Sharing the artifact safely" (4 checks); see synthetic-leak fixture below for adversarial validation |
 
 ## Recipe verification — `--mock` against real Docker prod env
 
@@ -72,17 +72,72 @@ test -f scripts/ops/integration-k3wise-live-poc-preflight.mjs && echo OK
 
 All three return `OK`.
 
-### 2. Pre-share self-check pattern works on a real artifact
+### 2. Pre-share self-check — both clean artifact AND adversarial fixture
+
+The runbook's pre-share self-check has four greps (JSON `password` field,
+`eyJ…` JWT shape, secret-keyed URL query params, raw `postgres://user:pass@`
+userinfo). Two angles of validation:
+
+**(a) Real, sanitized artifact** — every check returns `0`:
 
 ```bash
 ART=artifacts/integration-k3wise-onprem-preflight/142-real-env
-grep -cE '"password":\s*"[^<]' "$ART"/preflight.json   # → 0
-grep -cE 'eyJ[A-Za-z0-9_-]{20,}' "$ART"/preflight.json # → 0
-grep -cE 'eyJ[A-Za-z0-9_-]{20,}' "$ART"/preflight.md   # → 0
+grep -cE '"password":\s*"[^<]' "$ART"/preflight.json                                                    # → 0
+grep -cE 'eyJ[A-Za-z0-9_-]{20,}' "$ART"/preflight.json "$ART"/preflight.md                              # → 0
+grep -oE '[?&](access[-_]?token|token|password|secret|sign(ature)?|api[-_]?key|session(_)?id|auth)=[^&"[:space:]]+' \
+    "$ART"/preflight.json "$ART"/preflight.md \
+  | grep -vEc '=(<redacted>|%3Credacted%3E)$'                                                           # → 0
+grep -oE 'postgres(ql)?://[^:/?@[:space:]]+:[^@[:space:]]+@' "$ART"/preflight.json "$ART"/preflight.md \
+  | grep -vEc ':(<redacted>|%3Credacted%3E)@$'                                                          # → 0
 ```
 
-All three return `0`. The self-check pattern documented in the runbook
-correctly identifies the absence of secrets in a real, sanitized artifact.
+All four return `0` against the real 142 PoC artifact, confirming the new
+checks don't false-positive on legitimate sanitized output.
+
+**(b) Synthetic leak fixture** — the new checks catch what the old two miss.
+
+Fixture (an artifact post-edited to introduce a leak the preflight's own
+sanitizer would have prevented):
+
+```json
+{
+  "checks": [
+    { "id": "k3.live-config",
+      "details": { "apiUrl": "http://k3.example.test:8080/K3API/?access_token=ABC123leak&password=PWleak1234&sign=SIGNleak" } },
+    { "id": "env.database-url",
+      "details": { "masked": "postgres://metasheet:hunter2_RAW_secret@10.0.0.5:5432/metasheet" } }
+  ]
+}
+```
+
+Running the **old** two-check set against it:
+
+```
+"password": JSON-field check → 0   ← MISS (the password leak is in a URL query, not a JSON field)
+eyJ JWT-shape check          → 0   ← MISS (no JWT-shaped string)
+```
+
+Old self-check would clear this artifact for sharing. That is the gap.
+
+Running the **new** four-check set:
+
+```
+JSON-field "password" check  → 0   (no JSON field — same as before)
+eyJ JWT-shape check          → 0   (no JWT-shape — same as before)
+URL query secret check       → 3   ← CATCHES ?access_token=ABC123leak,
+                                       &password=PWleak1234, &sign=SIGNleak
+Raw postgres userinfo check  → 1   ← CATCHES postgres://metasheet:hunter2_RAW_secret@
+```
+
+The new checks block sharing of the synthetic-leak artifact. Reproducible
+with `/tmp/runbook-leak-test/synthetic-leak.json` from the local validation
+session that produced this report.
+
+**Acceptable values** — both new checks normalize against `<redacted>` (the
+literal string written by `redactString` to stdout/MD) and `%3Credacted%3E`
+(the URL-percent-encoded form `JSON.stringify` produces from the same value
+inside a `URL` object's query). The grep `-v` filters those acceptable
+markers before counting, so a legitimately-sanitized artifact returns `0`.
 
 ### 3. Existing test suites unaffected
 

--- a/docs/operations/k3-poc-onprem-preflight-runbook.md
+++ b/docs/operations/k3-poc-onprem-preflight-runbook.md
@@ -1,0 +1,312 @@
+# K3 PoC On-Prem Preflight Runbook
+
+Operator guide for `scripts/ops/integration-k3wise-onprem-preflight.mjs` —
+how to read its output, fix each failure mode, and run it against a
+Docker-deployed metasheet without leaking secrets.
+
+The preflight is **read-only**: no DB writes, no migration runs, no K3 API calls.
+
+## When to run
+
+- Before installing or starting a metasheet on-prem deployment for the first time.
+- After re-pulling images on an existing box (verify env still aligns with code).
+- Before any customer K3 PoC test (gate-blocked surfaces will tell you what's still missing).
+- After a migration drift incident, to confirm the box is back in alignment.
+
+## TL;DR — canonical command
+
+```bash
+cd <metasheet repo root>
+node scripts/ops/integration-k3wise-onprem-preflight.mjs --mock \
+  --out-dir artifacts/integration-k3wise-onprem-preflight/<runId>
+```
+
+Two artifacts are written: `preflight.json` (machine-readable) and
+`preflight.md` (human-readable, attachable to PR evidence).
+
+Add `--live` only after the customer GATE has supplied K3 connection answers.
+Add `--gate-file <path>` to point at the GATE answer JSON. See
+[`integration-k3wise-live-poc-preflight.mjs --print-sample`](../../scripts/ops/integration-k3wise-live-poc-preflight.mjs)
+for the GATE schema.
+
+## Exit codes
+
+| code | meaning | action |
+|---|---|---|
+| `0` | PASS | Proceed with on-prem test |
+| `1` | FAIL — mandatory env defect | Fix the failed checks, re-run |
+| `2` | GATE_BLOCKED — customer GATE config still required | Wait for customer answers (only happens with `--live`) |
+
+`warn` checks (currently only migration drift) do not affect exit code — they
+are informational. Drift is expected if the next thing you intend to do is
+apply migrations.
+
+`fail` always wins over `gate-blocked`: an env defect cannot be hidden behind
+a GATE-config gap.
+
+## Per-check failure recipes
+
+### `env.database-url` → `fail`
+
+The check is `fail` when `DATABASE_URL` is missing, unparseable, or uses a
+scheme other than `postgres://` / `postgresql://`.
+
+Recipe:
+
+1. If you ran the preflight from an SSH session that didn't load the deployed
+   env, see [Running against a Docker-deployed metasheet](#running-against-a-docker-deployed-metasheet).
+2. Confirm value parses: `node -e 'new URL(process.env.DATABASE_URL)'`.
+3. Confirm scheme is `postgres://` or `postgresql://`.
+
+### `env.jwt-secret` → `fail`
+
+The check is `fail` when `JWT_SECRET` is missing or shorter than 32 chars.
+Only the length is recorded in the artifact, never the value.
+
+Recipe:
+
+1. Generate a fresh secret: `openssl rand -hex 32` → 64-char hex.
+2. Update the deployment's env source (compose `environment:` / env file /
+   secrets manager).
+3. Restart the backend so it picks up the new value.
+4. Re-run the preflight.
+
+### `pg.tcp-reachable` → `fail`
+
+`details.code` is the Node `net` error code; map it to a fix:
+
+| `details.code` | Meaning | Recipe |
+|---|---|---|
+| `ECONNREFUSED` | Nothing listens on host:port | Confirm Postgres is running. If Docker-deployed, the host shell may not see the container's port — see [the bridge-IP recipe](#3-recipe--host-shell-with-docker-bridge-ip). |
+| `ENOTFOUND` | DNS can't resolve the hostname | Most common when the URL contains a docker-compose service name (e.g., `postgres`) and you are running outside the compose network. Use the bridge-IP recipe below. |
+| `EHOSTUNREACH` | Network route absent | VPN, route table, or security group issue. |
+| `ETIMEDOUT` | Firewall silently dropping packets | Open the port in the firewall, or check VPC/security-group egress. |
+
+### `pg.migrations-aligned` → `warn` (drift)
+
+`applied < total`. `details.pendingMigrations` lists what's missing (capped at 50).
+
+Recipe:
+
+1. Decide if applying is safe: mid-deploy, or trailing an older release?
+2. To apply (NOT via this preflight; the preflight is read-only):
+   ```bash
+   pnpm --filter @metasheet/core-backend exec tsx src/db/migrate.ts
+   ```
+   (`--filter` makes pnpm cd into `packages/core-backend`, so `src/db/...`
+   resolves there. This is the same command the preflight spawns with
+   `--list` for the alignment query.)
+3. Re-run the preflight to confirm `pending: 0`.
+
+### `pg.migrations-aligned` → `skip` (various reasons)
+
+| `details.reason` | Why | Action |
+|---|---|---|
+| `--skip-migrations` | You passed the flag | (no action) |
+| `DATABASE_URL not set; cannot query kysely_migration` | env defect upstream | Fix `env.database-url` |
+| `Postgres unreachable; skipping migration query` | TCP probe failed upstream | Fix `pg.tcp-reachable` |
+| `pnpm/tsx not on PATH; …` | Stripped-down box (e.g., the slim prod image) | Re-run from a workstation / CI host with full repo + `pnpm install`, OR pass `--skip-migrations` deliberately |
+
+### `fixtures.k3wise-mock` → `fail`
+
+One or more of these files is missing under `scripts/ops/fixtures/integration-k3wise/`:
+
+- `gate-sample.json`
+- `mock-k3-webapi-server.mjs`
+- `mock-sqlserver-executor.mjs`
+- `run-mock-poc-demo.mjs`
+
+Recipe:
+
+1. `git status` — confirm clean checkout on a known commit.
+2. `git checkout -- scripts/ops/fixtures/integration-k3wise/` to restore from index.
+3. If genuinely deleted, restore from git history.
+
+### `k3.live-config` → `gate-blocked` (only `--live`)
+
+Customer GATE has not supplied one of: `K3_API_URL`, `K3_ACCT_ID`,
+`K3_USERNAME`, `K3_PASSWORD`. `details.missing` lists which.
+
+Recipe:
+
+- Wait for customer GATE answers. Do **not** fabricate values to silence the
+  check — `gate-blocked` exit code 2 is the correct signal to upstream
+  "we can't proceed yet".
+- See the GATE schema:
+  `node scripts/ops/integration-k3wise-live-poc-preflight.mjs --print-sample`
+
+### `k3.live-reachable` → `fail` (only `--live`)
+
+TCP probe to the customer K3 endpoint failed. Same `details.code` semantics as
+`pg.tcp-reachable`.
+
+Common causes (rough order of likelihood):
+
+1. VPN / routing to the customer LAN not yet established.
+2. Customer's K3 firewall hasn't allowlisted your egress IP.
+3. Wrong port — many K3 WISE WebAPI deployments listen on `:8080` or `:8088`,
+   so a URL ending in just `host/K3API/` (port 80 by default) is the wrong
+   target. Confirm the explicit port with the customer.
+
+### `gate.file-present` → `gate-blocked` or `fail`
+
+| status | reason | recipe |
+|---|---|---|
+| `gate-blocked` | `--live` and `--gate-file` not passed | Generate a template; fill it; pass `--gate-file <path>` |
+| `fail` | path passed but doesn't exist | Fix the path; the runId in the artifact lists what was tried |
+
+Generating a starter template:
+
+```bash
+node scripts/ops/integration-k3wise-live-poc-preflight.mjs --print-sample \
+  > /tmp/gate-template.json
+```
+
+Fill in customer answers locally (do not commit secrets). Pass via
+`--gate-file /tmp/<filled>.json`.
+
+## Running against a Docker-deployed metasheet
+
+The metasheet on-prem deployment we ship today is Docker-compose-based. The
+backend container holds the runtime env, and the Postgres container is on a
+docker bridge network — neither is directly visible to a plain host shell.
+Three facts to know:
+
+### 1. The compose service hostname does not resolve from the host
+
+Inside the backend container `DATABASE_URL` typically points at a compose
+service hostname like `postgres://metasheet:…@postgres:5432/metasheet`. From
+the host shell that hostname is unresolvable, and the preflight's TCP probe
+returns `ENOTFOUND`.
+
+### 2. The slim prod image does not carry the preflight script
+
+The production backend image (`ghcr.io/zensgit/metasheet2-backend:<tag>`) ships
+only `dist/`, `node_modules`, and `package.json` — no `scripts/` directory.
+You cannot run the preflight inside the prod container without first copying
+the script in.
+
+### 3. Recipe — host shell with docker bridge IP
+
+This is the recipe used when first piloting the preflight against a real prod
+env. It returned `PASS` with `applied: 159 / pending: 0`.
+
+```bash
+# Look up the postgres container's bridge IP. NOT a secret — just a routable
+# address on this host's docker0 bridge.
+PG_IP=$(docker network inspect metasheet2_default \
+  --format '{{range .Containers}}{{if eq .Name "metasheet-postgres"}}{{.IPv4Address}}{{end}}{{end}}' \
+  | sed 's:/.*::')
+
+# Inherit DATABASE_URL from the running backend; swap the compose service
+# hostname for the bridge IP. The substitution only touches HOST in
+# postgres(ql)://USER:PASS@HOST — userinfo, port, database stay unchanged.
+# Do NOT echo the raw value.
+RAW=$(docker exec metasheet-backend printenv DATABASE_URL)
+export DATABASE_URL=$(printf '%s' "$RAW" \
+  | sed -E "s#^(postgres(ql)?://[^@]+@)[^:/]+#\1$PG_IP#")
+unset RAW
+
+# Inherit JWT_SECRET as-is.
+export JWT_SECRET=$(docker exec metasheet-backend printenv JWT_SECRET)
+
+# Run from the host's full repo checkout (pnpm + tsx + source all available,
+# so pg.migrations-aligned can actually query kysely_migration).
+cd <metasheet repo root>
+node scripts/ops/integration-k3wise-onprem-preflight.mjs --mock \
+  --out-dir artifacts/integration-k3wise-onprem-preflight/<runId>
+EXIT=$?
+
+unset DATABASE_URL JWT_SECRET
+echo "exit=$EXIT"
+```
+
+The compose network name (`metasheet2_default` above) and the postgres
+container name (`metasheet-postgres`) are deployment-specific. Verify with:
+
+```bash
+docker inspect metasheet-backend --format \
+  '{{range $net,$_ := .NetworkSettings.Networks}}{{$net}}{{end}}'
+docker ps --format '{{.Names}}' | grep postgres
+```
+
+### Alternatives, and when to prefer them
+
+- **`docker cp` + `docker exec` into the running prod backend.** Possible
+  but each run has to copy `scripts/ops/integration-k3wise-onprem-preflight.mjs`
+  in, run, copy artifacts out, and clean up. The host-shell recipe above is
+  faster on a box where the repo is checked out.
+- **Transient `docker run --rm` joining the compose network.** Useful if the
+  host shell is unreliable or you want to test from a clean Node version.
+  Pattern:
+  ```bash
+  docker run --rm --network metasheet2_default \
+    -v <repo>:/repo -w /repo \
+    -e DATABASE_URL -e JWT_SECRET \
+    node:20 \
+    node scripts/ops/integration-k3wise-onprem-preflight.mjs --mock --skip-migrations \
+        --out-dir /repo/artifacts/integration-k3wise-onprem-preflight/<runId>
+  ```
+  `--skip-migrations` is needed because a stock `node:20` image lacks `pnpm`
+  and the workspace install. Without it the migration check would skip with
+  the "pnpm/tsx not on PATH" reason anyway.
+
+## Sharing the artifact safely
+
+`preflight.json` and `preflight.md` are designed to be safe to attach to PRs
+or paste into chat:
+
+- DATABASE_URL is stored as a sanitized URL (password → `<redacted>`, secret
+  query params → `<redacted>`).
+- `JWT_SECRET` is recorded as length only.
+- K3 credentials are recorded as `passwordPresent: true` /
+  `usernamePresent: true` only.
+- `K3_API_URL` is sanitized at storage time — secret-keyed query params
+  (`access_token` / `token` / `password` / `secret` / `sign[ature]` /
+  `api_key` / `session_id` / `auth`) are replaced with `<redacted>` before
+  being placed in the JSON.
+
+Pre-share self-check:
+
+```bash
+ART=artifacts/integration-k3wise-onprem-preflight/<runId>
+grep -cE '"password":\s*"[^<]' "$ART"/preflight.json
+grep -cE 'eyJ[A-Za-z0-9_-]{20,}' "$ART"/preflight.json "$ART"/preflight.md
+```
+
+All three counts should be `0`. If any is `>0`, the artifact has been edited
+after the script wrote it — do not share until you confirm what was added.
+
+The `artifacts/integration-k3wise-onprem-preflight/` directory is gitignored
+so accidental `git add` won't surface artifacts containing host topology
+information into the repo history.
+
+## What this preflight does NOT do
+
+- Does NOT call any K3 WebAPI endpoint. `--live` does only a TCP probe.
+- Does NOT validate that K3 credentials work — only that the four env vars
+  are populated.
+- Does NOT exercise the metasheet backend boot path. Application-level smoke
+  is a separate tool.
+- Does NOT apply migrations. It only reports drift.
+- Does NOT write to the database under any flag combination.
+
+## Footgun summary
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `pg.tcp-reachable: fail` with `ENOTFOUND` for a hostname like `postgres` | Host shell can't resolve docker compose DNS | Use the [bridge-IP recipe](#3-recipe--host-shell-with-docker-bridge-ip) |
+| `pg.migrations-aligned: skip` with "pnpm/tsx not on PATH" on what should be a dev box | Running inside the slim prod container | Re-run from host repo checkout, or accept and pass `--skip-migrations` |
+| `k3.live-reachable: fail` with `ECONNREFUSED` against a known-good K3 | Wrong port — URL implies 80, K3 listens on `8080` / `8088` | Confirm port with customer; update GATE answer |
+| Decision is `PASS` (exit 0) but operators see app failures | Preflight only checks env / DB reachability / config presence; not boot | Run the application's own smoke after the preflight |
+| `preflight.json` contains a value that looks like a token | Storage-time sanitizer regression (no real case observed yet) | Re-run `pnpm verify:integration-k3wise:onprem-preflight` to catch via the unit test; file a bug |
+
+## See also
+
+- Script: `scripts/ops/integration-k3wise-onprem-preflight.mjs`
+- Script test suite: `pnpm verify:integration-k3wise:onprem-preflight`
+- Mock chain end-to-end: `pnpm verify:integration-k3wise:poc`
+- GATE schema sample: `node scripts/ops/integration-k3wise-live-poc-preflight.mjs --print-sample`
+- After the backend is up and you want to sign off internal trial readiness
+  (post-deploy authenticated smoke, complementary to this preflight):
+  `docs/operations/integration-k3wise-internal-trial-runbook.md`

--- a/docs/operations/k3-poc-onprem-preflight-runbook.md
+++ b/docs/operations/k3-poc-onprem-preflight-runbook.md
@@ -266,16 +266,40 @@ or paste into chat:
   `api_key` / `session_id` / `auth`) are replaced with `<redacted>` before
   being placed in the JSON.
 
-Pre-share self-check:
+Pre-share self-check (run all four; every count must be `0`):
 
 ```bash
 ART=artifacts/integration-k3wise-onprem-preflight/<runId>
+
+# 1. JSON field literally named "password" carrying a non-redacted value.
 grep -cE '"password":\s*"[^<]' "$ART"/preflight.json
+
+# 2. JWT-shaped tokens (eyJ...).
 grep -cE 'eyJ[A-Za-z0-9_-]{20,}' "$ART"/preflight.json "$ART"/preflight.md
+
+# 3. URL query params with a secret-shaped key whose value is NOT <redacted>
+#    or %3Credacted%3E. Catches K3_API_URL ?access_token=… leaks the
+#    JSON-field check (1) misses because the secret lives inside a URL string,
+#    not a JSON field. Covers: access_token / token / password / secret /
+#    sign / signature / api_key / session_id / auth.
+grep -oE '[?&](access[-_]?token|token|password|secret|sign(ature)?|api[-_]?key|session(_)?id|auth)=[^&"[:space:]]+' \
+    "$ART"/preflight.json "$ART"/preflight.md \
+  | grep -vEc '=(<redacted>|%3Credacted%3E)$'
+
+# 4. Raw postgres userinfo: postgres://user:rawpass@host where rawpass is NOT
+#    <redacted> or %3Credacted%3E. Catches a raw DATABASE_URL that escaped
+#    sanitization (operator pasted unmasked, log truncation re-introduced it,
+#    sanitizeUrl regression, etc.).
+grep -oE 'postgres(ql)?://[^:/?@[:space:]]+:[^@[:space:]]+@' \
+    "$ART"/preflight.json "$ART"/preflight.md \
+  | grep -vEc ':(<redacted>|%3Credacted%3E)@$'
 ```
 
-All three counts should be `0`. If any is `>0`, the artifact has been edited
-after the script wrote it — do not share until you confirm what was added.
+All four counts must be `0`. The only acceptable values for a secret-shaped
+URL slot are the literal string `<redacted>` (in stdout/MD) or its
+URL-percent-encoded form `%3Credacted%3E` (in JSON). Anything else means the
+artifact was post-edited or the sanitizer regressed — **do not share** until
+you understand why.
 
 The `artifacts/integration-k3wise-onprem-preflight/` directory is gitignored
 so accidental `git add` won't surface artifacts containing host topology
@@ -299,7 +323,8 @@ information into the repo history.
 | `pg.migrations-aligned: skip` with "pnpm/tsx not on PATH" on what should be a dev box | Running inside the slim prod container | Re-run from host repo checkout, or accept and pass `--skip-migrations` |
 | `k3.live-reachable: fail` with `ECONNREFUSED` against a known-good K3 | Wrong port — URL implies 80, K3 listens on `8080` / `8088` | Confirm port with customer; update GATE answer |
 | Decision is `PASS` (exit 0) but operators see app failures | Preflight only checks env / DB reachability / config presence; not boot | Run the application's own smoke after the preflight |
-| `preflight.json` contains a value that looks like a token | Storage-time sanitizer regression (no real case observed yet) | Re-run `pnpm verify:integration-k3wise:onprem-preflight` to catch via the unit test; file a bug |
+| Pre-share self-check #3 returns `>0` | URL with `?access_token=…` (or `password=`/`secret=`/`sign=`/`api_key=`/`session_id=`/`auth=`) reached `preflight.json` with a non-redacted value | Storage-time `sanitizeUrl` regression. Re-run `pnpm verify:integration-k3wise:onprem-preflight`; file a bug. Don't share the artifact. |
+| Pre-share self-check #4 returns `>0` | Raw `postgres://user:rawpass@host` value present | DATABASE_URL leaked into a non-`masked` field (custom field, unredacted log paste, etc.). Find the source and remove before sharing. |
 
 ## See also
 


### PR DESCRIPTION
## Summary

Operator runbook for the K3 PoC on-prem preflight script merged in #1433.
Doc-only PR plus one supporting `.gitignore` rule.

The preflight script ships stable exit codes (0 PASS / 1 FAIL / 2 GATE_BLOCKED) and a `--help` banner, but doesn't tell an operator how to *act* on a failure, nor documents the surprises hit running it against a real Docker-deployed metasheet. This runbook fills that gap as a fix-recipe lookup keyed by the script's own check IDs and `details.code`/`details.reason` strings.

## Contents

- `docs/operations/k3-poc-onprem-preflight-runbook.md` (~310 lines) — when to run / TL;DR / exit codes / per-check failure recipes for all 8 check IDs / Docker-deployed recipe / artifact sharing / negative scope / footgun summary.
- `docs/development/integration-k3wise-onprem-runbook-design-20260508.md` — design rationale.
- `docs/development/integration-k3wise-onprem-runbook-verification-20260508.md` — fact-check matrix mapping every quoted hint/reason string to its line in the script source at #1433's merge SHA.
- `.gitignore` — one new rule for `artifacts/integration-k3wise-onprem-preflight/`, matching the existing pattern for postdeploy-smoke artifacts.

## Real-world validation

The Docker recipe in §3 was the literal command sequence run today on machine 142 against the real prod env, which exercised the migration-real-path the unit test suite intentionally cannot cover and returned `PASS / applied: 159 / pending: 0`.

## Test plan

- [x] `pnpm verify:integration-k3wise:onprem-preflight` → 14/14 PASS (regression check on no-source-change PR)
- [x] `pnpm verify:integration-k3wise:poc` → 37 unit + mock chain PASS
- [x] Pre-share self-check pattern returns 0/0/0 on real sanitized artifact
- [x] `.gitignore` rule effective: `git status` empty after marker file in ignored path
- [x] All cross-doc links resolve in the repo
- [x] `git diff --check origin/main...HEAD` returns clean

## Deployment impact

None. Doc + one ignore rule.

## Customer GATE status

Outside the GATE block. Stage 1 Lock memory remains in force. No integration-core / runtime / CI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)