### PR TITLE
fix(migrations): harden plugin infrastructure SQL upgrades

### DIFF
--- a/docs/development/onprem-plugin-infrastructure-migration-compat-design-20260511.md
+++ b/docs/development/onprem-plugin-infrastructure-migration-compat-design-20260511.md
@@ -1,0 +1,63 @@
+# On-Prem Plugin Infrastructure Migration Compatibility Design
+
+## Context
+
+Windows/on-prem deployment failed while applying `008_plugin_infrastructure.sql`.
+The upgraded package now ships the legacy SQL migration folder, so databases that
+previously ran the newer TypeScript migration
+`20250924180000_create_plugin_management_tables.ts` can encounter `008` for the
+first time.
+
+That existing TypeScript schema is not identical to the legacy SQL schema:
+
+- `plugin_configs` exists but lacks `config_key`, `scope`, `value`,
+  `encrypted`, and `updated_at`.
+- `plugin_registry.capabilities` and `plugin_registry.permissions` may be
+  `jsonb`, while `008` creates views using `array_length(...)` as if they were
+  `text[]`.
+- `plugin_security_audit` exists with `event_type` / `resource` columns, while
+  `008` later indexes `operation` / `result`.
+- `plugin_cache` may lack `updated_at`, while `008` installs an update trigger
+  that writes that column.
+
+The visible deployment failure was the first item: the partial indexes in `008`
+referenced `scope` after `CREATE TABLE IF NOT EXISTS plugin_configs` skipped the
+already-existing table.
+
+## Change
+
+`packages/core-backend/migrations/008_plugin_infrastructure.sql` now contains
+compatibility guards immediately after the relevant `CREATE TABLE IF NOT EXISTS`
+statements:
+
+1. Normalize `plugin_registry.capabilities` and `permissions` from `jsonb` to
+   `text[]` when an older table already exists.
+2. Add the scoped config columns that `008` expects to `plugin_configs` when the
+   older table already exists.
+3. Backfill `plugin_configs.value` from the old `config` JSON column when that
+   column exists.
+4. Add `idx_plugin_configs_scoped_identity`, matching the expression conflict
+   target used by `PluginConfigManager`.
+5. Add missing `plugin_security_audit` columns before `008` creates indexes on
+   them, preserving old `event_type` and `resource` values into the new columns.
+6. Add `plugin_cache.updated_at` before installing the update trigger.
+
+## Non-Goals
+
+- No new feature behavior is introduced.
+- No integration-core API contract changes are made.
+- No destructive cleanup is performed on old compatibility columns such as
+  `plugin_configs.config` or `plugin_security_audit.event_type`; old data stays
+  readable for any legacy route still expecting those columns.
+- This does not mark the customer K3 live GATE as complete. It only unblocks
+  package migration on an already-upgraded on-prem database.
+
+## Deployment Impact
+
+The change is migration-only plus a unit regression test. Existing on-prem
+deployments should be able to re-run the deploy package; PostgreSQL
+`ADD COLUMN IF NOT EXISTS` and guarded conversion blocks keep the migration
+idempotent.
+
+If a previous deploy failed while applying `008`, the same deploy flow should be
+safe to retry after installing a package containing this fix.

