### PR TITLE
docs(integration): record issue1542 postdeploy signoff

### DIFF
--- a/docs/development/data-factory-issue1542-postdeploy-signoff-development-20260515.md
+++ b/docs/development/data-factory-issue1542-postdeploy-signoff-development-20260515.md
@@ -1,0 +1,82 @@
+# Data Factory issue #1542 postdeploy signoff development - 2026-05-15
+
+## Summary
+
+This slice records the first successful deployment-side Data Factory issue
+#1542 smoke after the `issue1542_install_staging` GitHub Actions input landed.
+
+No product code changed in this slice. The development work was operational:
+
+- use the new manual workflow input added by
+  `ci(integration): expose issue1542 install-staging smoke`;
+- run it against the 142 bridge/test deployment;
+- verify the staging-table-as-source path, K3 material target schema, and draft
+  pipeline save contract from a real deployed backend;
+- preserve the result as a redaction-safe closeout note.
+
+## Triggered Workflow
+
+- Workflow: `K3 WISE Postdeploy Smoke`
+- Run: `25905364900`
+- Ref: `main`
+- Commit: `f612a04c00b05baaf7aeb6016a16defc6c72f871`
+- Event: `workflow_dispatch`
+- URL: `https://github.com/zensgit/metasheet2/actions/runs/25905364900`
+
+Inputs:
+
+- `base_url`: bridge/test MetaSheet HTTP endpoint
+- `require_auth`: `true`
+- `tenant_id`: `default`
+- `auto_discover_tenant`: `false`
+- `issue1542_install_staging`: `true`
+- `timeout_ms`: `10000`
+
+The token was resolved by the deploy-host fallback. Token values were never
+printed in the workflow log or copied into this document.
+
+## What This Proves
+
+The issue #1542 deployment retest covers the path that previously blocked the
+Workbench dry-run setup:
+
+1. install integration staging descriptors;
+2. create or reuse the `metasheet:staging` source system from installed staging
+   metadata;
+3. verify `standard_materials` source schema discovery;
+4. verify K3 WISE material target schema discovery;
+5. save a draft staging-to-K3 material pipeline without running dry-run or K3
+   writes.
+
+This specifically closes the deployment-observed symptoms:
+
+- staging source had to be created manually;
+- staging source schema returned `fields: []`;
+- pipeline save failed with PostgreSQL `22P02`;
+- dry-run could not begin because no pipeline id was returned.
+
+## Safety Boundary
+
+The smoke writes metadata only:
+
+- staging descriptors and sheet/open-link metadata;
+- a MetaSheet staging source external-system record;
+- a metadata-only K3 target if no live target is available for this smoke;
+- a draft pipeline definition.
+
+It does not execute:
+
+- source record read;
+- transform/dry-run;
+- K3 Save-only;
+- Submit;
+- Audit;
+- SQL Server executor calls.
+
+## Remaining Non-Blocking Gap
+
+SQL Server source execution remains outside this signoff. The issue #1542 smoke
+proves the staging-table-as-source route, which is enough for Data Factory users
+to clean data in MetaSheet and validate a staging-to-K3 pipeline shape. SQL
+Server reads still need a deployed allowlist executor before the advanced SQL
+channel can become a normal source path.

