### PR TITLE
docs(ops): refine staging deploy alignment runbooks

### DIFF
--- a/docs/development/operations-docs-delivery-20260426.md
+++ b/docs/development/operations-docs-delivery-20260426.md
@@ -45,7 +45,7 @@ which made parallel-development sense for this slice.
 ### staging-deploy-sop.md
 
 **Audience**: human operator running a manual `docker-compose pull && up -d`
-deploy on a shared host (e.g. 142.171.239.56). NOT for the bootstrap
+deploy on a shared host (e.g. <staging-host>). NOT for the bootstrap
 script `scripts/deploy-ghcr.sh` — that one auto-migrates and is
 covered by the existing `deploy-ghcr.md`.
 

--- a/docs/development/staging-deploy-d88ad587b-20260426.md
+++ b/docs/development/staging-deploy-d88ad587b-20260426.md
@@ -130,7 +130,7 @@ Names also lost the `@metasheet/` scope prefix in display (cosmetic — same plu
 | Web container | Up, image `d88ad587b2c17402f861e1cf712f9de8e0148a0a` |
 | Postgres | Up 2h healthy, image cd848ee12e8e (untouched) |
 | Redis | Up 2h healthy, image aa189b5a1954 (untouched) |
-| `/home/mainuser/...staging/.env IMAGE_TAG` | `d88ad587b2c17402f861e1cf712f9de8e0148a0a` (changed) |
+| `<staging-stack-dir>/.env IMAGE_TAG` | `d88ad587b2c17402f861e1cf712f9de8e0148a0a` (changed) |
 | `.env` backup files | `.env.bak.before-d88ad587b-20260426` and `.env.bak.before-d88ad587b-20260426` (rollback path preserved) |
 | Wave 8 / 9 / M-Feishu-1 routes | Mounted (verified by 401 not 404 transition) |
 | Existing staging admin JWT | Invalidated by new backend |
@@ -138,7 +138,7 @@ Names also lost the `@metasheet/` scope prefix in display (cosmetic — same plu
 
 ## Next steps (user-driven)
 
-1. **Re-issue staging admin JWT**: run `scripts/gen-staging-token.js` (or equivalent) against the new backend container to issue a fresh 72h token signed with whatever the current JWT_SECRET is. Save under `/tmp/metasheet-142-staging-admin-72h.jwt`.
+1. **Re-issue staging admin JWT**: run `scripts/gen-staging-token.js` (or equivalent) against the new backend container to issue a fresh 72h token signed with whatever the current JWT_SECRET is. Save under `<artifact-dir>/staging-admin-72h.jwt`.
 2. **Authorize me to re-probe** with the new JWT to confirm `/api/approvals/metrics/summary`, MF1/MF2/MF3 backend paths, and other Wave-protected routes return 200 (not 401).
 3. **(Optional) Investigate plugin count drop**:
    - Diff `plugins/` directory between the two image SHAs.

--- a/docs/development/staging-ops-docs-parallel-development-20260514.md
+++ b/docs/development/staging-ops-docs-parallel-development-20260514.md
@@ -1,0 +1,77 @@
+# Staging Ops Docs Parallel Development
+
+## 背景
+
+PR #1546 已经进入 review gate，继续向同一 PR 添加内容只会反复触发 CI，并不能推动合并。本轮按并行开发策略，选择一个与考勤/目录收口完全独立的 docs-only 切片：把 2026-04-26 staging deploy 事故复盘、手工部署 SOP 和 migration alignment runbook 从本地未跟踪状态整理成可 review 的运维文档分支。
+
+分支创建后，`origin/main` 通过 `a0e5d9f85 docs: archive local planning and staging operation notes` 已合入部分同名文档。本分支随后 rebase 到最新 `origin/main`，最终范围缩小为：
+
+- 对主干已有 staging ops 文档做路径中立性清洗；
+- 更新 SOP 中关于 PR #1190 的过期未来时表述；
+- 追加本轮并行开发和验证说明。
+
+## 分支策略
+
+本轮创建独立 worktree 和分支：
+
+```text
+<repo-worktree>
+codex/staging-ops-docs-20260514
+```
+
+该分支基于最新 `origin/main`，不复用 PR #1546 的分支，不修改功能代码，不修改 schema。
+
+## 交付范围
+
+本轮涉及文档：
+
+```text
+docs/development/operations-docs-delivery-20260426.md
+docs/development/staging-deploy-d88ad587b-20260426.md
+docs/operations/staging-deploy-sop.md
+docs/operations/staging-migration-alignment-runbook.md
+```
+
+配套新增本开发/验证说明：
+
+```text
+docs/development/staging-ops-docs-parallel-development-20260514.md
+docs/development/staging-ops-docs-parallel-verification-20260514.md
+```
+
+## 内容处理
+
+本轮保留了文档中的关键操作知识：
+
+- docker-compose v1.29.2 与 Docker Engine 27+ 的 `ContainerConfig` 问题；
+- 手工 image-pull 部署必须先做 migration diff；
+- 不能只看 `/api/health`，必须做 authenticated round-trip；
+- staging/prod-track 多栈同机时必须定位 backend 所在 network 的 postgres；
+- `kysely_migration` tracking-state divergence 的 synthetic catch-up 和 full restore 分支；
+- 失败时先保留 dump，再决定是否恢复。
+
+同时做了文档中立性清洗：
+
+- staging 主机 IP 替换为 `<staging-host>`；
+- SSH 用户替换为 `<staging-ssh-user>`；
+- 本机/远端栈路径替换为 `<staging-stack-dir>`；
+- 临时产物目录替换为 `<artifact-dir>`。
+
+## 已同步事实
+
+文档引用的 `migrate.ts` flag fix 已合入：
+
+```text
+PR #1190 fix(core-backend): honor --list/--rollback/--reset in migrate.ts
+mergedAt: 2026-04-27T01:17:22Z
+```
+
+因此 `staging-deploy-sop.md` 中不再使用“PR lands 后”的未来时表述。
+
+## 非目标
+
+本轮不执行真实 staging deploy，不登录远端主机，不运行 migration alignment，不处理 `output/` 目录，也不移动原工作区其他未跟踪文档。
+
+## 结论
+
+本轮把 staging deploy 事故的可复用经验整理为独立、路径中立、可 review 的运维文档切片。它可以与 PR #1546 并行 review，不互相阻塞；在主干已合入基础文档后，本分支保留为路径中立性和验证说明收口。

--- a/docs/development/staging-ops-docs-parallel-verification-20260514.md
+++ b/docs/development/staging-ops-docs-parallel-verification-20260514.md
@@ -1,0 +1,95 @@
+# Staging Ops Docs Parallel Verification
+
+## 验证环境
+
+- 日期：2026-05-14
+- Worktree：`<repo-worktree>`
+- 分支：`codex/staging-ops-docs-20260514`
+- 基线：最新 `origin/main`
+
+## 范围检查
+
+执行：
+
+```bash
+git ls-tree -r --name-only origin/main -- docs/development/staging-deploy-d88ad587b-20260426.md docs/development/staging-deploy-d88ad587b-postmortem-20260426.md docs/development/operations-docs-delivery-20260426.md docs/operations/staging-deploy-sop.md docs/operations/staging-migration-alignment-runbook.md
+```
+
+初始执行时无输出，确认这些文档当时尚未在 `origin/main`。后续 rebase 时，`origin/main` 已通过 `a0e5d9f85 docs: archive local planning and staging operation notes` 合入部分同名文档，因此本分支范围收缩为对主干文档做路径中立性修正，并新增本轮开发/验证说明。
+
+执行：
+
+```bash
+git diff --name-only origin/main...HEAD
+```
+
+最终预期范围：
+
+```text
+docs/development/operations-docs-delivery-20260426.md
+docs/development/staging-deploy-d88ad587b-20260426.md
+docs/development/staging-ops-docs-parallel-development-20260514.md
+docs/development/staging-ops-docs-parallel-verification-20260514.md
+docs/operations/staging-deploy-sop.md
+docs/operations/staging-migration-alignment-runbook.md
+```
+
+## 上游依赖检查
+
+执行：
+
+```bash
+gh pr view 1190 --json number,title,url,state,mergedAt,mergeCommit
+```
+
+结果：
+
+```text
+state: MERGED
+mergedAt: 2026-04-27T01:17:22Z
+mergeCommit: 303ff0520119a296b6294a5a8812cffa97491f4e
+```
+
+结论：`migrate.ts --list/--rollback/--reset` 相关 SOP 前提已经合入主干。
+
+## 路径中立性检查
+
+执行：
+
+```bash
+rg -n "<real-staging-host>|<real-staging-ssh-user>|<local-home-pattern>|<temp-artifact-pattern>|<remote-stack-path-pattern>" docs/development/staging-deploy-d88ad587b-20260426.md docs/development/staging-deploy-d88ad587b-postmortem-20260426.md docs/development/operations-docs-delivery-20260426.md docs/operations/staging-deploy-sop.md docs/operations/staging-migration-alignment-runbook.md
+```
+
+结果：使用真实本地/远端路径和 staging host 模式执行扫描后，无命中。
+
+占位符检查：
+
+```bash
+rg -n "<staging-host>|<staging-ssh-user>|<artifact-dir>|<staging-stack-dir>" docs/development/staging-deploy-d88ad587b-20260426.md docs/development/staging-deploy-d88ad587b-postmortem-20260426.md docs/development/operations-docs-delivery-20260426.md docs/operations/staging-deploy-sop.md docs/operations/staging-migration-alignment-runbook.md
+```
+
+结果：命中预期占位符。
+
+## 敏感值检查
+
+执行：
+
+```bash
+rg -n "(eyJ[A-Za-z0-9_-]{20,}|sk-[A-Za-z0-9]|xox[baprs]-|gh[pousr]_[A-Za-z0-9]|AKIA[0-9A-Z]{16}|SEC[0-9A-Za-z_-]{10,}|https://oapi\\.dingtalk\\.com/robot/send\\?access_token=|-----BEGIN [A-Z ]*PRIVATE KEY)" docs/development/staging-deploy-d88ad587b-20260426.md docs/development/staging-deploy-d88ad587b-postmortem-20260426.md docs/development/operations-docs-delivery-20260426.md docs/operations/staging-deploy-sop.md docs/operations/staging-migration-alignment-runbook.md
+```
+
+结果：无命中。
+
+## Markdown/Whitespace 检查
+
+执行：
+
+```bash
+git diff --check -- docs/development/operations-docs-delivery-20260426.md docs/development/staging-deploy-d88ad587b-20260426.md docs/development/staging-deploy-d88ad587b-postmortem-20260426.md docs/development/staging-ops-docs-parallel-development-20260514.md docs/development/staging-ops-docs-parallel-verification-20260514.md docs/operations/staging-deploy-sop.md docs/operations/staging-migration-alignment-runbook.md
+```
+
+结果：无输出。
+
+## 当前结论
+
+本轮是 docs-only 交付。文档范围、路径中立性、敏感值扫描和 whitespace 检查均通过；未执行真实 staging 操作。

--- a/docs/operations/staging-deploy-sop.md
+++ b/docs/operations/staging-deploy-sop.md
@@ -1,7 +1,7 @@
 # Staging Deploy SOP — Manual image-pull mode
 
 This SOP applies to **manual deploys** on shared hosts (e.g.
-`142.171.239.56` running `docker-compose.app.staging.yml`) where you
+`<staging-host>` running `docker-compose.app.staging.yml`) where you
 update the running stack by editing `.env` and running
 `docker-compose pull && up -d`. For the **bootstrap script** that
 clones + builds + auto-migrates, see [`deploy-ghcr.md`](./deploy-ghcr.md)
@@ -102,7 +102,6 @@ sudo docker exec -w /app/packages/core-backend <backend-container> \
   node dist/src/db/migrate.js --list
 ```
 
-After [PR #1190](https://github.com/zensgit/metasheet2/pull/1190) lands,
 `--list` shows pending migrations without applying them. Review the
 list, then:
 

--- a/docs/operations/staging-migration-alignment-runbook.md
+++ b/docs/operations/staging-migration-alignment-runbook.md
@@ -20,7 +20,7 @@ and a real human is at the keyboard.
 
 ### Required access
 
-- SSH to the host (e.g. `tempadmin142@142.171.239.56`)
+- SSH to the host (e.g. `<staging-ssh-user>@<staging-host>`)
 - `sudo` for `docker exec` against postgres + backend
 - A reachable, healthy prod-track stack with a known-good
   `kysely_migration` table to use as the canonical reference
@@ -42,8 +42,8 @@ Save `$CURRENT_IMAGE` somewhere persistent (paste into a memo / chat).
 PG=<staging-postgres-container>  # may be hash-prefixed if compose v1 renamed it
 TS=$(date -u +%Y%m%dT%H%M%SZ)
 sudo docker exec "$PG" pg_dump -U metasheet -d metasheet -Fc \
-  > /tmp/metasheet-staging-pgdump-$TS.dump
-ls -la /tmp/metasheet-staging-pgdump-$TS.dump  # confirm size > 0
+  > <artifact-dir>/metasheet-staging-pgdump-$TS.dump
+ls -la <artifact-dir>/metasheet-staging-pgdump-$TS.dump  # confirm size > 0
 ```
 
 `-Fc` = custom format = compressed, restorable via `pg_restore`. If
@@ -68,8 +68,8 @@ SQL was applied long ago via the old runner).
 PROD_PG=<prod-track-postgres-container>
 sudo docker exec "$PROD_PG" psql -U metasheet -d metasheet -tA -c \
   "SELECT name, timestamp FROM kysely_migration ORDER BY name;" \
