### PR TITLE
fix(attendance): resolve longrun auth from deploy host

### DIFF
--- a/.github/workflows/attendance-import-perf-longrun.yml
+++ b/.github/workflows/attendance-import-perf-longrun.yml
@@ -241,6 +241,11 @@ jobs:
       LOGIN_EMAIL: ${{ secrets.ATTENDANCE_ADMIN_EMAIL || vars.ATTENDANCE_ADMIN_EMAIL || '' }}
       LOGIN_PASSWORD: ${{ secrets.ATTENDANCE_ADMIN_PASSWORD || vars.ATTENDANCE_ADMIN_PASSWORD || '' }}
       AUTH_RESOLVE_ALLOW_INSECURE_HTTP: ${{ vars.ATTENDANCE_ALLOW_INSECURE_HTTP || 'true' }}
+      DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+      DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+      DEPLOY_SSH_KEY_B64: ${{ secrets.DEPLOY_SSH_KEY_B64 }}
+      DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+      DEPLOY_COMPOSE_FILE: ${{ secrets.DEPLOY_COMPOSE_FILE }}
       COMMIT_ASYNC: 'true'
       UPLOAD_CSV: ${{ inputs.upload_csv || vars.ATTENDANCE_PERF_UPLOAD_CSV || 'true' }}
       PAYLOAD_SOURCE: ${{ inputs.payload_source || vars.ATTENDANCE_PERF_PAYLOAD_SOURCE || 'auto' }}
@@ -267,8 +272,11 @@ jobs:
           set -euo pipefail
           mkdir -p "output/playwright/attendance-import-perf-longrun/current/${{ matrix.id }}"
           meta_file="output/playwright/attendance-import-perf-longrun/current/${{ matrix.id }}/auth-resolve-meta.txt"
+          fallback_log="output/playwright/attendance-import-perf-longrun/current/${{ matrix.id }}/deploy-host-auth-fallback.log"
 
-          if ! resolved_token="$(
+          resolved_token=""
+          set +e
+          resolved_token="$(
             API_BASE="${API_BASE}" \
             AUTH_TOKEN="${AUTH_TOKEN}" \
             LOGIN_EMAIL="${LOGIN_EMAIL}" \
@@ -276,7 +284,43 @@ jobs:
             AUTH_RESOLVE_ALLOW_INSECURE_HTTP="${AUTH_RESOLVE_ALLOW_INSECURE_HTTP}" \
             AUTH_RESOLVE_META_FILE="${meta_file}" \
             ./scripts/ops/attendance-resolve-auth.sh
-          )"; then
+          )"
+          resolve_rc=$?
+          set -e
+
+          if [[ "${resolve_rc}" != "0" ]]; then
+            echo "[attendance-import-perf-longrun] configured auth failed; trying deploy-host token fallback" | tee "${fallback_log}"
+            set +e
+            fallback_token="$(
+              ATTENDANCE_TOKEN_RESOLVE_REQUIRED=false \
+              DEPLOY_HOST="${DEPLOY_HOST}" \
+              DEPLOY_USER="${DEPLOY_USER}" \
+              DEPLOY_SSH_KEY_B64="${DEPLOY_SSH_KEY_B64}" \
+              DEPLOY_PATH="${DEPLOY_PATH}" \
+              DEPLOY_COMPOSE_FILE="${DEPLOY_COMPOSE_FILE}" \
+              ./scripts/ops/resolve-attendance-smoke-token.sh 2> >(tee -a "${fallback_log}" >&2)
+            )"
+            fallback_rc=$?
+            set -e
+
+            if [[ "${fallback_rc}" == "0" && -n "${fallback_token}" ]]; then
+              echo "::add-mask::${fallback_token}"
+              set +e
+              resolved_token="$(
+                API_BASE="${API_BASE}" \
+                AUTH_TOKEN="${fallback_token}" \
+                LOGIN_EMAIL="" \
+                LOGIN_PASSWORD="" \
+                AUTH_RESOLVE_ALLOW_INSECURE_HTTP="${AUTH_RESOLVE_ALLOW_INSECURE_HTTP}" \
+                AUTH_RESOLVE_META_FILE="${meta_file}" \
+                ./scripts/ops/attendance-resolve-auth.sh
+              )"
+              resolve_rc=$?
+              set -e
+            fi
+          fi
+
+          if [[ "${resolve_rc}" != "0" || -z "${resolved_token}" ]]; then
             API_BASE="${API_BASE}" \
             ./scripts/ops/attendance-write-auth-error.sh \
               "${meta_file}" \
