### PR TITLE
fix(integration): make system integration the default page

### DIFF
--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -38,7 +38,7 @@
             <router-link v-if="canManageUsers" to="/admin/permissions" class="nav-link">{{ navLabels.permissions }}</router-link>
             <router-link v-if="canManageUsers" to="/admin/audit" class="nav-link">{{ navLabels.adminAudit }}</router-link>
             <router-link v-if="canManageUsers" to="/approvals/metrics" class="nav-link">{{ navLabels.approvalMetrics }}</router-link>
-            <router-link v-if="canUseIntegration" to="/integrations/k3-wise" class="nav-link">{{ navLabels.erpIntegration }}</router-link>
+            <router-link v-if="canUseIntegration" to="/integrations/workbench" class="nav-link">{{ navLabels.systemIntegration }}</router-link>
             <router-link v-if="isAdmin" to="/admin/plugins" class="nav-link">{{ navLabels.plugins }}</router-link>
             <router-link v-if="canUsePlm" to="/plm" class="nav-link">{{ navLabels.plm }}</router-link>
             <router-link v-if="canUsePlm" to="/plm/audit" class="nav-link">{{ navLabels.audit }}</router-link>
@@ -133,7 +133,7 @@ const navLabels = computed(() => {
       permissions: '权限',
       adminAudit: '管理审计',
       approvalMetrics: '审批 SLA',
-      erpIntegration: 'ERP 对接',
+      systemIntegration: '系统对接',
       plugins: '插件',
       plm: 'PLM',
       audit: '审计',
@@ -159,7 +159,7 @@ const navLabels = computed(() => {
     permissions: 'Permissions',
     adminAudit: 'Admin Audit',
     approvalMetrics: 'Approval SLA',
-    erpIntegration: 'ERP Integration',
+    systemIntegration: 'System Integration',
     plugins: 'Plugins',
     plm: 'PLM',
     audit: 'Audit',

--- a/apps/web/src/router/appRoutes.ts
+++ b/apps/web/src/router/appRoutes.ts
@@ -188,13 +188,13 @@ export const appRoutes: RouteRecordRaw[] = [
     path: '/integrations/workbench',
     name: AppRouteNames.INTEGRATION_WORKBENCH,
     component: () => import('../views/IntegrationWorkbenchView.vue'),
-    meta: { title: 'Integration Workbench', titleZh: '数据集成工作台', requiresAuth: true, permissions: ['integration:write'] }
+    meta: { title: 'System Integration', titleZh: '系统对接', requiresAuth: true, permissions: ['integration:write'] }
   },
   {
     path: '/integrations/k3-wise',
     name: AppRouteNames.INTEGRATION_K3_WISE,
     component: () => import('../views/IntegrationK3WiseSetupView.vue'),
-    meta: { title: 'K3 WISE Integration', titleZh: 'K3 WISE 对接', requiresAuth: true, permissions: ['integration:write'] }
+    meta: { title: 'K3 WISE Setup Preset', titleZh: 'K3 WISE 预设向导', requiresAuth: true, permissions: ['integration:write'] }
   },
   {
     path: '/workflows',

--- a/apps/web/src/views/IntegrationK3WiseSetupView.vue
+++ b/apps/web/src/views/IntegrationK3WiseSetupView.vue
@@ -2,9 +2,9 @@
   <section class="k3-setup" data-testid="k3-wise-setup">
     <header class="k3-setup__header">
       <div>
-        <p class="k3-setup__eyebrow">ERP Integration</p>
-        <h1>K3 WISE 对接配置</h1>
-        <p class="k3-setup__lead">先接通 K3 WISE，再把 PLM 数据放进多维表清洗，最后 dry-run 后推送 ERP。</p>
+        <p class="k3-setup__eyebrow">System Integration Preset</p>
+        <h1>K3 WISE 预设向导</h1>
+        <p class="k3-setup__lead">这是系统对接里的 K3 WISE 快速预设。先接通 K3 WISE，再把 PLM 数据放进多维表清洗，最后 dry-run 后 Save-only 推送。</p>
       </div>
       <div class="k3-setup__header-actions">
         <router-link class="k3-setup__btn" data-testid="generic-workbench-link" to="/integrations/workbench">
@@ -877,7 +877,7 @@ async function saveConfiguration(): Promise<void> {
       form.sqlHasCredentials = sql.hasCredentials === true
     }
     await loadSystems(true)
-    setStatus('K3 WISE 对接配置已保存', 'success')
+    setStatus('K3 WISE 预设配置已保存', 'success')
   } catch (error) {
     setStatus(formatError(error), 'error')
   } finally {

--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -2,9 +2,9 @@
   <section class="integration-workbench">
     <header class="integration-workbench__header">
       <div>
-        <p class="integration-workbench__eyebrow">Integration Workbench</p>
-        <h1>通用数据集成工作台</h1>
-        <p class="integration-workbench__lead">选择来源系统和目标系统，把数据在多维表中清洗后，先预览 payload，再 dry-run 和 Save-only 推送。</p>
+        <p class="integration-workbench__eyebrow">System Integration</p>
+        <h1>系统对接</h1>
+        <p class="integration-workbench__lead">这是默认的通用系统对接页面。选择任意来源系统和目标系统，把数据在多维表中清洗后，先预览 payload，再 dry-run 和 Save-only 推送。</p>
       </div>
       <router-link class="integration-workbench__k3-link" to="/integrations/k3-wise">K3 WISE 预设向导</router-link>
     </header>

--- a/apps/web/tests/IntegrationWorkbenchView.spec.ts
+++ b/apps/web/tests/IntegrationWorkbenchView.spec.ts
@@ -220,7 +220,8 @@ describe('IntegrationWorkbenchView', () => {
     app.mount(container)
     await flushUi()
 
-    expect(container.textContent).toContain('通用数据集成工作台')
+    expect(container.textContent).toContain('系统对接')
+    expect(container.textContent).toContain('默认的通用系统对接页面')
     expect(container.textContent).toContain('HTTP API')
     expect(container.textContent).not.toContain('K3 WISE SQL Server Channel')
     expect(container.textContent).toContain('已隐藏 1 个高级连接')

--- a/apps/web/tests/k3WiseSetup.spec.ts
+++ b/apps/web/tests/k3WiseSetup.spec.ts
@@ -357,7 +357,7 @@ describe('K3 WISE setup helpers', () => {
     const routeBlock = source.slice(routeStart, routeEnd)
 
     expect(routeBlock).toContain("path: '/integrations/k3-wise'")
-    expect(routeBlock).toContain("titleZh: 'K3 WISE 对接'")
+    expect(routeBlock).toContain("titleZh: 'K3 WISE 预设向导'")
     expect(routeBlock).toContain("permissions: ['integration:write']")
     expect(routeBlock).not.toContain("requiredFeature: 'attendanceAdmin'")
     expect(mainSource).toContain('to.meta?.permissions')

--- a/apps/web/tests/platform-shell-nav.spec.ts
+++ b/apps/web/tests/platform-shell-nav.spec.ts
@@ -188,7 +188,7 @@ describe('platform shell navigation', () => {
     }))
 
     expect(links).toEqual(expect.arrayContaining([
-      expect.objectContaining({ href: '/integrations/k3-wise', text: 'ERP 对接' }),
+      expect.objectContaining({ href: '/integrations/workbench', text: '系统对接' }),
     ]))
     expect(links.some((link) => link.href === '/admin/users')).toBe(false)
   })

--- a/docs/development/system-integration-default-page-development-20260513.md
+++ b/docs/development/system-integration-default-page-development-20260513.md
@@ -1,0 +1,35 @@
+# System Integration Default Page Development - 2026-05-13
+
+## Goal
+
+Make the integration entry point product-neutral. The top navigation should no longer present the feature as only ERP integration or route users directly into the K3 WISE preset. The default page is the generic system integration workbench where users can choose any source system, clean data through multitable staging, and push to any supported target system.
+
+## Changes
+
+- Updated the platform shell integration nav item:
+  - Chinese label: `系统对接`
+  - English label: `System Integration`
+  - default route: `/integrations/workbench`
+- Updated `/integrations/workbench` route metadata:
+  - `title: System Integration`
+  - `titleZh: 系统对接`
+- Repositioned the workbench header as the default generic system integration page.
+- Repositioned `/integrations/k3-wise` as a specialized preset:
+  - route title: `K3 WISE Setup Preset`
+  - Chinese title: `K3 WISE 预设向导`
+  - page eyebrow: `System Integration Preset`
+- Kept the K3 WISE preset link from the generic workbench, so K3 remains a fast path without being the default product surface.
+
+## Non-goals
+
+- No backend route, adapter, migration, or pipeline behavior changed.
+- No K3 credential, tenant scope, or WebAPI request behavior changed.
+- No new connector type was added.
+
+## Expected UX
+
+1. User opens the app navigation.
+2. The integration entry reads `系统对接` / `System Integration`.
+3. Clicking it opens `/integrations/workbench`.
+4. The page explains that it is the default generic system integration page.
+5. K3 WISE remains available as a preset button for customers using K3 WISE.

--- a/docs/development/system-integration-default-page-verification-20260513.md
+++ b/docs/development/system-integration-default-page-verification-20260513.md
@@ -1,0 +1,42 @@
+# System Integration Default Page Verification - 2026-05-13
+
+## Local Checks
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/platform-shell-nav.spec.ts tests/IntegrationWorkbenchView.spec.ts tests/IntegrationK3WiseSetupView.spec.ts tests/k3WiseSetup.spec.ts --watch=false
+```
+
+Result: PASS, 4 files / 37 tests.
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result: PASS (`vue-tsc -b` + Vite build). Existing large-chunk warning only.
+
+```bash
+git diff --check
+```
+
+Result: PASS.
+
+## Install Side Effects
+
+The temporary worktree did not have a usable workspace bin at first, so `pnpm install --frozen-lockfile` was run before tests. It marked several tracked plugin/tool `node_modules` symlinks as modified; those install side effects were restored before staging. Final tracked diff contains only frontend source, frontend tests, and these docs.
+
+## Coverage Matrix
+
+| Area | Expected | Evidence |
+| --- | --- | --- |
+| Platform nav | `系统对接` links to `/integrations/workbench` | `platform-shell-nav.spec.ts` |
+| Generic workbench | Header says `系统对接` and describes the default generic system integration page | `IntegrationWorkbenchView.spec.ts` |
+| K3 preset route | K3 page stays protected by `integration:write` and is titled `K3 WISE 预设向导` | `k3WiseSetup.spec.ts` |
+| K3 preset bridge | K3 page still links back to `/integrations/workbench` | `IntegrationK3WiseSetupView.spec.ts` |
+| Runtime behavior | No backend or adapter behavior changed | frontend-only diff review |
+
+## Deployment Impact
+
+Frontend-only copy and route-target change. Existing deep links keep working:
+
+- `/integrations/workbench` is now the default nav entry.
+- `/integrations/k3-wise` remains available for K3 WISE setup.


### PR DESCRIPTION
## Summary

- make the platform nav integration entry product-neutral: `系统对接` / `System Integration`
- route the default nav entry to `/integrations/workbench` instead of the K3-only preset
- reposition `/integrations/workbench` as the default generic system integration page
- keep `/integrations/k3-wise` as a K3 WISE preset wizard with updated titles
- add development and verification notes for the UI naming/default-route change

## Verification

- `pnpm --filter @metasheet/web exec vitest run tests/platform-shell-nav.spec.ts tests/IntegrationWorkbenchView.spec.ts tests/IntegrationK3WiseSetupView.spec.ts tests/k3WiseSetup.spec.ts --watch=false` PASS, 4 files / 37 tests
- `pnpm --filter @metasheet/web build` PASS (`vue-tsc -b` + Vite build; existing chunk-size warning only)
- `git diff --check` PASS

## Deployment impact

Frontend-only copy and route-target change. Existing deep links keep working:

- `/integrations/workbench` is now the default nav entry for system integration.
- `/integrations/k3-wise` remains available as the K3 WISE preset wizard.
