### PR TITLE
test(multitable): tighten delegate gate status to strict fail-closed

### DIFF
--- a/docs/development/multitable-phase3-delegate-gate-strict-status-development-20260514.md
+++ b/docs/development/multitable-phase3-delegate-gate-strict-status-development-20260514.md
@@ -1,0 +1,202 @@
+# Multitable Feishu Phase 3 — Delegate Gate Strict Status Hardening (Development)
+
+- Date: 2026-05-14
+- Branch: `codex/multitable-phase3-delegate-gate-strict-status-20260514`
+- Base: `origin/main` at `855ba871e` (after #1547 automation soak gate)
+- Author: Claude (Opus 4.7, 1M context), interactive harness; operator-supervised
+- Redaction policy: this PR contains no AI provider key, SMTP
+  credential, JWT, bearer token, DingTalk webhook URL or robot
+  `SEC...`, K3 endpoint password, Agent ID value, recipient user id,
+  temporary password, or `.env` content.
+
+## Why this PR exists
+
+PRs #1544 (D1 — email real-send delegate) and #1547 (D4 — automation
+soak delegate) both wire their respective harnesses into the Phase 3
+release gate via the same `child exit code → status` pattern:
+
+```js
+const status = child.error ? 'fail' : statusFromExitCode(childExitCode)
+```
+
+`statusFromExitCode(0) === 'pass'`, `statusFromExitCode(2) === 'blocked'`,
+everything else `'fail'`. This trusts the child process's exit code
+**without** checking that the child's `report.json` `status` / `ok`
+fields agree with the exit code.
+
+That gap means:
+
+- If a delegated child script exits `0` but writes
+  `report.status === 'blocked'` (script bug / racing redact /
+  malformed I/O), the Phase 3 release gate reports **pass** even
+  though the harness itself disagrees.
+- If a child exits `2` but writes `report.status === 'pass'` (less
+  likely but symmetric), the release gate reports **blocked** without
+  flagging the inconsistency.
+- If `report.ok === false` but exit code is `0`, the email harness's
+  own "I did not succeed" signal is ignored.
+
+For a release gate, this is the wrong direction: any disagreement
+between exit code and report fields should be **fail-closed**, not
+silently routed to the exit-code-implied state.
+
+This PR introduces a strict translator covering both delegate gates
+(email + automation) uniformly, and adds `childStdoutSample` /
+`childStderrSample` (1200-char, redacted) for diagnostic value when a
+delegated child fails.
+
+## Scope
+
+In scope (this PR):
+
+- Strict translation of delegate gate status for both email and
+  automation.
+- Mismatch detection: spawn error, signal-kill (null exit), missing
+  / unparseable child report.json, exit / status / ok inconsistency
+  all map to **fail** (exit 1).
+- Diagnostic samples: `childStdoutSample` and `childStderrSample`
+  in delegate return shape, redacted via the existing Phase 3
+  redactor and capped at 1200 characters.
+- `spawnFn` injection option on both delegate functions so tests can
+  drive the full state machine in-process without invoking pnpm.
+- Test coverage spanning the translator, both delegate functions
+  with mock spawn, and the aggregator state machine.
+
+Out of scope:
+
+- No change to `scripts/ops/multitable-email-real-send-smoke.ts`.
+- No change to `scripts/ops/multitable-automation-soak.mjs`.
+- No change to `verify:multitable-email:*` or
+  `verify:multitable-automation:soak` package scripts.
+- No new package script.
+- No change under `plugins/plugin-integration-core/*`,
+  `lib/adapters/k3-wise-*`, multitable runtime, OpenAPI, migrations,
+  routes, workflows.
+
+## Strict translation contract
+
+The new `translateDelegateStatus` function (exported for tests):
+
+```js
+translateDelegateStatus({ gate, childExitCode, childError, childReport })
+  // → { status, exitCode, mismatchReason }
+```
+
+Rules:
+
+- **PASS** iff:
+  - `childExitCode === 0`, AND
+  - `childReport.status === 'pass'`, AND
+  - if delegate `requiresOkField` (email only): `childReport.ok === true`.
+
+- **BLOCKED** iff:
+  - `childExitCode === 2`, AND
+  - `childReport.status === 'blocked'`.
+
+- **FAIL** in every other case, including:
+  - Spawn launch error (e.g. `ENOENT`).
+  - Non-numeric exit code (signal kill, spawn aborted).
+  - Missing or unparseable child report.json.
+  - Exit / status / ok inconsistency.
+
+`mismatchReason` is `null` for PASS and BLOCKED; for FAIL it carries
+a redaction-safe explanation. Examples (verbatim from tests):
+
+- `Fail-closed: child exit=0 report.status=blocked ok=false — did not match pass (exit=0, status=pass, ok=true) or blocked (exit=2, status=blocked) contracts.`
+- `Spawn launch error: spawn pnpm ENOENT`
+- `Child exit code was not numeric (signal kill or spawn aborted): null.`
+- `Child report.json missing or unparseable; release gate cannot verify exit-code / report consistency.`
+
+## Delegate-side changes
+
+Both `runEmailRealSendGate` and `runAutomationSoakGate` now:
+
+1. Use `options.spawnFn ?? spawnSync` (allows mock injection).
+2. Call `translateDelegateStatus` instead of `statusFromExitCode`.
+3. When `mismatchReason` is set, the gate's `reason` field surfaces
+   that mismatch directly so the report.json / report.md shows why
+   the delegate failed-closed.
+4. Add `childStdoutSample` and `childStderrSample` fields to the
+   return object, each redacted and capped at 1200 chars.
+5. `childExitCode` becomes `null` when child status was non-numeric
+   (signal kill), instead of being silently coerced to `EXIT_FAIL=1`.
+6. `childOk` becomes `null` instead of being inferred from
+   `status === 'pass'`, so the raw report value is preserved or
+   `null` if absent.
+
+The runner's CLI behavior, gate ids, and output paths are unchanged.
+
+## Test coverage
+
+The hardening PR adds **28 new tests** to
+`scripts/ops/multitable-phase3-release-gate.test.mjs`:
+
+- **14 translator unit tests** covering: email pass, email blocked,
+  4 email mismatch flavors (`exit=0 + status=blocked`,
+  `exit=2 + status=pass`, `exit=0 + status=pass + ok=false`,
+  `exit=0 + status=pass + ok=missing`), automation pass, automation
+  blocked, 2 automation mismatch flavors, missing report,
+  non-object report, spawn `ENOENT`, signal-kill null exit.
+- **6 in-process delegate tests** with mock `spawnFn`: email pass
+  / mismatch / missing report; automation pass / mismatch / spawn
+  error.
+- **5 aggregator state machine tests** with routed mock `spawnFn`:
+  email PASS + 3 BLOCKED → BLOCKED (partial PASS does not collapse);
+  email FAIL + others BLOCKED → FAIL; automation FAIL beats email
+  PASS → FAIL; email mismatch → aggregate FAIL; automation mismatch
+  → aggregate FAIL.
+- **3 artifact-integrity tests**: real SMTP env-value redaction in
+  email delegate samples; webhook + auth-token redaction in
+  automation delegate samples; aggregator report.json carries no
+  raw delegate stdout / stderr.
+
+All 28 new tests are pure in-process (no `pnpm` spawn dependency,
+no `node_modules/.bin/tsx` requirement). Pre-existing spawn-based
+tests continue to pass when `pnpm install` has run; in a fresh
+worktree they fail at the spawn step with `pnpm: tsx: command not
+found` (this is the same baseline behavior on `origin/main` before
+this PR — not a regression).
+
+## Files
+
+| Path | Change | Note |
+| --- | --- | --- |
+| `scripts/ops/multitable-phase3-release-gate.mjs` | modify | Replace `statusFromExitCode` with `translateDelegateStatus`; add `compactSample`; refactor both delegate functions to use translator + add samples + spawnFn injection; export `translateDelegateStatus`. |
+| `scripts/ops/multitable-phase3-release-gate.test.mjs` | modify | Import translator; add 28 new tests as described above. |
+| `docs/development/multitable-phase3-delegate-gate-strict-status-development-20260514.md` | new | this file |
+| `docs/development/multitable-phase3-delegate-gate-strict-status-verification-20260514.md` | new | verification MD |
+
+No other file is touched.
+
+## Stage-1 lock compliance
+
+| Check | Result |
+| --- | --- |
+| No change under `plugins/plugin-integration-core/*` | PASS |
+| No change under `lib/adapters/k3-wise-*` | PASS |
+| No new product战线 | PASS — hardening on already-shipped delegate gates |
+| No schema / migration / route / workflow change | PASS |
+| No change to email or automation harness scripts | PASS |
+| No change to `verify:multitable-email:*` or `verify:multitable-automation:soak` package scripts | PASS |
+| No new package script | PASS |
+| Kernel polish on shipped release-gate aggregator | PASS |
+
+## Cross-references
+
+- Plan: `docs/development/multitable-feishu-phase3-ai-hardening-plan-20260514.md`
+- TODO: `docs/development/multitable-feishu-phase3-ai-hardening-todo-20260514.md`
+- Independent review: `docs/development/multitable-feishu-phase3-ai-hardening-review-20260514.md`
+- D0 skeleton (#1541): merge commit `a92189533`
+- D1 email delegate (#1544): merge commit `1f9061f56`
+- D4 automation soak delegate (#1547): merge commit `855ba871e`
+- Closed in favor of this PR: #1545 (Claude's parallel D1 implementation, closed as duplicate after Codex landed #1544)
+
+## Follow-ups (not in this PR)
+
+- If `pnpm install` precedes tests in CI (it does for Plugin System
+  Tests), the previously-spawn-based tests continue to pass; if a
+  future CI lane runs without `pnpm install`, those tests would need
+  skip guards similar to PR R3's `existsSync('node_modules/.bin/tsx')`
+  pattern. Out of scope for this hardening PR.
+- D2 (perf large-table) and D3 (permission matrix) remain deferred
+  under stage-1 lock plus T4 / T5 closure.

--- a/docs/development/multitable-phase3-delegate-gate-strict-status-verification-20260514.md
+++ b/docs/development/multitable-phase3-delegate-gate-strict-status-verification-20260514.md
@@ -1,0 +1,253 @@
+# Multitable Feishu Phase 3 — Delegate Gate Strict Status Hardening (Verification)
+
+- Date: 2026-05-14
+- Branch: `codex/multitable-phase3-delegate-gate-strict-status-20260514`
+- Base: `origin/main` at `855ba871e` (after #1547 automation soak gate)
+- Author: Claude (Opus 4.7, 1M context), interactive harness; operator-supervised
+- Companion: `multitable-phase3-delegate-gate-strict-status-development-20260514.md`
+- Redaction policy: this document contains no AI provider key, SMTP
+  credential, JWT, bearer token, DingTalk webhook URL or robot
+  `SEC...`, K3 endpoint password, recipient user id, temporary
+  password, or `.env` content.
+
+## Result
+
+**PASS / hardening landing**.
+
+- **44 / 44 tests PASS** with `pnpm install` done in the worktree
+  (which is the CI baseline).
+- Without `pnpm install`, **40 / 44 PASS** — the 4 failing tests are
+  pre-existing spawn-based integration tests that require
+  `node_modules/.bin/tsx`; they have the same failure mode on
+  `origin/main` before this PR. They are not regressions; my changes
+  do not alter their spawn or runtime behavior.
+
+## V1 — Worktree provenance
+
+```bash
+git fetch origin main
+git worktree add /private/tmp/ms2-phase3-hardening-20260514 \
+  -b codex/multitable-phase3-delegate-gate-strict-status-20260514 origin/main
+```
+
+Result: `HEAD is now at 855ba871e test(multitable): add phase3
+automation soak gate (#1547)`.
+
+## V2 — Focused tests (with `pnpm install`)
+
+```bash
+pnpm install --frozen-lockfile --prefer-offline
+node --test scripts/ops/multitable-phase3-release-gate.test.mjs
+```
+
+Result:
+
+```text
+ℹ tests 44
+ℹ pass 44
+ℹ fail 0
+ℹ skipped 0
+```
+
+Breakdown:
+
+- **16 pre-existing tests** (baseline before this PR) all pass with
+  the new translator. The strict translator is a no-op for the
+  passing real spawn cases (`email exit=2 + status=blocked → blocked`
+  remains blocked; `automation exit=2 + status=blocked → blocked`
+  remains blocked).
+- **28 new tests** added by this PR. All pass without `pnpm install`
+  too, because they use in-process mock `spawnFn` injection.
+
+## V3 — Sibling test files unchanged
+
+```bash
+node --test scripts/ops/multitable-phase3-release-gate-redact.test.mjs \
+            scripts/ops/multitable-phase3-release-gate-report.test.mjs
+```
+
+Result:
+
+```text
+ℹ tests 24
+ℹ pass 24
+ℹ fail 0
+```
+
+Confirms no collateral damage to the redactor or report writer.
+
+## V4 — New translator unit tests (14 cases)
+
+```bash
+node --test scripts/ops/multitable-phase3-release-gate.test.mjs 2>&1 \
+  | grep 'translateDelegateStatus'
+```
+
+Result (all PASS):
+
+```text
+✔ translateDelegateStatus — email pass case: exit=0 + status=pass + ok=true → pass
+✔ translateDelegateStatus — email blocked case: exit=2 + status=blocked → blocked
+✔ translateDelegateStatus — email mismatch: exit=0 + status=blocked (script bug) → fail-closed
+✔ translateDelegateStatus — email mismatch: exit=2 + status=pass → fail-closed
+✔ translateDelegateStatus — email mismatch: exit=0 + status=pass + ok=false → fail-closed
+✔ translateDelegateStatus — email mismatch: exit=0 + status=pass + ok missing → fail-closed
+✔ translateDelegateStatus — automation pass: exit=0 + status=pass (no ok required) → pass
+✔ translateDelegateStatus — automation blocked: exit=2 + status=blocked → blocked
+✔ translateDelegateStatus — automation mismatch: exit=0 + status=blocked → fail-closed
+✔ translateDelegateStatus — automation mismatch: exit=2 + status=pass → fail-closed
+✔ translateDelegateStatus — child report missing → fail-closed
+✔ translateDelegateStatus — child report non-object (parse failure already returned null) → fail-closed
+✔ translateDelegateStatus — spawn error (ENOENT) → fail-closed
+✔ translateDelegateStatus — null exit (signal kill) → fail-closed
+```
+
+## V5 — Delegate state-machine tests (6 cases)
+
+```bash
+node --test scripts/ops/multitable-phase3-release-gate.test.mjs 2>&1 \
+  | grep 'delegate with mock'
+```
+
+Result (all PASS):
+
+```text
+✔ email delegate with mock — pass case round-trips through translator
+✔ email delegate with mock — mismatch (exit=0 + status=blocked) is FAIL not PASS
+✔ email delegate with mock — child report missing → FAIL
+✔ automation delegate with mock — pass case round-trips through translator
+✔ automation delegate with mock — mismatch (exit=0 + status=blocked) is FAIL not PASS
+✔ automation delegate with mock — spawn ENOENT → FAIL
+```
+
+Each test injects a mock `spawnFn` that simulates a specific child
+behavior (exit + report), runs the real delegate function in-process,
+and asserts the resulting status / exitCode / reason against the
+strict-translation contract.
+
+## V6 — Aggregator state machine tests (5 cases)
+
+```bash
+node --test scripts/ops/multitable-phase3-release-gate.test.mjs 2>&1 \
+  | grep 'aggregator state machine'
+```
+
+Result (all PASS):
+
+```text
+✔ aggregator state machine — email PASS + automation BLOCKED + 2 D0 BLOCKED → BLOCKED (does NOT collapse to PASS)
+✔ aggregator state machine — email FAIL + automation BLOCKED + 2 D0 BLOCKED → FAIL (any delegate fail → aggregate fail)
+✔ aggregator state machine — automation FAIL beats email PASS + others BLOCKED → FAIL
+✔ aggregator state machine — email mismatch (exit=0 + status=blocked) → aggregate FAIL
+✔ aggregator state machine — automation mismatch (exit=2 + status=pass) → aggregate FAIL
+```
+
+The "partial PASS does not collapse to PASS" invariant is preserved.
+Mismatches in either delegate now poison the aggregate to FAIL,
+matching the strict-translation contract.
+
+## V7 — Artifact-integrity tests (3 cases)
+
+```bash
+node --test scripts/ops/multitable-phase3-release-gate.test.mjs 2>&1 \
+  | grep -E 'real SMTP env values do not leak|webhook URLs and auth tokens|aggregator report\.json does not include dirty samples'
+```
+
+Result (all PASS):
+
+```text
+✔ artifact integrity — real SMTP env values do not leak via delegate childStdoutSample / childStderrSample (email)
+✔ artifact integrity — webhook URLs and auth tokens do not leak via automation delegate samples
+✔ artifact integrity — Phase 3 aggregator report.json does not include dirty samples raw
+```
+
+These cover the user's explicit requirement that real SMTP, webhook,
+and token env values do not appear in Phase 3 JSON / MD / stdout /
+stderr after the bridge runs. The tests inject worst-case dirty
+content (env-shaped key=value assignments, full SMTP credentials,
+real recipient email shapes, Bearer / sk- / OPENAI_API_KEY patterns,
+webhook URLs with embedded `access_token` parameters) into the mock
+spawn result, then assert these substrings do not survive into the
+delegate samples or the aggregator report.
+
+## V8 — Scope check
+
+```bash
+git diff --cached --name-only
+```
+
+Result:
+
+```text
+docs/development/multitable-phase3-delegate-gate-strict-status-development-20260514.md
+docs/development/multitable-phase3-delegate-gate-strict-status-verification-20260514.md
+scripts/ops/multitable-phase3-release-gate.mjs
+scripts/ops/multitable-phase3-release-gate.test.mjs
+```
+
+No file under `plugins/plugin-integration-core/`, `lib/adapters/`,
+`packages/`, `apps/`, `.github/workflows/`, `docker/`, or any
+migration directory is modified. Stage-1 lock compliance affirmed.
+
+## V9 — Whitespace and conflict-marker check
+
+```bash
+git diff --cached --check
+```
+
+Result: clean (reported at staging time).
+
+## V10 — Secret-pattern scan
+
+```bash
+grep -rEn --include='*.mjs' --include='*.md' \
+  '(SEC[A-Z0-9+/=_-]{8,}|Bearer[[:space:]]+[A-Za-z0-9._-]{20,}|eyJ[A-Za-z0-9._-]{20,}|sk-[A-Za-z0-9_-]{20,}|DINGTALK_CLIENT_SECRET[[:space:]]*=[[:space:]]*[A-Za-z][A-Za-z0-9_]+)' \
+  scripts/ops/multitable-phase3-release-gate.mjs \
+  scripts/ops/multitable-phase3-release-gate.test.mjs \
+  docs/development/multitable-phase3-delegate-gate-strict-status-*-20260514.md
+```
+
+Result: only `.test.mjs` fixture matches surface, all inside
+`assert.doesNotMatch(...)` / `assert.match(...)` clauses proving
+redaction. No real provider key, robot SEC, JWT, SMTP password, or
+client secret is committed.
+
+## V11 — Stage-1 lock self-attestation
+
+| Check | Result |
+| --- | --- |
+| No change under `plugins/plugin-integration-core/*` | PASS |
+| No change under `lib/adapters/k3-wise-*` | PASS |
+| No new product战线 | PASS |
+| No schema / migration / route / workflow change | PASS |
+| No change to `multitable-email-real-send-smoke.ts`, `multitable-automation-soak.mjs`, or any other delegate harness | PASS |
+| No change to `verify:multitable-email:*` or `verify:multitable-automation:soak` package scripts | PASS |
+| No new package script | PASS |
+| Kernel polish on shipped release-gate aggregator | PASS |
+
+## V12 — Translator semantic table (cross-checked against tests)
+
+| sourceExitCode | report.status | report.ok | Email translation | Automation translation |
+| --- | --- | --- | --- | --- |
+| `0` | `'pass'` | `true` | **pass** | **pass** |
+| `0` | `'pass'` | `false` | fail (ok mismatch) | n/a (no ok field) |
+| `0` | `'pass'` | (missing) | fail (ok missing) | **pass** |
+| `0` | `'blocked'` | any | **fail** (status mismatch) | **fail** |
+| `0` | `'failed'` / `'fail'` | any | **fail** | **fail** |
+| `2` | `'blocked'` | any | **blocked** | **blocked** |
+| `2` | `'pass'` | any | **fail** (status mismatch) | **fail** |
+| `1` | any | any | **fail** | **fail** |
+| `null` (signal kill) | any | any | **fail** | **fail** |
+| any | (missing report) | n/a | **fail** | **fail** |
+| any | (unparseable) | n/a | **fail** | **fail** |
+| (spawn ENOENT) | n/a | n/a | **fail** | **fail** |
+
+## Final verdict
+
+PASS. The strict translator + diagnostic sample fields close the
+`statusFromExitCode` correctness gap that was shared by PRs #1544
+and #1547 on `main`. After this PR, a release gate that returns
+`release:phase3 status=pass` carries a stronger guarantee than
+"exit code agreed with itself" — every delegated child's exit code,
+report.status, and (where applicable) report.ok must all agree, and
+any inconsistency fails the gate closed.

--- a/scripts/ops/multitable-phase3-release-gate.mjs
+++ b/scripts/ops/multitable-phase3-release-gate.mjs
@@ -174,10 +174,96 @@ function parseArgs(argv) {
   return opts
 }
 
-function statusFromExitCode(exitCode) {
-  if (exitCode === EXIT_PASS) return 'pass'
-  if (exitCode === EXIT_BLOCKED) return 'blocked'
-  return 'fail'
+const SAMPLE_MAX_LENGTH = 1200
+
+/**
+ * Per-delegate translation requirements. Delegates that produce an
+ * `ok` field in their child report (e.g. the email smoke harness)
+ * must report `ok === true` for a pass — required for strict
+ * mismatch detection.
+ */
+const DELEGATE_TRANSLATIONS = {
+  [EMAIL_REAL_SEND_GATE]: { requiresOkField: true },
+  [AUTOMATION_SOAK_GATE]: { requiresOkField: false },
+}
+
+/**
+ * Strict fail-closed status translation for delegated gates.
+ *
+ * Rules (each must hold; otherwise fail-closed):
+ *   - PASS    iff child exit=0 AND report.status='pass'
+ *             AND (delegate.requiresOkField ? report.ok === true : true)
+ *   - BLOCKED iff child exit=2 AND report.status='blocked'
+ *   - FAIL    in every other case, including:
+ *               spawn launch error,
+ *               non-numeric exit (signal kill / aborted),
+ *               missing or unparseable child report.json,
+ *               exit / status / ok inconsistency.
+ *
+ * The function returns `{ status, exitCode, mismatchReason }`. When
+ * status is 'pass' or 'blocked', mismatchReason is null. Otherwise
+ * mismatchReason carries a redaction-safe explanation of which signals
+ * disagreed.
+ */
+export function translateDelegateStatus({ gate, childExitCode, childError, childReport }) {
+  const config = DELEGATE_TRANSLATIONS[gate] ?? { requiresOkField: false }
+  if (childError) {
+    const message = childError instanceof Error ? childError.message : String(childError)
+    return {
+      status: 'fail',
+      exitCode: EXIT_FAIL,
+      mismatchReason: `Spawn launch error: ${redactString(message ?? '')}`,
+    }
+  }
+  if (typeof childExitCode !== 'number') {
+    const display = childExitCode === null || childExitCode === undefined
+      ? 'null'
+      : String(childExitCode)
+    return {
+      status: 'fail',
+      exitCode: EXIT_FAIL,
+      mismatchReason: `Child exit code was not numeric (signal kill or spawn aborted): ${display}.`,
+    }
+  }
+  if (!childReport || typeof childReport !== 'object') {
+    return {
+      status: 'fail',
+      exitCode: EXIT_FAIL,
+      mismatchReason:
+        'Child report.json missing or unparseable; release gate cannot verify exit-code / report consistency.',
+    }
+  }
+  const reportStatus = childReport.status ?? null
+  const reportOk = childReport.ok
+  const passMatch =
+    childExitCode === EXIT_PASS &&
+    reportStatus === 'pass' &&
+    (config.requiresOkField ? reportOk === true : true)
+  const blockedMatch =
+    childExitCode === EXIT_BLOCKED && reportStatus === 'blocked'
+  if (passMatch) {
+    return { status: 'pass', exitCode: EXIT_PASS, mismatchReason: null }
+  }
+  if (blockedMatch) {
+    return { status: 'blocked', exitCode: EXIT_BLOCKED, mismatchReason: null }
+  }
+  const okClause = config.requiresOkField ? ', ok=true' : ''
+  const okSuffix = config.requiresOkField ? ` ok=${reportOk}` : ''
+  return {
+    status: 'fail',
+    exitCode: EXIT_FAIL,
+    mismatchReason:
+      `Fail-closed: child exit=${childExitCode} report.status=${reportStatus}${okSuffix} — ` +
+      `did not match pass (exit=0, status=pass${okClause}) or blocked (exit=2, status=blocked) contracts.`,
+  }
+}
+
+function compactSample(value) {
+  const redacted = redactString(value ?? '')
+  if (!redacted) return ''
+  return redacted.length > SAMPLE_MAX_LENGTH
+    ? `${redacted.slice(0, SAMPLE_MAX_LENGTH - 3)}...`
+    : redacted
 }
 
 function keepProcessEnvForChild(env, extraEnv) {
@@ -225,7 +311,8 @@ function runEmailRealSendGate(env, options = {}) {
   const childReportMd = path.join(childDir, 'report.md')
   mkdirSync(childDir, { recursive: true })
 
-  const child = spawnSync('pnpm', ['verify:multitable-email:real-send'], {
+  const spawnFn = options.spawnFn ?? spawnSync
+  const child = spawnFn('pnpm', ['verify:multitable-email:real-send'], {
     cwd: options.cwd ?? process.cwd(),
     env: keepProcessEnvForChild(env, {
       EMAIL_REAL_SEND_JSON: childReportJson,
@@ -234,20 +321,25 @@ function runEmailRealSendGate(env, options = {}) {
     encoding: 'utf8',
   })
 
-  const childExitCode = typeof child.status === 'number' ? child.status : EXIT_FAIL
-  const status = child.error ? 'fail' : statusFromExitCode(childExitCode)
-  const exitCode = status === 'pass' ? EXIT_PASS : status === 'blocked' ? EXIT_BLOCKED : EXIT_FAIL
   const childReport = safeReadJson(childReportJson)
+  const childStdoutSample = compactSample(child?.stdout)
+  const childStderrSample = compactSample(child?.stderr)
+  const { status, exitCode, mismatchReason } = translateDelegateStatus({
+    gate: EMAIL_REAL_SEND_GATE,
+    childExitCode: child?.status,
+    childError: child?.error,
+    childReport,
+  })
   const missingEnv = config.requiredEnv.filter((name) => !env[name] || env[name] === '')
 
-  let reason = 'Real SMTP send smoke passed.'
-  if (child.error) {
-    reason = `Failed to launch delegated real-send smoke: ${child.error.message}`
-  } else if (status === 'blocked') {
+  let reason
+  if (mismatchReason) {
+    reason = mismatchReason
+  } else if (status === 'pass') {
+    reason = 'Real SMTP send smoke passed (child exit=0, report.status=pass, ok=true).'
+  } else {
     reason =
-      'Delegated real-send smoke is BLOCKED. Configure SMTP mode, explicit real-send smoke, explicit send confirmation, and a dedicated test recipient before treating this gate as GO.'
-  } else if (status === 'fail') {
-    reason = 'Delegated real-send smoke returned FAIL.'
+      'Delegated real-send smoke is BLOCKED (child exit=2, report.status=blocked). Configure SMTP mode, explicit real-send smoke, explicit send confirmation, and a dedicated test recipient before treating this gate as GO.'
   }
 
   return {
@@ -262,14 +354,16 @@ function runEmailRealSendGate(env, options = {}) {
     startedAt,
     completedAt: new Date().toISOString(),
     delegatedCommand: EMAIL_REAL_SEND_COMMAND,
-    childExitCode,
+    childExitCode: typeof child?.status === 'number' ? child.status : null,
     childReportJson,
     childReportMd,
-    childStatus: childReport?.status ?? status,
-    childOk: childReport?.ok ?? status === 'pass',
+    childStatus: childReport?.status ?? null,
+    childOk: typeof childReport?.ok === 'boolean' ? childReport.ok : null,
     childMode: childReport?.mode,
     childNotificationStatus: childReport?.notificationStatus,
     childFailedReason: childReport?.failedReason,
+    childStdoutSample,
+    childStderrSample,
   }
 }
 
@@ -284,7 +378,8 @@ function runAutomationSoakGate(env, options = {}) {
   const childReportMd = path.join(childDir, 'report.md')
   mkdirSync(childDir, { recursive: true })
 
-  const child = spawnSync('pnpm', ['verify:multitable-automation:soak'], {
+  const spawnFn = options.spawnFn ?? spawnSync
+  const child = spawnFn('pnpm', ['verify:multitable-automation:soak'], {
     cwd: options.cwd ?? process.cwd(),
     env: keepProcessEnvForChild(env, {
       AUTOMATION_SOAK_OUTPUT_DIR: childDir,
@@ -294,20 +389,25 @@ function runAutomationSoakGate(env, options = {}) {
     encoding: 'utf8',
   })
 
-  const childExitCode = typeof child.status === 'number' ? child.status : EXIT_FAIL
-  const status = child.error ? 'fail' : statusFromExitCode(childExitCode)
-  const exitCode = status === 'pass' ? EXIT_PASS : status === 'blocked' ? EXIT_BLOCKED : EXIT_FAIL
   const childReport = safeReadJson(childReportJson)
+  const childStdoutSample = compactSample(child?.stdout)
+  const childStderrSample = compactSample(child?.stderr)
+  const { status, exitCode, mismatchReason } = translateDelegateStatus({
+    gate: AUTOMATION_SOAK_GATE,
+    childExitCode: child?.status,
+    childError: child?.error,
+    childReport,
+  })
   const missingEnv = config.requiredEnv.filter((name) => !env[name] || env[name] === '')
 
-  let reason = 'Automation soak passed.'
-  if (child.error) {
-    reason = `Failed to launch delegated automation soak: ${child.error.message}`
-  } else if (status === 'blocked') {
+  let reason
+  if (mismatchReason) {
+    reason = mismatchReason
+  } else if (status === 'pass') {
+    reason = 'Automation soak passed (child exit=0, report.status=pass).'
+  } else {
     reason =
-      'Delegated automation soak is BLOCKED. Configure API/auth, explicit soak confirmation, mock email safe-mode acknowledgement, and controlled webhook sinks before treating this gate as GO.'
-  } else if (status === 'fail') {
-    reason = 'Delegated automation soak returned FAIL.'
+      'Delegated automation soak is BLOCKED (child exit=2, report.status=blocked). Configure API/auth, explicit soak confirmation, mock email safe-mode acknowledgement, and controlled webhook sinks before treating this gate as GO.'
   }
 
   return {
@@ -322,12 +422,14 @@ function runAutomationSoakGate(env, options = {}) {
     startedAt,
     completedAt: new Date().toISOString(),
     delegatedCommand: AUTOMATION_SOAK_COMMAND,
-    childExitCode,
+    childExitCode: typeof child?.status === 'number' ? child.status : null,
     childReportJson,
     childReportMd,
-    childStatus: childReport?.status ?? status,
+    childStatus: childReport?.status ?? null,
     childIterations: childReport?.iterations,
     childEvidence: childReport?.evidence,
+    childStdoutSample,
+    childStderrSample,
   }
 }
 

--- a/scripts/ops/multitable-phase3-release-gate.test.mjs
+++ b/scripts/ops/multitable-phase3-release-gate.test.mjs
@@ -5,7 +5,12 @@ import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { spawnSync } from 'node:child_process'
 
-import { executeGate } from './multitable-phase3-release-gate.mjs'
+import { mkdirSync, writeFileSync } from 'node:fs'
+
+import {
+  executeGate,
+  translateDelegateStatus,
+} from './multitable-phase3-release-gate.mjs'
 
 const SCRIPT = 'scripts/ops/multitable-phase3-release-gate.mjs'
 
@@ -344,5 +349,475 @@ test('artifact integrity — MULTITABLE_EMAIL_SMTP_HOST/USER/FROM/PASSWORD real 
     assert.doesNotMatch(all, /aggregator-to@example\.com/)
   } finally {
     cleanup(r.dir)
+  }
+})
+
+//
+// ============================================================
+// Strict delegate-gate status translation tests — hardening PR
+// ============================================================
+//
+// These tests cover the translator + mock-injected delegate state
+// machine in-process. They do not spawn pnpm and do not require
+// node_modules.
+//
+
+test('translateDelegateStatus — email pass case: exit=0 + status=pass + ok=true → pass', () => {
+  const t = translateDelegateStatus({
+    gate: 'email:real-send',
+    childExitCode: 0,
+    childError: undefined,
+    childReport: { status: 'pass', ok: true, mode: 'smtp' },
+  })
+  assert.equal(t.status, 'pass')
+  assert.equal(t.exitCode, 0)
+  assert.equal(t.mismatchReason, null)
+})
+
+test('translateDelegateStatus — email blocked case: exit=2 + status=blocked → blocked', () => {
+  const t = translateDelegateStatus({
+    gate: 'email:real-send',
+    childExitCode: 2,
+    childError: undefined,
+    childReport: { status: 'blocked', ok: false },
+  })
+  assert.equal(t.status, 'blocked')
+  assert.equal(t.exitCode, 2)
+  assert.equal(t.mismatchReason, null)
+})
+
+test('translateDelegateStatus — email mismatch: exit=0 + status=blocked (script bug) → fail-closed', () => {
+  const t = translateDelegateStatus({
+    gate: 'email:real-send',
+    childExitCode: 0,
+    childError: undefined,
+    childReport: { status: 'blocked', ok: false },
+  })
+  assert.equal(t.status, 'fail')
+  assert.equal(t.exitCode, 1)
+  assert.match(t.mismatchReason, /Fail-closed/)
+})
+
+test('translateDelegateStatus — email mismatch: exit=2 + status=pass → fail-closed', () => {
+  const t = translateDelegateStatus({
+    gate: 'email:real-send',
+    childExitCode: 2,
+    childError: undefined,
+    childReport: { status: 'pass', ok: true },
+  })
+  assert.equal(t.status, 'fail')
+  assert.equal(t.exitCode, 1)
+  assert.match(t.mismatchReason, /Fail-closed/)
+})
+
+test('translateDelegateStatus — email mismatch: exit=0 + status=pass + ok=false → fail-closed', () => {
+  const t = translateDelegateStatus({
+    gate: 'email:real-send',
+    childExitCode: 0,
+    childError: undefined,
+    childReport: { status: 'pass', ok: false },
+  })
+  assert.equal(t.status, 'fail')
+  assert.equal(t.exitCode, 1)
+  assert.match(t.mismatchReason, /Fail-closed/)
+  assert.match(t.mismatchReason, /ok=false/)
+})
+
+test('translateDelegateStatus — email mismatch: exit=0 + status=pass + ok missing → fail-closed', () => {
+  const t = translateDelegateStatus({
+    gate: 'email:real-send',
+    childExitCode: 0,
+    childError: undefined,
+    childReport: { status: 'pass' },
+  })
+  assert.equal(t.status, 'fail')
+  assert.equal(t.exitCode, 1)
+  assert.match(t.mismatchReason, /Fail-closed/)
+})
+
+test('translateDelegateStatus — automation pass: exit=0 + status=pass (no ok required) → pass', () => {
+  const t = translateDelegateStatus({
+    gate: 'automation:soak',
+    childExitCode: 0,
+    childError: undefined,
+    childReport: { status: 'pass', iterations: 3 },
+  })
+  assert.equal(t.status, 'pass')
+  assert.equal(t.exitCode, 0)
+  assert.equal(t.mismatchReason, null)
+})
+
+test('translateDelegateStatus — automation blocked: exit=2 + status=blocked → blocked', () => {
+  const t = translateDelegateStatus({
+    gate: 'automation:soak',
+    childExitCode: 2,
+    childError: undefined,
+    childReport: { status: 'blocked' },
+  })
+  assert.equal(t.status, 'blocked')
+  assert.equal(t.exitCode, 2)
+  assert.equal(t.mismatchReason, null)
+})
+
+test('translateDelegateStatus — automation mismatch: exit=0 + status=blocked → fail-closed', () => {
+  const t = translateDelegateStatus({
+    gate: 'automation:soak',
+    childExitCode: 0,
+    childError: undefined,
+    childReport: { status: 'blocked' },
+  })
+  assert.equal(t.status, 'fail')
+  assert.equal(t.exitCode, 1)
+  assert.match(t.mismatchReason, /Fail-closed/)
+})
+
+test('translateDelegateStatus — automation mismatch: exit=2 + status=pass → fail-closed', () => {
+  const t = translateDelegateStatus({
+    gate: 'automation:soak',
+    childExitCode: 2,
+    childError: undefined,
+    childReport: { status: 'pass' },
+  })
+  assert.equal(t.status, 'fail')
+  assert.equal(t.exitCode, 1)
+  assert.match(t.mismatchReason, /Fail-closed/)
+})
+
+test('translateDelegateStatus — child report missing → fail-closed', () => {
+  const t = translateDelegateStatus({
+    gate: 'email:real-send',
+    childExitCode: 0,
+    childError: undefined,
+    childReport: null,
+  })
+  assert.equal(t.status, 'fail')
+  assert.equal(t.exitCode, 1)
+  assert.match(t.mismatchReason, /report\.json missing|unparseable/)
+})
+
+test('translateDelegateStatus — child report non-object (parse failure already returned null) → fail-closed', () => {
+  const t = translateDelegateStatus({
+    gate: 'email:real-send',
+    childExitCode: 0,
+    childError: undefined,
+    childReport: 'broken',
+  })
+  assert.equal(t.status, 'fail')
+  assert.equal(t.exitCode, 1)
+  assert.match(t.mismatchReason, /unparseable|missing/)
+})
+
+test('translateDelegateStatus — spawn error (ENOENT) → fail-closed', () => {
+  const t = translateDelegateStatus({
+    gate: 'email:real-send',
+    childExitCode: null,
+    childError: new Error('spawn pnpm ENOENT'),
+    childReport: null,
+  })
+  assert.equal(t.status, 'fail')
+  assert.equal(t.exitCode, 1)
+  assert.match(t.mismatchReason, /Spawn launch error/)
+})
+
+test('translateDelegateStatus — null exit (signal kill) → fail-closed', () => {
+  const t = translateDelegateStatus({
+    gate: 'automation:soak',
+    childExitCode: null,
+    childError: undefined,
+    childReport: { status: 'pass' },
+  })
+  assert.equal(t.status, 'fail')
+  assert.equal(t.exitCode, 1)
+  assert.match(t.mismatchReason, /not numeric|signal kill/)
+})
+
+//
+// In-process delegate tests with mock spawnFn
+// (drive the full delegate function without invoking pnpm)
+//
+
+function makeMockSpawn({ exitCode, report, stdout = '', stderr = '', spawnError = null }) {
+  return (cmd, args, opts) => {
+    if (spawnError) {
+      return { status: null, stdout: '', stderr: '', error: spawnError }
+    }
+    const env = opts?.env ?? {}
+    let jsonPath = env.EMAIL_REAL_SEND_JSON || env.AUTOMATION_SOAK_JSON
+    let mdPath = env.EMAIL_REAL_SEND_MD || env.AUTOMATION_SOAK_MD
+    if (jsonPath && report !== undefined) {
+      mkdirSync(path.dirname(jsonPath), { recursive: true })
+      writeFileSync(
+        jsonPath,
+        typeof report === 'string' ? report : `${JSON.stringify(report, null, 2)}\n`,
+      )
+    }
+    if (mdPath && report !== undefined) {
+      mkdirSync(path.dirname(mdPath), { recursive: true })
+      writeFileSync(mdPath, `# mock report (status=${report?.status ?? 'n/a'})\n`)
+    }
+    return { status: exitCode, stdout, stderr, error: null }
+  }
+}
+
+test('email delegate with mock — pass case round-trips through translator', () => {
+  const dir = mkdtempSync(path.join(tmpdir(), 'mt-phase3-hardening-'))
+  try {
+    const spawnFn = makeMockSpawn({ exitCode: 0, report: { ok: true, status: 'pass', mode: 'smtp' } })
+    const result = executeGate('email:real-send', {}, { outputDir: dir, spawnFn })
+    assert.equal(result.status, 'pass')
+    assert.equal(result.exitCode, 0)
+    assert.equal(result.childStatus, 'pass')
+    assert.equal(result.childOk, true)
+  } finally {
+    cleanup(dir)
+  }
+})
+
+test('email delegate with mock — mismatch (exit=0 + status=blocked) is FAIL not PASS', () => {
+  const dir = mkdtempSync(path.join(tmpdir(), 'mt-phase3-hardening-'))
+  try {
+    const spawnFn = makeMockSpawn({ exitCode: 0, report: { ok: false, status: 'blocked' } })
+    const result = executeGate('email:real-send', {}, { outputDir: dir, spawnFn })
+    assert.equal(result.status, 'fail', 'mismatch must fail, not pass (release-gate correctness)')
+    assert.equal(result.exitCode, 1)
+    assert.match(result.reason, /Fail-closed/)
+  } finally {
+    cleanup(dir)
+  }
+})
+
+test('email delegate with mock — child report missing → FAIL', () => {
+  const dir = mkdtempSync(path.join(tmpdir(), 'mt-phase3-hardening-'))
+  try {
+    const spawnFn = makeMockSpawn({ exitCode: 0, report: undefined })
+    const result = executeGate('email:real-send', {}, { outputDir: dir, spawnFn })
+    assert.equal(result.status, 'fail')
+    assert.equal(result.exitCode, 1)
+  } finally {
+    cleanup(dir)
+  }
+})
+
+test('automation delegate with mock — pass case round-trips through translator', () => {
+  const dir = mkdtempSync(path.join(tmpdir(), 'mt-phase3-hardening-'))
+  try {
+    const spawnFn = makeMockSpawn({ exitCode: 0, report: { status: 'pass', iterations: 3 } })
+    const result = executeGate('automation:soak', {}, { outputDir: dir, spawnFn })
+    assert.equal(result.status, 'pass')
+    assert.equal(result.exitCode, 0)
+    assert.equal(result.childStatus, 'pass')
+  } finally {
+    cleanup(dir)
+  }
+})
+
+test('automation delegate with mock — mismatch (exit=0 + status=blocked) is FAIL not PASS', () => {
+  const dir = mkdtempSync(path.join(tmpdir(), 'mt-phase3-hardening-'))
+  try {
+    const spawnFn = makeMockSpawn({ exitCode: 0, report: { status: 'blocked' } })
+    const result = executeGate('automation:soak', {}, { outputDir: dir, spawnFn })
+    assert.equal(result.status, 'fail', 'automation mismatch must fail too — same hardening applies')
+    assert.equal(result.exitCode, 1)
+    assert.match(result.reason, /Fail-closed/)
+  } finally {
+    cleanup(dir)
+  }
+})
+
+test('automation delegate with mock — spawn ENOENT → FAIL', () => {
+  const dir = mkdtempSync(path.join(tmpdir(), 'mt-phase3-hardening-'))
+  try {
+    const spawnFn = makeMockSpawn({ exitCode: null, spawnError: new Error('spawn pnpm ENOENT') })
+    const result = executeGate('automation:soak', {}, { outputDir: dir, spawnFn })
+    assert.equal(result.status, 'fail')
+    assert.equal(result.exitCode, 1)
+    assert.match(result.reason, /Spawn launch error/)
+  } finally {
+    cleanup(dir)
+  }
+})
+
+//
+// Aggregator state machine with mocked delegate spawns
+//
+
+function makeRoutingSpawn({ email, automation }) {
+  return (cmd, args, opts) => {
+    const env = opts?.env ?? {}
+    if (env.EMAIL_REAL_SEND_JSON) {
+      const e = email ?? { exitCode: 2, report: { ok: false, status: 'blocked' } }
+      return makeMockSpawn(e)(cmd, args, opts)
+    }
+    if (env.AUTOMATION_SOAK_JSON) {
+      const a = automation ?? { exitCode: 2, report: { status: 'blocked' } }
+      return makeMockSpawn(a)(cmd, args, opts)
+    }
+    throw new Error(`unexpected spawn route: ${cmd} ${args.join(' ')}`)
+  }
+}
+
+test('aggregator state machine — email PASS + automation BLOCKED + 2 D0 BLOCKED → BLOCKED (does NOT collapse to PASS)', () => {
+  const dir = mkdtempSync(path.join(tmpdir(), 'mt-phase3-hardening-'))
+  try {
+    const spawnFn = makeRoutingSpawn({
+      email: { exitCode: 0, report: { ok: true, status: 'pass', mode: 'smtp' } },
+      automation: { exitCode: 2, report: { status: 'blocked' } },
+    })
+    const result = executeGate('release:phase3', {}, { outputDir: dir, spawnFn })
+    assert.equal(result.status, 'blocked', 'partial PASS must not collapse aggregate to PASS')
+    assert.equal(result.exitCode, 2)
+    const emailChild = result.children.find((c) => c.gate === 'email:real-send')
+    assert.equal(emailChild.status, 'pass')
+    assert.match(result.reason, /BLOCKED/)
+  } finally {
+    cleanup(dir)
+  }
+})
+
+test('aggregator state machine — email FAIL + automation BLOCKED + 2 D0 BLOCKED → FAIL (any delegate fail → aggregate fail)', () => {
+  const dir = mkdtempSync(path.join(tmpdir(), 'mt-phase3-hardening-'))
+  try {
+    const spawnFn = makeRoutingSpawn({
+      email: { exitCode: 1, report: { ok: false, status: 'failed' } },
+      automation: { exitCode: 2, report: { status: 'blocked' } },
+    })
+    const result = executeGate('release:phase3', {}, { outputDir: dir, spawnFn })
+    assert.equal(result.status, 'fail')
+    assert.equal(result.exitCode, 1)
+  } finally {
+    cleanup(dir)
+  }
+})
+
+test('aggregator state machine — automation FAIL beats email PASS + others BLOCKED → FAIL', () => {
+  const dir = mkdtempSync(path.join(tmpdir(), 'mt-phase3-hardening-'))
+  try {
+    const spawnFn = makeRoutingSpawn({
+      email: { exitCode: 0, report: { ok: true, status: 'pass', mode: 'smtp' } },
+      automation: { exitCode: 1, report: { status: 'fail' } },
+    })
+    const result = executeGate('release:phase3', {}, { outputDir: dir, spawnFn })
+    assert.equal(result.status, 'fail', 'any delegate FAIL must propagate even when others PASS')
+    assert.equal(result.exitCode, 1)
+  } finally {
+    cleanup(dir)
+  }
+})
+
+test('aggregator state machine — email mismatch (exit=0 + status=blocked) → aggregate FAIL', () => {
+  const dir = mkdtempSync(path.join(tmpdir(), 'mt-phase3-hardening-'))
+  try {
+    const spawnFn = makeRoutingSpawn({
+      email: { exitCode: 0, report: { ok: false, status: 'blocked' } },
+      automation: { exitCode: 2, report: { status: 'blocked' } },
+    })
+    const result = executeGate('release:phase3', {}, { outputDir: dir, spawnFn })
+    assert.equal(result.status, 'fail', 'email mismatch should poison the aggregate to FAIL')
+    assert.equal(result.exitCode, 1)
+  } finally {
+    cleanup(dir)
+  }
+})
+
+test('aggregator state machine — automation mismatch (exit=2 + status=pass) → aggregate FAIL', () => {
+  const dir = mkdtempSync(path.join(tmpdir(), 'mt-phase3-hardening-'))
+  try {
+    const spawnFn = makeRoutingSpawn({
+      email: { exitCode: 2, report: { ok: false, status: 'blocked' } },
+      automation: { exitCode: 2, report: { status: 'pass' } },
+    })
+    const result = executeGate('release:phase3', {}, { outputDir: dir, spawnFn })
+    assert.equal(result.status, 'fail', 'automation mismatch should poison the aggregate to FAIL')
+    assert.equal(result.exitCode, 1)
+  } finally {
+    cleanup(dir)
+  }
+})
+
+//
+// Artifact integrity — real SMTP / webhook / token env names through mock path
+//
+
+test('artifact integrity — real SMTP env values do not leak via delegate childStdoutSample / childStderrSample (email)', () => {
+  const dir = mkdtempSync(path.join(tmpdir(), 'mt-phase3-hardening-'))
+  try {
+    // Simulate worst-case: email script accidentally echoes env values
+    // into stdout/stderr. Bridge must redact before storing samples.
+    const dirtyStdout = [
+      'SMTP_HOST=smtp.privateops.example.com',
+      'SMTP_USER=privateops-smtp-user',
+      'MULTITABLE_EMAIL_SMTP_PASSWORD=privateOpsSmtpPw99',
+      'MULTITABLE_EMAIL_SMOKE_TO=private-recipient@example.com',
+      'Bearer abcdefghijklmnopqrstuvwxyz1234567890',
+    ].join('\n')
+    const dirtyStderr = 'sk-leakytestonly1234567890abcdef\nOPENAI_API_KEY=plaintextkey-leak'
+    const spawnFn = makeMockSpawn({
+      exitCode: 2,
+      report: { ok: false, status: 'blocked' },
+      stdout: dirtyStdout,
+      stderr: dirtyStderr,
+    })
+    const result = executeGate('email:real-send', {}, { outputDir: dir, spawnFn })
+    const sampled = `${result.childStdoutSample}\n${result.childStderrSample}`
+    assert.doesNotMatch(sampled, /smtp\.privateops\.example\.com/, 'leak: SMTP_HOST value')
+    assert.doesNotMatch(sampled, /privateops-smtp-user/, 'leak: SMTP_USER value')
+    assert.doesNotMatch(sampled, /privateOpsSmtpPw99/, 'leak: SMTP_PASSWORD value')
+    assert.doesNotMatch(sampled, /private-recipient@example\.com/, 'leak: recipient value')
+    assert.doesNotMatch(sampled, /abcdefghijklmnopqrstuvwxyz1234567890/, 'leak: Bearer token')
+    assert.doesNotMatch(sampled, /sk-leakytestonly1234567890abcdef/, 'leak: sk- API key')
+    assert.doesNotMatch(sampled, /plaintextkey-leak/, 'leak: OPENAI_API_KEY value')
+  } finally {
+    cleanup(dir)
+  }
+})
+
+test('artifact integrity — webhook URLs and auth tokens do not leak via automation delegate samples', () => {
+  const dir = mkdtempSync(path.join(tmpdir(), 'mt-phase3-hardening-'))
+  try {
+    const dirtyStderr = [
+      'MULTITABLE_AUTOMATION_SOAK_WEBHOOK_URL=https://hook.example.com/path?access_token=secret-leak-token-12345',
+      'MULTITABLE_AUTOMATION_SOAK_FAIL_WEBHOOK_URL=https://hook.example.com/fail?access_token=fail-leak-token-67890',
+      'AUTH_TOKEN=Bearer raw-bearer-leak-token-aaaaaaaaaaaa',
+    ].join('\n')
+    const spawnFn = makeMockSpawn({
+      exitCode: 2,
+      report: { status: 'blocked' },
+      stderr: dirtyStderr,
+    })
+    const result = executeGate('automation:soak', {}, { outputDir: dir, spawnFn })
+    const sampled = `${result.childStdoutSample}\n${result.childStderrSample}`
+    assert.doesNotMatch(sampled, /secret-leak-token-12345/, 'leak: webhook access_token')
+    assert.doesNotMatch(sampled, /fail-leak-token-67890/, 'leak: fail-webhook access_token')
+    assert.doesNotMatch(sampled, /raw-bearer-leak-token-aaaaaaaaaaaa/, 'leak: bearer token')
+  } finally {
+    cleanup(dir)
+  }
+})
+
+test('artifact integrity — Phase 3 aggregator report.json does not include dirty samples raw', () => {
+  // The aggregator's report.json only stores summarized children
+  // (gate, status, exitCode, deferral, delegatedCommand, child paths).
+  // Even if delegate samples contained dirty content, they don't
+  // surface in the aggregator's own report.json.
+  const dir = mkdtempSync(path.join(tmpdir(), 'mt-phase3-hardening-'))
+  try {
+    const spawnFn = makeRoutingSpawn({
+      email: {
+        exitCode: 2,
+        report: { ok: false, status: 'blocked' },
+        stdout: 'SMTP_PASSWORD=p4ssw0rd-leak\n',
+      },
+      automation: {
+        exitCode: 2,
+        report: { status: 'blocked' },
+        stdout: 'TOKEN=tokenvalue-leak\n',
+      },
+    })
+    const result = executeGate('release:phase3', {}, { outputDir: dir, spawnFn })
+    const serialized = JSON.stringify(result)
+    assert.doesNotMatch(serialized, /p4ssw0rd-leak/)
+    assert.doesNotMatch(serialized, /tokenvalue-leak/)
+  } finally {
+    cleanup(dir)
   }
 })


### PR DESCRIPTION
## Summary

Hardens the Phase 3 release gate so neither delegated sub-gate
(`email:real-send` from #1544, `automation:soak` from #1547) accepts
inconsistent child signals.

The current `statusFromExitCode(childExitCode)` helper trusts the child
exit code without checking that the child's `report.json` `status` /
`ok` fields agree with the exit code, so `exit=0 + report.status=blocked`
(script bug / racing redact / malformed I/O) silently lands as **pass**
at the release-gate level. For a release gate, that is the wrong
direction.

This PR replaces the loose mapping with a strict translator that covers
**both** delegates uniformly, and adds 1200-char redacted
`childStdoutSample` / `childStderrSample` for diagnostic value when a
child fails-closed.

## Strict translation contract

| Child signals | Outcome |
| --- | --- |
| `exit=0` AND `status='pass'` AND (email only: `ok=true`) | **pass** |
| `exit=2` AND `status='blocked'` | **blocked** |
| Spawn launch error (e.g. `ENOENT`) | **fail** |
| Non-numeric exit (signal kill / aborted) | **fail** |
| Missing or unparseable `report.json` | **fail** |
| Exit / status / ok inconsistency | **fail** |

Every fail case carries a redaction-safe `mismatchReason` that surfaces
in the gate's `report.json` / `report.md` `reason` field.

## What's NOT changed (intentional)

- `scripts/ops/multitable-email-real-send-smoke.ts` — untouched.
- `scripts/ops/multitable-automation-soak.mjs` — untouched.
- `verify:multitable-email:*` and `verify:multitable-automation:soak`
  package scripts — untouched.
- No new package script.
- No change under `plugins/plugin-integration-core/`, `lib/adapters/`,
  multitable runtime, OpenAPI, migrations, routes, workflows.

## Test coverage (28 new tests)

| Group | Tests | Notes |
| --- | --- | --- |
| `translateDelegateStatus` unit | 14 | email + automation pass / blocked / mismatch flavors / missing report / spawn ENOENT / signal kill |
| In-process delegate (mock `spawnFn`) | 6 | email + automation pass / mismatch / error |
| Aggregator state machine (routed mock) | 5 | email PASS + others BLOCKED → BLOCKED (partial PASS does not collapse); FAIL propagation; mismatch poisoning |
| Artifact integrity | 3 | real SMTP env values, webhook URLs, auth tokens never leak into delegate samples or aggregator report |

All 28 new tests are pure in-process (no `pnpm` spawn dependency).

## Test plan

- [x] `pnpm install --frozen-lockfile --prefer-offline`
- [x] `node --test scripts/ops/multitable-phase3-release-gate.test.mjs`
      → **tests 44, pass 44, fail 0**
- [x] `node --test scripts/ops/multitable-phase3-release-gate-redact.test.mjs scripts/ops/multitable-phase3-release-gate-report.test.mjs`
      → **tests 24, pass 24, fail 0** (sibling files unaffected)
- [x] `git diff --cached --check` clean
- [x] Secret-pattern scan returns only `.test.mjs` fixture matches,
      all inside `assert.doesNotMatch` / `assert.match` clauses

## Stage-1 lock compliance

- [x] No change under `plugins/plugin-integration-core/*`
- [x] No change under `lib/adapters/k3-wise-*`
- [x] No new product战线 — kernel polish on already-shipped delegate
      gates
- [x] No schema / migration / route / workflow change
- [x] No change to existing delegate harness scripts
- [x] No change to package scripts

## Files (4 changes, +1064 / -32)

| Path | Change | Lines |
| --- | --- | --- |
| `scripts/ops/multitable-phase3-release-gate.mjs` | modify | +164 / -32 |
| `scripts/ops/multitable-phase3-release-gate.test.mjs` | modify | +477 |
| `docs/development/multitable-phase3-delegate-gate-strict-status-development-20260514.md` | new | 202 |
| `docs/development/multitable-phase3-delegate-gate-strict-status-verification-20260514.md` | new | 253 |

## Cross-references

- D1 email delegate (#1544): merge commit `1f9061f56`
- D4 automation soak delegate (#1547): merge commit `855ba871e`
- Closed in favor of this PR: #1545 (Claude's parallel D1
  implementation, closed as duplicate after Codex landed #1544)
- Operator direction: 2026-05-14 review of delegate gate status
  translation across both #1544 and #1547

🤖 Generated with [Claude Code](https://claude.com/claude-code)