-  > /tmp/prod-kysely_migration.tsv
-wc -l /tmp/prod-kysely_migration.tsv  # expect ~152 lines (Apr 2026 baseline)
+  > <artifact-dir>/prod-kysely_migration.tsv
+wc -l <artifact-dir>/prod-kysely_migration.tsv  # expect ~152 lines (Apr 2026 baseline)
 ```
 
 #### A.2 Compute the diff (entries in prod, not in staging)
@@ -77,17 +77,17 @@ wc -l /tmp/prod-kysely_migration.tsv  # expect ~152 lines (Apr 2026 baseline)
 ```bash
 sudo docker exec "$STAGING_PG" psql -U metasheet -d metasheet -tA -c \
   "SELECT name FROM kysely_migration ORDER BY name;" \
-  > /tmp/stg-kysely_migration.tsv
+  > <artifact-dir>/stg-kysely_migration.tsv
 
 # Lines in prod, not in staging — the candidate insert set
-diff /tmp/prod-kysely_migration.tsv /tmp/stg-kysely_migration.tsv \
-  | grep '^<' | sed 's/^< //' > /tmp/missing-from-staging.tsv
-wc -l /tmp/missing-from-staging.tsv
+diff <artifact-dir>/prod-kysely_migration.tsv <artifact-dir>/stg-kysely_migration.tsv \
+  | grep '^<' | sed 's/^< //' > <artifact-dir>/missing-from-staging.tsv
+wc -l <artifact-dir>/missing-from-staging.tsv
 ```
 
 #### A.3 Audit the diff before inserting
 
-For each entry in `/tmp/missing-from-staging.tsv`:
+For each entry in `<artifact-dir>/missing-from-staging.tsv`:
 
 - **Legacy numeric migrations** (e.g. `008_plugin_infrastructure`,
   `032-057_*`, `20250925_create_view_tables`,
@@ -103,11 +103,11 @@ For each entry in `/tmp/missing-from-staging.tsv`:
   insert. They need to run for real via `pnpm migrate` after the
   synthetic catch-up completes.
 
-Split `/tmp/missing-from-staging.tsv` into two files:
+Split `<artifact-dir>/missing-from-staging.tsv` into two files:
 
-- `/tmp/synthetic-mark-applied.tsv` — schema is already in place
+- `<artifact-dir>/synthetic-mark-applied.tsv` — schema is already in place
   (legacy + early-modern)
-- `/tmp/genuinely-pending.tsv` — must actually run
+- `<artifact-dir>/genuinely-pending.tsv` — must actually run
 
 For the 2026-04-26 baseline this is roughly:
 - ~28 entries → synthetic (legacy 008-057, 20250925, 20250926)
@@ -123,13 +123,13 @@ For the 2026-04-26 baseline this is roughly:
     # Use prod's timestamp if available, otherwise epoch zero (any non-null is fine)
     [ -z "$ts" ] && ts=0
     echo "INSERT INTO kysely_migration (name, timestamp) VALUES ('$name', $ts);"
-  done < /tmp/synthetic-mark-applied.tsv
+  done < <artifact-dir>/synthetic-mark-applied.tsv
   echo "COMMIT;"
-} > /tmp/synthetic-mark-applied.sql
+} > <artifact-dir>/synthetic-mark-applied.sql
 
 # Apply
 sudo docker exec -i "$STAGING_PG" psql -U metasheet -d metasheet \
-  < /tmp/synthetic-mark-applied.sql
+  < <artifact-dir>/synthetic-mark-applied.sql
 ```
 
 Verify count:
