### PR TITLE
test(multitable): close phase3 email log todo

### DIFF
--- a/docs/development/multitable-feishu-phase3-ai-hardening-todo-20260514.md
+++ b/docs/development/multitable-feishu-phase3-ai-hardening-todo-20260514.md
@@ -522,12 +522,12 @@ guards.
   - Development MD: `docs/development/multitable-phase3-real-smtp-gate-development-20260514.md`
   - Verification MD: `docs/development/multitable-phase3-real-smtp-gate-verification-20260514.md`
   - Verification summary: existing real-send harness exits 2 unless `MULTITABLE_EMAIL_SMOKE_TO` is configured; D1 tests prove recipient values are redacted from aggregate artifacts.
-- [ ] Tie send result to automation execution log.
-  - PR:
-  - Merge commit:
-  - Development MD:
-  - Verification MD:
-  - Verification summary: intentionally not claimed by this transport-level D1 aggregation slice; the shipped RC automation smoke covers execution-log behavior with the default mock channel, and D4 remains the correct place for repeat-fire automation-log soak semantics.
+- [x] Tie send result to automation execution log.
+  - PR: #1554
+  - Merge commit: pending until squash merge
+  - Development MD: `docs/development/multitable-phase3-email-log-closeout-development-20260514.md`
+  - Verification MD: `docs/development/multitable-phase3-email-log-closeout-verification-20260514.md`
+  - Verification summary: `AutomationService.executeRule` now has unit-level coverage proving successful `send_email` steps are persisted through `AutomationLogService.record` with `notificationId`, `notificationStatus`, and `recipientCount`; the pre-existing RC E2E smoke continues to cover the HTTP/logs API path.
 - [x] Redact SMTP credentials and recipients in artifacts.
   - PR: #1544
   - Merge commit: `1f9061f56`

--- a/docs/development/multitable-phase3-email-log-closeout-development-20260514.md
+++ b/docs/development/multitable-phase3-email-log-closeout-development-20260514.md
@@ -1,0 +1,58 @@
+# Multitable Phase 3 Email Log Closeout Development - 2026-05-14
+
+## Summary
+
+This slice closes the remaining Lane D1 TODO item, "Tie send result to
+automation execution log", without changing runtime behavior.
+
+Current `main` already persists automation executions through
+`AutomationService.executeRule()` and `AutomationLogService.record()`. The
+`send_email` executor step already returns notification evidence, and the RC
+E2E smoke already validates the HTTP logs path. The missing closeout was a
+small unit-level contract proving the successful `send_email` result is passed
+to the execution log writer.
+
+## Changes
+
+- Added a backend unit test in
+  `packages/core-backend/tests/unit/automation-v1.test.ts` for successful
+  `send_email` execution logging.
+- The new test asserts the persisted execution contains:
+  - `status: success`
+  - `steps[0].actionType: send_email`
+  - `steps[0].output.notificationId`
+  - `steps[0].output.notificationStatus`
+  - `steps[0].output.recipientCount`
+- Updated
+  `docs/development/multitable-feishu-phase3-ai-hardening-todo-20260514.md`
+  to mark Lane D1's execution-log item complete.
+- Replaced stale D1/D4 "merge pending" entries with the already-merged commits:
+  - D1 real SMTP gate: `1f9061f56`
+  - D4 automation soak gate: `855ba871e`
+
+## Scope Control
+
+This is intentionally a closeout/test slice:
+
+- No automation runtime code changes.
+- No SMTP provider changes.
+- No real email send.
+- No live staging invocation.
+- No changes to deferred Phase 3 AI/provider lanes.
+
+## Code Path Confirmed
+
+`AutomationExecutor.executeSendEmail()` returns a `send_email` step output with
+notification status and recipient count. `AutomationService.executeRule()` then
+records the resulting `AutomationExecution` through `AutomationLogService`.
+
+The new test locks this contract at the service boundary so a future refactor
+cannot silently drop the notification result before persistence.
+
+## Parallel Review Note
+
+A parallel read-only audit reached the same conclusion: current `main` already
+persists `send_email` execution results into automation logs. The audit pointed
+to the executor, service, log service, RC E2E smoke, and D4 soak harness as
+existing evidence. This PR therefore stays as a closeout/test slice, not a
+runtime behavior change.

