### PR TITLE
test(integration): let issue1542 smoke install staging source

### DIFF
--- a/docs/development/data-factory-issue1542-install-smoke-development-20260515.md
+++ b/docs/development/data-factory-issue1542-install-smoke-development-20260515.md
@@ -1,0 +1,104 @@
+# Data Factory issue #1542 install-staging smoke development - 2026-05-15
+
+## Summary
+
+This slice closes the gap between the #1572 staging-install project-scope fix
+and the deployed-box #1542 smoke.
+
+Before this change, the opt-in `--issue1542-workbench-smoke` expected a
+`metasheet:staging` source external system to already exist. That meant a
+freshly deployed box still needed a separate manual or seed step before the
+smoke could verify the real Data Factory setup path.
+
+The smoke now supports:
+
+```bash
+--issue1542-workbench-smoke --issue1542-install-staging
+```
+
+With both flags, the script:
+
+1. reads staging descriptors;
+2. calls `POST /api/integration/staging/install`;
+3. requires `sheetIds.standard_materials`;
+4. builds a `metasheet:staging` source config from returned `targets` or
+   `sheetIds`;
+5. upserts that source through `POST /api/integration/external-systems`;
+6. continues the existing #1542 schema and draft-pipeline save checks.
+
+The flag intentionally creates only the MetaSheet staging source. It still
+expects an `erp:k3-wise-webapi` target to exist from the K3 preset page, the
+Data Factory target-system form, or the existing metadata-only seed helper.
+
+## Safety
+
+- This is opt-in and does not run during the default postdeploy smoke.
+- It writes only staging/source/pipeline metadata.
+- It does not call pipeline dry-run.
+- It does not call Save-only, Submit, or Audit.
+- It does not include credentials, K3 tokens, SQL connection strings, or
+  authority codes in evidence.
+
+## Files changed
+
+- `scripts/ops/integration-k3wise-postdeploy-smoke.mjs`
+- `scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs`
+- `docs/operations/integration-k3wise-internal-trial-runbook.md`
+- `docs/development/data-factory-issue1542-install-smoke-development-20260515.md`
+- `docs/development/data-factory-issue1542-install-smoke-verification-20260515.md`
+
+## Runtime behavior
+
+The new check ID is:
+
+```text
+issue1542-staging-install
+```
+
+A passing check records:
+
+- resolved project ID;
+- created/upserted staging source system ID;
+- returned staging sheet IDs;
+- configured staging objects;
+- warning count.
+
+If staging install fails or returns no `standard_materials` sheet, the smoke
+fails before attempting schema or pipeline-save checks. This makes the failure
+cause direct and keeps the evidence small.
+
+When multiple `metasheet:staging` sources already exist, the smoke carries the
+freshly installed/upserted source system ID forward and uses that exact source
+for schema discovery and draft pipeline save. This prevents the deployment
+smoke from accidentally validating an older staging source left in the tenant.
+
+## Operator command
+
+Prerequisite: save or seed one K3 WISE WebAPI target for the same tenant scope.
+
+```bash
+node scripts/ops/integration-k3wise-postdeploy-smoke.mjs \
+  --base-url "$METASHEET_BASE_URL" \
+  --token-file "$METASHEET_AUTH_TOKEN_FILE" \
+  --tenant-id "$METASHEET_TENANT_ID" \
+  --require-auth \
+  --issue1542-workbench-smoke \
+  --issue1542-install-staging \
+  --out-dir artifacts/integration-k3wise/internal-trial/postdeploy-smoke-issue1542
+```
+
+Expected passing #1542 checks:
+
+- `issue1542-staging-install`
+- `issue1542-system-readiness`
+- `issue1542-staging-source-schema`
+- `issue1542-k3-material-schema`
+- `issue1542-pipeline-save`
+
+## Out of scope
+
+- SQL Server executor implementation remains outside this slice.
+- No new migration.
+- No frontend UI change.
+- No automatic K3 target creation in the smoke itself.
+- No K3 live write.

