### PR TITLE
fix(multitable): honor automation condition conjunctions

### DIFF
--- a/docs/development/multitable-automation-nested-conditions-development-20260511.md
+++ b/docs/development/multitable-automation-nested-conditions-development-20260511.md
@@ -1,0 +1,72 @@
+# Multitable Automation Nested Conditions Development - 2026-05-11
+
+## Context
+
+Phase 2 email real-send mailbox receipt is intentionally deferred because it needs operator-controlled SMTP credentials and a real recipient.
+
+The next source-only Feishu parity slice targets automation conditions. `packages/core-backend/src/multitable/automation-conditions.ts` still described a V1-only flat condition list, and it accepted only backend-shaped `logic: 'and' | 'or'`.
+
+The current frontend rule editor sends `conditions.conjunction: 'AND' | 'OR'`. Before this slice, the backend evaluator ignored `conjunction`; any frontend-authored `AND` group fell through to the default OR branch. That made multi-condition automation rules fire too broadly.
+
+## Scope
+
+Implemented:
+
+- Accept both backend `logic` and frontend `conjunction` group keys.
+- Default unknown/missing group logic to `and`, which is the safer fail-closed behavior for rule conditions.
+- Evaluate nested condition groups recursively.
+- Add backend support for `greater_or_equal` and `less_or_equal`, matching frontend condition operator types.
+- Simplify executor gating so empty or malformed condition groups go through the evaluator instead of reading `.conditions.length` directly.
+- Add focused unit coverage for:
+  - backend `logic=and`;
+  - frontend `conjunction=AND`;
+  - frontend `conjunction=OR`;
+  - nested group recursion;
+  - inclusive comparison operators.
+
+Not implemented:
+
+- Frontend nested-condition editor UI.
+- Condition schema migration or DB shape changes.
+- New route payload validation. Existing routes already persist JSONB condition payloads.
+- SMTP real mailbox receipt verification.
+
+## Design
+
+### Dual group shape
+
+`ConditionGroup` now supports both:
+
+```ts
+{ logic: 'and', conditions: [...] }
+{ conjunction: 'AND', conditions: [...] }
+```
+
+This preserves older backend callers while making existing frontend-authored rules execute with the intended conjunction.
+
+### Recursive nodes
+
+The evaluator now treats each group entry as either a leaf `AutomationCondition` or another `ConditionGroup`.
+
+```ts
+type AutomationConditionNode = AutomationCondition | ConditionGroup
+```
+
+This enables API clients and future UI work to submit nested rule trees without changing the executor contract.
+
+### Safe fallback
+
+If a group has neither a recognized `logic` nor `conjunction`, the evaluator uses `and`.
+
+Reason: a malformed condition group should not broaden automation execution accidentally.
+
+## Files Changed
+
+- `packages/core-backend/src/multitable/automation-conditions.ts`
+- `packages/core-backend/src/multitable/automation-executor.ts`
+- `packages/core-backend/tests/unit/multitable-automation-conditions.test.ts`
+
+## Follow-Ups
+
+- Add a frontend nested-condition builder only after product confirms the desired interaction model.
+- Add route-level zod validation if automation rules start accepting externally authored nested condition trees from untrusted integrations.

