### PR TITLE
feat(integration): simplify K3 WISE setup page

### DIFF
--- a/apps/web/src/views/IntegrationK3WiseSetupView.vue
+++ b/apps/web/src/views/IntegrationK3WiseSetupView.vue
@@ -4,7 +4,7 @@
       <div>
         <p class="k3-setup__eyebrow">ERP Integration</p>
         <h1>K3 WISE 对接配置</h1>
-        <p class="k3-setup__lead">维护 WebAPI、账套、凭据和 SQL Server 通道信息。</p>
+        <p class="k3-setup__lead">先接通 K3 WISE，再把 PLM 数据放进多维表清洗，最后 dry-run 后推送 ERP。</p>
       </div>
       <div class="k3-setup__header-actions">
         <button class="k3-setup__btn" type="button" :disabled="loading" @click="loadSystems">
@@ -17,6 +17,25 @@
     </header>
 
     <p v-if="statusMessage" class="k3-setup__status" :data-kind="statusKind">{{ statusMessage }}</p>
+
+    <nav class="k3-setup__journey" aria-label="K3 WISE setup path">
+      <div class="k3-setup__journey-step">
+        <strong>1. 接通 K3</strong>
+        <span>填写地址和授权码</span>
+      </div>
+      <div class="k3-setup__journey-step">
+        <strong>2. 准备多维表</strong>
+        <span>安装 staging 表并清洗数据</span>
+      </div>
+      <div class="k3-setup__journey-step">
+        <strong>3. 创建链路</strong>
+        <span>生成物料和 BOM pipeline</span>
+      </div>
+      <div class="k3-setup__journey-step">
+        <strong>4. Dry-run 后推送</strong>
+        <span>先验证，再打开真实执行</span>
+      </div>
+    </nav>
 
     <section class="k3-setup__layout">
       <aside class="k3-setup__rail">
@@ -132,11 +151,11 @@
           <pre v-if="pipelineResult" class="k3-setup__test-result">{{ pipelineResult }}</pre>
         </div>
 
-        <div class="k3-setup__panel">
-          <div class="k3-setup__panel-head">
-            <h2>执行 Pipeline</h2>
-            <span>{{ form.allowLivePipelineRun ? 'run enabled' : 'dry-run first' }}</span>
-          </div>
+        <details class="k3-setup__panel k3-setup__collapsible-panel">
+          <summary class="k3-setup__panel-summary">
+            <span>执行 Pipeline</span>
+            <small>{{ form.allowLivePipelineRun ? 'run enabled' : 'dry-run first' }}</small>
+          </summary>
           <button
             class="k3-setup__btn k3-setup__btn--full"
             type="button"
@@ -175,13 +194,13 @@
             </li>
           </ul>
           <pre v-if="pipelineRunResult" class="k3-setup__test-result">{{ pipelineRunResult }}</pre>
-        </div>
+        </details>
 
-        <div class="k3-setup__panel">
-          <div class="k3-setup__panel-head">
-            <h2>运行观察</h2>
-            <span>{{ observationSummary }}</span>
-          </div>
+        <details class="k3-setup__panel k3-setup__collapsible-panel">
+          <summary class="k3-setup__panel-summary">
+            <span>运行观察</span>
+            <small>{{ observationSummary }}</small>
+          </summary>
           <button
             class="k3-setup__btn k3-setup__btn--full"
             type="button"
@@ -236,14 +255,14 @@
               </div>
             </template>
           </div>
-        </div>
+        </details>
       </aside>
 
       <form class="k3-setup__form" @submit.prevent="saveConfiguration">
-        <section class="k3-setup__section">
+        <section class="k3-setup__section k3-setup__section--primary">
           <div class="k3-setup__section-head">
-            <h2>作用域</h2>
-            <span>tenant / workspace</span>
+            <h2>基础连接</h2>
+            <span>首次部署只需先完成这些字段</span>
           </div>
           <div class="k3-setup__grid">
             <label class="k3-setup__field">
@@ -254,17 +273,8 @@
               <span>Workspace ID</span>
               <input v-model.trim="form.workspaceId" autocomplete="off" />
             </label>
