### PR TITLE
chore(integration): verify workbench onprem package contract

### DIFF
--- a/docs/development/generic-integration-workbench-package-proof-development-20260513.md
+++ b/docs/development/generic-integration-workbench-package-proof-development-20260513.md
@@ -1,0 +1,50 @@
+# Generic Integration Workbench Package Proof Development - 2026-05-13
+
+## Scope
+
+This slice adds a package-level guard for the generic integration workbench and K3 WISE quick-start delivery path.
+
+The previous delivery closeout ensured that runbooks and K3 postdeploy tools are copied into the on-prem package. This slice tightens the verifier so a downloaded `.tgz` or Windows `.zip` package also proves that the built frontend contains:
+
+- `/integrations/workbench`
+- `/integrations/k3-wise`
+- `dictMap` mapping editor support
+- Save-only execution copy
+
+It also keeps the operator documentation contract in the package verifier:
+
+- Windows on-prem guide documents both integration routes.
+- K3 internal-trial runbook documents SQL Server as an advanced channel.
+
+## Change
+
+Updated `scripts/ops/multitable-onprem-package-verify.sh` with `verify_generic_integration_workbench_contract()`.
+
+The new verifier checks:
+
+- `apps/web/dist` contains `/integrations/workbench`.
+- `apps/web/dist` contains `/integrations/k3-wise`.
+- `apps/web/dist` contains `dictMap`.
+- `apps/web/dist` contains `Save-only`.
+- `docs/deployment/multitable-windows-onprem-easy-start-20260319.md` documents `/integrations/workbench`.
+- `docs/deployment/multitable-windows-onprem-easy-start-20260319.md` documents `/integrations/k3-wise`.
+- `docs/operations/integration-k3wise-internal-trial-runbook.md` documents SQL Server as an advanced channel.
+
+## Why
+
+The package verifier already required the K3 operator scripts and runbooks, but it did not prove that the frontend route bundle actually shipped the workbench entry points. That left a small delivery gap: a package could pass content checks while still missing the operator UI route.
+
+This is intentionally a package verifier guard, not a runtime change.
+
+## Files
+
+- `scripts/ops/multitable-onprem-package-verify.sh`
+- `docs/development/generic-integration-workbench-package-proof-development-20260513.md`
+- `docs/development/generic-integration-workbench-package-proof-verification-20260513.md`
+
+## Non-Goals
+
+- No frontend source change.
+- No backend runtime change.
+- No migration.
+- No customer live K3 call.

--- a/docs/development/generic-integration-workbench-package-proof-verification-20260513.md
+++ b/docs/development/generic-integration-workbench-package-proof-verification-20260513.md
@@ -29,6 +29,8 @@ Result:
 | `scripts/ops/multitable-onprem-package-verify.sh output/releases/multitable-onprem/metasheet-multitable-onprem-v2.5.0-workbench-package-proof-20260513.tgz` | PASS | Verifier passed with the new frontend route and workbench contract checks. |
 | `scripts/ops/multitable-onprem-package-verify.sh output/releases/multitable-onprem/metasheet-multitable-onprem-v2.5.0-workbench-package-proof-20260513.zip` | PASS | Windows zip verifier passed with the new frontend route and workbench contract checks. |
 | `PACKAGE_JSON=output/releases/multitable-onprem/metasheet-multitable-onprem-v2.5.0-workbench-package-proof-20260513.json DELIVERY_OUTPUT_ROOT=output/delivery/multitable-onprem/workbench-package-proof-20260513 node scripts/ops/multitable-onprem-delivery-bundle.mjs` | PASS | Customer delivery bundle was generated from the package metadata. |
+| `find output/delivery/multitable-onprem/workbench-package-proof-20260513/metasheet-multitable-onprem-v2.5.0-workbench-package-proof-20260513/docs -maxdepth 1 -type f \| sort \| rg 'k3\|integration-k3wise\|multitable-windows\|onprem-customer'` | PASS | Confirmed the delivery bundle contains the K3 internal-trial, live-gate, preflight, Windows easy-start, and customer checklist docs. |
+| `git diff --check` | PASS | No whitespace errors in tracked changes. |
 
 ## Contract Assertions
 

