### PR TITLE
feat(integration): refresh K3 delivery readiness gate

### DIFF
--- a/docs/development/integration-k3wise-delivery-readiness-refresh-design-20260513.md
+++ b/docs/development/integration-k3wise-delivery-readiness-refresh-design-20260513.md
@@ -1,0 +1,79 @@
+# K3 WISE Delivery Readiness Gate Refresh Design - 2026-05-13
+
+## Goal
+
+Give the K3 WISE PLM->ERP PoC a single, evidence-driven answer to:
+
+- Is the deployed MetaSheet integration surface internally ready?
+- Can customer test-account live PoC start?
+- Did customer live PoC pass?
+- Is production use ready?
+
+This refresh supersedes stale PR #1355 on current `main`. Before this change, the evidence existed in separate places:
+
+- postdeploy smoke JSON;
+- live preflight packet JSON;
+- live evidence report JSON.
+
+Operators had to read those manually and infer the stage. That made "can we deliver now?" ambiguous.
+
+## Design
+
+Added `scripts/ops/integration-k3wise-delivery-readiness.mjs`.
+
+Inputs are optional and additive:
+
+- `--postdeploy-smoke <path>` reads `integration-k3wise-postdeploy-smoke.json`.
+- `--preflight-packet <path>` reads live PoC `packet.json`.
+- `--live-evidence-report <path>` reads `integration-k3wise-live-poc-evidence-report.json`.
+- `--out-dir <dir>` writes JSON and Markdown artifacts.
+- `--fail-on-blocked` exits non-zero when the decision is `BLOCKED`.
+
+The script emits:
+
+- `integration-k3wise-delivery-readiness.json`
+- `integration-k3wise-delivery-readiness.md`
+
+## Decisions
+
+The readiness decision is intentionally conservative:
+
+| Decision | Meaning |
+|---|---|
+| `BLOCKED` | One gate failed, or internal postdeploy evidence is missing. Do not start the next stage. |
+| `INTERNAL_READY_WAITING_CUSTOMER_GATE` | Authenticated postdeploy smoke passed; wait for customer GATE answers. |
+| `CUSTOMER_TRIAL_READY` | Postdeploy smoke and Save-only preflight packet passed; start customer test-account live PoC. |
+| `CUSTOMER_TRIAL_SIGNED_OFF` | Live evidence report passed; prepare production change review. |
+
+`CUSTOMER_TRIAL_SIGNED_OFF` does not mark production ready. The report always keeps
+`productionUse.ready=false` until customer change approval, backup/rollback confirmation,
+and a scheduled go-live window exist outside this script.
+
+## Gate Rules
+
+Postdeploy smoke passes only when:
+
+- `ok === true`;
+- authenticated checks ran;
+- `signoff.internalTrial === "pass"` or legacy authenticated evidence has no signoff block.
+
+Preflight packet passes only when:
+
+- `status === "preflight-ready"`;
+- `safety.saveOnly === true`;
+- `safety.autoSubmit === false`;
+- `safety.autoAudit === false`;
+- `safety.productionWriteBlocked === true`.
+
+Live evidence passes only when:
+
+- evidence report `decision === "PASS"`.
+
+## Files Changed
+
+- `scripts/ops/integration-k3wise-delivery-readiness.mjs`
+- `scripts/ops/integration-k3wise-delivery-readiness.test.mjs`
+- `package.json`
+- `packages/core-backend/claudedocs/integration-plm-k3wise-mvp.md`
+- `docs/development/integration-k3wise-delivery-readiness-refresh-design-20260513.md`
+- `docs/development/integration-k3wise-delivery-readiness-refresh-verification-20260513.md`

