### PR TITLE
fix(migrations): keep superseded legacy history visible

### DIFF
--- a/docs/development/migration-legacy-sql-skip-design-20260512.md
+++ b/docs/development/migration-legacy-sql-skip-design-20260512.md
@@ -15,8 +15,9 @@ timestamp migration schema.
 ## Decision
 
 The provider now treats legacy numeric core SQL migrations `032` through `055`
-as superseded by the modern timestamp migration stream and excludes them from
-the default migration set.
+as superseded by the modern timestamp migration stream. By default it keeps
+their names visible to Kysely as no-op history markers instead of executing the
+legacy SQL bodies.
 
 The default skip list covers:
 
@@ -73,6 +74,11 @@ the failure occurs. The package verifier can continue asserting that K3/on-prem
 SQL migrations are present in the archive, while the migrator stops applying
 legacy core migrations that have already been replaced by timestamp migrations.
 
+Keeping no-op history markers is required for upgraded databases that already
+have `032` through `055` in `kysely_migration`. Hiding those names completely
+makes Kysely reject the database as a corrupted migration history even though
+the runtime schema is healthy.
+
 The approach avoids three bad outcomes:
 
 - no more one-by-one emergency patching of obsolete SQL assumptions;
@@ -101,9 +107,12 @@ The approach avoids three bad outcomes:
 This is a migration-provider policy change. It affects which pending migrations
 are visible to `db:migrate` and `db:list`.
 
-Existing databases that already applied any skipped legacy migration are not
-rolled back. New or upgraded on-prem databases should now follow the modern
-timestamp migration stream plus the on-prem SQL tail (`056` and later).
+Existing databases that already applied any superseded legacy migration are not
+rolled back and no longer trip Kysely's missing-provider corruption check. New
+or upgraded on-prem databases should now follow the modern timestamp migration
+stream plus the on-prem SQL tail (`056` and later); `032` through `055` are
+recorded only as no-op superseded markers unless the explicit compatibility
+audit flag is enabled.
 
 ## GATE Impact
 

--- a/docs/development/migration-legacy-sql-skip-verification-20260512.md
+++ b/docs/development/migration-legacy-sql-skip-verification-20260512.md
@@ -3,8 +3,9 @@
 ## Goal
 
 Prove that the migration provider no longer applies superseded legacy numeric
-core SQL migrations by default, while preserving the on-prem/K3 SQL migrations
-needed by packaged deployments.
+core SQL migrations by default, while preserving their names as Kysely-visible
+no-op history markers and keeping the on-prem/K3 SQL migrations needed by
+packaged deployments.
 
 ## Local Commands
 
@@ -18,8 +19,8 @@ Expected result:
 
 - migration provider unit tests pass;
 - `032_create_approval_records`, `037_add_gallery_form_support`, and
-  `055_create_attendance_import_tokens` are absent from the default migration
-  set;
+  `055_create_attendance_import_tokens` are present as no-op history markers in
+  the default migration set;
 - `056_add_users_must_change_password` and
   `057_create_integration_core_tables` remain present.
 
@@ -70,15 +71,15 @@ Observed:
 
 ```json
 {
-  "has032": false,
-  "has037": false,
-  "has055": false,
+  "has032": true,
+  "has037": true,
+  "has055": true,
   "has056": true,
   "hasModernMustChange": true,
   "has057": true,
   "has058": true,
   "has059": true,
-  "total": 131
+  "total": 160
 }
 ```
 
@@ -88,11 +89,11 @@ Observed:
 | --- | --- |
 | Source-style runtime loads timestamp code migration plus `056` | Present |
 | Dist-style runtime loads timestamp SQL migration plus `056` | Present |
-| Default provider sees `032`, `037`, `055`, `056`, `057` in legacy folder | Only `056` and `057` remain |
+| Default provider sees `032`, `037`, `055`, `056`, `057` in legacy folder | `032`, `037`, and `055` remain visible as no-op markers; `056` and `057` remain executable |
 | Fresh replay applies `056` before timestamp `users` creation | `056` is guarded and does not fail |
 | Timestamp users migration has run | `zzzz20260512100000_add_users_must_change_password` adds the required column |
 | Legacy event-bus SQL is skipped | CI allows `20250924200000_create_event_bus_tables` to run so later event-bus alignment has tables to alter |
