### PR TITLE
fix(integration): gate Data Factory pipeline save readiness

### DIFF
--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -406,7 +406,7 @@
           <h2>Pipeline 执行</h2>
           <p>先保存 pipeline，再 dry-run。Save-only 推送必须显式勾选，默认不会 Submit / Audit。</p>
         </div>
-        <button type="button" class="integration-workbench__button" data-testid="save-pipeline" :disabled="savingPipeline" @click="savePipeline">
+        <button type="button" class="integration-workbench__button" data-testid="save-pipeline" :disabled="savingPipeline || !canSavePipeline" @click="savePipeline">
           {{ savingPipeline ? '保存中' : '保存 Pipeline' }}
         </button>
       </div>
@@ -462,8 +462,10 @@
 
       <div class="integration-workbench__readiness" data-testid="pipeline-readiness">
         <div>
+          <strong>保存 Pipeline 前置条件</strong>
+          <p data-testid="save-readiness-summary">{{ savePipelineBlockedSummary }}</p>
           <strong>Dry-run 前置条件</strong>
-          <p>{{ dryRunBlockedSummary }}</p>
+          <p data-testid="dry-run-readiness-summary">{{ dryRunBlockedSummary }}</p>
         </div>
         <ul>
           <li v-for="item in dryRunReadinessItems" :key="item.id" :data-ready="item.ready ? 'true' : 'false'">
@@ -822,6 +824,50 @@ const protocolSplitNotice = computed(() => {
 })
 const hasMappingRules = computed(() => mappings.value.some((mapping) => mapping.sourceField.trim() && mapping.targetField.trim()))
 const hasIdempotencyFields = computed(() => parseList(idempotencyFieldsText.value).length > 0)
