### PR TITLE
docs(dingtalk): record oauth stability ops gap

### DIFF
--- a/docs/development/dingtalk-oauth-stability-opsgap-development-20260512.md
+++ b/docs/development/dingtalk-oauth-stability-opsgap-development-20260512.md
@@ -1,0 +1,90 @@
+# DingTalk OAuth Stability Ops Gap - Development
+
+- Date: 2026-05-12
+- Scope: scheduled `DingTalk OAuth Stability Recording (Lite)` health monitor.
+- Current main SHA inspected: `3ce51240190ba7e6b6af72e851b9b527f2b1f79e`
+- Latest failed run analyzed: `25719530101`
+- Run URL: `https://github.com/zensgit/metasheet2/actions/runs/25719530101`
+
+## Purpose
+
+Record the post-merge status of the scheduled DingTalk OAuth stability monitor and separate it from product/runtime delivery state.
+
+The K3 WISE package docs PR #1480 merged cleanly and the normal deploy gates passed. The remaining red workflow is the scheduled `DingTalk OAuth Stability Recording (Lite)` job. Its failure is an ops configuration gap, not a code regression from #1480, #1478, or the DingTalk runtime closeout.
+
+## Current Finding
+
+The workflow reached the remote host and completed the stability command:
+
+```text
+STABILITY_RC=0
+HEALTHY=false
+```
+
+The downloaded summary artifact reported:
+
+```text
+Health: status=ok plugins=13 ok=True
+Webhook: configured=False
+Alertmanager: activeAlerts=0 notifyErrors=0
+Storage: rootUse=91% maxUse=95%
+Failure reason: Alertmanager webhook is not configured
+Failure reason: No supported GitHub webhook secret was available for Alertmanager self-heal
+```
+
+The last 10 scheduled `DingTalk OAuth Stability Recording (Lite)` runs were all failures, across multiple SHAs. That makes this a persistent monitor configuration issue rather than a newly introduced runtime failure.
+
+## Required Ops Inputs
+
+One of the supported GitHub Actions secrets must be configured:
+
+- `ALERTMANAGER_WEBHOOK_URL`
+- `ALERT_WEBHOOK_URL`
+- `SLACK_WEBHOOK_URL`
+- `ATTENDANCE_ALERT_SLACK_WEBHOOK_URL`
+
+Current repo secret-name inspection found all four missing. Secret values are not readable from GitHub and were not printed or recorded.
+
+## Closure Procedure
+
+1. Prepare the Alertmanager webhook URL in a local environment variable or stdin. Do not paste it into chat or tracked files.
+2. Validate or set one supported GitHub Actions secret with:
+
+```bash
+printf '%s' "$ALERTMANAGER_WEBHOOK_URL" | \
+  node scripts/ops/set-dingtalk-alertmanager-webhook-secret.mjs \
+    --repo zensgit/metasheet2 \
+    --name ALERTMANAGER_WEBHOOK_URL \
+    --stdin
+```
+
+3. Re-run the scheduled monitor manually:
+
+```bash
+gh workflow run "DingTalk OAuth Stability Recording (Lite)" \
+  --repo zensgit/metasheet2 \
+  --ref main
+```
+
+4. Confirm the new run reports:
+
+```text
+STABILITY_RC=0
+HEALTHY=true
+Webhook: configured=True
+```
+
+5. If `HEALTHY=false` remains after the secret is present, inspect Alertmanager and bridge logs before changing application code.
+
+## Security Notes
+
+- This document records only secret names and redacted status.
+- It does not include webhook values, JWTs, bearer tokens, app secrets, temporary passwords, or DingTalk robot secrets.
+- The helper script validates supported secret names and webhook shape before writing to GitHub secrets.
+
+## Non-Goals
+
+- No runtime code changes.
+- No deployment change.
+- No attempt to bypass the hard `HEALTHY=true` workflow gate.
+- No replacement of the existing monitor workflow.

