### PR TITLE
test(integration): seed issue1542 workbench systems

### DIFF
--- a/docs/development/data-factory-issue1542-seed-workbench-systems-development-20260515.md
+++ b/docs/development/data-factory-issue1542-seed-workbench-systems-development-20260515.md
@@ -1,0 +1,146 @@
+# Data Factory Issue #1542 Workbench Seed Helper - Development
+
+Date: 2026-05-15
+
+## Purpose
+
+The postdeploy smoke added for issue #1542 can now verify the Data Factory
+Workbench route, adapter metadata, staging schema discovery, K3 material schema
+discovery, and draft pipeline save. The first run on the 142 host failed before
+the real smoke surface because `integration_external_systems` was empty:
+
+```text
+issue1542-system-readiness failed:
+MetaSheet staging source system is not configured
+```
+
+That is a deployment setup precondition, not a product code failure. Operators
+need a repeatable way to create the minimum metadata required for the retest
+without entering real K3 credentials or calling K3 Save.
+
+## Scope
+
+This slice adds a metadata-only operator helper:
+
+```bash
+scripts/ops/integration-issue1542-seed-workbench-systems.mjs
+```
+
+The helper creates or updates:
+
+- one `metasheet:staging` source system scoped to the supplied tenant/project;
+- one `erp:k3-wise-webapi` target system for K3 Material schema discovery.
+
+It deliberately does not:
+
+- write K3 credentials;
+- run dry-run;
+- run Save-only;
+- run Submit or Audit;
+- modify `integration_pipelines`;
+- bypass customer GATE.
+
+## Modes
+
+### Existing Staging Sheet
+
+If the operator already created staging multitable sheets, they can provide the
+`standard_materials` sheet id directly:
+
+```bash
+node scripts/ops/integration-issue1542-seed-workbench-systems.mjs \
+  --base-url "$METASHEET_BASE_URL" \
+  --token-file "$METASHEET_AUTH_TOKEN_FILE" \
+  --tenant-id default \
+  --project-id default \
+  --standard-materials-sheet-id "$STANDARD_MATERIALS_SHEET_ID"
+```
+
+### Install Then Seed
+
+For a fresh deployment, the helper can first call the existing
+`POST /api/integration/staging/install` route and use the returned
+`sheetIds.standard_materials`:
+
+```bash
+node scripts/ops/integration-issue1542-seed-workbench-systems.mjs \
+  --base-url "$METASHEET_BASE_URL" \
+  --token-file "$METASHEET_AUTH_TOKEN_FILE" \
+  --tenant-id default \
+  --project-id default \
+  --install-staging
+```
+
+This mirrors the Workbench UI path: create staging tables, then use
+`standard_materials` as a Dry-run source.
+
+## Payload Contract
+
+The staging source payload matches the UI's existing `activateStagingAsSource`
+shape:
+
+```json
+{
+  "kind": "metasheet:staging",
+  "role": "source",
+  "status": "active",
+  "config": {
+    "projectId": "default",
+    "objects": {
+      "standard_materials": {
+        "sheetId": "sheet_x",
+        "fields": ["code", "name", "uom"],
+        "fieldDetails": []
+      }
+    }
+  }
+}
+```
+
+The K3 target payload is intentionally metadata-only. K3 schema discovery is
+local to the adapter template registry, so the postdeploy smoke can verify the
+K3 Material template without a live K3 token:
+
+```json
+{
+  "kind": "erp:k3-wise-webapi",
+  "role": "target",
+  "status": "active",
+  "config": {
+    "baseUrl": "http://127.0.0.1/K3API/",
+    "autoSubmit": false,
+    "autoAudit": false,
+    "objects": {},
+    "metadataOnly": true
+  }
+}
+```
+
+The helper omits `credentials`, so it will not create or overwrite K3 secrets.
+
+## Artifact Contract
+
+The helper writes two local artifacts under `--out-dir`:
+
+- `integration-issue1542-seed-workbench-systems.json`
+- `integration-issue1542-seed-workbench-systems.md`
+
+Files are written with mode `0600`; the directory is created with mode `0700`.
+The artifact records ids, sheet ids, status, mode, and next command guidance.
+It stores no bearer token and no K3 credential.
+
+## Package Surface
+
+`scripts/ops/multitable-onprem-package-verify.sh` now checks that the helper is
+included in the Windows/on-prem package and that the internal-trial runbook
+documents it next to `--issue1542-workbench-smoke`.
+
+## Expected Operator Flow
+
+1. Generate a short-lived admin token on the deployment host.
+2. Run the seed helper with `--install-staging` or a known
+   `--standard-materials-sheet-id`.
+3. Run `integration-k3wise-postdeploy-smoke.mjs --issue1542-workbench-smoke`.
+4. If the smoke passes, the Data Factory workbench metadata path is ready.
+5. Enter real K3 WebAPI credentials only from the K3 setup page before any
+   Save-only/live work.

