### PR TITLE
fix(attendance): make live auth source explicit

### DIFF
--- a/docs/development/attendance-report-fields-live-auth-source-development-20260514.md
+++ b/docs/development/attendance-report-fields-live-auth-source-development-20260514.md
@@ -1,0 +1,85 @@
+# Attendance Report Fields Live Auth Source Development
+
+Date: 2026-05-14
+
+## Background
+
+The attendance report fields live harness already supports three credential inputs:
+
+- `AUTH_TOKEN` / `TOKEN`
+- `AUTH_TOKEN_FILE` / `TOKEN_FILE`
+- `ALLOW_DEV_TOKEN=1`
+
+The default priority is useful for simple local runs, but it is ambiguous in long-running staging sessions where an old environment token and a fresh local token file may both be present. The previous failure mode could reach the network first and only then reveal that the intended credential source was not the one being exercised.
+
+This slice makes the auth source explicit and moves token-file validation ahead of remote health checks in live mode.
+
+## Changes
+
+`scripts/ops/attendance-report-fields-live-acceptance.mjs`
+
+- Adds `AUTH_SOURCE` / `TOKEN_SOURCE`.
+- Accepts `AUTH_TOKEN`, `AUTH_TOKEN_FILE`, and `ALLOW_DEV_TOKEN`.
+- Normalizes aliases:
+  - `token` -> `AUTH_TOKEN`
+  - `token-file` / `TOKEN_FILE` -> `AUTH_TOKEN_FILE`
+  - `dev-token` / `DEV_TOKEN` -> `ALLOW_DEV_TOKEN`
+- Rejects unknown explicit sources during config validation.
+- Requires the matching credential when an explicit source is requested.
+- Records a `config.auth-source` check with:
+  - `selected`
+  - `present`
+  - `ignored`
+  - `requested`
+- Adds `Auth source` to the Markdown evidence summary.
+- Resolves the configured live auth input before `/api/health`, so unreadable or unsafe token files fail locally.
+- Preserves `API_HOST_HEADER` handling for 142 reverse-proxy access.
+
+`scripts/ops/attendance-report-fields-live-acceptance.test.mjs`
+
+- Covers explicit source normalization.
+- Covers unavailable and unknown explicit source validation.
+- Covers `AUTH_SOURCE=AUTH_TOKEN_FILE` taking precedence over a simultaneously present `AUTH_TOKEN`.
+- Covers preflight not reading token files.
+- Covers token-file failures stopping before `/api/health`.
+- Covers Markdown auth-source evidence without leaking token values.
+
+## Runtime Behavior
+
+Without `AUTH_SOURCE`, the harness keeps the existing priority:
+
+```text
+AUTH_TOKEN > AUTH_TOKEN_FILE > ALLOW_DEV_TOKEN
+```
+
+With `AUTH_SOURCE`, the selected source is mandatory. Examples:
+
+```bash
+AUTH_SOURCE=AUTH_TOKEN AUTH_TOKEN=... pnpm run verify:attendance-report-fields:live
+AUTH_SOURCE=AUTH_TOKEN_FILE AUTH_TOKEN_FILE=/tmp/metasheet-142-main-admin-72h.jwt pnpm run verify:attendance-report-fields:live
+AUTH_SOURCE=ALLOW_DEV_TOKEN ALLOW_DEV_TOKEN=1 pnpm run verify:attendance-report-fields:live
+```
+
+If `AUTH_SOURCE=AUTH_TOKEN_FILE` is set and `AUTH_TOKEN` is also present, the token file wins and the env token is reported as ignored. The token value itself is not written to JSON or Markdown artifacts.
+
+## 142 Use Case
+
+The 142 deployment requires the host override from the previous harness slice:
+
+```bash
+API_BASE=http://142.171.239.56:8081
+API_HOST_HEADER=localhost
+AUTH_SOURCE=AUTH_TOKEN_FILE
+AUTH_TOKEN_FILE=/tmp/metasheet-142-main-admin-72h.jwt
+CONFIRM_SYNC=1
+```
+
+This combination now produces deterministic evidence that the local file token was selected before remote requests are made.
+
+## Boundaries
+
+- No attendance business API behavior changed.
+- No token generation or token refresh behavior changed.
+- No changes to `scripts/multitable-auth.mjs`.
+- Preflight mode still avoids credential resolution and sync calls.
+- Token contents and bearer headers remain excluded from generated artifacts.

