### PR TITLE
feat(multitable): add grid bulk edit action

### DIFF
--- a/apps/web/src/multitable/components/MetaBulkEditDialog.vue
+++ b/apps/web/src/multitable/components/MetaBulkEditDialog.vue
@@ -31,11 +31,17 @@
           <div v-if="mode === 'set' && selectedField" class="meta-bulk-edit__row">
             <span class="meta-bulk-edit__label">Value</span>
             <div class="meta-bulk-edit__value-wrap">
+              <!--
+                Intentionally NOT wiring @confirm to onApply: MetaCellEditor
+                fires `confirm` on select/boolean `@change` (cells/MetaCellEditor.vue:113,124),
+                which would silently submit the bulk patch the moment the
+                user opens the select dropdown or toggles a checkbox. Bulk
+                edit must require an explicit "Set value" click.
+              -->
               <MetaCellEditor
                 :field="selectedField"
                 :model-value="value"
                 @update:modelValue="value = $event"
-                @confirm="onApply"
                 @cancel="onCancel"
               />
             </div>

--- a/apps/web/src/multitable/components/MetaBulkEditDialog.vue
+++ b/apps/web/src/multitable/components/MetaBulkEditDialog.vue
@@ -1,0 +1,177 @@
+<template>
+  <Teleport to="body">
+    <div v-if="visible" class="meta-bulk-edit-overlay" @click.self="onCancel">
+      <div class="meta-bulk-edit-modal" role="dialog" :aria-label="title">
+        <div class="meta-bulk-edit__header">
+          <strong>{{ title }}</strong>
+          <button class="meta-bulk-edit__close" aria-label="Close" @click="onCancel">&times;</button>
+        </div>
+
+        <div class="meta-bulk-edit__body">
+          <p class="meta-bulk-edit__hint">{{ summary }}</p>
+
+          <label class="meta-bulk-edit__row">
+            <span class="meta-bulk-edit__label">Field</span>
+            <select
+              v-model="selectedFieldId"
+              class="meta-bulk-edit__select"
+              aria-label="Field to update"
+              @change="onFieldChange"
+            >
+              <option value="">(choose a field)</option>
+              <option v-for="field in eligibleFields" :key="field.id" :value="field.id">
+                {{ field.name }}
+              </option>
+            </select>
+          </label>
+          <p v-if="!eligibleFields.length" class="meta-bulk-edit__hint meta-bulk-edit__hint--muted">
+            No bulk-editable fields are available for the current selection.
+          </p>
+
+          <div v-if="mode === 'set' && selectedField" class="meta-bulk-edit__row">
+            <span class="meta-bulk-edit__label">Value</span>
+            <div class="meta-bulk-edit__value-wrap">
+              <MetaCellEditor
+                :field="selectedField"
+                :model-value="value"
+                @update:modelValue="value = $event"
+                @confirm="onApply"
+                @cancel="onCancel"
+              />
+            </div>
+          </div>
+          <div v-else-if="mode === 'clear' && selectedField" class="meta-bulk-edit__row">
+            <span class="meta-bulk-edit__label">Action</span>
+            <span class="meta-bulk-edit__hint">
+              Will clear <strong>{{ selectedField.name }}</strong> on {{ recordIds.length }} record(s).
+            </span>
+          </div>
+
+          <div v-if="error" class="meta-bulk-edit__error" role="alert">{{ error }}</div>
+          <div v-if="resultMessage" class="meta-bulk-edit__success" role="status">{{ resultMessage }}</div>
+        </div>
+
+        <div class="meta-bulk-edit__actions">
+          <button class="meta-bulk-edit__btn" :disabled="busy" @click="onCancel">Cancel</button>
+          <button
+            class="meta-bulk-edit__btn meta-bulk-edit__btn--primary"
+            :disabled="!canSubmit || busy"
+            @click="onApply"
+          >
+            {{ submitLabel }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import type { MetaField } from '../types'
+import { isFieldBulkEditable } from '../utils/field-permissions'
+import MetaCellEditor from './cells/MetaCellEditor.vue'
+
+const props = defineProps<{
+  visible: boolean
+  mode: 'set' | 'clear'
+  fields: MetaField[]
+  canEdit: boolean
+  fieldPermissions?: Record<string, { readOnly?: boolean }>
+  recordIds: string[]
+  busy?: boolean
+  error?: string | null
+  resultMessage?: string | null
+}>()
+
+const emit = defineEmits<{
+  (e: 'apply', payload: { mode: 'set' | 'clear'; fieldId: string; value: unknown; recordIds: string[] }): void
+  (e: 'cancel'): void
+}>()
+
+const selectedFieldId = ref<string>('')
+const value = ref<unknown>('')
+
+const eligibleFields = computed(() =>
+  props.fields.filter((field) =>
+    isFieldBulkEditable({
+      field,
+      canEdit: props.canEdit,
+      fieldPermission: props.fieldPermissions?.[field.id],
+    }),
+  ),
+)
+
+const selectedField = computed<MetaField | null>(
+  () => eligibleFields.value.find((f) => f.id === selectedFieldId.value) ?? null,
+)
+
+const title = computed(() => (props.mode === 'clear' ? 'Clear field for selected records' : 'Set field for selected records'))
+const summary = computed(() =>
+  props.mode === 'clear'
+    ? `Pick a field to clear on ${props.recordIds.length} selected record(s).`
+    : `Pick a field and a value to set on ${props.recordIds.length} selected record(s).`,
+)
+const submitLabel = computed(() => (props.mode === 'clear' ? 'Clear' : 'Set value'))
+const canSubmit = computed(() => Boolean(selectedField.value) && (props.mode === 'clear' || hasMeaningfulValue(value.value)))
+
+watch(
+  () => [props.visible, props.mode],
+  ([visible]) => {
+    if (visible) {
+      selectedFieldId.value = ''
+      value.value = ''
+    }
+  },
+  { immediate: true },
+)
+
+function hasMeaningfulValue(input: unknown): boolean {
+  if (input === null || input === undefined) return false
+  if (typeof input === 'string') return input.length > 0
+  if (Array.isArray(input)) return input.length > 0
+  return true
+}
+
+function onFieldChange() {
+  value.value = ''
+}
+
+function onApply() {
+  if (!selectedField.value) return
+  if (props.mode === 'set' && !hasMeaningfulValue(value.value)) return
+  emit('apply', {
+    mode: props.mode,
+    fieldId: selectedField.value.id,
+    value: props.mode === 'clear' ? null : value.value,
+    recordIds: [...props.recordIds],
+  })
+}
+
+function onCancel() {
+  emit('cancel')
+}
+</script>
+
+<style scoped>
+.meta-bulk-edit-overlay { position: fixed; inset: 0; z-index: 110; background: rgba(0,0,0,.3); display: flex; align-items: center; justify-content: center; }
+.meta-bulk-edit-modal { background: #fff; border-radius: 6px; min-width: 420px; max-width: 540px; box-shadow: 0 10px 40px rgba(0,0,0,.18); display: flex; flex-direction: column; }
+.meta-bulk-edit__header { display: flex; align-items: center; justify-content: space-between; padding: 12px 16px; border-bottom: 1px solid #ebedf0; }
+.meta-bulk-edit__close { background: transparent; border: none; font-size: 22px; line-height: 1; cursor: pointer; color: #909399; }
+.meta-bulk-edit__close:hover { color: #303133; }
+.meta-bulk-edit__body { padding: 16px; display: flex; flex-direction: column; gap: 12px; }
+.meta-bulk-edit__hint { color: #606266; font-size: 13px; margin: 0; }
+.meta-bulk-edit__hint--muted { color: #909399; font-style: italic; }
+.meta-bulk-edit__row { display: flex; flex-direction: column; gap: 4px; }
+.meta-bulk-edit__label { font-size: 12px; color: #909399; }
+.meta-bulk-edit__select { padding: 6px 8px; border: 1px solid #dcdfe6; border-radius: 4px; font-size: 14px; }
+.meta-bulk-edit__value-wrap { border: 1px solid #dcdfe6; border-radius: 4px; padding: 4px; min-height: 36px; }
+.meta-bulk-edit__error { color: #f56c6c; background: #fef0f0; padding: 8px 10px; border-radius: 4px; font-size: 13px; }
+.meta-bulk-edit__success { color: #67c23a; background: #f0f9eb; padding: 8px 10px; border-radius: 4px; font-size: 13px; }
+.meta-bulk-edit__actions { display: flex; justify-content: flex-end; gap: 8px; padding: 12px 16px; border-top: 1px solid #ebedf0; }
+.meta-bulk-edit__btn { background: #fff; border: 1px solid #dcdfe6; padding: 6px 14px; border-radius: 4px; cursor: pointer; font-size: 14px; }
+.meta-bulk-edit__btn:hover:not(:disabled) { border-color: #c0c4cc; }
+.meta-bulk-edit__btn:disabled { opacity: .55; cursor: not-allowed; }
+.meta-bulk-edit__btn--primary { background: #409eff; color: #fff; border-color: #409eff; }
+.meta-bulk-edit__btn--primary:hover:not(:disabled) { background: #66b1ff; border-color: #66b1ff; }
+</style>

--- a/apps/web/src/multitable/components/MetaGridTable.vue
+++ b/apps/web/src/multitable/components/MetaGridTable.vue
@@ -49,7 +49,7 @@
                 @click="emit('select-record', row.id)"
               >
                 <td v-if="enableMultiSelect" class="meta-grid__check-col" @click.stop>
-                  <input type="checkbox" :checked="selectedIds.has(row.id)" :disabled="!resolveRowActions(row.id).canDelete" @change="toggleSelectRow(row.id)" />
+                  <input type="checkbox" :checked="selectedIds.has(row.id)" :disabled="!rowAllowsAnyBulkAction(row.id)" @change="toggleSelectRow(row.id)" />
                 </td>
                 <td class="meta-grid__row-num">
                   <span>{{ startIndex + flatIndex(group, ri) + 1 }}</span>
@@ -128,7 +128,7 @@
               @click="emit('select-record', row.id)"
             >
               <td v-if="enableMultiSelect" class="meta-grid__check-col" @click.stop>
-                <input type="checkbox" :checked="selectedIds.has(row.id)" :disabled="!resolveRowActions(row.id).canDelete" @change="toggleSelectRow(row.id)" />
+                <input type="checkbox" :checked="selectedIds.has(row.id)" :disabled="!rowAllowsAnyBulkAction(row.id)" @change="toggleSelectRow(row.id)" />
               </td>
               <td class="meta-grid__row-num">
                 <button class="meta-grid__expand-btn" :class="{ 'meta-grid__expand-btn--open': expandedRowIds.has(row.id) }" :aria-label="expandedRowIds.has(row.id) ? 'Collapse row' : 'Expand row'" @click.stop="toggleRowExpand(row.id)">&#x25B6;</button>
@@ -344,9 +344,14 @@ function toggleRowExpand(rowId: string) {
   expandedRowIds.value = s
 }
 
+function rowAllowsAnyBulkAction(recordId: string): boolean {
+  const actions = resolveRowActions(recordId)
+  return actions.canEdit === true || actions.canDelete === true
+}
+
 const selectableRowIds = computed(() =>
   filteredRows.value
-    .filter((row) => resolveRowActions(row.id).canDelete)
+    .filter((row) => rowAllowsAnyBulkAction(row.id))
     .map((row) => row.id),
 )
 const allSelected = computed(() =>
@@ -404,7 +409,7 @@ function toggleSelectAll() {
 }
 
 function toggleSelectRow(recordId: string) {
-  if (!resolveRowActions(recordId).canDelete) return
+  if (!rowAllowsAnyBulkAction(recordId)) return
   const s = new Set(selectedIds.value)
   if (s.has(recordId)) s.delete(recordId)
   else s.add(recordId)
@@ -412,12 +417,20 @@ function toggleSelectRow(recordId: string) {
   emit('selection-change', [...s])
 }
 
+// Bulk actions filter the selection to rows that actually permit the
+// requested action — so canEdit-only users selecting from a mixed grid
+// can still bulk-edit, and canDelete-only buttons silently skip
+// edit-only rows. This matches the per-action gating pattern in
+// MultitableWorkbench.onBulkDelete which calls ensureCanDeleteRecord
+// per row before issuing deletes.
 function onBulkDelete() {
-  if (selectedIds.value.size > 0) emit('bulk-delete', [...selectedIds.value])
+  const deletable = [...selectedIds.value].filter((id) => resolveRowActions(id).canDelete)
+  if (deletable.length > 0) emit('bulk-delete', deletable)
 }
 
 function onBulkEdit(mode: 'set' | 'clear') {
-  if (selectedIds.value.size > 0) emit('bulk-edit', { mode, recordIds: [...selectedIds.value] })
+  const editable = [...selectedIds.value].filter((id) => resolveRowActions(id).canEdit)
+  if (editable.length > 0) emit('bulk-edit', { mode, recordIds: editable })
 }
 
 watch(() => props.rows, () => { selectedIds.value = new Set() })

--- a/apps/web/src/multitable/components/MetaGridTable.vue
+++ b/apps/web/src/multitable/components/MetaGridTable.vue
@@ -2,6 +2,8 @@
   <div class="meta-grid" :class="[rowDensity ? `meta-grid--${rowDensity}` : '']" tabindex="0" role="grid" aria-label="Data grid" @keydown="onKeydown">
     <div v-if="enableMultiSelect && selectedIds.size > 0" class="meta-grid__bulk-bar">
       <span class="meta-grid__bulk-count">{{ selectedIds.size }} selected</span>
+      <button v-if="canBulkEdit" class="meta-grid__bulk-btn" aria-label="Set field on selected records" @click="onBulkEdit('set')">Set field</button>
+      <button v-if="canBulkEdit" class="meta-grid__bulk-btn" aria-label="Clear field on selected records" @click="onBulkEdit('clear')">Clear field</button>
       <button v-if="canDelete" class="meta-grid__bulk-btn meta-grid__bulk-btn--danger" aria-label="Delete selected records" @click="onBulkDelete">Delete selected</button>
       <button class="meta-grid__bulk-btn" aria-label="Clear selection" @click="selectedIds = new Set(); emit('selection-change', [])">Clear</button>
     </div>
@@ -284,6 +286,7 @@ const props = defineProps<{
   selectedRecordId?: string | null
   canEdit: boolean
   canDelete?: boolean
+  canBulkEdit?: boolean
   rowActionOverrides?: Record<string, MetaRowActions>
   fieldReadOnlyIds?: string[]
   columnWidths?: Record<string, number>
@@ -311,6 +314,7 @@ const emit = defineEmits<{
   (e: 'resize-column', fieldId: string, width: number): void
   (e: 'selection-change', recordIds: string[]): void
   (e: 'bulk-delete', recordIds: string[]): void
+  (e: 'bulk-edit', payload: { mode: 'set' | 'clear'; recordIds: string[] }): void
   (e: 'reorder-field', fromFieldId: string, toFieldId: string): void
 }>()
 
@@ -410,6 +414,10 @@ function toggleSelectRow(recordId: string) {
 
 function onBulkDelete() {
   if (selectedIds.value.size > 0) emit('bulk-delete', [...selectedIds.value])
+}
+
+function onBulkEdit(mode: 'set' | 'clear') {
+  if (selectedIds.value.size > 0) emit('bulk-edit', { mode, recordIds: [...selectedIds.value] })
 }
 
 watch(() => props.rows, () => { selectedIds.value = new Set() })

--- a/apps/web/src/multitable/composables/useMultitableGrid.ts
+++ b/apps/web/src/multitable/composables/useMultitableGrid.ts
@@ -592,6 +592,36 @@ export function useMultitableGrid(opts: {
     }
   }
 
+  async function bulkPatch(args: {
+    fieldId: string
+    value: unknown
+    recordIds: string[]
+  }): Promise<{ updated: string[]; failed: Array<{ recordId: string; reason: string }> }> {
+    const changes = args.recordIds
+      .map((recordId) => {
+        const row = rows.value.find((r) => r.id === recordId)
+        if (!row) return null
+        return {
+          recordId,
+          fieldId: args.fieldId,
+          value: args.value,
+          expectedVersion: row.version,
+        }
+      })
+      .filter((change): change is { recordId: string; fieldId: string; value: unknown; expectedVersion: number } => change !== null)
+
+    if (changes.length === 0) return { updated: [], failed: [] }
+
+    const result = await client.patchRecords({
+      sheetId: opts.sheetId.value || undefined,
+      viewId: opts.viewId.value || undefined,
+      changes,
+    })
+    applyPatchResult(result)
+    const updated = (result.updated ?? []).map((u) => u.recordId)
+    return { updated, failed: [] }
+  }
+
   function applyPatchResult(result?: PatchResult) {
     if (!result) return
     for (const update of result.updated ?? []) {
@@ -806,7 +836,7 @@ export function useMultitableGrid(opts: {
     addSortRule, removeSortRule,
     addFilterRule, updateFilterRule, removeFilterRule, clearFilters,
     applySortFilter,
-    createRecord, deleteRecord, patchCell,
+    createRecord, deleteRecord, patchCell, bulkPatch,
     mergeRemoteRecord, applyRemoteRecordPatch, removeRemoteRecord,
     undo, redo, clearEditHistory, dismissConflict, retryConflict,
     setColumnWidth, setGroupField,

--- a/apps/web/src/multitable/utils/field-permissions.ts
+++ b/apps/web/src/multitable/utils/field-permissions.ts
@@ -1,4 +1,5 @@
 import type { MetaField } from '../types'
+import { isSystemField } from './system-fields'
 
 export function isPropertyHiddenField(field: Pick<MetaField, 'property'>): boolean {
   return field.property?.hidden === true || field.property?.visible === false
@@ -6,4 +7,27 @@ export function isPropertyHiddenField(field: Pick<MetaField, 'property'>): boole
 
 export function filterPropertyVisibleFields<T extends Pick<MetaField, 'property'>>(fields: T[]): T[] {
   return fields.filter((field) => !isPropertyHiddenField(field))
+}
+
+const NON_BULK_EDITABLE_TYPES = new Set<string>([
+  'formula',
+  'lookup',
+  'rollup',
+  'attachment',
+  'link',
+])
+
+export function isFieldBulkEditable(args: {
+  field: MetaField
+  canEdit: boolean
+  fieldPermission?: { readOnly?: boolean }
+}): boolean {
+  if (!args.canEdit) return false
+  if (args.fieldPermission?.readOnly === true) return false
+  if (isSystemField(args.field)) return false
+  const property = args.field.property as Record<string, unknown> | undefined
+  if (property?.readonly === true || property?.readOnly === true) return false
+  if (NON_BULK_EDITABLE_TYPES.has(args.field.type)) return false
+  if (isPropertyHiddenField(args.field)) return false
+  return true
 }

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -224,6 +224,12 @@
           @reparent-record="onHierarchyReparentRecord"
           @update-view-config="onPersistActiveViewConfig"
         />
+        <!--
+          MetaGridTable: enable-multi-select must be canDelete OR canEdit so
+          canEdit-only users (no delete permission) can still select rows
+          for bulk edit. Gating selection solely on delete-capability
+          locks them out. See PR #1451 review.
+        -->
         <MetaGridTable
           v-else
           :rows="grid.rows.value" :visible-fields="scopedGridFields" :sort-rules="grid.sortRules.value"
@@ -232,7 +238,7 @@
           :can-delete="gridAllowsAnyDelete" :can-bulk-edit="effectiveRowActions.canEdit" :field-read-only-ids="readOnlyFieldIds" :column-widths="grid.columnWidths.value"
           :row-action-overrides="grid.rowActionOverrides.value"
           :link-summaries="grid.linkSummaries.value" :attachment-summaries="grid.attachmentSummaries.value"
-          :enable-multi-select="gridAllowsAnyDelete"
+          :enable-multi-select="gridAllowsAnyDelete || effectiveRowActions.canEdit"
           :group-field="grid.groupField.value"
           :search-text="searchText" :row-density="rowDensity"
           :upload-fn="uploadAttachmentFn"

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -229,7 +229,7 @@
           :rows="grid.rows.value" :visible-fields="scopedGridFields" :sort-rules="grid.sortRules.value"
           :loading="grid.loading.value" :current-page="grid.currentPage.value" :total-pages="grid.totalPages.value"
           :start-index="pageStartIndex" :selected-record-id="selectedRecordId" :can-edit="effectiveRowActions.canEdit"
-          :can-delete="gridAllowsAnyDelete" :field-read-only-ids="readOnlyFieldIds" :column-widths="grid.columnWidths.value"
+          :can-delete="gridAllowsAnyDelete" :can-bulk-edit="effectiveRowActions.canEdit" :field-read-only-ids="readOnlyFieldIds" :column-widths="grid.columnWidths.value"
           :row-action-overrides="grid.rowActionOverrides.value"
           :link-summaries="grid.linkSummaries.value" :attachment-summaries="grid.attachmentSummaries.value"
           :enable-multi-select="gridAllowsAnyDelete"
@@ -242,7 +242,7 @@
           :conditional-formatting="conditionalFormattingByRecord"
           @select-record="onSelectRecord" @toggle-sort="onToggleSort" @patch-cell="onPatchCell"
           @go-to-page="grid.goToPage" @open-link-picker="onGridLinkPicker" @resize-column="grid.setColumnWidth"
-          @bulk-delete="onBulkDelete" @reorder-field="onReorderField"
+          @bulk-delete="onBulkDelete" @bulk-edit="onBulkEditRequest" @reorder-field="onReorderField"
           @open-comments="onOpenRecordComments"
           @open-field-comments="onOpenGridFieldComments"
         />
@@ -301,6 +301,19 @@
         </div>
       </div>
     </div>
+    <MetaBulkEditDialog
+      :visible="bulkEditDialog.visible"
+      :mode="bulkEditDialog.mode"
+      :fields="scopedAllFields"
+      :can-edit="effectiveRowActions.canEdit"
+      :field-permissions="effectiveFieldPermissions"
+      :record-ids="bulkEditDialog.recordIds"
+      :busy="bulkEditDialog.busy"
+      :error="bulkEditDialog.error"
+      :result-message="bulkEditDialog.resultMessage"
+      @apply="onBulkEditApply"
+      @cancel="onBulkEditCancel"
+    />
     <MetaImportModal
       :visible="showImportModal"
       :sheet-id="workbench.activeSheetId.value"
@@ -368,7 +381,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, nextTick, onMounted, onBeforeUnmount, watch } from 'vue'
+import { ref, reactive, computed, nextTick, onMounted, onBeforeUnmount, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuth } from '../../composables/useAuth'
 import type {
@@ -426,6 +439,7 @@ import MetaGanttView from '../components/MetaGanttView.vue'
 import MetaHierarchyView from '../components/MetaHierarchyView.vue'
 import MetaToast from '../components/MetaToast.vue'
 import MetaImportModal from '../components/MetaImportModal.vue'
+import MetaBulkEditDialog from '../components/MetaBulkEditDialog.vue'
 import MetaMentionPopover from '../components/MetaMentionPopover.vue'
 import MetaDashboardView from '../components/MetaDashboardView.vue'
 import type { MetaBase } from '../types'
@@ -2402,6 +2416,67 @@ async function onBulkDelete(recordIds: string[]) {
     if (selectedRecordId.value && recordIds.includes(selectedRecordId.value)) selectedRecordId.value = null
     showSuccess(`${recordIds.length} record(s) deleted`)
   } catch (e: any) { showError(e.message ?? 'Bulk delete failed') }
+}
+
+const bulkEditDialog = reactive<{
+  visible: boolean
+  mode: 'set' | 'clear'
+  recordIds: string[]
+  busy: boolean
+  error: string | null
+  resultMessage: string | null
+}>({ visible: false, mode: 'set', recordIds: [], busy: false, error: null, resultMessage: null })
+
+function onBulkEditRequest(payload: { mode: 'set' | 'clear'; recordIds: string[] }) {
+  if (!effectiveRowActions.value.canEdit) return
+  bulkEditDialog.visible = true
+  bulkEditDialog.mode = payload.mode
+  bulkEditDialog.recordIds = payload.recordIds
+  bulkEditDialog.busy = false
+  bulkEditDialog.error = null
+  bulkEditDialog.resultMessage = null
+}
+
+function onBulkEditCancel() {
+  bulkEditDialog.visible = false
+  bulkEditDialog.busy = false
+  bulkEditDialog.error = null
+  bulkEditDialog.resultMessage = null
+}
+
+async function onBulkEditApply(payload: { mode: 'set' | 'clear'; fieldId: string; value: unknown; recordIds: string[] }) {
+  bulkEditDialog.busy = true
+  bulkEditDialog.error = null
+  bulkEditDialog.resultMessage = null
+  try {
+    const result = await grid.bulkPatch({
+      fieldId: payload.fieldId,
+      value: payload.mode === 'clear' ? null : payload.value,
+      recordIds: payload.recordIds,
+    })
+    const updatedCount = result.updated.length
+    const requestedCount = payload.recordIds.length
+    if (result.failed.length > 0) {
+      bulkEditDialog.error = `${result.failed.length} of ${requestedCount} record(s) failed`
+    } else if (updatedCount < requestedCount) {
+      bulkEditDialog.resultMessage = `${updatedCount} of ${requestedCount} record(s) updated`
+    } else {
+      bulkEditDialog.resultMessage = `${updatedCount} record(s) ${payload.mode === 'clear' ? 'cleared' : 'updated'}`
+    }
+    if (updatedCount > 0 && bulkEditDialog.resultMessage) showSuccess(bulkEditDialog.resultMessage)
+    if (result.failed.length === 0 && updatedCount === requestedCount) {
+      bulkEditDialog.visible = false
+    }
+  } catch (e: any) {
+    const message = e?.message ?? 'Bulk edit failed'
+    const errorMessage = e?.code === 'VERSION_CONFLICT'
+      ? `Some records were modified elsewhere. Reload and retry. (${message})`
+      : message
+    bulkEditDialog.error = errorMessage
+    showError(errorMessage)
+  } finally {
+    bulkEditDialog.busy = false
+  }
 }
 
 // --- Deep-link record fetch (when record not in current page) ---

--- a/apps/web/tests/multitable-bulk-edit-dialog.spec.ts
+++ b/apps/web/tests/multitable-bulk-edit-dialog.spec.ts
@@ -7,7 +7,7 @@ const baseFields: MetaField[] = [
   { id: 'fld_name', name: 'Name', type: 'string', property: {} },
   { id: 'fld_notes', name: 'Notes', type: 'longText', property: {} },
   { id: 'fld_amount', name: 'Amount', type: 'number', property: {} },
-  { id: 'fld_status', name: 'Status', type: 'select', property: { options: [{ value: 'Open' }] } },
+  { id: 'fld_status', name: 'Status', type: 'select', options: [{ value: 'Open' }, { value: 'Closed' }], property: {} },
   { id: 'fld_link', name: 'Linked', type: 'link', property: {} },
   { id: 'fld_attach', name: 'Files', type: 'attachment', property: {} },
   { id: 'fld_formula', name: 'Calc', type: 'formula', property: {} },
@@ -221,6 +221,66 @@ describe('MetaBulkEditDialog', () => {
 
     const submit = Array.from(root.querySelectorAll('.meta-bulk-edit__btn--primary'))[0] as HTMLButtonElement
     expect(submit.disabled).toBe(true)
+    app.unmount()
+  })
+
+  it('does NOT auto-submit when a select-typed editor fires its native change (regression: Codex review on PR #1451)', async () => {
+    // MetaCellEditor emits `confirm` on select/boolean `@change` for ergonomic
+    // single-cell edits. The bulk dialog must NOT bind that to onApply, or
+    // opening the dropdown would silently bulk-patch every selected record
+    // without the explicit "Set value" click.
+    const onApply = vi.fn()
+    const { app, root } = mountDialog({ mode: 'set', onApply })
+    await nextTick()
+
+    const fieldSelect = root.querySelector('.meta-bulk-edit__select') as HTMLSelectElement
+    fieldSelect.value = 'fld_status'
+    fieldSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await nextTick()
+
+    const valueSelect = root.querySelector('.meta-bulk-edit__value-wrap select') as HTMLSelectElement | null
+    expect(valueSelect).not.toBeNull()
+    valueSelect!.value = 'Open'
+    valueSelect!.dispatchEvent(new Event('change', { bubbles: true }))
+    await nextTick()
+
+    expect(onApply).not.toHaveBeenCalled()
+
+    const submit = Array.from(root.querySelectorAll('.meta-bulk-edit__btn--primary'))[0] as HTMLButtonElement
+    submit.click()
+    await nextTick()
+
+    expect(onApply).toHaveBeenCalledTimes(1)
+    expect(onApply).toHaveBeenCalledWith({
+      mode: 'set',
+      fieldId: 'fld_status',
+      value: 'Open',
+      recordIds: ['rec_1', 'rec_2', 'rec_3'],
+    })
+    app.unmount()
+  })
+
+  it('does NOT auto-submit when a boolean editor fires its native change', async () => {
+    const onApply = vi.fn()
+    const { app, root } = mountDialog({
+      mode: 'set',
+      fields: [{ id: 'fld_done', name: 'Done', type: 'boolean', property: {} }],
+      onApply,
+    })
+    await nextTick()
+
+    const fieldSelect = root.querySelector('.meta-bulk-edit__select') as HTMLSelectElement
+    fieldSelect.value = 'fld_done'
+    fieldSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await nextTick()
+
+    const checkbox = root.querySelector('.meta-bulk-edit__value-wrap input[type=checkbox]') as HTMLInputElement | null
+    expect(checkbox).not.toBeNull()
+    checkbox!.checked = true
+    checkbox!.dispatchEvent(new Event('change', { bubbles: true }))
+    await nextTick()
+
+    expect(onApply).not.toHaveBeenCalled()
     app.unmount()
   })
 

--- a/apps/web/tests/multitable-bulk-edit-dialog.spec.ts
+++ b/apps/web/tests/multitable-bulk-edit-dialog.spec.ts
@@ -1,0 +1,239 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick } from 'vue'
+import MetaBulkEditDialog from '../src/multitable/components/MetaBulkEditDialog.vue'
+import type { MetaField } from '../src/multitable/types'
+
+const baseFields: MetaField[] = [
+  { id: 'fld_name', name: 'Name', type: 'string', property: {} },
+  { id: 'fld_notes', name: 'Notes', type: 'longText', property: {} },
+  { id: 'fld_amount', name: 'Amount', type: 'number', property: {} },
+  { id: 'fld_status', name: 'Status', type: 'select', property: { options: [{ value: 'Open' }] } },
+  { id: 'fld_link', name: 'Linked', type: 'link', property: {} },
+  { id: 'fld_attach', name: 'Files', type: 'attachment', property: {} },
+  { id: 'fld_formula', name: 'Calc', type: 'formula', property: {} },
+  { id: 'fld_lookup', name: 'Lookup', type: 'lookup', property: {} },
+  { id: 'fld_rollup', name: 'Rollup', type: 'rollup', property: {} },
+  { id: 'fld_locked', name: 'Locked', type: 'string', property: { readonly: true } },
+  { id: 'fld_hidden', name: 'Hidden', type: 'string', property: { hidden: true } },
+  { id: 'fld_auto', name: 'AutoNum', type: 'autoNumber', property: {} },
+  { id: 'fld_created', name: 'Created', type: 'createdTime', property: {} },
+]
+
+function mountDialog(propsOverride: Partial<{
+  mode: 'set' | 'clear'
+  visible: boolean
+  fields: MetaField[]
+  canEdit: boolean
+  fieldPermissions: Record<string, { readOnly?: boolean }>
+  recordIds: string[]
+  busy: boolean
+  error: string | null
+  resultMessage: string | null
+  onApply: (...args: unknown[]) => unknown
+  onCancel: (...args: unknown[]) => unknown
+}> = {}) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const props = {
+    visible: true,
+    mode: 'set' as const,
+    fields: baseFields,
+    canEdit: true,
+    fieldPermissions: {},
+    recordIds: ['rec_1', 'rec_2', 'rec_3'],
+    busy: false,
+    error: null as string | null,
+    resultMessage: null as string | null,
+    onApply: vi.fn(),
+    onCancel: vi.fn(),
+    ...propsOverride,
+  }
+  const app = createApp({
+    render() {
+      return h(MetaBulkEditDialog, props)
+    },
+  })
+  app.mount(container)
+  return { app, container, props, root: document.body }
+}
+
+describe('MetaBulkEditDialog', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  it('shows the set-mode title and summary when mode is set', async () => {
+    const { app, root } = mountDialog({ mode: 'set' })
+    await nextTick()
+    expect(root.querySelector('.meta-bulk-edit__header strong')?.textContent).toBe('Set field for selected records')
+    expect(root.querySelector('.meta-bulk-edit__hint')?.textContent).toContain('Pick a field and a value')
+    app.unmount()
+  })
+
+  it('shows the clear-mode title when mode is clear', async () => {
+    const { app, root } = mountDialog({ mode: 'clear' })
+    await nextTick()
+    expect(root.querySelector('.meta-bulk-edit__header strong')?.textContent).toBe('Clear field for selected records')
+    app.unmount()
+  })
+
+  it('field picker excludes system, derived, link, attachment, hidden, and readonly fields', async () => {
+    const { app, root } = mountDialog()
+    await nextTick()
+    const options = Array.from(root.querySelectorAll('.meta-bulk-edit__select option'))
+      .map((option) => (option as HTMLOptionElement).value)
+      .filter((value) => value.length > 0)
+    expect(options).toEqual(['fld_name', 'fld_notes', 'fld_amount', 'fld_status'])
+    expect(options).not.toContain('fld_link')
+    expect(options).not.toContain('fld_attach')
+    expect(options).not.toContain('fld_formula')
+    expect(options).not.toContain('fld_lookup')
+    expect(options).not.toContain('fld_rollup')
+    expect(options).not.toContain('fld_locked')
+    expect(options).not.toContain('fld_hidden')
+    expect(options).not.toContain('fld_auto')
+    expect(options).not.toContain('fld_created')
+    app.unmount()
+  })
+
+  it('field picker also respects explicit fieldPermissions readOnly map', async () => {
+    const { app, root } = mountDialog({
+      fieldPermissions: { fld_name: { readOnly: true } },
+    })
+    await nextTick()
+    const options = Array.from(root.querySelectorAll('.meta-bulk-edit__select option'))
+      .map((option) => (option as HTMLOptionElement).value)
+      .filter((value) => value.length > 0)
+    expect(options).not.toContain('fld_name')
+    expect(options).toContain('fld_notes')
+    app.unmount()
+  })
+
+  it('field picker is empty when canEdit is false', async () => {
+    const { app, root } = mountDialog({ canEdit: false })
+    await nextTick()
+    const options = Array.from(root.querySelectorAll('.meta-bulk-edit__select option'))
+      .map((option) => (option as HTMLOptionElement).value)
+      .filter((value) => value.length > 0)
+    expect(options).toEqual([])
+    expect(root.querySelector('.meta-bulk-edit__hint--muted')?.textContent).toContain('No bulk-editable fields')
+    app.unmount()
+  })
+
+  it('emits apply with set-mode payload after picking a field and value', async () => {
+    const onApply = vi.fn()
+    const { app, root } = mountDialog({ mode: 'set', onApply })
+    await nextTick()
+
+    const select = root.querySelector('.meta-bulk-edit__select') as HTMLSelectElement
+    select.value = 'fld_name'
+    select.dispatchEvent(new Event('change', { bubbles: true }))
+    await nextTick()
+
+    const input = root.querySelector('.meta-bulk-edit__value-wrap input[type=text]') as HTMLInputElement
+    input.value = 'Alpha'
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+    await nextTick()
+
+    const submit = Array.from(root.querySelectorAll('.meta-bulk-edit__btn--primary'))[0] as HTMLButtonElement
+    submit.click()
+    await nextTick()
+
+    expect(onApply).toHaveBeenCalledTimes(1)
+    expect(onApply).toHaveBeenCalledWith({
+      mode: 'set',
+      fieldId: 'fld_name',
+      value: 'Alpha',
+      recordIds: ['rec_1', 'rec_2', 'rec_3'],
+    })
+    app.unmount()
+  })
+
+  it('emits apply with clear-mode payload (value: null) without a value editor', async () => {
+    const onApply = vi.fn()
+    const { app, root } = mountDialog({ mode: 'clear', onApply })
+    await nextTick()
+
+    const select = root.querySelector('.meta-bulk-edit__select') as HTMLSelectElement
+    select.value = 'fld_notes'
+    select.dispatchEvent(new Event('change', { bubbles: true }))
+    await nextTick()
+
+    expect(root.querySelector('.meta-bulk-edit__value-wrap input')).toBeNull()
+
+    const submit = Array.from(root.querySelectorAll('.meta-bulk-edit__btn--primary'))[0] as HTMLButtonElement
+    submit.click()
+    await nextTick()
+
+    expect(onApply).toHaveBeenCalledTimes(1)
+    expect(onApply).toHaveBeenCalledWith({
+      mode: 'clear',
+      fieldId: 'fld_notes',
+      value: null,
+      recordIds: ['rec_1', 'rec_2', 'rec_3'],
+    })
+    app.unmount()
+  })
+
+  it('Apply is disabled in set mode until a value is entered', async () => {
+    const { app, root } = mountDialog({ mode: 'set' })
+    await nextTick()
+
+    const select = root.querySelector('.meta-bulk-edit__select') as HTMLSelectElement
+    select.value = 'fld_name'
+    select.dispatchEvent(new Event('change', { bubbles: true }))
+    await nextTick()
+
+    const submit = Array.from(root.querySelectorAll('.meta-bulk-edit__btn--primary'))[0] as HTMLButtonElement
+    expect(submit.disabled).toBe(true)
+    app.unmount()
+  })
+
+  it('renders an error message when the parent passes a conflict / failure', async () => {
+    const onApply = vi.fn()
+    const { app, root } = mountDialog({
+      mode: 'set',
+      error: 'Some records were modified elsewhere. Reload and retry.',
+      onApply,
+    })
+    await nextTick()
+
+    const errorBlock = root.querySelector('.meta-bulk-edit__error')
+    expect(errorBlock).not.toBeNull()
+    expect(errorBlock?.textContent).toContain('modified elsewhere')
+    app.unmount()
+  })
+
+  it('disables Apply while busy is true (re-entrancy guard)', async () => {
+    const { app, root } = mountDialog({ mode: 'set', busy: true })
+    await nextTick()
+
+    const select = root.querySelector('.meta-bulk-edit__select') as HTMLSelectElement
+    select.value = 'fld_name'
+    select.dispatchEvent(new Event('change', { bubbles: true }))
+    await nextTick()
+
+    const input = root.querySelector('.meta-bulk-edit__value-wrap input[type=text]') as HTMLInputElement
+    input.value = 'Alpha'
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+    await nextTick()
+
+    const submit = Array.from(root.querySelectorAll('.meta-bulk-edit__btn--primary'))[0] as HTMLButtonElement
+    expect(submit.disabled).toBe(true)
+    app.unmount()
+  })
+
+  it('emits cancel when the close button is clicked', async () => {
+    const onCancel = vi.fn()
+    const { app, root } = mountDialog({ onCancel })
+    await nextTick()
+
+    const close = root.querySelector('.meta-bulk-edit__close') as HTMLButtonElement
+    close.click()
+    await nextTick()
+
+    expect(onCancel).toHaveBeenCalledTimes(1)
+    app.unmount()
+  })
+})

--- a/apps/web/tests/multitable-grid-bulk-edit.spec.ts
+++ b/apps/web/tests/multitable-grid-bulk-edit.spec.ts
@@ -1,0 +1,133 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick } from 'vue'
+import MetaGridTable from '../src/multitable/components/MetaGridTable.vue'
+import type { MetaField } from '../src/multitable/types'
+
+const fields: MetaField[] = [
+  { id: 'fld_name', name: 'Name', type: 'string', property: {} },
+  { id: 'fld_amount', name: 'Amount', type: 'number', property: {} },
+]
+
+const rows = [
+  { id: 'rec_1', data: { fld_name: 'Alpha', fld_amount: 1 }, version: 1 },
+  { id: 'rec_2', data: { fld_name: 'Beta', fld_amount: 2 }, version: 1 },
+  { id: 'rec_3', data: { fld_name: 'Gamma', fld_amount: 3 }, version: 1 },
+]
+
+function mount(overrides: Record<string, unknown> = {}) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const props: Record<string, unknown> = {
+    rows,
+    visibleFields: fields,
+    sortRules: [],
+    loading: false,
+    currentPage: 1,
+    totalPages: 1,
+    startIndex: 0,
+    canEdit: true,
+    canDelete: true,
+    canBulkEdit: true,
+    enableMultiSelect: true,
+    ...overrides,
+  }
+  const app = createApp({
+    render() {
+      return h(MetaGridTable, props)
+    },
+  })
+  app.mount(container)
+  return { app, container, props }
+}
+
+function selectAllRows(container: HTMLElement) {
+  const headerCheckbox = container.querySelector('thead .meta-grid__check-col input[type=checkbox]') as HTMLInputElement
+  headerCheckbox.click()
+}
+
+describe('MetaGridTable bulk-edit affordances', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  it('renders Set field and Clear field buttons when canBulkEdit and selection are present', async () => {
+    const { app, container } = mount()
+    await nextTick()
+
+    selectAllRows(container)
+    await nextTick()
+
+    const buttons = Array.from(container.querySelectorAll('.meta-grid__bulk-bar .meta-grid__bulk-btn')) as HTMLButtonElement[]
+    const labels = buttons.map((btn) => btn.textContent?.trim())
+    expect(labels).toContain('Set field')
+    expect(labels).toContain('Clear field')
+    expect(labels).toContain('Delete selected')
+    app.unmount()
+  })
+
+  it('hides Set/Clear field buttons when canBulkEdit is false', async () => {
+    const { app, container } = mount({ canBulkEdit: false })
+    await nextTick()
+
+    selectAllRows(container)
+    await nextTick()
+
+    const buttons = Array.from(container.querySelectorAll('.meta-grid__bulk-bar .meta-grid__bulk-btn')) as HTMLButtonElement[]
+    const labels = buttons.map((btn) => btn.textContent?.trim())
+    expect(labels).not.toContain('Set field')
+    expect(labels).not.toContain('Clear field')
+    app.unmount()
+  })
+
+  it('clicking Set field emits bulk-edit with mode=set and current selection', async () => {
+    const onBulkEdit = vi.fn()
+    const { app, container } = mount({ onBulkEdit })
+    await nextTick()
+
+    selectAllRows(container)
+    await nextTick()
+
+    const setBtn = Array.from(container.querySelectorAll('.meta-grid__bulk-bar .meta-grid__bulk-btn'))
+      .find((btn) => btn.textContent?.trim() === 'Set field') as HTMLButtonElement
+    setBtn.click()
+    await nextTick()
+
+    expect(onBulkEdit).toHaveBeenCalledTimes(1)
+    expect(onBulkEdit).toHaveBeenCalledWith({
+      mode: 'set',
+      recordIds: ['rec_1', 'rec_2', 'rec_3'],
+    })
+    app.unmount()
+  })
+
+  it('clicking Clear field emits bulk-edit with mode=clear and current selection', async () => {
+    const onBulkEdit = vi.fn()
+    const { app, container } = mount({ onBulkEdit })
+    await nextTick()
+
+    selectAllRows(container)
+    await nextTick()
+
+    const clearBtn = Array.from(container.querySelectorAll('.meta-grid__bulk-bar .meta-grid__bulk-btn'))
+      .find((btn) => btn.textContent?.trim() === 'Clear field') as HTMLButtonElement
+    clearBtn.click()
+    await nextTick()
+
+    expect(onBulkEdit).toHaveBeenCalledTimes(1)
+    expect(onBulkEdit).toHaveBeenCalledWith({
+      mode: 'clear',
+      recordIds: ['rec_1', 'rec_2', 'rec_3'],
+    })
+    app.unmount()
+  })
+
+  it('does not render Set/Clear buttons when there is no selection', async () => {
+    const { app, container } = mount()
+    await nextTick()
+
+    const bar = container.querySelector('.meta-grid__bulk-bar')
+    expect(bar).toBeNull()
+    app.unmount()
+  })
+})

--- a/apps/web/tests/multitable-grid-bulk-edit.spec.ts
+++ b/apps/web/tests/multitable-grid-bulk-edit.spec.ts
@@ -130,4 +130,109 @@ describe('MetaGridTable bulk-edit affordances', () => {
     expect(bar).toBeNull()
     app.unmount()
   })
+
+  it('canEdit=true / canDelete=false: row checkboxes are enabled and bulk-edit emits all editable IDs (regression: PR #1451 review)', async () => {
+    const onBulkEdit = vi.fn()
+    const onBulkDelete = vi.fn()
+    const { app, container } = mount({
+      canEdit: true,
+      canDelete: false,
+      canBulkEdit: true,
+      onBulkEdit,
+      onBulkDelete,
+    })
+    await nextTick()
+
+    const rowCheckboxes = Array.from(
+      container.querySelectorAll('tbody .meta-grid__check-col input[type=checkbox]'),
+    ) as HTMLInputElement[]
+    expect(rowCheckboxes.length).toBe(3)
+    for (const cb of rowCheckboxes) {
+      expect(cb.disabled).toBe(false)
+    }
+
+    selectAllRows(container)
+    await nextTick()
+
+    const buttons = Array.from(
+      container.querySelectorAll('.meta-grid__bulk-bar .meta-grid__bulk-btn'),
+    ) as HTMLButtonElement[]
+    const labels = buttons.map((btn) => btn.textContent?.trim())
+    expect(labels).toContain('Set field')
+    expect(labels).toContain('Clear field')
+    expect(labels).not.toContain('Delete selected')
+
+    const setBtn = buttons.find((btn) => btn.textContent?.trim() === 'Set field') as HTMLButtonElement
+    setBtn.click()
+    await nextTick()
+
+    expect(onBulkEdit).toHaveBeenCalledTimes(1)
+    expect(onBulkEdit).toHaveBeenCalledWith({
+      mode: 'set',
+      recordIds: ['rec_1', 'rec_2', 'rec_3'],
+    })
+    expect(onBulkDelete).not.toHaveBeenCalled()
+    app.unmount()
+  })
+
+  it('mixed per-row permissions: bulk-delete emits only deletable IDs and bulk-edit emits only editable IDs', async () => {
+    const onBulkDelete = vi.fn()
+    const onBulkEdit = vi.fn()
+    const { app, container } = mount({
+      canEdit: true,
+      canDelete: true,
+      canBulkEdit: true,
+      rowActionOverrides: {
+        rec_1: { canEdit: true, canDelete: false, canComment: true },
+        rec_2: { canEdit: false, canDelete: true, canComment: true },
+        rec_3: { canEdit: true, canDelete: true, canComment: true },
+      },
+      onBulkDelete,
+      onBulkEdit,
+    })
+    await nextTick()
+
+    selectAllRows(container)
+    await nextTick()
+
+    const buttons = Array.from(
+      container.querySelectorAll('.meta-grid__bulk-bar .meta-grid__bulk-btn'),
+    ) as HTMLButtonElement[]
+
+    const setBtn = buttons.find((btn) => btn.textContent?.trim() === 'Set field') as HTMLButtonElement
+    setBtn.click()
+    await nextTick()
+
+    expect(onBulkEdit).toHaveBeenCalledWith({
+      mode: 'set',
+      recordIds: ['rec_1', 'rec_3'],
+    })
+
+    const deleteBtn = buttons.find((btn) => btn.textContent?.trim() === 'Delete selected') as HTMLButtonElement
+    deleteBtn.click()
+    await nextTick()
+
+    expect(onBulkDelete).toHaveBeenCalledWith(['rec_2', 'rec_3'])
+    app.unmount()
+  })
+
+  it('row with neither canEdit nor canDelete keeps its checkbox disabled even when sheet allows bulk actions', async () => {
+    const { app, container } = mount({
+      canEdit: true,
+      canDelete: true,
+      canBulkEdit: true,
+      rowActionOverrides: {
+        rec_2: { canEdit: false, canDelete: false, canComment: true },
+      },
+    })
+    await nextTick()
+
+    const rowCheckboxes = Array.from(
+      container.querySelectorAll('tbody .meta-grid__check-col input[type=checkbox]'),
+    ) as HTMLInputElement[]
+    expect(rowCheckboxes[0].disabled).toBe(false)
+    expect(rowCheckboxes[1].disabled).toBe(true)
+    expect(rowCheckboxes[2].disabled).toBe(false)
+    app.unmount()
+  })
 })

--- a/apps/web/tests/multitable-grid.spec.ts
+++ b/apps/web/tests/multitable-grid.spec.ts
@@ -525,6 +525,108 @@ describe('useMultitableGrid', () => {
     expect(grid.error.value).toBe('Row changed elsewhere')
   })
 
+  it('bulkPatch sends one patchRecords request with expectedVersion per selected row', async () => {
+    const patchCalls: Array<{ url: string; body: any }> = []
+    const fetchFn = vi.fn(async (input: string, init?: RequestInit) => {
+      if (!input.startsWith('/api/multitable/patch')) throw new Error(`Unexpected request: ${input}`)
+      patchCalls.push({ url: input, body: JSON.parse(init?.body as string) })
+      return new Response(JSON.stringify({
+        ok: true,
+        data: {
+          updated: [
+            { recordId: 'r1', version: 4 },
+            { recordId: 'r2', version: 4 },
+            { recordId: 'r3', version: 4 },
+          ],
+        },
+      }), { status: 200 })
+    })
+
+    const grid = useMultitableGrid({
+      sheetId: ref(''),
+      viewId: ref(''),
+      client: new MultitableApiClient({ fetchFn }),
+    })
+
+    grid.rows.value = [
+      { id: 'r1', version: 3, data: { f1: 'a' } },
+      { id: 'r2', version: 3, data: { f1: 'b' } },
+      { id: 'r3', version: 3, data: { f1: 'c' } },
+    ]
+
+    const result = await grid.bulkPatch({
+      fieldId: 'f1',
+      value: 'set-by-bulk',
+      recordIds: ['r1', 'r2', 'r3'],
+    })
+
+    expect(patchCalls).toHaveLength(1)
+    expect(patchCalls[0].body.changes).toEqual([
+      { recordId: 'r1', fieldId: 'f1', value: 'set-by-bulk', expectedVersion: 3 },
+      { recordId: 'r2', fieldId: 'f1', value: 'set-by-bulk', expectedVersion: 3 },
+      { recordId: 'r3', fieldId: 'f1', value: 'set-by-bulk', expectedVersion: 3 },
+    ])
+    expect(result.updated).toEqual(['r1', 'r2', 'r3'])
+    expect(result.failed).toEqual([])
+    for (const row of grid.rows.value) {
+      expect(row.version).toBe(4)
+    }
+  })
+
+  it('bulkPatch propagates a VERSION_CONFLICT error so the caller can surface it', async () => {
+    const fetchFn = vi.fn(async (input: string) => {
+      if (!input.startsWith('/api/multitable/patch')) throw new Error(`Unexpected request: ${input}`)
+      return new Response(JSON.stringify({
+        ok: false,
+        error: { code: 'VERSION_CONFLICT', message: 'Row changed elsewhere' },
+      }), { status: 409 })
+    })
+
+    const grid = useMultitableGrid({
+      sheetId: ref(''),
+      viewId: ref(''),
+      client: new MultitableApiClient({ fetchFn }),
+    })
+
+    grid.rows.value = [
+      { id: 'r1', version: 3, data: { f1: 'a' } },
+      { id: 'r2', version: 3, data: { f1: 'b' } },
+    ]
+
+    await expect(
+      grid.bulkPatch({ fieldId: 'f1', value: 'x', recordIds: ['r1', 'r2'] }),
+    ).rejects.toMatchObject({ code: 'VERSION_CONFLICT' })
+  })
+
+  it('bulkPatch skips recordIds not present in rows.value (no version available)', async () => {
+    const patchCalls: Array<{ body: any }> = []
+    const fetchFn = vi.fn(async (input: string, init?: RequestInit) => {
+      if (!input.startsWith('/api/multitable/patch')) throw new Error(`Unexpected request: ${input}`)
+      patchCalls.push({ body: JSON.parse(init?.body as string) })
+      return new Response(JSON.stringify({
+        ok: true,
+        data: { updated: [{ recordId: 'r1', version: 4 }] },
+      }), { status: 200 })
+    })
+
+    const grid = useMultitableGrid({
+      sheetId: ref(''),
+      viewId: ref(''),
+      client: new MultitableApiClient({ fetchFn }),
+    })
+
+    grid.rows.value = [{ id: 'r1', version: 3, data: { f1: 'a' } }]
+
+    const result = await grid.bulkPatch({
+      fieldId: 'f1',
+      value: 'x',
+      recordIds: ['r1', 'r2_offscreen'],
+    })
+
+    expect(patchCalls[0].body.changes.map((c: any) => c.recordId)).toEqual(['r1'])
+    expect(result.updated).toEqual(['r1'])
+  })
+
   it('rejects deleteRecord when scoped rowActions disallow deletes', async () => {
     const fetchFn = vi.fn(async (input: string) => {
       if (!input.startsWith('/api/multitable/records/')) throw new Error(`Unexpected request: ${input}`)

--- a/docs/development/multitable-phase2-lane-c-grid-bulk-edit-development-20260509.md
+++ b/docs/development/multitable-phase2-lane-c-grid-bulk-edit-development-20260509.md
@@ -1,0 +1,113 @@
+# Multitable Phase 2 Lane C — Grid Bulk Edit · Development
+
+> Date: 2026-05-09
+> Branch: `codex/multitable-phase2-grid-bulk-edit-20260509`
+> Base: `origin/main@c74c15a2b`
+> Spec: PR #1448 (`docs(multitable): plan Feishu phase 2 lanes`), Lane C
+
+## Background
+
+Lane C from #1448 turns the existing grid selection + `patchRecords` plumbing into a user-facing bulk-edit flow. Pre-PR: the only bulk action was `Delete selected`; users could not change a value on many records in one shot.
+
+## Scope
+
+### In
+
+1. New shared helper `isFieldBulkEditable(field, canEdit, fieldPermission)` in `apps/web/src/multitable/utils/field-permissions.ts`.
+2. New SFC `apps/web/src/multitable/components/MetaBulkEditDialog.vue` — modal dialog with field picker (filtered by the helper) + `MetaCellEditor` for value entry + per-mode behavior.
+3. New emit `bulk-edit` on `MetaGridTable.vue` plus two bulk-bar buttons (`Set field`, `Clear field`) gated by a new `canBulkEdit` prop.
+4. New composable method `bulkPatch({ fieldId, value, recordIds })` on `useMultitableGrid.ts` — builds the `changes` array with `expectedVersion: row.version` and dispatches a single `patchRecords` request.
+5. `MultitableWorkbench.vue` mounts the dialog, wires the emit, calls `grid.bulkPatch(...)`, surfaces the result via existing toast helpers.
+6. Three spec files exercising:
+   - `multitable-grid-bulk-edit.spec.ts` — bulk-bar buttons / gating / emit shape (5 tests)
+   - `multitable-bulk-edit-dialog.spec.ts` — picker filtering / apply emit / disabled states / error rendering (11 tests)
+   - `multitable-grid.spec.ts` — composable `bulkPatch` request shape, version-conflict propagation, and skipping records absent from `rows.value` (3 tests added; total 38)
+
+### Out
+
+- **Per-record partial-success UI**: backend `patchRecords` runs in a single DB transaction (`record-write-service.ts:518`) and aborts on the first `VersionConflictError` / `RecordValidationError`. Surfacing a "X succeeded, Y failed" breakdown requires a new backend mode that doesn't exist today; **scoped explicitly to a follow-up backend PR (Codex-owned)**. Frontend already uses a forward-compatible return shape (`{ updated: string[]; failed: Array<{recordId, reason}> }`) so when backend grows partial-success, the dialog can render it without re-shape.
+- **Multi-field bulk edit in one dialog** — explicit non-goal in #1448.
+- **Bulk edits across filtered-out records or all pages** — explicit non-goal in #1448.
+- **Spreadsheet-like drag-fill** — explicit non-goal in #1448.
+- **Bulk edit for `attachment` / `link`** — these need attachment-upload + link-picker UIs that are heavier than this slice; the helper excludes them. Documented as a known limitation.
+- **Lane B** — Codex-owned per #1448.
+
+## K3 PoC Stage 1 Lock
+
+- Does NOT modify `plugins/plugin-integration-core/*`.
+- No migration / OpenAPI dist / runtime changes outside the multitable workbench.
+- Does NOT touch DingTalk / public-form / Gantt / Hierarchy / formula / automation runtime.
+
+## Implementation notes
+
+### Helper extraction (advisor item 1)
+
+`MetaRecordDrawer.vue:361` already has a `canEditField(fieldId)` that depends on row-specific state (`rowActions?.canEdit`) and per-field permission overrides. For bulk edit the question is field-level (not row-level) — does the sheet allow edit + is this field writable + is it a derived/system/hidden field — so we extracted a NEW pure helper rather than refactoring drawer's row-aware check. The two checks intentionally serve different surfaces; they share the underlying `isSystemField` utility. Documented here so the duplication is pre-cleared.
+
+### Forward-compatible return shape (advisor item 2)
+
+```ts
+type BulkPatchResult = { updated: string[]; failed: Array<{ recordId: string; reason: string }> }
+```
+
+Today: `failed` is always empty (transactions are all-or-nothing — full success or thrown error). When backend grows partial-success, the same shape carries per-record failures with no consumer change.
+
+### Conflict / error path (advisor item 3)
+
+Workbench's `onBulkEditApply`:
+- Wraps `grid.bulkPatch(...)` in `try/catch`.
+- On `VERSION_CONFLICT`: surfaces "Some records were modified elsewhere. Reload and retry. (<server message>)" via `bulkEditDialog.error` + `showError`.
+- On non-version errors: displays the original message.
+- On success: closes the dialog and shows a success toast.
+
+Dialog has a dedicated `error` prop the parent flows in; when present, the dialog renders `.meta-bulk-edit__error` so failures cannot silently disappear (within the all-or-nothing constraint).
+
+### Value editor reuse (advisor item 4)
+
+Tried `MetaCellEditor` directly with only `field` + `modelValue`. Its `recordId` is documented optional ("When absent, the Yjs opt-in cannot engage; the editor falls back to the existing REST path") so it works for primitive types out of the box. Attachment / link types are excluded from the picker, so the editor never has to render their record-bound branches inside the dialog.
+
+The cut here vs. spec ("Value editor reuses field-specific editor behavior **where practical**"): `MetaCellEditor` is reused for every field type the picker exposes — `string`, `longText`, `number`, `boolean`, `date`, `dateTime`, `select`, `multiSelect`, `currency`, `percent`, `rating`, `url`, `email`, `phone`, `barcode`, `location`. Excluded types are listed under Known limitations.
+
+### Capabilities plumbing (advisor item 5)
+
+Mirrors the drawer's path:
+
+```
+Workbench
+  ├── effectiveRowActions.canEdit  ──>  :can-edit
+  ├── effectiveFieldPermissions     ──>  :field-permissions
+  └── scopedAllFields               ──>  :fields
+```
+
+`canBulkEdit` on `MetaGridTable` is bound to the same `effectiveRowActions.canEdit` so the bar buttons appear iff the user has sheet-level edit. The dialog applies the field-level filter via the helper.
+
+## Files changed
+
+| File | Change |
+|---|---|
+| `apps/web/src/multitable/utils/field-permissions.ts` | Add `isFieldBulkEditable` + `NON_BULK_EDITABLE_TYPES` set; import `isSystemField`. |
+| `apps/web/src/multitable/components/MetaBulkEditDialog.vue` | New SFC, ~150 lines incl. style. |
+| `apps/web/src/multitable/components/MetaGridTable.vue` | Add `canBulkEdit?: boolean` prop, two bulk-bar buttons, `bulk-edit` emit, `onBulkEdit(mode)` handler. |
+| `apps/web/src/multitable/composables/useMultitableGrid.ts` | Add `bulkPatch(...)` method (~30 lines) + expose in return. |
+| `apps/web/src/multitable/views/MultitableWorkbench.vue` | Import + mount `MetaBulkEditDialog`, dialog state via `reactive`, three handlers (`onBulkEditRequest` / `onBulkEditCancel` / `onBulkEditApply`), `:can-bulk-edit="effectiveRowActions.canEdit"` on grid, `@bulk-edit="onBulkEditRequest"` listener. |
+| `apps/web/tests/multitable-grid-bulk-edit.spec.ts` | New, 5 tests on bulk-bar UX. |
+| `apps/web/tests/multitable-bulk-edit-dialog.spec.ts` | New, 11 tests on dialog. |
+| `apps/web/tests/multitable-grid.spec.ts` | Add 3 `bulkPatch` composable tests. |
+| `docs/development/multitable-phase2-lane-c-grid-bulk-edit-development-20260509.md` | This file. |
+| `docs/development/multitable-phase2-lane-c-grid-bulk-edit-verification-20260509.md` | Companion verification. |
+
+## Known limitations
+
+1. **All-or-nothing transactions** — see Out-of-scope above. Following backend changes can surface per-record failures via the existing `failed[]` field.
+2. **Attachment / link bulk edit** excluded — needs additional UI (file uploader / link picker) beyond the dialog's MetaCellEditor reuse. Filed implicitly as a follow-up via the explicit `NON_BULK_EDITABLE_TYPES` set in `field-permissions.ts`.
+3. **No undo for bulk edits** — single-cell edits push to `editHistory`; bulk does not. Reasoning: bulk undo is itself a bulk write that may conflict; the simpler "show conflict on retry, refresh, repeat" loop is the same UX the rest of the app already presents. Filed as follow-up if user feedback warrants.
+4. **MetaRecordDrawer's row-aware `canEditField` is not unified** with the new field-level helper because the two answer different questions (per-row vs. sheet-level). Deliberate per advisor review.
+
+## Cross-references
+
+- Backend transaction guarantee: `packages/core-backend/src/multitable/record-write-service.ts:518` (transactional patch) and `:548–550` (`VersionConflictError` throws aborts the batch).
+- Existing single-cell edit precedent: `apps/web/src/multitable/composables/useMultitableGrid.ts:499–552` (`patchCell`).
+- Existing bulk-delete precedent: `apps/web/src/multitable/views/MultitableWorkbench.vue:2411` (`onBulkDelete`).
+- Drawer's row-aware permission check: `apps/web/src/multitable/components/MetaRecordDrawer.vue:361` (`canEditField`).
+- Lane A audit (sibling PR): #1449.
+- Phase 2 plan: #1448.

--- a/docs/development/multitable-phase2-lane-c-grid-bulk-edit-verification-20260509.md
+++ b/docs/development/multitable-phase2-lane-c-grid-bulk-edit-verification-20260509.md
@@ -66,19 +66,35 @@ Cases:
 
 ### Codex review fixes (2026-05-10)
 
-Two bugs reported on PR #1451:
+Three bugs reported on PR #1451:
 
-1. **Selection gate too tight** — `:enable-multi-select` was bound to `gridAllowsAnyDelete`, so users with `canEdit=true / canDelete=false` could not select rows for bulk edit. Fix: bind to `gridAllowsAnyDelete || effectiveRowActions.canEdit`. Also added an explanatory HTML comment above the `<MetaGridTable>` element so the gate's intent is durable in code.
-2. **Auto-submit on select/boolean change** — `MetaCellEditor`'s `select` (line 124) and `boolean` (line 113) branches emit `confirm` on native `@change`. The dialog was wiring `@confirm="onApply"`, which would silently bulk-patch the moment a user opened the dropdown or toggled a checkbox. Fix: remove the `@confirm="onApply"` binding so the explicit "Set value" / "Clear" button is the only commit path. Added an HTML comment in the dialog template explaining why the binding is intentionally omitted.
+1. **Selection gate too tight (round 1)** — `:enable-multi-select` was bound to `gridAllowsAnyDelete` in `MultitableWorkbench.vue`. First fix: bind to `gridAllowsAnyDelete || effectiveRowActions.canEdit` so canEdit-only users get the bulk bar at all.
 
-Two new regression tests added to `multitable-bulk-edit-dialog.spec.ts`:
+2. **Selection gate too tight (round 2 — same bug, deeper layer)** — Even with the workbench v-bind opened up, `MetaGridTable.vue` itself filtered selection on `canDelete` in three places (`selectableRowIds`, `toggleSelectRow`, two checkbox `:disabled` bindings). canEdit-only users still saw disabled checkboxes and a no-op header toggle. Second fix: introduced a per-row predicate `rowAllowsAnyBulkAction(recordId)` that returns `actions.canEdit || actions.canDelete`, and replaced all three sites. Also made `onBulkDelete` / `onBulkEdit` action-aware — they now filter the selected set to deletable / editable records before emitting, so:
+   - canEdit-only user clicks `Set field` → emits `bulk-edit` with all selected (all editable) IDs.
+   - Mixed permissions: clicking `Delete selected` only emits the deletable subset; clicking `Set field` only emits the editable subset.
+   - A row with neither permission stays disabled even when sheet-level allows both actions.
+
+3. **Auto-submit on select/boolean change** — `MetaCellEditor`'s `select` (line 124) and `boolean` (line 113) branches emit `confirm` on native `@change`. The dialog was wiring `@confirm="onApply"`, which would silently bulk-patch the moment a user opened the dropdown or toggled a checkbox. Fix: remove the `@confirm="onApply"` binding so the explicit "Set value" / "Clear" button is the only commit path. Added an HTML comment in the dialog template explaining the deliberate omission.
+
+#### Regression tests added
+
+`multitable-bulk-edit-dialog.spec.ts`:
 
 ```
 ✓ does NOT auto-submit when a select-typed editor fires its native change (regression: Codex review on PR #1451)
 ✓ does NOT auto-submit when a boolean editor fires its native change
 ```
 
-Total dialog spec count: 11 → 13.
+`multitable-grid-bulk-edit.spec.ts`:
+
+```
+✓ canEdit=true / canDelete=false: row checkboxes are enabled and bulk-edit emits all editable IDs (regression: PR #1451 review)
+✓ mixed per-row permissions: bulk-delete emits only deletable IDs and bulk-edit emits only editable IDs
+✓ row with neither canEdit nor canDelete keeps its checkbox disabled even when sheet-level allows bulk actions
+```
+
+Spec counts: dialog 11 → 13; grid bulk-edit 5 → 8.
 
 ### MetaBulkEditDialog (new spec)
 

--- a/docs/development/multitable-phase2-lane-c-grid-bulk-edit-verification-20260509.md
+++ b/docs/development/multitable-phase2-lane-c-grid-bulk-edit-verification-20260509.md
@@ -1,0 +1,113 @@
+# Multitable Phase 2 Lane C — Grid Bulk Edit · Verification
+
+> Companion to `multitable-phase2-lane-c-grid-bulk-edit-development-20260509.md`
+
+## Acceptance bullets → evidence
+
+| Acceptance bullet (#1448) | Where validated |
+|---|---|
+| Bulk bar offers "Set field" and "Clear field" only when selected records exist | `multitable-grid-bulk-edit.spec.ts` — *renders Set field and Clear field buttons when canBulkEdit and selection are present*; *does not render Set/Clear buttons when there is no selection* |
+| Field picker excludes read-only/system fields and fields the current user cannot write | `multitable-bulk-edit-dialog.spec.ts` — *field picker excludes system, derived, link, attachment, hidden, and readonly fields*; *field picker also respects explicit fieldPermissions readOnly map*; *field picker is empty when canEdit is false* |
+| Value editor reuses field-specific editor behavior where practical | `MetaBulkEditDialog.vue` mounts `MetaCellEditor` for the picked field; covered indirectly by the apply-with-set-mode test |
+| Apply path uses one `patchRecords` request with expected versions when available | `multitable-grid.spec.ts` — *bulkPatch sends one patchRecords request with expectedVersion per selected row* |
+| UI reports success count (and conflict/failure count, scoped to backend support) | Workbench `onBulkEditApply` parses `result.updated`/`result.failed` and surfaces via dialog `resultMessage`/`error` props; smoke-tested by *renders an error message when the parent passes a conflict / failure* |
+| Partial failures do not silently disappear (within all-or-nothing backend constraint) | Forward-compat shape `{ updated, failed }` documented; conflict surface validated by *bulkPatch propagates a VERSION_CONFLICT error so the caller can surface it* |
+| Record history and subscription side effects remain consistent with normal batch writes | Backend `patchRecords` is reused unchanged — no new side-effect path |
+| Existing bulk delete remains unchanged | `multitable-grid.spec.ts` regression: 38/38 (was 35; +3 new). Existing *Delete selected* button remains in `MetaGridTable.vue` bar — verified visually via *renders Set field and Clear field buttons when canBulkEdit and selection are present* (which also asserts `Delete selected` is still in the bar) |
+
+## Test runs
+
+### Vue typecheck
+
+```
+$ pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+(no output — clean)
+```
+
+### useMultitableGrid (bulkPatch added)
+
+```
+$ pnpm --filter @metasheet/web exec vitest run tests/multitable-grid.spec.ts --reporter=dot
+
+ ✓ tests/multitable-grid.spec.ts  (38 tests) 172ms
+
+ Test Files  1 passed (1)
+      Tests  38 passed (38)
+```
+
+The three new bulkPatch tests (added to the existing `describe('useMultitableGrid', ...)`):
+
+```
+✓ bulkPatch sends one patchRecords request with expectedVersion per selected row
+✓ bulkPatch propagates a VERSION_CONFLICT error so the caller can surface it
+✓ bulkPatch skips recordIds not present in rows.value (no version available)
+```
+
+### MetaGridTable bulk-bar (new spec)
+
+```
+$ pnpm --filter @metasheet/web exec vitest run tests/multitable-grid-bulk-edit.spec.ts --reporter=dot
+
+ ✓ tests/multitable-grid-bulk-edit.spec.ts  (5 tests) 29ms
+
+ Test Files  1 passed (1)
+      Tests  5 passed (5)
+```
+
+Cases:
+
+```
+✓ renders Set field and Clear field buttons when canBulkEdit and selection are present
+✓ hides Set/Clear field buttons when canBulkEdit is false
+✓ clicking Set field emits bulk-edit with mode=set and current selection
+✓ clicking Clear field emits bulk-edit with mode=clear and current selection
+✓ does not render Set/Clear buttons when there is no selection
+```
+
+### MetaBulkEditDialog (new spec)
+
+```
+$ pnpm --filter @metasheet/web exec vitest run tests/multitable-bulk-edit-dialog.spec.ts --reporter=dot
+
+ ✓ tests/multitable-bulk-edit-dialog.spec.ts  (11 tests) 32ms
+
+ Test Files  1 passed (1)
+      Tests  11 passed (11)
+```
+
+Cases:
+
+```
+✓ shows the set-mode title and summary when mode is set
+✓ shows the clear-mode title when mode is clear
+✓ field picker excludes system, derived, link, attachment, hidden, and readonly fields
+✓ field picker also respects explicit fieldPermissions readOnly map
+✓ field picker is empty when canEdit is false
+✓ emits apply with set-mode payload after picking a field and value
+✓ emits apply with clear-mode payload (value: null) without a value editor
+✓ Apply is disabled in set mode until a value is entered
+✓ renders an error message when the parent passes a conflict / failure
+✓ disables Apply while busy is true (re-entrancy guard)
+✓ emits cancel when the close button is clicked
+```
+
+## Diff hygiene
+
+```
+$ git diff --check origin/main..HEAD
+(no output — clean)
+```
+
+## Pre-deployment checks
+
+- [x] `vue-tsc -b --noEmit` clean across `@metasheet/web`.
+- [x] `multitable-grid.spec.ts` regression: 38/38 (35 → 38; the +3 are bulkPatch tests).
+- [x] `multitable-bulk-edit-dialog.spec.ts`: 11/11 new.
+- [x] `multitable-grid-bulk-edit.spec.ts`: 5/5 new.
+- [x] No DingTalk / public-form / Gantt / Hierarchy / formula / automation runtime / `plugins/plugin-integration-core/*` files touched.
+- [x] No migration / OpenAPI dist / package script / env var changes.
+- [x] Pre-existing `multitable-workbench-import-flow.spec.ts` failure (`window.localStorage.clear is not a function`) verified by `git stash` regression to be a happy-dom polyfill issue on `origin/main`, **not** caused by this PR.
+
+## Result
+
+Lane C MVP shipped. Bulk Set / Clear flow operational over the existing `patchRecords` path with optimistic locking. Forward-compatible result shape lets a follow-up backend PR (per-record partial success) light up new dialog UI without API rework. Lane A (longText) audit is sibling PR #1449; Lane B (real email transport) remains Codex-owned per #1448.

--- a/docs/development/multitable-phase2-lane-c-grid-bulk-edit-verification-20260509.md
+++ b/docs/development/multitable-phase2-lane-c-grid-bulk-edit-verification-20260509.md
@@ -64,6 +64,22 @@ Cases:
 ✓ does not render Set/Clear buttons when there is no selection
 ```
 
+### Codex review fixes (2026-05-10)
+
+Two bugs reported on PR #1451:
+
+1. **Selection gate too tight** — `:enable-multi-select` was bound to `gridAllowsAnyDelete`, so users with `canEdit=true / canDelete=false` could not select rows for bulk edit. Fix: bind to `gridAllowsAnyDelete || effectiveRowActions.canEdit`. Also added an explanatory HTML comment above the `<MetaGridTable>` element so the gate's intent is durable in code.
+2. **Auto-submit on select/boolean change** — `MetaCellEditor`'s `select` (line 124) and `boolean` (line 113) branches emit `confirm` on native `@change`. The dialog was wiring `@confirm="onApply"`, which would silently bulk-patch the moment a user opened the dropdown or toggled a checkbox. Fix: remove the `@confirm="onApply"` binding so the explicit "Set value" / "Clear" button is the only commit path. Added an HTML comment in the dialog template explaining why the binding is intentionally omitted.
+
+Two new regression tests added to `multitable-bulk-edit-dialog.spec.ts`:
+
+```
+✓ does NOT auto-submit when a select-typed editor fires its native change (regression: Codex review on PR #1451)
+✓ does NOT auto-submit when a boolean editor fires its native change
+```
+
+Total dialog spec count: 11 → 13.
+
 ### MetaBulkEditDialog (new spec)
 
 ```


### PR DESCRIPTION
## Summary
- Lane C from PR #1448 — turns the existing grid selection + `patchRecords` plumbing into a user-facing bulk Set/Clear field flow.
- New `MetaBulkEditDialog.vue` (field picker filtered by new `isFieldBulkEditable` helper, MetaCellEditor for value entry, per-mode UX, error rendering).
- New bulk-bar affordances on `MetaGridTable.vue` (`Set field` + `Clear field`) gated by a `canBulkEdit` prop; existing `Delete selected` unchanged.
- New composable method `bulkPatch({ fieldId, value, recordIds })` that issues a single `patchRecords` request with `expectedVersion` per selected row and returns a forward-compatible `{ updated, failed }` shape.
- `MultitableWorkbench.vue` wires the emit, mounts the dialog, surfaces success + `VERSION_CONFLICT` errors via existing toast helpers.
- 19 new focused tests (5 bulk-bar UX + 11 dialog + 3 composable); existing `multitable-grid.spec.ts`: 35 → 38.

## Honest scope cut (called out, not buried)
**Per-record partial-success UI is scoped to a follow-up backend PR.** Backend `patchRecords` is single-transactional (`record-write-service.ts:518`) and aborts on the first `VersionConflictError` / `RecordValidationError`. The dialog already accepts a `failed[]` array in its return shape so the day backend gains partial-success, the consumer renders it without rework. Until then: a `VERSION_CONFLICT` from any selected record fails the entire batch and the dialog displays a 'modified elsewhere; reload + retry' error, satisfying *partial failures do not silently disappear* within the all-or-nothing constraint.

## Acceptance bullet → evidence
| #1448 acceptance bullet | Evidence |
|---|---|
| Bulk bar offers Set/Clear only when selected records exist | `multitable-grid-bulk-edit.spec.ts` (5 tests) |
| Field picker excludes read-only/system/derived/link/attachment/hidden fields | `multitable-bulk-edit-dialog.spec.ts` (3 picker tests inc. `fieldPermissions.readOnly` map + `canEdit=false`) |
| Value editor reuses field-specific editor behavior where practical | Dialog mounts `MetaCellEditor` for the picked field; covered indirectly by apply-with-set test |
| Apply path uses one `patchRecords` request with expected versions | Composable test *bulkPatch sends one patchRecords request with expectedVersion per selected row* |
| UI reports success / conflict counts (within backend constraints) | Dialog `error` + `resultMessage` props; `renders an error message when the parent passes a conflict / failure` |
| Partial failures do not silently disappear | Conflict propagation test + forward-compat `failed[]` shape |
| Record history / subscription side effects consistent | Backend `patchRecords` reused unchanged |
| Existing bulk delete unchanged | `multitable-grid-bulk-edit.spec.ts` asserts \`Delete selected\` still in the bar |

## K3 PoC Stage 1 Lock
- Does NOT modify \`plugins/plugin-integration-core/*\`.
- Frontend-only; no migration / OpenAPI dist / package script / env var.
- Does NOT touch DingTalk / public-form / Gantt / Hierarchy / formula / automation runtime.

## Test plan
- [x] `pnpm --filter @metasheet/web exec vue-tsc -b --noEmit` clean.
- [x] `pnpm --filter @metasheet/web exec vitest run tests/multitable-grid.spec.ts` → 38/38 (was 35; +3 new bulkPatch).
- [x] `pnpm --filter @metasheet/web exec vitest run tests/multitable-bulk-edit-dialog.spec.ts` → 11/11.
- [x] `pnpm --filter @metasheet/web exec vitest run tests/multitable-grid-bulk-edit.spec.ts` → 5/5.
- [x] `git diff --check origin/main..HEAD` clean.
- [x] Pre-existing `multitable-workbench-import-flow.spec.ts` failure (`window.localStorage.clear is not a function`) verified with `git stash` to be a happy-dom polyfill issue on `origin/main`, NOT caused by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)