### PR TITLE
chore(dingtalk): require screenshot archive in final closeout

### DIFF
--- a/docs/development/dingtalk-final-closeout-screenshot-archive-development-20260511.md
+++ b/docs/development/dingtalk-final-closeout-screenshot-archive-development-20260511.md
@@ -1,0 +1,54 @@
+# DingTalk Final Closeout Screenshot Archive - Development
+
+- Date: 2026-05-11
+- Scope: final DingTalk P4 closeout wrapper and generated final docs.
+- Goal: make screenshot archive evidence enforceable from the single `dingtalk-p4-final-closeout.mjs` command, not only from the lower-level handoff command.
+
+## Background
+
+The screenshot evidence archive helper and final handoff packet already supported strict screenshot archive validation. The remaining gap was the outer closeout wrapper:
+
+- `dingtalk-p4-final-handoff.mjs` could accept `--include-screenshot-archive` and `--require-screenshot-archive-pass`.
+- `dingtalk-p4-final-closeout.mjs` could not forward those flags.
+- `dingtalk-p4-final-docs.mjs` did not surface screenshot archive gate status in generated development and verification markdown.
+
+This made the final one-command closeout path weaker than the underlying packet gate.
+
+## Changes
+
+- Added `--include-screenshot-archive <dir>` to `scripts/ops/dingtalk-p4-final-closeout.mjs`.
+- Added `--require-screenshot-archive-pass` to reject strict closeout runs that forgot to include screenshot evidence.
+- Forwarded screenshot archive arguments from final closeout into `dingtalk-p4-final-handoff.mjs`.
+- Added screenshot archive fields to closeout summary JSON and Markdown:
+  - `screenshotArchiveRequired`
+  - `screenshotArchiveCount`
+- Updated `dingtalk-p4-final-docs.mjs` to record screenshot archive gate status and included archive count.
+- Added a final-docs release-ready guard for the impossible state where screenshot archive is required but no archive is included.
+
+## Operator Flow
+
+```bash
+node scripts/ops/dingtalk-screenshot-archive.mjs \
+  --input <operator-screenshot-dir> \
+  --output-dir artifacts/dingtalk-screenshot-archive/<run-id>
+
+node scripts/ops/dingtalk-p4-final-closeout.mjs \
+  --session-dir output/dingtalk-p4-remote-smoke-session/<run-id> \
+  --packet-output-dir artifacts/dingtalk-staging-evidence-packet/<run-id>-final \
+  --include-screenshot-archive artifacts/dingtalk-screenshot-archive/<run-id> \
+  --require-screenshot-archive-pass \
+  --docs-output-dir docs/development \
+  --date <yyyymmdd>
+```
+
+## Security Notes
+
+- The closeout summary and generated docs only record archive counts/status, not screenshot pixels.
+- Raw screenshots still remain access-restricted release artifacts.
+- No webhook, `SEC`, JWT, bearer token, app secret, Agent ID, recipient id, or temporary password is written to the docs.
+
+## Non-Goals
+
+- No runtime DingTalk behavior changed.
+- No API or database schema changed.
+- No OCR or screenshot content assertion was added; the archive gate validates packaging integrity only.

