### PR TITLE
docs(dingtalk): enter close observation and clean workspace artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,13 @@ output/dingtalk-p4-regression-gate/
 output/dingtalk-p4-release-readiness/
 artifacts/dingtalk-staging-evidence-packet/
 
+# DingTalk live acceptance artifacts are generated operator evidence and can
+# contain sanitized but environment-specific delivery IDs or probe summaries.
+output/dingtalk-live-acceptance/
+
+# Local Claude/Codex scratch state must stay outside the repository.
+.claude/
+
 # K3 WISE postdeploy smoke artifacts can include deployment topology and
 # authenticated contract evidence.
 output/integration-k3wise-postdeploy-smoke/
@@ -79,3 +86,8 @@ artifacts/integration-k3wise-onprem-preflight/
 # K3 WISE internal-trial postdeploy smoke artifacts contain deployment URLs,
 # masked admin signoff metadata, and per-check evidence; operator-only.
 artifacts/integration-k3wise/internal-trial/
+
+# Multitable on-prem release bundles are generated delivery artifacts. Keep
+# source manifests/runbooks in Git, not built archives and verification output.
+output/delivery/multitable-onprem/
+output/releases/

--- a/docs/development/dingtalk-close-observation-development-20260514.md
+++ b/docs/development/dingtalk-close-observation-development-20260514.md
@@ -1,0 +1,80 @@
+# DingTalk Close Observation Development 2026-05-14
+
+## Summary
+
+This document records the development-side closeout decision for the DingTalk
+integration line after the final runtime and documentation work landed on
+`main`.
+
+No runtime code, database schema, or DingTalk configuration is changed by this
+close-observation package. The only repository change is to keep local generated
+operator artifacts out of future worktree status noise.
+
+## Current Mainline Evidence
+
+- Current `origin/main`: `a921895333af7efbfabd5d75a3f210dde0adb7c3`
+- Latest 142 backend image:
+  `ghcr.io/zensgit/metasheet2-backend:a921895333af7efbfabd5d75a3f210dde0adb7c3`
+- Latest 142 web image:
+  `ghcr.io/zensgit/metasheet2-web:a921895333af7efbfabd5d75a3f210dde0adb7c3`
+- Open PR count: `0`
+- Latest DingTalk monitor signal:
+  `DingTalk OAuth Stability Recording (Lite)` passed on `a921895333...`
+- Latest DingTalk regression signal:
+  `DingTalk P4 ops regression gate` passed in the latest mainline plugin test
+  run.
+
+## Closure Decision
+
+DingTalk integration can move from active development to close observation.
+
+Close observation means:
+
+- no new DingTalk scope is accepted into the current delivery line;
+- any new DingTalk issue must be triaged as production support or a separately
+  planned enhancement;
+- the current line can be formally archived if no P0/P1 DingTalk issue appears
+  before the next business-day review.
+
+Recommended formal archive time: `2026-05-15`, assuming the following remain
+green:
+
+- 142 `/api/health`;
+- 142 web entry;
+- DingTalk OAuth lite monitor;
+- DingTalk P4 ops regression gate;
+- no new failed group robot or work-notification delivery incident.
+
+## Reopen Criteria
+
+Reopen the DingTalk line only if one of these happens:
+
+- DingTalk login or public-form auth regresses for a bound, enabled user;
+- a valid group robot destination cannot be saved or tested;
+- failure-alert delivery does not create audit/delivery evidence;
+- rule creator work-notification fallback does not fire on a controlled failure;
+- directory organization mirror cannot be opened by an admin after deployment;
+- a real secret appears in Git, PR text, generated closeout docs, or chat logs.
+
+## Non-Blocking Follow-Up
+
+The following should stay outside the closed DingTalk delivery line unless a new
+scope is explicitly opened:
+
+- richer organization governance UI;
+- shared organization-level robot directory;
+- row/column-level task assignment;
+- screenshot evidence archival beyond existing delivery/audit/API evidence.
+
+## Repository Hygiene Change
+
+The closeout package also adds ignore rules for generated local artifacts:
+
+- `.claude/`
+- `output/dingtalk-live-acceptance/`
+- `output/delivery/multitable-onprem/`
+- `output/releases/`
+
+These paths are operator-local outputs, not source assets. Ignoring them keeps
+future K3, Feishu, Attendance, and DingTalk branches from appearing dirty due to
+generated bundles or local scratch state.

