### PR TITLE
fix(integration): clarify data factory onboarding readiness

### DIFF
--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -86,8 +86,8 @@
           <ul class="integration-workbench__inventory-list">
             <li v-for="descriptor in stagingDatasetCards" :key="descriptor.id">
               <strong>{{ descriptor.name }}</strong>
-              <span>{{ descriptor.area }} · {{ descriptor.fieldCount }} fields</span>
-              <small>{{ descriptor.openLink ? '可打开多维表' : '等待安装后返回 open link' }}</small>
+              <span>{{ descriptor.area }} · {{ descriptor.fieldCount }} 个字段</span>
+              <small>{{ descriptor.openLink ? '可打开多维表' : '等待安装后返回打开链接' }}</small>
             </li>
           </ul>
         </div>
@@ -238,7 +238,7 @@
           </div>
           <p>{{ sourceDatasetDescription }}</p>
           <div class="integration-workbench__metric-row">
-            <span>{{ sourceSchema.fields.length }} fields</span>
+            <span>{{ sourceSchema.fields.length }} 个字段</span>
             <span>{{ sourceConnectionLabel }}</span>
           </div>
         </article>
@@ -250,7 +250,7 @@
           </div>
           <p>原始区、清洗区和回写区都在多维表中呈现，业务人员不需要直接维护 JSON。</p>
           <div class="integration-workbench__metric-row">
-            <span>{{ stagingDescriptors.length }} tables</span>
+            <span>{{ stagingDescriptors.length }} 张表</span>
             <span>{{ selectedStagingDescriptor ? getStagingAreaLabel(selectedStagingDescriptor.id) : '待选择' }}</span>
           </div>
         </article>
@@ -262,8 +262,8 @@
           </div>
           <p>{{ targetDatasetDescription }}</p>
           <div class="integration-workbench__metric-row">
-            <span>{{ targetSchema.fields.length }} fields</span>
-            <span>{{ requiredTargetFieldCount }} required</span>
+            <span>{{ targetSchema.fields.length }} 个字段</span>
+            <span>{{ requiredTargetFieldCount }} 个必填</span>
           </div>
         </article>
       </div>
@@ -273,7 +273,7 @@
           <div>
             <strong>{{ descriptor.name }}</strong>
             <p>{{ descriptor.description }}</p>
-            <small>{{ descriptor.id }} · {{ descriptor.fieldCount }} fields · {{ descriptor.area }}</small>
+            <small>{{ descriptor.id }} · {{ descriptor.fieldCount }} 个字段 · {{ descriptor.area }}</small>
           </div>
           <a
             v-if="descriptor.openLink"
