### PR TITLE
test(integration): smoke data factory route after deploy

### DIFF
--- a/docs/development/data-factory-postdeploy-smoke-development-20260514.md
+++ b/docs/development/data-factory-postdeploy-smoke-development-20260514.md
@@ -1,0 +1,59 @@
+# Data Factory Postdeploy Smoke Development - 2026-05-14
+
+## Summary
+
+This slice extends the existing K3 WISE postdeploy smoke so a deployed
+MetaSheet instance proves that the main Data Factory route is reachable, not
+only the K3 WISE preset route.
+
+The intent is operational: after Windows on-prem deployment, an operator can
+run the existing smoke command and see both integration surfaces checked:
+
+- `/integrations/k3-wise` for the K3 WISE preset wizard
+- `/integrations/workbench` for the default Data Factory workbench
+
+No backend route, database migration, or integration business behavior changes
+were added.
+
+## Files Changed
+
+- `scripts/ops/integration-k3wise-postdeploy-smoke.mjs`
+  - Adds a `data-factory-frontend-route` check.
+  - Reuses the same app-shell validation used by the K3 WISE frontend route.
+  - Keeps authenticated API checks unchanged.
+- `scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs`
+  - Adds the fake `/integrations/workbench` route.
+  - Updates public smoke expectations from 3 to 4 pass checks.
+  - Verifies `data-factory-frontend-route` is present and passing.
+- `scripts/ops/multitable-onprem-package-build.sh`
+  - Includes this development and verification note in the Windows on-prem
+    package.
+- `scripts/ops/multitable-onprem-package-verify.sh`
+  - Verifies the packaged smoke script contains the
+    `data-factory-frontend-route` check.
+
+## Behavior
+
+The public smoke path now checks:
+
+1. `/api/health`
+2. `/api/integration/health`
+3. `/integrations/k3-wise`
+4. `/integrations/workbench`
+
+When a token is provided, existing authenticated control-plane checks still run:
+
+- `/api/auth/me`
+- `/api/integration/status`
+- list probes for systems, pipelines, runs, and dead letters
+- staging descriptor contract
+
+## Guardrails
+
+- No external K3 call.
+- No SQL call.
+- No Save-only push.
+- No Submit / Audit behavior.
+- No token value written to JSON, Markdown, stdout, or stderr.
+- Data Factory smoke remains part of the existing postdeploy command, so the
+  deployment procedure does not gain another command to remember.

