### PR TITLE
test(integration): refresh K3 SQL mock channel contract

### DIFF
--- a/docs/development/integration-k3wise-sqlmock-channel-contract-refresh-development-20260513.md
+++ b/docs/development/integration-k3wise-sqlmock-channel-contract-refresh-development-20260513.md
@@ -1,0 +1,47 @@
+# K3 WISE SQL Mock Channel Contract Refresh Development - 2026-05-13
+
+## Context
+
+PR #1335 was still open from the 2026-05-06 K3 WISE stale queue. Its original goal was to align the offline SQL Server mock with the real K3 WISE SQL Server channel contract.
+
+Current `main` already contains a narrower SQL parser hardening from #1404: bracketed and three-part identifiers resolve correctly. The remaining gap was still real:
+
+- The mock executor implemented `query()` and `exec()`.
+- The real K3 SQL Server channel requires `queryExecutor.select()` for reads.
+- The real K3 SQL Server channel requires `queryExecutor.insertMany()` for middle-table writes.
+- `run-mock-poc-demo.mjs` still called `mockSql.query()` directly, so the offline PoC could pass without exercising the real channel read/upsert path.
+
+## Change
+
+This refresh keeps the #1404 identifier coverage and adds the missing channel contract:
+
+- `createMockSqlServerExecutor()` now implements `select()` and `insertMany()`.
+- The mock still exposes legacy `query()` and `exec()` for focused SQL safety probes.
+- `run-mock-poc-demo.mjs` now calls `sqlChannel.read()` and `sqlChannel.upsert()` before the raw `exec()` core-table write rejection probe.
+- `verify:integration-k3wise:poc` now includes `mock-sqlserver-executor.test.mjs`.
+- The fixture README documents the real channel contract and the extra local verification command.
+
+## Safety Hardening
+
+The mock parser now treats these as writes or forbidden operations:
+
+- CTE-wrapped mutating SQL, such as `WITH ... DELETE ...`
+- `MERGE INTO ...`
+- unsupported SQL operations such as `EXEC ...`
+- schema DDL verbs such as `CREATE`, `ALTER`, `DROP`, and `TRUNCATE`
+
+Direct writes to K3 core tables remain blocked. Writes to integration middle tables remain allowed.
+
+## Disposition Of Old PR
+
+This current-main refresh supersedes #1335. The old branch lacked the later #1404 identifier tests and should be closed after this branch is opened.
+
+## Files
+
+- `package.json`
+- `scripts/ops/fixtures/integration-k3wise/mock-sqlserver-executor.mjs`
+- `scripts/ops/fixtures/integration-k3wise/mock-sqlserver-executor.test.mjs`
+- `scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs`
+- `scripts/ops/fixtures/integration-k3wise/README.md`
+- `docs/development/integration-k3wise-sqlmock-channel-contract-refresh-development-20260513.md`
+- `docs/development/integration-k3wise-sqlmock-channel-contract-refresh-verification-20260513.md`

