### PR TITLE
feat(multitable): add nested automation condition builder

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -88,89 +88,127 @@
               @click="draft.conditions.conjunction = 'OR'"
             >OR</button>
           </div>
-          <div v-if="hasNestedConditionGroups" class="meta-rule-editor__hint" data-field="nestedConditionNotice">
-            Nested condition groups are preserved when saving, but this editor only changes top-level conditions.
-          </div>
-          <div
-            v-for="{ condition: cond, index: idx } in editableConditionEntries"
-            :key="idx"
-            class="meta-rule-editor__condition-row"
-            :data-condition-index="idx"
-          >
-            <select
-              :value="cond.fieldId"
-              class="meta-rule-editor__select meta-rule-editor__select--sm"
-              @change="onConditionFieldChange(cond, ($event.target as HTMLSelectElement).value)"
-            >
-              <option value="">-- field --</option>
-              <option v-for="f in fields" :key="f.id" :value="f.id">{{ f.name }}</option>
-            </select>
-            <select
-              :value="cond.operator"
-              class="meta-rule-editor__select meta-rule-editor__select--sm"
-              @change="onConditionOperatorChange(cond, ($event.target as HTMLSelectElement).value as ConditionOperator)"
-            >
-              <option v-for="op in conditionOperatorsForField(cond.fieldId)" :key="op.value" :value="op.value">{{ op.label }}</option>
-            </select>
-            <template v-if="!isUnaryOperator(cond.operator)">
-              <select
-                v-if="conditionValueWidget(cond) === 'booleanMultiSelect'"
-                :value="booleanMultiSelectConditionValues(cond)"
-                class="meta-rule-editor__select meta-rule-editor__select--sm"
-                data-condition-value="boolean-multi-select"
-                multiple
-                @change="onBooleanMultiSelectConditionValueChange(cond, $event)"
+          <div class="meta-rule-editor__condition-list">
+            <template v-for="entry in conditionEditorEntries" :key="entry.pathKey">
+              <div
+                v-if="entry.kind === 'group'"
+                class="meta-rule-editor__condition-group"
+                :style="conditionIndentStyle(entry.depth)"
+                :data-condition-group-path="entry.pathKey"
               >
-                <option value="true">true</option>
-                <option value="false">false</option>
-              </select>
-              <select
-                v-else-if="conditionValueWidget(cond) === 'boolean'"
-                :value="booleanConditionValue(cond)"
-                class="meta-rule-editor__select meta-rule-editor__select--sm"
-                data-condition-value="boolean"
-                @change="onBooleanConditionValueChange(cond, ($event.target as HTMLSelectElement).value)"
-              >
-                <option value="">-- value --</option>
-                <option value="true">true</option>
-                <option value="false">false</option>
-              </select>
-              <select
-                v-else-if="conditionValueWidget(cond) === 'select'"
-                :value="singleSelectConditionValue(cond)"
-                class="meta-rule-editor__select meta-rule-editor__select--sm"
-                data-condition-value="select"
-                @change="cond.value = ($event.target as HTMLSelectElement).value"
-              >
-                <option value="">-- value --</option>
-                <option v-for="option in conditionFieldOptions(cond)" :key="option.value" :value="option.value">
-                  {{ optionLabel(option) }}
-                </option>
-              </select>
-              <select
-                v-else-if="conditionValueWidget(cond) === 'multiSelect'"
-                :value="multiSelectConditionValues(cond)"
-                class="meta-rule-editor__select meta-rule-editor__select--sm"
-                data-condition-value="multi-select"
-                multiple
-                @change="onMultiSelectConditionValueChange(cond, $event)"
-              >
-                <option v-for="option in conditionFieldOptions(cond)" :key="option.value" :value="option.value">
-                  {{ optionLabel(option) }}
-                </option>
-              </select>
-              <input
+                <span class="meta-rule-editor__group-label">Group</span>
+                <div class="meta-rule-editor__conjunction">
+                  <button
+                    type="button"
+                    class="meta-rule-editor__toggle-btn"
+                    :class="{ 'meta-rule-editor__toggle-btn--active': normalizeConditionConjunction(entry.group) === 'AND' }"
+                    @click="setGroupConjunction(entry.group, 'AND')"
+                  >AND</button>
+                  <button
+                    type="button"
+                    class="meta-rule-editor__toggle-btn"
+                    :class="{ 'meta-rule-editor__toggle-btn--active': normalizeConditionConjunction(entry.group) === 'OR' }"
+                    @click="setGroupConjunction(entry.group, 'OR')"
+                  >OR</button>
+                </div>
+                <div class="meta-rule-editor__condition-actions">
+                  <button class="meta-rule-editor__btn" type="button" data-action="add-nested-condition" @click="addConditionToGroup(entry.path)">+ Condition</button>
+                  <button
+                    class="meta-rule-editor__btn"
+                    type="button"
+                    data-action="add-condition-group"
+                    :disabled="!entry.canAddGroup"
+                    @click="addGroupToGroup(entry.path)"
+                  >+ Group</button>
+                  <button class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="removeConditionNode(entry.path)" title="Remove group">&times;</button>
+                </div>
+              </div>
+              <div
                 v-else
