### PR TITLE
docs(attendance): record locale zh deploy-token live pass

### DIFF
--- a/docs/development/attendance-locale-zh-deploy-token-fallback-verification-20260514.md
+++ b/docs/development/attendance-locale-zh-deploy-token-fallback-verification-20260514.md
@@ -8,7 +8,7 @@
 - `bash -n scripts/ops/resolve-attendance-smoke-token.sh`
 - `node --test scripts/ops/attendance-auth-scripts.test.mjs scripts/ops/attendance-locale-zh-workflow-contract.test.mjs scripts/ops/resolve-attendance-smoke-token.test.mjs`
 - `git diff --check`
-- Changed-file secret scan for `access_token=`, `SEC...`, JWT-looking values, `Bearer ...`, and `ATTENDANCE_ADMIN_PASSWORD=`.
+- Changed-file secret scan for webhook tokens, DingTalk signing secrets, JWT-looking values, bearer tokens, and attendance password assignments.
 
 ## Live Evidence Before This Change
 
@@ -24,14 +24,27 @@
   - `login_password_present=false`
 - Repository secret inventory shows `ATTENDANCE_ADMIN_JWT` exists, while `ATTENDANCE_ADMIN_EMAIL` and `ATTENDANCE_ADMIN_PASSWORD` are not configured.
 
-## Expected Post-Merge Verification
+## Post-Merge Live Verification
 
-1. Merge this patch to `main`.
-2. Rerun `Attendance Locale zh Smoke (Prod)` manually on `main`.
-3. Confirm the resolver first rejects the stale configured token, then records deploy-host fallback in `deploy-host-auth-fallback.log`.
-4. Confirm `AUTH SOURCE` in the workflow summary is `token`, because the minted fallback token is revalidated through the existing resolver.
-5. Confirm `Run zh locale smoke` executes and produces `attendance-zh-locale-summary.json` plus `attendance-zh-locale-calendar.png`.
+- PR: `#1535`
+- Merge SHA: `288a64353ec601fe63f2ecc29b340def3bac5f9a`
+- Build and deploy run: `25844315249`
+- Build and deploy result: `success`
+- Manual live smoke run: `25844468696`
+- Live smoke result: `success`
+- Smoke job result: `success`
+- Issue job result: `success`
+- `Resolve valid auth token`: `success`
+- `Run zh locale smoke`: `success`
+- Artifact: `attendance-locale-zh-smoke-prod-25844468696-1`
+
+Artifact checks:
+
+- `deploy-host-auth-fallback.log` confirms configured auth failed first, then deploy-host fallback minted a token from the backend runtime.
+- `auth-resolve-meta.txt` confirms `AUTH_SOURCE=token` and `AUTH_ME_LAST_HTTP=200` after the minted token was revalidated through the existing resolver.
+- `attendance-zh-locale-summary.json` confirms `status=pass`, `ok=true`, `authSource=token`, `locale=zh-CN`, `lunarLabelCount=35`, `holidayCheckEnabled=true`, and cleanup `holidayDeleted=true`.
+- `attendance-zh-locale-calendar.png` was produced.
 
 ## Current Conclusion
 
-Before live rerun, the prior state is `不可交付` for this scheduled smoke gate because the only long-lived attendance admin JWT is invalid and no login fallback exists. This patch should make the gate independent of that stale long-lived JWT while preserving redacted failure diagnostics.
+This scheduled smoke gate is now `可交付` for the tested path. The long-lived `ATTENDANCE_ADMIN_JWT` is still stale, but the workflow no longer depends on it: when configured auth fails, it mints and validates a short-lived token from the deployed backend runtime, then runs the real zh locale smoke successfully.


### PR DESCRIPTION
## Summary
- update the Attendance locale zh deploy-token fallback verification doc with post-merge live evidence
- record successful run `25844468696` on merge SHA `288a64353ec601fe63f2ecc29b340def3bac5f9a`
- record artifact-level checks for fallback log, auth metadata, summary JSON, and screenshot output

## Verification
- `git diff --check`
- changed-file secret scan: pass
