### PR TITLE
fix(attendance): support host-routed live acceptance

### DIFF
--- a/docs/development/attendance-report-fields-live-host-header-development-20260514.md
+++ b/docs/development/attendance-report-fields-live-host-header-development-20260514.md
@@ -1,0 +1,45 @@
+# Attendance Report Fields Live Host Header Development
+
+日期：2026-05-14
+
+## 背景
+
+`#1530` 合入后，考勤统计字段 live acceptance harness 已经可以覆盖字段目录同步、记录查询、JSON/CSV 导出和字段证据链。但在 142 环境运行时发现一个部署层细节：
+
+- `http://142.171.239.56:8081/api/health` 使用默认 `Host: 142.171.239.56:8081` 会被反代直接断开，表现为 empty reply。
+- 同一地址使用 `Host: localhost` 或 `Host: metasheet.local` 可以正常返回 `/api/health`。
+
+原 harness 使用 Node `fetch()`，不能可靠覆盖 `Host` header，因此无法在这类按 Host 分流的 staging 入口上完成 live acceptance。
+
+## 改动
+
+- `scripts/ops/attendance-report-fields-live-acceptance.mjs`
+  - 新增 `API_HOST_HEADER` / `HOST_HEADER` 配置。
+  - 新增 host header 格式校验，只允许 `host` 或 `host:port`，拒绝带协议、路径或凭据的值。
+  - 将内部请求实现从 `fetch()` 切换为 `node:http` / `node:https`，保留原返回结构：`res.ok`、`res.status`、`res.headers.get()`、`json`、`text`。
+  - `requestJson()`、preflight、auth helper dev-token fallback 和完整 live 链路都复用同一 host header。
+  - Markdown 报告记录 `Host header`，便于复盘反代分流配置。
+- `scripts/ops/attendance-report-fields-live-acceptance.test.mjs`
+  - 新增非法 `API_HOST_HEADER=http://...` 配置拒绝用例。
+  - 新增 preflight host header 透传用例，mock server 断言收到 `Host: metasheet.local`。
+  - 保持既有 token-file、权限守卫、home 路径脱敏、CSV evidence 用例。
+
+## 设计边界
+
+- 不改变考勤业务 API。
+- 不改变字段目录同步、记录查询或导出契约。
+- 不把 token 或 Authorization header 写入报告。
+- `API_HOST_HEADER` 是可选项；默认行为仍按 URL host 发送。
+- 不自动修改 `/etc/hosts`，不要求本机 DNS 配置。
+
+## 142 运行方式
+
+```bash
+AUTH_TOKEN_FILE=/tmp/metasheet-142-main-admin-72h.jwt \
+CONFIRM_SYNC=1 \
+API_BASE=http://142.171.239.56:8081 \
+API_HOST_HEADER=localhost \
+ORG_ID=default \
+OUTPUT_DIR=/tmp/metasheet-attendance-report-fields-live-142-20260514 \
+pnpm run verify:attendance-report-fields:live
+```