-| `includeSupersededLegacySqlMigrations: true` | `037` is visible for explicit audits |
+| `includeSupersededLegacySqlMigrations: true` | `037` is visible with its real SQL body for explicit audits |
 | `MIGRATION_EXCLUDE` / `excludedNames` excludes `056` | Existing exclusion behavior preserved |
 | Duplicate migration names across provider folders | Still fails fast |
 
@@ -117,7 +118,7 @@ The package should still include the required K3/on-prem SQL files:
 For the Windows/on-prem deployment that hit issue `#651`, acceptance is:
 
 1. deploy package built from the merged SHA;
-2. migration step no longer attempts superseded legacy SQL `032` through `055`;
+2. migration step no longer executes superseded legacy SQL `032` through `055`;
 3. `056` still supplies `users.must_change_password`;
 4. `057` through `059` still supply integration runtime tables and indexes;
 5. service starts without manual database patching.

--- a/docs/development/migration-superseded-legacy-noop-development-20260512.md
+++ b/docs/development/migration-superseded-legacy-noop-development-20260512.md
@@ -1,0 +1,60 @@
+# Superseded Legacy SQL No-op Migration Provider Development
+
+## Summary
+
+142 deployment of the DingTalk closeout image reached healthy containers, but
+the GitHub deploy job failed during `db:migrate` with Kysely reporting a
+corrupted migration history. The deployed database already contained legacy SQL
+migration records `032_create_approval_records` through
+`055_create_attendance_import_tokens`, while the latest migration provider hid
+those names by default.
+
+This change keeps superseded legacy SQL migrations visible to Kysely as no-op
+history markers. That preserves the intended fresh-install behavior: the old SQL
+bodies are not replayed. It also makes upgraded databases with existing
+`kysely_migration` rows valid again.
+
+## Root Cause
+
+Kysely treats an executed migration row as corrupted if the current provider no
+longer returns that migration name. The prior skip-list implementation filtered
+`032` through `055` out of the provider response. That is safe only for fresh
+databases that never recorded those names; it is unsafe for upgraded production
+databases that already executed them historically.
+
+## Implementation
+
+- Added `createNoopMigration()` in the core backend migration provider.
+- Split default superseded legacy handling from explicit operator exclusions.
+- Replaced loaded superseded legacy SQL migrations with no-op migrations instead
+  of filtering them out.
+- Preserved `MIGRATION_INCLUDE_SUPERSEDED_LEGACY_SQL=true` and
+  `includeSupersededLegacySqlMigrations: true` for compatibility audits that
+  need the real legacy SQL body.
+- Preserved `MIGRATION_EXCLUDE` / `excludedNames` as an explicit operator escape
+  hatch that can still hide migrations.
+- Updated migration-provider tests and existing migration design/verification
+  docs to describe no-op markers instead of complete absence.
+
+## Changed Files
+
+- `packages/core-backend/src/db/migration-provider.ts`
+- `packages/core-backend/tests/unit/migration-provider.test.ts`
+- `docs/development/migration-legacy-sql-skip-design-20260512.md`
+- `docs/development/migration-legacy-sql-skip-verification-20260512.md`
+- `docs/development/migration-superseded-legacy-noop-development-20260512.md`
+- `docs/development/migration-superseded-legacy-noop-verification-20260512.md`
+
+## Deployment Impact
+
+Fresh databases still avoid replaying the superseded `032` through `055` SQL
+bodies. Upgraded databases that already have those names in `kysely_migration`
+now pass Kysely migration history validation. No table drops, data backfills, or
+manual database edits are introduced.
+
+## Rollback
+
+Rollback is the previous GHCR backend/web tag. If a deploy issue appears after
+this patch, switch `metasheet-backend` and `metasheet-web` back to the previous
+known-good image tag and verify `/api/health`, `/`, and `/api/auth/me` returns
+`401` when unauthenticated.

