### PR TITLE
docs(integration): record issue1542 seed fallback

### DIFF
--- a/docs/development/data-factory-issue1542-142-retest-verification-20260515.md
+++ b/docs/development/data-factory-issue1542-142-retest-verification-20260515.md
@@ -1,0 +1,149 @@
+# Data Factory Issue #1542 142 Retest Verification
+
+Date: 2026-05-15
+
+## Baseline
+
+- PR #1569 merged to main as `7e38fee72`.
+- Main workflows for that merge completed successfully:
+  - Phase 5 Production Flags Guard
+  - Deploy to Production
+  - Build and Push Docker Images
+  - Plugin System Tests
+  - SafetyGuard E2E
+  - Observability E2E
+  - monitoring-alert
+- 142 host checkout: `HEAD=7e38fee`.
+- 142 backend health:
+  - `status=ok`
+  - `pluginsSummary.total=13`
+  - `pluginsSummary.active=13`
+  - `pluginsSummary.failed=0`
+
+## Token Handling
+
+A short-lived admin JWT was minted inside the `metasheet-backend` container and
+written to a temporary `0600` file. The token value was not printed. The
+temporary token file was removed by shell trap after the retest.
+
+## First Attempt: Install Staging Then Seed
+
+Command shape:
+
+```bash
+node scripts/ops/integration-issue1542-seed-workbench-systems.mjs \
+  --base-url http://127.0.0.1:8081 \
+  --token-file "$TOKEN_FILE" \
+  --tenant-id default \
+  --project-id default \
+  --install-staging \
+  --out-dir artifacts/integration-k3wise/internal-trial/issue1542-seed
+```
+
+Result:
+
+```text
+token_shape=valid
+staging install did not return sheetIds.standard_materials
+```
+
+Interpretation: the deployment accepted authenticated control-plane calls, but
+the current multitable provisioning path did not return a `standard_materials`
+sheet id. This blocks real staging dry-run readiness, but it does not block the
+metadata-only #1542 schema/pipeline-save retest.
+
+## Fallback Attempt: Metadata-Only Sheet Id
+
+Command shape:
+
+```bash
+node scripts/ops/integration-issue1542-seed-workbench-systems.mjs \
+  --base-url http://127.0.0.1:8081 \
+  --token-file "$TOKEN_FILE" \
+  --tenant-id default \
+  --project-id default \
+  --standard-materials-sheet-id issue1542_metadata_standard_materials \
+  --standard-materials-view-id issue1542_metadata_view \
+  --standard-materials-open-link /multitable/issue1542_metadata_standard_materials/issue1542_metadata_view \
+  --out-dir artifacts/integration-k3wise/internal-trial/issue1542-seed-direct
+```
+
+Seed result:
+
+```json
+{
+  "decision": "PASS",
+  "mode": "seed-existing-sheet",
+  "stagingSource": "metasheet_staging_default",
+  "k3Target": "issue1542_k3wise_webapi_metadata_target",
+  "sheetIdPresent": true
+}
+```
+
+## Issue #1542 Smoke Result
+
+Command shape:
+
+```bash
+node scripts/ops/integration-k3wise-postdeploy-smoke.mjs \
+  --base-url http://127.0.0.1:8081 \
+  --token-file "$TOKEN_FILE" \
+  --tenant-id default \
+  --require-auth \
+  --issue1542-workbench-smoke \
+  --out-dir artifacts/integration-k3wise/internal-trial/postdeploy-smoke-issue1542-direct
+```
+
+Result:
+
+```json
+{
+  "ok": true,
+  "signoff": "pass",
+  "reason": "authenticated smoke passed",
+  "summary": {
+    "pass": 16,
+    "skipped": 0,
+    "fail": 0
+  },
+  "issue1542": [
+    { "id": "issue1542-system-readiness", "status": "pass" },
+    { "id": "issue1542-staging-source-schema", "status": "pass" },
+    { "id": "issue1542-k3-material-schema", "status": "pass" },
+    { "id": "issue1542-pipeline-save", "status": "pass" }
+  ]
+}
+```
+
+## Secret Leak Check
+
+The generated seed and smoke artifact directories were scanned:
+
+```text
+secret_jwt_shape_hits=0
+secret_bearer_hits=0
+secret_field_hits=0
+```
+
+## Artifact Paths On 142
+
+```text
+artifacts/integration-k3wise/internal-trial/issue1542-seed-direct-20260515T043104Z/
+artifacts/integration-k3wise/internal-trial/postdeploy-smoke-issue1542-direct-20260515T043104Z/
+```
+
+## Conclusion
+
+The #1542 Data Factory metadata path is verified on 142 after #1569:
+
+- authenticated integration routes work;
+- `metasheet:staging` source metadata can expose `standard_materials` schema;
+- K3 WebAPI target metadata exposes the `material` schema;
+- the fixed issue #1542 draft pipeline can be saved;
+- artifacts remain token-safe.
+
+Remaining deployment gap: real staging table provisioning did not return
+`sheetIds.standard_materials`. The metadata fallback is acceptable for #1542
+schema/pipeline-save retest only. Real dry-run still requires fixing or
+rerunning multitable provisioning so `standard_materials` is backed by an
+actual sheet.

