### PR TITLE
docs(multitable): archive RC staging verification

### DIFF
--- a/docs/development/artifacts/multitable-rc-staging-142-20260508/report.json
+++ b/docs/development/artifacts/multitable-rc-staging-142-20260508/report.json
@@ -1,0 +1,86 @@
+{
+  "apiBase": "http://127.0.0.1:18990",
+  "startedAt": "2026-05-08T07:48:20.497Z",
+  "finishedAt": "2026-05-08T07:48:37.146Z",
+  "total": 7,
+  "passes": 7,
+  "fails": 0,
+  "skips": 0,
+  "results": [
+    {
+      "name": "lifecycle",
+      "status": "pass",
+      "durationMs": 2637,
+      "evidence": {
+        "sheetId": "sheet_2fec8215-488c-4cc9-be7f-a99fe3d48fa5",
+        "viewId": "view_628bb6d3-48a9-4c39-ae1e-cde37534e8f4",
+        "recordId": "rec_e904684c-e814-4342-b81e-07bea422ae0e",
+        "fieldId": "fld_97718188-40ca-4f1d-8b42-2c7398604142"
+      }
+    },
+    {
+      "name": "public-form",
+      "status": "pass",
+      "durationMs": 3045,
+      "evidence": {
+        "sheetId": "sheet_43f06ae5-4e63-43ae-96c0-705ede25aa4a",
+        "viewId": "view_9a68d789-104a-4fcc-ad65-2d89cfbd7687",
+        "recordId": "rec_1b2325c7-90c6-47d5-a932-f5adc3887614",
+        "rotatedRecordId": "rec_c468283f-46d6-4962-9acb-d67f8e6aa91b"
+      }
+    },
+    {
+      "name": "hierarchy",
+      "status": "pass",
+      "durationMs": 1757,
+      "evidence": {
+        "sheetId": "sheet_3a949813-c771-4a96-bb59-5f789e04e983",
+        "parentFieldId": "fld_367c58ff-4529-49b7-9582-3b5495b8ea18",
+        "recordId": "rec_31b6608f-c499-4df3-bb6c-6c0e1084911c"
+      }
+    },
+    {
+      "name": "gantt-config",
+      "status": "pass",
+      "durationMs": 2131,
+      "evidence": {
+        "sheetId": "sheet_fcd550bc-022a-452c-9269-acd841c45b59",
+        "viewId": "view_3847beb6-5b91-4c08-a7bd-da231b544b79"
+      }
+    },
+    {
+      "name": "formula",
+      "status": "pass",
+      "durationMs": 1947,
+      "evidence": {
+        "sheetId": "sheet_79d58570-29a5-43b2-93f8-5f02b84dc67d",
+        "formulaFieldId": "fld_ff915ffa-e264-47c5-a0f7-c718e98e977f"
+      }
+    },
+    {
+      "name": "automation-email",
+      "status": "pass",
+      "durationMs": 2191,
+      "evidence": {
+        "sheetId": "sheet_0dd4d5fd-6f76-438a-92ca-99b9ab20d8e8",
+        "ruleId": "atr_9f603083-8b95-434f-a44d-b9443d68cc40",
+        "executionId": "axe_06c04914-b096-491f-a3e9-61225be9c1ba"
+      }
+    },
+    {
+      "name": "autoNumber-backfill",
+      "status": "pass",
+      "durationMs": 2940,
+      "evidence": {
+        "sheetId": "sheet_2d57347f-b0f6-442d-867f-57ae570556b3",
+        "fieldId": "fld_9dd71b70-5cb0-40dd-9622-caa5619581e0",
+        "backfilled": [
+          1000,
+          1001,
+          1002
+        ],
+        "freshValue": 1003
+      }
+    }
+  ]
+}

--- a/docs/development/artifacts/multitable-rc-staging-142-20260508/report.md
+++ b/docs/development/artifacts/multitable-rc-staging-142-20260508/report.md
@@ -1,0 +1,16 @@
+# Multitable RC Staging Smoke Report
+
+- API: `http://127.0.0.1:18990`
+- Started: 2026-05-08T07:48:20.497Z
+- Finished: 2026-05-08T07:48:37.146Z
+- Total: 7 (pass=7, fail=0, skip=0)
+
+| Check | Status | Duration |
+| --- | --- | --- |
+| lifecycle | pass | 2637ms |
+| public-form | pass | 3045ms |
+| hierarchy | pass | 1757ms |
+| gantt-config | pass | 2131ms |
+| formula | pass | 1947ms |
+| automation-email | pass | 2191ms |
+| autoNumber-backfill | pass | 2940ms |

