### PR TITLE
docs(multitable): plan Feishu phase 2 lanes

### DIFF
--- a/docs/development/multitable-feishu-phase2-development-20260509.md
+++ b/docs/development/multitable-feishu-phase2-development-20260509.md
@@ -1,0 +1,127 @@
+# Multitable Feishu Phase 2 Planning · Development
+
+> Date: 2026-05-09
+> Branch: `codex/multitable-feishu-phase2-plan-20260509`
+> Baseline: `origin/main@c74c15a2b`; refreshed against `origin/main@3a484622c`
+> Scope: docs-only execution plan for post-RC multitable development
+
+## Context
+
+The multitable RC line is closed at `multitable-rc-20260508b-08c6036284`, and PR #1446 archived the final RC evidence plus the UI smoke wrapper. Continuing from the older `multitable-feishu-three-lane-claude-execution-plan-20260507.md` would be incorrect because several planned items have since landed:
+
+- `autoNumber` and its hardening are already implemented.
+- Gantt dependency arrows, self-table validation, and staging UI smoke passed.
+- Hierarchy drag reparent and cycle prevention are implemented.
+- The RC smoke suite is complete and archived.
+
+This slice creates a fresh Phase 2 plan for product development after RC sign-off.
+
+Update on 2026-05-11: before merging this planning PR, the branch was rebased
+onto `origin/main@3a484622c`. Lane C's core grid bulk edit work has already
+landed through PR #1451 and PR #1456, so the plan now treats Lane C as complete
+except for optional UX follow-up.
+
+## Local State Considerations
+
+The root checkout is currently not a safe implementation base:
+
+- It is on `codex/integration-k3wise-live-gate-rehearsal-fixups-20260509`.
+- The remote tracking branch is gone.
+- It contains unrelated untracked docs and `.claude/`.
+
+For that reason this planning slice was created in a clean worktree:
+
+```bash
+git worktree add -b codex/multitable-feishu-phase2-plan-20260509 \
+  /private/tmp/ms2-feishu-phase2-plan-20260509 origin/main
+```
+
+## What Changed
+
+Added the Phase 2 TODO document:
+
+- `docs/development/multitable-feishu-phase2-todo-20260509.md`
+
+Added this development record:
+
+- `docs/development/multitable-feishu-phase2-development-20260509.md`
+
+Added the verification record:
+
+- `docs/development/multitable-feishu-phase2-verification-20260509.md`
+
+No source code, migrations, OpenAPI generated outputs, package scripts, or runtime behavior were changed.
+
+## Planning Decisions
+
+### Decision 1 - Treat RC as closed
+
+The next workstream should not reopen RC smoke scope unless staging produces a regression. Phase 2 should add product value beyond RC sign-off.
+
+### Decision 2 - Pick three file-bounded lanes
+
+The selected lanes are:
+
+| Lane | Theme | Why now |
+|---|---|---|
+| A | `longText` field | High-frequency Feishu parity gap; small enough to ship quickly. |
+| B | real email transport gate | RC `send_email` only proved mock delivery; real transport needs secret-safe gates. |
+| C | grid bulk edit | Completed after this plan was drafted through #1451 and #1456; keep only optional polish follow-up. |
+
+### Decision 3 - Keep AI, rich text, and marketplace out of this phase
+
+These are larger product bets and should not be mixed with the first post-RC development wave.
+
+### Decision 4 - Split email into B1 and B2
+
+Email is security-sensitive. The first PR should add an env-gated readiness seam and redacted verification. Actual SMTP/provider delivery should wait until dependency and operations policy are clear.
+
+### Decision 5 - Let Claude implement broad UI lanes, keep Codex on review/security
+
+Claude can move faster on Lane A and Lane C. Codex should own or closely review Lane B because it touches credentials, logs, staging gates, and failure handling.
+
+## File Boundary Summary
+
+Lane A will likely touch field codecs, field config/display utilities, cell editor/renderer, form/drawer behavior, OpenAPI, and focused field tests.
+
+Lane B will likely touch `NotificationService`, automation executor/service validation, release-gate scripts, and redaction tests.
+
+Lane C has landed through #1451 and #1456. Optional follow-up should be limited
+to UX polish, such as a richer per-row failure table, rather than reopening the
+core bulk edit write path.
+
+No lane is expected to touch:
+
+- `plugins/plugin-integration-core/*`
+- K3 WISE PoC scripts
+- DingTalk OAuth/public-form auth policy
+- Deployment compose files
+
+## Handoff Instructions for Claude
+
+Start with Lane A only if worktrees are clean:
+
+```bash
+git worktree add -b codex/multitable-phase2-long-text-field-20260509 \
+  /private/tmp/ms2-phase2-longtext-20260509 origin/main
+```
+
+Do not start Lane B2 until B1 exists and the email dependency choice is explicit.
+
+Every PR must include:
+
+- Development MD
+- Verification MD
+- Focused test output
+- Secret/leak scan if it handles credentials or email
+
+## Expected PR Order
+
+1. Lane C grid bulk edit - done through #1451 and #1456.
+2. Lane A `longText`.
+3. Lane B1 email readiness/gate.
+4. Lane B2 real SMTP/provider transport, if approved.
+
+Lane A and Lane B1 can be developed in parallel because their file boundaries
+are mostly disjoint. Do not start B2 until B1 lands and the transport dependency
+choice is explicit.