@@ -475,7 +519,17 @@ jobs:
       - name: Add trend markdown to summary
         if: always()
         run: |
-          cat "${{ steps.trend.outputs.report_markdown }}" >> "$GITHUB_STEP_SUMMARY"
+          set -euo pipefail
+          report_markdown="${{ steps.trend.outputs.report_markdown }}"
+          if [[ -n "${report_markdown}" && -f "${report_markdown}" ]]; then
+            cat "${report_markdown}" >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "## Attendance Import Perf Long Run"
+              echo ""
+              echo "Trend report markdown was not produced. Check scenario artifacts and auth diagnostics."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Upload trend artifacts
         if: always()

--- a/docs/development/attendance-import-perf-longrun-auth-fallback-development-20260514.md
+++ b/docs/development/attendance-import-perf-longrun-auth-fallback-development-20260514.md
@@ -1,0 +1,55 @@
+# Attendance Import Perf Long Run Auth Fallback Development 2026-05-14
+
+## Summary
+
+The scheduled `Attendance Import Perf Long Run` workflow failed on `main` at
+run `25845123113` before executing any perf scenario. Every matrix job stopped
+in `Resolve valid auth token` because the configured `ATTENDANCE_ADMIN_JWT`
+could not validate against `/api/auth/me`, and no login credentials were
+available for fallback.
+
+This change applies the same deploy-host token fallback used by the passing
+`Attendance Locale zh Smoke (Prod)` workflow. If the configured token,
+refresh-token, and login paths fail, the long-run workflow mints a short-lived
+Attendance admin token from the running backend container through the deploy
+host, masks it, validates it with `attendance-resolve-auth.sh`, and uses only
+the validated token for the scenario.
+
+## Changes
+
+- Added `DEPLOY_HOST`, `DEPLOY_USER`, `DEPLOY_SSH_KEY_B64`, `DEPLOY_PATH`, and
+  `DEPLOY_COMPOSE_FILE` to the long-run scenario job environment.
+- Added deploy-host fallback execution through
+  `scripts/ops/resolve-attendance-smoke-token.sh`.
+- Kept the original auth order intact:
+  `ATTENDANCE_ADMIN_JWT` -> refresh-token -> login -> deploy-host mint.
+- Wrote fallback diagnostics to each scenario artifact under
+  `deploy-host-auth-fallback.log`.
+- Kept token values masked and out of logs, docs, artifacts, and Git.
+- Hardened trend summary rendering so the workflow no longer runs `cat ""`
+  when trend generation fails before producing a markdown path.
+- Added a workflow contract test for the long-run auth fallback and trend
+  summary guard.
+
+## Scope
+
+In scope:
+
+- `.github/workflows/attendance-import-perf-longrun.yml`
+- `scripts/ops/attendance-import-perf-longrun-workflow-contract.test.mjs`
+- this development note and the companion verification note
+
+Out of scope:
+
+- Attendance runtime APIs
+- Database migrations
+- Perf scenario thresholds
+- DingTalk runtime behavior
+- The existing dirty root worktree changes for Attendance report fields/export
+  and DingTalk directory UI
+
+## Rollback
+
+Revert this commit to return the long-run workflow to configured-token-only
+resolution. If reverted, scheduled long-run runs will remain dependent on a
+fresh `ATTENDANCE_ADMIN_JWT` or configured login credentials.

