### PR TITLE
fix(migrations): skip superseded legacy SQL by default

### DIFF
--- a/.github/workflows/migration-replay.yml
+++ b/.github/workflows/migration-replay.yml
@@ -72,7 +72,6 @@ jobs:
           # TODO: Rewrite these migrations with correct PostgreSQL syntax
           # Exclude 20250924120000_create_views_view_states.ts - View states migration with schema issues
           # Exclude 20250924140000_create_gantt_tables.ts - FK points at pre-fix text view ids
-          # Exclude 20250924200000_create_event_bus_tables.ts - runtime schema clashes with earlier event bus tables during replay
           # Exclude 20250925_create_view_tables.sql - legacy owner_id FK assumes pre-text user ids during replay
           # Exclude 20251117000001_add_snapshot_labels.ts - re-applies chk_protection_level after earlier snapshot schema creation during replay
           # Exclude 20251117000002_create_protection_rules.ts - re-creates protection_rules after replay paths already created the table
@@ -80,14 +79,14 @@ jobs:
           # Exclude zzzz20260114110000_create_user_orgs_table.ts - replay paths hit legacy user_orgs is_active reference incompatibility
           # Exclude 042a_core_model_views.sql - References non-existent last_accessed column
           # TODO: Fix last_accessed column reference in 042a_core_model_views.sql
-          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924120000_create_views_view_states.ts,20250924140000_create_gantt_tables.ts,20250924200000_create_event_bus_tables.ts,20250925_create_view_tables.sql,20251117000001_add_snapshot_labels.ts,20251117000002_create_protection_rules.ts,20251201000001_create_change_management_tables.ts,zzzz20260114110000_create_user_orgs_table.ts
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924120000_create_views_view_states.ts,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql,20251117000001_add_snapshot_labels.ts,20251117000002_create_protection_rules.ts,20251201000001_create_change_management_tables.ts,zzzz20260114110000_create_user_orgs_table.ts
         run: |
           pnpm -F @metasheet/core-backend db:migrate
           pnpm -F @metasheet/core-backend db:migrate
       - name: List migrations
         env:
           DATABASE_URL: postgresql://127.0.0.1/metasheet
-          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924120000_create_views_view_states.ts,20250924140000_create_gantt_tables.ts,20250924200000_create_event_bus_tables.ts,20250925_create_view_tables.sql,20251117000001_add_snapshot_labels.ts,20251117000002_create_protection_rules.ts,20251201000001_create_change_management_tables.ts,zzzz20260114110000_create_user_orgs_table.ts
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924120000_create_views_view_states.ts,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql,20251117000001_add_snapshot_labels.ts,20251117000002_create_protection_rules.ts,20251201000001_create_change_management_tables.ts,zzzz20260114110000_create_user_orgs_table.ts
         run: pnpm -F @metasheet/core-backend db:list
 
       - name: Upload install logs on failure

--- a/.github/workflows/observability-e2e.yml
+++ b/.github/workflows/observability-e2e.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Run DB migrations
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/metasheet
-          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924120000_create_views_view_states.ts,20250924140000_create_gantt_tables.ts,20250924200000_create_event_bus_tables.ts,20250925_create_view_tables.sql,20251117000001_add_snapshot_labels.ts,20251117000002_create_protection_rules.ts,20251201000001_create_change_management_tables.ts,zzzz20260114110000_create_user_orgs_table.ts
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924120000_create_views_view_states.ts,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql,20251117000001_add_snapshot_labels.ts,20251117000002_create_protection_rules.ts,20251201000001_create_change_management_tables.ts,zzzz20260114110000_create_user_orgs_table.ts
         run: |
           pnpm -F @metasheet/core-backend db:list || true
           pnpm -F @metasheet/core-backend db:migrate

--- a/.github/workflows/observability-strict.yml
+++ b/.github/workflows/observability-strict.yml
@@ -100,13 +100,12 @@ jobs:
           # Exclude problematic migrations (see migration-replay.yml for details)
           # 042a_core_model_views.sql - References non-existent last_accessed column
           # 20250924140000_create_gantt_tables.ts - FK points at pre-fix text view ids