-                v-model="cond.value"
-                class="meta-rule-editor__input meta-rule-editor__input--sm"
-                :type="conditionValueInputType(cond)"
-                :inputmode="conditionValueInputMode(cond)"
-                :placeholder="conditionValuePlaceholder(cond)"
-              />
+                class="meta-rule-editor__condition-row"
+                :style="conditionIndentStyle(entry.depth)"
+                :data-condition-index="entry.pathKey"
+                :data-condition-path="entry.pathKey"
+              >
+                <select
+                  :value="entry.condition.fieldId"
+                  class="meta-rule-editor__select meta-rule-editor__select--sm"
+                  @change="onConditionFieldChange(entry.condition, ($event.target as HTMLSelectElement).value)"
+                >
+                  <option value="">-- field --</option>
+                  <option v-for="f in fields" :key="f.id" :value="f.id">{{ f.name }}</option>
+                </select>
+                <select
+                  :value="entry.condition.operator"
+                  class="meta-rule-editor__select meta-rule-editor__select--sm"
+                  @change="onConditionOperatorChange(entry.condition, ($event.target as HTMLSelectElement).value as ConditionOperator)"
+                >
+                  <option v-for="op in conditionOperatorsForField(entry.condition.fieldId)" :key="op.value" :value="op.value">{{ op.label }}</option>
+                </select>
+                <template v-if="!isUnaryOperator(entry.condition.operator)">
+                  <select
+                    v-if="conditionValueWidget(entry.condition) === 'booleanMultiSelect'"
+                    :value="booleanMultiSelectConditionValues(entry.condition)"
+                    class="meta-rule-editor__select meta-rule-editor__select--sm"
+                    data-condition-value="boolean-multi-select"
+                    multiple
+                    @change="onBooleanMultiSelectConditionValueChange(entry.condition, $event)"
+                  >
+                    <option value="true">true</option>
+                    <option value="false">false</option>
+                  </select>
+                  <select
+                    v-else-if="conditionValueWidget(entry.condition) === 'boolean'"
+                    :value="booleanConditionValue(entry.condition)"
+                    class="meta-rule-editor__select meta-rule-editor__select--sm"
+                    data-condition-value="boolean"
+                    @change="onBooleanConditionValueChange(entry.condition, ($event.target as HTMLSelectElement).value)"
+                  >
+                    <option value="">-- value --</option>
+                    <option value="true">true</option>
+                    <option value="false">false</option>
+                  </select>
+                  <select
+                    v-else-if="conditionValueWidget(entry.condition) === 'select'"
+                    :value="singleSelectConditionValue(entry.condition)"
+                    class="meta-rule-editor__select meta-rule-editor__select--sm"
+                    data-condition-value="select"
+                    @change="entry.condition.value = ($event.target as HTMLSelectElement).value"
+                  >
+                    <option value="">-- value --</option>
+                    <option v-for="option in conditionFieldOptions(entry.condition)" :key="option.value" :value="option.value">
+                      {{ optionLabel(option) }}
+                    </option>
+                  </select>
+                  <select
+                    v-else-if="conditionValueWidget(entry.condition) === 'multiSelect'"
+                    :value="multiSelectConditionValues(entry.condition)"
+                    class="meta-rule-editor__select meta-rule-editor__select--sm"
+                    data-condition-value="multi-select"
+                    multiple
+                    @change="onMultiSelectConditionValueChange(entry.condition, $event)"
+                  >
+                    <option v-for="option in conditionFieldOptions(entry.condition)" :key="option.value" :value="option.value">
+                      {{ optionLabel(option) }}
+                    </option>
+                  </select>
+                  <input
+                    v-else
+                    v-model="entry.condition.value"
+                    class="meta-rule-editor__input meta-rule-editor__input--sm"
+                    :type="conditionValueInputType(entry.condition)"
+                    :inputmode="conditionValueInputMode(entry.condition)"
+                    :placeholder="conditionValuePlaceholder(entry.condition)"
+                  />
+                </template>
+                <button class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="removeConditionNode(entry.path)" title="Remove condition">&times;</button>
+              </div>
             </template>