@@ -772,8 +772,11 @@ const dryRunReadinessItems = computed(() => [
   {
     id: 'source-system',
     label: '选择可读取的数据源',
-    ready: Boolean(sourceSystemId.value && selectedSourceSystem.value && !sourceRuntimeBlocker.value),
-    detail: sourceRuntimeBlocker.value || (sourceSystemId.value ? '数据源已选择' : '还没有选择数据源；也可以先使用 K3 预设配置目标，再补来源。'),
+    ready: Boolean(sourceSystemId.value && selectedSourceSystem.value?.status === 'active' && !sourceRuntimeBlocker.value),
+    detail: sourceRuntimeBlocker.value
+      || (selectedSourceSystem.value && selectedSourceSystem.value.status !== 'active'
+        ? connectionStatusLabel(selectedSourceSystem.value)
+        : (sourceSystemId.value ? '数据源已选择且状态可用' : '还没有选择数据源；也可以先使用 K3 预设配置目标，再补来源。')),
   },
   {
     id: 'source-object',
@@ -784,8 +787,10 @@ const dryRunReadinessItems = computed(() => [
   {
     id: 'target-system',
     label: '选择目标系统',
-    ready: Boolean(targetSystemId.value),
-    detail: targetSystemId.value ? '目标系统已选择' : '请选择 K3 WebAPI 或其他可写目标。',
+    ready: Boolean(targetSystemId.value && selectedTargetSystem.value?.status === 'active'),
+    detail: selectedTargetSystem.value && selectedTargetSystem.value.status !== 'active'
+      ? connectionStatusLabel(selectedTargetSystem.value)
+      : (targetSystemId.value ? '目标系统已选择且状态可用' : '请选择 K3 WebAPI 或其他可写目标。'),
   },
   {
     id: 'target-object',
@@ -838,10 +843,10 @@ function isAdvancedSystem(system: WorkbenchExternalSystem): boolean {
 function runtimeBlockerForSystem(system: WorkbenchExternalSystem | null): string {
   if (!system) return ''
   const errorText = system.lastError || ''
-  if (/queryExecutor/i.test(errorText)) {
+  if (system.kind === 'erp:k3-wise-sqlserver' && /queryExecutor|executor|injected|注入|执行器/i.test(errorText)) {
     return 'SQL 连接已配置，但当前部署未注入 SQL 执行器；可保留为高级连接，暂不能作为可读 source 执行 dry-run。'
   }
-  if (system.kind === 'erp:k3-wise-sqlserver' && system.status === 'error') {
+  if (system.kind === 'erp:k3-wise-sqlserver' && system.status === 'error' && !errorText) {
     return 'K3 SQL Server 只读通道需要部署 allowlist queryExecutor 后才能读取样本或作为 source。'
   }
   return ''

--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -31,6 +31,68 @@
         </button>
       </div>
 
+      <div class="integration-workbench__onboarding" data-testid="connection-onboarding">
+        <div>
+          <strong>连接新系统</strong>
+          <p>从这里开始接入 PLM、ERP、CRM、SRM、HTTP API 或 SQL 数据源；已配置连接会回到下方数据源/目标选择器。</p>
+        </div>
+        <div class="integration-workbench__onboarding-actions">
+          <router-link class="integration-workbench__button" to="/integrations/k3-wise" data-testid="k3-preset-entry">
+            使用 K3 WISE 预设
+          </router-link>
+          <button type="button" class="integration-workbench__button" data-testid="connect-new-system" @click="showConnectionGuide">
+            连接新系统
+          </button>
+          <button type="button" class="integration-workbench__button" data-testid="show-sql-setup" @click="showSqlSetup">
+            查看 SQL / 高级连接
+          </button>
+        </div>
+      </div>
+
+      <button
+        type="button"
+        class="integration-workbench__inventory-toggle"
+        data-testid="toggle-inventory-overview"
+        :aria-expanded="inventoryExpanded ? 'true' : 'false'"
+        @click="inventoryExpanded = !inventoryExpanded"
+      >
+        {{ inventorySummary }} <span>{{ inventoryExpanded ? '收起' : '展开' }}</span>
+      </button>
+
+      <div v-if="inventoryExpanded" class="integration-workbench__inventory" data-testid="inventory-overview">
+        <div>
+          <h3>已配置连接</h3>
+          <div v-if="systems.length === 0" class="integration-workbench__empty">暂无连接。请使用 K3 WISE 预设或后续连接向导创建。</div>
+          <ul v-else class="integration-workbench__inventory-list">
+            <li v-for="system in systems" :key="system.id">
+              <strong>{{ system.name }}</strong>
+              <span>{{ system.kind }} · {{ system.role }} · {{ connectionStatusLabel(system) }}</span>
+              <small v-if="runtimeBlockerForSystem(system)">{{ runtimeBlockerForSystem(system) }}</small>
+            </li>
+          </ul>
+        </div>
+        <div>
+          <h3>可用适配器</h3>
+          <ul class="integration-workbench__inventory-list">
+            <li v-for="adapter in adapters" :key="adapter.kind">
+              <strong>{{ adapter.label }}</strong>
+              <span>{{ adapter.kind }} · {{ adapter.roles.join('/') }}</span>
+              <small>{{ adapter.advanced ? '高级 / 实施人员使用' : '普通连接' }}</small>
+            </li>
+          </ul>
+        </div>
+        <div>
+          <h3>Staging 多维表</h3>
+          <ul class="integration-workbench__inventory-list">
+            <li v-for="descriptor in stagingDatasetCards" :key="descriptor.id">
+              <strong>{{ descriptor.name }}</strong>
+              <span>{{ descriptor.area }} · {{ descriptor.fieldCount }} fields</span>
+              <small>{{ descriptor.openLink ? '可打开多维表' : '等待安装后返回 open link' }}</small>
+            </li>
+          </ul>
+        </div>
+      </div>
+
       <div class="integration-workbench__adapter-list">
         <span
           v-for="adapter in visibleAdapters"
@@ -79,6 +141,17 @@
               </option>
             </select>
           </label>
+          <div v-if="sourceSystems.length === 0" class="integration-workbench__empty integration-workbench__empty--actionable" data-testid="source-empty-state">
+            <strong>还没有可读取的数据源。</strong>
+            <p>连接 PLM、HTTP API 或启用 SQL 只读通道后，可将数据导入 staging 多维表再清洗。</p>
+            <div class="integration-workbench__actions">
+              <router-link class="integration-workbench__button" to="/integrations/k3-wise">使用 K3 WISE 预设</router-link>
+              <button type="button" class="integration-workbench__button" @click="showSqlSetup">启用 SQL 只读通道</button>
+            </div>
+          </div>
+          <div v-if="sourceRuntimeBlocker" class="integration-workbench__hint integration-workbench__hint--strong" data-testid="source-runtime-blocker">
+            {{ sourceRuntimeBlocker }}
+          </div>
           <div class="integration-workbench__connection-row">
             <span class="integration-workbench__badge" :data-status="sourceConnectionStatus">{{ sourceConnectionLabel }}</span>
             <button type="button" class="integration-workbench__button" data-testid="test-source-system" @click="testSystem('source')">
@@ -352,11 +425,25 @@
         <span>允许本次 Save-only 推送。保持 Submit / Audit 关闭。</span>
       </label>
 
+      <div class="integration-workbench__readiness" data-testid="pipeline-readiness">
+        <div>
+          <strong>Dry-run 前置条件</strong>
+          <p>{{ dryRunBlockedSummary }}</p>
+        </div>
+        <ul>
+          <li v-for="item in dryRunReadinessItems" :key="item.id" :data-ready="item.ready ? 'true' : 'false'">
+            <span>{{ item.ready ? '已完成' : '待处理' }}</span>
+            <strong>{{ item.label }}</strong>
+            <small>{{ item.detail }}</small>
+          </li>
+        </ul>
+      </div>
+
       <div class="integration-workbench__actions">
-        <button type="button" class="integration-workbench__button" data-testid="run-dry-run" :disabled="runningPipeline !== ''" @click="executePipeline(true)">
+        <button type="button" class="integration-workbench__button" data-testid="run-dry-run" :disabled="runningPipeline !== '' || !canRunDryRun" @click="executePipeline(true)">
           {{ runningPipeline === 'dry-run' ? 'Dry-run 中' : 'Dry-run' }}
         </button>
-        <button type="button" class="integration-workbench__button integration-workbench__button--danger" data-testid="run-save-only" :disabled="runningPipeline !== '' || !allowSaveOnlyRun" @click="executePipeline(false)">
+        <button type="button" class="integration-workbench__button integration-workbench__button--danger" data-testid="run-save-only" :disabled="runningPipeline !== '' || !allowSaveOnlyRun || !canRunDryRun" @click="executePipeline(false)">
           {{ runningPipeline === 'run' ? '推送中' : 'Save-only 推送' }}
         </button>
       </div>
@@ -570,6 +657,7 @@ const workspaceInput = computed({
 const adapters = ref<IntegrationAdapterMetadata[]>([])
 const systems = ref<WorkbenchExternalSystem[]>([])
 const showAdvancedConnectors = ref(false)
+const inventoryExpanded = ref(false)
 const sourceSystemId = ref('')
 const targetSystemId = ref('')
 const sourceObjects = ref<IntegrationSystemObject[]>([])
@@ -612,6 +700,7 @@ const sampleRecordText = ref(JSON.stringify({
 }, null, 2))
 
 const adapterMetadataByKind = computed(() => new Map(adapters.value.map((adapter) => [adapter.kind, adapter])))
+const inventorySummary = computed(() => `已加载 ${systems.value.length} 个连接 · ${adapters.value.length} 个适配器 · ${stagingDescriptors.value.length} 个 staging 表`)
 const visibleAdapters = computed(() => adapters.value.filter((adapter) => showAdvancedConnectors.value || !adapter.advanced))
 const hiddenAdvancedSystemCount = computed(() => systems.value.filter((system) => isAdvancedSystem(system)).length)
 const visibleSystems = computed(() => systems.value.filter((system) => showAdvancedConnectors.value || !isAdvancedSystem(system)))
@@ -625,6 +714,7 @@ const sourceConnectionStatus = computed(() => selectedSourceSystem.value?.status
 const targetConnectionStatus = computed(() => selectedTargetSystem.value?.status || 'inactive')
 const sourceConnectionLabel = computed(() => connectionStatusLabel(selectedSourceSystem.value))
 const targetConnectionLabel = computed(() => connectionStatusLabel(selectedTargetSystem.value))
+const sourceRuntimeBlocker = computed(() => runtimeBlockerForSystem(selectedSourceSystem.value))
 const sourceDatasetTitle = computed(() => selectedObjectLabel('source') || '请选择来源数据集')
 const targetDatasetTitle = computed(() => selectedObjectLabel('target') || '请选择目标数据集')
 const sourceDatasetDescription = computed(() => selectedSourceSystem.value
@@ -676,6 +766,58 @@ const protocolSplitNotice = computed(() => {
   }
   return ''
 })
+const hasMappingRules = computed(() => mappings.value.some((mapping) => mapping.sourceField.trim() && mapping.targetField.trim()))
+const hasIdempotencyFields = computed(() => parseList(idempotencyFieldsText.value).length > 0)
+const dryRunReadinessItems = computed(() => [
+  {
+    id: 'source-system',
+    label: '选择可读取的数据源',
+    ready: Boolean(sourceSystemId.value && selectedSourceSystem.value && !sourceRuntimeBlocker.value),
+    detail: sourceRuntimeBlocker.value || (sourceSystemId.value ? '数据源已选择' : '还没有选择数据源；也可以先使用 K3 预设配置目标，再补来源。'),
+  },
+  {
+    id: 'source-object',
+    label: '选择来源数据集',
+    ready: Boolean(sourceObjectName.value),
+    detail: sourceObjectName.value || '加载来源数据集后才能保存 pipeline。',
+  },
+  {
+    id: 'target-system',
+    label: '选择目标系统',
+    ready: Boolean(targetSystemId.value),
+    detail: targetSystemId.value ? '目标系统已选择' : '请选择 K3 WebAPI 或其他可写目标。',
+  },
+  {
+    id: 'target-object',
+    label: '选择目标数据集 / 模板',
+    ready: Boolean(targetObjectName.value),
+    detail: targetObjectName.value || '加载目标数据集后才能生成 payload 或保存 pipeline。',
+  },
+  {
+    id: 'mapping',
+    label: '配置清洗映射规则',
+    ready: hasMappingRules.value,
+    detail: hasMappingRules.value ? '至少一条 source -> target 映射已配置。' : '请先加载目标 schema 或手工新增映射。',
+  },
+  {
+    id: 'idempotency',
+    label: '填写幂等字段',
+    ready: hasIdempotencyFields.value,
+    detail: hasIdempotencyFields.value ? '幂等字段已填写。' : '例如 code 或 sourceId,revision。',
+  },
+  {
+    id: 'pipeline-id',
+    label: '保存 Pipeline',
+    ready: Boolean(savedPipelineId.value.trim()),
+    detail: savedPipelineId.value.trim() || 'Payload 预览通过不等于 pipeline dry-run；请先保存 pipeline。',
+  },
+])
+const canRunDryRun = computed(() => dryRunReadinessItems.value.every((item) => item.ready))
+const dryRunBlockedSummary = computed(() => {
+  const missing = dryRunReadinessItems.value.filter((item) => !item.ready)
+  if (missing.length === 0) return '已满足 dry-run 前置条件。Dry-run 只生成 preview，不写外部系统。'
+  return `还缺 ${missing.length} 项：${missing.map((item) => item.label).join('、')}`
+})
 
 function setStatus(message: string, kind: 'success' | 'error' | 'idle' = 'idle'): void {
   statusMessage.value = message
@@ -693,8 +835,31 @@ function isAdvancedSystem(system: WorkbenchExternalSystem): boolean {
   return adapterMetadataByKind.value.get(system.kind)?.advanced === true
 }
 
+function runtimeBlockerForSystem(system: WorkbenchExternalSystem | null): string {
+  if (!system) return ''
+  const errorText = system.lastError || ''
+  if (/queryExecutor/i.test(errorText)) {
+    return 'SQL 连接已配置，但当前部署未注入 SQL 执行器；可保留为高级连接，暂不能作为可读 source 执行 dry-run。'
+  }
+  if (system.kind === 'erp:k3-wise-sqlserver' && system.status === 'error') {
+    return 'K3 SQL Server 只读通道需要部署 allowlist queryExecutor 后才能读取样本或作为 source。'
+  }
+  return ''
+}
+
 function isK3WiseSystem(system: WorkbenchExternalSystem): boolean {
   return system.kind.startsWith('erp:k3-wise')
+}
+
+function showConnectionGuide(): void {
+  inventoryExpanded.value = true
+  setStatus('连接新系统第一步：优先使用 K3 WISE 预设；PLM/HTTP/SQL 连接向导会在后续版本补齐。', 'idle')
+}
+
+function showSqlSetup(): void {
+  showAdvancedConnectors.value = true
+  inventoryExpanded.value = true
+  setStatus('已显示 SQL / 高级连接。SQL source 需要部署 allowlist queryExecutor 后才能读取。', 'idle')
 }
 
 function selectedObjectLabel(side: WorkbenchSide): string {
@@ -1425,6 +1590,93 @@ watch(showAdvancedConnectors, () => {
   margin-top: 14px;
 }
 
+.integration-workbench__onboarding,
+.integration-workbench__readiness {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-top: 14px;
+  padding: 12px;
+  border: 1px solid #d7deea;
+  border-radius: 8px;
+  background: #f8fafc;
+}
+
+.integration-workbench__onboarding strong,
+.integration-workbench__readiness strong {
+  color: #1f3551;
+}
+
+.integration-workbench__onboarding p,
+.integration-workbench__readiness p {
+  margin: 4px 0 0;
+  color: #5c6878;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.integration-workbench__onboarding-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.integration-workbench__inventory-toggle {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 14px;
+  padding: 10px 12px;
+  border: 1px solid #d8e0e8;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #233246;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 700;
+  text-align: left;
+}
+
+.integration-workbench__inventory-toggle span {
+  color: #357abd;
+  font-size: 13px;
+}
+
+.integration-workbench__inventory {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 10px;
+}
+
+.integration-workbench__inventory-list {
+  display: grid;
+  gap: 8px;
+  margin: 10px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.integration-workbench__inventory-list li {
+  display: grid;
+  gap: 4px;
+  padding: 10px;
+  border: 1px solid #e4ebf2;
+  border-radius: 6px;
+  background: #ffffff;
+}
+
+.integration-workbench__inventory-list span,
+.integration-workbench__inventory-list small {
+  color: #5c6878;
+  font-size: 12px;
+  line-height: 1.4;
+}
+
 .integration-workbench__adapter {
   display: inline-flex;
   align-items: center;
@@ -1695,6 +1947,50 @@ watch(showAdvancedConnectors, () => {
   margin-top: 14px;
 }
 
+.integration-workbench__readiness {
+  display: grid;
+  grid-template-columns: minmax(220px, 0.4fr) minmax(0, 1fr);
+}
+
+.integration-workbench__readiness ul {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.integration-workbench__readiness li {
+  display: grid;
+  gap: 4px;
+  padding: 8px;
+  border: 1px solid #e4ebf2;
+  border-radius: 6px;
+  background: #ffffff;
+}
+
+.integration-workbench__readiness li[data-ready="true"] {
+  border-color: #b9dfc4;
+  background: #f3fbf5;
+}
+
+.integration-workbench__readiness li > span {
+  color: #7a4a00;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.integration-workbench__readiness li[data-ready="true"] > span {
+  color: #17622f;
+}
+
+.integration-workbench__readiness small {
+  color: #5c6878;
+  font-size: 12px;
+  line-height: 1.4;
+}
+
 .integration-workbench__export {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(160px, 220px) auto;
@@ -1736,6 +2032,18 @@ watch(showAdvancedConnectors, () => {
   border: 1px dashed #cbd5e1;
   border-radius: 6px;
   color: #5c6878;
+}
+
+.integration-workbench__empty--actionable {
+  margin-top: 10px;
+}
+
+.integration-workbench__empty strong {
+  color: #1f3551;
+}
+
+.integration-workbench__empty p {
+  margin: 6px 0 0;
 }
 
 .integration-workbench__record-list {
@@ -1786,6 +2094,10 @@ watch(showAdvancedConnectors, () => {
   .integration-workbench__observation,
   .integration-workbench__flow,
   .integration-workbench__dataset-grid,
+  .integration-workbench__inventory,
+  .integration-workbench__onboarding,
+  .integration-workbench__readiness,
+  .integration-workbench__readiness ul,
   .integration-workbench__staging-list,
   .integration-workbench__export,
   .integration-workbench__grid {
@@ -1795,6 +2107,15 @@ watch(showAdvancedConnectors, () => {
   .integration-workbench__header,
   .integration-workbench__panel-head {
     display: grid;
+  }
+
+  .integration-workbench__onboarding,
+  .integration-workbench__readiness {
+    display: grid;
+  }
+
+  .integration-workbench__onboarding-actions {
+    justify-content: flex-start;
   }
 }
 </style>

--- a/apps/web/tests/IntegrationWorkbenchView.spec.ts
+++ b/apps/web/tests/IntegrationWorkbenchView.spec.ts
@@ -581,4 +581,63 @@ describe('IntegrationWorkbenchView', () => {
     expect((container.querySelector('[data-testid="show-advanced-connectors"]') as HTMLInputElement).checked).toBe(true)
     expect(container.textContent).toContain('SQL source 需要部署 allowlist queryExecutor 后才能读取')
   })
+
+  it('does not mark error-state source or target systems as dry-run ready', async () => {
+    apiFetchMock.mockImplementation(async (url: string) => {
+      if (url === '/api/integration/adapters') {
+        return jsonResponse([
+          { kind: 'http', label: 'HTTP API', roles: ['source', 'target'], supports: ['read', 'upsert'], advanced: false },
+          { kind: 'erp:k3-wise-webapi', label: 'K3 WISE WebAPI', roles: ['target'], supports: ['upsert'], advanced: false },
+        ])
+      }
+      if (url === '/api/integration/external-systems?tenantId=default') {
+        return jsonResponse([
+          {
+            id: 'plm_error',
+            tenantId: 'default',
+            workspaceId: null,
+            name: 'PLM Source Error',
+            kind: 'http',
+            role: 'source',
+            status: 'error',
+            lastError: 'network timeout',
+          },
+          {
+            id: 'k3_error',
+            tenantId: 'default',
+            workspaceId: null,
+            name: 'K3 Target Error',
+            kind: 'erp:k3-wise-webapi',
+            role: 'target',
+            status: 'error',
+            lastError: 'ERP endpoint unavailable',
+          },
+        ])
+      }
+      if (url === '/api/integration/staging/descriptors') {
+        return jsonResponse([])
+      }
+      throw new Error(`unexpected URL ${url}`)
+    })
+
+    const View = (await import('../src/views/IntegrationWorkbenchView.vue')).default
+
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    app.component('router-link', {
+      props: ['to'],
+      setup(_props, { slots }) {
+        return () => h('a', slots.default?.())
+      },
+    })
+    app.mount(container)
+    await flushUi()
+
+    expect(container.textContent).toContain('异常：network timeout')
+    expect(container.textContent).toContain('异常：ERP endpoint unavailable')
+    expect(container.textContent).toContain('还缺')
+    expect(container.textContent).not.toContain('已满足 dry-run 前置条件')
+    expect((container.querySelector('[data-testid="run-dry-run"]') as HTMLButtonElement).disabled).toBe(true)
+  })
 })

--- a/apps/web/tests/IntegrationWorkbenchView.spec.ts
+++ b/apps/web/tests/IntegrationWorkbenchView.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { createApp, nextTick, type App as VueApp, type Component } from 'vue'
+import { createApp, h, nextTick, type App as VueApp, type Component } from 'vue'
 
 const apiFetchMock = vi.fn()
 
@@ -81,7 +81,16 @@ describe('IntegrationWorkbenchView', () => {
           { id: 'plm_1', tenantId: 'default', workspaceId: null, name: 'PLM Source', kind: 'http', role: 'source', status: 'active' },
           { id: 'k3_1', tenantId: 'default', workspaceId: null, name: 'K3 Target', kind: 'erp:k3-wise-webapi', role: 'target', status: 'active' },
           { id: 'crm_1', tenantId: 'default', workspaceId: null, name: 'CRM Bidirectional', kind: 'http', role: 'bidirectional', status: 'active' },
-          { id: 'k3_sql', tenantId: 'default', workspaceId: null, name: 'K3 SQL Read Channel', kind: 'erp:k3-wise-sqlserver', role: 'source', status: 'active' },
+          {
+            id: 'k3_sql',
+            tenantId: 'default',
+            workspaceId: null,
+            name: 'K3 SQL Read Channel',
+            kind: 'erp:k3-wise-sqlserver',
+            role: 'source',
+            status: 'error',
+            lastError: 'K3 WISE SQL Server channel requires an injected queryExecutor',
+          },
         ])
       }
       if (url === '/api/integration/staging/descriptors') {
@@ -314,14 +323,17 @@ describe('IntegrationWorkbenchView', () => {
     app = createApp(View as Component)
     app.component('router-link', {
       props: ['to'],
-      render() {
-        return null
+      setup(_props, { slots }) {
+        return () => h('a', slots.default?.())
       },
     })
     app.mount(container)
     await flushUi()
 
     expect(container.textContent).toContain('数据工厂')
+    expect(container.textContent).toContain('连接新系统')
+    expect(container.textContent).toContain('使用 K3 WISE 预设')
+    expect(container.textContent).toContain('已加载 4 个连接 · 2 个适配器 · 3 个 staging 表')
     expect(container.textContent).toContain('连接系统')
     expect(container.textContent).toContain('选择数据集')
     expect(container.textContent).toContain('多维表清洗')
@@ -338,6 +350,12 @@ describe('IntegrationWorkbenchView', () => {
     expect(Array.from((container.querySelector('[data-testid="source-system"]') as HTMLSelectElement).options).map((option) => option.textContent))
       .not.toContain('K3 SQL Read Channel · erp:k3-wise-sqlserver')
 
+    ;(container.querySelector('[data-testid="toggle-inventory-overview"]') as HTMLButtonElement).click()
+    await flushUi()
+    expect(container.textContent).toContain('已配置连接')
+    expect(container.textContent).toContain('可用适配器')
+    expect(container.textContent).toContain('SQL 连接已配置，但当前部署未注入 SQL 执行器')
+
     ;(container.querySelector('[data-testid="show-advanced-connectors"]') as HTMLInputElement).click()
     await flushUi()
     expect(container.textContent).toContain('K3 WISE SQL Server Channel')
@@ -353,6 +371,7 @@ describe('IntegrationWorkbenchView', () => {
     sourceSystemSelect.dispatchEvent(new Event('change'))
     await flushUi()
     expect(container.textContent).toContain('SQL read channel 作为来源，WebAPI Save channel 作为目标')
+    expect(container.textContent).toContain('暂不能作为可读 source 执行 dry-run')
 
     sourceSystemSelect.value = 'crm_1'
     sourceSystemSelect.dispatchEvent(new Event('change'))
@@ -466,6 +485,7 @@ describe('IntegrationWorkbenchView', () => {
     })
     expect((container.querySelector('[data-testid="pipeline-id"]') as HTMLInputElement).value).toBe('pipe_1')
     expect(container.textContent).toContain('Pipeline 已保存：pipe_1')
+    expect(container.textContent).toContain('已满足 dry-run 前置条件')
 
     ;(container.querySelector('[data-testid="run-dry-run"]') as HTMLButtonElement).click()
     await flushUi(16)
@@ -514,5 +534,51 @@ describe('IntegrationWorkbenchView', () => {
       },
     })
     expect(container.textContent).toContain('Save-only 推送已提交')
+  })
+
+  it('shows actionable source-empty and dry-run readiness guidance when no readable source exists', async () => {
+    apiFetchMock.mockImplementation(async (url: string) => {
+      if (url === '/api/integration/adapters') {
+        return jsonResponse([
+          { kind: 'erp:k3-wise-webapi', label: 'K3 WISE WebAPI', roles: ['target'], supports: ['upsert'], advanced: false },
+          { kind: 'erp:k3-wise-sqlserver', label: 'K3 WISE SQL Server Channel', roles: ['source'], supports: ['read'], advanced: true },
+        ])
+      }
+      if (url === '/api/integration/external-systems?tenantId=default') {
+        return jsonResponse([
+          { id: 'k3_target', tenantId: 'default', workspaceId: null, name: 'K3 Target', kind: 'erp:k3-wise-webapi', role: 'target', status: 'active' },
+        ])
+      }
+      if (url === '/api/integration/staging/descriptors') {
+        return jsonResponse([])
+      }
+      throw new Error(`unexpected URL ${url}`)
+    })
+
+    const View = (await import('../src/views/IntegrationWorkbenchView.vue')).default
+
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    app.component('router-link', {
+      props: ['to'],
+      setup(_props, { slots }) {
+        return () => h('a', slots.default?.())
+      },
+    })
+    app.mount(container)
+    await flushUi()
+
+    expect(container.textContent).toContain('还没有可读取的数据源')
+    expect(container.textContent).toContain('连接 PLM、HTTP API 或启用 SQL 只读通道')
+    expect(container.textContent).toContain('还缺')
+    expect(container.textContent).toContain('选择可读取的数据源')
+    expect(container.textContent).toContain('Payload 预览通过不等于 pipeline dry-run')
+    expect((container.querySelector('[data-testid="run-dry-run"]') as HTMLButtonElement).disabled).toBe(true)
+
+    ;(container.querySelector('[data-testid="show-sql-setup"]') as HTMLButtonElement).click()
+    await flushUi()
+    expect((container.querySelector('[data-testid="show-advanced-connectors"]') as HTMLInputElement).checked).toBe(true)
+    expect(container.textContent).toContain('SQL source 需要部署 allowlist queryExecutor 后才能读取')
   })
 })

--- a/docs/development/data-factory-onboarding-readiness-development-20260514.md
+++ b/docs/development/data-factory-onboarding-readiness-development-20260514.md
@@ -47,7 +47,7 @@ The existing loaded counts are now clickable. Expanding the overview shows:
 
 - configured external systems, their roles, kinds, and connection states;
 - available adapters, including whether each is advanced;
-- staging multitable descriptors and whether each has an open link.
+- staging multitable descriptors and whether each has an `打开多维表` link.
 
 When a configured system has a known runtime blocker, the overview shows it
 inline instead of letting the operator infer it from a failed dry-run.
@@ -97,6 +97,20 @@ message:
 
 The dry-run button and Save-only button are disabled until the checklist is
 complete. Save-only still also requires explicit operator opt-in.
+
+### Review hardening
+
+Reviewer feedback tightened this slice in three places:
+
+- selected source and target systems must be `active` before they can satisfy
+  dry-run readiness;
+- error-state systems show their actual connection status instead of a generic
+  selected-state message;
+- SQL executor-missing guidance is only applied to K3 SQL Server connections
+  whose error text specifically indicates a missing executor/injection issue.
+
+The visible field-count labels in the Data Factory cards and inventory overview
+were also normalized to Chinese copy.
 
 ## Files Changed
 

--- a/docs/development/data-factory-onboarding-readiness-development-20260514.md
+++ b/docs/development/data-factory-onboarding-readiness-development-20260514.md
@@ -1,0 +1,125 @@
+# Data Factory Onboarding Readiness Development - 2026-05-14
+
+## Goal
+
+Close the first high-value gap from issue #1542 without expanding the backend
+surface: a user opening Data Factory should understand where to start, why a
+source list may be empty, and why payload preview is not the same as a full
+pipeline dry-run.
+
+This slice keeps the existing route `/integrations/workbench` and does not add
+new migrations, new integration APIs, a SQL executor, or a connection-builder
+wizard.
+
+## Problem
+
+The Data Factory workbench already had the underlying pieces for K3 preset
+configuration, external-system discovery, staging descriptors, template
+preview, pipeline save, dry-run, and Save-only execution. The issue was the
+first-run experience:
+
+- an empty source selector did not tell the operator what to do next;
+- K3 WISE preset configuration was not discoverable enough from the workbench;
+- the connection inventory count was passive text rather than a usable overview;
+- SQL Server source connections could look selectable even when the deployed
+  backend had no allowlisted `queryExecutor`;
+- the page let users reach the dry-run button without clearly listing missing
+  prerequisites.
+
+## Implementation
+
+### Connection onboarding
+
+`IntegrationWorkbenchView` now adds an onboarding block above the source/target
+selectors:
+
+- `使用 K3 WISE 预设` links to `/integrations/k3-wise`;
+- `连接新系统` opens the inventory overview and explains the current first step;
+- `查看 SQL / 高级连接` reveals advanced connectors and makes SQL source limits
+  explicit.
+
+This is intentionally a UX guide, not a new connection manager. The K3 preset
+remains the production-ready entry point for this stage.
+
+### Inventory overview
+
+The existing loaded counts are now clickable. Expanding the overview shows:
+
+- configured external systems, their roles, kinds, and connection states;
+- available adapters, including whether each is advanced;
+- staging multitable descriptors and whether each has an open link.
+
+When a configured system has a known runtime blocker, the overview shows it
+inline instead of letting the operator infer it from a failed dry-run.
+
+### Source empty state
+
+If no readable source system is available, the source selector now renders an
+actionable empty state:
+
+- tells the user to connect PLM, HTTP API, or SQL read channel;
+- offers the K3 WISE preset path;
+- offers the SQL advanced-connector reveal action.
+
+The page keeps K3 WebAPI as a target-only connection; it does not pretend a
+target adapter can be used as a source.
+
+### SQL runtime blocker
+
+The workbench detects the known `queryExecutor` missing condition from
+`lastError` and shows:
+
+`SQL 连接已配置，但当前部署未注入 SQL 执行器；可保留为高级连接，暂不能作为可读 source 执行 dry-run。`
+
+For K3 SQL Server source connections with error status, it also explains that
+the allowlisted `queryExecutor` must be deployed before the channel can read
+samples or execute as a source.
+
+This keeps SQL as an advanced capability without implying it is ready on every
+deployment package.
+
+### Dry-run readiness checklist
+
+The pipeline panel now lists the concrete prerequisites for dry-run:
+
+- readable source system;
+- source dataset;
+- target system;
+- target dataset/template;
+- at least one mapping rule;
+- idempotency fields;
+- saved pipeline ID.
+
+The checklist distinguishes K3 payload preview from pipeline dry-run with the
+message:
+
+`Payload 预览通过不等于 pipeline dry-run；请先保存 pipeline。`
+
+The dry-run button and Save-only button are disabled until the checklist is
+complete. Save-only still also requires explicit operator opt-in.
+
+## Files Changed
+
+- `apps/web/src/views/IntegrationWorkbenchView.vue`
+- `apps/web/tests/IntegrationWorkbenchView.spec.ts`
+- `docs/development/data-factory-onboarding-readiness-development-20260514.md`
+- `docs/development/data-factory-onboarding-readiness-verification-20260514.md`
+
+## Non-Goals
+
+- No SQL execution implementation.
+- No staging-table-as-source backend fallback.
+- No new connection wizard.
+- No K3 live Save / Submit / Audit change.
+- No database migration.
+- No new backend route.
+
+## Deployment Impact
+
+Frontend-only. Existing deployments keep the same routes:
+
+- `/integrations/workbench`
+- `/integrations/k3-wise`
+
+The change makes a missing backend executor visible, but it does not change
+runtime execution behavior.

--- a/docs/development/data-factory-onboarding-readiness-verification-20260514.md
+++ b/docs/development/data-factory-onboarding-readiness-verification-20260514.md
@@ -1,0 +1,138 @@
+# Data Factory Onboarding Readiness Verification - 2026-05-14
+
+## Scope
+
+This verification covers the first issue #1542 Data Factory onboarding slice:
+
+- K3 WISE preset is discoverable from Data Factory;
+- connection inventory can be expanded;
+- empty source state gives an actionable next step;
+- SQL read-channel runtime blocker is visible;
+- dry-run and Save-only are disabled until prerequisites are complete;
+- K3 setup page regression remains green.
+
+## Frontend Focused Tests
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/IntegrationWorkbenchView.spec.ts \
+  tests/IntegrationK3WiseSetupView.spec.ts \
+  --watch=false
+```
+
+Result:
+
+```text
+Test Files  2 passed (2)
+Tests       5 passed (5)
+```
+
+Coverage:
+
+- Data Factory workbench renders `连接新系统` and `使用 K3 WISE 预设`.
+- Inventory summary renders loaded connection, adapter, and staging counts.
+- Inventory expansion renders configured systems, adapters, staging tables, and
+  the SQL `queryExecutor` blocker.
+- Advanced SQL connector stays hidden until the operator enables advanced
+  connectors.
+- K3 SQL read + K3 WebAPI write guidance remains visible.
+- Source-empty state explains PLM / HTTP / SQL source onboarding.
+- Dry-run readiness checklist reports missing prerequisites.
+- Dry-run is disabled when no readable source exists.
+- Saved pipeline path reports `已满足 dry-run 前置条件`.
+- K3 WISE setup page tests remain green.
+
+## Production Build
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result:
+
+```text
+PASS - vue-tsc -b and vite build completed.
+```
+
+Notes:
+
+- Vite emitted existing large chunk / dynamic import warnings.
+- No new build failure or type error was introduced by this slice.
+
+## Static Check
+
+Command:
+
+```bash
+git diff --check
+```
+
+Result:
+
+```text
+PASS - no whitespace errors or conflict markers.
+```
+
+## K3 Offline PoC Regression
+
+Command:
+
+```bash
+pnpm verify:integration-k3wise:poc
+```
+
+Result:
+
+```text
+PASS - K3 WISE PoC mock chain verified end-to-end.
+```
+
+Coverage:
+
+- live PoC preflight packet tests passed;
+- live evidence compiler tests passed;
+- K3 fixture contract tests passed;
+- mock K3 WebAPI tests passed;
+- mock SQL Server executor tests passed;
+- mock material and BOM Save-only chain completed with 0 Submit / Audit calls.
+
+## Manual Review Checklist
+
+1. Open `/integrations/workbench`.
+2. Confirm the page title remains Data Factory.
+3. Confirm the onboarding block offers K3 WISE preset, connection guidance, and
+   SQL advanced guidance.
+4. Expand the inventory overview and confirm configured connections, adapters,
+   and staging tables are visible.
+5. Use a backend response where K3 SQL source has `lastError` containing
+   `queryExecutor`; confirm the blocker appears in the overview and source
+   panel.
+6. Use a backend response with no source systems; confirm the empty state
+   explains how to add a readable source.
+7. Confirm `Dry-run` is disabled until source, source dataset, target, target
+   dataset, mapping, idempotency, and saved pipeline are all present.
+8. Confirm `Save-only 推送` remains disabled unless Save-only is explicitly
+   checked and the dry-run prerequisites are satisfied.
+
+## Deployment Impact
+
+- No migration.
+- No backend route change.
+- No package script change.
+- No K3 live Submit / Audit enablement.
+- No secrets are rendered or stored by this UX-only slice.
+
+## Remaining Work
+
+This slice intentionally does not resolve the deeper blockers from issue #1542:
+
+- a real generic connection wizard;
+- SQL allowlisted `queryExecutor` deployment;
+- staging multitable rows as a readable source fallback;
+- full live K3 pipeline execution after customer GATE.
+
+Those should be separate PRs because they change backend execution semantics.

--- a/docs/development/data-factory-onboarding-readiness-verification-20260514.md
+++ b/docs/development/data-factory-onboarding-readiness-verification-20260514.md
@@ -26,7 +26,7 @@ Result:
 
 ```text
 Test Files  2 passed (2)
-Tests       5 passed (5)
+Tests       6 passed (6)
 ```
 
 Coverage:
@@ -41,8 +41,24 @@ Coverage:
 - Source-empty state explains PLM / HTTP / SQL source onboarding.
 - Dry-run readiness checklist reports missing prerequisites.
 - Dry-run is disabled when no readable source exists.
+- Error-state source and target systems are not treated as dry-run ready.
 - Saved pipeline path reports `已满足 dry-run 前置条件`.
 - K3 WISE setup page tests remain green.
+
+## Review Hardening Coverage
+
+The focused workbench test now includes an error-state source and an
+error-state target:
+
+- source system `status: error` with a generic network timeout is shown as
+  `异常：network timeout`;
+- target system `status: error` with a generic ERP endpoint failure is shown as
+  `异常：ERP endpoint unavailable`;
+- neither selected system satisfies dry-run readiness;
+- the dry-run button remains disabled.
+
+This covers the reviewer concern that selected-but-broken systems should not be
+reported as ready.
 
 ## Production Build
 


### PR DESCRIPTION
## Summary

Closes the first UX/readiness slice from #1542: make Data Factory tell operators where to start, why source systems may be missing, and why K3 payload preview is not yet a full pipeline dry-run.

This PR adds:

- a Data Factory connection onboarding block with a K3 WISE preset entry;
- an expandable connection/adapter/staging inventory overview;
- an actionable empty state when no readable source exists;
- explicit SQL `queryExecutor` runtime-blocker copy;
- a dry-run readiness checklist that disables Dry-run / Save-only until prerequisites are complete;
- development and verification markdown for this slice.

## Scope

Frontend-only. No backend route, database migration, SQL executor, staging-as-source implementation, or K3 live Submit/Audit change.

## Verification

- `pnpm --filter @metasheet/web exec vitest run tests/IntegrationWorkbenchView.spec.ts tests/IntegrationK3WiseSetupView.spec.ts --watch=false`
  - 2 files passed, 5 tests passed
- `pnpm --filter @metasheet/web build`
  - PASS, existing Vite large chunk / dynamic import warnings only
- `pnpm verify:integration-k3wise:poc`
  - PASS, K3 WISE PoC mock chain verified end-to-end
- `git diff --check`
  - PASS

## Deployment Impact

- No migration required.
- Existing routes remain stable: `/integrations/workbench`, `/integrations/k3-wise`.
- The UI now surfaces missing backend executor state instead of implying SQL source is ready everywhere.
