### PR TITLE
feat(multitable): add email transport readiness gate

### DIFF
--- a/docs/development/multitable-feishu-phase2-todo-20260509.md
+++ b/docs/development/multitable-feishu-phase2-todo-20260509.md
@@ -4,6 +4,7 @@
 
 - Baseline: `origin/main@c74c15a2b` after PR #1446.
 - Refreshed baseline before merge: `origin/main@3a484622c`.
+- B1 implementation baseline: `origin/main@013797fc3` after PR #1448, K3 token auth #1459, and DingTalk no-email admission #1460.
 - Prior RC: `multitable-rc-20260508b-08c6036284`.
 - Goal: continue Feishu-parity development after the signed RC without reopening the RC smoke scope.
 - Rule: every completed item must include PR, merge commit, development MD, verification MD, and verification summary.
@@ -36,6 +37,8 @@ Mark an item complete only after all are true:
 
 Owner recommendation: Claude can implement; Codex reviews.
 
+Status: complete. PR #1449 `test(multitable): audit-only test coverage for longText field` merged at `2082f169e879e088ffd09f7e1f3cc5124b3f4dc7`; current main already has end-to-end `longText` implementation and coverage.
+
 ### Objective
 
 Add a native `longText` field type for multi-line plain text. This is not rich text, not Markdown rendering, and not a full collaborative document editor. It closes the high-frequency Feishu parity gap where users need notes, descriptions, and multi-line imported content.
@@ -65,14 +68,14 @@ Likely frontend files:
 
 ### Requirements
 
-- [ ] `longText`, `long_text`, and `multiline` normalize to canonical `longText`.
-- [ ] Stored raw value is a string; non-string values sanitize consistently with string field behavior unless validation explicitly rejects.
-- [ ] Grid editor uses `<textarea>` or equivalent multi-line control.
-- [ ] Renderer preserves newlines with `white-space: pre-wrap` or equivalent.
-- [ ] Form view and record drawer render/edit long text without collapsing newlines.
-- [ ] Import/export preserves embedded newlines.
-- [ ] OpenAPI field type enum includes `longText`.
-- [ ] Existing `string` field behavior remains unchanged.
+- [x] `longText`, `long_text`, and `multiline` normalize to canonical `longText`.
+- [x] Stored raw value is a string; non-string values sanitize consistently with string field behavior unless validation explicitly rejects.
+- [x] Grid editor uses `<textarea>` or equivalent multi-line control.
+- [x] Renderer preserves newlines with `white-space: pre-wrap` or equivalent.
+- [x] Form view and record drawer render/edit long text without collapsing newlines.
+- [x] Import/export preserves embedded newlines.
+- [x] OpenAPI field type enum includes `longText`.
+- [x] Existing `string` field behavior remains unchanged.
 
 ### Explicit Non-Goals
 
@@ -82,12 +85,12 @@ Likely frontend files:
 
 ### Minimum Tests
 
-- [ ] Backend codec test for aliases and newline preservation.
-- [ ] Backend import/export test for embedded newlines.
-- [ ] Frontend renderer test for newline display.
-- [ ] Frontend editor test that edit/save preserves multi-line value.
-- [ ] Field manager test for creating a longText field.
-- [ ] OpenAPI parity test if schema output changes.
+- [x] Backend codec test for aliases and newline preservation.
+- [x] Backend import/export test for embedded newlines.
+- [x] Frontend renderer test for newline display.
+- [x] Frontend editor test that edit/save preserves multi-line value.
+- [x] Field manager test for creating a longText field.
+- [x] OpenAPI parity test if schema output changes.
 
 ### Suggested PR
 
@@ -98,6 +101,14 @@ Likely frontend files:
 ## Lane B - Real Email Transport Gate
 
 Owner recommendation: Codex should implement or directly review because this touches credentials, logs, and staging gates.
+
+Status: B1 implemented in PR #1461 on branch `codex/multitable-phase2-email-transport-gate-20260511`. B2 real SMTP/provider delivery remains explicitly deferred.
+
+B1 artifacts:
+
+- Development MD: `docs/development/multitable-phase2-lane-b1-email-transport-gate-development-20260511.md`
+- Verification MD: `docs/development/multitable-phase2-lane-b1-email-transport-gate-verification-20260511.md`
+- Command: `pnpm verify:multitable-email:readiness`
 
 ### Objective
 
@@ -125,13 +136,13 @@ Likely frontend files:
 
 ### Requirements
 
-- [ ] Default local/dev behavior remains mock unless an explicit env enables real email transport.
-- [ ] Missing SMTP/provider env reports `blocked`, not `pass`, in a release gate.
-- [ ] Logs and artifacts redact SMTP host credentials, usernames, passwords, tokens, recipient lists if configured sensitive, and bearer tokens.
-- [ ] Automation logs keep the existing flat logs API contract used by RC smoke.
-- [ ] Failed transport returns a controlled failed step, not a backend crash.
-- [ ] Staging can run a no-send readiness check without sending real email.
-- [ ] Real-send smoke requires an explicit `CONFIRM_SEND_EMAIL=1` style guard.
+- [x] Default local/dev behavior remains mock unless an explicit env enables real email transport.
+- [x] Missing SMTP/provider env reports `blocked`, not `pass`, in a release gate.
+- [x] Logs and artifacts redact SMTP host credentials, usernames, passwords, tokens, recipient lists if configured sensitive, and bearer tokens.
+- [x] Automation logs keep the existing flat logs API contract used by RC smoke.
+- [x] Failed transport returns a controlled failed step, not a backend crash.
+- [x] Staging can run a no-send readiness check without sending real email.
+- [x] Real-send smoke requires an explicit `CONFIRM_SEND_EMAIL=1` style guard.
 
 ### Explicit Non-Goals
 
