### PR TITLE
fix(multitable): support boolean automation condition lists

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -114,7 +114,18 @@
             </select>
             <template v-if="!isUnaryOperator(cond.operator)">
               <select
-                v-if="conditionValueWidget(cond) === 'boolean'"
+                v-if="conditionValueWidget(cond) === 'booleanMultiSelect'"
+                :value="booleanMultiSelectConditionValues(cond)"
+                class="meta-rule-editor__select meta-rule-editor__select--sm"
+                data-condition-value="boolean-multi-select"
+                multiple
+                @change="onBooleanMultiSelectConditionValueChange(cond, $event)"
+              >
+                <option value="true">true</option>
+                <option value="false">false</option>
+              </select>
+              <select
+                v-else-if="conditionValueWidget(cond) === 'boolean'"
                 :value="booleanConditionValue(cond)"
                 class="meta-rule-editor__select meta-rule-editor__select--sm"
                 data-condition-value="boolean"
@@ -1023,7 +1034,7 @@ const DINGTALK_TEST_RUN_CONFIRM_MESSAGE =
   'Test Run executes the saved rule and can send real DingTalk messages to configured groups or users. Unsaved changes are not included. Continue?'
 
 type ConditionOperatorOption = { value: ConditionOperator; label: string }
-type ConditionValueWidget = 'text' | 'number' | 'date' | 'dateTime' | 'boolean' | 'select' | 'multiSelect'
+type ConditionValueWidget = 'text' | 'number' | 'date' | 'dateTime' | 'boolean' | 'booleanMultiSelect' | 'select' | 'multiSelect'
 
 const conditionOperators: ConditionOperatorOption[] = [
   { value: 'equals', label: 'Equals' },
@@ -1133,7 +1144,7 @@ function optionLabel(option: FieldOption): string {
 function conditionValueWidget(condition: AutomationCondition): ConditionValueWidget {
   const field = conditionField(condition)
   if (!field) return 'text'
-  if (field.type === 'boolean') return 'boolean'
+  if (field.type === 'boolean') return isArrayOperator(condition.operator) ? 'booleanMultiSelect' : 'boolean'
   if (isNumericConditionFieldType(field.type)) return 'number'
   if (field.type === 'date') return 'date'
   if (field.type === 'dateTime' || field.type === 'createdTime' || field.type === 'modifiedTime') return 'dateTime'
@@ -1164,6 +1175,11 @@ function booleanConditionValue(condition: AutomationCondition): string {
   return ''
 }
 
+function booleanMultiSelectConditionValues(condition: AutomationCondition): string[] {
+  return (parseBooleanConditionArrayValue(condition.value) ?? [])
+    .map((entry) => entry ? 'true' : 'false')
+}
+
 function singleSelectConditionValue(condition: AutomationCondition): string {
   return typeof condition.value === 'string' ? condition.value : ''
 }
@@ -1180,6 +1196,11 @@ function onBooleanConditionValueChange(condition: AutomationCondition, value: st
   } else {
     condition.value = ''
   }
+}
+
+function onBooleanMultiSelectConditionValueChange(condition: AutomationCondition, event: Event) {
+  const select = event.target as HTMLSelectElement
+  condition.value = Array.from(select.selectedOptions).map((option) => option.value)
 }
 
 function onMultiSelectConditionValueChange(condition: AutomationCondition, event: Event) {
@@ -1314,6 +1335,13 @@ function parseBooleanConditionValue(value: unknown): boolean | null {
   return null
 }
 
+function parseBooleanConditionArrayValue(value: unknown): boolean[] | null {
+  const values = parseConditionArrayValue(value)
+  if (!values.length) return null
+  const booleans = values.map(parseBooleanConditionValue)
+  return booleans.every((entry): entry is boolean => entry !== null) ? booleans : null
+}
+
 function conditionFieldType(fieldId: string): string | undefined {
   return props.fields.find((field) => field.id === fieldId)?.type
 }
@@ -1321,9 +1349,9 @@ function conditionFieldType(fieldId: string): string | undefined {
 function buildConditionValuePayload(condition: AutomationCondition): unknown {
   const fieldType = conditionFieldType(condition.fieldId)
   if (isArrayOperator(condition.operator)) {
-    return isNumericConditionFieldType(fieldType)
-      ? parseNumericConditionArrayValue(condition.value) ?? []
-      : parseConditionArrayValue(condition.value)
+    if (isNumericConditionFieldType(fieldType)) return parseNumericConditionArrayValue(condition.value) ?? []
+    if (fieldType === 'boolean') return parseBooleanConditionArrayValue(condition.value) ?? []
+    return parseConditionArrayValue(condition.value)
   }
   if (isNumericConditionFieldType(fieldType)) {
     return parseNumberConditionValue(condition.value)
@@ -1339,9 +1367,9 @@ function isConditionLeafComplete(condition: AutomationCondition): boolean {
   if (isUnaryOperator(condition.operator)) return true
   const fieldType = conditionFieldType(condition.fieldId)
   if (isArrayOperator(condition.operator)) {
-    return isNumericConditionFieldType(fieldType)
-      ? parseNumericConditionArrayValue(condition.value) !== null
-      : parseConditionArrayValue(condition.value).length > 0
+    if (isNumericConditionFieldType(fieldType)) return parseNumericConditionArrayValue(condition.value) !== null
+    if (fieldType === 'boolean') return parseBooleanConditionArrayValue(condition.value) !== null
+    return parseConditionArrayValue(condition.value).length > 0
   }
   if (isNumericConditionFieldType(fieldType)) return parseNumberConditionValue(condition.value) !== null
   if (fieldType === 'boolean') return parseBooleanConditionValue(condition.value) !== null

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -473,6 +473,80 @@ describe('MetaAutomationRuleEditor', () => {
     })
   })
 
+  it('serializes boolean list condition values as booleans', async () => {
+    const saved = vi.fn()
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, onSave: saved })
+    await flushPromises()
+
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    nameInput.value = 'Done list condition'
+    nameInput.dispatchEvent(new Event('input'))
+
+    ;(container.querySelector('[data-action="add-condition"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    const conditionRow = container.querySelector('[data-condition-index="0"]') as HTMLElement
+    const [fieldSelect] = Array.from(conditionRow.querySelectorAll('select')) as HTMLSelectElement[]
+    fieldSelect.value = 'fld_done'
+    fieldSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const operatorSelect = Array.from(conditionRow.querySelectorAll('select'))[1] as HTMLSelectElement
+    operatorSelect.value = 'in'
+    operatorSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const valueSelect = conditionRow.querySelector('[data-condition-value="boolean-multi-select"]') as HTMLSelectElement
+    expect(valueSelect.multiple).toBe(true)
+    valueSelect.options[0].selected = true
+    valueSelect.options[1].selected = true
+    valueSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    ;(container.querySelector('[data-action="save"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    expect(saved).toHaveBeenCalledTimes(1)
+    expect(saved.mock.calls[0][0].conditions).toEqual({
+      conjunction: 'AND',
+      conditions: [{ fieldId: 'fld_done', operator: 'in', value: [true, false] }],
+    })
+  })
+
+  it('keeps save disabled for empty boolean list condition values', async () => {
+    const saved = vi.fn()
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, onSave: saved })
+    await flushPromises()
+
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    nameInput.value = 'Empty done list condition'
+    nameInput.dispatchEvent(new Event('input'))
+
+    ;(container.querySelector('[data-action="add-condition"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    const conditionRow = container.querySelector('[data-condition-index="0"]') as HTMLElement
+    const [fieldSelect] = Array.from(conditionRow.querySelectorAll('select')) as HTMLSelectElement[]
+    fieldSelect.value = 'fld_done'
+    fieldSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const operatorSelect = Array.from(conditionRow.querySelectorAll('select'))[1] as HTMLSelectElement
+    operatorSelect.value = 'not_in'
+    operatorSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const valueSelect = conditionRow.querySelector('[data-condition-value="boolean-multi-select"]') as HTMLSelectElement
+    expect(valueSelect.multiple).toBe(true)
+
+    const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(true)
+    saveBtn.click()
+    await flushPromises()
+
+    expect(saved).not.toHaveBeenCalled()
+  })
+
   it('uses configured select options for single-value conditions', async () => {
     const saved = vi.fn()
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, onSave: saved })

--- a/docs/development/multitable-automation-boolean-list-condition-development-20260512.md
+++ b/docs/development/multitable-automation-boolean-list-condition-development-20260512.md
@@ -1,0 +1,58 @@
+# Multitable Automation Boolean List Condition Development - 2026-05-12
+
+## Context
+
+Automation conditions already expose `in` / `not_in` for boolean fields, and
+backend field-aware validation accepts boolean arrays for those operators. The
+frontend editor still rendered the single-value true/false select for boolean
+fields even after switching the operator to `in` or `not_in`.
+
+That made boolean list conditions impossible to save: the draft value became a
+single boolean, while the editor completeness check expected a list.
+
+## Scope
+
+Implemented:
+
+- Added a boolean multi-select value widget for boolean `in` / `not_in`
+  conditions.
+- Serialized boolean list condition payloads as `boolean[]`.
+- Kept Save disabled when a boolean list condition has no selected values.
+- Preserved existing single-value boolean behavior for `equals` /
+  `not_equals`.
+- Added unit coverage for both the happy path and empty-list disabled state.
+
+Not implemented:
+
+- No backend changes.
+- No evaluator changes.
+- No browser smoke.
+
+## Design Decisions
+
+### Match Backend Contract
+
+The backend already validates boolean list values as booleans. The frontend now
+emits the same primitive shape instead of string arrays or a scalar boolean.
+
+### Dedicated Boolean Multi-Select
+
+Reusing the option-backed `multiSelect` path would require fake field options.
+A dedicated widget keeps the true/false choices explicit and avoids conflating
+boolean fields with select fields.
+
+### Empty List Is Incomplete
+
+An empty `in` / `not_in` condition is not useful and would be rejected by the
+backend semantic validator. The editor therefore keeps Save disabled until at
+least one boolean value is selected.
+
+## Files Changed
+
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+
+## Follow-Ups
+
+- Add async option/value validation for person/link/lookup once those option
+  sources are standardized.

--- a/docs/development/multitable-automation-boolean-list-condition-verification-20260512.md
+++ b/docs/development/multitable-automation-boolean-list-condition-verification-20260512.md
@@ -1,0 +1,74 @@
+# Multitable Automation Boolean List Condition Verification - 2026-05-12
+
+## Environment
+
+- Worktree: `/private/tmp/ms2-boolean-condition-list-authoring-20260512`
+- Branch: `codex/multitable-boolean-condition-list-authoring-20260512`
+- Baseline: `origin/main@6777e3d80`
+- Scope: frontend automation editor boolean `in` / `not_in` authoring.
+
+## Commands
+
+### Install Workspace Links
+
+```bash
+pnpm install --ignore-scripts
+git restore -- plugins tools
+```
+
+Result:
+
+- workspace executable links restored for this temporary worktree;
+- dependency symlink dirt under `plugins/` and `tools/` reverted;
+- no dependency or lockfile changes remain in the business diff.
+
+### Automation Rule Editor Unit Tests
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/multitable-automation-rule-editor.spec.ts \
+  --watch=false
+```
+
+Expected:
+
+- existing automation rule editor behavior remains green;
+- scalar boolean conditions still serialize as booleans;
+- boolean `in` / `not_in` conditions render a true/false multi-select;
+- boolean list payloads serialize as `boolean[]`;
+- empty boolean list conditions keep Save disabled.
+
+Result:
+
+- 1 file passed.
+- 76 tests passed.
+
+### Frontend Type Check
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc --noEmit --pretty false
+```
+
+Expected: pass.
+
+Result:
+
+- pass.
+
+### Diff Hygiene
+
+```bash
+git diff --check
+```
+
+Expected: pass.
+
+Result:
+
+- pass.
+
+## Non-Verification
+
+- No backend tests were run because this slice is frontend-only.
+- No live browser smoke was run.
+- No staging automation rule was created.


### PR DESCRIPTION
## Summary

- add a dedicated true/false multi-select for boolean `in` / `not_in` automation conditions
- serialize boolean list condition values as `boolean[]` to match backend validation and evaluator semantics
- keep Save disabled when a boolean list condition has no selected values
- add development and verification MD artifacts

## Verification

- `pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts --watch=false` (76/76 pass)
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit --pretty false`
- `git diff --check origin/main..HEAD`
