### PR TITLE
fix(multitable): align automation condition editor schema

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -88,8 +88,11 @@
               @click="draft.conditions.conjunction = 'OR'"
             >OR</button>
           </div>
+          <div v-if="hasNestedConditionGroups" class="meta-rule-editor__hint" data-field="nestedConditionNotice">
+            Nested condition groups are preserved when saving, but this editor only changes top-level conditions.
+          </div>
           <div
-            v-for="(cond, idx) in draft.conditions.conditions"
+            v-for="{ condition: cond, index: idx } in editableConditionEntries"
             :key="idx"
             class="meta-rule-editor__condition-row"
             :data-condition-index="idx"
@@ -106,7 +109,7 @@
               v-model="cond.value"
               class="meta-rule-editor__input meta-rule-editor__input--sm"
               type="text"
-              placeholder="Value"
+              :placeholder="conditionValuePlaceholder(cond.operator)"
             />
             <button class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="removeCondition(idx)" title="Remove condition">&times;</button>
           </div>
@@ -837,6 +840,8 @@ import type {
   ConditionOperator,
   AutomationAction,
   AutomationCondition,
+  AutomationConditionNode,
+  ConditionGroup,
   DingTalkGroupDestination,
   MetaSheetPermissionCandidate,
   MetaView,
@@ -906,7 +911,7 @@ interface Draft {
   name: string
   triggerType: AutomationTriggerType
   triggerConfig: Record<string, unknown>
-  conditions: { conjunction: 'AND' | 'OR'; conditions: AutomationCondition[] }
+  conditions: ConditionGroup & { conjunction: 'AND' | 'OR' }
   actions: DraftAction[]
 }
 
@@ -973,10 +978,113 @@ const conditionOperators: Array<{ value: ConditionOperator; label: string }> = [
   { value: 'less_or_equal', label: 'Less or equal' },
   { value: 'is_empty', label: 'Is empty' },
   { value: 'is_not_empty', label: 'Is not empty' },
+  { value: 'in', label: 'In list' },
+  { value: 'not_in', label: 'Not in list' },
 ]
 
 function isUnaryOperator(op: ConditionOperator): boolean {
   return op === 'is_empty' || op === 'is_not_empty'
+}
+
+function isArrayOperator(op: ConditionOperator): boolean {
+  return op === 'in' || op === 'not_in'
+}
+
+function conditionValuePlaceholder(op: ConditionOperator): string {
+  return isArrayOperator(op) ? 'Comma-separated values' : 'Value'
+}
+
+function isConditionGroupNode(node: AutomationConditionNode): node is ConditionGroup {
+  return Array.isArray((node as ConditionGroup).conditions)
+}
+
+function normalizeConditionConjunction(group: ConditionGroup | undefined): 'AND' | 'OR' {
+  if (group?.conjunction === 'OR') return 'OR'
+  if (group?.conjunction === 'AND') return 'AND'
+  return group?.logic === 'or' ? 'OR' : 'AND'
+}
+
+function cloneConditionLeaf(condition: AutomationCondition): AutomationCondition {
+  const cloned: AutomationCondition = {
+    fieldId: condition.fieldId,
+    operator: condition.operator,
+  }
+  if (condition.value !== undefined) {
+    cloned.value = isArrayOperator(condition.operator) && Array.isArray(condition.value)
+      ? condition.value.join(', ')
+      : condition.value
+  }
+  return cloned
+}
+
+function cloneConditionNode(node: AutomationConditionNode): AutomationConditionNode {
+  if (isConditionGroupNode(node)) {
+    const cloned: ConditionGroup = {
+      conditions: node.conditions.map(cloneConditionNode),
+    }
+    if (node.conjunction === 'AND' || node.conjunction === 'OR') cloned.conjunction = node.conjunction
+    if (node.logic === 'and' || node.logic === 'or') cloned.logic = node.logic
+    return cloned
+  }
+  return cloneConditionLeaf(node)
+}
+
+function conditionGroupFromRule(group: ConditionGroup | undefined): Draft['conditions'] {
+  return {
+    conjunction: normalizeConditionConjunction(group),
+    conditions: group?.conditions.map(cloneConditionNode) ?? [],
+  }
+}
+
+function parseConditionArrayValue(value: unknown): unknown[] {
+  if (Array.isArray(value)) {
+    return value
+      .map((entry) => typeof entry === 'string' ? entry.trim() : entry)
+      .filter((entry) => typeof entry === 'string' ? entry.length > 0 : entry !== null && entry !== undefined)
+  }
+  if (typeof value !== 'string') return []
+  return value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+}
+
+function isConditionLeafComplete(condition: AutomationCondition): boolean {
+  if (!condition.fieldId.trim()) return false
+  if (isUnaryOperator(condition.operator)) return true
+  if (isArrayOperator(condition.operator)) return parseConditionArrayValue(condition.value).length > 0
+  return typeof condition.value === 'string'
+    ? condition.value.trim().length > 0
+    : condition.value !== undefined && condition.value !== null
+}
+
+function areConditionsComplete(node: AutomationConditionNode): boolean {
+  if (isConditionGroupNode(node)) return node.conditions.every(areConditionsComplete)
+  return isConditionLeafComplete(node)
+}
+
+function buildConditionNodePayload(node: AutomationConditionNode): AutomationConditionNode {
+  if (isConditionGroupNode(node)) {
+    const group: ConditionGroup = {
+      conditions: node.conditions.map(buildConditionNodePayload),
+    }
+    if (node.conjunction === 'AND' || node.conjunction === 'OR') group.conjunction = node.conjunction
+    if (node.logic === 'and' || node.logic === 'or') group.logic = node.logic
+    return group
+  }
+
+  const condition: AutomationCondition = {
+    fieldId: node.fieldId.trim(),
+    operator: node.operator,
+  }
+  if (!isUnaryOperator(node.operator)) {
+    condition.value = isArrayOperator(node.operator)
+      ? parseConditionArrayValue(node.value)
+      : typeof node.value === 'string'
+        ? node.value.trim()
+        : node.value
+  }
+  return condition
 }
 
 function emptyDraft(): Draft {
@@ -1040,9 +1148,7 @@ function draftFromRule(rule: AutomationRule): Draft {
     name: rule.name,
     triggerType: rule.triggerType,
     triggerConfig: { ...rule.triggerConfig, ...(rule.trigger?.config ?? {}) },
-    conditions: rule.conditions
-      ? { conjunction: rule.conditions.conjunction, conditions: rule.conditions.conditions.map((c) => ({ ...c })) }
-      : { conjunction: 'AND', conditions: [] },
+    conditions: conditionGroupFromRule(rule.conditions),
     actions: rule.actions && rule.actions.length
       ? rule.actions.map((a) => ({ type: a.type, config: draftConfigFromAction(a.type, a.config) }))
       : [{ type: rule.actionType, config: draftConfigFromAction(rule.actionType, rule.actionConfig) }],
@@ -1050,6 +1156,14 @@ function draftFromRule(rule: AutomationRule): Draft {
 }
 
 const draft = ref<Draft>(emptyDraft())
+const editableConditionEntries = computed(() =>
+  draft.value.conditions.conditions
+    .map((condition, index) => ({ condition, index }))
+    .filter((entry): entry is { condition: AutomationCondition; index: number } => !isConditionGroupNode(entry.condition)),
+)
+const hasNestedConditionGroups = computed(() =>
+  draft.value.conditions.conditions.some(isConditionGroupNode),
+)
 
 watch(
   () => props.visible,
@@ -1080,6 +1194,7 @@ watch(
 const canSave = computed(() => {
   if (!draft.value.name.trim()) return false
   if (draft.value.actions.length < 1) return false
+  if (!draft.value.conditions.conditions.every(areConditionsComplete)) return false
   for (const action of draft.value.actions) {
     if (action.type === 'send_dingtalk_group_message') {
       const destinationIds = parseGroupDestinationIds(action.config.destinationIds ?? action.config.destinationId)
@@ -1797,7 +1912,12 @@ function buildPayload(): Partial<AutomationRule> {
     triggerType: d.triggerType,
     triggerConfig,
     trigger: { type: d.triggerType, config: triggerConfig },
-    conditions: d.conditions.conditions.length > 0 ? d.conditions : undefined,
+    conditions: d.conditions.conditions.length > 0
+      ? {
+        conjunction: d.conditions.conjunction,
+        conditions: d.conditions.conditions.map(buildConditionNodePayload),
+      }
+      : undefined,
     actions,
     actionType: actions[0]?.type ?? 'update_record',
     actionConfig: actions[0]?.config ?? {},

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -753,6 +753,8 @@ export type ConditionOperator =
   | 'less_or_equal'
   | 'is_empty'
   | 'is_not_empty'
+  | 'in'
+  | 'not_in'
 
 export interface AutomationCondition {
   fieldId: string
@@ -760,9 +762,12 @@ export interface AutomationCondition {
   value?: unknown
 }
 
+export type AutomationConditionNode = AutomationCondition | ConditionGroup
+
 export interface ConditionGroup {
-  conjunction: 'AND' | 'OR'
-  conditions: AutomationCondition[]
+  conjunction?: 'AND' | 'OR'
+  logic?: 'and' | 'or'
+  conditions: AutomationConditionNode[]
 }
 
 export type AutomationActionType =

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -6,7 +6,7 @@ function flushPromises() {
 }
 
 import MetaAutomationRuleEditor from '../src/multitable/components/MetaAutomationRuleEditor.vue'
-import type { AutomationRule } from '../src/multitable/types'
+import type { AutomationRule, ConditionGroup } from '../src/multitable/types'
 
 const fields = [
   { id: 'fld_1', name: 'Status', type: 'select' },
@@ -241,6 +241,93 @@ describe('MetaAutomationRuleEditor', () => {
     await flushPromises()
 
     expect(container.querySelectorAll('[data-condition-index]').length).toBe(0)
+  })
+
+  it('serializes list membership conditions as arrays', async () => {
+    const saved = vi.fn()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      onSave: saved,
+    })
+    await flushPromises()
+
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    nameInput.value = 'List condition'
+    nameInput.dispatchEvent(new Event('input'))
+
+    ;(container.querySelector('[data-action="add-condition"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    const conditionRow = container.querySelector('[data-condition-index="0"]') as HTMLElement
+    const [fieldSelect, operatorSelect] = Array.from(conditionRow.querySelectorAll('select')) as HTMLSelectElement[]
+    fieldSelect.value = 'fld_1'
+    fieldSelect.dispatchEvent(new Event('change'))
+    operatorSelect.value = 'in'
+    operatorSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(true)
+
+    const valueInput = conditionRow.querySelector('input') as HTMLInputElement
+    valueInput.value = 'Ready, Blocked'
+    valueInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    expect(saveBtn.disabled).toBe(false)
+    saveBtn.click()
+    await flushPromises()
+
+    expect(saved).toHaveBeenCalledTimes(1)
+    expect(saved.mock.calls[0][0].conditions).toEqual({
+      conjunction: 'AND',
+      conditions: [{ fieldId: 'fld_1', operator: 'in', value: ['Ready', 'Blocked'] }],
+    })
+  })
+
+  it('preserves nested condition groups while editing other rule fields', async () => {
+    const saved = vi.fn()
+    const nestedConditions: ConditionGroup = {
+      logic: 'or',
+      conditions: [
+        { fieldId: 'fld_1', operator: 'equals', value: 'Ready' },
+        {
+          logic: 'and',
+          conditions: [
+            { fieldId: 'fld_2', operator: 'contains', value: 'VIP' },
+            { fieldId: 'assigneeUserIds', operator: 'in', value: ['user_1', 'user_2'] },
+          ],
+        },
+      ],
+    }
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      rule: fakeRule({ conditions: nestedConditions }),
+      onSave: saved,
+    })
+    await flushPromises()
+
+    expect(container.querySelector('[data-field="nestedConditionNotice"]')?.textContent)
+      .toContain('Nested condition groups are preserved')
+    expect(container.querySelectorAll('[data-condition-index]').length).toBe(1)
+
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    nameInput.value = 'Preserve nested'
+    nameInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    ;(container.querySelector('[data-action="save"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    expect(saved).toHaveBeenCalledTimes(1)
+    expect(saved.mock.calls[0][0].conditions).toEqual({
+      conjunction: 'OR',
+      conditions: nestedConditions.conditions,
+    })
   })
 
   it('can add actions up to max 3', async () => {

--- a/docs/development/multitable-automation-condition-ui-development-20260511.md
+++ b/docs/development/multitable-automation-condition-ui-development-20260511.md
@@ -1,0 +1,60 @@
+# Multitable Automation Condition UI Development - 2026-05-11
+
+## Context
+
+PR #1466 fixed backend condition evaluation for both `logic` and `conjunction`.
+PR #1467 then added route-boundary validation so malformed automation `conditions` no longer persist as JSONB.
+
+This follow-up aligns the frontend rule editor with that validated schema.
+
+## Scope
+
+Implemented:
+
+- Extended frontend automation condition types to include:
+  - `in`
+  - `not_in`
+  - nested `ConditionGroup` nodes
+  - backend-style `logic`
+  - frontend-style `conjunction`
+- Added `In list` and `Not in list` operators to `MetaAutomationRuleEditor`.
+- Serialized `in` / `not_in` UI text as arrays before save.
+- Kept save disabled when a condition row is incomplete.
+- Preserved existing nested condition groups when editing other rule fields.
+- Added a readonly notice when nested groups exist, because the editor still only edits top-level leaf conditions.
+
+Not implemented:
+
+- Full nested-condition builder UX.
+- Drag/drop condition group authoring.
+- Field-type-aware operator filtering.
+- Backend changes.
+
+## Design Decisions
+
+### Preserve Nested Groups Rather Than Flattening
+
+The backend now supports nested condition groups, but the current editor is a single-level builder.
+Flattening nested payloads would silently change automation semantics.
+
+The editor now preserves nested groups on save and shows a notice that only top-level conditions are editable.
+
+### Convert List Operators At Save Boundary
+
+The route validator requires arrays for `in` and `not_in`.
+The UI keeps a simple comma-separated text field and converts it to an array in `buildPayload()`.
+
+### Keep This Slice Compatibility-Oriented
+
+This slice intentionally avoids a broader nested builder. The goal is to prevent schema drift and data loss after #1467, not to introduce a new complex authoring workflow.
+
+## Files Changed
+
+- `apps/web/src/multitable/types.ts`
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+
+## Follow-Ups
+
+- Build a full nested-condition editor after UX is confirmed.
+- Add field-aware operator filtering if product wants type-specific condition authoring.

--- a/docs/development/multitable-automation-condition-ui-verification-20260511.md
+++ b/docs/development/multitable-automation-condition-ui-verification-20260511.md
@@ -1,0 +1,77 @@
+# Multitable Automation Condition UI Verification - 2026-05-11
+
+## Environment
+
+- Worktree: `/private/tmp/ms2-automation-condition-ui-20260511`
+- Branch: `codex/multitable-automation-condition-ui-20260511`
+- Baseline: `origin/main@4c533472f`
+- Scope: frontend automation condition schema compatibility.
+
+## Commands
+
+### Automation Rule Editor Unit Tests
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/multitable-automation-rule-editor.spec.ts \
+  --watch=false
+```
+
+Expected:
+
+- existing rule editor behavior remains green;
+- `in` list conditions serialize as arrays;
+- incomplete list conditions keep Save disabled;
+- nested condition groups are preserved when editing other fields.
+
+Result:
+
+- 1 file passed.
+- 65 tests passed.
+
+### Multitable API Client Regression
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/multitable-client.spec.ts \
+  --watch=false
+```
+
+Expected:
+
+- existing automation rule response normalization remains green after widening the condition types.
+
+Result:
+
+- 1 file passed.
+- 20 tests passed.
+
+### Frontend Type Check
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc --noEmit --pretty false
+```
+
+Expected: pass.
+
+Result:
+
+- pass.
+
+### Diff Hygiene
+
+```bash
+git diff --check
+```
+
+Expected: pass.
+
+Result:
+
+- pass.
+
+## Non-Verification
+
+- No browser smoke was run.
+- No live backend route call was run.
+- No full nested-condition authoring UX was implemented.


### PR DESCRIPTION
## Summary

- align frontend automation condition types with the backend schema from #1467
- add `in` / `not_in` operators to the automation rule editor and serialize comma-separated values as arrays
- preserve existing nested condition groups while editing top-level rule fields
- keep Save disabled for incomplete condition rows
- add development and verification notes under `docs/development/`

## Verification

- `pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts --watch=false` — 65/65 pass
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-client.spec.ts --watch=false` — 20/20 pass
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit --pretty false` — pass
- `git diff --check` — pass

## Notes

- This does not add a full nested-condition builder. Existing nested groups are preserved and surfaced with a readonly notice.
- No backend changes are included.