@@ -141,11 +152,12 @@ Likely frontend files:
 
 ### Minimum Tests
 
-- [ ] Unit test: mock channel remains default when env is absent.
-- [ ] Unit test: enabled real transport with missing required env returns readiness `blocked`.
-- [ ] Unit test: transport error becomes failed automation step and execution log persists.
-- [ ] Redaction test: logs/artifacts do not contain SMTP credentials or bearer tokens.
+- [x] Unit test: mock channel remains default when env is absent.
+- [x] Unit test: enabled real transport with missing required env returns readiness `blocked`.
+- [x] Unit test: transport error becomes failed automation step and execution log persists.
+- [x] Redaction test: logs/artifacts do not contain SMTP credentials or bearer tokens.
 - [ ] Existing `multitable-rc-automation-send-email-smoke` still passes in mock mode.
+  - Local live-stack Playwright was not rerun in B1; the RC/staging smoke path is unchanged and default mock behavior is covered by unit tests.
 
 ### Suggested PR Split
 

--- a/docs/development/multitable-phase2-lane-b1-email-transport-gate-development-20260511.md
+++ b/docs/development/multitable-phase2-lane-b1-email-transport-gate-development-20260511.md
@@ -1,0 +1,116 @@
+# Multitable Phase 2 Lane B1 Email Transport Gate - Development
+
+> Date: 2026-05-11
+> Branch: `codex/multitable-phase2-email-transport-gate-20260511`
+> PR: #1461
+> Baseline: `origin/main@013797fc3`
+> Scope: env-gated readiness for `send_email` automation transport
+
+## Context
+
+Phase 2 Lane B exists because the RC proved the `send_email` automation wire path through the default mock `EmailNotificationChannel`, not real SMTP/provider delivery.
+
+Before coding this slice, Lane A was rechecked and found complete in main:
+
+- PR #1449 merged audit-only `longText` coverage at `2082f169e`.
+- `longText` exists in backend codecs, OpenAPI, frontend editors/renderers/forms/drawer, XLSX tests, and focused frontend tests.
+
+So this branch pivots to Lane B1, the smallest security-sensitive prerequisite for future real email delivery.
+
+## What Changed
+
+### Readiness Resolver
+
+Added `packages/core-backend/src/services/email-transport-readiness.ts`.
+
+It resolves:
+
+- `MULTITABLE_EMAIL_TRANSPORT`
+  - unset / `mock` / `disabled` / `off` -> mock mode
+  - `smtp` -> SMTP readiness mode
+  - any other value -> blocked unsupported mode
+- `MULTITABLE_EMAIL_REAL_SEND_SMOKE`
+- `CONFIRM_SEND_EMAIL`
+- required SMTP env when SMTP mode is enabled:
+  - `MULTITABLE_EMAIL_SMTP_HOST`
+  - `MULTITABLE_EMAIL_SMTP_PORT`
+  - `MULTITABLE_EMAIL_SMTP_USER`
+  - `MULTITABLE_EMAIL_SMTP_PASSWORD`
+  - `MULTITABLE_EMAIL_SMTP_FROM`
+
+The resolver returns `status: "pass" | "blocked"` and only redacted env values. It never sends email.
+
+### Runtime Guard
+
+Updated `EmailNotificationChannel` in `packages/core-backend/src/services/NotificationService.ts`.
+
+Behavior:
+
+- Default/mock mode remains the existing no-real-send behavior.
+- Explicit SMTP mode with missing env returns a controlled failed notification result through the existing channel error path.
+- Explicit SMTP mode with complete env still fails controlled with `SMTP email transport is configured but not implemented in this build`; B2 must add the actual provider implementation before real sends can succeed.
+- Mock-mode logging no longer prints raw recipient or subject text.
+
+This prevents a future deployment from setting `MULTITABLE_EMAIL_TRANSPORT=smtp` and silently receiving mock `sent` results.
+
+### Ops Gate
+
+Added:
+
+- `scripts/ops/multitable-email-transport-readiness.ts`
+- `scripts/ops/multitable-email-transport-readiness.test.mjs`
+- root script `pnpm verify:multitable-email:readiness`
+
+Default outputs:
+
+```text
+output/multitable-email-transport-readiness/report.json
+output/multitable-email-transport-readiness/report.md
+```
+
+Exit codes:
+
+- `0` - readiness passes.
+- `2` - readiness is blocked by configuration.
+- `1` - script/runtime error.
+
+The gate is intentionally no-send. A real-send smoke path must be a later B2/B3 slice and must set `MULTITABLE_EMAIL_REAL_SEND_SMOKE=1` plus `CONFIRM_SEND_EMAIL=1`.
+
+## Design Decisions
+
+### Decision 1 - No SMTP dependency in B1
+
+This branch does not add `nodemailer`, SendGrid, SES, Mailgun, or any provider dependency. B1 is the seam and release gate only.
+
+Reason: the security risk is not the SMTP call itself; the immediate gap is that staging/release gates had no explicit way to distinguish "mock wire works" from "real transport is configured".
+
+### Decision 2 - Explicit SMTP mode fails closed until B2
+
+If SMTP mode is enabled before a provider is implemented, `EmailNotificationChannel` returns a failed result instead of mock success.
+
+Reason: false `sent` is worse than a visible failed automation step.
+
+### Decision 3 - Redacted artifacts by construction
+
+The readiness report stores only `<set>`, `<unset>`, `true`, `false`, or simple non-secret values like the SMTP port. It does not render SMTP host URLs, usernames, passwords, bearer tokens, JWTs, or recipient lists.
+
+### Decision 4 - Keep existing automation logs API unchanged
+
+No route or schema changes were made. The existing flat automation logs API remains the contract used by RC smoke.
+
+## Non-Goals
+
+- No real SMTP/provider send.
+- No dev-only email history endpoint.
+- No recipient/body inspection endpoint.
+- No DingTalk behavior changes.
+- No frontend editor changes.
+
+## Follow-Up
+
+B2 can now add the actual SMTP/provider channel behind the same env names. Required follow-up checks:
+
+- real provider dependency and deployment policy approved;
+- explicit real-send smoke with `CONFIRM_SEND_EMAIL=1`;
+- no raw recipient, subject/body, credential, bearer token, or JWT leakage in logs/artifacts;
+- automation execution log persists failed transport steps.