--- a/docs/development/data-factory-issue1542-install-smoke-verification-20260515.md
+++ b/docs/development/data-factory-issue1542-install-smoke-verification-20260515.md
@@ -1,0 +1,111 @@
+# Data Factory issue #1542 install-staging smoke verification - 2026-05-15
+
+## Local commands
+
+```bash
+node --check scripts/ops/integration-k3wise-postdeploy-smoke.mjs
+node --check scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
+node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
+pnpm verify:integration-k3wise:poc
+git diff --check
+```
+
+## Results
+
+```text
+node --check scripts/ops/integration-k3wise-postdeploy-smoke.mjs
+PASS
+
+node --check scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
+PASS
+
+node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
+22 tests passed
+
+pnpm verify:integration-k3wise:poc
+PASS: preflight tests, evidence tests, fixture contract, mock K3 WebAPI,
+mock SQL executor, and the mock PoC demo all passed.
+
+git diff --check
+PASS
+```
+
+## New coverage
+
+### Install-and-register happy path
+
+Test:
+
+```text
+issue1542 install-staging smoke creates staging source before schema and pipeline checks
+```
+
+Assertions:
+
+- the script calls `POST /api/integration/staging/install`;
+- the request body contains only tenant/workspace scope;
+- the install result resolves `tenant-smoke:integration-core`;
+- the script upserts a `metasheet:staging` source system;
+- if an older staging source already exists, the script uses the freshly
+  installed source ID for schema discovery and draft pipeline save;
+- the source system config contains `standard_materials.sheetId`;
+- field details are copied into the staging source config;
+- downstream #1542 checks pass:
+  - `issue1542-system-readiness`;
+  - `issue1542-staging-source-schema`;
+  - `issue1542-pipeline-save`.
+
+### Install failure path
+
+Test:
+
+```text
+issue1542 install-staging smoke fails clearly when staging install fails
+```
+
+Assertions:
+
+- the smoke exits non-zero;
+- evidence contains `issue1542-staging-install=fail`;
+- the error names `/api/integration/staging/install returned HTTP 500`;
+- the script does not continue to `issue1542-pipeline-save`.
+
+## Existing coverage preserved
+
+The existing #1542 smoke tests still pass:
+
+- schema discovery failure when staging source fields are empty;
+- JSONB `22P02` pipeline-save regression;
+- token redaction in stdout/stderr/JSON evidence.
+
+## Deploy-box retest command
+
+After deploying a package containing this change:
+
+Prerequisite: the deployment has one saved or seeded `erp:k3-wise-webapi`
+target for the same tenant scope. The install-staging smoke creates the
+MetaSheet staging source only.
+
+```bash
+node scripts/ops/integration-k3wise-postdeploy-smoke.mjs \
+  --base-url "$METASHEET_BASE_URL" \
+  --token-file "$METASHEET_AUTH_TOKEN_FILE" \
+  --tenant-id "$METASHEET_TENANT_ID" \
+  --require-auth \
+  --issue1542-workbench-smoke \
+  --issue1542-install-staging \
+  --out-dir artifacts/integration-k3wise/internal-trial/postdeploy-smoke-issue1542
+```
+
+Expected result:
+
+```text
+summary.fail = 0
+signoff.internalTrial = pass
+```
+
+## Notes
+
+`SQLSERVER_EXECUTOR_MISSING` remains a separate runtime deployment item. This
+smoke proves the Data Factory staging-to-K3 metadata path can bootstrap itself
+after deploy; it does not claim SQL Server direct-read readiness.

--- a/docs/operations/integration-k3wise-internal-trial-runbook.md
+++ b/docs/operations/integration-k3wise-internal-trial-runbook.md
@@ -110,39 +110,18 @@ node scripts/ops/integration-k3wise-postdeploy-smoke.mjs \
 ```
 
 For the Data Factory issue #1542 deployment retest, add the opt-in workbench
-smoke flag. If the deployment has no Data Factory external systems yet, seed
-metadata-only systems first. This writes a `metasheet:staging` source and a
-K3 WebAPI target for schema/pipeline-save verification only; it does not write
-real K3 credentials and does not run dry-run, Save-only, Submit, or Audit.
+smoke flags. `--issue1542-install-staging` first calls
+`/api/integration/staging/install`, then upserts a `metasheet:staging` source
+from the returned sheet/open-link metadata. This verifies the same one-click
+staging setup path that the UI uses. It does not run dry-run, Save-only,
+Submit, or Audit.
 
-```bash
-node scripts/ops/integration-issue1542-seed-workbench-systems.mjs \
-  --base-url "$METASHEET_BASE_URL" \
-  --token-file "$METASHEET_AUTH_TOKEN_FILE" \
-  --tenant-id "$METASHEET_TENANT_ID" \
-  --project-id "${METASHEET_PROJECT_ID:-default}" \
-  --install-staging \
-  --out-dir artifacts/integration-k3wise/internal-trial/issue1542-seed
-```
-
-If this fails with `staging install did not return sheetIds.standard_materials`,
-the deployment can still run the metadata-only #1542 retest by supplying an
-explicit placeholder sheet id. Use this fallback only for schema/pipeline-save
-smoke evidence; fix multitable provisioning before real dry-run testing.
-
-```bash
-node scripts/ops/integration-issue1542-seed-workbench-systems.mjs \
-  --base-url "$METASHEET_BASE_URL" \
-  --token-file "$METASHEET_AUTH_TOKEN_FILE" \
-  --tenant-id "$METASHEET_TENANT_ID" \
-  --project-id "${METASHEET_PROJECT_ID:-default}" \
-  --standard-materials-sheet-id issue1542_metadata_standard_materials \
-  --standard-materials-view-id issue1542_metadata_view \
-  --standard-materials-open-link /multitable/issue1542_metadata_standard_materials/issue1542_metadata_view \
-  --out-dir artifacts/integration-k3wise/internal-trial/issue1542-seed
-```
-
-Then run the smoke:
+This path assumes the K3 WISE WebAPI target has already been saved through the
+K3 preset page or Data Factory target-system form. It creates the MetaSheet
+staging source only. If you need a metadata-only target for an isolated smoke
+where no K3 target has been configured, run
+`scripts/ops/integration-issue1542-seed-workbench-systems.mjs` first and then
+run the smoke below.
 
 ```bash
 node scripts/ops/integration-k3wise-postdeploy-smoke.mjs \