-            <button class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="removeCondition(idx)" title="Remove condition">&times;</button>
           </div>
-          <button class="meta-rule-editor__btn" type="button" data-action="add-condition" @click="addCondition">+ Add condition</button>
+          <div class="meta-rule-editor__condition-actions">
+            <button class="meta-rule-editor__btn" type="button" data-action="add-condition" @click="addCondition">+ Add condition</button>
+            <button class="meta-rule-editor__btn" type="button" data-action="add-condition-group" @click="addGroupToGroup([])">+ Add group</button>
+          </div>
         </section>
 
         <!-- 3. Actions -->
@@ -1035,6 +1073,23 @@ const DINGTALK_TEST_RUN_CONFIRM_MESSAGE =
 
 type ConditionOperatorOption = { value: ConditionOperator; label: string }
 type ConditionValueWidget = 'text' | 'number' | 'date' | 'dateTime' | 'boolean' | 'booleanMultiSelect' | 'select' | 'multiSelect'
+type ConditionPath = number[]
+type ConditionEditorEntry =
+  | {
+    kind: 'group'
+    group: ConditionGroup
+    path: ConditionPath
+    pathKey: string
+    depth: number
+    canAddGroup: boolean
+  }
+  | {
+    kind: 'condition'
+    condition: AutomationCondition
+    path: ConditionPath
+    pathKey: string
+    depth: number
+  }
 
 const conditionOperators: ConditionOperatorOption[] = [
   { value: 'equals', label: 'Equals' },
@@ -1084,6 +1139,7 @@ const MULTI_VALUE_OPERATOR_OPTIONS = [
   'is_empty',
   'is_not_empty',
 ] as const
+const MAX_CONDITION_GROUP_DEPTH = 5
 
 function optionsFromOperators(operators: readonly ConditionOperator[]): ConditionOperatorOption[] {
   return operators
@@ -1285,10 +1341,9 @@ function cloneConditionLeaf(condition: AutomationCondition): AutomationCondition
 function cloneConditionNode(node: AutomationConditionNode): AutomationConditionNode {
   if (isConditionGroupNode(node)) {
     const cloned: ConditionGroup = {
+      conjunction: normalizeConditionConjunction(node),
       conditions: node.conditions.map(cloneConditionNode),
     }
-    if (node.conjunction === 'AND' || node.conjunction === 'OR') cloned.conjunction = node.conjunction
-    if (node.logic === 'and' || node.logic === 'or') cloned.logic = node.logic
     return cloned
   }
   return cloneConditionLeaf(node)
@@ -1381,17 +1436,16 @@ function isConditionLeafComplete(condition: AutomationCondition): boolean {
 }
 
 function areConditionsComplete(node: AutomationConditionNode): boolean {
-  if (isConditionGroupNode(node)) return node.conditions.every(areConditionsComplete)
+  if (isConditionGroupNode(node)) return node.conditions.length > 0 && node.conditions.every(areConditionsComplete)
   return isConditionLeafComplete(node)
 }
 
 function buildConditionNodePayload(node: AutomationConditionNode): AutomationConditionNode {
   if (isConditionGroupNode(node)) {
     const group: ConditionGroup = {
+      conjunction: normalizeConditionConjunction(node),
       conditions: node.conditions.map(buildConditionNodePayload),
     }
-    if (node.conjunction === 'AND' || node.conjunction === 'OR') group.conjunction = node.conjunction
-    if (node.logic === 'and' || node.logic === 'or') group.logic = node.logic
     return group
   }
 
@@ -1474,14 +1528,84 @@ function draftFromRule(rule: AutomationRule): Draft {
 }
 
 const draft = ref<Draft>(emptyDraft())
-const editableConditionEntries = computed(() =>
-  draft.value.conditions.conditions
-    .map((condition, index) => ({ condition, index }))
-    .filter((entry): entry is { condition: AutomationCondition; index: number } => !isConditionGroupNode(entry.condition)),
-)
-const hasNestedConditionGroups = computed(() =>
-  draft.value.conditions.conditions.some(isConditionGroupNode),
-)
+const conditionEditorEntries = computed(() => collectConditionEditorEntries(draft.value.conditions.conditions))
+
+function conditionPathKey(path: ConditionPath): string {
+  return path.join('-') || 'root'
+}
+
+function conditionIndentStyle(depth: number): Record<string, string> {
+  return { '--condition-depth': String(Math.max(0, depth)) }
+}
+
+function createBlankCondition(): AutomationCondition {
+  return { fieldId: '', operator: 'equals', value: '' }
+}
+
+function createBlankConditionGroup(): ConditionGroup {
+  return {
+    conjunction: 'AND',
+    conditions: [createBlankCondition()],
+  }
+}
+
+function collectConditionEditorEntries(
+  nodes: AutomationConditionNode[],
+  parentPath: ConditionPath = [],
+): ConditionEditorEntry[] {
+  const entries: ConditionEditorEntry[] = []
+  nodes.forEach((node, index) => {
+    const path = [...parentPath, index]
+    const pathKey = conditionPathKey(path)
+    const depth = Math.max(0, path.length - 1)
+    if (isConditionGroupNode(node)) {
+      entries.push({
+        kind: 'group',
+        group: node,
+        path,
+        pathKey,
+        depth,
+        canAddGroup: canAddGroupToPath(path),
+      })
+      entries.push(...collectConditionEditorEntries(node.conditions, path))
+      return
+    }
+    entries.push({
+      kind: 'condition',
+      condition: node,
+      path,
+      pathKey,
+      depth,
+    })
+  })
+  return entries
+}
+
+function canAddGroupToPath(path: ConditionPath): boolean {
+  return path.length < MAX_CONDITION_GROUP_DEPTH
+}
+
+function groupAtPath(path: ConditionPath): ConditionGroup | null {
+  let group: ConditionGroup = draft.value.conditions
+  for (const index of path) {
+    const node = group.conditions[index]
+    if (!node || !isConditionGroupNode(node)) return null
+    group = node
+  }
+  return group
+}
+
+function parentGroupForPath(path: ConditionPath): { group: ConditionGroup; index: number } | null {
+  const index = path[path.length - 1]
+  if (index === undefined) return null
+  const group = groupAtPath(path.slice(0, -1))
+  return group ? { group, index } : null
+}
+
+function setGroupConjunction(group: ConditionGroup, conjunction: 'AND' | 'OR') {
+  group.conjunction = conjunction
+  delete group.logic
+}
 
 watch(
   () => props.visible,
@@ -1545,11 +1669,30 @@ const canSave = computed(() => {
 })
 
 function addCondition() {
-  draft.value.conditions.conditions.push({ fieldId: '', operator: 'equals', value: '' })
+  addConditionToGroup([])
+}
+
+function addConditionToGroup(path: ConditionPath) {
+  const group = groupAtPath(path)
+  if (!group) return
+  group.conditions.push(createBlankCondition())
+}
+
+function addGroupToGroup(path: ConditionPath) {
+  if (!canAddGroupToPath(path)) return
+  const group = groupAtPath(path)
+  if (!group) return
+  group.conditions.push(createBlankConditionGroup())
 }
 
 function removeCondition(idx: number) {
-  draft.value.conditions.conditions.splice(idx, 1)
+  removeConditionNode([idx])
+}
+
+function removeConditionNode(path: ConditionPath) {
+  const parent = parentGroupForPath(path)
+  if (!parent) return
+  parent.group.conditions.splice(parent.index, 1)
 }
 
 function addAction() {
@@ -2399,6 +2542,40 @@ function onTestRun() {
   display: flex;
   gap: 6px;
   align-items: center;
+}
+
+.meta-rule-editor__condition-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.meta-rule-editor__condition-row,
+.meta-rule-editor__condition-group {
+  margin-left: calc(var(--condition-depth, 0) * 18px);
+}
+
+.meta-rule-editor__condition-group {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  padding: 8px;
+  border: 1px dashed #cbd5e1;
+  border-radius: 8px;
+  background: #f8fafc;
+}
+
+.meta-rule-editor__group-label {
+  color: #475569;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.meta-rule-editor__condition-actions {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  flex-wrap: wrap;
 }
 
 .meta-rule-editor__conjunction { display: flex; gap: 4px; }

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -765,7 +765,7 @@ describe('MetaAutomationRuleEditor', () => {
     })
   })
 
-  it('preserves nested condition groups while editing other rule fields', async () => {
+  it('edits existing nested condition groups and saves canonical conjunctions', async () => {
     const saved = vi.fn()
     const nestedConditions: ConditionGroup = {
       logic: 'or',
@@ -789,12 +789,18 @@ describe('MetaAutomationRuleEditor', () => {
     })
     await flushPromises()
 
-    expect(container.querySelector('[data-field="nestedConditionNotice"]')?.textContent)
-      .toContain('Nested condition groups are preserved')
-    expect(container.querySelectorAll('[data-condition-index]').length).toBe(1)
+    expect(container.querySelector('[data-field="nestedConditionNotice"]')).toBeNull()
+    expect(container.querySelectorAll('[data-condition-index]').length).toBe(3)
+    expect(container.querySelector('[data-condition-group-path="1"]')).toBeTruthy()
+
+    const nestedNameRow = container.querySelector('[data-condition-path="1-0"]') as HTMLElement
+    const nestedValueInput = nestedNameRow.querySelector('input') as HTMLInputElement
+    nestedValueInput.value = 'Enterprise'
+    nestedValueInput.dispatchEvent(new Event('input'))
+    await flushPromises()
 
     const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
-    nameInput.value = 'Preserve nested'
+    nameInput.value = 'Edit nested'
     nameInput.dispatchEvent(new Event('input'))
     await flushPromises()
 
@@ -804,8 +810,120 @@ describe('MetaAutomationRuleEditor', () => {
     expect(saved).toHaveBeenCalledTimes(1)
     expect(saved.mock.calls[0][0].conditions).toEqual({
       conjunction: 'OR',
-      conditions: nestedConditions.conditions,
+      conditions: [
+        { fieldId: 'fld_1', operator: 'equals', value: 'Ready' },
+        {
+          conjunction: 'AND',
+          conditions: [
+            { fieldId: 'fld_2', operator: 'contains', value: 'Enterprise' },
+            { fieldId: 'assigneeUserIds', operator: 'in', value: ['user_1', 'user_2'] },
+          ],
+        },
+      ],
     })
+  })
+
+  it('creates nested condition groups from the visual builder', async () => {
+    const saved = vi.fn()
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, onSave: saved })
+    await flushPromises()
+
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    nameInput.value = 'Nested builder'
+    nameInput.dispatchEvent(new Event('input'))
+
+    ;(container.querySelector('[data-action="add-condition"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    const rootConditionRow = container.querySelector('[data-condition-path="0"]') as HTMLElement
+    const rootSelects = Array.from(rootConditionRow.querySelectorAll('select')) as HTMLSelectElement[]
+    rootSelects[0].value = 'fld_1'
+    rootSelects[0].dispatchEvent(new Event('change'))
+    await flushPromises()
+    const rootValueInput = rootConditionRow.querySelector('input') as HTMLInputElement
+    rootValueInput.value = 'Ready'
+    rootValueInput.dispatchEvent(new Event('input'))
+
+    ;(container.querySelector('[data-action="add-condition-group"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    const nestedGroup = container.querySelector('[data-condition-group-path="1"]') as HTMLElement
+    const groupToggleButtons = Array.from(nestedGroup.querySelectorAll('.meta-rule-editor__toggle-btn')) as HTMLButtonElement[]
+    groupToggleButtons[1].click()
+    await flushPromises()
+
+    const nestedConditionRow = container.querySelector('[data-condition-path="1-0"]') as HTMLElement
+    const nestedSelects = Array.from(nestedConditionRow.querySelectorAll('select')) as HTMLSelectElement[]
+    nestedSelects[0].value = 'fld_2'
+    nestedSelects[0].dispatchEvent(new Event('change'))
+    await flushPromises()
+    nestedSelects[1].value = 'contains'
+    nestedSelects[1].dispatchEvent(new Event('change'))
+    await flushPromises()
+    const nestedValueInput = nestedConditionRow.querySelector('input') as HTMLInputElement
+    nestedValueInput.value = 'VIP'
+    nestedValueInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    ;(container.querySelector('[data-action="save"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    expect(saved).toHaveBeenCalledTimes(1)
+    expect(saved.mock.calls[0][0].conditions).toEqual({
+      conjunction: 'AND',
+      conditions: [
+        { fieldId: 'fld_1', operator: 'equals', value: 'Ready' },
+        {
+          conjunction: 'OR',
+          conditions: [{ fieldId: 'fld_2', operator: 'contains', value: 'VIP' }],
+        },
+      ],
+    })
+  })
+
+  it('prevents creating condition groups deeper than the backend limit', async () => {
+    const deepestCondition = { fieldId: 'fld_1', operator: 'equals', value: 'Ready' } as const
+    const deepConditions: ConditionGroup = {
+      conjunction: 'AND',
+      conditions: [
+        {
+          conjunction: 'AND',
+          conditions: [
+            {
+              conjunction: 'AND',
+              conditions: [
+                {
+                  conjunction: 'AND',
+                  conditions: [
+                    {
+                      conjunction: 'AND',
+                      conditions: [
+                        {
+                          conjunction: 'AND',
+                          conditions: [deepestCondition],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      rule: fakeRule({ conditions: deepConditions }),
+    })
+    await flushPromises()
+
+    const deepestGroup = container.querySelector('[data-condition-group-path="0-0-0-0-0"]') as HTMLElement
+    const addGroupButton = deepestGroup.querySelector('[data-action="add-condition-group"]') as HTMLButtonElement
+
+    expect(addGroupButton.disabled).toBe(true)
   })
 
   it('can add actions up to max 3', async () => {

--- a/docs/development/multitable-phase3-automation-builder-development-20260512.md
+++ b/docs/development/multitable-phase3-automation-builder-development-20260512.md
@@ -1,0 +1,48 @@
+# Multitable Phase 3 Automation Builder Development
+
+Date: 2026-05-12
+Branch: `codex/multitable-phase3-automation-builder-20260512`
+Base: `origin/main@e40ac3f90`
+
+## Goal
+
+Close the Phase 3 Automation Builder gap where nested automation condition groups were accepted by the backend but only preserved read-only in the frontend rule editor.
+
+## Scope
+
+- Add visual editing for nested condition groups in `MetaAutomationRuleEditor.vue`.
+- Keep backend API, migrations, and OpenAPI unchanged because nested groups are already parsed and evaluated by `packages/core-backend/src/multitable/automation-conditions.ts`.
+- Preserve existing top-level condition selectors and typed value widgets.
+
+## Design
+
+The editor now renders a flattened condition tree with path metadata:
+
+- Leaf rows use `data-condition-path` and preserve `data-condition-index` compatibility for existing tests.
+- Group rows use `data-condition-group-path`, show an `AND` / `OR` toggle, and expose add-condition, add-group, and remove actions.
+- Root controls still support root-level `AND` / `OR`, add condition, and add group.
+
+Condition payloads are canonicalized to `conjunction: 'AND' | 'OR'` when cloned and saved. This avoids emitting conflicting legacy `logic` plus current `conjunction` values after a user edits an existing nested group.
+
+## Depth Guard
+
+The backend allows condition groups through depth 5. The frontend mirrors that guard by disabling `+ Group` on a group whose path length is already 5, while still allowing leaf conditions inside that group.
+
+## Validation Rules
+
+- Empty root condition list is still valid because conditions are optional.
+- Empty nested groups are invalid and keep Save disabled.
+- Leaf validation keeps the existing field-aware behavior for numeric, boolean, list, date, select, and unary operators.
+
+## Files Changed
+
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+- `docs/development/multitable-phase3-automation-builder-development-20260512.md`
+- `docs/development/multitable-phase3-automation-builder-verification-20260512.md`
+
+## Non-Goals
+
+- No backend behavior change.
+- No automation execution engine change.
+- No staging run in this slice; this is a frontend builder and serialization improvement.

--- a/docs/development/multitable-phase3-automation-builder-verification-20260512.md
+++ b/docs/development/multitable-phase3-automation-builder-verification-20260512.md
@@ -1,0 +1,28 @@
+# Multitable Phase 3 Automation Builder Verification
+
+Date: 2026-05-12
+Branch: `codex/multitable-phase3-automation-builder-20260512`
+Base: `origin/main@e40ac3f90`
+
+## Verification Matrix
+
+| Check | Result | Notes |
+| --- | --- | --- |
+| `pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts --watch=false` | PASS | 79/79 tests |
+| `pnpm --filter @metasheet/web exec vue-tsc --noEmit` | PASS | Clean |
+| `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/multitable-automation-conditions.test.ts --reporter=dot` | PASS | 11/11 tests |
+| `git diff --check` | PASS | Clean |
+
+## Coverage Added
+
+- Existing nested groups render as editable group rows instead of read-only preserved state.
+- Editing a nested leaf condition saves updated nested payload.
+- Existing legacy `logic` groups save as canonical `conjunction` groups after frontend edit.
+- The visual builder can create a new nested group and serialize it.
+- The UI disables adding groups beyond the backend depth limit.
+
+## Notes
+
+The first validation attempt failed before dependency installation because the temporary worktree had no `node_modules`. `pnpm install --frozen-lockfile` was run in the temporary worktree only. Generated plugin/CLI node_modules symlink dirt was reverted before preparing this PR.
+
+The final frontend Vitest run emitted `WebSocket server error: Port is already in use` from the test environment, but the targeted suite completed successfully with 79/79 tests passing.


### PR DESCRIPTION
## Summary
- replace the automation rule editor nested-condition read-only path with an editable group/condition builder
- add path-based add/remove/toggle operations and canonicalize saved groups to `conjunction`
- mirror the backend max condition group depth in the UI and add dev/verification docs

## Verification
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts --watch=false`
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/multitable-automation-conditions.test.ts --reporter=dot`
- `git diff --check`

## Docs
- `docs/development/multitable-phase3-automation-builder-development-20260512.md`
- `docs/development/multitable-phase3-automation-builder-verification-20260512.md`