### PR TITLE
feat(attendance): add report field catalog foundation

### DIFF
--- a/apps/web/src/composables/useLocale.ts
+++ b/apps/web/src/composables/useLocale.ts
@@ -18,7 +18,9 @@ function normalizeLocale(value: unknown): AppLocale {
 
 function resolveInitialLocale(): AppLocale {
   if (typeof window === 'undefined') return 'en'
-  const fromStorage = window.localStorage.getItem(LOCALE_STORAGE_KEY)
+  const fromStorage = typeof window.localStorage?.getItem === 'function'
+    ? window.localStorage.getItem(LOCALE_STORAGE_KEY)
+    : null
   if (fromStorage) return normalizeLocale(fromStorage)
   if (typeof navigator !== 'undefined') {
     return normalizeLocale(navigator.language)
@@ -33,6 +35,7 @@ function setDocumentLang(locale: AppLocale): void {
 
 function persistLocale(locale: AppLocale): void {
   if (typeof window === 'undefined') return
+  if (typeof window.localStorage?.setItem !== 'function') return
   window.localStorage.setItem(LOCALE_STORAGE_KEY, locale)
 }
 
@@ -71,4 +74,3 @@ export function useLocale() {
     supportedLocales: ['en', 'zh-CN'] as const,
   }
 }
-

--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -898,6 +898,17 @@
           <h3>{{ tr('Records', '记录') }}</h3>
           <div class="attendance__records-actions">
             <button class="attendance__btn" :disabled="loading" @click="reloadRecordsWithStatus">{{ tr('Reload', '重载') }}</button>
+            <label class="attendance__field attendance__field--compact" for="attendance-record-export-header">
+              <span>{{ tr('CSV header', 'CSV 表头') }}</span>
+              <select
+                id="attendance-record-export-header"
+                name="recordExportHeader"
+                v-model="exportCsvHeaderMode"
+              >
+                <option value="label">{{ tr('Field names', '字段名称') }}</option>
+                <option value="code">{{ tr('Field codes', '字段编码') }}</option>
+              </select>
+            </label>
             <button class="attendance__btn" :disabled="exporting || loading" @click="exportCsv">
               {{ exporting ? tr('Exporting...', '导出中...') : tr('Export CSV', '导出 CSV') }}
             </button>
@@ -912,6 +923,38 @@
             )
           }}
         </p>
+        <div
+          v-if="recordReportConfigDetails.length > 0"
+          class="attendance__report-config"
+          data-record-report-config
+        >
+          <span
+            v-for="detail in recordReportConfigDetails"
+            :key="detail.key"
+            :class="detail.tone ? `attendance__report-config-item--${detail.tone}` : ''"
+            :data-record-report-config-detail="detail.key"
+          >
+            <strong>{{ detail.label }}</strong>
+            <code v-if="detail.monospace">{{ detail.value }}</code>
+            <span v-else>{{ detail.value }}</span>
+          </span>
+        </div>
+        <div
+          v-if="lastRecordCsvExportDetails.length > 0"
+          class="attendance__report-config"
+          data-record-export-config
+        >
+          <span
+            v-for="detail in lastRecordCsvExportDetails"
+            :key="detail.key"
+            :class="detail.tone ? `attendance__report-config-item--${detail.tone}` : ''"
+            :data-record-export-config-detail="detail.key"
+          >
+            <strong>{{ detail.label }}</strong>
+            <code v-if="detail.monospace">{{ detail.value }}</code>
+            <span v-else>{{ detail.value }}</span>
+          </span>
+        </div>
         <div v-if="records.length === 0" class="attendance__empty">{{ tr('No records.', '暂无记录。') }}</div>
         <div v-else-if="filteredRecords.length === 0" class="attendance__empty">
           {{ tr('No records match the current filters on this page.', '当前页筛选条件下没有匹配的记录。') }}
@@ -920,30 +963,18 @@
           <table class="attendance__table attendance__table--records">
             <thead>
               <tr>
-                <th>{{ tr('Date', '日期') }}</th>
-                <th>{{ tr('First in', '首次打卡') }}</th>
-                <th>{{ tr('Last out', '最后打卡') }}</th>
-                <th>{{ tr('Work (min)', '工时（分钟）') }}</th>
-                <th>{{ tr('Late', '迟到') }}</th>
-                <th>{{ tr('Early leave', '早退') }}</th>
-                <th>{{ tr('Leave', '请假') }}</th>
-                <th>{{ tr('Overtime', '加班') }}</th>
-                <th>{{ tr('Status', '状态') }}</th>
+                <th v-for="column in recordReportColumns" :key="column.code">
+                  {{ column.label }}
+                </th>
                 <th></th>
               </tr>
             </thead>
             <tbody>
               <template v-for="record in filteredRecords" :key="record.id">
                 <tr>
-                  <td>{{ record.work_date }}</td>
-                  <td>{{ formatDateTime(record.first_in_at) }}</td>
-                  <td>{{ formatDateTime(record.last_out_at) }}</td>
-                  <td>{{ record.work_minutes }}</td>
-                  <td>{{ record.late_minutes }}</td>
-                  <td>{{ record.early_leave_minutes }}</td>
-                  <td>{{ formatMetaMinutes(record.meta, 'leave') }}</td>
-                  <td>{{ formatMetaMinutes(record.meta, 'overtime') }}</td>
-                  <td>{{ formatStatus(record.status) }}</td>
+                  <td v-for="column in recordReportColumns" :key="`${record.id}-${column.code}`">
+                    {{ formatRecordReportCell(record, column.code) }}
+                  </td>
                   <td class="attendance__table-actions">
                     <button
                       class="attendance__btn"
@@ -3371,6 +3402,17 @@
             </div>
 
             <div
+              v-show="shouldShowAdminSection(ATTENDANCE_ADMIN_SECTION_IDS.reportFields)"
+              class="attendance__admin-section"
+              v-bind="adminSectionBinding(ATTENDANCE_ADMIN_SECTION_IDS.reportFields)"
+            >
+              <AttendanceReportFieldsSection
+                :tr="tr"
+                :org-id="normalizedOrgId()"
+              />
+            </div>
+
+            <div
               v-show="shouldShowAdminSection(ATTENDANCE_ADMIN_SECTION_IDS.payrollTemplates)"
               class="attendance__admin-section"
               v-bind="adminSectionBinding(ATTENDANCE_ADMIN_SECTION_IDS.payrollTemplates)"
@@ -4577,6 +4619,7 @@ import AttendanceAdminRail from './attendance/AttendanceAdminRail.vue'
 import AttendanceImportBatchesSection from './attendance/AttendanceImportBatchesSection.vue'
 import AttendanceHolidayDataSection from './attendance/AttendanceHolidayDataSection.vue'
 import AttendanceUserPickerField from './attendance/AttendanceUserPickerField.vue'