--- a/docs/development/data-factory-issue1542-seed-workbench-systems-verification-20260515.md
+++ b/docs/development/data-factory-issue1542-seed-workbench-systems-verification-20260515.md
@@ -1,0 +1,87 @@
+# Data Factory Issue #1542 Workbench Seed Helper - Verification
+
+Date: 2026-05-15
+
+## Test Matrix
+
+| Area | Command | Expected |
+| --- | --- | --- |
+| Seed helper unit coverage | `pnpm verify:integration-issue1542:seed-workbench` | PASS: 4/4 |
+| Existing postdeploy smoke regression | `node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs` | PASS: 20/20 |
+| K3 offline PoC regression | `pnpm verify:integration-k3wise:poc` | PASS: preflight/evidence/fixture/mock chain |
+| Syntax | `node --check scripts/ops/integration-issue1542-seed-workbench-systems.mjs` | PASS |
+| Package verifier syntax | `bash -n scripts/ops/multitable-onprem-package-verify.sh` | PASS |
+| Whitespace/conflict markers | `git diff --check origin/main...HEAD` | PASS |
+
+## Unit Scenarios
+
+`scripts/ops/integration-issue1542-seed-workbench-systems.test.mjs` covers:
+
+1. Existing `standard_materials` sheet id creates:
+   - `metasheet:staging` source with `standard_materials.sheetId`;
+   - `erp:k3-wise-webapi` target with `autoSubmit=false`, `autoAudit=false`;
+   - no `credentials` property in the K3 target payload.
+2. `--install-staging` calls `POST /api/integration/staging/install` and uses
+   the returned `sheetIds.standard_materials`.
+3. Missing sheet id without `--install-staging` fails before any network write.
+4. JSON and Markdown artifacts are written with mode `0600` and do not contain
+   bearer tokens or raw URL userinfo/query secrets.
+
+## Manual 142 Retest Plan
+
+After this PR is deployed on 142, use the same token mint path as the previous
+internal-trial smoke, then run:
+
+```bash
+node scripts/ops/integration-issue1542-seed-workbench-systems.mjs \
+  --base-url http://127.0.0.1:8081 \
+  --token-file "$TOKEN_FILE" \
+  --tenant-id default \
+  --project-id default \
+  --install-staging \
+  --out-dir artifacts/integration-k3wise/internal-trial/issue1542-seed
+```
+
+Expected result:
+
+```text
+Issue #1542 Data Factory seed: PASS
+Mode: install-staging-and-seed
+Staging source: metasheet_staging_default
+K3 target: issue1542_k3wise_webapi_metadata_target
+```
+
+Then rerun:
+
+```bash
+node scripts/ops/integration-k3wise-postdeploy-smoke.mjs \
+  --base-url http://127.0.0.1:8081 \
+  --token-file "$TOKEN_FILE" \
+  --tenant-id default \
+  --require-auth \
+  --issue1542-workbench-smoke \
+  --out-dir artifacts/integration-k3wise/internal-trial/postdeploy-smoke-issue1542
+```
+
+Expected issue #1542 checks:
+
+- `issue1542-system-readiness`: PASS
+- `issue1542-staging-source-schema`: PASS
+- `issue1542-k3-material-schema`: PASS
+- `issue1542-pipeline-save`: PASS
+
+## Safety Checks
+
+- The helper does not accept or persist K3 username/password/token values.
+- `credentials` is omitted from the K3 target upsert payload, so existing
+  stored credentials are not overwritten.
+- The K3 target is marked `metadataOnly` and keeps `autoSubmit=false` and
+  `autoAudit=false`.
+- Artifacts are `0600` and redact token-shaped strings, URL userinfo, and
+  secret query parameters.
+
+## Deployment Impact
+
+This is an opt-in operator tool plus docs/package verification. Runtime product
+behavior is unchanged until an operator explicitly runs the script with an auth
+token.

--- a/docs/operations/integration-k3wise-internal-trial-runbook.md
+++ b/docs/operations/integration-k3wise-internal-trial-runbook.md
@@ -110,7 +110,22 @@ node scripts/ops/integration-k3wise-postdeploy-smoke.mjs \
 ```
 
 For the Data Factory issue #1542 deployment retest, add the opt-in workbench
-smoke flag:
+smoke flag. If the deployment has no Data Factory external systems yet, seed
+metadata-only systems first. This writes a `metasheet:staging` source and a
+K3 WebAPI target for schema/pipeline-save verification only; it does not write
+real K3 credentials and does not run dry-run, Save-only, Submit, or Audit.
+
+```bash
+node scripts/ops/integration-issue1542-seed-workbench-systems.mjs \
+  --base-url "$METASHEET_BASE_URL" \
+  --token-file "$METASHEET_AUTH_TOKEN_FILE" \
+  --tenant-id "$METASHEET_TENANT_ID" \
+  --project-id "${METASHEET_PROJECT_ID:-default}" \
+  --install-staging \
+  --out-dir artifacts/integration-k3wise/internal-trial/issue1542-seed
+```
+
+Then run the smoke:
 
 ```bash
 node scripts/ops/integration-k3wise-postdeploy-smoke.mjs \

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "verify:integration-k3wise:delivery": "node --test scripts/ops/integration-k3wise-delivery-readiness.test.mjs",
     "verify:integration-k3wise:onprem-preflight": "node --test scripts/ops/integration-k3wise-onprem-preflight.test.mjs",
     "verify:integration-k3wise:postdeploy-env-check": "node --test scripts/ops/integration-k3wise-postdeploy-env-check.test.mjs",
+    "verify:integration-issue1542:seed-workbench": "node --test scripts/ops/integration-issue1542-seed-workbench-systems.test.mjs",
     "phase5:run-all": "bash scripts/phase5-run-all.sh",
     "build": "pnpm -r build",
     "test": "pnpm -r test",