-          # 20250924200000_create_event_bus_tables.ts - runtime schema clashes with earlier event bus tables during replay
           # 20250925_create_view_tables.sql - legacy owner_id FK assumes pre-text user ids during replay
           # 20251117000001_add_snapshot_labels.ts - re-applies chk_protection_level after earlier snapshot schema creation during replay
           # 20251117000002_create_protection_rules.ts - re-creates protection_rules after replay paths already created the table
           # 20251201000001_create_change_management_tables.ts - legacy snapshot_id text FKs no longer match replay-built uuid snapshot ids
           # zzzz20260114110000_create_user_orgs_table.ts - replay paths hit legacy user_orgs is_active reference incompatibility
-          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924120000_create_views_view_states.ts,20250924140000_create_gantt_tables.ts,20250924200000_create_event_bus_tables.ts,20250925_create_view_tables.sql,20251117000001_add_snapshot_labels.ts,20251117000002_create_protection_rules.ts,20251201000001_create_change_management_tables.ts,zzzz20260114110000_create_user_orgs_table.ts
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924120000_create_views_view_states.ts,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql,20251117000001_add_snapshot_labels.ts,20251117000002_create_protection_rules.ts,20251201000001_create_change_management_tables.ts,zzzz20260114110000_create_user_orgs_table.ts
         run: |
           pnpm -F @metasheet/core-backend db:list || true
           pnpm -F @metasheet/core-backend db:migrate

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Run DB migrations
         env:
           DATABASE_URL: postgresql://postgres@localhost:5432/metasheet_test
-          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924120000_create_views_view_states.ts,20250924140000_create_gantt_tables.ts,20250924200000_create_event_bus_tables.ts,20250925_create_view_tables.sql,20251117000001_add_snapshot_labels.ts,20251117000002_create_protection_rules.ts,20251201000001_create_change_management_tables.ts,zzzz20260114110000_create_user_orgs_table.ts
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924120000_create_views_view_states.ts,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql,20251117000001_add_snapshot_labels.ts,20251117000002_create_protection_rules.ts,20251201000001_create_change_management_tables.ts,zzzz20260114110000_create_user_orgs_table.ts
         run: |
           pnpm --filter @metasheet/core-backend db:migrate
 
@@ -280,7 +280,7 @@ jobs:
       - name: Run DB migrations
         env:
           DATABASE_URL: postgresql://postgres@localhost:5432/metasheet_test
-          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924120000_create_views_view_states.ts,20250924140000_create_gantt_tables.ts,20250924200000_create_event_bus_tables.ts,20250925_create_view_tables.sql,20251117000001_add_snapshot_labels.ts,20251117000002_create_protection_rules.ts,20251201000001_create_change_management_tables.ts,zzzz20260114110000_create_user_orgs_table.ts
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924120000_create_views_view_states.ts,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql,20251117000001_add_snapshot_labels.ts,20251117000002_create_protection_rules.ts,20251201000001_create_change_management_tables.ts,zzzz20260114110000_create_user_orgs_table.ts
         run: |
           pnpm --filter @metasheet/core-backend db:migrate
 

--- a/.github/workflows/safety-guard-e2e.yml
+++ b/.github/workflows/safety-guard-e2e.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Run DB migrations
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/metasheet
-          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924120000_create_views_view_states.ts,20250924140000_create_gantt_tables.ts,20250924200000_create_event_bus_tables.ts,20250925_create_view_tables.sql,20251117000001_add_snapshot_labels.ts,20251117000002_create_protection_rules.ts,20251201000001_create_change_management_tables.ts,zzzz20260114110000_create_user_orgs_table.ts
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924120000_create_views_view_states.ts,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql,20251117000001_add_snapshot_labels.ts,20251117000002_create_protection_rules.ts,20251201000001_create_change_management_tables.ts,zzzz20260114110000_create_user_orgs_table.ts
         run: |
           pnpm -F @metasheet/core-backend db:list || true
           pnpm -F @metasheet/core-backend db:migrate

