### PR TITLE
feat(integration): add generic integration workbench

### DIFF
--- a/apps/web/src/router/appRoutes.ts
+++ b/apps/web/src/router/appRoutes.ts
@@ -185,6 +185,12 @@ export const appRoutes: RouteRecordRaw[] = [
     meta: { title: 'Admin Audit', requiresAuth: true }
   },
   {
+    path: '/integrations/workbench',
+    name: AppRouteNames.INTEGRATION_WORKBENCH,
+    component: () => import('../views/IntegrationWorkbenchView.vue'),
+    meta: { title: 'Integration Workbench', titleZh: '数据集成工作台', requiresAuth: true, permissions: ['integration:write'] }
+  },
+  {
     path: '/integrations/k3-wise',
     name: AppRouteNames.INTEGRATION_K3_WISE,
     component: () => import('../views/IntegrationK3WiseSetupView.vue'),

--- a/apps/web/src/router/types.ts
+++ b/apps/web/src/router/types.ts
@@ -91,6 +91,7 @@ export const AppRouteNames = {
   ADMIN_DASHBOARD: 'admin-dashboard',
   ADMIN_SETTINGS: 'admin-settings',
   ADMIN_LOGS: 'admin-logs',
+  INTEGRATION_WORKBENCH: 'integration-workbench',
   INTEGRATION_K3_WISE: 'integration-k3-wise',
 
   // Error routes
@@ -159,6 +160,7 @@ export interface AppRouteParams {
   'admin-dashboard': Record<string, never>
   'admin-settings': Record<string, never>
   'admin-logs': Record<string, never>
+  'integration-workbench': Record<string, never>
   'integration-k3-wise': Record<string, never>
   'not-found': Record<string, never>
   'forbidden': Record<string, never>

--- a/apps/web/src/services/integration/workbench.ts
+++ b/apps/web/src/services/integration/workbench.ts
@@ -1,0 +1,401 @@
+import { apiFetch } from '../../utils/api'
+
+export interface IntegrationApiEnvelope<T> {
+  ok: boolean
+  data?: T
+  error?: {
+    code?: string
+    message?: string
+    details?: Record<string, unknown>
+  }
+}
+
+export interface IntegrationScope {
+  tenantId?: string
+  workspaceId?: string | null
+}
+
+export interface IntegrationAdapterMetadata {
+  kind: string
+  label: string
+  roles: Array<'source' | 'target' | 'bidirectional' | string>
+  supports: string[]
+  advanced: boolean
+  guardrails?: {
+    read?: Record<string, unknown>
+    write?: Record<string, unknown>
+    ui?: Record<string, unknown>
+    [key: string]: unknown
+  }
+}
+
+export interface WorkbenchExternalSystem {
+  id: string
+  tenantId: string
+  workspaceId: string | null
+  name: string
+  kind: string
+  role: 'source' | 'target' | 'bidirectional'
+  status: 'active' | 'inactive' | 'error'
+  config?: Record<string, unknown>
+  capabilities?: Record<string, unknown>
+  hasCredentials?: boolean
+  lastTestedAt?: string | null
+  lastError?: string | null
+}
+
+export interface IntegrationConnectionTestResult {
+  ok: boolean
+  status?: string | number
+  code?: string
+  message?: string
+  authenticated?: boolean
+  connected?: boolean
+  system?: WorkbenchExternalSystem
+}
+
+export interface IntegrationObjectSchemaField {
+  name: string
+  label?: string
+  type?: string
+  required?: boolean
+  [key: string]: unknown
+}
+
+export interface IntegrationSystemObject {
+  name: string
+  object?: string
+  label?: string
+  operations?: string[]
+  source?: string
+  schema?: IntegrationObjectSchemaField[]
+  template?: Record<string, unknown>
+  advanced?: boolean
+}
+
+export interface IntegrationObjectSchema {
+  object: string
+  fields: IntegrationObjectSchemaField[]
+  template?: Record<string, unknown>
+  raw?: unknown
+}
+
+export interface IntegrationFieldMapping {
+  sourceField: string
+  targetField: string
+  transform?: unknown
+  validation?: Array<Record<string, unknown>>
+  defaultValue?: unknown
+  sortOrder?: number
+}
+
+export type IntegrationPipelineMode = 'manual' | 'incremental' | 'full'
+export type IntegrationPipelineRunStatus = 'pending' | 'running' | 'succeeded' | 'partial' | 'failed' | 'cancelled'
+export type IntegrationDeadLetterStatus = 'open' | 'replayed' | 'discarded'
+
+export interface IntegrationPipeline {
+  id: string
+  tenantId: string
+  workspaceId: string | null
+  projectId?: string | null
+  name: string
+  description?: string | null
+  sourceSystemId: string
+  sourceObject: string
+  targetSystemId: string
+  targetObject: string
+  stagingSheetId?: string | null
+  mode: IntegrationPipelineMode
+  idempotencyKeyFields: string[]
+  options: Record<string, unknown>
+  status: 'draft' | 'active' | 'paused' | 'disabled'
+  fieldMappings?: IntegrationFieldMapping[]
+  createdAt?: string | null
+  updatedAt?: string | null
+}
+
+export interface IntegrationPipelineUpsertRequest extends IntegrationScope {
+  id?: string
+  projectId?: string | null
+  name: string
+  description?: string
+  sourceSystemId: string
+  sourceObject: string
+  targetSystemId: string
+  targetObject: string
+  stagingSheetId?: string | null
+  mode: IntegrationPipelineMode
+  idempotencyKeyFields: string[]
+  options: Record<string, unknown>
+  status: 'draft' | 'active' | 'paused' | 'disabled'
+  fieldMappings: IntegrationFieldMapping[]
+}
+
+export interface IntegrationPipelineRunPayload extends IntegrationScope {
+  mode: IntegrationPipelineMode
+  cursor?: string
+  sampleLimit?: number
+}
+
+export interface IntegrationPipelineRunResult {
+  id?: string
+  runId?: string
+  pipelineId?: string
+  status?: string
+  dryRun?: boolean
+  metrics?: Record<string, unknown>
+  preview?: Record<string, unknown>
+  [key: string]: unknown
+}
+
+export interface IntegrationPipelineObservationQuery extends IntegrationScope {
+  pipelineId: string
+  status?: string
+  limit?: number
+  offset?: number
+}
+
+export interface IntegrationPipelineRun {
+  id: string
+  tenantId: string
+  workspaceId: string | null
+  pipelineId: string
+  mode: IntegrationPipelineMode | string
+  triggeredBy?: string | null
+  status: IntegrationPipelineRunStatus | string
+  rowsRead: number
+  rowsCleaned: number
+  rowsWritten: number
+  rowsFailed: number
+  startedAt?: string | null
+  finishedAt?: string | null
+  durationMs?: number | null
+  errorSummary?: string | null
+  details?: Record<string, unknown>
+  createdAt?: string | null
+}
+
+export interface IntegrationDeadLetter {
+  id: string
+  tenantId: string
+  workspaceId: string | null
+  runId: string
+  pipelineId: string
+  idempotencyKey?: string | null
+  errorCode: string
+  errorMessage: string
+  retryCount?: number
+  status: IntegrationDeadLetterStatus | string
+  lastReplayRunId?: string | null
+  payloadRedacted?: boolean
+  createdAt?: string | null
+  updatedAt?: string | null
+}
+
+export interface IntegrationStagingDescriptor {
+  id: string
+  name: string
+  fields: string[]
+  fieldDetails?: Array<{
+    id: string
+    name: string
+    type: string
+    options?: string[]
+  }>
+}
+
+export interface IntegrationTemplatePreviewRequest {
+  sourceRecord: Record<string, unknown>
+  fieldMappings: IntegrationFieldMapping[]
+  template?: {
+    id?: string
+    version?: string
+    documentType?: string
+    bodyKey?: string
+    endpointPath?: string
+    schema?: IntegrationObjectSchemaField[]
+  }
+}
+
+export interface IntegrationTemplatePreviewResult {
+  valid: boolean
+  payload: Record<string, unknown>
+  targetRecord: Record<string, unknown>
+  errors: Array<Record<string, unknown>>
+  transformErrors: Array<Record<string, unknown>>
+  validationErrors: Array<Record<string, unknown>>
+  schemaErrors: Array<Record<string, unknown>>
+  template?: Record<string, unknown>
+}
+
+async function parseIntegrationResponse<T>(response: Response): Promise<T> {
+  let payload: IntegrationApiEnvelope<T> | null = null
+  try {
+    payload = await response.json() as IntegrationApiEnvelope<T>
+  } catch {
+    payload = null
+  }
+  if (!response.ok || payload?.ok === false) {
+    const message = payload?.error?.message || `${response.status} ${response.statusText}`.trim()
+    throw new Error(message || 'Integration API request failed')
+  }
+  return payload?.data as T
+}
+
+function buildQueryString(input: Record<string, unknown>): string {
+  const params = new URLSearchParams()
+  for (const [key, value] of Object.entries(input)) {
+    if (value === undefined || value === null || value === '') continue
+    params.set(key, String(value))
+  }
+  return params.toString()
+}
+
+function buildObservationQueryString(query: IntegrationPipelineObservationQuery): string {
+  return buildQueryString({
+    tenantId: query.tenantId,
+    workspaceId: query.workspaceId,
+    pipelineId: query.pipelineId,
+    status: query.status,
+    limit: query.limit,
+    offset: query.offset,
+  })
+}
+
+function getLocalStorageValue(key: string): string {
+  if (typeof localStorage === 'undefined' || typeof localStorage.getItem !== 'function') return ''
+  return localStorage.getItem(key) || ''
+}
+
+export function getDefaultIntegrationScope(): Required<IntegrationScope> {
+  return {
+    tenantId: getLocalStorageValue('tenantId') || 'default',
+    workspaceId: getLocalStorageValue('workspaceId') || null,
+  }
+}
+
+export async function listIntegrationAdapters(): Promise<IntegrationAdapterMetadata[]> {
+  const response = await apiFetch('/api/integration/adapters')
+  const data = await parseIntegrationResponse<IntegrationAdapterMetadata[]>(response)
+  return Array.isArray(data) ? data : []
+}
+
+export async function listWorkbenchExternalSystems(scope: IntegrationScope = {}): Promise<WorkbenchExternalSystem[]> {
+  const query = buildQueryString({
+    tenantId: scope.tenantId,
+    workspaceId: scope.workspaceId,
+  })
+  const response = await apiFetch(`/api/integration/external-systems${query ? `?${query}` : ''}`)
+  const data = await parseIntegrationResponse<WorkbenchExternalSystem[]>(response)
+  return Array.isArray(data) ? data : []
+}
+
+export async function listExternalSystemObjects(
+  systemId: string,
+  scope: IntegrationScope = {},
+): Promise<IntegrationSystemObject[]> {
+  const query = buildQueryString({
+    tenantId: scope.tenantId,
+    workspaceId: scope.workspaceId,
+  })
+  const response = await apiFetch(`/api/integration/external-systems/${encodeURIComponent(systemId)}/objects${query ? `?${query}` : ''}`)
+  const data = await parseIntegrationResponse<IntegrationSystemObject[]>(response)
+  return Array.isArray(data) ? data : []
+}
+
+export async function getExternalSystemSchema(
+  systemId: string,
+  input: IntegrationScope & { object: string },
+): Promise<IntegrationObjectSchema> {
+  const query = buildQueryString({
+    tenantId: input.tenantId,
+    workspaceId: input.workspaceId,
+    object: input.object,
+  })
+  const response = await apiFetch(`/api/integration/external-systems/${encodeURIComponent(systemId)}/schema?${query}`)
+  const data = await parseIntegrationResponse<IntegrationObjectSchema>(response)
+  return {
+    object: data?.object || input.object,
+    fields: Array.isArray(data?.fields) ? data.fields : [],
+    template: data?.template,
+    raw: data?.raw,
+  }
+}
+
+export async function testExternalSystemConnection(
+  systemId: string,
+  scope: IntegrationScope = {},
+): Promise<IntegrationConnectionTestResult> {
+  const query = buildQueryString({
+    tenantId: scope.tenantId,
+    workspaceId: scope.workspaceId,
+  })
+  const response = await apiFetch(`/api/integration/external-systems/${encodeURIComponent(systemId)}/test${query ? `?${query}` : ''}`, {
+    method: 'POST',
+    body: JSON.stringify({}),
+  })
+  return parseIntegrationResponse<IntegrationConnectionTestResult>(response)
+}
+
+export async function previewIntegrationTemplate(
+  payload: IntegrationTemplatePreviewRequest,
+): Promise<IntegrationTemplatePreviewResult> {
+  const response = await apiFetch('/api/integration/templates/preview', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  })
+  return parseIntegrationResponse<IntegrationTemplatePreviewResult>(response)
+}
+
+export async function upsertIntegrationPipeline(
+  payload: IntegrationPipelineUpsertRequest,
+): Promise<IntegrationPipeline> {
+  const response = await apiFetch('/api/integration/pipelines', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  })
+  return parseIntegrationResponse<IntegrationPipeline>(response)
+}
+
+export async function runIntegrationPipeline(
+  pipelineId: string,
+  payload: IntegrationPipelineRunPayload,
+  dryRun = false,
+): Promise<IntegrationPipelineRunResult> {
+  const endpoint = dryRun ? 'dry-run' : 'run'
+  const response = await apiFetch(`/api/integration/pipelines/${encodeURIComponent(pipelineId)}/${endpoint}`, {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  })
+  return parseIntegrationResponse<IntegrationPipelineRunResult>(response)
+}
+
+export async function listIntegrationPipelineRuns(
+  query: IntegrationPipelineObservationQuery,
+): Promise<IntegrationPipelineRun[]> {
+  const response = await apiFetch(`/api/integration/runs?${buildObservationQueryString(query)}`)
+  const data = await parseIntegrationResponse<IntegrationPipelineRun[]>(response)
+  return Array.isArray(data) ? data : []
+}
+
+export async function listIntegrationDeadLetters(
+  query: IntegrationPipelineObservationQuery,
+): Promise<IntegrationDeadLetter[]> {
+  const response = await apiFetch(`/api/integration/dead-letters?${buildObservationQueryString(query)}`)
+  const data = await parseIntegrationResponse<IntegrationDeadLetter[]>(response)
+  return Array.isArray(data) ? data : []
+}
+
+export async function listIntegrationStagingDescriptors(): Promise<IntegrationStagingDescriptor[]> {
+  const response = await apiFetch('/api/integration/staging/descriptors')
+  const data = await parseIntegrationResponse<IntegrationStagingDescriptor[]>(response)
+  return Array.isArray(data) ? data : []
+}
+
+export function canReadFromSystem(system: WorkbenchExternalSystem): boolean {
+  return system.role === 'source' || system.role === 'bidirectional'
+}
+
+export function canWriteToSystem(system: WorkbenchExternalSystem): boolean {
+  return system.role === 'target' || system.role === 'bidirectional'
+}

--- a/apps/web/src/views/IntegrationK3WiseSetupView.vue
+++ b/apps/web/src/views/IntegrationK3WiseSetupView.vue
@@ -7,6 +7,9 @@
         <p class="k3-setup__lead">先接通 K3 WISE，再把 PLM 数据放进多维表清洗，最后 dry-run 后推送 ERP。</p>
       </div>
       <div class="k3-setup__header-actions">
+        <router-link class="k3-setup__btn" data-testid="generic-workbench-link" to="/integrations/workbench">
+          打开通用工作台
+        </router-link>
         <button class="k3-setup__btn" type="button" :disabled="loading" @click="loadSystems(false)">
           {{ loading ? '刷新中' : '刷新' }}
         </button>
@@ -1340,6 +1343,9 @@ onMounted(() => {
 }
 
 .k3-setup__btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   border: 1px solid #cbd5e1;
   border-radius: 6px;
   padding: 9px 12px;
@@ -1347,6 +1353,7 @@ onMounted(() => {
   color: #172033;
   font: inherit;
   cursor: pointer;
+  text-decoration: none;
 }
 
 .k3-setup__btn--primary {

--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -1,0 +1,1166 @@
+<template>
+  <section class="integration-workbench">
+    <header class="integration-workbench__header">
+      <div>
+        <p class="integration-workbench__eyebrow">Integration Workbench</p>
+        <h1>通用数据集成工作台</h1>
+        <p class="integration-workbench__lead">选择来源系统和目标系统，把数据在多维表中清洗后，先预览 payload，再 dry-run 和 Save-only 推送。</p>
+      </div>
+      <router-link class="integration-workbench__k3-link" to="/integrations/k3-wise">K3 WISE 预设向导</router-link>
+    </header>
+
+    <div v-if="statusMessage" class="integration-workbench__status" :data-kind="statusKind">
+      {{ statusMessage }}
+    </div>
+
+    <section class="integration-workbench__panel">
+      <div class="integration-workbench__panel-head">
+        <div>
+          <h2>连接系统</h2>
+          <p>SQL 通道标记为高级能力，适合实施人员配置只读表、视图或中间表。</p>
+        </div>
+        <button type="button" class="integration-workbench__button" data-testid="refresh-systems" @click="refreshBootstrap">
+          刷新连接
+        </button>
+      </div>
+
+      <div class="integration-workbench__adapter-list">
+        <span
+          v-for="adapter in visibleAdapters"
+          :key="adapter.kind"
+          class="integration-workbench__adapter"
+          :data-advanced="adapter.advanced ? 'true' : 'false'"
+        >
+          {{ adapter.label }}
+          <small v-if="adapter.advanced">高级</small>
+        </span>
+      </div>
+
+      <label class="integration-workbench__advanced-toggle">
+        <input v-model="showAdvancedConnectors" type="checkbox" data-testid="show-advanced-connectors" />
+        <span>显示 SQL / 高级连接（实施人员或管理员使用）</span>
+      </label>
+      <div v-if="!showAdvancedConnectors && hiddenAdvancedSystemCount > 0" class="integration-workbench__hint" data-testid="advanced-hidden-hint">
+        已隐藏 {{ hiddenAdvancedSystemCount }} 个高级连接。SQL 通道默认不进入业务用户连接列表。
+      </div>
+      <div v-if="showAdvancedConnectors" class="integration-workbench__hint" data-testid="advanced-visible-hint">
+        高级连接只用于 allowlist 表/视图读取或中间表写入；不要把核心业务表直写暴露给普通用户。
+      </div>
+
+      <div class="integration-workbench__grid">
+        <label>
+          <span>Tenant ID</span>
+          <input v-model="scope.tenantId" data-testid="tenant-id" />
+        </label>
+        <label>
+          <span>Workspace ID</span>
+          <input v-model="workspaceInput" data-testid="workspace-id" placeholder="可选" />
+        </label>
+      </div>
+    </section>
+
+    <section class="integration-workbench__panel">
+      <div class="integration-workbench__grid integration-workbench__grid--systems">
+        <div class="integration-workbench__system-column">
+          <h2>来源</h2>
+          <label>
+            <span>来源系统</span>
+            <select v-model="sourceSystemId" data-testid="source-system">
+              <option value="">请选择来源系统</option>
+              <option v-for="system in sourceSystems" :key="system.id" :value="system.id">
+                {{ system.name }} · {{ system.kind }}
+              </option>
+            </select>
+          </label>
+          <div class="integration-workbench__connection-row">
+            <span class="integration-workbench__badge" :data-status="sourceConnectionStatus">{{ sourceConnectionLabel }}</span>
+            <button type="button" class="integration-workbench__button" data-testid="test-source-system" @click="testSystem('source')">
+              测试来源连接
+            </button>
+            <button type="button" class="integration-workbench__button" data-testid="load-source-objects" @click="loadObjects('source')">
+              加载来源对象
+            </button>
+          </div>
+          <label>
+            <span>来源对象</span>
+            <select v-model="sourceObjectName" data-testid="source-object" @change="loadSchema('source')">
+              <option value="">请选择来源对象</option>
+              <option v-for="object in sourceObjects" :key="object.name" :value="object.name">
+                {{ object.label || object.name }}
+              </option>
+            </select>
+          </label>
+          <ul class="integration-workbench__schema-list">
+            <li v-for="field in sourceSchema.fields" :key="field.name">
+              {{ field.label || field.name }} <code>{{ field.name }}</code>
+            </li>
+          </ul>
+        </div>
+
+        <div class="integration-workbench__system-column">
+          <h2>目标</h2>
+          <label>
+            <span>目标系统</span>
+            <select v-model="targetSystemId" data-testid="target-system">
+              <option value="">请选择目标系统</option>
+              <option v-for="system in targetSystems" :key="system.id" :value="system.id">
+                {{ system.name }} · {{ system.kind }}
+              </option>
+            </select>
+          </label>
+          <div class="integration-workbench__connection-row">
+            <span class="integration-workbench__badge" :data-status="targetConnectionStatus">{{ targetConnectionLabel }}</span>
+            <button type="button" class="integration-workbench__button" data-testid="test-target-system" @click="testSystem('target')">
+              测试目标连接
+            </button>
+            <button type="button" class="integration-workbench__button" data-testid="load-target-objects" @click="loadObjects('target')">
+              加载目标对象
+            </button>
+          </div>
+          <label>
+            <span>目标对象 / 模板</span>
+            <select v-model="targetObjectName" data-testid="target-object" @change="loadSchema('target')">
+              <option value="">请选择目标对象</option>
+              <option v-for="object in targetObjects" :key="object.name" :value="object.name">
+                {{ object.label || object.name }}
+              </option>
+            </select>
+          </label>
+          <ul class="integration-workbench__schema-list">
+            <li v-for="field in targetSchema.fields" :key="field.name">
+              {{ field.label || field.name }} <code>{{ field.name }}</code>
+              <strong v-if="field.required">必填</strong>
+            </li>
+          </ul>
+        </div>
+      </div>
+      <div v-if="sameSystemNotice" class="integration-workbench__hint integration-workbench__hint--strong" data-testid="same-system-notice">
+        {{ sameSystemNotice }}
+      </div>
+      <div v-if="protocolSplitNotice" class="integration-workbench__hint" data-testid="protocol-split-notice">
+        {{ protocolSplitNotice }}
+      </div>
+    </section>
+
+    <section class="integration-workbench__panel">
+      <div class="integration-workbench__panel-head">
+        <div>
+          <h2>字段映射</h2>
+          <p>这里只允许白名单转换函数；复杂逻辑应进入 adapter 或后端模板，而不是用户脚本。</p>
+        </div>
+        <button type="button" class="integration-workbench__button" data-testid="add-mapping" @click="addMapping">
+          新增映射
+        </button>
+      </div>
+
+      <table class="integration-workbench__mapping-table">
+        <thead>
+          <tr>
+            <th>源字段</th>
+            <th>目标字段</th>
+            <th>转换</th>
+            <th>必填</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="(mapping, index) in mappings" :key="mapping.id">
+            <td><input v-model="mapping.sourceField" :data-testid="`source-field-${index}`" /></td>
+            <td><input v-model="mapping.targetField" :data-testid="`target-field-${index}`" /></td>
+            <td><input v-model="mapping.transformText" :data-testid="`transform-${index}`" placeholder="trim,upper" /></td>
+            <td><input v-model="mapping.required" type="checkbox" :data-testid="`required-${index}`" /></td>
+            <td>
+              <button type="button" class="integration-workbench__icon-button" @click="removeMapping(index)">删除</button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="integration-workbench__panel">
+      <div class="integration-workbench__panel-head">
+        <div>
+          <h2>Pipeline 执行</h2>
+          <p>先保存 pipeline，再 dry-run。Save-only 推送必须显式勾选，默认不会 Submit / Audit。</p>
+        </div>
+        <button type="button" class="integration-workbench__button" data-testid="save-pipeline" :disabled="savingPipeline" @click="savePipeline">
+          {{ savingPipeline ? '保存中' : '保存 Pipeline' }}
+        </button>
+      </div>
+
+      <div class="integration-workbench__grid">
+        <label>
+          <span>Pipeline 名称</span>
+          <input v-model="pipelineName" data-testid="pipeline-name" placeholder="例如 PLM material to K3 material" />
+        </label>
+        <label>
+          <span>Pipeline 模式</span>
+          <select v-model="pipelineMode" data-testid="pipeline-mode">
+            <option value="manual">manual</option>
+            <option value="incremental">incremental</option>
+            <option value="full">full</option>
+          </select>
+        </label>
+        <label>
+          <span>幂等字段</span>
+          <input v-model="idempotencyFieldsText" data-testid="idempotency-fields" placeholder="code 或 sourceId,revision" />
+        </label>
+        <label>
+          <span>清洗 staging 表</span>
+          <select v-model="stagingSheetId" data-testid="staging-sheet">
+            <option value="">不绑定 staging 表</option>
+            <option v-for="descriptor in stagingDescriptors" :key="descriptor.id" :value="descriptor.id">
+              {{ descriptor.name }} · {{ descriptor.id }}
+            </option>
+          </select>
+        </label>
+        <label>
+          <span>已保存 Pipeline ID</span>
+          <input v-model="savedPipelineId" data-testid="pipeline-id" placeholder="保存后自动回填，也可粘贴已有 ID" />
+        </label>
+        <label>
+          <span>运行模式</span>
+          <select v-model="pipelineRunMode" data-testid="pipeline-run-mode">
+            <option value="manual">manual</option>
+            <option value="incremental">incremental</option>
+            <option value="full">full</option>
+          </select>
+        </label>
+        <label>
+          <span>Dry-run 样本数</span>
+          <input v-model="pipelineSampleLimit" data-testid="sample-limit" inputmode="numeric" />
+        </label>
+      </div>
+
+      <label class="integration-workbench__inline-check">
+        <input v-model="allowSaveOnlyRun" type="checkbox" data-testid="allow-save-only-run" />
+        <span>允许本次 Save-only 推送。保持 Submit / Audit 关闭。</span>
+      </label>
+
+      <div class="integration-workbench__actions">
+        <button type="button" class="integration-workbench__button" data-testid="run-dry-run" :disabled="runningPipeline !== ''" @click="executePipeline(true)">
+          {{ runningPipeline === 'dry-run' ? 'Dry-run 中' : 'Dry-run' }}
+        </button>
+        <button type="button" class="integration-workbench__button integration-workbench__button--danger" data-testid="run-save-only" :disabled="runningPipeline !== '' || !allowSaveOnlyRun" @click="executePipeline(false)">
+          {{ runningPipeline === 'run' ? '推送中' : 'Save-only 推送' }}
+        </button>
+      </div>
+
+      <pre data-testid="pipeline-result">{{ pipelineResultText }}</pre>
+    </section>
+
+    <section class="integration-workbench__panel">
+      <div class="integration-workbench__panel-head">
+        <div>
+          <h2>运行观察</h2>
+          <p>{{ observationSummary }}。这里显示最近 5 条 run 和 open dead letters，便于清洗后回看失败原因。</p>
+        </div>
+        <button type="button" class="integration-workbench__button" data-testid="refresh-observation" :disabled="observingPipeline" @click="refreshPipelineObservation(false)">
+          {{ observingPipeline ? '刷新中' : '刷新观察' }}
+        </button>
+      </div>
+
+      <div class="integration-workbench__observation">
+        <div>
+          <h3>最近运行</h3>
+          <div v-if="pipelineRuns.length === 0" class="integration-workbench__empty">暂无运行记录。</div>
+          <ol v-else class="integration-workbench__record-list" data-testid="pipeline-runs">
+            <li v-for="run in pipelineRuns" :key="run.id">
+              <strong>{{ run.status }}</strong>
+              <span>{{ run.mode }}</span>
+              <span>read {{ run.rowsRead }} / clean {{ run.rowsCleaned }} / write {{ run.rowsWritten }} / fail {{ run.rowsFailed }}</span>
+              <small>{{ run.startedAt || run.createdAt || run.id }}</small>
+            </li>
+          </ol>
+        </div>
+        <div>
+          <h3>Open Dead Letters</h3>
+          <div v-if="deadLetters.length === 0" class="integration-workbench__empty">暂无 open dead letters。</div>
+          <ol v-else class="integration-workbench__record-list" data-testid="dead-letters">
+            <li v-for="deadLetter in deadLetters" :key="deadLetter.id">
+              <strong>{{ deadLetter.errorCode }}</strong>
+              <span>{{ deadLetter.errorMessage }}</span>
+              <small>{{ deadLetter.status }} · {{ deadLetter.createdAt || deadLetter.id }}</small>
+            </li>
+          </ol>
+        </div>
+      </div>
+    </section>
+
+    <section class="integration-workbench__panel integration-workbench__preview">
+      <div>
+        <h2>样例记录</h2>
+        <textarea v-model="sampleRecordText" data-testid="sample-record" spellcheck="false"></textarea>
+      </div>
+      <div>
+        <div class="integration-workbench__panel-head">
+          <div>
+            <h2>Payload 预览</h2>
+            <p>预览只做纯计算，不写数据库，也不会调用 ERP/CRM/PLM/SRM。</p>
+          </div>
+          <button type="button" class="integration-workbench__button" data-testid="preview-payload" @click="previewPayload">
+            生成 JSON 预览
+          </button>
+        </div>
+        <pre data-testid="payload-preview">{{ previewText }}</pre>
+      </div>
+    </section>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, reactive, ref, watch } from 'vue'
+import {
+  canReadFromSystem,
+  canWriteToSystem,
+  getDefaultIntegrationScope,
+  getExternalSystemSchema,
+  listIntegrationDeadLetters,
+  listIntegrationPipelineRuns,
+  listIntegrationStagingDescriptors,
+  listExternalSystemObjects,
+  listIntegrationAdapters,
+  listWorkbenchExternalSystems,
+  previewIntegrationTemplate,
+  runIntegrationPipeline,
+  testExternalSystemConnection,
+  upsertIntegrationPipeline,
+  type IntegrationAdapterMetadata,
+  type IntegrationFieldMapping,
+  type IntegrationObjectSchema,
+  type IntegrationObjectSchemaField,
+  type IntegrationDeadLetter,
+  type IntegrationPipelineMode,
+  type IntegrationPipelineRun,
+  type IntegrationStagingDescriptor,
+  type IntegrationSystemObject,
+  type WorkbenchExternalSystem,
+} from '../services/integration/workbench'
+
+type WorkbenchSide = 'source' | 'target'
+
+interface EditableMapping {
+  id: string
+  sourceField: string
+  targetField: string
+  transformText: string
+  required: boolean
+}
+
+const defaultScope = getDefaultIntegrationScope()
+const scope = reactive({
+  tenantId: defaultScope.tenantId,
+  workspaceId: defaultScope.workspaceId,
+})
+const workspaceInput = computed({
+  get: () => scope.workspaceId || '',
+  set: (value: string) => {
+    scope.workspaceId = value.trim() || null
+  },
+})
+
+const adapters = ref<IntegrationAdapterMetadata[]>([])
+const systems = ref<WorkbenchExternalSystem[]>([])
+const showAdvancedConnectors = ref(false)
+const sourceSystemId = ref('')
+const targetSystemId = ref('')
+const sourceObjects = ref<IntegrationSystemObject[]>([])
+const targetObjects = ref<IntegrationSystemObject[]>([])
+const stagingDescriptors = ref<IntegrationStagingDescriptor[]>([])
+const sourceObjectName = ref('')
+const targetObjectName = ref('')
+const stagingSheetId = ref('')
+const sourceSchema = ref<IntegrationObjectSchema>({ object: '', fields: [] })
+const targetSchema = ref<IntegrationObjectSchema>({ object: '', fields: [] })
+const mappings = ref<EditableMapping[]>([])
+const previewText = ref('尚未生成预览')
+const pipelineResultText = ref('尚未执行')
+const pipelineRuns = ref<IntegrationPipelineRun[]>([])
+const deadLetters = ref<IntegrationDeadLetter[]>([])
+const statusMessage = ref('')
+const statusKind = ref<'idle' | 'success' | 'error'>('idle')
+const pipelineName = ref('')
+const pipelineMode = ref<IntegrationPipelineMode>('manual')
+const pipelineRunMode = ref<IntegrationPipelineMode>('manual')
+const idempotencyFieldsText = ref('code')
+const pipelineSampleLimit = ref('20')
+const savedPipelineId = ref('')
+const savingPipeline = ref(false)
+const runningPipeline = ref<'dry-run' | 'run' | ''>('')
+const observingPipeline = ref(false)
+const allowSaveOnlyRun = ref(false)
+const sampleRecordText = ref(JSON.stringify({
+  code: ' mat-001 ',
+  name: ' Bolt ',
+  uom: 'EA',
+  quantity: '2',
+}, null, 2))
+
+const adapterMetadataByKind = computed(() => new Map(adapters.value.map((adapter) => [adapter.kind, adapter])))
+const visibleAdapters = computed(() => adapters.value.filter((adapter) => showAdvancedConnectors.value || !adapter.advanced))
+const hiddenAdvancedSystemCount = computed(() => systems.value.filter((system) => isAdvancedSystem(system)).length)
+const visibleSystems = computed(() => systems.value.filter((system) => showAdvancedConnectors.value || !isAdvancedSystem(system)))
+const sourceSystems = computed(() => visibleSystems.value.filter(canReadFromSystem))
+const targetSystems = computed(() => visibleSystems.value.filter(canWriteToSystem))
+const selectedTargetObject = computed(() => targetObjects.value.find((object) => object.name === targetObjectName.value) || null)
+const selectedSourceSystem = computed(() => systems.value.find((system) => system.id === sourceSystemId.value) || null)
+const selectedTargetSystem = computed(() => systems.value.find((system) => system.id === targetSystemId.value) || null)
+const sourceConnectionStatus = computed(() => selectedSourceSystem.value?.status || 'inactive')
+const targetConnectionStatus = computed(() => selectedTargetSystem.value?.status || 'inactive')
+const sourceConnectionLabel = computed(() => connectionStatusLabel(selectedSourceSystem.value))
+const targetConnectionLabel = computed(() => connectionStatusLabel(selectedTargetSystem.value))
+const observationSummary = computed(() => `${pipelineRuns.value.length} runs / ${deadLetters.value.length} open dead letters`)
+const sameSystemNotice = computed(() => {
+  if (!sourceSystemId.value || sourceSystemId.value !== targetSystemId.value) return ''
+  if (selectedSourceSystem.value?.role === 'bidirectional') {
+    return 'same system, different business object：同一个双向连接可以作为来源和目标，但请选择不同业务对象避免误解为 loopback sync。'
+  }
+  return '同一连接同时作为来源和目标只支持 role=bidirectional 的外部系统。'
+})
+const protocolSplitNotice = computed(() => {
+  const source = selectedSourceSystem.value
+  const target = selectedTargetSystem.value
+  if (!source || !target) return ''
+  if (isK3WiseSystem(source) && isK3WiseSystem(target) && source.kind !== target.kind) {
+    return '同一物理 K3 WISE 使用不同协议时，建议配置两条逻辑连接：SQL read channel 作为来源，WebAPI Save channel 作为目标。'
+  }
+  if (showAdvancedConnectors.value) {
+    return '如果同一物理系统需要不同协议，请使用两条逻辑连接区分读取和写入职责。'
+  }
+  return ''
+})
+
+function setStatus(message: string, kind: 'success' | 'error' | 'idle' = 'idle'): void {
+  statusMessage.value = message
+  statusKind.value = kind
+}
+
+function currentScope() {
+  return {
+    tenantId: scope.tenantId.trim() || 'default',
+    workspaceId: scope.workspaceId || null,
+  }
+}
+
+function isAdvancedSystem(system: WorkbenchExternalSystem): boolean {
+  return adapterMetadataByKind.value.get(system.kind)?.advanced === true
+}
+
+function isK3WiseSystem(system: WorkbenchExternalSystem): boolean {
+  return system.kind.startsWith('erp:k3-wise')
+}
+
+function normalizeSystemSelections(): void {
+  if (sourceSystemId.value && !sourceSystems.value.some((system) => system.id === sourceSystemId.value)) {
+    sourceSystemId.value = sourceSystems.value[0]?.id || ''
+  }
+  if (targetSystemId.value && !targetSystems.value.some((system) => system.id === targetSystemId.value)) {
+    targetSystemId.value = targetSystems.value[0]?.id || ''
+  }
+  if (!sourceSystemId.value) sourceSystemId.value = sourceSystems.value[0]?.id || ''
+  if (!targetSystemId.value) targetSystemId.value = targetSystems.value[0]?.id || ''
+}
+
+async function refreshBootstrap(): Promise<void> {
+  try {
+    const resolvedScope = currentScope()
+    const [adapterList, systemList, descriptorList] = await Promise.all([
+      listIntegrationAdapters(),
+      listWorkbenchExternalSystems(resolvedScope),
+      listIntegrationStagingDescriptors(),
+    ])
+    adapters.value = adapterList
+    systems.value = systemList
+    stagingDescriptors.value = descriptorList
+    normalizeSystemSelections()
+    if (!stagingSheetId.value) stagingSheetId.value = descriptorList.find((descriptor) => descriptor.id === 'standard_materials')?.id || descriptorList[0]?.id || ''
+    setStatus(`已加载 ${systemList.length} 个连接、${adapterList.length} 个适配器和 ${descriptorList.length} 个 staging 表`, 'success')
+  } catch (error) {
+    setStatus(error instanceof Error ? error.message : String(error), 'error')
+  }
+}
+
+function connectionStatusLabel(system: WorkbenchExternalSystem | null): string {
+  if (!system) return '未选择'
+  if (system.status === 'active') return system.lastTestedAt ? '已连接' : '可用'
+  if (system.status === 'error') return system.lastError ? `异常：${system.lastError}` : '异常'
+  return '未启用'
+}
+
+function replaceSystem(updated: WorkbenchExternalSystem): void {
+  const index = systems.value.findIndex((system) => system.id === updated.id)
+  if (index >= 0) {
+    systems.value.splice(index, 1, updated)
+  } else {
+    systems.value.push(updated)
+  }
+}
+
+async function testSystem(side: WorkbenchSide): Promise<void> {
+  const systemId = side === 'source' ? sourceSystemId.value : targetSystemId.value
+  if (!systemId) {
+    setStatus(`${side === 'source' ? '来源' : '目标'}系统未选择`, 'error')
+    return
+  }
+  try {
+    const result = await testExternalSystemConnection(systemId, currentScope())
+    if (result.system) replaceSystem(result.system)
+    const label = side === 'source' ? '来源' : '目标'
+    setStatus(result.ok ? `${label}连接测试通过` : `${label}连接测试失败：${result.message || result.code || 'unknown error'}`, result.ok ? 'success' : 'error')
+  } catch (error) {
+    setStatus(error instanceof Error ? error.message : String(error), 'error')
+  }
+}
+
+async function loadObjects(side: WorkbenchSide): Promise<void> {
+  const systemId = side === 'source' ? sourceSystemId.value : targetSystemId.value
+  if (!systemId) {
+    setStatus(`${side === 'source' ? '来源' : '目标'}系统未选择`, 'error')
+    return
+  }
+  try {
+    const objects = await listExternalSystemObjects(systemId, currentScope())
+    if (side === 'source') {
+      sourceObjects.value = objects
+      sourceObjectName.value = objects[0]?.name || ''
+    } else {
+      targetObjects.value = objects
+      targetObjectName.value = objects[0]?.name || ''
+    }
+    if (objects.length > 0) await loadSchema(side)
+    setStatus(`已加载 ${objects.length} 个${side === 'source' ? '来源' : '目标'}对象`, 'success')
+  } catch (error) {
+    setStatus(error instanceof Error ? error.message : String(error), 'error')
+  }
+}
+
+async function loadSchema(side: WorkbenchSide): Promise<void> {
+  const systemId = side === 'source' ? sourceSystemId.value : targetSystemId.value
+  const objectName = side === 'source' ? sourceObjectName.value : targetObjectName.value
+  if (!systemId || !objectName) return
+  const schema = await getExternalSystemSchema(systemId, {
+    ...currentScope(),
+    object: objectName,
+  })
+  if (side === 'source') {
+    sourceSchema.value = schema
+  } else {
+    targetSchema.value = schema
+    seedMappingsFromTargetSchema(schema.fields)
+  }
+}
+
+function guessSourceField(targetField: string): string {
+  const known: Record<string, string> = {
+    FNumber: 'code',
+    FName: 'name',
+    FModel: 'spec',
+    FBaseUnitID: 'uom',
+    FUnitID: 'uom',
+    FQty: 'quantity',
+    FEntryID: 'sequence',
+    FParentItemNumber: 'parentCode',
+    FChildItemNumber: 'childCode',
+  }
+  if (known[targetField]) return known[targetField]
+  return targetField.replace(/^F/, '').replace(/Number$/, 'Code')
+}
+
+function seedMappingsFromTargetSchema(fields: IntegrationObjectSchemaField[]): void {
+  if (mappings.value.length > 0 || fields.length === 0) return
+  mappings.value = fields.slice(0, 8).map((field, index) => ({
+    id: `mapping_${index}_${field.name}`,
+    sourceField: guessSourceField(field.name),
+    targetField: field.name,
+    transformText: field.type === 'number' ? 'toNumber' : 'trim',
+    required: field.required === true,
+  }))
+}
+
+function addMapping(): void {
+  mappings.value.push({
+    id: `mapping_${Date.now()}_${mappings.value.length}`,
+    sourceField: '',
+    targetField: '',
+    transformText: '',
+    required: false,
+  })
+}
+
+function removeMapping(index: number): void {
+  mappings.value.splice(index, 1)
+}
+
+function parseTransform(text: string): unknown {
+  const steps = text.split(',').map((item) => item.trim()).filter(Boolean)
+  if (steps.length === 0) return undefined
+  return steps.length === 1 ? { fn: steps[0] } : steps
+}
+
+function buildMappings(): IntegrationFieldMapping[] {
+  return mappings.value
+    .filter((mapping) => mapping.sourceField.trim() && mapping.targetField.trim())
+    .map((mapping, index) => {
+      const validation = mapping.required ? [{ type: 'required' }] : undefined
+      return {
+        sourceField: mapping.sourceField.trim(),
+        targetField: mapping.targetField.trim(),
+        transform: parseTransform(mapping.transformText),
+        validation,
+        sortOrder: index,
+      }
+    })
+}
+
+function parseList(value: string): string[] {
+  return Array.from(new Set(value.split(/[\n,]/).map((item) => item.trim()).filter(Boolean)))
+}
+
+function parseOptionalPositiveInteger(value: string): number | undefined {
+  const trimmed = value.trim()
+  if (!trimmed) return undefined
+  const numeric = Number(trimmed)
+  if (!Number.isInteger(numeric) || numeric <= 0) {
+    throw new Error('Dry-run 样本数必须是正整数')
+  }
+  return numeric
+}
+
+function defaultPipelineName(): string {
+  const sourceName = selectedSourceSystem.value?.name || sourceSystemId.value || 'source'
+  const targetName = selectedTargetSystem.value?.name || targetSystemId.value || 'target'
+  return `${sourceName}:${sourceObjectName.value || 'object'} -> ${targetName}:${targetObjectName.value || 'object'}`
+}
+
+function selectedTemplateMeta(): Record<string, unknown> {
+  const template = selectedTargetObject.value?.template || targetSchema.value.template || {}
+  return {
+    id: typeof template.id === 'string' ? template.id : undefined,
+    version: typeof template.version === 'string' ? template.version : undefined,
+    documentType: targetObjectName.value,
+    bodyKey: typeof template.bodyKey === 'string' ? template.bodyKey : 'Data',
+    endpointPath: typeof template.endpointPath === 'string' ? template.endpointPath : undefined,
+  }
+}
+
+function buildPipelinePayload() {
+  const resolvedScope = currentScope()
+  const fieldMappings = buildMappings()
+  const idempotencyKeyFields = parseList(idempotencyFieldsText.value)
+  if (!sourceSystemId.value) throw new Error('请选择来源系统')
+  if (!targetSystemId.value) throw new Error('请选择目标系统')
+  if (!sourceObjectName.value) throw new Error('请选择来源对象')
+  if (!targetObjectName.value) throw new Error('请选择目标对象')
+  if (fieldMappings.length === 0) throw new Error('请至少配置一条字段映射')
+  if (idempotencyKeyFields.length === 0) throw new Error('请至少配置一个幂等字段')
+
+  const templateMeta = selectedTemplateMeta()
+  const hasTemplate = typeof templateMeta.id === 'string' || typeof templateMeta.endpointPath === 'string'
+  return {
+    ...(savedPipelineId.value.trim() ? { id: savedPipelineId.value.trim() } : {}),
+    ...resolvedScope,
+    name: pipelineName.value.trim() || defaultPipelineName(),
+    description: 'Generic integration workbench pipeline. Business data is cleansed in MetaSheet tables; this pipeline stores mapping and execution policy only.',
+    sourceSystemId: sourceSystemId.value,
+    sourceObject: sourceObjectName.value,
+    targetSystemId: targetSystemId.value,
+    targetObject: targetObjectName.value,
+    stagingSheetId: stagingSheetId.value.trim() || null,
+    mode: pipelineMode.value,
+    status: 'active' as const,
+    idempotencyKeyFields,
+    options: {
+      target: {
+        autoSubmit: false,
+        autoAudit: false,
+      },
+      workbench: {
+        source: 'generic-integration-workbench',
+        version: 'v1',
+      },
+      ...(hasTemplate ? { k3Template: templateMeta } : {}),
+    },
+    fieldMappings,
+  }
+}
+
+function buildObservationQuery(status?: string) {
+  const pipelineId = savedPipelineId.value.trim()
+  if (!pipelineId) throw new Error('请先保存 Pipeline，或粘贴已有 Pipeline ID')
+  return {
+    ...currentScope(),
+    pipelineId,
+    ...(status ? { status } : {}),
+    limit: 5,
+  }
+}
+
+async function refreshPipelineObservation(silent = false): Promise<void> {
+  observingPipeline.value = true
+  try {
+    const [runs, openDeadLetters] = await Promise.all([
+      listIntegrationPipelineRuns(buildObservationQuery()),
+      listIntegrationDeadLetters(buildObservationQuery('open')),
+    ])
+    pipelineRuns.value = runs
+    deadLetters.value = openDeadLetters
+    if (!silent) setStatus('Pipeline 运行记录已刷新', 'success')
+  } catch (error) {
+    if (!silent) setStatus(error instanceof Error ? error.message : String(error), 'error')
+  } finally {
+    observingPipeline.value = false
+  }
+}
+
+async function savePipeline(): Promise<void> {
+  savingPipeline.value = true
+  try {
+    const pipeline = await upsertIntegrationPipeline(buildPipelinePayload())
+    savedPipelineId.value = pipeline.id
+    pipelineName.value = pipeline.name
+    pipelineResultText.value = JSON.stringify({ action: 'save-pipeline', pipeline }, null, 2)
+    setStatus(`Pipeline 已保存：${pipeline.id}`, 'success')
+  } catch (error) {
+    setStatus(error instanceof Error ? error.message : String(error), 'error')
+  } finally {
+    savingPipeline.value = false
+  }
+}
+
+async function executePipeline(dryRun: boolean): Promise<void> {
+  const pipelineId = savedPipelineId.value.trim()
+  if (!pipelineId) {
+    setStatus('请先保存 Pipeline，或粘贴已有 Pipeline ID', 'error')
+    return
+  }
+  if (!dryRun && !allowSaveOnlyRun.value) {
+    setStatus('Save-only 推送前必须显式勾选允许本次推送', 'error')
+    return
+  }
+  runningPipeline.value = dryRun ? 'dry-run' : 'run'
+  try {
+    const payload = {
+      ...currentScope(),
+      mode: pipelineRunMode.value,
+      sampleLimit: parseOptionalPositiveInteger(pipelineSampleLimit.value),
+    }
+    const result = await runIntegrationPipeline(pipelineId, payload, dryRun)
+    pipelineResultText.value = JSON.stringify({
+      action: dryRun ? 'dry-run' : 'save-only-run',
+      pipelineId,
+      payload,
+      result,
+    }, null, 2)
+    await refreshPipelineObservation(true)
+    setStatus(dryRun ? 'Dry-run 已提交' : 'Save-only 推送已提交', 'success')
+  } catch (error) {
+    setStatus(error instanceof Error ? error.message : String(error), 'error')
+  } finally {
+    runningPipeline.value = ''
+  }
+}
+
+async function previewPayload(): Promise<void> {
+  try {
+    const sourceRecord = JSON.parse(sampleRecordText.value) as Record<string, unknown>
+    const template = selectedTemplateMeta()
+    const result = await previewIntegrationTemplate({
+      sourceRecord,
+      fieldMappings: buildMappings(),
+      template: {
+        id: typeof template.id === 'string' ? template.id : targetObjectName.value,
+        version: typeof template.version === 'string' ? template.version : undefined,
+        documentType: typeof template.documentType === 'string' ? template.documentType : targetObjectName.value,
+        bodyKey: typeof template.bodyKey === 'string' ? template.bodyKey : 'Data',
+        endpointPath: typeof template.endpointPath === 'string' ? template.endpointPath : undefined,
+        schema: targetSchema.value.fields,
+      },
+    })
+    previewText.value = JSON.stringify(result, null, 2)
+    setStatus(result.valid ? 'Payload 预览通过' : `Payload 预览发现 ${result.errors.length} 个问题`, result.valid ? 'success' : 'error')
+  } catch (error) {
+    previewText.value = '预览失败'
+    setStatus(error instanceof Error ? error.message : String(error), 'error')
+  }
+}
+
+onMounted(() => {
+  void refreshBootstrap()
+})
+
+watch(showAdvancedConnectors, () => {
+  normalizeSystemSelections()
+})
+</script>
+
+<style scoped>
+.integration-workbench {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 24px;
+  color: #17202a;
+}
+
+.integration-workbench__header,
+.integration-workbench__panel-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.integration-workbench__header {
+  margin-bottom: 18px;
+}
+
+.integration-workbench__eyebrow {
+  margin: 0 0 6px;
+  color: #54637a;
+  font-size: 13px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.integration-workbench h1,
+.integration-workbench h2 {
+  margin: 0;
+}
+
+.integration-workbench h1 {
+  font-size: 28px;
+}
+
+.integration-workbench h2 {
+  font-size: 17px;
+}
+
+.integration-workbench__lead,
+.integration-workbench__panel p {
+  margin: 8px 0 0;
+  color: #5c6878;
+  line-height: 1.5;
+}
+
+.integration-workbench__k3-link,
+.integration-workbench__button,
+.integration-workbench__icon-button {
+  border: 1px solid #bfccd9;
+  border-radius: 6px;
+  background: #ffffff;
+  color: #233246;
+  cursor: pointer;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.integration-workbench__k3-link,
+.integration-workbench__button {
+  padding: 8px 12px;
+}
+
+.integration-workbench__icon-button {
+  padding: 6px 8px;
+}
+
+.integration-workbench__button:hover,
+.integration-workbench__icon-button:hover,
+.integration-workbench__k3-link:hover {
+  border-color: #357abd;
+}
+
+.integration-workbench__button--danger {
+  border-color: #c77777;
+  color: #8f1d1d;
+}
+
+.integration-workbench__status {
+  margin-bottom: 14px;
+  padding: 10px 12px;
+  border-radius: 6px;
+  background: #eef4fb;
+  color: #24476b;
+}
+
+.integration-workbench__status[data-kind="error"] {
+  background: #fff0f0;
+  color: #9b1c1c;
+}
+
+.integration-workbench__status[data-kind="success"] {
+  background: #edf7ef;
+  color: #17622f;
+}
+
+.integration-workbench__panel {
+  margin-bottom: 16px;
+  padding: 16px;
+  border: 1px solid #d8e0e8;
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.integration-workbench__adapter-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 14px;
+}
+
+.integration-workbench__adapter {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 8px;
+  border: 1px solid #d8e0e8;
+  border-radius: 999px;
+  color: #35465c;
+  font-size: 13px;
+}
+
+.integration-workbench__adapter small {
+  color: #8a4d00;
+  font-weight: 700;
+}
+
+.integration-workbench__advanced-toggle {
+  display: flex;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 8px;
+  margin-top: 14px;
+}
+
+.integration-workbench__advanced-toggle input {
+  width: auto;
+}
+
+.integration-workbench__hint {
+  margin-top: 10px;
+  color: #5c6878;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.integration-workbench__hint--strong {
+  padding: 10px 12px;
+  border-radius: 6px;
+  background: #fff8e8;
+  color: #744600;
+}
+
+.integration-workbench__connection-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.integration-workbench__badge {
+  display: inline-flex;
+  align-items: center;
+  max-width: 100%;
+  padding: 5px 8px;
+  border-radius: 999px;
+  background: #eef2f7;
+  color: #3c4b60;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.integration-workbench__badge[data-status="active"] {
+  background: #edf7ef;
+  color: #17622f;
+}
+
+.integration-workbench__badge[data-status="error"] {
+  background: #fff0f0;
+  color: #9b1c1c;
+}
+
+.integration-workbench__grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+  margin-top: 16px;
+}
+
+.integration-workbench__grid--systems {
+  align-items: start;
+}
+
+.integration-workbench__system-column {
+  display: grid;
+  gap: 12px;
+}
+
+.integration-workbench label {
+  display: grid;
+  gap: 6px;
+  color: #35465c;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.integration-workbench input,
+.integration-workbench select,
+.integration-workbench textarea {
+  width: 100%;
+  box-sizing: border-box;
+  border: 1px solid #bfccd9;
+  border-radius: 6px;
+  padding: 8px 10px;
+  color: #17202a;
+  font: inherit;
+}
+
+.integration-workbench textarea {
+  min-height: 260px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 12px;
+}
+
+.integration-workbench__schema-list {
+  min-height: 84px;
+  margin: 0;
+  padding: 10px 12px;
+  border: 1px solid #e4ebf2;
+  border-radius: 6px;
+  background: #f8fafc;
+  list-style: none;
+}
+
+.integration-workbench__schema-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 4px 0;
+  color: #42536a;
+}
+
+.integration-workbench code {
+  color: #1f5f99;
+  font-size: 12px;
+}
+
+.integration-workbench__schema-list strong {
+  color: #9b1c1c;
+  font-size: 12px;
+}
+
+.integration-workbench__mapping-table {
+  width: 100%;
+  margin-top: 14px;
+  border-collapse: collapse;
+}
+
+.integration-workbench__mapping-table th,
+.integration-workbench__mapping-table td {
+  padding: 8px;
+  border-bottom: 1px solid #e4ebf2;
+  text-align: left;
+}
+
+.integration-workbench__mapping-table th {
+  color: #5c6878;
+  font-size: 12px;
+}
+
+.integration-workbench__mapping-table input[type="checkbox"] {
+  width: auto;
+}
+
+.integration-workbench__inline-check {
+  display: flex;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 8px;
+  margin-top: 14px;
+}
+
+.integration-workbench__inline-check input {
+  width: auto;
+}
+
+.integration-workbench__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 14px;
+}
+
+.integration-workbench__observation {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+  margin-top: 14px;
+}
+
+.integration-workbench h3 {
+  margin: 0 0 10px;
+  font-size: 14px;
+}
+
+.integration-workbench__empty {
+  padding: 12px;
+  border: 1px dashed #cbd5e1;
+  border-radius: 6px;
+  color: #5c6878;
+}
+
+.integration-workbench__record-list {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.integration-workbench__record-list li {
+  display: grid;
+  gap: 4px;
+  padding: 10px;
+  border: 1px solid #e4ebf2;
+  border-radius: 6px;
+  background: #f8fafc;
+}
+
+.integration-workbench__record-list small {
+  color: #5c6878;
+}
+
+.integration-workbench__preview {
+  display: grid;
+  grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
+  gap: 16px;
+}
+
+.integration-workbench pre {
+  min-height: 260px;
+  max-height: 420px;
+  overflow: auto;
+  margin: 12px 0 0;
+  padding: 12px;
+  border: 1px solid #d8e0e8;
+  border-radius: 6px;
+  background: #111827;
+  color: #e5edf7;
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+@media (max-width: 900px) {
+  .integration-workbench__header,
+  .integration-workbench__panel-head,
+  .integration-workbench__preview,
+  .integration-workbench__observation,
+  .integration-workbench__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .integration-workbench__header,
+  .integration-workbench__panel-head {
+    display: grid;
+  }
+}
+</style>

--- a/apps/web/tests/IntegrationK3WiseSetupView.spec.ts
+++ b/apps/web/tests/IntegrationK3WiseSetupView.spec.ts
@@ -52,6 +52,13 @@ async function flushUi(cycles = 4): Promise<void> {
   }
 }
 
+function registerRouterLinkStub(app: VueApp<Element>): void {
+  app.component('router-link', {
+    props: ['to'],
+    template: '<a :href="to"><slot /></a>',
+  })
+}
+
 describe('IntegrationK3WiseSetupView', () => {
   let app: VueApp<Element> | null = null
   let container: HTMLDivElement | null = null
@@ -75,9 +82,13 @@ describe('IntegrationK3WiseSetupView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    registerRouterLinkStub(app)
     app.mount(container)
     await flushUi()
 
+    const workbenchLink = container.querySelector('[data-testid="generic-workbench-link"]') as HTMLAnchorElement
+    expect(workbenchLink?.getAttribute('href')).toBe('/integrations/workbench')
+    expect(workbenchLink?.textContent).toContain('打开通用工作台')
     expect(container.textContent).toContain('1. 接通 K3')
     expect(container.textContent).toContain('2. 准备多维表')
     expect(container.textContent).toContain('基础连接')
@@ -162,6 +173,7 @@ describe('IntegrationK3WiseSetupView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(View as Component)
+    registerRouterLinkStub(app)
     app.mount(container)
     await flushUi()
 

--- a/apps/web/tests/IntegrationWorkbenchView.spec.ts
+++ b/apps/web/tests/IntegrationWorkbenchView.spec.ts
@@ -1,0 +1,355 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, nextTick, type App as VueApp, type Component } from 'vue'
+
+const apiFetchMock = vi.fn()
+
+vi.mock('../src/utils/api', () => ({
+  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+}))
+
+function jsonResponse(data: unknown): Response {
+  return new Response(JSON.stringify({ ok: true, data }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+async function flushUi(cycles = 5): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+describe('IntegrationWorkbenchView', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    apiFetchMock.mockReset()
+    if (typeof localStorage?.clear === 'function') localStorage.clear()
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+  })
+
+  it('loads systems, object schemas, and previews a template payload', async () => {
+    const previewBodies: Array<Record<string, unknown>> = []
+    const pipelineBodies: Array<Record<string, unknown>> = []
+    const runBodies: Array<{ url: string; body: Record<string, unknown> }> = []
+    apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === '/api/integration/adapters') {
+        return jsonResponse([
+          { kind: 'http', label: 'HTTP API', roles: ['bidirectional'], supports: ['read', 'upsert'], advanced: false },
+          { kind: 'erp:k3-wise-sqlserver', label: 'K3 WISE SQL Server Channel', roles: ['source', 'target'], supports: ['read'], advanced: true },
+        ])
+      }
+      if (url === '/api/integration/external-systems?tenantId=default') {
+        return jsonResponse([
+          { id: 'plm_1', tenantId: 'default', workspaceId: null, name: 'PLM Source', kind: 'http', role: 'source', status: 'active' },
+          { id: 'k3_1', tenantId: 'default', workspaceId: null, name: 'K3 Target', kind: 'erp:k3-wise-webapi', role: 'target', status: 'active' },
+          { id: 'crm_1', tenantId: 'default', workspaceId: null, name: 'CRM Bidirectional', kind: 'http', role: 'bidirectional', status: 'active' },
+          { id: 'k3_sql', tenantId: 'default', workspaceId: null, name: 'K3 SQL Read Channel', kind: 'erp:k3-wise-sqlserver', role: 'source', status: 'active' },
+        ])
+      }
+      if (url === '/api/integration/staging/descriptors') {
+        return jsonResponse([
+          { id: 'standard_materials', name: 'Standard Materials', fields: ['code', 'name'] },
+        ])
+      }
+      if (url === '/api/integration/external-systems/plm_1/objects?tenantId=default') {
+        return jsonResponse([{ name: 'materials', label: 'Materials', operations: ['read'] }])
+      }
+      if (url === '/api/integration/external-systems/plm_1/schema?tenantId=default&object=materials') {
+        return jsonResponse({
+          object: 'materials',
+          fields: [
+            { name: 'code', label: 'Code', type: 'string' },
+            { name: 'name', label: 'Name', type: 'string' },
+          ],
+        })
+      }
+      if (url === '/api/integration/external-systems/plm_1/test?tenantId=default') {
+        return jsonResponse({
+          ok: true,
+          status: 200,
+          system: {
+            id: 'plm_1',
+            tenantId: 'default',
+            workspaceId: null,
+            name: 'PLM Source',
+            kind: 'http',
+            role: 'source',
+            status: 'active',
+            lastTestedAt: '2026-05-12T00:00:00.000Z',
+          },
+        })
+      }
+      if (url === '/api/integration/external-systems/k3_1/objects?tenantId=default') {
+        return jsonResponse([
+          {
+            name: 'material',
+            label: 'K3 Material',
+            source: 'documentTemplate',
+            template: { id: 'k3wise.material.v1', bodyKey: 'Data', endpointPath: '/K3API/Material/Save' },
+          },
+        ])
+      }
+      if (url === '/api/integration/external-systems/k3_1/schema?tenantId=default&object=material') {
+        return jsonResponse({
+          object: 'material',
+          template: { id: 'k3wise.material.v1', bodyKey: 'Data' },
+          fields: [
+            { name: 'FNumber', label: 'Material code', type: 'string', required: true },
+            { name: 'FName', label: 'Material name', type: 'string', required: true },
+            { name: 'FBaseUnitID', label: 'Base unit', type: 'string' },
+          ],
+        })
+      }
+      if (url === '/api/integration/external-systems/k3_1/test?tenantId=default') {
+        return jsonResponse({
+          ok: false,
+          code: 'ERP_DOWN',
+          message: 'ERP endpoint unavailable',
+          system: {
+            id: 'k3_1',
+            tenantId: 'default',
+            workspaceId: null,
+            name: 'K3 Target',
+            kind: 'erp:k3-wise-webapi',
+            role: 'target',
+            status: 'error',
+            lastError: 'ERP endpoint unavailable',
+          },
+        })
+      }
+      if (url === '/api/integration/templates/preview') {
+        const body = JSON.parse(String(init?.body || '{}')) as Record<string, unknown>
+        previewBodies.push(body)
+        return jsonResponse({
+          valid: true,
+          payload: { Data: { FNumber: 'MAT-001', FName: 'Bolt', FBaseUnitID: 'Pcs' } },
+          targetRecord: { FNumber: 'MAT-001', FName: 'Bolt', FBaseUnitID: 'Pcs' },
+          errors: [],
+          transformErrors: [],
+          validationErrors: [],
+          schemaErrors: [],
+        })
+      }
+      if (url === '/api/integration/pipelines') {
+        const body = JSON.parse(String(init?.body || '{}')) as Record<string, unknown>
+        pipelineBodies.push(body)
+        return jsonResponse({
+          id: 'pipe_1',
+          tenantId: 'default',
+          workspaceId: null,
+          name: body.name || 'Workbench pipeline',
+          sourceSystemId: 'plm_1',
+          sourceObject: 'materials',
+          targetSystemId: 'k3_1',
+          targetObject: 'material',
+          mode: 'manual',
+          idempotencyKeyFields: ['code'],
+          options: body.options || {},
+          status: 'active',
+        })
+      }
+      if (url === '/api/integration/pipelines/pipe_1/dry-run' || url === '/api/integration/pipelines/pipe_1/run') {
+        const body = JSON.parse(String(init?.body || '{}')) as Record<string, unknown>
+        runBodies.push({ url, body })
+        return jsonResponse({
+          pipelineId: 'pipe_1',
+          dryRun: url.endsWith('/dry-run'),
+          metrics: url.endsWith('/dry-run')
+            ? { rowsRead: 1, rowsCleaned: 1, rowsWritten: 0 }
+            : { rowsRead: 1, rowsCleaned: 1, rowsWritten: 1 },
+        })
+      }
+      if (url === '/api/integration/runs?tenantId=default&pipelineId=pipe_1&limit=5') {
+        return jsonResponse([
+          {
+            id: 'run_1',
+            tenantId: 'default',
+            workspaceId: null,
+            pipelineId: 'pipe_1',
+            mode: 'manual',
+            status: 'succeeded',
+            rowsRead: 1,
+            rowsCleaned: 1,
+            rowsWritten: 0,
+            rowsFailed: 0,
+            startedAt: '2026-05-12T00:00:00.000Z',
+          },
+        ])
+      }
+      if (url === '/api/integration/dead-letters?tenantId=default&pipelineId=pipe_1&status=open&limit=5') {
+        return jsonResponse([
+          {
+            id: 'dl_1',
+            tenantId: 'default',
+            workspaceId: null,
+            pipelineId: 'pipe_1',
+            runId: 'run_1',
+            errorCode: 'VALIDATION_FAILED',
+            errorMessage: 'missing required code',
+            status: 'open',
+            createdAt: '2026-05-12T00:00:01.000Z',
+          },
+        ])
+      }
+      throw new Error(`unexpected URL ${url}`)
+    })
+
+    const View = (await import('../src/views/IntegrationWorkbenchView.vue')).default
+
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    app.component('router-link', {
+      props: ['to'],
+      render() {
+        return null
+      },
+    })
+    app.mount(container)
+    await flushUi()
+
+    expect(container.textContent).toContain('通用数据集成工作台')
+    expect(container.textContent).toContain('HTTP API')
+    expect(container.textContent).not.toContain('K3 WISE SQL Server Channel')
+    expect(container.textContent).toContain('已隐藏 1 个高级连接')
+    expect((container.querySelector('[data-testid="staging-sheet"]') as HTMLSelectElement).value).toBe('standard_materials')
+    expect(Array.from((container.querySelector('[data-testid="source-system"]') as HTMLSelectElement).options).map((option) => option.textContent))
+      .not.toContain('K3 SQL Read Channel · erp:k3-wise-sqlserver')
+
+    ;(container.querySelector('[data-testid="show-advanced-connectors"]') as HTMLInputElement).click()
+    await flushUi()
+    expect(container.textContent).toContain('K3 WISE SQL Server Channel')
+    expect(container.textContent).toContain('高级')
+    expect(container.textContent).toContain('allowlist 表/视图读取或中间表写入')
+    expect(Array.from((container.querySelector('[data-testid="source-system"]') as HTMLSelectElement).options).map((option) => option.textContent))
+      .toContain('K3 SQL Read Channel · erp:k3-wise-sqlserver')
+
+    const sourceSystemSelect = container.querySelector('[data-testid="source-system"]') as HTMLSelectElement
+    const targetSystemSelect = container.querySelector('[data-testid="target-system"]') as HTMLSelectElement
+
+    sourceSystemSelect.value = 'k3_sql'
+    sourceSystemSelect.dispatchEvent(new Event('change'))
+    await flushUi()
+    expect(container.textContent).toContain('SQL read channel 作为来源，WebAPI Save channel 作为目标')
+
+    sourceSystemSelect.value = 'crm_1'
+    sourceSystemSelect.dispatchEvent(new Event('change'))
+    targetSystemSelect.value = 'crm_1'
+    targetSystemSelect.dispatchEvent(new Event('change'))
+    await flushUi()
+    expect(container.textContent).toContain('same system, different business object')
+
+    sourceSystemSelect.value = 'plm_1'
+    sourceSystemSelect.dispatchEvent(new Event('change'))
+    targetSystemSelect.value = 'k3_1'
+    targetSystemSelect.dispatchEvent(new Event('change'))
+    await flushUi()
+
+    expect(container.textContent).toContain('可用')
+    ;(container.querySelector('[data-testid="test-source-system"]') as HTMLButtonElement).click()
+    await flushUi(8)
+    expect(container.textContent).toContain('来源连接测试通过')
+    expect(container.textContent).toContain('已连接')
+
+    ;(container.querySelector('[data-testid="test-target-system"]') as HTMLButtonElement).click()
+    await flushUi(8)
+    expect(container.textContent).toContain('目标连接测试失败：ERP endpoint unavailable')
+    expect(container.textContent).toContain('异常：ERP endpoint unavailable')
+
+    ;(container.querySelector('[data-testid="load-source-objects"]') as HTMLButtonElement).click()
+    await flushUi(8)
+    ;(container.querySelector('[data-testid="load-target-objects"]') as HTMLButtonElement).click()
+    await flushUi(8)
+
+    expect((container.querySelector('[data-testid="source-field-0"]') as HTMLInputElement).value).toBe('code')
+    expect((container.querySelector('[data-testid="target-field-0"]') as HTMLInputElement).value).toBe('FNumber')
+    expect(container.textContent).toContain('Material code')
+
+    ;(container.querySelector('[data-testid="preview-payload"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    expect(previewBodies).toHaveLength(1)
+    expect(previewBodies[0]).toMatchObject({
+      template: {
+        id: 'k3wise.material.v1',
+        bodyKey: 'Data',
+      },
+      fieldMappings: [
+        { sourceField: 'code', targetField: 'FNumber' },
+        { sourceField: 'name', targetField: 'FName' },
+        { sourceField: 'uom', targetField: 'FBaseUnitID' },
+      ],
+    })
+    expect(container.textContent).toContain('"FNumber": "MAT-001"')
+    expect(container.textContent).toContain('Payload 预览通过')
+
+    ;(container.querySelector('[data-testid="save-pipeline"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    expect(pipelineBodies).toHaveLength(1)
+    expect(pipelineBodies[0]).toMatchObject({
+      tenantId: 'default',
+      sourceSystemId: 'plm_1',
+      sourceObject: 'materials',
+      targetSystemId: 'k3_1',
+      targetObject: 'material',
+      stagingSheetId: 'standard_materials',
+      mode: 'manual',
+      status: 'active',
+      idempotencyKeyFields: ['code'],
+      options: {
+        target: {
+          autoSubmit: false,
+          autoAudit: false,
+        },
+        k3Template: {
+          id: 'k3wise.material.v1',
+          documentType: 'material',
+        },
+      },
+    })
+    expect((container.querySelector('[data-testid="pipeline-id"]') as HTMLInputElement).value).toBe('pipe_1')
+    expect(container.textContent).toContain('Pipeline 已保存：pipe_1')
+
+    ;(container.querySelector('[data-testid="run-dry-run"]') as HTMLButtonElement).click()
+    await flushUi(16)
+    expect(runBodies[0]).toEqual({
+      url: '/api/integration/pipelines/pipe_1/dry-run',
+      body: {
+        tenantId: 'default',
+        workspaceId: null,
+        mode: 'manual',
+        sampleLimit: 20,
+      },
+    })
+    expect(container.textContent).toContain('Dry-run 已提交')
+    expect(container.textContent).toContain('succeeded')
+    expect(container.textContent).toContain('VALIDATION_FAILED')
+    expect(container.textContent).toContain('1 runs / 1 open dead letters')
+
+    ;(container.querySelector('[data-testid="allow-save-only-run"]') as HTMLInputElement).click()
+    await flushUi()
+    ;(container.querySelector('[data-testid="run-save-only"]') as HTMLButtonElement).click()
+    await flushUi(16)
+    expect(runBodies[1]).toEqual({
+      url: '/api/integration/pipelines/pipe_1/run',
+      body: {
+        tenantId: 'default',
+        workspaceId: null,
+        mode: 'manual',
+        sampleLimit: 20,
+      },
+    })
+    expect(container.textContent).toContain('Save-only 推送已提交')
+  })
+})

--- a/apps/web/tests/integrationWorkbench.spec.ts
+++ b/apps/web/tests/integrationWorkbench.spec.ts
@@ -1,0 +1,200 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  getDefaultIntegrationScope,
+  getExternalSystemSchema,
+  listIntegrationDeadLetters,
+  listExternalSystemObjects,
+  listIntegrationAdapters,
+  listIntegrationPipelineRuns,
+  listIntegrationStagingDescriptors,
+  listWorkbenchExternalSystems,
+  previewIntegrationTemplate,
+  runIntegrationPipeline,
+  testExternalSystemConnection,
+  upsertIntegrationPipeline,
+} from '../src/services/integration/workbench'
+
+const apiFetchMock = vi.fn()
+
+vi.mock('../src/utils/api', () => ({
+  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+}))
+
+function jsonResponse(data: unknown): Response {
+  return new Response(JSON.stringify({ ok: true, data }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('integration workbench service', () => {
+  beforeEach(() => {
+    apiFetchMock.mockReset()
+    if (typeof localStorage?.clear === 'function') localStorage.clear()
+  })
+
+  it('uses single-tenant defaults when no scope is stored', () => {
+    expect(getDefaultIntegrationScope()).toEqual({
+      tenantId: 'default',
+      workspaceId: null,
+    })
+  })
+
+  it('calls backend discovery and preview endpoints with scoped URLs', async () => {
+    apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === '/api/integration/adapters') {
+        return jsonResponse([{ kind: 'http', label: 'HTTP API', roles: ['bidirectional'], supports: ['read'], advanced: false }])
+      }
+      if (url === '/api/integration/external-systems?tenantId=default') {
+        return jsonResponse([{ id: 'sys_1', name: 'HTTP source', kind: 'http', role: 'bidirectional', status: 'active' }])
+      }
+      if (url === '/api/integration/external-systems/sys%201/objects?tenantId=default') {
+        return jsonResponse([{ name: 'materials', label: 'Materials', operations: ['read'] }])
+      }
+      if (url === '/api/integration/external-systems/sys%201/schema?tenantId=default&object=materials') {
+        return jsonResponse({ object: 'materials', fields: [{ name: 'code', label: 'Code', type: 'string' }] })
+      }
+      if (url === '/api/integration/staging/descriptors') {
+        return jsonResponse([{ id: 'standard_materials', name: 'Standard Materials', fields: ['code', 'name'] }])
+      }
+      if (url === '/api/integration/external-systems/sys%201/test?tenantId=default') {
+        expect(init?.method).toBe('POST')
+        expect(JSON.parse(String(init?.body))).toEqual({})
+        return jsonResponse({
+          ok: true,
+          status: 200,
+          system: {
+            id: 'sys 1',
+            name: 'HTTP source',
+            kind: 'http',
+            role: 'bidirectional',
+            status: 'active',
+            tenantId: 'default',
+            workspaceId: null,
+            lastTestedAt: '2026-05-12T00:00:00.000Z',
+          },
+        })
+      }
+      if (url === '/api/integration/templates/preview') {
+        expect(init?.method).toBe('POST')
+        expect(JSON.parse(String(init?.body))).toMatchObject({
+          sourceRecord: { code: 'MAT-001' },
+          template: { bodyKey: 'Data' },
+        })
+        return jsonResponse({
+          valid: true,
+          payload: { Data: { FNumber: 'MAT-001' } },
+          targetRecord: { FNumber: 'MAT-001' },
+          errors: [],
+          transformErrors: [],
+          validationErrors: [],
+          schemaErrors: [],
+        })
+      }
+      if (url === '/api/integration/pipelines') {
+        expect(init?.method).toBe('POST')
+        expect(JSON.parse(String(init?.body))).toMatchObject({
+          tenantId: 'default',
+          sourceSystemId: 'sys 1',
+          targetSystemId: 'sys 1',
+          options: {
+            target: {
+              autoSubmit: false,
+              autoAudit: false,
+            },
+          },
+        })
+        return jsonResponse({
+          id: 'pipe_1',
+          tenantId: 'default',
+          workspaceId: null,
+          name: 'Generic pipeline',
+          sourceSystemId: 'sys 1',
+          sourceObject: 'materials',
+          targetSystemId: 'sys 1',
+          targetObject: 'material',
+          mode: 'manual',
+          idempotencyKeyFields: ['code'],
+          options: {},
+          status: 'active',
+        })
+      }
+      if (url === '/api/integration/pipelines/pipe%201/dry-run') {
+        expect(init?.method).toBe('POST')
+        expect(JSON.parse(String(init?.body))).toEqual({
+          tenantId: 'default',
+          mode: 'manual',
+          sampleLimit: 5,
+        })
+        return jsonResponse({ pipelineId: 'pipe 1', dryRun: true, metrics: { rowsRead: 1, rowsWritten: 0 } })
+      }
+      if (url === '/api/integration/pipelines/pipe%201/run') {
+        expect(init?.method).toBe('POST')
+        return jsonResponse({ pipelineId: 'pipe 1', dryRun: false, metrics: { rowsWritten: 1 } })
+      }
+      if (url === '/api/integration/runs?tenantId=default&pipelineId=pipe+1&limit=5') {
+        return jsonResponse([{ id: 'run_1', tenantId: 'default', workspaceId: null, pipelineId: 'pipe 1', mode: 'manual', status: 'succeeded', rowsRead: 1, rowsCleaned: 1, rowsWritten: 0, rowsFailed: 0 }])
+      }
+      if (url === '/api/integration/dead-letters?tenantId=default&pipelineId=pipe+1&status=open&limit=5') {
+        return jsonResponse([{ id: 'dl_1', tenantId: 'default', workspaceId: null, pipelineId: 'pipe 1', runId: 'run_1', errorCode: 'VALIDATION_FAILED', errorMessage: 'missing code', status: 'open' }])
+      }
+      throw new Error(`unexpected URL ${url}`)
+    })
+
+    await expect(listIntegrationAdapters()).resolves.toHaveLength(1)
+    await expect(listWorkbenchExternalSystems({ tenantId: 'default' })).resolves.toHaveLength(1)
+    await expect(listExternalSystemObjects('sys 1', { tenantId: 'default' })).resolves.toHaveLength(1)
+    await expect(getExternalSystemSchema('sys 1', { tenantId: 'default', object: 'materials' })).resolves.toMatchObject({
+      object: 'materials',
+      fields: [{ name: 'code', label: 'Code', type: 'string' }],
+    })
+    await expect(listIntegrationStagingDescriptors()).resolves.toEqual([
+      { id: 'standard_materials', name: 'Standard Materials', fields: ['code', 'name'] },
+    ])
+    await expect(testExternalSystemConnection('sys 1', { tenantId: 'default' })).resolves.toMatchObject({
+      ok: true,
+      system: { id: 'sys 1', status: 'active' },
+    })
+    await expect(previewIntegrationTemplate({
+      sourceRecord: { code: 'MAT-001' },
+      fieldMappings: [{ sourceField: 'code', targetField: 'FNumber' }],
+      template: { bodyKey: 'Data' },
+    })).resolves.toMatchObject({
+      valid: true,
+      payload: { Data: { FNumber: 'MAT-001' } },
+    })
+    await expect(upsertIntegrationPipeline({
+      tenantId: 'default',
+      name: 'Generic pipeline',
+      sourceSystemId: 'sys 1',
+      sourceObject: 'materials',
+      targetSystemId: 'sys 1',
+      targetObject: 'material',
+      mode: 'manual',
+      idempotencyKeyFields: ['code'],
+      options: { target: { autoSubmit: false, autoAudit: false } },
+      status: 'active',
+      fieldMappings: [{ sourceField: 'code', targetField: 'FNumber' }],
+    })).resolves.toMatchObject({ id: 'pipe_1' })
+    await expect(runIntegrationPipeline('pipe 1', {
+      tenantId: 'default',
+      mode: 'manual',
+      sampleLimit: 5,
+    }, true)).resolves.toMatchObject({ dryRun: true })
+    await expect(runIntegrationPipeline('pipe 1', {
+      tenantId: 'default',
+      mode: 'manual',
+    }, false)).resolves.toMatchObject({ dryRun: false })
+    await expect(listIntegrationPipelineRuns({
+      tenantId: 'default',
+      pipelineId: 'pipe 1',
+      limit: 5,
+    })).resolves.toHaveLength(1)
+    await expect(listIntegrationDeadLetters({
+      tenantId: 'default',
+      pipelineId: 'pipe 1',
+      status: 'open',
+      limit: 5,
+    })).resolves.toHaveLength(1)
+  })
+})

--- a/docs/development/generic-integration-workbench-advanced-connectors-design-20260512.md
+++ b/docs/development/generic-integration-workbench-advanced-connectors-design-20260512.md
@@ -1,0 +1,44 @@
+# Generic Integration Workbench Advanced Connectors Design - 2026-05-12
+
+## Purpose
+
+Close the Workbench UX gap around SQL channels and same-system object conversion:
+
+- SQL channels should not appear in the default business-user connector lists.
+- Advanced implementers should be able to reveal SQL/advanced connections explicitly.
+- Same-system pipelines must be described as "same system, different business object", not as loopback sync.
+- When one physical K3 WISE account uses different protocols, the UI should recommend two logical connections.
+
+## Implementation
+
+`IntegrationWorkbenchView.vue` now derives advanced status from adapter discovery metadata:
+
+- `adapters[].advanced === true` marks a connector kind as advanced.
+- Default source and target system lists filter out systems whose adapter kind is advanced.
+- The adapter pill list also hides advanced adapters by default.
+- A new `显示 SQL / 高级连接` toggle reveals advanced adapters and systems.
+
+The system selectors continue to use the existing backend external-system list. No backend route or schema change was needed.
+
+## Same-System Copy
+
+When source and target system IDs match:
+
+- role `bidirectional` shows the exact copy `same system, different business object`;
+- any non-bidirectional same-system selection shows a warning that same-system mode requires `role=bidirectional`.
+
+When source and target are both K3 WISE but use different connector kinds, the UI recommends:
+
+- SQL read channel as the source logical connection;
+- WebAPI Save channel as the target logical connection.
+
+## Security Boundary
+
+The advanced toggle is a UI exposure control, not an authorization boundary. Backend permissions and adapter allowlists remain the enforcement layer. The UI copy explicitly states that SQL is for allowlisted table/view reads or middle-table writes and that direct core-table writes must not be exposed to normal users.
+
+## Non-Goals
+
+- No SQL allowlist editor in this slice.
+- No middle-table write configuration in this slice.
+- No raw SQL field.
+- No backend permission or registry change.

--- a/docs/development/generic-integration-workbench-advanced-connectors-verification-20260512.md
+++ b/docs/development/generic-integration-workbench-advanced-connectors-verification-20260512.md
@@ -1,0 +1,37 @@
+# Generic Integration Workbench Advanced Connectors Verification - 2026-05-12
+
+## Verification Matrix
+
+| Check | Result | Notes |
+| --- | --- | --- |
+| `pnpm --filter @metasheet/web exec vitest run tests/IntegrationWorkbenchView.spec.ts --watch=false` | PASS | 1/1 test |
+| `pnpm --filter @metasheet/web exec vitest run tests/integrationWorkbench.spec.ts --watch=false` | PASS | 2/2 tests |
+| `pnpm --filter @metasheet/web exec vitest run tests/IntegrationWorkbenchView.spec.ts tests/integrationWorkbench.spec.ts --watch=false` | PASS | 3/3 tests |
+| `pnpm --filter @metasheet/web exec vue-tsc --noEmit` | PASS | Clean |
+| `pnpm --filter @metasheet/web build` | PASS | `vue-tsc -b` plus Vite build |
+| `pnpm -F plugin-integration-core test` | PASS | Full plugin integration-core test chain |
+| `git diff --check` | PASS | Clean |
+
+## Coverage Added
+
+- SQL adapter pill is hidden by default.
+- SQL source system is hidden from the default source selector.
+- Advanced toggle reveals the SQL adapter and SQL source system.
+- Advanced hint mentions allowlist table/view reads and middle-table writes.
+- K3 SQL source plus K3 WebAPI target shows the two-logical-connections recommendation.
+- Same-system bidirectional selection shows `same system, different business object`.
+
+## Not Covered
+
+- Backend SQL allowlist enforcement. That remains in adapter/backend tests and future configuration UI.
+- Live K3 SQL/WebAPI connectivity.
+
+## Additional Fix
+
+The production web build surfaced a pre-existing service type issue in `listIntegrationPipelineRuns()` and `listIntegrationDeadLetters()`: `IntegrationPipelineObservationQuery` was being cast directly to `Record<string, unknown>`. This slice replaced that cast with a typed `buildObservationQueryString()` helper. No runtime behavior changed.
+
+## Warnings Observed
+
+- Frontend Vitest emitted the existing `--localstorage-file was provided without a valid path` warning.
+- One frontend Vitest run emitted the existing `WebSocket server error: Port is already in use` warning.
+- Vite build emitted existing dynamic/static import and chunk-size warnings.

--- a/docs/development/generic-integration-workbench-connection-test-design-20260512.md
+++ b/docs/development/generic-integration-workbench-connection-test-design-20260512.md
@@ -1,0 +1,30 @@
+# Generic Integration Workbench Connection Test Design - 2026-05-12
+
+## Purpose
+
+Close the first interactive Workbench gap after discovery and preview: users must be able to verify whether selected source and target systems are reachable before loading objects, mapping fields, or running future dry-run/save-only actions.
+
+## Scope
+
+- Add a frontend service wrapper for `POST /api/integration/external-systems/:id/test`.
+- Add source and target connection status badges in `IntegrationWorkbenchView.vue`.
+- Add source and target "test connection" buttons.
+- Update selected system state from the sanitized backend `system` returned by the test endpoint.
+- Keep this slice frontend-only. The backend route and redaction behavior already exist in `plugin-integration-core`.
+
+## UX Rules
+
+- `active` systems display `可用`, or `已连接` when `lastTestedAt` exists.
+- `error` systems display `异常` plus the sanitized `lastError` when available.
+- inactive or missing systems display `未启用` or `未选择`.
+- Source and target tests are independent so users can validate one side without blocking the other.
+
+## Security
+
+The service sends an empty JSON body and relies on the existing backend route to load credentials server-side. Credentials are never sent from the browser and are never displayed in badges or status text.
+
+## Non-Goals
+
+- No dry-run or save-only execution in this slice.
+- No connection creation/editing UI.
+- No backend route changes.

--- a/docs/development/generic-integration-workbench-connection-test-verification-20260512.md
+++ b/docs/development/generic-integration-workbench-connection-test-verification-20260512.md
@@ -1,0 +1,28 @@
+# Generic Integration Workbench Connection Test Verification - 2026-05-12
+
+## Verification Matrix
+
+| Check | Result | Notes |
+| --- | --- | --- |
+| `pnpm --filter @metasheet/web exec vitest run tests/integrationWorkbench.spec.ts tests/IntegrationWorkbenchView.spec.ts --watch=false` | PASS | 3/3 tests |
+| `pnpm --filter @metasheet/web exec vue-tsc --noEmit` | PASS | Clean |
+| `git diff --check` | PASS | Clean |
+| `pnpm -F plugin-integration-core test` | PASS | Full plugin integration-core test chain |
+| `pnpm --filter @metasheet/web build` | PASS | Vite build complete |
+
+## Coverage Added
+
+- Service wrapper calls `POST /api/integration/external-systems/:id/test` with scoped query params and an empty JSON body.
+- Source connection success updates the displayed source badge to `已连接`.
+- Target connection failure updates the displayed target badge to `异常：...` using the sanitized backend message.
+- Existing object discovery, schema discovery, mapping seed, and preview assertions still run in the same view test.
+
+## Not Covered
+
+- Live vendor connectivity. This is intentionally left to staging or customer environment verification because local tests use mocked `apiFetch`.
+- Backend credential redaction. Existing plugin route tests already cover that route behavior.
+
+## Warnings Observed
+
+- Frontend Vitest emitted the existing `--localstorage-file was provided without a valid path` Node warning. Tests passed.
+- Frontend build emitted existing Vite chunk-size and mixed dynamic/static import warnings. Build passed.

--- a/docs/development/generic-integration-workbench-contract-closeout-development-20260512.md
+++ b/docs/development/generic-integration-workbench-contract-closeout-development-20260512.md
@@ -1,0 +1,53 @@
+# Generic Integration Workbench Contract Closeout Development - 2026-05-12
+
+## Scope
+
+This slice closes two remaining backend-contract TODOs for the generic integration workbench:
+
+- M1 discovery API: unknown external systems must return a scoped 404 and must not instantiate adapters.
+- M5 template preview API: K3 WISE BOM payload preview must be covered alongside the existing Material preview.
+
+No frontend behavior or route shape was changed.
+
+## Design
+
+### Unknown system discovery
+
+The test overrides `externalSystemRegistry.getExternalSystemForAdapter()` to throw `ExternalSystemNotFoundError`.
+
+Covered routes:
+
+- `GET /api/integration/external-systems/:id/objects`
+- `GET /api/integration/external-systems/:id/schema`
+
+Acceptance:
+
+- Response status is `404`.
+- Error code remains `ExternalSystemNotFoundError`.
+- Scoped lookup includes `id`, `tenantId`, and `workspaceId`.
+- `adapterRegistry.createAdapter()` is never called after the registry miss.
+
+### K3 BOM template preview
+
+The preview test builds a K3 BOM-style payload with:
+
+- `FParentItemNumber` from `parentCode` using `trim` and `upper`.
+- `FChildItemNumber` from `childCode` using `trim` and `upper`.
+- `FQty` from `quantity` using `toNumber`.
+- `FScrapRate` from `scrapRate` using `toNumber`.
+- `bodyKey: Data`.
+
+Acceptance:
+
+- `valid` is `true`.
+- Payload is wrapped under `Data`.
+- Numeric fields are numbers, not strings.
+- Source secret fields are redacted from the response.
+- Preview path does not call integration services or target adapters.
+
+## Files
+
+- `plugins/plugin-integration-core/__tests__/http-routes.test.cjs`
+- `docs/development/generic-integration-workbench-todo-20260512.md`
+- `docs/development/generic-integration-workbench-contract-closeout-development-20260512.md`
+- `docs/development/generic-integration-workbench-contract-closeout-verification-20260512.md`

--- a/docs/development/generic-integration-workbench-contract-closeout-verification-20260512.md
+++ b/docs/development/generic-integration-workbench-contract-closeout-verification-20260512.md
@@ -1,0 +1,38 @@
+# Generic Integration Workbench Contract Closeout Verification - 2026-05-12
+
+## Scope
+
+Verification for:
+
+- Unknown external system discovery contract.
+- K3 WISE BOM template preview contract.
+- Regression coverage for the existing integration-core HTTP route suite.
+- Frontend workbench regression after backend-only test additions.
+
+## Results
+
+| Command | Result | Notes |
+| --- | --- | --- |
+| `node plugins/plugin-integration-core/__tests__/http-routes.test.cjs` | PASS | Direct route contract suite passed. |
+| `pnpm -F plugin-integration-core test` | PASS | Plugin package suite passed, including `http-routes`, PLM/K3 WISE mock chain, K3 WISE adapters, staging installer, and migration SQL checks. |
+| `pnpm --filter @metasheet/web exec vitest run tests/IntegrationWorkbenchView.spec.ts tests/integrationWorkbench.spec.ts --watch=false` | PASS | 2 files / 3 tests passed. Vitest emitted the existing `--localstorage-file` warning. |
+| `pnpm --filter @metasheet/web exec vue-tsc --noEmit` | PASS | Frontend type check passed. |
+| `pnpm --filter @metasheet/web build` | PASS | Frontend production build passed. Existing Vite dynamic-import and chunk-size warnings remained. |
+| `git diff --check` | PASS | No whitespace errors. |
+
+## Contract Assertions
+
+- Unknown system object discovery returns `404` with `ExternalSystemNotFoundError`.
+- Unknown system schema discovery returns `404` with `ExternalSystemNotFoundError`.
+- Unknown system lookups keep tenant/workspace scoping.
+- Unknown system lookups do not instantiate adapters.
+- K3 BOM preview returns `valid: true`.
+- K3 BOM preview wraps payload under `Data`.
+- K3 BOM preview transforms parent/child codes and numeric fields.
+- K3 BOM preview redacts source secret fields.
+- K3 BOM preview does not call integration services.
+
+## Notes
+
+- This slice adds tests only for backend contracts and documentation. It does not change runtime route handlers.
+- The frontend gates were run because this branch already contains the generic workbench UI work; the new backend tests did not introduce frontend regressions.

--- a/docs/development/generic-integration-workbench-development-plan-20260512.md
+++ b/docs/development/generic-integration-workbench-development-plan-20260512.md
@@ -1,0 +1,324 @@
+# Generic Integration Workbench Development Plan - 2026-05-12
+
+## Summary
+
+Build a generic integration workbench on top of the existing `plugin-integration-core` pipeline model. The product goal is:
+
+1. connect any supported CRM / PLM / ERP / SRM / HTTP / SQL source;
+2. land raw data into MetaSheet staging tables;
+3. cleanse and review data in multitable views;
+4. map clean rows to any supported target object;
+5. preview the target payload;
+6. run dry-run first;
+7. push with Save-only by default;
+8. write target IDs, document numbers, and errors back to integration feedback.
+
+K3 WISE remains the first preset implementation. Its Material and BOM flows should become built-in target templates, not a one-off product direction. The K3 setup page remains as a quick-start wizard, while the generic workbench becomes the reusable configuration surface.
+
+## Current Baseline
+
+The repo already has the important backend primitives:
+
+- `integration_external_systems` stores external connection metadata and encrypted credentials.
+- `integration_pipelines` stores source/target system IDs, source/target objects, staging table ID, mode, options, and status.
+- `integration_field_mappings` stores source field, target field, transform, validation, default value, and sort order.
+- `integration_runs` and `integration_dead_letters` store run history and failed rows.
+- Adapter contract already supports `testConnection`, `listObjects`, `getSchema`, `read`, and `upsert`.
+- Existing adapter kinds include `http`, `plm:yuantus-wrapper`, `erp:k3-wise-webapi`, and `erp:k3-wise-sqlserver`.
+- Transform engine already supports `trim`, `upper`, `lower`, `toNumber`, `toDate`, `defaultValue`, `concat`, and `dictMap`.
+- Validator already supports `required`, `pattern`, `enum`, `min`, and `max`.
+
+The immediate missing product layer is discovery and configuration UX:
+
+- list available adapters with labels and capabilities;
+- list objects and schemas for a selected external system;
+- let users create mappings and templates without editing raw JSON;
+- preview target payloads before running;
+- present K3 WISE as a preset, not as the only path.
+
+## Product Shape
+
+### User Layers
+
+| Layer | Users | Allowed configuration | Not allowed |
+| --- | --- | --- | --- |
+| Business user | operations / data owners | select systems, select objects, choose staging table, configure field mappings, dictionary mappings, validation rules, dry-run, Save-only push | raw SQL, user JavaScript, direct K3 core table writes, production Submit/Audit |
+| Advanced implementer | delivery / admin users | configure HTTP paths, target templates, schema fields, response mapping, SQL read channel allowlists, middle-table writes | secrets in templates, absolute unsafe endpoints, direct core-table writes by default |
+| Developer | product / plugin developers | add adapters, vendor auth flows, pagination, watermark logic, error dictionaries | runtime code execution from user config |
+
+### Data Flow
+
+```mermaid
+flowchart LR
+  A["Source system object"] --> B["Adapter read"]
+  B --> C["Raw staging multitable"]
+  C --> D["User cleansing and review"]
+  D --> E["Field mappings + validation"]
+  E --> F["Target template preview"]
+  F --> G["Dry-run"]
+  G --> H["Save-only target upsert"]
+  H --> I["Feedback: external ID / bill number / errors"]
+```
+
+### Same-System Object Conversion
+
+The workbench must support pipelines where the source and target system are the same external system, as long as the system role is `bidirectional`.
+
+Examples:
+
+| Scenario | Source | Target |
+| --- | --- | --- |
+| CRM internal cleansing | same CRM `customers_raw` | same CRM `customers_clean` |
+| SRM supplier normalization | same SRM `supplier_candidates` | same SRM `suppliers` |
+| K3 table-to-WebAPI correction | same K3 account through two logical connections | K3 WebAPI Save object |
+
+Recommended UX:
+
+- Allow `sourceSystemId === targetSystemId` only when the selected external system is `bidirectional`.
+- Encourage two logical connections for physical systems that use different protocols:
+  - `K3 WISE SQL read channel` as source;
+  - `K3 WISE WebAPI write channel` as target.
+- The UI should label this as "same system, different business object" instead of "loopback sync".
+
+### SQL Channel as Advanced Feature
+
+SQL channel is useful, but it must be treated as an advanced implementation surface:
+
+- source-side SQL can read from allowlisted tables or views;
+- target-side SQL can write only to configured middle tables by default;
+- raw SQL is not accepted;
+- identifiers must pass allowlist validation;
+- direct K3 core table writes stay hidden and disabled unless explicitly enabled by an admin-only escape hatch;
+- ordinary business users should see SQL channel only as "implemented by delivery/admin", not as a casual connector option.
+
+## Backend Changes
+
+### Adapter Discovery API
+
+Add:
+
+```http
+GET /api/integration/adapters
+```
+
+Response shape:
+
+```json
+{
+  "ok": true,
+  "data": [
+    {
+      "kind": "http",
+      "label": "HTTP API",
+      "roles": ["source", "target", "bidirectional"],
+      "supports": ["testConnection", "listObjects", "getSchema", "read", "upsert"],
+      "advanced": false
+    },
+    {
+      "kind": "erp:k3-wise-sqlserver",
+      "label": "K3 WISE SQL Server Channel",
+      "roles": ["source", "target"],
+      "supports": ["testConnection", "listObjects", "getSchema", "read", "upsert"],
+      "advanced": true
+    }
+  ]
+}
+```
+
+Implementation:
+
+- reuse `adapterRegistry.listAdapterKinds()`;
+- add plugin-local metadata for labels, role hints, and advanced flags;
+- never return credentials.
+
+### Object Discovery API
+
+Add:
+
+```http
+GET /api/integration/external-systems/:id/objects?tenantId=...&workspaceId=...
+```
+
+Behavior:
+
+- load the scoped external system;
+- create its adapter;
+- call `adapter.listObjects()`;
+- merge any `system.config.documentTemplates[]` target objects;
+- redact all returned metadata.
+
+### Schema Discovery API
+
+Add:
+
+```http
+GET /api/integration/external-systems/:id/schema?tenantId=...&workspaceId=...&object=...
+```
+
+Behavior:
+
+- call `adapter.getSchema({ object })`;
+- if object is from `documentTemplates[]`, return the template schema;
+- normalize fields to `{ name, label, type, required }`.
+
+### Template Preview API
+
+Add:
+
+```http
+POST /api/integration/templates/preview
+```
+
+Behavior:
+
+- accepts `sourceRecord`, `fieldMappings`, and `template`;
+- runs current transform and validation engine;
+- returns `{ payload, valid, errors }`;
+- does not call target adapter;
+- does not write DB;
+- redacts payload and errors before responding.
+
+### Custom Target Templates
+
+Store v1 templates in `integration_external_systems.config.documentTemplates`; do not add a new table in v1.
+
+Template shape:
+
+```json
+{
+  "id": "custom.supplier.v1",
+  "version": "2026.05.v1",
+  "label": "Supplier",
+  "object": "supplier",
+  "bodyKey": "Data",
+  "endpointPath": "/Supplier/Save",
+  "method": "POST",
+  "keyFields": ["FNumber"],
+  "schema": [
+    { "name": "FNumber", "label": "Supplier code", "type": "string", "required": true },
+    { "name": "FName", "label": "Supplier name", "type": "string", "required": true }
+  ],
+  "lifecycle": {
+    "saveOnlyDefault": true,
+    "allowSubmit": false,
+    "allowAudit": false
+  },
+  "responseMapping": {
+    "externalId": "Data.FItemID",
+    "externalNumber": "Data.FNumber",
+    "billNo": "Data.FBillNo",
+    "errorCode": "ErrorCode",
+    "errorMessage": "Message"
+  }
+}
+```
+
+Validation:
+
+- `id`, `label`, and `object` are required;
+- `endpointPath` must be relative;
+- `bodyKey` defaults to `Data`;
+- `schema[].name` is required;
+- template content must not contain secrets;
+- Save-only defaults to true.
+
+### Pipeline Options
+
+When a workbench creates a pipeline, store:
+
+```json
+{
+  "targetTemplate": {
+    "id": "k3wise.material.v1",
+    "version": "2026.05.v1",
+    "documentType": "material",
+    "bodyKey": "Data",
+    "source": "builtin"
+  },
+  "lifecycle": {
+    "saveOnly": true,
+    "autoSubmit": false,
+    "autoAudit": false
+  }
+}
+```
+
+No change to the existing pipeline columns is required.
+
+## Frontend Changes
+
+Add:
+
+- `apps/web/src/services/integration/workbench.ts`
+- `apps/web/src/views/IntegrationWorkbenchView.vue`
+- `apps/web/tests/IntegrationWorkbenchView.spec.ts`
+
+Page flow:
+
+1. choose source system;
+2. choose target system;
+3. test both connections;
+4. choose source object and target object/template;
+5. choose or install staging table;
+6. configure field mappings;
+7. configure validation and dictionary mappings;
+8. preview payload;
+9. dry-run;
+10. Save-only run;
+11. view feedback and dead letters.
+
+K3 WISE setup page remains available as a shortcut:
+
+- it should link to the generic workbench;
+- tenant ID should come from current context;
+- workspace ID should be advanced-only;
+- WebAPI Base URL and relative endpoint path help text must avoid `/K3API/` duplication.
+
+## Security Rules
+
+- Never output credentials, tokens, authority codes, SQL connection strings, or bearer headers.
+- Redact URL query secrets: `access_token`, `token`, `password`, `secret`, `sign`, `signature`, `api_key`, `session_id`, and `auth`.
+- Do not allow user-provided JavaScript transforms.
+- Do not allow raw SQL.
+- Do not allow direct K3 core table writes in normal UI.
+- Dry-run must not write target systems, create dead letters, or advance watermarks.
+- Production Submit/Audit stays off until separately approved.
+
+## Delivery Split
+
+1. **PR-1: backend discovery and same-system guard tests**
+   - adapters API;
+   - object/schema discovery;
+   - bidirectional same-system test;
+   - design and verification docs.
+
+2. **PR-2: template registry and preview API**
+   - custom template validation;
+   - preview endpoint;
+   - no DB migration.
+
+3. **PR-3: workbench service and shell UI**
+   - system/object/schema selection;
+   - mapping editor shell.
+
+4. **PR-4: preview, dry-run, run feedback**
+   - payload preview;
+   - dry-run and Save-only run;
+   - dead-letter display.
+
+5. **PR-5: K3 WISE page convergence**
+   - tenant/workspace UX cleanup;
+   - endpoint path guidance;
+   - link to generic workbench.
+
+## Acceptance Criteria
+
+- A user can configure source and target systems without entering tenant ID manually.
+- A user can map source fields to target fields through the UI.
+- A user can choose a K3 WISE built-in template or a custom target template.
+- Same-system different-object pipelines work when the system is bidirectional.
+- SQL channel is visible only as an advanced capability with allowlist guardrails.
+- Dry-run produces a target payload preview and no external writes.
+- Save-only run can write through a target adapter.
+- Failure records go to dead letters and do not stop the whole batch.
+- K3 WISE Material/BOM flows continue to pass existing offline PoC checks.

--- a/docs/development/generic-integration-workbench-discovery-api-design-20260512.md
+++ b/docs/development/generic-integration-workbench-discovery-api-design-20260512.md
@@ -1,0 +1,90 @@
+# Generic Integration Workbench Discovery API Design - 2026-05-12
+
+## Purpose
+
+The generic integration workbench needs backend discovery before frontend users can configure mappings safely:
+
+- what adapter kinds are available;
+- whether an adapter is a normal business connector or an advanced implementation connector;
+- which objects a saved external system exposes;
+- which fields a selected object exposes.
+
+This slice adds read-only discovery routes to `plugin-integration-core`. It does not add migrations, does not write pipeline state, and does not run external writes.
+
+## Routes
+
+### `GET /api/integration/adapters`
+
+Returns registered adapter kinds with stable UI metadata:
+
+```json
+{
+  "kind": "erp:k3-wise-sqlserver",
+  "label": "K3 WISE SQL Server Channel",
+  "roles": ["source", "target"],
+  "supports": ["testConnection", "listObjects", "getSchema", "read", "upsert"],
+  "advanced": true
+}
+```
+
+`advanced: true` is the UI signal to keep SQL channels out of the default business-user connector picker.
+
+### `GET /api/integration/external-systems/:id/objects`
+
+Loads the scoped external system with adapter credentials, creates the adapter, calls `adapter.listObjects()`, and appends valid `config.documentTemplates[]` entries as custom target objects.
+
+Template object output uses:
+
+```json
+{
+  "name": "supplier",
+  "label": "Supplier",
+  "operations": ["upsert"],
+  "schema": [{ "name": "FNumber", "label": "Supplier code", "type": "string", "required": true }],
+  "source": "documentTemplate",
+  "template": {
+    "id": "custom.supplier.v1",
+    "version": "2026.05.v1",
+    "bodyKey": "Data",
+    "endpointPath": "/api/suppliers/save",
+    "source": "custom"
+  }
+}
+```
+
+### `GET /api/integration/external-systems/:id/schema?object=...`
+
+Loads schema for an object:
+
+- if `object` matches a configured document template, returns the template schema without calling adapter `getSchema`;
+- otherwise calls `adapter.getSchema({ object })`.
+
+Missing `object` returns `400 OBJECT_REQUIRED`.
+
+## Template Handling
+
+This slice intentionally implements only discovery-safe template normalization:
+
+- `config.documentTemplates` must be an array when present;
+- each template must be an object;
+- `object` or `targetObject` is required;
+- `bodyKey` defaults to `Data`;
+- `endpointPath` / `savePath` / `path` must be relative when present;
+- `schema[]` entries must contain `name`.
+
+Full template lifecycle validation and preview execution remain in the next slice.
+
+## Security
+
+All discovery responses pass through `sanitizeIntegrationPayload()` before returning. The routes may load adapter credentials internally so that schema discovery can call authenticated vendor endpoints, but credentials are never returned.
+
+SQL channel exposure is metadata-only in this slice. The existing SQL adapter still enforces identifier validation, allowlisted read/write tables, and middle-table write mode.
+
+## Non-Goals
+
+- No template preview API.
+- No frontend workbench page.
+- No new tables.
+- No writes to target systems.
+- No raw SQL.
+- No user JavaScript.

--- a/docs/development/generic-integration-workbench-discovery-api-verification-20260512.md
+++ b/docs/development/generic-integration-workbench-discovery-api-verification-20260512.md
@@ -1,0 +1,47 @@
+# Generic Integration Workbench Discovery API Verification - 2026-05-12
+
+## Files Changed
+
+- `plugins/plugin-integration-core/lib/http-routes.cjs`
+- `plugins/plugin-integration-core/__tests__/http-routes.test.cjs`
+- `docs/development/generic-integration-workbench-todo-20260512.md`
+- `docs/development/generic-integration-workbench-discovery-api-design-20260512.md`
+- `docs/development/generic-integration-workbench-discovery-api-verification-20260512.md`
+
+## Verification Matrix
+
+| Case | Expected | Evidence |
+| --- | --- | --- |
+| Adapter discovery route | Returns adapter metadata | `testDiscoveryRoutes()` |
+| SQL Server channel metadata | `advanced: true` | `testDiscoveryRoutes()` |
+| Unknown adapter metadata | Falls back to kind label and `advanced: false` | `testDiscoveryRoutes()` |
+| Object discovery route | Calls adapter `listObjects()` and returns object list | `testDiscoveryRoutes()` |
+| Custom document template object | Merged into object list as `source: documentTemplate` | `testDiscoveryRoutes()` |
+| Object discovery redaction | Does not leak template secret or bearer token | `testDiscoveryRoutes()` |
+| Adapter schema route | Calls adapter `getSchema({ object })` | `testDiscoveryRoutes()` |
+| Adapter schema redaction | Redacts nested credential payload | `testDiscoveryRoutes()` |
+| Template schema route | Returns template schema without adapter `getSchema()` | `testDiscoveryRoutes()` |
+| Missing schema object | Returns `400 OBJECT_REQUIRED` | `testDiscoveryRoutes()` |
+
+## Commands
+
+Executed in `/Users/chouhua/Downloads/Github/metasheet2`:
+
+```bash
+node plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+pnpm -F plugin-integration-core test
+git diff --check
+```
+
+## Result
+
+PASS.
+
+| Command | Result |
+| --- | --- |
+| `node plugins/plugin-integration-core/__tests__/http-routes.test.cjs` | PASS - REST auth/list/upsert/run/dry-run/staging/replay tests passed, including discovery route coverage |
+| `node plugins/plugin-integration-core/__tests__/pipelines.test.cjs` | PASS - pipeline registry tests passed, including same-system bidirectional coverage |
+| `pnpm -F plugin-integration-core test` | PASS - all plugin-integration-core test files passed |
+| `git diff --check` | PASS - no whitespace errors or conflict markers |
+
+The full plugin test run covered plugin runtime smoke, host loader activation, credential store, DB guard, external systems, adapter contracts, HTTP adapter, PLM wrapper, pipelines, transform/validator, runner support, payload redaction, pipeline runner, REST routes, PLM-to-K3 mock chain, K3 WISE adapters, ERP feedback, E2E writeback, staging installer, and migration SQL shape.

--- a/docs/development/generic-integration-workbench-frontend-shell-design-20260512.md
+++ b/docs/development/generic-integration-workbench-frontend-shell-design-20260512.md
@@ -1,0 +1,82 @@
+# Generic Integration Workbench Frontend Shell Design - 2026-05-12
+
+## Purpose
+
+This slice adds the first user-visible generic integration workbench. It started with the configuration path that must exist before dry-run/run UI:
+
+1. load adapter metadata;
+2. load external systems;
+3. choose source and target systems;
+4. discover source/target objects;
+5. discover schemas;
+6. edit field mappings;
+7. generate a target payload preview;
+8. save the mapping as a pipeline;
+9. run dry-run or explicitly gated Save-only execution.
+
+The pipeline save/run controls were added by the companion pipeline-run slice documented in `generic-integration-workbench-pipeline-run-design-20260512.md`.
+
+## New Frontend Service
+
+`apps/web/src/services/integration/workbench.ts` wraps the new backend APIs:
+
+- `listIntegrationAdapters()`;
+- `listWorkbenchExternalSystems(scope)`;
+- `listExternalSystemObjects(systemId, scope)`;
+- `getExternalSystemSchema(systemId, { object, tenantId, workspaceId })`;
+- `previewIntegrationTemplate(payload)`;
+- `getDefaultIntegrationScope()`;
+- `canReadFromSystem(system)`;
+- `canWriteToSystem(system)`.
+
+The service defaults `tenantId` to `default` for single-tenant on-prem installs and omits blank `workspaceId` from query strings.
+
+## New Route and View
+
+`/integrations/workbench` is registered as:
+
+- route name: `integration-workbench`;
+- component: `IntegrationWorkbenchView.vue`;
+- permission: `integration:write`;
+- title: `Integration Workbench` / `数据集成工作台`.
+
+The view is intentionally dense and operational:
+
+- no landing page;
+- no marketing hero;
+- source and target panels are side by side;
+- SQL channel is surfaced as an advanced adapter badge;
+- K3 WISE setup remains reachable through a preset-link button;
+- payload preview is shown as JSON for implementation debugging.
+
+## Mapping Behavior
+
+When a target schema loads, the page seeds a small initial mapping set from target fields:
+
+| Target field | Default source guess |
+| --- | --- |
+| `FNumber` | `code` |
+| `FName` | `name` |
+| `FModel` | `spec` |
+| `FBaseUnitID` / `FUnitID` | `uom` |
+| `FQty` | `quantity` |
+| `FParentItemNumber` | `parentCode` |
+| `FChildItemNumber` | `childCode` |
+
+This keeps the K3 Material/BOM happy path usable while remaining generic.
+
+## Security and Boundaries
+
+- Discovery and preview remain read-only/pure.
+- Pipeline save calls the existing `POST /api/integration/pipelines` route.
+- Dry-run calls the existing `POST /api/integration/pipelines/:id/dry-run` route.
+- Save-only run calls the existing `POST /api/integration/pipelines/:id/run` route only after explicit operator confirmation.
+- It does not expose a raw JSON editor for template mutation.
+- It does not expose raw SQL.
+- The transform input is text for the shell; a stricter whitelist selector is still listed in TODO.
+
+## Non-Goals
+
+- No staging install flow.
+- No dead-letter display.
+- No custom template authoring UI.

--- a/docs/development/generic-integration-workbench-frontend-shell-verification-20260512.md
+++ b/docs/development/generic-integration-workbench-frontend-shell-verification-20260512.md
@@ -1,0 +1,59 @@
+# Generic Integration Workbench Frontend Shell Verification - 2026-05-12
+
+## Files Changed
+
+- `apps/web/src/services/integration/workbench.ts`
+- `apps/web/src/views/IntegrationWorkbenchView.vue`
+- `apps/web/src/router/appRoutes.ts`
+- `apps/web/src/router/types.ts`
+- `apps/web/tests/integrationWorkbench.spec.ts`
+- `apps/web/tests/IntegrationWorkbenchView.spec.ts`
+- `docs/development/generic-integration-workbench-todo-20260512.md`
+- `docs/development/generic-integration-workbench-frontend-shell-design-20260512.md`
+- `docs/development/generic-integration-workbench-frontend-shell-verification-20260512.md`
+
+## Verification Matrix
+
+| Case | Expected | Evidence |
+| --- | --- | --- |
+| Service defaults | `tenantId=default`, blank workspace omitted | `integrationWorkbench.spec.ts` |
+| Adapter discovery | Calls `/api/integration/adapters` | `integrationWorkbench.spec.ts` |
+| System discovery | Calls scoped `/api/integration/external-systems` | `integrationWorkbench.spec.ts` |
+| Object discovery | URL-encodes system ID and sends tenant scope | `integrationWorkbench.spec.ts` |
+| Schema discovery | Sends `object` and tenant scope | `integrationWorkbench.spec.ts` |
+| Preview service | POSTs to `/api/integration/templates/preview` | `integrationWorkbench.spec.ts` |
+| Pipeline service | POSTs pipeline upsert and run/dry-run payloads | `integrationWorkbench.spec.ts` |
+| Observation service | Lists staging descriptors, runs, and open dead letters | `integrationWorkbench.spec.ts` |
+| Workbench view bootstrap | Loads adapters and systems on mount | `IntegrationWorkbenchView.spec.ts` |
+| SQL advanced signal | Shows SQL Server adapter as `高级` | `IntegrationWorkbenchView.spec.ts` |
+| Source/target object loading | Loads object lists and schemas | `IntegrationWorkbenchView.spec.ts` |
+| Mapping seed | Seeds K3 Material-style mappings from target schema | `IntegrationWorkbenchView.spec.ts` |
+| Payload preview | Sends template/mapping request and renders JSON result | `IntegrationWorkbenchView.spec.ts` |
+| Pipeline execution panel | Saves pipeline, dry-runs, and Save-only runs with explicit guard | `IntegrationWorkbenchView.spec.ts` |
+| Observation panel | Renders recent runs and open dead-letter errors after dry-run | `IntegrationWorkbenchView.spec.ts` |
+| K3 setup regression | Existing K3 setup tests still pass | `IntegrationK3WiseSetupView.spec.ts`, `k3WiseSetup.spec.ts` |
+| Production build | `vue-tsc -b && vite build` passes | `pnpm --filter @metasheet/web build` |
+
+## Commands
+
+Executed in `/Users/chouhua/Downloads/Github/metasheet2`:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/integrationWorkbench.spec.ts tests/IntegrationWorkbenchView.spec.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/k3WiseSetup.spec.ts tests/IntegrationK3WiseSetupView.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+## Result
+
+PASS.
+
+| Command | Result |
+| --- | --- |
+| `pnpm --filter @metasheet/web exec vitest run tests/integrationWorkbench.spec.ts tests/IntegrationWorkbenchView.spec.ts --watch=false` | PASS - 2 files, 3 tests |
+| `pnpm --filter @metasheet/web exec vitest run tests/k3WiseSetup.spec.ts tests/IntegrationK3WiseSetupView.spec.ts --watch=false` | PASS - 2 files, 30 tests |
+| `pnpm --filter @metasheet/web build` | PASS - existing chunk-size/import warnings only |
+| `git diff --check` | PASS - no whitespace errors or conflict markers |
+
+The frontend route is intentionally available at `/integrations/workbench` without changing the main application navigation in this slice. That keeps the rollout low-risk while the workbench is still preview-only.

--- a/docs/development/generic-integration-workbench-observation-design-20260512.md
+++ b/docs/development/generic-integration-workbench-observation-design-20260512.md
@@ -1,0 +1,59 @@
+# Generic Integration Workbench Observation Design - 2026-05-12
+
+## Purpose
+
+This slice adds the missing operator feedback loop to the generic integration workbench:
+
+1. choose the staging multitable object that represents the cleansing surface;
+2. save that staging object into the pipeline as `stagingSheetId`;
+3. refresh recent pipeline runs;
+4. refresh open dead letters.
+
+The goal is not to build a full monitoring console. It is to keep the first reusable CRM/PLM/ERP/SRM cleansing flow operable from one page: configure, preview, save, dry-run, run Save-only, then inspect failures.
+
+## API Usage
+
+The frontend reuses existing integration-core routes:
+
+- `GET /api/integration/staging/descriptors`;
+- `GET /api/integration/runs`;
+- `GET /api/integration/dead-letters`.
+
+No backend route, migration, or table is added in this slice.
+
+## Staging Selector
+
+`IntegrationWorkbenchView.vue` loads staging descriptors during bootstrap and defaults to `standard_materials` when available.
+
+The selected descriptor id is sent as:
+
+```json
+{
+  "stagingSheetId": "standard_materials"
+}
+```
+
+This keeps the workbench aligned with the product principle: business users clean data in multitable fields, while JSON remains only a payload/template preview.
+
+## Observation Panel
+
+The new `运行观察` panel shows:
+
+- the latest 5 pipeline runs;
+- open dead letters for the saved pipeline;
+- a compact count summary.
+
+The panel refreshes in two paths:
+
+- automatically after dry-run or Save-only run;
+- manually via `刷新观察`.
+
+Dead-letter payloads are not requested with `includePayload=true`, so source/transformed payloads stay redacted by the backend default response.
+
+## Boundaries
+
+- No dead-letter replay button yet.
+- No dead-letter full payload view.
+- No run pagination.
+- No global pipeline list.
+- No staging object installation flow; this page only selects descriptors already known to the plugin.

--- a/docs/development/generic-integration-workbench-observation-verification-20260512.md
+++ b/docs/development/generic-integration-workbench-observation-verification-20260512.md
@@ -1,0 +1,42 @@
+# Generic Integration Workbench Observation Verification - 2026-05-12
+
+## Files Changed
+
+- `apps/web/src/services/integration/workbench.ts`
+- `apps/web/src/views/IntegrationWorkbenchView.vue`
+- `apps/web/tests/integrationWorkbench.spec.ts`
+- `apps/web/tests/IntegrationWorkbenchView.spec.ts`
+- `docs/development/generic-integration-workbench-todo-20260512.md`
+- `docs/development/generic-integration-workbench-observation-design-20260512.md`
+- `docs/development/generic-integration-workbench-observation-verification-20260512.md`
+
+## Verification Matrix
+
+| Case | Expected | Evidence |
+| --- | --- | --- |
+| Staging descriptor service | Calls `GET /api/integration/staging/descriptors` | `integrationWorkbench.spec.ts` |
+| Run history service | Calls `GET /api/integration/runs` with tenant, pipeline id, and limit | `integrationWorkbench.spec.ts` |
+| Dead-letter service | Calls `GET /api/integration/dead-letters` with `status=open` | `integrationWorkbench.spec.ts` |
+| Staging selector bootstrap | Defaults to `standard_materials` when descriptor exists | `IntegrationWorkbenchView.spec.ts` |
+| Pipeline save payload | Includes selected `stagingSheetId` | `IntegrationWorkbenchView.spec.ts` |
+| Auto observation refresh | Dry-run refreshes recent runs and open dead letters | `IntegrationWorkbenchView.spec.ts` |
+| Manual observation shape | Observation panel renders run counters and dead-letter errors | `IntegrationWorkbenchView.spec.ts` |
+| Payload redaction boundary | Dead-letter full payload is not requested | Service URL has no `includePayload=true` |
+
+## Commands
+
+Executed in `/Users/chouhua/Downloads/Github/metasheet2`:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/integrationWorkbench.spec.ts tests/IntegrationWorkbenchView.spec.ts --watch=false
+```
+
+## Result
+
+PASS.
+
+| Command | Result |
+| --- | --- |
+| `pnpm --filter @metasheet/web exec vitest run tests/integrationWorkbench.spec.ts tests/IntegrationWorkbenchView.spec.ts --watch=false` | PASS - 2 files, 3 tests |
+
+Full frontend regression, frontend build, plugin tests, and diff checks are run in the final combined verification pass.

--- a/docs/development/generic-integration-workbench-pipeline-run-design-20260512.md
+++ b/docs/development/generic-integration-workbench-pipeline-run-design-20260512.md
@@ -1,0 +1,102 @@
+# Generic Integration Workbench Pipeline Run Design - 2026-05-12
+
+## Purpose
+
+This slice turns the generic integration workbench from a preview-only page into a small execution loop:
+
+1. save the selected source/target/object/mapping setup as an `integration_pipelines` row;
+2. run the saved pipeline in dry-run mode;
+3. optionally run a guarded Save-only push;
+4. refresh run/dead-letter observation in the companion observation slice.
+
+The product boundary stays the same: MetaSheet tables remain the cleansing and review surface. The workbench stores mapping and execution policy. It does not become a full ERP document editor.
+
+## Frontend Service Additions
+
+`apps/web/src/services/integration/workbench.ts` now exposes:
+
+- `upsertIntegrationPipeline(payload)`;
+- `runIntegrationPipeline(pipelineId, payload, dryRun)`;
+- pipeline request/result types shared by the workbench view tests.
+
+The service uses the existing plugin routes:
+
+- `POST /api/integration/pipelines`;
+- `POST /api/integration/pipelines/:id/dry-run`;
+- `POST /api/integration/pipelines/:id/run`.
+
+No backend route or migration is added in this slice.
+
+## Workbench UI Additions
+
+`apps/web/src/views/IntegrationWorkbenchView.vue` now includes a `Pipeline 执行` section:
+
+- pipeline name;
+- pipeline mode: `manual`, `incremental`, `full`;
+- idempotency key fields;
+- staging descriptor selector;
+- saved pipeline ID;
+- run mode;
+- dry-run sample limit;
+- Save-only confirmation checkbox;
+- buttons for save, dry-run, and Save-only run;
+- result JSON panel.
+
+The saved pipeline is created as `status: active` so operator-triggered dry-run/run works immediately. This does not schedule anything by itself; execution still requires an explicit button click.
+
+## Payload Shape
+
+The upsert payload keeps the generic workbench contract small:
+
+```json
+{
+  "tenantId": "default",
+  "workspaceId": null,
+  "name": "PLM Source:materials -> K3 Target:material",
+  "sourceSystemId": "plm_1",
+  "sourceObject": "materials",
+  "targetSystemId": "k3_1",
+  "targetObject": "material",
+  "stagingSheetId": "standard_materials",
+  "mode": "manual",
+  "status": "active",
+  "idempotencyKeyFields": ["code"],
+  "options": {
+    "target": {
+      "autoSubmit": false,
+      "autoAudit": false
+    },
+    "workbench": {
+      "source": "generic-integration-workbench",
+      "version": "v1"
+    },
+    "k3Template": {
+      "id": "k3wise.material.v1",
+      "documentType": "material",
+      "bodyKey": "Data"
+    }
+  },
+  "fieldMappings": []
+}
+```
+
+`fieldMappings` are built from the mapping grid. `options.k3Template` is included only when the selected target object carries template metadata.
+
+## Save-Only Guard
+
+Save-only push is guarded in the UI:
+
+- dry-run does not require confirmation;
+- live run is disabled until the operator checks `允许本次 Save-only 推送`;
+- the generated pipeline options always set `autoSubmit: false` and `autoAudit: false`;
+- the result panel shows the exact sanitized API response returned by the backend.
+
+This matches the current K3 WISE Stage 1 rule: live customer Submit/Audit remains blocked until the customer GATE data and explicit sign-off exist.
+
+## Non-Goals
+
+- No scheduled pipeline automation.
+- No dead-letter table UI yet.
+- No pipeline list/search UI yet.
+- No staging table picker yet.
+- No custom template authoring UI.

--- a/docs/development/generic-integration-workbench-pipeline-run-verification-20260512.md
+++ b/docs/development/generic-integration-workbench-pipeline-run-verification-20260512.md
@@ -1,0 +1,45 @@
+# Generic Integration Workbench Pipeline Run Verification - 2026-05-12
+
+## Files Changed
+
+- `apps/web/src/services/integration/workbench.ts`
+- `apps/web/src/views/IntegrationWorkbenchView.vue`
+- `apps/web/tests/integrationWorkbench.spec.ts`
+- `apps/web/tests/IntegrationWorkbenchView.spec.ts`
+- `docs/development/generic-integration-workbench-todo-20260512.md`
+- `docs/development/generic-integration-workbench-pipeline-run-design-20260512.md`
+- `docs/development/generic-integration-workbench-pipeline-run-verification-20260512.md`
+- `docs/development/generic-integration-workbench-frontend-shell-design-20260512.md`
+- `docs/development/generic-integration-workbench-frontend-shell-verification-20260512.md`
+
+## Verification Matrix
+
+| Case | Expected | Evidence |
+| --- | --- | --- |
+| Pipeline service upsert | Calls `POST /api/integration/pipelines` | `integrationWorkbench.spec.ts` |
+| Pipeline service dry-run | Calls `POST /api/integration/pipelines/:id/dry-run` with tenant/mode/sampleLimit | `integrationWorkbench.spec.ts` |
+| Pipeline service Save-only run | Calls `POST /api/integration/pipelines/:id/run` | `integrationWorkbench.spec.ts` |
+| View saves pipeline | Sends selected source/target objects, field mappings, idempotency fields, and active status | `IntegrationWorkbenchView.spec.ts` |
+| Save-only default | Pipeline options force `autoSubmit=false` and `autoAudit=false` | `IntegrationWorkbenchView.spec.ts` |
+| Template traceability | K3 template metadata is copied into `options.k3Template` | `IntegrationWorkbenchView.spec.ts` |
+| Dry-run button | Uses saved pipeline ID and sample limit | `IntegrationWorkbenchView.spec.ts` |
+| Save-only guard | Live run button requires explicit checkbox before execution | `IntegrationWorkbenchView.spec.ts` |
+| Result panel | Shows submitted action and backend result JSON | `IntegrationWorkbenchView.spec.ts` |
+
+## Commands
+
+Executed in `/Users/chouhua/Downloads/Github/metasheet2`:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/integrationWorkbench.spec.ts tests/IntegrationWorkbenchView.spec.ts --watch=false
+```
+
+## Result
+
+PASS.
+
+| Command | Result |
+| --- | --- |
+| `pnpm --filter @metasheet/web exec vitest run tests/integrationWorkbench.spec.ts tests/IntegrationWorkbenchView.spec.ts --watch=false` | PASS - 2 files, 3 tests |
+
+Full K3 setup regression, frontend build, and diff checks are run in the final verification pass for the combined workbench slice.

--- a/docs/development/generic-integration-workbench-same-system-sql-design-20260512.md
+++ b/docs/development/generic-integration-workbench-same-system-sql-design-20260512.md
@@ -1,0 +1,63 @@
+# Generic Integration Workbench Same-System and SQL Advanced Design - 2026-05-12
+
+## Purpose
+
+This slice turns two product decisions into concrete repo artifacts:
+
+1. a source and target may be the same external system when the business objects differ;
+2. SQL channels are supported as advanced implementation features, not casual business-user connectors.
+
+The implementation intentionally stays narrow: it adds regression coverage and planning docs, but does not introduce new runtime APIs or database migrations.
+
+## Same-System Rule
+
+The pipeline model already separates system identity from business object identity:
+
+- `sourceSystemId`
+- `sourceObject`
+- `targetSystemId`
+- `targetObject`
+
+Therefore a valid pipeline may read `customers_raw` and write `customers_clean` on the same CRM connection, or read a source object and write a normalized object on the same SRM connection.
+
+The safety condition is role-based:
+
+- same-system pipeline is valid when the external system role is `bidirectional`;
+- same-system pipeline is invalid when the external system is only `source`;
+- same-system pipeline is invalid when the external system is only `target`.
+
+This matches the existing registry role checks and is now explicitly covered by tests.
+
+## SQL Channel Rule
+
+SQL channel should be exposed as an advanced connector path:
+
+- SQL read is allowed only through configured object metadata and table allowlists.
+- SQL write is allowed only for configured middle tables by default.
+- Raw SQL is never accepted.
+- Direct writes to K3 WISE core tables remain outside normal UI.
+- Delivery/admin users may configure SQL objects; ordinary business users should consume the resulting connector, not author SQL behavior.
+
+This aligns with the existing K3 WISE SQL Server adapter, which uses object configuration, identifier validation, read/write allowlists, and middle-table write mode.
+
+## Product Impact
+
+The generic workbench can support these examples:
+
+| Example | Source | Target | Recommended setup |
+| --- | --- | --- | --- |
+| CRM cleanup | CRM `customers_raw` | CRM `customers_clean` | one `bidirectional` CRM HTTP system |
+| SRM supplier normalization | SRM `supplier_candidates` | SRM `suppliers` | one `bidirectional` SRM HTTP system |
+| K3 table correction | K3 SQL `t_ICItem` read object | K3 WebAPI `material` Save | two logical systems pointing to one K3 account |
+| K3 middle-table integration | K3 SQL source view | K3 SQL middle table | advanced SQL channel with allowlists |
+
+The UI copy should use "same system, different business object" rather than "loopback" to avoid implying uncontrolled self-sync.
+
+## Non-Goals
+
+- No new `integration_document_templates` table in this slice.
+- No new REST endpoints in this slice.
+- No user-defined JavaScript.
+- No raw SQL editor.
+- No direct K3 core-table write UI.
+- No Submit/Audit default enablement.

--- a/docs/development/generic-integration-workbench-same-system-sql-verification-20260512.md
+++ b/docs/development/generic-integration-workbench-same-system-sql-verification-20260512.md
@@ -1,0 +1,41 @@
+# Generic Integration Workbench Same-System and SQL Advanced Verification - 2026-05-12
+
+## Files Changed
+
+- `plugins/plugin-integration-core/__tests__/pipelines.test.cjs`
+- `docs/development/generic-integration-workbench-development-plan-20260512.md`
+- `docs/development/generic-integration-workbench-todo-20260512.md`
+- `docs/development/generic-integration-workbench-same-system-sql-design-20260512.md`
+- `docs/development/generic-integration-workbench-same-system-sql-verification-20260512.md`
+
+## Verification Matrix
+
+| Case | Expected | Evidence |
+| --- | --- | --- |
+| Same source and target system with `bidirectional` role | Pipeline is accepted | New `crm_bidirectional` test case |
+| Same source and target system with `source` role | Pipeline is rejected as invalid target | New `crm_source_only` test case |
+| Source and target objects differ on same system | Objects are preserved separately | New assertions on `customers_raw` and `customers_clean` |
+| SQL channel positioning | Advanced-only in plan/TODO | Development plan and TODO M3 |
+| No migration introduced | PASS by inspection | Only docs and one test file changed |
+
+## Commands
+
+Executed in `/Users/chouhua/Downloads/Github/metasheet2`:
+
+```bash
+node plugins/plugin-integration-core/__tests__/pipelines.test.cjs
+pnpm -F plugin-integration-core test
+git diff --check
+```
+
+## Result
+
+PASS.
+
+| Command | Result |
+| --- | --- |
+| `node plugins/plugin-integration-core/__tests__/pipelines.test.cjs` | PASS - pipeline registry tests passed, including same-system bidirectional coverage |
+| `pnpm -F plugin-integration-core test` | PASS - all 20 plugin-integration-core test files passed |
+| `git diff --check` | PASS - no whitespace errors or conflict markers |
+
+The full plugin test run also covered K3 WISE WebAPI, K3 WISE SQL Server channel, HTTP adapter, PLM wrapper, pipeline runner, REST routes, feedback writer, staging installer, and migration SQL shape tests.

--- a/docs/development/generic-integration-workbench-sql-guardrails-development-20260512.md
+++ b/docs/development/generic-integration-workbench-sql-guardrails-development-20260512.md
@@ -1,0 +1,56 @@
+# Generic Integration Workbench SQL Guardrails Development - 2026-05-12
+
+## Scope
+
+This slice closes the M3 SQL advanced-channel TODOs by making the existing K3 WISE SQL Server safety rules explicit in adapter discovery metadata.
+
+The runtime SQL adapter already enforces:
+
+- Read objects must use configured read allowlists.
+- Writes must target configured middle tables.
+- Direct K3 core-table writes are blocked unless an explicit low-level escape hatch is configured outside the normal workbench UI.
+
+This change exposes those rules to Workbench clients through `GET /api/integration/adapters`.
+
+## Design
+
+`erp:k3-wise-sqlserver` now returns:
+
+```json
+{
+  "advanced": true,
+  "guardrails": {
+    "read": {
+      "requiresTableAllowlist": true,
+      "allowlistKeys": ["readTables", "allowedTables"]
+    },
+    "write": {
+      "requiresMiddleTableMode": true,
+      "requiresTableAllowlist": true,
+      "allowlistKeys": ["writeTables", "allowedTables"],
+      "writeModes": ["middle-table"]
+    },
+    "ui": {
+      "hiddenByDefault": true,
+      "normalUiDirectCoreTableWrites": false
+    }
+  }
+}
+```
+
+The generic Workbench already hides advanced connectors by default and shows the implementation warning only after the advanced toggle is enabled. The new metadata gives future clients a machine-readable contract instead of relying only on copy text.
+
+## Files
+
+- `plugins/plugin-integration-core/lib/http-routes.cjs`
+- `plugins/plugin-integration-core/__tests__/http-routes.test.cjs`
+- `apps/web/src/services/integration/workbench.ts`
+- `docs/development/generic-integration-workbench-todo-20260512.md`
+- `docs/development/generic-integration-workbench-sql-guardrails-development-20260512.md`
+- `docs/development/generic-integration-workbench-sql-guardrails-verification-20260512.md`
+
+## Non-Goals
+
+- No raw SQL UI was added.
+- No direct K3 core-table write UI was added.
+- No change was made to the SQL adapter runtime enforcement path.

--- a/docs/development/generic-integration-workbench-sql-guardrails-verification-20260512.md
+++ b/docs/development/generic-integration-workbench-sql-guardrails-verification-20260512.md
@@ -1,0 +1,36 @@
+# Generic Integration Workbench SQL Guardrails Verification - 2026-05-12
+
+## Scope
+
+Verification for M3 SQL advanced-channel closeout:
+
+- Adapter discovery exposes SQL read/write/UI guardrails.
+- Unknown adapters do not inherit SQL guardrails.
+- Existing K3 WISE SQL adapter runtime guard tests remain green.
+- Workbench frontend still hides SQL connectors from normal UI by default.
+
+## Results
+
+| Command | Result | Notes |
+| --- | --- | --- |
+| `node plugins/plugin-integration-core/__tests__/http-routes.test.cjs` | PASS | Direct metadata contract suite passed. |
+| `node plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs` | PASS | Runtime SQL allowlist and middle-table guard regression passed. |
+| `pnpm -F plugin-integration-core test` | PASS | Full plugin package regression passed. |
+| `pnpm --filter @metasheet/web exec vitest run tests/IntegrationWorkbenchView.spec.ts tests/integrationWorkbench.spec.ts --watch=false` | PASS | 2 files / 3 tests passed. Vitest emitted the existing `--localstorage-file` warning. |
+| `pnpm --filter @metasheet/web exec vue-tsc --noEmit` | PASS | Frontend type check passed after adapter metadata type expansion. |
+| `pnpm --filter @metasheet/web build` | PASS | Frontend production build passed. Existing Vite dynamic-import and chunk-size warnings remained. |
+| `git diff --check` | PASS | No whitespace errors. |
+
+## Contract Assertions
+
+- `erp:k3-wise-sqlserver` remains `advanced: true`.
+- SQL metadata advertises read table allowlist requirements.
+- SQL metadata advertises middle-table write mode requirements.
+- SQL metadata advertises normal UI direct core-table writes as disabled.
+- Unknown adapter metadata does not include SQL guardrails.
+- Existing K3 SQL adapter tests still reject disallowed reads, read-only writes, write-only reads, and direct table writes.
+
+## Notes
+
+- Runtime SQL guard enforcement was already implemented in `k3-wise-sqlserver-channel.cjs`; this slice made the safety contract discoverable through adapter metadata.
+- The generic Workbench still keeps SQL adapters hidden until the advanced connector toggle is enabled.

--- a/docs/development/generic-integration-workbench-template-contract-design-20260512.md
+++ b/docs/development/generic-integration-workbench-template-contract-design-20260512.md
@@ -1,0 +1,33 @@
+# Generic Integration Workbench Template Contract Design - 2026-05-12
+
+## Purpose
+
+Close the custom target template contract gap for `integration_external_systems.config.documentTemplates[]`.
+
+The first discovery slice accepted template-like objects with fallbacks such as `object || targetObject || name` and `label || object`. That was useful during bootstrap, but it made customer template configs ambiguous. This slice makes v1 template discovery explicit:
+
+- `id` is required;
+- `label` is required;
+- `object` is required;
+- `targetObject` and `name` no longer satisfy the required object field.
+
+## Behavior
+
+Discovery still normalizes safe template metadata for UI use:
+
+- `bodyKey` defaults to `Data`;
+- `endpointPath`, `savePath`, or `path` must be relative and safe when present;
+- `operations` defaults to `['upsert']`;
+- `schema[].name` remains required;
+- secret-like template values are still redacted before response.
+
+## Why Strict
+
+The Workbench stores target-template intent into pipeline options and uses object/schema discovery to seed mapping UI. Fallback IDs and labels make later review/audit harder because the displayed template may not match the implementer-authored config. Requiring the three identity fields makes templates stable and reviewable.
+
+## Non-Goals
+
+- No new template table.
+- No template authoring UI.
+- No adapter write behavior change.
+- No change to `POST /api/integration/templates/preview`; preview remains a pure calculation endpoint.

--- a/docs/development/generic-integration-workbench-template-contract-verification-20260512.md
+++ b/docs/development/generic-integration-workbench-template-contract-verification-20260512.md
@@ -1,0 +1,29 @@
+# Generic Integration Workbench Template Contract Verification - 2026-05-12
+
+## Verification Matrix
+
+| Check | Result | Notes |
+| --- | --- | --- |
+| `node plugins/plugin-integration-core/__tests__/http-routes.test.cjs` | PASS | Discovery and template route coverage |
+| `pnpm -F plugin-integration-core test` | PASS | Full plugin integration-core chain |
+| `pnpm --filter @metasheet/web exec vitest run tests/IntegrationWorkbenchView.spec.ts tests/integrationWorkbench.spec.ts --watch=false` | PASS | 3/3 tests |
+| `pnpm --filter @metasheet/web exec vue-tsc --noEmit` | PASS | Clean |
+| `pnpm --filter @metasheet/web build` | PASS | `vue-tsc -b` plus Vite build |
+| `git diff --check` | PASS | Clean |
+
+## Coverage Added
+
+- Custom supplier template discovery asserts stable `id`, `label`, `object`, operations, `template.id`, `template.bodyKey`, and `template.endpointPath`.
+- Missing `config.documentTemplates[0].id` rejects with `INVALID_DOCUMENT_TEMPLATE`.
+- Missing `config.documentTemplates[0].label` rejects with `INVALID_DOCUMENT_TEMPLATE`.
+- Missing `config.documentTemplates[0].object` rejects with `INVALID_DOCUMENT_TEMPLATE`, even if legacy `targetObject` is present.
+
+## Not Covered
+
+- Live external-system configs. This remains mocked route coverage.
+- Template authoring UI.
+
+## Warnings Observed
+
+- Frontend Vitest emitted the existing `--localstorage-file was provided without a valid path` warning.
+- Vite build emitted existing dynamic/static import and chunk-size warnings.

--- a/docs/development/generic-integration-workbench-template-preview-design-20260512.md
+++ b/docs/development/generic-integration-workbench-template-preview-design-20260512.md
@@ -1,0 +1,101 @@
+# Generic Integration Workbench Template Preview Design - 2026-05-12
+
+## Purpose
+
+The workbench needs a safe way to show users what a mapped record will look like before any ERP/CRM/PLM/SRM write happens. This slice adds a pure preview endpoint:
+
+```http
+POST /api/integration/templates/preview
+```
+
+The endpoint transforms one sample source record into a target payload, validates it, wraps it with the target template `bodyKey`, and returns structured errors. It does not read or write database state and does not call any external adapter.
+
+## Request Shape
+
+```json
+{
+  "sourceRecord": {
+    "code": " mat-001 ",
+    "name": " Bolt ",
+    "uom": "EA"
+  },
+  "fieldMappings": [
+    {
+      "sourceField": "code",
+      "targetField": "FNumber",
+      "transform": ["trim", "upper"],
+      "validation": [{ "type": "required" }]
+    }
+  ],
+  "template": {
+    "id": "k3wise.material.v1",
+    "version": "2026.05.v1",
+    "documentType": "material",
+    "bodyKey": "Data",
+    "endpointPath": "/K3API/Material/Save",
+    "schema": [
+      { "name": "FNumber", "label": "Material code", "type": "string", "required": true }
+    ]
+  }
+}
+```
+
+`template` is optional. When absent, `bodyKey` defaults to `Data` and the full transformed target record is returned.
+
+## Response Shape
+
+```json
+{
+  "ok": true,
+  "data": {
+    "valid": true,
+    "payload": {
+      "Data": {
+        "FNumber": "MAT-001"
+      }
+    },
+    "targetRecord": {
+      "FNumber": "MAT-001"
+    },
+    "errors": [],
+    "transformErrors": [],
+    "validationErrors": [],
+    "schemaErrors": [],
+    "template": {
+      "id": "k3wise.material.v1",
+      "version": "2026.05.v1",
+      "documentType": "material",
+      "bodyKey": "Data",
+      "endpointPath": "/K3API/Material/Save"
+    }
+  }
+}
+```
+
+## Behavior
+
+1. Require `integration:write` or admin permission because preview is part of pipeline authoring.
+2. Require `sourceRecord` to be a plain object.
+3. Require `fieldMappings` to be an array.
+4. Reuse `transformRecord()` from `transform-engine.cjs`.
+5. Reuse `validateRecord()` from `validator.cjs`.
+6. Apply template-schema required checks for fields marked `required: true`.
+7. Project the target record to the template schema when a schema is provided.
+8. Wrap the projected record as `{ [bodyKey]: targetRecord }`.
+9. Pass the final response through `sanitizeIntegrationPayload()`.
+
+## Safety Rules
+
+- Preview never calls `adapter.read()` or `adapter.upsert()`.
+- Preview never writes `integration_*` tables.
+- Preview rejects unsafe body keys such as `__proto__`, `prototype`, and `constructor`.
+- Preview rejects absolute or scheme-bearing template endpoint paths.
+- Preview does not execute user JavaScript; unsupported transforms become structured transform errors.
+- Preview response avoids shared object references before redaction so JSON output cannot degrade into `[circular]` placeholders for normal payload data.
+
+## Non-Goals
+
+- No pipeline creation.
+- No dry-run execution.
+- No adapter discovery changes beyond the previous slice.
+- No frontend page in this slice.

--- a/docs/development/generic-integration-workbench-template-preview-verification-20260512.md
+++ b/docs/development/generic-integration-workbench-template-preview-verification-20260512.md
@@ -1,0 +1,47 @@
+# Generic Integration Workbench Template Preview Verification - 2026-05-12
+
+## Files Changed
+
+- `plugins/plugin-integration-core/lib/http-routes.cjs`
+- `plugins/plugin-integration-core/__tests__/http-routes.test.cjs`
+- `docs/development/generic-integration-workbench-todo-20260512.md`
+- `docs/development/generic-integration-workbench-template-preview-design-20260512.md`
+- `docs/development/generic-integration-workbench-template-preview-verification-20260512.md`
+
+## Verification Matrix
+
+| Case | Expected | Evidence |
+| --- | --- | --- |
+| Route registration | `POST /api/integration/templates/preview` registered | `testTemplatePreviewRoute()` |
+| K3 Material-style preview | Returns `{ Data: { FNumber, FName, FBaseUnitID, FQty } }` | `testTemplatePreviewRoute()` |
+| Transform reuse | `trim`, `upper`, `dictMap`, and `toNumber` applied | `testTemplatePreviewRoute()` |
+| Validator reuse | Field-mapping `required` and `min` rules evaluated | `testTemplatePreviewRoute()` |
+| Template required fields | Missing schema-required fields return errors | `testTemplatePreviewRoute()` |
+| Unsupported transform | Returns structured transform error without throwing 500 | `testTemplatePreviewRoute()` |
+| Unsafe body key | `__proto__` rejected with `400 INVALID_TEMPLATE_PREVIEW` | `testTemplatePreviewRoute()` |
+| Permission boundary | read-only integration user gets `403` | `testTemplatePreviewRoute()` |
+| No service calls | Preview does not call registries, runner, or adapters | `testTemplatePreviewRoute()` |
+| Secret redaction | Unmapped source password does not appear in response | `testTemplatePreviewRoute()` |
+
+## Commands
+
+Executed in `/Users/chouhua/Downloads/Github/metasheet2`:
+
+```bash
+node plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+pnpm -F plugin-integration-core test
+git diff --check
+```
+
+## Result
+
+PASS.
+
+| Command | Result |
+| --- | --- |
+| `node plugins/plugin-integration-core/__tests__/http-routes.test.cjs` | PASS - route suite passed, including template preview coverage |
+| `node plugins/plugin-integration-core/__tests__/pipelines.test.cjs` | PASS - pipeline registry suite still passes |
+| `pnpm -F plugin-integration-core test` | PASS - all plugin-integration-core test files passed |
+| `git diff --check` | PASS - no whitespace errors or conflict markers |
+
+The full plugin test run covered runtime smoke, host loader activation, credential store, DB guard, external systems, adapter contracts, HTTP adapter, PLM wrapper, pipelines, transform/validator, runner support, payload redaction, pipeline runner, REST routes, PLM-to-K3 mock chain, K3 WISE adapters, ERP feedback, E2E writeback, staging installer, and migration SQL shape.

--- a/docs/development/generic-integration-workbench-todo-20260512.md
+++ b/docs/development/generic-integration-workbench-todo-20260512.md
@@ -1,0 +1,164 @@
+# Generic Integration Workbench TODO - 2026-05-12
+
+## M0 - Scope Lock
+
+- [x] Keep MetaSheet multitable as the cleansing and review surface.
+- [x] Treat JSON as template/payload preview, not as the primary business data store.
+- [x] Keep K3 WISE Material and BOM as v1 built-in templates.
+- [x] Allow same source and target external system only when role is `bidirectional`.
+- [x] Treat SQL channel as an advanced feature.
+- [x] Do not add a v1 template table.
+- [x] Do not allow user JavaScript transforms.
+- [x] Do not allow raw SQL.
+- [x] Keep Save-only as the default write strategy.
+- [x] Keep Submit/Audit disabled by default.
+
+## M1 - Backend Discovery API
+
+- [x] Add `GET /api/integration/adapters`.
+- [x] Add adapter metadata for labels, roles, supports, and advanced flag.
+- [x] Add `GET /api/integration/external-systems/:id/objects`.
+- [x] Add `GET /api/integration/external-systems/:id/schema`.
+- [x] Merge adapter objects with `config.documentTemplates[]` objects.
+- [x] Redact all discovery output.
+- [x] Add tenant/workspace scope tests through scoped route invocation.
+- [x] Add unknown system test.
+- [x] Add missing object test.
+- [x] Add SQL advanced metadata test.
+
+## M2 - Same-System Pipeline Support
+
+- [x] Confirm the registry does not forbid `sourceSystemId === targetSystemId`.
+- [x] Add test for bidirectional same-system different-object pipeline.
+- [x] Add test that source-only same-system pipeline is rejected as target.
+- [x] Surface same-system mode in the workbench UI.
+- [x] Use copy: "same system, different business object".
+- [x] Recommend two logical connections when one physical system uses different protocols.
+
+## M3 - SQL Advanced Channel
+
+- [x] Mark `erp:k3-wise-sqlserver` as `advanced: true` in adapter metadata.
+- [x] Hide SQL channel from default business-user connector list.
+- [x] Show SQL channel under advanced settings for admins/implementers.
+- [x] Require table allowlists for read objects.
+- [x] Require middle-table write mode for target objects.
+- [x] Keep direct core-table writes out of normal UI.
+- [x] Add tests for SQL metadata and allowlist hints.
+
+## M4 - Custom Target Templates
+
+- [x] Define `config.documentTemplates[]` parser.
+- [x] Require template `id`, `label`, and `object`.
+- [x] Default `bodyKey` to `Data`.
+- [x] Reject absolute endpoint paths.
+- [x] Reject unsafe endpoint paths.
+- [x] Require `schema[].name`.
+- [x] Redact secret-like template values.
+- [x] Include template objects in object discovery.
+- [x] Include template schema in schema discovery.
+- [x] Add tests for a custom supplier template.
+
+## M5 - Template Preview API
+
+- [x] Add `POST /api/integration/templates/preview`.
+- [x] Reuse transform engine.
+- [x] Reuse validator.
+- [x] Wrap target record with `bodyKey`.
+- [x] Return `valid`, `payload`, and `errors`.
+- [x] Do not write DB.
+- [x] Do not call target adapter.
+- [x] Redact response payload and errors.
+- [x] Test K3 Material preview.
+- [x] Test K3 BOM preview.
+- [x] Test custom template-style schema preview.
+- [x] Test missing required fields.
+- [x] Test unsupported transform.
+
+## M6 - Frontend Workbench Service
+
+- [x] Add `apps/web/src/services/integration/workbench.ts`.
+- [x] Implement list adapters.
+- [x] Implement list systems.
+- [x] Implement test system.
+- [x] Implement list objects.
+- [x] Implement get schema.
+- [x] Implement preview template.
+- [x] Implement upsert pipeline.
+- [x] Implement dry-run.
+- [x] Implement Save-only run.
+- [x] Automatically include tenant ID from app context/local storage.
+- [x] Omit blank workspace ID instead of sending an empty string.
+
+## M7 - Frontend Workbench Page
+
+- [x] Add `IntegrationWorkbenchView.vue`.
+- [x] Add route `/integrations/workbench`.
+- [x] Add source system selector.
+- [x] Add target system selector.
+- [x] Add connection status badges.
+- [x] Add source object selector.
+- [x] Add target object/template selector.
+- [x] Add staging table selector.
+- [x] Add field mapping grid.
+- [ ] Add transform selector from whitelist.
+- [ ] Add dictionary mapping editor.
+- [ ] Add validation rule editor.
+- [x] Add payload preview panel.
+- [x] Add dry-run button.
+- [x] Add Save-only run button.
+- [x] Add run result summary.
+- [x] Add dead-letter list.
+
+## M8 - K3 WISE Page Convergence
+
+- [ ] Keep K3 setup page as a quick-start preset.
+- [x] Add link to generic workbench.
+- [ ] Remove tenant ID from ordinary required input.
+- [ ] Move workspace ID to advanced context.
+- [ ] Explain Base URL vs endpoint path clearly.
+- [ ] Warn when Base URL and endpoint both include `/K3API/`.
+- [ ] Keep WebAPI connected status after successful test.
+- [ ] Keep SQL channel as advanced.
+- [ ] Preserve Material/BOM template preview.
+- [ ] Preserve current K3 WISE tests.
+
+## M9 - Documentation and Delivery
+
+- [x] Add development MD for backend discovery.
+- [x] Add verification MD for backend discovery.
+- [x] Add development MD for template preview.
+- [x] Add verification MD for template preview.
+- [x] Add development MD for frontend workbench shell.
+- [x] Add verification MD for frontend workbench shell.
+- [x] Add development MD for connection test and status badges.
+- [x] Add verification MD for connection test and status badges.
+- [x] Add development MD for frontend pipeline run controls.
+- [x] Add verification MD for frontend pipeline run controls.
+- [x] Add development MD for frontend observation controls.
+- [x] Add verification MD for frontend observation controls.
+- [x] Add development MD for K3 preset to generic workbench link.
+- [x] Add verification MD for K3 preset to generic workbench link.
+- [x] Add development MD for advanced connector and same-system UX.
+- [x] Add verification MD for advanced connector and same-system UX.
+- [x] Add development MD for strict document template contract.
+- [x] Add verification MD for strict document template contract.
+- [x] Add development MD for backend contract closeout.
+- [x] Add verification MD for backend contract closeout.
+- [x] Add development MD for SQL advanced guardrails.
+- [x] Add verification MD for SQL advanced guardrails.
+- [ ] Update Windows on-prem runbook.
+- [ ] Update K3 WISE runbook.
+- [ ] Update package verify script if new docs/routes must be included.
+- [ ] Run K3 offline PoC.
+- [x] Run frontend build.
+
+## Suggested Verification Commands
+
+```bash
+pnpm -F plugin-integration-core test
+pnpm --filter @metasheet/web exec vitest run apps/web/tests/IntegrationWorkbenchView.spec.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run apps/web/tests/k3WiseSetup.spec.ts apps/web/tests/IntegrationK3WiseSetupView.spec.ts --watch=false
+pnpm --filter @metasheet/web build
+pnpm verify:integration-k3wise:poc
+pnpm verify:integration-erp-plm:deploy-readiness
+```

--- a/docs/development/integration-k3wise-generic-workbench-link-design-20260512.md
+++ b/docs/development/integration-k3wise-generic-workbench-link-design-20260512.md
@@ -1,0 +1,33 @@
+# K3 WISE Generic Workbench Link Design - 2026-05-12
+
+## Purpose
+
+The K3 WISE setup page is still the fast path for the first customer PoC. The generic integration workbench is now the reusable surface for source/target selection, mapping, preview, pipeline execution, and observation.
+
+This slice adds a direct bridge from the K3 WISE preset page to the generic workbench so operators do not need to know or type `/integrations/workbench`.
+
+## Change
+
+`apps/web/src/views/IntegrationK3WiseSetupView.vue` adds a header action:
+
+```html
+<router-link to="/integrations/workbench">打开通用工作台</router-link>
+```
+
+The link uses the existing `k3-setup__btn` visual style and is intentionally placed next to refresh/save actions, not inside the setup form.
+
+## Product Boundary
+
+This keeps the product model clear:
+
+- K3 WISE page: guided preset for K3 WebAPI / SQL channel setup and Material/BOM bootstrap.
+- Generic workbench: reusable CRM/PLM/ERP/SRM mapping, preview, pipeline run, and observation surface.
+
+No K3 connection payload, pipeline payload, route permission, or backend behavior changes in this slice.
+
+## Non-Goals
+
+- No main navigation change.
+- No redirect from K3 to the workbench.
+- No migration.
+- No backend API change.

--- a/docs/development/integration-k3wise-generic-workbench-link-verification-20260512.md
+++ b/docs/development/integration-k3wise-generic-workbench-link-verification-20260512.md
@@ -1,0 +1,39 @@
+# K3 WISE Generic Workbench Link Verification - 2026-05-12
+
+## Files Changed
+
+- `apps/web/src/views/IntegrationK3WiseSetupView.vue`
+- `apps/web/tests/IntegrationK3WiseSetupView.spec.ts`
+- `docs/development/generic-integration-workbench-todo-20260512.md`
+- `docs/development/integration-k3wise-generic-workbench-link-design-20260512.md`
+- `docs/development/integration-k3wise-generic-workbench-link-verification-20260512.md`
+
+## Verification Matrix
+
+| Case | Expected | Evidence |
+| --- | --- | --- |
+| K3 page bridge | Header contains `打开通用工作台` | `IntegrationK3WiseSetupView.spec.ts` |
+| Route target | Link points to `/integrations/workbench` | `IntegrationK3WiseSetupView.spec.ts` |
+| Existing first-run copy | K3 setup guidance remains visible | `IntegrationK3WiseSetupView.spec.ts` |
+| Existing WebAPI test flow | Saved WebAPI test still sends tenant scope | `IntegrationK3WiseSetupView.spec.ts` |
+| Scope | No backend or migration changes | Diff limited to frontend/docs/TODO for this slice |
+
+## Commands
+
+Executed in `/Users/chouhua/Downloads/Github/metasheet2`:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/IntegrationK3WiseSetupView.spec.ts --watch=false
+```
+
+## Result
+
+PASS.
+
+| Command | Result |
+| --- | --- |
+| `pnpm --filter @metasheet/web exec vitest run tests/IntegrationK3WiseSetupView.spec.ts --watch=false` | PASS - 1 file, 2 tests |
+| `pnpm --filter @metasheet/web exec vitest run tests/integrationWorkbench.spec.ts tests/IntegrationWorkbenchView.spec.ts --watch=false` | PASS - 2 files, 3 tests |
+| `pnpm --filter @metasheet/web exec vitest run tests/k3WiseSetup.spec.ts tests/IntegrationK3WiseSetupView.spec.ts --watch=false` | PASS - 2 files, 30 tests |
+| `pnpm --filter @metasheet/web build` | PASS - existing chunk-size/import warnings only |
+| `git diff --check` | PASS - no whitespace errors or conflict markers |

--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -551,6 +551,262 @@ async function testExternalSystemTestRedactsAdapterResultSecrets() {
   assert.equal(statusUpdate.lastError.includes('liveBearerToken123456'), false)
 }
 
+async function testDiscoveryRoutes() {
+  const { calls, services } = createMockServices({
+    externalSystemRegistry: {
+      async getExternalSystemForAdapter(input) {
+        calls.push(['getExternalSystemForAdapter', input])
+        return {
+          id: input.id,
+          tenantId: input.tenantId,
+          workspaceId: input.workspaceId,
+          name: 'Bidirectional CRM',
+          kind: 'http',
+          role: 'bidirectional',
+          config: {
+            documentTemplates: [
+              {
+                id: 'custom.supplier.v1',
+                version: '2026.05.v1',
+                object: 'supplier',
+                label: 'Supplier',
+                endpointPath: '/api/suppliers/save',
+                bodyKey: 'Data',
+                schema: [
+                  { name: 'FNumber', label: 'Supplier code', type: 'string', required: true },
+                  { name: 'FName', label: 'Supplier name', type: 'string', required: true },
+                ],
+                password: 'template-secret-should-not-leak',
+              },
+            ],
+          },
+          credentials: { bearerToken: 'secret-token' },
+        }
+      },
+    },
+    adapterRegistry: {
+      listAdapterKinds() {
+        calls.push(['listAdapterKinds'])
+        return ['http', 'erp:k3-wise-sqlserver', 'custom:unknown']
+      },
+      createAdapter(input) {
+        calls.push(['createAdapter', input])
+        return {
+          async listObjects() {
+            calls.push(['listObjects'])
+            return [
+              {
+                name: 'customers_raw',
+                label: 'Customers raw',
+                operations: ['read'],
+                schema: [
+                  { name: 'rawName', label: 'Raw name', type: 'string' },
+                ],
+              },
+            ]
+          },
+          async getSchema(input) {
+            calls.push(['getSchema', input])
+            return {
+              object: input.object,
+              fields: [
+                { name: 'rawName', label: 'Raw name', type: 'string' },
+                { name: 'accessToken', label: 'Token-like source field', type: 'string' },
+              ],
+              raw: {
+                credentials: { password: 'schema-secret-should-not-leak' },
+              },
+            }
+          },
+        }
+      },
+    },
+  })
+  const { routes, registered } = mountRoutes(services)
+
+  assert.ok(registered.includes('GET /api/integration/adapters'), 'adapter discovery route registered')
+  assert.ok(registered.includes('GET /api/integration/external-systems/:id/objects'), 'object discovery route registered')
+  assert.ok(registered.includes('GET /api/integration/external-systems/:id/schema'), 'schema discovery route registered')
+
+  let res = await invoke(routes, 'GET', '/api/integration/adapters', {
+    user: READ_USER,
+  })
+  assertOkResponse(res, 200)
+  const sqlMetadata = res.body.data.find((adapter) => adapter.kind === 'erp:k3-wise-sqlserver')
+  assert.equal(sqlMetadata.label, 'K3 WISE SQL Server Channel')
+  assert.equal(sqlMetadata.advanced, true, 'SQL Server channel is marked as advanced')
+  assert.deepEqual(sqlMetadata.guardrails, {
+    read: {
+      requiresTableAllowlist: true,
+      allowlistKeys: ['readTables', 'allowedTables'],
+    },
+    write: {
+      requiresMiddleTableMode: true,
+      requiresTableAllowlist: true,
+      allowlistKeys: ['writeTables', 'allowedTables'],
+      writeModes: ['middle-table'],
+    },
+    ui: {
+      hiddenByDefault: true,
+      normalUiDirectCoreTableWrites: false,
+    },
+  })
+  const unknownMetadata = res.body.data.find((adapter) => adapter.kind === 'custom:unknown')
+  assert.equal(unknownMetadata.label, 'custom:unknown')
+  assert.equal(unknownMetadata.advanced, false)
+  assert.equal(unknownMetadata.guardrails, undefined)
+
+  res = await invoke(routes, 'GET', '/api/integration/external-systems/:id/objects', {
+    user: READ_USER,
+    params: { id: 'crm_1' },
+    query: { workspaceId: 'workspace_1' },
+  })
+  assertOkResponse(res, 200)
+  assert.deepEqual(findCall(calls, 'getExternalSystemForAdapter')[1], {
+    id: 'crm_1',
+    tenantId: 'tenant_1',
+    workspaceId: 'workspace_1',
+  })
+  assert.deepEqual(res.body.data.map((object) => object.name), ['customers_raw', 'supplier'])
+  const supplierObject = res.body.data.find((object) => object.name === 'supplier')
+  assert.equal(supplierObject.id, 'custom.supplier.v1')
+  assert.equal(supplierObject.label, 'Supplier')
+  assert.equal(supplierObject.object, 'supplier')
+  assert.equal(supplierObject.source, 'documentTemplate')
+  assert.deepEqual(supplierObject.operations, ['upsert'])
+  assert.equal(supplierObject.template.bodyKey, 'Data')
+  assert.equal(supplierObject.template.id, 'custom.supplier.v1')
+  assert.equal(supplierObject.template.endpointPath, '/api/suppliers/save')
+  assert.equal(JSON.stringify(res.body).includes('template-secret-should-not-leak'), false)
+  assert.equal(JSON.stringify(res.body).includes('secret-token'), false)
+
+  calls.length = 0
+  res = await invoke(routes, 'GET', '/api/integration/external-systems/:id/schema', {
+    user: READ_USER,
+    params: { id: 'crm_1' },
+    query: { workspaceId: 'workspace_1', object: 'customers_raw' },
+  })
+  assertOkResponse(res, 200)
+  assert.equal(res.body.data.object, 'customers_raw')
+  assert.deepEqual(findCall(calls, 'getSchema')[1], { object: 'customers_raw' })
+  assert.equal(JSON.stringify(res.body).includes('schema-secret-should-not-leak'), false)
+  assert.equal(res.body.data.raw.credentials, '[redacted]')
+
+  calls.length = 0
+  res = await invoke(routes, 'GET', '/api/integration/external-systems/:id/schema', {
+    user: READ_USER,
+    params: { id: 'crm_1' },
+    query: { workspaceId: 'workspace_1', object: 'supplier' },
+  })
+  assertOkResponse(res, 200)
+  assert.equal(res.body.data.object, 'supplier')
+  assert.deepEqual(res.body.data.fields.map((field) => field.name), ['FNumber', 'FName'])
+  assert.equal(findCalls(calls, 'getSchema').length, 0, 'template schema does not call adapter getSchema')
+
+  const missingObject = await invoke(routes, 'GET', '/api/integration/external-systems/:id/schema', {
+    user: READ_USER,
+    params: { id: 'crm_1' },
+    query: { workspaceId: 'workspace_1' },
+  })
+  assert.equal(missingObject.statusCode, 400)
+  assert.equal(missingObject.body.error.code, 'OBJECT_REQUIRED')
+}
+
+async function testDiscoveryRoutesRejectUnknownSystem() {
+  const { calls, services } = createMockServices()
+  services.externalSystemRegistry.getExternalSystemForAdapter = async (input) => {
+    calls.push(['getExternalSystemForAdapter', input])
+    const error = new Error('external system missing')
+    error.name = 'ExternalSystemNotFoundError'
+    throw error
+  }
+  const { routes } = mountRoutes(services)
+
+  let res = await invoke(routes, 'GET', '/api/integration/external-systems/:id/objects', {
+    user: READ_USER,
+    params: { id: 'missing_sys' },
+    query: { workspaceId: 'workspace_1' },
+  })
+  assert.equal(res.statusCode, 404)
+  assert.equal(res.body.error.code, 'ExternalSystemNotFoundError')
+  assert.deepEqual(findCall(calls, 'getExternalSystemForAdapter')[1], {
+    id: 'missing_sys',
+    tenantId: 'tenant_1',
+    workspaceId: 'workspace_1',
+  })
+  assert.equal(findCalls(calls, 'createAdapter').length, 0, 'unknown system does not create an adapter')
+
+  calls.length = 0
+  res = await invoke(routes, 'GET', '/api/integration/external-systems/:id/schema', {
+    user: READ_USER,
+    params: { id: 'missing_sys' },
+    query: { workspaceId: 'workspace_1', object: 'material' },
+  })
+  assert.equal(res.statusCode, 404)
+  assert.equal(res.body.error.code, 'ExternalSystemNotFoundError')
+  assert.equal(findCalls(calls, 'createAdapter').length, 0, 'unknown system schema lookup does not create an adapter')
+}
+
+async function testDocumentTemplateValidation() {
+  const cases = [
+    {
+      name: 'missing id',
+      template: { label: 'Supplier', object: 'supplier', schema: [{ name: 'FNumber' }] },
+      field: 'config.documentTemplates[0].id',
+    },
+    {
+      name: 'missing label',
+      template: { id: 'custom.supplier.v1', object: 'supplier', schema: [{ name: 'FNumber' }] },
+      field: 'config.documentTemplates[0].label',
+    },
+    {
+      name: 'missing object',
+      template: { id: 'custom.supplier.v1', label: 'Supplier', targetObject: 'supplier', schema: [{ name: 'FNumber' }] },
+      field: 'config.documentTemplates[0].object',
+    },
+  ]
+
+  for (const { name, template, field } of cases) {
+    const { services } = createMockServices({
+      externalSystemRegistry: {
+        async getExternalSystemForAdapter(input) {
+          return {
+            id: input.id,
+            tenantId: input.tenantId,
+            workspaceId: input.workspaceId,
+            name: 'Template Host',
+            kind: 'http',
+            role: 'bidirectional',
+            config: {
+              documentTemplates: [template],
+            },
+          }
+        },
+      },
+      adapterRegistry: {
+        createAdapter() {
+          return {
+            async listObjects() {
+              return []
+            },
+          }
+        },
+      },
+    })
+    const { routes } = mountRoutes(services)
+
+    const res = await invoke(routes, 'GET', '/api/integration/external-systems/:id/objects', {
+      user: READ_USER,
+      params: { id: `template_${name.replace(/\s+/g, '_')}` },
+      query: { workspaceId: 'workspace_1' },
+    })
+
+    assert.equal(res.statusCode, 400, `${name} should reject with 400`)
+    assert.equal(res.body.error.code, 'INVALID_DOCUMENT_TEMPLATE')
+    assert.equal(res.body.error.details.field, field)
+  }
+}
+
 async function testPipelineRoutes() {
   const { calls, services } = createMockServices()
   const { routes } = mountRoutes(services)
@@ -676,6 +932,222 @@ async function testPipelineRoutes() {
   })
   assert.equal(dryModeRes.statusCode, 400, "mode 'replay' must be rejected on dry-run too")
   assert.equal(dryModeRes.body.error.code, 'INVALID_RUN_MODE')
+}
+
+async function testTemplatePreviewRoute() {
+  const { calls, services } = createMockServices()
+  const { routes, registered } = mountRoutes(services)
+
+  assert.ok(
+    registered.includes('POST /api/integration/templates/preview'),
+    'template preview route registered',
+  )
+
+  let res = await invoke(routes, 'POST', '/api/integration/templates/preview', {
+    user: WRITE_USER,
+    body: {
+      sourceRecord: {
+        code: ' mat-001 ',
+        name: ' Bolt ',
+        uom: 'EA',
+        quantity: '2',
+        password: 'source-secret-should-not-leak',
+      },
+      fieldMappings: [
+        {
+          sourceField: 'code',
+          targetField: 'FNumber',
+          transform: ['trim', 'upper'],
+          validation: [{ type: 'required' }],
+        },
+        {
+          sourceField: 'name',
+          targetField: 'FName',
+          transform: { fn: 'trim' },
+          validation: [{ type: 'required' }],
+        },
+        {
+          sourceField: 'uom',
+          targetField: 'FBaseUnitID',
+          transform: {
+            fn: 'dictMap',
+            map: { EA: 'Pcs', PCS: 'Pcs', KG: 'Kg' },
+          },
+        },
+        {
+          sourceField: 'quantity',
+          targetField: 'FQty',
+          transform: { fn: 'toNumber' },
+          validation: [{ type: 'min', value: 0.000001 }],
+        },
+      ],
+      template: {
+        id: 'k3wise.material.preview',
+        version: '2026.05.v1',
+        documentType: 'material',
+        bodyKey: 'Data',
+        endpointPath: '/K3API/Material/Save',
+        schema: [
+          { name: 'FNumber', label: 'Material code', type: 'string', required: true },
+          { name: 'FName', label: 'Material name', type: 'string', required: true },
+          { name: 'FBaseUnitID', label: 'Base unit', type: 'string' },
+          { name: 'FQty', label: 'Quantity', type: 'number' },
+        ],
+      },
+    },
+  })
+  assertOkResponse(res, 200)
+  assert.equal(res.body.data.valid, true)
+  assert.deepEqual(JSON.parse(JSON.stringify(res.body.data.payload)), {
+    Data: {
+      FNumber: 'MAT-001',
+      FName: 'Bolt',
+      FBaseUnitID: 'Pcs',
+      FQty: 2,
+    },
+  })
+  assert.deepEqual(res.body.data.errors, [])
+  assert.equal(JSON.stringify(res.body).includes('source-secret-should-not-leak'), false)
+  assert.equal(calls.length, 0, 'template preview does not call integration services')
+
+  res = await invoke(routes, 'POST', '/api/integration/templates/preview', {
+    user: WRITE_USER,
+    body: {
+      sourceRecord: {
+        parentCode: ' bom-parent-001 ',
+        childCode: ' mat-child-002 ',
+        quantity: '2.5',
+        scrapRate: '0.03',
+        password: 'bom-secret-should-not-leak',
+      },
+      fieldMappings: [
+        {
+          sourceField: 'parentCode',
+          targetField: 'FParentItemNumber',
+          transform: ['trim', 'upper'],
+          validation: [{ type: 'required' }],
+        },
+        {
+          sourceField: 'childCode',
+          targetField: 'FChildItemNumber',
+          transform: ['trim', 'upper'],
+          validation: [{ type: 'required' }],
+        },
+        {
+          sourceField: 'quantity',
+          targetField: 'FQty',
+          transform: { fn: 'toNumber' },
+          validation: [{ type: 'min', value: 0.000001 }],
+        },
+        {
+          sourceField: 'scrapRate',
+          targetField: 'FScrapRate',
+          transform: { fn: 'toNumber' },
+        },
+      ],
+      template: {
+        id: 'k3wise.bom.preview',
+        version: '2026.05.v1',
+        documentType: 'bom',
+        bodyKey: 'Data',
+        endpointPath: '/K3API/BOM/Save',
+        schema: [
+          { name: 'FParentItemNumber', label: 'Parent material', type: 'string', required: true },
+          { name: 'FChildItemNumber', label: 'Child material', type: 'string', required: true },
+          { name: 'FQty', label: 'Quantity', type: 'number', required: true },
+          { name: 'FScrapRate', label: 'Scrap rate', type: 'number' },
+        ],
+      },
+    },
+  })
+  assertOkResponse(res, 200)
+  assert.equal(res.body.data.valid, true)
+  assert.deepEqual(JSON.parse(JSON.stringify(res.body.data.payload)), {
+    Data: {
+      FParentItemNumber: 'BOM-PARENT-001',
+      FChildItemNumber: 'MAT-CHILD-002',
+      FQty: 2.5,
+      FScrapRate: 0.03,
+    },
+  })
+  assert.deepEqual(res.body.data.errors, [])
+  assert.equal(JSON.stringify(res.body).includes('bom-secret-should-not-leak'), false)
+  assert.equal(calls.length, 0, 'BOM template preview does not call integration services')
+
+  res = await invoke(routes, 'POST', '/api/integration/templates/preview', {
+    user: WRITE_USER,
+    body: {
+      sourceRecord: {
+        code: '',
+      },
+      fieldMappings: [
+        {
+          sourceField: 'code',
+          targetField: 'FNumber',
+          transform: { fn: 'trim' },
+          validation: [{ type: 'required' }],
+        },
+      ],
+      template: {
+        bodyKey: 'Data',
+        schema: [
+          { name: 'FNumber', label: 'Material code', required: true },
+          { name: 'FName', label: 'Material name', required: true },
+        ],
+      },
+    },
+  })
+  assertOkResponse(res, 200)
+  assert.equal(res.body.data.valid, false)
+  assert.ok(res.body.data.errors.some((error) => error.field === 'FNumber' && error.code === 'REQUIRED'))
+  assert.ok(res.body.data.errors.some((error) => error.field === 'FName' && error.code === 'REQUIRED'))
+
+  res = await invoke(routes, 'POST', '/api/integration/templates/preview', {
+    user: WRITE_USER,
+    body: {
+      sourceRecord: {
+        code: 'MAT-001',
+      },
+      fieldMappings: [
+        {
+          sourceField: 'code',
+          targetField: 'FNumber',
+          transform: { fn: 'unsafeUserScript' },
+        },
+      ],
+      template: {
+        bodyKey: 'Data',
+        schema: [
+          { name: 'FNumber', label: 'Material code', required: true },
+        ],
+      },
+    },
+  })
+  assertOkResponse(res, 200)
+  assert.equal(res.body.data.valid, false)
+  assert.ok(res.body.data.transformErrors.some((error) => /unsupported transform/.test(error.message)))
+
+  const unsafeTemplate = await invoke(routes, 'POST', '/api/integration/templates/preview', {
+    user: WRITE_USER,
+    body: {
+      sourceRecord: {},
+      fieldMappings: [],
+      template: {
+        bodyKey: '__proto__',
+      },
+    },
+  })
+  assert.equal(unsafeTemplate.statusCode, 400)
+  assert.equal(unsafeTemplate.body.error.code, 'INVALID_TEMPLATE_PREVIEW')
+
+  const readOnlyPreview = await invoke(routes, 'POST', '/api/integration/templates/preview', {
+    user: READ_USER,
+    body: {
+      sourceRecord: {},
+      fieldMappings: [],
+    },
+  })
+  assert.equal(readOnlyPreview.statusCode, 403, 'preview is restricted to integration write users')
 }
 
 async function testStagingRoutes() {
@@ -1189,7 +1661,11 @@ async function main() {
   await testExternalSystemRoutes()
   await testExternalSystemTestPersistsFailureAndPreservesInactive()
   await testExternalSystemTestRedactsAdapterResultSecrets()
+  await testDiscoveryRoutes()
+  await testDiscoveryRoutesRejectUnknownSystem()
+  await testDocumentTemplateValidation()
   await testPipelineRoutes()
+  await testTemplatePreviewRoute()
   await testStagingRoutes()
   await testRunAndDeadLetterRoutes()
   await testErrorResponseShape()

--- a/plugins/plugin-integration-core/__tests__/pipelines.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/pipelines.test.cjs
@@ -244,6 +244,60 @@ async function main() {
   assert.ok(badRole instanceof PipelineValidationError, 'source-only system cannot be target')
   assert.equal(badRole.details.field, 'targetSystemId')
 
+  // --- 6b. Same external system can bridge different objects only when bidirectional.
+  {
+    const sameSystemDb = createMockDb()
+    sameSystemDb.seed('integration_external_systems', [
+      {
+        id: 'crm_bidirectional',
+        tenant_id: 'tenant_1',
+        workspace_id: null,
+        name: 'CRM bidirectional',
+        role: 'bidirectional',
+        kind: 'http',
+      },
+      {
+        id: 'crm_source_only',
+        tenant_id: 'tenant_1',
+        workspace_id: null,
+        name: 'CRM source only',
+        role: 'source',
+        kind: 'http',
+      },
+    ])
+    const sameSystemRegistry = createPipelineRegistry({
+      db: sameSystemDb,
+      idGenerator: createIdGenerator(),
+    })
+
+    const sameSystemPipeline = await sameSystemRegistry.upsertPipeline({
+      tenantId: 'tenant_1',
+      name: 'CRM customer cleanse in-place',
+      sourceSystemId: 'crm_bidirectional',
+      sourceObject: 'customers_raw',
+      targetSystemId: 'crm_bidirectional',
+      targetObject: 'customers_clean',
+      fieldMappings: [
+        { sourceField: 'rawName', targetField: 'name', transform: { fn: 'trim' } },
+      ],
+    })
+    assert.equal(sameSystemPipeline.sourceSystemId, 'crm_bidirectional')
+    assert.equal(sameSystemPipeline.targetSystemId, 'crm_bidirectional')
+    assert.equal(sameSystemPipeline.sourceObject, 'customers_raw')
+    assert.equal(sameSystemPipeline.targetObject, 'customers_clean')
+
+    const sameSystemBadRole = await sameSystemRegistry.upsertPipeline({
+      tenantId: 'tenant_1',
+      name: 'CRM bad in-place target',
+      sourceSystemId: 'crm_source_only',
+      sourceObject: 'customers_raw',
+      targetSystemId: 'crm_source_only',
+      targetObject: 'customers_clean',
+    }).catch((error) => error)
+    assert.ok(sameSystemBadRole instanceof PipelineValidationError, 'same source-only system cannot be target')
+    assert.equal(sameSystemBadRole.details.field, 'targetSystemId')
+  }
+
   // --- 7. Validation + not-found errors ---------------------------------
   let badMapping = null
   try {

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -10,15 +10,19 @@
 
 const ROUTES = [
   ['GET', '/api/integration/status', 'status'],
+  ['GET', '/api/integration/adapters', 'adaptersList'],
   ['GET', '/api/integration/external-systems', 'externalSystemsList'],
   ['POST', '/api/integration/external-systems', 'externalSystemsUpsert'],
   ['GET', '/api/integration/external-systems/:id', 'externalSystemsGet'],
   ['POST', '/api/integration/external-systems/:id/test', 'externalSystemsTest'],
+  ['GET', '/api/integration/external-systems/:id/objects', 'externalSystemObjects'],
+  ['GET', '/api/integration/external-systems/:id/schema', 'externalSystemSchema'],
   ['GET', '/api/integration/pipelines', 'pipelinesList'],
   ['POST', '/api/integration/pipelines', 'pipelinesUpsert'],
   ['GET', '/api/integration/pipelines/:id', 'pipelinesGet'],
   ['POST', '/api/integration/pipelines/:id/run', 'pipelinesRun'],
   ['POST', '/api/integration/pipelines/:id/dry-run', 'pipelinesDryRun'],
+  ['POST', '/api/integration/templates/preview', 'templatesPreview'],
   ['GET', '/api/integration/staging/descriptors', 'stagingDescriptors'],
   ['POST', '/api/integration/staging/install', 'stagingInstall'],
   ['GET', '/api/integration/runs', 'runsList'],
@@ -26,6 +30,8 @@ const ROUTES = [
   ['POST', '/api/integration/dead-letters/:id/replay', 'deadLettersReplay'],
 ]
 const { sanitizeIntegrationPayload } = require('./payload-redaction.cjs')
+const { getPath, setPath, transformRecord } = require('./transform-engine.cjs')
+const { validateRecord } = require('./validator.cjs')
 
 class HttpRouteError extends Error {
   constructor(status, code, message, details = {}) {
@@ -260,6 +266,47 @@ const SECRET_TEXT_PATTERN = /(?:access[_-]?token|refresh[_-]?token|id[_-]?token|
 const AUTH_TEXT_PATTERN = /\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]{8,}/ig
 const JWT_TEXT_PATTERN = /\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g
 const SECRET_ID_PATTERN = /\bSEC[A-Za-z0-9_-]{12,}\b/g
+const DEFAULT_ADAPTER_SUPPORTS = ['testConnection', 'listObjects', 'getSchema', 'read', 'upsert']
+const DEFAULT_ADAPTER_ROLES = ['source', 'target', 'bidirectional']
+const DANGEROUS_JSON_KEYS = new Set(['__proto__', 'prototype', 'constructor'])
+const ADAPTER_METADATA = {
+  http: {
+    label: 'HTTP API',
+    roles: DEFAULT_ADAPTER_ROLES,
+    advanced: false,
+  },
+  'plm:yuantus-wrapper': {
+    label: 'Yuantus PLM',
+    roles: ['source'],
+    advanced: false,
+  },
+  'erp:k3-wise-webapi': {
+    label: 'K3 WISE WebAPI',
+    roles: ['target'],
+    advanced: false,
+  },
+  'erp:k3-wise-sqlserver': {
+    label: 'K3 WISE SQL Server Channel',
+    roles: ['source', 'target'],
+    advanced: true,
+    guardrails: {
+      read: {
+        requiresTableAllowlist: true,
+        allowlistKeys: ['readTables', 'allowedTables'],
+      },
+      write: {
+        requiresMiddleTableMode: true,
+        requiresTableAllowlist: true,
+        allowlistKeys: ['writeTables', 'allowedTables'],
+        writeModes: ['middle-table'],
+      },
+      ui: {
+        hiddenByDefault: true,
+        normalUiDirectCoreTableWrites: false,
+      },
+    },
+  },
+}
 
 function redactSecretText(value) {
   if (typeof value !== 'string') return value
@@ -272,6 +319,237 @@ function redactSecretText(value) {
     .replace(AUTH_TEXT_PATTERN, '$1 [redacted]')
     .replace(JWT_TEXT_PATTERN, '[redacted-jwt]')
     .replace(SECRET_ID_PATTERN, '[redacted-secret-id]')
+}
+
+function isPlainObject(value) {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value))
+}
+
+function cloneJson(value) {
+  return value === undefined ? undefined : JSON.parse(JSON.stringify(value))
+}
+
+function describeAdapterKind(kind) {
+  const metadata = ADAPTER_METADATA[kind] || {}
+  return {
+    kind,
+    label: metadata.label || kind,
+    roles: Array.isArray(metadata.roles) ? [...metadata.roles] : [...DEFAULT_ADAPTER_ROLES],
+    supports: Array.isArray(metadata.supports) ? [...metadata.supports] : [...DEFAULT_ADAPTER_SUPPORTS],
+    advanced: metadata.advanced === true,
+    ...(metadata.guardrails ? { guardrails: cloneJson(metadata.guardrails) } : {}),
+  }
+}
+
+function assertRelativeTemplatePath(value, field) {
+  if (value === undefined || value === null || value === '') return null
+  if (typeof value !== 'string') {
+    throw new HttpRouteError(400, 'INVALID_DOCUMENT_TEMPLATE', `${field} must be a string`, { field })
+  }
+  const trimmed = value.trim()
+  if (!trimmed) return null
+  if (/^[a-z][a-z0-9+.-]*:/i.test(trimmed) || trimmed.startsWith('//')) {
+    throw new HttpRouteError(400, 'INVALID_DOCUMENT_TEMPLATE', `${field} must be relative to the external-system base URL`, { field })
+  }
+  if (/[\u0000-\u001F\u007F]/.test(trimmed) || trimmed.includes('\\')) {
+    throw new HttpRouteError(400, 'INVALID_DOCUMENT_TEMPLATE', `${field} must be a safe URL path`, { field })
+  }
+  return trimmed.startsWith('/') ? trimmed : `/${trimmed}`
+}
+
+function normalizeTemplateSchema(schema, field) {
+  if (schema === undefined || schema === null) return []
+  if (!Array.isArray(schema)) {
+    throw new HttpRouteError(400, 'INVALID_DOCUMENT_TEMPLATE', `${field}.schema must be an array`, { field: `${field}.schema` })
+  }
+  return schema.map((item, index) => {
+    if (!isPlainObject(item)) {
+      throw new HttpRouteError(400, 'INVALID_DOCUMENT_TEMPLATE', `${field}.schema[${index}] must be an object`, {
+        field: `${field}.schema[${index}]`,
+      })
+    }
+    const name = firstString(item.name)
+    if (!name) {
+      throw new HttpRouteError(400, 'INVALID_DOCUMENT_TEMPLATE', `${field}.schema[${index}].name is required`, {
+        field: `${field}.schema[${index}].name`,
+      })
+    }
+    return {
+      ...sanitizeIntegrationPayload(item),
+      name,
+      label: firstString(item.label) || name,
+      type: firstString(item.type) || 'string',
+      required: item.required === true,
+    }
+  })
+}
+
+function normalizeDocumentTemplate(template, index) {
+  const field = `config.documentTemplates[${index}]`
+  if (!isPlainObject(template)) {
+    throw new HttpRouteError(400, 'INVALID_DOCUMENT_TEMPLATE', `${field} must be an object`, { field })
+  }
+  const id = firstString(template.id)
+  if (!id) {
+    throw new HttpRouteError(400, 'INVALID_DOCUMENT_TEMPLATE', `${field}.id is required`, { field: `${field}.id` })
+  }
+  const label = firstString(template.label)
+  if (!label) {
+    throw new HttpRouteError(400, 'INVALID_DOCUMENT_TEMPLATE', `${field}.label is required`, { field: `${field}.label` })
+  }
+  const object = firstString(template.object)
+  if (!object) {
+    throw new HttpRouteError(400, 'INVALID_DOCUMENT_TEMPLATE', `${field}.object is required`, { field: `${field}.object` })
+  }
+  const bodyKey = firstString(template.bodyKey) || 'Data'
+  const endpointPath = assertRelativeTemplatePath(
+    firstString(template.endpointPath, template.savePath, template.path),
+    `${field}.endpointPath`,
+  )
+  const operations = Array.isArray(template.operations) && template.operations.length > 0
+    ? template.operations.map((operation) => firstString(operation)).filter(Boolean)
+    : ['upsert']
+  return {
+    id,
+    name: object,
+    object,
+    label,
+    operations: operations.length > 0 ? operations : ['upsert'],
+    schema: normalizeTemplateSchema(template.schema, field),
+    source: 'documentTemplate',
+    template: sanitizeIntegrationPayload({
+      id,
+      version: firstString(template.version),
+      bodyKey,
+      endpointPath,
+      source: 'custom',
+    }),
+  }
+}
+
+function listDocumentTemplates(system) {
+  const templates = system && system.config ? system.config.documentTemplates : undefined
+  if (templates === undefined || templates === null) return []
+  if (!Array.isArray(templates)) {
+    throw new HttpRouteError(400, 'INVALID_DOCUMENT_TEMPLATES', 'config.documentTemplates must be an array', {
+      field: 'config.documentTemplates',
+    })
+  }
+  return templates.map((template, index) => normalizeDocumentTemplate(template, index))
+}
+
+function findDocumentTemplate(system, object) {
+  return listDocumentTemplates(system).find((template) => template.object === object || template.name === object) || null
+}
+
+function normalizePreviewFieldMappings(value) {
+  if (!Array.isArray(value)) {
+    throw new HttpRouteError(400, 'INVALID_TEMPLATE_PREVIEW', 'fieldMappings must be an array', { field: 'fieldMappings' })
+  }
+  return value
+}
+
+function normalizePreviewBodyKey(value) {
+  const bodyKey = firstString(value) || 'Data'
+  if (DANGEROUS_JSON_KEYS.has(bodyKey)) {
+    throw new HttpRouteError(400, 'INVALID_TEMPLATE_PREVIEW', 'template.bodyKey is unsafe', { field: 'template.bodyKey' })
+  }
+  if (/[\u0000-\u001F\u007F]/.test(bodyKey)) {
+    throw new HttpRouteError(400, 'INVALID_TEMPLATE_PREVIEW', 'template.bodyKey must be a safe JSON key', { field: 'template.bodyKey' })
+  }
+  return bodyKey
+}
+
+function normalizePreviewTemplate(value) {
+  if (value === undefined || value === null) {
+    return {
+      bodyKey: 'Data',
+      schema: [],
+      meta: { bodyKey: 'Data' },
+    }
+  }
+  if (!isPlainObject(value)) {
+    throw new HttpRouteError(400, 'INVALID_TEMPLATE_PREVIEW', 'template must be an object', { field: 'template' })
+  }
+  const endpointPath = assertRelativeTemplatePath(
+    firstString(value.endpointPath, value.savePath, value.path),
+    'template.endpointPath',
+  )
+  const bodyKey = normalizePreviewBodyKey(value.bodyKey)
+  return {
+    bodyKey,
+    schema: normalizeTemplateSchema(value.schema, 'template'),
+    meta: sanitizeIntegrationPayload({
+      id: firstString(value.id),
+      version: firstString(value.version),
+      documentType: firstString(value.documentType, value.object, value.targetObject),
+      bodyKey,
+      endpointPath,
+    }),
+  }
+}
+
+function schemaRequiredErrors(record, schema) {
+  const errors = []
+  for (const field of schema || []) {
+    if (field && field.required === true) {
+      const value = getPath(record, field.name)
+      if (value === undefined || value === null || (typeof value === 'string' && value.trim() === '')) {
+        errors.push({
+          field: field.name,
+          code: 'REQUIRED',
+          message: `${field.label || field.name} is required`,
+          value,
+          rule: 'required',
+          details: { source: 'template.schema' },
+        })
+      }
+    }
+  }
+  return errors
+}
+
+function projectRecordForTemplate(record, schema) {
+  if (!Array.isArray(schema) || schema.length === 0) return record
+  const projected = {}
+  for (const field of schema) {
+    const value = getPath(record, field.name)
+    if (value !== undefined) setPath(projected, field.name, value)
+  }
+  return projected
+}
+
+function buildTemplatePreview(input) {
+  if (!isPlainObject(input)) {
+    throw new HttpRouteError(400, 'INVALID_TEMPLATE_PREVIEW', 'input must be an object')
+  }
+  if (!isPlainObject(input.sourceRecord)) {
+    throw new HttpRouteError(400, 'INVALID_TEMPLATE_PREVIEW', 'sourceRecord must be an object', { field: 'sourceRecord' })
+  }
+  const fieldMappings = normalizePreviewFieldMappings(input.fieldMappings)
+  const template = normalizePreviewTemplate(input.template)
+  const transformed = transformRecord(input.sourceRecord, fieldMappings)
+  const validation = transformed.ok ? validateRecord(transformed.value, fieldMappings) : { ok: true, valid: true, errors: [] }
+  const requiredErrors = transformed.ok ? schemaRequiredErrors(transformed.value, template.schema) : []
+  const targetRecord = projectRecordForTemplate(transformed.value, template.schema)
+  const payload = {
+    [template.bodyKey]: cloneJson(targetRecord),
+  }
+  const errors = [
+    ...transformed.errors,
+    ...validation.errors,
+    ...requiredErrors,
+  ].map((error) => cloneJson(error))
+  return sanitizeIntegrationPayload({
+    valid: errors.length === 0,
+    payload,
+    targetRecord: cloneJson(targetRecord),
+    errors,
+    transformErrors: transformed.errors.map((error) => cloneJson(error)),
+    validationErrors: validation.errors.map((error) => cloneJson(error)),
+    schemaErrors: requiredErrors.map((error) => cloneJson(error)),
+    template: template.meta,
+  })
 }
 
 function sanitizeTestConnectionResult(result) {
@@ -360,6 +638,11 @@ function createHandlers(services) {
       })
     },
 
+    async adaptersList(req, res) {
+      requireAccess(req, 'read')
+      return sendOk(res, adapterRegistry.listAdapterKinds().map(describeAdapterKind))
+    },
+
     async externalSystemsList(req, res) {
       requireAccess(req, 'read')
       const query = requestQuery(req)
@@ -399,6 +682,49 @@ function createHandlers(services) {
         ...result,
         system: redactSystemForTest(updatedSystem),
       })
+    },
+
+    async externalSystemObjects(req, res) {
+      requireAccess(req, 'read')
+      const loadSystem = typeof externalSystems.getExternalSystemForAdapter === 'function'
+        ? externalSystems.getExternalSystemForAdapter.bind(externalSystems)
+        : externalSystems.getExternalSystem.bind(externalSystems)
+      const system = await loadSystem(scopedInput(req, { id: requestParams(req).id }))
+      const adapter = adapterRegistry.createAdapter(system)
+      const adapterObjects = typeof adapter.listObjects === 'function'
+        ? await adapter.listObjects()
+        : []
+      const documentTemplateObjects = listDocumentTemplates(system)
+      return sendOk(res, sanitizeIntegrationPayload([
+        ...(Array.isArray(adapterObjects) ? adapterObjects : []),
+        ...documentTemplateObjects,
+      ]))
+    },
+
+    async externalSystemSchema(req, res) {
+      requireAccess(req, 'read')
+      const query = requestQuery(req)
+      const object = firstString(query.object, query.name)
+      if (!object) {
+        throw new HttpRouteError(400, 'OBJECT_REQUIRED', 'object is required')
+      }
+      const loadSystem = typeof externalSystems.getExternalSystemForAdapter === 'function'
+        ? externalSystems.getExternalSystemForAdapter.bind(externalSystems)
+        : externalSystems.getExternalSystem.bind(externalSystems)
+      const system = await loadSystem(scopedInput(req, { id: requestParams(req).id }))
+      const template = findDocumentTemplate(system, object)
+      if (template) {
+        return sendOk(res, sanitizeIntegrationPayload({
+          object: template.object,
+          fields: template.schema,
+          template: template.template,
+        }))
+      }
+      const adapter = adapterRegistry.createAdapter(system)
+      const schema = typeof adapter.getSchema === 'function'
+        ? await adapter.getSchema({ object })
+        : { object, fields: [] }
+      return sendOk(res, sanitizeIntegrationPayload(schema))
     },
 
     async pipelinesList(req, res) {
@@ -451,6 +777,11 @@ function createHandlers(services) {
         triggeredBy: 'api',
         dryRun: true,
       })), 200)
+    },
+
+    async templatesPreview(req, res) {
+      requireAccess(req, 'write')
+      return sendOk(res, buildTemplatePreview(requestBody(req)))
     },
 
     async stagingDescriptors(req, res) {


### PR DESCRIPTION
## Summary

Adds the generic integration workbench for CRM/PLM/ERP/SRM-style data cleansing flows while keeping K3 WISE as the first preset.

Included:
- backend discovery APIs for adapters, external-system objects, and schemas
- template preview API using the existing transform engine and validator
- same-system bidirectional pipeline coverage
- SQL/K3 WISE advanced-channel metadata and guardrail discovery
- frontend `/integrations/workbench` route with source/target selection, object/schema discovery, mapping grid, payload preview, pipeline save, dry-run, Save-only run, staging selector, and run/dead-letter observation
- K3 WISE preset page link into the generic workbench
- development/verification/TODO docs for the workbench slices

## Verification

- `node plugins/plugin-integration-core/__tests__/http-routes.test.cjs`
- `node plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs`
- `pnpm -F plugin-integration-core test`
- `pnpm --filter @metasheet/web exec vitest run tests/integrationWorkbench.spec.ts tests/IntegrationWorkbenchView.spec.ts --watch=false`
- `pnpm --filter @metasheet/web exec vitest run tests/k3WiseSetup.spec.ts tests/IntegrationK3WiseSetupView.spec.ts --watch=false`
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit`
- `pnpm --filter @metasheet/web build`
- `git diff --check`

All passed locally. Vite still reports the existing dynamic/static import and chunk-size warnings. One workbench Vitest run emitted the existing local WebSocket port warning, but the tests passed.

## Deployment impact

No new DB migration. No raw SQL UI. No backend write path beyond existing integration pipeline routes. Save-only runs stay explicitly gated in the frontend and force `autoSubmit=false`, `autoAudit=false`.

## Notes

Unrelated local untracked files were left untouched.
