### PR TITLE
fix(multitable): validate automation condition payloads

### DIFF
--- a/docs/development/multitable-automation-condition-schema-development-20260511.md
+++ b/docs/development/multitable-automation-condition-schema-development-20260511.md
@@ -1,0 +1,72 @@
+# Multitable Automation Condition Schema Development - 2026-05-11
+
+## Context
+
+PR #1466 fixed automation condition execution so the backend evaluator honors both:
+
+- backend-style `logic: 'and' | 'or'`;
+- frontend-style `conjunction: 'AND' | 'OR'`.
+
+That made existing rules execute correctly, but route parsing still accepted arbitrary `conditions` objects and persisted them as JSONB. A malformed payload could still survive until execution time.
+
+This follow-up adds route-boundary validation without changing the database schema or frontend UI.
+
+## Scope
+
+Implemented:
+
+- Added `normalizeConditionGroupInput(...)` in `automation-conditions.ts`.
+- Added `ConditionGroupValidationError` for schema-level failures.
+- Wired `parseCreateRuleInput(...)` and `parseUpdateRuleInput(...)` to validate and normalize `conditions`.
+- Preserved both accepted condition group shapes:
+  - `{ logic: 'and' | 'or', conditions: [...] }`
+  - `{ conjunction: 'AND' | 'OR', conditions: [...] }`
+- Supported nested condition groups recursively with a maximum nesting depth.
+- Validated leaf conditions:
+  - non-empty `fieldId`;
+  - known operator;
+  - required `value` for value-bearing operators;
+  - array `value` for `in` / `not_in`.
+- Normalized:
+  - `conjunction: 'and'` to `conjunction: 'AND'`;
+  - `logic: 'OR'` to `logic: 'or'`;
+  - trimmed leaf `fieldId`.
+
+Not implemented:
+
+- Frontend nested-condition editor UI.
+- Field-type-aware semantic validation, because the parser does not receive sheet field metadata.
+- DB migration or persisted JSONB rewrite.
+- SMTP real-send mailbox receipt verification.
+
+## Design Decisions
+
+### Validate At The Route Parse Boundary
+
+The route layer already funnels create/update bodies through `parseCreateRuleInput(...)` and `parseUpdateRuleInput(...)`.
+
+Putting validation there gives API callers deterministic `VALIDATION_ERROR` behavior while keeping the executor simple.
+
+### Keep Evaluator Backward-Compatible
+
+The evaluator still has a safe default for malformed old persisted rows. This follow-up only blocks new malformed route input.
+
+Reason: existing JSONB rows may predate the validator; execution should remain fail-safe rather than crash.
+
+### Do Not Over-Validate Field Semantics
+
+The validator checks operator/value shape but does not verify whether a specific field supports a comparison.
+
+Reason: field metadata is not available at this generic route parse boundary. Runtime evaluation already returns false for incompatible comparison types.
+
+## Files Changed
+
+- `packages/core-backend/src/multitable/automation-conditions.ts`
+- `packages/core-backend/src/multitable/automation-service.ts`
+- `packages/core-backend/tests/unit/multitable-automation-conditions.test.ts`
+- `packages/core-backend/tests/unit/multitable-automation-service.test.ts`
+
+## Follow-Ups
+
+- Add a frontend nested-condition builder after product confirms UX.
+- Add field-aware validation later if the automation rule route starts loading field metadata during create/update.

