### PR TITLE
fix(integration): use temp key for K3 smoke token fallback

### DIFF
--- a/docs/development/integration-k3wise-smoke-token-temp-key-refresh-development-20260512.md
+++ b/docs/development/integration-k3wise-smoke-token-temp-key-refresh-development-20260512.md
@@ -1,0 +1,39 @@
+# K3 WISE Smoke Token Temp Key Refresh Development
+
+Date: 2026-05-12
+Branch: `codex/k3wise-smoke-token-temp-key-refresh-20260513`
+Base: `origin/main@f8bc09865`
+
+## Context
+
+PR #1327 proposed using a temporary SSH private key for the K3 WISE smoke token
+resolver, but its branch predates current `main` hardening for compact JWT
+validation, tenant single-line validation, GitHub env heredoc delimiters, and
+safe output-name validation.
+
+This refresh keeps the current `main` safety behavior and applies only the
+durable part of #1327: deploy-host fallback no longer writes
+`~/.ssh/deploy_key`.
+
+## Changes
+
+- `scripts/ops/resolve-k3wise-smoke-token.sh`
+  - Decode `DEPLOY_SSH_KEY_B64` into `mktemp` under `${TMPDIR:-/tmp}`.
+  - Set the temporary key mode to `0600`.
+  - Pass SSH options as a bash array so the temporary key path is quoted.
+  - Install an `EXIT` trap that removes the key after fallback execution or
+    failure.
+  - Preserve current compact-JWT and GitHub env export guards unchanged.
+
+- `scripts/ops/resolve-k3wise-smoke-token.test.mjs`
+  - Assert the deploy-host fallback does not use or create
+    `~/.ssh/deploy_key`.
+  - Add a regression test that the temporary key exists during fake SSH
+    execution, has mode `0600`, and is deleted after resolver exit.
+
+## Non-Goals
+
+- No changes to token minting semantics inside the remote backend container.
+- No changes to tenant auto-discovery behavior.
+- No changes to postdeploy smoke evidence/signoff gates.
+

--- a/docs/development/integration-k3wise-smoke-token-temp-key-refresh-verification-20260512.md
+++ b/docs/development/integration-k3wise-smoke-token-temp-key-refresh-verification-20260512.md
@@ -1,0 +1,42 @@
+# K3 WISE Smoke Token Temp Key Refresh Verification
+
+Date: 2026-05-12
+Branch: `codex/k3wise-smoke-token-temp-key-refresh-20260513`
+Base: `origin/main@f8bc09865`
+
+## Commands
+
+```bash
+bash -n scripts/ops/resolve-k3wise-smoke-token.sh
+node --test scripts/ops/resolve-k3wise-smoke-token.test.mjs
+node --test scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs
+pnpm verify:integration-k3wise:poc
+git diff --check
+```
+
+## Results
+
+- `bash -n scripts/ops/resolve-k3wise-smoke-token.sh`: pass
+- `node --test scripts/ops/resolve-k3wise-smoke-token.test.mjs`: 11/11 pass
+- `node --test scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs`: 2/2 pass
+- `pnpm verify:integration-k3wise:poc`: preflight 20/20 pass, evidence 37/37 pass, mock PoC chain PASS
+- `git diff --check`: pass
+
+## Coverage Notes
+
+- Configured-token path still writes a compact JWT through the safe
+  `K3WISE_ENV_EOF` heredoc delimiter.
+- Malicious configured-token newline payload still fails before `::add-mask::`.
+- Invalid GitHub env output name still fails before writing.
+- Multiline tenant scope still fails before writing.
+- Deploy-host fallback now proves:
+  - SSH receives `-i <tmp>/k3wise-smoke-ssh-key.*`.
+  - The key file exists while fake SSH runs.
+  - The key file mode is `0600`.
+  - The key file is removed before the resolver process exits.
+  - No `~/.ssh/deploy_key` file is created.
+
+## PR Queue Impact
+
+This refresh supersedes the useful part of PR #1327 without reintroducing the
+older branch's GitHub env safety regressions.

--- a/scripts/ops/resolve-k3wise-smoke-token.sh
+++ b/scripts/ops/resolve-k3wise-smoke-token.sh
@@ -115,6 +115,14 @@ shell_quote() {
   printf '%q' "$1"
 }
 