+const savePipelineReadinessItems = computed(() => [
+  {
+    id: 'source-system',
+    label: '选择数据源系统',
+    ready: Boolean(sourceSystemId.value),
+    detail: sourceSystemId.value ? '数据源系统已选择。' : '请选择已有数据源，或先创建 staging 多维表作为来源。',
+  },
+  {
+    id: 'source-object',
+    label: '选择来源数据集',
+    ready: Boolean(sourceObjectName.value),
+    detail: sourceObjectName.value || '加载来源数据集后才能保存 pipeline。',
+  },
+  {
+    id: 'target-system',
+    label: '选择目标系统',
+    ready: Boolean(targetSystemId.value),
+    detail: targetSystemId.value ? '目标系统已选择。' : '请选择 K3 WebAPI、多维表或其他可写目标。',
+  },
+  {
+    id: 'target-object',
+    label: '选择目标数据集 / 模板',
+    ready: Boolean(targetObjectName.value),
+    detail: targetObjectName.value || '加载目标数据集后才能生成 payload 或保存 pipeline。',
+  },
+  {
+    id: 'mapping',
+    label: '配置清洗映射规则',
+    ready: hasMappingRules.value,
+    detail: hasMappingRules.value ? '至少一条 source -> target 映射已配置。' : '请先加载目标 schema 或手工新增映射。',
+  },
+  {
+    id: 'idempotency',
+    label: '填写幂等字段',
+    ready: hasIdempotencyFields.value,
+    detail: hasIdempotencyFields.value ? '幂等字段已填写。' : '例如 code 或 sourceId,revision。',
+  },
+])
+const canSavePipeline = computed(() => savePipelineReadinessItems.value.every((item) => item.ready))
+const savePipelineBlockedSummary = computed(() => {
+  const missing = savePipelineReadinessItems.value.filter((item) => !item.ready)
+  if (missing.length === 0) return '已满足保存条件。保存只写入 pipeline 配置，不调用外部系统。'
+  return `还缺 ${missing.length} 项：${missing.map((item) => item.label).join('、')}`
+})
 const dryRunReadinessItems = computed(() => [
   {
     id: 'source-system',

--- a/apps/web/tests/IntegrationWorkbenchView.spec.ts
+++ b/apps/web/tests/IntegrationWorkbenchView.spec.ts
@@ -399,6 +399,8 @@ describe('IntegrationWorkbenchView', () => {
     expect(container.textContent).not.toContain('K3 WISE SQL Server Channel')
     expect(container.textContent).toContain('已隐藏 1 个高级连接')
     expect((container.querySelector('[data-testid="staging-sheet"]') as HTMLSelectElement).value).toBe('standard_materials')
+    expect((container.querySelector('[data-testid="save-pipeline"]') as HTMLButtonElement).disabled).toBe(true)
+    expect(container.querySelector('[data-testid="save-readiness-summary"]')?.textContent).toContain('选择来源数据集')
     expect(Array.from((container.querySelector('[data-testid="source-system"]') as HTMLSelectElement).options).map((option) => option.textContent))
       .not.toContain('K3 SQL Read Channel · erp:k3-wise-sqlserver')
 
@@ -501,6 +503,8 @@ describe('IntegrationWorkbenchView', () => {
     expect((container.querySelector('[data-testid="transform-fn-0"]') as HTMLSelectElement).value).toBe('trim')
     expect((container.querySelector('[data-testid="transform-fn-3"]') as HTMLSelectElement).value).toBe('toNumber')
     expect(container.textContent).toContain('Material code')
+    expect((container.querySelector('[data-testid="save-pipeline"]') as HTMLButtonElement).disabled).toBe(false)
+    expect(container.querySelector('[data-testid="save-readiness-summary"]')?.textContent).toContain('已满足保存条件')
 
     const firstTransform = container.querySelector('[data-testid="transform-fn-0"]') as HTMLSelectElement
     firstTransform.value = 'upper'
@@ -694,7 +698,9 @@ describe('IntegrationWorkbenchView', () => {
     expect(container.textContent).toContain('连接 PLM、HTTP API 或启用 SQL 只读通道')
     expect(container.textContent).toContain('还缺')
     expect(container.textContent).toContain('选择可读取的数据源')
+    expect(container.querySelector('[data-testid="save-readiness-summary"]')?.textContent).toContain('选择数据源系统')
     expect(container.textContent).toContain('Payload 预览通过不等于 pipeline dry-run')
+    expect((container.querySelector('[data-testid="save-pipeline"]') as HTMLButtonElement).disabled).toBe(true)
     expect((container.querySelector('[data-testid="run-dry-run"]') as HTMLButtonElement).disabled).toBe(true)
 
     ;(container.querySelector('[data-testid="show-sql-setup"]') as HTMLButtonElement).click()

--- a/docs/development/data-factory-issue1542-p2-prereq-design-20260515.md
+++ b/docs/development/data-factory-issue1542-p2-prereq-design-20260515.md
@@ -1,0 +1,142 @@
+# Data Factory issue #1542 P2 prerequisite guidance - design notes - 2026-05-15
+
+## Purpose
+
+Issue #1542 is mainly an onboarding problem: users can reach the Data Factory Workbench, but when a source, target, mapping, or saved pipeline is missing, the page can feel like a dead end.
+
+P0 fixed pipeline persistence. P1 made staging-as-source and blocked SQL executor states visible. This P2 slice tightens the next operator-facing gap: do not let users click `保存 Pipeline` when the Workbench already knows the pipeline cannot be saved yet.
+
+This is a frontend-only guardrail. It does not add a backend API, migration, SQL executor, K3 template, or new integration behavior.
+
+## Scope
+
+Changed:
+
+- `apps/web/src/views/IntegrationWorkbenchView.vue`
+- `apps/web/tests/IntegrationWorkbenchView.spec.ts`
+- This design MD
+- Companion verification MD
+
+Out of scope:
+
+- No `plugins/plugin-integration-core` changes.
+- No migration.
+- No real SQL Server query executor.
+- No Save-only behavior change.
+- No route change for `/integrations/workbench`.
+- No new connection-management page.
+
+## Problem
+
+Before this slice, the page already rendered a `Dry-run 前置条件` checklist and disabled the dry-run button until all required conditions were ready.
+
+However, `保存 Pipeline` was still enabled unless a save request was already in flight:
+
+```html
+<button :disabled="savingPipeline">保存 Pipeline</button>
+```
+
+If source object, target object, field mappings, or idempotency keys were missing, clicking the button fell through to `buildPipelinePayload()` and surfaced one error at a time.
+
+That behavior was safe, but poor for deployed trial users. It made the page reactive instead of guiding:
+
+1. User clicks save.
+2. UI reports the first missing item.
+3. User fixes that item.
+4. User clicks again.
+5. UI reports the next missing item.
+
+The issue asked for a clear checklist of missing prerequisites instead of generic late errors.
+
+## Design
+
+### 1. Separate save readiness from dry-run readiness
+
+The page now computes save readiness independently:
+
+```ts
+const savePipelineReadinessItems = computed(() => [
+  source system,
+  source object,
+  target system,
+  target object,
+  mapping,
+  idempotency,
+])
+```
+
+`canSavePipeline` is true only when every save prerequisite is ready.
+
+`savePipelineBlockedSummary` renders either:
+
+- `已满足保存条件。保存只写入 pipeline 配置，不调用外部系统。`
+- `还缺 N 项：...`
+
+This intentionally does not require a successful live connection test. Saving pipeline configuration is a metadata operation. Runtime availability is still handled by dry-run readiness and backend execution errors.
+
+### 2. Disable Save Pipeline until prerequisites are complete
+
+The save button now uses:
+
+```html
+:disabled="savingPipeline || !canSavePipeline"
+```
+
+The existing `buildPipelinePayload()` validation remains as a defensive guard for programmatic calls and unexpected UI states. The UI guard is a product affordance, not the only validation layer.
+
+### 3. Preserve dry-run semantics
+
+`dryRunReadinessItems` remains stricter than save readiness. It still requires:
+
+- active readable source,
+- selected source object,
+- active target,
+- selected target object,
+- mappings,
+- idempotency,
+- saved pipeline ID.
+
+This keeps the distinction visible:
+
+- `保存 Pipeline`: writes only pipeline config.
+- `Dry-run`: runs the pipeline preview path and requires a saved pipeline.
+
+### 4. Keep copy deployment-friendly
+
+The new copy avoids implying that payload preview equals dry-run or that saving writes to K3:
+
+- Save summary explicitly says saving only writes pipeline config.
+- Dry-run summary still says dry-run only generates preview and does not write external systems.
+
+## Compatibility
+
+- Existing route: unchanged.
+- Existing API calls: unchanged.
+- Existing backend validation: unchanged.
+- Existing complete Workbench happy path: preserved.
+- Existing source-empty and SQL blocked guidance: preserved.
+
+The only UX behavior change is that `保存 Pipeline` cannot be clicked before the minimum config shape exists.
+
+## Deployment impact
+
+No deployment-side impact:
+
+- no new env,
+- no database migration,
+- no Docker/package change,
+- no workflow change,
+- no Windows on-prem packaging change.
+
+This can ship as a normal frontend update.
+
+## GATE status
+
+This does not lift the K3 customer GATE. It only makes the internal/bridge trial Workbench clearer while GATE data is still pending.
+
+## Risk
+
+Low. The main risk is an overly strict save gate. To avoid that, save readiness only checks that IDs/objects/mappings/idempotency are present; it does not require connection status to be active.
+
+Dry-run remains the stricter runtime gate.
+

--- a/docs/development/data-factory-issue1542-p2-prereq-verification-20260515.md
+++ b/docs/development/data-factory-issue1542-p2-prereq-verification-20260515.md
@@ -1,0 +1,135 @@
+# Data Factory issue #1542 P2 prerequisite guidance - verification - 2026-05-15
+
+## Scope
+
+Verifies the P2 frontend guardrail for issue #1542:
+
+- `保存 Pipeline` is disabled until minimum save prerequisites are complete.
+- The Workbench shows a save-specific prerequisite summary.
+- Existing dry-run readiness remains intact.
+- Existing staging-as-source and SQL blocked UX still pass.
+
+No backend, migration, route, or package change is included.
+
+## Local commands and results
+
+### 1. Focused Workbench view suite
+
+```text
+cd apps/web
+pnpm vitest run tests/IntegrationWorkbenchView.spec.ts --watch=false
+```
+
+Result:
+
+```text
+RUN  v1.6.1 /Users/chouhua/Downloads/Github/metasheet2/apps/web
+
+✓ tests/IntegrationWorkbenchView.spec.ts  (5 tests) 208ms
+
+Test Files  1 passed (1)
+Tests  5 passed (5)
+```
+
+### 2. Workbench client + view regression
+
+```text
+cd apps/web
+pnpm vitest run tests/integrationWorkbench.spec.ts tests/IntegrationWorkbenchView.spec.ts --watch=false
+```
+
+Result:
+
+```text
+✓ tests/integrationWorkbench.spec.ts  (2 tests) 5ms
+✓ tests/IntegrationWorkbenchView.spec.ts  (5 tests) 216ms
+
+Test Files  2 passed (2)
+Tests  7 passed (7)
+```
+
+### 3. Type check
+
+```text
+cd apps/web
+pnpm vue-tsc --noEmit
+```
+
+Result: exit code 0.
+
+### 4. Frontend production build
+
+```text
+cd apps/web
+pnpm build
+```
+
+Result:
+
+```text
+> @metasheet/web@2.0.0-alpha.1 build /Users/chouhua/Downloads/Github/metasheet2/apps/web
+> vue-tsc -b && vite build
+
+✓ 2391 modules transformed.
+✓ built in 6.03s
+```
+
+Vite emitted the existing large chunk warning and the existing mixed dynamic/static import warning for `WorkflowDesigner.vue`; neither is introduced by this Data Factory view change.
+
+### 5. Whitespace / conflict marker check
+
+```text
+git diff --check origin/main...HEAD
+```
+
+Result: exit code 0.
+
+## Assertions added
+
+The existing full Workbench smoke now asserts:
+
+- initial bootstrap disables `save-pipeline` while source/target objects and mappings are still missing,
+- `save-readiness-summary` names `选择来源数据集` as one missing prerequisite,
+- after staging-as-source is selected, target schema is loaded, mappings are seeded, and idempotency is present, `save-pipeline` becomes enabled,
+- `save-readiness-summary` changes to `已满足保存条件`.
+
+The existing source-empty guidance test now asserts:
+
+- `save-readiness-summary` names `选择数据源系统` when no readable source exists,
+- `save-pipeline` is disabled,
+- `run-dry-run` remains disabled.
+
+## Preserved behavior
+
+The focused suite still covers and passes:
+
+- Workbench renders `数据工厂`.
+- K3 WISE preset entry remains visible.
+- SQL Server source option is disabled when `queryExecutor` is missing.
+- Staging creation CTA remains visible in source-empty and staging-empty states.
+- Creating staging tables can auto-create/select `metasheet:staging` as source.
+- Template payload preview still produces the K3 `Data` wrapper.
+- Saving a complete pipeline still posts to `/api/integration/pipelines`.
+- Dry-run still posts to `/api/integration/pipelines/:id/dry-run`.
+- Save-only run still requires the explicit checkbox.
+- Exported dry-run results still redact secret-shaped values.
+
+## Safety checks
+
+The change does not:
+
+- print or store secrets,
+- call external systems,
+- alter Save-only execution,
+- change submit/audit defaults,
+- expose raw SQL,
+- introduce new migrations.
+
+## Manual reasoning
+
+Save readiness and dry-run readiness are deliberately not identical:
+
+- Saving a pipeline is metadata persistence, so it only needs selected systems/objects, mappings, and idempotency.
+- Dry-run is an execution path, so it still requires active source/target status plus a saved pipeline ID.
+
+This prevents a common deployment-test trap: users can see exactly why they cannot save yet, without mistaking payload preview for pipeline dry-run.


### PR DESCRIPTION
## Summary

Closes the next small UX gap from issue #1542 after #1561/#1563:

- disables `保存 Pipeline` until the minimum save prerequisites exist,
- adds a save-specific readiness summary separate from Dry-run readiness,
- keeps Dry-run stricter by requiring active source/target state and saved pipeline ID,
- documents the design and verification in two MD files.

This is frontend-only. It does not add a migration, backend route, SQL executor, K3 feature, or Save-only behavior change.

## Verification

Local commands run:

```text
cd apps/web
pnpm vitest run tests/IntegrationWorkbenchView.spec.ts --watch=false
pnpm vitest run tests/integrationWorkbench.spec.ts tests/IntegrationWorkbenchView.spec.ts --watch=false
pnpm vue-tsc --noEmit
pnpm build
```

Results:

- `IntegrationWorkbenchView.spec.ts`: 5/5 pass
- `integrationWorkbench.spec.ts + IntegrationWorkbenchView.spec.ts`: 7/7 pass
- `pnpm vue-tsc --noEmit`: exit 0
- `pnpm build`: success (`2391 modules transformed`, `built in 6.03s`)
- `git diff --check origin/main...HEAD`: exit 0

## Deployment impact

- No env changes
- No DB migration
- No package/runtime dependency changes
- No route changes
- No customer GATE unlock

## Notes

Save readiness deliberately does not require a successful runtime connection test. Saving is metadata persistence. Dry-run remains the stricter execution gate.