--- a/docs/development/multitable-phase3-email-log-closeout-verification-20260514.md
+++ b/docs/development/multitable-phase3-email-log-closeout-verification-20260514.md
@@ -1,0 +1,84 @@
+# Multitable Phase 3 Email Log Closeout Verification - 2026-05-14
+
+## Scope
+
+Verification covers the Lane D1 closeout for `send_email` automation execution
+logs plus the Phase 3 TODO metadata update.
+
+## Local Verification
+
+Commands run from the standalone `metasheet2-phase3-email-log-closeout-20260514`
+worktree.
+
+### Targeted Backend Unit Test
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts --reporter=dot
+```
+
+Result: PASS.
+
+```text
+Test Files  1 passed (1)
+Tests       133 passed (133)
+```
+
+Note: this standalone worktree reuses the root and core-backend
+`node_modules` from the main checkout via local symlinks because the new
+worktree did not have its own dependency install.
+
+### D4 Soak Harness Regression
+
+```bash
+node --test scripts/ops/multitable-automation-soak.test.mjs
+```
+
+Result: PASS.
+
+```text
+tests 5
+pass 5
+fail 0
+```
+
+### Script Syntax / Repository Diff Checks
+
+```bash
+git diff --check
+```
+
+Result: PASS.
+
+```bash
+git diff --name-status origin/main...HEAD
+```
+
+Expected final range:
+
+```text
+M docs/development/multitable-feishu-phase3-ai-hardening-todo-20260514.md
+A docs/development/multitable-phase3-email-log-closeout-development-20260514.md
+A docs/development/multitable-phase3-email-log-closeout-verification-20260514.md
+M packages/core-backend/tests/unit/automation-v1.test.ts
+```
+
+### Sensitive Artifact Scan
+
+Result: PASS; no token-like, private-key-like, staging-host, or local absolute
+path matches in the final changed content.
+
+## Evidence Expected
+
+- The new test proves `AutomationService.executeRule()` calls
+  `AutomationLogService.record()` with a successful `send_email` step.
+- The recorded step includes `notificationId`, `notificationStatus: sent`, and
+  `recipientCount`.
+- The Phase 3 TODO no longer reports D1/D4 merged work as `pending`.
+- A parallel read-only audit confirmed this is a closeout/test evidence gap,
+  not a runtime persistence bug.
+
+## Live Verification
+
+Not run in this slice. The change is unit-test and documentation closeout only;
+real SMTP sends remain guarded by the existing `CONFIRM_SEND_EMAIL=1` and
+`MULTITABLE_EMAIL_REAL_SEND_SMOKE=1` harness requirements.

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -2361,6 +2361,50 @@ describe('AutomationService — Rule CRUD', () => {
     }))
   })
 
+  it('executeRule records successful send_email notification results', async () => {
+    const send = vi.fn(async () => ({
+      id: 'notif_success_1',
+      status: 'sent' as const,
+    }))
+    service = new AutomationService(eventBus, makeMockDb() as never, queryFn, undefined, null, {}, { send })
+    const logSpy = vi.spyOn(service.logs, 'record').mockResolvedValueOnce()
+
+    const execution = await service.executeRule(
+      createMockRule({
+        actions: [{
+          type: 'send_email',
+          config: {
+            recipients: ['ops@example.com', 'owner@example.com'],
+            subjectTemplate: 'Record {{record.title}} changed',
+            bodyTemplate: 'Status: {{record.status}}',
+          },
+        }],
+      }),
+      {
+        sheetId: 'sheet_1',
+        recordId: 'rec_1',
+        data: { title: 'Incident', status: 'open' },
+        _triggeredBy: 'test',
+      },
+    )
+
+    expect(execution.status).toBe('success')
+    expect(logSpy).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'success',
+      steps: [
+        expect.objectContaining({
+          actionType: 'send_email',
+          status: 'success',
+          output: expect.objectContaining({
+            notificationId: 'notif_success_1',
+            notificationStatus: 'sent',
+            recipientCount: 2,
+          }),
+        }),
+      ],
+    }))
+  })
+
   it('getRule returns null when not found', async () => {
     dbExecuteTakeFirstResults.push(undefined)
     const rule = await service.getRule('nonexistent')


### PR DESCRIPTION
## Summary
- add unit coverage that successful send_email automation executions are passed to AutomationLogService.record with notification result output
- close the remaining Phase 3 Lane D1 execution-log TODO and refresh merged D1/D4 commit metadata
- add development and verification closeout notes

## Verification
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts --reporter=dot
- node --test scripts/ops/multitable-automation-soak.test.mjs
- git diff --cached --check
- cached diff sensitive/path scan