### PR TITLE
test(integration): add issue1542 Data Factory postdeploy smoke

### DIFF
--- a/docs/development/data-factory-issue1542-postdeploy-smoke-design-20260515.md
+++ b/docs/development/data-factory-issue1542-postdeploy-smoke-design-20260515.md
@@ -1,0 +1,79 @@
+# Data Factory issue #1542 postdeploy smoke - design notes - 2026-05-15
+
+## Scope
+
+This slice extends the existing K3 WISE postdeploy smoke with an opt-in Data
+Factory retest for issue #1542. The goal is to make the deployed-box validation
+repeatable after a new package is installed, without turning the normal
+postdeploy smoke into a write-heavy test.
+
+The new flag is:
+
+```bash
+--issue1542-workbench-smoke
+```
+
+It is intentionally opt-in because it creates or updates one draft integration
+pipeline metadata row. It never runs pipeline dry-run, Save-only, Submit, or
+Audit.
+
+## Why this exists
+
+The bridge/test feedback for #1542 had three practical blockers:
+
+- `metasheet:staging` source schema returned `fields: []`.
+- `POST /api/integration/pipelines` failed with PostgreSQL JSONB `22P02`.
+- SQL Server still returned `SQLSERVER_EXECUTOR_MISSING`.
+
+The first two should be retestable from the deployed host immediately after a
+package update. The third remains a separate SQL executor deployment/wiring
+item and is not claimed by this smoke.
+
+## Behavior
+
+When `--issue1542-workbench-smoke` is supplied together with an auth token, the
+script adds these checks:
+
+| Check | Purpose |
+| --- | --- |
+| `issue1542-system-readiness` | Load configured external systems and find a `metasheet:staging` source plus an `erp:k3-wise-webapi` target. |
+| `issue1542-staging-source-schema` | Call staging source objects/schema APIs and require `standard_materials` fields `code`, `name`, and `uom`. |
+| `issue1542-k3-material-schema` | Call K3 target objects/schema APIs and require material fields `FNumber`, `FName`, and `FBaseUnitID`. |
+| `issue1542-pipeline-save` | Save a fixed draft pipeline id and verify JSONB-shaped values hydrate back as arrays/objects. |
+
+The fixed pipeline id is:
+
+```text
+issue1542_postdeploy_staging_material_smoke
+```
+
+Using a fixed id avoids creating a new pipeline on every smoke run. Re-running
+the smoke should update the same draft metadata row.
+
+## Safety
+
+- The pipeline status is `draft`.
+- `options.target.autoSubmit=false`.
+- `options.target.autoAudit=false`.
+- The script does not call `/dry-run` or `/run`.
+- The target object is K3 `material`, but this slice only saves metadata in
+  MetaSheet.
+- Existing token/base-url redaction continues to cover stdout, JSON evidence,
+  and Markdown evidence.
+
+## Files changed
+
+- `scripts/ops/integration-k3wise-postdeploy-smoke.mjs`
+- `scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs`
+- `scripts/ops/multitable-onprem-package-verify.sh`
+- `docs/operations/integration-k3wise-internal-trial-runbook.md`
+- `docs/development/data-factory-issue1542-postdeploy-smoke-design-20260515.md`
+- `docs/development/data-factory-issue1542-postdeploy-smoke-verification-20260515.md`
+
+## Out of scope
+
+- No SQL Server executor implementation.
+- No new database migration.
+- No frontend behavior change.
+- No customer K3 live Submit/Audit.
+- No automatic cleanup route for pipelines; the fixed draft id is reused instead.

