### PR TITLE
test(integration): refresh K3 signoff gate

### DIFF
--- a/.github/workflows/integration-k3wise-postdeploy-smoke.yml
+++ b/.github/workflows/integration-k3wise-postdeploy-smoke.yml
@@ -182,6 +182,8 @@ jobs:
 
       - name: Fail when K3 WISE smoke failed
         if: always()
+        env:
+          REQUIRE_AUTH: ${{ github.event.inputs.require_auth || 'true' }}
         run: |
           token_rc="${{ steps.token_resolve.outputs.token_resolve_rc }}"
           env_check_rc="${{ steps.env_check.outputs.env_check_rc }}"
@@ -209,4 +211,8 @@ jobs:
           if [[ "$rc" != "0" ]]; then
             echo "K3 WISE postdeploy smoke failed: rc=$rc" >&2
             exit 1
+          fi
+          if [[ "$REQUIRE_AUTH" == "true" ]]; then
+            node scripts/ops/integration-k3wise-signoff-gate.mjs \
+              --input output/integration-k3wise-postdeploy-smoke/manual/integration-k3wise-postdeploy-smoke.json
           fi

--- a/docs/development/integration-k3wise-signoff-gate-refresh-development-20260513.md
+++ b/docs/development/integration-k3wise-signoff-gate-refresh-development-20260513.md
@@ -1,0 +1,67 @@
+# K3 WISE Signoff Gate Refresh Development - 2026-05-13
+
+## Context
+
+PR #1324 and PR #1326 were still open from the 2026-05-06 K3 WISE stale queue:
+
+- #1324 added a machine-readable postdeploy signoff gate.
+- #1326 hardened the human-readable postdeploy summary so contradictory evidence cannot render `Internal trial signoff: PASS`.
+
+Current `main` already includes the newer postdeploy evidence preservation work from #1501, #1502, #1503, and the K3 workbench release docs. This refresh reapplies the still-missing signoff semantics on top of current `main`.
+
+## Change
+
+Added `scripts/ops/integration-k3wise-signoff-gate.mjs`.
+
+The gate accepts:
+
+```bash
+node scripts/ops/integration-k3wise-signoff-gate.mjs --input <evidence.json>
+```
+
+It returns exit `0` only when all of the following hold:
+
+- `ok === true`
+- `authenticated === true`
+- `signoff.internalTrial === "pass"`
+- `summary.fail === 0`
+- required authenticated checks are present and passing:
+  - `auth-me`
+  - `integration-route-contract`
+  - `integration-list-external-systems`
+  - `integration-list-pipelines`
+  - `integration-list-runs`
+  - `integration-list-dead-letters`
+  - `staging-descriptor-contract`
+
+The manual `K3 WISE Postdeploy Smoke` workflow invokes this gate in the final failure step when `require_auth=true`. Summary and artifact upload still run before the final gate, so blocked signoff evidence is preserved.
+
+## Summary Consistency
+
+`integration-k3wise-postdeploy-summary.mjs` now treats explicit or inferred signoff PASS as valid only when:
+
+- top-level `ok` is true
+- authenticated checks ran
+- `summary.fail` is zero
+
+If a stale or hand-edited evidence file says `signoff.internalTrial="pass"` while one of those fields contradicts it, the summary renders `Internal trial signoff: BLOCKED` and names the inconsistent field.
+
+## Disposition Of Old PRs
+
+This current-main refresh supersedes:
+
+- #1324 `test(integration): add K3 WISE signoff evidence gate`
+- #1326 `fix(integration): block inconsistent K3 signoff summaries`
+
+Both old PRs should be closed after this branch is opened because their original branches are stale and split one signoff concern across two PRs.
+
+## Files
+
+- `.github/workflows/integration-k3wise-postdeploy-smoke.yml`
+- `scripts/ops/integration-k3wise-signoff-gate.mjs`
+- `scripts/ops/integration-k3wise-signoff-gate.test.mjs`
+- `scripts/ops/integration-k3wise-postdeploy-summary.mjs`
+- `scripts/ops/integration-k3wise-postdeploy-summary.test.mjs`
+- `scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs`
+- `docs/development/integration-k3wise-signoff-gate-refresh-development-20260513.md`
+- `docs/development/integration-k3wise-signoff-gate-refresh-verification-20260513.md`

