### PR TITLE
fix(attendance): sanitize import perf template payload

### DIFF
--- a/docs/development/attendance-import-perf-template-payload-development-20260514.md
+++ b/docs/development/attendance-import-perf-template-payload-development-20260514.md
@@ -1,0 +1,39 @@
+# Attendance Import Perf Template Payload Development 2026-05-14
+
+## Summary
+
+After PR `#1539` fixed long-run auth resolution, live run `25846123607`
+advanced past `Resolve valid auth token` and failed inside
+`rows10k-commit / Run long-run scenario`.
+
+The failure was not an auth failure. The perf helper used
+`GET /attendance/import/template` as a baseline payload and spread
+`payloadExample` directly into the preview/commit request. That template
+contains display-oriented fields such as `columns: ["日期", "工号", ...]` and
+`requiredFields`. The current import API schema treats top-level `columns` as
+API column objects, so string columns fail validation.
+
+## Changes
+
+- Added `sanitizeImportTemplatePayloadExample()` in
+  `scripts/ops/attendance-import-perf.mjs`.
+- Removed display-only string `columns` from template examples before building
+  live preview/commit payloads.
+- Removed `requiredFields`, which is documentation metadata and not part of the
+  import request contract.
+- Preserved API-style object columns when present.
+- Reused `template.data.mapping` as the request `mapping` when the sanitized
+  payload example does not already include one.
+- Guarded the script entrypoint so the sanitizer can be imported by focused
+  tests without executing the live perf run.
+
+## Scope
+
+This is an ops-helper compatibility fix only. It does not change the Attendance
+import API, database schema, or production runtime behavior.
+
+## Rollback
+
+Revert this commit to restore the old helper behavior. If reverted, long-run
+perf scenarios may again fail when template examples include display-only
+string columns.

--- a/docs/development/attendance-import-perf-template-payload-verification-20260514.md
+++ b/docs/development/attendance-import-perf-template-payload-verification-20260514.md
@@ -1,0 +1,51 @@
+# Attendance Import Perf Template Payload Verification 2026-05-14
+
+## Baseline Failure
+
+- Live workflow: `Attendance Import Perf Long Run`
+- Run: `25846123607`
+- Head SHA: `0b4575fe332141a88e9cedb5e8531a7c91257dea`
+
+Auth status:
+
+- `rows10k-commit`: `Resolve valid auth token` passed.
+- `rows50k-preview`: `Resolve valid auth token` passed.
+- Skipped matrix entries also reached scenario gating after auth resolution.
+
+Observed runtime failure:
+
+```text
+POST /attendance/import/preview: HTTP 400
+VALIDATION_ERROR
+path: ["columns", ...]
+expected: object
+received: string
+```
+
+## Verification Commands
+
+```bash
+node --test scripts/ops/attendance-import-perf-payload.test.mjs
+node --check scripts/ops/attendance-import-perf.mjs
+git diff --check
+git diff --name-only -z | xargs -0 rg -n "access_token=[^[:space:]]+|SEC[0-9A-Za-z]{20,}|eyJ[0-9A-Za-z_-]+\\.|Bearer[[:space:]]+[A-Za-z0-9._-]{20,}"
+```
+
+## Local Results
+
+- sanitizer unit test: 3 pass
+- `node --check`: pass
+- `git diff --check`: pass
+- changed-file strict value-pattern secret scan: 0 findings
+
+## Expected Post-Merge Live Check
+
+Rerun `Attendance Import Perf Long Run` from `main`.
+
+Success criteria:
+
+- Auth resolution remains green through the deploy-host fallback.
+- `rows10k-commit` no longer fails with top-level `columns` validation.
+- Trend summary does not emit `cat: '': No such file or directory`.
+- Any remaining failure should be a real import/perf condition, not template
+  payload shape drift.

