### PR TITLE
test(onprem): guard superseded migration bridge in package verify

### DIFF
--- a/docs/development/onprem-migration-gap-guard-development-20260514.md
+++ b/docs/development/onprem-migration-gap-guard-development-20260514.md
@@ -1,0 +1,75 @@
+# On-Prem Migration Gap Guard Development - 2026-05-14
+
+## Summary
+
+This slice adds a regression guard for the Windows/on-prem upgrade failure
+reported from the K3 WISE deployment path.
+
+The failed deployment was not a K3 adapter issue. It was a migration bridge
+gap: packages built from the newer codebase still carried legacy numeric SQL
+migrations, while the target database had already followed the timestamp-based
+schema path. Replaying legacy migrations such as
+`037_add_gallery_form_support` and `038_config_and_secrets` against that
+database can fail on missing historical columns like `form_id` or `category`.
+
+Current runtime behavior already no-ops superseded legacy SQL migrations by
+default through `migration-provider.ts`. This work makes that contract harder
+to regress by testing the two issue-facing migrations directly and by making
+the on-prem package verifier assert the packaged provider still carries the
+skip-list entries.
+
+## Files Changed
+
+- `packages/core-backend/tests/unit/migration-provider.test.ts`
+  - Adds `038_config_and_secrets` to the superseded legacy SQL fixture.
+  - Asserts `037_add_gallery_form_support` and `038_config_and_secrets`
+    resolve as no-op markers by default.
+  - Keeps the explicit audit opt-in path intact, so
+    `includeSupersededLegacySqlMigrations: true` can still expose real SQL
+    migrations for compatibility inspection.
+- `scripts/ops/multitable-onprem-package-verify.sh`
+  - Extends `verify_migration_bridge_contract()` to require
+    `037_add_gallery_form_support` and `038_config_and_secrets` in the
+    packaged migration provider skip list.
+  - Verifies this development and verification note are present in the
+    packaged zip.
+- `scripts/ops/multitable-onprem-package-build.sh`
+  - Includes this development and verification note in the Windows/on-prem
+    release package.
+- `docs/development/onprem-migration-gap-guard-verification-20260514.md`
+  - Records the focused validation and deployment impact.
+
+## Runtime Contract
+
+Normal on-prem upgrades must not set:
+
+```bash
+MIGRATION_INCLUDE_SUPERSEDED_LEGACY_SQL=true
+```
+
+With the default setting, superseded legacy SQL migrations stay visible to the
+Kysely migration provider as marker names, but their `up()` functions do
+nothing. That lets existing migration history remain understandable without
+replaying legacy SQL against a newer schema.
+
+The opt-in flag remains reserved for explicit compatibility audits. It is not a
+normal deployment switch and should not be used to repair production upgrade
+failures.
+
+## Deployment Impact
+
+- No database migration.
+- No backend API change.
+- No frontend change.
+- No K3 WebAPI, SQL Server, Submit, or Audit behavior change.
+- Package verification now fails earlier if the migration bridge guard is
+  accidentally removed from the packaged backend.
+
+## Issue Linkage
+
+This guard addresses the class of deployment failures where a Windows/on-prem
+package tries to replay legacy numeric SQL migrations against a database that
+already contains the equivalent timestamp migration path. The specific cases
+covered here are the `037` gallery/form migration and the `038`
+config/secrets migration, matching the observed schema-gap pattern from issue
+`#651`.