--- a/docs/development/multitable-phase2-lane-b1-email-transport-gate-verification-20260511.md
+++ b/docs/development/multitable-phase2-lane-b1-email-transport-gate-verification-20260511.md
@@ -1,0 +1,164 @@
+# Multitable Phase 2 Lane B1 Email Transport Gate - Verification
+
+> Date: 2026-05-11
+> Branch: `codex/multitable-phase2-email-transport-gate-20260511`
+> PR: #1461
+> Baseline: `origin/main@013797fc3`
+> Scope: focused verification for env-gated `send_email` transport readiness
+
+## Source Recon
+
+Confirmed current `send_email` state:
+
+```bash
+rg -n "send_email|EmailNotificationChannel|SMTP|notificationStatus" \
+  packages/core-backend/src packages/core-backend/tests scripts docs/development
+```
+
+Findings:
+
+- `send_email` is wired through automation validation, executor, frontend editor, RC Playwright smoke, and staging API harness.
+- `EmailNotificationChannel` was still mock-only.
+- There is no SMTP/provider dependency in the workspace.
+- Existing RC smoke asserts `notificationStatus === "sent"` from mock delivery, not mailbox receipt.
+
+Confirmed Lane A is already complete:
+
+```bash
+rg -n "longText|long text|#1449" \
+  docs/development packages/core-backend/src apps/web/src packages/openapi/src/base.yml \
+  apps/web/tests packages/core-backend/tests/unit
+```
+
+Result: PR #1449 audit coverage is merged, and `longText` is present across backend, frontend, OpenAPI, XLSX, and tests.
+
+## Tests Run
+
+### Readiness resolver + channel gate
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/email-transport-readiness.test.ts --reporter=dot
+```
+
+Result:
+
+```text
+Test Files  1 passed (1)
+Tests       8 passed (8)
+```
+
+Covered:
+
+- mock mode is default;
+- SMTP mode with missing provider env is `blocked`;
+- complete SMTP env passes readiness without sending;
+- real-send smoke requires `CONFIRM_SEND_EMAIL=1`;
+- markdown rendering redacts SMTP secrets and bearer-like values;
+- `EmailNotificationChannel` still sends through mock mode by default;
+- explicit SMTP mode fails controlled until B2 implements the provider.
+
+### Automation executor regression
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/automation-v1.test.ts --reporter=dot
+```
+
+Result:
+
+```text
+Test Files  1 passed (1)
+Tests       132 passed (132)
+```
+
+New assertion:
+
+- `send_email` transport failure becomes a failed automation step with the failed notification result preserved in step output.
+- `AutomationService.executeRule()` still records that failed execution through the log service.
+
+### Ops script tests
+
+```bash
+node --test scripts/ops/multitable-email-transport-readiness.test.mjs
+```
+
+Result:
+
+```text
+tests 4
+pass 4
+fail 0
+```
+
+Covered:
+
+- default package/script path passes in mock mode;
+- SMTP mode with incomplete env exits `2`;
+- generated markdown/JSON/stdout/stderr do not contain raw SMTP URL credentials, tokens, password values, or private sender addresses;
+- `pnpm verify:multitable-email:readiness` works.
+
+### Manual script probes
+
+```bash
+pnpm exec tsx scripts/ops/multitable-email-transport-readiness.ts >/tmp/email-readiness-mock.out
+
+set +e
+MULTITABLE_EMAIL_TRANSPORT=smtp \
+  pnpm exec tsx scripts/ops/multitable-email-transport-readiness.ts \
+  >/tmp/email-readiness-blocked.out
+code=$?
+set -e
+printf 'blocked_exit=%s\n' "$code"
+grep -q 'smtp-password-secret\|Bearer raw-token-value\|ops-private@example.com' \
+  /tmp/email-readiness-blocked.out && echo 'secret_leak' || echo 'no_secret_leak'
+```
+
+Result:
+
+```text
+blocked_exit=2
+no_secret_leak
+```
+
+### Type check
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
+```
+
+Result: pass.
+
+### Playwright smoke parse
+
+```bash
+pnpm --filter @metasheet/core-backend exec playwright test \
+  --config tests/e2e/playwright.config.ts \
+  tests/e2e/multitable-automation-send-email-smoke.spec.ts --list
+```
+
+Result:
+
+```text
+Total: 3 tests in 1 file
+```
+
+## Non-Verification
+
+- No real email was sent.
+- No SMTP/provider connection was attempted.
+- The local Playwright RC smoke was not rerun against a live dev stack in this branch; the default mock path is covered by the new channel unit test and the existing RC/staging harness remains unchanged.
+
+## Risk Review
+
+| Risk | Verification |
+|---|---|
+| SMTP env missing but release gate reports pass | Script test asserts exit `2` and `status: "blocked"`. |
+| Secrets leak into reports | Unit and script tests assert raw SMTP URL credentials, token, password, and sender address are absent. |
+| Mock mode regresses | Channel unit test asserts default mock send still returns `sent`. |
+| Explicit SMTP mode falsely reports `sent` before B2 | Channel unit test asserts controlled failed result. |
+| Automation executor crashes on transport failure | `automation-v1` regression asserts failed step output instead. |
+
+## Result
+
+Lane B1 is ready for review. It adds a safe readiness seam and no-send release gate for future real email transport work while preserving default mock behavior.

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "verify:multitable-pilot:staging": "bash scripts/ops/multitable-pilot-staging.sh",
     "verify:multitable-rc:staging": "node scripts/verify-multitable-rc-staging-smoke.mjs",
     "verify:multitable-rc:ui": "bash scripts/verify-multitable-rc-ui-smoke.sh",
+    "verify:multitable-email:readiness": "tsx scripts/ops/multitable-email-transport-readiness.ts",
     "verify:multitable-pilot:staging:test": "node --test scripts/ops/multitable-pilot-staging.test.mjs",
     "verify:multitable-pilot:readiness": "node scripts/ops/multitable-pilot-readiness.mjs",
     "verify:multitable-pilot:readiness:test": "node --test scripts/ops/multitable-pilot-readiness.test.mjs",

--- a/packages/core-backend/src/services/NotificationService.ts
+++ b/packages/core-backend/src/services/NotificationService.ts
@@ -27,6 +27,11 @@ import {
   DingTalkRobotResponseError,
   validateDingTalkRobotResponse,
 } from '../integrations/dingtalk/robot'
+import {
+  resolveEmailTransportReadiness,
+  type EmailTransportEnv,
+  type EmailTransportReadinessReport,
+} from './email-transport-readiness'
 
 /**
  * Email notification payload
@@ -159,10 +164,12 @@ export class EmailNotificationChannel implements NotificationChannel {
   type = 'email' as const
   config: NotificationChannelConfig
   private logger: Logger
+  private readiness: EmailTransportReadinessReport
 
   constructor(config: NotificationChannelConfig) {
     this.config = config
     this.logger = new Logger('EmailChannel')
+    this.readiness = resolveEmailTransportReadiness(resolveEmailTransportEnv(config))
   }
 
   async sender(notification: Notification, recipients: NotificationRecipient[]): Promise<NotificationResult> {
@@ -204,12 +211,36 @@ export class EmailNotificationChannel implements NotificationChannel {
   }
 
   private async sendEmail(params: EmailPayload): Promise<void> {
-    // 实际邮件发送实现
-    this.logger.info(`Sending email to ${params.to}: ${params.subject}`)
+    if (this.readiness.mode === 'smtp') {
+      if (!this.readiness.ok) {
+        throw new Error(`SMTP email transport blocked: ${this.readiness.messages.join(' ')}`)
+      }
+      throw new Error('SMTP email transport is configured but not implemented in this build')
+    }
+    if (this.readiness.mode === 'unsupported') {
+      throw new Error(`Email transport configuration is unsupported: ${this.readiness.messages.join(' ')}`)
+    }
+
+    this.logger.info('Mock email channel accepted notification', {
+      channel: 'email',
+      transport: 'mock',
+      metadata: params.metadata,
+    })
 
     // 模拟异步发送
     await new Promise(resolve => setTimeout(resolve, 100))
   }
+}
+
+function resolveEmailTransportEnv(config: NotificationChannelConfig): EmailTransportEnv {
+  const candidate = config.env
+  if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) return process.env
+
+  const env: EmailTransportEnv = {}
+  for (const [key, value] of Object.entries(candidate as Record<string, unknown>)) {
+    if (typeof value === 'string') env[key] = value
+  }
+  return env
 }
 
 /**

--- a/packages/core-backend/src/services/email-transport-readiness.ts
+++ b/packages/core-backend/src/services/email-transport-readiness.ts
@@ -1,0 +1,153 @@
+export const EMAIL_TRANSPORT_ENV = 'MULTITABLE_EMAIL_TRANSPORT'
+export const EMAIL_REAL_SEND_SMOKE_ENV = 'MULTITABLE_EMAIL_REAL_SEND_SMOKE'
+export const EMAIL_CONFIRM_SEND_ENV = 'CONFIRM_SEND_EMAIL'
+
+export const EMAIL_SMTP_REQUIRED_ENV = [
+  'MULTITABLE_EMAIL_SMTP_HOST',
+  'MULTITABLE_EMAIL_SMTP_PORT',
+  'MULTITABLE_EMAIL_SMTP_USER',
+  'MULTITABLE_EMAIL_SMTP_PASSWORD',
+  'MULTITABLE_EMAIL_SMTP_FROM',
+] as const
+
+export type EmailTransportMode = 'mock' | 'smtp' | 'unsupported'
+export type EmailTransportReadinessStatus = 'pass' | 'blocked'
+
+export interface EmailTransportEnvStatus {
+  name: string
+  present: boolean
+  value: string
+}
+
+export interface EmailTransportReadinessReport {
+  ok: boolean
+  status: EmailTransportReadinessStatus
+  mode: EmailTransportMode
+  transportEnv: EmailTransportEnvStatus
+  realSendRequested: boolean
+  confirmSend: boolean
+  requiredEnv: EmailTransportEnvStatus[]
+  messages: string[]
+}
+
+export type EmailTransportEnv = Record<string, string | undefined>
+
+function envString(env: EmailTransportEnv, name: string): string {
+  const value = env[name]
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function isTruthyEnv(value: string): boolean {
+  return ['1', 'true', 'yes', 'on'].includes(value.trim().toLowerCase())
+}
+
+function resolveMode(value: string): EmailTransportMode {
+  if (!value) return 'mock'
+  const normalized = value.toLowerCase()
+  if (normalized === 'mock' || normalized === 'disabled' || normalized === 'off') return 'mock'
+  if (normalized === 'smtp') return 'smtp'
+  return 'unsupported'
+}
+
+export function redactEmailTransportValue(name: string, value: string): string {
+  if (!value) return '<unset>'
+  const upper = name.toUpperCase()
+  if (name === EMAIL_TRANSPORT_ENV) return resolveMode(value)
+  if (name === EMAIL_REAL_SEND_SMOKE_ENV || name === EMAIL_CONFIRM_SEND_ENV) {
+    return isTruthyEnv(value) ? 'true' : 'false'
+  }
+  if (upper.endsWith('_PORT') && /^\d+$/.test(value)) return value
+  if (upper.endsWith('_SECURE')) return isTruthyEnv(value) ? 'true' : 'false'
+  return '<set>'
+}
+
+function envStatus(env: EmailTransportEnv, name: string): EmailTransportEnvStatus {
+  const value = envString(env, name)
+  return {
+    name,
+    present: value.length > 0,
+    value: redactEmailTransportValue(name, value),
+  }
+}
+
+export function resolveEmailTransportReadiness(
+  env: EmailTransportEnv = process.env,
+): EmailTransportReadinessReport {
+  const transportEnv = envStatus(env, EMAIL_TRANSPORT_ENV)
+  const mode = resolveMode(envString(env, EMAIL_TRANSPORT_ENV))
+  const realSendRequested = isTruthyEnv(envString(env, EMAIL_REAL_SEND_SMOKE_ENV))
+  const confirmSend = isTruthyEnv(envString(env, EMAIL_CONFIRM_SEND_ENV))
+  const requiredEnv = mode === 'smtp'
+    ? EMAIL_SMTP_REQUIRED_ENV.map((name) => envStatus(env, name))
+    : []
+  const missing = requiredEnv.filter((item) => !item.present).map((item) => item.name)
+  const messages: string[] = []
+
+  if (mode === 'unsupported') {
+    messages.push(`${EMAIL_TRANSPORT_ENV} must be "mock" or "smtp".`)
+  } else if (mode === 'mock') {
+    messages.push('Email transport is mock; no real email will be sent.')
+  } else {
+    if (missing.length > 0) {
+      messages.push(`SMTP transport is enabled but missing required env: ${missing.join(', ')}.`)
+    } else {
+      messages.push('SMTP transport env is present; readiness check does not send email.')
+    }
+  }
+
+  if (realSendRequested && !confirmSend) {
+    messages.push(`${EMAIL_REAL_SEND_SMOKE_ENV}=1 requires ${EMAIL_CONFIRM_SEND_ENV}=1.`)
+  }
+
+  const blocked = mode === 'unsupported' || missing.length > 0 || (realSendRequested && !confirmSend)
+
+  return {
+    ok: !blocked,
+    status: blocked ? 'blocked' : 'pass',
+    mode,
+    transportEnv,
+    realSendRequested,
+    confirmSend,
+    requiredEnv,
+    messages,
+  }
+}
+
+export function renderEmailTransportReadinessMarkdown(report: EmailTransportReadinessReport): string {
+  const lines = [
+    '# Multitable Email Transport Readiness',
+    '',
+    `- Status: \`${report.status}\``,
+    `- Mode: \`${report.mode}\``,
+    `- Real-send smoke requested: \`${report.realSendRequested ? 'yes' : 'no'}\``,
+    `- Confirm-send guard: \`${report.confirmSend ? 'set' : 'unset'}\``,
+    '',
+    '## Messages',
+    '',
+    ...report.messages.map((message) => `- ${message}`),
+    '',
+    '## Environment',
+    '',
+    '| Name | Present | Redacted value |',
+    '| --- | --- | --- |',
+    `| ${report.transportEnv.name} | ${report.transportEnv.present ? 'yes' : 'no'} | \`${report.transportEnv.value}\` |`,
+    `| ${EMAIL_REAL_SEND_SMOKE_ENV} | ${report.realSendRequested ? 'yes' : 'no'} | \`${report.realSendRequested ? 'true' : 'false'}\` |`,
+    `| ${EMAIL_CONFIRM_SEND_ENV} | ${report.confirmSend ? 'yes' : 'no'} | \`${report.confirmSend ? 'true' : 'false'}\` |`,
+  ]
+
+  if (report.requiredEnv.length > 0) {
+    lines.push(...report.requiredEnv.map((item) =>
+      `| ${item.name} | ${item.present ? 'yes' : 'no'} | \`${item.value}\` |`,
+    ))
+  }
+
+  lines.push(
+    '',
+    '## Notes',
+    '',
+    '- This gate validates transport configuration only; it never sends real email.',
+    '- Raw SMTP credentials, bearer tokens, JWTs, and recipient lists are not rendered in this report.',
+  )
+
+  return `${lines.join('\n')}\n`
+}

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -446,6 +446,44 @@ describe('AutomationExecutor', () => {
     }))
   })
 