--- a/docs/development/attendance-import-perf-longrun-auth-fallback-verification-20260514.md
+++ b/docs/development/attendance-import-perf-longrun-auth-fallback-verification-20260514.md
@@ -1,0 +1,73 @@
+# Attendance Import Perf Long Run Auth Fallback Verification 2026-05-14
+
+## Baseline Failure
+
+- Workflow: `Attendance Import Perf Long Run`
+- Run: `25845123113`
+- Head SHA: `298de5699df9d96900d0dbf936b4673d3a1dbadc`
+- Event: scheduled run
+- Result: failure
+
+Observed failure:
+
+- Scenario jobs failed in `Resolve valid auth token`.
+- Resolver emitted `no valid auth token after token/refresh/login fallback`.
+- `LOGIN_EMAIL` and `LOGIN_PASSWORD` were empty in the job environment.
+- `trend-report` then failed because no current perf summary existed.
+- The summary step also attempted to read an empty markdown output path.
+
+## Verification Commands
+
+Run from repo root:
+
+```bash
+ruby -e 'require "yaml"; YAML.load_file(".github/workflows/attendance-import-perf-longrun.yml"); puts "yaml-parse-ok"'
+bash -n scripts/ops/resolve-attendance-smoke-token.sh
+bash -n scripts/ops/attendance-resolve-auth.sh
+bash -n scripts/ops/attendance-write-auth-error.sh
+node --test scripts/ops/attendance-import-perf-longrun-workflow-contract.test.mjs
+node --test scripts/ops/resolve-attendance-smoke-token.test.mjs scripts/ops/attendance-auth-scripts.test.mjs
+files="$(git diff --name-only)"
+pattern='access_''token=[^[:space:]]+|SEC[0-9A-Za-z]{20,}|ey''J[0-9A-Za-z_-]+\.|Bearer[[:space:]]+[A-Za-z0-9._-]{20,}|ATTENDANCE_ADMIN_''PASSWORD=\S'
+rg -n "${pattern}" ${files}
+```
+
+## Expected Result
+
+- YAML parses successfully.
+- Shell scripts pass syntax checks.
+- Workflow contract test confirms:
+  - configured token/login fallback remains present;
+  - deploy-host fallback secrets are wired;
+  - `resolve-attendance-smoke-token.sh` is called only after configured auth
+    fails;
+  - fallback diagnostics are written to `deploy-host-auth-fallback.log`;
+  - trend summary no longer runs `cat` with an empty output path.
+- Existing auth resolver and deploy-host token resolver tests continue to pass.
+- Secret scan has no real token/webhook/password findings.
+
+## Local Results
+
+- `yaml-parse-ok`
+- shell syntax checks: pass
+- `attendance-import-perf-longrun-workflow-contract.test.mjs`: 2 pass
+- `resolve-attendance-smoke-token.test.mjs` +
+  `attendance-auth-scripts.test.mjs`: 8 pass
+- `git diff --check`: pass
+- changed-file strict value-pattern secret scan: 0 findings
+
+## Post-Merge Live Check
+
+After merge, manually rerun `Attendance Import Perf Long Run` or wait for the
+next scheduled run. Success criteria:
+
+- At least the enabled scenarios pass the auth resolution step.
+- Scenario artifacts show either configured auth or deploy-host fallback as the
+  source, without exposing token values.
+- Trend report no longer fails with `cat: '': No such file or directory`.
+
+## Current Delivery Status
+
+This patch fixes the workflow-level red introduced by credential drift. It does
+not change Attendance business behavior and does not change DingTalk runtime
+behavior.

