### PR TITLE
fix(attendance): mint locale zh smoke token from deploy host

### DIFF
--- a/.github/workflows/attendance-locale-zh-smoke-prod.yml
+++ b/.github/workflows/attendance-locale-zh-smoke-prod.yml
@@ -64,6 +64,11 @@ jobs:
       LOGIN_EMAIL: ${{ secrets.ATTENDANCE_ADMIN_EMAIL || vars.ATTENDANCE_ADMIN_EMAIL || '' }}
       LOGIN_PASSWORD: ${{ secrets.ATTENDANCE_ADMIN_PASSWORD || vars.ATTENDANCE_ADMIN_PASSWORD || '' }}
       AUTH_RESOLVE_ALLOW_INSECURE_HTTP: ${{ vars.ATTENDANCE_ALLOW_INSECURE_HTTP || 'true' }}
+      DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+      DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+      DEPLOY_SSH_KEY_B64: ${{ secrets.DEPLOY_SSH_KEY_B64 }}
+      DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+      DEPLOY_COMPOSE_FILE: ${{ secrets.DEPLOY_COMPOSE_FILE }}
       HEADLESS: 'true'
       OUTPUT_DIR: output/playwright/attendance-locale-zh-smoke
       DRILL_FAIL: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.drill_fail == 'true' }}
@@ -114,8 +119,11 @@ jobs:
           set -euo pipefail
           mkdir -p output/playwright/attendance-locale-zh-smoke
           meta_file="output/playwright/attendance-locale-zh-smoke/auth-resolve-meta.txt"
+          fallback_log="output/playwright/attendance-locale-zh-smoke/deploy-host-auth-fallback.log"
 
-          if ! resolved_token="$(
+          resolved_token=""
+          set +e
+          resolved_token="$(
             API_BASE="${API_BASE}" \
             AUTH_TOKEN="${AUTH_TOKEN}" \
             LOGIN_EMAIL="${LOGIN_EMAIL}" \
@@ -123,7 +131,43 @@ jobs:
             AUTH_RESOLVE_ALLOW_INSECURE_HTTP="${AUTH_RESOLVE_ALLOW_INSECURE_HTTP}" \
             AUTH_RESOLVE_META_FILE="${meta_file}" \
             ./scripts/ops/attendance-resolve-auth.sh
-          )"; then
+          )"
+          resolve_rc=$?
+          set -e
+
+          if [[ "${resolve_rc}" != "0" ]]; then
+            echo "[attendance-locale-zh-smoke] configured auth failed; trying deploy-host token fallback" | tee "${fallback_log}"
+            set +e
+            fallback_token="$(
+              ATTENDANCE_TOKEN_RESOLVE_REQUIRED=false \
+              DEPLOY_HOST="${DEPLOY_HOST}" \
+              DEPLOY_USER="${DEPLOY_USER}" \
+              DEPLOY_SSH_KEY_B64="${DEPLOY_SSH_KEY_B64}" \
+              DEPLOY_PATH="${DEPLOY_PATH}" \
+              DEPLOY_COMPOSE_FILE="${DEPLOY_COMPOSE_FILE}" \
+              ./scripts/ops/resolve-attendance-smoke-token.sh 2> >(tee -a "${fallback_log}" >&2)
+            )"
+            fallback_rc=$?
+            set -e
+
+            if [[ "${fallback_rc}" == "0" && -n "${fallback_token}" ]]; then
+              echo "::add-mask::${fallback_token}"
+              set +e
+              resolved_token="$(
+                API_BASE="${API_BASE}" \
+                AUTH_TOKEN="${fallback_token}" \
+                LOGIN_EMAIL="" \
+                LOGIN_PASSWORD="" \
+                AUTH_RESOLVE_ALLOW_INSECURE_HTTP="${AUTH_RESOLVE_ALLOW_INSECURE_HTTP}" \
+                AUTH_RESOLVE_META_FILE="${meta_file}" \
+                ./scripts/ops/attendance-resolve-auth.sh
+              )"
+              resolve_rc=$?
+              set -e
+            fi
+          fi
+
+          if [[ "${resolve_rc}" != "0" || -z "${resolved_token}" ]]; then
             API_BASE="${API_BASE}" \
             ./scripts/ops/attendance-write-auth-error.sh \
               "${meta_file}" \

