### PR TITLE
fix(multitable): coerce numeric automation condition lists

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -1144,6 +1144,7 @@ function conditionValueWidget(condition: AutomationCondition): ConditionValueWid
 }
 
 function conditionValueInputType(condition: AutomationCondition): string {
+  if (isArrayOperator(condition.operator)) return 'text'
   const widget = conditionValueWidget(condition)
   if (widget === 'number') return 'number'
   if (widget === 'date') return 'date'
@@ -1152,6 +1153,7 @@ function conditionValueInputType(condition: AutomationCondition): string {
 }
 
 function conditionValueInputMode(condition: AutomationCondition): 'decimal' | undefined {
+  if (isArrayOperator(condition.operator)) return undefined
   return conditionValueWidget(condition) === 'number' ? 'decimal' : undefined
 }
 
@@ -1298,6 +1300,13 @@ function parseNumberConditionValue(value: unknown): number | null {
   return Number.isFinite(parsed) ? parsed : null
 }
 
+function parseNumericConditionArrayValue(value: unknown): number[] | null {
+  const values = parseConditionArrayValue(value)
+  if (!values.length) return null
+  const numbers = values.map(parseNumberConditionValue)
+  return numbers.every((entry): entry is number => entry !== null) ? numbers : null
+}
+
 function parseBooleanConditionValue(value: unknown): boolean | null {
   if (value === true || value === false) return value
   if (value === 'true') return true
@@ -1310,9 +1319,12 @@ function conditionFieldType(fieldId: string): string | undefined {
 }
 
 function buildConditionValuePayload(condition: AutomationCondition): unknown {
-  if (isArrayOperator(condition.operator)) return parseConditionArrayValue(condition.value)
-
   const fieldType = conditionFieldType(condition.fieldId)
+  if (isArrayOperator(condition.operator)) {
+    return isNumericConditionFieldType(fieldType)
+      ? parseNumericConditionArrayValue(condition.value) ?? []
+      : parseConditionArrayValue(condition.value)
+  }
   if (isNumericConditionFieldType(fieldType)) {
     return parseNumberConditionValue(condition.value)
   }
@@ -1325,8 +1337,12 @@ function buildConditionValuePayload(condition: AutomationCondition): unknown {
 function isConditionLeafComplete(condition: AutomationCondition): boolean {
   if (!condition.fieldId.trim()) return false
   if (isUnaryOperator(condition.operator)) return true
-  if (isArrayOperator(condition.operator)) return parseConditionArrayValue(condition.value).length > 0
   const fieldType = conditionFieldType(condition.fieldId)
+  if (isArrayOperator(condition.operator)) {
+    return isNumericConditionFieldType(fieldType)
+      ? parseNumericConditionArrayValue(condition.value) !== null
+      : parseConditionArrayValue(condition.value).length > 0
+  }
   if (isNumericConditionFieldType(fieldType)) return parseNumberConditionValue(condition.value) !== null
   if (fieldType === 'boolean') return parseBooleanConditionValue(condition.value) !== null
   return typeof condition.value === 'string'

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -363,6 +363,82 @@ describe('MetaAutomationRuleEditor', () => {
     })
   })
 
+  it('serializes numeric list condition values as numbers', async () => {
+    const saved = vi.fn()
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, onSave: saved })
+    await flushPromises()
+
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    nameInput.value = 'Score list condition'
+    nameInput.dispatchEvent(new Event('input'))
+
+    ;(container.querySelector('[data-action="add-condition"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    const conditionRow = container.querySelector('[data-condition-index="0"]') as HTMLElement
+    const [fieldSelect] = Array.from(conditionRow.querySelectorAll('select')) as HTMLSelectElement[]
+    fieldSelect.value = 'fld_score'
+    fieldSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const operatorSelect = Array.from(conditionRow.querySelectorAll('select'))[1] as HTMLSelectElement
+    operatorSelect.value = 'in'
+    operatorSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const valueInput = conditionRow.querySelector('input') as HTMLInputElement
+    expect(valueInput.type).toBe('text')
+    expect(valueInput.placeholder).toBe('Comma-separated values')
+    valueInput.value = '1, 2.5, -3'
+    valueInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    ;(container.querySelector('[data-action="save"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    expect(saved).toHaveBeenCalledTimes(1)
+    expect(saved.mock.calls[0][0].conditions).toEqual({
+      conjunction: 'AND',
+      conditions: [{ fieldId: 'fld_score', operator: 'in', value: [1, 2.5, -3] }],
+    })
+  })
+
+  it('keeps save disabled for invalid numeric list condition values', async () => {
+    const saved = vi.fn()
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, onSave: saved })
+    await flushPromises()
+
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    nameInput.value = 'Invalid score list condition'
+    nameInput.dispatchEvent(new Event('input'))
+
+    ;(container.querySelector('[data-action="add-condition"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    const conditionRow = container.querySelector('[data-condition-index="0"]') as HTMLElement
+    const [fieldSelect] = Array.from(conditionRow.querySelectorAll('select')) as HTMLSelectElement[]
+    fieldSelect.value = 'fld_score'
+    fieldSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const operatorSelect = Array.from(conditionRow.querySelectorAll('select'))[1] as HTMLSelectElement
+    operatorSelect.value = 'not_in'
+    operatorSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const valueInput = conditionRow.querySelector('input') as HTMLInputElement
+    valueInput.value = '1, nope'
+    valueInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(true)
+    saveBtn.click()
+    await flushPromises()
+
+    expect(saved).not.toHaveBeenCalled()
+  })
+
   it('serializes boolean condition values as booleans', async () => {
     const saved = vi.fn()
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, onSave: saved })

--- a/docs/development/multitable-automation-numeric-list-condition-development-20260511.md
+++ b/docs/development/multitable-automation-numeric-list-condition-development-20260511.md
@@ -1,0 +1,62 @@
+# Multitable Automation Numeric List Condition Development - 2026-05-11
+
+## Context
+
+Backend condition validation now accepts numeric list operators only when every
+entry can be interpreted as a finite number. The frontend still serialized
+numeric `in` / `not_in` condition values through the generic comma-list parser,
+which produced string arrays such as `["1", "2"]`.
+
+That payload passes JSON shape validation but does not match the runtime
+evaluator's strict equality check for numeric record values. A record value `1`
+will not match a condition list entry `"1"`.
+
+## Scope
+
+Implemented:
+
+- Numeric fields using `in` / `not_in` now render a text input, not
+  `<input type="number">`, so comma-separated lists are actually authorable.
+- Numeric list values are parsed into finite `number[]` payloads during save.
+- Invalid numeric list entries keep the Save button disabled.
+- Existing scalar numeric operators still use `<input type="number">`.
+- Non-numeric list operators keep the existing string-array behavior.
+
+Not implemented:
+
+- No backend changes.
+- No evaluator changes.
+- No async option hydration for person/link/lookup fields.
+- No browser smoke.
+
+## Design Decisions
+
+### Coerce At Payload Boundary
+
+Draft state remains compatible with the existing editor input model. Coercion
+happens only when building the API payload, where scalar numeric values were
+already converted.
+
+### Text Input For Numeric Lists
+
+Comma-separated lists cannot be represented with `type="number"`. The list
+operator path uses a text input with the existing "Comma-separated values"
+placeholder, then validates each entry with the same finite-number parser used
+for scalar numeric values.
+
+### Disable Save On Partial Invalid Lists
+
+The editor does not silently drop invalid list entries. If any entry fails
+numeric parsing, the condition is incomplete and Save remains disabled.
+
+## Files Changed
+
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+
+## Follow-Ups
+
+- Add boolean `in` / `not_in` authoring if product wants multi-value boolean
+  conditions; today boolean equality remains the practical UI path.
+- Add async option/value validation for person/link/lookup once those option
+  sources are standardized.

--- a/docs/development/multitable-automation-numeric-list-condition-verification-20260511.md
+++ b/docs/development/multitable-automation-numeric-list-condition-verification-20260511.md
@@ -1,0 +1,75 @@
+# Multitable Automation Numeric List Condition Verification - 2026-05-11
+
+## Environment
+
+- Worktree: `/private/tmp/ms2-numeric-condition-list-coercion-20260511`
+- Branch: `codex/multitable-numeric-condition-list-coercion-20260511`
+- Baseline: `origin/main@de3ba19ae`
+- Scope: frontend automation editor numeric list condition input and payload
+  coercion.
+
+## Commands
+
+### Install Workspace Links
+
+```bash
+pnpm install --ignore-scripts
+git restore -- plugins tools
+```
+
+Result:
+
+- workspace executable links restored for this temporary worktree;
+- dependency symlink dirt under `plugins/` and `tools/` reverted;
+- no dependency or lockfile changes remain in the business diff.
+
+### Automation Rule Editor Unit Tests
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/multitable-automation-rule-editor.spec.ts \
+  --watch=false
+```
+
+Expected:
+
+- existing automation rule editor behavior remains green;
+- scalar numeric conditions still serialize as numbers;
+- numeric `in` / `not_in` conditions render a text input for comma lists;
+- numeric list payloads serialize as `number[]`;
+- invalid numeric list entries keep Save disabled.
+
+Result:
+
+- 1 file passed.
+- 74 tests passed.
+
+### Frontend Type Check
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc --noEmit --pretty false
+```
+
+Expected: pass.
+
+Result:
+
+- pass.
+
+### Diff Hygiene
+
+```bash
+git diff --check
+```
+
+Expected: pass.
+
+Result:
+
+- pass.
+
+## Non-Verification
+
+- No backend tests were run because this slice is frontend-only.
+- No live browser smoke was run.
+- No staging automation rule was created.


### PR DESCRIPTION
## Summary

- make numeric `in` / `not_in` automation condition inputs use a text field for comma-separated values
- serialize numeric list condition values as `number[]` so evaluator strict equality matches numeric record values
- keep Save disabled when any numeric list entry is invalid
- add development and verification MD artifacts

## Verification

- `pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts --watch=false` (74/74 pass)
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit --pretty false`
- `git diff --check`
