### PR TITLE
feat(integration): add data factory multitable target action

### DIFF
--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -295,6 +295,15 @@
             >
               作为 Dry-run 来源
             </button>
+            <button
+              type="button"
+              class="integration-workbench__button"
+              :disabled="!descriptor.openLink"
+              :data-testid="`use-staging-target-${descriptor.id}`"
+              @click="useStagingAsTarget(descriptor.id)"
+            >
+              作为写入目标
+            </button>
           </div>
         </article>
       </div>
@@ -615,6 +624,8 @@ interface StagingObjectConfig {
   openLink?: string
   fields: string[]
   fieldDetails?: IntegrationStagingDescriptor['fieldDetails']
+  keyFields?: string[]
+  mode?: 'append' | 'upsert'
 }
 
 type ExportCell = string | number | boolean | null
@@ -905,6 +916,11 @@ function stagingSourceSystemId(projectId: string): string {
   return `metasheet_staging_${suffix}`
 }
 
+function stagingTargetSystemId(projectId: string): string {
+  const suffix = (projectId || 'default').replace(/[^A-Za-z0-9_-]+/g, '_').replace(/^_+|_+$/g, '') || 'default'
+  return `metasheet_target_${suffix}`
+}
+
 function descriptorToSchemaFields(descriptor: IntegrationStagingDescriptor | null): IntegrationObjectSchemaField[] {
   if (!descriptor) return []
   if (Array.isArray(descriptor.fieldDetails) && descriptor.fieldDetails.length > 0) {
@@ -920,6 +936,15 @@ function descriptorToSchemaFields(descriptor: IntegrationStagingDescriptor | nul
     label: field,
     type: 'string',
   }))
+}
+
+function defaultTargetKeyFields(descriptor: IntegrationStagingDescriptor): string[] {
+  const fields = new Set(descriptor.fields)
+  if (descriptor.id === 'bom_cleanse' && fields.has('parentCode') && fields.has('childCode')) return ['parentCode', 'childCode']
+  if (fields.has('code')) return ['code']
+  if (fields.has('externalId')) return ['externalId']
+  if (fields.has('id')) return ['id']
+  return []
 }
 
 function buildStagingSourceObjectsConfig(): Record<string, StagingObjectConfig> {
@@ -940,6 +965,27 @@ function buildStagingSourceObjectsConfig(): Record<string, StagingObjectConfig> 
   return objects
 }
 
+function buildStagingTargetObjectsConfig(): Record<string, StagingObjectConfig> {
+  const objects: Record<string, StagingObjectConfig> = {}
+  for (const descriptor of stagingDescriptors.value) {
+    const target = stagingOpenTargetById.value.get(descriptor.id)
+    if (!target?.sheetId) continue
+    const keyFields = defaultTargetKeyFields(descriptor)
+    objects[descriptor.id] = {
+      name: stagingDatasetCopy[descriptor.id]?.name || descriptor.name,
+      sheetId: target.sheetId,
+      viewId: target.viewId,
+      baseId: target.baseId || stagingBaseId.value.trim() || null,
+      openLink: target.openLink,
+      fields: descriptor.fields,
+      fieldDetails: descriptor.fieldDetails,
+      keyFields,
+      mode: keyFields.length > 0 ? 'upsert' : 'append',
+    }
+  }
+  return objects
+}
+
 function buildStagingSourceObjects(): IntegrationSystemObject[] {
   return stagingDescriptors.value.flatMap((descriptor) => {
     const target = stagingOpenTargetById.value.get(descriptor.id)
@@ -949,6 +995,20 @@ function buildStagingSourceObjects(): IntegrationSystemObject[] {
       label: stagingDatasetCopy[descriptor.id]?.name || descriptor.name,
       operations: ['read'],
       source: 'metasheet:staging',
+      schema: descriptorToSchemaFields(descriptor),
+    }]
+  })
+}
+
+function buildStagingTargetObjects(): IntegrationSystemObject[] {
+  return stagingDescriptors.value.flatMap((descriptor) => {
+    const target = stagingOpenTargetById.value.get(descriptor.id)
+    if (!target?.sheetId) return []
+    return [{
+      name: descriptor.id,
+      label: stagingDatasetCopy[descriptor.id]?.name || descriptor.name,
+      operations: ['upsert'],
+      source: 'metasheet:multitable',
       schema: descriptorToSchemaFields(descriptor),
     }]
   })
@@ -1276,6 +1336,61 @@ async function useStagingAsSource(objectId: string): Promise<void> {
       },
     }
     setStatus(`已将 ${stagingDatasetCopy[objectId]?.name || descriptor.name} 设为 Dry-run 来源`, 'success')
