### PR TITLE
fix(integration): support K3API authority-code token auth

### DIFF
--- a/apps/web/src/services/integration/k3WiseSetup.ts
+++ b/apps/web/src/services/integration/k3WiseSetup.ts
@@ -2,6 +2,7 @@ import { apiFetch } from '../../utils/api'
 
 export type IntegrationSystemStatus = 'active' | 'inactive' | 'error'
 export type K3SqlServerMode = 'readonly' | 'middle-table' | 'stored-procedure'
+export type K3WiseWebApiAuthMode = 'authority-code' | 'login'
 export type IntegrationPipelineRunMode = 'manual' | 'incremental' | 'full'
 export type K3WisePipelineTarget = 'material' | 'bom'
 export type IntegrationPipelineRunStatus = 'pending' | 'running' | 'succeeded' | 'partial' | 'failed' | 'cancelled'
@@ -132,8 +133,11 @@ export interface K3WiseSetupForm {
   version: string
   environment: 'test' | 'uat' | 'staging' | 'production' | 'other'
   baseUrl: string
+  webApiAuthMode: K3WiseWebApiAuthMode
+  tokenPath: string
   loginPath: string
   healthPath: string
+  authorityCode: string
   acctId: string
   username: string
   password: string
@@ -246,6 +250,11 @@ function optionalString(value: string): string | undefined {
   return normalized.length > 0 ? normalized : undefined
 }
 
+function getLocalStorageValue(key: string): string {
+  if (typeof localStorage === 'undefined' || typeof localStorage.getItem !== 'function') return ''
+  return localStorage.getItem(key) || ''
+}
+
 export function splitList(value: string): string[] {
   return value
     .split(/\r?\n|,/)
@@ -304,8 +313,8 @@ function validateHttpUrl(value: string, field: keyof K3WiseSetupForm, issues: K3
 }
 
 export function createDefaultK3WiseSetupForm(): K3WiseSetupForm {
-  const tenantId = typeof localStorage === 'undefined' ? '' : localStorage.getItem('tenantId') || ''
-  const workspaceId = typeof localStorage === 'undefined' ? '' : localStorage.getItem('workspaceId') || ''
+  const tenantId = getLocalStorageValue('tenantId')
+  const workspaceId = getLocalStorageValue('workspaceId')
   return {
     tenantId,
     workspaceId,
@@ -317,8 +326,11 @@ export function createDefaultK3WiseSetupForm(): K3WiseSetupForm {
     version: '',
     environment: 'test',
     baseUrl: '',
+    webApiAuthMode: 'authority-code',
+    tokenPath: '/K3API/Token/Create',
     loginPath: '/K3API/Login',
-    healthPath: '/K3API/Health',
+    healthPath: '',
+    authorityCode: '',
     acctId: '',
     username: '',
     password: '',
@@ -363,12 +375,21 @@ export function validateK3WiseSetupForm(form: K3WiseSetupForm): K3WiseSetupValid
   if (!trim(form.tenantId)) issues.push({ field: 'tenantId', message: 'tenantId is required' })
   if (!trim(form.webApiName)) issues.push({ field: 'webApiName', message: 'WebAPI system name is required' })
   if (!trim(form.version)) issues.push({ field: 'version', message: 'K3 WISE version is required' })
-  const webApiCredentialTouched = Boolean(trim(form.username) || trim(form.password) || trim(form.acctId))
+  const webApiCredentialTouched = Boolean(trim(form.authorityCode) || trim(form.username) || trim(form.password) || trim(form.acctId))
   const webApiCredentialRequired = !form.webApiSystemId || !form.webApiHasCredentials || webApiCredentialTouched
-  if (webApiCredentialRequired && !trim(form.acctId)) issues.push({ field: 'acctId', message: 'acctId is required' })
-  if (webApiCredentialRequired && !trim(form.username)) issues.push({ field: 'username', message: 'K3 WISE username is required' })
-  if (webApiCredentialRequired && !trim(form.password)) {
-    issues.push({ field: 'password', message: 'K3 WISE password is required when credentials are created or replaced' })
+  if (!['authority-code', 'login'].includes(form.webApiAuthMode)) {
+    issues.push({ field: 'webApiAuthMode', message: 'WebAPI auth mode must be authority-code or login' })
+  }
+  if (form.webApiAuthMode === 'authority-code') {
+    if (webApiCredentialRequired && !trim(form.authorityCode)) {
+      issues.push({ field: 'authorityCode', message: 'K3 WISE authority code is required' })
+    }
+  } else {
+    if (webApiCredentialRequired && !trim(form.acctId)) issues.push({ field: 'acctId', message: 'acctId is required' })
+    if (webApiCredentialRequired && !trim(form.username)) issues.push({ field: 'username', message: 'K3 WISE username is required' })
+    if (webApiCredentialRequired && !trim(form.password)) {
+      issues.push({ field: 'password', message: 'K3 WISE password is required when credentials are created or replaced' })
+    }
   }
   if (!isPositiveIntegerText(form.lcid)) {
     issues.push({ field: 'lcid', message: 'lcid must be a positive integer' })
@@ -377,6 +398,7 @@ export function validateK3WiseSetupForm(form: K3WiseSetupForm): K3WiseSetupValid
     issues.push({ field: 'timeoutMs', message: 'timeoutMs must be a positive integer' })
   }
   validateHttpUrl(form.baseUrl, 'baseUrl', issues)
+  assertRelativePath(form.tokenPath, 'tokenPath', issues)
   assertRelativePath(form.loginPath, 'loginPath', issues)
   if (trim(form.healthPath)) assertRelativePath(form.healthPath, 'healthPath', issues)
   assertRelativePath(form.materialSavePath, 'materialSavePath', issues)
@@ -490,11 +512,13 @@ function gateItem(
 }
 
 export function buildK3WiseDeployGateChecklist(form: K3WiseSetupForm): K3WiseDeployGateItem[] {
-  const webApiCredentialTouched = Boolean(trim(form.username) || trim(form.password) || trim(form.acctId))
+  const webApiCredentialTouched = Boolean(trim(form.authorityCode) || trim(form.username) || trim(form.password) || trim(form.acctId))
   const webApiCredentialsReady = form.webApiHasCredentials && !webApiCredentialTouched
     ? true
-    : Boolean(trim(form.acctId) && trim(form.username) && trim(form.password))
-  const webApiConfigReady = Boolean(trim(form.tenantId) && trim(form.version) && trim(form.baseUrl) && trim(form.loginPath))
+    : form.webApiAuthMode === 'authority-code'
+      ? Boolean(trim(form.authorityCode))
+      : Boolean(trim(form.acctId) && trim(form.username) && trim(form.password))
+  const webApiConfigReady = Boolean(trim(form.tenantId) && trim(form.version) && trim(form.baseUrl) && trim(form.tokenPath) && trim(form.loginPath))
   const stagingReady = Boolean(trim(form.tenantId) && trim(form.projectId))
   const pipelineTemplateReady = Boolean(trim(form.sourceSystemId) && trim(form.webApiSystemId) && trim(form.materialStagingObjectId) && trim(form.bomStagingObjectId))
   const materialDryRunReady = Boolean(trim(form.materialPipelineId))
@@ -518,8 +542,8 @@ export function buildK3WiseDeployGateChecklist(form: K3WiseSetupForm): K3WiseDep
       'K3 WISE WebAPI',
       webApiConfigReady ? 'ready' : 'missing',
       webApiConfigReady
-        ? '版本、环境、Base URL 和接口路径已具备'
-        : '部署后可在页面填写 K3 WISE 版本、环境、WebAPI Base URL 和相对接口路径',
+        ? '版本、环境、Base URL、Token Path 和接口路径已具备'
+        : '部署后可在页面填写 K3 WISE 版本、环境、WebAPI Base URL、Token Path 和相对接口路径',
       webApiConfigReady ? undefined : 'baseUrl',
     ),
     gateItem(
@@ -529,9 +553,13 @@ export function buildK3WiseDeployGateChecklist(form: K3WiseSetupForm): K3WiseDep
       webApiCredentialsReady
         ? form.webApiHasCredentials && !webApiCredentialTouched
           ? '已保存凭据会保留，页面不会回显密码'
-          : 'Acct ID、用户名和密码已可用于保存或替换凭据'
-        : '部署后可在页面填写 acctId、用户名和密码；密码只会提交保存，不会回显',
-      webApiCredentialsReady ? undefined : 'acctId',
+          : form.webApiAuthMode === 'authority-code'
+            ? '授权码已可用于申请 K3 API Token'
+            : 'Acct ID、用户名和密码已可用于保存或替换凭据'
+        : form.webApiAuthMode === 'authority-code'
+          ? '部署后可在页面填写 K3 API 授权码；授权码只会提交保存，不会回显'
+          : '部署后可在页面填写 acctId、用户名和密码；密码只会提交保存，不会回显',
+      webApiCredentialsReady ? undefined : form.webApiAuthMode === 'authority-code' ? 'authorityCode' : 'acctId',
     ),
     gateItem(
       'submit-audit-policy',
@@ -743,10 +771,11 @@ export function buildK3WiseSetupPayloads(form: K3WiseSetupForm): K3WiseSetupPayl
     status: 'active',
   }
   const webApiCredentials: Record<string, unknown> = {}
-  if (trim(form.username) || trim(form.acctId) || trim(form.password)) {
-    webApiCredentials.username = trim(form.username)
-    webApiCredentials.acctId = trim(form.acctId)
-    webApiCredentials.password = form.password
+  if (trim(form.authorityCode) || trim(form.username) || trim(form.acctId) || trim(form.password)) {
+    if (trim(form.authorityCode)) webApiCredentials.authorityCode = trim(form.authorityCode)
+    if (trim(form.username)) webApiCredentials.username = trim(form.username)
+    if (trim(form.acctId)) webApiCredentials.acctId = trim(form.acctId)
+    if (form.password) webApiCredentials.password = form.password
   }
   const webApi = {
     ...baseSystem,
@@ -758,6 +787,9 @@ export function buildK3WiseSetupPayloads(form: K3WiseSetupForm): K3WiseSetupPayl
       version: trim(form.version),
       environment: form.environment,
       baseUrl: trim(form.baseUrl),
+      authMode: form.webApiAuthMode,
+      tokenPath: trim(form.tokenPath),
+      tokenQueryParam: 'Token',
       loginPath: trim(form.loginPath),
       ...(optionalString(form.healthPath) ? { healthPath: trim(form.healthPath) } : {}),
       lcid: parseRequiredPositiveInteger(form.lcid, 'lcid'),
@@ -1028,6 +1060,11 @@ export function applyExternalSystemToForm(form: K3WiseSetupForm, system: Integra
     next.version = typeof config.version === 'string' ? config.version : next.version
     next.environment = typeof config.environment === 'string' ? config.environment as K3WiseSetupForm['environment'] : next.environment
     next.baseUrl = typeof config.baseUrl === 'string' ? config.baseUrl : next.baseUrl
+    const legacyLoginConfig = config.authMode === undefined &&
+      typeof config.loginPath === 'string' &&
+      typeof config.tokenPath !== 'string'
+    next.webApiAuthMode = config.authMode === 'login' || legacyLoginConfig ? 'login' : 'authority-code'
+    next.tokenPath = typeof config.tokenPath === 'string' ? config.tokenPath : next.tokenPath
     next.loginPath = typeof config.loginPath === 'string' ? config.loginPath : next.loginPath
     next.healthPath = typeof config.healthPath === 'string' ? config.healthPath : next.healthPath
     next.lcid = config.lcid === undefined ? next.lcid : String(config.lcid)

--- a/apps/web/src/views/IntegrationK3WiseSetupView.vue
+++ b/apps/web/src/views/IntegrationK3WiseSetupView.vue
@@ -286,6 +286,17 @@
               <input v-model.trim="form.baseUrl" placeholder="https://k3.example.test/K3API/" autocomplete="off" />
             </label>
             <label class="k3-setup__field">
+              <span>认证模式</span>
+              <select v-model="form.webApiAuthMode">
+                <option value="authority-code">授权码 Token</option>
+                <option value="login">账套登录</option>
+              </select>
+            </label>
+            <label v-if="form.webApiAuthMode === 'authority-code'" class="k3-setup__field">
+              <span>Token Path</span>
+              <input v-model.trim="form.tokenPath" autocomplete="off" />
+            </label>
+            <label v-if="form.webApiAuthMode === 'login'" class="k3-setup__field">
               <span>Login Path</span>
               <input v-model.trim="form.loginPath" autocomplete="off" />
             </label>
@@ -310,15 +321,19 @@
             <span>{{ form.webApiHasCredentials ? '已有凭据，留空则保留' : '需要填写' }}</span>
           </div>
           <div class="k3-setup__grid">
-            <label class="k3-setup__field">
+            <label v-if="form.webApiAuthMode === 'authority-code'" class="k3-setup__field k3-setup__field--wide">
+              <span>授权码</span>
+              <input v-model="form.authorityCode" type="password" autocomplete="new-password" />
+            </label>
+            <label v-if="form.webApiAuthMode === 'login'" class="k3-setup__field">
               <span>Acct ID</span>
               <input v-model.trim="form.acctId" autocomplete="off" />
             </label>
-            <label class="k3-setup__field">
+            <label v-if="form.webApiAuthMode === 'login'" class="k3-setup__field">
               <span>用户名</span>
               <input v-model.trim="form.username" autocomplete="off" />
             </label>
-            <label class="k3-setup__field">
+            <label v-if="form.webApiAuthMode === 'login'" class="k3-setup__field">
               <span>密码</span>
               <input v-model="form.password" type="password" autocomplete="new-password" />
             </label>

--- a/apps/web/tests/k3WiseSetup.spec.ts
+++ b/apps/web/tests/k3WiseSetup.spec.ts
@@ -31,6 +31,7 @@ describe('K3 WISE setup helpers', () => {
       webApiName: 'K3 WISE WebAPI',
       version: 'K3 WISE 15.x test',
       baseUrl: 'https://k3.example.test/K3API/',
+      webApiAuthMode: 'login',
       acctId: 'AIS_TEST',
       username: 'k3-user',
       password: 'secret',
@@ -56,6 +57,7 @@ describe('K3 WISE setup helpers', () => {
       },
       config: {
         baseUrl: 'https://k3.example.test/K3API/',
+        authMode: 'login',
         autoSubmit: false,
         autoAudit: false,
       },
@@ -66,6 +68,38 @@ describe('K3 WISE setup helpers', () => {
       config: {
         allowedTables: ['dbo.t_ICItem', 'dbo.t_ICBOM', 'dbo.t_ICBomChild'],
         middleTables: ['dbo.integration_material_stage'],
+      },
+    })
+  })
+
+  it('builds K3 API authority-code token payloads from the setup form', () => {
+    const form = createDefaultK3WiseSetupForm()
+    Object.assign(form, {
+      tenantId: 'tenant_1',
+      webApiName: 'K3 WISE WebAPI',
+      version: 'K3 WISE 15.x test',
+      baseUrl: 'http://k3.local/K3API/',
+      authorityCode: 'auth-code-from-k3-admin',
+    })
+
+    expect(validateK3WiseSetupForm(form)).toEqual([])
+    const payloads = buildK3WiseSetupPayloads(form)
+
+    expect(payloads.webApi).toMatchObject({
+      kind: 'erp:k3-wise-webapi',
+      role: 'target',
+      credentials: {
+        authorityCode: 'auth-code-from-k3-admin',
+      },
+      config: {
+        authMode: 'authority-code',
+        tokenPath: '/K3API/Token/Create',
+        tokenQueryParam: 'Token',
+      },
+    })
+    expect(payloads.webApi).not.toMatchObject({
+      credentials: {
+        username: expect.any(String),
       },
     })
   })
@@ -186,6 +220,7 @@ describe('K3 WISE setup helpers', () => {
       webApiName: 'K3 WISE WebAPI',
       version: 'K3 WISE 15.x test',
       baseUrl: 'https://k3.example.test/K3API/',
+      webApiAuthMode: 'login',
       username: 'new-user',
       password: '',
       acctId: 'AIS_TEST',
@@ -204,6 +239,7 @@ describe('K3 WISE setup helpers', () => {
       webApiName: 'K3 WISE WebAPI',
       version: 'K3 WISE 15.x test',
       baseUrl: 'https://k3.example.test/K3API/',
+      webApiAuthMode: 'login',
       acctId: 'AIS_TEST',
       username: 'k3-user',
       password: 'secret',
@@ -498,9 +534,7 @@ describe('K3 WISE setup helpers', () => {
       tenantId: 'tenant_1',
       version: 'K3 WISE 15.x test',
       baseUrl: 'https://k3.example.test/K3API/',
-      acctId: 'AIS_TEST',
-      username: 'k3-user',
-      password: 'secret',
+      authorityCode: 'auth-code-from-k3-admin',
     })
 
     const checklist = buildK3WiseDeployGateChecklist(form)

--- a/docs/development/k3wise-api-authority-token-auth-design-20260511.md
+++ b/docs/development/k3wise-api-authority-token-auth-design-20260511.md
@@ -1,0 +1,96 @@
+# K3 WISE API Authority Token Auth - Design
+
+## Context
+
+The customer-side K3 server package was reviewed from:
+
+```text
+/Users/chouhua/Downloads/K3API.zip
+```
+
+The zip is not committed. It contains the deployed K3 WebAPI application,
+operator documentation, logs, and a nested APITest C# sample. The logs include
+live-looking authorization material, so findings below intentionally describe
+shapes and endpoints only.
+
+## Package Findings
+
+The bundled APITest client and documentation show the real K3 WISE API flow:
+
+1. Request a temporary token:
+
+```text
+GET /K3API/Token/Create?authorityCode=<redacted>
+```
+
+2. Send business calls with the token in the query string:
+
+```text
+POST /K3API/Material/Save?Token=<redacted>
+POST /K3API/BOM/Save?Token=<redacted>
+```
+
+3. Send payloads under the `Data` envelope:
+
+```json
+{
+  "Data": {
+    "FNumber": "..."
+  }
+}
+```
+
+The sample also includes PO operations (`GetTemplate`, `GetList`, `GetDetail`,
+`Save`, `Update`, `CheckBill`) and DES/ECB/PKCS7 helper code for encrypted
+responses. Encryption support is not enabled in this slice; the first live path
+needs plain JSON token auth.
+
+## Prior Gap
+
+`plugin-integration-core` originally assumed a login-session style K3 adapter:
+
+- `POST /K3API/Login`
+- `username`, `password`, `acctId`
+- session header or cookie on subsequent requests
+- default save body key `Model`
+
+That still works for existing mocks, but it does not match this K3API package.
+Against the real package, the adapter would fail before any material/BOM write.
+
+## Design
+
+### Backend Adapter
+
+`plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs`
+now supports both modes:
+
+- `authMode: "authority-code"` or credentials containing `authorityCode`
+  requests `/K3API/Token/Create` and caches the returned token until its
+  reported validity approaches expiry.
+- `authMode: "login"` continues to use the previous username/password/acctId
+  path.
+- business calls append the K3 token as `Token=<redacted>` query param.
+- default K3 WISE save payload envelope is now `Data`, matching the customer
+  package.
+- K3 package response shapes are accepted through `StatusCode`, `Data.Code`,
+  `Data.Token`, `Data.FItemID`, and `Data.FNumber`.
+
+### Frontend Setup
+
+`apps/web/src/services/integration/k3WiseSetup.ts` and
+`apps/web/src/views/IntegrationK3WiseSetupView.vue` now expose a WebAPI auth
+mode:
+
+- `授权码 Token` is the default for the current K3API package.
+- `账套登录` remains available for existing login-session deployments.
+- the authority code is treated as a credential and is never echoed back.
+- saved legacy systems without `authMode` but with `loginPath` still load as
+  login mode.
+
+## Non-goals
+
+- Do not commit or redistribute the K3API package.
+- Do not enable encrypted response support yet.
+- Do not change SQL Server channel behavior.
+- Do not automatically Submit/Audit after Save.
+- Do not bypass the customer GATE or live-run approval controls.

--- a/docs/development/k3wise-api-authority-token-auth-verification-20260511.md
+++ b/docs/development/k3wise-api-authority-token-auth-verification-20260511.md
@@ -1,0 +1,114 @@
+# K3 WISE API Authority Token Auth - Verification
+
+## Package Review
+
+Reviewed `/Users/chouhua/Downloads/K3API.zip` in a temporary directory.
+
+Relevant evidence:
+
+- top-level K3 WebAPI files: `Default.aspx`, `DoAction.ashx`, `Web.config`,
+  `DOCUMENT/*.aspx`, `XML/*.xml`, and `BIN/Kingdee.K3.API.*.dll`
+- nested APITest project under `FILE/APITest.zip`
+- APITest calls `Token/Create?authorityCode=...`, then `...?Token=...`
+- material logs show `controller: Material`, `action: Save`, and `k3data`
+  shaped as `{ "Data": { ... } }`
+
+Secret handling:
+
+- no token, authority code, password, or URL query secret from the package is
+  copied into this document
+- the package remains outside git
+
+## Local Tests
+
+### K3 WebAPI adapter contract
+
+```bash
+node plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
+```
+
+Result:
+
+```text
+PASS - WebAPI, SQL Server channel, and auto-flag coercion tests passed
+```
+
+Coverage added:
+
+- authority-code token request uses `authorityCode` query param
+- returned token is cached across `testConnection()` and `upsert()`
+- material save sends `Token` as query param
+- default body envelope is `Data`
+- K3 package response shape maps to successful upsert metadata
+- legacy login-session mode still passes
+
+### Frontend setup helpers
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/k3WiseSetup.spec.ts --watch=false
+```
+
+Result:
+
+```text
+PASS - 26 tests
+```
+
+Coverage added:
+
+- frontend builds authority-code token external-system payloads
+- login mode remains available and validates username/password/acctId
+- saved legacy login config loads back as login mode
+- localStorage fallback works when the test environment exposes a partial
+  `localStorage` object
+
+### REST PoC control plane
+
+```bash
+node plugins/plugin-integration-core/__tests__/http-routes-plm-k3wise-poc.test.cjs
+```
+
+Result:
+
+```text
+PASS - REST PLM -> K3 WISE mock control-plane chain passed
+```
+
+### E2E PLM to K3 writeback
+
+```bash
+node plugins/plugin-integration-core/__tests__/e2e-plm-k3wise-writeback.test.cjs
+```
+
+Result:
+
+```text
+PASS - mock PLM -> K3 WISE -> feedback tests passed
+```
+
+### K3 WISE offline PoC readiness
+
+```bash
+pnpm run verify:integration-k3wise:poc
+```
+
+Result:
+
+```text
+PASS - preflight tests, evidence tests, and mock PoC demo passed
+```
+
+## Deployment Impact
+
+This is runtime-safe for the current Windows/on-prem package path:
+
+- no migration
+- no package-layout change
+- no new runtime dependency
+- no secret printed to logs or documentation
+- existing `/K3API/Login` deployments can still select login mode
+
+The next Windows package should include both this PR and #1458 so that:
+
+1. the integration plugin routes are present in the package
+2. the K3 WebAPI adapter matches the real K3API authority-code token flow

--- a/plugins/plugin-integration-core/__tests__/e2e-plm-k3wise-writeback.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/e2e-plm-k3wise-writeback.test.cjs
@@ -35,7 +35,7 @@ function createK3FetchMock() {
       return jsonResponse(200, { success: true, sessionId: 'session_1' })
     }
     if (parsed.pathname === '/K3API/Material/Save') {
-      const number = body.Model.FNumber
+      const number = (body.Model || body.Data).FNumber
       if (number === 'BAD-02') {
         return jsonResponse(200, { success: false, code: 'K3_MATERIAL_INVALID', message: 'material code rejected' })
       }

--- a/plugins/plugin-integration-core/__tests__/http-routes-plm-k3wise-poc.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes-plm-k3wise-poc.test.cjs
@@ -68,7 +68,7 @@ function createK3FetchMock() {
     }
 
     if (parsed.pathname === '/K3API/Material/Save') {
-      const number = body.Model.FNumber
+      const number = (body.Model || body.Data).FNumber
       if (number === 'BAD-02') {
         return jsonResponse(200, {
           success: false,
@@ -666,7 +666,7 @@ async function main() {
 
   const saveCalls = harness.k3FetchMock.calls.filter((call) => call.pathname === '/K3API/Material/Save')
   assert.equal(saveCalls.length, 2)
-  assert.deepEqual(saveCalls.map((call) => call.body.Model.FNumber), ['GOOD-01', 'BAD-02'])
+  assert.deepEqual(saveCalls.map((call) => (call.body.Model || call.body.Data).FNumber), ['GOOD-01', 'BAD-02'])
   assert.equal(harness.k3FetchMock.calls.some((call) => call.pathname === '/K3API/Material/Submit'), false)
   assert.equal(harness.k3FetchMock.calls.some((call) => call.pathname === '/K3API/Material/Audit'), false)
 

--- a/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
@@ -37,10 +37,21 @@ function createK3FetchMock() {
     const body = options.body ? JSON.parse(options.body) : undefined
     calls.push({
       pathname: parsed.pathname,
+      query: Object.fromEntries(parsed.searchParams.entries()),
       options,
       body,
     })
 
+    if (parsed.pathname === '/K3API/Token/Create') {
+      if (parsed.searchParams.get('authorityCode') !== 'auth-code-1') {
+        return jsonResponse(200, { StatusCode: 401, Message: 'invalid authority code', Data: { Code: 'N' } })
+      }
+      return jsonResponse(200, {
+        StatusCode: 200,
+        Message: 'Token request succeeded',
+        Data: { Code: 'Y', Token: 'k3-token-1', Validity: 3600 },
+      })
+    }
     if (parsed.pathname === '/K3API/Login') {
       return jsonResponse(200, { success: true, sessionId: 'k3-session-1' })
     }
@@ -48,10 +59,18 @@ function createK3FetchMock() {
       return jsonResponse(200, { ok: true })
     }
     if (parsed.pathname === '/K3API/Material/Save') {
-      if (body.Model.FNumber === 'BAD') {
+      const record = body.Model || body.Data
+      if (record.FNumber === 'BAD') {
         return jsonResponse(200, { success: false, message: 'invalid material' })
       }
-      return jsonResponse(200, { success: true, externalId: `item-${body.Model.FNumber}`, billNo: body.Model.FNumber })
+      if (parsed.searchParams.get('Token')) {
+        return jsonResponse(200, {
+          StatusCode: 200,
+          Message: 'Material saved',
+          Data: { Code: 'Y', FItemID: `item-${record.FNumber}`, FNumber: record.FNumber },
+        })
+      }
+      return jsonResponse(200, { success: true, externalId: `item-${record.FNumber}`, billNo: record.FNumber })
     }
     if (parsed.pathname === '/K3API/Material/Submit') {
       return jsonResponse(200, { success: true, submitted: body.Number })
@@ -161,7 +180,7 @@ async function testK3WebApiAdapter() {
   assert.equal(submitCalls.length, 1, 'submit runs only after successful save')
   assert.equal(auditCalls.length, 1, 'audit runs only after successful save')
   assert.equal(saveCalls[0].options.headers['X-K3-Session'], 'k3-session-1')
-  assert.deepEqual(saveCalls[0].body, { Model: { FNumber: 'MAT-001', FName: 'Bolt' } })
+  assert.deepEqual(saveCalls[0].body, { Data: { FNumber: 'MAT-001', FName: 'Bolt' } })
   assert.deepEqual(submitCalls[0].body, { Number: 'MAT-001' })
 
   const targetOnlyRead = await adapter.read({ object: 'material' }).catch((error) => error)
@@ -210,6 +229,8 @@ async function testK3WebApiAdapter() {
   assert.match(missingAcctIdStatus.message, /acctId/)
 
   assert.equal(webApiInternals.businessSuccess({ success: true }, {}), true)
+  assert.equal(webApiInternals.businessSuccess({ StatusCode: 200, Data: { Code: 'Y' } }, {}), true)
+  assert.equal(webApiInternals.businessSuccess({ StatusCode: 500, Data: { Code: 'N' } }, {}), false)
   assert.equal(webApiInternals.businessSuccess({ Result: { ResponseStatus: { IsSuccess: true } } }, {}), true)
   assert.equal(webApiInternals.businessSuccess({ Result: { ResponseStatus: { IsSuccess: false } } }, {}), false)
   assert.equal(webApiInternals.businessSuccess({ id: 'silent-success' }, {}), false)
@@ -228,6 +249,46 @@ async function testK3WebApiAdapter() {
   assert.ok(invalidBaseUrl instanceof AdapterValidationError, 'non-http K3 baseUrl rejected')
 
   assert.equal(K3WiseWebApiAdapterError.name, 'K3WiseWebApiAdapterError')
+}
+
+async function testK3WebApiAuthorityCodeToken() {
+  const { calls, fetchImpl } = createK3FetchMock()
+  const adapter = createK3WiseWebApiAdapter({
+    system: createK3WebApiSystem({
+      credentials: {
+        authorityCode: 'auth-code-1',
+      },
+      config: {
+        baseUrl: 'https://k3.example.test',
+        authMode: 'authority-code',
+        tokenPath: '/K3API/Token/Create',
+        autoSubmit: false,
+        autoAudit: false,
+      },
+    }),
+    fetchImpl,
+  })
+
+  const connection = await adapter.testConnection({ skipHealth: true })
+  assert.equal(connection.ok, true, 'authorityCode token testConnection succeeds')
+  assert.equal(connection.authenticated, true, 'query-token auth counts as authenticated')
+
+  const upsert = await adapter.upsert({
+    object: 'material',
+    records: [{ FNumber: 'MAT-TOKEN-001', FName: 'Token material' }],
+    keyFields: ['FNumber'],
+  })
+
+  const tokenCalls = calls.filter((call) => call.pathname === '/K3API/Token/Create')
+  const saveCalls = calls.filter((call) => call.pathname === '/K3API/Material/Save')
+  assert.equal(tokenCalls.length, 1, 'authorityCode token is cached across testConnection and upsert')
+  assert.equal(tokenCalls[0].query.authorityCode, 'auth-code-1')
+  assert.equal(saveCalls.length, 1)
+  assert.equal(saveCalls[0].query.Token, 'k3-token-1', 'K3 API token is sent as query parameter')
+  assert.deepEqual(saveCalls[0].body, { Data: { FNumber: 'MAT-TOKEN-001', FName: 'Token material' } })
+  assert.equal(upsert.written, 1)
+  assert.equal(upsert.results[0].externalId, 'item-MAT-TOKEN-001')
+  assert.equal(upsert.results[0].billNo, 'MAT-TOKEN-001')
 }
 
 async function testK3SqlServerChannel() {
@@ -514,6 +575,7 @@ async function testK3WebApiAutoFlagCoercion() {
 
 async function main() {
   await testK3WebApiAdapter()
+  await testK3WebApiAuthorityCodeToken()
   await testK3SqlServerChannel()
   await testK3WebApiAutoFlagCoercion()
   console.log('✓ k3-wise-adapters: WebAPI, SQL Server channel, and auto-flag coercion tests passed')

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
@@ -34,7 +34,7 @@ const DEFAULT_OBJECTS = {
     savePath: '/K3API/Material/Save',
     submitPath: '/K3API/Material/Submit',
     auditPath: '/K3API/Material/Audit',
-    bodyKey: 'Model',
+    bodyKey: 'Data',
     keyField: 'FNumber',
     keyParam: 'Number',
     schema: [
@@ -50,7 +50,7 @@ const DEFAULT_OBJECTS = {
     savePath: '/K3API/BOM/Save',
     submitPath: '/K3API/BOM/Submit',
     auditPath: '/K3API/BOM/Audit',
-    bodyKey: 'Model',
+    bodyKey: 'Data',
     keyField: 'FNumber',
     keyParam: 'Number',
     schema: [
@@ -180,6 +180,15 @@ function responseOk(response) {
   return response.status >= 200 && response.status < 300
 }
 
+function toPositiveNumber(value) {
+  if (typeof value === 'number' && Number.isFinite(value) && value > 0) return value
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value.trim())
+    if (Number.isFinite(parsed) && parsed > 0) return parsed
+  }
+  return null
+}
+
 function normalizeObjects(config) {
   const configured = toPlainObject(config.objects, 'config.objects')
   const normalized = {}
@@ -229,7 +238,7 @@ function buildSaveBody(record, request, objectConfig) {
   if (typeof objectConfig.buildBody === 'function') {
     return objectConfig.buildBody(record, request)
   }
-  const bodyKey = objectConfig.bodyKey || 'Model'
+  const bodyKey = objectConfig.bodyKey || 'Data'
   const base = isPlainObject(objectConfig.bodyTemplate) ? { ...objectConfig.bodyTemplate } : {}
   base[bodyKey] = record
   return base
@@ -246,6 +255,11 @@ function buildLifecycleBody(record, request, objectConfig, operation) {
 
 function businessSuccess(data, config) {
   if (config.successPath) return Boolean(getPath(data, config.successPath))
+  const statusCode = toPositiveNumber(firstDefined(getPath(data, 'StatusCode'), getPath(data, 'statusCode')))
+  const dataCode = firstDefined(getPath(data, 'Data.Code'), getPath(data, 'data.code'))
+  if (typeof dataCode === 'string' && ['N', 'NO', 'FALSE', 'FAILED', 'ERROR'].includes(dataCode.trim().toUpperCase())) return false
+  if (typeof dataCode === 'string' && ['Y', 'YES', 'TRUE', 'SUCCESS', 'OK'].includes(dataCode.trim().toUpperCase())) return true
+  if (statusCode !== null) return statusCode >= 200 && statusCode < 300
   const candidates = [
     getPath(data, 'success'),
     getPath(data, 'ok'),
@@ -279,6 +293,8 @@ function responseCode(data, config, fallback = 'OK') {
     getPath(data, 'Code'),
     getPath(data, 'errorCode'),
     getPath(data, 'ErrorCode'),
+    getPath(data, 'StatusCode'),
+    getPath(data, 'Data.Code'),
     getPath(data, 'Result.ResponseStatus.ErrorCode'),
     fallback,
   )
@@ -291,6 +307,8 @@ function responseBillNo(data, config) {
     getPath(data, 'BillNo'),
     getPath(data, 'number'),
     getPath(data, 'Number'),
+    getPath(data, 'Data.FBillNo'),
+    getPath(data, 'Data.FNumber'),
     getPath(data, 'Result.Number'),
     getPath(data, 'Result.ResponseStatus.SuccessEntitys.0.Number'),
   )
@@ -303,6 +321,8 @@ function responseExternalId(data, config) {
     getPath(data, 'id'),
     getPath(data, 'Id'),
     getPath(data, 'FItemID'),
+    getPath(data, 'Data.FItemID'),
+    getPath(data, 'Data.Id'),
     getPath(data, 'Result.Id'),
     getPath(data, 'Result.ResponseStatus.SuccessEntitys.0.Id'),
   )
@@ -316,8 +336,12 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
   const objects = normalizeObjects(config)
   const timeoutMs = Number.isInteger(config.timeoutMs) && config.timeoutMs > 0 ? config.timeoutMs : 30000
   const loginPath = assertRelativePath(config.loginPath || '/K3API/Login', 'config.loginPath')
+  const tokenPath = assertRelativePath(config.tokenPath || '/K3API/Token/Create', 'config.tokenPath')
+  const tokenQueryParam = typeof config.tokenQueryParam === 'string' && config.tokenQueryParam.trim()
+    ? config.tokenQueryParam.trim()
+    : 'Token'
   const healthPath = config.healthPath ? assertRelativePath(config.healthPath, 'config.healthPath') : null
-  let cachedAuthHeaders = null
+  let cachedAuthContext = null
 
   if (typeof fetchImpl !== 'function') {
     throw new AdapterValidationError('K3 WISE WebAPI adapter requires fetch implementation', {
@@ -325,8 +349,17 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
     })
   }
 
-  async function requestJson(path, { method = 'GET', headers, body } = {}) {
-    const url = new URL(assertRelativePath(path, 'path'), baseUrl).toString()
+  function buildUrl(path, query) {
+    const url = new URL(assertRelativePath(path, 'path'), baseUrl)
+    for (const [key, value] of Object.entries(query || {})) {
+      if (value === undefined || value === null || value === '') continue
+      url.searchParams.set(key, String(value))
+    }
+    return url.toString()
+  }
+
+  async function requestJson(path, { method = 'GET', query, headers, body } = {}) {
+    const url = buildUrl(path, query)
     const controller = typeof AbortController === 'function' ? new AbortController() : null
     const timeout = controller ? setTimeout(() => controller.abort(), timeoutMs) : null
     const requestHeaders = mergeHeaders(
@@ -372,12 +405,59 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
     }
   }
 
+  function isFreshAuthContext(context) {
+    return Boolean(context && (!context.expiresAt || context.expiresAt > Date.now() + 60000))
+  }
+
+  async function loginWithAuthorityCode(authorityCode) {
+    const { data } = await requestJson(tokenPath, {
+      method: config.tokenMethod || 'GET',
+      query: { authorityCode },
+    })
+    const token = firstDefined(
+      config.tokenPathInResponse ? getPath(data, config.tokenPathInResponse) : undefined,
+      getPath(data, 'Data.Token'),
+      getPath(data, 'data.token'),
+      getPath(data, 'token'),
+      getPath(data, 'Token'),
+    )
+    if (!token || !businessSuccess(data, config)) {
+      throw new K3WiseWebApiAdapterError(String(responseMessage(data, config, 'K3 WISE token request failed')), {
+        code: 'K3_WISE_TOKEN_FAILED',
+        body: data,
+      })
+    }
+    const validitySeconds = toPositiveNumber(firstDefined(
+      getPath(data, 'Data.Validity'),
+      getPath(data, 'data.validity'),
+      getPath(data, 'validity'),
+      getPath(data, 'Validity'),
+    ))
+    return {
+      headers: {},
+      query: { [tokenQueryParam]: String(token) },
+      expiresAt: validitySeconds ? Date.now() + (validitySeconds * 1000) : null,
+    }
+  }
+
   async function login() {
-    if (cachedAuthHeaders) return cachedAuthHeaders
+    if (isFreshAuthContext(cachedAuthContext)) return cachedAuthContext
     if (credentials.sessionId) {
       const header = config.sessionHeader || 'X-K3-Session'
-      cachedAuthHeaders = { [header]: String(credentials.sessionId) }
-      return cachedAuthHeaders
+      cachedAuthContext = { headers: { [header]: String(credentials.sessionId) }, query: {}, expiresAt: null }
+      return cachedAuthContext
+    }
+
+    const authorityCode = firstDefined(credentials.authorityCode, credentials.authCode, config.authorityCode)
+    const authMode = firstDefined(config.authMode, authorityCode ? 'authority-code' : null, 'login')
+    if (authMode === 'authority-code' || authMode === 'authorityCode' || authMode === 'token') {
+      if (!authorityCode) {
+        throw new K3WiseWebApiAdapterError('K3 WISE WebAPI authorityCode is required for token authentication', {
+          code: 'K3_WISE_CREDENTIALS_MISSING',
+        })
+      }
+      cachedAuthContext = await loginWithAuthorityCode(String(authorityCode))
+      return cachedAuthContext
     }
 
     const username = firstDefined(credentials.username, credentials.userName)
@@ -419,21 +499,30 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
     )
     if (cookie) authHeaders.Cookie = cookie
     if (sessionId) authHeaders[config.sessionHeader || 'X-K3-Session'] = String(sessionId)
-    cachedAuthHeaders = authHeaders
-    return cachedAuthHeaders
+    cachedAuthContext = { headers: authHeaders, query: {}, expiresAt: null }
+    return cachedAuthContext
   }
 
   async function testConnection(input = {}) {
     try {
-      const authHeaders = await login()
+      const authContext = await login()
       if (input.skipHealth || !healthPath) {
-        return { ok: true, status: 200, authenticated: Object.keys(authHeaders).length > 0 }
+        return {
+          ok: true,
+          status: 200,
+          authenticated: Object.keys(authContext.headers || {}).length > 0 || Object.keys(authContext.query || {}).length > 0,
+        }
       }
       const { response } = await requestJson(healthPath, {
         method: input.method || 'GET',
-        headers: authHeaders,
+        query: authContext.query,
+        headers: authContext.headers,
       })
-      return { ok: true, status: response.status, authenticated: Object.keys(authHeaders).length > 0 }
+      return {
+        ok: true,
+        status: response.status,
+        authenticated: Object.keys(authContext.headers || {}).length > 0 || Object.keys(authContext.query || {}).length > 0,
+      }
     } catch (error) {
       return {
         ok: false,
@@ -478,7 +567,7 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
     const auditPath = objectConfig.auditPath ? assertRelativePath(objectConfig.auditPath, 'object.auditPath') : null
     const autoSubmit = resolveAutoFlag(request.options.autoSubmit, config.autoSubmit, 'autoSubmit')
     const autoAudit = resolveAutoFlag(request.options.autoAudit, config.autoAudit, 'autoAudit')
-    const authHeaders = await login()
+    const authContext = await login()
     const results = []
     const errors = []
     const raw = []
@@ -489,7 +578,8 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
       try {
         const save = await requestJson(savePath, {
           method: objectConfig.saveMethod || 'POST',
-          headers: authHeaders,
+          query: authContext.query,
+          headers: authContext.headers,
           body: buildSaveBody(record, request, objectConfig),
         })
         raw.push({ index, operation: 'save', body: save.data })
@@ -512,7 +602,8 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
           }
           const submit = await requestJson(submitPath, {
             method: objectConfig.submitMethod || 'POST',
-            headers: authHeaders,
+            query: authContext.query,
+            headers: authContext.headers,
             body: buildLifecycleBody(record, request, objectConfig, 'submit'),
           })
           raw.push({ index, operation: 'submit', body: submit.data })
@@ -536,7 +627,8 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
           }
           const audit = await requestJson(auditPath, {
             method: objectConfig.auditMethod || 'POST',
-            headers: authHeaders,
+            query: authContext.query,
+            headers: authContext.headers,
             body: buildLifecycleBody(record, request, objectConfig, 'audit'),
           })
           raw.push({ index, operation: 'audit', body: audit.data })

--- a/scripts/ops/fixtures/integration-k3wise/mock-k3-webapi-server.mjs
+++ b/scripts/ops/fixtures/integration-k3wise/mock-k3-webapi-server.mjs
@@ -83,7 +83,7 @@ export function createMockK3WebApiServer({ logger = () => {}, knownBadFNumbers =
       return
     }
     if (pathname === '/K3API/Material/Save') {
-      const fNumber = body?.Model?.FNumber
+      const fNumber = (body?.Model || body?.Data)?.FNumber
       if (knownBadFNumbers.has(fNumber)) {
         jsonResponse(res, 200, { success: false, message: `mock K3 rejects ${fNumber}: invalid material code` })
         return
@@ -100,7 +100,7 @@ export function createMockK3WebApiServer({ logger = () => {}, knownBadFNumbers =
       return
     }
     if (pathname === '/K3API/BOM/Save') {
-      const fNumber = body?.Model?.FNumber
+      const fNumber = (body?.Model || body?.Data)?.FNumber
       if (knownBadFNumbers.has(fNumber)) {
         jsonResponse(res, 200, { success: false, message: `mock K3 BOM rejects ${fNumber}` })
         return

--- a/scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs
+++ b/scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs
@@ -147,7 +147,8 @@ async function main() {
     assert(bomUpsertResult.failed === 0, `expected 0 BOM failed, got ${bomUpsertResult.failed}`)
     const bomSaveCalls = mockK3.calls.filter((call) => call.pathname === '/K3API/BOM/Save')
     assert(bomSaveCalls.length === 1, `expected 1 BOM Save call, got ${bomSaveCalls.length}`)
-    assert(Array.isArray(bomSaveCalls[0].body?.Model?.FChildItems), 'BOM Save payload must include FChildItems array')
+    const bomPayload = bomSaveCalls[0].body?.Model || bomSaveCalls[0].body?.Data
+    assert(Array.isArray(bomPayload?.FChildItems), 'BOM Save payload must include FChildItems array')
     console.log('✓ step 6b: K3 BOM Save-only upsert wrote 1 BOM with FChildItems array')
 
     // 7. SQL channel readonly probe + safety check


### PR DESCRIPTION
## Summary
- align the K3 WISE WebAPI adapter with the customer K3API package: authorityCode -> /K3API/Token/Create -> query Token on business calls
- switch the default K3 WISE save envelope from Model to Data while keeping legacy login-session mode available
- add K3 setup page auth-mode fields so operators can fill authority-code Token mode or legacy login mode
- update the offline K3 mock fixture to accept Data/Model envelopes and document K3API.zip findings without committing the package or secrets

## Verification
- node plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
- node plugins/plugin-integration-core/__tests__/http-routes-plm-k3wise-poc.test.cjs
- node plugins/plugin-integration-core/__tests__/e2e-plm-k3wise-writeback.test.cjs
- pnpm run verify:integration-k3wise:poc
- pnpm -F plugin-integration-core test
- pnpm --filter @metasheet/web exec vitest run tests/k3WiseSetup.spec.ts --watch=false
- pnpm --filter @metasheet/web build
- git diff --cached --check

## Deployment impact
- no migration
- no package-layout change
- no new runtime dependency
- existing login-session deployments can still choose login mode
- next Windows package should include this plus #1458 so integration routes are bundled and real K3API auth works