### PR TITLE
fix(integration): unblock Data Factory pipeline save

### DIFF
--- a/docs/development/data-factory-issue1542-pipeline-jsonb-development-20260515.md
+++ b/docs/development/data-factory-issue1542-pipeline-jsonb-development-20260515.md
@@ -1,0 +1,72 @@
+# Data Factory Issue 1542 Pipeline Save Development Notes - 2026-05-15
+
+## Context
+
+Issue #1542 started as a Data Factory onboarding gap, then exposed two deploy-time blockers while testing the staging-to-K3 material pipeline:
+
+- `POST /api/integration/pipelines` returned HTTP 500 with PostgreSQL code `22P02` and `invalid input syntax for type json`.
+- A manually created `metasheet:staging` external system could connect, but `standard_materials` schema discovery returned `fields: []`.
+
+The SQL Server source executor is still intentionally outside this patch. That lane needs a separate product decision because direct SQL access must stay behind the advanced connection guardrails.
+
+## Root Cause
+
+The pipeline registry writes several structured fields into JSONB columns:
+
+- `integration_pipelines.idempotency_key_fields`
+- `integration_pipelines.options`
+- `integration_field_mappings.transform`
+- `integration_field_mappings.validation`
+- `integration_field_mappings.default_value`
+- `integration_runs.details`
+
+`node-postgres` treats JavaScript arrays as PostgreSQL array literals when they are passed as bind parameters. A value such as `['sourceId', 'revision']` therefore reaches PostgreSQL as an array literal, not JSON text, and fails when the destination column is JSONB.
+
+There was also a nearby primitive JSONB risk: `default_value` can be a string such as `PCS`. That must be stored as JSON text `"PCS"`, not as the raw SQL parameter `PCS`.
+
+The staging source schema issue came from manual system creation. The workbench-created path includes `fields` / `fieldDetails`, but the manually-created path only provided `sheetId`. The adapter had no fallback to the plugin-owned staging descriptor catalog.
+
+## Changes
+
+### Pipeline JSONB Writes
+
+`plugins/plugin-integration-core/lib/pipelines.cjs` now serializes JSONB-owned columns before they reach the scoped DB helper:
+
+- Arrays become JSON text, for example `["sourceId","revision"]`.
+- Objects become JSON text, for example `{"batchSize":100}`.
+- Primitive default values become valid JSON text, for example `"PCS"`.
+- Row hydration accepts either parsed JSONB values from PostgreSQL or JSON text from tests/fakes.
+
+This keeps the JSONB ownership visible at the pipeline registry boundary instead of relying on driver-specific behavior.
+
+### Scoped DB Defense
+
+`plugins/plugin-integration-core/lib/db.cjs` also serializes array/plain-object bind values before calling the host database. This is defense in depth for other integration tables that store JSONB values through the same CRUD helper.
+
+The DB helper still exposes no raw SQL path. Identifier validation and parameterized statements are unchanged.
+
+### Staging Schema Fallback
+
+`plugins/plugin-integration-core/lib/adapters/metasheet-staging-source-adapter.cjs` now derives known staging object fields from `listStagingDescriptors()` when a config object omits explicit `fields` / `fieldDetails`.
+
+For example, this manual config is now sufficient for schema discovery:
+
+```json
+{
+  "objects": {
+    "standard_materials": {
+      "sheetId": "sheet_materials"
+    }
+  }
+}
+```
+
+The adapter still rejects unknown objects and still requires `context.api.multitable.records.queryRecords()` for reads.
+
+## Compatibility
+
+- No new migration.
+- No API shape change.
+- Existing workbench-created staging source configs continue to use their explicit field metadata.
+- Existing pipeline read responses continue to return parsed arrays/objects/primitives.
+- The SQL executor missing state remains unchanged and should continue to be shown as an advanced-source blocker rather than silently attempted.