+  it('converts send_email transport failures into failed automation steps', async () => {
+    const send = vi.fn(async () => ({
+      id: 'notif_1',
+      status: 'failed' as const,
+      failedReason: 'SMTP email transport blocked: missing provider env',
+    }))
+    deps = createMockDeps({ notificationService: { send } })
+    executor = new AutomationExecutor(deps)
+
+    const rule = createMockRule({
+      actions: [{
+        type: 'send_email',
+        config: {
+          recipients: ['ops@example.com'],
+          subjectTemplate: 'Record {{record.title}} changed',
+          bodyTemplate: 'Status: {{record.status}}',
+        },
+      }],
+    })
+    const result = await executor.execute(rule, {
+      recordId: 'r1',
+      data: { title: 'Incident', status: 'open' },
+      sheetId: 'sheet_1',
+      actorId: 'user_1',
+    })
+
+    expect(result.status).toBe('failed')
+    expect(result.steps[0]).toEqual(expect.objectContaining({
+      actionType: 'send_email',
+      status: 'failed',
+      error: 'SMTP email transport blocked: missing provider env',
+    }))
+    expect(result.steps[0].output).toEqual(expect.objectContaining({
+      status: 'failed',
+      failedReason: 'SMTP email transport blocked: missing provider env',
+    }))
+  })
+
   it('fails send_email with no recipients', async () => {
     const send = vi.fn(async () => ({ id: 'notif_1', status: 'sent' as const }))
     deps = createMockDeps({ notificationService: { send } })
@@ -2280,6 +2318,47 @@ describe('AutomationService — Rule CRUD', () => {
     expect(logFailure).toHaveBeenCalledOnce()
     expect(execution.status).toBe('success')
     expect(execution.steps).toEqual([])
+  })
+
+  it('executeRule records failed send_email transport executions', async () => {
+    const send = vi.fn(async () => ({
+      id: 'notif_1',
+      status: 'failed' as const,
+      failedReason: 'SMTP email transport blocked: missing provider env',
+    }))
+    service = new AutomationService(eventBus, makeMockDb() as never, queryFn, undefined, null, {}, { send })
+    const logSpy = vi.spyOn(service.logs, 'record').mockResolvedValueOnce()
+
+    const execution = await service.executeRule(
+      createMockRule({
+        actions: [{
+          type: 'send_email',
+          config: {
+            recipients: ['ops@example.com'],
+            subjectTemplate: 'Record {{record.title}} changed',
+            bodyTemplate: 'Status: {{record.status}}',
+          },
+        }],
+      }),
+      {
+        sheetId: 'sheet_1',
+        recordId: 'rec_1',
+        data: { title: 'Incident', status: 'open' },
+        _triggeredBy: 'test',
+      },
+    )
+
+    expect(execution.status).toBe('failed')
+    expect(logSpy).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'failed',
+      steps: [
+        expect.objectContaining({
+          actionType: 'send_email',
+          status: 'failed',
+          error: 'SMTP email transport blocked: missing provider env',
+        }),
+      ],
+    }))
   })
 
   it('getRule returns null when not found', async () => {

--- a/packages/core-backend/tests/unit/email-transport-readiness.test.ts
+++ b/packages/core-backend/tests/unit/email-transport-readiness.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi } from 'vitest'
+import { Logger } from '../../src/core/logger'
+import {
+  EMAIL_CONFIRM_SEND_ENV,
+  EMAIL_REAL_SEND_SMOKE_ENV,
+  EMAIL_SMTP_REQUIRED_ENV,
+  EMAIL_TRANSPORT_ENV,
+  redactEmailTransportValue,
+  renderEmailTransportReadinessMarkdown,
+  resolveEmailTransportReadiness,
+} from '../../src/services/email-transport-readiness'
+import { EmailNotificationChannel } from '../../src/services/NotificationService'
+
+const COMPLETE_SMTP_ENV = {
+  [EMAIL_TRANSPORT_ENV]: 'smtp',
+  MULTITABLE_EMAIL_SMTP_HOST: 'smtp.example.com',
+  MULTITABLE_EMAIL_SMTP_PORT: '587',
+  MULTITABLE_EMAIL_SMTP_USER: 'smtp-user',
+  MULTITABLE_EMAIL_SMTP_PASSWORD: 'smtp-password-secret',
+  MULTITABLE_EMAIL_SMTP_FROM: 'ops@example.com',
+}
+
+describe('email transport readiness', () => {
+  it('keeps mock email transport as the default', () => {
+    const report = resolveEmailTransportReadiness({})
+
+    expect(report.ok).toBe(true)
+    expect(report.status).toBe('pass')
+    expect(report.mode).toBe('mock')
+    expect(report.requiredEnv).toEqual([])
+    expect(report.messages.join('\n')).toContain('mock')
+  })
+
+  it('blocks smtp transport when required provider env is missing', () => {
+    const report = resolveEmailTransportReadiness({
+      [EMAIL_TRANSPORT_ENV]: 'smtp',
+      MULTITABLE_EMAIL_SMTP_HOST: 'smtp.example.com',
+    })
+
+    expect(report.ok).toBe(false)
+    expect(report.status).toBe('blocked')
+    for (const name of EMAIL_SMTP_REQUIRED_ENV.filter((name) => name !== 'MULTITABLE_EMAIL_SMTP_HOST')) {
+      expect(report.messages.join('\n')).toContain(name)
+    }
+  })
+
+  it('passes smtp readiness when all provider env is present without sending email', () => {
+    const report = resolveEmailTransportReadiness(COMPLETE_SMTP_ENV)
+
+    expect(report.ok).toBe(true)
+    expect(report.status).toBe('pass')
+    expect(report.mode).toBe('smtp')
+    expect(report.messages.join('\n')).toContain('does not send email')
+  })
+
+  it('requires explicit confirmation for real-send smoke requests', () => {
+    const report = resolveEmailTransportReadiness({
+      ...COMPLETE_SMTP_ENV,
+      [EMAIL_REAL_SEND_SMOKE_ENV]: '1',
+    })
+
+    expect(report.ok).toBe(false)
+    expect(report.status).toBe('blocked')
+    expect(report.messages.join('\n')).toContain(`${EMAIL_CONFIRM_SEND_ENV}=1`)
+  })
+
+  it('redacts smtp values and bearer-like secrets from markdown reports', () => {
+    const report = resolveEmailTransportReadiness({
+      ...COMPLETE_SMTP_ENV,
+      MULTITABLE_EMAIL_SMTP_HOST: 'smtp://user:pass@smtp.example.com?token=secret-token',
+      MULTITABLE_EMAIL_SMTP_PASSWORD: 'Bearer raw-token-value',
+      MULTITABLE_EMAIL_SMTP_FROM: 'ops-private@example.com',
+      [EMAIL_REAL_SEND_SMOKE_ENV]: '1',
+      [EMAIL_CONFIRM_SEND_ENV]: '1',
+    })
+    const markdown = renderEmailTransportReadinessMarkdown(report)
+
+    expect(markdown).not.toContain('smtp://user:pass@smtp.example.com')
+    expect(markdown).not.toContain('secret-token')
+    expect(markdown).not.toContain('raw-token-value')
+    expect(markdown).not.toContain('ops-private@example.com')
+    expect(markdown).toContain('<set>')
+  })
+
+  it('redacts individual values defensively', () => {
+    expect(redactEmailTransportValue('MULTITABLE_EMAIL_SMTP_PASSWORD', 'Bearer abc.def.ghi')).toBe('<set>')
+    expect(redactEmailTransportValue('MULTITABLE_EMAIL_SMTP_PORT', '587')).toBe('587')
+  })
+})
+
+describe('EmailNotificationChannel transport gate', () => {
+  it('sends through the mock channel when transport env is absent', async () => {
+    vi.spyOn(Logger.prototype, 'info').mockImplementation(() => undefined)
+    const channel = new EmailNotificationChannel({ env: {} })
+
+    const result = await channel.sender(
+      {
+        channel: 'email',
+        subject: 'Mock subject',
+        content: 'Mock body',
+        recipients: [{ id: 'ops@example.com', type: 'email' }],
+      },
+      [{ id: 'ops@example.com', type: 'email' }],
+    )
+
+    expect(result.status).toBe('sent')
+    expect(result.metadata).toEqual(expect.objectContaining({
+      channel: 'email',
+      recipientCount: 1,
+    }))
+  })
+
+  it('fails controlled when smtp transport is explicitly requested before SMTP implementation lands', async () => {
+    vi.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined)
+    const channel = new EmailNotificationChannel({ env: COMPLETE_SMTP_ENV })
+
+    const result = await channel.sender(
+      {
+        channel: 'email',
+        subject: 'Real subject',
+        content: 'Real body',
+        recipients: [{ id: 'ops@example.com', type: 'email' }],
+      },
+      [{ id: 'ops@example.com', type: 'email' }],
+    )
+
+    expect(result.status).toBe('failed')
+    expect(result.failedReason).toContain('SMTP email transport is configured but not implemented')
+  })
+})

