### PR TITLE
feat(integration): expose multitable target in workbench

### DIFF
--- a/apps/web/src/services/integration/workbench.ts
+++ b/apps/web/src/services/integration/workbench.ts
@@ -80,6 +80,7 @@ export interface IntegrationSystemObject {
   label?: string
   operations?: string[]
   source?: string
+  target?: string
   schema?: IntegrationObjectSchemaField[]
   template?: Record<string, unknown>
   advanced?: boolean

--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -299,10 +299,10 @@
               type="button"
               class="integration-workbench__button"
               :disabled="!descriptor.openLink"
-              :data-testid="`use-staging-target-${descriptor.id}`"
+              :data-testid="`use-multitable-target-${descriptor.id}`"
               @click="useStagingAsTarget(descriptor.id)"
             >
-              作为写入目标
+              作为目标多维表
             </button>
           </div>
         </article>
@@ -916,7 +916,7 @@ function stagingSourceSystemId(projectId: string): string {
   return `metasheet_staging_${suffix}`
 }
 
-function stagingTargetSystemId(projectId: string): string {
+function multitableTargetSystemId(projectId: string): string {
   const suffix = (projectId || 'default').replace(/[^A-Za-z0-9_-]+/g, '_').replace(/^_+|_+$/g, '') || 'default'
   return `metasheet_target_${suffix}`
 }
@@ -938,12 +938,14 @@ function descriptorToSchemaFields(descriptor: IntegrationStagingDescriptor | nul
   }))
 }
 
-function defaultTargetKeyFields(descriptor: IntegrationStagingDescriptor): string[] {
-  const fields = new Set(descriptor.fields)
-  if (descriptor.id === 'bom_cleanse' && fields.has('parentCode') && fields.has('childCode')) return ['parentCode', 'childCode']
-  if (fields.has('code')) return ['code']
-  if (fields.has('externalId')) return ['externalId']
-  if (fields.has('id')) return ['id']
+function defaultMultitableTargetKeyFields(descriptor: IntegrationStagingDescriptor): string[] {
+  const fieldNames = new Set(descriptorToSchemaFields(descriptor).map((field) => field.name))
+  if (fieldNames.has('code')) return ['code']
+  if (fieldNames.has('parentCode') && fieldNames.has('childCode')) {
+    return ['parentCode', 'childCode', ...(fieldNames.has('sequence') ? ['sequence'] : [])]
+  }
+  if (fieldNames.has('externalId')) return ['externalId']
+  if (fieldNames.has('id')) return ['id']
   return []
 }
 
@@ -965,12 +967,12 @@ function buildStagingSourceObjectsConfig(): Record<string, StagingObjectConfig> 
   return objects
 }
 