+  } catch (error) {
+    setStatus(error instanceof Error ? error.message : String(error), 'error')
+  }
+}
+
+async function useStagingAsTarget(objectId: string): Promise<void> {
+  const descriptor = stagingDescriptors.value.find((item) => item.id === objectId) || null
+  const target = stagingOpenTargetById.value.get(objectId)
+  if (!descriptor || !target?.sheetId) {
+    setStatus('请先创建清洗表，确认该 staging 表已有 sheetId / open link 后再作为写入目标。', 'error')
+    return
+  }
+  const projectId = stagingProjectId.value.trim() || 'default'
+  const objects = buildStagingTargetObjectsConfig()
+  if (!objects[objectId]) {
+    setStatus('当前 staging 表缺少 sheetId，不能作为写入目标。', 'error')
+    return
+  }
+  try {
+    const system = await upsertWorkbenchExternalSystem({
+      ...currentScope(),
+      id: stagingTargetSystemId(projectId),
+      projectId,
+      name: 'MetaSheet 写入多维表',
+      kind: 'metasheet:multitable',
+      role: 'target',
+      status: 'active',
+      config: {
+        projectId,
+        baseId: stagingBaseId.value.trim() || target.baseId || null,
+        objects,
+      },
+      capabilities: {
+        write: true,
+        multitableTarget: true,
+        saveOnly: true,
+      },
+    })
+    replaceSystem(system)
+    targetSystemId.value = system.id
+    targetObjects.value = buildStagingTargetObjects()
+    targetObjectName.value = objectId
+    targetSchema.value = {
+      object: objectId,
+      fields: descriptorToSchemaFields(descriptor),
+      raw: {
+        sheetId: target.sheetId,
+        viewId: target.viewId,
+        openLink: target.openLink,
+        keyFields: objects[objectId].keyFields || [],
+        mode: objects[objectId].mode || 'append',
+      },
+    }
+    seedMappingsFromTargetSchema(targetSchema.value.fields)
+    setStatus(`已将 ${stagingDatasetCopy[objectId]?.name || descriptor.name} 设为写入目标`, 'success')
   } catch (error) {
     setStatus(error instanceof Error ? error.message : String(error), 'error')
   }

--- a/apps/web/tests/IntegrationWorkbenchView.spec.ts
+++ b/apps/web/tests/IntegrationWorkbenchView.spec.ts
@@ -76,6 +76,7 @@ describe('IntegrationWorkbenchView', () => {
           { kind: 'http', label: 'HTTP API', roles: ['bidirectional'], supports: ['read', 'upsert'], advanced: false },
           { kind: 'erp:k3-wise-sqlserver', label: 'K3 WISE SQL Server Channel', roles: ['source', 'target'], supports: ['read'], advanced: true },
           { kind: 'metasheet:staging', label: 'MetaSheet staging multitable', roles: ['source'], supports: ['read'], advanced: false },
+          { kind: 'metasheet:multitable', label: 'MetaSheet multitable', roles: ['target'], supports: ['upsert'], advanced: false },
         ])
       }
       if (url === '/api/integration/external-systems?tenantId=default') {
@@ -383,7 +384,7 @@ describe('IntegrationWorkbenchView', () => {
     expect(container.textContent).toContain('数据工厂')
     expect(container.textContent).toContain('连接新系统')
     expect(container.textContent).toContain('使用 K3 WISE 预设')
-    expect(container.textContent).toContain('已加载 4 个连接 · 3 个适配器 · 3 个 staging 表')
+    expect(container.textContent).toContain('已加载 4 个连接 · 4 个适配器 · 3 个 staging 表')
     expect(container.textContent).toContain('连接系统')
     expect(container.textContent).toContain('选择数据集')
     expect(container.textContent).toContain('多维表清洗')
@@ -617,6 +618,41 @@ describe('IntegrationWorkbenchView', () => {
       },
     })
     expect(container.textContent).toContain('Save-only 推送已提交')
+
+    ;(container.querySelector('[data-testid="use-staging-target-bom_cleanse"]') as HTMLButtonElement).click()
+    await flushUi(10)
+    expect(externalSystemBodies).toHaveLength(2)
+    expect(externalSystemBodies[1]).toMatchObject({
+      id: 'metasheet_target_project_1',
+      tenantId: 'default',
+      workspaceId: null,
+      projectId: 'project_1',
+      name: 'MetaSheet 写入多维表',
+      kind: 'metasheet:multitable',
+      role: 'target',
+      status: 'active',
+      capabilities: {
+        write: true,
+        multitableTarget: true,
+        saveOnly: true,
+      },
+    })
+    expect(externalSystemBodies[1].config).toMatchObject({
+      projectId: 'project_1',
+      objects: {
+        bom_cleanse: {
+          sheetId: 'sheet_bom',
+          viewId: 'view_bom',
+          openLink: '/multitable/sheet_bom/view_bom',
+          fields: ['parentCode', 'childCode', 'quantity'],
+          keyFields: ['parentCode', 'childCode'],
+          mode: 'upsert',
+        },
+      },
+    })
+    expect((container.querySelector('[data-testid="target-system"]') as HTMLSelectElement).value).toBe('metasheet_target_project_1')
+    expect((container.querySelector('[data-testid="target-object"]') as HTMLSelectElement).value).toBe('bom_cleanse')
+    expect(container.textContent).toContain('已将 BOM 清洗 设为写入目标')
   })
 
   it('shows actionable source-empty and dry-run readiness guidance when no readable source exists', async () => {

--- a/docs/development/data-factory-staging-target-action-development-20260514.md
+++ b/docs/development/data-factory-staging-target-action-development-20260514.md
@@ -1,0 +1,69 @@
+# Data Factory staging target action - development notes - 2026-05-14
+
+## Purpose
+
+This slice completes the local multitable side of the Data Factory workflow:
+
+```text
+source system -> staging multitable -> dry-run -> target system / target multitable
+```
+
+PR #1550 added `metasheet:staging` as a read-only source. PR #1553 added
+`metasheet:multitable` as a target-only adapter. This change exposes the target
+adapter in the workbench UI so an operator can choose an installed cleansing
+table as a write destination without hand-editing external system JSON.
+
+## UI behavior
+
+Each installed staging card now has three actions:
+
+- `打开多维表` opens the business cleansing table.
+- `作为 Dry-run 来源` configures the table through `metasheet:staging`.
+- `作为写入目标` configures the table through `metasheet:multitable`.
+
+The target action upserts a deterministic external system:
+
+```text
+metasheet_target_<projectId>
+```
+
+The generated system is target-only:
+
+```json
+{
+  "kind": "metasheet:multitable",
+  "role": "target",
+  "capabilities": {
+    "write": true,
+    "multitableTarget": true,
+    "saveOnly": true
+  }
+}
+```
+
+## Target object config
+
+The workbench builds target object config from the existing staging descriptors
+and open links returned by `/api/integration/staging/install`.
+
+For stable business tables, the UI supplies key fields:
+
+- `standard_materials`: `["code"]`
+- `bom_cleanse`: `["parentCode", "childCode"]`
+- any descriptor with `externalId`: `["externalId"]`
+- any descriptor with `id`: `["id"]`
+
+When no stable key can be inferred, the target object uses `append` mode. This
+keeps logging/exception-style tables usable while avoiding fake upsert keys.
+
+## Boundaries
+
+- No new migration.
+- No backend route change.
+- No arbitrary user-table permission design.
+- No live K3 Submit / Audit behavior change.
+- No raw SQL or JavaScript authoring surface.
+
+The action only configures the already-merged `metasheet:multitable` adapter.
+Actual writes still pass through the plugin-scoped multitable records API and
+the normal pipeline dry-run / Save-only controls.

--- a/docs/development/data-factory-staging-target-action-verification-20260514.md
+++ b/docs/development/data-factory-staging-target-action-verification-20260514.md
@@ -1,0 +1,114 @@
+# Data Factory staging target action - verification - 2026-05-14
+
+## Scope
+
+This verification covers the Data Factory workbench UI action that turns an
+installed staging multitable into a `metasheet:multitable` target system.
+
+It does not validate arbitrary user-owned table permissions or live K3 writes.
+
+## Checks
+
+### Frontend workbench test
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/IntegrationWorkbenchView.spec.ts --watch=false
+```
+
+Expected coverage:
+
+- adapter inventory includes `metasheet:multitable`;
+- installed staging cards render `作为写入目标`;
+- clicking the action posts a `metasheet:multitable` external system;
+- generated target config includes `sheetId`, `viewId`, `openLink`, fields,
+  inferred key fields, and write mode;
+- the target select and target object select switch to the generated MetaSheet
+  target system;
+- existing K3 target object loading still works after switching back.
+
+Result: PASS.
+
+### Frontend integration service test
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/integrationWorkbench.spec.ts --watch=false
+```
+
+Expected coverage:
+
+- `upsertWorkbenchExternalSystem()` still posts through the existing
+  `/api/integration/external-systems` endpoint;
+- staging source service behavior remains unchanged.
+
+Result: PASS.
+
+### Frontend build
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Expected coverage:
+
+- Vue template and TypeScript checks compile;
+- the Data Factory workbench bundle is emitted successfully.
+
+Result: PASS.
+
+Observed note: Vite reported the existing large-chunk warning. The build exited
+`0`.
+
+### Backend plugin regression
+
+Command:
+
+```bash
+pnpm -F plugin-integration-core test
+```
+
+Expected coverage:
+
+- `metasheet:staging` remains registered as source-only;
+- `metasheet:multitable` remains registered as target-only;
+- adapter metadata and runtime smoke still assert both adapter kinds.
+
+Result: PASS.
+
+### K3 offline PoC regression
+
+Command:
+
+```bash
+pnpm verify:integration-k3wise:poc
+```
+
+Expected coverage:
+
+- K3 WISE Material/BOM mock chain remains PASS;
+- the MetaSheet target UI action does not change K3 WebAPI behavior.
+
+Result: PASS.
+
+### Diff hygiene
+
+Command:
+
+```bash
+git diff --check origin/main...HEAD
+```
+
+Result: PASS.
+
+## Manual review checklist
+
+- No migration added.
+- No secret values added.
+- K3 WISE remains a preset, not the whole product surface.
+- SQL channel remains an advanced connector.
+- Save-only remains explicit and Submit / Audit remains opt-in.


### PR DESCRIPTION
## Summary

Adds a Data Factory workbench action that turns an installed staging multitable into a `metasheet:multitable` write target. This completes the local table-to-table operator path after #1550 and #1553:

- `打开多维表` remains the normal business cleansing entry.
- `作为 Dry-run 来源` configures `metasheet:staging` for read-only dry-run source data.
- `作为写入目标` configures `metasheet:multitable` for Save-only target output.

## Implementation

- Generates a deterministic target external system id: `metasheet_target_<projectId>`.
- Builds target object config from staging descriptors and open links.
- Infers stable target key fields for common cleansing tables:
  - `standard_materials` -> `code`
  - `bom_cleanse` -> `parentCode`, `childCode`
  - fallback `externalId` / `id`, otherwise append mode
- Keeps writes behind the existing pipeline dry-run / Save-only controls.

## Verification

- `pnpm --filter @metasheet/web exec vitest run tests/IntegrationWorkbenchView.spec.ts --watch=false` PASS
- `pnpm --filter @metasheet/web exec vitest run tests/integrationWorkbench.spec.ts --watch=false` PASS
- `pnpm --filter @metasheet/web build` PASS
- `pnpm -F plugin-integration-core test` PASS
- `pnpm verify:integration-k3wise:poc` PASS
- `git diff --check origin/main...HEAD` PASS

## Docs

- `docs/development/data-factory-staging-target-action-development-20260514.md`
- `docs/development/data-factory-staging-target-action-verification-20260514.md`

## Deployment impact

No migration, no backend route change, no K3 Submit/Audit behavior change. Frontend-only operator action plus docs/tests.
