### PR TITLE
fix(dingtalk): harden no-email directory admission

### DIFF
--- a/docs/development/dingtalk-final-remote-smoke-development-20260511.md
+++ b/docs/development/dingtalk-final-remote-smoke-development-20260511.md
@@ -1,0 +1,47 @@
+# DingTalk Final Remote Smoke Development
+
+- Date: 20260511
+- Generated at: 2026-05-11T05:46:54.814Z
+- Session directory: `output/dingtalk-p4-remote-smoke-session/142-live-20260510`
+- Packet directory: `artifacts/dingtalk-staging-evidence-packet/142-live-20260510-final`
+- Status summary: `output/dingtalk-p4-remote-smoke-session/142-live-20260510/smoke-status.json`
+- Handoff summary: `artifacts/dingtalk-staging-evidence-packet/142-live-20260510-final/handoff-summary.json`
+
+## Completed Work
+
+- Ran the P4 smoke session through final strict evidence compilation.
+- Collected API/bootstrap, DingTalk-client, and manual-admin evidence.
+- Exported the final gated evidence packet.
+- Ran the publish validator and release-ready status gate.
+
+## Final Status
+
+- Session phase: **finalize**
+- Session status: **pass**
+- Final strict status: **pass**
+- Compiled status: **pass**
+- API bootstrap status: **pass**
+- Remote client status: **pass**
+- Remote smoke phase: **finalize_pending**
+- Smoke status: **release_ready**
+- Handoff status: **pass**
+- Publish status: **pass**
+
+## Required Checks
+
+| Doc | Step | Check | Status | Source | Evidence Snapshot | Manual Issues |
+| --- | --- | --- | --- | --- | --- | --- |
+| Smoke 1 | Create table and form view | `create-table-form` | pass | not_available | Redacted disposable base/sheet/form identifiers were created for the 142 smoke session. | 0 |
+| Smoke 2 | Bind two DingTalk groups | `bind-two-dingtalk-groups` | pass | not_available | Two redacted DingTalk group destinations were bound and each produced one manual test delivery. | 0 |
+| Smoke 1 | Set dingtalk_granted access | `set-form-dingtalk-granted` | pass | not_available | Form access mode was `dingtalk_granted`; one local user was allowlisted and no member group was required. | 0 |
+| Smoke 3 | Send group message with form link | `send-group-message-form-link` | pass | manual-client | Real DingTalk A/B group screenshots showed protected form link delivery; group delivery count was 2. | 0 |
+| Smoke 4 | Authorized user submit | `authorized-user-submit` | pass | manual-client | Authorized DingTalk-bound user opened the protected form and submitted successfully. | 0 |
+| Smoke 5 | Unauthorized user denied | `unauthorized-user-denied` | pass | manual-client | Unauthorized DingTalk-bound user was blocked with zero record insertion. | 0 |
+| Smoke 6 | Delivery history | `delivery-history-group-person` | pass | not_available | Delivery history contained two group deliveries and one person delivery. | 0 |
+| Smoke 7 | No-email account create/bind | `no-email-user-create-bind` | pass | manual-admin | `ddzz` was created as an enabled no-email local user and linked to the synced DingTalk identity; temporary password redacted. | 0 |
+
+## Residual Risks
+
+- Manual screenshot truthfulness still depends on operator evidence quality.
+- Raw artifacts must remain restricted to the release team unless separately reviewed.
+- Do not publish this packet externally until the human release owner reviews the final artifacts.

