### PR TITLE
fix(integration): write K3 smoke evidence for token file failures

### DIFF
--- a/docs/development/integration-k3wise-smoke-token-file-evidence-refresh-development-20260512.md
+++ b/docs/development/integration-k3wise-smoke-token-file-evidence-refresh-development-20260512.md
@@ -1,0 +1,37 @@
+# K3 WISE Smoke Token File Evidence Refresh Development
+
+Date: 2026-05-12
+Branch: `codex/k3wise-smoke-token-file-evidence-refresh-20260512`
+Base: `origin/main@72bf68f49`
+
+## Context
+
+PR #1330 aimed to preserve postdeploy smoke evidence when a configured token
+file cannot be read. Current `main` still reads the token before initializing
+the check list; a missing `--token-file` exits through the top-level CLI error
+handler and does not write `integration-k3wise-postdeploy-smoke.json` or
+`.md`.
+
+The stale #1330 branch also includes broader operator-permission work. This
+refresh deliberately keeps scope to the token-file evidence gap only.
+
+## Changes
+
+- `scripts/ops/integration-k3wise-postdeploy-smoke.mjs`
+  - Adds `resolveToken(opts)` around `readToken(opts)`.
+  - Converts token-read errors into an `auth-token` failing check.
+  - Continues public smoke probes and final evidence rendering even when the
+    token file is missing.
+
+- `scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs`
+  - Adds a regression where `--token-file` points to a missing file and
+    `--require-auth` is enabled.
+  - Asserts the CLI exits nonzero, writes both JSON and Markdown evidence, and
+    records `auth-token` plus `authenticated-integration-contract` failures.
+
+## Non-Goals
+
+- No operator-permission gate changes.
+- No workflow YAML changes.
+- No changes to authenticated route/staging descriptor contract checks.
+

--- a/docs/development/integration-k3wise-smoke-token-file-evidence-refresh-verification-20260512.md
+++ b/docs/development/integration-k3wise-smoke-token-file-evidence-refresh-verification-20260512.md
@@ -1,0 +1,42 @@
+# K3 WISE Smoke Token File Evidence Refresh Verification
+
+Date: 2026-05-12
+Branch: `codex/k3wise-smoke-token-file-evidence-refresh-20260512`
+Base: `origin/main@72bf68f49`
+
+## Commands
+
+```bash
+node --check scripts/ops/integration-k3wise-postdeploy-smoke.mjs
+node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
+node --test scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs
+git diff --check
+```
+
+## Expected Coverage
+
+- Missing token-file path is captured as `checks[].id === "auth-token"`.
+- Public probes still run, so the evidence distinguishes "token unavailable"
+  from "deployment unavailable".
+- Required-auth mode still fails the run because authenticated checks cannot
+  execute.
+- JSON and Markdown evidence are written even when the token file is missing.
+
+## Results
+
+- `node --check scripts/ops/integration-k3wise-postdeploy-smoke.mjs`: pass
+- `node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs`: 16/16 pass
+- `node --test scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs`: 2/2 pass
+- `git diff --check`: pass
+
+## Regression Details
+
+The new missing-token-file test proves:
+
+- CLI exits `1`.
+- `stdout` remains valid JSON with `ok: false`, `authenticated: false`, and
+  `summary.fail === 2`.
+- `integration-k3wise-postdeploy-smoke.json` is written.
+- `integration-k3wise-postdeploy-smoke.md` is written.
+- Evidence contains `auth-token: fail`, `api-health: pass`, and
+  `authenticated-integration-contract: fail`.

--- a/scripts/ops/integration-k3wise-postdeploy-smoke.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-smoke.mjs
@@ -305,6 +305,20 @@ async function readToken(opts) {
   return raw.trim()
 }
 
+async function resolveToken(opts) {
+  try {
+    return {
+      token: await readToken(opts),
+      check: null,
+    }
+  } catch (error) {
+    return {
+      token: '',
+      check: failResult('auth-token', error),
+    }
+  }
+}
+
 async function fetchWithTimeout(url, options = {}, timeoutMs = 10_000) {
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), timeoutMs)
@@ -512,8 +526,10 @@ function extractTenantId(authBody) {
 }
 
 async function runSmoke(opts) {
-  const token = await readToken(opts)
   const checks = []
+  const resolvedToken = await resolveToken(opts)
+  const token = resolvedToken.token
+  if (resolvedToken.check) checks.push(resolvedToken.check)
 
   try {
     const health = await requestJson(opts.baseUrl, '/api/health', { timeoutMs: opts.timeoutMs })

--- a/scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
@@ -692,6 +692,46 @@ test('require-auth turns missing token into a failing check', async () => {
   }
 })
 
+test('missing token file still writes failure evidence for signoff audit', async () => {
+  const fake = createFakeServer()
+  const baseUrl = await fake.listen()
+  const outDir = makeTmpDir()
+  try {
+    const result = await runScript([
+      '--base-url', baseUrl,
+      '--token-file', path.join(outDir, 'missing-token.txt'),
+      '--require-auth',
+      '--out-dir', outDir,
+    ])
+
+    assert.equal(result.status, 1)
+    const stdout = JSON.parse(result.stdout)
+    assert.equal(stdout.ok, false)
+    assert.equal(stdout.authenticated, false)
+    assert.equal(stdout.summary.fail, 2)
+    assert.deepEqual(stdout.signoff, {
+      internalTrial: 'blocked',
+      reason: 'one or more smoke checks failed',
+    })
+
+    const evidencePath = path.join(outDir, 'integration-k3wise-postdeploy-smoke.json')
+    const markdownPath = path.join(outDir, 'integration-k3wise-postdeploy-smoke.md')
+    const evidenceText = readFileSync(evidencePath, 'utf8')
+    const markdownText = readFileSync(markdownPath, 'utf8')
+    const evidence = JSON.parse(evidenceText)
+    const tokenCheck = evidence.checks.find((check) => check.id === 'auth-token')
+    assert.equal(tokenCheck.status, 'fail')
+    assert.match(tokenCheck.error, /ENOENT/)
+    assert.equal(evidence.checks.find((check) => check.id === 'api-health').status, 'pass')
+    assert.equal(evidence.checks.find((check) => check.id === 'authenticated-integration-contract').status, 'fail')
+    assert.match(markdownText, /auth-token/)
+    assert.match(markdownText, /authenticated-integration-contract/)
+  } finally {
+    await fake.close()
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
 test('postdeploy smoke rejects inline base URL credentials without leaking them', async () => {
   const secretPassword = 'super-secret-inline-password'
   const result = await runScript([


### PR DESCRIPTION
## Summary

- refreshes stale #1330 on current main without bringing in the older branch's unrelated operator-permission changes
- converts token-file read failures into an `auth-token` failing check instead of aborting before evidence is written
- keeps public probes running so the evidence separates token resolution failure from deployment unavailability
- adds regression coverage for missing `--token-file` in `--require-auth` mode

## Verification

- `node --check scripts/ops/integration-k3wise-postdeploy-smoke.mjs`
- `node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs` — 16/16 pass
- `node --test scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs` — 2/2 pass
- `git diff --check`

## Notes

Supersedes PR #1330. This PR preserves the useful token-file evidence behavior only; operator permission gates remain out of scope for this minimal refresh.