--- a/docs/development/attendance-locale-zh-deploy-token-fallback-development-20260514.md
+++ b/docs/development/attendance-locale-zh-deploy-token-fallback-development-20260514.md
@@ -1,0 +1,30 @@
+# Attendance Locale zh Deploy Token Fallback Development
+
+## Summary
+
+`Attendance Locale zh Smoke (Prod)` already rejects an expired `ATTENDANCE_ADMIN_JWT` before running the real smoke. The live run proved that the only configured token is stale and no email/password fallback exists. This change keeps that validation, then adds a deploy-host temporary token fallback using the same safety model as the K3 WISE postdeploy smoke.
+
+## Change
+
+- Added `scripts/ops/resolve-attendance-smoke-token.sh`.
+- The resolver uses `DEPLOY_HOST`, `DEPLOY_USER`, and `DEPLOY_SSH_KEY_B64` to SSH into the deploy host from GitHub Actions.
+- It executes inside the running backend container and signs a short-lived admin token with the backend runtime `authService.createToken()`.
+- The token is printed only to stdout for command substitution, masked by the workflow, and never persisted as a repository secret.
+- Updated `.github/workflows/attendance-locale-zh-smoke-prod.yml` so the auth flow is:
+  1. validate configured `ATTENDANCE_ADMIN_JWT`;
+  2. try refresh/login fallback when configured;
+  3. if still invalid, mint a deploy-host temporary token;
+  4. validate the minted token through `/api/auth/me`;
+  5. only then run `pnpm verify:attendance-locale-zh`.
+
+## Safety Notes
+
+- No database schema changes.
+- No business runtime API changes.
+- No secret values are written to docs, logs, or Git.
+- The temporary SSH key is created under `${TMPDIR:-/tmp}` with mode `0600` and removed on exit.
+- The fallback is read-only against application data; it selects one active admin user and signs a temporary smoke token.
+
+## Follow-Up
+
+If the deploy-host fallback passes live, the stale `ATTENDANCE_ADMIN_JWT` can remain as a non-blocking cleanup item or be rotated separately. The workflow no longer depends on a long-lived repo token for this smoke path.

--- a/docs/development/attendance-locale-zh-deploy-token-fallback-verification-20260514.md
+++ b/docs/development/attendance-locale-zh-deploy-token-fallback-verification-20260514.md
@@ -1,0 +1,37 @@
+# Attendance Locale zh Deploy Token Fallback Verification
+
+## Local Verification
+
+- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/attendance-locale-zh-smoke-prod.yml"); puts "yaml-parse-ok"'`
+- `bash -n scripts/ops/attendance-resolve-auth.sh`
+- `bash -n scripts/ops/attendance-write-auth-error.sh`
+- `bash -n scripts/ops/resolve-attendance-smoke-token.sh`
+- `node --test scripts/ops/attendance-auth-scripts.test.mjs scripts/ops/attendance-locale-zh-workflow-contract.test.mjs scripts/ops/resolve-attendance-smoke-token.test.mjs`
+- `git diff --check`
+- Changed-file secret scan for `access_token=`, `SEC...`, JWT-looking values, `Bearer ...`, and `ATTENDANCE_ADMIN_PASSWORD=`.
+
+## Live Evidence Before This Change
+
+- Workflow: `Attendance Locale zh Smoke (Prod)`
+- Run: `25843193505`
+- Head SHA: `c4e026efbcc741fa8764587dad33171dbd494c87`
+- Result: failed before real smoke at `Resolve valid auth token`.
+- Redacted diagnosis:
+  - `auth_me_last_http=401`
+  - `refresh_last_http=401`
+  - `login_last_http=unknown`
+  - `login_email_present=false`
+  - `login_password_present=false`
+- Repository secret inventory shows `ATTENDANCE_ADMIN_JWT` exists, while `ATTENDANCE_ADMIN_EMAIL` and `ATTENDANCE_ADMIN_PASSWORD` are not configured.
+
+## Expected Post-Merge Verification
+
+1. Merge this patch to `main`.
+2. Rerun `Attendance Locale zh Smoke (Prod)` manually on `main`.
+3. Confirm the resolver first rejects the stale configured token, then records deploy-host fallback in `deploy-host-auth-fallback.log`.
+4. Confirm `AUTH SOURCE` in the workflow summary is `token`, because the minted fallback token is revalidated through the existing resolver.
+5. Confirm `Run zh locale smoke` executes and produces `attendance-zh-locale-summary.json` plus `attendance-zh-locale-calendar.png`.
+
+## Current Conclusion
+
+Before live rerun, the prior state is `不可交付` for this scheduled smoke gate because the only long-lived attendance admin JWT is invalid and no login fallback exists. This patch should make the gate independent of that stale long-lived JWT while preserving redacted failure diagnostics.

