### PR TITLE
test(integration): render adapter drift in postdeploy summary

### DIFF
--- a/docs/development/data-factory-postdeploy-summary-adapter-details-development-20260514.md
+++ b/docs/development/data-factory-postdeploy-summary-adapter-details-development-20260514.md
@@ -1,0 +1,51 @@
+# Data Factory postdeploy summary adapter details - development notes - 2026-05-14
+
+## Purpose
+
+This slice closes the operator-observability gap left after the Data Factory
+adapter discovery smoke landed.
+
+The smoke already fails when `GET /api/integration/adapters` omits or
+mis-describes the local MetaSheet Data Factory adapters. Before this change,
+the GitHub Step Summary renderer did not expand `invalidAdapters`, so an
+operator had to open the raw JSON evidence to see which adapter field drifted.
+
+## Implementation
+
+`scripts/ops/integration-k3wise-postdeploy-summary.mjs` now includes
+`invalidAdapters` in failed-check detail rendering.
+
+This means a failed `data-factory-adapter-discovery` check can show details
+such as:
+
+```text
+invalidAdapters: metasheet:staging: guardrails.write.supported: `expected false but got true`
+```
+
+The existing nested-detail formatter is reused. No new evidence schema,
+workflow option, or backend route was added.
+
+## Files Changed
+
+- `scripts/ops/integration-k3wise-postdeploy-summary.mjs`
+  - renders `invalidAdapters` alongside `missingAdapters`, `missingRoutes`,
+    `missingFields`, and `invalidFields`.
+- `scripts/ops/integration-k3wise-postdeploy-summary.test.mjs`
+  - adds a regression case for Data Factory adapter metadata drift details.
+- `scripts/ops/multitable-onprem-package-build.sh`
+  - includes this development/verification note pair in the on-prem package.
+- `scripts/ops/multitable-onprem-package-verify.sh`
+  - verifies the packaged postdeploy summary renderer still contains the
+    `invalidAdapters` detail path;
+  - verifies this document pair is included in the package.
+
+## Deployment Impact
+
+- No runtime API change.
+- No migration.
+- No live external request.
+- No write operation.
+- Existing smoke evidence JSON shape remains unchanged.
+
+The change only improves how already-collected failure evidence is rendered in
+operator summaries.

--- a/docs/development/data-factory-postdeploy-summary-adapter-details-verification-20260514.md
+++ b/docs/development/data-factory-postdeploy-summary-adapter-details-verification-20260514.md
@@ -1,0 +1,122 @@
+# Data Factory postdeploy summary adapter details - verification - 2026-05-14
+
+## Scope
+
+This verification covers the postdeploy summary rendering update for Data
+Factory adapter discovery failures.
+
+Validated behavior:
+
+- failed smoke evidence with `details.invalidAdapters` renders the nested
+  adapter and field path in the summary;
+- existing missing adapter, route, field, signoff, markdown escaping, and
+  missing-evidence behavior stays unchanged;
+- on-prem package scripts include and verify this closeout documentation.
+
+## Commands
+
+### Script syntax
+
+Command:
+
+```bash
+node --check scripts/ops/integration-k3wise-postdeploy-summary.mjs
+node --check scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
+bash -n scripts/ops/multitable-onprem-package-build.sh
+bash -n scripts/ops/multitable-onprem-package-verify.sh
+```
+
+Expected: PASS.
+
+Result: PASS.
+
+### Summary renderer regression
+
+Command:
+
+```bash
+node --test scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
+```
+
+Expected:
+
+- the new Data Factory adapter metadata drift case passes;
+- summary renderer exits `0` for failed smoke evidence;
+- existing summary tests remain green.
+
+Result: PASS.
+
+Observed output:
+
+```text
+✔ renders Data Factory adapter metadata drift details
+ℹ tests 15
+ℹ pass 15
+```
+
+### Postdeploy smoke regression
+
+Command:
+
+```bash
+node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
+```
+
+Expected:
+
+- adapter discovery smoke evidence still records
+  `data-factory-adapter-discovery`;
+- the smoke-level `invalidAdapters` failure case remains unchanged.
+
+Result: PASS.
+
+Observed output:
+
+```text
+✔ authenticated postdeploy smoke fails when Data Factory adapter metadata loses staging write guardrails
+ℹ tests 17
+ℹ pass 17
+```
+
+### Workflow wiring regression
+
+Command:
+
+```bash
+node --test scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs
+```
+
+Expected:
+
+- manual and deploy workflows still call the postdeploy summary renderer.
+
+Result: PASS.
+
+Observed output:
+
+```text
+✔ manual K3 WISE postdeploy smoke workflow keeps dispatch and auth contract stable
+✔ deploy workflow keeps K3 WISE smoke evidence wired into deploy summary and artifacts
+ℹ tests 2
+ℹ pass 2
+```
+
+### Diff and staged hygiene
+
+Commands:
+
+```bash
+git diff --check
+git diff --cached --check
+```
+
+Expected: PASS.
+
+Result: PASS.
+
+## Manual Checklist
+
+- No bearer token, JWT, private key, webhook, or local absolute path is added.
+- No package artifact under `output/` is generated or staged.
+- The summary renderer consumes existing evidence only; it does not perform
+  live network calls.