--- a/scripts/ops/attendance-import-perf-payload.test.mjs
+++ b/scripts/ops/attendance-import-perf-payload.test.mjs
@@ -1,0 +1,41 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { sanitizeImportTemplatePayloadExample } from './attendance-import-perf.mjs'
+
+test('sanitizeImportTemplatePayloadExample removes display-only string columns', () => {
+  const sanitized = sanitizeImportTemplatePayloadExample({
+    source: 'dingtalk',
+    mode: 'override',
+    columns: ['日期', '工号'],
+    requiredFields: ['日期'],
+    userMap: {},
+  })
+
+  assert.equal(sanitized.source, 'dingtalk')
+  assert.equal(sanitized.mode, 'override')
+  assert.deepEqual(sanitized.userMap, {})
+  assert.equal('columns' in sanitized, false)
+  assert.equal('requiredFields' in sanitized, false)
+})
+
+test('sanitizeImportTemplatePayloadExample keeps API column objects', () => {
+  const sanitized = sanitizeImportTemplatePayloadExample({
+    columns: [
+      { id: 'workDate', name: 'workDate' },
+      { id: 1, alias: 'userId' },
+    ],
+    requiredFields: ['workDate'],
+  })
+
+  assert.deepEqual(sanitized.columns, [
+    { id: 'workDate', name: 'workDate' },
+    { id: 1, alias: 'userId' },
+  ])
+  assert.equal('requiredFields' in sanitized, false)
+})
+
+test('sanitizeImportTemplatePayloadExample ignores non-object examples', () => {
+  assert.deepEqual(sanitizeImportTemplatePayloadExample(null), {})
+  assert.deepEqual(sanitizeImportTemplatePayloadExample(['日期']), {})
+  assert.deepEqual(sanitizeImportTemplatePayloadExample('template'), {})
+})

--- a/scripts/ops/attendance-import-perf.mjs
+++ b/scripts/ops/attendance-import-perf.mjs
@@ -9,6 +9,7 @@
 
 import fs from 'fs/promises'
 import path from 'path'
+import { fileURLToPath } from 'url'
 import { assertImportTelemetry, coerceNonNegativeNumber } from './attendance-import-telemetry-utils.mjs'
 
 const apiBase = String(process.env.API_BASE || '').replace(/\/+$/, '')
@@ -433,6 +434,21 @@ function normalizeRecordUpsertStrategy(value) {
   return ''
 }
 
+export function sanitizeImportTemplatePayloadExample(payloadExample) {
+  if (!payloadExample || typeof payloadExample !== 'object' || Array.isArray(payloadExample)) {
+    return {}
+  }
+
+  const sanitized = { ...payloadExample }
+  if (Array.isArray(sanitized.columns) && sanitized.columns.some((column) => {
+    return !column || typeof column !== 'object' || Array.isArray(column)
+  })) {
+    delete sanitized.columns
+  }
+  delete sanitized.requiredFields
+  return sanitized
+}
+
 function resolveSyntheticImportShape(totalRows) {
   const normalizedRows = Math.max(1, Math.floor(Number(totalRows) || 1))
   if (perfUserPoolSize) {
@@ -732,6 +748,10 @@ async function run() {
   assertOk(template, 'GET /attendance/import/template')
   const payloadExample = template.body?.data?.payloadExample
   if (!payloadExample || typeof payloadExample !== 'object') die('payloadExample missing')
+  const templateMapping = template.body?.data?.mapping && typeof template.body.data.mapping === 'object'
+    ? template.body.data.mapping
+    : null
+  const payloadExampleBase = sanitizeImportTemplatePayloadExample(payloadExample)
   const resolvedMappingProfileId =
     mappingProfileIdOverride ||
     String(payloadExample.mappingProfileId || '') ||
@@ -789,7 +809,8 @@ async function run() {
   }
 
   const basePayload = {
-    ...payloadExample,
+    ...payloadExampleBase,
+    ...(payloadExampleBase.mapping || !templateMapping ? {} : { mapping: templateMapping }),
     orgId,
     userId,
     timezone: payloadExample.timezone || timezone,
@@ -1385,8 +1406,10 @@ async function run() {
   }
 }
 
-run().catch((error) => {
-  const msg = error instanceof Error ? error.message : String(error)
-  console.error(`[attendance-import-perf] Failed: ${msg}`)
-  process.exit(1)
-})
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  run().catch((error) => {
+    const msg = error instanceof Error ? error.message : String(error)
+    console.error(`[attendance-import-perf] Failed: ${msg}`)
+    process.exit(1)
+  })
+}


### PR DESCRIPTION
## Summary
- sanitize Attendance import template examples before using them as perf preview/commit payloads
- remove display-only string `columns` and `requiredFields` from live request payloads
- preserve API-style object columns and reuse template `mapping` when needed
- add focused sanitizer tests and development/verification notes

## Verification
- `node --test scripts/ops/attendance-import-perf-payload.test.mjs`
- `node --check scripts/ops/attendance-import-perf.mjs`
- `git diff --check`
- changed-file strict value-pattern secret scan: 0 findings

## Live Evidence
After #1539, live run `25846123607` passed auth resolution and then failed at `rows10k-commit` with `POST /attendance/import/preview: HTTP 400` because `payloadExample.columns` contains display strings while the current import schema expects column objects. This PR fixes that helper-side payload drift.