--- a/scripts/ops/multitable-email-transport-readiness.test.mjs
+++ b/scripts/ops/multitable-email-transport-readiness.test.mjs
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import { execFileSync, spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+
+function runReadiness(env) {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ms2-email-readiness-'))
+  const jsonPath = path.join(tmpRoot, 'report.json')
+  const mdPath = path.join(tmpRoot, 'report.md')
+  const result = spawnSync('pnpm', ['exec', 'tsx', 'scripts/ops/multitable-email-transport-readiness.ts'], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      ...env,
+      EMAIL_READINESS_JSON: jsonPath,
+      EMAIL_READINESS_MD: mdPath,
+    },
+    encoding: 'utf8',
+  })
+
+  return {
+    ...result,
+    jsonPath,
+    mdPath,
+    json: fs.existsSync(jsonPath) ? JSON.parse(fs.readFileSync(jsonPath, 'utf8')) : null,
+    markdown: fs.existsSync(mdPath) ? fs.readFileSync(mdPath, 'utf8') : '',
+  }
+}
+
+test('email readiness script passes in default mock mode', () => {
+  const result = runReadiness({})
+
+  assert.equal(result.status, 0)
+  assert.equal(result.json.ok, true)
+  assert.equal(result.json.mode, 'mock')
+  assert.match(result.markdown, /Status: `pass`/)
+})
+
+test('email readiness script exits 2 when smtp env is incomplete', () => {
+  const result = runReadiness({
+    MULTITABLE_EMAIL_TRANSPORT: 'smtp',
+    MULTITABLE_EMAIL_SMTP_HOST: 'smtp.example.com',
+  })
+
+  assert.equal(result.status, 2)
+  assert.equal(result.json.ok, false)
+  assert.equal(result.json.status, 'blocked')
+  assert.match(result.markdown, /MULTITABLE_EMAIL_SMTP_PASSWORD/)
+})
+
+test('email readiness script redacts SMTP secrets and bearer tokens from artifacts', () => {
+  const result = runReadiness({
+    MULTITABLE_EMAIL_TRANSPORT: 'smtp',
+    MULTITABLE_EMAIL_SMTP_HOST: 'smtp://user:pass@smtp.example.com?token=secret-token',
+    MULTITABLE_EMAIL_SMTP_PORT: '587',
+    MULTITABLE_EMAIL_SMTP_USER: 'smtp-user',
+    MULTITABLE_EMAIL_SMTP_PASSWORD: 'Bearer raw-token-value',
+    MULTITABLE_EMAIL_SMTP_FROM: 'ops-private@example.com',
+  })
+
+  assert.equal(result.status, 0)
+  const combined = [
+    result.stdout,
+    result.stderr,
+    result.markdown,
+    JSON.stringify(result.json),
+  ].join('\n')
+  assert.doesNotMatch(combined, /smtp:\/\/user:pass@smtp\.example\.com/)
+  assert.doesNotMatch(combined, /secret-token/)
+  assert.doesNotMatch(combined, /raw-token-value/)
+  assert.doesNotMatch(combined, /ops-private@example\.com/)
+})
+
+test('email readiness script can be launched through package script', () => {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ms2-email-readiness-script-'))
+  const jsonPath = path.join(tmpRoot, 'report.json')
+  const mdPath = path.join(tmpRoot, 'report.md')
+
+  execFileSync('pnpm', ['verify:multitable-email:readiness'], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      EMAIL_READINESS_JSON: jsonPath,
+      EMAIL_READINESS_MD: mdPath,
+    },
+    stdio: 'pipe',
+  })
+
+  const report = JSON.parse(fs.readFileSync(jsonPath, 'utf8'))
+  assert.equal(report.status, 'pass')
+})