--- a/docs/development/onprem-plugin-infrastructure-migration-compat-verification-20260511.md
+++ b/docs/development/onprem-plugin-infrastructure-migration-compat-verification-20260511.md
@@ -1,0 +1,91 @@
+# On-Prem Plugin Infrastructure Migration Compatibility Verification
+
+## Local Checks
+
+### Targeted Regression
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/plugin-infrastructure-sql-migration.test.ts \
+  --watch=false
+```
+
+Result:
+
+```text
+Test Files  1 passed (1)
+Tests       4 passed (4)
+```
+
+Coverage:
+
+- `plugin_configs` compatibility columns are added before scoped indexes
+  reference `scope`.
+- The expression unique index required by `PluginConfigManager` is present.
+- `plugin_registry` jsonb array normalization runs before plugin statistics
+  views call `array_length(...)`.
+- `plugin_security_audit` and `plugin_cache` compatibility columns are added
+  before indexes/triggers reference them.
+
+### Migration Provider Regression
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/migration-provider.test.ts \
+  tests/unit/plugin-infrastructure-sql-migration.test.ts \
+  --watch=false
+```
+
+Result:
+
+```text
+Test Files  2 passed (2)
+Tests       8 passed (8)
+```
+
+This confirms the SQL migration folder still participates in the packaged
+runtime migration provider and that the new `008` guards are present.
+
+### Whitespace / Conflict Marker Check
+
+```bash
+git diff --check
+```
+
+Result: `0`.
+
+## Environment-Limited Check
+
+Attempted to start a local PostgreSQL container to run the exact SQL against a
+simulated old plugin schema:
+
+```bash
+docker run -d --name ms2-mig-scope-pg \
+  -e POSTGRES_PASSWORD=postgres \
+  -e POSTGRES_DB=ms2_mig_scope \
+  -p 55436:5432 \
+  postgres:15-alpine
+```
+
+Result:
+
+```text
+failed to connect to the docker API at unix:///Users/chouhua/.docker/run/docker.sock
+```
+
+The local Docker daemon is unavailable in this environment, so this PR relies on
+static SQL regression checks locally and should still go through CI
+`migration-replay` before merge.
+
+## Expected On-Prem Validation
+
+After a package containing this fix is built:
+
+1. Re-run the normal Windows/on-prem deploy flow against the same database that
+   failed on `008_plugin_infrastructure`.
+2. Confirm deploy exit code is `0`.
+3. Confirm backend updated to the new package SHA.
+4. Confirm `/api/integration/health` and the K3 WISE setup page no longer show
+   missing backend route symptoms.
+5. Keep customer K3 live GATE blocked until the real K3 API/account answers are
+   supplied.

