### PR TITLE
fix(multitable): validate automation conditions against fields

### DIFF
--- a/docs/development/multitable-automation-condition-backend-validation-development-20260511.md
+++ b/docs/development/multitable-automation-condition-backend-validation-development-20260511.md
@@ -1,0 +1,92 @@
+# Multitable Automation Condition Backend Validation Development - 2026-05-11
+
+## Context
+
+The automation rule editor now filters condition operators by field type and
+serializes number / boolean values with the right primitive types. The backend
+route still only validated the condition JSON shape, so direct API clients could
+persist rules that the UI would never author:
+
+- unknown `fieldId` values;
+- text-only operators such as `contains` on numeric fields;
+- scalar value type mismatches such as `"42"` for a number field or `"false"`
+  for a boolean field;
+- attachment fields using non-empty-state operators.
+
+This slice closes that REST boundary gap without changing the condition runtime
+evaluator or stored payload shape.
+
+## Scope
+
+Implemented:
+
+- Added `validateConditionGroupAgainstFields()` in the automation condition
+  engine.
+- Mirrored the frontend field-type operator families:
+  - comparable: `number`, `currency`, `percent`, `rating`, `date`, `dateTime`,
+    `createdTime`, `modifiedTime`, `autoNumber`;
+  - equality-only: `boolean`, `select`, `person`, `user`, `link`, `lookup`,
+    `rollup`, `createdBy`, `modifiedBy`;
+  - multi-value: `multiSelect`;
+  - empty-state only: `attachment`;
+  - text fallback: other field types.
+- Added scalar value type validation for number, boolean, and string-like
+  fields.
+- Added `preflightAutomationConditionFields()` to load `meta_fields` by
+  `sheet_id` and convert condition validation failures into
+  `AutomationRuleValidationError`.
+- Wired the preflight into automation rule create and update routes before
+  persistence.
+- Added unit tests for the condition validator and route-level tests for create
+  / update API rejection.
+
+Not implemented:
+
+- No migration or DB schema change.
+- No evaluator behavior change.
+- No frontend change.
+- No live staging smoke.
+
+## Design Decisions
+
+### Route Preflight, Not Executor-Time Validation
+
+The automation executor should only evaluate already-saved rules. Field metadata
+validation belongs at the API boundary where malformed rules are created or
+updated. This keeps the runtime path stable and prevents invalid data from being
+persisted.
+
+### Preserve Existing Payload Shape
+
+Conditions still store the same `ConditionGroup` JSON shape. The validator
+checks field existence, operator compatibility, and scalar value primitives, but
+does not rewrite payload values.
+
+### Allow Numeric Strings Only In List Operators
+
+The current frontend list fallback can produce string entries for `in` /
+`not_in`. To avoid making that existing fallback unusable, list entries for
+numeric field types accept finite numeric strings. Scalar numeric operators
+remain strict and require actual numbers.
+
+### Keep Empty Conditions Valid
+
+An empty condition group continues to mean "always pass". Field lookup still
+runs only when a rule carries a condition group, but an empty group has no leaf
+fields to reject.
+
+## Files Changed
+
+- `packages/core-backend/src/multitable/automation-conditions.ts`
+- `packages/core-backend/src/multitable/automation-service.ts`
+- `packages/core-backend/src/routes/univer-meta.ts`
+- `packages/core-backend/tests/unit/multitable-automation-conditions.test.ts`
+- `packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts`
+
+## Follow-Ups
+
+- Consider coercing numeric `in` / `not_in` entries to numbers in the frontend
+  so stored list payloads match evaluator strict equality for numeric record
+  values.
+- Add async option validation for person/link/lookup fields after those option
+  sources are standardized.

