### PR TITLE
docs(multitable): close phase3 active queue metadata

### DIFF
--- a/docs/development/multitable-feishu-phase3-ai-hardening-todo-20260514.md
+++ b/docs/development/multitable-feishu-phase3-ai-hardening-todo-20260514.md
@@ -647,7 +647,7 @@ Owner recommendation: Codex.
   - Verification summary: soak polls automation logs for every rule and treats the controlled failing webhook as PASS only when failed executions are persisted with step errors.
 - [x] Add redacted execution support packet copy/download actions to the shipped run-history UI.
   - PR: #1564
-  - Merge commit: pending.
+  - Merge commit: `8dd1eb1b1`
   - Development MD: `docs/development/multitable-automation-log-support-packet-development-20260515.md`
   - Verification MD: `docs/development/multitable-automation-log-support-packet-verification-20260515.md`
   - Verification summary: `MetaAutomationLogViewer` exposes copy/download actions for each expanded execution; generated Markdown/JSON packets use the shared automation log redactor and summarize step output/error without raw recipient, token, SMTP, webhook, or DingTalk receiver values.

--- a/docs/development/multitable-phase3-active-queue-closeout-development-20260515.md
+++ b/docs/development/multitable-phase3-active-queue-closeout-development-20260515.md
@@ -1,0 +1,42 @@
+# Multitable Phase 3 Active Queue Closeout - Development
+
+Date: 2026-05-15
+
+## Purpose
+
+This is a docs-only closeout after PR #1564 merged. The Phase 3 TODO
+requires completed implementation items to carry PR number, merge
+commit, development MD, verification MD, and verification summary. PR
+#1564 was merged after its own TODO entry was written, so the TODO still
+contained `Merge commit: pending`.
+
+## Change
+
+Updated
+`docs/development/multitable-feishu-phase3-ai-hardening-todo-20260514.md`
+for the automation log support-packet item:
+
+- PR: `#1564`
+- Merge commit: `8dd1eb1b1`
+
+## Scope
+
+In scope:
+
+- Phase 3 TODO metadata correction only.
+- This development note.
+- Matching verification note.
+
+Out of scope:
+
+- No source code change.
+- No test code change.
+- No route, migration, OpenAPI, workflow, K3, Data Factory, Attendance,
+  DingTalk runtime, or `plugins/plugin-integration-core/*` change.
+- No change to the still-deferred Phase 3 AI / formula / template /
+  performance / permission-matrix lanes.
+
+## Claude Handoff
+
+No Claude development is needed for this closeout. The task is a
+deterministic metadata correction from GitHub merge state.

--- a/docs/development/multitable-phase3-active-queue-closeout-verification-20260515.md
+++ b/docs/development/multitable-phase3-active-queue-closeout-verification-20260515.md
@@ -1,0 +1,56 @@
+# Multitable Phase 3 Active Queue Closeout - Verification
+
+Date: 2026-05-15
+
+## Result
+
+PASS.
+
+## Verified Inputs
+
+- PR #1564 state: `MERGED`
+- PR #1564 merge time: `2026-05-15T02:18:25Z`
+- PR #1564 merge commit: `8dd1eb1b1`
+- Base for this closeout worktree: `origin/main@1bcbcce98`
+
+## Verification Commands
+
+```bash
+gh pr view 1564 --json number,state,mergeCommit,mergedAt \
+  --jq '{number,state,mergedAt,mergeCommit:(.mergeCommit.oid[0:9])}'
+```
+
+Observed:
+
+```json
+{"mergeCommit":"8dd1eb1b1","mergedAt":"2026-05-15T02:18:25Z","number":1564,"state":"MERGED"}
+```
+
+```bash
+git diff --check
+```
+
+Result: passed with no output.
+
+```bash
+rg -n "Merge commit: pending|#1564" docs/development/multitable-feishu-phase3-ai-hardening-todo-20260514.md
+```
+
+Result: `#1564` now records `Merge commit: \`8dd1eb1b1\``.
+
+## Scope Check
+
+Changed files are docs-only:
+
+- `docs/development/multitable-feishu-phase3-ai-hardening-todo-20260514.md`
+- `docs/development/multitable-phase3-active-queue-closeout-development-20260515.md`
+- `docs/development/multitable-phase3-active-queue-closeout-verification-20260515.md`
+
+No application source, tests, route, migration, workflow, OpenAPI,
+K3, Data Factory, Attendance, DingTalk runtime, or
+`plugins/plugin-integration-core/*` file is modified.
+
+## Final Verdict
+
+PASS. This closeout only synchronizes the Phase 3 TODO with the already
+merged #1564 GitHub state.


### PR DESCRIPTION
## Summary
- Record #1564 merge commit in the Phase 3 TODO.
- Add docs-only development and verification notes for the active queue closeout.

## Scope
- Docs-only metadata correction.
- No source, test, route, migration, OpenAPI, workflow, Data Factory, K3, Attendance, DingTalk runtime, or plugin-integration-core changes.

## Verification
- gh pr view 1564 --json number,state,mergeCommit,mergedAt --jq '{number,state,mergedAt,mergeCommit:(.mergeCommit.oid[0:9])}'
  - observed MERGED / 8dd1eb1b1 / 2026-05-15T02:18:25Z
- git diff --check
  - passed with no output
- rg confirmed #1564 now records Merge commit: 8dd1eb1b1 in the Phase 3 TODO

## Claude
- Not needed; this is deterministic docs metadata closeout.