### PR TITLE
docs: archive local planning and staging operation notes

### DIFF
--- a/docs/development/integration-k3wise-stage1-closeout-20260509.md
+++ b/docs/development/integration-k3wise-stage1-closeout-20260509.md
@@ -1,0 +1,168 @@
+# K3 WISE Stage 1 Internal Closeout — 2026-05-09
+
+## Purpose
+
+Snapshot of the K3 WISE Stage 1 internal work completed before the customer
+GATE answers arrive. Captures what shipped, where the work paused (and why
+that pause is correct), what is gated on customer input, and what remains
+optional and operator-facing should we want to keep moving while the GATE
+window stays open.
+
+This document is a closeout, not a runbook — operators continuing the work
+after the GATE arrives should read
+`docs/operations/integration-k3wise-live-gate-execution-package.md` (PR
+#1445 + the rehearsal fixups in #1447) as the canonical sequence; this
+document only locates where that runbook fits.
+
+---
+
+## Stage 1 invariants (preserved end-to-end)
+
+- Customer GATE answers have not arrived → no integration-core touch, no
+  new战线, 内核打磨 only — per the `K3 PoC Stage 1 Lock` memory.
+- Every PR shipped this stage was `docs(...)`, `chore(integration)`, or
+  `fix(integration)` scope; no `plugin-integration-core/` runtime,
+  adapter, pipeline, or runner code was modified.
+- All operator-shareable artifacts (preflight JSON / MD, postdeploy smoke
+  evidence, live PoC packet) carry the same four-grep secret-hygiene
+  contract; verified `0/0/0/0` against real artifacts and against
+  synthetic-leak fixtures designed to defeat the older two-grep version.
+
+---
+
+## Shipped this stage (5 PRs)
+
+| # | Title | Merge SHA | Triggered by |
+|---|---|---|---|
+| #1433 | `chore(integration): add K3 PoC on-prem preflight script` | `b26d3d501` | initial scope from operator |
+| #1437 | `docs(integration): add K3 PoC on-prem preflight runbook` (also: `fix(integration): sanitize K3_API_URL query secrets at storage time`) | `36ca5250d` | advisor flagged `sanitizeUrl` storage-time gap |
+| #1442 | `docs(integration): expand K3 WISE internal-trial runbook with host-shell path` | `1fb028bc6` | 142 host-shell mint pattern run on real prod env |
+| #1445 | `docs(integration): add K3 WISE live GATE execution package` | `ff0a11efe` | preparing for customer GATE arrival |
+| #1447 | `docs(integration): close 3 GATE-package operator footguns surfaced by rehearsal` | `364f9e2d8` | self-driven rehearsal exposed G1 / G2 / G3 |
+
+Each PR was driven by real-execution evidence from the previous one — the
+sequence is "tool ships → run it for real → record gap → next PR closes
+gap". No invented requirements.
+
+---
+
+## Verified deployment-side state (machine 142)
+
+Both verifications fall under the closing `K3 WISE Internal Trial`
+runbook contract.
+
+| Check | Result | Captured by |
+|---|---|---|
+| On-prem preflight (mock mode, host shell) | `decision=PASS / exit 0 / 5 pass / 3 skip / 0 fail` | local artifact + `pnpm verify:integration-k3wise:onprem-preflight` 14/14 PASS |
+| On-prem preflight (`--mock` against real prod env via Docker bridge-IP recipe) | `decision=PASS / exit 0`; `pg.migrations-aligned: applied=159 / pending=0` | first execution of the migration-real-path the unit suite cannot cover; recipe lives in PR #1437 runbook |
+| Internal-trial postdeploy smoke (host shell, fresh-minted admin token via `docker exec metasheet-backend node`) | `signoff.internalTrial=pass / 10 pass / 0 skipped / 0 fail` | full chain: `api-health` / `integration-plugin-health` / `k3-wise-frontend-route` / `auth-me` / `integration-route-contract` / four control-plane lists / `staging-descriptor-contract` |
+| Public surface access posture | TCP-allow + HTTP-deny by source (curl error 52 from external workstation; GHA + host-loopback succeed) | matches design intent; documented in PR #1442's runbook |
+
+The 142 deploy is internal-trial-signoff-ready under the existing
+contract. The customer-side bits (real K3 endpoint, customer GATE
+answers, rollback contract owner) cannot be closed without customer
+input.
+
+---
+
+## What is **gated on customer GATE arrival** (frozen by design)
+
+Following the Stage 1 chain `142 PASS → GATE package → wait → C0–C10 →
+evidence PASS → platformization decision`, the next four boxes are all
+deliberately blocked until the customer fills A.1–A.6 of the live GATE
+execution package:
+
+- **C2** — `integration-k3wise-onprem-preflight.mjs --live` against the
+  customer's real K3 endpoint (TCP probe of K3 host:port; configured K3
+  env presence check). Returns `exit 2 / GATE_BLOCKED` until
+  `K3_API_URL` / `K3_ACCT_ID` / `K3_USERNAME` / `K3_PASSWORD` are
+  supplied.
+- **C3** — `integration-k3wise-live-poc-preflight.mjs --input
+  <gate.json>` to build the live PoC packet. Throws on any of the hard
+  contracts the package documents under A.1–A.6.
+- **C4–C9** — testConnection (PLM + K3) → material dry-run → material
+  Save-only PoC → optional BOM Save-only → dead-letter replay → rollback
+  rehearsal. Each requires a real customer K3 to be reachable and
+  authenticated.
+- **C10** — Evidence compiler (`integration-k3wise-live-poc-evidence.mjs`)
+  signoff. Returns `decision=PASS` only when every Save-only / row-count
+  / K3-record / BOM-product-scope / legacy-product-id contract is
+  satisfied with real evidence from C4–C9.
+
+Trying to run any of these earlier than the customer GATE arrives would
+produce only synthetic data — exactly the rehearsal we already did, with
+diminishing returns past PR #1447.
+
+---
+
+## Optional pre-GATE work that does not require customer input
+
+These are independent of the customer; they would be additive once
+chosen, and none would touch `plugin-integration-core` runtime.
+
+| Item | Effort | Trigger |
+|---|---|---|
+| Customer-facing GATE intake template (Stage D gap #1) — semi-structured Chinese plus a fillable YAML/wiki page covering A.1–A.6 in plain language with `<fill-outside-git>` placeholders for every credential slot | small docs PR, ~200 lines | when you decide which delivery channel (PDF / Lark wiki / email attachment) the customer prefers |
+| On-site evidence-collection template (Stage D gap #2) — slot-per-step JSON skeleton for C4–C9 (runId / externalId / billNo / dead-letter row id / rollback evidence), drops directly into `integration-k3wise-live-poc-evidence.mjs --evidence <file>` | small docs PR, ~100 lines | when you decide whether the on-site recording happens in the JSON skeleton or in a wiki transcript that we then translate into JSON |
+| Field-semantics explainer (Chinese, Stage D gap #3) — design intent ("why production is forbidden", "why BOM requires product scope", "why core-table writes are blocked outside `readonly` mode") | small docs PR, ~80 lines | only after the first live PoC produces real customer questions; deferred is correct |
+| `K3_SESSION_ID` env path in `integration-k3wise-onprem-preflight.mjs` — closes the C2-vs-C3 sessionId-only divergence the runbook surfaces under A.2 | small script PR + tests | only when a customer GATE answer arrives with a sessionId-only credential bundle; until then this gap is documented and harmless |
+
+The first two are the natural closeout of the Stage D gap list in PR
+#1445. They're cheap and ship-ready; the only blocker is the
+deliverable shape question.
+
+The last two are deliberately deferred — not because they're
+expensive, but because acting on them now would be guessing.
+
+---
+
+## Untracked drafts on the workstation
+
+These files exist on disk after this session but were intentionally not
+committed (they're either still drafts under review, or evidence that
+already lived in a merged PR via a more polished form).
+
+```
+docs/development/
+├── integration-k3wise-live-gate-rehearsal-20260509.md            # superseded — equivalent merged in PR #1447
+└── integration-k3wise-stage1-closeout-20260509.md                # this file
+```
+
+Plus all rehearsal artifact directories under
+`artifacts/integration-k3wise/internal-trial/rehearsal-*/` — covered by
+the gitignore rule from PR #1442 and inert to repo state.
+
+---
+
+## Acceptance criteria for "Stage 1 fully closes"
+
+Stage 1 cleanly closes — and the platformization decision can begin —
+when *all* of the following hold against a real customer K3:
+
+- `signoff.internalTrial=pass` (already true on 142).
+- `integration-k3wise-live-poc-preflight.mjs` packet built without
+  `normalizeGate` throws against real GATE answers.
+- `integration-k3wise-live-poc-evidence.mjs` returns `decision=PASS /
+  issues=[]` with at least one material Save-only PoC and (when BOM in
+  scope) one BOM Save-only PoC.
+- `rollback.owner` exercised the rollback strategy on test rows.
+- Pre-share self-check returns `0/0/0/0` on every artifact attached
+  to the customer report.
+
+Until these hold, Stage 1 is **paused**, not finished. The pause is
+correct — pushing further internal effort right now would be
+diminishing-returns rehearsal of code paths the test suites already
+cover.
+
+---
+
+## See also
+
+- `docs/operations/integration-k3wise-live-gate-execution-package.md` —
+  canonical execution sequence (C0–C10, PASS/FAIL gates).
+- `docs/operations/k3-poc-onprem-preflight-runbook.md` — per-check fix
+  recipes for the on-prem preflight (#1437).
+- `docs/operations/integration-k3wise-internal-trial-runbook.md` —
+  postdeploy auth smoke + host-shell mint pattern (#1442).
+- `scripts/ops/integration-k3wise-live-poc-preflight.mjs --print-sample`
+  — schema source of truth for the GATE answer JSON.

--- a/docs/development/local-docs-archive-cleanup-20260514.md
+++ b/docs/development/local-docs-archive-cleanup-20260514.md
@@ -1,0 +1,58 @@
+# Local Docs Archive Cleanup - 2026-05-14
+
+## Purpose
+
+This PR archives local documentation files that were left untracked in the
+operator root checkout after the related development lanes had already moved
+on. Several current `origin/main` documents reference these files by path, so
+deleting them locally would leave historical cross-references broken.
+
+This is a docs-only cleanup. It does not change runtime code, migrations,
+scripts, OpenAPI contracts, CI workflows, or deployment configuration.
+
+## Files Archived
+
+| File | Reason |
+| --- | --- |
+| `docs/development/integration-k3wise-stage1-closeout-20260509.md` | Preserves the K3 WISE stage-1 closeout snapshot and gated handoff context. |
+| `docs/development/multitable-feishu-three-lane-plan-discussion-20260507.md` | Referenced by the merged Gantt dependency tightening development note. |
+| `docs/development/multitable-feishu-three-lane-claude-execution-plan-20260507.md` | Referenced by the Phase 2 multitable development note as the older plan that was superseded. |
+| `docs/development/operations-docs-delivery-20260426.md` | Delivery record for the staging SOP and migration-alignment runbook. |
+| `docs/development/staging-deploy-d88ad587b-20260426.md` | Forensic deploy note preserved with a correction banner. |
+| `docs/development/staging-deploy-d88ad587b-postmortem-20260426.md` | Referenced by the K3 on-prem preflight design note and staging operations docs. |
+| `docs/operations/staging-deploy-sop.md` | Operational SOP referenced by the migration-alignment runbook. |
+| `docs/operations/staging-migration-alignment-runbook.md` | Operational recovery runbook referenced by the staging SOP and older multitable execution plan. |
+
+## Files Deliberately Not Archived
+
+| Path | Decision |
+| --- | --- |
+| `.claude/` | Local assistant configuration/state; not a repository artifact. |
+| `output/delivery/multitable-onprem/` | Generated release/package evidence; keep local unless explicitly promoted to an artifact store. |
+| `output/dingtalk-live-acceptance/` | Generated live acceptance evidence; keep local unless explicitly promoted to an artifact store. |
+| `output/releases/` | Generated release bundles and checksums; do not commit to the docs cleanup PR. |
+
+## Superseded Local Files Removed From Root Checkout
+
+The following local-only files were removed before this PR because newer or
+more complete versions already exist on `origin/main`:
+
+- `docs/development/integration-core-external-system-config-preserve-*-20260426.md`
+- `docs/development/integration-core-external-system-kind-immutable-*-20260426.md`
+- `docs/development/integration-core-finishrun-error-guard-*-20260426.md`
+- `docs/development/integration-core-replay-mark-guard-*-20260426.md`
+- `docs/development/integration-core-run-mode-guard-*-20260426.md`
+- stale local copies of the Phase 3 plan and TODO that predated PR #1537's activation-gate patch
+- stale local copy of `k3wise-bridge-machine-codex-handoff-20260513.md` that lacked the latest mainline handoff notes
+
+## Verification
+
+Checks run before opening the PR:
+
+- `git diff --cached --check` passed.
+- Path scope check passed: changed files are under `docs/`.
+- Secret-pattern scan passed: no bearer, JWT, API key, SEC token,
+  access-token query value, client secret, DingTalk secret assignment, or
+  password-assignment matches in the changed files.
+- Cross-reference check passed for the previously missing docs referenced by
+  current `origin/main` development notes.

--- a/docs/development/multitable-feishu-three-lane-claude-execution-plan-20260507.md
+++ b/docs/development/multitable-feishu-three-lane-claude-execution-plan-20260507.md
@@ -1,0 +1,358 @@
+# 多维表 Feishu 深水区 · Claude 执行计划
+
+> Date: 2026-05-07
+> Status: 执行计划（待 §5 八问确认后正式启动）
+> 配套讨论文档: `docs/development/multitable-feishu-three-lane-plan-discussion-20260507.md`
+> 上游 TODO: `docs/development/multitable-feishu-rc-todo-20260430.md`
+
+本文是讨论文档的姊妹篇。**讨论文档**记录"为什么这么做"，**本文**记录"具体怎么做、做哪些、什么顺序、什么命令、什么验收标准"。Claude 启动每条 lane 时按本文条目逐步执行。
+
+---
+
+## 0. 前置假设（基于讨论文档默认推荐方案）
+
+启动前用户对讨论文档 §5 的 8 问已答复，本文按以下默认方案推进；若用户答复不同，对应章节对照修改：
+
+| # | 问题 | 默认方案 |
+|---|---|---|
+| 1 | K3 PoC Lock 适用性 | 采用 §2 的 PR 描述模板，三条 lane 均纳入"已发布功能 parity 深化" |
+| 2 | A1 advisory lock | 若当前 record insert 路径无 sheet 级 advisory lock，本 lane 引入 |
+| 3 | A2 批量号段策略 | 号段领取（`UPDATE ... RETURNING`），不走逐行 FOR UPDATE |
+| 4 | A3 staging migration alignment | 本 lane 内顺手对齐 staging（参见 `docs/operations/staging-migration-alignment-runbook.md`） |
+| 5 | B1 跨表 link | 跨表依赖不在 RC scope，dependencyFieldId 限制 self-table |
+| 6 | C1 parent link 单值 | 硬约束：parent link field 必须 maxValues=1，否则禁用拖拽 |
+| 7 | 工作树清场 | Claude 执行 Phase 0，把 4 条战线分别落盘 |
+| 8 | 节奏 | Phase 1 (A) 独跑 → Phase 2 (B+C) 并行 |
+
+---
+
+## 1. Phase 0 · 工作树清场（约 60-90 min）
+
+启动三 lane 之前，根目录工作树必须干净。
+
+### 1.1 战线盘点固化
+
+| 战线 | 文件 | 推荐分支名 |
+|---|---|---|
+| #1 directory return banner | `apps/web/src/views/{DirectoryManagementView,UserManagementView}.vue` + 对应 spec + `directory-sync.ts` | 当前分支 `codex/dingtalk-directory-return-banner-tests-20260505` 直接整理 |
+| #2 group failure alert → rule creator | 14 文件（automation-actions/executor/service + dingtalk-automation-link-validation + MetaAutomation* + automation-v1 + dingtalk-automation-link-routes）+ probe 脚本 + 4 verification doc | `codex/dingtalk-group-failure-alert-creator-20260507` |
+| #3 group destination verify-before-save | `dingtalk-group-destination-service.ts` + 路由/单元测试 + 多份 0506 verification doc | `codex/dingtalk-group-destination-verify-20260506` |
+| #4 API token manager | `MetaApiTokenManager.vue` + spec + `api-tokens.ts` + `multitable-client.spec.ts` | `codex/multitable-api-token-manager-polish-20260506` |
+
+### 1.2 执行步骤（按战线顺序）
+
+每条战线执行同一套动作：
+
+```bash
+# 起 worktree（基于 origin/main）
+EnterWorktree(branch="<推荐分支名>", base="origin/main")
+
+# 在 worktree 内
+git checkout -b <推荐分支名>
+git -C <根目录> stash push --keep-index --include-untracked -- <该战线的全部文件>
+# 或者用 git checkout 把该战线的 working-tree 改动捡到 worktree 内
+
+# 自测
+cd <worktree>
+pnpm install --frozen-lockfile
+<战线对应 vitest 套件>
+git diff --check
+git status
+
+# 提交
+git add <精确文件列表，不用 git add -A>
+git commit -m "<conventional commit message>"
+git push -u origin HEAD
+gh pr create --title "..." --body "..."
+```
+
+### 1.3 验收
+
+Phase 0 完成的判据：
+
+- [ ] 4 条战线各自有独立分支 + 独立 PR + CI 启动
+- [ ] `git status` 在根目录显示 clean（除 `.claude/` 外）
+- [ ] 50+ 未追踪 verification doc 已归位到对应 PR
+- [ ] 根目录 `git log` 不变（不在根目录直接 commit 三 lane 之外的东西）
+
+只有 Phase 0 全部 ✅ 后，才能进 Phase 1。
+
+---
+
+## 2. Phase 1 · Lane A autoNumber 字段（约 1-1.5 天）
+
+**分支**: `feat/multitable-auto-number-field-20260507`（基于 origin/main worktree）
+
+**核心约束**:
+- 用持久 sequence 表，不用 row index
+- backfill + new-record allocation 必须并发安全
+- 用户禁止写入 raw value
+- 删除不复用号
+
+### 2.1 文件清单
+
+#### 后端
+
+| 文件 | 操作 | 关键点 |
+|---|---|---|
+| `packages/core-backend/migrations/<timestamp>_meta_field_sequences.ts` | 新增 | `tenant_id, sheet_id, field_id, next_value, created_at, updated_at`；UNIQUE (tenant_id, sheet_id, field_id) |
+| `packages/core-backend/src/multitable/field-types.ts` | 改 | enum 增 `'autoNumber'`；写约束：raw 是 number；property: `{ prefix: string, digits: number, start: number }` |
+| `packages/core-backend/src/multitable/field-sequence-service.ts` | 新增 | `allocateNext(tenant, sheet, field, batchSize=1)` 用 `UPDATE ... SET next_value = next_value + :n RETURNING next_value - :n AS start_value` |
+| `packages/core-backend/src/multitable/record-create-service.ts` | 改 | record 创建路径在同一 transaction 调 allocateNext；reject 用户传入 autoNumber raw value |
+| `packages/core-backend/src/multitable/record-import-service.ts` | 改 | import 路径走 batch 号段 |
+| `packages/core-backend/src/multitable/field-create-service.ts` | 改 | CREATE FIELD autoNumber 时：advisory lock → backfill (created_at, id) → INSERT meta_field_sequences (next_value = N+1) |
+| `packages/core-backend/src/multitable/record-patch-service.ts` | 改 | reject 用户 patch autoNumber 字段 |
+| `packages/core-backend/src/openapi/...` | 改 | field type schema 增 autoNumber，property schema 加上 |
+
+#### 前端
+
+| 文件 | 操作 | 关键点 |
+|---|---|---|
+| `apps/web/src/multitable/types.ts` | 改 | FieldType 增 `'autoNumber'` |
+| `apps/web/src/multitable/components/MetaFieldManager.vue` | 改 | 字段类型下拉新增 autoNumber，配置面板：prefix / digits / start |
+| `apps/web/src/multitable/components/cell-renderers/AutoNumberCell.vue` | 新增 | 只读渲染：`prefix + zeroPad(raw, digits)` |
+| `apps/web/src/multitable/components/MetaGridView.vue` | 改 | 接入 AutoNumberCell |
+| `apps/web/src/multitable/components/MetaRecordDrawer.vue` | 改 | 只读展示 |
+| `apps/web/src/multitable/components/MetaRecordForm.vue` | 改 | autoNumber 字段不渲染表单输入 |
+
+### 2.2 自测命令
+
+```bash
+# 后端
+pnpm --filter @metasheet/core-backend exec vitest run \
+  packages/core-backend/tests/unit/multitable/field-sequence-service.test.ts \
+  packages/core-backend/tests/unit/multitable/auto-number-field.test.ts \
+  packages/core-backend/tests/integration/auto-number-record-create.test.ts \
+  packages/core-backend/tests/integration/auto-number-import.test.ts \
+  --watch=false
+
+# 前端
+pnpm --filter @metasheet/web exec vitest run \
+  apps/web/tests/multitable-auto-number-cell.spec.ts \
+  apps/web/tests/multitable-auto-number-field-manager.spec.ts \
+  --watch=false
+
+# 类型 + lint + diff
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+git diff --check
+
+# OpenAPI gate
+pnpm --filter @metasheet/core-backend run openapi:check
+pnpm --filter @metasheet/web run openapi:check  # 若前端有生成 client
+```
+
+### 2.3 测试用例必须覆盖
+
+后端：
+
+- [ ] 创建 autoNumber 字段时 sheet 已有 N records → 全部按 (created_at, id) 回填 1..N，next_value = N+1
+- [ ] 回填中并发 record insert 被 advisory lock 阻塞，回填完成后这条 record 拿到 N+1（不是漏号也不是冲突）
+- [ ] 连续 10 次 create record → 编号严格递增 1..10
+- [ ] 删除编号 5 的 record 后，再 create → 拿 11，不复用 5
+- [ ] xlsx import 100 行 → 一次号段领取，编号连续 N+1..N+100
+- [ ] 用户 create payload 带 `autoNumber: 999` → 后端拒绝 + 4xx + 错误信息明确
+- [ ] 用户 patch payload 带 autoNumber 字段 → 后端拒绝
+- [ ] 同一 sheet 两个 autoNumber 字段互不干扰（各自独立 sequence）
+- [ ] property `digits=4, prefix='INV-', start=1000` → next_value 从 1000 起
+
+前端：
+
+- [ ] Field Manager 选 autoNumber → 显示 prefix/digits/start 配置
+- [ ] Grid 渲染 raw=42 + property `{prefix:'A-',digits:4}` → 显示 "A-0042"
+- [ ] Drawer + Form 显示该字段为只读
+- [ ] property `digits=0` → 不补零
+- [ ] property `prefix=''` → 无前缀
+
+### 2.4 验证 doc
+
+写：
+- `docs/development/multitable-auto-number-field-development-verification-20260507.md`
+- 更新 `docs/development/multitable-feishu-rc-todo-20260430.md`
+
+### 2.5 PR 描述模板
+
+```markdown
+## 摘要
+
+为多维表新增 autoNumber 字段类型，对齐 Feishu RC 字段能力。
+
+## K3 PoC Stage 1 Lock 适用性
+
+本 PR 不触发 lock 拦截，因为：
+1. 不修改 plugins/plugin-integration-core/* 任何文件
+2. 多维表内核已在 Wave 系列发布，本 PR 是字段类型扩展而非新平台能力
+3. 不引入对接外部 ERP 的代码路径
+
+参见 docs/development/multitable-feishu-rc-todo-20260430.md。
+
+## 关键决策
+
+- 持久 sequence 表 meta_field_sequences，不用 row index
+- 创建字段时 advisory lock + 回填 + 设 next_value=N+1，全在单 transaction
+- 批量 import 走号段领取（UPDATE ... RETURNING），不逐行 FOR UPDATE
+- 用户 create/patch/import 写 autoNumber 一律拒绝
+- 删除不复用号
+
+## 测试
+
+[贴 vitest 输出]
+
+## Migration
+
+新增 meta_field_sequences。staging 已预先对齐到 prod baseline。
+```
+
+### 2.6 Phase 1 验收
+
+- [ ] PR CI 全绿
+- [ ] OpenAPI gate 通过
+- [ ] vue-tsc 通过
+- [ ] 测试用例 §2.3 全覆盖
+- [ ] verification doc 已写
+- [ ] PR 进入 review 状态
+
+仅在以上全 ✅ 后启动 Phase 2。
+
+---
+
+## 3. Phase 2A · Lane B Gantt dependency arrows（约 0.5-1 天）
+
+**分支**: `feat/multitable-gantt-dependency-arrows-20260507`（基于 Lane A 分支或 Lane A merge 后的 main）
+
+**核心约束**:
+- 仅扩 view config，不改后端 schema
+- dependencyFieldId 限 self-table link field
+- 渲染必须 cycle-defensive
+
+### 3.1 文件清单
+
+| 文件 | 操作 | 关键点 |
+|---|---|---|
+| `apps/web/src/multitable/view-config.ts` | 改 | GanttViewConfig 增 `dependencyFieldId?: string \| null` |
+| `apps/web/src/multitable/components/MetaGanttView.vue` | 改 | 读 dependencyFieldId；遍历前置任务时带 visited set；最大递归深度 1024 |
+| `apps/web/src/multitable/components/MetaGanttView/DependencyArrows.vue` | 新增 | SVG 箭头层；渲染算法 cycle-defensive |
+| `apps/web/src/multitable/components/MetaGanttView/GanttConfigDrawer.vue` | 改 | dependencyFieldId 选项仅列 self-table link field |
+| `packages/core-backend/src/multitable/view-config-schema.ts` | 改 | Gantt config zod 增 dependencyFieldId 字段；save 时校验 self-table link |
+| `packages/core-backend/src/openapi/...` | 改 | view config schema 同步 |
+
+### 3.2 自测命令
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  apps/web/tests/multitable-gantt-dependency-arrows.spec.ts \
+  --watch=false
+
+pnpm --filter @metasheet/core-backend exec vitest run \
+  packages/core-backend/tests/unit/view-config-gantt-dep.test.ts \
+  --watch=false
+
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+git diff --check
+```
+
+### 3.3 测试用例必须覆盖
+
+- [ ] 配 dependencyFieldId → 持久化到 view config
+- [ ] 配置后渲染箭头：A 依赖 B → B 末端到 A 起点的箭头
+- [ ] missing dependency（指向已删除 record）→ console.warn + 不画箭头 + 不阻断渲染
+- [ ] self dependency（A 依赖 A）→ console.warn + 不画箭头
+- [ ] cycle (A→B→A) → console.warn + 渲染时 visited set 截断 + 不死循环
+- [ ] dependencyFieldId 配的是非 self-table link → save 时被 backend 拒绝
+- [ ] dependencyFieldId 未配 → 保持旧 Gantt 行为（无箭头层）
+
+### 3.4 验证 doc
+
+写：
+- `docs/development/multitable-gantt-dependency-arrows-development-verification-20260507.md`
+- 更新 `docs/development/multitable-feishu-rc-todo-20260430.md`
+
+---
+
+## 4. Phase 2B · Lane C Hierarchy drag-to-reparent（约 0.5-1 天，可与 Lane B 并行）
+
+**分支**: `feat/multitable-hierarchy-drag-reparent-20260507`（基于 Lane A 分支或 Lane A merge 后的 main）
+
+**核心约束**:
+- 拖拽 patch 复用现有 record patch path，不加 REST API
+- parent link field 必须 maxValues=1
+- render 层 cycle-defensive
+
+### 4.1 文件清单
+
+| 文件 | 操作 | 关键点 |
+|---|---|---|
+| `apps/web/src/multitable/components/MetaHierarchyView.vue` | 改 | 树渲染加 visited set + max depth 1024；拖拽事件挂载 |
+| `apps/web/src/multitable/components/MetaHierarchyView/HierarchyNode.vue` | 改 | draggable + dragover + drop 事件 |
+| `apps/web/src/multitable/components/MetaHierarchyView/HierarchyConfigDrawer.vue` | 改 | parent link field 仅列 maxValues=1 的 link field；多值 link 不可选 |
+| `apps/web/src/multitable/composables/useHierarchyDrag.ts` | 新增 | 客户端 self-parent / descendant-parent 阻断；patch 调用 |
+| `packages/core-backend/src/multitable/view-config-schema.ts` | 改 | Hierarchy config save 校验 parent link field 满足 maxValues=1 |
+
+### 4.2 自测命令
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  apps/web/tests/multitable-hierarchy-drag.spec.ts \
+  --watch=false
+
+pnpm --filter @metasheet/core-backend exec vitest run \
+  packages/core-backend/tests/unit/view-config-hierarchy-parent-link.test.ts \
+  --watch=false
+
+pnpm --filter @metasheet/web exec vue-tsc -b --noEmit
+git diff --check
+```
+
+### 4.3 测试用例必须覆盖
+
+- [ ] 拖 child 到另一 node → 发出 patch 把 parent link field 设为 [targetRecordId]
+- [ ] 拖 child 到 root 区域 → 发出 patch 清空 parent link field
+- [ ] 拖 self 到 self → drop 被阻断，不发 patch
+- [ ] 拖 ancestor 到 descendant → drop 被阻断
+- [ ] 配置 parent link field 为多值 link → drawer 不允许选；强行配的 view 加载报错
+- [ ] 树数据中存在环 → 渲染 visited set 截断，不死循环
+- [ ] 原有 select / comment / create child 行为不回归
+
+### 4.4 验证 doc
+
+写：
+- `docs/development/multitable-hierarchy-drag-reparent-development-verification-20260507.md`
+- 更新 `docs/development/multitable-feishu-rc-todo-20260430.md`
+
+---
+
+## 5. 全局验收清单
+
+三 lane 全部完成后：
+
+- [ ] 三个 PR 全部 CI 绿
+- [ ] 各 PR vue-tsc / vitest / openapi gate 通过
+- [ ] 三份 verification MD 已写
+- [ ] `multitable-feishu-rc-todo-20260430.md` 三条对应行已勾完
+- [ ] Codex 二次 review 通过
+- [ ] 合并顺序严格 A → B → C
+- [ ] B / C 在 A merge 后 rebase 到 main，重跑 CI
+
+---
+
+## 6. 重要操作纪律（避免历史踩过的坑）
+
+- **绝对禁止 `git add -A` 或 `git add .`** —— 必有 50+ 未追踪 verification doc，会误纳无关战线
+- **绝对禁止 `git commit --no-verify`** —— 触发 hook 失败必须根因修复
+- **每 lane 单独 worktree** —— 不允许在同一 worktree 切来切去，避免 stash 污染
+- **migration 落地前先对齐 staging** —— 参见 `docs/operations/staging-migration-alignment-runbook.md`
+- **PR 描述必须含 K3 PoC Lock 适用性段落** —— Codex review 第一关
+- **每条 PR 自带 verification MD** —— 项目惯例，无 doc 不 merge
+- **不创建 plan/decision MD 除非 user 要求** —— 本文 + 讨论文档已是唯一两份
+
+---
+
+## 7. Claude 启动信号
+
+收到用户以下任一指令即视为开工：
+
+- "开始 Phase 0"
+- "开始清场"
+- "起 Lane A"
+- "执行计划开始"
+
+收到信号前，仅就 §5 八问做澄清问答，不动代码。

--- a/docs/development/multitable-feishu-three-lane-plan-discussion-20260507.md
+++ b/docs/development/multitable-feishu-three-lane-plan-discussion-20260507.md
@@ -1,0 +1,260 @@
+# 多维表 Feishu 深水区 · 三线并行计划讨论
+
+> Date: 2026-05-07
+> Status: 讨论中（pre-execution review）
+> Scope: Lane A autoNumber / Lane B Gantt deps / Lane C Hierarchy drag-to-reparent
+> 上游计划: 用户提交的"Claude 三线并行开发计划：多维表 Feishu 深水区"
+
+## 0. 本文目的
+
+在动手前把以下 4 类问题摆桌面：
+
+1. **当前工作树状态**与三线开发的关系（必须先解决，否则 worktree 会污染）
+2. **K3 PoC Stage 1 Lock 适用性**（这批是不是被 lock 拦下的"新战线"？）
+3. **6 处技术风险**（Codex review 时大概率会问，先解决能省一轮）
+4. **执行节奏与并行度**（3 lane 同时开 vs 串行落地）
+
+最后给出建议执行顺序与待确认事项清单。
+
+---
+
+## 1. 当前工作树状态（必须先处理）
+
+**分支**: `codex/dingtalk-directory-return-banner-tests-20260505`，比 main 领先 1 commit (`67898d144`)
+
+**未提交改动 = 4 条独立战线，22 文件混合**
+
+| # | 战线 | LOC | 完成度 | 推荐处理 |
+|---|---|---|---|---|
+| 1 | Directory return banner / governance（匹配分支名） | +2381 | 看 doc 已写好 verification | 留当前分支，整理后开 PR |
+| 2 | **Group failure alert → rule creator**（0507 头条） | +1763 | **final-handoff 已写、4 套 vitest 全绿、build 全过、probe 测试 4/4 过、scoped diff clean、secret scan 干净** | **先切 worktree commit + push 落袋，最快可发** |
+| 3 | Group destination verify-before-save / validity-test history | +304 | 昨日已写 verification | 切 worktree 收尾 |
+| 4 | API token manager | +312 | 局部改动 | 切 worktree 收尾 |
+
+**额外**: 50+ 未追踪 verification doc（dingtalk 系列 0505-0507）+ 2 份新 ops 脚本 + staging-deploy SOP/migration runbook + postmortem。需归位到对应 PR。
+
+**结论**: 三线开发开始前，根目录必须冻结。否则 worktree 内任何 `git status`、CI、build 都会被这 4 条战线污染。最低成本路径是先把战线 #2（最完整）切出去 commit。
+
+---
+
+## 2. K3 PoC Stage 1 Lock 适用性
+
+Lock 原文（来自 memory 文件 `project_k3_poc_stage1_lock.md`）：
+
+- ❌ Touches `plugins/plugin-integration-core/*` → blocked
+- ❌ New 平台-化 work → blocked
+- ✅ 已发布功能的 follow-up → permitted
+- ✅ Pure operational hygiene / Ops/observability 打磨 on shipped features → permitted
+
+**本批三条 lane 评估**：
+
+| Lane | 是否触 integration-core | 是否新建平台能力 | 是否已发布功能延伸 | 判定 |
+|---|---|---|---|---|
+| A autoNumber 字段类型 | 否 | **是 —— 新增字段类型枚举** | 多维表 M0-M5 已发布，是 parity 深化 | 边界情况：新增 field type 严格说是平台能力扩展。**PR 描述需明确"已发布多维表的 parity 深化，非新平台能力"** |
+| B Gantt dependency arrows | 否 | 否（仅 view config 扩展） | 已有 Gantt view，加新配置项 | 通过 |
+| C Hierarchy drag-to-reparent | 否 | 否（复用现有 patch path） | 已有 Hierarchy view，加交互 | 通过 |
+
+**结论**: A 介于"新建平台能力"和"已发布功能延伸"之间。建议在 PR 描述模板里写：
+
+```
+本 PR 属于多维表 M5 后 Feishu RC parity 深化（参见 docs/development/multitable-feishu-rc-todo-20260430.md）。
+不触发 K3 PoC Stage 1 Lock，因为：
+1. 不修改 plugins/plugin-integration-core/* 任何文件
+2. 多维表内核已在 Wave 系列发布，本 PR 是字段类型扩展而非新平台
+3. 不引入对接外部 ERP 的代码路径
+```
+
+否则 Codex review 时 lock 检查可能直接打回。
+
+---
+
+## 3. 6 处技术风险（按风险等级排序）
+
+### 🔴 高 · A1. autoNumber 回填窗口期的并发写入
+
+**计划原文**: "创建 autoNumber 字段时，对已有 records 按 created_at, id 回填 1..N，并把 next_value 设为 N + 1"
+
+**问题**: 回填执行期间，若有用户在同一 sheet insert record，会出现以下任一坏情况：
+
+- 新 record 走 `next_value` 路径分号，回填段也用 `next_value` → 号段冲突或重复
+- 新 record 在回填窗口被忽略 → 漏号
+- 回填读快照外的 record 被忽略 → 漏号
+
+**建议方案**:
+
+`CREATE FIELD autoNumber` 整个动作包在单 transaction，且第一步即取 advisory lock：
+
+```sql
+BEGIN;
+SELECT pg_advisory_xact_lock(hashtext('meta_sheet_writes:' || :sheet_id::text));
+-- 1) 物化新字段 schema
+-- 2) 按 (created_at, id) 回填 records
+-- 3) INSERT meta_field_sequences (...) VALUES (..., :next_value := N+1)
+COMMIT;
+```
+
+advisory lock key 必须和"普通 record insert"路径共用同一 key，让 record 写入在回填期间也阻塞。
+
+**待确认**: 当前 record insert 是否已有 sheet 级 advisory lock？若无，本 PR 需同时引入。
+
+### 🔴 高 · A2. xlsx import / 批量 insert 性能
+
+**计划原文**: "新建 record 时在同一 DB transaction 内 FOR UPDATE 锁 sequence 行并分配编号"
+
+**问题**: FOR UPDATE 是单行语义。xlsx import 一次 10k 行 → 10k 次 round-trip + 10k 次锁竞争。当前 import 路径若能容忍此性能，未来其他批量场景未必。
+
+**建议方案**:
+
+batch 路径单独走号段领取：
+
+```sql
+UPDATE meta_field_sequences
+SET next_value = next_value + :batch_size,
+    updated_at = NOW()
+WHERE sheet_id = :sheet_id AND field_id = :field_id
+RETURNING next_value - :batch_size AS start_value;
+```
+
+backend 在内存中给批次内每行赋号 `start_value, start_value+1, ..., start_value+batch_size-1`。
+
+**待确认**: import 路径走 vitest 还是真表？10k 行端到端时间预算是多少？
+
+### 🟡 中 · A3. Schema 缺 tenant_id
+
+**计划原文**: `meta_field_sequences(sheet_id, field_id, next_value, created_at, updated_at)`
+
+**问题**: metasheet2 多维表惯例是所有表 tenant_id 字段化。sheet_id 能间接 JOIN 出 tenant，但跨租户审计、按租户分区、未来 RLS 都需要直接列。
+
+**建议**:
+
+```sql
+CREATE TABLE meta_field_sequences (
+  id BIGSERIAL PRIMARY KEY,
+  tenant_id UUID NOT NULL REFERENCES tenants(id),
+  sheet_id UUID NOT NULL,
+  field_id UUID NOT NULL,
+  next_value BIGINT NOT NULL DEFAULT 1,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (tenant_id, sheet_id, field_id)
+);
+CREATE INDEX idx_meta_field_sequences_sheet ON meta_field_sequences (sheet_id, field_id);
+```
+
+注意 staging migration 已落后 prod 66 entries（参见 `project_staging_migration_alignment.md`）—— 本迁移落地前需对齐 staging。
+
+### 🟡 中 · B1. dependencyFieldId 必须限制为 self-table link
+
+**计划原文**: "只接受 link field"
+
+**问题**: 多维表的 link field 可指向当前 sheet 也可指向其他 sheet。predecessor 依赖只对 self-table 有意义。如果允许跨表 link，箭头要么画不出来，要么把跨表 record 当成本表 record，逻辑错乱。
+
+**建议**: dependencyFieldId 校验链上加 self-table 限定：
+
+- 前端 view config drawer：仅列出 `linkConfig.targetSheetId === currentSheetId` 的 link field
+- 后端 OpenAPI schema：增加 `x-linkTarget: self` 标注（若现有约定支持）；否则在 view config save 校验里拒绝
+- 文档明确"跨表依赖不在本 RC scope"
+
+### 🟡 中 · B2 + C2. 渲染层必须对环免疫
+
+**计划原文**: 仅做 client-side warning
+
+**问题**: 即使前端加 warning，环仍可能从其他写路径混入：
+
+- 老数据
+- xlsx import
+- 直接 API 调用
+- 多用户并发编辑下的 race window
+
+Gantt 箭头渲染若递归遍历依赖图，无 visited set 会栈溢出 / 死循环。Hierarchy 树同理。
+
+**建议**: 不论 server 是否阻止，**render 层必须自带 cycle guard**：
+
+```ts
+function renderTree(root: NodeId, visited = new Set<NodeId>()): TreeNode | null {
+  if (visited.has(root)) return null; // cycle, truncate
+  visited.add(root);
+  const children = getChildren(root)
+    .map(c => renderTree(c, visited))
+    .filter(isNonNull);
+  return { id: root, children };
+}
+```
+
+最大递归深度兜底（如 max 1024）也加上。
+
+### 🟠 中高 · C1. parent link field 必须 max=1
+
+**计划原文**: "拖到节点：patch parent link field 为 [targetRecordId]"
+
+**问题**: 如果 parent link field 配置为多值 link，patch 成单值数组会**抹掉用户已设的其他 parent**。这是 silent destructive。
+
+**建议**: Hierarchy view 配置 drawer 强约束 parent link field 必须 `linkConfig.maxValues === 1`：
+
+- 多值 link field 不出现在 parent field 选项里
+- 已配的 view 若 link field 后来被改成多值，view 加载时报错并要求重选
+- 拖拽功能开关本身依赖 parent field 满足约束
+
+否则用户配错的代价是丢数据，不可接受。
+
+---
+
+## 4. 执行节奏建议
+
+### 阶段 0（先做）· 工作树清场
+
+1. 战线 #2（group-failure-alert）→ 切 worktree → commit + push 出独立 PR（30 min）
+2. 战线 #1（directory return banner）→ 留当前分支，整理 verification doc → 推 PR
+3. 战线 #3 (group destination) + #4 (api tokens) → 各自 worktree commit + PR
+4. 50+ 未追踪 verification doc → 按战线归位，避免 cross-PR 引用
+
+阶段 0 完成后，根目录工作树**完全干净**，再开三 lane。
+
+### 阶段 1 · Lane A（autoNumber）独立推进
+
+理由：A 改 OpenAPI / types / 新 migration，是冲突源头。先合让 B/C rebase 成本最小。
+
+执行节奏：
+- 起 worktree `feat/multitable-auto-number-field-20260507`
+- backend schema + migration → backend 字段类型枚举 → OpenAPI 生成物 → 前端 Field Manager + renderer → 测试
+- 每个原子改动都跑 backend vitest + 前端 vitest + vue-tsc + diff --check
+- PR 描述必须包含"K3 PoC Stage 1 Lock 适用性说明"段落（见 §2）
+- 等 Lane A PR **CI 全绿且进入 review 状态**再开 Lane B/C
+
+### 阶段 2 · Lane B + C 并行
+
+A 进入 review 后，B/C 可以并行起 worktree（彼此不冲突），但 rebase 基线必须是 Lane A 分支或 A merge 后的 main。
+
+### 阶段 3 · 收尾
+
+每条 lane 落地后：
+- 更新 `docs/development/multitable-feishu-rc-todo-20260430.md`
+- 写 `*-development-verification-20260507.md`
+- Codex 二次 review
+
+---
+
+## 5. 待用户确认清单
+
+执行前必须收到的明确答复：
+
+1. **K3 PoC lock 适用性**：用户是否同意 §2 给出的 PR 描述模板？还是觉得 Lane A 应推迟到 K3 PoC GATE PASS 之后？
+2. **A1 advisory lock**：当前 record insert 路径是否已有 sheet 级 advisory lock？若没有，本 PR 是否可以引入？
+3. **A2 batch import 策略**：选号段领取（推荐）还是逐行 FOR UPDATE？后者性能差但实现简单。
+4. **A3 staging migration alignment**：本 migration 落地前是否需要先把 staging 66 entries 对齐？还是可在本 lane 内顺手对齐？
+5. **B1 跨表 link**：是否同意"跨表依赖不在本 RC scope"？
+6. **C1 parent link 单值约束**：是否同意作为 Hierarchy view 配置硬约束？
+7. **工作树清场**：阶段 0 由我执行还是用户自己处理？50+ untracked doc 是否都保留？
+8. **节奏**：阶段 1（A）→ 阶段 2（B+C 并行）的串行/并行策略是否接受？还是要 A/B/C 全并行？
+
+---
+
+## 6. 我的结论
+
+**计划方向 + 拆 PR + clean worktree 三大原则我都同意。** 但 6 处技术风险中至少 A1 / A2 / A3 / C1 必须在动手前明确处理方式 —— 这是结构性决策，落到代码后改成本远高于现在改方案。
+
+**最小动作建议**：
+
+- 立刻可做：阶段 0 工作树清场（先把战线 #2 切出去）
+- 等用户确认：§5 八问，逐条回答后再起 Lane A worktree
+- 不建议立刻三 lane 并行：A 改的 types/OpenAPI 是真冲突源，先让 A 跑出 PR 形态再开 B/C

--- a/docs/development/operations-docs-delivery-20260426.md
+++ b/docs/development/operations-docs-delivery-20260426.md
@@ -1,0 +1,211 @@
+# Operations Docs Delivery — Staging Deploy SOP + Migration Alignment Runbook + migrate.ts Flag Fix — 2026-04-26
+
+## Scope
+
+Three deliverables capturing lessons from the 2026-04-26 staging deploy
+incident (d88ad587b broke auth on staging, rolled back; full diagnosis
+in `staging-deploy-d88ad587b-postmortem-20260426.md`):
+
+1. **PR [#1190](https://github.com/zensgit/metasheet2/pull/1190)** —
+   `migrate.ts` flag handling: implements `--list`/`--rollback`/`--reset`
+   that the package.json scripts already named but the script ignored.
+   Single-file change, +83/-6 lines.
+2. **`docs/operations/staging-deploy-sop.md`** — 12-step manual
+   image-pull deploy checklist. Mandatory: migration-pending diff
+   pre-deploy, log scan post-deploy, authenticated round-trip
+   verification (not just `/api/health`).
+3. **`docs/operations/staging-migration-alignment-runbook.md`** —
+   recovery procedure for the case where target env's
+   `kysely_migration` table is out of sync with actual schema state.
+   Includes pg_dump-first discipline, synthetic-catch-up vs
+   full-restore decision tree, failure modes.
+
+Plus memory updates so future sessions have the operational context.
+
+## Why these three
+
+Independent slices of the same lesson:
+
+- **#1190 (the tool)**: makes pre-deploy migration diff actually
+  observable. Without `--list`, the only way to "see what's pending"
+  was to run `migrate.js` and watch what happened — destructive
+  observation. With `--list`, anyone can preview safely.
+- **`staging-deploy-sop.md` (the procedure)**: codifies how to use
+  `--list` (and the rest) in the deploy flow. References #1190.
+- **`staging-migration-alignment-runbook.md` (the recovery)**: handles
+  the case where the SOP's pre-flight check reveals tracking-state
+  divergence. References both #1190 and the SOP, plus the
+  post-mortem.
+
+The three reinforce each other but were independently writable —
+which made parallel-development sense for this slice.
+
+## Design notes
+
+### staging-deploy-sop.md
+
+**Audience**: human operator running a manual `docker-compose pull && up -d`
+deploy on a shared host (e.g. 142.171.239.56). NOT for the bootstrap
+script `scripts/deploy-ghcr.sh` — that one auto-migrates and is
+covered by the existing `deploy-ghcr.md`.
+
+**Structure**:
+- §1-4 Pre-deploy (read-only checks)
+- §5-8 Deploy itself (migrations FIRST, then image swap via
+  workaround B for docker-compose v1 ContainerConfig bug)
+- §9-12 Post-deploy verification (60-second window)
+- §"Rollback" section (uses workaround B again, with cached previous
+  image)
+- §"What this SOP does NOT cover" (boundaries)
+- §"Quick checklist" (printable 12-item version for ops shift handoff)
+
+**Key decisions**:
+- Made migration application a **mandatory step that blocks** image
+  swap (§5). The 2026-04-26 failure mode was deploying new image
+  before migrations; codifying the order prevents recurrence.
+- Required **authenticated 200** post-deploy verification (§10),
+  explicitly calling out that `/api/health` alone is insufficient.
+- Added the **plugin-count sanity check** (§12) since the 13 vs 14
+  count drop on d88ad587b was a real signal we initially dismissed
+  as cosmetic — it was actually a downstream effect of broken auth.
+- `--no-deps` requirement on the `up -d` command, with explanation —
+  docker-compose v1.29.2's reconciler silently touches postgres/redis
+  without it.
+
+### staging-migration-alignment-runbook.md
+
+**Audience**: human operator with SSH + sudo access who has been told
+"the deploy SOP §5 failed with `column scope does not exist`" or
+similar.
+
+**Structure**:
+- §Pre-flight (pg_dump is non-negotiable)
+- §Option A: Synthetic catch-up (recommended for the 2026-04-26
+  pattern — drift in tracking, schema is fine)
+- §Option B: Full restore from prod-track (recommended if drift
+  audit reveals real schema gaps)
+- §Post-alignment verification
+- §Failure modes & recovery (with the "I changed something I
+  shouldn't have" branch documented as a first-class case)
+- §"What this runbook does NOT cover" (rollback of applied schema
+  changes — that's an incident plan, not routine alignment)
+
+**Key decisions**:
+- pg_dump-first as **the** non-negotiable step. Everything else in the
+  runbook assumes the dump exists. Not having one means stop.
+- Two distinct alignment options with explicit "pick exactly one, do
+  not mix" — different problems, different solutions. The choice
+  hinges on the §A.3 audit (does the schema actually match what the
+  missing migrations would have produced).
+- Audit step (§A.3) is the load-bearing decision point. Most of the
+  runbook's risk lives in this step's correctness; the runbook calls
+  it out as such.
+- Failure-mode recovery includes restore-from-dump as an explicit
+  branch — important because under pressure during alignment, "what
+  if I screwed up?" is exactly the question that needs a pre-written
+  answer.
+
+### migrate.ts (PR #1190)
+
+**Design**:
+- Split into command functions (`commandLatest`, `commandList`,
+  `commandRollback`, `commandReset`). Each handles its own
+  `db.destroy()`. Original 43-line script grew to 119 lines but most
+  of the growth is the four command paths + help text.
+- `--reset` guarded behind `ALLOW_DB_RESET=true` env var. Without
+  the guard, `pnpm db:reset` would be a one-keystroke destructor; the
+  env var forces explicit acknowledgment.
+- Default behavior (no flag) is byte-identical to the original
+  `migrateToLatest()` semantics. No call sites need to change.
+- Help text references both the read-only `--list` and the destructive
+  `--reset`/`--rollback` paths, so an operator running
+  `pnpm migrate --help` sees the safe options first.
+
+## Verification
+
+### PR #1190 (migrate.ts)
+
+| Check | Method | Result |
+|---|---|---|
+| `--help` prints usage, exits 0 | `pnpm exec tsx src/db/migrate.ts --help; echo $?` | ✅ exit 0, full usage shown |
+| `--reset` without env var refuses | `pnpm exec tsx src/db/migrate.ts --reset > log; echo $?; cat log` | ✅ exit 1, refusal message correct |
+| `tsc --noEmit -p tsconfig.json` clean | full project typecheck | ✅ exit 0, 0 errors |
+| Default (no flag) preserves behavior | code review of `commandLatest()` against original `migrateToLatest()` | ✅ same provider config, same error/results handling, same `db.destroy()` |
+| `--list` runtime behavior | required dev DB; deferred to PR reviewer / next person to spin up local pg | ⚠️ not exercised locally (acknowledged in PR test plan) |
+| `--rollback` runtime | same as above | ⚠️ same |
+| `--reset` runtime with env | same as above | ⚠️ same |
+
+The runtime behaviors of `--list`/`--rollback`/`--reset` are gated on
+having a working dev DB — exercising them via the actual kysely
+`Migrator` API. The gate is documented in the PR's test plan; CI's
+existing build/typecheck steps cover the static side.
+
+### staging-deploy-sop.md
+
+| Check | Method | Result |
+|---|---|---|
+| Internal cross-references resolve | manual review of §-references | ✅ §1-12 numbering consistent |
+| External cross-references resolve | grep for `[…](path)` patterns and check files exist | ✅ `deploy-ghcr.md`, `staging-migration-alignment-runbook.md`, `staging-deploy-d88ad587b-postmortem-20260426.md` all real |
+| Covers all 12 lessons from post-mortem | side-by-side check against `staging-deploy-d88ad587b-postmortem-20260426.md` §"Lessons captured" | ✅ all 5 captured lessons → SOP steps |
+| Quick checklist matches body | re-derive checklist from §-headings | ✅ items 1-13 cover §1-12 plus rollback decision |
+| No prescriptive command that's untested | review every code block | ✅ all commands are either standard docker/curl OR explicitly noted as requiring substitution |
+
+### staging-migration-alignment-runbook.md
+
+| Check | Method | Result |
+|---|---|---|
+| pg_dump precondition is enforced | first sub-section under §Pre-flight, with "non-negotiable" explicit wording | ✅ §"pg_dump first" |
+| Two alignment options are clearly disjoint | re-read §A vs §B; check "pick exactly one" call-out | ✅ §"Pick exactly one. Do not mix." in §"Alignment options" intro |
+| Failure-mode recovery exists for each option | §"Failure modes & recovery" enumerates 3 modes | ✅ "duplicate key", "column already exists mid-migrate", "I changed something" |
+| Restore path mentioned in every error branch | grep for `pg_restore` in failure section | ✅ explicit dump-restore in the catch-all branch |
+| References the post-mortem and PR #1190 | §Provenance, §"What this runbook does NOT cover" | ✅ both linked |
+| Numbers in commentary match the 2026-04-26 audit | re-check 86/152/66 numbers against post-mortem | ✅ matches |
+
+### Memory cross-links
+
+| Memory entry | Updated section | Result |
+|---|---|---|
+| `feedback_deploy_migration_check.md` | added "Operational doc" line pointing to `staging-deploy-sop.md` | ✅ |
+| `project_staging_migration_alignment.md` | replaced "Related docs" list with the 4 new + existing references | ✅ |
+| `MEMORY.md` index | unchanged (entries still under same titles, no new memory files) | ✅ |
+
+## State at end of session
+
+| Surface | State |
+|---|---|
+| PR #1190 | open, `BLOCKED/MERGEABLE`, awaiting human review |
+| `docs/operations/staging-deploy-sop.md` | created, untracked locally, ready to commit |
+| `docs/operations/staging-migration-alignment-runbook.md` | created, untracked locally, ready to commit |
+| `docs/development/operations-docs-delivery-20260426.md` (this file) | created, untracked locally |
+| `docs/development/staging-deploy-d88ad587b-20260426.md` | modified earlier this session (CORRECTION banner), still untracked from session-prior baseline |
+| `docs/development/staging-deploy-d88ad587b-postmortem-20260426.md` | created earlier this session (rollback record), still untracked |
+| Memory: `feedback_deploy_migration_check.md` | updated with cross-link |
+| Memory: `project_staging_migration_alignment.md` | updated with cross-link |
+| Local working tree: `migrate.ts` | reverted to HEAD state (change is on PR branch only) |
+
+## Recommended next steps
+
+1. **Wait for PR #1190 review** — once merged, references to it in
+   the SOP doc (e.g. `--list` recommendation in §5) become live.
+2. **Decide whether to bundle the docs into a PR** — they're untracked
+   right now. Two options:
+   - Open a separate `docs/` PR with the 4 new MDs (+ the modified
+     `staging-deploy-d88ad587b-20260426.md` correction banner). Same
+     pattern as #1181 (Wave M-Feishu-1 doc archive).
+   - Wait for next "session docs archive" PR to bundle everything.
+3. **Schedule the migration alignment maintenance window** — the
+   runbook is now ready for it. Pre-conditions: ~30-minute staging
+   downtime tolerance, prod-track stack reachable, operator with SSH +
+   sudo, fresh JWT for post-alignment verification.
+4. **Do NOT redeploy d88ad587b until alignment is done** — the
+   post-mortem MD already says this; the SOP makes it operational.
+
+## Roadmap compliance
+
+- ✅ 阶段一 lock honored: pure 内核打磨 / operational hygiene
+- ✅ No new战线 — these are all defensive docs + a footgun fix
+- ✅ No `plugins/plugin-integration-core/*` touched
+- ✅ Default behaviors preserved (`pnpm migrate` unchanged, deploy
+  process unchanged for the prior known-good path)
+- ✅ All actions reversible (PR can be closed; docs are docs; memory
+  edits are forward-only but additive)

--- a/docs/development/staging-deploy-d88ad587b-20260426.md
+++ b/docs/development/staging-deploy-d88ad587b-20260426.md
@@ -1,0 +1,159 @@
+# Staging Deploy — main@d88ad587b — 2026-04-26
+
+> **STATUS (2026-04-26 12:31 UTC): ROLLED BACK to `62a75f9809-itemresults`.**
+> The diagnosis below is **partially wrong** in two specific places (JWT_SECRET hypothesis,
+> plugin count drop). The actual root cause was a 66-migration schema gap on staging postgres,
+> not a JWT_SECRET rotation. See the corrected diagnosis and rollback record in:
+> [`staging-deploy-d88ad587b-postmortem-20260426.md`](./staging-deploy-d88ad587b-postmortem-20260426.md)
+>
+> **Wave 8 / 9 / M-Feishu-1 routes are NOT live on staging right now.** The deploy is
+> deferred until a planned migration-alignment maintenance window aligns staging postgres
+> with prod-track's `kysely_migration` state.
+>
+> The body below is preserved for forensic value (the docker-compose v1.29.2 bug analysis
+> and workaround B are accurate and reusable).
+
+## Outcome
+
+**Deploy succeeded** on third attempt (workaround required for `docker-compose v1.29.2 + Docker daemon` ContainerConfig bug). Backend + web were running on `ghcr.io/zensgit/metasheet2-{backend,web}:d88ad587b2c17402f861e1cf712f9de8e0148a0a`. Postgres + redis untouched. Wave 8/9/M-Feishu-1 backend routes were mounted on staging — **but functionally inaccessible** due to schema mismatch.
+
+**Three followups** surfaced post-deploy (corrected interpretation in postmortem):
+
+1. ~~Pre-existing staging admin JWT is **invalidated**~~ → **Wrong.** Token signature verifies fine. The 401s came from `AuthService.getUserById` failing on `column "username" does not exist` — a schema gap (migration `zzzz20260418170000_*` not applied to staging).
+2. ~~**Plugin count 14 → 13**~~ → **Probably also a schema-gap artifact.** Post-rollback probe shows plugins:14. The 13 count likely came from one plugin that hit a similar DB query during health check.
+3. UI manual smoke (Wave M-Feishu-1 checklist `wave-m-feishu-1-staging-verification-checklist-20260426.md`) deferred — blocked until d88ad587b can be redeployed against an aligned staging DB.
+
+## Deploy attempts
+
+### Attempt 1 — wrong image tag format (rolled back)
+
+Set `.env IMAGE_TAG=21493058e → IMAGE_TAG=d88ad587b` (9-char prefix), pulled.
+
+```text
+Pulling backend ... error
+ERROR: for backend  manifest unknown
+```
+
+Cause: GHCR uses **40-char full SHA** as image tags. `d88ad587b` did not exist. Auto-rolled-back `.env`.
+
+### Attempt 2 — full SHA pull succeeded, up failed (containers stopped, recovered)
+
+`IMAGE_TAG=d88ad587b2c17402f861e1cf712f9de8e0148a0a`. Pull ✅. `docker-compose up -d backend web` ❌:
+
+```text
+File "/usr/lib/python3/dist-packages/compose/service.py", line 1579, in get_container_data_volumes
+    container.image_config['ContainerConfig'].get('Volumes') or {}
+KeyError: 'ContainerConfig'
+```
+
+**Known docker-compose v1.29.2 bug** with newer Docker Engine (27+ removes the `ContainerConfig` field that v1 relied on for volume migration).
+
+**Side effect — boundary violation**: even though `up -d backend web` listed only those services, docker-compose v1's reconciler also touched `postgres` and `redis`, leaving them in `Exit 0` state with hash-prefixed renames (`6a3b8dcc2a37_metasheet-staging-postgres` etc.). User authorization was "**不动 postgres / redis**" — this was unintended impact.
+
+**Recovery executed immediately**: `docker start` on the renamed-and-stopped postgres + redis containers. Both came back healthy within seconds. `/api/multitable/bases` 200 with `{ok, data}` confirmed DB connectivity restored. Total disruption: ~2 minutes for backend (which restarted as a side effect).
+
+### Attempt 3 — workaround B succeeded
+
+Per user authorization, executed `stop + rm -f + up -d --no-deps`:
+
+```bash
+docker-compose -f docker-compose.app.staging.yml stop backend web
+docker-compose -f docker-compose.app.staging.yml rm -f backend web   # NOT -v, volumes preserved
+docker-compose -f docker-compose.app.staging.yml up -d --no-deps backend web
+```
+
+**Why this avoids the bug**: `stop + rm` removes the OLD container before `up`, so compose has no existing container to migrate volumes from. The `get_container_data_volumes` code path (which crashes on `ContainerConfig`) is skipped entirely. `--no-deps` ensures only `backend` and `web` are touched (no reconciliation of postgres/redis).
+
+Verified containers swapped to new image:
+
+```text
+metasheet-staging-web|ghcr.io/zensgit/metasheet2-web:d88ad587b2c17402f861e1cf712f9de8e0148a0a|Up 25s
+metasheet-staging-backend|ghcr.io/zensgit/metasheet2-backend:d88ad587b2c17402f861e1cf712f9de8e0148a0a|Up 26s
+6a3b8dcc2a37_metasheet-staging-postgres|cd848ee12e8e|Up 2 hours (healthy)
+dd50c7844281_metasheet-staging-redis|aa189b5a1954|Up 2 hours (healthy)
+```
+
+## Post-deploy verification
+
+| Probe | Expected | Got |
+|-------|----------|-----|
+| `/api/health` | 200, dbPool > 0 | ✅ 200, `dbPool:{total:1, idle:1, waiting:0}`, plugins:13 |
+| Frontend `HEAD /` | 200 | ✅ HTTP/1.1 200 OK |
+| **Wave 8 NEW route** `/api/approvals/metrics/summary` | **200** (was 404 pre-deploy) | ⚠️ **401 Invalid token** — route mounted ✓ but JWT verification fails |
+| `/api/approvals/metrics/breaches` | 200 | ⚠️ **401** same as above |
+| `/api/multitable/bases` | 200 | ⚠️ **401** same — was 200 on pre-deploy backend with same token |
+| `/api/auth/me` | 200 | ⚠️ **401** same |
+| `/api/plugins` (public) | 200 | ✅ 200, 13 plugins |
+| Local `node --test scripts/ops/integration-k3wise-live-poc-{evidence,preflight}.test.mjs` | 44/44 pass | ✅ 44/44 (run on local main, not staging — these scripts are CI-style) |
+
+### Why Wave 8 routes returning 401 (not 404) is the **key positive signal**
+
+Pre-deploy: `/api/approvals/metrics/summary` returned **404 "Cannot GET"** — Express default for unmounted route. Definitively NOT in the running code.
+
+Post-deploy: same path returns **401 with `code:UNAUTHORIZED`** — JSON body indicates the route IS mounted, the auth middleware ran, the JWT verification rejected. This is **proof Wave 8 SLA observability code is live on staging**.
+
+### JWT_SECRET appears to have changed
+
+Pre-deploy state probed at 06:something UTC: `staging admin token` → `/api/auth/me` 200, `/api/multitable/bases` 200.
+
+Post-deploy state probed at 08:44 UTC, **same token file** unchanged on disk: `/api/auth/me` 401 "Invalid token". Same shape on `/api/multitable/bases`, `/api/approvals/metrics/summary`.
+
+Hypothesis: the new backend image reads `JWT_SECRET` differently (e.g., new code generates ephemeral secret if env var unset, or reads from a different config source). Whatever the cause, the existing 72h staging JWT no longer verifies.
+
+**Mitigation**: re-issue staging admin JWT using `scripts/gen-staging-token.js` against the new backend (whichever JWT_SECRET it now uses).
+
+## Plugin count change (14 → 13)
+
+Pre-deploy probe showed 14 active plugins (full list not captured). Post-deploy shows 13:
+
+```
+✅ active (12):
+  example-plugin, hello-world, plugin-after-sales, plugin-attendance,
+  plugin-audit-logger, plugin-integration-core, plugin-intelligent-restore,
+  plugin-test-a, plugin-test-b, plugin-view-gantt, plugin-view-kanban,
+  sample-basic
+🟡 inactive (1):
+  plugin-telemetry-otel
+```
+
+Two changes:
+- `plugin-telemetry-otel` moved active → inactive. Likely missing `OTEL_EXPORTER_*` env vars on new container; not a code regression. Low priority.
+- One plugin is genuinely **gone** from the list (cannot pinpoint without pre-deploy full list). May be a deliberate exclusion in the new build, or a renamed plugin. Worth a quick check: compare `plugins/` directory between `62a75f9809-itemresults` and `d88ad587b2c17402f861e1cf712f9de8e0148a0a` build manifests.
+
+Names also lost the `@metasheet/` scope prefix in display (cosmetic — same plugin loader, different label format).
+
+## State at end of session
+
+| Surface | State |
+|---------|-------|
+| Backend container | Up, image `d88ad587b2c17402f861e1cf712f9de8e0148a0a` |
+| Web container | Up, image `d88ad587b2c17402f861e1cf712f9de8e0148a0a` |
+| Postgres | Up 2h healthy, image cd848ee12e8e (untouched) |
+| Redis | Up 2h healthy, image aa189b5a1954 (untouched) |
+| `/home/mainuser/...staging/.env IMAGE_TAG` | `d88ad587b2c17402f861e1cf712f9de8e0148a0a` (changed) |
+| `.env` backup files | `.env.bak.before-d88ad587b-20260426` and `.env.bak.before-d88ad587b-20260426` (rollback path preserved) |
+| Wave 8 / 9 / M-Feishu-1 routes | Mounted (verified by 401 not 404 transition) |
+| Existing staging admin JWT | Invalidated by new backend |
+| UI manual smoke (Wave M-Feishu-1 checklist) | Not started — needs new JWT + tester |
+
+## Next steps (user-driven)
+
+1. **Re-issue staging admin JWT**: run `scripts/gen-staging-token.js` (or equivalent) against the new backend container to issue a fresh 72h token signed with whatever the current JWT_SECRET is. Save under `/tmp/metasheet-142-staging-admin-72h.jwt`.
+2. **Authorize me to re-probe** with the new JWT to confirm `/api/approvals/metrics/summary`, MF1/MF2/MF3 backend paths, and other Wave-protected routes return 200 (not 401).
+3. **(Optional) Investigate plugin count drop**:
+   - Diff `plugins/` directory between the two image SHAs.
+   - Re-enable telemetry-otel by adding `OTEL_*` env vars if telemetry is wanted on staging.
+4. **Run UI manual smoke** per `wave-m-feishu-1-staging-verification-checklist-20260426.md` — this is the actual product validation that human eyes need.
+5. **Roadmap-stage decision (your step 5 from the deploy plan)**: if UI smoke passes, decide whether to launch next dev wave (阶段二 stage 2 lane plan in `stage2-vendor-abstraction-lanes-20260426.md` is dormant-and-ready).
+
+## Roadmap compliance
+
+✅ **No new战线 opened** during deploy — purely staging deployment of already-merged code.
+✅ **No `plugins/plugin-integration-core/*` source touched** — staging now runs the merged version (the K3 PoC tooling track is preserved).
+✅ **No platform-化 work** — staging is now on production-track main, not Stage 3 platform code.
+
+## Lessons captured
+
+- **`docker-compose v1.29.2 + Docker Engine 27+` is broken on `up -d` against existing containers**. Workaround: `stop + rm -f + up -d --no-deps <services>`. Real fix: upgrade to docker compose v2 (`docker compose` plugin), but out of scope for ad-hoc deploys.
+- **GHCR image tags here are 40-char full SHA**, not 7- or 9-char prefix. The `21493058e` value previously in `.env` was a stale 9-char prefix that had not actually been rolled out (the running tag `62a75f9809-itemresults` was a feature-build, not main).
+- **`docker-compose up -d <service>` does NOT reliably scope to that service in v1.29.2** — it can still silently `Exit 0` related services during reconciliation. Use explicit `--no-deps` and prefer `stop + rm + up` over plain `up` when isolating service updates.

--- a/docs/development/staging-deploy-d88ad587b-postmortem-20260426.md
+++ b/docs/development/staging-deploy-d88ad587b-postmortem-20260426.md
@@ -1,0 +1,401 @@
+# Staging Deploy d88ad587b — Post-Mortem & Migration Misalignment Diagnosis — 2026-04-26
+
+## TL;DR
+
+The original deploy MD's conclusion that "JWT_SECRET appears to have changed"
+is **wrong**. The actual root cause of post-deploy 401 responses is a
+**database schema mismatch**: the staging postgres is missing **66
+migrations** the new image (d88ad587b) requires. JWT signature verifies
+fine — the auth middleware then queries `users.username` (column added by
+migration `zzzz20260418170000_*` on 2026-04-18), which does not exist on
+staging postgres, and the query failure surfaces as `Invalid token`.
+
+Running `pnpm migrate` to fix it does **not** work because kysely tracks
+legacy numeric migrations (008-057, etc.) as un-applied and tries to
+RE-RUN them (they already created the schema via a different runner long
+ago). First migration kysely attempts hits `column "scope" does not
+exist` and aborts the entire run.
+
+Staging is currently in a broken-auth state on d88ad587b. The original
+deploy MD's "Wave 8 routes mounted (401 not 404)" finding is still
+correct — routes are live — but they're functionally inaccessible to any
+authenticated client.
+
+**Recommendation**: roll back to the previous image
+(`62a75f9809-itemresults`), schedule migration-alignment as a separate
+planned maintenance window. **Do not** attempt migrations under live
+deploy pressure with this state divergence.
+
+## What we learned (in order)
+
+### 1. The 401 is not a JWT problem
+
+Probed `/api/auth/me` with the supposedly-valid 8082 staging admin token:
+
+```
+{"ok":false,"error":{"code":"UNAUTHORIZED","message":"Invalid token"}}
+HTTP_CODE: 401
+```
+
+Decoded JWT payload — token is well within its 72h validity window.
+JWT_SECRET on the backend container env matches the one used to issue
+the token (verified via `printenv` inside the container; same prefix as
+prior deploy). So the signature verifies.
+
+The actual error surfaces in backend logs, repeatedly:
+
+```
+warn: Database query failed
+  context: AuthService
+  error: column "username" does not exist
+  stack: at AuthService.getUserById (.../AuthService.js:304:32)
+         at AuthService.verifyToken (.../AuthService.js:158:26)
+         at hydrateAuthenticatedUser (.../jwt-middleware.js:68:22)
+```
+
+Auth flow: `verifyToken` → `getUserById` runs
+`SELECT id, email, username, ... FROM users WHERE id = $1`. Column
+`username` doesn't exist on staging → query fails → middleware returns
+401. So the 401 is misleading: it's not auth rejection, it's a schema
+gap masquerading as auth rejection.
+
+### 2. Two stacks on the same host (initial confusion)
+
+`docker ps` shows:
+
+| Container | Image | Network |
+|-----------|-------|---------|
+| `metasheet-staging-backend` | `…d88ad587b…` | `metasheet2-dingtalk-staging_default` |
+| `metasheet-staging-web` | `…d88ad587b…` | `metasheet2-dingtalk-staging_default` |
+| `6a3b8dcc2a37_metasheet-staging-postgres` | postgres:15-alpine | `metasheet2-dingtalk-staging_default` |
+| `dd50c7844281_metasheet-staging-redis` | redis:7-alpine | `metasheet2-dingtalk-staging_default` |
+| `metasheet-backend` | `…1a341bbdc96…` (commit AFTER d88ad587b) | another network |
+| `metasheet-web` | `…1a341bbdc96…` | another network |
+| `metasheet-postgres` | postgres:15-alpine | another network |
+| `metasheet-redis` | redis:7-alpine | another network |
+
+The host runs **two parallel stacks**:
+
+- `metasheet-staging-*` — the staging stack we just deployed at d88ad587b
+- `metasheet-*` (no `-staging`) — appears to be a prod-track stack
+  running a newer commit `1a341bbdc966…` (3 days post d88ad587b)
+
+The two postgres containers are isolated (different networks). The
+staging backend resolves `postgres` to `6a3b8dcc2a37_metasheet-staging-postgres`
+(172.18.0.3 inside its network), NOT `metasheet-postgres`. My first
+schema probe accidentally hit `metasheet-postgres` (the wrong one) which
+**does** have the `username` column — leading to a brief moment of
+"the schema is fine, why is it failing?" confusion. The actual staging
+postgres is missing the column.
+
+The hash-prefix names on staging postgres+redis are leftover from the
+docker-compose v1 ContainerConfig bug recovery we did during the deploy
+(see original deploy MD attempt 2). They're functioning normally just
+under those renamed names.
+
+### 3. Migration tracking divergence
+
+Staging postgres `kysely_migration` table:
+
+- 86 entries
+- Earliest: `20250924105000_create_approval_tables`
+- Latest: `zzzz20260409154000_create_platform_member_groups_and_delegated_group_scopes`
+- **Nothing tracked from 2026-04-10 onwards**
+- **No legacy numeric migrations tracked** (008, 032-057, etc.)
+
+Prod-track postgres `kysely_migration` table:
+
+- 152 entries
+- Includes legacy numeric (008-057+) AND modern migrations through the
+  newer commit they're running
+
+Diff (in prod, NOT in staging) = 66 entries. Notable groups:
+
+- **Legacy numeric**: `008_plugin_infrastructure`, `032_create_approval_records`,
+  `033_create_rbac_core`, …, `057_create_integration_core_tables`,
+  `20250925_create_view_tables`, `20250926_create_audit_tables` (~28 entries)
+- **April 10+ modern migrations**: `zzzz20260410100000_create_plugin_automation_rule_registry`,
+  `zzzz20260411120000_create_user_namespace_admissions`,
+  `zzzz20260418170000_allow_no_email_users_and_add_username` (the one
+  that introduces the `username` column required by the new auth code),
+  …, `zzzz20260426100000_add_breach_notified_at` (~38 entries)
+
+### 4. Why naive migrate run can't fix it
+
+`packages/core-backend/src/db/migrate.ts` reads:
+
+```ts
+const migrator = new Migrator({
+  db,
+  allowUnorderedMigrations: true,
+  provider: createCoreBackendMigrationProvider({…}),
+})
+const { error, results } = await migrator.migrateToLatest()
+```
+
+The provider (`migration-provider.ts`) loads from MULTIPLE folders:
+
+- `dist/src/db/migrations/` (modern .ts → compiled .js)
+- `migrations/*.sql` (legacy SQL)
+- `_meta/` (excluded)
+
+So the provider sees **both** modern and legacy migrations. With
+`allowUnorderedMigrations: true`, kysely ignores name-ordering and runs
+anything not in `kysely_migration`. On staging, that's all 66 missing
+entries.
+
+When I attempted `node dist/src/db/migrate.js` inside the container:
+
+```
+failed to execute migration "008_plugin_infrastructure"
+failed to migrate
+error: column "scope" does not exist
+```
+
+`008_plugin_infrastructure.sql` is the legacy SQL that originally created
+plugin tables. The schema is already in place (via the legacy SQL runner
+that originally bootstrapped staging — pre-kysely tracking). Re-running
+the SQL file fails because the schema state differs from what the SQL
+expects to start from.
+
+**Critical observation**: the `migrate.ts` script ignores `process.argv`
+entirely. The package.json lists `db:migrate`, `db:list`, `db:reset`,
+`db:rollback` — but they all run the same `migrateToLatest()`. The
+`--list`, `--reset`, `--rollback` aliases are misleading; they don't
+behave any differently. (Worth fixing in a separate PR — the script
+should either implement those flags or remove them from package.json.)
+
+## How prod-track stack avoided this
+
+`metasheet-postgres` (prod-track) has all 152 entries including legacy
+numerics. Either:
+
+- The prod-track DB was bootstrapped at a later point with a runner that
+  tracked legacy migrations, OR
+- Someone manually inserted the legacy entries into kysely_migration at
+  some point to align the tracking with the actual schema, OR
+- A different deploy script with a "synthetic catch-up" step ran on
+  prod-track but not staging.
+
+Whichever it was, that knowledge was not encoded in the staging deploy
+SOP. The staging deploy MD plan assumed `docker compose pull && up -d`
+was sufficient; in reality, the codebase has had a hidden two-track
+migration pattern that needed manual reconciliation per environment.
+
+## Recommended recovery — option-by-option analysis
+
+### Option 1: Roll back to previous image (RECOMMENDED)
+
+```bash
+# on host
+sudo cp .env.bak.before-d88ad587b-20260426 .env  # restore IMAGE_TAG=21493058e
+sudo docker-compose -f docker-compose.app.staging.yml stop backend web
+sudo docker-compose -f docker-compose.app.staging.yml rm -f backend web
+sudo docker-compose -f docker-compose.app.staging.yml up -d --no-deps backend web
+```
+
+**What this does**: restores staging to the previous backend image
+(`62a75f9809-itemresults`, `IMAGE_TAG=21493058e`) which works with the
+current schema state.
+
+**What this preserves**: postgres + redis untouched. No data lost.
+Schema state unchanged. The only thing reverting is the backend + web
+container image.
+
+**What this defers**: Wave 8/9/M-Feishu-1 routes are not yet live on
+staging. UI smoke can't proceed against d88ad587b code. Migration
+alignment becomes a planned task.
+
+**Recovery time**: ~1 minute (uses the same workaround B that succeeded
+on the original deploy attempt 3).
+
+**Risk**: very low. The .env backup is intact, the previous image is
+still in the local docker cache (no need to re-pull).
+
+### Option 2: Surgical kysely_migration catch-up
+
+Copy the 66 missing entries from prod-track to staging's `kysely_migration`
+table (mark them as applied without running their up()), then run
+`pnpm migrate` to apply only the genuinely-not-yet-applied ones.
+
+**Mechanism**:
+
+```sql
+-- Inside staging postgres
+INSERT INTO kysely_migration (name, timestamp)
+SELECT name, timestamp FROM ...prod-track snapshot...
+WHERE name NOT IN (SELECT name FROM kysely_migration);
+```
+
+**Risk**: HIGH. Assumes staging's actual schema matches what the legacy
+migrations would have produced. If they don't match (e.g., if staging
+was bootstrapped with a slightly different SQL set, or a hand-applied
+fix introduced drift), later migrations will fail in unpredictable
+ways. Could leave staging in a half-migrated state that's worse than
+the current one.
+
+**Why this is risky for staging specifically**: staging has been a
+disposable env for a while; nobody has been auditing its schema state
+against the canonical migration list. The 66-entry gap suggests it's
+been drifting for weeks. Reconciling under live deploy pressure is the
+wrong place to discover a schema mismatch.
+
+**Mitigation if attempted**:
+- Take a postgres dump first
+- Run in a transaction with explicit rollback path
+- Verify after each migration
+
+### Option 3: Stay on d88ad587b in broken state
+
+Don't change anything. Document the issue. Wait for a planned maintenance
+window.
+
+**Cost**: staging is unusable for any authenticated workflow. UI smoke
+can't run. Wave 8/9/M-Feishu-1 backend integration verification on
+staging is blocked.
+
+## Lessons captured
+
+1. **Deploy SOP missed `pnpm migrate` step**. The original deploy plan
+   (5-step) only covered image-pull + up. For any deploy where the
+   image's code expects newer schema than the env's DB has, migrations
+   are required. The 5-step plan needs a step 0: "diff
+   kysely_migration latest against new image's required migrations
+   (compute via `git log --since=<last-deploy-date> -- packages/core-backend/src/db/migrations/`),
+   apply pending migrations FIRST, then deploy backend image".
+
+2. **Two-track migration model is invisible**. The codebase has both
+   `migrations/*.sql` (legacy) and `src/db/migrations/*.ts` (modern
+   kysely) loaded by the same provider. There's no documentation of
+   which environments have legacy entries pre-tracked in
+   `kysely_migration` and which don't. **Action item**: write a
+   `docs/operations/migration-tracking-state.md` mapping env → tracking
+   state, AND fix the migrate.ts script to support a real
+   `--check-pending` flag that diffs files vs tracking table without
+   running.
+
+3. **`migrate.ts` flag handling is broken**. `db:list`, `db:reset`,
+   `db:rollback` package.json scripts all run `migrateToLatest()` —
+   they ignore argv. **Action item**: separate PR to either implement
+   those flags or remove them. As written, `db:reset` is a footgun
+   (claims to reset but actually advances).
+
+4. **JWT_SECRET red herring**. When auth fails post-deploy, our
+   diagnosis defaulted to "JWT_SECRET changed" without checking the
+   backend logs. The logs definitively showed the real cause (DB query
+   failure). **Action item**: deploy verification SOP should include
+   `docker logs metasheet-staging-backend 2>&1 | tail -100 | grep -E
+   "warn|error"` immediately after `up -d`, before claiming success.
+
+5. **404→401 transition is necessary but not sufficient**. The original
+   deploy MD's celebration of "Wave 8 routes return 401 not 404 = code
+   is live" is correct in narrow scope (proves the route is mounted)
+   but masked the real failure (auth path broken). A complete
+   verification needs at least one authenticated 200 against a Wave 8
+   endpoint.
+
+## Next steps after rollback (proposed)
+
+1. **Re-issue staging admin token** if needed — though current token
+   should work against the previous image.
+2. **Re-run UI smoke** against rolled-back staging (working state).
+3. **Schedule migration-alignment maintenance window**: take pg_dump
+   first, then either:
+   - Manually align kysely_migration entries to match prod-track exactly
+     (only the legacy + already-applied ones), then run `pnpm migrate`
+     for the genuinely-pending ones
+   - OR clone prod-track DB into staging (drop staging DB, restore from
+     prod dump with PII anonymized)
+4. **Re-deploy d88ad587b** post-alignment, verify auth+200 on Wave 8
+   endpoints before declaring success.
+5. **Update deploy SOP** with all lessons above, especially the
+   migration-pending diff step.
+
+## Roadmap compliance
+
+- ✅ No new战线 opened (this is a deploy recovery diagnosis, not a
+  feature)
+- ✅ No `plugins/plugin-integration-core/*` source touched
+- ✅ No platform-化 work
+- ✅ Pure operational hygiene + SOP repair
+
+## Rollback executed — 2026-04-26 12:31 UTC
+
+User authorized option 1. Rollback completed in one SSH session:
+
+```bash
+# 1. backup current .env (post-d88ad587b state)
+sudo cp .env .env.bak.rollback-from-d88ad587b-20260426T123123Z
+
+# 2. swap IMAGE_TAG (NOT restored from pre-deploy backup, which had stale 21493058e)
+sudo sed -i 's|^IMAGE_TAG=.*|IMAGE_TAG=62a75f9809-itemresults|' .env
+
+# 3. workaround B — stop + rm + up --no-deps
+sudo docker-compose -f docker-compose.app.staging.yml stop backend web
+sudo docker-compose -f docker-compose.app.staging.yml rm -f backend web
+sudo docker-compose -f docker-compose.app.staging.yml up -d --no-deps backend web
+```
+
+**Note**: the pre-deploy `.env.bak.before-d88ad587b-20260426` had `IMAGE_TAG=21493058e`
+(stale 9-char prefix that never matched a real image — see original deploy MD lessons).
+The actually-running image before the deploy was `62a75f9809-itemresults` (a feature
+build, 11 days old, cached locally). I wrote that tag directly into `.env` rather than
+restore the broken backup.
+
+### Post-rollback verification
+
+| Probe | Expected | Got |
+|-------|----------|-----|
+| `/api/health` | 200, plugins:14, dbPool healthy | ✅ 200, plugins:14, dbPool {total:3, idle:3, waiting:0} |
+| `/api/auth/me` (with 8082 admin token) | 200 (real user data) | ✅ 200, returns admin user data |
+| `/api/multitable/bases` | 200 | ✅ 200, returns base_legacy |
+| `/api/approvals/metrics/summary` (Wave 8) | 404 (route NOT mounted on pre-d88ad587b image) | ✅ 404 "Cannot GET" |
+
+**Confirms**:
+- Token IS valid (signature + DB hydration both work on this image).
+- Plugin count back to **14** (the "drop to 13" on d88ad587b was a schema-gap artifact, not a real plugin loss).
+- Wave 8 routes correctly absent — this is the pre-Wave 8 image.
+- Staging is back to its prior working state. UI smoke can resume against this image, but
+  Wave 8/9/M-Feishu-1 verification is deferred until d88ad587b is redeployed post-alignment.
+
+### State after rollback
+
+| Surface | State |
+|---------|-------|
+| Backend container | Up, image `62a75f9809-itemresults` (working) |
+| Web container | Up, image `62a75f9809-itemresults` (working) |
+| Staging postgres `6a3b8dcc2a37_…` | Up, **schema unchanged** (no migrations run, no rows touched) |
+| Staging redis `dd50c7844281_…` | Up, healthy |
+| Wave 8/9/M-Feishu-1 routes | Not mounted (deferred until next deploy) |
+| 8082 staging admin JWT | ✅ confirmed valid, no need to reissue |
+| kysely_migration table | 86 rows (unchanged) — alignment task still pending |
+| `.env IMAGE_TAG` | `62a75f9809-itemresults` (current) |
+| `.env.bak.rollback-from-d88ad587b-20260426T123123Z` | preserved — forward-roll-again path |
+| `.env.bak.before-d88ad587b-20260426` | preserved (still contains stale `21493058e` — do not use directly) |
+
+## Open follow-ups (deferred, not in this session)
+
+1. **Migration alignment maintenance task** — needs its own session and pg_dump-first
+   discipline. Approach options laid out in §"Recommended recovery — option-by-option
+   analysis" above.
+2. **Fix `migrate.ts` flag handling** — separate small PR to make `db:list`/`db:reset`/
+   `db:rollback` either honor argv or be removed from package.json (currently footgun).
+3. **Write deploy SOP doc** — `docs/operations/staging-deploy-sop.md` capturing:
+   - Pre-deploy: `git log --since=<last-deploy-date> -- packages/core-backend/src/db/migrations/`
+     to enumerate pending migrations
+   - Pre-deploy: confirm kysely_migration on target env contains all entries through the
+     image's expected schema state (diff against canonical)
+   - During deploy: check backend logs for warn/error within first 60s of `up -d`
+   - During deploy: at least one authenticated 200 against an endpoint added by the new image
+     before declaring success
+   - Post-deploy: only after all verification is green, declare done; if any fails, roll back
+     immediately rather than diagnose under live deploy pressure
+4. **Redeploy d88ad587b** post-alignment to land Wave 8/9/M-Feishu-1 routes on staging.
+
+## Roadmap compliance (final)
+
+- ✅ No new战线 opened (this is recovery + diagnosis hygiene)
+- ✅ No `plugins/plugin-integration-core/*` source touched
+- ✅ No platform-化 work
+- ✅ No destructive actions taken on staging postgres (no migrations run, no rows touched)
+- ✅ Recovery path was fully reversible at every step

--- a/docs/operations/staging-deploy-sop.md
+++ b/docs/operations/staging-deploy-sop.md
@@ -1,0 +1,254 @@
+# Staging Deploy SOP — Manual image-pull mode
+
+This SOP applies to **manual deploys** on shared hosts (e.g.
+`142.171.239.56` running `docker-compose.app.staging.yml`) where you
+update the running stack by editing `.env` and running
+`docker-compose pull && up -d`. For the **bootstrap script** that
+clones + builds + auto-migrates, see [`deploy-ghcr.md`](./deploy-ghcr.md)
+— that script runs migrations automatically; this SOP exists because
+manual `pull && up -d` does **not**.
+
+The codebase has no auto-migrate-on-startup. If the new image's code
+expects schema the env doesn't have, authenticated routes will fail
+silently (DB query inside the auth middleware → 401, not a clear
+schema error to the client). This SOP catches that before it bites.
+
+## Pre-deploy (read-only checks — do NOT skip)
+
+### 1. Identify the new image's full SHA
+
+GHCR uses the **40-char full commit SHA** as the image tag. The 7- or
+9-char prefix that may appear in `.env` will not pull cleanly.
+
+```bash
+COMMIT=<short-sha>  # e.g. d88ad587b
+gh api "/users/zensgit/packages/container/metasheet2-backend/versions" \
+  --paginate \
+  --jq '.[] | select(.metadata.container.tags[]? | startswith($prefix)) | .metadata.container.tags[]' \
+  --arg prefix "$COMMIT" | head -3
+```
+
+Confirm an image tag matches `<COMMIT_FULL_SHA>` exactly. Save that as
+`IMAGE_SHA_FULL`.
+
+### 2. Diff pending migrations vs target env
+
+Find what migrations the new image requires that the target env hasn't
+applied. Two ways:
+
+**A. Quick local check** — list migrations newer than the previous
+deployed commit:
+
+```bash
+PREV=<previous deployed full SHA>  # from .env IMAGE_TAG before this deploy
+NEW=$IMAGE_SHA_FULL
+git log --oneline "$PREV..$NEW" -- packages/core-backend/src/db/migrations/
+```
+
+If the output is non-empty, the deploy will require migrations.
+
+**B. Authoritative check** — compare the target env's `kysely_migration`
+table against the latest migrations in the new image:
+
+```bash
+# On the host
+PG=$(sudo docker ps --format '{{.Names}}' | grep postgres | head -1)
+sudo docker exec "$PG" psql -U metasheet -d metasheet -c \
+  "SELECT name FROM kysely_migration ORDER BY name DESC LIMIT 5;"
+```
+
+Compare the latest applied name to the most recent file in
+`packages/core-backend/src/db/migrations/` for the target image's
+commit. If the env is behind, you have pending work.
+
+### 3. Confirm the target env is on the expected schema track
+
+Multi-tenant hosts may run multiple stacks (e.g. `metasheet-*` AND
+`metasheet-staging-*` — they share a host but have separate postgres
+containers on separate networks). Resolve which postgres the backend
+ACTUALLY connects to:
+
+```bash
+sudo docker inspect <backend-container> -f \
+  '{{range $net, $cfg := .NetworkSettings.Networks}}{{$net}}{{end}}' \
+  | xargs -I {} sudo docker network inspect {} \
+  -f '{{range .Containers}}{{.Name}}: {{.IPv4Address}}{{"\n"}}{{end}}'
+```
+
+The postgres on the **same network** as the backend is the one to
+probe. Probing the wrong postgres will produce false-clean results.
+
+### 4. Backup `.env`
+
+```bash
+sudo cp /path/to/.env /path/to/.env.bak.before-${IMAGE_SHA_FULL:0:9}-$(date -u +%Y%m%d)
+```
+
+Rollback path: restoring this file lets a future `pull && up -d` revert
+to the previous image (assuming the previous image is still cached
+locally, which is usually true for recent deploys).
+
+## Deploy
+
+### 5. Apply migrations FIRST (if any are pending from step 2)
+
+Migrations must precede the new image — old image still works against
+the migrated schema (since migrations are typically additive), but new
+image will fail against the un-migrated schema.
+
+```bash
+# From inside the CURRENT (not new) backend container
+sudo docker exec -w /app/packages/core-backend <backend-container> \
+  node dist/src/db/migrate.js --list
+```
+
+After [PR #1190](https://github.com/zensgit/metasheet2/pull/1190) lands,
+`--list` shows pending migrations without applying them. Review the
+list, then:
+
+```bash
+sudo docker exec -w /app/packages/core-backend <backend-container> \
+  node dist/src/db/migrate.js
+```
+
+If the env has a tracking-state divergence (legacy SQL migrations not
+recorded in `kysely_migration`), this fails. See
+[`staging-migration-alignment-runbook.md`](./staging-migration-alignment-runbook.md)
+for the recovery path. **Do NOT proceed with the image swap until
+migrations succeed**.
+
+### 6. Update `.env IMAGE_TAG`
+
+```bash
+sudo sed -i.bak2 "s|^IMAGE_TAG=.*|IMAGE_TAG=$IMAGE_SHA_FULL|" /path/to/.env
+sudo grep '^IMAGE_TAG' /path/to/.env  # verify
+```
+
+Use full SHA, not prefix.
+
+### 7. Pull the new image
+
+```bash
+sudo docker-compose -f /path/to/docker-compose.app.staging.yml pull backend web
+```
+
+Should succeed; if "manifest unknown", the SHA is wrong (re-check step 1).
+
+### 8. Bring up backend + web (workaround B)
+
+```bash
+sudo docker-compose -f /path/to/docker-compose.app.staging.yml stop backend web
+sudo docker-compose -f /path/to/docker-compose.app.staging.yml rm -f backend web
+sudo docker-compose -f /path/to/docker-compose.app.staging.yml up -d --no-deps backend web
+```
+
+**Why workaround B** (instead of plain `up -d`): docker-compose v1.29.2
+has a `KeyError: 'ContainerConfig'` bug against Docker Engine 27+ that
+crashes during volume migration on existing containers. `stop + rm + up`
+removes the old container first so the volume-migration code path is
+skipped. `--no-deps` prevents v1's reconciler from silently touching
+postgres/redis (which it does even when only `backend web` are listed).
+
+## Post-deploy verification (within 60 seconds)
+
+### 9. Watch backend logs for schema errors
+
+```bash
+sleep 30  # let the container bootstrap
+sudo docker logs --tail 100 <backend-container> 2>&1 | \
+  grep -iE 'warn|error' | head -20
+```
+
+If you see:
+
+- `column "X" does not exist`, `relation "X" does not exist` →
+  migration was missed or failed. **Roll back** before users notice.
+- `Database query failed` repeatedly → DB connectivity or schema gap.
+- `JWT` or signature errors → genuine JWT_SECRET issue (rare).
+
+### 10. Authenticated round-trip — at least one route must return 200
+
+`/api/health` returning 200 is **not enough** — it doesn't verify auth
+or DB hydration. Probe at least:
+
+```bash
+TOKEN=$(cat /path/to/admin-token.jwt)
+curl -s -w '%{http_code}\n' -H "Authorization: Bearer $TOKEN" \
+  http://localhost:<port>/api/auth/me
+curl -s -w '%{http_code}\n' -H "Authorization: Bearer $TOKEN" \
+  http://localhost:<port>/api/multitable/bases
+```
+
+Both should return **200** with valid JSON. If either returns 401, do
+NOT default to "JWT_SECRET changed" — check backend logs first (step 9);
+the most common cause is a schema gap surfaced as auth rejection
+(see post-mortem `staging-deploy-d88ad587b-postmortem-20260426.md` in
+docs/development for the full case study).
+
+### 11. New-route smoke (optional, only if the deploy adds new routes)
+
+For routes the new image adds, expect **401 with code:UNAUTHORIZED**
+(route mounted, auth rejected because no token) or **200** (with token).
+Pre-deploy these would have been **404 "Cannot GET"**. The 404→401 (or
+404→200) transition is the proof the new code is loaded.
+
+### 12. Plugin count sanity check
+
+```bash
+curl -s http://localhost:<port>/api/health | jq '.plugins, .pluginsSummary'
+```
+
+Compare to the previous deploy's count. A drop is a yellow flag — most
+likely a plugin failed to register due to a missing dependency or env
+var, not a real plugin loss. Investigate before declaring success.
+
+## Rollback (if any verification fails)
+
+```bash
+# 1. Restore .env IMAGE_TAG to previous full SHA (or the cached image tag)
+sudo sed -i.bakR "s|^IMAGE_TAG=.*|IMAGE_TAG=<previous-full-sha-or-tag>|" /path/to/.env
+
+# 2. Workaround B again
+sudo docker-compose -f /path/to/docker-compose.app.staging.yml stop backend web
+sudo docker-compose -f /path/to/docker-compose.app.staging.yml rm -f backend web
+sudo docker-compose -f /path/to/docker-compose.app.staging.yml up -d --no-deps backend web
+```
+
+Postgres + redis are NOT touched by rollback. Schema state remains as
+of the migration step (un-rolled-back, since migrations are additive
+and the previous image works against the new schema). If the new
+image's migrations included BREAKING schema changes (column drops,
+type narrowings), rollback requires also rolling back the schema —
+out of scope for this SOP, file an incident ticket.
+
+## What this SOP does NOT cover
+
+- **Bootstrap deploys** (fresh host) — see
+  [`deploy-ghcr.md`](./deploy-ghcr.md).
+- **Migration tracking-state misalignment recovery** — see
+  [`staging-migration-alignment-runbook.md`](./staging-migration-alignment-runbook.md).
+- **Schema-breaking migrations** (drops, type narrowings) — needs an
+  incident-grade rollback plan; not the routine forward-deploy path.
+- **CI-driven deploys** — out of scope; this is the manual operator path.
+
+## Quick checklist (printable)
+
+- [ ] 1. Resolve full 40-char `IMAGE_SHA_FULL`
+- [ ] 2. Diff pending migrations (`git log` + `kysely_migration` query)
+- [ ] 3. Confirm correct postgres on backend's network
+- [ ] 4. Backup `.env`
+- [ ] 5. **Apply migrations** (`migrate.js --list` then run) — block on success
+- [ ] 6. Update `.env IMAGE_TAG=$IMAGE_SHA_FULL`
+- [ ] 7. `docker-compose pull backend web`
+- [ ] 8. Workaround B: `stop + rm -f + up -d --no-deps backend web`
+- [ ] 9. `docker logs --tail 100 ... | grep -iE 'warn|error'` — clean?
+- [ ] 10. Authenticated round-trip 200 on `/api/auth/me` + `/api/multitable/bases`
+- [ ] 11. New-route smoke: 404→401 (or 404→200) transition confirmed
+- [ ] 12. Plugin count matches expectation
+- [ ] 13. Declare success OR roll back per §"Rollback"
+
+## Provenance
+
+This SOP captures lessons from the 2026-04-26 staging deploy of
+`d88ad587b` which broke auth on staging due to skipped migrations.
+Full case study: `docs/development/staging-deploy-d88ad587b-postmortem-20260426.md`.

--- a/docs/operations/staging-migration-alignment-runbook.md
+++ b/docs/operations/staging-migration-alignment-runbook.md
@@ -1,0 +1,273 @@
+# Staging Migration Alignment Runbook
+
+This runbook handles the case where a target env's `kysely_migration`
+table is **out of sync with the actual schema state** — typically
+manifests as `pnpm migrate` failing on an old migration that
+"shouldn't" need to run because the schema is already in place.
+
+The 2026-04-26 staging diagnosis surfaced this: staging postgres had
+86 entries in `kysely_migration` (latest 2026-04-09) while prod-track
+had 152 (including legacy numerics 008-057+ and modern Apr-10+). The
+legacy numerics had been applied to staging via the old SQL runner but
+never recorded in the kysely tracking table. Naive `pnpm migrate`
+fails on the first such "phantom-pending" migration.
+
+This is a **planned maintenance task**, not a hot-deploy fix. Schedule
+it during a window where staging can be unavailable for ~15 minutes
+and a real human is at the keyboard.
+
+## Pre-flight
+
+### Required access
+
+- SSH to the host (e.g. `tempadmin142@142.171.239.56`)
+- `sudo` for `docker exec` against postgres + backend
+- A reachable, healthy prod-track stack with a known-good
+  `kysely_migration` table to use as the canonical reference
+
+### Preserve the rollback path
+
+```bash
+# Pin the current backend image SHA so we can roll back if the
+# alignment goes sideways
+CURRENT_IMAGE=$(sudo docker inspect <staging-backend> -f '{{.Config.Image}}')
+echo "rollback target: $CURRENT_IMAGE"
+```
+
+Save `$CURRENT_IMAGE` somewhere persistent (paste into a memo / chat).
+
+### pg_dump first — this is non-negotiable
+
+```bash
+PG=<staging-postgres-container>  # may be hash-prefixed if compose v1 renamed it
+TS=$(date -u +%Y%m%dT%H%M%SZ)
+sudo docker exec "$PG" pg_dump -U metasheet -d metasheet -Fc \
+  > /tmp/metasheet-staging-pgdump-$TS.dump
+ls -la /tmp/metasheet-staging-pgdump-$TS.dump  # confirm size > 0
+```
+
+`-Fc` = custom format = compressed, restorable via `pg_restore`. If
+this dump fails or is empty, **stop**. Do not proceed without a
+working backup.
+
+## Alignment options
+
+Pick exactly one. Do not mix.
+
+### Option A: Synthetic catch-up (RECOMMENDED for the 2026-04-26 case)
+
+Copy the missing entries from prod-track's `kysely_migration` into
+staging's, marking them as applied without re-running. Assumes
+staging's actual schema matches what those migrations would have
+produced (true in the 2026-04-26 case for the legacy numerics — the
+SQL was applied long ago via the old runner).
+
+#### A.1 Snapshot prod-track's tracking table
+
+```bash
+PROD_PG=<prod-track-postgres-container>
+sudo docker exec "$PROD_PG" psql -U metasheet -d metasheet -tA -c \
+  "SELECT name, timestamp FROM kysely_migration ORDER BY name;" \
+  > /tmp/prod-kysely_migration.tsv
+wc -l /tmp/prod-kysely_migration.tsv  # expect ~152 lines (Apr 2026 baseline)
+```
+
+#### A.2 Compute the diff (entries in prod, not in staging)
+
+```bash
+sudo docker exec "$STAGING_PG" psql -U metasheet -d metasheet -tA -c \
+  "SELECT name FROM kysely_migration ORDER BY name;" \
+  > /tmp/stg-kysely_migration.tsv
+
+# Lines in prod, not in staging — the candidate insert set
+diff /tmp/prod-kysely_migration.tsv /tmp/stg-kysely_migration.tsv \
+  | grep '^<' | sed 's/^< //' > /tmp/missing-from-staging.tsv
+wc -l /tmp/missing-from-staging.tsv
+```
+
+#### A.3 Audit the diff before inserting
+
+For each entry in `/tmp/missing-from-staging.tsv`:
+
+- **Legacy numeric migrations** (e.g. `008_plugin_infrastructure`,
+  `032-057_*`, `20250925_create_view_tables`,
+  `20250926_create_audit_tables`): these created schema via the old
+  `migrations/*.sql` runner. Check `\d <relevant table>` on staging
+  to confirm the schema actually exists. If yes, mark-as-applied is
+  safe.
+- **Modern migrations from before staging's last applied date**: same
+  audit — if the schema effects are visible on staging, they were
+  applied via some other path. Mark as applied.
+- **Modern migrations from AFTER staging's last applied date**: these
+  are GENUINELY pending. Do **NOT** include them in the synthetic
+  insert. They need to run for real via `pnpm migrate` after the
+  synthetic catch-up completes.
+
+Split `/tmp/missing-from-staging.tsv` into two files:
+
+- `/tmp/synthetic-mark-applied.tsv` — schema is already in place
+  (legacy + early-modern)
+- `/tmp/genuinely-pending.tsv` — must actually run
+
+For the 2026-04-26 baseline this is roughly:
+- ~28 entries → synthetic (legacy 008-057, 20250925, 20250926)
+- ~38 entries → genuinely-pending (everything dated `zzzz20260410+`)
+
+#### A.4 Insert synthetic-applied entries
+
+```bash
+# Build the SQL file
+{
+  echo "BEGIN;"
+  while IFS=$'\t' read -r name ts; do
+    # Use prod's timestamp if available, otherwise epoch zero (any non-null is fine)
+    [ -z "$ts" ] && ts=0
+    echo "INSERT INTO kysely_migration (name, timestamp) VALUES ('$name', $ts);"
+  done < /tmp/synthetic-mark-applied.tsv
+  echo "COMMIT;"
+} > /tmp/synthetic-mark-applied.sql
+
+# Apply
+sudo docker exec -i "$STAGING_PG" psql -U metasheet -d metasheet \
+  < /tmp/synthetic-mark-applied.sql
+```
+
+Verify count:
+
+```bash
+sudo docker exec "$STAGING_PG" psql -U metasheet -d metasheet -c \
+  "SELECT count(*) FROM kysely_migration;"
+# Should be old-count + len(synthetic-mark-applied.tsv)
+```
+
+#### A.5 Run pnpm migrate to apply the genuinely-pending ones
+
+```bash
+sudo docker exec -w /app/packages/core-backend <staging-backend> \
+  node dist/src/db/migrate.js --list
+# Confirms the only pending entries match /tmp/genuinely-pending.tsv
+
+sudo docker exec -w /app/packages/core-backend <staging-backend> \
+  node dist/src/db/migrate.js
+# Apply them
+```
+
+Each migration prints "executed successfully" or "failed". If any
+fails, **stop** and investigate before retrying — the schema is now
+mid-flight.
+
+### Option B: Full restore from prod-track snapshot
+
+Drop staging's DB, restore from a sanitized prod-track dump. Use this
+if option A's audit (§A.3) reveals significant schema drift between
+staging and what the missing migrations would have produced.
+
+```bash
+# 1. Take a fresh prod-track dump
+sudo docker exec "$PROD_PG" pg_dump -U metasheet -d metasheet -Fc \
+  > /tmp/prod-source.dump
+
+# 2. (If needed) sanitize PII — out of scope for this runbook;
+#    likely not required if staging is already non-prod data
+
+# 3. Drop and re-create staging DB
+sudo docker exec "$STAGING_PG" psql -U metasheet -d postgres -c \
+  "DROP DATABASE metasheet;"
+sudo docker exec "$STAGING_PG" psql -U metasheet -d postgres -c \
+  "CREATE DATABASE metasheet;"
+
+# 4. Restore
+sudo docker exec -i "$STAGING_PG" pg_restore -U metasheet -d metasheet -c \
+  < /tmp/prod-source.dump
+```
+
+After this, staging's schema + `kysely_migration` table both match
+prod-track's. Subsequent deploys work normally.
+
+**Cost**: staging loses its current data (which is typically fine for
+a non-prod env — but confirm with the team before doing this).
+
+## Post-alignment verification
+
+```bash
+# 1. kysely_migration matches expectation
+sudo docker exec "$STAGING_PG" psql -U metasheet -d metasheet -c \
+  "SELECT count(*) FROM kysely_migration;"
+# Should match the new image's expected baseline
+
+# 2. Critical schema checks (case-by-case based on the deploy that triggered alignment)
+sudo docker exec "$STAGING_PG" psql -U metasheet -d metasheet -c \
+  "\d users"
+# Look for columns the new image's auth code expects (e.g. username,
+# dingtalk_open_id, must_change_password)
+
+# 3. Authenticated round-trip
+TOKEN=$(cat /path/to/admin-token.jwt)
+curl -s -w '%{http_code}\n' -H "Authorization: Bearer $TOKEN" \
+  http://localhost:<port>/api/auth/me
+# Expect 200
+
+# 4. (Optional) re-deploy the failed image
+# Follow staging-deploy-sop.md from step 6 onwards now that the
+# tracking table aligns with what the new image expects.
+```
+
+## Failure modes & recovery
+
+### "Insert failed: duplicate key"
+
+You're trying to insert a name that's already present. Adjust
+`/tmp/synthetic-mark-applied.tsv` to exclude already-tracked entries:
+
+```bash
+sudo docker exec "$STAGING_PG" psql -U metasheet -d metasheet -tA -c \
+  "SELECT name FROM kysely_migration ORDER BY name;" \
+  > /tmp/stg-current.tsv
+comm -23 \
+  <(sort /tmp/synthetic-mark-applied.tsv | cut -f1) \
+  <(sort /tmp/stg-current.tsv) \
+  > /tmp/synthetic-mark-applied-clean.tsv
+```
+
+### "Migration failed: column already exists" mid-`pnpm migrate`
+
+A migration in `/tmp/genuinely-pending.tsv` overlaps with schema that
+was already applied via a non-tracked path. Move that name from
+`/tmp/genuinely-pending.tsv` to `/tmp/synthetic-mark-applied-extra.tsv`,
+insert it as synthetic-applied, then resume `pnpm migrate`.
+
+### "I changed something I shouldn't have"
+
+Restore from `/tmp/metasheet-staging-pgdump-$TS.dump`:
+
+```bash
+sudo docker exec "$STAGING_PG" psql -U metasheet -d postgres -c \
+  "DROP DATABASE metasheet;"
+sudo docker exec "$STAGING_PG" psql -U metasheet -d postgres -c \
+  "CREATE DATABASE metasheet;"
+sudo docker exec -i "$STAGING_PG" pg_restore -U metasheet -d metasheet \
+  < /tmp/metasheet-staging-pgdump-$TS.dump
+```
+
+This is why the §Pre-flight pg_dump is non-negotiable.
+
+## Provenance
+
+- Diagnosis: `docs/development/staging-deploy-d88ad587b-postmortem-20260426.md`
+- Original deploy MD: `docs/development/staging-deploy-d88ad587b-20260426.md`
+- Triggering staging gap: 86 → 152 in `kysely_migration` between
+  staging and prod-track stacks on host `142.171.239.56`
+- Memory entry tracking the deferred task:
+  `~/.claude/.../memory/project_staging_migration_alignment.md`
+
+## What this runbook does NOT cover
+
+- **Rolling back already-applied modern migrations** (the down() path)
+  — kysely supports `migrateDown()` per-migration, exposed by
+  `migrate.js --rollback` after [PR #1190](https://github.com/zensgit/metasheet2/pull/1190)
+  lands. But rolling back applied schema changes risks data loss; do
+  it as part of an incident-grade plan, not this routine alignment.
+- **Cross-vendor migration tooling** (Sequelize/Prisma/etc) — kysely
+  is the only tracking system in this codebase right now.
+- **Multi-tenant database scope-isolation issues** — different problem,
+  see Stage 3 roadmap.


### PR DESCRIPTION
## Summary

Archive local documentation files that were left untracked in the operator root checkout but are referenced by current mainline docs or preserve staging/K3/multitable planning history.

## Scope

- Add K3 stage-1 closeout and multitable three-lane planning docs.
- Add staging d88ad587b deploy/postmortem notes.
- Add staging deploy SOP and migration-alignment runbook.
- Add a cleanup note documenting which local artifacts were archived vs intentionally left local.

## Verification

- `git diff --cached --check`
- Changed-path scope is limited to `docs/`
- Secret-pattern scan across changed files found no bearer/JWT/API-key/webhook-looking values
- Cross-reference check confirms the previously missing docs now exist in this branch

## Notes

No runtime code, migrations, scripts, OpenAPI, workflows, or generated release artifacts are changed.
