### PR TITLE
test(integration): smoke data factory adapter discovery

### DIFF
--- a/docs/development/data-factory-adapter-discovery-postdeploy-development-20260514.md
+++ b/docs/development/data-factory-adapter-discovery-postdeploy-development-20260514.md
@@ -1,0 +1,71 @@
+# Data Factory adapter discovery postdeploy smoke - development notes - 2026-05-14
+
+## Purpose
+
+This slice extends the existing K3 WISE postdeploy smoke with a Data Factory
+adapter discovery check.
+
+The deployed smoke already verifies the frontend Data Factory route and the
+authenticated integration status contract. This change adds one more
+authenticated probe:
+
+```text
+GET /api/integration/adapters
+```
+
+The goal is to catch deployments where the Data Factory UI is reachable but the
+local MetaSheet adapters needed for multitable cleansing flows are missing or
+mis-described.
+
+## Contract Checked
+
+The smoke now verifies the minimum stable metadata for:
+
+- `metasheet:staging`
+  - has `source` role;
+  - is not marked advanced;
+  - declares host-owned, dry-run friendly, no-external-network read guardrails;
+  - declares `guardrails.write.supported: false`.
+- `metasheet:multitable`
+  - has `target` role;
+  - is not marked advanced;
+  - supports `testConnection`, `listObjects`, `getSchema`, and `upsert`;
+  - declares read unsupported;
+  - declares host-owned, plugin-scoped write guardrails with append and keyed
+    upsert support.
+
+The smoke intentionally does not require the staging adapter's exact `supports`
+list. That keeps this slice independent from the narrower metadata hygiene PR
+that makes staging supports explicitly read-only. The read-only staging contract
+is enforced through `roles` and `guardrails.write.supported: false`.
+
+## Files Changed
+
+- `scripts/ops/integration-k3wise-postdeploy-smoke.mjs`
+  - added `metasheet:staging` and `metasheet:multitable` to required runtime
+    adapters;
+  - added `/api/integration/adapters` to required integration routes;
+  - added `data-factory-adapter-discovery` authenticated smoke check;
+  - added metadata validation for Data Factory multitable adapters.
+- `scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs`
+  - added fake adapter discovery responses;
+  - asserted the new pass check in authenticated smoke evidence;
+  - added a failure case for lost staging write guardrails.
+- `scripts/ops/multitable-onprem-package-build.sh`
+  - includes this development/verification note in the Windows on-prem package.
+- `scripts/ops/multitable-onprem-package-verify.sh`
+  - checks the packaged smoke script still contains the adapter discovery
+    smoke check;
+  - verifies this document pair is included in the package.
+
+## Deployment Impact
+
+- No backend route change.
+- No migration.
+- No live K3 call.
+- No SQL call.
+- No write operation.
+- Existing public unauthenticated smoke behavior is unchanged.
+
+Authenticated postdeploy smoke now fails if the deployed integration plugin
+does not expose the Data Factory multitable adapter metadata needed by the UI.

--- a/docs/development/data-factory-adapter-discovery-postdeploy-verification-20260514.md
+++ b/docs/development/data-factory-adapter-discovery-postdeploy-verification-20260514.md
@@ -1,0 +1,93 @@
+# Data Factory adapter discovery postdeploy smoke - verification - 2026-05-14
+
+## Scope
+
+This verification covers the postdeploy smoke extension for Data Factory
+adapter discovery.
+
+Validated behavior:
+
+- authenticated smoke calls `/api/integration/adapters`;
+- smoke evidence includes `data-factory-adapter-discovery`;
+- `metasheet:staging` is validated as the source-side multitable adapter;
+- `metasheet:multitable` is validated as the target-side multitable adapter;
+- a missing or unsafe guardrail causes the smoke to fail.
+- the Windows on-prem package scripts include and verify this smoke evidence.
+
+## Commands
+
+### Smoke unit test
+
+Command:
+
+```bash
+node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
+```
+
+Expected:
+
+- public smoke remains unchanged and still skips authenticated checks without a
+  token;
+- authenticated smoke now records the adapter discovery check;
+- failure evidence remains redacted;
+- metadata drift in Data Factory multitable adapters fails the smoke.
+
+Result: PASS.
+
+Observed output:
+
+```text
+✔ authenticated postdeploy smoke validates route and staging contracts without leaking token
+✔ authenticated postdeploy smoke fails when Data Factory adapter metadata loses staging write guardrails
+ℹ tests 17
+ℹ pass 17
+```
+
+### K3 WISE mock PoC regression
+
+Command:
+
+```bash
+pnpm verify:integration-k3wise:poc
+```
+
+Expected:
+
+- Save-only K3 mock chain remains PASS;
+- adding a read-only adapter discovery smoke does not change K3 execution.
+
+Result: PASS.
+
+Observed output:
+
+```text
+✓ step 6: K3 Save-only upsert wrote 2 records, 0 Submit, 0 Audit (PoC safety preserved)
+✓ step 8-9: evidence compiler returned PASS with 0 issues
+✓ K3 WISE PoC mock chain verified end-to-end (PASS)
+```
+
+### Script syntax and diff hygiene
+
+Commands:
+
+```bash
+node --check scripts/ops/integration-k3wise-postdeploy-smoke.mjs
+node --check scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
+bash -n scripts/ops/multitable-onprem-package-build.sh
+bash -n scripts/ops/multitable-onprem-package-verify.sh
+git diff --check
+```
+
+Expected: PASS.
+
+Result: PASS.
+
+## Manual Checklist
+
+- No bearer token is printed to stdout, stderr, JSON evidence, or Markdown
+  evidence.
+- No live external write is performed by the new check.
+- The check requires only stable roles and guardrails, not staging's exact
+  supports list.
+- The on-prem package verifier checks the smoke script for
+  `data-factory-adapter-discovery`.

