### PR TITLE
docs(integration): record K3 workbench release publication

### DIFF
--- a/docs/development/k3wise-workbench-release-publication-development-20260513.md
+++ b/docs/development/k3wise-workbench-release-publication-development-20260513.md
@@ -1,0 +1,55 @@
+# K3 WISE Workbench Release Publication Development - 2026-05-13
+
+## Scope
+
+This slice converts the verified K3 WISE + generic integration workbench
+on-prem package from a short-lived GitHub Actions artifact into a durable
+GitHub prerelease.
+
+The previous deploy-readiness proof showed that the Windows `.zip` package could
+be generated and verified. GitHub Actions artifacts expire, so this slice
+publishes the same deployable package shape as a prerelease asset set that field
+operators can download directly.
+
+## Release
+
+- Release: `multitable-onprem-k3wise-workbench-20260513-20548fe`
+- URL: `https://github.com/zensgit/metasheet2/releases/tag/multitable-onprem-k3wise-workbench-20260513-20548fe`
+- Type: GitHub prerelease
+- Target commit: `20548fe6980a28cad8d6472312aea38a7caf99d6`
+- Package workflow run: `25783182629`
+- Package tag: `k3wise-workbench-20548fe`
+
+## Published Assets
+
+- `metasheet-multitable-onprem-v2.5.0-k3wise-workbench-20548fe.zip`
+- `metasheet-multitable-onprem-v2.5.0-k3wise-workbench-20548fe.tgz`
+- `metasheet-multitable-onprem-v2.5.0-k3wise-workbench-20548fe.zip.sha256`
+- `metasheet-multitable-onprem-v2.5.0-k3wise-workbench-20548fe.tgz.sha256`
+- `SHA256SUMS`
+- `metasheet-multitable-onprem-v2.5.0-k3wise-workbench-20548fe.json`
+- `metasheet-multitable-onprem-v2.5.0-k3wise-workbench-20548fe.zip.verify.json`
+- `metasheet-multitable-onprem-v2.5.0-k3wise-workbench-20548fe.zip.verify.md`
+- `metasheet-multitable-onprem-v2.5.0-k3wise-workbench-20548fe.tgz.verify.json`
+- `metasheet-multitable-onprem-v2.5.0-k3wise-workbench-20548fe.tgz.verify.md`
+
+## Deployment Interpretation
+
+Use the `.zip` asset for Windows Server entity-machine deployment testing.
+
+The release is marked prerelease because the platform can be deployed and tested
+now, but real K3 WISE Save-only writes still require customer GATE credentials
+and field mapping answers. Submit/Audit remains outside the default deployment
+path until explicitly validated.
+
+## Files
+
+- `docs/development/k3wise-workbench-release-publication-development-20260513.md`
+- `docs/development/k3wise-workbench-release-publication-verification-20260513.md`
+
+## Non-Goals
+
+- No source code change.
+- No migration change.
+- No customer K3 endpoint call.
+- No promotion to latest stable GitHub Release.