@@ -145,7 +145,7 @@ sudo docker exec "$STAGING_PG" psql -U metasheet -d metasheet -c \
 ```bash
 sudo docker exec -w /app/packages/core-backend <staging-backend> \
   node dist/src/db/migrate.js --list
-# Confirms the only pending entries match /tmp/genuinely-pending.tsv
+# Confirms the only pending entries match <artifact-dir>/genuinely-pending.tsv
 
 sudo docker exec -w /app/packages/core-backend <staging-backend> \
   node dist/src/db/migrate.js
@@ -165,7 +165,7 @@ staging and what the missing migrations would have produced.
 ```bash
 # 1. Take a fresh prod-track dump
 sudo docker exec "$PROD_PG" pg_dump -U metasheet -d metasheet -Fc \
-  > /tmp/prod-source.dump
+  > <artifact-dir>/prod-source.dump
 
 # 2. (If needed) sanitize PII — out of scope for this runbook;
 #    likely not required if staging is already non-prod data
@@ -178,7 +178,7 @@ sudo docker exec "$STAGING_PG" psql -U metasheet -d postgres -c \
 
 # 4. Restore
 sudo docker exec -i "$STAGING_PG" pg_restore -U metasheet -d metasheet -c \
-  < /tmp/prod-source.dump
+  < <artifact-dir>/prod-source.dump
 ```
 
 After this, staging's schema + `kysely_migration` table both match
@@ -217,28 +217,28 @@ curl -s -w '%{http_code}\n' -H "Authorization: Bearer $TOKEN" \
 ### "Insert failed: duplicate key"
 
 You're trying to insert a name that's already present. Adjust
-`/tmp/synthetic-mark-applied.tsv` to exclude already-tracked entries:
+`<artifact-dir>/synthetic-mark-applied.tsv` to exclude already-tracked entries:
 
 ```bash
 sudo docker exec "$STAGING_PG" psql -U metasheet -d metasheet -tA -c \
   "SELECT name FROM kysely_migration ORDER BY name;" \