--- a/docs/development/integration-k3wise-sqlmock-channel-contract-refresh-verification-20260513.md
+++ b/docs/development/integration-k3wise-sqlmock-channel-contract-refresh-verification-20260513.md
@@ -1,0 +1,59 @@
+# K3 WISE SQL Mock Channel Contract Refresh Verification - 2026-05-13
+
+## Local Verification
+
+```bash
+node --check scripts/ops/fixtures/integration-k3wise/mock-sqlserver-executor.mjs
+```
+
+Result:
+
+- Syntax check passes.
+
+```bash
+node --test scripts/ops/fixtures/integration-k3wise/mock-sqlserver-executor.test.mjs
+```
+
+Result:
+
+- SQL mock contract suite passed: 12/12.
+- Real channel `read()` goes through mock `select()`.
+- Real channel `upsert()` goes through mock `insertMany()`.
+- Direct K3 core-table upsert stays rejected before executor write.
+- CTE-wrapped writes, `MERGE`, and unsupported `EXEC` are rejected.
+- Existing bracketed and three-part identifier coverage remains passing.
+
+```bash
+node scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs
+```
+
+Result:
+
+- Mock K3 WebAPI Save-only flow passes.
+- SQL channel `read()` returns one canned K3 core-table row.
+- SQL channel `upsert()` writes one integration middle-table row.
+- Raw SQL safety probe rejects `INSERT` into `t_ICItem`.
+- Evidence compiler returns PASS.
+
+```bash
+pnpm run verify:integration-k3wise:poc
+```
+
+Result:
+
+- Preflight tests passed: 20/20.
+- Evidence tests passed: 37/37.
+- SQL mock contract tests passed: 12/12.
+- Mock PoC chain completed with PASS.
+
+```bash
+git diff --check origin/main..HEAD
+```
+
+Result:
+
+- No whitespace errors.
+
+## Notes
+
+This verification is offline. It validates fixture/adapter contract coverage before a live customer K3 WISE run, not a real customer database.

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "profile:multitable-grid:staging": "RUNNER_SCRIPT=scripts/profile-multitable-grid.mjs RUN_LABEL=multitable-grid-profile-staging RUN_MODE=staging RUNNER_REPORT_BASENAME=staging-report AUTO_START_SERVICES=false REQUIRE_RUNNING_SERVICES=true bash scripts/ops/multitable-pilot-local.sh",
     "verify:multitable-grid-profile:summary": "node scripts/ops/multitable-grid-profile-summary.mjs",
     "verify:integration-erp-plm:deploy-readiness": "node scripts/ops/integration-erp-plm-deploy-readiness.mjs",
-    "verify:integration-k3wise:poc": "node --test scripts/ops/integration-k3wise-live-poc-preflight.test.mjs && node --test scripts/ops/integration-k3wise-live-poc-evidence.test.mjs && node scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs",
+    "verify:integration-k3wise:poc": "node --test scripts/ops/integration-k3wise-live-poc-preflight.test.mjs && node --test scripts/ops/integration-k3wise-live-poc-evidence.test.mjs && node --test scripts/ops/fixtures/integration-k3wise/mock-sqlserver-executor.test.mjs && node scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs",
     "verify:integration-k3wise:onprem-preflight": "node --test scripts/ops/integration-k3wise-onprem-preflight.test.mjs",
     "verify:integration-k3wise:postdeploy-env-check": "node --test scripts/ops/integration-k3wise-postdeploy-env-check.test.mjs",
     "phase5:run-all": "bash scripts/phase5-run-all.sh",

--- a/scripts/ops/fixtures/integration-k3wise/README.md
+++ b/scripts/ops/fixtures/integration-k3wise/README.md
@@ -12,14 +12,16 @@ Fixtures and mock server for the K3 WISE Live PoC chain. Used to:
 | `gate-sample.json` | Customer GATE answer template. Customer copies, fills in real values (K3 version, URLs, credentials placeholders), saves outside Git. Endpoint URLs must not include inline username/password or secret-like query params; use credential fields instead. |
 | `evidence-sample.json` | Customer-side evidence template after live PoC. Customer fills in run IDs, K3 record IDs, statuses, etc. |
 | `mock-k3-webapi-server.mjs` | Minimal in-process HTTP mock for K3 WISE WebAPI: Login / Health / Material / BOM Save / Submit / Audit. NOT a full K3 simulator. |
-| `mock-sqlserver-executor.mjs` | Mock SQL executor: read-only on K3 core tables, writeable on integration middle tables, rejects writes to `t_ICItem` / `t_ICBOM`. |
-| `run-mock-poc-demo.mjs` | End-to-end smoke: loads gate sample → preflight → spins up mock K3 → adapter Save-only → SQL channel readonly probe → evidence compile → asserts PASS. |
+| `mock-sqlserver-executor.mjs` | Mock SQL executor: implements the real K3 SQL channel `select()` / `insertMany()` contract, keeps legacy `query()` / `exec()` probes, and rejects core-table writes. |
+| `mock-sqlserver-executor.test.mjs` | Contract test for SQL mock safety parsing and real channel compatibility, including CTE-wrapped writes, `MERGE`, and bracket-qualified K3 core tables. |
+| `run-mock-poc-demo.mjs` | End-to-end smoke: loads gate sample → preflight → spins up mock K3 → adapter Save-only → SQL channel read/upsert probes → evidence compile → asserts PASS. |
 
 ## Local verification
 
 From repo root:
 
 ```bash
+node --test scripts/ops/fixtures/integration-k3wise/mock-sqlserver-executor.test.mjs
 node scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs
 ```
 