--- a/docs/development/data-factory-issue1542-pipeline-jsonb-verification-20260515.md
+++ b/docs/development/data-factory-issue1542-pipeline-jsonb-verification-20260515.md
@@ -1,0 +1,94 @@
+# Data Factory Issue 1542 Pipeline Save Verification - 2026-05-15
+
+## Scope
+
+This verification covers the P0 parts of issue #1542:
+
+- Pipeline save no longer emits JSONB `22P02` for array/object/string JSON values.
+- Manual `metasheet:staging` source configs can discover known staging object schemas.
+
+It does not claim SQL Server source execution is available. `SQLSERVER_EXECUTOR_MISSING` remains a separate advanced-connection gap.
+
+## Local Regression Commands
+
+```bash
+node plugins/plugin-integration-core/__tests__/db.test.cjs
+node plugins/plugin-integration-core/__tests__/pipelines.test.cjs
+node plugins/plugin-integration-core/__tests__/metasheet-staging-source-adapter.test.cjs
+```
+
+Result:
+
+```text
+PASS db.cjs: all CRUD + boundary + injection tests passed
+PASS pipelines: registry + endpoint + field-mapping + run-ledger + concurrent-guard + stale-run-cleanup tests passed
+PASS metasheet-staging-source-adapter: read-only multitable source tests passed
+```
+
+## Assertions Added
+
+### DB Helper
+
+- `idempotency_key_fields: ['sourceId', 'revision']` is passed to the host DB as JSON text.
+- `options: { k3Template: { id: 'material', version: 1 } }` is passed to the host DB as JSON text.
+- Existing SQL-injection and identifier-boundary tests remain green.
+
+### Pipeline Registry
+
+- Pipeline insert stores `idempotency_key_fields` as `["sourceId","revision"]`.
+- Pipeline insert stores `options` as `{"batchSize":100}`.
+- Field mapping string default stores as `"PCS"` for JSONB validity.
+- Field mapping object/array values store as JSON text.
+- Pipeline output hydrates JSON text back into the public response shape.
+- Pipeline run `details` stores as JSON text and hydrates back to an object.
+
+### Staging Source Adapter
+
+- Manual config with only `objects.standard_materials.sheetId` now returns a non-empty schema.
+- The fallback includes known material fields such as `code` and `name`.
+- Existing read-only paging behavior remains unchanged.
+
+## Manual Retest Recipe for the Deployed Box
+
+After deploying a package containing this patch:
+
+1. Ensure the `metasheet:staging` adapter is present in `/api/integration/adapters`.
+2. Create or use a staging source with `objects.standard_materials.sheetId`.
+3. Call schema discovery for `standard_materials`; it should return fields instead of `[]`.
+4. Save a minimal `metasheet:staging -> erp:k3-wise-webapi` material pipeline with:
+
+```json
+{
+  "idempotencyKeyFields": ["code"],
+  "options": {
+    "k3Template": {
+      "id": "material",
+      "version": 1,
+      "documentType": "material"
+    }
+  },
+  "fieldMappings": [
+    {
+      "sourceField": "code",
+      "targetField": "FNumber",
+      "validation": [{ "type": "required" }]
+    },
+    {
+      "sourceField": "uom",
+      "targetField": "FBaseUnitID",
+      "defaultValue": "PCS"
+    }
+  ]
+}
+```
+
+Expected result:
+
+- HTTP 200/201 for pipeline save.
+- No PostgreSQL `22P02`.
+- Returned pipeline contains parsed `idempotencyKeyFields`, `options`, `validation`, and `defaultValue`.
+
+## Remaining Issue Notes
+
+- SQL Server source still needs a real injected `queryExecutor` or a disabled-state UX that explains why direct SQL read is unavailable.
+- This patch unblocks the staging-to-K3 path; it does not broaden direct SQL privileges.