--- a/docs/development/data-factory-issue1542-postdeploy-smoke-verification-20260515.md
+++ b/docs/development/data-factory-issue1542-postdeploy-smoke-verification-20260515.md
@@ -1,0 +1,102 @@
+# Data Factory issue #1542 postdeploy smoke - verification - 2026-05-15
+
+## Commands
+
+```bash
+node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
+pnpm verify:integration-k3wise:poc
+git diff --check
+```
+
+## Results
+
+```text
+node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
+20 tests passed
+```
+
+New coverage:
+
+- `issue1542 workbench smoke verifies staging schema and draft pipeline save`
+- `issue1542 workbench smoke fails when staging schema is empty`
+- `issue1542 workbench smoke fails clearly when pipeline save still hits JSONB 22P02`
+
+```text
+pnpm verify:integration-k3wise:poc
+PASS
+```
+
+Included sub-results:
+
+- preflight tests: 21 passed
+- evidence tests: 50 passed
+- fixture contract tests: 2 passed
+- mock K3 WebAPI tests: 4 passed
+- mock SQL Server executor tests: 12 passed
+- mock PoC chain: PASS
+
+```text
+git diff --check
+0 whitespace/conflict-marker findings
+```
+
+## Assertions
+
+### Opt-in behavior
+
+Default postdeploy smoke behavior is unchanged. The new #1542 checks only run
+when `--issue1542-workbench-smoke` is supplied.
+
+### Staging schema regression
+
+The smoke fails if the deployed staging source returns `fields: []` for
+`standard_materials`. The failure check records:
+
+- object name;
+- returned field count;
+- required fields;
+- missing fields.
+
+### Pipeline JSONB regression
+
+The smoke fails clearly if pipeline save still returns HTTP 500 with PostgreSQL
+`22P02`. This catches the deployed-box symptom reported in #1542 before an
+operator attempts a UI dry-run.
+
+### Secret handling
+
+The existing postdeploy smoke token leak assertions continue to pass:
+
+- token value is not present in stdout;
+- token value is not present in stderr;
+- token value is not present in generated JSON evidence.
+
+The new #1542 smoke does not add credentials or connection strings to evidence.
+
+## Deployment retest command
+
+After installing a package that contains this change:
+
+```bash
+node scripts/ops/integration-k3wise-postdeploy-smoke.mjs \
+  --base-url "$METASHEET_BASE_URL" \
+  --token-file "$METASHEET_AUTH_TOKEN_FILE" \
+  --tenant-id "$METASHEET_TENANT_ID" \
+  --require-auth \
+  --issue1542-workbench-smoke \
+  --out-dir artifacts/integration-k3wise/internal-trial/postdeploy-smoke-issue1542
+```
+
+Expected additional passing checks:
+
+- `issue1542-system-readiness`
+- `issue1542-staging-source-schema`
+- `issue1542-k3-material-schema`
+- `issue1542-pipeline-save`
+
+## Remaining risk
+
+`SQLSERVER_EXECUTOR_MISSING` is still outside this slice. The smoke makes that
+separation explicit: staging-to-K3 metadata readiness can pass while direct SQL
+Server source execution remains blocked until a real executor is deployed and
+wired.

--- a/docs/operations/integration-k3wise-internal-trial-runbook.md
+++ b/docs/operations/integration-k3wise-internal-trial-runbook.md
@@ -109,6 +109,25 @@ node scripts/ops/integration-k3wise-postdeploy-smoke.mjs \
   --out-dir artifacts/integration-k3wise/internal-trial/postdeploy-smoke
 ```
 
+For the Data Factory issue #1542 deployment retest, add the opt-in workbench
+smoke flag:
+
+```bash
+node scripts/ops/integration-k3wise-postdeploy-smoke.mjs \
+  --base-url "$METASHEET_BASE_URL" \
+  --token-file "$METASHEET_AUTH_TOKEN_FILE" \
+  --tenant-id "$METASHEET_TENANT_ID" \
+  --require-auth \
+  --issue1542-workbench-smoke \
+  --out-dir artifacts/integration-k3wise/internal-trial/postdeploy-smoke-issue1542
+```
+
+This extra smoke verifies that a configured `metasheet:staging` source exposes
+non-empty `standard_materials` schema, the K3 target exposes the `material`
+template schema, and a fixed draft pipeline ID can be saved without PostgreSQL
+JSONB `22P02`. It writes pipeline metadata only and never runs dry-run,
+Save-only, Submit, or Audit.
+
 Then render the summary:
 
 ```bash

--- a/scripts/ops/integration-k3wise-postdeploy-smoke.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-smoke.mjs
@@ -5,6 +5,7 @@ import { pathToFileURL } from 'node:url'
 
 const DEFAULT_BASE_URL = 'http://142.171.239.56:8081'
 const DEFAULT_OUTPUT_ROOT = 'output/integration-k3wise-postdeploy-smoke'