--- a/docs/development/migration-legacy-sql-skip-design-20260512.md
+++ b/docs/development/migration-legacy-sql-skip-design-20260512.md
@@ -1,0 +1,112 @@
+# Legacy SQL Migration Skip Design
+
+## Context
+
+Windows/on-prem K3 WISE deployment exposed a systemic migration mismatch. The
+core migration provider loads both modern timestamp migrations from
+`packages/core-backend/src/db/migrations` and legacy numeric SQL migrations from
+`packages/core-backend/migrations`.
+
+Patching one legacy SQL file at a time is not a stable upgrade path. After
+`037_add_gallery_form_support.sql` was guarded, deployment could still fail on
+the next legacy core migration whose assumptions no longer match the current
+timestamp migration schema.
+
+## Decision
+
+The provider now treats legacy numeric core SQL migrations `032` through `055`
+as superseded by the modern timestamp migration stream and excludes them from
+the default migration set.
+
+The default skip list covers:
+
+- approval/RBAC/spreadsheet/file/view core tables;
+- config, data source, script sandbox, event bus, audit/cache, snapshot, and
+  protection-rule legacy migrations;
+- legacy users and attendance import token SQL migrations.
+
+The provider still keeps the SQL migrations currently required by the on-prem
+package path:
+
+- `008_plugin_infrastructure.sql`
+- `056_add_users_must_change_password.sql`
+- `057_create_integration_core_tables.sql`
+- `058_integration_runs_running_unique.sql`
+- `059_integration_runs_history_index.sql`
+
+`056_add_users_must_change_password.sql` is now guarded for fresh replay order.
+If `users` does not exist yet, it no-ops instead of failing. A modern timestamp
+bridge migration,
+`zzzz20260512100000_add_users_must_change_password.ts`, adds the same column
+after the timestamp users migration has created the table.
+
+CI replay exclusions were also updated so
+`20250924200000_create_event_bus_tables.ts` runs again. The previous exclusion
+only made sense while replay depended on the legacy event-bus SQL path; with
+legacy core SQL skipped by default, the modern event-bus migration must be the
+source of `event_subscriptions` before the later runtime-schema alignment
+migration runs.
+
+## Operator Escape Hatch
+
+For compatibility audits only, the provider accepts:
+
+```bash
+MIGRATION_INCLUDE_SUPERSEDED_LEGACY_SQL=true
+```
+
+or the equivalent programmatic option:
+
+```ts
+createCoreBackendMigrationProvider({
+  includeSupersededLegacySqlMigrations: true,
+})
+```
+
+This is not the normal deployment mode. It exists so engineers can replay old
+legacy SQL intentionally when diagnosing historical databases.
+
+## Why This Shape
+
+This keeps the package contents stable while changing runtime behavior where
+the failure occurs. The package verifier can continue asserting that K3/on-prem
+SQL migrations are present in the archive, while the migrator stops applying
+legacy core migrations that have already been replaced by timestamp migrations.
+
+The approach avoids three bad outcomes:
+
+- no more one-by-one emergency patching of obsolete SQL assumptions;
+- no need to delete historical migration files from the repository or package;
+- no loss of the recent K3/on-prem SQL migrations required for login and
+  integration tables.
+
+## Changed Files
+
+- `packages/core-backend/src/db/migration-provider.ts`
+- `packages/core-backend/migrations/056_add_users_must_change_password.sql`
+- `packages/core-backend/src/db/migrations/zzzz20260512100000_add_users_must_change_password.ts`
+- `packages/core-backend/tests/unit/migration-provider.test.ts`
+- `packages/core-backend/tests/unit/users-must-change-password-migration.test.ts`
+- `.github/workflows/migration-replay.yml`
+- `.github/workflows/observability-e2e.yml`
+- `.github/workflows/observability-strict.yml`
+- `.github/workflows/plugin-tests.yml`
+- `.github/workflows/safety-guard-e2e.yml`
+- `packages/core-backend/MIGRATION_EXCLUDE_TRACKING.md`
+- `docs/development/migration-legacy-sql-skip-design-20260512.md`
+- `docs/development/migration-legacy-sql-skip-verification-20260512.md`
+
+## Deployment Impact
+
+This is a migration-provider policy change. It affects which pending migrations
+are visible to `db:migrate` and `db:list`.
+
+Existing databases that already applied any skipped legacy migration are not
+rolled back. New or upgraded on-prem databases should now follow the modern
+timestamp migration stream plus the on-prem SQL tail (`056` and later).
+
+## GATE Impact
+
+This does not unlock true K3 WISE live push. Customer GATE requirements remain
+unchanged. It only removes the current Windows/on-prem deployment blocker so the
+K3 setup page and dry-run path can be tested again.