--- a/docs/development/attendance-report-fields-live-host-header-verification-20260514.md
+++ b/docs/development/attendance-report-fields-live-host-header-verification-20260514.md
@@ -1,0 +1,129 @@
+# Attendance Report Fields Live Host Header Verification
+
+日期：2026-05-14
+
+## 范围
+
+本轮验证覆盖：
+
+- `API_HOST_HEADER` 配置解析与非法值拒绝。
+- 低层 HTTP/HTTPS requester 的语法与 mock 测试。
+- 142 反代 Host 分流场景的 preflight。
+- 142 真实 live acceptance：字段目录同步、记录查询、JSON/CSV 导出、字段指纹、字段编码和 CSV backing。
+
+## 本地验证
+
+```bash
+node --check scripts/ops/attendance-report-fields-live-acceptance.mjs
+node --check scripts/ops/attendance-report-fields-live-acceptance.test.mjs
+pnpm run verify:attendance-report-fields:live:test
+```
+
+结果：
+
+- `node --check`：通过。
+- `pnpm run verify:attendance-report-fields:live:test`：`13/13` 通过。
+
+新增覆盖：
+
+- `validateConfig` 拒绝 `API_HOST_HEADER=http://localhost`。
+- `renderHelp()` 展示 `API_HOST_HEADER=localhost`。
+- preflight mock server 收到 `Host: metasheet.local`。
+- Markdown artifact 展示 `Host header: metasheet.local`。
+
+## 142 Preflight
+
+命令：
+
+```bash
+API_BASE=http://142.171.239.56:8081 \
+API_HOST_HEADER=localhost \
+OUTPUT_DIR=/tmp/metasheet-attendance-host-preflight \
+TIMEOUT_MS=8000 \
+pnpm run verify:attendance-report-fields:preflight
+```
+
+结果：PASS。
+
+关键 checks：
+
+```json
+[
+  ["config.required", true],
+  ["api.health", true, 200],
+  ["preflight.completed", true],
+  ["runner.completed", true]
+]
+```
+
+## 142 Live Acceptance
+
+命令：
+
+```bash
+AUTH_TOKEN_FILE=/tmp/metasheet-142-main-admin-72h.jwt \
+CONFIRM_SYNC=1 \
+API_BASE=http://142.171.239.56:8081 \
+API_HOST_HEADER=localhost \
+ORG_ID=default \
+OUTPUT_DIR=/tmp/metasheet-attendance-report-fields-live-142-20260514 \
+TIMEOUT_MS=15000 \
+pnpm run verify:attendance-report-fields:live
+```
+
+结果：PASS。
+
+Artifact：
+
+```text
+/tmp/metasheet-attendance-report-fields-live-142-20260514/report.json
+/tmp/metasheet-attendance-report-fields-live-142-20260514/report.md
+```
+
+关键结果：
+
+```json
+{
+  "ok": true,
+  "hostHeader": "localhost",
+  "projectId": "default:attendance",
+  "sheetId": "sheet_75b4c963aa445cf3f96d29fe",
+  "viewId": "view_d1d034d6227e8cfee00460c1",
+  "catalogFieldCount": 34,
+  "recordsFieldCount": 34,
+  "exportFieldCount": 34,
+  "csvFieldCount": 34
+}
+```
+
+通过的关键链路：
+
+- `api.health`
+- `api.auth.me`
+- `api.report-fields.read-before-sync`
+- `api.report-fields.sync`
+- `catalog.required-categories`
+- `api.records.read`
+- `api.export.json`
+- `api.export.csv`
+- `api.export.csv-code-header`
+- `records-export.report-field-codes-match`
+- `records-export.report-field-config-match`
+- `catalog-records.report-field-fingerprint-match`
+- `records-export.report-field-fingerprint-match`
+- `export.csv.report-field-codes-match`
+- `export.csv.report-field-backing-match`
+- `export.csv-code.report-field-codes-match`
+- `export.csv-code.report-field-backing-match`
+
+## 安全检查
+
+- 使用 `AUTH_TOKEN_FILE`，未在命令输出、MD 或 Git diff 中写入 token。
+- token 文件权限检查通过，脚本记录为 owner-only。
+- 报告只保留 token 来源、字段证据、状态码和低敏 metadata。
+
+## 未覆盖项
+
+- 本轮不执行浏览器 UI 点击验收。
+- 本轮不验证其它 orgId 或隐藏字段手动切换场景。
+- 本轮不部署 142；验证针对当前 142 运行中的服务。