--- a/docs/development/dingtalk-final-remote-smoke-verification-20260511.md
+++ b/docs/development/dingtalk-final-remote-smoke-verification-20260511.md
@@ -1,0 +1,62 @@
+# DingTalk Final Remote Smoke Verification
+
+- Date: 20260511
+- Generated at: 2026-05-11T05:46:54.814Z
+
+## Commands
+
+```bash
+node scripts/ops/dingtalk-p4-smoke-status.mjs \
+  --session-dir output/dingtalk-p4-remote-smoke-session/142-live-20260510 \
+  --handoff-summary artifacts/dingtalk-staging-evidence-packet/142-live-20260510-final/handoff-summary.json \
+  --require-release-ready
+
+node scripts/ops/validate-dingtalk-staging-evidence-packet.mjs \
+  --packet-dir artifacts/dingtalk-staging-evidence-packet/142-live-20260510-final \
+  --output-json artifacts/dingtalk-staging-evidence-packet/142-live-20260510-final/publish-check.json
+
+node scripts/ops/dingtalk-p4-final-docs.mjs \
+  --session-dir output/dingtalk-p4-remote-smoke-session/142-live-20260510 \
+  --handoff-summary artifacts/dingtalk-staging-evidence-packet/142-live-20260510-final/handoff-summary.json \
+  --require-release-ready \
+  --output-dir docs/development \
+  --date 20260511
+```
+
+## Actual Results
+
+- Required checks passed: 8/8
+- Remaining checks: 0
+- Manual evidence issues: 0
+- Secret findings: 0
+- Session status: **pass**
+- Final strict status: **pass**
+- Compiled status: **pass**
+- API bootstrap status: **pass**
+- Remote client status: **pass**
+- Remote smoke phase: **finalize_pending**
+- Smoke status: **release_ready**
+- Handoff status: **pass**
+- Publish status: **pass**
+
+## Required Checks
+
+| Doc | Step | Check | Status | Source | Evidence Snapshot | Manual Issues |
+| --- | --- | --- | --- | --- | --- | --- |
+| Smoke 1 | Create table and form view | `create-table-form` | pass | not_available | Redacted disposable base/sheet/form identifiers were created for the 142 smoke session. | 0 |
+| Smoke 2 | Bind two DingTalk groups | `bind-two-dingtalk-groups` | pass | not_available | Two redacted DingTalk group destinations were bound and each produced one manual test delivery. | 0 |
+| Smoke 1 | Set dingtalk_granted access | `set-form-dingtalk-granted` | pass | not_available | Form access mode was `dingtalk_granted`; one local user was allowlisted and no member group was required. | 0 |
+| Smoke 3 | Send group message with form link | `send-group-message-form-link` | pass | manual-client | Real DingTalk A/B group screenshots showed protected form link delivery; group delivery count was 2. | 0 |
+| Smoke 4 | Authorized user submit | `authorized-user-submit` | pass | manual-client | Authorized DingTalk-bound user opened the protected form and submitted successfully. | 0 |
+| Smoke 5 | Unauthorized user denied | `unauthorized-user-denied` | pass | manual-client | Unauthorized DingTalk-bound user was blocked with zero record insertion. | 0 |
+| Smoke 6 | Delivery history | `delivery-history-group-person` | pass | not_available | Delivery history contained two group deliveries and one person delivery. | 0 |
+| Smoke 7 | No-email account create/bind | `no-email-user-create-bind` | pass | manual-admin | `ddzz` was created as an enabled no-email local user and linked to the synced DingTalk identity; temporary password redacted. | 0 |
+
+## Failures
+
+- None
+
+## Evidence Hygiene
+
+- This report is generated from redacted summaries and does not include raw tokens, full webhooks, cookies, public form tokens, or temporary passwords.
+- Final raw artifacts still require human review before external sharing.

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -2908,12 +2908,12 @@ async function applyDirectoryAccountBindInTransaction(
   const conflictingIdentityResult = await client.query(
     `SELECT local_user_id
      FROM user_external_identities
-     WHERE provider = $1
-       AND local_user_id <> $5
+     WHERE provider = $1::text
+       AND local_user_id <> $5::text
        AND (
-         external_key = $2
-         OR ($3 IS NOT NULL AND provider_union_id = $3 AND corp_id IS NOT DISTINCT FROM $4)
-         OR ($6 IS NOT NULL AND provider_open_id = $6 AND corp_id IS NOT DISTINCT FROM $4)
+         external_key = $2::text
+         OR ($3::text IS NOT NULL AND provider_union_id = $3::text AND corp_id IS NOT DISTINCT FROM $4::text)
+         OR ($6::text IS NOT NULL AND provider_open_id = $6::text AND corp_id IS NOT DISTINCT FROM $4::text)
      )
      LIMIT 1`,
     [account.provider, identityExternalKey, account.union_id, account.corp_id, localUser.id, account.open_id],
@@ -2926,10 +2926,10 @@ async function applyDirectoryAccountBindInTransaction(
     `SELECT l.directory_account_id
      FROM directory_account_links l
      JOIN directory_accounts a ON a.id = l.directory_account_id
-     WHERE a.provider = $1
-       AND l.local_user_id = $2
+     WHERE a.provider = $1::text
+       AND l.local_user_id = $2::text
        AND l.link_status = 'linked'
-       AND l.directory_account_id <> $3
+       AND l.directory_account_id <> $3::uuid
      LIMIT 1`,
     [account.provider, localUser.id, normalizedAccountId],
   )
@@ -2940,7 +2940,7 @@ async function applyDirectoryAccountBindInTransaction(
   const existingIdentityResult = await client.query(
     `SELECT id
      FROM user_external_identities
-     WHERE provider = $1 AND local_user_id = $2
+     WHERE provider = $1::text AND local_user_id = $2::text
      LIMIT 1`,
     [account.provider, localUser.id],
   )
@@ -2948,14 +2948,14 @@ async function applyDirectoryAccountBindInTransaction(
   if (existingIdentityResult.rows.length > 0) {
     await client.query(
       `UPDATE user_external_identities
-       SET external_key = $3,
-           provider_union_id = $4,
-           provider_open_id = $5,
-           corp_id = $6,
+       SET external_key = $3::text,
+           provider_union_id = $4::text,
+           provider_open_id = $5::text,
+           corp_id = $6::text,
            profile = $7::jsonb,
-           bound_by = COALESCE(bound_by, $8),
+           bound_by = COALESCE(bound_by, $8::text),
            updated_at = NOW()
-       WHERE provider = $1 AND local_user_id = $2`,
+       WHERE provider = $1::text AND local_user_id = $2::text`,
       [
         account.provider,
         localUser.id,
@@ -2981,7 +2981,7 @@ async function applyDirectoryAccountBindInTransaction(
          created_at,
          updated_at
        )
-       VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8, NOW(), NOW())`,
+       VALUES ($1::text, $2::text, $3::text, $4::text, $5::text, $6::text, $7::jsonb, $8::text, NOW(), NOW())`,
       [
         account.provider,
         identityExternalKey,
@@ -2998,7 +2998,7 @@ async function applyDirectoryAccountBindInTransaction(
   if (enableDingTalkGrant) {
     await client.query(
       `INSERT INTO user_external_auth_grants (provider, local_user_id, enabled, granted_by, created_at, updated_at)
-       VALUES ($1, $2, TRUE, $3, NOW(), NOW())
+       VALUES ($1::text, $2::text, TRUE, $3::text, NOW(), NOW())
        ON CONFLICT (provider, local_user_id)
        DO UPDATE SET enabled = TRUE, granted_by = EXCLUDED.granted_by, updated_at = NOW()`,
       [account.provider, localUser.id, normalizedAdminUserId],
@@ -3009,7 +3009,7 @@ async function applyDirectoryAccountBindInTransaction(
     `INSERT INTO directory_account_links (
        directory_account_id, local_user_id, link_status, match_strategy, reviewed_by, review_note, created_at, updated_at
      )
-     VALUES ($1, $2, 'linked', 'manual_admin', $3, NULL, NOW(), NOW())
+     VALUES ($1::uuid, $2::text, 'linked', 'manual_admin', $3::text, NULL, NOW(), NOW())
      ON CONFLICT (directory_account_id)
      DO UPDATE SET
        local_user_id = EXCLUDED.local_user_id,
@@ -3052,7 +3052,7 @@ async function createDirectoryAdmittedUserInTransaction(
     const existingUserResult = await client.query(
       `SELECT id
        FROM users
-       WHERE email = $1
+       WHERE email = $1::text
        LIMIT 1`,
       [options.email],
     )
@@ -3065,7 +3065,7 @@ async function createDirectoryAdmittedUserInTransaction(
     const existingUsernameResult = await client.query(
       `SELECT id
        FROM users
-       WHERE lower(username) = lower($1)
+       WHERE lower(username) = lower($1::text)
        LIMIT 1`,
       [options.username],
     )
@@ -3078,7 +3078,7 @@ async function createDirectoryAdmittedUserInTransaction(
     const existingMobileResult = await client.query(
       `SELECT id
        FROM users
-       WHERE mobile = $1
+       WHERE mobile = $1::text
        LIMIT 1`,
       [options.mobile],
     )
@@ -3089,7 +3089,7 @@ async function createDirectoryAdmittedUserInTransaction(
 
   await client.query(
     `INSERT INTO users (id, email, username, name, mobile, password_hash, must_change_password, role, permissions, is_active, is_admin, created_at, updated_at)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, 'user', $8::jsonb, TRUE, FALSE, NOW(), NOW())`,
+     VALUES ($1::text, $2::text, $3::text, $4::text, $5::text, $6::text, $7::boolean, 'user', $8::jsonb, TRUE, FALSE, NOW(), NOW())`,
     [userId, options.email, options.username, options.name, options.mobile, options.passwordHash, options.mustChangePassword, JSON.stringify([])],
   )
 

--- a/packages/core-backend/tests/unit/directory-sync-bind-account.test.ts
+++ b/packages/core-backend/tests/unit/directory-sync-bind-account.test.ts
@@ -701,6 +701,99 @@ describe('bindDirectoryAccount', () => {
     expect(inviteTokenMocks.issueInviteToken).not.toHaveBeenCalled()
   })
 
+  it('admits a no-email union-only DingTalk account when grant is disabled', async () => {
+    const clientQuery = vi.fn().mockResolvedValue({ rows: [] })
+    pgMocks.transaction.mockImplementation(async (handler) => handler({ query: clientQuery }))
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'account-admit-union-only',
+          integration_id: 'dir-1',
+          provider: 'dingtalk',
+          corp_id: 'dingcorp',
+          external_user_id: '0447654442691100',
+          union_id: 'union-only',
+          open_id: null,
+          external_key: 'union-only',
+          name: 'ddzz',
+          email: null,
+          mobile: null,
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          local_user_id: null,
+          local_user_email: null,
+          local_user_username: null,
+          local_user_name: null,
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          integration_id: 'dir-1',
+          provider: 'dingtalk',
+          corp_id: 'dingcorp',
+          directory_account_id: 'account-admit-union-only',
+          external_user_id: '0447654442691100',
+          union_id: 'union-only',
+          open_id: null,
+          external_key: 'union-only',
+          account_name: 'ddzz',
+          account_email: null,
+          account_mobile: null,
+          account_is_active: true,
+          account_updated_at: '2026-04-11T08:00:00.000Z',
+          link_status: 'linked',
+          match_strategy: 'manual_admin',
+          reviewed_by: 'admin-1',
+          review_note: null,
+          link_updated_at: '2026-04-11T08:00:00.000Z',
+          local_user_id: 'user-created-union-only',
+          local_user_email: null,
+          local_user_username: 'ddzz142',
+          local_user_name: 'ddzz',
+          department_paths: ['DingTalk CN'],
+        }],
+      })
+
+    const result = await admitDirectoryAccountUser('account-admit-union-only', {
+      adminUserId: 'admin-1',
+      name: 'ddzz',
+      username: 'ddzz142',
+      enableDingTalkGrant: false,
+    })
+
+    const createUserCall = clientQuery.mock.calls.find((entry) => String(entry[0]).includes('INSERT INTO users'))
+    const conflictIdentityCall = clientQuery.mock.calls.find((entry) => String(entry[0]).includes('SELECT local_user_id'))
+    const conflictLinkCall = clientQuery.mock.calls.find((entry) => String(entry[0]).includes('JOIN directory_accounts'))
+    const linkCall = clientQuery.mock.calls.find((entry) => String(entry[0]).includes('INSERT INTO directory_account_links'))
+
+    expect(createUserCall?.[1]).toEqual(expect.arrayContaining([
+      null,
+      'ddzz142',
+      'ddzz',
+      null,
+      JSON.stringify([]),
+    ]))
+    expect(String(conflictIdentityCall?.[0])).toContain('$3::text IS NOT NULL')
+    expect(String(conflictIdentityCall?.[0])).toContain('provider_union_id = $3::text')
+    expect(String(conflictIdentityCall?.[0])).toContain('$6::text IS NOT NULL')
+    expect(String(conflictLinkCall?.[0])).toContain('l.directory_account_id <> $3::uuid')
+    expect(String(linkCall?.[0])).toContain('VALUES ($1::uuid, $2::text')
+    expect(clientQuery).not.toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO user_external_auth_grants'),
+      expect.anything(),
+    )
+    expect(result).toMatchObject({
+      user: {
+        email: null,
+        username: 'ddzz142',
+        mobile: null,
+      },
+      inviteToken: null,
+    })
+  })
+
   it('rejects manual admission with DingTalk grant when the directory account is missing openId', async () => {
     pgMocks.query
       .mockResolvedValueOnce({


### PR DESCRIPTION
## Summary
- Import the final 142 DingTalk remote smoke development and verification MD for the 2026-05-11 live acceptance.
- Add explicit PostgreSQL casts in DingTalk directory bind/admit SQL so no-email / union-only admission paths do not fail with unknown parameter types.
- Add a regression test for the ddzz-style no-email, union-only DingTalk account admission path with grant disabled.

## Verification
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/directory-sync-bind-account.test.ts`
- `pnpm --filter @metasheet/core-backend build`
- `git diff --check`
- Redaction scan on the two final MD files and touched DingTalk backend/test files: no token/webhook/JWT/SEC/password value matches.

## Notes
- The tracked MD files use redacted summaries only; the raw 142 evidence packet remains restricted to release operators.
- The live 142 smoke session already reached `release_ready`, with 8/8 checks complete and `secretFindingCount=0` in the closeout summary.