--- a/docs/development/k3wise-workbench-release-publication-verification-20260513.md
+++ b/docs/development/k3wise-workbench-release-publication-verification-20260513.md
@@ -1,0 +1,89 @@
+# K3 WISE Workbench Release Publication Verification - 2026-05-13
+
+## Scope
+
+Verification for publishing the deployable K3 WISE + generic integration
+workbench on-prem package as a durable GitHub prerelease.
+
+## Package Build
+
+```bash
+gh workflow run multitable-onprem-package-build.yml \
+  --repo zensgit/metasheet2 \
+  --ref main \
+  -f package_tag=k3wise-workbench-20548fe \
+  -f publish_release=false
+```
+
+Result:
+
+- Run: `25783182629`
+- URL: `https://github.com/zensgit/metasheet2/actions/runs/25783182629`
+- Head SHA: `20548fe6980a28cad8d6472312aea38a7caf99d6`
+- Status: `success`
+- Artifact: `multitable-onprem-package-25783182629-1`
+
+## Local Pre-Publish Verification
+
+| Command | Result | Notes |
+| --- | --- | --- |
+| `shasum -a 256 -c SHA256SUMS` | PASS | `.tgz` and `.zip` checksums match. |
+| `scripts/ops/multitable-onprem-package-verify.sh output/playwright/ga/25783182629/metasheet-multitable-onprem-v2.5.0-k3wise-workbench-20548fe.zip` | PASS | Windows package verifier passed. |
+| `scripts/ops/multitable-onprem-package-verify.sh output/playwright/ga/25783182629/metasheet-multitable-onprem-v2.5.0-k3wise-workbench-20548fe.tgz` | PASS | Linux package verifier passed. |
+| `PACKAGE_JSON=output/releases/multitable-onprem/metasheet-multitable-onprem-v2.5.0-k3wise-workbench-20548fe.json DELIVERY_OUTPUT_ROOT=output/delivery/multitable-onprem/k3wise-workbench-20548fe node scripts/ops/multitable-onprem-delivery-bundle.mjs` | PASS | Customer delivery bundle generated. |
+
+Package content spot-check confirmed:
+
+- `scripts/ops/multitable-onprem-apply-package.ps1`
+- `scripts/ops/integration-k3wise-onprem-preflight.mjs`
+- `scripts/ops/integration-k3wise-postdeploy-smoke.mjs`
+- `plugins/plugin-integration-core/plugin.json`
+- `plugins/plugin-integration-core/lib/adapters/k3-wise-document-templates.cjs`
+- `apps/web/dist/assets/IntegrationWorkbenchView-*.js`
+- `apps/web/dist/assets/IntegrationK3WiseSetupView-*.js`
+
+## Published Release
+
+Release:
+
+```text
+https://github.com/zensgit/metasheet2/releases/tag/multitable-onprem-k3wise-workbench-20260513-20548fe
+```
+
+Release metadata:
+
+- `isDraft=false`
+- `isPrerelease=true`
+- `targetCommitish=20548fe6980a28cad8d6472312aea38a7caf99d6`
+- assets uploaded: 10
+
+## Release Download Verification
+
+The release was downloaded back into:
+
+```text
+/tmp/metasheet2-k3wise-workbench-release-20548fe/
+```
+
+Post-download checks:
+
+| Command | Result | Notes |
+| --- | --- | --- |
+| `shasum -a 256 -c SHA256SUMS` | PASS | Release-downloaded `.tgz` and `.zip` match published checksums. |
+| `scripts/ops/multitable-onprem-package-verify.sh /tmp/metasheet2-k3wise-workbench-release-20548fe/metasheet-multitable-onprem-v2.5.0-k3wise-workbench-20548fe.zip` | PASS | Release-downloaded Windows package verifier passed. |
+| `scripts/ops/multitable-onprem-package-verify.sh /tmp/metasheet2-k3wise-workbench-release-20548fe/metasheet-multitable-onprem-v2.5.0-k3wise-workbench-20548fe.tgz` | PASS | Release-downloaded Linux package verifier passed. |
+| `node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs scripts/ops/integration-k3wise-postdeploy-summary.test.mjs` | PASS | 28/28 postdeploy smoke and workflow tests passed. |
+
+## Deployment Answer
+
+Yes, the release package can be used for Windows Server entity-machine
+deployment testing.
+
+The release gives field operators a stable download location, unlike the
+short-lived GitHub Actions artifact. Use the `.zip` package for Windows Server.
+
+## Notes
+
+- No customer K3 endpoint was contacted.
+- No secrets were used or written into tracked docs.
+- The release is intentionally a prerelease, not a latest-stable promotion.


### PR DESCRIPTION
## Summary

Records the durable GitHub prerelease publication for the K3 WISE + generic integration workbench on-prem test package.

Release:
https://github.com/zensgit/metasheet2/releases/tag/multitable-onprem-k3wise-workbench-20260513-20548fe

Windows package:
`metasheet-multitable-onprem-v2.5.0-k3wise-workbench-20548fe.zip`

## Verification

- Package workflow `25783182629` completed successfully on main commit `20548fe6980a28cad8d6472312aea38a7caf99d6`.
- Published release metadata checked: draft=false, prerelease=true, targetCommitish matches, 10 assets uploaded.
- Downloaded release assets back from GitHub and verified SHA256SUMS.
- Ran package verifier for release-downloaded `.zip`: PASS.
- Ran package verifier for release-downloaded `.tgz`: PASS.
- Ran postdeploy smoke/workflow Node tests: 28/28 PASS.
- `git diff --check`: PASS.

## Deployment impact

Docs-only PR. No runtime, migration, or package-generation logic changes.

This confirms the package can be used for Windows Server entity-machine deployment testing. Real K3 WISE Save-only writes still require customer GATE credentials and mapping answers.