--- a/scripts/ops/integration-issue1542-seed-workbench-systems.mjs
+++ b/scripts/ops/integration-issue1542-seed-workbench-systems.mjs
@@ -1,0 +1,598 @@
+#!/usr/bin/env node
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+
+const DEFAULT_BASE_URL = process.env.METASHEET_BASE_URL || process.env.PUBLIC_APP_URL || 'http://127.0.0.1:8081'
+const DEFAULT_OUTPUT_ROOT = 'output/integration-issue1542-seed-workbench-systems'
+const DEFAULT_TENANT_ID = process.env.METASHEET_TENANT_ID || process.env.TENANT_ID || 'default'
+const DEFAULT_PROJECT_ID = process.env.METASHEET_PROJECT_ID || process.env.PROJECT_ID || 'default'
+const DEFAULT_K3_BASE_URL = 'http://127.0.0.1/K3API/'
+const SECRET_QUERY_PARAM_PATTERN = /^(access[_-]?token|refresh[_-]?token|id[_-]?token|session[_-]?id|api[_-]?key|token|password|passwd|pwd|secret|signature|sign|auth|authorization)$/i
+const TOKEN_PATTERN = /\b(?:Bearer\s+)?[A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{16,}\b/g
+const REQUIRED_STANDARD_MATERIAL_FIELDS = ['code', 'name', 'uom']
+
+class Issue1542SeedError extends Error {
+  constructor(message, details = {}) {
+    super(message)
+    this.name = 'Issue1542SeedError'
+    this.details = details
+  }
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/ops/integration-issue1542-seed-workbench-systems.mjs [options]
+
+Seeds the minimum Data Factory external-system metadata required by the
+postdeploy --issue1542-workbench-smoke check. It writes metadata only:
+no real K3 credentials, no dry-run, no Save-only, no Submit, no Audit.
+
+Options:
+  --base-url <url>                     MetaSheet base URL, default ${DEFAULT_BASE_URL}
+  --auth-token <token>                 Bearer token. Prefer --token-file.
+  --token-file <path>                  File containing bearer token.
+  --tenant-id <id>                     Tenant scope, default ${DEFAULT_TENANT_ID}
+  --workspace-id <id>                  Optional workspace scope.
+  --project-id <id>                    Project scope/staging suffix, default ${DEFAULT_PROJECT_ID}
+  --base-id <id>                       Optional multitable base id.
+  --install-staging                    Call /api/integration/staging/install first and use its standard_materials sheet.
+  --standard-materials-sheet-id <id>   Existing standard_materials sheet id when --install-staging is not used.
+  --standard-materials-view-id <id>    Optional view id for the existing standard_materials sheet.
+  --standard-materials-open-link <url> Optional open link for the existing standard_materials sheet.
+  --staging-source-id <id>             Source system id, default metasheet_staging_<projectId>
+  --k3-target-id <id>                  Target system id, default issue1542_k3wise_webapi_metadata_target
+  --k3-base-url <url>                  Metadata-only K3 base URL, default ${DEFAULT_K3_BASE_URL}
+  --out-dir <dir>                      Artifact directory, default ${DEFAULT_OUTPUT_ROOT}/<timestamp>
+  --timeout-ms <ms>                    Per-request timeout, default 10000
+  --help                               Show this help
+
+Recommended 142 flow:
+  node scripts/ops/integration-issue1542-seed-workbench-systems.mjs \\
+    --base-url http://127.0.0.1:8081 \\
+    --token-file /tmp/metasheet-admin.jwt \\
+    --tenant-id default \\
+    --project-id default \\
+    --install-staging
+`)
+}
+
+function readRequiredValue(argv, index, flag) {
+  const value = argv[index + 1]
+  if (!value || value.startsWith('--')) {
+    throw new Issue1542SeedError(`${flag} requires a value`, { flag })
+  }
+  return value
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+  const opts = {
+    baseUrl: DEFAULT_BASE_URL,
+    authToken: process.env.METASHEET_AUTH_TOKEN || process.env.ADMIN_TOKEN || process.env.AUTH_TOKEN || '',
+    tokenFile: process.env.METASHEET_AUTH_TOKEN_FILE || process.env.AUTH_TOKEN_FILE || '',
+    tenantId: DEFAULT_TENANT_ID,
+    workspaceId: process.env.METASHEET_WORKSPACE_ID || process.env.WORKSPACE_ID || '',
+    projectId: DEFAULT_PROJECT_ID,
+    baseId: '',
+    installStaging: false,
+    standardMaterialsSheetId: '',
+    standardMaterialsViewId: '',
+    standardMaterialsOpenLink: '',
+    stagingSourceId: '',
+    k3TargetId: 'issue1542_k3wise_webapi_metadata_target',
+    k3BaseUrl: DEFAULT_K3_BASE_URL,
+    outDir: '',
+    timeoutMs: 10_000,
+    help: false,
+  }
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    switch (arg) {
+      case '--base-url':
+        opts.baseUrl = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--auth-token':
+        opts.authToken = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--token-file':
+        opts.tokenFile = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--tenant-id':
+        opts.tenantId = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--workspace-id':
+        opts.workspaceId = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--project-id':
+        opts.projectId = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--base-id':
+        opts.baseId = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--install-staging':
+        opts.installStaging = true
+        break
+      case '--standard-materials-sheet-id':
+        opts.standardMaterialsSheetId = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--standard-materials-view-id':
+        opts.standardMaterialsViewId = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--standard-materials-open-link':
+        opts.standardMaterialsOpenLink = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--staging-source-id':
+        opts.stagingSourceId = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--k3-target-id':
+        opts.k3TargetId = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--k3-base-url':
+        opts.k3BaseUrl = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--out-dir':
+        opts.outDir = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--timeout-ms':
+        opts.timeoutMs = Number(readRequiredValue(argv, i, arg))
+        i += 1
+        break
+      case '--help':
+      case '-h':
+        opts.help = true
+        break
+      default:
+        throw new Issue1542SeedError(`unknown option: ${arg}`, { arg })
+    }
+  }
+
+  return normalizeOptions(opts)
+}
+
+function normalizeOptions(opts) {
+  const normalized = { ...opts }
+  normalized.baseUrl = normalizeBaseUrl(normalized.baseUrl)
+  normalized.k3BaseUrl = normalizeBaseUrl(normalized.k3BaseUrl)
+  normalized.tenantId = requiredString(normalized.tenantId, 'tenantId')
+  normalized.workspaceId = optionalString(normalized.workspaceId)
+  normalized.projectId = requiredString(normalized.projectId, 'projectId')
+  normalized.baseId = optionalString(normalized.baseId)
+  normalized.standardMaterialsSheetId = optionalString(normalized.standardMaterialsSheetId)
+  normalized.standardMaterialsViewId = optionalString(normalized.standardMaterialsViewId)
+  normalized.standardMaterialsOpenLink = optionalString(normalized.standardMaterialsOpenLink)
+  normalized.stagingSourceId = optionalString(normalized.stagingSourceId) || stagingSourceSystemId(normalized.projectId)
+  normalized.k3TargetId = requiredString(normalized.k3TargetId, 'k3TargetId')
+  if (!Number.isFinite(normalized.timeoutMs) || normalized.timeoutMs <= 0) {
+    throw new Issue1542SeedError('timeoutMs must be a positive number', { field: 'timeoutMs' })
+  }
+  if (!normalized.installStaging && !normalized.standardMaterialsSheetId) {
+    throw new Issue1542SeedError('--standard-materials-sheet-id is required unless --install-staging is supplied', {
+      field: 'standardMaterialsSheetId',
+    })
+  }
+  return normalized
+}
+
+function requiredString(value, field) {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Issue1542SeedError(`${field} is required`, { field })
+  }
+  return value.trim()
+}
+
+function optionalString(value) {
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+function normalizeBaseUrl(value) {
+  const raw = requiredString(value, 'baseUrl')
+  const url = new URL(raw)
+  if (!['http:', 'https:'].includes(url.protocol)) {
+    throw new Issue1542SeedError('baseUrl must be http or https', { field: 'baseUrl' })
+  }
+  url.hash = ''
+  return url.toString().replace(/\/+$/, '')
+}
+
+function stagingSourceSystemId(projectId) {
+  const suffix = (projectId || 'default').replace(/[^A-Za-z0-9_-]+/g, '_').replace(/^_+|_+$/g, '') || 'default'
+  return `metasheet_staging_${suffix}`
+}
+
+async function loadToken(opts) {
+  if (opts.authToken) return opts.authToken.trim()
+  if (!opts.tokenFile) {
+    throw new Issue1542SeedError('auth token is required; use --token-file or METASHEET_AUTH_TOKEN_FILE', {
+      field: 'tokenFile',
+    })
+  }
+  const token = (await readFile(opts.tokenFile, 'utf8')).trim()
+  if (!token) {
+    throw new Issue1542SeedError('token file is empty', { field: 'tokenFile' })
+  }
+  return token
+}
+
+function withQuery(pathname, query = {}) {
+  const search = new URLSearchParams()
+  for (const [key, value] of Object.entries(query)) {
+    if (value === undefined || value === null || value === '') continue
+    search.set(key, String(value))
+  }
+  const suffix = search.toString()
+  return suffix ? `${pathname}?${suffix}` : pathname
+}
+
+async function requestJson(baseUrl, pathname, { token, method = 'GET', body, timeoutMs, acceptStatuses = [200, 201] } = {}) {
+  const url = new URL(pathname, `${baseUrl}/`)
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const response = await fetch(url, {
+      method,
+      headers: {
+        Accept: 'application/json',
+        ...(body === undefined ? {} : { 'Content-Type': 'application/json' }),
+        Authorization: `Bearer ${token}`,
+      },
+      body: body === undefined ? undefined : JSON.stringify(body),
+      signal: controller.signal,
+    })
+    const text = await response.text()
+    let parsed = null
+    if (text) {
+      try {
+        parsed = JSON.parse(text)
+      } catch {
+        parsed = text
+      }
+    }
+    if (!acceptStatuses.includes(response.status)) {
+      throw new Issue1542SeedError(`HTTP ${response.status} ${method} ${url.pathname} failed`, {
+        status: response.status,
+        body: sanitizeBody(parsed),
+      })
+    }
+    return { status: response.status, body: parsed }
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+function responseData(body) {
+  return body && Object.prototype.hasOwnProperty.call(body, 'data') ? body.data : body
+}
+
+function assertArray(value, label) {
+  if (!Array.isArray(value)) {
+    throw new Issue1542SeedError(`${label} must be an array`, { received: typeof value })
+  }
+  return value
+}
+
+function standardMaterialsDescriptor(descriptors) {
+  const descriptor = assertArray(descriptors, 'staging descriptors').find((item) => item && item.id === 'standard_materials')
+  if (!descriptor) {
+    throw new Issue1542SeedError('standard_materials staging descriptor is missing', {
+      descriptorIds: descriptors.filter(Boolean).map((item) => item.id).filter(Boolean),
+    })
+  }
+  const fields = Array.isArray(descriptor.fieldDetails) && descriptor.fieldDetails.length > 0
+    ? descriptor.fieldDetails.map((field) => field.id || field.name).filter(Boolean)
+    : (Array.isArray(descriptor.fields) ? descriptor.fields : [])
+  const missingFields = REQUIRED_STANDARD_MATERIAL_FIELDS.filter((field) => !fields.includes(field))
+  if (missingFields.length > 0) {
+    throw new Issue1542SeedError('standard_materials descriptor is missing required fields', {
+      missingFields,
+      fields,
+    })
+  }
+  return descriptor
+}
+
+function sheetTargetFromInstallResult(result) {
+  const data = responseData(result)
+  const sheetId = data?.sheetIds?.standard_materials
+  if (!sheetId) {
+    throw new Issue1542SeedError('staging install did not return sheetIds.standard_materials', {
+      sheetIds: data?.sheetIds || {},
+    })
+  }
+  const target = Array.isArray(data.targets)
+    ? data.targets.find((item) => item && item.id === 'standard_materials')
+    : null
+  return {
+    sheetId,
+    viewId: target?.viewId || data?.viewIds?.standard_materials || null,
+    baseId: target?.baseId || null,
+    openLink: target?.openLink || data?.openLinks?.standard_materials || null,
+    warnings: Array.isArray(data.warnings) ? data.warnings : [],
+  }
+}
+
+function directSheetTarget(opts) {
+  return {
+    sheetId: opts.standardMaterialsSheetId,
+    viewId: opts.standardMaterialsViewId,
+    baseId: opts.baseId,
+    openLink: opts.standardMaterialsOpenLink,
+    warnings: [],
+  }
+}
+
+function buildScope(opts) {
+  return {
+    tenantId: opts.tenantId,
+    workspaceId: opts.workspaceId,
+  }
+}
+
+function buildStagingPayload(opts, descriptor, target) {
+  return {
+    ...buildScope(opts),
+    id: opts.stagingSourceId,
+    projectId: opts.projectId,
+    name: 'MetaSheet staging source (issue #1542 smoke)',
+    kind: 'metasheet:staging',
+    role: 'source',
+    status: 'active',
+    config: {
+      projectId: opts.projectId,
+      baseId: target.baseId || opts.baseId || null,
+      objects: {
+        standard_materials: {
+          name: descriptor.name || 'standard_materials',
+          sheetId: target.sheetId,
+          viewId: target.viewId || null,
+          baseId: target.baseId || opts.baseId || null,
+          openLink: target.openLink || null,
+          fields: Array.isArray(descriptor.fields) ? descriptor.fields : [],
+          fieldDetails: Array.isArray(descriptor.fieldDetails) ? descriptor.fieldDetails : [],
+        },
+      },
+    },
+    capabilities: {
+      read: true,
+      stagingSource: true,
+      dryRunFriendly: true,
+      issue1542Smoke: true,
+    },
+  }
+}
+
+function buildK3Payload(opts) {
+  return {
+    ...buildScope(opts),
+    id: opts.k3TargetId,
+    projectId: opts.projectId,
+    name: 'K3 WISE WebAPI target (metadata-only issue #1542 smoke)',
+    kind: 'erp:k3-wise-webapi',
+    role: 'target',
+    status: 'active',
+    config: {
+      baseUrl: opts.k3BaseUrl,
+      loginPath: '/K3API/Login',
+      tokenPath: '/K3API/Token/Create',
+      tokenQueryParam: 'Token',
+      autoSubmit: false,
+      autoAudit: false,
+      objects: {},
+      metadataOnly: true,
+    },
+    capabilities: {
+      write: true,
+      dryRunFriendly: true,
+      k3TemplatePreview: true,
+      metadataOnly: true,
+      saveOnlyRequiresRealCredentials: true,
+    },
+  }
+}
+
+async function upsertExternalSystem(opts, token, payload) {
+  const response = await requestJson(opts.baseUrl, '/api/integration/external-systems', {
+    token,
+    method: 'POST',
+    body: payload,
+    timeoutMs: opts.timeoutMs,
+  })
+  return responseData(response.body)
+}
+
+function sanitizeUrl(value) {
+  if (typeof value !== 'string' || value.length === 0) return value
+  try {
+    const url = new URL(value)
+    if (url.username) url.username = '<redacted>'
+    if (url.password) url.password = '<redacted>'
+    for (const key of [...url.searchParams.keys()]) {
+      if (SECRET_QUERY_PARAM_PATTERN.test(key)) {
+        url.searchParams.set(key, '<redacted>')
+      }
+    }
+    return url.toString()
+  } catch {
+    return value.replace(/([?&](?:access[_-]?token|refresh[_-]?token|id[_-]?token|session[_-]?id|api[_-]?key|token|password|passwd|pwd|secret|signature|sign|auth|authorization)=)([^&#\s]+)/ig, '$1<redacted>')
+  }
+}
+
+function sanitizeBody(value) {
+  if (typeof value === 'string') return value.replace(TOKEN_PATTERN, '<redacted>')
+  if (Array.isArray(value)) return value.map(sanitizeBody)
+  if (!value || typeof value !== 'object') return value
+  const out = {}
+  for (const [key, item] of Object.entries(value)) {
+    if (SECRET_QUERY_PARAM_PATTERN.test(key)) {
+      out[key] = '<redacted>'
+    } else if (typeof item === 'string' && /^https?:\/\//i.test(item)) {
+      out[key] = sanitizeUrl(item)
+    } else {
+      out[key] = sanitizeBody(item)
+    }
+  }
+  return out
+}
+
+function timestampForPath() {
+  return new Date().toISOString().replace(/[:.]/g, '-')
+}
+
+function outputDir(opts) {
+  return opts.outDir || path.join(DEFAULT_OUTPUT_ROOT, timestampForPath())
+}
+
+function buildSummary({ opts, source, target, sheetTarget, descriptor, installed }) {
+  return sanitizeBody({
+    ok: true,
+    decision: 'PASS',
+    mode: installed ? 'install-staging-and-seed' : 'seed-existing-sheet',
+    scope: {
+      tenantId: opts.tenantId,
+      workspaceId: opts.workspaceId,
+      projectId: opts.projectId,
+      baseId: sheetTarget.baseId || opts.baseId || null,
+    },
+    systems: {
+      stagingSource: {
+        id: source.id || opts.stagingSourceId,
+        kind: source.kind || 'metasheet:staging',
+        role: source.role || 'source',
+        status: source.status || 'active',
+        object: 'standard_materials',
+        sheetId: sheetTarget.sheetId,
+        viewId: sheetTarget.viewId || null,
+        openLink: sheetTarget.openLink || null,
+      },
+      k3Target: {
+        id: target.id || opts.k3TargetId,
+        kind: target.kind || 'erp:k3-wise-webapi',
+        role: target.role || 'target',
+        status: target.status || 'active',
+        baseUrl: opts.k3BaseUrl,
+        credentials: 'not written by this tool',
+        autoSubmit: false,
+        autoAudit: false,
+      },
+    },
+    descriptor: {
+      id: descriptor.id,
+      name: descriptor.name || null,
+      fields: Array.isArray(descriptor.fields) ? descriptor.fields.length : 0,
+      fieldDetails: Array.isArray(descriptor.fieldDetails) ? descriptor.fieldDetails.length : 0,
+      requiredSmokeFields: REQUIRED_STANDARD_MATERIAL_FIELDS,
+    },
+    next: [
+      'Run integration-k3wise-postdeploy-smoke.mjs --issue1542-workbench-smoke with the same tenant/workspace scope.',
+      'Use real K3 credentials only in the K3 setup page before Save-only/live testing.',
+    ],
+    warnings: sheetTarget.warnings,
+  })
+}
+
+function renderMarkdown(summary) {
+  const lines = [
+    '# Issue #1542 Data Factory Seed Result',
+    '',
+    `- Decision: ${summary.decision}`,
+    `- Mode: ${summary.mode}`,
+    `- Tenant: ${summary.scope.tenantId}`,
+    `- Workspace: ${summary.scope.workspaceId || '(none)'}`,
+    `- Project: ${summary.scope.projectId}`,
+    `- Staging source: ${summary.systems.stagingSource.id}`,
+    `- K3 target: ${summary.systems.k3Target.id}`,
+    `- Staging object: ${summary.systems.stagingSource.object}`,
+    `- Staging sheet: ${summary.systems.stagingSource.sheetId}`,
+    `- K3 credentials: ${summary.systems.k3Target.credentials}`,
+    `- Auto Submit: ${summary.systems.k3Target.autoSubmit}`,
+    `- Auto Audit: ${summary.systems.k3Target.autoAudit}`,
+    '',
+    '## Next Command',
+    '',
+    'Run the postdeploy smoke with `--issue1542-workbench-smoke` using the same tenant/workspace scope.',
+    '',
+    'This tool does not write real K3 secrets and does not call K3 Save / Submit / Audit.',
+  ]
+  if (summary.warnings.length > 0) {
+    lines.push('', '## Warnings', '', ...summary.warnings.map((item) => `- ${item}`))
+  }
+  return `${lines.join('\n')}\n`
+}
+
+async function writeOutputs(opts, summary) {
+  const dir = outputDir(opts)
+  await mkdir(dir, { recursive: true, mode: 0o700 })
+  const jsonPath = path.join(dir, 'integration-issue1542-seed-workbench-systems.json')
+  const mdPath = path.join(dir, 'integration-issue1542-seed-workbench-systems.md')
+  await writeFile(jsonPath, `${JSON.stringify(summary, null, 2)}\n`, { mode: 0o600 })
+  await writeFile(mdPath, renderMarkdown(summary), { mode: 0o600 })
+  return { dir, jsonPath, mdPath }
+}
+
+async function seed(opts, token) {
+  const descriptorsResponse = await requestJson(opts.baseUrl, withQuery('/api/integration/staging/descriptors', buildScope(opts)), {
+    token,
+    timeoutMs: opts.timeoutMs,
+  })
+  const descriptor = standardMaterialsDescriptor(responseData(descriptorsResponse.body))
+
+  let installed = false
+  let sheetTarget = directSheetTarget(opts)
+  if (opts.installStaging) {
+    const installResponse = await requestJson(opts.baseUrl, '/api/integration/staging/install', {
+      token,
+      method: 'POST',
+      timeoutMs: opts.timeoutMs,
+      body: {
+        ...buildScope(opts),
+        projectId: opts.projectId,
+        baseId: opts.baseId,
+      },
+    })
+    sheetTarget = sheetTargetFromInstallResult(installResponse.body)
+    installed = true
+  }
+
+  const sourcePayload = buildStagingPayload(opts, descriptor, sheetTarget)
+  const targetPayload = buildK3Payload(opts)
+  const source = await upsertExternalSystem(opts, token, sourcePayload)
+  const target = await upsertExternalSystem(opts, token, targetPayload)
+
+  return buildSummary({ opts, source, target, sheetTarget, descriptor, installed })
+}
+
+async function main() {
+  const opts = parseArgs()
+  if (opts.help) {
+    printHelp()
+    return
+  }
+  const token = await loadToken(opts)
+  const summary = await seed(opts, token)
+  const outputs = await writeOutputs(opts, summary)
+  console.log(`Issue #1542 Data Factory seed: ${summary.decision}`)
+  console.log(`Mode: ${summary.mode}`)
+  console.log(`Staging source: ${summary.systems.stagingSource.id}`)
+  console.log(`K3 target: ${summary.systems.k3Target.id}`)
+  console.log(`Artifacts: ${outputs.dir}`)
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    const details = error && error.details ? ` ${JSON.stringify(sanitizeBody(error.details))}` : ''
+    console.error(`[issue1542-seed] ${error && error.message ? error.message : String(error)}${details}`)
+    process.exitCode = 1
+  })
+}

