### PR TITLE
test(multitable): audit-only test coverage for longText field

### DIFF
--- a/apps/web/tests/multitable-field-manager.spec.ts
+++ b/apps/web/tests/multitable-field-manager.spec.ts
@@ -110,6 +110,49 @@ describe('MetaFieldManager', () => {
     app.unmount()
   })
 
+  it('emits longText field creation without requiring an options panel', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const createSpy = vi.fn()
+
+    const app = createApp({
+      render() {
+        return h(MetaFieldManager, {
+          visible: true,
+          sheetId: 'sheet_1',
+          sheets: [],
+          fields: [],
+          onCreateField: createSpy,
+        })
+      },
+    })
+
+    app.mount(container)
+    await nextTick()
+
+    const nameInput = container.querySelector('.meta-field-mgr__add-row .meta-field-mgr__input') as HTMLInputElement
+    const typeSelect = container.querySelector('.meta-field-mgr__add-row .meta-field-mgr__select') as HTMLSelectElement
+    nameInput.value = 'Notes'
+    nameInput.dispatchEvent(new Event('input', { bubbles: true }))
+    typeSelect.value = 'longText'
+    typeSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await nextTick()
+
+    ;(Array.from(container.querySelectorAll('.meta-field-mgr__btn-add')) as HTMLButtonElement[])
+      .find((button) => button.textContent?.includes('+ Add'))
+      ?.click()
+    await nextTick()
+
+    expect(createSpy).toHaveBeenCalledWith({
+      sheetId: 'sheet_1',
+      name: 'Notes',
+      type: 'longText',
+      property: {},
+    })
+
+    app.unmount()
+  })
+
   it('emits attachment field property updates from the config panel', async () => {
     const container = document.createElement('div')
     document.body.appendChild(container)

--- a/docs/development/multitable-phase2-lane-a-audit-development-20260509.md
+++ b/docs/development/multitable-phase2-lane-a-audit-development-20260509.md
@@ -1,0 +1,72 @@
+# Multitable Phase 2 Lane A (`longText`) — Audit · Development
+
+> Date: 2026-05-09
+> Branch: `codex/multitable-phase2-long-text-field-20260509`
+> Base: `origin/main@c74c15a2b`
+> Spec: PR #1448 (`docs(multitable): plan Feishu phase 2 lanes`)
+
+## TL;DR
+
+**Lane A is already shipped.** The `longText` field type was implemented end-to-end before this Phase 2 slice was opened. Every acceptance bullet from the Phase 2 todo MD maps to existing code at `c74c15a2b`. This PR is the audit-only follow-up the user authorized: no production code changes; three test additions to close coverage gaps; this development MD records the discovery so the planning todo MD can be reconciled.
+
+## Discovery
+
+While orienting on the Lane A file boundary listed in `multitable-feishu-phase2-todo-20260509.md`, I direct-grepped the canonical insertion points and found `longText` already wired:
+
+| Acceptance bullet | Location at `c74c15a2b` | Status |
+|---|---|---|
+| Aliases `longText`/`long_text`/`multiline` normalize to `longText` | `packages/core-backend/src/multitable/field-codecs.ts:139–151` (also handles `long-text`, `textarea`, `multi_line_text`) | ✓ done |
+| Stored raw value is a string | `validateLongTextValue` at `field-codecs.ts:502–508` | ✓ done |
+| Grid editor uses `<textarea>` | `apps/web/src/multitable/components/cells/MetaCellEditor.vue:57` | ✓ done |
+| Renderer preserves newlines via `white-space: pre-wrap` | `apps/web/src/multitable/components/cells/MetaCellRenderer.vue:8` (CSS rule `.meta-cell-renderer__long-text` at line 238–241) | ✓ done |
+| Form view + record drawer render/edit long text | `apps/web/src/multitable/components/MetaFormView.vue:41` and `MetaRecordDrawer.vue:85` | ✓ done |
+| OpenAPI field type enum | `packages/openapi/src/base.yml:1673` | ✓ done |
+| Existing `string` behavior unchanged | type union in `field-codecs.ts:4–31` adds `longText` alongside `string`; both retain independent codec paths | ✓ done |
+
+Git log on `field-codecs.ts` shows two prior `feat(multitable): add long text field` commits (`152053cbf`, `f633f3b0f`) that introduced `longText`. The Phase 2 planning MD (PR #1448) was authored without grepping current main.
+
+## Test Coverage Audit
+
+| Acceptance test | File | Pre-audit | Post-audit |
+|---|---|---|---|
+| Backend codec test for aliases | `packages/core-backend/tests/unit/multitable-field-types-batch1.test.ts:75–81` | Covered `longText`, `long_text`, `textarea`, `multi_line_text` (4/6 listed in source) | Now covers `long-text` and `multiline` too (6/6) |
+| Backend codec test for newline preservation | same file, `validateLongTextValue` describe at line 434–447 | Already covered (`'line 1\\n  line 2\\n'` round-trip) | Unchanged |
+| Backend xlsx test for embedded newlines | `packages/core-backend/tests/unit/multitable-xlsx-service.test.ts` | Missing | Added — `serializeXlsxCell` preserves `\n`, `buildXlsxBuffer`/`parseXlsxBuffer` round-trip a multi-line cell |
+| Frontend renderer test for newline display | `apps/web/tests/multitable-longtext-cell.spec.ts` | Already covered (renderer + textarea + Ctrl+Enter) | Unchanged |
+| Frontend editor test for multi-line save | same file | Already covered | Unchanged |
+| Field manager test for creating a `longText` field | `apps/web/tests/multitable-field-manager.spec.ts` | Validation-panel test only (line 520) — no creation-path test | Added — selects `longText` type in picker, clicks `+ Add`, asserts emitted shape |
+| OpenAPI parity | `packages/openapi/tests/**` | n/a — schema unchanged by this audit | n/a |
+
+## What changed in this PR
+
+Only test additions and docs. No source code change.
+
+| File | Change |
+|---|---|
+| `packages/core-backend/tests/unit/multitable-field-types-batch1.test.ts` | Extend `longText` alias test from 4 to 6 aliases (adds `long-text`, `multiline`) |
+| `packages/core-backend/tests/unit/multitable-xlsx-service.test.ts` | Add `round-trips embedded newlines for longText cells` test |
+| `apps/web/tests/multitable-field-manager.spec.ts` | Add `emits longText field creation without requiring an options panel` test |
+| `docs/development/multitable-phase2-lane-a-audit-development-20260509.md` | This file |
+| `docs/development/multitable-phase2-lane-a-audit-verification-20260509.md` | Companion verification record |
+
+## Reconciliation with PR #1448
+
+The planning MD's Lane A acceptance can be reconciled in one of two ways. This PR does NOT modify `multitable-feishu-phase2-todo-20260509.md` (it lives on the as-yet-unmerged #1448 branch). After #1448 lands, the user can either:
+
+- Edit the Phase 2 todo MD on main to mark Lane A `[x] done` with a pointer to commits `152053cbf` / `f633f3b0f` and to this audit PR; or
+- Land this audit PR first and treat its development MD as the canonical Lane A closure record (#1448's todo MD remains as the original spec).
+
+Either path is consistent. This PR is intentionally narrow so it does not block #1448's review.
+
+## K3 PoC Stage 1 Lock applicability
+
+- Does NOT modify `plugins/plugin-integration-core/*`.
+- Test-only + docs change.
+- Does NOT touch DingTalk / public-form / Gantt / Hierarchy / formula / automation runtime.
+
+## Out of scope
+
+- Modifying any Lane A production code (it's already shipped).
+- Lane B / Lane C work — separate PRs.
+- Updating PR #1448's todo MD — handled separately by the user or a follow-up.
+- Rich-text marks, mentions, Markdown preview — explicit non-goals per #1448.

--- a/docs/development/multitable-phase2-lane-a-audit-verification-20260509.md
+++ b/docs/development/multitable-phase2-lane-a-audit-verification-20260509.md
@@ -1,0 +1,90 @@
+# Multitable Phase 2 Lane A (`longText`) — Audit · Verification
+
+> Companion to `multitable-phase2-lane-a-audit-development-20260509.md`
+
+## Backend codec batch1 (alias coverage extended)
+
+```
+$ pnpm --filter @metasheet/core-backend exec vitest run \
+    tests/unit/multitable-field-types-batch1.test.ts --reporter=dot
+
+ ✓ tests/unit/multitable-field-types-batch1.test.ts  (80 tests) 15ms
+
+ Test Files  1 passed (1)
+      Tests  80 passed (80)
+```
+
+Specifically the extended alias test now asserts all six normalization paths:
+
+```
+expect(mapFieldType('longText')).toBe('longText')
+expect(mapFieldType('long_text')).toBe('longText')
+expect(mapFieldType('long-text')).toBe('longText')
+expect(mapFieldType('textarea')).toBe('longText')
+expect(mapFieldType('multi_line_text')).toBe('longText')
+expect(mapFieldType('multiline')).toBe('longText')
+```
+
+## Backend xlsx (newline round-trip added)
+
+```
+$ pnpm --filter @metasheet/core-backend exec vitest run \
+    tests/unit/multitable-xlsx-service.test.ts --reporter=dot
+
+ ✓ tests/unit/multitable-xlsx-service.test.ts  (6 tests) 10ms
+
+ Test Files  1 passed (1)
+      Tests  6 passed (6)
+```
+
+The new test exercises both `serializeXlsxCell` (verbatim multi-line string) and the `buildXlsxBuffer` → `parseXlsxBuffer` round-trip, asserting the multi-line value emerges with `\n` and indentation intact.
+
+## Frontend field-manager (longText creation added)
+
+```
+$ pnpm --filter @metasheet/web exec vitest run \
+    tests/multitable-field-manager.spec.ts --reporter=dot
+
+ ✓ tests/multitable-field-manager.spec.ts  (18 tests) 71ms
+
+ Test Files  1 passed (1)
+      Tests  18 passed (18)
+```
+
+The new creation-path test:
+
+1. Mounts `MetaFieldManager` with empty fields.
+2. Sets the new-field name to `Notes`.
+3. Selects `longText` from the type dropdown (which auto-opens the validation-config panel).
+4. Clicks `+ Add`.
+5. Asserts `create-field` emitted with `{ sheetId: 'sheet_1', name: 'Notes', type: 'longText', property: {} }` — the empty `property` reflects the current MetaFieldManager behavior at `c74c15a2b` for text-typed fields with untouched validation.
+
+## Frontend longtext cell (regression)
+
+```
+$ pnpm --filter @metasheet/web exec vitest run \
+    tests/multitable-longtext-cell.spec.ts --reporter=dot
+
+ ✓ tests/multitable-longtext-cell.spec.ts  (2 tests) 10ms
+```
+
+Pre-existing renderer + editor coverage continues to pass; not modified by this PR.
+
+## Diff hygiene
+
+```
+$ git diff --check origin/main..HEAD
+(no output — clean)
+```
+
+## Pre-deployment checks
+
+- [x] Test-only + docs change. No source modification.
+- [x] No DingTalk / public-form / Gantt / Hierarchy / formula / automation runtime / `plugins/plugin-integration-core/*` files touched.
+- [x] No migration / OpenAPI / route changes.
+- [x] No new dependencies, package scripts, or env vars.
+- [x] All three new tests pass; all touched files keep their pre-PR pass count + the new tests.
+
+## Result
+
+Lane A audit complete. `longText` field type is verified production-ready at `c74c15a2b`; three small test gaps closed. Phase 2 planning MD (PR #1448) Lane A acceptance is satisfied — the next round of Phase 2 work can move directly to Lane C (and Lane B, owned by Codex) without an additional Lane A code-change PR.

--- a/packages/core-backend/tests/unit/multitable-field-types-batch1.test.ts
+++ b/packages/core-backend/tests/unit/multitable-field-types-batch1.test.ts
@@ -75,8 +75,10 @@ describe('mapFieldType — MF2 batch-1', () => {
   it('recognises longText aliases without falling back to string', () => {
     expect(mapFieldType('longText')).toBe('longText')
     expect(mapFieldType('long_text')).toBe('longText')
+    expect(mapFieldType('long-text')).toBe('longText')
     expect(mapFieldType('textarea')).toBe('longText')
     expect(mapFieldType('multi_line_text')).toBe('longText')
+    expect(mapFieldType('multiline')).toBe('longText')
   })
 
   it('recognises location aliases without falling back to string', () => {

--- a/packages/core-backend/tests/unit/multitable-xlsx-service.test.ts
+++ b/packages/core-backend/tests/unit/multitable-xlsx-service.test.ts
@@ -78,4 +78,19 @@ describe('multitable xlsx service', () => {
     expect(serializeXlsxCell({ id: 'att_1', filename: 'a.pdf' })).toBe('{"id":"att_1","filename":"a.pdf"}')
     expect(serializeXlsxCell(null)).toBe('')
   })
+
+  test('round-trips embedded newlines for longText cells', () => {
+    const multiline = 'first line\nsecond line\n  indented third line'
+
+    expect(serializeXlsxCell(multiline)).toBe(multiline)
+
+    const buffer = buildXlsxBuffer(xlsx, {
+      sheetName: 'Notes',
+      headers: ['Notes'],
+      rows: [[multiline]],
+    })
+
+    const parsed = parseXlsxBuffer(xlsx, buffer)
+    expect(parsed.rows).toEqual([[multiline]])
+  })
 })


### PR DESCRIPTION
## Summary
- Lane A from PR #1448 (Phase 2 plan) is **already shipped end-to-end at `c74c15a2b`** — every acceptance bullet maps to existing code (`field-codecs.ts`, `MetaCellEditor`, `MetaCellRenderer` with `white-space: pre-wrap`, `MetaFormView`, `MetaRecordDrawer`, OpenAPI enum, dedicated `multitable-longtext-cell.spec.ts`). The development MD inside this PR has the per-bullet file:line cross-reference and git-log proof of the prior \`feat(multitable): add long text field\` commits (`152053cbf`, `f633f3b0f`).
- This PR is the **audit-only** follow-up the user authorized after the discovery: no production code change; three small test additions to close coverage gaps.

## Test additions
- `packages/core-backend/tests/unit/multitable-field-types-batch1.test.ts` — extend the `longText` alias test from 4 → 6 aliases (now also asserts `long-text` and `multiline`, both already present in the source mapping).
- `packages/core-backend/tests/unit/multitable-xlsx-service.test.ts` — new test verifying `serializeXlsxCell` preserves embedded newlines and `buildXlsxBuffer`/`parseXlsxBuffer` round-trip a multi-line cell unchanged.
- `apps/web/tests/multitable-field-manager.spec.ts` — new creation-path test asserting that selecting `longText` in the type picker and clicking `+ Add` emits `create-field` with `{ sheetId, name, type: 'longText', property: {} }`.

## Reconciliation with #1448
This PR does NOT modify `multitable-feishu-phase2-todo-20260509.md` (it lives on the still-open #1448 branch). After #1448 lands, you can mark Lane A `[x]` with a pointer to commits `152053cbf` / `f633f3b0f` and to this audit PR — or just treat this PR's development MD as the canonical Lane A closure record. Either path is consistent. Lane C work continues separately in `codex/multitable-phase2-grid-bulk-edit-20260509`.

## K3 PoC Stage 1 Lock
- Does NOT modify \`plugins/plugin-integration-core/*\`.
- Test-only + docs change.
- Does NOT touch DingTalk / public-form / Gantt / Hierarchy / formula / automation runtime.

## Test plan
- [x] `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/multitable-field-types-batch1.test.ts` → 80/80 pass.
- [x] `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/multitable-xlsx-service.test.ts` → 6/6 pass (5 → 6).
- [x] `pnpm --filter @metasheet/web exec vitest run tests/multitable-field-manager.spec.ts` → 18/18 pass (17 → 18).
- [x] `pnpm --filter @metasheet/web exec vitest run tests/multitable-longtext-cell.spec.ts` → 2/2 pass (regression check).
- [x] `git diff --check origin/main..HEAD` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)