### PR TITLE
chore(dingtalk): require screenshot archive in final handoff

### DIFF
--- a/docs/development/dingtalk-screenshot-handoff-development-20260511.md
+++ b/docs/development/dingtalk-screenshot-handoff-development-20260511.md
@@ -1,0 +1,65 @@
+# DingTalk Screenshot Handoff Development
+
+## Summary
+
+Integrated the DingTalk screenshot archive helper into the final DingTalk P4 handoff chain. The final packet can now include a redaction-safe screenshot archive and optionally require it to pass strict validation before release handoff.
+
+## Scope
+
+- `scripts/ops/export-dingtalk-staging-evidence-packet.mjs`
+- `scripts/ops/validate-dingtalk-staging-evidence-packet.mjs`
+- `scripts/ops/dingtalk-p4-final-handoff.mjs`
+- Direct tests for exporter, validator, final handoff, and screenshot archive.
+
+## Behavior
+
+The packet exporter now supports:
+
+```bash
+--include-screenshot-archive <dir>
+--require-screenshot-archive-pass
+```
+
+The final handoff command forwards the same options:
+
+```bash
+node scripts/ops/dingtalk-p4-final-handoff.mjs \
+  --session-dir <session-dir> \
+  --output-dir <packet-dir> \
+  --include-screenshot-archive <screenshot-archive-dir> \
+  --require-screenshot-archive-pass
+```
+
+When enabled, the exporter copies the screenshot archive to:
+
+```text
+screenshot-archive/NN-<archive-name>
+```
+
+The packet manifest records:
+
+- `requireScreenshotArchivePass`
+- `includedScreenshotArchive`
+- `screenshotArchiveStatus.status`
+- `screenshotArchiveStatus.screenshotCount`
+- archive `manifest.json` and `README.md` references
+
+## Strict Gate
+
+Strict screenshot archive validation requires:
+
+- Archive directory exists.
+- `manifest.json` exists and has `tool = dingtalk-screenshot-archive`.
+- `manifest.status = pass`.
+- `screenshotCount > 0`.
+- `README.md` exists.
+- `copiedScreenshots.length` matches `screenshotCount`.
+- Every screenshot `archivePath` stays inside the archive directory.
+- Every referenced screenshot file exists.
+- Every screenshot has a SHA-256 digest that matches the copied file.
+
+## Security Notes
+
+- Existing secret scanning still runs over the full packet.
+- Screenshot archive metadata must stay redacted; raw screenshots remain restricted artifacts because image pixels can contain personal or operational data.
+- The new gate validates archive structure and file hashes; it does not OCR screenshot content.

--- a/docs/development/dingtalk-screenshot-handoff-verification-20260511.md
+++ b/docs/development/dingtalk-screenshot-handoff-verification-20260511.md
@@ -1,0 +1,61 @@
+# DingTalk Screenshot Handoff Verification
+
+## Summary
+
+Validation for wiring DingTalk screenshot archive evidence into the final P4 handoff packet.
+
+## Automated Verification
+
+```bash
+node --test scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs
+```
+
+Result: PASS, 20 tests.
+
+```bash
+node --test scripts/ops/validate-dingtalk-staging-evidence-packet.test.mjs
+```
+
+Result: PASS, 20 tests.
+
+```bash
+node --test scripts/ops/dingtalk-p4-final-handoff.test.mjs
+```
+
+Result: PASS, 13 tests.
+
+```bash
+node --test scripts/ops/dingtalk-screenshot-archive.test.mjs
+```
+
+Result: PASS, 5 tests.
+
+## Coverage
+
+- Exporter accepts a strict screenshot archive and copies it into the packet.
+- Exporter rejects an empty screenshot archive when strict gate is enabled.
+- Validator accepts final screenshot archive evidence.
+- Validator rejects screenshot archive hash mismatch.
+- Final handoff passes through screenshot archive arguments, validates the packet, and writes summary metadata.
+- Final handoff fails early and writes a failure summary when the strict screenshot archive gate is required but no archive is provided.
+- Existing mobile signoff and DingTalk P4 gates continue to pass.
+
+## Pending Checks
+
+```bash
+git diff --check
+```
+
+Result: PASS.
+
+```bash
+git diff \
+  | rg -n 'access_token=[A-Za-z0-9]|SEC[A-Za-z0-9+/=_-]{16,}|Bearer [A-Za-z0-9._~+/=-]{16,}|eyJ[A-Za-z0-9._-]{20,}|https://oapi\.dingtalk\.com/robot/send\?' \
+  | rg -v '<redacted>|0123456789abcdef0123456789abcdef|SECabcdefghijklmnop12345678' || true
+```
+
+Result: PASS, no findings after excluding intentional synthetic redaction fixtures.
+
+## Result
+
+PASS. Screenshot archive evidence can now be included in the strict final DingTalk P4 handoff packet.

--- a/scripts/ops/dingtalk-p4-final-handoff.mjs
+++ b/scripts/ops/dingtalk-p4-final-handoff.mjs
@@ -18,6 +18,10 @@ Options:
                                Optional strict mobile public-form signoff output dir
   --require-mobile-signoff-pass
                                Require every included mobile signoff output to be strict passing
+  --include-screenshot-archive <dir>
+                               Optional DingTalk screenshot archive output dir
+  --require-screenshot-archive-pass
+                               Require every included screenshot archive to be strict passing
   --publish-check-json <file>  Validator JSON output, default <output-dir>/publish-check.json
   --summary-json <file>        Handoff JSON summary, default <output-dir>/handoff-summary.json
   --summary-md <file>          Handoff Markdown summary, default <output-dir>/handoff-summary.md
