### PR TITLE
fix(attendance): resolve locale zh smoke auth before run

### DIFF
--- a/.github/workflows/attendance-locale-zh-smoke-prod.yml
+++ b/.github/workflows/attendance-locale-zh-smoke-prod.yml
@@ -60,9 +60,10 @@ jobs:
       VERIFY_HOLIDAY: ${{ inputs.verify_holiday || 'true' }}
       REQUIRE_TOGGLE_CHECKS: ${{ inputs.require_toggle_checks || vars.ATTENDANCE_LOCALE_ZH_REQUIRE_TOGGLE_CHECKS || 'false' }}
       REQUIRE_SHELL_TAB_CHECKS: ${{ inputs.require_shell_tab_checks || vars.ATTENDANCE_LOCALE_ZH_REQUIRE_SHELL_TAB_CHECKS || 'false' }}
-      AUTH_TOKEN: ${{ secrets.ATTENDANCE_ADMIN_JWT }}
-      LOGIN_EMAIL: ${{ secrets.ATTENDANCE_ADMIN_EMAIL }}
-      LOGIN_PASSWORD: ${{ secrets.ATTENDANCE_ADMIN_PASSWORD }}
+      AUTH_TOKEN: ${{ secrets.ATTENDANCE_ADMIN_JWT || vars.ATTENDANCE_ADMIN_JWT || '' }}
+      LOGIN_EMAIL: ${{ secrets.ATTENDANCE_ADMIN_EMAIL || vars.ATTENDANCE_ADMIN_EMAIL || '' }}
+      LOGIN_PASSWORD: ${{ secrets.ATTENDANCE_ADMIN_PASSWORD || vars.ATTENDANCE_ADMIN_PASSWORD || '' }}
+      AUTH_RESOLVE_ALLOW_INSECURE_HTTP: ${{ vars.ATTENDANCE_ALLOW_INSECURE_HTTP || 'true' }}
       HEADLESS: 'true'
       OUTPUT_DIR: output/playwright/attendance-locale-zh-smoke
       DRILL_FAIL: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.drill_fail == 'true' }}
@@ -106,8 +107,44 @@ jobs:
         if: ${{ env.DRILL_FAIL != 'true' }}
         run: pnpm exec playwright install chromium --with-deps
 
+      - name: Resolve valid auth token
+        if: ${{ env.DRILL_FAIL != 'true' }}
+        id: resolve-auth-token
+        run: |
+          set -euo pipefail
+          mkdir -p output/playwright/attendance-locale-zh-smoke
+          meta_file="output/playwright/attendance-locale-zh-smoke/auth-resolve-meta.txt"
+
+          if ! resolved_token="$(
+            API_BASE="${API_BASE}" \
+            AUTH_TOKEN="${AUTH_TOKEN}" \
+            LOGIN_EMAIL="${LOGIN_EMAIL}" \
+            LOGIN_PASSWORD="${LOGIN_PASSWORD}" \
+            AUTH_RESOLVE_ALLOW_INSECURE_HTTP="${AUTH_RESOLVE_ALLOW_INSECURE_HTTP}" \
+            AUTH_RESOLVE_META_FILE="${meta_file}" \
+            ./scripts/ops/attendance-resolve-auth.sh
+          )"; then
+            API_BASE="${API_BASE}" \
+            ./scripts/ops/attendance-write-auth-error.sh \
+              "${meta_file}" \
+              "output/playwright/attendance-locale-zh-smoke/auth-error.txt"
+            echo "::error::No valid attendance admin token; see auth-error.txt artifact."
+            exit 1
+          fi
+
+          echo "::add-mask::${resolved_token}"
+          echo "AUTH_TOKEN_EFFECTIVE=${resolved_token}" >> "$GITHUB_ENV"
+
+          auth_source="unknown"
+          if [[ -f "${meta_file}" ]]; then
+            auth_source="$(awk -F= '/^AUTH_SOURCE=/{print $2}' "${meta_file}" | tail -n1)"
+          fi
+          echo "auth_source=${auth_source}" >> "$GITHUB_OUTPUT"
+
       - name: Run zh locale smoke
         if: ${{ env.DRILL_FAIL != 'true' }}