--- a/scripts/ops/multitable-email-transport-readiness.ts
+++ b/scripts/ops/multitable-email-transport-readiness.ts
@@ -1,0 +1,42 @@
+#!/usr/bin/env tsx
+
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import emailTransportReadinessModule from '../../packages/core-backend/src/services/email-transport-readiness.ts'
+
+const {
+  renderEmailTransportReadinessMarkdown,
+  resolveEmailTransportReadiness,
+} = emailTransportReadinessModule as typeof import('../../packages/core-backend/src/services/email-transport-readiness')
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url))
+const repoRoot = path.resolve(scriptDir, '../..')
+
+function outputPath(envName: string, fallback: string): string {
+  const raw = process.env[envName]?.trim()
+  return path.resolve(repoRoot, raw || fallback)
+}
+
+async function main(): Promise<void> {
+  const report = resolveEmailTransportReadiness(process.env)
+  const jsonPath = outputPath('EMAIL_READINESS_JSON', 'output/multitable-email-transport-readiness/report.json')
+  const mdPath = outputPath('EMAIL_READINESS_MD', 'output/multitable-email-transport-readiness/report.md')
+  const markdown = renderEmailTransportReadinessMarkdown(report)
+
+  await fs.mkdir(path.dirname(jsonPath), { recursive: true })
+  await fs.mkdir(path.dirname(mdPath), { recursive: true })
+  await fs.writeFile(jsonPath, `${JSON.stringify(report, null, 2)}\n`)
+  await fs.writeFile(mdPath, markdown)
+
+  process.stdout.write(markdown)
+  process.stdout.write(`\nJSON report: ${jsonPath}\nMarkdown report: ${mdPath}\n`)
+
+  process.exitCode = report.ok ? 0 : 2
+}
+
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error)
+  process.stderr.write(`multitable email transport readiness failed: ${message}\n`)
+  process.exitCode = 1
+})


