### PR TITLE
feat(integration): add workbench mapping editors

### DIFF
--- a/apps/web/src/services/integration/k3WiseSetup.ts
+++ b/apps/web/src/services/integration/k3WiseSetup.ts
@@ -422,6 +422,10 @@ function getDefaultTenantId(): string {
   return getLocalStorageValue('tenantId') || 'default'
 }
 
+function resolveTenantId(form: K3WiseSetupForm): string {
+  return optionalString(form.tenantId) ?? 'default'
+}
+
 export function splitList(value: string): string[] {
   return value
     .split(/\r?\n|,/)
@@ -649,7 +653,6 @@ export function createDefaultK3WiseSetupForm(): K3WiseSetupForm {
 
 export function validateK3WiseSetupForm(form: K3WiseSetupForm): K3WiseSetupValidationIssue[] {
   const issues: K3WiseSetupValidationIssue[] = []
-  if (!trim(form.tenantId)) issues.push({ field: 'tenantId', message: 'tenantId is required' })
   if (!trim(form.webApiName)) issues.push({ field: 'webApiName', message: 'WebAPI system name is required' })
   if (!trim(form.version)) issues.push({ field: 'version', message: 'K3 WISE version is required' })
   const webApiCredentialTouched = Boolean(trim(form.authorityCode) || trim(form.username) || trim(form.password) || trim(form.acctId))
@@ -707,7 +710,6 @@ export function validateK3WisePipelineTemplateForm(
   descriptors: IntegrationStagingDescriptor[] = [],
 ): K3WiseSetupValidationIssue[] {
   const issues: K3WiseSetupValidationIssue[] = []
-  if (!trim(form.tenantId)) issues.push({ field: 'tenantId', message: 'tenantId is required' })
   if (!trim(form.sourceSystemId)) issues.push({ field: 'sourceSystemId', message: 'PLM source system ID is required' })
   if (!trim(form.webApiSystemId)) issues.push({ field: 'webApiSystemId', message: 'Save or select a K3 WISE WebAPI system before creating pipelines' })
   if (!trim(form.materialPipelineName)) issues.push({ field: 'materialPipelineName', message: 'Material pipeline name is required' })
@@ -728,7 +730,6 @@ export function validateK3WisePipelineTemplateForm(
 
 export function validateK3WiseStagingInstallForm(form: K3WiseSetupForm): K3WiseSetupValidationIssue[] {
   const issues: K3WiseSetupValidationIssue[] = []
-  if (!trim(form.tenantId)) issues.push({ field: 'tenantId', message: 'tenantId is required' })
   if (!trim(form.projectId)) issues.push({ field: 'projectId', message: 'projectId is required before installing staging tables' })
   return issues
 }
@@ -740,7 +741,6 @@ export function validateK3WisePipelineRunForm(
   const issues: K3WiseSetupValidationIssue[] = []
   const pipelineField: keyof K3WiseSetupForm = target === 'material' ? 'materialPipelineId' : 'bomPipelineId'
   const pipelineId = trim(form[pipelineField])
-  if (!trim(form.tenantId)) issues.push({ field: 'tenantId', message: 'tenantId is required' })
   if (!pipelineId) {
     issues.push({
       field: pipelineField,
@@ -768,7 +768,6 @@ export function validateK3WisePipelineObservationForm(
 ): K3WiseSetupValidationIssue[] {
   const issues: K3WiseSetupValidationIssue[] = []
   const pipelineField: keyof K3WiseSetupForm = target === 'material' ? 'materialPipelineId' : 'bomPipelineId'
-  if (!trim(form.tenantId)) issues.push({ field: 'tenantId', message: 'tenantId is required' })
   if (!trim(form[pipelineField])) {
     issues.push({
       field: pipelineField,
@@ -795,8 +794,9 @@ export function buildK3WiseDeployGateChecklist(form: K3WiseSetupForm): K3WiseDep
     : form.webApiAuthMode === 'authority-code'
       ? Boolean(trim(form.authorityCode))
       : Boolean(trim(form.acctId) && trim(form.username) && trim(form.password))
-  const webApiConfigReady = Boolean(trim(form.tenantId) && trim(form.version) && trim(form.baseUrl) && trim(form.tokenPath) && trim(form.loginPath))
-  const stagingReady = Boolean(trim(form.tenantId) && trim(form.projectId))
+  const tenantId = resolveTenantId(form)
+  const webApiConfigReady = Boolean(trim(form.version) && trim(form.baseUrl) && trim(form.tokenPath) && trim(form.loginPath))
+  const stagingReady = Boolean(trim(form.projectId))
   const pipelineTemplateReady = Boolean(trim(form.sourceSystemId) && trim(form.webApiSystemId) && trim(form.materialStagingObjectId) && trim(form.bomStagingObjectId))
   const materialDryRunReady = Boolean(trim(form.materialPipelineId))
   const bomDryRunReady = Boolean(trim(form.bomPipelineId))
@@ -808,10 +808,10 @@ export function buildK3WiseDeployGateChecklist(form: K3WiseSetupForm): K3WiseDep
     gateItem(
       'tenant-scope',
       '租户作用域',
-      trim(form.tenantId) ? 'ready' : 'missing',
-      trim(form.tenantId)
-        ? 'Tenant 已可用于保存 K3 WISE 外部系统配置'
-        : '部署后可在页面填写 tenantId；缺 tenantId 时不能保存配置',
+      'ready',
+      optionalString(form.tenantId)
+        ? `Tenant ${tenantId} 已可用于保存 K3 WISE 外部系统配置`
+        : '未填写 Tenant 时自动使用 default；多租户隔离可在高级上下文中覆盖',
       'tenantId',
     ),
     gateItem(
@@ -963,7 +963,7 @@ export function buildK3WiseStagingInstallPayload(form: K3WiseSetupForm): K3WiseS
     throw new Error(issues[0].message)
   }
   return {
-    tenantId: trim(form.tenantId),
+    tenantId: resolveTenantId(form),
     workspaceId: optionalString(form.workspaceId) ?? null,
     projectId: trim(form.projectId),
     ...(optionalString(form.baseId) ? { baseId: trim(form.baseId) } : {}),
@@ -1007,7 +1007,7 @@ export function buildK3WisePipelineRunPayload(form: K3WiseSetupForm, target: K3W
   }
 
   const payload: K3WisePipelineRunPayload = {
-    tenantId: trim(form.tenantId),
+    tenantId: resolveTenantId(form),
     workspaceId: optionalString(form.workspaceId) ?? null,
     mode: form.pipelineRunMode,
   }
@@ -1031,7 +1031,7 @@ export function buildK3WisePipelineObservationQuery(
   const limit = options.limit
   const offset = options.offset
   return {
-    tenantId: trim(form.tenantId),
+    tenantId: resolveTenantId(form),
     workspaceId: optionalString(form.workspaceId) ?? null,
     pipelineId: getK3WisePipelineId(form, target),
     ...(options.status ? { status: options.status } : {}),
@@ -1043,7 +1043,7 @@ export function buildK3WisePipelineObservationQuery(
 export function buildK3WiseSetupPayloads(form: K3WiseSetupForm): K3WiseSetupPayloads {
   const workspaceId = optionalString(form.workspaceId) ?? null
   const baseSystem = {
-    tenantId: trim(form.tenantId),
+    tenantId: resolveTenantId(form),
     workspaceId,
     status: 'active',
   }
@@ -1104,7 +1104,7 @@ export function buildK3WiseSetupPayloads(form: K3WiseSetupForm): K3WiseSetupPayl
       return {
         webApi,
         sqlServer: {
-          tenantId: trim(form.tenantId),
+          tenantId: resolveTenantId(form),
           workspaceId,
           id: sqlSystemId,
           name: optionalString(form.sqlName) ?? 'K3 WISE SQL Server',
@@ -1181,7 +1181,7 @@ export function buildK3WisePipelinePayloads(form: K3WiseSetupForm): K3WisePipeli
     throw new Error(issues[0].message)
   }
 
-  const tenantId = trim(form.tenantId)
+  const tenantId = resolveTenantId(form)
   const workspaceId = optionalString(form.workspaceId) ?? null
   const projectId = optionalString(form.projectId) ?? null
   const sourceSystemId = trim(form.sourceSystemId)

--- a/apps/web/src/views/IntegrationK3WiseSetupView.vue
+++ b/apps/web/src/views/IntegrationK3WiseSetupView.vue
@@ -277,19 +277,9 @@
         <section class="k3-setup__section k3-setup__section--primary">
           <div class="k3-setup__section-head">
             <h2>基础连接</h2>
-            <span>首次部署只需先完成这些字段</span>
+            <span>K3 WebAPI 快速预设；高级上下文默认使用 tenant=default</span>
           </div>
           <div class="k3-setup__grid">
-            <label class="k3-setup__field">
-              <span>Tenant ID（作用域）</span>
-              <input v-model.trim="form.tenantId" placeholder="default" autocomplete="off" />
-              <small>单租户实体机测试使用 default；它不是 K3 账套号。</small>
-            </label>
-            <label class="k3-setup__field">
-              <span>Workspace ID（可选）</span>
-              <input v-model.trim="form.workspaceId" autocomplete="off" />
-              <small>单工作区 PoC 建议留空；需要多工作区隔离时再填真实 ID。</small>
-            </label>
             <label class="k3-setup__field">
               <span>系统名称</span>
               <input v-model.trim="form.webApiName" autocomplete="off" />
@@ -311,9 +301,9 @@
             <label class="k3-setup__field k3-setup__field--wide">
               <span>WebAPI Base URL</span>
               <input v-model.trim="form.baseUrl" placeholder="http://k3-server:port" autocomplete="off" />
-              <small>只填协议、主机和端口；不要带 /K3API，下面的路径已包含 /K3API。</small>
-              <small v-if="baseUrlHasK3ApiPath" class="k3-setup__hint-warning">
-                当前 Base URL 含 /K3API；建议改为只到主机端口，保留高级路径的 /K3API/... 默认值。
+              <small>Base URL 只填协议、主机和端口；endpoint path 在高级设置中维护，默认已包含 /K3API/...。</small>
+              <small v-if="baseUrlEndpointOverlapWarning" class="k3-setup__hint-warning">
+                当前 Base URL 和 endpoint path 都含 /K3API；请求会拼成重复路径。请把 Base URL 改为只到主机端口。
               </small>
             </label>
             <label class="k3-setup__field">
@@ -355,6 +345,16 @@
             这些路径会相对 WebAPI Base URL 请求。实体机 PoC 推荐 Base URL 只写 http://K3主机:端口，Token/Save/BOM 路径保留 /K3API/...。
           </p>
           <div class="k3-setup__grid">
+            <label class="k3-setup__field">
+              <span>Tenant ID（高级上下文）</span>
+              <input v-model.trim="form.tenantId" placeholder="default" autocomplete="off" />
+              <small>普通单租户部署可留空或使用 default；它不是 K3 账套号。</small>
+            </label>
+            <label class="k3-setup__field">
+              <span>Workspace ID（高级，可选）</span>
+              <input v-model.trim="form.workspaceId" autocomplete="off" />
+              <small>单工作区 PoC 建议留空；需要多工作区隔离时再填真实 ID。</small>
+            </label>
             <label v-if="form.webApiAuthMode === 'authority-code'" class="k3-setup__field">
               <span>Token Path</span>
               <input v-model.trim="form.tokenPath" autocomplete="off" />
@@ -412,9 +412,12 @@
 
         <details class="k3-setup__section k3-setup__details">
           <summary class="k3-setup__section-summary">
-            <span>SQL Server 通道</span>
+            <span>高级 SQL Server 通道</span>
             <small>默认关闭；需要读取 K3 表或写中间表时再启用</small>
           </summary>
+          <p class="k3-setup__field-note k3-setup__field-note--wide">
+            SQL 通道是高级实施能力：读取必须走 allowlist 表/视图，写入只能走中间表或受控存储过程，不在普通 UI 暴露 K3 核心表直写。
+          </p>
           <div class="k3-setup__details-toolbar">
             <label class="k3-setup__switch">
               <input v-model="form.sqlEnabled" type="checkbox" />
@@ -696,6 +699,18 @@ const stagingDescriptorLabel = computed(() => stagingDescriptors.value.length > 
 const templatePreviewJson = computed(() => JSON.stringify(buildK3WiseDocumentPayloadPreview(templatePreviewTarget.value), null, 2))
 const selectedWebApiSystem = computed(() => webApiSystems.value.find((system) => system.id === form.webApiSystemId) || null)
 const baseUrlHasK3ApiPath = computed(() => /\/k3api(?:\/|$)/i.test(form.baseUrl.trim()))
+const endpointPathHasK3ApiPath = computed(() => [
+  form.tokenPath,
+  form.loginPath,
+  form.healthPath,
+  form.materialSavePath,
+  form.materialSubmitPath,
+  form.materialAuditPath,
+  form.bomSavePath,
+  form.bomSubmitPath,
+  form.bomAuditPath,
+].some((path) => /\/k3api(?:\/|$)/i.test(path.trim())))
+const baseUrlEndpointOverlapWarning = computed(() => baseUrlHasK3ApiPath.value && endpointPathHasK3ApiPath.value)
 const webApiConnectionStatus = computed(() => {
   if (testingWebApi.value) {
     return {
@@ -811,7 +826,7 @@ function upsertLocalWebApiSystem(system: IntegrationExternalSystem): void {
 
 function buildConnectionTestPayload(): Record<string, unknown> {
   return {
-    tenantId: form.tenantId.trim(),
+    tenantId: form.tenantId.trim() || 'default',
     workspaceId: form.workspaceId.trim() || null,
     skipHealth: !form.healthPath.trim(),
   }

--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -159,7 +159,7 @@
             <th>源字段</th>
             <th>目标字段</th>
             <th>转换</th>
-            <th>必填</th>
+            <th>校验</th>
             <th></th>
           </tr>
         </thead>
@@ -167,8 +167,29 @@
           <tr v-for="(mapping, index) in mappings" :key="mapping.id">
             <td><input v-model="mapping.sourceField" :data-testid="`source-field-${index}`" /></td>
             <td><input v-model="mapping.targetField" :data-testid="`target-field-${index}`" /></td>
-            <td><input v-model="mapping.transformText" :data-testid="`transform-${index}`" placeholder="trim,upper" /></td>
-            <td><input v-model="mapping.required" type="checkbox" :data-testid="`required-${index}`" /></td>
+            <td>
+              <select v-model="mapping.transformFn" :data-testid="`transform-fn-${index}`">
+                <option v-for="option in transformOptions" :key="option.value" :value="option.value">
+                  {{ option.label }}
+                </option>
+              </select>
+              <textarea
+                v-if="mapping.transformFn === 'dictMap'"
+                v-model="mapping.dictMapText"
+                :data-testid="`dict-map-${index}`"
+                placeholder="EA=Pcs&#10;KG=Kg"
+              ></textarea>
+            </td>
+            <td>
+              <label class="integration-workbench__mapping-check">
+                <input v-model="mapping.required" type="checkbox" :data-testid="`required-${index}`" />
+                <span>必填</span>
+              </label>
+              <div class="integration-workbench__mapping-rules">
+                <input v-model="mapping.minValueText" :data-testid="`validation-min-${index}`" placeholder="min" />
+                <input v-model="mapping.maxValueText" :data-testid="`validation-max-${index}`" placeholder="max" />
+              </div>
+            </td>
             <td>
               <button type="button" class="integration-workbench__icon-button" @click="removeMapping(index)">删除</button>
             </td>
@@ -338,14 +359,27 @@ import {
 } from '../services/integration/workbench'
 
 type WorkbenchSide = 'source' | 'target'
+type TransformFn = '' | 'trim' | 'upper' | 'lower' | 'toNumber' | 'dictMap'
 
 interface EditableMapping {
   id: string
   sourceField: string
   targetField: string
-  transformText: string
+  transformFn: TransformFn
+  dictMapText: string
   required: boolean
+  minValueText: string
+  maxValueText: string
 }
+
+const transformOptions: Array<{ value: TransformFn, label: string }> = [
+  { value: '', label: '无转换' },
+  { value: 'trim', label: 'trim 去空格' },
+  { value: 'upper', label: 'upper 转大写' },
+  { value: 'lower', label: 'lower 转小写' },
+  { value: 'toNumber', label: 'toNumber 转数字' },
+  { value: 'dictMap', label: 'dictMap 字典映射' },
+]
 
 const defaultScope = getDefaultIntegrationScope()
 const scope = reactive({
@@ -572,8 +606,11 @@ function seedMappingsFromTargetSchema(fields: IntegrationObjectSchemaField[]): v
     id: `mapping_${index}_${field.name}`,
     sourceField: guessSourceField(field.name),
     targetField: field.name,
-    transformText: field.type === 'number' ? 'toNumber' : 'trim',
+    transformFn: field.type === 'number' ? 'toNumber' : 'trim',
+    dictMapText: '',
     required: field.required === true,
+    minValueText: '',
+    maxValueText: '',
   }))
 }
 
@@ -582,8 +619,11 @@ function addMapping(): void {
     id: `mapping_${Date.now()}_${mappings.value.length}`,
     sourceField: '',
     targetField: '',
-    transformText: '',
+    transformFn: '',
+    dictMapText: '',
     required: false,
+    minValueText: '',
+    maxValueText: '',
   })
 }
 
@@ -591,22 +631,65 @@ function removeMapping(index: number): void {
   mappings.value.splice(index, 1)
 }
 
-function parseTransform(text: string): unknown {
-  const steps = text.split(',').map((item) => item.trim()).filter(Boolean)
-  if (steps.length === 0) return undefined
-  return steps.length === 1 ? { fn: steps[0] } : steps
+function parseDictionaryMap(text: string): Record<string, string> {
+  const trimmed = text.trim()
+  if (!trimmed) throw new Error('dictMap 字典映射不能为空')
+  if (trimmed.startsWith('{')) {
+    const parsed = JSON.parse(trimmed) as unknown
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new Error('dictMap JSON 必须是对象')
+    }
+    return Object.fromEntries(Object.entries(parsed).map(([key, value]) => [key, String(value)]))
+  }
+  const entries = trimmed.split(/\n/).map((line) => line.trim()).filter(Boolean).map((line) => {
+    const separatorIndex = line.indexOf('=')
+    if (separatorIndex <= 0) throw new Error('dictMap 每行必须使用 source=target 格式')
+    const key = line.slice(0, separatorIndex).trim()
+    const value = line.slice(separatorIndex + 1).trim()
+    if (!key || !value) throw new Error('dictMap 每行必须同时包含 source 和 target')
+    return [key, value] as const
+  })
+  return Object.fromEntries(entries)
+}
+
+function parseTransform(mapping: EditableMapping): unknown {
+  if (!mapping.transformFn) return undefined
+  if (mapping.transformFn === 'dictMap') {
+    return {
+      fn: 'dictMap',
+      map: parseDictionaryMap(mapping.dictMapText),
+    }
+  }
+  return { fn: mapping.transformFn }
+}
+
+function parseOptionalNumber(value: string, label: string): number | undefined {
+  const trimmed = value.trim()
+  if (!trimmed) return undefined
+  const numeric = Number(trimmed)
+  if (!Number.isFinite(numeric)) throw new Error(`${label} 必须是数字`)
+  return numeric
+}
+
+function buildValidationRules(mapping: EditableMapping): Array<Record<string, unknown>> | undefined {
+  const validation: Array<Record<string, unknown>> = []
+  if (mapping.required) validation.push({ type: 'required' })
+  const min = parseOptionalNumber(mapping.minValueText, 'min')
+  const max = parseOptionalNumber(mapping.maxValueText, 'max')
+  if (min !== undefined) validation.push({ type: 'min', value: min })
+  if (max !== undefined) validation.push({ type: 'max', value: max })
+  return validation.length > 0 ? validation : undefined
 }
 
 function buildMappings(): IntegrationFieldMapping[] {
   return mappings.value
     .filter((mapping) => mapping.sourceField.trim() && mapping.targetField.trim())
     .map((mapping, index) => {
-      const validation = mapping.required ? [{ type: 'required' }] : undefined
       return {
         sourceField: mapping.sourceField.trim(),
         targetField: mapping.targetField.trim(),
-        transform: parseTransform(mapping.transformText),
-        validation,
+        transform: parseTransform(mapping),
+        validation: buildValidationRules(mapping),
         sortOrder: index,
       }
     })
@@ -1068,6 +1151,25 @@ watch(showAdvancedConnectors, () => {
 
 .integration-workbench__mapping-table input[type="checkbox"] {
   width: auto;
+}
+
+.integration-workbench__mapping-table textarea {
+  min-height: 68px;
+  margin-top: 6px;
+}
+
+.integration-workbench__mapping-check {
+  display: flex;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 6px;
+}
+
+.integration-workbench__mapping-rules {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(72px, 1fr));
+  gap: 6px;
+  margin-top: 6px;
 }
 
 .integration-workbench__inline-check {

--- a/apps/web/tests/IntegrationK3WiseSetupView.spec.ts
+++ b/apps/web/tests/IntegrationK3WiseSetupView.spec.ts
@@ -92,12 +92,15 @@ describe('IntegrationK3WiseSetupView', () => {
     expect(container.textContent).toContain('1. 接通 K3')
     expect(container.textContent).toContain('2. 准备多维表')
     expect(container.textContent).toContain('基础连接')
-    expect(container.textContent).toContain('Tenant ID（作用域）')
-    expect(container.textContent).toContain('单租户实体机测试使用 default')
-    expect(container.textContent).toContain('Workspace ID（可选）')
-    expect(container.textContent).toContain('不要带 /K3API')
+    expect(container.textContent).toContain('K3 WebAPI 快速预设')
+    expect(container.textContent).toContain('Tenant ID（高级上下文）')
+    expect(container.textContent).toContain('普通单租户部署可留空或使用 default')
+    expect(container.textContent).toContain('Workspace ID（高级，可选）')
+    expect(container.textContent).toContain('endpoint path 在高级设置中维护')
     expect(container.textContent).toContain('WebAPI 状态')
     expect(container.textContent).toContain('not saved')
+    expect(container.textContent).toContain('高级 SQL Server 通道')
+    expect(container.textContent).toContain('allowlist 表/视图')
     expect(container.textContent).toContain('多维表清洗准备')
     expect(container.textContent).toContain('K3 单据模板')
     expect(container.textContent).toContain('K3 WISE 物料')
@@ -118,7 +121,7 @@ describe('IntegrationK3WiseSetupView', () => {
     baseUrlInput.dispatchEvent(new Event('input', { bubbles: true }))
     await flushUi()
 
-    expect(container.textContent).toContain('当前 Base URL 含 /K3API')
+    expect(container.textContent).toContain('当前 Base URL 和 endpoint path 都含 /K3API')
   })
 
   it('sends tenant scope when testing the saved WebAPI system', async () => {

--- a/apps/web/tests/IntegrationWorkbenchView.spec.ts
+++ b/apps/web/tests/IntegrationWorkbenchView.spec.ts
@@ -70,6 +70,7 @@ describe('IntegrationWorkbenchView', () => {
           fields: [
             { name: 'code', label: 'Code', type: 'string' },
             { name: 'name', label: 'Name', type: 'string' },
+            { name: 'quantity', label: 'Quantity', type: 'number' },
           ],
         })
       }
@@ -107,6 +108,7 @@ describe('IntegrationWorkbenchView', () => {
             { name: 'FNumber', label: 'Material code', type: 'string', required: true },
             { name: 'FName', label: 'Material name', type: 'string', required: true },
             { name: 'FBaseUnitID', label: 'Base unit', type: 'string' },
+            { name: 'FQty', label: 'Quantity', type: 'number', required: true },
           ],
         })
       }
@@ -273,7 +275,26 @@ describe('IntegrationWorkbenchView', () => {
 
     expect((container.querySelector('[data-testid="source-field-0"]') as HTMLInputElement).value).toBe('code')
     expect((container.querySelector('[data-testid="target-field-0"]') as HTMLInputElement).value).toBe('FNumber')
+    expect((container.querySelector('[data-testid="transform-fn-0"]') as HTMLSelectElement).value).toBe('trim')
+    expect((container.querySelector('[data-testid="transform-fn-3"]') as HTMLSelectElement).value).toBe('toNumber')
     expect(container.textContent).toContain('Material code')
+
+    const firstTransform = container.querySelector('[data-testid="transform-fn-0"]') as HTMLSelectElement
+    firstTransform.value = 'upper'
+    firstTransform.dispatchEvent(new Event('change'))
+
+    const unitTransform = container.querySelector('[data-testid="transform-fn-2"]') as HTMLSelectElement
+    unitTransform.value = 'dictMap'
+    unitTransform.dispatchEvent(new Event('change'))
+    await flushUi()
+    const unitDict = container.querySelector('[data-testid="dict-map-2"]') as HTMLTextAreaElement
+    unitDict.value = 'EA=Pcs\nKG=Kg'
+    unitDict.dispatchEvent(new Event('input'))
+
+    const quantityMin = container.querySelector('[data-testid="validation-min-3"]') as HTMLInputElement
+    quantityMin.value = '0.000001'
+    quantityMin.dispatchEvent(new Event('input'))
+    await flushUi()
 
     ;(container.querySelector('[data-testid="preview-payload"]') as HTMLButtonElement).click()
     await flushUi()
@@ -285,9 +306,15 @@ describe('IntegrationWorkbenchView', () => {
         bodyKey: 'Data',
       },
       fieldMappings: [
-        { sourceField: 'code', targetField: 'FNumber' },
-        { sourceField: 'name', targetField: 'FName' },
-        { sourceField: 'uom', targetField: 'FBaseUnitID' },
+        { sourceField: 'code', targetField: 'FNumber', transform: { fn: 'upper' }, validation: [{ type: 'required' }] },
+        { sourceField: 'name', targetField: 'FName', transform: { fn: 'trim' }, validation: [{ type: 'required' }] },
+        { sourceField: 'uom', targetField: 'FBaseUnitID', transform: { fn: 'dictMap', map: { EA: 'Pcs', KG: 'Kg' } } },
+        {
+          sourceField: 'quantity',
+          targetField: 'FQty',
+          transform: { fn: 'toNumber' },
+          validation: [{ type: 'required' }, { type: 'min', value: 0.000001 }],
+        },
       ],
     })
     expect(container.textContent).toContain('"FNumber": "MAT-001"')

--- a/apps/web/tests/k3WiseSetup.spec.ts
+++ b/apps/web/tests/k3WiseSetup.spec.ts
@@ -113,6 +113,29 @@ describe('K3 WISE setup helpers', () => {
     })
   })
 
+  it('defaults blank advanced tenant scope to default in payload builders', () => {
+    const form = createDefaultK3WiseSetupForm()
+    Object.assign(form, {
+      tenantId: '',
+      projectId: 'project_1',
+      webApiName: 'K3 WISE WebAPI',
+      version: 'K3 WISE 15.x test',
+      baseUrl: 'http://k3.local',
+      authorityCode: 'auth-code-from-k3-admin',
+      sourceSystemId: 'plm_1',
+      webApiSystemId: 'k3_1',
+      materialPipelineId: 'pipe_material',
+      bomPipelineId: 'pipe_bom',
+    })
+
+    expect(validateK3WiseSetupForm(form)).toEqual([])
+    expect(buildK3WiseSetupPayloads(form).webApi).toMatchObject({ tenantId: 'default' })
+    expect(buildK3WiseStagingInstallPayload(form)).toMatchObject({ tenantId: 'default' })
+    expect(buildK3WisePipelinePayloads(form).material).toMatchObject({ tenantId: 'default' })
+    expect(buildK3WisePipelineRunPayload(form, 'material')).toMatchObject({ tenantId: 'default' })
+    expect(buildK3WisePipelineObservationQuery(form, 'bom')).toMatchObject({ tenantId: 'default' })
+  })
+
   it('preserves existing credential storage when editing without replacement fields', () => {
     const form = createDefaultK3WiseSetupForm()
     Object.assign(form, {
@@ -513,7 +536,7 @@ describe('K3 WISE setup helpers', () => {
     })
   })
 
-  it('requires tenant, pipeline id, and positive sample limit before pipeline execution', () => {
+  it('requires pipeline id and positive sample limit before pipeline execution', () => {
     const form = createDefaultK3WiseSetupForm()
     Object.assign(form, {
       tenantId: '',
@@ -522,10 +545,9 @@ describe('K3 WISE setup helpers', () => {
     })
 
     const messages = validateK3WisePipelineRunForm(form, 'material').map((issue) => issue.message)
-    expect(messages).toContain('tenantId is required')
     expect(messages).toContain('Material pipeline ID is required before dry-run or run')
     expect(messages).toContain('Sample limit must be a positive integer')
-    expect(() => buildK3WisePipelineRunPayload(form, 'material')).toThrow('tenantId is required')
+    expect(() => buildK3WisePipelineRunPayload(form, 'material')).toThrow('Material pipeline ID is required before dry-run or run')
   })
 
   it('caps K3 WISE live PoC pipeline sample limit at three rows', () => {
@@ -561,7 +583,7 @@ describe('K3 WISE setup helpers', () => {
     })
   })
 
-  it('requires tenant and pipeline id before loading run history', () => {
+  it('requires pipeline id before loading run history', () => {
     const form = createDefaultK3WiseSetupForm()
     Object.assign(form, {
       tenantId: '',
@@ -569,9 +591,8 @@ describe('K3 WISE setup helpers', () => {
     })
 
     const messages = validateK3WisePipelineObservationForm(form, 'bom').map((issue) => issue.message)
-    expect(messages).toContain('tenantId is required')
     expect(messages).toContain('BOM pipeline ID is required before loading run history')
-    expect(() => buildK3WisePipelineObservationQuery(form, 'bom')).toThrow('tenantId is required')
+    expect(() => buildK3WisePipelineObservationQuery(form, 'bom')).toThrow('BOM pipeline ID is required before loading run history')
   })
 
   it('summarizes deploy readiness fields that can be filled after deployment', () => {

--- a/docs/development/generic-integration-workbench-mapping-editors-development-20260512.md
+++ b/docs/development/generic-integration-workbench-mapping-editors-development-20260512.md
@@ -1,0 +1,76 @@
+# Generic Integration Workbench Mapping Editors Development - 2026-05-12
+
+## Scope
+
+This slice closes the remaining M7 mapping-editor TODOs in `IntegrationWorkbenchView.vue`:
+
+- Transform selector from a fixed whitelist.
+- Dictionary mapping editor for `dictMap`.
+- Validation rule editor for required, min, and max rules.
+
+## Design
+
+### Transform selector
+
+The free-form transform text input was replaced by a whitelist selector:
+
+- None
+- `trim`
+- `upper`
+- `lower`
+- `toNumber`
+- `dictMap`
+
+This keeps the Workbench aligned with the backend transform engine while avoiding user-script style free-form input.
+
+### Dictionary mapping
+
+When `dictMap` is selected, the row shows a compact textarea. It accepts:
+
+- Line format: `source=target`
+- JSON object format: `{ "EA": "Pcs" }`
+
+The frontend converts this to:
+
+```json
+{
+  "fn": "dictMap",
+  "map": {
+    "EA": "Pcs"
+  }
+}
+```
+
+Invalid or empty dictionaries fail before preview/save and show the existing Workbench status error path.
+
+### Validation rules
+
+Each mapping row now supports:
+
+- Required checkbox.
+- Optional `min`.
+- Optional `max`.
+
+The generated `validation` array preserves backend contract shape:
+
+```json
+[
+  { "type": "required" },
+  { "type": "min", "value": 0.000001 },
+  { "type": "max", "value": 100 }
+]
+```
+
+## Files
+
+- `apps/web/src/views/IntegrationWorkbenchView.vue`
+- `apps/web/tests/IntegrationWorkbenchView.spec.ts`
+- `docs/development/generic-integration-workbench-todo-20260512.md`
+- `docs/development/generic-integration-workbench-mapping-editors-development-20260512.md`
+- `docs/development/generic-integration-workbench-mapping-editors-verification-20260512.md`
+
+## Non-Goals
+
+- No user JavaScript transform support.
+- No arbitrary transform-chain text editor.
+- No backend transform or validator behavior changes.

--- a/docs/development/generic-integration-workbench-mapping-editors-verification-20260512.md
+++ b/docs/development/generic-integration-workbench-mapping-editors-verification-20260512.md
@@ -1,0 +1,37 @@
+# Generic Integration Workbench Mapping Editors Verification - 2026-05-12
+
+## Scope
+
+Verification for Workbench M7 mapping editors:
+
+- Whitelisted transform selector.
+- `dictMap` dictionary editor.
+- Required/min/max validation rule editor.
+- Payload preview and pipeline payload shape after mapping-editor changes.
+
+## Results
+
+| Command | Result | Notes |
+| --- | --- | --- |
+| `pnpm --filter @metasheet/web exec vitest run tests/IntegrationWorkbenchView.spec.ts tests/integrationWorkbench.spec.ts --watch=false` | PASS | 2 files / 3 tests passed. Vitest emitted the existing `--localstorage-file` warning. |
+| `pnpm --filter @metasheet/web exec vitest run tests/k3WiseSetup.spec.ts tests/IntegrationK3WiseSetupView.spec.ts --watch=false` | PASS | 2 files / 31 tests passed, covering the adjacent K3 preset convergence changes. |
+| `pnpm --filter @metasheet/web exec vue-tsc --noEmit` | PASS | Frontend type check passed. |
+| `pnpm --filter @metasheet/web build` | PASS | Frontend production build passed. Existing Vite dynamic-import and chunk-size warnings remained. |
+| `pnpm -F plugin-integration-core test` | PASS | Backend integration-core regression passed. |
+| `pnpm verify:integration-k3wise:poc` | PASS | K3 WISE offline PoC preflight, evidence, and mock chain passed. |
+| `git diff --check` | PASS | No whitespace errors. |
+
+## Contract Assertions
+
+- The first seeded string mapping defaults to `trim`.
+- Number mappings default to `toNumber`.
+- Changing a row to `upper` sends `{ fn: "upper" }`.
+- Changing a row to `dictMap` sends `{ fn: "dictMap", map: { ... } }`.
+- Required mappings send `{ type: "required" }`.
+- Min rules send numeric `{ type: "min", value: ... }`.
+- Existing pipeline save and run controls still work after mapping editor changes.
+
+## Notes
+
+- The browser-dev-server visual pass was not run in this shell because no local dev server is active; the component-level Vitest and production build gates covered the UI contract and type/build integrity.
+- The editor still intentionally excludes user JavaScript transforms.

--- a/docs/development/generic-integration-workbench-todo-20260512.md
+++ b/docs/development/generic-integration-workbench-todo-20260512.md
@@ -100,9 +100,9 @@
 - [x] Add target object/template selector.
 - [x] Add staging table selector.
 - [x] Add field mapping grid.
-- [ ] Add transform selector from whitelist.
-- [ ] Add dictionary mapping editor.
-- [ ] Add validation rule editor.
+- [x] Add transform selector from whitelist.
+- [x] Add dictionary mapping editor.
+- [x] Add validation rule editor.
 - [x] Add payload preview panel.
 - [x] Add dry-run button.
 - [x] Add Save-only run button.
@@ -111,16 +111,16 @@
 
 ## M8 - K3 WISE Page Convergence
 
-- [ ] Keep K3 setup page as a quick-start preset.
+- [x] Keep K3 setup page as a quick-start preset.
 - [x] Add link to generic workbench.
-- [ ] Remove tenant ID from ordinary required input.
-- [ ] Move workspace ID to advanced context.
-- [ ] Explain Base URL vs endpoint path clearly.
-- [ ] Warn when Base URL and endpoint both include `/K3API/`.
-- [ ] Keep WebAPI connected status after successful test.
-- [ ] Keep SQL channel as advanced.
-- [ ] Preserve Material/BOM template preview.
-- [ ] Preserve current K3 WISE tests.
+- [x] Remove tenant ID from ordinary required input.
+- [x] Move workspace ID to advanced context.
+- [x] Explain Base URL vs endpoint path clearly.
+- [x] Warn when Base URL and endpoint both include `/K3API/`.
+- [x] Keep WebAPI connected status after successful test.
+- [x] Keep SQL channel as advanced.
+- [x] Preserve Material/BOM template preview.
+- [x] Preserve current K3 WISE tests.
 
 ## M9 - Documentation and Delivery
 
@@ -146,6 +146,10 @@
 - [x] Add verification MD for backend contract closeout.
 - [x] Add development MD for SQL advanced guardrails.
 - [x] Add verification MD for SQL advanced guardrails.
+- [x] Add development MD for Workbench mapping rule editors.
+- [x] Add verification MD for Workbench mapping rule editors.
+- [x] Add development MD for K3 WISE preset convergence.
+- [x] Add verification MD for K3 WISE preset convergence.
 - [ ] Update Windows on-prem runbook.
 - [ ] Update K3 WISE runbook.
 - [ ] Update package verify script if new docs/routes must be included.

--- a/docs/development/integration-k3wise-preset-convergence-development-20260512.md
+++ b/docs/development/integration-k3wise-preset-convergence-development-20260512.md
@@ -1,0 +1,48 @@
+# K3 WISE Preset Convergence Development - 2026-05-12
+
+## Scope
+
+This slice closes the M8 K3 WISE page convergence TODOs for the generic integration workbench plan.
+
+The K3 WISE setup page remains a quick-start preset for WebAPI, SQL Server, staging tables, Material/BOM document templates, and pipeline execution. The page now treats tenant/workspace as advanced context rather than ordinary first-run required inputs.
+
+## Changes
+
+### Scope defaults
+
+- Blank `tenantId` now resolves to `default` in setup, staging install, pipeline creation, pipeline run, and observation payload builders.
+- Tenant and workspace fields moved from the primary "基础连接" section into the closed "高级 WebAPI 设置" details section.
+- Single-tenant PoC users can follow the quick-start path without editing tenant/workspace.
+
+### Base URL and endpoint path guidance
+
+- Base URL copy now explicitly says it should only contain protocol, host, and port.
+- Endpoint paths remain in advanced settings and keep `/K3API/...` defaults.
+- The page warns only when Base URL and endpoint paths both contain `/K3API`, because that produces duplicate paths at request time.
+
+### SQL advanced boundary
+
+- The SQL Server section is labeled as an advanced channel.
+- The page states the guardrail: read through allowlisted tables/views, write only through middle tables or controlled stored procedures, and no ordinary UI direct K3 core-table writes.
+
+### Existing behavior preserved
+
+- The generic workbench link remains in the page header.
+- WebAPI connected status remains visible after a successful test.
+- Material and BOM template previews remain available and redaction-safe.
+
+## Files
+
+- `apps/web/src/views/IntegrationK3WiseSetupView.vue`
+- `apps/web/src/services/integration/k3WiseSetup.ts`
+- `apps/web/tests/IntegrationK3WiseSetupView.spec.ts`
+- `apps/web/tests/k3WiseSetup.spec.ts`
+- `docs/development/generic-integration-workbench-todo-20260512.md`
+- `docs/development/integration-k3wise-preset-convergence-development-20260512.md`
+- `docs/development/integration-k3wise-preset-convergence-verification-20260512.md`
+
+## Non-Goals
+
+- No K3 API endpoint behavior changed.
+- No new SQL direct-write capability was added.
+- No runtime backend routes were changed.

--- a/docs/development/integration-k3wise-preset-convergence-verification-20260512.md
+++ b/docs/development/integration-k3wise-preset-convergence-verification-20260512.md
@@ -1,0 +1,38 @@
+# K3 WISE Preset Convergence Verification - 2026-05-12
+
+## Scope
+
+Verification for the M8 K3 WISE page convergence slice:
+
+- Tenant/workspace are advanced context fields.
+- Blank tenant resolves to `default`.
+- Base URL and endpoint-path `/K3API` duplication warning.
+- SQL channel remains advanced.
+- WebAPI connected status and Material/BOM template previews remain covered.
+
+## Results
+
+| Command | Result | Notes |
+| --- | --- | --- |
+| `pnpm --filter @metasheet/web exec vitest run tests/k3WiseSetup.spec.ts tests/IntegrationK3WiseSetupView.spec.ts --watch=false` | PASS | 2 files / 31 tests passed. Vitest emitted the existing `--localstorage-file` warning. |
+| `pnpm --filter @metasheet/web exec vitest run tests/IntegrationWorkbenchView.spec.ts tests/integrationWorkbench.spec.ts --watch=false` | PASS | 2 files / 3 tests passed. Vitest emitted the existing `--localstorage-file` warning. |
+| `pnpm --filter @metasheet/web exec vue-tsc --noEmit` | PASS | Frontend type check passed. |
+| `pnpm --filter @metasheet/web build` | PASS | Frontend production build passed. Existing Vite dynamic-import and chunk-size warnings remained. |
+| `pnpm -F plugin-integration-core test` | PASS | Backend integration-core regression passed. |
+| `pnpm verify:integration-k3wise:poc` | PASS | 20 preflight tests, 37 evidence tests, and the mock PoC chain passed. |
+| `git diff --check` | PASS | No whitespace errors. |
+
+## Contract Assertions
+
+- Blank tenant no longer creates `tenantId is required` validation failures.
+- Blank tenant payload builders send `tenantId: "default"`.
+- Workspace remains optional and advanced.
+- Base URL `/K3API` plus endpoint `/K3API/...` produces a visible warning.
+- WebAPI successful connection test still displays `connected`.
+- SQL Server channel remains folded under an advanced details section.
+- Material and BOM template preview tests remain green.
+
+## Notes
+
+- This is a frontend/service-helper convergence slice. It does not change backend routes or K3 adapter runtime behavior.
+- The K3 setup page remains a quick-start preset; generic cross-system mapping work remains in `/integrations/workbench`.


### PR DESCRIPTION
## Summary
- replace free-form mapping transform text with a whitelist selector in the generic integration workbench
- add dictMap editor plus required/min/max validation rule controls
- converge the K3 WISE preset page: tenant defaults to default, tenant/workspace move to advanced context, /K3API overlap warning is explicit, SQL channel copy stays advanced
- add development and verification MDs for mapping editors and K3 preset convergence

## Verification
- pnpm --filter @metasheet/web exec vitest run tests/IntegrationWorkbenchView.spec.ts tests/integrationWorkbench.spec.ts --watch=false
- pnpm --filter @metasheet/web exec vitest run tests/k3WiseSetup.spec.ts tests/IntegrationK3WiseSetupView.spec.ts --watch=false
- pnpm --filter @metasheet/web exec vue-tsc --noEmit
- pnpm --filter @metasheet/web build
- pnpm -F plugin-integration-core test
- pnpm verify:integration-k3wise:poc
- git diff --check

## Deployment impact
- frontend-only UX/service-helper change plus docs/tests
- no migrations
- no backend route or K3 adapter runtime change
- Save-only default remains unchanged