### PR TITLE
fix(integration): refresh K3 disabled SQL preflight guidance

### DIFF
--- a/docs/development/integration-k3wise-preflight-disabled-mode-refresh-design-20260513.md
+++ b/docs/development/integration-k3wise-preflight-disabled-mode-refresh-design-20260513.md
@@ -1,0 +1,49 @@
+# K3 WISE Preflight Disabled SQL Mode Refresh Design - 2026-05-13
+
+## Scope
+
+Refresh stale PR #1316 on current `main` after the K3 WISE PoC hardening queue moved forward.
+
+The behavior gap is narrow: a GATE packet with `sqlServer.enabled=true` and `sqlServer.mode=disabled` is already invalid, but current `main` reports the generic mode error:
+
+`sqlServer.mode must be readonly, middle-table, or stored-procedure`
+
+That message is technically correct but not actionable for customer-filled GATE JSON. If the operator wants to disable SQL Server, the field to change is `sqlServer.enabled=false`.
+
+## Design
+
+`normalizeSqlMode()` keeps existing semantics:
+
+- `enabled=false` and no explicit mode normalizes to `disabled`.
+- `enabled=true` and no explicit mode defaults to `readonly`.
+- Valid enabled modes remain `readonly`, `middle-table`, and `stored-procedure`.
+- Unknown modes still use the generic validation error.
+
+The only new branch is the explicit invalid shape:
+
+```json
+{
+  "sqlServer": {
+    "enabled": true,
+    "mode": "disabled"
+  }
+}
+```
+
+It now throws `LivePocPreflightError` with operator-facing remediation:
+
+`sqlServer.mode=disabled requires sqlServer.enabled=false; set enabled=false or choose readonly, middle-table, or stored-procedure`
+
+Machine-readable details include:
+
+- `field: "sqlServer.mode"`
+- `mode`
+- `sqlServerEnabled: true`
+- `acceptedModes`
+
+The K3 WISE runbook quick lookup table now maps the exact error to the same remediation.
+
+## Compatibility
+
+This does not change SQL Server write safety or any accepted packet shape. It only improves guidance for a packet that was already rejected.
+

--- a/docs/development/integration-k3wise-preflight-disabled-mode-refresh-verification-20260513.md
+++ b/docs/development/integration-k3wise-preflight-disabled-mode-refresh-verification-20260513.md
@@ -1,0 +1,57 @@
+# K3 WISE Preflight Disabled SQL Mode Refresh Verification - 2026-05-13
+
+## Worktree
+
+`/private/tmp/ms2-k3wise-disabled-mode-refresh-20260513`
+
+Branch:
+
+`codex/k3wise-preflight-disabled-mode-refresh-20260513`
+
+Baseline:
+
+`origin/main` at `d32e721e7`.
+
+## Validation Plan
+
+Run the focused K3 WISE preflight suite, the offline PoC chain, and whitespace checks:
+
+```bash
+node --test scripts/ops/integration-k3wise-live-poc-preflight.test.mjs
+pnpm run verify:integration-k3wise:poc
+git diff --check origin/main..HEAD
+```
+
+## Coverage
+
+- `sqlServer.enabled=true` with `sqlServer.mode=disabled` throws a targeted `LivePocPreflightError`.
+- The assertion checks operator-facing remediation text:
+  - set `sqlServer.enabled=false`, or
+  - choose `readonly`, `middle-table`, or `stored-procedure`.
+- The assertion checks machine-readable details:
+  - `field === "sqlServer.mode"`
+  - `sqlServerEnabled === true`
+  - `acceptedModes` includes `readonly`.
+- The runbook quick lookup table includes the same exact error string and fix.
+
+## Results
+
+All planned commands passed:
+
+- `node --test scripts/ops/integration-k3wise-live-poc-preflight.test.mjs`
+  - 21/21 passed.
+  - New coverage: `buildPacket explains disabled SQL mode requires sqlServer.enabled=false`.
+- `pnpm run verify:integration-k3wise:poc`
+  - preflight tests: 21/21 passed.
+  - evidence tests: 41/41 passed.
+  - mock K3 WebAPI tests: 4/4 passed.
+  - mock SQL executor tests: 12/12 passed.
+  - mock PoC demo ended with `K3 WISE PoC mock chain verified end-to-end (PASS)`.
+- `git diff --check origin/main..HEAD`
+  - passed.
+
+## Not Covered
+
+- Real K3 WISE connectivity.
+- Real SQL Server connectivity.
+- UI copy changes; this slice only covers preflight and runbook guidance.

--- a/packages/core-backend/claudedocs/integration-plm-k3wise-mvp.md
+++ b/packages/core-backend/claudedocs/integration-plm-k3wise-mvp.md
@@ -645,13 +645,14 @@ node scripts/ops/integration-k3wise-postdeploy-smoke.mjs \
 
 ### 9.8 错误处理快查表
 