@@ -46,6 +50,8 @@ function parseArgs(argv) {
     outputDir: '',
     includeMobileSignoffDirs: [],
     requireMobileSignoffPass: false,
+    includeScreenshotArchiveDirs: [],
+    requireScreenshotArchivePass: false,
     publishCheckJson: '',
     summaryJson: '',
     summaryMd: '',
@@ -68,6 +74,13 @@ function parseArgs(argv) {
         break
       case '--require-mobile-signoff-pass':
         opts.requireMobileSignoffPass = true
+        break
+      case '--include-screenshot-archive':
+        opts.includeScreenshotArchiveDirs.push(path.resolve(process.cwd(), readRequiredValue(argv, i, arg)))
+        i += 1
+        break
+      case '--require-screenshot-archive-pass':
+        opts.requireScreenshotArchivePass = true
         break
       case '--publish-check-json':
         opts.publishCheckJson = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
@@ -189,6 +202,12 @@ function validateMobileSignoffArgs(opts) {
   }
 }
 
+function validateScreenshotArchiveArgs(opts) {
+  if (opts.requireScreenshotArchivePass && opts.includeScreenshotArchiveDirs.length === 0) {
+    throw new Error('--require-screenshot-archive-pass requires at least one --include-screenshot-archive directory')
+  }
+}
+
 function clearGeneratedHandoffMarkers(opts) {
   for (const file of [opts.publishCheckJson, opts.summaryJson, opts.summaryMd]) {
     rmSync(file, { force: true })
@@ -201,6 +220,15 @@ function mobileSignoffExportArgs(opts) {
     args.push('--include-mobile-signoff', relativePath(dir))
   }
   if (opts.requireMobileSignoffPass) args.push('--require-mobile-signoff-pass')
+  return args
+}
+
+function screenshotArchiveExportArgs(opts) {
+  const args = []
+  for (const dir of opts.includeScreenshotArchiveDirs) {
+    args.push('--include-screenshot-archive', relativePath(dir))
+  }
+  if (opts.requireScreenshotArchivePass) args.push('--require-screenshot-archive-pass')
   return args
 }
 
@@ -248,6 +276,10 @@ Publish check status: **${publishStatus}**
 Mobile signoff gate: **${summary.mobileSignoff.required ? 'required' : 'not_required'}**
 
 Included mobile signoff count: **${summary.mobileSignoff.includedCount}**
+
+Screenshot archive gate: **${summary.screenshotArchive.required ? 'required' : 'not_required'}**
+
+Included screenshot archive count: **${summary.screenshotArchive.includedCount}**
 
 ## Steps
 
@@ -307,6 +339,11 @@ function buildSummary(opts, steps) {
       includedCount: publishCheck?.includedMobileSignoffCount ?? 0,
       sources: opts.includeMobileSignoffDirs.map((dir) => displayPath(dir)),
     },
+    screenshotArchive: {
+      required: opts.requireScreenshotArchivePass,
+      includedCount: publishCheck?.includedScreenshotArchiveCount ?? 0,
+      sources: opts.includeScreenshotArchiveDirs.map((dir) => displayPath(dir)),
+    },
     failures,
     outputs: {
       manifest: displayPath(path.join(opts.outputDir, 'manifest.json')),
@@ -327,6 +364,7 @@ async function main() {
     validateOutputDir(opts)
     clearGeneratedHandoffMarkers(opts)
     validateMobileSignoffArgs(opts)
+    validateScreenshotArchiveArgs(opts)
 
     const exportStep = runNodeStep('export-packet', 'Export final gated packet', [
       'scripts/ops/export-dingtalk-staging-evidence-packet.mjs',
@@ -334,6 +372,7 @@ async function main() {
       relativePath(opts.sessionDir),
       '--require-dingtalk-p4-pass',
       ...mobileSignoffExportArgs(opts),
+      ...screenshotArchiveExportArgs(opts),
       '--output-dir',
       relativePath(opts.outputDir),
     ])

--- a/scripts/ops/dingtalk-p4-final-handoff.test.mjs
+++ b/scripts/ops/dingtalk-p4-final-handoff.test.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict'
 import { spawnSync } from 'node:child_process'
+import crypto from 'node:crypto'
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
@@ -102,6 +103,39 @@ function writeMobileSignoffOutput(signoffDir, overrides = {}) {
   })
 }
 
+function writeScreenshotArchiveOutput(archiveDir, overrides = {}) {
+  mkdirSync(path.join(archiveDir, 'screenshots'), { recursive: true })
+  const screenshotBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00, 0x01, 0x02, 0x03])
+  const screenshotPath = path.join(archiveDir, 'screenshots', 'screenshot-001.png')
+  writeFileSync(screenshotPath, screenshotBytes)
+  const sha256 = crypto.createHash('sha256').update(screenshotBytes).digest('hex')
+  const manifest = {
+    tool: 'dingtalk-screenshot-archive',
+    generatedAt: '2026-05-11T00:00:00.000Z',
+    status: 'pass',
+    allowEmpty: false,
+    outputDir: path.relative(repoRoot, archiveDir).replaceAll('\\', '/'),
+    manifestJson: path.relative(repoRoot, path.join(archiveDir, 'manifest.json')).replaceAll('\\', '/'),
+    readmeMd: path.relative(repoRoot, path.join(archiveDir, 'README.md')).replaceAll('\\', '/'),
+    inputCount: 1,
+    screenshotCount: 1,
+    copiedScreenshots: [
+      {
+        index: 1,
+        sourceLabel: 'mobile-dingtalk-form.png',
+        archivePath: 'screenshots/screenshot-001.png',
+        extension: '.png',
+        sizeBytes: screenshotBytes.length,
+        sha256,
+      },
+    ],
+    warnings: [],
+    ...overrides.manifest,
+  }
+  writeJson(path.join(archiveDir, 'manifest.json'), manifest)
+  writeFileSync(path.join(archiveDir, 'README.md'), '# DingTalk Screenshot Evidence Archive\n\n- Status: **pass**\n', 'utf8')
+}
+
 function runScript(args) {
   return spawnSync(process.execPath, [scriptPath, ...args], {
     cwd: repoRoot,
@@ -176,6 +210,46 @@ test('dingtalk-p4-final-handoff includes strict mobile signoff in final packet',
   }
 })
 
+test('dingtalk-p4-final-handoff includes strict screenshot archive in final packet', () => {
+  const tmpDir = makeTmpDir()
+  const sessionDir = path.join(tmpDir, '142-session')
+  const screenshotArchiveDir = path.join(tmpDir, 'screenshot-archive-compiled')
+  const outputDir = path.join(tmpDir, 'packet')
+
+  try {
+    writeFinalSession(sessionDir)
+    writeScreenshotArchiveOutput(screenshotArchiveDir)
+
+    const result = runScript([
+      '--session-dir',
+      sessionDir,
+      '--output-dir',
+      outputDir,
+      '--include-screenshot-archive',
+      screenshotArchiveDir,
+      '--require-screenshot-archive-pass',
+    ])
+
+    assert.equal(result.status, 0, result.stderr || result.stdout)
+    const manifest = JSON.parse(readFileSync(path.join(outputDir, 'manifest.json'), 'utf8'))
+    assert.equal(manifest.requireScreenshotArchivePass, true)
+    assert.equal(manifest.includedScreenshotArchive.length, 1)
+    assert.equal(manifest.includedScreenshotArchive[0].screenshotArchiveStatus.screenshotCount, 1)
+    assert.equal(existsSync(path.join(outputDir, 'screenshot-archive', '01-screenshot-archive-compiled', 'screenshots', 'screenshot-001.png')), true)
+    const publishCheck = JSON.parse(readFileSync(path.join(outputDir, 'publish-check.json'), 'utf8'))
+    assert.equal(publishCheck.status, 'pass')
+    assert.equal(publishCheck.includedScreenshotArchiveCount, 1)
+    const summary = JSON.parse(readFileSync(path.join(outputDir, 'handoff-summary.json'), 'utf8'))
+    assert.equal(summary.status, 'pass')
+    assert.equal(summary.screenshotArchive.required, true)
+    assert.equal(summary.screenshotArchive.includedCount, 1)
+    assert.deepEqual(summary.screenshotArchive.sources, [path.relative(repoRoot, screenshotArchiveDir).replaceAll('\\', '/')])
+    assert.match(readFileSync(path.join(outputDir, 'handoff-summary.md'), 'utf8'), /Screenshot archive gate: \*\*required\*\*/)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
 test('dingtalk-p4-final-handoff rejects required mobile signoff without input', () => {
   const tmpDir = makeTmpDir()
   const sessionDir = path.join(tmpDir, '142-session')
@@ -191,6 +265,27 @@ test('dingtalk-p4-final-handoff rejects required mobile signoff without input', 
     const summary = JSON.parse(readFileSync(path.join(outputDir, 'handoff-summary.json'), 'utf8'))
     assert.equal(summary.status, 'fail')
     assert.equal(summary.failures.some((failure) => failure.includes('--require-mobile-signoff-pass requires')), true)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-p4-final-handoff rejects required screenshot archive without input', () => {
+  const tmpDir = makeTmpDir()
+  const sessionDir = path.join(tmpDir, '142-session')
+  const outputDir = path.join(tmpDir, 'packet')
+
+  try {
+    writeFinalSession(sessionDir)
+
+    const result = runScript(['--session-dir', sessionDir, '--output-dir', outputDir, '--require-screenshot-archive-pass'])
+
+    assert.equal(result.status, 1)
+    assert.match(result.stderr, /--require-screenshot-archive-pass requires at least one --include-screenshot-archive directory/)
+    const summary = JSON.parse(readFileSync(path.join(outputDir, 'handoff-summary.json'), 'utf8'))
+    assert.equal(summary.status, 'fail')
+    assert.equal(summary.screenshotArchive.includedCount, 0)
+    assert.equal(summary.failures.some((failure) => failure.includes('--require-screenshot-archive-pass requires')), true)
   } finally {
     rmSync(tmpDir, { recursive: true, force: true })
   }

--- a/scripts/ops/export-dingtalk-staging-evidence-packet.mjs
+++ b/scripts/ops/export-dingtalk-staging-evidence-packet.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import crypto from 'node:crypto'
 import { cpSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
 
@@ -148,6 +149,11 @@ const requiredPacketFiles = [
     description: 'builds, records, TODO-tracks, and strict-compiles real DingTalk mobile public-form signoff evidence',
   },
   {
+    path: 'scripts/ops/dingtalk-screenshot-archive.mjs',
+    kind: 'script',
+    description: 'packages DingTalk mobile/manual screenshots into a redaction-safe screenshot archive',
+  },
+  {
     path: 'scripts/ops/validate-dingtalk-staging-evidence-packet.mjs',
     kind: 'script',
     description: 'validates final gated evidence packets and scans for secret-like raw evidence before handoff',
@@ -165,6 +171,10 @@ Options:
   --require-dingtalk-p4-pass      Require every included output to be a finalized passing P4 session
   --include-mobile-signoff <dir>  Optional strict mobile signoff output dir to copy into mobile-signoff/
   --require-mobile-signoff-pass   Require every included mobile signoff output to be strict passing
+  --include-screenshot-archive <dir>
+                                  Optional redaction-safe screenshot archive dir to copy into screenshot-archive/
+  --require-screenshot-archive-pass
+                                  Require every included screenshot archive to contain passing screenshot evidence
   --help                          Show this help
 
 Examples:
@@ -178,7 +188,9 @@ Examples:
     --include-output output/dingtalk-p4-remote-smoke-session/142-session \\
     --require-dingtalk-p4-pass \\
     --include-mobile-signoff output/dingtalk-public-form-mobile-signoff/142-compiled \\
-    --require-mobile-signoff-pass
+    --require-mobile-signoff-pass \\
+    --include-screenshot-archive artifacts/dingtalk-screenshot-archive/live-acceptance \\
+    --require-screenshot-archive-pass
 `)
 }
 
@@ -197,6 +209,8 @@ function parseArgs(argv) {
     requireDingTalkP4Pass: false,
     includeMobileSignoffDirs: [],
     requireMobileSignoffPass: false,
+    includeScreenshotArchiveDirs: [],
+    requireScreenshotArchivePass: false,
   }
 
   for (let i = 0; i < argv.length; i += 1) {
@@ -220,6 +234,13 @@ function parseArgs(argv) {
         break
       case '--require-mobile-signoff-pass':
         opts.requireMobileSignoffPass = true
+        break
+      case '--include-screenshot-archive':
+        opts.includeScreenshotArchiveDirs.push(path.resolve(process.cwd(), readRequiredValue(argv, i, arg)))
+        i += 1
+        break
+      case '--require-screenshot-archive-pass':
+        opts.requireScreenshotArchivePass = true
         break
       case '--help':
         printHelp()
@@ -265,6 +286,10 @@ function readJsonFile(file, label) {
   } catch (error) {
     throw new Error(`${label} is not valid JSON: ${error instanceof Error ? error.message : String(error)}`)
   }
+}
+
+function sha256File(file) {
+  return crypto.createHash('sha256').update(readFileSync(file)).digest('hex')
 }
 
 function getArray(value, field, failures) {
@@ -399,6 +424,68 @@ function validateMobileSignoffDir(sourceDir, opts) {
   return opts.requireMobileSignoffPass ? validateMobileSignoffPass(sourceDir) : null
 }
 
+function validateScreenshotArchivePass(sourceDir) {
+  const manifestPath = path.join(sourceDir, 'manifest.json')
+  const readmePath = path.join(sourceDir, 'README.md')
+  const manifest = readJsonFile(manifestPath, 'screenshot archive manifest.json')
+  const failures = []
+
+  if (manifest.tool !== 'dingtalk-screenshot-archive') failures.push('manifest.json tool is not dingtalk-screenshot-archive')
+  if (manifest.status !== 'pass') failures.push('manifest.json status is not pass')
+  if (!Number.isInteger(manifest.screenshotCount) || manifest.screenshotCount <= 0) {
+    failures.push('manifest.json screenshotCount is not greater than 0')
+  }
+  if (!existsSync(readmePath) || !statSync(readmePath).isFile()) {
+    failures.push('README.md does not exist')
+  }
+  if (!Array.isArray(manifest.copiedScreenshots)) {
+    failures.push('manifest.json copiedScreenshots is not an array')
+  } else {
+    if (manifest.copiedScreenshots.length !== manifest.screenshotCount) {
+      failures.push('manifest.json copiedScreenshots length does not match screenshotCount')
+    }
+    for (const [index, screenshot] of manifest.copiedScreenshots.entries()) {
+      const archivePath = screenshot?.archivePath
+      if (!archivePath || path.isAbsolute(archivePath)) {
+        failures.push(`copiedScreenshots[${index}].archivePath must be relative`)
+        continue
+      }
+      const resolved = path.resolve(sourceDir, archivePath)
+      const normalizedSource = path.resolve(sourceDir)
+      if (resolved !== normalizedSource && !resolved.startsWith(`${normalizedSource}${path.sep}`)) {
+        failures.push(`copiedScreenshots[${index}].archivePath escapes the screenshot archive`)
+        continue
+      }
+      if (!existsSync(resolved) || !statSync(resolved).isFile()) {
+        failures.push(`copiedScreenshots[${index}].archivePath file does not exist`)
+      }
+      if (!screenshot?.sha256 || !/^[a-f0-9]{64}$/.test(screenshot.sha256)) {
+        failures.push(`copiedScreenshots[${index}].sha256 is not a SHA-256 hex digest`)
+      } else if (existsSync(resolved) && statSync(resolved).isFile() && sha256File(resolved) !== screenshot.sha256) {
+        failures.push(`copiedScreenshots[${index}].sha256 does not match archive file`)
+      }
+    }
+  }
+
+  if (failures.length > 0) {
+    throw new Error(`included screenshot archive is not strict pass: ${path.relative(process.cwd(), sourceDir).replaceAll('\\', '/')} (${failures.join('; ')})`)
+  }
+
+  return {
+    status: 'pass',
+    manifest: path.relative(sourceDir, manifestPath).replaceAll('\\', '/'),
+    readme: path.relative(sourceDir, readmePath).replaceAll('\\', '/'),
+    screenshotCount: manifest.screenshotCount,
+  }
+}
+
+function validateScreenshotArchiveDir(sourceDir, opts) {
+  if (!existsSync(sourceDir) || !statSync(sourceDir).isDirectory()) {
+    throw new Error(`--include-screenshot-archive must point to an existing directory: ${sourceDir}`)
+  }
+  return opts.requireScreenshotArchivePass ? validateScreenshotArchivePass(sourceDir) : null
+}
+
 function inspectExistingPacketOutputDir(outputDir) {
   if (!existsSync(outputDir)) return { exists: false, isExistingPacket: false, entryCount: 0 }
   if (!statSync(outputDir).isDirectory()) {
@@ -434,6 +521,7 @@ function clearGeneratedPacketMarkers(outputDir) {
   if (!inspected.exists || inspected.entryCount === 0) return
   if (inspected.isExistingPacket) {
     rmSync(path.join(outputDir, 'evidence'), { recursive: true, force: true })
+    rmSync(path.join(outputDir, 'screenshot-archive'), { recursive: true, force: true })
   }
   for (const file of ['manifest.json', 'README.md']) {
     rmSync(path.join(outputDir, file), { force: true })
@@ -466,11 +554,25 @@ function copyMobileSignoffDir(sourceDir, outputDir, index, mobileSignoffStatus) 
   }
 }
 
+function copyScreenshotArchiveDir(sourceDir, outputDir, index, screenshotArchiveStatus) {
+  const destinationName = `${String(index + 1).padStart(2, '0')}-${sanitizeEvidenceName(sourceDir)}`
+  const destination = path.join(outputDir, 'screenshot-archive', destinationName)
+  mkdirSync(path.dirname(destination), { recursive: true })
+  rmSync(destination, { recursive: true, force: true })
+  cpSync(sourceDir, destination, { recursive: true })
+  return {
+    source: path.relative(process.cwd(), sourceDir).replaceAll('\\', '/'),
+    destination: path.relative(outputDir, destination).replaceAll('\\', '/'),
+    ...(screenshotArchiveStatus ? { screenshotArchiveStatus } : {}),
+  }
+}
+
 function renderReadme(manifest) {
   const docs = manifest.files.filter((file) => file.kind !== 'script')
   const scripts = manifest.files.filter((file) => file.kind === 'script')
   const evidence = manifest.includedEvidence
   const mobileSignoff = Array.isArray(manifest.includedMobileSignoff) ? manifest.includedMobileSignoff : []
+  const screenshotArchive = Array.isArray(manifest.includedScreenshotArchive) ? manifest.includedScreenshotArchive : []
 
   const fileLine = (file) => `- \`${file.path}\` — ${file.description}`
   const evidenceLines = evidence.length
@@ -479,12 +581,18 @@ function renderReadme(manifest) {
   const mobileSignoffLines = mobileSignoff.length
     ? mobileSignoff.map((entry) => `- \`${entry.destination}\` copied from \`${entry.source}\``).join('\n')
     : '- No mobile public-form signoff directory was included. Re-run with `--include-mobile-signoff <dir>` after real DingTalk mobile signoff.'
+  const screenshotArchiveLines = screenshotArchive.length
+    ? screenshotArchive.map((entry) => `- \`${entry.destination}\` copied from \`${entry.source}\``).join('\n')
+    : '- No screenshot archive was included. Re-run with `--include-screenshot-archive <dir>` after packaging DingTalk screenshots.'
   const gateLine = manifest.requireDingTalkP4Pass
     ? '- DingTalk P4 final-pass gate was enabled; every included output was validated before copy.'
     : '- DingTalk P4 final-pass gate was not enabled. Use `--require-dingtalk-p4-pass` for release evidence handoff.'
   const mobileGateLine = manifest.requireMobileSignoffPass
     ? '- DingTalk mobile public-form signoff gate was enabled; every included mobile signoff output was validated before copy.'
     : '- DingTalk mobile public-form signoff gate was not enabled. Use `--require-mobile-signoff-pass` for release evidence handoff.'
+  const screenshotGateLine = manifest.requireScreenshotArchivePass
+    ? '- DingTalk screenshot archive gate was enabled; every included screenshot archive was validated before copy.'
+    : '- DingTalk screenshot archive gate was not enabled. Use `--require-screenshot-archive-pass` for release evidence handoff when screenshots are required.'
 
   return `# DingTalk Staging Evidence Packet
 
@@ -510,10 +618,15 @@ ${evidenceLines}
 
 ${mobileSignoffLines}
 
+## Included Screenshot Archive
+
+${screenshotArchiveLines}
+
 ## Evidence Gates
 
 ${gateLine}
 ${mobileGateLine}
+${screenshotGateLine}
 
 ## Recommended Order
 
@@ -536,7 +649,8 @@ ${mobileGateLine}
 17. For public-form mobile acceptance, create a kit with \`node scripts/ops/dingtalk-public-form-mobile-signoff.mjs --init-kit <mobile-kit-dir>\`.
 18. Track remaining checks with \`node scripts/ops/dingtalk-public-form-mobile-signoff.mjs --todo <mobile-kit-dir>/mobile-signoff.json --output-dir <mobile-kit-dir>/todo\`.
 19. Record each real DingTalk mobile result with the suggested \`--record ... --compile-when-ready\` command until strict output is written.
-20. If debugging manually, re-export with \`--include-output <session-dir> --require-dingtalk-p4-pass --include-mobile-signoff <mobile-compiled-dir> --require-mobile-signoff-pass\`, then validate with \`validate-dingtalk-staging-evidence-packet.mjs\`.
+20. Package screenshots with \`node scripts/ops/dingtalk-screenshot-archive.mjs --input <screenshot-dir> --output-dir <screenshot-archive-dir>\`.
+21. If debugging manually, re-export with \`--include-output <session-dir> --require-dingtalk-p4-pass --include-mobile-signoff <mobile-compiled-dir> --require-mobile-signoff-pass --include-screenshot-archive <screenshot-archive-dir> --require-screenshot-archive-pass\`, then validate with \`validate-dingtalk-staging-evidence-packet.mjs\`.
 
 ## Non-Goals
 
@@ -557,8 +671,12 @@ async function main() {
     if (opts.requireMobileSignoffPass && opts.includeMobileSignoffDirs.length === 0) {
       throw new Error('--require-mobile-signoff-pass requires at least one --include-mobile-signoff directory')
     }
+    if (opts.requireScreenshotArchivePass && opts.includeScreenshotArchiveDirs.length === 0) {
+      throw new Error('--require-screenshot-archive-pass requires at least one --include-screenshot-archive directory')
+    }
     const evidenceValidations = opts.includeOutputDirs.map((dir) => validateEvidenceDir(dir, opts))
     const mobileSignoffValidations = opts.includeMobileSignoffDirs.map((dir) => validateMobileSignoffDir(dir, opts))
+    const screenshotArchiveValidations = opts.includeScreenshotArchiveDirs.map((dir) => validateScreenshotArchiveDir(dir, opts))
     mkdirSync(opts.outputDir, { recursive: true })
 
     const copiedFiles = requiredPacketFiles.map((entry) => {
@@ -582,15 +700,23 @@ async function main() {
       return copied
     })
 
+    const includedScreenshotArchive = opts.includeScreenshotArchiveDirs.map((dir, index) => {
+      const copied = copyScreenshotArchiveDir(dir, opts.outputDir, index, screenshotArchiveValidations[index])
+      console.log(`Copied screenshot archive ${copied.source}`)
+      return copied
+    })
+
     const manifest = {
       packet: 'dingtalk-staging-evidence-packet',
       generatedAt: new Date().toISOString(),
       repoRoot: process.cwd(),
       requireDingTalkP4Pass: opts.requireDingTalkP4Pass,
       requireMobileSignoffPass: opts.requireMobileSignoffPass,
+      requireScreenshotArchivePass: opts.requireScreenshotArchivePass,
       files: copiedFiles,
       includedEvidence,
       includedMobileSignoff,
+      includedScreenshotArchive,
     }
 
     const manifestPath = path.join(opts.outputDir, 'manifest.json')

--- a/scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs
+++ b/scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict'
 import { spawnSync } from 'node:child_process'
+import crypto from 'node:crypto'
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
@@ -99,6 +100,38 @@ function writeMobileSignoffOutput(dir, overrides = {}) {
     checks: mobileSignoffRequiredCheckIds.map((id) => ({ id, status: 'pass' })),
     ...overrides.redactedEvidence,
   }, null, 2)}\n`, 'utf8')
+}
+
+function writeScreenshotArchiveOutput(dir, overrides = {}) {
+  mkdirSync(path.join(dir, 'screenshots'), { recursive: true })
+  const screenshotBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00, 0x09])
+  const screenshotPath = path.join(dir, 'screenshots', 'screenshot-001.png')
+  writeFileSync(screenshotPath, screenshotBytes)
+  const sha256 = crypto.createHash('sha256').update(screenshotBytes).digest('hex')
+  writeFileSync(path.join(dir, 'manifest.json'), `${JSON.stringify({
+    tool: 'dingtalk-screenshot-archive',
+    generatedAt: '2026-05-11T00:00:00.000Z',
+    status: 'pass',
+    allowEmpty: false,
+    outputDir: path.relative(repoRoot, dir).replaceAll('\\', '/'),
+    manifestJson: path.relative(repoRoot, path.join(dir, 'manifest.json')).replaceAll('\\', '/'),
+    readmeMd: path.relative(repoRoot, path.join(dir, 'README.md')).replaceAll('\\', '/'),
+    inputCount: 1,
+    screenshotCount: 1,
+    copiedScreenshots: [
+      {
+        index: 1,
+        sourceLabel: 'mobile-dingtalk-form.png',
+        archivePath: 'screenshots/screenshot-001.png',
+        extension: '.png',
+        sizeBytes: screenshotBytes.length,
+        sha256,
+      },
+    ],
+    warnings: [],
+    ...overrides.manifest,
+  }, null, 2)}\n`, 'utf8')
+  writeFileSync(path.join(dir, 'README.md'), '# DingTalk Screenshot Evidence Archive\n\n- Status: **pass**\n', 'utf8')
 }
 
 test('export-dingtalk-staging-evidence-packet copies required handoff files and writes manifest', () => {
@@ -242,13 +275,16 @@ test('export-dingtalk-staging-evidence-packet copies required handoff files and 
     assert.match(readme, /dingtalk-p4-final-docs\.mjs/)
     assert.match(readme, /dingtalk-p4-final-closeout\.mjs/)
     assert.match(readme, /dingtalk-public-form-mobile-signoff\.mjs/)
+    assert.match(readme, /dingtalk-screenshot-archive\.mjs/)
     assert.match(readme, /dingtalk-p4-smoke-status\.mjs --session-dir <session-dir> --handoff-summary <packet-dir>\/handoff-summary\.json --require-release-ready/)
     assert.match(readme, /validate-dingtalk-staging-evidence-packet\.mjs/)
     assert.match(readme, /compile-dingtalk-p4-smoke-evidence\.mjs/)
     assert.match(readme, /No runtime evidence directory was included/)
     assert.match(readme, /No mobile public-form signoff directory was included/)
+    assert.match(readme, /No screenshot archive was included/)
     assert.match(readme, /DingTalk P4 final-pass gate was not enabled/)
     assert.match(readme, /DingTalk mobile public-form signoff gate was not enabled/)
+    assert.match(readme, /DingTalk screenshot archive gate was not enabled/)
     assert.match(readme, /does not generate secrets/)
   } finally {
     rmSync(tmpDir, { recursive: true, force: true })
@@ -301,6 +337,99 @@ test('export-dingtalk-staging-evidence-packet accepts strict mobile signoff pass
     assert.match(readme, /Included Mobile Public-Form Signoff/)
     assert.match(readme, /DingTalk mobile public-form signoff gate was enabled/)
     assert.match(readme, /--include-mobile-signoff <mobile-compiled-dir> --require-mobile-signoff-pass/)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('export-dingtalk-staging-evidence-packet accepts strict screenshot archive evidence when required', () => {
+  const tmpDir = makeTmpDir()
+  const outputDir = path.join(tmpDir, 'packet')
+  const evidenceDir = path.join(tmpDir, '142-session')
+  const screenshotArchiveDir = path.join(tmpDir, 'screenshot-archive-compiled')
+
+  try {
+    writeDingTalkP4Session(evidenceDir)
+    writeScreenshotArchiveOutput(screenshotArchiveDir)
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        scriptPath,
+        '--output-dir',
+        outputDir,
+        '--include-output',
+        evidenceDir,
+        '--require-dingtalk-p4-pass',
+        '--include-screenshot-archive',
+        screenshotArchiveDir,
+        '--require-screenshot-archive-pass',
+      ],
+      {
+        cwd: repoRoot,
+        encoding: 'utf8',
+      },
+    )
+
+    assert.equal(result.status, 0, result.stderr)
+    const manifest = JSON.parse(readFileSync(path.join(outputDir, 'manifest.json'), 'utf8'))
+    assert.equal(manifest.requireScreenshotArchivePass, true)
+    assert.equal(manifest.includedScreenshotArchive.length, 1)
+    assert.equal(manifest.includedScreenshotArchive[0].destination, 'screenshot-archive/01-screenshot-archive-compiled')
+    assert.equal(manifest.includedScreenshotArchive[0].screenshotArchiveStatus.status, 'pass')
+    assert.equal(manifest.includedScreenshotArchive[0].screenshotArchiveStatus.screenshotCount, 1)
+    assert.equal(
+      existsSync(path.join(outputDir, 'screenshot-archive/01-screenshot-archive-compiled/screenshots/screenshot-001.png')),
+      true,
+    )
+
+    const readme = readFileSync(path.join(outputDir, 'README.md'), 'utf8')
+    assert.match(readme, /Included Screenshot Archive/)
+    assert.match(readme, /DingTalk screenshot archive gate was enabled/)
+    assert.match(readme, /--include-screenshot-archive <screenshot-archive-dir> --require-screenshot-archive-pass/)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('export-dingtalk-staging-evidence-packet rejects empty screenshot archive when required', () => {
+  const tmpDir = makeTmpDir()
+  const outputDir = path.join(tmpDir, 'packet')
+  const evidenceDir = path.join(tmpDir, '142-session')
+  const screenshotArchiveDir = path.join(tmpDir, 'screenshot-archive-empty')
+
+  try {
+    writeDingTalkP4Session(evidenceDir)
+    writeScreenshotArchiveOutput(screenshotArchiveDir, {
+      manifest: {
+        status: 'pass',
+        screenshotCount: 0,
+        copiedScreenshots: [],
+      },
+    })
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        scriptPath,
+        '--output-dir',
+        outputDir,
+        '--include-output',
+        evidenceDir,
+        '--require-dingtalk-p4-pass',
+        '--include-screenshot-archive',
+        screenshotArchiveDir,
+        '--require-screenshot-archive-pass',
+      ],
+      {
+        cwd: repoRoot,
+        encoding: 'utf8',
+      },
+    )
+
+    assert.equal(result.status, 1)
+    assert.match(result.stderr, /screenshotCount is not greater than 0/)
+    assert.equal(existsSync(path.join(outputDir, 'manifest.json')), false)
   } finally {
     rmSync(tmpDir, { recursive: true, force: true })
   }

--- a/scripts/ops/validate-dingtalk-staging-evidence-packet.mjs
+++ b/scripts/ops/validate-dingtalk-staging-evidence-packet.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import crypto from 'node:crypto'
 import {
   existsSync,
   closeSync,
@@ -142,6 +143,10 @@ function readJsonFile(file, label) {
   }
 }
 
+function sha256File(file) {
+  return crypto.createHash('sha256').update(readFileSync(file)).digest('hex')
+}
+
 function resolveInside(baseDir, relativeFile, label) {
   if (!relativeFile || path.isAbsolute(relativeFile)) {
     throw new Error(`${label} must be a relative path inside the packet`)
@@ -174,6 +179,13 @@ function mobileSignoffTopLevelName(destination) {
   if (typeof destination !== 'string') return ''
   const parts = destination.replaceAll('\\', '/').split('/').filter(Boolean)
   if (parts[0] !== 'mobile-signoff' || !parts[1]) return ''
+  return parts[1]
+}
+
+function screenshotArchiveTopLevelName(destination) {
+  if (typeof destination !== 'string') return ''
+  const parts = destination.replaceAll('\\', '/').split('/').filter(Boolean)
+  if (parts[0] !== 'screenshot-archive' || !parts[1]) return ''
   return parts[1]
 }
 
@@ -213,6 +225,26 @@ function validateRegisteredMobileSignoffEntries(packetDir, includedMobileSignoff
   for (const entry of readdirSync(mobileSignoffDir, { withFileTypes: true })) {
     if (!registered.has(entry.name)) {
       failures.push(`mobile-signoff/${entry.name} is not registered in manifest includedMobileSignoff`)
+    }
+  }
+}
+
+function validateRegisteredScreenshotArchiveEntries(packetDir, includedScreenshotArchive, failures) {
+  const screenshotArchiveDir = path.join(packetDir, 'screenshot-archive')
+  if (!existsSync(screenshotArchiveDir)) return
+  if (!statSync(screenshotArchiveDir).isDirectory()) {
+    failures.push('screenshot-archive is not a directory')
+    return
+  }
+
+  const registered = new Set(
+    Array.isArray(includedScreenshotArchive)
+      ? includedScreenshotArchive.map((entry) => screenshotArchiveTopLevelName(entry?.destination)).filter(Boolean)
+      : [],
+  )
+  for (const entry of readdirSync(screenshotArchiveDir, { withFileTypes: true })) {
+    if (!registered.has(entry.name)) {
+      failures.push(`screenshot-archive/${entry.name} is not registered in manifest includedScreenshotArchive`)
     }
   }
 }
@@ -370,6 +402,75 @@ function validateIncludedMobileSignoff(packetDir, entry, index, failures) {
   }
 }
 
+function validateIncludedScreenshotArchive(packetDir, entry, index, failures) {
+  const label = `includedScreenshotArchive[${index}]`
+  let archiveDir
+  try {
+    archiveDir = resolveInside(packetDir, entry?.destination, `${label}.destination`)
+  } catch (error) {
+    failures.push(error.message)
+    return
+  }
+  if (!existsSync(archiveDir) || !statSync(archiveDir).isDirectory()) {
+    failures.push(`${label}.destination directory does not exist`)
+    return
+  }
+
+  const status = entry.screenshotArchiveStatus
+  if (status?.status !== 'pass') failures.push(`${label}.screenshotArchiveStatus.status is not pass`)
+  if (!Number.isInteger(status?.screenshotCount) || status.screenshotCount <= 0) {
+    failures.push(`${label}.screenshotArchiveStatus.screenshotCount is not greater than 0`)
+  }
+
+  let manifest
+  try {
+    manifest = readJsonFile(path.join(archiveDir, 'manifest.json'), `${label}/manifest.json`)
+  } catch (error) {
+    failures.push(error.message)
+    return
+  }
+
+  if (!existsSync(path.join(archiveDir, 'README.md'))) {
+    failures.push(`${label}/README.md does not exist`)
+  }
+  if (manifest.tool !== 'dingtalk-screenshot-archive') failures.push(`${label}/manifest.json tool is not dingtalk-screenshot-archive`)
+  if (manifest.status !== 'pass') failures.push(`${label}/manifest.json status is not pass`)
+  if (!Number.isInteger(manifest.screenshotCount) || manifest.screenshotCount <= 0) {
+    failures.push(`${label}/manifest.json screenshotCount is not greater than 0`)
+  }
+  if (
+    Number.isInteger(status?.screenshotCount)
+    && Number.isInteger(manifest.screenshotCount)
+    && status.screenshotCount !== manifest.screenshotCount
+  ) {
+    failures.push(`${label}.screenshotArchiveStatus.screenshotCount does not match manifest`)
+  }
+  if (!Array.isArray(manifest.copiedScreenshots)) {
+    failures.push(`${label}/manifest.json copiedScreenshots is not an array`)
+    return
+  }
+  if (manifest.copiedScreenshots.length !== manifest.screenshotCount) {
+    failures.push(`${label}/manifest.json copiedScreenshots length does not match screenshotCount`)
+  }
+  for (const [screenshotIndex, screenshot] of manifest.copiedScreenshots.entries()) {
+    let screenshotFile
+    try {
+      screenshotFile = resolveInside(archiveDir, screenshot?.archivePath, `${label}.copiedScreenshots[${screenshotIndex}].archivePath`)
+    } catch (error) {
+      failures.push(error.message)
+      continue
+    }
+    if (!existsSync(screenshotFile) || !statSync(screenshotFile).isFile()) {
+      failures.push(`${label}.copiedScreenshots[${screenshotIndex}].archivePath file does not exist`)
+    }
+    if (!screenshot?.sha256 || !/^[a-f0-9]{64}$/.test(screenshot.sha256)) {
+      failures.push(`${label}.copiedScreenshots[${screenshotIndex}].sha256 is not a SHA-256 hex digest`)
+    } else if (existsSync(screenshotFile) && statSync(screenshotFile).isFile() && sha256File(screenshotFile) !== screenshot.sha256) {
+      failures.push(`${label}.copiedScreenshots[${screenshotIndex}].sha256 does not match archive file`)
+    }
+  }
+}
+
 function isLikelyText(buffer) {
   return !buffer.includes(0)
 }
@@ -464,6 +565,7 @@ function validatePacket(packetDir) {
   const readmePath = path.join(packetDir, 'README.md')
   const manifest = readJsonFile(manifestPath, 'manifest.json')
   const includedMobileSignoff = Array.isArray(manifest.includedMobileSignoff) ? manifest.includedMobileSignoff : []
+  const includedScreenshotArchive = Array.isArray(manifest.includedScreenshotArchive) ? manifest.includedScreenshotArchive : []
 
   if (!existsSync(readmePath) || !statSync(readmePath).isFile()) {
     failures.push('README.md does not exist')
@@ -480,8 +582,13 @@ function validatePacket(packetDir) {
   if (manifest.requireMobileSignoffPass === true && includedMobileSignoff.length === 0) {
     failures.push('manifest requireMobileSignoffPass is true but includedMobileSignoff is empty')
   }
+  if (manifest.requireScreenshotArchivePass === true && includedScreenshotArchive.length === 0) {
+    failures.push('manifest requireScreenshotArchivePass is true but includedScreenshotArchive is empty')
+  }
   validateRegisteredMobileSignoffEntries(packetDir, includedMobileSignoff, failures)
   includedMobileSignoff.forEach((entry, index) => validateIncludedMobileSignoff(packetDir, entry, index, failures))
+  validateRegisteredScreenshotArchiveEntries(packetDir, includedScreenshotArchive, failures)
+  includedScreenshotArchive.forEach((entry, index) => validateIncludedScreenshotArchive(packetDir, entry, index, failures))
 
   let scannedFiles = 0
   walkFiles(packetDir, (file) => {
@@ -499,6 +606,7 @@ function validatePacket(packetDir) {
     status: failures.length === 0 ? 'pass' : 'fail',
     includedEvidenceCount: Array.isArray(manifest.includedEvidence) ? manifest.includedEvidence.length : 0,
     includedMobileSignoffCount: includedMobileSignoff.length,
+    includedScreenshotArchiveCount: includedScreenshotArchive.length,
     scannedFiles,
     secretFindings,
     failures,

--- a/scripts/ops/validate-dingtalk-staging-evidence-packet.test.mjs
+++ b/scripts/ops/validate-dingtalk-staging-evidence-packet.test.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict'
 import { spawnSync } from 'node:child_process'
+import crypto from 'node:crypto'
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
@@ -101,6 +102,38 @@ function writeMobileSignoffOutput(signoffDir, overrides = {}) {
   })
 }
 
+function writeScreenshotArchiveOutput(archiveDir, overrides = {}) {
+  mkdirSync(path.join(archiveDir, 'screenshots'), { recursive: true })
+  const screenshotBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00, 0x03])
+  const screenshotPath = path.join(archiveDir, 'screenshots', 'screenshot-001.png')
+  writeFileSync(screenshotPath, screenshotBytes)
+  const sha256 = crypto.createHash('sha256').update(screenshotBytes).digest('hex')
+  writeJson(path.join(archiveDir, 'manifest.json'), {
+    tool: 'dingtalk-screenshot-archive',
+    generatedAt: '2026-05-11T00:00:00.000Z',
+    status: 'pass',
+    allowEmpty: false,
+    outputDir: path.relative(repoRoot, archiveDir).replaceAll('\\', '/'),
+    manifestJson: path.relative(repoRoot, path.join(archiveDir, 'manifest.json')).replaceAll('\\', '/'),
+    readmeMd: path.relative(repoRoot, path.join(archiveDir, 'README.md')).replaceAll('\\', '/'),
+    inputCount: 1,
+    screenshotCount: 1,
+    copiedScreenshots: [
+      {
+        index: 1,
+        sourceLabel: 'mobile-dingtalk-form.png',
+        archivePath: 'screenshots/screenshot-001.png',
+        extension: '.png',
+        sizeBytes: screenshotBytes.length,
+        sha256,
+      },
+    ],
+    warnings: [],
+    ...overrides.manifest,
+  })
+  writeFileSync(path.join(archiveDir, 'README.md'), '# DingTalk Screenshot Evidence Archive\n\n- Status: **pass**\n', 'utf8')
+}
+
 function writePacket(packetDir, overrides = {}) {
   const evidenceDestination = overrides.destination ?? 'evidence/01-142-session'
   const evidenceDir = path.join(packetDir, evidenceDestination)
@@ -162,6 +195,32 @@ function addMobileSignoffToPacket(packetDir, overrides = {}) {
   ]
   writeJson(manifestPath, manifest)
   return signoffDir
+}
+
+function addScreenshotArchiveToPacket(packetDir, overrides = {}) {
+  const destination = overrides.destination ?? 'screenshot-archive/01-screenshot-archive-compiled'
+  const archiveDir = path.join(packetDir, destination)
+  writeScreenshotArchiveOutput(archiveDir, overrides)
+
+  const manifestPath = path.join(packetDir, 'manifest.json')
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'))
+  const screenshotManifest = JSON.parse(readFileSync(path.join(archiveDir, 'manifest.json'), 'utf8'))
+  manifest.requireScreenshotArchivePass = overrides.requireScreenshotArchivePass ?? true
+  manifest.includedScreenshotArchive = [
+    {
+      source: 'artifacts/dingtalk-screenshot-archive/142-compiled',
+      destination,
+      screenshotArchiveStatus: {
+        status: 'pass',
+        manifest: 'manifest.json',
+        readme: 'README.md',
+        screenshotCount: screenshotManifest.screenshotCount,
+        ...overrides.screenshotArchiveStatus,
+      },
+    },
+  ]
+  writeJson(manifestPath, manifest)
+  return archiveDir
 }
 
 function runValidator(args) {
@@ -248,6 +307,57 @@ test('validate-dingtalk-staging-evidence-packet accepts final mobile signoff evi
     const report = JSON.parse(readFileSync(reportPath, 'utf8'))
     assert.equal(report.status, 'pass')
     assert.equal(report.includedMobileSignoffCount, 1)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('validate-dingtalk-staging-evidence-packet accepts final screenshot archive evidence', () => {
+  const tmpDir = makeTmpDir()
+  const packetDir = path.join(tmpDir, 'packet')
+  const reportPath = path.join(tmpDir, 'publish-check.json')
+
+  try {
+    writePacket(packetDir)
+    addScreenshotArchiveToPacket(packetDir)
+
+    const result = runValidator(['--packet-dir', packetDir, '--output-json', reportPath])
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stdout, /publish check passed/)
+    const report = JSON.parse(readFileSync(reportPath, 'utf8'))
+    assert.equal(report.status, 'pass')
+    assert.equal(report.includedScreenshotArchiveCount, 1)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('validate-dingtalk-staging-evidence-packet rejects screenshot archive hash mismatch', () => {
+  const tmpDir = makeTmpDir()
+  const packetDir = path.join(tmpDir, 'packet')
+
+  try {
+    writePacket(packetDir)
+    addScreenshotArchiveToPacket(packetDir, {
+      manifest: {
+        copiedScreenshots: [
+          {
+            index: 1,
+            sourceLabel: 'mobile-dingtalk-form.png',
+            archivePath: 'screenshots/screenshot-001.png',
+            extension: '.png',
+            sizeBytes: 6,
+            sha256: '0'.repeat(64),
+          },
+        ],
+      },
+    })
+
+    const result = runValidator(['--packet-dir', packetDir])
+
+    assert.equal(result.status, 1)
+    assert.match(result.stderr, /sha256 does not match archive file/)
   } finally {
     rmSync(tmpDir, { recursive: true, force: true })
   }


### PR DESCRIPTION
## Summary
- wire DingTalk screenshot archives into the final P4 handoff/export/validate chain
- add strict screenshot archive gate with manifest, screenshot count, path containment, file existence, and SHA-256 verification
- include development and verification MD for this closeout slice

## Verification
- node --test scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs
- node --test scripts/ops/validate-dingtalk-staging-evidence-packet.test.mjs
- node --test scripts/ops/dingtalk-p4-final-handoff.test.mjs
- node --test scripts/ops/dingtalk-screenshot-archive.test.mjs
- git diff --cached --check
- staged diff sensitive-value scan excluding synthetic redaction fixtures

## Notes
- no runtime business logic changes
- raw screenshots remain restricted artifacts; this only gates archive metadata and copied screenshot file integrity