### PR TITLE
feat(multitable): support partial-success bulk edits

### DIFF
--- a/apps/web/src/multitable/composables/useMultitableGrid.ts
+++ b/apps/web/src/multitable/composables/useMultitableGrid.ts
@@ -615,11 +615,16 @@ export function useMultitableGrid(opts: {
     const result = await client.patchRecords({
       sheetId: opts.sheetId.value || undefined,
       viewId: opts.viewId.value || undefined,
+      partialSuccess: true,
       changes,
     })
     applyPatchResult(result)
     const updated = (result.updated ?? []).map((u) => u.recordId)
-    return { updated, failed: [] }
+    const failed = (result.failed ?? []).map((failure) => ({
+      recordId: failure.recordId,
+      reason: failure.message || failure.code || 'Patch failed',
+    }))
+    return { updated, failed }
   }
 
   function applyPatchResult(result?: PatchResult) {

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -468,8 +468,16 @@ export interface RecordVersion {
   version: number
 }
 
+export interface PatchFailure {
+  recordId: string
+  code: string
+  message: string
+  serverVersion?: number
+}
+
 export interface PatchResult {
   updated: RecordVersion[]
+  failed?: PatchFailure[]
   records?: Array<{ recordId: string; data: Record<string, unknown> }>
   linkSummaries?: Record<string, Record<string, LinkedRecordSummary[]>>
   attachmentSummaries?: Record<string, Record<string, MetaAttachment[]>>
@@ -614,6 +622,7 @@ export interface CreateRecordInput {
 export interface PatchRecordsInput {
   viewId?: string
   sheetId?: string
+  partialSuccess?: boolean
   changes: CellChange[]
 }
 

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -2463,13 +2463,21 @@ async function onBulkEditApply(payload: { mode: 'set' | 'clear'; fieldId: string
     const updatedCount = result.updated.length
     const requestedCount = payload.recordIds.length
     if (result.failed.length > 0) {
-      bulkEditDialog.error = `${result.failed.length} of ${requestedCount} record(s) failed`
+      const sampleFailures = result.failed
+        .slice(0, 3)
+        .map((failure) => `${failure.recordId}: ${failure.reason}`)
+        .join('; ')
+      bulkEditDialog.error = `${result.failed.length} of ${requestedCount} record(s) failed${sampleFailures ? ` (${sampleFailures})` : ''}`
+      if (updatedCount > 0) {
+        bulkEditDialog.resultMessage = `${updatedCount} of ${requestedCount} record(s) ${payload.mode === 'clear' ? 'cleared' : 'updated'}`
+      }
     } else if (updatedCount < requestedCount) {
       bulkEditDialog.resultMessage = `${updatedCount} of ${requestedCount} record(s) updated`
     } else {
       bulkEditDialog.resultMessage = `${updatedCount} record(s) ${payload.mode === 'clear' ? 'cleared' : 'updated'}`
     }
     if (updatedCount > 0 && bulkEditDialog.resultMessage) showSuccess(bulkEditDialog.resultMessage)
+    if (result.failed.length > 0 && bulkEditDialog.error) showError(bulkEditDialog.error)
     if (result.failed.length === 0 && updatedCount === requestedCount) {
       bulkEditDialog.visible = false
     }

--- a/apps/web/tests/multitable-grid.spec.ts
+++ b/apps/web/tests/multitable-grid.spec.ts
@@ -10,6 +10,16 @@ import {
 } from '../src/multitable/composables/useMultitableGrid'
 import { MultitableApiClient } from '../src/multitable/api/client'
 
+type PatchRequestBody = {
+  partialSuccess?: boolean
+  changes: Array<{
+    recordId: string
+    fieldId?: string
+    value?: unknown
+    expectedVersion?: number
+  }>
+}
+
 function createMockClient() {
   return new MultitableApiClient({
     fetchFn: vi.fn().mockResolvedValue(new Response(JSON.stringify({ ok: true, data: {} }), { status: 200 })),
@@ -526,10 +536,10 @@ describe('useMultitableGrid', () => {
   })
 
   it('bulkPatch sends one patchRecords request with expectedVersion per selected row', async () => {
-    const patchCalls: Array<{ url: string; body: any }> = []
+    const patchCalls: Array<{ url: string; body: PatchRequestBody }> = []
     const fetchFn = vi.fn(async (input: string, init?: RequestInit) => {
       if (!input.startsWith('/api/multitable/patch')) throw new Error(`Unexpected request: ${input}`)
-      patchCalls.push({ url: input, body: JSON.parse(init?.body as string) })
+      patchCalls.push({ url: input, body: JSON.parse(init?.body as string) as PatchRequestBody })
       return new Response(JSON.stringify({
         ok: true,
         data: {
@@ -561,6 +571,7 @@ describe('useMultitableGrid', () => {
     })
 
     expect(patchCalls).toHaveLength(1)
+    expect(patchCalls[0].body.partialSuccess).toBe(true)
     expect(patchCalls[0].body.changes).toEqual([
       { recordId: 'r1', fieldId: 'f1', value: 'set-by-bulk', expectedVersion: 3 },
       { recordId: 'r2', fieldId: 'f1', value: 'set-by-bulk', expectedVersion: 3 },
@@ -598,11 +609,52 @@ describe('useMultitableGrid', () => {
     ).rejects.toMatchObject({ code: 'VERSION_CONFLICT' })
   })
 
+  it('bulkPatch applies successful rows and returns per-row failures from partialSuccess responses', async () => {
+    const fetchFn = vi.fn(async (input: string) => {
+      if (!input.startsWith('/api/multitable/patch')) throw new Error(`Unexpected request: ${input}`)
+      return new Response(JSON.stringify({
+        ok: true,
+        data: {
+          updated: [{ recordId: 'r1', version: 4 }],
+          records: [{ recordId: 'r1', data: { f1: 'patched' } }],
+          failed: [{
+            recordId: 'r2',
+            code: 'VERSION_CONFLICT',
+            message: 'Version conflict for r2',
+            serverVersion: 8,
+          }],
+        },
+      }), { status: 200 })
+    })
+
+    const grid = useMultitableGrid({
+      sheetId: ref(''),
+      viewId: ref(''),
+      client: new MultitableApiClient({ fetchFn }),
+    })
+
+    grid.rows.value = [
+      { id: 'r1', version: 3, data: { f1: 'a' } },
+      { id: 'r2', version: 3, data: { f1: 'b' } },
+    ]
+
+    const result = await grid.bulkPatch({
+      fieldId: 'f1',
+      value: 'patched',
+      recordIds: ['r1', 'r2'],
+    })
+
+    expect(result.updated).toEqual(['r1'])
+    expect(result.failed).toEqual([{ recordId: 'r2', reason: 'Version conflict for r2' }])
+    expect(grid.rows.value[0]).toMatchObject({ version: 4, data: { f1: 'patched' } })
+    expect(grid.rows.value[1]).toMatchObject({ version: 3, data: { f1: 'b' } })
+  })
+
   it('bulkPatch skips recordIds not present in rows.value (no version available)', async () => {
-    const patchCalls: Array<{ body: any }> = []
+    const patchCalls: Array<{ body: PatchRequestBody }> = []
     const fetchFn = vi.fn(async (input: string, init?: RequestInit) => {
       if (!input.startsWith('/api/multitable/patch')) throw new Error(`Unexpected request: ${input}`)
-      patchCalls.push({ body: JSON.parse(init?.body as string) })
+      patchCalls.push({ body: JSON.parse(init?.body as string) as PatchRequestBody })
       return new Response(JSON.stringify({
         ok: true,
         data: { updated: [{ recordId: 'r1', version: 4 }] },
@@ -623,7 +675,8 @@ describe('useMultitableGrid', () => {
       recordIds: ['r1', 'r2_offscreen'],
     })
 
-    expect(patchCalls[0].body.changes.map((c: any) => c.recordId)).toEqual(['r1'])
+    expect(patchCalls[0].body.partialSuccess).toBe(true)
+    expect(patchCalls[0].body.changes.map((change) => change.recordId)).toEqual(['r1'])
     expect(result.updated).toEqual(['r1'])
   })
 

--- a/docs/development/multitable-bulk-edit-partial-success-development-20260510.md
+++ b/docs/development/multitable-bulk-edit-partial-success-development-20260510.md
@@ -1,0 +1,78 @@
+# Multitable Bulk Edit Partial Success - Development - 2026-05-10
+
+## Status
+
+Implemented on branch `codex/multitable-bulk-edit-partial-success-20260510`.
+
+This slice follows PR #1451. PR #1451 added the user-facing bulk Set/Clear dialog and reserved a frontend return shape:
+
+```ts
+{ updated: string[]; failed: Array<{ recordId: string; reason: string }> }
+```
+
+Before this slice, the backend `/api/multitable/patch` route still executed all changes in one `RecordWriteService.patchRecords()` call. A single row-level version conflict rejected the whole request and left the reserved `failed[]` shape unused.
+
+## Design
+
+The implementation is opt-in and preserves existing all-or-nothing behavior by default.
+
+- `POST /api/multitable/patch` accepts `partialSuccess?: boolean`.
+- If `partialSuccess` is absent or false, the route calls `RecordWriteService.patchRecords()` once with the full `changesByRecord` map, exactly as before.
+- If `partialSuccess` is true, the route iterates records and calls `RecordWriteService.patchRecords()` once per record, each in the existing service transaction boundary.
+- Known per-row failures are serialized into `data.failed[]` instead of aborting successful rows.
+- Unknown/internal failures are not swallowed; they still propagate to the existing 500 path.
+
+## Failure Shape
+
+```ts
+type PatchFailurePayload = {
+  recordId: string
+  code: string
+  message: string
+  serverVersion?: number
+}
+```
+
+Serialized per-row failures:
+
+- `CONFLICT`
+- `VERSION_CONFLICT`
+- `NOT_FOUND`
+- `FIELD_READONLY` and other service field-forbidden codes
+- `VALIDATION_ERROR` and service validation codes such as `HIERARCHY_CYCLE`
+
+## Frontend Behavior
+
+`useMultitableGrid.bulkPatch()` now sends:
+
+```ts
+partialSuccess: true
+```
+
+It applies successful row updates through the existing `applyPatchResult()` path, then maps backend `failed[]` into the reserved frontend shape:
+
+```ts
+{ recordId, reason }
+```
+
+`MultitableWorkbench` now shows both sides of a partial result:
+
+- Success toast for the records actually updated.
+- Dialog error with a compact failure summary for failed rows.
+- Dialog remains open when any rows fail, so the user can inspect the failure and retry after reload or correction.
+
+## Files Changed
+
+- `packages/core-backend/src/routes/univer-meta.ts`
+- `packages/core-backend/tests/integration/multitable-patch-partial-success.api.test.ts`
+- `apps/web/src/multitable/types.ts`
+- `apps/web/src/multitable/composables/useMultitableGrid.ts`
+- `apps/web/src/multitable/views/MultitableWorkbench.vue`
+- `apps/web/tests/multitable-grid.spec.ts`
+
+## Non-Goals
+
+- No change to single-cell edit, undo, redo, timeline, gantt, or hierarchy patch callers; they keep all-or-nothing semantics.
+- No new database migration.
+- No OpenAPI schema update in this slice; this is an internal client-route contract extension under the existing multitable patch endpoint.
+- No live PostgreSQL performance claim. The route-level test mocks `RecordWriteService` to lock behavior without requiring DB provisioning.

--- a/docs/development/multitable-bulk-edit-partial-success-verification-20260510.md
+++ b/docs/development/multitable-bulk-edit-partial-success-verification-20260510.md
@@ -1,0 +1,125 @@
+# Multitable Bulk Edit Partial Success - Verification - 2026-05-10
+
+## Summary
+
+Branch: `codex/multitable-bulk-edit-partial-success-20260510`
+
+Result: targeted backend and frontend verification passed.
+
+## Commands
+
+### Install
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+Result: passed. The worktree initially had no `node_modules`, so Vitest was unavailable until install linked workspace dependencies.
+
+### Backend Partial-Success Route Spec
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/integration/multitable-patch-partial-success.api.test.ts \
+  --watch=false
+```
+
+Result:
+
+```text
+Test Files  1 passed (1)
+Tests       2 passed (2)
+```
+
+Coverage:
+
+- `partialSuccess: true` keeps successful rows and reports a stale row as `VERSION_CONFLICT` in `data.failed[]`.
+- Default mode without `partialSuccess` still calls `RecordWriteService.patchRecords()` once with all records and does not include `failed`.
+
+### Frontend Grid Composable Spec
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/multitable-grid.spec.ts \
+  --watch=false
+```
+
+Result:
+
+```text
+Test Files  1 passed (1)
+Tests       39 passed (39)
+```
+
+Coverage:
+
+- `bulkPatch()` sends `partialSuccess: true`.
+- It preserves `expectedVersion` per selected row.
+- It applies successful rows from `records[]`.
+- It maps backend `failed[]` into `{ recordId, reason }`.
+- Top-level API errors still reject normally.
+
+### Bulk Edit Component Regressions
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/multitable-grid-bulk-edit.spec.ts \
+  tests/multitable-bulk-edit-dialog.spec.ts \
+  --watch=false
+```
+
+Result:
+
+```text
+Test Files  2 passed (2)
+Tests       21 passed (21)
+```
+
+Coverage:
+
+- PR #1451 edit-only selection regression remains covered.
+- PR #1451 select/boolean no-auto-submit regression remains covered.
+
+### Type Checks
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+```
+
+Result: both passed.
+
+### Whitespace
+
+```bash
+git diff --check
+```
+
+Result: passed.
+
+## Attempted Adjacent Backend Regression
+
+Command:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/integration/multitable-record-form.api.test.ts \
+  --watch=false
+```
+
+Result: not run by current backend Vitest config.
+
+Reason:
+
+```text
+No test files found
+exclude: ... tests/integration/multitable-record-form.api.test.ts ...
+```
+
+This is a config exclusion, not a product failure. The new route-level spec covers this slice's changed branch directly.
+
+## Known Limits
+
+- Partial success is record-level, not field-level. Multiple field changes for one record still succeed or fail together via one service transaction.
+- Unknown/internal exceptions are intentionally not converted into `failed[]`; they still fail the request to avoid hiding server bugs.
+- The UI shows a compact first-three-failures summary, not a full per-row error table. A richer result panel can be a later UX polish if operators need it.

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -2899,6 +2899,40 @@ class ValidationError extends Error {
   }
 }
 
+type PatchFailurePayload = {
+  recordId: string
+  code: string
+  message: string
+  serverVersion?: number
+}
+
+function serializePatchFailure(recordId: string, err: unknown): PatchFailurePayload | null {
+  if (err instanceof ConflictError) {
+    return { recordId, code: 'CONFLICT', message: err.message }
+  }
+  if (err instanceof VersionConflictError || err instanceof ServiceVersionConflictError) {
+    return {
+      recordId,
+      code: 'VERSION_CONFLICT',
+      message: err.message,
+      serverVersion: err.serverVersion,
+    }
+  }
+  if (err instanceof NotFoundError || err instanceof ServiceNotFoundError) {
+    return { recordId, code: 'NOT_FOUND', message: err.message }
+  }
+  if (err instanceof ServiceFieldForbiddenError) {
+    return { recordId, code: err.code, message: err.message }
+  }
+  if (err instanceof ValidationError) {
+    return { recordId, code: 'VALIDATION_ERROR', message: err.message }
+  }
+  if (err instanceof ServiceValidationError) {
+    return { recordId, code: err.code || 'VALIDATION_ERROR', message: err.message }
+  }
+  return null
+}
+
 function stringFromRecord(value: Record<string, unknown>, keys: string[]): string {
   for (const key of keys) {
     const raw = value[key]
@@ -7468,6 +7502,7 @@ export function univerMetaRouter(): Router {
     const schema = z.object({
       viewId: z.string().min(1).optional(),
       sheetId: z.string().min(1).optional(),
+      partialSuccess: z.boolean().optional(),
       changes: z.array(z.object({
         recordId: z.string().min(1),
         fieldId: z.string().min(1),
@@ -7539,6 +7574,58 @@ export function univerMetaRouter(): Router {
       const recordWriteService = new RecordWriteService(pool, eventBus, writeHelpers)
       if (yjsInvalidator) {
         recordWriteService.setPostCommitHooks([createYjsInvalidationPostCommitHook(yjsInvalidator)])
+      }
+
+      if (parsed.data.partialSuccess === true) {
+        const updated: Array<{ recordId: string; version: number }> = []
+        const records: Array<{ recordId: string; data: Record<string, unknown> }> = []
+        const relatedRecords: Array<{ sheetId: string; recordId: string; data: Record<string, unknown> }> = []
+        const failures: PatchFailurePayload[] = []
+        let linkSummaries: Record<string, unknown> | undefined
+        let attachmentSummaries: Record<string, unknown> | undefined
+
+        for (const [recordId, recordChanges] of changesByRecord.entries()) {
+          try {
+            const result = await recordWriteService.patchRecords({
+              sheetId,
+              changesByRecord: new Map([[recordId, recordChanges]]) as Map<string, Array<{ fieldId: string; value: unknown; expectedVersion?: number }>>,
+              actorId: getRequestActorId(req),
+              fields,
+              visiblePropertyFields,
+              visiblePropertyFieldIds,
+              attachmentFields,
+              fieldById,
+              capabilities,
+              sheetScope,
+              access,
+            })
+            updated.push(...result.updated)
+            if (result.records) records.push(...(result.records as Array<{ recordId: string; data: Record<string, unknown> }>))
+            if (result.relatedRecords) relatedRecords.push(...(result.relatedRecords as Array<{ sheetId: string; recordId: string; data: Record<string, unknown> }>))
+            if (result.linkSummaries) {
+              linkSummaries = { ...(linkSummaries ?? {}), ...(result.linkSummaries as Record<string, unknown>) }
+            }
+            if (result.attachmentSummaries) {
+              attachmentSummaries = { ...(attachmentSummaries ?? {}), ...(result.attachmentSummaries as Record<string, unknown>) }
+            }
+          } catch (err) {
+            const failure = serializePatchFailure(recordId, err)
+            if (!failure) throw err
+            failures.push(failure)
+          }
+        }
+
+        return res.json({
+          ok: true,
+          data: {
+            updated,
+            failed: failures,
+            ...(records.length > 0 ? { records } : {}),
+            ...(linkSummaries ? { linkSummaries } : {}),
+            ...(attachmentSummaries ? { attachmentSummaries } : {}),
+            ...(relatedRecords.length > 0 ? { relatedRecords } : {}),
+          },
+        })
       }
 
       const result = await recordWriteService.patchRecords({

--- a/packages/core-backend/tests/integration/multitable-patch-partial-success.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-patch-partial-success.api.test.ts
@@ -1,0 +1,167 @@
+import express from 'express'
+import request from 'supertest'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+type QueryResult = {
+  rows: any[]
+  rowCount?: number
+}
+
+type QueryHandler = (sql: string, params?: unknown[]) => QueryResult | Promise<QueryResult>
+
+const patchRecordsMock = vi.fn()
+const setPostCommitHooksMock = vi.fn()
+
+function createMockPool(queryHandler: QueryHandler) {
+  const query = vi.fn(async (sql: string, params?: unknown[]) => {
+    if (sql.includes('FROM spreadsheet_permissions')) return { rows: [], rowCount: 0 }
+    if (sql.includes('FROM field_permissions')) return { rows: [], rowCount: 0 }
+    if (sql.includes('FROM view_permissions')) return { rows: [], rowCount: 0 }
+    if (sql.includes('FROM meta_view_permissions')) return { rows: [], rowCount: 0 }
+    if (sql.includes('FROM record_permissions')) return { rows: [], rowCount: 0 }
+    return queryHandler(sql, params)
+  })
+  const transaction = vi.fn(async (fn: (client: { query: typeof query }) => Promise<unknown>) => fn({ query }))
+  return { query, transaction }
+}
+
+async function createApp(args: {
+  queryHandler?: QueryHandler
+}) {
+  vi.resetModules()
+
+  vi.doMock('../../src/rbac/service', () => ({
+    isAdmin: vi.fn().mockResolvedValue(false),
+    userHasPermission: vi.fn().mockResolvedValue(false),
+    listUserPermissions: vi.fn().mockResolvedValue([]),
+    invalidateUserPerms: vi.fn(),
+    getPermCacheStatus: vi.fn(),
+  }))
+  vi.doMock('../../src/multitable/record-write-service', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../../src/multitable/record-write-service')>()
+    return {
+      ...actual,
+      RecordWriteService: vi.fn().mockImplementation(() => ({
+        patchRecords: patchRecordsMock,
+        setPostCommitHooks: setPostCommitHooksMock,
+      })),
+    }
+  })
+
+  const { poolManager } = await import('../../src/integration/db/connection-pool')
+  const { univerMetaRouter, setYjsInvalidatorForRoutes } = await import('../../src/routes/univer-meta')
+  setYjsInvalidatorForRoutes(null)
+  const mockPool = createMockPool(args.queryHandler ?? (() => ({ rows: [], rowCount: 0 })))
+  vi.spyOn(poolManager, 'get').mockReturnValue(mockPool as any)
+
+  const app = express()
+  app.use(express.json())
+  app.use((req, _res, next) => {
+    req.user = {
+      id: 'user_partial_patch',
+      roles: [],
+      perms: ['multitable:write'],
+    }
+    next()
+  })
+  app.use('/api/multitable', univerMetaRouter())
+  return { app, mockPool }
+}
+
+describe('Multitable POST /patch partialSuccess', () => {
+  afterEach(async () => {
+    const univerMetaModule = await import('../../src/routes/univer-meta')
+    univerMetaModule.setYjsInvalidatorForRoutes(null)
+    patchRecordsMock.mockReset()
+    setPostCommitHooksMock.mockReset()
+    vi.restoreAllMocks()
+    vi.resetModules()
+  })
+
+  test('keeps successful record patches and reports per-row version conflicts', async () => {
+    const { app } = await createApp({
+      queryHandler: async (sql, params) => {
+        if (sql.includes('SELECT id, name, type, property, "order" FROM meta_fields WHERE sheet_id = $1')) {
+          expect(params).toEqual(['sheet_partial'])
+          return { rows: [{ id: 'fld_title', name: 'Title', type: 'string', property: {}, order: 1 }] }
+        }
+        throw new Error(`Unhandled SQL in test: ${sql}`)
+      },
+    })
+    const { VersionConflictError } = await import('../../src/multitable/record-write-service')
+    patchRecordsMock.mockImplementation(async (input: { changesByRecord: Map<string, unknown> }) => {
+      const recordId = [...input.changesByRecord.keys()][0]
+      if (recordId === 'rec_stale') throw new VersionConflictError(recordId, 9)
+      return {
+        updated: [{ recordId, version: 4 }],
+        records: [{ recordId, data: { fld_title: 'Bulk value' } }],
+      }
+    })
+
+    const response = await request(app)
+      .post('/api/multitable/patch')
+      .send({
+        sheetId: 'sheet_partial',
+        partialSuccess: true,
+        changes: [
+          { recordId: 'rec_ok', fieldId: 'fld_title', value: 'Bulk value', expectedVersion: 3 },
+          { recordId: 'rec_stale', fieldId: 'fld_title', value: 'Bulk value', expectedVersion: 3 },
+        ],
+      })
+      .expect(200)
+
+    expect(response.body).toMatchObject({
+      ok: true,
+      data: {
+        updated: [{ recordId: 'rec_ok', version: 4 }],
+        records: [{ recordId: 'rec_ok', data: { fld_title: 'Bulk value' } }],
+        failed: [{
+          recordId: 'rec_stale',
+          code: 'VERSION_CONFLICT',
+          message: 'Version conflict for rec_stale',
+          serverVersion: 9,
+        }],
+      },
+    })
+    expect(patchRecordsMock).toHaveBeenCalledTimes(2)
+    expect([...patchRecordsMock.mock.calls[0][0].changesByRecord.keys()]).toEqual(['rec_ok'])
+    expect([...patchRecordsMock.mock.calls[1][0].changesByRecord.keys()]).toEqual(['rec_stale'])
+  })
+
+  test('preserves all-or-nothing mode when partialSuccess is not requested', async () => {
+    patchRecordsMock.mockResolvedValue({
+      updated: [
+        { recordId: 'rec_1', version: 4 },
+        { recordId: 'rec_2', version: 4 },
+      ],
+    })
+
+    const { app } = await createApp({
+      queryHandler: async (sql) => {
+        if (sql.includes('SELECT id, name, type, property, "order" FROM meta_fields WHERE sheet_id = $1')) {
+          return { rows: [{ id: 'fld_title', name: 'Title', type: 'string', property: {}, order: 1 }] }
+        }
+        throw new Error(`Unhandled SQL in test: ${sql}`)
+      },
+    })
+
+    const response = await request(app)
+      .post('/api/multitable/patch')
+      .send({
+        sheetId: 'sheet_partial',
+        changes: [
+          { recordId: 'rec_1', fieldId: 'fld_title', value: 'Bulk value', expectedVersion: 3 },
+          { recordId: 'rec_2', fieldId: 'fld_title', value: 'Bulk value', expectedVersion: 3 },
+        ],
+      })
+      .expect(200)
+
+    expect(response.body.data.failed).toBeUndefined()
+    expect(response.body.data.updated).toEqual([
+      { recordId: 'rec_1', version: 4 },
+      { recordId: 'rec_2', version: 4 },
+    ])
+    expect(patchRecordsMock).toHaveBeenCalledTimes(1)
+    expect([...patchRecordsMock.mock.calls[0][0].changesByRecord.keys()]).toEqual(['rec_1', 'rec_2'])
+  })
+})


### PR DESCRIPTION
## Summary
- add opt-in `partialSuccess` handling to `POST /api/multitable/patch` while preserving default all-or-nothing behavior
- return per-row `failed[]` payloads for known row-level conflicts/validation errors
- wire bulk Set/Clear to request partial success, apply successful rows, and keep the dialog open with failure details
- archive development and verification notes under `docs/development/`

## Verification
- `pnpm --filter @metasheet/core-backend exec vitest run tests/integration/multitable-patch-partial-success.api.test.ts --watch=false`
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-grid.spec.ts --watch=false`
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-grid-bulk-edit.spec.ts tests/multitable-bulk-edit-dialog.spec.ts --watch=false`
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit`
- `pnpm --filter @metasheet/web exec vue-tsc -b --noEmit`
- `git diff --check`