### PR TITLE
test(multitable): add phase3 automation soak gate

### DIFF
--- a/docs/development/multitable-feishu-phase3-ai-hardening-todo-20260514.md
+++ b/docs/development/multitable-feishu-phase3-ai-hardening-todo-20260514.md
@@ -530,7 +530,7 @@ guards.
   - Verification summary: intentionally not claimed by this transport-level D1 aggregation slice; the shipped RC automation smoke covers execution-log behavior with the default mock channel, and D4 remains the correct place for repeat-fire automation-log soak semantics.
 - [x] Redact SMTP credentials and recipients in artifacts.
   - PR: #1544
-  - Merge commit: pending.
+  - Merge commit: `1f9061f56`
   - Development MD: `docs/development/multitable-phase3-real-smtp-gate-development-20260514.md`
   - Verification MD: `docs/development/multitable-phase3-real-smtp-gate-verification-20260514.md`
   - Verification summary: D1 adds email delegate artifact-integrity coverage for SMTP host/user/password/from and smoke recipient values.
@@ -615,36 +615,36 @@ Status: pending — active queue (kernel polish on shipped automation execution 
 
 Owner recommendation: Codex.
 
-- [ ] Exercise `record.created` trigger repeatedly.
-  - PR:
-  - Merge commit:
-  - Development MD:
-  - Verification MD:
-  - Verification summary:
-- [ ] Exercise `update_record` action repeatedly.
-  - PR:
-  - Merge commit:
-  - Development MD:
-  - Verification MD:
-  - Verification summary:
-- [ ] Exercise `send_email` action repeatedly in safe mode.
-  - PR:
-  - Merge commit:
-  - Development MD:
-  - Verification MD:
-  - Verification summary:
-- [ ] Exercise `send_webhook` action against a controlled local/staging sink.
-  - PR:
-  - Merge commit:
-  - Development MD:
-  - Verification MD:
-  - Verification summary:
-- [ ] Verify execution log persistence and failure handling.
-  - PR:
-  - Merge commit:
-  - Development MD:
-  - Verification MD:
-  - Verification summary:
+- [x] Exercise `record.created` trigger repeatedly.
+  - PR: #1547
+  - Merge commit: pending.
+  - Development MD: `docs/development/multitable-phase3-automation-soak-gate-development-20260514.md`
+  - Verification MD: `docs/development/multitable-phase3-automation-soak-gate-verification-20260514.md`
+  - Verification summary: `MULTITABLE_AUTOMATION_SOAK_ITERATIONS` controls repeated record creation; fake-fetch tests cover two iterations and the default remote gate blocks until configured.
+- [x] Exercise `update_record` action repeatedly.
+  - PR: #1547
+  - Merge commit: pending.
+  - Development MD: `docs/development/multitable-phase3-automation-soak-gate-development-20260514.md`
+  - Verification MD: `docs/development/multitable-phase3-automation-soak-gate-verification-20260514.md`
+  - Verification summary: soak rule updates a status field on each created record and verifies read-back state.
+- [x] Exercise `send_email` action repeatedly in safe mode.
+  - PR: #1547
+  - Merge commit: pending.
+  - Development MD: `docs/development/multitable-phase3-automation-soak-gate-development-20260514.md`
+  - Verification MD: `docs/development/multitable-phase3-automation-soak-gate-verification-20260514.md`
+  - Verification summary: soak requires `MULTITABLE_AUTOMATION_SOAK_EMAIL_SAFE_MODE=mock` and uses reserved test-local recipient identifiers; tests validate execution-log shape without real SMTP.
+- [x] Exercise `send_webhook` action against a controlled local/staging sink.
+  - PR: #1547
+  - Merge commit: pending.
+  - Development MD: `docs/development/multitable-phase3-automation-soak-gate-development-20260514.md`
+  - Verification MD: `docs/development/multitable-phase3-automation-soak-gate-verification-20260514.md`
+  - Verification summary: soak requires both success and expected-failure webhook sink URLs before it can PASS.
+- [x] Verify execution log persistence and failure handling.
+  - PR: #1547
+  - Merge commit: pending.
+  - Development MD: `docs/development/multitable-phase3-automation-soak-gate-development-20260514.md`
+  - Verification MD: `docs/development/multitable-phase3-automation-soak-gate-verification-20260514.md`
+  - Verification summary: soak polls automation logs for every rule and treats the controlled failing webhook as PASS only when failed executions are persisted with step errors.
 
 ## Final Phase 3 Acceptance
 

--- a/docs/development/multitable-phase3-automation-soak-gate-development-20260514.md
+++ b/docs/development/multitable-phase3-automation-soak-gate-development-20260514.md
@@ -1,0 +1,88 @@
+# Multitable Phase 3 Automation Soak Gate - Development
+
+Date: 2026-05-14
+
+## Scope
+
+This slice implements Phase 3 PR R4 / Lane D4 by replacing the
+`automation:soak` skeleton with a guarded remote/API harness.
+
+The harness exercises already-shipped automation execution paths only:
+
+- `record.created` trigger
+- `update_record`
+- `send_email`
+- `send_webhook`
+- automation execution-log persistence
+- controlled failure handling
+
+No product runtime code, DB schema, migration, K3 PoC adapter, or AI
+surface is changed.
+
+## Design
+
+`scripts/ops/multitable-automation-soak.mjs` is blocked by default.
+It requires:
+
+- `API_BASE`
+- `AUTH_TOKEN`
+- `MULTITABLE_AUTOMATION_SOAK_CONFIRM=1`
+- `MULTITABLE_AUTOMATION_SOAK_EMAIL_SAFE_MODE=mock`
+- `MULTITABLE_AUTOMATION_SOAK_WEBHOOK_URL`
+- `MULTITABLE_AUTOMATION_SOAK_FAIL_WEBHOOK_URL`
+
+Optional knobs:
+
+- `MULTITABLE_AUTOMATION_SOAK_ITERATIONS`, default `3`, clamped to
+  `1..10`
+- `POLL_TIMEOUT_MS`, default `15000`
+- `POLL_INTERVAL_MS`, default `1000`
+- `AUTOMATION_SOAK_OUTPUT_DIR`
+- `AUTOMATION_SOAK_JSON`
+- `AUTOMATION_SOAK_MD`
+
+When configured, the harness creates a fresh base/sheet, adds fields,
+creates four automation rules, creates N records, and polls execution
+logs for each rule.
+
+## Rule Matrix
+
+| Rule | Expected status | Validation |
+| --- | --- | --- |
+| `record.created -> update_record` | success | every created record is read back with `Status=soaked` |
+| `record.created -> send_email` | success | step output has `recipientCount=2` and `notificationStatus=sent` |
+| `record.created -> send_webhook` | success | step output has a 2xx `httpStatus` |
+| `record.created -> send_webhook` expected failure | failed | execution and first step are persisted as failed with an error |
+
+The expected-failure webhook is intentionally part of the passing
+gate. It proves that automation failures are not swallowed and that
+the execution log records the failed step.
+
+## Release Gate Wiring
+
+`package.json` now points:
+
+```bash
+pnpm verify:multitable-automation:soak
+```
+
+to the new harness. The Phase 3 aggregate runner delegates
+`automation:soak` to that package script and records the child report
+path under:
+
+```text
+children/automation-soak/automation-soak/report.{json,md}
+```
+
+`release:phase3` still returns BLOCKED when any child is blocked.
+After this slice, D2 and D3 remain the intentional blockers under the
+K3 stage-1 lock.
+
+## Safety
+
+- The default path sends no webhook and no email.
+- `send_email` requires an explicit `mock` safe-mode acknowledgement
+  and uses `@test.local` recipients.
+- Webhook URLs are operator-provided controlled sinks and are passed
+  only to the deployed backend when the gate is explicitly confirmed.
+- Reports use the shared Phase 3 redaction writer.

--- a/docs/development/multitable-phase3-automation-soak-gate-verification-20260514.md
+++ b/docs/development/multitable-phase3-automation-soak-gate-verification-20260514.md
@@ -1,0 +1,170 @@
+# Multitable Phase 3 Automation Soak Gate - Verification
+
+Date: 2026-05-14
+
+## Summary
+
+Result: PASS for the D4 implementation slice.
+
+This verification proves that the new automation soak harness blocks
+safely by default, passes against a fake API model that exercises the
+full rule matrix, delegates through the Phase 3 release gate, and
+keeps auth/webhook values out of wrapper artifacts.
+
+No live staging API, real webhook sink, or real SMTP credential was
+used in this local verification.
+
+## Environment
+
+- Worktree: `/private/tmp/ms2-phase3-d4-automation-soak-20260514`
+- Base: `origin/main@1f9061f56`
+- Branch: `codex/multitable-phase3-d4-automation-soak-20260514`
+- Dependency note: the temporary worktree required
+  `pnpm install --frozen-lockfile --ignore-scripts` for TSX-backed
+  delegated tests. Generated dependency-link noise under `plugins/`
+  and `tools/` was restored before commit.
+
+## Focused Tests
+
+### Automation Soak Harness
+
+Command:
+
+```bash
+node --test scripts/ops/multitable-automation-soak.test.mjs
+```
+
+Result:
+
+```text
+tests 5
+pass 5
+fail 0
+```
+
+Covered:
+
+- default BLOCKED config
+- credential-bearing `API_BASE` rejection
+- blocked report when required env is missing
+- fake API PASS path with two repeated iterations
+- expected-failure webhook execution logs persisted as failed
+- spawned script writes redacted blocked artifacts
+
+### Phase 3 Release Gate
+
+Command:
+
+```bash
+node --test scripts/ops/multitable-phase3-release-gate.test.mjs
+```
+
+Result:
+
+```text
+tests 16
+pass 16
+fail 0
+```
+
+Covered:
+
+- `automation:soak` delegates to
+  `pnpm verify:multitable-automation:soak`
+- default automation soak exits 2 / BLOCKED
+- aggregate gate keeps four children
+- aggregate BLOCKED still exits 2 and does not collapse into FAIL
+- auth token and webhook URL query values do not leak through wrapper
+  artifacts
+
+### Report Writer Regression
+
+Command:
+
+```bash
+node --test scripts/ops/multitable-phase3-release-gate-report.test.mjs
+```
+
+Result:
+
+```text
+tests 5
+pass 5
+fail 0
+```
+
+## End-to-End Gate Checks
+
+### Direct Automation Soak
+
+Command:
+
+```bash
+pnpm verify:multitable-automation:soak
+```
+
+Result in a clean environment:
+
+```text
+exit=2
+[multitable-automation-soak] status=blocked exit=2
+```
+
+### Phase 3 Sub-Gate Wrapper
+
+Command:
+
+```bash
+node scripts/ops/multitable-phase3-release-gate.mjs \
+  --gate automation:soak \
+  --output-dir /tmp/ms2-d4-automation-soak-gate
+```
+
+Expected in a clean environment:
+
+```text
+exit=2
+status=blocked
+delegatedCommand=pnpm verify:multitable-automation:soak
+childStatus=blocked
+```
+
+### Aggregate Release Gate
+
+Command:
+
+```bash
+pnpm verify:multitable-release:phase3
+```
+
+Expected until D2/D3 are activated:
+
+```text
+exit=2
+status=blocked
+```
+
+`email:real-send` and `automation:soak` are now delegated child
+gates. `perf:large-table` and `permissions:matrix` remain blocked by
+the K3 stage-1 lock and their own open T-numbered decisions.
+
+## Secret Handling
+
+The D4 artifact-integrity test injects a fake bearer token and
+webhook URLs with query-token values, then asserts those literal
+values do not appear in:
+
+- stdout
+- stderr
+- Phase 3 wrapper `report.json`
+- Phase 3 wrapper `report.md`
+
+No real token, webhook secret, SMTP credential, JWT, or recipient list
+is recorded in this document.
+
+## Remaining Work
+
+- Run this gate against staging only after controlled success/failure
+  webhook sinks are available.
+- D2 large-table perf and D3 permission matrix remain intentionally
+  deferred under the Phase 3 activation rules.

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "verify:multitable-release:phase3": "node scripts/ops/multitable-phase3-release-gate.mjs --gate release:phase3",
     "verify:multitable-perf:large-table": "node scripts/ops/multitable-phase3-release-gate.mjs --gate perf:large-table",
     "verify:multitable-permissions:matrix": "node scripts/ops/multitable-phase3-release-gate.mjs --gate permissions:matrix",
-    "verify:multitable-automation:soak": "node scripts/ops/multitable-phase3-release-gate.mjs --gate automation:soak",
+    "verify:multitable-automation:soak": "node scripts/ops/multitable-automation-soak.mjs",
     "prepare:multitable-pilot:handoff": "node scripts/ops/multitable-pilot-handoff.mjs",
     "prepare:multitable-pilot:handoff:release-bound": "bash scripts/ops/multitable-pilot-handoff-release-bound.sh",
     "prepare:multitable-pilot:handoff:staging:release-bound": "RUN_MODE=staging bash scripts/ops/multitable-pilot-handoff-release-bound.sh",

--- a/scripts/ops/multitable-automation-soak.mjs
+++ b/scripts/ops/multitable-automation-soak.mjs
@@ -1,0 +1,414 @@
+#!/usr/bin/env node
+
+/**
+ * Multitable Phase 3 Automation Soak Gate.
+ *
+ * Remote/API harness for the shipped automation execution paths. It is
+ * blocked by default and only runs when an operator provides an admin token,
+ * a deployed API, explicit confirmation, and controlled webhook sinks.
+ */
+
+import { mkdirSync } from 'node:fs'
+import path from 'node:path'
+import { buildReport, writeReport } from './multitable-phase3-release-gate-report.mjs'
+import { redactString } from './multitable-phase3-release-gate-redact.mjs'
+
+const TOOL = 'multitable-automation-soak'
+const DEFAULT_OUTPUT_DIR = 'output/multitable-automation-soak'
+
+const EXIT_PASS = 0
+const EXIT_FAIL = 1
+const EXIT_BLOCKED = 2
+
+export const REQUIRED_ENV = [
+  'API_BASE',
+  'AUTH_TOKEN',
+  'MULTITABLE_AUTOMATION_SOAK_CONFIRM',
+  'MULTITABLE_AUTOMATION_SOAK_EMAIL_SAFE_MODE',
+  'MULTITABLE_AUTOMATION_SOAK_WEBHOOK_URL',
+  'MULTITABLE_AUTOMATION_SOAK_FAIL_WEBHOOK_URL',
+]
+
+function envString(env, name) {
+  return typeof env[name] === 'string' ? env[name].trim() : ''
+}
+
+function normalizeApiBase(rawValue) {
+  const value = (rawValue || '').trim().replace(/\/+$/, '')
+  if (!value) return { ok: false, value: '', error: 'API_BASE is required' }
+  let parsed
+  try {
+    parsed = new URL(value)
+  } catch {
+    return { ok: false, value: '', error: 'API_BASE must be an absolute http(s) URL' }
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return { ok: false, value: '', error: 'API_BASE must use http or https' }
+  }
+  if (parsed.username || parsed.password || parsed.search || parsed.hash) {
+    return {
+      ok: false,
+      value: '',
+      error: 'API_BASE must not contain credentials, query, or fragment',
+    }
+  }
+  return { ok: true, value }
+}
+
+function normalizeWebhookUrl(rawValue, label) {
+  const value = (rawValue || '').trim()
+  if (!value) return { ok: false, value: '', error: `${label} is required` }
+  let parsed
+  try {
+    parsed = new URL(value)
+  } catch {
+    return { ok: false, value: '', error: `${label} must be an absolute http(s) URL` }
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return { ok: false, value: '', error: `${label} must use http or https` }
+  }
+  return { ok: true, value }
+}
+
+function normalizeIterations(rawValue) {
+  if (!rawValue) return 3
+  const parsed = Number(rawValue)
+  if (!Number.isFinite(parsed)) return 3
+  return Math.max(1, Math.min(10, Math.floor(parsed)))
+}
+
+export function resolveAutomationSoakConfig(env = process.env) {
+  const missingEnv = REQUIRED_ENV.filter((name) => !envString(env, name))
+  const messages = []
+  const apiBase = normalizeApiBase(envString(env, 'API_BASE'))
+  const webhookUrl = normalizeWebhookUrl(
+    envString(env, 'MULTITABLE_AUTOMATION_SOAK_WEBHOOK_URL'),
+    'MULTITABLE_AUTOMATION_SOAK_WEBHOOK_URL',
+  )
+  const failWebhookUrl = normalizeWebhookUrl(
+    envString(env, 'MULTITABLE_AUTOMATION_SOAK_FAIL_WEBHOOK_URL'),
+    'MULTITABLE_AUTOMATION_SOAK_FAIL_WEBHOOK_URL',
+  )
+  const confirm = envString(env, 'MULTITABLE_AUTOMATION_SOAK_CONFIRM') === '1'
+  const emailSafeMode = envString(env, 'MULTITABLE_AUTOMATION_SOAK_EMAIL_SAFE_MODE')
+  if (!apiBase.ok) messages.push(apiBase.error)
+  if (!webhookUrl.ok) messages.push(webhookUrl.error)
+  if (!failWebhookUrl.ok) messages.push(failWebhookUrl.error)
+  if (!confirm) messages.push('MULTITABLE_AUTOMATION_SOAK_CONFIRM=1 is required')
+  if (emailSafeMode !== 'mock') {
+    messages.push('MULTITABLE_AUTOMATION_SOAK_EMAIL_SAFE_MODE=mock is required')
+  }
+  return {
+    ok:
+      missingEnv.length === 0 &&
+      apiBase.ok &&
+      webhookUrl.ok &&
+      failWebhookUrl.ok &&
+      confirm &&
+      emailSafeMode === 'mock',
+    apiBase: apiBase.value,
+    authToken: envString(env, 'AUTH_TOKEN'),
+    webhookUrl: webhookUrl.value,
+    failWebhookUrl: failWebhookUrl.value,
+    iterations: normalizeIterations(envString(env, 'MULTITABLE_AUTOMATION_SOAK_ITERATIONS')),
+    pollTimeoutMs: Number(envString(env, 'POLL_TIMEOUT_MS')) || 15000,
+    pollIntervalMs: Number(envString(env, 'POLL_INTERVAL_MS')) || 1000,
+    missingEnv,
+    messages,
+  }
+}
+
+function requireValue(value, label) {
+  if (value === undefined || value === null || value === '') {
+    throw new Error(`Expected ${label} in API response`)
+  }
+  return value
+}
+
+function uniqueLabel(prefix) {
+  return `phase3-soak-${prefix}-${Date.now()}-${Math.floor(Math.random() * 10000)}`
+}
+
+function makeClient(config, fetchFn) {
+  const headers = {
+    Authorization: `Bearer ${config.authToken}`,
+    'Content-Type': 'application/json',
+  }
+  async function request(method, urlPath, body) {
+    const response = await fetchFn(`${config.apiBase}${urlPath}`, {
+      method,
+      headers,
+      body: body === undefined ? undefined : JSON.stringify(body),
+    })
+    let json = null
+    try {
+      json = await response.json()
+    } catch {}
+    if (!response.ok) {
+      throw new Error(`${method} ${urlPath} -> ${response.status}: ${JSON.stringify(json)}`)
+    }
+    return json
+  }
+  return {
+    get: (urlPath) => request('GET', urlPath),
+    post: (urlPath, body) => request('POST', urlPath, body),
+  }
+}
+
+async function createBase(client, name) {
+  return requireValue((await client.post('/api/multitable/bases', { name })).data?.base, 'base')
+}
+
+async function createSheet(client, baseId, name) {
+  return requireValue((await client.post('/api/multitable/sheets', { baseId, name })).data?.sheet, 'sheet')
+}
+
+async function createField(client, sheetId, name, type) {
+  return requireValue(
+    (await client.post('/api/multitable/fields', { sheetId, name, type })).data?.field,
+    `${type} field ${name}`,
+  )
+}
+
+async function createRecord(client, sheetId, data) {
+  return requireValue(
+    (await client.post('/api/multitable/records', { sheetId, data })).data?.record,
+    'record',
+  )
+}
+
+async function createAutomationRule(client, sheetId, body) {
+  return requireValue(
+    (await client.post(`/api/multitable/sheets/${sheetId}/automations`, body)).data?.rule,
+    `automation rule ${body.name}`,
+  )
+}
+
+async function getAutomationLogs(client, sheetId, ruleId, limit) {
+  const body = await client.get(`/api/multitable/sheets/${sheetId}/automations/${ruleId}/logs?limit=${limit}`)
+  return Array.isArray(body?.executions) ? body.executions : []
+}
+
+async function pollForExecutions(client, config, sheetId, ruleId, count) {
+  const deadline = Date.now() + config.pollTimeoutMs
+  let last = []
+  while (Date.now() < deadline) {
+    last = await getAutomationLogs(client, sheetId, ruleId, Math.max(20, count + 5))
+    if (last.length >= count) return last.slice(0, count)
+    await new Promise((resolve) => setTimeout(resolve, config.pollIntervalMs))
+  }
+  throw new Error(`Expected ${count} executions for rule ${ruleId}; observed ${last.length}`)
+}
+
+function assertAllExecutions(executions, ruleName, expectedStatus, expectedActionType) {
+  for (const execution of executions) {
+    if (execution.status !== expectedStatus) {
+      throw new Error(`${ruleName} execution ${execution.id} status=${execution.status}; expected ${expectedStatus}`)
+    }
+    const step = execution.steps?.[0]
+    if (step?.actionType !== expectedActionType) {
+      throw new Error(`${ruleName} step.actionType=${step?.actionType}; expected ${expectedActionType}`)
+    }
+    if (step?.status !== expectedStatus) {
+      throw new Error(`${ruleName} step.status=${step?.status}; expected ${expectedStatus}`)
+    }
+  }
+}
+
+async function runConfiguredSoak(config, fetchFn) {
+  const client = makeClient(config, fetchFn)
+  const label = uniqueLabel('d4')
+  const base = await createBase(client, `${label}-base`)
+  const sheet = await createSheet(client, base.id, `${label}-sheet`)
+  const title = await createField(client, sheet.id, 'Title', 'string')
+  const status = await createField(client, sheet.id, 'Status', 'string')
+  const owner = await createField(client, sheet.id, 'Owner', 'string')
+
+  const updateRule = await createAutomationRule(client, sheet.id, {
+    name: `${label}-update-record`,
+    triggerType: 'record.created',
+    triggerConfig: {},
+    actionType: 'update_record',
+    actionConfig: { fields: { [status.id]: 'soaked' } },
+    enabled: true,
+  })
+  const emailRule = await createAutomationRule(client, sheet.id, {
+    name: `${label}-send-email`,
+    triggerType: 'record.created',
+    triggerConfig: {},
+    actionType: 'send_email',
+    actionConfig: {
+      recipients: ['phase3-soak-team-test-local', 'phase3-soak-lead-test-local'],
+      subjectTemplate: '[phase3-soak] {{recordId}}',
+      bodyTemplate: `Title={{record.${title.id}}} Owner={{record.${owner.id}}}`,
+    },
+    enabled: true,
+  })
+  const webhookRule = await createAutomationRule(client, sheet.id, {
+    name: `${label}-send-webhook`,
+    triggerType: 'record.created',
+    triggerConfig: {},
+    actionType: 'send_webhook',
+    actionConfig: {
+      url: config.webhookUrl,
+      method: 'POST',
+      body: { source: 'phase3-automation-soak', mode: 'success' },
+    },
+    enabled: true,
+  })
+  const failWebhookRule = await createAutomationRule(client, sheet.id, {
+    name: `${label}-send-webhook-fail`,
+    triggerType: 'record.created',
+    triggerConfig: {},
+    actionType: 'send_webhook',
+    actionConfig: {
+      url: config.failWebhookUrl,
+      method: 'POST',
+      body: { source: 'phase3-automation-soak', mode: 'expected-failure' },
+    },
+    enabled: true,
+  })
+
+  const createdRecords = []
+  for (let i = 0; i < config.iterations; i += 1) {
+    const record = await createRecord(client, sheet.id, {
+      [title.id]: `${label}-record-${i + 1}`,
+      [owner.id]: `owner-${i + 1}`,
+    })
+    createdRecords.push(record.id)
+  }
+
+  const [updateExecutions, emailExecutions, webhookExecutions, failWebhookExecutions] = await Promise.all([
+    pollForExecutions(client, config, sheet.id, updateRule.id, config.iterations),
+    pollForExecutions(client, config, sheet.id, emailRule.id, config.iterations),
+    pollForExecutions(client, config, sheet.id, webhookRule.id, config.iterations),
+    pollForExecutions(client, config, sheet.id, failWebhookRule.id, config.iterations),
+  ])
+
+  assertAllExecutions(updateExecutions, 'update_record', 'success', 'update_record')
+  assertAllExecutions(emailExecutions, 'send_email', 'success', 'send_email')
+  assertAllExecutions(webhookExecutions, 'send_webhook', 'success', 'send_webhook')
+  assertAllExecutions(failWebhookExecutions, 'send_webhook expected failure', 'failed', 'send_webhook')
+
+  for (const step of emailExecutions.map((execution) => execution.steps?.[0])) {
+    if (step?.output?.recipientCount !== 2) {
+      throw new Error(`send_email recipientCount=${step?.output?.recipientCount}; expected 2`)
+    }
+    if (step?.output?.notificationStatus !== 'sent') {
+      throw new Error(`send_email notificationStatus=${step?.output?.notificationStatus}; expected sent`)
+    }
+  }
+  for (const step of webhookExecutions.map((execution) => execution.steps?.[0])) {
+    const httpStatus = Number(step?.output?.httpStatus)
+    if (!Number.isFinite(httpStatus) || httpStatus < 200 || httpStatus >= 300) {
+      throw new Error(`send_webhook httpStatus=${step?.output?.httpStatus}; expected 2xx`)
+    }
+  }
+  for (const step of failWebhookExecutions.map((execution) => execution.steps?.[0])) {
+    if (!step?.error) {
+      throw new Error('expected-failure webhook step did not record an error')
+    }
+  }
+
+  const records = (await client.get(`/api/multitable/records?sheetId=${sheet.id}`)).data?.records ?? []
+  for (const recordId of createdRecords) {
+    const persisted = records.find((record) => record.id === recordId)
+    if (!persisted) throw new Error(`created record ${recordId} missing from read-back`)
+    if (persisted.data?.[status.id] !== 'soaked') {
+      throw new Error(`record ${recordId} status=${persisted.data?.[status.id]}; expected soaked`)
+    }
+  }
+
+  return {
+    sheetId: sheet.id,
+    iterations: config.iterations,
+    recordsCreated: createdRecords.length,
+    rules: [
+      { actionType: 'update_record', ruleId: updateRule.id, executions: updateExecutions.length },
+      { actionType: 'send_email', ruleId: emailRule.id, executions: emailExecutions.length },
+      { actionType: 'send_webhook', ruleId: webhookRule.id, executions: webhookExecutions.length },
+      {
+        actionType: 'send_webhook',
+        ruleId: failWebhookRule.id,
+        executions: failWebhookExecutions.length,
+        expectedFailure: true,
+      },
+    ],
+  }
+}
+
+export async function runAutomationSoak({ env = process.env, fetchFn = globalThis.fetch } = {}) {
+  const startedAt = new Date().toISOString()
+  const config = resolveAutomationSoakConfig(env)
+  if (!config.ok) {
+    return {
+      tool: TOOL,
+      gate: 'automation:soak',
+      status: 'blocked',
+      exitCode: EXIT_BLOCKED,
+      reason: 'Automation soak is BLOCKED until API/auth/confirm/email-safe-mode/webhook sink env is configured.',
+      requiredEnv: REQUIRED_ENV,
+      missingEnv: config.missingEnv,
+      messages: config.messages,
+      startedAt,
+      completedAt: new Date().toISOString(),
+    }
+  }
+  try {
+    const evidence = await runConfiguredSoak(config, fetchFn)
+    return {
+      tool: TOOL,
+      gate: 'automation:soak',
+      status: 'pass',
+      exitCode: EXIT_PASS,
+      reason: 'Automation soak passed.',
+      startedAt,
+      completedAt: new Date().toISOString(),
+      iterations: config.iterations,
+      evidence,
+    }
+  } catch (error) {
+    return {
+      tool: TOOL,
+      gate: 'automation:soak',
+      status: 'fail',
+      exitCode: EXIT_FAIL,
+      reason: redactString(error instanceof Error ? error.message : String(error)),
+      startedAt,
+      completedAt: new Date().toISOString(),
+      iterations: config.iterations,
+    }
+  }
+}
+
+function outputPath(env, envName, fallback) {
+  const raw = envString(env, envName)
+  return path.resolve(process.cwd(), raw || fallback)
+}
+
+async function main() {
+  const outputDir = outputPath(process.env, 'AUTOMATION_SOAK_OUTPUT_DIR', DEFAULT_OUTPUT_DIR)
+  const outputJson = outputPath(process.env, 'AUTOMATION_SOAK_JSON', path.join(outputDir, 'report.json'))
+  const outputMd = outputPath(process.env, 'AUTOMATION_SOAK_MD', path.join(outputDir, 'report.md'))
+  mkdirSync(outputDir, { recursive: true })
+  const result = await runAutomationSoak()
+  const report = buildReport(result)
+  writeReport({ outputJson, outputMd, report })
+  console.log(redactString(`[${TOOL}] status=${report.status} exit=${report.exitCode}`))
+  console.log(redactString(`[${TOOL}] report json: ${outputJson}`))
+  console.log(redactString(`[${TOOL}] report md:   ${outputMd}`))
+  return report.exitCode
+}
+
+const invokedDirectly = import.meta.url === `file://${process.argv[1]}`
+
+if (invokedDirectly) {
+  main()
+    .then((exitCode) => {
+      process.exit(exitCode)
+    })
+    .catch((error) => {
+      console.error(redactString(error instanceof Error ? error.message : String(error)))
+      process.exit(EXIT_FAIL)
+    })
+}

--- a/scripts/ops/multitable-automation-soak.test.mjs
+++ b/scripts/ops/multitable-automation-soak.test.mjs
@@ -1,0 +1,177 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { spawnSync } from 'node:child_process'
+
+import { resolveAutomationSoakConfig, runAutomationSoak } from './multitable-automation-soak.mjs'
+
+const SCRIPT = 'scripts/ops/multitable-automation-soak.mjs'
+
+function makeJsonResponse(status, body) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    async json() {
+      return body
+    },
+  }
+}
+
+function makeFakeFetch() {
+  let fieldSeq = 0
+  let ruleSeq = 0
+  let recordSeq = 0
+  const fields = []
+  const rules = []
+  const records = []
+  const executionsByRuleId = new Map()
+
+  function addExecutions(record) {
+    for (const rule of rules) {
+      const step = {
+        actionType: rule.actionType,
+        status: rule.expectedFailure ? 'failed' : 'success',
+      }
+      if (rule.actionType === 'update_record') {
+        step.output = { updatedFields: Object.keys(rule.actionConfig.fields ?? {}) }
+        Object.assign(record.data, rule.actionConfig.fields ?? {})
+      } else if (rule.actionType === 'send_email') {
+        step.output = { recipientCount: 2, notificationStatus: 'sent' }
+      } else if (rule.actionType === 'send_webhook' && rule.expectedFailure) {
+        step.error = 'Webhook failed after 3 attempts: HTTP 500'
+      } else if (rule.actionType === 'send_webhook') {
+        step.output = { httpStatus: 204, attempt: 1 }
+      }
+      const execution = {
+        id: `exec_${rule.id}_${record.id}`,
+        status: rule.expectedFailure ? 'failed' : 'success',
+        steps: [step],
+      }
+      const current = executionsByRuleId.get(rule.id) ?? []
+      executionsByRuleId.set(rule.id, [execution, ...current])
+    }
+  }
+
+  return async function fakeFetch(url, options = {}) {
+    const parsed = new URL(url)
+    const route = parsed.pathname
+    const body = options.body ? JSON.parse(options.body) : {}
+
+    if (options.method === 'POST' && route === '/api/multitable/bases') {
+      return makeJsonResponse(200, { data: { base: { id: 'base_fake', name: body.name } } })
+    }
+    if (options.method === 'POST' && route === '/api/multitable/sheets') {
+      return makeJsonResponse(200, { data: { sheet: { id: 'sheet_fake', baseId: body.baseId } } })
+    }
+    if (options.method === 'POST' && route === '/api/multitable/fields') {
+      fieldSeq += 1
+      const field = { id: `field_${fieldSeq}`, name: body.name, type: body.type }
+      fields.push(field)
+      return makeJsonResponse(200, { data: { field } })
+    }
+    if (options.method === 'POST' && route === '/api/multitable/sheets/sheet_fake/automations') {
+      ruleSeq += 1
+      const rule = {
+        id: `rule_${ruleSeq}`,
+        actionType: body.actionType,
+        actionConfig: body.actionConfig,
+        expectedFailure: body.name.includes('fail'),
+      }
+      rules.push(rule)
+      executionsByRuleId.set(rule.id, [])
+      return makeJsonResponse(200, { data: { rule } })
+    }
+    if (options.method === 'POST' && route === '/api/multitable/records') {
+      recordSeq += 1
+      const record = { id: `record_${recordSeq}`, data: { ...body.data } }
+      records.push(record)
+      addExecutions(record)
+      return makeJsonResponse(200, { data: { record } })
+    }
+    if (options.method === 'GET' && route === '/api/multitable/records') {
+      return makeJsonResponse(200, { data: { records } })
+    }
+    const logs = route.match(/^\/api\/multitable\/sheets\/sheet_fake\/automations\/([^/]+)\/logs$/)
+    if (options.method === 'GET' && logs) {
+      return makeJsonResponse(200, { executions: executionsByRuleId.get(logs[1]) ?? [] })
+    }
+    return makeJsonResponse(404, { error: { message: `unhandled ${options.method} ${route}` } })
+  }
+}
+
+function completeEnv() {
+  return {
+    API_BASE: 'https://metasheet.test',
+    AUTH_TOKEN: 'fake-admin-token',
+    MULTITABLE_AUTOMATION_SOAK_CONFIRM: '1',
+    MULTITABLE_AUTOMATION_SOAK_EMAIL_SAFE_MODE: 'mock',
+    MULTITABLE_AUTOMATION_SOAK_WEBHOOK_URL: 'https://sink.test/success',
+    MULTITABLE_AUTOMATION_SOAK_FAIL_WEBHOOK_URL: 'https://sink.test/fail',
+    MULTITABLE_AUTOMATION_SOAK_ITERATIONS: '2',
+    POLL_TIMEOUT_MS: '200',
+    POLL_INTERVAL_MS: '1',
+  }
+}
+
+test('resolveAutomationSoakConfig blocks by default', () => {
+  const config = resolveAutomationSoakConfig({})
+  assert.equal(config.ok, false)
+  assert.ok(config.missingEnv.includes('API_BASE'))
+  assert.ok(config.messages.some((message) => message.includes('CONFIRM')))
+})
+
+test('resolveAutomationSoakConfig rejects credential-bearing API_BASE', () => {
+  const config = resolveAutomationSoakConfig({
+    ...completeEnv(),
+    API_BASE: 'https://user:pass@metasheet.test?token=secret',
+  })
+  assert.equal(config.ok, false)
+  assert.ok(config.messages.some((message) => message.includes('credentials')))
+})
+
+test('runAutomationSoak returns blocked report when required env is missing', async () => {
+  const report = await runAutomationSoak({ env: {}, fetchFn: makeFakeFetch() })
+  assert.equal(report.status, 'blocked')
+  assert.equal(report.exitCode, 2)
+  assert.ok(report.missingEnv.includes('AUTH_TOKEN'))
+})
+
+test('runAutomationSoak passes against fake API and validates expected-failure webhook logs', async () => {
+  const report = await runAutomationSoak({ env: completeEnv(), fetchFn: makeFakeFetch() })
+  assert.equal(report.status, 'pass')
+  assert.equal(report.exitCode, 0)
+  assert.equal(report.evidence.iterations, 2)
+  assert.equal(report.evidence.recordsCreated, 2)
+  const failureRule = report.evidence.rules.find((rule) => rule.expectedFailure)
+  assert.equal(failureRule.actionType, 'send_webhook')
+  assert.equal(failureRule.executions, 2)
+})
+
+test('spawned script blocks by default and writes redacted artifacts', () => {
+  const dir = mkdtempSync(path.join(tmpdir(), 'mt-automation-soak-'))
+  try {
+    const result = spawnSync('node', [SCRIPT], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        AUTOMATION_SOAK_OUTPUT_DIR: dir,
+        AUTOMATION_SOAK_JSON: path.join(dir, 'report.json'),
+        AUTOMATION_SOAK_MD: path.join(dir, 'report.md'),
+        AUTH_TOKEN: 'Bearer leaky-admin-token-value',
+        MULTITABLE_AUTOMATION_SOAK_WEBHOOK_URL: 'https://sink.test/success?access_token=leaky-token',
+      },
+      encoding: 'utf8',
+    })
+    assert.equal(result.status, 2)
+    const json = readFileSync(path.join(dir, 'report.json'), 'utf8')
+    const md = readFileSync(path.join(dir, 'report.md'), 'utf8')
+    const all = `${result.stdout}\n${result.stderr}\n${json}\n${md}`
+    assert.doesNotMatch(all, /leaky-admin-token-value/)
+    assert.doesNotMatch(all, /leaky-token/)
+    assert.match(all, /blocked/)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})

