### PR TITLE
test(multitable): bind email real-send into phase3 release gate

### DIFF
--- a/docs/development/multitable-phase3-email-bridge-development-20260514.md
+++ b/docs/development/multitable-phase3-email-bridge-development-20260514.md
@@ -1,0 +1,210 @@
+# Multitable Feishu Phase 3 — D1 Email Bridge (Development)
+
+- Date: 2026-05-14
+- Branch: `codex/multitable-phase3-email-bridge-20260514`
+- Base: `origin/main` at `a92189533` (after #1541 D0 skeleton)
+- Author: Claude (Opus 4.7, 1M context), interactive harness; operator-supervised
+- PR sequence anchor: PR R3 per
+  `docs/development/multitable-feishu-phase3-ai-hardening-plan-20260514.md`
+  § Suggested PR Sequence (active queue)
+- Redaction policy: this PR contains no AI provider key, SMTP
+  credential, JWT, bearer token, DingTalk webhook URL or robot
+  `SEC...`, K3 endpoint password, Agent ID value, recipient user id,
+  temporary password, or `.env` content. The bridge introduces an
+  additional redaction layer over the email sub-gate's stdout /
+  stderr / report fields as defense-in-depth.
+
+## What this PR ships
+
+Binds the existing `verify:multitable-email:real-send` package script
+(which runs `tsx scripts/ops/multitable-email-real-send-smoke.ts`)
+into the Phase 3 release-gate aggregator as the `email:real-send`
+sub-gate. The bridge is **fail-closed**: only `exit=0` + `status=pass`
++ `ok=true` maps to PASS, only `exit=2` + `status=blocked` maps to
+BLOCKED; every other shape — including missing report, parse
+failure, exit/status mismatch, spawn error, signal kill — maps to
+FAIL.
+
+The aggregator now has four children: `email:real-send` plus the
+three D0 stubs (`perf:large-table`, `permissions:matrix`,
+`automation:soak`). When email PASS, the other three stay BLOCKED,
+and the aggregator correctly returns BLOCKED (exit 2) — it does
+**not** collapse a partial-pass to PASS.
+
+## What this PR explicitly does NOT do
+
+- Does **not** modify `scripts/ops/multitable-email-real-send-smoke.ts`,
+  `scripts/ops/multitable-email-transport-readiness.ts`, or the
+  underlying email transport modules.
+- Does **not** modify the existing `verify:multitable-email:readiness`
+  or `verify:multitable-email:real-send` package scripts.
+- Does **not** add a new `verify:multitable-*` package script for
+  `email:real-send`. The Phase 3 runner exposes `email:real-send` via
+  `--gate email:real-send` only, so the email sub-gate stays a single
+  source of truth even when invoked through the Phase 3 aggregator.
+- Does **not** touch `plugins/plugin-integration-core/*`,
+  `lib/adapters/k3-wise-*`, multitable runtime, OpenAPI source,
+  generated dist, migrations, routes, workflows.
+- Does **not** open a new product战线. Per the Activation Constraints
+  in the plan, R3 is kernel polish on the already-shipped
+  `multitable-email-real-send-smoke.ts` harness.
+
+## Hard constraints from PR R3 design review
+
+The bridge implementation honors four pre-implementation constraints
+articulated by the operator:
+
+### Constraint #1 — spawn via package script
+
+`defaultRunScript` spawns `pnpm verify:multitable-email:real-send`,
+**never** `tsx scripts/ops/...` directly. Rationale: routes through
+the existing package script so the aggregator does not drift when
+the email script's path or executor changes (e.g., if `tsx` is
+replaced by `tsx --experimental-strip-types` or the script is
+relocated).
+
+### Constraint #2 — independent output paths
+
+The bridge injects `EMAIL_REAL_SEND_JSON=<phase3-out>/children/email-real-send/report.json`
+and `EMAIL_REAL_SEND_MD=<phase3-out>/children/email-real-send/report.md`
+into the child process env. The existing email script reads these
+env vars to override its default output location at
+`output/multitable-email-real-send-smoke/`. Effect: each Phase 3
+aggregator run gets its own child report, eliminating stale-report
+and concurrent-overwrite risks.
+
+### Constraint #3 — fail-closed status translation
+
+Strict matching with sourceExitCode + sourceStatus + sourceOk
+required:
+
+| sourceExitCode | sourceStatus | sourceOk | Bridge outcome |
+| --- | --- | --- | --- |
+| `0` | `'pass'` | `true` | **pass** (exit 0) |
+| `2` | `'blocked'` | any | **blocked** (exit 2) |
+| any other shape | — | — | **fail** (exit 1) |
+
+Specifically every one of these maps to fail-closed:
+
+- Missing `report.json` (script crashed before writing).
+- `report.json` present but malformed JSON.
+- Mismatched signals (`exit=0` + `status=blocked`, `exit=2` +
+  `status=pass`, `exit=0` + `status=pass` + `ok=false`, etc.).
+- `spawnSync` throws synchronously.
+- `spawnSync` returns `result.error` (e.g., `ENOENT` for missing
+  pnpm).
+- Process killed by signal (`exit` is `null` or `undefined`).
+
+In every fail-closed case, the bridge result preserves
+`sourceExitCode`, `sourceStatus`, `sourceReportPath` for diagnostic
+purposes, but only **redacted** stdout / stderr samples (1200-char
+cap) appear in the bridge result — never raw stream content.
+
+### Constraint #4 — real SMTP env name redaction
+
+The bridge's redaction layer covers the project's actual env names
+consumed by `multitable-email-real-send-smoke.ts`:
+
+- `MULTITABLE_EMAIL_SMTP_HOST` / `USER` / `PASSWORD` / `PORT` / `FROM`
+- `MULTITABLE_EMAIL_SMOKE_TO` / `SUBJECT`
+- `CONFIRM_SEND_EMAIL` (via generic `*_PASSWORD` family — covered by
+  D0 redactor)
+
+The D0 redactor (`multitable-phase3-release-gate-redact.mjs`) was
+patched in PR #1541's follow-up commit to handle these env names.
+This PR adds bridge-side tests proving the protection holds end-to-
+end: artifact-integrity tests inject these env names into a spawned
+gate run and assert none of the original values appear in
+`stdout / stderr / report.json / report.md` of either the email
+sub-gate alone or the aggregator path.
+
+## File inventory
+
+| Path | Lines | Purpose |
+| --- | --- | --- |
+| `scripts/ops/multitable-phase3-release-gate-email-bridge.mjs` | ~190 | Bridge — spawn + status translate + redact + fail-closed. |
+| `scripts/ops/multitable-phase3-release-gate-email-bridge.test.mjs` | ~270 | 16 tests covering pass / blocked / fail / 5 mismatch flavors / missing report / parse fail / spawn throws / spawn error / signal kill / disk writes / sample redaction / truncation. |
+| `scripts/ops/multitable-phase3-release-gate.mjs` | +60 | Imports bridge, adds `email:real-send` to PUBLIC_GATES, threads `outputDir` and `emailRunScript` through `executeGate`, runs email child first in aggregator, extracts `summarizeAggregateChildren`. |
+| `scripts/ops/multitable-phase3-release-gate.test.mjs` | +180 | Adds mock runScript helpers, multi-state aggregator tests, summarizer unit tests, standalone email-gate routing tests, outputDir requirement tests; spawn-based aggregator test gains a `node_modules/.bin/tsx`-presence skip guard. |
+| `docs/development/multitable-phase3-email-bridge-development-20260514.md` | this file | Development MD. |
+| `docs/development/multitable-phase3-email-bridge-verification-20260514.md` | sibling | Verification MD. |
+
+No change to `package.json`, no change to existing email scripts.
+
+## Aggregator state machine
+
+Children are evaluated in order `email:real-send` → `perf:large-table`
+→ `permissions:matrix` → `automation:soak`. Aggregate status comes
+from `summarizeAggregateChildren`:
+
+| Child mix | Aggregate status | Aggregate exit |
+| --- | --- | --- |
+| Any child FAIL | fail | 1 |
+| No FAIL, any BLOCKED | blocked | 2 |
+| Every child PASS | pass | 0 |
+
+Critical invariants (proven by tests):
+
+- A partial PASS (email pass + 3 BLOCKED) yields **BLOCKED**, not
+  PASS. Partial pass cannot collapse the aggregate to pass.
+- A child FAIL beats any number of BLOCKED. A failed child cannot
+  hide behind blocked siblings.
+- BLOCKED never collapses to FAIL.
+
+## CLI
+
+`email:real-send` is invokable as a standalone gate:
+
+```bash
+node scripts/ops/multitable-phase3-release-gate.mjs \
+  --gate email:real-send \
+  --output-dir /tmp/phase3-email
+```
+
+The aggregator continues to be invoked the usual way:
+
+```bash
+node scripts/ops/multitable-phase3-release-gate.mjs \
+  --gate release:phase3 \
+  --output-dir /tmp/phase3-aggregate
+```
+
+Both paths require `--output-dir` because the bridge writes child
+reports under `<output-dir>/children/email-real-send/`.
+
+## Stage-1 lock compliance
+
+| Check | Result |
+| --- | --- |
+| No change under `plugins/plugin-integration-core/*` | PASS |
+| No change under `lib/adapters/k3-wise-*` | PASS |
+| No new product战线 | PASS — kernel polish wraps an already-shipped script |
+| No schema / migration / route / workflow change | PASS |
+| No change to existing `verify:multitable-email:*` scripts | PASS |
+| No change to `multitable-email-{real-send-smoke,transport-readiness}.ts` | PASS |
+| No new package script (no `verify:multitable-phase3:email:*`) | PASS |
+| Email script bound only via fail-closed wrapper | PASS |
+
+## Cross-references
+
+- Phase 3 plan: `docs/development/multitable-feishu-phase3-ai-hardening-plan-20260514.md`
+  (Activation Constraints + Suggested PR Sequence active queue,
+  R2 → R3 → R4)
+- Phase 3 TODO: `docs/development/multitable-feishu-phase3-ai-hardening-todo-20260514.md`
+  (Lane D1 — Real SMTP Gate)
+- Phase 3 review: `docs/development/multitable-feishu-phase3-ai-hardening-review-20260514.md`
+- D0 skeleton (R2): merge commit `a92189533` (PR #1541)
+- Email script (NOT modified): `scripts/ops/multitable-email-real-send-smoke.ts`
+- Email readiness script (NOT modified): `scripts/ops/multitable-email-transport-readiness.ts`
+- Phase 3 redactor (was patched in #1541 follow-up):
+  `scripts/ops/multitable-phase3-release-gate-redact.mjs`
+
+## Follow-ups (not in this PR)
+
+- PR R4 — D4 automation soak gate: replace the `automation:soak`
+  blocked stub with a real `record.created` / `update_record` /
+  `send_email` / `send_webhook` repeat-fire harness, wired through
+  the same fail-closed bridge pattern.
+- D2 (perf large-table) and D3 (permission matrix) stay deferred
+  under stage-1 lock plus T4 / T5 closure, per Activation
+  Constraints in the plan.

--- a/docs/development/multitable-phase3-email-bridge-verification-20260514.md
+++ b/docs/development/multitable-phase3-email-bridge-verification-20260514.md
@@ -1,0 +1,351 @@
+# Multitable Feishu Phase 3 — D1 Email Bridge (Verification)
+
+- Date: 2026-05-14
+- Branch: `codex/multitable-phase3-email-bridge-20260514`
+- Base: `origin/main` at `a92189533` (after #1541 D0 skeleton)
+- Author: Claude (Opus 4.7, 1M context), interactive harness; operator-supervised
+- Companion: `multitable-phase3-email-bridge-development-20260514.md`
+- Redaction policy: this document contains no AI provider key, SMTP
+  credential, JWT, bearer token, DingTalk webhook URL or robot
+  `SEC...`, K3 endpoint password, recipient user id, temporary
+  password, or `.env` content.
+
+## Result
+
+**PASS / R3 bridge landing**.
+
+- **62 / 62 focused tests PASS** via `node --test`. (One additional
+  test skips locally with reason `requires node_modules/.bin/tsx`;
+  it runs in CI where `pnpm install` has already populated
+  `node_modules`.)
+- CLI end-to-end verification: all 5 gates produce structurally
+  correct artifacts. Without `pnpm install` in the worktree, the
+  email-bridge path fail-closes to `exit=1, status=fail` — exactly
+  the design intent.
+- Four hard constraints from PR R3 review are all honored by the
+  shipping code.
+
+## V1 — Worktree provenance
+
+```bash
+git fetch origin main
+git worktree add /private/tmp/ms2-phase3-r3-20260514 \
+  -b codex/multitable-phase3-email-bridge-20260514 origin/main
+```
+
+Result: `HEAD is now at a92189533 test(multitable): add phase3
+release gate skeleton (#1541)`.
+
+## V2 — Focused tests
+
+```bash
+node --test \
+  scripts/ops/multitable-phase3-release-gate-redact.test.mjs \
+  scripts/ops/multitable-phase3-release-gate-report.test.mjs \
+  scripts/ops/multitable-phase3-release-gate-email-bridge.test.mjs \
+  scripts/ops/multitable-phase3-release-gate.test.mjs
+```
+
+Result:
+
+```text
+ℹ tests 63
+ℹ pass 62
+ℹ fail 0
+ℹ skipped 1
+ℹ duration_ms ~840
+```
+
+Test breakdown:
+
+- `multitable-phase3-release-gate-redact.test.mjs` — 19 tests
+  (unchanged from #1541 baseline plus its follow-up
+  `MULTITABLE_EMAIL_SMTP_*` and `MULTITABLE_EMAIL_SMOKE_*` patches).
+- `multitable-phase3-release-gate-report.test.mjs` — 5 tests
+  (unchanged from #1541).
+- `multitable-phase3-release-gate-email-bridge.test.mjs` — **16 tests
+  (new)**: EMAIL_SUB_GATE_ID export, outputDir requirement,
+  pass / blocked / fail mappings, 4 fail-closed mismatch flavors,
+  missing report.json, malformed JSON, spawn throws, spawn error,
+  signal kill (null exit), disk writes to `<outputDir>/children/`,
+  redaction of SMTP / Bearer / sk- sentinels in samples, 1200-char
+  truncation, source field preservation.
+- `multitable-phase3-release-gate.test.mjs` — 23 tests (was 14 in
+  #1541, **+9 net**): updated aggregator-blocked test for 4
+  children, new aggregator multi-state tests (email pass + 3
+  blocked → blocked; email fail + 3 blocked → fail), summarizer
+  unit tests (all-pass / fail-beats-blocked / pass-plus-blocked-but-
+  no-fail-stays-blocked), standalone email-gate routing (pass +
+  blocked cases), `executeGate` outputDir guard tests.
+
+The single skipped test is
+`release:phase3 aggregator exits 2 (blocked) not 1 (fail) via spawn —
+all 4 children blocked`. It is gated by
+`existsSync('node_modules/.bin/tsx')` because the spawn-based
+integration path requires the email script's runtime dependencies.
+It runs in CI where `pnpm install` precedes tests; it skips in fresh
+worktrees, with the skip reason printed inline.
+
+## V3 — CLI end-to-end exit codes (without `pnpm install`)
+
+```bash
+for gate in 'release:phase3' 'email:real-send' 'perf:large-table' 'permissions:matrix' 'automation:soak'; do
+  node scripts/ops/multitable-phase3-release-gate.mjs --gate "$gate" \
+    --output-dir /tmp/r3-verify-"${gate//:/-}" >/dev/null 2>&1
+  echo "  --gate $gate => exit=$?"
+done
+```
+
+Result:
+
+```text
+--gate release:phase3 => exit=1
+--gate email:real-send => exit=1
+--gate perf:large-table => exit=2
+--gate permissions:matrix => exit=2
+--gate automation:soak => exit=2
+```
+
+Interpretation:
+
+- `email:real-send` exits `1` (fail) because the worktree has no
+  `node_modules` — the bridge spawns `pnpm verify:multitable-email:real-send`,
+  pnpm cannot find `tsx`, the email script never writes a
+  `report.json`, the bridge fail-closes per constraint #3.
+- `release:phase3` aggregator exits `1` (fail) because its
+  `email:real-send` child failed-closed; the aggregator correctly
+  propagates a child FAIL to aggregate FAIL.
+- The other three sub-gates exit `2` (blocked) per the D0 skeleton.
+
+In CI where `pnpm install` has run before tests, the email script
+will start, exit `2` with `status=blocked` (because real-send env
+vars are not set), the bridge will translate to blocked, and the
+aggregator will return `2` (blocked) — the BLOCKED-not-FAIL
+invariant from PR R2 (#1541) still holds when prerequisites are
+present.
+
+## V4 — Sample fail-closed artifact (no node_modules path)
+
+```bash
+cat /tmp/r3-verify-email-real-send/report.json
+```
+
+Result (verbatim, redaction-clean):
+
+```json
+{
+  "schemaVersion": 1,
+  "tool": "multitable-phase3-release-gate",
+  "gate": "email:real-send",
+  "status": "fail",
+  "exitCode": 1,
+  "reason": "Email script did not write a report.json at /tmp/r3-verify-email-real-send/children/email-real-send/report.json.",
+  "startedAt": "2026-05-14T07:39:22.764Z",
+  "completedAt": "2026-05-14T07:39:23.006Z",
+  "sourceExitCode": 1,
+  "sourceStatus": null,
+  "sourceReportPath": "/tmp/r3-verify-email-real-send/children/email-real-send/report.json",
+  "stdoutSample": "[pnpm boot text + ELIFECYCLE Command failed]",
+  "stderrSample": "sh: tsx: command not found"
+}
+```
+
+`sourceExitCode` preserved (`1` from pnpm's ELIFECYCLE exit),
+`sourceStatus` null (no report to parse), `sourceReportPath`
+recorded for forensics. `stdoutSample` and `stderrSample` are
+1200-char-capped and redacted. No env-supplied secret was ever fed
+into the email script (it never ran), so there is nothing to leak.
+
+## V5 — Sample aggregator artifact with 4 children
+
+```bash
+cat /tmp/r3-verify-release-phase3/report.json
+```
+
+Result (verbatim, abbreviated):
+
+```json
+{
+  "schemaVersion": 1,
+  "tool": "multitable-phase3-release-gate",
+  "gate": "release:phase3",
+  "status": "fail",
+  "exitCode": 1,
+  "reason": "One or more child sub-gates returned FAIL. Aggregator exits 1 (FAIL).",
+  "children": [
+    { "gate": "email:real-send", "status": "fail", "exitCode": 1, "deferral": null,
+      "sourceExitCode": 1, "sourceStatus": null },
+    { "gate": "perf:large-table", "status": "blocked", "exitCode": 2,
+      "deferral": "D2 — Large Table Performance Gate" },
+    { "gate": "permissions:matrix", "status": "blocked", "exitCode": 2,
+      "deferral": "D3 — Permission Matrix Gate" },
+    { "gate": "automation:soak", "status": "blocked", "exitCode": 2,
+      "deferral": "D4 — Automation Soak Gate" }
+  ]
+}
+```
+
+Four children present. Email child fails-closed (no node_modules in
+worktree); the other three remain blocked per the D0 plan.
+
+## V6 — Aggregator state machine invariants
+
+| Test | Result |
+| --- | --- |
+| All 4 children BLOCKED → aggregate BLOCKED (exit 2) | PASS (in-process with mock email runScript) |
+| Email PASS + 3 others BLOCKED → aggregate BLOCKED (NOT PASS) | PASS — partial pass never collapses |
+| Email FAIL + 3 others BLOCKED → aggregate FAIL (exit 1) | PASS — any FAIL beats BLOCKED |
+| `summarizeAggregateChildren` synthetic all-PASS → PASS | PASS |
+| `summarizeAggregateChildren` synthetic PASS + FAIL + BLOCKED → FAIL | PASS |
+| `summarizeAggregateChildren` synthetic PASS + BLOCKED → BLOCKED | PASS |
+
+## V7 — Fail-closed mapping invariants
+
+Bridge unit tests prove these mappings:
+
+| Mock source state | Bridge outcome | Test |
+| --- | --- | --- |
+| exit=0, status=pass, ok=true | pass (exit 0) | PASS |
+| exit=2, status=blocked | blocked (exit 2) | PASS |
+| exit=1, status=failed | fail (exit 1) | PASS |
+| exit=0, status=blocked (mismatch) | fail (exit 1) | PASS |
+| exit=2, status=pass (mismatch) | fail (exit 1) | PASS |
+| exit=0, status=pass, ok=false (mismatch) | fail (exit 1) | PASS |
+| Missing report.json | fail (exit 1) | PASS |
+| Malformed report.json | fail (exit 1) | PASS |
+| spawn throws | fail (exit 1) | PASS |
+| spawn returns result.error (ENOENT) | fail (exit 1) | PASS |
+| Null exit (signal kill) | fail (exit 1) | PASS |
+
+## V8 — Spawn command shape
+
+```bash
+grep -nE "spawnSync\\('pnpm'|spawnSync\\('tsx'" scripts/ops/multitable-phase3-release-gate-email-bridge.mjs
+```
+
+Result:
+
+```text
+scripts/ops/multitable-phase3-release-gate-email-bridge.mjs:48:  return spawnSync('pnpm', ['verify:multitable-email:real-send'], {
+```
+
+Constraint #1 verified: the bridge spawns `pnpm`, never `tsx`
+directly. The package script is the indirection point.
+
+## V9 — Output-path injection
+
+```bash
+grep -nE "EMAIL_REAL_SEND_JSON|EMAIL_REAL_SEND_MD" scripts/ops/multitable-phase3-release-gate-email-bridge.mjs
+```
+
+Result: 2 lines, both inside `defaultRunScript`, injecting the
+child-specific paths into the spawned process env.
+Constraint #2 verified.
+
+## V10 — Artifact integrity (real env names through bridge)
+
+The existing two artifact-integrity tests (introduced in #1541) plus
+the inline tests in this PR continue to pass after the bridge is
+wired in. Each injects:
+
+- `MULTITABLE_EMAIL_SMTP_HOST=smtp-aggregator-leak.example.com`
+- `MULTITABLE_EMAIL_SMTP_USER=aggregator-smtp-user`
+- `MULTITABLE_EMAIL_SMTP_PASSWORD=aggregatorSmtpPw88`
+- `MULTITABLE_EMAIL_SMTP_FROM=aggregator-from@example.com`
+- `MULTITABLE_EMAIL_SMOKE_TO=aggregator-to@example.com`
+
+into the spawned aggregator's env. After the run, `stdout + stderr +
+report.json + report.md` are concatenated and asserted to contain no
+original value substring. Even when the bridge fail-closes (no
+node_modules), there is no leak path because:
+
+- The bridge never copies env values into its own result fields.
+- `stdoutSample` / `stderrSample` from pnpm contain only pnpm
+  diagnostic text (ELIFECYCLE, "tsx: command not found"), none of
+  which echo env values.
+- Even hypothetical leaks via pnpm would pass through the bridge's
+  `compactSample` → `redactString` redaction layer (constraint #4,
+  defense-in-depth).
+
+Constraint #4 verified.
+
+## V11 — Existing email scripts untouched
+
+```bash
+git diff --cached -- scripts/ops/multitable-email-real-send-smoke.ts \
+                     scripts/ops/multitable-email-transport-readiness.ts \
+                     scripts/ops/multitable-email-real-send-smoke.test.mjs \
+                     scripts/ops/multitable-email-transport-readiness.test.mjs
+```
+
+Result: empty diff. Email-side files are untouched. The
+`verify:multitable-email:real-send` and
+`verify:multitable-email:readiness` package scripts in `package.json`
+are also unchanged.
+
+## V12 — Whitespace and conflict-marker check
+
+```bash
+git diff --cached --check
+```
+
+Result: clean (reported at staging time).
+
+## V13 — Secret-pattern scan
+
+```bash
+grep -rEn --include='*.mjs' --include='*.ts' --include='*.md' --include='*.json' \
+  '(SEC[A-Z0-9+/=_-]{8,}|Bearer[[:space:]]+[A-Za-z0-9._-]{20,}|eyJ[A-Za-z0-9._-]{20,}|sk-[A-Za-z0-9_-]{20,}|DINGTALK_CLIENT_SECRET[[:space:]]*=[[:space:]]*[A-Za-z][A-Za-z0-9_]+)' \
+  scripts/ops/multitable-phase3-release-gate*.mjs \
+  docs/development/multitable-phase3-email-bridge-*-20260514.md
+```
+
+Result: only `.test.mjs` fixture matches surface, all inside
+`assert.doesNotMatch(...)` / `assert.match(...)` clauses proving
+redaction. Same posture as #1541. No real provider key, robot SEC,
+JWT, SMTP password, or client secret is committed.
+
+## V14 — Stage-1 lock self-attestation
+
+| Check | Result |
+| --- | --- |
+| No change under `plugins/plugin-integration-core/*` | PASS |
+| No change under `lib/adapters/k3-wise-*` | PASS |
+| No new product战线 | PASS — wraps already-shipped email harness |
+| No schema / migration / route / workflow change | PASS |
+| No change to existing `verify:multitable-email:*` scripts | PASS |
+| No change to `multitable-email-{real-send-smoke,transport-readiness}.ts` | PASS |
+| No new `package.json` script | PASS — only `email:real-send` --gate routing added inside runner |
+| Kernel polish on shipped automation send_email path | PASS |
+
+## V15 — 142 production impact assessment
+
+Same as #1541: `scripts/ops/` paths are not copied into the
+Dockerfile.backend runner stage, so the runtime image's K3 PoC
+behavior is unaffected. The runtime image's `package.json` is the
+same as #1541's main HEAD `package.json` because R3 adds **no new
+package script** — only internal runner routing changes. Build will
+still re-push an image tagged with this PR's merge SHA, but the
+runtime contents are byte-identical to the previous image, and 142
+does not auto-pull, so the K3 PoC stable image stays in place
+unless the operator explicitly syncs.
+
+## Open follow-ups after this PR merges
+
+- PR R4 — D4 automation soak gate: replace the `automation:soak`
+  blocked stub with a real repeat-fire harness against shipped
+  automation actions, using the same fail-closed bridge pattern.
+- D2 / D3 stay deferred under stage-1 lock plus T4 / T5 closure.
+- Once a 142-side or staging-side SMTP target is provisioned with
+  proper CONFIRM_SEND_EMAIL guards, the email sub-gate can begin
+  returning real PASS signals — proving the aggregator can
+  partially-pass as designed.
+
+## Final verdict
+
+PASS. PR R3 binds the existing email-real-send harness into the
+Phase 3 aggregator via a fail-closed bridge that honors all four
+pre-implementation constraints from the design review. The bridge
+preserves source diagnostic fields, redacts samples, never modifies
+the email-side resources, and the aggregator's BLOCKED-vs-FAIL
+invariant continues to hold across the new state machine surface.

--- a/scripts/ops/multitable-phase3-release-gate-email-bridge.mjs
+++ b/scripts/ops/multitable-phase3-release-gate-email-bridge.mjs
@@ -1,0 +1,240 @@
+/**
+ * Phase 3 release-gate email:real-send bridge.
+ *
+ * Binds the existing `verify:multitable-email:real-send` package script
+ * (which itself runs `tsx scripts/ops/multitable-email-real-send-smoke.ts`)
+ * into the Phase 3 release-gate aggregator as the `email:real-send`
+ * sub-gate.
+ *
+ * Hard constraints from PR R3 design review:
+ *
+ * 1. Bridge spawns `pnpm verify:multitable-email:real-send`, never
+ *    `tsx scripts/ops/...` directly. This routes through the existing
+ *    package script, so aggregator does not drift when the email
+ *    script path or executor changes.
+ *
+ * 2. Bridge injects independent output paths via EMAIL_REAL_SEND_JSON
+ *    and EMAIL_REAL_SEND_MD env vars so the child report goes to
+ *    `<phase3-output>/children/email-real-send/report.{json,md}`,
+ *    never the default `output/multitable-email-real-send-smoke/`
+ *    location. Eliminates stale-report and concurrent-overwrite
+ *    risks.
+ *
+ * 3. Fail-closed status translation. Only two source-state shapes
+ *    map to non-fail outcomes:
+ *      - exit=0 AND status=pass AND ok=true        → pass (exit 0)
+ *      - exit=2 AND status=blocked                  → blocked (exit 2)
+ *    Every other shape — including missing report, parse failure,
+ *    exit/status mismatch, spawn error, signal-kill — maps to fail
+ *    (exit 1). sourceExitCode, sourceStatus, sourceReportPath are
+ *    preserved in the bridge result. stdout / stderr appear only as
+ *    redacted 1200-char samples, never as raw streams.
+ *
+ * 4. All sample text and structured fields run through the Phase 3
+ *    redactor before surfacing into the bridge result.
+ */
+
+import { existsSync, mkdirSync, readFileSync } from 'node:fs'
+import { spawnSync } from 'node:child_process'
+import path from 'node:path'
+
+import { redactString } from './multitable-phase3-release-gate-redact.mjs'
+
+export const EMAIL_SUB_GATE_ID = 'email:real-send'
+
+const SAMPLE_MAX_LENGTH = 1200
+const SPAWN_MAX_BUFFER = 20 * 1024 * 1024
+
+/**
+ * Default runScript implementation. Always spawns `pnpm <script>`,
+ * never `tsx` directly.
+ */
+export function defaultRunScript({ jsonPath, mdPath, env }) {
+  return spawnSync('pnpm', ['verify:multitable-email:real-send'], {
+    cwd: process.cwd(),
+    env: {
+      ...env,
+      EMAIL_REAL_SEND_JSON: jsonPath,
+      EMAIL_REAL_SEND_MD: mdPath,
+    },
+    encoding: 'utf8',
+    maxBuffer: SPAWN_MAX_BUFFER,
+  })
+}
+
+function compactSample(value) {
+  const redacted = redactString(value ?? '')
+  if (!redacted) return ''
+  return redacted.length > SAMPLE_MAX_LENGTH
+    ? `${redacted.slice(0, SAMPLE_MAX_LENGTH - 3)}...`
+    : redacted
+}
+
+function readSourceReport(jsonPath) {
+  if (!existsSync(jsonPath)) return { ok: false, report: null, parseError: null }
+  try {
+    const raw = readFileSync(jsonPath, 'utf8')
+    return { ok: true, report: JSON.parse(raw), parseError: null }
+  } catch (err) {
+    return {
+      ok: false,
+      report: null,
+      parseError: err instanceof Error ? err.message : String(err),
+    }
+  }
+}
+
+function buildBridgeResult({
+  gateLabel,
+  status,
+  exitCode,
+  reason,
+  startedAt,
+  sourceExitCode,
+  sourceStatus,
+  sourceReportPath,
+  stdoutSample,
+  stderrSample,
+}) {
+  return {
+    tool: 'multitable-phase3-release-gate',
+    gate: gateLabel,
+    status,
+    exitCode,
+    reason,
+    startedAt,
+    completedAt: new Date().toISOString(),
+    sourceExitCode,
+    sourceStatus,
+    sourceReportPath,
+    stdoutSample,
+    stderrSample,
+  }
+}
+
+/**
+ * Run the email real-send sub-gate. `runScript` is injectable for
+ * tests; in production it defaults to `defaultRunScript` which
+ * spawns `pnpm verify:multitable-email:real-send`.
+ */
+export function runEmailRealSendSubGate({
+  outputDir,
+  env = process.env,
+  runScript = defaultRunScript,
+}) {
+  if (!outputDir) {
+    throw new Error('runEmailRealSendSubGate: outputDir is required')
+  }
+  const startedAt = new Date().toISOString()
+  const childDir = path.resolve(outputDir, 'children/email-real-send')
+  const jsonPath = path.join(childDir, 'report.json')
+  const mdPath = path.join(childDir, 'report.md')
+  mkdirSync(childDir, { recursive: true })
+
+  const failClosed = (reason, partial = {}) =>
+    buildBridgeResult({
+      gateLabel: EMAIL_SUB_GATE_ID,
+      status: 'fail',
+      exitCode: 1,
+      reason,
+      startedAt,
+      sourceExitCode: partial.sourceExitCode ?? null,
+      sourceStatus: partial.sourceStatus ?? null,
+      sourceReportPath: jsonPath,
+      stdoutSample: partial.stdoutSample ?? '',
+      stderrSample: partial.stderrSample ?? '',
+    })
+
+  let result
+  try {
+    result = runScript({ jsonPath, mdPath, env })
+  } catch (err) {
+    return failClosed('Spawn error before email script could run.', {
+      stderrSample: compactSample(err instanceof Error ? err.message : String(err)),
+    })
+  }
+
+  if (result && result.error) {
+    return failClosed(
+      `Spawn returned an error: ${redactString(
+        result.error instanceof Error ? result.error.message : String(result.error),
+      )}`,
+      {
+        stdoutSample: compactSample(result.stdout),
+        stderrSample: compactSample(result.stderr || (result.error?.message ?? '')),
+        sourceExitCode: result.status ?? null,
+      },
+    )
+  }
+
+  const sourceExitCode = result?.status
+  const stdoutSample = compactSample(result?.stdout)
+  const stderrSample = compactSample(result?.stderr)
+
+  if (sourceExitCode === null || sourceExitCode === undefined) {
+    return failClosed(
+      'Email script exit code was null (killed by signal or spawn aborted).',
+      { stdoutSample, stderrSample },
+    )
+  }
+
+  const { ok: parseOk, report: sourceReport, parseError } = readSourceReport(jsonPath)
+
+  if (!parseOk || !sourceReport) {
+    const why = parseError
+      ? `Email script report.json failed to parse: ${redactString(parseError)}`
+      : `Email script did not write a report.json at ${jsonPath}.`
+    return failClosed(why, {
+      sourceExitCode,
+      stdoutSample,
+      stderrSample,
+    })
+  }
+
+  const sourceStatus = sourceReport.status ?? null
+  const sourceOk = sourceReport.ok
+
+  const passConsistent =
+    sourceExitCode === 0 && sourceStatus === 'pass' && sourceOk === true
+  const blockedConsistent = sourceExitCode === 2 && sourceStatus === 'blocked'
+
+  if (passConsistent) {
+    return buildBridgeResult({
+      gateLabel: EMAIL_SUB_GATE_ID,
+      status: 'pass',
+      exitCode: 0,
+      reason: 'Email real-send smoke passed (exit=0, status=pass, ok=true).',
+      startedAt,
+      sourceExitCode,
+      sourceStatus,
+      sourceReportPath: jsonPath,
+      stdoutSample,
+      stderrSample,
+    })
+  }
+  if (blockedConsistent) {
+    return buildBridgeResult({
+      gateLabel: EMAIL_SUB_GATE_ID,
+      status: 'blocked',
+      exitCode: 2,
+      reason:
+        'Email real-send smoke blocked (exit=2, status=blocked). Missing required env: MULTITABLE_EMAIL_TRANSPORT=smtp, MULTITABLE_EMAIL_REAL_SEND_SMOKE=1, CONFIRM_SEND_EMAIL=1, MULTITABLE_EMAIL_SMOKE_TO.',
+      startedAt,
+      sourceExitCode,
+      sourceStatus,
+      sourceReportPath: jsonPath,
+      stdoutSample,
+      stderrSample,
+    })
+  }
+
+  return failClosed(
+    `Fail-closed: source signals did not match pass or blocked contracts. exit=${sourceExitCode} status=${sourceStatus} ok=${sourceOk}.`,
+    {
+      sourceExitCode,
+      sourceStatus,
+      stdoutSample,
+      stderrSample,
+    },
+  )
+}

--- a/scripts/ops/multitable-phase3-release-gate-email-bridge.test.mjs
+++ b/scripts/ops/multitable-phase3-release-gate-email-bridge.test.mjs
@@ -1,0 +1,336 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import {
+  EMAIL_SUB_GATE_ID,
+  runEmailRealSendSubGate,
+} from './multitable-phase3-release-gate-email-bridge.mjs'
+
+function newOutputDir() {
+  return mkdtempSync(path.join(tmpdir(), 'mt-phase3-email-bridge-'))
+}
+
+function cleanup(dir) {
+  rmSync(dir, { recursive: true, force: true })
+}
+
+/**
+ * Build a synthetic runScript that writes a fake report.json and
+ * returns a synthetic spawn result. This lets us cover every
+ * source-state combination without invoking pnpm + tsx + the real
+ * email script.
+ */
+function makeRunScript({
+  exitCode = 0,
+  reportJson = null,
+  reportMd = null,
+  stdout = '',
+  stderr = '',
+  throwErr = null,
+  resultErr = null,
+  skipReportWrite = false,
+}) {
+  return ({ jsonPath, mdPath }) => {
+    if (throwErr) throw throwErr
+    if (!skipReportWrite && reportJson !== null) {
+      mkdirSync(path.dirname(jsonPath), { recursive: true })
+      mkdirSync(path.dirname(mdPath), { recursive: true })
+      // Match the real email script's pretty-printed JSON output shape
+      // (`JSON.stringify(report, null, 2)`) so tests assert against
+      // formatted output, mirroring on-disk reality.
+      writeFileSync(
+        jsonPath,
+        typeof reportJson === 'string'
+          ? reportJson
+          : `${JSON.stringify(reportJson, null, 2)}\n`,
+      )
+      writeFileSync(mdPath, reportMd ?? '# fake markdown\n')
+    }
+    return {
+      status: exitCode,
+      stdout,
+      stderr,
+      error: resultErr,
+    }
+  }
+}
+
+test('EMAIL_SUB_GATE_ID is exported as the canonical gate id', () => {
+  assert.equal(EMAIL_SUB_GATE_ID, 'email:real-send')
+})
+
+test('runEmailRealSendSubGate throws when outputDir is missing', () => {
+  assert.throws(() => runEmailRealSendSubGate({ outputDir: '' }))
+})
+
+test('pass: exit=0 + status=pass + ok=true → status=pass exit=0', () => {
+  const dir = newOutputDir()
+  try {
+    const runScript = makeRunScript({
+      exitCode: 0,
+      reportJson: { ok: true, status: 'pass', mode: 'smtp', messages: [] },
+    })
+    const result = runEmailRealSendSubGate({ outputDir: dir, runScript })
+    assert.equal(result.gate, EMAIL_SUB_GATE_ID)
+    assert.equal(result.status, 'pass')
+    assert.equal(result.exitCode, 0)
+    assert.equal(result.sourceExitCode, 0)
+    assert.equal(result.sourceStatus, 'pass')
+    assert.ok(result.sourceReportPath.endsWith('children/email-real-send/report.json'))
+  } finally {
+    cleanup(dir)
+  }
+})
+
+test('blocked: exit=2 + status=blocked → status=blocked exit=2', () => {
+  const dir = newOutputDir()
+  try {
+    const runScript = makeRunScript({
+      exitCode: 2,
+      reportJson: { ok: false, status: 'blocked', mode: 'smtp', messages: [] },
+    })
+    const result = runEmailRealSendSubGate({ outputDir: dir, runScript })
+    assert.equal(result.status, 'blocked')
+    assert.equal(result.exitCode, 2)
+    assert.equal(result.sourceExitCode, 2)
+    assert.equal(result.sourceStatus, 'blocked')
+    assert.match(result.reason, /MULTITABLE_EMAIL_/)
+  } finally {
+    cleanup(dir)
+  }
+})
+
+test('fail: exit=1 + status=failed → status=fail exit=1', () => {
+  const dir = newOutputDir()
+  try {
+    const runScript = makeRunScript({
+      exitCode: 1,
+      reportJson: { ok: false, status: 'failed', mode: 'smtp', messages: [] },
+    })
+    const result = runEmailRealSendSubGate({ outputDir: dir, runScript })
+    assert.equal(result.status, 'fail')
+    assert.equal(result.exitCode, 1)
+    assert.equal(result.sourceExitCode, 1)
+    assert.equal(result.sourceStatus, 'failed')
+  } finally {
+    cleanup(dir)
+  }
+})
+
+test('fail-closed: exit=0 + status=blocked (mismatch) → status=fail', () => {
+  const dir = newOutputDir()
+  try {
+    const runScript = makeRunScript({
+      exitCode: 0,
+      reportJson: { ok: false, status: 'blocked', mode: 'smtp', messages: [] },
+    })
+    const result = runEmailRealSendSubGate({ outputDir: dir, runScript })
+    assert.equal(result.status, 'fail')
+    assert.equal(result.exitCode, 1)
+    assert.match(result.reason, /Fail-closed/)
+  } finally {
+    cleanup(dir)
+  }
+})
+
+test('fail-closed: exit=2 + status=pass (mismatch) → status=fail', () => {
+  const dir = newOutputDir()
+  try {
+    const runScript = makeRunScript({
+      exitCode: 2,
+      reportJson: { ok: true, status: 'pass', mode: 'smtp', messages: [] },
+    })
+    const result = runEmailRealSendSubGate({ outputDir: dir, runScript })
+    assert.equal(result.status, 'fail')
+    assert.equal(result.exitCode, 1)
+    assert.match(result.reason, /Fail-closed/)
+  } finally {
+    cleanup(dir)
+  }
+})
+
+test('fail-closed: exit=0 + status=pass + ok=false (ok mismatch) → status=fail', () => {
+  const dir = newOutputDir()
+  try {
+    const runScript = makeRunScript({
+      exitCode: 0,
+      reportJson: { ok: false, status: 'pass', mode: 'smtp', messages: [] },
+    })
+    const result = runEmailRealSendSubGate({ outputDir: dir, runScript })
+    assert.equal(result.status, 'fail')
+    assert.equal(result.exitCode, 1)
+    assert.match(result.reason, /Fail-closed/)
+  } finally {
+    cleanup(dir)
+  }
+})
+
+test('fail-closed: report.json missing → status=fail', () => {
+  const dir = newOutputDir()
+  try {
+    const runScript = makeRunScript({
+      exitCode: 0,
+      reportJson: { ok: true, status: 'pass', mode: 'smtp' },
+      skipReportWrite: true,
+    })
+    const result = runEmailRealSendSubGate({ outputDir: dir, runScript })
+    assert.equal(result.status, 'fail')
+    assert.equal(result.exitCode, 1)
+    assert.match(result.reason, /did not write a report\.json/)
+  } finally {
+    cleanup(dir)
+  }
+})
+
+test('fail-closed: report.json malformed → status=fail', () => {
+  const dir = newOutputDir()
+  try {
+    const runScript = makeRunScript({
+      exitCode: 0,
+      reportJson: '{ not valid json',
+    })
+    const result = runEmailRealSendSubGate({ outputDir: dir, runScript })
+    assert.equal(result.status, 'fail')
+    assert.equal(result.exitCode, 1)
+    assert.match(result.reason, /failed to parse/)
+  } finally {
+    cleanup(dir)
+  }
+})
+
+test('fail-closed: spawn throws → status=fail', () => {
+  const dir = newOutputDir()
+  try {
+    const runScript = makeRunScript({
+      throwErr: new Error('synthetic spawn explosion'),
+    })
+    const result = runEmailRealSendSubGate({ outputDir: dir, runScript })
+    assert.equal(result.status, 'fail')
+    assert.equal(result.exitCode, 1)
+    assert.match(result.reason, /Spawn error/)
+    assert.match(result.stderrSample, /synthetic spawn explosion/)
+  } finally {
+    cleanup(dir)
+  }
+})
+
+test('fail-closed: spawn returns result.error → status=fail', () => {
+  const dir = newOutputDir()
+  try {
+    const runScript = makeRunScript({
+      exitCode: null,
+      resultErr: { code: 'ENOENT', message: 'pnpm: command not found' },
+    })
+    const result = runEmailRealSendSubGate({ outputDir: dir, runScript })
+    assert.equal(result.status, 'fail')
+    assert.equal(result.exitCode, 1)
+    assert.match(result.reason, /Spawn returned an error/)
+  } finally {
+    cleanup(dir)
+  }
+})
+
+test('fail-closed: null exit code (signal kill) → status=fail', () => {
+  const dir = newOutputDir()
+  try {
+    const runScript = makeRunScript({
+      exitCode: null,
+    })
+    const result = runEmailRealSendSubGate({ outputDir: dir, runScript })
+    assert.equal(result.status, 'fail')
+    assert.equal(result.exitCode, 1)
+    assert.match(result.reason, /null|killed/i)
+  } finally {
+    cleanup(dir)
+  }
+})
+
+test('bridge writes child report.json + report.md to <outputDir>/children/email-real-send/', () => {
+  const dir = newOutputDir()
+  try {
+    const runScript = makeRunScript({
+      exitCode: 0,
+      reportJson: { ok: true, status: 'pass', mode: 'smtp', messages: [] },
+      reportMd: '# Child markdown\n',
+    })
+    const result = runEmailRealSendSubGate({ outputDir: dir, runScript })
+    assert.equal(result.status, 'pass')
+    const expectedJson = path.join(dir, 'children/email-real-send/report.json')
+    const expectedMd = path.join(dir, 'children/email-real-send/report.md')
+    assert.equal(result.sourceReportPath, expectedJson)
+    const json = readFileSync(expectedJson, 'utf8')
+    const md = readFileSync(expectedMd, 'utf8')
+    assert.match(json, /"status": "pass"/)
+    assert.match(md, /Child markdown/)
+  } finally {
+    cleanup(dir)
+  }
+})
+
+test('bridge redacts SMTP / Bearer / sk-* sentinels in stdoutSample and stderrSample', () => {
+  const dir = newOutputDir()
+  try {
+    const runScript = makeRunScript({
+      exitCode: 0,
+      reportJson: { ok: true, status: 'pass', mode: 'smtp', messages: [] },
+      stdout:
+        'Subject sent via SMTP_USER=admin@example.com SMTP_HOST=smtp.example.com Bearer abcdefghijklmnop1234567890',
+      stderr:
+        'OPENAI_API_KEY=sk-leakytestonly1234567890abcdef\nMULTITABLE_EMAIL_SMTP_PASSWORD=l3akyPwd99',
+    })
+    const result = runEmailRealSendSubGate({ outputDir: dir, runScript })
+    assert.equal(result.status, 'pass')
+    const all = `${result.stdoutSample}\n${result.stderrSample}`
+    assert.doesNotMatch(all, /admin@example\.com/)
+    assert.doesNotMatch(all, /smtp\.example\.com/)
+    assert.doesNotMatch(all, /abcdefghijklmnop1234567890/)
+    assert.doesNotMatch(all, /sk-leakytestonly1234567890abcdef/)
+    assert.doesNotMatch(all, /l3akyPwd99/)
+    assert.match(all, /<redacted>|Bearer <redacted>|sk-<redacted>/)
+  } finally {
+    cleanup(dir)
+  }
+})
+
+test('bridge truncates oversized stdout to 1200-char sample', () => {
+  const dir = newOutputDir()
+  try {
+    const longText = 'A'.repeat(5000)
+    const runScript = makeRunScript({
+      exitCode: 0,
+      reportJson: { ok: true, status: 'pass', mode: 'smtp', messages: [] },
+      stdout: longText,
+    })
+    const result = runEmailRealSendSubGate({ outputDir: dir, runScript })
+    assert.ok(result.stdoutSample.length <= 1200, `actual length ${result.stdoutSample.length}`)
+    assert.ok(result.stdoutSample.endsWith('...'))
+  } finally {
+    cleanup(dir)
+  }
+})
+
+test('bridge preserves sourceExitCode and sourceStatus on fail-closed mismatch', () => {
+  const dir = newOutputDir()
+  try {
+    const runScript = makeRunScript({
+      exitCode: 0,
+      reportJson: { ok: true, status: 'pass', mode: 'smtp', messages: [] },
+    })
+    const result = runEmailRealSendSubGate({ outputDir: dir, runScript })
+    // Pass case: verify the source fields are present and accurate.
+    assert.equal(result.sourceExitCode, 0)
+    assert.equal(result.sourceStatus, 'pass')
+    assert.ok(result.sourceReportPath.includes('children/email-real-send/report.json'))
+  } finally {
+    cleanup(dir)
+  }
+})

--- a/scripts/ops/multitable-phase3-release-gate.mjs
+++ b/scripts/ops/multitable-phase3-release-gate.mjs
@@ -1,32 +1,48 @@
 #!/usr/bin/env node
 
 /**
- * Phase 3 release gate skeleton.
+ * Phase 3 release gate.
  *
  * Routing + blocked-mode + shared redaction + JSON+MD report writer.
- * All sub-gates are blocked at this PR's stage (D0). Real harnesses
- * land in subsequent PRs (R3 D1 SMTP, R4 D4 automation soak). D2/D3
- * stay blocked under the K3 PoC stage-1 lock.
+ * The aggregator (`release:phase3`) iterates over four sub-gates:
+ *
+ *   - `email:real-send`     — wired via a fail-closed bridge to the
+ *                             existing `verify:multitable-email:real-send`
+ *                             package script (added in PR R3).
+ *   - `perf:large-table`    — D2 deferred (always blocked).
+ *   - `permissions:matrix`  — D3 deferred (always blocked).
+ *   - `automation:soak`     — D4 stub (always blocked until PR R4).
+ *
+ * The aggregator never collapses BLOCKED into FAIL, and never lets a
+ * partial PASS (e.g. email pass + others blocked) collapse the
+ * aggregate to PASS — that remains BLOCKED.
  *
  * Exit codes:
  *   0  PASS
  *   1  FAIL
  *   2  BLOCKED — never collapsed into FAIL.
  *
- * Email real-send is NOT routed here at D0; the existing
- * `verify:multitable-email:real-send` script (
- * `scripts/ops/multitable-email-real-send-smoke.ts`) is left untouched
- * and will be bound into the aggregator in PR R3.
+ * The existing `verify:multitable-email:real-send` package script and
+ * `scripts/ops/multitable-email-real-send-smoke.ts` are left
+ * untouched. The bridge invokes them via `pnpm` and injects
+ * EMAIL_REAL_SEND_JSON / EMAIL_REAL_SEND_MD output paths under
+ * `<outputDir>/children/email-real-send/` so reports never collide
+ * with the email script's default output location.
  *
  * See:
  *   docs/development/multitable-feishu-phase3-ai-hardening-plan-20260514.md
  *   docs/development/multitable-feishu-phase3-ai-hardening-review-20260514.md
+ *   docs/development/multitable-phase3-email-bridge-development-20260514.md
  */
 
 import { mkdirSync } from 'node:fs'
 import path from 'node:path'
 import { redactString } from './multitable-phase3-release-gate-redact.mjs'
 import { buildReport, writeReport } from './multitable-phase3-release-gate-report.mjs'
+import {
+  EMAIL_SUB_GATE_ID,
+  runEmailRealSendSubGate,
+} from './multitable-phase3-release-gate-email-bridge.mjs'
 
 const TOOL = 'multitable-phase3-release-gate'
 const DEFAULT_OUTPUT_DIR = 'output/multitable-phase3-release-gate'
@@ -57,14 +73,15 @@ const SUB_GATES = {
 }
 
 const AGGREGATE_GATE = 'release:phase3'
-const PUBLIC_GATES = [AGGREGATE_GATE, ...Object.keys(SUB_GATES)]
+const PUBLIC_GATES = [AGGREGATE_GATE, EMAIL_SUB_GATE_ID, ...Object.keys(SUB_GATES)]
 
 function printHelp() {
   console.log(`Usage: node scripts/ops/multitable-phase3-release-gate.mjs --gate <id> [options]
 
-Runs the Phase 3 release gate skeleton. All sub-gates are blocked at
-the D0 PR stage; only routing, redaction, and report writing are
-exercised.
+Runs the Phase 3 release gate. The email:real-send sub-gate is wired
+to the existing pnpm verify:multitable-email:real-send script via a
+fail-closed bridge; other sub-gates remain blocked under the K3 PoC
+stage-1 lock and Lane D4 stub.
 
 Gates:
   ${PUBLIC_GATES.map((g) => `\`${g}\``).join(', ')}
@@ -174,34 +191,61 @@ function runSubGate(gate, env) {
   }
 }
 
-function runAggregate(env) {
-  const startedAt = new Date().toISOString()
-  const children = []
-  for (const gate of Object.keys(SUB_GATES)) {
-    const child = runSubGate(gate, env)
-    children.push({
-      gate: child.gate,
-      status: child.status,
-      exitCode: child.exitCode,
-      deferral: child.deferral,
-    })
-  }
+export function summarizeAggregateChildren(children) {
   const anyFail = children.some((c) => c.status === 'fail')
   const anyBlocked = children.some((c) => c.status === 'blocked')
-  let status = 'pass'
-  let exitCode = EXIT_PASS
-  let reason = 'All sub-gates passed.'
   if (anyFail) {
-    status = 'fail'
-    exitCode = EXIT_FAIL
-    reason = 'One or more child sub-gates returned FAIL.'
-  } else if (anyBlocked) {
-    // Critical: BLOCKED must NOT collapse into FAIL. Aggregator returns 2.
-    status = 'blocked'
-    exitCode = EXIT_BLOCKED
-    reason =
-      'One or more child sub-gates are BLOCKED. Aggregator exits 2 (BLOCKED); it does not collapse into 1 (FAIL).'
+    return {
+      status: 'fail',
+      exitCode: EXIT_FAIL,
+      reason:
+        'One or more child sub-gates returned FAIL. Aggregator exits 1 (FAIL).',
+    }
   }
+  if (anyBlocked) {
+    // Critical: BLOCKED must NOT collapse into FAIL. Aggregator returns 2.
+    return {
+      status: 'blocked',
+      exitCode: EXIT_BLOCKED,
+      reason:
+        'One or more child sub-gates are BLOCKED. Aggregator exits 2 (BLOCKED); it does not collapse into 1 (FAIL) or 0 (PASS).',
+    }
+  }
+  return {
+    status: 'pass',
+    exitCode: EXIT_PASS,
+    reason: 'All sub-gates passed.',
+  }
+}
+
+function summarizeChild(child) {
+  return {
+    gate: child.gate,
+    status: child.status,
+    exitCode: child.exitCode,
+    reason: child.reason ?? null,
+    deferral: child.deferral ?? null,
+    sourceExitCode: child.sourceExitCode ?? null,
+    sourceStatus: child.sourceStatus ?? null,
+  }
+}
+
+function runAggregate(env, { outputDir, emailRunScript } = {}) {
+  const startedAt = new Date().toISOString()
+  const children = []
+  // Email sub-gate first so a real PASS signal can surface even when
+  // every other sub-gate is BLOCKED.
+  const emailChild = runEmailRealSendSubGate({
+    outputDir,
+    env,
+    runScript: emailRunScript,
+  })
+  children.push(summarizeChild(emailChild))
+  for (const gate of Object.keys(SUB_GATES)) {
+    const child = runSubGate(gate, env)
+    children.push(summarizeChild(child))
+  }
+  const { status, exitCode, reason } = summarizeAggregateChildren(children)
   return {
     tool: TOOL,
     gate: AGGREGATE_GATE,
@@ -214,15 +258,26 @@ function runAggregate(env) {
   }
 }
 
-export function executeGate(gate, env) {
-  if (gate === AGGREGATE_GATE) return runAggregate(env)
+export function executeGate(gate, env, { outputDir = '', emailRunScript } = {}) {
+  if (gate === AGGREGATE_GATE) {
+    if (!outputDir) {
+      throw new Error('executeGate: outputDir is required when invoking the aggregator')
+    }
+    return runAggregate(env, { outputDir, emailRunScript })
+  }
+  if (gate === EMAIL_SUB_GATE_ID) {
+    if (!outputDir) {
+      throw new Error(`executeGate: outputDir is required when invoking ${EMAIL_SUB_GATE_ID}`)
+    }
+    return runEmailRealSendSubGate({ outputDir, env, runScript: emailRunScript })
+  }
   return runSubGate(gate, env)
 }
 
 function main(argv) {
   const opts = parseArgs(argv)
   mkdirSync(opts.outputDir, { recursive: true })
-  const result = executeGate(opts.gate, process.env)
+  const result = executeGate(opts.gate, process.env, { outputDir: opts.outputDir })
   const report = buildReport(result)
   writeReport({ outputJson: opts.outputJson, outputMd: opts.outputMd, report })
   const summary = redactString(

--- a/scripts/ops/multitable-phase3-release-gate.test.mjs
+++ b/scripts/ops/multitable-phase3-release-gate.test.mjs
@@ -1,13 +1,49 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { spawnSync } from 'node:child_process'
 
-import { executeGate } from './multitable-phase3-release-gate.mjs'
+import { executeGate, summarizeAggregateChildren } from './multitable-phase3-release-gate.mjs'
 
 const SCRIPT = 'scripts/ops/multitable-phase3-release-gate.mjs'
+
+function newOutputDir() {
+  return mkdtempSync(path.join(tmpdir(), 'mt-phase3-gate-inproc-'))
+}
+
+/**
+ * Build a mock runScript for the email bridge that writes the
+ * specified report shape and returns the requested exit code.
+ */
+function mockEmailRunScript({ exitCode, status, ok = status === 'pass' }) {
+  return ({ jsonPath, mdPath }) => {
+    mkdirSync(path.dirname(jsonPath), { recursive: true })
+    writeFileSync(
+      jsonPath,
+      JSON.stringify({ ok, status, mode: 'smtp', messages: [] }),
+    )
+    writeFileSync(mdPath, `# mock ${status}\n`)
+    return { status: exitCode, stdout: '', stderr: '' }
+  }
+}
+
+const EMAIL_PASS_MOCK = mockEmailRunScript({ exitCode: 0, status: 'pass', ok: true })
+const EMAIL_BLOCKED_MOCK = mockEmailRunScript({ exitCode: 2, status: 'blocked' })
+const EMAIL_FAIL_MOCK = mockEmailRunScript({ exitCode: 1, status: 'failed', ok: false })
+
+/**
+ * Spawn-based tests that invoke `pnpm verify:multitable-email:real-send`
+ * via the email bridge require node_modules/.bin/tsx to be present.
+ * In CI, pnpm install runs before tests; in a fresh worktree it may
+ * not yet have run. Use this to skip those tests in the latter case
+ * while still asserting the rest of the suite.
+ */
+const BRIDGE_SPAWN_SKIP =
+  existsSync(path.resolve(process.cwd(), 'node_modules/.bin/tsx'))
+    ? undefined
+    : 'requires node_modules/.bin/tsx (run `pnpm install` to enable)'
 
 function runGate(gate, { env = {}, allowBlocked = false } = {}) {
   const dir = mkdtempSync(path.join(tmpdir(), 'mt-phase3-gate-'))
@@ -72,18 +108,141 @@ test('executeGate (in-process) still blocks even when env is present at D0', () 
   assert.match(result.reason, /D0 skeleton/)
 })
 
-test('executeGate aggregator returns BLOCKED, never FAIL, when children are blocked', () => {
-  const result = executeGate('release:phase3', {})
-  assert.equal(result.status, 'blocked')
+test('executeGate aggregator returns BLOCKED, never FAIL, when all four children are blocked', () => {
+  const dir = newOutputDir()
+  try {
+    const result = executeGate('release:phase3', {}, {
+      outputDir: dir,
+      emailRunScript: EMAIL_BLOCKED_MOCK,
+    })
+    assert.equal(result.status, 'blocked')
+    assert.equal(result.exitCode, 2)
+    assert.notEqual(result.status, 'fail', 'aggregator status must not be fail')
+    assert.notEqual(result.exitCode, 1, 'aggregator must not collapse BLOCKED into FAIL=1')
+    assert.equal(result.children.length, 4)
+    assert.ok(result.children.every((c) => c.status === 'blocked'))
+    assert.ok(result.children.every((c) => c.exitCode === 2))
+    assert.match(result.reason, /BLOCKED/)
+    // email is the first child
+    assert.equal(result.children[0].gate, 'email:real-send')
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('aggregator: email PASS + 3 others blocked → status=blocked exit=2 (does NOT collapse to PASS)', () => {
+  const dir = newOutputDir()
+  try {
+    const result = executeGate('release:phase3', {}, {
+      outputDir: dir,
+      emailRunScript: EMAIL_PASS_MOCK,
+    })
+    assert.equal(result.status, 'blocked', 'partial PASS must not collapse aggregate to PASS')
+    assert.equal(result.exitCode, 2)
+    assert.equal(result.children.length, 4)
+    const emailChild = result.children.find((c) => c.gate === 'email:real-send')
+    assert.equal(emailChild.status, 'pass')
+    assert.equal(emailChild.exitCode, 0)
+    const others = result.children.filter((c) => c.gate !== 'email:real-send')
+    assert.ok(others.every((c) => c.status === 'blocked'))
+    assert.match(result.reason, /BLOCKED/)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('aggregator: email FAIL + 3 others blocked → status=fail exit=1', () => {
+  const dir = newOutputDir()
+  try {
+    const result = executeGate('release:phase3', {}, {
+      outputDir: dir,
+      emailRunScript: EMAIL_FAIL_MOCK,
+    })
+    assert.equal(result.status, 'fail', 'any FAIL child must propagate to FAIL aggregate')
+    assert.equal(result.exitCode, 1)
+    assert.equal(result.children.length, 4)
+    const emailChild = result.children.find((c) => c.gate === 'email:real-send')
+    assert.equal(emailChild.status, 'fail')
+    assert.match(result.reason, /FAIL/)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('summarizeAggregateChildren: every child PASS → status=pass exit=0 (synthetic)', () => {
+  // D2/D3/D4 are hard-coded blocked, so executeGate cannot drive an
+  // all-pass aggregate end-to-end. We test the summarizer branch
+  // directly with synthesized children.
+  const result = summarizeAggregateChildren([
+    { gate: 'email:real-send', status: 'pass', exitCode: 0 },
+    { gate: 'perf:large-table', status: 'pass', exitCode: 0 },
+    { gate: 'permissions:matrix', status: 'pass', exitCode: 0 },
+    { gate: 'automation:soak', status: 'pass', exitCode: 0 },
+  ])
+  assert.equal(result.status, 'pass')
+  assert.equal(result.exitCode, 0)
+})
+
+test('summarizeAggregateChildren: any FAIL beats any number of BLOCKED → status=fail', () => {
+  const result = summarizeAggregateChildren([
+    { gate: 'email:real-send', status: 'pass', exitCode: 0 },
+    { gate: 'perf:large-table', status: 'blocked', exitCode: 2 },
+    { gate: 'permissions:matrix', status: 'fail', exitCode: 1 },
+    { gate: 'automation:soak', status: 'blocked', exitCode: 2 },
+  ])
+  assert.equal(result.status, 'fail')
+  assert.equal(result.exitCode, 1)
+})
+
+test('summarizeAggregateChildren: pass + blocked but no fail → status=blocked', () => {
+  const result = summarizeAggregateChildren([
+    { gate: 'email:real-send', status: 'pass', exitCode: 0 },
+    { gate: 'perf:large-table', status: 'blocked', exitCode: 2 },
+    { gate: 'permissions:matrix', status: 'blocked', exitCode: 2 },
+    { gate: 'automation:soak', status: 'blocked', exitCode: 2 },
+  ])
+  assert.equal(result.status, 'blocked', 'partial PASS with BLOCKED present must stay BLOCKED')
   assert.equal(result.exitCode, 2)
-  assert.notEqual(result.status, 'fail', 'aggregator status must not be fail')
-  assert.notEqual(result.exitCode, 1, 'aggregator must not collapse BLOCKED into FAIL=1')
-  assert.equal(result.children.length, 3)
-  assert.ok(result.children.every((c) => c.status === 'blocked'))
-  assert.ok(result.children.every((c) => c.exitCode === 2))
-  // The reason text explicitly references both BLOCKED and FAIL to document the
-  // non-collapse rule; substring guard is intentionally narrow.
-  assert.match(result.reason, /BLOCKED/)
+})
+
+test('email:real-send standalone gate routes through bridge (pass case)', () => {
+  const dir = newOutputDir()
+  try {
+    const result = executeGate('email:real-send', {}, {
+      outputDir: dir,
+      emailRunScript: EMAIL_PASS_MOCK,
+    })
+    assert.equal(result.gate, 'email:real-send')
+    assert.equal(result.status, 'pass')
+    assert.equal(result.exitCode, 0)
+    assert.equal(result.sourceExitCode, 0)
+    assert.equal(result.sourceStatus, 'pass')
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('email:real-send standalone gate routes through bridge (blocked case)', () => {
+  const dir = newOutputDir()
+  try {
+    const result = executeGate('email:real-send', {}, {
+      outputDir: dir,
+      emailRunScript: EMAIL_BLOCKED_MOCK,
+    })
+    assert.equal(result.gate, 'email:real-send')
+    assert.equal(result.status, 'blocked')
+    assert.equal(result.exitCode, 2)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('executeGate throws when aggregator is invoked without outputDir', () => {
+  assert.throws(() => executeGate('release:phase3', {}), /outputDir/)
+})
+
+test('executeGate throws when email:real-send is invoked without outputDir', () => {
+  assert.throws(() => executeGate('email:real-send', {}), /outputDir/)
 })
 
 test('perf:large-table exits 2 (blocked) by default via spawn', () => {
@@ -122,20 +281,24 @@ test('automation:soak exits 2 (blocked) by default via spawn', () => {
   }
 })
 
-test('release:phase3 aggregator exits 2 (blocked) not 1 (fail) via spawn', () => {
-  const r = runGate('release:phase3')
-  try {
-    assert.equal(r.exitCode, 2, 'aggregator must exit 2, not 1')
-    const obj = JSON.parse(r.json)
-    assert.equal(obj.status, 'blocked')
-    assert.equal(obj.exitCode, 2)
-    assert.ok(Array.isArray(obj.children) && obj.children.length === 3)
-    assert.ok(obj.children.every((c) => c.status === 'blocked' && c.exitCode === 2))
-    assert.match(obj.reason, /BLOCKED/)
-  } finally {
-    cleanup(r.dir)
-  }
-})
+test(
+  'release:phase3 aggregator exits 2 (blocked) not 1 (fail) via spawn — all 4 children blocked',
+  { skip: BRIDGE_SPAWN_SKIP },
+  () => {
+    const r = runGate('release:phase3')
+    try {
+      assert.equal(r.exitCode, 2, 'aggregator must exit 2, not 1')
+      const obj = JSON.parse(r.json)
+      assert.equal(obj.status, 'blocked')
+      assert.equal(obj.exitCode, 2)
+      assert.ok(Array.isArray(obj.children) && obj.children.length === 4)
+      assert.ok(obj.children.every((c) => c.status === 'blocked' && c.exitCode === 2))
+      assert.match(obj.reason, /BLOCKED/)
+    } finally {
+      cleanup(r.dir)
+    }
+  },
+)
 
 test('--allow-blocked overrides exit code to 0 but keeps status field as blocked', () => {
   const r = runGate('perf:large-table', { allowBlocked: true })


### PR DESCRIPTION
## Summary

Implements PR R3 of the Phase 3 active queue per
`docs/development/multitable-feishu-phase3-ai-hardening-plan-20260514.md`
§ Suggested PR Sequence.

Binds the existing `verify:multitable-email:real-send` package
script into the Phase 3 release-gate aggregator as the
`email:real-send` sub-gate through a **fail-closed bridge**.

## Four hard constraints from PR R3 design review — all honored

| # | Constraint | Verified |
| --- | --- | --- |
| 1 | Bridge spawns `pnpm verify:multitable-email:real-send`, never `tsx scripts/ops/...` directly | grep shows `spawnSync('pnpm', ...)` at line 48; no `tsx` in bridge file |
| 2 | Bridge injects `EMAIL_REAL_SEND_JSON` / `EMAIL_REAL_SEND_MD` to land child reports at `<phase3-output>/children/email-real-send/` | grep finds 2 occurrences inside `defaultRunScript` |
| 3 | Fail-closed status translation: only `exit=0 + status=pass + ok=true` → pass; only `exit=2 + status=blocked` → blocked; every other shape → fail | 11 bridge unit tests cover every mismatch / missing-report / parse-fail / spawn-error / signal-kill case |
| 4 | `MULTITABLE_EMAIL_SMTP_HOST/USER/PASSWORD/FROM` and `MULTITABLE_EMAIL_SMOKE_TO` real env names never appear in Phase 3 JSON / MD / stdout / stderr after bridge runs | inherited from #1541 D0 redaction patch; re-verified via 2 spawn-based artifact-integrity tests on aggregator path |

## Aggregator state-machine invariants

| Invariant | Status |
| --- | --- |
| All 4 children BLOCKED → aggregate BLOCKED (exit 2) | PASS |
| Email PASS + 3 BLOCKED → aggregate BLOCKED (does **not** collapse to PASS) | PASS |
| Email FAIL + 3 BLOCKED → aggregate FAIL (exit 1) | PASS |
| BLOCKED never collapses into FAIL | PASS (carried from #1541, still holds) |

## What this PR explicitly does NOT do

- Does **not** modify `scripts/ops/multitable-email-real-send-smoke.ts`
  or `multitable-email-transport-readiness.ts`.
- Does **not** modify `verify:multitable-email:real-send` or
  `verify:multitable-email:readiness` package scripts.
- Does **not** add any new `verify:multitable-*` package script.
  `email:real-send` is exposed only via `--gate email:real-send`
  routing inside the Phase 3 runner.
- Does **not** touch `plugins/plugin-integration-core/`,
  `lib/adapters/`, multitable runtime, OpenAPI, migrations, routes,
  workflows.

## Files (6 changes, +1420 / -65)

| Path | Change | Lines |
| --- | --- | --- |
| `scripts/ops/multitable-phase3-release-gate-email-bridge.mjs` | new | 240 |
| `scripts/ops/multitable-phase3-release-gate-email-bridge.test.mjs` | new | 336 |
| `scripts/ops/multitable-phase3-release-gate.mjs` | modify | +131 / -65 (refactor: extract summarizer, thread outputDir / emailRunScript, add email child to aggregator) |
| `scripts/ops/multitable-phase3-release-gate.test.mjs` | modify | +217 (mock helpers + 9 multi-state tests + skip guard) |
| `docs/development/multitable-phase3-email-bridge-development-20260514.md` | new | 210 |
| `docs/development/multitable-phase3-email-bridge-verification-20260514.md` | new | 351 |

No `package.json` change. No existing email script touched.

## Test plan

- [x] `node --test scripts/ops/multitable-phase3-release-gate*.test.mjs`
      → tests 63, pass 62, fail 0, skipped 1.
      The single skip is intentional: spawn-based aggregator test
      requires `node_modules/.bin/tsx` (gated by `existsSync`).
      Runs in CI after `pnpm install`.
- [x] End-to-end exit codes verified for all 5 gates (`release:phase3`,
      `email:real-send`, `perf:large-table`, `permissions:matrix`,
      `automation:soak`). Without `pnpm install` in worktree, the
      email bridge fail-closes to exit 1 — exact design intent.
- [x] `git diff --cached --check` clean.
- [x] Secret-pattern scan returns only `.test.mjs` fixture matches,
      all inside `assert.doesNotMatch` / `assert.match` clauses.
- [x] No `package.json` change, no existing email script touched.

## Stage-1 lock compliance

- [x] No change under `plugins/plugin-integration-core/*`.
- [x] No change under `lib/adapters/k3-wise-*`.
- [x] No new product战线.
- [x] No schema / migration / route / workflow change.
- [x] Existing email scripts and package scripts untouched.
- [x] Kernel polish on already-shipped automation send_email path.

## Follow-ups (not in this PR)

- PR R4 — D4 automation soak gate: replace `automation:soak`
  blocked stub with real `record.created` / `update_record` /
  `send_email` / `send_webhook` repeat-fire harness, using the same
  fail-closed bridge pattern.
- D2 (perf large-table) and D3 (permission matrix) stay deferred
  under stage-1 lock plus T4 / T5 closure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)