-  > /tmp/stg-current.tsv
+  > <artifact-dir>/stg-current.tsv
 comm -23 \
-  <(sort /tmp/synthetic-mark-applied.tsv | cut -f1) \
-  <(sort /tmp/stg-current.tsv) \
-  > /tmp/synthetic-mark-applied-clean.tsv
+  <(sort <artifact-dir>/synthetic-mark-applied.tsv | cut -f1) \
+  <(sort <artifact-dir>/stg-current.tsv) \
+  > <artifact-dir>/synthetic-mark-applied-clean.tsv
 ```
 
 ### "Migration failed: column already exists" mid-`pnpm migrate`
 
-A migration in `/tmp/genuinely-pending.tsv` overlaps with schema that
+A migration in `<artifact-dir>/genuinely-pending.tsv` overlaps with schema that
 was already applied via a non-tracked path. Move that name from
-`/tmp/genuinely-pending.tsv` to `/tmp/synthetic-mark-applied-extra.tsv`,
+`<artifact-dir>/genuinely-pending.tsv` to `<artifact-dir>/synthetic-mark-applied-extra.tsv`,
 insert it as synthetic-applied, then resume `pnpm migrate`.
 
 ### "I changed something I shouldn't have"
 
-Restore from `/tmp/metasheet-staging-pgdump-$TS.dump`:
+Restore from `<artifact-dir>/metasheet-staging-pgdump-$TS.dump`:
 
 ```bash
 sudo docker exec "$STAGING_PG" psql -U metasheet -d postgres -c \