--- a/scripts/ops/multitable-phase3-release-gate.mjs
+++ b/scripts/ops/multitable-phase3-release-gate.mjs
@@ -5,9 +5,8 @@
  *
  * Routing + blocked-mode + shared redaction + JSON+MD report writer.
  * D1 binds the existing guarded email real-send smoke into this
- * aggregator. Remaining skeleton gates stay blocked until their
- * dedicated follow-up PRs land. D2/D3 stay blocked under the K3 PoC
- * stage-1 lock.
+ * aggregator. D4 binds the guarded automation soak harness. D2/D3
+ * stay blocked under the K3 PoC stage-1 lock.
  *
  * Exit codes:
  *   0  PASS
@@ -35,6 +34,8 @@ const TOOL = 'multitable-phase3-release-gate'
 const DEFAULT_OUTPUT_DIR = 'output/multitable-phase3-release-gate'
 const EMAIL_REAL_SEND_GATE = 'email:real-send'
 const EMAIL_REAL_SEND_COMMAND = 'pnpm verify:multitable-email:real-send'
+const AUTOMATION_SOAK_GATE = 'automation:soak'
+const AUTOMATION_SOAK_COMMAND = 'pnpm verify:multitable-automation:soak'
 
 const EXIT_PASS = 0
 const EXIT_FAIL = 1