+tmp_ssh_key=""
+
+cleanup_tmp_key() {
+  if [[ -n "${tmp_ssh_key}" && -f "${tmp_ssh_key}" ]]; then
+    rm -f "${tmp_ssh_key}"
+  fi
+}
+
 if [[ -n "${secret_token}" ]]; then
   write_resolved_tenant "${tenant_id}" "METASHEET_TENANT_ID"
   write_token "${secret_token}" "METASHEET_K3WISE_SMOKE_TOKEN"
@@ -132,13 +140,14 @@ if [[ -z "${DEPLOY_HOST:-}" || -z "${DEPLOY_USER:-}" || -z "${DEPLOY_SSH_KEY_B64
   warn_or_fail "METASHEET_K3WISE_SMOKE_TOKEN is not set and DEPLOY_HOST/DEPLOY_USER/DEPLOY_SSH_KEY_B64 are incomplete"
 fi
 
-mkdir -p ~/.ssh
-if ! printf '%s' "${DEPLOY_SSH_KEY_B64}" | base64 -d > ~/.ssh/deploy_key; then
+tmp_ssh_key="$(mktemp "${TMPDIR:-/tmp}/k3wise-smoke-ssh-key.XXXXXX")"
+trap cleanup_tmp_key EXIT
+if ! printf '%s' "${DEPLOY_SSH_KEY_B64}" | base64 -d > "${tmp_ssh_key}"; then
   warn_or_fail "failed to decode DEPLOY_SSH_KEY_B64 for K3 WISE smoke token fallback"
 fi
-chmod 600 ~/.ssh/deploy_key
+chmod 600 "${tmp_ssh_key}"
 
-ssh_opts="-o BatchMode=yes -o ConnectTimeout=15 -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i ~/.ssh/deploy_key"
+ssh_opts=(-o BatchMode=yes -o ConnectTimeout=15 -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i "${tmp_ssh_key}")
 quoted_deploy_path="$(shell_quote "${deploy_path}")"
 quoted_compose_file="$(shell_quote "${deploy_compose_file}")"
 quoted_tenant_id="$(shell_quote "${tenant_id}")"
@@ -147,7 +156,7 @@ quoted_auto_discover_tenant="$(shell_quote "${auto_discover_tenant}")"
 
 set +e
 token="$(
-  ssh ${ssh_opts} "${DEPLOY_USER}@${DEPLOY_HOST}" \
+  ssh "${ssh_opts[@]}" "${DEPLOY_USER}@${DEPLOY_HOST}" \
     "DEPLOY_PATH=${quoted_deploy_path} DEPLOY_COMPOSE_FILE=${quoted_compose_file} K3_WISE_SMOKE_TENANT_ID=${quoted_tenant_id} K3_WISE_SMOKE_TOKEN_EXPIRY=${quoted_token_expiry} K3_WISE_SMOKE_TENANT_AUTO_DISCOVER=${quoted_auto_discover_tenant} bash -s" <<'EOF'
 set -euo pipefail
 if [[ "${DEPLOY_PATH}" == /* ]]; then

--- a/scripts/ops/resolve-k3wise-smoke-token.test.mjs
+++ b/scripts/ops/resolve-k3wise-smoke-token.test.mjs
@@ -171,7 +171,70 @@ printf 'header.payload.signature\\n'
     const githubEnvText = readFileSync(githubEnv, 'utf8')
     assert.match(githubEnvText, /K3_WISE_SMOKE_TENANT_ID<<K3WISE_ENV_EOF\ntenant-auto\nK3WISE_ENV_EOF/)
     assert.match(githubEnvText, /K3_WISE_SMOKE_TOKEN<<K3WISE_ENV_EOF\nheader\.payload\.signature\nK3WISE_ENV_EOF/)
-    assert.match(readFileSync(sshArgsPath, 'utf8'), /K3_WISE_SMOKE_TENANT_AUTO_DISCOVER=true/)
+    const sshArgs = readFileSync(sshArgsPath, 'utf8')
+    assert.match(sshArgs, /K3_WISE_SMOKE_TENANT_AUTO_DISCOVER=true/)
+    assert.doesNotMatch(sshArgs, /\.ssh\/deploy_key/)
+    assert.equal(existsSync(path.join(tmp, '.ssh', 'deploy_key')), false)
+  } finally {
+    rmSync(tmp, { recursive: true, force: true })
+  }
+})
+
+test('resolver cleans up temporary deploy SSH key after fallback execution', async () => {
+  const tmp = makeTmpDir()
+  const githubEnv = path.join(tmp, 'github-env')
+  const binDir = path.join(tmp, 'bin')
+  const sshArgsPath = path.join(tmp, 'ssh-args')
+  const sshKeyPathFile = path.join(tmp, 'ssh-key-path')
+  try {
+    mkdirSync(binDir)
+    const sshPath = path.join(binDir, 'ssh')
+    writeFileSync(sshPath, `#!/usr/bin/env bash
+printf '%s\\n' "$*" > "$FAKE_SSH_ARGS_PATH"
+while [[ "$#" -gt 0 ]]; do
+  if [[ "$1" == "-i" ]]; then
+    shift
+    printf '%s\\n' "$1" > "$FAKE_SSH_KEY_PATH"
+    if [[ ! -f "$1" ]]; then
+      echo "missing ssh key" >&2
+      exit 9
+    fi
+    mode="$(stat -f %Lp "$1" 2>/dev/null || stat -c %a "$1")"
+    if [[ "$mode" != "600" ]]; then
+      echo "bad ssh key mode: $mode" >&2
+      exit 10
+    fi
+  fi
+  shift
+done
+cat >/dev/null
+printf 'K3_WISE_SMOKE_TENANT_ID=tenant-auto\\n'
+printf 'header.payload.signature\\n'
+`)
+    chmodSync(sshPath, 0o755)
+
+    const result = await runResolver({
+      GITHUB_ENV: githubEnv,
+      HOME: tmp,
+      TMPDIR: tmp,
+      PATH: `${binDir}:${process.env.PATH || ''}`,
+      FAKE_SSH_ARGS_PATH: sshArgsPath,
+      FAKE_SSH_KEY_PATH: sshKeyPathFile,
+      K3_WISE_TOKEN_AUTO_DISCOVER_TENANT: 'true',
+      DEPLOY_HOST: 'deploy.example.test',
+      DEPLOY_USER: 'deployer',
+      DEPLOY_SSH_KEY_B64: Buffer.from('fake-key').toString('base64'),
+    })
+
+    assert.equal(result.status, 0, result.stderr)
+    const usedKeyPath = readFileSync(sshKeyPathFile, 'utf8').trim()
+    assert.match(
+      usedKeyPath,
+      new RegExp(`^${tmp.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}/k3wise-smoke-ssh-key\\.`),
+    )
+    assert.equal(existsSync(usedKeyPath), false)
+    assert.equal(existsSync(path.join(tmp, '.ssh', 'deploy_key')), false)
+    assert.doesNotMatch(readFileSync(sshArgsPath, 'utf8'), /\.ssh\/deploy_key/)
   } finally {
     rmSync(tmp, { recursive: true, force: true })
   }


### PR DESCRIPTION
## Summary

- refreshes stale #1327 on current main without reverting the newer JWT/GitHub env safety guards
- decodes `DEPLOY_SSH_KEY_B64` into a `mktemp` file instead of `~/.ssh/deploy_key`
- passes SSH options as an array and removes the temporary key via `EXIT` trap
- adds regression coverage proving the key exists only during fake SSH execution, is mode `0600`, and is removed after resolver exit

## Verification

- `bash -n scripts/ops/resolve-k3wise-smoke-token.sh`
- `node --test scripts/ops/resolve-k3wise-smoke-token.test.mjs` — 11/11 pass
- `node --test scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs` — 2/2 pass
- `pnpm verify:integration-k3wise:poc` — preflight 20/20 pass, evidence 37/37 pass, mock chain PASS
- `git diff --check`

## Notes

This supersedes PR #1327. The older branch had the useful temp-key direction but predates current `main` safety hardening, so this PR carries only the minimal current-main fix.