--- a/scripts/ops/fixtures/integration-k3wise/mock-sqlserver-executor.mjs
+++ b/scripts/ops/fixtures/integration-k3wise/mock-sqlserver-executor.mjs
@@ -7,6 +7,8 @@
 //
 // Returns a small executor object compatible with the adapter contract:
 //   testConnection() → { ok: true, ... }
+//   select({ table, ... }) → { records, nextCursor, done }
+//   insertMany({ table, records, ... }) → { written, failed, errors, results }
 //   query({ sql, params }) → { rows: [...] }
 //   exec({ sql, params }) → { rowsAffected, lastId? }
 //
@@ -20,11 +22,12 @@ const K3_CORE_TABLES = new Set([
   't_measureunit',
   't_organization',
 ])
+const WRITE_OPERATIONS = new Set(['insert', 'update', 'delete', 'merge'])
 
 function tableNameFromSql(sql) {
   const identifier = /(?:"[^"]+"|\[[^\]]+\]|[a-z_][a-z0-9_]*)/i
   const reference = new RegExp(
-    `(?:from|into|update|table)\\s+(${identifier.source}(?:\\s*\\.\\s*${identifier.source}){0,2})`,
+    `(?:from|into|update|table|merge(?:\\s+into)?)\\s+(${identifier.source}(?:\\s*\\.\\s*${identifier.source}){0,2})`,
     'i',
   )
   const match = sql.match(reference)
@@ -35,12 +38,35 @@ function tableNameFromSql(sql) {
   return table ? table.replace(/^["[]|["\]]$/g, '').toLowerCase() : null
 }
 