--- a/docs/development/integration-k3wise-signoff-gate-refresh-verification-20260513.md
+++ b/docs/development/integration-k3wise-signoff-gate-refresh-verification-20260513.md
@@ -1,0 +1,51 @@
+# K3 WISE Signoff Gate Refresh Verification - 2026-05-13
+
+## Local Verification
+
+```bash
+node --check scripts/ops/integration-k3wise-signoff-gate.mjs
+```
+
+Result:
+
+- Syntax check passes.
+
+```bash
+node --test scripts/ops/integration-k3wise-signoff-gate.test.mjs
+```
+
+Result:
+
+- The signoff gate test suite passed: 8/8.
+- Authenticated evidence with all required checks passes.
+- Public-only diagnostic evidence is blocked.
+- Stale explicit PASS with `ok=false`, `summary.fail>0`, missing checks, or failing checks is blocked.
+
+```bash
+node --test scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
+```
+
+Result:
+
+- The summary test suite passed: 14/14.
+- Explicit PASS evidence that contradicts `ok`, `authenticated`, or `summary.fail` renders BLOCKED.
+
+```bash
+node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs scripts/ops/integration-k3wise-postdeploy-summary.test.mjs scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs scripts/ops/integration-k3wise-signoff-gate.test.mjs
+```
+
+Result:
+
+- The postdeploy smoke, summary, workflow-contract, and signoff-gate suites passed together: 40/40.
+
+```bash
+git diff --check origin/main..HEAD
+```
+
+Result:
+
+- No whitespace errors.
+
+## Notes
+
+This verification is offline. It validates the postdeploy evidence/signoff contract and workflow wiring, not a live 142 deployment run.

--- a/scripts/ops/integration-k3wise-postdeploy-summary.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-summary.mjs
@@ -99,14 +99,40 @@ function renderMissingSummary(inputPath, { requireAuthSignoff = false } = {}) {
   return lines.join('\n')
 }
 
