### PR TITLE
fix(multitable): validate automation select option conditions

### DIFF
--- a/docs/development/multitable-automation-select-option-validation-development-20260512.md
+++ b/docs/development/multitable-automation-select-option-validation-development-20260512.md
@@ -1,0 +1,50 @@
+# Multitable Automation Select Option Validation Development
+
+Date: 2026-05-12
+Branch: `codex/multitable-automation-select-option-validation-20260512`
+Baseline: `origin/main@7a5902f92`
+
+## Context
+
+The previous automation condition hardening validated field existence, operator
+compatibility, and primitive value types at the route boundary. Direct API
+clients could still save `select` or `multiSelect` condition values that were
+not present in the field's configured options.
+
+The frontend already presents configured option pickers when `field.options`
+are available, so this slice closes the backend/API gap without changing the
+condition payload shape.
+
+## Design
+
+- `preflightAutomationConditionFields()` now reads `property` from
+  `meta_fields` in addition to `id` and `type`.
+- `AutomationConditionField` carries optional raw `property` data.
+- The condition validator resolves option values from
+  `property.options[].value` for `select` and `multiSelect` fields.
+- When configured options exist, value-bearing operators must reference one of
+  those option values.
+- The validator reports exact nested paths such as
+  `conditions.conditions[0].value[1]` for list operators.
+
+## Compatibility
+
+- Fields without a normalized `options` array keep the previous behavior. This
+  avoids breaking historical fields or imported data that lack standardized
+  option metadata.
+- Empty-state operators (`is_empty`, `is_not_empty`) do not inspect option
+  values.
+- No migration, frontend change, or execution-time evaluator change is needed.
+
+## Files Changed
+
+- `packages/core-backend/src/multitable/automation-conditions.ts`
+- `packages/core-backend/src/multitable/automation-service.ts`
+- `packages/core-backend/tests/unit/multitable-automation-conditions.test.ts`
+- `packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts`
+
+## Follow-Ups
+
+- Person/user/link/lookup condition values still only receive primitive type
+  validation. Stronger validation would require sheet/user/link target lookup
+  and should be handled as a separate, narrower slice.

--- a/docs/development/multitable-automation-select-option-validation-verification-20260512.md
+++ b/docs/development/multitable-automation-select-option-validation-verification-20260512.md
@@ -1,0 +1,48 @@
+# Multitable Automation Select Option Validation Verification
+
+Date: 2026-05-12
+Branch: `codex/multitable-automation-select-option-validation-20260512`
+Baseline: `origin/main@7a5902f92`
+
+## Scope
+
+Verify backend route-boundary validation for `select` and `multiSelect`
+automation condition option values.
+
+## Commands
+
+```bash
+pnpm install --ignore-scripts
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/multitable-automation-conditions.test.ts \
+  tests/integration/dingtalk-automation-link-routes.api.test.ts \
+  --reporter=dot
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+git diff --check
+git restore plugins tools
+```
+
+## Results
+
+- `vitest`: passed, 2 files / 48 tests.
+- `tsc --noEmit`: passed.
+- `git diff --check`: passed.
+- `pnpm install --ignore-scripts` created workspace dependency-link noise under
+  `plugins/` and `tools/`; those paths were restored before commit.
+
+## Assertions Added
+
+- Unit coverage accepts configured select/multiSelect option values.
+- Unit coverage rejects unknown scalar select values.
+- Unit coverage rejects unknown list entries with indexed error paths.
+- Unit coverage preserves backward compatibility for select-like fields without
+  configured options.
+- Route coverage rejects unknown select options on create before persistence.
+- Route coverage rejects unknown multiSelect options on update before
+  persistence.
+
+## Not Covered
+
+- Live PostgreSQL replay is not required; this slice only extends the existing
+  field metadata query and pure validator logic.
+- Frontend rendering is unchanged.

--- a/packages/core-backend/src/multitable/automation-conditions.ts
+++ b/packages/core-backend/src/multitable/automation-conditions.ts
@@ -100,6 +100,7 @@ export interface AutomationCondition {
 export type AutomationConditionField = {
   id: string
   type: string
+  property?: unknown
 }
 
 export type AutomationConditionNode = AutomationCondition | ConditionGroup
@@ -123,6 +124,38 @@ function isConditionGroup(node: AutomationConditionNode): node is ConditionGroup
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+function normalizeJsonObject(value: unknown): Record<string, unknown> {
+  if (isPlainObject(value)) return value
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value) as unknown
+      return isPlainObject(parsed) ? parsed : {}
+    } catch {
+      return {}
+    }
+  }
+  return {}
+}
+
+function configuredOptionValuesForField(field: AutomationConditionField): Set<string> | null {
+  if (field.type !== 'select' && field.type !== 'multiSelect') return null
+
+  const property = normalizeJsonObject(field.property)
+  const options = property.options
+  if (!Array.isArray(options)) return null
+
+  const values: string[] = []
+  for (const option of options) {
+    if (!isPlainObject(option)) continue
+    const value = option.value
+    if (typeof value === 'string' || typeof value === 'number') {
+      values.push(String(value))
+    }
+  }
+
+  return values.length > 0 ? new Set(values) : null
 }
 
 function resolveGroupLogic(conditionGroup: ConditionGroup): 'and' | 'or' {
@@ -320,6 +353,33 @@ function assertConditionValueType(
   })
 }
 