--- a/docs/development/attendance-report-fields-live-auth-source-verification-20260514.md
+++ b/docs/development/attendance-report-fields-live-auth-source-verification-20260514.md
@@ -1,0 +1,148 @@
+# Attendance Report Fields Live Auth Source Verification
+
+Date: 2026-05-14
+
+## Result
+
+Status: `PASS`
+
+The attendance report fields live harness now supports explicit auth-source selection and validates local token-file configuration before touching the network in live mode. The 142 live run passed with `AUTH_SOURCE=AUTH_TOKEN_FILE` plus `API_HOST_HEADER=localhost`.
+
+## Local Verification
+
+```bash
+node --check scripts/ops/attendance-report-fields-live-acceptance.mjs
+node --check scripts/ops/attendance-report-fields-live-acceptance.test.mjs
+pnpm run verify:attendance-report-fields:live:test
+node --test scripts/multitable-auth.test.mjs
+```
+
+Observed result:
+
+```text
+attendance-report-fields-live-acceptance.test.mjs: 17/17 pass
+scripts/multitable-auth.test.mjs: 4/4 pass
+```
+
+## 142 Live Verification
+
+Command shape:
+
+```bash
+AUTH_SOURCE=AUTH_TOKEN_FILE \
+AUTH_TOKEN_FILE=/tmp/metasheet-142-main-admin-72h.jwt \
+CONFIRM_SYNC=1 \
+API_BASE=http://142.171.239.56:8081 \
+API_HOST_HEADER=localhost \
+ORG_ID=default \
+OUTPUT_DIR=/tmp/metasheet-attendance-report-fields-auth-source-142-20260514 \
+TIMEOUT_MS=15000 \
+pnpm run verify:attendance-report-fields:live
+```
+
+Observed result:
+
+```json
+{
+  "ok": true,
+  "hostHeader": "localhost",
+  "authSource": "AUTH_TOKEN_FILE",
+  "projectId": "default:attendance",
+  "sheetId": "sheet_75b4c963aa445cf3f96d29fe",
+  "viewId": "view_d1d034d6227e8cfee00460c1",
+  "catalogFieldCount": 34,
+  "csvFieldCount": 34
+}
+```
+
+Selected checks:
+
+```text
+config.auth-source: selected=AUTH_TOKEN_FILE, present=AUTH_TOKEN_FILE, ignored=none, requested=AUTH_TOKEN_FILE
+api.health: 200
+api.auth.me: 200
+api.report-fields.sync: 200
+runner.completed: pass
+```
+
+Artifacts:
+
+```text
+/tmp/metasheet-attendance-report-fields-auth-source-142-20260514/report.json
+/tmp/metasheet-attendance-report-fields-auth-source-142-20260514/report.md
+```
+
+## Local Fail-Fast Verification
+
+Command shape:
+
+```bash
+AUTH_TOKEN_FILE=/tmp/metasheet-attendance-missing-admin.jwt \
+CONFIRM_SYNC=1 \
+API_BASE=http://142.171.239.56:8081 \
+API_HOST_HEADER=localhost \
+OUTPUT_DIR=/tmp/metasheet-attendance-report-fields-local-auth-precheck-20260514 \
+TIMEOUT_MS=3000 \
+pnpm run verify:attendance-report-fields:live
+```
+
+Observed result:
+
+```text
+exit=1
+blocker=AUTH_TOKEN_FILE_INVALID
+checks=config.required, config.auth-source, config.auth-token-file, runner.completed
+```
+
+No `api.health` check was recorded. This confirms the missing local token file is rejected before the harness calls the remote API.
+
+Artifacts:
+
+```text
+/tmp/metasheet-attendance-report-fields-local-auth-precheck-20260514/report.json
+/tmp/metasheet-attendance-report-fields-local-auth-precheck-20260514/report.md
+```
+
+## Final Gates
+
+```bash
+git diff --check
+python3 - <<'PY'
+import pathlib
+import re
+import sys
+
+files = [
+    'scripts/ops/attendance-report-fields-live-acceptance.mjs',
+    'scripts/ops/attendance-report-fields-live-acceptance.test.mjs',
+    'docs/development/attendance-report-fields-live-auth-source-development-20260514.md',
+    'docs/development/attendance-report-fields-live-auth-source-verification-20260514.md',
+]
+patterns = [
+    'eyJ' + r'[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}',
+    'Bearer' + r'\s+[A-Za-z0-9._-]{20,}',
+    'AUTH_TOKEN=' + 'eyJ',
+    'TOKEN=' + 'eyJ',
+    'gh' + r'[opsu]_[A-Za-z0-9_]{20,}',
+]
+regex = re.compile('|'.join(patterns))
+hits = []
+for name in files:
+    path = pathlib.Path(name)
+    for index, line in enumerate(path.read_text(errors='ignore').splitlines(), 1):
+        if regex.search(line):
+            hits.append(f'{name}:{index}')
+if hits:
+    print('\n'.join(hits))
+    sys.exit(1)
+print('secret-scan-ok')
+PY
+```
+
+Expected result: no diff whitespace errors and no secret matches.
+
+## Not Covered
+
+- This slice does not rotate or mint attendance admin credentials.
+- This slice does not change the production GitHub Actions attendance locale workflow.
+- This slice does not add browser UI coverage; it only hardens the live API acceptance harness.

