### PR TITLE
fix(integration): refresh K3 ERP feedback evidence gate

### DIFF
--- a/docs/development/integration-k3wise-erp-feedback-evidence-refresh-development-20260513.md
+++ b/docs/development/integration-k3wise-erp-feedback-evidence-refresh-development-20260513.md
@@ -1,0 +1,60 @@
+# K3 WISE ERP Feedback Evidence Refresh Development - 2026-05-13
+
+## Context
+
+PR #1338 was opened from an older K3 WISE PoC branch to require ERP feedback
+writeback evidence before a live PoC evidence packet can return `PASS`.
+Current `main` has since absorbed later K3 validation work, including the SQL
+mock channel contract refresh from #1508. This refresh ports only the still
+useful ERP feedback evidence gate onto current `main`.
+
+Before this change, the evidence compiler proved that K3 WISE accepted the
+Save-only material write, but it did not prove that MetaSheet wrote the ERP
+result back to staging rows for operator traceability.
+
+## Design
+
+`scripts/ops/integration-k3wise-live-poc-evidence.mjs` now adds required
+`erpFeedback` evidence immediately after the `materialSaveOnly` phase.
+
+Missing `erpFeedback` leaves the report at `PARTIAL`. A passed `erpFeedback`
+phase must prove:
+
+- at least one staging row or item was updated
+- field coverage includes `erpSyncStatus`
+- field coverage includes `erpResponseCode`
+- field coverage includes `erpResponseMessage`
+- field coverage includes `lastSyncedAt`
+- field coverage includes at least one external reference, either
+  `erpExternalId` or `erpBillNo`
+
+The validator accepts row-shaped proof through `updatedRows`, `updatedItems`,
+`items`, or `records`. It also accepts compact proof through `rowsUpdated` plus
+`fieldsUpdated` or `updatedFields`. This keeps the customer evidence packet
+flexible while preserving the required PASS contract.
+
+## Fixture Updates
+
+Updated evidence fixtures:
+
+- `scripts/ops/fixtures/integration-k3wise/evidence-sample.json`
+- `scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs`
+
+The mock PoC demo synthesizes feedback rows from the K3 Save-only upsert result.
+It preserves the current SQL channel probes from #1508:
+
+- `sqlChannel.read()` proves the read-only SQL route
+- `sqlChannel.upsert()` proves the middle-table write route
+- direct `mockSql.exec()` into a core table remains rejected by the safety guard
+
+## Compatibility
+
+This change touches only K3 WISE PoC evidence tooling, fixtures, tests, and
+development documentation. It does not alter runtime adapters, production
+routes, database schema, or deployment configuration.
+
+## Superseded Work
+
+This refresh supersedes PR #1338. The old branch carried the right evidence
+idea, but it was behind later K3 validation work and had stale verification
+artifacts.

