### PR TITLE
chore(onprem): verify migration bridge in multitable package

### DIFF
--- a/docs/development/onprem-migration-bridge-package-verify-design-20260512.md
+++ b/docs/development/onprem-migration-bridge-package-verify-design-20260512.md
@@ -1,0 +1,62 @@
+# On-Prem Migration Bridge Package Verify Design
+
+## Purpose
+
+After issue `#651`, the Windows/on-prem package must not only contain SQL
+files. It must contain the migration runtime policy that makes those files safe
+to run on upgraded databases.
+
+The previous package verification checked that `056` through `059` were present
+inside the archive, but it did not prove that the package also included:
+
+- the rebuilt migration provider with the superseded legacy SQL skip policy;
+- the timestamp bridge that adds `users.must_change_password` after the modern
+  `users` table exists;
+- the guarded `056` SQL that no-ops when `users` has not been created yet.
+
+Without those checks, a future package could pass verify while still carrying
+the same class of migration failure seen on the entity machine.
+
+## Change
+
+`scripts/ops/multitable-onprem-package-verify.sh` now requires two additional
+runtime files:
+
+```text
+packages/core-backend/dist/src/db/migration-provider.js
+packages/core-backend/dist/src/db/migrations/zzzz20260512100000_add_users_must_change_password.js
+```
+
+It also validates the content contract:
+
+- `migration-provider.js` contains the superseded legacy SQL opt-in
+  `MIGRATION_INCLUDE_SUPERSEDED_LEGACY_SQL`;
+- `migration-provider.js` contains a known skipped legacy migration name,
+  `032_create_approval_records`;
+- `056_add_users_must_change_password.sql` contains the `to_regclass` guard for
+  absent `users` tables;
+- the timestamp bridge migration contains `must_change_password`.
+
+## Why Content Checks
+
+Path checks alone only prove that a file with the right name exists. The
+operator risk here is subtler: an archive built from the wrong SHA could include
+the old `migration-provider.js` and still pass if the verifier only checked
+generic runtime paths.
+
+The content checks are intentionally small and stable. They avoid parsing
+compiled JavaScript while still proving the package includes the specific
+runtime migration policy needed by the K3 WISE on-prem deployment.
+
+## Non-Goals
+
+- No new database migration.
+- No changes to K3 WISE adapter, setup page, or pipeline behavior.
+- No change to package layout beyond stronger verification.
+- No automatic deployment to the Windows/entity machine.
+
+## Deployment Impact
+
+Future Windows/on-prem package builds fail earlier if they omit the migration
+bridge. This is a packaging quality gate only; it does not change runtime
+behavior once the package is installed.

--- a/docs/development/onprem-migration-bridge-package-verify-verification-20260512.md
+++ b/docs/development/onprem-migration-bridge-package-verify-verification-20260512.md
@@ -1,0 +1,98 @@
+# On-Prem Migration Bridge Package Verify Verification
+
+## Scope
+
+Verify that the multitable on-prem package verifier now fails closed if the
+archive does not include the migration bridge required by issue `#651`.
+
+## Local Checks
+
+```bash
+bash -n scripts/ops/multitable-onprem-package-verify.sh
+```
+
+Expected:
+
+- shell syntax is valid.
+
+Observed:
+
+- exit `0`.
+
+```bash
+scripts/ops/multitable-onprem-package-verify.sh \
+  /tmp/metasheet2-k3wise-migbridge-25725063918/metasheet-multitable-onprem-v2.5.0-k3wise-migbridge-36ee325.zip
+```
+
+Expected:
+
+- checksum passes;
+- required content passes;
+- migration bridge content checks pass.
+
+Observed:
+
+```text
+metasheet-multitable-onprem-v2.5.0-k3wise-migbridge-36ee325.zip: OK
+[multitable-onprem-package-verify] Package verify OK
+```
+
+```bash
+scripts/ops/multitable-onprem-package-verify.sh \
+  /tmp/metasheet2-k3wise-migbridge-25725063918/metasheet-multitable-onprem-v2.5.0-k3wise-migbridge-36ee325.tgz
+```
+
+Expected:
+
+- same checks pass for the `.tgz` archive.
+
+Observed:
+
+```text
+metasheet-multitable-onprem-v2.5.0-k3wise-migbridge-36ee325.tgz: OK
+[multitable-onprem-package-verify] Package verify OK
+```
+
+```bash
+git diff --check origin/main...HEAD
+```
+
+Expected:
+
+- no whitespace errors;
+- no conflict markers.
+
+Observed:
+
+- exit `0`.
+
+## Package Used
+
+The verification package was the post-`#1486` package generated from main:
+
+- workflow run: `25725063918`
+- package tag: `k3wise-migbridge-36ee325`
+- zip:
+  `metasheet-multitable-onprem-v2.5.0-k3wise-migbridge-36ee325.zip`
+- tgz:
+  `metasheet-multitable-onprem-v2.5.0-k3wise-migbridge-36ee325.tgz`
+
+## Acceptance Matrix
+
+| Check | Expected |
+| --- | --- |
+| `migration-provider.js` exists in archive | PASS |
+| `zzzz20260512100000_add_users_must_change_password.js` exists in archive | PASS |
+| Provider contains `MIGRATION_INCLUDE_SUPERSEDED_LEGACY_SQL` | PASS |
+| Provider contains `032_create_approval_records` skip-list marker | PASS |
+| Legacy `056` SQL contains `to_regclass('public.users') IS NOT NULL` | PASS |
+| Timestamp bridge contains `must_change_password` | PASS |
+| ZIP verify | PASS |
+| TGZ verify | PASS |
+
+## Result
+
+The package verifier now treats the migration bridge as part of the Windows
+on-prem delivery contract. A future package that omits the runtime provider
+policy or timestamp bridge should fail before reaching the entity-machine
+deployment step.