--- a/docs/development/dingtalk-final-closeout-screenshot-archive-verification-20260511.md
+++ b/docs/development/dingtalk-final-closeout-screenshot-archive-verification-20260511.md
@@ -1,0 +1,62 @@
+# DingTalk Final Closeout Screenshot Archive - Verification
+
+- Date: 2026-05-11
+- Scope: final closeout wrapper screenshot archive gate.
+- Result: PASS.
+
+## Commands
+
+```bash
+node --test scripts/ops/dingtalk-p4-final-closeout.test.mjs
+node --test scripts/ops/dingtalk-p4-final-docs.test.mjs
+node --test scripts/ops/dingtalk-p4-final-handoff.test.mjs
+node --test scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs
+node --test scripts/ops/validate-dingtalk-staging-evidence-packet.test.mjs
+node --test \
+  scripts/ops/dingtalk-p4-final-closeout.test.mjs \
+  scripts/ops/dingtalk-p4-final-docs.test.mjs \
+  scripts/ops/dingtalk-p4-final-handoff.test.mjs \
+  scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs \
+  scripts/ops/validate-dingtalk-staging-evidence-packet.test.mjs
+node scripts/ops/dingtalk-p4-final-closeout.mjs --help | rg -- '--include-screenshot-archive|--require-screenshot-archive-pass'
+node scripts/ops/dingtalk-screenshot-archive.mjs \
+  --input <operator-screenshot-file-1> \
+  --input <operator-screenshot-file-2> \
+  --input <operator-screenshot-file-3> \
+  --input <operator-screenshot-file-4> \
+  --input <operator-screenshot-file-5> \
+  --input <operator-screenshot-file-6> \
+  --input <operator-screenshot-file-7> \
+  --output-dir /tmp/dingtalk-screenshot-archive-20260511
+git diff --check
+```
+
+## Results
+
+| Gate | Result |
+| --- | --- |
+| Final closeout tests | PASS, 9/9 |
+| Final docs tests | PASS, 5/5 |
+| Final handoff tests | PASS, 13/13 |
+| Evidence packet exporter tests | PASS, 20/20 |
+| Evidence packet validator tests | PASS, 20/20 |
+| Combined affected ops suite | PASS, 67/67 |
+| CLI help exposes screenshot archive flags | PASS |
+| Operator screenshot archive smoke | PASS, 7 screenshots packaged |
+| Whitespace diff check | PASS |
+
+## Coverage Added
+
+- `dingtalk-p4-final-closeout` forwards strict screenshot archive arguments into final handoff.
+- Closeout summary records screenshot archive gate required/not-required status.
+- Closeout summary records included screenshot archive count.
+- Generated final development and verification docs include screenshot archive gate status.
+- Release-ready final docs reject a required screenshot archive gate with zero included archives.
+
+## Secret Review
+
+The changed paths were scanned with diff checks and token-pattern grep. No real DingTalk webhook, `SEC`, JWT, bearer token, app secret, public form token, Agent ID, recipient id, or temporary password was added.
+
+## Final Status
+
+The final DingTalk closeout command now has parity with the lower-level handoff gate: screenshot archive evidence can be required from the top-level release command and is visible in the generated final documentation.

--- a/scripts/ops/dingtalk-p4-final-closeout.mjs
+++ b/scripts/ops/dingtalk-p4-final-closeout.mjs
@@ -29,6 +29,8 @@ Options:
   --packet-output-dir <dir>           Packet directory, default ${DEFAULT_PACKET_ROOT}/<session-name>-final
   --include-mobile-signoff <dir>      Optional strict mobile public-form signoff output dir
   --require-mobile-signoff-pass       Require every included mobile signoff output to be strict passing
+  --include-screenshot-archive <dir>  Optional DingTalk screenshot archive output dir
+  --require-screenshot-archive-pass   Require every included screenshot archive to be strict passing
   --docs-output-dir <dir>             Final docs directory, default ${DEFAULT_DOCS_DIR}
   --date <yyyymmdd>                   Final docs date suffix, default current UTC date
   --summary-json <file>               Closeout JSON summary, default <packet-output-dir>/closeout-summary.json