--- a/docs/development/data-factory-issue1542-seed-workbench-systems-verification-20260515.md
+++ b/docs/development/data-factory-issue1542-seed-workbench-systems-verification-20260515.md
@@ -6,7 +6,7 @@ Date: 2026-05-15
 
 | Area | Command | Expected |
 | --- | --- | --- |
-| Seed helper unit coverage | `pnpm verify:integration-issue1542:seed-workbench` | PASS: 4/4 |
+| Seed helper unit coverage | `pnpm verify:integration-issue1542:seed-workbench` | PASS: 5/5 |
 | Existing postdeploy smoke regression | `node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs` | PASS: 20/20 |
 | K3 offline PoC regression | `pnpm verify:integration-k3wise:poc` | PASS: preflight/evidence/fixture/mock chain |
 | Syntax | `node --check scripts/ops/integration-issue1542-seed-workbench-systems.mjs` | PASS |
@@ -23,8 +23,10 @@ Date: 2026-05-15
    - no `credentials` property in the K3 target payload.
 2. `--install-staging` calls `POST /api/integration/staging/install` and uses
    the returned `sheetIds.standard_materials`.
-3. Missing sheet id without `--install-staging` fails before any network write.
-4. JSON and Markdown artifacts are written with mode `0600` and do not contain
+3. `--install-staging` with empty `sheetIds` fails before any external-system
+   writes and prints the metadata-only fallback command.
+4. Missing sheet id without `--install-staging` fails before any network write.
+5. JSON and Markdown artifacts are written with mode `0600` and do not contain
    bearer tokens or raw URL userinfo/query secrets.
 
 ## Manual 142 Retest Plan
@@ -50,6 +52,25 @@ Mode: install-staging-and-seed
 Staging source: metasheet_staging_default
 K3 target: issue1542_k3wise_webapi_metadata_target
 ```
+
+If the install route returns no `sheetIds.standard_materials`, use the
+metadata-only fallback that was validated on 142:
+
+```bash
+node scripts/ops/integration-issue1542-seed-workbench-systems.mjs \
+  --base-url http://127.0.0.1:8081 \
+  --token-file "$TOKEN_FILE" \
+  --tenant-id default \
+  --project-id default \
+  --standard-materials-sheet-id issue1542_metadata_standard_materials \
+  --standard-materials-view-id issue1542_metadata_view \
+  --standard-materials-open-link /multitable/issue1542_metadata_standard_materials/issue1542_metadata_view \
+  --out-dir artifacts/integration-k3wise/internal-trial/issue1542-seed
+```
+
+This fallback is only for the #1542 schema and draft-pipeline-save smoke. It
+does not prove real staging records can be read; fix multitable provisioning
+before dry-run.
 
 Then rerun:
 

--- a/docs/operations/integration-k3wise-internal-trial-runbook.md
+++ b/docs/operations/integration-k3wise-internal-trial-runbook.md
@@ -125,6 +125,23 @@ node scripts/ops/integration-issue1542-seed-workbench-systems.mjs \
   --out-dir artifacts/integration-k3wise/internal-trial/issue1542-seed
 ```
 
