### PR TITLE
feat(dingtalk): add directory org tree admin mirror

### DIFF
--- a/apps/web/src/views/DirectoryManagementView.vue
+++ b/apps/web/src/views/DirectoryManagementView.vue
@@ -370,6 +370,500 @@
         <section v-if="selectedIntegration" class="directory-admin__section">
           <div class="directory-admin__section-head">
             <div>
+              <h3>组织架构镜像</h3>
+              <p class="directory-admin__hint">
+                按需读取已同步的钉钉部门树；这里只展示本地目录镜像，不反写钉钉。
+              </p>
+            </div>
+            <button
+              class="directory-admin__button directory-admin__button--secondary"
+              type="button"
+              :disabled="loadingDepartments"
+              @click="void loadDepartments(selectedIntegration.id, { force: true })"
+            >
+              {{ loadingDepartments ? '加载中...' : departmentsLoaded ? '刷新组织架构' : '加载组织架构' }}
+            </button>
+          </div>
+          <div v-if="departmentsLoaded" class="directory-admin__chips">
+            <span class="directory-admin__chip">部门 {{ departmentRows.length }}</span>
+            <span v-if="departmentFilterActive" class="directory-admin__chip">匹配 {{ visibleDepartmentRows.length }}</span>
+            <span v-if="hasScopedDepartmentConfig" class="directory-admin__chip">
+              已配置 {{ configuredDepartmentCount }}
+            </span>
+            <span
+              v-if="departmentConfigReferenceIssues.length > 0"
+              class="directory-admin__chip directory-admin__chip--warning"
+            >
+              异常引用 {{ departmentConfigReferenceIssues.length }}
+            </span>
+            <span class="directory-admin__chip">成员 {{ departmentAccountCount }}</span>
+            <span class="directory-admin__chip">已绑定 {{ departmentLinkedAccountCount }}</span>
+            <span v-if="departmentUnlinkedAccountCount > 0" class="directory-admin__chip directory-admin__chip--warning">
+              未绑定 {{ departmentUnlinkedAccountCount }}
+            </span>
+            <span v-if="inactiveDepartmentCount > 0" class="directory-admin__chip directory-admin__chip--warning">
+              停用部门 {{ inactiveDepartmentCount }}
+            </span>
+          </div>
+          <div
+            v-if="departmentsLoaded && departmentRows.length > 0"
+            class="directory-admin__mirror-observation"
+            :class="{ 'directory-admin__mirror-observation--warning': departmentMirrorObservationHasWarnings }"
+          >
+            <div class="directory-admin__alert-head">
+              <div>
+                <strong>组织镜像同步观测</strong>
+                <p class="directory-admin__hint">
+                  {{ departmentMirrorObservationMessage }}
+                </p>
+              </div>
+              <button
+                class="directory-admin__link-button"
+                type="button"
+                @click="void copyDepartmentMirrorObservationReport()"
+              >
+                复制同步观测报告
+              </button>
+            </div>
+            <div class="directory-admin__chips">
+              <span
+                class="directory-admin__chip"
+                :class="departmentMirrorObservationHasWarnings ? 'directory-admin__chip--warning' : 'directory-admin__chip--success'"
+              >
+                最新批次 {{ formatDateTime(departmentMirrorLatestSeenAt) }}
+              </span>
+              <span class="directory-admin__chip">批次部门 {{ departmentMirrorCurrentBatchCount }}</span>
+              <span
+                v-if="departmentMirrorStaleSeenCount > 0"
+                class="directory-admin__chip directory-admin__chip--warning"
+              >
+                未在最新批次出现 {{ departmentMirrorStaleSeenCount }}
+              </span>
+              <span class="directory-admin__chip">最近更新 {{ formatDateTime(departmentMirrorLatestUpdatedAt) }}</span>
+              <span class="directory-admin__chip">集成上次成功 {{ formatDateTime(selectedIntegration.lastSuccessAt) }}</span>
+            </div>
+            <div class="directory-admin__department-actions">
+              <button
+                v-if="departmentMirrorStaleSeenCount > 0"
+                class="directory-admin__link-button"
+                type="button"
+                @click="focusDepartmentScopeFilter('staleBatch')"
+              >
+                查看非最新批次
+              </button>
+              <button
+                v-if="inactiveDepartmentCount > 0"
+                class="directory-admin__link-button"
+                type="button"
+                @click="focusDepartmentScopeFilter('inactive')"
+              >
+                查看停用部门
+              </button>
+              <button
+                v-if="departmentUnlinkedAccountCount > 0"
+                class="directory-admin__link-button"
+                type="button"
+                @click="focusDepartmentScopeFilter('unlinked')"
+              >
+                查看未绑定部门
+              </button>
+            </div>
+          </div>
+          <div
+            v-if="departmentsLoaded && departmentRows.length > 0"
+            class="directory-admin__department-scope-filters"
+          >
+            <button
+              v-for="option in departmentScopeFilterOptions"
+              :key="option.value"
+              class="directory-admin__button directory-admin__button--secondary"
+              :class="{ 'directory-admin__button--active': departmentScopeFilter === option.value }"
+              type="button"
+              @click="departmentScopeFilter = option.value"
+            >
+              {{ option.label }}{{ readDepartmentScopeFilterCount(option.value) }}
+            </button>
+            <button
+              v-if="departmentUnlinkedAccountCount > 0"
+              class="directory-admin__button directory-admin__button--secondary"
+              type="button"
+              @click="void copyDepartmentBindingGapReport()"
+            >
+              复制未绑定部门报告
+            </button>
+            <button
+              v-if="inactiveDepartmentCount > 0"
+              class="directory-admin__button directory-admin__button--secondary"
+              type="button"
+              @click="void copyInactiveDepartmentReport()"
+            >
+              复制停用部门报告
+            </button>
+          </div>
+          <label
+            v-if="departmentsLoaded && departmentRows.length > 0"
+            class="directory-admin__field directory-admin__field--wide directory-admin__department-search"
+          >
+            <span>筛选部门</span>
+            <input
+              v-model.trim="departmentQuery"
+              class="directory-admin__input"
+              type="search"
+              placeholder="输入部门名、部门 ID 或完整路径"
+            />
+          </label>
+          <div
+            v-if="departmentViewFilterActive"
+            class="directory-admin__department-filter-reset"
+          >
+            <button
+              class="directory-admin__link-button"
+              type="button"
+              @click="resetDepartmentViewFilters()"
+            >
+              清空部门筛选
+            </button>
+          </div>
+          <div
+            v-if="showVisibleDepartmentBulkActions"
+            class="directory-admin__visible-department-actions"
+          >
+            <p class="directory-admin__hint">
+              当前可见 {{ visibleDepartmentRows.length }} 个部门；批量增删仅更新当前草稿，保存前仍可继续检查和清理。
+            </p>
+            <label class="directory-admin__field directory-admin__field--wide">
+              <span>当前可见部门 ID 预览</span>
+              <textarea
+                class="directory-admin__input directory-admin__textarea directory-admin__visible-department-preview"
+                :rows="Math.min(visibleDepartmentRows.length, 6)"
+                :value="visibleDepartmentIdPreview"
+                readonly
+              />
+            </label>
+            <div class="directory-admin__department-actions">
+              <button
+                class="directory-admin__link-button"
+                type="button"
+                @click="void copyVisibleDepartmentIds()"
+              >
+                复制当前可见部门 ID
+              </button>
+              <button
+                class="directory-admin__link-button"
+                type="button"
+                @click="void copyVisibleDepartmentReport()"
+              >
+                复制当前可见部门报告
+              </button>
+              <button
+                class="directory-admin__link-button"
+                type="button"
+                @click="addVisibleDepartmentsToTarget('admission')"
+              >
+                批量加入当前可见到准入白名单
+              </button>
+              <button
+                class="directory-admin__link-button"
+                type="button"
+                @click="removeVisibleDepartmentsFromTarget('admission')"
+              >
+                从准入白名单移除当前可见
+              </button>
+              <button
+                class="directory-admin__link-button"
+                type="button"
+                @click="addVisibleDepartmentsToTarget('exclude')"
+              >
+                批量加入当前可见到排除部门
+              </button>
+              <button
+                class="directory-admin__link-button"
+                type="button"
+                @click="removeVisibleDepartmentsFromTarget('exclude')"
+              >
+                从排除部门移除当前可见
+              </button>
+              <button
+                class="directory-admin__link-button"
+                type="button"
+                @click="addVisibleDepartmentsToTarget('memberGroup')"
+              >
+                批量加入当前可见到成员组同步
+              </button>
+              <button
+                class="directory-admin__link-button"
+                type="button"
+                @click="removeVisibleDepartmentsFromTarget('memberGroup')"
+              >
+                从成员组同步移除当前可见
+              </button>
+            </div>
+          </div>
+          <div class="directory-admin__manual-department">
+            <div>
+              <strong>手动部门 ID</strong>
+              <p class="directory-admin__hint">
+                适用于钉钉部门暂未同步到本地镜像、但管理员已确认部门 ID 的场景；这里仍只写入当前配置草稿。
+              </p>
+            </div>
+            <div class="directory-admin__manual-department-fields">
+              <label class="directory-admin__field">
+                <span>部门 ID</span>
+                <input
+                  v-model.trim="manualDepartmentId"
+                  class="directory-admin__input"
+                  type="text"
+                  placeholder="例如 123456"
+                />
+              </label>
+              <label class="directory-admin__field">
+                <span>备注名称（可选）</span>
+                <input
+                  v-model.trim="manualDepartmentName"
+                  class="directory-admin__input"
+                  type="text"
+                  placeholder="例如 财务共享中心"
+                />
+              </label>
+            </div>
+            <div class="directory-admin__department-actions">
+              <button
+                class="directory-admin__link-button"
+                type="button"
+                :disabled="manualDepartmentId.trim().length === 0"
+                @click="addManualDepartmentToTarget('admission')"
+              >
+                手动加入准入白名单
+              </button>
+              <button
+                class="directory-admin__link-button"
+                type="button"
+                :disabled="manualDepartmentId.trim().length === 0"
+                @click="addManualDepartmentToTarget('exclude')"
+              >
+                手动加入排除部门
+              </button>
+              <button
+                class="directory-admin__link-button"
+                type="button"
+                :disabled="manualDepartmentId.trim().length === 0"
+                @click="addManualDepartmentToTarget('memberGroup')"
+              >
+                手动加入成员组同步
+              </button>
+            </div>
+          </div>
+          <div
+            v-if="hasDepartmentDraftScopeChanges"
+            class="directory-admin__draft-scope-changes"
+          >
+            <div class="directory-admin__alert-head">
+              <div>
+                <strong>部门范围草稿变更</strong>
+                <p class="directory-admin__hint">
+                  当前草稿与已保存配置不一致；保存前可复制报告给管理员复核。
+                </p>
+              </div>
+              <button
+                class="directory-admin__link-button"
+                type="button"
+                @click="void copyDepartmentDraftScopeChangeReport()"
+              >
+                复制草稿变更报告
+              </button>
+              <button
+                class="directory-admin__link-button"
+                type="button"
+                @click="restoreDepartmentScopeDraftsToSavedConfig()"
+              >
+                还原已保存范围
+              </button>
+            </div>
+            <div class="directory-admin__chips">
+              <span v-if="departmentDraftScopeAddedCount > 0" class="directory-admin__chip directory-admin__chip--success">
+                新增 {{ departmentDraftScopeAddedCount }}
+              </span>
+              <span v-if="departmentDraftScopeRemovedCount > 0" class="directory-admin__chip directory-admin__chip--warning">
+                移除 {{ departmentDraftScopeRemovedCount }}
+              </span>
+            </div>
+            <ul>
+              <li v-for="change in departmentDraftScopeChanges" :key="change.field">
+                <strong>{{ change.fieldLabel }}</strong>
+                <span v-if="change.added.length > 0" class="directory-admin__chip directory-admin__chip--success">
+                  新增 {{ change.added.join('、') }}
+                </span>
+                <span v-if="change.removed.length > 0" class="directory-admin__chip directory-admin__chip--warning">
+                  移除 {{ change.removed.join('、') }}
+                </span>
+                <button
+                  class="directory-admin__link-button"
+                  type="button"
+                  @click="restoreDepartmentScopeDraftToSavedConfig(change.field)"
+                >
+                  还原此范围
+                </button>
+              </li>
+            </ul>
+          </div>
+          <div
+            v-if="departmentsLoaded && hasScopedDepartmentConfig"
+            class="directory-admin__reference-issues"
+            :class="{ 'directory-admin__reference-issues--ok': departmentConfigReferenceIssues.length === 0 }"
+          >
+            <strong>配置引用检查</strong>
+            <div class="directory-admin__reference-actions">
+              <button
+                class="directory-admin__link-button"
+                type="button"
+                @click="void copyDepartmentConfigReferenceReport()"
+              >
+                复制配置引用报告
+              </button>
+            </div>
+            <p v-if="departmentConfigReferenceIssues.length === 0" class="directory-admin__hint">
+              当前准入、排除和成员组同步配置中的部门 ID 均能匹配已同步的有效部门。
+            </p>
+            <div v-else>
+              <div class="directory-admin__reference-actions">
+                <button
+                  class="directory-admin__link-button"
+                  type="button"
+                  @click="void copyDepartmentReferenceIssueReport()"
+                >
+                  复制异常引用报告
+                </button>
+                <button
+                  class="directory-admin__link-button"
+                  type="button"
+                  @click="removeAllDepartmentReferenceIssues()"
+                >
+                  清理全部异常引用
+                </button>
+              </div>
+              <ul>
+                <li v-for="issue in departmentConfigReferenceIssues" :key="issue.key">
+                  <span
+                    class="directory-admin__chip"
+                    :class="issue.kind === 'missing' ? 'directory-admin__chip--danger' : 'directory-admin__chip--warning'"
+                  >
+                    {{ issue.kind === 'missing' ? '未同步' : '已停用' }}
+                  </span>
+                  {{ readDepartmentReferenceIssueLabel(issue) }}
+                  <button
+                    class="directory-admin__link-button"
+                    type="button"
+                    @click="removeDepartmentFromTarget(issue.departmentId, issue.field)"
+                  >
+                    从{{ issue.fieldLabel }}移除
+                  </button>
+                </li>
+              </ul>
+            </div>
+          </div>
+          <p v-if="departmentLoadError" class="directory-admin__status directory-admin__status--error">
+            {{ departmentLoadError }}
+          </p>
+          <div v-if="loadingDepartments" class="directory-admin__empty">组织架构加载中...</div>
+          <div v-else-if="!departmentsLoaded" class="directory-admin__empty">
+            点击“加载组织架构”查看当前钉钉部门树、成员数量和本地绑定覆盖情况。
+          </div>
+          <div v-else-if="departmentRows.length === 0" class="directory-admin__empty">
+            暂无已同步部门；请先执行手动同步或检查根部门 ID。
+          </div>
+          <div v-else-if="visibleDepartmentRows.length === 0" class="directory-admin__empty">
+            {{ departmentTreeEmptyMessage }}
+          </div>
+          <div v-else class="directory-admin__department-tree">
+            <article
+              v-for="department in visibleDepartmentRows"
+              :key="department.id"
+              class="directory-admin__department-node"
+              :class="{ 'directory-admin__department-node--inactive': !department.isActive }"
+              :style="readDepartmentIndentStyle(department)"
+            >
+              <div>
+                <strong>{{ department.name }}</strong>
+                <p class="directory-admin__hint">
+                  {{ department.fullPath || department.name }} · 部门 ID {{ department.externalDepartmentId }}
+                </p>
+                <p class="directory-admin__hint">
+                  上级：{{ describeDepartmentParent(department) }} · 最近同步：{{ formatDateTime(department.updatedAt) }}
+                </p>
+              </div>
+              <div class="directory-admin__chips">
+                <span class="directory-admin__chip">成员 {{ department.accountCount }}</span>
+                <span class="directory-admin__chip">已绑定 {{ department.linkedAccountCount }}</span>
+                <span
+                  v-if="readDepartmentUnlinkedAccountCount(department) > 0"
+                  class="directory-admin__chip directory-admin__chip--warning"
+                >
+                  未绑定 {{ readDepartmentUnlinkedAccountCount(department) }}
+                </span>
+                <span v-if="department.childCount > 0" class="directory-admin__chip">子部门 {{ department.childCount }}</span>
+                <span v-if="!department.isActive" class="directory-admin__chip directory-admin__chip--warning">已停用</span>
+                <span
+                  v-if="!isDepartmentInLatestMirrorBatch(department)"
+                  class="directory-admin__chip directory-admin__chip--warning"
+                >
+                  非最新批次
+                </span>
+                <span
+                  v-if="departmentConfigScope.admission.has(department.externalDepartmentId)"
+                  class="directory-admin__chip directory-admin__chip--success"
+                >
+                  准入白名单
+                </span>
+                <span
+                  v-if="departmentConfigScope.exclude.has(department.externalDepartmentId)"
+                  class="directory-admin__chip directory-admin__chip--warning"
+                >
+                  排除部门
+                </span>
+                <span
+                  v-if="departmentConfigScope.memberGroup.has(department.externalDepartmentId)"
+                  class="directory-admin__chip directory-admin__chip--success"
+                >
+                  成员组同步
+                </span>
+              </div>
+              <div class="directory-admin__department-actions">
+                <button
+                  class="directory-admin__link-button"
+                  type="button"
+                  @click="void copyDepartmentId(department)"
+                >
+                  复制部门 ID
+                </button>
+                <button
+                  class="directory-admin__link-button"
+                  type="button"
+                  @click="addDepartmentToTarget(department, 'admission')"
+                >
+                  加入准入白名单
+                </button>
+                <button
+                  class="directory-admin__link-button"
+                  type="button"
+                  @click="addDepartmentToTarget(department, 'exclude')"
+                >
+                  加入排除部门
+                </button>
+                <button
+                  class="directory-admin__link-button"
+                  type="button"
+                  @click="addDepartmentToTarget(department, 'memberGroup')"
+                >
+                  加入成员组同步
+                </button>
+              </div>
+            </article>
+          </div>
+        </section>
+
+        <section v-if="selectedIntegration" class="directory-admin__section">
+          <div class="directory-admin__section-head">
+            <div>
               <h3>待处理队列</h3>
               <p class="directory-admin__hint">展示待绑定、目录停用待停权、缺少钉钉身份标识的成员。</p>
               <p class="directory-admin__hint">