@@ -246,7 +246,7 @@ sudo docker exec "$STAGING_PG" psql -U metasheet -d postgres -c \
 sudo docker exec "$STAGING_PG" psql -U metasheet -d postgres -c \
   "CREATE DATABASE metasheet;"
 sudo docker exec -i "$STAGING_PG" pg_restore -U metasheet -d metasheet \
-  < /tmp/metasheet-staging-pgdump-$TS.dump
+  < <artifact-dir>/metasheet-staging-pgdump-$TS.dump
 ```
 
 This is why the §Pre-flight pg_dump is non-negotiable.
@@ -256,7 +256,7 @@ This is why the §Pre-flight pg_dump is non-negotiable.
 - Diagnosis: `docs/development/staging-deploy-d88ad587b-postmortem-20260426.md`
 - Original deploy MD: `docs/development/staging-deploy-d88ad587b-20260426.md`
 - Triggering staging gap: 86 → 152 in `kysely_migration` between
-  staging and prod-track stacks on host `142.171.239.56`
+  staging and prod-track stacks on host `<staging-host>`
 - Memory entry tracking the deferred task:
   `~/.claude/.../memory/project_staging_migration_alignment.md`
 


### PR DESCRIPTION
## Summary

- Refines the staging deploy SOP and migration alignment runbook that are now on main via local planning/docs archival.
- Replaces staging host/user/path/temp artifacts with neutral placeholders.
- Updates the staging deploy SOP now that PR #1190 has landed, so the migrate --list section is written as current behavior rather than future behavior.
- Adds development and verification markdown for this parallel docs-only slice.

## Verification

- gh pr view 1190 --json number,title,url,state,mergedAt,mergeCommit
- rg -n "142\.171\.239\.56|tempadmin142|/home/mainuser|/tmp/metasheet|/tmp/prod-|/tmp/stg-|/tmp/missing-|/tmp/synthetic-|/tmp/genuinely-|/tmp/prod-source|/Users/chouhua" docs/development/staging-deploy-d88ad587b-20260426.md docs/development/operations-docs-delivery-20260426.md docs/development/staging-ops-docs-parallel-development-20260514.md docs/development/staging-ops-docs-parallel-verification-20260514.md docs/operations/staging-deploy-sop.md docs/operations/staging-migration-alignment-runbook.md
- rg -n "(eyJ[A-Za-z0-9_-]{20,}|sk-[A-Za-z0-9]|xox[baprs]-|gh[pousr]_[A-Za-z0-9]|AKIA[0-9A-Z]{16}|SEC[0-9A-Za-z_-]{10,}|https://oapi\.dingtalk\.com/robot/send\?access_token=|-----BEGIN [A-Z ]*PRIVATE KEY)" docs/development/staging-deploy-d88ad587b-20260426.md docs/development/operations-docs-delivery-20260426.md docs/development/staging-ops-docs-parallel-development-20260514.md docs/development/staging-ops-docs-parallel-verification-20260514.md docs/operations/staging-deploy-sop.md docs/operations/staging-migration-alignment-runbook.md
- git diff --check origin/main...HEAD
- git diff --unified=0 origin/main...HEAD | rg -n '^\+.*(<sensitive-patterns>)' || true

## Not Run

- No real staging deploy, remote host login, migration alignment, or database operation was performed.

## Notes

- Docs-only PR.
- Independent from PR #1546, which remains auto-merge enabled and blocked only by review requirement.