### PR TITLE
fix(integration): refresh K3 WebAPI auth transport guard

### DIFF
--- a/docs/development/integration-k3wise-webapi-auth-transport-refresh-design-20260513.md
+++ b/docs/development/integration-k3wise-webapi-auth-transport-refresh-design-20260513.md
@@ -1,0 +1,64 @@
+# K3 WISE WebAPI Auth Transport Refresh Design - 2026-05-13
+
+## Context
+
+PR #1352 carried useful K3 WISE adapter hardening, but it was stale and
+conflicting against current `main`. Current `main` already added credential
+redaction to the mock K3 WebAPI fixture, so this refresh ports the remaining
+auth and URL hardening while preserving that redaction behavior.
+
+## Goals
+
+- Fail K3 WebAPI connection testing when login reports business success but
+  returns no reusable auth transport for later Save-only writes.
+- Reject unsafe endpoint path forms that can escape `config.baseUrl`.
+- Preserve `baseUrl` context paths such as `https://k3.example.test/K3API` when
+  joined with endpoint paths such as `/login`.
+- Keep the mock K3 WebAPI fixture close to the real endpoint method contract.
+- Keep mock call logs redacted so credential values do not leak into artifacts.
+
+## Adapter Changes
+
+`plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs`
+continues to accept normal relative K3 paths, but now rejects:
+
+- any leading URL scheme such as `http:`, `https:`, or `k3api:`
+- protocol-relative paths beginning with `//`
+- paths containing backslashes
+
+Request URL construction now uses an adapter-local join helper. If the base URL
+contains a context path, the helper preserves that context unless the configured
+endpoint path already includes it.
+
+After credential login succeeds, the adapter requires at least one reusable auth
+transport:
+
+- `Set-Cookie` response header
+- configured or response-derived session id header
+
+If neither exists, `testConnection()` returns code
+`K3_WISE_AUTH_TRANSPORT_MISSING` and does not continue to health checks.
+Authority-code token mode is unchanged because it authenticates through a query
+token rather than cookie/session headers.
+
+## Mock Fixture Changes
+
+`scripts/ops/fixtures/integration-k3wise/mock-k3-webapi-server.mjs` now supports:
+
+- optional login responses with no cookie and no session id
+- method checks for login, health, material, and BOM endpoints
+- existing redacted call logging for credential-bearing request bodies
+
+The full K3 WISE offline PoC gate now runs the mock K3 WebAPI contract test
+before the SQL Server mock contract and end-to-end mock PoC demo.
+
+## Compatibility
+
+This is integration tooling and adapter hardening only. It does not change
+database schema, production routes, frontend UI, or customer credentials.
+
+## Superseded Work
+
+This refresh supersedes PR #1352. The refreshed version is based on current
+`main`, preserves later mock redaction work, and records current verification
+output.

--- a/docs/development/integration-k3wise-webapi-auth-transport-refresh-verification-20260513.md
+++ b/docs/development/integration-k3wise-webapi-auth-transport-refresh-verification-20260513.md
@@ -1,0 +1,79 @@
+# K3 WISE WebAPI Auth Transport Refresh Verification - 2026-05-13
+
+## Scope
+
+Refresh of PR #1352 on top of current `main` to require usable K3 WebAPI auth
+transport, reject unsafe endpoint paths, preserve base URL context paths, and
+tighten the mock K3 WebAPI contract.
+
+## Commands
+
+```bash
+node plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
+node --test scripts/ops/fixtures/integration-k3wise/mock-k3-webapi-server.test.mjs
+pnpm run verify:integration-k3wise:poc
+git diff --check origin/main..HEAD
+```
+
+## Expected Coverage
+
+- login success without cookie or session id returns
+  `K3_WISE_AUTH_TRANSPORT_MISSING`
+- adapter stops at login and does not run health after missing auth transport
+- protocol-relative endpoint paths are rejected
+- backslash-normalized endpoint paths are rejected
+- `baseUrl` context paths are preserved when joining endpoint paths
+- mock K3 endpoint methods match the expected K3 WebAPI contract
+- mock K3 can model login success without auth transport
+- mock K3 call logs still redact login credential fields
+
+## Local Results
+
+### Adapter Test
+
+```bash
+node plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
+```
+
+Result: passed.
+
+- WebAPI, SQL Server channel, and auto-flag coercion tests passed.
+- New coverage verifies `K3_WISE_AUTH_TRANSPORT_MISSING`.
+- New coverage verifies context-path URL joining.
+- New coverage verifies protocol-relative and backslash endpoint rejection.
+
+### Mock K3 WebAPI Contract Test
+
+```bash
+node --test scripts/ops/fixtures/integration-k3wise/mock-k3-webapi-server.test.mjs
+```
+
+Result: passed.
+
+- 4/4 tests passed.
+- Credential redaction coverage still passes.
+- Raw material payload evaluation still passes.
+- Method contract coverage passes.
+- Login-without-auth-transport simulation passes.
+
+### Full Offline K3 WISE PoC Gate
+
+```bash
+pnpm run verify:integration-k3wise:poc
+```
+
+Result: passed.
+
+- preflight suite: 20/20 passed
+- evidence suite: 41/41 passed
+- mock K3 WebAPI suite: 4/4 passed
+- mock SQL Server suite: 12/12 passed
+- mock PoC demo: PASS
+
+### Whitespace Check
+
+```bash
+git diff --check
+```
+
+Result: passed, no whitespace errors.

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "profile:multitable-grid:staging": "RUNNER_SCRIPT=scripts/profile-multitable-grid.mjs RUN_LABEL=multitable-grid-profile-staging RUN_MODE=staging RUNNER_REPORT_BASENAME=staging-report AUTO_START_SERVICES=false REQUIRE_RUNNING_SERVICES=true bash scripts/ops/multitable-pilot-local.sh",
     "verify:multitable-grid-profile:summary": "node scripts/ops/multitable-grid-profile-summary.mjs",
     "verify:integration-erp-plm:deploy-readiness": "node scripts/ops/integration-erp-plm-deploy-readiness.mjs",