--- a/docs/development/multitable-feishu-phase2-todo-20260509.md
+++ b/docs/development/multitable-feishu-phase2-todo-20260509.md
@@ -1,0 +1,259 @@
+# Multitable Feishu Phase 2 TODO - 2026-05-09
+
+## Status
+
+- Baseline: `origin/main@c74c15a2b` after PR #1446.
+- Refreshed baseline before merge: `origin/main@3a484622c`.
+- Prior RC: `multitable-rc-20260508b-08c6036284`.
+- Goal: continue Feishu-parity development after the signed RC without reopening the RC smoke scope.
+- Rule: every completed item must include PR, merge commit, development MD, verification MD, and verification summary.
+- Worktree rule: all implementation work must start from clean worktrees based on `origin/main`; do not develop from a root checkout that has unrelated untracked docs or an unrelated branch checked out.
+
+## Completion Rules
+
+Mark an item complete only after all are true:
+
+- Code is merged or explicitly accepted as docs-only.
+- Focused backend and frontend tests are recorded.
+- `git diff --check` passes.
+- OpenAPI parity is updated when route/schema contracts change.
+- Staging claims include an artifact path or a redacted command transcript.
+- Secrets, JWTs, SMTP credentials, public form tokens, and webhook URLs are not written to docs or logs.
+
+## Phase 0 - Local Hygiene
+
+- [ ] Move root checkout back to a safe base or use only clean worktrees.
+  - Current observation: root checkout contains unrelated untracked docs and `.claude/`.
+  - Acceptance: new feature work happens in `/private/tmp/ms2-*` or `.worktrees/*` worktrees from `origin/main`.
+- [ ] Classify existing untracked docs into archive, delete, or hand off.
+  - Acceptance: no new multitable Phase 2 PR accidentally includes integration/K3/DingTalk docs.
+- [x] Create Phase 2 planning docs.
+  - Development MD: `docs/development/multitable-feishu-phase2-development-20260509.md`
+  - Verification MD: `docs/development/multitable-feishu-phase2-verification-20260509.md`
+  - Verification summary: docs-only plan created from `origin/main@c74c15a2b`; scoped to three non-overlapping lanes plus a hygiene gate.
+
+## Lane A - Long Text Field
+
+Owner recommendation: Claude can implement; Codex reviews.
+
+### Objective
+
+Add a native `longText` field type for multi-line plain text. This is not rich text, not Markdown rendering, and not a full collaborative document editor. It closes the high-frequency Feishu parity gap where users need notes, descriptions, and multi-line imported content.
+
+### File Boundary
+
+Likely backend files:
+
+- `packages/core-backend/src/multitable/field-codecs.ts`
+- `packages/core-backend/src/multitable/field-type-registry.ts`
+- `packages/core-backend/src/multitable/field-validation.ts`
+- `packages/core-backend/src/multitable/xlsx-service.ts`
+- `packages/openapi/**`
+- Focused backend tests under `packages/core-backend/tests/**`
+
+Likely frontend files:
+
+- `apps/web/src/multitable/types.ts`
+- `apps/web/src/multitable/utils/field-display.ts`
+- `apps/web/src/multitable/utils/field-config.ts`
+- `apps/web/src/multitable/components/MetaFieldManager.vue`
+- `apps/web/src/multitable/components/cells/MetaCellEditor.vue`
+- `apps/web/src/multitable/components/cells/MetaCellRenderer.vue`
+- `apps/web/src/multitable/components/MetaFormView.vue`
+- `apps/web/src/multitable/components/MetaRecordDrawer.vue`
+- Focused frontend tests under `apps/web/tests/**`
+
+### Requirements
+
+- [ ] `longText`, `long_text`, and `multiline` normalize to canonical `longText`.
+- [ ] Stored raw value is a string; non-string values sanitize consistently with string field behavior unless validation explicitly rejects.
+- [ ] Grid editor uses `<textarea>` or equivalent multi-line control.
+- [ ] Renderer preserves newlines with `white-space: pre-wrap` or equivalent.
+- [ ] Form view and record drawer render/edit long text without collapsing newlines.
+- [ ] Import/export preserves embedded newlines.
+- [ ] OpenAPI field type enum includes `longText`.
+- [ ] Existing `string` field behavior remains unchanged.
+
+### Explicit Non-Goals
+
+- Rich text marks, mentions inside long text, Markdown preview, and per-character Yjs collaboration.
+- Automatic migration of existing string fields into long text.
+- AI summarize/expand actions.
+
+### Minimum Tests
+
+- [ ] Backend codec test for aliases and newline preservation.
+- [ ] Backend import/export test for embedded newlines.
+- [ ] Frontend renderer test for newline display.
+- [ ] Frontend editor test that edit/save preserves multi-line value.
+- [ ] Field manager test for creating a longText field.
+- [ ] OpenAPI parity test if schema output changes.
+
+### Suggested PR
+
+- Branch: `codex/multitable-phase2-long-text-field-20260509`
+- Title: `feat(multitable): add longText field type`
+- Merge order: first among Phase 2 lanes.
+
+## Lane B - Real Email Transport Gate
+
+Owner recommendation: Codex should implement or directly review because this touches credentials, logs, and staging gates.
+
+### Objective
+
+Move `send_email` automation from "default mock channel proves the wire path" toward an env-gated real transport path. The first acceptable slice is a safe transport seam plus readiness gate; the second slice may add actual SMTP delivery if dependency and operations policy are approved.
+
+### Current Fact
+
+`EmailNotificationChannel` currently logs and simulates async delivery. There is no `nodemailer`, SendGrid, SES, Mailgun, or SMTP dependency in the workspace. The RC verified `notificationStatus === 'sent'` through the default mock channel, not actual mailbox receipt.
+
+### File Boundary
+
+Likely backend files:
+
+- `packages/core-backend/src/services/NotificationService.ts`
+- `packages/core-backend/src/multitable/automation-executor.ts`
+- `packages/core-backend/src/multitable/automation-service.ts`
+- `packages/core-backend/src/index.ts` or runtime wiring if channel registration becomes configurable
+- `scripts/ops/**` for readiness and redacted smoke helpers
+- Focused backend tests under `packages/core-backend/tests/**`
+
+Likely frontend files:
+
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+- Optional tests under `apps/web/tests/**` only if UI copy or validation changes.
+
+### Requirements
+
+- [ ] Default local/dev behavior remains mock unless an explicit env enables real email transport.
+- [ ] Missing SMTP/provider env reports `blocked`, not `pass`, in a release gate.
+- [ ] Logs and artifacts redact SMTP host credentials, usernames, passwords, tokens, recipient lists if configured sensitive, and bearer tokens.
+- [ ] Automation logs keep the existing flat logs API contract used by RC smoke.
+- [ ] Failed transport returns a controlled failed step, not a backend crash.
+- [ ] Staging can run a no-send readiness check without sending real email.
+- [ ] Real-send smoke requires an explicit `CONFIRM_SEND_EMAIL=1` style guard.
+
+### Explicit Non-Goals
+
+- Adding a dev-only inspect endpoint that exposes email body history.
+- Printing mailbox credentials or raw recipient lists in docs.
+- Changing DingTalk notification behavior.
+
+### Minimum Tests
+
+- [ ] Unit test: mock channel remains default when env is absent.
+- [ ] Unit test: enabled real transport with missing required env returns readiness `blocked`.
+- [ ] Unit test: transport error becomes failed automation step and execution log persists.
+- [ ] Redaction test: logs/artifacts do not contain SMTP credentials or bearer tokens.
+- [ ] Existing `multitable-rc-automation-send-email-smoke` still passes in mock mode.
+
+### Suggested PR Split
+
+- B1 branch: `codex/multitable-phase2-email-transport-gate-20260509`
+- B1 title: `feat(multitable): add env-gated email transport readiness`
+- B2 branch: `codex/multitable-phase2-email-smtp-transport-20260509`
+- B2 title: `feat(multitable): add SMTP email notification transport`
+
+Do B2 only after B1 lands and dependency choice is agreed.
+
+## Lane C - Grid Bulk Edit
+
+Owner recommendation: Claude can implement; Codex reviews conflict handling and permission behavior.
+
+Status: complete for core scope.
+
+Completed by:
+
+- PR #1451 `feat(multitable): add grid bulk edit action`, merge commit `783695ded05bf7893068efa2aa046dd2e481221a`.
+- PR #1456 `feat(multitable): support partial-success bulk edits`, merge commit `f6c8bd435e7c8d154de06d82f1b852d2d8706e3d`.
+
+### Objective
+
+Turn existing grid selection and backend `patchRecords` capability into a user-facing bulk edit flow: select records, choose a writable field, set or clear a value, then apply one batch write with conflict and partial-failure reporting.
+
+### Current Fact
+
+`MetaGridTable.vue` now has the user-facing bulk set/clear flow. `useMultitableGrid.ts` requests `partialSuccess: true` for bulk edits, applies successful rows, and surfaces row-level failures instead of silently dropping them.
+
+### File Boundary
+
+Likely backend files:
+
+- `packages/core-backend/src/multitable/record-write-service.ts`
+- Existing tests for `patchRecords` and permissions
+
+Likely frontend files:
+
+- `apps/web/src/multitable/components/MetaGridTable.vue`
+- `apps/web/src/multitable/composables/useMultitableGrid.ts`
+- `apps/web/src/multitable/api/client.ts`
+- New or existing focused frontend tests under `apps/web/tests/**`
+
+### Requirements
+
+- [x] Bulk bar offers "Set field" and "Clear field" only when selected records exist.
+- [x] Field picker excludes read-only/system fields and fields the current user cannot write.
+- [x] Value editor reuses field-specific editor behavior where practical.
+- [x] Apply path uses `patchRecords` with expected versions when available.
+- [x] UI reports success count and conflict/failure count.
+- [x] Partial failures do not silently disappear.
+- [x] Existing bulk delete remains unchanged.
+- [x] Default backend patch behavior remains all-or-nothing unless `partialSuccess` is explicitly requested.
+
+### Explicit Non-Goals
+
+- Spreadsheet-like drag fill handle.
+- Multi-field bulk edit in one dialog.
+- Bulk edits across filtered-out records or all pages.
+
+### Minimum Tests
+
+- [x] Frontend test: selected rows open bulk set dialog and submit batch patch.
+- [x] Frontend test: read-only/system fields are absent or disabled.
+- [x] Frontend test: row-level failures are surfaced.
+- [x] Backend route regression: default patch mode remains all-or-nothing.
+- [x] Backend route regression: `partialSuccess: true` reports per-row `VERSION_CONFLICT` while keeping successful rows.
+
+### Suggested PR
+
+- Branch: `codex/multitable-phase2-grid-bulk-edit-20260509`
+- Title: `feat(multitable): add grid bulk edit action`
+- Result: landed through #1451 and #1456.
+- Optional follow-up: replace the compact first-three-failures dialog summary with a richer per-row result table if operators need bulk remediation details.
+
+## Parallelization Plan
+
+Preferred sequence:
+
+1. Phase 0 hygiene.
+2. Lane C core is complete through #1451 and #1456.
+3. Lane A and Lane B1 can run in parallel because their file boundaries are mostly disjoint.
+4. Lane B2 waits for B1 and explicit dependency approval.
+
+Conflict notes:
+
+- Lane A may touch `MetaCellEditor.vue`; avoid reopening Lane C files unless doing explicit UX polish.
+- Lane B must not touch DingTalk files unless a shared notification interface truly requires it.
+- No lane should touch `plugins/plugin-integration-core/*` or K3 PoC scripts.
+
+## Global Verification Commands
+
+Run the relevant subset per PR:
+
+```bash
+git diff --check
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+pnpm --filter @metasheet/core-backend exec vitest run <focused backend tests> --reporter=dot
+pnpm --filter @metasheet/web exec vitest run <focused frontend tests> --watch=false --reporter=dot
+pnpm verify:multitable-openapi:parity
+```
+
+For staging-facing gates:
+
+```bash
+pnpm verify:multitable-rc:staging
+pnpm verify:multitable-rc:ui
+```
+
+Only run real email sends with a dedicated test recipient and an explicit confirmation env.

