### PR TITLE
fix(integration): scope K3 setup connection test

### DIFF
--- a/apps/web/src/services/integration/k3WiseSetup.ts
+++ b/apps/web/src/services/integration/k3WiseSetup.ts
@@ -1349,8 +1349,18 @@ export async function upsertIntegrationSystem(payload: Record<string, unknown>):
   return parseIntegrationResponse<IntegrationExternalSystem>(response)
 }
 
+function buildScopeQuery(input: Record<string, unknown>): string {
+  const params = new URLSearchParams()
+  const tenantId = typeof input.tenantId === 'string' ? input.tenantId.trim() : ''
+  const workspaceId = typeof input.workspaceId === 'string' ? input.workspaceId.trim() : ''
+  if (tenantId) params.set('tenantId', tenantId)
+  if (workspaceId) params.set('workspaceId', workspaceId)
+  return params.toString()
+}
+
 export async function testIntegrationSystem(systemId: string, input: Record<string, unknown> = {}): Promise<Record<string, unknown>> {
-  const response = await apiFetch(`/api/integration/external-systems/${encodeURIComponent(systemId)}/test`, {
+  const query = buildScopeQuery(input)
+  const response = await apiFetch(`/api/integration/external-systems/${encodeURIComponent(systemId)}/test${query ? `?${query}` : ''}`, {
     method: 'POST',
     body: JSON.stringify(input),
   })

--- a/apps/web/tests/IntegrationK3WiseSetupView.spec.ts
+++ b/apps/web/tests/IntegrationK3WiseSetupView.spec.ts
@@ -147,7 +147,7 @@ describe('IntegrationK3WiseSetupView', () => {
       if (url.startsWith('/api/integration/external-systems?kind=erp%3Ak3-wise-sqlserver')) {
         return jsonResponse([])
       }
-      if (url === '/api/integration/external-systems/k3_sys_1/test') {
+      if (url === '/api/integration/external-systems/k3_sys_1/test?tenantId=default') {
         const body = JSON.parse(String(init?.body || '{}'))
         expect(body).toMatchObject({
           tenantId: 'default',

--- a/docs/development/k3wise-setup-tenant-scope-test-development-20260513.md
+++ b/docs/development/k3wise-setup-tenant-scope-test-development-20260513.md
@@ -1,0 +1,60 @@
+# K3 WISE Setup Tenant-Scope Test Development - 2026-05-13
+
+## Scope
+
+Bridge-machine validation proved that the saved K3 WISE WebAPI target can connect
+when the backend receives an explicit tenant scope, but the K3 setup page's
+"Test WebAPI" button still surfaced `tenantId is required`.
+
+This slice fixes that UI/API contract mismatch.
+
+## Root Cause
+
+The backend route `POST /api/integration/external-systems/:id/test` loads the
+external system before it passes the request body to the adapter. During that
+load step, tenant scope is resolved from:
+
+- explicit route input
+- query string
+- route params
+- authenticated user context
+
+The K3 setup page sent `tenantId` only in the POST body. That body was still
+useful for adapter options such as `skipHealth`, but it was too late for the
+route's external-system lookup. The generic integration workbench already sends
+tenant scope in the query string, which is why the bridge-machine direct
+workbench-style test passed.
+
+## Change
+
+Updated `apps/web/src/services/integration/k3WiseSetup.ts`:
+
+- Added a small scope-query builder for `tenantId` and `workspaceId`.
+- Updated `testIntegrationSystem()` to append the scope query to the test URL.
+- Kept the original request body unchanged so `skipHealth`, `tenantId`,
+  `workspaceId`, and future adapter test options still reach the adapter.
+
+Updated `apps/web/tests/IntegrationK3WiseSetupView.spec.ts`:
+
+- The K3 setup page WebAPI test now expects:
+  `POST /api/integration/external-systems/k3_sys_1/test?tenantId=default`
+- The request body still includes `{ tenantId: "default", workspaceId: null,
+  skipHealth: true }`.
+
+## Deployment Impact
+
+Frontend-only behavior change. No migration, backend, plugin, or K3 adapter
+changes.
+
+After deployment, the setup page should follow the same tenant-scope contract as
+the generic integration workbench. A saved K3 WebAPI target under tenant
+`default` should no longer fail the setup-page test button with
+`tenantId is required`.
+
+## Non-Goals
+
+- No real K3 write.
+- No Submit/Audit change.
+- No new pipeline creation.
+- No change to the generic integration workbench.
+- No change to bridge-machine secret handling.

--- a/docs/development/k3wise-setup-tenant-scope-test-verification-20260513.md
+++ b/docs/development/k3wise-setup-tenant-scope-test-verification-20260513.md
@@ -1,0 +1,51 @@
+# K3 WISE Setup Tenant-Scope Test Verification - 2026-05-13
+
+## Scope
+
+Verification for fixing the K3 setup page WebAPI test button tenant-scope
+contract.
+
+## Commands
+
+| Command | Result | Notes |
+| --- | --- | --- |
+| `pnpm install --frozen-lockfile` | PASS | Installed dependencies inside isolated worktree `/tmp/ms2-k3wise-tenant-test-20260513`. |
+| `pnpm --filter @metasheet/web exec vitest run tests/IntegrationK3WiseSetupView.spec.ts tests/k3WiseSetup.spec.ts tests/integrationWorkbench.spec.ts --watch=false` | PASS | 3 files, 35 tests passed. |
+| `pnpm --filter @metasheet/web build` | PASS | `vue-tsc -b` and Vite production build passed. Existing chunk-size warnings only. |
+
+## Regression Coverage
+
+The targeted K3 setup view test now proves the page calls:
+
+```text
+/api/integration/external-systems/k3_sys_1/test?tenantId=default
+```
+
+while preserving the adapter test body:
+
+```json
+{
+  "tenantId": "default",
+  "workspaceId": null,
+  "skipHealth": true
+}
+```
+
+This matches the backend route order: tenant scope is available before the
+external system is loaded, and adapter-specific test options remain in the body.
+
+## Bridge-Machine Finding Addressed
+
+The bridge-machine comment on PR #1510 reported:
+
+- direct API/workbench-style K3 WebAPI connection test passed with tenant scope
+- K3 setup page button failed with `tenantId is required`
+
+This patch aligns the K3 setup page button with the passing workbench-style
+contract.
+
+## Not Verified In This Slice
+
+- No live bridge-machine retest was run from this development worktree.
+- No real K3 Save-only write was attempted.
+- No deployment to 142 was triggered in this slice.


### PR DESCRIPTION
## Summary

Fixes the K3 WISE setup page WebAPI test button tenant-scope contract surfaced by the bridge-machine verification on PR #1510.

The backend loads `/api/integration/external-systems/:id/test` using tenant scope before adapter test options from the body are used. The setup page previously sent `tenantId` only in the POST body, so the route could fail with `tenantId is required` before it reached the adapter. This aligns the setup page helper with the generic workbench path by adding `tenantId` / `workspaceId` to the test URL query while preserving the body.

## Changes

- `testIntegrationSystem()` now appends tenant/workspace scope query params when present.
- K3 setup view test now expects `?tenantId=default` on the WebAPI test call.
- Added development and verification MDs for the bridge-machine finding.

## Verification

- `pnpm install --frozen-lockfile` in isolated worktree: PASS
- `pnpm --filter @metasheet/web exec vitest run tests/IntegrationK3WiseSetupView.spec.ts tests/k3WiseSetup.spec.ts tests/integrationWorkbench.spec.ts --watch=false`: 35/35 PASS
- `pnpm --filter @metasheet/web build`: PASS
- `pnpm --filter @metasheet/web exec vitest run tests/IntegrationK3WiseSetupView.spec.ts --watch=false`: 2/2 PASS after cleanup
- `git diff --cached --check`: PASS

## Deployment impact

Frontend/service-only fix. No migration, backend, plugin, or K3 adapter changes. After deployment, the K3 setup page test button should use the same tenant-scope contract as the passing workbench-style connection test.
