### PR TITLE
fix(multitable): clear stale automation condition values

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -1232,6 +1232,8 @@ function onConditionFieldChange(condition: AutomationCondition, fieldId: string)
   const allowedOperators = conditionOperatorsForField(fieldId)
   if (!previousFieldId || !allowedOperators.some((operator) => operator.value === condition.operator)) {
     condition.operator = firstOperatorForField(fieldId)
+  }
+  if (previousFieldId !== fieldId) {
     resetConditionValue(condition)
   }
 }

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -581,6 +581,70 @@ describe('MetaAutomationRuleEditor', () => {
     })
   })
 
+  it('clears stale condition values when switching between compatible fields', async () => {
+    const saved = vi.fn()
+    const fieldsWithSecondSelect = [
+      ...fields,
+      {
+        id: 'fld_stage',
+        name: 'Stage',
+        type: 'select',
+        options: [
+          { value: 'todo', label: 'Todo' },
+          { value: 'done', label: 'Done' },
+        ],
+      },
+    ]
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields: fieldsWithSecondSelect,
+      onSave: saved,
+    })
+    await flushPromises()
+
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    nameInput.value = 'Stage condition'
+    nameInput.dispatchEvent(new Event('input'))
+
+    ;(container.querySelector('[data-action="add-condition"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    const conditionRow = container.querySelector('[data-condition-index="0"]') as HTMLElement
+    const [fieldSelect, operatorSelect] = Array.from(conditionRow.querySelectorAll('select')) as HTMLSelectElement[]
+    fieldSelect.value = 'fld_priority'
+    fieldSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const priorityValueSelect = conditionRow.querySelector('[data-condition-value="select"]') as HTMLSelectElement
+    priorityValueSelect.value = 'high'
+    priorityValueSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+    expect((container.querySelector('[data-action="save"]') as HTMLButtonElement).disabled).toBe(false)
+
+    fieldSelect.value = 'fld_stage'
+    fieldSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const stageValueSelect = conditionRow.querySelector('[data-condition-value="select"]') as HTMLSelectElement
+    expect(operatorSelect.value).toBe('equals')
+    expect(stageValueSelect.value).toBe('')
+    expect((container.querySelector('[data-action="save"]') as HTMLButtonElement).disabled).toBe(true)
+
+    stageValueSelect.value = 'todo'
+    stageValueSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    ;(container.querySelector('[data-action="save"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    expect(saved).toHaveBeenCalledTimes(1)
+    expect(saved.mock.calls[0][0].conditions).toEqual({
+      conjunction: 'AND',
+      conditions: [{ fieldId: 'fld_stage', operator: 'equals', value: 'todo' }],
+    })
+  })
+
   it('uses configured select options for list membership conditions', async () => {
     const saved = vi.fn()
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, onSave: saved })

--- a/docs/development/multitable-automation-clear-stale-condition-value-development-20260512.md
+++ b/docs/development/multitable-automation-clear-stale-condition-value-development-20260512.md
@@ -1,0 +1,47 @@
+# Multitable Automation Clear Stale Condition Value Development
+
+Date: 2026-05-12
+Branch: `codex/multitable-automation-clear-stale-condition-value-20260512`
+Baseline: `origin/main@3ce512401`
+
+## Context
+
+The backend now validates configured `select` and `multiSelect` option values at
+the automation route boundary. The rule editor still had a stale-value UX gap:
+when a user changed a condition from one compatible field to another, the
+existing operator stayed valid and the old value was kept.
+
+Example:
+
+1. Choose `Priority equals high`.
+2. Change the field to another select field such as `Stage`.
+3. The editor could keep `high`, even if `Stage` does not define that option.
+
+That value would be rejected by the backend on save. This slice prevents the
+bad payload before submit.
+
+## Design
+
+- Keep the existing operator-reset behavior when the old operator is not
+  supported by the new field type.
+- Additionally clear the condition value whenever the selected `fieldId`
+  changes.
+- Preserve the operator when it remains compatible, so users do not lose their
+  intended comparison mode.
+- Leave same-field changes untouched; only actual field identity changes clear
+  value state.
+
+## Files Changed
+
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+
+## User-Facing Behavior
+
+Switching a condition field now clears the value control and disables Save until
+the user chooses or enters a value valid for the new field.
+
+## Follow-Ups
+
+- Async person/link/lookup option pickers remain separate work. This slice only
+  addresses stale editor state across field switches.

--- a/docs/development/multitable-automation-clear-stale-condition-value-verification-20260512.md
+++ b/docs/development/multitable-automation-clear-stale-condition-value-verification-20260512.md
@@ -1,0 +1,43 @@
+# Multitable Automation Clear Stale Condition Value Verification
+
+Date: 2026-05-12
+Branch: `codex/multitable-automation-clear-stale-condition-value-20260512`
+Baseline: `origin/main@3ce512401`
+
+## Scope
+
+Verify the frontend rule editor clears stale condition values when changing a
+condition field, while preserving compatible operators.
+
+## Commands
+
+```bash
+pnpm install --ignore-scripts
+pnpm --filter @metasheet/web exec vitest run \
+  tests/multitable-automation-rule-editor.spec.ts \
+  --watch=false
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+git diff --check
+git restore plugins tools
+```
+
+## Results
+
+- `multitable-automation-rule-editor.spec.ts`: passed, 77/77 tests.
+- `vue-tsc --noEmit`: passed.
+- `git diff --check`: passed.
+- `pnpm install --ignore-scripts` created workspace dependency-link noise under
+  `plugins/` and `tools/`; those paths were restored before commit.
+
+## Assertions Added
+
+- A condition can be authored as `Priority equals high`.
+- Changing the condition field to another select field keeps `equals`.
+- The old `high` value is cleared.
+- Save is disabled until a value for the new field is selected.
+- Saving after selecting the new value emits the new field/value pair only.
+
+## Not Covered
+
+- No backend route behavior changed in this slice.
+- No async option hydration for person/link/lookup fields was added.


### PR DESCRIPTION
## Summary
- clear condition values whenever the selected condition field changes
- preserve compatible operators, but prevent stale select/list values from being submitted for the new field
- add regression coverage for switching between compatible select fields

## Verification
- pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts --watch=false
- pnpm --filter @metasheet/web exec vue-tsc --noEmit
- git diff --check

## Docs
- docs/development/multitable-automation-clear-stale-condition-value-development-20260512.md
- docs/development/multitable-automation-clear-stale-condition-value-verification-20260512.md