### PR TITLE
fix(multitable): filter automation condition operators by field

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -97,12 +97,20 @@
             class="meta-rule-editor__condition-row"
             :data-condition-index="idx"
           >
-            <select v-model="cond.fieldId" class="meta-rule-editor__select meta-rule-editor__select--sm">
+            <select
+              :value="cond.fieldId"
+              class="meta-rule-editor__select meta-rule-editor__select--sm"
+              @change="onConditionFieldChange(cond, ($event.target as HTMLSelectElement).value)"
+            >
               <option value="">-- field --</option>
               <option v-for="f in fields" :key="f.id" :value="f.id">{{ f.name }}</option>
             </select>
-            <select v-model="cond.operator" class="meta-rule-editor__select meta-rule-editor__select--sm">
-              <option v-for="op in conditionOperators" :key="op.value" :value="op.value">{{ op.label }}</option>
+            <select
+              :value="cond.operator"
+              class="meta-rule-editor__select meta-rule-editor__select--sm"
+              @change="onConditionOperatorChange(cond, ($event.target as HTMLSelectElement).value as ConditionOperator)"
+            >
+              <option v-for="op in conditionOperatorsForField(cond.fieldId)" :key="op.value" :value="op.value">{{ op.label }}</option>
             </select>
             <input
               v-if="!isUnaryOperator(cond.operator)"
