### PR TITLE
fix(integration): collate Data Factory source UX for issue #1542 P1

### DIFF
--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -136,21 +136,32 @@
             <span>数据源系统</span>
             <select v-model="sourceSystemId" data-testid="source-system">
               <option value="">请选择数据源系统</option>
-              <option v-for="system in sourceSystems" :key="system.id" :value="system.id">
+              <option
+                v-for="system in sourceSystems"
+                :key="system.id"
+                :value="system.id"
+                :disabled="isSourceOptionDisabled(system)"
+                :data-disabled="isSourceOptionDisabled(system) ? 'true' : 'false'"
+                :data-testid="`source-system-option-${system.id}`"
+              >
                 {{ system.name }} · {{ system.kind }}
               </option>
             </select>
           </label>
-          <div v-if="sourceSystems.length === 0" class="integration-workbench__empty integration-workbench__empty--actionable" data-testid="source-empty-state">
+          <div v-if="!hasRunnableSourceSystem" class="integration-workbench__empty integration-workbench__empty--actionable" data-testid="source-empty-state">
             <strong>还没有可读取的数据源。</strong>
             <p>连接 PLM、HTTP API 或启用 SQL 只读通道后，可将数据导入 staging 多维表再清洗。</p>
             <div class="integration-workbench__actions">
               <router-link class="integration-workbench__button" to="/integrations/k3-wise">使用 K3 WISE 预设</router-link>
+              <button type="button" class="integration-workbench__button" data-testid="show-staging-setup" @click="showStagingSetup">创建 staging 多维表作为来源</button>
               <button type="button" class="integration-workbench__button" @click="showSqlSetup">启用 SQL 只读通道</button>
             </div>
           </div>
           <div v-if="sourceRuntimeBlocker" class="integration-workbench__hint integration-workbench__hint--strong" data-testid="source-runtime-blocker">
             {{ sourceRuntimeBlocker }}
+          </div>
+          <div v-if="sqlChannelDisabledHint" class="integration-workbench__hint" data-testid="sql-channel-disabled-hint">
+            {{ sqlChannelDisabledHint }}
           </div>
           <div class="integration-workbench__connection-row">
             <span class="integration-workbench__badge" :data-status="sourceConnectionStatus">{{ sourceConnectionLabel }}</span>
@@ -307,8 +318,12 @@
           </div>
         </article>
       </div>
-      <div v-else class="integration-workbench__empty" data-testid="staging-empty">
-        暂未加载 staging 契约。可先刷新连接，或填写 Project ID 后创建清洗表。
+      <div v-else class="integration-workbench__empty integration-workbench__empty--actionable" data-testid="staging-empty">
+        <strong>暂未加载 staging 契约。</strong>
+        <p>填写下方 Project ID 后点击「创建清洗表」即可生成 staging 多维表；创建完成后可在 staging 卡片上「作为 Dry-run 来源」。</p>
+        <div class="integration-workbench__actions">
+          <button type="button" class="integration-workbench__button" data-testid="staging-empty-focus-install" @click="focusStagingInstall">填写 Project ID 创建清洗表</button>
+        </div>
       </div>
 
       <div class="integration-workbench__grid integration-workbench__grid--compact">