--- a/scripts/ops/attendance-report-fields-live-acceptance.mjs
+++ b/scripts/ops/attendance-report-fields-live-acceptance.mjs
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 import fs from 'node:fs'
+import http from 'node:http'
+import https from 'node:https'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -20,6 +22,15 @@ export function parseBoolean(value) {
 export function normalizeBaseUrl(value) {
   const normalized = String(value || '').trim().replace(/\/+$/, '')
   return normalized || DEFAULT_API_BASE
+}
+
+export function normalizeHostHeader(value) {
+  return String(value || '').trim()
+}
+
+function isValidHostHeader(value) {
+  if (!value) return true
+  return /^[A-Za-z0-9.-]+(?::\d+)?$/.test(value)
 }
 
 function toDateOnly(date) {
@@ -43,6 +54,7 @@ export function parseConfig(env = process.env, now = new Date()) {
   const timeoutMs = Number(env.TIMEOUT_MS || DEFAULT_TIMEOUT_MS)
   return {
     apiBase: normalizeBaseUrl(env.API_BASE || env.BASE_URL),
+    hostHeader: normalizeHostHeader(env.API_HOST_HEADER || env.HOST_HEADER),
     authToken: String(env.AUTH_TOKEN || env.TOKEN || '').trim(),
     authTokenFile: String(env.AUTH_TOKEN_FILE || env.TOKEN_FILE || '').trim(),
     allowDevToken: parseBoolean(env.ALLOW_DEV_TOKEN),
@@ -69,6 +81,7 @@ export function validateConfig(config) {
   }
   if (!config.preflightOnly && !config.confirmSync) missing.push('CONFIRM_SYNC=1')
   if (!config.orgId) missing.push('ORG_ID')
+  if (!isValidHostHeader(config.hostHeader)) missing.push('API_HOST_HEADER host[:port]')
   if (!/^\d{4}-\d{2}-\d{2}$/.test(config.from)) missing.push('FROM_DATE yyyy-mm-dd')
   if (!/^\d{4}-\d{2}-\d{2}$/.test(config.to)) missing.push('TO_DATE yyyy-mm-dd')
   return missing
@@ -91,6 +104,7 @@ function createReport(config) {
     ok: true,
     runMode: config.preflightOnly ? 'preflight' : 'live',
     apiBase: config.apiBase,
+    hostHeader: config.hostHeader || 'default',
     orgId: config.orgId,
     userId: config.userId || 'token-user',
     from: config.from,
@@ -186,24 +200,76 @@ function resolveConfiguredAuthToken(config, record) {
   return { token, source: 'AUTH_TOKEN_FILE' }
 }
 
-async function fetchJson(url, options = {}, timeoutMs = DEFAULT_TIMEOUT_MS) {
-  const controller = new AbortController()
-  const timer = setTimeout(() => controller.abort(), timeoutMs)
-  try {
-    const res = await fetch(url, { ...options, signal: controller.signal })
-    const text = await res.text()
-    let json = null
-    if (text) {
-      try {
-        json = JSON.parse(text)
-      } catch {
-        json = { raw: text }
-      }
-    }
-    return { res, json, text }
-  } finally {
-    clearTimeout(timer)
+function responseHeaderAccessor(headers) {
+  return {
+    get(name) {
+      const value = headers[String(name || '').toLowerCase()]
+      if (Array.isArray(value)) return value.join(', ')
+      return value || ''
+    },
   }
+}
+
+async function fetchJson(url, options = {}, timeoutMs = DEFAULT_TIMEOUT_MS, hostHeader = '') {
+  const target = new URL(url)
+  const transport = target.protocol === 'https:' ? https : http
+  if (target.protocol !== 'http:' && target.protocol !== 'https:') {
+    throw new Error(`Unsupported protocol: ${target.protocol}`)
+  }
+
+  const body = options.body === undefined || options.body === null
+    ? null
+    : typeof options.body === 'string' || Buffer.isBuffer(options.body)
+      ? options.body
+      : String(options.body)
+  const headers = { ...(options.headers || {}) }
+  if (hostHeader) headers.Host = hostHeader
+  if (body !== null && !Object.keys(headers).some(key => key.toLowerCase() === 'content-length')) {
+    headers['Content-Length'] = Buffer.byteLength(body)
+  }
+
+  return new Promise((resolve, reject) => {
+    const req = transport.request({
+      protocol: target.protocol,
+      hostname: target.hostname,
+      port: target.port,
+      path: `${target.pathname}${target.search}`,
+      method: options.method || 'GET',
+      headers,
+    }, (res) => {
+      const chunks = []
+      res.setEncoding('utf8')
+      res.on('data', chunk => chunks.push(chunk))
+      res.on('end', () => {
+        const text = chunks.join('')
+        let json = null
+        if (text) {
+          try {
+            json = JSON.parse(text)
+          } catch {
+            json = { raw: text }
+          }
+        }
+        resolve({
+          res: {
+            ok: Number(res.statusCode) >= 200 && Number(res.statusCode) < 300,
+            status: res.statusCode ?? 0,
+            statusText: res.statusMessage || '',
+            headers: responseHeaderAccessor(res.headers),
+          },
+          json,
+          text,
+        })
+      })
+    })
+
+    req.setTimeout(timeoutMs, () => {
+      req.destroy(new Error(`Request timed out after ${timeoutMs}ms`))
+    })
+    req.on('error', reject)
+    if (body !== null) req.write(body)
+    req.end()
+  })
 }
 
 async function requestJson(config, token, route, options = {}) {
@@ -215,7 +281,7 @@ async function requestJson(config, token, route, options = {}) {
       ...(options.body ? { 'Content-Type': 'application/json' } : {}),
       ...(options.headers || {}),
     },
-  }, config.timeoutMs)
+  }, config.timeoutMs, config.hostHeader)
 }
 
 async function checkedRequest(config, token, route, checkName, label, record, options = {}) {
@@ -364,12 +430,21 @@ function csvReportFieldBacking(result) {
 function classifyBlocker(error, config) {
   const message = stringifyError(error)
   const lower = message.toLowerCase()
-  if (lower.includes('econnrefused') || lower.includes('enotfound') || lower.includes('eai_again') || lower.includes('fetch failed')) {
+  if (
+    lower.includes('econnrefused')
+    || lower.includes('enotfound')
+    || lower.includes('eai_again')
+    || lower.includes('fetch failed')
+    || lower.includes('socket hang up')
+    || lower.includes('other side closed')
+    || lower.includes('timed out')
+  ) {
     return {
       code: 'BACKEND_UNREACHABLE',
       message,
       nextActions: [
         `确认 API_BASE 是否正确：${config.apiBase}`,
+        config.hostHeader ? `确认 API_HOST_HEADER 是否正确：${config.hostHeader}` : '如果反代按 Host 分流，设置 API_HOST_HEADER=<host>',
         '启动后端服务：pnpm --filter @metasheet/core-backend dev',
         '如果依赖本地 Postgres/Redis，先启动 Docker daemon 后执行 pnpm docker:dev',
       ],
@@ -444,6 +519,7 @@ export function renderHelp() {
     '',
     'Common options:',
     '  API_BASE=http://127.0.0.1:8900',
+    '  API_HOST_HEADER=localhost',
     '  ORG_ID=default',
     '  USER_ID=<optional-user-id>',
     '  FROM_DATE=2026-05-01',
@@ -538,6 +614,7 @@ export function renderAcceptanceMarkdown(report) {
     `- Overall: **${report?.ok === false ? 'FAIL' : 'PASS'}**`,
     `- Run mode: \`${report?.runMode || 'live'}\``,
     `- API base: \`${report?.apiBase || 'missing'}\``,
+    `- Host header: \`${report?.hostHeader || 'default'}\``,
     `- Org ID: \`${report?.orgId || 'missing'}\``,
     `- User scope: \`${report?.userId || 'token-user'}\``,
     `- Date range: \`${report?.from || 'missing'}..${report?.to || 'missing'}\``,
@@ -646,7 +723,7 @@ export async function runAttendanceReportFieldsAcceptance(config) {
       apiBase: config.apiBase,
       envToken: configuredAuth.token,
       tokenSource: configuredAuth.source === 'AUTH_TOKEN_FILE' ? 'AUTH_TOKEN_FILE' : 'AUTH_TOKEN',
-      fetchJson: (url) => fetchJson(url, {}, config.timeoutMs),
+      fetchJson: (url) => fetchJson(url, {}, config.timeoutMs, config.hostHeader),
       record,
       perms: 'attendance:admin,attendance:read,multitable:read,multitable:write',
       userId: config.devUserId,

--- a/scripts/ops/attendance-report-fields-live-acceptance.test.mjs
+++ b/scripts/ops/attendance-report-fields-live-acceptance.test.mjs
@@ -101,9 +101,11 @@ function catalogPayload() {
 
 async function startMockServer() {
   const calls = []
+  const hostHeaders = []
   const server = http.createServer((req, res) => {
     const url = new URL(req.url || '/', 'http://127.0.0.1')
     calls.push(`${req.method} ${url.pathname}`)
+    hostHeaders.push(req.headers.host || '')
 
     if (url.pathname === '/api/health') {
       send(res, 200, { ok: true, status: 'healthy' })
@@ -167,6 +169,7 @@ async function startMockServer() {
   return {
     baseUrl: `http://127.0.0.1:${address.port}`,
     calls,
+    hostHeaders,
     close: () => new Promise((resolve) => server.close(resolve)),
   }
 }
@@ -201,6 +204,18 @@ test('validateConfig accepts an auth token file for live mode', () => {
   })
   assert.equal(config.authTokenFile, '/tmp/metasheet-admin.jwt')
   assert.deepEqual(validateConfig(config), [])
+})
+
+test('validateConfig rejects invalid API host headers', () => {
+  const config = parseConfig({
+    API_BASE: 'https://staging.example.test/',
+    API_HOST_HEADER: 'http://localhost',
+    AUTH_TOKEN: 'jwt-from-env',
+    CONFIRM_SYNC: '1',
+    FROM_DATE: '2026-05-01',
+    TO_DATE: '2026-05-13',
+  })
+  assert.deepEqual(validateConfig(config), ['API_HOST_HEADER host[:port]'])
 })
 
 test('validateConfig allows preflight without auth or sync confirmation', () => {
@@ -282,6 +297,7 @@ test('renderHelp documents preflight and live-mode configuration', () => {
   const help = renderHelp()
   assert.match(help, /AUTH_TOKEN=<token>, AUTH_TOKEN_FILE=<path>, or ALLOW_DEV_TOKEN=1/)
   assert.match(help, /CONFIRM_SYNC=1/)
+  assert.match(help, /API_HOST_HEADER=localhost/)
   assert.match(help, /PREFLIGHT_ONLY=1/)
 })
 
@@ -303,6 +319,27 @@ test('preflight mode checks backend reachability without sync or auth', async ()
     assert.equal(server.calls.includes('GET /api/auth/me'), false)
     assert.ok(fs.existsSync(path.join(outputDir, 'report.json')))
     assert.ok(fs.existsSync(path.join(outputDir, 'report.md')))
+  } finally {
+    await server.close()
+  }
+})
+
+test('preflight mode applies the configured API host header', async () => {
+  const server = await startMockServer()
+  const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'attendance-report-fields-preflight-host-'))
+  try {
+    const report = await runAttendanceReportFieldsAcceptance(parseConfig({
+      API_BASE: server.baseUrl,
+      API_HOST_HEADER: 'metasheet.local',
+      PREFLIGHT_ONLY: '1',
+      OUTPUT_DIR: outputDir,
+    }))
+
+    assert.equal(report.ok, true)
+    assert.equal(report.hostHeader, 'metasheet.local')
+    assert.equal(server.hostHeaders[0], 'metasheet.local')
+    const markdown = fs.readFileSync(path.join(outputDir, 'report.md'), 'utf8')
+    assert.match(markdown, /Host header: `metasheet\.local`/)
   } finally {
     await server.close()
   }


### PR DESCRIPTION
## Summary
- add optional API_HOST_HEADER/HOST_HEADER support to the attendance report fields live acceptance harness
- replace the internal fetch path with node:http/node:https so Host can be set for host-routed reverse proxies
- keep token-file security/redaction behavior and document the 142 live acceptance result

## Verification
- node --check scripts/ops/attendance-report-fields-live-acceptance.mjs
- node --check scripts/ops/attendance-report-fields-live-acceptance.test.mjs
- pnpm run verify:attendance-report-fields:live:test (13/13)
- node --test scripts/multitable-auth.test.mjs (4/4)
- API_BASE=http://142.171.239.56:8081 API_HOST_HEADER=localhost pnpm run verify:attendance-report-fields:preflight (PASS)
- AUTH_TOKEN_FILE=/tmp/metasheet-142-main-admin-72h.jwt CONFIRM_SYNC=1 API_BASE=http://142.171.239.56:8081 API_HOST_HEADER=localhost ORG_ID=default pnpm run verify:attendance-report-fields:live (PASS)
- git diff --check

## Notes
- no token value is included in code, docs, or artifacts
- 142 direct IP Host currently returns socket hang up; API_HOST_HEADER=localhost is required for this route