### PR TITLE
test(dingtalk): restore P4 ops regression gate

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -19,6 +19,33 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
+  dingtalk-p4-ops-regression-gate:
+    name: DingTalk P4 ops regression gate
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Run DingTalk P4 ops regression gate
+        run: |
+          node scripts/ops/dingtalk-p4-regression-gate.mjs \
+            --profile ops \
+            --output-dir output/dingtalk-p4-regression-gate/ci
+
+      - name: Upload DingTalk P4 ops regression gate evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dingtalk-p4-ops-regression-gate
+          path: output/dingtalk-p4-regression-gate/ci/
+          if-no-files-found: ignore
+
   k3wise-offline-poc:
     name: K3 WISE offline PoC
     runs-on: ubuntu-latest

--- a/scripts/ops/dingtalk-p4-offline-handoff.test.mjs
+++ b/scripts/ops/dingtalk-p4-offline-handoff.test.mjs
@@ -24,6 +24,10 @@ function makeTmpDir() {
 }
 
 function readRequestBody(req) {
+  if (req.method === 'GET' || req.method === 'HEAD') {
+    return Promise.resolve(null)
+  }
+
   return new Promise((resolve, reject) => {
     let raw = ''
     req.setEncoding('utf8')
@@ -64,6 +68,16 @@ function createFakeApiServer() {
 
       if (req.method === 'GET' && url.pathname === '/health') {
         sendJson(res, 200, { ok: true })
+        return
+      }
+
+      if (req.method === 'GET' && url.pathname === '/api/auth/me') {
+        sendJson(res, 200, {
+          success: true,
+          email: 'qa@example.test',
+          role: 'admin',
+          plm: true,
+        })
         return
       }
 

--- a/scripts/ops/dingtalk-p4-smoke-session.test.mjs
+++ b/scripts/ops/dingtalk-p4-smoke-session.test.mjs
@@ -107,6 +107,10 @@ function writeCompletedSession(sessionDir, options = {}) {
 }
 
 function readRequestBody(req) {
+  if (req.method === 'GET' || req.method === 'HEAD') {
+    return Promise.resolve(null)
+  }
+
   return new Promise((resolve, reject) => {
     let raw = ''
     req.setEncoding('utf8')
@@ -156,6 +160,16 @@ function createFakeApiServer() {
 
       if (req.method === 'GET' && url.pathname === '/health') {
         sendJson(res, 200, { ok: true })
+        return
+      }
+
+      if (req.method === 'GET' && url.pathname === '/api/auth/me') {
+        sendJson(res, 200, {
+          success: true,
+          email: 'qa@example.test',
+          role: 'admin',
+          plm: true,
+        })
         return
       }
 


### PR DESCRIPTION
## Summary
- Restore the DingTalk P4 ops regression gate after #1274 hardened preflight/auth behavior.
- Update the smoke-session and offline-handoff fake API servers to support GET/HEAD requests without hanging on body reads.
- Add `/api/auth/me` success responses so the new admin-token preflight path is covered.
- Add `dingtalk-p4-regression-gate.mjs --profile ops` to the Plugin System Tests workflow so this blind spot is CI-covered.

## Verification
- `node --test scripts/ops/dingtalk-p4-smoke-session.test.mjs scripts/ops/dingtalk-p4-offline-handoff.test.mjs scripts/ops/dingtalk-p4-final-handoff.test.mjs scripts/ops/validate-dingtalk-staging-evidence-packet.test.mjs` -> 40/40 PASS
- `node scripts/ops/dingtalk-p4-regression-gate.mjs --profile ops --output-dir output/dingtalk-p4-regression-gate/codex-after-fix` -> 11/11 PASS
- `git diff --check` -> PASS
- Diff-only secret scan for newly added lines -> 0 matches

## Notes
- No runtime product code changed.
- No real DingTalk webhook, SEC secret, JWT, bearer token, or admin token is added. Existing dummy fixtures remain test-only.