### PR TITLE
docs(dingtalk): record live acceptance evidence gap

### DIFF
--- a/docs/development/dingtalk-live-acceptance-manual-evidence-gap-development-20260512.md
+++ b/docs/development/dingtalk-live-acceptance-manual-evidence-gap-development-20260512.md
@@ -1,0 +1,169 @@
+# DingTalk Live Acceptance Manual Evidence Gap Development - 2026-05-12
+
+## Summary
+
+This closeout slice records the remaining strict evidence gap for the 142 DingTalk live acceptance run after the production runtime was restored and the automated checks passed.
+
+No runtime code changed in this slice. The change is intentionally documentation-only because the current blocker is evidence quality and target selection, not an application defect.
+
+## Current Live Session
+
+| Item | Value |
+| --- | --- |
+| 142 backend image | `ghcr.io/zensgit/metasheet2-backend:b88f6c243ce882c65dc794c188e8d0e677f6cb64` |
+| 142 web image | `ghcr.io/zensgit/metasheet2-web:b88f6c243ce882c65dc794c188e8d0e677f6cb64` |
+| Smoke session | `142-live-20260512-token` |
+| Session status | `manual_pending` |
+| Progress | `4/8` required checks complete |
+| Current generated sheet | `sheet_9bb5ca3e-dbf9-4a8f-9bf4-5c3dc1047c97` |
+| Current generated form view | `view_d7bfe0f1-0624-4370-97b8-40e07b1483c1` |
+
+Completed checks:
+
+- `create-table-form`
+- `bind-two-dingtalk-groups`
+- `set-form-dingtalk-granted`
+- `delivery-history-group-person`
+
+Pending checks:
+
+- `send-group-message-form-link`
+- `authorized-user-submit`
+- `unauthorized-user-denied`
+- `no-email-user-create-bind`
+
+## Evidence Decision
+
+The screenshots available in the local Downloads folder cannot be used as strict PASS evidence for the current 2026-05-12 live session.
+
+Reason:
+
+- Their file timestamps are 2026-05-10.
+- They show the prior smoke sheet context, not the current `sheet_9bb5ca3e-dbf9-4a8f-9bf4-5c3dc1047c97` session.
+- Strict closeout evidence must match the active smoke session and current generated form link.
+
+This avoids incorrectly closing the matrix with stale screenshots.
+
+## No-Email Target Finding
+
+The generated no-email target in the active smoke session is not suitable for strict `no-email-user-create-bind` PASS evidence.
+
+Live 142 directory inspection showed:
+
+- The generated smoke target ending in `1174` is a blank-email DingTalk directory account, but it is already linked to the admin local user.
+- The `ddzz` DingTalk directory account ending in `9104` is also blank-email and linked to a no-email local user.
+
+Implication:
+
+- The generated target cannot prove the required "create a local no-email user and bind the DingTalk identity" flow because the account is already linked to an existing admin user.
+- The `ddzz` account can support an "existing no-email linked DingTalk user" proof, but it does not by itself satisfy the stricter "create-and-bind during this evidence run" semantics unless the admin flow is re-executed and captured.
+
+## Required Strict Evidence
+
+The code-level evidence contract requires `no-email-user-create-bind` PASS evidence to include all of the following:
+
+- `emailWasBlank: true`
+- `createdLocalUserId`
+- `boundDingTalkExternalId`
+- `accountLinkedAfterRefresh: true`
+- `temporaryPasswordRedacted: true`
+- Admin artifacts for create/bind result and refresh-after-bind state
+
+The recorder also rejects admin evidence flags on non-`no-email-user-create-bind` checks and requires the admin flags when this check is marked PASS.
+
+## Recommended Closeout Path
+
+Use one of these two paths before flipping the final matrix to CLOSED.
+
+Path A, preferred:
+
+1. Pick a truly unbound DingTalk directory account with no email.
+2. Put that external id into the private P4 env file as `DINGTALK_P4_NO_EMAIL_DINGTALK_EXTERNAL_ID`.
+3. Re-run the P4 smoke session so the generated target matches the planned admin evidence.
+4. Create the local user from the synced DingTalk directory account in the admin UI.
+5. Confirm the account remains linked after refresh.
+6. Record `no-email-user-create-bind` with redacted artifacts and no temporary password in text.
+
+Path B, acceptable only if the product owner agrees to narrowed semantics:
+
+1. Use `ddzz` as a pre-existing no-email DingTalk-linked local user proof.
+2. Record the evidence as "existing no-email linked identity verified" instead of "created during this session".
+3. Keep `no-email-user-create-bind` marked pending in the strict release matrix unless the create-and-bind action is performed and captured.
+
+## Manual Evidence Still Needed
+
+For current session `142-live-20260512-token`, collect fresh 2026-05-12 evidence for:
+
+- DingTalk group message with the current protected form link.
+- Authorized user open and successful submit.
+- Unauthorized user denial with zero record insert.
+- No-email DingTalk directory account create/bind, or an explicitly approved narrowed proof.
+
+## Recorder Commands
+
+Use the generated session commands, with artifacts placed under `workspace/artifacts/<check-id>/`:
+
+```bash
+node scripts/ops/dingtalk-p4-evidence-record.mjs \
+  --session-dir output/dingtalk-p4-remote-smoke-session/142-live-20260512-token \
+  --check-id send-group-message-form-link \
+  --status pass \
+  --source manual-client \
+  --operator <operator> \
+  --summary "<summary>" \
+  --artifact artifacts/send-group-message-form-link/<file>
+```
+
+```bash
+node scripts/ops/dingtalk-p4-evidence-record.mjs \
+  --session-dir output/dingtalk-p4-remote-smoke-session/142-live-20260512-token \
+  --check-id authorized-user-submit \
+  --status pass \
+  --source manual-client \
+  --operator <operator> \
+  --summary "<summary>" \
+  --artifact artifacts/authorized-user-submit/<file>
+```
+
+```bash
+node scripts/ops/dingtalk-p4-evidence-record.mjs \
+  --session-dir output/dingtalk-p4-remote-smoke-session/142-live-20260512-token \
+  --check-id unauthorized-user-denied \
+  --status pass \
+  --source manual-client \
+  --operator <operator> \
+  --summary "<summary>" \
+  --artifact artifacts/unauthorized-user-denied/<file> \
+  --submit-blocked \
+  --record-insert-delta 0 \
+  --blocked-reason "<visible denial reason>"
+```
+
+```bash
+node scripts/ops/dingtalk-p4-evidence-record.mjs \
+  --session-dir output/dingtalk-p4-remote-smoke-session/142-live-20260512-token \
+  --check-id no-email-user-create-bind \
+  --status pass \
+  --source manual-admin \
+  --operator <operator> \
+  --summary "Admin created and bound a no-email DingTalk-synced local user; temporary password is redacted." \
+  --artifact artifacts/no-email-user-create-bind/admin-create-bind-result.png \
+  --artifact artifacts/no-email-user-create-bind/account-linked-after-refresh.png \
+  --admin-email-was-blank \
+  --admin-created-local-user-id <local-user-id> \
+  --admin-bound-dingtalk-external-id <dingtalk-external-id> \
+  --admin-account-linked-after-refresh
+```
+
+Finalize only after all four pending checks are recorded:
+
+```bash
+node scripts/ops/dingtalk-p4-smoke-session.mjs \
+  --finalize output/dingtalk-p4-remote-smoke-session/142-live-20260512-token
+```
+
+## Security Notes
+
+- Do not commit or paste webhook URLs, `SEC` values, bearer tokens, JWTs, app secrets, temporary passwords, or complete public form tokens.
+- Screenshot artifacts must be reviewed before commit or upload to ensure no secrets are visible.
+- Temporary password evidence should be a redacted note or masked screenshot only.

