### PR TITLE
test(multitable): add SMTP real-send smoke harness

### DIFF
--- a/docs/development/multitable-feishu-phase2-todo-20260509.md
+++ b/docs/development/multitable-feishu-phase2-todo-20260509.md
@@ -115,6 +115,13 @@ B2 artifacts:
 - Development MD: `docs/development/multitable-phase2-lane-b2-email-smtp-transport-development-20260511.md`
 - Verification MD: `docs/development/multitable-phase2-lane-b2-email-smtp-transport-verification-20260511.md`
 
+B3 artifacts:
+
+- Development MD: `docs/development/multitable-phase2-lane-b3-email-real-send-smoke-development-20260511.md`
+- Verification MD: `docs/development/multitable-phase2-lane-b3-email-real-send-smoke-verification-20260511.md`
+- PR: #1465
+- Command: `pnpm verify:multitable-email:real-send`
+
 ### Objective
 
 Move `send_email` automation from "default mock channel proves the wire path" toward an env-gated real transport path. The first acceptable slice is a safe transport seam plus readiness gate; the second slice may add actual SMTP delivery if dependency and operations policy are approved.
@@ -166,8 +173,11 @@ Likely frontend files:
 - [x] B2: SMTP mode calls the provider transport instead of returning mock success.
 - [x] B2: invalid SMTP port / timeout config is blocked before runtime.
 - [x] B2: provider errors return controlled failed notification results with secrets redacted.
+- [x] B3: guarded operator command exists for real mailbox receipt smoke and is fail-closed by default.
+- [x] B3: blocked command artifacts redact SMTP secrets and recipient addresses.
 - [ ] B2: real mailbox receipt smoke on staging with production-like SMTP credentials.
-  - Not run in source verification; requires real credentials and operator-controlled environment.
+  - Not run in source verification; requires real credentials, a dedicated test recipient, and operator-controlled environment.
+  - Use `pnpm verify:multitable-email:real-send` after configuring SMTP env, `MULTITABLE_EMAIL_REAL_SEND_SMOKE=1`, `CONFIRM_SEND_EMAIL=1`, and `MULTITABLE_EMAIL_SMOKE_TO`.
 
 ### Suggested PR Split
 
@@ -175,6 +185,8 @@ Likely frontend files:
 - B1 title: `feat(multitable): add env-gated email transport readiness`
 - B2 branch: `codex/multitable-phase2-email-smtp-transport-20260509`
 - B2 title: `feat(multitable): add SMTP email notification transport`
+- B3 branch: `codex/multitable-phase2-email-real-smoke-20260511`
+- B3 title: `test(multitable): add SMTP real-send smoke harness`
 
 Do B2 only after B1 lands and dependency choice is agreed.
 

