### PR TITLE
test(multitable): add phase3 real smtp gate

### DIFF
--- a/docs/development/multitable-feishu-phase3-ai-hardening-todo-20260514.md
+++ b/docs/development/multitable-feishu-phase3-ai-hardening-todo-20260514.md
@@ -55,24 +55,24 @@ tables in
 
 ## Phase 0 - Planning and Hygiene
 
-- [ ] Create Phase 3 plan and TODO docs.
-  - PR:
-  - Merge commit:
+- [x] Create Phase 3 plan and TODO docs.
+  - PR: #1537
+  - Merge commit: `55b4b685d`
   - Development MD: `docs/development/multitable-feishu-phase3-ai-hardening-plan-20260514.md`
-  - Verification MD:
-  - Verification summary:
-- [ ] Confirm root checkout is not used for Phase 3 implementation.
-  - PR:
-  - Merge commit:
-  - Development MD:
-  - Verification MD:
-  - Verification summary:
-- [ ] Create clean worktree naming convention for Phase 3 lanes.
-  - PR:
-  - Merge commit:
-  - Development MD:
-  - Verification MD:
-  - Verification summary:
+  - Verification MD: `docs/development/multitable-feishu-phase3-ai-hardening-review-landing-verification-20260514.md`
+  - Verification summary: plan/review/TODO docs landed; active queue limited to D0/D1/D4 under the K3 stage-1 lock.
+- [x] Confirm root checkout is not used for Phase 3 implementation.
+  - PR: #1537
+  - Merge commit: `55b4b685d`
+  - Development MD: `docs/development/multitable-feishu-phase3-ai-hardening-review-landing-development-20260514.md`
+  - Verification MD: `docs/development/multitable-feishu-phase3-ai-hardening-review-landing-verification-20260514.md`
+  - Verification summary: TODO records the clean-worktree rule; subsequent D0/D1 work starts from `/private/tmp/ms2-multitable-phase3-*`.
+- [x] Create clean worktree naming convention for Phase 3 lanes.
+  - PR: #1537
+  - Merge commit: `55b4b685d`
+  - Development MD: `docs/development/multitable-feishu-phase3-ai-hardening-review-landing-development-20260514.md`
+  - Verification MD: `docs/development/multitable-feishu-phase3-ai-hardening-review-landing-verification-20260514.md`
+  - Verification summary: naming convention documented as `/private/tmp/ms2-multitable-phase3-<lane>-20260514`.
 - [ ] Classify existing unrelated dirty root files before opening any Phase 3 PR from root.
   - PR:
   - Merge commit:
@@ -88,46 +88,46 @@ Owner recommendation: Codex.
 
 Reason: this lane defines artifact shape, redaction, and release safety constraints.
 
-- [ ] Add shared Phase 3 report writer for JSON and Markdown artifacts.
-  - PR:
-  - Merge commit:
-  - Development MD:
-  - Verification MD:
-  - Verification summary:
-- [ ] Add shared secret redaction helper for AI, SMTP, webhook, JWT, bearer, and recipient-like values.
-  - PR:
-  - Merge commit:
-  - Development MD:
-  - Verification MD:
-  - Verification summary:
-- [ ] Add blocked-mode command `pnpm verify:multitable-release:phase3`.
-  - PR:
-  - Merge commit:
-  - Development MD:
-  - Verification MD:
-  - Verification summary:
-- [ ] Add placeholder blocked-mode commands for:
+- [x] Add shared Phase 3 report writer for JSON and Markdown artifacts.
+  - PR: #1541
+  - Merge commit: `a92189533`
+  - Development MD: `docs/development/multitable-phase3-release-gate-skeleton-development-20260514.md`
+  - Verification MD: `docs/development/multitable-phase3-release-gate-skeleton-verification-20260514.md`
+  - Verification summary: `multitable-phase3-release-gate-report.test.mjs` passed; JSON/Markdown artifacts are redacted before write.
+- [x] Add shared secret redaction helper for AI, SMTP, webhook, JWT, bearer, and recipient-like values.
+  - PR: #1541
+  - Merge commit: `a92189533`
+  - Development MD: `docs/development/multitable-phase3-release-gate-skeleton-development-20260514.md`
+  - Verification MD: `docs/development/multitable-phase3-release-gate-skeleton-verification-20260514.md`
+  - Verification summary: redaction tests cover bearer/JWT/sk/SEC/query tokens, SMTP envs, recipient envs, and DB URI credentials.
+- [x] Add blocked-mode command `pnpm verify:multitable-release:phase3`.
+  - PR: #1541
+  - Merge commit: `a92189533`
+  - Development MD: `docs/development/multitable-phase3-release-gate-skeleton-development-20260514.md`
+  - Verification MD: `docs/development/multitable-phase3-release-gate-skeleton-verification-20260514.md`
+  - Verification summary: `release:phase3` exits 2 when child gates are blocked and does not collapse BLOCKED into FAIL.
+- [x] Add placeholder blocked-mode commands for:
   - `pnpm verify:multitable-email:real-send`
   - `pnpm verify:multitable-perf:large-table`
   - `pnpm verify:multitable-permissions:matrix`
   - `pnpm verify:multitable-automation:soak`