--- a/docs/development/integration-k3wise-delivery-readiness-refresh-verification-20260513.md
+++ b/docs/development/integration-k3wise-delivery-readiness-refresh-verification-20260513.md
@@ -1,0 +1,63 @@
+# K3 WISE Delivery Readiness Gate Refresh Verification - 2026-05-13
+
+## Scope
+
+Verify the refreshed delivery readiness gate for the K3 WISE PLM->ERP PoC.
+
+This verification does not contact real PLM, K3 WISE, SQL Server, or a deployed
+MetaSheet backend. It validates the local gate logic and keeps the existing mock
+PoC chain green on current `main`.
+
+## Commands
+
+```bash
+node --check scripts/ops/integration-k3wise-delivery-readiness.mjs
+node --test scripts/ops/integration-k3wise-delivery-readiness.test.mjs
+pnpm run verify:integration-k3wise:delivery
+pnpm run verify:integration-k3wise:poc
+git diff --check
+```
+
+## Results
+
+All planned commands passed:
+
+| Check | Result |
+|---|---|
+| Syntax check | PASS |
+| Delivery readiness unit tests | PASS, 7/7 |
+| Package script `verify:integration-k3wise:delivery` | PASS, 7/7 |
+| Existing K3 WISE mock PoC chain | PASS |
+| Whitespace check | PASS |
+
+`pnpm run verify:integration-k3wise:poc` preserved the current full chain:
+
+- preflight tests: 21/21 passed.
+- evidence tests: 41/41 passed.
+- mock K3 WebAPI tests: 4/4 passed.
+- mock SQL executor tests: 12/12 passed.
+- mock PoC demo ended with `K3 WISE PoC mock chain verified end-to-end (PASS)`.
+
+## Covered Cases
+
+- Authenticated postdeploy smoke alone returns `INTERNAL_READY_WAITING_CUSTOMER_GATE`.
+- Postdeploy smoke plus Save-only preflight packet returns `CUSTOMER_TRIAL_READY`.
+- Postdeploy smoke plus preflight plus PASS live evidence returns `CUSTOMER_TRIAL_SIGNED_OFF`.
+- A preflight packet with `autoSubmit=true` returns `BLOCKED`.
+- A `PARTIAL` live evidence report returns `BLOCKED`.
+- Markdown output includes the production caveat.
+- CLI writes JSON and Markdown artifacts.
+
+## Delivery Interpretation
+
+Current code can prove internal/mock readiness without customer systems.
+
+Customer-use readiness still requires:
+
+1. deployment of the merged backend/frontend;
+2. authenticated postdeploy smoke PASS;
+3. customer GATE packet PASS;
+4. customer test-account live PoC PASS.
+
+Production use remains blocked until customer change approval, backup/rollback
+confirmation, and go-live scheduling are recorded outside this technical gate.

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "verify:multitable-grid-profile:summary": "node scripts/ops/multitable-grid-profile-summary.mjs",
     "verify:integration-erp-plm:deploy-readiness": "node scripts/ops/integration-erp-plm-deploy-readiness.mjs",
     "verify:integration-k3wise:poc": "node --test scripts/ops/integration-k3wise-live-poc-preflight.test.mjs && node --test scripts/ops/integration-k3wise-live-poc-evidence.test.mjs && node --test scripts/ops/fixtures/integration-k3wise/mock-k3-webapi-server.test.mjs && node --test scripts/ops/fixtures/integration-k3wise/mock-sqlserver-executor.test.mjs && node scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs",
+    "verify:integration-k3wise:delivery": "node --test scripts/ops/integration-k3wise-delivery-readiness.test.mjs",
     "verify:integration-k3wise:onprem-preflight": "node --test scripts/ops/integration-k3wise-onprem-preflight.test.mjs",
     "verify:integration-k3wise:postdeploy-env-check": "node --test scripts/ops/integration-k3wise-postdeploy-env-check.test.mjs",
     "phase5:run-all": "bash scripts/phase5-run-all.sh",