--- a/plugins/plugin-integration-core/__tests__/db.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/db.test.cjs
@@ -130,6 +130,18 @@ async function main() {
   assert.match(q6.sql, /^INSERT INTO "integration_pipelines" \("id", "name", "status"\) VALUES \(\$1, \$2, \$3\) RETURNING \*$/)
   assert.deepEqual(q6.params, ['p1', 'X', 'draft'])
 
+  await db6.insertOne('integration_pipelines', {
+    id: 'p_json',
+    idempotency_key_fields: ['sourceId', 'revision'],
+    options: { k3Template: { id: 'material', version: 1 } },
+  })
+  const q6b = mockDb6.calls[1]
+  assert.deepEqual(
+    q6b.params,
+    ['p_json', '["sourceId","revision"]', '{"k3Template":{"id":"material","version":1}}'],
+    'arrays/plain objects are serialized as JSON text before reaching node-postgres',
+  )
+
   // insertMany with consistent keys
   const mockDb7 = mockDatabase()
   const db7 = createDb({ database: mockDb7 })

--- a/plugins/plugin-integration-core/__tests__/metasheet-staging-source-adapter.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/metasheet-staging-source-adapter.test.cjs
@@ -83,6 +83,25 @@ async function main() {
   assert.deepEqual(schema.fields.map((field) => field.name), ['code', 'name', 'quantity'])
   assert.equal(schema.raw.sheetId, 'sheet_materials')
 
+  const manualConfigAdapter = createMetaSheetStagingSourceAdapter({
+    system: createSystem({
+      objects: {
+        standard_materials: {
+          sheetId: 'sheet_materials',
+        },
+      },
+    }),
+    context,
+  })
+  const fallbackObjects = await manualConfigAdapter.listObjects()
+  assert.ok(
+    fallbackObjects[0].schema.some((field) => field.name === 'code'),
+    'manual staging source config derives schema from built-in descriptors',
+  )
+  const fallbackSchema = await manualConfigAdapter.getSchema({ object: 'standard_materials' })
+  assert.ok(fallbackSchema.fields.length > 0, 'manual staging source schema is not empty')
+  assert.ok(fallbackSchema.fields.some((field) => field.name === 'name'), 'descriptor fallback includes material name field')
+
   const firstPage = await adapter.read({ object: 'standard_materials', limit: 1 })
   assert.equal(firstPage.records.length, 1)
   assert.equal(firstPage.records[0].code, 'MAT-001')

--- a/plugins/plugin-integration-core/__tests__/pipelines.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/pipelines.test.cjs
@@ -141,7 +141,7 @@ async function main() {
     status: 'active',
     createdBy: 'admin',
     fieldMappings: [
-      { sourceField: 'code', targetField: 'FNumber', sortOrder: 0 },
+      { sourceField: 'code', targetField: 'FNumber', defaultValue: 'PCS', sortOrder: 0 },
       { sourceField: 'name', targetField: 'FName', transform: { fn: 'trim' }, validation: [{ type: 'required' }], sortOrder: 1 },
     ],
   })
@@ -153,12 +153,26 @@ async function main() {
   assert.equal(created.status, 'active')
   assert.equal(created.fieldMappings.length, 2)
   assert.deepEqual(created.fieldMappings.map(mapping => mapping.id), ['id_2', 'id_3'])
+  assert.equal(created.fieldMappings[0].defaultValue, 'PCS')
   assert.ok(db.calls.some(([name]) => name === 'transaction'), 'field mapping writes are transactional')
+  const pipelineInsert = db.calls.find(call => call[0] === 'insertOne' && call[1] === 'integration_pipelines')
+  assert.equal(pipelineInsert[2].idempotency_key_fields, '["sourceId","revision"]',
+    'pipeline idempotency JSONB array is stored as JSON text')
+  assert.equal(pipelineInsert[2].options, '{"batchSize":100}',
+    'pipeline options JSONB object is stored as JSON text')
+  const mappingInsert = db.calls.find(call => call[0] === 'insertMany' && call[1] === 'integration_field_mappings')
+  assert.equal(mappingInsert[2][0].default_value, '"PCS"',
+    'field mapping JSONB string default is stored as valid JSON text')
+  assert.equal(mappingInsert[2][1].transform, '{"fn":"trim"}',
+    'field mapping transform JSONB object is stored as JSON text')
+  assert.equal(mappingInsert[2][1].validation, '[{"type":"required"}]',
+    'field mapping validation JSONB array is stored as JSON text')
 
   // --- 2. getPipeline returns mappings and safe definition shape ---------
   const fetched = await registry.getPipeline({ tenantId: 'tenant_1', workspaceId: null, id: 'id_1' })
   assert.equal(fetched.id, 'id_1')
   assert.equal(fetched.fieldMappings.length, 2)
+  assert.equal(fetched.fieldMappings[0].defaultValue, 'PCS')
   assert.equal(fetched.fieldMappings[1].transform.fn, 'trim')
   assert.equal(fetched.credentials, undefined, 'pipeline output never includes credentials')
   assert.equal(fetched.credentialsEncrypted, undefined, 'pipeline output never includes ciphertext')
@@ -337,6 +351,9 @@ async function main() {
   assert.equal(run.status, 'pending')
   assert.equal(run.rowsRead, 0)
   assert.deepEqual(run.details, { dryRun: true })
+  const runInsert = db.calls.find(call => call[0] === 'insertOne' && call[1] === 'integration_runs')
+  assert.equal(runInsert[2].details, '{"dryRun":true}',
+    'pipeline run details JSONB object is stored as JSON text')
 
   const completedRun = await registry.updatePipelineRun({
     tenantId: 'tenant_1',

--- a/plugins/plugin-integration-core/lib/adapters/metasheet-staging-source-adapter.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/metasheet-staging-source-adapter.cjs
@@ -15,6 +15,7 @@ const {
   normalizeReadRequest,
   unsupportedAdapterOperation,
 } = require('../contracts.cjs')
+const { listStagingDescriptors } = require('../staging-installer.cjs')
 
 function isPlainObject(value) {
   return Boolean(value && typeof value === 'object' && !Array.isArray(value))
@@ -47,10 +48,19 @@ function normalizeField(field) {
   }
 }
 
-function normalizeFields(config = {}) {
+function descriptorFieldsForObject(objectId) {
+  const descriptor = listStagingDescriptors().find((item) => item.id === objectId)
+  if (!descriptor) return []
+  return Array.isArray(descriptor.fieldDetails) && descriptor.fieldDetails.length > 0
+    ? descriptor.fieldDetails
+    : descriptor.fields || []
+}
+
+function normalizeFields(config = {}, objectId = null) {
   const detailed = Array.isArray(config.fieldDetails) ? config.fieldDetails : null
   const fields = detailed || (Array.isArray(config.fields) ? config.fields : [])
-  return fields.map(normalizeField)
+  const fallbackFields = fields.length > 0 ? fields : descriptorFieldsForObject(objectId)
+  return fallbackFields.map(normalizeField)
 }
 
 function targetArrayToObjects(targets) {
@@ -92,7 +102,7 @@ function normalizeObjects(config = {}) {
       viewId: optionalString(objectConfig.viewId),
       baseId: optionalString(objectConfig.baseId),
       openLink: optionalString(objectConfig.openLink),
-      fields: normalizeFields(objectConfig),
+      fields: normalizeFields(objectConfig, objectId),
     }
   }
   return objects
@@ -222,6 +232,7 @@ module.exports = {
   __internals: {
     normalizeObjects,
     normalizeFields,
+    descriptorFieldsForObject,
     parseOffsetCursor,
     recordData,
   },

--- a/plugins/plugin-integration-core/lib/db.cjs
+++ b/plugins/plugin-integration-core/lib/db.cjs
@@ -70,6 +70,26 @@ function quoteIdent(name) {
   return `"${name}"`
 }
 
+function isPlainObject(value) {
+  return Boolean(
+    value
+    && typeof value === 'object'
+    && !Array.isArray(value)
+    && !(value instanceof Date)
+    && !(typeof Buffer !== 'undefined' && Buffer.isBuffer(value))
+  )
+}
+
+function prepareParamValue(value) {
+  // node-postgres treats JavaScript arrays as PostgreSQL array literals. That
+  // breaks JSONB columns such as integration_pipelines.idempotency_key_fields
+  // with 22P02 "invalid input syntax for type json". The integration_* schema
+  // stores structured values as JSONB, so send arrays/plain objects as JSON
+  // text and let PostgreSQL cast them to JSONB.
+  if (Array.isArray(value) || isPlainObject(value)) return JSON.stringify(value)
+  return value
+}
+
 function buildWhereClause(where, startParamIndex) {
   if (where === undefined || where === null) {
     return { sql: '', params: [], nextIndex: startParamIndex }
@@ -88,7 +108,7 @@ function buildWhereClause(where, startParamIndex) {
       continue
     }
     parts.push(`${quoteIdent(col)} = $${idx}`)
-    params.push(val)
+    params.push(prepareParamValue(val))
     idx += 1
   }
   return {
@@ -147,7 +167,7 @@ function createDb({ database, logger } = {}) {
     if (cols.length === 0) throw new Error('insertOne: row must have at least one column')
     const colIdents = cols.map((c) => quoteIdent(assertColumn(c))).join(', ')
     const placeholders = cols.map((_, i) => `$${i + 1}`).join(', ')
-    const values = cols.map((c) => row[c])
+    const values = cols.map((c) => prepareParamValue(row[c]))
     const sql = `INSERT INTO ${tableIdent} (${colIdents}) VALUES (${placeholders}) RETURNING *`
     return database.query(sql, values)
   }
@@ -173,7 +193,7 @@ function createDb({ database, logger } = {}) {
         throw new Error(`insertMany: rows[${rowIdx}] has inconsistent keys`)
       }
       const placeholders = cols.map((c) => {
-        params.push(row[c])
+        params.push(prepareParamValue(row[c]))
         return `$${params.length}`
       })
       return `(${placeholders.join(', ')})`
@@ -193,7 +213,7 @@ function createDb({ database, logger } = {}) {
     const setCols = Object.keys(set)
     const params = []
     const setPairs = setCols.map((col) => {
-      params.push(set[col])
+      params.push(prepareParamValue(set[col]))
       return `${quoteIdent(assertColumn(col))} = $${params.length}`
     })
     const whereClause = buildWhereClause(where, params.length + 1)
@@ -275,6 +295,7 @@ module.exports = {
     assertColumn,
     buildWhereClause,
     quoteIdent,
+    prepareParamValue,
     IDENT_RE,
   },
 }

--- a/plugins/plugin-integration-core/lib/pipelines.cjs
+++ b/plugins/plugin-integration-core/lib/pipelines.cjs
@@ -100,6 +100,20 @@ function optionalJson(value, field) {
   return Array.isArray(value) ? value.slice() : { ...value }
 }
 
+function jsonbParam(value) {
+  return JSON.stringify(value)
+}
+
+function parseJsonbValue(value, fallback) {
+  if (value === undefined || value === null) return fallback
+  if (typeof value !== 'string') return value
+  try {
+    return JSON.parse(value)
+  } catch {
+    return value
+  }
+}
+
 function validateIsoTimestamp(value, field) {
   if (value === undefined || value === null || value === '') return null
   const text = requiredString(value, field)
@@ -241,7 +255,7 @@ function normalizeUpdateRunInput(input, now) {
     finished_at: finishedAt,
     duration_ms: input.durationMs === undefined || input.durationMs === null ? null : nonNegativeInteger(input.durationMs, 'durationMs'),
     error_summary: optionalString(input.errorSummary, 'errorSummary'),
-    details: input.details === undefined ? undefined : jsonObject(input.details, 'details'),
+    details: input.details === undefined ? undefined : jsonbParam(jsonObject(input.details, 'details')),
   }
   for (const key of Object.keys(set)) {
     if (set[key] === undefined || set[key] === null) delete set[key]
@@ -269,8 +283,8 @@ function rowToPipeline(row, fieldMappings) {
     targetObject: row.target_object,
     stagingSheetId: row.staging_sheet_id ?? null,
     mode: row.mode,
-    idempotencyKeyFields: row.idempotency_key_fields ?? [],
-    options: row.options ?? {},
+    idempotencyKeyFields: parseJsonbValue(row.idempotency_key_fields, []),
+    options: parseJsonbValue(row.options, {}),
     status: row.status,
     createdBy: row.created_by ?? null,
     createdAt: row.created_at ?? null,
@@ -286,9 +300,9 @@ function rowToFieldMapping(row) {
     pipelineId: row.pipeline_id,
     sourceField: row.source_field,
     targetField: row.target_field,
-    transform: row.transform ?? null,
-    validation: row.validation ?? null,
-    defaultValue: row.default_value ?? null,
+    transform: parseJsonbValue(row.transform, null),
+    validation: parseJsonbValue(row.validation, null),
+    defaultValue: parseJsonbValue(row.default_value, null),
     sortOrder: row.sort_order ?? 0,
     createdAt: row.created_at ?? null,
   }
@@ -311,7 +325,7 @@ function rowToPipelineRun(row) {
     finishedAt: row.finished_at ?? null,
     durationMs: row.duration_ms ?? null,
     errorSummary: row.error_summary ?? null,
-    details: row.details ?? {},
+    details: parseJsonbValue(row.details, {}),
     createdAt: row.created_at ?? null,
   }
 }
@@ -402,9 +416,9 @@ async function replaceFieldMappings(db, pipelineId, mappings, idGenerator) {
     pipeline_id: pipelineId,
     source_field: mapping.sourceField,
     target_field: mapping.targetField,
-    transform: mapping.transform,
-    validation: mapping.validation,
-    default_value: mapping.defaultValue,
+    transform: mapping.transform === null ? null : jsonbParam(mapping.transform),
+    validation: mapping.validation === null ? null : jsonbParam(mapping.validation),
+    default_value: mapping.defaultValue === null ? null : jsonbParam(mapping.defaultValue),
     sort_order: mapping.sortOrder,
   }))
   return unwrapRows(await db.insertMany(FIELD_MAPPINGS_TABLE, rows)).map(rowToFieldMapping)
@@ -465,8 +479,8 @@ function createPipelineRegistry({ db, idGenerator = crypto.randomUUID } = {}) {
         target_object: normalized.targetObject,
         staging_sheet_id: normalized.stagingSheetId,
         mode: normalized.mode,
-        idempotency_key_fields: normalized.idempotencyKeyFields,
-        options: normalized.options,
+        idempotency_key_fields: jsonbParam(normalized.idempotencyKeyFields),
+        options: jsonbParam(normalized.options),
         status: normalized.status,
       }
 
@@ -596,7 +610,7 @@ function createPipelineRegistry({ db, idGenerator = crypto.randomUUID } = {}) {
         finished_at: normalized.finishedAt,
         duration_ms: normalized.durationMs,
         error_summary: normalized.errorSummary,
-        details: normalized.details,
+        details: jsonbParam(normalized.details),
       }
       try {
         const rows = unwrapRows(await db.insertOne(RUNS_TABLE, insertRow))
@@ -719,6 +733,8 @@ module.exports = {
     normalizeFieldMappings,
     normalizeCreateRunInput,
     normalizeUpdateRunInput,
+    jsonbParam,
+    parseJsonbValue,
     rowToPipeline,
     rowToFieldMapping,
     rowToPipelineRun,


### PR DESCRIPTION
## Summary

Refs #1542.

This PR fixes the P0 Data Factory blockers found during the staging-to-K3 WISE material pipeline test:

- serialize pipeline JSONB values before they reach node-postgres, including array/object values and string `default_value` values;
- hydrate JSONB text back into the existing public pipeline response shape for tests/fakes;
- add scoped DB defense for array/plain-object bind params;
- derive known staging schemas from built-in staging descriptors when a manually-created `metasheet:staging` system only provides `sheetId`.

The SQL Server executor gap remains outside this patch and should stay tracked separately as an advanced-source capability/disabled-state item.

## Verification

- `node plugins/plugin-integration-core/__tests__/db.test.cjs`
- `node plugins/plugin-integration-core/__tests__/pipelines.test.cjs`
- `node plugins/plugin-integration-core/__tests__/metasheet-staging-source-adapter.test.cjs`
- `pnpm -F plugin-integration-core test`
- `pnpm verify:integration-k3wise:poc`
- `git diff --cached --check` before commit

## Docs

- `docs/development/data-factory-issue1542-pipeline-jsonb-development-20260515.md`
- `docs/development/data-factory-issue1542-pipeline-jsonb-verification-20260515.md`