-  - PR:
-  - Merge commit:
-  - Development MD:
-  - Verification MD:
-  - Verification summary:
-- [ ] Add unit tests proving blocked gates exit non-zero when required env is missing.
-  - PR:
-  - Merge commit:
-  - Development MD:
-  - Verification MD:
-  - Verification summary:
-- [ ] Add unit tests proving artifacts do not leak token-like or credential-like values.
-  - PR:
-  - Merge commit:
-  - Development MD:
-  - Verification MD:
-  - Verification summary:
+  - PR: #1541
+  - Merge commit: `a92189533`
+  - Development MD: `docs/development/multitable-phase3-release-gate-skeleton-development-20260514.md`
+  - Verification MD: `docs/development/multitable-phase3-release-gate-skeleton-verification-20260514.md`
+  - Verification summary: D0 skeleton added perf/permissions/automation placeholders; email real-send existed already and is wired into the aggregate gate by D1.
+- [x] Add unit tests proving blocked gates exit non-zero when required env is missing.
+  - PR: #1541
+  - Merge commit: `a92189533`
+  - Development MD: `docs/development/multitable-phase3-release-gate-skeleton-development-20260514.md`
+  - Verification MD: `docs/development/multitable-phase3-release-gate-skeleton-verification-20260514.md`
+  - Verification summary: spawn tests verify exit 2 for blocked gates and `--allow-blocked` preserves report status.
+- [x] Add unit tests proving artifacts do not leak token-like or credential-like values.
+  - PR: #1541
+  - Merge commit: `a92189533`
+  - Development MD: `docs/development/multitable-phase3-release-gate-skeleton-development-20260514.md`
+  - Verification MD: `docs/development/multitable-phase3-release-gate-skeleton-verification-20260514.md`
+  - Verification summary: artifact-integrity tests assert stdout/stderr/report JSON/report MD do not contain injected secret values.
 
 ## Lane A1 - AI Provider Readiness Contract
 
