### PR TITLE
docs(dingtalk): add final remote smoke closeout

### DIFF
--- a/docs/development/dingtalk-final-remote-smoke-development-20260512.md
+++ b/docs/development/dingtalk-final-remote-smoke-development-20260512.md
@@ -1,0 +1,50 @@
+# DingTalk Final Remote Smoke Development
+
+Date: 2026-05-12
+
+## Scope
+
+This closeout documents the final DingTalk P4 live acceptance pass for the 142 deployment after the backend/web images were updated to the immutable `e40ac3f909a2c5cad5072bc0e75f351c89513d10` tag.
+
+The goal was to close the remaining manual gates without committing raw secrets, webhook URLs, JWTs, temporary passwords, or screenshot originals.
+
+## Implementation Notes
+
+- Created a clean final smoke session for the current 142 image tag.
+- Re-ran the P4 remote smoke bootstrap against 142 through an SSH tunnel to the backend API.
+- Calibrated the no-email account target to the current `ddzz` DingTalk/local user state instead of reusing a stale external ID from an older session.
+- Recorded user-provided DingTalk mobile screenshots as manual-client evidence for group message visibility, authorized submission, and unauthorized denial.
+- Verified the no-email local user bind through the 142 database using the `users`, `user_external_identities`, and `user_external_auth_grants` truth sources.
+- Stored only redacted admin evidence in the smoke artifact note; the temporary password was not printed or committed.
+- Ran strict finalization and generated the evidence packet locally; raw artifacts remain outside Git for release-owner review.
+
+## Smoke Session
+
+- Session: `142-session-e40ac3f9-ddzz-20260512`
+- Local session path: `/tmp/metasheet2-migration-provider-superseded-noop-20260512/output/dingtalk-p4-remote-smoke-session/142-session-e40ac3f9-ddzz-20260512`
+- Local evidence packet path: `/tmp/metasheet2-migration-provider-superseded-noop-20260512/artifacts/dingtalk-staging-evidence-packet/142-session-e40ac3f9-ddzz-20260512-final`
+- Final status: `release_ready`
+
+## Completed Checks
+
+| Check | Result | Evidence |
+| --- | --- | --- |
+| Create table and form view | PASS | API bootstrap created disposable base, sheet, field, and form view. |
+| Bind two DingTalk groups | PASS | Two group destinations were created and test-send delivery rows were recorded. |
+| Set `dingtalk_granted` form access | PASS | Form share was active and restricted to the allowed local user scope. |
+| Send group message with form link | PASS | User-provided DingTalk screenshots showed A/B group cards and form entry; API delivery rows existed for the current session. |
+| Authorized user submit | PASS | User-provided DingTalk screenshots showed form open and successful submission. |
+| Unauthorized user denied | PASS | User-provided DingTalk screenshot showed the selected-user/member-group denial message; evidence recorded `submitBlocked=true` and `recordInsertDelta=0`. |
+| Delivery history group/person | PASS | API delivery history contained group and person sends. |
+| No-email account create/bind | PASS | 142 DB/admin verification confirmed `ddzz` has blank email, active local account, enabled DingTalk auth grant, and linked DingTalk identity. |
+
+## Security Handling
+
+- No webhook URL, `SEC` signing secret, JWT, bearer token, public form token, cookie, or temporary password was committed.
+- The docs only reference local artifact paths and redacted evidence summaries.
+- Raw screenshots are intentionally not committed in this docs-only closeout.
+
+## Follow-up
+
+- If the release owner wants auditable screenshot archival in Git, run the existing screenshot archive workflow separately with a redaction review first.
+- The 142 deployment remains on the `e40ac3f909a2c5cad5072bc0e75f351c89513d10` runtime image while this docs-only closeout is reviewed.