-function buildStagingTargetObjectsConfig(): Record<string, StagingObjectConfig> {
+function buildMultitableTargetObjectsConfig(): Record<string, StagingObjectConfig> {
   const objects: Record<string, StagingObjectConfig> = {}
   for (const descriptor of stagingDescriptors.value) {
     const target = stagingOpenTargetById.value.get(descriptor.id)
     if (!target?.sheetId) continue
-    const keyFields = defaultTargetKeyFields(descriptor)
+    const keyFields = defaultMultitableTargetKeyFields(descriptor)
     objects[descriptor.id] = {
       name: stagingDatasetCopy[descriptor.id]?.name || descriptor.name,
       sheetId: target.sheetId,
@@ -1000,7 +1002,7 @@ function buildStagingSourceObjects(): IntegrationSystemObject[] {
   })
 }
 
-function buildStagingTargetObjects(): IntegrationSystemObject[] {
+function buildMultitableTargetObjects(): IntegrationSystemObject[] {
   return stagingDescriptors.value.flatMap((descriptor) => {
     const target = stagingOpenTargetById.value.get(descriptor.id)
     if (!target?.sheetId) return []
@@ -1008,7 +1010,7 @@ function buildStagingTargetObjects(): IntegrationSystemObject[] {
       name: descriptor.id,
       label: stagingDatasetCopy[descriptor.id]?.name || descriptor.name,
       operations: ['upsert'],
-      source: 'metasheet:multitable',
+      target: 'metasheet:multitable',
       schema: descriptorToSchemaFields(descriptor),
     }]
   })
@@ -1345,21 +1347,22 @@ async function useStagingAsTarget(objectId: string): Promise<void> {
   const descriptor = stagingDescriptors.value.find((item) => item.id === objectId) || null
   const target = stagingOpenTargetById.value.get(objectId)
   if (!descriptor || !target?.sheetId) {
-    setStatus('请先创建清洗表，确认该 staging 表已有 sheetId / open link 后再作为写入目标。', 'error')
+    setStatus('请先创建清洗表，确认该多维表已有 sheetId / open link 后再作为目标。', 'error')
     return
   }
   const projectId = stagingProjectId.value.trim() || 'default'
-  const objects = buildStagingTargetObjectsConfig()
-  if (!objects[objectId]) {
-    setStatus('当前 staging 表缺少 sheetId，不能作为写入目标。', 'error')
+  const objects = buildMultitableTargetObjectsConfig()
+  const objectConfig = objects[objectId]
+  if (!objectConfig) {
+    setStatus('当前多维表缺少 sheetId，不能作为写回目标。', 'error')
     return
   }
   try {
     const system = await upsertWorkbenchExternalSystem({
       ...currentScope(),
-      id: stagingTargetSystemId(projectId),
+      id: multitableTargetSystemId(projectId),
       projectId,
-      name: 'MetaSheet 写入多维表',
+      name: 'MetaSheet 目标多维表',
       kind: 'metasheet:multitable',
       role: 'target',
       status: 'active',
@@ -1371,12 +1374,13 @@ async function useStagingAsTarget(objectId: string): Promise<void> {
       capabilities: {
         write: true,
         multitableTarget: true,
-        saveOnly: true,
+        append: true,
+        upsert: true,
       },
     })
     replaceSystem(system)
     targetSystemId.value = system.id
-    targetObjects.value = buildStagingTargetObjects()
+    targetObjects.value = buildMultitableTargetObjects()
     targetObjectName.value = objectId
     targetSchema.value = {
       object: objectId,
@@ -1385,12 +1389,12 @@ async function useStagingAsTarget(objectId: string): Promise<void> {
         sheetId: target.sheetId,
         viewId: target.viewId,
         openLink: target.openLink,
-        keyFields: objects[objectId].keyFields || [],
-        mode: objects[objectId].mode || 'append',
+        keyFields: objectConfig.keyFields || [],
+        mode: objectConfig.mode || 'append',
       },
     }
-    seedMappingsFromTargetSchema(targetSchema.value.fields)
-    setStatus(`已将 ${stagingDatasetCopy[objectId]?.name || descriptor.name} 设为写入目标`, 'success')
+    if (mappings.value.length === 0) seedMappingsFromTargetSchema(targetSchema.value.fields)
+    setStatus(`已将 ${stagingDatasetCopy[objectId]?.name || descriptor.name} 设为写回目标`, 'success')
   } catch (error) {
     setStatus(error instanceof Error ? error.message : String(error), 'error')
   }

--- a/apps/web/tests/IntegrationWorkbenchView.spec.ts
+++ b/apps/web/tests/IntegrationWorkbenchView.spec.ts
@@ -76,7 +76,7 @@ describe('IntegrationWorkbenchView', () => {
           { kind: 'http', label: 'HTTP API', roles: ['bidirectional'], supports: ['read', 'upsert'], advanced: false },
           { kind: 'erp:k3-wise-sqlserver', label: 'K3 WISE SQL Server Channel', roles: ['source', 'target'], supports: ['read'], advanced: true },
           { kind: 'metasheet:staging', label: 'MetaSheet staging multitable', roles: ['source'], supports: ['read'], advanced: false },
-          { kind: 'metasheet:multitable', label: 'MetaSheet multitable', roles: ['target'], supports: ['upsert'], advanced: false },
+          { kind: 'metasheet:multitable', label: 'MetaSheet multitable', roles: ['target'], supports: ['testConnection', 'listObjects', 'getSchema', 'upsert'], advanced: false },
         ])
       }
       if (url === '/api/integration/external-systems?tenantId=default') {
@@ -395,6 +395,7 @@ describe('IntegrationWorkbenchView', () => {
     expect(container.textContent).toContain('BOM 清洗')
     expect(container.textContent).toContain('回写区')
     expect(container.textContent).toContain('HTTP API')
+    expect(container.textContent).toContain('MetaSheet multitable')
     expect(container.textContent).not.toContain('K3 WISE SQL Server Channel')
     expect(container.textContent).toContain('已隐藏 1 个高级连接')
     expect((container.querySelector('[data-testid="staging-sheet"]') as HTMLSelectElement).value).toBe('standard_materials')
@@ -619,7 +620,7 @@ describe('IntegrationWorkbenchView', () => {
     })
     expect(container.textContent).toContain('Save-only 推送已提交')
 
-    ;(container.querySelector('[data-testid="use-staging-target-bom_cleanse"]') as HTMLButtonElement).click()
+    ;(container.querySelector('[data-testid="use-multitable-target-standard_materials"]') as HTMLButtonElement).click()
     await flushUi(10)
     expect(externalSystemBodies).toHaveLength(2)
     expect(externalSystemBodies[1]).toMatchObject({
@@ -627,32 +628,33 @@ describe('IntegrationWorkbenchView', () => {
       tenantId: 'default',
       workspaceId: null,
       projectId: 'project_1',
-      name: 'MetaSheet 写入多维表',
+      name: 'MetaSheet 目标多维表',
       kind: 'metasheet:multitable',
       role: 'target',
       status: 'active',
       capabilities: {
         write: true,
         multitableTarget: true,
-        saveOnly: true,
+        append: true,
+        upsert: true,
       },
     })
     expect(externalSystemBodies[1].config).toMatchObject({
       projectId: 'project_1',
       objects: {
-        bom_cleanse: {
-          sheetId: 'sheet_bom',
-          viewId: 'view_bom',
-          openLink: '/multitable/sheet_bom/view_bom',
-          fields: ['parentCode', 'childCode', 'quantity'],
-          keyFields: ['parentCode', 'childCode'],
+        standard_materials: {
+          sheetId: 'sheet_materials',
+          viewId: 'view_materials',
+          openLink: '/multitable/sheet_materials/view_materials',
+          fields: ['code', 'name'],
+          keyFields: ['code'],
           mode: 'upsert',
         },
       },
     })
     expect((container.querySelector('[data-testid="target-system"]') as HTMLSelectElement).value).toBe('metasheet_target_project_1')
-    expect((container.querySelector('[data-testid="target-object"]') as HTMLSelectElement).value).toBe('bom_cleanse')
-    expect(container.textContent).toContain('已将 BOM 清洗 设为写入目标')
+    expect((container.querySelector('[data-testid="target-object"]') as HTMLSelectElement).value).toBe('standard_materials')
+    expect(container.textContent).toContain('已将 物料清洗 设为写回目标')
   })
 
   it('shows actionable source-empty and dry-run readiness guidance when no readable source exists', async () => {

--- a/docs/development/data-factory-multitable-ui-development-20260514.md
+++ b/docs/development/data-factory-multitable-ui-development-20260514.md
@@ -1,0 +1,74 @@
+# Data Factory multitable UI entry - development notes - 2026-05-14
+
+## Purpose
+
+This slice makes the newly merged MetaSheet multitable adapters visible from the
+Data Factory workbench.
+
+The previous backend slices added:
+
+- `metasheet:staging` as a source-only adapter for reading cleaned staging
+  multitables;
+- `metasheet:multitable` as a target-only adapter for writing cleansed output
+  back into plugin-scoped multitables.
+
+This change closes the operator-facing gap by allowing a staging multitable card
+to be registered either as a dry-run source or as a multitable write target.
+
+## UX behavior
+
+Each installed staging dataset card now exposes three actions:
+
+- open the multitable;
+- use it as the dry-run source;
+- use it as the target multitable.
+
+The new target action creates or updates an external system with:
+
+- `kind: metasheet:multitable`;
+- `role: target`;
+- `status: active`;
+- `capabilities.write: true`;
+- `capabilities.multitableTarget: true`;
+- object configs derived from the installed staging descriptors and returned
+  sheet/view/open-link metadata.
+
+The target selector is updated immediately after the external system is saved,
+and the target object/schema is hydrated from the descriptor so the operator can
+continue into mapping, preview, dry-run, and save-only execution without
+manually typing target object ids.
+
+## Target object defaults
+
+The UI derives conservative write defaults from descriptor fields:
+
+- descriptors with `code` use keyed `upsert` on `code`;
+- BOM-like descriptors with `parentCode` and `childCode` use keyed `upsert`
+  on those fields, plus `sequence` when available;
+- descriptors with `externalId` or `id` use that field as the key;
+- descriptors without a stable key use append mode.
+
+These defaults match the target adapter contract: configured object key fields
+win over the runner's internal idempotency key, while `_integration_*` fields
+remain filtered by the adapter unless an object explicitly opts into them.
+
+## Files changed
+
+- `apps/web/src/views/IntegrationWorkbenchView.vue`
+  - added the target registration action;
+  - added target-system id generation;
+  - added target object config builders;
+  - hydrated the target selector/object/schema after registration.
+- `apps/web/src/services/integration/workbench.ts`
+  - added optional `target` metadata on discovered objects.
+- `apps/web/tests/IntegrationWorkbenchView.spec.ts`
+  - covered visible `metasheet:multitable` adapter metadata;
+  - covered target external-system payload shape and selected target state.
+
+## Non-goals
+
+- No backend API shape change.
+- No new migration.
+- No arbitrary user-owned sheet write permission.
+- No formula/expert-mode mapping editor.
+- No live external-system run in this slice.

--- a/docs/development/data-factory-multitable-ui-verification-20260514.md
+++ b/docs/development/data-factory-multitable-ui-verification-20260514.md
@@ -1,0 +1,189 @@
+# Data Factory multitable UI entry - verification - 2026-05-14
+
+## Scope
+
+This verification covers the Data Factory workbench UI entry for local
+MetaSheet multitable source/target flows.
+
+Validated behavior:
+
+- adapter inventory renders `metasheet:multitable`;
+- installed staging cards expose a target registration action;
+- target registration writes an external system using `kind:
+  metasheet:multitable` and `role: target`;
+- generated object config includes sheet/view/open-link metadata, field
+  projection, key fields, and write mode;
+- target selector and target object selector are updated after registration.
+
+## Commands
+
+### Frontend targeted spec
+
+Command:
+
+```bash
+NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/IntegrationWorkbenchView.spec.ts --watch=false
+```
+
+Expected:
+
+- the existing Data Factory workbench flow remains green;
+- the new target action creates `metasheet_target_<projectId>`;
+- the target object defaults to the selected staging descriptor;
+- the external-system payload keeps `metasheet:staging` and
+  `metasheet:multitable` as separate source and target systems.
+
+Result: PASS.
+
+Observed output:
+
+```text
+✓ tests/IntegrationWorkbenchView.spec.ts  (3 tests) 201ms
+Test Files  1 passed (1)
+Tests  3 passed (3)
+```
+
+Environment note: Vitest printed `WebSocket server error: Port is already in
+use`, but the targeted suite completed with `rc=0`.
+
+### Service targeted spec
+
+Command:
+
+```bash
+NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/integrationWorkbench.spec.ts --watch=false
+```
+
+Expected:
+
+- service URL construction and external-system upsert behavior remain stable;
+- the added optional object `target` field is type-level only and does not
+  change existing request paths.
+
+Result: PASS.
+
+Observed output:
+
+```text
+✓ tests/integrationWorkbench.spec.ts  (2 tests) 5ms
+Test Files  1 passed (1)
+Tests  2 passed (2)
+```
+
+### Plugin metadata and adapter contract checks
+
+Commands:
+
+```bash
+pnpm -F plugin-integration-core test:http-routes
+pnpm -F plugin-integration-core test:metasheet-staging-source
+pnpm -F plugin-integration-core test:metasheet-multitable-target
+```
+
+Expected:
+
+- `/api/integration/adapters` still exposes both `metasheet:staging` and
+  `metasheet:multitable`;
+- staging remains read-only;
+- multitable target remains write-only and supports append/upsert.
+
+Result: PASS.
+
+Observed output:
+
+```text
+http-routes: REST auth/list/upsert/run/dry-run/staging/replay tests passed
+✓ metasheet-staging-source-adapter: read-only multitable source tests passed
+✓ metasheet-multitable-target-adapter: write-only multitable target tests passed
+```
+
+### Type check
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web type-check
+```
+
+Expected:
+
+- `IntegrationSystemObject.target` is accepted by Vue workbench code;
+- no regressions in existing web type surfaces.
+
+Result: PASS.
+
+Observed output:
+
+```text
+> @metasheet/web@2.0.0-alpha.1 type-check apps/web
+> vue-tsc -b
+```
+
+### Frontend production build
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Expected:
+
+- Vue type check and Vite production build complete;
+- Data Factory workbench bundle compiles with the new target action.
+
+Result: PASS.
+
+Observed output:
+
+```text
+> vue-tsc -b && vite build
+✓ 2389 modules transformed.
+✓ built in 6.53s
+```
+
+Environment note: Vite reported existing large chunk and dynamic/static import
+warnings. The build completed with `rc=0`.
+
+### K3 WISE mock PoC regression
+
+Command:
+
+```bash
+pnpm verify:integration-k3wise:poc
+```
+
+Expected:
+
+- Save-only K3 mock chain remains PASS;
+- adding a local multitable target UI entry does not change K3 preset safety.
+
+Result: PASS.
+
+Observed output:
+
+```text
+✓ step 6: K3 Save-only upsert wrote 2 records, 0 Submit, 0 Audit (PoC safety preserved)
+✓ step 8-9: evidence compiler returned PASS with 0 issues
+✓ K3 WISE PoC mock chain verified end-to-end (PASS)
+```
+
+### Diff hygiene
+
+Command:
+
+```bash
+git diff --check
+```
+
+Expected: PASS.
+
+Result: PASS.
+
+## Manual checklist
+
+- `metasheet:staging` remains source-only in the UI flow.
+- `metasheet:multitable` is used only as a target connection.
+- The UI still tells operators to dry-run before save-only push.
+- The new target action does not expose SQL advanced connectors by default.
+- No secrets, tokens, or live credentials are added to docs or tests.


### PR DESCRIPTION
## Summary
- add a Data Factory workbench action to register installed staging multitables as `metasheet:multitable` targets
- hydrate target system/object/schema selection after registration so operators can continue into mapping, preview, dry-run, and save-only execution
- document the development and verification evidence for the UI entry slice

## Verification
- NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/IntegrationWorkbenchView.spec.ts --watch=false
- NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/integrationWorkbench.spec.ts --watch=false
- pnpm -F plugin-integration-core test:http-routes
- pnpm -F plugin-integration-core test:metasheet-staging-source
- pnpm -F plugin-integration-core test:metasheet-multitable-target
- pnpm --filter @metasheet/web type-check
- pnpm --filter @metasheet/web build
- pnpm verify:integration-k3wise:poc
- git diff --check