### PR TITLE
docs(integration): expand K3 WISE internal-trial runbook with host-shell path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,7 @@ output/deploy/k3wise-postdeploy-smoke*/
 # K3 WISE on-prem preflight artifacts contain deployment topology
 # (docker bridge IPs, migration counts, sanitized DATABASE_URL); operator-only.
 artifacts/integration-k3wise-onprem-preflight/
+
+# K3 WISE internal-trial postdeploy smoke artifacts contain deployment URLs,
+# masked admin signoff metadata, and per-check evidence; operator-only.
+artifacts/integration-k3wise/internal-trial/

--- a/docs/development/integration-k3wise-internal-trial-runbook-update-design-20260508.md
+++ b/docs/development/integration-k3wise-internal-trial-runbook-update-design-20260508.md
@@ -1,0 +1,121 @@
+# Design: Internal-Trial Runbook Update — Host-Shell Path & Public Posture
+
+**Date**: 2026-05-08
+**Files**:
+- `docs/operations/integration-k3wise-internal-trial-runbook.md` (modified)
+- `.gitignore` (one new ignore rule)
+
+---
+
+## Problem
+
+`integration-k3wise-internal-trial-runbook.md` today documents two paths to a
+signoff: the GHA workflow and the equivalent CLI run with `$METASHEET_AUTH_TOKEN_FILE`
+already provided. It does not show how to *obtain* a fresh admin token when
+operating directly on the deploy host. The token-resolver script
+(`scripts/ops/resolve-k3wise-smoke-token.sh`) is GHA-shaped — it requires
+`DEPLOY_HOST` / `DEPLOY_USER` / `DEPLOY_SSH_KEY_B64` env vars and is meant to
+run from a CI control plane that SSHes into the deploy host. An operator
+already on the deploy host has to read the resolver, extract the
+deploy-host-fallback Node script, and re-derive the `docker exec
+metasheet-backend node …` invocation themselves — about thirty minutes of
+work, every time.
+
+A second gap: the runbook treats `--base-url http://<deploy-host>:8081` as if
+it works from anywhere, but on 142 today the public `:8081` surface has an
+application-level allowlist (TCP succeeds, HTTP returns empty reply) that
+permits GHA and host-loopback but blocks ad-hoc workstation `curl`. Operators
+trying to run a workstation smoke against `:8081` get curl error 52 with no
+guidance.
+
+## Goal
+
+Capture both findings as small, additive sections in the existing runbook so
+the next operator (or the same operator weeks later) does not have to rederive
+them. Plus a one-line `.gitignore` for the matching artifact path so accidental
+`git add` of host smoke evidence doesn't surface deployment topology in the
+repo history.
+
+## Non-goals
+
+- New runtime / script behaviour. PR is doc-only plus a single ignore rule.
+- Replacing `scripts/ops/resolve-k3wise-smoke-token.sh`. The host-shell snippet
+  is a **mirror** of its deploy-host fallback inner script, not a replacement.
+- Changing the public `:8081` access posture. Loosening the allowlist is a
+  deployment-side change in `metasheet-web` nginx config or a front-door reverse
+  proxy, not a runbook change.
+
+## Design
+
+### What is added
+
+A new **"Host-Shell Mint and Smoke (deploy host, no GHA)"** section between
+"CLI Path" and "Deployment Workflow", with:
+
+- A 4-step recipe: mint token via `docker exec metasheet-backend node` reading
+  the same admin user / `authService.createToken()` path as the resolver; write
+  to a `0600` `/tmp/...jwt` file; run the smoke; render summary; optional
+  `shred` cleanup.
+- Inlined Node `--input-type=module` heredoc — the literal mint logic so the
+  operator can copy-paste, not derive.
+- Notes on what re-derivation looks like when the resolver script changes
+  upstream (so the runbook can rot gracefully).
+
+A new **"Public Surface Access Posture"** section between "Deployment
+Workflow" and "142 Internal Trial Evidence", with:
+
+- A one-paragraph statement of the observed posture (TCP-allow / HTTP-deny by
+  source) with the curl exit code so operators recognize it.
+- An explicit reachable / non-reachable list — GHA, host-shell, ad-hoc
+  workstation.
+- A pointer that loosening the allowlist is out of scope (lives in
+  `metasheet-web` nginx config or a front-door reverse proxy).
+
+The **"142 Internal Trial Evidence"** section gains a second entry for the
+2026-05-08 host-shell signoff run, kept in newest-first chronological order.
+The original GHA run entry is preserved so historical traceability stays
+intact.
+
+### `.gitignore`
+
+One new rule for `artifacts/integration-k3wise/internal-trial/`, matching the
+existing pattern for `artifacts/integration-k3wise-onprem-preflight/` (added
+in PR #1437) and the older
+`output/integration-k3wise-postdeploy-smoke/` pattern.
+
+### Fact-check discipline
+
+- The Node mint heredoc was lifted from
+  `scripts/ops/resolve-k3wise-smoke-token.sh` lines 175–289 at commit
+  `854b27bd9` and shaped into a single literal source the operator can run
+  without GHA env. It was executed against 142 today and produced a working
+  token whose subsequent smoke returned `signoff.internalTrial=pass / 10 pass
+  / 0 fail` — see verification MD §1.
+- The "Public Surface Access Posture" claims (TCP-allow / HTTP-deny / curl
+  error 52 / GHA reachable / host-shell reachable / ad-hoc workstation
+  blocked) were observed in this session — see verification MD §2.
+
+## Affected files
+
+| File | Change |
+|---|---|
+| `docs/operations/integration-k3wise-internal-trial-runbook.md` | Two new sections + one expanded evidence section. |
+| `.gitignore` | One new rule: ignore `artifacts/integration-k3wise/internal-trial/`. |
+
+No source code change. No script change. No CI workflow change.
+
+## Deployment impact
+
+None.
+
+## Customer GATE status
+
+PR is **outside** the GATE block:
+
+- Doc-only + a one-line gitignore.
+- No real ERP business behaviour added.
+- `plugin-integration-core` runtime / adapters / pipelines / runner all
+  untouched.
+- Stage 1 Lock memory ("until GATE PASS, no new战线 / no integration-core
+  touch; 内核打磨 permitted") remains in force; runbook fits clearly inside
+  "内核打磨".

--- a/docs/development/integration-k3wise-internal-trial-runbook-update-verification-20260508.md
+++ b/docs/development/integration-k3wise-internal-trial-runbook-update-verification-20260508.md
@@ -1,0 +1,165 @@
+# Verification: Internal-Trial Runbook Update — Host-Shell Path & Public Posture
+
+**Date**: 2026-05-08
+**Design**: `docs/development/integration-k3wise-internal-trial-runbook-update-design-20260508.md`
+**Files under verification**:
+- `docs/operations/integration-k3wise-internal-trial-runbook.md`
+- `.gitignore`
+
+---
+
+## 1. Host-Shell Mint and Smoke — recipe was actually executed end-to-end today
+
+The Node mint heredoc and the smoke + summary commands in the new section are
+the literal commands run on machine 142 (`racknerd-0de8668`, Ubuntu 5.15,
+node v20.20.2, pnpm 10.33.0) on 2026-05-08 against main `36ca525` (PR #1437
+merge SHA, which contains PR #1433 + #1437).
+
+Result captured:
+
+```
+token file: /tmp/metasheet-142-admin-fresh-20260508T083206Z.jwt
+  size: 312 bytes
+  perm: 600
+  owner: mainuser:mainuser
+  jwt 3-segment shape match: 1
+
+smoke exit=0
+ok: true
+authenticated: true
+signoff.internalTrial: pass
+signoff.reason: authenticated smoke passed
+summary: {"pass":10,"skipped":0,"fail":0}
+```
+
+Summary script with `--require-auth-signoff` rendered "Internal trial
+signoff: **PASS** / Status: **PASS** / 10 pass / 0 skipped / 0 fail" with all
+ten individual checks (`api-health`, `integration-plugin-health`,
+`k3-wise-frontend-route`, `auth-me`, `integration-route-contract`, the four
+control-plane list probes, `staging-descriptor-contract`) marked `pass`.
+
+Artifact leak self-check on
+`artifacts/integration-k3wise/internal-trial/postdeploy-smoke/integration-k3wise-postdeploy-smoke.json`:
+
+| Pattern | Count |
+|---|---|
+| `eyJ…` JWT-shape | 0 |
+| `Bearer …` header | 0 |
+| `"authorization"` / `"token"` / `"access_token"` JSON field with non-redacted value | 0 |
+| Literal token value match (`grep -F`) | 0 |
+
+The recipe is reproducible and leak-free.
+
+## 2. Public Surface Access Posture — observed today
+
+From workstation outside 142:
+
+```
+$ nc -z -w 5 142.171.239.56 8081
+Connection to 142.171.239.56 port 8081 [tcp/sunproxyadmin] succeeded!
+
+$ curl -sS --max-time 8 -o /dev/null -w "%{http_code}\n" http://142.171.239.56:8081/health
+000
+$ curl -sS --max-time 8 -o /dev/null -w "%{http_code}\n" http://142.171.239.56:8081/api/health
+000
+$ curl -sS --max-time 8 -o /dev/null -w "%{http_code}\n" http://142.171.239.56:8081/
+000
+# All three: curl: (52) Empty reply from server
+```
+
+From workstation outside 142, full smoke against `:8081`:
+
+```
+smoke exit=1
+ok: false
+signoff.internalTrial: blocked
+summary: {"pass":0,"skipped":0,"fail":10}
+```
+
+(Each check `error: "fetch failed"` — same root cause as the curl error 52.)
+
+From 142 host shell against the same `:8081`:
+
+```
+smoke exit=0
+ok: true
+signoff.internalTrial: pass
+summary: {"pass":10,"skipped":0,"fail":0}
+```
+
+Same code, same backend, same token in both runs (token written to a
+host-local `0600` file). Only difference: source IP. Confirms the runbook's
+"TCP-allow / HTTP-deny by source" wording.
+
+## 3. Heredoc-vs-resolver consistency (simplified extract, not byte mirror)
+
+The Node mint heredoc in the runbook section is a **simplified extract** of
+the deploy-host fallback inner script in
+`scripts/ops/resolve-k3wise-smoke-token.sh` (lines ~175–289 at commit
+`854b27bd9`), not a byte-for-byte mirror.
+
+What is preserved:
+
+- Admin-selection SQL — same `users` / `user_roles` join, same WHERE clauses,
+  same ORDER BY tiebreakers (collapsed to a single-line string for heredoc
+  compatibility).
+- `authService.createToken({ … })` field set and call shape, including the
+  `'K3 WISE Smoke Admin'` default `name` fallback.
+- `JWT_EXPIRY=2h` default and the `K3_WISE_SMOKE_TENANT_ID=default` env shape.
+- Exit codes `2` (no tenant) and `4` (no admin).
+
+What is omitted (intentionally — none apply when the recipe always supplies
+an explicit `--tenant-id default`):
+
+- The auto-discover-tenant pathway (`tableExists`, `collectTenantIds`,
+  `inferSingletonTenantId`).
+- The `DATABASE_URL` existence guard (resolver exit code `3`).
+- The multi-tenant ambiguity guard (resolver exit code `5`).
+- GHA-only env-passing scaffolding (`SSH_KEY_B64` etc.) — not applicable when
+  running directly on the deploy host.
+
+The runbook explicitly tells operators to re-derive the heredoc when the
+resolver changes upstream — so it's a tested simplified extract at this point
+in time, not a maintained fork.
+
+## 4. `.gitignore` rule effective
+
+```bash
+mkdir -p artifacts/integration-k3wise/internal-trial/test-marker
+echo test > artifacts/integration-k3wise/internal-trial/test-marker/file
+git status --porcelain artifacts/integration-k3wise/internal-trial/
+# expected: empty
+rm -rf artifacts/integration-k3wise/internal-trial/test-marker
+```
+
+Empty `git status` confirms the rule excludes the path.
+
+## 5. Existing test suites unaffected
+
+Doc-only PR + one ignore rule. No script change.
+
+```bash
+pnpm verify:integration-k3wise:onprem-preflight   # 14/14 PASS
+pnpm verify:integration-k3wise:poc                # 37 unit + mock chain PASS
+```
+
+Both were last green on the merge of PR #1437; this PR doesn't touch any
+source they cover, so they remain green.
+
+## CI status
+
+Not modified. No CI workflow file is touched.
+
+## Deployment impact
+
+**None.** Doc + ignore rule only.
+
+## Customer GATE status
+
+Outside the GATE block. Stage 1 Lock memory remains in force.
+
+## Worktree
+
+Branch: `codex/integration-k3wise-internal-trial-runbook-update-20260508`
+(forked from `origin/main` at `34d731670`).
+Cwd: `/Users/chouhua/Downloads/Github/metasheet2`.

--- a/docs/operations/integration-k3wise-internal-trial-runbook.md
+++ b/docs/operations/integration-k3wise-internal-trial-runbook.md
@@ -79,6 +79,104 @@ node scripts/ops/integration-k3wise-postdeploy-summary.mjs \
   --require-auth-signoff
 ```
 
+## Host-Shell Mint and Smoke (deploy host, no GHA)
+
+When you have shell access to the deploy host and need a one-off internal-trial
+smoke without firing a GHA workflow, you can mint a temporary admin token
+directly inside the running backend container. This bypasses
+`scripts/ops/resolve-k3wise-smoke-token.sh`, which is GHA-shaped (it wants
+`DEPLOY_HOST` / `DEPLOY_USER` / `DEPLOY_SSH_KEY_B64` and is meant to run from a
+control plane SSHing in).
+
+The container-internal mint script below uses the same admin-selection and
+token-mint logic as the resolver's deploy-host fallback, simplified for the
+explicit-tenant case (no `auto_discover_tenant`, no multi-tenant ambiguity
+guard). Treat it as a tested simplified extract, not a maintained mirror;
+re-derive from the resolver when it changes upstream.
+
+```bash
+# 1. Mint a 2-hour admin token via the running backend container.
+TS=$(date -u +%Y%m%dT%H%M%SZ)
+TOKEN_FILE=/tmp/metasheet-host-admin-fresh-${TS}.jwt
+umask 077
+
+RAW=$(docker exec -i \
+  -e K3_WISE_SMOKE_TENANT_ID=default \
+  -e K3_WISE_SMOKE_TENANT_AUTO_DISCOVER=false \
+  -e JWT_EXPIRY=2h \
+  metasheet-backend \
+  node --input-type=module - 2>&1 <<'NODE_END'
+import pg from 'pg'
+import { authService } from '/app/packages/core-backend/dist/src/auth/AuthService.js'
+const tenantId = String(process.env.K3_WISE_SMOKE_TENANT_ID || '').trim()
+const { Client } = pg
+const client = new Client({
+  connectionString: process.env.DATABASE_URL,
+  ssl: process.env.DB_SSL === 'true' ? { rejectUnauthorized: false } : false,
+})
+try {
+  await client.connect()
+  if (!tenantId) { console.error('tenant_id required'); process.exit(2) }
+  const r = await client.query(
+    "SELECT u.id, u.email, u.username, u.name, u.mobile, u.role, u.permissions, u.is_active, u.must_change_password, (ur.user_id IS NOT NULL) AS has_rbac_admin FROM users u LEFT JOIN user_roles ur ON ur.user_id = u.id AND ur.role_id = 'admin' WHERE COALESCE(u.is_active,true)=true AND COALESCE(u.must_change_password,false)=false AND (u.role='admin' OR ur.user_id IS NOT NULL) ORDER BY CASE WHEN ur.user_id IS NOT NULL THEN 0 ELSE 1 END, CASE WHEN u.id='admin' THEN 0 ELSE 1 END, u.created_at ASC LIMIT 1"
+  )
+  const row = r.rows[0]
+  if (!row) { console.error('no admin'); process.exit(4) }
+  const token = authService.createToken({
+    id: String(row.id),
+    email: typeof row.email === 'string' ? row.email : '',
+    username: row.username ?? null,
+    name: typeof row.name === 'string' && row.name.trim() ? row.name : 'K3 WISE Smoke Admin',
+    mobile: row.mobile ?? null,
+    role: row.has_rbac_admin ? 'admin' : (typeof row.role === 'string' && row.role.trim() ? row.role : 'admin'),
+    permissions: Array.isArray(row.permissions) ? row.permissions : [],
+    tenantId,
+    is_active: row.is_active,
+    must_change_password: row.must_change_password,
+    created_at: new Date(),
+    updated_at: new Date(),
+  })
+  console.log(token)
+} finally { await client.end().catch(()=>{}) }
+NODE_END
+)
+RC=$?
+TOKEN=$(printf '%s\n' "$RAW" | awk '/^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/ {f=$0} END {if(f) print f}')
+unset RAW
+[ -n "$TOKEN" ] || { echo "MINT FAILED rc=$RC"; exit 1; }
+printf '%s' "$TOKEN" > "$TOKEN_FILE"
+chmod 600 "$TOKEN_FILE"
+unset TOKEN
+
+# 2. Run the smoke against the host-internal public URL.
+node scripts/ops/integration-k3wise-postdeploy-smoke.mjs \
+  --base-url http://<deploy-host-public-url>:8081 \
+  --token-file "$TOKEN_FILE" \
+  --tenant-id default \
+  --require-auth \
+  --out-dir artifacts/integration-k3wise/internal-trial/postdeploy-smoke
+
+# 3. Render the summary.
+node scripts/ops/integration-k3wise-postdeploy-summary.mjs \
+  --input artifacts/integration-k3wise/internal-trial/postdeploy-smoke/integration-k3wise-postdeploy-smoke.json \
+  --require-auth-signoff
+
+# 4. Optional: shred the token file when done.
+shred -u "$TOKEN_FILE" 2>/dev/null || rm -f "$TOKEN_FILE"
+```
+
+Notes:
+
+- `metasheet-backend` is the backend container name in the default
+  `docker-compose.app.yml`.
+- `JWT_EXPIRY=2h` matches the resolver default.
+- The token value never enters the shell prompt; the heredoc captures
+  container stdout, an `awk` extracts the 3-segment JWT shape, and the value
+  is `unset` from the shell as soon as it is on disk at `0600`.
+- The smoke script's pre-share self-check pattern from
+  `docs/operations/k3-poc-onprem-preflight-runbook.md` (URL query secret
+  check + raw `Bearer` / `eyJ` / token field) applies to this artifact too.
+
 ## Deployment Workflow
 
 The automatic deploy workflow can be made a hard authenticated smoke gate by
@@ -92,18 +190,65 @@ Keep it unset or `false` only when the deployment is still in diagnostic mode.
 Diagnostic mode can prove the web/API surface is reachable, but cannot sign off
 the internal K3 WISE trial.
 
+## Public Surface Access Posture
+
+The `metasheet-web` container's published HTTP port (e.g., `:8081` on 142) is
+**not openly accessible from arbitrary external networks**. As of 2026-05-08
+142 has been observed with the following posture:
+
+- TCP `connect` to `:8081` succeeds from any source.
+- HTTP requests from sources outside the configured allowlist receive an
+  empty reply at the application layer (`curl: (52) Empty reply from
+  server`). The TCP connection is closed without a status line.
+
+Observed reachable paths:
+
+- `K3 WISE Postdeploy Smoke` GHA workflow — succeeds. GitHub Actions egress IP
+  ranges appear to be allowlisted.
+- The deploy host's own shell (loopback via the host's public IP, or via the
+  docker network) — succeeds.
+
+Observed non-reachable path:
+
+- Ad-hoc workstation `curl` from outside the allowlist — TCP succeeds, HTTP
+  returns empty reply.
+
+Implication for operators: if you want to run an ad-hoc smoke without going
+through GHA, prefer the host-shell pattern (SSH into the deploy host and run
+the smoke locally). Do **not** assume `--base-url http://<deploy-host>:8081`
+works from an unprivileged workstation.
+
+Loosening this posture (e.g., adding additional source networks to the
+`:8081` HTTP allowlist) happens in the `metasheet-web` container's nginx
+config or in any front-door reverse proxy, not in this repo, and is out of
+scope for this runbook.
+
 ## 142 Internal Trial Evidence
 
-Latest confirmed signoff run:
+Latest confirmed signoff runs (newest first):
 
-- Workflow: `K3 WISE Postdeploy Smoke`
-- Run: `https://github.com/zensgit/metasheet2/actions/runs/25157307393`
-- Tenant source: repository variable `METASHEET_TENANT_ID=default`
-- Result: `signoff.internalTrial=pass`
-- Summary: `10 pass / 0 skipped / 0 fail`
-- Artifact: `integration-k3wise-postdeploy-smoke-25157307393-1`
+### 2026-05-08, deploy-host shell
 
-The run proved the deployed 142 environment can mint a temporary masked admin
-token from the deploy host, reach the K3 setup frontend route, validate the
-integration plugin route contract, list the four tenant-scoped control-plane
-collections, and validate staging descriptors.
+- Path: "Host-Shell Mint and Smoke" section above.
+- Tenant source: `--tenant-id default` (explicit).
+- Token: minted via host-local `docker exec metasheet-backend node` against the
+  running prod container; written to `/tmp/...` at `0600`; never printed in
+  console, logs, or artifact.
+- Result: `signoff.internalTrial=pass`.
+- Summary: `10 pass / 0 skipped / 0 fail`.
+- Artifact: `artifacts/integration-k3wise/internal-trial/postdeploy-smoke/`
+  on the deploy host (gitignored).
+
+### Earlier, GHA
+
+- Workflow: `K3 WISE Postdeploy Smoke`.
+- Run: `https://github.com/zensgit/metasheet2/actions/runs/25157307393`.
+- Tenant source: repository variable `METASHEET_TENANT_ID=default`.
+- Result: `signoff.internalTrial=pass`.
+- Summary: `10 pass / 0 skipped / 0 fail`.
+- Artifact: `integration-k3wise-postdeploy-smoke-25157307393-1`.
+
+Both runs proved the deployed 142 environment can mint a temporary masked
+admin token, reach the K3 setup frontend route, validate the integration
+plugin route contract, list the four tenant-scoped control-plane collections,
+and validate staging descriptors.


### PR DESCRIPTION
## Summary

Expands `docs/operations/integration-k3wise-internal-trial-runbook.md` with two operator-readiness gaps surfaced while running the runbook for real on 142 today, plus a one-line `.gitignore`. Doc-only PR.

## Two gaps closed

1. **Host-Shell Mint and Smoke (deploy host, no GHA)** — the runbook had a CLI Path that assumed `$METASHEET_AUTH_TOKEN_FILE` was already set, but did not show how to obtain that token when operating on the deploy host directly. `scripts/ops/resolve-k3wise-smoke-token.sh` is GHA-shaped (wants `DEPLOY_HOST`/`DEPLOY_USER`/`DEPLOY_SSH_KEY_B64`); an operator already on the deploy host had to read the resolver, extract the inner Node script, and re-derive `docker exec metasheet-backend node …` themselves (~30 min, every time). The new section inlines the simplified heredoc the runbook author actually ran today — preserving admin-selection SQL, `authService.createToken({...})` shape, and the 2-hour expiry default; intentionally omitting the auto-discover-tenant pathway and two guards that don't apply for the explicit-tenant recipe.

2. **Public Surface Access Posture** — captures the observed "TCP-allow / HTTP-deny by source" posture for `:8081` (curl error 52 from outside the allowlist) and lists reachable vs non-reachable paths (GHA ✓, host-shell ✓, ad-hoc workstation ✗). Saves the next operator from chasing phantom failures.

## Real-world validation

The host-shell recipe was executed end-to-end on 142 today against main `36ca525` (PR #1437 merge SHA) and returned `signoff.internalTrial=pass` / 10 pass / 0 fail. The public-posture observations are the literal commands run from a workstation outside the allowlist. See verification MD §1 and §2.

## Contents

- `docs/operations/integration-k3wise-internal-trial-runbook.md` (+158 lines / -12) — two new sections + a second entry under "142 Internal Trial Evidence" for today's host-shell PASS run, newest-first.
- `docs/development/integration-k3wise-internal-trial-runbook-update-design-20260508.md` — design rationale.
- `docs/development/integration-k3wise-internal-trial-runbook-update-verification-20260508.md` — fact-check matrix + heredoc-vs-resolver explicit list of preserved/omitted bits.
- `.gitignore` (+4 lines) — `artifacts/integration-k3wise/internal-trial/`, matching the existing patterns for postdeploy-smoke and onprem-preflight artifacts.

## Test plan

- [x] Both runbook code blocks (mint + smoke + summary) executed end-to-end on 142 today, decision PASS, 10/10 fail-free
- [x] `pnpm verify:integration-k3wise:onprem-preflight` → 14/14 PASS
- [x] `pnpm verify:integration-k3wise:poc` → 37 unit + mock chain PASS
- [x] `.gitignore` rule effective: marker-file `git status` empty
- [x] `git diff --check origin/main...HEAD` rc=0
- [x] Verification MD §3 explicitly lists what the heredoc preserves vs omits relative to the resolver (no overclaim)

## Deployment impact

None. Doc + one ignore rule.

## Customer GATE status

Outside the GATE block. Stage 1 Lock memory remains in force. No integration-core / runtime / CI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)