--- a/docs/development/integration-k3wise-erp-feedback-evidence-refresh-verification-20260513.md
+++ b/docs/development/integration-k3wise-erp-feedback-evidence-refresh-verification-20260513.md
@@ -1,0 +1,84 @@
+# K3 WISE ERP Feedback Evidence Refresh Verification - 2026-05-13
+
+## Scope
+
+Refresh of PR #1338 on top of current `main` to require ERP feedback writeback
+evidence in the K3 WISE live PoC evidence compiler.
+
+## Commands
+
+```bash
+node --test scripts/ops/integration-k3wise-live-poc-evidence.test.mjs
+node scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs
+pnpm run verify:integration-k3wise:poc
+git diff --check origin/main..HEAD
+```
+
+## Expected Coverage
+
+- complete sample evidence returns `PASS`
+- missing `erpFeedback` returns `PARTIAL`
+- passed feedback with no updated rows returns `FAIL`
+- passed feedback missing required field coverage returns `FAIL`
+- compact `rowsUpdated + fieldsUpdated` proof can return `PASS`
+- mock PoC demo still exercises the SQL channel read/upsert contract from #1508
+
+## Local Results
+
+### Evidence Unit Suite
+
+```bash
+node --test scripts/ops/integration-k3wise-live-poc-evidence.test.mjs
+```
+
+Result: passed.
+
+- 41 tests passed
+- 0 failed
+- new ERP feedback cases passed:
+  - missing `erpFeedback` returns `PARTIAL`
+  - passed feedback with no updated rows returns `FAIL`
+  - passed feedback missing required field coverage returns `FAIL`
+  - compact `rowsUpdated + fieldsUpdated` proof can return `PASS`
+
+### Mock PoC Demo
+
+```bash
+node scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs
+```
+
+Result: passed.
+
+- K3 Save-only mock upsert wrote 2 records with 0 Submit and 0 Audit
+- BOM Save-only mock upsert wrote 1 BOM record
+- SQL channel read-only probe returned 1 row
+- SQL channel middle-table upsert wrote 1 integration row
+- SQL safety guard rejected direct core-table insert
+- evidence compiler returned `PASS` with 0 issues
+
+### Full K3 WISE PoC Gate
+
+```bash
+pnpm run verify:integration-k3wise:poc
+```
+
+Result: passed.
+
+- preflight suite: 20/20 passed
+- evidence suite: 41/41 passed
+- SQL mock contract suite: 12/12 passed
+- mock PoC demo: PASS
+
+### Whitespace Check
+
+```bash
+git diff --cached --check
+```
+
+Result: passed, no whitespace errors.
+
+## Notes
+
+This verification is local and offline. It validates the evidence compiler,
+fixtures, SQL mock channel contract, and mock PoC demo. It does not call a live
+K3 WISE instance.

--- a/scripts/ops/fixtures/integration-k3wise/evidence-sample.json
+++ b/scripts/ops/fixtures/integration-k3wise/evidence-sample.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Customer-side evidence template. Fill in after the live PoC run: status fields accept canonical (pass/fail/partial/skipped/todo/blocked), English synonyms (passed/complete/failed/error/etc), or Chinese (通过/成功/完成/失败/进行中/跳过/阻塞). Boolean fields (autoSubmit, autoAudit, legacyPipelineOptionsSourceProductId) accept true/false, 'true'/'false', 'yes'/'no', '是'/'否', or 0/1. ID fields (runId, productId) accept strings or finite numbers. Run: node scripts/ops/integration-k3wise-live-poc-evidence.mjs --packet <preflight-out>/packet.json --evidence <this>",
+  "_comment": "Customer-side evidence template. Fill in after the live PoC run: status fields accept canonical (pass/fail/partial/skipped/todo/blocked), English synonyms (passed/complete/failed/error/etc), or Chinese (通过/成功/完成/失败/进行中/跳过/阻塞). Boolean fields (autoSubmit, autoAudit, legacyPipelineOptionsSourceProductId) accept true/false, 'true'/'false', 'yes'/'no', '是'/'否', or 0/1. ID fields (runId, productId) accept strings or finite numbers. erpFeedback proves MetaSheet staging feedback fields were updated after K3 Save-only. Run: node scripts/ops/integration-k3wise-live-poc-evidence.mjs --packet <preflight-out>/packet.json --evidence <this>",
   "gate": {
     "status": "pass",
     "archivePath": "customer-secure-share://k3wise-gate-answers"
@@ -23,6 +23,32 @@
     "k3Records": [
       { "materialCode": "MAT-001", "externalId": "K3-1001", "billNo": "K3-BILL-001" },
       { "materialCode": "MAT-002", "externalId": "K3-1002", "billNo": "K3-BILL-002" }
+    ]
+  },
+  "erpFeedback": {
+    "status": "pass",
+    "runId": "run-feedback-001",
+    "rowsUpdated": 2,
+    "fieldsUpdated": ["erpSyncStatus", "erpExternalId", "erpBillNo", "erpResponseCode", "erpResponseMessage", "lastSyncedAt"],
+    "updatedRows": [
+      {
+        "materialCode": "MAT-001",
+        "erpSyncStatus": "synced",
+        "erpExternalId": "K3-1001",
+        "erpBillNo": "K3-BILL-001",
+        "erpResponseCode": "OK",
+        "erpResponseMessage": "K3 WISE save succeeded",
+        "lastSyncedAt": "2026-04-25T10:05:00.000Z"
+      },
+      {
+        "materialCode": "MAT-002",
+        "erpSyncStatus": "synced",
+        "erpExternalId": "K3-1002",
+        "erpBillNo": "K3-BILL-002",
+        "erpResponseCode": "OK",
+        "erpResponseMessage": "K3 WISE save succeeded",
+        "lastSyncedAt": "2026-04-25T10:05:00.000Z"
+      }
     ]
   },
   "deadLetterReplay": {

--- a/scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs
+++ b/scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs
@@ -205,6 +205,21 @@ async function main() {
           billNo: r.billNo,
         })),
       },