--- a/scripts/ops/integration-issue1542-seed-workbench-systems.test.mjs
+++ b/scripts/ops/integration-issue1542-seed-workbench-systems.test.mjs
@@ -1,0 +1,244 @@
+import assert from 'node:assert/strict'
+import { createServer } from 'node:http'
+import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { spawn } from 'node:child_process'
+import { test } from 'node:test'
+
+const SCRIPT = path.resolve('scripts/ops/integration-issue1542-seed-workbench-systems.mjs')
+const TOKEN = 'header.payload.signature-value-for-tests'
+
+function descriptor() {
+  return {
+    id: 'standard_materials',
+    name: 'Standard materials',
+    fields: ['code', 'name', 'uom', 'erpSyncStatus'],
+    fieldDetails: [
+      { id: 'code', name: 'Code', type: 'string' },
+      { id: 'name', name: 'Name', type: 'string' },
+      { id: 'uom', name: 'UOM', type: 'string' },
+      { id: 'erpSyncStatus', name: 'ERP Sync Status', type: 'select', options: ['pending', 'synced', 'failed'] },
+    ],
+  }
+}
+
+async function readJson(req) {
+  let text = ''
+  for await (const chunk of req) text += chunk
+  return text ? JSON.parse(text) : null
+}
+
+async function withFakeServer(handler, fn) {
+  const calls = []
+  const server = createServer(async (req, res) => {
+    try {
+      if (req.headers.authorization !== `Bearer ${TOKEN}`) {
+        res.writeHead(401, { 'content-type': 'application/json' })
+        res.end(JSON.stringify({ error: { code: 'UNAUTHENTICATED' } }))
+        return
+      }
+      await handler(req, res, calls)
+    } catch (error) {
+      res.writeHead(500, { 'content-type': 'application/json' })
+      res.end(JSON.stringify({ error: { message: error.message } }))
+    }
+  })
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve))
+  const address = server.address()
+  try {
+    return await fn(`http://127.0.0.1:${address.port}`, calls)
+  } finally {
+    await new Promise((resolve) => server.close(resolve))
+  }
+}
+
+async function defaultHandler(req, res, calls) {
+  const url = new URL(req.url, 'http://127.0.0.1')
+  if (req.method === 'GET' && url.pathname === '/api/integration/staging/descriptors') {
+    calls.push({ method: req.method, path: url.pathname })
+    res.writeHead(200, { 'content-type': 'application/json' })
+    res.end(JSON.stringify({ data: [descriptor()] }))
+    return
+  }
+  if (req.method === 'POST' && url.pathname === '/api/integration/staging/install') {
+    const body = await readJson(req)
+    calls.push({ method: req.method, path: url.pathname, body })
+    res.writeHead(201, { 'content-type': 'application/json' })
+    res.end(JSON.stringify({
+      data: {
+        sheetIds: { standard_materials: 'sheet_from_install' },
+        viewIds: { standard_materials: 'view_from_install' },
+        openLinks: { standard_materials: '/multitable/sheet_from_install/view_from_install' },
+        targets: [{
+          id: 'standard_materials',
+          sheetId: 'sheet_from_install',
+          viewId: 'view_from_install',
+          openLink: '/multitable/sheet_from_install/view_from_install',
+        }],
+        warnings: [],
+      },
+    }))
+    return
+  }
+  if (req.method === 'POST' && url.pathname === '/api/integration/external-systems') {
+    const body = await readJson(req)
+    calls.push({ method: req.method, path: url.pathname, body })
+    res.writeHead(201, { 'content-type': 'application/json' })
+    res.end(JSON.stringify({ data: { ...body, createdAt: '2026-05-15T00:00:00Z' } }))
+    return
+  }
+  res.writeHead(404, { 'content-type': 'application/json' })
+  res.end(JSON.stringify({ error: { code: 'NOT_FOUND' } }))
+}
+
+async function runScript(args, { token = TOKEN } = {}) {
+  const dir = await mkdtemp(path.join(tmpdir(), 'issue1542-seed-'))
+  const tokenFile = path.join(dir, 'token.jwt')
+  await writeFile(tokenFile, token, { mode: 0o600 })
+  const outDir = path.join(dir, 'out')
+  const result = await new Promise((resolve) => {
+    const child = spawn(process.execPath, [
+      SCRIPT,
+      '--token-file',
+      tokenFile,
+      '--out-dir',
+      outDir,
+      ...args,
+    ], {
+      cwd: process.cwd(),
+      env: { ...process.env, METASHEET_AUTH_TOKEN: '', ADMIN_TOKEN: '', AUTH_TOKEN: '' },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', (chunk) => { stdout += chunk })
+    child.stderr.on('data', (chunk) => { stderr += chunk })
+    child.on('close', (code) => resolve({ code, stdout, stderr, dir, outDir }))
+  })
+  return result
+}
+
+test('seeds staging source and metadata-only K3 target from existing sheet id', async () => {
+  await withFakeServer(defaultHandler, async (baseUrl, calls) => {
+    const result = await runScript([
+      '--base-url',
+      baseUrl,
+      '--tenant-id',
+      'default',
+      '--project-id',
+      'project_a',
+      '--standard-materials-sheet-id',
+      'sheet_materials',
+      '--standard-materials-view-id',
+      'view_materials',
+      '--standard-materials-open-link',
+      '/multitable/sheet_materials/view_materials',
+    ])
+    assert.equal(result.code, 0, result.stderr)
+    assert.match(result.stdout, /Issue #1542 Data Factory seed: PASS/)
+
+    const upserts = calls.filter((call) => call.method === 'POST' && call.path === '/api/integration/external-systems')
+    assert.equal(upserts.length, 2)
+    const source = upserts.find((call) => call.body.kind === 'metasheet:staging').body
+    const target = upserts.find((call) => call.body.kind === 'erp:k3-wise-webapi').body
+    assert.equal(source.id, 'metasheet_staging_project_a')
+    assert.equal(source.role, 'source')
+    assert.equal(source.status, 'active')
+    assert.equal(source.config.objects.standard_materials.sheetId, 'sheet_materials')
+    assert.equal(source.config.objects.standard_materials.viewId, 'view_materials')
+    assert.equal(target.role, 'target')
+    assert.equal(target.status, 'active')
+    assert.equal(target.config.autoSubmit, false)
+    assert.equal(target.config.autoAudit, false)
+    assert.equal(target.config.metadataOnly, true)
+    assert.equal(Object.prototype.hasOwnProperty.call(target, 'credentials'), false)
+
+    const evidence = JSON.parse(await readFile(path.join(result.outDir, 'integration-issue1542-seed-workbench-systems.json'), 'utf8'))
+    assert.equal(evidence.decision, 'PASS')
+    assert.equal(evidence.mode, 'seed-existing-sheet')
+    assert.equal(evidence.systems.stagingSource.sheetId, 'sheet_materials')
+    assert.equal(evidence.systems.k3Target.credentials, 'not written by this tool')
+    await rm(result.dir, { recursive: true, force: true })
+  })
+})
+test('can install staging first and use returned standard_materials sheet id', async () => {
+  await withFakeServer(defaultHandler, async (baseUrl, calls) => {
+    const result = await runScript([
+      '--base-url',
+      baseUrl,
+      '--tenant-id',
+      'default',
+      '--project-id',
+      'project_b',
+      '--install-staging',
+    ])
+    assert.equal(result.code, 0, result.stderr)
+
+    const install = calls.find((call) => call.method === 'POST' && call.path === '/api/integration/staging/install')
+    assert.ok(install)
+    assert.equal(install.body.projectId, 'project_b')
+    const source = calls.find((call) => call.body?.kind === 'metasheet:staging').body
+    assert.equal(source.config.objects.standard_materials.sheetId, 'sheet_from_install')
+
+    const evidence = JSON.parse(await readFile(path.join(result.outDir, 'integration-issue1542-seed-workbench-systems.json'), 'utf8'))
+    assert.equal(evidence.mode, 'install-staging-and-seed')
+    assert.equal(evidence.systems.stagingSource.sheetId, 'sheet_from_install')
+    await rm(result.dir, { recursive: true, force: true })
+  })
+})
+
+test('rejects missing sheet id unless install-staging is supplied', async () => {
+  const result = await new Promise((resolve) => {
+    const child = spawn(process.execPath, [
+      SCRIPT,
+      '--base-url',
+      'http://127.0.0.1:9',
+      '--auth-token',
+      TOKEN,
+      '--tenant-id',
+      'default',
+    ], {
+      cwd: process.cwd(),
+      env: { ...process.env, METASHEET_AUTH_TOKEN: '', ADMIN_TOKEN: '', AUTH_TOKEN: '' },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    let stderr = ''
+    child.stderr.on('data', (chunk) => { stderr += chunk })
+    child.on('close', (code) => resolve({ code, stderr }))
+  })
+  assert.equal(result.code, 1)
+  assert.match(result.stderr, /--standard-materials-sheet-id is required unless --install-staging is supplied/)
+})
+
+test('writes artifacts with private file mode and without bearer token leakage', async () => {
+  await withFakeServer(defaultHandler, async (baseUrl) => {
+    const result = await runScript([
+      '--base-url',
+      `${baseUrl}?access_token=leak-me`,
+      '--tenant-id',
+      'default',
+      '--project-id',
+      'project_c',
+      '--standard-materials-sheet-id',
+      'sheet_materials',
+      '--k3-base-url',
+      'http://user:rawpass@k3.local/K3API/?api_key=raw&sign=raw',
+    ])
+    assert.equal(result.code, 0, result.stderr)
+    const jsonPath = path.join(result.outDir, 'integration-issue1542-seed-workbench-systems.json')
+    const mdPath = path.join(result.outDir, 'integration-issue1542-seed-workbench-systems.md')
+    const json = await readFile(jsonPath, 'utf8')
+    const md = await readFile(mdPath, 'utf8')
+    assert.equal(json.includes(TOKEN), false)
+    assert.equal(md.includes(TOKEN), false)
+    assert.equal(json.includes('rawpass'), false)
+    assert.equal(json.includes('api_key=raw'), false)
+    assert.equal(json.includes('sign=raw'), false)
+    const jsonMode = (await stat(jsonPath)).mode & 0o777
+    const mdMode = (await stat(mdPath)).mode & 0o777
+    assert.equal(jsonMode, 0o600)
+    assert.equal(mdMode, 0o600)
+    await rm(result.dir, { recursive: true, force: true })
+  })
+})

--- a/scripts/ops/multitable-onprem-package-verify.sh
+++ b/scripts/ops/multitable-onprem-package-verify.sh
@@ -92,6 +92,7 @@ function verify_generic_integration_workbench_contract() {
   local easy_start="${root}/docs/deployment/multitable-windows-onprem-easy-start-20260319.md"
   local k3_runbook="${root}/docs/operations/integration-k3wise-internal-trial-runbook.md"
   local postdeploy_smoke="${root}/scripts/ops/integration-k3wise-postdeploy-smoke.mjs"
+  local issue1542_seed="${root}/scripts/ops/integration-issue1542-seed-workbench-systems.mjs"
   local postdeploy_summary="${root}/scripts/ops/integration-k3wise-postdeploy-summary.mjs"
 
   search_fixed_string '/integrations/workbench' "$web_dist" || die "web dist must include the Data Factory route"
@@ -109,6 +110,9 @@ function verify_generic_integration_workbench_contract() {
   search_fixed_string 'data-factory-adapter-discovery' "$postdeploy_smoke" || die "postdeploy smoke must check Data Factory adapter discovery"
   search_fixed_string '--issue1542-workbench-smoke' "$postdeploy_smoke" || die "postdeploy smoke must include Data Factory issue #1542 workbench retest flag"
   search_fixed_string '--issue1542-workbench-smoke' "$k3_runbook" || die "K3 runbook must document the Data Factory issue #1542 workbench retest"
+  search_fixed_string 'integration-issue1542-seed-workbench-systems.mjs' "$k3_runbook" || die "K3 runbook must document the issue #1542 metadata seed helper"
+  search_fixed_string 'metasheet:staging' "$issue1542_seed" || die "issue #1542 seed helper must create the staging source system"
+  search_fixed_string 'erp:k3-wise-webapi' "$issue1542_seed" || die "issue #1542 seed helper must create the K3 target system"
   search_fixed_string 'invalidAdapters' "$postdeploy_summary" || die "postdeploy summary must render Data Factory adapter drift details"
 }
 
@@ -317,6 +321,7 @@ required=(
   "scripts/ops/integration-k3wise-live-poc-preflight.mjs"
   "scripts/ops/integration-k3wise-live-poc-evidence.mjs"
   "scripts/ops/integration-k3wise-postdeploy-smoke.mjs"
+  "scripts/ops/integration-issue1542-seed-workbench-systems.mjs"
   "scripts/ops/integration-k3wise-postdeploy-summary.mjs"
   "scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs"
   "scripts/ops/multitable-onprem-bootstrap-admin.ps1"


### PR DESCRIPTION
## Summary

Adds an operator-only metadata seed helper for the issue #1542 Data Factory postdeploy smoke.

The 142 smoke reached the real product surface, but failed at `issue1542-system-readiness` because `integration_external_systems` was empty. This PR makes that setup step repeatable without entering real K3 credentials:

- `scripts/ops/integration-issue1542-seed-workbench-systems.mjs`
  - creates/updates a `metasheet:staging` source system;
  - creates/updates a metadata-only `erp:k3-wise-webapi` target system;
  - supports either `--standard-materials-sheet-id` or `--install-staging`;
  - writes 0600 JSON/MD artifacts with no bearer token or K3 secret output.
- Adds focused node tests and a package script.
- Updates the internal-trial runbook to seed before running `--issue1542-workbench-smoke` on fresh deployments.
- Updates the on-prem package verifier so the helper is included in generated Windows packages.
- Adds development and verification MDs.

## Safety

- Does not write K3 credentials.
- Does not run dry-run, Save-only, Submit, or Audit.
- Does not create or modify pipelines.
- K3 target keeps `autoSubmit=false` and `autoAudit=false`.
- Artifacts redact token-shaped strings, URL userinfo, and secret query params.

## Verification

- `pnpm verify:integration-issue1542:seed-workbench` - 4/4 pass
- `node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs` - 20/20 pass
- `pnpm verify:integration-k3wise:poc` - pass
- `node --check scripts/ops/integration-issue1542-seed-workbench-systems.mjs` - pass
- `bash -n scripts/ops/multitable-onprem-package-verify.sh` - pass
- `git diff --check origin/main...HEAD` - pass

## Deployment Impact

Opt-in operator tool only. Runtime behavior is unchanged unless an operator explicitly runs the script with an auth token.