--- a/packages/core-backend/migrations/008_plugin_infrastructure.sql
+++ b/packages/core-backend/migrations/008_plugin_infrastructure.sql
@@ -24,6 +24,60 @@ CREATE TABLE IF NOT EXISTS plugin_registry (
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
+-- Compatibility guard for databases that already ran the newer TypeScript
+-- plugin management migration before this legacy SQL migration was packaged.
+-- That migration created plugin_registry with jsonb capabilities/permissions,
+-- while this SQL migration's views and seed data expect text[] arrays.
+CREATE OR REPLACE FUNCTION __metasheet_plugin_jsonb_to_text_array(input JSONB)
+RETURNS TEXT[] AS $$
+  SELECT CASE
+    WHEN input IS NULL THEN ARRAY[]::TEXT[]
+    WHEN jsonb_typeof(input) = 'array' THEN ARRAY(SELECT jsonb_array_elements_text(input))
+    WHEN jsonb_typeof(input) = 'object' THEN ARRAY(SELECT jsonb_object_keys(input))
+    WHEN jsonb_typeof(input) = 'string' THEN ARRAY[input #>> '{}']
+    ELSE ARRAY[]::TEXT[]
+  END
+$$ LANGUAGE SQL IMMUTABLE;
+
+ALTER TABLE plugin_registry ADD COLUMN IF NOT EXISTS error TEXT;
+ALTER TABLE plugin_registry ADD COLUMN IF NOT EXISTS error_message TEXT;
+ALTER TABLE plugin_registry ADD COLUMN IF NOT EXISTS capabilities TEXT[] DEFAULT '{}'::TEXT[];
+ALTER TABLE plugin_registry ADD COLUMN IF NOT EXISTS permissions TEXT[] DEFAULT '{}'::TEXT[];
+DROP INDEX IF EXISTS idx_plugin_registry_capabilities;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_name = 'plugin_registry'
+      AND column_name = 'capabilities'
+      AND udt_name = 'jsonb'
+  ) THEN
+    ALTER TABLE plugin_registry ALTER COLUMN capabilities DROP DEFAULT;
+    ALTER TABLE plugin_registry
+      ALTER COLUMN capabilities TYPE TEXT[]
+      USING __metasheet_plugin_jsonb_to_text_array(capabilities);
+    ALTER TABLE plugin_registry ALTER COLUMN capabilities SET DEFAULT '{}'::TEXT[];
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_name = 'plugin_registry'
+      AND column_name = 'permissions'
+      AND udt_name = 'jsonb'
+  ) THEN
+    ALTER TABLE plugin_registry ALTER COLUMN permissions DROP DEFAULT;
+    ALTER TABLE plugin_registry
+      ALTER COLUMN permissions TYPE TEXT[]
+      USING __metasheet_plugin_jsonb_to_text_array(permissions);
+    ALTER TABLE plugin_registry ALTER COLUMN permissions SET DEFAULT '{}'::TEXT[];
+  END IF;
+END $$;
+
+DROP FUNCTION IF EXISTS __metasheet_plugin_jsonb_to_text_array(JSONB);
+
 -- Plugin Key-Value Storage Table
 -- Provides persistent storage for plugin data
 CREATE TABLE IF NOT EXISTS plugin_kv (
@@ -64,6 +118,31 @@ CREATE TABLE IF NOT EXISTS plugin_configs (
     FOREIGN KEY (plugin_name) REFERENCES plugin_registry(name) ON DELETE CASCADE
 );
 
+-- Compatibility guard for older plugin_configs tables created by
+-- 20250924180000_create_plugin_management_tables.ts. Those tables stored one
+-- JSON config blob per plugin and did not have config_key/scope columns, so the
+-- partial indexes below failed on upgraded on-prem databases.
+ALTER TABLE plugin_configs ADD COLUMN IF NOT EXISTS config_key VARCHAR(255) NOT NULL DEFAULT 'default';
+ALTER TABLE plugin_configs ADD COLUMN IF NOT EXISTS value TEXT;
+ALTER TABLE plugin_configs ADD COLUMN IF NOT EXISTS encrypted BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE plugin_configs ADD COLUMN IF NOT EXISTS scope VARCHAR(50) NOT NULL DEFAULT 'global';
+ALTER TABLE plugin_configs ADD COLUMN IF NOT EXISTS user_id VARCHAR(255);
+ALTER TABLE plugin_configs ADD COLUMN IF NOT EXISTS tenant_id VARCHAR(255);
+ALTER TABLE plugin_configs ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+ALTER TABLE plugin_configs ADD COLUMN IF NOT EXISTS updated_by VARCHAR(255);
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_name = 'plugin_configs'
+      AND column_name = 'config'
+  ) THEN
+    EXECUTE 'UPDATE plugin_configs SET value = config::TEXT WHERE value IS NULL AND config IS NOT NULL';
+  END IF;
+END $$;
+
 -- Unique constraints using partial indexes for each scope
 -- Global scope: only plugin_name and config_key matter
 CREATE UNIQUE INDEX IF NOT EXISTS idx_plugin_configs_global
@@ -79,6 +158,12 @@ WHERE scope = 'user';
 CREATE UNIQUE INDEX IF NOT EXISTS idx_plugin_configs_tenant
 ON plugin_configs (plugin_name, config_key, tenant_id)
 WHERE scope = 'tenant';
+
+-- Matches PluginConfigManager's ON CONFLICT target, including NULL-safe user
+-- and tenant identity. PostgreSQL supports expression unique indexes, while the
+-- earlier table-level UNIQUE attempt with COALESCE was invalid.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_plugin_configs_scoped_identity
+ON plugin_configs (plugin_name, config_key, scope, COALESCE(user_id, ''), COALESCE(tenant_id, ''));
 
 -- Plugin Capabilities Table
 -- Tracks capability registrations and implementations
