### PR TITLE
feat(integration): refresh K3 GATE readiness UI

### DIFF
--- a/apps/web/src/services/integration/k3WiseSetup.ts
+++ b/apps/web/src/services/integration/k3WiseSetup.ts
@@ -7,6 +7,7 @@ export type IntegrationPipelineRunMode = 'manual' | 'incremental' | 'full'
 export type K3WisePipelineTarget = 'material' | 'bom'
 export type IntegrationPipelineRunStatus = 'pending' | 'running' | 'succeeded' | 'partial' | 'failed' | 'cancelled'
 export type IntegrationDeadLetterStatus = 'open' | 'replayed' | 'discarded'
+export type PlmReadMethod = 'api' | 'database' | 'table' | 'file' | 'manual'
 
 export interface IntegrationApiEnvelope<T> {
   ok: boolean
@@ -139,6 +140,7 @@ export interface K3WiseSetupForm {
   workspaceId: string
   projectId: string
   baseId: string
+  operator: string
   webApiSystemId: string
   webApiHasCredentials: boolean
   webApiName: string
@@ -175,6 +177,16 @@ export interface K3WiseSetupForm {
   sqlAllowedTables: string
   sqlMiddleTables: string
   sqlStoredProcedures: string
+  plmKind: string
+  plmReadMethod: PlmReadMethod
+  plmBaseUrl: string
+  plmDefaultProductId: string
+  plmUsername: string
+  plmPassword: string
+  rollbackOwner: string
+  rollbackStrategy: string
+  bomEnabled: boolean
+  bomProductId: string
   sourceSystemId: string
   materialPipelineName: string
   materialPipelineId: string
@@ -274,11 +286,26 @@ export interface K3WiseDeployGateSummary {
   canRunLive: boolean
 }
 
+export interface K3WisePocCommandSet {
+  postdeploySmoke: string
+  postdeploySummary: string
+  preflight: string
+  offlineMock: string
+  evidence: string
+}
+
+export interface K3WiseGateJsonImportResult {
+  form: K3WiseSetupForm
+  warnings: string[]
+}
+
 const WEBAPI_KIND = 'erp:k3-wise-webapi'
 const SQLSERVER_KIND = 'erp:k3-wise-sqlserver'
 const K3_WISE_POC_MIN_SAMPLE_LIMIT = 1
 const K3_WISE_POC_MAX_SAMPLE_LIMIT = 3
 const K3_WISE_DOCUMENT_TEMPLATE_VERSION = '2026.05.v1'
+const IMPORT_SECRET_KEY_PATTERN =
+  /(password|passwd|pwd|secret|sessionid|session_id|cookie|accesskey|access_key|privatekey|private_key|clientsecret|client_secret|authoritycode|authority_code|^token$|access[_-]?token|bearer[_-]?token)/i
 
 const K3_WISE_DOCUMENT_TEMPLATES: Record<K3WisePipelineTarget, K3WiseDocumentTemplate> = {
   material: {
@@ -443,6 +470,16 @@ export function splitList(value: string): string[] {
     .split(/\r?\n|,/)
     .map((item) => item.trim())
     .filter(Boolean)
+}
+
+function normalizeSqlObjectLeaf(value: string): string {
+  const normalized = value.trim().replace(/[[\]"'`]/g, '')
+  const parts = normalized.split('.').map((part) => part.trim()).filter(Boolean)
+  return (parts.at(-1) || normalized).toLowerCase()
+}
+
+function isK3CoreBusinessTable(value: string): boolean {
+  return new Set(['t_icitem', 't_icbom', 't_icbomchild']).has(normalizeSqlObjectLeaf(value))
 }
 
 export function listK3WiseDocumentTemplates(): K3WiseDocumentTemplate[] {
@@ -690,6 +727,7 @@ export function createDefaultK3WiseSetupForm(): K3WiseSetupForm {
     workspaceId,
     projectId: '',
     baseId: '',
+    operator: '',
     webApiSystemId: '',
     webApiHasCredentials: false,
     webApiName: 'K3 WISE WebAPI',
@@ -726,6 +764,16 @@ export function createDefaultK3WiseSetupForm(): K3WiseSetupForm {
     sqlAllowedTables: 't_ICItem\nt_ICBOM\nt_ICBomChild',
     sqlMiddleTables: '',
     sqlStoredProcedures: '',
+    plmKind: 'plm:yuantus-wrapper',
+    plmReadMethod: 'api',
+    plmBaseUrl: '',
+    plmDefaultProductId: '',
+    plmUsername: '',
+    plmPassword: '',
+    rollbackOwner: '',
+    rollbackStrategy: 'disable-test-records',
+    bomEnabled: true,
+    bomProductId: '',
     sourceSystemId: '',
     materialPipelineName: 'PLM Material to K3 WISE',
     materialPipelineId: '',
@@ -790,6 +838,38 @@ export function validateK3WiseSetupForm(form: K3WiseSetupForm): K3WiseSetupValid
     if (sqlCredentialTouched && (!trim(form.sqlUsername) || !trim(form.sqlPassword))) {
       issues.push({ field: 'sqlPassword', message: 'SQL Server credentials must include both username and password' })
     }
+  }
+  return issues
+}
+
+export function validateK3WiseGateDraftForm(form: K3WiseSetupForm): K3WiseSetupValidationIssue[] {
+  const issues: K3WiseSetupValidationIssue[] = []
+  if (!trim(form.tenantId)) issues.push({ field: 'tenantId', message: 'tenantId is required' })
+  if (!trim(form.workspaceId)) issues.push({ field: 'workspaceId', message: 'workspaceId is required for live PoC GATE' })
+  if (!trim(form.operator)) issues.push({ field: 'operator', message: 'operator is required for live PoC GATE' })
+  if (!trim(form.version)) issues.push({ field: 'version', message: 'K3 WISE version is required' })
+  validateHttpUrl(form.baseUrl, 'baseUrl', issues)
+  if (form.webApiAuthMode === 'login' && !trim(form.acctId)) {
+    issues.push({ field: 'acctId', message: 'acctId is required for login-mode live PoC GATE' })
+  }
+  if (form.environment === 'production') {
+    issues.push({ field: 'environment', message: 'Live PoC GATE must target a non-production K3 WISE environment' })
+  } else if (!['test', 'uat', 'staging'].includes(form.environment)) {
+    issues.push({ field: 'environment', message: 'Live PoC GATE environment must be test, uat, or staging' })
+  }
+  if (form.autoSubmit || form.autoAudit) {
+    issues.push({ field: 'form', message: 'Live PoC GATE must stay Save-only: autoSubmit and autoAudit must be false' })
+  }
+  if (!trim(form.plmKind)) issues.push({ field: 'plmKind', message: 'PLM kind is required' })
+  if (!trim(form.plmReadMethod)) issues.push({ field: 'plmReadMethod', message: 'PLM read method is required' })
+  if (trim(form.plmBaseUrl)) validateHttpUrl(form.plmBaseUrl, 'plmBaseUrl', issues)
+  if (!trim(form.rollbackOwner)) issues.push({ field: 'rollbackOwner', message: 'Rollback owner is required' })
+  if (!trim(form.rollbackStrategy)) issues.push({ field: 'rollbackStrategy', message: 'Rollback strategy is required' })
+  if (form.bomEnabled && !trim(form.bomProductId) && !trim(form.plmDefaultProductId)) {
+    issues.push({ field: 'bomProductId', message: 'BOM PoC requires BOM product ID or PLM default product ID' })
+  }
+  if (form.sqlEnabled && form.sqlMode !== 'readonly' && splitList(form.sqlMiddleTables).some(isK3CoreBusinessTable)) {
+    issues.push({ field: 'sqlMiddleTables', message: 'Live PoC may not write K3 WISE core business tables' })
   }
   return issues
 }
@@ -1083,6 +1163,417 @@ export function formatIntegrationStagingDescriptorFieldSummary(descriptor: Integ
   return selectFields.length > 0
     ? `${details.length} fields · ${typeText} · select ${selectFields.join(', ')}`
     : `${details.length} fields · ${typeText}`
+}
+
+function credentialPlaceholder(): string {
+  return '<fill-outside-git>'
+}
+
+function buildMaterialGateMappings(): Array<Record<string, unknown>> {
+  return [
+    { sourceField: 'code', targetField: 'FNumber', transform: { type: 'upperTrim' }, validation: [{ type: 'required' }] },
+    { sourceField: 'name', targetField: 'FName', validation: [{ type: 'required' }] },
+    { sourceField: 'uom', targetField: 'FBaseUnitID', transform: { type: 'dictMap', dictionary: 'unit' } },
+    { sourceField: 'spec', targetField: 'FModel', transform: { type: 'trim' } },
+  ]
+}
+
+function buildBomGateMappings(): Array<Record<string, unknown>> {
+  return [
+    { sourceField: 'parentCode', targetField: 'FParentItemNumber', validation: [{ type: 'required' }] },
+    { sourceField: 'childCode', targetField: 'FChildItems[].FItemNumber', validation: [{ type: 'required' }] },
+    { sourceField: 'quantity', targetField: 'FChildItems[].FQty', transform: { type: 'toNumber' } },
+  ]
+}
+
+export function buildK3WiseGateDraft(form: K3WiseSetupForm): Record<string, unknown> {
+  const issues = validateK3WiseGateDraftForm(form)
+  if (issues.length > 0) {
+    throw new Error(issues[0].message)
+  }
+
+  const plmConfig: Record<string, unknown> = {}
+  if (trim(form.plmDefaultProductId)) plmConfig.defaultProductId = trim(form.plmDefaultProductId)
+
+  const k3Credentials = form.webApiAuthMode === 'authority-code'
+    ? { authorityCode: credentialPlaceholder() }
+    : {
+      username: trim(form.username) || credentialPlaceholder(),
+      password: credentialPlaceholder(),
+    }
+
+  return {
+    tenantId: resolveTenantId(form),
+    workspaceId: trim(form.workspaceId),
+    ...(optionalString(form.projectId) ? { projectId: trim(form.projectId) } : {}),
+    operator: trim(form.operator),
+    k3Wise: {
+      version: trim(form.version),
+      apiUrl: trim(form.baseUrl),
+      environment: form.environment,
+      authMode: form.webApiAuthMode,
+      ...(form.webApiAuthMode === 'authority-code' ? { tokenPath: trim(form.tokenPath) } : { loginPath: trim(form.loginPath), acctId: trim(form.acctId) }),
+      credentials: k3Credentials,
+      autoSubmit: false,
+      autoAudit: false,
+    },
+    plm: {
+      kind: trim(form.plmKind),
+      readMethod: form.plmReadMethod,
+      ...(optionalString(form.plmBaseUrl) ? { baseUrl: trim(form.plmBaseUrl) } : {}),
+      ...(Object.keys(plmConfig).length > 0 ? { config: plmConfig } : {}),
+      credentials: {
+        username: trim(form.plmUsername) || credentialPlaceholder(),
+        password: credentialPlaceholder(),
+      },
+    },
+    sqlServer: {
+      enabled: form.sqlEnabled,
+      mode: form.sqlEnabled ? form.sqlMode : 'readonly',
+      ...(optionalString(form.sqlServer) ? { server: trim(form.sqlServer) } : {}),
+      ...(optionalString(form.sqlDatabase) ? { database: trim(form.sqlDatabase) } : {}),
+      allowedTables: splitList(form.sqlAllowedTables),
+      middleTables: splitList(form.sqlMiddleTables),
+      storedProcedures: splitList(form.sqlStoredProcedures),
+      writeCoreTables: false,
+    },
+    rollback: {
+      owner: trim(form.rollbackOwner),
+      strategy: trim(form.rollbackStrategy),
+    },
+    bom: {
+      enabled: form.bomEnabled,
+      ...(form.bomEnabled ? { productId: trim(form.bomProductId) || trim(form.plmDefaultProductId) } : {}),
+    },
+    fieldMappings: {
+      material: buildMaterialGateMappings(),
+      ...(form.bomEnabled ? { bom: buildBomGateMappings() } : {}),
+    },
+  }
+}
+
+export function stringifyK3WiseGateDraft(form: K3WiseSetupForm): string {
+  return JSON.stringify(buildK3WiseGateDraft(form), null, 2)
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function hasOwn(record: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(record, key)
+}
+
+function recordAt(record: Record<string, unknown>, key: string): Record<string, unknown> | null {
+  const value = record[key]
+  return isPlainRecord(value) ? value : null
+}
+
+function importedString(value: unknown): string {
+  if (typeof value === 'string') return trim(value)
+  if (typeof value === 'number' && Number.isFinite(value)) return String(value)
+  return ''
+}
+
+function firstImportedString(record: Record<string, unknown> | null, keys: string[]): string {
+  if (!record) return ''
+  for (const key of keys) {
+    if (!hasOwn(record, key)) continue
+    const value = importedString(record[key])
+    if (value) return value
+  }
+  return ''
+}
+
+function firstImportedValue(record: Record<string, unknown> | null, keys: string[]): unknown {
+  if (!record) return undefined
+  for (const key of keys) {
+    if (hasOwn(record, key)) return record[key]
+  }
+  return undefined
+}
+
+function importedListText(value: unknown): string {
+  if (Array.isArray(value)) {
+    return value.map((item) => importedString(item)).filter(Boolean).join('\n')
+  }
+  if (typeof value === 'string') {
+    return splitList(value).join('\n')
+  }
+  return ''
+}
+
+function normalizeImportedBoolean(
+  value: unknown,
+  fallback: boolean,
+  field: string,
+  warnings: Set<string>,
+): boolean {
+  if (value === undefined || value === null || value === '') return fallback
+  if (typeof value === 'boolean') return value
+  if (typeof value === 'number') {
+    if (value === 0 || value === 1) return value === 1
+    warnings.add(`${field} ignored because it is not a boolean-like value`)
+    return fallback
+  }
+  if (typeof value !== 'string') {
+    warnings.add(`${field} ignored because it is not a boolean-like value`)
+    return fallback
+  }
+
+  const normalized = trim(value).toLowerCase()
+  if (BOOLEAN_TRUE_TEXT.has(normalized) || ['yes', 'y', 'on', '是', '启用', '开启', '开'].includes(normalized)) return true
+  if (BOOLEAN_FALSE_TEXT.has(normalized) || ['no', 'n', 'off', '否', '禁用', '关闭', '关'].includes(normalized)) return false
+  warnings.add(`${field} ignored because it is not a boolean-like value`)
+  return fallback
+}
+
+function normalizeImportedEnvironment(
+  value: unknown,
+  fallback: K3WiseSetupForm['environment'],
+  warnings: Set<string>,
+): K3WiseSetupForm['environment'] {
+  const normalized = importedString(value).toLowerCase()
+  if (!normalized) return fallback
+  if (['test', 'testing', '测试'].includes(normalized)) return 'test'
+  if (['uat', '用户验收'].includes(normalized)) return 'uat'
+  if (['staging', 'stage', 'pre', '预发'].includes(normalized)) return 'staging'
+  if (['production', 'prod', '生产'].includes(normalized)) return 'production'
+  if (normalized === 'other') return 'other'
+  warnings.add(`k3Wise.environment "${importedString(value)}" mapped to other`)
+  return 'other'
+}
+
+function normalizeImportedWebApiAuthMode(
+  value: unknown,
+  fallback: K3WiseWebApiAuthMode,
+  warnings: Set<string>,
+): K3WiseWebApiAuthMode {
+  const normalized = importedString(value)
+    .toLowerCase()
+    .replace(/[\s_]+/g, '-')
+  if (!normalized) return fallback
+  if (['authority-code', 'auth-code', 'token', 'authorization-code', '授权码'].includes(normalized)) return 'authority-code'
+  if (['login', 'password', 'account-login', '账套登录'].includes(normalized)) return 'login'
+  warnings.add(`k3Wise.authMode "${importedString(value)}" ignored; kept ${fallback}`)
+  return fallback
+}
+
+function normalizeImportedSqlMode(
+  value: unknown,
+  fallback: K3SqlServerMode,
+  warnings: Set<string>,
+): K3SqlServerMode {
+  const normalized = importedString(value)
+    .toLowerCase()
+    .replace(/[\s_]+/g, '-')
+  if (!normalized) return fallback
+  if (['readonly', 'read-only', 'ro', '只读'].includes(normalized)) return 'readonly'
+  if (['middle-table', 'integration-table', 'staging-table', '中间表'].includes(normalized)) return 'middle-table'
+  if (['stored-procedure', 'procedure', 'proc', 'sp', '存储过程'].includes(normalized)) return 'stored-procedure'
+  warnings.add(`sqlServer.mode "${importedString(value)}" ignored; kept ${fallback}`)
+  return fallback
+}
+
+function normalizeImportedPlmReadMethod(
+  value: unknown,
+  fallback: PlmReadMethod,
+  warnings: Set<string>,
+): PlmReadMethod {
+  const normalized = importedString(value)
+    .toLowerCase()
+    .replace(/[\s_]+/g, '-')
+  if (!normalized) return fallback
+  if (['api', 'rest', 'webapi', 'interface', '接口'].includes(normalized)) return 'api'
+  if (['database', 'db', 'sql', '数据库'].includes(normalized)) return 'database'
+  if (['table', 'data-table', '数据表', '表'].includes(normalized)) return 'table'
+  if (['file', 'excel', 'csv', '文件'].includes(normalized)) return 'file'
+  if (['manual', 'hand', '手工', '手动'].includes(normalized)) return 'manual'
+  warnings.add(`plm.readMethod "${importedString(value)}" ignored; mapped to manual`)
+  return 'manual'
+}
+
+function hasPresentSecretValue(value: unknown): boolean {
+  if (typeof value === 'string') return trim(value).length > 0
+  if (Array.isArray(value)) return value.length > 0
+  if (isPlainRecord(value)) return Object.keys(value).length > 0
+  return value !== undefined && value !== null
+}
+
+function collectIgnoredSecretWarnings(value: unknown, path: string, warnings: Set<string>): void {
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => collectIgnoredSecretWarnings(item, `${path}[${index}]`, warnings))
+    return
+  }
+  if (!isPlainRecord(value)) return
+
+  for (const [key, child] of Object.entries(value)) {
+    const nextPath = path ? `${path}.${key}` : key
+    if (IMPORT_SECRET_KEY_PATTERN.test(key) && hasPresentSecretValue(child)) {
+      warnings.add(`${nextPath} ignored; enter it in the credential form if needed`)
+      continue
+    }
+    collectIgnoredSecretWarnings(child, nextPath, warnings)
+  }
+}
+
+function hasImportedSqlConfig(sqlServer: Record<string, unknown>): boolean {
+  return ['mode', 'server', 'database', 'allowedTables', 'middleTables', 'storedProcedures'].some((key) => {
+    if (!hasOwn(sqlServer, key)) return false
+    const value = sqlServer[key]
+    if (Array.isArray(value)) return value.length > 0
+    if (isPlainRecord(value)) return Object.keys(value).length > 0
+    return importedString(value).length > 0 || typeof value === 'boolean'
+  })
+}
+
+export function parseK3WiseGateJsonText(jsonText: string): Record<string, unknown> {
+  const normalized = trim(jsonText)
+  if (!normalized) {
+    throw new Error('GATE JSON is required')
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(normalized)
+  } catch {
+    throw new Error('GATE JSON must be valid JSON')
+  }
+  if (!isPlainRecord(parsed)) {
+    throw new Error('GATE JSON must be an object')
+  }
+  return parsed
+}
+
+export function applyK3WiseGateJsonToForm(form: K3WiseSetupForm, jsonText: string): K3WiseGateJsonImportResult {
+  const draft = parseK3WiseGateJsonText(jsonText)
+  const warnings = new Set<string>()
+  collectIgnoredSecretWarnings(draft, '', warnings)
+
+  const k3Wise = recordAt(draft, 'k3Wise')
+  const k3Credentials = recordAt(k3Wise || {}, 'credentials')
+  const plm = recordAt(draft, 'plm')
+  const plmCredentials = recordAt(plm || {}, 'credentials')
+  const plmConfig = recordAt(plm || {}, 'config')
+  const sqlServer = recordAt(draft, 'sqlServer')
+  const sqlCredentials = recordAt(sqlServer || {}, 'credentials')
+  const rollback = recordAt(draft, 'rollback')
+  const bom = recordAt(draft, 'bom')
+
+  const next: K3WiseSetupForm = {
+    ...form,
+    authorityCode: '',
+    password: '',
+    plmPassword: '',
+    sqlPassword: '',
+  }
+
+  const tenantId = firstImportedString(draft, ['tenantId'])
+  if (tenantId) next.tenantId = tenantId
+  const workspaceId = firstImportedString(draft, ['workspaceId'])
+  if (workspaceId) next.workspaceId = workspaceId
+  const projectId = firstImportedString(draft, ['projectId'])
+  if (projectId) next.projectId = projectId
+  const operator = firstImportedString(draft, ['operator'])
+  if (operator) next.operator = operator
+
+  const version = firstImportedString(k3Wise, ['version'])
+  if (version) next.version = version
+  const baseUrl = firstImportedString(k3Wise, ['apiUrl', 'baseUrl', 'url'])
+  if (baseUrl) next.baseUrl = baseUrl
+  next.webApiAuthMode = normalizeImportedWebApiAuthMode(firstImportedValue(k3Wise, ['authMode']), next.webApiAuthMode, warnings)
+  const tokenPath = firstImportedString(k3Wise, ['tokenPath'])
+  if (tokenPath) next.tokenPath = tokenPath
+  const loginPath = firstImportedString(k3Wise, ['loginPath'])
+  if (loginPath) next.loginPath = loginPath
+  const acctId = firstImportedString(k3Wise, ['acctId', 'accountId', 'account'])
+  if (acctId) next.acctId = acctId
+  next.environment = normalizeImportedEnvironment(firstImportedValue(k3Wise, ['environment']), next.environment, warnings)
+  const username = firstImportedString(k3Credentials, ['username', 'userName', 'user']) || firstImportedString(k3Wise, ['username', 'userName', 'user'])
+  if (username) next.username = username
+  next.autoSubmit = normalizeImportedBoolean(firstImportedValue(k3Wise, ['autoSubmit']), next.autoSubmit, 'k3Wise.autoSubmit', warnings)
+  next.autoAudit = normalizeImportedBoolean(firstImportedValue(k3Wise, ['autoAudit']), next.autoAudit, 'k3Wise.autoAudit', warnings)
+
+  const plmKind = firstImportedString(plm, ['kind', 'type'])
+  if (plmKind) next.plmKind = plmKind
+  next.plmReadMethod = normalizeImportedPlmReadMethod(firstImportedValue(plm, ['readMethod']), next.plmReadMethod, warnings)
+  const plmBaseUrl = firstImportedString(plm, ['baseUrl', 'apiUrl', 'url'])
+  if (plmBaseUrl) next.plmBaseUrl = plmBaseUrl
+  const plmDefaultProductId =
+    firstImportedString(plm, ['defaultProductId', 'productId']) ||
+    firstImportedString(plmConfig, ['defaultProductId', 'productId'])
+  if (plmDefaultProductId) next.plmDefaultProductId = plmDefaultProductId
+  const plmUsername = firstImportedString(plmCredentials, ['username', 'userName', 'user']) || firstImportedString(plm, ['username', 'userName', 'user'])
+  if (plmUsername) next.plmUsername = plmUsername
+
+  if (sqlServer) {
+    const enabledValue = firstImportedValue(sqlServer, ['enabled'])
+    next.sqlEnabled = enabledValue === undefined
+      ? (hasImportedSqlConfig(sqlServer) || next.sqlEnabled)
+      : normalizeImportedBoolean(enabledValue, next.sqlEnabled, 'sqlServer.enabled', warnings)
+    next.sqlMode = normalizeImportedSqlMode(firstImportedValue(sqlServer, ['mode']), next.sqlMode, warnings)
+    const sqlHost = firstImportedString(sqlServer, ['server', 'host'])
+    if (sqlHost) next.sqlServer = sqlHost
+    const database = firstImportedString(sqlServer, ['database', 'dbName'])
+    if (database) next.sqlDatabase = database
+    const sqlUsername = firstImportedString(sqlCredentials, ['username', 'userName', 'user']) || firstImportedString(sqlServer, ['username', 'userName', 'user'])
+    if (sqlUsername) next.sqlUsername = sqlUsername
+    if (hasOwn(sqlServer, 'allowedTables')) next.sqlAllowedTables = importedListText(sqlServer.allowedTables)
+    if (hasOwn(sqlServer, 'middleTables')) next.sqlMiddleTables = importedListText(sqlServer.middleTables)
+    if (hasOwn(sqlServer, 'storedProcedures')) next.sqlStoredProcedures = importedListText(sqlServer.storedProcedures)
+  }
+
+  const rollbackOwner = firstImportedString(rollback, ['owner'])
+  if (rollbackOwner) next.rollbackOwner = rollbackOwner
+  const rollbackStrategy = firstImportedString(rollback, ['strategy'])
+  if (rollbackStrategy) next.rollbackStrategy = rollbackStrategy
+
+  if (bom) {
+    next.bomEnabled = normalizeImportedBoolean(firstImportedValue(bom, ['enabled']), next.bomEnabled, 'bom.enabled', warnings)
+    const bomProductId = firstImportedString(bom, ['productId'])
+    if (bomProductId) next.bomProductId = bomProductId
+  }
+
+  return {
+    form: next,
+    warnings: Array.from(warnings),
+  }
+}
+
+export function buildK3WisePocCommandSet(gatePath = 'artifacts/integration-live-poc/gate.json'): K3WisePocCommandSet {
+  return {
+    postdeploySmoke: 'node scripts/ops/integration-k3wise-postdeploy-smoke.mjs --base-url "$METASHEET_BASE_URL" --token-file "$METASHEET_AUTH_TOKEN_FILE" --tenant-id "$METASHEET_TENANT_ID" --require-auth --out-dir artifacts/integration-live-poc/postdeploy-smoke',
+    postdeploySummary: 'node scripts/ops/integration-k3wise-postdeploy-summary.mjs --input artifacts/integration-live-poc/postdeploy-smoke/integration-k3wise-postdeploy-smoke.json --require-auth-signoff',
+    preflight: `node scripts/ops/integration-k3wise-live-poc-preflight.mjs --input ${gatePath} --out-dir artifacts/integration-live-poc`,
+    offlineMock: 'pnpm run verify:integration-k3wise:poc',
+    evidence: 'node scripts/ops/integration-k3wise-live-poc-evidence.mjs --packet artifacts/integration-live-poc/packet.json --evidence artifacts/integration-live-poc/evidence.json --out-dir artifacts/integration-live-poc/evidence',
+  }
+}
+
+function shellDoubleQuote(value: string): string {
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\$/g, '\\$').replace(/`/g, '\\`')}"`
+}
+
+export function buildK3WisePocEnvironmentTemplate(form: Pick<K3WiseSetupForm, 'tenantId'>): string {
+  const tenantId = trim(form.tenantId) || '<tenant-id>'
+  return [
+    `export METASHEET_BASE_URL=${shellDoubleQuote('https://metasheet.example.test')}`,
+    `export METASHEET_AUTH_TOKEN_FILE=${shellDoubleQuote('/secure/path/metasheet-admin.jwt')}`,
+    `export METASHEET_TENANT_ID=${shellDoubleQuote(tenantId)}`,
+  ].join('\n')
+}
+
+export function buildK3WisePostdeploySignoffBundle(
+  form: Pick<K3WiseSetupForm, 'tenantId'>,
+  commands: Pick<K3WisePocCommandSet, 'postdeploySmoke' | 'postdeploySummary'> = buildK3WisePocCommandSet(),
+): string {
+  return [
+    '# K3 WISE postdeploy signoff - replace placeholders outside Git before running',
+    'set -euo pipefail',
+    buildK3WisePocEnvironmentTemplate(form),
+    '',
+    commands.postdeploySmoke,
+    commands.postdeploySummary,
+  ].join('\n')
 }
 
 export function getK3WisePipelineId(form: K3WiseSetupForm, target: K3WisePipelineTarget): string {

--- a/apps/web/src/views/IntegrationK3WiseSetupView.vue
+++ b/apps/web/src/views/IntegrationK3WiseSetupView.vue
@@ -228,6 +228,109 @@
           <pre v-if="pipelineRunResult" class="k3-setup__test-result">{{ pipelineRunResult }}</pre>
         </details>
 
+        <div class="k3-setup__panel">
+          <div class="k3-setup__panel-head">
+            <h2>PoC 准备</h2>
+            <span>{{ gateIssues.length ? `${gateIssues.length} gaps` : 'ready' }}</span>
+          </div>
+          <button
+            class="k3-setup__btn k3-setup__btn--full"
+            type="button"
+            data-testid="k3-wise-gate-copy-button"
+            :disabled="gateIssues.length > 0 || !gateDraftText"
+            @click="copyGateDraft"
+          >
+            复制 GATE JSON
+          </button>
+          <button
+            class="k3-setup__btn k3-setup__btn--full"
+            type="button"
+            data-testid="k3-wise-gate-download-button"
+            :disabled="gateIssues.length > 0 || !gateDraftText"
+            @click="downloadGateDraft"
+          >
+            下载 GATE JSON
+          </button>
+          <label class="k3-setup__field k3-setup__gate-import">
+            <span>导入客户 GATE JSON</span>
+            <textarea
+              v-model="gateImportText"
+              data-testid="k3-wise-gate-import-textarea"
+              rows="6"
+              spellcheck="false"
+              placeholder="粘贴客户回传的 GATE JSON，导入后会清空输入框和密码字段"
+            />
+          </label>
+          <button
+            class="k3-setup__btn k3-setup__btn--full"
+            type="button"
+            data-testid="k3-wise-gate-import-button"
+            :disabled="!gateImportText.trim()"
+            @click="importGateJson"
+          >
+            导入 GATE JSON
+          </button>
+          <ul v-if="gateImportWarnings.length" class="k3-setup__issues k3-setup__issues--compact" data-testid="k3-wise-gate-import-warnings">
+            <li v-for="warning in gateImportWarnings" :key="`gate-import:${warning}`">
+              {{ warning }}
+            </li>
+          </ul>
+          <ul v-if="gateIssues.length" class="k3-setup__issues k3-setup__issues--compact">
+            <li v-for="issue in gateIssues" :key="`gate:${issue.field}:${issue.message}`">
+              {{ issue.message }}
+            </li>
+          </ul>
+          <div class="k3-setup__commands" data-testid="k3-wise-gate-commands">
+            <div class="k3-setup__command k3-setup__command--env" data-testid="k3-wise-env-template">
+              <div class="k3-setup__command-head">
+                <strong>Deploy env</strong>
+                <button
+                  class="k3-setup__command-copy"
+                  type="button"
+                  data-testid="k3-wise-copy-env-template"
+                  @click="copyGateCommand('Deploy env', gateEnvTemplate)"
+                >
+                  复制
+                </button>
+              </div>
+              <code>{{ gateEnvTemplate }}</code>
+            </div>
+            <div class="k3-setup__command k3-setup__command--env" data-testid="k3-wise-postdeploy-bundle">
+              <div class="k3-setup__command-head">
+                <strong>Deploy signoff bundle</strong>
+                <button
+                  class="k3-setup__command-copy"
+                  type="button"
+                  data-testid="k3-wise-copy-postdeploy-bundle"
+                  @click="copyGateCommand('Deploy signoff bundle', postdeploySignoffBundle)"
+                >
+                  复制
+                </button>
+              </div>
+              <code>{{ postdeploySignoffBundle }}</code>
+            </div>
+            <div
+              v-for="command in gateCommandItems"
+              :key="command.key"
+              class="k3-setup__command"
+            >
+              <div class="k3-setup__command-head">
+                <strong>{{ command.label }}</strong>
+                <button
+                  class="k3-setup__command-copy"
+                  type="button"
+                  :data-testid="`k3-wise-copy-command-${command.key}`"
+                  @click="copyGateCommand(command.label, command.value)"
+                >
+                  复制
+                </button>
+              </div>
+              <code>{{ command.value }}</code>
+            </div>
+          </div>
+          <pre v-if="gateDraftText" class="k3-setup__test-result">{{ gateDraftText }}</pre>
+        </div>
+
         <details class="k3-setup__panel k3-setup__collapsible-panel">
           <summary class="k3-setup__panel-summary">
             <span>运行观察</span>
@@ -485,6 +588,66 @@
           </div>
         </details>
 
+        <section class="k3-setup__section">
+          <div class="k3-setup__section-head">
+            <h2>客户 GATE / PLM Source</h2>
+            <span>preflight JSON</span>
+          </div>
+          <div class="k3-setup__grid">
+            <label class="k3-setup__field">
+              <span>Operator</span>
+              <input v-model.trim="form.operator" autocomplete="off" />
+            </label>
+            <label class="k3-setup__field">
+              <span>PLM Kind</span>
+              <input v-model.trim="form.plmKind" autocomplete="off" />
+            </label>
+            <label class="k3-setup__field">
+              <span>PLM Read Method</span>
+              <select v-model="form.plmReadMethod">
+                <option value="api">api</option>
+                <option value="database">database</option>
+                <option value="table">table</option>
+                <option value="file">file</option>
+                <option value="manual">manual</option>
+              </select>
+            </label>
+            <label class="k3-setup__field k3-setup__field--wide">
+              <span>PLM Base URL</span>
+              <input v-model.trim="form.plmBaseUrl" placeholder="https://plm.example.test/" autocomplete="off" />
+            </label>
+            <label class="k3-setup__field">
+              <span>PLM Default Product ID</span>
+              <input v-model.trim="form.plmDefaultProductId" autocomplete="off" />
+            </label>
+            <label class="k3-setup__field">
+              <span>PLM 用户名</span>
+              <input v-model.trim="form.plmUsername" autocomplete="off" />
+            </label>
+            <label class="k3-setup__field">
+              <span>PLM 密码</span>
+              <input v-model="form.plmPassword" type="password" autocomplete="new-password" />
+              <small>只作为导入客户 GATE 后的本地草稿；导出 JSON 永远使用占位符。</small>
+            </label>
+            <label class="k3-setup__field">
+              <span>Rollback Owner</span>
+              <input v-model.trim="form.rollbackOwner" autocomplete="off" />
+            </label>
+            <label class="k3-setup__field">
+              <span>Rollback Strategy</span>
+              <input v-model.trim="form.rollbackStrategy" autocomplete="off" />
+            </label>
+            <label class="k3-setup__check">
+              <input v-model="form.bomEnabled" type="checkbox" />
+              <span>启用 BOM PoC</span>
+            </label>
+            <label v-if="form.bomEnabled" class="k3-setup__field">
+              <span>BOM Product ID</span>
+              <input v-model.trim="form.bomProductId" autocomplete="off" />
+            </label>
+          </div>
+        </section>
+
         <section v-if="validationIssues.length" class="k3-setup__section k3-setup__section--issues">
           <div class="k3-setup__section-head">
             <h2>待补字段</h2>
@@ -637,8 +800,12 @@ import {
   K3_WISE_SQLSERVER_KIND,
   K3_WISE_WEBAPI_KIND,
   applyExternalSystemToForm,
+  applyK3WiseGateJsonToForm,
   buildK3WiseDocumentPayloadPreview,
   buildK3WiseDeployGateChecklist,
+  buildK3WisePocCommandSet,
+  buildK3WisePocEnvironmentTemplate,
+  buildK3WisePostdeploySignoffBundle,
   buildK3WiseSqlConnectionFingerprint,
   buildK3WiseSqlSystemConnectionFingerprint,
   buildK3WiseWebApiConnectionFingerprint,
@@ -659,10 +826,12 @@ import {
   listIntegrationStagingDescriptors,
   listIntegrationSystems,
   runIntegrationPipeline,
+  stringifyK3WiseGateDraft,
   summarizeK3WiseDeployGateChecklist,
   testIntegrationSystem,
   upsertIntegrationPipeline,
   upsertIntegrationSystem,
+  validateK3WiseGateDraftForm,
   validateK3WisePipelineTemplateForm,
   validateK3WisePipelineObservationForm,
   validateK3WisePipelineRunForm,
@@ -697,6 +866,8 @@ const stagingResult = ref('')
 const stagingInstallResult = ref<IntegrationStagingInstallResult | null>(null)
 const pipelineResult = ref('')
 const pipelineRunResult = ref('')
+const gateImportText = ref('')
+const gateImportWarnings = ref<string[]>([])
 const webApiLastTest = ref<{
   systemId: string
   ok: boolean
@@ -715,8 +886,27 @@ const stagingIssues = computed(() => validateK3WiseStagingInstallForm(form))
 const pipelineIssues = computed(() => validateK3WisePipelineTemplateForm(form, stagingDescriptors.value))
 const materialRunIssues = computed(() => validateK3WisePipelineRunForm(form, 'material'))
 const bomRunIssues = computed(() => validateK3WisePipelineRunForm(form, 'bom'))
+const gateIssues = computed(() => validateK3WiseGateDraftForm(form))
 const deployGateChecklist = computed(() => buildK3WiseDeployGateChecklist(form))
 const deployGateSummary = computed(() => summarizeK3WiseDeployGateChecklist(deployGateChecklist.value))
+const gateCommands = buildK3WisePocCommandSet()
+const gateEnvTemplate = computed(() => buildK3WisePocEnvironmentTemplate(form))
+const postdeploySignoffBundle = computed(() => buildK3WisePostdeploySignoffBundle(form, gateCommands))
+const gateCommandItems = [
+  { key: 'postdeploy-smoke', label: 'Postdeploy smoke', value: gateCommands.postdeploySmoke },
+  { key: 'postdeploy-summary', label: 'Postdeploy summary', value: gateCommands.postdeploySummary },
+  { key: 'preflight', label: 'Preflight', value: gateCommands.preflight },
+  { key: 'offline-mock', label: 'Offline mock', value: gateCommands.offlineMock },
+  { key: 'evidence', label: 'Evidence', value: gateCommands.evidence },
+]
+const gateDraftText = computed(() => {
+  if (gateIssues.value.length > 0) return ''
+  try {
+    return stringifyK3WiseGateDraft(form)
+  } catch {
+    return ''
+  }
+})
 const observationSummary = computed(() => `${pipelineRuns.value.length} runs / ${deadLetters.value.length} open`)
 const stagingDescriptorLabel = computed(() => stagingDescriptors.value.length > 0 ? `${stagingDescriptors.value.length} descriptors` : 'not loaded')
 const templatePreviewJson = computed(() => JSON.stringify(buildK3WiseDocumentPayloadPreview(templatePreviewTarget.value), null, 2))
@@ -893,6 +1083,59 @@ function formatDeployGateStatus(status: string): string {
   if (status === 'missing') return 'failed'
   if (status === 'warning') return 'partial'
   return 'open'
+}
+
+async function copyGateDraft(): Promise<void> {
+  if (!gateDraftText.value) return
+  try {
+    await navigator.clipboard.writeText(gateDraftText.value)
+    setStatus('GATE JSON 已复制', 'success')
+  } catch (error) {
+    setStatus(formatError(error), 'error')
+  }
+}
+
+async function copyGateCommand(label: string, command: string): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(command)
+    setStatus(`${label} 命令已复制`, 'success')
+  } catch (error) {
+    setStatus(formatError(error), 'error')
+  }
+}
+
+function downloadGateDraft(): void {
+  if (!gateDraftText.value || typeof document === 'undefined' || typeof URL.createObjectURL !== 'function') return
+  const blob = new Blob([gateDraftText.value], { type: 'application/json;charset=utf-8' })
+  const url = URL.createObjectURL(blob)
+  const anchor = document.createElement('a')
+  anchor.href = url
+  anchor.download = 'k3-wise-live-poc-gate.json'
+  anchor.rel = 'noopener'
+  anchor.style.display = 'none'
+  document.body.appendChild(anchor)
+  anchor.click()
+  anchor.remove()
+  window.setTimeout(() => URL.revokeObjectURL(url), 0)
+  setStatus('GATE JSON 已生成', 'success')
+}
+
+function importGateJson(): void {
+  try {
+    const result = applyK3WiseGateJsonToForm(form, gateImportText.value)
+    Object.assign(form, result.form)
+    gateImportWarnings.value = result.warnings
+    gateImportText.value = ''
+    setStatus(
+      result.warnings.length > 0
+        ? `GATE JSON 已导入，${result.warnings.length} 项需要人工确认`
+        : 'GATE JSON 已导入',
+      result.warnings.length > 0 ? 'info' : 'success',
+    )
+  } catch (error) {
+    gateImportWarnings.value = []
+    setStatus(formatError(error), 'error')
+  }
 }
 
 function formatTemplateTransform(transform: unknown): string {
@@ -1589,6 +1832,60 @@ onMounted(() => {
   flex-direction: column;
   gap: 8px;
   margin-top: 12px;
+}
+
+.k3-setup__commands {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.k3-setup__command {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.k3-setup__command-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.k3-setup__command-head strong {
+  color: #334155;
+  font-size: 12px;
+}
+
+.k3-setup__command-copy {
+  border: 1px solid #cbd5e1;
+  border-radius: 6px;
+  padding: 3px 8px;
+  background: #fff;
+  color: #334155;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.k3-setup__command-copy:hover {
+  border-color: #94a3b8;
+  background: #f8fafc;
+}
+
+.k3-setup__commands code {
+  display: block;
+  overflow-wrap: anywhere;
+  border-radius: 6px;
+  padding: 8px;
+  background: #f1f5f9;
+  color: #172033;
+  font-size: 12px;
+}
+
+.k3-setup__command--env code {
+  white-space: pre-wrap;
 }
 
 .k3-setup__descriptor-list {

--- a/apps/web/tests/k3WiseSetup.spec.ts
+++ b/apps/web/tests/k3WiseSetup.spec.ts
@@ -2,8 +2,13 @@ import { describe, expect, it } from 'vitest'
 import { readFile } from 'node:fs/promises'
 import {
   applyExternalSystemToForm,
+  applyK3WiseGateJsonToForm,
   buildK3WiseDocumentPayloadPreview,
   buildK3WiseDeployGateChecklist,
+  buildK3WiseGateDraft,
+  buildK3WisePocCommandSet,
+  buildK3WisePocEnvironmentTemplate,
+  buildK3WisePostdeploySignoffBundle,
   buildK3WiseSqlConnectionFingerprint,
   buildK3WiseSqlSystemConnectionFingerprint,
   buildK3WiseWebApiConnectionFingerprint,
@@ -19,7 +24,9 @@ import {
   getK3WisePipelineId,
   listK3WiseDocumentTemplates,
   splitList,
+  stringifyK3WiseGateDraft,
   summarizeK3WiseDeployGateChecklist,
+  validateK3WiseGateDraftForm,
   validateK3WisePipelineObservationForm,
   validateK3WisePipelineTemplateForm,
   validateK3WisePipelineRunForm,
@@ -585,6 +592,259 @@ describe('K3 WISE setup helpers', () => {
       },
     })
     expect(JSON.stringify(materialPreview)).not.toMatch(/authorityCode|Token|password|sourceId|revision|_integration/i)
+  })
+
+  it('builds a redacted authority-code customer GATE draft and command set', () => {
+    const form = createDefaultK3WiseSetupForm()
+    Object.assign(form, {
+      tenantId: 'tenant_1',
+      workspaceId: 'workspace_1',
+      projectId: 'project_1',
+      operator: 'customer-k3-admin',
+      version: 'K3 WISE 15.x test',
+      environment: 'uat',
+      baseUrl: 'https://k3.example.test/',
+      authorityCode: 'real-authority-code',
+      plmKind: 'plm:yuantus-wrapper',
+      plmReadMethod: 'api',
+      plmBaseUrl: 'https://plm.example.test/',
+      plmDefaultProductId: 'PRODUCT-TEST-001',
+      plmUsername: 'plm-user',
+      plmPassword: 'real-plm-password',
+      rollbackOwner: 'customer-k3-admin',
+      sqlEnabled: true,
+      sqlMode: 'middle-table',
+      sqlServer: '10.0.0.10',
+      sqlDatabase: 'AIS_TEST',
+      sqlMiddleTables: 'dbo.integration_material_stage',
+    })
+
+    expect(validateK3WiseGateDraftForm(form)).toEqual([])
+    const draft = buildK3WiseGateDraft(form)
+
+    expect(draft).toMatchObject({
+      tenantId: 'tenant_1',
+      workspaceId: 'workspace_1',
+      projectId: 'project_1',
+      operator: 'customer-k3-admin',
+      k3Wise: {
+        version: 'K3 WISE 15.x test',
+        apiUrl: 'https://k3.example.test/',
+        environment: 'uat',
+        authMode: 'authority-code',
+        tokenPath: '/K3API/Token/Create',
+        credentials: {
+          authorityCode: '<fill-outside-git>',
+        },
+        autoSubmit: false,
+        autoAudit: false,
+      },
+      plm: {
+        kind: 'plm:yuantus-wrapper',
+        readMethod: 'api',
+        baseUrl: 'https://plm.example.test/',
+        config: {
+          defaultProductId: 'PRODUCT-TEST-001',
+        },
+        credentials: {
+          username: 'plm-user',
+          password: '<fill-outside-git>',
+        },
+      },
+      sqlServer: {
+        enabled: true,
+        mode: 'middle-table',
+        server: '10.0.0.10',
+        database: 'AIS_TEST',
+        middleTables: ['dbo.integration_material_stage'],
+        writeCoreTables: false,
+      },
+      rollback: {
+        owner: 'customer-k3-admin',
+        strategy: 'disable-test-records',
+      },
+      bom: {
+        enabled: true,
+        productId: 'PRODUCT-TEST-001',
+      },
+    })
+    expect(JSON.stringify(draft)).not.toContain('real-authority-code')
+    expect(JSON.stringify(draft)).not.toContain('real-plm-password')
+    expect(stringifyK3WiseGateDraft(form)).toContain('"fieldMappings"')
+
+    const commands = buildK3WisePocCommandSet()
+    expect(commands.postdeploySmoke).toContain('integration-k3wise-postdeploy-smoke.mjs')
+    expect(commands.postdeploySmoke).toContain('--require-auth')
+    expect(commands.postdeploySummary).toContain('integration-k3wise-postdeploy-summary.mjs')
+    expect(commands.preflight).toContain('integration-k3wise-live-poc-preflight.mjs')
+    expect(commands.offlineMock).toBe('pnpm run verify:integration-k3wise:poc')
+    expect(commands.evidence).toContain('integration-k3wise-live-poc-evidence.mjs')
+  })
+
+  it('builds redacted postdeploy environment and signoff command bundles', () => {
+    const form = createDefaultK3WiseSetupForm()
+    Object.assign(form, {
+      tenantId: 'tenant_1',
+    })
+
+    const env = buildK3WisePocEnvironmentTemplate(form)
+    expect(env).toContain('METASHEET_BASE_URL')
+    expect(env).toContain('METASHEET_AUTH_TOKEN_FILE')
+    expect(env).toContain('METASHEET_TENANT_ID="tenant_1"')
+    expect(env).not.toMatch(/eyJ|Bearer|password/i)
+
+    const bundle = buildK3WisePostdeploySignoffBundle(form)
+    expect(bundle).toContain('set -euo pipefail')
+    expect(bundle).toContain('integration-k3wise-postdeploy-smoke.mjs')
+    expect(bundle).toContain('integration-k3wise-postdeploy-summary.mjs')
+    expect(bundle).not.toMatch(/eyJ|Bearer|password/i)
+  })
+
+  it('blocks unsafe live PoC GATE drafts before preflight JSON is copied', () => {
+    const form = createDefaultK3WiseSetupForm()
+    Object.assign(form, {
+      tenantId: 'tenant_1',
+      workspaceId: 'workspace_1',
+      operator: 'customer-k3-admin',
+      version: 'K3 WISE prod',
+      environment: 'production',
+      baseUrl: 'https://k3.example.test/',
+      autoSubmit: true,
+      sqlEnabled: true,
+      sqlMode: 'middle-table',
+      sqlMiddleTables: 'dbo.t_ICItem',
+      rollbackOwner: 'customer-k3-admin',
+      plmKind: 'plm:yuantus-wrapper',
+      plmDefaultProductId: '',
+      bomProductId: '',
+    })
+
+    const messages = validateK3WiseGateDraftForm(form).map((issue) => issue.message)
+    expect(messages).toContain('Live PoC GATE must target a non-production K3 WISE environment')
+    expect(messages).toContain('Live PoC GATE must stay Save-only: autoSubmit and autoAudit must be false')
+    expect(messages).toContain('BOM PoC requires BOM product ID or PLM default product ID')
+    expect(messages).toContain('Live PoC may not write K3 WISE core business tables')
+    expect(() => buildK3WiseGateDraft(form)).toThrow('Live PoC GATE must target a non-production K3 WISE environment')
+  })
+
+  it('imports customer GATE JSON public fields without credential secrets', () => {
+    const form = createDefaultK3WiseSetupForm()
+    Object.assign(form, {
+      authorityCode: 'old-authority-code',
+      password: 'old-k3-secret',
+      plmPassword: 'old-plm-secret',
+      sqlPassword: 'old-sql-secret',
+    })
+
+    const result = applyK3WiseGateJsonToForm(form, JSON.stringify({
+      tenantId: 'tenant_customer',
+      workspaceId: 'workspace_customer',
+      projectId: 'project_customer',
+      operator: 'customer-k3-admin',
+      k3Wise: {
+        version: 'K3 WISE 15.x',
+        apiUrl: 'https://k3.customer.test/',
+        environment: 'staging',
+        authMode: 'authority-code',
+        tokenPath: '/K3API/Token/Create',
+        credentials: {
+          authorityCode: 'customer-authority-code',
+          username: 'ignored-for-authority-code',
+        },
+        autoSubmit: 'false',
+        autoAudit: 'false',
+      },
+      plm: {
+        kind: 'plm:third-party',
+        readMethod: 'database',
+        baseUrl: 'https://plm.example.test/',
+        config: {
+          defaultProductId: 'PRODUCT-001',
+        },
+        credentials: {
+          username: 'plm-user',
+          password: 'plm-secret',
+          token: 'plm-token',
+        },
+      },
+      sqlServer: {
+        enabled: true,
+        mode: 'middle-table',
+        server: '10.0.0.10',
+        database: 'AIS_TEST',
+        username: 'sql-user',
+        password: 'sql-secret',
+        allowedTables: ['dbo.t_ICItem', 'dbo.t_ICBOM'],
+        middleTables: 'dbo.integration_material_stage',
+      },
+      rollback: {
+        owner: 'rollback-owner',
+        strategy: 'delete-test-records',
+      },
+      bom: {
+        enabled: true,
+        productId: 'PRODUCT-BOM-001',
+      },
+    }))
+
+    expect(result.form).toMatchObject({
+      tenantId: 'tenant_customer',
+      workspaceId: 'workspace_customer',
+      projectId: 'project_customer',
+      operator: 'customer-k3-admin',
+      version: 'K3 WISE 15.x',
+      baseUrl: 'https://k3.customer.test/',
+      webApiAuthMode: 'authority-code',
+      tokenPath: '/K3API/Token/Create',
+      environment: 'staging',
+      authorityCode: '',
+      password: '',
+      plmKind: 'plm:third-party',
+      plmReadMethod: 'database',
+      plmBaseUrl: 'https://plm.example.test/',
+      plmDefaultProductId: 'PRODUCT-001',
+      plmUsername: 'plm-user',
+      plmPassword: '',
+      sqlEnabled: true,
+      sqlMode: 'middle-table',
+      sqlServer: '10.0.0.10',
+      sqlDatabase: 'AIS_TEST',
+      sqlUsername: 'sql-user',
+      sqlPassword: '',
+      sqlAllowedTables: 'dbo.t_ICItem\ndbo.t_ICBOM',
+      sqlMiddleTables: 'dbo.integration_material_stage',
+      rollbackOwner: 'rollback-owner',
+      rollbackStrategy: 'delete-test-records',
+      bomEnabled: true,
+      bomProductId: 'PRODUCT-BOM-001',
+    })
+    expect(result.warnings).toContain('k3Wise.credentials.authorityCode ignored; enter it in the credential form if needed')
+    expect(result.warnings).toContain('plm.credentials.password ignored; enter it in the credential form if needed')
+    expect(result.warnings).toContain('plm.credentials.token ignored; enter it in the credential form if needed')
+    expect(result.warnings).toContain('sqlServer.password ignored; enter it in the credential form if needed')
+    expect(result.warnings).not.toContain('k3Wise.tokenPath ignored; enter it in the credential form if needed')
+  })
+
+  it('rejects invalid customer GATE JSON before applying it to the form', () => {
+    const form = createDefaultK3WiseSetupForm()
+
+    expect(() => applyK3WiseGateJsonToForm(form, '')).toThrow('GATE JSON is required')
+    expect(() => applyK3WiseGateJsonToForm(form, '{broken')).toThrow('GATE JSON must be valid JSON')
+    expect(() => applyK3WiseGateJsonToForm(form, '[]')).toThrow('GATE JSON must be an object')
+  })
+
+  it('exposes customer GATE copy, download, import, and postdeploy controls in the setup page', async () => {
+    const source = await readFile('src/views/IntegrationK3WiseSetupView.vue', 'utf8')
+
+    expect(source).toContain('data-testid="k3-wise-gate-copy-button"')
+    expect(source).toContain('data-testid="k3-wise-gate-download-button"')
+    expect(source).toContain('data-testid="k3-wise-gate-import-textarea"')
+    expect(source).toContain('data-testid="k3-wise-gate-import-button"')
+    expect(source).toContain('data-testid="k3-wise-postdeploy-bundle"')
+    expect(source).toContain('copyGateDraft')
+    expect(source).toContain('downloadGateDraft')
+    expect(source).toContain('importGateJson')
+    expect(source).toContain('buildK3WisePostdeploySignoffBundle')
   })
 
   it('requires saved PLM source and K3 target systems before pipeline template creation', () => {

--- a/docs/development/integration-k3wise-gate-readiness-ui-refresh-development-20260514.md
+++ b/docs/development/integration-k3wise-gate-readiness-ui-refresh-development-20260514.md
@@ -1,0 +1,82 @@
+# K3 WISE GATE Readiness UI Refresh Development - 2026-05-14
+
+## Context
+
+PR #1305 was opened from an older K3 WISE setup branch and is now conflicting with
+current `main`. The old branch predates several mainline changes:
+
+- authority-code WebAPI auth mode;
+- saved/draft connection-test guard;
+- staging multitable open targets;
+- current deploy-readiness script and mainline workflow gate.
+
+Replaying the old branch would reintroduce stale assumptions and large merge
+noise. This refresh ports only the still-missing product surface: customer GATE
+JSON preparation, import, redacted copy/download, and postdeploy command bundle
+surfacing.
+
+## Scope
+
+Changed files:
+
+- `apps/web/src/services/integration/k3WiseSetup.ts`
+- `apps/web/src/views/IntegrationK3WiseSetupView.vue`
+- `apps/web/tests/k3WiseSetup.spec.ts`
+
+This is frontend/service helper only. It does not add backend routes or contact
+customer PLM/K3/SQL systems from the browser.
+
+## Design
+
+### Form model
+
+`K3WiseSetupForm` now includes the GATE-only draft fields:
+
+- operator;
+- PLM kind/read method/base URL/default product ID/credential draft;
+- rollback owner/strategy;
+- BOM PoC enablement/product ID.
+
+These fields are separate from the saved K3 WebAPI/SQL external-system payload.
+They are used for readiness packet generation, not for saving integration
+systems directly.
+
+### Redacted GATE JSON
+
+`buildK3WiseGateDraft()` validates a Save-only non-production PoC packet and
+emits redacted JSON:
+
+- authority-code mode emits `credentials.authorityCode = "<fill-outside-git>"`;
+- login mode keeps non-secret `acctId` and emits password placeholder;
+- PLM and SQL credential secrets are never emitted;
+- SQL middle-table mode rejects K3 core business tables as write targets;
+- BOM PoC requires a BOM product ID or PLM default product ID.
+
+### Import behavior
+
+`applyK3WiseGateJsonToForm()` imports public fields from customer GATE JSON and
+clears secret drafts:
+
+- authority code, K3 password, PLM password, and SQL password are always reset;
+- secret-looking imported fields produce warnings;
+- unsupported enum aliases are conservative and either normalized or warned.
+
+### UI
+
+`IntegrationK3WiseSetupView.vue` adds:
+
+- GATE JSON copy/download buttons;
+- customer GATE JSON import textarea;
+- import warnings list;
+- deploy env and postdeploy signoff command bundle;
+- preflight/offline/evidence command copy controls;
+- PLM Source / rollback / BOM PoC form section.
+
+The UI keeps the existing K3 setup flow intact and reuses current-main
+connection-test guards and staging open-target behavior.
+
+## Supersedes
+
+This refresh supersedes #1305's stale branch implementation. The old branch
+still had useful UX/test intent, but its code assumed a pre-authority-code K3
+setup model.

--- a/docs/development/integration-k3wise-gate-readiness-ui-refresh-verification-20260514.md
+++ b/docs/development/integration-k3wise-gate-readiness-ui-refresh-verification-20260514.md
@@ -1,0 +1,101 @@
+# K3 WISE GATE Readiness UI Refresh Verification - 2026-05-14
+
+## Worktree
+
+`/private/tmp/ms2-k3wise-gate-readiness-ui-refresh-20260514`
+
+Branch:
+
+`codex/k3wise-gate-readiness-ui-refresh-20260514`
+
+Baseline:
+
+`origin/main` at `8067c8e04`.
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/web exec vitest run --watch=false tests/k3WiseSetup.spec.ts
+pnpm --filter @metasheet/web type-check
+pnpm --filter @metasheet/web build
+pnpm run verify:integration-k3wise:poc
+git diff --check
+```
+
+## Results
+
+Executed locally on 2026-05-14.
+
+### K3 WISE setup helper tests
+
+```text
+tests/k3WiseSetup.spec.ts: 40 passed
+Test Files: 1 passed
+```
+
+Coverage added:
+
+- redacted authority-code GATE JSON generation;
+- postdeploy environment/signoff command bundle generation;
+- unsafe live PoC validation for production, auto-submit/audit, core-table writes,
+  and missing BOM product context;
+- customer GATE JSON import without retaining credential secrets;
+- invalid JSON rejection;
+- source contract for GATE copy/download/import/postdeploy controls.
+
+### Web type-check
+
+```text
+pnpm --filter @metasheet/web type-check
+```
+
+Result: passed.
+
+### Web build
+
+```text
+pnpm --filter @metasheet/web build
+```
+
+Result: passed.
+
+Vite emitted the existing large-chunk and mixed dynamic/static import warnings;
+the build completed successfully.
+
+### K3 WISE offline PoC
+
+```text
+pnpm run verify:integration-k3wise:poc
+```
+
+Result: passed.
+
+Observed suites:
+
+- preflight tests: 21/21 passed;
+- evidence tests: 50/50 passed;
+- fixture contract tests: 2/2 passed;
+- mock K3 WebAPI tests: 4/4 passed;
+- mock SQL executor tests: 12/12 passed;
+- mock PoC demo: PASS.
+
+### Diff hygiene
+
+```text
+git diff --check
+```
+
+Result: passed.
+
+## Notes
+
+The temporary worktree required `pnpm install --frozen-lockfile` before frontend
+tests because `node_modules` was absent. Generated dependency link noise under
+`plugins/*/node_modules` and `tools/cli/node_modules` was removed before commit.
+
+## Not Covered
+
+- Real customer PLM connectivity.
+- Real K3 WISE connectivity.
+- Real SQL Server connectivity.
+- Browser clipboard/download behavior in a live browser session.


### PR DESCRIPTION
## Summary

- Refreshes the still-useful scope from stale PR #1305 on current `main` without replaying old merge commits or pre-authority-code assumptions.
- Adds customer GATE / PLM Source draft fields to the K3 WISE setup model.
- Adds redacted GATE JSON generation, copy/download, customer JSON import, and postdeploy command bundle surfacing.
- Keeps credentials out of generated JSON; authority-code, K3 password, PLM password, and SQL password imports are cleared and reported as warnings.
- Preserves current-main behavior for authority-code auth mode, saved/draft connection test guards, deploy checklist, and staging multitable open targets.

Supersedes #1305.

## Verification

- `pnpm --filter @metasheet/web exec vitest run --watch=false tests/k3WiseSetup.spec.ts`
- `pnpm --filter @metasheet/web type-check`
- `pnpm --filter @metasheet/web build`
- `pnpm run verify:integration-k3wise:poc`
- `git diff --check`

## Docs

- `docs/development/integration-k3wise-gate-readiness-ui-refresh-development-20260514.md`
- `docs/development/integration-k3wise-gate-readiness-ui-refresh-verification-20260514.md`