+function assertConditionOptionValues(
+  condition: AutomationCondition,
+  field: AutomationConditionField,
+  path: string,
+): void {
+  if (!VALUE_REQUIRED_OPERATORS.has(condition.operator)) return
+
+  const optionValues = configuredOptionValuesForField(field)
+  if (!optionValues) return
+
+  const values = ARRAY_VALUE_OPERATORS.has(condition.operator)
+    ? condition.value as unknown[]
+    : [condition.value]
+
+  values.forEach((value, index) => {
+    if (typeof value !== 'string') return
+    if (optionValues.has(value)) return
+
+    const valuePath = ARRAY_VALUE_OPERATORS.has(condition.operator)
+      ? `${path}.value[${index}]`
+      : `${path}.value`
+    throw new ConditionGroupValidationError(
+      `${valuePath} is not a configured option for field ${field.id}: ${value}`,
+    )
+  })
+}
+
 function validateConditionNodeAgainstFields(
   node: AutomationConditionNode,
   fieldsById: Map<string, AutomationConditionField>,
@@ -345,6 +405,7 @@ function validateConditionNodeAgainstFields(
   }
 
   assertConditionValueType(node, field.type, path)
+  assertConditionOptionValues(node, field, path)
 }
 
 export function validateConditionGroupAgainstFields(

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -155,7 +155,8 @@ function serializeAutomationConditionFieldRows(rows: unknown[]): AutomationCondi
       const record = row as Record<string, unknown>
       const id = typeof record.id === 'string' ? record.id : ''
       const type = typeof record.type === 'string' ? record.type : ''
-      return id && type ? { id, type } : null
+      const property = Object.prototype.hasOwnProperty.call(record, 'property') ? record.property : undefined
+      return id && type ? { id, type, ...(property !== undefined ? { property } : {}) } : null
     })
     .filter((field): field is AutomationConditionField => !!field)
 }
@@ -941,7 +942,7 @@ export async function preflightAutomationConditionFields(
   if (!conditions) return
 
   const fieldRes = await queryFn(
-    'SELECT id, type FROM meta_fields WHERE sheet_id = $1',
+    'SELECT id, type, property FROM meta_fields WHERE sheet_id = $1',
     [sheetId],
   )
   try {

--- a/packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts
+++ b/packages/core-backend/tests/integration/dingtalk-automation-link-routes.api.test.ts
@@ -31,6 +31,7 @@ type FieldRow = {
   id: string
   sheet_id: string
   type: string
+  property?: Record<string, unknown> | string | null
 }
 
 function makePublicFormConfig(options: {
@@ -93,6 +94,7 @@ function createDingTalkLinkQueryHandler(views = makeViewRows(), fields: FieldRow
         .map((field) => ({
           id: field.id,
           type: field.type,
+          property: field.property,
         }))
       return { rows, rowCount: rows.length }
     }
@@ -611,6 +613,40 @@ describe('DingTalk automation link route validation', () => {
     }))
   })
 
+  it('rejects unknown select options before persisting the rule', async () => {
+    const { app, automationService } = await createApp({
+      queryHandler: createDingTalkLinkQueryHandler(makeViewRows(), [
+        {
+          id: 'fld_status',
+          sheet_id: SHEET_ID,
+          type: 'select',
+          property: { options: [{ value: 'Ready' }, { value: 'Blocked' }] },
+        },
+      ]),
+    })
+
+    const res = await request(app)
+      .post(`/api/multitable/sheets/${SHEET_ID}/automations`)
+      .send({
+        name: 'Condition option guard',
+        triggerType: 'record.created',
+        triggerConfig: {},
+        actionType: 'send_notification',
+        actionConfig: {},
+        conditions: {
+          conjunction: 'AND',
+          conditions: [{ fieldId: 'fld_status', operator: 'equals', value: 'Done' }],
+        },
+      })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toEqual({
+      code: 'VALIDATION_ERROR',
+      message: 'conditions.conditions[0].value is not a configured option for field fld_status: Done',
+    })
+    expect(automationService.createRule).not.toHaveBeenCalled()
+  })
+
   it('rejects field-incompatible automation conditions on update before persisting', async () => {
     const automationService = createMockAutomationService()
     const { app } = await createApp({
@@ -633,6 +669,37 @@ describe('DingTalk automation link route validation', () => {
     expect(res.body.error).toEqual({
       code: 'VALIDATION_ERROR',
       message: 'conditions.conditions[0].operator contains is not supported for field type number',
+    })
+    expect(automationService.updateRule).not.toHaveBeenCalled()
+  })
+
+  it('rejects unknown multiSelect options on update before persisting', async () => {
+    const automationService = createMockAutomationService()
+    const { app } = await createApp({
+      automationService,
+      queryHandler: createDingTalkLinkQueryHandler(makeViewRows(), [
+        {
+          id: 'fld_tags',
+          sheet_id: SHEET_ID,
+          type: 'multiSelect',
+          property: { options: [{ value: 'VIP' }, { value: 'Internal' }] },
+        },
+      ]),
+    })
+
+    const res = await request(app)
+      .patch(`/api/multitable/sheets/${SHEET_ID}/automations/${RULE_ID}`)
+      .send({
+        conditions: {
+          conjunction: 'AND',
+          conditions: [{ fieldId: 'fld_tags', operator: 'in', value: ['VIP', 'External'] }],
+        },
+      })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toEqual({
+      code: 'VALIDATION_ERROR',
+      message: 'conditions.conditions[0].value[1] is not a configured option for field fld_tags: External',
     })
     expect(automationService.updateRule).not.toHaveBeenCalled()
   })

--- a/packages/core-backend/tests/unit/multitable-automation-conditions.test.ts
+++ b/packages/core-backend/tests/unit/multitable-automation-conditions.test.ts
@@ -196,4 +196,54 @@ describe('multitable automation conditions', () => {
       }],
     }, fields)).toThrow('conditions.conditions[0].conditions[0].value must not be empty for in')
   })