+function normalizeTableName(table) {
+  return String(table || '')
+    .trim()
+    .replace(/["\[\]]/g, '')
+    .split('.')
+    .pop()
+    .toLowerCase()
+}
+
+function hasMutatingCte(sql) {
+  return /\b(?:INSERT\s+INTO|UPDATE|DELETE\s+FROM|MERGE(?:\s+INTO)?|TRUNCATE\s+TABLE|ALTER\s+TABLE|DROP\s+TABLE|CREATE\s+TABLE)\b/i.test(sql)
+}
+
 function operationFromSql(sql) {
   const trimmed = sql.trim().toUpperCase()
-  if (trimmed.startsWith('SELECT') || trimmed.startsWith('WITH')) return 'read'
+  if (trimmed.startsWith('SELECT')) return 'read'
+  if (trimmed.startsWith('WITH')) return hasMutatingCte(sql) ? 'cte-write' : 'read'
   if (trimmed.startsWith('INSERT')) return 'insert'
   if (trimmed.startsWith('UPDATE')) return 'update'
   if (trimmed.startsWith('DELETE')) return 'delete'
+  if (trimmed.startsWith('MERGE')) return 'merge'
+  if (
+    trimmed.startsWith('TRUNCATE') ||
+    trimmed.startsWith('ALTER') ||
+    trimmed.startsWith('DROP') ||
+    trimmed.startsWith('CREATE')
+  ) {
+    return 'schema'
+  }
   return 'unknown'
 }
 
@@ -67,12 +93,37 @@ export function createMockSqlServerExecutor({
       const rows = cannedReadResults[table] || []
       return { rows }
     },
+    async select({ table, columns, limit, cursor, filters, orderBy, watermark, options, system } = {}) {
+      const normalizedTable = normalizeTableName(table)
+      queryLog.push({
+        op: 'select',
+        table: normalizedTable,
+        columns,
+        limit,
+        cursor,
+        filters,
+        orderBy,
+        watermark,
+        options,
+        systemId: system && system.id,
+      })
+      const rows = cannedReadResults[normalizedTable] || []
+      const boundedRows = Number.isInteger(limit) && limit >= 0 ? rows.slice(0, limit) : rows
+      return {
+        records: boundedRows,
+        nextCursor: null,
+        done: true,
+      }
+    },
     async exec({ sql, params = [] } = {}) {
       const op = operationFromSql(sql)
       const table = tableNameFromSql(sql)
       queryLog.push({ sql, params, op, table })
       if (op === 'read') {
         throw new Error(`mock SQL: exec() rejects read operation; use query() instead`)
+      }
+      if (!WRITE_OPERATIONS.has(op)) {
+        throw new Error(`mock SQL safety: unsupported operation "${op}" on ${table || sql.slice(0, 60)} is forbidden in PoC`)
       }
       if (table && K3_CORE_TABLES.has(table)) {
         throw new Error(`mock SQL safety: ${op.toUpperCase()} on K3 core table ${table} is forbidden in PoC`)
@@ -84,6 +135,37 @@ export function createMockSqlServerExecutor({
       list.push({ sql, params })
       writes.set(table, list)
       return { rowsAffected: 1 }
+    },
+    async insertMany({ table, records = [], keyFields = [], mode, options, system } = {}) {
+      const normalizedTable = normalizeTableName(table)
+      queryLog.push({
+        op: 'insertMany',
+        table: normalizedTable,
+        records,
+        keyFields,
+        mode,
+        options,
+        systemId: system && system.id,
+      })
+      if (K3_CORE_TABLES.has(normalizedTable)) {
+        throw new Error(`mock SQL safety: INSERTMANY on K3 core table ${normalizedTable} is forbidden in PoC`)
+      }
+      if (!normalizedTable.startsWith(middleTablePrefix)) {
+        throw new Error(`mock SQL safety: INSERTMANY on non-middle table ${normalizedTable} is forbidden (prefix must be "${middleTablePrefix}")`)
+      }
+      const list = writes.get(normalizedTable) || []
+      for (const record of records) list.push({ record, keyFields, mode, options })
+      writes.set(normalizedTable, list)
+      return {
+        written: records.length,
+        failed: 0,
+        errors: [],
+        results: records.map((record, index) => ({
+          index,
+          status: 'written',
+          key: keyFields.length > 0 ? record[keyFields[0]] : undefined,
+        })),
+      }
     },
   }
 }

--- a/scripts/ops/fixtures/integration-k3wise/mock-sqlserver-executor.test.mjs
+++ b/scripts/ops/fixtures/integration-k3wise/mock-sqlserver-executor.test.mjs
@@ -1,9 +1,109 @@
 #!/usr/bin/env node
 
 import assert from 'node:assert/strict'
+import { createRequire } from 'node:module'
 import test from 'node:test'
 
 import { createMockSqlServerExecutor } from './mock-sqlserver-executor.mjs'
+
+const require = createRequire(import.meta.url)
+const { createK3WiseSqlServerChannel } = require('../../../../plugins/plugin-integration-core/lib/adapters/k3-wise-sqlserver-channel.cjs')
+
+function createExecutor() {
+  return createMockSqlServerExecutor({
+    cannedReadResults: {
+      t_icitem: [{ FItemID: 1001, FNumber: 'MAT-EXISTING', FName: 'Existing material' }],
+    },
+  })
+}
+
+function createChannel(executor = createExecutor()) {
+  return createK3WiseSqlServerChannel({
+    system: {
+      id: 'mock-sql',
+      name: 'Mock K3 SQL',
+      kind: 'erp:k3-wise-sqlserver',
+      role: 'bidirectional',
+      config: {
+        allowedTables: ['t_ICItem', 'dbo.integration_material_stage'],
+        objects: {
+          material_stage: {
+            table: 'dbo.integration_material_stage',
+            operations: ['upsert'],
+            writeMode: 'middle-table',
+            keyField: 'FNumber',
+            schema: [{ name: 'FNumber', type: 'string', required: true }],
+          },
+        },
+      },
+    },
+    queryExecutor: executor,
+  })
+}
+
+test('mock SQL executor satisfies real channel read contract', async () => {
+  const executor = createExecutor()
+  const channel = createChannel(executor)
+  const result = await channel.read({ object: 'material', limit: 1 })
+
+  assert.equal(result.records.length, 1)
+  assert.equal(result.records[0].FNumber, 'MAT-EXISTING')
+  assert.equal(result.metadata.table, 't_ICItem')
+  assert.equal(executor.queryLog[0].op, 'select')
+  assert.equal(executor.queryLog[0].table, 't_icitem')
+})
+
+test('mock SQL executor satisfies real channel middle-table upsert contract', async () => {
+  const executor = createExecutor()
+  const channel = createChannel(executor)
+  const result = await channel.upsert({
+    object: 'material_stage',
+    records: [{ FNumber: 'MAT-MOCK-001', FName: 'Mock material' }],
+    keyFields: ['FNumber'],
+  })
+
+  assert.equal(result.written, 1)
+  assert.equal(result.failed, 0)
+  assert.equal(result.metadata.table, 'dbo.integration_material_stage')
+  assert.equal(executor.writes.get('integration_material_stage').length, 1)
+  assert.deepEqual(executor.writes.get('integration_material_stage')[0].record, {
+    FNumber: 'MAT-MOCK-001',
+    FName: 'Mock material',
+  })
+})
+
+test('real channel still rejects direct K3 core table upsert before executor write', async () => {
+  const executor = createExecutor()
+  const channel = createK3WiseSqlServerChannel({
+    system: {
+      id: 'mock-sql',
+      name: 'Mock K3 SQL',
+      kind: 'erp:k3-wise-sqlserver',
+      role: 'bidirectional',
+      config: {
+        allowedTables: ['t_ICItem'],
+        objects: {
+          material_write: {
+            table: 't_ICItem',
+            operations: ['upsert'],
+            keyField: 'FNumber',
+          },
+        },
+      },
+    },
+    queryExecutor: executor,
+  })
+
+  await assert.rejects(
+    channel.upsert({
+      object: 'material_write',
+      records: [{ FNumber: 'MAT-FORBIDDEN' }],
+      keyFields: ['FNumber'],
+    }),
+    /only writes to configured middle tables/,
+  )
+  assert.equal(executor.writes.size, 0)
+})
 
 test('mock SQL executor resolves bracketed schema-qualified K3 core table reads', async () => {
   const executor = createMockSqlServerExecutor({
@@ -62,6 +162,51 @@ test('mock SQL executor still blocks bracketed schema-qualified K3 core table wr
     /K3 core table t_icitem is forbidden/,
   )
   assert.equal(executor.queryLog[0].table, 't_icitem')
+})
+
+test('mock SQL executor allows read-only CTE queries against K3 core tables', async () => {
+  const executor = createExecutor()
+  const result = await executor.query({
+    sql: 'WITH existing AS (SELECT FItemID, FNumber FROM [dbo].[t_ICItem]) SELECT * FROM existing WHERE FNumber = ?',
+    params: ['MAT-EXISTING'],
+  })
+
+  assert.equal(result.rows.length, 1)
+  assert.equal(executor.queryLog[0].op, 'read')
+  assert.equal(executor.queryLog[0].table, 't_icitem')
+})
+
+test('mock SQL executor rejects CTE-wrapped mutating queries through query()', async () => {
+  const executor = createExecutor()
+
+  await assert.rejects(
+    executor.query({
+      sql: 'WITH doomed AS (SELECT FItemID FROM dbo.t_ICItem) DELETE FROM doomed WHERE FItemID = ?',
+      params: [1001],
+    }),
+    /query\(\) rejects non-read operation "cte-write" on t_icitem/,
+  )
+})
+
+test('mock SQL executor rejects MERGE into K3 core tables', async () => {
+  const executor = createExecutor()
+
+  await assert.rejects(
+    executor.exec({
+      sql: 'MERGE INTO [dbo].[t_ICItem] AS target USING dbo.integration_material_stage AS source ON target.FNumber = source.FNumber WHEN MATCHED THEN UPDATE SET FName = source.FName;',
+    }),
+    /MERGE on K3 core table t_icitem is forbidden in PoC/,
+  )
+})
+
+test('mock SQL executor rejects unsupported operations instead of logging null-table writes', async () => {
+  const executor = createExecutor()
+
+  await assert.rejects(
+    executor.exec({ sql: 'EXEC dbo.SomeUnsafeProcedure' }),
+    /unsupported operation "unknown".*forbidden in PoC/,
+  )
+  assert.equal(executor.writes.size, 0)
 })
 
 test('mock SQL executor resolves quoted schema-qualified middle-table writes', async () => {

--- a/scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs
+++ b/scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs
@@ -10,7 +10,7 @@
 //   4. Spin up mock SQL Server executor (in-process)
 //   5. Adapter testConnection on both
 //   6. Adapter Material Save-only upsert against mock K3 (autoSubmit=false, autoAudit=false)
-//   7. SQL channel readonly probe to verify the mock blocks core-table writes
+//   7. SQL channel read/upsert probes to verify the mock matches channel contract
 //   8. Compose evidence JSON (hardcoded for the values we just produced)
 //   9. evidence compiler: buildEvidenceReport(packet, evidence) → assert PASS
 //
@@ -90,7 +90,7 @@ async function main() {
         kind: 'erp:k3-wise-sqlserver',
         role: 'bidirectional',
         config: {
-          allowedTables: ['dbo.t_ICItem', 'dbo.integration_material_stage'],
+          allowedTables: ['t_ICItem', 'dbo.t_ICItem', 'dbo.integration_material_stage'],
           objects: {
             material_stage: {
               table: 'dbo.integration_material_stage',
@@ -156,13 +156,24 @@ async function main() {
     assert(bomPayload?.sourceId === undefined, 'BOM Save payload must not include internal source fields')
     console.log('✓ step 6b: K3 BOM Save-only upsert wrote 1 BOM with v1 Data template fields')
 
-    // 7. SQL channel readonly probe + safety check
+    // 7. SQL channel contract probes + safety check
     try {
-      sqlReadResult = await mockSql.query({ sql: 'SELECT FItemID, FNumber, FName FROM dbo.t_ICItem WHERE FNumber = ?', params: ['MAT-EXISTING'] })
-      assert(sqlReadResult.rows.length === 1, 'mock SQL readonly probe should return 1 row')
-      console.log(`✓ step 7a: SQL readonly probe returned ${sqlReadResult.rows.length} row from t_ICItem`)
+      sqlReadResult = await sqlChannel.read({ object: 'material', limit: 1 })
+      assert(sqlReadResult.records.length === 1, 'SQL channel readonly probe should return 1 row')
+      console.log(`✓ step 7a: SQL channel readonly probe returned ${sqlReadResult.records.length} row from t_ICItem`)
     } catch (error) {
-      throw new Error(`SQL readonly probe failed: ${error.message}`)
+      throw new Error(`SQL channel readonly probe failed: ${error.message}`)
+    }
+    try {
+      const middleWriteResult = await sqlChannel.upsert({
+        object: 'material_stage',
+        records: [{ FNumber: 'MAT-STAGE-001', FName: 'Mock staged material' }],
+        keyFields: ['FNumber'],
+      })
+      assert(middleWriteResult.written === 1, `expected 1 SQL middle-table write, got ${middleWriteResult.written}`)
+      console.log('✓ step 7b: SQL channel middle-table upsert wrote 1 integration row')
+    } catch (error) {
+      throw new Error(`SQL channel middle-table upsert failed: ${error.message}`)
     }
     try {
       await mockSql.exec({ sql: 'INSERT INTO dbo.t_ICItem (FNumber, FName) VALUES (?, ?)', params: ['MAT-FORBIDDEN', 'should be blocked'] })
@@ -171,7 +182,7 @@ async function main() {
       sqlWriteRejected = /core table/.test(error.message)
     }
     assert(sqlWriteRejected, 'SQL safety: write to t_ICItem must be rejected')
-    console.log('✓ step 7b: SQL safety guard rejected INSERT into t_ICItem (core table)')
+    console.log('✓ step 7c: SQL safety guard rejected INSERT into t_ICItem (core table)')
 
     // 8-9. Compose evidence + run compiler
     const evidence = {


### PR DESCRIPTION
## Summary
- aligns the K3 WISE SQL Server mock with the real channel select()/insertMany() contract
- moves the offline mock PoC demo through sqlChannel.read() and sqlChannel.upsert()
- keeps existing bracketed/three-part identifier coverage while adding CTE-write, MERGE, unsupported EXEC, and direct core-table write guards
- adds the SQL mock contract test into verify:integration-k3wise:poc
- records current-main development and verification evidence

## Verification
- node --check scripts/ops/fixtures/integration-k3wise/mock-sqlserver-executor.mjs
- node --test scripts/ops/fixtures/integration-k3wise/mock-sqlserver-executor.test.mjs
- node scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs
- pnpm run verify:integration-k3wise:poc
- git diff --check origin/main..HEAD

Supersedes #1335.