### PR TITLE
feat(integration): open staging multitables after install

### DIFF
--- a/apps/web/src/services/integration/k3WiseSetup.ts
+++ b/apps/web/src/services/integration/k3WiseSetup.ts
@@ -117,8 +117,20 @@ export interface IntegrationStagingDescriptor {
   fieldDetails?: IntegrationStagingFieldDetail[]
 }
 
+export interface IntegrationStagingOpenTarget {
+  id: string
+  name: string
+  sheetId: string
+  viewId: string
+  baseId?: string | null
+  openLink: string
+}
+
 export interface IntegrationStagingInstallResult {
   sheetIds: Record<string, string>
+  viewIds?: Record<string, string>
+  openLinks?: Record<string, string>
+  targets?: IntegrationStagingOpenTarget[]
   warnings: string[]
 }
 

--- a/apps/web/src/views/IntegrationK3WiseSetupView.vue
+++ b/apps/web/src/views/IntegrationK3WiseSetupView.vue
@@ -151,6 +151,21 @@
               {{ issue.message }}
             </li>
           </ul>
+          <div v-if="stagingOpenTargets.length" class="k3-setup__open-targets" data-testid="staging-open-targets">
+            <div v-for="target in stagingOpenTargets" :key="target.id" class="k3-setup__open-target">
+              <div>
+                <strong>{{ target.name }}</strong>
+                <small>{{ target.description }}</small>
+              </div>
+              <router-link
+                class="k3-setup__btn k3-setup__btn--compact"
+                :to="target.openLink"
+                :data-testid="`open-staging-${target.id}`"
+              >
+                打开多维表
+              </router-link>
+            </div>
+          </div>
           <pre v-if="stagingResult" class="k3-setup__test-result">{{ stagingResult }}</pre>
           <button
             class="k3-setup__btn k3-setup__btn--full"
@@ -657,6 +672,7 @@ import {
   type IntegrationExternalSystem,
   type IntegrationPipelineRun,
   type IntegrationStagingDescriptor,
+  type IntegrationStagingInstallResult,
   type K3WiseDocumentTemplateMapping,
   type K3WisePipelineTarget,
 } from '../services/integration/k3WiseSetup'
@@ -678,6 +694,7 @@ const statusMessage = ref('')
 const statusKind = ref<'info' | 'success' | 'error'>('info')
 const testResult = ref('')
 const stagingResult = ref('')