--- a/scripts/ops/attendance-report-fields-live-acceptance.mjs
+++ b/scripts/ops/attendance-report-fields-live-acceptance.mjs
@@ -10,6 +10,7 @@ import { resolveMultitableAuthToken } from '../multitable-auth.mjs'
 const DEFAULT_API_BASE = 'http://127.0.0.1:8900'
 const DEFAULT_TIMEOUT_MS = 15_000
 const REQUIRED_CATEGORY_IDS = ['fixed', 'basic', 'attendance', 'anomaly', 'leave', 'overtime']
+const AUTH_SOURCE_CHOICES = Object.freeze(['AUTH_TOKEN', 'AUTH_TOKEN_FILE', 'ALLOW_DEV_TOKEN'])
 
 function timestampSlug(date = new Date()) {
   return date.toISOString().replace(/[:.]/g, '-')
@@ -31,6 +32,15 @@ export function normalizeHostHeader(value) {
 function isValidHostHeader(value) {
   if (!value) return true
   return /^[A-Za-z0-9.-]+(?::\d+)?$/.test(value)
+}
+
+function normalizeAuthSource(value) {
+  const normalized = String(value || '').trim().toUpperCase().replace(/[-\s]+/g, '_')
+  if (!normalized) return ''
+  if (normalized === 'TOKEN') return 'AUTH_TOKEN'
+  if (normalized === 'TOKEN_FILE') return 'AUTH_TOKEN_FILE'
+  if (normalized === 'DEV_TOKEN') return 'ALLOW_DEV_TOKEN'
+  return normalized
 }
 
 function toDateOnly(date) {
@@ -55,6 +65,7 @@ export function parseConfig(env = process.env, now = new Date()) {
   return {
     apiBase: normalizeBaseUrl(env.API_BASE || env.BASE_URL),
     hostHeader: normalizeHostHeader(env.API_HOST_HEADER || env.HOST_HEADER),
+    authSource: normalizeAuthSource(env.AUTH_SOURCE || env.TOKEN_SOURCE),
     authToken: String(env.AUTH_TOKEN || env.TOKEN || '').trim(),
     authTokenFile: String(env.AUTH_TOKEN_FILE || env.TOKEN_FILE || '').trim(),
     allowDevToken: parseBoolean(env.ALLOW_DEV_TOKEN),
@@ -76,8 +87,20 @@ export function parseConfig(env = process.env, now = new Date()) {
 
 export function validateConfig(config) {
   const missing = []
+  if (config.authSource && !AUTH_SOURCE_CHOICES.includes(config.authSource)) {
+    missing.push('AUTH_SOURCE one of AUTH_TOKEN, AUTH_TOKEN_FILE, ALLOW_DEV_TOKEN')
+  }
   if (!config.preflightOnly && !config.authToken && !config.authTokenFile && !config.allowDevToken) {
     missing.push('AUTH_TOKEN/AUTH_TOKEN_FILE or ALLOW_DEV_TOKEN=1')
+  }
+  if (!config.preflightOnly && config.authSource === 'AUTH_TOKEN' && !config.authToken) {
+    missing.push('AUTH_SOURCE=AUTH_TOKEN requires AUTH_TOKEN/TOKEN')
+  }
+  if (!config.preflightOnly && config.authSource === 'AUTH_TOKEN_FILE' && !config.authTokenFile) {
+    missing.push('AUTH_SOURCE=AUTH_TOKEN_FILE requires AUTH_TOKEN_FILE/TOKEN_FILE')
+  }
+  if (!config.preflightOnly && config.authSource === 'ALLOW_DEV_TOKEN' && !config.allowDevToken) {
+    missing.push('AUTH_SOURCE=ALLOW_DEV_TOKEN requires ALLOW_DEV_TOKEN=1')
   }
   if (!config.preflightOnly && !config.confirmSync) missing.push('CONFIRM_SYNC=1')
   if (!config.orgId) missing.push('ORG_ID')
@@ -145,15 +168,48 @@ function redactTokenFileReason(value, tokenFile) {
   return String(value || '').split(tokenFile).join(redactHomePath(tokenFile))
 }
 
+function configuredAuthSources(config) {
+  return [
+    config.authToken ? 'AUTH_TOKEN' : '',
+    config.authTokenFile ? 'AUTH_TOKEN_FILE' : '',
+    config.allowDevToken ? 'ALLOW_DEV_TOKEN' : '',
+  ].filter(Boolean)
+}
+
+function recordConfiguredAuthSource(record, selected, presentSources, requested = '') {
+  const ignored = presentSources.filter(source => source !== selected)
+  const details = {
+    selected,
+    present: presentSources.join(',') || 'none',
+    ignored: ignored.join(',') || 'none',
+  }
+  if (requested) details.requested = requested
+  record('config.auth-source', true, details)
+}
+
 function resolveConfiguredAuthToken(config, record) {
-  if (config.authToken) {
+  const presentSources = configuredAuthSources(config)
+  const selectedSource = config.authSource || (
+    config.authToken
+      ? 'AUTH_TOKEN'
+      : config.authTokenFile
+        ? 'AUTH_TOKEN_FILE'
+        : config.allowDevToken
+          ? 'ALLOW_DEV_TOKEN'
+          : 'none'
+  )
+
+  if (selectedSource === 'AUTH_TOKEN') {
+    recordConfiguredAuthSource(record, 'AUTH_TOKEN', presentSources, config.authSource)
     return { token: config.authToken, source: 'AUTH_TOKEN' }
   }
 
-  if (!config.authTokenFile) {
-    return { token: '', source: config.allowDevToken ? 'ALLOW_DEV_TOKEN' : 'none' }
+  if (selectedSource === 'ALLOW_DEV_TOKEN' || selectedSource === 'none') {
+    recordConfiguredAuthSource(record, selectedSource, presentSources, config.authSource)
+    return { token: '', source: selectedSource }
   }
 
+  recordConfiguredAuthSource(record, 'AUTH_TOKEN_FILE', presentSources, config.authSource)
   const tokenFile = path.resolve(config.authTokenFile)
   const tokenFileDisplay = redactHomePath(tokenFile)
   let stat = null
@@ -526,6 +582,7 @@ export function renderHelp() {
     '  TO_DATE=2026-05-13',
     '  EXPECT_VISIBLE_CODE=work_date',
     '  EXPECT_HIDDEN_CODE=<field_code>',
+    '  AUTH_SOURCE=AUTH_TOKEN|AUTH_TOKEN_FILE|ALLOW_DEV_TOKEN',
     '  OUTPUT_DIR=output/attendance-report-fields-live-acceptance/<run>',
     '',
     'Preflight only:',
@@ -549,6 +606,10 @@ const MARKDOWN_CHECK_DETAIL_KEYS = Object.freeze([
   'csvCodeBacking',
   'exportBacking',
   'fieldCount',
+  'selected',
+  'present',
+  'ignored',
+  'requested',
 ])
 
 function formatMarkdownInlineValue(value) {
@@ -571,6 +632,7 @@ function renderMarkdownCheckDetailLines(details) {
 }
 
 const EVIDENCE_SUMMARY_METADATA_KEYS = Object.freeze([
+  ['Auth source', 'authSource'],
   ['Catalog fingerprint', 'catalogFieldFingerprint'],
   ['Records fingerprint', 'recordsFieldFingerprint'],
   ['Export fingerprint', 'exportFieldFingerprint'],
@@ -708,6 +770,12 @@ export async function runAttendanceReportFieldsAcceptance(config) {
   record('config.required', true, { apiBase: config.apiBase, orgId: config.orgId })
 
   try {
+    let configuredAuth = { token: '', source: 'preflight' }
+    if (!config.preflightOnly) {
+      configuredAuth = resolveConfiguredAuthToken(config, record)
+      report.metadata.authSource = configuredAuth.source
+    }
+
     const healthData = await checkedRequest(config, '', '/api/health', 'api.health', 'GET /api/health', record)
     report.metadata.healthStatus = healthData?.status || healthData?.data?.status || 'ok'
 
@@ -717,8 +785,6 @@ export async function runAttendanceReportFieldsAcceptance(config) {
       return report
     }
 
-    const configuredAuth = resolveConfiguredAuthToken(config, record)
-    report.metadata.authSource = configuredAuth.source
     const token = await resolveMultitableAuthToken({
       apiBase: config.apiBase,
       envToken: configuredAuth.token,

--- a/scripts/ops/attendance-report-fields-live-acceptance.test.mjs
+++ b/scripts/ops/attendance-report-fields-live-acceptance.test.mjs
@@ -197,13 +197,43 @@ test('validateConfig requires explicit auth and sync confirmation', () => {
 test('validateConfig accepts an auth token file for live mode', () => {
   const config = parseConfig({
     API_BASE: 'https://staging.example.test/',
+    AUTH_SOURCE: 'token-file',
     AUTH_TOKEN_FILE: '/tmp/metasheet-admin.jwt',
     CONFIRM_SYNC: '1',
     FROM_DATE: '2026-05-01',
     TO_DATE: '2026-05-13',
   })
+  assert.equal(config.authSource, 'AUTH_TOKEN_FILE')
   assert.equal(config.authTokenFile, '/tmp/metasheet-admin.jwt')
   assert.deepEqual(validateConfig(config), [])
+})
+
+test('validateConfig rejects an unavailable requested auth source', () => {
+  const config = parseConfig({
+    API_BASE: 'https://staging.example.test/',
+    AUTH_SOURCE: 'AUTH_TOKEN_FILE',
+    AUTH_TOKEN: 'unit-test-env-token',
+    CONFIRM_SYNC: '1',
+    FROM_DATE: '2026-05-01',
+    TO_DATE: '2026-05-13',
+  })
+  assert.deepEqual(validateConfig(config), [
+    'AUTH_SOURCE=AUTH_TOKEN_FILE requires AUTH_TOKEN_FILE/TOKEN_FILE',
+  ])
+})
+
+test('validateConfig rejects an unknown requested auth source', () => {
+  const config = parseConfig({
+    API_BASE: 'https://staging.example.test/',
+    AUTH_SOURCE: 'cookie',
+    AUTH_TOKEN: 'unit-test-env-token',
+    CONFIRM_SYNC: '1',
+    FROM_DATE: '2026-05-01',
+    TO_DATE: '2026-05-13',
+  })
+  assert.deepEqual(validateConfig(config), [
+    'AUTH_SOURCE one of AUTH_TOKEN, AUTH_TOKEN_FILE, ALLOW_DEV_TOKEN',
+  ])
 })
 
 test('validateConfig rejects invalid API host headers', () => {
@@ -226,6 +256,55 @@ test('validateConfig allows preflight without auth or sync confirmation', () => 
     TO_DATE: '2026-05-13',
   })
   assert.deepEqual(validateConfig(config), [])
+})
+
+test('live mode honors AUTH_SOURCE=AUTH_TOKEN_FILE over AUTH_TOKEN', async () => {
+  const server = await startMockServer()
+  const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'attendance-report-fields-auth-source-forced-file-'))
+  const tokenFile = path.join(outputDir, 'admin.jwt')
+  fs.writeFileSync(tokenFile, 'unit-test-file-token\n', { mode: 0o600 })
+  try {
+    const report = await runAttendanceReportFieldsAcceptance(parseConfig({
+      API_BASE: server.baseUrl,
+      AUTH_SOURCE: 'AUTH_TOKEN_FILE',
+      AUTH_TOKEN: 'unit-test-env-token',
+      AUTH_TOKEN_FILE: tokenFile,
+      CONFIRM_SYNC: '1',
+      ORG_ID: 'default',
+      FROM_DATE: '2026-05-01',
+      TO_DATE: '2026-05-13',
+      OUTPUT_DIR: outputDir,
+    }))
+
+    assert.equal(report.ok, true)
+    assert.equal(report.metadata.authSource, 'AUTH_TOKEN_FILE')
+    assert.ok(report.checks.some((check) => (
+      check.name === 'config.auth-source'
+      && check.ok
+      && check.details.requested === 'AUTH_TOKEN_FILE'
+      && check.details.selected === 'AUTH_TOKEN_FILE'
+      && check.details.present === 'AUTH_TOKEN,AUTH_TOKEN_FILE'
+      && check.details.ignored === 'AUTH_TOKEN'
+    )))
+    assert.ok(report.checks.some((check) => (
+      check.name === 'config.auth-token-file'
+      && check.ok
+      && check.details.status === 'loaded'
+    )))
+    assert.ok(report.checks.some((check) => (
+      check.name === 'api.auth-token'
+      && check.ok
+      && check.details.source === 'AUTH_TOKEN_FILE'
+    )))
+    const markdown = fs.readFileSync(path.join(outputDir, 'report.md'), 'utf8')
+    assert.match(markdown, /Auth source: `AUTH_TOKEN_FILE`/)
+    assert.match(markdown, /requested: `AUTH_TOKEN_FILE`/)
+    assert.match(markdown, /ignored: `AUTH_TOKEN`/)
+    assert.doesNotMatch(markdown, /unit-test-env-token/)
+    assert.doesNotMatch(markdown, /unit-test-file-token/)
+  } finally {
+    await server.close()
+  }
 })
 
 test('renderAcceptanceMarkdown summarizes checks without leaking auth material', () => {
@@ -296,6 +375,7 @@ test('renderAcceptanceMarkdown summarizes checks without leaking auth material',
 test('renderHelp documents preflight and live-mode configuration', () => {
   const help = renderHelp()
   assert.match(help, /AUTH_TOKEN=<token>, AUTH_TOKEN_FILE=<path>, or ALLOW_DEV_TOKEN=1/)
+  assert.match(help, /AUTH_SOURCE=AUTH_TOKEN\|AUTH_TOKEN_FILE\|ALLOW_DEV_TOKEN/)
   assert.match(help, /CONFIRM_SYNC=1/)
   assert.match(help, /API_HOST_HEADER=localhost/)
   assert.match(help, /PREFLIGHT_ONLY=1/)
@@ -308,6 +388,7 @@ test('preflight mode checks backend reachability without sync or auth', async ()
     const report = await runAttendanceReportFieldsAcceptance(parseConfig({
       API_BASE: server.baseUrl,
       PREFLIGHT_ONLY: '1',
+      AUTH_TOKEN_FILE: path.join(outputDir, 'missing.jwt'),
       OUTPUT_DIR: outputDir,
     }))
 
@@ -315,6 +396,7 @@ test('preflight mode checks backend reachability without sync or auth', async ()
     assert.equal(report.runMode, 'preflight')
     assert.ok(report.checks.some((check) => check.name === 'api.health' && check.ok))
     assert.ok(report.checks.some((check) => check.name === 'preflight.completed' && check.ok))
+    assert.equal(report.checks.some((check) => check.name === 'config.auth-token-file'), false)
     assert.equal(server.calls.includes('POST /api/attendance/report-fields/sync'), false)
     assert.equal(server.calls.includes('GET /api/auth/me'), false)
     assert.ok(fs.existsSync(path.join(outputDir, 'report.json')))
@@ -373,8 +455,9 @@ test('live mode classifies an unreadable auth token file as a configuration bloc
 
     assert.equal(report.ok, false)
     assert.equal(report.blocker.code, 'AUTH_TOKEN_FILE_INVALID')
-    assert.ok(report.checks.some((check) => check.name === 'api.health' && check.ok))
+    assert.equal(report.checks.some((check) => check.name === 'api.health'), false)
     assert.ok(report.checks.some((check) => check.name === 'config.auth-token-file' && !check.ok))
+    assert.equal(server.calls.includes('GET /api/health'), false)
     assert.equal(server.calls.includes('POST /api/attendance/report-fields/sync'), false)
     assert.ok(fs.existsSync(path.join(outputDir, 'report.json')))
     assert.ok(fs.existsSync(path.join(outputDir, 'report.md')))
@@ -402,6 +485,8 @@ test('live mode redacts home directory auth token file paths in artifacts', asyn
     assert.match(report.blocker.message, /~\/\.tokens\/admin\.jwt/)
     const tokenFileCheck = report.checks.find((check) => check.name === 'config.auth-token-file')
     assert.equal(tokenFileCheck?.details?.tokenFile, '~/.tokens/admin.jwt')
+    assert.equal(report.checks.some((check) => check.name === 'api.health'), false)
+    assert.equal(server.calls.includes('GET /api/health'), false)
     assert.equal(server.calls.includes('POST /api/attendance/report-fields/sync'), false)
 
     const json = fs.readFileSync(path.join(outputDir, 'report.json'), 'utf8')
@@ -440,6 +525,8 @@ test('live mode blocks auth token files with group or other permissions', async 
       && !check.ok
       && check.details.mode === '0644'
     )))
+    assert.equal(report.checks.some((check) => check.name === 'api.health'), false)
+    assert.equal(server.calls.includes('GET /api/health'), false)
     assert.equal(server.calls.includes('POST /api/attendance/report-fields/sync'), false)
     const markdown = fs.readFileSync(path.join(outputDir, 'report.md'), 'utf8')
     assert.doesNotMatch(markdown, /unit-test-token/)
@@ -467,6 +554,13 @@ test('runAttendanceReportFieldsAcceptance verifies catalog, records, export, and
     assert.equal(report.ok, true)
     assert.equal(report.metadata.authSource, 'AUTH_TOKEN_FILE')
     assert.equal(report.metadata.projectId, 'default:attendance')
+    assert.ok(report.checks.some((check) => (
+      check.name === 'config.auth-source'
+      && check.ok
+      && check.details.selected === 'AUTH_TOKEN_FILE'
+      && check.details.present === 'AUTH_TOKEN_FILE'
+      && check.details.ignored === 'none'
+    )))
     assert.ok(report.checks.some((check) => (
       check.name === 'config.auth-token-file'
       && check.ok
@@ -524,7 +618,49 @@ test('runAttendanceReportFieldsAcceptance verifies catalog, records, export, and
     assert.ok(markdown.includes('- CSV field codes: `work_date,employee_name,late_minutes`'))
     assert.ok(markdown.includes('- CSV backing: `default:attendance|attendance_report_field_catalog|sheet_attendance_report_fields|fields_by_category`'))
     assert.ok(markdown.includes('- CSV code backing: `default:attendance|attendance_report_field_catalog|sheet_attendance_report_fields|fields_by_category`'))
+    assert.match(markdown, /Auth source: `AUTH_TOKEN_FILE`/)
     assert.doesNotMatch(markdown, /unit-test-token/)
+  } finally {
+    await server.close()
+  }
+})
+
+test('live mode records selected auth source when multiple auth sources are present', async () => {
+  const server = await startMockServer()
+  const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'attendance-report-fields-auth-source-'))
+  try {
+    const report = await runAttendanceReportFieldsAcceptance(parseConfig({
+      API_BASE: server.baseUrl,
+      AUTH_TOKEN: 'unit-test-env-token',
+      AUTH_TOKEN_FILE: path.join(outputDir, 'missing-and-ignored.jwt'),
+      ALLOW_DEV_TOKEN: '1',
+      CONFIRM_SYNC: '1',
+      ORG_ID: 'default',
+      FROM_DATE: '2026-05-01',
+      TO_DATE: '2026-05-13',
+      OUTPUT_DIR: outputDir,
+    }))
+
+    assert.equal(report.ok, true)
+    assert.equal(report.metadata.authSource, 'AUTH_TOKEN')
+    assert.ok(report.checks.some((check) => (
+      check.name === 'config.auth-source'
+      && check.ok
+      && check.details.selected === 'AUTH_TOKEN'
+      && check.details.present === 'AUTH_TOKEN,AUTH_TOKEN_FILE,ALLOW_DEV_TOKEN'
+      && check.details.ignored === 'AUTH_TOKEN_FILE,ALLOW_DEV_TOKEN'
+    )))
+    assert.equal(report.checks.some((check) => check.name === 'config.auth-token-file'), false)
+    assert.ok(report.checks.some((check) => (
+      check.name === 'api.auth-token'
+      && check.ok
+      && check.details.source === 'AUTH_TOKEN'
+    )))
+    const markdown = fs.readFileSync(path.join(outputDir, 'report.md'), 'utf8')
+    assert.match(markdown, /Auth source: `AUTH_TOKEN`/)
+    assert.match(markdown, /selected: `AUTH_TOKEN`/)
+    assert.match(markdown, /ignored: `AUTH_TOKEN_FILE,ALLOW_DEV_TOKEN`/)
+    assert.doesNotMatch(markdown, /unit-test-env-token/)
   } finally {
     await server.close()
   }


### PR DESCRIPTION
## Summary

- Add explicit `AUTH_SOURCE` / `TOKEN_SOURCE` selection to the attendance report fields live harness.
- Fail fast on local `AUTH_TOKEN_FILE` problems before calling `/api/health` in live mode.
- Record selected/present/ignored/requested auth source in JSON and Markdown artifacts.
- Preserve `API_HOST_HEADER` support for the 142 reverse-proxy path.

## Verification

- `node --check scripts/ops/attendance-report-fields-live-acceptance.mjs`
- `node --check scripts/ops/attendance-report-fields-live-acceptance.test.mjs`
- `pnpm run verify:attendance-report-fields:live:test` -> 17/17 pass
- `node --test scripts/multitable-auth.test.mjs` -> 4/4 pass
- 142 live acceptance with `AUTH_SOURCE=AUTH_TOKEN_FILE`, `API_HOST_HEADER=localhost` -> PASS, catalog/csv field count 34
- Missing local `AUTH_TOKEN_FILE` precheck -> FAIL as expected with `AUTH_TOKEN_FILE_INVALID` before `api.health`
- `git diff --check`
- redacted secret scan over changed script/test/docs -> `secret-scan-ok`

## Docs

- `docs/development/attendance-report-fields-live-auth-source-development-20260514.md`
- `docs/development/attendance-report-fields-live-auth-source-verification-20260514.md`
