### PR TITLE
chore(dingtalk): add screenshot evidence archive helper

### DIFF
--- a/docs/development/dingtalk-screenshot-archive-development-20260511.md
+++ b/docs/development/dingtalk-screenshot-archive-development-20260511.md
@@ -1,0 +1,55 @@
+# DingTalk Screenshot Archive Development
+
+## Summary
+
+Added a small ops helper to package DingTalk mobile/manual screenshots into a redaction-safe archive. The helper is intentionally narrow: it copies screenshot image files into stable names, writes `manifest.json` and `README.md`, and records size/hash metadata without exposing token-like values in labels.
+
+## Scope
+
+- New CLI: `scripts/ops/dingtalk-screenshot-archive.mjs`
+- New tests: `scripts/ops/dingtalk-screenshot-archive.test.mjs`
+- Output shape:
+  - `manifest.json`
+  - `README.md`
+  - `screenshots/screenshot-NNN.<ext>`
+
+## Design
+
+The archive tool is evidence packaging, not evidence interpretation. It does not OCR or inspect screenshot pixels, so screenshots remain restricted artifacts. The generated metadata is safe to include in closeout packets because source labels are redacted and copied files are renamed.
+
+Supported image extensions are `.png`, `.jpg`, `.jpeg`, `.webp`, `.gif`, `.heic`, and `.heif`. Directory inputs are scanned recursively, non-image files are ignored with warnings, and empty archives fail by default unless `--allow-empty` is passed.
+
+## Redaction Rules
+
+The manifest and README redact:
+
+- DingTalk robot URLs and `access_token=...`
+- `publicToken=...`
+- DingTalk signature query values such as `sign` and `timestamp`
+- DingTalk client/state secrets
+- `Bearer ...`
+- `SEC...`
+- JWT-looking values
+
+## Usage
+
+```bash
+node scripts/ops/dingtalk-screenshot-archive.mjs \
+  --input /path/to/dingtalk-screenshots \
+  --output-dir artifacts/dingtalk-screenshot-archive/live-acceptance-20260511
+```
+
+Use `--input` repeatedly when evidence is split across folders:
+
+```bash
+node scripts/ops/dingtalk-screenshot-archive.mjs \
+  --input /path/to/mobile-form-screenshots \
+  --input /path/to/group-message-screenshots \
+  --output-dir artifacts/dingtalk-screenshot-archive/live-acceptance-20260511
+```
+
+## Operational Notes
+
+- Keep raw archive directories access-restricted because screenshot pixels can contain personal or operational data.
+- Commit only redacted manifests or docs when they contain no sensitive content.
+- Prefer linking the archive manifest from final closeout verification rather than pasting screenshot content into Git.

--- a/docs/development/dingtalk-screenshot-archive-verification-20260511.md
+++ b/docs/development/dingtalk-screenshot-archive-verification-20260511.md
@@ -1,0 +1,40 @@
+# DingTalk Screenshot Archive Verification
+
+## Summary
+
+This document records validation for the DingTalk screenshot archive helper added on 2026-05-11.
+
+## Automated Verification
+
+```bash
+node --test scripts/ops/dingtalk-screenshot-archive.test.mjs
+```
+
+Result: PASS
+
+- 5 tests passed.
+- Covered nested screenshot copy, non-image warnings, redaction of token-like source labels, empty archive failure behavior, explicit `--allow-empty`, and output/input overlap rejection.
+
+```bash
+git diff --check
+```
+
+Result: PASS
+
+```bash
+git diff --cached \
+  | rg -n 'access_token=[A-Za-z0-9]|SEC[A-Za-z0-9+/=_-]{16,}|Bearer [A-Za-z0-9._~+/=-]{16,}|eyJ[A-Za-z0-9._-]{20,}|https://oapi\.dingtalk\.com/robot/send\?' \
+  | rg -v '<redacted>|robot-secret|archive-secret|secret-token|SECabcdef1234567890' || true
+```
+
+Result: PASS, no matches after excluding intentional synthetic test fixtures and `<redacted>` literals.
+
+## Manual Review
+
+- Confirmed archive output uses stable names under `screenshots/screenshot-NNN.<ext>`.
+- Confirmed manifest/README record redacted source labels, byte sizes, and SHA-256 hashes.
+- Confirmed raw screenshots are intentionally treated as restricted artifacts because pixels may still contain personal or operational data.
+
+## Result
+
+PASS. The helper is ready to use for DingTalk live-acceptance screenshot evidence packaging.