+        env:
+          AUTH_TOKEN: ${{ env.AUTH_TOKEN_EFFECTIVE }}
         run: pnpm verify:attendance-locale-zh
 
       - name: Write step summary
@@ -128,6 +165,9 @@ jobs:
             zh_admin_tab="$(jq -r '.zhLabels.adminTab // "unknown"' output/playwright/attendance-locale-zh-smoke/attendance-zh-locale-summary.json 2>/dev/null || echo 'unknown')"
             zh_workflow_tab="$(jq -r '.zhLabels.workflowTab // "unknown"' output/playwright/attendance-locale-zh-smoke/attendance-zh-locale-summary.json 2>/dev/null || echo 'unknown')"
           fi
+          if [[ "${auth_source}" == 'unknown' && -f output/playwright/attendance-locale-zh-smoke/auth-resolve-meta.txt ]]; then
+            auth_source="$(awk -F= '/^AUTH_SOURCE=/{print $2}' output/playwright/attendance-locale-zh-smoke/auth-resolve-meta.txt | tail -n1)"
+          fi
           {
             echo "## Attendance Locale zh Smoke (Prod)"
             echo ""
@@ -144,6 +184,9 @@ jobs:
             echo ""
             echo "Expected screenshot:"
             echo "- \`output/playwright/attendance-locale-zh-smoke/attendance-zh-locale-calendar.png\`"
+            echo ""
+            echo "Auth diagnostics on resolver failure:"
+            echo "- \`output/playwright/attendance-locale-zh-smoke/auth-error.txt\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload artifacts

--- a/docs/development/attendance-locale-zh-smoke-auth-resolver-development-20260514.md
+++ b/docs/development/attendance-locale-zh-smoke-auth-resolver-development-20260514.md
@@ -1,0 +1,51 @@
+# Attendance Locale zh Smoke Auth Resolver Development - 2026-05-14
+
+## Summary
+
+Implemented the production attendance zh-locale smoke workflow auth closeout slice.
+
+The workflow had drifted away from the shared attendance production gate auth resolver. It passed the configured admin JWT directly into `pnpm verify:attendance-locale-zh`; when that JWT was stale and login fallback values were absent, the smoke failed inside the Node smoke script with a less actionable failure.
+
+This slice reuses the shared `scripts/ops/attendance-resolve-auth.sh` and `scripts/ops/attendance-write-auth-error.sh` path already used by the strict and perf production gates.
+
+## Changed Behavior
+
+- `Attendance Locale zh Smoke (Prod)` now resolves a valid auth token before running the real zh-locale smoke.
+- The workflow now reads attendance admin auth inputs from GitHub Secrets first, then GitHub Variables, then an empty fallback.
+- The resolver validates the configured token with `/api/auth/me`, tries refresh, then tries login when email/password are configured.
+- On resolver failure, the workflow writes a redacted `auth-error.txt` artifact and fails before launching Playwright.
+- The real smoke step receives only the resolved masked token through `AUTH_TOKEN_EFFECTIVE`.
+- Drill mode remains unchanged and still exits before setup, install, resolver, and real smoke steps.
+- Step summary now points operators to the expected screenshot on success and to `auth-error.txt` on resolver failure.
+
+## Files Changed
+
+- `.github/workflows/attendance-locale-zh-smoke-prod.yml`
+- `scripts/ops/attendance-locale-zh-workflow-contract.test.mjs`
+- `docs/development/attendance-locale-zh-smoke-auth-resolver-development-20260514.md`
+- `docs/development/attendance-locale-zh-smoke-auth-resolver-verification-20260514.md`
+
+## Design Notes
+
+This change intentionally does not duplicate auth fallback logic in the workflow. The shell resolver remains the single production-gate auth path for attendance workflows.
+
+The workflow-level resolver is useful even though `scripts/verify-attendance-locale-zh-smoke.mjs` still has its own fallback logic: the workflow can now fail earlier with a standard diagnostic artifact, and all attendance production gates use the same token validation contract.
+
+No runtime API, frontend, database, DingTalk, or attendance product behavior is changed by this slice.
+
+Added a small `node:test` workflow contract so the locale smoke workflow keeps the shared resolver, fallback variables, resolved-token handoff, redacted auth-error artifact, and drill ordering intact.
+
+## Security Notes
+
+- No admin JWT, login password, DingTalk webhook, DingTalk signing secret, or bearer token is written to Git.
+- The resolved token is masked through `::add-mask::` before being exported to the job environment.
+- The failure artifact records only HTTP status diagnostics and whether login fields were present.
+- GitHub Secrets remain the preferred source. GitHub Variables are supported only as the existing production-gate compatibility fallback.
+
+## Operational Follow-Up
+
+After this PR reaches `main`, rerun `Attendance Locale zh Smoke (Prod)`.
+
+If GitHub Secrets or Variables contain either a valid attendance admin JWT or valid attendance admin login credentials, the workflow should pass or reach a product-level smoke assertion.
+
+If neither credential source is valid, the workflow should fail with a redacted `auth-error.txt` artifact. That is an ops credential blocker, not a workflow implementation failure.

--- a/docs/development/attendance-locale-zh-smoke-auth-resolver-verification-20260514.md
+++ b/docs/development/attendance-locale-zh-smoke-auth-resolver-verification-20260514.md
@@ -1,0 +1,103 @@
+# Attendance Locale zh Smoke Auth Resolver Verification - 2026-05-14
+
+## Result
+
+Status: `PASS - source verified; live prod rerun pending after merge`
+
+The workflow now uses the shared attendance auth resolver before running the zh-locale smoke. The latest observed production failure was caused by stale token configuration plus missing login fallback fields. This change makes that failure path deterministic and redacted, while allowing valid token, refresh, or login fallback to proceed to the real smoke.
+
+## Baseline Failure Evidence
+
+- Workflow: `Attendance Locale zh Smoke (Prod)`
+- Latest failed run inspected: `25839971449`
+- Head SHA: `94c4694599f91819539a4ee2f4dd1fc07fbf87fa`
+- Branch: `main`
+- Failure lines:
+  - `AUTH_TOKEN is not usable (http_401), trying refresh/login fallback`
+  - `refresh fallback failed: API /auth/refresh-token failed: HTTP 401`
+  - `FAIL: AUTH_TOKEN is invalid and LOGIN_EMAIL/LOGIN_PASSWORD are missing`
+
+## Verification Commands
+
+```bash
+ruby -e 'require "yaml"; YAML.load_file(".github/workflows/attendance-locale-zh-smoke-prod.yml"); puts "yaml-parse-ok"'
+bash -n scripts/ops/attendance-resolve-auth.sh
+bash -n scripts/ops/attendance-write-auth-error.sh
+node --test scripts/ops/attendance-auth-scripts.test.mjs scripts/ops/attendance-locale-zh-workflow-contract.test.mjs
+python3 - <<'PY'
+import pathlib
+import re
+import subprocess
+import sys
+
+patterns = [
+    'access_' + 'token=',
+    'SEC' + r'[0-9a-fA-F]{20,}',
+    'eyJ' + r'[0-9A-Za-z_-]{20,}\.[0-9A-Za-z_-]{20,}',
+    'Bearer' + r'\s+[A-Za-z0-9._-]{20,}',
+    'ATTENDANCE_ADMIN_' + 'PASSWORD=',
+]
+regex = re.compile('|'.join(patterns))
+files = subprocess.check_output(['git', 'diff', '--name-only', '--', '.github', 'docs', 'scripts'], text=True).splitlines()
+hits = []
+for name in files:
+    path = pathlib.Path(name)
+    if not path.is_file():
+        continue
+    for index, line in enumerate(path.read_text(errors='ignore').splitlines(), 1):
+        if regex.search(line):
+            hits.append(f'{name}:{index}')
+if hits:
+    print('\n'.join(hits))
+    sys.exit(1)
+print('secret-scan-ok')
+PY
+git diff --check -- .github/workflows/attendance-locale-zh-smoke-prod.yml scripts/ops/attendance-locale-zh-workflow-contract.test.mjs docs/development/attendance-locale-zh-smoke-auth-resolver-development-20260514.md docs/development/attendance-locale-zh-smoke-auth-resolver-verification-20260514.md
+```
+
+## Expected Workflow Checks
+
+- The workflow YAML parses successfully.
+- Shell syntax checks pass for the shared auth resolver and auth-error writer.
+- `attendance-auth-scripts.test.mjs` and `attendance-locale-zh-workflow-contract.test.mjs` pass with `node --test`.
+- Secret scan has zero real-value matches.
+- Drill mode still skips real production API calls.
+- On missing or invalid credentials, the workflow writes `output/playwright/attendance-locale-zh-smoke/auth-error.txt`.
+- On valid credentials, the workflow exports `AUTH_TOKEN_EFFECTIVE` and runs `pnpm verify:attendance-locale-zh`.
+
+## 142 DingTalk Directory Page Boundary
+
+Direct public HTTP access from this workstation to `142.171.239.56:8081` still returns `curl: (52) Empty reply from server` for both `/admin/directory` and `/api/admin/directory/integrations`.
+
+SSH from this workstation also failed with `Permission denied (publickey,password)`.
+
+This means page-level `/admin/directory` and authenticated directory API verification must be completed through one of these paths:
+
+- SSH tunnel from a machine with the correct 142 key.
+- Server-side curl on 142.
+- Existing GitHub deploy/smoke runner access if it exposes a redacted artifact.
+
+This is a verification-access boundary, not evidence of a DingTalk directory runtime regression. The previous DingTalk directory deployment evidence remains the source of truth until page-level tunnel verification is rerun.
+
+## Command Correction
+
+The originally requested `pnpm exec vitest run scripts/ops/attendance-auth-scripts.test.mjs --runInBand` is not valid for this repository snapshot:
+
+- Before dependency install, `pnpm exec vitest` failed because the clean worktree had no `node_modules`.
+- After `pnpm install --frozen-lockfile`, Vitest rejected `--runInBand`.
+- Without `--runInBand`, Vitest reported no suite because `attendance-auth-scripts.test.mjs` uses Node's built-in `node:test` runner.
+
+The supported command is therefore `node --test scripts/ops/attendance-auth-scripts.test.mjs scripts/ops/attendance-locale-zh-workflow-contract.test.mjs`, which passed with 6 tests.
+
+## Pending Live Acceptance
+
+After this branch is merged:
+
+- Rerun `Attendance Locale zh Smoke (Prod)` on `main`.
+- If it fails, inspect `auth-error.txt` first.
+- If `auth-error.txt` reports missing login fields and invalid token, rotate or configure `ATTENDANCE_ADMIN_JWT` or `ATTENDANCE_ADMIN_EMAIL` plus `ATTENDANCE_ADMIN_PASSWORD` in GitHub Secrets or Variables.
+- Run `/admin/directory` page verification through SSH tunnel or server-side curl and append the redacted result to the DingTalk directory verification record.
+
+## Conclusion
+
+The workflow implementation is ready for PR review. Full operational closure still needs one live post-merge workflow rerun and one `/admin/directory` page/API check from an environment with working 142 access.

--- a/scripts/ops/attendance-locale-zh-workflow-contract.test.mjs
+++ b/scripts/ops/attendance-locale-zh-workflow-contract.test.mjs
@@ -1,0 +1,49 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+const repoRoot = process.cwd()
+const workflowPath = path.join(repoRoot, '.github/workflows/attendance-locale-zh-smoke-prod.yml')
+
+test('attendance locale zh smoke workflow resolves auth before real smoke', () => {
+  const raw = readFileSync(workflowPath, 'utf8')
+
+  assert.match(
+    raw,
+    /AUTH_TOKEN:\s+\$\{\{\s*secrets\.ATTENDANCE_ADMIN_JWT\s+\|\|\s+vars\.ATTENDANCE_ADMIN_JWT\s+\|\|\s+''\s*\}\}/,
+  )
+  assert.match(
+    raw,
+    /LOGIN_EMAIL:\s+\$\{\{\s*secrets\.ATTENDANCE_ADMIN_EMAIL\s+\|\|\s+vars\.ATTENDANCE_ADMIN_EMAIL\s+\|\|\s+''\s*\}\}/,
+  )
+  assert.match(
+    raw,
+    /LOGIN_PASSWORD:\s+\$\{\{\s*secrets\.ATTENDANCE_ADMIN_PASSWORD\s+\|\|\s+vars\.ATTENDANCE_ADMIN_PASSWORD\s+\|\|\s+''\s*\}\}/,
+  )
+  assert.match(raw, /AUTH_RESOLVE_ALLOW_INSECURE_HTTP:/)
+  assert.match(raw, /- name: Resolve valid auth token/)
+  assert.match(raw, /\.\/scripts\/ops\/attendance-resolve-auth\.sh/)
+  assert.match(raw, /\.\/scripts\/ops\/attendance-write-auth-error\.sh/)
+  assert.match(raw, /AUTH_TOKEN_EFFECTIVE=\$\{resolved_token\}/)
+  assert.match(raw, /AUTH_TOKEN:\s+\$\{\{\s+env\.AUTH_TOKEN_EFFECTIVE\s+\}\}/)
+  assert.match(raw, /output\/playwright\/attendance-locale-zh-smoke\/auth-error\.txt/)
+})
+
+test('attendance locale zh smoke workflow keeps drill before resolver and real smoke', () => {
+  const raw = readFileSync(workflowPath, 'utf8')
+  const drillIndex = raw.indexOf('- name: Drill failure injection')
+  const installIndex = raw.indexOf('- name: Install dependencies')
+  const resolverIndex = raw.indexOf('- name: Resolve valid auth token')
+  const smokeIndex = raw.indexOf('- name: Run zh locale smoke')
+
+  assert.notEqual(drillIndex, -1)
+  assert.notEqual(installIndex, -1)
+  assert.notEqual(resolverIndex, -1)
+  assert.notEqual(smokeIndex, -1)
+  assert.ok(drillIndex < installIndex)
+  assert.ok(installIndex < resolverIndex)
+  assert.ok(resolverIndex < smokeIndex)
+  assert.match(raw, /if:\s+\$\{\{\s+env\.DRILL_FAIL != 'true'\s+\}\}\n\s+id: resolve-auth-token/)
+  assert.match(raw, /if:\s+\$\{\{\s+env\.DRILL_FAIL != 'true'\s+\}\}\n\s+env:\n\s+AUTH_TOKEN:/)
+})


### PR DESCRIPTION
## Summary
- route `Attendance Locale zh Smoke (Prod)` through the shared attendance auth resolver before the real smoke step
- add GitHub Secrets -> Variables fallback for attendance admin JWT/email/password inputs
- write redacted `auth-error.txt` diagnostics on resolver failure and keep drill mode before resolver/smoke
- add a small workflow contract test plus development/verification MD

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/attendance-locale-zh-smoke-prod.yml"); puts "yaml-parse-ok"'`
- `bash -n scripts/ops/attendance-resolve-auth.sh`
- `bash -n scripts/ops/attendance-write-auth-error.sh`
- `node --test scripts/ops/attendance-auth-scripts.test.mjs scripts/ops/attendance-locale-zh-workflow-contract.test.mjs`
- `git diff --check origin/main...HEAD -- .github/workflows/attendance-locale-zh-smoke-prod.yml scripts/ops/attendance-locale-zh-workflow-contract.test.mjs docs/development/attendance-locale-zh-smoke-auth-resolver-development-20260514.md docs/development/attendance-locale-zh-smoke-auth-resolver-verification-20260514.md`
- strict changed-file secret scan: `secret-scan-ok`

## Notes
- latest inspected prod failure `25839971449` failed because the configured token returned HTTP 401 and login fallback fields were missing
- live closure still requires rerunning `Attendance Locale zh Smoke (Prod)` after merge with valid GitHub Secrets/Variables
- direct local HTTP to 142 `:8081` still returns empty reply and local SSH lacks key; `/admin/directory` page-level verification must use a machine with SSH tunnel/server-side access