--- a/docs/development/generic-integration-workbench-package-proof-verification-20260513.md
+++ b/docs/development/generic-integration-workbench-package-proof-verification-20260513.md
@@ -1,0 +1,57 @@
+# Generic Integration Workbench Package Proof Verification - 2026-05-13
+
+## Scope
+
+Verification for the package-level generic integration workbench and K3 WISE delivery guard.
+
+## Local Package Built
+
+```bash
+PACKAGE_TAG=workbench-package-proof-20260513 \
+INSTALL_DEPS=0 \
+BUILD_WEB=0 \
+BUILD_BACKEND=0 \
+scripts/ops/multitable-onprem-package-build.sh
+```
+
+Result:
+
+- `output/releases/multitable-onprem/metasheet-multitable-onprem-v2.5.0-workbench-package-proof-20260513.tgz`
+- `output/releases/multitable-onprem/metasheet-multitable-onprem-v2.5.0-workbench-package-proof-20260513.zip`
+- `output/releases/multitable-onprem/metasheet-multitable-onprem-v2.5.0-workbench-package-proof-20260513.json`
+- `output/releases/multitable-onprem/SHA256SUMS`
+
+## Results
+
+| Command | Result | Notes |
+| --- | --- | --- |
+| `bash -n scripts/ops/multitable-onprem-package-verify.sh` | PASS | Shell syntax check passed. |
+| `scripts/ops/multitable-onprem-package-verify.sh output/releases/multitable-onprem/metasheet-multitable-onprem-v2.5.0-workbench-package-proof-20260513.tgz` | PASS | Verifier passed with the new frontend route and workbench contract checks. |
+| `scripts/ops/multitable-onprem-package-verify.sh output/releases/multitable-onprem/metasheet-multitable-onprem-v2.5.0-workbench-package-proof-20260513.zip` | PASS | Windows zip verifier passed with the new frontend route and workbench contract checks. |
+| `PACKAGE_JSON=output/releases/multitable-onprem/metasheet-multitable-onprem-v2.5.0-workbench-package-proof-20260513.json DELIVERY_OUTPUT_ROOT=output/delivery/multitable-onprem/workbench-package-proof-20260513 node scripts/ops/multitable-onprem-delivery-bundle.mjs` | PASS | Customer delivery bundle was generated from the package metadata. |
+
+## Contract Assertions
+
+- Packaged `apps/web/dist` contains `/integrations/workbench`.
+- Packaged `apps/web/dist` contains `/integrations/k3-wise`.
+- Packaged `apps/web/dist` contains `dictMap`.
+- Packaged `apps/web/dist` contains `Save-only`.
+- Packaged Windows on-prem guide documents both integration routes.
+- Packaged K3 internal-trial runbook documents SQL Server as an advanced channel.
+- Delivery bundle includes K3 operator docs:
+  - `docs/k3-poc-onprem-preflight-runbook.md`
+  - `docs/integration-k3wise-internal-trial-runbook.md`
+  - `docs/integration-k3wise-live-gate-execution-package.md`
+
+## Generated Artifact Paths
+
+- Package proof release root: `output/releases/multitable-onprem/`
+- Verify reports: `output/releases/multitable-onprem/verify/`
+- Delivery bundle: `output/delivery/multitable-onprem/workbench-package-proof-20260513/metasheet-multitable-onprem-v2.5.0-workbench-package-proof-20260513/`
+
+These output artifacts are generated evidence and are not intended to be committed.
+
+## Notes
+
+- No customer K3 endpoint was contacted.
+- No secrets were used or written into tracked docs.

--- a/docs/development/generic-integration-workbench-todo-20260512.md
+++ b/docs/development/generic-integration-workbench-todo-20260512.md
@@ -155,6 +155,10 @@
 - [x] Update package verify script if new docs/routes must be included.
 - [x] Run K3 offline PoC.
 - [x] Run frontend build.