--- a/scripts/ops/attendance-locale-zh-workflow-contract.test.mjs
+++ b/scripts/ops/attendance-locale-zh-workflow-contract.test.mjs
@@ -22,12 +22,17 @@ test('attendance locale zh smoke workflow resolves auth before real smoke', () =
     /LOGIN_PASSWORD:\s+\$\{\{\s*secrets\.ATTENDANCE_ADMIN_PASSWORD\s+\|\|\s+vars\.ATTENDANCE_ADMIN_PASSWORD\s+\|\|\s+''\s*\}\}/,
   )
   assert.match(raw, /AUTH_RESOLVE_ALLOW_INSECURE_HTTP:/)
+  assert.match(raw, /DEPLOY_HOST:\s+\$\{\{\s*secrets\.DEPLOY_HOST\s*\}\}/)
+  assert.match(raw, /DEPLOY_USER:\s+\$\{\{\s*secrets\.DEPLOY_USER\s*\}\}/)
+  assert.match(raw, /DEPLOY_SSH_KEY_B64:\s+\$\{\{\s*secrets\.DEPLOY_SSH_KEY_B64\s*\}\}/)
   assert.match(raw, /- name: Resolve valid auth token/)
   assert.match(raw, /\.\/scripts\/ops\/attendance-resolve-auth\.sh/)
+  assert.match(raw, /\.\/scripts\/ops\/resolve-attendance-smoke-token\.sh/)
   assert.match(raw, /\.\/scripts\/ops\/attendance-write-auth-error\.sh/)
   assert.match(raw, /AUTH_TOKEN_EFFECTIVE=\$\{resolved_token\}/)
   assert.match(raw, /AUTH_TOKEN:\s+\$\{\{\s+env\.AUTH_TOKEN_EFFECTIVE\s+\}\}/)
   assert.match(raw, /output\/playwright\/attendance-locale-zh-smoke\/auth-error\.txt/)