--- a/docs/development/multitable-automation-condition-schema-verification-20260511.md
+++ b/docs/development/multitable-automation-condition-schema-verification-20260511.md
@@ -1,0 +1,82 @@
+# Multitable Automation Condition Schema Verification - 2026-05-11
+
+## Environment
+
+- Worktree: `/private/tmp/ms2-automation-condition-schema-20260511`
+- Branch: `codex/multitable-automation-condition-schema-20260511`
+- Baseline: `origin/main@30e55e417`
+- Scope: backend automation condition route-boundary schema validation.
+
+## Commands
+
+### Focused condition evaluator and normalizer tests
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/multitable-automation-conditions.test.ts \
+  --reporter=dot
+```
+
+Expected:
+
+- existing evaluator behavior remains green;
+- valid nested route payloads normalize;
+- invalid operator / invalid group logic / invalid `in` value fail loudly.
+
+Result:
+
+- 1 file passed.
+- 7 tests passed.
+
+### Automation service parser regression
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/multitable-automation-service.test.ts \
+  --reporter=dot
+```
+
+Expected:
+
+- create/update rule parsing normalizes condition payloads;
+- malformed condition payloads throw `AutomationRuleValidationError`;
+- existing DingTalk/send_email validation behavior remains green.
+
+Result:
+
+- 1 file passed.
+- 36 tests passed.
+
+### Type Check
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false
+```
+
+Expected: pass.
+
+Result:
+
+- pass.
+
+### Diff Hygiene
+
+```bash
+git diff --check
+```
+
+Expected: pass.
+
+Result:
+
+- pass.
+
+## Non-Verification
+
+- No frontend nested-condition editor was added or smoke-tested.
+- No live PostgreSQL route integration was run.
+- No SMTP real-send mailbox receipt was attempted.
+
+## Result
+
+Source verification passed. Automation rule create/update parsing now rejects malformed condition JSON before persistence, while preserving the condition shapes already used by backend callers and the frontend rule editor.

--- a/packages/core-backend/src/multitable/automation-conditions.ts
+++ b/packages/core-backend/src/multitable/automation-conditions.ts
@@ -21,6 +21,37 @@ export type ConditionOperator =
   | 'in'
   | 'not_in'
 
+const VALID_CONDITION_OPERATORS = new Set<ConditionOperator>([
+  'equals',
+  'not_equals',
+  'contains',
+  'not_contains',
+  'greater_than',
+  'less_than',
+  'greater_or_equal',
+  'less_or_equal',
+  'is_empty',
+  'is_not_empty',
+  'in',
+  'not_in',
+])
+
+const VALUE_REQUIRED_OPERATORS = new Set<ConditionOperator>([
+  'equals',
+  'not_equals',
+  'contains',
+  'not_contains',
+  'greater_than',
+  'less_than',
+  'greater_or_equal',
+  'less_or_equal',
+  'in',
+  'not_in',
+])
+
+const ARRAY_VALUE_OPERATORS = new Set<ConditionOperator>(['in', 'not_in'])
+const MAX_CONDITION_GROUP_DEPTH = 5
+
 export interface AutomationCondition {
   fieldId: string
   operator: ConditionOperator
@@ -35,8 +66,19 @@ export interface ConditionGroup {
   conditions: AutomationConditionNode[]
 }
 
+export class ConditionGroupValidationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ConditionGroupValidationError'
+  }
+}
+
 function isConditionGroup(node: AutomationConditionNode): node is ConditionGroup {
   return typeof (node as ConditionGroup).conditions !== 'undefined'
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
 }
 
 function resolveGroupLogic(conditionGroup: ConditionGroup): 'and' | 'or' {
@@ -47,6 +89,97 @@ function resolveGroupLogic(conditionGroup: ConditionGroup): 'and' | 'or' {
   if (conjunction === 'and' || conjunction === 'or') return conjunction
 
   return 'and'
+}
+
+function normalizeLogicToken(value: unknown, path: string): 'and' | 'or' | null {
+  if (value === undefined) return null
+  if (typeof value !== 'string') {
+    throw new ConditionGroupValidationError(`${path} must be "and" or "or"`)
+  }
+  const normalized = value.toLowerCase()
+  if (normalized === 'and' || normalized === 'or') return normalized
+  throw new ConditionGroupValidationError(`${path} must be "and" or "or"`)
+}
+
+function normalizeConjunctionToken(value: unknown, path: string): 'AND' | 'OR' | null {
+  if (value === undefined) return null
+  if (typeof value !== 'string') {
+    throw new ConditionGroupValidationError(`${path} must be "AND" or "OR"`)
+  }
+  const normalized = value.toUpperCase()
+  if (normalized === 'AND' || normalized === 'OR') return normalized
+  throw new ConditionGroupValidationError(`${path} must be "AND" or "OR"`)
+}
+
+function normalizeConditionLeaf(value: unknown, path: string): AutomationCondition {
+  if (!isPlainObject(value)) {
+    throw new ConditionGroupValidationError(`${path} must be an object`)
+  }
+
+  const fieldId = typeof value.fieldId === 'string' ? value.fieldId.trim() : ''
+  if (!fieldId) {
+    throw new ConditionGroupValidationError(`${path}.fieldId is required`)
+  }
+
+  const operator = value.operator
+  if (typeof operator !== 'string' || !VALID_CONDITION_OPERATORS.has(operator as ConditionOperator)) {
+    throw new ConditionGroupValidationError(`${path}.operator is invalid`)
+  }
+
+  const normalizedOperator = operator as ConditionOperator
+  if (VALUE_REQUIRED_OPERATORS.has(normalizedOperator) && value.value === undefined) {
+    throw new ConditionGroupValidationError(`${path}.value is required for ${normalizedOperator}`)
+  }
+  if (ARRAY_VALUE_OPERATORS.has(normalizedOperator) && !Array.isArray(value.value)) {
+    throw new ConditionGroupValidationError(`${path}.value must be an array for ${normalizedOperator}`)
+  }
+
+  const condition: AutomationCondition = { fieldId, operator: normalizedOperator }
+  if (value.value !== undefined) condition.value = value.value
+  return condition
+}
+
+function normalizeConditionNodeInput(
+  value: unknown,
+  path: string,
+  depth: number,
+): AutomationConditionNode {
+  if (isPlainObject(value) && Object.prototype.hasOwnProperty.call(value, 'conditions')) {
+    return normalizeConditionGroupInput(value, path, depth)
+  }
+  return normalizeConditionLeaf(value, path)
+}
+
+export function normalizeConditionGroupInput(
+  value: unknown,
+  path = 'conditions',
+  depth = 0,
+): ConditionGroup {
+  if (depth > MAX_CONDITION_GROUP_DEPTH) {
+    throw new ConditionGroupValidationError(`${path} exceeds maximum nesting depth ${MAX_CONDITION_GROUP_DEPTH}`)
+  }
+  if (!isPlainObject(value)) {
+    throw new ConditionGroupValidationError(`${path} must be an object`)
+  }
+
+  const logic = normalizeLogicToken(value.logic, `${path}.logic`)
+  const conjunction = normalizeConjunctionToken(value.conjunction, `${path}.conjunction`)
+  if (!logic && !conjunction) {
+    throw new ConditionGroupValidationError(`${path}.logic or ${path}.conjunction is required`)
+  }
+  if (logic && conjunction && logic !== conjunction.toLowerCase()) {
+    throw new ConditionGroupValidationError(`${path}.logic and ${path}.conjunction must agree`)
+  }
+  if (!Array.isArray(value.conditions)) {
+    throw new ConditionGroupValidationError(`${path}.conditions must be an array`)
+  }
+
+  const conditions = value.conditions.map((condition, index) =>
+    normalizeConditionNodeInput(condition, `${path}.conditions[${index}]`, depth + 1),
+  )
+
+  if (conjunction) return { conjunction, conditions }
+  return { logic: logic ?? 'and', conditions }
 }
 
 /**

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -3,7 +3,11 @@ import type { Kysely } from 'kysely'
 import type { EventBus } from '../integration/events/event-bus'
 import { Logger } from '../core/logger'
 import { matchesTrigger, TRIGGER_TYPE_BY_EVENT, type AutomationTriggerType } from './automation-triggers'
-import type { ConditionGroup } from './automation-conditions'
+import {
+  ConditionGroupValidationError,
+  normalizeConditionGroupInput,
+  type ConditionGroup,
+} from './automation-conditions'
 import { AutomationExecutor, type AutomationRule as ExecutorRule, type AutomationExecution, type AutomationDeps } from './automation-executor'
 import type { AutomationAction } from './automation-actions'
 import type { AutomationTrigger } from './automation-triggers'
@@ -93,6 +97,17 @@ function validateSendEmailActionConfigs(
     if (error) return error
   }
   return null
+}
+
+function parseConditionGroupInput(value: unknown): ConditionGroup {
+  try {
+    return normalizeConditionGroupInput(value)
+  } catch (error) {
+    if (error instanceof ConditionGroupValidationError) {
+      throw new AutomationRuleValidationError(error.message)
+    }
+    throw error
+  }
 }
 
 /**
@@ -787,9 +802,9 @@ export function parseCreateRuleInput(
     throw new AutomationRuleValidationError(`Invalid action_type: ${actionType}`)
   }
 
-  const conditions = body?.conditions && typeof body.conditions === 'object'
-    ? body.conditions as ConditionGroup
-    : null
+  const conditions = body?.conditions === undefined || body.conditions === null
+    ? null
+    : parseConditionGroupInput(body.conditions)
 
   return {
     name,
@@ -846,7 +861,7 @@ export function parseUpdateRuleInput(body: Record<string, unknown> | undefined):
     touched = true
   }
   if (body?.conditions !== undefined) {
-    input.conditions = body.conditions ? (body.conditions as ConditionGroup) : null
+    input.conditions = body.conditions === null ? null : parseConditionGroupInput(body.conditions)
     touched = true
   }
   if (body?.actions !== undefined) {

--- a/packages/core-backend/tests/unit/multitable-automation-conditions.test.ts
+++ b/packages/core-backend/tests/unit/multitable-automation-conditions.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import {
   evaluateCondition,
   evaluateConditions,
+  normalizeConditionGroupInput,
   type ConditionGroup,
 } from '../../src/multitable/automation-conditions'
 
@@ -94,5 +95,48 @@ describe('multitable automation conditions', () => {
       { fieldId: 'name', operator: 'less_or_equal', value: 'm' },
       { name: 'alpha' },
     )).toBe(true)
+  })
+
+  it('normalizes nested condition groups from untrusted route payloads', () => {
+    const group = normalizeConditionGroupInput({
+      conjunction: 'and',
+      conditions: [
+        { fieldId: ' status ', operator: 'is_not_empty' },
+        {
+          logic: 'OR',
+          conditions: [
+            { fieldId: 'owner', operator: 'equals', value: 'Alice' },
+            { fieldId: 'score', operator: 'in', value: [1, 2, 3] },
+          ],
+        },
+      ],
+    })
+
+    expect(group).toEqual({
+      conjunction: 'AND',
+      conditions: [
+        { fieldId: 'status', operator: 'is_not_empty' },
+        {
+          logic: 'or',
+          conditions: [
+            { fieldId: 'owner', operator: 'equals', value: 'Alice' },
+            { fieldId: 'score', operator: 'in', value: [1, 2, 3] },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('rejects invalid route condition payloads', () => {
+    expect(() => normalizeConditionGroupInput({ conjunction: 'X', conditions: [] }))
+      .toThrow('conditions.conjunction must be "AND" or "OR"')
+    expect(() => normalizeConditionGroupInput({
+      conjunction: 'AND',
+      conditions: [{ fieldId: 'status', operator: 'missing' }],
+    })).toThrow('conditions.conditions[0].operator is invalid')
+    expect(() => normalizeConditionGroupInput({
+      conjunction: 'AND',
+      conditions: [{ fieldId: 'status', operator: 'in', value: 'Ready' }],
+    })).toThrow('conditions.conditions[0].value must be an array for in')
   })
 })

--- a/packages/core-backend/tests/unit/multitable-automation-service.test.ts
+++ b/packages/core-backend/tests/unit/multitable-automation-service.test.ts
@@ -439,6 +439,26 @@ describe('M5 — Automation route helpers', () => {
       expect(input.conditions).toEqual({ logic: 'and', conditions: [] })
     })
 
+    it('normalizes frontend condition conjunctions at the route boundary', () => {
+      const input = parseCreateRuleInput({
+        triggerType: 'record.created',
+        actionType: 'send_notification',
+        conditions: {
+          conjunction: 'and',
+          conditions: [
+            { fieldId: ' status ', operator: 'equals', value: 'Ready' },
+          ],
+        },
+      }, null)
+
+      expect(input.conditions).toEqual({
+        conjunction: 'AND',
+        conditions: [
+          { fieldId: 'status', operator: 'equals', value: 'Ready' },
+        ],
+      })
+    })
+
     it('falls back to first action when actionType / actionConfig are absent', () => {
       const body = {
         triggerType: 'record.created',
@@ -468,6 +488,29 @@ describe('M5 — Automation route helpers', () => {
           null,
         ),
       ).toThrow(AutomationRuleValidationError)
+    })
+
+    it('throws AutomationRuleValidationError for malformed condition payloads', () => {
+      expect(() =>
+        parseCreateRuleInput(
+          {
+            triggerType: 'record.created',
+            actionType: 'send_notification',
+            conditions: { conjunction: 'AND', conditions: [{ fieldId: '', operator: 'equals', value: 'x' }] },
+          },
+          null,
+        ),
+      ).toThrow(AutomationRuleValidationError)
+      expect(() =>
+        parseCreateRuleInput(
+          {
+            triggerType: 'record.created',
+            actionType: 'send_notification',
+            conditions: { conjunction: 'AND', conditions: [{ fieldId: 'status', operator: 'in', value: 'Ready' }] },
+          },
+          null,
+        ),
+      ).toThrow('conditions.conditions[0].value must be an array for in')
     })
 
     it('defaults enabled to true and treats missing optional fields safely', () => {
@@ -508,6 +551,27 @@ describe('M5 — Automation route helpers', () => {
       const out = parseUpdateRuleInput({ conditions: null, actions: null })
       expect(out?.conditions).toBeNull()
       expect(out?.actions).toBeNull()
+    })
+
+    it('validates condition payloads on update', () => {
+      expect(parseUpdateRuleInput({
+        conditions: {
+          conjunction: 'OR',
+          conditions: [
+            { fieldId: 'status', operator: 'equals', value: 'Ready' },
+            { fieldId: 'priority', operator: 'greater_or_equal', value: 2 },
+          ],
+        },
+      })?.conditions).toEqual({
+        conjunction: 'OR',
+        conditions: [
+          { fieldId: 'status', operator: 'equals', value: 'Ready' },
+          { fieldId: 'priority', operator: 'greater_or_equal', value: 2 },
+        ],
+      })
+
+      expect(() => parseUpdateRuleInput({ conditions: { conditions: [] } }))
+        .toThrow('conditions.logic or conditions.conjunction is required')
     })
 
     it('rejects an invalid trigger type', () => {


### PR DESCRIPTION
## Summary

- validate and normalize automation `conditions` at create/update route parsing time
- preserve backend `logic` and frontend `conjunction` condition group shapes, including nested groups
- reject malformed operators, missing field IDs, missing values, and non-array `in` / `not_in` values before JSONB persistence
- add development and verification notes under `docs/development/`

## Verification

- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/multitable-automation-conditions.test.ts --reporter=dot` — 7/7 pass
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/multitable-automation-service.test.ts --reporter=dot` — 36/36 pass
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false` — pass
- `git diff --check` — pass

## Notes

- No frontend nested-condition editor is added in this slice.
- No database schema change or persisted JSONB rewrite is included.