-    "verify:integration-k3wise:poc": "node --test scripts/ops/integration-k3wise-live-poc-preflight.test.mjs && node --test scripts/ops/integration-k3wise-live-poc-evidence.test.mjs && node --test scripts/ops/fixtures/integration-k3wise/mock-sqlserver-executor.test.mjs && node scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs",
+    "verify:integration-k3wise:poc": "node --test scripts/ops/integration-k3wise-live-poc-preflight.test.mjs && node --test scripts/ops/integration-k3wise-live-poc-evidence.test.mjs && node --test scripts/ops/fixtures/integration-k3wise/mock-k3-webapi-server.test.mjs && node --test scripts/ops/fixtures/integration-k3wise/mock-sqlserver-executor.test.mjs && node scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs",
     "verify:integration-k3wise:onprem-preflight": "node --test scripts/ops/integration-k3wise-onprem-preflight.test.mjs",
     "verify:integration-k3wise:postdeploy-env-check": "node --test scripts/ops/integration-k3wise-postdeploy-env-check.test.mjs",
     "phase5:run-all": "bash scripts/phase5-run-all.sh",

--- a/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
@@ -256,6 +256,53 @@ async function testK3WebApiAdapter() {
   assert.equal(missingAcctIdStatus.code, 'K3_WISE_CREDENTIALS_MISSING')
   assert.match(missingAcctIdStatus.message, /acctId/)
 
+  const loginWithoutAuthTransportCalls = []
+  const loginWithoutAuthTransport = createK3WiseWebApiAdapter({
+    system: createK3WebApiSystem(),
+    fetchImpl: async (url, options = {}) => {
+      const parsed = new URL(url)
+      loginWithoutAuthTransportCalls.push({ pathname: parsed.pathname, options })
+      if (parsed.pathname === '/K3API/Login') {
+        return jsonResponse(200, { success: true })
+      }
+      return jsonResponse(200, { ok: true })
+    },
+  })
+  const missingAuthTransportStatus = await loginWithoutAuthTransport.testConnection({ skipHealth: true })
+  assert.equal(missingAuthTransportStatus.ok, false)
+  assert.equal(missingAuthTransportStatus.code, 'K3_WISE_AUTH_TRANSPORT_MISSING')
+  assert.match(missingAuthTransportStatus.message, /session cookie or session id/)
+  assert.deepEqual(
+    loginWithoutAuthTransportCalls.map((call) => call.pathname),
+    ['/K3API/Login'],
+    'missing auth transport fails at login and does not continue to health checks',
+  )
+
+  const contextPathCalls = []
+  const contextPathAdapter = createK3WiseWebApiAdapter({
+    system: createK3WebApiSystem({
+      config: {
+        baseUrl: 'https://k3.example.test/K3API',
+        loginPath: '/login',
+        healthPath: '/health',
+      },
+    }),
+    fetchImpl: async (url) => {
+      const parsed = new URL(url)
+      contextPathCalls.push(parsed.pathname)
+      if (parsed.pathname === '/K3API/login') {
+        return jsonResponse(200, { success: true, sessionId: 'k3-context-session' })
+      }
+      if (parsed.pathname === '/K3API/health') {
+        return jsonResponse(200, { ok: true })
+      }
+      return jsonResponse(404, { success: false, message: 'not found' })
+    },
+  })
+  const contextPathStatus = await contextPathAdapter.testConnection()
+  assert.equal(contextPathStatus.ok, true, 'baseUrl context path is preserved for relative K3 paths')
+  assert.deepEqual(contextPathCalls, ['/K3API/login', '/K3API/health'])
+
   assert.equal(webApiInternals.businessSuccess({ success: true }, {}), true)
   assert.equal(webApiInternals.businessSuccess({ StatusCode: 200, Data: { Code: 'Y' } }, {}), true)
   assert.equal(webApiInternals.businessSuccess({ StatusCode: 500, Data: { Code: 'N' } }, {}), false)
@@ -275,6 +322,42 @@ async function testK3WebApiAdapter() {
     }
   })()
   assert.ok(invalidBaseUrl instanceof AdapterValidationError, 'non-http K3 baseUrl rejected')