--- a/docs/development/multitable-automation-condition-backend-validation-verification-20260511.md
+++ b/docs/development/multitable-automation-condition-backend-validation-verification-20260511.md
@@ -1,0 +1,78 @@
+# Multitable Automation Condition Backend Validation Verification - 2026-05-11
+
+## Environment
+
+- Worktree: `/private/tmp/ms2-automation-condition-backend-validation-20260511`
+- Branch: `codex/multitable-automation-condition-backend-validation-20260511`
+- Baseline: `origin/main@d88e24ef4`
+- Scope: backend route preflight for automation condition field/operator/value
+  compatibility.
+
+## Commands
+
+### Install Workspace Links
+
+```bash
+pnpm install --ignore-scripts
+git restore -- plugins tools
+```
+
+Result:
+
+- workspace executable links restored for this temporary worktree;
+- dependency symlink dirt under `plugins/` and `tools/` reverted;
+- no dependency or lockfile changes remain in the business diff.
+
+### Targeted Backend Tests
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/multitable-automation-conditions.test.ts \
+  tests/integration/dingtalk-automation-link-routes.api.test.ts \
+  --reporter=dot
+```
+
+Expected:
+
+- condition evaluator and normalization behavior remain green;
+- field-aware validator accepts compatible field/operator/value combinations;
+- validator rejects unknown fields, unsupported operators, wrong scalar value
+  types, and empty list operators;
+- automation create rejects an unknown condition field before persistence;
+- automation create persists field-compatible conditions;
+- automation update rejects field-incompatible conditions before persistence.
+
+Result:
+
+- 2 files passed.
+- 44 tests passed.
+
+### Backend Type Check
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+```
+
+Expected: pass.
+
+Result:
+
+- pass.
+
+### Diff Hygiene
+
+```bash
+git diff --check
+```
+
+Expected: pass.
+
+Result:
+
+- pass.
+
+## Non-Verification
+
+- No live staging automation rule was created.
+- No browser smoke was run.
+- No migration replay was run because this slice has no migration.