+import AttendanceReportFieldsSection from './attendance/AttendanceReportFieldsSection.vue'
 import { useAttendanceAdminImportBatches } from './attendance/useAttendanceAdminImportBatches'
 import {
   buildRuleSetPreviewRecommendations,
@@ -4707,6 +4750,9 @@ interface AttendanceSummary {
 interface AttendanceRecord {
   id: string
   work_date: string
+  user_id?: string
+  user_name?: string | null
+  username?: string | null
   first_in_at: string | null
   last_out_at: string | null
   work_minutes: number
@@ -4715,6 +4761,59 @@ interface AttendanceRecord {
   status: string
   is_workday?: boolean
   meta?: Record<string, any>
+  workday_context?: {
+    shiftName?: string | null
+  } | null
+}
+
+interface AttendanceRecordReportField {
+  code: string
+  name: string
+  category?: string
+  categoryLabel?: string
+  unit?: string
+  sortOrder?: number
+}
+
+interface AttendanceRecordReportFieldConfig {
+  multitable?: {
+    available?: boolean
+    degraded?: boolean
+    projectId?: string
+    objectId?: string
+    sheetId?: string
+    viewId?: string
+    reason?: string
+  }
+  fieldsFingerprint?: {
+    algorithm?: string
+    value?: string
+    fieldCount?: number
+    codes?: string[]
+  }
+}
+
+interface AttendanceRecordReportConfigDetail {
+  key: string
+  label: string
+  value: string
+  monospace?: boolean
+  tone?: 'ok' | 'warn'
+}
+
+interface AttendanceRecordCsvExportConfig {
+  headerMode: 'label' | 'code'
+  filename: string
+  from: string
+  to: string
+  fingerprintAlgorithm?: string
+  fingerprint?: string
+  fieldCount?: number
+  fieldCodes?: string[]
+  projectId?: string
+  objectId?: string
+  sheetId?: string
+  viewId?: string
 }
 
 interface AttendancePunchEvent {
@@ -5337,6 +5436,9 @@ const punching = ref(false)
 const requestSubmitting = ref(false)
 const summary = ref<AttendanceSummary | null>(null)
 const records = ref<AttendanceRecord[]>([])
+const recordReportFields = ref<AttendanceRecordReportField[]>([])
+const recordReportFieldConfig = ref<AttendanceRecordReportFieldConfig | null>(null)
+const lastRecordCsvExportConfig = ref<AttendanceRecordCsvExportConfig | null>(null)
 const expandedRecordId = ref('')
 const recordTimelineLoadingId = ref('')
 const recordTimelineById = ref<Record<string, AttendancePunchEvent[]>>({})
@@ -5351,6 +5453,7 @@ const statusMeta = ref<AttendanceStatusMeta | null>(null)
 const calendarMonth = ref(new Date())
 const pluginsLoaded = ref(false)
 const exporting = ref(false)
+const exportCsvHeaderMode = ref<'label' | 'code'>('label')
 const settingsLoading = ref(false)
 const holidaySyncLoading = ref(false)
 const provisionLoading = ref(false)
@@ -5448,7 +5551,6 @@ const payrollCycleGenerating = ref(false)
 const payrollCycleGenerateResult = ref<{ created: number; skipped: number } | null>(null)
 const importLoading = ref(false)
 const adminForbidden = ref(false)
-const recordsTableColumnCount = 10
 const defaultTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
 const timezoneOptions = computed(() =>
   buildTimezoneOptions([defaultTimezone, 'UTC', 'Asia/Shanghai', 'America/Los_Angeles', 'America/New_York'])
@@ -5683,6 +5785,293 @@ const filteredRequestReportTotal = computed(() =>
 const filteredRequestReportMinutesTotal = computed(() =>
   filteredRequestReport.value.reduce((sum, row) => sum + (Number(row.minutes) || 0), 0)
 )
+
+const fallbackRecordReportFields = computed<AttendanceRecordReportField[]>(() => [
+  { code: 'work_date', name: tr('Date', '日期'), sortOrder: 1000 },
+  { code: 'punch_times', name: tr('Punch times', '打卡时间'), sortOrder: 2000 },
+  { code: 'work_duration', name: tr('Work (min)', '工时（分钟）'), sortOrder: 3000 },
+  { code: 'late_duration', name: tr('Late', '迟到'), sortOrder: 4000 },
+  { code: 'early_leave_duration', name: tr('Early leave', '早退'), sortOrder: 5000 },
+  { code: 'leave_duration', name: tr('Leave', '请假'), sortOrder: 6000 },
+  { code: 'overtime_approval_duration', name: tr('Overtime', '加班'), sortOrder: 7000 },
+  { code: 'attendance_result', name: tr('Status', '状态'), sortOrder: 8000 },
+])
+
+const recordReportColumns = computed(() => {
+  const source = recordReportFields.value.length > 0 ? recordReportFields.value : fallbackRecordReportFields.value
+  return source
+    .map(field => ({
+      ...field,
+      label: formatRecordReportFieldLabel(field),
+      sortOrder: Number(field.sortOrder) || 0,
+    }))
+    .sort((left, right) => {
+      if (left.sortOrder !== right.sortOrder) return left.sortOrder - right.sortOrder
+      return left.code.localeCompare(right.code)
+    })
+})
+
+const recordReportConfigDetails = computed<AttendanceRecordReportConfigDetail[]>(() => {
+  const config = recordReportFieldConfig.value
+  if (!config && recordReportFields.value.length === 0) return []
+
+  const rows: AttendanceRecordReportConfigDetail[] = []
+  const multitable = config?.multitable ?? {}
+  const fingerprint = config?.fieldsFingerprint ?? {}
+  const fieldCount = Number.isFinite(Number(fingerprint.fieldCount))
+    ? Number(fingerprint.fieldCount)
+    : recordReportColumns.value.length
+  const backing = multitable.degraded
+    ? tr('Degraded', '已降级')
+    : multitable.available
+      ? tr('Connected', '已连接')
+      : tr('Built-in', '内置')
+
+  rows.push({
+    key: 'backing',
+    label: tr('Field config', '字段配置'),
+    value: backing,
+  })
+  rows.push({
+    key: 'fieldCount',
+    label: tr('Fields', '字段数'),
+    value: String(fieldCount),
+  })
+
+  const algorithm = String(fingerprint.algorithm || '').trim()
+  const value = String(fingerprint.value || '').trim()
+  const fieldCodes = Array.isArray(fingerprint.codes)
+    ? fingerprint.codes.map(code => String(code || '').trim()).filter(Boolean)
+    : []
+  const projectId = String(multitable.projectId || '').trim()
+  if (algorithm) {
+    rows.push({
+      key: 'fingerprintAlgorithm',
+      label: tr('Algorithm', '算法'),
+      value: algorithm,
+      monospace: true,
+    })
+  }
+  if (value) {
+    rows.push({
+      key: 'fingerprint',
+      label: tr('Fingerprint', '指纹'),
+      value,
+      monospace: true,
+    })
+  }
+  if (fieldCodes.length > 0) {
+    rows.push({
+      key: 'fieldCodes',
+      label: tr('Field codes', '字段编码'),
+      value: fieldCodes.join(', '),
+      monospace: true,
+    })
+  }
+  if (projectId) {
+    rows.push({
+      key: 'projectId',
+      label: tr('Project', '项目'),
+      value: projectId,
+      monospace: true,
+    })
+  }
+
+  return rows
+})
+
+const lastRecordCsvExportDetails = computed<AttendanceRecordReportConfigDetail[]>(() => {
+  const config = lastRecordCsvExportConfig.value
+  if (!config) return []
+  const recordFingerprint = String(recordReportFieldConfig.value?.fieldsFingerprint?.value || '').trim()
+  const exportFingerprint = String(config.fingerprint || '').trim()
+  const configMatch = recordFingerprint && exportFingerprint
+    ? recordFingerprint === exportFingerprint
+    : null
+  const recordFieldCountRaw = Number(recordReportFieldConfig.value?.fieldsFingerprint?.fieldCount)
+  const recordFieldCount = Number.isFinite(recordFieldCountRaw)
+    ? recordFieldCountRaw
+    : recordReportColumns.value.length
+  const exportFieldCount = Number(config.fieldCount)
+  const fieldCountMatch = Number.isFinite(exportFieldCount) && Number.isFinite(recordFieldCount)
+    ? recordFieldCount === exportFieldCount
+    : null
+  const recordFieldCodes = Array.isArray(recordReportFieldConfig.value?.fieldsFingerprint?.codes)
+    ? recordReportFieldConfig.value.fieldsFingerprint.codes.map(code => String(code || '').trim()).filter(Boolean)
+    : []
+  const exportFieldCodes = Array.isArray(config.fieldCodes)
+    ? config.fieldCodes.map(code => String(code || '').trim()).filter(Boolean)
+    : []
+  const fieldCodesMatch = recordFieldCodes.length > 0 && exportFieldCodes.length > 0
+    ? recordFieldCodes.join('|') === exportFieldCodes.join('|')
+    : null
+  const recordBackingParts = [
+    recordReportFieldConfig.value?.multitable?.projectId,
+    recordReportFieldConfig.value?.multitable?.objectId,
+    recordReportFieldConfig.value?.multitable?.sheetId,
+    recordReportFieldConfig.value?.multitable?.viewId,
+  ].map(value => String(value || '').trim())
+  const exportBackingParts = [
+    config.projectId,
+    config.objectId,
+    config.sheetId,
+    config.viewId,
+  ].map(value => String(value || '').trim())
+  const hasRecordBacking = recordBackingParts.every(Boolean)
+  const hasExportBacking = exportBackingParts.every(Boolean)
+  const backingMatch = hasRecordBacking && hasExportBacking
+    ? recordBackingParts.join('|') === exportBackingParts.join('|')
+    : null
+  const missingEvidenceLabels: string[] = []
+  if (!Number.isFinite(exportFieldCount)) missingEvidenceLabels.push(tr('field count', '字段数量'))
+  if (!exportFingerprint) missingEvidenceLabels.push(tr('fingerprint', '字段指纹'))
+  if (exportFieldCodes.length === 0) missingEvidenceLabels.push(tr('field codes', '字段编码'))
+  const rangeMatch = config.from === fromDate.value && config.to === toDate.value
+  const rows: AttendanceRecordReportConfigDetail[] = [
+    {
+      key: 'headerMode',
+      label: tr('Last CSV export', '最近 CSV 导出'),
+      value: config.headerMode === 'code'
+        ? tr('Field codes', '字段编码')
+        : tr('Field names', '字段名称'),
+    },
+  ]
+  rows.push({
+    key: 'evidenceStatus',
+    label: tr('Export evidence', '导出证据'),
+    value: missingEvidenceLabels.length === 0
+      ? tr('Complete', '完整')
+      : `${tr('Missing', '缺少')}: ${missingEvidenceLabels.join(', ')}`,
+    tone: missingEvidenceLabels.length === 0 ? 'ok' : 'warn',
+  })
+  rows.push({
+    key: 'range',
+    label: tr('Range', '区间'),
+    value: `${formatShortDate(config.from)} - ${formatShortDate(config.to)}`,
+  })
+  rows.push({
+    key: 'rangeMatch',
+    label: tr('Range match', '区间一致性'),
+    value: rangeMatch
+      ? tr('Current range', '当前区间')
+      : tr('Different range', '不同区间'),
+    tone: rangeMatch ? 'ok' : 'warn',
+  })
+  if (Number.isFinite(Number(config.fieldCount))) {
+    rows.push({
+      key: 'fieldCount',
+      label: tr('Fields', '字段数'),
+      value: String(config.fieldCount),
+    })
+  }
+  if (fieldCountMatch !== null) {
+    rows.push({
+      key: 'fieldCountMatch',
+      label: tr('Field count match', '字段数量一致性'),
+      value: fieldCountMatch
+        ? tr('Matches records', '与记录表一致')
+        : tr('Differs from records', '与记录表不一致'),
+      tone: fieldCountMatch ? 'ok' : 'warn',
+    })
+  }
+  if (configMatch !== null) {
+    rows.push({
+      key: 'configMatch',
+      label: tr('Config match', '配置一致性'),
+      value: configMatch
+        ? tr('Matches records', '与记录表一致')
+        : tr('Differs from records', '与记录表不一致'),
+      tone: configMatch ? 'ok' : 'warn',
+    })
+  }
+  if (fieldCodesMatch !== null) {
+    rows.push({
+      key: 'fieldCodesMatch',
+      label: tr('Field codes match', '字段编码一致性'),
+      value: fieldCodesMatch
+        ? tr('Matches records', '与记录表一致')
+        : tr('Differs from records', '与记录表不一致'),
+      tone: fieldCodesMatch ? 'ok' : 'warn',
+    })
+  }
+  if (backingMatch !== null) {
+    rows.push({
+      key: 'backingMatch',
+      label: tr('Backing match', '底座一致性'),
+      value: backingMatch
+        ? tr('Matches records', '与记录表一致')
+        : tr('Differs from records', '与记录表不一致'),
+      tone: backingMatch ? 'ok' : 'warn',
+    })
+  }
+  if (config.projectId) {
+    rows.push({
+      key: 'projectId',
+      label: tr('Project', '项目'),
+      value: config.projectId,
+      monospace: true,
+    })
+  }
+  if (config.objectId) {
+    rows.push({
+      key: 'objectId',
+      label: tr('Object', '对象'),
+      value: config.objectId,
+      monospace: true,
+    })
+  }
+  if (config.sheetId) {
+    rows.push({
+      key: 'sheetId',
+      label: tr('Sheet', '表格'),
+      value: config.sheetId,
+      monospace: true,
+    })
+  }
+  if (config.viewId) {
+    rows.push({
+      key: 'viewId',
+      label: tr('View', '视图'),
+      value: config.viewId,
+      monospace: true,
+    })
+  }
+  if (config.fingerprintAlgorithm) {
+    rows.push({
+      key: 'fingerprintAlgorithm',
+      label: tr('Algorithm', '算法'),
+      value: config.fingerprintAlgorithm,
+      monospace: true,
+    })
+  }
+  if (config.fingerprint) {
+    rows.push({
+      key: 'fingerprint',
+      label: tr('Fingerprint', '指纹'),
+      value: config.fingerprint,
+      monospace: true,
+    })
+  }
+  if (Array.isArray(config.fieldCodes) && config.fieldCodes.length > 0) {
+    rows.push({
+      key: 'fieldCodes',
+      label: tr('Field codes', '字段编码'),
+      value: config.fieldCodes.join(', '),
+      monospace: true,
+    })
+  }
+  if (config.filename) {
+    rows.push({
+      key: 'filename',
+      label: tr('File', '文件'),
+      value: config.filename,
+      monospace: true,
+    })
+  }
+  return rows
+})
+
+const recordsTableColumnCount = computed(() => Math.max(1, recordReportColumns.value.length) + 1)
 
 const filteredRecords = computed(() =>
   records.value.filter((record) => {
@@ -7517,6 +7906,158 @@ function formatMetaMinutes(meta: Record<string, any> | undefined, key: 'leave' |
   const overtimeMinutes = Number(meta.overtime_minutes ?? meta.overtimeMinutes ?? 0)
   const value = key === 'leave' ? leaveMinutes : overtimeMinutes
   return Number.isFinite(value) && value > 0 ? String(value) : '--'
+}
+
+function recordMetaValue(record: AttendanceRecord, keys: string[]): unknown {
+  const meta = record.meta ?? {}
+  for (const key of keys) {
+    if (Object.prototype.hasOwnProperty.call(meta, key)) return meta[key]
+  }
+  return undefined
+}
+
+function firstRecordValue(...values: unknown[]): string {
+  for (const value of values) {
+    if (Array.isArray(value)) {
+      const joined = value.map(item => String(item ?? '').trim()).filter(Boolean).join(', ')
+      if (joined) return joined
+      continue
+    }
+    const normalized = String(value ?? '').trim()
+    if (normalized) return normalized
+  }
+  return '--'
+}
+
+function recordMetaMinutes(record: AttendanceRecord, keys: string[]): number {
+  const value = recordMetaValue(record, keys)
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+function formatRecordMinutes(value: unknown): string {
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed) || parsed === 0) return '--'
+  return String(parsed)
+}
+
+function formatRecordReportFieldLabel(field: AttendanceRecordReportField): string {
+  const labels: Record<string, string> = {
+    work_date: tr('Date', '日期'),
+    employee_name: tr('Name', '姓名'),
+    employee_no: tr('Employee No.', '工号'),
+    department: tr('Department', '部门'),
+    position: tr('Position', '职位'),
+    attendance_group: tr('Attendance group', '考勤组'),
+    punch_times: tr('Punch times', '打卡时间'),
+    punch_result: tr('Punch result', '打卡结果'),
+    approval_forms: tr('Approval forms', '关联的审批单'),
+    expected_attendance_days: tr('Expected days', '应出勤天数'),
+    correction_count: tr('Corrections', '补卡次数'),
+    attendance_shift: tr('Attendance shift', '出勤班次'),
+    attendance_days: tr('Attendance days', '出勤天数'),
+    rest_days: tr('Rest days', '休息天数'),
+    work_duration: tr('Work (min)', '工时（分钟）'),
+    business_trip_duration: tr('Business trip (min)', '出差时长'),
+    outing_duration: tr('Outing (min)', '外出时长'),
+    attendance_result: tr('Status', '考勤结果'),
+    shift: tr('Shift', '班次'),
+    late_count: tr('Late count', '迟到次数'),
+    late_duration: tr('Late', '迟到'),
+    severe_late_count: tr('Severe late count', '严重迟到次数'),
+    severe_late_duration: tr('Severe late (min)', '严重迟到时长'),
+    absence_late_count: tr('Absence-late count', '旷工迟到次数'),
+    early_leave_count: tr('Early leave count', '早退次数'),
+    early_leave_duration: tr('Early leave', '早退'),
+    missing_clock_in_count: tr('Missing in', '上班缺卡次数'),
+    missing_clock_out_count: tr('Missing out', '下班缺卡次数'),
+    absenteeism_days: tr('Absence days', '旷工天数'),
+    leave_duration: tr('Leave', '请假'),
+    overtime_approval_duration: tr('Overtime', '加班'),
+    workday_overtime_duration: tr('Workday OT', '工作日加班'),
+    restday_overtime_duration: tr('Rest day OT', '休息日加班'),
+    holiday_overtime_duration: tr('Holiday OT', '节假日加班'),
+  }
+  return labels[field.code] ?? field.name ?? field.code
+}
+
+function formatRecordReportCell(record: AttendanceRecord, code: string): string {
+  const isWorkday = record.is_workday !== false
+  const status = String(record.status || '')
+  const leaveMinutes = recordMetaMinutes(record, ['leave_minutes', 'leaveMinutes'])
+  const overtimeMinutes = recordMetaMinutes(record, ['overtime_minutes', 'overtimeMinutes'])
+
+  switch (code) {
+    case 'work_date':
+      return record.work_date
+    case 'employee_name':
+      return firstRecordValue(record.user_name, record.username, record.user_id)
+    case 'employee_no':
+      return firstRecordValue(recordMetaValue(record, ['empNo', 'employeeNo', 'employee_no', '工号']), record.user_id)
+    case 'department':
+      return firstRecordValue(recordMetaValue(record, ['department', '部门']))
+    case 'position':
+      return firstRecordValue(recordMetaValue(record, ['position', 'role', 'roleTags', 'role_tags', '职位']))
+    case 'attendance_group':
+      return firstRecordValue(recordMetaValue(record, ['attendanceGroup', 'attendance_group', '考勤组']))
+    case 'punch_times':
+      return [formatDateTime(record.first_in_at), formatDateTime(record.last_out_at)].filter(item => item !== '--').join(' / ') || '--'
+    case 'punch_result':
+    case 'attendance_result':
+      return formatStatus(status)
+    case 'approval_forms':
+      return firstRecordValue(recordMetaValue(record, ['approvalSummary', 'approval_summary', 'attendance_approve', '关联的审批单']))
+    case 'expected_attendance_days':
+      return isWorkday ? '1' : '0'
+    case 'correction_count':
+      return String(Number(recordMetaValue(record, ['correction_count', 'correctionCount']) ?? (status === 'adjusted' ? 1 : 0)))
+    case 'attendance_shift':
+      return firstRecordValue(recordMetaValue(record, ['attendanceClass', 'attendance_class', '出勤班次']))
+    case 'attendance_days':
+      return isWorkday && !['absent', 'off'].includes(status) ? '1' : '0'
+    case 'rest_days':
+      return isWorkday ? '0' : '1'
+    case 'work_duration':
+      return formatRecordMinutes(record.work_minutes)
+    case 'business_trip_duration':
+      return formatRecordMinutes(recordMetaMinutes(record, ['business_trip_minutes', 'businessTripMinutes', 'businessTripDuration']))
+    case 'outing_duration':
+      return formatRecordMinutes(recordMetaMinutes(record, ['outing_minutes', 'outingMinutes', 'outingDuration']))
+    case 'shift':
+      return firstRecordValue(recordMetaValue(record, ['shiftName', 'shift_name', '班次']), record.workday_context?.shiftName)
+    case 'late_count':
+      return Number(record.late_minutes) > 0 ? '1' : '0'
+    case 'late_duration':
+      return formatRecordMinutes(record.late_minutes)
+    case 'severe_late_count':
+      return String(Number(recordMetaValue(record, ['severe_late_count', 'severeLateCount']) ?? 0))
+    case 'severe_late_duration':
+      return formatRecordMinutes(recordMetaMinutes(record, ['severe_late_minutes', 'severeLateMinutes']))
+    case 'absence_late_count':
+      return String(Number(recordMetaValue(record, ['absence_late_count', 'absenceLateCount']) ?? 0))
+    case 'early_leave_count':
+      return Number(record.early_leave_minutes) > 0 ? '1' : '0'
+    case 'early_leave_duration':
+      return formatRecordMinutes(record.early_leave_minutes)
+    case 'missing_clock_in_count':
+      return isWorkday && !record.first_in_at ? '1' : '0'
+    case 'missing_clock_out_count':
+      return isWorkday && !record.last_out_at ? '1' : '0'
+    case 'absenteeism_days':
+      return status === 'absent' ? '1' : '0'
+    case 'leave_duration':
+      return formatRecordMinutes(leaveMinutes)
+    case 'overtime_approval_duration':
+      return formatRecordMinutes(overtimeMinutes)
+    case 'workday_overtime_duration':
+      return formatRecordMinutes(isWorkday ? overtimeMinutes : 0)
+    case 'restday_overtime_duration':
+      return formatRecordMinutes(!isWorkday ? overtimeMinutes : 0)
+    case 'holiday_overtime_duration':
+      return formatRecordMinutes(recordMetaMinutes(record, ['holiday_overtime_minutes', 'holidayOvertimeMinutes']))
+    default:
+      return '--'
+  }
 }
 
 function parseJsonConfig(value: string): Record<string, any> | null {
@@ -11028,6 +11569,8 @@ async function loadRecords() {
   resetRecordTimelineState()
   records.value = data.data.items
   recordsTotal.value = data.data.total
+  recordReportFields.value = Array.isArray(data.data.reportFields) ? data.data.reportFields : []
+  recordReportFieldConfig.value = data.data.reportFieldConfig ?? null
 }
 
 async function toggleRecordTimeline(record: AttendanceRecord): Promise<void> {
@@ -11432,6 +11975,7 @@ async function exportCsv() {
       to: toDate.value,
       orgId: normalizedOrgId(),
       userId: normalizedUserId(),
+      header: exportCsvHeaderMode.value,
     })
     const response = await apiFetch(`/api/attendance/export?${query.toString()}`)
     const text = await response.text()
@@ -11457,6 +12001,32 @@ async function exportCsv() {
     link.click()
     link.remove()
     URL.revokeObjectURL(url)
+    const fingerprintAlgorithm = response.headers.get('x-attendance-report-fields-fingerprint-algorithm') || undefined
+    const fingerprint = response.headers.get('x-attendance-report-fields-fingerprint') || undefined
+    const fieldCountHeader = String(response.headers.get('x-attendance-report-fields-count') || '').trim()
+    const fieldCount = Number(fieldCountHeader)
+    const fieldCodes = (response.headers.get('x-attendance-report-fields-codes') || '')
+      .split(',')
+      .map(code => code.trim())
+      .filter(Boolean)
+    const projectId = response.headers.get('x-attendance-report-fields-project-id') || undefined
+    const objectId = response.headers.get('x-attendance-report-fields-object-id') || undefined
+    const sheetId = response.headers.get('x-attendance-report-fields-sheet-id') || undefined
+    const viewId = response.headers.get('x-attendance-report-fields-view-id') || undefined
+    lastRecordCsvExportConfig.value = {
+      headerMode: exportCsvHeaderMode.value,
+      filename,
+      from: fromDate.value,
+      to: toDate.value,
+      fingerprintAlgorithm,
+      fingerprint,
+      fieldCount: fieldCountHeader && Number.isFinite(fieldCount) ? fieldCount : undefined,
+      fieldCodes,
+      projectId,
+      objectId,
+      sheetId,
+      viewId,
+    }
     setStatus(appendStatusContext(tr('Export ready.', '导出完成。'), recordsTimezoneContextHint.value))
   } catch (error: any) {
     setStatus(
@@ -13739,6 +14309,14 @@ const holidaySectionBindings = {
   flex: 1;
 }
 
+.attendance__field--compact {
+  min-width: 136px;
+}
+
+.attendance__field--compact select {
+  min-width: 136px;
+}
+
 .attendance__field--checkbox {
   flex-direction: row;
   align-items: center;
@@ -14427,7 +15005,37 @@ const holidaySectionBindings = {
 
 .attendance__records-actions {
   display: flex;
+  align-items: center;
+  flex-wrap: wrap;
   gap: 8px;
+}
+
+.attendance__report-config {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+  margin: 8px 0 12px;
+  color: #555;
+  font-size: 12px;
+}
+
+.attendance__report-config span {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+}
+
+.attendance__report-config code {
+  overflow-wrap: anywhere;
+}
+
+.attendance__report-config-item--ok {
+  color: #17633a;
+}
+
+.attendance__report-config-item--warn {
+  color: #9a3412;
 }
 
 .attendance__timeline-list {

--- a/apps/web/src/views/attendance/AttendanceReportFieldsSection.vue
+++ b/apps/web/src/views/attendance/AttendanceReportFieldsSection.vue
@@ -1,0 +1,954 @@
+<template>
+  <div class="attendance-report-fields">
+    <div class="attendance__admin-section-header">
+      <div>
+        <h4>{{ tr('Report fields', '统计字段') }}</h4>
+        <div class="attendance__section-meta">
+          {{ tr('Fields loaded', '已加载字段') }}: {{ reportFields.length }}
+          <span v-if="enabledCount"> · {{ tr('Enabled', '已启用') }}: {{ enabledCount }}</span>
+          <span v-if="visibleCount"> · {{ tr('Report visible', '报表展示') }}: {{ visibleCount }}</span>
+          <span v-if="configuredCount"> · {{ tr('Configured', '已配置') }}: {{ configuredCount }}</span>
+          <span v-if="disabledCount"> · {{ tr('Disabled', '已停用') }}: {{ disabledCount }}</span>
+          <span v-if="hiddenCount"> · {{ tr('Hidden', '已隐藏') }}: {{ hiddenCount }}</span>
+          <span v-if="multitableProjectId"> · Project: <code>{{ multitableProjectId }}</code></span>
+        </div>
+      </div>
+      <div class="attendance__admin-actions">
+        <a
+          v-if="multitableHref"
+          class="attendance__btn"
+          :href="multitableHref"
+          target="_blank"
+          rel="noreferrer"
+        >
+          {{ tr('Open multitable', '打开多维表') }}
+        </a>
+        <button class="attendance__btn" type="button" :disabled="syncing" @click="syncReportFields">
+          {{ syncing ? tr('Syncing...', '同步中...') : tr('Sync catalog', '同步字段目录') }}
+        </button>
+        <button class="attendance__btn" type="button" :disabled="loading" @click="loadReportFields">
+          {{ loading ? tr('Loading...', '加载中...') : tr('Reload fields', '重载字段') }}
+        </button>
+      </div>
+    </div>
+
+    <div
+      v-if="syncStatusMessage"
+      class="attendance__status"
+      :class="{ 'attendance__status--error': syncStatusKind === 'error' }"
+      role="status"
+    >
+      {{ syncStatusMessage }}
+    </div>
+    <div
+      v-if="loadError"
+      class="attendance__status attendance__status--error"
+      role="status"
+    >
+      {{ loadError }}
+    </div>
+    <div
+      v-else-if="multitableDegraded"
+      class="attendance__status"
+      role="status"
+    >
+      {{ tr('Using built-in report field definitions because multitable configuration is not available.', '多维表配置暂不可用，当前使用内置统计字段定义。') }}
+    </div>
+
+    <div v-if="reportFields.length === 0 && !loading" class="attendance__empty">
+      {{ tr('No report fields loaded yet.', '尚未加载统计字段。') }}
+    </div>
+
+    <div
+      v-if="reportFields.length > 0"
+      class="attendance-report-fields__filters"
+      data-report-field-filters
+    >
+      <label class="attendance-report-fields__filter" for="attendance-report-field-search">
+        <span>{{ tr('Search fields', '搜索字段') }}</span>
+        <input
+          id="attendance-report-field-search"
+          v-model="fieldSearchTerm"
+          type="search"
+          :placeholder="tr('Name, code, description', '名称、编码、说明')"
+        >
+      </label>
+      <label class="attendance-report-fields__filter" for="attendance-report-field-status-filter">
+        <span>{{ tr('Field state', '字段状态') }}</span>
+        <select
+          id="attendance-report-field-status-filter"
+          v-model="fieldStatusFilter"
+        >
+          <option value="all">{{ tr('All fields', '全部字段') }}</option>
+          <option value="configured">{{ tr('Configured', '已配置') }}</option>
+          <option value="disabled">{{ tr('Disabled', '已停用') }}</option>
+          <option value="hidden">{{ tr('Hidden', '已隐藏') }}</option>
+        </select>
+      </label>
+      <label class="attendance-report-fields__filter" for="attendance-report-field-category-filter">
+        <span>{{ tr('Category', '分类') }}</span>
+        <select
+          id="attendance-report-field-category-filter"
+          v-model="fieldCategoryFilter"
+        >
+          <option value="all">{{ tr('All categories', '全部分类') }}</option>
+          <option
+            v-for="category in categoryFilterOptions"
+            :key="category.id"
+            :value="category.id"
+          >
+            {{ category.label }}
+          </option>
+        </select>
+      </label>
+      <div class="attendance-report-fields__filter-summary">
+        {{ tr('Filtered fields', '筛选字段') }}: {{ filteredReportFields.length }} / {{ reportFields.length }}
+      </div>
+      <button
+        class="attendance__btn"
+        type="button"
+        :disabled="!hasActiveFieldFilters"
+        data-report-field-reset-filters
+        @click="resetReportFieldFilters"
+      >
+        {{ tr('Reset filters', '重置筛选') }}
+      </button>
+      <div
+        v-if="activeFieldFilterLabels.length > 0"
+        class="attendance-report-fields__active-filters"
+        data-report-field-active-filters
+      >
+        {{ tr('Active filters', '当前筛选') }}: {{ activeFieldFilterLabels.join(' · ') }}
+      </div>
+    </div>
+
+    <div
+      v-if="multitableDetailRows.length > 0"
+      class="attendance-report-fields__basis"
+      data-report-field-multitable-status
+    >
+      <div class="attendance-report-fields__basis-header">
+        <div class="attendance-report-fields__basis-title">
+          {{ tr('Multitable backing', '多维表底座') }}
+        </div>
+        <span
+          class="attendance-report-fields__status-pill"
+          :class="{
+            'attendance-report-fields__status-pill--ok': multitableConnected,
+            'attendance-report-fields__status-pill--warn': multitableDegraded,
+            'attendance-report-fields__status-pill--off': !multitableConnected && !multitableDegraded,
+          }"
+        >
+          {{ multitableStatusLabel }}
+        </span>
+      </div>
+      <dl class="attendance-report-fields__basis-details">
+        <div
+          v-for="row in multitableDetailRows"
+          :key="row.key"
+          class="attendance-report-fields__basis-detail"
+          :data-report-field-multitable-detail="row.key"
+        >
+          <dt>{{ row.label }}</dt>
+          <dd>
+            <code v-if="row.monospace">{{ row.value }}</code>
+            <span v-else>{{ row.value }}</span>
+          </dd>
+        </div>
+      </dl>
+    </div>
+
+    <div v-if="reportFields.length > 0 && filteredReportFields.length === 0" class="attendance__empty">
+      {{ tr('No report fields match the current filters.', '当前筛选条件下没有匹配的统计字段。') }}
+    </div>
+
+    <div v-if="filteredReportFields.length > 0" class="attendance-report-fields__grid">
+      <section
+        v-for="category in visibleCategories"
+        :key="category.id"
+        class="attendance-report-fields__category"
+        :data-report-field-category="category.id"
+      >
+        <div class="attendance-report-fields__category-header">
+          <div>
+            <h5>{{ category.label }}</h5>
+            <div class="attendance__section-meta">
+              {{ tr('Fields', '字段') }}: {{ categoryStats(category.id).total }}
+              <span> · {{ tr('Enabled', '启用') }}: {{ categoryStats(category.id).enabled }}</span>
+              <span> · {{ tr('Visible', '展示') }}: {{ categoryStats(category.id).visible }}</span>
+            </div>
+          </div>
+        </div>
+        <div class="attendance__table-wrapper attendance-report-fields__table-wrapper">
+          <table class="attendance__table attendance-report-fields__table">
+            <thead>
+              <tr>
+                <th>{{ tr('Field', '字段') }}</th>
+                <th>{{ tr('Code', '编码') }}</th>
+                <th>{{ tr('Unit', '单位') }}</th>
+                <th>{{ tr('Enabled', '启用') }}</th>
+                <th>{{ tr('Report', '报表') }}</th>
+                <th>{{ tr('Source', '来源') }}</th>
+                <th>{{ tr('Configuration', '配置') }}</th>
+                <th>{{ tr('Mapping', '映射') }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="field in fieldsByCategory(category.id)" :key="field.code">
+                <td>
+                  <strong>{{ field.name }}</strong>
+                  <div class="attendance__field-hint">{{ field.description || field.dingtalkFieldName }}</div>
+                </td>
+                <td><code>{{ field.code }}</code></td>
+                <td>{{ formatUnit(field.unit) }}</td>
+                <td>
+                  <span class="attendance-report-fields__pill" :class="{ 'attendance-report-fields__pill--off': !field.enabled }">
+                    {{ field.enabled ? tr('On', '开') : tr('Off', '关') }}
+                  </span>
+                </td>
+                <td>
+                  <span class="attendance-report-fields__pill" :class="{ 'attendance-report-fields__pill--off': !field.reportVisible }">
+                    {{ field.reportVisible ? tr('Shown', '展示') : tr('Hidden', '隐藏') }}
+                  </span>
+                </td>
+                <td>{{ formatSource(field.source, field.systemDefined) }}</td>
+                <td>
+                  <span
+                    class="attendance-report-fields__pill"
+                    :class="configurationPillClass(field)"
+                  >
+                    {{ formatConfigurationSource(field) }}
+                  </span>
+                </td>
+                <td class="attendance-report-fields__mapping">
+                  <div
+                    v-for="row in fieldMappingRows(field)"
+                    :key="row.key"
+                    class="attendance-report-fields__mapping-row"
+                  >
+                    <span>{{ row.label }}</span>
+                    <code v-if="row.monospace">{{ row.value }}</code>
+                    <strong v-else>{{ row.value }}</strong>
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { apiFetch } from '../../utils/api'
+import { readErrorMessage } from '../../utils/error'
+
+type TranslateFn = (en: string, zh: string) => string
+type ReportFieldStatusFilter = 'all' | 'configured' | 'disabled' | 'hidden'
+
+interface AttendanceReportFieldCategory {
+  id: string
+  label: string
+  sortOrder: number
+}
+
+interface AttendanceReportFieldItem {
+  code: string
+  name: string
+  category: string
+  categoryLabel: string
+  source: string
+  unit: string
+  enabled: boolean
+  reportVisible: boolean
+  sortOrder: number
+  dingtalkFieldName?: string
+  description?: string
+  internalKey?: string
+  configured?: boolean
+  systemDefined?: boolean
+}
+
+interface AttendanceReportFieldsPayload {
+  categories?: AttendanceReportFieldCategory[]
+  items?: AttendanceReportFieldItem[]
+  reportFieldConfig?: {
+    fieldsFingerprint?: {
+      algorithm?: string
+      value?: string
+      fieldCount?: number
+      codes?: string[]
+    }
+  }
+  multitable?: {
+    available?: boolean
+    degraded?: boolean
+    reason?: string | null
+    error?: string | null
+    projectId?: string
+    objectId?: string | null
+    baseId?: string | null
+    sheetId?: string | null
+    viewId?: string | null
+    seeded?: number
+    existing?: number
+    recordCount?: number
+  }
+}
+
+interface MultitableDetailRow {
+  key: string
+  label: string
+  value: string
+  monospace?: boolean
+}
+
+interface FieldMappingRow {
+  key: string
+  label: string
+  value: string
+  monospace?: boolean
+}
+
+const props = defineProps<{
+  tr: TranslateFn
+  orgId?: string
+}>()
+
+const tr = props.tr
+const loading = ref(false)
+const syncing = ref(false)
+const loadError = ref('')
+const syncStatusMessage = ref('')
+const syncStatusKind = ref<'info' | 'error'>('info')
+const fieldSearchTerm = ref('')
+const fieldStatusFilter = ref<ReportFieldStatusFilter>('all')
+const fieldCategoryFilter = ref('all')
+const reportFieldsPayload = ref<AttendanceReportFieldsPayload>({
+  categories: [],
+  items: [],
+  multitable: { available: false },
+})
+
+const reportFields = computed(() => reportFieldsPayload.value.items ?? [])
+const enabledCount = computed(() => reportFields.value.filter(field => field.enabled).length)
+const visibleCount = computed(() => reportFields.value.filter(field => field.reportVisible).length)
+const configuredCount = computed(() => reportFields.value.filter(field => field.configured).length)
+const disabledCount = computed(() => reportFields.value.filter(field => field.enabled === false).length)
+const hiddenCount = computed(() => reportFields.value.filter(field => field.reportVisible === false).length)
+const hasActiveFieldFilters = computed(() => (
+  fieldSearchTerm.value.trim() !== ''
+  || fieldStatusFilter.value !== 'all'
+  || fieldCategoryFilter.value !== 'all'
+))
+const filteredReportFields = computed(() => {
+  const search = fieldSearchTerm.value.trim().toLowerCase()
+  return reportFields.value.filter((field) => {
+    if (!matchesFieldStatusFilter(field)) return false
+    if (fieldCategoryFilter.value !== 'all' && field.category !== fieldCategoryFilter.value) return false
+    if (!search) return true
+    const haystack = [
+      field.code,
+      field.name,
+      field.category,
+      field.categoryLabel,
+      field.source,
+      field.unit,
+      field.dingtalkFieldName,
+      field.description,
+      field.internalKey,
+    ].map(value => String(value ?? '').toLowerCase())
+    return haystack.some(value => value.includes(search))
+  })
+})
+const categoryFilterOptions = computed<AttendanceReportFieldCategory[]>(() => {
+  const categories = reportFieldsPayload.value.categories ?? []
+  const categoryIdsWithFields = new Set(reportFields.value.map(field => field.category))
+  if (categories.length > 0) {
+    return categories
+      .filter(category => categoryIdsWithFields.has(category.id))
+      .sort((left, right) => left.sortOrder - right.sortOrder)
+  }
+  const fallback = new Map<string, AttendanceReportFieldCategory>()
+  for (const field of reportFields.value) {
+    if (!fallback.has(field.category)) {
+      fallback.set(field.category, {
+        id: field.category,
+        label: field.categoryLabel || field.category,
+        sortOrder: field.sortOrder,
+      })
+    }
+  }
+  return Array.from(fallback.values()).sort((left, right) => left.sortOrder - right.sortOrder)
+})
+const activeFieldFilterLabels = computed(() => {
+  const labels: string[] = []
+  const search = fieldSearchTerm.value.trim()
+  if (search) labels.push(`${tr('Search', '搜索')}: ${search}`)
+  if (fieldStatusFilter.value !== 'all') {
+    labels.push(`${tr('State', '状态')}: ${formatStatusFilterLabel(fieldStatusFilter.value)}`)
+  }
+  if (fieldCategoryFilter.value !== 'all') {
+    const category = categoryFilterOptions.value.find(item => item.id === fieldCategoryFilter.value)
+    labels.push(`${tr('Category', '分类')}: ${category?.label || fieldCategoryFilter.value}`)
+  }
+  return labels
+})
+const multitableState = computed(() => reportFieldsPayload.value.multitable ?? { available: false })
+const multitableProjectId = computed(() => multitableState.value.projectId || '')
+const multitableConnected = computed(() => Boolean(multitableState.value.available && !multitableState.value.degraded))
+const multitableDegraded = computed(() => Boolean(multitableState.value.degraded))
+const multitableStatusLabel = computed(() => {
+  if (multitableConnected.value) return tr('Connected', '已连接')
+  if (multitableDegraded.value) return tr('Degraded', '已降级')
+  return tr('Unavailable', '不可用')
+})
+const multitableHref = computed(() => {
+  const multitable = multitableState.value
+  if (!multitable?.sheetId || !multitable.viewId) return ''
+  const params = new URLSearchParams()
+  if (multitable.baseId) params.set('baseId', multitable.baseId)
+  const suffix = params.toString()
+  return `/multitable/${encodeURIComponent(multitable.sheetId)}/${encodeURIComponent(multitable.viewId)}${suffix ? `?${suffix}` : ''}`
+})
+const multitableDetailRows = computed<MultitableDetailRow[]>(() => {
+  const multitable = multitableState.value
+  const rows: MultitableDetailRow[] = []
+  const addId = (key: string, label: string, value?: string | null) => {
+    const normalized = String(value ?? '').trim()
+    if (normalized) rows.push({ key, label, value: normalized, monospace: true })
+  }
+  const addNumber = (key: string, label: string, value?: number) => {
+    if (Number.isFinite(value)) rows.push({ key, label, value: String(value) })
+  }
+
+  addId('projectId', tr('Project ID', '项目 ID'), multitable.projectId)
+  addId('objectId', tr('Object ID', '对象 ID'), multitable.objectId)
+  addId('baseId', tr('Base ID', '底座 ID'), multitable.baseId)
+  addId('sheetId', tr('Sheet ID', '表格 ID'), multitable.sheetId)
+  addId('viewId', tr('View ID', '视图 ID'), multitable.viewId)
+  addNumber('recordCount', tr('Catalog records', '目录记录'), multitable.recordCount)
+  addNumber('seeded', tr('Seeded', '本次写入'), multitable.seeded)
+  addNumber('existing', tr('Existing', '已存在'), multitable.existing)
+  const fingerprint = reportFieldsPayload.value.reportFieldConfig?.fieldsFingerprint
+  addId('fieldsFingerprintAlgorithm', tr('Fingerprint algorithm', '指纹算法'), fingerprint?.algorithm)
+  addId('fieldsFingerprint', tr('Field fingerprint', '字段指纹'), fingerprint?.value)
+  addNumber('fieldsFingerprintCount', tr('Fingerprint fields', '指纹字段数'), fingerprint?.fieldCount)
+  addId('reason', tr('Reason', '原因'), multitable.reason)
+  const error = String(multitable.error ?? '').trim()
+  if (error) rows.push({ key: 'error', label: tr('Error', '错误'), value: error })
+  return rows
+})
+
+const visibleCategories = computed<AttendanceReportFieldCategory[]>(() => {
+  const categoryIdsWithFields = new Set(filteredReportFields.value.map(field => field.category))
+  if (categoryFilterOptions.value.length > 0) {
+    return categoryFilterOptions.value
+      .filter(category => categoryIdsWithFields.has(category.id))
+  }
+  const fallback = new Map<string, AttendanceReportFieldCategory>()
+  for (const field of filteredReportFields.value) {
+    if (!fallback.has(field.category)) {
+      fallback.set(field.category, {
+        id: field.category,
+        label: field.categoryLabel || field.category,
+        sortOrder: field.sortOrder,
+      })
+    }
+  }
+  return Array.from(fallback.values()).sort((left, right) => left.sortOrder - right.sortOrder)
+})
+
+function fieldsByCategory(categoryId: string): AttendanceReportFieldItem[] {
+  return filteredReportFields.value
+    .filter(field => field.category === categoryId)
+    .sort((left, right) => {
+      if (left.sortOrder !== right.sortOrder) return left.sortOrder - right.sortOrder
+      return left.code.localeCompare(right.code)
+    })
+}
+
+function categoryStats(categoryId: string) {
+  const fields = fieldsByCategory(categoryId)
+  return {
+    total: fields.length,
+    enabled: fields.filter(field => field.enabled).length,
+    visible: fields.filter(field => field.reportVisible).length,
+  }
+}
+
+function matchesFieldStatusFilter(field: AttendanceReportFieldItem): boolean {
+  if (fieldStatusFilter.value === 'configured') return Boolean(field.configured)
+  if (fieldStatusFilter.value === 'disabled') return field.enabled === false
+  if (fieldStatusFilter.value === 'hidden') return field.reportVisible === false
+  return true
+}
+
+function formatStatusFilterLabel(value: ReportFieldStatusFilter): string {
+  if (value === 'configured') return tr('Configured', '已配置')
+  if (value === 'disabled') return tr('Disabled', '已停用')
+  if (value === 'hidden') return tr('Hidden', '已隐藏')
+  return tr('All fields', '全部字段')
+}
+
+function resetReportFieldFilters(): void {
+  fieldSearchTerm.value = ''
+  fieldStatusFilter.value = 'all'
+  fieldCategoryFilter.value = 'all'
+}
+
+function formatUnit(unit: string): string {
+  const normalized = String(unit || '').trim()
+  const labels: Record<string, string> = {
+    text: tr('Text', '文本'),
+    dateTime: tr('Date time', '日期时间'),
+    days: tr('Days', '天'),
+    minutes: tr('Minutes', '分钟'),
+    count: tr('Count', '次数'),
+    hours: tr('Hours', '小时'),
+  }
+  return labels[normalized] ?? (normalized || '--')
+}
+
+function formatSource(source: string, systemDefined?: boolean): string {
+  const normalized = String(source || '').trim()
+  if (normalized === 'system') return tr('System', '系统')
+  if (normalized === 'dingtalk') return tr('DingTalk', '钉钉')
+  if (normalized === 'multitable') return tr('Multitable', '多维表')
+  if (normalized === 'custom') return tr('Custom', '自定义')
+  return normalized || (systemDefined ? tr('System', '系统') : '--')
+}
+
+function formatConfigurationSource(field: AttendanceReportFieldItem): string {
+  if (field.systemDefined === false) return tr('Custom', '自定义')
+  if (field.configured) return tr('Configured', '已配置')
+  return tr('Built-in', '内置')
+}
+
+function configurationPillClass(field: AttendanceReportFieldItem): Record<string, boolean> {
+  return {
+    'attendance-report-fields__pill--configured': Boolean(field.configured && field.systemDefined !== false),
+    'attendance-report-fields__pill--custom': field.systemDefined === false,
+  }
+}
+
+function fieldMappingRows(field: AttendanceReportFieldItem): FieldMappingRow[] {
+  const rows: FieldMappingRow[] = []
+  const dingtalkFieldName = String(field.dingtalkFieldName ?? '').trim()
+  const internalKey = String(field.internalKey ?? '').trim()
+  const sortOrder = Number(field.sortOrder)
+  if (dingtalkFieldName) {
+    rows.push({
+      key: 'dingtalkFieldName',
+      label: tr('DingTalk field', '钉钉字段'),
+      value: dingtalkFieldName,
+    })
+  }
+  if (internalKey) {
+    rows.push({
+      key: 'internalKey',
+      label: tr('Internal key', '内部键'),
+      value: internalKey,
+      monospace: true,
+    })
+  }
+  if (Number.isFinite(sortOrder)) {
+    rows.push({
+      key: 'sortOrder',
+      label: tr('Order', '排序'),
+      value: String(sortOrder),
+      monospace: true,
+    })
+  }
+  return rows
+}
+
+function syncStatusMetric(labelEn: string, labelZh: string, value?: number): string {
+  return Number.isFinite(value) ? `${tr(labelEn, labelZh)}: ${value}` : ''
+}
+
+function buildSyncStatusMessage(data: AttendanceReportFieldsPayload): string {
+  const multitable = data.multitable ?? {}
+  const details = [
+    syncStatusMetric('Seeded', '本次写入', multitable.seeded),
+    syncStatusMetric('Existing', '已存在', multitable.existing),
+    syncStatusMetric('Records', '记录数', multitable.recordCount),
+  ].filter(Boolean)
+
+  if (multitable.degraded) {
+    details.push(`${tr('Status', '状态')}: ${tr('Degraded', '已降级')}`)
+  } else if (multitable.available) {
+    details.push(`${tr('Status', '状态')}: ${tr('Connected', '已连接')}`)
+  }
+
+  const summary = details.length > 0 ? ` ${details.join(' · ')}` : ''
+  return `${tr('Report field catalog synchronized.', '统计字段目录已同步。')}${summary}`
+}
+
+async function loadReportFields(): Promise<void> {
+  loading.value = true
+  loadError.value = ''
+  try {
+    const params = new URLSearchParams()
+    const orgId = props.orgId?.trim()
+    if (orgId) params.set('orgId', orgId)
+    const suffix = params.toString()
+    const response = await apiFetch(`/api/attendance/report-fields${suffix ? `?${suffix}` : ''}`)
+    const payload = await response.json()
+    if (!response.ok || payload?.ok === false) {
+      throw payload
+    }
+    reportFieldsPayload.value = payload?.data ?? { categories: [], items: [], multitable: { available: false } }
+  } catch (error) {
+    loadError.value = readErrorMessage(error, tr('Failed to load report fields', '加载统计字段失败'))
+  } finally {
+    loading.value = false
+  }
+}
+
+async function syncReportFields(): Promise<void> {
+  syncing.value = true
+  syncStatusMessage.value = ''
+  syncStatusKind.value = 'info'
+  try {
+    const params = new URLSearchParams()
+    const orgId = props.orgId?.trim()
+    if (orgId) params.set('orgId', orgId)
+    const suffix = params.toString()
+    const response = await apiFetch(`/api/attendance/report-fields/sync${suffix ? `?${suffix}` : ''}`, {
+      method: 'POST',
+    })
+    const payload = await response.json()
+    if (!response.ok || payload?.ok === false) {
+      throw payload
+    }
+    const data = payload?.data ?? { categories: [], items: [], multitable: { available: false } }
+    reportFieldsPayload.value = data
+    syncStatusMessage.value = buildSyncStatusMessage(data)
+  } catch (error) {
+    syncStatusKind.value = 'error'
+    syncStatusMessage.value = readErrorMessage(error, tr('Failed to sync report fields', '同步统计字段失败'))
+  } finally {
+    syncing.value = false
+  }
+}
+
+watch(
+  () => props.orgId,
+  () => {
+    void loadReportFields()
+  },
+  { immediate: true },
+)
+</script>
+
+<style scoped>
+.attendance-report-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.attendance__admin-section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.attendance__admin-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.attendance__section-meta,
+.attendance__field-hint {
+  color: #64748b;
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.attendance__btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 34px;
+  padding: 7px 12px;
+  border: 1px solid #cbd5e1;
+  border-radius: 6px;
+  background: #fff;
+  color: #1f2937;
+  font-size: 13px;
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.attendance__btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.attendance__status,
+.attendance__empty {
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: #f8fafc;
+  color: #475569;
+  font-size: 13px;
+}
+
+.attendance__status--error {
+  border: 1px solid #fecaca;
+  background: #fff1f2;
+  color: #b91c1c;
+}
+
+.attendance__table-wrapper {
+  width: 100%;
+  overflow-x: auto;
+}
+
+.attendance__table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.attendance__table th,
+.attendance__table td {
+  border-bottom: 1px solid #e2e8f0;
+  padding: 9px 10px;
+  text-align: left;
+  font-size: 13px;
+}
+
+.attendance__table th {
+  color: #475569;
+  font-weight: 700;
+  background: #f8fafc;
+}
+
+.attendance-report-fields__grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 12px;
+}
+
+.attendance-report-fields__filters {
+  display: flex;
+  align-items: end;
+  flex-wrap: wrap;
+  gap: 10px;
+  padding: 12px 14px;
+  border: 1px solid #d8dee8;
+  border-radius: 8px;
+  background: #fff;
+}
+
+.attendance-report-fields__filter {
+  display: grid;
+  gap: 4px;
+  min-width: 180px;
+  color: #475569;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.attendance-report-fields__filter input,
+.attendance-report-fields__filter select {
+  min-height: 34px;
+  padding: 6px 9px;
+  border: 1px solid #cbd5e1;
+  border-radius: 6px;
+  background: #fff;
+  color: #1f2937;
+  font-size: 13px;
+}
+
+.attendance-report-fields__filter-summary {
+  min-height: 34px;
+  display: inline-flex;
+  align-items: center;
+  color: #64748b;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.attendance-report-fields__active-filters {
+  flex: 1 1 100%;
+  color: #64748b;
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.attendance-report-fields__basis {
+  display: grid;
+  gap: 10px;
+  padding: 12px 14px;
+  border: 1px solid #d8dee8;
+  border-radius: 8px;
+  background: #fff;
+}
+
+.attendance-report-fields__basis-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.attendance-report-fields__basis-title {
+  color: #1f2937;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.attendance-report-fields__basis-details {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 8px 12px;
+  margin: 0;
+}
+
+.attendance-report-fields__basis-detail {
+  min-width: 0;
+}
+
+.attendance-report-fields__basis-detail dt {
+  color: #64748b;
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.attendance-report-fields__basis-detail dd {
+  margin: 2px 0 0;
+  color: #1f2937;
+  font-size: 13px;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.attendance-report-fields__basis-detail code {
+  font-size: 12px;
+}
+
+.attendance-report-fields__category {
+  border: 1px solid #d8dee8;
+  border-radius: 8px;
+  background: #fff;
+  overflow: hidden;
+}
+
+.attendance-report-fields__category-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px;
+  border-bottom: 1px solid #edf1f5;
+  background: #f8fafc;
+}
+
+.attendance-report-fields__category h5 {
+  margin: 0 0 4px;
+  font-size: 14px;
+}
+
+.attendance-report-fields__table-wrapper {
+  margin: 0;
+  border: 0;
+  border-radius: 0;
+}
+
+.attendance-report-fields__table th,
+.attendance-report-fields__table td {
+  vertical-align: top;
+}
+
+.attendance-report-fields__pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: #e9f7ef;
+  color: #17633a;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.attendance-report-fields__pill--off {
+  background: #f1f5f9;
+  color: #64748b;
+}
+
+.attendance-report-fields__pill--configured {
+  background: #e0f2fe;
+  color: #075985;
+}
+
+.attendance-report-fields__pill--custom {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.attendance-report-fields__mapping {
+  min-width: 180px;
+}
+
+.attendance-report-fields__mapping-row {
+  display: grid;
+  gap: 2px;
+  margin-bottom: 6px;
+}
+
+.attendance-report-fields__mapping-row:last-child {
+  margin-bottom: 0;
+}
+
+.attendance-report-fields__mapping-row span {
+  color: #64748b;
+  font-size: 11px;
+  line-height: 1.3;
+}
+
+.attendance-report-fields__mapping-row strong,
+.attendance-report-fields__mapping-row code {
+  color: #1f2937;
+  font-size: 12px;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.attendance-report-fields__status-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 72px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: #f1f5f9;
+  color: #64748b;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.attendance-report-fields__status-pill--ok {
+  background: #e9f7ef;
+  color: #17633a;
+}
+
+.attendance-report-fields__status-pill--warn {
+  background: #fff7ed;
+  color: #9a3412;
+}
+
+.attendance-report-fields__status-pill--off {
+  background: #f1f5f9;
+  color: #64748b;
+}
+</style>

--- a/apps/web/src/views/attendance/useAttendanceAdminRail.ts
+++ b/apps/web/src/views/attendance/useAttendanceAdminRail.ts
@@ -22,6 +22,7 @@ export const ATTENDANCE_ADMIN_SECTION_IDS = {
   groupMembers: 'attendance-admin-group-members',
   import: 'attendance-admin-import',
   importBatches: 'attendance-admin-import-batches',
+  reportFields: 'attendance-admin-report-fields',
   payrollTemplates: 'attendance-admin-payroll-templates',
   payrollCycles: 'attendance-admin-payroll-cycles',
   leaveTypes: 'attendance-admin-leave-types',
@@ -167,6 +168,7 @@ export function useAttendanceAdminRail({
     { id: ATTENDANCE_ADMIN_SECTION_IDS.groupMembers, label: tr('Group members', '分组成员') },
     { id: ATTENDANCE_ADMIN_SECTION_IDS.import, label: tr('Import', '导入') },
     { id: ATTENDANCE_ADMIN_SECTION_IDS.importBatches, label: tr('Import batches', '导入批次') },
+    { id: ATTENDANCE_ADMIN_SECTION_IDS.reportFields, label: tr('Report fields', '统计字段') },
     { id: ATTENDANCE_ADMIN_SECTION_IDS.payrollTemplates, label: tr('Payroll Templates', '计薪模板') },
     { id: ATTENDANCE_ADMIN_SECTION_IDS.payrollCycles, label: tr('Payroll Cycles', '计薪周期') },
     { id: ATTENDANCE_ADMIN_SECTION_IDS.leaveTypes, label: tr('Leave Types', '请假类型') },
@@ -228,6 +230,7 @@ export function useAttendanceAdminRail({
       itemIds: [
         ATTENDANCE_ADMIN_SECTION_IDS.import,
         ATTENDANCE_ADMIN_SECTION_IDS.importBatches,
+        ATTENDANCE_ADMIN_SECTION_IDS.reportFields,
         ATTENDANCE_ADMIN_SECTION_IDS.payrollTemplates,
         ATTENDANCE_ADMIN_SECTION_IDS.payrollCycles,
       ],

--- a/apps/web/tests/AttendanceReportFieldsSection.spec.ts
+++ b/apps/web/tests/AttendanceReportFieldsSection.spec.ts
@@ -1,0 +1,268 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, nextTick, type App } from 'vue'
+import AttendanceReportFieldsSection from '../src/views/attendance/AttendanceReportFieldsSection.vue'
+import { apiFetch } from '../src/utils/api'
+
+vi.mock('../src/utils/api', () => ({
+  apiFetch: vi.fn(),
+}))
+
+function jsonResponse(status: number, payload: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => payload,
+    text: async () => JSON.stringify(payload),
+  } as unknown as Response
+}
+
+async function flushUi(cycles = 5): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+function populatedCatalogPayload() {
+  return {
+    ok: true,
+    data: {
+      categories: [
+        { id: 'fixed', label: '固定字段', sortOrder: 10 },
+        { id: 'basic', label: '基础字段', sortOrder: 20 },
+        { id: 'attendance', label: '出勤统计字段', sortOrder: 30 },
+        { id: 'anomaly', label: '异常统计字段', sortOrder: 40 },
+        { id: 'leave', label: '请假统计字段', sortOrder: 50 },
+        { id: 'overtime', label: '加班统计字段', sortOrder: 60 },
+      ],
+      items: [
+        { code: 'employee_name', name: '姓名', category: 'fixed', categoryLabel: '固定字段', source: 'system', unit: 'text', enabled: true, reportVisible: true, sortOrder: 1001, dingtalkFieldName: '姓名', description: '员工姓名', internalKey: 'employee.name', systemDefined: true },
+        { code: 'punch_result', name: '打卡结果', category: 'basic', categoryLabel: '基础字段', source: 'system', unit: 'text', enabled: true, reportVisible: true, sortOrder: 2001, dingtalkFieldName: '打卡结果', description: '打卡是否正常', internalKey: 'record.punchResult', systemDefined: true },
+        { code: 'attendance_days', name: '出勤天数', category: 'attendance', categoryLabel: '出勤统计字段', source: 'system', unit: 'days', enabled: true, reportVisible: true, sortOrder: 3001, dingtalkFieldName: '出勤天数', description: '有效出勤天数', internalKey: 'summary.attendanceDays', systemDefined: true },
+        { code: 'late_count', name: '迟到次数', category: 'anomaly', categoryLabel: '异常统计字段', source: 'system', unit: 'count', enabled: true, reportVisible: false, sortOrder: 4001, dingtalkFieldName: '迟到次数', description: '迟到次数', internalKey: 'summary.lateCount', configured: true, systemDefined: true },
+        { code: 'leave_duration', name: '请假时长', category: 'leave', categoryLabel: '请假统计字段', source: 'system', unit: 'minutes', enabled: true, reportVisible: true, sortOrder: 5001, dingtalkFieldName: '请假时长', description: '请假分钟数', internalKey: 'summary.leaveMinutes', systemDefined: true },
+        { code: 'workday_overtime_duration', name: '工作日加班时长', category: 'overtime', categoryLabel: '加班统计字段', source: 'system', unit: 'minutes', enabled: false, reportVisible: true, sortOrder: 6001, dingtalkFieldName: '工作日加班时长', description: '工作日加班分钟数', internalKey: 'summary.workdayOvertimeMinutes', systemDefined: true },
+      ],
+      multitable: {
+        available: true,
+        degraded: false,
+        projectId: 'org-1:attendance',
+        objectId: 'attendance_report_field_catalog',
+        baseId: 'base-1',
+        sheetId: 'sheet-1',
+        viewId: 'view-1',
+        seeded: 0,
+        existing: 6,
+        recordCount: 6,
+      },
+      reportFieldConfig: {
+        fieldsFingerprint: {
+          algorithm: 'sha1',
+          value: 'unit-test-report-fields-fingerprint',
+          fieldCount: 6,
+          codes: [
+            'employee_name',
+            'punch_result',
+            'attendance_days',
+            'late_count',
+            'leave_duration',
+            'workday_overtime_duration',
+          ],
+        },
+      },
+    },
+  }
+}
+
+describe('AttendanceReportFieldsSection', () => {
+  let app: App<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    container = document.createElement('div')
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+  })
+
+  function mountSection(orgId = 'org-1') {
+    app = createApp(AttendanceReportFieldsSection, {
+      tr: (en: string) => en,
+      orgId,
+    })
+    app.mount(container!)
+  }
+
+  it('renders DingTalk-compatible report field categories and multitable entry', async () => {
+    vi.mocked(apiFetch).mockResolvedValue(jsonResponse(200, populatedCatalogPayload()))
+
+    mountSection()
+    await flushUi()
+
+    expect(apiFetch).toHaveBeenCalledWith('/api/attendance/report-fields?orgId=org-1')
+    expect(container!.textContent).toContain('Report fields')
+    expect(container!.textContent).toContain('固定字段')
+    expect(container!.textContent).toContain('基础字段')
+    expect(container!.textContent).toContain('出勤统计字段')
+    expect(container!.textContent).toContain('异常统计字段')
+    expect(container!.textContent).toContain('请假统计字段')
+    expect(container!.textContent).toContain('加班统计字段')
+    expect(container!.textContent).toContain('Configured: 1')
+    expect(container!.textContent).toContain('Disabled: 1')
+    expect(container!.textContent).toContain('Hidden: 1')
+    expect(container!.textContent).toContain('Configuration')
+    expect(container!.textContent).toContain('Mapping')
+    expect(container!.textContent).toContain('Built-in')
+    expect(container!.textContent).toContain('Configured')
+    expect(container!.textContent).toContain('DingTalk field')
+    expect(container!.textContent).toContain('Internal key')
+    expect(container!.textContent).toContain('summary.lateCount')
+    expect(container!.textContent).toContain('Order')
+    expect(container!.textContent).toContain('4001')
+    expect(container!.querySelector<HTMLAnchorElement>('a.attendance__btn')?.getAttribute('href')).toBe('/multitable/sheet-1/view-1?baseId=base-1')
+    expect(container!.querySelector('[data-report-field-multitable-status]')?.textContent).toContain('Connected')
+    expect(container!.querySelector('[data-report-field-multitable-detail="projectId"]')?.textContent).toContain('org-1:attendance')
+    expect(container!.querySelector('[data-report-field-multitable-detail="objectId"]')?.textContent).toContain('attendance_report_field_catalog')
+    expect(container!.querySelector('[data-report-field-multitable-detail="sheetId"]')?.textContent).toContain('sheet-1')
+    expect(container!.querySelector('[data-report-field-multitable-detail="recordCount"]')?.textContent).toContain('6')
+    expect(container!.querySelector('[data-report-field-multitable-detail="fieldsFingerprintAlgorithm"]')?.textContent).toContain('sha1')
+    expect(container!.querySelector('[data-report-field-multitable-detail="fieldsFingerprint"]')?.textContent).toContain('unit-test-report-fields-fingerprint')
+    expect(container!.querySelector('[data-report-field-multitable-detail="fieldsFingerprintCount"]')?.textContent).toContain('6')
+
+    const syncButton = Array.from(container!.querySelectorAll<HTMLButtonElement>('button'))
+      .find(button => button.textContent?.includes('Sync catalog'))
+    expect(syncButton).toBeTruthy()
+    syncButton!.click()
+    await flushUi()
+    expect(apiFetch).toHaveBeenCalledWith('/api/attendance/report-fields/sync?orgId=org-1', {
+      method: 'POST',
+    })
+    const syncStatus = Array.from(container!.querySelectorAll<HTMLElement>('[role="status"]'))
+      .find(element => element.textContent?.includes('Report field catalog synchronized.'))
+    expect(syncStatus?.textContent).toContain('Seeded: 0')
+    expect(syncStatus?.textContent).toContain('Existing: 6')
+    expect(syncStatus?.textContent).toContain('Records: 6')
+    expect(syncStatus?.textContent).toContain('Status: Connected')
+  })
+
+  it('filters report fields by text and operational state', async () => {
+    vi.mocked(apiFetch).mockResolvedValue(jsonResponse(200, populatedCatalogPayload()))
+
+    mountSection()
+    await flushUi()
+
+    const searchInput = container!.querySelector<HTMLInputElement>('#attendance-report-field-search')
+    const statusSelect = container!.querySelector<HTMLSelectElement>('#attendance-report-field-status-filter')
+    const categorySelect = container!.querySelector<HTMLSelectElement>('#attendance-report-field-category-filter')
+    const resetButton = container!.querySelector<HTMLButtonElement>('[data-report-field-reset-filters]')
+    expect(searchInput).toBeTruthy()
+    expect(statusSelect).toBeTruthy()
+    expect(categorySelect).toBeTruthy()
+    expect(resetButton).toBeTruthy()
+    expect(resetButton!.disabled).toBe(true)
+    expect(container!.textContent).toContain('Filtered fields: 6 / 6')
+
+    categorySelect!.value = 'leave'
+    categorySelect!.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+    expect(container!.textContent).toContain('Filtered fields: 1 / 6')
+    expect(container!.querySelector('[data-report-field-active-filters]')?.textContent).toContain('Category: 请假统计字段')
+    expect(resetButton!.disabled).toBe(false)
+    expect(container!.textContent).toContain('leave_duration')
+    expect(container!.textContent).not.toContain('late_count')
+
+    statusSelect!.value = 'hidden'
+    statusSelect!.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+    expect(container!.textContent).toContain('Filtered fields: 0 / 6')
+    expect(container!.querySelector('[data-report-field-active-filters]')?.textContent).toContain('State: Hidden')
+    expect(container!.textContent).toContain('No report fields match the current filters.')
+
+    resetButton!.click()
+    await flushUi()
+    expect(searchInput!.value).toBe('')
+    expect(statusSelect!.value).toBe('all')
+    expect(categorySelect!.value).toBe('all')
+    expect(resetButton!.disabled).toBe(true)
+    expect(container!.querySelector('[data-report-field-active-filters]')).toBeNull()
+    expect(container!.textContent).toContain('Filtered fields: 6 / 6')
+
+    categorySelect!.value = 'all'
+    categorySelect!.dispatchEvent(new Event('change', { bubbles: true }))
+    statusSelect!.value = 'all'
+    statusSelect!.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+    expect(container!.textContent).toContain('Filtered fields: 6 / 6')
+
+    searchInput!.value = 'late_count'
+    searchInput!.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+    expect(container!.textContent).toContain('Filtered fields: 1 / 6')
+    expect(container!.textContent).toContain('late_count')
+    expect(container!.textContent).not.toContain('employee_name')
+
+    searchInput!.value = ''
+    searchInput!.dispatchEvent(new Event('input', { bubbles: true }))
+    statusSelect!.value = 'disabled'
+    statusSelect!.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+    expect(container!.textContent).toContain('Filtered fields: 1 / 6')
+    expect(container!.textContent).toContain('workday_overtime_duration')
+    expect(container!.textContent).not.toContain('employee_name')
+
+    statusSelect!.value = 'hidden'
+    statusSelect!.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+    expect(container!.textContent).toContain('Filtered fields: 1 / 6')
+    expect(container!.textContent).toContain('late_count')
+
+    searchInput!.value = 'not-a-field'
+    searchInput!.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+    expect(container!.textContent).toContain('Filtered fields: 0 / 6')
+    expect(container!.textContent).toContain('No report fields match the current filters.')
+  })
+
+  it('handles an empty initial catalog without crashing', async () => {
+    vi.mocked(apiFetch).mockResolvedValue(jsonResponse(200, {
+      ok: true,
+      data: {
+        categories: [
+          { id: 'fixed', label: '固定字段', sortOrder: 10 },
+          { id: 'basic', label: '基础字段', sortOrder: 20 },
+        ],
+        items: [],
+        multitable: {
+          available: false,
+          degraded: true,
+          reason: 'MULTITABLE_UNAVAILABLE',
+          projectId: 'default:attendance',
+        },
+      },
+    }))
+
+    mountSection('')
+    await flushUi()
+
+    expect(apiFetch).toHaveBeenCalledWith('/api/attendance/report-fields')
+    expect(container!.textContent).toContain('No report fields loaded yet.')
+    expect(container!.textContent).toContain('Using built-in report field definitions')
+    expect(container!.querySelector('[data-report-field-multitable-status]')?.textContent).toContain('Degraded')
+    expect(container!.querySelector('[data-report-field-multitable-detail="reason"]')?.textContent).toContain('MULTITABLE_UNAVAILABLE')
+
+    const syncButton = Array.from(container!.querySelectorAll<HTMLButtonElement>('button'))
+      .find(button => button.textContent?.includes('Sync catalog'))
+    expect(syncButton).toBeTruthy()
+    syncButton!.click()
+    await flushUi()
+    const syncStatus = Array.from(container!.querySelectorAll<HTMLElement>('[role="status"]'))
+      .find(element => element.textContent?.includes('Report field catalog synchronized.'))
+    expect(syncStatus?.textContent).toContain('Status: Degraded')
+  })
+})

--- a/apps/web/tests/attendance-admin-anchor-nav.spec.ts
+++ b/apps/web/tests/attendance-admin-anchor-nav.spec.ts
@@ -124,13 +124,14 @@ describe('Attendance admin anchor navigation', () => {
     )
 
     expect(groupLabels).toEqual(['Workspace', 'Scheduling', 'Organization', 'Policies', 'Data & Payroll'])
-    expect(labels).toHaveLength(22)
+    expect(labels).toHaveLength(23)
     expect(labels).toEqual(
       expect.arrayContaining([
         'Settings',
         'User Access',
         'Import',
         'Import batches',
+        'Report fields',
         'Payroll Cycles',
         'Approval Flows',
         'Holidays',
@@ -279,7 +280,7 @@ describe('Attendance admin anchor navigation', () => {
 
     const jumpSelect = container!.querySelector<HTMLSelectElement>('[data-admin-quick-jump="true"]')
     expect(jumpSelect).toBeTruthy()
-    expect(Array.from(jumpSelect!.querySelectorAll('option')).length).toBe(22)
+    expect(Array.from(jumpSelect!.querySelectorAll('option')).length).toBe(23)
 
     jumpSelect!.value = 'attendance-admin-shifts'
     jumpSelect!.dispatchEvent(new Event('change', { bubbles: true }))

--- a/apps/web/tests/attendance-admin-regressions.spec.ts
+++ b/apps/web/tests/attendance-admin-regressions.spec.ts
@@ -33,6 +33,17 @@ function jsonResponse(status: number, payload: unknown): Response {
   } as unknown as Response
 }
 
+function textResponse(status: number, text: string, headers: Record<string, string> = {}): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: new Headers(headers),
+    json: async () => JSON.parse(text),
+    text: async () => text,
+    blob: async () => new Blob([text], { type: headers['Content-Type'] || 'text/plain' }),
+  } as unknown as Response
+}
+
 async function flushUi(cycles = 6): Promise<void> {
   for (let i = 0; i < cycles; i += 1) {
     await Promise.resolve()
@@ -63,9 +74,23 @@ describe('Attendance admin regressions', () => {
   let app: App<Element> | null = null
   let container: HTMLDivElement | null = null
   let originalScrollIntoView: typeof HTMLElement.prototype.scrollIntoView | undefined
+  let exportReportFieldFingerprint = 'records-unit-test-fingerprint'
+  let exportReportFieldCodes = 'work_date,employee_name'
+  let exportReportFieldCount = '2'
+  let exportReportFieldProjectId = 'default:attendance'
+  let exportReportFieldObjectId = 'attendance_report_field_catalog'
+  let exportReportFieldSheetId = 'sheet-1'
+  let exportReportFieldViewId = 'fields_by_category'
 
   beforeEach(() => {
     vi.clearAllMocks()
+    exportReportFieldFingerprint = 'records-unit-test-fingerprint'
+    exportReportFieldCodes = 'work_date,employee_name'
+    exportReportFieldCount = '2'
+    exportReportFieldProjectId = 'default:attendance'
+    exportReportFieldObjectId = 'attendance_report_field_catalog'
+    exportReportFieldSheetId = 'sheet-1'
+    exportReportFieldViewId = 'fields_by_category'
     window.localStorage.clear()
     window.localStorage.setItem('metasheet_locale', 'en')
     window.history.replaceState({}, '', '/attendance')
@@ -282,6 +307,64 @@ describe('Attendance admin regressions', () => {
           },
         })
       }
+      if (url.includes('/api/attendance/records')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            items: [
+              {
+                id: 'record-1',
+                work_date: '2026-05-13',
+                user_id: 'user-1',
+                user_name: 'Ada',
+                first_in_at: '2026-05-13T09:00:00.000Z',
+                last_out_at: '2026-05-13T18:00:00.000Z',
+                work_minutes: 480,
+                late_minutes: 0,
+                early_leave_minutes: 0,
+                status: 'normal',
+                is_workday: true,
+                meta: {},
+              },
+            ],
+            total: 1,
+            reportFields: [
+              { code: 'work_date', name: '日期', sortOrder: 1000 },
+              { code: 'employee_name', name: '姓名', sortOrder: 1010 },
+            ],
+            reportFieldConfig: {
+              multitable: {
+                available: true,
+                degraded: false,
+                projectId: 'default:attendance',
+                objectId: 'attendance_report_field_catalog',
+                sheetId: 'sheet-1',
+                viewId: 'fields_by_category',
+              },
+              fieldsFingerprint: {
+                algorithm: 'sha1',
+                value: 'records-unit-test-fingerprint',
+                fieldCount: 2,
+                codes: ['work_date', 'employee_name'],
+              },
+            },
+          },
+        })
+      }
+      if (url.includes('/api/attendance/export')) {
+        return textResponse(200, '日期,姓名\n2026-05-13,Ada\n', {
+          'Content-Type': 'text/csv',
+          'Content-Disposition': 'attachment; filename="attendance-export.csv"',
+          'X-Attendance-Report-Fields-Fingerprint-Algorithm': 'sha1',
+          'X-Attendance-Report-Fields-Fingerprint': exportReportFieldFingerprint,
+          'X-Attendance-Report-Fields-Count': exportReportFieldCount,
+          'X-Attendance-Report-Fields-Codes': exportReportFieldCodes,
+          'X-Attendance-Report-Fields-Project-Id': exportReportFieldProjectId,
+          'X-Attendance-Report-Fields-Object-Id': exportReportFieldObjectId,
+          'X-Attendance-Report-Fields-Sheet-Id': exportReportFieldSheetId,
+          'X-Attendance-Report-Fields-View-Id': exportReportFieldViewId,
+        })
+      }
       return emptyAttendanceResponse()
     })
 
@@ -330,6 +413,279 @@ describe('Attendance admin regressions', () => {
     expect(container!.querySelector('[data-admin-shortcut="attendance-admin-group-members"]')?.textContent).toContain('Organization · Group members')
     expect(container!.textContent).toContain('User picker')
     expect(container!.textContent).toContain('Append selected user')
+  })
+
+  it('passes the selected CSV header mode when exporting report records', async () => {
+    const originalCreateObjectURL = URL.createObjectURL
+    const originalRevokeObjectURL = URL.revokeObjectURL
+    const createObjectURL = vi.fn(() => 'blob:attendance-export')
+    const revokeObjectURL = vi.fn()
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+    Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: createObjectURL })
+    Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: revokeObjectURL })
+
+    try {
+      app = createApp(AttendanceView, { mode: 'reports' })
+      app.mount(container!)
+      await flushUi()
+
+      const headerSelect = container!.querySelector<HTMLSelectElement>('#attendance-record-export-header')
+      expect(headerSelect).toBeTruthy()
+      expect(headerSelect!.value).toBe('label')
+      headerSelect!.value = 'code'
+      headerSelect!.dispatchEvent(new Event('change', { bubbles: true }))
+      await flushUi(2)
+      expect(headerSelect!.value).toBe('code')
+
+      const exportButton = Array.from(container!.querySelectorAll<HTMLButtonElement>('button'))
+        .find(button => button.textContent?.includes('Export CSV'))
+      expect(exportButton).toBeTruthy()
+      exportButton!.click()
+      await flushUi(6)
+
+      const exportCall = vi.mocked(apiFetch).mock.calls
+        .map(call => String(call[0]))
+        .find(url => url.includes('/api/attendance/export?'))
+      expect(exportCall).toContain('header=code')
+      expect(createObjectURL).toHaveBeenCalledTimes(1)
+      expect(clickSpy).toHaveBeenCalledTimes(1)
+      expect(revokeObjectURL).toHaveBeenCalledWith('blob:attendance-export')
+      expect(container!.querySelector('[data-record-export-config]')?.textContent).toContain('Last CSV export')
+      expect(container!.querySelector('[data-record-export-config-detail="headerMode"]')?.textContent).toContain('Field codes')
+      expect(container!.querySelector('[data-record-export-config-detail="evidenceStatus"]')?.textContent).toContain('Complete')
+      expect(container!.querySelector('[data-record-export-config-detail="evidenceStatus"]')?.classList.contains('attendance__report-config-item--ok')).toBe(true)
+      expect(container!.querySelector('[data-record-export-config-detail="range"]')?.textContent).toContain(' - ')
+      expect(container!.querySelector('[data-record-export-config-detail="rangeMatch"]')?.textContent).toContain('Current range')
+      expect(container!.querySelector('[data-record-export-config-detail="rangeMatch"]')?.classList.contains('attendance__report-config-item--ok')).toBe(true)
+      expect(container!.querySelector('[data-record-export-config-detail="fieldCount"]')?.textContent).toContain('2')
+      expect(container!.querySelector('[data-record-export-config-detail="fieldCountMatch"]')?.textContent).toContain('Matches records')
+      expect(container!.querySelector('[data-record-export-config-detail="fieldCountMatch"]')?.classList.contains('attendance__report-config-item--ok')).toBe(true)
+      expect(container!.querySelector('[data-record-export-config-detail="configMatch"]')?.textContent).toContain('Matches records')
+      expect(container!.querySelector('[data-record-export-config-detail="configMatch"]')?.classList.contains('attendance__report-config-item--ok')).toBe(true)
+      expect(container!.querySelector('[data-record-export-config-detail="fieldCodesMatch"]')?.textContent).toContain('Matches records')
+      expect(container!.querySelector('[data-record-export-config-detail="fieldCodesMatch"]')?.classList.contains('attendance__report-config-item--ok')).toBe(true)
+      expect(container!.querySelector('[data-record-export-config-detail="backingMatch"]')?.textContent).toContain('Matches records')
+      expect(container!.querySelector('[data-record-export-config-detail="backingMatch"]')?.classList.contains('attendance__report-config-item--ok')).toBe(true)
+      expect(container!.querySelector('[data-record-export-config-detail="projectId"]')?.textContent).toContain('default:attendance')
+      expect(container!.querySelector('[data-record-export-config-detail="objectId"]')?.textContent).toContain('attendance_report_field_catalog')
+      expect(container!.querySelector('[data-record-export-config-detail="sheetId"]')?.textContent).toContain('sheet-1')
+      expect(container!.querySelector('[data-record-export-config-detail="viewId"]')?.textContent).toContain('fields_by_category')
+      expect(container!.querySelector('[data-record-export-config-detail="fingerprintAlgorithm"]')?.textContent).toContain('sha1')
+      expect(container!.querySelector('[data-record-export-config-detail="fingerprint"]')?.textContent).toContain('records-unit-test-fingerprint')
+      expect(container!.querySelector('[data-record-export-config-detail="fieldCodes"]')?.textContent).toContain('work_date, employee_name')
+      expect(container!.querySelector('[data-record-export-config-detail="filename"]')?.textContent).toContain('attendance-export.csv')
+
+      const fromInput = container!.querySelector<HTMLInputElement>('#attendance-from-date')
+      expect(fromInput).toBeTruthy()
+      fromInput!.value = '2026-01-01'
+      fromInput!.dispatchEvent(new Event('input', { bubbles: true }))
+      fromInput!.dispatchEvent(new Event('change', { bubbles: true }))
+      await flushUi(2)
+      expect(container!.querySelector('[data-record-export-config-detail="rangeMatch"]')?.textContent).toContain('Different range')
+      expect(container!.querySelector('[data-record-export-config-detail="rangeMatch"]')?.classList.contains('attendance__report-config-item--warn')).toBe(true)
+    } finally {
+      clickSpy.mockRestore()
+      Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: originalCreateObjectURL })
+      Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: originalRevokeObjectURL })
+    }
+  })
+
+  it('warns when the CSV export field config differs from the loaded records', async () => {
+    exportReportFieldFingerprint = 'csv-mismatch-fingerprint'
+    const originalCreateObjectURL = URL.createObjectURL
+    const originalRevokeObjectURL = URL.revokeObjectURL
+    const createObjectURL = vi.fn(() => 'blob:attendance-export')
+    const revokeObjectURL = vi.fn()
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+    Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: createObjectURL })
+    Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: revokeObjectURL })
+
+    try {
+      app = createApp(AttendanceView, { mode: 'reports' })
+      app.mount(container!)
+      await flushUi()
+
+      const exportButton = Array.from(container!.querySelectorAll<HTMLButtonElement>('button'))
+        .find(button => button.textContent?.includes('Export CSV'))
+      expect(exportButton).toBeTruthy()
+      exportButton!.click()
+      await flushUi(6)
+
+      expect(createObjectURL).toHaveBeenCalledTimes(1)
+      expect(clickSpy).toHaveBeenCalledTimes(1)
+      expect(container!.querySelector('[data-record-export-config-detail="configMatch"]')?.textContent).toContain('Differs from records')
+      expect(container!.querySelector('[data-record-export-config-detail="configMatch"]')?.classList.contains('attendance__report-config-item--warn')).toBe(true)
+      expect(container!.querySelector('[data-record-export-config-detail="fieldCountMatch"]')?.textContent).toContain('Matches records')
+      expect(container!.querySelector('[data-record-export-config-detail="fieldCountMatch"]')?.classList.contains('attendance__report-config-item--ok')).toBe(true)
+      expect(container!.querySelector('[data-record-export-config-detail="fieldCodesMatch"]')?.textContent).toContain('Matches records')
+      expect(container!.querySelector('[data-record-export-config-detail="fieldCodesMatch"]')?.classList.contains('attendance__report-config-item--ok')).toBe(true)
+      expect(container!.querySelector('[data-record-export-config-detail="fingerprint"]')?.textContent).toContain('csv-mismatch-fingerprint')
+      expect(container!.querySelector('[data-record-export-config-detail="fieldCodes"]')?.textContent).toContain('work_date, employee_name')
+    } finally {
+      clickSpy.mockRestore()
+      Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: originalCreateObjectURL })
+      Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: originalRevokeObjectURL })
+    }
+  })
+
+  it('warns when the CSV export field codes differ from the loaded records', async () => {
+    exportReportFieldCodes = 'employee_name,work_date'
+    const originalCreateObjectURL = URL.createObjectURL
+    const originalRevokeObjectURL = URL.revokeObjectURL
+    const createObjectURL = vi.fn(() => 'blob:attendance-export')
+    const revokeObjectURL = vi.fn()
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+    Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: createObjectURL })
+    Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: revokeObjectURL })
+
+    try {
+      app = createApp(AttendanceView, { mode: 'reports' })
+      app.mount(container!)
+      await flushUi()
+
+      const exportButton = Array.from(container!.querySelectorAll<HTMLButtonElement>('button'))
+        .find(button => button.textContent?.includes('Export CSV'))
+      expect(exportButton).toBeTruthy()
+      exportButton!.click()
+      await flushUi(6)
+
+      expect(createObjectURL).toHaveBeenCalledTimes(1)
+      expect(clickSpy).toHaveBeenCalledTimes(1)
+      expect(container!.querySelector('[data-record-export-config-detail="configMatch"]')?.textContent).toContain('Matches records')
+      expect(container!.querySelector('[data-record-export-config-detail="configMatch"]')?.classList.contains('attendance__report-config-item--ok')).toBe(true)
+      expect(container!.querySelector('[data-record-export-config-detail="fieldCountMatch"]')?.textContent).toContain('Matches records')
+      expect(container!.querySelector('[data-record-export-config-detail="fieldCountMatch"]')?.classList.contains('attendance__report-config-item--ok')).toBe(true)
+      expect(container!.querySelector('[data-record-export-config-detail="fieldCodesMatch"]')?.textContent).toContain('Differs from records')
+      expect(container!.querySelector('[data-record-export-config-detail="fieldCodesMatch"]')?.classList.contains('attendance__report-config-item--warn')).toBe(true)
+      expect(container!.querySelector('[data-record-export-config-detail="fieldCodes"]')?.textContent).toContain('employee_name, work_date')
+    } finally {
+      clickSpy.mockRestore()
+      Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: originalCreateObjectURL })
+      Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: originalRevokeObjectURL })
+    }
+  })
+
+  it('warns when the CSV export field count differs from the loaded records', async () => {
+    exportReportFieldCount = '3'
+    const originalCreateObjectURL = URL.createObjectURL
+    const originalRevokeObjectURL = URL.revokeObjectURL
+    const createObjectURL = vi.fn(() => 'blob:attendance-export')
+    const revokeObjectURL = vi.fn()
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+    Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: createObjectURL })
+    Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: revokeObjectURL })
+
+    try {
+      app = createApp(AttendanceView, { mode: 'reports' })
+      app.mount(container!)
+      await flushUi()
+
+      const exportButton = Array.from(container!.querySelectorAll<HTMLButtonElement>('button'))
+        .find(button => button.textContent?.includes('Export CSV'))
+      expect(exportButton).toBeTruthy()
+      exportButton!.click()
+      await flushUi(6)
+
+      expect(createObjectURL).toHaveBeenCalledTimes(1)
+      expect(clickSpy).toHaveBeenCalledTimes(1)
+      expect(container!.querySelector('[data-record-export-config-detail="fieldCount"]')?.textContent).toContain('3')
+      expect(container!.querySelector('[data-record-export-config-detail="fieldCountMatch"]')?.textContent).toContain('Differs from records')
+      expect(container!.querySelector('[data-record-export-config-detail="fieldCountMatch"]')?.classList.contains('attendance__report-config-item--warn')).toBe(true)
+      expect(container!.querySelector('[data-record-export-config-detail="configMatch"]')?.textContent).toContain('Matches records')
+      expect(container!.querySelector('[data-record-export-config-detail="fieldCodesMatch"]')?.textContent).toContain('Matches records')
+    } finally {
+      clickSpy.mockRestore()
+      Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: originalCreateObjectURL })
+      Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: originalRevokeObjectURL })
+    }
+  })
+
+  it('warns when the CSV export backing differs from the loaded records', async () => {
+    exportReportFieldSheetId = 'sheet-from-other-catalog'
+    const originalCreateObjectURL = URL.createObjectURL
+    const originalRevokeObjectURL = URL.revokeObjectURL
+    const createObjectURL = vi.fn(() => 'blob:attendance-export')
+    const revokeObjectURL = vi.fn()
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+    Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: createObjectURL })
+    Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: revokeObjectURL })
+
+    try {
+      app = createApp(AttendanceView, { mode: 'reports' })
+      app.mount(container!)
+      await flushUi()
+
+      const exportButton = Array.from(container!.querySelectorAll<HTMLButtonElement>('button'))
+        .find(button => button.textContent?.includes('Export CSV'))
+      expect(exportButton).toBeTruthy()
+      exportButton!.click()
+      await flushUi(6)
+
+      expect(createObjectURL).toHaveBeenCalledTimes(1)
+      expect(clickSpy).toHaveBeenCalledTimes(1)
+      expect(container!.querySelector('[data-record-export-config-detail="configMatch"]')?.textContent).toContain('Matches records')
+      expect(container!.querySelector('[data-record-export-config-detail="fieldCountMatch"]')?.textContent).toContain('Matches records')
+      expect(container!.querySelector('[data-record-export-config-detail="fieldCodesMatch"]')?.textContent).toContain('Matches records')
+      expect(container!.querySelector('[data-record-export-config-detail="backingMatch"]')?.textContent).toContain('Differs from records')
+      expect(container!.querySelector('[data-record-export-config-detail="backingMatch"]')?.classList.contains('attendance__report-config-item--warn')).toBe(true)
+      expect(container!.querySelector('[data-record-export-config-detail="sheetId"]')?.textContent).toContain('sheet-from-other-catalog')
+    } finally {
+      clickSpy.mockRestore()
+      Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: originalCreateObjectURL })
+      Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: originalRevokeObjectURL })
+    }
+  })
+
+  it('warns when CSV export field evidence headers are incomplete', async () => {
+    exportReportFieldFingerprint = ''
+    exportReportFieldCount = ''
+    exportReportFieldCodes = ''
+    const originalCreateObjectURL = URL.createObjectURL
+    const originalRevokeObjectURL = URL.revokeObjectURL
+    const createObjectURL = vi.fn(() => 'blob:attendance-export')
+    const revokeObjectURL = vi.fn()
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+    Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: createObjectURL })
+    Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: revokeObjectURL })
+
+    try {
+      app = createApp(AttendanceView, { mode: 'reports' })
+      app.mount(container!)
+      await flushUi()
+
+      const exportButton = Array.from(container!.querySelectorAll<HTMLButtonElement>('button'))
+        .find(button => button.textContent?.includes('Export CSV'))
+      expect(exportButton).toBeTruthy()
+      exportButton!.click()
+      await flushUi(6)
+
+      expect(createObjectURL).toHaveBeenCalledTimes(1)
+      expect(clickSpy).toHaveBeenCalledTimes(1)
+      expect(container!.querySelector('[data-record-export-config-detail="evidenceStatus"]')?.textContent).toContain('Missing: field count, fingerprint, field codes')
+      expect(container!.querySelector('[data-record-export-config-detail="evidenceStatus"]')?.classList.contains('attendance__report-config-item--warn')).toBe(true)
+      expect(container!.querySelector('[data-record-export-config-detail="fieldCount"]')).toBeNull()
+      expect(container!.querySelector('[data-record-export-config-detail="fieldCountMatch"]')).toBeNull()
+      expect(container!.querySelector('[data-record-export-config-detail="configMatch"]')).toBeNull()
+      expect(container!.querySelector('[data-record-export-config-detail="fieldCodesMatch"]')).toBeNull()
+    } finally {
+      clickSpy.mockRestore()
+      Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: originalCreateObjectURL })
+      Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: originalRevokeObjectURL })
+    }
+  })
+
+  it('shows the active record report field config fingerprint', async () => {
+    app = createApp(AttendanceView, { mode: 'reports' })
+    app.mount(container!)
+    await flushUi()
+
+    expect(container!.querySelector('[data-record-report-config]')?.textContent).toContain('Field config')
+    expect(container!.querySelector('[data-record-report-config-detail="backing"]')?.textContent).toContain('Connected')
+    expect(container!.querySelector('[data-record-report-config-detail="fieldCount"]')?.textContent).toContain('2')
+    expect(container!.querySelector('[data-record-report-config-detail="fingerprintAlgorithm"]')?.textContent).toContain('sha1')
+    expect(container!.querySelector('[data-record-report-config-detail="fingerprint"]')?.textContent).toContain('records-unit-test-fingerprint')
+    expect(container!.querySelector('[data-record-report-config-detail="fieldCodes"]')?.textContent).toContain('work_date, employee_name')
+    expect(container!.querySelector('[data-record-report-config-detail="projectId"]')?.textContent).toContain('default:attendance')
   })
 
   it('keeps edit buttons visible for the active section while focused mode hides inactive sections', async () => {

--- a/docs/development/attendance-report-fields-multitable-foundation-design-20260513.md
+++ b/docs/development/attendance-report-fields-multitable-foundation-design-20260513.md
@@ -1,0 +1,50 @@
+# 考勤统计字段多维表底座开发说明
+
+日期：2026-05-13（2026-05-14 收口于 `codex/attendance-report-fields-foundation-20260514`）
+
+## 背景
+
+本次实现采用“考勤领域表为事实源，多维表作为报表字段配置层”的方案。`attendance_*` 继续承载打卡、排班、导入、回滚、审批和计薪周期等事务数据；多维表只承载统计字段目录、展示开关、字段说明和后续自定义字段入口。
+
+## 后端实现
+
+- `plugins/plugin-attendance/index.cjs` 新增 `attendance_report_field_catalog` 对象 descriptor。
+- 插件通过 `context.api.multitable.provisioning.ensureObject()` 创建对象，`projectId` 固定为 `${orgId}:attendance`。
+- 首次 provision 后通过插件作用域内的 `records.createRecord()` 补齐内置字段目录记录，不直接操作 `meta_*` 表。
+- 新增只读接口：
+  - `GET /api/attendance/report-fields`
+  - 权限：`attendance:admin`
+  - 返回：内置系统字段、字段分类、多维表配置合并结果，以及 multitable 对象入口信息。
+- 新增同步接口：
+  - `POST /api/attendance/report-fields/sync`
+  - 权限：`attendance:admin`
+  - 用于显式 provision / seed 字段目录，便于部署后或配置漂移后人工触发。
+- 记录查询、JSON 导出和 CSV 导出复用同一份字段配置 envelope，并通过 `X-Attendance-Report-Fields-*` 响应头输出字段指纹、字段数量、字段编码和多维表 backing 信息。
+- 多维表不可用或配置读取失败时，接口降级返回内置系统字段，并在 `multitable.degraded` 中标记原因。
+
+## 字段范围
+
+首版字段目录覆盖钉钉《考勤统计字段说明》的六类：
+
+- 固定字段
+- 基础字段
+- 出勤统计字段
+- 异常统计字段
+- 请假统计字段
+- 加班统计字段
+
+每条目录记录包含：字段编码、字段名称、分类、来源、单位、是否启用、报表可见、排序、钉钉原字段名、说明、内部计算键。
+
+## 前端实现
+
+- 新增 `AttendanceReportFieldsSection.vue`，在考勤管理中心展示统计字段目录。
+- `useAttendanceAdminRail.ts` 新增 `attendance-admin-report-fields` 导航项，归入“数据与计薪”分组。
+- `AttendanceView.vue` 将统计字段区块接入管理中心，并提供跳转到对应多维表对象的入口。
+- 记录表从固定列改为按字段配置渲染，配置不可用时回退到原有核心列。
+- CSV 导出新增字段名称 / 字段编码两种表头模式，并在导出后展示本次使用的字段指纹和 backing 信息。
+
+## 非目标
+
+- 不迁移 `attendance_records` 或其他考勤主表到 `meta_records`。
+- 不让考勤插件直接写 `meta_bases/meta_sheets/meta_fields/meta_records`。
+- 不实现钉钉专业版“专家模式”的自定义公式执行；后续应接入统一公式引擎。

--- a/docs/development/attendance-report-fields-multitable-foundation-verification-20260513.md
+++ b/docs/development/attendance-report-fields-multitable-foundation-verification-20260513.md
@@ -1,0 +1,51 @@
+# 考勤统计字段多维表底座验证记录
+
+日期：2026-05-13（2026-05-14 于 `codex/attendance-report-fields-foundation-20260514` 重跑）
+
+## 目标
+
+验证考勤统计字段目录已经通过插件 multitable API provision，前端管理中心可以展示固定、基础、出勤、异常、请假、加班六类字段，并且原有考勤事实源与导入/回滚链路不被迁移或改写。
+
+## 覆盖项
+
+- 后端字段目录 descriptor 稳定性。
+- `projectId = ${orgId}:attendance`。
+- 插件通过 `context.api.multitable.provisioning.ensureObject()` 和 `records.createRecord()` provision/seed 字段目录。
+- 多维表配置缺失时，聚合接口降级返回内置字段。
+- 前端统计字段区块展示字段分类、启用状态、报表可见状态，并生成多维表入口。
+- 管理中心左侧 rail 新增“统计字段”导航。
+- 记录表使用字段配置渲染列，配置不可用时回退到原有核心列。
+- JSON/CSV 导出复用同一字段配置，并返回字段指纹响应头。
+- CSV 导出支持字段名称和字段编码两种表头模式。
+
+## 验证命令
+
+```bash
+node --check plugins/plugin-attendance/index.cjs
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-report-field-catalog.test.ts --reporter=dot
+NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/AttendanceReportFieldsSection.spec.ts tests/attendance-admin-anchor-nav.spec.ts --watch=false
+NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/attendance-admin-regressions.spec.ts --watch=false --reporter=dot
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/web type-check
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+## 结果
+
+- `node --check plugins/plugin-attendance/index.cjs`：通过。
+- `attendance-report-field-catalog.test.ts`：7 个后端单元测试通过。
+- `AttendanceReportFieldsSection.spec.ts` 与 `attendance-admin-anchor-nav.spec.ts`：25 个前端测试通过。
+- `attendance-admin-regressions.spec.ts`：11 个前端回归测试通过，覆盖记录表字段配置、JSON/CSV 导出字段指纹、CSV label/code 表头和配置降级提示。
+- `pnpm --filter @metasheet/core-backend build`：通过。
+- `pnpm --filter @metasheet/web type-check`：通过。
+- `pnpm --filter @metasheet/web build`：通过；Vite 仅输出既有 large chunk / dynamic import warning。
+- `git diff --check`：通过。
+
+## 备注
+
+当前 Node 运行环境会暴露实验性的 `globalThis.localStorage` 空对象，导致 jsdom 用例里的 `window.localStorage` 没有 `getItem/clear` 方法。前端 Vitest 命令使用 `NODE_OPTIONS=--no-experimental-webstorage` 让 jsdom 接管 Web Storage；同时 `useLocale` 增加了轻量防御判断，避免真实运行时遇到异常 storage 形状时中断页面初始化。
+
+## 当前结论
+
+实现已按方案完成并通过目标验证。考勤领域数据源仍为 `attendance_*` 表，多维表只作为统计字段目录与报表配置层。

--- a/packages/core-backend/tests/unit/attendance-report-field-catalog.test.ts
+++ b/packages/core-backend/tests/unit/attendance-report-field-catalog.test.ts
@@ -1,0 +1,349 @@
+import { createRequire } from 'node:module'
+import { readFileSync } from 'node:fs'
+import { describe, expect, it, vi } from 'vitest'
+
+const require = createRequire(import.meta.url)
+const attendancePlugin = require('../../../../plugins/plugin-attendance/index.cjs')
+const helpers = attendancePlugin.__attendanceReportFieldCatalogForTests
+
+describe('attendance report field catalog multitable foundation', () => {
+  it('keeps the descriptor stable and covers DingTalk report field categories', () => {
+    const descriptor = helpers.getAttendanceReportFieldCatalogDescriptor()
+    const categories = helpers.cloneAttendanceReportFieldCategories()
+    const fieldIds = descriptor.fields.map((field: { id: string }) => field.id)
+
+    expect(descriptor.id).toBe('attendance_report_field_catalog')
+    expect(helpers.getAttendanceReportFieldProjectId('org-a')).toBe('org-a:attendance')
+    expect(categories.map((category: { label: string }) => category.label)).toEqual([
+      '固定字段',
+      '基础字段',
+      '出勤统计字段',
+      '异常统计字段',
+      '请假统计字段',
+      '加班统计字段',
+    ])
+    expect(fieldIds).toEqual([
+      'field_code',
+      'field_name',
+      'category',
+      'source',
+      'unit',
+      'enabled',
+      'report_visible',
+      'sort_order',
+      'dingtalk_field_name',
+      'description',
+      'internal_key',
+    ])
+  })
+
+  it('provisions and seeds the catalog through the multitable plugin API only', async () => {
+    const fieldIds = Object.fromEntries(
+      Object.values(helpers.ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS).map((fieldId) => [fieldId, `fld_${fieldId}`]),
+    )
+    const context = {
+      api: {
+        multitable: {
+          provisioning: {
+            ensureObject: vi.fn().mockResolvedValue({
+              baseId: 'base-1',
+              sheet: {
+                id: 'sheet-1',
+                baseId: 'base-1',
+                name: '考勤统计字段目录',
+                description: null,
+              },
+              fields: [],
+            }),
+            ensureView: vi.fn().mockResolvedValue({
+              id: 'view-1',
+              sheetId: 'sheet-1',
+              name: '按分类查看',
+              type: 'grid',
+              filterInfo: {},
+              sortInfo: {},
+              groupInfo: {},
+              hiddenFieldIds: [],
+              config: {},
+            }),
+            resolveFieldIds: vi.fn().mockResolvedValue(fieldIds),
+          },
+          records: {
+            queryRecords: vi.fn().mockResolvedValue([]),
+            createRecord: vi.fn().mockImplementation(async (input) => ({
+              id: 'rec-1',
+              sheetId: input.sheetId,
+              version: 1,
+              data: input.data,
+            })),
+          },
+        },
+      },
+    }
+
+    const result = await helpers.ensureAttendanceReportFieldCatalog(context, 'org-a', { warn: vi.fn() })
+
+    expect(result.projectId).toBe('org-a:attendance')
+    expect(result.sheetId).toBe('sheet-1')
+    expect(result.viewId).toBe('view-1')
+    expect(context.api.multitable.provisioning.ensureObject).toHaveBeenCalledWith({
+      projectId: 'org-a:attendance',
+      descriptor: expect.objectContaining({
+        id: 'attendance_report_field_catalog',
+        name: '考勤统计字段目录',
+      }),
+    })
+    expect(context.api.multitable.records.createRecord).toHaveBeenCalledTimes(
+      helpers.cloneAttendanceReportFieldDefinitions().length,
+    )
+    const firstRecord = context.api.multitable.records.createRecord.mock.calls[0]?.[0]
+    expect(firstRecord.sheetId).toBe('sheet-1')
+    expect(firstRecord.data.fld_field_code).toBe('work_date')
+    expect(firstRecord.data.fld_category).toBe('固定字段')
+  })
+
+  it('loads the catalog read-only for report usage without provisioning writes', async () => {
+    const context = {
+      api: {
+        multitable: {
+          provisioning: {
+            ensureObject: vi.fn(),
+            findObjectSheet: vi.fn().mockResolvedValue({
+              id: 'sheet-1',
+              baseId: 'base-1',
+              name: '考勤统计字段目录',
+              description: null,
+            }),
+            resolveFieldIds: vi.fn().mockResolvedValue({
+              field_code: 'fld_code',
+              sort_order: 'fld_sort',
+            }),
+          },
+          records: {
+            queryRecords: vi.fn().mockResolvedValue([]),
+          },
+        },
+      },
+    }
+
+    const result = await helpers.loadAttendanceReportFieldCatalog(context, 'org-a')
+
+    expect(result.available).toBe(true)
+    expect(result.projectId).toBe('org-a:attendance')
+    expect(result.sheetId).toBe('sheet-1')
+    expect(result.viewId).toMatch(/^view_/)
+    expect(context.api.multitable.provisioning.ensureObject).not.toHaveBeenCalled()
+  })
+
+  it('merges system fields with multitable configuration and degrades to built-ins', async () => {
+    const fieldIds = {
+      field_code: 'fld_code',
+      field_name: 'fld_name',
+      category: 'fld_category',
+      source: 'fld_source',
+      unit: 'fld_unit',
+      enabled: 'fld_enabled',
+      report_visible: 'fld_visible',
+      sort_order: 'fld_sort',
+      dingtalk_field_name: 'fld_dingtalk',
+      description: 'fld_description',
+      internal_key: 'fld_internal',
+    }
+    const merged = helpers.mergeAttendanceReportFieldDefinitions([
+      {
+        id: 'rec-late-count',
+        data: {
+          fld_code: 'late_count',
+          fld_name: '迟到次数',
+          fld_category: '异常统计字段',
+          fld_source: 'custom',
+          fld_unit: 'count',
+          fld_enabled: false,
+          fld_visible: true,
+          fld_sort: 4100,
+          fld_dingtalk: '迟到次数',
+          fld_description: '运营侧关闭该字段',
+          fld_internal: 'summary.lateCount',
+        },
+      },
+    ], fieldIds)
+
+    const lateCount = merged.find((field: { code: string }) => field.code === 'late_count')
+    expect(lateCount).toMatchObject({
+      enabled: false,
+      configured: true,
+      source: 'custom',
+      description: '运营侧关闭该字段',
+    })
+
+    const fallback = await helpers.buildAttendanceReportFieldCatalogResponse(
+      { api: { multitable: null } },
+      'org-z',
+      { warn: vi.fn() },
+    )
+    expect(fallback.multitable.available).toBe(false)
+    expect(fallback.multitable.projectId).toBe('org-z:attendance')
+    expect(fallback.items.some((field: { code: string }) => field.code === 'employee_name')).toBe(true)
+  })
+
+  it('applies enabled/reportVisible/sortOrder to record report fields and export values', () => {
+    const fields = helpers.resolveAttendanceRecordReportFields([
+      {
+        code: 'late_duration',
+        name: '迟到时长',
+        category: 'anomaly',
+        categoryLabel: '异常统计字段',
+        unit: 'minutes',
+        enabled: true,
+        reportVisible: true,
+        sortOrder: 30,
+      },
+      {
+        code: 'leave_duration',
+        name: '请假时长',
+        category: 'leave',
+        categoryLabel: '请假统计字段',
+        unit: 'minutes',
+        enabled: true,
+        reportVisible: false,
+        sortOrder: 20,
+      },
+      {
+        code: 'work_date',
+        name: '日期',
+        category: 'fixed',
+        categoryLabel: '固定字段',
+        unit: 'text',
+        enabled: true,
+        reportVisible: true,
+        sortOrder: 10,
+      },
+    ])
+    expect(fields.map((field: { code: string }) => field.code)).toEqual(['work_date', 'late_duration'])
+
+    const row = {
+      work_date: '2026-05-13',
+      status: 'late',
+      late_minutes: 12,
+      early_leave_minutes: 0,
+      work_minutes: 460,
+      is_workday: true,
+      meta: {
+        leave_minutes: 60,
+      },
+    }
+    expect(helpers.buildAttendanceRecordReportExportItem(row, fields)).toEqual({
+      work_date: '2026-05-13',
+      late_duration: 12,
+    })
+    expect(helpers.buildAttendanceRecordReportCsv([
+      helpers.buildAttendanceRecordReportExportItem(row, fields),
+    ], fields)).toBe('日期,迟到时长\n2026-05-13,12')
+    expect(helpers.buildAttendanceRecordReportCsv([
+      helpers.buildAttendanceRecordReportExportItem(row, fields),
+    ], fields, { headerMode: 'code' })).toBe('work_date,late_duration\n2026-05-13,12')
+  })
+
+  it('builds a shared report field config envelope for records and JSON exports', () => {
+    const fields = helpers.resolveAttendanceRecordReportFields([
+      {
+        code: 'work_date',
+        name: '日期',
+        category: 'fixed',
+        categoryLabel: '固定字段',
+        unit: 'text',
+        enabled: true,
+        reportVisible: true,
+        sortOrder: 10,
+      },
+      {
+        code: 'late_duration',
+        name: '迟到时长',
+        category: 'anomaly',
+        categoryLabel: '异常统计字段',
+        unit: 'minutes',
+        enabled: true,
+        reportVisible: true,
+        sortOrder: 20,
+        configured: true,
+      },
+    ])
+
+    expect(helpers.buildAttendanceReportFieldConfig({
+      fields,
+      multitable: {
+        available: true,
+        degraded: false,
+        projectId: 'org-a:attendance',
+        objectId: 'attendance_report_field_catalog',
+        baseId: 'base-1',
+        sheetId: 'sheet-1',
+        viewId: 'fields_by_category',
+      },
+    })).toEqual({
+      multitable: {
+        available: true,
+        degraded: false,
+        projectId: 'org-a:attendance',
+        objectId: 'attendance_report_field_catalog',
+        baseId: 'base-1',
+        sheetId: 'sheet-1',
+        viewId: 'fields_by_category',
+      },
+      fieldsFingerprint: {
+        algorithm: 'sha1',
+        value: helpers.buildAttendanceReportFieldConfigFingerprint(fields).value,
+        fieldCount: 2,
+        codes: ['work_date', 'late_duration'],
+      },
+    })
+
+    expect(helpers.buildAttendanceReportFieldConfig(null)).toEqual({
+      multitable: {
+        available: false,
+        degraded: true,
+        reason: 'REPORT_FIELD_CONFIG_UNAVAILABLE',
+      },
+      fieldsFingerprint: {
+        algorithm: 'sha1',
+        value: helpers.buildAttendanceReportFieldConfigFingerprint([]).value,
+        fieldCount: 0,
+        codes: [],
+      },
+    })
+
+    expect(helpers.buildAttendanceReportFieldConfigHeaders({
+      multitable: {
+        projectId: 'org-a:attendance',
+        objectId: 'attendance_report_field_catalog',
+        sheetId: 'sheet-1',
+        viewId: 'fields_by_category',
+      },
+      fieldsFingerprint: {
+        algorithm: 'sha1',
+        value: 'abc123',
+        fieldCount: 2,
+        codes: ['work_date', 'late_duration'],
+      },
+    })).toEqual({
+      'X-Attendance-Report-Fields-Fingerprint-Algorithm': 'sha1',
+      'X-Attendance-Report-Fields-Fingerprint': 'abc123',
+      'X-Attendance-Report-Fields-Count': '2',
+      'X-Attendance-Report-Fields-Codes': 'work_date,late_duration',
+      'X-Attendance-Report-Fields-Project-Id': 'org-a:attendance',
+      'X-Attendance-Report-Fields-Object-Id': 'attendance_report_field_catalog',
+      'X-Attendance-Report-Fields-Sheet-Id': 'sheet-1',
+      'X-Attendance-Report-Fields-View-Id': 'fields_by_category',
+    })
+  })
+
+  it('does not add direct meta table writes to the attendance plugin', () => {
+    const source = readFileSync(
+      new URL('../../../../plugins/plugin-attendance/index.cjs', import.meta.url),
+      'utf8',
+    )
+    expect(source).not.toMatch(/INSERT\s+INTO\s+meta_/i)
+    expect(source).not.toMatch(/UPDATE\s+meta_/i)
+    expect(source).not.toMatch(/DELETE\s+FROM\s+meta_/i)
+  })
+})

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -248,6 +248,1132 @@ const IMPORT_REQUIRED_FIELD_ALIASES = {
   '下班2打卡时间': ['2_off_duty_user_check_time', 'clockOut2'],
 }
 
+const ATTENDANCE_REPORT_FIELD_CATALOG_OBJECT_ID = 'attendance_report_field_catalog'
+const ATTENDANCE_REPORT_FIELD_CATALOG_VIEW_ID = 'fields_by_category'
+const ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS = Object.freeze({
+  fieldCode: 'field_code',
+  fieldName: 'field_name',
+  category: 'category',
+  source: 'source',
+  unit: 'unit',
+  enabled: 'enabled',
+  reportVisible: 'report_visible',
+  sortOrder: 'sort_order',
+  dingtalkFieldName: 'dingtalk_field_name',
+  description: 'description',
+  internalKey: 'internal_key',
+})
+
+const ATTENDANCE_REPORT_FIELD_CATEGORIES = Object.freeze([
+  { id: 'fixed', label: '固定字段', sortOrder: 10 },
+  { id: 'basic', label: '基础字段', sortOrder: 20 },
+  { id: 'attendance', label: '出勤统计字段', sortOrder: 30 },
+  { id: 'anomaly', label: '异常统计字段', sortOrder: 40 },
+  { id: 'leave', label: '请假统计字段', sortOrder: 50 },
+  { id: 'overtime', label: '加班统计字段', sortOrder: 60 },
+])
+
+const ATTENDANCE_REPORT_FIELD_SOURCE_OPTIONS = Object.freeze(['system', 'dingtalk', 'multitable', 'custom'])
+const ATTENDANCE_REPORT_FIELD_UNIT_OPTIONS = Object.freeze(['text', 'dateTime', 'days', 'minutes', 'count', 'hours'])
+
+const ATTENDANCE_REPORT_FIELD_DEFINITIONS = Object.freeze([
+  {
+    code: 'work_date',
+    name: '日期',
+    category: 'fixed',
+    source: 'system',
+    unit: 'text',
+    dingtalkFieldName: '日期',
+    description: '考勤记录所属工作日期。',
+    internalKey: 'attendanceRecords.workDate',
+  },
+  {
+    code: 'employee_name',
+    name: '姓名',
+    category: 'fixed',
+    source: 'system',
+    unit: 'text',
+    dingtalkFieldName: '姓名',
+    description: '员工在考勤报表中的展示姓名。',
+    internalKey: 'user.name',
+  },
+  {
+    code: 'attendance_group',
+    name: '考勤组',
+    category: 'fixed',
+    source: 'system',
+    unit: 'text',
+    dingtalkFieldName: '考勤组',
+    description: '员工当前匹配的考勤组名称。',
+    internalKey: 'attendanceGroup.name',
+  },
+  {
+    code: 'department',
+    name: '部门',
+    category: 'fixed',
+    source: 'system',
+    unit: 'text',
+    dingtalkFieldName: '部门',
+    description: '员工所属组织或部门路径。',
+    internalKey: 'user.department',
+  },
+  {
+    code: 'employee_no',
+    name: '工号',
+    category: 'fixed',
+    source: 'system',
+    unit: 'text',
+    dingtalkFieldName: '工号',
+    description: '员工唯一工号或外部人员编号。',
+    internalKey: 'user.employeeNo',
+  },
+  {
+    code: 'position',
+    name: '职位',
+    category: 'fixed',
+    source: 'system',
+    unit: 'text',
+    dingtalkFieldName: '职位',
+    description: '员工职位、岗位或角色标签。',
+    internalKey: 'user.position',
+  },
+  {
+    code: 'punch_times',
+    name: '打卡时间',
+    category: 'basic',
+    source: 'system',
+    unit: 'dateTime',
+    dingtalkFieldName: '打卡时间',
+    description: '上下班打卡时间集合，来自考勤记录和导入明细。',
+    internalKey: 'attendanceRecords.punchTimes',
+  },
+  {
+    code: 'punch_result',
+    name: '打卡结果',
+    category: 'basic',
+    source: 'system',
+    unit: 'text',
+    dingtalkFieldName: '打卡结果',
+    description: '单次或当日打卡是否正常、迟到、早退、缺卡等结果。',
+    internalKey: 'attendanceRecords.status',
+  },
+  {
+    code: 'approval_forms',
+    name: '关联的审批单',
+    category: 'basic',
+    source: 'system',
+    unit: 'text',
+    dingtalkFieldName: '关联的审批单',
+    description: '补卡、请假、外出或加班等与考勤结果关联的审批摘要。',
+    internalKey: 'attendanceRequests.approvalSummary',
+  },
+  {
+    code: 'expected_attendance_days',
+    name: '应出勤天数',
+    category: 'attendance',
+    source: 'system',
+    unit: 'days',
+    dingtalkFieldName: '应出勤天数',
+    description: '按排班、工作日和节假日规则计算的应出勤天数。',
+    internalKey: 'summary.expectedAttendanceDays',
+  },
+  {
+    code: 'correction_count',
+    name: '补卡次数',
+    category: 'attendance',
+    source: 'system',
+    unit: 'count',
+    dingtalkFieldName: '补卡次数',
+    description: '统计周期内通过补卡或更正审批调整的次数。',
+    internalKey: 'requests.correctionCount',
+  },
+  {
+    code: 'attendance_shift',
+    name: '出勤班次',
+    category: 'attendance',
+    source: 'system',
+    unit: 'text',
+    dingtalkFieldName: '出勤班次',
+    description: '员工当日实际归属的出勤班次。',
+    internalKey: 'workContext.attendanceShift',
+  },
+  {
+    code: 'attendance_days',
+    name: '出勤天数',
+    category: 'attendance',
+    source: 'system',
+    unit: 'days',
+    dingtalkFieldName: '出勤天数',
+    description: '统计周期内有效出勤天数。',
+    internalKey: 'summary.attendanceDays',
+  },
+  {
+    code: 'rest_days',
+    name: '休息天数',
+    category: 'attendance',
+    source: 'system',
+    unit: 'days',
+    dingtalkFieldName: '休息天数',
+    description: '统计周期内休息日或非工作日天数。',
+    internalKey: 'summary.restDays',
+  },
+  {
+    code: 'work_duration',
+    name: '工作时长',
+    category: 'attendance',
+    source: 'system',
+    unit: 'minutes',
+    dingtalkFieldName: '工作时长',
+    description: '统计周期内累计工作分钟数。',
+    internalKey: 'summary.workMinutes',
+  },
+  {
+    code: 'business_trip_duration',
+    name: '出差时长',
+    category: 'attendance',
+    source: 'system',
+    unit: 'minutes',
+    dingtalkFieldName: '出差时长',
+    description: '由审批或导入字段归集的出差时长。',
+    internalKey: 'requests.businessTripMinutes',
+  },
+  {
+    code: 'outing_duration',
+    name: '外出时长',
+    category: 'attendance',
+    source: 'system',
+    unit: 'minutes',
+    dingtalkFieldName: '外出时长',
+    description: '由审批或导入字段归集的外出时长。',
+    internalKey: 'requests.outingMinutes',
+  },
+  {
+    code: 'attendance_result',
+    name: '考勤结果',
+    category: 'attendance',
+    source: 'system',
+    unit: 'text',
+    dingtalkFieldName: '考勤结果',
+    description: '按日或周期汇总后的考勤结果。',
+    internalKey: 'summary.attendanceResult',
+  },
+  {
+    code: 'shift',
+    name: '班次',
+    category: 'attendance',
+    source: 'system',
+    unit: 'text',
+    dingtalkFieldName: '班次',
+    description: '排班计划中的班次名称。',
+    internalKey: 'shift.name',
+  },
+  {
+    code: 'late_count',
+    name: '迟到次数',
+    category: 'anomaly',
+    source: 'system',
+    unit: 'count',
+    dingtalkFieldName: '迟到次数',
+    description: '统计周期内迟到发生次数。',
+    internalKey: 'summary.lateCount',
+  },
+  {
+    code: 'late_duration',
+    name: '迟到时长',
+    category: 'anomaly',
+    source: 'system',
+    unit: 'minutes',
+    dingtalkFieldName: '迟到时长',
+    description: '统计周期内累计迟到分钟数。',
+    internalKey: 'summary.lateMinutes',
+  },
+  {
+    code: 'severe_late_count',
+    name: '严重迟到次数',
+    category: 'anomaly',
+    source: 'system',
+    unit: 'count',
+    dingtalkFieldName: '严重迟到次数',
+    description: '超过严重迟到阈值的迟到次数。',
+    internalKey: 'summary.severeLateCount',
+  },
+  {
+    code: 'severe_late_duration',
+    name: '严重迟到时长',
+    category: 'anomaly',
+    source: 'system',
+    unit: 'minutes',
+    dingtalkFieldName: '严重迟到时长',
+    description: '超过严重迟到阈值后的累计迟到分钟数。',
+    internalKey: 'summary.severeLateMinutes',
+  },
+  {
+    code: 'absence_late_count',
+    name: '旷工迟到次数',
+    category: 'anomaly',
+    source: 'system',
+    unit: 'count',
+    dingtalkFieldName: '旷工迟到次数',
+    description: '按规则被识别为旷工级迟到的次数。',
+    internalKey: 'summary.absenceLateCount',
+  },
+  {
+    code: 'early_leave_count',
+    name: '早退次数',
+    category: 'anomaly',
+    source: 'system',
+    unit: 'count',
+    dingtalkFieldName: '早退次数',
+    description: '统计周期内早退发生次数。',
+    internalKey: 'summary.earlyLeaveCount',
+  },
+  {
+    code: 'early_leave_duration',
+    name: '早退时长',
+    category: 'anomaly',
+    source: 'system',
+    unit: 'minutes',
+    dingtalkFieldName: '早退时长',
+    description: '统计周期内累计早退分钟数。',
+    internalKey: 'summary.earlyLeaveMinutes',
+  },
+  {
+    code: 'missing_clock_in_count',
+    name: '上班缺卡次数',
+    category: 'anomaly',
+    source: 'system',
+    unit: 'count',
+    dingtalkFieldName: '上班缺卡次数',
+    description: '统计周期内上班卡缺失次数。',
+    internalKey: 'summary.missingClockInCount',
+  },
+  {
+    code: 'missing_clock_out_count',
+    name: '下班缺卡次数',
+    category: 'anomaly',
+    source: 'system',
+    unit: 'count',
+    dingtalkFieldName: '下班缺卡次数',
+    description: '统计周期内下班卡缺失次数。',
+    internalKey: 'summary.missingClockOutCount',
+  },
+  {
+    code: 'absenteeism_days',
+    name: '旷工天数',
+    category: 'anomaly',
+    source: 'system',
+    unit: 'days',
+    dingtalkFieldName: '旷工天数',
+    description: '统计周期内被识别为旷工的天数。',
+    internalKey: 'summary.absentDays',
+  },
+  {
+    code: 'leave_duration',
+    name: '请假时长',
+    category: 'leave',
+    source: 'system',
+    unit: 'minutes',
+    dingtalkFieldName: '请假时长',
+    description: '统计周期内审批或导入归集的请假分钟数。',
+    internalKey: 'summary.leaveMinutes',
+  },
+  {
+    code: 'overtime_approval_duration',
+    name: '加班审批时长',
+    category: 'overtime',
+    source: 'system',
+    unit: 'minutes',
+    dingtalkFieldName: '加班审批时长',
+    description: '统计周期内审批确认的加班分钟数。',
+    internalKey: 'requests.overtimeApprovalMinutes',
+  },
+  {
+    code: 'workday_overtime_duration',
+    name: '工作日加班时长',
+    category: 'overtime',
+    source: 'system',
+    unit: 'minutes',
+    dingtalkFieldName: '工作日加班时长',
+    description: '工作日规则下归集的加班分钟数。',
+    internalKey: 'summary.workdayOvertimeMinutes',
+  },
+  {
+    code: 'restday_overtime_duration',
+    name: '休息日加班时长',
+    category: 'overtime',
+    source: 'system',
+    unit: 'minutes',
+    dingtalkFieldName: '休息日加班时长',
+    description: '休息日规则下归集的加班分钟数。',
+    internalKey: 'summary.restdayOvertimeMinutes',
+  },
+  {
+    code: 'holiday_overtime_duration',
+    name: '节假日加班时长',
+    category: 'overtime',
+    source: 'system',
+    unit: 'minutes',
+    dingtalkFieldName: '节假日加班时长',
+    description: '法定节假日或节假日规则下归集的加班分钟数。',
+    internalKey: 'summary.holidayOvertimeMinutes',
+  },
+].map((field, index) => ({
+  enabled: true,
+  reportVisible: true,
+  sortOrder: (ATTENDANCE_REPORT_FIELD_CATEGORIES.find(category => category.id === field.category)?.sortOrder ?? 90) * 100 + index,
+  ...field,
+})))
+
+function normalizeAttendanceReportFieldOrgId(orgId) {
+  const normalized = typeof orgId === 'string' ? orgId.trim() : ''
+  return normalized || DEFAULT_ORG_ID
+}
+
+function getAttendanceReportFieldProjectId(orgId) {
+  return `${normalizeAttendanceReportFieldOrgId(orgId)}:attendance`
+}
+
+function stableAttendanceMultitableId(prefix, ...parts) {
+  const digest = crypto
+    .createHash('sha1')
+    .update(parts.join(':'))
+    .digest('hex')
+    .slice(0, 24)
+  return `${prefix}_${digest}`.slice(0, 50)
+}
+
+function getAttendanceReportFieldCatalogViewId(projectId) {
+  return stableAttendanceMultitableId(
+    'view',
+    projectId,
+    ATTENDANCE_REPORT_FIELD_CATALOG_OBJECT_ID,
+    ATTENDANCE_REPORT_FIELD_CATALOG_VIEW_ID,
+  )
+}
+
+function getAttendanceReportFieldCategory(value) {
+  const normalized = String(value ?? '').trim()
+  if (!normalized) return ATTENDANCE_REPORT_FIELD_CATEGORIES[0]
+  return ATTENDANCE_REPORT_FIELD_CATEGORIES.find(category => (
+    category.id === normalized || category.label === normalized
+  )) ?? ATTENDANCE_REPORT_FIELD_CATEGORIES[0]
+}
+
+function cloneAttendanceReportFieldCategories() {
+  return ATTENDANCE_REPORT_FIELD_CATEGORIES.map(category => ({ ...category }))
+}
+
+function cloneAttendanceReportFieldDefinitions() {
+  return ATTENDANCE_REPORT_FIELD_DEFINITIONS.map(field => ({ ...field }))
+}
+
+function getAttendanceReportFieldCatalogDescriptor() {
+  return {
+    id: ATTENDANCE_REPORT_FIELD_CATALOG_OBJECT_ID,
+    name: '考勤统计字段目录',
+    description: '考勤插件私有字段目录：用于对标钉钉考勤统计字段说明并管理报表字段可见性。',
+    fields: [
+      { id: ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.fieldCode, name: '字段编码', type: 'string', order: 10, property: { validation: { required: true }, width: 160 } },
+      { id: ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.fieldName, name: '字段名称', type: 'string', order: 20, property: { validation: { required: true }, width: 160 } },
+      { id: ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.category, name: '分类', type: 'select', order: 30, options: ATTENDANCE_REPORT_FIELD_CATEGORIES.map(category => category.label), property: { validation: { required: true } } },
+      { id: ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.source, name: '来源', type: 'select', order: 40, options: ATTENDANCE_REPORT_FIELD_SOURCE_OPTIONS },
+      { id: ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.unit, name: '单位', type: 'select', order: 50, options: ATTENDANCE_REPORT_FIELD_UNIT_OPTIONS },
+      { id: ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.enabled, name: '是否启用', type: 'boolean', order: 60 },
+      { id: ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.reportVisible, name: '报表可见', type: 'boolean', order: 70 },
+      { id: ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.sortOrder, name: '排序', type: 'number', order: 80 },
+      { id: ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.dingtalkFieldName, name: '钉钉原字段名', type: 'string', order: 90, property: { width: 180 } },
+      { id: ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.description, name: '说明', type: 'longText', order: 100, property: { width: 360 } },
+      { id: ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.internalKey, name: '内部计算键', type: 'string', order: 110, property: { width: 220 } },
+    ],
+  }
+}
+
+function getAttendanceReportFieldCatalogViewDescriptor(fieldIds = {}) {
+  const categoryFieldId = fieldIds[ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.category] || ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.category
+  const sortOrderFieldId = fieldIds[ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.sortOrder] || ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.sortOrder
+  return {
+    id: ATTENDANCE_REPORT_FIELD_CATALOG_VIEW_ID,
+    objectId: ATTENDANCE_REPORT_FIELD_CATALOG_OBJECT_ID,
+    name: '按分类查看',
+    type: 'grid',
+    sortInfo: {
+      rules: [
+        { fieldId: categoryFieldId, direction: 'asc' },
+        { fieldId: sortOrderFieldId, direction: 'asc' },
+      ],
+    },
+    groupInfo: {
+      fieldId: categoryFieldId,
+      direction: 'asc',
+    },
+    config: {
+      purpose: 'attendance-report-field-catalog',
+    },
+  }
+}
+
+function buildAttendanceReportFieldCatalogRecordData(field, fieldIds) {
+  const data = {}
+  const assign = (logicalFieldId, value) => {
+    data[fieldIds?.[logicalFieldId] || logicalFieldId] = value
+  }
+  const category = getAttendanceReportFieldCategory(field.category)
+  assign(ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.fieldCode, field.code)
+  assign(ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.fieldName, field.name)
+  assign(ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.category, category.label)
+  assign(ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.source, field.source || 'system')
+  assign(ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.unit, field.unit || 'text')
+  assign(ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.enabled, field.enabled !== false)
+  assign(ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.reportVisible, field.reportVisible !== false)
+  assign(ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.sortOrder, Number(field.sortOrder) || 0)
+  assign(ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.dingtalkFieldName, field.dingtalkFieldName || field.name)
+  assign(ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.description, field.description || '')
+  assign(ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.internalKey, field.internalKey || field.code)
+  return data
+}
+
+function readAttendanceReportFieldCatalogCell(record, fieldIds, logicalFieldId) {
+  const data = record?.data && typeof record.data === 'object' ? record.data : record
+  if (!data || typeof data !== 'object') return undefined
+  const physicalFieldId = fieldIds?.[logicalFieldId]
+  if (physicalFieldId && Object.prototype.hasOwnProperty.call(data, physicalFieldId)) {
+    return data[physicalFieldId]
+  }
+  if (Object.prototype.hasOwnProperty.call(data, logicalFieldId)) {
+    return data[logicalFieldId]
+  }
+  return undefined
+}
+
+function normalizeCatalogString(value, fallback = '') {
+  const normalized = typeof value === 'string' ? value.trim() : ''
+  return normalized || fallback
+}
+
+function normalizeCatalogBoolean(value, fallback) {
+  if (typeof value === 'boolean') return value
+  if (typeof value === 'number') return value !== 0
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase()
+    if (['true', '1', 'yes', 'y', 'enabled', 'on'].includes(normalized)) return true
+    if (['false', '0', 'no', 'n', 'disabled', 'off'].includes(normalized)) return false
+  }
+  return fallback
+}
+
+function normalizeCatalogNumber(value, fallback = 0) {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+
+function mapAttendanceReportFieldConfigRecord(record, fieldIds) {
+  const read = (fieldId) => readAttendanceReportFieldCatalogCell(record, fieldIds, fieldId)
+  const code = normalizeCatalogString(read(ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.fieldCode))
+  if (!code) return null
+  const category = getAttendanceReportFieldCategory(read(ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.category))
+  return {
+    recordId: record?.id || '',
+    code,
+    name: normalizeCatalogString(read(ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.fieldName), code),
+    category: category.id,
+    categoryLabel: category.label,
+    source: normalizeCatalogString(read(ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.source), 'custom'),
+    unit: normalizeCatalogString(read(ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.unit), 'text'),
+    enabled: normalizeCatalogBoolean(read(ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.enabled), true),
+    reportVisible: normalizeCatalogBoolean(read(ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.reportVisible), true),
+    sortOrder: normalizeCatalogNumber(read(ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.sortOrder), category.sortOrder * 100),
+    dingtalkFieldName: normalizeCatalogString(read(ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.dingtalkFieldName)),
+    description: normalizeCatalogString(read(ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.description)),
+    internalKey: normalizeCatalogString(read(ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.internalKey), code),
+  }
+}
+
+function mergeAttendanceReportFieldDefinitions(configRecords, fieldIds) {
+  const categories = new Map(ATTENDANCE_REPORT_FIELD_CATEGORIES.map(category => [category.id, category]))
+  const configsByCode = new Map()
+  for (const record of configRecords || []) {
+    const config = mapAttendanceReportFieldConfigRecord(record, fieldIds)
+    if (config) configsByCode.set(config.code, config)
+  }
+
+  const systemCodes = new Set()
+  const items = cloneAttendanceReportFieldDefinitions().map((field) => {
+    systemCodes.add(field.code)
+    const category = getAttendanceReportFieldCategory(field.category)
+    const config = configsByCode.get(field.code)
+    const mergedCategory = getAttendanceReportFieldCategory(config?.category ?? category.id)
+    return {
+      code: field.code,
+      name: config?.name || field.name,
+      category: mergedCategory.id,
+      categoryLabel: mergedCategory.label,
+      source: config?.source || field.source || 'system',
+      unit: config?.unit || field.unit || 'text',
+      enabled: config ? config.enabled : field.enabled !== false,
+      reportVisible: config ? config.reportVisible : field.reportVisible !== false,
+      sortOrder: config?.sortOrder ?? field.sortOrder,
+      dingtalkFieldName: config?.dingtalkFieldName || field.dingtalkFieldName || field.name,
+      description: config?.description || field.description || '',
+      internalKey: config?.internalKey || field.internalKey || field.code,
+      recordId: config?.recordId || null,
+      configured: Boolean(config),
+      systemDefined: true,
+    }
+  })
+
+  for (const config of configsByCode.values()) {
+    if (systemCodes.has(config.code)) continue
+    items.push({
+      ...config,
+      configured: true,
+      systemDefined: false,
+    })
+  }
+
+  return items.sort((left, right) => {
+    const leftCategory = categories.get(left.category)?.sortOrder ?? 999
+    const rightCategory = categories.get(right.category)?.sortOrder ?? 999
+    if (leftCategory !== rightCategory) return leftCategory - rightCategory
+    if (left.sortOrder !== right.sortOrder) return left.sortOrder - right.sortOrder
+    return left.code.localeCompare(right.code)
+  })
+}
+
+async function seedAttendanceReportFieldCatalogRecords(multitable, sheetId, fieldIds, logger) {
+  const records = multitable?.records
+  if (!records?.queryRecords || !records?.createRecord) {
+    return { skipped: true, seeded: 0, existing: 0 }
+  }
+
+  const existingRecords = await records.queryRecords({
+    sheetId,
+    orderBy: {
+      fieldId: fieldIds?.[ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.sortOrder] || ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.sortOrder,
+      direction: 'asc',
+    },
+    limit: 1000,
+  })
+  const existingCodes = new Set(
+    existingRecords
+      .map(record => normalizeCatalogString(readAttendanceReportFieldCatalogCell(
+        record,
+        fieldIds,
+        ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.fieldCode,
+      )))
+      .filter(Boolean),
+  )
+
+  let seeded = 0
+  for (const field of ATTENDANCE_REPORT_FIELD_DEFINITIONS) {
+    if (existingCodes.has(field.code)) continue
+    try {
+      await records.createRecord({
+        sheetId,
+        data: buildAttendanceReportFieldCatalogRecordData(field, fieldIds),
+      })
+      seeded += 1
+    } catch (error) {
+      logger?.warn?.('Failed to seed attendance report field catalog record', {
+        code: field.code,
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
+
+  return { skipped: false, seeded, existing: existingRecords.length }
+}
+
+async function ensureAttendanceReportFieldCatalog(context, orgId, logger, options = {}) {
+  const projectId = getAttendanceReportFieldProjectId(orgId)
+  const multitable = context?.api?.multitable
+  if (!multitable?.provisioning?.ensureObject) {
+    return {
+      available: false,
+      reason: 'MULTITABLE_API_UNAVAILABLE',
+      projectId,
+      objectId: ATTENDANCE_REPORT_FIELD_CATALOG_OBJECT_ID,
+      sheetId: null,
+      viewId: null,
+      fieldIds: {},
+      seeded: 0,
+      existing: 0,
+    }
+  }
+
+  const descriptor = getAttendanceReportFieldCatalogDescriptor()
+  const provisioned = await multitable.provisioning.ensureObject({
+    projectId,
+    descriptor,
+  })
+  const logicalFieldIds = Object.values(ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS)
+  let fieldIds = {}
+  if (typeof multitable.provisioning.resolveFieldIds === 'function') {
+    fieldIds = await multitable.provisioning.resolveFieldIds({
+      projectId,
+      objectId: ATTENDANCE_REPORT_FIELD_CATALOG_OBJECT_ID,
+      fieldIds: logicalFieldIds,
+    })
+  } else if (typeof multitable.provisioning.getFieldId === 'function') {
+    fieldIds = Object.fromEntries(logicalFieldIds.map(fieldId => [
+      fieldId,
+      multitable.provisioning.getFieldId(projectId, ATTENDANCE_REPORT_FIELD_CATALOG_OBJECT_ID, fieldId),
+    ]))
+  }
+
+  let viewId = null
+  if (typeof multitable.provisioning.ensureView === 'function') {
+    try {
+      const view = await multitable.provisioning.ensureView({
+        projectId,
+        sheetId: provisioned.sheet.id,
+        descriptor: getAttendanceReportFieldCatalogViewDescriptor(fieldIds),
+      })
+      viewId = view?.id || null
+    } catch (error) {
+      logger?.warn?.('Failed to ensure attendance report field catalog view', error)
+    }
+  }
+
+  const seedResult = options.seedRecords === false
+    ? { skipped: true, seeded: 0, existing: 0 }
+    : await seedAttendanceReportFieldCatalogRecords(multitable, provisioned.sheet.id, fieldIds, logger)
+
+  return {
+    available: true,
+    reason: null,
+    projectId,
+    objectId: ATTENDANCE_REPORT_FIELD_CATALOG_OBJECT_ID,
+    baseId: provisioned.baseId,
+    sheetId: provisioned.sheet.id,
+    viewId,
+    fieldIds,
+    seeded: seedResult.seeded,
+    existing: seedResult.existing,
+    seedSkipped: seedResult.skipped,
+  }
+}
+
+async function loadAttendanceReportFieldCatalog(context, orgId) {
+  const projectId = getAttendanceReportFieldProjectId(orgId)
+  const multitable = context?.api?.multitable
+  const provisioning = multitable?.provisioning
+  if (!provisioning?.findObjectSheet || !multitable?.records?.queryRecords) {
+    return {
+      available: false,
+      reason: 'MULTITABLE_API_UNAVAILABLE',
+      projectId,
+      objectId: ATTENDANCE_REPORT_FIELD_CATALOG_OBJECT_ID,
+      sheetId: null,
+      viewId: null,
+      fieldIds: {},
+    }
+  }
+
+  const sheet = await provisioning.findObjectSheet({
+    projectId,
+    objectId: ATTENDANCE_REPORT_FIELD_CATALOG_OBJECT_ID,
+  })
+  if (!sheet) {
+    return {
+      available: false,
+      reason: 'CATALOG_NOT_PROVISIONED',
+      projectId,
+      objectId: ATTENDANCE_REPORT_FIELD_CATALOG_OBJECT_ID,
+      sheetId: null,
+      viewId: null,
+      fieldIds: {},
+    }
+  }
+
+  const logicalFieldIds = Object.values(ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS)
+  let fieldIds = {}
+  if (typeof provisioning.resolveFieldIds === 'function') {
+    fieldIds = await provisioning.resolveFieldIds({
+      projectId,
+      objectId: ATTENDANCE_REPORT_FIELD_CATALOG_OBJECT_ID,
+      fieldIds: logicalFieldIds,
+    })
+  } else if (typeof provisioning.getFieldId === 'function') {
+    fieldIds = Object.fromEntries(logicalFieldIds.map(fieldId => [
+      fieldId,
+      provisioning.getFieldId(projectId, ATTENDANCE_REPORT_FIELD_CATALOG_OBJECT_ID, fieldId),
+    ]))
+  }
+
+  return {
+    available: true,
+    reason: null,
+    projectId,
+    objectId: ATTENDANCE_REPORT_FIELD_CATALOG_OBJECT_ID,
+    baseId: sheet.baseId || null,
+    sheetId: sheet.id,
+    viewId: getAttendanceReportFieldCatalogViewId(projectId),
+    fieldIds,
+    seeded: 0,
+    existing: 0,
+    seedSkipped: true,
+  }
+}
+
+function buildAttendanceReportFieldCatalogFallback(orgId, reason, error) {
+  const projectId = getAttendanceReportFieldProjectId(orgId)
+  const items = mergeAttendanceReportFieldDefinitions([], {})
+  const multitable = {
+    available: false,
+    degraded: true,
+    reason,
+    error: error instanceof Error ? error.message : undefined,
+    projectId,
+    objectId: ATTENDANCE_REPORT_FIELD_CATALOG_OBJECT_ID,
+    sheetId: null,
+    viewId: null,
+    seeded: 0,
+    existing: 0,
+  }
+  return {
+    categories: cloneAttendanceReportFieldCategories(),
+    items,
+    multitable,
+    reportFieldConfig: buildAttendanceReportFieldConfig({
+      fields: resolveAttendanceRecordReportFields(items),
+      multitable,
+    }),
+  }
+}
+
+async function buildAttendanceReportFieldCatalogResponse(context, orgId, logger, options = {}) {
+  let catalog
+  try {
+    catalog = options.provision === true
+      ? await ensureAttendanceReportFieldCatalog(context, orgId, logger, { seedRecords: options.seedRecords !== false })
+      : await loadAttendanceReportFieldCatalog(context, orgId, logger)
+  } catch (error) {
+    logger?.warn?.('Attendance report field catalog provisioning degraded', error)
+    return buildAttendanceReportFieldCatalogFallback(orgId, 'PROVISIONING_FAILED', error)
+  }
+
+  if (!catalog.available) {
+    return buildAttendanceReportFieldCatalogFallback(orgId, catalog.reason || 'MULTITABLE_UNAVAILABLE')
+  }
+
+  try {
+    const records = context.api.multitable.records?.queryRecords
+      ? await context.api.multitable.records.queryRecords({
+        sheetId: catalog.sheetId,
+        orderBy: {
+          fieldId: catalog.fieldIds?.[ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.sortOrder] || ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.sortOrder,
+          direction: 'asc',
+        },
+        limit: 1000,
+      })
+      : []
+    const items = mergeAttendanceReportFieldDefinitions(records, catalog.fieldIds)
+    const multitable = {
+      available: true,
+      degraded: false,
+      projectId: catalog.projectId,
+      objectId: catalog.objectId,
+      baseId: catalog.baseId || null,
+      sheetId: catalog.sheetId,
+      viewId: catalog.viewId,
+      seeded: catalog.seeded,
+      existing: catalog.existing,
+      recordCount: records.length,
+    }
+    return {
+      categories: cloneAttendanceReportFieldCategories(),
+      items,
+      multitable,
+      reportFieldConfig: buildAttendanceReportFieldConfig({
+        fields: resolveAttendanceRecordReportFields(items),
+        multitable,
+      }),
+    }
+  } catch (error) {
+    logger?.warn?.('Attendance report field catalog read degraded', error)
+    return buildAttendanceReportFieldCatalogFallback(orgId, 'READ_FAILED', error)
+  }
+}
+
+const ATTENDANCE_RECORD_REPORT_FIELD_CODES = Object.freeze([
+  'work_date',
+  'employee_name',
+  'employee_no',
+  'department',
+  'position',
+  'attendance_group',
+  'punch_times',
+  'punch_result',
+  'approval_forms',
+  'expected_attendance_days',
+  'correction_count',
+  'attendance_shift',
+  'attendance_days',
+  'rest_days',
+  'work_duration',
+  'business_trip_duration',
+  'outing_duration',
+  'attendance_result',
+  'shift',
+  'late_count',
+  'late_duration',
+  'severe_late_count',
+  'severe_late_duration',
+  'absence_late_count',
+  'early_leave_count',
+  'early_leave_duration',
+  'missing_clock_in_count',
+  'missing_clock_out_count',
+  'absenteeism_days',
+  'leave_duration',
+  'overtime_approval_duration',
+  'workday_overtime_duration',
+  'restday_overtime_duration',
+  'holiday_overtime_duration',
+])
+
+const ATTENDANCE_RECORD_REPORT_FIELD_CODE_SET = new Set(ATTENDANCE_RECORD_REPORT_FIELD_CODES)
+
+function resolveAttendanceRecordReportFields(items) {
+  const sourceItems = Array.isArray(items) && items.length > 0
+    ? items
+    : mergeAttendanceReportFieldDefinitions([], {})
+  return sourceItems
+    .filter(field => (
+      field
+      && field.enabled !== false
+      && field.reportVisible !== false
+      && ATTENDANCE_RECORD_REPORT_FIELD_CODE_SET.has(field.code)
+    ))
+    .map(field => ({
+      code: field.code,
+      name: field.name || field.code,
+      category: field.category || 'attendance',
+      categoryLabel: field.categoryLabel || getAttendanceReportFieldCategory(field.category).label,
+      unit: field.unit || 'text',
+      sortOrder: Number(field.sortOrder) || 0,
+      source: field.source || 'system',
+      description: field.description || '',
+      systemDefined: field.systemDefined !== false,
+      configured: Boolean(field.configured),
+      exportKey: field.code,
+    }))
+    .sort((left, right) => {
+      if (left.sortOrder !== right.sortOrder) return left.sortOrder - right.sortOrder
+      return left.code.localeCompare(right.code)
+    })
+}
+
+async function loadAttendanceRecordReportFields(context, orgId, logger) {
+  const catalog = await buildAttendanceReportFieldCatalogResponse(context, orgId, logger, { provision: false })
+  return {
+    fields: resolveAttendanceRecordReportFields(catalog.items),
+    multitable: catalog.multitable,
+  }
+}
+
+function buildAttendanceReportFieldConfigFingerprint(fields) {
+  const normalized = Array.isArray(fields)
+    ? fields
+      .map(field => ({
+        code: String(field?.code || ''),
+        name: String(field?.name || ''),
+        category: String(field?.category || ''),
+        unit: String(field?.unit || ''),
+        sortOrder: Number(field?.sortOrder) || 0,
+        source: String(field?.source || ''),
+        configured: Boolean(field?.configured),
+        systemDefined: field?.systemDefined !== false,
+      }))
+      .filter(field => field.code)
+      .sort((left, right) => {
+        if (left.sortOrder !== right.sortOrder) return left.sortOrder - right.sortOrder
+        return left.code.localeCompare(right.code)
+      })
+    : []
+  const value = crypto
+    .createHash('sha1')
+    .update(JSON.stringify(normalized))
+    .digest('hex')
+  return {
+    algorithm: 'sha1',
+    value,
+    fieldCount: normalized.length,
+    codes: normalized.map(field => field.code),
+  }
+}
+
+function buildAttendanceReportFieldConfig(reportFields) {
+  const fields = Array.isArray(reportFields?.fields) ? reportFields.fields : []
+  return {
+    multitable: reportFields?.multitable || {
+      available: false,
+      degraded: true,
+      reason: 'REPORT_FIELD_CONFIG_UNAVAILABLE',
+    },
+    fieldsFingerprint: buildAttendanceReportFieldConfigFingerprint(fields),
+  }
+}
+
+function buildAttendanceReportFieldConfigHeaders(reportFieldConfig) {
+  const fingerprint = reportFieldConfig?.fieldsFingerprint || {}
+  const multitable = reportFieldConfig?.multitable || {}
+  const headers = {}
+  const algorithm = String(fingerprint.algorithm || '').trim()
+  const value = String(fingerprint.value || '').trim()
+  const fieldCount = Number(fingerprint.fieldCount)
+  const codes = Array.isArray(fingerprint.codes)
+    ? fingerprint.codes.map(code => String(code || '').trim()).filter(Boolean)
+    : []
+  if (algorithm) headers['X-Attendance-Report-Fields-Fingerprint-Algorithm'] = algorithm
+  if (value) headers['X-Attendance-Report-Fields-Fingerprint'] = value
+  if (Number.isFinite(fieldCount)) headers['X-Attendance-Report-Fields-Count'] = String(fieldCount)
+  if (codes.length > 0) headers['X-Attendance-Report-Fields-Codes'] = codes.join(',')
+  const projectId = String(multitable.projectId || '').trim()
+  const objectId = String(multitable.objectId || '').trim()
+  const sheetId = String(multitable.sheetId || '').trim()
+  const viewId = String(multitable.viewId || '').trim()
+  if (projectId) headers['X-Attendance-Report-Fields-Project-Id'] = projectId
+  if (objectId) headers['X-Attendance-Report-Fields-Object-Id'] = objectId
+  if (sheetId) headers['X-Attendance-Report-Fields-Sheet-Id'] = sheetId
+  if (viewId) headers['X-Attendance-Report-Fields-View-Id'] = viewId
+  return headers
+}
+
+function setAttendanceReportFieldConfigHeaders(res, reportFieldConfig) {
+  for (const [key, value] of Object.entries(buildAttendanceReportFieldConfigHeaders(reportFieldConfig))) {
+    res.setHeader(key, value)
+  }
+}
+
+function firstNonEmptyValue(...values) {
+  for (const value of values) {
+    if (Array.isArray(value)) {
+      const joined = value.map(item => String(item ?? '').trim()).filter(Boolean).join(', ')
+      if (joined) return joined
+      continue
+    }
+    const normalized = typeof value === 'string' ? value.trim() : value
+    if (normalized !== undefined && normalized !== null && normalized !== '') return normalized
+  }
+  return ''
+}
+
+function readAttendanceRecordMeta(row, keys) {
+  const meta = normalizeMetadata(row?.meta)
+  for (const key of keys) {
+    if (Object.prototype.hasOwnProperty.call(meta, key)) {
+      return meta[key]
+    }
+  }
+  return undefined
+}
+
+function readAttendanceRecordMinutes(row, keys, fallback = 0) {
+  const value = readAttendanceRecordMeta(row, keys)
+  const parsed = Number(value)
+  if (Number.isFinite(parsed)) return parsed
+  return fallback
+}
+
+function formatAttendanceRecordReportDateTime(value, timezone) {
+  return value ? formatDateTimeForCsv(value, timezone) : ''
+}
+
+function getAttendanceRecordReportFieldValue(row, fieldCode) {
+  const timezone = row?.timezone
+  const workDate = normalizeDateOnly(row?.work_date) ?? String(row?.work_date ?? '').slice(0, 10)
+  const status = String(row?.status ?? '')
+  const isWorkday = row?.is_workday !== false
+  const workMinutes = Number(row?.work_minutes ?? 0)
+  const lateMinutes = Number(row?.late_minutes ?? 0)
+  const earlyLeaveMinutes = Number(row?.early_leave_minutes ?? 0)
+  const leaveMinutes = readAttendanceRecordMinutes(row, ['leave_minutes', 'leaveMinutes'], 0)
+  const overtimeMinutes = readAttendanceRecordMinutes(row, ['overtime_minutes', 'overtimeMinutes'], 0)
+
+  switch (fieldCode) {
+    case 'work_date':
+      return workDate
+    case 'employee_name':
+      return firstNonEmptyValue(row?.user_name, row?.username, row?.user_id)
+    case 'employee_no':
+      return firstNonEmptyValue(readAttendanceRecordMeta(row, ['empNo', 'employeeNo', 'employee_no', '工号']), row?.user_id)
+    case 'department':
+      return firstNonEmptyValue(readAttendanceRecordMeta(row, ['department', '部门']))
+    case 'position':
+      return firstNonEmptyValue(readAttendanceRecordMeta(row, ['position', 'role', 'roleTags', 'role_tags', '职位']))
+    case 'attendance_group':
+      return firstNonEmptyValue(readAttendanceRecordMeta(row, ['attendanceGroup', 'attendance_group', '考勤组']))
+    case 'punch_times':
+      return [
+        formatAttendanceRecordReportDateTime(row?.first_in_at, timezone),
+        formatAttendanceRecordReportDateTime(row?.last_out_at, timezone),
+      ].filter(Boolean).join(' / ')
+    case 'punch_result':
+    case 'attendance_result':
+      return status
+    case 'approval_forms':
+      return firstNonEmptyValue(readAttendanceRecordMeta(row, ['approvalSummary', 'approval_summary', 'attendance_approve', '关联的审批单']))
+    case 'expected_attendance_days':
+      return isWorkday ? 1 : 0
+    case 'correction_count':
+      return Number(readAttendanceRecordMeta(row, ['correction_count', 'correctionCount']) ?? (status === 'adjusted' ? 1 : 0))
+    case 'attendance_shift':
+      return firstNonEmptyValue(readAttendanceRecordMeta(row, ['attendanceClass', 'attendance_class', '出勤班次']))
+    case 'attendance_days':
+      return isWorkday && !['absent', 'off'].includes(status) ? 1 : 0
+    case 'rest_days':
+      return isWorkday ? 0 : 1
+    case 'work_duration':
+      return workMinutes
+    case 'business_trip_duration':
+      return readAttendanceRecordMinutes(row, ['business_trip_minutes', 'businessTripMinutes', 'businessTripDuration'], 0)
+    case 'outing_duration':
+      return readAttendanceRecordMinutes(row, ['outing_minutes', 'outingMinutes', 'outingDuration'], 0)
+    case 'shift':
+      return firstNonEmptyValue(readAttendanceRecordMeta(row, ['shiftName', 'shift_name', '班次']), row?.workday_context?.shiftName)
+    case 'late_count':
+      return lateMinutes > 0 ? 1 : 0
+    case 'late_duration':
+      return lateMinutes
+    case 'severe_late_count':
+      return Number(readAttendanceRecordMeta(row, ['severe_late_count', 'severeLateCount']) ?? 0)
+    case 'severe_late_duration':
+      return readAttendanceRecordMinutes(row, ['severe_late_minutes', 'severeLateMinutes'], 0)
+    case 'absence_late_count':
+      return Number(readAttendanceRecordMeta(row, ['absence_late_count', 'absenceLateCount']) ?? 0)
+    case 'early_leave_count':
+      return earlyLeaveMinutes > 0 ? 1 : 0
+    case 'early_leave_duration':
+      return earlyLeaveMinutes
+    case 'missing_clock_in_count':
+      return isWorkday && !row?.first_in_at ? 1 : 0
+    case 'missing_clock_out_count':
+      return isWorkday && !row?.last_out_at ? 1 : 0
+    case 'absenteeism_days':
+      return status === 'absent' ? 1 : 0
+    case 'leave_duration':
+      return leaveMinutes
+    case 'overtime_approval_duration':
+      return overtimeMinutes
+    case 'workday_overtime_duration':
+      return isWorkday ? overtimeMinutes : 0
+    case 'restday_overtime_duration':
+      return !isWorkday ? overtimeMinutes : 0
+    case 'holiday_overtime_duration':
+      return Number(readAttendanceRecordMeta(row, ['holiday_overtime_minutes', 'holidayOvertimeMinutes']) ?? 0)
+    default:
+      return ''
+  }
+}
+
+function buildAttendanceRecordReportExportItem(row, reportFields) {
+  return Object.fromEntries(reportFields.map(field => [
+    field.exportKey || field.code,
+    getAttendanceRecordReportFieldValue(row, field.code),
+  ]))
+}
+
 function findImportProfile(profileId) {
   if (!profileId) return null
   return IMPORT_MAPPING_PROFILES.find((profile) => profile.id === profileId) ?? null
@@ -6733,6 +7859,31 @@ function buildCsv(rows, headers) {
   return lines.join('\n')
 }
 
+function buildCsvWithColumns(rows, columns) {
+  const normalizedColumns = Array.isArray(columns)
+    ? columns.filter(column => column && column.key)
+    : []
+  const lines = [
+    normalizedColumns.map(column => formatCsvValue(column.label || column.key)).join(','),
+  ]
+  for (const row of rows) {
+    const line = normalizedColumns.map(column => formatCsvValue(row[column.key])).join(',')
+    lines.push(line)
+  }
+  return lines.join('\n')
+}
+
+function buildAttendanceRecordReportCsv(rows, reportFields, options = {}) {
+  const headerMode = options.headerMode === 'code' ? 'code' : 'label'
+  const columns = reportFields.map(field => ({
+    key: field.exportKey || field.code,
+    label: headerMode === 'code'
+      ? (field.exportKey || field.code)
+      : (field.name || field.exportKey || field.code),
+  }))
+  return buildCsvWithColumns(rows, columns)
+}
+
 function buildPayrollSummaryCsv(summary, cycle) {
   const headers = ['cycle_id', 'cycle_name', 'start_date', 'end_date', 'metric', 'value']
   const rows = [
@@ -7140,6 +8291,28 @@ async function isApproverAllowed(db, userId, step, logger) {
 }
 
 module.exports = {
+  __attendanceReportFieldCatalogForTests: {
+    ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS,
+    ATTENDANCE_REPORT_FIELD_CATALOG_OBJECT_ID,
+    ATTENDANCE_REPORT_FIELD_CATALOG_VIEW_ID,
+    buildAttendanceReportFieldCatalogRecordData,
+    buildAttendanceReportFieldCatalogResponse,
+    cloneAttendanceReportFieldCategories,
+    cloneAttendanceReportFieldDefinitions,
+    ensureAttendanceReportFieldCatalog,
+    getAttendanceRecordReportFieldValue,
+    getAttendanceReportFieldCatalogDescriptor,
+    getAttendanceReportFieldProjectId,
+    loadAttendanceReportFieldCatalog,
+    mergeAttendanceReportFieldDefinitions,
+    resolveAttendanceRecordReportFields,
+    buildAttendanceRecordReportExportItem,
+    buildAttendanceRecordReportCsv,
+    buildAttendanceReportFieldConfig,
+    buildAttendanceReportFieldConfigHeaders,
+    buildAttendanceReportFieldConfigFingerprint,
+  },
+
   async activate(context) {
     const db = context.api.database
     const logger = context.logger
@@ -9883,9 +11056,11 @@ module.exports = {
           const total = Number(countRows[0]?.total ?? 0)
 
           const rows = await db.query(
-            `SELECT * FROM attendance_records
-             WHERE user_id = $1 AND org_id = $2 AND work_date BETWEEN $3 AND $4
-             ORDER BY work_date DESC
+            `SELECT ar.*, u.name AS user_name, u.username AS username
+             FROM attendance_records ar
+             LEFT JOIN users u ON u.id = ar.user_id
+             WHERE ar.user_id = $1 AND ar.org_id = $2 AND ar.work_date BETWEEN $3 AND $4
+             ORDER BY ar.work_date DESC
              LIMIT $5 OFFSET $6`,
             [targetUserId, orgId, from, to, pageSize, offset]
           )
@@ -9896,6 +11071,7 @@ module.exports = {
             workDates: rows.map((row) => row.work_date),
           })
           const approvedMap = await loadApprovedMinutesRange(db, orgId, targetUserId, from, to)
