### PR TITLE
test(multitable): support staging UI smoke auth bootstrap

### DIFF
--- a/docs/development/multitable-staging-ui-smoke-bootstrap-development-20260508.md
+++ b/docs/development/multitable-staging-ui-smoke-bootstrap-development-20260508.md
@@ -1,0 +1,89 @@
+# Multitable Staging UI Smoke Bootstrap - Development - 2026-05-08
+
+## Context
+
+The Multitable RC API/staging harness is green, but the browser-level RC
+Playwright specs were still local-only:
+
+- Frontend URL hard-coded to `http://127.0.0.1:8899`.
+- Backend URL hard-coded to `http://localhost:7778`.
+- Auth hard-coded to `phase0@test.local` / `Phase0Test!2026`.
+
+On staging/142, the `phase0@test.local` account is not available, so those
+tests skip or fail before exercising the UI. The goal of this slice is to make
+the existing RC Playwright smokes runnable against staging using a short-lived
+admin token, without creating accounts or changing product runtime code.
+
+## Changes
+
+### E2E helper bootstrap
+
+Updated `packages/core-backend/tests/e2e/multitable-helpers.ts`:
+
+- `FE_BASE_URL` now reads `process.env.FE_BASE_URL`, falling back to
+  `http://127.0.0.1:8899`.
+- `API_BASE_URL` now reads `process.env.API_BASE_URL`, falling back to
+  `http://localhost:7778`.
+- Base URLs strip trailing slashes so callers can pass either
+  `http://host:port` or `http://host:port/`.
+- `resolveE2EAuthToken(request)` now uses `AUTH_TOKEN` when present and falls
+  back to `loginAsPhase0(request)` otherwise.
+- `ensureServersReachable()` still checks `/health`, and now falls back to
+  `/api/health` before skipping.
+- `injectTokenAndGo()` now writes the current frontend auth keys:
+  `auth_token`, `jwt`, and `devToken`.
+- The previous smoke-only keys `metasheet_token` and `token` are still written
+  for backwards compatibility.
+
+### Spec wiring
+
+Updated the six multitable RC Playwright specs to call
+`resolveE2EAuthToken(request)` instead of `loginAsPhase0(request)` directly:
+
+- `multitable-lifecycle-smoke.spec.ts`
+- `multitable-public-form-smoke.spec.ts`
+- `multitable-hierarchy-smoke.spec.ts`
+- `multitable-gantt-smoke.spec.ts`
+- `multitable-formula-smoke.spec.ts`
+- `multitable-automation-send-email-smoke.spec.ts`
+
+Local behavior is unchanged when `AUTH_TOKEN` is absent.
+
+### Playwright config and docs
+
+Updated `packages/core-backend/tests/e2e/playwright.config.ts`:
+
+- `use.baseURL` now follows `FE_BASE_URL` when provided.
+
+Updated `packages/core-backend/tests/e2e/README.md`:
+
+- Documented `FE_BASE_URL`, `API_BASE_URL`, and `AUTH_TOKEN`.
+- Added a staging/remote execution example using SSH tunnels.
+- Clarified that `phase0@test.local` is the local fallback, not a staging
+  prerequisite.
+
+### Regression coverage
+
+Added `packages/core-backend/tests/unit/multitable-e2e-helper-env.test.ts`:
+
+- Defaults to local URLs when env is absent.
+- Reads env URLs and strips trailing slashes.
+- Uses `AUTH_TOKEN` before attempting phase0 login.
+- Keeps injected browser storage keys aligned with the current frontend auth
+  storage keys plus legacy smoke keys.
+
+## Security Notes
+
+- This change does not introduce any new token generation endpoint.
+- Staging tokens remain operator-supplied via environment or file.
+- The README examples use `AUTH_TOKEN="$(cat /tmp/...)"` and do not include any
+  token literal.
+- During verification, temporary token files were deleted after use.
+
+## Non-Goals
+
+- This slice does not fix product UI rendering behavior.
+- This slice does not create staging users.
+- This slice does not change the deployed staging image.
+- This slice does not make `handoff-journey.spec.ts` remote-token aware; that
+  spec still has a separate PLM/Yuantus setup model.