+- [x] Generate on-prem package archive for Workbench/K3 docs closeout.
+- [x] Verify on-prem package `.tgz` and `.zip` include required K3 runbooks and postdeploy smoke scripts.
+- [x] Add package-level verifier proof for packaged Workbench/K3 frontend routes and mapping editor copy.
+- [x] Generate customer delivery bundle and confirm K3 runbooks are included.
 
 ## Suggested Verification Commands
 

--- a/scripts/ops/multitable-onprem-package-verify.sh
+++ b/scripts/ops/multitable-onprem-package-verify.sh
@@ -84,6 +84,21 @@ function verify_migration_bridge_contract() {
   search_fixed_string 'must_change_password' "$timestamp_must_change" || die "timestamp users must_change_password bridge migration must be packaged"
 }
 
+function verify_generic_integration_workbench_contract() {
+  local root="$1"
+  local web_dist="${root}/apps/web/dist"
+  local easy_start="${root}/docs/deployment/multitable-windows-onprem-easy-start-20260319.md"
+  local k3_runbook="${root}/docs/operations/integration-k3wise-internal-trial-runbook.md"
+
+  search_fixed_string '/integrations/workbench' "$web_dist" || die "web dist must include the generic integration workbench route"
+  search_fixed_string '/integrations/k3-wise' "$web_dist" || die "web dist must include the K3 WISE setup route"
+  search_fixed_string 'dictMap' "$web_dist" || die "web dist must include the workbench dictionary mapping editor"
+  search_fixed_string 'Save-only' "$web_dist" || die "web dist must keep Save-only execution copy"
+  search_fixed_string '/integrations/workbench' "$easy_start" || die "Windows on-prem guide must document the generic integration workbench route"
+  search_fixed_string '/integrations/k3-wise' "$easy_start" || die "Windows on-prem guide must document the K3 WISE setup route"
+  search_fixed_string 'SQL Server is an advanced channel' "$k3_runbook" || die "K3 runbook must document SQL Server as an advanced channel"
+}
+
 function write_optional_report() {
   local checksum_status="SKIPPED"
   local link_status="SKIPPED"
@@ -322,6 +337,7 @@ bootstrap_run_wrapper="$(find "$pkg_root" -maxdepth 1 -type f -name 'bootstrap-a
 verify_windows_entrypoints "$pkg_root"
 verify_root_runtime_dependencies "$pkg_root"
 verify_migration_bridge_contract "$pkg_root"
+verify_generic_integration_workbench_contract "$pkg_root"
 
 if [[ "$VERIFY_NO_GITHUB_LINKS" == "1" ]]; then
   verify_no_github_links "$pkg_root"


### PR DESCRIPTION
## Summary
- add package verifier checks for packaged /integrations/workbench and /integrations/k3-wise frontend routes
- assert packaged workbench dist still contains dictionary mapping and Save-only copy
- document the package proof and mark the closeout TODO items complete

## Verification
- bash -n scripts/ops/multitable-onprem-package-verify.sh
- git diff --check
- scripts/ops/multitable-onprem-package-verify.sh output/releases/multitable-onprem/metasheet-multitable-onprem-v2.5.0-workbench-package-proof-20260513.tgz
- scripts/ops/multitable-onprem-package-verify.sh output/releases/multitable-onprem/metasheet-multitable-onprem-v2.5.0-workbench-package-proof-20260513.zip
- PACKAGE_JSON=output/releases/multitable-onprem/metasheet-multitable-onprem-v2.5.0-workbench-package-proof-20260513.json DELIVERY_OUTPUT_ROOT=output/delivery/multitable-onprem/workbench-package-proof-20260513 node scripts/ops/multitable-onprem-delivery-bundle.mjs

## Deployment impact
Verifier/docs only. No runtime code, migrations, or integration-core business behavior changes.

## Gate status
Customer K3 live GATE remains blocked on customer-provided credentials and field answers; this PR only closes package-level deployability proof.