--- a/docs/development/multitable-phase2-lane-b3-email-real-send-smoke-development-20260511.md
+++ b/docs/development/multitable-phase2-lane-b3-email-real-send-smoke-development-20260511.md
@@ -1,0 +1,128 @@
+# Multitable Phase 2 Lane B3 Email Real-Send Smoke - Development
+
+> Date: 2026-05-11
+> Branch: `codex/multitable-phase2-email-real-smoke-20260511`
+> PR: #1465
+> Baseline: `origin/main@ca70e340a`
+> Scope: operator-run real SMTP mailbox smoke harness
+
+## Context
+
+Lane B1 added the no-send readiness gate. Lane B2 added SMTP runtime delivery through `nodemailer`.
+
+The remaining gap is not source code delivery; it is an operator-controlled mailbox receipt proof. That proof needs real SMTP credentials and a real recipient, so it cannot be safely run by default in CI or source verification.
+
+This B3 slice adds a guarded harness that operators can run on staging or another controlled runtime without exposing credentials in tracked artifacts.
+
+## What Changed
+
+### Real-Send Smoke Script
+
+Added:
+
+```bash
+scripts/ops/multitable-email-real-send-smoke.ts
+```
+
+Package script:
+
+```bash
+pnpm verify:multitable-email:real-send
+```
+
+The script sends one real email only when all required guards are present:
+
+```bash
+MULTITABLE_EMAIL_TRANSPORT=smtp
+MULTITABLE_EMAIL_SMTP_HOST=...
+MULTITABLE_EMAIL_SMTP_PORT=587
+MULTITABLE_EMAIL_SMTP_USER=...
+MULTITABLE_EMAIL_SMTP_PASSWORD=...
+MULTITABLE_EMAIL_SMTP_FROM=...
+MULTITABLE_EMAIL_REAL_SEND_SMOKE=1
+CONFIRM_SEND_EMAIL=1
+MULTITABLE_EMAIL_SMOKE_TO=recipient@example.com
+```
+
+Optional:
+
+```bash
+MULTITABLE_EMAIL_SMOKE_SUBJECT="MetaSheet staging SMTP smoke"
+EMAIL_REAL_SEND_JSON=output/multitable-email-real-send-smoke/report.json
+EMAIL_REAL_SEND_MD=output/multitable-email-real-send-smoke/report.md
+```
+
+### Exit Codes
+
+| Code | Meaning |
+| --- | --- |
+| 0 | Real-send smoke returned a sent notification result. |
+| 1 | Runtime send failed after guards passed. |
+| 2 | Configuration or safety guard blocked the send before any real email attempt. |
+
+### Reports
+
+The harness writes:
+
+- `output/multitable-email-real-send-smoke/report.json`
+- `output/multitable-email-real-send-smoke/report.md`
+
+Reports include:
+
+- pass / blocked / failed status;
+- readiness result;
+- whether a recipient was configured;
+- notification status and id when available;
+- redacted failure reason when available.
+
+Reports intentionally do not include raw SMTP credentials or recipient addresses.
+
+## Design Decisions
+
+### Decision 1 - Fail closed by default
+
+Running `pnpm verify:multitable-email:real-send` with no env exits `2` and sends nothing.
+
+### Decision 2 - Reuse production channel path
+
+The script uses `EmailNotificationChannel` rather than calling `nodemailer` directly. That keeps the smoke aligned with the actual automation email transport path.
+
+### Decision 3 - Keep mailbox receipt manual
+
+The script can prove that MetaSheet returned a sent result. The operator still needs to confirm the configured mailbox received the message and archive that external evidence separately.
+
+### Decision 4 - No tracked secrets
+
+All artifact text passes through the same email transport redaction helper, plus recipient-address redaction.
+
+## Non-Goals
+
+- No SMTP credentials committed to repo files.
+- No default CI real-send job.
+- No mailbox polling or IMAP integration.
+- No HTML email rendering.
+- No changes to DingTalk or webhook notification channels.
+
+## Operator Command
+
+Use a shell environment, secret manager, or CI masked variables. Do not paste credentials into docs or PR comments.
+
+```bash
+MULTITABLE_EMAIL_TRANSPORT=smtp \
+MULTITABLE_EMAIL_SMTP_HOST="$SMTP_HOST" \
+MULTITABLE_EMAIL_SMTP_PORT="$SMTP_PORT" \
+MULTITABLE_EMAIL_SMTP_USER="$SMTP_USER" \
+MULTITABLE_EMAIL_SMTP_PASSWORD="$SMTP_PASSWORD" \
+MULTITABLE_EMAIL_SMTP_FROM="$SMTP_FROM" \
+MULTITABLE_EMAIL_REAL_SEND_SMOKE=1 \
+CONFIRM_SEND_EMAIL=1 \
+MULTITABLE_EMAIL_SMOKE_TO="$SMTP_TEST_RECIPIENT" \
+pnpm verify:multitable-email:real-send
+```
+
+Acceptance for staging:
+
+1. Script exits `0`.
+2. `report.md` contains `Status: pass`.
+3. The test recipient mailbox receives the smoke email.
+4. The archived evidence contains no SMTP credential or recipient address unless stored in a private operator vault.

