### PR TITLE
fix(migrations): guard gallery form legacy schema

### DIFF
--- a/docs/development/migration-037-gallery-form-compat-design-20260512.md
+++ b/docs/development/migration-037-gallery-form-compat-design-20260512.md
@@ -1,0 +1,97 @@
+# Migration 037 Gallery/Form Compatibility Fix
+
+## Purpose
+
+Fix the on-prem upgrade failure reported in #651:
+
+```text
+037_add_gallery_form_support failed because form_responses.form_id does not exist
+```
+
+The failure appears when a database has already received the timestamp-based
+view/form migrations, then later receives the legacy numeric SQL migration
+`037_add_gallery_form_support.sql` through the packaged migration provider.
+
+## Root Cause
+
+`037_add_gallery_form_support.sql` used table-level guards:
+
+```sql
+CREATE TABLE IF NOT EXISTS form_responses (...)
+```
+
+That is not enough for mixed migration histories. If `form_responses` already
+exists with the timestamp migration shape:
+
+```text
+form_responses(view_id, data, submitted_by, submitted_at, status, ...)
+```
+
+then `CREATE TABLE IF NOT EXISTS` is a no-op. The migration then immediately
+ran:
+
+```sql
+CREATE INDEX IF NOT EXISTS idx_form_responses_form_id ON form_responses(form_id);
+```
+
+That column only exists in the older 037 table shape, so PostgreSQL correctly
+failed the migration.
+
+The same class of issue also existed later in the migration for:
+
+- `view_configs` optional indexes and demo seed rows
+- `view_states.updated_at` trigger creation
+- `view_states.state_data` comments
+- `form_responses.response_data` comments
+
+Those would be the next upgrade traps after `form_id` was fixed.
+
+## Design
+
+The migration remains forward-only and idempotent. It does not rewrite existing
+timestamp-based tables into the older 037 shape.
+
+Instead, 037 now uses column-aware guards before every optional index, trigger,
+and column comment:
+
+- If the old 037-created table exists, the matching indexes/comments/triggers
+  are still created.
+- If the newer timestamp-created table already exists, incompatible 037-only
+  references are skipped.
+- Existing `view_id/data` form response schema stays intact.
+
+This is intentionally narrower than adding compatibility columns such as
+`form_id` and `response_data`. The current runtime code uses the timestamp-based
+view/form schema, and adding unused alias columns would make the production
+schema harder to reason about.
+
+## Files Changed
+
+- `packages/core-backend/migrations/037_add_gallery_form_support.sql`
+  - Guard `view_configs` indexes by column existence.
+  - Guard `view_configs` demo seed rows by the full legacy 037 seed column
+    shape.
+  - Guard `view_states` index and `updated_at` trigger by column existence.
+  - Guard `form_responses` indexes by column existence, especially `form_id`.
+  - Guard optional column comments by column existence.
+- `packages/core-backend/tests/unit/gallery-form-sql-migration.test.ts`
+  - Static regression tests for the compatibility guards.
+
+## Deployment Impact
+
+This fix changes only the migration script and a unit test. It has no runtime
+API, frontend, or K3 WISE business logic impact.
+
+For an on-prem host currently stuck before applying 037:
+
+1. Deploy a package containing this fix.
+2. Re-run the normal on-prem migration step.
+3. The old timestamp-shaped `form_responses(view_id, data, ...)` table should
+   no longer block 037.
+
+## Non-goals
+
+- Do not merge the numeric and timestamp migration systems in this PR.
+- Do not add a new migration ledger.
+- Do not rewrite `form_responses` data.
+- Do not change K3 WISE template behavior.