--- a/docs/development/data-factory-issue1542-postdeploy-signoff-verification-20260515.md
+++ b/docs/development/data-factory-issue1542-postdeploy-signoff-verification-20260515.md
@@ -1,0 +1,124 @@
+# Data Factory issue #1542 postdeploy signoff verification - 2026-05-15
+
+## Verification Source
+
+Evidence was collected from GitHub Actions workflow run `25905364900`:
+
+```text
+Workflow: K3 WISE Postdeploy Smoke
+Run URL: https://github.com/zensgit/metasheet2/actions/runs/25905364900
+Commit: f612a04c00b05baaf7aeb6016a16defc6c72f871
+Conclusion: success
+Job: smoke / success
+```
+
+The run used the manual input `issue1542_install_staging=true`.
+
+## Input Check Result
+
+```text
+ok=true
+summary=6 pass / 0 warn / 0 fail
+```
+
+Checks:
+
+| Check | Result |
+| --- | --- |
+| `base-url` | pass |
+| `auth-token` | pass |
+| `tenant-id` | pass |
+| `issue1542-install-staging` | pass |
+| `smoke-output` | pass |
+| `timeout` | pass |
+
+## Postdeploy Smoke Result
+
+```text
+ok=true
+authenticated=true
+signoff.internalTrial=pass
+summary=17 pass / 0 skipped / 0 fail
+```
+
+Baseline checks passed:
+
+- `api-health`
+- `integration-plugin-health`
+- `k3-wise-frontend-route`
+- `data-factory-frontend-route`
+- `auth-me`
+- `integration-route-contract`
+- `data-factory-adapter-discovery`
+- `integration-list-external-systems`
+- `integration-list-pipelines`
+- `integration-list-runs`
+- `integration-list-dead-letters`
+- `staging-descriptor-contract`
+
+Issue #1542 checks passed:
+
+| Check | Evidence |
+| --- | --- |
+| `issue1542-staging-install` | installed 5 staging objects: `plm_raw_items`, `standard_materials`, `bom_cleanse`, `integration_exceptions`, `integration_run_log` |
+| `issue1542-system-readiness` | checked 3 systems, including the generated `metasheet:staging` source and K3 metadata target |
+| `issue1542-staging-source-schema` | `standard_materials` returned 11 fields; required fields include `code`, `name`, `uom` |
+| `issue1542-k3-material-schema` | `material` returned 4 target fields; required fields include `FNumber`, `FName`, `FBaseUnitID` |
+| `issue1542-pipeline-save` | saved draft pipeline `issue1542_postdeploy_staging_material_smoke` with 3 field mappings |
+
+## Regression Interpretation
+
+The deployment no longer reproduces the previously reported issue #1542 P0
+blockers:
+
+- `standard_materials` schema is not empty;
+- staging can be used as a source via installed metadata;
+- `POST /api/integration/pipelines` did not return `22P02`;
+- a pipeline id was returned for the draft staging-to-K3 material pipeline.
+
+## Local Artifact Inspection
+
+The workflow artifact was downloaded locally and inspected from:
+
+```text
+/tmp/ms2-issue1542-workflow-artifacts/integration-k3wise-postdeploy-smoke-25905364900-1/
+```
+
+Inspected files:
+
+- `integration-k3wise-postdeploy-env-check/manual/integration-k3wise-postdeploy-env-check.json`
+- `integration-k3wise-postdeploy-smoke/manual/integration-k3wise-postdeploy-smoke.json`
+- `integration-k3wise-postdeploy-smoke/manual/integration-k3wise-postdeploy-smoke.md`
+
+Only redacted/sanitized evidence is copied into this document. No bearer token,
+authority code, password, SQL connection string, JDBC URL, or K3 credential is
+included.
+
+## Commands Used
+
+```bash
+gh workflow run integration-k3wise-postdeploy-smoke.yml \
+  --ref main \
+  -f base_url=http://142.171.239.56:8081 \
+  -f require_auth=true \
+  -f tenant_id=default \
+  -f auto_discover_tenant=false \
+  -f issue1542_install_staging=true \
+  -f timeout_ms=10000
+
+gh run watch 25905364900 --interval 10
+
+gh run download 25905364900 \
+  --dir /tmp/ms2-issue1542-workflow-artifacts
+```
+
+## Out Of Scope
+
+This verification does not claim:
+
+- SQL Server source executor availability;
+- K3 live Save-only success;
+- Submit/Audit success;
+- customer production GATE readiness.
+
+Those remain separate deployment/customer-GATE validations.


### PR DESCRIPTION
## Summary
- record the successful 142 bridge/test postdeploy smoke for Data Factory issue #1542
- document the exact workflow run, commit, inputs, and redacted evidence
- capture that staging install, staging source schema, K3 material schema, and draft pipeline save all passed

## Verification
- GitHub Actions run 25905364900: K3 WISE Postdeploy Smoke — success
- issue1542_install_staging=true
- Input check: 6 pass / 0 warn / 0 fail
- Smoke: 17 pass / 0 skipped / 0 fail
- Local artifact inspection: issue1542-staging-install, issue1542-staging-source-schema, issue1542-k3-material-schema, issue1542-pipeline-save all pass
- git diff --check — PASS
- redaction grep for JWT/Bearer/password/authorityCode/JDBC/SQL URL patterns — 0 hits

## Deployment impact
Docs only. No runtime code, workflow, package, migration, or K3 behavior change.

## Issue #1542 interpretation
The current main deployment no longer reproduces the earlier pipeline JSONB 22P02 blocker. SQL Server executor availability remains out of scope for this signoff and should stay as a separate advanced-source deployment item.