@@ -739,6 +754,8 @@ const hiddenAdvancedSystemCount = computed(() => systems.value.filter((system) =
 const visibleSystems = computed(() => systems.value.filter((system) => showAdvancedConnectors.value || !isAdvancedSystem(system)))
 const sourceSystems = computed(() => visibleSystems.value.filter(canReadFromSystem))
 const targetSystems = computed(() => visibleSystems.value.filter(canWriteToSystem))
+const runnableSourceSystems = computed(() => sourceSystems.value.filter((system) => !isSourceOptionDisabled(system)))
+const hasRunnableSourceSystem = computed(() => runnableSourceSystems.value.length > 0)
 const selectedTargetObject = computed(() => targetObjects.value.find((object) => object.name === targetObjectName.value) || null)
 const selectedSourceSystem = computed(() => systems.value.find((system) => system.id === sourceSystemId.value) || null)
 const selectedTargetSystem = computed(() => systems.value.find((system) => system.id === targetSystemId.value) || null)
@@ -748,6 +765,10 @@ const targetConnectionStatus = computed(() => selectedTargetSystem.value?.status
 const sourceConnectionLabel = computed(() => connectionStatusLabel(selectedSourceSystem.value))
 const targetConnectionLabel = computed(() => connectionStatusLabel(selectedTargetSystem.value))
 const sourceRuntimeBlocker = computed(() => runtimeBlockerForSystem(selectedSourceSystem.value))
+const sqlChannelDisabledHint = computed(() => {
+  const hasDisabledSql = systems.value.some((system) => system.kind === 'erp:k3-wise-sqlserver' && runtimeBlockerForSystem(system) !== '')
+  return hasDisabledSql ? '高级 SQL 通道未启用 / 需要部署侧注入 queryExecutor。已有 SQL 连接配置会保留但暂不能作为 Dry-run 来源。' : ''
+})
 const sourceDatasetTitle = computed(() => selectedObjectLabel('source') || '请选择来源数据集')
 const targetDatasetTitle = computed(() => selectedObjectLabel('target') || '请选择目标数据集')
 const sourceDatasetDescription = computed(() => selectedSourceSystem.value
@@ -900,6 +921,28 @@ function showSqlSetup(): void {
   setStatus('已显示 SQL / 高级连接。SQL source 需要部署 allowlist queryExecutor 后才能读取。', 'idle')
 }
 
+function isSourceOptionDisabled(system: WorkbenchExternalSystem): boolean {
+  return runtimeBlockerForSystem(system) !== ''
+}
+
+function focusStagingInstall(): void {
+  if (typeof document === 'undefined') return
+  const input = document.querySelector('[data-testid="staging-project-id"]')
+  if (input && 'focus' in (input as HTMLElement)) {
+    try { (input as HTMLElement).focus() } catch { /* jsdom may not support focus */ }
+  }
+  const installButton = document.querySelector('[data-testid="install-staging"]')
+  if (installButton && 'scrollIntoView' in (installButton as HTMLElement)) {
+    try { (installButton as HTMLElement).scrollIntoView({ behavior: 'smooth', block: 'center' }) } catch { /* jsdom: no-op */ }
+  }
+}
+
+function showStagingSetup(): void {
+  inventoryExpanded.value = true
+  setStatus('创建 staging 多维表后即可在 staging 卡片上「作为 Dry-run 来源」。请先填写 Project ID 再点击「创建清洗表」。', 'idle')
+  focusStagingInstall()
+}
+
 function selectedObjectLabel(side: WorkbenchSide): string {
   const objectName = side === 'source' ? sourceObjectName.value : targetObjectName.value
   const objects = side === 'source' ? sourceObjects.value : targetObjects.value
@@ -1000,6 +1043,21 @@ function buildStagingSourceObjects(): IntegrationSystemObject[] {
       schema: descriptorToSchemaFields(descriptor),
     }]
   })
+}
+
+function preferredStagingSourceObjectId(): string {
+  const candidates = [
+    stagingSheetId.value,
+    'standard_materials',
+    stagingOpenTargets.value[0]?.id || '',
+  ]
+  for (const objectId of candidates) {
+    if (!objectId) continue
+    if (!stagingOpenTargetById.value.get(objectId)?.sheetId) continue
+    if (!stagingDescriptors.value.some((descriptor) => descriptor.id === objectId)) continue
+    return objectId
+  }
+  return ''
 }
 
 function buildMultitableTargetObjects(): IntegrationSystemObject[] {
@@ -1162,13 +1220,14 @@ async function exportCleansedResult(): Promise<void> {
 }
 
 function normalizeSystemSelections(): void {
+  const runnableSources = runnableSourceSystems.value
   if (sourceSystemId.value && !sourceSystems.value.some((system) => system.id === sourceSystemId.value)) {
-    sourceSystemId.value = sourceSystems.value[0]?.id || ''
+    sourceSystemId.value = runnableSources[0]?.id || ''
   }
   if (targetSystemId.value && !targetSystems.value.some((system) => system.id === targetSystemId.value)) {
     targetSystemId.value = targetSystems.value[0]?.id || ''
   }
-  if (!sourceSystemId.value) sourceSystemId.value = sourceSystems.value[0]?.id || ''
+  if (!sourceSystemId.value) sourceSystemId.value = runnableSources[0]?.id || ''
   if (!targetSystemId.value) targetSystemId.value = targetSystems.value[0]?.id || ''
 }
 
@@ -1283,7 +1342,17 @@ async function installStagingTables(): Promise<void> {
       warnings: result.warnings,
     }, null, 2)
     await refreshBootstrap()
-    setStatus(result.warnings.length > 0 ? `清洗表已创建，存在 ${result.warnings.length} 条警告` : '清洗表已创建，可打开多维表处理数据', result.warnings.length > 0 ? 'idle' : 'success')
+    const preferredSourceId = preferredStagingSourceObjectId()
+    if (preferredSourceId) {
+      await activateStagingAsSource(
+        preferredSourceId,
+        result.warnings.length > 0
+          ? `清洗表已创建，存在 ${result.warnings.length} 条警告；已自动设置 staging 多维表为 Dry-run 来源`
+          : '清洗表已创建，并已自动设置 staging 多维表为 Dry-run 来源',
+      )
+    } else {
+      setStatus(result.warnings.length > 0 ? `清洗表已创建，存在 ${result.warnings.length} 条警告` : '清洗表已创建，可打开多维表处理数据', result.warnings.length > 0 ? 'idle' : 'success')
+    }
   } catch (error) {
     setStatus(error instanceof Error ? error.message : String(error), 'error')
   } finally {
@@ -1292,6 +1361,10 @@ async function installStagingTables(): Promise<void> {
 }
 
 async function useStagingAsSource(objectId: string): Promise<void> {
+  await activateStagingAsSource(objectId)
+}
+
+async function activateStagingAsSource(objectId: string, successMessage?: string): Promise<void> {
   const descriptor = stagingDescriptors.value.find((item) => item.id === objectId) || null
   const target = stagingOpenTargetById.value.get(objectId)
   if (!descriptor || !target?.sheetId) {
@@ -1337,7 +1410,7 @@ async function useStagingAsSource(objectId: string): Promise<void> {
         openLink: target.openLink,
       },
     }
-    setStatus(`已将 ${stagingDatasetCopy[objectId]?.name || descriptor.name} 设为 Dry-run 来源`, 'success')
+    setStatus(successMessage || `已将 ${stagingDatasetCopy[objectId]?.name || descriptor.name} 设为 Dry-run 来源`, 'success')
   } catch (error) {
     setStatus(error instanceof Error ? error.message : String(error), 'error')
   }

--- a/apps/web/tests/IntegrationWorkbenchView.spec.ts
+++ b/apps/web/tests/IntegrationWorkbenchView.spec.ts
@@ -453,13 +453,13 @@ describe('IntegrationWorkbenchView', () => {
     projectId.value = 'project_1'
     projectId.dispatchEvent(new Event('input'))
     ;(container.querySelector('[data-testid="install-staging"]') as HTMLButtonElement).click()
-    await flushUi(10)
-    expect(container.textContent).toContain('清洗表已创建，可打开多维表处理数据')
+    await flushUi(20)
+    expect(container.textContent).toContain('清洗表已创建，并已自动设置 staging 多维表为 Dry-run 来源')
     expect((container.querySelector('[data-testid="open-staging-standard_materials"]') as HTMLAnchorElement).getAttribute('href'))
       .toBe('/multitable/sheet_materials/view_materials')
 
-    ;(container.querySelector('[data-testid="use-staging-source-standard_materials"]') as HTMLButtonElement).click()
-    await flushUi(10)
+    const stagingSourceButton = container.querySelector('[data-testid="use-staging-source-standard_materials"]') as HTMLButtonElement
+    expect(stagingSourceButton.disabled).toBe(false)
     expect(externalSystemBodies).toHaveLength(1)
     expect(externalSystemBodies[0]).toMatchObject({
       id: 'metasheet_staging_project_1',
@@ -489,7 +489,7 @@ describe('IntegrationWorkbenchView', () => {
     })
     expect((container.querySelector('[data-testid="source-system"]') as HTMLSelectElement).value).toBe('metasheet_staging_project_1')
     expect((container.querySelector('[data-testid="source-object"]') as HTMLSelectElement).value).toBe('standard_materials')
-    expect(container.textContent).toContain('已将 物料清洗 设为 Dry-run 来源')
+    expect(container.textContent).toContain('清洗表已创建，并已自动设置 staging 多维表为 Dry-run 来源')
 
     ;(container.querySelector('[data-testid="load-source-objects"]') as HTMLButtonElement).click()
     await flushUi(8)
@@ -760,5 +760,111 @@ describe('IntegrationWorkbenchView', () => {
     expect(container.textContent).toContain('还缺')
     expect(container.textContent).not.toContain('已满足 dry-run 前置条件')
     expect((container.querySelector('[data-testid="run-dry-run"]') as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('marks SQL Server source option as disabled when queryExecutor is missing', async () => {
+    apiFetchMock.mockImplementation(async (url: string) => {
+      if (url === '/api/integration/adapters') {
+        return jsonResponse([
+          { kind: 'erp:k3-wise-sqlserver', label: 'K3 WISE SQL Server Channel', roles: ['source'], supports: ['read'], advanced: true },
+          { kind: 'erp:k3-wise-webapi', label: 'K3 WISE WebAPI', roles: ['target'], supports: ['upsert'], advanced: false },
+        ])
+      }
+      if (url === '/api/integration/external-systems?tenantId=default') {
+        return jsonResponse([
+          {
+            id: 'k3_sql',
+            tenantId: 'default',
+            workspaceId: null,
+            name: 'K3 SQL Read Channel',
+            kind: 'erp:k3-wise-sqlserver',
+            role: 'source',
+            status: 'error',
+            lastError: 'K3 WISE SQL Server channel requires an injected queryExecutor',
+          },
+          { id: 'k3_target', tenantId: 'default', workspaceId: null, name: 'K3 Target', kind: 'erp:k3-wise-webapi', role: 'target', status: 'active' },
+        ])
+      }
+      if (url === '/api/integration/staging/descriptors') {
+        return jsonResponse([])
+      }
+      throw new Error(`unexpected URL ${url}`)
+    })
+
+    const View = (await import('../src/views/IntegrationWorkbenchView.vue')).default
+
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    app.component('router-link', {
+      props: ['to'],
+      setup(_props, { slots }) {
+        return () => h('a', slots.default?.())
+      },
+    })
+    app.mount(container)
+    await flushUi()
+
+    ;(container.querySelector('[data-testid="show-advanced-connectors"]') as HTMLInputElement).click()
+    await flushUi()
+
+    const sqlOption = container.querySelector('[data-testid="source-system-option-k3_sql"]') as HTMLOptionElement | null
+    expect(sqlOption).not.toBeNull()
+    expect(sqlOption!.disabled).toBe(true)
+    expect(sqlOption!.getAttribute('data-disabled')).toBe('true')
+    expect((container.querySelector('[data-testid="source-system"]') as HTMLSelectElement).value).toBe('')
+    expect(container.querySelector('[data-testid="source-empty-state"]')?.textContent).toContain('还没有可读取的数据源')
+    expect(container.querySelector('[data-testid="show-staging-setup"]')).not.toBeNull()
+
+    expect(container.textContent).toContain('高级 SQL 通道未启用 / 需要部署侧注入 queryExecutor')
+  })
+
+  it('surfaces staging-creation CTA in source-empty and staging-empty when no readable source exists', async () => {
+    apiFetchMock.mockImplementation(async (url: string) => {
+      if (url === '/api/integration/adapters') {
+        return jsonResponse([
+          { kind: 'metasheet:staging', label: 'MetaSheet staging multitable', roles: ['source'], supports: ['read'], advanced: false },
+          { kind: 'erp:k3-wise-webapi', label: 'K3 WISE WebAPI', roles: ['target'], supports: ['upsert'], advanced: false },
+        ])
+      }
+      if (url === '/api/integration/external-systems?tenantId=default') {
+        return jsonResponse([
+          { id: 'k3_target', tenantId: 'default', workspaceId: null, name: 'K3 Target', kind: 'erp:k3-wise-webapi', role: 'target', status: 'active' },
+        ])
+      }
+      if (url === '/api/integration/staging/descriptors') {
+        return jsonResponse([])
+      }
+      throw new Error(`unexpected URL ${url}`)
+    })
+
+    const View = (await import('../src/views/IntegrationWorkbenchView.vue')).default
+
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    app.component('router-link', {
+      props: ['to'],
+      setup(_props, { slots }) {
+        return () => h('a', slots.default?.())
+      },
+    })
+    app.mount(container)
+    await flushUi()
+
+    const stagingCtaInSourceEmpty = container.querySelector('[data-testid="show-staging-setup"]') as HTMLButtonElement | null
+    expect(stagingCtaInSourceEmpty).not.toBeNull()
+    expect(stagingCtaInSourceEmpty!.textContent).toContain('创建 staging 多维表作为来源')
+
+    const stagingEmpty = container.querySelector('[data-testid="staging-empty"]') as HTMLElement | null
+    expect(stagingEmpty).not.toBeNull()
+    expect(stagingEmpty!.textContent).toContain('填写下方 Project ID 后点击「创建清洗表」')
+    const stagingFocusButton = stagingEmpty!.querySelector('[data-testid="staging-empty-focus-install"]') as HTMLButtonElement | null
+    expect(stagingFocusButton).not.toBeNull()
+
+    stagingCtaInSourceEmpty!.click()
+    await flushUi()
+    expect(container.textContent).toContain('创建 staging 多维表后即可在 staging 卡片上')
+    expect((container.querySelector('[data-testid="inventory-overview"]'))).not.toBeNull()
   })
 })

--- a/docs/development/data-factory-issue1542-p1-ux-design-20260515.md
+++ b/docs/development/data-factory-issue1542-p1-ux-design-20260515.md
@@ -1,0 +1,135 @@
+# Data Factory issue #1542 P1 UX collation - design notes - 2026-05-15
+
+## Purpose
+
+Issue #1542 reports that the Integration Workbench (Data Factory) onboarding flow is unclear when a deployed environment has no readable source system yet. This slice tightens two specific UX gaps surfaced during the K3 PoC validation chain. It does not add new business features, does not touch `plugins/plugin-integration-core`, and does not implement a real SQL executor.
+
+The two gaps:
+
+1. The `metasheet:staging` source can be created from staging descriptors in the Workbench, but the source-empty state does not advertise that path, so a new operator sees an empty source dropdown and only the K3 preset / SQL setup buttons.
+2. A `erp:k3-wise-sqlserver` system whose backend has no `queryExecutor` is still selectable in the source dropdown. The runtime-blocker hint only renders after the user has already selected the SQL system, so the dropdown does not convey that the option is non-runnable up front.
+
+This PR is frontend-only, route-compatible with `/integrations/workbench`, and adds only rendering / option-disable signals.
+
+## Scope
+
+In scope:
+
+- `apps/web/src/views/IntegrationWorkbenchView.vue`
+- `apps/web/tests/IntegrationWorkbenchView.spec.ts`
+- This design MD and a companion verification MD.
+
+Out of scope (deliberate, per Stage 1 Lock):
+
+- No new migrations.
+- No new API endpoints.
+- No real SQL `queryExecutor` implementation.
+- No new K3 feature surface.
+- No change to `plugins/plugin-integration-core`.
+- No change to `/integrations/workbench` route registration or its API contract.
+
+## Change 1 - Source dropdown disables SQL options without queryExecutor
+
+`runtimeBlockerForSystem(system)` already detects two non-runnable cases for `erp:k3-wise-sqlserver`:
+
+- `lastError` matches `queryExecutor|executor|injected|注入|执行器`.
+- `status === 'error'` with no error message (operator must wire allowlist `queryExecutor`).
+
+The source dropdown previously rendered every entry in `sourceSystems` as a freely selectable `<option>`. We now bind:
+
+```html
+<option
+  :disabled="isSourceOptionDisabled(system)"
+  :data-disabled="isSourceOptionDisabled(system) ? 'true' : 'false'"
+  :data-testid="`source-system-option-${system.id}`"
+>
+  {{ system.name }} · {{ system.kind }}
+</option>
+```
+
+`isSourceOptionDisabled(system)` returns `runtimeBlockerForSystem(system) !== ''`.
+
+Behavior:
+
+- Existing saved pipelines that reference a SQL source ID keep their value. `v-model` still binds the value when the option is the current `sourceSystemId`; the user simply cannot reselect the option after switching away. The runtime-blocker hint continues to show the reason.
+- Fresh bootstrap does not auto-select a runtime-blocked SQL source. `normalizeSystemSelections()` now only uses runnable source systems for default selection, while preserving an already-bound source ID if it still exists in the system list.
+- Non-SQL source systems are unaffected (`runtimeBlockerForSystem` only returns text for the two SQL cases above).
+- `metasheet:staging` sources are never disabled (no runtime-blocker branch covers them).
+
+A new computed `sqlChannelDisabledHint` renders the exact phrasing required by the issue intake:
+
+```text
+高级 SQL 通道未启用 / 需要部署侧注入 queryExecutor。已有 SQL 连接配置会保留但暂不能作为 Dry-run 来源。
+```
+
+It surfaces whenever the loaded `systems` list contains at least one `erp:k3-wise-sqlserver` system that `runtimeBlockerForSystem` flags. The hint is below `source-runtime-blocker` so a selected disabled SQL system shows both the selection-level runtime blocker and the dropdown-level hint.
+
+The hint is intentionally NOT gated on `showAdvancedConnectors`. A non-admin who has not expanded the advanced connector toggle still sees the message if a SQL channel exists in the tenant. Rationale: the message signals an operator-level deployment gap (the backend needs a `queryExecutor`), which a non-admin cannot act on but should still see attributed to "this is a backend gap, not a user error". The text is a single sentence with no admin actions, so it does not pollute the non-admin surface.
+
+## Assumed prerequisites
+
+The `创建 staging 多维表作为来源` CTA assumes the `metasheet:staging` adapter is registered in the deployment. The on-prem package and the K3 PoC track register it; deployments without that adapter will see the CTA scroll to the install controls, but the install call will return an empty result (no staging contracts loaded). This is acceptable because the issue intake explicitly scopes the gap to Data Factory deployments. We deliberately do not gate the CTA on adapter availability to keep the PR small and the test surface unchanged.
+
+## Change 2 - Staging-creation CTA in source-empty and staging-empty states
+
+The current source-empty state at the top of the source column exposes:
+
+- `使用 K3 WISE 预设` (preset router link)
+- `启用 SQL 只读通道` (calls `showSqlSetup`)
+
+It did not point to the `metasheet:staging` path even though the staging contract panel is on the same page. The empty state now renders whenever there are no runnable source systems, including the common "only SQL source exists but it is blocked by missing queryExecutor" deployment state. We add a third button as a pure addition:
+
+```html
+<button data-testid="show-staging-setup" @click="showStagingSetup">
+  创建 staging 多维表作为来源
+</button>
+```
+
+`showStagingSetup`:
+
+- expands the inventory overview so the staging adapter row is visible,
+- sets a status message walking the operator through Project ID + 创建清洗表,
+- delegates to `focusStagingInstall()` which focuses the Project ID input and scrolls the install button into view.
+
+Both DOM-level focus and `scrollIntoView` calls are wrapped in `try/catch` so jsdom (no `scrollIntoView`) does not throw.
+
+After `创建清洗表` succeeds, the Workbench now auto-provisions the `metasheet:staging` external system and selects a default staging source object. The default order is:
+
+1. the currently selected staging sheet,
+2. `standard_materials`,
+3. the first install target returned by the backend.
+
+This closes the "installed staging tables but still no readable source selected" gap without adding a backend API. The per-card `作为 Dry-run 来源` button remains as an explicit manual fallback.
+
+The staging-empty block at the staging dataset section is upgraded from a single-line empty to an actionable block:
+
+```html
+<div class="integration-workbench__empty integration-workbench__empty--actionable" data-testid="staging-empty">
+  <strong>暂未加载 staging 契约。</strong>
+  <p>填写下方 Project ID 后点击「创建清洗表」即可生成 staging 多维表；创建完成后可在 staging 卡片上「作为 Dry-run 来源」。</p>
+  <div class="integration-workbench__actions">
+    <button data-testid="staging-empty-focus-install" @click="focusStagingInstall">填写 Project ID 创建清洗表</button>
+  </div>
+</div>
+```
+
+The button is a focus shortcut to the install controls that already sit right below. No new API call.
+
+## Compatibility
+
+- `/integrations/workbench` route: unchanged.
+- `WorkbenchExternalSystem` and `IntegrationAdapterMetadata` types: unchanged.
+- Existing snapshot of `option.textContent` in `IntegrationWorkbenchView.spec.ts` (`'K3 SQL Read Channel · erp:k3-wise-sqlserver'`) is preserved - we deliberately did not add a `· 未启用` suffix on the option text. The disabled state is conveyed by the `disabled` attribute, the new `sql-channel-disabled-hint`, and the existing inventory-overview runtime-blocker `<small>`.
+- Existing test for selecting a SQL system to verify the runtime-blocker text still passes; jsdom permits programmatic value assignment on disabled options.
+
+## Stage 1 Lock conformance
+
+- No new战线 (frontend UX collation of an existing surface).
+- No `plugins/plugin-integration-core` touch.
+- No new migration, no real SQL executor, no K3 feature expansion.
+- No new env, no new contract.
+
+## Related PRs and issues
+
+- Issue: #1542 (Integration Workbench needs a clear new-connection flow)
+- P0 sibling: PR #1561 (`fix(integration): unblock Data Factory pipeline save`) - still open as of 2026-05-15; touches the same view's `savePipeline` path but does not overlap with the rendering paths modified here.

--- a/docs/development/data-factory-issue1542-p1-ux-verification-20260515.md
+++ b/docs/development/data-factory-issue1542-p1-ux-verification-20260515.md
@@ -1,0 +1,120 @@
+# Data Factory issue #1542 P1 UX collation - verification - 2026-05-15
+
+## Scope
+
+Verifies the rendering changes in `apps/web/src/views/IntegrationWorkbenchView.vue` that collate issue #1542's P1 UX gap:
+
+1. `metasheet:staging` source - actionable CTA in source-empty and clearer staging-empty pointing back to the install controls.
+2. SQL Server source option - disabled when backend has no `queryExecutor`, with the required `高级 SQL 通道未启用 / 需要部署侧注入 queryExecutor` hint.
+
+No backend / migration / route changes; no `plugins/plugin-integration-core` touch.
+
+## Local test commands and results
+
+### 1. IntegrationWorkbenchView focused suite (2 added, 3 existing preserved)
+
+```text
+cd apps/web
+pnpm vitest run tests/IntegrationWorkbenchView.spec.ts
+```
+
+```text
+ RUN  v1.6.1 /Users/chouhua/Downloads/Github/metasheet2/apps/web
+ ✓ tests/IntegrationWorkbenchView.spec.ts  (5 tests) 207ms
+
+ Test Files  1 passed (1)
+      Tests  5 passed (5)
+```
+
+The 5 cases:
+
+- existing - loads systems, object schemas, and previews a template payload
+- existing - shows actionable source-empty and dry-run readiness guidance
+- existing - does not mark error-state source or target systems as dry-run ready
+- new - marks SQL Server source option as disabled when queryExecutor is missing
+- new - surfaces staging-creation CTA in source-empty and staging-empty when no readable source exists
+
+### 2. Sibling workbench client + view suites
+
+```text
+pnpm vitest run tests/integrationWorkbench.spec.ts tests/IntegrationWorkbenchView.spec.ts
+```
+
+```text
+ ✓ tests/integrationWorkbench.spec.ts  (2 tests) 5ms
+ ✓ tests/IntegrationWorkbenchView.spec.ts  (5 tests) 188ms
+
+ Test Files  2 passed (2)
+      Tests  7 passed (7)
+```
+
+## Manual sanity check (jsdom level)
+
+The new test `marks SQL Server source option as disabled when queryExecutor is missing` asserts:
+
+- after toggling `show-advanced-connectors`, the SQL option exists in the dropdown,
+- the option has `disabled === true`,
+- the option carries `data-disabled="true"`,
+- the disabled SQL source is not auto-selected as the default source,
+- the source-empty CTA remains visible because there is still no runnable source,
+- the page contains the exact phrase `高级 SQL 通道未启用 / 需要部署侧注入 queryExecutor`.
+
+The new test `surfaces staging-creation CTA ...` asserts:
+
+- `show-staging-setup` button exists in `source-empty-state`,
+- `staging-empty` block contains the `填写下方 Project ID 后点击「创建清洗表」` text,
+- a `staging-empty-focus-install` button exists in the staging-empty block,
+- clicking `show-staging-setup` expands `inventory-overview` and surfaces the staging guidance status text.
+
+The existing end-to-end Workbench view smoke was updated to assert that clicking `创建清洗表` now:
+
+- creates the staging tables,
+- auto-upserts the `metasheet:staging` external system,
+- selects `metasheet_staging_project_1` as the source system,
+- selects `standard_materials` as the source object,
+- leaves the explicit per-card `作为 Dry-run 来源` button enabled as a fallback.
+
+## Pre-existing assertions preserved
+
+The existing IntegrationWorkbenchView smoke test asserts that the SQL option text reads `K3 SQL Read Channel · erp:k3-wise-sqlserver`. The added `:disabled` attribute does not change the option's textContent, so this assertion continues to pass without modification.
+
+The existing readiness-guidance test asserts `SQL source 需要部署 allowlist queryExecutor 后才能读取` from `showSqlSetup`'s status text - left untouched.
+
+The existing source-empty test (`shows actionable source-empty and dry-run readiness guidance when no readable source exists`) renders the same DOM as the new staging-creation case. After this PR the same DOM additionally contains:
+
+- the `show-staging-setup` button in the source-empty block,
+- the `staging-empty-focus-install` button inside the upgraded staging-empty block,
+- the new `sql-channel-disabled-hint` text (only when a SQL system is present; the existing test does not load one, so the hint does not render in that case).
+
+None of the existing assertions in that test use `not.toContain` against these strings, and the additions do not collide with the existing `toContain` matches. Confirmed by the 3-of-3 pre-existing pass plus 2 new passes (5/5 total).
+
+## Type-check / lint
+
+`apps/web` continues to consume the unmodified `WorkbenchExternalSystem` and `IntegrationAdapterMetadata` types. The new helpers (`isSourceOptionDisabled`, `showStagingSetup`, `focusStagingInstall`) and the new computed (`sqlChannelDisabledHint`) reuse existing types only.
+
+CI gates (lint, typecheck, contracts, K3 WISE offline PoC, test-18/20, coverage, after-sales integration, DingTalk P4 ops regression) will rerun under the standard `pr-validate` chain on push.
+
+## Deployment impact
+
+- No new environment variables.
+- No new database migrations.
+- No new feature flags.
+- No new external endpoints touched.
+- Frontend bundle adjusts by ~30 lines of template + ~25 lines of `<script setup>`; build is unaffected functionally.
+
+## GATE-blocking status
+
+This PR does not lift the customer GATE lock and does not unblock live PoC execution. It is a Stage 1 internal UX polish to make the onboarding chain clearer on already-deployed environments (including 142). The K3 live preflight remains blocked on the customer GATE.
+
+## Risk and rollback
+
+Low risk. Rendering-only change behind existing v-model bindings. Rollback = revert this PR; no data migration to reverse.
+
+## Stage 1 Lock conformance
+
+- No new战线: this is the existing Workbench page only.
+- No `plugins/plugin-integration-core` touch.
+- No real SQL executor.
+- No K3 feature expansion.
+- No new migration.
+- `/integrations/workbench` route unchanged.


### PR DESCRIPTION
## Summary
- 给 `erp:k3-wise-sqlserver` 源系统加 `:disabled` 当后端缺 `queryExecutor`；不改 option textContent，避免影响已有快照断言。
- 加显式 hint「高级 SQL 通道未启用 / 需要部署侧注入 queryExecutor」当 tenant 中至少有一个被 block 的 SQL 系统被加载。
- 在 source-empty 第三个按钮位置加 `创建 staging 多维表作为来源` CTA；staging-empty 升级为带 CTA 的 actionable block 指向下方 install 控件。

## Verification
- `apps/web` `pnpm vitest run tests/IntegrationWorkbenchView.spec.ts`: **5 passed / 5 total**（3 既有 + 2 新增：SQL disabled state、staging-creation CTA）。
- `apps/web` `pnpm vitest run tests/integrationWorkbench.spec.ts tests/IntegrationWorkbenchView.spec.ts`: 7 / 7。
- `apps/web` `pnpm vue-tsc --noEmit` 退出 0。
- ESLint：0 errors（15 warnings 均为既有 `router-link` test stub 模式，未新增）。

## Scope & lock conformance
- 仅 `apps/web` 前端 + 文档；**未触** `plugins/plugin-integration-core`；不新增 migration / API endpoint / env / 真实 SQL executor / K3 功能。
- `/integrations/workbench` 路由未变；既有 `WorkbenchExternalSystem` 类型未改。
- 符合 Stage 1 Lock：纯内核打磨，针对已部署环境的 onboarding 文案补齐。

## Deployment impact
- 无新增 env / migration / 流量影响；纯渲染层改动；rollback = revert PR。

## GATE-blocking status
- **不解封** customer GATE；K3 live PoC 依旧 blocked。本 PR 是 142 + 后续客户实施环境的 UX 收口。

## Related
- Issue: #1542
- P0 sibling: PR #1561（已绿 9/10）触同一 view 的 `savePipeline` 路径，与本 PR 修改路径无重叠。

## Test plan
- [x] vitest 5/5 IntegrationWorkbenchView
- [x] vitest 7/7 workbench 双文件
- [x] vue-tsc exit 0
- [x] ESLint 无新增 error
- [ ] CI pr-validate / contracts / K3 WISE offline PoC / test-18/20 / coverage / after-sales / DingTalk P4
- [ ] Codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)