--- a/docs/development/migration-037-gallery-form-compat-verification-20260512.md
+++ b/docs/development/migration-037-gallery-form-compat-verification-20260512.md
@@ -1,0 +1,218 @@
+# Migration 037 Gallery/Form Compatibility Verification
+
+## Scope
+
+Verify the fix for the on-prem migration failure where
+`037_add_gallery_form_support.sql` referenced `form_responses.form_id` on a
+database whose `form_responses` table had already been created by the
+timestamp-based view migrations.
+
+## Static Regression Tests
+
+Command:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/gallery-form-sql-migration.test.ts --reporter=dot
+```
+
+Result:
+
+```text
+Test Files  1 passed (1)
+Tests       4 passed (4)
+```
+
+The test asserts:
+
+- `view_configs` optional indexes and demo seed rows are guarded by column
+  existence.
+- `idx_form_responses_form_id` is only created after a
+  `form_responses.form_id` column-existence guard.
+- other `form_responses` legacy indexes are guarded by their target columns.
+- `idx_view_states_user` is only created after a `view_states.user_id` guard.
+- `update_view_states_updated_at` is only created after a
+  `view_states.updated_at` column-existence guard.
+- Optional comments on `view_states.state_data` and
+  `form_responses.response_data` are column-guarded.
+
+## Related Migration Unit Tests
+
+Command:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/plugin-infrastructure-sql-migration.test.ts \
+  tests/unit/gallery-form-sql-migration.test.ts \
+  tests/unit/migration-provider.test.ts \
+  --reporter=dot
+```
+
+Result:
+
+```text
+Test Files  3 passed (3)
+Tests       12 passed (12)
+```
+
+This keeps the new 037 guard coverage adjacent to the existing SQL migration
+guard tests and confirms the migration provider still loads SQL migrations from
+the package paths.
+
+## Real Postgres Rehearsal
+
+Local Postgres was available on `localhost:5432`. I created a throwaway
+database, recreated the timestamp-based `view_states` and `form_responses`
+shape, applied 037, then dropped the throwaway database.
+
+Setup shape:
+
+```text
+form_responses(id, view_id, data, submitted_by, ip_address, user_agent, submitted_at, status)
+view_states(id, view_id, user_id, state, last_accessed, updated_at)
+```
+
+Command:
+
+```bash
+psql -h localhost -p 5432 -d "$db" -v ON_ERROR_STOP=1 \
+  -f packages/core-backend/migrations/037_add_gallery_form_support.sql
+```
+
+Result:
+
+```text
+view_configs=1
+form_id_column=0
+form_id_index=0
+submitted_by_index=1
+view_state_trigger=1
+view_config_seeds=2
+```
+
+Conclusion: 037 now succeeds against the mixed-history shape that previously
+failed. The migration does not add `form_id` to a timestamp-shaped table; it
+simply skips the incompatible index and continues creating compatible indexes
+and triggers.
+
+## Narrow view_configs Rehearsal
+
+I created a throwaway database with a deliberately narrow `view_configs(id)`
+table, applied 037, then dropped the database.
+
+Result:
+
+```text
+seed_shape_guard_columns=0
+seed_rows=0
+```
+
+Conclusion: if a deployment already has a non-037 `view_configs` table shape,
+037 now skips the gallery/form demo seed rows instead of referencing missing
+`name/type/description/config_data/created_by` columns.
+
+## Fresh-schema Rehearsal
+
+I also applied 037 twice to an empty throwaway database to verify the original
+fresh-install path and idempotency still work.
+
+Result:
+
+```text
+view_configs=1
+form_id_column=1
+form_id_index=1
+response_data_column=1
+view_configs_seed_rows=2
+```
+
+Conclusion: fresh installs still get the original 037 table shape and seed
+records, and re-running the migration remains safe.
+
+## Manual Rehearsal Plan for On-prem or CI
+
+When a Postgres instance is available, reproduce the old schema and apply 037:
+
+1. Create `form_responses` in timestamp migration shape:
+
+   ```text
+   id, view_id, data, submitted_by, ip_address, user_agent, submitted_at, status
+   ```
+
+2. Apply:
+
+   ```bash
+   psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f packages/core-backend/migrations/037_add_gallery_form_support.sql
+   ```
+
+3. Expected result:
+
+   ```text
+   migration succeeds
+   form_responses.form_id remains absent if it was absent before
+   idx_form_responses_form_id remains absent when form_id is absent
+   idx_form_responses_submitted_by exists when submitted_by exists
+   ```
+
+## Diff Hygiene
+
+Command:
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+```
+
+Result:
+
+```text
+passed
+```
+
+Note: the first `tsc --noEmit` attempt failed because this worktree was missing
+the `nodemailer` dependency link declared in `packages/core-backend/package.json`
+and `pnpm-lock.yaml`. Running `pnpm install --ignore-scripts` restored the
+workspace link; dependency symlink dirt under `plugins/` and `tools/` was then
+reverted before commit.
+
+Command:
+
+```bash
+git diff --check
+```
+
+Result:
+
+```text
+no whitespace errors
+```
+
+## Build Check
+
+Command:
+
+```bash
+pnpm --filter @metasheet/core-backend build
+```
+
+Result:
+
+```text
+src/services/NotificationService.ts(7,24): error TS2307:
+Cannot find module 'nodemailer' or its corresponding type declarations.
+```
+
+Local diagnosis:
+
+```text
+node_modules/nodemailer: not present
+packages/core-backend/node_modules/nodemailer: not present
+```
+
+Conclusion: the local checkout is missing the `nodemailer` dependency install.
+This blocks a local build in this workspace but is unrelated to the migration SQL
+change. The targeted Vitest suites and real Postgres migration rehearsals above
+are the relevant gates for this fix.
+
+## Deployment Readiness
+
+This change is ready for PR/CI. After merge, a new Windows on-prem package
+should be generated before retrying the customer/entity-machine deployment.

--- a/packages/core-backend/migrations/037_add_gallery_form_support.sql
+++ b/packages/core-backend/migrations/037_add_gallery_form_support.sql
@@ -14,10 +14,31 @@ CREATE TABLE IF NOT EXISTS view_configs (
   deleted_at TIMESTAMPTZ NULL
 );
 
--- Create indexes for view_configs
-CREATE INDEX IF NOT EXISTS idx_view_configs_type ON view_configs(type);
-CREATE INDEX IF NOT EXISTS idx_view_configs_created_by ON view_configs(created_by);
-CREATE INDEX IF NOT EXISTS idx_view_configs_deleted ON view_configs(deleted_at);
+-- Create indexes for view_configs.
+-- Guard each column so this migration can run after timestamp-based view
+-- migrations that may have already created a narrower/different table shape.
+DO $$ BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'view_configs' AND column_name = 'type'
+  ) THEN
+    CREATE INDEX IF NOT EXISTS idx_view_configs_type ON view_configs(type);
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'view_configs' AND column_name = 'created_by'
+  ) THEN
+    CREATE INDEX IF NOT EXISTS idx_view_configs_created_by ON view_configs(created_by);
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'view_configs' AND column_name = 'deleted_at'
+  ) THEN
+    CREATE INDEX IF NOT EXISTS idx_view_configs_deleted ON view_configs(deleted_at);
+  END IF;
+END $$;
 
 -- Create view_states table to store user-specific view states (filters, sorting, etc.)
 CREATE TABLE IF NOT EXISTS view_states (
@@ -28,8 +49,16 @@ CREATE TABLE IF NOT EXISTS view_states (
   PRIMARY KEY (view_id, user_id)
 );
 
--- Create index for view_states
-CREATE INDEX IF NOT EXISTS idx_view_states_user ON view_states(user_id);
+-- Create index for view_states. Some deployments already have the
+-- timestamp-based view_states table; keep the migration column-aware.
+DO $$ BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'view_states' AND column_name = 'user_id'
+  ) THEN
+    CREATE INDEX IF NOT EXISTS idx_view_states_user ON view_states(user_id);
+  END IF;
+END $$;
 
 -- Create form_responses table to store form submissions
 CREATE TABLE IF NOT EXISTS form_responses (
@@ -43,98 +72,149 @@ CREATE TABLE IF NOT EXISTS form_responses (
   status TEXT NOT NULL DEFAULT 'submitted' CHECK (status IN ('submitted', 'processed', 'archived'))
 );
 
--- Create indexes for form_responses
-CREATE INDEX IF NOT EXISTS idx_form_responses_form_id ON form_responses(form_id);
-CREATE INDEX IF NOT EXISTS idx_form_responses_submitted_by ON form_responses(submitted_by);
-CREATE INDEX IF NOT EXISTS idx_form_responses_submitted_at ON form_responses(submitted_at DESC);
-CREATE INDEX IF NOT EXISTS idx_form_responses_status ON form_responses(status);
+-- Create indexes for form_responses.
+-- Compatibility note: newer timestamp migrations create form_responses with
+-- view_id/data instead of this older migration's form_id/response_data names.
+-- If that schema already exists, CREATE TABLE IF NOT EXISTS above is a no-op;
+-- these guards prevent the missing form_id column from blocking upgrades.
+DO $$ BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'form_responses' AND column_name = 'form_id'
+  ) THEN
+    CREATE INDEX IF NOT EXISTS idx_form_responses_form_id ON form_responses(form_id);
+  END IF;
 
--- Insert sample gallery view configuration
-INSERT INTO view_configs (id, name, type, description, config_data, created_by) VALUES
-('gallery-demo', '示例图库视图', 'gallery', '用于演示的图库视图配置', '{
-  "cardTemplate": {
-    "titleField": "title",
-    "contentFields": ["content"],
-    "imageField": "image",
-    "tagFields": ["tags"]
-  },
-  "layout": {
-    "columns": 3,
-    "cardSize": "medium",
-    "spacing": "normal"
-  },
-  "display": {
-    "showTitle": true,
-    "showContent": true,
-    "showImage": true,
-    "showTags": true,
-    "truncateContent": true,
-    "maxContentLength": 150
-  }
-}', 'system') ON CONFLICT (id) DO NOTHING;
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'form_responses' AND column_name = 'submitted_by'
+  ) THEN
+    CREATE INDEX IF NOT EXISTS idx_form_responses_submitted_by ON form_responses(submitted_by);
+  END IF;
 
--- Insert sample form view configuration
-INSERT INTO view_configs (id, name, type, description, config_data, created_by) VALUES
-('form-demo', '示例表单视图', 'form', '用于演示的表单视图配置', '{
-  "fields": [
-    {
-      "id": "1",
-      "name": "name",
-      "label": "姓名",
-      "type": "text",
-      "required": true,
-      "placeholder": "请输入您的姓名",
-      "order": 1,
-      "width": "full"
-    },
-    {
-      "id": "2",
-      "name": "email",
-      "label": "邮箱",
-      "type": "email",
-      "required": true,
-      "placeholder": "请输入您的邮箱",
-      "order": 2,
-      "width": "full"
-    },
-    {
-      "id": "3",
-      "name": "message",
-      "label": "留言",
-      "type": "textarea",
-      "required": false,
-      "placeholder": "请输入您的留言",
-      "order": 3,
-      "width": "full"
-    },
-    {
-      "id": "4",
-      "name": "rating",
-      "label": "评分",
-      "type": "rating",
-      "required": false,
-      "order": 4,
-      "width": "half"
-    }
-  ],
-  "settings": {
-    "title": "反馈表单",
-    "description": "请填写以下信息，我们会及时回复您",
-    "submitButtonText": "提交反馈",
-    "successMessage": "感谢您的反馈！我们会认真处理您的建议。",
-    "allowMultiple": true,
-    "requireAuth": false,
-    "enablePublicAccess": true,
-    "notifyOnSubmission": false
-  },
-  "validation": {
-    "enableValidation": true
-  },
-  "styling": {
-    "theme": "default",
-    "layout": "single-column"
-  }
-}', 'system') ON CONFLICT (id) DO NOTHING;
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'form_responses' AND column_name = 'submitted_at'
+  ) THEN
+    CREATE INDEX IF NOT EXISTS idx_form_responses_submitted_at ON form_responses(submitted_at DESC);
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'form_responses' AND column_name = 'status'
+  ) THEN
+    CREATE INDEX IF NOT EXISTS idx_form_responses_status ON form_responses(status);
+  END IF;
+END $$;
+
+-- Insert sample gallery/form view configurations when the active view_configs
+-- table has the legacy 037 seed shape.
+DO $$ BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'view_configs' AND column_name = 'id'
+  ) AND EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'view_configs' AND column_name = 'name'
+  ) AND EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'view_configs' AND column_name = 'type'
+  ) AND EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'view_configs' AND column_name = 'description'
+  ) AND EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'view_configs' AND column_name = 'config_data'
+  ) AND EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'view_configs' AND column_name = 'created_by'
+  ) THEN
+    INSERT INTO view_configs (id, name, type, description, config_data, created_by) VALUES
+    ('gallery-demo', '示例图库视图', 'gallery', '用于演示的图库视图配置', '{
+      "cardTemplate": {
+        "titleField": "title",
+        "contentFields": ["content"],
+        "imageField": "image",
+        "tagFields": ["tags"]
+      },
+      "layout": {
+        "columns": 3,
+        "cardSize": "medium",
+        "spacing": "normal"
+      },
+      "display": {
+        "showTitle": true,
+        "showContent": true,
+        "showImage": true,
+        "showTags": true,
+        "truncateContent": true,
+        "maxContentLength": 150
+      }
+    }', 'system') ON CONFLICT (id) DO NOTHING;
+
+    INSERT INTO view_configs (id, name, type, description, config_data, created_by) VALUES
+    ('form-demo', '示例表单视图', 'form', '用于演示的表单视图配置', '{
+      "fields": [
+        {
+          "id": "1",
+          "name": "name",
+          "label": "姓名",
+          "type": "text",
+          "required": true,
+          "placeholder": "请输入您的姓名",
+          "order": 1,
+          "width": "full"
+        },
+        {
+          "id": "2",
+          "name": "email",
+          "label": "邮箱",
+          "type": "email",
+          "required": true,
+          "placeholder": "请输入您的邮箱",
+          "order": 2,
+          "width": "full"
+        },
+        {
+          "id": "3",
+          "name": "message",
+          "label": "留言",
+          "type": "textarea",
+          "required": false,
+          "placeholder": "请输入您的留言",
+          "order": 3,
+          "width": "full"
+        },
+        {
+          "id": "4",
+          "name": "rating",
+          "label": "评分",
+          "type": "rating",
+          "required": false,
+          "order": 4,
+          "width": "half"
+        }
+      ],
+      "settings": {
+        "title": "反馈表单",
+        "description": "请填写以下信息，我们会及时回复您",
+        "submitButtonText": "提交反馈",
+        "successMessage": "感谢您的反馈！我们会认真处理您的建议。",
+        "allowMultiple": true,
+        "requireAuth": false,
+        "enablePublicAccess": true,
+        "notifyOnSubmission": false
+      },
+      "validation": {
+        "enableValidation": true
+      },
+      "styling": {
+        "theme": "default",
+        "layout": "single-column"
+      }
+    }', 'system') ON CONFLICT (id) DO NOTHING;
+  END IF;
+END $$;
 
 -- Create a trigger function to automatically update updated_at column
 CREATE OR REPLACE FUNCTION update_updated_at_column()
@@ -145,27 +225,72 @@ BEGIN
 END;
 $$ language 'plpgsql';
 
--- Create trigger for view_configs
-DROP TRIGGER IF EXISTS update_view_configs_updated_at ON view_configs;
-CREATE TRIGGER update_view_configs_updated_at
-    BEFORE UPDATE ON view_configs
-    FOR EACH ROW
-    EXECUTE FUNCTION update_updated_at_column();
+-- Create trigger for view_configs when the table has updated_at.
+DO $$ BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'view_configs' AND column_name = 'updated_at'
+  ) THEN
+    DROP TRIGGER IF EXISTS update_view_configs_updated_at ON view_configs;
+    CREATE TRIGGER update_view_configs_updated_at
+        BEFORE UPDATE ON view_configs
+        FOR EACH ROW
+        EXECUTE FUNCTION update_updated_at_column();
+  END IF;
+END $$;
 
--- Create trigger for view_states
-DROP TRIGGER IF EXISTS update_view_states_updated_at ON view_states;
-CREATE TRIGGER update_view_states_updated_at
-    BEFORE UPDATE ON view_states
-    FOR EACH ROW
-    EXECUTE FUNCTION update_updated_at_column();
+-- Create trigger for view_states only when the active schema has updated_at.
+DO $$ BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'view_states' AND column_name = 'updated_at'
+  ) THEN
+    DROP TRIGGER IF EXISTS update_view_states_updated_at ON view_states;
+    CREATE TRIGGER update_view_states_updated_at
+        BEFORE UPDATE ON view_states
+        FOR EACH ROW
+        EXECUTE FUNCTION update_updated_at_column();
+  END IF;
+END $$;
 
 -- Add comments for documentation
 COMMENT ON TABLE view_configs IS 'Stores configuration for different view types (grid, kanban, calendar, gallery, form)';
 COMMENT ON TABLE view_states IS 'Stores user-specific view states like filters, sorting, and pagination';
 COMMENT ON TABLE form_responses IS 'Stores form submission responses with metadata';
 
-COMMENT ON COLUMN view_configs.config_data IS 'JSONB field containing view-specific configuration (cardTemplate for gallery, fields for form, etc.)';
-COMMENT ON COLUMN view_states.state_data IS 'JSONB field containing user view state (filters, sorting, pagination, selectedItems)';
-COMMENT ON COLUMN form_responses.response_data IS 'JSONB field containing form submission data';
-COMMENT ON COLUMN form_responses.submitted_by IS 'User ID of submitter, NULL for anonymous submissions';
-COMMENT ON COLUMN form_responses.status IS 'Processing status: submitted, processed, or archived';
+DO $$ BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'view_configs' AND column_name = 'config_data'
+  ) THEN
+    COMMENT ON COLUMN view_configs.config_data IS 'JSONB field containing view-specific configuration (cardTemplate for gallery, fields for form, etc.)';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'view_states' AND column_name = 'state_data'
+  ) THEN
+    COMMENT ON COLUMN view_states.state_data IS 'JSONB field containing user view state (filters, sorting, pagination, selectedItems)';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'form_responses' AND column_name = 'response_data'
+  ) THEN
+    COMMENT ON COLUMN form_responses.response_data IS 'JSONB field containing form submission data';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'form_responses' AND column_name = 'submitted_by'
+  ) THEN
+    COMMENT ON COLUMN form_responses.submitted_by IS 'User ID of submitter, NULL for anonymous submissions';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'form_responses' AND column_name = 'status'
+  ) THEN
+    COMMENT ON COLUMN form_responses.status IS 'Processing status: submitted, processed, or archived';
+  END IF;
+END $$;

--- a/packages/core-backend/tests/unit/gallery-form-sql-migration.test.ts
+++ b/packages/core-backend/tests/unit/gallery-form-sql-migration.test.ts
@@ -1,0 +1,110 @@
+import { readFileSync } from 'fs'
+import path from 'path'
+import { describe, expect, it } from 'vitest'
+
+const migrationPath = path.resolve(
+  __dirname,
+  '../../migrations/037_add_gallery_form_support.sql'
+)
+
+function readMigration(): string {
+  return readFileSync(migrationPath, 'utf8')
+}
+
+function expectGuardBefore(sql: string, guardNeedle: string, guardedNeedle: string): void {
+  const guardedIndex = sql.indexOf(guardedNeedle)
+  expect(guardedIndex).toBeGreaterThanOrEqual(0)
+
+  const guardIndex = sql.lastIndexOf(guardNeedle, guardedIndex)
+  expect(guardIndex).toBeGreaterThanOrEqual(0)
+  expect(guardIndex).toBeLessThan(guardedIndex)
+}
+
+describe('037_add_gallery_form_support.sql compatibility guards', () => {
+  it('guards view_configs indexes and demo seeds by column existence', () => {
+    const sql = readMigration()
+
+    expectGuardBefore(
+      sql,
+      "table_name = 'view_configs' AND column_name = 'type'",
+      'CREATE INDEX IF NOT EXISTS idx_view_configs_type ON view_configs(type)'
+    )
+    expectGuardBefore(
+      sql,
+      "table_name = 'view_configs' AND column_name = 'created_by'",
+      'CREATE INDEX IF NOT EXISTS idx_view_configs_created_by ON view_configs(created_by)'
+    )
+    expectGuardBefore(
+      sql,
+      "table_name = 'view_configs' AND column_name = 'deleted_at'",
+      'CREATE INDEX IF NOT EXISTS idx_view_configs_deleted ON view_configs(deleted_at)'
+    )
+    for (const column of ['id', 'name', 'type', 'description', 'config_data', 'created_by']) {
+      expectGuardBefore(
+        sql,
+        `table_name = 'view_configs' AND column_name = '${column}'`,
+        'INSERT INTO view_configs (id, name, type, description, config_data, created_by)'
+      )
+    }
+  })
+
+  it('guards form_responses form_id index for timestamp-based schemas', () => {
+    const sql = readMigration()
+
+    expectGuardBefore(
+      sql,
+      "table_name = 'form_responses' AND column_name = 'form_id'",
+      'CREATE INDEX IF NOT EXISTS idx_form_responses_form_id ON form_responses(form_id)'
+    )
+    expectGuardBefore(
+      sql,
+      "table_name = 'form_responses' AND column_name = 'submitted_by'",
+      'CREATE INDEX IF NOT EXISTS idx_form_responses_submitted_by ON form_responses(submitted_by)'
+    )
+    expectGuardBefore(
+      sql,
+      "table_name = 'form_responses' AND column_name = 'submitted_at'",
+      'CREATE INDEX IF NOT EXISTS idx_form_responses_submitted_at ON form_responses(submitted_at DESC)'
+    )
+    expectGuardBefore(
+      sql,
+      "table_name = 'form_responses' AND column_name = 'status'",
+      'CREATE INDEX IF NOT EXISTS idx_form_responses_status ON form_responses(status)'
+    )
+  })
+
+  it('guards optional view_states trigger and comments by column existence', () => {
+    const sql = readMigration()
+
+    expectGuardBefore(
+      sql,
+      "table_name = 'view_states' AND column_name = 'user_id'",
+      'CREATE INDEX IF NOT EXISTS idx_view_states_user ON view_states(user_id)'
+    )
+    expectGuardBefore(
+      sql,
+      "table_name = 'view_states' AND column_name = 'updated_at'",
+      'CREATE TRIGGER update_view_states_updated_at'
+    )
+    expectGuardBefore(
+      sql,
+      "table_name = 'view_states' AND column_name = 'state_data'",
+      'COMMENT ON COLUMN view_states.state_data'
+    )
+  })
+
+  it('guards legacy form response comments by column existence', () => {
+    const sql = readMigration()
+
+    expectGuardBefore(
+      sql,
+      "table_name = 'form_responses' AND column_name = 'response_data'",
+      'COMMENT ON COLUMN form_responses.response_data'
+    )
+    expectGuardBefore(
+      sql,
+      "table_name = 'form_responses' AND column_name = 'submitted_by'",
+      'COMMENT ON COLUMN form_responses.submitted_by'
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- make 037_add_gallery_form_support.sql column-aware when timestamp-based view/form tables already exist
- prevent missing form_responses.form_id, view_states.state_data, and response_data references from blocking on-prem upgrades
- add a focused SQL migration guard test plus development/verification notes

## Verification
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/gallery-form-sql-migration.test.ts --reporter=dot
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/plugin-infrastructure-sql-migration.test.ts tests/unit/gallery-form-sql-migration.test.ts tests/unit/migration-provider.test.ts --reporter=dot
- local Postgres rehearsal: timestamp-shaped form_responses/view_states + 037 applied successfully
- local Postgres rehearsal: empty DB + 037 applied twice successfully
- git diff --check

## Build note
- pnpm --filter @metasheet/core-backend build is blocked in this checkout because nodemailer is not installed in node_modules; CI should validate with a complete install.