### PR TITLE
fix(integration): reject secret-bearing postdeploy base URLs

### DIFF
--- a/docs/development/integration-k3wise-postdeploy-url-secret-guard-refresh-development-20260513.md
+++ b/docs/development/integration-k3wise-postdeploy-url-secret-guard-refresh-development-20260513.md
@@ -1,0 +1,54 @@
+# Integration K3 WISE Postdeploy URL Secret Guard Refresh Development - 2026-05-13
+
+## Scope
+
+This slice refreshes the intent of PR #1370 on top of current `main`.
+
+The old PR was still open but conflicted with current `main`. Re-applying the
+guard directly avoids merging a stale branch while preserving the security
+contract:
+
+- `scripts/ops/integration-k3wise-postdeploy-smoke.mjs` must reject
+  secret-bearing MetaSheet `--base-url` values before any network request.
+- Error output must not echo inline credentials, query values, or URL hash
+  fragments.
+
+## Changes
+
+Updated `scripts/ops/integration-k3wise-postdeploy-smoke.mjs`:
+
+- Added URL-aware redaction for HTTP/HTTPS URLs.
+- Kept existing bearer/JWT redaction.
+- Rejected `--base-url` values containing inline username/password.
+- Rejected `--base-url` values containing query strings or hash fragments.
+
+Updated `scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs`:
+
+- Added a regression test for inline credential rejection.
+- Added a regression test for query/hash rejection.
+- Both tests assert the raw secret value is absent from stdout/stderr.
+
+## Design Notes
+
+The guard intentionally mirrors the stricter postdeploy env-check behavior
+rather than accepting "safe-looking" query keys. A MetaSheet base URL should be
+only protocol, host, optional port, and optional deployment path. Query strings
+and hashes are not useful for the smoke target and are too easy to misuse for
+tokens or session identifiers.
+
+This is a CLI input guard only. It does not change runtime integration routes,
+K3 adapter behavior, or smoke request semantics for valid URLs.
+
+## Files
+
+- `scripts/ops/integration-k3wise-postdeploy-smoke.mjs`
+- `scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs`
+- `docs/development/integration-k3wise-postdeploy-url-secret-guard-refresh-development-20260513.md`
+- `docs/development/integration-k3wise-postdeploy-url-secret-guard-refresh-verification-20260513.md`
+
+## Non-Goals
+
+- No live K3 customer endpoint call.
+- No GitHub Actions workflow change.
+- No package/build script change.
+- No attempt to merge the stale/conflicting #1370 branch.

--- a/docs/development/integration-k3wise-postdeploy-url-secret-guard-refresh-verification-20260513.md
+++ b/docs/development/integration-k3wise-postdeploy-url-secret-guard-refresh-verification-20260513.md
@@ -11,6 +11,7 @@ Verification for the refreshed K3 WISE postdeploy smoke base URL guard.
 | `node --check scripts/ops/integration-k3wise-postdeploy-smoke.mjs` | PASS | Script syntax check passed. |
 | `node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs` | PASS | 15/15 tests passed, including new inline-credential and query/hash rejection regressions. |
 | `node --test scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs scripts/ops/integration-k3wise-postdeploy-summary.test.mjs` | PASS | 12/12 tests passed; workflow wiring and summary rendering stayed stable. |
+| `pnpm verify:integration-k3wise:poc` | PASS | K3 live PoC preflight tests 20/20, evidence tests 37/37, and mock WebAPI/SQL chain PASS. |
 | `git diff --check` | PASS | No whitespace errors. |
 
 ## Regression Assertions

--- a/docs/development/integration-k3wise-postdeploy-url-secret-guard-refresh-verification-20260513.md
+++ b/docs/development/integration-k3wise-postdeploy-url-secret-guard-refresh-verification-20260513.md
@@ -1,0 +1,33 @@
+# Integration K3 WISE Postdeploy URL Secret Guard Refresh Verification - 2026-05-13
+
+## Scope
+
+Verification for the refreshed K3 WISE postdeploy smoke base URL guard.
+
+## Results
+
+| Command | Result | Notes |
+| --- | --- | --- |
+| `node --check scripts/ops/integration-k3wise-postdeploy-smoke.mjs` | PASS | Script syntax check passed. |
+| `node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs` | PASS | 15/15 tests passed, including new inline-credential and query/hash rejection regressions. |
+| `node --test scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs scripts/ops/integration-k3wise-postdeploy-summary.test.mjs` | PASS | 12/12 tests passed; workflow wiring and summary rendering stayed stable. |
+| `git diff --check` | PASS | No whitespace errors. |
+
+## Regression Assertions
+
+New tests verify:
+
+- `https://admin:<secret>@metasheet.example.test` exits 1.
+- The inline password is absent from stdout and stderr.
+- Error output contains the redacted URL username marker instead of the raw
+  secret.
+- `https://metasheet.example.test?token=<secret>#<secret>` exits 1.
+- Query and hash secrets are absent from stdout and stderr.
+- Query and hash output are URL-redacted before being serialized in the error
+  details.
+
+## Notes
+
+- No customer K3 endpoint was contacted.
+- The old #1370 branch remains a stale/conflicting implementation source; this
+  refreshed slice is the current-main replacement.