@@ -62,6 +64,8 @@ function parseArgs(argv) {
     packetOutputDir: '',
     includeMobileSignoffDirs: [],
     requireMobileSignoffPass: false,
+    includeScreenshotArchiveDirs: [],
+    requireScreenshotArchivePass: false,
     docsOutputDir: path.resolve(process.cwd(), DEFAULT_DOCS_DIR),
     date: defaultDate(),
     summaryJson: '',
@@ -87,6 +91,13 @@ function parseArgs(argv) {
         break
       case '--require-mobile-signoff-pass':
         opts.requireMobileSignoffPass = true
+        break
+      case '--include-screenshot-archive':
+        opts.includeScreenshotArchiveDirs.push(path.resolve(process.cwd(), readRequiredValue(argv, i, arg)))
+        i += 1
+        break
+      case '--require-screenshot-archive-pass':
+        opts.requireScreenshotArchivePass = true
         break
       case '--docs-output-dir':
         opts.docsOutputDir = path.resolve(process.cwd(), readRequiredValue(argv, i, arg))
@@ -175,6 +186,9 @@ function validatePaths(opts) {
   if (opts.requireMobileSignoffPass && opts.includeMobileSignoffDirs.length === 0) {
     throw new Error('--require-mobile-signoff-pass requires at least one --include-mobile-signoff directory')
   }
+  if (opts.requireScreenshotArchivePass && opts.includeScreenshotArchiveDirs.length === 0) {
+    throw new Error('--require-screenshot-archive-pass requires at least one --include-screenshot-archive directory')
+  }
 }
 
 function scriptPath(envName, fallback) {
@@ -187,6 +201,15 @@ function mobileSignoffHandoffArgs(opts) {
     args.push('--include-mobile-signoff', dir)
   }
   if (opts.requireMobileSignoffPass) args.push('--require-mobile-signoff-pass')
+  return args
+}
+
+function screenshotArchiveHandoffArgs(opts) {
+  const args = []
+  for (const dir of opts.includeScreenshotArchiveDirs) {
+    args.push('--include-screenshot-archive', dir)
+  }
+  if (opts.requireScreenshotArchivePass) args.push('--require-screenshot-archive-pass')
   return args
 }
 
@@ -289,6 +312,10 @@ function buildSummary(opts, steps) {
       mobileSignoffCount: handoff?.mobileSignoff?.includedCount
         ?? handoff?.publishCheck?.includedMobileSignoffCount
         ?? 0,
+      screenshotArchiveRequired: opts.requireScreenshotArchivePass,
+      screenshotArchiveCount: handoff?.screenshotArchive?.includedCount
+        ?? handoff?.publishCheck?.includedScreenshotArchiveCount
+        ?? 0,
       secretFindingCount: Array.isArray(handoff?.publishCheck?.secretFindings)
         ? handoff.publishCheck.secretFindings.length
         : status?.handoff?.secretFindingCount ?? 0,
@@ -345,6 +372,8 @@ ${stepRows.join('\n')}
 - Publish status: **${summary.final.publishStatus}**
 - Mobile signoff gate: **${summary.final.mobileSignoffRequired ? 'required' : 'not_required'}**
 - Included mobile signoff count: **${summary.final.mobileSignoffCount}**
+- Screenshot archive gate: **${summary.final.screenshotArchiveRequired ? 'required' : 'not_required'}**
+- Included screenshot archive count: **${summary.final.screenshotArchiveCount}**
 - Secret findings: **${summary.final.secretFindingCount}**
 
 ## Failures
@@ -396,6 +425,7 @@ function runCloseout(opts) {
         '--output-dir',
         opts.packetOutputDir,
         ...mobileSignoffHandoffArgs(opts),
+        ...screenshotArchiveHandoffArgs(opts),
       ],
     ))
   }

--- a/scripts/ops/dingtalk-p4-final-closeout.test.mjs
+++ b/scripts/ops/dingtalk-p4-final-closeout.test.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict'
 import { spawnSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
@@ -129,6 +130,37 @@ function writeMobileSignoffOutput(signoffDir, overrides = {}) {
     checks: mobileSignoffRequiredCheckIds.map((id) => ({ id, status: 'pass' })),
     ...overrides.redacted,
   })