+const stagingInstallResult = ref<IntegrationStagingInstallResult | null>(null)
 const pipelineResult = ref('')
 const pipelineRunResult = ref('')
 const webApiLastTest = ref<{
@@ -703,6 +720,7 @@ const deployGateSummary = computed(() => summarizeK3WiseDeployGateChecklist(depl
 const observationSummary = computed(() => `${pipelineRuns.value.length} runs / ${deadLetters.value.length} open`)
 const stagingDescriptorLabel = computed(() => stagingDescriptors.value.length > 0 ? `${stagingDescriptors.value.length} descriptors` : 'not loaded')
 const templatePreviewJson = computed(() => JSON.stringify(buildK3WiseDocumentPayloadPreview(templatePreviewTarget.value), null, 2))
+const stagingOpenTargets = computed(() => buildStagingOpenTargets(stagingInstallResult.value, form.baseId))
 const selectedWebApiSystem = computed(() => webApiSystems.value.find((system) => system.id === form.webApiSystemId) || null)
 const selectedSqlSystem = computed(() => sqlSystems.value.find((system) => system.id === form.sqlSystemId) || null)
 const hasUnsavedWebApiConnectionDraft = computed(() => {
@@ -780,6 +798,75 @@ const webApiConnectionStatus = computed(() => {
     message: '配置已保存，但尚未测试；点击“测试 WebAPI”确认是否连上 K3。',
   }
 })
+
+type StagingOpenTargetView = {
+  id: string
+  name: string
+  description: string
+  sheetId: string
+  viewId: string
+  openLink: string
+}
+
+const STAGING_OPEN_TARGET_COPY: Record<string, { name: string; description: string }> = {
+  plm_raw_items: {
+    name: '原始数据',
+    description: '来源系统拉取后的只读追溯表，先确认数据是否进来。',
+  },
+  standard_materials: {
+    name: '物料清洗',
+    description: '业务主要在这里修正物料编码、名称、规格、单位和同步状态。',
+  },
+  bom_cleanse: {
+    name: 'BOM 清洗',
+    description: '业务主要在这里修正父子件、数量、单位、序号和版本。',
+  },
+  integration_exceptions: {
+    name: '异常处理',
+    description: '缺字段、非法数量、单位映射失败等问题先在这里处理。',
+  },
+  integration_run_log: {
+    name: '运行日志',
+    description: '查看 dry-run、Save-only 推送和回写结果。',
+  },
+}
+
+const STAGING_OPEN_TARGET_ORDER = [
+  'standard_materials',
+  'bom_cleanse',
+  'integration_exceptions',
+  'plm_raw_items',
+  'integration_run_log',
+] as const
+
+function buildMultitableOpenLink(sheetId: string, viewId: string, baseId?: string | null): string {
+  const path = `/multitable/${encodeURIComponent(sheetId)}/${encodeURIComponent(viewId)}`
+  const normalizedBaseId = typeof baseId === 'string' && baseId.trim() ? baseId.trim() : ''
+  return normalizedBaseId ? `${path}?baseId=${encodeURIComponent(normalizedBaseId)}` : path
+}
+
+function buildStagingOpenTargets(
+  result: IntegrationStagingInstallResult | null,
+  fallbackBaseId?: string,
+): StagingOpenTargetView[] {
+  if (!result) return []
+  const targetsById = new Map((result.targets ?? []).map((target) => [target.id, target]))
+  return STAGING_OPEN_TARGET_ORDER.flatMap((id) => {
+    const target = targetsById.get(id)
+    const sheetId = target?.sheetId ?? result.sheetIds?.[id]
+    const viewId = target?.viewId ?? result.viewIds?.[id]
+    if (!sheetId || !viewId) return []
+    const copy = STAGING_OPEN_TARGET_COPY[id]
+    return [{
+      id,
+      name: copy.name,
+      description: copy.description,
+      sheetId,
+      viewId,
+      openLink: target?.openLink ?? result.openLinks?.[id] ?? buildMultitableOpenLink(sheetId, viewId, target?.baseId ?? fallbackBaseId),
+    }]
+  })
+}
 
 function setStatus(message: string, kind: 'info' | 'success' | 'error' = 'info'): void {
   statusMessage.value = message
@@ -979,8 +1066,10 @@ async function installStagingTables(): Promise<void> {
   }
   installingStaging.value = true
   stagingResult.value = ''
+  stagingInstallResult.value = null
   try {
     const result = await installIntegrationStaging(buildK3WiseStagingInstallPayload(form))
+    stagingInstallResult.value = result
     stagingResult.value = JSON.stringify(result, null, 2)
     await loadStagingDescriptors(true)
     setStatus('Staging 多维表已安装或确认存在', result.warnings.length > 0 ? 'info' : 'success')
@@ -1414,6 +1503,11 @@ onMounted(() => {
   margin-top: 8px;
 }
 
+.k3-setup__btn--compact {
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
+
 .k3-setup__btn:disabled {
   cursor: not-allowed;
   opacity: 0.55;
@@ -1556,6 +1650,48 @@ onMounted(() => {
 .k3-setup__descriptor small {
   color: #64748b;
   font-size: 12px;
+}
+
+.k3-setup__open-targets {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.k3-setup__open-target {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: center;
+  min-width: 0;
+  border: 1px solid #ccfbf1;
+  border-radius: 6px;
+  padding: 10px;
+  background: #f0fdfa;
+}
+
+.k3-setup__open-target div {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.k3-setup__open-target strong,
+.k3-setup__open-target small {
+  overflow-wrap: anywhere;
+}
+
+.k3-setup__open-target strong {
+  color: #115e59;
+  font-size: 13px;
+}
+
+.k3-setup__open-target small {
+  color: #475569;
+  font-size: 12px;
+  line-height: 1.35;
 }
 
 .k3-setup__record-head,

--- a/apps/web/tests/IntegrationK3WiseSetupView.spec.ts
+++ b/apps/web/tests/IntegrationK3WiseSetupView.spec.ts
@@ -41,6 +41,50 @@ function mockIntegrationApi(): void {
         },
       ])
     }
+    if (url === '/api/integration/staging/install') {
+      return jsonResponse({
+        sheetIds: {
+          plm_raw_items: 'sheet_plm_raw_items',
+          standard_materials: 'sheet_standard_materials',
+          bom_cleanse: 'sheet_bom_cleanse',
+          integration_exceptions: 'sheet_integration_exceptions',
+          integration_run_log: 'sheet_integration_run_log',
+        },
+        viewIds: {
+          plm_raw_items: 'view_plm_raw_items',
+          standard_materials: 'view_standard_materials',
+          bom_cleanse: 'view_bom_cleanse',
+          integration_exceptions: 'view_integration_exceptions',
+          integration_run_log: 'view_integration_run_log',
+        },
+        openLinks: {
+          plm_raw_items: '/multitable/sheet_plm_raw_items/view_plm_raw_items?baseId=base_k3',
+          standard_materials: '/multitable/sheet_standard_materials/view_standard_materials?baseId=base_k3',
+          bom_cleanse: '/multitable/sheet_bom_cleanse/view_bom_cleanse?baseId=base_k3',
+          integration_exceptions: '/multitable/sheet_integration_exceptions/view_integration_exceptions?baseId=base_k3',
+          integration_run_log: '/multitable/sheet_integration_run_log/view_integration_run_log?baseId=base_k3',
+        },
+        targets: [
+          {
+            id: 'standard_materials',
+            name: 'Standard Materials',
+            sheetId: 'sheet_standard_materials',
+            viewId: 'view_standard_materials',
+            baseId: 'base_k3',
+            openLink: '/multitable/sheet_standard_materials/view_standard_materials?baseId=base_k3',
+          },
+          {
+            id: 'bom_cleanse',
+            name: 'BOM Cleanse',
+            sheetId: 'sheet_bom_cleanse',
+            viewId: 'view_bom_cleanse',
+            baseId: 'base_k3',
+            openLink: '/multitable/sheet_bom_cleanse/view_bom_cleanse?baseId=base_k3',
+          },
+        ],
+        warnings: [],
+      })
+    }
     return jsonResponse({})
   })
 }
@@ -57,6 +101,13 @@ function registerRouterLinkStub(app: VueApp<Element>): void {
     props: ['to'],
     template: '<a :href="to"><slot /></a>',
   })
+}
+
+function inputByLabel(container: HTMLElement, labelText: string): HTMLInputElement {
+  const label = Array.from(container.querySelectorAll('label')).find((item) => item.textContent?.includes(labelText))
+  const input = label?.querySelector('input')
+  if (!(input instanceof HTMLInputElement)) throw new Error(`input not found for label: ${labelText}`)
+  return input
 }
 
 describe('IntegrationK3WiseSetupView', () => {
@@ -187,5 +238,44 @@ describe('IntegrationK3WiseSetupView', () => {
 
     expect(container.textContent).toContain('connected')
     expect(container.textContent).toContain('WebAPI 连接测试完成')
+  })
+
+  it('opens installed staging multitable sheets from the setup page', async () => {
+    const View = (await import('../src/views/IntegrationK3WiseSetupView.vue')).default
+
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    registerRouterLinkStub(app)
+    app.mount(container)
+    await flushUi()
+
+    const projectInput = inputByLabel(container, 'Project ID')
+    projectInput.value = 'k3-poc'
+    projectInput.dispatchEvent(new Event('input', { bubbles: true }))
+    const baseInput = inputByLabel(container, 'Base ID')
+    baseInput.value = 'base_k3'
+    baseInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+
+    const button = Array.from(container.querySelectorAll('button')).find((item) => item.textContent?.includes('安装 Staging 多维表')) as HTMLButtonElement
+    expect(button.disabled).toBe(false)
+    button.click()
+    await flushUi(8)
+
+    expect(apiFetchMock).toHaveBeenCalledWith('/api/integration/staging/install', expect.objectContaining({
+      method: 'POST',
+      body: expect.stringContaining('"projectId":"k3-poc"'),
+    }))
+    expect(container.textContent).toContain('物料清洗')
+    expect(container.textContent).toContain('BOM 清洗')
+    expect(container.textContent).toContain('业务主要在这里修正物料编码')
+    expect(container.textContent).not.toContain('sheet_standard_materials / view_standard_materials')
+
+    const materialLink = container.querySelector('[data-testid="open-staging-standard_materials"]') as HTMLAnchorElement
+    const bomLink = container.querySelector('[data-testid="open-staging-bom_cleanse"]') as HTMLAnchorElement
+    expect(materialLink?.getAttribute('href')).toBe('/multitable/sheet_standard_materials/view_standard_materials?baseId=base_k3')
+    expect(materialLink?.textContent).toContain('打开多维表')
+    expect(bomLink?.getAttribute('href')).toBe('/multitable/sheet_bom_cleanse/view_bom_cleanse?baseId=base_k3')
   })
 })

--- a/docs/development/integration-staging-open-multitable-design-20260514.md
+++ b/docs/development/integration-staging-open-multitable-design-20260514.md
@@ -1,0 +1,92 @@
+# Integration Staging Open Multitable Design - 2026-05-14
+
+## Goal
+
+After PLM / external-system data is pulled into integration staging, operators need a direct way to open the generated multitable sheets and clean the data there. Before this change, `/api/integration/staging/install` returned only `sheetIds`, while the multitable route requires both `sheetId` and `viewId`. The K3 WISE setup page therefore showed a JSON blob instead of an operator-friendly "open table" path.
+
+This slice closes that gap without changing the K3 adapter, pipeline schema, or database migrations.
+
+## Scope
+
+Changed files:
+
+- `plugins/plugin-integration-core/lib/staging-installer.cjs`
+- `plugins/plugin-integration-core/__tests__/staging-installer.test.cjs`
+- `apps/web/src/services/integration/k3WiseSetup.ts`
+- `apps/web/src/views/IntegrationK3WiseSetupView.vue`
+- `apps/web/tests/IntegrationK3WiseSetupView.spec.ts`
+
+No SQL migration, no K3 WebAPI behavior change, no pipeline execution behavior change.
+
+## Backend Contract
+
+`installStaging()` still provisions the five user-visible staging sheets:
+
+- `plm_raw_items`
+- `standard_materials`
+- `bom_cleanse`
+- `integration_exceptions`
+- `integration_run_log`
+
+It now also attempts to provision one default grid view for each sheet through `context.api.multitable.provisioning.ensureView()`.
+
+The response keeps the existing `sheetIds` map and adds:
+
+```json
+{
+  "viewIds": {
+    "standard_materials": "view_..."
+  },
+  "openLinks": {
+    "standard_materials": "/multitable/sheet_.../view_...?baseId=base_..."
+  },
+  "targets": [
+    {
+      "id": "standard_materials",
+      "name": "Standard Materials",
+      "sheetId": "sheet_...",
+      "viewId": "view_...",
+      "baseId": "base_...",
+      "openLink": "/multitable/sheet_.../view_...?baseId=base_..."
+    }
+  ],
+  "warnings": []
+}
+```
+
+`ensureView` is treated as optional for backward compatibility with older plugin-host test contexts. If it is missing, sheets are still installed and the response warns that open links could not be generated.
+
+## Frontend Behavior
+
+After "安装 Staging 多维表" succeeds, the K3 WISE setup page now renders an "open target" list instead of forcing users to interpret raw ids.
+
+Display order is intentionally workflow-oriented:
+
+1. `standard_materials` - main material cleansing table
+2. `bom_cleanse` - main BOM cleansing table
+3. `integration_exceptions` - rows that need manual correction
+4. `plm_raw_items` - raw source audit table
+5. `integration_run_log` - execution trace
+
+The cards show business labels and short usage hints. Technical ids remain available in the JSON response for debugging, but they are not printed into the primary card copy.
+
+## Route Shape
+
+Generated links target the existing multitable route:
+
+```text
+/multitable/:sheetId/:viewId?baseId=:baseId
+```
+
+Route segments and `baseId` are URI-encoded both backend-side and frontend fallback-side.
+
+## Why This Is The Right Cut
+
+This keeps the product centered on multitable cleansing:
+
+- Data still lands in multitable staging sheets.
+- Business users open `standard_materials` and `bom_cleanse` to fix data.
+- JSON remains a transport/debug artifact, not the primary business surface.
+- K3 Save-only / dry-run flow stays unchanged.
+
+The next deployment can therefore tell users: install staging tables, click "打开多维表", clean the rows, then run dry-run.

--- a/docs/development/integration-staging-open-multitable-verification-20260514.md
+++ b/docs/development/integration-staging-open-multitable-verification-20260514.md
@@ -1,0 +1,67 @@
+# Integration Staging Open Multitable Verification - 2026-05-14
+
+## Summary
+
+Verified the new staging open-link contract at backend unit level and the K3 WISE setup page at frontend component level.
+
+## Commands
+
+| Command | Result |
+| --- | --- |
+| `node plugins/plugin-integration-core/__tests__/staging-installer.test.cjs` | PASS - staging installer assertions updated to cover 5 sheets, 5 default views, open links, idempotency, partial failure, and legacy no-`ensureView` fallback. |
+| `pnpm -F plugin-integration-core test` | PASS - full plugin integration-core test script, including staging installer and existing PLM -> K3 WISE mock chain. |
+| `pnpm --filter @metasheet/web exec vitest run tests/IntegrationK3WiseSetupView.spec.ts --watch=false` | PASS - 1 file / 3 tests. |
+| `pnpm --filter @metasheet/web exec vitest run tests/k3WiseSetup.spec.ts tests/IntegrationK3WiseSetupView.spec.ts --watch=false` | PASS - 2 files / 34 tests. |
+| `pnpm --filter @metasheet/web build` | PASS - `vue-tsc -b` and Vite production build completed. Existing Vite chunk-size warning remains non-blocking. |
+| `git diff --check` | PASS - no whitespace errors or conflict markers. |
+
+## Backend Assertions
+
+The staging installer test now proves:
+
+- `ensureObject()` is still called once per staging descriptor.
+- `ensureView()` is called once per successfully provisioned sheet.
+- Each descriptor returns:
+  - `sheetIds[id]`
+  - `viewIds[id]`
+  - `openLinks[id]`
+  - one `targets[]` entry
+- Re-running install returns the same sheet ids, view ids, and open links.
+- If one descriptor fails, the other sheets and views still install.
+- If the plugin host lacks `ensureView`, sheets still install and a warning is returned instead of failing the whole operation.
+- Route parts are URI-encoded.
+
+Example asserted link:
+
+```text
+/multitable/sheet_standard_materials/view_standard_materials?baseId=base_default
+```
+
+## Frontend Assertions
+
+The K3 WISE setup view test now proves:
+
+- The page can install staging tables after `Project ID` is entered.
+- The request body includes the entered `projectId`.
+- The page renders business-facing open targets after install:
+  - `物料清洗`
+  - `BOM 清洗`
+- The primary card copy does not expose raw `sheetId / viewId` pairs.
+- The "打开多维表" links target the generated multitable URLs.
+
+## UX Check
+
+Expected operator flow after this change:
+
+1. Open K3 WISE preset page.
+2. Enter `Project ID` and optional `Base ID`.
+3. Click `安装 Staging 多维表`.
+4. Click `打开多维表` on `物料清洗` or `BOM 清洗`.
+5. Clean rows in multitable.
+6. Return to the setup page for dry-run and Save-only push.
+
+## Deployment Impact
+
+No migration is required. The change uses the existing multitable provisioning API and existing `/multitable/:sheetId/:viewId` route.
+
+If a deployment has already installed staging sheets, rerunning the installer is expected and idempotent; it will ensure the missing default views and produce open links.

--- a/plugins/plugin-integration-core/__tests__/staging-installer.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/staging-installer.test.cjs
@@ -37,7 +37,9 @@ const EXPECTED_IDS = [
 
 function createMockContext({ failOn = new Set() } = {}) {
   const calls = []
+  const viewCalls = []
   const sheetIdsByDescriptor = new Map()
+  const viewIdsByDescriptor = new Map()
   return {
     context: {
       api: {
@@ -65,12 +67,29 @@ function createMockContext({ failOn = new Set() } = {}) {
                 })),
               }
             },
+            async ensureView({ projectId, sheetId, descriptor }) {
+              viewCalls.push({ projectId, sheetId, descriptor })
+              if (!viewIdsByDescriptor.has(descriptor.objectId)) {
+                viewIdsByDescriptor.set(descriptor.objectId, `view_${descriptor.objectId}`)
+              }
+              return {
+                id: viewIdsByDescriptor.get(descriptor.objectId),
+                sheetId,
+                name: descriptor.name,
+                type: descriptor.type,
+                filterInfo: {},
+                sortInfo: {},
+                groupInfo: {},
+                hiddenFieldIds: [],
+                config: descriptor.config || {},
+              }
+            },
           },
         },
       },
       logger: { info: () => {}, warn: () => {}, error: () => {} },
     },
-    inspect: { calls, sheetIdsByDescriptor },
+    inspect: { calls, viewCalls, sheetIdsByDescriptor, viewIdsByDescriptor },
   }
 }
 