--- a/docs/development/multitable-rc-staging-142-verification-20260508.md
+++ b/docs/development/multitable-rc-staging-142-verification-20260508.md
@@ -1,0 +1,119 @@
+# Multitable RC Staging 142 Verification - 2026-05-08
+
+## Scope
+
+This is a verification-only artifact for the 142 staging deployment after the
+`send_email` automation action fixes landed.
+
+Validated fixes:
+
+- PR `#1435` / commit `4fae7dc32d1a2b3ed6241c675bc3ec4c0729f72d`:
+  database CHECK constraint includes `send_email`.
+- PR `#1436` / commit `1b06bf286915b4eafc4d5d0287f5ce6ad95cbd9b`:
+  automation execution log persists JSONB steps without crashing the backend.
+
+No source code was changed in this verification run.
+
+## Deployment Evidence
+
+Target:
+
+- Host: `staging/142`
+- Backend local API: `http://127.0.0.1:8900`
+- Verification access path: SSH local port forward to backend local API
+
+Observed deployment state:
+
+- `IMAGE_TAG=1b06bf286915b4eafc4d5d0287f5ce6ad95cbd9b`
+- Backend image: `ghcr.io/zensgit/metasheet2-backend:1b06bf286915b4eafc4d5d0287f5ce6ad95cbd9b`
+- Web image: `ghcr.io/zensgit/metasheet2-web:1b06bf286915b4eafc4d5d0287f5ce6ad95cbd9b`
+- Backend container started at `2026-05-08T07:35:22.391346218Z`
+- The image tags above were observed from `docker-compose -f docker-compose.app.yml images`.
+- Health check: `/api/health` returned `status="ok"`, `plugins=13`, `failed=0`.
+- Functional multitable readiness is asserted by the seven-check harness below,
+  not by plugin count alone.
+
+## Auth Handling
+
+A short-lived staging admin JWT was generated from the running backend
+container using the server signing configuration and a real active admin user
+record.
+
+Validation:
+
+- `/api/auth/me` returned HTTP 200.
+- Returned user role was `admin`.
+- The token value was not written to this document.
+- Local and remote temporary token files were removed after the harness run.
+
+## Harness Command
+
+The 142 host does not have a host-level Node runtime, so the harness was run
+from the local repository through an SSH tunnel:
+
+```bash
+ssh -fN \
+  -L 18990:127.0.0.1:8900 \
+  -o ExitOnForwardFailure=yes \
+  -o BatchMode=yes \
+  -o ConnectTimeout=8 \
+  -o StrictHostKeyChecking=accept-new \
+  <staging-142>
+
+OUTPUT_DIR=/tmp/metasheet-rc-staging-verify-20260508-004820 \
+API_BASE=http://127.0.0.1:18990 \
+AUTH_TOKEN="$(cat /tmp/metasheet-staging-admin.jwt)" \
+pnpm verify:multitable-rc:staging
+```
+
+The tunnel was closed after the run.
+
+## Result
+
+Original temporary report files:
+
+- `/tmp/metasheet-rc-staging-verify-20260508-004820/report.json`
+- `/tmp/metasheet-rc-staging-verify-20260508-004820/report.md`
+
+Committed report artifacts:
+
+- `docs/development/artifacts/multitable-rc-staging-142-20260508/report.json`
+- `docs/development/artifacts/multitable-rc-staging-142-20260508/report.md`
+
+Summary:
+
+```text
+[rc-smoke] PASS lifecycle (2637ms)
+[rc-smoke] PASS public-form (3045ms)
+[rc-smoke] PASS hierarchy (1757ms)
+[rc-smoke] PASS gantt-config (2131ms)
+[rc-smoke] PASS formula (1947ms)
+[rc-smoke] PASS automation-email (2191ms)
+[rc-smoke] PASS autoNumber-backfill (2940ms)
+[rc-smoke] result: 7 pass / 0 fail / 0 skip / 7 total
+```
+
+Report table:
+
+| Check | Status | Duration |
+| --- | --- | --- |
+| lifecycle | pass | 2637ms |
+| public-form | pass | 3045ms |
+| hierarchy | pass | 1757ms |
+| gantt-config | pass | 2131ms |
+| formula | pass | 1947ms |
+| automation-email | pass | 2191ms |
+| autoNumber-backfill | pass | 2940ms |
+
+## Conclusion
+
+142 staging is green for the Multitable RC remote harness on image
+`1b06bf286915b4eafc4d5d0287f5ce6ad95cbd9b`.
+
+RC decision signal:
+
+- `GO` for the seven automated staging checks covered by
+  `pnpm verify:multitable-rc:staging`.
+- Manual browser checks can still be run separately if product/UI sign-off is
+  required, but the previous staging blockers in automation `send_email` are
+  cleared.