--- a/docs/development/dingtalk-live-acceptance-manual-evidence-gap-verification-20260512.md
+++ b/docs/development/dingtalk-live-acceptance-manual-evidence-gap-verification-20260512.md
@@ -1,0 +1,161 @@
+# DingTalk Live Acceptance Manual Evidence Gap Verification - 2026-05-12
+
+## Summary
+
+This verification records why the current DingTalk live acceptance remains `manual_pending` and why the available screenshots must not be used as strict current-session PASS evidence.
+
+Result: not CLOSED. The live 142 runtime is healthy, automated smoke checks are partly complete, but four manual evidence items remain pending.
+
+## Verification Matrix
+
+| Gate | Result | Evidence |
+| --- | --- | --- |
+| 142 backend health | PASS | Server-local `/api/health` returned `status=ok`, `plugins=13` |
+| 142 web entry | PASS | Server-local `/` returned HTTP 200 |
+| Runtime image check | PASS | backend/web are both on `b88f6c243ce882c65dc794c188e8d0e677f6cb64` |
+| Current smoke status | PENDING | `142-live-20260512-token` is `manual_pending`, `4/8` complete |
+| Screenshot freshness | FAIL for strict reuse | Latest supplied DingTalk screenshots are dated 2026-05-10 and show prior smoke context |
+| No-email target | FAIL for strict create/bind proof | Generated target is already linked to an admin local user |
+| Secret hygiene | PASS | This doc records redacted ids only and no webhook/JWT/SEC/password values |
+| Local doc validation | PASS | `git diff --check`, secret-pattern scan, and DingTalk evidence tests passed |
+
+## Commands Run
+
+Repository/worktree state:
+
+```bash
+git status --short --branch
+git rev-parse --short HEAD
+```
+
+Evidence contract inspection:
+
+```bash
+sed -n '640,710p' scripts/ops/compile-dingtalk-p4-smoke-evidence.mjs
+sed -n '450,530p' scripts/ops/dingtalk-p4-evidence-record.mjs
+```
+
+Current smoke status:
+
+```bash
+SESSION=/tmp/metasheet2-dingtalk-live-acceptance-20260512/output/dingtalk-p4-remote-smoke-session/142-live-20260512-token
+sed -n '1,220p' "$SESSION/smoke-status.md"
+sed -n '1,220p' "$SESSION/smoke-todo.md"
+```
+
+142 health and runtime:
+
+```bash
+ssh -i ~/.ssh/metasheet2_deploy -o BatchMode=yes -o StrictHostKeyChecking=no mainuser@142.171.239.56 \
+  "docker ps --format '{{.Names}} {{.Image}}' | grep -E 'metasheet-(backend|web)' && \
+   curl -fsS http://127.0.0.1:8081/api/health | head -c 220 && printf '\n' && \
+   curl -fsSI http://127.0.0.1:8081/ | head -5"
+```
+
+No-email directory state, with sensitive values omitted from the report:
+
+```bash
+ssh -i ~/.ssh/metasheet2_deploy -o BatchMode=yes -o StrictHostKeyChecking=no mainuser@142.171.239.56 \
+  "docker exec metasheet-postgres psql -U metasheet -d metasheet -Atc \"<redacted directory account query>\""
+```
+
+Screenshot freshness:
+
+```bash
+find /Users/chouhua/Downloads -maxdepth 1 -type f \( -name '*.JPG' -o -name '*.PNG' -o -name '*.jpg' -o -name '*.png' \) -print0 \
+  | xargs -0 stat -f '%Sm %N' -t '%Y-%m-%d %H:%M:%S' \
+  | sort \
+  | tail -12
+```
+
+Local validation:
+
+```bash
+git diff --check
+git diff -- docs/development/dingtalk-live-acceptance-manual-evidence-gap-development-20260512.md docs/development/dingtalk-live-acceptance-manual-evidence-gap-verification-20260512.md \
+  | rg -n "<strict secret value pattern>" \
+  || true
+node --test scripts/ops/dingtalk-p4-evidence-record.test.mjs scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs
+```
+
+## Observed Results
+
+142 runtime:
+
+```text
+metasheet-web ghcr.io/zensgit/metasheet2-web:b88f6c243ce882c65dc794c188e8d0e677f6cb64
+metasheet-backend ghcr.io/zensgit/metasheet2-backend:b88f6c243ce882c65dc794c188e8d0e677f6cb64
+backend /api/health: status ok, plugins 13
+web /: HTTP 200
+```
+
+Current smoke status:
+
+```text
+Overall status: manual_pending
+Progress: 4/8 complete, 4 remaining
+Pending: send-group-message-form-link
+Pending: authorized-user-submit
+Pending: unauthorized-user-denied
+Pending: no-email-user-create-bind
+```
+
+Screenshot freshness scan:
+
+```text
+2026-05-10 17:07:05 IMG_1149.PNG
+2026-05-10 17:07:35 IMG_1150.PNG
+2026-05-10 17:08:05 IMG_1151.PNG
+2026-05-10 18:34:29 178bb7b3c1961dd8ae1bea9a1e4f4548.JPG
+2026-05-10 20:56:05 56e648b6002e4185c1cb2cbe384090f9.JPG
+2026-05-10 21:14:07 894a95ca7a48f3fa4d5d8131ed992fea.JPG
+2026-05-10 21:14:09 3e630dade053bf7152a9f50d080faeca.JPG
+```
+
+Directory state:
+
+```text
+Generated no-email target ending 1174: blank email, active, already linked to admin local user.
+ddzz target ending 9104: blank email, active, already linked to a no-email local user.
+```
+
+Local validation:
+
+```text
+git diff --check: pass
+secret-pattern scan: 0 matches
+node --test DingTalk evidence suites: 45 tests, 45 pass, 0 fail
+```
+
+## Evidence Contract Result
+
+The strict no-email check cannot be recorded as PASS unless all required admin evidence fields are present and true/non-empty:
+
+- `emailWasBlank`
+- `createdLocalUserId`
+- `boundDingTalkExternalId`
+- `accountLinkedAfterRefresh`
+- `temporaryPasswordRedacted`
+
+Because the generated active-session target is already linked to an admin local user, using it would misrepresent the create-and-bind workflow.
+
+## Remaining Manual Acceptance Items
+
+The following must still be captured against the current generated session before the final closeout can be marked CLOSED:
+
+- Current DingTalk group message screenshot or delivery artifact for `send-group-message-form-link`.
+- Authorized-user current-session form submit success evidence for `authorized-user-submit`.
+- Unauthorized-user current-session denial evidence plus zero record insert proof for `unauthorized-user-denied`.
+- A no-email DingTalk directory account create/bind artifact set that matches strict `no-email-user-create-bind` semantics.
+
+## Conclusion
+
+142 is healthy and the automated DingTalk smoke bootstrap remains usable, but the final DingTalk closeout is still blocked by manual evidence quality.
+
+The correct status is:
+
+```text
+manual_pending
+```
+
+Do not mark the final DingTalk matrix CLOSED until fresh current-session manual evidence is recorded and `dingtalk-p4-smoke-session.mjs --finalize` succeeds.


### PR DESCRIPTION
## Summary
- record the current 142 DingTalk live acceptance status after runtime recovery
- document why the 2026-05-10 screenshots cannot be reused for the 2026-05-12 smoke session
- document the no-email target mismatch and strict remaining evidence requirements

## Verification
- git diff --check
- strict value-pattern secret scan on the docs diff: 0 matches
- node --test scripts/ops/dingtalk-p4-evidence-record.test.mjs scripts/ops/compile-dingtalk-p4-smoke-evidence.test.mjs
- 142 server-local /api/health=ok and web /=200

## Status
- DingTalk live acceptance remains manual_pending, 4/8 complete
- no runtime code changed