### PR TITLE
docs(dingtalk): note postmerge runtime drift

### DIFF
--- a/docs/development/dingtalk-final-remote-smoke-development-20260512.md
+++ b/docs/development/dingtalk-final-remote-smoke-development-20260512.md
@@ -4,7 +4,7 @@ Date: 2026-05-12
 
 ## Scope
 
-This closeout documents the final DingTalk P4 live acceptance pass for the 142 deployment after the backend/web images were updated to the immutable `e40ac3f909a2c5cad5072bc0e75f351c89513d10` tag.
+This closeout documents the final DingTalk P4 live acceptance pass for the 142 deployment. The strict live acceptance run was executed against the immutable `e40ac3f909a2c5cad5072bc0e75f351c89513d10` image tag.
 
 The goal was to close the remaining manual gates without committing raw secrets, webhook URLs, JWTs, temporary passwords, or screenshot originals.
 
@@ -21,9 +21,23 @@ The goal was to close the remaining manual gates without committing raw secrets,
 ## Smoke Session
 
 - Session: `142-session-e40ac3f9-ddzz-20260512`
+- Acceptance runtime image: `e40ac3f909a2c5cad5072bc0e75f351c89513d10`
 - Local session path: `/tmp/metasheet2-migration-provider-superseded-noop-20260512/output/dingtalk-p4-remote-smoke-session/142-session-e40ac3f9-ddzz-20260512`
 - Local evidence packet path: `/tmp/metasheet2-migration-provider-superseded-noop-20260512/artifacts/dingtalk-staging-evidence-packet/142-session-e40ac3f9-ddzz-20260512-final`
 - Final status: `release_ready`
+
+## Post-Merge Runtime Note
+
+After PR #1494 was merged, the 142 deployment was observed running `3e59d6a4c83a7aabd0c4d66006f62661f3b0bd21`.
+
+Diff review from `e40ac3f909a2c5cad5072bc0e75f351c89513d10` to `3e59d6a4c83a7aabd0c4d66006f62661f3b0bd21` showed only:
+
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+- `docs/development/multitable-phase3-automation-builder-development-20260512.md`
+- `docs/development/multitable-phase3-automation-builder-verification-20260512.md`
+
+No DingTalk auth, delivery, public-form, backend route, or P4 smoke helper files changed in that runtime drift window.
 
 ## Completed Checks
 
@@ -47,4 +61,4 @@ The goal was to close the remaining manual gates without committing raw secrets,
 ## Follow-up
 
 - If the release owner wants auditable screenshot archival in Git, run the existing screenshot archive workflow separately with a redaction review first.
-- The 142 deployment remains on the `e40ac3f909a2c5cad5072bc0e75f351c89513d10` runtime image while this docs-only closeout is reviewed.
+- The post-merge 142 runtime remains healthy on `3e59d6a4c83a7aabd0c4d66006f62661f3b0bd21`; the DingTalk acceptance evidence remains tied to the stricter live smoke run on `e40ac3f909a2c5cad5072bc0e75f351c89513d10`.

--- a/docs/development/dingtalk-final-remote-smoke-verification-20260512.md
+++ b/docs/development/dingtalk-final-remote-smoke-verification-20260512.md
@@ -5,8 +5,10 @@ Date: 2026-05-12
 ## Environment
 
 - Target: 142 deployment
-- Backend image: `ghcr.io/zensgit/metasheet2-backend:e40ac3f909a2c5cad5072bc0e75f351c89513d10`
-- Web image: `ghcr.io/zensgit/metasheet2-web:e40ac3f909a2c5cad5072bc0e75f351c89513d10`
+- Acceptance backend image: `ghcr.io/zensgit/metasheet2-backend:e40ac3f909a2c5cad5072bc0e75f351c89513d10`
+- Acceptance web image: `ghcr.io/zensgit/metasheet2-web:e40ac3f909a2c5cad5072bc0e75f351c89513d10`
+- Post-merge observed backend image: `ghcr.io/zensgit/metasheet2-backend:3e59d6a4c83a7aabd0c4d66006f62661f3b0bd21`
+- Post-merge observed web image: `ghcr.io/zensgit/metasheet2-web:3e59d6a4c83a7aabd0c4d66006f62661f3b0bd21`
 - Smoke session: `142-session-e40ac3f9-ddzz-20260512`
 
 ## Commands Run
@@ -73,8 +75,10 @@ node scripts/ops/validate-dingtalk-staging-evidence-packet.mjs \
 | Backend `/api/health` | `200` |
 | Web `/` | `200` |
 | Unauthenticated `/api/auth/me` | `401` |
-| Backend image tag | `e40ac3f909a2c5cad5072bc0e75f351c89513d10` |
-| Web image tag | `e40ac3f909a2c5cad5072bc0e75f351c89513d10` |
+| Acceptance backend image tag | `e40ac3f909a2c5cad5072bc0e75f351c89513d10` |
+| Acceptance web image tag | `e40ac3f909a2c5cad5072bc0e75f351c89513d10` |
+| Post-merge observed backend image tag | `3e59d6a4c83a7aabd0c4d66006f62661f3b0bd21` |
+| Post-merge observed web image tag | `3e59d6a4c83a7aabd0c4d66006f62661f3b0bd21` |
 
 ## Smoke Verification Results
 
@@ -105,6 +109,24 @@ rg -n -P "(access_token=(?!<redacted>|\\.\\.\\.)[A-Za-z0-9._~+/=-]{16,}|SEC[A-Za
 ```
 
 Result: no matches.
+
+## Post-Merge Runtime Drift Check
+
+```bash
+git diff --name-only \
+  e40ac3f909a2c5cad5072bc0e75f351c89513d10..3e59d6a4c83a7aabd0c4d66006f62661f3b0bd21
+```
+
+Result:
+
+```text
+apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+apps/web/tests/multitable-automation-rule-editor.spec.ts
+docs/development/multitable-phase3-automation-builder-development-20260512.md
+docs/development/multitable-phase3-automation-builder-verification-20260512.md
+```
+
+No DingTalk auth, delivery, public-form, backend route, or P4 smoke helper files changed between the live acceptance image and the post-merge observed 142 image.
 
 ## Conclusion
 


### PR DESCRIPTION
## Summary
- clarify that strict DingTalk live acceptance ran on e40ac3f9 while 142 was later observed running 3e59d6a4
- add post-merge runtime drift review showing the drift touched only multitable automation editor files/tests/docs
- preserve the DingTalk closeout conclusion while making the SHA/runtime relationship explicit

## Verification
- git diff --check
- strict value-pattern secret scan on the two DingTalk closeout MD files: no matches
- 142 post-merge runtime check: backend /api/health=200, web /=200, unauth /api/auth/me=401

## Notes
- This is docs-only and does not include raw screenshots, webhook URLs, SEC secrets, JWTs, public form tokens, or temporary passwords.