### PR TITLE
fix(ops): preserve success exit for multitable package verify

### DIFF
--- a/scripts/ops/multitable-onprem-package-verify.sh
+++ b/scripts/ops/multitable-onprem-package-verify.sh
@@ -298,5 +298,9 @@ write_optional_report
 info "Package verify OK"
 info "  package: ${PACKAGE_FILE}"
 info "  root: ${pkg_root}"
-[[ -n "$VERIFY_REPORT_JSON" ]] && info "  verify_report_json: ${VERIFY_REPORT_JSON}"
-[[ -n "$VERIFY_REPORT_MD" ]] && info "  verify_report_md: ${VERIFY_REPORT_MD}"
+if [[ -n "$VERIFY_REPORT_JSON" ]]; then
+  info "  verify_report_json: ${VERIFY_REPORT_JSON}"
+fi
+if [[ -n "$VERIFY_REPORT_MD" ]]; then
+  info "  verify_report_md: ${VERIFY_REPORT_MD}"
+fi


### PR DESCRIPTION
## Summary

Fixes `scripts/ops/multitable-onprem-package-verify.sh` returning exit code 1 after printing `Package verify OK` when no optional report paths are configured.

The failure was caused by trailing conditional log expressions evaluating false in the default workflow path. This unblocks the `Multitable On-Prem Package Build` workflow after #1454.

## Verification

- `bash -n scripts/ops/multitable-onprem-package-verify.sh`
- `bash -n scripts/ops/multitable-onprem-package-build.sh`
- `PACKAGE_TAG=local-verify-exit-fix INSTALL_DEPS=0 BUILD_WEB=0 BUILD_BACKEND=0 scripts/ops/multitable-onprem-package-build.sh`
- `scripts/ops/multitable-onprem-package-verify.sh output/releases/multitable-onprem/metasheet-multitable-onprem-v2.5.0-local-verify-exit-fix.tgz` -> rc 0
- `scripts/ops/multitable-onprem-package-verify.sh output/releases/multitable-onprem/metasheet-multitable-onprem-v2.5.0-local-verify-exit-fix.zip` -> rc 0

No package content changes; this is exit-code correctness only.