--- a/docs/development/onprem-migration-gap-guard-verification-20260514.md
+++ b/docs/development/onprem-migration-gap-guard-verification-20260514.md
@@ -1,0 +1,105 @@
+# On-Prem Migration Gap Guard Verification - 2026-05-14
+
+## Scope
+
+This verification covers the regression guard for superseded legacy SQL
+migrations in Windows/on-prem packages.
+
+The guard is intentionally narrow:
+
+- prove `037_add_gallery_form_support` is a no-op marker by default
+- prove `038_config_and_secrets` is a no-op marker by default
+- prove the explicit audit opt-in can still expose both real SQL migration
+  names
+- prove the package verifier checks for these migration bridge entries
+
+## Local Verification
+
+### Migration provider unit tests
+
+Command:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/migration-provider.test.ts tests/unit/gallery-form-sql-migration.test.ts tests/unit/users-must-change-password-migration.test.ts --watch=false
+```
+
+Result:
+
+- 3 files passed.
+- 12 tests passed.
+
+Expected coverage:
+
+- superseded legacy SQL marker mode includes `037_add_gallery_form_support`
+  and `038_config_and_secrets`
+- marker-mode `up()` resolves without executing SQL
+- explicit audit mode still exposes the real SQL migration names
+- gallery/form SQL bridge tests remain green
+- users `must_change_password` bridge tests remain green
+
+### Script syntax checks
+
+Commands:
+
+```bash
+bash -n scripts/ops/multitable-onprem-package-build.sh
+bash -n scripts/ops/multitable-onprem-package-verify.sh
+```
+
+Result:
+
+- Passed with exit code 0.
+
+### Package contract
+
+Command:
+
+```bash
+scripts/ops/multitable-onprem-package-build.sh
+scripts/ops/multitable-onprem-package-verify.sh <generated-package.zip>
+```
+
+Result:
+
+- Package build passed with `BUILD_WEB=1` and `BUILD_BACKEND=1`.
+- Frontend build passed; Vite emitted the existing large-chunk warning.
+- Backend `tsc` build passed.
+- Package verifier passed against:
+  `output/releases/multitable-onprem/metasheet-multitable-onprem-v2.5.0-gap-guard-20260514.zip`.
+
+Expected package verifier coverage:
+
+- packaged `migration-provider.js` contains
+  `MIGRATION_INCLUDE_SUPERSEDED_LEGACY_SQL`
+- packaged `migration-provider.js` contains
+  `037_add_gallery_form_support`
+- packaged `migration-provider.js` contains `038_config_and_secrets`
+- packaged docs include this development and verification note
+
+### Diff hygiene
+
+Command:
+
+```bash
+git diff --check
+```
+
+Result:
+
+- Passed with exit code 0.
+
+## Deployment Impact
+
+- No live 142 deployment was touched.
+- No production database was touched.
+- No migration file was added.
+- No runtime API behavior was changed.
+- This is a tests/package-verifier hardening slice for the on-prem upgrade
+  path.
+
+## Operator Note
+
+For normal upgrades, leave `MIGRATION_INCLUDE_SUPERSEDED_LEGACY_SQL` unset.
+Setting it to `true` is only for compatibility audits and can intentionally
+re-expose legacy SQL migrations that are not safe to replay against every
+newer on-prem schema.

--- a/packages/core-backend/tests/unit/migration-provider.test.ts
+++ b/packages/core-backend/tests/unit/migration-provider.test.ts
@@ -107,6 +107,10 @@ describe('createCoreBackendMigrationProvider', () => {
       'alter table form_responses add column if not exists form_id uuid;'
     )
     await writeFile(
+      path.join(legacySqlDir, '038_config_and_secrets.sql'),
+      'create index if not exists idx_configs_category on system_configs(category);'
+    )
+    await writeFile(
       path.join(legacySqlDir, '055_create_attendance_import_tokens.sql'),
       'create table if not exists attendance_import_tokens (id text primary key);'
     )
@@ -125,6 +129,7 @@ describe('createCoreBackendMigrationProvider', () => {
     expect(Object.keys(migrations).sort()).toEqual([
       '032_create_approval_records',
       '037_add_gallery_form_support',
+      '038_config_and_secrets',
       '055_create_attendance_import_tokens',
       '056_add_users_must_change_password',
       '057_create_integration_core_tables',
@@ -132,6 +137,12 @@ describe('createCoreBackendMigrationProvider', () => {
     ])
     await expect(
       migrations['032_create_approval_records']?.up({} as never)
+    ).resolves.toBeUndefined()
+    await expect(
+      migrations['037_add_gallery_form_support']?.up({} as never)
+    ).resolves.toBeUndefined()
+    await expect(
+      migrations['038_config_and_secrets']?.up({} as never)
     ).resolves.toBeUndefined()
   })
 
@@ -143,6 +154,10 @@ describe('createCoreBackendMigrationProvider', () => {
     await writeFile(
       path.join(legacySqlDir, '037_add_gallery_form_support.sql'),
       'alter table form_responses add column if not exists form_id uuid;'
+    )
+    await writeFile(
+      path.join(legacySqlDir, '038_config_and_secrets.sql'),
+      'create index if not exists idx_configs_category on system_configs(category);'
     )
     await writeFile(
       path.join(legacySqlDir, '056_add_users_must_change_password.sql'),
@@ -157,6 +172,7 @@ describe('createCoreBackendMigrationProvider', () => {
 
     expect(Object.keys(migrations).sort()).toEqual([
       '037_add_gallery_form_support',
+      '038_config_and_secrets',
       '056_add_users_must_change_password',
     ])
   })

--- a/scripts/ops/multitable-onprem-package-build.sh
+++ b/scripts/ops/multitable-onprem-package-build.sh
@@ -77,6 +77,8 @@ REQUIRED_PATHS=(
   "docs/development/data-factory-cleansed-export-verification-20260514.md"
   "docs/development/data-factory-postdeploy-smoke-development-20260514.md"
   "docs/development/data-factory-postdeploy-smoke-verification-20260514.md"
+  "docs/development/onprem-migration-gap-guard-development-20260514.md"
+  "docs/development/onprem-migration-gap-guard-verification-20260514.md"
   "docker/app.env.example"
   "docker/app.env.multitable-onprem.template"
   "ops/nginx/multitable-onprem.conf.example"

--- a/scripts/ops/multitable-onprem-package-verify.sh
+++ b/scripts/ops/multitable-onprem-package-verify.sh
@@ -80,6 +80,8 @@ function verify_migration_bridge_contract() {
 
   search_fixed_string 'MIGRATION_INCLUDE_SUPERSEDED_LEGACY_SQL' "$provider" || die "migration-provider.js must expose the superseded legacy SQL opt-in"
   search_fixed_string '032_create_approval_records' "$provider" || die "migration-provider.js must carry the superseded legacy SQL skip list"
+  search_fixed_string '037_add_gallery_form_support' "$provider" || die "migration-provider.js must no-op superseded gallery/form SQL on upgraded on-prem DBs"
+  search_fixed_string '038_config_and_secrets' "$provider" || die "migration-provider.js must no-op superseded config/secrets SQL on upgraded on-prem DBs"
   search_fixed_string "to_regclass('public.users') IS NOT NULL" "$legacy_must_change" || die "056_add_users_must_change_password.sql must no-op when users table is absent"
   search_fixed_string 'must_change_password' "$timestamp_must_change" || die "timestamp users must_change_password bridge migration must be packaged"
 }
@@ -334,6 +336,8 @@ required=(
   "docs/development/data-factory-cleansed-export-verification-20260514.md"
   "docs/development/data-factory-postdeploy-smoke-development-20260514.md"
   "docs/development/data-factory-postdeploy-smoke-verification-20260514.md"
+  "docs/development/onprem-migration-gap-guard-development-20260514.md"
+  "docs/development/onprem-migration-gap-guard-verification-20260514.md"
   "docs/deployment/multitable-platform-rc-notes-20260404.md"
   "docs/deployment/multitable-windows-onprem-easy-start-20260319.md"
   "docs/deployment/multitable-onprem-package-layout-20260319.md"


### PR DESCRIPTION
## Summary
- add regression coverage that 037_add_gallery_form_support and 038_config_and_secrets remain no-op marker migrations by default
- extend the Windows/on-prem package verifier to assert the packaged migration provider keeps those skip-list entries
- package the paired development and verification notes so the #651 upgrade-gap lesson is carried with release artifacts

## Verification
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/migration-provider.test.ts tests/unit/gallery-form-sql-migration.test.ts tests/unit/users-must-change-password-migration.test.ts --watch=false
- bash -n scripts/ops/multitable-onprem-package-build.sh && bash -n scripts/ops/multitable-onprem-package-verify.sh && git diff --check
- PACKAGE_TAG=gap-guard-20260514 BUILD_WEB=1 BUILD_BACKEND=1 scripts/ops/multitable-onprem-package-build.sh
- scripts/ops/multitable-onprem-package-verify.sh output/releases/multitable-onprem/metasheet-multitable-onprem-v2.5.0-gap-guard-20260514.zip

## Deployment impact
- no runtime API change
- no frontend change
- no new migration
- no live 142 deployment touched
- normal on-prem upgrades should leave MIGRATION_INCLUDE_SUPERSEDED_LEGACY_SQL unset