### PR TITLE
docs(integration): record K3 WISE template package refresh

### DIFF
--- a/docs/development/integration-k3wise-template-onprem-package-refresh-development-20260512.md
+++ b/docs/development/integration-k3wise-template-onprem-package-refresh-development-20260512.md
@@ -1,0 +1,101 @@
+# K3 WISE Template On-Prem Package Refresh Development - 2026-05-12
+
+## Purpose
+
+Produce a Windows/on-prem deployment package after the K3 WISE material/BOM
+document-template work landed in main.
+
+This is an operations packaging slice. The product code already landed through
+PR #1476:
+
+- merge commit: `de3ba19ae`
+- scope: K3 WISE material/BOM template registry, dry-run K3 `Data` payload
+  preview, setup-page template preview, and package verify coverage
+
+The package in this refresh was built from current main:
+
+- package source SHA: `6777e3d80ab66ab5b489da2c3ae4b46c7f532524`
+- package tag: `k3wise-templates-6777e3d`
+
+## Workflow
+
+Triggered GitHub Actions workflow:
+
+- workflow: `Multitable On-Prem Package Build`
+- run id: `25718709234`
+- run URL: `https://github.com/zensgit/metasheet2/actions/runs/25718709234`
+- branch/ref: `main`
+- package tag: `k3wise-templates-6777e3d`
+- publish release: `false`
+
+Command:
+
+```bash
+gh workflow run "Multitable On-Prem Package Build" \
+  --repo zensgit/metasheet2 \
+  --ref main \
+  -f package_tag=k3wise-templates-6777e3d \
+  -f publish_release=false
+```
+
+## Output
+
+Artifact:
+
+- `multitable-onprem-package-25718709234-1`
+
+Files:
+
+- `metasheet-multitable-onprem-v2.5.0-k3wise-templates-6777e3d.zip`
+- `metasheet-multitable-onprem-v2.5.0-k3wise-templates-6777e3d.tgz`
+- `metasheet-multitable-onprem-v2.5.0-k3wise-templates-6777e3d.json`
+- `SHA256SUMS`
+
+Local download path used for verification:
+
+```text
+/tmp/metasheet2-k3wise-onprem-25718709234/
+```
+
+## Deployment Meaning
+
+Use the new `k3wise-templates-6777e3d` zip for the next Windows/entity-machine
+installation test.
+
+It supersedes earlier K3 WISE packages for ERP/PLM template testing because it
+includes:
+
+- simplified K3 WISE setup page
+- K3 WISE material/BOM document template registry
+- K3 setup-page template mapping table and read-only JSON preview
+- dry-run target K3 `Data` payload preview
+- K3 offline PoC mock chain updated to the v1 BOM template fields
+- packaged integration plugin backend and K3 operator runbooks
+
+## Deployment Order
+
+For a Windows/on-prem test box:
+
+1. Install or upgrade with the generated zip.
+2. Run the multitable on-prem preflight.
+3. Log in and open the K3 WISE setup page.
+4. Save K3 WebAPI configuration.
+5. Review `K3 单据模板` for material and BOM mappings.
+6. Use the JSON preview to confirm the generated `{ "Data": ... }` payload.
+7. Create draft pipelines.
+8. Run dry-run first and inspect `preview.records[].targetPayload.Data`.
+9. Only then enable Save-only live execution for 1-3 test rows.
+
+Submit/Audit remains outside this package refresh. It still needs explicit
+customer approval through the GATE process.
+
+## Non-Goals
+
+This refresh does not:
+
+- publish a GitHub Release
+- add or change database migrations
+- run against a real customer K3 WISE endpoint
+- validate customer unit-code dictionaries beyond the seed `PCS` / `EA` / `KG`
+- enable purchase order, sales order, stock-in, or other K3 document templates
+- deploy to the Windows server from this local session