+
+  const protocolRelativeLoginPath = (() => {
+    try {
+      createK3WiseWebApiAdapter({
+        system: createK3WebApiSystem({
+          config: {
+            baseUrl: 'https://k3.example.test',
+            loginPath: '//evil.example.test/K3API/Login',
+          },
+        }),
+        fetchImpl,
+      })
+      return null
+    } catch (error) {
+      return error
+    }
+  })()
+  assert.ok(protocolRelativeLoginPath instanceof AdapterValidationError, 'protocol-relative K3 paths are rejected')
+
+  const backslashLoginPath = (() => {
+    try {
+      createK3WiseWebApiAdapter({
+        system: createK3WebApiSystem({
+          config: {
+            baseUrl: 'https://k3.example.test',
+            loginPath: '\\\\evil.example.test\\K3API\\Login',
+          },
+        }),
+        fetchImpl,
+      })
+      return null
+    } catch (error) {
+      return error
+    }
+  })()
+  assert.ok(backslashLoginPath instanceof AdapterValidationError, 'backslash-normalized K3 paths are rejected')
 
   const invalidObjectEndpoint = (() => {
     try {

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
@@ -67,10 +67,29 @@ function assertRelativePath(path, field) {
     throw new AdapterValidationError(`${field} is required`, { field })
   }
   const trimmed = path.trim()
-  if (/^https?:\/\//i.test(trimmed)) {
+  const hasScheme = /^[A-Za-z][A-Za-z0-9+.-]*:/.test(trimmed)
+  const isProtocolRelative = trimmed.startsWith('//')
+  const hasBackslash = trimmed.includes('\\')
+  if (hasScheme || isProtocolRelative || hasBackslash) {
     throw new AdapterValidationError(`${field} must be relative to baseUrl`, { field })
   }
   return trimmed.startsWith('/') ? trimmed : `/${trimmed}`
+}
+
+function buildEndpointUrl(baseUrl, path) {
+  const endpointPath = assertRelativePath(path, 'path')
+  const url = new URL(baseUrl)
+  const basePath = url.pathname && url.pathname !== '/'
+    ? url.pathname.replace(/\/+$/, '')
+    : ''
+  if (basePath && endpointPath !== basePath && !endpointPath.startsWith(`${basePath}/`)) {
+    url.pathname = `${basePath}${endpointPath}`
+  } else {
+    url.pathname = endpointPath
+  }
+  url.search = ''
+  url.hash = ''
+  return url
 }
 
 function normalizeHeaders(value, field) {
@@ -358,7 +377,7 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
   }
 
   function buildUrl(path, query) {
-    const url = new URL(assertRelativePath(path, 'path'), baseUrl)
+    const url = buildEndpointUrl(baseUrl, path)
     for (const [key, value] of Object.entries(query || {})) {
       if (value === undefined || value === null || value === '') continue
       url.searchParams.set(key, String(value))
@@ -507,6 +526,12 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
     )
     if (cookie) authHeaders.Cookie = cookie
     if (sessionId) authHeaders[config.sessionHeader || 'X-K3-Session'] = String(sessionId)
+    if (Object.keys(authHeaders).length === 0) {
+      throw new K3WiseWebApiAdapterError('K3 WISE WebAPI login succeeded but did not return a session cookie or session id', {
+        code: 'K3_WISE_AUTH_TRANSPORT_MISSING',
+        body: data,
+      })
+    }
     cachedAuthContext = { headers: authHeaders, query: {}, expiresAt: null }
     return cachedAuthContext
   }

--- a/scripts/ops/fixtures/integration-k3wise/mock-k3-webapi-server.mjs
+++ b/scripts/ops/fixtures/integration-k3wise/mock-k3-webapi-server.mjs
@@ -41,7 +41,12 @@ function sanitizeMockBody(value) {
   )
 }
 
-export function createMockK3WebApiServer({ logger = () => {}, knownBadFNumbers = new Set(['BAD']) } = {}) {
+export function createMockK3WebApiServer({
+  logger = () => {},
+  knownBadFNumbers = new Set(['BAD']),
+  includeSessionCookie = true,
+  includeSessionId = true,
+} = {}) {
   const calls = []
 
   async function readBody(req) {
@@ -53,11 +58,24 @@ export function createMockK3WebApiServer({ logger = () => {}, knownBadFNumbers =
     })
   }
 
-  function jsonResponse(res, status, payload) {
+  function jsonResponse(res, status, payload, { setCookie = includeSessionCookie } = {}) {
     res.statusCode = status
     res.setHeader('Content-Type', 'application/json')
-    res.setHeader('Set-Cookie', 'K3SESSION=mock-cookie-1; Path=/; HttpOnly')
+    if (setCookie) res.setHeader('Set-Cookie', 'K3SESSION=mock-cookie-1; Path=/; HttpOnly')
     res.end(JSON.stringify(payload))
+  }
+
+  function requireMethod(req, res, expectedMethod) {
+    if (req.method === expectedMethod) return true
+    res.statusCode = 405
+    res.setHeader('Content-Type', 'application/json')
+    res.setHeader('Allow', expectedMethod)
+    res.end(JSON.stringify({
+      success: false,
+      message: `mock K3 method not allowed: ${req.method} ${req.url}`,
+      expectedMethod,
+    }))
+    return false
   }
 
   const server = createServer(async (req, res) => {
@@ -75,14 +93,20 @@ export function createMockK3WebApiServer({ logger = () => {}, knownBadFNumbers =
     logger(safeCall)
 
     if (pathname === '/K3API/Login') {
-      jsonResponse(res, 200, { success: true, sessionId: 'mock-session-1' })
+      if (!requireMethod(req, res, 'POST')) return
+      jsonResponse(res, 200, {
+        success: true,
+        ...(includeSessionId ? { sessionId: 'mock-session-1' } : {}),
+      })
       return
     }
     if (pathname === '/K3API/Health') {
+      if (!requireMethod(req, res, 'GET')) return
       jsonResponse(res, 200, { ok: true })
       return
     }
     if (pathname === '/K3API/Material/Save') {
+      if (!requireMethod(req, res, 'POST')) return
       const fNumber = (body?.Model || body?.Data)?.FNumber
       if (knownBadFNumbers.has(fNumber)) {
         jsonResponse(res, 200, { success: false, message: `mock K3 rejects ${fNumber}: invalid material code` })
@@ -92,14 +116,17 @@ export function createMockK3WebApiServer({ logger = () => {}, knownBadFNumbers =
       return
     }
     if (pathname === '/K3API/Material/Submit') {
+      if (!requireMethod(req, res, 'POST')) return
       jsonResponse(res, 200, { success: true, submitted: body?.Number })
       return
     }
     if (pathname === '/K3API/Material/Audit') {
+      if (!requireMethod(req, res, 'POST')) return
       jsonResponse(res, 200, { success: true, audited: body?.Number })
       return
     }
     if (pathname === '/K3API/BOM/Save') {
+      if (!requireMethod(req, res, 'POST')) return
       const fNumber = (body?.Model || body?.Data)?.FNumber
       if (knownBadFNumbers.has(fNumber)) {
         jsonResponse(res, 200, { success: false, message: `mock K3 BOM rejects ${fNumber}` })
@@ -109,10 +136,12 @@ export function createMockK3WebApiServer({ logger = () => {}, knownBadFNumbers =
       return
     }
     if (pathname === '/K3API/BOM/Submit') {
+      if (!requireMethod(req, res, 'POST')) return
       jsonResponse(res, 200, { success: true, submitted: body?.Number })
       return
     }
     if (pathname === '/K3API/BOM/Audit') {
+      if (!requireMethod(req, res, 'POST')) return
       jsonResponse(res, 200, { success: true, audited: body?.Number })
       return
     }

--- a/scripts/ops/fixtures/integration-k3wise/mock-k3-webapi-server.test.mjs
+++ b/scripts/ops/fixtures/integration-k3wise/mock-k3-webapi-server.test.mjs
@@ -6,13 +6,18 @@ import test from 'node:test'
 import { createMockK3WebApiServer } from './mock-k3-webapi-server.mjs'
 
 async function postJson(baseUrl, pathname, payload) {
-  const response = await fetch(`${baseUrl}${pathname}`, {
+  return fetchJson(baseUrl, pathname, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify(payload),
   })
+}
+
+async function fetchJson(baseUrl, pathname, options = {}) {
+  const response = await fetch(`${baseUrl}${pathname}`, options)
   return {
     status: response.status,
+    headers: response.headers,
     body: await response.json(),
   }
 }
@@ -83,6 +88,63 @@ test('mock K3 still evaluates material payloads with the raw request body', asyn
     assert.match(result.body.message, /BAD/)
     assert.equal(mock.calls.length, 1)
     assert.equal(mock.calls[0].body.Model.FNumber, 'BAD')
+  } finally {
+    await mock.stop()
+  }
+})
+
+test('mock K3 WebAPI rejects methods that real K3 endpoints would not accept', async () => {
+  const mock = createMockK3WebApiServer()
+  const baseUrl = await mock.start()
+  try {
+    const cases = [
+      { pathname: '/K3API/Login', method: 'GET', expectedMethod: 'POST' },
+      { pathname: '/K3API/Health', method: 'POST', expectedMethod: 'GET' },
+      { pathname: '/K3API/Material/Save', method: 'GET', expectedMethod: 'POST' },
+      { pathname: '/K3API/Material/Submit', method: 'GET', expectedMethod: 'POST' },
+      { pathname: '/K3API/Material/Audit', method: 'GET', expectedMethod: 'POST' },
+      { pathname: '/K3API/BOM/Save', method: 'GET', expectedMethod: 'POST' },
+      { pathname: '/K3API/BOM/Submit', method: 'GET', expectedMethod: 'POST' },
+      { pathname: '/K3API/BOM/Audit', method: 'GET', expectedMethod: 'POST' },
+    ]
+
+    for (const item of cases) {
+      const result = await fetchJson(baseUrl, item.pathname, { method: item.method })
+      assert.equal(result.status, 405, `${item.method} ${item.pathname} should be rejected`)
+      assert.equal(result.headers.get('allow'), item.expectedMethod)
+      assert.deepEqual(result.body, {
+        success: false,
+        message: `mock K3 method not allowed: ${item.method} ${item.pathname}`,
+        expectedMethod: item.expectedMethod,
+      })
+    }
+
+    assert.deepEqual(
+      mock.calls.map((call) => `${call.method} ${call.pathname}`),
+      cases.map((item) => `${item.method} ${item.pathname}`),
+      'rejected calls remain visible for debugging',
+    )
+  } finally {
+    await mock.stop()
+  }
+})
+
+test('mock K3 WebAPI can model successful login responses without usable auth transport', async () => {
+  const mock = createMockK3WebApiServer({
+    includeSessionCookie: false,
+    includeSessionId: false,
+  })
+  const baseUrl = await mock.start()
+  try {
+    const login = await postJson(baseUrl, '/K3API/Login', {
+      username: 'demo',
+      password: 'demo',
+      acctId: 'AIS_TEST',
+    })
+
+    assert.equal(login.status, 200)
+    assert.equal(login.headers.get('set-cookie'), null)
+    assert.deepEqual(login.body, { success: true })
   } finally {
     await mock.stop()
   }


### PR DESCRIPTION
## Summary
- requires credential-login responses to return reusable K3 WebAPI auth transport before connection tests pass
- rejects protocol-relative, scheme-prefixed, and backslash endpoint paths
- preserves baseUrl context paths when joining K3 endpoint paths
- tightens the mock K3 WebAPI method contract while preserving credential redaction
- adds the mock K3 WebAPI contract suite to verify:integration-k3wise:poc
- records current-main design and verification evidence

## Verification
- node plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
- node --test scripts/ops/fixtures/integration-k3wise/mock-k3-webapi-server.test.mjs
- pnpm run verify:integration-k3wise:poc
- git diff --check origin/main..HEAD

Supersedes #1352.