### PR TITLE
fix(integration): refresh K3 unsaved draft test guard

### DIFF
--- a/apps/web/src/services/integration/k3WiseSetup.ts
+++ b/apps/web/src/services/integration/k3WiseSetup.ts
@@ -503,6 +503,66 @@ function normalizeSavedBoolean(value: unknown): boolean {
   return false
 }
 
+function fingerprintJson(value: Record<string, unknown>): string {
+  return JSON.stringify(value)
+}
+
+function normalizeListFingerprint(value: string): string[] {
+  return splitList(value)
+}
+
+function hasWebApiCredentialDraft(form: K3WiseSetupForm): boolean {
+  return Boolean(trim(form.authorityCode) || trim(form.username) || trim(form.acctId) || trim(form.password))
+}
+
+function hasSqlCredentialDraft(form: K3WiseSetupForm): boolean {
+  return Boolean(trim(form.sqlUsername) || trim(form.sqlPassword))
+}
+
+export function buildK3WiseWebApiConnectionFingerprint(form: K3WiseSetupForm): string {
+  return fingerprintJson({
+    tenantId: trim(form.tenantId),
+    workspaceId: trim(form.workspaceId),
+    systemId: trim(form.webApiSystemId),
+    hasCredentials: form.webApiHasCredentials === true,
+    credentialDraftTouched: hasWebApiCredentialDraft(form),
+    version: trim(form.version),
+    environment: form.environment,
+    authMode: form.webApiAuthMode,
+    baseUrl: trim(form.baseUrl),
+    tokenPath: trim(form.tokenPath),
+    loginPath: trim(form.loginPath),
+    healthPath: trim(form.healthPath),
+    lcid: trim(form.lcid),
+    timeoutMs: trim(form.timeoutMs),
+  })
+}
+
+export function buildK3WiseSqlConnectionFingerprint(form: K3WiseSetupForm): string {
+  return fingerprintJson({
+    tenantId: trim(form.tenantId),
+    workspaceId: trim(form.workspaceId),
+    enabled: form.sqlEnabled === true,
+    systemId: trim(form.sqlSystemId),
+    hasCredentials: form.sqlHasCredentials === true,
+    credentialDraftTouched: hasSqlCredentialDraft(form),
+    mode: form.sqlMode,
+    server: trim(form.sqlServer),
+    database: trim(form.sqlDatabase),
+    allowedTables: normalizeListFingerprint(form.sqlAllowedTables),
+    middleTables: normalizeListFingerprint(form.sqlMiddleTables),
+    storedProcedures: normalizeListFingerprint(form.sqlStoredProcedures),
+  })
+}
+
+export function buildK3WiseWebApiSystemConnectionFingerprint(system: IntegrationExternalSystem): string {
+  return buildK3WiseWebApiConnectionFingerprint(applyExternalSystemToForm(createDefaultK3WiseSetupForm(), system))
+}
+
+export function buildK3WiseSqlSystemConnectionFingerprint(system: IntegrationExternalSystem): string {
+  return buildK3WiseSqlConnectionFingerprint(applyExternalSystemToForm(createDefaultK3WiseSetupForm(), system))
+}
+
 function assertRelativePath(value: string, field: keyof K3WiseSetupForm, issues: K3WiseSetupValidationIssue[]): void {
   const normalized = trim(value)
   if (!normalized) {
@@ -1273,6 +1333,10 @@ export function applyExternalSystemToForm(form: K3WiseSetupForm, system: Integra
     const bom = objects.bom || {}
     next.webApiSystemId = system.id
     next.webApiHasCredentials = system.hasCredentials === true
+    next.authorityCode = ''
+    next.acctId = ''
+    next.username = ''
+    next.password = ''
     next.tenantId = system.tenantId || next.tenantId
     next.workspaceId = system.workspaceId || ''
     next.webApiName = system.name
@@ -1285,7 +1349,7 @@ export function applyExternalSystemToForm(form: K3WiseSetupForm, system: Integra
     next.webApiAuthMode = config.authMode === 'login' || legacyLoginConfig ? 'login' : 'authority-code'
     next.tokenPath = typeof config.tokenPath === 'string' ? config.tokenPath : next.tokenPath
     next.loginPath = typeof config.loginPath === 'string' ? config.loginPath : next.loginPath
-    next.healthPath = typeof config.healthPath === 'string' ? config.healthPath : next.healthPath
+    next.healthPath = typeof config.healthPath === 'string' ? config.healthPath : ''
     next.lcid = config.lcid === undefined ? next.lcid : String(config.lcid)
     next.timeoutMs = config.timeoutMs === undefined ? next.timeoutMs : String(config.timeoutMs)
     next.autoSubmit = normalizeSavedBoolean(config.autoSubmit)
@@ -1302,6 +1366,8 @@ export function applyExternalSystemToForm(form: K3WiseSetupForm, system: Integra
     next.sqlEnabled = true
     next.sqlSystemId = system.id
     next.sqlHasCredentials = system.hasCredentials === true
+    next.sqlUsername = ''
+    next.sqlPassword = ''
     next.tenantId = system.tenantId || next.tenantId
     next.workspaceId = system.workspaceId || ''
     next.sqlName = system.name

--- a/apps/web/src/views/IntegrationK3WiseSetupView.vue
+++ b/apps/web/src/views/IntegrationK3WiseSetupView.vue
@@ -100,15 +100,17 @@
             </div>
             <small>{{ webApiConnectionStatus.message }}</small>
           </div>
-          <button class="k3-setup__btn k3-setup__btn--full" type="button" :disabled="testingWebApi || !form.webApiSystemId" @click="testWebApi">
+          <button class="k3-setup__btn k3-setup__btn--full" type="button" :disabled="webApiTestDisabled" @click="testWebApi">
             {{ testingWebApi ? '测试中' : '测试 WebAPI' }}
           </button>
+          <p v-if="hasUnsavedWebApiConnectionDraft" class="k3-setup__hint">WebAPI 连接配置有未保存改动，请先保存再测试。</p>
           <p class="k3-setup__field-note">
             先保存配置，再测试 WebAPI；测试通过后这里会显示已连接和最近测试时间。
           </p>
-          <button class="k3-setup__btn k3-setup__btn--full" type="button" :disabled="testingSql || !form.sqlSystemId" @click="testSqlServer">
+          <button class="k3-setup__btn k3-setup__btn--full" type="button" :disabled="sqlTestDisabled" @click="testSqlServer">
             {{ testingSql ? '测试中' : '测试 SQL Server' }}
           </button>
+          <p v-if="hasUnsavedSqlConnectionDraft" class="k3-setup__hint">SQL Server 通道配置有未保存改动，请先保存再测试。</p>
           <pre v-if="testResult" class="k3-setup__test-result">{{ testResult }}</pre>
         </div>
 
@@ -622,6 +624,10 @@ import {
   applyExternalSystemToForm,
   buildK3WiseDocumentPayloadPreview,
   buildK3WiseDeployGateChecklist,
+  buildK3WiseSqlConnectionFingerprint,
+  buildK3WiseSqlSystemConnectionFingerprint,
+  buildK3WiseWebApiConnectionFingerprint,
+  buildK3WiseWebApiSystemConnectionFingerprint,
   buildK3WisePipelineObservationQuery,
   buildK3WisePipelinePayloads,
   buildK3WisePipelineRunPayload,
@@ -698,6 +704,19 @@ const observationSummary = computed(() => `${pipelineRuns.value.length} runs / $
 const stagingDescriptorLabel = computed(() => stagingDescriptors.value.length > 0 ? `${stagingDescriptors.value.length} descriptors` : 'not loaded')
 const templatePreviewJson = computed(() => JSON.stringify(buildK3WiseDocumentPayloadPreview(templatePreviewTarget.value), null, 2))
 const selectedWebApiSystem = computed(() => webApiSystems.value.find((system) => system.id === form.webApiSystemId) || null)
+const selectedSqlSystem = computed(() => sqlSystems.value.find((system) => system.id === form.sqlSystemId) || null)
+const hasUnsavedWebApiConnectionDraft = computed(() => {
+  const system = selectedWebApiSystem.value
+  if (!system) return Boolean(form.webApiSystemId)
+  return buildK3WiseWebApiConnectionFingerprint(form) !== buildK3WiseWebApiSystemConnectionFingerprint(system)
+})
+const hasUnsavedSqlConnectionDraft = computed(() => {
+  const system = selectedSqlSystem.value
+  if (!system) return Boolean(form.sqlSystemId)
+  return buildK3WiseSqlConnectionFingerprint(form) !== buildK3WiseSqlSystemConnectionFingerprint(system)
+})
+const webApiTestDisabled = computed(() => Boolean(testingWebApi.value || !form.webApiSystemId || hasUnsavedWebApiConnectionDraft.value))
+const sqlTestDisabled = computed(() => Boolean(testingSql.value || !form.sqlSystemId || hasUnsavedSqlConnectionDraft.value))
 const baseUrlHasK3ApiPath = computed(() => /\/k3api(?:\/|$)/i.test(form.baseUrl.trim()))
 const endpointPathHasK3ApiPath = computed(() => [
   form.tokenPath,
@@ -871,10 +890,16 @@ async function saveConfiguration(): Promise<void> {
     const webApi = await upsertIntegrationSystem(payloads.webApi)
     form.webApiSystemId = webApi.id
     form.webApiHasCredentials = webApi.hasCredentials === true
+    form.authorityCode = ''
+    form.acctId = ''
+    form.username = ''
+    form.password = ''
     if (payloads.sqlServer) {
       const sql = await upsertIntegrationSystem(payloads.sqlServer)
       form.sqlSystemId = sql.id
       form.sqlHasCredentials = sql.hasCredentials === true
+      form.sqlUsername = ''
+      form.sqlPassword = ''
     }
     await loadSystems(true)
     setStatus('K3 WISE 预设配置已保存', 'success')
@@ -886,7 +911,7 @@ async function saveConfiguration(): Promise<void> {
 }
 
 async function testWebApi(): Promise<void> {
-  if (!form.webApiSystemId) return
+  if (!form.webApiSystemId || hasUnsavedWebApiConnectionDraft.value) return
   testingWebApi.value = true
   testResult.value = ''
   try {
@@ -919,7 +944,7 @@ async function testWebApi(): Promise<void> {
 }
 
 async function testSqlServer(): Promise<void> {
-  if (!form.sqlSystemId) return
+  if (!form.sqlSystemId || hasUnsavedSqlConnectionDraft.value) return
   testingSql.value = true
   testResult.value = ''
   try {
@@ -1314,6 +1339,13 @@ onMounted(() => {
 
 .k3-setup__field-note--wide {
   grid-column: 1 / -1;
+}
+
+.k3-setup__hint {
+  margin: 6px 0 0;
+  color: #9a3412;
+  font-size: 12px;
+  line-height: 1.4;
 }
 
 .k3-setup__hint-warning {

--- a/apps/web/tests/k3WiseSetup.spec.ts
+++ b/apps/web/tests/k3WiseSetup.spec.ts
@@ -4,6 +4,10 @@ import {
   applyExternalSystemToForm,
   buildK3WiseDocumentPayloadPreview,
   buildK3WiseDeployGateChecklist,
+  buildK3WiseSqlConnectionFingerprint,
+  buildK3WiseSqlSystemConnectionFingerprint,
+  buildK3WiseWebApiConnectionFingerprint,
+  buildK3WiseWebApiSystemConnectionFingerprint,
   buildK3WisePipelineObservationQuery,
   buildK3WisePipelinePayloads,
   buildK3WisePipelineRunPayload,
@@ -213,6 +217,12 @@ describe('K3 WISE setup helpers', () => {
 
   it('loads public external-system config without exposing credentials', () => {
     const form = createDefaultK3WiseSetupForm()
+    Object.assign(form, {
+      authorityCode: 'draft-authority-code',
+      acctId: 'draft-acct',
+      username: 'draft-user',
+      password: 'draft-password',
+    })
     const system: IntegrationExternalSystem = {
       id: 'sys_1',
       tenantId: 'tenant_1',
@@ -240,7 +250,114 @@ describe('K3 WISE setup helpers', () => {
     expect(next.webApiSystemId).toBe('sys_1')
     expect(next.webApiHasCredentials).toBe(true)
     expect(next.baseUrl).toBe('https://k3.example.test/')
+    expect(next.healthPath).toBe('')
+    expect(next.authorityCode).toBe('')
+    expect(next.acctId).toBe('')
+    expect(next.username).toBe('')
     expect(next.password).toBe('')
+  })
+
+  it('tracks unsaved WebAPI connection drafts without reacting to pipeline-only edits', () => {
+    const form = createDefaultK3WiseSetupForm()
+    const system: IntegrationExternalSystem = {
+      id: 'sys_1',
+      tenantId: 'tenant_1',
+      workspaceId: 'workspace_1',
+      name: 'K3 loaded',
+      kind: 'erp:k3-wise-webapi',
+      role: 'target',
+      status: 'active',
+      hasCredentials: true,
+      config: {
+        version: 'K3 WISE 15.x',
+        environment: 'uat',
+        authMode: 'authority-code',
+        baseUrl: 'https://k3.example.test/',
+        tokenPath: '/token',
+        loginPath: '/login',
+        healthPath: '/health',
+        lcid: 2052,
+        timeoutMs: 30000,
+      },
+      capabilities: {},
+    }
+    const loaded = applyExternalSystemToForm(form, system)
+    const savedFingerprint = buildK3WiseWebApiSystemConnectionFingerprint(system)
+
+    expect(buildK3WiseWebApiConnectionFingerprint(loaded)).toBe(savedFingerprint)
+
+    loaded.projectId = 'project_1'
+    loaded.materialPipelineId = 'pipe_material'
+    loaded.pipelineCursor = 'cursor_1'
+    loaded.allowLivePipelineRun = true
+    expect(buildK3WiseWebApiConnectionFingerprint(loaded)).toBe(savedFingerprint)
+
+    loaded.baseUrl = 'https://k3-new.example.test/'
+    expect(buildK3WiseWebApiConnectionFingerprint(loaded)).not.toBe(savedFingerprint)
+
+    loaded.baseUrl = 'https://k3.example.test/'
+    loaded.username = 'replacement-user'
+    expect(buildK3WiseWebApiConnectionFingerprint(loaded)).not.toBe(savedFingerprint)
+
+    loaded.username = ''
+    loaded.authorityCode = 'replacement-authority-code'
+    expect(buildK3WiseWebApiConnectionFingerprint(loaded)).not.toBe(savedFingerprint)
+  })
+
+  it('tracks unsaved SQL Server connection drafts without reacting to pipeline-only edits', () => {
+    const form = createDefaultK3WiseSetupForm()
+    form.sqlUsername = 'draft-user'
+    form.sqlPassword = 'draft-password'
+    const system: IntegrationExternalSystem = {
+      id: 'sql_1',
+      tenantId: 'tenant_1',
+      workspaceId: 'workspace_1',
+      name: 'K3 SQL loaded',
+      kind: 'erp:k3-wise-sqlserver',
+      role: 'bidirectional',
+      status: 'active',
+      hasCredentials: true,
+      config: {
+        mode: 'readonly',
+        server: '10.0.0.10',
+        database: 'AIS_TEST',
+        allowedTables: ['dbo.t_ICItem', 'dbo.t_ICBOM'],
+        middleTables: ['dbo.integration_material_stage'],
+        storedProcedures: ['dbo.usp_integration_material'],
+      },
+      capabilities: {},
+    }
+    const loaded = applyExternalSystemToForm(form, system)
+    const savedFingerprint = buildK3WiseSqlSystemConnectionFingerprint(system)
+
+    expect(loaded.sqlUsername).toBe('')
+    expect(loaded.sqlPassword).toBe('')
+    expect(buildK3WiseSqlConnectionFingerprint(loaded)).toBe(savedFingerprint)
+
+    loaded.projectId = 'project_1'
+    loaded.bomPipelineId = 'pipe_bom'
+    loaded.pipelineCursor = 'cursor_1'
+    expect(buildK3WiseSqlConnectionFingerprint(loaded)).toBe(savedFingerprint)
+
+    loaded.sqlServer = '10.0.0.11'
+    expect(buildK3WiseSqlConnectionFingerprint(loaded)).not.toBe(savedFingerprint)
+
+    loaded.sqlServer = '10.0.0.10'
+    loaded.sqlPassword = 'replacement-password'
+    expect(buildK3WiseSqlConnectionFingerprint(loaded)).not.toBe(savedFingerprint)
+  })
+
+  it('keeps K3 setup connection test controls behind saved-draft fingerprints', async () => {
+    const source = await readFile('src/views/IntegrationK3WiseSetupView.vue', 'utf8')
+
+    expect(source).toContain(':disabled="webApiTestDisabled"')
+    expect(source).toContain(':disabled="sqlTestDisabled"')
+    expect(source).toContain('hasUnsavedWebApiConnectionDraft')
+    expect(source).toContain('hasUnsavedSqlConnectionDraft')
+    expect(source).toContain('if (!system) return Boolean(form.webApiSystemId)')
+    expect(source).toContain('if (!system) return Boolean(form.sqlSystemId)')
+    expect(source).toContain('if (!form.webApiSystemId || hasUnsavedWebApiConnectionDraft.value) return')
+    expect(source).toContain('if (!form.sqlSystemId || hasUnsavedSqlConnectionDraft.value) return')
   })
 
   it('normalizes saved K3 WISE auto-submit flags from boolean, string, numeric, and Chinese variants', () => {

--- a/docs/development/integration-k3wise-unsaved-draft-guard-refresh-design-20260514.md
+++ b/docs/development/integration-k3wise-unsaved-draft-guard-refresh-design-20260514.md
@@ -1,0 +1,59 @@
+# K3 WISE Unsaved Draft Test Guard Refresh Design - 2026-05-14
+
+## Scope
+
+Refresh stale PR #1348 on current `main`. The target gap is the K3 WISE setup page's saved-system test contract:
+
+- `POST /api/integration/external-systems/:id/test` tests the persisted external system identified by `:id`.
+- The route does not test replacement connection config or credentials from the request body.
+- Therefore the UI must not allow an operator to edit connection fields locally and then test the stale saved system as if the draft were being tested.
+
+## Design
+
+### Saved/draft fingerprints
+
+`apps/web/src/services/integration/k3WiseSetup.ts` now exposes fingerprint helpers:
+
+- `buildK3WiseWebApiConnectionFingerprint(form)`
+- `buildK3WiseSqlConnectionFingerprint(form)`
+- `buildK3WiseWebApiSystemConnectionFingerprint(system)`
+- `buildK3WiseSqlSystemConnectionFingerprint(system)`
+
+The fingerprints include connection-test inputs only:
+
+- scope: tenant, workspace, selected system id;
+- saved credential presence plus whether credential replacement fields are currently touched;
+- WebAPI: version, environment, auth mode, base URL, token/login/health paths, LCID, timeout;
+- SQL Server: enabled flag, mode, server, database, allowed tables, middle tables, stored procedures.
+
+Credential values are intentionally excluded. Only `credentialDraftTouched` is recorded;
+for WebAPI this includes authority-code and login credential replacement fields.
+
+### UI guard
+
+`IntegrationK3WiseSetupView.vue` computes:
+
+- `hasUnsavedWebApiConnectionDraft`
+- `hasUnsavedSqlConnectionDraft`
+- `webApiTestDisabled`
+- `sqlTestDisabled`
+
+The WebAPI and SQL Server test buttons are disabled when the current draft no longer matches the selected saved system. Inline hints tell the operator to save before testing. The click handlers have the same guard, so scripted or keyboard invocation cannot bypass the disabled state.
+
+If the form still has a saved system id but the refreshed saved-system list no longer contains it, the draft is treated as stale and testing is disabled.
+
+After a successful save or saved-system load, credential replacement fields are cleared. This prevents a newly saved credential replacement from leaving the page in a permanently dirty state without echoing secrets back into the browser.
+
+### Backend route contract
+
+`plugins/plugin-integration-core/__tests__/http-routes.test.cjs` now pins the saved-system-only route contract:
+
+- missing saved system returns `404`;
+- request-body draft config and credentials are ignored;
+- no adapter is created;
+- no connection test runs;
+- no external system upsert happens.
+
+## Boundary
+
+This does not add a "test unsaved draft" backend endpoint. Operators must save before testing, which matches the existing persisted-system route contract.

--- a/docs/development/integration-k3wise-unsaved-draft-guard-refresh-verification-20260514.md
+++ b/docs/development/integration-k3wise-unsaved-draft-guard-refresh-verification-20260514.md
@@ -1,0 +1,83 @@
+# K3 WISE Unsaved Draft Test Guard Refresh Verification - 2026-05-14
+
+## Worktree
+
+`/private/tmp/ms2-k3wise-unsaved-draft-guard-refresh-20260514`
+
+Branch:
+
+`codex/k3wise-unsaved-draft-guard-refresh-20260514`
+
+Baseline:
+
+`origin/main` at `32b12d815`.
+
+## Validation Plan
+
+```bash
+node --test plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+pnpm --filter @metasheet/web exec vitest run --watch=false tests/k3WiseSetup.spec.ts
+pnpm --filter @metasheet/web type-check
+git diff --check origin/main..HEAD
+```
+
+## Coverage
+
+- WebAPI saved/draft fingerprints match immediately after loading a saved system.
+- Pipeline-only edits do not block connection testing.
+- WebAPI transport edits and credential replacement drafts, including authority-code
+  replacement, block testing.
+- SQL Server saved/draft fingerprints match immediately after loading a saved system.
+- SQL channel edits and credential replacement drafts block testing.
+- Loading/saving clears credential replacement fields.
+- Missing selected saved systems are treated as stale.
+- The saved-system-only backend route ignores request-body draft config and credentials.
+
+## Results
+
+Executed locally on 2026-05-14:
+
+```bash
+node --test plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+```
+
+Result: pass.
+
+```text
+http-routes: REST auth/list/upsert/run/dry-run/staging/replay tests passed
+tests 1, pass 1
+```
+
+```bash
+pnpm --filter @metasheet/web exec vitest run --watch=false tests/k3WiseSetup.spec.ts
+```
+
+Result: pass.
+
+```text
+tests/k3WiseSetup.spec.ts: 34 passed
+Test Files 1 passed
+```
+
+```bash
+pnpm --filter @metasheet/web type-check
+```
+
+Result: pass.
+
+```bash
+git diff --check origin/main..HEAD
+```
+
+Result: pass.
+
+Note: the temporary worktree initially had no `node_modules`, so a local
+`pnpm install --frozen-lockfile` was required before running frontend gates.
+Generated dependency link noise under `plugins/*/node_modules` and
+`tools/cli/node_modules` was removed before committing.
+
+## Not Covered
+
+- Real K3 WISE connectivity.
+- Real SQL Server connectivity.
+- A future unsaved-draft connection-test endpoint.

--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -500,6 +500,53 @@ async function testExternalSystemTestPersistsFailureAndPreservesInactive() {
   assert.equal(inactiveUpdate.lastError, null)
 }
 
+async function testExternalSystemTestRequiresSavedSystem() {
+  const { calls, services } = createMockServices({
+    externalSystemRegistry: {
+      async getExternalSystemForAdapter(input) {
+        calls.push(['getExternalSystemForAdapter', input])
+        const error = new Error('external system not found')
+        error.name = 'ExternalSystemNotFoundError'
+        throw error
+      },
+    },
+    adapterRegistry: {
+      createAdapter(input) {
+        calls.push(['createAdapter', input])
+        return {
+          async testConnection() {
+            calls.push(['testConnection'])
+            return { ok: true, status: 200 }
+          },
+        }
+      },
+    },
+  })
+  const { routes } = mountRoutes(services)
+
+  const res = await invoke(routes, 'POST', '/api/integration/external-systems/:id/test', {
+    user: WRITE_USER,
+    params: { id: 'missing_sys' },
+    query: { workspaceId: 'workspace_1' },
+    body: {
+      name: 'Unsaved K3 draft',
+      kind: 'erp:k3-wise-webapi',
+      config: { baseUrl: 'https://draft.example.test/K3API/' },
+      credentials: { username: 'draft-user', password: 'draft-password', acctId: 'AIS_DRAFT' },
+    },
+  })
+
+  assertErrorResponse(res, [404])
+  assert.deepEqual(findCall(calls, 'getExternalSystemForAdapter')[1], {
+    id: 'missing_sys',
+    tenantId: 'tenant_1',
+    workspaceId: 'workspace_1',
+  })
+  assert.equal(findCalls(calls, 'createAdapter').length, 0, 'missing systems do not instantiate adapters')
+  assert.equal(findCalls(calls, 'testConnection').length, 0, 'missing systems do not run connection tests')
+  assert.equal(findCalls(calls, 'upsertExternalSystem').length, 0, 'request body drafts are not persisted by test route')
+}
+
 async function testExternalSystemTestRedactsAdapterResultSecrets() {
   const { calls, services } = createMockServices({
     adapterRegistry: {
@@ -1660,6 +1707,7 @@ async function main() {
   await testUnauthenticatedWriteRequestIsRejected()
   await testExternalSystemRoutes()
   await testExternalSystemTestPersistsFailureAndPreservesInactive()
+  await testExternalSystemTestRequiresSavedSystem()
   await testExternalSystemTestRedactsAdapterResultSecrets()
   await testDiscoveryRoutes()
   await testDiscoveryRoutesRejectUnknownSystem()


### PR DESCRIPTION
## Summary

- Refreshes stale PR #1348 on current `main`.
- Prevents K3 WISE setup tests from running against stale persisted WebAPI/SQL systems when local connection drafts are unsaved.
- Adds saved/draft fingerprints for connection-affecting fields only, excluding credential values while treating credential replacement fields as dirty.
- Clears credential replacement drafts after loading or saving saved systems so secrets are not echoed and the form does not stay permanently dirty.
- Pins the backend route contract: `/api/integration/external-systems/:id/test` tests only the saved system and ignores request-body draft config/credentials.

Supersedes #1348.

## Verification

- `node --test plugins/plugin-integration-core/__tests__/http-routes.test.cjs`
- `pnpm --filter @metasheet/web exec vitest run --watch=false tests/k3WiseSetup.spec.ts`
- `pnpm --filter @metasheet/web type-check`
- `git diff --check origin/main..HEAD`

## Docs

- `docs/development/integration-k3wise-unsaved-draft-guard-refresh-design-20260514.md`
- `docs/development/integration-k3wise-unsaved-draft-guard-refresh-verification-20260514.md`