-下表覆盖客户/操作员最可能遇到的 7 类错误，按"看到这条信息→怎么办"组织：
+下表覆盖客户/操作员最可能遇到的错误，按"看到这条信息→怎么办"组织：
 
 | 错误信号 | 典型场景 | 怎么办 |
 |---|---|---|
 | `LivePocPreflightError: <field> must be a boolean, 0/1, or boolean-like string` | GATE 答卷写了 `autoSubmit: "maybe"` 或类似无效值 | 改成允许的写法（`true/false/是/否/0/1/...`）后重跑 preflight |
 | `LivePocPreflightError: M2 live PoC packet is Save-only: autoSubmit and autoAudit must be false` | GATE 答卷写了 `autoSubmit: true` | M2 PoC 强制 Save-only。等过 PoC 后再单独申请开 auto-submit。改回 `false` 重跑 |
 | `LivePocPreflightError: SQL Server channel may not write K3 core business tables in live PoC` | `sqlServer.allowedTables` 含 `t_ICItem` / `t_ICBOM` 且 `mode != readonly` | 把 mode 改回 `readonly`，或把 allowedTables 限制到中间表 |
+| `LivePocPreflightError: sqlServer.mode=disabled requires sqlServer.enabled=false` | 想关闭 SQL Server 通道时只写了 `sqlServer.mode: "disabled"`，但 `sqlServer.enabled` 仍是 `true` | 真正关闭通道请设 `sqlServer.enabled=false`；如果要启用通道，只能选择 `readonly` / `middle-table` / `stored-procedure` |
 | `LivePocPreflightError: K3 WISE live PoC must target a non-production test environment` | `k3Wise.environment` 写成 `production` / `prod` | 改成 `test` / `uat` / `staging` 等非生产环境标识 |
 | `LivePocEvidenceError: evidence contains unredacted secret-like fields` | evidence JSON 里残留了真密码 / token / sessionId | 把 secret-like key 的值替换成 `<redacted>` 或空字符串后重跑 |
 | `SAVE_ONLY_VIOLATED` (evidence 报告 issues) | evidence 中 `materialSaveOnly.autoSubmit` 或 `autoAudit` 是 truthy（含字符串/数字/中文） | 客户 K3 实际跑时确实开了自动审核——按 GATE 答卷 Save-only 约定重新跑客户侧 K3 测试，或回流 M2 adapter 硬化 |

--- a/scripts/ops/integration-k3wise-live-poc-preflight.mjs
+++ b/scripts/ops/integration-k3wise-live-poc-preflight.mjs
@@ -142,6 +142,17 @@ function normalizeSqlMode(value, sqlEnabled) {
   const key = text.toLowerCase().replace(/\s+/g, ' ')
   const normalized = SQL_MODE_ALIASES.get(key) || key
   if (normalized === 'disabled' && !sqlEnabled) return normalized
+  if (normalized === 'disabled' && sqlEnabled) {
+    throw new LivePocPreflightError(
+      'sqlServer.mode=disabled requires sqlServer.enabled=false; set enabled=false or choose readonly, middle-table, or stored-procedure',
+      {
+        field: 'sqlServer.mode',
+        mode: text,
+        sqlServerEnabled: true,
+        acceptedModes: ['readonly', 'middle-table', 'stored-procedure'],
+      },
+    )
+  }
   if (!SQL_MODES.has(normalized)) {
     throw new LivePocPreflightError('sqlServer.mode must be readonly, middle-table, or stored-procedure', {
       field: 'sqlServer.mode',

--- a/scripts/ops/integration-k3wise-live-poc-preflight.test.mjs
+++ b/scripts/ops/integration-k3wise-live-poc-preflight.test.mjs
@@ -324,6 +324,24 @@ test('buildPacket coerces sqlServer.enabled "true" string and still applies allo
   assert.equal(packet.safety.sqlServerMode, 'disabled', 'string "no" + no explicit mode disables sql server')
 })
 
+test('buildPacket explains disabled SQL mode requires sqlServer.enabled=false', () => {
+  assert.throws(
+    () => buildPacket(gate({
+      sqlServer: {
+        enabled: true,
+        mode: 'disabled',
+        allowedTables: [],
+      },
+    })),
+    (error) => error instanceof LivePocPreflightError &&
+      error.details.field === 'sqlServer.mode' &&
+      error.details.sqlServerEnabled === true &&
+      error.details.acceptedModes.includes('readonly') &&
+      /requires sqlServer\.enabled=false/.test(error.message),
+    'enabled SQL Server channel with mode=disabled must tell operators to set enabled=false instead',
+  )
+})
+
 test('buildPacket coerces sqlServer.writeCoreTables "true" string', () => {
   // Same string-truthy pattern: customer typing writeCoreTables: "true" was
   // previously read as not-true (=== true comparison), bypassing the guard.


### PR DESCRIPTION
## Summary
- refresh stale #1316 on current main with the targeted `sqlServer.enabled=true` + `sqlServer.mode=disabled` preflight guidance
- keep accepted SQL Server modes and disabled-channel semantics unchanged
- add 2026-05-13 design/verification docs and runbook quick-lookup entry

## Verification
- `node --test scripts/ops/integration-k3wise-live-poc-preflight.test.mjs`
- `pnpm run verify:integration-k3wise:poc`
- `git diff --check origin/main..HEAD`

## Supersedes
- Supersedes stale PR #1316.