--- a/docs/development/multitable-feishu-phase2-verification-20260509.md
+++ b/docs/development/multitable-feishu-phase2-verification-20260509.md
@@ -1,0 +1,155 @@
+# Multitable Feishu Phase 2 Planning · Verification
+
+> Date: 2026-05-09
+> Branch: `codex/multitable-feishu-phase2-plan-20260509`
+> Baseline: `origin/main@c74c15a2b`; refreshed against `origin/main@3a484622c`
+> Scope: docs-only verification for the Phase 2 plan
+
+## Baseline Verification
+
+Fetched latest main and confirmed the planning base:
+
+```bash
+git fetch origin main --prune
+git rev-parse origin/main
+```
+
+Result:
+
+```text
+c74c15a2bf31f33acee702389cc80db3358b0789
+```
+
+The root checkout was intentionally not used as the implementation base because it is on a remote-deleted K3 branch and contains unrelated untracked docs.
+
+Before merge, the branch was rebased onto the latest main:
+
+```bash
+git fetch origin main
+git rebase origin/main
+git rev-parse --short origin/main
+```
+
+Result:
+
+```text
+3a484622c
+```
+
+This refresh accounts for post-plan work that landed after the original
+`c74c15a2b` baseline, especially PR #1451 and PR #1456 for Lane C.
+
+## Source Recon
+
+Checked current planning and implementation evidence:
+
+```bash
+rg -n "Long text|longText|send_email|bulk edit|bulk delete|batch|Phase 2|P0|P1" \
+  docs/development/multitable-feishu-gap-analysis-20260426.md \
+  docs/development/multitable-feishu-rc-todo-20260430.md \
+  docs/development/multitable-rc-automation-send-email-smoke-development-20260507.md \
+  docs/development/multitable-record-history-development-20260430.md \
+  docs/development/multitable-record-subscription-development-20260503.md
+```
+
+Key findings:
+
+- `longText` remains a named Feishu parity gap in the original analysis.
+- `send_email` exists now, but the RC smoke proved mock `NotificationService` delivery, not real SMTP/provider delivery.
+- Bulk edit core is no longer an open product gap. PR #1451 added the grid bulk edit action and PR #1456 added partial-success bulk edit handling.
+- The old Phase 2 name in `multitable-feishu-rc-todo-20260430.md` refers to the earlier backend XLSX route phase, not this post-RC Phase 2.
+
+Checked current email implementation:
+
+```bash
+rg -n "EmailNotificationChannel|send_email|SMTP|nodemailer|email" \
+  packages/core-backend/src/services/NotificationService.ts \
+  packages/core-backend/src/multitable/automation-executor.ts \
+  packages/core-backend/src/multitable/automation-actions.ts \
+  packages/core-backend/src/multitable/automation-service.ts \
+  apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+```
+
+Result summary:
+
+- `send_email` is wired in automation actions, service validation, executor, and frontend editor.
+- `EmailNotificationChannel` still simulates async sending.
+- No SMTP/provider dependency was found in `package.json`, package manifests, or `pnpm-lock.yaml`.
+
+Checked bulk-edit surface:
+
+```bash
+rg -n "patchRecords|delete|bulk|selected|selection|batch" \
+  packages/core-backend/src/multitable/record-service.ts \
+  packages/core-backend/src/multitable/record-write-service.ts \
+  packages/core-backend/src/routes/univer-meta.ts \
+  apps/web/src/multitable/components/MetaGridTable.vue \
+  apps/web/src/multitable/composables/useMultitableGrid.ts \
+  apps/web/src/multitable/api/client.ts
+```
+
+Result summary:
+
+- `MetaGridTable.vue` already has selected row state and a bulk delete bar.
+- `useMultitableGrid.ts` and the API client already use `patchRecords`.
+- A user-facing bulk set/clear field action can be added without inventing a new backend write primitive.
+
+## Docs Changed
+
+```text
+docs/development/multitable-feishu-phase2-todo-20260509.md
+docs/development/multitable-feishu-phase2-development-20260509.md
+docs/development/multitable-feishu-phase2-verification-20260509.md
+```
+
+## Hygiene Checks
+
+Whitespace check:
+
+```bash
+git diff --check
+```
+
+Result: pass.
+
+Post-rebase refresh:
+
+```bash
+git diff --check
+```
+
+Result: pass.
+
+Scoped diff check:
+
+```bash
+git diff --stat origin/main...HEAD
+```
+
+Expected result: docs-only additions under `docs/development/`.
+
+## Non-Verification
+
+This PR does not verify product behavior because it is a planning slice. It does not run backend build, frontend type-check, Vitest, Playwright, or staging harnesses.
+
+Future implementation PRs must run focused tests listed in `multitable-feishu-phase2-todo-20260509.md`.
+
+## Risk Review
+
+| Risk | Mitigation in plan |
+|---|---|
+| Accidentally developing on a stale K3 branch | Phase 0 requires clean worktrees from `origin/main`. |
+| Reopening RC scope after sign-off | Plan states RC is closed unless staging regresses. |
+| Email credentials leak in logs/artifacts | Lane B requires redaction tests and file-based secret handling. |
+| Claude over-broad implementation | Lanes include file boundaries, explicit non-goals, and minimum tests. |
+| Bulk edit bypasses permission/history/subscription behavior | Lane C requires using existing `patchRecords` path and regression tests. |
+
+## Result
+
+Phase 2 is ready to continue as bounded lanes:
+
+- Lane A: `longText` field.
+- Lane B: email transport readiness and optional SMTP/provider transport.
+- Lane C: grid bulk edit core is complete through #1451 and #1456; only optional UX polish remains.
+
+The next implementation step should be Lane A or Lane B1 from a clean worktree.


### PR DESCRIPTION
## Summary

Creates the post-RC Multitable Feishu Phase 2 execution plan after `multitable-rc-20260508b-08c6036284` and PR #1446.

Adds three docs:

- `docs/development/multitable-feishu-phase2-todo-20260509.md`
- `docs/development/multitable-feishu-phase2-development-20260509.md`
- `docs/development/multitable-feishu-phase2-verification-20260509.md`

## Planned lanes

- Lane A: native `longText` field.
- Lane B: env-gated real email transport readiness, with SMTP/provider transport split into a later approval-gated slice.
- Lane C: grid bulk edit using existing selection and `patchRecords` plumbing.

## Verification

- `git diff --cached --check` before commit: passed.
- `git diff --check origin/main..HEAD`: passed.
- Source recon used existing RC, Feishu gap, send_email, and bulk grid docs/code to avoid reusing stale pre-RC assumptions.

## Notes

Docs-only. No source code, migrations, OpenAPI dist, package scripts, or runtime behavior changed.