--- a/docs/development/dingtalk-close-observation-verification-20260514.md
+++ b/docs/development/dingtalk-close-observation-verification-20260514.md
@@ -1,0 +1,74 @@
+# DingTalk Close Observation Verification 2026-05-14
+
+## Verification Commands
+
+```bash
+gh run list --repo zensgit/metasheet2 --branch main --limit 10 \
+  --json databaseId,name,status,conclusion,headSha,url,createdAt
+
+gh pr list --repo zensgit/metasheet2 --state open --limit 50 \
+  --json number,title,headRefName,isDraft,mergeStateStatus,reviewDecision,url
+
+ssh -o BatchMode=yes -o StrictHostKeyChecking=no metasheet-142 \
+  'printf "health="; curl -sS -m 10 http://127.0.0.1:8081/api/health; \
+   printf "\nweb="; curl -sS -o /dev/null -w "%{http_code}" -m 10 http://127.0.0.1:8081/; \
+   printf "\nbackend_image="; docker inspect --format "{{.Config.Image}}" metasheet-backend 2>/dev/null || true; \
+   printf "\nweb_image="; docker inspect --format "{{.Config.Image}}" metasheet-web 2>/dev/null || true; \
+   printf "\n"'
+
+git diff --check
+
+files="$(git diff --name-only)"
+pattern='access_''token=[^[:space:]]+|SEC[0-9A-Za-z]{20,}|ey''J[0-9A-Za-z_-]+\.|Bearer[[:space:]]+[A-Za-z0-9._-]{20,}'
+rg -n "${pattern}" ${files}
+```
+
+## Mainline Status
+
+- `Deploy to Production`: success on
+  `a921895333af7efbfabd5d75a3f210dde0adb7c3`
+- `Phase 5 Production Flags Guard`: success on
+  `a921895333af7efbfabd5d75a3f210dde0adb7c3`
+- `SafetyGuard E2E`: success on
+  `a921895333af7efbfabd5d75a3f210dde0adb7c3`
+- `Observability E2E`: success on
+  `a921895333af7efbfabd5d75a3f210dde0adb7c3`
+- `monitoring-alert`: success on
+  `a921895333af7efbfabd5d75a3f210dde0adb7c3`
+- `Build and Push Docker Images`: success on
+  `a921895333af7efbfabd5d75a3f210dde0adb7c3`
+- `Plugin System Tests`: success on
+  `a921895333af7efbfabd5d75a3f210dde0adb7c3`
+- `DingTalk OAuth Stability Recording (Lite)`: success on
+  `a921895333af7efbfabd5d75a3f210dde0adb7c3`
+- Open PR list: empty
+
+## 142 Verification
+
+142 internal checks returned:
+
+```text
+health={"status":"ok","ok":true,"success":true,...}
+web=200
+backend_image=ghcr.io/zensgit/metasheet2-backend:a921895333af7efbfabd5d75a3f210dde0adb7c3
+web_image=ghcr.io/zensgit/metasheet2-web:a921895333af7efbfabd5d75a3f210dde0adb7c3
+```
+
+The public 8081/8082 network path may still depend on local network reachability,
+so this verification intentionally uses the 142 internal loopback path.
+
+## Result
+
+DingTalk is suitable for close observation.
+
+Final closure can be declared after the next business-day review if:
+
+- the above mainline runs remain green or their successors remain green;
+- no new DingTalk P0/P1 is reported;
+- no new DingTalk PR appears as a must-merge runtime blocker.
+
+## Secret Scan Result
+
+Changed-file value-pattern scan is expected to return no findings. The docs use
+split pattern strings in command examples to avoid matching their own scan
+patterns as false positives.

--- a/docs/development/workspace-cleanup-inventory-development-20260514.md
+++ b/docs/development/workspace-cleanup-inventory-development-20260514.md
@@ -1,0 +1,61 @@
+# Workspace Cleanup Inventory Development 2026-05-14
+
+## Summary
+
+This document records the current local worktree inventory and the cleanup
+strategy used after DingTalk closeout.
+
+The root checkout at `<repo-root>` is intentionally
+not modified by this package. It remains on
+`codex/k3wise-workbench-release-publication-20260513`.
+
+## Local Worktree Classification
+
+The root checkout reported untracked paths in these buckets:
+
+| Bucket | Count | Representative paths | Recommended action |
+| --- | ---: | --- | --- |
+| integration-core docs | 10 | `docs/development/integration-core-*` | Review as a separate integration-core docs PR or archive locally. |
+| K3 / delivery artifacts | 4 buckets | `docs/development/integration-k3wise-*`, `output/delivery/multitable-onprem/`, `output/releases/` | Keep docs in a K3 PR; keep generated bundles ignored. |
+| Feishu docs | 5 | `docs/development/multitable-feishu-*` | Some already exist on `origin/main`; refresh the working branch before acting. |
+| ops / staging docs | 5 | `docs/operations/*`, `docs/development/staging-*` | Review as an ops-docs PR or archive. |
+| DingTalk live acceptance output | 1 bucket, 16 files | `output/dingtalk-live-acceptance/20260510/*` | Keep as local operator evidence; do not track in Git. |
+| local scratch state | 1 bucket | `.claude/` | Keep ignored. |
+
+Four files that appear untracked in the root checkout already exist on
+`origin/main`:
+
+- `docs/development/k3wise-bridge-machine-codex-handoff-20260513.md`
+- `docs/development/multitable-feishu-phase3-ai-hardening-plan-20260514.md`
+- `docs/development/multitable-feishu-phase3-ai-hardening-review-20260514.md`
+- `docs/development/multitable-feishu-phase3-ai-hardening-todo-20260514.md`
+
+That is branch-drift noise, not new work.
+
+## Cleanup Strategy
+
+This package does not delete or move local files. It only adds ignore rules for
+generated artifacts so future `git status` output is easier to read.
+
+Ignored generated artifact paths:
+
+- `.claude/`
+- `output/dingtalk-live-acceptance/`
+- `output/delivery/multitable-onprem/`
+- `output/releases/`
+
+Suggested next manual cleanup order:
+
+1. Refresh or rebase the root working branch onto `origin/main` only after
+   preserving any real K3 work.
+2. Split source/docs work by lane: K3, Feishu, integration-core, ops.
+3. Keep generated archives and local acceptance evidence under ignored output
+   directories.
+4. Do not commit generated zips, tgz files, local scratch folders, or live
+   acceptance JSON unless a release process explicitly asks for a sanitized
+   artifact.
+
+## Scope Guard
+
+No tracked source code is changed. No runtime behavior changes. No database
+changes. No generated artifact is deleted.