@@ -174,6 +259,8 @@ CREATE TABLE IF NOT EXISTS plugin_cache (
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
+
+ALTER TABLE plugin_cache ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
 
 CREATE INDEX IF NOT EXISTS idx_plugin_cache_plugin_name ON plugin_cache(plugin_name);
 CREATE INDEX IF NOT EXISTS idx_plugin_cache_expires_at ON plugin_cache(expires_at);
@@ -273,6 +360,45 @@ CREATE TABLE IF NOT EXISTS plugin_security_audit (
     severity VARCHAR(50) NOT NULL DEFAULT 'info' CHECK (severity IN ('info', 'warning', 'error', 'critical')),
     timestamp TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
+
+-- Compatibility guard for older plugin_security_audit tables created by the
+-- TypeScript plugin management migration. The legacy table used event_type and
+-- resource columns; the SQL migration indexes operation/result below.
+ALTER TABLE plugin_security_audit ADD COLUMN IF NOT EXISTS operation VARCHAR(100);
+ALTER TABLE plugin_security_audit ADD COLUMN IF NOT EXISTS resource_type VARCHAR(100);
+ALTER TABLE plugin_security_audit ADD COLUMN IF NOT EXISTS resource_id VARCHAR(255);
+ALTER TABLE plugin_security_audit ADD COLUMN IF NOT EXISTS result VARCHAR(50);
+ALTER TABLE plugin_security_audit ADD COLUMN IF NOT EXISTS request_data JSONB DEFAULT '{}';
+ALTER TABLE plugin_security_audit ADD COLUMN IF NOT EXISTS response_data JSONB DEFAULT '{}';
+ALTER TABLE plugin_security_audit ADD COLUMN IF NOT EXISTS error_message TEXT;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_name = 'plugin_security_audit'
+      AND column_name = 'event_type'
+  ) THEN
+    EXECUTE 'UPDATE plugin_security_audit SET operation = event_type WHERE operation IS NULL AND event_type IS NOT NULL';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_name = 'plugin_security_audit'
+      AND column_name = 'resource'
+  ) THEN
+    EXECUTE 'UPDATE plugin_security_audit SET resource_type = resource WHERE resource_type IS NULL AND resource IS NOT NULL';
+  END IF;
+END $$;
+
+UPDATE plugin_security_audit SET operation = COALESCE(operation, 'unknown');
+UPDATE plugin_security_audit SET result = COALESCE(result, 'allowed');
+ALTER TABLE plugin_security_audit ALTER COLUMN operation SET DEFAULT 'unknown';
+ALTER TABLE plugin_security_audit ALTER COLUMN operation SET NOT NULL;
+ALTER TABLE plugin_security_audit ALTER COLUMN result SET DEFAULT 'allowed';
+ALTER TABLE plugin_security_audit ALTER COLUMN result SET NOT NULL;
 
 CREATE INDEX IF NOT EXISTS idx_plugin_security_audit_plugin_name ON plugin_security_audit(plugin_name);
 CREATE INDEX IF NOT EXISTS idx_plugin_security_audit_operation ON plugin_security_audit(operation);