--- a/scripts/ops/integration-k3wise-postdeploy-smoke.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-smoke.mjs
@@ -106,6 +106,7 @@ const REQUIRED_STAGING_FIELD_DETAILS = {
   },
 }
 const TOKEN_PATTERN = /([A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{16,}|Bearer\s+[A-Za-z0-9._-]{16,})/g
+const URL_PATTERN = /\bhttps?:\/\/[^\s"'<>]+/gi
 
 class K3WisePostdeploySmokeError extends Error {
   constructor(message, details = {}) {
@@ -224,11 +225,38 @@ function normalizeBaseUrl(value) {
   if (url.protocol !== 'http:' && url.protocol !== 'https:') {
     throw new K3WisePostdeploySmokeError('--base-url must use http or https', { baseUrl: value })
   }
+  if (url.username || url.password) {
+    throw new K3WisePostdeploySmokeError('--base-url must not contain inline credentials', { baseUrl: redactText(value) })
+  }
+  if (url.search || url.hash) {
+    throw new K3WisePostdeploySmokeError('--base-url must not contain query string or hash', { baseUrl: redactText(value) })
+  }
   return url.toString().replace(/\/+$/, '')
 }
 
 function redactText(value) {
-  return String(value).replace(TOKEN_PATTERN, '<redacted-token>')
+  return String(value)
+    .replace(TOKEN_PATTERN, '<redacted-token>')
+    .replace(URL_PATTERN, redactUrl)
+}
+
+function redactUrl(value) {
+  try {
+    const url = new URL(value)
+    if (url.username || url.password) {
+      url.username = '<redacted-credentials>'
+      url.password = ''
+    }
+    for (const key of Array.from(url.searchParams.keys())) {
+      url.searchParams.set(key, '<redacted>')
+    }
+    if (url.hash) {
+      url.hash = '#<redacted>'
+    }
+    return url.toString()
+  } catch {
+    return value
+  }
 }
 
 function markdownText(value) {

--- a/scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
@@ -692,6 +692,37 @@ test('require-auth turns missing token into a failing check', async () => {
   }
 })
 
+test('postdeploy smoke rejects inline base URL credentials without leaking them', async () => {
+  const secretPassword = 'super-secret-inline-password'
+  const result = await runScript([
+    '--base-url',
+    `https://admin:${secretPassword}@metasheet.example.test`,
+  ])
+
+  assert.equal(result.status, 1)
+  assert.equal(result.stdout, '')
+  assert.match(result.stderr, /--base-url must not contain inline credentials/)
+  assert.doesNotMatch(result.stderr, new RegExp(secretPassword))
+  assert.match(result.stderr, /%3Credacted-credentials%3E/)
+})
+
+test('postdeploy smoke rejects query and hash base URLs without leaking them', async () => {
+  const secretQuery = 'super-secret-query-value'
+  const secretHash = 'super-secret-hash-value'
+  const result = await runScript([
+    '--base-url',
+    `https://metasheet.example.test?token=${secretQuery}#${secretHash}`,
+  ])
+
+  assert.equal(result.status, 1)
+  assert.equal(result.stdout, '')
+  assert.match(result.stderr, /--base-url must not contain query string or hash/)
+  assert.doesNotMatch(result.stderr, new RegExp(secretQuery))
+  assert.doesNotMatch(result.stderr, new RegExp(secretHash))
+  assert.match(result.stderr, /token=%3Credacted%3E/)
+  assert.match(result.stderr, /#%3Credacted%3E/)
+})
+
 test('postdeploy smoke markdown escapes table-breaking evidence values', async () => {
   const { renderMarkdown } = await import(pathToFileURL(scriptPath).href)
   const markdown = renderMarkdown({


### PR DESCRIPTION
## Summary
- reject K3 WISE postdeploy smoke --base-url values containing inline credentials, query strings, or hash fragments
- add URL-aware redaction for postdeploy smoke error details while preserving existing JWT/Bearer redaction
- add development and verification docs for the refreshed guard

## Verification
- node --check scripts/ops/integration-k3wise-postdeploy-smoke.mjs
- node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
- node --test scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
- git diff --check

## Deployment impact
Operator script guard only. No runtime routes, migrations, K3 adapter behavior, or customer live endpoint calls.

## Notes
This refreshes the intent of the stale/conflicting #1370 work on top of current main.