+const ISSUE1542_SMOKE_PIPELINE_ID = 'issue1542_postdeploy_staging_material_smoke'
 const REQUIRED_ADAPTERS = [
   'http',
   'plm:yuantus-wrapper',
@@ -163,9 +164,14 @@ Options:
   --auth-token <token>   Optional bearer token for authenticated checks
   --token-file <path>    Optional file containing bearer token
   --tenant-id <id>       Optional tenant scope for authenticated list probes
+  --workspace-id <id>    Optional workspace scope for authenticated probes
   --require-auth         Fail when no token is supplied or auth checks are skipped
   --out-dir <dir>        Output directory, default ${DEFAULT_OUTPUT_ROOT}/<timestamp>
   --timeout-ms <ms>      Per-request timeout, default 10000
+  --issue1542-workbench-smoke
+                          Opt-in Data Factory #1542 smoke: verify staging schema
+                          discovery and draft pipeline save. Writes metadata only;
+                          never runs dry-run or Save-only.
   --help                 Show this help
 
 Environment fallbacks:
@@ -198,7 +204,9 @@ function parseArgs(argv = process.argv.slice(2)) {
     authToken: envValue('METASHEET_AUTH_TOKEN', 'ADMIN_TOKEN', 'AUTH_TOKEN'),
     tokenFile: envValue('METASHEET_AUTH_TOKEN_FILE', 'AUTH_TOKEN_FILE'),
     tenantId: envValue('METASHEET_TENANT_ID', 'TENANT_ID'),
+    workspaceId: envValue('METASHEET_WORKSPACE_ID', 'WORKSPACE_ID'),
     requireAuth: false,
+    issue1542WorkbenchSmoke: false,
     outDir: '',
     timeoutMs: 10_000,
     help: false,
@@ -223,8 +231,15 @@ function parseArgs(argv = process.argv.slice(2)) {
         opts.tenantId = readRequiredValue(argv, i, arg)
         i += 1
         break
+      case '--workspace-id':
+        opts.workspaceId = readRequiredValue(argv, i, arg)
+        i += 1
+        break
       case '--require-auth':
         opts.requireAuth = true
+        break
+      case '--issue1542-workbench-smoke':
+        opts.issue1542WorkbenchSmoke = true
         break
       case '--out-dir':
         opts.outDir = readRequiredValue(argv, i, arg)
@@ -367,10 +382,21 @@ async function fetchWithTimeout(url, options = {}, timeoutMs = 10_000) {
   }
 }
 
-async function requestJson(baseUrl, pathname, { token = '', timeoutMs = 10_000, acceptStatuses = [200] } = {}) {
+async function requestJson(baseUrl, pathname, {
+  token = '',
+  timeoutMs = 10_000,
+  acceptStatuses = [200],
+  method = 'GET',
+  requestBody,
+} = {}) {
   const headers = { Accept: 'application/json' }
+  const request = { headers, method }
+  if (requestBody !== undefined) {
+    headers['Content-Type'] = 'application/json'
+    request.body = JSON.stringify(requestBody)
+  }
   if (token) headers.Authorization = `Bearer ${token}`
-  const response = await fetchWithTimeout(`${baseUrl}${pathname}`, { headers }, timeoutMs)
+  const response = await fetchWithTimeout(`${baseUrl}${pathname}`, request, timeoutMs)
   const text = await response.text()
   let body = null
   if (text) {
@@ -622,6 +648,257 @@ function assertListResponse(body, probeId) {
   return { rows: data.length }
 }
 
+function responseData(body) {
+  return body && Object.prototype.hasOwnProperty.call(body, 'data') ? body.data : body
+}
+
+function requireSystem(systems, { kind, role, label }) {
+  const system = systems.find((candidate) => {
+    if (!candidate || candidate.kind !== kind) return false
+    return !role || candidate.role === role || candidate.role === 'bidirectional'
+  })
+  if (!system) {
+    throw new K3WisePostdeploySmokeError(`${label || kind} system is not configured`, {
+      kind,
+      role: role || null,
+      configuredKinds: systems
+        .filter((candidate) => candidate && typeof candidate.kind === 'string')
+        .map((candidate) => `${candidate.kind}:${candidate.role || 'unknown'}`),
+    })
+  }
+  return system
+}
+
+function assertObjectListed(body, objectName, label) {
+  const data = responseData(body)
+  if (!Array.isArray(data)) {
+    throw new K3WisePostdeploySmokeError(`${label} object list response data must be an array`, {
+      received: Array.isArray(data) ? 'array' : typeof data,
+    })
+  }
+  const object = data.find((item) => item && (item.name === objectName || item.object === objectName))
+  if (!object) {
+    throw new K3WisePostdeploySmokeError(`${label} does not list required object ${objectName}`, {
+      objectName,
+      listedObjects: data
+        .filter((item) => item && (typeof item.name === 'string' || typeof item.object === 'string'))
+        .map((item) => item.name || item.object),
+    })
+  }
+  return object
+}
+
+function assertSchemaFields(body, objectName, requiredFields, label) {
+  const data = responseData(body)
+  const fields = Array.isArray(data?.fields) ? data.fields : []
+  const fieldNames = fields
+    .map((field) => (field && typeof field === 'object' ? field.name || field.id : field))
+    .filter((field) => typeof field === 'string' && field)
+  const missingFields = requiredFields.filter((field) => !fieldNames.includes(field))
+  if (fields.length === 0 || missingFields.length > 0) {
+    throw new K3WisePostdeploySmokeError(`${label} schema is missing required fields`, {
+      objectName,
+      fieldCount: fields.length,
+      requiredFields,
+      missingFields,
+      fieldNames,
+    })
+  }
+  return {
+    object: data?.object || objectName,
+    fieldCount: fields.length,
+    requiredFields,
+  }
+}
+
+function issue1542PipelinePayload({ tenantId, workspaceId, sourceSystemId, targetSystemId }) {
+  return {
+    id: ISSUE1542_SMOKE_PIPELINE_ID,
+    tenantId,
+    workspaceId: workspaceId || null,
+    name: 'Issue 1542 postdeploy smoke: staging material to K3',
+    description: 'Draft metadata-only smoke. Verifies Data Factory pipeline save without running dry-run or Save-only.',
+    sourceSystemId,
+    sourceObject: 'standard_materials',
+    targetSystemId,
+    targetObject: 'material',
+    mode: 'manual',
+    status: 'draft',
+    idempotencyKeyFields: ['code'],
+    options: {
+      target: {
+        autoSubmit: false,
+        autoAudit: false,
+      },
+      workbench: {
+        source: 'integration-k3wise-postdeploy-smoke',
+        issue: '#1542',
+      },
+      k3Template: {
+        id: 'material',
+        version: '1',
+        documentType: 'material',
+        bodyKey: 'Data',
+      },
+    },
+    fieldMappings: [
+      {
+        sourceField: 'code',
+        targetField: 'FNumber',
+        validation: [{ type: 'required' }],
+        sortOrder: 0,
+      },
+      {
+        sourceField: 'name',
+        targetField: 'FName',
+        validation: [{ type: 'required' }],
+        sortOrder: 1,
+      },
+      {
+        sourceField: 'uom',
+        targetField: 'FBaseUnitID',
+        defaultValue: 'PCS',
+        sortOrder: 2,
+      },
+    ],
+  }
+}
+
+function assertPipelineSaveResponse(body) {
+  const data = responseData(body)
+  if (!data || typeof data !== 'object' || !data.id) {
+    throw new K3WisePostdeploySmokeError('pipeline save did not return a pipeline id', {
+      body: sanitizeBody(body),
+    })
+  }
+  if (data.id !== ISSUE1542_SMOKE_PIPELINE_ID) {
+    throw new K3WisePostdeploySmokeError('pipeline save returned an unexpected id', {
+      expected: ISSUE1542_SMOKE_PIPELINE_ID,
+      actual: data.id,
+    })
+  }
+  if (!Array.isArray(data.idempotencyKeyFields) || !data.idempotencyKeyFields.includes('code')) {
+    throw new K3WisePostdeploySmokeError('pipeline save did not hydrate idempotencyKeyFields as an array', {
+      idempotencyKeyFields: data.idempotencyKeyFields,
+    })
+  }
+  if (!data.options || typeof data.options !== 'object' || data.options?.k3Template?.id !== 'material') {
+    throw new K3WisePostdeploySmokeError('pipeline save did not hydrate options.k3Template', {
+      options: sanitizeBody(data.options),
+    })
+  }
+  if (!Array.isArray(data.fieldMappings) || data.fieldMappings.length < 3) {
+    throw new K3WisePostdeploySmokeError('pipeline save did not return field mappings', {
+      fieldMappingsLength: Array.isArray(data.fieldMappings) ? data.fieldMappings.length : null,
+    })
+  }
+  return {
+    pipelineId: data.id,
+    status: data.status || null,
+    fieldMappings: data.fieldMappings.length,
+  }
+}
+
+async function runIssue1542WorkbenchSmoke({ baseUrl, token, tenantId, workspaceId, timeoutMs }) {
+  const checks = []
+  let systems = []
+  let stagingSystem = null
+  let k3TargetSystem = null
+
+  try {
+    const systemsResponse = await requestJson(baseUrl, withQuery('/api/integration/external-systems', {
+      tenantId,
+      workspaceId,
+      limit: 100,
+    }), { token, timeoutMs })
+    const data = responseData(systemsResponse.body)
+    if (!Array.isArray(data)) {
+      throw new K3WisePostdeploySmokeError('external systems response data must be an array', {
+        received: Array.isArray(data) ? 'array' : typeof data,
+      })
+    }
+    systems = data
+    stagingSystem = requireSystem(systems, {
+      kind: 'metasheet:staging',
+      role: 'source',
+      label: 'MetaSheet staging source',
+    })
+    k3TargetSystem = requireSystem(systems, {
+      kind: 'erp:k3-wise-webapi',
+      role: 'target',
+      label: 'K3 WISE WebAPI target',
+    })
+    checks.push(result('issue1542-system-readiness', 'pass', {
+      stagingSourceId: stagingSystem.id,
+      targetSystemId: k3TargetSystem.id,
+      systemsChecked: systems.length,
+    }))
+  } catch (error) {
+    return [failResult('issue1542-system-readiness', error)]
+  }
+
+  try {
+    const objects = await requestJson(baseUrl, withQuery(`/api/integration/external-systems/${encodeURIComponent(stagingSystem.id)}/objects`, {
+      tenantId,
+      workspaceId,
+    }), { token, timeoutMs })
+    assertObjectListed(objects.body, 'standard_materials', 'MetaSheet staging source')
+
+    const schema = await requestJson(baseUrl, withQuery(`/api/integration/external-systems/${encodeURIComponent(stagingSystem.id)}/schema`, {
+      tenantId,
+      workspaceId,
+      object: 'standard_materials',
+    }), { token, timeoutMs })
+    checks.push(result('issue1542-staging-source-schema', 'pass', {
+      systemId: stagingSystem.id,
+      ...assertSchemaFields(schema.body, 'standard_materials', ['code', 'name', 'uom'], 'MetaSheet staging source'),
+    }))
+  } catch (error) {
+    checks.push(failResult('issue1542-staging-source-schema', error))
+  }
+
+  try {
+    const objects = await requestJson(baseUrl, withQuery(`/api/integration/external-systems/${encodeURIComponent(k3TargetSystem.id)}/objects`, {
+      tenantId,
+      workspaceId,
+    }), { token, timeoutMs })
+    assertObjectListed(objects.body, 'material', 'K3 WISE target')
+
+    const schema = await requestJson(baseUrl, withQuery(`/api/integration/external-systems/${encodeURIComponent(k3TargetSystem.id)}/schema`, {
+      tenantId,
+      workspaceId,
+      object: 'material',
+    }), { token, timeoutMs })
+    checks.push(result('issue1542-k3-material-schema', 'pass', {
+      systemId: k3TargetSystem.id,
+      ...assertSchemaFields(schema.body, 'material', ['FNumber', 'FName', 'FBaseUnitID'], 'K3 WISE target'),
+    }))
+  } catch (error) {
+    checks.push(failResult('issue1542-k3-material-schema', error))
+  }
+
+  try {
+    const payload = issue1542PipelinePayload({
+      tenantId,
+      workspaceId,
+      sourceSystemId: stagingSystem.id,
+      targetSystemId: k3TargetSystem.id,
+    })
+    const saved = await requestJson(baseUrl, '/api/integration/pipelines', {
+      token,
+      timeoutMs,
+      method: 'POST',
+      requestBody: payload,
+      acceptStatuses: [200, 201],
+    })
+    checks.push(result('issue1542-pipeline-save', 'pass', assertPipelineSaveResponse(saved.body)))
+  } catch (error) {
+    checks.push(failResult('issue1542-pipeline-save', error))
+  }
+
+  return checks
+}
+
 function assertFrontendAppShell(page, label) {
   if (!/id=["']app["']/.test(page.text) && !/MetaSheet|metasheet/i.test(page.text)) {
     throw new K3WisePostdeploySmokeError(`${label} frontend route did not look like the app shell`)
@@ -708,6 +985,11 @@ async function runSmoke(opts) {
       reason: 'no bearer token supplied',
     })
     checks.push(skipped)
+    if (opts.issue1542WorkbenchSmoke) {
+      checks.push(result('issue1542-workbench-smoke', 'fail', {
+        reason: '--issue1542-workbench-smoke requires an auth token because it probes configured systems and saves draft pipeline metadata',
+      }))
+    }
   } else {
     let tenantId = opts.tenantId
     try {
@@ -758,6 +1040,22 @@ async function runSmoke(opts) {
       checks.push(result('staging-descriptor-contract', 'pass', assertStagingDescriptors(descriptors.body)))
     } catch (error) {
       checks.push(failResult('staging-descriptor-contract', error))
+    }
+
+    if (opts.issue1542WorkbenchSmoke) {
+      if (!tenantId) {
+        checks.push(result('issue1542-workbench-smoke', 'fail', {
+          reason: 'tenantId could not be resolved from --tenant-id, environment, or /api/auth/me',
+        }))
+      } else {
+        checks.push(...await runIssue1542WorkbenchSmoke({
+          baseUrl: opts.baseUrl,
+          token,
+          tenantId,
+          workspaceId: opts.workspaceId || '',
+          timeoutMs: opts.timeoutMs,
+        }))
+      }
     }
   }
 

--- a/scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
@@ -180,6 +180,46 @@ const DEFAULT_STAGING_DESCRIPTORS = [
   { id: 'integration_exceptions', name: 'Integration Exceptions', fields: DEFAULT_STAGING_FIELDS.integration_exceptions, fieldDetails: makeFieldDetails('integration_exceptions') },
   { id: 'integration_run_log', name: 'Integration Run Log', fields: DEFAULT_STAGING_FIELDS.integration_run_log, fieldDetails: makeFieldDetails('integration_run_log') },
 ]
+const DEFAULT_SYSTEMS = [
+  {
+    id: 'staging_source_1',
+    tenantId: 'tenant-smoke',
+    workspaceId: null,
+    name: 'MetaSheet Staging Source',
+    kind: 'metasheet:staging',
+    role: 'source',
+    status: 'active',
+  },
+  {
+    id: 'k3_target_1',
+    tenantId: 'tenant-smoke',
+    workspaceId: null,
+    name: 'K3 WISE WebAPI',
+    kind: 'erp:k3-wise-webapi',
+    role: 'target',
+    status: 'active',
+  },
+]
+const DEFAULT_STAGING_OBJECTS = [
+  {
+    name: 'standard_materials',
+    label: 'Standard Materials',
+    operations: ['read'],
+    schema: makeFieldDetails('standard_materials').map((field) => ({ name: field.id, ...field })),
+  },
+]
+const DEFAULT_K3_OBJECTS = [
+  {
+    name: 'material',
+    label: 'K3 WISE Material',
+    operations: ['upsert'],
+    schema: [
+      { name: 'FNumber', label: 'Material Code', type: 'string', required: true },
+      { name: 'FName', label: 'Material Name', type: 'string', required: true },
+      { name: 'FBaseUnitID', label: 'Base Unit', type: 'string' },
+    ],
+  },
+]
 
 function makeTmpDir() {
   return mkdtempSync(path.join(tmpdir(), 'integration-k3wise-postdeploy-smoke-'))
@@ -232,9 +272,30 @@ function sendHtml(res, status, body) {
   res.end(body)
 }
 
+function readRequestBody(req) {
+  return new Promise((resolve) => {
+    let body = ''
+    req.setEncoding('utf8')
+    req.on('data', (chunk) => {
+      body += chunk
+    })
+    req.on('end', () => {
+      if (!body) {
+        resolve(null)
+        return
+      }
+      try {
+        resolve(JSON.parse(body))
+      } catch {
+        resolve({ raw: body })
+      }
+    })
+  })
+}
+
 function createFakeServer(options = {}) {
   const requests = []
-  const server = http.createServer((req, res) => {
+  const server = http.createServer(async (req, res) => {
     const url = new URL(req.url || '/', 'http://127.0.0.1')
     requests.push({
       method: req.method,
@@ -314,10 +375,22 @@ function createFakeServer(options = {}) {
       return
     }
 
+    if (req.method === 'GET' && url.pathname === '/api/integration/external-systems') {
+      if (req.headers.authorization !== 'Bearer test.jwt.token') {
+        sendJson(res, 401, { ok: false, error: { message: 'bad token' } })
+        return
+      }
+      if (options.failControlPlanePath === url.pathname) {
+        sendJson(res, 500, { ok: false, error: { message: `${url.pathname} unavailable` } })
+        return
+      }
+      sendJson(res, 200, { ok: true, data: options.externalSystems || [] })
+      return
+    }
+
     if (
       req.method === 'GET' &&
       [
-        '/api/integration/external-systems',
         '/api/integration/pipelines',
         '/api/integration/runs',
         '/api/integration/dead-letters',
@@ -332,6 +405,76 @@ function createFakeServer(options = {}) {
         return
       }
       sendJson(res, 200, { ok: true, data: [] })
+      return
+    }
+
+    if (req.method === 'GET' && url.pathname === '/api/integration/external-systems/staging_source_1/objects') {
+      if (req.headers.authorization !== 'Bearer test.jwt.token') {
+        sendJson(res, 401, { ok: false, error: { message: 'bad token' } })
+        return
+      }
+      sendJson(res, 200, { ok: true, data: options.stagingObjects || DEFAULT_STAGING_OBJECTS })
+      return
+    }
+
+    if (req.method === 'GET' && url.pathname === '/api/integration/external-systems/staging_source_1/schema') {
+      if (req.headers.authorization !== 'Bearer test.jwt.token') {
+        sendJson(res, 401, { ok: false, error: { message: 'bad token' } })
+        return
+      }
+      sendJson(res, 200, {
+        ok: true,
+        data: options.stagingSchema || {
+          object: url.searchParams.get('object') || 'standard_materials',
+          fields: DEFAULT_STAGING_OBJECTS[0].schema,
+        },
+      })
+      return
+    }
+
+    if (req.method === 'GET' && url.pathname === '/api/integration/external-systems/k3_target_1/objects') {
+      if (req.headers.authorization !== 'Bearer test.jwt.token') {
+        sendJson(res, 401, { ok: false, error: { message: 'bad token' } })
+        return
+      }
+      sendJson(res, 200, { ok: true, data: options.k3Objects || DEFAULT_K3_OBJECTS })
+      return
+    }
+
+    if (req.method === 'GET' && url.pathname === '/api/integration/external-systems/k3_target_1/schema') {
+      if (req.headers.authorization !== 'Bearer test.jwt.token') {
+        sendJson(res, 401, { ok: false, error: { message: 'bad token' } })
+        return
+      }
+      sendJson(res, 200, {
+        ok: true,
+        data: options.k3Schema || {
+          object: url.searchParams.get('object') || 'material',
+          fields: DEFAULT_K3_OBJECTS[0].schema,
+          template: { id: 'material', bodyKey: 'Data' },
+        },
+      })
+      return
+    }
+
+    if (req.method === 'POST' && url.pathname === '/api/integration/pipelines') {
+      if (req.headers.authorization !== 'Bearer test.jwt.token') {
+        sendJson(res, 401, { ok: false, error: { message: 'bad token' } })
+        return
+      }
+      if (options.failPipelineSave) {
+        sendJson(res, 500, { ok: false, error: { code: '22P02', message: '类型json的输入语法无效' } })
+        return
+      }
+      const body = await readRequestBody(req)
+      sendJson(res, 201, {
+        ok: true,
+        data: {
+          ...body,
+          id: body?.id || 'pipe_smoke',
+          fieldMappings: Array.isArray(body?.fieldMappings) ? body.fieldMappings : [],
+        },
+      })
       return
     }
 
@@ -492,6 +635,106 @@ test('authenticated postdeploy smoke validates route and staging contracts witho
     assert.ok(fake.requests.some((request) => request.pathname === '/api/integration/pipelines'))
     assert.ok(fake.requests.some((request) => request.pathname === '/api/integration/runs'))
     assert.ok(fake.requests.some((request) => request.pathname === '/api/integration/dead-letters'))
+  } finally {
+    await fake.close()
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('issue1542 workbench smoke verifies staging schema and draft pipeline save', async () => {
+  const fake = createFakeServer({ externalSystems: DEFAULT_SYSTEMS })
+  const baseUrl = await fake.listen()
+  const outDir = makeTmpDir()
+  try {
+    const result = await runScript([
+      '--base-url', baseUrl,
+      '--auth-token', 'test.jwt.token',
+      '--require-auth',
+      '--issue1542-workbench-smoke',
+      '--out-dir', outDir,
+    ])
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.equal(result.stdout.includes('test.jwt.token'), false)
+    const evidenceText = readFileSync(path.join(outDir, 'integration-k3wise-postdeploy-smoke.json'), 'utf8')
+    assert.equal(evidenceText.includes('test.jwt.token'), false)
+    const evidence = JSON.parse(evidenceText)
+    assert.equal(evidence.summary.fail, 0)
+    assert.equal(evidence.checks.find((check) => check.id === 'issue1542-system-readiness').status, 'pass')
+    const stagingSchema = evidence.checks.find((check) => check.id === 'issue1542-staging-source-schema')
+    assert.equal(stagingSchema.status, 'pass')
+    assert.equal(stagingSchema.object, 'standard_materials')
+    assert.ok(stagingSchema.fieldCount >= 3)
+    const k3Schema = evidence.checks.find((check) => check.id === 'issue1542-k3-material-schema')
+    assert.equal(k3Schema.status, 'pass')
+    assert.equal(k3Schema.object, 'material')
+    const pipelineSave = evidence.checks.find((check) => check.id === 'issue1542-pipeline-save')
+    assert.equal(pipelineSave.status, 'pass')
+    assert.equal(pipelineSave.pipelineId, 'issue1542_postdeploy_staging_material_smoke')
+    assert.equal(pipelineSave.fieldMappings, 3)
+
+    const pipelineRequest = fake.requests.find((request) => request.method === 'POST' && request.pathname === '/api/integration/pipelines')
+    assert.ok(pipelineRequest, 'issue1542 smoke saves a draft pipeline metadata record')
+    assert.ok(fake.requests.some((request) => request.pathname === '/api/integration/external-systems/staging_source_1/schema'))
+    assert.ok(fake.requests.some((request) => request.pathname === '/api/integration/external-systems/k3_target_1/schema'))
+  } finally {
+    await fake.close()
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('issue1542 workbench smoke fails when staging schema is empty', async () => {
+  const fake = createFakeServer({
+    externalSystems: DEFAULT_SYSTEMS,
+    stagingSchema: { object: 'standard_materials', fields: [] },
+  })
+  const baseUrl = await fake.listen()
+  const outDir = makeTmpDir()
+  try {
+    const result = await runScript([
+      '--base-url', baseUrl,
+      '--auth-token', 'test.jwt.token',
+      '--require-auth',
+      '--issue1542-workbench-smoke',
+      '--out-dir', outDir,
+    ])
+
+    assert.equal(result.status, 1)
+    const evidence = JSON.parse(readFileSync(path.join(outDir, 'integration-k3wise-postdeploy-smoke.json'), 'utf8'))
+    const stagingSchema = evidence.checks.find((check) => check.id === 'issue1542-staging-source-schema')
+    assert.equal(stagingSchema.status, 'fail')
+    assert.match(stagingSchema.error, /schema is missing required fields/)
+    assert.equal(stagingSchema.details.fieldCount, 0)
+  } finally {
+    await fake.close()
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('issue1542 workbench smoke fails clearly when pipeline save still hits JSONB 22P02', async () => {
+  const fake = createFakeServer({
+    externalSystems: DEFAULT_SYSTEMS,
+    failPipelineSave: true,
+  })
+  const baseUrl = await fake.listen()
+  const outDir = makeTmpDir()
+  try {
+    const result = await runScript([
+      '--base-url', baseUrl,
+      '--auth-token', 'test.jwt.token',
+      '--require-auth',
+      '--issue1542-workbench-smoke',
+      '--out-dir', outDir,
+    ])
+
+    assert.equal(result.status, 1)
+    assert.equal(result.stdout.includes('test.jwt.token'), false)
+    assert.equal(result.stderr.includes('test.jwt.token'), false)
+    const evidence = JSON.parse(readFileSync(path.join(outDir, 'integration-k3wise-postdeploy-smoke.json'), 'utf8'))
+    const pipelineSave = evidence.checks.find((check) => check.id === 'issue1542-pipeline-save')
+    assert.equal(pipelineSave.status, 'fail')
+    assert.match(pipelineSave.error, /\/api\/integration\/pipelines returned HTTP 500/)
+    assert.equal(pipelineSave.details.body.error.code, '22P02')
   } finally {
     await fake.close()
     rmSync(outDir, { recursive: true, force: true })

--- a/scripts/ops/multitable-onprem-package-verify.sh
+++ b/scripts/ops/multitable-onprem-package-verify.sh
@@ -107,6 +107,8 @@ function verify_generic_integration_workbench_contract() {
   search_fixed_string 'SQL Server is an advanced channel' "$k3_runbook" || die "K3 runbook must document SQL Server as an advanced channel"
   search_fixed_string 'data-factory-frontend-route' "$postdeploy_smoke" || die "postdeploy smoke must check the Data Factory frontend route"
   search_fixed_string 'data-factory-adapter-discovery' "$postdeploy_smoke" || die "postdeploy smoke must check Data Factory adapter discovery"
+  search_fixed_string '--issue1542-workbench-smoke' "$postdeploy_smoke" || die "postdeploy smoke must include Data Factory issue #1542 workbench retest flag"
+  search_fixed_string '--issue1542-workbench-smoke' "$k3_runbook" || die "K3 runbook must document the Data Factory issue #1542 workbench retest"
   search_fixed_string 'invalidAdapters' "$postdeploy_summary" || die "postdeploy summary must render Data Factory adapter drift details"
 }
 


### PR DESCRIPTION
## Summary

Adds an opt-in postdeploy smoke for Data Factory issue #1542 so deployed boxes can be retested without hand-clicking the Workbench.

The new flag is:

```bash
--issue1542-workbench-smoke
```

It verifies:

- configured `metasheet:staging` source + `erp:k3-wise-webapi` target exist;
- staging `standard_materials` schema is non-empty and exposes `code`, `name`, `uom`;
- K3 material schema exposes `FNumber`, `FName`, `FBaseUnitID`;
- a fixed draft pipeline metadata record can be saved without JSONB `22P02`.

Safety: this writes/updates one draft pipeline metadata row only. It does not run dry-run, Save-only, Submit, or Audit.

## Verification

- `node --check scripts/ops/integration-k3wise-postdeploy-smoke.mjs`
- `bash -n scripts/ops/multitable-onprem-package-verify.sh`
- `node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs` — 20/20 pass
- `pnpm verify:integration-k3wise:poc` — pass
- `git diff --check` — pass

## Docs

- `docs/development/data-factory-issue1542-postdeploy-smoke-design-20260515.md`
- `docs/development/data-factory-issue1542-postdeploy-smoke-verification-20260515.md`
- `docs/operations/integration-k3wise-internal-trial-runbook.md`

## Remaining out of scope

`SQLSERVER_EXECUTOR_MISSING` remains a separate runtime/deployment wiring item. This PR only makes staging-to-K3 metadata readiness repeatable after deployment.