--- a/scripts/ops/integration-k3wise-postdeploy-smoke.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-smoke.mjs
@@ -10,9 +10,12 @@ const REQUIRED_ADAPTERS = [
   'plm:yuantus-wrapper',
   'erp:k3-wise-webapi',
   'erp:k3-wise-sqlserver',
+  'metasheet:staging',
+  'metasheet:multitable',
 ]
 const REQUIRED_ROUTES = [
   ['GET', '/api/integration/status'],
+  ['GET', '/api/integration/adapters'],
   ['GET', '/api/integration/external-systems'],
   ['POST', '/api/integration/external-systems'],
   ['GET', '/api/integration/external-systems/:id'],
@@ -28,6 +31,38 @@ const REQUIRED_ROUTES = [
   ['GET', '/api/integration/staging/descriptors'],
   ['POST', '/api/integration/staging/install'],
 ]
+const REQUIRED_DATA_FACTORY_ADAPTER_METADATA = {
+  'metasheet:staging': {
+    roles: ['source'],
+    advanced: false,
+    guardrails: {
+      read: {
+        hostOwned: true,
+        dryRunFriendly: true,
+        noExternalNetwork: true,
+      },
+      write: {
+        supported: false,
+      },
+    },
+  },
+  'metasheet:multitable': {
+    roles: ['target'],
+    supports: ['testConnection', 'listObjects', 'getSchema', 'upsert'],
+    advanced: false,
+    guardrails: {
+      read: {
+        supported: false,
+      },
+      write: {
+        hostOwned: true,
+        pluginScopedSheetsOnly: true,
+        supportsAppend: true,
+        supportsUpsertByKey: true,
+      },
+    },
+  },
+}
 const CONTROL_PLANE_LIST_PROBES = [
   ['integration-list-external-systems', '/api/integration/external-systems'],
   ['integration-list-pipelines', '/api/integration/pipelines'],
@@ -412,6 +447,81 @@ function assertStatusRoutes(statusBody) {
   return { adapters, adaptersChecked: REQUIRED_ADAPTERS.length, routesChecked: REQUIRED_ROUTES.length }
 }
 
+function valueAtPath(value, path) {
+  return path.split('.').reduce((current, segment) => {
+    if (!current || typeof current !== 'object') return undefined
+    return current[segment]
+  }, value)
+}
+
+function addInvalidAdapterField(invalidAdapters, kind, path, message) {
+  if (!invalidAdapters[kind]) invalidAdapters[kind] = {}
+  invalidAdapters[kind][path] = message
+}
+
+function assertArrayIncludes(actual, expected, invalidAdapters, kind, path) {
+  if (!Array.isArray(actual)) {
+    addInvalidAdapterField(invalidAdapters, kind, path, 'expected array')
+    return
+  }
+  const missing = expected.filter((item) => !actual.includes(item))
+  if (missing.length > 0) {
+    addInvalidAdapterField(invalidAdapters, kind, path, `missing ${missing.join(', ')}`)
+  }
+}
+
+function assertBooleanFields(adapter, expectedFields, invalidAdapters, kind, prefix) {
+  for (const [field, expected] of Object.entries(expectedFields || {})) {
+    const path = prefix ? `${prefix}.${field}` : field
+    if (expected && typeof expected === 'object' && !Array.isArray(expected)) {
+      assertBooleanFields(adapter, expected, invalidAdapters, kind, path)
+      continue
+    }
+    const actual = valueAtPath(adapter, path)
+    if (actual !== expected) {
+      addInvalidAdapterField(invalidAdapters, kind, path, `expected ${String(expected)} but got ${String(actual)}`)
+    }
+  }
+}
+
+function assertDataFactoryAdapterDiscovery(body) {
+  const data = body && body.data !== undefined ? body.data : body
+  if (!Array.isArray(data)) {
+    throw new K3WisePostdeploySmokeError('adapter discovery response data must be an array', {
+      received: Array.isArray(data) ? 'array' : typeof data,
+    })
+  }
+  const adaptersByKind = new Map()
+  for (const adapter of data) {
+    if (adapter && typeof adapter.kind === 'string') adaptersByKind.set(adapter.kind, adapter)
+  }
+  const missingAdapters = []
+  const invalidAdapters = {}
+  for (const [kind, expected] of Object.entries(REQUIRED_DATA_FACTORY_ADAPTER_METADATA)) {
+    const adapter = adaptersByKind.get(kind)
+    if (!adapter) {
+      missingAdapters.push(kind)
+      continue
+    }
+    assertArrayIncludes(adapter.roles, expected.roles || [], invalidAdapters, kind, 'roles')
+    if (expected.supports) assertArrayIncludes(adapter.supports, expected.supports, invalidAdapters, kind, 'supports')
+    if (Object.prototype.hasOwnProperty.call(expected, 'advanced') && adapter.advanced !== expected.advanced) {
+      addInvalidAdapterField(invalidAdapters, kind, 'advanced', `expected ${String(expected.advanced)} but got ${String(adapter.advanced)}`)
+    }
+    assertBooleanFields(adapter, expected.guardrails || {}, invalidAdapters, kind, 'guardrails')
+  }
+  if (missingAdapters.length > 0 || Object.keys(invalidAdapters).length > 0) {
+    throw new K3WisePostdeploySmokeError('adapter discovery is missing required Data Factory multitable metadata', {
+      missingAdapters,
+      invalidAdapters,
+    })
+  }
+  return {
+    adapters: Array.from(adaptersByKind.keys()),
+    adaptersChecked: Object.keys(REQUIRED_DATA_FACTORY_ADAPTER_METADATA).length,
+  }
+}
+
 function collectDescriptorFields(descriptor) {
   const fieldIds = new Set()
   const fieldDetailsById = new Map()
@@ -620,6 +730,13 @@ async function runSmoke(opts) {
       checks.push(failResult('integration-route-contract', error))
     }
 
+    try {
+      const adapterDiscovery = await requestJson(opts.baseUrl, '/api/integration/adapters', { token, timeoutMs: opts.timeoutMs })
+      checks.push(result('data-factory-adapter-discovery', 'pass', assertDataFactoryAdapterDiscovery(adapterDiscovery.body)))
+    } catch (error) {
+      checks.push(failResult('data-factory-adapter-discovery', error))
+    }
+
     for (const [id, pathname] of CONTROL_PLANE_LIST_PROBES) {
       try {
         const response = await requestJson(opts.baseUrl, withQuery(pathname, {
@@ -740,6 +857,7 @@ if (entryPath && import.meta.url === entryPath) {
 
 export {
   K3WisePostdeploySmokeError,
+  assertDataFactoryAdapterDiscovery,
   assertStagingDescriptors,
   assertStatusRoutes,
   markdownInlineCode,

--- a/scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
@@ -14,9 +14,12 @@ const DEFAULT_ADAPTERS = [
   'plm:yuantus-wrapper',
   'erp:k3-wise-webapi',
   'erp:k3-wise-sqlserver',
+  'metasheet:staging',
+  'metasheet:multitable',
 ]
 const DEFAULT_ROUTES = [
   ['GET', '/api/integration/status'],
+  ['GET', '/api/integration/adapters'],
   ['GET', '/api/integration/external-systems'],
   ['POST', '/api/integration/external-systems'],
   ['GET', '/api/integration/external-systems/:id'],
@@ -31,6 +34,71 @@ const DEFAULT_ROUTES = [
   ['POST', '/api/integration/dead-letters/:id/replay'],
   ['GET', '/api/integration/staging/descriptors'],
   ['POST', '/api/integration/staging/install'],
+]
+const DEFAULT_ADAPTER_METADATA = [
+  {
+    kind: 'http',
+    label: 'HTTP API',
+    roles: ['source', 'target', 'bidirectional'],
+    supports: ['testConnection', 'listObjects', 'getSchema', 'read', 'upsert'],
+    advanced: false,
+  },
+  {
+    kind: 'plm:yuantus-wrapper',
+    label: 'Yuantus PLM',
+    roles: ['source'],
+    supports: ['testConnection', 'listObjects', 'getSchema', 'read'],
+    advanced: false,
+  },
+  {
+    kind: 'erp:k3-wise-webapi',
+    label: 'K3 WISE WebAPI',
+    roles: ['target'],
+    supports: ['testConnection', 'listObjects', 'getSchema', 'upsert'],
+    advanced: false,
+  },
+  {
+    kind: 'erp:k3-wise-sqlserver',
+    label: 'K3 WISE SQL Server Channel',
+    roles: ['source', 'target'],
+    supports: ['testConnection', 'listObjects', 'getSchema', 'read', 'upsert'],
+    advanced: true,
+  },
+  {
+    kind: 'metasheet:staging',
+    label: 'MetaSheet staging multitable',
+    roles: ['source'],
+    supports: ['testConnection', 'listObjects', 'getSchema', 'read'],
+    advanced: false,
+    guardrails: {
+      read: {
+        hostOwned: true,
+        dryRunFriendly: true,
+        noExternalNetwork: true,
+      },
+      write: {
+        supported: false,
+      },
+    },
+  },
+  {
+    kind: 'metasheet:multitable',
+    label: 'MetaSheet multitable',
+    roles: ['target'],
+    supports: ['testConnection', 'listObjects', 'getSchema', 'upsert'],
+    advanced: false,
+    guardrails: {
+      read: {
+        supported: false,
+      },
+      write: {
+        hostOwned: true,
+        pluginScopedSheetsOnly: true,
+        supportsAppend: true,
+        supportsUpsertByKey: true,
+      },
+    },
+  },
 ]
 const DEFAULT_STAGING_FIELD_DETAILS = {
   plm_raw_items: {
@@ -234,6 +302,18 @@ function createFakeServer(options = {}) {
       return
     }
 
+    if (req.method === 'GET' && url.pathname === '/api/integration/adapters') {
+      if (req.headers.authorization !== 'Bearer test.jwt.token') {
+        sendJson(res, 401, { ok: false, error: { message: 'bad token' } })
+        return
+      }
+      sendJson(res, 200, {
+        ok: true,
+        data: options.integrationAdapterMetadata || DEFAULT_ADAPTER_METADATA,
+      })
+      return
+    }
+
     if (
       req.method === 'GET' &&
       [
@@ -383,6 +463,12 @@ test('authenticated postdeploy smoke validates route and staging contracts witho
     const routeCheck = evidence.checks.find((check) => check.id === 'integration-route-contract')
     assert.equal(routeCheck.status, 'pass')
     assert.equal(routeCheck.routesChecked, DEFAULT_ROUTES.length)
+    assert.equal(routeCheck.adaptersChecked, DEFAULT_ADAPTERS.length)
+    const adapterDiscoveryCheck = evidence.checks.find((check) => check.id === 'data-factory-adapter-discovery')
+    assert.equal(adapterDiscoveryCheck.status, 'pass')
+    assert.equal(adapterDiscoveryCheck.adaptersChecked, 2)
+    assert.ok(adapterDiscoveryCheck.adapters.includes('metasheet:staging'))
+    assert.ok(adapterDiscoveryCheck.adapters.includes('metasheet:multitable'))
     for (const id of [
       'integration-list-external-systems',
       'integration-list-pipelines',
@@ -401,6 +487,7 @@ test('authenticated postdeploy smoke validates route and staging contracts witho
     )
     assert.equal(stagingCheck.fieldDetailsChecked, stagingCheck.fieldsChecked)
     assert.ok(fake.requests.some((request) => request.pathname === '/api/auth/me' && request.authorization === 'Bearer test.jwt.token'))
+    assert.ok(fake.requests.some((request) => request.pathname === '/api/integration/adapters'))
     assert.ok(fake.requests.some((request) => request.pathname === '/api/integration/external-systems'))
     assert.ok(fake.requests.some((request) => request.pathname === '/api/integration/pipelines'))
     assert.ok(fake.requests.some((request) => request.pathname === '/api/integration/runs'))
@@ -543,6 +630,45 @@ test('authenticated postdeploy smoke fails when status omits a required source a
     const routeCheck = evidence.checks.find((check) => check.id === 'integration-route-contract')
     assert.equal(routeCheck.status, 'fail')
     assert.match(routeCheck.error, /missing required adapters or routes/)
+  } finally {
+    await fake.close()
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('authenticated postdeploy smoke fails when Data Factory adapter metadata loses staging write guardrails', async () => {
+  const fake = createFakeServer({
+    integrationAdapterMetadata: DEFAULT_ADAPTER_METADATA.map((adapter) => {
+      if (adapter.kind !== 'metasheet:staging') return adapter
+      return {
+        ...adapter,
+        guardrails: {
+          read: adapter.guardrails.read,
+          write: { supported: true },
+        },
+      }
+    }),
+  })
+  const baseUrl = await fake.listen()
+  const outDir = makeTmpDir()
+  try {
+    const result = await runScript([
+      '--base-url', baseUrl,
+      '--auth-token', 'test.jwt.token',
+      '--require-auth',
+      '--out-dir', outDir,
+    ])
+
+    assert.equal(result.status, 1)
+    const evidence = JSON.parse(readFileSync(path.join(outDir, 'integration-k3wise-postdeploy-smoke.json'), 'utf8'))
+    const adapterCheck = evidence.checks.find((check) => check.id === 'data-factory-adapter-discovery')
+    assert.equal(adapterCheck.status, 'fail')
+    assert.match(adapterCheck.error, /adapter discovery is missing required Data Factory multitable metadata/)
+    assert.deepEqual(adapterCheck.details.invalidAdapters, {
+      'metasheet:staging': {
+        'guardrails.write.supported': 'expected false but got true',
+      },
+    })
   } finally {
     await fake.close()
     rmSync(outDir, { recursive: true, force: true })

--- a/scripts/ops/multitable-onprem-package-build.sh
+++ b/scripts/ops/multitable-onprem-package-build.sh
@@ -77,6 +77,8 @@ REQUIRED_PATHS=(
   "docs/development/data-factory-cleansed-export-verification-20260514.md"
   "docs/development/data-factory-postdeploy-smoke-development-20260514.md"
   "docs/development/data-factory-postdeploy-smoke-verification-20260514.md"
+  "docs/development/data-factory-adapter-discovery-postdeploy-development-20260514.md"
+  "docs/development/data-factory-adapter-discovery-postdeploy-verification-20260514.md"
   "docs/development/onprem-migration-gap-guard-development-20260514.md"
   "docs/development/onprem-migration-gap-guard-verification-20260514.md"
   "docker/app.env.example"

--- a/scripts/ops/multitable-onprem-package-verify.sh
+++ b/scripts/ops/multitable-onprem-package-verify.sh
@@ -105,6 +105,7 @@ function verify_generic_integration_workbench_contract() {
   search_fixed_string '/integrations/k3-wise' "$easy_start" || die "Windows on-prem guide must document the K3 WISE setup route"
   search_fixed_string 'SQL Server is an advanced channel' "$k3_runbook" || die "K3 runbook must document SQL Server as an advanced channel"
   search_fixed_string 'data-factory-frontend-route' "$postdeploy_smoke" || die "postdeploy smoke must check the Data Factory frontend route"
+  search_fixed_string 'data-factory-adapter-discovery' "$postdeploy_smoke" || die "postdeploy smoke must check Data Factory adapter discovery"
 }
 
 function write_optional_report() {
@@ -336,6 +337,8 @@ required=(
   "docs/development/data-factory-cleansed-export-verification-20260514.md"
   "docs/development/data-factory-postdeploy-smoke-development-20260514.md"
   "docs/development/data-factory-postdeploy-smoke-verification-20260514.md"
+  "docs/development/data-factory-adapter-discovery-postdeploy-development-20260514.md"
+  "docs/development/data-factory-adapter-discovery-postdeploy-verification-20260514.md"
   "docs/development/onprem-migration-gap-guard-development-20260514.md"
   "docs/development/onprem-migration-gap-guard-verification-20260514.md"
   "docs/deployment/multitable-platform-rc-notes-20260404.md"


### PR DESCRIPTION
## Summary
- add authenticated postdeploy smoke coverage for Data Factory adapter discovery
- validate `metasheet:staging` and `metasheet:multitable` roles/guardrails through `/api/integration/adapters`
- include adapter discovery smoke docs in the on-prem package build/verify list

## Verification
- `node --check scripts/ops/integration-k3wise-postdeploy-smoke.mjs`
- `node --check scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs`
- `bash -n scripts/ops/multitable-onprem-package-build.sh`
- `bash -n scripts/ops/multitable-onprem-package-verify.sh`
- `git diff --check`
- `node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs`
- `pnpm verify:integration-k3wise:poc`

## Docs
- `docs/development/data-factory-adapter-discovery-postdeploy-development-20260514.md`
- `docs/development/data-factory-adapter-discovery-postdeploy-verification-20260514.md`