--- a/packages/core-backend/claudedocs/integration-plm-k3wise-mvp.md
+++ b/packages/core-backend/claudedocs/integration-plm-k3wise-mvp.md
@@ -694,6 +694,28 @@ node --test scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs
 
 `pnpm run verify:integration-k3wise:poc` 是 CI 入口：它串起 preflight 单测、evidence 单测、端到端 mock PoC demo，并在 `Plugin System Tests` 的独立 Node 20 job 中执行，不依赖客户凭据或真实外部系统。
 
+### 10.1.1 交付状态判定
+
+当 postdeploy smoke、客户 GATE preflight、客户 live evidence 逐步产生后，用统一 readiness gate 合并证据：
+
+```bash
+node scripts/ops/integration-k3wise-delivery-readiness.mjs \
+  --postdeploy-smoke output/integration-k3wise-postdeploy-smoke/manual/integration-k3wise-postdeploy-smoke.json \
+  --preflight-packet artifacts/integration-live-poc/packet.json \
+  --live-evidence-report artifacts/integration-live-poc/evidence/integration-k3wise-live-poc-evidence-report.json \
+  --out-dir artifacts/integration-k3wise/delivery-readiness \
+  --fail-on-blocked
+```
+
+输出：
+
+- `INTERNAL_READY_WAITING_CUSTOMER_GATE`：部署侧 K3 WISE control-plane 已通过，等待客户 GATE 答卷。
+- `CUSTOMER_TRIAL_READY`：客户 GATE 已经生成 Save-only preflight packet，可以进入客户测试账套 live PoC。
+- `CUSTOMER_TRIAL_SIGNED_OFF`：客户 live evidence 为 PASS，可以准备生产变更评审。
+- `BLOCKED`：至少一个 gate 失败，不能进入下一阶段。
+
+注意：`CUSTOMER_TRIAL_SIGNED_OFF` 仍不等于生产可直接上线；生产使用还需要客户变更批准、备份/回滚确认和上线窗口。
+
 ### 10.2 测试账套验收
 
 客户测试账套必须完成：