+  assert.match(raw, /deploy-host-auth-fallback\.log/)
 })
 
 test('attendance locale zh smoke workflow keeps drill before resolver and real smoke', () => {

--- a/scripts/ops/resolve-attendance-smoke-token.sh
+++ b/scripts/ops/resolve-attendance-smoke-token.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+required="${ATTENDANCE_TOKEN_RESOLVE_REQUIRED:-false}"
+token_expiry="${ATTENDANCE_SMOKE_TOKEN_EXPIRY:-2h}"
+deploy_path="${DEPLOY_PATH:-metasheet2}"
+deploy_compose_file="${DEPLOY_COMPOSE_FILE:-docker-compose.app.yml}"
+
+is_truthy() {
+  case "${1:-}" in
+    true|TRUE|True|1|yes|YES|Yes|on|ON|On)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+is_required() {
+  is_truthy "${required}"
+}
+
+warn_or_fail() {
+  local message="$1"
+  if is_required; then
+    echo "::error::${message}" >&2
+    exit 1
+  fi
+  echo "::warning::${message}" >&2
+  exit 0
+}
+
+is_compact_jwt() {
+  [[ "$1" =~ ^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$ ]]
+}
+
+shell_quote() {
+  printf '%q' "$1"
+}
+
+tmp_ssh_key=""
+
+cleanup_tmp_key() {
+  if [[ -n "${tmp_ssh_key}" && -f "${tmp_ssh_key}" ]]; then
+    rm -f "${tmp_ssh_key}"
+  fi
+}
+
+if [[ -z "${DEPLOY_HOST:-}" || -z "${DEPLOY_USER:-}" || -z "${DEPLOY_SSH_KEY_B64:-}" ]]; then
+  warn_or_fail "ATTENDANCE_ADMIN_JWT is invalid and DEPLOY_HOST/DEPLOY_USER/DEPLOY_SSH_KEY_B64 are incomplete for deploy-host token fallback"
+fi
+
+tmp_ssh_key="$(mktemp "${TMPDIR:-/tmp}/attendance-smoke-ssh-key.XXXXXX")"
+trap cleanup_tmp_key EXIT
+if ! printf '%s' "${DEPLOY_SSH_KEY_B64}" | base64 -d > "${tmp_ssh_key}"; then
+  warn_or_fail "failed to decode DEPLOY_SSH_KEY_B64 for Attendance smoke token fallback"
+fi
+chmod 600 "${tmp_ssh_key}"
+
+ssh_opts=(-o BatchMode=yes -o ConnectTimeout=15 -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i "${tmp_ssh_key}")
+quoted_deploy_path="$(shell_quote "${deploy_path}")"
+quoted_compose_file="$(shell_quote "${deploy_compose_file}")"
+quoted_token_expiry="$(shell_quote "${token_expiry}")"
+
+set +e
+token="$(
+  ssh "${ssh_opts[@]}" "${DEPLOY_USER}@${DEPLOY_HOST}" \
+    "DEPLOY_PATH=${quoted_deploy_path} DEPLOY_COMPOSE_FILE=${quoted_compose_file} ATTENDANCE_SMOKE_TOKEN_EXPIRY=${quoted_token_expiry} bash -s" <<'EOF'
+set -euo pipefail
+if [[ "${DEPLOY_PATH}" == /* ]]; then
+  DEPLOY_REPO_PATH="${DEPLOY_PATH}"
+elif [[ "${DEPLOY_PATH}" == ~/* ]]; then
+  DEPLOY_REPO_PATH="${HOME}/${DEPLOY_PATH#~/}"
+else
+  DEPLOY_REPO_PATH="${HOME}/${DEPLOY_PATH}"
+fi
+cd "${DEPLOY_REPO_PATH}"
+
+if docker compose version >/dev/null 2>&1; then
+  COMPOSE_CMD=(docker compose)
+elif command -v docker-compose >/dev/null 2>&1; then
+  COMPOSE_CMD=(docker-compose)
+else
+  echo "docker compose is not available" >&2
+  exit 125
+fi
+
+"${COMPOSE_CMD[@]}" -f "${DEPLOY_COMPOSE_FILE}" exec -T backend \
+  env JWT_EXPIRY="${ATTENDANCE_SMOKE_TOKEN_EXPIRY:-2h}" \
+  node --input-type=module - <<'NODE'
+import pg from 'pg'
+import { authService } from '/app/packages/core-backend/dist/src/auth/AuthService.js'
+
+const { Client } = pg
+const databaseUrl = process.env.DATABASE_URL
+if (!databaseUrl) {
+  console.error('DATABASE_URL missing from backend runtime env')
+  process.exit(3)
+}
+
+const client = new Client({
+  connectionString: databaseUrl,
+  ssl: process.env.DB_SSL === 'true' ? { rejectUnauthorized: false } : false,
+})
+
+try {
+  await client.connect()
+  const result = await client.query(`
+    SELECT
+      u.id,
+      u.email,
+      u.username,
+      u.name,
+      u.mobile,
+      u.role,
+      u.permissions,
+      u.is_active,
+      u.must_change_password,
+      (ur.user_id IS NOT NULL) AS has_rbac_admin
+    FROM users u
+    LEFT JOIN user_roles ur ON ur.user_id = u.id AND ur.role_id = 'admin'
+    WHERE COALESCE(u.is_active, true) = true
+      AND COALESCE(u.must_change_password, false) = false
+      AND (u.role = 'admin' OR ur.user_id IS NOT NULL)
+    ORDER BY
+      CASE WHEN ur.user_id IS NOT NULL THEN 0 ELSE 1 END,
+      CASE WHEN u.id = 'admin' THEN 0 ELSE 1 END,
+      u.created_at ASC
+    LIMIT 1
+  `)
+  const row = result.rows[0]
+  if (!row) {
+    console.error('No active admin user found for Attendance smoke token')
+    process.exit(4)
+  }
+
+  const token = authService.createToken({
+    id: String(row.id),
+    email: typeof row.email === 'string' ? row.email : '',
+    username: row.username ?? null,
+    name: typeof row.name === 'string' && row.name.trim() ? row.name : 'Attendance Smoke Admin',
+    mobile: row.mobile ?? null,
+    role: row.has_rbac_admin ? 'admin' : (typeof row.role === 'string' && row.role.trim() ? row.role : 'admin'),
+    permissions: Array.isArray(row.permissions) ? row.permissions : [],
+    is_active: row.is_active,
+    must_change_password: row.must_change_password,
+    created_at: new Date(),
+    updated_at: new Date(),
+  })
+  console.log(token)
+} finally {
+  await client.end().catch(() => {})
+}
+NODE
+EOF
+)"
+rc=$?
+set -e
+token="$(printf '%s\n' "${token}" | awk '/^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/ { found = $0 } END { if (found) print found }')"
+
+if [[ "${rc}" != "0" || -z "${token}" ]]; then
+  warn_or_fail "failed to mint temporary Attendance smoke token from deploy host"
+fi
+
+if ! is_compact_jwt "${token}"; then
+  warn_or_fail "deploy-host Attendance smoke token was not a compact JWT"
+fi
+
+echo "[resolve-attendance-smoke-token] token minted from deploy-host backend runtime" >&2
+printf '%s' "${token}"

--- a/scripts/ops/resolve-attendance-smoke-token.test.mjs
+++ b/scripts/ops/resolve-attendance-smoke-token.test.mjs
@@ -1,0 +1,141 @@
+import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const scriptPath = path.join(repoRoot, 'scripts', 'ops', 'resolve-attendance-smoke-token.sh')
+
+function makeTmpDir() {
+  return mkdtempSync(path.join(tmpdir(), 'resolve-attendance-smoke-token-'))
+}
+
+function runResolver(env = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn('bash', [scriptPath], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: {
+        PATH: process.env.PATH || '',
+        HOME: process.env.HOME || '',
+        ...env,
+      },
+    })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.setEncoding('utf8')
+    child.stderr.setEncoding('utf8')
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk
+    })
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk
+    })
+    child.on('error', reject)
+    child.on('close', (status) => {
+      resolve({ status, stdout, stderr })
+    })
+  })
+}
+
+test('attendance token resolver exits zero without deploy inputs when fallback is optional', async () => {
+  const result = await runResolver()
+
+  assert.equal(result.status, 0)
+  assert.equal(result.stdout, '')
+  assert.match(result.stderr, /DEPLOY_HOST\/DEPLOY_USER\/DEPLOY_SSH_KEY_B64 are incomplete/)
+})
+
+test('attendance token resolver fails without deploy inputs when fallback is required', async () => {
+  const result = await runResolver({ ATTENDANCE_TOKEN_RESOLVE_REQUIRED: 'true' })
+
+  assert.equal(result.status, 1)
+  assert.equal(result.stdout, '')
+  assert.match(result.stderr, /::error::ATTENDANCE_ADMIN_JWT is invalid and DEPLOY_HOST\/DEPLOY_USER\/DEPLOY_SSH_KEY_B64 are incomplete/)
+})
+
+test('attendance token resolver mints token through deploy-host fallback', async () => {
+  const tmp = makeTmpDir()
+  const binDir = path.join(tmp, 'bin')
+  const sshArgsPath = path.join(tmp, 'ssh-args')
+  try {
+    mkdirSync(binDir)
+    const sshPath = path.join(binDir, 'ssh')
+    writeFileSync(sshPath, `#!/usr/bin/env bash
+printf '%s\\n' "$*" > "$FAKE_SSH_ARGS_PATH"
+cat >/dev/null
+printf 'header.payload.signature\\n'
+`)
+    chmodSync(sshPath, 0o755)
+
+    const result = await runResolver({
+      HOME: tmp,
+      PATH: `${binDir}:${process.env.PATH || ''}`,
+      FAKE_SSH_ARGS_PATH: sshArgsPath,
+      DEPLOY_HOST: 'deploy.example.test',
+      DEPLOY_USER: 'deployer',
+      DEPLOY_SSH_KEY_B64: Buffer.from('fake-key').toString('base64'),
+    })
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.equal(result.stdout, 'header.payload.signature')
+    assert.match(result.stderr, /token minted from deploy-host backend runtime/)
+    assert.doesNotMatch(result.stderr, /header\.payload\.signature/)
+    assert.doesNotMatch(readFileSync(sshArgsPath, 'utf8'), /\.ssh\/deploy_key/)
+  } finally {
+    rmSync(tmp, { recursive: true, force: true })
+  }
+})
+
+test('attendance token resolver cleans up temporary deploy SSH key after fallback execution', async () => {
+  const tmp = makeTmpDir()
+  const binDir = path.join(tmp, 'bin')
+  const sshKeyPathFile = path.join(tmp, 'ssh-key-path')
+  try {
+    mkdirSync(binDir)
+    const sshPath = path.join(binDir, 'ssh')
+    writeFileSync(sshPath, `#!/usr/bin/env bash
+while [[ "$#" -gt 0 ]]; do
+  if [[ "$1" == "-i" ]]; then
+    shift
+    printf '%s\\n' "$1" > "$FAKE_SSH_KEY_PATH"
+    if [[ ! -f "$1" ]]; then
+      echo "missing ssh key" >&2
+      exit 9
+    fi
+    mode="$(stat -f %Lp "$1" 2>/dev/null || stat -c %a "$1")"
+    if [[ "$mode" != "600" ]]; then
+      echo "bad ssh key mode: $mode" >&2
+      exit 10
+    fi
+  fi
+  shift
+done
+cat >/dev/null
+printf 'header.payload.signature\\n'
+`)
+    chmodSync(sshPath, 0o755)
+
+    const result = await runResolver({
+      HOME: tmp,
+      TMPDIR: tmp,
+      PATH: `${binDir}:${process.env.PATH || ''}`,
+      FAKE_SSH_KEY_PATH: sshKeyPathFile,
+      DEPLOY_HOST: 'deploy.example.test',
+      DEPLOY_USER: 'deployer',
+      DEPLOY_SSH_KEY_B64: Buffer.from('fake-key').toString('base64'),
+    })
+
+    assert.equal(result.status, 0, result.stderr)
+    const usedKeyPath = readFileSync(sshKeyPathFile, 'utf8').trim()
+    assert.match(
+      usedKeyPath,
+      new RegExp(`^${tmp.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}/attendance-smoke-ssh-key\\.`),
+    )
+    assert.equal(existsSync(usedKeyPath), false)
+  } finally {
+    rmSync(tmp, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary
- add an Attendance locale zh deploy-host token fallback modeled after the existing K3 WISE postdeploy smoke resolver
- keep the configured ATTENDANCE_ADMIN_JWT / refresh / login resolver first, then mint a short-lived backend-runtime token only when configured auth fails
- add workflow contract coverage, resolver tests, and development/verification MD

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/attendance-locale-zh-smoke-prod.yml"); puts "yaml-parse-ok"'`
- `bash -n scripts/ops/attendance-resolve-auth.sh`
- `bash -n scripts/ops/attendance-write-auth-error.sh`
- `bash -n scripts/ops/resolve-attendance-smoke-token.sh`
- `node --test scripts/ops/attendance-auth-scripts.test.mjs scripts/ops/attendance-locale-zh-workflow-contract.test.mjs scripts/ops/resolve-attendance-smoke-token.test.mjs`
- `git diff --check`
- changed-file secret scan: pass

## Live context
Run `25843193505` failed before the real zh smoke because the existing `ATTENDANCE_ADMIN_JWT` returned 401 and no email/password fallback is configured. This patch keeps that failure evidence and adds a deploy-host temporary token path so the smoke can proceed without persisting a new long-lived repo secret.