### PR DESCRIPTION
## Summary

Adds Phase 2 Lane B1 for `send_email` automation: an env-gated, no-send email transport readiness gate before any real SMTP/provider implementation lands.

What changed:
- Adds `email-transport-readiness.ts` to resolve mock vs SMTP readiness and render redacted reports.
- Keeps default local/dev behavior on the mock email channel.
- Fails closed when `MULTITABLE_EMAIL_TRANSPORT=smtp` is explicitly configured before B2 implements the real provider.
- Adds `pnpm verify:multitable-email:readiness` with JSON/MD artifacts and exit code `2` for blocked readiness.
- Updates Phase 2 TODO and adds development/verification MD.

Non-goals:
- No real SMTP/provider send in this PR.
- No dev-only email history endpoint.
- No DingTalk behavior changes.

## Verification

- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/email-transport-readiness.test.ts tests/unit/automation-v1.test.ts --reporter=dot` → 2 files / 140 tests pass
- `node --test scripts/ops/multitable-email-transport-readiness.test.mjs` → 4/4 pass
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false` → pass
- `pnpm --filter @metasheet/core-backend exec playwright test --config tests/e2e/playwright.config.ts tests/e2e/multitable-automation-send-email-smoke.spec.ts --list` → 3 tests listed
- `git diff --check` → pass