--- a/docs/development/multitable-phase2-lane-b3-email-real-send-smoke-verification-20260511.md
+++ b/docs/development/multitable-phase2-lane-b3-email-real-send-smoke-verification-20260511.md
@@ -1,0 +1,123 @@
+# Multitable Phase 2 Lane B3 Email Real-Send Smoke - Verification
+
+> Date: 2026-05-11
+> Branch: `codex/multitable-phase2-email-real-smoke-20260511`
+> PR: #1465
+> Baseline: `origin/main@ca70e340a`
+> Scope: source verification for guarded real-send SMTP smoke harness
+
+## Tests Run
+
+### Harness unit tests
+
+```bash
+node --test scripts/ops/multitable-email-real-send-smoke.test.mjs
+```
+
+Result:
+
+```text
+tests 4
+pass 4
+fail 0
+```
+
+Covered:
+
+- real-send smoke blocks unless `MULTITABLE_EMAIL_REAL_SEND_SMOKE=1` and `CONFIRM_SEND_EMAIL=1` are set;
+- real-send smoke blocks when `MULTITABLE_EMAIL_SMOKE_TO` is missing;
+- blocked artifacts redact SMTP URL credentials, URL token parameters, bearer-like passwords, SMTP from address, and recipient address;
+- package script `pnpm verify:multitable-email:real-send` launches the harness.
+
+### Default blocked command
+
+```bash
+pnpm verify:multitable-email:real-send
+```
+
+Result:
+
+```text
+exit code 2
+Status: `blocked`
+Mode: `mock`
+Recipient configured: `no`
+```
+
+Purpose:
+
+- Confirms the operator-facing command is fail-closed by default.
+- Confirms no real email is attempted without explicit SMTP mode, real-send guard, confirm guard, and recipient env.
+
+### Existing readiness script regression
+
+```bash
+node --test scripts/ops/multitable-email-transport-readiness.test.mjs
+```
+
+Result:
+
+```text
+tests 4
+pass 4
+fail 0
+```
+
+Purpose:
+
+- Confirms B3 did not regress the B1 no-send readiness gate.
+
+### Email transport unit regression
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/email-transport-readiness.test.ts --reporter=dot
+```
+
+Result:
+
+```text
+Test Files  1 passed (1)
+Tests       13 passed (13)
+```
+
+Purpose:
+
+- Confirms B2 SMTP config and transport behavior remain source-verified.
+
+### Type check
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
+```
+
+Result: pass.
+
+### Diff hygiene
+
+```bash
+git diff --check
+```
+
+Result: pass.
+
+## Non-Verification
+
+- No real SMTP server was contacted.
+- No mailbox receipt was produced.
+- No staging deployment was touched.
+- No SMTP credential was provided to this source verification run.
+
+## Risk Review
+
+| Risk | Verification |
+| --- | --- |
+| A developer accidentally sends real email by running the package script | Default command exits `2` and sends nothing. |
+| Real-send smoke runs with incomplete env | Tests cover missing guards and missing recipient. |
+| Reports expose SMTP secrets or recipient addresses | Redaction test scans stdout, stderr, markdown, and JSON. |
+| B3 regresses B1 readiness behavior | Existing readiness script tests remain green. |
+| B3 regresses B2 runtime types | Core backend `tsc --noEmit` remains green. |
+
+## Result
+
+B3 is source-verified. The repo now has a guarded, repeatable command for the remaining B2 staging evidence item. Actual mailbox receipt remains an operator/staging task that requires real SMTP credentials and a dedicated test recipient.

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "verify:multitable-rc:staging": "node scripts/verify-multitable-rc-staging-smoke.mjs",
     "verify:multitable-rc:ui": "bash scripts/verify-multitable-rc-ui-smoke.sh",
     "verify:multitable-email:readiness": "tsx scripts/ops/multitable-email-transport-readiness.ts",
+    "verify:multitable-email:real-send": "tsx scripts/ops/multitable-email-real-send-smoke.ts",
     "verify:multitable-pilot:staging:test": "node --test scripts/ops/multitable-pilot-staging.test.mjs",
     "verify:multitable-pilot:readiness": "node scripts/ops/multitable-pilot-readiness.mjs",
     "verify:multitable-pilot:readiness:test": "node --test scripts/ops/multitable-pilot-readiness.test.mjs",

