### PR TITLE
fix(dingtalk): notify rule creator on group delivery failure

### DIFF
--- a/docs/development/dingtalk-final-closeout-development-20260508.md
+++ b/docs/development/dingtalk-final-closeout-development-20260508.md
@@ -1,0 +1,153 @@
+# DingTalk Final Closeout — Development
+
+- Date: 2026-05-08
+- Branch: `codex/dingtalk-final-closeout-20260508` (PR #1443)
+- PR head before operator rebase: `e5787cf8d3deeb38bb0d0bd6d9b973bda8cd92c0`
+- origin/main HEAD after operator rebase: `c74c15a2b`
+- Main commit deployed on 142 (observed 2026-05-08 at this update): `08c6036284bf975dc1396c752d07f44486c7d4b2`
+- Scope: consolidate the DingTalk feature line into a single closeout, close the
+  rule-creator failure-alert runtime gap, triage the open PR backlog, and capture
+  the operational TODO that remains before delivery is declared closed.
+
+## Merge / Deploy Status (2026-05-08 final update)
+
+- PR #1443 is **NOT MERGED**. Before this operator update, GitHub reported
+  `mergeable=MERGEABLE`, `mergeStateStatus=BEHIND`, and
+  `reviewDecision=REVIEW_REQUIRED`. Codex then rebased this branch onto
+  `origin/main` at `c74c15a2b`; GitHub will recompute mergeability after the
+  updated branch is pushed. Only bot reviewers (`gemini-code-assist`,
+  `copilot-pull-request-reviewer`) had posted `COMMENTED` reviews at the
+  Claude evidence handoff; no human approval was recorded.
+- 142 currently runs `08c603628…` for both backend and web (1 commit behind
+  `origin/main`, and ahead of the prior `34d731670…` snapshot referenced in
+  earlier evidence). The new failure-alert runtime path introduced by this PR
+  is therefore **not live on 142** at the time of writing.
+- Per repository review policy and the explicit conditional in the closeout
+  task ("merge only if authorized and repository rules are satisfied"), the
+  closeout cannot transition to PASS for the merge-dependent rows until: (1)
+  PR #1443 receives an approving human review, (2) it merges, and (3) 142
+  auto-deploys the resulting `main` HEAD.
+
+## Implemented Capability Summary
+
+The following product capabilities are present in the deployed `main` image and
+covered by tests / earlier verification docs:
+
+- Multiple DingTalk groups bindable per table; group robot binding UI + API.
+- Organization-scoped DingTalk group destination catalog v1.
+- Group automation with form links; person messaging recipients across users,
+  member groups, and dynamic fields.
+- Form access modes `public`, `dingtalk`, and `dingtalk_granted` plus an
+  explicit local user / member-group allowlist for DingTalk-protected forms.
+- DingTalk directory sync account list; admin "create + bind" path for synced
+  DingTalk users that arrive without an email.
+- Delivery history for both group sends and person sends.
+- New in this branch (NOT yet on 142): failed `send_dingtalk_group_message`
+  automation steps now attempt a default DingTalk work-notification alert to
+  the rule creator and write the alert attempt into
+  `dingtalk_person_deliveries`. If the creator is not linked to DingTalk, the
+  alert is recorded as `skipped` without hiding the original group-send
+  failure.
+- Work-notification Agent ID admin configuration (status / test / save
+  endpoints + directory-management Agent ID UI), shipped to `main` via the
+  Agent ID mainline integration (PR #1430).
+- P4 closeout tooling: smoke session, evidence recorder, status TODO, strict
+  finalize, final handoff packet, release-ready gate, regression gate
+  (ops + product profiles), redacted JSON / MD summaries, and a one-command
+  `dingtalk-p4-final-closeout.mjs` wrapper.
+- Mobile signoff wired into the final closeout flow (PR #1239).
+
+## PR Triage
+
+All open DingTalk PRs in scope of this closeout are CI-green at the time of
+writing. They are bucketed by whether they must land before the delivery
+blocker policy can be declared satisfied.
+
+### Must merge before closeout (delivery-critical)
+
+| PR | Title | Reason it is on the critical path |
+| --- | --- | --- |
+| #1443 | fix(dingtalk): notify rule creator on group delivery failure | failure-alert runtime path |
+| #1269 | fix(dingtalk): redact final secret assignments | "no secret leakage" gate |
+| #1366 | fix(dingtalk): scan large evidence files for secrets | "no secret leakage" gate |
+| #1272 | fix(dingtalk): redact gate secret assignments | "no secret leakage" gate |
+| #1267 | fix(dingtalk): redact spaced secret assignments in smoke logs | "no secret leakage" gate |
+| #1265 | fix(dingtalk): catch spaced secret assignments in evidence | "no secret leakage" gate |
+| #1263 | chore(dingtalk): harden env secret setters | "no secret leakage" gate |
+| #1260 | chore(dingtalk): scan packet secret assignments | "no secret leakage" gate |
+| #1274 | fix(dingtalk): harden live smoke preflight and robot delivery | A/B group robot delivery + preflight reliability |
+| #1239 | feat(dingtalk): wire mobile signoff into final closeout | mobile signoff completeness |
+| #1253 | test(dingtalk): include public form checks in P4 gate | `public` / `dingtalk` / `dingtalk_granted` form path gate |
+| #1256 | feat(dingtalk): expose final input blocked count | preflight visibility for the final input gate |
+| #1248 | feat(dingtalk): add public form bind recovery CTA | public form path UX recovery |
+| #1251 | test(dingtalk): cover public form unbound users | public form path coverage |
+
+### Can defer (non-blocking polish)
+
+| PR | Title | Reason it is deferrable |
+| --- | --- | --- |
+| #1259 | feat(dingtalk): break down smoke todo progress | UX summary on existing TODO output |
+| #1261 | feat(dingtalk): summarize preflight check totals | UX summary on existing preflight output |
+| #1264 | feat(dingtalk): summarize release readiness gates | UX summary on existing readiness output |
+
+### Archive (out of scope)
+
+- Shared org-level group robot catalog.
+- Row / column-level fill assignment.
+- Finer DingTalk org governance UI.
+- Screenshot-only archive.
+
+## Runtime Patch In This Branch
+
+- `AutomationExecutor` now calls a redaction-safe rule-creator alert path after
+  a DingTalk group automation action fails.
+- The alert resolves the rule creator through the existing DingTalk directory
+  account link path and sends a work notification through the runtime Agent ID
+  config.
+- Alert send success/failure/skipped state is written to person delivery
+  history and summarized under the failed step output as `failureAlert`.
+- Alert failures never convert the original group delivery result into success
+  and never print webhook, token, `SEC...`, JWT, Agent ID, or recipient values.
+
+## Branch Validation Completed
+
+- Backend DingTalk target suite passed: 11 files / 232 tests.
+- Frontend DingTalk target suite passed: 4 files / 58 tests.
+- Backend typecheck and backend build passed.
+- Web build passed with only existing Vite chunk warnings.
+- `git diff --check` passed.
+- Strict branch secret scan passed; the only broader-scan hits were fixed dummy
+  test values such as `dt-app-secret`, not real credentials.
+
+## Remaining Operational TODO
+
+1. Obtain human review approval on PR #1443 (and on remaining "must merge"
+   PRs above), then `git rebase origin/main` and squash-merge per repository
+   policy.
+2. Wait for 142 to auto-deploy the post-merge `main` HEAD; record the new
+   image SHA in the verification doc.
+3. Re-run on the new 142 image:
+   - `dingtalk-work-notification-admin-agent-id.mjs --save` and real-send
+     (`--recipient-user-id-file`) → both `status=pass`,
+     `agent_value_printed=false`, `recipient_value_printed=false`.
+   - `dingtalk-p4-release-readiness.mjs --run-smoke-session` followed by
+     `dingtalk-p4-final-closeout.mjs` → confirm
+     `closeout-summary.json` shows `overallStatus=pass`,
+     `finalStrictStatus=pass`, no pending checks.
+4. Trigger a real failed `send_dingtalk_group_message` automation step on the
+   new image and confirm:
+   - new `dingtalk_group_deliveries` row recorded as failure;
+   - new `dingtalk_person_deliveries` row created for the rule creator with
+     the `failureAlert` shape;
+   - work notification reaches the creator.
+5. Confirm 142 health remains 200 on `/api/health` and `/` after each step,
+   and that the deployed image SHA matches the post-merge `main` HEAD.
+6. After delivery declaration, re-evaluate the "can defer" PR set and either
+   merge or close them; update the archive list above if anything moves.
+
+## Out of Scope
+
+- Any change to the K3 PoC stage-1 lock or integration-core surface.
+- Multitable / Feishu / field-type work.
+- Reading or printing any secret value, webhook URL, robot `SEC...`, admin
+  JWT, Agent ID value, recipient user id list, or temporary password.

--- a/docs/development/dingtalk-final-closeout-execution-design-20260508.md
+++ b/docs/development/dingtalk-final-closeout-execution-design-20260508.md
@@ -1,0 +1,138 @@
+# DingTalk Final Closeout — Execution Design
+
+- Date: 2026-05-08 / 2026-05-09 operator update
+- Branch: `codex/dingtalk-final-closeout-20260508` (PR #1443)
+- Reference PR head after operator rebase and before this execution-package
+  doc-only update: `ca5ea87dc08a9146d678ea6e8281d2af73a011a8`
+- Base used for the operator rebase: `origin/main=c74c15a2b`
+- Current 142 deployed image observed by Claude evidence: `08c6036284bf975dc1396c752d07f44486c7d4b2`
+- Delivery verdict at this checkpoint: **NOT DELIVERABLE — merge blocked**
+
+## Purpose
+
+This execution design records how the DingTalk closeout moves from a green PR
+to a production-verified delivery without mixing responsibilities, leaking
+secrets, or bypassing repository review rules.
+
+The closeout package is intentionally split into two layers:
+
+- Closeout package updates:
+  `dingtalk-final-closeout-development-20260508.md` and
+  `dingtalk-final-closeout-verification-20260508.md` capture the product
+  state, blocker matrix, and acceptance checklist.
+- Execution package updates:
+  this document and `dingtalk-final-closeout-execution-verification-20260508.md`
+  capture the operator boundary, ownership split, post-merge runbook,
+  rollback plan, and this run's evidence ledger.
+
+## Current Boundary
+
+PR #1443 is ready for human review from a code and CI perspective, but it is
+not a deployable delivery yet because the failure-alert runtime path is not
+merged into `main` and therefore is not deployed on 142.
+
+The final closeout may only move from **NOT DELIVERABLE** to **CLOSED** after:
+
+1. a human reviewer approves PR #1443;
+2. PR #1443 is squash-merged into `main`;
+3. 142 deploys the resulting immutable GHCR image tag;
+4. Codex performs the live post-merge acceptance checklist on 142;
+5. the final evidence packet and secret scan pass.
+
+## Ownership Split
+
+### Codex Owns
+
+- Updating the PR branch under explicit user direction.
+- Running local code verification, branch secret scans, and PR diff checks.
+- Rebasing the PR branch onto current `origin/main` when needed.
+- Verifying GitHub CI after push.
+- After merge, independently validating 142 image tags, health, admin API,
+  DingTalk work notification, group robot delivery, public form modes, and
+  failure-alert audit behavior.
+- Recording only redaction-safe evidence in repository docs.
+
+### Human Reviewer Owns
+
+- Reviewing the PR diff.
+- Approving PR #1443.
+- Deciding whether to squash-merge.
+- Confirming any production-risk acceptance when live fault injection is run.
+
+### Claude Owns
+
+- Drafting and refining the closeout / execution markdown package.
+- Producing operator-readable evidence summaries from redaction-safe probes.
+- Stating blockers and boundaries.
+- Not merging, not approving, not handling private credentials in chat.
+
+## Hard Rules
+
+- Do not print or commit real DingTalk webhook URLs, robot `SEC...` values,
+  JWTs, bearer tokens, app secrets, Agent ID values, recipient user ids, or
+  temporary passwords.
+- Private values must remain in private files or environment variables outside
+  git.
+- Do not bypass human review or repository branch protection.
+- Do not hot-patch 142 as a delivery substitute; production delivery must use
+  the post-merge GHCR image tag.
+- Do not change K3, ERP, Feishu, unrelated multitable, or plugin surfaces in
+  this closeout.
+- Do not leave any intentionally broken DingTalk destination after failure
+  injection; rollback the test fault immediately.
+
+## Post-Merge Execution Sequence
+
+Run these steps only after PR #1443 is approved and squash-merged.
+
+1. Record the merged `main` SHA and old 142 backend/web image tags.
+2. Wait for GHCR image build and 142 auto-deploy to complete.
+3. Verify `metasheet-backend` and `metasheet-web` image tags equal the merged
+   `main` SHA.
+4. Verify 142 health: backend `/api/health=200`, web `/=200`, and expected
+   unauthenticated admin/auth probes return `401`.
+5. Validate the admin token through `/api/auth/me` using a private token file;
+   do not print the token.
+6. Run `dingtalk-work-notification-admin-agent-id.mjs --save` using the
+   private Agent ID file and verify redaction flags show no value printed.
+7. Run the same helper with `--recipient-user-id-file` and verify real
+   DingTalk work notification delivery succeeds.
+8. Re-run A/B DingTalk group robot `test-send` and confirm delivery rows show
+   success for both groups.
+9. Run `dingtalk-p4-release-readiness.mjs --run-smoke-session` against the
+   post-merge 142 session.
+10. Run `dingtalk-p4-final-closeout.mjs` and confirm the generated summary has
+    `overallStatus=pass`, `finalStrictStatus=pass`, and no pending checks.
+11. Run the failure-alert injection regression: force one controlled group
+    send failure, confirm group delivery failure row, person delivery
+    `failureAlert` row, rule-creator work notification, then restore the
+    destination and run the final secret scan over generated evidence.
+
+## Rollback Strategy
+
+Rollback is image-level unless a deployment script explicitly introduces a
+schema migration. The current PR changes backend runtime code and docs only;
+it does not add a migration.
+
+1. Before deployment, record old backend and web GHCR image tags.
+2. If post-merge health fails or the app cannot serve forms, set backend/web
+   tags back to the recorded old values and restart only those services.
+3. Recheck backend `/api/health`, web `/`, and `/api/auth/me`.
+4. If DingTalk delivery fails but core app health remains good, keep the app
+   up, disable the affected automation/destination, and preserve delivery
+   rows for diagnosis.
+5. If failure injection modified any destination state, restore the original
+   destination configuration immediately.
+6. Record rollback evidence without printing secrets.
+
+## Delivery Decision Logic
+
+- **CLOSED**: PR #1443 merged, 142 runs the post-merge SHA, all blocker rows in
+  the verification matrix pass, and final evidence secret scan is clean.
+- **TRIAL ONLY**: code and CI pass, but one live DingTalk or public form
+  acceptance row remains pending with a documented non-production workaround.
+- **NOT DELIVERABLE**: PR is not merged, 142 does not run the post-merge SHA,
+  a blocker row fails, or any real secret appears in git / PR / docs / chat.
+
+Current decision: **NOT DELIVERABLE** because PR #1443 remains open and
+requires human review before merge.

--- a/docs/development/dingtalk-final-closeout-execution-verification-20260508.md
+++ b/docs/development/dingtalk-final-closeout-execution-verification-20260508.md
@@ -1,0 +1,107 @@
+# DingTalk Final Closeout — Execution Verification
+
+- Date: 2026-05-08 / 2026-05-09 operator update
+- Branch: `codex/dingtalk-final-closeout-20260508` (PR #1443)
+- Reference PR head after operator rebase and before this execution-package
+  doc-only update: `ca5ea87dc08a9146d678ea6e8281d2af73a011a8`
+- Base used for latest operator rebase: `origin/main=c74c15a2b`
+- Current 142 deployed image observed by Claude evidence: `08c6036284bf975dc1396c752d07f44486c7d4b2`
+- Verdict: **NOT DELIVERABLE — merge blocked**
+
+## Evidence Ledger
+
+| ID | Evidence | Status |
+| --- | --- | --- |
+| E1 | PR #1443 branch exists and is non-draft. | PASS |
+| E2 | PR #1443 contains only DingTalk closeout docs, `automation-executor.ts`, and `automation-v1.test.ts`. | PASS |
+| E3 | Branch was rebased onto `origin/main=c74c15a2b`. | PASS |
+| E4 | Branch is `0 behind / 1 ahead` relative to `origin/main` after the final push. | PASS |
+| E5 | PR #1443 CI passed after the operator rebase push at `ca5ea87dc…`; for later doc-only heads, use GitHub PR checks as the live source of truth. | PASS for referenced head |
+| E6 | `Strict E2E with Enhanced Gates` is skipped by workflow configuration, not failed. | PASS |
+| E7 | Local `automation-v1` target suite passed after rebase: 130 tests. | PASS |
+| E8 | Backend `tsc --noEmit` passed after the first operator rebase. | PASS |
+| E9 | `git diff --check` passed after the final rebase. | PASS |
+| E10 | Strict branch secret scan returned `SECRET_SCAN_PASS`. | PASS |
+| E11 | `/tmp` closeout markdown inputs existed, were line-counted, hashed, scanned, and then used to overwrite the PR branch closeout docs. | PASS |
+| E12 | No `/tmp/*execution*.md` input file existed, so Codex authored the execution package directly in the PR branch. | PASS |
+| E13 | 142 pre-merge backend and web were observed running image `08c6036284bf…`, not PR #1443. | PASS |
+| E14 | 142 pre-merge backend `/api/health` and web `/` were healthy in Claude evidence. | PASS |
+| E15 | 142 pre-merge DingTalk delivery tables had existing rows, but those rows cannot validate PR #1443 because the runtime path is not deployed. | PASS |
+| E16 | PR #1443 remains blocked by human review / merge, not by CI. | PASS |
+| E17 | Final delivery remains blocked until post-merge 142 acceptance flips all pending blocker rows to PASS. | PASS |
+
+## Pending Codex Acceptance Items
+
+Codex owns these after PR #1443 is approved and merged.
+
+| ID | Pending item | Required result |
+| --- | --- | --- |
+| P1 | Confirm squash merge SHA for PR #1443. | Merged SHA recorded. |
+| P2 | Confirm 142 backend image tag equals the merged `main` SHA. | Exact tag match. |
+| P3 | Confirm 142 web image tag equals the merged `main` SHA. | Exact tag match. |
+| P4 | Verify 142 backend `/api/health`. | HTTP 200. |
+| P5 | Verify 142 web `/`. | HTTP 200. |
+| P6 | Verify admin API with private admin token file. | `/api/auth/me` succeeds; token not printed. |
+| P7 | Run Agent ID save helper. | `status=pass`, value redaction flags true/false as expected, no secrets printed. |
+| P8 | Run Agent ID real-send helper. | Work notification delivered to private recipient, zero failures. |
+| P9 | Re-run A/B group robot tests. | Both groups produce successful delivery rows. |
+| P10 | Run public form live evidence for `public`, `dingtalk`, and `dingtalk_granted`. | All three modes PASS. |
+| P11 | Run failure-alert injection regression. | Group failure row, person delivery alert row, and rule-creator work notification observed. |
+| P12 | Run final closeout wrapper and packet generation. | `overallStatus=pass`, `finalStrictStatus=pass`, no pending checks. |
+| P13 | Run final secret scan over generated evidence and docs. | No real secrets found. |
+
+## Current Blocker Matrix
+
+| Blocker | Current state | Why it blocks delivery |
+| --- | --- | --- |
+| PR #1443 not merged | PENDING | The new failure-alert runtime path is not in `main`. |
+| 142 not on post-merge SHA | PENDING | Production has not executed the new runtime path. |
+| Agent ID real-send on post-merge image | PENDING | Must be re-proven after deploy. |
+| A/B robot delivery on post-merge image | PENDING | Must be re-proven after deploy. |
+| Failure-alert live injection | PENDING | Unit tests pass, but live 142 audit/notification is not proven. |
+| Public form three modes | PENDING | Must be included in final live packet. |
+| Final evidence secret scan | PENDING | Must run after the final populated packet exists. |
+
+## Commands Verified In This Execution Layer
+
+These commands were run against the PR branch or GitHub state and produced
+redaction-safe results.
+
+```bash
+git rev-list --left-right --count origin/main...HEAD
+git diff --check origin/main...HEAD
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts --watch=false
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+gh pr checks 1443 --watch --interval 10
+```
+
+Strict branch secret scan pattern returned:
+
+```text
+SECRET_SCAN_PASS
+```
+
+GitHub CI after the final push returned success for:
+
+- `contracts (dashboard)`
+- `contracts (openapi)`
+- `contracts (strict)`
+- `core-backend-cache`
+- `e2e`
+- `migration-replay`
+- `pr-validate`
+- `telemetry-plugin`
+- `K3 WISE offline PoC`
+- `after-sales integration`
+- `test (18.x)`
+- `test (20.x)`
+- `coverage`
+
+`Strict E2E with Enhanced Gates` was skipped by workflow configuration.
+
+## Final Operator Conclusion
+
+The execution package is complete for the pre-merge phase. PR #1443 is
+code-ready and CI-green, but the DingTalk delivery is **not closed** and is
+**not deliverable** until human review, merge, 142 redeploy, and live Codex
+acceptance complete.

--- a/docs/development/dingtalk-final-closeout-verification-20260508.md
+++ b/docs/development/dingtalk-final-closeout-verification-20260508.md
@@ -1,0 +1,278 @@
+# DingTalk Final Closeout — Verification
+
+- Date: 2026-05-08
+- Branch: `codex/dingtalk-final-closeout-20260508` (PR #1443)
+- PR head before operator rebase: `e5787cf8d3deeb38bb0d0bd6d9b973bda8cd92c0`
+- origin/main HEAD after operator rebase: `c74c15a2b`
+- Main commit deployed on 142 (observed 2026-05-08): `08c6036284bf975dc1396c752d07f44486c7d4b2`
+- Companion document:
+  `docs/development/dingtalk-final-closeout-development-20260508.md`
+- Redaction policy: no real DingTalk webhook, robot `SEC...`, admin JWT, Agent
+  ID value, recipient user id, temporary password, or `.env` contents appears
+  in this document. Helpers are quoted with `agentIdValuePrinted=false` and
+  length-only fields.
+
+## Today's Pre-Merge Re-Verification (2026-05-08)
+
+Read-only re-check executed against the currently deployed image
+`08c6036284bf…` on 142 prior to PR #1443 merging. No private credentials
+were used and no secret values were printed.
+
+| Probe | Result |
+| --- | --- |
+| `docker inspect` backend image | `ghcr.io/zensgit/metasheet2-backend:08c6036284bf975dc1396c752d07f44486c7d4b2` |
+| `docker inspect` web image | `ghcr.io/zensgit/metasheet2-web:08c6036284bf975dc1396c752d07f44486c7d4b2` |
+| backend container state | `running` |
+| web container state | `running` |
+| postgres container | `running (healthy)` |
+| `127.0.0.1:8900/api/health` | `200` |
+| `127.0.0.1:8081/` | `200` |
+| `127.0.0.1:8900/api/admin/directory/dingtalk/work-notification` (unauth probe) | `401` (route present, gate active) |
+| `127.0.0.1:8900/api/auth/me` (unauth probe) | `401` (route present, gate active) |
+| `dingtalk_group_deliveries` total rows | `71` |
+| `dingtalk_group_deliveries` last 7d | `success=5`, `failed=2` |
+| `dingtalk_person_deliveries` total rows | `10` |
+| `dingtalk_person_deliveries` last 7d | `failed=1` |
+| Strict secret scan over today's evidence file | `SECRET_SCAN_PASS` (0 matches) |
+
+The 2 recent group failures observed in the last 7 days predate the PR
+#1443 failure-alert path. They cannot be used to validate the new
+rule-creator notification because that code path is not in image
+`08c6036284bf…`.
+
+## Verification Matrix
+
+Status meanings: **PASS** = live-proven on the current deployed `main` image
+or in CI for the recorded commit; **PENDING** = not yet live-proven, awaiting
+merge/deploy or final Codex execution against 142 with the real private inputs.
+
+| # | Gate | Source / Owner | Status |
+| --- | --- | --- | --- |
+| 1 | 142 backend `/api/health` returns 200 | 142 host probe | PASS (re-confirmed on `08c6036284bf…`) |
+| 2 | 142 web HTTP root returns 200 | 142 host probe | PASS (re-confirmed on `08c6036284bf…`) |
+| 3 | Latest `main` CI green for the deployed SHA (`08c603628…`); PR #1443 post-rebase code CI green at `ca5ea87dc…`; newer doc-only heads should use GitHub PR checks as the live source of truth | GitHub Actions | PASS for deployed SHA and referenced code head |
+| 4 | DingTalk PR backlog secret-redaction set is CI-green (PRs #1269, #1366, #1272, #1267, #1265, #1263, #1260) | GitHub PR rollups | PASS |
+| 5 | Live smoke preflight + robot delivery hardening PR is CI-green (#1274) | GitHub PR rollup | PASS |
+| 6 | Mobile signoff into final closeout is CI-green (#1239) | GitHub PR rollup | PASS |
+| 7 | Public form path coverage PRs are CI-green (#1253, #1256, #1248, #1251) | GitHub PR rollups | PASS |
+| 8 | Agent ID admin route exists and is authenticated on the deployed image | 142 unauth probe → 401 | PASS |
+| 9 | Agent ID real save succeeds with the populated private file | 142 helper `--save` | PENDING (must re-run after 142 redeploys post-merge) |
+| 10 | Agent ID real-send work notification delivers (Agent ID required-work-notification gate) | 142 helper `--recipient-user-id-file` | PENDING (re-run after 142 redeploys post-merge) |
+| 11 | A/B group robot — at least one valid message delivered on each group | 142 direct `test-send` + delivery rows | PENDING (re-run after 142 redeploys post-merge) |
+| 12 | Failure-alert code path: group failure creates a rule-creator work-notification attempt and person delivery audit | Local unit test | PASS (unit test) |
+| 13 | Failure-alert end-to-end on 142 after this branch deploys | Live remote smoke session | PENDING (depends on PR #1443 merge + 142 redeploy) |
+| 14 | `public` / `dingtalk` / `dingtalk_granted` form paths pass on the live session | Live remote smoke session | PENDING |
+| 15 | No secret leakage in branch code / docs | Local strict branch scan | PASS |
+| 16 | "Must merge" PR set merged into `main` per review policy | Repository merge state | PENDING (PR #1443 CI is green, but human review and merge are still required) |
+| 17 | No secret leakage anywhere in populated remote evidence packet | Repo + packet secret scans | PENDING (re-run final scan over the populated session) |
+
+## Commands To Run (Codex, in order, after PR #1443 merges)
+
+All commands assume Codex is running on 142 or in the trusted operator
+environment. Claude does not run any of these. Replace `<...>` only with
+private values that stay outside git.
+
+### 1. Confirm 142 is on the post-merge `main` SHA
+
+```bash
+docker inspect --format '{{.Config.Image}}' metasheet-backend
+docker inspect --format '{{.Config.Image}}' metasheet-web
+curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:8900/api/health
+curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:8081/
+```
+
+Expected: both image tags equal the post-merge `main` HEAD; both HTTP
+probes return `200`.
+
+### 2. Confirm Agent ID admin route is present on the deployed image
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' \
+  http://127.0.0.1:8900/api/admin/directory/dingtalk/work-notification
+```
+
+Expected: `401` (unauthenticated probe rejected, route present).
+
+### 3. Real Agent ID save (Codex only — uses private file, never echoed)
+
+```bash
+node scripts/ops/dingtalk-work-notification-admin-agent-id.mjs \
+  --api-base http://127.0.0.1:8900 \
+  --auth-token-file <private-admin-token-file> \
+  --agent-id-file <private-agent-id-file> \
+  --save
+```
+
+Expected (redaction-safe shape only):
+
+```json
+{ "status": "pass", "agentIdValuePrinted": false }
+```
+
+If the helper exits with `AGENT_ID_FILE_EMPTY`, the private Agent ID file is
+still empty and must be populated outside git before retry.
+
+### 4. Real-send work notification (Codex only — recipient list is private)
+
+```bash
+node scripts/ops/dingtalk-work-notification-admin-agent-id.mjs \
+  --api-base http://127.0.0.1:8900 \
+  --auth-token-file <private-admin-token-file> \
+  --agent-id-file <private-agent-id-file> \
+  --recipient-user-id-file <private-recipient-user-id-file>
+```
+
+Expected: `status: "pass"`, no `failures[]` entries, no Agent ID or recipient
+ids printed.
+
+### 5. Live remote smoke session and final closeout wrapper
+
+```bash
+node scripts/ops/dingtalk-p4-release-readiness.mjs \
+  --p4-env-file "$HOME/.config/yuantus/dingtalk-p4-staging.env" \
+  --regression-profile ops \
+  --run-smoke-session \
+  --smoke-output-dir output/dingtalk-p4-remote-smoke-session/142-session
+
+node scripts/ops/dingtalk-p4-final-closeout.mjs \
+  --session-dir output/dingtalk-p4-remote-smoke-session/142-session \
+  --packet-output-dir artifacts/dingtalk-staging-evidence-packet/142-final \
+  --docs-output-dir docs/development \
+  --date 20260508
+```
+
+Expected: `closeout-summary.json` shows `overallStatus: "pass"`,
+`finalStrictStatus: "pass"`, no pending checks; `closeout-summary.md` lists
+A/B group robot, failure-alert, and the three form access modes as PASS.
+
+### 6. Failure-alert end-to-end (this PR's regression case)
+
+Trigger a real `send_dingtalk_group_message` automation step that fails on
+the new image (e.g., temporarily de-authorize one of the bound robots or
+target an unreachable group) and confirm:
+
+- a new row appears in `dingtalk_group_deliveries` with `success=false`;
+- a new row appears in `dingtalk_person_deliveries` for the rule creator
+  whose origin shape matches `failureAlert`;
+- the rule creator receives a DingTalk work notification.
+
+Roll back the temporary fault after the run; do not leave production
+destinations de-authorized.
+
+## Current Verified Evidence (cumulative)
+
+These are facts established prior to and during this Claude run. Quoted as
+redaction-safe identifiers only.
+
+- Pre-merge re-verification on `08c6036284bf…` (this run, see "Today's
+  Pre-Merge Re-Verification" above): `/api/health=200`, `/=200`,
+  admin route `401`, `auth/me 401` for unauthenticated probes.
+- DB row health on 142: `dingtalk_group_deliveries` total=71 (last 7d:
+  5 success / 2 failed); `dingtalk_person_deliveries` total=10 (last 7d:
+  1 failed). No PII/secret values queried or printed.
+- Earlier evidence on `34d731670…` (Codex, prior pass): Agent ID helper
+  returned `status=pass`, `access_token_verified=true`,
+  `notification_sent=true`, `saved=true`, `status_after_available=true`,
+  `agent_value_printed=false`, `recipient_value_printed=false`,
+  `failure_count=0`. Work-notification release gate returned `status=pass`,
+  `health.ok=true`, `auth.ok=true`, `workNotification.available=true`,
+  `failures=[]`. A/B group robot direct test-sends returned `204`; newest
+  delivery rows showed `success=true`, `http_status=200`. These results
+  must be re-run on the post-merge image because 142 has since advanced
+  to `08c603628…` and will advance again after PR #1443 merges.
+- Latest `main` CI known green at the Claude evidence handoff:
+  `34d731670…`, `08c603628…`, and then-current HEAD `ff0a11efe…` across
+  the standard required workflows. The operator rebase later used
+  `origin/main=c74c15a2b`; PR #1443 post-rebase code CI passed at
+  `ca5ea87dc…`. For later doc-only heads, use GitHub PR checks as the live
+  source of truth.
+- Open DingTalk PRs in the closeout backlog are CI-green at observation
+  time:
+  - Failure-alert (this PR): #1443 (post-rebase code CI green; later
+    doc-only heads must be checked in GitHub; human review and merge still
+    required).
+  - Secret redaction / scan: #1269, #1366, #1272, #1267, #1265, #1263, #1260.
+  - Preflight + live delivery: #1274.
+  - Mobile signoff into closeout: #1239.
+  - Closeout summary polish (deferrable): #1259, #1261, #1264.
+  - Public form coverage / UX / blocked-count: #1253, #1256, #1248, #1251.
+  - PRs #1248 and #1251 each show one **skipped** check; remaining required
+    checks on those two PRs are green.
+- Local DingTalk backend target suite passed:
+  `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts tests/unit/dingtalk-work-notification.test.ts tests/unit/dingtalk-work-notification-settings.test.ts tests/unit/dingtalk-group-destination-service.test.ts tests/unit/dingtalk-group-delivery-service.test.ts tests/unit/dingtalk-person-delivery-service.test.ts tests/unit/dingtalk-oauth-login-gates.test.ts tests/unit/jwt-middleware.test.ts tests/unit/auth-login-routes.test.ts tests/integration/dingtalk-group-destination-routes.api.test.ts tests/integration/dingtalk-delivery-routes.api.test.ts --watch=false`
+  with 11 files / 232 tests passed.
+- Local DingTalk frontend target suite passed:
+  `pnpm --filter @metasheet/web exec vitest run tests/dingtalk-public-form-link-warnings.spec.ts tests/dingtalk-recipient-field-warnings.spec.ts tests/dingtalk-auth-callback.spec.ts tests/directoryManagementView.spec.ts --watch=false`
+  with 4 files / 58 tests passed.
+- Backend typecheck passed:
+  `pnpm --filter @metasheet/core-backend exec tsc --noEmit`.
+- Backend build passed:
+  `pnpm --filter @metasheet/core-backend build`.
+- Web build passed:
+  `pnpm --filter @metasheet/web build`. Vite emitted only the existing large
+  chunk / mixed static-dynamic import warnings.
+- Whitespace check passed:
+  `git diff --check`.
+- Strict branch secret scan passed with `SECRET_SCAN_PASS`. A broader first
+  pass only matched fixed dummy test fixtures such as `dt-app-secret`; no
+  real webhook, robot secret, JWT, bearer token, app secret, Agent ID value,
+  or recipient user id was found in the changed files.
+
+## Blocker Status (per delivery blocker policy)
+
+| Blocker policy line | Required outcome | Current status |
+| --- | --- | --- |
+| Agent ID real work notification must pass | Live `--save` + real-send round trip on the post-merge `main` image | PENDING (re-run required on new image after PR #1443 merges) |
+| A/B group robot — at least one valid message must pass | One delivered message on each of group A and group B on the post-merge image | PENDING (re-run required) |
+| Failure alert must have delivery / audit and notify rule creator | Local runtime path covered; live end-to-end run after deploy still required | PENDING |
+| `public` / `dingtalk` / `dingtalk_granted` form paths must pass | All three modes covered green in the live session | PENDING |
+| CI and 142 health must pass | `main` CI green + 142 health 200 | PASS |
+| No secret leakage | Branch code/docs strict scan + today's pre-merge evidence scan are clean; final packet scan must be repeated after final populated session | PASS for branch + this Claude run; PENDING for final packet |
+
+Until every blocker line is PASS, delivery remains **NOT CLOSED**. The
+non-blocking deferrals (shared org-level group robot catalog,
+row/column-level fill assignment, finer DingTalk org governance UI,
+screenshot-only archive) are explicitly excluded from this matrix.
+
+## Acceptance Checklist For Codex Final Verification
+
+Codex marks each item PASS only after running the corresponding command and
+confirming the redaction-safe outcome. PENDING is the default.
+
+- [ ] PR #1443 is approved by a human reviewer and squash-merged. Post-rebase
+      code CI is already green at `ca5ea87dc…`; verify GitHub checks for the
+      current PR head before merge.
+- [ ] After merge, 142 backend and web containers run the post-merge `main`
+      HEAD image (record the new SHA in this doc).
+- [ ] `/api/health` returns 200 and web `/` returns 200 after the new image
+      auto-deploys.
+- [ ] `/api/admin/directory/dingtalk/work-notification` returns 401
+      unauthenticated on the new image.
+- [ ] Admin helper `--save` against the real private Agent ID file returns
+      `status: "pass"` with `agentIdValuePrinted=false`.
+- [ ] Admin helper real-send with `--recipient-user-id-file` returns
+      `status: "pass"` and zero `failures[]`.
+- [ ] Live remote smoke session reaches `finalize_pending`,
+      `dingtalk-p4-final-closeout.mjs` completes, and
+      `closeout-summary.json` reports `overallStatus: "pass"` with
+      `finalStrictStatus: "pass"` and no pending checks.
+- [ ] A/B group robot — at least one delivered message recorded for each
+      group on the post-merge image; included in the final packet.
+- [ ] Failure-alert end-to-end run on 142 shows: `dingtalk_group_deliveries`
+      failure row, `dingtalk_person_deliveries` `failureAlert` row for the
+      rule creator, and DingTalk work notification delivered to that creator.
+- [ ] `public`, `dingtalk`, and `dingtalk_granted` form paths each PASS in
+      the live session evidence.
+- [ ] Final secret scan over the populated session and packet returns no
+      findings (matches limited to redactor code, scan commands, and dummy
+      fixtures).
+- [ ] All PRs in the "must merge" bucket of the development doc are merged
+      into `main`.
+- [ ] After the must-merge set lands, 142 auto-deploys the new `main` image
+      and items above are re-confirmed against that image — not against a
+      manually switched feature tag.
+
+When every box above is checked, Codex may declare the DingTalk feature
+delivery **CLOSED** and update the PR / release notes accordingly. Until
+then this document, and the matrix above, remain the source of truth for
+closeout status.

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -37,6 +37,7 @@ const logger = new Logger('AutomationExecutor')
 const WEBHOOK_TIMEOUT_MS = 5_000
 const MAX_WEBHOOK_RETRIES = 2
 const DINGTALK_PERSON_BATCH_SIZE = 100
+const DINGTALK_FAILURE_ALERT_CONTENT_LIMIT = 1_000
 
 function readJsonSafely(response: Response): Promise<unknown> {
   return response.json().catch(() => null)
@@ -208,6 +209,29 @@ function stringifyResponseBody(payload: unknown, fallback: string | null = null)
     return JSON.stringify(payload)
   } catch {
     return fallback
+  }
+}
+
+function redactDingTalkFailureAlertText(value: unknown): string {
+  return String(value ?? '')
+    .replace(/https:\/\/oapi\.dingtalk\.com\/robot\/send\?access_token=[A-Za-z0-9._~-]+/gi, '<dingtalk-robot-webhook-redacted>')
+    .replace(/access_token=[A-Za-z0-9._~-]+/gi, 'access_token=<redacted>')
+    .replace(/SEC[A-Za-z0-9+/=_-]{8,}/g, 'SEC<redacted>')
+    .replace(/Bearer\s+[A-Za-z0-9._-]{8,}/gi, 'Bearer <redacted>')
+    .replace(/eyJ[A-Za-z0-9._-]{20,}/g, '<jwt-redacted>')
+    .slice(0, DINGTALK_FAILURE_ALERT_CONTENT_LIMIT)
+}
+
+function mergeFailureAlertOutput(
+  output: unknown,
+  failureAlert: Record<string, unknown>,
+): Record<string, unknown> {
+  const base = output && typeof output === 'object' && !Array.isArray(output)
+    ? output as Record<string, unknown>
+    : {}
+  return {
+    ...base,
+    failureAlert,
   }
 }
 
@@ -603,6 +627,20 @@ export class AutomationExecutor {
       }
 
       result.durationMs = Date.now() - startMs
+
+      if (action.type === 'send_dingtalk_group_message' && result.status === 'failed') {
+        let failureAlert: Record<string, unknown>
+        try {
+          failureAlert = await this.notifyRuleCreatorOfDingTalkGroupFailure(result, context)
+        } catch (error) {
+          failureAlert = {
+            status: 'failed',
+            reason: redactDingTalkFailureAlertText(error instanceof Error ? error.message : String(error)),
+          }
+        }
+        result.output = mergeFailureAlertOutput(result.output, failureAlert)
+      }
+
       results.push(result)
 
       // Stop on failure
@@ -620,6 +658,118 @@ export class AutomationExecutor {
     }
 
     return results
+  }
+
+  private async notifyRuleCreatorOfDingTalkGroupFailure(
+    failedStep: AutomationStepResult,
+    context: ExecutionContext,
+  ): Promise<Record<string, unknown>> {
+    const ruleCreatorId = typeof context.ruleCreatedBy === 'string' ? context.ruleCreatedBy.trim() : ''
+    const subject = 'MetaSheet DingTalk group delivery failed'
+    const content = [
+      'A DingTalk group automation message failed.',
+      `Rule: ${context.ruleId}`,
+      `Sheet: ${context.sheetId}`,
+      context.recordId ? `Record: ${context.recordId}` : '',
+      `Error: ${redactDingTalkFailureAlertText(failedStep.error ?? 'Unknown DingTalk group delivery failure')}`,
+    ].filter(Boolean).join('\n')
+
+    if (!ruleCreatorId) {
+      return { status: 'skipped', reason: 'missing_rule_creator' }
+    }
+
+    const recipientResult = await this.deps.queryFn(
+      `SELECT u.id AS local_user_id,
+              linked.external_user_id AS dingtalk_user_id
+         FROM users u
+         LEFT JOIN LATERAL (
+           SELECT a.external_user_id
+             FROM directory_account_links l
+             JOIN directory_accounts a ON a.id = l.directory_account_id
+            WHERE l.local_user_id = u.id
+              AND l.link_status = 'linked'
+              AND a.provider = 'dingtalk'
+              AND a.is_active = TRUE
+            ORDER BY a.updated_at DESC
+            LIMIT 1
+         ) linked ON TRUE
+        WHERE u.id = $1
+          AND u.is_active = TRUE
+        LIMIT 1`,
+      [ruleCreatorId],
+    )
+    const row = (recipientResult.rows[0] ?? null) as Record<string, unknown> | null
+    const dingtalkUserId = typeof row?.dingtalk_user_id === 'string' ? row.dingtalk_user_id.trim() : ''
+
+    if (!row || !dingtalkUserId) {
+      await recordDingTalkPersonDeliverySafely(this.deps.queryFn, {
+        localUserId: ruleCreatorId,
+        sourceType: 'automation',
+        subject,
+        content,
+        success: false,
+        status: 'skipped',
+        errorMessage: 'Rule creator DingTalk account is not linked or user is inactive',
+        automationRuleId: context.ruleId,
+        recordId: context.recordId,
+        initiatedBy: context.actorId ?? null,
+      })
+      return { status: 'skipped', reason: 'rule_creator_not_linked' }
+    }
+
+    try {
+      const messageConfig = await readDingTalkMessageConfigFromRuntime()
+      const accessToken = await fetchDingTalkAppAccessToken(messageConfig, { fetchFn: this.deps.fetchFn })
+      const result = await sendDingTalkWorkNotification(
+        accessToken,
+        {
+          userIds: [dingtalkUserId],
+          title: subject,
+          content,
+        },
+        messageConfig,
+        { fetchFn: this.deps.fetchFn },
+      )
+      await recordDingTalkPersonDeliverySafely(this.deps.queryFn, {
+        localUserId: ruleCreatorId,
+        dingtalkUserId,
+        sourceType: 'automation',
+        subject,
+        content,
+        success: true,
+        status: 'success',
+        httpStatus: 200,
+        responseBody: stringifyResponseBody(result.raw),
+        automationRuleId: context.ruleId,
+        recordId: context.recordId,
+        initiatedBy: context.actorId ?? null,
+      })
+      return { status: 'success', notifiedUsers: 1 }
+    } catch (error) {
+      const httpStatus = error instanceof DingTalkRequestError ? error.statusCode : error instanceof DingTalkBusinessError ? 200 : null
+      const responseBody = error instanceof DingTalkRequestError
+        ? stringifyResponseBody(error.responseBody)
+        : error instanceof DingTalkBusinessError
+          ? stringifyResponseBody(error.responseBody)
+          : null
+      const errorMessage = redactDingTalkFailureAlertText(error instanceof Error ? error.message : String(error))
+      await recordDingTalkPersonDeliverySafely(this.deps.queryFn, {
+        localUserId: ruleCreatorId,
+        dingtalkUserId,
+        sourceType: 'automation',
+        subject,
+        content,
+        success: false,
+        status: 'failed',
+        httpStatus,
+        responseBody,
+        errorMessage,
+        automationRuleId: context.ruleId,
+        recordId: context.recordId,
+        initiatedBy: context.actorId ?? null,
+      })
+      return { status: 'failed', reason: errorMessage }
+    }
   }
 
   // ── Individual action executors ─────────────────────────────────────────

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -848,6 +848,120 @@ describe('AutomationExecutor', () => {
     expect(insertArgs?.[8]).toContain('signature mismatch')
   })
 
+  it('notifies the rule creator when send_dingtalk_group_message fails', async () => {
+    process.env.DINGTALK_APP_KEY = 'dt-app-key'
+    process.env.DINGTALK_APP_SECRET = 'dt-app-secret'
+    process.env.DINGTALK_AGENT_ID = '123456789'
+
+    const queryFn = vi.fn()
+      .mockResolvedValueOnce({
+        rows: [{ id: 'dt_1', name: 'Ops Group', webhook_url: 'https://oapi.dingtalk.com/robot/send?access_token=test', secret: null, enabled: true }],
+      })
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [{ local_user_id: 'user_1', dingtalk_user_id: 'dt-user-1' }] })
+      .mockResolvedValue({ rows: [], rowCount: 1 })
+    const fetchFn = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ errcode: 310000, errmsg: 'signature mismatch' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: 'app-access-token' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ errcode: 0, errmsg: 'ok', task_id: 778899 }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })) as unknown as typeof fetch
+
+    deps = createMockDeps({ queryFn, fetchFn })
+    executor = new AutomationExecutor(deps)
+
+    const rule = createMockRule({
+      actions: [{
+        type: 'send_dingtalk_group_message',
+        config: {
+          destinationId: 'dt_1',
+          titleTemplate: 'Record {{record.title}} ready',
+          bodyTemplate: 'Status: {{record.status}}',
+        },
+      }],
+    })
+    const result = await executor.execute(rule, {
+      recordId: 'r1',
+      data: { title: 'Incident', status: 'open' },
+      sheetId: 'sheet_1',
+      actorId: 'user_2',
+    })
+
+    expect(result.status).toBe('failed')
+    expect(result.steps[0].output).toEqual(expect.objectContaining({
+      failureAlert: expect.objectContaining({ status: 'success', notifiedUsers: 1 }),
+    }))
+    expect(fetchFn).toHaveBeenCalledTimes(3)
+    const [, notificationInit] = fetchFn.mock.calls[2] as [string, RequestInit]
+    const payload = JSON.parse(notificationInit.body as string)
+    expect(payload.userid_list).toBe('dt-user-1')
+    expect(payload.msg.markdown.text).toContain('MetaSheet DingTalk group delivery failed')
+    expect(payload.msg.markdown.text).toContain('Rule: rule_1')
+    expect(payload.msg.markdown.text).toContain('signature mismatch')
+
+    const personInsertCalls = queryFn.mock.calls.filter((call) => String(call[0]).includes('INSERT INTO dingtalk_person_deliveries'))
+    expect(personInsertCalls).toHaveLength(1)
+    const insertArgs = personInsertCalls[0]?.[1] as unknown[] | undefined
+    expect(insertArgs?.[1]).toBe('user_1')
+    expect(insertArgs?.[2]).toBe('dt-user-1')
+    expect(insertArgs?.[6]).toBe(true)
+    expect(insertArgs?.[7]).toBe('success')
+  })
+
+  it('audits a skipped rule-creator alert when the creator is not linked to DingTalk', async () => {
+    const queryFn = vi.fn()
+      .mockResolvedValueOnce({
+        rows: [{ id: 'dt_1', name: 'Ops Group', webhook_url: 'https://oapi.dingtalk.com/robot/send?access_token=test', secret: null, enabled: true }],
+      })
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [{ local_user_id: 'user_1', dingtalk_user_id: null }] })
+      .mockResolvedValue({ rows: [], rowCount: 1 })
+    const fetchFn = vi.fn(async () => new Response(JSON.stringify({ errcode: 310000, errmsg: 'signature mismatch' }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })) as unknown as typeof fetch
+
+    deps = createMockDeps({ queryFn, fetchFn })
+    executor = new AutomationExecutor(deps)
+
+    const rule = createMockRule({
+      actions: [{
+        type: 'send_dingtalk_group_message',
+        config: {
+          destinationId: 'dt_1',
+          titleTemplate: 'Record {{record.title}} ready',
+          bodyTemplate: 'Status: {{record.status}}',
+        },
+      }],
+    })
+    const result = await executor.execute(rule, {
+      recordId: 'r1',
+      data: { title: 'Incident', status: 'open' },
+      sheetId: 'sheet_1',
+      actorId: 'user_2',
+    })
+
+    expect(result.status).toBe('failed')
+    expect(result.steps[0].output).toEqual(expect.objectContaining({
+      failureAlert: expect.objectContaining({ status: 'skipped', reason: 'rule_creator_not_linked' }),
+    }))
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+    const personInsertCalls = queryFn.mock.calls.filter((call) => String(call[0]).includes('INSERT INTO dingtalk_person_deliveries'))
+    expect(personInsertCalls).toHaveLength(1)
+    const insertArgs = personInsertCalls[0]?.[1] as unknown[] | undefined
+    expect(insertArgs?.[1]).toBe('user_1')
+    expect(insertArgs?.[6]).toBe(false)
+    expect(insertArgs?.[7]).toBe('skipped')
+    expect(insertArgs?.[10]).toContain('not linked')
+  })
+
   it('keeps send_dingtalk_group_message successful when delivery history persistence fails', async () => {
     process.env.APP_BASE_URL = 'https://app.example.com'
     const queryFn = vi.fn()
@@ -965,11 +1079,13 @@ describe('AutomationExecutor', () => {
 
   it('scopes send_dingtalk_group_message destinations to the current sheet and rule creator', async () => {
     const queryFn = vi.fn(async (sql: string, params?: unknown[]) => {
-      expect(sql).toContain('sheet_id = $2')
-      expect(sql).toContain('org_id IS NULL AND created_by = $3')
-      expect(sql).toContain('FROM user_orgs uo')
-      expect(sql).toContain('uo.org_id = dg.org_id')
-      expect(params).toEqual([['dt_other_sheet'], 'sheet_1', 'user_1'])
+      if (sql.includes('FROM dingtalk_group_destinations')) {
+        expect(sql).toContain('sheet_id = $2')
+        expect(sql).toContain('org_id IS NULL AND created_by = $3')
+        expect(sql).toContain('FROM user_orgs uo')
+        expect(sql).toContain('uo.org_id = dg.org_id')
+        expect(params).toEqual([['dt_other_sheet'], 'sheet_1', 'user_1'])
+      }
       return { rows: [], rowCount: 0 }
     })
     deps = createMockDeps({ queryFn })
@@ -997,7 +1113,10 @@ describe('AutomationExecutor', () => {
     expect(result.steps[0].status).toBe('failed')
     expect(result.steps[0].error).toContain('DingTalk destinations not found')
     expect(result.steps[0].error).toContain('dt_other_sheet')
-    expect(queryFn).toHaveBeenCalledTimes(1)
+    expect(result.steps[0].output).toEqual(expect.objectContaining({
+      failureAlert: expect.objectContaining({ status: 'skipped', reason: 'rule_creator_not_linked' }),
+    }))
+    expect(queryFn).toHaveBeenCalledTimes(3)
   })
 
   it('fails send_dingtalk_group_message when dynamic record path resolves no destinations', async () => {


### PR DESCRIPTION
## Summary
- Adds the missing default failure-alert runtime path for failed `send_dingtalk_group_message` automation steps.
- Resolves the rule creator through the DingTalk directory link, sends a DingTalk work notification when possible, and always records the alert attempt in `dingtalk_person_deliveries`.
- Adds final closeout development and verification docs with redacted 142 evidence and remaining non-blocking/pending items.

## Validation
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts tests/unit/dingtalk-work-notification.test.ts tests/unit/dingtalk-work-notification-settings.test.ts tests/unit/dingtalk-group-destination-service.test.ts tests/unit/dingtalk-group-delivery-service.test.ts tests/unit/dingtalk-person-delivery-service.test.ts tests/unit/dingtalk-oauth-login-gates.test.ts tests/unit/jwt-middleware.test.ts tests/unit/auth-login-routes.test.ts tests/integration/dingtalk-group-destination-routes.api.test.ts tests/integration/dingtalk-delivery-routes.api.test.ts --watch=false` (11 files / 232 tests)
- `pnpm --filter @metasheet/web exec vitest run tests/dingtalk-public-form-link-warnings.spec.ts tests/dingtalk-recipient-field-warnings.spec.ts tests/dingtalk-auth-callback.spec.ts tests/directoryManagementView.spec.ts --watch=false` (4 files / 58 tests)
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit`
- `pnpm --filter @metasheet/core-backend build`
- `pnpm --filter @metasheet/web build`
- `git diff --check`
- Strict changed-file secret scan: `SECRET_SCAN_PASS`

## 142 Evidence
- Current deployed main image tag observed: `34d731670e05b9cea5bf603905b880ec36d4bd98`.
- Backend `/api/health` returned HTTP 200; Web `/` returned HTTP 200.
- Agent ID admin helper passed real save and real work-notification send using private files; no Agent ID or recipient values printed.
- A/B DingTalk group robot direct `test-send` calls returned HTTP 204; newest delivery rows showed success with HTTP 200 and no error.

## Notes
- No webhook, robot `SEC...`, JWT, bearer token, app secret, Agent ID value, recipient user id, or temporary password is included in code, docs, or this PR body.
- Live end-to-end verification for the new failure-alert path is still required after this branch is merged and deployed to 142.