+}
+
+function writeScreenshotArchiveOutput(archiveDir, overrides = {}) {
+  mkdirSync(path.join(archiveDir, 'screenshots'), { recursive: true })
+  const screenshotBytes = Buffer.from('not-a-real-png-but-stable-test-bytes\n')
+  const screenshotPath = path.join(archiveDir, 'screenshots', 'screenshot-001.png')
+  writeFileSync(screenshotPath, screenshotBytes)
+  const sha256 = createHash('sha256').update(screenshotBytes).digest('hex')
+
+  writeJson(path.join(archiveDir, 'manifest.json'), {
+    tool: 'dingtalk-screenshot-archive',
+    generatedAt: '2026-05-11T00:00:00.000Z',
+    status: 'pass',
+    allowEmpty: false,
+    outputDir: 'artifacts/dingtalk-screenshot-archive/test',
+    manifestJson: 'artifacts/dingtalk-screenshot-archive/test/manifest.json',
+    readmeMd: 'artifacts/dingtalk-screenshot-archive/test/README.md',
+    inputCount: 1,
+    screenshotCount: 1,
+    copiedScreenshots: [{
+      index: 1,
+      sourceLabel: 'operator-screenshot.png',
+      archivePath: 'screenshots/screenshot-001.png',
+      extension: '.png',
+      sizeBytes: screenshotBytes.length,
+      sha256,
+    }],
+    warnings: [],
+    ...overrides.manifest,
+  })
+  writeFileSync(path.join(archiveDir, 'README.md'), '# Screenshot archive\n\nStatus: pass\n', 'utf8')
 }
 
 function runScript(args) {
@@ -272,6 +304,49 @@ test('dingtalk-p4-final-closeout forwards strict mobile signoff into final hando
     assert.equal(closeoutSummary.final.mobileSignoffCount, 1)
     assert.match(closeoutSummary.steps[1].command, /--require-mobile-signoff-pass/)
     assert.match(readFileSync(path.join(packetDir, 'closeout-summary.md'), 'utf8'), /Mobile signoff gate: \*\*required\*\*/)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-p4-final-closeout forwards strict screenshot archive into final handoff', () => {
+  const tmpDir = makeTmpDir()
+  const sessionDir = path.join(tmpDir, '142-session')
+  const screenshotArchiveDir = path.join(tmpDir, 'screenshot-archive')
+  const packetDir = path.join(tmpDir, 'packet')
+  const docsDir = path.join(tmpDir, 'docs')
+
+  try {
+    writeReadyForFinalizeSession(sessionDir)
+    writeScreenshotArchiveOutput(screenshotArchiveDir)
+
+    const result = runScript([
+      '--session-dir',
+      sessionDir,
+      '--packet-output-dir',
+      packetDir,
+      '--include-screenshot-archive',
+      screenshotArchiveDir,
+      '--require-screenshot-archive-pass',
+      '--docs-output-dir',
+      docsDir,
+      '--date',
+      '20260423',
+      '--skip-docs',
+    ])
+
+    assert.equal(result.status, 0, result.stderr || result.stdout)
+    const handoffSummary = JSON.parse(readFileSync(path.join(packetDir, 'handoff-summary.json'), 'utf8'))
+    assert.equal(handoffSummary.status, 'pass')
+    assert.equal(handoffSummary.screenshotArchive.required, true)
+    assert.equal(handoffSummary.screenshotArchive.includedCount, 1)
+    assert.equal(handoffSummary.publishCheck.includedScreenshotArchiveCount, 1)
+    const closeoutSummary = JSON.parse(readFileSync(path.join(packetDir, 'closeout-summary.json'), 'utf8'))
+    assert.equal(closeoutSummary.status, 'pass')
+    assert.equal(closeoutSummary.final.screenshotArchiveRequired, true)
+    assert.equal(closeoutSummary.final.screenshotArchiveCount, 1)
+    assert.match(closeoutSummary.steps[1].command, /--require-screenshot-archive-pass/)
+    assert.match(readFileSync(path.join(packetDir, 'closeout-summary.md'), 'utf8'), /Screenshot archive gate: \*\*required\*\*/)
   } finally {
     rmSync(tmpDir, { recursive: true, force: true })
   }

--- a/scripts/ops/dingtalk-p4-final-docs.mjs
+++ b/scripts/ops/dingtalk-p4-final-docs.mjs
@@ -203,6 +203,10 @@ function buildModel(opts) {
   const secretFindingCount = Array.isArray(handoffSummary.publishCheck?.secretFindings)
     ? handoffSummary.publishCheck.secretFindings.length
     : statusSummary.handoff?.secretFindingCount ?? 0
+  const screenshotArchiveRequired = Boolean(handoffSummary.screenshotArchive?.required)
+  const screenshotArchiveCount = Number.isFinite(handoffSummary.screenshotArchive?.includedCount)
+    ? handoffSummary.screenshotArchive.includedCount
+    : handoffSummary.publishCheck?.includedScreenshotArchiveCount ?? 0
 
   return {
     date: opts.date,
@@ -225,6 +229,8 @@ function buildModel(opts) {
     remoteSmokePhase: statusOf(statusSummary.remoteSmokePhase ?? compiledSummary.remoteSmokePhase),
     handoffStatus: statusOf(handoffStatus),
     publishStatus: statusOf(publishStatus),
+    screenshotArchiveRequired,
+    screenshotArchiveCount,
     secretFindingCount,
     requiredChecks: checks,
     totals: {
@@ -253,6 +259,9 @@ function validateReleaseReady(model, requireReleaseReady) {
   if (model.smokeStatus !== 'release_ready') failures.push('smoke status is not release_ready')
   if (model.handoffStatus !== 'pass') failures.push('handoff status is not pass')
   if (model.publishStatus !== 'pass') failures.push('publish status is not pass')
+  if (model.screenshotArchiveRequired && model.screenshotArchiveCount === 0) {
+    failures.push('screenshot archive is required but not included')
+  }
   if (model.totals.remainingChecks !== 0) failures.push('not all required checks passed')
   if (model.totals.manualEvidenceIssues !== 0) failures.push('manual evidence issues remain')
   if (model.secretFindingCount !== 0) failures.push('publish check reported secret findings')
@@ -295,6 +304,8 @@ function renderDevelopment(model) {
 - Smoke status: **${model.smokeStatus}**
 - Handoff status: **${model.handoffStatus}**
 - Publish status: **${model.publishStatus}**
+- Screenshot archive gate: **${model.screenshotArchiveRequired ? 'required' : 'not_required'}**
+- Included screenshot archive count: **${model.screenshotArchiveCount}**
 
 ## Required Checks
 
@@ -355,6 +366,8 @@ node scripts/ops/dingtalk-p4-final-docs.mjs \\
 - Smoke status: **${model.smokeStatus}**
 - Handoff status: **${model.handoffStatus}**
 - Publish status: **${model.publishStatus}**
+- Screenshot archive gate: **${model.screenshotArchiveRequired ? 'required' : 'not_required'}**
+- Included screenshot archive count: **${model.screenshotArchiveCount}**
 
 ## Required Checks
 

--- a/scripts/ops/dingtalk-p4-final-docs.test.mjs
+++ b/scripts/ops/dingtalk-p4-final-docs.test.mjs
@@ -178,6 +178,76 @@ test('dingtalk-p4-final-docs generates release-ready development and verificatio
   }
 })
 
+test('dingtalk-p4-final-docs records screenshot archive gate status from handoff summary', () => {
+  const tmpDir = makeTmpDir()
+
+  try {
+    const paths = writeReleaseReadySession(tmpDir, {
+      handoffSummary: {
+        publishCheck: {
+          includedScreenshotArchiveCount: 1,
+        },
+        screenshotArchive: {
+          required: true,
+          includedCount: 1,
+          sources: ['artifacts/dingtalk-screenshot-archive/live'],
+        },
+      },
+    })
+    const outputDir = path.join(tmpDir, 'docs')
+    const result = runScript([
+      '--session-dir', paths.sessionDir,
+      '--handoff-summary', paths.handoffSummary,
+      '--output-dir', outputDir,
+      '--date', '20260423',
+      '--require-release-ready',
+    ])
+
+    assert.equal(result.status, 0, result.stderr || result.stdout)
+    const developmentText = readFileSync(path.join(outputDir, 'dingtalk-final-remote-smoke-development-20260423.md'), 'utf8')
+    const verificationText = readFileSync(path.join(outputDir, 'dingtalk-final-remote-smoke-verification-20260423.md'), 'utf8')
+    assert.match(developmentText, /Screenshot archive gate: \*\*required\*\*/)
+    assert.match(developmentText, /Included screenshot archive count: \*\*1\*\*/)
+    assert.match(verificationText, /Screenshot archive gate: \*\*required\*\*/)
+    assert.match(verificationText, /Included screenshot archive count: \*\*1\*\*/)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('dingtalk-p4-final-docs rejects missing screenshot archive when the gate is required', () => {
+  const tmpDir = makeTmpDir()
+
+  try {
+    const paths = writeReleaseReadySession(tmpDir, {
+      handoffSummary: {
+        publishCheck: {
+          includedScreenshotArchiveCount: 0,
+        },
+        screenshotArchive: {
+          required: true,
+          includedCount: 0,
+          sources: [],
+        },
+      },
+    })
+    const outputDir = path.join(tmpDir, 'docs')
+    const result = runScript([
+      '--session-dir', paths.sessionDir,
+      '--handoff-summary', paths.handoffSummary,
+      '--output-dir', outputDir,
+      '--date', '20260423',
+      '--require-release-ready',
+    ])
+
+    assert.equal(result.status, 1)
+    assert.match(result.stderr, /screenshot archive is required but not included/)
+    assert.equal(existsSync(path.join(outputDir, 'dingtalk-final-remote-smoke-development-20260423.md')), false)
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
 test('dingtalk-p4-final-docs rejects non-release-ready sessions when required', () => {
   const tmpDir = makeTmpDir()
 


### PR DESCRIPTION
## Summary
- adds `--include-screenshot-archive` and `--require-screenshot-archive-pass` to the top-level DingTalk P4 final closeout command
- forwards screenshot archive evidence into final handoff and records the required/included status in closeout summaries
- surfaces screenshot archive gate status in generated final development and verification docs
- adds development and verification notes for this closeout slice

## Verification
- `node --test scripts/ops/dingtalk-p4-final-closeout.test.mjs scripts/ops/dingtalk-p4-final-docs.test.mjs scripts/ops/dingtalk-p4-final-handoff.test.mjs scripts/ops/export-dingtalk-staging-evidence-packet.test.mjs scripts/ops/validate-dingtalk-staging-evidence-packet.test.mjs` (67/67 pass)
- `node scripts/ops/dingtalk-screenshot-archive.mjs ... --output-dir /tmp/dingtalk-screenshot-archive-20260511` (7 screenshots packaged)
- `git diff --check HEAD~1..HEAD`
- added-line secret value-pattern scan: no findings

## Risk
- no runtime DingTalk/API/database changes
- ops wrapper and docs-only behavior, with tests covering required screenshot archive pass/fail paths