--- a/scripts/ops/attendance-import-perf-longrun-workflow-contract.test.mjs
+++ b/scripts/ops/attendance-import-perf-longrun-workflow-contract.test.mjs
@@ -1,0 +1,40 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+const repoRoot = process.cwd()
+const workflowPath = path.join(repoRoot, '.github/workflows/attendance-import-perf-longrun.yml')
+
+test('attendance import perf longrun workflow can mint auth from deploy host', () => {
+  const raw = readFileSync(workflowPath, 'utf8')
+
+  assert.match(
+    raw,
+    /AUTH_TOKEN:\s+\$\{\{\s*secrets\.ATTENDANCE_ADMIN_JWT\s+\|\|\s+vars\.ATTENDANCE_ADMIN_JWT\s+\|\|\s+''\s*\}\}/,
+  )
+  assert.match(
+    raw,
+    /LOGIN_EMAIL:\s+\$\{\{\s*secrets\.ATTENDANCE_ADMIN_EMAIL\s+\|\|\s+vars\.ATTENDANCE_ADMIN_EMAIL\s+\|\|\s+''\s*\}\}/,
+  )
+  assert.match(
+    raw,
+    /LOGIN_PASSWORD:\s+\$\{\{\s*secrets\.ATTENDANCE_ADMIN_PASSWORD\s+\|\|\s+vars\.ATTENDANCE_ADMIN_PASSWORD\s+\|\|\s+''\s*\}\}/,
+  )
+  assert.match(raw, /DEPLOY_HOST:\s+\$\{\{\s*secrets\.DEPLOY_HOST\s*\}\}/)
+  assert.match(raw, /DEPLOY_USER:\s+\$\{\{\s*secrets\.DEPLOY_USER\s*\}\}/)
+  assert.match(raw, /DEPLOY_SSH_KEY_B64:\s+\$\{\{\s*secrets\.DEPLOY_SSH_KEY_B64\s*\}\}/)
+  assert.match(raw, /\.\/scripts\/ops\/attendance-resolve-auth\.sh/)
+  assert.match(raw, /\.\/scripts\/ops\/resolve-attendance-smoke-token\.sh/)
+  assert.match(raw, /deploy-host-auth-fallback\.log/)
+  assert.match(raw, /AUTH_TOKEN_EFFECTIVE=\$\{resolved_token\}/)
+})
+
+test('attendance import perf longrun trend summary does not cat an empty output path', () => {
+  const raw = readFileSync(workflowPath, 'utf8')
+
+  assert.match(raw, /report_markdown="\$\{\{\s*steps\.trend\.outputs\.report_markdown\s*\}\}"/)
+  assert.match(raw, /\[\[ -n "\$\{report_markdown\}" && -f "\$\{report_markdown\}" \]\]/)
+  assert.match(raw, /Trend report markdown was not produced/)
+  assert.doesNotMatch(raw, /cat "\$\{\{\s*steps\.trend\.outputs\.report_markdown\s*\}\}" >> "\$GITHUB_STEP_SUMMARY"/)
+})


### PR DESCRIPTION
## Summary
- add deploy-host token fallback to `Attendance Import Perf Long Run` when configured admin JWT/refresh/login all fail
- mask and revalidate the fallback token before using it in perf scenarios
- guard trend summary rendering so it no longer runs `cat ""` after early failures
- add development and verification notes for the red-light fix

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/attendance-import-perf-longrun.yml"); puts "yaml-parse-ok"'`
- `bash -n scripts/ops/resolve-attendance-smoke-token.sh && bash -n scripts/ops/attendance-resolve-auth.sh && bash -n scripts/ops/attendance-write-auth-error.sh`
- `node --test scripts/ops/attendance-import-perf-longrun-workflow-contract.test.mjs`
- `node --test scripts/ops/resolve-attendance-smoke-token.test.mjs scripts/ops/attendance-auth-scripts.test.mjs`
- `git diff --cached --check`
- changed-file strict value-pattern secret scan: 0 findings

## Live Follow-up
After merge, rerun `Attendance Import Perf Long Run` on `main`; success criteria are auth resolution passes for enabled scenarios and no `cat: '': No such file or directory` noise in `trend-report`.