--- a/scripts/ops/integration-k3wise-delivery-readiness.mjs
+++ b/scripts/ops/integration-k3wise-delivery-readiness.mjs
@@ -1,0 +1,346 @@
+#!/usr/bin/env node
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const DEFAULT_OUTPUT_ROOT = 'artifacts/integration-k3wise/delivery-readiness'
+const BLOCKED_DECISION = 'BLOCKED'
+const INTERNAL_READY_DECISION = 'INTERNAL_READY_WAITING_CUSTOMER_GATE'
+const CUSTOMER_READY_DECISION = 'CUSTOMER_TRIAL_READY'
+const CUSTOMER_SIGNED_OFF_DECISION = 'CUSTOMER_TRIAL_SIGNED_OFF'
+
+class K3WiseDeliveryReadinessError extends Error {
+  constructor(message, details = {}) {
+    super(message)
+    this.name = 'K3WiseDeliveryReadinessError'
+    this.details = details
+  }
+}
+
+function nowStamp(date = new Date()) {
+  return date.toISOString().replace(/[:.]/g, '-')
+}
+
+function isPlainObject(value) {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value))
+}
+
+function readRequiredValue(argv, index, flag) {
+  const next = argv[index + 1]
+  if (!next || next.startsWith('--')) {
+    throw new K3WiseDeliveryReadinessError(`${flag} requires a value`, { flag })
+  }
+  return next
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+  const opts = {
+    postdeploySmoke: '',
+    preflightPacket: '',
+    liveEvidenceReport: '',
+    outDir: '',
+    failOnBlocked: false,
+    help: false,
+  }
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    switch (arg) {
+      case '--postdeploy-smoke':
+        opts.postdeploySmoke = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--preflight-packet':
+        opts.preflightPacket = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--live-evidence-report':
+        opts.liveEvidenceReport = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--out-dir':
+        opts.outDir = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--fail-on-blocked':
+        opts.failOnBlocked = true
+        break
+      case '--help':
+      case '-h':
+        opts.help = true
+        break
+      default:
+        throw new K3WiseDeliveryReadinessError(`unknown option: ${arg}`, { arg })
+    }
+  }
+
+  return opts
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/ops/integration-k3wise-delivery-readiness.mjs [options]
+
+Combines K3 WISE delivery evidence into one readiness decision.
+
+Options:
+  --postdeploy-smoke <path>      integration-k3wise-postdeploy-smoke.json
+  --preflight-packet <path>      packet.json from live PoC preflight
+  --live-evidence-report <path>  integration-k3wise-live-poc-evidence-report.json
+  --out-dir <dir>                Output directory, default ${DEFAULT_OUTPUT_ROOT}/<timestamp>
+  --fail-on-blocked              Exit non-zero when the readiness decision is BLOCKED
+  --help                         Show this help
+`)
+}
+
+function gate(id, label, status, details = {}) {
+  return {
+    id,
+    label,
+    status,
+    ...details,
+  }
+}
+
+function evaluatePostdeploySmoke(evidence) {
+  if (!evidence) {
+    return gate('postdeploy-smoke', 'Deployed MetaSheet K3 WISE smoke', 'pending', {
+      reason: 'postdeploy smoke evidence not provided',
+      requiredFor: CUSTOMER_READY_DECISION,
+    })
+  }
+  if (!isPlainObject(evidence)) {
+    return gate('postdeploy-smoke', 'Deployed MetaSheet K3 WISE smoke', 'fail', {
+      reason: 'postdeploy smoke evidence must be a JSON object',
+    })
+  }
+
+  const authenticated = evidence.authenticated === true
+  const signoff = evidence.signoff && typeof evidence.signoff === 'object' ? evidence.signoff : {}
+  if (evidence.ok === true && authenticated && signoff.internalTrial === 'pass') {
+    return gate('postdeploy-smoke', 'Deployed MetaSheet K3 WISE smoke', 'pass', {
+      reason: signoff.reason || 'authenticated postdeploy smoke passed',
+      summary: evidence.summary || {},
+    })
+  }
+  if (evidence.ok === true && authenticated && signoff.internalTrial === undefined) {
+    return gate('postdeploy-smoke', 'Deployed MetaSheet K3 WISE smoke', 'pass', {
+      reason: 'authenticated postdeploy smoke passed; legacy evidence has no signoff block',
+      summary: evidence.summary || {},
+      warning: 'missing signoff.internalTrial in postdeploy evidence',
+    })
+  }
+  return gate('postdeploy-smoke', 'Deployed MetaSheet K3 WISE smoke', 'fail', {
+    reason: signoff.reason || (authenticated ? 'postdeploy smoke did not pass' : 'authenticated checks did not run'),
+    authenticated,
+    summary: evidence.summary || {},
+  })
+}
+
+function evaluatePreflightPacket(packet) {
+  if (!packet) {
+    return gate('preflight-packet', 'Customer GATE preflight packet', 'pending', {
+      reason: 'preflight packet not provided',
+      requiredFor: CUSTOMER_READY_DECISION,
+    })
+  }
+  if (!isPlainObject(packet)) {
+    return gate('preflight-packet', 'Customer GATE preflight packet', 'fail', {
+      reason: 'preflight packet must be a JSON object',
+    })
+  }
+  const safety = isPlainObject(packet.safety) ? packet.safety : {}
+  const failures = []
+  if (packet.status !== 'preflight-ready') failures.push('packet.status must be preflight-ready')
+  if (safety.saveOnly !== true) failures.push('packet.safety.saveOnly must be true')
+  if (safety.autoSubmit !== false) failures.push('packet.safety.autoSubmit must be false')
+  if (safety.autoAudit !== false) failures.push('packet.safety.autoAudit must be false')
+  if (safety.productionWriteBlocked !== true) failures.push('packet.safety.productionWriteBlocked must be true')
+
+  if (failures.length > 0) {
+    return gate('preflight-packet', 'Customer GATE preflight packet', 'fail', {
+      reason: failures.join('; '),
+      tenantId: packet.tenantId || null,
+      workspaceId: packet.workspaceId || null,
+    })
+  }
+  return gate('preflight-packet', 'Customer GATE preflight packet', 'pass', {
+    reason: 'preflight packet is Save-only and production-write blocked',
+    tenantId: packet.tenantId || null,
+    workspaceId: packet.workspaceId || null,
+    projectId: packet.projectId || null,
+  })
+}
+
+function evaluateLiveEvidenceReport(report) {
+  if (!report) {
+    return gate('live-evidence', 'Customer live PoC evidence report', 'pending', {
+      reason: 'live evidence report not provided',
+      requiredFor: CUSTOMER_SIGNED_OFF_DECISION,
+    })
+  }
+  if (!isPlainObject(report)) {
+    return gate('live-evidence', 'Customer live PoC evidence report', 'fail', {
+      reason: 'live evidence report must be a JSON object',
+    })
+  }
+  if (report.decision === 'PASS') {
+    return gate('live-evidence', 'Customer live PoC evidence report', 'pass', {
+      reason: 'live PoC evidence decision is PASS',
+      issues: Array.isArray(report.issues) ? report.issues.length : 0,
+    })
+  }
+  return gate('live-evidence', 'Customer live PoC evidence report', 'fail', {
+    reason: `live PoC evidence decision is ${report.decision || 'missing'}`,
+    issues: Array.isArray(report.issues) ? report.issues : [],
+  })
+}
+
+function decide(gates) {
+  if (gates.some((item) => item.status === 'fail')) return BLOCKED_DECISION
+  const postdeploy = gates.find((item) => item.id === 'postdeploy-smoke')
+  const preflight = gates.find((item) => item.id === 'preflight-packet')
+  const live = gates.find((item) => item.id === 'live-evidence')
+
+  if (postdeploy?.status === 'pass' && preflight?.status === 'pass' && live?.status === 'pass') {
+    return CUSTOMER_SIGNED_OFF_DECISION
+  }
+  if (postdeploy?.status === 'pass' && preflight?.status === 'pass') {
+    return CUSTOMER_READY_DECISION
+  }
+  if (postdeploy?.status === 'pass') {
+    return INTERNAL_READY_DECISION
+  }
+  return BLOCKED_DECISION
+}
+
+function nextAction(decision) {
+  switch (decision) {
+    case CUSTOMER_SIGNED_OFF_DECISION:
+      return 'Customer trial is signed off. Production use still requires customer change approval, backup/rollback confirmation, and an agreed go-live window.'
+    case CUSTOMER_READY_DECISION:
+      return 'Start the customer K3 WISE test-account live PoC: create systems, run dry-run, run Save-only, compile live evidence.'
+    case INTERNAL_READY_DECISION:
+      return 'Wait for customer GATE answers, then run live preflight to produce a preflight-ready packet.'
+    default:
+      return 'Do not start customer live work. Fix failing gates or run the missing internal postdeploy smoke first.'
+  }
+}
+
+function buildReadinessReport(inputs = {}, { generatedAt = new Date().toISOString() } = {}) {
+  const gates = [
+    evaluatePostdeploySmoke(inputs.postdeploySmoke),
+    evaluatePreflightPacket(inputs.preflightPacket),
+    evaluateLiveEvidenceReport(inputs.liveEvidenceReport),
+  ]
+  const decision = decide(gates)
+  return {
+    schemaVersion: 1,
+    generatedAt,
+    decision,
+    gates,
+    productionUse: {
+      ready: false,
+      reason: 'production go-live requires explicit customer signoff, backup/rollback approval, and a scheduled change window',
+    },
+    nextAction: nextAction(decision),
+  }
+}
+
+function renderMarkdown(report) {
+  const lines = [
+    `# K3 WISE Delivery Readiness - ${report.generatedAt.slice(0, 10)}`,
+    '',
+    '## Decision',
+    '',
+    `- Readiness: **${report.decision}**`,
+    `- Production use ready: **${report.productionUse.ready ? 'yes' : 'no'}**`,
+    `- Production note: ${report.productionUse.reason}`,
+    `- Next action: ${report.nextAction}`,
+    '',
+    '## Gates',
+    '',
+    '| Gate | Status | Reason |',
+    '|---|---|---|',
+    ...report.gates.map((item) => `| ${item.label} | ${item.status} | ${item.reason || '-'} |`),
+    '',
+  ]
+  return `${lines.join('\n')}\n`
+}
+
+async function readJsonFile(filePath, label) {
+  if (!filePath) return null
+  const absolutePath = path.resolve(filePath)
+  let raw
+  try {
+    raw = await readFile(absolutePath, 'utf8')
+  } catch (error) {
+    throw new K3WiseDeliveryReadinessError(`${label} file cannot be read`, {
+      path: absolutePath,
+      cause: error && error.message ? error.message : String(error),
+    })
+  }
+  try {
+    return JSON.parse(raw)
+  } catch (error) {
+    throw new K3WiseDeliveryReadinessError(`${label} file is not valid JSON`, {
+      path: absolutePath,
+      cause: error && error.message ? error.message : String(error),
+    })
+  }
+}
+
+async function runCli(argv = process.argv.slice(2)) {
+  const opts = parseArgs(argv)
+  if (opts.help) {
+    printHelp()
+    return 0
+  }
+  const [postdeploySmoke, preflightPacket, liveEvidenceReport] = await Promise.all([
+    readJsonFile(opts.postdeploySmoke, 'postdeploy smoke'),
+    readJsonFile(opts.preflightPacket, 'preflight packet'),
+    readJsonFile(opts.liveEvidenceReport, 'live evidence report'),
+  ])
+  const report = buildReadinessReport({ postdeploySmoke, preflightPacket, liveEvidenceReport })
+  const outDir = path.resolve(opts.outDir || path.join(DEFAULT_OUTPUT_ROOT, nowStamp()))
+  await mkdir(outDir, { recursive: true })
+  const jsonPath = path.join(outDir, 'integration-k3wise-delivery-readiness.json')
+  const mdPath = path.join(outDir, 'integration-k3wise-delivery-readiness.md')
+  await writeFile(jsonPath, `${JSON.stringify(report, null, 2)}\n`)
+  await writeFile(mdPath, renderMarkdown(report))
+  console.log(JSON.stringify({
+    ok: report.decision !== BLOCKED_DECISION,
+    decision: report.decision,
+    jsonPath,
+    mdPath,
+  }, null, 2))
+  return opts.failOnBlocked && report.decision === BLOCKED_DECISION ? 1 : 0
+}
+
+const entryPath = process.argv[1] ? pathToFileURL(path.resolve(process.argv[1])).href : null
+if (entryPath && import.meta.url === entryPath) {
+  runCli().then((code) => {
+    process.exitCode = code
+  }).catch((error) => {
+    const body = error instanceof K3WiseDeliveryReadinessError
+      ? { ok: false, code: error.name, message: error.message, details: error.details }
+      : { ok: false, code: error && error.name ? error.name : 'Error', message: error && error.message ? error.message : String(error) }
+    console.error(JSON.stringify(body, null, 2))
+    process.exitCode = 1
+  })
+}
+
+export {
+  BLOCKED_DECISION,
+  CUSTOMER_READY_DECISION,
+  CUSTOMER_SIGNED_OFF_DECISION,
+  INTERNAL_READY_DECISION,
+  K3WiseDeliveryReadinessError,
+  buildReadinessReport,
+  decide,
+  evaluateLiveEvidenceReport,
+  evaluatePostdeploySmoke,
+  evaluatePreflightPacket,
+  parseArgs,
+  renderMarkdown,
+  runCli,
+}