--- a/docs/development/dingtalk-oauth-stability-opsgap-verification-20260512.md
+++ b/docs/development/dingtalk-oauth-stability-opsgap-verification-20260512.md
@@ -1,0 +1,117 @@
+# DingTalk OAuth Stability Ops Gap - Verification
+
+- Date: 2026-05-12
+- Scope: scheduled `DingTalk OAuth Stability Recording (Lite)` failure classification.
+- Result: PASS for diagnosis; unresolved ops input remains.
+
+## Commands
+
+```bash
+gh run view 25719530101 \
+  --repo zensgit/metasheet2 \
+  --json databaseId,headSha,event,workflowName,status,conclusion,createdAt,updatedAt,url,jobs
+
+gh run view 25719530101 \
+  --repo zensgit/metasheet2 \
+  --log-failed
+
+gh run list \
+  --repo zensgit/metasheet2 \
+  --workflow "DingTalk OAuth Stability Recording (Lite)" \
+  --limit 10 \
+  --json databaseId,headSha,event,status,conclusion,createdAt,url
+
+gh secret list --repo zensgit/metasheet2 --json name,updatedAt
+
+gh run download 25719530101 \
+  --repo zensgit/metasheet2 \
+  -D /tmp/dingtalk-oauth-lite-25719530101
+
+node --test scripts/ops/dingtalk-oauth-stability-workflow-contract.test.mjs
+node --test scripts/ops/github-dingtalk-oauth-stability-summary.test.mjs
+node --test scripts/ops/set-dingtalk-alertmanager-webhook-secret.test.mjs
+bash -n scripts/ops/dingtalk-oauth-stability-check.sh
+bash -n scripts/ops/set-dingtalk-onprem-alertmanager-webhook-config.sh
+python3 -m py_compile scripts/ops/github-dingtalk-oauth-stability-summary.py
+git diff --check
+```
+
+## Observed Workflow Result
+
+```text
+workflow: DingTalk OAuth Stability Recording (Lite)
+run: 25719530101
+event: schedule
+headSha: e1677fd4d84dbf8f81ff353a7191e082fa5ec31d
+status: completed
+conclusion: failure
+job: stability-record
+failed step: Fail if stability check is unhealthy
+```
+
+Failed-step log:
+
+```text
+STABILITY_RC: 0
+HEALTHY: false
+stability check completed but reported healthy=false
+```
+
+Downloaded artifact summary:
+
+```text
+Overall: FAIL
+Stability rc: 0
+Healthy: false
+Webhook self-heal secret available: false
+Health: status=ok plugins=13 ok=True
+Webhook: configured=False host=
+Alertmanager: activeAlerts=0 notifyErrors=0
+Storage: rootUse=91% availKBlocks=7128380 maxUse=95%
+Failure reason: Alertmanager webhook is not configured
+Failure reason: No supported GitHub webhook secret was available for Alertmanager self-heal
+```
+
+## Secret Name Inspection
+
+Supported webhook secret names checked:
+
+| Secret name | Status |
+| --- | --- |
+| `ALERTMANAGER_WEBHOOK_URL` | missing |
+| `ALERT_WEBHOOK_URL` | missing |
+| `SLACK_WEBHOOK_URL` | missing |
+| `ATTENDANCE_ALERT_SLACK_WEBHOOK_URL` | missing |
+
+Only secret names were inspected. No secret values were read or printed.
+
+## Trend
+
+The last 10 scheduled `DingTalk OAuth Stability Recording (Lite)` runs were all failures. They span multiple main SHAs, including runs before and after the K3 package docs merge, so this is not attributable to the docs-only PR #1480.
+
+## Local Contract Checks
+
+| Check | Result |
+| --- | --- |
+| OAuth stability workflow contract test | PASS |
+| OAuth stability summary renderer test | PASS |
+| Alertmanager webhook secret setter test | PASS |
+| `dingtalk-oauth-stability-check.sh` syntax | PASS |
+| `set-dingtalk-onprem-alertmanager-webhook-config.sh` syntax | PASS |
+| `github-dingtalk-oauth-stability-summary.py` compile | PASS |
+| Whitespace diff check | PASS |
+
+## Classification
+
+This is a persistent ops configuration blocker for the scheduled monitor:
+
+- application health is OK;
+- Alertmanager has no active alerts and no notify errors;
+- the stability command exits successfully;
+- the hard gate fails because the webhook is unconfigured and no supported GitHub secret exists for self-heal.
+
+## Remaining Action
+
+Configure one supported GitHub Actions webhook secret, trigger `DingTalk OAuth Stability Recording (Lite)` manually, and require a new run with `HEALTHY=true`.
+
+Until that is done, deploy gates can be treated as passing, but the scheduled OAuth stability monitor must remain explicitly listed as a non-blocking ops follow-up rather than described as green.


### PR DESCRIPTION
## Summary
- document the current DingTalk OAuth Stability Recording (Lite) red state as an ops configuration gap
- record the latest failed run evidence and supported GitHub webhook secret names without exposing secret values
- add a verification/closure checklist for configuring the Alertmanager webhook and rerunning the scheduled stability workflow

## Verification
- node --test scripts/ops/dingtalk-oauth-stability-workflow-contract.test.mjs scripts/ops/github-dingtalk-oauth-stability-summary.test.mjs scripts/ops/set-dingtalk-alertmanager-webhook-secret.test.mjs
- bash -n scripts/ops/dingtalk-oauth-stability-check.sh && bash -n scripts/ops/set-dingtalk-onprem-alertmanager-webhook-config.sh && python3 -m py_compile scripts/ops/github-dingtalk-oauth-stability-summary.py
- git diff --check
- staged diff secret-pattern scan: no findings

## Notes
- docs-only change; no runtime behavior change
- closure still requires ops to provide the real webhook secret, then rerun DingTalk OAuth Stability Recording (Lite) until HEALTHY=true