+          const reportFields = await loadAttendanceRecordReportFields(context, orgId, logger)
           const records = rows.map((row) => {
             const workDate = normalizeDateOnly(row.work_date) ?? String(row.work_date ?? '').slice(0, 10)
             const meta = normalizeMetadata(row.meta)
@@ -9931,6 +11107,8 @@ module.exports = {
               total,
               page,
               pageSize,
+              reportFields: reportFields.fields,
+              reportFieldConfig: buildAttendanceReportFieldConfig(reportFields),
             },
           })
         } catch (error) {
@@ -19107,6 +20285,36 @@ module.exports = {
 
     context.api.http.addRoute(
       'GET',
+      '/api/attendance/report-fields',
+      withPermission('attendance:admin', async (req, res) => {
+        const orgId = getOrgId(req)
+        const data = await buildAttendanceReportFieldCatalogResponse(context, orgId, logger, { provision: false })
+        res.json({ ok: true, data })
+      })
+    )
+
+    context.api.http.addRoute(
+      'POST',
+      '/api/attendance/report-fields/sync',
+      withPermission('attendance:admin', async (req, res) => {
+        const orgId = getOrgId(req)
+        const data = await buildAttendanceReportFieldCatalogResponse(context, orgId, logger, {
+          provision: true,
+          seedRecords: true,
+        })
+        emitEvent('attendance.report_fields.synced', {
+          orgId,
+          projectId: data.multitable?.projectId,
+          sheetId: data.multitable?.sheetId,
+          recordCount: data.multitable?.recordCount,
+          syncedAt: new Date().toISOString(),
+        })
+        res.json({ ok: true, data })
+      })
+    )
+
+    context.api.http.addRoute(
+      'GET',
       '/api/attendance/settings',
       withPermission('attendance:admin', async (_req, res) => {
         try {
@@ -19165,6 +20373,7 @@ module.exports = {
           to: z.string().optional(),
           limit: z.string().optional(),
           format: z.enum(['csv', 'json']).optional(),
+          header: z.enum(['label', 'code']).optional(),
         })
 
         const parsed = schema.safeParse({
@@ -19174,6 +20383,7 @@ module.exports = {
           to: typeof req.query.to === 'string' ? req.query.to : undefined,
           limit: typeof req.query.limit === 'string' ? req.query.limit : undefined,
           format: typeof req.query.format === 'string' ? req.query.format.toLowerCase() : undefined,
+          header: typeof req.query.header === 'string' ? req.query.header.toLowerCase() : undefined,
         })
 
         if (!parsed.success) {
@@ -19208,41 +20418,34 @@ module.exports = {
 
         try {
           const rows = await db.query(
-            `SELECT user_id, org_id, work_date, timezone, first_in_at, last_out_at, work_minutes, late_minutes,
-                    early_leave_minutes, status, is_workday
-             FROM attendance_records
-             WHERE user_id = $1 AND org_id = $2 AND work_date BETWEEN $3 AND $4
-             ORDER BY work_date DESC
+            `SELECT ar.user_id, ar.org_id, ar.work_date, ar.timezone, ar.first_in_at, ar.last_out_at,
+                    ar.work_minutes, ar.late_minutes, ar.early_leave_minutes, ar.status, ar.is_workday,
+                    ar.meta, u.name AS user_name, u.username AS username
+             FROM attendance_records ar
+             LEFT JOIN users u ON u.id = ar.user_id
+             WHERE ar.user_id = $1 AND ar.org_id = $2 AND ar.work_date BETWEEN $3 AND $4
+             ORDER BY ar.work_date DESC
              LIMIT $5`,
             [targetUserId, orgId, from, to, limit]
           )
 
-          const headers = [
-            'user_id',
-            'org_id',
-            'work_date',
-            'timezone',
-            'first_in_at',
-            'last_out_at',
-            'work_minutes',
-            'late_minutes',
-            'early_leave_minutes',
-            'status',
-            'is_workday',
-          ]
-          const exportItems = rows.map((row) => ({
-            user_id: row.user_id ?? '',
-            org_id: row.org_id ?? '',
-            work_date: formatDateOnlyForCsv(row.work_date),
-            timezone: row.timezone ?? '',
-            first_in_at: formatDateTimeForCsv(row.first_in_at, row.timezone),
-            last_out_at: formatDateTimeForCsv(row.last_out_at, row.timezone),
-            work_minutes: row.work_minutes ?? 0,
-            late_minutes: row.late_minutes ?? 0,
-            early_leave_minutes: row.early_leave_minutes ?? 0,
-            status: row.status ?? '',
-            is_workday: row.is_workday ?? '',
-          }))
+          const approvedMap = await loadApprovedMinutesRange(db, orgId, targetUserId, from, to)
+          const reportFields = await loadAttendanceRecordReportFields(context, orgId, logger)
+          const exportRows = rows.map((row) => {
+            const workDate = normalizeDateOnly(row.work_date) ?? String(row.work_date ?? '').slice(0, 10)
+            const approved = approvedMap.get(workDate) ?? { leaveMinutes: 0, overtimeMinutes: 0 }
+            return {
+              ...row,
+              work_date: workDate,
+              meta: {
+                ...normalizeMetadata(row.meta),
+                leave_minutes: approved.leaveMinutes,
+                overtime_minutes: approved.overtimeMinutes,
+              },
+            }
+          })
+          const exportItems = exportRows.map(row => buildAttendanceRecordReportExportItem(row, reportFields.fields))
+          const reportFieldConfig = buildAttendanceReportFieldConfig(reportFields)
           if (parsed.data.format === 'json') {
             emitEvent('attendance.exported', {
               orgId,
@@ -19261,11 +20464,15 @@ module.exports = {
                 from,
                 to,
                 format: 'json',
+                reportFields: reportFields.fields,
+                reportFieldConfig,
               },
             })
             return
           }
-          const csv = buildCsv(exportItems, headers)
+          const csv = buildAttendanceRecordReportCsv(exportItems, reportFields.fields, {
+            headerMode: parsed.data.header || 'label',
+          })
           const filename = `attendance-${orgId}-${from}-to-${to}.csv`
 
           emitEvent('attendance.exported', {
@@ -19277,6 +20484,7 @@ module.exports = {
           })
           res.setHeader('Content-Type', 'text/csv')
           res.setHeader('Content-Disposition', `attachment; filename="${filename}"`)
+          setAttendanceReportFieldConfigHeaders(res, reportFieldConfig)
           res.status(200).send(csv)
         } catch (error) {
           if (isDatabaseSchemaError(error)) {
@@ -19296,6 +20504,12 @@ module.exports = {
 	      scheduleImportUploadCleanup()
 	    } catch (error) {
 	      logger.warn('Attendance settings preload failed', error)
+	    }
+
+	    try {
+	      await ensureAttendanceReportFieldCatalog(context, DEFAULT_ORG_ID, logger)
+	    } catch (error) {
+	      logger.warn('Attendance report field catalog preload failed', error)
 	    }
 
     logger.info('Attendance plugin activated')


### PR DESCRIPTION
## Summary\n- add the attendance report field catalog descriptor and multitable provisioning/read path\n- expose report field catalog and sync APIs through the attendance plugin, with built-in fallback when multitable is unavailable\n- wire the admin UI report-fields section plus record table/export field configuration evidence\n\n## Verification\n- node --check plugins/plugin-attendance/index.cjs\n- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-report-field-catalog.test.ts --reporter=dot\n- NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/AttendanceReportFieldsSection.spec.ts tests/attendance-admin-anchor-nav.spec.ts --watch=false --reporter=dot\n- NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/attendance-admin-regressions.spec.ts --watch=false --reporter=dot\n- pnpm --filter @metasheet/core-backend build\n- pnpm --filter @metasheet/web type-check\n- pnpm --filter @metasheet/web build\n- git diff --check\n\n## Notes\n- source of truth for attendance facts remains the attendance domain tables; multitable is used for field catalog/config only\n- frontend Vitest emitted an existing local WebSocket port-in-use warning but exited successfully\n