### PR TITLE
fix(multitable): add automation condition value widgets

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -112,13 +112,51 @@
             >
               <option v-for="op in conditionOperatorsForField(cond.fieldId)" :key="op.value" :value="op.value">{{ op.label }}</option>
             </select>
-            <input
-              v-if="!isUnaryOperator(cond.operator)"
-              v-model="cond.value"
-              class="meta-rule-editor__input meta-rule-editor__input--sm"
-              type="text"
-              :placeholder="conditionValuePlaceholder(cond.operator)"
-            />
+            <template v-if="!isUnaryOperator(cond.operator)">
+              <select
+                v-if="conditionValueWidget(cond) === 'boolean'"
+                :value="booleanConditionValue(cond)"
+                class="meta-rule-editor__select meta-rule-editor__select--sm"
+                data-condition-value="boolean"
+                @change="onBooleanConditionValueChange(cond, ($event.target as HTMLSelectElement).value)"
+              >
+                <option value="">-- value --</option>
+                <option value="true">true</option>
+                <option value="false">false</option>
+              </select>
+              <select
+                v-else-if="conditionValueWidget(cond) === 'select'"
+                :value="singleSelectConditionValue(cond)"
+                class="meta-rule-editor__select meta-rule-editor__select--sm"
+                data-condition-value="select"
+                @change="cond.value = ($event.target as HTMLSelectElement).value"
+              >
+                <option value="">-- value --</option>
+                <option v-for="option in conditionFieldOptions(cond)" :key="option.value" :value="option.value">
+                  {{ optionLabel(option) }}
+                </option>
+              </select>
+              <select
+                v-else-if="conditionValueWidget(cond) === 'multiSelect'"
+                :value="multiSelectConditionValues(cond)"
+                class="meta-rule-editor__select meta-rule-editor__select--sm"
+                data-condition-value="multi-select"
+                multiple
+                @change="onMultiSelectConditionValueChange(cond, $event)"
+              >
+                <option v-for="option in conditionFieldOptions(cond)" :key="option.value" :value="option.value">
+                  {{ optionLabel(option) }}
+                </option>
+              </select>
+              <input
+                v-else
+                v-model="cond.value"
+                class="meta-rule-editor__input meta-rule-editor__input--sm"
+                :type="conditionValueInputType(cond)"
+                :inputmode="conditionValueInputMode(cond)"
+                :placeholder="conditionValuePlaceholder(cond)"
+              />
+            </template>
             <button class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="removeCondition(idx)" title="Remove condition">&times;</button>
           </div>
           <button class="meta-rule-editor__btn" type="button" data-action="add-condition" @click="addCondition">+ Add condition</button>
@@ -923,6 +961,15 @@ interface Draft {
   actions: DraftAction[]
 }
 
+type FieldOption = { value: string; label?: string; color?: string }
+type AutomationRuleEditorField = {
+  id: string
+  name: string
+  type: string
+  property?: Record<string, unknown>
+  options?: FieldOption[]
+}
+
 const props = defineProps<{
   sheetId: string
   rule?: AutomationRule
@@ -931,7 +978,7 @@ const props = defineProps<{
     message: string
   }
   visible: boolean
-  fields: Array<{ id: string; name: string; type: string; property?: Record<string, unknown> }>
+  fields: AutomationRuleEditorField[]
   client?: MultitableApiClient
   views?: MetaView[]
 }>()
@@ -976,6 +1023,7 @@ const DINGTALK_TEST_RUN_CONFIRM_MESSAGE =
   'Test Run executes the saved rule and can send real DingTalk messages to configured groups or users. Unsaved changes are not included. Continue?'
 
 type ConditionOperatorOption = { value: ConditionOperator; label: string }