--- a/packages/core-backend/src/multitable/automation-conditions.ts
+++ b/packages/core-backend/src/multitable/automation-conditions.ts
@@ -51,11 +51,55 @@ const VALUE_REQUIRED_OPERATORS = new Set<ConditionOperator>([
 
 const ARRAY_VALUE_OPERATORS = new Set<ConditionOperator>(['in', 'not_in'])
 const MAX_CONDITION_GROUP_DEPTH = 5
+const EMPTY_VALUE_OPERATORS = new Set<ConditionOperator>(['is_empty', 'is_not_empty'])
+const EQUALITY_OPERATORS = new Set<ConditionOperator>([
+  'equals',
+  'not_equals',
+  'in',
+  'not_in',
+  'is_empty',
+  'is_not_empty',
+])
+const TEXT_OPERATORS = new Set<ConditionOperator>([
+  'equals',
+  'not_equals',
+  'contains',
+  'not_contains',
+  'in',
+  'not_in',
+  'is_empty',
+  'is_not_empty',
+])
+const COMPARABLE_OPERATORS = new Set<ConditionOperator>([
+  'equals',
+  'not_equals',
+  'greater_than',
+  'less_than',
+  'greater_or_equal',
+  'less_or_equal',
+  'in',
+  'not_in',
+  'is_empty',
+  'is_not_empty',
+])
+const MULTI_VALUE_OPERATORS = new Set<ConditionOperator>([
+  'contains',
+  'not_contains',
+  'in',
+  'not_in',
+  'is_empty',
+  'is_not_empty',
+])
 
 export interface AutomationCondition {
   fieldId: string
   operator: ConditionOperator
   value?: unknown
+}
+
+export type AutomationConditionField = {
+  id: string
+  type: string
 }
 
 export type AutomationConditionNode = AutomationCondition | ConditionGroup
@@ -180,6 +224,139 @@ export function normalizeConditionGroupInput(
 
   if (conjunction) return { conjunction, conditions }
   return { logic: logic ?? 'and', conditions }
+}
+
+function allowedOperatorsForFieldType(fieldType: string): ReadonlySet<ConditionOperator> {
+  switch (fieldType) {
+    case 'number':
+    case 'currency':
+    case 'percent':
+    case 'rating':
+    case 'date':
+    case 'dateTime':
+    case 'createdTime':
+    case 'modifiedTime':
+    case 'autoNumber':
+      return COMPARABLE_OPERATORS
+    case 'boolean':
+    case 'select':
+    case 'person':
+    case 'user':
+    case 'link':
+    case 'lookup':
+    case 'rollup':
+    case 'createdBy':
+    case 'modifiedBy':
+      return EQUALITY_OPERATORS
+    case 'multiSelect':
+      return MULTI_VALUE_OPERATORS
+    case 'attachment':
+      return EMPTY_VALUE_OPERATORS
+    default:
+      return TEXT_OPERATORS
+  }
+}
+
+function expectedValueKindForFieldType(fieldType: string): 'number' | 'boolean' | 'string' | null {
+  switch (fieldType) {
+    case 'number':
+    case 'currency':
+    case 'percent':
+    case 'rating':
+    case 'autoNumber':
+      return 'number'
+    case 'boolean':
+      return 'boolean'
+    case 'attachment':
+      return null
+    default:
+      return 'string'
+  }
+}
+
+function assertNumericValue(value: unknown, path: string, allowNumericString: boolean): void {
+  if (typeof value === 'number' && Number.isFinite(value)) return
+  if (allowNumericString && typeof value === 'string') {
+    const trimmed = value.trim()
+    if (trimmed && Number.isFinite(Number(trimmed))) return
+  }
+  throw new ConditionGroupValidationError(`${path} must be a number`)
+}
+
+function assertConditionValueType(
+  condition: AutomationCondition,
+  fieldType: string,
+  path: string,
+): void {
+  if (!VALUE_REQUIRED_OPERATORS.has(condition.operator)) return
+
+  const expectedKind = expectedValueKindForFieldType(fieldType)
+  if (!expectedKind) return
+
+  const isArrayOperator = ARRAY_VALUE_OPERATORS.has(condition.operator)
+  if (isArrayOperator && !Array.isArray(condition.value)) {
+    throw new ConditionGroupValidationError(`${path}.value must be an array for ${condition.operator}`)
+  }
+  const values: unknown[] = isArrayOperator ? condition.value as unknown[] : [condition.value]
+  if (isArrayOperator && values.length === 0) {
+    throw new ConditionGroupValidationError(`${path}.value must not be empty for ${condition.operator}`)
+  }
+
+  values.forEach((value, index) => {
+    const valuePath = isArrayOperator ? `${path}.value[${index}]` : `${path}.value`
+    if (expectedKind === 'number') {
+      assertNumericValue(value, valuePath, isArrayOperator)
+      return
+    }
+    if (expectedKind === 'boolean') {
+      if (typeof value !== 'boolean') {
+        throw new ConditionGroupValidationError(`${valuePath} must be a boolean`)
+      }
+      return
+    }
+    if (typeof value !== 'string') {
+      throw new ConditionGroupValidationError(`${valuePath} must be a string`)
+    }
+  })
+}
+
+function validateConditionNodeAgainstFields(
+  node: AutomationConditionNode,
+  fieldsById: Map<string, AutomationConditionField>,
+  path: string,
+): void {
+  if (isConditionGroup(node)) {
+    node.conditions.forEach((condition, index) =>
+      validateConditionNodeAgainstFields(condition, fieldsById, `${path}.conditions[${index}]`),
+    )
+    return
+  }
+
+  const field = fieldsById.get(node.fieldId)
+  if (!field) {
+    throw new ConditionGroupValidationError(`${path}.fieldId does not exist on sheet: ${node.fieldId}`)
+  }
+
+  const allowedOperators = allowedOperatorsForFieldType(field.type)
+  if (!allowedOperators.has(node.operator)) {
+    throw new ConditionGroupValidationError(
+      `${path}.operator ${node.operator} is not supported for field type ${field.type}`,
+    )
+  }
+
+  assertConditionValueType(node, field.type, path)
+}
+
+export function validateConditionGroupAgainstFields(
+  conditionGroup: ConditionGroup | null | undefined,
+  fields: AutomationConditionField[],
+  path = 'conditions',
+): void {
+  if (!conditionGroup) return
+  const fieldsById = new Map(fields.map((field) => [field.id, field]))
+  conditionGroup.conditions.forEach((condition, index) =>
+    validateConditionNodeAgainstFields(condition, fieldsById, `${path}.conditions[${index}]`),
+  )
 }
 
 /**

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -6,6 +6,8 @@ import { matchesTrigger, TRIGGER_TYPE_BY_EVENT, type AutomationTriggerType } fro
 import {
   ConditionGroupValidationError,
   normalizeConditionGroupInput,
+  validateConditionGroupAgainstFields,
+  type AutomationConditionField,
   type ConditionGroup,
 } from './automation-conditions'
 import { AutomationExecutor, type AutomationRule as ExecutorRule, type AutomationExecution, type AutomationDeps } from './automation-executor'
@@ -144,6 +146,18 @@ export type AutomationEventPayload = {
   actorId?: string | null
   _automationDepth?: number
   _triggeredBy?: string
+}
+
+function serializeAutomationConditionFieldRows(rows: unknown[]): AutomationConditionField[] {
+  return rows
+    .map((row) => {
+      if (!row || typeof row !== 'object') return null
+      const record = row as Record<string, unknown>
+      const id = typeof record.id === 'string' ? record.id : ''
+      const type = typeof record.type === 'string' ? record.type : ''
+      return id && type ? { id, type } : null
+    })
+    .filter((field): field is AutomationConditionField => !!field)
 }
 
 /** Input for creating a rule */
@@ -911,6 +925,36 @@ export async function preflightDingTalkAutomationCreate(
   if (linkErr) throw new AutomationRuleValidationError(linkErr)
 
   return { ...input, actionConfig, actions }
+}
+
+/**
+ * Validate automation conditions against the sheet's current fields. The
+ * route parser only validates JSON shape; this preflight closes the API gap
+ * where direct clients could persist unknown fields, unsupported operators, or
+ * frontend-incompatible scalar value types.
+ */
+export async function preflightAutomationConditionFields(
+  queryFn: AutomationQueryFn,
+  sheetId: string,
+  conditions: ConditionGroup | null | undefined,
+): Promise<void> {
+  if (!conditions) return
+
+  const fieldRes = await queryFn(
+    'SELECT id, type FROM meta_fields WHERE sheet_id = $1',
+    [sheetId],
+  )
+  try {
+    validateConditionGroupAgainstFields(
+      conditions,
+      serializeAutomationConditionFieldRows(fieldRes.rows),
+    )
+  } catch (error) {
+    if (error instanceof ConditionGroupValidationError) {
+      throw new AutomationRuleValidationError(error.message)
+    }
+    throw error
+  }
 }
 
 /**

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -106,6 +106,7 @@ import {
   parseCreateRuleInput,
   parseDingTalkAutomationDeliveryLimit,
   parseUpdateRuleInput,
+  preflightAutomationConditionFields,
   preflightDingTalkAutomationCreate,
   preflightDingTalkAutomationUpdate,
   serializeAutomationRule,
@@ -7728,6 +7729,7 @@ export function univerMetaRouter(): Router {
 
       const parsed = parseCreateRuleInput(req.body as Record<string, unknown> | undefined, access.userId)
       const input = await preflightDingTalkAutomationCreate(pool.query.bind(pool), sheetId, parsed)
+      await preflightAutomationConditionFields(pool.query.bind(pool), sheetId, input.conditions)
       const rule = await automationService.createRule(sheetId, input)
 
       return res.json({
@@ -7776,6 +7778,7 @@ export function univerMetaRouter(): Router {
       if (!input) {
         return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Automation rule not found' } })
       }
+      await preflightAutomationConditionFields(pool.query.bind(pool), sheetId, input.conditions)
 
       const updated = await automationService.updateRule(ruleId, sheetId, input)
       if (!updated) {

--- a/packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts
+++ b/packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts
@@ -27,6 +27,12 @@ type ViewRow = {
   config: Record<string, unknown> | string
 }
 
+type FieldRow = {
+  id: string
+  sheet_id: string
+  type: string
+}
+
 function makePublicFormConfig(options: {
   enabled?: boolean
   token?: string
@@ -78,8 +84,19 @@ function makeViewRows(nowMs = Date.now()): ViewRow[] {
   ]
 }
 
-function createDingTalkLinkQueryHandler(views = makeViewRows()): QueryHandler {
+function createDingTalkLinkQueryHandler(views = makeViewRows(), fields: FieldRow[] = []): QueryHandler {
   return (sql, params) => {
+    if (sql.includes('FROM meta_fields') && sql.includes('sheet_id = $1')) {
+      const sheetId = typeof params?.[0] === 'string' ? params[0] : ''
+      const rows = fields
+        .filter((field) => field.sheet_id === sheetId)
+        .map((field) => ({
+          id: field.id,
+          type: field.type,
+        }))
+      return { rows, rowCount: rows.length }
+    }
+
     if (sql.includes('FROM meta_views') && sql.includes('id::text = ANY')) {
       const sheetId = typeof params?.[0] === 'string' ? params[0] : ''
       const ids = Array.isArray(params?.[1]) ? params[1].map(String) : []
@@ -533,6 +550,91 @@ describe('DingTalk automation link route validation', () => {
     ])
     expect(res.body.data.rule).not.toHaveProperty('sheet_id')
     expect(res.body.data.rule).not.toHaveProperty('action_type')
+  })
+
+  it('rejects an unknown automation condition field before persisting the rule', async () => {
+    const { app, automationService } = await createApp()
+
+    const res = await request(app)
+      .post(`/api/multitable/sheets/${SHEET_ID}/automations`)
+      .send({
+        name: 'Condition guard',
+        triggerType: 'record.created',
+        triggerConfig: {},
+        actionType: 'send_notification',
+        actionConfig: {},
+        conditions: {
+          conjunction: 'AND',
+          conditions: [{ fieldId: 'fld_missing', operator: 'equals', value: 'Ready' }],
+        },
+      })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toEqual({
+      code: 'VALIDATION_ERROR',
+      message: 'conditions.conditions[0].fieldId does not exist on sheet: fld_missing',
+    })
+    expect(automationService.createRule).not.toHaveBeenCalled()
+  })
+
+  it('persists an automation rule with field-compatible conditions', async () => {
+    const { app, automationService } = await createApp({
+      queryHandler: createDingTalkLinkQueryHandler(makeViewRows(), [
+        { id: 'fld_score', sheet_id: SHEET_ID, type: 'number' },
+        { id: 'fld_done', sheet_id: SHEET_ID, type: 'boolean' },
+      ]),
+    })
+
+    const conditions = {
+      conjunction: 'AND',
+      conditions: [
+        { fieldId: 'fld_score', operator: 'greater_or_equal', value: 10 },
+        { fieldId: 'fld_done', operator: 'equals', value: false },
+      ],
+    }
+
+    const res = await request(app)
+      .post(`/api/multitable/sheets/${SHEET_ID}/automations`)
+      .send({
+        name: 'Condition guard',
+        triggerType: 'record.created',
+        triggerConfig: {},
+        actionType: 'send_notification',
+        actionConfig: {},
+        conditions,
+      })
+
+    expect(res.status).toBe(200)
+    expect(res.body.ok).toBe(true)
+    expect(automationService.createRule).toHaveBeenCalledWith(SHEET_ID, expect.objectContaining({
+      conditions,
+    }))
+  })
+
+  it('rejects field-incompatible automation conditions on update before persisting', async () => {
+    const automationService = createMockAutomationService()
+    const { app } = await createApp({
+      automationService,
+      queryHandler: createDingTalkLinkQueryHandler(makeViewRows(), [
+        { id: 'fld_score', sheet_id: SHEET_ID, type: 'number' },
+      ]),
+    })
+
+    const res = await request(app)
+      .patch(`/api/multitable/sheets/${SHEET_ID}/automations/${RULE_ID}`)
+      .send({
+        conditions: {
+          conjunction: 'AND',
+          conditions: [{ fieldId: 'fld_score', operator: 'contains', value: '10' }],
+        },
+      })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toEqual({
+      code: 'VALIDATION_ERROR',
+      message: 'conditions.conditions[0].operator contains is not supported for field type number',
+    })
+    expect(automationService.updateRule).not.toHaveBeenCalled()
   })
 
   it('persists a V1 DingTalk person action when public form and internal links are valid', async () => {

--- a/packages/core-backend/tests/unit/multitable-automation-conditions.test.ts
+++ b/packages/core-backend/tests/unit/multitable-automation-conditions.test.ts
@@ -4,6 +4,7 @@ import {
   evaluateCondition,
   evaluateConditions,
   normalizeConditionGroupInput,
+  validateConditionGroupAgainstFields,
   type ConditionGroup,
 } from '../../src/multitable/automation-conditions'
 
@@ -138,5 +139,61 @@ describe('multitable automation conditions', () => {
       conjunction: 'AND',
       conditions: [{ fieldId: 'status', operator: 'in', value: 'Ready' }],
     })).toThrow('conditions.conditions[0].value must be an array for in')
+  })
+
+  it('validates condition operators and scalar values against field types', () => {
+    const fields = [
+      { id: 'status', type: 'string' },
+      { id: 'score', type: 'number' },
+      { id: 'done', type: 'boolean' },
+      { id: 'files', type: 'attachment' },
+    ]
+
+    expect(() => validateConditionGroupAgainstFields({
+      conjunction: 'AND',
+      conditions: [
+        { fieldId: 'status', operator: 'contains', value: 'Ready' },
+        { fieldId: 'score', operator: 'greater_or_equal', value: 3 },
+        { fieldId: 'done', operator: 'equals', value: false },
+        { fieldId: 'files', operator: 'is_not_empty' },
+      ],
+    }, fields)).not.toThrow()
+
+    expect(() => validateConditionGroupAgainstFields({
+      conjunction: 'AND',
+      conditions: [{ fieldId: 'score', operator: 'contains', value: '3' }],
+    }, fields)).toThrow('conditions.conditions[0].operator contains is not supported for field type number')
+
+    expect(() => validateConditionGroupAgainstFields({
+      conjunction: 'AND',
+      conditions: [{ fieldId: 'score', operator: 'greater_than', value: '3' }],
+    }, fields)).toThrow('conditions.conditions[0].value must be a number')
+
+    expect(() => validateConditionGroupAgainstFields({
+      conjunction: 'AND',
+      conditions: [{ fieldId: 'done', operator: 'equals', value: 'false' }],
+    }, fields)).toThrow('conditions.conditions[0].value must be a boolean')
+
+    expect(() => validateConditionGroupAgainstFields({
+      conjunction: 'AND',
+      conditions: [{ fieldId: 'files', operator: 'equals', value: 'file_1' }],
+    }, fields)).toThrow('conditions.conditions[0].operator equals is not supported for field type attachment')
+  })
+
+  it('reports unknown fields and nested validation paths', () => {
+    const fields = [{ id: 'score', type: 'number' }]
+
+    expect(() => validateConditionGroupAgainstFields({
+      conjunction: 'AND',
+      conditions: [{ fieldId: 'missing', operator: 'equals', value: 'x' }],
+    }, fields)).toThrow('conditions.conditions[0].fieldId does not exist on sheet: missing')
+
+    expect(() => validateConditionGroupAgainstFields({
+      conjunction: 'AND',
+      conditions: [{
+        conjunction: 'OR',
+        conditions: [{ fieldId: 'score', operator: 'in', value: [] }],
+      }],
+    }, fields)).toThrow('conditions.conditions[0].conditions[0].value must not be empty for in')
   })
 })


### PR DESCRIPTION
## Summary

- validate automation condition field ids against the sheet's `meta_fields`
- enforce backend operator families matching the field-aware frontend editor
- reject scalar number/boolean/string value type mismatches before rule persistence
- add unit coverage for the validator and route coverage for create/update rejection
- add development and verification MD artifacts

## Verification

- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/multitable-automation-conditions.test.ts tests/integration/dingtalk-automation-link-routes.api.test.ts --reporter=dot` (44/44 pass)
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit`
- `git diff --check`