--- a/docs/development/multitable-staging-ui-smoke-bootstrap-verification-20260508.md
+++ b/docs/development/multitable-staging-ui-smoke-bootstrap-verification-20260508.md
@@ -1,0 +1,204 @@
+# Multitable Staging UI Smoke Bootstrap - Verification - 2026-05-08
+
+## Local Verification
+
+### Install/link dependencies in isolated worktree
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+Result:
+
+- Completed successfully.
+- Used existing pnpm store; no downloads were needed.
+
+### Unit regression
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/multitable-e2e-helper-env.test.ts \
+  --reporter=verbose
+```
+
+Result:
+
+```text
+Test Files  1 passed (1)
+Tests       4 passed (4)
+```
+
+Covered:
+
+- Default local URLs.
+- Env URL override and trailing-slash normalization.
+- `AUTH_TOKEN` precedence over phase0 login.
+- Browser auth storage key list.
+
+### Playwright discoverability
+
+```bash
+pnpm --filter @metasheet/core-backend exec playwright test \
+  --config tests/e2e/playwright.config.ts \
+  --list
+```
+
+Result:
+
+```text
+Total: 22 tests in 7 files
+```
+
+The six multitable RC files account for 18 tests. `handoff-journey.spec.ts`
+remains separate because it depends on the PLM/Yuantus flow.
+
+### TypeScript targeted check
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit --skipLibCheck \
+  tests/e2e/multitable-helpers.ts \
+  tests/e2e/playwright.config.ts \
+  tests/unit/multitable-e2e-helper-env.test.ts
+```
+
+Result:
+
+```text
+exit 0
+```
+
+## Staging/142 Verification
+
+### Setup
+
+The tests were run from the local worktree against staging/142 through SSH
+tunnels:
+
+```bash
+ssh -fN \
+  -L 18081:127.0.0.1:8081 \
+  -L 18990:127.0.0.1:8900 \
+  <staging-142>
+```
+
+Health checks:
+
+- Frontend tunnel: `http://127.0.0.1:18081/`
+- Backend tunnel: `http://127.0.0.1:18990/api/health`
+
+A short-lived staging admin token was generated from the running backend
+container and read from a local temporary file. The token literal is not
+recorded here.
+
+### First remote run, before browser storage-key fix
+
+Command shape:
+
+```bash
+FE_BASE_URL=http://127.0.0.1:18081 \
+API_BASE_URL=http://127.0.0.1:18990 \
+AUTH_TOKEN="$(cat /tmp/metasheet-staging-ui-smoke-admin.jwt)" \
+pnpm --filter @metasheet/core-backend exec playwright test \
+  --config tests/e2e/playwright.config.ts \
+  multitable-lifecycle-smoke.spec.ts \
+  multitable-public-form-smoke.spec.ts \
+  multitable-hierarchy-smoke.spec.ts \
+  multitable-gantt-smoke.spec.ts \
+  multitable-formula-smoke.spec.ts \
+  multitable-automation-send-email-smoke.spec.ts \
+  --reporter=line
+```
+
+Result:
+
+```text
+11 passed
+7 failed
+```
+
+Finding:
+
+- Browser-rendering cases landed on the login page.
+- Root cause: `injectTokenAndGo()` wrote `metasheet_token` / `token`, while the
+  current frontend reads `auth_token` / `jwt` / `devToken`.
+
+This finding directly drove the storage-key fix in this slice.
+
+### Second remote run, after browser storage-key fix
+
+Command shape:
+
+```bash
+FE_BASE_URL=http://127.0.0.1:18081 \
+API_BASE_URL=http://127.0.0.1:18990 \
+AUTH_TOKEN="$(cat /tmp/metasheet-staging-ui-smoke-admin.jwt)" \
+pnpm --filter @metasheet/core-backend exec playwright test \
+  --config tests/e2e/playwright.config.ts \
+  multitable-lifecycle-smoke.spec.ts \
+  multitable-public-form-smoke.spec.ts \
+  multitable-hierarchy-smoke.spec.ts \
+  multitable-gantt-smoke.spec.ts \
+  multitable-formula-smoke.spec.ts \
+  multitable-automation-send-email-smoke.spec.ts \
+  --workers=1 \
+  --reporter=line
+```
+
+Output was filtered to redact `Authorization: Bearer ...` if a failure printed
+request headers.
+
+Result:
+
+```text
+15 passed
+3 failed
+```
+
+Passed surfaces after this bootstrap:
+
+- Automation `send_email` save/execute path.
+- Formula render smoke first case.
+- Formula helper/envelope and sanitize regressions except one transient API
+  socket failure noted below.
+- Hierarchy render and cycle guards.
+- Lifecycle render and autoNumber raw-write guard.
+- Public form happy path, disabled-view guard, and rotated-token guard.
+
+Remaining failures:
+
+1. `multitable-formula-smoke.spec.ts` / `updates a formula expression via PATCH`
+   failed once with `apiRequestContext.post: socket hang up` when creating a
+   base. Backend container health was OK after the run and the container start
+   timestamp did not change, so this is recorded as a staging transport /
+   transient failure rather than an auth-bootstrap failure.
+2. `multitable-gantt-smoke.spec.ts` / bar rendering failed because the browser
+   rendered the sheet in grid mode. The page contained the expected task data
+   but no `.meta-gantt__bar`.
+3. `multitable-gantt-smoke.spec.ts` / dependency-arrow rendering failed for the
+   same reason. The page contained the expected predecessor data in grid mode
+   but no `.meta-gantt__dependency-arrow`.
+
+Important positive signal:
+
+- The login-page failure disappeared after the storage-key fix.
+- This confirms `AUTH_TOKEN` plus `injectTokenAndGo()` now works against
+  staging/142 for browser-level multitable smoke tests.
+
+## Cleanup
+
+- Local temporary admin token file was removed.
+- SSH tunnels were closed.
+- No staging user was created.
+
+## Conclusion
+
+The staging UI smoke bootstrap is working:
+
+- Remote URLs can be supplied without code edits.
+- Staging auth can use an operator-provided `AUTH_TOKEN`.
+- Browser auth injection now matches current frontend storage keys.
+
+This does not claim full UI RC sign-off. It converts the previous blocker
+(`phase0` account required, login page under staging) into a usable staging
+Playwright path and exposes the next real UI follow-up: Gantt deep-link/view
+selection renders grid content instead of the Gantt component on 142.