@@ -67,12 +68,19 @@ const SUB_GATES = {
     blockedReason:
       'Lane D3 deferred. Requires explicit snapshot-vs-golden-matrix semantics decision (T5) before activation.',
   },
-  'automation:soak': {
-    kind: 'skeleton',
-    requiredEnv: ['MULTITABLE_AUTOMATION_SOAK_CONFIRM'],
+  [AUTOMATION_SOAK_GATE]: {
+    kind: 'delegate',
+    requiredEnv: [
+      'API_BASE',
+      'AUTH_TOKEN',
+      'MULTITABLE_AUTOMATION_SOAK_CONFIRM',
+      'MULTITABLE_AUTOMATION_SOAK_EMAIL_SAFE_MODE',
+      'MULTITABLE_AUTOMATION_SOAK_WEBHOOK_URL',
+      'MULTITABLE_AUTOMATION_SOAK_FAIL_WEBHOOK_URL',
+    ],
     deferral: 'D4 — Automation Soak Gate',
     blockedReason:
-      'Lane D4 implementation stub. D0 skeleton only; real soak harness lands in PR R4.',
+      'Lane D4 delegates to verify:multitable-automation:soak and stays BLOCKED until API/auth/confirm/email-safe-mode/webhook sink env is configured.',
   },
 }
 