--- a/docs/development/dingtalk-final-remote-smoke-verification-20260512.md
+++ b/docs/development/dingtalk-final-remote-smoke-verification-20260512.md
@@ -1,0 +1,111 @@
+# DingTalk Final Remote Smoke Verification
+
+Date: 2026-05-12
+
+## Environment
+
+- Target: 142 deployment
+- Backend image: `ghcr.io/zensgit/metasheet2-backend:e40ac3f909a2c5cad5072bc0e75f351c89513d10`
+- Web image: `ghcr.io/zensgit/metasheet2-web:e40ac3f909a2c5cad5072bc0e75f351c89513d10`
+- Smoke session: `142-session-e40ac3f9-ddzz-20260512`
+
+## Commands Run
+
+```bash
+node scripts/ops/dingtalk-p4-smoke-session.mjs \
+  --env-file /tmp/dingtalk-p4-live-acceptance-tunnel-20260512.env \
+  --no-email-dingtalk-external-id <redacted-ddzz-dingtalk-user-id> \
+  --output-dir output/dingtalk-p4-remote-smoke-session/142-session-e40ac3f9-ddzz-20260512 \
+  --timeout-ms 120000
+
+node scripts/ops/dingtalk-p4-evidence-record.mjs \
+  --session-dir output/dingtalk-p4-remote-smoke-session/142-session-e40ac3f9-ddzz-20260512 \
+  --check-id send-group-message-form-link \
+  --status pass \
+  --source manual-client
+
+node scripts/ops/dingtalk-p4-evidence-record.mjs \
+  --session-dir output/dingtalk-p4-remote-smoke-session/142-session-e40ac3f9-ddzz-20260512 \
+  --check-id authorized-user-submit \
+  --status pass \
+  --source manual-client
+
+node scripts/ops/dingtalk-p4-evidence-record.mjs \
+  --session-dir output/dingtalk-p4-remote-smoke-session/142-session-e40ac3f9-ddzz-20260512 \
+  --check-id unauthorized-user-denied \
+  --status pass \
+  --source manual-client \
+  --submit-blocked \
+  --record-insert-delta 0
+
+node scripts/ops/dingtalk-p4-evidence-record.mjs \
+  --session-dir output/dingtalk-p4-remote-smoke-session/142-session-e40ac3f9-ddzz-20260512 \
+  --check-id no-email-user-create-bind \
+  --status pass \
+  --source manual-admin \
+  --admin-email-was-blank \
+  --admin-bound-dingtalk-external-id <redacted-ddzz-dingtalk-user-id> \
+  --admin-account-linked-after-refresh
+
+node scripts/ops/dingtalk-p4-smoke-session.mjs \
+  --finalize output/dingtalk-p4-remote-smoke-session/142-session-e40ac3f9-ddzz-20260512
+
+node scripts/ops/dingtalk-p4-final-closeout.mjs \
+  --session-dir output/dingtalk-p4-remote-smoke-session/142-session-e40ac3f9-ddzz-20260512 \
+  --packet-output-dir artifacts/dingtalk-staging-evidence-packet/142-session-e40ac3f9-ddzz-20260512-final \
+  --docs-output-dir docs/development \
+  --date 20260512
+
+node scripts/ops/dingtalk-p4-smoke-status.mjs \
+  --session-dir output/dingtalk-p4-remote-smoke-session/142-session-e40ac3f9-ddzz-20260512 \
+  --handoff-summary artifacts/dingtalk-staging-evidence-packet/142-session-e40ac3f9-ddzz-20260512-final/handoff-summary.json \
+  --require-release-ready
+
+node scripts/ops/validate-dingtalk-staging-evidence-packet.mjs \
+  --packet-dir artifacts/dingtalk-staging-evidence-packet/142-session-e40ac3f9-ddzz-20260512-final \
+  --output-json artifacts/dingtalk-staging-evidence-packet/142-session-e40ac3f9-ddzz-20260512-final/publish-check.recheck.json
+```
+
+## Runtime Verification
+
+| Gate | Result |
+| --- | --- |
+| Backend `/api/health` | `200` |
+| Web `/` | `200` |
+| Unauthenticated `/api/auth/me` | `401` |
+| Backend image tag | `e40ac3f909a2c5cad5072bc0e75f351c89513d10` |
+| Web image tag | `e40ac3f909a2c5cad5072bc0e75f351c89513d10` |
+
+## Smoke Verification Results
+
+| Gate | Result |
+| --- | --- |
+| Required checks | `8/8 PASS` |
+| Remaining checks | `0` |
+| Final strict status | `PASS` |
+| API bootstrap status | `PASS` |
+| Remote client status | `PASS` |
+| Smoke status | `release_ready` |
+| Evidence packet publish check | `PASS` |
+| Secret findings in generated closeout | `0` |
+
+## Manual Evidence Summary
+
+- A/B group robot cards were visible in DingTalk and included the protected form entry point.
+- The authorized DingTalk-bound user opened the protected form and submitted successfully.
+- The unauthorized DingTalk-bound user was denied by the selected users/member groups gate.
+- The no-email `ddzz` local account was confirmed as active, email blank, DingTalk identity linked, and DingTalk auth grant enabled.
+
+## Secret Scan
+
+```bash
+rg -n -P "(access_token=(?!<redacted>|\\.\\.\\.)[A-Za-z0-9._~+/=-]{16,}|SEC[A-Za-z0-9]{20,}|eyJ[A-Za-z0-9_-]{20,}\\.[A-Za-z0-9_-]{20,}\\.[A-Za-z0-9_-]{20,}|Bearer\\s+[A-Za-z0-9._-]{20,})" \
+  docs/development/dingtalk-final-remote-smoke-development-20260512.md \
+  docs/development/dingtalk-final-remote-smoke-verification-20260512.md
+```
+
+Result: no matches.
+
+## Conclusion
+
+The DingTalk P4 live acceptance path is release-ready for the 142 deployment. The runtime checks, strict smoke finalization, evidence packet validation, and docs-only secret scan all passed.


### PR DESCRIPTION
## Summary
- add sanitized DingTalk final remote smoke development MD for the 142 live acceptance closeout
- add verification MD with runtime gates, strict smoke status, evidence packet validation, and secret scan result
- keep raw screenshots, webhook URLs, SEC secrets, JWTs, public form tokens, and temporary passwords out of Git

## Verification
- git diff --check
- strict value-pattern secret scan on the two new MD files: no matches
- scope check: only the two DingTalk closeout docs are staged/committed

## Notes
- Runtime evidence referenced in these docs was generated from 142 image tag e40ac3f909a2c5cad5072bc0e75f351c89513d10.
- Raw artifacts remain local/release-owner scoped and are not part of this docs-only PR.