--- a/scripts/ops/dingtalk-screenshot-archive.mjs
+++ b/scripts/ops/dingtalk-screenshot-archive.mjs
@@ -1,0 +1,303 @@
+#!/usr/bin/env node
+
+import crypto from 'node:crypto'
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const DEFAULT_OUTPUT_ROOT = 'artifacts/dingtalk-screenshot-archive'
+const IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.webp', '.gif', '.heic', '.heif'])
+
+function printHelp() {
+  console.log(`Usage: node scripts/ops/dingtalk-screenshot-archive.mjs [options]
+
+Creates a redaction-safe DingTalk screenshot evidence archive.
+
+Options:
+  --input <path>       Screenshot file or directory, repeatable (required)
+  --output-dir <dir>   Archive directory, default ${DEFAULT_OUTPUT_ROOT}/<timestamp>
+  --allow-empty        Exit successfully when no screenshot files are found
+  --help               Show this help
+
+Notes:
+  - Images are copied to screenshots/screenshot-NNN.<ext>.
+  - manifest.json and README.md contain redacted source labels, sizes, and SHA-256 hashes.
+  - The tool does not OCR or inspect screenshot pixels; keep raw screenshot archives access-restricted.
+`)
+}
+
+function readRequiredValue(argv, index, flag) {
+  const next = argv[index + 1]
+  if (!next || next.startsWith('--')) {
+    throw new Error(`${flag} requires a value`)
+  }
+  return next
+}
+
+function timestampSlug(date = new Date()) {
+  return date.toISOString().replace(/[:.]/g, '-')
+}
+
+function parseArgs(argv) {
+  const opts = {
+    inputs: [],
+    outputDir: '',
+    allowEmpty: false,
+  }
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    switch (arg) {
+      case '--input':
+        opts.inputs.push(path.resolve(process.cwd(), readRequiredValue(argv, i, arg)))
+        i += 1
+        break
+      case '--output-dir':
+        opts.outputDir = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
+        i += 1
+        break
+      case '--allow-empty':
+        opts.allowEmpty = true
+        break
+      case '--help':
+        printHelp()
+        process.exit(0)
+        break
+      default:
+        throw new Error(`Unknown argument: ${arg}`)
+    }
+  }
+
+  if (opts.inputs.length === 0) throw new Error('--input is required')
+  opts.outputDir ||= path.resolve(process.cwd(), DEFAULT_OUTPUT_ROOT, timestampSlug())
+  return opts
+}
+
+function relativePath(file) {
+  return path.relative(process.cwd(), file).replaceAll('\\', '/')
+}
+
+function redactString(value) {
+  return String(value)
+    .replace(/https:\/\/oapi\.dingtalk\.com\/robot\/send\?[^)\s"'`<>]+/gi, 'https://oapi.dingtalk.com/robot/send?<redacted>')
+    .replace(/(access_token=)[^&\s)"'`<>/]+/gi, '$1<redacted>')
+    .replace(/(publicToken=)[^&\s)"'`<>/]+/gi, '$1<redacted>')
+    .replace(/([?&](?:sign|timestamp)=)[^&\s)"'`<>]+/gi, '$1<redacted>')
+    .replace(/\b((?:client_secret|DINGTALK_CLIENT_SECRET|DINGTALK_STATE_SECRET)\s*=\s*)[^&\s)"'`<>]+/gi, '$1<redacted>')
+    .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]+/gi, 'Bearer <redacted>')
+    .replace(/\bSEC[A-Za-z0-9+/=_-]{8,}\b/g, 'SEC<redacted>')
+    .replace(/\beyJ[A-Za-z0-9._-]{20,}\b/g, '<jwt:redacted>')
+}
+
+function displayPath(file) {
+  const absolute = path.resolve(file)
+  const relative = path.relative(process.cwd(), absolute)
+  const isInsideCwd = relative && !relative.startsWith('..') && !path.isAbsolute(relative)
+  return redactString(isInsideCwd ? relative.replaceAll('\\', '/') : path.basename(absolute))
+}
+
+function archiveRelativePath(file, outputDir) {
+  return path.relative(outputDir, file).replaceAll('\\', '/')
+}
+
+function isImageFile(file) {
+  return IMAGE_EXTENSIONS.has(path.extname(file).toLowerCase())
+}
+
+function pathsOverlap(left, right) {
+  const a = path.resolve(left)
+  const b = path.resolve(right)
+  return a === b || a.startsWith(`${b}${path.sep}`) || b.startsWith(`${a}${path.sep}`)
+}
+
+function walkDirectory(dir, warnings) {
+  const files = []
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const file = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      files.push(...walkDirectory(file, warnings))
+    } else if (entry.isFile() && isImageFile(file)) {
+      files.push(file)
+    } else if (entry.isFile()) {
+      warnings.push(`ignored non-image file: ${displayPath(file)}`)
+    }
+  }
+  return files
+}
+
+function collectScreenshotFiles(inputs) {
+  const warnings = []
+  const files = []
+
+  for (const input of inputs) {
+    if (!existsSync(input)) {
+      warnings.push(`missing input: ${displayPath(input)}`)
+      continue
+    }
+
+    const stats = statSync(input)
+    if (stats.isDirectory()) {
+      files.push(...walkDirectory(input, warnings))
+    } else if (stats.isFile() && isImageFile(input)) {
+      files.push(input)
+    } else if (stats.isFile()) {
+      warnings.push(`ignored non-image file: ${displayPath(input)}`)
+    } else {
+      warnings.push(`ignored unsupported input: ${displayPath(input)}`)
+    }
+  }
+
+  const uniqueFiles = [...new Set(files.map((file) => path.resolve(file)))].sort()
+  return {
+    files: uniqueFiles,
+    warnings: warnings.map((warning) => redactString(warning)),
+  }
+}
+
+function validateOutputDir(opts) {
+  for (const input of opts.inputs) {
+    if (!existsSync(input) || !statSync(input).isDirectory()) continue
+    if (pathsOverlap(opts.outputDir, input)) {
+      throw new Error('--output-dir must not overlap with any input directory')
+    }
+  }
+}
+
+function sha256File(file) {
+  return crypto.createHash('sha256').update(readFileSync(file)).digest('hex')
+}
+
+function writeJson(file, value) {
+  mkdirSync(path.dirname(file), { recursive: true })
+  writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`, 'utf8')
+}
+
+function writeReadme(file, summary) {
+  const lines = [
+    '# DingTalk Screenshot Evidence Archive',
+    '',
+    `- Status: **${summary.status}**`,
+    `- Generated at: ${summary.generatedAt}`,
+    `- Screenshot count: ${summary.screenshotCount}`,
+    `- Input count: ${summary.inputCount}`,
+    '',
+    '## Security Notes',
+    '',
+    '- Source labels are path-only metadata with token-like values redacted.',
+    '- Screenshot files are renamed to stable archive names and should remain access-restricted because pixels may contain personal or operational data.',
+    '- This archive proves packaging integrity only; it does not OCR or validate screenshot content.',
+    '',
+    '## Screenshots',
+    '',
+  ]
+
+  if (summary.copiedScreenshots.length === 0) {
+    lines.push('_No screenshot files were archived._', '')
+  } else {
+    lines.push('| # | Archive path | Source label | Size | SHA-256 |')
+    lines.push('|---:|---|---|---:|---|')
+    for (const screenshot of summary.copiedScreenshots) {
+      lines.push(
+        `| ${screenshot.index} | \`${screenshot.archivePath}\` | \`${screenshot.sourceLabel}\` | ${screenshot.sizeBytes} | \`${screenshot.sha256}\` |`,
+      )
+    }
+    lines.push('')
+  }
+
+  if (summary.warnings.length > 0) {
+    lines.push('## Warnings', '')
+    for (const warning of summary.warnings) {
+      lines.push(`- ${warning}`)
+    }
+    lines.push('')
+  }
+
+  writeFileSync(file, `${lines.join('\n')}\n`, 'utf8')
+}
+
+function buildScreenshotArchive(opts) {
+  validateOutputDir(opts)
+
+  const generatedAt = new Date().toISOString()
+  const { files, warnings } = collectScreenshotFiles(opts.inputs)
+  const outputDir = path.resolve(opts.outputDir)
+  const screenshotDir = path.join(outputDir, 'screenshots')
+  const manifestJson = path.join(outputDir, 'manifest.json')
+  const readmeMd = path.join(outputDir, 'README.md')
+
+  mkdirSync(outputDir, { recursive: true })
+  if (files.length > 0) mkdirSync(screenshotDir, { recursive: true })
+
+  const copiedScreenshots = files.map((source, index) => {
+    const extension = path.extname(source).toLowerCase()
+    const archiveName = `screenshot-${String(index + 1).padStart(3, '0')}${extension}`
+    const archiveFile = path.join(screenshotDir, archiveName)
+    copyFileSync(source, archiveFile)
+
+    return {
+      index: index + 1,
+      sourceLabel: displayPath(source),
+      archivePath: archiveRelativePath(archiveFile, outputDir),
+      extension,
+      sizeBytes: statSync(source).size,
+      sha256: sha256File(source),
+    }
+  })
+
+  const summaryWarnings = [...warnings]
+  if (files.length === 0) summaryWarnings.push('no screenshot images found')
+
+  const status = files.length > 0 || opts.allowEmpty ? 'pass' : 'fail'
+  const summary = {
+    tool: 'dingtalk-screenshot-archive',
+    generatedAt,
+    status,
+    allowEmpty: opts.allowEmpty,
+    outputDir: redactString(relativePath(outputDir)),
+    manifestJson: redactString(relativePath(manifestJson)),
+    readmeMd: redactString(relativePath(readmeMd)),
+    inputCount: opts.inputs.length,
+    screenshotCount: copiedScreenshots.length,
+    copiedScreenshots,
+    warnings: summaryWarnings.map((warning) => redactString(warning)),
+  }
+
+  writeJson(manifestJson, summary)
+  writeReadme(readmeMd, summary)
+  return summary
+}
+
+function main() {
+  try {
+    const opts = parseArgs(process.argv.slice(2))
+    const summary = buildScreenshotArchive(opts)
+    console.log(
+      `[dingtalk-screenshot-archive] ${summary.status}: ${summary.screenshotCount} screenshot(s), manifest=${summary.manifestJson}`,
+    )
+    if (summary.status !== 'pass') process.exit(1)
+  } catch (error) {
+    console.error(`[dingtalk-screenshot-archive] ERROR: ${redactString(error.message)}`)
+    process.exit(1)
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main()
+}
+
+export {
+  buildScreenshotArchive,
+  collectScreenshotFiles,
+  displayPath,
+  isImageFile,
+  parseArgs,
+  redactString,
+}

--- a/scripts/ops/dingtalk-screenshot-archive.test.mjs
+++ b/scripts/ops/dingtalk-screenshot-archive.test.mjs
@@ -1,0 +1,151 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const scriptPath = path.join(repoRoot, 'scripts', 'ops', 'dingtalk-screenshot-archive.mjs')
+
+function makeTmpDir() {
+  return mkdtempSync(path.join(tmpdir(), 'dingtalk-screenshot-archive-'))
+}
+
+function runScript(args) {
+  return spawnSync(process.execPath, [scriptPath, ...args], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  })
+}
+
+function writeFixture(file, content = 'fixture-image-bytes') {
+  mkdirSync(path.dirname(file), { recursive: true })
+  writeFileSync(file, content)
+}
+
+function readJson(file) {
+  return JSON.parse(readFileSync(file, 'utf8'))
+}
+
+test('dingtalk-screenshot-archive copies nested screenshots and writes manifest docs', () => {
+  const tmpDir = makeTmpDir()
+  const inputDir = path.join(tmpDir, 'evidence')
+  const outputDir = path.join(tmpDir, 'archive')
+
+  try {
+    writeFixture(path.join(inputDir, 'mobile-form.png'), 'png-one')
+    writeFixture(path.join(inputDir, 'nested', 'group-message.JPG'), 'jpg-two')
+    writeFixture(path.join(inputDir, 'notes.txt'), 'not an image')
+
+    const result = runScript(['--input', inputDir, '--output-dir', outputDir])
+
+    assert.equal(result.status, 0, result.stderr || result.stdout)
+    assert.equal(existsSync(path.join(outputDir, 'manifest.json')), true)
+    assert.equal(existsSync(path.join(outputDir, 'README.md')), true)
+    assert.equal(existsSync(path.join(outputDir, 'screenshots', 'screenshot-001.png')), true)
+    assert.equal(existsSync(path.join(outputDir, 'screenshots', 'screenshot-002.jpg')), true)
+
+    const manifest = readJson(path.join(outputDir, 'manifest.json'))
+    assert.equal(manifest.status, 'pass')
+    assert.equal(manifest.screenshotCount, 2)
+    assert.equal(manifest.copiedScreenshots[0].archivePath, 'screenshots/screenshot-001.png')
+    assert.equal(manifest.copiedScreenshots[1].archivePath, 'screenshots/screenshot-002.jpg')
+    assert.equal(manifest.warnings.some((warning) => warning.includes('notes.txt')), true)
+    assert.match(readFileSync(path.join(outputDir, 'README.md'), 'utf8'), /Screenshot count: 2/)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-screenshot-archive redacts token-like values from manifest and README', () => {
+  const tmpDir = makeTmpDir()
+  const inputDir = path.join(tmpDir, 'evidence')
+  const outputDir = path.join(tmpDir, 'access_token=archive-secret', 'archive')
+
+  try {
+    writeFixture(
+      path.join(inputDir, 'access_token=robot-secret SECabcdef1234567890 Bearer secret-token screenshot.png'),
+      'png-secret',
+    )
+
+    const result = runScript(['--input', inputDir, '--output-dir', outputDir])
+
+    assert.equal(result.status, 0, result.stderr || result.stdout)
+    const manifestText = readFileSync(path.join(outputDir, 'manifest.json'), 'utf8')
+    const readmeText = readFileSync(path.join(outputDir, 'README.md'), 'utf8')
+    assert.doesNotMatch(manifestText, /robot-secret/)
+    assert.doesNotMatch(readmeText, /robot-secret/)
+    assert.doesNotMatch(manifestText, /archive-secret/)
+    assert.doesNotMatch(result.stdout, /archive-secret/)
+    assert.doesNotMatch(manifestText, /SECabcdef1234567890/)
+    assert.doesNotMatch(readmeText, /SECabcdef1234567890/)
+    assert.doesNotMatch(manifestText, /secret-token/)
+    assert.doesNotMatch(readmeText, /secret-token/)
+    assert.match(manifestText, /access_token=<redacted>/)
+    assert.match(manifestText, /SEC<redacted>/)
+    assert.match(manifestText, /Bearer <redacted>/)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-screenshot-archive fails empty input by default but writes failure summary', () => {
+  const tmpDir = makeTmpDir()
+  const inputDir = path.join(tmpDir, 'empty')
+  const outputDir = path.join(tmpDir, 'archive')
+
+  try {
+    mkdirSync(inputDir, { recursive: true })
+
+    const result = runScript(['--input', inputDir, '--output-dir', outputDir])
+
+    assert.equal(result.status, 1)
+    assert.match(result.stdout, /fail: 0 screenshot/)
+    const manifest = readJson(path.join(outputDir, 'manifest.json'))
+    assert.equal(manifest.status, 'fail')
+    assert.equal(manifest.screenshotCount, 0)
+    assert.equal(manifest.warnings.includes('no screenshot images found'), true)
+    assert.match(readFileSync(path.join(outputDir, 'README.md'), 'utf8'), /No screenshot files were archived/)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-screenshot-archive supports explicit allow-empty archive runs', () => {
+  const tmpDir = makeTmpDir()
+  const inputDir = path.join(tmpDir, 'empty')
+  const outputDir = path.join(tmpDir, 'archive')
+
+  try {
+    mkdirSync(inputDir, { recursive: true })
+
+    const result = runScript(['--input', inputDir, '--output-dir', outputDir, '--allow-empty'])
+
+    assert.equal(result.status, 0, result.stderr || result.stdout)
+    const manifest = readJson(path.join(outputDir, 'manifest.json'))
+    assert.equal(manifest.status, 'pass')
+    assert.equal(manifest.allowEmpty, true)
+    assert.equal(manifest.screenshotCount, 0)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-screenshot-archive rejects archives nested inside an input directory', () => {
+  const tmpDir = makeTmpDir()
+  const inputDir = path.join(tmpDir, 'evidence')
+  const outputDir = path.join(inputDir, 'archive')
+
+  try {
+    writeFixture(path.join(inputDir, 'mobile-form.png'), 'png-one')
+
+    const result = runScript(['--input', inputDir, '--output-dir', outputDir])
+
+    assert.equal(result.status, 1)
+    assert.match(result.stderr, /--output-dir must not overlap with any input directory/)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary
- add a redaction-safe DingTalk screenshot archive CLI
- copy screenshots to stable names and write manifest/README metadata
- document development and verification results for the archive helper

## Verification
- node --test scripts/ops/dingtalk-screenshot-archive.test.mjs
- git diff --cached --check
- staged diff sensitive-value scan excluding synthetic redaction test fixtures

## Notes
- raw screenshots remain restricted artifacts; generated metadata redacts token-like values
- this is a non-runtime closeout evidence helper