@@ -498,36 +498,42 @@ Status: pending — active queue (kernel polish on shipped automation send_email
 
 Owner recommendation: Codex.
 
-- [ ] Implement guarded real-send smoke.
-  - PR:
-  - Merge commit:
-  - Development MD:
-  - Verification MD:
-  - Verification summary:
-- [ ] Require `CONFIRM_SEND_EMAIL=1`.
-  - PR:
-  - Merge commit:
-  - Development MD:
-  - Verification MD:
-  - Verification summary:
-- [ ] Require dedicated test recipient env.
-  - PR:
-  - Merge commit:
-  - Development MD:
-  - Verification MD:
-  - Verification summary:
+Scope note: the guarded SMTP transport smoke already existed before
+Phase 3. This D1 slice wires that existing harness into the Phase 3
+aggregate release gate as `email:real-send`; it does not add a new
+SMTP provider or send a real email without the existing explicit
+guards.
+
+- [x] Implement guarded real-send smoke.
+  - PR: pre-existing before Phase 3; aggregated by #1544.
+  - Merge commit: pre-existing before Phase 3; D1 aggregation merge pending.
+  - Development MD: `docs/development/multitable-phase3-real-smtp-gate-development-20260514.md`
+  - Verification MD: `docs/development/multitable-phase3-real-smtp-gate-verification-20260514.md`
+  - Verification summary: `email:real-send` delegates to `pnpm verify:multitable-email:real-send` and reports child status/path in Phase 3 artifacts.
+- [x] Require `CONFIRM_SEND_EMAIL=1`.
+  - PR: pre-existing before Phase 3; aggregated by #1544.
+  - Merge commit: pre-existing before Phase 3; D1 aggregation merge pending.
+  - Development MD: `docs/development/multitable-phase3-real-smtp-gate-development-20260514.md`
+  - Verification MD: `docs/development/multitable-phase3-real-smtp-gate-verification-20260514.md`
+  - Verification summary: existing real-send harness exits 2 unless `CONFIRM_SEND_EMAIL=1` and `MULTITABLE_EMAIL_REAL_SEND_SMOKE=1` are both present.
+- [x] Require dedicated test recipient env.
+  - PR: pre-existing before Phase 3; aggregated by #1544.
+  - Merge commit: pre-existing before Phase 3; D1 aggregation merge pending.
+  - Development MD: `docs/development/multitable-phase3-real-smtp-gate-development-20260514.md`
+  - Verification MD: `docs/development/multitable-phase3-real-smtp-gate-verification-20260514.md`
+  - Verification summary: existing real-send harness exits 2 unless `MULTITABLE_EMAIL_SMOKE_TO` is configured; D1 tests prove recipient values are redacted from aggregate artifacts.
 - [ ] Tie send result to automation execution log.
   - PR:
   - Merge commit:
   - Development MD:
   - Verification MD:
-  - Verification summary:
-- [ ] Redact SMTP credentials and recipients in artifacts.
-  - PR:
-  - Merge commit:
-  - Development MD:
-  - Verification MD:
-  - Verification summary:
+  - Verification summary: intentionally not claimed by this transport-level D1 aggregation slice; the shipped RC automation smoke covers execution-log behavior with the default mock channel, and D4 remains the correct place for repeat-fire automation-log soak semantics.
+- [x] Redact SMTP credentials and recipients in artifacts.
+  - PR: #1544
+  - Merge commit: pending.
+  - Development MD: `docs/development/multitable-phase3-real-smtp-gate-development-20260514.md`
+  - Verification MD: `docs/development/multitable-phase3-real-smtp-gate-verification-20260514.md`
+  - Verification summary: D1 adds email delegate artifact-integrity coverage for SMTP host/user/password/from and smoke recipient values.
 
 ## Lane D2 - Large Table Performance Gate
 

--- a/docs/development/multitable-phase3-real-smtp-gate-development-20260514.md
+++ b/docs/development/multitable-phase3-real-smtp-gate-development-20260514.md
@@ -1,0 +1,77 @@
+# Multitable Phase 3 Real SMTP Gate - Development
+
+Date: 2026-05-14
+
+## Scope
+
+This slice implements PR R3 / Lane D1 from the Phase 3 plan by wiring
+the existing guarded email real-send smoke into the Phase 3 release
+gate aggregator.
+
+The implementation deliberately reuses
+`pnpm verify:multitable-email:real-send` instead of duplicating SMTP
+send logic. The delegated smoke remains the authority for SMTP
+readiness, explicit send confirmation, recipient configuration, and
+actual transport execution.
+
+## Changes
+
+- Added `email:real-send` as the first Phase 3 sub-gate.
+- Delegated `email:real-send` to
+  `pnpm verify:multitable-email:real-send`.
+- Wrote the child email report under the Phase 3 gate output
+  directory:
+  `children/email-real-send/real-send-smoke/report.{json,md}`.
+- Preserved the release-gate exit-code contract:
+  `0=PASS`, `1=FAIL`, `2=BLOCKED`.
+- Kept `release:phase3` as BLOCKED when any child is BLOCKED.
+- Extended Markdown report rendering to show delegated command and
+  child report path.
+- Extended tests so the aggregate gate now expects four children:
+  `email:real-send`, `perf:large-table`, `permissions:matrix`, and
+  `automation:soak`.
+- Updated the Phase 3 TODO with the already-merged Phase 0 / D0 facts
+  and the D1 aggregation status.
+
+## Guard Semantics
+
+The real-send child gate remains BLOCKED unless all of these are true:
+
+- `MULTITABLE_EMAIL_TRANSPORT=smtp`
+- `MULTITABLE_EMAIL_REAL_SEND_SMOKE=1`
+- `CONFIRM_SEND_EMAIL=1`
+- `MULTITABLE_EMAIL_SMOKE_TO` is a dedicated test recipient
+
+The Phase 3 wrapper does not weaken those guards. In a clean
+environment it delegates to the child smoke, records child status, and
+returns BLOCKED with exit code `2`.
+
+## Non-Goals
+
+- No new SMTP provider or SMTP config surface.
+- No real email send during tests or default local runs.
+- No schema, migration, route, or production runtime change.
+- No K3 PoC path touched.
+- No claim that this transport-level D1 slice validates automation
+  execution-log persistence with real SMTP. The existing RC automation
+  smoke covers execution-log behavior with the default mock channel;
+  repeat-fire automation-log soak remains Lane D4.
+
+## Files
+
+| Path | Purpose |
+| --- | --- |
+| `scripts/ops/multitable-phase3-release-gate.mjs` | Adds `email:real-send` routing and delegate execution. |
+| `scripts/ops/multitable-phase3-release-gate-report.mjs` | Renders delegated command and child report paths. |
+| `scripts/ops/multitable-phase3-release-gate.test.mjs` | Covers delegate BLOCKED behavior, aggregate child count, and SMTP redaction. |
+| `docs/development/multitable-feishu-phase3-ai-hardening-todo-20260514.md` | Updates Phase 0 / D0 status and D1 aggregation notes. |
+| `docs/development/multitable-phase3-real-smtp-gate-development-20260514.md` | This design and implementation record. |
+| `docs/development/multitable-phase3-real-smtp-gate-verification-20260514.md` | Verification evidence. |
+
+## Stage-1 Lock Compliance
+
+- No changes under `plugins/plugin-integration-core/*`.
+- No changes under K3 adapter paths.
+- No new AI or industry-template product surface.
+- No staging or live SMTP credentials recorded.
+- Real-send remains opt-in through explicit env confirmation.

--- a/docs/development/multitable-phase3-real-smtp-gate-verification-20260514.md
+++ b/docs/development/multitable-phase3-real-smtp-gate-verification-20260514.md
@@ -1,0 +1,211 @@
+# Multitable Phase 3 Real SMTP Gate - Verification
+
+Date: 2026-05-14
+
+## Summary
+
+Result: PASS for the D1 aggregation slice.
+
+This verification proves that `email:real-send` is now visible to the
+Phase 3 release gate, delegates to the existing guarded SMTP smoke,
+returns BLOCKED in a clean environment, and does not leak SMTP or
+recipient values into the Phase 3 wrapper artifacts.
+
+No real SMTP credentials were used and no real email was sent.
+
+## Environment
+
+- Worktree: `/private/tmp/ms2-phase3-d1-email-gate-20260514`
+- Base: `origin/main@a92189533`
+- Branch: `codex/multitable-phase3-d1-email-gate-20260514`
+- Dependency note: this temporary worktree required
+  `pnpm install --frozen-lockfile --ignore-scripts` before running the
+  existing TSX-based email smoke tests. Generated dependency-link
+  noise under `plugins/` and `tools/` was restored before commit.
+
+## Focused Tests
+
+### Phase 3 Release Gate
+
+Command:
+
+```bash
+node --test scripts/ops/multitable-phase3-release-gate.test.mjs
+```
+
+Result:
+
+```text
+tests 15
+pass 15
+fail 0
+```
+
+Covered:
+
+- `email:real-send` delegates to
+  `pnpm verify:multitable-email:real-send`.
+- `email:real-send` exits 2 / BLOCKED by default.
+- `release:phase3` now has four child gates.
+- Aggregate BLOCKED still exits 2 and does not collapse into FAIL.
+- SMTP host/user/password/from and smoke recipient values are redacted
+  from wrapper stdout, stderr, JSON, and Markdown artifacts.
+
+### Report Writer
+
+Command:
+
+```bash
+node --test scripts/ops/multitable-phase3-release-gate-report.test.mjs
+```
+
+Result:
+
+```text
+tests 5
+pass 5
+fail 0
+```
+
+Covered:
+
+- schema stamping
+- secret redaction
+- Markdown rendering for delegated command and children
+- disk write redaction
+
+### Existing Email Real-Send Smoke
+
+Command:
+
+```bash
+node --test scripts/ops/multitable-email-real-send-smoke.test.mjs
+```
+
+Result:
+
+```text
+tests 4
+pass 4
+fail 0
+```
+
+This confirms the delegated child harness behavior remains unchanged.
+
+## End-to-End Gate Checks
+
+### Direct D1 Gate
+
+Command:
+
+```bash
+node scripts/ops/multitable-phase3-release-gate.mjs \
+  --gate email:real-send \
+  --output-dir /tmp/ms2-d1-email-real-send-gate
+```
+
+Result:
+
+```text
+exit=2
+[multitable-phase3-release-gate] gate=email:real-send status=blocked exit=2
+```
+
+Report excerpt:
+
+```json
+{
+  "gate": "email:real-send",
+  "status": "blocked",
+  "exitCode": 2,
+  "delegatedCommand": "pnpm verify:multitable-email:real-send",
+  "childExitCode": 2,
+  "childStatus": "blocked",
+  "childMode": "mock"
+}
+```
+
+### Aggregate Release Gate
+
+Command:
+
+```bash
+node scripts/ops/multitable-phase3-release-gate.mjs \
+  --gate release:phase3 \
+  --output-dir /tmp/ms2-d1-release-phase3
+```
+
+Result:
+
+```text
+exit=2
+[multitable-phase3-release-gate] gate=release:phase3 status=blocked exit=2
+```
+
+The aggregate report now lists four children:
+
+```text
+email:real-send        blocked 2
+perf:large-table       blocked 2
+permissions:matrix     blocked 2
+automation:soak        blocked 2
+```
+
+### Existing Package Script
+
+Command:
+
+```bash
+pnpm verify:multitable-email:real-send
+```
+
+Result in a clean environment:
+
+```text
+exit=2
+Status: blocked
+Mode: mock
+```
+
+The child harness blocks because no SMTP mode, explicit send
+confirmation, or dedicated smoke recipient was configured.
+
+### Aggregate Package Script
+
+Command:
+
+```bash
+pnpm verify:multitable-release:phase3
+```
+
+Result:
+
+```text
+exit=2
+[multitable-phase3-release-gate] gate=release:phase3 status=blocked exit=2
+```
+
+This is expected until the remaining active/deferred child gates are
+implemented or explicitly configured.
+
+## Secret Handling
+
+No real SMTP credential, bearer token, JWT, webhook URL, or recipient
+address appears in this document.
+
+The new artifact-integrity test injects fake SMTP host/user/password,
+from-address, and smoke-recipient values into `email:real-send`, then
+asserts those literal values do not appear in:
+
+- stdout
+- stderr
+- Phase 3 wrapper `report.json`
+- Phase 3 wrapper `report.md`
+
+## Known Remaining Work
+
+- The TODO item "Tie send result to automation execution log" is not
+  claimed by this transport-level aggregation slice. D4 remains the
+  appropriate lane for real automation-log soak semantics.
+- `perf:large-table`, `permissions:matrix`, and `automation:soak`
+  remain BLOCKED child gates by design.

--- a/scripts/ops/multitable-phase3-release-gate-report.mjs
+++ b/scripts/ops/multitable-phase3-release-gate-report.mjs
@@ -31,6 +31,9 @@ export function renderMarkdown(report) {
   if (report.completedAt) lines.push(`- Completed at: \`${report.completedAt}\``)
   if (report.deferral) lines.push(`- Deferral: ${report.deferral}`)
   if (report.reason) lines.push(`- Reason: ${report.reason}`)
+  if (report.delegatedCommand) lines.push(`- Delegated command: \`${report.delegatedCommand}\``)
+  if (report.childReportJson) lines.push(`- Child JSON report: \`${report.childReportJson}\``)
+  if (report.childReportMd) lines.push(`- Child Markdown report: \`${report.childReportMd}\``)
 
   if (Array.isArray(report.requiredEnv) && report.requiredEnv.length) {
     lines.push('', '## Required env', '')
@@ -41,9 +44,17 @@ export function renderMarkdown(report) {
     for (const name of report.missingEnv) lines.push(`- \`${name}\``)
   }
   if (Array.isArray(report.children) && report.children.length) {
-    lines.push('', '## Children', '', '| Gate | Status | Exit code |', '| --- | --- | ---: |')
+    lines.push(
+      '',
+      '## Children',
+      '',
+      '| Gate | Status | Exit code | Delegated command | Child JSON report |',
+      '| --- | --- | ---: | --- | --- |',
+    )
     for (const child of report.children) {
-      lines.push(`| \`${child.gate}\` | ${child.status} | ${child.exitCode} |`)
+      lines.push(
+        `| \`${child.gate}\` | ${child.status} | ${child.exitCode} | ${child.delegatedCommand ? `\`${child.delegatedCommand}\`` : ''} | ${child.childReportJson ? `\`${child.childReportJson}\`` : ''} |`,
+      )
     }
   }
   return `${lines.join('\n')}\n`

--- a/scripts/ops/multitable-phase3-release-gate.mjs
+++ b/scripts/ops/multitable-phase3-release-gate.mjs
@@ -4,51 +4,71 @@
  * Phase 3 release gate skeleton.
  *
  * Routing + blocked-mode + shared redaction + JSON+MD report writer.
- * All sub-gates are blocked at this PR's stage (D0). Real harnesses
- * land in subsequent PRs (R3 D1 SMTP, R4 D4 automation soak). D2/D3
- * stay blocked under the K3 PoC stage-1 lock.
+ * D1 binds the existing guarded email real-send smoke into this
+ * aggregator. Remaining skeleton gates stay blocked until their
+ * dedicated follow-up PRs land. D2/D3 stay blocked under the K3 PoC
+ * stage-1 lock.
  *
  * Exit codes:
  *   0  PASS
  *   1  FAIL
  *   2  BLOCKED — never collapsed into FAIL.
  *
- * Email real-send is NOT routed here at D0; the existing
- * `verify:multitable-email:real-send` script (
- * `scripts/ops/multitable-email-real-send-smoke.ts`) is left untouched
- * and will be bound into the aggregator in PR R3.
+ * Email real-send is delegated to the existing
+ * `verify:multitable-email:real-send` script
+ * (`scripts/ops/multitable-email-real-send-smoke.ts`) so the Phase 3
+ * release gate has a single GO/NO-GO aggregation surface without
+ * duplicating SMTP send logic.
  *
  * See:
  *   docs/development/multitable-feishu-phase3-ai-hardening-plan-20260514.md
  *   docs/development/multitable-feishu-phase3-ai-hardening-review-20260514.md
  */
 
-import { mkdirSync } from 'node:fs'
+import { existsSync, mkdirSync, readFileSync } from 'node:fs'
+import { spawnSync } from 'node:child_process'
 import path from 'node:path'
 import { redactString } from './multitable-phase3-release-gate-redact.mjs'
 import { buildReport, writeReport } from './multitable-phase3-release-gate-report.mjs'
 
 const TOOL = 'multitable-phase3-release-gate'
 const DEFAULT_OUTPUT_DIR = 'output/multitable-phase3-release-gate'
+const EMAIL_REAL_SEND_GATE = 'email:real-send'
+const EMAIL_REAL_SEND_COMMAND = 'pnpm verify:multitable-email:real-send'
 
 const EXIT_PASS = 0
 const EXIT_FAIL = 1
 const EXIT_BLOCKED = 2
 
 const SUB_GATES = {
+  [EMAIL_REAL_SEND_GATE]: {
+    kind: 'delegate',
+    requiredEnv: [
+      'MULTITABLE_EMAIL_TRANSPORT',
+      'MULTITABLE_EMAIL_REAL_SEND_SMOKE',
+      'CONFIRM_SEND_EMAIL',
+      'MULTITABLE_EMAIL_SMOKE_TO',
+    ],
+    deferral: 'D1 — Real SMTP Gate',
+    blockedReason:
+      'Lane D1 delegates to verify:multitable-email:real-send and stays BLOCKED until SMTP mode, explicit real-send smoke, explicit send confirmation, and a dedicated test recipient are configured.',
+  },
   'perf:large-table': {
+    kind: 'skeleton',
     requiredEnv: ['MULTITABLE_PERF_LARGE_TABLE_CONFIRM', 'MULTITABLE_PERF_TARGET_DB'],
     deferral: 'D2 — Large Table Performance Gate',
     blockedReason:
       'Lane D2 deferred under K3 PoC stage-1 lock. Requires K3-free staging plus T4 closure before activation.',
   },
   'permissions:matrix': {
+    kind: 'skeleton',
     requiredEnv: ['MULTITABLE_PERM_MATRIX_CONFIRM'],
     deferral: 'D3 — Permission Matrix Gate',
     blockedReason:
       'Lane D3 deferred. Requires explicit snapshot-vs-golden-matrix semantics decision (T5) before activation.',
   },
   'automation:soak': {
+    kind: 'skeleton',
     requiredEnv: ['MULTITABLE_AUTOMATION_SOAK_CONFIRM'],
     deferral: 'D4 — Automation Soak Gate',
     blockedReason:
@@ -63,8 +83,9 @@ function printHelp() {
   console.log(`Usage: node scripts/ops/multitable-phase3-release-gate.mjs --gate <id> [options]
 
 Runs the Phase 3 release gate skeleton. All sub-gates are blocked at
-the D0 PR stage; only routing, redaction, and report writing are
-exercised.
+the D0/D1 PR stage unless their real harness is explicitly wired and
+configured. D1 delegates \`email:real-send\` to the existing guarded
+SMTP smoke harness.
 
 Gates:
   ${PUBLIC_GATES.map((g) => `\`${g}\``).join(', ')}
@@ -145,8 +166,108 @@ function parseArgs(argv) {
   return opts
 }
 
-function runSubGate(gate, env) {
+function statusFromExitCode(exitCode) {
+  if (exitCode === EXIT_PASS) return 'pass'
+  if (exitCode === EXIT_BLOCKED) return 'blocked'
+  return 'fail'
+}
+
+function keepProcessEnvForChild(env, extraEnv) {
+  const passthroughKeys = [
+    'PATH',
+    'HOME',
+    'USER',
+    'LOGNAME',
+    'SHELL',
+    'TMPDIR',
+    'TEMP',
+    'TMP',
+    'NODE_OPTIONS',
+    'PNPM_HOME',
+    'COREPACK_HOME',
+  ]
+  const childEnv = {}
+  for (const key of passthroughKeys) {
+    if (process.env[key]) childEnv[key] = process.env[key]
+  }
+  return {
+    ...childEnv,
+    ...env,
+    ...extraEnv,
+  }
+}
+
+function safeReadJson(file) {
+  if (!existsSync(file)) return null
+  try {
+    return JSON.parse(readFileSync(file, 'utf8'))
+  } catch {
+    return null
+  }
+}
+
+function runEmailRealSendGate(env, options = {}) {
+  const config = SUB_GATES[EMAIL_REAL_SEND_GATE]
+  const startedAt = new Date().toISOString()
+  const outputDir =
+    options.outputDir ??
+    path.resolve(process.cwd(), DEFAULT_OUTPUT_DIR, EMAIL_REAL_SEND_GATE.replace(/:/g, '-'))
+  const childDir = path.join(outputDir, 'real-send-smoke')
+  const childReportJson = path.join(childDir, 'report.json')
+  const childReportMd = path.join(childDir, 'report.md')
+  mkdirSync(childDir, { recursive: true })
+
+  const child = spawnSync('pnpm', ['verify:multitable-email:real-send'], {
+    cwd: options.cwd ?? process.cwd(),
+    env: keepProcessEnvForChild(env, {
+      EMAIL_REAL_SEND_JSON: childReportJson,
+      EMAIL_REAL_SEND_MD: childReportMd,
+    }),
+    encoding: 'utf8',
+  })
+
+  const childExitCode = typeof child.status === 'number' ? child.status : EXIT_FAIL
+  const status = child.error ? 'fail' : statusFromExitCode(childExitCode)
+  const exitCode = status === 'pass' ? EXIT_PASS : status === 'blocked' ? EXIT_BLOCKED : EXIT_FAIL
+  const childReport = safeReadJson(childReportJson)
+  const missingEnv = config.requiredEnv.filter((name) => !env[name] || env[name] === '')
+
+  let reason = 'Real SMTP send smoke passed.'
+  if (child.error) {
+    reason = `Failed to launch delegated real-send smoke: ${child.error.message}`
+  } else if (status === 'blocked') {
+    reason =
+      'Delegated real-send smoke is BLOCKED. Configure SMTP mode, explicit real-send smoke, explicit send confirmation, and a dedicated test recipient before treating this gate as GO.'
+  } else if (status === 'fail') {
+    reason = 'Delegated real-send smoke returned FAIL.'
+  }
+
+  return {
+    tool: TOOL,
+    gate: EMAIL_REAL_SEND_GATE,
+    status,
+    exitCode,
+    reason,
+    requiredEnv: config.requiredEnv,
+    missingEnv,
+    deferral: config.deferral,
+    startedAt,
+    completedAt: new Date().toISOString(),
+    delegatedCommand: EMAIL_REAL_SEND_COMMAND,
+    childExitCode,
+    childReportJson,
+    childReportMd,
+    childStatus: childReport?.status ?? status,
+    childOk: childReport?.ok ?? status === 'pass',
+    childMode: childReport?.mode,
+    childNotificationStatus: childReport?.notificationStatus,
+    childFailedReason: childReport?.failedReason,
+  }
+}
+
+function runSubGate(gate, env, options = {}) {
   const config = SUB_GATES[gate]
+  if (gate === EMAIL_REAL_SEND_GATE) return runEmailRealSendGate(env, options)
   const startedAt = new Date().toISOString()
   const missingEnv = config.requiredEnv.filter((name) => !env[name] || env[name] === '')
   const baseReport = {
@@ -174,16 +295,25 @@ function runSubGate(gate, env) {
   }
 }
 
-function runAggregate(env) {
+function runAggregate(env, options = {}) {
   const startedAt = new Date().toISOString()
   const children = []
   for (const gate of Object.keys(SUB_GATES)) {
-    const child = runSubGate(gate, env)
+    const childOutputDir = options.outputDir
+      ? path.join(options.outputDir, 'children', gate.replace(/:/g, '-'))
+      : undefined
+    const child = runSubGate(gate, env, {
+      ...options,
+      outputDir: childOutputDir,
+    })
     children.push({
       gate: child.gate,
       status: child.status,
       exitCode: child.exitCode,
       deferral: child.deferral,
+      delegatedCommand: child.delegatedCommand,
+      childReportJson: child.childReportJson,
+      childReportMd: child.childReportMd,
     })
   }
   const anyFail = children.some((c) => c.status === 'fail')
@@ -214,15 +344,18 @@ function runAggregate(env) {
   }
 }
 
-export function executeGate(gate, env) {
-  if (gate === AGGREGATE_GATE) return runAggregate(env)
-  return runSubGate(gate, env)
+export function executeGate(gate, env, options = {}) {
+  if (gate === AGGREGATE_GATE) return runAggregate(env, options)
+  return runSubGate(gate, env, options)
 }
 
 function main(argv) {
   const opts = parseArgs(argv)
   mkdirSync(opts.outputDir, { recursive: true })
-  const result = executeGate(opts.gate, process.env)
+  const result = executeGate(opts.gate, process.env, {
+    cwd: process.cwd(),
+    outputDir: opts.outputDir,
+  })
   const report = buildReport(result)
   writeReport({ outputJson: opts.outputJson, outputMd: opts.outputMd, report })
   const summary = redactString(

--- a/scripts/ops/multitable-phase3-release-gate.test.mjs
+++ b/scripts/ops/multitable-phase3-release-gate.test.mjs
@@ -21,6 +21,16 @@ function runGate(gate, { env = {}, allowBlocked = false } = {}) {
     'MULTITABLE_PERF_TARGET_DB',
     'MULTITABLE_PERM_MATRIX_CONFIRM',
     'MULTITABLE_AUTOMATION_SOAK_CONFIRM',
+    'MULTITABLE_EMAIL_TRANSPORT',
+    'MULTITABLE_EMAIL_SMTP_HOST',
+    'MULTITABLE_EMAIL_SMTP_PORT',
+    'MULTITABLE_EMAIL_SMTP_USER',
+    'MULTITABLE_EMAIL_SMTP_PASSWORD',
+    'MULTITABLE_EMAIL_SMTP_FROM',
+    'MULTITABLE_EMAIL_REAL_SEND_SMOKE',
+    'CONFIRM_SEND_EMAIL',
+    'MULTITABLE_EMAIL_SMOKE_TO',
+    'MULTITABLE_EMAIL_SMOKE_SUBJECT',
   ]) {
     if (!(key in env)) delete childEnv[key]
   }
@@ -73,17 +83,23 @@ test('executeGate (in-process) still blocks even when env is present at D0', () 
 })
 
 test('executeGate aggregator returns BLOCKED, never FAIL, when children are blocked', () => {
-  const result = executeGate('release:phase3', {})
-  assert.equal(result.status, 'blocked')
-  assert.equal(result.exitCode, 2)
-  assert.notEqual(result.status, 'fail', 'aggregator status must not be fail')
-  assert.notEqual(result.exitCode, 1, 'aggregator must not collapse BLOCKED into FAIL=1')
-  assert.equal(result.children.length, 3)
-  assert.ok(result.children.every((c) => c.status === 'blocked'))
-  assert.ok(result.children.every((c) => c.exitCode === 2))
-  // The reason text explicitly references both BLOCKED and FAIL to document the
-  // non-collapse rule; substring guard is intentionally narrow.
-  assert.match(result.reason, /BLOCKED/)
+  const dir = mkdtempSync(path.join(tmpdir(), 'mt-phase3-gate-inproc-'))
+  try {
+    const result = executeGate('release:phase3', {}, { outputDir: dir })
+    assert.equal(result.status, 'blocked')
+    assert.equal(result.exitCode, 2)
+    assert.notEqual(result.status, 'fail', 'aggregator status must not be fail')
+    assert.notEqual(result.exitCode, 1, 'aggregator must not collapse BLOCKED into FAIL=1')
+    assert.equal(result.children.length, 4)
+    assert.ok(result.children.some((c) => c.gate === 'email:real-send'))
+    assert.ok(result.children.every((c) => c.status === 'blocked'))
+    assert.ok(result.children.every((c) => c.exitCode === 2))
+    // The reason text explicitly references both BLOCKED and FAIL to document the
+    // non-collapse rule; substring guard is intentionally narrow.
+    assert.match(result.reason, /BLOCKED/)
+  } finally {
+    cleanup(dir)
+  }
 })
 
 test('perf:large-table exits 2 (blocked) by default via spawn', () => {
@@ -122,6 +138,24 @@ test('automation:soak exits 2 (blocked) by default via spawn', () => {
   }
 })
 
+test('email:real-send delegates to the existing real-send smoke and exits 2 (blocked) by default via spawn', () => {
+  const r = runGate('email:real-send')
+  try {
+    assert.equal(r.exitCode, 2)
+    const obj = JSON.parse(r.json)
+    assert.equal(obj.status, 'blocked')
+    assert.equal(obj.exitCode, 2)
+    assert.equal(obj.delegatedCommand, 'pnpm verify:multitable-email:real-send')
+    assert.equal(obj.childExitCode, 2)
+    assert.equal(obj.childStatus, 'blocked')
+    assert.match(obj.childReportJson, /real-send-smoke\/report\.json$/)
+    assert.match(obj.childReportMd, /real-send-smoke\/report\.md$/)
+    assert.ok(obj.missingEnv.includes('MULTITABLE_EMAIL_SMOKE_TO'))
+  } finally {
+    cleanup(r.dir)
+  }
+})
+
 test('release:phase3 aggregator exits 2 (blocked) not 1 (fail) via spawn', () => {
   const r = runGate('release:phase3')
   try {
@@ -129,7 +163,11 @@ test('release:phase3 aggregator exits 2 (blocked) not 1 (fail) via spawn', () =>
     const obj = JSON.parse(r.json)
     assert.equal(obj.status, 'blocked')
     assert.equal(obj.exitCode, 2)
-    assert.ok(Array.isArray(obj.children) && obj.children.length === 3)
+    assert.ok(Array.isArray(obj.children) && obj.children.length === 4)
+    const emailChild = obj.children.find((c) => c.gate === 'email:real-send')
+    assert.ok(emailChild)
+    assert.equal(emailChild.delegatedCommand, 'pnpm verify:multitable-email:real-send')
+    assert.match(emailChild.childReportJson, /children\/email-real-send\/real-send-smoke\/report\.json$/)
     assert.ok(obj.children.every((c) => c.status === 'blocked' && c.exitCode === 2))
     assert.match(obj.reason, /BLOCKED/)
   } finally {
@@ -195,6 +233,32 @@ test('artifact integrity — release:phase3 aggregator does not leak env-supplie
     assert.doesNotMatch(all, /sk-aggregatorleak1234567890abcdef/)
     assert.doesNotMatch(all, /aggregatorClientSecretValue/)
     assert.doesNotMatch(all, /aggregatorSmtpPw/)
+  } finally {
+    cleanup(r.dir)
+  }
+})
+
+test('artifact integrity — email:real-send delegate output paths and summary do not leak env-supplied SMTP values', () => {
+  const env = {
+    MULTITABLE_EMAIL_TRANSPORT: 'smtp',
+    MULTITABLE_EMAIL_SMTP_HOST: 'smtp.email-gate-private.example.com',
+    MULTITABLE_EMAIL_SMTP_PORT: '70000',
+    MULTITABLE_EMAIL_SMTP_USER: 'email-gate-private-user',
+    MULTITABLE_EMAIL_SMTP_PASSWORD: 'emailGatePrivatePw99',
+    MULTITABLE_EMAIL_SMTP_FROM: 'email-gate-from-address',
+    MULTITABLE_EMAIL_REAL_SEND_SMOKE: '1',
+    CONFIRM_SEND_EMAIL: '1',
+    MULTITABLE_EMAIL_SMOKE_TO: 'email-gate-to-address',
+  }
+  const r = runGate('email:real-send', { env })
+  try {
+    assert.equal(r.exitCode, 2)
+    const all = `${r.stdout}\n${r.stderr}\n${r.json ?? ''}\n${r.md ?? ''}`
+    assert.doesNotMatch(all, /smtp\.email-gate-private\.example\.com/)
+    assert.doesNotMatch(all, /email-gate-private-user/)
+    assert.doesNotMatch(all, /emailGatePrivatePw99/)
+    assert.doesNotMatch(all, /email-gate-from-address/)
+    assert.doesNotMatch(all, /email-gate-to-address/)
   } finally {
     cleanup(r.dir)
   }


### PR DESCRIPTION
## Summary

- Add `email:real-send` to the Phase 3 release gate aggregator.
- Delegate the gate to the existing guarded `pnpm verify:multitable-email:real-send` harness instead of duplicating SMTP send logic.
- Record delegated command + child report paths in JSON/Markdown release-gate artifacts.
- Update Phase 3 TODO and add D1 development / verification MDs.

## Scope note

This is the D1 transport-level aggregation slice. It preserves the existing explicit real-send guards and does not send real email unless SMTP mode, `MULTITABLE_EMAIL_REAL_SEND_SMOKE=1`, `CONFIRM_SEND_EMAIL=1`, and a dedicated `MULTITABLE_EMAIL_SMOKE_TO` recipient are configured.

The TODO item for tying real SMTP send results to automation execution-log persistence is intentionally not claimed here; D4 remains the correct lane for automation soak semantics.

## Verification

- `node --test scripts/ops/multitable-phase3-release-gate.test.mjs scripts/ops/multitable-phase3-release-gate-report.test.mjs scripts/ops/multitable-email-real-send-smoke.test.mjs` → 24/24 pass
- `node scripts/ops/multitable-phase3-release-gate.mjs --gate email:real-send --output-dir /tmp/ms2-d1-email-real-send-gate` → exit 2 / BLOCKED in clean env
- `node scripts/ops/multitable-phase3-release-gate.mjs --gate release:phase3 --output-dir /tmp/ms2-d1-release-phase3` → exit 2 / BLOCKED with four children
- `pnpm verify:multitable-email:real-send` → exit 2 / BLOCKED in clean env
- `pnpm verify:multitable-release:phase3` → exit 2 / BLOCKED by design
- `git diff --check origin/main..HEAD -- <changed files>` → clean
- Secret scan over changed diff for bearer/JWT/sk/SEC/password/token/webhook/email-like values → clean

## Docs

- `docs/development/multitable-phase3-real-smtp-gate-development-20260514.md`
- `docs/development/multitable-phase3-real-smtp-gate-verification-20260514.md`