@@ -967,7 +975,9 @@ const savedRuleHasDingTalkActions = computed(() => ruleHasDingTalkActions(props.
 const DINGTALK_TEST_RUN_CONFIRM_MESSAGE =
   'Test Run executes the saved rule and can send real DingTalk messages to configured groups or users. Unsaved changes are not included. Continue?'
 
-const conditionOperators: Array<{ value: ConditionOperator; label: string }> = [
+type ConditionOperatorOption = { value: ConditionOperator; label: string }
+
+const conditionOperators: ConditionOperatorOption[] = [
   { value: 'equals', label: 'Equals' },
   { value: 'not_equals', label: 'Not equals' },
   { value: 'contains', label: 'Contains' },
@@ -981,6 +991,109 @@ const conditionOperators: Array<{ value: ConditionOperator; label: string }> = [
   { value: 'in', label: 'In list' },
   { value: 'not_in', label: 'Not in list' },
 ]
+
+const CONDITION_OPERATOR_LOOKUP = new Map(conditionOperators.map((operator) => [operator.value, operator]))
+const EMPTY_VALUE_OPERATOR_OPTIONS = ['is_empty', 'is_not_empty'] as const
+const EQUALITY_OPERATOR_OPTIONS = ['equals', 'not_equals', 'in', 'not_in', 'is_empty', 'is_not_empty'] as const
+const TEXT_OPERATOR_OPTIONS = [
+  'equals',
+  'not_equals',
+  'contains',
+  'not_contains',
+  'in',
+  'not_in',
+  'is_empty',
+  'is_not_empty',
+] as const
+const COMPARABLE_OPERATOR_OPTIONS = [
+  'equals',
+  'not_equals',
+  'greater_than',
+  'less_than',
+  'greater_or_equal',
+  'less_or_equal',
+  'in',
+  'not_in',
+  'is_empty',
+  'is_not_empty',
+] as const
+const MULTI_VALUE_OPERATOR_OPTIONS = [
+  'contains',
+  'not_contains',
+  'in',
+  'not_in',
+  'is_empty',
+  'is_not_empty',
+] as const
+
+function optionsFromOperators(operators: readonly ConditionOperator[]): ConditionOperatorOption[] {
+  return operators
+    .map((operator) => CONDITION_OPERATOR_LOOKUP.get(operator))
+    .filter((operator): operator is ConditionOperatorOption => !!operator)
+}
+
+function conditionOperatorsForField(fieldId: string): ConditionOperatorOption[] {
+  const fieldType = props.fields.find((field) => field.id === fieldId)?.type
+  if (!fieldType) return optionsFromOperators(EMPTY_VALUE_OPERATOR_OPTIONS)
+
+  switch (fieldType) {
+    case 'number':
+    case 'currency':
+    case 'percent':
+    case 'rating':
+    case 'date':
+    case 'dateTime':
+    case 'createdTime':
+    case 'modifiedTime':
+    case 'autoNumber':
+      return optionsFromOperators(COMPARABLE_OPERATOR_OPTIONS)
+    case 'boolean':
+      return optionsFromOperators(EQUALITY_OPERATOR_OPTIONS)
+    case 'select':
+    case 'person':
+    case 'link':
+    case 'lookup':
+    case 'rollup':
+    case 'createdBy':
+    case 'modifiedBy':
+      return optionsFromOperators(EQUALITY_OPERATOR_OPTIONS)
+    case 'multiSelect':
+      return optionsFromOperators(MULTI_VALUE_OPERATOR_OPTIONS)
+    case 'attachment':
+      return optionsFromOperators(EMPTY_VALUE_OPERATOR_OPTIONS)
+    default:
+      return optionsFromOperators(TEXT_OPERATOR_OPTIONS)
+  }
+}
+
+function firstOperatorForField(fieldId: string): ConditionOperator {
+  return conditionOperatorsForField(fieldId)[0]?.value ?? 'is_empty'
+}
+
+function resetConditionValue(condition: AutomationCondition) {
+  if (isUnaryOperator(condition.operator)) {
+    delete condition.value
+  } else if (isArrayOperator(condition.operator)) {
+    condition.value = ''
+  } else {
+    condition.value = ''
+  }
+}
+
+function onConditionFieldChange(condition: AutomationCondition, fieldId: string) {
+  const previousFieldId = condition.fieldId
+  condition.fieldId = fieldId
+  const allowedOperators = conditionOperatorsForField(fieldId)
+  if (!previousFieldId || !allowedOperators.some((operator) => operator.value === condition.operator)) {
+    condition.operator = firstOperatorForField(fieldId)
+    resetConditionValue(condition)
+  }
+}
+
+function onConditionOperatorChange(condition: AutomationCondition, operator: ConditionOperator) {
+  condition.operator = operator
+  resetConditionValue(condition)
+}
 
 function isUnaryOperator(op: ConditionOperator): boolean {
   return op === 'is_empty' || op === 'is_not_empty'

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -11,6 +11,8 @@ import type { AutomationRule, ConditionGroup } from '../src/multitable/types'
 const fields = [
   { id: 'fld_1', name: 'Status', type: 'select' },
   { id: 'fld_2', name: 'Name', type: 'string' },
+  { id: 'fld_score', name: 'Score', type: 'number' },
+  { id: 'fld_files', name: 'Files', type: 'attachment' },
   { id: 'assigneeUserIds', name: 'Assignees', type: 'user' },
   { id: 'reviewerUserId', name: 'Reviewer', type: 'user' },
   { id: 'watcherGroupIds', name: 'Watcher groups', type: 'link', property: { refKind: 'member-group' } },
@@ -243,6 +245,70 @@ describe('MetaAutomationRuleEditor', () => {
     expect(container.querySelectorAll('[data-condition-index]').length).toBe(0)
   })
 
+  it('filters condition operators by selected field type and resets incompatible choices', async () => {
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields })
+    await flushPromises()
+
+    ;(container.querySelector('[data-action="add-condition"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    const conditionRow = container.querySelector('[data-condition-index="0"]') as HTMLElement
+    const [fieldSelect, operatorSelect] = Array.from(conditionRow.querySelectorAll('select')) as HTMLSelectElement[]
+
+    fieldSelect.value = 'fld_2'
+    fieldSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    expect(Array.from(operatorSelect.options).map((option) => option.value)).toContain('contains')
+    expect(Array.from(operatorSelect.options).map((option) => option.value)).not.toContain('greater_than')
+
+    operatorSelect.value = 'contains'
+    operatorSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+    expect(operatorSelect.value).toBe('contains')
+
+    fieldSelect.value = 'fld_score'
+    fieldSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const numericOperatorValues = Array.from(operatorSelect.options).map((option) => option.value)
+    expect(numericOperatorValues).toContain('greater_than')
+    expect(numericOperatorValues).not.toContain('contains')
+    expect(operatorSelect.value).toBe('equals')
+  })
+
+  it('limits attachment field conditions to empty-state operators', async () => {
+    const saved = vi.fn()
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, onSave: saved })
+    await flushPromises()
+
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    nameInput.value = 'Files condition'
+    nameInput.dispatchEvent(new Event('input'))
+
+    ;(container.querySelector('[data-action="add-condition"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    const conditionRow = container.querySelector('[data-condition-index="0"]') as HTMLElement
+    const [fieldSelect, operatorSelect] = Array.from(conditionRow.querySelectorAll('select')) as HTMLSelectElement[]
+    fieldSelect.value = 'fld_files'
+    fieldSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    expect(Array.from(operatorSelect.options).map((option) => option.value)).toEqual(['is_empty', 'is_not_empty'])
+    expect(operatorSelect.value).toBe('is_empty')
+    expect(conditionRow.querySelector('input')).toBeNull()
+
+    ;(container.querySelector('[data-action="save"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    expect(saved).toHaveBeenCalledTimes(1)
+    expect(saved.mock.calls[0][0].conditions).toEqual({
+      conjunction: 'AND',
+      conditions: [{ fieldId: 'fld_files', operator: 'is_empty' }],
+    })
+  })
+
   it('serializes list membership conditions as arrays', async () => {
     const saved = vi.fn()
     const { container } = mount({
@@ -261,9 +327,12 @@ describe('MetaAutomationRuleEditor', () => {
     await flushPromises()
 
     const conditionRow = container.querySelector('[data-condition-index="0"]') as HTMLElement
-    const [fieldSelect, operatorSelect] = Array.from(conditionRow.querySelectorAll('select')) as HTMLSelectElement[]
+    const [fieldSelect] = Array.from(conditionRow.querySelectorAll('select')) as HTMLSelectElement[]
     fieldSelect.value = 'fld_1'
     fieldSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const operatorSelect = Array.from(conditionRow.querySelectorAll('select'))[1] as HTMLSelectElement
     operatorSelect.value = 'in'
     operatorSelect.dispatchEvent(new Event('change'))
     await flushPromises()

--- a/docs/development/multitable-automation-field-aware-operators-development-20260511.md
+++ b/docs/development/multitable-automation-field-aware-operators-development-20260511.md
@@ -1,0 +1,53 @@
+# Multitable Automation Field-Aware Operators Development - 2026-05-11
+
+## Context
+
+PR #1467 added backend validation for automation condition payloads.
+PR #1470 aligned the frontend editor with that schema by preserving nested groups and serializing `in` / `not_in` values as arrays.
+
+This follow-up reduces bad authoring at the UI layer by filtering condition operators based on the selected field type.
+
+## Scope
+
+Implemented:
+
+- Added field-aware operator lists in `MetaAutomationRuleEditor`.
+- Text-like fields keep text operators such as `contains` and `not_contains`.
+- Numeric/date/system-time fields get comparison operators such as `greater_than` and `less_or_equal`.
+- Boolean, select, person, link, lookup, rollup, and system-user fields get equality/list/empty-state operators.
+- Multi-select fields get membership and empty-state operators.
+- Attachment fields only get empty-state operators.
+- Changing a condition field resets incompatible operators to the selected field's default operator.
+- Changing an operator clears stale value state so old text values do not leak across operator types.
+
+Not implemented:
+
+- Field metadata dependent value widgets.
+- Full nested-condition group authoring.
+- Backend field-aware semantic validation.
+
+## Design Decisions
+
+### Filter In The Editor, Keep Backend Generic
+
+The backend parser intentionally validates JSON shape rather than loading field metadata.
+This slice keeps the backend generic and improves the authoring UX where the field list is already available.
+
+### Reset Incompatible Operators
+
+When a user switches a condition from a text field to a numeric field, `contains` is no longer a meaningful option.
+The editor now resets that operator to the first valid operator for the new field and clears the old value.
+
+### Preserve Existing Schema Behavior
+
+This change does not alter payload shape. It only changes which operators the UI presents and how stale local draft state is cleaned.
+
+## Files Changed
+
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+
+## Follow-Ups
+
+- Add type-specific value widgets, for example date pickers, number inputs, boolean selects, and option pickers.
+- Add a full nested-condition builder after UX confirmation.

--- a/docs/development/multitable-automation-field-aware-operators-verification-20260511.md
+++ b/docs/development/multitable-automation-field-aware-operators-verification-20260511.md
@@ -1,0 +1,61 @@
+# Multitable Automation Field-Aware Operators Verification - 2026-05-11
+
+## Environment
+
+- Worktree: `/private/tmp/ms2-automation-field-aware-operators-20260511`
+- Branch: `codex/multitable-automation-field-aware-operators-20260511`
+- Baseline: `origin/main@158bd831e`
+- Scope: frontend automation condition operator filtering.
+
+## Commands
+
+### Automation Rule Editor Unit Tests
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/multitable-automation-rule-editor.spec.ts \
+  --watch=false
+```
+
+Expected:
+
+- existing rule editor behavior remains green;
+- text fields show text operators but not numeric comparison operators;
+- numeric fields show comparison operators and reset incompatible text operators;
+- attachment fields only show empty-state operators;
+- existing list and nested condition coverage remains green.
+
+Result:
+
+- 1 file passed.
+- 67 tests passed.
+
+### Frontend Type Check
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc --noEmit --pretty false
+```
+
+Expected: pass.
+
+Result:
+
+- pass.
+
+### Diff Hygiene
+
+```bash
+git diff --check
+```
+
+Expected: pass.
+
+Result:
+
+- pass.
+
+## Non-Verification
+
+- No browser smoke was run.
+- No live backend route call was run.
+- No field-specific value picker UI was implemented.


### PR DESCRIPTION
## Summary

- Filters automation condition operators by the selected multitable field type.
- Resets incompatible operators and stale condition values when a condition field/operator changes.
- Limits attachment field conditions to empty-state operators while preserving text, numeric/date, equality, and multi-value operator groups.
- Adds development and verification notes for the slice.

## Verification

- `pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts --watch=false` — 67/67 pass
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit --pretty false` — pass
- `git diff --check` — pass

## Notes

- No backend payload schema change.
- No field-specific value widgets in this slice; that remains a follow-up.
