### PR TITLE
feat(attendance): add report formula fields hardening

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -973,7 +973,7 @@
               <template v-for="record in filteredRecords" :key="record.id">
                 <tr>
                   <td v-for="column in recordReportColumns" :key="`${record.id}-${column.code}`">
-                    {{ formatRecordReportCell(record, column.code) }}
+                    {{ formatRecordReportCell(record, column) }}
                   </td>
                   <td class="attendance__table-actions">
                     <button
@@ -4761,6 +4761,8 @@ interface AttendanceRecord {
   status: string
   is_workday?: boolean
   meta?: Record<string, any>
+  report_values?: Record<string, unknown>
+  reportValues?: Record<string, unknown>
   workday_context?: {
     shiftName?: string | null
   } | null
@@ -4773,6 +4775,12 @@ interface AttendanceRecordReportField {
   categoryLabel?: string
   unit?: string
   sortOrder?: number
+  formulaEnabled?: boolean
+  formulaExpression?: string
+  formulaScope?: string
+  formulaOutputType?: string
+  formulaValid?: boolean
+  formulaError?: string | null
 }
 
 interface AttendanceRecordReportFieldConfig {
@@ -7941,6 +7949,13 @@ function formatRecordMinutes(value: unknown): string {
   return String(parsed)
 }
 
+function formatRecordReportValue(value: unknown): string {
+  if (value === null || value === undefined || value === '') return '--'
+  if (typeof value === 'number') return Number.isFinite(value) ? String(value) : '--'
+  if (typeof value === 'boolean') return value ? tr('Yes', '是') : tr('No', '否')
+  return String(value)
+}
+
 function formatRecordReportFieldLabel(field: AttendanceRecordReportField): string {
   const labels: Record<string, string> = {
     work_date: tr('Date', '日期'),
@@ -7981,7 +7996,18 @@ function formatRecordReportFieldLabel(field: AttendanceRecordReportField): strin
   return labels[field.code] ?? field.name ?? field.code
 }
 
-function formatRecordReportCell(record: AttendanceRecord, code: string): string {
+function readRecordReportValue(record: AttendanceRecord, code: string): unknown {
+  const reportValues = record.report_values ?? record.reportValues
+  if (!reportValues || typeof reportValues !== 'object') return undefined
+  return Object.prototype.hasOwnProperty.call(reportValues, code) ? reportValues[code] : undefined
+}
+
+function formatRecordReportCell(record: AttendanceRecord, field: AttendanceRecordReportField | string): string {
+  const code = typeof field === 'string' ? field : field.code
+  const serverValue = readRecordReportValue(record, code)
+  if (typeof field !== 'string' && field.formulaEnabled) {
+    return formatRecordReportValue(serverValue)
+  }
   const isWorkday = record.is_workday !== false
   const status = String(record.status || '')
   const leaveMinutes = recordMetaMinutes(record, ['leave_minutes', 'leaveMinutes'])
@@ -8056,7 +8082,7 @@ function formatRecordReportCell(record: AttendanceRecord, code: string): string 
     case 'holiday_overtime_duration':
       return formatRecordMinutes(recordMetaMinutes(record, ['holiday_overtime_minutes', 'holidayOvertimeMinutes']))
     default:
-      return '--'
+      return serverValue !== undefined ? formatRecordReportValue(serverValue) : '--'
   }
 }
 

--- a/apps/web/src/views/attendance/AttendanceReportFieldsSection.vue
+++ b/apps/web/src/views/attendance/AttendanceReportFieldsSection.vue
@@ -8,6 +8,8 @@
           <span v-if="enabledCount"> · {{ tr('Enabled', '已启用') }}: {{ enabledCount }}</span>
           <span v-if="visibleCount"> · {{ tr('Report visible', '报表展示') }}: {{ visibleCount }}</span>
           <span v-if="configuredCount"> · {{ tr('Configured', '已配置') }}: {{ configuredCount }}</span>
+          <span v-if="formulaCount"> · {{ tr('Formula', '公式') }}: {{ formulaCount }}</span>
+          <span v-if="formulaErrorCount"> · {{ tr('Formula errors', '公式错误') }}: {{ formulaErrorCount }}</span>
           <span v-if="disabledCount"> · {{ tr('Disabled', '已停用') }}: {{ disabledCount }}</span>
           <span v-if="hiddenCount"> · {{ tr('Hidden', '已隐藏') }}: {{ hiddenCount }}</span>
           <span v-if="multitableProjectId"> · Project: <code>{{ multitableProjectId }}</code></span>
@@ -81,6 +83,8 @@
         >
           <option value="all">{{ tr('All fields', '全部字段') }}</option>
           <option value="configured">{{ tr('Configured', '已配置') }}</option>
+          <option value="formula">{{ tr('Formula fields', '公式字段') }}</option>
+          <option value="formula_error">{{ tr('Formula errors', '公式错误') }}</option>
           <option value="disabled">{{ tr('Disabled', '已停用') }}</option>
           <option value="hidden">{{ tr('Hidden', '已隐藏') }}</option>
         </select>
@@ -190,6 +194,7 @@
                 <th>{{ tr('Report', '报表') }}</th>
                 <th>{{ tr('Source', '来源') }}</th>
                 <th>{{ tr('Configuration', '配置') }}</th>
+                <th>{{ tr('Formula', '公式') }}</th>
                 <th>{{ tr('Mapping', '映射') }}</th>
               </tr>
             </thead>
@@ -220,6 +225,28 @@
                     {{ formatConfigurationSource(field) }}
                   </span>
                 </td>
+                <td class="attendance-report-fields__formula">
+                  <template v-if="field.formulaEnabled">
+                    <span
+                      class="attendance-report-fields__pill attendance-report-fields__pill--formula"
+                      :class="{ 'attendance-report-fields__pill--error': field.formulaValid === false }"
+                    >
+                      {{ field.formulaValid === false ? tr('Invalid', '异常') : tr('Formula', '公式') }}
+                    </span>
+                    <code v-if="field.formulaExpression">{{ field.formulaExpression }}</code>
+                    <div class="attendance__field-hint">
+                      {{ formatFormulaMeta(field) }}
+                    </div>
+                    <div
+                      v-if="field.formulaError"
+                      class="attendance-report-fields__formula-error"
+                      role="status"
+                    >
+                      {{ field.formulaError }}
+                    </div>
+                  </template>
+                  <span v-else class="attendance__field-hint">{{ tr('No formula', '无公式') }}</span>
+                </td>
                 <td class="attendance-report-fields__mapping">
                   <div
                     v-for="row in fieldMappingRows(field)"
@@ -246,7 +273,7 @@ import { apiFetch } from '../../utils/api'
 import { readErrorMessage } from '../../utils/error'
 
 type TranslateFn = (en: string, zh: string) => string
-type ReportFieldStatusFilter = 'all' | 'configured' | 'disabled' | 'hidden'
+type ReportFieldStatusFilter = 'all' | 'configured' | 'formula' | 'formula_error' | 'disabled' | 'hidden'
 
 interface AttendanceReportFieldCategory {
   id: string
@@ -269,6 +296,13 @@ interface AttendanceReportFieldItem {
   internalKey?: string
   configured?: boolean
   systemDefined?: boolean
+  formulaEnabled?: boolean
+  formulaExpression?: string
+  formulaScope?: string
+  formulaOutputType?: string
+  formulaValid?: boolean
+  formulaError?: string | null
+  formulaReferences?: string[]
 }
 
 interface AttendanceReportFieldsPayload {
@@ -336,6 +370,8 @@ const reportFields = computed(() => reportFieldsPayload.value.items ?? [])
 const enabledCount = computed(() => reportFields.value.filter(field => field.enabled).length)
 const visibleCount = computed(() => reportFields.value.filter(field => field.reportVisible).length)
 const configuredCount = computed(() => reportFields.value.filter(field => field.configured).length)
+const formulaCount = computed(() => reportFields.value.filter(field => field.formulaEnabled).length)
+const formulaErrorCount = computed(() => reportFields.value.filter(field => field.formulaEnabled && field.formulaValid === false).length)
 const disabledCount = computed(() => reportFields.value.filter(field => field.enabled === false).length)
 const hiddenCount = computed(() => reportFields.value.filter(field => field.reportVisible === false).length)
 const hasActiveFieldFilters = computed(() => (
@@ -359,6 +395,11 @@ const filteredReportFields = computed(() => {
       field.dingtalkFieldName,
       field.description,
       field.internalKey,
+      field.formulaExpression,
+      field.formulaScope,
+      field.formulaOutputType,
+      field.formulaError,
+      ...(field.formulaReferences ?? []),
     ].map(value => String(value ?? '').toLowerCase())
     return haystack.some(value => value.includes(search))
   })
@@ -481,6 +522,8 @@ function categoryStats(categoryId: string) {
 
 function matchesFieldStatusFilter(field: AttendanceReportFieldItem): boolean {
   if (fieldStatusFilter.value === 'configured') return Boolean(field.configured)
+  if (fieldStatusFilter.value === 'formula') return Boolean(field.formulaEnabled)
+  if (fieldStatusFilter.value === 'formula_error') return Boolean(field.formulaEnabled && field.formulaValid === false)
   if (fieldStatusFilter.value === 'disabled') return field.enabled === false
   if (fieldStatusFilter.value === 'hidden') return field.reportVisible === false
   return true
@@ -488,6 +531,8 @@ function matchesFieldStatusFilter(field: AttendanceReportFieldItem): boolean {
 
 function formatStatusFilterLabel(value: ReportFieldStatusFilter): string {
   if (value === 'configured') return tr('Configured', '已配置')
+  if (value === 'formula') return tr('Formula fields', '公式字段')
+  if (value === 'formula_error') return tr('Formula errors', '公式错误')
   if (value === 'disabled') return tr('Disabled', '已停用')
   if (value === 'hidden') return tr('Hidden', '已隐藏')
   return tr('All fields', '全部字段')
@@ -532,6 +577,38 @@ function configurationPillClass(field: AttendanceReportFieldItem): Record<string
     'attendance-report-fields__pill--configured': Boolean(field.configured && field.systemDefined !== false),
     'attendance-report-fields__pill--custom': field.systemDefined === false,
   }
+}
+
+function formatFormulaScope(scope?: string): string {
+  const normalized = String(scope || 'record').trim()
+  if (normalized === 'record') return tr('Record scope', '单记录')
+  return normalized || '--'
+}
+
+function formatFormulaOutputType(outputType?: string): string {
+  const normalized = String(outputType || '').trim()
+  const labels: Record<string, string> = {
+    number: tr('Number', '数字'),
+    duration_minutes: tr('Duration minutes', '分钟时长'),
+    text: tr('Text', '文本'),
+    boolean: tr('Boolean', '布尔'),
+    date: tr('Date', '日期'),
+  }
+  return labels[normalized] ?? (normalized || '--')
+}
+
+function formatFormulaMeta(field: AttendanceReportFieldItem): string {
+  const parts = [
+    formatFormulaScope(field.formulaScope),
+    formatFormulaOutputType(field.formulaOutputType),
+  ]
+  const references = Array.isArray(field.formulaReferences)
+    ? field.formulaReferences.filter(Boolean)
+    : []
+  if (references.length > 0) {
+    parts.push(`${tr('References', '引用')}: ${references.join(', ')}`)
+  }
+  return parts.filter(Boolean).join(' · ')
 }
 
 function fieldMappingRows(field: AttendanceReportFieldItem): FieldMappingRow[] {
@@ -894,6 +971,37 @@ watch(
 .attendance-report-fields__pill--custom {
   background: #fef3c7;
   color: #92400e;
+}
+
+.attendance-report-fields__pill--formula {
+  background: #ecfdf5;
+  color: #047857;
+}
+
+.attendance-report-fields__pill--error {
+  background: #fff1f2;
+  color: #be123c;
+}
+
+.attendance-report-fields__formula {
+  min-width: 220px;
+}
+
+.attendance-report-fields__formula code {
+  display: block;
+  margin-top: 6px;
+  color: #1f2937;
+  font-size: 12px;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.attendance-report-fields__formula-error {
+  margin-top: 6px;
+  color: #be123c;
+  font-size: 12px;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
 }
 
 .attendance-report-fields__mapping {

--- a/apps/web/tests/AttendanceReportFieldsSection.spec.ts
+++ b/apps/web/tests/AttendanceReportFieldsSection.spec.ts
@@ -39,7 +39,7 @@ function populatedCatalogPayload() {
         { code: 'employee_name', name: '姓名', category: 'fixed', categoryLabel: '固定字段', source: 'system', unit: 'text', enabled: true, reportVisible: true, sortOrder: 1001, dingtalkFieldName: '姓名', description: '员工姓名', internalKey: 'employee.name', systemDefined: true },
         { code: 'punch_result', name: '打卡结果', category: 'basic', categoryLabel: '基础字段', source: 'system', unit: 'text', enabled: true, reportVisible: true, sortOrder: 2001, dingtalkFieldName: '打卡结果', description: '打卡是否正常', internalKey: 'record.punchResult', systemDefined: true },
         { code: 'attendance_days', name: '出勤天数', category: 'attendance', categoryLabel: '出勤统计字段', source: 'system', unit: 'days', enabled: true, reportVisible: true, sortOrder: 3001, dingtalkFieldName: '出勤天数', description: '有效出勤天数', internalKey: 'summary.attendanceDays', systemDefined: true },
-        { code: 'late_count', name: '迟到次数', category: 'anomaly', categoryLabel: '异常统计字段', source: 'system', unit: 'count', enabled: true, reportVisible: false, sortOrder: 4001, dingtalkFieldName: '迟到次数', description: '迟到次数', internalKey: 'summary.lateCount', configured: true, systemDefined: true },
+        { code: 'late_count', name: '迟到次数', category: 'anomaly', categoryLabel: '异常统计字段', source: 'system', unit: 'count', enabled: true, reportVisible: false, sortOrder: 4001, dingtalkFieldName: '迟到次数', description: '迟到次数', internalKey: 'summary.lateCount', configured: true, systemDefined: true, formulaEnabled: true, formulaExpression: '={late_duration}+{early_leave_duration}', formulaScope: 'record', formulaOutputType: 'number', formulaValid: true, formulaError: null, formulaReferences: ['early_leave_duration', 'late_duration'] },
         { code: 'leave_duration', name: '请假时长', category: 'leave', categoryLabel: '请假统计字段', source: 'system', unit: 'minutes', enabled: true, reportVisible: true, sortOrder: 5001, dingtalkFieldName: '请假时长', description: '请假分钟数', internalKey: 'summary.leaveMinutes', systemDefined: true },
         { code: 'workday_overtime_duration', name: '工作日加班时长', category: 'overtime', categoryLabel: '加班统计字段', source: 'system', unit: 'minutes', enabled: false, reportVisible: true, sortOrder: 6001, dingtalkFieldName: '工作日加班时长', description: '工作日加班分钟数', internalKey: 'summary.workdayOvertimeMinutes', systemDefined: true },
       ],
@@ -114,9 +114,11 @@ describe('AttendanceReportFieldsSection', () => {
     expect(container!.textContent).toContain('请假统计字段')
     expect(container!.textContent).toContain('加班统计字段')
     expect(container!.textContent).toContain('Configured: 1')
+    expect(container!.textContent).toContain('Formula: 1')
     expect(container!.textContent).toContain('Disabled: 1')
     expect(container!.textContent).toContain('Hidden: 1')
     expect(container!.textContent).toContain('Configuration')
+    expect(container!.textContent).toContain('Formula')
     expect(container!.textContent).toContain('Mapping')
     expect(container!.textContent).toContain('Built-in')
     expect(container!.textContent).toContain('Configured')
@@ -125,6 +127,8 @@ describe('AttendanceReportFieldsSection', () => {
     expect(container!.textContent).toContain('summary.lateCount')
     expect(container!.textContent).toContain('Order')
     expect(container!.textContent).toContain('4001')
+    expect(container!.textContent).toContain('={late_duration}+{early_leave_duration}')
+    expect(container!.textContent).toContain('References: early_leave_duration, late_duration')
     expect(container!.querySelector<HTMLAnchorElement>('a.attendance__btn')?.getAttribute('href')).toBe('/multitable/sheet-1/view-1?baseId=base-1')
     expect(container!.querySelector('[data-report-field-multitable-status]')?.textContent).toContain('Connected')
     expect(container!.querySelector('[data-report-field-multitable-detail="projectId"]')?.textContent).toContain('org-1:attendance')
@@ -214,6 +218,14 @@ describe('AttendanceReportFieldsSection', () => {
     await flushUi()
     expect(container!.textContent).toContain('Filtered fields: 1 / 6')
     expect(container!.textContent).toContain('workday_overtime_duration')
+    expect(container!.textContent).not.toContain('employee_name')
+
+    statusSelect!.value = 'formula'
+    statusSelect!.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+    expect(container!.textContent).toContain('Filtered fields: 1 / 6')
+    expect(container!.querySelector('[data-report-field-active-filters]')?.textContent).toContain('State: Formula fields')
+    expect(container!.textContent).toContain('late_count')
     expect(container!.textContent).not.toContain('employee_name')
 
     statusSelect!.value = 'hidden'

--- a/docs/development/attendance-dingtalk-formula-development-20260515.md
+++ b/docs/development/attendance-dingtalk-formula-development-20260515.md
@@ -1,0 +1,62 @@
+# 考勤字段公式能力开发记录
+
+Date: 2026-05-15
+
+## Summary
+
+本轮实现 P1：在既有考勤统计字段多维表底座上增加受限版公式字段能力。`attendance_*` 仍是事实源，多维表继续作为字段目录/配置层，公式字段作为报表字段参与记录展示、JSON 导出、CSV 导出和 evidence fingerprint。
+
+## Backend
+
+- `plugins/plugin-attendance/index.cjs`
+  - 字段目录 descriptor 新增公式配置字段：启用公式、公式表达式、公式范围、公式输出类型。
+  - 字段合并逻辑读取多维表公式配置，缺失配置时保持内置字段回退。
+  - 新增考勤公式包装层：
+    - 公式引用语法：`{field_code}`。
+    - v1 范围：`record`。
+    - 允许确定性函数白名单：`IF`、`AND`、`OR`、`NOT`、`ROUND`、`CEILING`、`FLOOR`、`ABS`、`MIN`、`MAX`、`SUM`、`AVERAGE`、`COUNT`、`COUNTA`、`DATEDIF`、`DATEDIFF`、`DATE`、`YEAR`、`MONTH`、`DAY`、`CONCAT`、`CONCATENATE`、`LEFT`、`RIGHT`、`MID`、`LEN`、`TRIM`、`UPPER`、`LOWER`。
+    - 禁止 `NOW`、`TODAY`、lookup 和跨公式字段引用。
+    - 公式错误返回 `#ERROR!`，不阻断整行报表。
+  - 新增 `POST /api/attendance/report-fields/formula/preview`。
+  - 记录接口为每条记录补充 `report_values`，供前端读取公式/custom 字段值。
+  - 导出接口改为异步构建报表行，公式字段进入 JSON/CSV。
+  - field fingerprint 纳入公式启用状态、表达式、范围、输出类型和校验状态。
+- `packages/core-backend/src/services/FormulaService.ts`
+  - 将原空实现接到后端 `FormulaEngine`。
+  - 支持 `calculateFormula(expression, resolver?)`，保留 `{key}` resolver 注入能力。
+
+## Frontend
+
+- `apps/web/src/views/attendance/AttendanceReportFieldsSection.vue`
+  - 表格增加“Formula/公式”列。
+  - 顶部展示公式字段数和公式错误数。
+  - 筛选器增加“公式字段”和“公式错误”。
+  - 公式字段展示表达式、record scope、输出类型、引用字段和错误。
+- `apps/web/src/views/AttendanceView.vue`
+  - 记录表支持读取后端 `report_values` 中的公式字段值。
+  - 系统字段仍按既有前端格式化逻辑展示，避免改变老字段的零值显示。
+
+## Live Acceptance
+
+- `scripts/ops/attendance-report-fields-live-acceptance.mjs`
+  - 新增 `EXPECT_FORMULA_CODE`。
+  - 检查 catalog、records、export 三处公式字段一致性。
+  - 报告 metadata 增加公式字段 codes 与 invalid codes。
+- `scripts/ops/attendance-report-fields-live-acceptance.test.mjs`
+  - mock catalog/records/export 增加 `net_work_minutes` 公式字段。
+  - CSV label/code header 覆盖公式字段。
+
+## Compatibility
+
+- 未新增考勤事实表 migration。
+- 未改变 `attendance_records` 主存储。
+- 未直接操作 `meta_bases/meta_sheets/meta_fields/meta_records`。
+- 老字段配置没有公式字段时，接口继续返回内置字段和 `formulaEnabled: false`。
+
+## Known Limits
+
+- v1 不支持公式字段引用公式字段。
+- v1 不支持跨记录/跨周期聚合公式。
+- v1 不提供内联公式编辑器，编辑入口仍是多维表字段目录。
+- v1 将钉钉“打卡时间”和“打卡结果”按单字段聚合展示；上班 1/2/3、下班 1/2/3 六字段拆分列入 P2。
+- 当前测试覆盖公式字段主路径、未知字段、`NOW()` 禁用、公式字段引用公式字段禁用，并已按条件/数学/聚合/日期/文本大类覆盖白名单代表函数。

--- a/docs/development/attendance-dingtalk-formula-hardening-development-20260515.md
+++ b/docs/development/attendance-dingtalk-formula-hardening-development-20260515.md
@@ -1,0 +1,191 @@
+# 考勤公式字段 P1 Hardening 开发记录
+
+Date: 2026-05-15
+
+## Summary
+
+P1 closeout 共六轮加固，本文件汇总所有改动。
+
+- **Round 1**：补齐公式白名单 5 大类测试 + 文档差异收口。
+- **Round 2**：拒绝裸 spreadsheet cell / range 引用；取消 preview 让 `sample` key 扩展合法字段集合的副作用。
+- **Round 3**：把公式取值源从「报表可见字段列表」改为「系统字段全集」（硬编码）。已被 Round 4 取代。
+- **Round 4**：按 catalog 驱动的两套字段集模型重构（`outputFields` + `formulaSourceFields`），落实「`enabled` 控公式可用性、`reportVisible` 只控显示」的解耦原则。
+- **Round 5**：v1 字段来源策略与 raw alias 语义二选一收口——product contract：custom 非公式字段不作为公式源；raw alias 不受 catalog `enabled` 控制。
+- **Round 6（本轮）**：Raw alias codes 设为保留字（reserved）——catalog 不允许创建与 raw alias 同名的字段，validator 也加 defense-in-depth；修正 Round 5 文档中误导的 raw alias 阻断方法描述。
+
+不扩大功能范围，仍保持 record-scope 公式字段、多维表配置层和 `attendance_*` 事实源。
+
+## Round 6 — Raw alias 保留字 + Raw alias 阻断路径澄清
+
+### 决策 3（本轮）：Raw alias codes 为保留字，catalog 不可同名
+
+**Bug repro**（用户在本地复现）：管理员在多维表里创建一个公式字段 `late_minutes`（与 raw alias 同名）后，其它公式 `={late_minutes}+1` 会因为 `formulaFieldCodes.has('late_minutes')` 命中 formula-to-formula 拒绝路径，返回 `Formula field reference late_minutes is not supported in v1.`。
+
+这违反 Round 5 写下的契约「Raw alias 永远合法，独立通道」。
+
+**修复**：把 5 个 raw alias codes 设为保留字（`ATTENDANCE_REPORT_FORMULA_RESERVED_CODES`）。两层防御：
+
+1. **Merge 层（主防御）**——`mergeAttendanceReportFieldDefinitions` 在 push 自定义字段时新增 `ATTENDANCE_REPORT_FORMULA_RESERVED_CODES.has(config.code)` 跳过路径。结果：catalog 配置记录里只要 code 是 raw alias 之一，整条记录被静默丢弃，merged catalog 与 `outputFields` / `formulaSourceFields` 都不会出现。
+2. **Validator 层（depth）**——`getAttendanceReportFormulaReferenceCodes` 在 push 字段进任何 set 之前先检查 reserved 跳过。结果：哪怕 merged catalog 历史遗留了 raw alias 同名字段（比如旧版本写入的记录），validator 也不会把它视为 formula 字段或合法 catalog 字段。`{late_minutes}` 始终走 raw alias 初始化路径（`new Set(ATTENDANCE_REPORT_FORMULA_RAW_REFERENCE_KEYS)`）。
+
+副作用：catalog 中如果有遗留 raw alias 同名记录，前端不再显示——这是预期行为；如果客户报告字段消失，运维提示「raw alias name reserved」。如果未来需要 UI 反馈层，加在 catalog 响应里返回 `droppedReservedCodes` 字段，P2 落实。
+
+**Why both layers**：
+
+- 仅 merge 层防御：如果 merge 层有 bug 漏掉一些路径（比如 hot-cache 旧数据），validator 还能兜底。
+- 仅 validator 层防御：catalog 响应仍会泄露 raw alias 同名字段给前端，前端可能渲染 phantom 列。
+
+两层一起最稳。
+
+### 修正 1（本轮，P3）：Raw alias 阻断路径表述
+
+Round 5 文档原句（误导）：
+
+> 如果想阻止某个度量被公式访问，正确做法：把对应 stat 字段保留 `enabled=true` 即可，公式可经 stat 字段引用；并在公式 review 时由人工审计 raw alias 使用。
+
+这与 raw alias 不受 enabled 控制的契约自相矛盾（保留 `enabled=true` 并不会阻断任何路径）。
+
+**新表述**：
+
+> v1 **没有**通过 catalog 状态阻止 raw alias 引用的机制——`{late_minutes}` 与 `{late_duration}` 走两条独立通道，停用 `late_duration` 只切断后者。如果需要阻止某个 metric 经 raw alias 访问，依靠公式 review 审计；未来在系统层引入 `attendance.formula.allowRawAliases` env / config 提供全局开关。
+
+## 字段状态语义矩阵
+
+| `source` | `enabled` | `reportVisible` | 出现在 `outputFields` | 出现在 `formulaSourceFields` | 公式引用结果 |
+| --- | --- | --- | --- | --- | --- |
+| system | true | true | ✅ | ✅ | 正常取值 |
+| system | true | false | ❌ | ✅ | 正常取值（隐藏字段仍可计算）|
+| system | false | * | ❌ | ❌ | validator → Unknown reference → `#ERROR!` |
+| custom 非公式 | * | * | ❌ | ❌（v1 不支持） | validator → Unknown reference → `#ERROR!` |
+| custom 公式 | true | true | ✅ 显示公式结果 | ❌（永远不在源集合）| formula-to-formula 拒绝 |
+| **Raw alias** | n/a | n/a | n/a | n/a（独立通道）| **永远合法**，直接读 `row.*` |
+| **Reserved code shadow**（catalog 任意类型字段 code ∈ raw alias） | * | * | ❌（merge 层丢弃） | ❌（merge 层丢弃） | raw alias 通道仍可用，不被 catalog 字段遮蔽 |
+
+## Scope
+
+- 后端：`plugins/plugin-attendance/index.cjs` 加 reserved-codes 防御层（merge + validator）。
+- 测试：`packages/core-backend/tests/unit/attendance-report-field-formula-engine.test.ts` 累计 13 个用例（formula 引擎）。
+- 文档：本文件 + `attendance-dingtalk-formula-hardening-verification-20260515.md` 同步刷新。
+- 不新增生产功能代码。
+- 不触 `attendance_*` 事实表。
+- 不直接读写 `meta_*` 表。
+- 不实现钉钉打卡时间/打卡结果拆字段。
+- 不运行真实 staging live acceptance（缺凭据）。
+
+## Hardenings
+
+### 1. Reject bare spreadsheet cell references (round 2)
+
+新增 `extractAttendanceReportFormulaCellReferences()`：strip strings → strip `{...}` 内容 → 扫描 `(?<![A-Za-z0-9_])[A-Za-z]+\d+(?::[A-Za-z]+\d+)?(?![A-Za-z0-9_])`。错误：`Spreadsheet cell reference <ref> is not allowed; use {field_code} to reference attendance fields.`
+
+### 2. Sample keys no longer extend the legal field set (round 2)
+
+`getAttendanceReportFormulaReferenceCodes(fields)` 移除 `options.sampleCodes`；`previewAttendanceReportFormula` 不再把 sample keys 喂给 validator。
+
+### 3. Two-field-set model: outputFields ⊥ formulaSourceFields (round 4)
+
+新增 `resolveAttendanceFormulaSourceFields(items)` helper；`buildAttendanceReportFormulaValueMap(row, sources)` catalog 驱动；调用链穿透 `formulaSourceFields`；validator 增 `enabled === false` 跳过。
+
+### 4. v1 source filter: only systemDefined fields (round 5)
+
+`resolveAttendanceFormulaSourceFields` filter 加 `field.systemDefined !== false`；`getAttendanceReportFormulaReferenceCodes` 增 `if (field.systemDefined === false) continue`。
+
+### 5. Raw alias policy (round 5)
+
+无代码改动；加 1 个测试 + docs 显式声明 raw alias 不受 catalog `enabled` 控制。
+
+### 6. Raw alias codes reserved (round 6，本轮)
+
+新增常量：
+
+```js
+const ATTENDANCE_REPORT_FORMULA_RESERVED_CODES = new Set(ATTENDANCE_REPORT_FORMULA_RAW_REFERENCE_KEYS)
+```
+
+**Merge 层防御**：
+
+```js
+for (const config of configsByCode.values()) {
+  if (systemCodes.has(config.code)) continue
+  if (ATTENDANCE_REPORT_FORMULA_RESERVED_CODES.has(config.code)) continue  // ← 本轮新增
+  items.push({...})
+}
+```
+
+**Validator 层防御**：
+
+```js
+for (const field of fields || []) {
+  const code = normalizeCatalogString(field?.code)
+  if (!code) continue
+  if (ATTENDANCE_REPORT_FORMULA_RESERVED_CODES.has(code)) continue  // ← 本轮新增
+  if (field.formulaEnabled) {
+    formulaFieldCodes.add(code)
+    continue
+  }
+  ...
+}
+```
+
+修复确认（Round 6 test）：
+- 创建 `fld_code: 'work_minutes'`（非公式自定义）+ `fld_code: 'late_minutes'`（公式自定义）+ `fld_code: 'use_raw_late'`（合法公式 `={late_minutes}+1`）
+- 断言 `merged` 中前两条不存在（被 merge 层丢弃）
+- 断言 `use_raw_late.formulaValid === true`，`formulaReferences === ['late_minutes']`
+- 断言 `validateAttendanceReportFormulaExpression('={late_minutes}+1', { fields: merged })` 通过
+- 行级 row.late_minutes=12 → 导出值 `use_raw_late === 13`
+
+## Formula Whitelist Coverage (round 1，未变)
+
+完整白名单（与 PLAN.md 对齐，共 29 个函数）：`IF`、`AND`、`OR`、`NOT`、`ROUND`、`CEILING`、`FLOOR`、`ABS`、`MIN`、`MAX`、`SUM`、`AVERAGE`、`COUNT`、`COUNTA`、`DATEDIF`、`DATEDIFF`、`DATE`、`YEAR`、`MONTH`、`DAY`、`CONCAT`、`CONCATENATE`、`LEFT`、`RIGHT`、`MID`、`LEN`、`TRIM`、`UPPER`、`LOWER`。
+
+代表函数测试覆盖 5 大类（条件/数学/聚合/日期/文本）。
+
+## Test Surface
+
+`packages/core-backend/tests/unit/attendance-report-field-formula-engine.test.ts` 当前包含 13 个用例（formula 引擎），加上 catalog 7 个用例，共 20 个后端单测：
+
+| # | 用例 | 加固来源 |
+| --- | --- | --- |
+| 1 | merges custom formula fields and evaluates them through the formula API | base |
+| 2 | rejects unknown references, volatile functions, and formula-to-formula references | base |
+| 3 | allows representative formula functions from each whitelist category | round 1 |
+| 4 | returns #ERROR! for invalid formula fields without blocking the row export | base |
+| 5 | includes formula metadata in the report field fingerprint | base |
+| 6 | previews formulas against supplied sample values | base |
+| 7 | rejects bare spreadsheet cell and range references | round 2 |
+| 8 | hidden but enabled source field still resolves in formulas | round 4 |
+| 9 | disabled source field is rejected by the validator and yields #ERROR! at evaluation | round 4 |
+| 10 | v1 rejects custom non-formula fields as formula sources | round 5 |
+| 11 | raw alias references bypass catalog enable/visibility state | round 5 |
+| 12 | **catalog fields with raw alias codes are dropped (raw aliases are reserved)** | **round 6** |
+| 13 | preview does not let sample keys extend the legal field set | round 2 |
+
+## Documentation Updates
+
+- `attendance-dingtalk-formula-todo-20260515.md`：P2 backlog 已含 (a) custom 非公式字段公式源解析层 + (b) raw alias 全局门控建议 `attendance.formula.allowRawAliases`，本轮新增 (c) UI 反馈层透出 reserved-code shadow drop。
+- `attendance-dingtalk-formula-development-20260515.md`：未变。
+- `attendance-dingtalk-formula-verification-20260515.md`：未变。
+- 本文件 + `attendance-dingtalk-formula-hardening-verification-20260515.md`：
+  - **Round 6（本轮）**：reserved-codes 双层防御 + 字段状态矩阵第 7 行 + 测试拆分到 #12 + Raw alias 阻断路径表述修正。
+
+## Remaining Blocker
+
+真实 staging live acceptance 仍依赖外部环境：
+
+- `API_BASE` 或 `BASE_URL`
+- 短期 admin JWT 文件
+- `CONFIRM_SYNC=1`
+- 可写 evidence 输出目录
+
+拿到凭据后运行：
+
+```bash
+AUTH_SOURCE=AUTH_TOKEN_FILE \
+AUTH_TOKEN_FILE=/path/to/admin.jwt \
+CONFIRM_SYNC=1 \
+API_BASE=<staging-api-base> \
+ORG_ID=<org-id> \
+EXPECT_VISIBLE_CODE=work_date \
+EXPECT_FORMULA_CODE=net_work_minutes \
+pnpm run verify:attendance-report-fields:live
+```

--- a/docs/development/attendance-dingtalk-formula-hardening-verification-20260515.md
+++ b/docs/development/attendance-dingtalk-formula-hardening-verification-20260515.md
@@ -1,0 +1,169 @@
+# 考勤公式字段 P1 Hardening 验证记录
+
+Date: 2026-05-15
+
+## Commands Run
+
+```bash
+node --check plugins/plugin-attendance/index.cjs
+node --check scripts/ops/attendance-report-fields-live-acceptance.mjs
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/attendance-report-field-catalog.test.ts \
+  tests/unit/attendance-report-field-formula-engine.test.ts \
+  --reporter=dot
+NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run \
+  tests/AttendanceReportFieldsSection.spec.ts \
+  tests/attendance-admin-regressions.spec.ts \
+  --watch=false
+node --test scripts/ops/attendance-report-fields-live-acceptance.test.mjs
+pnpm run verify:attendance-report-fields:live:test
+pnpm --filter @metasheet/web type-check
+git diff --check
+```
+
+## Results (latest run, round 6)
+
+| Check | Result |
+| --- | --- |
+| Plugin syntax (`plugin-attendance/index.cjs`) | PASS |
+| Live acceptance script syntax | PASS |
+| Backend catalog + formula unit tests | **PASS, 20 tests** (7 catalog + 13 formula; +1 vs round 5) |
+| Frontend report fields + admin regression specs | PASS, 14 tests (3 + 11) |
+| Live acceptance unit harness (`node --test`) | PASS, 17 tests |
+| Live acceptance unit harness (package script) | PASS, 17 tests |
+| Web type-check (`vue-tsc -b`) | PASS |
+| `git diff --check` whitespace check | PASS |
+
+## 字段状态语义矩阵（产品契约 — round 6 完整版）
+
+| `source` | `enabled` | `reportVisible` | `outputFields` | `formulaSourceFields` | 公式引用 |
+| --- | --- | --- | --- | --- | --- |
+| system | true | true | ✅ | ✅ | 正常 |
+| system | true | false | ❌ | ✅ | **正常**（隐藏字段仍可计算） |
+| system | false | * | ❌ | ❌ | validator 拒绝 → `#ERROR!` |
+| custom 非公式 | * | * | ❌ | ❌ | validator 拒绝 → `#ERROR!` |
+| custom 公式 | true | true | ✅ 显示结果 | ❌ | formula-to-formula 拒绝 |
+| **Raw alias** | n/a | n/a | n/a | n/a（独立通道）| **永远合法**，直接读 `row.*` |
+| **Reserved code shadow** | * | * | ❌（merge 层丢弃）| ❌ | raw alias 通道仍合法 |
+
+## Round 6 — Hardening Evidence
+
+### Test #12 — `catalog fields with raw alias codes are dropped (raw aliases are reserved)`
+
+完整复现了用户报告的 P1 bug + 验证双层防御。设置：
+
+- `rec-shadow-nonformula`：`fld_code: 'work_minutes'`，非公式自定义字段
+- `rec-shadow-formula`：`fld_code: 'late_minutes'`，公式自定义字段（**正是用户复现的场景**）
+- `rec-use-raw`：`fld_code: 'use_raw_late'`，合法公式 `={late_minutes}+1`
+
+断言（按执行顺序）：
+
+1. `merged.find(f => f.code === 'work_minutes')` → `undefined`（merge 层丢弃）
+2. `merged.find(f => f.code === 'late_minutes')` → `undefined`（merge 层丢弃）
+3. `use_raw_late.formulaValid === true`，`formulaError === null`，`formulaReferences === ['late_minutes']`
+4. `validateAttendanceReportFormulaExpression('={late_minutes}+1', { fields: merged })` 返回 `valid: true`，`error: null`——**Bug 修复确认**：之前会因为 `formulaFieldCodes.has('late_minutes')` 命中 formula-to-formula 拒绝路径返回 `Formula field reference late_minutes is not supported in v1.`，现在通过
+5. `buildAttendanceRecordReportExportItemAsync` 用 row.late_minutes=12 → `calculateFormula` 收到 `=12+1` → 返回 13 → 导出 `use_raw_late === 13`
+6. `calculateFormula` 调用次数 = 1
+
+## 历史轮次 Hardening Evidence
+
+详细测试断言见 `attendance-dingtalk-formula-hardening-development-20260515.md` 与 git 历史。要点：
+
+- **Round 2**：cell-ref 拒绝 + sample-key 收紧（Test #7、#13）
+- **Round 4**：hidden 字段仍可计算 + disabled 字段被拒（Test #8、#9）
+- **Round 5**：custom 非公式字段不作为源 + raw alias 不受 enabled 控制（Test #10、#11）
+- **Round 6**：raw alias codes 设为保留字（Test #12）
+
+## Acceptance Criteria
+
+- 公式白名单按 5 大类代表函数全部通过验证（Round 1）。
+- 禁用函数（`NOW`）、未知字段引用、公式字段引用公式字段三条拒绝路径仍返回 `valid: false` 及对应 error。
+- 裸 `A1`、`A1:B2`、混合 `A1+{...}`、小写 `b2`、范围在 `SUM()` 内全部被拒绝（Round 2）。
+- 字符串字面量内出现的 `"A1"`、`"B2"` 不被识别为 cell ref（Round 2）。
+- `{A1}` 走 unknown-reference 路径（Round 2）。
+- preview 接口对 sample 中未在 catalog 注册的字段名仍返回 `Unknown attendance report field reference`，`calculateFormula` 不被调用（Round 2）。
+- `enabled=true && reportVisible=false` 的字段——在 `formulaSourceFields` 中存在、`outputFields` 中不存在；公式 `={late_duration}+1` 仍按 row 的 `late_minutes` 计算（Round 4）。
+- `enabled=false` 的字段——既不在 `outputFields` 也不在 `formulaSourceFields`；公式 `={late_duration}+1` 被 validator 拒绝并标记 `formulaValid: false`；export 返回 `#ERROR!`；`calculateFormula` 未被调用（Round 4）。
+- `source=custom && formulaEnabled=false` 的字段——既不在 `outputFields` 也不在 `formulaSourceFields`；公式 `={custom_metric}+1` 被 validator 拒绝（Round 5）。
+- Raw alias `{late_minutes}` 不受 `late_duration.enabled` 控制——即使 `late_duration` 已停用，`={late_minutes}+1` 仍合法、仍按 row 计算（Round 5）。
+- **Round 6**：catalog 配置记录 code ∈ raw alias（包括 `work_minutes`/`late_minutes`/`early_leave_minutes`/`leave_minutes`/`overtime_minutes`）——无论是否为 formula 字段——在 merge 阶段被静默丢弃，不出现在 `outputFields` 或 `formulaSourceFields`。
+- **Round 6**：用户报告的 bug `formulaEnabled` 字段 code 为 `late_minutes` 时 `={late_minutes}+1` 误判 formula-to-formula——本轮修复，validator 通过；row 计算返回正确值。
+- 无效公式仍输出 `#ERROR!`，不阻断同行其它字段导出。
+- 公式启用状态/表达式/范围/输出类型进入 report field fingerprint。
+- 公式预览接口 `previewAttendanceReportFormula` 返回 references 排序稳定。
+- catalog 7 项稳定 ID 测试仍通过。
+- 前端 report fields 区域公式列、错误数、公式字段筛选仍通过。
+- live acceptance mock harness 覆盖 catalog/records/export/CSV header + 公式字段进入 evidence metadata。
+- web type-check 无新 TS 错误。
+- `git diff --check` 无尾随空白或冲突标记。
+- 真实 staging live acceptance 当前会话**未跑**（缺凭据），仍标记为环境待补，**不写成通过**。
+
+## Staging Live Acceptance — PASS (Round 7, 2026-05-15)
+
+真实 staging live acceptance 在 2026-05-15 跑通。完整 evidence 在 `~/Downloads/Github/metasheet2/output/attendance-report-fields-live-acceptance/2026-05-15T07-01-24-382Z/`（已脱敏，本机非提交）。
+
+### 环境
+
+- API base: `http://localhost:8081`（SSH tunnel: `ssh -i ~/.ssh/metasheet2_deploy -fN -L 8081:localhost:8081 mainuser@142.171.239.56`）
+- Auth source: `AUTH_TOKEN_FILE` (`/tmp/<admin-jwt-file>.jwt`，mode 0600，admin role 已验证)
+- Org ID: `default`
+- Auth identity: `zhouhua@china-yaguang.com` (role=admin)
+- Run window: 2026-04-15 → 2026-05-15
+
+### 跑了什么
+
+```bash
+ssh -i ~/.ssh/metasheet2_deploy -fN -L 8081:localhost:8081 mainuser@142.171.239.56
+
+PREFLIGHT_ONLY=1 \
+API_BASE=http://localhost:8081 \
+ORG_ID=default \
+AUTH_SOURCE=AUTH_TOKEN_FILE \
+AUTH_TOKEN_FILE=/tmp/<admin-jwt-file>.jwt \
+pnpm run verify:attendance-report-fields:live
+# → PASS, 4 checks (preflight 模式仅 config + health)
+
+CONFIRM_SYNC=1 \
+API_BASE=http://localhost:8081 \
+ORG_ID=default \
+AUTH_SOURCE=AUTH_TOKEN_FILE \
+AUTH_TOKEN_FILE=/tmp/<admin-jwt-file>.jwt \
+EXPECT_VISIBLE_CODE=work_date \
+pnpm run verify:attendance-report-fields:live
+# → PASS, 48 checks
+```
+
+`EXPECT_FORMULA_CODE` 本轮**未传**：staging catalog 目前 0 个 formula 字段（`formulaFieldCodes: []`、`formulaInvalidCodes: []`）。要补完整 formula 端到端 evidence，运维先通过字段管理 UI 在多维表 `attendance_report_field_catalog` 里 seed 一个 formula 字段（例如 `code=net_work_minutes`、`formulaExpression='={work_minutes}-{late_minutes}-{early_leave_minutes}'`），再加 `EXPECT_FORMULA_CODE=net_work_minutes` 重跑即可。
+
+### Live evidence — 关键断言
+
+48 checks 分布：
+
+| Check 组 | 内容 |
+| --- | --- |
+| `config.*` (4) | auth source / token file mode 0600 / token loaded |
+| `api.*` (5) | health 200 / token attached / auth.me 200 / report-fields read & sync 200 |
+| `catalog.*` (5) | multitable available（projectId=`default:attendance`，sheetId=`sheet_75b4c963aa445cf3f96d29fe`，recordCount=34）/ 6 categories 完整 / expected-visible (`work_date`) 存在 / formula-fields.valid（0 invalid） |
+| `records.*` (3) | records read / report-fields-expected-visible / formula-expected（trivially ok since none expected）|
+| `export.json.*` (3) | export read / expected-visible 存在 / formula-expected |
+| `export.csv.*` (8) | CSV label header / fingerprint / 字段数 / 字段 codes / backing 一致 |
+| `export.csv-code.*` (4) | CSV code-header 变种全部一致 |
+| `*.fingerprint-match` (3) | catalog ↔ records ↔ export ↔ csv ↔ csv-code 五处 sha1 fingerprint 完全一致：**`d7f0d74172d35268bae4295af089947ceeedd20f`** |
+| `runner.completed` | 完整流程结束 |
+
+跨视图 fingerprint 一致是 Round 4-6 整套 catalog driven 字段集模型的端到端证据：catalog → records → export JSON → CSV (label) → CSV (code) 五个出口的字段配置 hash 完全相等，证明：
+- `outputFields` 在不同接口都从同一份 catalog 派生
+- 公式相关 descriptor 字段（`formulaEnabled`/`formulaExpression`/`formulaScope`/`formulaOutputType`/`formulaValid`）也参与 fingerprint，未来 admin 添加 formula 字段时任何不一致都会被这套检查抓到
+
+### 待补全项
+
+- [ ] 在 staging seed 一个 formula 字段（例如 `net_work_minutes`）后重跑 acceptance + `EXPECT_FORMULA_CODE`，以验证 formula 评估链路在真实后端的 evaluation。
+- [ ] (P3) Round 6 catalog `droppedReservedCodes` UI 反馈层，便于 admin 看到 raw alias shadow 被丢弃的字段（已记入 `attendance-dingtalk-formula-todo-20260515.md` P2 backlog）。
+
+### Secrets / safety check
+
+- 无 JWT (`eyJ`) 出现在 `report.json` / `report.md`
+- 无 `AUTH_TOKEN=` literal 出现
+- 用户家目录绝对路径在 evidence 文件中已 `sed` 替换为 `~`
+- AUTH_TOKEN_FILE 是 `/tmp/` 短期路径，mode 0600，会话结束删除
+- SSH tunnel 在本机 `127.0.0.1:8081`，acceptance 结束后已关闭

--- a/docs/development/attendance-dingtalk-formula-todo-20260515.md
+++ b/docs/development/attendance-dingtalk-formula-todo-20260515.md
@@ -1,0 +1,79 @@
+# 考勤字段对齐钉钉与公式引擎 TODO
+
+Date: 2026-05-15
+
+## 背景
+
+P0 已完成“考勤统计字段多维表底座”：`attendance_*` SQL 表继续作为考勤事实源，多维表承载统计字段目录、启用状态、报表可见性、排序和映射配置。
+
+本轮 P1 目标是对齐钉钉字段管理体验，并提供受限版统计公式字段。当前 in-app browser 页面标题为“管理员设置拍照打卡”，该页面属于钉钉考勤设置能力，不直接改变本轮统计字段事实源方案。
+
+## 决策
+
+- 不迁移 `attendance_records` 到 `meta_records`。
+- 不让考勤插件直接写 `meta_*` 表。
+- 公式配置写入“考勤统计字段目录”多维表对象。
+- 用户公式使用 `{field_code}` 引用考勤统计字段，不暴露多维表内部 `{fld_xxx}`。
+- v1 只支持单条记录级公式，不支持跨人、跨天、跨周期聚合。
+- v1 禁用 `NOW`、`TODAY`、lookup、自定义脚本等非确定性或跨表能力。
+
+## 钉钉字段对齐矩阵
+
+| 分类 | 钉钉字段/能力 | 当前字段编码 | 当前状态 | 公式需求 | 优先级 | 备注 |
+| --- | --- | --- | --- | --- | --- | --- |
+| 固定字段 | 日期 | `work_date` | supported | 否 | P0 | 已进入目录、记录与导出 |
+| 固定字段 | 姓名 | `employee_name` | supported | 否 | P0 | 已进入目录、记录与导出 |
+| 固定字段 | 考勤组 | `attendance_group` | supported | 否 | P0 | 来自记录 meta 或规则上下文 |
+| 固定字段 | 部门 | `department` | supported | 否 | P0 | 来自员工/导入 meta |
+| 固定字段 | 工号 | `employee_no` | supported | 否 | P0 | 来自员工/导入 meta |
+| 固定字段 | 职位 | `position` | supported | 否 | P0 | 来自员工/导入 meta |
+| 基础字段 | 打卡时间 | `punch_times` | supported | 否 | P0 | 上/下班时间集合 |
+| 基础字段 | 打卡结果 | `punch_result` | supported | 否 | P0 | 与状态字段一致 |
+| 基础字段 | 关联审批单 | `approval_forms` | config_only | 否 | P1 | 依赖审批摘要导入/归集 |
+| 出勤统计 | 应出勤天数 | `expected_attendance_days` | supported | 否 | P0 | 由工作日/排班上下文计算 |
+| 出勤统计 | 出勤天数 | `attendance_days` | supported | 否 | P0 | 当前为按日记录级值 |
+| 出勤统计 | 工作时长 | `work_duration` | supported | 否 | P0 | 分钟单位 |
+| 出勤统计 | 自定义净工作时长 | custom formula field | formula_needed | 是 | P1 | 例：`={work_duration}-{late_duration}` |
+| 异常统计 | 迟到次数 | `late_count` | supported | 否 | P0 | 记录级规则 |
+| 异常统计 | 迟到时长 | `late_duration` | supported | 否 | P0 | 分钟单位 |
+| 异常统计 | 早退次数 | `early_leave_count` | supported | 否 | P0 | 记录级规则 |
+| 异常统计 | 早退时长 | `early_leave_duration` | supported | 否 | P0 | 分钟单位 |
+| 异常统计 | 缺卡次数 | `missing_clock_in_count` / `missing_clock_out_count` | supported | 否 | P0 | 上班/下班分列 |
+| 请假统计 | 请假时长 | `leave_duration` | supported | 否 | P0 | 来自审批/导入归集 |
+| 加班统计 | 加班审批时长 | `overtime_approval_duration` | supported | 否 | P0 | 来自审批/导入归集 |
+| 加班统计 | 工作日加班 | `workday_overtime_duration` | supported | 否 | P0 | 按工作日上下文拆分 |
+| 加班统计 | 休息日加班 | `restday_overtime_duration` | supported | 否 | P0 | 按工作日上下文拆分 |
+| 加班统计 | 节假日加班 | `holiday_overtime_duration` | config_only | 否 | P1 | 依赖节假日标记导入/规则 |
+| 专家模式 | 自定义公式 | custom formula field | formula_needed | 是 | P1 | v1 仅 record-scope |
+| 专家模式 | 跨周期汇总公式 | - | out_of_scope_v1 | 是 | P2 | 后续接汇总/薪资周期引擎 |
+
+## Claude Code TODO
+
+- [x] 扩展字段目录 descriptor：`formula_enabled`、`formula_expression`、`formula_scope`、`formula_output_type`。
+- [x] 扩展字段合并逻辑：多维表配置缺失时回退内置字段，配置存在时合并公式元数据。
+- [x] 新增考勤公式包装层：解析 `{field_code}`、校验引用、函数白名单、错误封装。
+- [x] 接入记录/导出：启用的公式字段进入 `reportFields`、JSON export、CSV export 和 field fingerprint。
+- [x] 新增公式预览 API：`POST /api/attendance/report-fields/formula/preview`。
+- [x] 前端统计字段区域展示公式徽标、表达式、范围、输出类型、引用和错误。
+- [x] live acceptance 支持 `EXPECT_FORMULA_CODE` 并检查目录/记录/导出的公式字段。
+- [x] 后端/前端/脚本测试覆盖公式字段主路径。
+
+## P1 Closeout Follow-up
+
+- [x] 公式白名单按函数大类补 wrapper 单测，每类至少一个代表函数：条件（`IF`）、数学（`ROUND`/`ABS`）、聚合（`SUM`/`COUNT`/`COUNTA`）、日期（`DATEDIF`/`DATE`/`YEAR`）、文本（`CONCAT`/`LEFT`/`LEN`）。
+- [x] staging 环境补跑真实 live acceptance：2026-05-15 通过 SSH tunnel + admin JWT 跑通，48 checks PASS，evidence 在 `output/attendance-report-fields-live-acceptance/2026-05-15T07-01-24-382Z/`（已脱敏）。
+- [x] 合并前复核真实 evidence 中 catalog、records、export、CSV label/code header 的 formula field fingerprint 一致：5 处全部 = `d7f0d74172d35268bae4295af089947ceeedd20f`。
+- [ ] staging 环境 seed 一个 formula 字段后重跑 + `EXPECT_FORMULA_CODE`，验证 formula 评估链路在真实后端的 evaluation（本轮 staging catalog 暂 0 个 formula 字段，acceptance 中 formula-related checks 是 trivially ok）。
+
+## P2 TODO
+
+- [ ] 对齐钉钉明细拆字段：将“打卡时间”拆成上班 1/2/3、下班 1/2/3 六个报表字段。
+- [ ] 对齐钉钉明细拆字段：将“打卡结果”拆成上班 1/2/3、下班 1/2/3 六个报表字段。
+- [ ] 内联公式编辑器与函数参考面板。
+- [ ] 公式字段依赖图与循环检测。
+- [ ] 周期汇总级公式。
+- [ ] 请假/加班子类型拆分字段。
+- [ ] 与薪资周期字段模板联动。
+- [ ] Custom 非公式字段作为公式源——v1 已明确 validator 拒绝（Round 5）；v2 设计自定义字段解析层：约定 `row.meta[code]` / `internalKey` dotted path / 命名 alias 三档来源，加 dotted-path lookup + circular guard + 单测，并在 catalog descriptor 增加 `formulaSourceMode` 元字段供用户选择来源策略。
+- [ ] Raw alias 全局门控——v1 已明确 `{late_minutes}` 等 5 个 raw alias 不受统计字段 `enabled` 控制（Round 5）。如果未来要给运维一个统一开关，单独引入 `attendance.formula.allowRawAliases` env / config，**不**复用 stat 字段 `enabled`，避免重蹈 Round 3 的语义耦合错误。
+- [ ] Reserved-code shadow UI 反馈——Round 6 已让 catalog 配置记录 code ∈ raw alias 集合（`work_minutes`/`late_minutes`/`early_leave_minutes`/`leave_minutes`/`overtime_minutes`）的字段在 merge 阶段被静默丢弃。如果客户报告字段消失，运维需要手动查 catalog 记录。P2 在 catalog response 增加 `droppedReservedCodes: string[]`（merge 时累计），前端在字段管理页面顶部 banner 提示，避免客户疑惑。

--- a/docs/development/attendance-dingtalk-formula-verification-20260515.md
+++ b/docs/development/attendance-dingtalk-formula-verification-20260515.md
@@ -1,0 +1,55 @@
+# 考勤字段公式能力验证记录
+
+Date: 2026-05-15
+
+## Commands Run
+
+```bash
+node --check scripts/ops/attendance-report-fields-live-acceptance.mjs
+node --check plugins/plugin-attendance/index.cjs
+node --test scripts/ops/attendance-report-fields-live-acceptance.test.mjs
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-report-field-catalog.test.ts tests/unit/attendance-report-field-formula-engine.test.ts --reporter=dot
+NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/AttendanceReportFieldsSection.spec.ts tests/attendance-admin-regressions.spec.ts --watch=false
+pnpm run verify:attendance-report-fields:live:test
+pnpm --filter @metasheet/web type-check
+pnpm --filter @metasheet/core-backend build
+git diff --check
+```
+
+## Results
+
+| Check | Result |
+| --- | --- |
+| Plugin syntax | PASS |
+| live acceptance script syntax | PASS |
+| live acceptance unit harness | PASS, 17 tests |
+| backend catalog/formula unit tests | PASS, 13 tests |
+| frontend report fields/admin regression specs | PASS, 14 tests |
+| package live harness script | PASS, 17 tests |
+| web type-check | PASS |
+| core-backend build | PASS |
+| git diff whitespace check | PASS |
+
+## Acceptance Focus
+
+- Descriptor 字段稳定，新增公式字段 ID 可重复。
+- 六类钉钉统计字段分类仍完整。
+- 多维表配置缺失时仍降级到内置字段。
+- 公式字段可通过 `{field_code}` 读取系统统计字段。
+- `NOW()`、未知字段、公式字段引用公式字段被拒绝。
+- 无效公式字段返回 `#ERROR!`，不阻断整行导出。
+- 公式表达式变化会改变 report field fingerprint。
+- 前端统计字段区域展示公式状态、表达式、引用和错误。
+- live acceptance 能验证公式字段进入 catalog、records、export、CSV header。
+
+## Follow-up Notes
+
+- 函数白名单实现已按 P1 范围接入，并已按条件/数学/聚合/日期/文本大类补代表函数测试。
+- 钉钉“打卡时间”和“打卡结果”在本轮仍是聚合字段；上班 1/2/3、下班 1/2/3 拆分字段是 P2 follow-up。
+- 真实 staging live acceptance 仍是合并前 evidence 待补项，需要真实 staging/local 后端地址和短期 admin JWT 文件。
+
+## Live Environment
+
+真实 live acceptance 需要外部后端地址和短期 admin JWT 文件。本轮默认不伪造真实 live 通过结果；没有凭据时只运行 mock/live harness 单元测试。
+
+本轮未运行真实外部后端 live acceptance，因为当前会话没有提供 staging/local 后端地址与短期 admin JWT 文件。

--- a/packages/core-backend/src/services/FormulaService.ts
+++ b/packages/core-backend/src/services/FormulaService.ts
@@ -1,13 +1,71 @@
+import { FormulaEngine } from '../formula/engine'
+
+const AVAILABLE_FUNCTIONS = Object.freeze([
+  'SUM',
+  'AVERAGE',
+  'COUNT',
+  'MAX',
+  'MIN',
+  'ABS',
+  'ROUND',
+  'CEILING',
+  'FLOOR',
+  'IF',
+  'AND',
+  'OR',
+  'NOT',
+  'DATE',
+  'YEAR',
+  'MONTH',
+  'DAY',
+  'DATEDIF',
+  'DATEDIFF',
+  'CONCAT',
+  'CONCATENATE',
+  'LEFT',
+  'RIGHT',
+  'MID',
+  'LEN',
+  'TRIM',
+  'UPPER',
+  'LOWER',
+])
+
+function formulaLiteral(value: unknown): string {
+  if (value === null || value === undefined || value === '') return '0'
+  if (typeof value === 'number') return Number.isFinite(value) ? String(value) : '0'
+  if (typeof value === 'boolean') return value ? 'TRUE' : 'FALSE'
+  if (value instanceof Date) return JSON.stringify(value.toISOString())
+  const parsed = Number(value)
+  if (Number.isFinite(parsed) && String(value).trim() !== '') return String(parsed)
+  return JSON.stringify(String(value))
+}
+
 export class FormulaService {
-  calculate(_functionName: string, ..._args: unknown[]): unknown {
-    return null
+  private readonly engine = new FormulaEngine()
+
+  async calculate(functionName: string, ...args: unknown[]): Promise<unknown> {
+    const name = String(functionName || '').trim()
+    if (!name) return '#ERROR!'
+    const expression = `=${name}(${args.map(formulaLiteral).join(',')})`
+    return this.calculateFormula(expression)
   }
 
-  calculateFormula(_expression: string, _contextResolver?: (key: string) => unknown): unknown {
-    return null
+  async calculateFormula(expression: string, contextResolver?: (key: string) => unknown): Promise<unknown> {
+    const resolved = String(expression || '').replace(/\{([A-Za-z][A-Za-z0-9_]*)\}/g, (_match, key: string) => {
+      if (!contextResolver) return '0'
+      return formulaLiteral(contextResolver(key))
+    })
+    const formula = resolved.trim().startsWith('=') ? resolved.trim() : `=${resolved.trim()}`
+    return this.engine.calculate(formula, {
+      sheetId: 'plugin-formula',
+      spreadsheetId: 'plugin-formula',
+      currentCell: { row: 0, col: 0 },
+      cache: new Map(),
+    })
   }
 
   getAvailableFunctions(): string[] {
-    return []
+    return [...AVAILABLE_FUNCTIONS]
   }
 }

--- a/packages/core-backend/tests/unit/attendance-report-field-catalog.test.ts
+++ b/packages/core-backend/tests/unit/attendance-report-field-catalog.test.ts
@@ -34,6 +34,10 @@ describe('attendance report field catalog multitable foundation', () => {
       'dingtalk_field_name',
       'description',
       'internal_key',
+      'formula_enabled',
+      'formula_expression',
+      'formula_scope',
+      'formula_output_type',
     ])
   })
 
@@ -148,6 +152,10 @@ describe('attendance report field catalog multitable foundation', () => {
       dingtalk_field_name: 'fld_dingtalk',
       description: 'fld_description',
       internal_key: 'fld_internal',
+      formula_enabled: 'fld_formula_enabled',
+      formula_expression: 'fld_formula_expression',
+      formula_scope: 'fld_formula_scope',
+      formula_output_type: 'fld_formula_output_type',
     }
     const merged = helpers.mergeAttendanceReportFieldDefinitions([
       {
@@ -164,6 +172,10 @@ describe('attendance report field catalog multitable foundation', () => {
           fld_dingtalk: '迟到次数',
           fld_description: '运营侧关闭该字段',
           fld_internal: 'summary.lateCount',
+          fld_formula_enabled: false,
+          fld_formula_expression: '',
+          fld_formula_scope: 'record',
+          fld_formula_output_type: 'number',
         },
       },
     ], fieldIds)

--- a/packages/core-backend/tests/unit/attendance-report-field-formula-engine.test.ts
+++ b/packages/core-backend/tests/unit/attendance-report-field-formula-engine.test.ts
@@ -1,0 +1,709 @@
+import { createRequire } from 'node:module'
+import { describe, expect, it, vi } from 'vitest'
+
+const require = createRequire(import.meta.url)
+const attendancePlugin = require('../../../../plugins/plugin-attendance/index.cjs')
+const helpers = attendancePlugin.__attendanceReportFieldCatalogForTests
+
+describe('attendance report field formula engine wrapper', () => {
+  const fieldIds = {
+    field_code: 'fld_code',
+    field_name: 'fld_name',
+    category: 'fld_category',
+    source: 'fld_source',
+    unit: 'fld_unit',
+    enabled: 'fld_enabled',
+    report_visible: 'fld_visible',
+    sort_order: 'fld_sort',
+    dingtalk_field_name: 'fld_dingtalk',
+    description: 'fld_description',
+    internal_key: 'fld_internal',
+    formula_enabled: 'fld_formula_enabled',
+    formula_expression: 'fld_formula_expression',
+    formula_scope: 'fld_formula_scope',
+    formula_output_type: 'fld_formula_output_type',
+  }
+
+  it('merges custom formula fields and evaluates them through the formula API', async () => {
+    const merged = helpers.mergeAttendanceReportFieldDefinitions([
+      {
+        id: 'rec-net-anomaly',
+        data: {
+          fld_code: 'net_anomaly_minutes',
+          fld_name: '异常净时长',
+          fld_category: '异常统计字段',
+          fld_source: 'custom',
+          fld_unit: 'minutes',
+          fld_enabled: true,
+          fld_visible: true,
+          fld_sort: 4500,
+          fld_dingtalk: '异常净时长',
+          fld_description: '迟到与早退分钟数之和。',
+          fld_internal: 'formula.netAnomalyMinutes',
+          fld_formula_enabled: true,
+          fld_formula_expression: '={late_duration}+{early_leave_duration}',
+          fld_formula_scope: 'record',
+          fld_formula_output_type: 'duration_minutes',
+        },
+      },
+    ], fieldIds)
+    const formulaField = merged.find((field: { code: string }) => field.code === 'net_anomaly_minutes')
+
+    expect(formulaField).toMatchObject({
+      formulaEnabled: true,
+      formulaExpression: '={late_duration}+{early_leave_duration}',
+      formulaScope: 'record',
+      formulaOutputType: 'duration_minutes',
+      formulaValid: true,
+      formulaError: null,
+      systemDefined: false,
+    })
+
+    const reportFields = helpers.resolveAttendanceRecordReportFields(merged)
+    const formulaSourceFields = helpers.resolveAttendanceFormulaSourceFields(merged)
+    expect(reportFields.some((field: { code: string }) => field.code === 'net_anomaly_minutes')).toBe(true)
+
+    const context = {
+      api: {
+        formula: {
+          calculateFormula: vi.fn(async (expression: string) => {
+            expect(expression).toBe('=12+5')
+            return 17
+          }),
+        },
+      },
+    }
+    const row = {
+      work_date: '2026-05-13',
+      status: 'late',
+      late_minutes: 12,
+      early_leave_minutes: 5,
+      work_minutes: 460,
+      is_workday: true,
+      meta: {},
+    }
+
+    await expect(helpers.buildAttendanceRecordReportExportItemAsync(context, row, reportFields, formulaSourceFields))
+      .resolves.toMatchObject({
+        late_duration: 12,
+        early_leave_duration: 5,
+        net_anomaly_minutes: 17,
+      })
+    expect(context.api.formula.calculateFormula).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects unknown references, volatile functions, and formula-to-formula references', () => {
+    const systemFields = helpers.cloneAttendanceReportFieldDefinitions()
+    expect(helpers.validateAttendanceReportFormulaExpression('={not_a_field}+1', { fields: systemFields }))
+      .toMatchObject({
+        valid: false,
+        error: 'Unknown attendance report field reference: not_a_field.',
+      })
+    expect(helpers.validateAttendanceReportFormulaExpression('=NOW()', { fields: systemFields }))
+      .toMatchObject({
+        valid: false,
+        error: 'Function NOW is not allowed for attendance report formulas.',
+      })
+
+    const merged = helpers.mergeAttendanceReportFieldDefinitions([
+      {
+        id: 'rec-a',
+        data: {
+          fld_code: 'formula_a',
+          fld_name: '公式 A',
+          fld_category: '出勤统计字段',
+          fld_source: 'custom',
+          fld_unit: 'minutes',
+          fld_enabled: true,
+          fld_visible: true,
+          fld_sort: 3500,
+          fld_formula_enabled: true,
+          fld_formula_expression: '={late_duration}+1',
+          fld_formula_scope: 'record',
+          fld_formula_output_type: 'duration_minutes',
+        },
+      },
+      {
+        id: 'rec-b',
+        data: {
+          fld_code: 'formula_b',
+          fld_name: '公式 B',
+          fld_category: '出勤统计字段',
+          fld_source: 'custom',
+          fld_unit: 'minutes',
+          fld_enabled: true,
+          fld_visible: true,
+          fld_sort: 3501,
+          fld_formula_enabled: true,
+          fld_formula_expression: '={formula_a}+1',
+          fld_formula_scope: 'record',
+          fld_formula_output_type: 'duration_minutes',
+        },
+      },
+    ], fieldIds)
+    expect(merged.find((field: { code: string }) => field.code === 'formula_b'))
+      .toMatchObject({
+        formulaValid: false,
+        formulaError: 'Formula field reference formula_a is not supported in v1.',
+      })
+  })
+
+  it('allows representative formula functions from each whitelist category', () => {
+    const systemFields = helpers.cloneAttendanceReportFieldDefinitions()
+    const cases = [
+      {
+        category: 'condition',
+        expression: '=IF({attendance_days}>0,{work_duration},0)',
+        functions: ['IF'],
+        references: ['attendance_days', 'work_duration'],
+      },
+      {
+        category: 'math',
+        expression: '=ROUND(ABS({late_duration}),0)',
+        functions: ['ABS', 'ROUND'],
+        references: ['late_duration'],
+      },
+      {
+        category: 'aggregate',
+        expression: '=SUM({late_duration},{early_leave_duration},COUNT({work_duration}),COUNTA({employee_name}))',
+        functions: ['COUNT', 'COUNTA', 'SUM'],
+        references: ['early_leave_duration', 'employee_name', 'late_duration', 'work_duration'],
+      },
+      {
+        category: 'date',
+        expression: '=DATEDIF(DATE(YEAR({work_date}),1,1),{work_date},"D")',
+        functions: ['DATE', 'DATEDIF', 'YEAR'],
+        references: ['work_date'],
+      },
+      {
+        category: 'text',
+        expression: '=CONCAT(LEFT({employee_name},1),LEN({employee_name}))',
+        functions: ['CONCAT', 'LEFT', 'LEN'],
+        references: ['employee_name'],
+      },
+    ]
+
+    for (const testCase of cases) {
+      expect(helpers.validateAttendanceReportFormulaExpression(testCase.expression, { fields: systemFields }))
+        .toMatchObject({
+          valid: true,
+          error: null,
+          functions: testCase.functions,
+          references: testCase.references,
+        })
+    }
+  })
+
+  it('returns #ERROR! for invalid formula fields without blocking the row export', async () => {
+    const merged = helpers.mergeAttendanceReportFieldDefinitions([
+      {
+        id: 'rec-bad',
+        data: {
+          fld_code: 'broken_formula',
+          fld_name: '错误公式',
+          fld_category: '异常统计字段',
+          fld_source: 'custom',
+          fld_unit: 'minutes',
+          fld_enabled: true,
+          fld_visible: true,
+          fld_sort: 4501,
+          fld_formula_enabled: true,
+          fld_formula_expression: '={missing_reference}+1',
+          fld_formula_scope: 'record',
+          fld_formula_output_type: 'duration_minutes',
+        },
+      },
+    ], fieldIds)
+    const reportFields = helpers.resolveAttendanceRecordReportFields(merged)
+    const formulaSourceFields = helpers.resolveAttendanceFormulaSourceFields(merged)
+    const context = {
+      api: {
+        formula: {
+          calculateFormula: vi.fn(),
+        },
+      },
+    }
+
+    await expect(helpers.buildAttendanceRecordReportExportItemAsync(context, {
+      work_date: '2026-05-13',
+      status: 'normal',
+      late_minutes: 0,
+      early_leave_minutes: 0,
+      work_minutes: 480,
+      is_workday: true,
+      meta: {},
+    }, reportFields, formulaSourceFields)).resolves.toMatchObject({
+      work_date: '2026-05-13',
+      broken_formula: '#ERROR!',
+    })
+    expect(context.api.formula.calculateFormula).not.toHaveBeenCalled()
+  })
+
+  it('includes formula metadata in the report field fingerprint', () => {
+    const baseField = {
+      code: 'net_anomaly_minutes',
+      name: '异常净时长',
+      category: 'anomaly',
+      unit: 'minutes',
+      enabled: true,
+      reportVisible: true,
+      sortOrder: 4500,
+      source: 'custom',
+      formulaEnabled: true,
+      formulaScope: 'record',
+      formulaOutputType: 'duration_minutes',
+      formulaValid: true,
+    }
+    const left = helpers.buildAttendanceReportFieldConfigFingerprint([
+      { ...baseField, formulaExpression: '={late_duration}+{early_leave_duration}' },
+    ])
+    const right = helpers.buildAttendanceReportFieldConfigFingerprint([
+      { ...baseField, formulaExpression: '={late_duration}' },
+    ])
+
+    expect(left.value).not.toBe(right.value)
+  })
+
+  it('previews formulas against supplied sample values', async () => {
+    const context = {
+      api: {
+        formula: {
+          calculateFormula: vi.fn(async (expression: string) => {
+            expect(expression).toBe('=12+3')
+            return 15
+          }),
+        },
+      },
+    }
+
+    await expect(helpers.previewAttendanceReportFormula(context, '={late_duration}+{early_leave_duration}', {
+      late_duration: 12,
+      early_leave_duration: 3,
+    }, helpers.cloneAttendanceReportFieldDefinitions())).resolves.toEqual({
+      ok: true,
+      value: 15,
+      references: ['early_leave_duration', 'late_duration'],
+      error: null,
+    })
+  })
+
+  it('rejects bare spreadsheet cell and range references', () => {
+    const systemFields = helpers.cloneAttendanceReportFieldDefinitions()
+
+    expect(helpers.validateAttendanceReportFormulaExpression('=A1+1', { fields: systemFields }))
+      .toMatchObject({
+        valid: false,
+        error: 'Spreadsheet cell reference A1 is not allowed; use {field_code} to reference attendance fields.',
+      })
+
+    expect(helpers.validateAttendanceReportFormulaExpression('=SUM(A1:B2)', { fields: systemFields }))
+      .toMatchObject({
+        valid: false,
+        error: 'Spreadsheet cell reference A1:B2 is not allowed; use {field_code} to reference attendance fields.',
+      })
+
+    expect(helpers.validateAttendanceReportFormulaExpression('=A1+{late_duration}', { fields: systemFields }))
+      .toMatchObject({
+        valid: false,
+        error: 'Spreadsheet cell reference A1 is not allowed; use {field_code} to reference attendance fields.',
+      })
+
+    expect(helpers.validateAttendanceReportFormulaExpression('=b2+1', { fields: systemFields }))
+      .toMatchObject({
+        valid: false,
+        error: 'Spreadsheet cell reference b2 is not allowed; use {field_code} to reference attendance fields.',
+      })
+
+    expect(helpers.validateAttendanceReportFormulaExpression('=IF({attendance_days}>0,"A1","B2")', { fields: systemFields }))
+      .toMatchObject({ valid: true, error: null })
+
+    expect(helpers.validateAttendanceReportFormulaExpression('={A1}+1', { fields: systemFields }))
+      .toMatchObject({
+        valid: false,
+        error: 'Unknown attendance report field reference: A1.',
+      })
+  })
+
+  it('hidden but enabled source field still resolves in formulas', async () => {
+    const merged = helpers.mergeAttendanceReportFieldDefinitions([
+      {
+        id: 'rec-late-hidden',
+        data: {
+          fld_code: 'late_duration',
+          fld_name: '迟到时长',
+          fld_category: '异常统计字段',
+          fld_source: 'system',
+          fld_unit: 'minutes',
+          fld_enabled: true,
+          fld_visible: false,
+          fld_sort: 4000,
+        },
+      },
+      {
+        id: 'rec-late-plus-one',
+        data: {
+          fld_code: 'late_plus_one',
+          fld_name: '迟到+1',
+          fld_category: '异常统计字段',
+          fld_source: 'custom',
+          fld_unit: 'minutes',
+          fld_enabled: true,
+          fld_visible: true,
+          fld_sort: 4500,
+          fld_formula_enabled: true,
+          fld_formula_expression: '={late_duration}+1',
+          fld_formula_scope: 'record',
+          fld_formula_output_type: 'duration_minutes',
+        },
+      },
+    ], fieldIds)
+
+    const lateField = merged.find((field: { code: string }) => field.code === 'late_duration')
+    expect(lateField).toMatchObject({ enabled: true, reportVisible: false })
+
+    const formulaField = merged.find((field: { code: string }) => field.code === 'late_plus_one')
+    expect(formulaField).toMatchObject({
+      formulaEnabled: true,
+      formulaValid: true,
+      formulaError: null,
+    })
+
+    const outputFields = helpers.resolveAttendanceRecordReportFields(merged)
+    expect(outputFields.some((field: { code: string }) => field.code === 'late_duration')).toBe(false)
+    expect(outputFields.some((field: { code: string }) => field.code === 'late_plus_one')).toBe(true)
+
+    const formulaSourceFields = helpers.resolveAttendanceFormulaSourceFields(merged)
+    expect(formulaSourceFields.some((field: { code: string }) => field.code === 'late_duration')).toBe(true)
+    expect(formulaSourceFields.some((field: { code: string }) => field.code === 'late_plus_one')).toBe(false)
+
+    const context = {
+      api: {
+        formula: {
+          calculateFormula: vi.fn(async (expression: string) => {
+            expect(expression).toBe('=12+1')
+            return 13
+          }),
+        },
+      },
+    }
+
+    await expect(helpers.buildAttendanceRecordReportExportItemAsync(context, {
+      work_date: '2026-05-13',
+      status: 'late',
+      late_minutes: 12,
+      early_leave_minutes: 0,
+      work_minutes: 460,
+      is_workday: true,
+      meta: {},
+    }, outputFields, formulaSourceFields)).resolves.toMatchObject({
+      late_plus_one: 13,
+    })
+    expect(context.api.formula.calculateFormula).toHaveBeenCalledTimes(1)
+  })
+
+  it('disabled source field is rejected by the validator and yields #ERROR! at evaluation', async () => {
+    const merged = helpers.mergeAttendanceReportFieldDefinitions([
+      {
+        id: 'rec-late-disabled',
+        data: {
+          fld_code: 'late_duration',
+          fld_name: '迟到时长',
+          fld_category: '异常统计字段',
+          fld_source: 'system',
+          fld_unit: 'minutes',
+          fld_enabled: false,
+          fld_visible: true,
+          fld_sort: 4000,
+        },
+      },
+      {
+        id: 'rec-late-plus-one',
+        data: {
+          fld_code: 'late_plus_one',
+          fld_name: '迟到+1',
+          fld_category: '异常统计字段',
+          fld_source: 'custom',
+          fld_unit: 'minutes',
+          fld_enabled: true,
+          fld_visible: true,
+          fld_sort: 4500,
+          fld_formula_enabled: true,
+          fld_formula_expression: '={late_duration}+1',
+          fld_formula_scope: 'record',
+          fld_formula_output_type: 'duration_minutes',
+        },
+      },
+    ], fieldIds)
+
+    const lateField = merged.find((field: { code: string }) => field.code === 'late_duration')
+    expect(lateField).toMatchObject({ enabled: false })
+
+    const formulaField = merged.find((field: { code: string }) => field.code === 'late_plus_one')
+    expect(formulaField).toMatchObject({
+      formulaEnabled: true,
+      formulaValid: false,
+      formulaError: 'Unknown attendance report field reference: late_duration.',
+    })
+
+    const formulaSourceFields = helpers.resolveAttendanceFormulaSourceFields(merged)
+    expect(formulaSourceFields.some((field: { code: string }) => field.code === 'late_duration')).toBe(false)
+
+    const outputFields = helpers.resolveAttendanceRecordReportFields(merged)
+    const context = {
+      api: {
+        formula: {
+          calculateFormula: vi.fn(),
+        },
+      },
+    }
+
+    await expect(helpers.buildAttendanceRecordReportExportItemAsync(context, {
+      work_date: '2026-05-13',
+      status: 'late',
+      late_minutes: 12,
+      early_leave_minutes: 0,
+      work_minutes: 460,
+      is_workday: true,
+      meta: {},
+    }, outputFields, formulaSourceFields)).resolves.toMatchObject({
+      late_plus_one: '#ERROR!',
+    })
+    expect(context.api.formula.calculateFormula).not.toHaveBeenCalled()
+  })
+
+  it('v1 rejects custom non-formula fields as formula sources', () => {
+    const merged = helpers.mergeAttendanceReportFieldDefinitions([
+      {
+        id: 'rec-custom-metric',
+        data: {
+          fld_code: 'custom_metric',
+          fld_name: '客户自定义指标',
+          fld_category: '出勤统计字段',
+          fld_source: 'custom',
+          fld_unit: 'minutes',
+          fld_enabled: true,
+          fld_visible: true,
+          fld_sort: 3000,
+        },
+      },
+      {
+        id: 'rec-uses-custom',
+        data: {
+          fld_code: 'uses_custom_metric',
+          fld_name: '用了自定义',
+          fld_category: '出勤统计字段',
+          fld_source: 'custom',
+          fld_unit: 'minutes',
+          fld_enabled: true,
+          fld_visible: true,
+          fld_sort: 3001,
+          fld_formula_enabled: true,
+          fld_formula_expression: '={custom_metric}+1',
+          fld_formula_scope: 'record',
+          fld_formula_output_type: 'duration_minutes',
+        },
+      },
+    ], fieldIds)
+
+    const customField = merged.find((field: { code: string }) => field.code === 'custom_metric')
+    expect(customField).toMatchObject({ systemDefined: false, enabled: true, formulaEnabled: false })
+
+    const usesField = merged.find((field: { code: string }) => field.code === 'uses_custom_metric')
+    expect(usesField).toMatchObject({
+      formulaEnabled: true,
+      formulaValid: false,
+      formulaError: 'Unknown attendance report field reference: custom_metric.',
+    })
+
+    const formulaSourceFields = helpers.resolveAttendanceFormulaSourceFields(merged)
+    expect(formulaSourceFields.some((field: { code: string }) => field.code === 'custom_metric')).toBe(false)
+    expect(formulaSourceFields.every((field: { systemDefined: boolean }) => field.systemDefined === true)).toBe(true)
+  })
+
+  it('raw alias references bypass catalog enable/visibility state', async () => {
+    const merged = helpers.mergeAttendanceReportFieldDefinitions([
+      {
+        id: 'rec-late-disabled',
+        data: {
+          fld_code: 'late_duration',
+          fld_name: '迟到时长',
+          fld_category: '异常统计字段',
+          fld_source: 'system',
+          fld_unit: 'minutes',
+          fld_enabled: false,
+          fld_visible: true,
+          fld_sort: 4000,
+        },
+      },
+      {
+        id: 'rec-raw-late-plus-one',
+        data: {
+          fld_code: 'raw_late_plus_one',
+          fld_name: '迟到分钟+1（raw alias）',
+          fld_category: '异常统计字段',
+          fld_source: 'custom',
+          fld_unit: 'minutes',
+          fld_enabled: true,
+          fld_visible: true,
+          fld_sort: 4501,
+          fld_formula_enabled: true,
+          fld_formula_expression: '={late_minutes}+1',
+          fld_formula_scope: 'record',
+          fld_formula_output_type: 'duration_minutes',
+        },
+      },
+    ], fieldIds)
+
+    const lateField = merged.find((field: { code: string }) => field.code === 'late_duration')
+    expect(lateField).toMatchObject({ enabled: false })
+
+    const rawFormula = merged.find((field: { code: string }) => field.code === 'raw_late_plus_one')
+    expect(rawFormula).toMatchObject({
+      formulaValid: true,
+      formulaError: null,
+      formulaReferences: ['late_minutes'],
+    })
+
+    const formulaSourceFields = helpers.resolveAttendanceFormulaSourceFields(merged)
+    expect(formulaSourceFields.some((field: { code: string }) => field.code === 'late_duration')).toBe(false)
+
+    const outputFields = helpers.resolveAttendanceRecordReportFields(merged)
+    const context = {
+      api: {
+        formula: {
+          calculateFormula: vi.fn(async (expression: string) => {
+            expect(expression).toBe('=12+1')
+            return 13
+          }),
+        },
+      },
+    }
+
+    await expect(helpers.buildAttendanceRecordReportExportItemAsync(context, {
+      work_date: '2026-05-13',
+      status: 'late',
+      late_minutes: 12,
+      early_leave_minutes: 0,
+      work_minutes: 460,
+      is_workday: true,
+      meta: {},
+    }, outputFields, formulaSourceFields)).resolves.toMatchObject({
+      raw_late_plus_one: 13,
+    })
+    expect(context.api.formula.calculateFormula).toHaveBeenCalledTimes(1)
+  })
+
+  it('catalog fields with raw alias codes are dropped (raw aliases are reserved)', async () => {
+    const merged = helpers.mergeAttendanceReportFieldDefinitions([
+      {
+        id: 'rec-shadow-nonformula',
+        data: {
+          fld_code: 'work_minutes',
+          fld_name: '工时分钟（违规非公式）',
+          fld_category: '出勤统计字段',
+          fld_source: 'custom',
+          fld_unit: 'minutes',
+          fld_enabled: true,
+          fld_visible: true,
+          fld_sort: 3501,
+        },
+      },
+      {
+        id: 'rec-shadow-formula',
+        data: {
+          fld_code: 'late_minutes',
+          fld_name: '迟到分钟（违规公式）',
+          fld_category: '异常统计字段',
+          fld_source: 'custom',
+          fld_unit: 'minutes',
+          fld_enabled: true,
+          fld_visible: true,
+          fld_sort: 4002,
+          fld_formula_enabled: true,
+          fld_formula_expression: '={attendance_days}*0',
+          fld_formula_scope: 'record',
+          fld_formula_output_type: 'duration_minutes',
+        },
+      },
+      {
+        id: 'rec-use-raw',
+        data: {
+          fld_code: 'use_raw_late',
+          fld_name: '用 raw alias',
+          fld_category: '异常统计字段',
+          fld_source: 'custom',
+          fld_unit: 'minutes',
+          fld_enabled: true,
+          fld_visible: true,
+          fld_sort: 4503,
+          fld_formula_enabled: true,
+          fld_formula_expression: '={late_minutes}+1',
+          fld_formula_scope: 'record',
+          fld_formula_output_type: 'duration_minutes',
+        },
+      },
+    ], fieldIds)
+
+    expect(merged.find((field: { code: string }) => field.code === 'work_minutes')).toBeUndefined()
+    expect(merged.find((field: { code: string }) => field.code === 'late_minutes')).toBeUndefined()
+
+    const useField = merged.find((field: { code: string }) => field.code === 'use_raw_late')
+    expect(useField).toMatchObject({
+      formulaValid: true,
+      formulaError: null,
+      formulaReferences: ['late_minutes'],
+    })
+
+    expect(helpers.validateAttendanceReportFormulaExpression('={late_minutes}+1', { fields: merged }))
+      .toMatchObject({ valid: true, error: null })
+
+    const outputFields = helpers.resolveAttendanceRecordReportFields(merged)
+    const formulaSourceFields = helpers.resolveAttendanceFormulaSourceFields(merged)
+    const context = {
+      api: {
+        formula: {
+          calculateFormula: vi.fn(async (expression: string) => {
+            expect(expression).toBe('=12+1')
+            return 13
+          }),
+        },
+      },
+    }
+
+    await expect(helpers.buildAttendanceRecordReportExportItemAsync(context, {
+      work_date: '2026-05-13',
+      status: 'late',
+      late_minutes: 12,
+      early_leave_minutes: 0,
+      work_minutes: 460,
+      is_workday: true,
+      meta: {},
+    }, outputFields, formulaSourceFields)).resolves.toMatchObject({
+      use_raw_late: 13,
+    })
+    expect(context.api.formula.calculateFormula).toHaveBeenCalledTimes(1)
+  })
+
+  it('preview does not let sample keys extend the legal field set', async () => {
+    const systemFields = helpers.cloneAttendanceReportFieldDefinitions()
+    const context = {
+      api: {
+        formula: {
+          calculateFormula: vi.fn(),
+        },
+      },
+    }
+
+    await expect(helpers.previewAttendanceReportFormula(
+      context,
+      '={phantom_field}+1',
+      { phantom_field: 99 },
+      systemFields,
+    )).resolves.toMatchObject({
+      ok: false,
+      value: null,
+      error: 'Unknown attendance report field reference: phantom_field.',
+    })
+    expect(context.api.formula.calculateFormula).not.toHaveBeenCalled()
+  })
+})

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -262,6 +262,10 @@ const ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS = Object.freeze({
   dingtalkFieldName: 'dingtalk_field_name',
   description: 'description',
   internalKey: 'internal_key',
+  formulaEnabled: 'formula_enabled',
+  formulaExpression: 'formula_expression',
+  formulaScope: 'formula_scope',
+  formulaOutputType: 'formula_output_type',
 })
 
 const ATTENDANCE_REPORT_FIELD_CATEGORIES = Object.freeze([
@@ -275,6 +279,56 @@ const ATTENDANCE_REPORT_FIELD_CATEGORIES = Object.freeze([
 
 const ATTENDANCE_REPORT_FIELD_SOURCE_OPTIONS = Object.freeze(['system', 'dingtalk', 'multitable', 'custom'])
 const ATTENDANCE_REPORT_FIELD_UNIT_OPTIONS = Object.freeze(['text', 'dateTime', 'days', 'minutes', 'count', 'hours'])
+const ATTENDANCE_REPORT_FIELD_FORMULA_SCOPE_OPTIONS = Object.freeze(['record'])
+const ATTENDANCE_REPORT_FIELD_FORMULA_OUTPUT_TYPE_OPTIONS = Object.freeze([
+  'number',
+  'duration_minutes',
+  'text',
+  'boolean',
+  'date',
+])
+const ATTENDANCE_REPORT_FORMULA_ERROR_VALUE = '#ERROR!'
+const ATTENDANCE_REPORT_FORMULA_REFERENCE_PATTERN = /\{([A-Za-z][A-Za-z0-9_]*)\}/g
+const ATTENDANCE_REPORT_FORMULA_CELL_REFERENCE_PATTERN = /(?<![A-Za-z0-9_])([A-Za-z]+\d+(?::[A-Za-z]+\d+)?)(?![A-Za-z0-9_])/g
+const ATTENDANCE_REPORT_FORMULA_ALLOWED_FUNCTIONS = new Set([
+  'IF',
+  'AND',
+  'OR',
+  'NOT',
+  'ROUND',
+  'CEILING',
+  'FLOOR',
+  'ABS',
+  'MIN',
+  'MAX',
+  'SUM',
+  'AVERAGE',
+  'COUNT',
+  'COUNTA',
+  'DATEDIF',
+  'DATEDIFF',
+  'DATE',
+  'YEAR',
+  'MONTH',
+  'DAY',
+  'CONCAT',
+  'CONCATENATE',
+  'LEFT',
+  'RIGHT',
+  'MID',
+  'LEN',
+  'TRIM',
+  'UPPER',
+  'LOWER',
+])
+const ATTENDANCE_REPORT_FORMULA_RAW_REFERENCE_KEYS = Object.freeze([
+  'work_minutes',
+  'late_minutes',
+  'early_leave_minutes',
+  'leave_minutes',
+  'overtime_minutes',
+])
+const ATTENDANCE_REPORT_FORMULA_RESERVED_CODES = new Set(ATTENDANCE_REPORT_FORMULA_RAW_REFERENCE_KEYS)
 
 const ATTENDANCE_REPORT_FIELD_DEFINITIONS = Object.freeze([
   {
@@ -684,6 +738,10 @@ function getAttendanceReportFieldCatalogDescriptor() {
       { id: ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.dingtalkFieldName, name: '钉钉原字段名', type: 'string', order: 90, property: { width: 180 } },
       { id: ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.description, name: '说明', type: 'longText', order: 100, property: { width: 360 } },
       { id: ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.internalKey, name: '内部计算键', type: 'string', order: 110, property: { width: 220 } },
+      { id: ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.formulaEnabled, name: '启用公式', type: 'boolean', order: 120 },
+      { id: ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.formulaExpression, name: '公式表达式', type: 'longText', order: 130, property: { width: 360 } },
+      { id: ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.formulaScope, name: '公式范围', type: 'select', order: 140, options: ATTENDANCE_REPORT_FIELD_FORMULA_SCOPE_OPTIONS },
+      { id: ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.formulaOutputType, name: '公式输出类型', type: 'select', order: 150, options: ATTENDANCE_REPORT_FIELD_FORMULA_OUTPUT_TYPE_OPTIONS },
     ],
   }
 }
@@ -729,6 +787,13 @@ function buildAttendanceReportFieldCatalogRecordData(field, fieldIds) {
   assign(ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.dingtalkFieldName, field.dingtalkFieldName || field.name)
   assign(ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.description, field.description || '')
   assign(ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.internalKey, field.internalKey || field.code)
+  assign(ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.formulaEnabled, Boolean(field.formulaEnabled))
+  assign(ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.formulaExpression, field.formulaExpression || '')
+  assign(ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.formulaScope, normalizeAttendanceReportFormulaScope(field.formulaScope))
+  assign(
+    ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.formulaOutputType,
+    normalizeAttendanceReportFormulaOutputType(field.formulaOutputType, field.unit),
+  )
   return data
 }
 
@@ -766,11 +831,42 @@ function normalizeCatalogNumber(value, fallback = 0) {
   return Number.isFinite(parsed) ? parsed : fallback
 }
 
+function normalizeAttendanceReportFormulaScope(value) {
+  const normalized = String(value || '').trim().toLowerCase()
+  return normalized === 'record' ? 'record' : 'record'
+}
+
+function normalizeAttendanceReportFormulaOutputType(value, unit = 'text') {
+  const normalized = String(value || '').trim().toLowerCase()
+  if (ATTENDANCE_REPORT_FIELD_FORMULA_OUTPUT_TYPE_OPTIONS.includes(normalized)) return normalized
+  const unitKey = String(unit || '').trim()
+  if (unitKey === 'minutes') return 'duration_minutes'
+  if (['days', 'hours', 'count'].includes(unitKey)) return 'number'
+  if (unitKey === 'dateTime') return 'date'
+  return 'text'
+}
+
+function normalizeAttendanceReportFormulaExpression(value) {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function normalizeAttendanceReportFormulaConfig(raw, unit = 'text') {
+  const formulaEnabled = normalizeCatalogBoolean(raw?.formulaEnabled, false)
+  const formulaExpression = normalizeAttendanceReportFormulaExpression(raw?.formulaExpression)
+  return {
+    formulaEnabled,
+    formulaExpression,
+    formulaScope: normalizeAttendanceReportFormulaScope(raw?.formulaScope),
+    formulaOutputType: normalizeAttendanceReportFormulaOutputType(raw?.formulaOutputType, unit),
+  }
+}
+
 function mapAttendanceReportFieldConfigRecord(record, fieldIds) {
   const read = (fieldId) => readAttendanceReportFieldCatalogCell(record, fieldIds, fieldId)
   const code = normalizeCatalogString(read(ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.fieldCode))
   if (!code) return null
   const category = getAttendanceReportFieldCategory(read(ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.category))
+  const unit = normalizeCatalogString(read(ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.unit), 'text')
   return {
     recordId: record?.id || '',
     code,
@@ -778,14 +874,172 @@ function mapAttendanceReportFieldConfigRecord(record, fieldIds) {
     category: category.id,
     categoryLabel: category.label,
     source: normalizeCatalogString(read(ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.source), 'custom'),
-    unit: normalizeCatalogString(read(ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.unit), 'text'),
+    unit,
     enabled: normalizeCatalogBoolean(read(ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.enabled), true),
     reportVisible: normalizeCatalogBoolean(read(ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.reportVisible), true),
     sortOrder: normalizeCatalogNumber(read(ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.sortOrder), category.sortOrder * 100),
     dingtalkFieldName: normalizeCatalogString(read(ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.dingtalkFieldName)),
     description: normalizeCatalogString(read(ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.description)),
     internalKey: normalizeCatalogString(read(ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.internalKey), code),
+    formulaEnabled: normalizeCatalogBoolean(read(ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.formulaEnabled), false),
+    formulaExpression: normalizeAttendanceReportFormulaExpression(read(ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.formulaExpression)),
+    formulaScope: normalizeAttendanceReportFormulaScope(read(ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.formulaScope)),
+    formulaOutputType: normalizeAttendanceReportFormulaOutputType(
+      read(ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS.formulaOutputType),
+      unit,
+    ),
   }
+}
+
+function stripAttendanceReportFormulaStrings(expression) {
+  const text = String(expression || '')
+  let output = ''
+  let inQuotes = false
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index]
+    const escaped = index > 0 && text[index - 1] === '\\'
+    if (char === '"' && !escaped) {
+      inQuotes = !inQuotes
+      output += ' '
+      continue
+    }
+    output += inQuotes ? ' ' : char
+  }
+  return output
+}
+
+function extractAttendanceReportFormulaReferences(expression) {
+  const normalized = stripAttendanceReportFormulaStrings(expression)
+  const references = new Set()
+  for (const match of normalized.matchAll(ATTENDANCE_REPORT_FORMULA_REFERENCE_PATTERN)) {
+    references.add(match[1])
+  }
+  return Array.from(references).sort()
+}
+
+function extractAttendanceReportFormulaCellReferences(expression) {
+  const withoutStrings = stripAttendanceReportFormulaStrings(expression)
+  const withoutCurly = withoutStrings.replace(/\{[^}]*\}/g, ' ')
+  const matches = []
+  for (const match of withoutCurly.matchAll(ATTENDANCE_REPORT_FORMULA_CELL_REFERENCE_PATTERN)) {
+    matches.push(match[1])
+  }
+  return matches
+}
+
+function extractAttendanceReportFormulaFunctions(expression) {
+  const normalized = stripAttendanceReportFormulaStrings(expression)
+  const functions = new Set()
+  const pattern = /\b([A-Za-z][A-Za-z0-9_]*)\s*\(/g
+  for (const match of normalized.matchAll(pattern)) {
+    functions.add(match[1].toUpperCase())
+  }
+  return Array.from(functions).sort()
+}
+
+function getAttendanceReportFormulaReferenceCodes(fields) {
+  const formulaFieldCodes = new Set()
+  const codes = new Set(ATTENDANCE_REPORT_FORMULA_RAW_REFERENCE_KEYS)
+  for (const field of fields || []) {
+    const code = normalizeCatalogString(field?.code)
+    if (!code) continue
+    if (ATTENDANCE_REPORT_FORMULA_RESERVED_CODES.has(code)) continue
+    if (field.formulaEnabled) {
+      formulaFieldCodes.add(code)
+      continue
+    }
+    if (field.enabled === false) continue
+    if (field.systemDefined === false) continue
+    codes.add(code)
+  }
+  return { codes, formulaFieldCodes }
+}
+
+function validateAttendanceReportFormulaExpression(expression, options = {}) {
+  const formulaExpression = normalizeAttendanceReportFormulaExpression(expression)
+  const references = extractAttendanceReportFormulaReferences(formulaExpression)
+  const functions = extractAttendanceReportFormulaFunctions(formulaExpression)
+  const { codes, formulaFieldCodes } = getAttendanceReportFormulaReferenceCodes(options.fields)
+
+  if (!formulaExpression) {
+    return {
+      valid: false,
+      references,
+      functions,
+      error: 'Formula expression is required when formula is enabled.',
+    }
+  }
+
+  const cellReferences = extractAttendanceReportFormulaCellReferences(formulaExpression)
+  if (cellReferences.length > 0) {
+    return {
+      valid: false,
+      references,
+      functions,
+      error: `Spreadsheet cell reference ${cellReferences[0]} is not allowed; use {field_code} to reference attendance fields.`,
+    }
+  }
+
+  const disallowedFunction = functions.find(name => !ATTENDANCE_REPORT_FORMULA_ALLOWED_FUNCTIONS.has(name))
+  if (disallowedFunction) {
+    return {
+      valid: false,
+      references,
+      functions,
+      error: `Function ${disallowedFunction} is not allowed for attendance report formulas.`,
+    }
+  }
+
+  const formulaFieldReference = references.find(reference => formulaFieldCodes.has(reference))
+  if (formulaFieldReference) {
+    return {
+      valid: false,
+      references,
+      functions,
+      error: `Formula field reference ${formulaFieldReference} is not supported in v1.`,
+    }
+  }
+
+  const unknownReference = references.find(reference => !codes.has(reference))
+  if (unknownReference) {
+    return {
+      valid: false,
+      references,
+      functions,
+      error: `Unknown attendance report field reference: ${unknownReference}.`,
+    }
+  }
+
+  return {
+    valid: true,
+    references,
+    functions,
+    error: null,
+  }
+}
+
+function applyAttendanceReportFormulaValidation(items) {
+  return items.map((field) => {
+    const formulaConfig = normalizeAttendanceReportFormulaConfig(field, field.unit)
+    if (!formulaConfig.formulaEnabled) {
+      return {
+        ...field,
+        ...formulaConfig,
+        formulaValid: true,
+        formulaError: null,
+      }
+    }
+    const validation = validateAttendanceReportFormulaExpression(formulaConfig.formulaExpression, {
+      fields: items,
+    })
+    return {
+      ...field,
+      ...formulaConfig,
+      formulaValid: validation.valid,
+      formulaError: validation.error,
+      formulaReferences: validation.references,
+    }
+  })
 }
 
 function mergeAttendanceReportFieldDefinitions(configRecords, fieldIds) {
@@ -802,6 +1056,7 @@ function mergeAttendanceReportFieldDefinitions(configRecords, fieldIds) {
     const category = getAttendanceReportFieldCategory(field.category)
     const config = configsByCode.get(field.code)
     const mergedCategory = getAttendanceReportFieldCategory(config?.category ?? category.id)
+    const formulaConfig = normalizeAttendanceReportFormulaConfig(config ?? field, config?.unit || field.unit)
     return {
       code: field.code,
       name: config?.name || field.name,
@@ -815,6 +1070,7 @@ function mergeAttendanceReportFieldDefinitions(configRecords, fieldIds) {
       dingtalkFieldName: config?.dingtalkFieldName || field.dingtalkFieldName || field.name,
       description: config?.description || field.description || '',
       internalKey: config?.internalKey || field.internalKey || field.code,
+      ...formulaConfig,
       recordId: config?.recordId || null,
       configured: Boolean(config),
       systemDefined: true,
@@ -823,20 +1079,23 @@ function mergeAttendanceReportFieldDefinitions(configRecords, fieldIds) {
 
   for (const config of configsByCode.values()) {
     if (systemCodes.has(config.code)) continue
+    if (ATTENDANCE_REPORT_FORMULA_RESERVED_CODES.has(config.code)) continue
     items.push({
       ...config,
+      ...normalizeAttendanceReportFormulaConfig(config, config.unit),
       configured: true,
       systemDefined: false,
     })
   }
 
-  return items.sort((left, right) => {
+  const sorted = items.sort((left, right) => {
     const leftCategory = categories.get(left.category)?.sortOrder ?? 999
     const rightCategory = categories.get(right.category)?.sortOrder ?? 999
     if (leftCategory !== rightCategory) return leftCategory - rightCategory
     if (left.sortOrder !== right.sortOrder) return left.sortOrder - right.sortOrder
     return left.code.localeCompare(right.code)
   })
+  return applyAttendanceReportFormulaValidation(sorted)
 }
 
 async function seedAttendanceReportFieldCatalogRecords(multitable, sheetId, fieldIds, logger) {
@@ -1143,7 +1402,7 @@ function resolveAttendanceRecordReportFields(items) {
       field
       && field.enabled !== false
       && field.reportVisible !== false
-      && ATTENDANCE_RECORD_REPORT_FIELD_CODE_SET.has(field.code)
+      && (ATTENDANCE_RECORD_REPORT_FIELD_CODE_SET.has(field.code) || field.formulaEnabled === true)
     ))
     .map(field => ({
       code: field.code,
@@ -1156,6 +1415,13 @@ function resolveAttendanceRecordReportFields(items) {
       description: field.description || '',
       systemDefined: field.systemDefined !== false,
       configured: Boolean(field.configured),
+      formulaEnabled: Boolean(field.formulaEnabled),
+      formulaExpression: field.formulaExpression || '',
+      formulaScope: normalizeAttendanceReportFormulaScope(field.formulaScope),
+      formulaOutputType: normalizeAttendanceReportFormulaOutputType(field.formulaOutputType, field.unit),
+      formulaValid: field.formulaValid !== false,
+      formulaError: field.formulaError || null,
+      formulaReferences: Array.isArray(field.formulaReferences) ? field.formulaReferences : [],
       exportKey: field.code,
     }))
     .sort((left, right) => {
@@ -1164,10 +1430,30 @@ function resolveAttendanceRecordReportFields(items) {
     })
 }
 
+function resolveAttendanceFormulaSourceFields(items) {
+  const sourceItems = Array.isArray(items) && items.length > 0
+    ? items
+    : mergeAttendanceReportFieldDefinitions([], {})
+  return sourceItems
+    .filter(field => (
+      field
+      && field.code
+      && field.enabled !== false
+      && field.formulaEnabled !== true
+      && field.systemDefined !== false
+    ))
+    .map(field => ({
+      code: field.code,
+      source: field.source || 'system',
+      systemDefined: true,
+    }))
+}
+
 async function loadAttendanceRecordReportFields(context, orgId, logger) {
   const catalog = await buildAttendanceReportFieldCatalogResponse(context, orgId, logger, { provision: false })
   return {
     fields: resolveAttendanceRecordReportFields(catalog.items),
+    formulaSourceFields: resolveAttendanceFormulaSourceFields(catalog.items),
     multitable: catalog.multitable,
   }
 }
@@ -1184,6 +1470,11 @@ function buildAttendanceReportFieldConfigFingerprint(fields) {
         source: String(field?.source || ''),
         configured: Boolean(field?.configured),
         systemDefined: field?.systemDefined !== false,
+        formulaEnabled: Boolean(field?.formulaEnabled),
+        formulaExpression: String(field?.formulaExpression || ''),
+        formulaScope: String(field?.formulaScope || ''),
+        formulaOutputType: String(field?.formulaOutputType || ''),
+        formulaValid: field?.formulaValid !== false,
       }))
       .filter(field => field.code)
       .sort((left, right) => {
@@ -1367,11 +1658,141 @@ function getAttendanceRecordReportFieldValue(row, fieldCode) {
   }
 }
 
+function attendanceFormulaLiteral(value) {
+  if (value === null || value === undefined || value === '') return '0'
+  if (typeof value === 'number') return Number.isFinite(value) ? String(value) : '0'
+  if (typeof value === 'boolean') return value ? 'TRUE' : 'FALSE'
+  if (value instanceof Date) return JSON.stringify(value.toISOString())
+  const parsed = Number(value)
+  if (Number.isFinite(parsed) && String(value).trim() !== '') return String(parsed)
+  return JSON.stringify(String(value))
+}
+
+function buildAttendanceReportFormulaValueMap(row, formulaSourceFields) {
+  const values = {}
+  for (const field of formulaSourceFields || []) {
+    if (!field?.code) continue
+    values[field.code] = getAttendanceRecordReportFieldValue(row, field.code)
+  }
+  values.work_minutes = Number(row?.work_minutes ?? 0)
+  values.late_minutes = Number(row?.late_minutes ?? 0)
+  values.early_leave_minutes = Number(row?.early_leave_minutes ?? 0)
+  values.leave_minutes = readAttendanceRecordMinutes(row, ['leave_minutes', 'leaveMinutes'], 0)
+  values.overtime_minutes = readAttendanceRecordMinutes(row, ['overtime_minutes', 'overtimeMinutes'], 0)
+  return values
+}
+
+function resolveAttendanceReportFormulaExpression(expression, values) {
+  return normalizeAttendanceReportFormulaExpression(expression)
+    .replace(ATTENDANCE_REPORT_FORMULA_REFERENCE_PATTERN, (_match, reference) => (
+      attendanceFormulaLiteral(Object.prototype.hasOwnProperty.call(values, reference) ? values[reference] : 0)
+    ))
+}
+
+function formatAttendanceReportFormulaValue(value, outputType) {
+  if (typeof value === 'string' && value.startsWith('#')) return ATTENDANCE_REPORT_FORMULA_ERROR_VALUE
+  const type = normalizeAttendanceReportFormulaOutputType(outputType)
+  if (type === 'number' || type === 'duration_minutes') {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : ATTENDANCE_REPORT_FORMULA_ERROR_VALUE
+  }
+  if (type === 'boolean') return Boolean(value)
+  if (type === 'date') {
+    if (value instanceof Date) return value.toISOString()
+    return String(value ?? '')
+  }
+  return value === null || value === undefined ? '' : String(value)
+}
+
+async function evaluateAttendanceReportFormulaField(context, row, field, formulaSourceFields) {
+  if (!field?.formulaEnabled) return getAttendanceRecordReportFieldValue(row, field?.code)
+  if (field.formulaValid === false) return ATTENDANCE_REPORT_FORMULA_ERROR_VALUE
+
+  const values = buildAttendanceReportFormulaValueMap(row, formulaSourceFields)
+  const expression = resolveAttendanceReportFormulaExpression(field.formulaExpression, values)
+  const formulaApi = context?.api?.formula
+  if (!formulaApi?.calculateFormula) return ATTENDANCE_REPORT_FORMULA_ERROR_VALUE
+
+  try {
+    const result = await Promise.resolve(formulaApi.calculateFormula(expression))
+    return formatAttendanceReportFormulaValue(result, field.formulaOutputType)
+  } catch {
+    return ATTENDANCE_REPORT_FORMULA_ERROR_VALUE
+  }
+}
+
+async function previewAttendanceReportFormula(context, expression, sample, fields) {
+  const sampleValues = sample && typeof sample === 'object' && !Array.isArray(sample) ? sample : {}
+  const validation = validateAttendanceReportFormulaExpression(expression, { fields })
+  if (!validation.valid) {
+    return {
+      ok: false,
+      value: null,
+      references: validation.references,
+      error: validation.error,
+    }
+  }
+
+  const values = {}
+  for (const reference of validation.references) {
+    values[reference] = Object.prototype.hasOwnProperty.call(sampleValues, reference)
+      ? sampleValues[reference]
+      : 0
+  }
+  const resolvedExpression = resolveAttendanceReportFormulaExpression(expression, values)
+  const formulaApi = context?.api?.formula
+  if (!formulaApi?.calculateFormula) {
+    return {
+      ok: false,
+      value: null,
+      references: validation.references,
+      error: 'Formula API is unavailable.',
+    }
+  }
+
+  try {
+    const value = await Promise.resolve(formulaApi.calculateFormula(resolvedExpression))
+    if (typeof value === 'string' && value.startsWith('#')) {
+      return {
+        ok: false,
+        value: ATTENDANCE_REPORT_FORMULA_ERROR_VALUE,
+        references: validation.references,
+        error: 'Formula evaluation failed.',
+      }
+    }
+    return {
+      ok: true,
+      value,
+      references: validation.references,
+      error: null,
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      value: null,
+      references: validation.references,
+      error: error instanceof Error ? error.message : 'Formula evaluation failed.',
+    }
+  }
+}
+
 function buildAttendanceRecordReportExportItem(row, reportFields) {
   return Object.fromEntries(reportFields.map(field => [
     field.exportKey || field.code,
     getAttendanceRecordReportFieldValue(row, field.code),
   ]))
+}
+
+async function buildAttendanceRecordReportExportItemAsync(context, row, reportFields, formulaSourceFields) {
+  const entries = []
+  for (const field of reportFields || []) {
+    const key = field.exportKey || field.code
+    const value = field.formulaEnabled
+      ? await evaluateAttendanceReportFormulaField(context, row, field, formulaSourceFields)
+      : getAttendanceRecordReportFieldValue(row, field.code)
+    entries.push([key, value])
+  }
+  return Object.fromEntries(entries)
 }
 
 function findImportProfile(profileId) {
@@ -8306,7 +8727,11 @@ module.exports = {
     loadAttendanceReportFieldCatalog,
     mergeAttendanceReportFieldDefinitions,
     resolveAttendanceRecordReportFields,
+    resolveAttendanceFormulaSourceFields,
+    validateAttendanceReportFormulaExpression,
+    previewAttendanceReportFormula,
     buildAttendanceRecordReportExportItem,
+    buildAttendanceRecordReportExportItemAsync,
     buildAttendanceRecordReportCsv,
     buildAttendanceReportFieldConfig,
     buildAttendanceReportFieldConfigHeaders,
@@ -11072,7 +11497,7 @@ module.exports = {
           })
           const approvedMap = await loadApprovedMinutesRange(db, orgId, targetUserId, from, to)
           const reportFields = await loadAttendanceRecordReportFields(context, orgId, logger)
-          const records = rows.map((row) => {
+          const records = await Promise.all(rows.map(async (row) => {
             const workDate = normalizeDateOnly(row.work_date) ?? String(row.work_date ?? '').slice(0, 10)
             const meta = normalizeMetadata(row.meta)
             const approved = approvedMap.get(workDate) ?? { leaveMinutes: 0, overtimeMinutes: 0 }
@@ -11083,7 +11508,7 @@ module.exports = {
               defaultRule: workContextPrefetch.defaultRule,
               prefetched: workContextPrefetch.prefetched,
             })
-            return {
+            const record = {
               ...row,
               work_date: workDate,
               workday_context: buildWorkdayContextSummary({
@@ -11097,7 +11522,11 @@ module.exports = {
                 overtime_minutes: approved.overtimeMinutes,
               },
             }
-          })
+            return {
+              ...record,
+              report_values: await buildAttendanceRecordReportExportItemAsync(context, record, reportFields.fields, reportFields.formulaSourceFields),
+            }
+          }))
 
 			          res.json({
 			            ok: true,
@@ -20314,6 +20743,31 @@ module.exports = {
     )
 
     context.api.http.addRoute(
+      'POST',
+      '/api/attendance/report-fields/formula/preview',
+      withPermission('attendance:admin', async (req, res) => {
+        const parsed = z.object({
+          expression: z.string().min(1).max(4000),
+          sample: z.record(z.unknown()).optional(),
+        }).safeParse(req.body ?? {})
+        if (!parsed.success) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
+          return
+        }
+
+        const orgId = getOrgId(req)
+        const catalog = await buildAttendanceReportFieldCatalogResponse(context, orgId, logger, { provision: false })
+        const data = await previewAttendanceReportFormula(
+          context,
+          parsed.data.expression,
+          parsed.data.sample,
+          catalog.items,
+        )
+        res.json({ ok: true, data })
+      })
+    )
+
+    context.api.http.addRoute(
       'GET',
       '/api/attendance/settings',
       withPermission('attendance:admin', async (_req, res) => {
@@ -20444,7 +20898,9 @@ module.exports = {
               },
             }
           })
-          const exportItems = exportRows.map(row => buildAttendanceRecordReportExportItem(row, reportFields.fields))
+          const exportItems = await Promise.all(
+            exportRows.map(row => buildAttendanceRecordReportExportItemAsync(context, row, reportFields.fields, reportFields.formulaSourceFields)),
+          )
           const reportFieldConfig = buildAttendanceReportFieldConfig(reportFields)
           if (parsed.data.format === 'json') {
             emitEvent('attendance.exported', {

--- a/scripts/ops/attendance-report-fields-live-acceptance.mjs
+++ b/scripts/ops/attendance-report-fields-live-acceptance.mjs
@@ -77,6 +77,7 @@ export function parseConfig(env = process.env, now = new Date()) {
     to: String(env.TO_DATE || env.TO || range.to).trim(),
     expectVisibleCode: String(env.EXPECT_VISIBLE_CODE || 'work_date').trim(),
     expectHiddenCode: String(env.EXPECT_HIDDEN_CODE || '').trim(),
+    expectFormulaCode: String(env.EXPECT_FORMULA_CODE || '').trim(),
     devUserId: String(env.DEV_USER_ID || 'dev-admin').trim(),
     outputDir,
     reportPath: String(env.REPORT_JSON || path.join(outputDir, 'report.json')),
@@ -134,6 +135,7 @@ function createReport(config) {
     to: config.to,
     expectedVisibleCode: config.expectVisibleCode || 'not-set',
     expectedHiddenCode: config.expectHiddenCode || 'not-set',
+    expectedFormulaCode: config.expectFormulaCode || 'not-set',
     reportPath: path.resolve(config.reportPath),
     reportMdPath: path.resolve(config.reportMdPath),
     startedAt: new Date().toISOString(),
@@ -403,6 +405,23 @@ function visibilityDetails(fields, config) {
   }
 }
 
+function formulaDetails(fields, config) {
+  const formulas = Array.isArray(fields)
+    ? fields.filter(field => field?.formulaEnabled === true)
+    : []
+  const codes = extractFieldCodes(formulas)
+  const expectedFormulaCode = config.expectFormulaCode || ''
+  return {
+    codes,
+    expectedFormulaCode: expectedFormulaCode || 'not-set',
+    expectedOk: !expectedFormulaCode || codes.includes(expectedFormulaCode),
+    invalidCodes: formulas
+      .filter(field => field?.formulaValid === false)
+      .map(field => String(field?.code || ''))
+      .filter(Boolean),
+  }
+}
+
 function exportedKeys(items) {
   if (!Array.isArray(items) || !items[0] || typeof items[0] !== 'object') return []
   return Object.keys(items[0])
@@ -582,6 +601,7 @@ export function renderHelp() {
     '  TO_DATE=2026-05-13',
     '  EXPECT_VISIBLE_CODE=work_date',
     '  EXPECT_HIDDEN_CODE=<field_code>',
+    '  EXPECT_FORMULA_CODE=<formula_field_code>',
     '  AUTH_SOURCE=AUTH_TOKEN|AUTH_TOKEN_FILE|ALLOW_DEV_TOKEN',
     '  OUTPUT_DIR=output/attendance-report-fields-live-acceptance/<run>',
     '',
@@ -610,6 +630,9 @@ const MARKDOWN_CHECK_DETAIL_KEYS = Object.freeze([
   'present',
   'ignored',
   'requested',
+  'code',
+  'codes',
+  'invalidCodes',
 ])
 
 function formatMarkdownInlineValue(value) {
@@ -644,6 +667,8 @@ const EVIDENCE_SUMMARY_METADATA_KEYS = Object.freeze([
   ['CSV field count', 'csvFieldCount'],
   ['CSV field codes', 'csvFieldCodes'],
   ['CSV code field codes', 'csvCodeFieldCodes'],
+  ['Formula field codes', 'formulaFieldCodes'],
+  ['Formula invalid codes', 'formulaInvalidCodes'],
   ['CSV backing', 'csvBacking'],
   ['CSV code backing', 'csvCodeBacking'],
 ])
@@ -682,6 +707,7 @@ export function renderAcceptanceMarkdown(report) {
     `- Date range: \`${report?.from || 'missing'}..${report?.to || 'missing'}\``,
     `- Expected visible field: \`${report?.expectedVisibleCode || 'not-set'}\``,
     `- Expected hidden field: \`${report?.expectedHiddenCode || 'not-set'}\``,
+    `- Expected formula field: \`${report?.expectedFormulaCode || 'not-set'}\``,
     `- Started at: \`${report?.startedAt || 'missing'}\``,
     `- Finished at: \`${report?.finishedAt || 'missing'}\``,
     `- JSON report: \`${report?.reportPath || 'missing'}\``,
@@ -846,6 +872,15 @@ export async function runAttendanceReportFieldsAcceptance(config) {
       code: catalogVisibility.expectedHiddenCode,
       skipped: !config.expectHiddenCode,
     })
+    const catalogFormula = formulaDetails(catalogData.items, config)
+    record('catalog.formula-field.expected', catalogFormula.expectedOk, {
+      code: catalogFormula.expectedFormulaCode,
+      codes: catalogFormula.codes.join(','),
+      skipped: !config.expectFormulaCode,
+    })
+    record('catalog.formula-fields.valid', catalogFormula.invalidCodes.length === 0, {
+      invalidCodes: catalogFormula.invalidCodes.join(',') || 'none',
+    })
 
     const recordsQuery = buildQuery(config, {
       from: config.from,
@@ -868,6 +903,12 @@ export async function runAttendanceReportFieldsAcceptance(config) {
     record('records.report-fields.expected-hidden', recordVisibility.hiddenOk, {
       code: recordVisibility.expectedHiddenCode,
       skipped: !config.expectHiddenCode,
+    })
+    const recordsFormula = formulaDetails(recordsData.reportFields, config)
+    record('records.report-fields.formula-expected', recordsFormula.expectedOk, {
+      code: recordsFormula.expectedFormulaCode,
+      codes: recordsFormula.codes.join(','),
+      skipped: !config.expectFormulaCode,
     })
 
     const exportQuery = buildQuery(config, {
@@ -892,6 +933,12 @@ export async function runAttendanceReportFieldsAcceptance(config) {
     record('export.report-fields.expected-hidden', exportVisibility.hiddenOk, {
       code: exportVisibility.expectedHiddenCode,
       skipped: !config.expectHiddenCode,
+    })
+    const exportFormula = formulaDetails(exportData.reportFields, config)
+    record('export.report-fields.formula-expected', exportFormula.expectedOk, {
+      code: exportFormula.expectedFormulaCode,
+      codes: exportFormula.codes.join(','),
+      skipped: !config.expectFormulaCode,
     })
 
     const recordCodes = extractFieldCodes(recordsData.reportFields)
@@ -951,6 +998,8 @@ export async function runAttendanceReportFieldsAcceptance(config) {
     report.metadata.recordsTotal = recordsData.total ?? 0
     report.metadata.exportTotal = exportData.total ?? 0
     report.metadata.exportSampleKeys = exportedKeys(exportData.items).join(',')
+    report.metadata.formulaFieldCodes = exportFormula.codes.join(',')
+    report.metadata.formulaInvalidCodes = catalogFormula.invalidCodes.join(',')
 
     const csvQuery = buildQuery(config, {
       from: config.from,

--- a/scripts/ops/attendance-report-fields-live-acceptance.test.mjs
+++ b/scripts/ops/attendance-report-fields-live-acceptance.test.mjs
@@ -36,6 +36,19 @@ const reportFields = [
   { code: 'work_date', name: '日期', category: 'fixed', reportVisible: true, exportKey: 'work_date' },
   { code: 'employee_name', name: '姓名', category: 'fixed', reportVisible: true, exportKey: 'employee_name' },
   { code: 'late_minutes', name: '迟到时长', category: 'anomaly', reportVisible: true, exportKey: 'late_minutes' },
+  {
+    code: 'net_work_minutes',
+    name: '净工作时长',
+    category: 'attendance',
+    reportVisible: true,
+    exportKey: 'net_work_minutes',
+    formulaEnabled: true,
+    formulaExpression: '={work_minutes}-{late_minutes}',
+    formulaScope: 'record',
+    formulaOutputType: 'duration_minutes',
+    formulaValid: true,
+    formulaError: null,
+  },
 ]
 
 function reportFieldConfigPayload() {
@@ -141,17 +154,17 @@ async function startMockServer() {
     if (url.pathname === '/api/attendance/export') {
       if (url.searchParams.get('format') === 'csv') {
         if (url.searchParams.get('header') === 'code') {
-          sendText(res, 200, 'work_date,employee_name,late_minutes\n2026-05-13,Admin,0\n', 'text/csv; charset=utf-8', csvReportFieldHeaders())
+          sendText(res, 200, 'work_date,employee_name,late_minutes,net_work_minutes\n2026-05-13,Admin,0,480\n', 'text/csv; charset=utf-8', csvReportFieldHeaders())
           return
         }
-        sendText(res, 200, '日期,姓名,迟到时长\n2026-05-13,Admin,0\n', 'text/csv; charset=utf-8', csvReportFieldHeaders())
+        sendText(res, 200, '日期,姓名,迟到时长,净工作时长\n2026-05-13,Admin,0,480\n', 'text/csv; charset=utf-8', csvReportFieldHeaders())
         return
       }
       send(res, 200, {
         ok: true,
         success: true,
         data: {
-          items: [{ work_date: '2026-05-13', employee_name: 'Admin', late_minutes: 0 }],
+          items: [{ work_date: '2026-05-13', employee_name: 'Admin', late_minutes: 0, net_work_minutes: 480 }],
           total: 1,
           format: 'json',
           reportFields,
@@ -327,9 +340,11 @@ test('renderAcceptanceMarkdown summarizes checks without leaking auth material',
       exportFieldFingerprint: 'unit-test-fingerprint',
       csvFieldFingerprint: 'unit-test-fingerprint',
       csvCodeFieldFingerprint: 'unit-test-fingerprint',
-      csvFieldCount: 3,
-      csvFieldCodes: 'work_date,employee_name,late_minutes',
-      csvCodeFieldCodes: 'work_date,employee_name,late_minutes',
+      csvFieldCount: 4,
+      csvFieldCodes: 'work_date,employee_name,late_minutes,net_work_minutes',
+      csvCodeFieldCodes: 'work_date,employee_name,late_minutes,net_work_minutes',
+      formulaFieldCodes: 'net_work_minutes',
+      formulaInvalidCodes: '',
       csvBacking: 'default:attendance|attendance_report_field_catalog|sheet_attendance_report_fields|fields_by_category',
       csvCodeBacking: 'default:attendance|attendance_report_field_catalog|sheet_attendance_report_fields|fields_by_category',
     },
@@ -364,7 +379,8 @@ test('renderAcceptanceMarkdown summarizes checks without leaking auth material',
   assert.match(markdown, /export: `unit-test-fingerprint`/)
   assert.match(markdown, /algorithm: `sha1`/)
   assert.match(markdown, /## Evidence Summary/)
-  assert.ok(markdown.includes('- CSV field codes: `work_date,employee_name,late_minutes`'))
+  assert.ok(markdown.includes('- CSV field codes: `work_date,employee_name,late_minutes,net_work_minutes`'))
+  assert.ok(markdown.includes('- Formula field codes: `net_work_minutes`'))
   assert.ok(markdown.includes('- CSV backing: `default:attendance|attendance_report_field_catalog|sheet_attendance_report_fields|fields_by_category`'))
   assert.ok(markdown.includes('- CSV code backing: `default:attendance|attendance_report_field_catalog|sheet_attendance_report_fields|fields_by_category`'))
   assert.match(markdown, /## Next Actions/)
@@ -375,6 +391,7 @@ test('renderAcceptanceMarkdown summarizes checks without leaking auth material',
 test('renderHelp documents preflight and live-mode configuration', () => {
   const help = renderHelp()
   assert.match(help, /AUTH_TOKEN=<token>, AUTH_TOKEN_FILE=<path>, or ALLOW_DEV_TOKEN=1/)
+  assert.match(help, /EXPECT_FORMULA_CODE=<formula_field_code>/)
   assert.match(help, /AUTH_SOURCE=AUTH_TOKEN\|AUTH_TOKEN_FILE\|ALLOW_DEV_TOKEN/)
   assert.match(help, /CONFIRM_SYNC=1/)
   assert.match(help, /API_HOST_HEADER=localhost/)
@@ -548,6 +565,7 @@ test('runAttendanceReportFieldsAcceptance verifies catalog, records, export, and
       ORG_ID: 'default',
       FROM_DATE: '2026-05-01',
       TO_DATE: '2026-05-13',
+      EXPECT_FORMULA_CODE: 'net_work_minutes',
       OUTPUT_DIR: outputDir,
     }))
 
@@ -577,6 +595,10 @@ test('runAttendanceReportFieldsAcceptance verifies catalog, records, export, and
       && check.details.source === 'AUTH_TOKEN_FILE'
     )))
     assert.ok(report.checks.some((check) => check.name === 'catalog.required-categories' && check.ok))
+    assert.ok(report.checks.some((check) => check.name === 'catalog.formula-field.expected' && check.ok))
+    assert.ok(report.checks.some((check) => check.name === 'catalog.formula-fields.valid' && check.ok))
+    assert.ok(report.checks.some((check) => check.name === 'records.report-fields.formula-expected' && check.ok))
+    assert.ok(report.checks.some((check) => check.name === 'export.report-fields.formula-expected' && check.ok))
     assert.ok(report.checks.some((check) => check.name === 'records-export.report-field-codes-match' && check.ok))
     assert.ok(report.checks.some((check) => check.name === 'records-export.report-field-config-match' && check.ok))
     assert.ok(report.checks.some((check) => check.name === 'catalog-records.report-field-fingerprint-match' && check.ok))
@@ -598,15 +620,17 @@ test('runAttendanceReportFieldsAcceptance verifies catalog, records, export, and
     assert.equal(report.metadata.catalogFieldFingerprint, 'unit-test-report-fields-fingerprint')
     assert.equal(report.metadata.recordsFieldFingerprint, 'unit-test-report-fields-fingerprint')
     assert.equal(report.metadata.exportFieldFingerprint, 'unit-test-report-fields-fingerprint')
-    assert.equal(report.metadata.csvHeader, '日期,姓名,迟到时长')
+    assert.equal(report.metadata.csvHeader, '日期,姓名,迟到时长,净工作时长')
     assert.equal(report.metadata.csvFieldFingerprint, 'unit-test-report-fields-fingerprint')
     assert.equal(report.metadata.csvFieldFingerprintAlgorithm, 'sha1')
     assert.equal(report.metadata.csvFieldCount, reportFields.length)
-    assert.equal(report.metadata.csvFieldCodes, 'work_date,employee_name,late_minutes')
+    assert.equal(report.metadata.csvFieldCodes, 'work_date,employee_name,late_minutes,net_work_minutes')
     assert.equal(report.metadata.csvBacking, 'default:attendance|attendance_report_field_catalog|sheet_attendance_report_fields|fields_by_category')
-    assert.equal(report.metadata.csvCodeHeader, 'work_date,employee_name,late_minutes')
+    assert.equal(report.metadata.csvCodeHeader, 'work_date,employee_name,late_minutes,net_work_minutes')
     assert.equal(report.metadata.csvCodeFieldFingerprint, 'unit-test-report-fields-fingerprint')
-    assert.equal(report.metadata.csvCodeFieldCodes, 'work_date,employee_name,late_minutes')
+    assert.equal(report.metadata.csvCodeFieldCodes, 'work_date,employee_name,late_minutes,net_work_minutes')
+    assert.equal(report.metadata.formulaFieldCodes, 'net_work_minutes')
+    assert.equal(report.metadata.formulaInvalidCodes, '')
     assert.equal(report.metadata.csvCodeBacking, 'default:attendance|attendance_report_field_catalog|sheet_attendance_report_fields|fields_by_category')
     assert.ok(server.calls.includes('POST /api/attendance/report-fields/sync'))
     assert.ok(server.calls.includes('GET /api/attendance/records'))
@@ -615,7 +639,8 @@ test('runAttendanceReportFieldsAcceptance verifies catalog, records, export, and
     assert.ok(fs.existsSync(path.join(outputDir, 'report.md')))
     const markdown = fs.readFileSync(path.join(outputDir, 'report.md'), 'utf8')
     assert.match(markdown, /## Evidence Summary/)
-    assert.ok(markdown.includes('- CSV field codes: `work_date,employee_name,late_minutes`'))
+    assert.ok(markdown.includes('- CSV field codes: `work_date,employee_name,late_minutes,net_work_minutes`'))
+    assert.ok(markdown.includes('- Formula field codes: `net_work_minutes`'))
     assert.ok(markdown.includes('- CSV backing: `default:attendance|attendance_report_field_catalog|sheet_attendance_report_fields|fields_by_category`'))
     assert.ok(markdown.includes('- CSV code backing: `default:attendance|attendance_report_field_catalog|sheet_attendance_report_fields|fields_by_category`'))
     assert.match(markdown, /Auth source: `AUTH_TOKEN_FILE`/)


### PR DESCRIPTION
## Summary

Adds **record-scope formula fields** to attendance reports, layered on the existing field catalog (no `attendance_*` migration, no direct `meta_*` writes).

**Implementation**:
- Field catalog descriptor extends with `formula_enabled` / `formula_expression` / `formula_scope` / `formula_output_type`
- Formula wrapper: `{field_code}` parser, function whitelist (29 functions: `IF` / `AND` / `OR` / `NOT` / `ROUND` / `CEILING` / `FLOOR` / `ABS` / `MIN` / `MAX` / `SUM` / `AVERAGE` / `COUNT` / `COUNTA` / `DATEDIF` / `DATEDIFF` / `DATE` / `YEAR` / `MONTH` / `DAY` / `CONCAT` / `CONCATENATE` / `LEFT` / `RIGHT` / `MID` / `LEN` / `TRIM` / `UPPER` / `LOWER`), `#ERROR!` envelope, cell-ref rejection (`A1` / `A1:B2`), sample-key isolation, source filter restricted to `systemDefined`, raw alias reservation (dual-layer merge + validator defense)
- Two field sets cleanly separated: `outputFields` (display, gated by `enabled + reportVisible`) vs `formulaSourceFields` (computation, gated by `enabled` only — hidden fields still resolvable)
- `POST /api/attendance/report-fields/formula/preview` endpoint
- Records + JSON/CSV export integrate formula values via `report_values`; field fingerprint covers formula metadata
- Frontend formula column with expression / scope / output type / references / errors

**Contract**: 6-row field state semantics matrix (see `docs/development/attendance-dingtalk-formula-hardening-development-20260515.md`). Raw aliases (`work_minutes` / `late_minutes` / `early_leave_minutes` / `leave_minutes` / `overtime_minutes`) are reserved — catalog fields cannot shadow them.

## Test plan

- [x] Backend unit: 20 tests (7 catalog + 13 formula) green
- [x] Frontend spec: 14 tests (3 report fields + 11 admin regression) green
- [x] Live acceptance mock harness: 17 tests green (`node --test` + `pnpm run verify:attendance-report-fields:live:test`)
- [x] Web type-check (`vue-tsc -b`) + core-backend build: green
- [x] `git diff --cached --check` whitespace + secret scan (JWT / private keys / `AUTH_TOKEN=` / `sk-*` / Bearer header / home paths): clean
- [x] **Real staging live acceptance: 48 checks PASS** against staging (sha1 fingerprint `d7f0d741…` consistent across catalog / records / JSON export / CSV label / CSV code header views)
- [ ] *(Bonus, not blocking)* Admin seeds one formula field via UI on staging, reruns with `EXPECT_FORMULA_CODE=<code>` to validate formula evaluation end-to-end

## Known follow-up (P2)

- Custom non-formula fields as formula sources (v1 explicitly rejects; v2 designs `row.meta[code]` / `internalKey` / alias resolution layer)
- Global `attendance.formula.allowRawAliases` env / config for raw alias gating (do NOT reuse stat field `enabled`)
- Reserved-code shadow UI feedback — surface `droppedReservedCodes` in catalog response
- DingTalk punch-time / punch-result 6-field split (上班 1/2/3 + 下班 1/2/3)
- Inline formula editor + function reference panel
- Formula dependency graph + cycle detection
- Period-aggregate formula
- Leave / overtime subtype split
- Salary period template integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)