### PR TITLE
fix(integration): include tenant scope in K3 WebAPI tests

### DIFF
--- a/apps/web/src/views/IntegrationK3WiseSetupView.vue
+++ b/apps/web/src/views/IntegrationK3WiseSetupView.vue
@@ -7,7 +7,7 @@
         <p class="k3-setup__lead">先接通 K3 WISE，再把 PLM 数据放进多维表清洗，最后 dry-run 后推送 ERP。</p>
       </div>
       <div class="k3-setup__header-actions">
-        <button class="k3-setup__btn" type="button" :disabled="loading" @click="loadSystems">
+        <button class="k3-setup__btn" type="button" :disabled="loading" @click="loadSystems(false)">
           {{ loading ? '刷新中' : '刷新' }}
         </button>
         <button class="k3-setup__btn k3-setup__btn--primary" type="button" :disabled="saving" @click="saveConfiguration">
@@ -668,6 +668,12 @@ const testResult = ref('')
 const stagingResult = ref('')
 const pipelineResult = ref('')
 const pipelineRunResult = ref('')
+const webApiLastTest = ref<{
+  systemId: string
+  ok: boolean
+  lastTestedAt: string
+  lastError: string | null
+} | null>(null)
 const pipelineRuns = ref<IntegrationPipelineRun[]>([])
 const deadLetters = ref<IntegrationDeadLetter[]>([])
 const stagingDescriptors = ref<IntegrationStagingDescriptor[]>([])
@@ -700,6 +706,20 @@ const webApiConnectionStatus = computed(() => {
       status: 'open',
       label: 'not saved',
       message: '还没有保存 K3 WISE WebAPI 配置；保存后才能测试连接。',
+    }
+  }
+  if (webApiLastTest.value?.systemId === form.webApiSystemId) {
+    if (webApiLastTest.value.ok) {
+      return {
+        status: 'succeeded',
+        label: 'connected',
+        message: `已连接 K3 WISE WebAPI；最近测试 ${formatTimestamp(webApiLastTest.value.lastTestedAt)}。`,
+      }
+    }
+    return {
+      status: 'failed',
+      label: 'failed',
+      message: `上次连接测试失败：${webApiLastTest.value.lastError || 'K3 WISE WebAPI returned an unsuccessful test result'}`,
     }
   }
   const system = selectedWebApiSystem.value
@@ -766,13 +786,42 @@ function isTemplateMappingRequired(mapping: K3WiseDocumentTemplateMapping): bool
   return validation.some((item) => Boolean(item && typeof item === 'object' && (item as { type?: unknown }).type === 'required'))
 }
 
+function getTestResultSystem(result: Record<string, unknown>): IntegrationExternalSystem | null {
+  const system = result.system
+  if (!system || typeof system !== 'object' || Array.isArray(system)) return null
+  const candidate = system as Partial<IntegrationExternalSystem>
+  if (typeof candidate.id !== 'string' || typeof candidate.name !== 'string' || typeof candidate.kind !== 'string') return null
+  return candidate as IntegrationExternalSystem
+}
+
+function upsertLocalWebApiSystem(system: IntegrationExternalSystem): void {
+  if (system.kind !== K3_WISE_WEBAPI_KIND) return
+  const index = webApiSystems.value.findIndex((item) => item.id === system.id)
+  if (index === -1) {
+    webApiSystems.value = [system, ...webApiSystems.value]
+    return
+  }
+  const next = [...webApiSystems.value]
+  next[index] = { ...next[index], ...system }
+  webApiSystems.value = next
+}
+
+function buildConnectionTestPayload(): Record<string, unknown> {
+  return {
+    tenantId: form.tenantId.trim(),
+    workspaceId: form.workspaceId.trim() || null,
+    skipHealth: !form.healthPath.trim(),
+  }
+}
+
 function loadSystemIntoForm(system: IntegrationExternalSystem): void {
   Object.assign(form, applyExternalSystemToForm(form, system))
   testResult.value = ''
+  webApiLastTest.value = null
   setStatus(`已载入 ${system.name}`, 'info')
 }
 