--- a/scripts/ops/multitable-onprem-package-verify.sh
+++ b/scripts/ops/multitable-onprem-package-verify.sh
@@ -72,6 +72,18 @@ function verify_root_runtime_dependencies() {
   search_fixed_string '"bcryptjs"' "$package_json" || die "root package.json must include bcryptjs for Windows bootstrap compatibility"
 }
 
+function verify_migration_bridge_contract() {
+  local root="$1"
+  local provider="${root}/packages/core-backend/dist/src/db/migration-provider.js"
+  local legacy_must_change="${root}/packages/core-backend/migrations/056_add_users_must_change_password.sql"
+  local timestamp_must_change="${root}/packages/core-backend/dist/src/db/migrations/zzzz20260512100000_add_users_must_change_password.js"
+
+  search_fixed_string 'MIGRATION_INCLUDE_SUPERSEDED_LEGACY_SQL' "$provider" || die "migration-provider.js must expose the superseded legacy SQL opt-in"
+  search_fixed_string '032_create_approval_records' "$provider" || die "migration-provider.js must carry the superseded legacy SQL skip list"
+  search_fixed_string "to_regclass('public.users') IS NOT NULL" "$legacy_must_change" || die "056_add_users_must_change_password.sql must no-op when users table is absent"
+  search_fixed_string 'must_change_password' "$timestamp_must_change" || die "timestamp users must_change_password bridge migration must be packaged"
+}
+
 function write_optional_report() {
   local checksum_status="SKIPPED"
   local link_status="SKIPPED"
@@ -255,6 +267,8 @@ required=(
   "apps/web/package.json"
   "packages/core-backend/dist/src/index.js"
   "packages/core-backend/dist/src/db/migrate.js"
+  "packages/core-backend/dist/src/db/migration-provider.js"
+  "packages/core-backend/dist/src/db/migrations/zzzz20260512100000_add_users_must_change_password.js"
   "packages/core-backend/package.json"
   "packages/core-backend/migrations/056_add_users_must_change_password.sql"
   "packages/core-backend/migrations/057_create_integration_core_tables.sql"
@@ -304,6 +318,7 @@ bootstrap_run_wrapper="$(find "$pkg_root" -maxdepth 1 -type f -name 'bootstrap-a
 [[ -n "$bootstrap_run_wrapper" ]] || die "Required package content missing: bootstrap-admin-<run>.bat"
 verify_windows_entrypoints "$pkg_root"
 verify_root_runtime_dependencies "$pkg_root"
+verify_migration_bridge_contract "$pkg_root"
 
 if [[ "$VERIFY_NO_GITHUB_LINKS" == "1" ]]; then
   verify_no_github_links "$pkg_root"


### PR DESCRIPTION
## Summary
- require the packaged migration provider and timestamp must_change_password bridge in multitable on-prem package verification
- add small content checks for the legacy SQL skip policy, the 056 users-table guard, and the timestamp bridge
- add development and verification docs for the #651 package-level guard

## Verification
- bash -n scripts/ops/multitable-onprem-package-verify.sh
- scripts/ops/multitable-onprem-package-verify.sh /tmp/metasheet2-k3wise-migbridge-25725063918/metasheet-multitable-onprem-v2.5.0-k3wise-migbridge-36ee325.zip
- scripts/ops/multitable-onprem-package-verify.sh /tmp/metasheet2-k3wise-migbridge-25725063918/metasheet-multitable-onprem-v2.5.0-k3wise-migbridge-36ee325.tgz
- git diff --check origin/main...HEAD

## Deployment impact
No runtime change. Future on-prem packages fail verification if they omit the migration bridge that prevents the #651 numeric-vs-timestamp migration gap.