--- a/docs/development/integration-k3wise-template-onprem-package-refresh-verification-20260512.md
+++ b/docs/development/integration-k3wise-template-onprem-package-refresh-verification-20260512.md
@@ -1,0 +1,134 @@
+# K3 WISE Template On-Prem Package Refresh Verification - 2026-05-12
+
+## Scope
+
+Verify the on-prem package built from main after PR #1476 so the next
+Windows/entity-machine deployment can test:
+
+- K3 WISE setup page template cards
+- material/BOM field mapping table
+- read-only K3 `Data` JSON preview
+- dry-run target payload preview
+- Save-only material/BOM mock chain
+
+Workflow run:
+
+- URL: `https://github.com/zensgit/metasheet2/actions/runs/25718709234`
+- workflow: `Multitable On-Prem Package Build`
+- conclusion: `success`
+- head SHA: `6777e3d80ab66ab5b489da2c3ae4b46c7f532524`
+- event: `workflow_dispatch`
+
+## Artifact Download
+
+Command:
+
+```bash
+rm -rf /tmp/metasheet2-k3wise-onprem-25718709234
+mkdir -p /tmp/metasheet2-k3wise-onprem-25718709234
+gh run download 25718709234 \
+  --repo zensgit/metasheet2 \
+  -n multitable-onprem-package-25718709234-1 \
+  -D /tmp/metasheet2-k3wise-onprem-25718709234
+```
+
+Downloaded files:
+
+```text
+/tmp/metasheet2-k3wise-onprem-25718709234/SHA256SUMS
+/tmp/metasheet2-k3wise-onprem-25718709234/metasheet-multitable-onprem-v2.5.0-k3wise-templates-6777e3d.json
+/tmp/metasheet2-k3wise-onprem-25718709234/metasheet-multitable-onprem-v2.5.0-k3wise-templates-6777e3d.tgz
+/tmp/metasheet2-k3wise-onprem-25718709234/metasheet-multitable-onprem-v2.5.0-k3wise-templates-6777e3d.tgz.sha256
+/tmp/metasheet2-k3wise-onprem-25718709234/metasheet-multitable-onprem-v2.5.0-k3wise-templates-6777e3d.zip
+/tmp/metasheet2-k3wise-onprem-25718709234/metasheet-multitable-onprem-v2.5.0-k3wise-templates-6777e3d.zip.sha256
+```
+
+## Checksums
+
+```text
+47b990a95f65bd00aa6a1b505f3c858db915e7b1a7b461ce6a01121a646e031e  metasheet-multitable-onprem-v2.5.0-k3wise-templates-6777e3d.zip
+38d2d1785a6266c8266cc0c06b7f518947286c7df22187a57b5c4a1cad5557b1  metasheet-multitable-onprem-v2.5.0-k3wise-templates-6777e3d.tgz
+```
+
+## Package Metadata
+
+```json
+{
+  "name": "metasheet-multitable-onprem-v2.5.0-k3wise-templates-6777e3d",
+  "version": "2.5.0",
+  "tag": "k3wise-templates-6777e3d",
+  "attendanceOnly": false,
+  "productMode": "platform",
+  "includedPlugins": ["plugin-attendance", "plugin-integration-core"],
+  "archive": "metasheet-multitable-onprem-v2.5.0-k3wise-templates-6777e3d.tgz",
+  "archiveZip": "metasheet-multitable-onprem-v2.5.0-k3wise-templates-6777e3d.zip",
+  "checksumFile": "SHA256SUMS",
+  "generatedAt": "2026-05-12T06:58:37Z"
+}
+```
+
+## Verify Script
+
+Commands:
+
+```bash
+scripts/ops/multitable-onprem-package-verify.sh \
+  /tmp/metasheet2-k3wise-onprem-25718709234/metasheet-multitable-onprem-v2.5.0-k3wise-templates-6777e3d.zip
+
+scripts/ops/multitable-onprem-package-verify.sh \
+  /tmp/metasheet2-k3wise-onprem-25718709234/metasheet-multitable-onprem-v2.5.0-k3wise-templates-6777e3d.tgz
+```
+
+Result:
+
+```text
+metasheet-multitable-onprem-v2.5.0-k3wise-templates-6777e3d.zip: OK
+metasheet-multitable-onprem-v2.5.0-k3wise-templates-6777e3d.tgz: OK
+```
+
+## K3 WISE Content Checks
+
+The zip contains the template runtime:
+
+```text
+plugins/plugin-integration-core/lib/adapters/k3-wise-document-templates.cjs
+plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
+```
+
+The zip contains the built K3 WISE setup page assets:
+
+```text
+apps/web/dist/assets/IntegrationK3WiseSetupView-DUXQEbav.css
+apps/web/dist/assets/IntegrationK3WiseSetupView-B4rDUAbD.js
+```
+
+The zip contains the K3 PoC scripts and runbooks:
+
+```text
+scripts/ops/integration-k3wise-live-poc-preflight.mjs
+scripts/ops/integration-k3wise-live-poc-evidence.mjs
+scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs
+docs/operations/integration-k3wise-live-gate-execution-package.md
+docs/operations/k3-poc-onprem-preflight-runbook.md
+```
+
+## Result
+
+The `k3wise-templates-6777e3d` on-prem package is ready for the next
+Windows/entity-machine deployment test.
+
+Use:
+
+```text
+/tmp/metasheet2-k3wise-onprem-25718709234/metasheet-multitable-onprem-v2.5.0-k3wise-templates-6777e3d.zip
+```
+
+Do not use older K3 WISE packages for ERP/PLM template verification, because
+they do not include PR #1476's template registry and dry-run K3 payload preview.
+
+## Remaining Live Blocker
+
+Customer live K3 WISE remains blocked on GATE answers. The package is ready for
+local/on-prem configuration and dry-run preview testing, but a real K3 Save-only
+run still needs customer K3 URL, account set, credentials, unit-code mapping,
+and rollback agreement.


### PR DESCRIPTION
## Summary
- Record the K3 WISE template on-prem package refresh built from main SHA 6777e3d80.
- Document workflow run 25718709234, package tag k3wise-templates-6777e3d, artifact contents, checksums, and deployment order.
- Capture verification evidence for zip/tgz package verify and K3 template/runtime/runbook inclusion.

## Verification
- Multitable On-Prem Package Build run 25718709234: success
- Downloaded artifact multitable-onprem-package-25718709234-1
- scripts/ops/multitable-onprem-package-verify.sh passed for zip and tgz
- zip content check found k3-wise-document-templates.cjs, k3-wise-webapi-adapter.cjs, K3 setup page assets, live PoC scripts, and K3 runbooks
- git diff --check

## Deployment impact
- Docs only.
- The package to use for the next Windows/entity-machine test is metasheet-multitable-onprem-v2.5.0-k3wise-templates-6777e3d.zip.

## GATE status
- Customer live K3 Save-only remains blocked on GATE answers.