-async function loadSystems(): Promise<void> {
+async function loadSystems(silent = false): Promise<void> {
   loading.value = true
   try {
     const [webApi, sql] = await Promise.all([
@@ -783,9 +832,9 @@ async function loadSystems(): Promise<void> {
     sqlSystems.value = sql
     if (!form.webApiSystemId && webApi[0]) loadSystemIntoForm(webApi[0])
     if (!form.sqlSystemId && sql[0]) loadSystemIntoForm(sql[0])
-    setStatus('K3 WISE 配置已刷新', 'success')
+    if (!silent) setStatus('K3 WISE 配置已刷新', 'success')
   } catch (error) {
-    setStatus(formatError(error), 'error')
+    if (!silent) setStatus(formatError(error), 'error')
   } finally {
     loading.value = false
   }
@@ -798,6 +847,7 @@ async function saveConfiguration(): Promise<void> {
     return
   }
   saving.value = true
+  webApiLastTest.value = null
   try {
     const payloads = buildK3WiseSetupPayloads(form)
     const webApi = await upsertIntegrationSystem(payloads.webApi)
@@ -808,7 +858,7 @@ async function saveConfiguration(): Promise<void> {
       form.sqlSystemId = sql.id
       form.sqlHasCredentials = sql.hasCredentials === true
     }
-    await loadSystems()
+    await loadSystems(true)
     setStatus('K3 WISE 对接配置已保存', 'success')
   } catch (error) {
     setStatus(formatError(error), 'error')
@@ -822,11 +872,28 @@ async function testWebApi(): Promise<void> {
   testingWebApi.value = true
   testResult.value = ''
   try {
-    const result = await testIntegrationSystem(form.webApiSystemId, { skipHealth: !form.healthPath.trim() })
+    const result = await testIntegrationSystem(form.webApiSystemId, buildConnectionTestPayload())
     testResult.value = JSON.stringify(result, null, 2)
-    await loadSystems()
-    setStatus('WebAPI 连接测试完成', 'success')
+    const testedSystem = getTestResultSystem(result)
+    if (testedSystem) upsertLocalWebApiSystem(testedSystem)
+    const lastTestedAt = testedSystem?.lastTestedAt || new Date().toISOString()
+    const lastError = typeof result.message === 'string' ? result.message : testedSystem?.lastError || null
+    webApiLastTest.value = {
+      systemId: form.webApiSystemId,
+      ok: result.ok === true,
+      lastTestedAt,
+      lastError,
+    }
+    testingWebApi.value = false
+    void loadSystems(true)
+    setStatus(result.ok === true ? 'WebAPI 连接测试完成' : 'WebAPI 连接测试失败', result.ok === true ? 'success' : 'error')
   } catch (error) {
+    webApiLastTest.value = {
+      systemId: form.webApiSystemId,
+      ok: false,
+      lastTestedAt: new Date().toISOString(),
+      lastError: formatError(error),
+    }
     setStatus(formatError(error), 'error')
   } finally {
     testingWebApi.value = false
@@ -838,9 +905,9 @@ async function testSqlServer(): Promise<void> {
   testingSql.value = true
   testResult.value = ''
   try {
-    const result = await testIntegrationSystem(form.sqlSystemId)
+    const result = await testIntegrationSystem(form.sqlSystemId, buildConnectionTestPayload())
     testResult.value = JSON.stringify(result, null, 2)
-    await loadSystems()
+    await loadSystems(true)
     setStatus('SQL Server 通道测试完成', 'success')
   } catch (error) {
     setStatus(formatError(error), 'error')
@@ -974,7 +1041,7 @@ async function executePipeline(target: K3WisePipelineTarget, dryRun: boolean): P
 }
 
 onMounted(() => {
-  void loadSystems()
+  void loadSystems(true)
   void loadStagingDescriptors(true)
 })
 </script>

--- a/apps/web/tests/IntegrationK3WiseSetupView.spec.ts
+++ b/apps/web/tests/IntegrationK3WiseSetupView.spec.ts
@@ -109,4 +109,68 @@ describe('IntegrationK3WiseSetupView', () => {
 
     expect(container.textContent).toContain('当前 Base URL 含 /K3API')
   })
+
+  it('sends tenant scope when testing the saved WebAPI system', async () => {
+    const system = {
+      id: 'k3_sys_1',
+      tenantId: 'default',
+      workspaceId: null,
+      name: 'K3 WISE WebAPI',
+      kind: 'erp:k3-wise-webapi',
+      role: 'target',
+      status: 'active',
+      hasCredentials: true,
+      config: {
+        version: 'K3 WISE 15.x',
+        baseUrl: 'http://k3.local',
+      },
+      capabilities: {},
+    }
+    apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url.startsWith('/api/integration/external-systems?kind=erp%3Ak3-wise-webapi')) {
+        return jsonResponse([system])
+      }
+      if (url.startsWith('/api/integration/external-systems?kind=erp%3Ak3-wise-sqlserver')) {
+        return jsonResponse([])
+      }
+      if (url === '/api/integration/external-systems/k3_sys_1/test') {
+        const body = JSON.parse(String(init?.body || '{}'))
+        expect(body).toMatchObject({
+          tenantId: 'default',
+          workspaceId: null,
+          skipHealth: true,
+        })
+        return jsonResponse({
+          ok: true,
+          status: 200,
+          authenticated: true,
+          system: {
+            ...system,
+            lastTestedAt: '2026-05-12T10:00:00.000Z',
+            lastError: null,
+          },
+        })
+      }
+      if (url === '/api/integration/staging/descriptors') {
+        return jsonResponse([])
+      }
+      return jsonResponse({})
+    })
+
+    const View = (await import('../src/views/IntegrationK3WiseSetupView.vue')).default
+
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    app.mount(container)
+    await flushUi()
+
+    const button = Array.from(container.querySelectorAll('button')).find((item) => item.textContent?.includes('测试 WebAPI')) as HTMLButtonElement
+    expect(button.disabled).toBe(false)
+    button.click()
+    await flushUi(8)
+
+    expect(container.textContent).toContain('connected')
+    expect(container.textContent).toContain('WebAPI 连接测试完成')
+  })
 })

--- a/docs/development/integration-k3wise-webapi-test-scope-design-20260512.md
+++ b/docs/development/integration-k3wise-webapi-test-scope-design-20260512.md
@@ -1,0 +1,51 @@
+# K3 WISE WebAPI test scope design
+
+## Context
+
+In the K3 WISE setup page, saving a WebAPI external system includes `tenantId` and optional `workspaceId`, but the `测试 WebAPI` button only posted `{ skipHealth }` to:
+
+```text
+POST /api/integration/external-systems/:id/test
+```
+
+The backend integration test route resolves scope from request body, query, route params, or user context. On on-prem admin sessions where the token does not carry a tenant context, the route returned:
+
+```text
+tenantId is required
+```
+
+This made the UI look like the K3 connection failed even though the saved system already had the correct scope.
+
+## Change
+
+The setup page now builds a scoped connection-test payload:
+
+```json
+{
+  "tenantId": "default",
+  "workspaceId": null,
+  "skipHealth": true
+}
+```
+
+Both WebAPI and SQL Server test buttons use this scoped payload.
+
+The WebAPI test UI also updates its local connection state immediately from the test response. The page no longer waits for the saved-system list refresh before showing `connected` or `failed`; list refresh runs silently after the result is rendered.
+
+## Why This Shape
+
+- Scope remains explicit and consistent with save/list/run APIs.
+- The backend route does not need special on-prem fallback logic.
+- The UI becomes responsive even when the post-test list refresh is slow or stale.
+- The test result still remains redaction-safe because the backend response already removes credentials.
+
+## Non-Goals
+
+- No backend route changes.
+- No K3 adapter behavior changes.
+- No migration or package layout changes.
+- No automatic live write to K3; this only affects the connection test button.
+
+## Deployment Impact
+
+Frontend-only bug fix. Safe to ship in the next Windows on-prem package.

--- a/docs/development/integration-k3wise-webapi-test-scope-verification-20260512.md
+++ b/docs/development/integration-k3wise-webapi-test-scope-verification-20260512.md
@@ -1,0 +1,53 @@
+# K3 WISE WebAPI test scope verification
+
+## Scope
+
+Verify the K3 WISE setup page sends tenant/workspace scope when testing a saved WebAPI system and shows `connected` immediately when the backend test succeeds.
+
+## Local Commands
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/IntegrationK3WiseSetupView.spec.ts tests/k3WiseSetup.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+## Expected Assertions
+
+- View test posts `tenantId: default` and `workspaceId: null` to `/api/integration/external-systems/:id/test`.
+- View test renders `connected` after a successful test response.
+- Existing K3 WISE setup helper tests remain green.
+- Web build passes.
+- Diff check is clean.
+
+## Result
+
+Executed on branch `codex/k3wise-webapi-test-status-20260512`:
+
+```text
+pnpm --filter @metasheet/web exec vitest run tests/IntegrationK3WiseSetupView.spec.ts tests/k3WiseSetup.spec.ts --watch=false
+```
+
+Result:
+
+```text
+Test Files  2 passed (2)
+Tests       30 passed (30)
+```
+
+```text
+pnpm --filter @metasheet/web build
+```
+
+Result:
+
+```text
+vue-tsc -b && vite build
+✓ built
+```
+
+```text
+git diff --check
+```
+
+Result: clean.


### PR DESCRIPTION
## Summary\n- send tenantId/workspaceId when testing saved K3 WISE WebAPI and SQL Server external systems\n- update WebAPI connection state immediately from the test response instead of waiting on the saved-system list refresh\n- add a regression test for the tenant scope payload and connected-state render\n- add design and verification docs\n\n## Verification\n- `pnpm --filter @metasheet/web exec vitest run tests/IntegrationK3WiseSetupView.spec.ts tests/k3WiseSetup.spec.ts --watch=false` -> 30/30 pass\n- `pnpm --filter @metasheet/web build` -> pass\n- `git diff --check` -> clean\n\n## Deployment Impact\n- frontend-only fix\n- no DB migration\n- no backend or K3 adapter behavior change\n\n## Operator Note\nThis fixes the on-prem setup-page symptom where clicking `测试 WebAPI` could show `tenantId is required` or leave WebAPI 状态 at `untested` even though the saved form already had Tenant ID = `default`.