--- a/docs/development/migration-legacy-sql-skip-verification-20260512.md
+++ b/docs/development/migration-legacy-sql-skip-verification-20260512.md
@@ -1,0 +1,123 @@
+# Legacy SQL Migration Skip Verification
+
+## Goal
+
+Prove that the migration provider no longer applies superseded legacy numeric
+core SQL migrations by default, while preserving the on-prem/K3 SQL migrations
+needed by packaged deployments.
+
+## Local Commands
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/migration-provider.test.ts \
+  --watch=false
+```
+
+Expected result:
+
+- migration provider unit tests pass;
+- `032_create_approval_records`, `037_add_gallery_form_support`, and
+  `055_create_attendance_import_tokens` are absent from the default migration
+  set;
+- `056_add_users_must_change_password` and
+  `057_create_integration_core_tables` remain present.
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/migration-provider.test.ts \
+  tests/unit/users-must-change-password-migration.test.ts \
+  tests/unit/gallery-form-sql-migration.test.ts \
+  tests/unit/plugin-infrastructure-sql-migration.test.ts \
+  --watch=false
+```
+
+Expected result:
+
+- provider behavior remains green;
+- `056_add_users_must_change_password.sql` no-ops safely when `users` does not
+  exist yet;
+- `zzzz20260512100000_add_users_must_change_password.ts` provides the modern
+  timestamp bridge after users table creation;
+- historical SQL compatibility tests remain available for audit coverage even
+  though superseded legacy SQL is skipped by default.
+
+Observed locally:
+
+- `4 passed` test files;
+- `16 passed` tests.
+
+```bash
+git diff --check origin/main...HEAD
+```
+
+Expected result:
+
+- no whitespace errors;
+- no conflict markers.
+
+Observed locally:
+
+- command exited `0`.
+
+## Real Provider Smoke
+
+```bash
+pnpm exec tsx -e "import path from 'node:path'; import { createCoreBackendMigrationProvider } from './packages/core-backend/src/db/migration-provider.ts'; (async()=>{ const provider=createCoreBackendMigrationProvider({ runtimeDir: path.resolve('packages/core-backend/src/db') }); const migrations=await provider.getMigrations(); const names=Object.keys(migrations); const report={ has032:names.includes('032_create_approval_records'), has037:names.includes('037_add_gallery_form_support'), has055:names.includes('055_create_attendance_import_tokens'), has056:names.includes('056_add_users_must_change_password'), hasModernMustChange:names.includes('zzzz20260512100000_add_users_must_change_password'), has057:names.includes('057_create_integration_core_tables'), has058:names.includes('058_integration_runs_running_unique'), has059:names.includes('059_integration_runs_history_index'), total:names.length }; console.log(JSON.stringify(report,null,2)); })();"
+```
+
+Observed:
+
+```json
+{
+  "has032": false,
+  "has037": false,
+  "has055": false,
+  "has056": true,
+  "hasModernMustChange": true,
+  "has057": true,
+  "has058": true,
+  "has059": true,
+  "total": 131
+}
+```
+
+## Regression Matrix
+
+| Case | Expected |
+| --- | --- |
+| Source-style runtime loads timestamp code migration plus `056` | Present |
+| Dist-style runtime loads timestamp SQL migration plus `056` | Present |
+| Default provider sees `032`, `037`, `055`, `056`, `057` in legacy folder | Only `056` and `057` remain |
+| Fresh replay applies `056` before timestamp `users` creation | `056` is guarded and does not fail |
+| Timestamp users migration has run | `zzzz20260512100000_add_users_must_change_password` adds the required column |
+| Legacy event-bus SQL is skipped | CI allows `20250924200000_create_event_bus_tables` to run so later event-bus alignment has tables to alter |
+| `includeSupersededLegacySqlMigrations: true` | `037` is visible for explicit audits |
+| `MIGRATION_EXCLUDE` / `excludedNames` excludes `056` | Existing exclusion behavior preserved |
+| Duplicate migration names across provider folders | Still fails fast |
+
+## Package Verification Follow-up
+
+After merge, the next on-prem package should be rebuilt from the new main SHA
+and verified with:
+
+```bash
+scripts/ops/multitable-onprem-package-verify.sh <package.zip-or-tgz>
+```
+
+The package should still include the required K3/on-prem SQL files:
+
+- `packages/core-backend/migrations/056_add_users_must_change_password.sql`
+- `packages/core-backend/migrations/057_create_integration_core_tables.sql`
+- `packages/core-backend/migrations/058_integration_runs_running_unique.sql`
+- `packages/core-backend/migrations/059_integration_runs_history_index.sql`
+
+## Deployment Acceptance
+
+For the Windows/on-prem deployment that hit issue `#651`, acceptance is:
+
+1. deploy package built from the merged SHA;
+2. migration step no longer attempts superseded legacy SQL `032` through `055`;
+3. `056` still supplies `users.must_change_password`;
+4. `057` through `059` still supply integration runtime tables and indexes;
+5. service starts without manual database patching.