--- a/docs/development/multitable-automation-nested-conditions-verification-20260511.md
+++ b/docs/development/multitable-automation-nested-conditions-verification-20260511.md
@@ -1,0 +1,79 @@
+# Multitable Automation Nested Conditions Verification - 2026-05-11
+
+## Environment
+
+- Worktree: `/private/tmp/ms2-automation-nested-conditions-20260511`
+- Branch: `codex/multitable-automation-nested-conditions-20260511`
+- Baseline: `origin/main@b354767a2`
+- Scope: backend automation condition evaluator compatibility and nested group support.
+
+## Commands
+
+### Focused condition evaluator tests
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/multitable-automation-conditions.test.ts \
+  --reporter=dot
+```
+
+Expected:
+
+- backend `logic=and` still works;
+- frontend `conjunction=AND` evaluates as AND, not OR;
+- frontend `conjunction=OR` evaluates as OR;
+- nested groups evaluate recursively;
+- `greater_or_equal` and `less_or_equal` operators work.
+
+Result:
+
+- 1 file passed.
+- 5 tests passed.
+
+### Automation service regression
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/multitable-automation-service.test.ts \
+  --reporter=dot
+```
+
+Expected:
+
+- create/update rule parsing still preserves condition payloads;
+- existing DingTalk/send_email automation validation tests remain green.
+
+Result:
+
+- 1 file passed.
+- 33 tests passed.
+
+### Type check
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
+```
+
+Expected: pass.
+
+Result: pass.
+
+### Diff hygiene
+
+```bash
+git diff --check
+```
+
+Expected: pass.
+
+Result: pass.
+
+## Non-Verification
+
+- No frontend nested-condition editor smoke was run because this slice does not add nested UI.
+- No live automation execution against PostgreSQL was run in this worktree.
+- No SMTP real-send mailbox receipt was attempted.
+
+## Result
+
+Source verification passed. The evaluator now honors frontend `conjunction` payloads, keeps backend `logic` payloads compatible, supports nested groups, and covers inclusive comparison operators without changing automation route or DB contracts.

--- a/packages/core-backend/src/multitable/automation-conditions.ts
+++ b/packages/core-backend/src/multitable/automation-conditions.ts
@@ -1,7 +1,10 @@
 /**
- * Automation Condition Engine — V1
- * Simple condition evaluation for "if/then" logic on record data.
- * No nested groups for V1 — flat condition list with AND/OR logic.
+ * Automation Condition Engine
+ *
+ * Evaluates record predicates for "if/then" automation rules. The evaluator
+ * accepts both the older backend `logic: 'and' | 'or'` shape and the current
+ * frontend `conjunction: 'AND' | 'OR'` shape, then recurses through nested
+ * groups when API clients send them.
  */
 
 export type ConditionOperator =
@@ -11,6 +14,8 @@ export type ConditionOperator =
   | 'not_contains'
   | 'greater_than'
   | 'less_than'
+  | 'greater_or_equal'
+  | 'less_or_equal'
   | 'is_empty'
   | 'is_not_empty'
   | 'in'
@@ -22,9 +27,26 @@ export interface AutomationCondition {
   value?: unknown
 }
 
+export type AutomationConditionNode = AutomationCondition | ConditionGroup
+
 export interface ConditionGroup {
-  logic: 'and' | 'or'
-  conditions: AutomationCondition[]
+  logic?: 'and' | 'or'
+  conjunction?: 'AND' | 'OR' | 'and' | 'or'
+  conditions: AutomationConditionNode[]
+}
+
+function isConditionGroup(node: AutomationConditionNode): node is ConditionGroup {
+  return typeof (node as ConditionGroup).conditions !== 'undefined'
+}
+
+function resolveGroupLogic(conditionGroup: ConditionGroup): 'and' | 'or' {
+  const logic = conditionGroup.logic?.toLowerCase()
+  if (logic === 'and' || logic === 'or') return logic
+
+  const conjunction = conditionGroup.conjunction?.toLowerCase()
+  if (conjunction === 'and' || conjunction === 'or') return conjunction
+
+  return 'and'
 }
 
 /**
@@ -83,6 +105,26 @@ export function evaluateCondition(
       return false
     }
 
+    case 'greater_or_equal': {
+      if (typeof fieldValue === 'number' && typeof condition.value === 'number') {
+        return fieldValue >= condition.value
+      }
+      if (typeof fieldValue === 'string' && typeof condition.value === 'string') {
+        return fieldValue >= condition.value
+      }
+      return false
+    }
+
+    case 'less_or_equal': {
+      if (typeof fieldValue === 'number' && typeof condition.value === 'number') {
+        return fieldValue <= condition.value
+      }
+      if (typeof fieldValue === 'string' && typeof condition.value === 'string') {
+        return fieldValue <= condition.value
+      }
+      return false
+    }
+
     case 'is_empty':
       return fieldValue === null || fieldValue === undefined || fieldValue === ''
 
@@ -104,6 +146,15 @@ export function evaluateCondition(
   }
 }
 
+function evaluateConditionNode(
+  node: AutomationConditionNode,
+  recordData: Record<string, unknown>,
+): boolean {
+  return isConditionGroup(node)
+    ? evaluateConditions(node, recordData)
+    : evaluateCondition(node, recordData)
+}
+
 /**
  * Evaluate a condition group against record data.
  * AND: all conditions must pass.
@@ -113,16 +164,17 @@ export function evaluateConditions(
   conditionGroup: ConditionGroup,
   recordData: Record<string, unknown>,
 ): boolean {
-  const { logic, conditions } = conditionGroup
+  const { conditions } = conditionGroup
 
   if (!conditions || conditions.length === 0) {
     return true // no conditions means always pass
   }
 
+  const logic = resolveGroupLogic(conditionGroup)
   if (logic === 'and') {
-    return conditions.every((c) => evaluateCondition(c, recordData))
+    return conditions.every((c) => evaluateConditionNode(c, recordData))
   }
 
   // logic === 'or'
-  return conditions.some((c) => evaluateCondition(c, recordData))
+  return conditions.some((c) => evaluateConditionNode(c, recordData))
 }

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -543,7 +543,7 @@ export class AutomationExecutor {
     }
 
     // Evaluate conditions
-    if (rule.conditions && rule.conditions.conditions.length > 0) {
+    if (rule.conditions) {
       const conditionsPassed = evaluateConditions(rule.conditions, context.recordData)
       if (!conditionsPassed) {
         execution.status = 'skipped'

--- a/packages/core-backend/tests/unit/multitable-automation-conditions.test.ts
+++ b/packages/core-backend/tests/unit/multitable-automation-conditions.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  evaluateCondition,
+  evaluateConditions,
+  type ConditionGroup,
+} from '../../src/multitable/automation-conditions'
+
+describe('multitable automation conditions', () => {
+  it('evaluates backend logic=and groups', () => {
+    const group: ConditionGroup = {
+      logic: 'and',
+      conditions: [
+        { fieldId: 'status', operator: 'equals', value: 'Ready' },
+        { fieldId: 'priority', operator: 'greater_or_equal', value: 2 },
+      ],
+    }
+
+    expect(evaluateConditions(group, { status: 'Ready', priority: 2 })).toBe(true)
+    expect(evaluateConditions(group, { status: 'Ready', priority: 1 })).toBe(false)
+  })
+
+  it('evaluates frontend conjunction=AND groups as AND, not OR', () => {
+    const group: ConditionGroup = {
+      conjunction: 'AND',
+      conditions: [
+        { fieldId: 'stage', operator: 'equals', value: 'Won' },
+        { fieldId: 'amount', operator: 'greater_than', value: 1000 },
+      ],
+    }
+
+    expect(evaluateConditions(group, { stage: 'Won', amount: 1500 })).toBe(true)
+    expect(evaluateConditions(group, { stage: 'Won', amount: 500 })).toBe(false)
+  })
+
+  it('evaluates frontend conjunction=OR groups', () => {
+    const group: ConditionGroup = {
+      conjunction: 'OR',
+      conditions: [
+        { fieldId: 'stage', operator: 'equals', value: 'Won' },
+        { fieldId: 'amount', operator: 'greater_than', value: 1000 },
+      ],
+    }
+
+    expect(evaluateConditions(group, { stage: 'Lost', amount: 1500 })).toBe(true)
+    expect(evaluateConditions(group, { stage: 'Lost', amount: 500 })).toBe(false)
+  })
+
+  it('evaluates nested groups recursively', () => {
+    const group: ConditionGroup = {
+      conjunction: 'AND',
+      conditions: [
+        { fieldId: 'status', operator: 'is_not_empty' },
+        {
+          conjunction: 'OR',
+          conditions: [
+            { fieldId: 'owner', operator: 'equals', value: 'Alice' },
+            {
+              logic: 'and',
+              conditions: [
+                { fieldId: 'priority', operator: 'greater_or_equal', value: 3 },
+                { fieldId: 'blocked', operator: 'not_equals', value: true },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+
+    expect(evaluateConditions(group, {
+      status: 'Open',
+      owner: 'Bob',
+      priority: 3,
+      blocked: false,
+    })).toBe(true)
+    expect(evaluateConditions(group, {
+      status: 'Open',
+      owner: 'Bob',
+      priority: 3,
+      blocked: true,
+    })).toBe(false)
+  })
+
+  it('supports inclusive comparison operators for frontend payloads', () => {
+    expect(evaluateCondition(
+      { fieldId: 'score', operator: 'greater_or_equal', value: 10 },
+      { score: 10 },
+    )).toBe(true)
+    expect(evaluateCondition(
+      { fieldId: 'score', operator: 'less_or_equal', value: 10 },
+      { score: 11 },
+    )).toBe(false)
+    expect(evaluateCondition(
+      { fieldId: 'name', operator: 'less_or_equal', value: 'm' },
+      { name: 'alpha' },
+    )).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

- Fix automation condition evaluation so frontend-authored `conjunction: 'AND' | 'OR'` payloads execute with the intended logic instead of falling through to OR.
- Keep backend `logic: 'and' | 'or'` payloads compatible, add recursive nested-group evaluation, and support `greater_or_equal` / `less_or_equal` operators already exposed in frontend types.
- Route empty or malformed condition groups through the evaluator instead of reading `.conditions.length` directly in the executor.
- Add development and verification docs for the slice.

## Verification

- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/multitable-automation-conditions.test.ts --reporter=dot` — 5/5 pass
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/multitable-automation-service.test.ts --reporter=dot` — 33/33 pass
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false` — pass
- `git diff --check` — pass

## Notes

- Does not add a frontend nested-condition editor.
- Does not touch SMTP real-send verification or DingTalk integration code.
