### PR TITLE
test(integration): refresh K3 preflight URL secret guard evidence

### DIFF
--- a/docs/development/integration-k3wise-preflight-url-secret-guard-refresh-development-20260513.md
+++ b/docs/development/integration-k3wise-preflight-url-secret-guard-refresh-development-20260513.md
@@ -1,0 +1,35 @@
+# K3 WISE Preflight URL Secret Guard Refresh Development - 2026-05-13
+
+## Context
+
+PR #1337 was still open from the 2026-05-06 K3 WISE stale queue. Its original goal was to prevent customer secrets from being embedded in preflight endpoint URLs before generated packets or Markdown evidence are archived.
+
+Current `main` already contains a broader implementation than #1337:
+
+- `validateUrl()` calls `assertNoSecretLikeText()`.
+- URL username/password components are rejected.
+- Secret-bearing query parameters are rejected.
+- Free-text token forms such as `Bearer ...`, JWTs, `SEC...`, and `password=...` are rejected.
+- `buildPacket()` already tests K3 API URL and PLM base URL rejection.
+
+The remaining gap was customer-facing guidance and one compatibility assertion from the stale PR: non-secret routing query parameters should remain accepted.
+
+## Change
+
+This refresh keeps source behavior unchanged and adds only the missing closeout pieces:
+
+- Update the K3 WISE fixture README so customers know endpoint URLs must not contain credentials or token-like query parameters.
+- Update `gate-sample.json` with the same instruction before customers copy it out of Git.
+- Extend the existing preflight URL secret test to assert that a non-secret PLM routing query parameter survives normalization.
+
+## Scope Control
+
+This is intentionally not a reimplementation of #1337. The older branch added a narrower `optionalUrl()` path and URL-only guard. Current `main` is stronger because the shared `assertNoSecretLikeText()` path also scans generated packets recursively.
+
+## Files
+
+- `scripts/ops/fixtures/integration-k3wise/README.md`
+- `scripts/ops/fixtures/integration-k3wise/gate-sample.json`
+- `scripts/ops/integration-k3wise-live-poc-preflight.test.mjs`
+- `docs/development/integration-k3wise-preflight-url-secret-guard-refresh-development-20260513.md`
+- `docs/development/integration-k3wise-preflight-url-secret-guard-refresh-verification-20260513.md`

--- a/docs/development/integration-k3wise-preflight-url-secret-guard-refresh-verification-20260513.md
+++ b/docs/development/integration-k3wise-preflight-url-secret-guard-refresh-verification-20260513.md
@@ -1,0 +1,51 @@
+# K3 WISE Preflight URL Secret Guard Refresh Verification - 2026-05-13
+
+## Local Verification
+
+```bash
+node --test scripts/ops/integration-k3wise-live-poc-preflight.test.mjs
+```
+
+Result:
+
+- 20/20 tests passed.
+- The URL secret guard test rejects credential-bearing K3 and PLM URLs.
+- The same test preserves non-secret PLM routing query parameters.
+
+```bash
+node -e "JSON.parse(require('fs').readFileSync('scripts/ops/fixtures/integration-k3wise/gate-sample.json','utf8'))"
+```
+
+Result:
+
+- `gate-sample.json` remains valid JSON after the customer guidance update.
+
+```bash
+pnpm run verify:integration-k3wise:poc
+```
+
+Result:
+
+- Preflight: 20/20 tests passed.
+- Evidence: 37/37 tests passed.
+- Mock K3 WISE PoC demo passed.
+
+```bash
+git diff --check origin/main..HEAD
+```
+
+Result:
+
+- No whitespace errors.
+
+## PR #1337 Disposition
+
+PR #1337 is superseded by current `main` plus this small refresh:
+
+- Core guard behavior already exists in `assertNoSecretLikeText()`.
+- This branch preserves the only remaining customer-facing instruction and compatibility assertion.
+- The old branch should be closed after this refresh PR is opened.
+
+## Not Covered
+
+This verification does not hit a live customer K3 WISE endpoint. It validates the offline preflight and mock PoC safety contract only.