--- a/scripts/ops/integration-k3wise-postdeploy-summary.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-summary.mjs
@@ -167,7 +167,7 @@ function formatDetailValue(value) {
 function summarizeCheckDetails(check) {
   const details = check && check.details && typeof check.details === 'object' ? check.details : {}
   const lines = []
-  for (const key of ['missingAdapters', 'missingRoutes', 'missingFields', 'invalidFields']) {
+  for (const key of ['missingAdapters', 'invalidAdapters', 'missingRoutes', 'missingFields', 'invalidFields']) {
     const value = details[key]
     const hasValue = Array.isArray(value)
       ? value.length > 0

--- a/scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
@@ -324,6 +324,44 @@ test('renders staging missing field details for failed descriptor checks', async
   }
 })
 
+test('renders Data Factory adapter metadata drift details', async () => {
+  const outDir = makeTmpDir()
+  const evidencePath = path.join(outDir, 'evidence.json')
+  try {
+    writeFileSync(evidencePath, `${JSON.stringify({
+      ok: false,
+      baseUrl: 'http://127.0.0.1:8081',
+      authenticated: true,
+      summary: { pass: 6, skipped: 0, fail: 1 },
+      checks: [
+        {
+          id: 'data-factory-adapter-discovery',
+          status: 'fail',
+          details: {
+            invalidAdapters: {
+              'metasheet:staging': {
+                'guardrails.write.supported': 'expected false but got true',
+              },
+              'metasheet:multitable': {
+                roles: 'missing target',
+              },
+            },
+          },
+        },
+      ],
+    })}\n`)
+
+    const result = await runScript(['--input', evidencePath])
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stdout, /`data-factory-adapter-discovery`: `fail`/)
+    assert.match(result.stdout, /invalidAdapters: metasheet:staging: guardrails\.write\.supported: `expected false but got true`/)
+    assert.match(result.stdout, /metasheet:multitable: roles: `missing target`/)
+  } finally {
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
 test('escapes markdown-breaking values in postdeploy summary output', async () => {
   const outDir = makeTmpDir()
   const evidencePath = path.join(outDir, 'evidence.json')

--- a/scripts/ops/multitable-onprem-package-build.sh
+++ b/scripts/ops/multitable-onprem-package-build.sh
@@ -79,6 +79,8 @@ REQUIRED_PATHS=(
   "docs/development/data-factory-postdeploy-smoke-verification-20260514.md"
   "docs/development/data-factory-adapter-discovery-postdeploy-development-20260514.md"
   "docs/development/data-factory-adapter-discovery-postdeploy-verification-20260514.md"
+  "docs/development/data-factory-postdeploy-summary-adapter-details-development-20260514.md"
+  "docs/development/data-factory-postdeploy-summary-adapter-details-verification-20260514.md"
   "docs/development/onprem-migration-gap-guard-development-20260514.md"
   "docs/development/onprem-migration-gap-guard-verification-20260514.md"
   "docker/app.env.example"

--- a/scripts/ops/multitable-onprem-package-verify.sh
+++ b/scripts/ops/multitable-onprem-package-verify.sh
@@ -92,6 +92,7 @@ function verify_generic_integration_workbench_contract() {
   local easy_start="${root}/docs/deployment/multitable-windows-onprem-easy-start-20260319.md"
   local k3_runbook="${root}/docs/operations/integration-k3wise-internal-trial-runbook.md"
   local postdeploy_smoke="${root}/scripts/ops/integration-k3wise-postdeploy-smoke.mjs"
+  local postdeploy_summary="${root}/scripts/ops/integration-k3wise-postdeploy-summary.mjs"
 
   search_fixed_string '/integrations/workbench' "$web_dist" || die "web dist must include the Data Factory route"
   search_fixed_string '/integrations/k3-wise' "$web_dist" || die "web dist must include the K3 WISE setup route"
@@ -106,6 +107,7 @@ function verify_generic_integration_workbench_contract() {
   search_fixed_string 'SQL Server is an advanced channel' "$k3_runbook" || die "K3 runbook must document SQL Server as an advanced channel"
   search_fixed_string 'data-factory-frontend-route' "$postdeploy_smoke" || die "postdeploy smoke must check the Data Factory frontend route"
   search_fixed_string 'data-factory-adapter-discovery' "$postdeploy_smoke" || die "postdeploy smoke must check Data Factory adapter discovery"
+  search_fixed_string 'invalidAdapters' "$postdeploy_summary" || die "postdeploy summary must render Data Factory adapter drift details"
 }
 
 function write_optional_report() {
@@ -339,6 +341,8 @@ required=(
   "docs/development/data-factory-postdeploy-smoke-verification-20260514.md"
   "docs/development/data-factory-adapter-discovery-postdeploy-development-20260514.md"
   "docs/development/data-factory-adapter-discovery-postdeploy-verification-20260514.md"
+  "docs/development/data-factory-postdeploy-summary-adapter-details-development-20260514.md"
+  "docs/development/data-factory-postdeploy-summary-adapter-details-verification-20260514.md"
   "docs/development/onprem-migration-gap-guard-development-20260514.md"
   "docs/development/onprem-migration-gap-guard-verification-20260514.md"
   "docs/deployment/multitable-platform-rc-notes-20260404.md"


### PR DESCRIPTION
## Summary
- render `invalidAdapters` details in the K3/Data Factory postdeploy summary
- add a regression case for `data-factory-adapter-discovery` metadata drift evidence
- include the closeout development/verification docs in the on-prem package build/verify list

## Verification
- `node --check scripts/ops/integration-k3wise-postdeploy-summary.mjs`
- `node --check scripts/ops/integration-k3wise-postdeploy-summary.test.mjs`
- `bash -n scripts/ops/multitable-onprem-package-build.sh`
- `bash -n scripts/ops/multitable-onprem-package-verify.sh`
- `git diff --check`
- `node --test scripts/ops/integration-k3wise-postdeploy-summary.test.mjs`
- `node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs`
- `node --test scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs`

## Docs
- `docs/development/data-factory-postdeploy-summary-adapter-details-development-20260514.md`
- `docs/development/data-factory-postdeploy-summary-adapter-details-verification-20260514.md`