+      erpFeedback: {
+        status: 'pass',
+        runId: 'mock-feedback-001',
+        rowsUpdated: upsertResult.results.length,
+        fieldsUpdated: ['erpSyncStatus', 'erpExternalId', 'erpBillNo', 'erpResponseCode', 'erpResponseMessage', 'lastSyncedAt'],
+        updatedRows: upsertResult.results.map((r) => ({
+          materialCode: r.key,
+          erpSyncStatus: 'synced',
+          erpExternalId: r.externalId,
+          erpBillNo: r.billNo,
+          erpResponseCode: 'OK',
+          erpResponseMessage: r.responseMessage || 'K3 WISE save succeeded',
+          lastSyncedAt: '2026-04-26T01:00:00.000Z',
+        })),
+      },
       deadLetterReplay: { status: 'pass', originalRunId: 'mock-fail-001', replayRunId: 'mock-replay-001' },
       bomPoC: {
         status: 'pass',

--- a/scripts/ops/integration-k3wise-live-poc-evidence.mjs
+++ b/scripts/ops/integration-k3wise-live-poc-evidence.mjs
@@ -37,6 +37,8 @@ const STATUS_SYNONYMS = new Map([
 // of cross-file imports for the customer-runnable script surface).
 const TRUE_BOOLEAN_TEXT = new Set(['true', '1', 'yes', 'y', 'on', '是', '启用', '开启'])
 const FALSE_BOOLEAN_TEXT = new Set(['false', '0', 'no', 'n', 'off', '否', '禁用', '关闭'])
+const ERP_FEEDBACK_REQUIRED_FIELDS = ['erpSyncStatus', 'erpResponseCode', 'erpResponseMessage', 'lastSyncedAt']
+const ERP_FEEDBACK_ID_FIELDS = ['erpExternalId', 'erpBillNo']
 
 class LivePocEvidenceError extends Error {
   constructor(message, details = {}) {
@@ -237,6 +239,7 @@ function evaluatePhases(packet, evidence) {
     phase(connections.k3Wise, 'k3Connection', 'K3 WISE testConnection', true),
     phase(evidence.materialDryRun, 'materialDryRun', 'Material dry-run', true),
     phase(evidence.materialSaveOnly, 'materialSaveOnly', 'Material Save-only write', true),
+    phase(evidence.erpFeedback, 'erpFeedback', 'ERP feedback writeback', true),
     phase(evidence.deadLetterReplay, 'deadLetterReplay', 'Dead letter and replay', true),
     phase(evidence.bomPoC, 'bomPoC', 'Simple BOM PoC', bomRequired),
     phase(evidence.rollback, 'rollback', 'Rollback or cleanup', true),
@@ -265,6 +268,56 @@ function evaluateMaterialSaveOnly(evidence, issues) {
   }
   if (asArray(save.k3Records, 'materialSaveOnly.k3Records').length === 0) {
     addIssue(issues, 'fail', 'K3_RECORD_REQUIRED', 'material Save-only evidence must include at least one K3 test record', 'materialSaveOnly')
+  }
+}
+
+function collectErpFeedbackRows(feedback) {
+  for (const field of ['updatedRows', 'updatedItems', 'items', 'records']) {
+    if (feedback[field] !== undefined && feedback[field] !== null) {
+      return asArray(feedback[field], `erpFeedback.${field}`)
+    }
+  }
+  return []
+}
+
+function collectErpFeedbackFields(feedback, rows) {
+  const fields = new Set()
+  for (const field of ['fieldsUpdated', 'updatedFields']) {
+    for (const item of asArray(feedback[field], `erpFeedback.${field}`)) {
+      const value = text(item)
+      if (value) fields.add(value)
+    }
+  }
+  for (const row of rows) {
+    if (!isPlainObject(row)) continue
+    for (const key of Object.keys(row)) fields.add(key)
+  }
+  return fields
+}
+
+function evaluateErpFeedback(evidence, issues) {
+  const feedback = asObject(evidence.erpFeedback, 'evidence.erpFeedback')
+  if (normalizeStatus(feedback.status) !== 'pass') return
+
+  const rows = collectErpFeedbackRows(feedback)
+  const rowsUpdated = Number(feedback.rowsUpdated)
+  const hasUpdatedRows = rows.length > 0 || (Number.isInteger(rowsUpdated) && rowsUpdated > 0)
+  if (!hasUpdatedRows) {
+    addIssue(issues, 'fail', 'ERP_FEEDBACK_ROWS_REQUIRED', 'ERP feedback evidence must include at least one updated staging row', 'erpFeedback')
+  }
+
+  const fields = collectErpFeedbackFields(feedback, rows)
+  const missingFields = ERP_FEEDBACK_REQUIRED_FIELDS.filter((field) => !fields.has(field))
+  const hasExternalReference = ERP_FEEDBACK_ID_FIELDS.some((field) => fields.has(field))
+  if (missingFields.length > 0 || !hasExternalReference) {
+    const required = [...ERP_FEEDBACK_REQUIRED_FIELDS, `${ERP_FEEDBACK_ID_FIELDS.join(' or ')}`]
+    addIssue(
+      issues,
+      'fail',
+      'ERP_FEEDBACK_FIELDS_REQUIRED',
+      `ERP feedback evidence must cover fields: ${required.join(', ')}`,
+      'erpFeedback',
+    )
   }
 }
 
@@ -325,6 +378,7 @@ function buildEvidenceReport(packet, evidence, { generatedAt = new Date().toISOS
   const issues = []
   const phases = evaluatePhases(packet, evidence)
   evaluateMaterialSaveOnly(evidence, issues)
+  evaluateErpFeedback(evidence, issues)
   evaluateBom(packet, evidence, issues)
 
   for (const item of phases) {
@@ -430,6 +484,23 @@ function sampleEvidence() {
       k3Records: [
         { materialCode: 'MAT-001', externalId: 'K3-1001', billNo: 'K3-BILL-001' },
         { materialCode: 'MAT-002', externalId: 'K3-1002', billNo: 'K3-BILL-002' },
+      ],
+    },
+    erpFeedback: {
+      status: 'pass',
+      runId: 'run-feedback-001',
+      rowsUpdated: 2,
+      fieldsUpdated: ['erpSyncStatus', 'erpExternalId', 'erpBillNo', 'erpResponseCode', 'erpResponseMessage', 'lastSyncedAt'],
+      updatedRows: [
+        {
+          materialCode: 'MAT-001',
+          erpSyncStatus: 'synced',
+          erpExternalId: 'K3-1001',
+          erpBillNo: 'K3-BILL-001',
+          erpResponseCode: 'OK',
+          erpResponseMessage: 'K3 WISE save succeeded',
+          lastSyncedAt: '2026-04-25T10:05:00.000Z',
+        },
       ],
     },
     deadLetterReplay: {

--- a/scripts/ops/integration-k3wise-live-poc-evidence.test.mjs
+++ b/scripts/ops/integration-k3wise-live-poc-evidence.test.mjs
@@ -29,6 +29,7 @@ test('buildEvidenceReport returns PASS for complete Save-only evidence', () => {
   assert.equal(report.issues.length, 0)
   assert.equal(report.scope.bomRequired, true)
   assert.equal(report.phases.find((phase) => phase.id === 'bomPoC').status, 'pass')
+  assert.equal(report.phases.find((phase) => phase.id === 'erpFeedback').status, 'pass')
   assert.match(renderMarkdown(report), /Decision: `PASS`/)
 })
 
@@ -38,6 +39,19 @@ test('buildEvidenceReport returns PARTIAL when a required phase is missing', () 
   const report = buildEvidenceReport(packet(), evidence)
   assert.equal(report.decision, 'PARTIAL')
   assert.equal(report.phases.find((phase) => phase.id === 'customerConfirmation').status, 'todo')
+})
+
+test('buildEvidenceReport returns PARTIAL when ERP feedback evidence is missing', () => {
+  const evidence = sampleEvidence()
+  delete evidence.erpFeedback
+  const report = buildEvidenceReport(packet(), evidence)
+  assert.equal(report.decision, 'PARTIAL')
+  assert.equal(report.phases.find((phase) => phase.id === 'erpFeedback').status, 'todo')
+  assert.equal(
+    report.issues.some((issue) => issue.code === 'ERP_FEEDBACK_FIELDS_REQUIRED'),
+    false,
+    'missing phase should be incomplete, not a malformed feedback payload',
+  )
 })
 
 test('buildEvidenceReport returns FAIL when Save-only row count exceeds PoC limit', () => {
@@ -54,6 +68,43 @@ test('buildEvidenceReport returns FAIL when autoAudit appears in Save-only evide
   const report = buildEvidenceReport(packet(), evidence)
   assert.equal(report.decision, 'FAIL')
   assert.equal(report.issues.some((issue) => issue.code === 'SAVE_ONLY_VIOLATED'), true)
+})
+
+test('buildEvidenceReport returns FAIL when passed ERP feedback has no updated rows', () => {
+  const evidence = sampleEvidence()
+  evidence.erpFeedback.updatedRows = []
+  evidence.erpFeedback.rowsUpdated = 0
+  const report = buildEvidenceReport(packet(), evidence)
+  assert.equal(report.decision, 'FAIL')
+  assert.equal(report.issues.some((issue) => issue.code === 'ERP_FEEDBACK_ROWS_REQUIRED'), true)
+})
+
+test('buildEvidenceReport returns FAIL when passed ERP feedback omits required fields', () => {
+  const evidence = sampleEvidence()
+  evidence.erpFeedback.fieldsUpdated = ['erpSyncStatus', 'erpExternalId', 'lastSyncedAt']
+  evidence.erpFeedback.updatedRows = [
+    {
+      erpSyncStatus: 'synced',
+      erpExternalId: 'K3-1001',
+      lastSyncedAt: '2026-04-25T10:05:00.000Z',
+    },
+  ]
+  const report = buildEvidenceReport(packet(), evidence)
+  assert.equal(report.decision, 'FAIL')
+  assert.equal(report.issues.some((issue) => issue.code === 'ERP_FEEDBACK_FIELDS_REQUIRED'), true)
+})
+
+test('buildEvidenceReport accepts ERP feedback proof from rowsUpdated plus fieldsUpdated', () => {
+  const evidence = sampleEvidence()
+  evidence.erpFeedback = {
+    status: 'pass',
+    runId: 'run-feedback-002',
+    rowsUpdated: 1,
+    fieldsUpdated: ['erpSyncStatus', 'erpBillNo', 'erpResponseCode', 'erpResponseMessage', 'lastSyncedAt'],
+  }
+  const report = buildEvidenceReport(packet(), evidence)
+  assert.equal(report.decision, 'PASS')
+  assert.equal(report.issues.some((issue) => issue.code.startsWith('ERP_FEEDBACK_')), false)
 })
 
 test('buildEvidenceReport rejects unredacted secret-like evidence fields', () => {


### PR DESCRIPTION
## Summary
- requires ERP feedback writeback evidence in the K3 WISE live PoC evidence compiler
- validates feedback rows or compact rowsUpdated/fieldsUpdated proof with required staging fields
- updates the evidence sample and mock PoC demo to synthesize feedback from K3 Save-only results
- preserves the current SQL channel read/upsert mock contract from #1508
- records current-main development and verification evidence

## Verification
- node --test scripts/ops/integration-k3wise-live-poc-evidence.test.mjs
- node scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs
- pnpm run verify:integration-k3wise:poc
- git diff --check origin/main..HEAD

Supersedes #1338.