--- a/scripts/ops/multitable-email-real-send-smoke.test.mjs
+++ b/scripts/ops/multitable-email-real-send-smoke.test.mjs
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+
+const COMPLETE_SMTP_ENV = {
+  MULTITABLE_EMAIL_TRANSPORT: 'smtp',
+  MULTITABLE_EMAIL_SMTP_HOST: 'smtp.example.com',
+  MULTITABLE_EMAIL_SMTP_PORT: '587',
+  MULTITABLE_EMAIL_SMTP_USER: 'smtp-user',
+  MULTITABLE_EMAIL_SMTP_PASSWORD: 'smtp-password-secret',
+  MULTITABLE_EMAIL_SMTP_FROM: 'ops-private@example.com',
+}
+
+function runRealSendSmoke(env, args = ['exec', 'tsx', 'scripts/ops/multitable-email-real-send-smoke.ts']) {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ms2-email-real-send-'))
+  const jsonPath = path.join(tmpRoot, 'report.json')
+  const mdPath = path.join(tmpRoot, 'report.md')
+  const result = spawnSync('pnpm', args, {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      ...env,
+      EMAIL_REAL_SEND_JSON: jsonPath,
+      EMAIL_REAL_SEND_MD: mdPath,
+    },
+    encoding: 'utf8',
+  })
+
+  return {
+    ...result,
+    jsonPath,
+    mdPath,
+    json: fs.existsSync(jsonPath) ? JSON.parse(fs.readFileSync(jsonPath, 'utf8')) : null,
+    markdown: fs.existsSync(mdPath) ? fs.readFileSync(mdPath, 'utf8') : '',
+  }
+}
+
+test('real-send smoke blocks unless explicit real-send guards are present', () => {
+  const result = runRealSendSmoke(COMPLETE_SMTP_ENV)
+
+  assert.equal(result.status, 2)
+  assert.equal(result.json.status, 'blocked')
+  assert.match(result.markdown, /MULTITABLE_EMAIL_REAL_SEND_SMOKE=1/)
+  assert.match(result.markdown, /CONFIRM_SEND_EMAIL=1/)
+})
+
+test('real-send smoke blocks when recipient is missing', () => {
+  const result = runRealSendSmoke({
+    ...COMPLETE_SMTP_ENV,
+    MULTITABLE_EMAIL_REAL_SEND_SMOKE: '1',
+    CONFIRM_SEND_EMAIL: '1',
+  })
+
+  assert.equal(result.status, 2)
+  assert.equal(result.json.status, 'blocked')
+  assert.match(result.markdown, /MULTITABLE_EMAIL_SMOKE_TO/)
+})
+
+test('real-send smoke redacts SMTP secrets and recipient from blocked artifacts', () => {
+  const result = runRealSendSmoke({
+    ...COMPLETE_SMTP_ENV,
+    MULTITABLE_EMAIL_SMTP_HOST: 'smtp://user:pass@smtp.example.com?token=secret-token',
+    MULTITABLE_EMAIL_SMTP_PORT: '70000',
+    MULTITABLE_EMAIL_SMTP_PASSWORD: 'Bearer raw-token-value',
+    MULTITABLE_EMAIL_REAL_SEND_SMOKE: '1',
+    CONFIRM_SEND_EMAIL: '1',
+    MULTITABLE_EMAIL_SMOKE_TO: 'recipient-private@example.com',
+  })
+
+  assert.equal(result.status, 2)
+  const combined = [
+    result.stdout,
+    result.stderr,
+    result.markdown,
+    JSON.stringify(result.json),
+  ].join('\n')
+  assert.doesNotMatch(combined, /user:pass/)
+  assert.doesNotMatch(combined, /secret-token/)
+  assert.doesNotMatch(combined, /raw-token-value/)
+  assert.doesNotMatch(combined, /ops-private@example\.com/)
+  assert.doesNotMatch(combined, /recipient-private@example\.com/)
+})
+
+test('package script launches the real-send smoke harness', () => {
+  const result = runRealSendSmoke({}, ['verify:multitable-email:real-send'])
+
+  assert.equal(result.status, 2)
+  assert.equal(result.json.status, 'blocked')
+})