+If this fails with `staging install did not return sheetIds.standard_materials`,
+the deployment can still run the metadata-only #1542 retest by supplying an
+explicit placeholder sheet id. Use this fallback only for schema/pipeline-save
+smoke evidence; fix multitable provisioning before real dry-run testing.
+
+```bash
+node scripts/ops/integration-issue1542-seed-workbench-systems.mjs \
+  --base-url "$METASHEET_BASE_URL" \
+  --token-file "$METASHEET_AUTH_TOKEN_FILE" \
+  --tenant-id "$METASHEET_TENANT_ID" \
+  --project-id "${METASHEET_PROJECT_ID:-default}" \
+  --standard-materials-sheet-id issue1542_metadata_standard_materials \
+  --standard-materials-view-id issue1542_metadata_view \
+  --standard-materials-open-link /multitable/issue1542_metadata_standard_materials/issue1542_metadata_view \
+  --out-dir artifacts/integration-k3wise/internal-trial/issue1542-seed
+```
+
 Then run the smoke:
 
 ```bash

--- a/scripts/ops/integration-issue1542-seed-workbench-systems.mjs
+++ b/scripts/ops/integration-issue1542-seed-workbench-systems.mjs
@@ -307,8 +307,10 @@ function sheetTargetFromInstallResult(result) {
   const data = responseData(result)
   const sheetId = data?.sheetIds?.standard_materials
   if (!sheetId) {
-    throw new Issue1542SeedError('staging install did not return sheetIds.standard_materials', {
+    throw new Issue1542SeedError('staging install did not return sheetIds.standard_materials; for the metadata-only issue #1542 smoke, rerun with --standard-materials-sheet-id issue1542_metadata_standard_materials, or fix multitable provisioning before real dry-run testing', {
       sheetIds: data?.sheetIds || {},
+      warnings: Array.isArray(data?.warnings) ? data.warnings : [],
+      fallback: '--standard-materials-sheet-id issue1542_metadata_standard_materials --standard-materials-view-id issue1542_metadata_view',
     })
   }
   const target = Array.isArray(data.targets)

--- a/scripts/ops/integration-issue1542-seed-workbench-systems.test.mjs
+++ b/scripts/ops/integration-issue1542-seed-workbench-systems.test.mjs
@@ -188,6 +188,47 @@ test('can install staging first and use returned standard_materials sheet id', a
   })
 })
 
+test('install-staging explains metadata-only fallback when no sheet id is returned', async () => {
+  await withFakeServer(async (req, res, calls) => {
+    const url = new URL(req.url, 'http://127.0.0.1')
+    if (req.method === 'GET' && url.pathname === '/api/integration/staging/descriptors') {
+      calls.push({ method: req.method, path: url.pathname })
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end(JSON.stringify({ data: [descriptor()] }))
+      return
+    }
+    if (req.method === 'POST' && url.pathname === '/api/integration/staging/install') {
+      calls.push({ method: req.method, path: url.pathname, body: await readJson(req) })
+      res.writeHead(201, { 'content-type': 'application/json' })
+      res.end(JSON.stringify({
+        data: {
+          sheetIds: {},
+          viewIds: {},
+          warnings: ['context.api.multitable.provisioning.ensureObject not available'],
+        },
+      }))
+      return
+    }
+    res.writeHead(404, { 'content-type': 'application/json' })
+    res.end(JSON.stringify({ error: { code: 'NOT_FOUND' } }))
+  }, async (baseUrl, calls) => {
+    const result = await runScript([
+      '--base-url',
+      baseUrl,
+      '--tenant-id',
+      'default',
+      '--project-id',
+      'project_b',
+      '--install-staging',
+    ])
+    assert.equal(result.code, 1)
+    assert.match(result.stderr, /staging install did not return sheetIds\.standard_materials/)
+    assert.match(result.stderr, /--standard-materials-sheet-id issue1542_metadata_standard_materials/)
+    assert.equal(calls.filter((call) => call.path === '/api/integration/external-systems').length, 0)
+    await rm(result.dir, { recursive: true, force: true })
+  })
+})
+
 test('rejects missing sheet id unless install-staging is supplied', async () => {
   const result = await new Promise((resolve) => {
     const child = spawn(process.execPath, [


### PR DESCRIPTION
## Summary

Follow-up to #1569 after running the new seed + #1542 smoke on the 142 host.

142 verified the metadata path, but its `/api/integration/staging/install` response did not include `sheetIds.standard_materials`. This PR makes that operator path less surprising:

- improves the seed helper error with the exact metadata-only fallback command;
- adds a regression test for empty staging-install sheetIds;
- updates the internal-trial runbook with the fallback command and the warning that it is for schema/pipeline-save smoke only;
- records the 142 retest evidence in a verification MD.

## 142 Evidence

- main SHA on 142: `7e38fee`
- backend health: `ok`, 13 active plugins, 0 failed plugins
- seed direct fallback: PASS
- `--issue1542-workbench-smoke`: PASS, `pass=16 / skipped=0 / fail=0`
- issue1542 checks: system readiness, staging schema, K3 material schema, pipeline save all pass
- artifact secret scan: JWT shape 0, Bearer 0, secret fields 0

## Safety

The fallback is explicitly metadata-only. It should not be used as evidence that real staging records can be read; real dry-run still requires fixing multitable provisioning so `standard_materials` has an actual sheet.

## Verification

- `pnpm verify:integration-issue1542:seed-workbench` - 5/5 pass
- `node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs` - 20/20 pass
- `node --check scripts/ops/integration-issue1542-seed-workbench-systems.mjs` - pass
- `bash -n scripts/ops/multitable-onprem-package-verify.sh` - pass
- `git diff --check origin/main...HEAD` - pass