+type ConditionValueWidget = 'text' | 'number' | 'date' | 'dateTime' | 'boolean' | 'select' | 'multiSelect'
 
 const conditionOperators: ConditionOperatorOption[] = [
   { value: 'equals', label: 'Equals' },
@@ -1070,6 +1118,81 @@ function firstOperatorForField(fieldId: string): ConditionOperator {
   return conditionOperatorsForField(fieldId)[0]?.value ?? 'is_empty'
 }
 
+function conditionField(condition: AutomationCondition): AutomationRuleEditorField | undefined {
+  return props.fields.find((field) => field.id === condition.fieldId)
+}
+
+function conditionFieldOptions(condition: AutomationCondition): FieldOption[] {
+  return conditionField(condition)?.options ?? []
+}
+
+function optionLabel(option: FieldOption): string {
+  return option.label ?? option.value
+}
+
+function conditionValueWidget(condition: AutomationCondition): ConditionValueWidget {
+  const field = conditionField(condition)
+  if (!field) return 'text'
+  if (field.type === 'boolean') return 'boolean'
+  if (isNumericConditionFieldType(field.type)) return 'number'
+  if (field.type === 'date') return 'date'
+  if (field.type === 'dateTime' || field.type === 'createdTime' || field.type === 'modifiedTime') return 'dateTime'
+  if ((field.type === 'select' || field.type === 'multiSelect') && conditionFieldOptions(condition).length > 0) {
+    return isArrayOperator(condition.operator) ? 'multiSelect' : 'select'
+  }
+  return 'text'
+}
+
+function conditionValueInputType(condition: AutomationCondition): string {
+  const widget = conditionValueWidget(condition)
+  if (widget === 'number') return 'number'
+  if (widget === 'date') return 'date'
+  if (widget === 'dateTime') return 'datetime-local'
+  return 'text'
+}
+
+function conditionValueInputMode(condition: AutomationCondition): 'decimal' | undefined {
+  return conditionValueWidget(condition) === 'number' ? 'decimal' : undefined
+}
+
+function booleanConditionValue(condition: AutomationCondition): string {
+  if (condition.value === true) return 'true'
+  if (condition.value === false) return 'false'
+  if (condition.value === 'true' || condition.value === 'false') return condition.value
+  return ''
+}
+
+function singleSelectConditionValue(condition: AutomationCondition): string {
+  return typeof condition.value === 'string' ? condition.value : ''
+}
+
+function multiSelectConditionValues(condition: AutomationCondition): string[] {
+  return parseConditionArrayValue(condition.value).map(String)
+}
+
+function onBooleanConditionValueChange(condition: AutomationCondition, value: string) {
+  if (value === 'true') {
+    condition.value = true
+  } else if (value === 'false') {
+    condition.value = false
+  } else {
+    condition.value = ''
+  }
+}
+
+function onMultiSelectConditionValueChange(condition: AutomationCondition, event: Event) {
+  const select = event.target as HTMLSelectElement
+  condition.value = Array.from(select.selectedOptions).map((option) => option.value)
+}
+
+function isNumericConditionFieldType(fieldType: string | undefined): boolean {
+  return fieldType === 'number' ||
+    fieldType === 'currency' ||
+    fieldType === 'percent' ||
+    fieldType === 'rating' ||
+    fieldType === 'autoNumber'
+}
+
 function resetConditionValue(condition: AutomationCondition) {
   if (isUnaryOperator(condition.operator)) {
     delete condition.value
@@ -1103,8 +1226,12 @@ function isArrayOperator(op: ConditionOperator): boolean {
   return op === 'in' || op === 'not_in'
 }
 
-function conditionValuePlaceholder(op: ConditionOperator): string {
-  return isArrayOperator(op) ? 'Comma-separated values' : 'Value'
+function conditionValuePlaceholder(condition: AutomationCondition): string {
+  if (isArrayOperator(condition.operator)) return 'Comma-separated values'
+  if (conditionValueWidget(condition) === 'number') return 'Number'
+  if (conditionValueWidget(condition) === 'date') return 'YYYY-MM-DD'
+  if (conditionValueWidget(condition) === 'dateTime') return 'Date and time'
+  return 'Value'
 }
 
 function isConditionGroupNode(node: AutomationConditionNode): node is ConditionGroup {
@@ -1162,10 +1289,46 @@ function parseConditionArrayValue(value: unknown): unknown[] {
     .filter(Boolean)
 }
 
+function parseNumberConditionValue(value: unknown): number | null {
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  if (!trimmed) return null
+  const parsed = Number(trimmed)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function parseBooleanConditionValue(value: unknown): boolean | null {
+  if (value === true || value === false) return value
+  if (value === 'true') return true
+  if (value === 'false') return false
+  return null
+}
+
+function conditionFieldType(fieldId: string): string | undefined {
+  return props.fields.find((field) => field.id === fieldId)?.type
+}
+
+function buildConditionValuePayload(condition: AutomationCondition): unknown {
+  if (isArrayOperator(condition.operator)) return parseConditionArrayValue(condition.value)
+
+  const fieldType = conditionFieldType(condition.fieldId)
+  if (isNumericConditionFieldType(fieldType)) {
+    return parseNumberConditionValue(condition.value)
+  }
+  if (fieldType === 'boolean') {
+    return parseBooleanConditionValue(condition.value)
+  }
+  return typeof condition.value === 'string' ? condition.value.trim() : condition.value
+}
+
 function isConditionLeafComplete(condition: AutomationCondition): boolean {
   if (!condition.fieldId.trim()) return false
   if (isUnaryOperator(condition.operator)) return true
   if (isArrayOperator(condition.operator)) return parseConditionArrayValue(condition.value).length > 0
+  const fieldType = conditionFieldType(condition.fieldId)
+  if (isNumericConditionFieldType(fieldType)) return parseNumberConditionValue(condition.value) !== null
+  if (fieldType === 'boolean') return parseBooleanConditionValue(condition.value) !== null
   return typeof condition.value === 'string'
     ? condition.value.trim().length > 0
     : condition.value !== undefined && condition.value !== null
@@ -1191,11 +1354,7 @@ function buildConditionNodePayload(node: AutomationConditionNode): AutomationCon
     operator: node.operator,
   }
   if (!isUnaryOperator(node.operator)) {
-    condition.value = isArrayOperator(node.operator)
-      ? parseConditionArrayValue(node.value)
-      : typeof node.value === 'string'
-        ? node.value.trim()
-        : node.value
+    condition.value = buildConditionValuePayload(node)
   }
   return condition
 }

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -12,7 +12,27 @@ const fields = [
   { id: 'fld_1', name: 'Status', type: 'select' },
   { id: 'fld_2', name: 'Name', type: 'string' },
   { id: 'fld_score', name: 'Score', type: 'number' },
+  { id: 'fld_done', name: 'Done', type: 'boolean' },
+  { id: 'fld_due', name: 'Due date', type: 'date' },
   { id: 'fld_files', name: 'Files', type: 'attachment' },
+  {
+    id: 'fld_priority',
+    name: 'Priority',
+    type: 'select',
+    options: [
+      { value: 'low', label: 'Low' },
+      { value: 'high', label: 'High' },
+    ],
+  },
+  {
+    id: 'fld_tags',
+    name: 'Tags',
+    type: 'multiSelect',
+    options: [
+      { value: 'red', label: 'Red' },
+      { value: 'blue', label: 'Blue' },
+    ],
+  },
   { id: 'assigneeUserIds', name: 'Assignees', type: 'user' },
   { id: 'reviewerUserId', name: 'Reviewer', type: 'user' },
   { id: 'watcherGroupIds', name: 'Watcher groups', type: 'link', property: { refKind: 'member-group' } },
@@ -306,6 +326,181 @@ describe('MetaAutomationRuleEditor', () => {
     expect(saved.mock.calls[0][0].conditions).toEqual({
       conjunction: 'AND',
       conditions: [{ fieldId: 'fld_files', operator: 'is_empty' }],
+    })
+  })
+
+  it('serializes numeric condition values as numbers', async () => {
+    const saved = vi.fn()
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, onSave: saved })
+    await flushPromises()
+
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    nameInput.value = 'Score condition'
+    nameInput.dispatchEvent(new Event('input'))
+
+    ;(container.querySelector('[data-action="add-condition"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    const conditionRow = container.querySelector('[data-condition-index="0"]') as HTMLElement
+    const [fieldSelect] = Array.from(conditionRow.querySelectorAll('select')) as HTMLSelectElement[]
+    fieldSelect.value = 'fld_score'
+    fieldSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const valueInput = conditionRow.querySelector('input') as HTMLInputElement
+    expect(valueInput.type).toBe('number')
+    valueInput.value = '42.5'
+    valueInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    ;(container.querySelector('[data-action="save"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    expect(saved).toHaveBeenCalledTimes(1)
+    expect(saved.mock.calls[0][0].conditions).toEqual({
+      conjunction: 'AND',
+      conditions: [{ fieldId: 'fld_score', operator: 'equals', value: 42.5 }],
+    })
+  })
+
+  it('serializes boolean condition values as booleans', async () => {
+    const saved = vi.fn()
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, onSave: saved })
+    await flushPromises()
+
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    nameInput.value = 'Done condition'
+    nameInput.dispatchEvent(new Event('input'))
+
+    ;(container.querySelector('[data-action="add-condition"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    const conditionRow = container.querySelector('[data-condition-index="0"]') as HTMLElement
+    const [fieldSelect] = Array.from(conditionRow.querySelectorAll('select')) as HTMLSelectElement[]
+    fieldSelect.value = 'fld_done'
+    fieldSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const valueSelect = conditionRow.querySelector('[data-condition-value="boolean"]') as HTMLSelectElement
+    expect(valueSelect).toBeTruthy()
+    valueSelect.value = 'false'
+    valueSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    ;(container.querySelector('[data-action="save"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    expect(saved).toHaveBeenCalledTimes(1)
+    expect(saved.mock.calls[0][0].conditions).toEqual({
+      conjunction: 'AND',
+      conditions: [{ fieldId: 'fld_done', operator: 'equals', value: false }],
+    })
+  })
+
+  it('uses configured select options for single-value conditions', async () => {
+    const saved = vi.fn()
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, onSave: saved })
+    await flushPromises()
+
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    nameInput.value = 'Priority condition'
+    nameInput.dispatchEvent(new Event('input'))
+
+    ;(container.querySelector('[data-action="add-condition"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    const conditionRow = container.querySelector('[data-condition-index="0"]') as HTMLElement
+    const [fieldSelect] = Array.from(conditionRow.querySelectorAll('select')) as HTMLSelectElement[]
+    fieldSelect.value = 'fld_priority'
+    fieldSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const valueSelect = conditionRow.querySelector('[data-condition-value="select"]') as HTMLSelectElement
+    expect(Array.from(valueSelect.options).map((option) => option.textContent)).toEqual(['-- value --', 'Low', 'High'])
+    valueSelect.value = 'high'
+    valueSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    ;(container.querySelector('[data-action="save"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    expect(saved).toHaveBeenCalledTimes(1)
+    expect(saved.mock.calls[0][0].conditions).toEqual({
+      conjunction: 'AND',
+      conditions: [{ fieldId: 'fld_priority', operator: 'equals', value: 'high' }],
+    })
+  })
+
+  it('uses configured select options for list membership conditions', async () => {
+    const saved = vi.fn()
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, onSave: saved })
+    await flushPromises()
+
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    nameInput.value = 'Tag list condition'
+    nameInput.dispatchEvent(new Event('input'))
+
+    ;(container.querySelector('[data-action="add-condition"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    const conditionRow = container.querySelector('[data-condition-index="0"]') as HTMLElement
+    const [fieldSelect] = Array.from(conditionRow.querySelectorAll('select')) as HTMLSelectElement[]
+    fieldSelect.value = 'fld_tags'
+    fieldSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const operatorSelect = Array.from(conditionRow.querySelectorAll('select'))[1] as HTMLSelectElement
+    operatorSelect.value = 'in'
+    operatorSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const valueSelect = conditionRow.querySelector('[data-condition-value="multi-select"]') as HTMLSelectElement
+    valueSelect.options[0].selected = true
+    valueSelect.options[1].selected = true
+    valueSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    ;(container.querySelector('[data-action="save"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    expect(saved).toHaveBeenCalledTimes(1)
+    expect(saved.mock.calls[0][0].conditions).toEqual({
+      conjunction: 'AND',
+      conditions: [{ fieldId: 'fld_tags', operator: 'in', value: ['red', 'blue'] }],
+    })
+  })
+
+  it('renders date conditions with a date input and preserves ISO date values', async () => {
+    const saved = vi.fn()
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, onSave: saved })
+    await flushPromises()
+
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    nameInput.value = 'Date condition'
+    nameInput.dispatchEvent(new Event('input'))
+
+    ;(container.querySelector('[data-action="add-condition"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    const conditionRow = container.querySelector('[data-condition-index="0"]') as HTMLElement
+    const [fieldSelect] = Array.from(conditionRow.querySelectorAll('select')) as HTMLSelectElement[]
+    fieldSelect.value = 'fld_due'
+    fieldSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const valueInput = conditionRow.querySelector('input') as HTMLInputElement
+    expect(valueInput.type).toBe('date')
+    valueInput.value = '2026-05-11'
+    valueInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    ;(container.querySelector('[data-action="save"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    expect(saved).toHaveBeenCalledTimes(1)
+    expect(saved.mock.calls[0][0].conditions).toEqual({
+      conjunction: 'AND',
+      conditions: [{ fieldId: 'fld_due', operator: 'equals', value: '2026-05-11' }],
     })
   })
 

--- a/docs/development/multitable-automation-condition-value-widgets-development-20260511.md
+++ b/docs/development/multitable-automation-condition-value-widgets-development-20260511.md
@@ -1,0 +1,80 @@
+# Multitable Automation Condition Value Widgets Development - 2026-05-11
+
+## Context
+
+PR #1472 filtered automation condition operators by selected field type, but the
+condition value control was still a generic text input. That left two practical
+authoring gaps:
+
+- numeric fields could show comparison operators while still saving string
+  values, which do not satisfy the backend numeric comparison evaluator;
+- boolean/select-like fields required hand-typing values instead of choosing from
+  the available field metadata.
+
+This slice keeps the existing automation condition payload shape and improves
+frontend authoring only.
+
+## Scope
+
+Implemented:
+
+- Numeric condition fields render `<input type="number">` and serialize saved
+  values as finite numbers.
+- Boolean condition fields render a true/false select and serialize saved values
+  as booleans.
+- Date condition fields render `<input type="date">`.
+- DateTime/system-time condition fields render `<input type="datetime-local">`.
+- Select and multiSelect fields with configured options render option pickers.
+- `in` / `not_in` conditions over option-backed fields render a multi-select and
+  preserve array payloads.
+- Existing comma-separated list fallback remains for fields without configured
+  options.
+- Invalid/empty numeric and boolean values keep the Save button disabled through
+  the existing condition completeness gate.
+
+Not implemented:
+
+- Backend field-aware semantic validation.
+- Async option hydration for person/link/lookup fields.
+- Full nested condition group authoring.
+- Timezone normalization for `datetime-local`; the value is preserved as the
+  browser-provided local datetime string.
+
+## Design Decisions
+
+### Keep Payload Shape Stable
+
+The backend condition parser already accepts `unknown` values and only requires
+arrays for `in` / `not_in`. This change only improves the draft editor and final
+payload coercion:
+
+- number-like fields produce `number`;
+- boolean fields produce `boolean`;
+- date/select/text fields produce trimmed strings;
+- list operators produce arrays.
+
+### Prefer Field Metadata When Already Present
+
+The editor receives `fields` in props. For select and multiSelect fields that
+already include `options`, the value control uses those options. If options are
+missing, the editor falls back to the previous text input path rather than
+blocking rule authoring.
+
+### No Backend Coupling In This Slice
+
+The backend evaluator remains generic. This keeps the slice frontend-only and
+avoids introducing field lookup into the automation runtime path.
+
+## Files Changed
+
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+
+## Follow-Ups
+
+- Add backend field-aware validation if automation rules start accepting rules
+  from non-UI API clients at higher volume.
+- Add async pickers for person/link/lookup/rollup fields once those option
+  sources are standardized for automation.
+- Add browser smoke coverage after the automation editor gets a stable page-level
+  route fixture.

--- a/docs/development/multitable-automation-condition-value-widgets-verification-20260511.md
+++ b/docs/development/multitable-automation-condition-value-widgets-verification-20260511.md
@@ -1,0 +1,76 @@
+# Multitable Automation Condition Value Widgets Verification - 2026-05-11
+
+## Environment
+
+- Worktree: `/private/tmp/ms2-automation-field-value-widgets-20260511`
+- Branch: `codex/multitable-automation-field-value-widgets-20260511`
+- Baseline: `origin/main@45589fd9`
+- Scope: frontend automation condition value controls and payload coercion.
+
+## Commands
+
+### Install Workspace Links
+
+```bash
+pnpm install --ignore-scripts
+git checkout -- plugins/ tools/ pnpm-lock.yaml
+```
+
+Result:
+
+- workspace executable links restored for this temporary worktree;
+- dependency symlink dirt under `plugins/` and `tools/` reverted.
+
+### Automation Rule Editor Unit Tests
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/multitable-automation-rule-editor.spec.ts \
+  --watch=false
+```
+
+Expected:
+
+- existing automation editor behavior remains green;
+- numeric condition values serialize as numbers;
+- boolean condition values serialize as booleans;
+- select fields with configured options use a select control;
+- `in` / `not_in` over option-backed fields use a multi-select and serialize arrays;
+- date fields render date inputs and preserve ISO date strings.
+
+Result:
+
+- 1 file passed.
+- 72 tests passed.
+
+### Frontend Type Check
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc --noEmit --pretty false
+pnpm --filter @metasheet/web type-check
+```
+
+Expected: pass.
+
+Result:
+
+- pass for direct `vue-tsc --noEmit`.
+- pass for CI-aligned `vue-tsc -b` via `pnpm --filter @metasheet/web type-check`.
+
+### Diff Hygiene
+
+```bash
+git diff --check
+```
+
+Expected: pass.
+
+Result:
+
+- pass.
+
+## Non-Verification
+
+- No browser smoke was run.
+- No live backend automation rule was created.
+- No backend condition evaluator change was made.


### PR DESCRIPTION
## Summary

- Adds field-aware value widgets to the multitable automation condition editor.
- Serializes number-like condition values as numbers and boolean condition values as booleans.
- Uses configured select/multiSelect options for single-value and `in` / `not_in` condition authoring.
- Keeps text/comma-separated fallbacks for fields without option metadata.
- Adds development and verification notes for the slice.

## Verification

- `pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts --watch=false` — 72/72 pass
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit --pretty false` — pass
- `git diff --check` — pass

## Notes

- Frontend-only; no backend condition evaluator or schema change.
- No async option hydration for person/link/lookup fields in this slice.
- No browser smoke was run.