-          </div>
-        </section>
-
-        <section class="k3-setup__section">
-          <div class="k3-setup__section-head">
-            <h2>K3 WISE WebAPI</h2>
-            <span>{{ form.webApiSystemId ? '编辑现有系统' : '新建系统' }}</span>
-          </div>
-          <div class="k3-setup__grid">
             <label class="k3-setup__field">
-              <span>名称</span>
+              <span>系统名称</span>
               <input v-model.trim="form.webApiName" autocomplete="off" />
             </label>
             <label class="k3-setup__field">
@@ -292,6 +302,35 @@
                 <option value="login">账套登录</option>
               </select>
             </label>
+            <label v-if="form.webApiAuthMode === 'authority-code'" class="k3-setup__field k3-setup__field--wide">
+              <span>授权码</span>
+              <input v-model="form.authorityCode" type="password" autocomplete="new-password" />
+              <small>只用于保存凭据，不会回显。</small>
+            </label>
+            <label v-if="form.webApiAuthMode === 'login'" class="k3-setup__field">
+              <span>Acct ID</span>
+              <input v-model.trim="form.acctId" autocomplete="off" />
+            </label>
+            <label v-if="form.webApiAuthMode === 'login'" class="k3-setup__field">
+              <span>用户名</span>
+              <input v-model.trim="form.username" autocomplete="off" />
+            </label>
+            <label v-if="form.webApiAuthMode === 'login'" class="k3-setup__field">
+              <span>密码</span>
+              <input v-model="form.password" type="password" autocomplete="new-password" />
+            </label>
+            <p v-if="form.webApiHasCredentials" class="k3-setup__field-note k3-setup__field-note--wide">
+              已保存凭据会保留；留空不会清除旧凭据。
+            </p>
+          </div>
+        </section>
+
+        <details class="k3-setup__section k3-setup__details">
+          <summary class="k3-setup__section-summary">
+            <span>高级 WebAPI 设置</span>
+            <small>路径、语言、超时和 Submit/Audit 策略；默认值通常可直接使用</small>
+          </summary>
+          <div class="k3-setup__grid">
             <label v-if="form.webApiAuthMode === 'authority-code'" class="k3-setup__field">
               <span>Token Path</span>
               <input v-model.trim="form.tokenPath" autocomplete="off" />
@@ -312,31 +351,6 @@
               <span>Timeout ms</span>
               <input v-model.trim="form.timeoutMs" inputmode="numeric" autocomplete="off" />
             </label>
-          </div>
-        </section>
-
-        <section class="k3-setup__section">
-          <div class="k3-setup__section-head">
-            <h2>WebAPI 凭据</h2>
-            <span>{{ form.webApiHasCredentials ? '已有凭据，留空则保留' : '需要填写' }}</span>
-          </div>
-          <div class="k3-setup__grid">
-            <label v-if="form.webApiAuthMode === 'authority-code'" class="k3-setup__field k3-setup__field--wide">
-              <span>授权码</span>
-              <input v-model="form.authorityCode" type="password" autocomplete="new-password" />
-            </label>
-            <label v-if="form.webApiAuthMode === 'login'" class="k3-setup__field">
-              <span>Acct ID</span>
-              <input v-model.trim="form.acctId" autocomplete="off" />
-            </label>
-            <label v-if="form.webApiAuthMode === 'login'" class="k3-setup__field">
-              <span>用户名</span>
-              <input v-model.trim="form.username" autocomplete="off" />
-            </label>
-            <label v-if="form.webApiAuthMode === 'login'" class="k3-setup__field">
-              <span>密码</span>
-              <input v-model="form.password" type="password" autocomplete="new-password" />
-            </label>
             <label class="k3-setup__check">
               <input v-model="form.autoSubmit" type="checkbox" />
               <span>Save 后自动 Submit</span>
@@ -345,15 +359,6 @@
               <input v-model="form.autoAudit" type="checkbox" />
               <span>Submit 后自动 Audit</span>
             </label>
-          </div>
-        </section>
-
-        <section class="k3-setup__section">
-          <div class="k3-setup__section-head">
-            <h2>物料 / BOM 接口</h2>
-            <span>relative paths</span>
-          </div>
-          <div class="k3-setup__grid">
             <label class="k3-setup__field">
               <span>Material Save</span>
               <input v-model.trim="form.materialSavePath" autocomplete="off" />