--- a/scripts/ops/multitable-email-real-send-smoke.ts
+++ b/scripts/ops/multitable-email-real-send-smoke.ts
@@ -1,0 +1,182 @@
+#!/usr/bin/env tsx
+
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import emailTransportReadinessModule from '../../packages/core-backend/src/services/email-transport-readiness.ts'
+
+const {
+  EMAIL_CONFIRM_SEND_ENV,
+  EMAIL_REAL_SEND_SMOKE_ENV,
+  EMAIL_TRANSPORT_ENV,
+  redactEmailTransportText,
+  resolveEmailTransportReadiness,
+} = emailTransportReadinessModule as typeof import('../../packages/core-backend/src/services/email-transport-readiness')
+
+type EmailTransportEnv = import('../../packages/core-backend/src/services/email-transport-readiness').EmailTransportEnv
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url))
+const repoRoot = path.resolve(scriptDir, '../..')
+const RECIPIENT_ENV = 'MULTITABLE_EMAIL_SMOKE_TO'
+
+interface RealSendSmokeReport {
+  ok: boolean
+  status: 'pass' | 'blocked' | 'failed'
+  mode: string
+  recipientConfigured: boolean
+  notificationStatus?: string
+  notificationId?: string
+  failedReason?: string
+  messages: string[]
+  readiness: ReturnType<typeof resolveEmailTransportReadiness>
+}
+
+function envString(name: string): string {
+  return process.env[name]?.trim() ?? ''
+}
+
+function outputPath(envName: string, fallback: string): string {
+  const raw = envString(envName)
+  return path.resolve(repoRoot, raw || fallback)
+}
+
+function redactRuntimeText(value: string, env: EmailTransportEnv): string {
+  const recipient = envString(RECIPIENT_ENV)
+  const redacted = redactEmailTransportText(value, env)
+  return recipient ? redacted.split(recipient).join('<redacted-recipient>') : redacted
+}
+
+function renderRealSendMarkdown(report: RealSendSmokeReport): string {
+  const lines = [
+    '# Multitable Email Real-Send Smoke',
+    '',
+    `- Status: \`${report.status}\``,
+    `- Mode: \`${report.mode}\``,
+    `- Recipient configured: \`${report.recipientConfigured ? 'yes' : 'no'}\``,
+  ]
+
+  if (report.notificationStatus) {
+    lines.push(`- Notification status: \`${report.notificationStatus}\``)
+  }
+  if (report.notificationId) {
+    lines.push(`- Notification id: \`${report.notificationId}\``)
+  }
+  if (report.failedReason) {
+    lines.push(`- Failed reason: ${report.failedReason}`)
+  }
+
+  lines.push(
+    '',
+    '## Messages',
+    '',
+    ...report.messages.map((message) => `- ${message}`),
+    '',
+    '## Notes',
+    '',
+    '- This script sends real email only when all explicit real-send guards are set.',
+    '- Raw SMTP credentials, bearer tokens, JWTs, and recipient addresses are not rendered in this report.',
+    '- Store SMTP credentials in the runtime secret store or shell environment, not in tracked docs.',
+  )
+
+  return `${lines.join('\n')}\n`
+}
+
+async function writeReport(report: RealSendSmokeReport): Promise<void> {
+  const jsonPath = outputPath('EMAIL_REAL_SEND_JSON', 'output/multitable-email-real-send-smoke/report.json')
+  const mdPath = outputPath('EMAIL_REAL_SEND_MD', 'output/multitable-email-real-send-smoke/report.md')
+  const markdown = renderRealSendMarkdown(report)
+
+  await fs.mkdir(path.dirname(jsonPath), { recursive: true })
+  await fs.mkdir(path.dirname(mdPath), { recursive: true })
+  await fs.writeFile(jsonPath, `${JSON.stringify(report, null, 2)}\n`)
+  await fs.writeFile(mdPath, markdown)
+
+  process.stdout.write(markdown)
+  process.stdout.write(`\nJSON report: ${jsonPath}\nMarkdown report: ${mdPath}\n`)
+}
+
+async function main(): Promise<void> {
+  const env = process.env as EmailTransportEnv
+  const readiness = resolveEmailTransportReadiness(env)
+  const recipient = envString(RECIPIENT_ENV)
+  const messages = [...readiness.messages]
+
+  if (readiness.mode !== 'smtp') {
+    messages.push(`${EMAIL_TRANSPORT_ENV}=smtp is required for real-send smoke.`)
+  }
+  if (!readiness.realSendRequested) {
+    messages.push(`${EMAIL_REAL_SEND_SMOKE_ENV}=1 is required for real-send smoke.`)
+  }
+  if (!readiness.confirmSend) {
+    messages.push(`${EMAIL_CONFIRM_SEND_ENV}=1 is required for real-send smoke.`)
+  }
+  if (!recipient) {
+    messages.push(`${RECIPIENT_ENV} is required for real-send smoke.`)
+  }
+
+  if (!readiness.ok || readiness.mode !== 'smtp' || !readiness.realSendRequested || !readiness.confirmSend || !recipient) {
+    await writeReport({
+      ok: false,
+      status: 'blocked',
+      mode: readiness.mode,
+      recipientConfigured: Boolean(recipient),
+      messages,
+      readiness,
+    })
+    process.exitCode = 2
+    return
+  }
+
+  const notificationServiceModule = await import('../../packages/core-backend/src/services/NotificationService.ts')
+  const { EmailNotificationChannel } = (notificationServiceModule.default ?? notificationServiceModule) as typeof import('../../packages/core-backend/src/services/NotificationService')
+  const channel = new EmailNotificationChannel({ env })
+  const subject = envString('MULTITABLE_EMAIL_SMOKE_SUBJECT') || `MetaSheet email transport smoke ${new Date().toISOString()}`
+  const result = await channel.sender(
+    {
+      channel: 'email',
+      subject,
+      content: [
+        'MetaSheet multitable send_email real-send smoke.',
+        `Generated at: ${new Date().toISOString()}`,
+        'If you received this message, SMTP transport delivery is wired.',
+      ].join('\n'),
+      recipients: [{ id: recipient, type: 'email' }],
+      metadata: {
+        source: 'multitable-email-real-send-smoke',
+      },
+    },
+    [{ id: recipient, type: 'email' }],
+  )
+
+  const ok = result.status === 'sent'
+  await writeReport({
+    ok,
+    status: ok ? 'pass' : 'failed',
+    mode: readiness.mode,
+    recipientConfigured: true,
+    notificationStatus: result.status,
+    notificationId: result.id,
+    failedReason: result.failedReason ? redactRuntimeText(result.failedReason, env) : undefined,
+    messages: ok
+      ? ['Real-send smoke completed; verify mailbox receipt for the configured recipient.']
+      : ['Real-send smoke failed before a successful notification result.'],
+    readiness,
+  })
+  process.exitCode = ok ? 0 : 1
+}
+
+main().catch(async (error: unknown) => {
+  const env = process.env as EmailTransportEnv
+  const readiness = resolveEmailTransportReadiness(env)
+  const message = redactRuntimeText(error instanceof Error ? error.message : String(error), env)
+  await writeReport({
+    ok: false,
+    status: 'failed',
+    mode: readiness.mode,
+    recipientConfigured: Boolean(envString(RECIPIENT_ENV)),
+    failedReason: message,
+    messages: ['Real-send smoke crashed before producing a successful notification result.'],
+    readiness,
+  })
+  process.exitCode = 1
+})


### PR DESCRIPTION
## Summary

- Adds `pnpm verify:multitable-email:real-send`, an operator-run SMTP mailbox smoke harness for the remaining Phase 2 email transport staging evidence.
- Fails closed by default: no real email is sent unless SMTP mode, real-send guard, confirm guard, and recipient env are all set.
- Writes redacted JSON/MD artifacts for pass/blocked/failed outcomes without raw SMTP credentials or recipient addresses.
- Updates the Phase 2 TODO plus B3 development/verification docs.

## Verification

- `node --test scripts/ops/multitable-email-real-send-smoke.test.mjs` — 4/4 pass
- `node --test scripts/ops/multitable-email-transport-readiness.test.mjs` — 4/4 pass
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/email-transport-readiness.test.ts --reporter=dot` — 13/13 pass
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false` — pass
- `pnpm verify:multitable-email:real-send` — exits 2 by default, blocked before any send attempt
- `git diff --check` — clean

## Not Run

- Real SMTP mailbox receipt. This PR only adds the guarded harness; actual send requires operator-controlled SMTP credentials and `MULTITABLE_EMAIL_SMOKE_TO`.
