### PR TITLE
fix(integration): clarify K3 WISE setup guidance

### DIFF
--- a/apps/web/src/services/integration/k3WiseSetup.ts
+++ b/apps/web/src/services/integration/k3WiseSetup.ts
@@ -418,6 +418,10 @@ function getLocalStorageValue(key: string): string {
   return localStorage.getItem(key) || ''
 }
 
+function getDefaultTenantId(): string {
+  return getLocalStorageValue('tenantId') || 'default'
+}
+
 export function splitList(value: string): string[] {
   return value
     .split(/\r?\n|,/)
@@ -586,7 +590,7 @@ function validateHttpUrl(value: string, field: keyof K3WiseSetupForm, issues: K3
 }
 
 export function createDefaultK3WiseSetupForm(): K3WiseSetupForm {
-  const tenantId = getLocalStorageValue('tenantId')
+  const tenantId = getDefaultTenantId()
   const workspaceId = getLocalStorageValue('workspaceId')
   return {
     tenantId,

--- a/apps/web/src/views/IntegrationK3WiseSetupView.vue
+++ b/apps/web/src/views/IntegrationK3WiseSetupView.vue
@@ -88,9 +88,21 @@
           <div class="k3-setup__panel-head">
             <h2>连接测试</h2>
           </div>
+          <div class="k3-setup__connection-state">
+            <div class="k3-setup__record-main">
+              <strong>WebAPI 状态</strong>
+              <span class="k3-setup__badge" :data-status="webApiConnectionStatus.status">
+                {{ webApiConnectionStatus.label }}
+              </span>
+            </div>
+            <small>{{ webApiConnectionStatus.message }}</small>
+          </div>
           <button class="k3-setup__btn k3-setup__btn--full" type="button" :disabled="testingWebApi || !form.webApiSystemId" @click="testWebApi">
             {{ testingWebApi ? '测试中' : '测试 WebAPI' }}
           </button>
+          <p class="k3-setup__field-note">
+            先保存配置，再测试 WebAPI；测试通过后这里会显示已连接和最近测试时间。
+          </p>
           <button class="k3-setup__btn k3-setup__btn--full" type="button" :disabled="testingSql || !form.sqlSystemId" @click="testSqlServer">
             {{ testingSql ? '测试中' : '测试 SQL Server' }}
           </button>
@@ -266,12 +278,14 @@
           </div>
           <div class="k3-setup__grid">
             <label class="k3-setup__field">
-              <span>Tenant ID</span>
-              <input v-model.trim="form.tenantId" autocomplete="off" />
+              <span>Tenant ID（作用域）</span>
+              <input v-model.trim="form.tenantId" placeholder="default" autocomplete="off" />
+              <small>单租户实体机测试使用 default；它不是 K3 账套号。</small>
             </label>
             <label class="k3-setup__field">
-              <span>Workspace ID</span>
+              <span>Workspace ID（可选）</span>
               <input v-model.trim="form.workspaceId" autocomplete="off" />
+              <small>单工作区 PoC 建议留空；需要多工作区隔离时再填真实 ID。</small>
             </label>
             <label class="k3-setup__field">
               <span>系统名称</span>
@@ -293,7 +307,11 @@
             </label>
             <label class="k3-setup__field k3-setup__field--wide">
               <span>WebAPI Base URL</span>
-              <input v-model.trim="form.baseUrl" placeholder="https://k3.example.test/K3API/" autocomplete="off" />
+              <input v-model.trim="form.baseUrl" placeholder="http://k3-server:port" autocomplete="off" />
+              <small>只填协议、主机和端口；不要带 /K3API，下面的路径已包含 /K3API。</small>
+              <small v-if="baseUrlHasK3ApiPath" class="k3-setup__hint-warning">
+                当前 Base URL 含 /K3API；建议改为只到主机端口，保留高级路径的 /K3API/... 默认值。
+              </small>
             </label>
             <label class="k3-setup__field">
               <span>认证模式</span>
@@ -330,6 +348,9 @@
             <span>高级 WebAPI 设置</span>
             <small>路径、语言、超时和 Submit/Audit 策略；默认值通常可直接使用</small>
           </summary>
+          <p class="k3-setup__field-note k3-setup__field-note--wide">
+            这些路径会相对 WebAPI Base URL 请求。实体机 PoC 推荐 Base URL 只写 http://K3主机:端口，Token/Save/BOM 路径保留 /K3API/...。
+          </p>
           <div class="k3-setup__grid">
             <label v-if="form.webApiAuthMode === 'authority-code'" class="k3-setup__field">
               <span>Token Path</span>
@@ -664,6 +685,44 @@ const deployGateSummary = computed(() => summarizeK3WiseDeployGateChecklist(depl
 const observationSummary = computed(() => `${pipelineRuns.value.length} runs / ${deadLetters.value.length} open`)
 const stagingDescriptorLabel = computed(() => stagingDescriptors.value.length > 0 ? `${stagingDescriptors.value.length} descriptors` : 'not loaded')
 const templatePreviewJson = computed(() => JSON.stringify(buildK3WiseDocumentPayloadPreview(templatePreviewTarget.value), null, 2))
+const selectedWebApiSystem = computed(() => webApiSystems.value.find((system) => system.id === form.webApiSystemId) || null)
+const baseUrlHasK3ApiPath = computed(() => /\/k3api(?:\/|$)/i.test(form.baseUrl.trim()))
+const webApiConnectionStatus = computed(() => {
+  if (testingWebApi.value) {
+    return {
+      status: 'partial',
+      label: 'testing',
+      message: '正在向已保存的 K3 WISE WebAPI 配置发起连接测试。',
+    }
+  }
+  if (!form.webApiSystemId) {
+    return {
+      status: 'open',
+      label: 'not saved',
+      message: '还没有保存 K3 WISE WebAPI 配置；保存后才能测试连接。',
+    }
+  }
+  const system = selectedWebApiSystem.value
+  if (system?.lastError) {
+    return {
+      status: 'failed',
+      label: 'failed',
+      message: `上次连接测试失败：${system.lastError}`,
+    }
+  }
+  if (system?.lastTestedAt) {
+    return {
+      status: 'succeeded',
+      label: 'connected',
+      message: `已连接 K3 WISE WebAPI；最近测试 ${formatTimestamp(system.lastTestedAt)}。`,
+    }
+  }
+  return {
+    status: 'open',
+    label: 'untested',
+    message: '配置已保存，但尚未测试；点击“测试 WebAPI”确认是否连上 K3。',
+  }
+})
 
 function setStatus(message: string, kind: 'info' | 'success' | 'error' = 'info'): void {
   statusMessage.value = message
@@ -1172,6 +1231,10 @@ onMounted(() => {
   grid-column: 1 / -1;
 }
 
+.k3-setup__hint-warning {
+  color: #92400e;
+}
+
 .k3-setup__field input,
 .k3-setup__field select,
 .k3-setup__field textarea {
@@ -1281,6 +1344,24 @@ onMounted(() => {
 
 .k3-setup__saved-error {
   color: #9f1239;
+  overflow-wrap: anywhere;
+}
+
+.k3-setup__connection-state {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  padding: 10px;
+  background: #f8fafc;
+}
+
+.k3-setup__connection-state small {
+  color: #64748b;
+  font-size: 12px;
+  line-height: 1.45;
   overflow-wrap: anywhere;
 }
 

--- a/apps/web/tests/IntegrationK3WiseSetupView.spec.ts
+++ b/apps/web/tests/IntegrationK3WiseSetupView.spec.ts
@@ -81,6 +81,12 @@ describe('IntegrationK3WiseSetupView', () => {
     expect(container.textContent).toContain('1. 接通 K3')
     expect(container.textContent).toContain('2. 准备多维表')
     expect(container.textContent).toContain('基础连接')
+    expect(container.textContent).toContain('Tenant ID（作用域）')
+    expect(container.textContent).toContain('单租户实体机测试使用 default')
+    expect(container.textContent).toContain('Workspace ID（可选）')
+    expect(container.textContent).toContain('不要带 /K3API')
+    expect(container.textContent).toContain('WebAPI 状态')
+    expect(container.textContent).toContain('not saved')
     expect(container.textContent).toContain('多维表清洗准备')
     expect(container.textContent).toContain('K3 单据模板')
     expect(container.textContent).toContain('K3 WISE 物料')
@@ -95,5 +101,12 @@ describe('IntegrationK3WiseSetupView', () => {
     const sideRailSections = Array.from(container.querySelectorAll('details.k3-setup__collapsible-panel')) as HTMLDetailsElement[]
     expect(sideRailSections).toHaveLength(2)
     expect(sideRailSections.every((section) => section.open === false)).toBe(true)
+
+    const baseUrlInput = Array.from(container.querySelectorAll('input')).find((input) => input.placeholder === 'http://k3-server:port') as HTMLInputElement
+    baseUrlInput.value = 'http://k3.local/K3API/'
+    baseUrlInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+
+    expect(container.textContent).toContain('当前 Base URL 含 /K3API')
   })
 })

--- a/apps/web/tests/k3WiseSetup.spec.ts
+++ b/apps/web/tests/k3WiseSetup.spec.ts
@@ -25,6 +25,13 @@ import {
 } from '../src/services/integration/k3WiseSetup'
 
 describe('K3 WISE setup helpers', () => {
+  it('defaults tenant scope to default for single-tenant on-prem setup', () => {
+    const form = createDefaultK3WiseSetupForm()
+
+    expect(form.tenantId).toBe('default')
+    expect(form.workspaceId).toBe('')
+  })
+
   it('builds WebAPI and SQL Server external-system payloads from the setup form', () => {
     const form = createDefaultK3WiseSetupForm()
     Object.assign(form, {

--- a/docs/development/integration-k3wise-setup-guidance-design-20260512.md
+++ b/docs/development/integration-k3wise-setup-guidance-design-20260512.md
@@ -1,0 +1,47 @@
+# K3 WISE setup guidance design
+
+## Context
+
+The Windows on-prem K3 WISE setup page exposed internal integration scope fields next to K3 connection fields without enough operator guidance. During manual deployment testing, this caused three avoidable questions:
+
+- whether `Tenant ID` should be removed;
+- whether `Workspace ID` is required;
+- whether `WebAPI Base URL` should include `/K3API` when advanced paths already contain `/K3API/...`;
+- how an operator can tell that K3 WISE is actually connected.
+
+## Decision
+
+Keep `Tenant ID` visible but document it as an integration scope, not a K3 business field. The backend requires a tenant scope for external-system and pipeline routes, so removing it would make the form less honest and push the error later into API validation.
+
+For the current single-tenant on-prem PoC:
+
+- default `Tenant ID` to `default` when no local tenant is available;
+- keep `Workspace ID` optional and advise leaving it blank for the current PoC;
+- tell operators that K3 `acctId` belongs in the credential section, not in `Tenant ID`;
+- change the Base URL placeholder to host-only form, for example `http://k3-server:port`;
+- explain that advanced WebAPI paths already include `/K3API/...`;
+- show a non-blocking warning when the Base URL contains `/K3API`;
+- add a visible WebAPI connection state in the side rail.
+
+## UX Contract
+
+The page now describes the expected deployment values:
+
+| Field | On-prem PoC guidance |
+| --- | --- |
+| Tenant ID | Use `default` for the single-tenant entity-machine test. |
+| Workspace ID | Leave blank unless multiple workspace scopes are explicitly required. |
+| WebAPI Base URL | Fill only protocol, host, and optional port. |
+| Token/Login/Save paths | Keep `/K3API/...` path defaults unless the customer K3 API package differs. |
+| WebAPI connection state | Save first, then click `Test WebAPI`; connected state requires a successful saved-system test. |
+
+## Non-Goals
+
+- This change does not alter backend authorization or route scope enforcement.
+- This change does not hide `Tenant ID`, because the API still needs it.
+- This change does not auto-test K3 on every form edit; connection testing remains an explicit operator action.
+- This change does not change K3 adapter URL composition.
+
+## Deployment Impact
+
+Frontend-only change. No migration, runtime config, credential, or plugin behavior change.

--- a/docs/development/integration-k3wise-setup-guidance-verification-20260512.md
+++ b/docs/development/integration-k3wise-setup-guidance-verification-20260512.md
@@ -1,0 +1,80 @@
+# K3 WISE setup guidance verification
+
+## Scope
+
+Verify the setup page now explains the integration scope fields, the WebAPI Base URL/path split, and the K3 connection test result without changing backend behavior.
+
+## Static Checks
+
+Expected source updates:
+
+- `apps/web/src/services/integration/k3WiseSetup.ts`
+  - defaults `tenantId` to `default` when local storage has no tenant;
+  - preserves stored local tenant when one exists.
+- `apps/web/src/views/IntegrationK3WiseSetupView.vue`
+  - labels `Tenant ID` as a scope field;
+  - labels `Workspace ID` as optional;
+  - changes Base URL placeholder to host-only form;
+  - warns when Base URL includes `/K3API`;
+  - adds WebAPI connection state messaging.
+
+## Local Test Plan
+
+Run:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/k3WiseSetup.spec.ts tests/IntegrationK3WiseSetupView.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+git diff --check origin/main...HEAD
+```
+
+Expected:
+
+- helper tests pass, including default `Tenant ID = default`;
+- setup view tests pass, including rendered guidance copy and `/K3API` warning;
+- frontend build passes;
+- diff check is clean.
+
+## Manual Operator Acceptance
+
+On the K3 WISE setup page:
+
+1. New empty form should show `Tenant ID` prefilled as `default`.
+2. `Workspace ID` should be visibly optional.
+3. `WebAPI Base URL` should show a host-only placeholder.
+4. If an operator enters `http://k3-host/K3API/`, the page should show a warning to remove `/K3API`.
+5. Side rail should show `WebAPI 状态`.
+6. Before saving, state should be `not saved`.
+7. After saving and running `测试 WebAPI`, a successful backend test should show `connected` with the last test time.
+
+## Result
+
+Executed on branch `codex/k3wise-setup-guidance-20260512`:
+
+```text
+pnpm --filter @metasheet/web exec vitest run tests/k3WiseSetup.spec.ts tests/IntegrationK3WiseSetupView.spec.ts --watch=false
+```
+
+Result:
+
+```text
+Test Files  2 passed (2)
+Tests       29 passed (29)
+```
+
+```text
+pnpm --filter @metasheet/web build
+```
+
+Result:
+
+```text
+vue-tsc -b && vite build
+✓ built
+```
+
+```text
+git diff --check
+```
+
+Result: clean.


### PR DESCRIPTION
## Summary\n- default the K3 WISE setup tenant scope to `default` for single-tenant on-prem tests\n- clarify Tenant ID / Workspace ID semantics and WebAPI Base URL vs `/K3API/...` path usage\n- add a visible WebAPI connection state so operators know whether K3 has been tested successfully\n- add design and verification docs for the setup guidance change\n\n## Verification\n- `pnpm --filter @metasheet/web exec vitest run tests/k3WiseSetup.spec.ts tests/IntegrationK3WiseSetupView.spec.ts --watch=false` -> 29/29 pass\n- `pnpm --filter @metasheet/web build` -> pass\n- `git diff --check` -> clean\n\n## Deployment Impact\n- frontend-only guidance change\n- no DB migration\n- no backend route or K3 adapter behavior change\n\n## Notes\nTenant ID is intentionally retained because integration external-system and pipeline APIs require tenant scope. For the current on-prem PoC, use `default`; leave Workspace ID blank unless a real workspace scope is required.