--- a/packages/core-backend/tests/e2e/README.md
+++ b/packages/core-backend/tests/e2e/README.md
@@ -7,8 +7,8 @@ Browser-level regression tests for federated PLM user journeys.
 These tests require **three servers running externally**:
 
 1. **Yuantus** on `http://127.0.0.1:7910`
-2. **Metasheet backend** on `http://localhost:7778`
-3. **Metasheet frontend** on `http://127.0.0.1:8899`
+2. **Metasheet backend** on `API_BASE_URL` or `http://localhost:7778`
+3. **Metasheet frontend** on `FE_BASE_URL` or `http://127.0.0.1:8899`
 
 Tests auto-skip if any server is unreachable.
 
@@ -34,6 +34,37 @@ cd /path/to/metasheet2/packages/core-backend
 npx playwright test --config tests/e2e/playwright.config.ts
 ```
 
+## Staging / remote run
+
+The multitable RC smoke specs can run against a deployed staging stack without
+creating the local `phase0@test.local` account. Provide:
+
+- `FE_BASE_URL`: frontend origin.
+- `API_BASE_URL`: backend origin.
+- `AUTH_TOKEN`: short-lived admin token. Prefer reading it from a local `0600`
+  file; do not paste token values into shell history or PR comments.
+
+Example with an SSH tunnel:
+
+```bash
+ssh -fN \
+  -L 18081:127.0.0.1:8081 \
+  -L 18990:127.0.0.1:8900 \
+  <staging-host>
+
+FE_BASE_URL=http://127.0.0.1:18081 \
+API_BASE_URL=http://127.0.0.1:18990 \
+AUTH_TOKEN="$(cat /tmp/metasheet-staging-admin.jwt)" \
+npx playwright test --config tests/e2e/playwright.config.ts \
+  multitable-lifecycle-smoke.spec.ts \
+  multitable-public-form-smoke.spec.ts \
+  multitable-hierarchy-smoke.spec.ts \
+  multitable-gantt-smoke.spec.ts \
+  multitable-formula-smoke.spec.ts \
+  multitable-automation-send-email-smoke.spec.ts \
+  --workers=1
+```
+
 ## Test data
 
 Tests use the B demo object:
@@ -42,7 +73,8 @@ Tests use the B demo object:
 - Has 1 file attachment + 1 AML related document (Doc UI Doc)
 - Has 1 ECO (DOCUI-ECO-1768357216, state=progress)
 
-Metasheet user: `phase0@test.local` / `Phase0Test!2026` (role=admin)
+Default local fallback user: `phase0@test.local` / `Phase0Test!2026`
+(role=admin). Remote/staging runs should prefer `AUTH_TOKEN`.
 
 ## What's tested
 
@@ -56,4 +88,4 @@ Metasheet user: `phase0@test.local` / `Phase0Test!2026` (role=admin)
 
 ### Shared scaffolding
 
-Helpers live in `multitable-helpers.ts`: `FE_BASE_URL` / `API_BASE_URL` constants, `Entity` / `ApiEnvelope` / `FailureResponse` types, `requireValue`, `ensureServersReachable`, `loginAsPhase0`, `makeAuthClient`, `injectTokenAndGo`, `uniqueLabel`, and the `createBase` / `createSheet` / `createField` / `createView` / `createRecord` primitives. The lifecycle / public-form / hierarchy / gantt / formula specs all consume this module; new RC smokes should fork the formula spec or extend the helpers rather than copying inline.
+Helpers live in `multitable-helpers.ts`: environment-overridable `FE_BASE_URL` / `API_BASE_URL` constants, `Entity` / `ApiEnvelope` / `FailureResponse` types, `requireValue`, `ensureServersReachable`, `loginAsPhase0`, `resolveE2EAuthToken`, `makeAuthClient`, `injectTokenAndGo`, `uniqueLabel`, and the `createBase` / `createSheet` / `createField` / `createView` / `createRecord` primitives. `resolveE2EAuthToken` uses `AUTH_TOKEN` when present and falls back to the local phase0 login otherwise. The lifecycle / public-form / hierarchy / gantt / formula specs all consume this module; new RC smokes should fork the formula spec or extend the helpers rather than copying inline.

--- a/packages/core-backend/tests/e2e/multitable-automation-send-email-smoke.spec.ts
+++ b/packages/core-backend/tests/e2e/multitable-automation-send-email-smoke.spec.ts
@@ -43,8 +43,8 @@ import {
   createSheet,
   createView,
   ensureServersReachable,
-  loginAsPhase0,
   makeAuthClient,
+  resolveE2EAuthToken,
   uniqueLabel,
   type AuthClient,
   type Entity,
@@ -54,7 +54,7 @@ let token = ''
 
 test.beforeAll(async ({ request }) => {
   await ensureServersReachable(request)
-  token = await loginAsPhase0(request)
+  token = await resolveE2EAuthToken(request)
 })
 
 type AutomationStep = {

--- a/packages/core-backend/tests/e2e/multitable-formula-smoke.spec.ts
+++ b/packages/core-backend/tests/e2e/multitable-formula-smoke.spec.ts
@@ -42,9 +42,9 @@ import {
   createView,
   ensureServersReachable,
   injectTokenAndGo,
-  loginAsPhase0,
   makeAuthClient,
   requireValue,
+  resolveE2EAuthToken,
   uniqueLabel,
   type ApiEnvelope,
   type Entity,
@@ -54,7 +54,7 @@ let token = ''
 
 test.beforeAll(async ({ request }) => {
   await ensureServersReachable(request)
-  token = await loginAsPhase0(request)
+  token = await resolveE2EAuthToken(request)
 })
 
 type FormulaFieldRow = Entity & {

--- a/packages/core-backend/tests/e2e/multitable-gantt-smoke.spec.ts
+++ b/packages/core-backend/tests/e2e/multitable-gantt-smoke.spec.ts
@@ -28,8 +28,8 @@ import {
   createView,
   ensureServersReachable,
   injectTokenAndGo,
-  loginAsPhase0,
   makeAuthClient,
+  resolveE2EAuthToken,
   uniqueLabel,
   type AuthClient,
   type Entity,
@@ -39,7 +39,7 @@ let token = ''
 
 test.beforeAll(async ({ request }) => {
   await ensureServersReachable(request)
-  token = await loginAsPhase0(request)
+  token = await resolveE2EAuthToken(request)
 })
 
 async function setupGanttSheet(client: AuthClient, label: string): Promise<{

--- a/packages/core-backend/tests/e2e/multitable-helpers.ts
+++ b/packages/core-backend/tests/e2e/multitable-helpers.ts
@@ -6,10 +6,11 @@
  * "rule of three" trigger noted in the post-#1421 review.
  *
  * Public surface:
- *   - FE_BASE_URL / API_BASE_URL constants
+ *   - FE_BASE_URL / API_BASE_URL constants, overridable by env
  *   - Entity / ApiEnvelope / FailureResponse types
  *   - requireValue() to safely unwrap optional response fields
- *   - ensureServersReachable() / loginAsPhase0() bootstrap
+ *   - ensureServersReachable() / loginAsPhase0() /
+ *     resolveE2EAuthToken() bootstrap
  *   - makeAuthClient() per-test bound to (request, token)
  *   - injectTokenAndGo() for browser-side auth setup
  *   - createBase / createSheet / createField / createView / createRecord
@@ -22,8 +23,19 @@
  */
 import { test, type APIRequestContext, type Page } from '@playwright/test'
 
-export const FE_BASE_URL = 'http://127.0.0.1:8899'
-export const API_BASE_URL = 'http://localhost:7778'
+function envBaseUrl(name: string, fallback: string): string {
+  const value = process.env[name]?.trim()
+  return (value && value.length > 0 ? value : fallback).replace(/\/+$/, '')
+}
+
+function envToken(name: string): string | undefined {
+  const value = process.env[name]?.trim()
+  return value && value.length > 0 ? value : undefined
+}
+
+export const FE_BASE_URL = envBaseUrl('FE_BASE_URL', 'http://127.0.0.1:8899')
+export const API_BASE_URL = envBaseUrl('API_BASE_URL', 'http://localhost:7778')
+export const AUTH_STORAGE_KEYS = ['auth_token', 'jwt', 'devToken', 'metasheet_token', 'token'] as const
 
 export type Entity = { id: string }
 
@@ -45,8 +57,11 @@ export function requireValue<T>(value: T | undefined, label: string): T {
 
 export async function ensureServersReachable(request: APIRequestContext): Promise<void> {
   try {
-    const apiHealth = await request.get(`${API_BASE_URL}/health`, { timeout: 3000 })
-    if (!apiHealth.ok()) test.skip(true, 'Metasheet backend not reachable')
+    const rootHealth = await request.get(`${API_BASE_URL}/health`, { timeout: 3000 })
+    if (!rootHealth.ok()) {
+      const apiHealth = await request.get(`${API_BASE_URL}/api/health`, { timeout: 3000 })
+      if (!apiHealth.ok()) test.skip(true, 'Metasheet backend not reachable')
+    }
   } catch {
     test.skip(true, 'Metasheet backend not reachable')
   }
@@ -72,6 +87,12 @@ export async function loginAsPhase0(request: APIRequestContext): Promise<string>
     throw new Error('unreachable')
   }
   return token
+}
+
+export async function resolveE2EAuthToken(request: APIRequestContext): Promise<string> {
+  const providedToken = envToken('AUTH_TOKEN')
+  if (providedToken) return providedToken
+  return loginAsPhase0(request)
 }
 
 export type AuthClient = {
@@ -128,10 +149,9 @@ export function makeAuthClient(request: APIRequestContext, token: string): AuthC
 
 export async function injectTokenAndGo(page: Page, token: string, path: string): Promise<void> {
   await page.goto(FE_BASE_URL)
-  await page.evaluate((t: string) => {
-    localStorage.setItem('metasheet_token', t)
-    localStorage.setItem('token', t)
-  }, token)
+  await page.evaluate(({ keys, value }: { keys: readonly string[], value: string }) => {
+    for (const key of keys) localStorage.setItem(key, value)
+  }, { keys: [...AUTH_STORAGE_KEYS], value: token })
   await page.goto(`${FE_BASE_URL}${path}`)
 }
 

--- a/packages/core-backend/tests/e2e/multitable-hierarchy-smoke.spec.ts
+++ b/packages/core-backend/tests/e2e/multitable-hierarchy-smoke.spec.ts
@@ -31,8 +31,8 @@ import {
   createView,
   ensureServersReachable,
   injectTokenAndGo,
-  loginAsPhase0,
   makeAuthClient,
+  resolveE2EAuthToken,
   uniqueLabel,
   type AuthClient,
   type Entity,
@@ -42,7 +42,7 @@ let token = ''
 
 test.beforeAll(async ({ request }) => {
   await ensureServersReachable(request)
-  token = await loginAsPhase0(request)
+  token = await resolveE2EAuthToken(request)
 })
 
 async function setupHierarchySheet(client: AuthClient, label: string): Promise<{

--- a/packages/core-backend/tests/e2e/multitable-lifecycle-smoke.spec.ts
+++ b/packages/core-backend/tests/e2e/multitable-lifecycle-smoke.spec.ts
@@ -26,9 +26,9 @@ import {
   createView,
   ensureServersReachable,
   injectTokenAndGo,
-  loginAsPhase0,
   makeAuthClient,
   requireValue,
+  resolveE2EAuthToken,
   uniqueLabel,
   type Entity,
 } from './multitable-helpers'
@@ -37,7 +37,7 @@ let token = ''
 
 test.beforeAll(async ({ request }) => {
   await ensureServersReachable(request)
-  token = await loginAsPhase0(request)
+  token = await resolveE2EAuthToken(request)
 })
 
 test.describe('Multitable lifecycle smoke', () => {

--- a/packages/core-backend/tests/e2e/multitable-public-form-smoke.spec.ts
+++ b/packages/core-backend/tests/e2e/multitable-public-form-smoke.spec.ts
@@ -23,9 +23,9 @@ import {
   createSheet,
   createView,
   ensureServersReachable,
-  loginAsPhase0,
   makeAuthClient,
   requireValue,
+  resolveE2EAuthToken,
   uniqueLabel,
   type AuthClient,
   type Entity,
@@ -35,7 +35,7 @@ let token = ''
 
 test.beforeAll(async ({ request }) => {
   await ensureServersReachable(request)
-  token = await loginAsPhase0(request)
+  token = await resolveE2EAuthToken(request)
 })
 
 async function setupSheetWithStringField(client: AuthClient, label: string): Promise<{

--- a/packages/core-backend/tests/e2e/playwright.config.ts
+++ b/packages/core-backend/tests/e2e/playwright.config.ts
@@ -5,8 +5,8 @@ import { defineConfig } from '@playwright/test'
  *
  * Prerequisites (external — not auto-started by this config):
  *   1. Yuantus on http://127.0.0.1:7910
- *   2. Metasheet backend on http://localhost:7778
- *   3. Metasheet frontend on http://127.0.0.1:8899
+ *   2. Metasheet backend on API_BASE_URL or http://localhost:7778
+ *   3. Metasheet frontend on FE_BASE_URL or http://127.0.0.1:8899
  *
  * Tests skip automatically if servers are not reachable.
  *
@@ -21,6 +21,6 @@ export default defineConfig({
   retries: 0,
   use: {
     headless: true,
-    baseURL: 'http://127.0.0.1:8899',
+    baseURL: process.env.FE_BASE_URL?.trim() || 'http://127.0.0.1:8899',
   },
 })

--- a/packages/core-backend/tests/unit/multitable-e2e-helper-env.test.ts
+++ b/packages/core-backend/tests/unit/multitable-e2e-helper-env.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { APIRequestContext } from '@playwright/test'
+
+const originalEnv = {
+  AUTH_TOKEN: process.env.AUTH_TOKEN,
+  API_BASE_URL: process.env.API_BASE_URL,
+  FE_BASE_URL: process.env.FE_BASE_URL,
+}
+
+function restoreEnv(): void {
+  for (const [key, value] of Object.entries(originalEnv)) {
+    if (value === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = value
+    }
+  }
+}
+
+async function loadHelpers() {
+  vi.resetModules()
+  return import('../e2e/multitable-helpers')
+}
+
+describe('multitable E2E helper environment bootstrap', () => {
+  afterEach(() => {
+    restoreEnv()
+    vi.resetModules()
+  })
+
+  it('defaults to local frontend and backend URLs', async () => {
+    delete process.env.FE_BASE_URL
+    delete process.env.API_BASE_URL
+
+    const helpers = await loadHelpers()
+
+    expect(helpers.FE_BASE_URL).toBe('http://127.0.0.1:8899')
+    expect(helpers.API_BASE_URL).toBe('http://localhost:7778')
+  })
+
+  it('reads staging URLs from env and strips trailing slashes', async () => {
+    process.env.FE_BASE_URL = 'http://127.0.0.1:18081///'
+    process.env.API_BASE_URL = 'http://127.0.0.1:18990///'
+
+    const helpers = await loadHelpers()
+
+    expect(helpers.FE_BASE_URL).toBe('http://127.0.0.1:18081')
+    expect(helpers.API_BASE_URL).toBe('http://127.0.0.1:18990')
+  })
+
+  it('uses AUTH_TOKEN before attempting phase0 login', async () => {
+    process.env.AUTH_TOKEN = 'staging-token-from-file'
+    const helpers = await loadHelpers()
+    const request = {
+      post: () => {
+        throw new Error('phase0 login should not be called when AUTH_TOKEN is set')
+      },
+    } as unknown as APIRequestContext
+
+    await expect(helpers.resolveE2EAuthToken(request)).resolves.toBe('staging-token-from-file')
+  })
+
+  it('injects tokens into current frontend auth storage keys and legacy smoke keys', async () => {
+    const helpers = await loadHelpers()
+
+    expect(helpers.AUTH_STORAGE_KEYS).toEqual([
+      'auth_token',
+      'jwt',
+      'devToken',
+      'metasheet_token',
+      'token',
+    ])
+  })
+})


### PR DESCRIPTION
## Summary
- Make multitable RC Playwright smokes runnable against staging/remote stacks via FE_BASE_URL, API_BASE_URL, and operator-supplied AUTH_TOKEN.
- Keep local phase0 login as the fallback when AUTH_TOKEN is absent.
- Inject the token into the current frontend auth storage keys (`auth_token`, `jwt`, `devToken`) plus legacy smoke keys.
- Add development and verification MD artifacts for the 2026-05-08 staging/142 run.

## Verification
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/multitable-e2e-helper-env.test.ts --reporter=verbose` → 4/4 passed
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit --skipLibCheck tests/e2e/multitable-helpers.ts tests/e2e/playwright.config.ts tests/unit/multitable-e2e-helper-env.test.ts` → exit 0
- `pnpm --filter @metasheet/core-backend exec playwright test --config tests/e2e/playwright.config.ts --list` → 22 tests discovered
- `git diff --check` → clean
- Secret scan on changed files → no token literals

## Staging notes
- Before the storage-key fix, 142 browser smokes reached the login page.
- After the fix, 142 browser smokes authenticated successfully and reached app surfaces: 15/18 passed.
- Remaining 3 failures are tracked as follow-up signals, not bootstrap failures: one transient `socket hang up` during formula setup, and two Gantt selector failures where the authenticated page rendered grid content instead of `.meta-gantt__bar` / `.meta-gantt__dependency-arrow`.

## Docs
- `docs/development/multitable-staging-ui-smoke-bootstrap-development-20260508.md`
- `docs/development/multitable-staging-ui-smoke-bootstrap-verification-20260508.md`