@@ -379,11 +384,14 @@
               <input v-model.trim="form.bomAuditPath" autocomplete="off" />
             </label>
           </div>
-        </section>
+        </details>
 
-        <section class="k3-setup__section">
-          <div class="k3-setup__section-head">
-            <h2>SQL Server 通道</h2>
+        <details class="k3-setup__section k3-setup__details">
+          <summary class="k3-setup__section-summary">
+            <span>SQL Server 通道</span>
+            <small>默认关闭；需要读取 K3 表或写中间表时再启用</small>
+          </summary>
+          <div class="k3-setup__details-toolbar">
             <label class="k3-setup__switch">
               <input v-model="form.sqlEnabled" type="checkbox" />
               <span>{{ form.sqlEnabled ? '启用' : '关闭' }}</span>
@@ -431,7 +439,7 @@
               <textarea v-model="form.sqlStoredProcedures" rows="4" spellcheck="false" />
             </label>
           </div>
-        </section>
+        </details>
 
         <section v-if="validationIssues.length" class="k3-setup__section k3-setup__section--issues">
           <div class="k3-setup__section-head">
@@ -445,10 +453,10 @@
           </ul>
         </section>
 
-        <section class="k3-setup__section">
+        <section class="k3-setup__section k3-setup__section--primary">
           <div class="k3-setup__section-head">
-            <h2>PLM → K3 清洗链路</h2>
-            <span>multitable staging + pipeline runner</span>
+            <h2>多维表清洗准备</h2>
+            <span>PLM 数据先进入 staging 多维表</span>
           </div>
           <div class="k3-setup__grid">
             <label class="k3-setup__field">
@@ -472,10 +480,6 @@
               <input v-model.trim="form.materialPipelineName" autocomplete="off" />
             </label>
             <label class="k3-setup__field">
-              <span>物料 Pipeline ID</span>
-              <input v-model.trim="form.materialPipelineId" autocomplete="off" />
-            </label>
-            <label class="k3-setup__field">
               <span>物料 Staging 对象</span>
               <select v-if="stagingDescriptors.length" v-model="form.materialStagingObjectId">
                 <option v-for="descriptor in stagingDescriptors" :key="`material:${descriptor.id}`" :value="descriptor.id">
@@ -489,10 +493,6 @@
               <input v-model.trim="form.bomPipelineName" autocomplete="off" />
             </label>
             <label class="k3-setup__field">
-              <span>BOM Pipeline ID</span>
-              <input v-model.trim="form.bomPipelineId" autocomplete="off" />
-            </label>
-            <label class="k3-setup__field">
               <span>BOM Staging 对象</span>
               <select v-if="stagingDescriptors.length" v-model="form.bomStagingObjectId">
                 <option v-for="descriptor in stagingDescriptors" :key="`bom:${descriptor.id}`" :value="descriptor.id">
@@ -500,6 +500,23 @@
                 </option>
               </select>
               <input v-else v-model.trim="form.bomStagingObjectId" autocomplete="off" />
+            </label>
+          </div>
+        </section>
+
+        <details class="k3-setup__section k3-setup__details">
+          <summary class="k3-setup__section-summary">
+            <span>Pipeline 执行参数</span>
+            <small>创建 pipeline 后会回填 ID；真实执行默认关闭</small>
+          </summary>
+          <div class="k3-setup__grid">
+            <label class="k3-setup__field">
+              <span>物料 Pipeline ID</span>
+              <input v-model.trim="form.materialPipelineId" autocomplete="off" />
+            </label>
+            <label class="k3-setup__field">
+              <span>BOM Pipeline ID</span>
+              <input v-model.trim="form.bomPipelineId" autocomplete="off" />
             </label>
             <label class="k3-setup__field">
               <span>执行模式</span>
@@ -522,7 +539,7 @@
               <span>允许真实执行 Pipeline</span>
             </label>
           </div>
-        </section>
+        </details>
       </form>
     </section>
   </section>