--- a/packages/core-backend/MIGRATION_EXCLUDE_TRACKING.md
+++ b/packages/core-backend/MIGRATION_EXCLUDE_TRACKING.md
@@ -4,11 +4,11 @@
 
 This document tracks database migrations that are currently excluded from automated replay testing. These migrations require manual review and fixing before they can be re-enabled.
 
-**Current Exclude Count**: 12 files
+**Current Exclude Count**: 11 files
 
-**Default Exclude in CI**: `008_plugin_infrastructure.sql, 048_create_event_bus_tables.sql, 049_create_bpmn_workflow_tables.sql, 042a_core_model_views.sql, 20250924120000_create_views_view_states.ts, 20250924140000_create_gantt_tables.ts, 20250924200000_create_event_bus_tables.ts, 20250925_create_view_tables.sql, 20251117000001_add_snapshot_labels.ts, 20251117000002_create_protection_rules.ts, 20251201000001_create_change_management_tables.ts, zzzz20260114110000_create_user_orgs_table.ts`
+**Default Exclude in CI**: `008_plugin_infrastructure.sql, 048_create_event_bus_tables.sql, 049_create_bpmn_workflow_tables.sql, 042a_core_model_views.sql, 20250924120000_create_views_view_states.ts, 20250924140000_create_gantt_tables.ts, 20250925_create_view_tables.sql, 20251117000001_add_snapshot_labels.ts, 20251117000002_create_protection_rules.ts, 20251201000001_create_change_management_tables.ts, zzzz20260114110000_create_user_orgs_table.ts`
 
-**Last Updated**: 2026-04-19
+**Last Updated**: 2026-05-12
 
 ---
 
@@ -27,10 +27,6 @@ This document tracks database migrations that are currently excluded from automa
 #### `20250924140000_create_gantt_tables.ts`
 **Status**: ❌ Excluded
 **Issue**: Creates gantt foreign keys against the same pre-fix `text` view ids and fails with `uuid` vs `text` FK incompatibility during replay paths.
-
-#### `20250924200000_create_event_bus_tables.ts`
-**Status**: ❌ Excluded
-**Issue**: Recreates runtime event bus tables that already exist through the earlier event bus SQL path, causing replay environments to fail with duplicate `event_types` relations.
 
 #### `20250925_create_view_tables.sql`
 **Status**: ❌ Excluded

--- a/packages/core-backend/migrations/056_add_users_must_change_password.sql
+++ b/packages/core-backend/migrations/056_add_users_must_change_password.sql
@@ -1,5 +1,10 @@
 -- 056_add_users_must_change_password.sql
 -- Support forced password change after admin resets or temporary-password onboarding
 
-ALTER TABLE users
-  ADD COLUMN IF NOT EXISTS must_change_password BOOLEAN NOT NULL DEFAULT FALSE;
+DO $$
+BEGIN
+  IF to_regclass('public.users') IS NOT NULL THEN
+    ALTER TABLE users
+      ADD COLUMN IF NOT EXISTS must_change_password BOOLEAN NOT NULL DEFAULT FALSE;
+  END IF;
+END $$;

--- a/packages/core-backend/src/db/migration-provider.ts
+++ b/packages/core-backend/src/db/migration-provider.ts
@@ -15,7 +15,40 @@ interface CreateCoreBackendMigrationProviderOptions {
   pathImpl?: NodePathLike
   runtimeDir?: string
   excludedNames?: string[]
+  includeSupersededLegacySqlMigrations?: boolean
 }