@@ -1385,6 +1879,7 @@ type DirectoryScheduleSnapshot = {
 }
 
 type DirectoryAlertFilter = 'all' | 'pending' | 'acknowledged'
+type DirectoryDepartmentScopeFilter = 'all' | 'configured' | 'issues' | 'inactive' | 'unlinked' | 'staleBatch' | DirectoryDepartmentTargetField
 
 type DirectorySyncAlert = {
   id: string
@@ -1475,6 +1970,45 @@ type DirectoryAccount = {
     name: string | null
   } | null
   departmentPaths: string[]
+}
+
+type DirectoryDepartment = {
+  id: string
+  integrationId: string
+  provider: string
+  externalDepartmentId: string
+  parentExternalDepartmentId: string | null
+  name: string
+  fullPath: string | null
+  orderIndex: number
+  isActive: boolean
+  lastSeenAt: string
+  updatedAt: string
+  accountCount: number
+  linkedAccountCount: number
+  childCount: number
+}
+
+type DirectoryDepartmentTreeRow = DirectoryDepartment & {
+  depth: number
+}
+
+type DirectoryDepartmentTargetField = 'admission' | 'exclude' | 'memberGroup'
+
+type DirectoryDepartmentReferenceIssue = {
+  key: string
+  field: DirectoryDepartmentTargetField
+  fieldLabel: string
+  kind: 'missing' | 'inactive'
+  departmentId: string
+  departmentName: string
+}
+
+type DirectoryDepartmentScopeChange = {
+  field: DirectoryDepartmentTargetField
+  fieldLabel: string
+  added: string[]
+  removed: string[]
 }
 
 type LocalUserOption = {
@@ -1586,6 +2120,7 @@ type DirectoryDraft = {
 const integrations = ref<DirectoryIntegration[]>([])
 const runs = ref<DirectoryRun[]>([])
 const accounts = ref<DirectoryAccount[]>([])
+const departments = ref<DirectoryDepartment[]>([])
 const scheduleSnapshot = ref<DirectoryScheduleSnapshot | null>(null)
 const alerts = ref<DirectorySyncAlert[]>([])
 const reviewItems = ref<DirectoryReviewItem[]>([])
@@ -1604,6 +2139,7 @@ const loadingAlerts = ref(false)
 const loadingReviewItems = ref(false)
 const loadingMoreReviewItems = ref(false)
 const loadingAccounts = ref(false)
+const loadingDepartments = ref(false)
 const busy = ref(false)
 const bindingAccountId = ref('')
 const unbindingAccountId = ref('')
@@ -1616,6 +2152,12 @@ const statusTone = ref<'info' | 'error'>('info')
 const routeNavigationFailureNotice = ref<DirectoryRouteNavigationFailureNotice | null>(null)
 const routeNavigationFailureAction = ref<'retry' | 'clear' | ''>('')
 const testResult = ref<TestResult | null>(null)
+const departmentsLoaded = ref(false)
+const departmentLoadError = ref('')
+const departmentQuery = ref('')
+const departmentScopeFilter = ref<DirectoryDepartmentScopeFilter>('all')
+const manualDepartmentId = ref('')
+const manualDepartmentName = ref('')
 const accountQuery = ref('')
 const alertFilter = ref<DirectoryAlertFilter>('all')
 const reviewFilter = ref<DirectoryReviewItemFilter>('all')
@@ -1661,6 +2203,18 @@ const pendingBindingManualReasonOptions = [
   { value: 'no_exact_match' as const, label: '无精确匹配' },
   { value: 'conflict' as const, label: '冲突待复核' },
 ]
+const departmentScopeFilterOptions = [
+  { value: 'all' as const, label: '全部部门' },
+  { value: 'unlinked' as const, label: '只看未全绑定' },
+  { value: 'inactive' as const, label: '只看停用部门' },
+  { value: 'staleBatch' as const, label: '只看非最新批次' },
+  { value: 'configured' as const, label: '只看已配置' },
+  { value: 'issues' as const, label: '只看异常' },
+  { value: 'admission' as const, label: '只看准入' },
+  { value: 'exclude' as const, label: '只看排除' },
+  { value: 'memberGroup' as const, label: '只看成员组同步' },
+]
+const departmentTargetFields: DirectoryDepartmentTargetField[] = ['admission', 'exclude', 'memberGroup']
 const directoryNavigation = ref(readInitialDirectoryNavigation())
 
 const draft = reactive<DirectoryDraft>({
@@ -1752,6 +2306,146 @@ const showPendingBindingManualReasonFilters = computed(() => (
 const focusedVisibleAccount = computed(() => (
   accounts.value.find((account) => account.id === focusedAccountId.value) ?? null
 ))
+const departmentRows = computed(() => buildDirectoryDepartmentTreeRows(departments.value))
+const departmentFilterActive = computed(() => departmentQuery.value.trim().length > 0)
+const departmentAccountCount = computed(() =>
+  departmentRows.value.reduce((sum, department) => sum + department.accountCount, 0),
+)
+const departmentLinkedAccountCount = computed(() =>
+  departmentRows.value.reduce((sum, department) => sum + department.linkedAccountCount, 0),
+)
+const departmentUnlinkedAccountCount = computed(() =>
+  departmentRows.value.reduce((sum, department) => sum + readDepartmentUnlinkedAccountCount(department), 0),
+)
+const departmentUnlinkedMirrorCount = computed(() =>
+  departmentRows.value.filter((department) => readDepartmentUnlinkedAccountCount(department) > 0).length,
+)
+const inactiveDepartmentCount = computed(() =>
+  departmentRows.value.filter((department) => !department.isActive).length,
+)
+const departmentMirrorLatestSeenAt = computed(() =>
+  readLatestDepartmentTimestamp(departmentRows.value, 'lastSeenAt'),
+)
+const departmentMirrorLatestUpdatedAt = computed(() =>
+  readLatestDepartmentTimestamp(departmentRows.value, 'updatedAt'),
+)
+const departmentMirrorCurrentBatchCount = computed(() => {
+  const latestSeenAtMs = readTimestampMs(departmentMirrorLatestSeenAt.value)
+  if (latestSeenAtMs === null) return departmentRows.value.length
+  return departmentRows.value.filter((department) => readTimestampMs(department.lastSeenAt) === latestSeenAtMs).length
+})
+const departmentMirrorStaleSeenCount = computed(() =>
+  Math.max(0, departmentRows.value.length - departmentMirrorCurrentBatchCount.value),
+)
+const departmentMirrorObservationHasWarnings = computed(() =>
+  departmentMirrorStaleSeenCount.value > 0 || inactiveDepartmentCount.value > 0,
+)
+const departmentMirrorObservationMessage = computed(() => {
+  if (departmentMirrorStaleSeenCount.value > 0) {
+    return `有 ${departmentMirrorStaleSeenCount.value} 个部门未出现在最新同步批次，建议复核是否为钉钉侧停用或本地镜像滞后。`
+  }
+  if (inactiveDepartmentCount.value > 0) {
+    return `最新镜像中存在 ${inactiveDepartmentCount.value} 个停用部门，建议复核配置引用后再清理。`
+  }
+  return '本地组织镜像批次一致，未发现停用或跨批次部门。'
+})
+const departmentConfigScope = computed<Record<DirectoryDepartmentTargetField, Set<string>>>(() => ({
+  admission: new Set(parseAdmissionDepartmentIdsText(draft.admissionDepartmentIdsText)),
+  exclude: new Set(parseAdmissionDepartmentIdsText(draft.excludeDepartmentIdsText)),
+  memberGroup: new Set(parseAdmissionDepartmentIdsText(draft.memberGroupDepartmentIdsText)),
+}))
+const departmentSavedConfigScope = computed<Record<DirectoryDepartmentTargetField, Set<string>>>(() => ({
+  admission: new Set(readSavedDepartmentTargetIds('admission')),
+  exclude: new Set(readSavedDepartmentTargetIds('exclude')),
+  memberGroup: new Set(readSavedDepartmentTargetIds('memberGroup')),
+}))
+const departmentDraftScopeChanges = computed(() =>
+  buildDepartmentScopeChanges(departmentConfigScope.value, departmentSavedConfigScope.value),
+)
+const hasDepartmentDraftScopeChanges = computed(() => departmentDraftScopeChanges.value.length > 0)
+const departmentDraftScopeAddedCount = computed(() =>
+  departmentDraftScopeChanges.value.reduce((sum, change) => sum + change.added.length, 0),
+)
+const departmentDraftScopeRemovedCount = computed(() =>
+  departmentDraftScopeChanges.value.reduce((sum, change) => sum + change.removed.length, 0),
+)
+const hasScopedDepartmentConfig = computed(() =>
+  departmentTargetFields.some((field) => departmentConfigScope.value[field].size > 0),
+)
+const departmentConfigReferenceIssues = computed(() =>
+  buildDepartmentConfigReferenceIssues(departments.value, departmentConfigScope.value),
+)
+const configuredDepartmentIds = computed(() => buildConfiguredDepartmentIdSet(departmentConfigScope.value))
+const configuredDepartmentCount = computed(() => configuredDepartmentIds.value.size)
+const departmentReferenceIssueIds = computed(() => new Set(
+  departmentConfigReferenceIssues.value.map((issue) => issue.departmentId),
+))
+const configuredDepartmentMirrorCount = computed(() => departmentRows.value.filter((department) =>
+  configuredDepartmentIds.value.has(department.externalDepartmentId),
+).length)
+const issueDepartmentMirrorCount = computed(() => departmentRows.value.filter((department) =>
+  departmentReferenceIssueIds.value.has(department.externalDepartmentId),
+).length)
+const scopeFilteredDepartmentRows = computed(() =>
+  filterDirectoryDepartmentRowsByScope(
+    departmentRows.value,
+    departmentScopeFilter.value,
+    configuredDepartmentIds.value,
+    departmentReferenceIssueIds.value,
+    departmentConfigScope.value,
+  ),
+)
+const visibleDepartmentRows = computed(() =>
+  filterDirectoryDepartmentRows(scopeFilteredDepartmentRows.value, departmentQuery.value),
+)
+const visibleDepartmentIdPreview = computed(() =>
+  visibleDepartmentRows.value.map((department) => department.externalDepartmentId).join('\n'),
+)
+const departmentViewFilterActive = computed(() =>
+  departmentFilterActive.value || departmentScopeFilter.value !== 'all',
+)
+const showVisibleDepartmentBulkActions = computed(() =>
+  visibleDepartmentRows.value.length > 0
+  && departmentViewFilterActive.value,
+)
+const departmentTreeEmptyMessage = computed(() => {
+  const query = departmentQuery.value.trim()
+  const hasQuery = query.length > 0
+  if (departmentScopeFilter.value === 'configured') {
+    return hasQuery
+      ? `没有匹配“${query}”的已配置部门；可清空筛选或切回全部部门。`
+      : '当前草稿没有可在组织架构镜像中展示的已配置部门；未同步引用请查看配置引用检查。'
+  }
+  if (departmentScopeFilter.value === 'issues') {
+    return hasQuery
+      ? `没有匹配“${query}”的异常部门；未同步引用请查看配置引用检查。`
+      : '当前没有可在组织架构镜像中展示的异常部门；未同步引用请查看配置引用检查。'
+  }
+  if (departmentScopeFilter.value === 'unlinked') {
+    return hasQuery
+      ? `没有匹配“${query}”的未全绑定部门；可清空筛选或切回全部部门。`
+      : '当前没有未完全绑定的部门。'
+  }
+  if (departmentScopeFilter.value === 'inactive') {
+    return hasQuery
+      ? `没有匹配“${query}”的停用部门；可清空筛选或切回全部部门。`
+      : '当前没有停用部门。'
+  }
+  if (departmentScopeFilter.value === 'staleBatch') {
+    return hasQuery
+      ? `没有匹配“${query}”的非最新批次部门；可清空筛选或切回全部部门。`
+      : '当前没有非最新批次部门。'
+  }
+  if (departmentTargetFields.includes(departmentScopeFilter.value as DirectoryDepartmentTargetField)) {
+    const targetLabel = readDepartmentTargetLabel(departmentScopeFilter.value as DirectoryDepartmentTargetField)
+    return hasQuery
+      ? `没有匹配“${query}”的${targetLabel}部门；可清空筛选或切回全部部门。`
+      : `当前草稿没有可在组织架构镜像中展示的${targetLabel}部门；未同步引用请查看配置引用检查。`
+  }
+  return hasQuery
+    ? `没有匹配“${query}”的部门；可按部门名、部门 ID 或完整路径筛选。`
+    : '没有可展示的部门。'
+})
 const focusedVisibleAccountBindDraft = computed(() => {
   if (!focusedVisibleAccount.value) return ''
   return readBindingDraft(focusedVisibleAccount.value).trim()
@@ -1889,6 +2583,13 @@ function resetDraft() {
   testResult.value = null
   runs.value = []
   accounts.value = []
+  departments.value = []
+  departmentsLoaded.value = false
+  departmentLoadError.value = ''
+  departmentQuery.value = ''
+  departmentScopeFilter.value = 'all'
+  manualDepartmentId.value = ''
+  manualDepartmentName.value = ''
   reviewBatchProgress.value = null
   scheduleSnapshot.value = null
   alerts.value = []
@@ -1969,6 +2670,628 @@ function parseAdmissionDepartmentIdsText(value: string): string[] {
   ))
 }
 
+function readDepartmentTargetText(field: DirectoryDepartmentTargetField): string {
+  if (field === 'exclude') return draft.excludeDepartmentIdsText
+  if (field === 'memberGroup') return draft.memberGroupDepartmentIdsText
+  return draft.admissionDepartmentIdsText
+}
+
+function writeDepartmentTargetText(field: DirectoryDepartmentTargetField, ids: string[]): void {
+  const nextValue = ids.join('\n')
+  if (field === 'exclude') {
+    draft.excludeDepartmentIdsText = nextValue
+    return
+  }
+  if (field === 'memberGroup') {
+    draft.memberGroupDepartmentIdsText = nextValue
+    return
+  }
+  draft.admissionDepartmentIdsText = nextValue
+}
+
+function readDepartmentTargetLabel(field: DirectoryDepartmentTargetField): string {
+  if (field === 'exclude') return '排除部门'
+  if (field === 'memberGroup') return '成员组同步部门'
+  return '准入白名单'
+}
+
+function readSavedDepartmentTargetIds(field: DirectoryDepartmentTargetField): string[] {
+  const integration = selectedIntegration.value
+  if (!integration) return []
+  if (field === 'exclude') return integration.config.excludeDepartmentIds
+  if (field === 'memberGroup') return integration.config.memberGroupDepartmentIds
+  return integration.config.admissionDepartmentIds
+}
+
+function buildConfiguredDepartmentIdSet(
+  scope: Record<DirectoryDepartmentTargetField, Set<string>>,
+): Set<string> {
+  const ids = new Set<string>()
+  for (const field of departmentTargetFields) {
+    for (const departmentId of scope[field]) ids.add(departmentId)
+  }
+  return ids
+}
+
+function buildDepartmentScopeChanges(
+  draftScope: Record<DirectoryDepartmentTargetField, Set<string>>,
+  savedScope: Record<DirectoryDepartmentTargetField, Set<string>>,
+): DirectoryDepartmentScopeChange[] {
+  return departmentTargetFields
+    .map((field) => {
+      const added = Array.from(draftScope[field]).filter((departmentId) => !savedScope[field].has(departmentId))
+      const removed = Array.from(savedScope[field]).filter((departmentId) => !draftScope[field].has(departmentId))
+      return {
+        field,
+        fieldLabel: readDepartmentTargetLabel(field),
+        added,
+        removed,
+      }
+    })
+    .filter((change) => change.added.length > 0 || change.removed.length > 0)
+}
+
+function readTimestampMs(value: string | null | undefined): number | null {
+  if (!value) return null
+  const timestamp = Date.parse(value)
+  return Number.isNaN(timestamp) ? null : timestamp
+}
+
+function readLatestDepartmentTimestamp(
+  rows: DirectoryDepartment[],
+  field: 'lastSeenAt' | 'updatedAt',
+): string | null {
+  let latestValue: string | null = null
+  let latestTimestamp: number | null = null
+  for (const department of rows) {
+    const timestamp = readTimestampMs(department[field])
+    if (timestamp === null) continue
+    if (latestTimestamp === null || timestamp > latestTimestamp) {
+      latestTimestamp = timestamp
+      latestValue = department[field]
+    }
+  }
+  return latestValue
+}
+
+function isDepartmentInLatestMirrorBatch(department: DirectoryDepartment): boolean {
+  const latestSeenAtMs = readTimestampMs(departmentMirrorLatestSeenAt.value)
+  if (latestSeenAtMs === null) return true
+  return readTimestampMs(department.lastSeenAt) === latestSeenAtMs
+}
+
+function readDepartmentUnlinkedAccountCount(department: DirectoryDepartment): number {
+  return Math.max(0, department.accountCount - department.linkedAccountCount)
+}
+
+function filterDirectoryDepartmentRowsByScope(
+  rows: DirectoryDepartmentTreeRow[],
+  filter: DirectoryDepartmentScopeFilter,
+  configuredIds: Set<string>,
+  issueIds: Set<string>,
+  scope: Record<DirectoryDepartmentTargetField, Set<string>>,
+): DirectoryDepartmentTreeRow[] {
+  if (filter === 'unlinked') {
+    return rows.filter((department) => readDepartmentUnlinkedAccountCount(department) > 0)
+  }
+  if (filter === 'inactive') {
+    return rows.filter((department) => !department.isActive)
+  }
+  if (filter === 'staleBatch') {
+    return rows.filter((department) => !isDepartmentInLatestMirrorBatch(department))
+  }
+  if (filter === 'configured') {
+    return rows.filter((department) => configuredIds.has(department.externalDepartmentId))
+  }
+  if (filter === 'issues') {
+    return rows.filter((department) => issueIds.has(department.externalDepartmentId))
+  }
+  if (departmentTargetFields.includes(filter as DirectoryDepartmentTargetField)) {
+    const field = filter as DirectoryDepartmentTargetField
+    return rows.filter((department) => scope[field].has(department.externalDepartmentId))
+  }
+  return rows
+}
+
+function readDepartmentScopeFilterCount(filter: DirectoryDepartmentScopeFilter): string {
+  if (filter === 'unlinked') return departmentUnlinkedMirrorCount.value > 0 ? ` (${departmentUnlinkedMirrorCount.value})` : ''
+  if (filter === 'inactive') return inactiveDepartmentCount.value > 0 ? ` (${inactiveDepartmentCount.value})` : ''
+  if (filter === 'staleBatch') return departmentMirrorStaleSeenCount.value > 0 ? ` (${departmentMirrorStaleSeenCount.value})` : ''
+  if (filter === 'configured') return configuredDepartmentMirrorCount.value > 0 ? ` (${configuredDepartmentMirrorCount.value})` : ''
+  if (filter === 'issues') return issueDepartmentMirrorCount.value > 0 ? ` (${issueDepartmentMirrorCount.value})` : ''
+  if (departmentTargetFields.includes(filter as DirectoryDepartmentTargetField)) {
+    const field = filter as DirectoryDepartmentTargetField
+    const count = departmentRows.value.filter((department) =>
+      departmentConfigScope.value[field].has(department.externalDepartmentId),
+    ).length
+    return count > 0 ? ` (${count})` : ''
+  }
+  return ''
+}
+
+function readDepartmentScopeFilterLabel(filter: DirectoryDepartmentScopeFilter): string {
+  return departmentScopeFilterOptions.find((option) => option.value === filter)?.label ?? '全部部门'
+}
+
+function resetDepartmentViewFilters(): void {
+  departmentQuery.value = ''
+  departmentScopeFilter.value = 'all'
+}
+
+function focusDepartmentScopeFilter(filter: DirectoryDepartmentScopeFilter): void {
+  departmentQuery.value = ''
+  departmentScopeFilter.value = filter
+}
+
+function restoreDepartmentScopeDraftsToSavedConfig(): void {
+  draft.admissionDepartmentIdsText = readSavedDepartmentTargetIds('admission').join('\n')
+  draft.excludeDepartmentIdsText = readSavedDepartmentTargetIds('exclude').join('\n')
+  draft.memberGroupDepartmentIdsText = readSavedDepartmentTargetIds('memberGroup').join('\n')
+  setStatus('已还原部门范围草稿为已保存配置')
+}
+
+function restoreDepartmentScopeDraftToSavedConfig(field: DirectoryDepartmentTargetField): void {
+  writeDepartmentTargetText(field, readSavedDepartmentTargetIds(field))
+  setStatus(`已还原${readDepartmentTargetLabel(field)}为已保存配置`)
+}
+
+async function writeClipboardText(
+  value: string,
+  successMessage: string,
+  options: {
+    emptyMessage?: string
+    unsupportedMessage?: string
+    failureMessage?: string
+  } = {},
+): Promise<void> {
+  const text = value.trim()
+  if (text.length === 0) {
+    setStatus(options.emptyMessage ?? '没有可复制的部门 ID', 'error')
+    return
+  }
+  if (typeof navigator === 'undefined' || !navigator.clipboard?.writeText) {
+    setStatus(options.unsupportedMessage ?? '当前浏览器不支持自动复制，请从预览框手动复制部门 ID', 'error')
+    return
+  }
+  try {
+    await navigator.clipboard.writeText(text)
+    setStatus(successMessage)
+  } catch {
+    setStatus(options.failureMessage ?? '复制部门 ID 失败，请从预览框手动复制', 'error')
+  }
+}
+
+async function copyVisibleDepartmentIds(): Promise<void> {
+  await writeClipboardText(
+    visibleDepartmentIdPreview.value,
+    `已复制 ${visibleDepartmentRows.value.length} 个当前可见部门 ID`,
+  )
+}
+
+function buildVisibleDepartmentReport(): string {
+  if (visibleDepartmentRows.value.length === 0) return ''
+  const integrationName = selectedIntegration.value?.name ?? '未选择集成'
+  const query = departmentQuery.value.trim()
+  const lines = [
+    'DingTalk organization visible department report',
+    `Integration: ${integrationName}`,
+    `Scope filter: ${readDepartmentScopeFilterLabel(departmentScopeFilter.value)}`,
+    `Search query: ${query.length > 0 ? query : 'none'}`,
+    `Visible department count: ${visibleDepartmentRows.value.length}`,
+    `Latest mirror batch: ${departmentMirrorLatestSeenAt.value ?? 'not_recorded'}`,
+    '',
+    ...visibleDepartmentRows.value.map((department, index) => {
+      const name = department.fullPath || department.name
+      const activeStatus = department.isActive ? 'active_department' : 'inactive_department'
+      const batchStatus = isDepartmentInLatestMirrorBatch(department) ? 'latest_batch' : 'not_latest_batch'
+      const gapCount = readDepartmentUnlinkedAccountCount(department)
+      return `${index + 1}. [${activeStatus}; ${batchStatus}] ${department.externalDepartmentId} · ${name} · members=${department.accountCount} · linked=${department.linkedAccountCount} · unlinked=${gapCount}`
+    }),
+  ]
+  return lines.join('\n')
+}
+
+async function copyVisibleDepartmentReport(): Promise<void> {
+  await writeClipboardText(
+    buildVisibleDepartmentReport(),
+    `已复制 ${visibleDepartmentRows.value.length} 个当前可见部门报告`,
+    {
+      emptyMessage: '当前没有可复制的可见部门',
+      unsupportedMessage: '当前浏览器不支持自动复制，请手动复制当前可见部门内容',
+      failureMessage: '复制当前可见部门报告失败，请手动复制当前可见部门内容',
+    },
+  )
+}
+
+async function copyDepartmentId(department: DirectoryDepartment): Promise<void> {
+  await writeClipboardText(
+    department.externalDepartmentId,
+    `已复制部门 ${department.name} (${department.externalDepartmentId}) 的 ID`,
+  )
+}
+
+function buildDepartmentReferenceIssueReport(): string {
+  const issues = departmentConfigReferenceIssues.value
+  if (issues.length === 0) return ''
+  const integrationName = selectedIntegration.value?.name ?? '未选择集成'
+  const lines = [
+    'DingTalk organization reference issue report',
+    `Integration: ${integrationName}`,
+    `Issue count: ${issues.length}`,
+    '',
+    ...issues.map((issue, index) => {
+      const status = issue.kind === 'missing' ? 'missing_from_mirror' : 'inactive_department'
+      return `${index + 1}. [${status}] ${readDepartmentReferenceIssueLabel(issue)}`
+    }),
+  ]
+  return lines.join('\n')
+}
+
+function describeDepartmentConfigReference(
+  departmentId: string,
+  departmentByExternalId: Map<string, DirectoryDepartment>,
+): string {
+  const department = departmentByExternalId.get(departmentId)
+  if (!department) return `${departmentId} · missing_from_mirror`
+  const status = department.isActive ? 'active_department' : 'inactive_department'
+  const name = department.fullPath || department.name
+  return `${departmentId} · ${status} · ${name}`
+}
+
+function buildDepartmentConfigReferenceReport(): string {
+  const departmentByExternalId = new Map(departments.value.map((department) => [department.externalDepartmentId, department]))
+  const integrationName = selectedIntegration.value?.name ?? '未选择集成'
+  const lines = [
+    'DingTalk organization configuration reference report',
+    `Integration: ${integrationName}`,
+    `Configured unique department IDs: ${configuredDepartmentCount.value}`,
+    `Mirror departments loaded: ${departments.value.length}`,
+    `Reference issue count: ${departmentConfigReferenceIssues.value.length}`,
+  ]
+  for (const field of departmentTargetFields) {
+    const ids = parseAdmissionDepartmentIdsText(readDepartmentTargetText(field))
+    lines.push('', `[${readDepartmentTargetLabel(field)}]`)
+    if (ids.length === 0) {
+      lines.push('- none')
+      continue
+    }
+    for (const departmentId of ids) {
+      lines.push(`- ${describeDepartmentConfigReference(departmentId, departmentByExternalId)}`)
+    }
+  }
+  return lines.join('\n')
+}
+
+function buildDepartmentBindingGapReport(): string {
+  const gapDepartments = departmentRows.value.filter((department) => readDepartmentUnlinkedAccountCount(department) > 0)
+  if (gapDepartments.length === 0) return ''
+  const integrationName = selectedIntegration.value?.name ?? '未选择集成'
+  const lines = [
+    'DingTalk organization binding gap report',
+    `Integration: ${integrationName}`,
+    `Unlinked member count: ${departmentUnlinkedAccountCount.value}`,
+    `Departments with gaps: ${gapDepartments.length}`,
+    '',
+    ...gapDepartments.map((department, index) => {
+      const status = department.isActive ? 'active_department' : 'inactive_department'
+      const name = department.fullPath || department.name
+      const gapCount = readDepartmentUnlinkedAccountCount(department)
+      return `${index + 1}. [${status}] ${department.externalDepartmentId} · ${name} · members=${department.accountCount} · linked=${department.linkedAccountCount} · unlinked=${gapCount}`
+    }),
+  ]
+  return lines.join('\n')
+}
+
+function buildInactiveDepartmentReport(): string {
+  const inactiveDepartments = departmentRows.value.filter((department) => !department.isActive)
+  if (inactiveDepartments.length === 0) return ''
+  const integrationName = selectedIntegration.value?.name ?? '未选择集成'
+  const lines = [
+    'DingTalk organization inactive department report',
+    `Integration: ${integrationName}`,
+    `Inactive department count: ${inactiveDepartments.length}`,
+    '',
+    ...inactiveDepartments.map((department, index) => {
+      const name = department.fullPath || department.name
+      const gapCount = readDepartmentUnlinkedAccountCount(department)
+      return `${index + 1}. [inactive_department] ${department.externalDepartmentId} · ${name} · members=${department.accountCount} · linked=${department.linkedAccountCount} · unlinked=${gapCount}`
+    }),
+  ]
+  return lines.join('\n')
+}
+
+function buildDepartmentMirrorObservationReport(): string {
+  if (departmentRows.value.length === 0) return ''
+  const integrationName = selectedIntegration.value?.name ?? '未选择集成'
+  const staleDepartments = departmentRows.value.filter((department) => !isDepartmentInLatestMirrorBatch(department))
+  const lines = [
+    'DingTalk organization mirror observation report',
+    `Integration: ${integrationName}`,
+    `Latest mirror batch: ${departmentMirrorLatestSeenAt.value ?? 'not_recorded'}`,
+    `Latest mirror update: ${departmentMirrorLatestUpdatedAt.value ?? 'not_recorded'}`,
+    `Integration last successful sync: ${selectedIntegration.value?.lastSuccessAt ?? 'not_recorded'}`,
+    `Mirror department count: ${departmentRows.value.length}`,
+    `Current batch departments: ${departmentMirrorCurrentBatchCount.value}`,
+    `Not seen in latest batch: ${departmentMirrorStaleSeenCount.value}`,
+    `Inactive departments: ${inactiveDepartmentCount.value}`,
+    `Unlinked member count: ${departmentUnlinkedAccountCount.value}`,
+  ]
+  if (staleDepartments.length > 0) {
+    lines.push('', '[not_seen_in_latest_batch]')
+    for (const department of staleDepartments) {
+      const name = department.fullPath || department.name
+      lines.push(`- ${department.externalDepartmentId} · ${name} · active=${department.isActive ? 'yes' : 'no'} · lastSeenAt=${department.lastSeenAt}`)
+    }
+  }
+  return lines.join('\n')
+}
+
+function buildDepartmentDraftScopeChangeReport(): string {
+  if (departmentDraftScopeChanges.value.length === 0) return ''
+  const departmentByExternalId = new Map(departments.value.map((department) => [department.externalDepartmentId, department]))
+  const integrationName = selectedIntegration.value?.name ?? '未选择集成'
+  const lines = [
+    'DingTalk organization draft scope change report',
+    `Integration: ${integrationName}`,
+    `Changed fields: ${departmentDraftScopeChanges.value.length}`,
+    `Added department references: ${departmentDraftScopeAddedCount.value}`,
+    `Removed department references: ${departmentDraftScopeRemovedCount.value}`,
+  ]
+  for (const change of departmentDraftScopeChanges.value) {
+    lines.push('', `[${change.fieldLabel}]`)
+    if (change.added.length > 0) {
+      lines.push('added:')
+      for (const departmentId of change.added) {
+        lines.push(`- ${describeDepartmentConfigReference(departmentId, departmentByExternalId)}`)
+      }
+    }
+    if (change.removed.length > 0) {
+      lines.push('removed:')
+      for (const departmentId of change.removed) {
+        lines.push(`- ${describeDepartmentConfigReference(departmentId, departmentByExternalId)}`)
+      }
+    }
+  }
+  return lines.join('\n')
+}
+
+async function copyDepartmentReferenceIssueReport(): Promise<void> {
+  await writeClipboardText(
+    buildDepartmentReferenceIssueReport(),
+    `已复制 ${departmentConfigReferenceIssues.value.length} 条异常引用报告`,
+    {
+      emptyMessage: '当前没有可复制的异常引用',
+      unsupportedMessage: '当前浏览器不支持自动复制，请手动复制异常引用内容',
+      failureMessage: '复制异常引用报告失败，请手动复制异常引用内容',
+    },
+  )
+}
+
+async function copyDepartmentConfigReferenceReport(): Promise<void> {
+  await writeClipboardText(
+    buildDepartmentConfigReferenceReport(),
+    `已复制 ${configuredDepartmentCount.value} 个配置部门引用报告`,
+    {
+      emptyMessage: '当前没有可复制的部门配置引用',
+      unsupportedMessage: '当前浏览器不支持自动复制，请手动复制配置引用内容',
+      failureMessage: '复制配置引用报告失败，请手动复制配置引用内容',
+    },
+  )
+}
+
+async function copyDepartmentBindingGapReport(): Promise<void> {
+  await writeClipboardText(
+    buildDepartmentBindingGapReport(),
+    `已复制 ${departmentUnlinkedMirrorCount.value} 个未全绑定部门报告`,
+    {
+      emptyMessage: '当前没有可复制的未绑定部门',
+      unsupportedMessage: '当前浏览器不支持自动复制，请手动复制未绑定部门内容',
+      failureMessage: '复制未绑定部门报告失败，请手动复制未绑定部门内容',
+    },
+  )
+}
+
+async function copyInactiveDepartmentReport(): Promise<void> {
+  await writeClipboardText(
+    buildInactiveDepartmentReport(),
+    `已复制 ${inactiveDepartmentCount.value} 个停用部门报告`,
+    {
+      emptyMessage: '当前没有可复制的停用部门',
+      unsupportedMessage: '当前浏览器不支持自动复制，请手动复制停用部门内容',
+      failureMessage: '复制停用部门报告失败，请手动复制停用部门内容',
+    },
+  )
+}
+
+async function copyDepartmentMirrorObservationReport(): Promise<void> {
+  await writeClipboardText(
+    buildDepartmentMirrorObservationReport(),
+    `已复制 ${departmentRows.value.length} 个部门的同步观测报告`,
+    {
+      emptyMessage: '当前没有可复制的同步观测数据',
+      unsupportedMessage: '当前浏览器不支持自动复制，请手动复制同步观测内容',
+      failureMessage: '复制同步观测报告失败，请手动复制同步观测内容',
+    },
+  )
+}
+
+async function copyDepartmentDraftScopeChangeReport(): Promise<void> {
+  await writeClipboardText(
+    buildDepartmentDraftScopeChangeReport(),
+    `已复制 ${departmentDraftScopeChanges.value.length} 个部门范围草稿变更报告`,
+    {
+      emptyMessage: '当前没有可复制的部门范围草稿变更',
+      unsupportedMessage: '当前浏览器不支持自动复制，请手动复制草稿变更内容',
+      failureMessage: '复制部门范围草稿变更报告失败，请手动复制草稿变更内容',
+    },
+  )
+}
+
+function buildDepartmentConfigReferenceIssues(
+  items: DirectoryDepartment[],
+  scope: Record<DirectoryDepartmentTargetField, Set<string>>,
+): DirectoryDepartmentReferenceIssue[] {
+  const hasConfiguredScope = departmentTargetFields.some((field) => scope[field].size > 0)
+  if (items.length === 0 && !hasConfiguredScope) return []
+  const departmentByExternalId = new Map(items.map((item) => [item.externalDepartmentId, item]))
+  const issues: DirectoryDepartmentReferenceIssue[] = []
+  for (const field of departmentTargetFields) {
+    const fieldLabel = readDepartmentTargetLabel(field)
+    for (const departmentId of scope[field]) {
+      const department = departmentByExternalId.get(departmentId)
+      if (!department) {
+        issues.push({
+          key: `${field}:missing:${departmentId}`,
+          field,
+          fieldLabel,
+          kind: 'missing',
+          departmentId,
+          departmentName: '',
+        })
+        continue
+      }
+      if (!department.isActive) {
+        issues.push({
+          key: `${field}:inactive:${departmentId}`,
+          field,
+          fieldLabel,
+          kind: 'inactive',
+          departmentId,
+          departmentName: department.name,
+        })
+      }
+    }
+  }
+  return issues
+}
+
+function readDepartmentReferenceIssueLabel(issue: DirectoryDepartmentReferenceIssue): string {
+  if (issue.kind === 'missing') {
+    return `${issue.fieldLabel}引用不存在的部门 ID ${issue.departmentId}`
+  }
+  return `${issue.fieldLabel}引用已停用部门 ${issue.departmentName} (${issue.departmentId})`
+}
+
+function addDepartmentIdToTarget(
+  departmentId: string,
+  departmentName: string,
+  field: DirectoryDepartmentTargetField,
+  options: { manual?: boolean } = {},
+): boolean {
+  const normalizedDepartmentId = departmentId.trim()
+  const normalizedDepartmentName = departmentName.trim() || (options.manual ? '手动部门' : '部门')
+  const targetLabel = readDepartmentTargetLabel(field)
+  if (normalizedDepartmentId.length === 0) {
+    setStatus(`${normalizedDepartmentName}缺少部门 ID，无法加入${targetLabel}`, 'error')
+    return false
+  }
+  const currentIds = parseAdmissionDepartmentIdsText(readDepartmentTargetText(field))
+  if (currentIds.includes(normalizedDepartmentId)) {
+    setStatus(`${normalizedDepartmentName} (${normalizedDepartmentId}) 已在${targetLabel}中`)
+    return false
+  }
+  writeDepartmentTargetText(field, [...currentIds, normalizedDepartmentId])
+  setStatus(`已将${options.manual ? '手动部门' : '部门'} ${normalizedDepartmentName} (${normalizedDepartmentId}) 加入${targetLabel}`)
+  return true
+}
+
+function addDepartmentToTarget(department: DirectoryDepartment, field: DirectoryDepartmentTargetField): void {
+  addDepartmentIdToTarget(department.externalDepartmentId, department.name, field)
+}
+
+function addVisibleDepartmentsToTarget(field: DirectoryDepartmentTargetField): void {
+  const targetLabel = readDepartmentTargetLabel(field)
+  const departmentIds = visibleDepartmentRows.value
+    .map((department) => department.externalDepartmentId.trim())
+    .filter((departmentId) => departmentId.length > 0)
+  if (departmentIds.length === 0) {
+    setStatus(`当前没有可加入${targetLabel}的可见部门`, 'error')
+    return
+  }
+  const currentIds = parseAdmissionDepartmentIdsText(readDepartmentTargetText(field))
+  const currentSet = new Set(currentIds)
+  const nextIds = [...currentIds]
+  for (const departmentId of departmentIds) {
+    if (currentSet.has(departmentId)) continue
+    currentSet.add(departmentId)
+    nextIds.push(departmentId)
+  }
+  const addedCount = nextIds.length - currentIds.length
+  if (addedCount === 0) {
+    setStatus(`当前可见部门均已在${targetLabel}中`)
+    return
+  }
+  writeDepartmentTargetText(field, nextIds)
+  setStatus(`已将 ${addedCount} 个当前可见部门加入${targetLabel}`)
+}
+
+function removeVisibleDepartmentsFromTarget(field: DirectoryDepartmentTargetField): void {
+  const targetLabel = readDepartmentTargetLabel(field)
+  const departmentIds = new Set(
+    visibleDepartmentRows.value
+      .map((department) => department.externalDepartmentId.trim())
+      .filter((departmentId) => departmentId.length > 0),
+  )
+  if (departmentIds.size === 0) {
+    setStatus(`当前没有可从${targetLabel}移除的可见部门`, 'error')
+    return
+  }
+  const currentIds = parseAdmissionDepartmentIdsText(readDepartmentTargetText(field))
+  const nextIds = currentIds.filter((departmentId) => !departmentIds.has(departmentId))
+  const removedCount = currentIds.length - nextIds.length
+  if (removedCount === 0) {
+    setStatus(`当前可见部门不在${targetLabel}中`)
+    return
+  }
+  writeDepartmentTargetText(field, nextIds)
+  setStatus(`已从${targetLabel}移除 ${removedCount} 个当前可见部门`)
+}
+
+function addManualDepartmentToTarget(field: DirectoryDepartmentTargetField): void {
+  addDepartmentIdToTarget(manualDepartmentId.value, manualDepartmentName.value, field, { manual: true })
+}
+
+function removeDepartmentFromTarget(departmentId: string, field: DirectoryDepartmentTargetField): void {
+  const normalizedDepartmentId = departmentId.trim()
+  const targetLabel = readDepartmentTargetLabel(field)
+  if (normalizedDepartmentId.length === 0) {
+    setStatus(`缺少部门 ID，无法从${targetLabel}移除`, 'error')
+    return
+  }
+  const currentIds = parseAdmissionDepartmentIdsText(readDepartmentTargetText(field))
+  const nextIds = currentIds.filter((id) => id !== normalizedDepartmentId)
+  if (nextIds.length === currentIds.length) {
+    setStatus(`部门 ${normalizedDepartmentId} 不在${targetLabel}中`)
+    return
+  }
+  writeDepartmentTargetText(field, nextIds)
+  setStatus(`已将部门 ${normalizedDepartmentId} 从${targetLabel}移除`)
+}
+
+function removeAllDepartmentReferenceIssues(): void {
+  const issues = departmentConfigReferenceIssues.value
+  if (issues.length === 0) {
+    setStatus('当前没有需要清理的异常部门引用')
+    return
+  }
+  const removeIdsByField: Record<DirectoryDepartmentTargetField, Set<string>> = {
+    admission: new Set(),
+    exclude: new Set(),
+    memberGroup: new Set(),
+  }
+  for (const issue of issues) {
+    removeIdsByField[issue.field].add(issue.departmentId)
+  }
+  for (const field of departmentTargetFields) {
+    const removeIds = removeIdsByField[field]
+    if (removeIds.size === 0) continue
+    const nextIds = parseAdmissionDepartmentIdsText(readDepartmentTargetText(field))
+      .filter((id) => !removeIds.has(id))
+    writeDepartmentTargetText(field, nextIds)
+  }
+  setStatus(`已清理 ${issues.length} 个异常部门引用`)
+}
+
 function readAdmissionModeLabel(integration: DirectoryIntegration): string {
   if (integration.config.admissionMode === 'auto_for_scoped_departments') {
     const includeCount = integration.config.admissionDepartmentIds.length
@@ -1996,9 +3319,93 @@ function readMemberGroupSyncLabel(integration: DirectoryIntegration): string {
   return '成员组同步已关闭'
 }
 
+function buildDirectoryDepartmentTreeRows(items: DirectoryDepartment[]): DirectoryDepartmentTreeRow[] {
+  if (items.length === 0) return []
+  const byExternalId = new Map(items.map((item) => [item.externalDepartmentId, item]))
+  const childrenByParent = new Map<string, DirectoryDepartment[]>()
+  const roots: DirectoryDepartment[] = []
+
+  for (const item of items) {
+    const parentId = item.parentExternalDepartmentId?.trim() || ''
+    if (!parentId || !byExternalId.has(parentId)) {
+      roots.push(item)
+      continue
+    }
+    const children = childrenByParent.get(parentId) ?? []
+    children.push(item)
+    childrenByParent.set(parentId, children)
+  }
+
+  const sortDepartments = (left: DirectoryDepartment, right: DirectoryDepartment) => (
+    left.orderIndex - right.orderIndex
+    || left.name.localeCompare(right.name, 'zh-Hans-CN')
+    || left.externalDepartmentId.localeCompare(right.externalDepartmentId)
+  )
+  roots.sort(sortDepartments)
+  for (const children of childrenByParent.values()) {
+    children.sort(sortDepartments)
+  }
+
+  const rows: DirectoryDepartmentTreeRow[] = []
+  const visit = (item: DirectoryDepartment, depth: number, seen: Set<string>) => {
+    if (seen.has(item.externalDepartmentId)) return
+    rows.push({ ...item, depth })
+    const nextSeen = new Set(seen)
+    nextSeen.add(item.externalDepartmentId)
+    for (const child of childrenByParent.get(item.externalDepartmentId) ?? []) {
+      visit(child, depth + 1, nextSeen)
+    }
+  }
+  for (const root of roots) visit(root, 0, new Set())
+  return rows
+}
+
+function normalizeDepartmentSearchValue(value: unknown): string {
+  return String(value ?? '').trim().toLocaleLowerCase('zh-Hans-CN')
+}
+
+function filterDirectoryDepartmentRows(
+  rows: DirectoryDepartmentTreeRow[],
+  query: string,
+): DirectoryDepartmentTreeRow[] {
+  const normalizedQuery = normalizeDepartmentSearchValue(query)
+  if (normalizedQuery.length === 0) return rows
+  return rows.filter((department) => {
+    const searchable = [
+      department.name,
+      department.fullPath,
+      department.externalDepartmentId,
+      department.parentExternalDepartmentId,
+    ]
+      .map(normalizeDepartmentSearchValue)
+      .join(' ')
+    return searchable.includes(normalizedQuery)
+  })
+}
+
+function readDepartmentIndentStyle(department: DirectoryDepartmentTreeRow): Record<string, string> {
+  return {
+    paddingLeft: `${Math.min(department.depth, 8) * 18 + 14}px`,
+  }
+}
+
+function describeDepartmentParent(department: DirectoryDepartment): string {
+  const parentId = department.parentExternalDepartmentId?.trim()
+  if (!parentId) return '根部门'
+  const parent = departments.value.find((item) => item.externalDepartmentId === parentId)
+  return parent ? `${parent.name} (${parent.externalDepartmentId})` : parentId
+}
+
 async function selectIntegration(integrationId: string): Promise<void> {
   selectedIntegrationId.value = integrationId
   testResult.value = null
+  departments.value = []
+  departmentsLoaded.value = false
+  departmentLoadError.value = ''
+  departmentQuery.value = ''
+  departmentScopeFilter.value = 'all'
+  manualDepartmentId.value = ''
+  manualDepartmentName.value = ''
   clearAutoAdmissionOnboardingPackets()
   clearFocusedAccount()
   accountPage.value = 1
@@ -2668,6 +4075,7 @@ async function syncIntegration() {
       loadAlerts(selectedIntegration.value.id),
       loadReviewItems(selectedIntegration.value.id),
       loadAccounts(selectedIntegration.value.id),
+      departmentsLoaded.value ? loadDepartments(selectedIntegration.value.id, { force: true }) : Promise.resolve(),
     ])
   } catch (error) {
     setStatus(error instanceof Error ? error.message : '目录同步失败', 'error')
@@ -2753,6 +4161,26 @@ async function loadAccounts(integrationId: string) {
     setStatus(error instanceof Error ? error.message : '加载目录成员失败', 'error')
   } finally {
     loadingAccounts.value = false
+  }
+}
+
+async function loadDepartments(integrationId: string, options: { force?: boolean } = {}) {
+  if (departmentsLoaded.value && options.force !== true) return
+  loadingDepartments.value = true
+  departmentLoadError.value = ''
+  try {
+    const response = await apiFetch(`/api/admin/directory/integrations/${integrationId}/departments`)
+    const body = await readJson(response)
+    if (!response.ok) throw new Error(readApiError(body, '加载组织架构失败'))
+    departments.value = Array.isArray(body?.data?.items) ? body.data.items : []
+    departmentsLoaded.value = true
+  } catch (error) {
+    departments.value = []
+    departmentsLoaded.value = true
+    departmentLoadError.value = error instanceof Error ? error.message : '加载组织架构失败'
+    setStatus(departmentLoadError.value, 'error')
+  } finally {
+    loadingDepartments.value = false
   }
 }
 
@@ -3791,6 +5219,16 @@ onUnmounted(() => {
   color: #1e3a8a;
 }
 
+.directory-admin__link-button {
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: #1d4ed8;
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+}
+
 .directory-admin__section {
   display: flex;
   flex-direction: column;
@@ -3958,6 +5396,128 @@ onUnmounted(() => {
   display: flex;
   flex-direction: column;
   gap: 8px;
+}
+
+.directory-admin__department-tree {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.directory-admin__department-node {
+  border: 1px solid #dbeafe;
+  border-radius: 14px;
+  padding: 12px 14px;
+  background: linear-gradient(180deg, #f8fbff 0%, #eff6ff 100%);
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.directory-admin__department-node--inactive {
+  border-color: #fde68a;
+  background: linear-gradient(180deg, #fffbeb 0%, #fef3c7 100%);
+}
+
+.directory-admin__department-search {
+  margin-top: 4px;
+}
+
+.directory-admin__department-scope-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.directory-admin__department-filter-reset {
+  margin-top: -4px;
+}
+
+.directory-admin__visible-department-actions {
+  border: 1px solid #bfdbfe;
+  border-radius: 14px;
+  padding: 10px 12px;
+  background: #eff6ff;
+}
+
+.directory-admin__mirror-observation {
+  border: 1px solid #bbf7d0;
+  border-radius: 14px;
+  padding: 12px 14px;
+  background: #f0fdf4;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.directory-admin__mirror-observation--warning {
+  border-color: #fde68a;
+  background: #fffbeb;
+}
+
+.directory-admin__manual-department {
+  border: 1px dashed #93c5fd;
+  border-radius: 14px;
+  padding: 12px 14px;
+  background: #f8fbff;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.directory-admin__manual-department-fields {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+}
+
+.directory-admin__department-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  flex-basis: 100%;
+}
+
+.directory-admin__reference-issues {
+  border: 1px solid #fecaca;
+  border-radius: 14px;
+  padding: 12px 14px;
+  background: #fef2f2;
+}
+
+.directory-admin__draft-scope-changes {
+  border: 1px solid #bfdbfe;
+  border-radius: 14px;
+  padding: 12px 14px;
+  background: #eff6ff;
+}
+
+.directory-admin__reference-issues--ok {
+  border-color: #bbf7d0;
+  background: #f0fdf4;
+}
+
+.directory-admin__draft-scope-changes ul,
+.directory-admin__reference-issues ul {
+  margin: 8px 0 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.directory-admin__draft-scope-changes li,
+.directory-admin__reference-issues li {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.directory-admin__reference-actions {
+  margin-top: 8px;
 }
 
 .directory-admin__review-admission {

--- a/apps/web/tests/directoryManagementView.spec.ts
+++ b/apps/web/tests/directoryManagementView.spec.ts
@@ -248,6 +248,7 @@ describe('DirectoryManagementView', () => {
       configurable: true,
       value: originalScrollIntoView,
     })
+    Reflect.deleteProperty(navigator, 'clipboard')
     window.history.replaceState({}, '', '/')
     app = null
     container = null
@@ -342,6 +343,639 @@ describe('DirectoryManagementView', () => {
     expect(container?.textContent).toContain('0447654442691174')
     expect(container?.textContent).toContain('最近目录同步')
     expect(container?.textContent).toContain('第 1 / 3 页')
+  })
+
+  it('loads the DingTalk organization tree on demand', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration()],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({ ok: true, data: { items: [] } }))
+      .mockResolvedValueOnce(createJsonResponse(createScheduleSnapshotPayload()))
+      .mockResolvedValueOnce(createJsonResponse(createAlertListPayload([])))
+      .mockResolvedValueOnce(createJsonResponse(createReviewItemsPayload([])))
+      .mockResolvedValueOnce(createJsonResponse(createAccountListPayload([])))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [
+            {
+              id: 'dept-row-1',
+              integrationId: 'dir-1',
+              provider: 'dingtalk',
+              externalDepartmentId: '1',
+              parentExternalDepartmentId: null,
+              name: '信息化团队',
+              fullPath: '信息化团队',
+              orderIndex: 1,
+              isActive: true,
+              lastSeenAt: '2026-05-13T00:00:00.000Z',
+              updatedAt: '2026-05-13T00:00:00.000Z',
+              accountCount: 3,
+              linkedAccountCount: 2,
+              childCount: 1,
+            },
+            {
+              id: 'dept-row-2',
+              integrationId: 'dir-1',
+              provider: 'dingtalk',
+              externalDepartmentId: '2',
+              parentExternalDepartmentId: '1',
+              name: '项目组',
+              fullPath: '信息化团队 / 项目组',
+              orderIndex: 2,
+              isActive: false,
+              lastSeenAt: '2026-05-12T00:00:00.000Z',
+              updatedAt: '2026-05-13T00:00:00.000Z',
+              accountCount: 1,
+              linkedAccountCount: 1,
+              childCount: 0,
+            },
+          ],
+          total: 2,
+        },
+      }))
+
+    const clipboardWriteText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: clipboardWriteText },
+    })
+
+    app = createApp(DirectoryManagementView)
+    registerRouterLink(app)
+    app.mount(container!)
+    await flushUi()
+
+    expect(container?.textContent).toContain('组织架构镜像')
+    expect(container?.textContent).toContain('点击“加载组织架构”')
+
+    const loadButton = Array.from(container!.querySelectorAll('button'))
+      .find((button) => button.textContent?.includes('加载组织架构'))
+    expect(loadButton).toBeTruthy()
+
+    loadButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+
+    expect(apiFetchMock).toHaveBeenCalledWith('/api/admin/directory/integrations/dir-1/departments')
+    expect(container?.textContent).toContain('信息化团队')
+    expect(container?.textContent).toContain('项目组')
+    expect(container?.textContent).toContain('部门 ID 1')
+    expect(container?.textContent).toContain('成员 4')
+    expect(container?.textContent).toContain('已绑定 3')
+    expect(container?.textContent).toContain('未绑定 1')
+    expect(container?.textContent).toContain('组织镜像同步观测')
+    expect(container?.textContent).toContain('批次部门 1')
+    expect(container?.textContent).toContain('未在最新批次出现 1')
+
+    const copyMirrorObservationReportButton = Array.from(container!.querySelectorAll('button'))
+      .find((button) => button.textContent?.includes('复制同步观测报告'))
+    expect(copyMirrorObservationReportButton).toBeTruthy()
+    copyMirrorObservationReportButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+    expect(clipboardWriteText).toHaveBeenCalledWith(expect.stringContaining('DingTalk organization mirror observation report'))
+    expect(clipboardWriteText).toHaveBeenCalledWith(expect.stringContaining('Current batch departments: 1'))
+    expect(clipboardWriteText).toHaveBeenCalledWith(expect.stringContaining('Not seen in latest batch: 1'))
+    expect(clipboardWriteText).toHaveBeenCalledWith(expect.stringContaining('[not_seen_in_latest_batch]'))
+    expect(container?.textContent).toContain('已复制 2 个部门的同步观测报告')
+
+    const focusStaleBatchButton = Array.from(container!.querySelectorAll('button'))
+      .find((button) => button.textContent?.includes('查看非最新批次'))
+    expect(focusStaleBatchButton).toBeTruthy()
+    focusStaleBatchButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+    expect(container?.textContent).toContain('部门 ID 2')
+    expect(container?.textContent).toContain('非最新批次')
+    expect(container?.textContent).not.toContain('部门 ID 1')
+
+    const focusInactiveButton = Array.from(container!.querySelectorAll('button'))
+      .find((button) => button.textContent?.includes('查看停用部门'))
+    expect(focusInactiveButton).toBeTruthy()
+    const focusUnlinkedButton = Array.from(container!.querySelectorAll('button'))
+      .find((button) => button.textContent?.includes('查看未绑定部门'))
+    expect(focusUnlinkedButton).toBeTruthy()
+
+    const allDepartmentsButton = Array.from(container!.querySelectorAll('button'))
+      .find((button) => button.textContent?.trim() === '全部部门')
+    expect(allDepartmentsButton).toBeTruthy()
+    allDepartmentsButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+    expect(container?.textContent).toContain('部门 ID 1')
+    expect(container?.textContent).toContain('部门 ID 2')
+
+    const staleBatchScopeButton = Array.from(container!.querySelectorAll('button'))
+      .find((button) => button.textContent?.includes('只看非最新批次'))
+    expect(staleBatchScopeButton?.textContent).toContain('(1)')
+    staleBatchScopeButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+    expect(container?.textContent).toContain('部门 ID 2')
+    expect(container?.textContent).toContain('非最新批次')
+    expect(container?.textContent).not.toContain('部门 ID 1')
+
+    const copyVisibleDepartmentReportButton = Array.from(container!.querySelectorAll('button'))
+      .find((button) => button.textContent?.includes('复制当前可见部门报告'))
+    expect(copyVisibleDepartmentReportButton).toBeTruthy()
+    copyVisibleDepartmentReportButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+    expect(clipboardWriteText).toHaveBeenCalledWith(expect.stringContaining('DingTalk organization visible department report'))
+    expect(clipboardWriteText).toHaveBeenCalledWith(expect.stringContaining('Scope filter: 只看非最新批次'))
+    expect(clipboardWriteText).toHaveBeenCalledWith(expect.stringContaining('Visible department count: 1'))
+    expect(clipboardWriteText).toHaveBeenCalledWith(expect.stringContaining('[inactive_department; not_latest_batch] 2'))
+    expect(container?.textContent).toContain('已复制 1 个当前可见部门报告')
+
+    allDepartmentsButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+    expect(container?.textContent).toContain('部门 ID 1')
+    expect(container?.textContent).toContain('部门 ID 2')
+
+    const copyBindingGapReportButton = Array.from(container!.querySelectorAll('button'))
+      .find((button) => button.textContent?.includes('复制未绑定部门报告'))
+    expect(copyBindingGapReportButton).toBeTruthy()
+    copyBindingGapReportButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+    expect(clipboardWriteText).toHaveBeenCalledWith(expect.stringContaining('Unlinked member count: 1'))
+    expect(clipboardWriteText).toHaveBeenCalledWith(expect.stringContaining('Departments with gaps: 1'))
+    expect(clipboardWriteText).toHaveBeenCalledWith(expect.stringContaining('members=3 · linked=2 · unlinked=1'))
+    expect(container?.textContent).toContain('已复制 1 个未全绑定部门报告')
+
+    const unlinkedScopeButton = Array.from(container!.querySelectorAll('button'))
+      .find((button) => button.textContent?.includes('只看未全绑定'))
+    expect(unlinkedScopeButton?.textContent).toContain('(1)')
+    unlinkedScopeButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+    expect(container?.textContent).toContain('部门 ID 1')
+    expect(container?.textContent).not.toContain('部门 ID 2')
+
+    allDepartmentsButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+    expect(container?.textContent).toContain('部门 ID 1')
+    expect(container?.textContent).toContain('部门 ID 2')
+
+    const copyInactiveDepartmentReportButton = Array.from(container!.querySelectorAll('button'))
+      .find((button) => button.textContent?.includes('复制停用部门报告'))
+    expect(copyInactiveDepartmentReportButton).toBeTruthy()
+    copyInactiveDepartmentReportButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+    expect(clipboardWriteText).toHaveBeenCalledWith(expect.stringContaining('Inactive department count: 1'))
+    expect(clipboardWriteText).toHaveBeenCalledWith(expect.stringContaining('[inactive_department] 2'))
+    expect(clipboardWriteText).toHaveBeenCalledWith(expect.stringContaining('members=1 · linked=1 · unlinked=0'))
+    expect(container?.textContent).toContain('已复制 1 个停用部门报告')
+
+    const inactiveScopeButton = Array.from(container!.querySelectorAll('button'))
+      .find((button) => button.textContent?.includes('只看停用部门'))
+    expect(inactiveScopeButton?.textContent).toContain('(1)')
+    inactiveScopeButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+    expect(container?.textContent).toContain('部门 ID 2')
+    expect(container?.textContent).toContain('已停用')
+    expect(container?.textContent).not.toContain('部门 ID 1')
+
+    allDepartmentsButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+    expect(container?.textContent).toContain('部门 ID 1')
+    expect(container?.textContent).toContain('部门 ID 2')
+
+    const departmentSearch = Array.from(container!.querySelectorAll('input'))
+      .find((input) => input.getAttribute('placeholder')?.includes('部门名')) as HTMLInputElement | undefined
+    expect(departmentSearch).toBeTruthy()
+    departmentSearch!.value = '2'
+    departmentSearch!.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+    expect(container?.textContent).toContain('匹配 1')
+    expect(container?.textContent).toContain('部门 ID 2')
+    expect(container?.textContent).toContain('当前可见 1 个部门')
+    const visibleDepartmentPreview = container!.querySelector('.directory-admin__visible-department-preview') as HTMLTextAreaElement | null
+    expect(visibleDepartmentPreview?.value).toBe('2')
+
+    const copyVisibleDepartmentIdsButton = Array.from(container!.querySelectorAll('button'))
+      .find((button) => button.textContent?.includes('复制当前可见部门 ID'))
+    expect(copyVisibleDepartmentIdsButton).toBeTruthy()
+    copyVisibleDepartmentIdsButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+    expect(clipboardWriteText).toHaveBeenCalledWith('2')
+    expect(container?.textContent).toContain('已复制 1 个当前可见部门 ID')
+
+    const bulkMemberGroupButton = Array.from(container!.querySelectorAll('button'))
+      .find((button) => button.textContent?.includes('批量加入当前可见到成员组同步'))
+    expect(bulkMemberGroupButton).toBeTruthy()
+    bulkMemberGroupButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+    const textareas = Array.from(container!.querySelectorAll('textarea')) as HTMLTextAreaElement[]
+    expect(textareas[2].value).toBe('2')
+    expect(container?.textContent).toContain('已将 1 个当前可见部门加入成员组同步部门')
+    expect(container?.textContent).toContain('部门范围草稿变更')
+    expect(container?.textContent).toContain('成员组同步部门')
+    expect(container?.textContent).toContain('新增 2')
+
+    const copyDraftScopeChangeReportButton = Array.from(container!.querySelectorAll('button'))
+      .find((button) => button.textContent?.includes('复制草稿变更报告'))
+    expect(copyDraftScopeChangeReportButton).toBeTruthy()
+    copyDraftScopeChangeReportButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+    expect(clipboardWriteText).toHaveBeenCalledWith(expect.stringContaining('DingTalk organization draft scope change report'))
+    expect(clipboardWriteText).toHaveBeenCalledWith(expect.stringContaining('Added department references: 1'))
+    expect(clipboardWriteText).toHaveBeenCalledWith(expect.stringContaining('[成员组同步部门]'))
+    expect(clipboardWriteText).toHaveBeenCalledWith(expect.stringContaining('- 2 · inactive_department · 信息化团队 / 项目组'))
+    expect(container?.textContent).toContain('已复制 1 个部门范围草稿变更报告')
+
+    const restoreSingleScopeButton = Array.from(container!.querySelectorAll('button'))
+      .find((button) => button.textContent?.includes('还原此范围'))
+    expect(restoreSingleScopeButton).toBeTruthy()
+    restoreSingleScopeButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+    expect(textareas[2].value).toBe('')
+    expect(container?.textContent).toContain('已还原成员组同步部门为已保存配置')
+    expect(container?.textContent).not.toContain('部门范围草稿变更')
+
+    bulkMemberGroupButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+    expect(textareas[2].value).toBe('2')
+    expect(container?.textContent).toContain('已将 1 个当前可见部门加入成员组同步部门')
+
+    const restoreSavedScopeButton = Array.from(container!.querySelectorAll('button'))
+      .find((button) => button.textContent?.includes('还原已保存范围'))
+    expect(restoreSavedScopeButton).toBeTruthy()
+    restoreSavedScopeButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+    expect(textareas[2].value).toBe('')
+    expect(container?.textContent).toContain('已还原部门范围草稿为已保存配置')
+    expect(container?.textContent).not.toContain('部门范围草稿变更')
+
+    bulkMemberGroupButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+    expect(textareas[2].value).toBe('2')
+    expect(container?.textContent).toContain('已将 1 个当前可见部门加入成员组同步部门')
+
+    bulkMemberGroupButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+    expect(textareas[2].value).toBe('2')
+    expect(container?.textContent).toContain('当前可见部门均已在成员组同步部门中')
+
+    const removeVisibleMemberGroupButton = Array.from(container!.querySelectorAll('button'))
+      .find((button) => button.textContent?.includes('从成员组同步移除当前可见'))
+    expect(removeVisibleMemberGroupButton).toBeTruthy()
+    removeVisibleMemberGroupButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+    expect(textareas[2].value).toBe('')
+    expect(container?.textContent).toContain('已从成员组同步部门移除 1 个当前可见部门')
+
+    removeVisibleMemberGroupButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+    expect(textareas[2].value).toBe('')
+    expect(container?.textContent).toContain('当前可见部门不在成员组同步部门中')
+
+    departmentSearch!.value = 'no-match'
+    departmentSearch!.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+    expect(container?.textContent).toContain('没有匹配“no-match”的部门')
+
+    const clearDepartmentFilterButton = Array.from(container!.querySelectorAll('button'))
+      .find((button) => button.textContent?.includes('清空部门筛选'))
+    expect(clearDepartmentFilterButton).toBeTruthy()
+    clearDepartmentFilterButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+    expect(departmentSearch!.value).toBe('')
+    expect(container?.textContent).toContain('部门 ID 1')
+    expect(container?.textContent).toContain('部门 ID 2')
+    expect(container?.textContent).not.toContain('当前可见 1 个部门')
+
+    const copyDepartmentIdButton = Array.from(container!.querySelectorAll('button'))
+      .find((button) => button.textContent?.trim() === '复制部门 ID')
+    expect(copyDepartmentIdButton).toBeTruthy()
+    copyDepartmentIdButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+    expect(clipboardWriteText).toHaveBeenCalledWith('1')
+    expect(container?.textContent).toContain('已复制部门 信息化团队 (1) 的 ID')
+
+    const admissionButton = Array.from(container!.querySelectorAll('button'))
+      .find((button) => button.textContent?.trim() === '加入准入白名单')
+    const excludeButton = Array.from(container!.querySelectorAll('button'))
+      .find((button) => button.textContent?.trim() === '加入排除部门')
+    const memberGroupButton = Array.from(container!.querySelectorAll('button'))
+      .find((button) => button.textContent?.trim() === '加入成员组同步')
+    expect(admissionButton).toBeTruthy()
+    expect(excludeButton).toBeTruthy()
+    expect(memberGroupButton).toBeTruthy()
+
+    admissionButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+    expect(textareas[0].value).toBe('1')
+    expect(container?.textContent).toContain('加入准入白名单')
+
+    admissionButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+    expect(textareas[0].value).toBe('1')
+    expect(container?.textContent).toContain('已在准入白名单中')
+
+    excludeButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    memberGroupButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+    expect(textareas[1].value).toBe('1')
+    expect(textareas[2].value).toBe('1')
+
+    const manualDepartmentIdInput = Array.from(container!.querySelectorAll('input'))
+      .find((input) => input.getAttribute('placeholder') === '例如 123456') as HTMLInputElement | undefined
+    const manualDepartmentNameInput = Array.from(container!.querySelectorAll('input'))
+      .find((input) => input.getAttribute('placeholder') === '例如 财务共享中心') as HTMLInputElement | undefined
+    expect(manualDepartmentIdInput).toBeTruthy()
+    expect(manualDepartmentNameInput).toBeTruthy()
+
+    manualDepartmentIdInput!.value = 'manual-42'
+    manualDepartmentIdInput!.dispatchEvent(new Event('input', { bubbles: true }))
+    manualDepartmentNameInput!.value = '外部协作组'
+    manualDepartmentNameInput!.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+
+    const manualAdmissionButton = Array.from(container!.querySelectorAll('button'))
+      .find((button) => button.textContent?.includes('手动加入准入白名单'))
+    expect(manualAdmissionButton).toBeTruthy()
+    expect(manualAdmissionButton).not.toHaveProperty('disabled', true)
+
+    manualAdmissionButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+    expect(textareas[0].value).toBe('1\nmanual-42')
+    expect(container?.textContent).toContain('已将手动部门 外部协作组 (manual-42) 加入准入白名单')
+    expect(container?.textContent).toContain('未同步')
+    expect(container?.textContent).toContain('准入白名单引用不存在的部门 ID manual-42')
+
+    manualAdmissionButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+    expect(textareas[0].value).toBe('1\nmanual-42')
+    expect(container?.textContent).toContain('外部协作组 (manual-42) 已在准入白名单中')
+    expect(container?.textContent).toContain('已配置 2')
+    expect(container?.textContent).toContain('异常引用 1')
+
+    const configuredScopeButton = Array.from(container!.querySelectorAll('button'))
+      .find((button) => button.textContent?.includes('只看已配置'))
+    expect(configuredScopeButton?.textContent).toContain('(1)')
+    configuredScopeButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+    expect(container?.textContent).toContain('部门 ID 1')
+    expect(container?.textContent).not.toContain('部门 ID 2')
+
+    const issueScopeButton = Array.from(container!.querySelectorAll('button'))
+      .find((button) => button.textContent?.includes('只看异常'))
+    expect(issueScopeButton).toBeTruthy()
+    issueScopeButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+    expect(container?.textContent).toContain('当前没有可在组织架构镜像中展示的异常部门')
+  })
+
+  it('flags stale department references in DingTalk organization scope drafts', async () => {
+    const scopedIntegration = createIntegration({
+      config: {
+        ...createIntegration().config,
+        admissionDepartmentIds: ['missing-dept'],
+        excludeDepartmentIds: ['2'],
+        memberGroupDepartmentIds: ['1'],
+      },
+    })
+
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [scopedIntegration],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({ ok: true, data: { items: [] } }))
+      .mockResolvedValueOnce(createJsonResponse(createScheduleSnapshotPayload()))
+      .mockResolvedValueOnce(createJsonResponse(createAlertListPayload([])))
+      .mockResolvedValueOnce(createJsonResponse(createReviewItemsPayload([])))
+      .mockResolvedValueOnce(createJsonResponse(createAccountListPayload([])))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [
+            {
+              id: 'dept-row-1',
+              integrationId: 'dir-1',
+              provider: 'dingtalk',
+              externalDepartmentId: '1',
+              parentExternalDepartmentId: null,
+              name: '信息化团队',
+              fullPath: '信息化团队',
+              orderIndex: 1,
+              isActive: true,
+              lastSeenAt: '2026-05-13T00:00:00.000Z',
+              updatedAt: '2026-05-13T00:00:00.000Z',
+              accountCount: 3,
+              linkedAccountCount: 2,
+              childCount: 1,
+            },
+            {
+              id: 'dept-row-2',
+              integrationId: 'dir-1',
+              provider: 'dingtalk',
+              externalDepartmentId: '2',
+              parentExternalDepartmentId: '1',
+              name: '项目组',
+              fullPath: '信息化团队 / 项目组',
+              orderIndex: 2,
+              isActive: false,
+              lastSeenAt: '2026-05-13T00:00:00.000Z',
+              updatedAt: '2026-05-13T00:00:00.000Z',
+              accountCount: 1,
+              linkedAccountCount: 1,
+              childCount: 0,
+            },
+          ],
+          total: 2,
+        },
+      }))
+
+    const clipboardWriteText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: clipboardWriteText },
+    })
+
+    app = createApp(DirectoryManagementView)
+    registerRouterLink(app)
+    app.mount(container!)
+    await flushUi()
+
+    const loadButton = Array.from(container!.querySelectorAll('button'))
+      .find((button) => button.textContent?.includes('加载组织架构'))
+    expect(loadButton).toBeTruthy()
+
+    loadButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+
+    expect(container?.textContent).toContain('配置引用检查')
+    expect(container?.textContent).toContain('准入白名单引用不存在的部门 ID missing-dept')
+    expect(container?.textContent).toContain('排除部门引用已停用部门 项目组 (2)')
+    expect(container?.textContent).toContain('成员组同步')
+    expect(container?.textContent).toContain('准入白名单')
+    expect(container?.textContent).toContain('排除部门')
+    expect(container?.textContent).toContain('清理全部异常引用')
+    expect(container?.textContent).toContain('已配置 3')
+    expect(container?.textContent).toContain('异常引用 2')
+
+    const copyConfigReportButton = Array.from(container!.querySelectorAll('button'))
+      .find((button) => button.textContent?.includes('复制配置引用报告'))
+    expect(copyConfigReportButton).toBeTruthy()
+    copyConfigReportButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+    expect(clipboardWriteText).toHaveBeenCalledWith(expect.stringContaining('Configured unique department IDs: 3'))
+    expect(clipboardWriteText).toHaveBeenCalledWith(expect.stringContaining('[准入白名单]'))
+    expect(clipboardWriteText).toHaveBeenCalledWith(expect.stringContaining('missing_from_mirror'))
+    expect(clipboardWriteText).toHaveBeenCalledWith(expect.stringContaining('inactive_department'))
+    expect(clipboardWriteText).toHaveBeenCalledWith(expect.stringContaining('active_department'))
+    expect(container?.textContent).toContain('已复制 3 个配置部门引用报告')
+
+    const copyIssueReportButton = Array.from(container!.querySelectorAll('button'))
+      .find((button) => button.textContent?.includes('复制异常引用报告'))
+    expect(copyIssueReportButton).toBeTruthy()
+    copyIssueReportButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+    expect(clipboardWriteText).toHaveBeenCalledWith(expect.stringContaining('Issue count: 2'))
+    expect(clipboardWriteText).toHaveBeenCalledWith(expect.stringContaining('missing-dept'))
+    expect(clipboardWriteText).toHaveBeenCalledWith(expect.stringContaining('inactive_department'))
+    expect(container?.textContent).toContain('已复制 2 条异常引用报告')
+
+    const issueScopeButton = Array.from(container!.querySelectorAll('button'))
+      .find((button) => button.textContent?.includes('只看异常'))
+    expect(issueScopeButton?.textContent).toContain('(1)')
+    issueScopeButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+    expect(container?.textContent).toContain('部门 ID 2')
+    expect(container?.textContent).not.toContain('部门 ID 1')
+
+    const configuredScopeButton = Array.from(container!.querySelectorAll('button'))
+      .find((button) => button.textContent?.includes('只看已配置'))
+    expect(configuredScopeButton?.textContent).toContain('(2)')
+    configuredScopeButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+    expect(container?.textContent).toContain('部门 ID 1')
+    expect(container?.textContent).toContain('部门 ID 2')
+
+    const excludeScopeButton = Array.from(container!.querySelectorAll('button'))
+      .find((button) => button.textContent?.includes('只看排除'))
+    expect(excludeScopeButton?.textContent).toContain('(1)')
+    excludeScopeButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+    expect(container?.textContent).toContain('部门 ID 2')
+    expect(container?.textContent).not.toContain('部门 ID 1')
+
+    const memberGroupScopeButton = Array.from(container!.querySelectorAll('button'))
+      .find((button) => button.textContent?.includes('只看成员组同步'))
+    expect(memberGroupScopeButton?.textContent).toContain('(1)')
+    memberGroupScopeButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+    expect(container?.textContent).toContain('部门 ID 1')
+    expect(container?.textContent).not.toContain('部门 ID 2')
+
+    const textareas = Array.from(container!.querySelectorAll('textarea')) as HTMLTextAreaElement[]
+    const removeAdmissionButton = Array.from(container!.querySelectorAll('button'))
+      .find((button) => button.textContent?.trim() === '从准入白名单移除')
+    const removeExcludeButton = Array.from(container!.querySelectorAll('button'))
+      .find((button) => button.textContent?.trim() === '从排除部门移除')
+    expect(removeAdmissionButton).toBeTruthy()
+    expect(removeExcludeButton).toBeTruthy()
+
+    removeAdmissionButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+    expect(textareas[0].value).toBe('')
+    expect(container?.textContent).not.toContain('准入白名单引用不存在的部门 ID missing-dept')
+
+    removeExcludeButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+    expect(textareas[1].value).toBe('')
+    expect(container?.textContent).toContain('当前准入、排除和成员组同步配置中的部门 ID 均能匹配已同步的有效部门')
+  })
+
+  it('cleans all stale department references from DingTalk organization scope drafts', async () => {
+    const scopedIntegration = createIntegration({
+      config: {
+        ...createIntegration().config,
+        admissionDepartmentIds: ['missing-dept', '1'],
+        excludeDepartmentIds: ['2'],
+        memberGroupDepartmentIds: ['1'],
+      },
+    })
+
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [scopedIntegration],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({ ok: true, data: { items: [] } }))
+      .mockResolvedValueOnce(createJsonResponse(createScheduleSnapshotPayload()))
+      .mockResolvedValueOnce(createJsonResponse(createAlertListPayload([])))
+      .mockResolvedValueOnce(createJsonResponse(createReviewItemsPayload([])))
+      .mockResolvedValueOnce(createJsonResponse(createAccountListPayload([])))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [
+            {
+              id: 'dept-row-1',
+              integrationId: 'dir-1',
+              provider: 'dingtalk',
+              externalDepartmentId: '1',
+              parentExternalDepartmentId: null,
+              name: '信息化团队',
+              fullPath: '信息化团队',
+              orderIndex: 1,
+              isActive: true,
+              lastSeenAt: '2026-05-13T00:00:00.000Z',
+              updatedAt: '2026-05-13T00:00:00.000Z',
+              accountCount: 3,
+              linkedAccountCount: 2,
+              childCount: 1,
+            },
+            {
+              id: 'dept-row-2',
+              integrationId: 'dir-1',
+              provider: 'dingtalk',
+              externalDepartmentId: '2',
+              parentExternalDepartmentId: '1',
+              name: '项目组',
+              fullPath: '信息化团队 / 项目组',
+              orderIndex: 2,
+              isActive: false,
+              lastSeenAt: '2026-05-13T00:00:00.000Z',
+              updatedAt: '2026-05-13T00:00:00.000Z',
+              accountCount: 1,
+              linkedAccountCount: 1,
+              childCount: 0,
+            },
+          ],
+          total: 2,
+        },
+      }))
+
+    app = createApp(DirectoryManagementView)
+    registerRouterLink(app)
+    app.mount(container!)
+    await flushUi()
+
+    const loadButton = Array.from(container!.querySelectorAll('button'))
+      .find((button) => button.textContent?.includes('加载组织架构'))
+    expect(loadButton).toBeTruthy()
+
+    loadButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+
+    const cleanupButton = Array.from(container!.querySelectorAll('button'))
+      .find((button) => button.textContent?.includes('清理全部异常引用'))
+    expect(cleanupButton).toBeTruthy()
+
+    cleanupButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi()
+
+    const textareas = Array.from(container!.querySelectorAll('textarea')) as HTMLTextAreaElement[]
+    expect(textareas[0].value).toBe('1')
+    expect(textareas[1].value).toBe('')
+    expect(textareas[2].value).toBe('1')
+    expect(container?.textContent).toContain('已清理 2 个异常部门引用')
+    expect(container?.textContent).toContain('当前准入、排除和成员组同步配置中的部门 ID 均能匹配已同步的有效部门')
   })
 
   it('warns and disables DingTalk grant toggles when a directory account is missing openId', async () => {

--- a/docs/development/dingtalk-directory-org-tree-development-20260513.md
+++ b/docs/development/dingtalk-directory-org-tree-development-20260513.md
@@ -1,0 +1,260 @@
+# DingTalk Directory Org Tree Development - 2026-05-13
+
+## Summary
+
+Implemented a safe first slice for DingTalk organization-structure usability inside MetaSheet directory management.
+
+This does not create a second editable organization master and does not write back to DingTalk. It exposes the already-synced DingTalk department mirror to administrators, with per-department member and local-binding coverage. The follow-up action slices let administrators reuse department IDs from that mirror, copy single or currently visible department IDs, copy visible-department, draft-scope-change, configuration, stale-reference, binding-gap, inactive-department, and mirror-observation reports, filter large department trees, focus on configured, problematic, inactive, not-fully-bound, or not-latest-batch departments, clear active view filters, bulk-add or bulk-remove narrowed department rows in draft scopes, review and revert scope changes before saving, and add a known department ID manually when the local mirror has not caught up yet.
+
+## Scope
+
+- Backend: add a read-only department summary API for a directory integration.
+- Frontend: add an on-demand "组织架构镜像" section on `/admin/directory`.
+- Frontend: add quick actions from each department row into admission whitelist, admission exclusions, and member-group sync scope.
+- Frontend: add reference checks for configured department IDs that are missing from the local mirror or already inactive.
+- Frontend: add inline cleanup actions for stale department references in the current draft.
+- Frontend: add a bulk cleanup action for all stale department references while preserving healthy references.
+- Frontend: add a clipboard report for all configured department references and their mirror status.
+- Frontend: add a clipboard report for stale department references.
+- Frontend: add client-side department filtering by department name, department ID, parent ID, or full path.
+- Frontend: add member-binding gap counters and a `只看未全绑定` department filter.
+- Frontend: add a clipboard report for departments that still have unlinked directory members.
+- Frontend: add a `只看停用部门` department filter.
+- Frontend: add a clipboard report for inactive departments.
+- Frontend: add a local mirror sync-observation card and clipboard report for department batch freshness.
+- Frontend: add a `只看非最新批次` department filter and per-row stale-batch chip.
+- Frontend: add mirror-observation quick focus actions for stale-batch, inactive, and unlinked departments.
+- Frontend: add scope-view filters for all departments, configured departments, and departments with visible issues.
+- Frontend: add a clear-filter action that resets both text search and scope-view filtering.
+- Frontend: add clipboard copy actions for a single department ID and the current visible department ID list.
+- Frontend: add a clipboard report for the current visible department rows.
+- Frontend: add save-before-review draft change summary and clipboard report for scoped department fields.
+- Frontend: add local "还原已保存范围" and per-field "还原此范围" actions for scoped department draft fields.
+- Frontend: add draft-only bulk add/remove actions for the currently visible filtered/scope-filtered departments.
+- Frontend: add a draft-only manual department ID tool for known departments that are not present in the local mirror yet.
+- Tests: add backend route coverage and frontend click-to-load coverage.
+- No database migration was needed because the existing schema already has:
+  - `directory_departments`
+  - `directory_accounts`
+  - `directory_account_departments`
+  - `directory_account_links`
+
+## Changed Files
+
+- `packages/core-backend/src/directory/directory-sync.ts`
+- `packages/core-backend/src/routes/admin-directory.ts`
+- `packages/core-backend/tests/unit/admin-directory-routes.test.ts`
+- `apps/web/src/views/DirectoryManagementView.vue`
+- `apps/web/tests/directoryManagementView.spec.ts`
+
+## Backend Design
+
+Added `listDirectoryIntegrationDepartments(integrationId)`:
+
+- Validates `integrationId`.
+- Reads `directory_departments` for the selected integration.
+- Aggregates active member count through `directory_account_departments` and `directory_accounts`.
+- Aggregates linked local-user count through `directory_account_links`.
+- Includes active child department count.
+- Returns a flat department list with parent external department IDs so the web client can render a tree safely.
+
+Added admin route:
+
+```text
+GET /api/admin/directory/integrations/:integrationId/departments
+```
+
+Response shape:
+
+```text
+items[]
+total
+```
+
+Each item includes department ID, external department ID, parent external department ID, name, full path, active status, member count, linked count, child count, and sync timestamps.
+
+## Frontend Design
+
+Added an on-demand "组织架构镜像" section to `/admin/directory`:
+
+- It does not automatically fetch on page load.
+- The administrator clicks "加载组织架构" or "刷新组织架构".
+- It renders a tree-like flat list using parent external department IDs.
+- It shows total departments, total members, linked local users, inactive department count, per-department member count, linked count, child count, parent label, and latest sync timestamp.
+- It explicitly tells users this is a local DingTalk directory mirror and does not write back to DingTalk.
+
+Added department quick actions:
+
+- "加入准入白名单" appends the department external ID into `admissionDepartmentIdsText`.
+- "加入排除部门" appends the department external ID into `excludeDepartmentIdsText`.
+- "加入成员组同步" appends the department external ID into `memberGroupDepartmentIdsText`.
+- The helper normalizes comma/newline separated values through the existing parser.
+- Duplicate department IDs are ignored and reported through the existing status banner.
+- The action only updates the current form draft; persistence still happens through the existing "保存变更" button, so users can review before saving.
+
+Added configuration reference checks:
+
+- Loaded department rows show badges when they are referenced by admission, exclusion, or member-group sync drafts.
+- If a configured department ID is not present in the synced mirror, the page shows a `未同步` warning.
+- If a configured department ID points to an inactive department, the page shows an `已停用` warning with the department name and ID.
+- When configured IDs all match active departments, the page shows an explicit healthy reference-check message.
+- This turns organization drift into a visible admin-page signal before the administrator saves or reuses a stale scope.
+
+Added inline cleanup actions:
+
+- Each stale-reference warning includes a "从...移除" action.
+- The action removes that department ID from the corresponding draft textarea only.
+- It uses the same normalized comma/newline parser as save/test payload construction, so duplicate or mixed-separator input is cleaned consistently.
+- When all stale references are removed and remaining IDs match active departments, the reference-check panel switches to the healthy state.
+
+Added bulk cleanup:
+
+- The reference-check panel shows "清理全部异常引用" when any stale reference exists.
+- Bulk cleanup removes all missing or inactive department IDs from their matching draft fields.
+- Valid department IDs already referenced by the same fields are preserved.
+- The action is still draft-only; persistence remains guarded by the existing "保存变更" button.
+
+Added stale-reference report copy:
+
+- The reference-check panel shows "复制异常引用报告" when any stale reference exists.
+- The copied report includes the integration name, issue count, issue status, field label, and department ID/name.
+- Missing departments are marked as `missing_from_mirror`.
+- Inactive departments are marked as `inactive_department`.
+- The report contains only configuration diagnostics already visible on the page; it does not include DingTalk secrets, robot webhooks, app secrets, JWTs, passwords, or full token values.
+- Copy failure is surfaced through the existing status banner and does not change any draft field.
+
+Added configuration-reference report copy:
+
+- The reference-check panel shows "复制配置引用报告" whenever scoped department configuration exists.
+- The copied report includes integration name, configured unique department count, loaded mirror department count, issue count, and the grouped department IDs for admission whitelist, exclusion, and member-group sync drafts.
+- Each configured department ID is marked as `active_department`, `inactive_department`, or `missing_from_mirror`.
+- The report is intended for save-before-review and operations handoff, especially when multiple draft fields share the same department ID.
+- The report contains only IDs and names already visible in the admin page; it does not include DingTalk secrets, robot webhooks, app secrets, JWTs, passwords, or full token values.
+- Copy failure is surfaced through the existing status banner and does not change any draft field.
+
+Added department filtering:
+
+- After the organization mirror is loaded, administrators can filter visible department rows by department name, full path, external department ID, or parent department ID.
+- Filtering is purely client-side and does not trigger another DingTalk or backend request.
+- The summary chips show total departments, matched departments while a filter is active, configured unique department IDs, and reference issue counts.
+- The summary chips show total unbound directory members when the loaded mirror has departments whose member count is greater than linked local-user count.
+- Each department row shows its own `未绑定` gap when member count is greater than linked local-user count.
+- An empty-state message explains the active search term when no department matches.
+- The "清空部门筛选" action clears text filtering and returns scope-view filtering to `全部部门`.
+- Clearing the filter restores the full loaded tree and hides visible-row bulk actions until the view is narrowed again.
+
+Added scope-view filters:
+
+- `全部部门` keeps the full loaded mirror visible.
+- `只看未全绑定` narrows the tree to departments whose synced member count is greater than linked local-user count.
+- `只看停用部门` narrows the tree to synced departments marked inactive in the local mirror.
+- `只看非最新批次` narrows the tree to synced departments whose `lastSeenAt` is older than the latest loaded mirror batch.
+- `只看已配置` narrows the tree to synced departments referenced by admission, exclusion, or member-group sync drafts.
+- `只看准入` narrows the tree to synced departments referenced by the admission whitelist draft.
+- `只看排除` narrows the tree to synced departments referenced by the admission exclusion draft.
+- `只看成员组同步` narrows the tree to synced departments referenced by the member-group sync draft.
+- `只看异常` narrows the tree to synced departments that have reference issues, such as inactive referenced departments.
+- Missing department IDs cannot appear as rows because they are not present in the mirror; they remain visible in the reference-check panel.
+- Scope filtering composes with text filtering and remains client-side only.
+
+Added binding-gap report copy:
+
+- The department filter row shows "复制未绑定部门报告" when the loaded mirror contains at least one department where member count is greater than linked local-user count.
+- The copied report includes integration name, total unlinked member count, department gap count, each department ID, path/name, active status, member count, linked count, and unlinked gap count.
+- The report is intended for operations handoff before running manual binding or no-email admission workflows.
+- The report contains only IDs/counts/names already visible in the admin page; it does not include DingTalk secrets, robot webhooks, app secrets, JWTs, passwords, or full token values.
+- Copy failure is surfaced through the existing status banner and does not change any draft field.
+
+Added inactive-department report copy:
+
+- The department filter row shows "复制停用部门报告" when the loaded mirror contains at least one inactive department.
+- The copied report includes integration name, inactive department count, each department ID, path/name, member count, linked count, and unlinked gap count.
+- The report is intended for operations handoff before cleaning stale scope references or checking DingTalk-side department lifecycle.
+- The report contains only IDs/counts/names already visible in the admin page; it does not include DingTalk secrets, robot webhooks, app secrets, JWTs, passwords, or full token values.
+- Copy failure is surfaced through the existing status banner and does not change any draft field.
+
+Added mirror sync-observation report copy:
+
+- The organization mirror section shows "组织镜像同步观测" after departments are loaded.
+- The card shows latest department mirror batch time, departments in the latest batch, departments not seen in that latest batch, latest row update time, and the selected integration's last successful sync time.
+- The card turns warning-styled when departments are inactive or not seen in the latest local mirror batch.
+- "复制同步观测报告" copies integration name, latest mirror batch, latest mirror update, integration last successful sync, total mirror department count, current batch count, stale batch count, inactive department count, unlinked member count, and a list of departments not seen in the latest batch.
+- The `只看非最新批次` scope filter reuses the same freshness calculation so administrators can locate stale-batch departments without leaving the page or parsing the copied report manually.
+- Department rows not seen in the latest batch show a `非最新批次` chip.
+- The observation card conditionally shows `查看非最新批次`, `查看停用部门`, and `查看未绑定部门` quick actions when those issue counts are present.
+- Quick focus actions clear any text search and switch to the matching scope-view filter so old search terms do not hide the issue rows.
+- The report is intended for scheduled-sync and organization-drift review before administrators clean references or chase DingTalk-side changes.
+- The report contains only IDs/counts/names/timestamps already visible or derived from the loaded admin page; it does not include DingTalk secrets, robot webhooks, app secrets, JWTs, passwords, or full token values.
+- Copy failure is surfaced through the existing status banner and does not change any draft field.
+
+Added visible-row bulk actions:
+
+- When a text filter or scope-view filter narrows the department list, the page shows the current visible department count.
+- The page also shows a read-only newline-separated preview of the exact currently visible department IDs.
+- Administrators can copy the currently visible department ID list to the clipboard for external review or reuse.
+- Administrators can copy a current visible department report that includes integration name, active scope filter, search query, visible count, latest mirror batch, each visible department ID/name, active state, latest-batch state, member count, linked count, and unlinked gap count.
+- Administrators can bulk-add those currently visible department IDs into admission whitelist, admission exclusions, or member-group sync scope.
+- Administrators can also bulk-remove those currently visible department IDs from the same draft scopes.
+- The bulk actions use the same normalized parser and duplicate prevention as the single-row quick actions.
+- The actions and ID preview are intentionally hidden for the default unfiltered `全部部门` view to avoid accidentally editing the whole organization.
+- The actions remain draft-only; persistence still requires the existing "保存变更" button.
+- The visible department report is intended for handoff after narrowing to stale-batch, inactive, unlinked, configured, or field-specific department rows, so reviewers do not need to parse raw ID-only lists.
+- The visible department report contains only IDs/counts/names/timestamps already visible or derived from the loaded admin page; it does not include DingTalk secrets, robot webhooks, app secrets, JWTs, passwords, or full token values.
+
+Added department scope draft-change review:
+
+- The organization mirror section shows "部门范围草稿变更" when the current draft differs from the selected integration's saved scoped department configuration.
+- The summary compares admission whitelist, admission exclusion, and member-group sync department IDs independently.
+- The card shows added and removed department counts, plus field-specific added/removed ID lists.
+- "复制草稿变更报告" copies integration name, changed field count, total added/removed department references, and the field-specific added/removed department IDs with mirror status when the local mirror is loaded.
+- This is intended as a save-before-review checkpoint after quick actions, visible-row bulk actions, manual department ID entry, or stale-reference cleanup.
+- "还原已保存范围" resets admission whitelist, admission exclusion, and member-group sync department drafts back to the selected integration's saved configuration.
+- Each changed field row also exposes "还原此范围", which restores only that field to its saved configuration.
+- Restore actions clear the matching pending scoped department draft changes locally and give a status message, but they do not call the backend or persist anything.
+- The report contains only IDs/counts/names/status already visible or derived from the loaded admin page and saved/draft config; it does not include DingTalk secrets, robot webhooks, app secrets, JWTs, passwords, or full token values.
+- Copy failure is surfaced through the existing status banner and does not change any draft field.
+
+Added department ID copy actions:
+
+- Each department row has a "复制部门 ID" action.
+- The visible-row preview has a "复制当前可见部门 ID" action.
+- Copy uses the browser clipboard API when available.
+- If automatic copy is unavailable or blocked by the browser, the page shows an explicit error and keeps the read-only preview available for manual copy.
+- Copy actions do not mutate drafts, do not call DingTalk, and do not persist configuration.
+
+Added manual department ID helper:
+
+- Administrators can enter a known department ID and optional display name.
+- The helper can add that ID into admission whitelist, admission exclusions, or member-group sync scope.
+- It uses the same normalized parser and duplicate prevention as mirrored department quick actions.
+- It does not create a local organization record and does not call DingTalk.
+- If the organization mirror is already loaded and the manual ID is absent, the existing reference-check panel immediately flags it as `未同步`.
+- This covers the practical "known DingTalk department ID, mirror not updated yet" workflow without expanding schema scope.
+
+## Safety Notes
+
+- No DingTalk `appSecret`, robot webhook, `SEC`, JWT, bearer credential, password, or full webhook URL is added.
+- This slice is read-only for organization structure.
+- Quick actions only copy department IDs into editable draft fields and do not persist until the administrator explicitly saves.
+- Reference checks, single cleanup, and bulk cleanup are client-side diagnostics over already-loaded mirror data; they do not call DingTalk and do not persist until the administrator explicitly saves.
+- Configuration-reference report copy is client-side diagnostics over already-loaded mirror data and current draft fields; it does not call DingTalk and does not mutate drafts.
+- Stale-reference report copy is client-side diagnostics over already-loaded mirror data; it does not call DingTalk and does not mutate drafts.
+- Department filtering only changes the visible list in the browser and does not mutate the loaded mirror or configuration drafts.
+- Scope-view filtering only changes the visible list and does not mutate the loaded mirror or configuration drafts.
+- Binding-gap report copy is client-side diagnostics over already-loaded mirror data; it does not call DingTalk and does not mutate drafts.
+- Inactive-department report copy is client-side diagnostics over already-loaded mirror data; it does not call DingTalk and does not mutate drafts.
+- Mirror sync-observation report copy is client-side diagnostics over already-loaded mirror data; it does not call DingTalk and does not mutate drafts.
+- Clipboard copy actions only copy IDs already visible in the UI and do not mutate loaded mirror data or configuration drafts.
+- Visible department report copy is client-side diagnostics over currently visible mirror rows; it does not call DingTalk and does not mutate drafts.
+- Draft scope change report copy compares selected saved config with current draft fields in the browser; it does not call DingTalk, does not persist, and does not mutate drafts.
+- Draft scope restore only resets local draft fields to the selected saved integration config; per-field restore narrows this to one scoped department field. Neither path calls DingTalk or persists until the administrator explicitly saves again later.
+- Visible-row bulk actions only append or remove visible IDs from draft configuration fields and never auto-save.
+- Manual department ID entry only updates draft configuration fields; it is intentionally shown as `未同步` if the ID is not present in the loaded mirror.
+- Existing automatic sync and manual member binding behavior are unchanged.
+- Existing route/page behavior remains stable because organization loading is user-triggered and not added to the initial page load.
+
+## Remaining Product Work
+
+- Add a persistent named local-organization overlay if administrators need first-class manual-only departments that do not exist in DingTalk.
+- Reuse the same department-picker pattern for forms, automations, and permission scope selectors.
+- Extend scheduled sync observability into backend alerts if the mirror freshness thresholds need persistent audit records instead of client-side diagnostics.

--- a/docs/development/dingtalk-directory-org-tree-verification-20260513.md
+++ b/docs/development/dingtalk-directory-org-tree-verification-20260513.md
@@ -1,0 +1,112 @@
+# DingTalk Directory Org Tree Verification - 2026-05-13
+
+## Result
+
+Status: `PASS`
+
+The DingTalk organization tree slice was implemented and validated with targeted backend route tests, frontend view tests, backend build, web build, and whitespace checks. Follow-up quick-action, reference-check, inline-cleanup, bulk-cleanup, filtering, clear-filter, clipboard-copy, visible-department report copy, draft-scope-change report copy, configuration-reference report copy, stale-reference report copy, binding-gap filtering/reporting, inactive-department filtering/reporting, mirror sync-observation reporting, scope-view filtering, visible-row bulk add/remove action, saved-scope restore, and manual department-ID slices were added so administrators can copy department IDs from the tree into scoped DingTalk configuration drafts, copy IDs and visible/draft-change/configuration/issue/binding-gap/inactive-department/mirror-observation reports to external review material, detect stale references, remove stale IDs, find target departments, reset narrowed views, focus on configured/problematic/inactive/not-fully-bound/not-latest-batch rows, bulk-add or bulk-remove narrowed rows, review or revert pending scope changes before save, and handle known departments before the local mirror catches up.
+
+## Verification Commands
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/admin-directory-routes.test.ts
+pnpm --filter @metasheet/web exec vitest run tests/directoryManagementView.spec.ts
+git diff --check -- packages/core-backend/src/directory/directory-sync.ts packages/core-backend/src/routes/admin-directory.ts packages/core-backend/tests/unit/admin-directory-routes.test.ts apps/web/src/views/DirectoryManagementView.vue apps/web/tests/directoryManagementView.spec.ts docs/development/dingtalk-directory-org-tree-development-20260513.md docs/development/dingtalk-directory-org-tree-verification-20260513.md
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/web build
+```
+
+## Test Evidence
+
+- Backend route test: `packages/core-backend/tests/unit/admin-directory-routes.test.ts`
+  - Result: `1 passed`
+  - Tests: `27 passed`
+  - New coverage: `GET /integrations/:integrationId/departments`
+
+- Frontend directory page test: `apps/web/tests/directoryManagementView.spec.ts`
+  - Result: `1 passed`
+  - Tests: `41 passed`
+  - New coverage: clicking "加载组织架构" calls `/api/admin/directory/integrations/dir-1/departments` and renders parent/child department rows plus aggregate member/binding counts.
+  - New coverage: department quick actions append department ID `1` into admission whitelist, admission exclusion, and member-group sync draft fields.
+  - New coverage: duplicate clicks do not duplicate the department ID and show a status message.
+  - New coverage: configured department IDs are checked against the loaded mirror, including missing department IDs and inactive referenced departments.
+  - New coverage: stale missing/inactive department references can be removed from the matching draft field and the panel returns to the healthy state.
+  - New coverage: bulk cleanup removes all stale references while preserving valid active department IDs.
+  - New coverage: full configuration reference reports can be copied through the clipboard helper and include configured unique count plus active/missing/inactive mirror diagnostics.
+  - New coverage: stale reference reports can be copied through the clipboard helper and include issue count plus missing/inactive department diagnostics.
+  - New coverage: not-fully-bound departments show `未绑定` counts, can be isolated with the `只看未全绑定` scope filter, and can be copied as a binding-gap report.
+  - New coverage: inactive departments can be isolated with the `只看停用部门` scope filter and copied as an inactive-department report.
+  - New coverage: mirror sync-observation shows latest batch counts, flags departments not seen in the latest batch, and copies a mirror-observation report through the clipboard helper.
+  - New coverage: departments not seen in the latest mirror batch can be isolated with `只看非最新批次` and show a `非最新批次` row chip.
+  - New coverage: mirror-observation quick focus actions can jump directly to stale-batch department rows, and inactive/unlinked quick focus actions are rendered when those issue counts exist.
+  - New coverage: the currently visible department rows can be copied as a diagnostic report after scope filtering, including filter label, visible count, department status, batch status, and binding counts.
+  - New coverage: draft scoped department changes are summarized against the selected integration's saved config and can be copied as a draft-change report with field-specific added department diagnostics.
+  - New coverage: scoped department draft changes can be restored back to the selected integration's saved config without saving, both for one changed field and for all scoped fields, and the draft-change card disappears after restore.
+  - New coverage: department filtering matches by department ID, shows matched counts, shows an empty state for no matches, and the clear-filter action restores all rows plus the default scope view.
+  - New coverage: filtered visible department IDs can be copied through the clipboard helper, and a single department row can copy its own department ID.
+  - New coverage: a manually entered department ID can be added into the admission draft, duplicate manual entries are blocked, and the loaded mirror flags the manual ID as `未同步`.
+  - New coverage: scope-view filters can show only configured departments, show field-specific admission exclusion and member-group sync department rows, show an empty state when only missing issues exist, and show synced inactive departments when filtering to visible issues.
+  - New coverage: filtered visible department IDs are shown in the read-only preview, filtered visible departments can be bulk-added into member-group sync draft fields, duplicate bulk adds are ignored, visible departments can be bulk-removed from the same draft field, duplicate bulk removes are ignored, and configured-row counts update accordingly.
+
+- Backend build:
+  - Command: `pnpm --filter @metasheet/core-backend build`
+  - Result: `PASS`
+
+- Web build:
+  - Command: `pnpm --filter @metasheet/web build`
+  - Result: `PASS`
+  - Note: Vite emitted existing chunk-size/dynamic-import warnings; build completed successfully.
+
+- Whitespace check:
+  - Command: `git diff --check -- ...`
+  - Result: `PASS`
+
+## Verification Warnings
+
+- The wider worktree still contains unrelated attendance/K3 changes. This verification only scopes the DingTalk directory files listed in the command block.
+- The frontend targeted Vitest run emitted a local test WebSocket port-in-use warning, but the suite completed successfully with `41 passed`; this did not affect the directory page assertions.
+
+## First Command Correction
+
+An initial targeted Vitest command used `--runInBand`, which this Vitest version does not support. That failed at CLI argument parsing before tests ran. The command was corrected to the supported `vitest run <test-file>` form, and both targeted suites passed.
+
+## Secret Scan
+
+- Command: strict value-pattern scan across `docs/development/dingtalk-directory-org-tree-*.md`.
+- Result: `PASS`
+- Scanner exit: `1`
+- Interpretation: `rg` found 0 matching sensitive values.
+- Coverage: DingTalk robot tokens, DingTalk `SEC` values, JWTs, bearer credentials, full DingTalk webhook URLs, and Slack webhook URLs.
+
+## Deployment Status
+
+Not deployed in this slice. This was a source-level implementation and local validation pass. Deploy should follow the existing GHCR/main pipeline after review/merge.
+
+## Conclusion
+
+The first organization-structure usability slice is ready for review:
+
+- The system can expose synced DingTalk departments as a local organization mirror.
+- Administrators can manually load and inspect the department tree from `/admin/directory`.
+- Administrators can reuse a department row to populate scoped admission and member-group sync draft fields safely.
+- Administrators can see stale or inactive department references after loading the organization mirror.
+- Administrators can remove stale department IDs from the current draft without manually editing textarea contents.
+- Administrators can bulk-clean all stale department references while preserving valid active references.
+- Administrators can copy a full configuration-reference report for save-before-review or operations handoff without exposing sensitive DingTalk values.
+- Administrators can copy a stale-reference report for review or operations handoff without exposing sensitive DingTalk values.
+- Administrators can identify departments that still have directory members without linked local users.
+- Administrators can copy a binding-gap report for manual binding/no-email admission follow-up without exposing sensitive DingTalk values.
+- Administrators can isolate inactive departments from the synced local mirror before deciding whether to clean stale scope references.
+- Administrators can copy an inactive-department report for operations handoff without exposing sensitive DingTalk values.
+- Administrators can inspect and copy a mirror sync-observation report for organization-drift review without exposing sensitive DingTalk values.
+- Administrators can isolate departments not seen in the latest local mirror batch before deciding whether they represent DingTalk-side lifecycle changes or local sync drift.
+- Administrators can use observation-card quick actions to jump from summary warnings to the matching filtered rows without manually choosing a separate scope filter.
+- Administrators can copy the currently visible department rows as a richer review report instead of handing off only raw department IDs.
+- Administrators can review and copy pending scoped department draft changes before saving, reducing the risk of accidental admission/exclusion/member-group scope edits.
+- Administrators can revert one scoped department field or all scoped department draft changes back to the saved integration config before saving, giving a low-friction recovery path after accidental bulk edits.
+- Administrators can filter large DingTalk department mirrors before applying scope actions.
+- Administrators can copy a single department ID or the currently visible filtered department ID list without mutating configuration drafts.
+- Administrators can switch between all departments, configured department rows, field-specific configured rows, and visible issue rows before applying scope actions.
+- Administrators can bulk-add or bulk-remove the currently visible filtered/scope-filtered department rows in draft scope fields without auto-saving.
+- Administrators can enter a known department ID manually and rely on the reference checker to mark it as `未同步` until the next directory sync includes it.
+- Existing user sync, binding, no-email admission, and work-notification settings are not changed by this slice.

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -114,6 +114,23 @@ type DirectoryDepartmentRow = {
   full_path?: string | null
 }
 
+type DirectoryDepartmentSummaryRow = {
+  directory_department_id: string
+  integration_id: string
+  provider: string
+  external_department_id: string
+  external_parent_department_id: string | null
+  name: string
+  full_path: string | null
+  order_index: number
+  is_active: boolean
+  last_seen_at: string
+  updated_at: string
+  account_count: number
+  linked_account_count: number
+  child_count: number
+}
+
 type DirectoryAccountRow = {
   id: string
   corp_id: string | null
@@ -271,6 +288,23 @@ export type DirectoryIntegrationSummary = {
     linkedCount: number
     lastRunStatus: string | null
   }
+}
+
+export type DirectoryDepartmentSummary = {
+  id: string
+  integrationId: string
+  provider: string
+  externalDepartmentId: string
+  parentExternalDepartmentId: string | null
+  name: string
+  fullPath: string | null
+  orderIndex: number
+  isActive: boolean
+  lastSeenAt: string
+  updatedAt: string
+  accountCount: number
+  linkedAccountCount: number
+  childCount: number
 }
 
 export type DirectoryIntegrationInput = {
@@ -998,6 +1032,25 @@ function summarizeAlert(row: DirectorySyncAlertRow): DirectorySyncAlertSummary {
     acknowledgedBy: row.acknowledged_by,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
+  }
+}
+
+function summarizeDirectoryDepartment(row: DirectoryDepartmentSummaryRow): DirectoryDepartmentSummary {
+  return {
+    id: row.directory_department_id,
+    integrationId: row.integration_id,
+    provider: row.provider,
+    externalDepartmentId: row.external_department_id,
+    parentExternalDepartmentId: row.external_parent_department_id,
+    name: row.name,
+    fullPath: row.full_path,
+    orderIndex: Number(row.order_index ?? 0),
+    isActive: Boolean(row.is_active),
+    lastSeenAt: row.last_seen_at,
+    updatedAt: row.updated_at,
+    accountCount: Number(row.account_count ?? 0),
+    linkedAccountCount: Number(row.linked_account_count ?? 0),
+    childCount: Number(row.child_count ?? 0),
   }
 }
 
@@ -3539,6 +3592,54 @@ export async function listDirectoryIntegrationAccounts(
   return {
     items: rowsResult.rows.map(summarizeDirectoryAccount),
     total: Number(countResult.rows[0]?.total ?? 0),
+  }
+}
+
+export async function listDirectoryIntegrationDepartments(
+  integrationId: string,
+): Promise<{ items: DirectoryDepartmentSummary[]; total: number }> {
+  const normalizedIntegrationId = normalizeText(integrationId)
+  if (!normalizedIntegrationId) throw new Error('integrationId is required')
+
+  const result = await query<DirectoryDepartmentSummaryRow>(
+    `SELECT
+        d.id AS directory_department_id,
+        d.integration_id,
+        d.provider,
+        d.external_department_id,
+        d.external_parent_department_id,
+        d.name,
+        d.full_path,
+        d.order_index,
+        d.is_active,
+        d.last_seen_at,
+        d.updated_at,
+        COUNT(DISTINCT ad.directory_account_id) FILTER (WHERE a.is_active = true) AS account_count,
+        COUNT(DISTINCT ad.directory_account_id) FILTER (
+          WHERE a.is_active = true
+            AND l.local_user_id IS NOT NULL
+            AND COALESCE(l.link_status, '') = 'linked'
+        ) AS linked_account_count,
+        COUNT(DISTINCT child.id) FILTER (WHERE child.is_active = true) AS child_count
+     FROM directory_departments d
+     LEFT JOIN directory_account_departments ad ON ad.directory_department_id = d.id
+     LEFT JOIN directory_accounts a ON a.id = ad.directory_account_id
+     LEFT JOIN directory_account_links l ON l.directory_account_id = a.id
+     LEFT JOIN directory_departments child
+       ON child.integration_id = d.integration_id
+      AND child.external_parent_department_id = d.external_department_id
+     WHERE d.integration_id = $1
+     GROUP BY
+       d.id, d.integration_id, d.provider, d.external_department_id, d.external_parent_department_id,
+       d.name, d.full_path, d.order_index, d.is_active, d.last_seen_at, d.updated_at
+     ORDER BY d.is_active DESC, COALESCE(d.full_path, d.name) ASC, d.order_index ASC, d.external_department_id ASC`,
+    [normalizedIntegrationId],
+  )
+
+  const items = result.rows.map(summarizeDirectoryDepartment)
+  return {
+    items,
+    total: items.length,
   }
 }
 

--- a/packages/core-backend/src/routes/admin-directory.ts
+++ b/packages/core-backend/src/routes/admin-directory.ts
@@ -12,6 +12,7 @@ import {
   getDirectoryAccountSummary,
   getDirectoryReviewItem,
   listDirectoryIntegrationAccounts,
+  listDirectoryIntegrationDepartments,
   listDirectoryIntegrations,
   listDirectoryReviewItems,
   listDirectorySyncAlerts,
@@ -332,6 +333,22 @@ export function adminDirectoryRouter(): Router {
     } catch (error) {
       const message = readErrorMessage(error, 'Failed to load directory accounts')
       jsonError(res, /required|invalid/i.test(message) ? 400 : 500, 'DIRECTORY_ACCOUNTS_FAILED', message)
+    }
+  })
+
+  router.get('/integrations/:integrationId/departments', async (req: Request, res: Response) => {
+    const adminUserId = await ensurePlatformAdmin(req, res)
+    if (!adminUserId) return
+
+    try {
+      const result = await listDirectoryIntegrationDepartments(req.params.integrationId)
+      jsonOk(res, {
+        items: result.items,
+        total: result.total,
+      })
+    } catch (error) {
+      const message = readErrorMessage(error, 'Failed to load directory departments')
+      jsonError(res, /required|invalid/i.test(message) ? 400 : 500, 'DIRECTORY_DEPARTMENTS_FAILED', message)
     }
   })
 

--- a/packages/core-backend/tests/unit/admin-directory-routes.test.ts
+++ b/packages/core-backend/tests/unit/admin-directory-routes.test.ts
@@ -20,6 +20,7 @@ const directoryMocks = vi.hoisted(() => ({
   getDirectoryAccountSummary: vi.fn(),
   getDirectoryReviewItem: vi.fn(),
   listDirectoryIntegrationAccounts: vi.fn(),
+  listDirectoryIntegrationDepartments: vi.fn(),
   listDirectoryIntegrations: vi.fn(),
   listDirectoryReviewItems: vi.fn(),
   listDirectorySyncAlerts: vi.fn(),
@@ -59,6 +60,7 @@ vi.mock('../../src/directory/directory-sync', () => ({
   getDirectoryAccountSummary: directoryMocks.getDirectoryAccountSummary,
   getDirectoryReviewItem: directoryMocks.getDirectoryReviewItem,
   listDirectoryIntegrationAccounts: directoryMocks.listDirectoryIntegrationAccounts,
+  listDirectoryIntegrationDepartments: directoryMocks.listDirectoryIntegrationDepartments,
   listDirectoryIntegrations: directoryMocks.listDirectoryIntegrations,
   listDirectoryReviewItems: directoryMocks.listDirectoryReviewItems,
   listDirectorySyncAlerts: directoryMocks.listDirectorySyncAlerts,
@@ -162,6 +164,7 @@ describe('adminDirectoryRouter', () => {
     directoryMocks.getDirectoryAccountSummary.mockReset()
     directoryMocks.getDirectoryReviewItem.mockReset()
     directoryMocks.listDirectoryIntegrationAccounts.mockReset()
+    directoryMocks.listDirectoryIntegrationDepartments.mockReset()
     directoryMocks.listDirectoryIntegrations.mockReset()
     directoryMocks.listDirectoryReviewItems.mockReset()
     directoryMocks.listDirectorySyncAlerts.mockReset()
@@ -595,6 +598,47 @@ describe('adminDirectoryRouter', () => {
       data: {
         total: 1,
         query: '0447',
+      },
+    })
+  })
+
+  it('lists directory departments for an integration', async () => {
+    directoryMocks.listDirectoryIntegrationDepartments.mockResolvedValue({
+      items: [
+        {
+          id: 'dept-row-1',
+          integrationId: 'dir-1',
+          externalDepartmentId: '1',
+          parentExternalDepartmentId: null,
+          name: '总部',
+          fullPath: '总部',
+          accountCount: 3,
+          linkedAccountCount: 2,
+          childCount: 1,
+        },
+      ],
+      total: 1,
+    })
+
+    const response = await invokeRoute('get', '/integrations/:integrationId/departments', {
+      params: { integrationId: 'dir-1' },
+      user: { id: 'admin-1', role: 'admin' },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(directoryMocks.listDirectoryIntegrationDepartments).toHaveBeenCalledWith('dir-1')
+    expect(response.body).toMatchObject({
+      ok: true,
+      data: {
+        total: 1,
+        items: [
+          {
+            externalDepartmentId: '1',
+            name: '总部',
+            accountCount: 3,
+            linkedAccountCount: 2,
+          },
+        ],
       },
     })
   })


### PR DESCRIPTION
## Summary
- Add backend endpoint to list DingTalk directory departments for a selected integration.
- Add `/admin/directory` organization mirror UI with department tree, health filters, scope draft helpers, visible-ID copy, and stale-reference cleanup controls.
- Add development and verification markdown for the DingTalk directory org-tree closeout slice.

## Verification
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/admin-directory-routes.test.ts` (27 passed)
- `pnpm --filter @metasheet/web exec vitest run tests/directoryManagementView.spec.ts` (41 passed; local WebSocket port warning only)
- `pnpm --filter @metasheet/core-backend build`
- `pnpm --filter @metasheet/web build` (existing Vite chunk/dynamic import warnings only)
- `git diff --cached --check`
- scoped secret scan for DingTalk webhook/token/JWT/Bearer patterns: 0 hits
