### PR TITLE
test(integration): surface SQL executor skipped diagnostic

### DIFF
--- a/docs/development/data-factory-sql-executor-signoff-summary-development-20260515.md
+++ b/docs/development/data-factory-sql-executor-signoff-summary-development-20260515.md
@@ -1,0 +1,88 @@
+# Data Factory SQL Executor Signoff Summary Development - 2026-05-15
+
+## Purpose
+
+This slice tightens the operator-facing evidence after the Data Factory
+postdeploy smoke reports a configured K3 WISE SQL Server source without a
+deployed query executor.
+
+The smoke already emits a non-blocking `sqlserver-executor-availability` check.
+Before this change, the GitHub step summary only showed:
+
+```text
+`sqlserver-executor-availability`: `skipped`
+```
+
+That was technically correct but too quiet for deploy operators. It did not
+surface `SQLSERVER_EXECUTOR_MISSING`, the reason text, or the blocked source
+system summary.
+
+## Scope
+
+Changed files:
+
+- `scripts/ops/integration-k3wise-postdeploy-summary.mjs`
+- `scripts/ops/integration-k3wise-postdeploy-summary.test.mjs`
+- `scripts/ops/integration-k3wise-signoff-gate.test.mjs`
+
+This PR intentionally does not implement a real SQL Server executor and does
+not change the K3 WISE integration runtime.
+
+## Behavior
+
+### Summary renderer
+
+`integration-k3wise-postdeploy-summary.mjs` now expands skipped details for the
+specific optional diagnostic:
+
+```text
+`sqlserver-executor-availability`: `skipped`
+    - code: `SQLSERVER_EXECUTOR_MISSING`
+    - reason: `K3 WISE SQL Server source is configured ...`
+    - systemsChecked: `1`
+    - blockedSystems: id: `sys_sql`; name: `K3 SQL Source`; role: `source`; status: `error`
+```
+
+Only this check gets expanded while skipped. This keeps the summary compact for
+ordinary skipped checks while making the advanced SQL-source deployment gap
+visible in PR and deploy evidence.
+
+### Nested detail formatting
+
+`formatDetailValue()` now handles arrays of objects recursively. This is needed
+for `blockedSystems`, which is emitted as an array of sanitized system
+summaries.
+
+Existing string arrays still render the same way, so existing failure details
+remain compatible.
+
+### Signoff gate
+
+The signoff gate behavior is unchanged:
+
+- required authenticated checks must still pass;
+- `summary.fail` must still be `0`;
+- `signoff.internalTrial` must still be `pass`;
+- `sqlserver-executor-availability` remains optional and non-blocking.
+
+A regression test locks this behavior so a skipped optional SQL executor
+diagnostic does not accidentally block staging-to-K3 internal-trial signoff.
+
+## Why this is the right slice
+
+The current deployment state separates two paths:
+
+- staging/multitable source to K3 target is signoff-ready;
+- direct K3 SQL Server source remains an advanced deployment item until the
+  bridge machine injects an allowlisted query executor.
+
+This change makes that split readable in evidence without pretending SQL Server
+source execution is available.
+
+## Deployment Impact
+
+- No database migration.
+- No API contract change.
+- No runtime integration-core behavior change.
+- No secret-bearing output added.
+- Affects only postdeploy evidence rendering and tests.