@@ -167,32 +186,84 @@ async function main() {
   const { context: ctx1, inspect: inspect1 } = createMockContext()
   const res1 = await installStaging({ context: ctx1, projectId: 'proj1' })
   assert.equal(inspect1.calls.length, 5, 'called once per descriptor')
+  assert.equal(inspect1.viewCalls.length, 5, 'ensured one default view per descriptor')
   assert.deepEqual(inspect1.calls.map((c) => c.descriptorId), EXPECTED_IDS)
+  assert.deepEqual(inspect1.viewCalls.map((c) => c.descriptor.objectId), EXPECTED_IDS)
+  assert.deepEqual(inspect1.viewCalls.map((c) => c.descriptor.id), Array(5).fill('default_grid'))
   assert.equal(Object.keys(res1.sheetIds).length, 5, 'all 5 sheet ids returned')
+  assert.equal(Object.keys(res1.viewIds).length, 5, 'all 5 view ids returned')
+  assert.equal(Object.keys(res1.openLinks).length, 5, 'all 5 open links returned')
+  assert.equal(res1.targets.length, 5, 'all 5 open targets returned')
   assert.equal(res1.warnings.length, 0, 'no warnings on happy path')
   for (const id of EXPECTED_IDS) {
     assert.equal(res1.sheetIds[id], `sheet_${id}`, `sheetId mapped for ${id}`)
+    assert.equal(res1.viewIds[id], `view_${id}`, `viewId mapped for ${id}`)
+    assert.equal(
+      res1.openLinks[id],
+      `/multitable/sheet_${id}/view_${id}?baseId=base_default`,
+      `openLink mapped for ${id}`,
+    )
   }
+  assert.deepEqual(res1.targets[0], {
+    id: 'plm_raw_items',
+    name: 'PLM Raw Items',
+    sheetId: 'sheet_plm_raw_items',
+    viewId: 'view_plm_raw_items',
+    baseId: 'base_default',
+    openLink: '/multitable/sheet_plm_raw_items/view_plm_raw_items?baseId=base_default',
+  })
 
   // --- 5. Idempotency: second install returns same sheet ids -----------
   const res2 = await installStaging({ context: ctx1, projectId: 'proj1' })
   assert.equal(inspect1.calls.length, 10, '5 more calls on second install (ensureObject is idempotent upstream)')
+  assert.equal(inspect1.viewCalls.length, 10, '5 more view calls on second install (ensureView is idempotent upstream)')
   assert.deepEqual(res1.sheetIds, res2.sheetIds, 'same sheet ids on re-install')
+  assert.deepEqual(res1.viewIds, res2.viewIds, 'same view ids on re-install')
+  assert.deepEqual(res1.openLinks, res2.openLinks, 'same open links on re-install')
 
   // --- 6. Partial failure: one descriptor fails, others continue ------
   const { context: ctx2, inspect: inspect2 } = createMockContext({ failOn: new Set(['bom_cleanse']) })
   const res3 = await installStaging({ context: ctx2, projectId: 'proj2' })
   assert.equal(inspect2.calls.length, 5, 'still attempted all 5 descriptors')
+  assert.equal(inspect2.viewCalls.length, 4, 'ensured views only for successfully provisioned sheets')
   assert.equal(Object.keys(res3.sheetIds).length, 4, '4 sheets provisioned')
+  assert.equal(Object.keys(res3.viewIds).length, 4, '4 views provisioned')
   assert.equal(res3.warnings.length, 1, 'one warning collected')
   assert.match(res3.warnings[0], /bom_cleanse/, 'warning names the failing descriptor')
   assert.ok(!('bom_cleanse' in res3.sheetIds), 'failing descriptor absent from sheetIds')
+  assert.ok(!('bom_cleanse' in res3.viewIds), 'failing descriptor absent from viewIds')
 
-  // --- 7. Internal helper ----------------------------------------------
+  // --- 7. View provisioning is optional for legacy plugin host tests ----
+  const legacyCtx = createMockContext().context
+  delete legacyCtx.api.multitable.provisioning.ensureView
+  const legacyRes = await installStaging({ context: legacyCtx, projectId: 'proj-legacy' })
+  assert.equal(Object.keys(legacyRes.sheetIds).length, 5, 'legacy context still provisions sheets')
+  assert.equal(Object.keys(legacyRes.viewIds).length, 0, 'legacy context has no views')
+  assert.equal(Object.keys(legacyRes.openLinks).length, 0, 'legacy context has no open links')
+  assert.match(legacyRes.warnings[0], /ensureView not available/, 'legacy context reports missing open links')
+
+  // --- 8. Internal helper ----------------------------------------------
   assert.equal(__internals.isProvisioningAvailable({ api: {} }), false)
   assert.equal(__internals.isProvisioningAvailable(ctx1), true)
+  assert.equal(__internals.isViewProvisioningAvailable({ api: {} }), false)
+  assert.equal(__internals.isViewProvisioningAvailable(ctx1), true)
+  assert.deepEqual(__internals.buildDefaultViewDescriptor({ id: 'standard_materials' }), {
+    id: 'default_grid',
+    objectId: 'standard_materials',
+    name: 'All records',
+    type: 'grid',
+    config: {
+      integrationStaging: true,
+      stagingObjectId: 'standard_materials',
+    },
+  })
+  assert.equal(
+    __internals.buildMultitableOpenLink({ sheetId: 'sheet A', viewId: 'view/B', baseId: 'base C' }),
+    '/multitable/sheet%20A/view%2FB?baseId=base%20C',
+    'open links encode route segments and baseId',
+  )
 
-  console.log('✓ staging-installer: all 7 assertions passed')
+  console.log('✓ staging-installer: all 8 assertions passed')
 }
 
 main().catch((err) => {

--- a/plugins/plugin-integration-core/lib/staging-installer.cjs
+++ b/plugins/plugin-integration-core/lib/staging-installer.cjs
@@ -167,10 +167,41 @@ function isProvisioningAvailable(context) {
   )
 }
 
+function isViewProvisioningAvailable(context) {
+  return Boolean(
+    isProvisioningAvailable(context)
+    && typeof context.api.multitable.provisioning.ensureView === 'function',
+  )
+}
+
+function buildDefaultViewDescriptor(descriptor) {
+  return {
+    id: 'default_grid',
+    objectId: descriptor.id,
+    name: 'All records',
+    type: 'grid',
+    config: {
+      integrationStaging: true,
+      stagingObjectId: descriptor.id,
+    },
+  }
+}
+
+function encodeRoutePart(value) {
+  return encodeURIComponent(String(value))
+}
+
+function buildMultitableOpenLink({ sheetId, viewId, baseId }) {
+  const path = `/multitable/${encodeRoutePart(sheetId)}/${encodeRoutePart(viewId)}`
+  if (!baseId) return path
+  return `${path}?baseId=${encodeRoutePart(baseId)}`
+}
+
 /**
  * Install the full staging sheet set for a given project.
  * Idempotent — re-invoking does not duplicate sheets.
- * Returns a map of `{ [descriptorId]: sheetId }` for downstream modules.
+ * Returns sheet/view/link maps so the UI can open the created multitable
+ * surfaces directly instead of asking operators to copy technical ids.
  */
 async function installStaging({ context, projectId, baseId = null, logger } = {}) {
   if (!isProvisioningAvailable(context)) {
@@ -181,8 +212,12 @@ async function installStaging({ context, projectId, baseId = null, logger } = {}
   }
 
   const log = logger && typeof logger.info === 'function' ? logger : console
-  const result = {}
+  const sheetIds = {}
+  const viewIds = {}
+  const openLinks = {}
+  const targets = []
   const warnings = []
+  const canEnsureView = isViewProvisioningAvailable(context)
 
   for (const descriptor of STAGING_DESCRIPTORS) {
     try {
@@ -192,7 +227,35 @@ async function installStaging({ context, projectId, baseId = null, logger } = {}
         descriptor,
       })
       if (provisioned && provisioned.sheet && provisioned.sheet.id) {
-        result[descriptor.id] = provisioned.sheet.id
+        const sheetId = provisioned.sheet.id
+        const resolvedBaseId = provisioned.baseId || provisioned.sheet.baseId || baseId || null
+        sheetIds[descriptor.id] = sheetId
+        if (canEnsureView) {
+          try {
+            const view = await context.api.multitable.provisioning.ensureView({
+              projectId,
+              sheetId,
+              descriptor: buildDefaultViewDescriptor(descriptor),
+            })
+            if (view && view.id) {
+              const openLink = buildMultitableOpenLink({ sheetId, viewId: view.id, baseId: resolvedBaseId })
+              viewIds[descriptor.id] = view.id
+              openLinks[descriptor.id] = openLink
+              targets.push({
+                id: descriptor.id,
+                name: descriptor.name,
+                sheetId,
+                viewId: view.id,
+                baseId: resolvedBaseId,
+                openLink,
+              })
+            } else {
+              warnings.push(`ensureView returned no view id for ${descriptor.id}`)
+            }
+          } catch (err) {
+            warnings.push(`failed to ensure default view for ${descriptor.id}: ${err && err.message ? err.message : err}`)
+          }
+        }
       } else {
         warnings.push(`ensureObject returned no sheet id for ${descriptor.id}`)
       }
@@ -201,10 +264,14 @@ async function installStaging({ context, projectId, baseId = null, logger } = {}
     }
   }
 
+  if (!canEnsureView) {
+    warnings.push('context.api.multitable.provisioning.ensureView not available; staging sheets installed without open links')
+  }
+
   log.info(
-    `[plugin-integration-core] staging install done. sheets=${Object.keys(result).length}/${STAGING_DESCRIPTORS.length} warnings=${warnings.length}`,
+    `[plugin-integration-core] staging install done. sheets=${Object.keys(sheetIds).length}/${STAGING_DESCRIPTORS.length} views=${Object.keys(viewIds).length}/${STAGING_DESCRIPTORS.length} warnings=${warnings.length}`,
   )
-  return { sheetIds: result, warnings }
+  return { sheetIds, viewIds, openLinks, targets, warnings }
 }
 
 function summarizeField(field) {
@@ -243,6 +310,9 @@ module.exports = {
   STAGING_DESCRIPTORS,
   __internals: {
     isProvisioningAvailable,
+    isViewProvisioningAvailable,
+    buildDefaultViewDescriptor,
+    buildMultitableOpenLink,
     materializeField,
     materializeDescriptor,
     summarizeField,


### PR DESCRIPTION
## Summary
- ensure integration staging install creates default grid views and returns sheet/view/open-link targets
- show business-facing "打开多维表" cards on the K3 WISE setup page after staging install
- document the design and verification for the multitable cleansing entrypoint

## Verification
- node plugins/plugin-integration-core/__tests__/staging-installer.test.cjs
- pnpm -F plugin-integration-core test
- pnpm --filter @metasheet/web exec vitest run tests/IntegrationK3WiseSetupView.spec.ts --watch=false
- pnpm --filter @metasheet/web exec vitest run tests/k3WiseSetup.spec.ts tests/IntegrationK3WiseSetupView.spec.ts --watch=false
- pnpm --filter @metasheet/web build
- git diff --check

## Deployment impact
- No migration required.
- Existing staging installs can be rerun idempotently to create the default views and open links.