--- a/packages/core-backend/tests/unit/plugin-infrastructure-sql-migration.test.ts
+++ b/packages/core-backend/tests/unit/plugin-infrastructure-sql-migration.test.ts
@@ -1,0 +1,66 @@
+import { readFileSync } from 'fs'
+import path from 'path'
+import { describe, expect, it } from 'vitest'
+
+const migrationPath = path.resolve(
+  __dirname,
+  '../../migrations/008_plugin_infrastructure.sql'
+)
+
+function readMigration(): string {
+  return readFileSync(migrationPath, 'utf8')
+}
+
+describe('008_plugin_infrastructure.sql compatibility guards', () => {
+  it('repairs legacy plugin_configs tables before scoped indexes reference scope', () => {
+    const sql = readMigration()
+
+    const createTable = sql.indexOf('CREATE TABLE IF NOT EXISTS plugin_configs')
+    const compatibilityGuard = sql.indexOf('ALTER TABLE plugin_configs ADD COLUMN IF NOT EXISTS scope')
+    const firstScopedIndex = sql.indexOf('CREATE UNIQUE INDEX IF NOT EXISTS idx_plugin_configs_global')
+
+    expect(createTable).toBeGreaterThanOrEqual(0)
+    expect(compatibilityGuard).toBeGreaterThan(createTable)
+    expect(firstScopedIndex).toBeGreaterThan(compatibilityGuard)
+    expect(sql).toContain('ALTER TABLE plugin_configs ADD COLUMN IF NOT EXISTS config_key')
+    expect(sql).toContain('ALTER TABLE plugin_configs ADD COLUMN IF NOT EXISTS value TEXT')
+    expect(sql).toContain('ALTER TABLE plugin_configs ADD COLUMN IF NOT EXISTS encrypted')
+    expect(sql).toContain('ALTER TABLE plugin_configs ADD COLUMN IF NOT EXISTS updated_at')
+  })
+
+  it('ships the expression unique index required by PluginConfigManager upserts', () => {
+    const sql = readMigration()
+
+    expect(sql).toContain('CREATE UNIQUE INDEX IF NOT EXISTS idx_plugin_configs_scoped_identity')
+    expect(sql).toContain("COALESCE(user_id, '')")
+    expect(sql).toContain("COALESCE(tenant_id, '')")
+  })
+
+  it('normalizes jsonb plugin registry arrays before plugin views call array_length', () => {
+    const sql = readMigration()
+
+    const helper = sql.indexOf('__metasheet_plugin_jsonb_to_text_array')
+    const statisticsView = sql.indexOf('CREATE OR REPLACE VIEW plugin_statistics')
+
+    expect(helper).toBeGreaterThanOrEqual(0)
+    expect(statisticsView).toBeGreaterThan(helper)
+    expect(sql).toContain('ALTER COLUMN capabilities TYPE TEXT[]')
+    expect(sql).toContain('ALTER COLUMN permissions TYPE TEXT[]')
+    expect(sql).toContain('DROP INDEX IF EXISTS idx_plugin_registry_capabilities')
+    expect(sql).toContain('DROP FUNCTION IF EXISTS __metasheet_plugin_jsonb_to_text_array')
+  })
+
+  it('repairs other legacy plugin tables before indexes and triggers reference new columns', () => {
+    const sql = readMigration()
+
+    expect(sql).toContain('ALTER TABLE plugin_security_audit ADD COLUMN IF NOT EXISTS operation')
+    expect(sql).toContain('ALTER TABLE plugin_security_audit ADD COLUMN IF NOT EXISTS result')
+    expect(sql.indexOf('ALTER TABLE plugin_security_audit ADD COLUMN IF NOT EXISTS operation')).toBeLessThan(
+      sql.indexOf('CREATE INDEX IF NOT EXISTS idx_plugin_security_audit_operation')
+    )
+    expect(sql).toContain('ALTER TABLE plugin_cache ADD COLUMN IF NOT EXISTS updated_at')
+    expect(sql.indexOf('ALTER TABLE plugin_cache ADD COLUMN IF NOT EXISTS updated_at')).toBeLessThan(
+      sql.indexOf('CREATE TRIGGER update_plugin_cache_updated_at')
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Fixes the on-prem deployment blocker where packaged legacy SQL migration `008_plugin_infrastructure.sql` can run after the newer TypeScript plugin management migration already created older plugin tables.

The visible failure was `plugin_configs.scope` missing when `008` attempted to create scoped indexes. This PR makes `008` idempotently repair the pre-existing plugin tables before later indexes/views/triggers reference the newer columns.

## Changes

- Add compatibility guards to `008_plugin_infrastructure.sql` for:
  - `plugin_configs`: add `config_key`, `value`, `encrypted`, `scope`, `user_id`, `tenant_id`, `updated_at`, `updated_by`; backfill `value` from old `config` JSON when present.
  - `plugin_registry`: normalize `capabilities` / `permissions` from `jsonb` to `text[]` before `plugin_statistics` uses `array_length`.
  - `plugin_security_audit`: add `operation`, `result`, and related columns before indexes reference them.
  - `plugin_cache`: add `updated_at` before the update trigger references it.
- Add `idx_plugin_configs_scoped_identity` to match the expression conflict target used by `PluginConfigManager`.
- Add unit regression coverage for the migration SQL ordering/guards.
- Add design and verification MDs for the on-prem migration compatibility fix.

## Verification

- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/migration-provider.test.ts tests/unit/plugin-infrastructure-sql-migration.test.ts --watch=false`
  - 2 files / 8 tests passed
- `git diff --check HEAD~1..HEAD`
  - clean

## Deployment Impact

Migration-only compatibility fix. No runtime API or K3 adapter behavior changes.

After this lands, rebuild the on-prem package and retry the same Windows/on-prem deploy that failed on `008_plugin_infrastructure`.

## Note

Local Docker daemon was unavailable, so I could not run a local PostgreSQL container replay in this workstation. CI `migration-replay` should be treated as the merge gate for SQL execution.