--- a/docs/development/data-factory-sql-executor-signoff-summary-verification-20260515.md
+++ b/docs/development/data-factory-sql-executor-signoff-summary-verification-20260515.md
@@ -1,0 +1,71 @@
+# Data Factory SQL Executor Signoff Summary Verification - 2026-05-15
+
+## Verification Date
+
+2026-05-15T08:09:50Z
+
+## Commands
+
+```bash
+node --test scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
+node --test scripts/ops/integration-k3wise-signoff-gate.test.mjs
+node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
+git diff --check origin/main...HEAD
+```
+
+## Expected Coverage
+
+### Postdeploy summary renderer
+
+The new test uses authenticated PASS evidence with:
+
+```json
+{
+  "id": "sqlserver-executor-availability",
+  "status": "skipped",
+  "code": "SQLSERVER_EXECUTOR_MISSING",
+  "systemsChecked": 1,
+  "blockedSystems": [
+    {
+      "id": "sys_sql",
+      "name": "K3 SQL Source",
+      "role": "source",
+      "status": "error"
+    }
+  ]
+}
+```
+
+The rendered Markdown must include:
+
+- internal trial signoff remains `PASS`;
+- `sqlserver-executor-availability` remains `skipped`;
+- `SQLSERVER_EXECUTOR_MISSING` is visible;
+- the human reason is visible;
+- `systemsChecked` is visible;
+- the blocked SQL source summary is visible.
+
+### Signoff gate
+
+The new signoff test confirms:
+
+- all required authenticated checks passing still returns exit code `0`;
+- `summary.skipped` can be `1` for the optional SQL executor diagnostic;
+- the signoff reason remains
+  `authenticated postdeploy smoke satisfies internal-trial gate`.
+
+### Smoke regression
+
+The existing postdeploy smoke test suite remains the source of truth for
+emitting the optional diagnostic from real smoke evidence. It is re-run to
+ensure the summary/signoff changes did not drift from the smoke output shape.
+
+## Result
+
+| Command | Result |
+| --- | --- |
+| `node --test scripts/ops/integration-k3wise-postdeploy-summary.test.mjs` | PASS, 16/16 |
+| `node --test scripts/ops/integration-k3wise-signoff-gate.test.mjs` | PASS, 9/9 |
+| `node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs` | PASS, 24/24 |
+
+`git diff --check origin/main...HEAD` is run after this document is written.