--- a/docs/development/data-factory-postdeploy-smoke-verification-20260514.md
+++ b/docs/development/data-factory-postdeploy-smoke-verification-20260514.md
@@ -1,0 +1,117 @@
+# Data Factory Postdeploy Smoke Verification - 2026-05-14
+
+## Scope
+
+This verification covers the Data Factory frontend-route extension inside the
+existing K3 WISE postdeploy smoke script.
+
+The smoke script should now prove that a deployed instance serves both:
+
+- `/integrations/k3-wise`
+- `/integrations/workbench`
+
+## Local Verification
+
+### Smoke unit test
+
+Command:
+
+```bash
+node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
+```
+
+Result:
+
+- 16/16 tests passed.
+- Public smoke now reports 4 pass checks when no auth token is supplied.
+- Authenticated smoke still validates the existing route contract and staging
+  descriptor contract.
+- Evidence still avoids token leakage.
+
+### Full integration regression
+
+Commands:
+
+```bash
+pnpm -F plugin-integration-core test
+pnpm verify:integration-k3wise:poc
+pnpm verify:integration-erp-plm:deploy-readiness
+```
+
+Result:
+
+- `pnpm -F plugin-integration-core test` passed.
+- `pnpm verify:integration-k3wise:poc` passed.
+- `pnpm verify:integration-erp-plm:deploy-readiness` returned exit code 1
+  because the latest main `Plugin System Tests` workflow was still
+  `in_progress` at verification time. Source gates in the command output were
+  still green: `k3-setup-deploy-checklist-service`,
+  `k3-setup-deploy-checklist-view`, `k3-offline-poc-chain`, and
+  `k3-postdeploy-smoke` all reported PASS.
+
+### Frontend regression
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/IntegrationWorkbenchView.spec.ts tests/IntegrationK3WiseSetupView.spec.ts tests/platform-shell-nav.spec.ts --watch=false
+```
+
+Result:
+
+- 3 files passed.
+- 7 tests passed.
+- Data Factory route and K3 WISE preset route continued to render in frontend
+  tests.
+
+### Frontend build
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result:
+
+- Build passed.
+- Vite emitted the existing large-chunk warning; no build failure.
+
+### Package verification
+
+Commands:
+
+```bash
+bash -n scripts/ops/multitable-onprem-package-build.sh
+bash -n scripts/ops/multitable-onprem-package-verify.sh
+scripts/ops/multitable-onprem-package-build.sh
+scripts/ops/multitable-onprem-package-verify.sh <generated-package.zip>
+```
+
+Result:
+
+- Package verifier passes.
+- Packaged smoke script contains `data-factory-frontend-route`.
+- The Windows on-prem package carries this development and verification note.
+- Locally generated package verified successfully:
+  `output/releases/multitable-onprem/metasheet-multitable-onprem-v2.5.0-20260513-202152.zip`.
+
+### Diff hygiene
+
+Command:
+
+```bash
+git diff --check
+```
+
+Result:
+
+- Passed with exit code 0.
+
+## Deployment Impact
+
+- No database migration.
+- No backend route change.
+- No frontend route change.
+- No K3 WebAPI or SQL Server behavior change.
+- Existing postdeploy command gains one extra public frontend route check.

--- a/scripts/ops/integration-k3wise-postdeploy-smoke.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-smoke.mjs
@@ -512,6 +512,16 @@ function assertListResponse(body, probeId) {
   return { rows: data.length }
 }
 
+function assertFrontendAppShell(page, label) {
+  if (!/id=["']app["']/.test(page.text) && !/MetaSheet|metasheet/i.test(page.text)) {
+    throw new K3WisePostdeploySmokeError(`${label} frontend route did not look like the app shell`)
+  }
+  return {
+    httpStatus: page.status,
+    bytes: page.text.length,
+  }
+}
+
 function extractTenantId(authBody) {
   const candidates = [
     authBody?.tenantId,
@@ -571,15 +581,16 @@ async function runSmoke(opts) {
 
   try {
     const page = await requestText(opts.baseUrl, '/integrations/k3-wise', { timeoutMs: opts.timeoutMs })
-    if (!/id=["']app["']/.test(page.text) && !/K3 WISE|MetaSheet|metasheet/i.test(page.text)) {
-      throw new K3WisePostdeploySmokeError('K3 WISE frontend route did not look like the app shell')
-    }
-    checks.push(result('k3-wise-frontend-route', 'pass', {
-      httpStatus: page.status,
-      bytes: page.text.length,
-    }))
+    checks.push(result('k3-wise-frontend-route', 'pass', assertFrontendAppShell(page, 'K3 WISE')))
   } catch (error) {
     checks.push(failResult('k3-wise-frontend-route', error))
+  }
+
+  try {
+    const page = await requestText(opts.baseUrl, '/integrations/workbench', { timeoutMs: opts.timeoutMs })
+    checks.push(result('data-factory-frontend-route', 'pass', assertFrontendAppShell(page, 'Data Factory')))
+  } catch (error) {
+    checks.push(failResult('data-factory-frontend-route', error))
   }
 
   if (!token) {

--- a/scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
@@ -204,6 +204,11 @@ function createFakeServer(options = {}) {
       return
     }
 
+    if (req.method === 'GET' && url.pathname === '/integrations/workbench') {
+      sendHtml(res, 200, '<!doctype html><html><body><div id="app"></div><script src="/assets/app.js"></script></body></html>')
+      return
+    }
+
     if (req.method === 'GET' && url.pathname === '/api/auth/me') {
       if (req.headers.authorization !== 'Bearer test.jwt.token') {
         sendJson(res, 401, { ok: false, error: { message: 'bad token' } })
@@ -294,7 +299,7 @@ test('public postdeploy smoke passes without an auth token and skips authenticat
     assert.equal(stdout.authenticated, false)
     assert.equal(stdout.summary.fail, 0)
     assert.equal(stdout.summary.skipped, 1)
-    assert.equal(stdout.summary.pass, 3)
+    assert.equal(stdout.summary.pass, 4)
     assert.deepEqual(stdout.signoff, {
       internalTrial: 'blocked',
       reason: 'authenticated checks did not run',
@@ -307,8 +312,10 @@ test('public postdeploy smoke passes without an auth token and skips authenticat
     })
     assert.equal(evidence.checks.find((check) => check.id === 'authenticated-integration-contract').status, 'skipped')
     assert.equal(evidence.checks.find((check) => check.id === 'k3-wise-frontend-route').status, 'pass')
+    assert.equal(evidence.checks.find((check) => check.id === 'data-factory-frontend-route').status, 'pass')
     assert.ok(fake.requests.some((request) => request.pathname === '/api/integration/health'))
     assert.ok(fake.requests.some((request) => request.pathname === '/integrations/k3-wise'))
+    assert.ok(fake.requests.some((request) => request.pathname === '/integrations/workbench'))
   } finally {
     await fake.close()
     rmSync(outDir, { recursive: true, force: true })
@@ -334,6 +341,7 @@ test('public postdeploy smoke skips plugin health when the deployment protects i
     const evidence = JSON.parse(readFileSync(path.join(outDir, 'integration-k3wise-postdeploy-smoke.json'), 'utf8'))
     assert.equal(evidence.checks.find((check) => check.id === 'integration-plugin-health').status, 'skipped')
     assert.equal(evidence.checks.find((check) => check.id === 'k3-wise-frontend-route').status, 'pass')
+    assert.equal(evidence.checks.find((check) => check.id === 'data-factory-frontend-route').status, 'pass')
   } finally {
     await fake.close()
     rmSync(outDir, { recursive: true, force: true })

--- a/scripts/ops/multitable-onprem-package-build.sh
+++ b/scripts/ops/multitable-onprem-package-build.sh
@@ -75,6 +75,8 @@ REQUIRED_PATHS=(
   "docs/development/data-factory-workbench-verification-20260514.md"
   "docs/development/data-factory-cleansed-export-development-20260514.md"
   "docs/development/data-factory-cleansed-export-verification-20260514.md"
+  "docs/development/data-factory-postdeploy-smoke-development-20260514.md"
+  "docs/development/data-factory-postdeploy-smoke-verification-20260514.md"
   "docker/app.env.example"
   "docker/app.env.multitable-onprem.template"
   "ops/nginx/multitable-onprem.conf.example"

--- a/scripts/ops/multitable-onprem-package-verify.sh
+++ b/scripts/ops/multitable-onprem-package-verify.sh
@@ -89,6 +89,7 @@ function verify_generic_integration_workbench_contract() {
   local web_dist="${root}/apps/web/dist"
   local easy_start="${root}/docs/deployment/multitable-windows-onprem-easy-start-20260319.md"
   local k3_runbook="${root}/docs/operations/integration-k3wise-internal-trial-runbook.md"
+  local postdeploy_smoke="${root}/scripts/ops/integration-k3wise-postdeploy-smoke.mjs"
 
   search_fixed_string '/integrations/workbench' "$web_dist" || die "web dist must include the Data Factory route"
   search_fixed_string '/integrations/k3-wise' "$web_dist" || die "web dist must include the K3 WISE setup route"
@@ -101,6 +102,7 @@ function verify_generic_integration_workbench_contract() {
   search_fixed_string '/integrations/workbench' "$easy_start" || die "Windows on-prem guide must document the Data Factory route"
   search_fixed_string '/integrations/k3-wise' "$easy_start" || die "Windows on-prem guide must document the K3 WISE setup route"
   search_fixed_string 'SQL Server is an advanced channel' "$k3_runbook" || die "K3 runbook must document SQL Server as an advanced channel"
+  search_fixed_string 'data-factory-frontend-route' "$postdeploy_smoke" || die "postdeploy smoke must check the Data Factory frontend route"
 }
 
 function write_optional_report() {
@@ -330,6 +332,8 @@ required=(
   "docs/development/data-factory-workbench-verification-20260514.md"
   "docs/development/data-factory-cleansed-export-development-20260514.md"
   "docs/development/data-factory-cleansed-export-verification-20260514.md"
+  "docs/development/data-factory-postdeploy-smoke-development-20260514.md"
+  "docs/development/data-factory-postdeploy-smoke-verification-20260514.md"
   "docs/deployment/multitable-platform-rc-notes-20260404.md"
   "docs/deployment/multitable-windows-onprem-easy-start-20260319.md"
   "docs/deployment/multitable-onprem-package-layout-20260319.md"


### PR DESCRIPTION
## Summary
- extend the existing K3 WISE postdeploy smoke with a public `/integrations/workbench` app-shell check
- add fake-server regression coverage for `data-factory-frontend-route`
- include the new design/verification notes in the Windows on-prem package and require the packaged smoke script to contain the Data Factory route check

## Verification
- `node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs` — 16/16 pass
- `pnpm --filter @metasheet/web exec vitest run tests/IntegrationWorkbenchView.spec.ts tests/IntegrationK3WiseSetupView.spec.ts tests/platform-shell-nav.spec.ts --watch=false` — 3 files / 7 tests pass
- `pnpm -F plugin-integration-core test` — pass
- `pnpm verify:integration-k3wise:poc` — pass
- `pnpm --filter @metasheet/web build` — pass, existing large-chunk warning only
- `bash -n scripts/ops/multitable-onprem-package-build.sh && bash -n scripts/ops/multitable-onprem-package-verify.sh` — pass
- `scripts/ops/multitable-onprem-package-build.sh` — generated local package
- `scripts/ops/multitable-onprem-package-verify.sh output/releases/multitable-onprem/metasheet-multitable-onprem-v2.5.0-20260513-202152.zip` — pass
- `git diff --cached --check` — pass

## Known non-code gate
- `pnpm verify:integration-erp-plm:deploy-readiness` returned exit code 1 because the latest main `Plugin System Tests` workflow was still `in_progress` at verification time. The source gates in that command output were green: `k3-setup-deploy-checklist-service`, `k3-setup-deploy-checklist-view`, `k3-offline-poc-chain`, and `k3-postdeploy-smoke`.

## Deployment Impact
- no database migration
- no backend route change
- no frontend route change
- no K3 WebAPI / SQL Server behavior change
- existing postdeploy smoke gains one extra public frontend route check