+
+const SUPERSEDED_LEGACY_SQL_MIGRATIONS = [
+  '032_create_approval_records',
+  '033_create_rbac_core',
+  '034_create_spreadsheets',
+  '035_create_files',
+  '036_create_spreadsheet_permissions',
+  '037_add_gallery_form_support',
+  '038_config_and_secrets',
+  '040_data_sources',
+  '041_script_sandbox',
+  '042_core_model_completion',
+  '042a_core_model_views',
+  '042b_external_data_model',
+  '042c_audit_placeholder',
+  '042d_audit_and_cache',
+  '042d_plugins_and_templates',
+  '043_core_model_views',
+  '044_external_data_model',
+  '045_audit_placeholder',
+  '046_plugins_and_templates',
+  '047_audit_and_cache',
+  '047_create_event_bus_tables',
+  '048_create_event_bus_tables',
+  '049_create_bpmn_workflow_tables',
+  '050_create_snapshot_core',
+  '051_create_minimal_views',
+  '052_recreate_minimal_views',
+  '053_create_protection_rules',
+  '054_create_users_table',
+  '055_create_attendance_import_tokens',
+]
 
 function dedupe(values: string[]): string[] {
   return [...new Set(values)]
@@ -141,12 +174,20 @@ export function createCoreBackendMigrationProvider(
   const runtimeDir = options.runtimeDir ?? __dirname
   const providerFolders = getProviderFolderCandidates(runtimeDir, pathImpl)
   const sqlFolders = getSqlFolderCandidates(runtimeDir, pathImpl)
-  const excludedNames = getExcludedNames(
+  const includeSupersededLegacySql =
+    options.includeSupersededLegacySqlMigrations ??
+    process.env.MIGRATION_INCLUDE_SUPERSEDED_LEGACY_SQL === 'true'
+  const configuredExcludedNames =
     options.excludedNames ??
-      (process.env.MIGRATION_EXCLUDE || '')
-        .split(',')
-        .map((value) => value.trim())
-        .filter(Boolean)
+    (process.env.MIGRATION_EXCLUDE || '')
+      .split(',')
+      .map((value) => value.trim())
+      .filter(Boolean)
+  const excludedNames = getExcludedNames(
+    [
+      ...(includeSupersededLegacySql ? [] : SUPERSEDED_LEGACY_SQL_MIGRATIONS),
+      ...configuredExcludedNames,
+    ]
   )
 
   return {

--- a/packages/core-backend/src/db/migrations/zzzz20260512100000_add_users_must_change_password.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260512100000_add_users_must_change_password.ts
@@ -1,0 +1,27 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+import { checkTableExists } from './_patterns'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  const exists = await checkTableExists(db, 'users')
+  if (!exists) {
+    return
+  }
+
+  await sql`
+    ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS must_change_password BOOLEAN NOT NULL DEFAULT FALSE
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  const exists = await checkTableExists(db, 'users')
+  if (!exists) {
+    return
+  }
+
+  await sql`
+    ALTER TABLE users
+    DROP COLUMN IF EXISTS must_change_password
+  `.execute(db)
+}

--- a/packages/core-backend/tests/unit/migration-provider.test.ts
+++ b/packages/core-backend/tests/unit/migration-provider.test.ts
@@ -88,6 +88,73 @@ describe('createCoreBackendMigrationProvider', () => {
     ])
   })
 
+  it('skips superseded legacy core sql migrations by default', async () => {
+    const projectRoot = await createTempProjectRoot()
+    const runtimeDir = path.join(projectRoot, 'src/db')
+    const sourceMigrationsDir = path.join(runtimeDir, 'migrations')
+    const legacySqlDir = path.join(projectRoot, 'migrations')
+
+    await writeFile(
+      path.join(sourceMigrationsDir, 'zzzz20260119100000_create_users_table.mjs'),
+      'export async function up() {}\n'
+    )
+    await writeFile(
+      path.join(legacySqlDir, '032_create_approval_records.sql'),
+      'create table if not exists approval_records (id uuid primary key);'
+    )
+    await writeFile(
+      path.join(legacySqlDir, '037_add_gallery_form_support.sql'),
+      'alter table form_responses add column if not exists form_id uuid;'
+    )
+    await writeFile(
+      path.join(legacySqlDir, '055_create_attendance_import_tokens.sql'),
+      'create table if not exists attendance_import_tokens (id text primary key);'
+    )
+    await writeFile(
+      path.join(legacySqlDir, '056_add_users_must_change_password.sql'),
+      'alter table users add column if not exists must_change_password boolean not null default false;'
+    )
+    await writeFile(
+      path.join(legacySqlDir, '057_create_integration_core_tables.sql'),
+      'create table if not exists integration_external_systems (id uuid primary key);'
+    )
+
+    const provider = createCoreBackendMigrationProvider({ runtimeDir })
+    const migrations = await provider.getMigrations()
+
+    expect(Object.keys(migrations).sort()).toEqual([
+      '056_add_users_must_change_password',
+      '057_create_integration_core_tables',
+      'zzzz20260119100000_create_users_table',
+    ])
+  })
+
+  it('can include superseded legacy sql migrations for explicit compatibility audits', async () => {
+    const projectRoot = await createTempProjectRoot()
+    const runtimeDir = path.join(projectRoot, 'src/db')
+    const legacySqlDir = path.join(projectRoot, 'migrations')
+
+    await writeFile(
+      path.join(legacySqlDir, '037_add_gallery_form_support.sql'),
+      'alter table form_responses add column if not exists form_id uuid;'
+    )
+    await writeFile(
+      path.join(legacySqlDir, '056_add_users_must_change_password.sql'),
+      'alter table users add column if not exists must_change_password boolean not null default false;'
+    )
+
+    const provider = createCoreBackendMigrationProvider({
+      runtimeDir,
+      includeSupersededLegacySqlMigrations: true,
+    })
+    const migrations = await provider.getMigrations()
+
+    expect(Object.keys(migrations).sort()).toEqual([
+      '037_add_gallery_form_support',
+      '056_add_users_must_change_password',
+    ])
+  })
+
   it('honors MIGRATION_EXCLUDE-style names with or without file extensions', async () => {
     const projectRoot = await createTempProjectRoot()
     const runtimeDir = path.join(projectRoot, 'src/db')

--- a/packages/core-backend/tests/unit/users-must-change-password-migration.test.ts
+++ b/packages/core-backend/tests/unit/users-must-change-password-migration.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { describe, expect, it } from 'vitest'
+
+const legacySqlPath = resolve(
+  __dirname,
+  '../../migrations/056_add_users_must_change_password.sql'
+)
+
+const modernMigrationPath = resolve(
+  __dirname,
+  '../../src/db/migrations/zzzz20260512100000_add_users_must_change_password.ts'
+)
+
+describe('users must_change_password migrations', () => {
+  it('guards legacy 056 SQL when users table is not created yet', () => {
+    const sql = readFileSync(legacySqlPath, 'utf8')
+
+    expect(sql).toContain("to_regclass('public.users') IS NOT NULL")
+    expect(sql).toContain('ADD COLUMN IF NOT EXISTS must_change_password')
+  })
+
+  it('adds a modern timestamp bridge migration after users table creation', () => {
+    const source = readFileSync(modernMigrationPath, 'utf8')
+
+    expect(source).toContain("checkTableExists(db, 'users')")
+    expect(source).toContain('ADD COLUMN IF NOT EXISTS must_change_password')
+    expect(source).toContain('DROP COLUMN IF EXISTS must_change_password')
+  })
+})


### PR DESCRIPTION
## Summary
- default-skip superseded legacy numeric core SQL migrations 032-055 in the combined migration provider
- keep on-prem/K3 SQL tail migrations 056-059 visible, plus existing explicit MIGRATION_EXCLUDE behavior
- add an explicit compatibility-audit opt-in via MIGRATION_INCLUDE_SUPERSEDED_LEGACY_SQL=true / provider option
- add design and verification docs for the #651 systemic migration gap

## Verification
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/migration-provider.test.ts --watch=false
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/migration-provider.test.ts tests/unit/gallery-form-sql-migration.test.ts tests/unit/plugin-infrastructure-sql-migration.test.ts --watch=false
- provider smoke: 032/037/055 absent; 056/057/058/059 present
- git diff --cached --check

## Deployment impact
This changes migration-provider runtime policy only. Existing applied migrations are not rolled back. New Windows/on-prem deployments should stop trying to apply obsolete core legacy SQL while still applying 056-059 for login and K3 integration runtime tables.

## GATE status
Does not unlock live K3 push; customer GATE remains required. This is the deployment unblocker for testing the installed K3 setup/dry-run path.