--- a/scripts/ops/integration-k3wise-postdeploy-summary.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-summary.mjs
@@ -153,7 +153,9 @@ function renderSignoffLines(evidence, { requireAuthSignoff = false } = {}) {
 function formatDetailValue(value) {
   if (Array.isArray(value)) {
     if (value.length === 0) return markdownInlineCode('none')
-    return value.map((item) => markdownInlineCode(item)).join(', ')
+    return value.map((item) => (
+      item && typeof item === 'object' ? formatDetailValue(item) : markdownInlineCode(item)
+    )).join(', ')
   }
   if (value && typeof value === 'object') {
     const entries = Object.entries(value)
@@ -169,6 +171,22 @@ function summarizeCheckDetails(check) {
   const lines = []
   for (const key of ['missingAdapters', 'invalidAdapters', 'missingRoutes', 'missingFields', 'invalidFields']) {
     const value = details[key]
+    const hasValue = Array.isArray(value)
+      ? value.length > 0
+      : value && typeof value === 'object'
+        ? Object.keys(value).length > 0
+        : value !== undefined && value !== null && value !== ''
+    if (hasValue) lines.push(`    - ${key}: ${formatDetailValue(value)}`)
+  }
+  return lines
+}
+
+function summarizeSkippedCheckDetails(check) {
+  if (check?.id !== 'sqlserver-executor-availability') return []
+
+  const lines = []
+  for (const key of ['code', 'reason', 'systemsChecked', 'blockedSystems']) {
+    const value = check[key]
     const hasValue = Array.isArray(value)
       ? value.length > 0
       : value && typeof value === 'object'
@@ -195,6 +213,8 @@ function renderEvidenceSummary(evidence, options = {}) {
     lines.push(`  - ${markdownInlineCode(check?.id || 'unknown')}: ${markdownInlineCode(check?.status || 'unknown')}`)
     if (check?.status === 'fail') {
       lines.push(...summarizeCheckDetails(check))
+    } else if (check?.status === 'skipped') {
+      lines.push(...summarizeSkippedCheckDetails(check))
     }
   }
   if (checks.length === 0) {
@@ -262,5 +282,6 @@ export {
   renderMissingSummary,
   renderSignoffLines,
   summarizeCheckDetails,
+  summarizeSkippedCheckDetails,
   runCli,
 }

--- a/scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
@@ -69,6 +69,53 @@ test('renders compact pass summary from evidence JSON', async () => {
   }
 })
 
+test('renders skipped SQL executor diagnostic details without failing signoff summary', async () => {
+  const outDir = makeTmpDir()
+  const evidencePath = path.join(outDir, 'evidence.json')
+  try {
+    writeFileSync(evidencePath, `${JSON.stringify({
+      ok: true,
+      baseUrl: 'http://127.0.0.1:8081',
+      authenticated: true,
+      signoff: {
+        internalTrial: 'pass',
+        reason: 'authenticated smoke passed',
+      },
+      summary: { pass: 10, skipped: 1, fail: 0 },
+      checks: [
+        { id: 'api-health', status: 'pass' },
+        {
+          id: 'sqlserver-executor-availability',
+          status: 'skipped',
+          code: 'SQLSERVER_EXECUTOR_MISSING',
+          reason: 'K3 WISE SQL Server source is configured but the deployment has not injected the allowlisted queryExecutor; staging-to-K3 smoke signoff can still pass.',
+          systemsChecked: 1,
+          blockedSystems: [
+            {
+              id: 'sys_sql',
+              name: 'K3 SQL Source',
+              role: 'source',
+              status: 'error',
+            },
+          ],
+        },
+      ],
+    })}\n`)
+
+    const result = await runScript(['--input', evidencePath, '--require-auth-signoff'])
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stdout, /Internal trial signoff: \*\*PASS\*\*/)
+    assert.match(result.stdout, /`sqlserver-executor-availability`: `skipped`/)
+    assert.match(result.stdout, /code: `SQLSERVER_EXECUTOR_MISSING`/)
+    assert.match(result.stdout, /reason: `K3 WISE SQL Server source is configured but the deployment has not injected the allowlisted queryExecutor; staging-to-K3 smoke signoff can still pass\.`/)
+    assert.match(result.stdout, /systemsChecked: `1`/)
+    assert.match(result.stdout, /blockedSystems: id: `sys_sql`; name: `K3 SQL Source`; role: `source`; status: `error`/)
+  } finally {
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
 test('renders blocked internal signoff for public-only smoke evidence', async () => {
   const outDir = makeTmpDir()
   const evidencePath = path.join(outDir, 'evidence.json')

--- a/scripts/ops/integration-k3wise-signoff-gate.test.mjs
+++ b/scripts/ops/integration-k3wise-signoff-gate.test.mjs
@@ -89,6 +89,44 @@ test('passes authenticated postdeploy evidence with all required checks', async 
   }
 })
 
+test('passes authenticated postdeploy evidence with skipped optional SQL executor diagnostic', async () => {
+  const outDir = makeTmpDir()
+  try {
+    const evidencePath = writeEvidence(outDir, {
+      checks: [
+        ...requiredPassChecks.map((id) => ({ id, status: 'pass' })),
+        {
+          id: 'sqlserver-executor-availability',
+          status: 'skipped',
+          code: 'SQLSERVER_EXECUTOR_MISSING',
+          reason: 'K3 WISE SQL Server source is configured but the deployment has not injected the allowlisted queryExecutor; staging-to-K3 smoke signoff can still pass.',
+          systemsChecked: 1,
+          blockedSystems: [
+            {
+              id: 'sys_sql',
+              name: 'K3 SQL Source',
+              role: 'source',
+              status: 'error',
+            },
+          ],
+        },
+      ],
+      summary: { pass: requiredPassChecks.length + 3, skipped: 1, fail: 0 },
+    })
+
+    const result = await runScript(['--input', evidencePath])
+
+    assert.equal(result.status, 0, result.stderr)
+    const body = JSON.parse(result.stdout)
+    assert.equal(body.ok, true)
+    assert.equal(body.status, 'PASS')
+    assert.equal(body.summary.skipped, 1)
+    assert.equal(body.reason, 'authenticated postdeploy smoke satisfies internal-trial gate')
+  } finally {
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
 test('blocks public-only evidence even when diagnostic smoke passed', async () => {
   const outDir = makeTmpDir()
   try {


### PR DESCRIPTION
## Summary
- Expand the K3 WISE postdeploy summary for the optional sqlserver-executor-availability skipped diagnostic.
- Surface SQLSERVER_EXECUTOR_MISSING, reason, systemsChecked, and blockedSystems so operators can distinguish advanced SQL-source deployment gaps from staging-to-K3 signoff failures.
- Add a signoff gate regression proving the optional SQL executor diagnostic remains non-blocking when authenticated required checks pass.

## Verification
- node --test scripts/ops/integration-k3wise-postdeploy-summary.test.mjs (16/16)
- node --test scripts/ops/integration-k3wise-signoff-gate.test.mjs (9/9)
- node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs (24/24)
- git diff --check origin/main...HEAD

## Deployment impact
No runtime integration-core behavior change, no DB migration, no API contract change. This is evidence rendering plus regression coverage only.

## Relation to #1580
Independent follow-up while #1580 CI is queued; #1580 packages the bridge-machine handoff docs, this PR improves postdeploy/signoff evidence readability.