### PR TITLE
fix(integration): refresh K3 setup boolean hydration

### DIFF
--- a/apps/web/src/services/integration/k3WiseSetup.ts
+++ b/apps/web/src/services/integration/k3WiseSetup.ts
@@ -486,6 +486,23 @@ function parseOptionalPositiveInteger(value: string): number | undefined {
   return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined
 }
 
+const BOOLEAN_TRUE_TEXT = new Set(['true', '1', 'yes', 'y', 'on', 'enable', 'enabled', '是', '启用', '开启'])
+const BOOLEAN_FALSE_TEXT = new Set(['false', '0', 'no', 'n', 'off', 'disable', 'disabled', '否', '禁用', '关闭'])
+
+function normalizeSavedBoolean(value: unknown): boolean {
+  if (value === true || value === false) return value
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    if (value === 1) return true
+    if (value === 0) return false
+  }
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase()
+    if (BOOLEAN_TRUE_TEXT.has(normalized)) return true
+    if (BOOLEAN_FALSE_TEXT.has(normalized)) return false
+  }
+  return false
+}
+
 function assertRelativePath(value: string, field: keyof K3WiseSetupForm, issues: K3WiseSetupValidationIssue[]): void {
   const normalized = trim(value)
   if (!normalized) {
@@ -1271,8 +1288,8 @@ export function applyExternalSystemToForm(form: K3WiseSetupForm, system: Integra
     next.healthPath = typeof config.healthPath === 'string' ? config.healthPath : next.healthPath
     next.lcid = config.lcid === undefined ? next.lcid : String(config.lcid)
     next.timeoutMs = config.timeoutMs === undefined ? next.timeoutMs : String(config.timeoutMs)
-    next.autoSubmit = config.autoSubmit === true
-    next.autoAudit = config.autoAudit === true
+    next.autoSubmit = normalizeSavedBoolean(config.autoSubmit)
+    next.autoAudit = normalizeSavedBoolean(config.autoAudit)
     next.materialSavePath = typeof material.savePath === 'string' ? material.savePath : next.materialSavePath
     next.materialSubmitPath = typeof material.submitPath === 'string' ? material.submitPath : next.materialSubmitPath
     next.materialAuditPath = typeof material.auditPath === 'string' ? material.auditPath : next.materialAuditPath

--- a/apps/web/tests/k3WiseSetup.spec.ts
+++ b/apps/web/tests/k3WiseSetup.spec.ts
@@ -243,6 +243,70 @@ describe('K3 WISE setup helpers', () => {
     expect(next.password).toBe('')
   })
 
+  it('normalizes saved K3 WISE auto-submit flags from boolean, string, numeric, and Chinese variants', () => {
+    const cases: Array<{ autoSubmit: unknown; autoAudit: unknown }> = [
+      { autoSubmit: true, autoAudit: false },
+      { autoSubmit: 1, autoAudit: 0 },
+      { autoSubmit: 'true', autoAudit: 'false' },
+      { autoSubmit: 'YES', autoAudit: 'NO' },
+      { autoSubmit: ' on ', autoAudit: ' off ' },
+      { autoSubmit: '是', autoAudit: '否' },
+      { autoSubmit: '启用', autoAudit: '禁用' },
+      { autoSubmit: '开启', autoAudit: '关闭' },
+    ]
+
+    for (const item of cases) {
+      const form = createDefaultK3WiseSetupForm()
+      Object.assign(form, {
+        autoSubmit: false,
+        autoAudit: true,
+      })
+      const system: IntegrationExternalSystem = {
+        id: 'sys_1',
+        tenantId: 'tenant_1',
+        workspaceId: null,
+        name: 'K3 loaded',
+        kind: 'erp:k3-wise-webapi',
+        role: 'target',
+        status: 'active',
+        config: item,
+        capabilities: {},
+      }
+
+      const next = applyExternalSystemToForm(form, system)
+
+      expect(next.autoSubmit).toBe(true)
+      expect(next.autoAudit).toBe(false)
+    }
+  })
+
+  it('clears K3 WISE auto-submit flags when saved config contains unknown values', () => {
+    const form = createDefaultK3WiseSetupForm()
+    Object.assign(form, {
+      autoSubmit: true,
+      autoAudit: false,
+    })
+    const system: IntegrationExternalSystem = {
+      id: 'sys_1',
+      tenantId: 'tenant_1',
+      workspaceId: null,
+      name: 'K3 loaded',
+      kind: 'erp:k3-wise-webapi',
+      role: 'target',
+      status: 'active',
+      config: {
+        autoSubmit: 'maybe',
+        autoAudit: {},
+      },
+      capabilities: {},
+    }
+
+    const next = applyExternalSystemToForm(form, system)
+
+    expect(next.autoSubmit).toBe(false)
+    expect(next.autoAudit).toBe(false)
+  })
+
   it('validates absolute endpoint paths and incomplete credential replacement', () => {
     const form = createDefaultK3WiseSetupForm()
     Object.assign(form, {

--- a/docs/development/integration-k3wise-setup-bool-hydration-refresh-development-20260513.md
+++ b/docs/development/integration-k3wise-setup-bool-hydration-refresh-development-20260513.md
@@ -1,0 +1,53 @@
+# K3 WISE Setup Boolean Hydration Refresh Development - 2026-05-13
+
+## Context
+
+PR #1344 fixed a frontend-only K3 WISE setup issue, but it was stale behind the
+current K3 validation queue. Current `main` still restored saved `autoSubmit`
+and `autoAudit` values only when the stored value was the literal boolean
+`true`.
+
+Backend and script-side K3 WISE safety tooling accepts common boolean variants
+from customer-edited packets and spreadsheet-like exports. The setup form should
+not display saved K3 flags incorrectly just because older rows or hand-edited
+JSON stored values such as `"true"`, `1`, or `是`.
+
+## Design
+
+`apps/web/src/services/integration/k3WiseSetup.ts` now normalizes saved
+`autoSubmit` and `autoAudit` when applying an external system to the setup form.
+
+Accepted true variants:
+
+- `true`
+- `1`
+- `"true"`, `"1"`, `"yes"`, `"y"`, `"on"`, `"enable"`, `"enabled"`
+- `"是"`, `"启用"`, `"开启"`
+
+Accepted false variants:
+
+- `false`
+- `0`
+- `"false"`, `"0"`, `"no"`, `"n"`, `"off"`, `"disable"`, `"disabled"`
+- `"否"`, `"禁用"`, `"关闭"`
+
+Unknown values hydrate to `false`. That keeps the UI safety-biased and prevents
+a checked value from the previously selected system from leaking into the newly
+loaded system.
+
+## Test Hardening
+
+The refreshed test suite keeps the original #1344 negative test and broadens the
+positive matrix to cover boolean, numeric, English string, whitespace/case, and
+Chinese variants. This keeps the development document aligned with actual test
+coverage.
+
+## Compatibility
+
+This change is frontend-only. It does not change saved payload shape, backend
+validation, K3 runtime execution, database schema, or deployment configuration.
+
+## Superseded Work
+
+This refresh supersedes PR #1344. The refreshed branch uses current `main`,
+current dates, and current verification output.

--- a/docs/development/integration-k3wise-setup-bool-hydration-refresh-verification-20260513.md
+++ b/docs/development/integration-k3wise-setup-bool-hydration-refresh-verification-20260513.md
@@ -1,0 +1,63 @@
+# K3 WISE Setup Boolean Hydration Refresh Verification - 2026-05-13
+
+## Scope
+
+Refresh of PR #1344 on top of current `main` to normalize saved K3 WISE
+`autoSubmit` and `autoAudit` values when hydrating the setup form.
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/web exec vitest run --watch=false tests/k3WiseSetup.spec.ts
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+git diff --check origin/main..HEAD
+```
+
+## Expected Coverage
+
+- saved literal booleans hydrate correctly
+- saved numeric `1` and `0` hydrate correctly
+- saved English string variants hydrate correctly
+- saved Chinese string variants hydrate correctly
+- unknown values hydrate to unchecked, even when the previous form value was
+  checked
+
+## Local Results
+
+### Targeted Vitest
+
+```bash
+pnpm --filter @metasheet/web exec vitest run --watch=false tests/k3WiseSetup.spec.ts
+```
+
+Result: passed.
+
+- Test Files: 1 passed
+- Tests: 31 passed
+
+### Frontend Type Check
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+```
+
+Result: passed.
+
+### Whitespace Check
+
+```bash
+git diff --cached --check
+```
+
+Result: passed, no whitespace errors.
+
+## Notes
+
+This verification is local and frontend-only. It does not call a live K3 WISE
+instance.
+
+The temporary worktree initially had no local dependency symlinks, so the first
+Vitest and `vue-tsc` attempts could not resolve `vitest` and `vue-tsc`. Running
+`pnpm install --frozen-lockfile --offline` created local links from the existing
+store. The resulting generated `plugins/` and `tools/` symlink changes were
+reverted before commit.


### PR DESCRIPTION
## Summary
- normalizes saved K3 WISE autoSubmit/autoAudit values when hydrating the setup form
- accepts boolean, numeric, English string, whitespace/case, and Chinese boolean variants
- keeps unknown saved values safety-biased to unchecked
- refreshes #1344 on top of current main with stronger test coverage and current docs

## Verification
- pnpm --filter @metasheet/web exec vitest run --watch=false tests/k3WiseSetup.spec.ts
- pnpm --filter @metasheet/web exec vue-tsc --noEmit
- git diff --check origin/main..HEAD

Supersedes #1344.