--- a/docs/development/migration-superseded-legacy-noop-verification-20260512.md
+++ b/docs/development/migration-superseded-legacy-noop-verification-20260512.md
@@ -1,0 +1,120 @@
+# Superseded Legacy SQL No-op Migration Provider Verification
+
+## Goal
+
+Verify the migration provider fix that unblocks upgraded databases with existing
+legacy migration history while still preventing superseded legacy SQL bodies
+from replaying on fresh installs.
+
+## Pre-fix Evidence
+
+142 had all superseded legacy SQL names recorded in `kysely_migration`:
+
+- `032_create_approval_records`
+- `033_create_rbac_core`
+- `034_create_spreadsheets`
+- `035_create_files`
+- `036_create_spreadsheet_permissions`
+- `037_add_gallery_form_support`
+- `038_config_and_secrets`
+- `040_data_sources`
+- `041_script_sandbox`
+- `042_core_model_completion`
+- `042a_core_model_views`
+- `042b_external_data_model`
+- `042c_audit_placeholder`
+- `042d_audit_and_cache`
+- `042d_plugins_and_templates`
+- `043_core_model_views`
+- `044_external_data_model`
+- `045_audit_placeholder`
+- `046_plugins_and_templates`
+- `047_audit_and_cache`
+- `047_create_event_bus_tables`
+- `048_create_event_bus_tables`
+- `049_create_bpmn_workflow_tables`
+- `050_create_snapshot_core`
+- `051_create_minimal_views`
+- `052_recreate_minimal_views`
+- `053_create_protection_rules`
+- `054_create_users_table`
+- `055_create_attendance_import_tokens`
+
+The failed deploy path reported:
+
+```text
+failed to migrate
+Error: corrupted migrations: previously executed migration 032_create_approval_records is missing
+```
+
+## Local Verification
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/migration-provider.test.ts \
+  tests/unit/migrations.rollback.test.ts \
+  tests/unit/db.test.ts \
+  --watch=false
+```
+
+Observed:
+
+```text
+Test Files  3 passed (3)
+Tests       23 passed (23)
+```
+
+```bash
+pnpm --filter @metasheet/core-backend build
+```
+
+Observed:
+
+```text
+exit 0
+```
+
+```bash
+pnpm exec tsx -e "import path from 'node:path'; import { createCoreBackendMigrationProvider } from './packages/core-backend/src/db/migration-provider.ts'; (async()=>{ const provider=createCoreBackendMigrationProvider({ runtimeDir: path.resolve('packages/core-backend/src/db') }); const migrations=await provider.getMigrations(); const names=Object.keys(migrations); const report={ has032:names.includes('032_create_approval_records'), has037:names.includes('037_add_gallery_form_support'), has055:names.includes('055_create_attendance_import_tokens'), has056:names.includes('056_add_users_must_change_password'), hasModernMustChange:names.includes('zzzz20260512100000_add_users_must_change_password'), has057:names.includes('057_create_integration_core_tables'), has058:names.includes('058_integration_runs_running_unique'), has059:names.includes('059_integration_runs_history_index'), total:names.length }; console.log(JSON.stringify(report,null,2)); })();"
+```
+
+Observed:
+
+```json
+{
+  "has032": true,
+  "has037": true,
+  "has055": true,
+  "has056": true,
+  "hasModernMustChange": true,
+  "has057": true,
+  "has058": true,
+  "has059": true,
+  "total": 160
+}
+```
+
+```bash
+git diff --check
+```
+
+Observed:
+
+```text
+exit 0
+```
+
+## Acceptance Criteria
+
+| Gate | Expected |
+| --- | --- |
+| Default provider returns `032`/`037`/`055` when files exist | Present as no-op markers |
+| Default provider returns `056` through `059` | Present and executable |
+| Explicit compatibility audit flag | Real superseded SQL migrations remain loadable |
+| `MIGRATION_EXCLUDE` / `excludedNames` | Explicit exclusions still hide requested names |
+| 142 deploy migration step | No Kysely corrupted-history failure |
+| 142 runtime health | Backend `/api/health=200`, Web `/=200`, unauthenticated `/api/auth/me=401` |
+
+## Post-merge Verification
+
+Pending until this branch is merged and the production deploy workflow reruns.

--- a/packages/core-backend/src/db/migration-provider.ts
+++ b/packages/core-backend/src/db/migration-provider.ts
@@ -111,6 +111,15 @@ function createSqlFileMigration(
   }
 }
 
+function createNoopMigration(): Migration {
+  return {
+    async up() {
+      // Superseded legacy SQL migrations remain visible so Kysely can validate
+      // existing migration history, but they must not replay on fresh installs.
+    },
+  }
+}
+
 async function addProviderMigrations(
   destination: Record<string, Migration>,
   provider: MigrationProvider
@@ -183,12 +192,10 @@ export function createCoreBackendMigrationProvider(
       .split(',')
       .map((value) => value.trim())
       .filter(Boolean)
-  const excludedNames = getExcludedNames(
-    [
-      ...(includeSupersededLegacySql ? [] : SUPERSEDED_LEGACY_SQL_MIGRATIONS),
-      ...configuredExcludedNames,
-    ]
+  const supersededLegacySqlNames = getExcludedNames(
+    includeSupersededLegacySql ? [] : SUPERSEDED_LEGACY_SQL_MIGRATIONS
   )
+  const excludedNames = getExcludedNames(configuredExcludedNames)
 
   return {
     async getMigrations() {
@@ -213,6 +220,12 @@ export function createCoreBackendMigrationProvider(
 
       for (const folder of sqlFolders) {
         await addSqlFileMigrations(migrations, folder, fsImpl, pathImpl)
+      }
+
+      for (const name of Object.keys(migrations)) {
+        if (supersededLegacySqlNames.has(name)) {
+          migrations[name] = createNoopMigration()
+        }
       }
 
       return Object.fromEntries(

--- a/packages/core-backend/tests/unit/migration-provider.test.ts
+++ b/packages/core-backend/tests/unit/migration-provider.test.ts
@@ -88,7 +88,7 @@ describe('createCoreBackendMigrationProvider', () => {
     ])
   })
 
-  it('skips superseded legacy core sql migrations by default', async () => {
+  it('exposes superseded legacy core sql migrations as no-op markers by default', async () => {
     const projectRoot = await createTempProjectRoot()
     const runtimeDir = path.join(projectRoot, 'src/db')
     const sourceMigrationsDir = path.join(runtimeDir, 'migrations')
@@ -123,10 +123,16 @@ describe('createCoreBackendMigrationProvider', () => {
     const migrations = await provider.getMigrations()
 
     expect(Object.keys(migrations).sort()).toEqual([
+      '032_create_approval_records',
+      '037_add_gallery_form_support',
+      '055_create_attendance_import_tokens',
       '056_add_users_must_change_password',
       '057_create_integration_core_tables',
       'zzzz20260119100000_create_users_table',
     ])
+    await expect(
+      migrations['032_create_approval_records']?.up({} as never)
+    ).resolves.toBeUndefined()
   })
 
   it('can include superseded legacy sql migrations for explicit compatibility audits', async () => {
@@ -169,10 +175,18 @@ describe('createCoreBackendMigrationProvider', () => {
       path.join(legacySqlDir, '056_add_users_must_change_password.sql'),
       'alter table users add column must_change_password boolean not null default false;'
     )
+    await writeFile(
+      path.join(legacySqlDir, '032_create_approval_records.sql'),
+      'create table if not exists approval_records (id uuid primary key);'
+    )
 
     const provider = createCoreBackendMigrationProvider({
       runtimeDir,
-      excludedNames: ['056_add_users_must_change_password.sql', '20260101000000_code.ts'],
+      excludedNames: [
+        '032_create_approval_records.sql',
+        '056_add_users_must_change_password.sql',
+        '20260101000000_code.ts',
+      ],
     })
     const migrations = await provider.getMigrations()
 


### PR DESCRIPTION
## Summary\n- keep superseded legacy SQL migration names visible as no-op provider markers instead of filtering them out\n- preserve explicit compatibility audit mode for loading real legacy SQL and preserve operator exclusions\n- update migration-provider tests plus development/verification docs\n\n## Why\n142 already has legacy SQL migrations 032-055 recorded in kysely_migration. Filtering them from the provider makes Kysely reject the history as corrupted even though the runtime containers are healthy.\n\n## Verification\n- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/migration-provider.test.ts tests/unit/migrations.rollback.test.ts tests/unit/db.test.ts --watch=false\n- pnpm --filter @metasheet/core-backend build\n- provider smoke confirmed 032/037/055 and 056-059 are visible\n- git diff --check\n- staged secret value scan: 0 matches