@@ -82,10 +90,10 @@ const PUBLIC_GATES = [AGGREGATE_GATE, ...Object.keys(SUB_GATES)]
 function printHelp() {
   console.log(`Usage: node scripts/ops/multitable-phase3-release-gate.mjs --gate <id> [options]
 
-Runs the Phase 3 release gate skeleton. All sub-gates are blocked at
-the D0/D1 PR stage unless their real harness is explicitly wired and
-configured. D1 delegates \`email:real-send\` to the existing guarded
-SMTP smoke harness.
+Runs the Phase 3 release gate. D1 delegates \`email:real-send\` to
+the existing guarded SMTP smoke harness. D4 delegates
+\`automation:soak\` to the guarded automation soak harness. Deferred
+or unconfigured gates return BLOCKED.
 
 Gates:
   ${PUBLIC_GATES.map((g) => `\`${g}\``).join(', ')}
@@ -265,9 +273,68 @@ function runEmailRealSendGate(env, options = {}) {
   }
 }
 
+function runAutomationSoakGate(env, options = {}) {
+  const config = SUB_GATES[AUTOMATION_SOAK_GATE]
+  const startedAt = new Date().toISOString()
+  const outputDir =
+    options.outputDir ??
+    path.resolve(process.cwd(), DEFAULT_OUTPUT_DIR, AUTOMATION_SOAK_GATE.replace(/:/g, '-'))
+  const childDir = path.join(outputDir, 'automation-soak')
+  const childReportJson = path.join(childDir, 'report.json')
+  const childReportMd = path.join(childDir, 'report.md')
+  mkdirSync(childDir, { recursive: true })
+
+  const child = spawnSync('pnpm', ['verify:multitable-automation:soak'], {
+    cwd: options.cwd ?? process.cwd(),
+    env: keepProcessEnvForChild(env, {
+      AUTOMATION_SOAK_OUTPUT_DIR: childDir,
+      AUTOMATION_SOAK_JSON: childReportJson,
+      AUTOMATION_SOAK_MD: childReportMd,
+    }),
+    encoding: 'utf8',
+  })
+
+  const childExitCode = typeof child.status === 'number' ? child.status : EXIT_FAIL
+  const status = child.error ? 'fail' : statusFromExitCode(childExitCode)
+  const exitCode = status === 'pass' ? EXIT_PASS : status === 'blocked' ? EXIT_BLOCKED : EXIT_FAIL
+  const childReport = safeReadJson(childReportJson)
+  const missingEnv = config.requiredEnv.filter((name) => !env[name] || env[name] === '')
+
+  let reason = 'Automation soak passed.'
+  if (child.error) {
+    reason = `Failed to launch delegated automation soak: ${child.error.message}`
+  } else if (status === 'blocked') {
+    reason =
+      'Delegated automation soak is BLOCKED. Configure API/auth, explicit soak confirmation, mock email safe-mode acknowledgement, and controlled webhook sinks before treating this gate as GO.'
+  } else if (status === 'fail') {
+    reason = 'Delegated automation soak returned FAIL.'
+  }
+
+  return {
+    tool: TOOL,
+    gate: AUTOMATION_SOAK_GATE,
+    status,
+    exitCode,
+    reason,
+    requiredEnv: config.requiredEnv,
+    missingEnv,
+    deferral: config.deferral,
+    startedAt,
+    completedAt: new Date().toISOString(),
+    delegatedCommand: AUTOMATION_SOAK_COMMAND,
+    childExitCode,
+    childReportJson,
+    childReportMd,
+    childStatus: childReport?.status ?? status,
+    childIterations: childReport?.iterations,
+    childEvidence: childReport?.evidence,
+  }
+}
+
 function runSubGate(gate, env, options = {}) {
   const config = SUB_GATES[gate]
   if (gate === EMAIL_REAL_SEND_GATE) return runEmailRealSendGate(env, options)
+  if (gate === AUTOMATION_SOAK_GATE) return runAutomationSoakGate(env, options)
   const startedAt = new Date().toISOString()
   const missingEnv = config.requiredEnv.filter((name) => !env[name] || env[name] === '')
   const baseReport = {

--- a/scripts/ops/multitable-phase3-release-gate.test.mjs
+++ b/scripts/ops/multitable-phase3-release-gate.test.mjs
@@ -20,7 +20,13 @@ function runGate(gate, { env = {}, allowBlocked = false } = {}) {
     'MULTITABLE_PERF_LARGE_TABLE_CONFIRM',
     'MULTITABLE_PERF_TARGET_DB',
     'MULTITABLE_PERM_MATRIX_CONFIRM',
+    'API_BASE',
+    'AUTH_TOKEN',
     'MULTITABLE_AUTOMATION_SOAK_CONFIRM',
+    'MULTITABLE_AUTOMATION_SOAK_EMAIL_SAFE_MODE',
+    'MULTITABLE_AUTOMATION_SOAK_WEBHOOK_URL',
+    'MULTITABLE_AUTOMATION_SOAK_FAIL_WEBHOOK_URL',
+    'MULTITABLE_AUTOMATION_SOAK_ITERATIONS',
     'MULTITABLE_EMAIL_TRANSPORT',
     'MULTITABLE_EMAIL_SMTP_HOST',
     'MULTITABLE_EMAIL_SMTP_PORT',
@@ -133,6 +139,10 @@ test('automation:soak exits 2 (blocked) by default via spawn', () => {
     assert.equal(r.exitCode, 2)
     const obj = JSON.parse(r.json)
     assert.equal(obj.status, 'blocked')
+    assert.equal(obj.delegatedCommand, 'pnpm verify:multitable-automation:soak')
+    assert.equal(obj.childExitCode, 2)
+    assert.equal(obj.childStatus, 'blocked')
+    assert.match(obj.childReportJson, /automation-soak\/report\.json$/)
   } finally {
     cleanup(r.dir)
   }
@@ -169,6 +179,10 @@ test('release:phase3 aggregator exits 2 (blocked) not 1 (fail) via spawn', () =>
     assert.equal(emailChild.delegatedCommand, 'pnpm verify:multitable-email:real-send')
     assert.match(emailChild.childReportJson, /children\/email-real-send\/real-send-smoke\/report\.json$/)
     assert.ok(obj.children.every((c) => c.status === 'blocked' && c.exitCode === 2))
+    const automationChild = obj.children.find((c) => c.gate === 'automation:soak')
+    assert.ok(automationChild)
+    assert.equal(automationChild.delegatedCommand, 'pnpm verify:multitable-automation:soak')
+    assert.match(automationChild.childReportJson, /children\/automation-soak\/automation-soak\/report\.json$/)
     assert.match(obj.reason, /BLOCKED/)
   } finally {
     cleanup(r.dir)
@@ -259,6 +273,24 @@ test('artifact integrity — email:real-send delegate output paths and summary d
     assert.doesNotMatch(all, /emailGatePrivatePw99/)
     assert.doesNotMatch(all, /email-gate-from-address/)
     assert.doesNotMatch(all, /email-gate-to-address/)
+  } finally {
+    cleanup(r.dir)
+  }
+})
+
+test('artifact integrity — automation:soak delegate does not leak auth token or webhook URLs', () => {
+  const env = {
+    API_BASE: 'https://metasheet-soak.example.com',
+    AUTH_TOKEN: 'automation-soak-private-token',
+    MULTITABLE_AUTOMATION_SOAK_WEBHOOK_URL: 'https://sink-soak.example.com/success/private-success',
+    MULTITABLE_AUTOMATION_SOAK_FAIL_WEBHOOK_URL: 'https://sink-soak.example.com/fail/private-fail',
+  }
+  const r = runGate('automation:soak', { env })
+  try {
+    const all = `${r.stdout}\n${r.stderr}\n${r.json ?? ''}\n${r.md ?? ''}`
+    assert.doesNotMatch(all, /automation-soak-private-token/)
+    assert.doesNotMatch(all, /private-success/)
+    assert.doesNotMatch(all, /private-fail/)
   } finally {
     cleanup(r.dir)
   }


### PR DESCRIPTION
## Summary

- Add `scripts/ops/multitable-automation-soak.mjs`, a guarded remote/API automation soak harness.
- Wire `automation:soak` in the Phase 3 release gate to delegate to `pnpm verify:multitable-automation:soak`.
- Exercise repeated `record.created` automation paths for `update_record`, `send_email`, `send_webhook`, and controlled failed webhook log persistence when configured.
- Update Phase 3 TODO plus D4 development / verification MDs.

## Safety

The harness is BLOCKED by default. It requires `API_BASE`, `AUTH_TOKEN`, `MULTITABLE_AUTOMATION_SOAK_CONFIRM=1`, `MULTITABLE_AUTOMATION_SOAK_EMAIL_SAFE_MODE=mock`, and controlled success/failure webhook sink URLs before it can run against a real deployment.

No product runtime, schema, migration, K3 PoC path, or AI surface is changed.

## Verification

- `node --test scripts/ops/multitable-automation-soak.test.mjs scripts/ops/multitable-phase3-release-gate.test.mjs scripts/ops/multitable-phase3-release-gate-report.test.mjs` → 26/26 pass
- `pnpm verify:multitable-automation:soak` → exit 2 / BLOCKED in clean env
- `node scripts/ops/multitable-phase3-release-gate.mjs --gate automation:soak --output-dir /tmp/ms2-d4-automation-soak-gate` → exit 2 / BLOCKED in clean env
- `pnpm verify:multitable-release:phase3` → exit 2 / BLOCKED by design; D2/D3 remain deferred blockers
- `git diff --check` → clean
- Changed-diff scan for bearer/JWT/sk/SEC/password/token/webhook-secret/email-like patterns → clean

## Docs

- `docs/development/multitable-phase3-automation-soak-gate-development-20260514.md`
- `docs/development/multitable-phase3-automation-soak-gate-verification-20260514.md`