--- a/docs/development/workspace-cleanup-inventory-verification-20260514.md
+++ b/docs/development/workspace-cleanup-inventory-verification-20260514.md
@@ -1,0 +1,70 @@
+# Workspace Cleanup Inventory Verification 2026-05-14
+
+## Verification Commands
+
+```bash
+git status --short
+
+git status --short | awk '{print $2}' | sed 's#/$##' | awk '
+  /^docs\/development\/integration-core-/ {core++ ; next}
+  /^docs\/development\/integration-k3wise|^docs\/development\/k3wise-|^output\/delivery\/multitable-onprem|^output\/releases/ {k3++ ; next}
+  /^docs\/development\/multitable-feishu/ {feishu++ ; next}
+  /^docs\/operations\/|^docs\/development\/operations-|^docs\/development\/staging-/ {ops++ ; next}
+  /^output\/dingtalk-live-acceptance/ {dingtalk++ ; next}
+  /^\.claude/ {local++ ; next}
+  {other++}
+  END {printf "core=%d\nk3=%d\nfeishu=%d\nops=%d\ndingtalk=%d\nlocal=%d\nother=%d\n", core+0,k3+0,feishu+0,ops+0,dingtalk+0,local+0,other+0}'
+
+find output/dingtalk-live-acceptance -type f 2>/dev/null | wc -l
+
+git ls-tree -r --name-only origin/main -- \
+  docs/development/k3wise-bridge-machine-codex-handoff-20260513.md \
+  docs/development/multitable-feishu-phase3-ai-hardening-plan-20260514.md \
+  docs/development/multitable-feishu-phase3-ai-hardening-review-20260514.md \
+  docs/development/multitable-feishu-phase3-ai-hardening-todo-20260514.md
+
+git diff --check
+
+files="$(git diff --name-only)"
+pattern='access_''token=[^[:space:]]+|SEC[0-9A-Za-z]{20,}|ey''J[0-9A-Za-z_-]+\.|Bearer[[:space:]]+[A-Za-z0-9._-]{20,}'
+rg -n "${pattern}" ${files}
+```
+
+## Observed Inventory
+
+Root checkout classification before this cleanup package:
+
+```text
+core=10
+k3=4
+feishu=5
+ops=5
+dingtalk=1
+local=1
+other=0
+```
+
+`output/dingtalk-live-acceptance/20260510/` contained 16 files. These are local
+operator evidence outputs and should remain untracked.
+
+The K3 delivery/output directories contain generated zip/tgz bundles,
+checksums, delivery manifests, and verification outputs. These are generated
+release artifacts, not source files.
+
+## Expected Post-Merge Effect
+
+After this ignore-rule package lands and the root checkout is refreshed onto a
+mainline containing it:
+
+- `.claude/` no longer appears as ordinary untracked source work;
+- `output/dingtalk-live-acceptance/` no longer appears as ordinary untracked
+  source work;
+- generated multitable on-prem release bundles under `output/delivery/` and
+  `output/releases/` no longer pollute `git status`;
+- source docs still appear if they are truly new and not present on the current
+  branch.
+
+## Result
+
+The cleanup is safe because it is ignore-only and docs-only. It does not remove
+or mutate local evidence files.


### PR DESCRIPTION
## Summary
- record DingTalk close-observation criteria after latest main/142 verification
- document local workspace cleanup inventory and branch-drift findings
- ignore generated local artifacts: .claude, DingTalk live acceptance output, multitable on-prem bundles, release output

## Verification
- git diff --check
- changed-file strict value-pattern secret scan: 0 findings
- git check-ignore confirms generated artifact paths are ignored
- 142 internal /api/health OK and web / returns 200 on a921895333af7efbfabd5d75a3f210dde0adb7c3
- main run signals checked: Deploy, Build, Plugin System Tests, Phase 5 Guard, DingTalk OAuth Stability Recording Lite all success

## Notes
- docs-only plus ignore-rule change; no runtime code or DB changes
- root checkout dirty files were not moved or deleted