--- a/scripts/ops/integration-k3wise-delivery-readiness.test.mjs
+++ b/scripts/ops/integration-k3wise-delivery-readiness.test.mjs
@@ -1,0 +1,165 @@
+import assert from 'node:assert/strict'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+
+import {
+  BLOCKED_DECISION,
+  CUSTOMER_READY_DECISION,
+  CUSTOMER_SIGNED_OFF_DECISION,
+  INTERNAL_READY_DECISION,
+  buildReadinessReport,
+  renderMarkdown,
+  runCli,
+} from './integration-k3wise-delivery-readiness.mjs'
+
+function postdeployPass() {
+  return {
+    ok: true,
+    authenticated: true,
+    signoff: {
+      internalTrial: 'pass',
+      reason: 'authenticated smoke passed',
+    },
+    summary: { pass: 12, skipped: 0, fail: 0 },
+  }
+}
+
+function preflightReadyPacket(overrides = {}) {
+  return {
+    status: 'preflight-ready',
+    tenantId: 'tenant_1',
+    workspaceId: 'workspace_1',
+    projectId: 'project_1',
+    safety: {
+      saveOnly: true,
+      autoSubmit: false,
+      autoAudit: false,
+      productionWriteBlocked: true,
+    },
+    ...overrides,
+  }
+}
+
+function liveEvidencePass() {
+  return {
+    decision: 'PASS',
+    issues: [],
+  }
+}
+
+function makeTmpDir() {
+  return mkdtempSync(path.join(tmpdir(), 'integration-k3wise-delivery-readiness-'))
+}
+
+test('reports internal readiness after authenticated postdeploy smoke passes', () => {
+  const report = buildReadinessReport({
+    postdeploySmoke: postdeployPass(),
+  }, { generatedAt: '2026-05-06T00:00:00.000Z' })
+
+  assert.equal(report.decision, INTERNAL_READY_DECISION)
+  assert.equal(report.gates.find((gate) => gate.id === 'postdeploy-smoke').status, 'pass')
+  assert.equal(report.gates.find((gate) => gate.id === 'preflight-packet').status, 'pending')
+  assert.match(report.nextAction, /Wait for customer GATE/)
+})
+
+test('reports customer trial ready after postdeploy and preflight pass', () => {
+  const report = buildReadinessReport({
+    postdeploySmoke: postdeployPass(),
+    preflightPacket: preflightReadyPacket(),
+  }, { generatedAt: '2026-05-06T00:00:00.000Z' })
+
+  assert.equal(report.decision, CUSTOMER_READY_DECISION)
+  assert.equal(report.productionUse.ready, false)
+  assert.match(report.nextAction, /Start the customer K3 WISE test-account live PoC/)
+})
+
+test('reports customer trial signed off after live evidence report passes', () => {
+  const report = buildReadinessReport({
+    postdeploySmoke: postdeployPass(),
+    preflightPacket: preflightReadyPacket(),
+    liveEvidenceReport: liveEvidencePass(),
+  }, { generatedAt: '2026-05-06T00:00:00.000Z' })
+
+  assert.equal(report.decision, CUSTOMER_SIGNED_OFF_DECISION)
+  assert.equal(report.productionUse.ready, false)
+  assert.match(report.productionUse.reason, /scheduled change window/)
+})
+
+test('blocks readiness when preflight packet loses Save-only safety', () => {
+  const report = buildReadinessReport({
+    postdeploySmoke: postdeployPass(),
+    preflightPacket: preflightReadyPacket({
+      safety: {
+        saveOnly: true,
+        autoSubmit: true,
+        autoAudit: false,
+        productionWriteBlocked: true,
+      },
+    }),
+  }, { generatedAt: '2026-05-06T00:00:00.000Z' })
+
+  assert.equal(report.decision, BLOCKED_DECISION)
+  const preflight = report.gates.find((gate) => gate.id === 'preflight-packet')
+  assert.equal(preflight.status, 'fail')
+  assert.match(preflight.reason, /autoSubmit must be false/)
+})
+
+test('blocks readiness when live evidence is partial or failed', () => {
+  const report = buildReadinessReport({
+    postdeploySmoke: postdeployPass(),
+    preflightPacket: preflightReadyPacket(),
+    liveEvidenceReport: {
+      decision: 'PARTIAL',
+      issues: [{ severity: 'warn', code: 'CUSTOMER_CONFIRMATION_PENDING' }],
+    },
+  }, { generatedAt: '2026-05-06T00:00:00.000Z' })
+
+  assert.equal(report.decision, BLOCKED_DECISION)
+  const live = report.gates.find((gate) => gate.id === 'live-evidence')
+  assert.equal(live.status, 'fail')
+  assert.match(live.reason, /PARTIAL/)
+})
+
+test('renders markdown gate table and production caveat', () => {
+  const report = buildReadinessReport({
+    postdeploySmoke: postdeployPass(),
+    preflightPacket: preflightReadyPacket(),
+  }, { generatedAt: '2026-05-06T00:00:00.000Z' })
+
+  const md = renderMarkdown(report)
+
+  assert.match(md, /Readiness: \*\*CUSTOMER_TRIAL_READY\*\*/)
+  assert.match(md, /Production use ready: \*\*no\*\*/)
+  assert.match(md, /\| Customer GATE preflight packet \| pass \|/)
+})
+
+test('CLI writes JSON and Markdown readiness artifacts', async () => {
+  const outDir = makeTmpDir()
+  try {
+    const postdeployPath = path.join(outDir, 'postdeploy.json')
+    const packetPath = path.join(outDir, 'packet.json')
+    const reportPath = path.join(outDir, 'evidence-report.json')
+    const readinessOut = path.join(outDir, 'readiness')
+    writeFileSync(postdeployPath, `${JSON.stringify(postdeployPass())}\n`)
+    writeFileSync(packetPath, `${JSON.stringify(preflightReadyPacket())}\n`)
+    writeFileSync(reportPath, `${JSON.stringify(liveEvidencePass())}\n`)
+
+    const code = await runCli([
+      '--postdeploy-smoke', postdeployPath,
+      '--preflight-packet', packetPath,
+      '--live-evidence-report', reportPath,
+      '--out-dir', readinessOut,
+      '--fail-on-blocked',
+    ])
+
+    assert.equal(code, 0)
+    const json = JSON.parse(readFileSync(path.join(readinessOut, 'integration-k3wise-delivery-readiness.json'), 'utf8'))
+    const md = readFileSync(path.join(readinessOut, 'integration-k3wise-delivery-readiness.md'), 'utf8')
+    assert.equal(json.decision, CUSTOMER_SIGNED_OFF_DECISION)
+    assert.match(md, /Customer live PoC evidence report/)
+  } finally {
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary
- refresh stale #1355 on current main with a K3 WISE delivery readiness gate
- combine postdeploy smoke, live preflight packet, and live evidence report into one conservative readiness decision
- add `verify:integration-k3wise:delivery` without weakening the current `verify:integration-k3wise:poc` chain
- add 2026-05-13 design/verification docs and runbook usage notes

## Verification
- `node --check scripts/ops/integration-k3wise-delivery-readiness.mjs`
- `node --test scripts/ops/integration-k3wise-delivery-readiness.test.mjs`
- `pnpm run verify:integration-k3wise:delivery`
- `pnpm run verify:integration-k3wise:poc`
- `git diff --check`

## Supersedes
- Supersedes stale PR #1355.