@@ -886,6 +903,38 @@ onMounted(() => {
   justify-content: flex-end;
 }
 
+.k3-setup__journey {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.k3-setup__journey-step {
+  min-width: 0;
+  padding: 12px;
+  border: 1px solid #d9e1ec;
+  border-radius: 8px;
+  background: #fff;
+}
+
+.k3-setup__journey-step strong,
+.k3-setup__journey-step span {
+  display: block;
+  overflow-wrap: anywhere;
+}
+
+.k3-setup__journey-step strong {
+  color: #111827;
+  font-size: 14px;
+}
+
+.k3-setup__journey-step span {
+  margin-top: 4px;
+  color: #64748b;
+  font-size: 12px;
+  line-height: 1.4;
+}
+
 .k3-setup__layout {
   display: grid;
   grid-template-columns: minmax(240px, 320px) minmax(0, 1fr);
@@ -906,6 +955,93 @@ onMounted(() => {
   border: 1px solid #d9e1ec;
   border-radius: 8px;
   background: #fff;
+}
+
+.k3-setup__section--primary {
+  border-color: #99f6e4;
+}
+
+.k3-setup__details[open] {
+  border-color: #cbd5e1;
+}
+
+.k3-setup__collapsible-panel {
+  padding: 0;
+}
+
+.k3-setup__collapsible-panel[open] {
+  padding: 0 16px 16px;
+}
+
+.k3-setup__panel-summary,
+.k3-setup__section-summary {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: center;
+  cursor: pointer;
+  list-style: none;
+}
+
+.k3-setup__panel-summary {
+  padding: 16px;
+}
+
+.k3-setup__collapsible-panel[open] .k3-setup__panel-summary {
+  margin: 0 -16px 14px;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.k3-setup__section-summary {
+  margin: -2px 0 0;
+}
+
+.k3-setup__details[open] .k3-setup__section-summary {
+  margin-bottom: 14px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.k3-setup__panel-summary::-webkit-details-marker,
+.k3-setup__section-summary::-webkit-details-marker {
+  display: none;
+}
+
+.k3-setup__panel-summary::after,
+.k3-setup__section-summary::after {
+  content: '+';
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 22px;
+  height: 22px;
+  border-radius: 999px;
+  background: #e2e8f0;
+  color: #334155;
+  font-weight: 700;
+}
+
+.k3-setup__collapsible-panel[open] .k3-setup__panel-summary::after,
+.k3-setup__details[open] .k3-setup__section-summary::after {
+  content: '-';
+}
+
+.k3-setup__panel-summary span,
+.k3-setup__section-summary span {
+  color: #111827;
+  font-size: 16px;
+  font-weight: 700;
+}
+
+.k3-setup__panel-summary small,
+.k3-setup__section-summary small {
+  color: #64748b;
+  font-size: 12px;
+}
+
+.k3-setup__details-toolbar {
+  margin-bottom: 12px;
 }
 
 .k3-setup__panel-head,
@@ -956,6 +1092,21 @@ onMounted(() => {
   color: #334155;
   font-size: 13px;
   font-weight: 600;
+}
+
+.k3-setup__field small,
+.k3-setup__field-note {
+  color: #64748b;
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.k3-setup__field-note {
+  margin: 0;
+}
+
+.k3-setup__field-note--wide {
+  grid-column: 1 / -1;
 }
 
 .k3-setup__field input,
@@ -1240,6 +1391,10 @@ onMounted(() => {
     grid-template-columns: 1fr;
   }
 
+  .k3-setup__journey {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .k3-setup__rail {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -1258,6 +1413,10 @@ onMounted(() => {
   .k3-setup__header-actions,
   .k3-setup__rail {
     display: flex;
+  }
+
+  .k3-setup__journey {
+    grid-template-columns: 1fr;
   }
 
   .k3-setup__grid {

--- a/apps/web/tests/IntegrationK3WiseSetupView.spec.ts
+++ b/apps/web/tests/IntegrationK3WiseSetupView.spec.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, nextTick, type App as VueApp, type Component } from 'vue'
+
+const apiFetchMock = vi.fn()
+
+vi.mock('../src/utils/api', () => ({
+  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+}))
+
+function jsonResponse(data: unknown): Response {
+  return new Response(JSON.stringify({ ok: true, data }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function mockIntegrationApi(): void {
+  apiFetchMock.mockImplementation(async (url: string) => {
+    if (url.startsWith('/api/integration/external-systems?')) {
+      return jsonResponse([])
+    }
+    if (url === '/api/integration/staging/descriptors') {
+      return jsonResponse([
+        {
+          id: 'standard_materials',
+          name: 'Standard materials',
+          fields: ['code', 'name'],
+          fieldDetails: [
+            { id: 'code', name: 'Code', type: 'text' },
+            { id: 'name', name: 'Name', type: 'text' },
+          ],
+        },
+        {
+          id: 'bom_cleanse',
+          name: 'BOM cleanse',
+          fields: ['parentCode', 'childCode'],
+          fieldDetails: [
+            { id: 'parentCode', name: 'Parent code', type: 'text' },
+            { id: 'childCode', name: 'Child code', type: 'text' },
+          ],
+        },
+      ])
+    }
+    return jsonResponse({})
+  })
+}
+
+async function flushUi(cycles = 4): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+describe('IntegrationK3WiseSetupView', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    apiFetchMock.mockReset()
+    mockIntegrationApi()
+    if (typeof localStorage?.clear === 'function') localStorage.clear()
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+  })
+
+  it('keeps first-run K3 setup focused while folding expert controls', async () => {
+    const View = (await import('../src/views/IntegrationK3WiseSetupView.vue')).default
+
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    app.mount(container)
+    await flushUi()
+
+    expect(container.textContent).toContain('1. 接通 K3')
+    expect(container.textContent).toContain('2. 准备多维表')
+    expect(container.textContent).toContain('基础连接')
+    expect(container.textContent).toContain('多维表清洗准备')
+
+    const advancedSections = Array.from(container.querySelectorAll('details.k3-setup__details')) as HTMLDetailsElement[]
+    expect(advancedSections).toHaveLength(3)
+    expect(advancedSections.every((section) => section.open === false)).toBe(true)
+
+    const sideRailSections = Array.from(container.querySelectorAll('details.k3-setup__collapsible-panel')) as HTMLDetailsElement[]
+    expect(sideRailSections).toHaveLength(2)
+    expect(sideRailSections.every((section) => section.open === false)).toBe(true)
+  })
+})

--- a/docs/development/integration-k3wise-setup-simplify-design-20260511.md
+++ b/docs/development/integration-k3wise-setup-simplify-design-20260511.md
@@ -1,0 +1,95 @@
+# K3 WISE Setup Page Simplification Design - 2026-05-11
+
+## Goal
+
+Reduce first-run operator friction on the K3 WISE integration page without changing backend contracts, stored payloads, plugin APIs, migrations, or deployment packaging.
+
+The page had grown from a connection form into a full integration cockpit:
+
+- K3 WISE WebAPI configuration
+- WebAPI credentials
+- endpoint path tuning
+- SQL Server channel setup
+- staging multitable installation
+- pipeline template creation
+- dry-run/live execution
+- run/dead-letter observation
+
+All of those capabilities are useful, but showing them all at once made the first deployment path look harder than it is.
+
+## Product Position
+
+The ERP page should not become a mini ERP administration system. It should be the control surface for:
+
+1. Connecting K3 WISE.
+2. Preparing staging multitables.
+3. Creating the PLM-to-K3 cleansing pipelines.
+4. Running dry-run/live execution after explicit operator review.
+
+The actual data cleaning experience remains in the multitable staging layer. This keeps the product centered on MetaSheet rather than turning the integration page into the place where users fix material and BOM data row by row.
+
+## Implementation
+
+Changed file:
+
+- `apps/web/src/views/IntegrationK3WiseSetupView.vue`
+
+Test file:
+
+- `apps/web/tests/IntegrationK3WiseSetupView.spec.ts`
+
+The UI is reorganized as follows:
+
+1. Added a four-step journey strip:
+   - connect K3
+   - prepare multitables
+   - create cleansing pipelines
+   - dry-run before push
+
+2. Merged the first-run fields into one primary `基础连接` section:
+   - tenant/workspace
+   - system name
+   - K3 version/environment
+   - WebAPI base URL
+   - auth mode
+   - authority code or login credentials
+
+3. Folded expert-only WebAPI controls into `高级 WebAPI 设置`:
+   - token/login/health paths
+   - LCID
+   - timeout
+   - Submit/Audit flags
+   - material/BOM endpoint paths
+
+4. Folded SQL Server channel setup into `SQL Server 通道`.
+
+5. Renamed and narrowed the visible pipeline section to `多维表清洗准备`.
+   It now foregrounds staging and pipeline preparation instead of live execution knobs.
+
+6. Folded pipeline IDs and run controls into `Pipeline 执行参数`.
+
+7. Folded side-rail `执行 Pipeline` and `运行观察` panels by default.
+
+## Non-Goals
+
+No changes were made to:
+
+- `plugins/plugin-integration-core`
+- backend routes
+- API request/response schemas
+- migrations
+- K3 adapter behavior
+- pipeline payload builders
+- deployment package scripts
+
+The existing field models and `buildK3WiseSetupPayloads()` / `buildK3WisePipelinePayloads()` behavior remain intact.
+
+## Expected Operator Flow
+
+1. Fill `基础连接`.
+2. Save and test WebAPI.
+3. Install or confirm staging multitables.
+4. Create draft material/BOM pipelines.
+5. Open execution/observation panels only when ready to dry-run or inspect failures.
+
+This is intentionally closer to an operator checklist than a raw configuration dump.

--- a/docs/development/integration-k3wise-setup-simplify-verification-20260511.md
+++ b/docs/development/integration-k3wise-setup-simplify-verification-20260511.md
@@ -1,0 +1,81 @@
+# K3 WISE Setup Page Simplification Verification - 2026-05-11
+
+## Scope
+
+This verification covers the frontend-only simplification of the K3 WISE setup page.
+
+Changed files:
+
+- `apps/web/src/views/IntegrationK3WiseSetupView.vue`
+- `apps/web/tests/IntegrationK3WiseSetupView.spec.ts`
+- `docs/development/integration-k3wise-setup-simplify-design-20260511.md`
+- `docs/development/integration-k3wise-setup-simplify-verification-20260511.md`
+
+## Assertions
+
+The new component test verifies:
+
+- the first-run journey strip renders the K3 setup path
+- `基础连接` remains visible by default
+- `多维表清洗准备` remains visible by default
+- advanced form sections are collapsed by default
+- side-rail execution/observation panels are collapsed by default
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/IntegrationK3WiseSetupView.spec.ts tests/k3WiseSetup.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+Targeted test result:
+
+```text
+Test Files  2 passed (2)
+Tests       27 passed (27)
+```
+
+Build result:
+
+```text
+@metasheet/web build passed.
+vue-tsc -b completed.
+vite build completed.
+```
+
+Diff check:
+
+```text
+git diff --check returned 0.
+```
+
+Notes:
+
+- The first attempt used workspace-root test paths while running inside the filtered `apps/web` package and Vitest correctly reported no files found.
+- The component test initially assumed `localStorage.clear()` existed in the test environment. The guard now checks that the function is available before calling it.
+- The production web build emitted pre-existing chunk-size and dynamic-import warnings, but exited successfully.
+
+## Behavior Compatibility
+
+No backend or service payload builder was changed. The existing `k3WiseSetup.spec.ts` suite still passed, covering:
+
+- WebAPI external-system payloads
+- authority-code token payloads
+- credential preservation
+- SQL Server channel payloads
+- staging install payloads
+- pipeline payloads and run queries
+- deploy-gate helper behavior
+
+## Deployment Impact
+
+Runtime impact is limited to the web UI. There are no:
+
+- migrations
+- plugin changes
+- backend route changes
+- package-build changes
+- secret-handling changes
+
+The deployment package can include this as a normal frontend update.


### PR DESCRIPTION
## Summary
- Reframes the K3 WISE page around a four-step operator path: connect K3, prepare staging multitables, create cleansing pipelines, then dry-run before push.
- Keeps first-run fields visible while folding WebAPI expert paths, SQL Server channel fields, pipeline execution parameters, and side-rail execution/observation panels by default.
- Adds a focused component test plus design and verification docs.

## Verification
- pnpm --filter @metasheet/web exec vitest run tests/IntegrationK3WiseSetupView.spec.ts tests/k3WiseSetup.spec.ts --watch=false
- pnpm --filter @metasheet/web build
- git diff --check

## Deployment impact
Frontend-only UI simplification. No backend routes, plugin code, migrations, package scripts, or API payload builders changed.