@@ -151,14 +130,16 @@ node scripts/ops/integration-k3wise-postdeploy-smoke.mjs \
   --tenant-id "$METASHEET_TENANT_ID" \
   --require-auth \
   --issue1542-workbench-smoke \
+  --issue1542-install-staging \
   --out-dir artifacts/integration-k3wise/internal-trial/postdeploy-smoke-issue1542
 ```
 
-This extra smoke verifies that a configured `metasheet:staging` source exposes
+This extra smoke verifies that staging installation returns
+`standard_materials` sheet metadata, a `metasheet:staging` source exposes
 non-empty `standard_materials` schema, the K3 target exposes the `material`
 template schema, and a fixed draft pipeline ID can be saved without PostgreSQL
-JSONB `22P02`. It writes pipeline metadata only and never runs dry-run,
-Save-only, Submit, or Audit.
+JSONB `22P02`. It writes staging/source/pipeline metadata only and never runs
+dry-run, Save-only, Submit, or Audit.
 
 Then render the summary:
 

--- a/scripts/ops/integration-k3wise-postdeploy-smoke.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-smoke.mjs
@@ -172,6 +172,10 @@ Options:
                           Opt-in Data Factory #1542 smoke: verify staging schema
                           discovery and draft pipeline save. Writes metadata only;
                           never runs dry-run or Save-only.
+  --issue1542-install-staging
+                          With --issue1542-workbench-smoke, first install staging
+                          multitables and upsert a MetaSheet staging source
+                          connection. Writes staging/source metadata only.
   --help                 Show this help
 
 Environment fallbacks:
@@ -207,6 +211,7 @@ function parseArgs(argv = process.argv.slice(2)) {
     workspaceId: envValue('METASHEET_WORKSPACE_ID', 'WORKSPACE_ID'),
     requireAuth: false,
     issue1542WorkbenchSmoke: false,
+    issue1542InstallStaging: false,
     outDir: '',
     timeoutMs: 10_000,
     help: false,
@@ -241,6 +246,9 @@ function parseArgs(argv = process.argv.slice(2)) {
       case '--issue1542-workbench-smoke':
         opts.issue1542WorkbenchSmoke = true
         break
+      case '--issue1542-install-staging':
+        opts.issue1542InstallStaging = true
+        break
       case '--out-dir':
         opts.outDir = readRequiredValue(argv, i, arg)
         i += 1
@@ -260,6 +268,9 @@ function parseArgs(argv = process.argv.slice(2)) {
 
   if (!Number.isInteger(opts.timeoutMs) || opts.timeoutMs <= 0) {
     throw new K3WisePostdeploySmokeError('--timeout-ms must be a positive integer', { timeoutMs: opts.timeoutMs })
+  }
+  if (opts.issue1542InstallStaging && !opts.issue1542WorkbenchSmoke) {
+    throw new K3WisePostdeploySmokeError('--issue1542-install-staging requires --issue1542-workbench-smoke')
   }
   opts.baseUrl = normalizeBaseUrl(opts.baseUrl)
   return opts
@@ -652,18 +663,21 @@ function responseData(body) {
   return body && Object.prototype.hasOwnProperty.call(body, 'data') ? body.data : body
 }
 
-function requireSystem(systems, { kind, role, label }) {
+function requireSystem(systems, { id, kind, role, label }) {
   const system = systems.find((candidate) => {
-    if (!candidate || candidate.kind !== kind) return false
+    if (!candidate) return false
+    if (id && candidate.id !== id) return false
+    if (kind && candidate.kind !== kind) return false
     return !role || candidate.role === role || candidate.role === 'bidirectional'
   })
   if (!system) {
     throw new K3WisePostdeploySmokeError(`${label || kind} system is not configured`, {
+      id: id || null,
       kind,
       role: role || null,
       configuredKinds: systems
         .filter((candidate) => candidate && typeof candidate.kind === 'string')
-        .map((candidate) => `${candidate.kind}:${candidate.role || 'unknown'}`),
+        .map((candidate) => `${candidate.id || 'unknown'}:${candidate.kind}:${candidate.role || 'unknown'}`),
     })
   }
   return system
@@ -799,11 +813,164 @@ function assertPipelineSaveResponse(body) {
   }
 }
 
-async function runIssue1542WorkbenchSmoke({ baseUrl, token, tenantId, workspaceId, timeoutMs }) {
+function safeSystemIdSuffix(value) {
+  return String(value || 'default')
+    .replace(/[^A-Za-z0-9_-]+/g, '_')
+    .replace(/^_+|_+$/g, '') || 'default'
+}
+
+function issue1542StagingSourceSystemId(projectId) {
+  return `metasheet_staging_${safeSystemIdSuffix(projectId)}`
+}
+
+function objectConfigFromInstallTarget(target, descriptor) {
+  const fields = Array.isArray(descriptor?.fields) ? descriptor.fields : []
+  const fieldDetails = Array.isArray(descriptor?.fieldDetails) ? descriptor.fieldDetails : []
+  return {
+    name: target.name || descriptor?.name || target.id,
+    sheetId: target.sheetId,
+    viewId: target.viewId || null,
+    baseId: target.baseId || null,
+    openLink: target.openLink || null,
+    fields,
+    fieldDetails,
+  }
+}
+
+function buildStagingSourceObjectsFromInstall(installResult, descriptorList) {
+  const descriptorsById = new Map(
+    (Array.isArray(descriptorList) ? descriptorList : [])
+      .filter((descriptor) => descriptor && typeof descriptor.id === 'string')
+      .map((descriptor) => [descriptor.id, descriptor]),
+  )
+  const targets = Array.isArray(installResult?.targets) ? installResult.targets : []
+  const objects = {}
+  for (const target of targets) {
+    if (!target || typeof target.id !== 'string' || typeof target.sheetId !== 'string' || !target.sheetId) continue
+    objects[target.id] = objectConfigFromInstallTarget(target, descriptorsById.get(target.id))
+  }
+  if (Object.keys(objects).length > 0) return objects
+
+  const sheetIds = installResult?.sheetIds && typeof installResult.sheetIds === 'object' ? installResult.sheetIds : {}
+  const viewIds = installResult?.viewIds && typeof installResult.viewIds === 'object' ? installResult.viewIds : {}
+  const openLinks = installResult?.openLinks && typeof installResult.openLinks === 'object' ? installResult.openLinks : {}
+  for (const [objectId, sheetId] of Object.entries(sheetIds)) {
+    if (typeof sheetId !== 'string' || !sheetId) continue
+    const descriptor = descriptorsById.get(objectId)
+    objects[objectId] = objectConfigFromInstallTarget({
+      id: objectId,
+      name: descriptor?.name || objectId,
+      sheetId,
+      viewId: viewIds[objectId] || null,
+      baseId: installResult?.baseId || null,
+      openLink: openLinks[objectId] || null,
+    }, descriptor)
+  }
+  return objects
+}
+
+async function installIssue1542StagingSource({ baseUrl, token, tenantId, workspaceId, timeoutMs }) {
+  const descriptorResponse = await requestJson(baseUrl, '/api/integration/staging/descriptors', {
+    token,
+    timeoutMs,
+  })
+  const descriptorList = responseData(descriptorResponse.body)
+  if (!Array.isArray(descriptorList)) {
+    throw new K3WisePostdeploySmokeError('staging descriptors response data must be an array', {
+      received: Array.isArray(descriptorList) ? 'array' : typeof descriptorList,
+    })
+  }
+
+  const installResponse = await requestJson(baseUrl, '/api/integration/staging/install', {
+    token,
+    timeoutMs,
+    method: 'POST',
+    acceptStatuses: [200, 201],
+    requestBody: {
+      tenantId,
+      workspaceId: workspaceId || null,
+    },
+  })
+  const installResult = responseData(installResponse.body)
+  const sheetIds = installResult?.sheetIds && typeof installResult.sheetIds === 'object' ? installResult.sheetIds : {}
+  if (!sheetIds.standard_materials) {
+    throw new K3WisePostdeploySmokeError('staging install did not return standard_materials sheetId', {
+      sheetIds,
+      warnings: Array.isArray(installResult?.warnings) ? installResult.warnings : [],
+    })
+  }
+
+  const projectId = typeof installResult?.projectId === 'string' && installResult.projectId.trim()
+    ? installResult.projectId.trim()
+    : `${tenantId}:integration-core`
+  const sourceSystemId = issue1542StagingSourceSystemId(projectId)
+  const objects = buildStagingSourceObjectsFromInstall(installResult, descriptorList)
+  if (!objects.standard_materials?.sheetId) {
+    throw new K3WisePostdeploySmokeError('staging source config could not be built from install result', {
+      projectId,
+      objectIds: Object.keys(objects),
+    })
+  }
+
+  const sourceSystemPayload = {
+    id: sourceSystemId,
+    tenantId,
+    workspaceId: workspaceId || null,
+    projectId,
+    name: 'MetaSheet staging source',
+    kind: 'metasheet:staging',
+    role: 'source',
+    status: 'active',
+    config: {
+      projectId,
+      objects,
+    },
+    capabilities: {
+      read: true,
+      stagingSource: true,
+      dryRunFriendly: true,
+    },
+  }
+  const upsertResponse = await requestJson(baseUrl, '/api/integration/external-systems', {
+    token,
+    timeoutMs,
+    method: 'POST',
+    acceptStatuses: [200, 201],
+    requestBody: sourceSystemPayload,
+  })
+  const savedSystem = responseData(upsertResponse.body)
+  return {
+    projectId,
+    sourceSystemId: savedSystem?.id || sourceSystemId,
+    sheetIds: Object.keys(sheetIds),
+    targets: Array.isArray(installResult?.targets) ? installResult.targets.length : 0,
+    objects: Object.keys(objects),
+    warnings: Array.isArray(installResult?.warnings) ? installResult.warnings.length : 0,
+  }
+}
+
+async function runIssue1542WorkbenchSmoke({ baseUrl, token, tenantId, workspaceId, timeoutMs, installStaging = false }) {
   const checks = []
   let systems = []
   let stagingSystem = null
   let k3TargetSystem = null
+  let installedStagingSourceId = ''
+
+  if (installStaging) {
+    try {
+      const installDetails = await installIssue1542StagingSource({
+        baseUrl,
+        token,
+        tenantId,
+        workspaceId,
+        timeoutMs,
+      })
+      installedStagingSourceId = installDetails.sourceSystemId
+      checks.push(result('issue1542-staging-install', 'pass', installDetails))
+    } catch (error) {
+      return [failResult('issue1542-staging-install', error)]
+    }
+  }
 
   try {
     const systemsResponse = await requestJson(baseUrl, withQuery('/api/integration/external-systems', {
@@ -819,6 +986,7 @@ async function runIssue1542WorkbenchSmoke({ baseUrl, token, tenantId, workspaceI
     }
     systems = data
     stagingSystem = requireSystem(systems, {
+      id: installedStagingSourceId || undefined,
       kind: 'metasheet:staging',
       role: 'source',
       label: 'MetaSheet staging source',
@@ -1054,6 +1222,7 @@ async function runSmoke(opts) {
           tenantId,
           workspaceId: opts.workspaceId || '',
           timeoutMs: opts.timeoutMs,
+          installStaging: opts.issue1542InstallStaging,
         }))
       }
     }

--- a/scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
@@ -221,6 +221,47 @@ const DEFAULT_K3_OBJECTS = [
   },
 ]
 
+function defaultStagingInstallResult(projectId = 'tenant-smoke:integration-core') {
+  const targets = [
+    {
+      id: 'standard_materials',
+      name: 'Standard Materials',
+      sheetId: 'sheet_standard_materials',
+      viewId: 'view_standard_materials',
+      baseId: 'base_integration_core',
+      openLink: '/multitable/sheet_standard_materials/view_standard_materials?baseId=base_integration_core',
+    },
+    {
+      id: 'bom_cleanse',
+      name: 'BOM Cleanse',
+      sheetId: 'sheet_bom_cleanse',
+      viewId: 'view_bom_cleanse',
+      baseId: 'base_integration_core',
+      openLink: '/multitable/sheet_bom_cleanse/view_bom_cleanse?baseId=base_integration_core',
+    },
+  ]
+  return {
+    projectId,
+    sheetIds: {
+      plm_raw_items: 'sheet_plm_raw_items',
+      standard_materials: 'sheet_standard_materials',
+      bom_cleanse: 'sheet_bom_cleanse',
+      integration_exceptions: 'sheet_integration_exceptions',
+      integration_run_log: 'sheet_integration_run_log',
+    },
+    viewIds: {
+      standard_materials: 'view_standard_materials',
+      bom_cleanse: 'view_bom_cleanse',
+    },
+    openLinks: {
+      standard_materials: '/multitable/sheet_standard_materials/view_standard_materials?baseId=base_integration_core',
+      bom_cleanse: '/multitable/sheet_bom_cleanse/view_bom_cleanse?baseId=base_integration_core',
+    },
+    targets,
+    warnings: [],
+  }
+}
+
 function makeTmpDir() {
   return mkdtempSync(path.join(tmpdir(), 'integration-k3wise-postdeploy-smoke-'))
 }
@@ -295,6 +336,9 @@ function readRequestBody(req) {
 
 function createFakeServer(options = {}) {
   const requests = []
+  const externalSystems = Array.isArray(options.externalSystems)
+    ? options.externalSystems.map((system) => ({ ...system }))
+    : []
   const server = http.createServer(async (req, res) => {
     const url = new URL(req.url || '/', 'http://127.0.0.1')
     requests.push({
@@ -384,7 +428,7 @@ function createFakeServer(options = {}) {
         sendJson(res, 500, { ok: false, error: { message: `${url.pathname} unavailable` } })
         return
       }
-      sendJson(res, 200, { ok: true, data: options.externalSystems || [] })
+      sendJson(res, 200, { ok: true, data: externalSystems })
       return
     }
 
@@ -408,52 +452,65 @@ function createFakeServer(options = {}) {
       return
     }
 
-    if (req.method === 'GET' && url.pathname === '/api/integration/external-systems/staging_source_1/objects') {
+    const externalSystemRoute = url.pathname.match(/^\/api\/integration\/external-systems\/([^/]+)\/(objects|schema)$/)
+    if (req.method === 'GET' && externalSystemRoute) {
       if (req.headers.authorization !== 'Bearer test.jwt.token') {
         sendJson(res, 401, { ok: false, error: { message: 'bad token' } })
         return
       }
-      sendJson(res, 200, { ok: true, data: options.stagingObjects || DEFAULT_STAGING_OBJECTS })
+      const systemId = decodeURIComponent(externalSystemRoute[1])
+      const action = externalSystemRoute[2]
+      const system = externalSystems.find((candidate) => candidate.id === systemId)
+      if (!system) {
+        sendJson(res, 404, { ok: false, error: { message: `system not found: ${systemId}` } })
+        return
+      }
+      if (system.kind === 'metasheet:staging' && action === 'objects') {
+        sendJson(res, 200, { ok: true, data: options.stagingObjects || DEFAULT_STAGING_OBJECTS })
+        return
+      }
+      if (system.kind === 'metasheet:staging' && action === 'schema') {
+        sendJson(res, 200, {
+          ok: true,
+          data: options.stagingSchema || {
+            object: url.searchParams.get('object') || 'standard_materials',
+            fields: DEFAULT_STAGING_OBJECTS[0].schema,
+          },
+        })
+        return
+      }
+      if (system.kind === 'erp:k3-wise-webapi' && action === 'objects') {
+        sendJson(res, 200, { ok: true, data: options.k3Objects || DEFAULT_K3_OBJECTS })
+        return
+      }
+      if (system.kind === 'erp:k3-wise-webapi' && action === 'schema') {
+        sendJson(res, 200, {
+          ok: true,
+          data: options.k3Schema || {
+            object: url.searchParams.get('object') || 'material',
+            fields: DEFAULT_K3_OBJECTS[0].schema,
+            template: { id: 'material', bodyKey: 'Data' },
+          },
+        })
+        return
+      }
+      sendJson(res, 400, { ok: false, error: { message: `unsupported system action: ${system.kind}/${action}` } })
       return
     }
 
-    if (req.method === 'GET' && url.pathname === '/api/integration/external-systems/staging_source_1/schema') {
+    if (req.method === 'POST' && url.pathname === '/api/integration/external-systems') {
       if (req.headers.authorization !== 'Bearer test.jwt.token') {
         sendJson(res, 401, { ok: false, error: { message: 'bad token' } })
         return
       }
-      sendJson(res, 200, {
-        ok: true,
-        data: options.stagingSchema || {
-          object: url.searchParams.get('object') || 'standard_materials',
-          fields: DEFAULT_STAGING_OBJECTS[0].schema,
-        },
-      })
-      return
-    }
-
-    if (req.method === 'GET' && url.pathname === '/api/integration/external-systems/k3_target_1/objects') {
-      if (req.headers.authorization !== 'Bearer test.jwt.token') {
-        sendJson(res, 401, { ok: false, error: { message: 'bad token' } })
-        return
-      }
-      sendJson(res, 200, { ok: true, data: options.k3Objects || DEFAULT_K3_OBJECTS })
-      return
-    }
-
-    if (req.method === 'GET' && url.pathname === '/api/integration/external-systems/k3_target_1/schema') {
-      if (req.headers.authorization !== 'Bearer test.jwt.token') {
-        sendJson(res, 401, { ok: false, error: { message: 'bad token' } })
-        return
-      }
-      sendJson(res, 200, {
-        ok: true,
-        data: options.k3Schema || {
-          object: url.searchParams.get('object') || 'material',
-          fields: DEFAULT_K3_OBJECTS[0].schema,
-          template: { id: 'material', bodyKey: 'Data' },
-        },
-      })
+      const body = await readRequestBody(req)
+      requests[requests.length - 1].body = body
+      const id = body?.id || `system_${externalSystems.length + 1}`
+      const saved = { ...body, id }
+      const index = externalSystems.findIndex((system) => system.id === id)
+      if (index >= 0) externalSystems[index] = saved
+      else externalSystems.push(saved)
+      sendJson(res, 201, { ok: true, data: saved })
       return
     }
 
@@ -462,11 +519,12 @@ function createFakeServer(options = {}) {
         sendJson(res, 401, { ok: false, error: { message: 'bad token' } })
         return
       }
+      const body = await readRequestBody(req)
+      requests[requests.length - 1].body = body
       if (options.failPipelineSave) {
         sendJson(res, 500, { ok: false, error: { code: '22P02', message: '类型json的输入语法无效' } })
         return
       }
-      const body = await readRequestBody(req)
       sendJson(res, 201, {
         ok: true,
         data: {
@@ -475,6 +533,22 @@ function createFakeServer(options = {}) {
           fieldMappings: Array.isArray(body?.fieldMappings) ? body.fieldMappings : [],
         },
       })
+      return
+    }
+
+    if (req.method === 'POST' && url.pathname === '/api/integration/staging/install') {
+      if (req.headers.authorization !== 'Bearer test.jwt.token') {
+        sendJson(res, 401, { ok: false, error: { message: 'bad token' } })
+        return
+      }
+      const body = await readRequestBody(req)
+      requests[requests.length - 1].body = body
+      if (options.failStagingInstall) {
+        sendJson(res, 500, { ok: false, error: { code: 'STAGING_INSTALL_EMPTY', message: 'no staging sheets provisioned' } })
+        return
+      }
+      const projectId = body?.projectId || `${body?.tenantId || 'tenant-smoke'}:integration-core`
+      sendJson(res, 201, { ok: true, data: options.stagingInstallResult || defaultStagingInstallResult(projectId) })
       return
     }
 
@@ -677,6 +751,85 @@ test('issue1542 workbench smoke verifies staging schema and draft pipeline save'
     assert.ok(pipelineRequest, 'issue1542 smoke saves a draft pipeline metadata record')
     assert.ok(fake.requests.some((request) => request.pathname === '/api/integration/external-systems/staging_source_1/schema'))
     assert.ok(fake.requests.some((request) => request.pathname === '/api/integration/external-systems/k3_target_1/schema'))
+  } finally {
+    await fake.close()
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('issue1542 install-staging smoke creates and uses the installed staging source before schema and pipeline checks', async () => {
+  const fake = createFakeServer({ externalSystems: DEFAULT_SYSTEMS })
+  const baseUrl = await fake.listen()
+  const outDir = makeTmpDir()
+  try {
+    const result = await runScript([
+      '--base-url', baseUrl,
+      '--auth-token', 'test.jwt.token',
+      '--tenant-id', 'tenant-smoke',
+      '--require-auth',
+      '--issue1542-workbench-smoke',
+      '--issue1542-install-staging',
+      '--out-dir', outDir,
+    ])
+
+    assert.equal(result.status, 0, result.stderr)
+    const evidence = JSON.parse(readFileSync(path.join(outDir, 'integration-k3wise-postdeploy-smoke.json'), 'utf8'))
+    const installCheck = evidence.checks.find((check) => check.id === 'issue1542-staging-install')
+    assert.equal(installCheck.status, 'pass')
+    assert.equal(installCheck.projectId, 'tenant-smoke:integration-core')
+    assert.equal(installCheck.sourceSystemId, 'metasheet_staging_tenant-smoke_integration-core')
+    assert.ok(installCheck.objects.includes('standard_materials'))
+
+    assert.equal(evidence.checks.find((check) => check.id === 'issue1542-system-readiness').status, 'pass')
+    assert.equal(evidence.checks.find((check) => check.id === 'issue1542-system-readiness').stagingSourceId, 'metasheet_staging_tenant-smoke_integration-core')
+    assert.equal(evidence.checks.find((check) => check.id === 'issue1542-staging-source-schema').status, 'pass')
+    assert.equal(evidence.checks.find((check) => check.id === 'issue1542-pipeline-save').status, 'pass')
+
+    const stagingInstallRequest = fake.requests.find((request) => request.method === 'POST' && request.pathname === '/api/integration/staging/install')
+    assert.ok(stagingInstallRequest, 'install-staging flag calls staging install')
+    assert.deepEqual(stagingInstallRequest.body, { tenantId: 'tenant-smoke', workspaceId: null })
+
+    const externalSystemRequest = fake.requests.find((request) => request.method === 'POST' && request.pathname === '/api/integration/external-systems')
+    assert.ok(externalSystemRequest, 'install-staging flag upserts a staging source system')
+    assert.equal(externalSystemRequest.body.kind, 'metasheet:staging')
+    assert.equal(externalSystemRequest.body.projectId, 'tenant-smoke:integration-core')
+    assert.equal(externalSystemRequest.body.config.objects.standard_materials.sheetId, 'sheet_standard_materials')
+    assert.ok(Array.isArray(externalSystemRequest.body.config.objects.standard_materials.fieldDetails))
+
+    const pipelineRequest = fake.requests.find((request) => request.method === 'POST' && request.pathname === '/api/integration/pipelines')
+    assert.equal(pipelineRequest.body.sourceSystemId, 'metasheet_staging_tenant-smoke_integration-core')
+    assert.ok(fake.requests.some((request) => request.pathname === '/api/integration/external-systems/metasheet_staging_tenant-smoke_integration-core/schema'))
+    assert.equal(fake.requests.some((request) => request.pathname === '/api/integration/external-systems/staging_source_1/schema'), false)
+  } finally {
+    await fake.close()
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('issue1542 install-staging smoke fails clearly when staging install fails', async () => {
+  const fake = createFakeServer({
+    externalSystems: DEFAULT_SYSTEMS.filter((system) => system.kind !== 'metasheet:staging'),
+    failStagingInstall: true,
+  })
+  const baseUrl = await fake.listen()
+  const outDir = makeTmpDir()
+  try {
+    const result = await runScript([
+      '--base-url', baseUrl,
+      '--auth-token', 'test.jwt.token',
+      '--tenant-id', 'tenant-smoke',
+      '--require-auth',
+      '--issue1542-workbench-smoke',
+      '--issue1542-install-staging',
+      '--out-dir', outDir,
+    ])
+
+    assert.equal(result.status, 1)
+    const evidence = JSON.parse(readFileSync(path.join(outDir, 'integration-k3wise-postdeploy-smoke.json'), 'utf8'))
+    const installCheck = evidence.checks.find((check) => check.id === 'issue1542-staging-install')
+    assert.equal(installCheck.status, 'fail')
+    assert.match(installCheck.error, /\/api\/integration\/staging\/install returned HTTP 500/)
+    assert.equal(evidence.checks.some((check) => check.id === 'issue1542-pipeline-save'), false)
   } finally {
     await fake.close()
     rmSync(outDir, { recursive: true, force: true })


### PR DESCRIPTION
## Summary

- add opt-in `--issue1542-install-staging` to the K3/Data Factory postdeploy smoke
- call staging install, upsert a `metasheet:staging` source, then run the existing #1542 schema + draft pipeline checks
- update the internal-trial runbook and add development/verification notes

## Safety / Deployment Impact

- opt-in only; default smoke behavior is unchanged
- writes staging/source/pipeline metadata only
- does not run dry-run, Save-only, Submit, Audit, or any K3 live write
- still requires an existing/saved K3 WebAPI target for the same tenant scope
- when multiple staging sources exist, the smoke now uses the freshly installed source ID for schema discovery and pipeline save

## Verification

- `node --check scripts/ops/integration-k3wise-postdeploy-smoke.mjs`
- `node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs` — 22/22 pass
- `pnpm verify:integration-k3wise:poc` — pass, including mock PoC demo
- `git diff --check` — pass