+
+  it('validates select and multiSelect condition values against configured options', () => {
+    const fields = [
+      {
+        id: 'status',
+        type: 'select',
+        property: { options: [{ value: 'Ready' }, { value: 'Blocked' }] },
+      },
+      {
+        id: 'tags',
+        type: 'multiSelect',
+        property: { options: [{ value: 'VIP' }, { value: 'Internal' }] },
+      },
+    ]
+
+    expect(() => validateConditionGroupAgainstFields({
+      conjunction: 'AND',
+      conditions: [
+        { fieldId: 'status', operator: 'equals', value: 'Ready' },
+        { fieldId: 'status', operator: 'in', value: ['Ready', 'Blocked'] },
+        { fieldId: 'tags', operator: 'contains', value: 'VIP' },
+        { fieldId: 'tags', operator: 'not_in', value: ['Internal'] },
+      ],
+    }, fields)).not.toThrow()
+
+    expect(() => validateConditionGroupAgainstFields({
+      conjunction: 'AND',
+      conditions: [{ fieldId: 'status', operator: 'equals', value: 'Done' }],
+    }, fields)).toThrow('conditions.conditions[0].value is not a configured option for field status: Done')
+
+    expect(() => validateConditionGroupAgainstFields({
+      conjunction: 'AND',
+      conditions: [{ fieldId: 'tags', operator: 'not_in', value: ['VIP', 'External'] }],
+    }, fields)).toThrow('conditions.conditions[0].value[1] is not a configured option for field tags: External')
+  })
+
+  it('keeps select-like fields without configured options backward compatible', () => {
+    const fields = [
+      { id: 'status', type: 'select', property: { options: [] } },
+      { id: 'tags', type: 'multiSelect', property: {} },
+    ]
+
+    expect(() => validateConditionGroupAgainstFields({
+      conjunction: 'AND',
+      conditions: [
+        { fieldId: 'status', operator: 'equals', value: 'Legacy status' },
+        { fieldId: 'tags', operator: 'in', value: ['Legacy tag'] },
+      ],
+    }, fields)).not.toThrow()
+  })
 })


### PR DESCRIPTION
## Summary
- extend automation condition preflight to load field `property` metadata
- reject direct API select/multiSelect condition values that are not configured options
- preserve compatibility for select-like fields without configured options

## Verification
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/multitable-automation-conditions.test.ts tests/integration/dingtalk-automation-link-routes.api.test.ts --reporter=dot
- pnpm --filter @metasheet/core-backend exec tsc --noEmit
- git diff --check

## Docs
- docs/development/multitable-automation-select-option-validation-development-20260512.md
- docs/development/multitable-automation-select-option-validation-verification-20260512.md