--- a/docs/release/multitable-rc-20260508-release-note.md
+++ b/docs/release/multitable-rc-20260508-release-note.md
@@ -1,0 +1,134 @@
+# Multitable RC Release Note - 2026-05-08
+
+## Candidate
+
+- RC tag proposal: `multitable-rc-20260508-1b06bf286`
+- Source commit: `1b06bf286915b4eafc4d5d0287f5ce6ad95cbd9b`
+- Staging host: `staging/142`
+- Staging image tag: `1b06bf286915b4eafc4d5d0287f5ce6ad95cbd9b`
+
+## Included Scope
+
+This RC covers the current Multitable Feishu-parity release candidate after the
+RC smoke, hardening, and staging blocker fixes.
+
+Major verified surfaces:
+
+- Basic multitable lifecycle.
+- Public form submission and rotated-token behavior.
+- Hierarchy view cycle guard.
+- Gantt dependency configuration validation.
+- Formula field persistence.
+- Automation `send_email` execution and log persistence.
+- AutoNumber backfill and raw-write rejection.
+
+Recent staging blockers resolved before this RC:
+
+- PR `#1435` / commit `4fae7dc32d1a2b3ed6241c675bc3ec4c0729f72d`:
+  `send_email` was accepted by application code but rejected by the database
+  `automation_rules.chk_automation_action_type` constraint.
+- Automation execution logs could crash persistence on JSONB `steps` insertion.
+  This was fixed by PR `#1436` / commit
+  `1b06bf286915b4eafc4d5d0287f5ce6ad95cbd9b`.
+
+## Verification
+
+Automated staging verification:
+
+```text
+pnpm verify:multitable-rc:staging
+```
+
+Result on 142 staging:
+
+```text
+7 pass / 0 fail / 0 skip / 7 total
+```
+
+Per-check result:
+
+| Check | Status |
+| --- | --- |
+| lifecycle | pass |
+| public-form | pass |
+| hierarchy | pass |
+| gantt-config | pass |
+| formula | pass |
+| automation-email | pass |
+| autoNumber-backfill | pass |
+
+Evidence artifact:
+
+- `docs/development/multitable-rc-staging-142-verification-20260508.md`
+- `docs/development/artifacts/multitable-rc-staging-142-20260508/report.json`
+- `docs/development/artifacts/multitable-rc-staging-142-20260508/report.md`
+
+## Known Limits
+
+- This RC note records automated API-level staging verification. Manual browser
+  visual sign-off is still useful for final product confidence, especially for
+  table layout, Gantt rendering, hierarchy interactions, and formula editor UX.
+- The staging harness creates timestamped test data and does not clean it up.
+- The harness validates the mocked/default email delivery path by execution log
+  output, not delivery to an external SMTP inbox.
+
+## Rollback
+
+Preferred rollback posture:
+
+- Prefer a forward bugfix over image rollback for this RC, because the previous
+  image before `#1436` is known to reintroduce the automation execution-log
+  crash when `send_email` rules run.
+- If rollback is required, the release owner must choose the rollback image and
+  confirm whether `send_email` automations are allowed to keep running.
+
+Partial rollback target:
+
+- `4fae7dc32d1a2b3ed6241c675bc3ec4c0729f72d` is only a partial rollback target
+  for issues isolated to `#1436`. It still contains `send_email` support and is
+  known to crash the automation execution-log path for triggered `send_email`
+  rules.
+
+Rollback preconditions:
+
+1. Backend and web images must be rolled as a matched tag pair.
+2. If rolling to an image before `#1436`, disable or quarantine active
+   `send_email` automation rules before restart.
+3. Leave the `#1435` widened CHECK constraint migration in place unless a
+   separate database rollback plan explicitly handles existing `send_email`
+   rows.
+
+Rollback procedure:
+
+1. Set `IMAGE_TAG` in the 142 deployment environment to the selected prior
+   image tag.
+2. Run `docker-compose -f docker-compose.app.yml pull`.
+3. Run `docker-compose -f docker-compose.app.yml up -d`.
+4. Verify `/api/health`.
+5. Re-run `pnpm verify:multitable-rc:staging` or a scoped equivalent for the
+   rollback target.
+
+Data note:
+
+- The `#1435` migration expands an allowed CHECK constraint value and is safe to
+  leave in place for forward-compatible rows. Rolling application code to a
+  version that does not understand `send_email` while leaving active
+  `send_email` rules enabled is not safe.
+
+Rollback success criteria:
+
+- `/api/health` returns healthy.
+- The selected staging smoke or scoped rollback smoke returns `0` failures.
+- Abort rollback completion if any smoke check fails or if backend logs show
+  automation execution-log persistence errors.
+
+## RC Decision
+
+Automated staging signal: `GO`.
+
+Recommended gate before broad rollout:
+
+- Keep the branch in bugfix-only mode.
+- Run a short manual browser smoke for visual/product confidence if the release
+  owner requires UI sign-off.
+- If no blocker is found, tag `multitable-rc-20260508-1b06bf286`.


### PR DESCRIPTION
## Summary

- Archive 142 staging RC verification evidence for image `1b06bf286915b4eafc4d5d0287f5ce6ad95cbd9b`.
- Add committed `report.json` and `report.md` artifacts for the 7/7 staging harness run.
- Add RC release note with scoped GO signal, known limits, and rollback guidance.

## Verification

- `git diff --check`
- `node -e 'JSON.parse(require("fs").readFileSync("docs/development/artifacts/multitable-rc-staging-142-20260508/report.json","utf8")); console.log("json_ok")'`\n- Secret scan for JWT/GitHub token/Bearer/IP/SSH-key literals in changed docs\n- Claude CLI read-only release-safety review: `NO BLOCKERS`\n\n## Notes\n\nDocs-only. No application code, migration, or deployment change.