+function countSummaryFailures(evidence) {
+  const failCount = Number(evidence?.summary?.fail ?? 0)
+  return Number.isFinite(failCount) ? failCount : 0
+}
+
+function getAuthenticatedPassBlockers(evidence) {
+  const blockers = []
+  if (evidence?.ok !== true) {
+    blockers.push('top-level ok is not true')
+  }
+  if (evidence?.authenticated !== true) {
+    blockers.push('authenticated checks did not run')
+  }
+  if (countSummaryFailures(evidence) !== 0) {
+    blockers.push('summary.fail is not 0')
+  }
+  return blockers
+}
+
 function inferInternalTrialSignoff(evidence) {
   if (evidence?.signoff?.internalTrial === 'pass') {
+    const blockers = getAuthenticatedPassBlockers(evidence)
+    if (blockers.length > 0) {
+      return {
+        status: 'BLOCKED',
+        reason: `authenticated signoff evidence is inconsistent: ${blockers.join('; ')}`,
+      }
+    }
     return { status: 'PASS', reason: evidence.signoff.reason || 'authenticated smoke passed' }
   }
   if (evidence?.signoff?.internalTrial === 'blocked') {
     return { status: 'BLOCKED', reason: evidence.signoff.reason || 'authenticated smoke did not pass' }
   }
-  if (evidence?.ok && evidence?.authenticated) {
+  if (evidence?.ok && evidence?.authenticated && countSummaryFailures(evidence) === 0) {
     return { status: 'PASS', reason: 'authenticated smoke passed' }
   }
   if (!evidence?.authenticated) {
@@ -225,7 +251,9 @@ if (entryPath && import.meta.url === entryPath) {
 
 export {
   K3WisePostdeploySummaryError,
+  countSummaryFailures,
   formatDetailValue,
+  getAuthenticatedPassBlockers,
   inferInternalTrialSignoff,
   markdownInlineCode,
   markdownText,

--- a/scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
@@ -129,6 +129,123 @@ test('renders passing internal signoff for authenticated smoke evidence', async 
   }
 })
 
+test('blocks explicit pass when signoff evidence says top-level ok is false', async () => {
+  const outDir = makeTmpDir()
+  const evidencePath = path.join(outDir, 'evidence.json')
+  try {
+    writeFileSync(evidencePath, `${JSON.stringify({
+      ok: false,
+      baseUrl: 'http://127.0.0.1:8081',
+      authenticated: true,
+      signoff: {
+        internalTrial: 'pass',
+        reason: 'authenticated smoke passed',
+      },
+      summary: { pass: 8, skipped: 0, fail: 0 },
+      checks: [
+        { id: 'api-health', status: 'pass' },
+        { id: 'auth-me', status: 'pass' },
+      ],
+    })}\n`)
+
+    const result = await runScript(['--input', evidencePath, '--require-auth-signoff'])
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stdout, /Internal trial signoff: \*\*BLOCKED\*\*/)
+    assert.match(result.stdout, /authenticated signoff evidence is inconsistent: top-level ok is not true/)
+    assert.match(result.stdout, /Status: \*\*FAIL\*\*/)
+  } finally {
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('blocks explicit pass when signoff evidence is not authenticated', async () => {
+  const outDir = makeTmpDir()
+  const evidencePath = path.join(outDir, 'evidence.json')
+  try {
+    writeFileSync(evidencePath, `${JSON.stringify({
+      ok: true,
+      baseUrl: 'http://127.0.0.1:8081',
+      authenticated: false,
+      signoff: {
+        internalTrial: 'pass',
+        reason: 'authenticated smoke passed',
+      },
+      summary: { pass: 8, skipped: 0, fail: 0 },
+      checks: [
+        { id: 'api-health', status: 'pass' },
+        { id: 'auth-me', status: 'pass' },
+      ],
+    })}\n`)
+
+    const result = await runScript(['--input', evidencePath, '--require-auth-signoff'])
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stdout, /Internal trial signoff: \*\*BLOCKED\*\*/)
+    assert.match(result.stdout, /authenticated signoff evidence is inconsistent: authenticated checks did not run/)
+    assert.match(result.stdout, /Authenticated checks: `no`/)
+  } finally {
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('blocks explicit pass when signoff evidence has failed checks', async () => {
+  const outDir = makeTmpDir()
+  const evidencePath = path.join(outDir, 'evidence.json')
+  try {
+    writeFileSync(evidencePath, `${JSON.stringify({
+      ok: true,
+      baseUrl: 'http://127.0.0.1:8081',
+      authenticated: true,
+      signoff: {
+        internalTrial: 'pass',
+        reason: 'authenticated smoke passed',
+      },
+      summary: { pass: 8, skipped: 0, fail: 1 },
+      checks: [
+        { id: 'api-health', status: 'pass' },
+        { id: 'auth-me', status: 'pass' },
+        { id: 'integration-route-contract', status: 'fail' },
+      ],
+    })}\n`)
+
+    const result = await runScript(['--input', evidencePath, '--require-auth-signoff'])
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stdout, /Internal trial signoff: \*\*BLOCKED\*\*/)
+    assert.match(result.stdout, /authenticated signoff evidence is inconsistent: summary\.fail is not 0/)
+    assert.match(result.stdout, /Summary: `8 pass \/ 0 skipped \/ 1 fail`/)
+  } finally {
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('blocks inferred pass when authenticated evidence has failed checks', async () => {
+  const outDir = makeTmpDir()
+  const evidencePath = path.join(outDir, 'evidence.json')
+  try {
+    writeFileSync(evidencePath, `${JSON.stringify({
+      ok: true,
+      baseUrl: 'http://127.0.0.1:8081',
+      authenticated: true,
+      summary: { pass: 8, skipped: 0, fail: 1 },
+      checks: [
+        { id: 'api-health', status: 'pass' },
+        { id: 'auth-me', status: 'pass' },
+        { id: 'integration-route-contract', status: 'fail' },
+      ],
+    })}\n`)
+
+    const result = await runScript(['--input', evidencePath, '--require-auth-signoff'])
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stdout, /Internal trial signoff: \*\*BLOCKED\*\*/)
+    assert.match(result.stdout, /Signoff reason: one or more smoke checks failed/)
+  } finally {
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
 test('renders fail summary without failing the summary renderer', async () => {
   const outDir = makeTmpDir()
   const evidencePath = path.join(outDir, 'evidence.json')

--- a/scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs
@@ -87,9 +87,12 @@ test('manual K3 WISE postdeploy smoke workflow keeps dispatch and auth contract 
   assertContains(raw, 'steps.token_resolve.outputs.token_resolve_rc', 'manual final gate')
   assertContains(raw, 'steps.env_check.outputs.env_check_rc', 'manual final gate')
   assertContains(raw, 'steps.smoke.outputs.smoke_rc', 'manual final gate')
+  assertContains(raw, "REQUIRE_AUTH: ${{ github.event.inputs.require_auth || 'true' }}", 'manual final gate')
   assertContains(raw, 'K3 WISE smoke token resolution failed', 'manual final gate')
   assertContains(raw, 'K3 WISE postdeploy smoke input check failed', 'manual final gate')
   assertContains(raw, 'K3 WISE postdeploy smoke failed', 'manual final gate')
+  assertContains(raw, 'scripts/ops/integration-k3wise-signoff-gate.mjs', 'manual final gate')
+  assertContains(raw, '--input output/integration-k3wise-postdeploy-smoke/manual/integration-k3wise-postdeploy-smoke.json', 'manual final gate')
 })
 
 test('deploy workflow keeps K3 WISE smoke evidence wired into deploy summary and artifacts', () => {

--- a/scripts/ops/integration-k3wise-signoff-gate.mjs
+++ b/scripts/ops/integration-k3wise-signoff-gate.mjs
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const REQUIRED_PASS_CHECKS = [
+  'auth-me',
+  'integration-route-contract',
+  'integration-list-external-systems',
+  'integration-list-pipelines',
+  'integration-list-runs',
+  'integration-list-dead-letters',
+  'staging-descriptor-contract',
+]
+
+class K3WiseSignoffGateError extends Error {
+  constructor(message, details = {}) {
+    super(message)
+    this.name = 'K3WiseSignoffGateError'
+    this.details = details
+  }
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/ops/integration-k3wise-signoff-gate.mjs --input <path>
+
+Machine-checks K3 WISE postdeploy smoke evidence for internal-trial signoff.
+Public-only smoke and presentation summaries are not accepted as signoff.
+
+Required evidence:
+  ok === true
+  authenticated === true
+  signoff.internalTrial === "pass"
+  summary.fail === 0
+  required checks pass: ${REQUIRED_PASS_CHECKS.join(', ')}
+
+Options:
+  --input <path>  K3 WISE postdeploy smoke evidence JSON path
+  --help          Show this help
+`)
+}
+
+function readRequiredValue(argv, index, flag) {
+  const next = argv[index + 1]
+  if (!next || next.startsWith('--')) {
+    throw new K3WiseSignoffGateError(`${flag} requires a value`, { flag })
+  }
+  return next
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+  const opts = {
+    input: '',
+    help: false,
+  }
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    switch (arg) {
+      case '--input':
+        opts.input = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--help':
+      case '-h':
+        opts.help = true
+        break
+      default:
+        throw new K3WiseSignoffGateError(`unknown option: ${arg}`, { arg })
+    }
+  }
+
+  if (!opts.help && !opts.input) {
+    throw new K3WiseSignoffGateError('--input is required')
+  }
+
+  return opts
+}
+
+function asNonNegativeInteger(value) {
+  if (value === undefined || value === null || value === '') return null
+  const number = Number(value)
+  return Number.isInteger(number) && number >= 0 ? number : null
+}
+
+function getCheckMap(evidence) {
+  const checks = Array.isArray(evidence?.checks) ? evidence.checks : []
+  return new Map(
+    checks
+      .filter((check) => check && typeof check === 'object' && typeof check.id === 'string')
+      .map((check) => [check.id, check]),
+  )
+}
+
+function evaluateSignoffEvidence(evidence) {
+  const failures = []
+  const checkMap = getCheckMap(evidence)
+  const summaryFail = asNonNegativeInteger(evidence?.summary?.fail)
+
+  if (!evidence || typeof evidence !== 'object' || Array.isArray(evidence)) {
+    failures.push('evidence JSON must be an object')
+  }
+  if (evidence?.ok !== true) {
+    failures.push('top-level ok must be true')
+  }
+  if (evidence?.authenticated !== true) {
+    failures.push('authenticated checks must have run')
+  }
+  if (evidence?.signoff?.internalTrial !== 'pass') {
+    failures.push('signoff.internalTrial must be pass')
+  }
+  if (summaryFail !== 0) {
+    failures.push('summary.fail must be 0')
+  }
+
+  const missingChecks = []
+  const failedChecks = []
+  for (const checkId of REQUIRED_PASS_CHECKS) {
+    const check = checkMap.get(checkId)
+    if (!check) {
+      missingChecks.push(checkId)
+    } else if (check.status !== 'pass') {
+      failedChecks.push(`${checkId}:${check.status || 'unknown'}`)
+    }
+  }
+
+  if (missingChecks.length > 0) {
+    failures.push(`missing required checks: ${missingChecks.join(', ')}`)
+  }
+  if (failedChecks.length > 0) {
+    failures.push(`required checks not passing: ${failedChecks.join(', ')}`)
+  }
+
+  return {
+    ok: failures.length === 0,
+    status: failures.length === 0 ? 'PASS' : 'BLOCKED',
+    reason: failures.length === 0 ? 'authenticated postdeploy smoke satisfies internal-trial gate' : failures.join('; '),
+    requiredChecks: REQUIRED_PASS_CHECKS,
+    summary: {
+      pass: asNonNegativeInteger(evidence?.summary?.pass),
+      skipped: asNonNegativeInteger(evidence?.summary?.skipped),
+      fail: summaryFail,
+    },
+    authenticated: evidence?.authenticated === true,
+    signoff: evidence?.signoff?.internalTrial || null,
+  }
+}
+
+async function readEvidence(inputPath) {
+  const raw = await readFile(inputPath, 'utf8')
+  try {
+    return JSON.parse(raw)
+  } catch (error) {
+    throw new K3WiseSignoffGateError(`invalid evidence JSON: ${inputPath}`, {
+      cause: error && error.message ? error.message : String(error),
+    })
+  }
+}
+
+async function runCli(argv = process.argv.slice(2)) {
+  const opts = parseArgs(argv)
+  if (opts.help) {
+    printHelp()
+    return 0
+  }
+
+  const inputPath = path.resolve(opts.input)
+  const evidence = await readEvidence(inputPath)
+  const result = evaluateSignoffEvidence(evidence)
+  console.log(JSON.stringify(result, null, 2))
+  return result.ok ? 0 : 1
+}
+
+const entryPath = process.argv[1] ? pathToFileURL(path.resolve(process.argv[1])).href : null
+if (entryPath && import.meta.url === entryPath) {
+  runCli().then((code) => {
+    process.exit(code)
+  }).catch((error) => {
+    const body = error instanceof K3WiseSignoffGateError
+      ? { ok: false, code: error.name, message: error.message, details: error.details }
+      : { ok: false, code: error && error.name ? error.name : 'Error', message: error && error.message ? error.message : String(error) }
+    console.error(JSON.stringify(body, null, 2))
+    process.exit(1)
+  })
+}
+
+export {
+  K3WiseSignoffGateError,
+  REQUIRED_PASS_CHECKS,
+  evaluateSignoffEvidence,
+  parseArgs,
+  runCli,
+}

--- a/scripts/ops/integration-k3wise-signoff-gate.test.mjs
+++ b/scripts/ops/integration-k3wise-signoff-gate.test.mjs
@@ -1,0 +1,211 @@
+import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const scriptPath = path.join(repoRoot, 'scripts', 'ops', 'integration-k3wise-signoff-gate.mjs')
+const requiredPassChecks = [
+  'auth-me',
+  'integration-route-contract',
+  'integration-list-external-systems',
+  'integration-list-pipelines',
+  'integration-list-runs',
+  'integration-list-dead-letters',
+  'staging-descriptor-contract',
+]
+
+function makeTmpDir() {
+  return mkdtempSync(path.join(tmpdir(), 'integration-k3wise-signoff-gate-'))
+}
+
+function runScript(args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [scriptPath, ...args], { stdio: ['ignore', 'pipe', 'pipe'] })
+    let stdout = ''
+    let stderr = ''
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL')
+      reject(new Error(`script timed out\nstdout=${stdout}\nstderr=${stderr}`))
+    }, 10_000)
+
+    child.stdout.setEncoding('utf8')
+    child.stderr.setEncoding('utf8')
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk
+    })
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk
+    })
+    child.on('error', (error) => {
+      clearTimeout(timer)
+      reject(error)
+    })
+    child.on('close', (status) => {
+      clearTimeout(timer)
+      resolve({ status, stdout, stderr })
+    })
+  })
+}
+
+function writeEvidence(dir, overrides = {}) {
+  const evidence = {
+    ok: true,
+    generatedAt: '2026-05-06T00:00:00.000Z',
+    baseUrl: 'http://127.0.0.1:8081',
+    authenticated: true,
+    requireAuth: true,
+    signoff: {
+      internalTrial: 'pass',
+      reason: 'authenticated smoke passed',
+    },
+    checks: requiredPassChecks.map((id) => ({ id, status: 'pass' })),
+    summary: { pass: requiredPassChecks.length + 3, skipped: 0, fail: 0 },
+    ...overrides,
+  }
+  const evidencePath = path.join(dir, 'integration-k3wise-postdeploy-smoke.json')
+  writeFileSync(evidencePath, `${JSON.stringify(evidence, null, 2)}\n`)
+  return evidencePath
+}
+
+test('passes authenticated postdeploy evidence with all required checks', async () => {
+  const outDir = makeTmpDir()
+  try {
+    const evidencePath = writeEvidence(outDir)
+
+    const result = await runScript(['--input', evidencePath])
+
+    assert.equal(result.status, 0, result.stderr)
+    const body = JSON.parse(result.stdout)
+    assert.equal(body.ok, true)
+    assert.equal(body.status, 'PASS')
+    assert.equal(body.signoff, 'pass')
+    assert.equal(body.summary.fail, 0)
+  } finally {
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('blocks public-only evidence even when diagnostic smoke passed', async () => {
+  const outDir = makeTmpDir()
+  try {
+    const evidencePath = writeEvidence(outDir, {
+      authenticated: false,
+      signoff: {
+        internalTrial: 'blocked',
+        reason: 'authenticated checks did not run',
+      },
+      checks: [
+        { id: 'api-health', status: 'pass' },
+        { id: 'integration-plugin-health', status: 'pass' },
+        { id: 'k3-wise-frontend-route', status: 'pass' },
+        { id: 'authenticated-integration-contract', status: 'skipped' },
+      ],
+      summary: { pass: 3, skipped: 1, fail: 0 },
+    })
+
+    const result = await runScript(['--input', evidencePath])
+
+    assert.equal(result.status, 1)
+    const body = JSON.parse(result.stdout)
+    assert.equal(body.status, 'BLOCKED')
+    assert.match(body.reason, /authenticated checks must have run/)
+    assert.match(body.reason, /missing required checks: auth-me/)
+  } finally {
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('blocks stale explicit pass when top-level ok is false', async () => {
+  const outDir = makeTmpDir()
+  try {
+    const evidencePath = writeEvidence(outDir, {
+      ok: false,
+      summary: { pass: requiredPassChecks.length, skipped: 0, fail: 0 },
+    })
+
+    const result = await runScript(['--input', evidencePath])
+
+    assert.equal(result.status, 1)
+    assert.match(JSON.parse(result.stdout).reason, /top-level ok must be true/)
+  } finally {
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('blocks stale explicit pass when summary.fail is nonzero', async () => {
+  const outDir = makeTmpDir()
+  try {
+    const evidencePath = writeEvidence(outDir, {
+      summary: { pass: requiredPassChecks.length, skipped: 0, fail: 1 },
+    })
+
+    const result = await runScript(['--input', evidencePath])
+
+    assert.equal(result.status, 1)
+    assert.match(JSON.parse(result.stdout).reason, /summary\.fail must be 0/)
+  } finally {
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('blocks when a required check is missing', async () => {
+  const outDir = makeTmpDir()
+  try {
+    const evidencePath = writeEvidence(outDir, {
+      checks: requiredPassChecks
+        .filter((id) => id !== 'staging-descriptor-contract')
+        .map((id) => ({ id, status: 'pass' })),
+    })
+
+    const result = await runScript(['--input', evidencePath])
+
+    assert.equal(result.status, 1)
+    assert.match(JSON.parse(result.stdout).reason, /missing required checks: staging-descriptor-contract/)
+  } finally {
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('blocks when a required check is not passing', async () => {
+  const outDir = makeTmpDir()
+  try {
+    const evidencePath = writeEvidence(outDir, {
+      checks: requiredPassChecks.map((id) => ({
+        id,
+        status: id === 'integration-list-runs' ? 'fail' : 'pass',
+      })),
+    })
+
+    const result = await runScript(['--input', evidencePath])
+
+    assert.equal(result.status, 1)
+    assert.match(JSON.parse(result.stdout).reason, /required checks not passing: integration-list-runs:fail/)
+  } finally {
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('missing evidence fails by default', async () => {
+  const outDir = makeTmpDir()
+  try {
+    const result = await runScript(['--input', path.join(outDir, 'missing.json')])
+
+    assert.equal(result.status, 1)
+    assert.match(result.stderr, /ENOENT/)
+    assert.equal(result.stdout, '')
+  } finally {
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('help prints usage', async () => {
+  const result = await runScript(['--help'])
+
+  assert.equal(result.status, 0, result.stderr)
+  assert.match(result.stdout, /Usage: node scripts\/ops\/integration-k3wise-signoff-gate\.mjs/)
+  assert.match(result.stdout, /auth-me/)
+})


### PR DESCRIPTION
## Summary
- adds a machine-readable K3 WISE postdeploy signoff gate for authenticated evidence
- blocks contradictory human summary PASS output when ok/authenticated/summary.fail disagree
- wires the manual postdeploy workflow final gate after summary/artifact upload so blocked evidence is preserved
- records current-main development and verification evidence

## Verification
- node --check scripts/ops/integration-k3wise-signoff-gate.mjs
- node --test scripts/ops/integration-k3wise-signoff-gate.test.mjs
- node --test scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
- node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs scripts/ops/integration-k3wise-postdeploy-summary.test.mjs scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs scripts/ops/integration-k3wise-signoff-gate.test.mjs
- git diff --check origin/main..HEAD

Supersedes #1324 and #1326.