--- a/scripts/ops/fixtures/integration-k3wise/README.md
+++ b/scripts/ops/fixtures/integration-k3wise/README.md
@@ -9,7 +9,7 @@ Fixtures and mock server for the K3 WISE Live PoC chain. Used to:
 
 | File | Purpose |
 |---|---|
-| `gate-sample.json` | Customer GATE answer template. Customer copies, fills in real values (K3 version, URLs, credentials placeholders), saves outside Git. |
+| `gate-sample.json` | Customer GATE answer template. Customer copies, fills in real values (K3 version, URLs, credentials placeholders), saves outside Git. Endpoint URLs must not include inline username/password or secret-like query params; use credential fields instead. |
 | `evidence-sample.json` | Customer-side evidence template after live PoC. Customer fills in run IDs, K3 record IDs, statuses, etc. |
 | `mock-k3-webapi-server.mjs` | Minimal in-process HTTP mock for K3 WISE WebAPI: Login / Health / Material / BOM Save / Submit / Audit. NOT a full K3 simulator. |
 | `mock-sqlserver-executor.mjs` | Mock SQL executor: read-only on K3 core tables, writeable on integration middle tables, rejects writes to `t_ICItem` / `t_ICBOM`. |

--- a/scripts/ops/fixtures/integration-k3wise/gate-sample.json
+++ b/scripts/ops/fixtures/integration-k3wise/gate-sample.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Customer GATE answer template. Copy this file outside Git, fill in real values, run: node scripts/ops/integration-k3wise-live-poc-preflight.mjs --input <path>. All fields below are accepted as: real boolean true/false, string 'true'/'false'/'yes'/'no'/'on'/'off', Chinese 是/否/启用/禁用, or numeric 0/1. Unknown values throw with the field name. Strings/numbers/Chinese for productId / runId are also accepted.",
+  "_comment": "Customer GATE answer template. Copy this file outside Git, fill in real values, run: node scripts/ops/integration-k3wise-live-poc-preflight.mjs --input <path>. All fields below are accepted as: real boolean true/false, string 'true'/'false'/'yes'/'no'/'on'/'off', Chinese 是/否/启用/禁用, or numeric 0/1. Unknown values throw with the field name. Strings/numbers/Chinese for productId / runId are also accepted. Do not put username/password/token/api_key values into k3Wise.apiUrl or plm.baseUrl; use credentials fields instead.",
   "tenantId": "tenant-test",
   "workspaceId": "workspace-test",
   "operator": "integration-admin",

--- a/scripts/ops/integration-k3wise-live-poc-preflight.test.mjs
+++ b/scripts/ops/integration-k3wise-live-poc-preflight.test.mjs
@@ -204,6 +204,17 @@ test('buildPacket rejects secret-bearing URL and free-text values before packet 
     (error) => error instanceof LivePocPreflightError && error.details.location === 'plm.baseUrl',
     'PLM baseUrl with signed query must be rejected',
   )
+
+  const packet = buildPacket(gate({
+    plm: {
+      baseUrl: 'https://plm.example.test/api?tenant=demo',
+    },
+  }))
+  assert.equal(
+    packet.externalSystems.find((system) => system.kind === 'plm:yuantus-wrapper').config.baseUrl,
+    'https://plm.example.test/api?tenant=demo',
+    'non-secret query parameters remain available for customer routing metadata',
+  )
 })
 
 test('buildPacket requires minimum K3 material target mappings', () => {


### PR DESCRIPTION
## Summary
- documents that K3 WISE preflight endpoint URLs must not include inline credentials or secret-like query params
- preserves the remaining #1337 compatibility assertion that non-secret PLM routing query params are accepted
- records the current-main development and verification evidence for closing stale PR #1337

## Verification
- node --test scripts/ops/integration-k3wise-live-poc-preflight.test.mjs
- node -e "JSON.parse(require('fs').readFileSync('scripts/ops/fixtures/integration-k3wise/gate-sample.json','utf8'))"
- pnpm run verify:integration-k3wise:poc
- git diff --check origin/main..HEAD

Supersedes #1337.