### PR TITLE
test(integration): require package evidence in delivery readiness

### DIFF
--- a/docs/development/data-factory-delivery-readiness-evidence-gates-development-20260515.md
+++ b/docs/development/data-factory-delivery-readiness-evidence-gates-development-20260515.md
@@ -1,0 +1,128 @@
+# Data Factory Delivery Readiness Evidence Gates Development - 2026-05-15
+
+## Purpose
+
+The K3 WISE postdeploy smoke can now emit a non-blocking
+`sqlserver-executor-availability` diagnostic when a configured K3 SQL Server
+source exists but the deployment has not injected the allowlisted
+`queryExecutor`.
+
+Before this change, `integration-k3wise-delivery-readiness.mjs` reduced the
+postdeploy smoke evidence to pass/fail plus a summary count. That meant a
+delivery-readiness artifact could say the internal staging-to-K3 trial was
+ready while silently dropping the advanced SQL-source blocker.
+
+This slice carries that diagnostic forward into the final readiness JSON and
+Markdown without changing the readiness decision.
+
+It also adds one missing delivery gate: the readiness compiler can now consume
+the JSON report emitted by `multitable-onprem-package-verify.sh`. Customer-trial
+readiness now requires a verified on-prem package in addition to authenticated
+postdeploy smoke and customer GATE preflight evidence.
+
+## Changed Files
+
+- `scripts/ops/integration-k3wise-delivery-readiness.mjs`
+- `scripts/ops/integration-k3wise-delivery-readiness.test.mjs`
+- `docs/development/data-factory-delivery-readiness-evidence-gates-development-20260515.md`
+- `docs/development/data-factory-delivery-readiness-evidence-gates-verification-20260515.md`
+
+## Behavior
+
+### Package verify gate
+
+`integration-k3wise-delivery-readiness.mjs` accepts:
+
+```bash
+--package-verify <path>
+```
+
+The input is the JSON report written by:
+
+```bash
+VERIFY_REPORT_JSON=<path> scripts/ops/multitable-onprem-package-verify.sh <package.zip-or-tgz>
+```
+
+The new `package-verify` gate passes only when:
+
+- `ok === true`;
+- `checks` is present and non-empty;
+- every emitted check has `status === "PASS"`.
+
+If package verify is missing, the gate is `pending` and the decision can still
+be `INTERNAL_READY_WAITING_CUSTOMER_GATE`, but it cannot advance to
+`CUSTOMER_TRIAL_READY`.
+
+If package verify fails, the overall decision is `BLOCKED`.
+
+### SQL executor diagnostic
+
+When postdeploy smoke includes:
+
+```json
+{
+  "id": "sqlserver-executor-availability",
+  "status": "skipped",
+  "code": "SQLSERVER_EXECUTOR_MISSING"
+}
+```
+
+the postdeploy gate in `integration-k3wise-delivery-readiness.json` now includes:
+
+```json
+{
+  "advancedSqlSource": {
+    "checkId": "sqlserver-executor-availability",
+    "status": "skipped",
+    "code": "SQLSERVER_EXECUTOR_MISSING"
+  }
+}
+```
+
+The Markdown output adds an `Advanced Diagnostics` table with the same high-level
+state.
+
+## Safety Boundary
+
+This does not make SQL Server source execution available. It only preserves the
+existing diagnostic in a later artifact.
+
+The readiness decision remains:
+
+- `INTERNAL_READY_WAITING_CUSTOMER_GATE` when authenticated postdeploy smoke
+  passes but package verify or customer GATE evidence is still pending;
+- `CUSTOMER_TRIAL_READY` only when authenticated postdeploy smoke, package
+  verify, and Save-only preflight packet all pass;
+- not blocked by an optional skipped SQL executor diagnostic;
+- still blocked by real postdeploy failures or unsafe preflight/live evidence.
+
+Only sanitized system summary fields are copied from the smoke check:
+
+- `id`
+- `name`
+- `role`
+- `status`
+
+Connection strings, passwords, and arbitrary source-system config fields are not
+copied into the readiness artifact.
+
+## Why This Is Useful
+
+The operator-facing state now says both truths at the same time:
+
+1. staging/multitable source to K3 target can be internally signed off;
+2. the on-prem package has or has not been verified;
+3. direct SQL Server source remains an advanced bridge-machine deployment task.
+
+That distinction matters when a customer or deploy operator asks whether the
+Data Factory path is ready. The answer is no longer flattened into a confusing
+single green/red result.
+
+## Deployment Impact
+
+- No database migration.
+- No runtime adapter behavior change.
+- Adds one CLI option to an ops script: `--package-verify`.
+- No API contract change.
+- No real SQL executor implementation.
+- Affects only the delivery-readiness evidence compiler and tests.

--- a/docs/development/data-factory-delivery-readiness-evidence-gates-verification-20260515.md
+++ b/docs/development/data-factory-delivery-readiness-evidence-gates-verification-20260515.md
@@ -1,0 +1,87 @@
+# Data Factory Delivery Readiness Evidence Gates Verification - 2026-05-15
+
+## Verification Date
+
+2026-05-15T08:19:51Z
+
+## Commands
+
+```bash
+node --test scripts/ops/integration-k3wise-delivery-readiness.test.mjs
+node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
+git diff --check
+```
+
+## Local Results
+
+| Command | Result |
+| --- | --- |
+| `node --test scripts/ops/integration-k3wise-delivery-readiness.test.mjs` | PASS, 10/10 |
+| `node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs` | PASS, 24/24 |
+
+`git diff --check` is run after this document is written.
+
+## Assertions Added
+
+### Package verify is required for customer trial readiness
+
+The new readiness tests cover:
+
+- package verify PASS plus postdeploy PASS and preflight PASS advances to
+  `CUSTOMER_TRIAL_READY`;
+- package verify missing leaves the decision at
+  `INTERNAL_READY_WAITING_CUSTOMER_GATE`;
+- package verify with a non-PASS check blocks readiness;
+- CLI accepts `--package-verify` and writes JSON/Markdown artifacts.
+
+### SQL executor diagnostic is preserved
+
+The new readiness test feeds authenticated PASS smoke evidence with:
+
+```json
+{
+  "id": "sqlserver-executor-availability",
+  "status": "skipped",
+  "code": "SQLSERVER_EXECUTOR_MISSING",
+  "systemsChecked": 1
+}
+```
+
+Expected result:
+
+- readiness remains `INTERNAL_READY_WAITING_CUSTOMER_GATE`;
+- postdeploy gate remains `pass`;
+- `advancedSqlSource.status` is `skipped`;
+- `advancedSqlSource.code` is `SQLSERVER_EXECUTOR_MISSING`;
+- `advancedSqlSource.systemsChecked` is `1`.
+
+### Secret-bearing fields are not copied
+
+The test fixture deliberately includes an extra blocked-system field:
+
+```text
+rawConnectionString=server=hidden;credential=should-not-copy
+```
+
+Expected result:
+
+- readiness JSON does not include `should-not-copy`;
+- Markdown does not include `should-not-copy`;
+- only `id`, `name`, `role`, and `status` are copied for blocked systems.
+
+### Markdown explains the split state
+
+The Markdown output includes:
+
+- existing gate table;
+- `Advanced Diagnostics` table;
+- `SQLSERVER_EXECUTOR_MISSING` under the postdeploy gate.
+
+## Scope Confirmation
+
+This branch does not:
+
+- implement a real SQL Server executor;
+- change K3 WebAPI Save-only behavior;
+- change customer GATE rules;
+- change production readiness rules.

--- a/scripts/ops/integration-k3wise-delivery-readiness.mjs
+++ b/scripts/ops/integration-k3wise-delivery-readiness.mjs
@@ -8,6 +8,7 @@ const BLOCKED_DECISION = 'BLOCKED'
 const INTERNAL_READY_DECISION = 'INTERNAL_READY_WAITING_CUSTOMER_GATE'
 const CUSTOMER_READY_DECISION = 'CUSTOMER_TRIAL_READY'
 const CUSTOMER_SIGNED_OFF_DECISION = 'CUSTOMER_TRIAL_SIGNED_OFF'
+const SQL_EXECUTOR_CHECK_ID = 'sqlserver-executor-availability'
 
 class K3WiseDeliveryReadinessError extends Error {
   constructor(message, details = {}) {
@@ -36,6 +37,7 @@ function readRequiredValue(argv, index, flag) {
 function parseArgs(argv = process.argv.slice(2)) {
   const opts = {
     postdeploySmoke: '',
+    packageVerify: '',
     preflightPacket: '',
     liveEvidenceReport: '',
     outDir: '',
@@ -48,6 +50,10 @@ function parseArgs(argv = process.argv.slice(2)) {
     switch (arg) {
       case '--postdeploy-smoke':
         opts.postdeploySmoke = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--package-verify':
+        opts.packageVerify = readRequiredValue(argv, i, arg)
         i += 1
         break
       case '--preflight-packet':
@@ -84,6 +90,7 @@ Combines K3 WISE delivery evidence into one readiness decision.
 
 Options:
   --postdeploy-smoke <path>      integration-k3wise-postdeploy-smoke.json
+  --package-verify <path>        multitable-onprem-package-verify report JSON
   --preflight-packet <path>      packet.json from live PoC preflight
   --live-evidence-report <path>  integration-k3wise-live-poc-evidence-report.json
   --out-dir <dir>                Output directory, default ${DEFAULT_OUTPUT_ROOT}/<timestamp>
@@ -99,6 +106,47 @@ function gate(id, label, status, details = {}) {
     status,
     ...details,
   }
+}
+
+function summarizeSystem(system) {
+  if (!isPlainObject(system)) return null
+  return {
+    id: typeof system.id === 'string' ? system.id : null,
+    name: typeof system.name === 'string' ? system.name : null,
+    role: typeof system.role === 'string' ? system.role : null,
+    status: typeof system.status === 'string' ? system.status : null,
+  }
+}
+
+function compactSqlExecutorDiagnostic(evidence) {
+  const checks = Array.isArray(evidence?.checks) ? evidence.checks : []
+  const check = checks.find((item) => item?.id === SQL_EXECUTOR_CHECK_ID)
+  if (!check) return null
+
+  const diagnostic = {
+    checkId: SQL_EXECUTOR_CHECK_ID,
+    status: typeof check.status === 'string' ? check.status : 'unknown',
+  }
+  if (typeof check.code === 'string' && check.code) diagnostic.code = check.code
+  if (typeof check.reason === 'string' && check.reason) diagnostic.reason = check.reason
+  if (Number.isFinite(Number(check.systemsChecked))) diagnostic.systemsChecked = Number(check.systemsChecked)
+
+  const blockedSystems = Array.isArray(check.blockedSystems)
+    ? check.blockedSystems.map(summarizeSystem).filter(Boolean)
+    : []
+  if (blockedSystems.length > 0) diagnostic.blockedSystems = blockedSystems
+
+  const readySystems = Array.isArray(check.readySystems)
+    ? check.readySystems.map(summarizeSystem).filter(Boolean)
+    : []
+  if (readySystems.length > 0) diagnostic.readySystems = readySystems
+
+  return diagnostic
+}
+
+function postdeployDetails(evidence, details = {}) {
+  const sqlExecutor = compactSqlExecutorDiagnostic(evidence)
+  return sqlExecutor ? { ...details, advancedSqlSource: sqlExecutor } : details
 }
 
 function evaluatePostdeploySmoke(evidence) {
@@ -117,22 +165,73 @@ function evaluatePostdeploySmoke(evidence) {
   const authenticated = evidence.authenticated === true
   const signoff = evidence.signoff && typeof evidence.signoff === 'object' ? evidence.signoff : {}
   if (evidence.ok === true && authenticated && signoff.internalTrial === 'pass') {
-    return gate('postdeploy-smoke', 'Deployed MetaSheet K3 WISE smoke', 'pass', {
+    return gate('postdeploy-smoke', 'Deployed MetaSheet K3 WISE smoke', 'pass', postdeployDetails(evidence, {
       reason: signoff.reason || 'authenticated postdeploy smoke passed',
       summary: evidence.summary || {},
-    })
+    }))
   }
   if (evidence.ok === true && authenticated && signoff.internalTrial === undefined) {
-    return gate('postdeploy-smoke', 'Deployed MetaSheet K3 WISE smoke', 'pass', {
+    return gate('postdeploy-smoke', 'Deployed MetaSheet K3 WISE smoke', 'pass', postdeployDetails(evidence, {
       reason: 'authenticated postdeploy smoke passed; legacy evidence has no signoff block',
       summary: evidence.summary || {},
       warning: 'missing signoff.internalTrial in postdeploy evidence',
-    })
+    }))
   }
-  return gate('postdeploy-smoke', 'Deployed MetaSheet K3 WISE smoke', 'fail', {
+  return gate('postdeploy-smoke', 'Deployed MetaSheet K3 WISE smoke', 'fail', postdeployDetails(evidence, {
     reason: signoff.reason || (authenticated ? 'postdeploy smoke did not pass' : 'authenticated checks did not run'),
     authenticated,
     summary: evidence.summary || {},
+  }))
+}
+
+function evaluatePackageVerify(report) {
+  if (!report) {
+    return gate('package-verify', 'On-prem package verification', 'pending', {
+      reason: 'package verify report not provided',
+      requiredFor: CUSTOMER_READY_DECISION,
+    })
+  }
+  if (!isPlainObject(report)) {
+    return gate('package-verify', 'On-prem package verification', 'fail', {
+      reason: 'package verify report must be a JSON object',
+    })
+  }
+
+  const checks = Array.isArray(report.checks) ? report.checks : []
+  const nonPassingChecks = checks
+    .filter((check) => !isPlainObject(check) || check.status !== 'PASS')
+    .map((check) => {
+      if (!isPlainObject(check)) return 'unknown:invalid'
+      return `${check.name || 'unknown'}:${check.status || 'missing'}`
+    })
+
+  if (report.ok !== true) {
+    return gate('package-verify', 'On-prem package verification', 'fail', {
+      reason: 'package verify ok must be true',
+      packageName: report.packageName || null,
+      archiveType: report.archiveType || null,
+    })
+  }
+  if (checks.length === 0) {
+    return gate('package-verify', 'On-prem package verification', 'fail', {
+      reason: 'package verify report must include checks',
+      packageName: report.packageName || null,
+      archiveType: report.archiveType || null,
+    })
+  }
+  if (nonPassingChecks.length > 0) {
+    return gate('package-verify', 'On-prem package verification', 'fail', {
+      reason: `package verify checks not passing: ${nonPassingChecks.join(', ')}`,
+      packageName: report.packageName || null,
+      archiveType: report.archiveType || null,
+    })
+  }
+
+  return gate('package-verify', 'On-prem package verification', 'pass', {
+    reason: 'package verifier passed all checks',
+    packageName: report.packageName || null,
+    archiveType: report.archiveType || null,
+    checkCount: checks.length,
   })
 }
 
@@ -197,14 +296,15 @@ function evaluateLiveEvidenceReport(report) {
 
 function decide(gates) {
   if (gates.some((item) => item.status === 'fail')) return BLOCKED_DECISION
+  const packageVerify = gates.find((item) => item.id === 'package-verify')
   const postdeploy = gates.find((item) => item.id === 'postdeploy-smoke')
   const preflight = gates.find((item) => item.id === 'preflight-packet')
   const live = gates.find((item) => item.id === 'live-evidence')
 
-  if (postdeploy?.status === 'pass' && preflight?.status === 'pass' && live?.status === 'pass') {
+  if (postdeploy?.status === 'pass' && packageVerify?.status === 'pass' && preflight?.status === 'pass' && live?.status === 'pass') {
     return CUSTOMER_SIGNED_OFF_DECISION
   }
-  if (postdeploy?.status === 'pass' && preflight?.status === 'pass') {
+  if (postdeploy?.status === 'pass' && packageVerify?.status === 'pass' && preflight?.status === 'pass') {
     return CUSTOMER_READY_DECISION
   }
   if (postdeploy?.status === 'pass') {
@@ -213,13 +313,22 @@ function decide(gates) {
   return BLOCKED_DECISION
 }
 
-function nextAction(decision) {
+function nextAction(decision, gates = []) {
+  const packageVerify = gates.find((item) => item.id === 'package-verify')
+  const preflight = gates.find((item) => item.id === 'preflight-packet')
+
   switch (decision) {
     case CUSTOMER_SIGNED_OFF_DECISION:
       return 'Customer trial is signed off. Production use still requires customer change approval, backup/rollback confirmation, and an agreed go-live window.'
     case CUSTOMER_READY_DECISION:
       return 'Start the customer K3 WISE test-account live PoC: create systems, run dry-run, run Save-only, compile live evidence.'
     case INTERNAL_READY_DECISION:
+      if (packageVerify?.status === 'pending') {
+        return 'Run the on-prem package verifier and capture its JSON report, then wait for customer GATE answers.'
+      }
+      if (preflight?.status === 'pending') {
+        return 'Wait for customer GATE answers, then run live preflight to produce a preflight-ready packet.'
+      }
       return 'Wait for customer GATE answers, then run live preflight to produce a preflight-ready packet.'
     default:
       return 'Do not start customer live work. Fix failing gates or run the missing internal postdeploy smoke first.'
@@ -229,6 +338,7 @@ function nextAction(decision) {
 function buildReadinessReport(inputs = {}, { generatedAt = new Date().toISOString() } = {}) {
   const gates = [
     evaluatePostdeploySmoke(inputs.postdeploySmoke),
+    evaluatePackageVerify(inputs.packageVerify),
     evaluatePreflightPacket(inputs.preflightPacket),
     evaluateLiveEvidenceReport(inputs.liveEvidenceReport),
   ]
@@ -242,11 +352,14 @@ function buildReadinessReport(inputs = {}, { generatedAt = new Date().toISOStrin
       ready: false,
       reason: 'production go-live requires explicit customer signoff, backup/rollback approval, and a scheduled change window',
     },
-    nextAction: nextAction(decision),
+    nextAction: nextAction(decision, gates),
   }
 }
 
 function renderMarkdown(report) {
+  const advancedDiagnostics = report.gates
+    .map((item) => item.advancedSqlSource ? { gate: item.label, ...item.advancedSqlSource } : null)
+    .filter(Boolean)
   const lines = [
     `# K3 WISE Delivery Readiness - ${report.generatedAt.slice(0, 10)}`,
     '',
@@ -264,6 +377,16 @@ function renderMarkdown(report) {
     ...report.gates.map((item) => `| ${item.label} | ${item.status} | ${item.reason || '-'} |`),
     '',
   ]
+  if (advancedDiagnostics.length > 0) {
+    lines.push(
+      '## Advanced Diagnostics',
+      '',
+      '| Gate | Check | Status | Code | Reason | Systems checked |',
+      '|---|---|---|---|---|---|',
+      ...advancedDiagnostics.map((item) => `| ${item.gate} | ${item.checkId} | ${item.status} | ${item.code || '-'} | ${item.reason || '-'} | ${item.systemsChecked ?? '-'} |`),
+      '',
+    )
+  }
   return `${lines.join('\n')}\n`
 }
 
@@ -295,12 +418,13 @@ async function runCli(argv = process.argv.slice(2)) {
     printHelp()
     return 0
   }
-  const [postdeploySmoke, preflightPacket, liveEvidenceReport] = await Promise.all([
+  const [postdeploySmoke, packageVerify, preflightPacket, liveEvidenceReport] = await Promise.all([
     readJsonFile(opts.postdeploySmoke, 'postdeploy smoke'),
+    readJsonFile(opts.packageVerify, 'package verify'),
     readJsonFile(opts.preflightPacket, 'preflight packet'),
     readJsonFile(opts.liveEvidenceReport, 'live evidence report'),
   ])
-  const report = buildReadinessReport({ postdeploySmoke, preflightPacket, liveEvidenceReport })
+  const report = buildReadinessReport({ postdeploySmoke, packageVerify, preflightPacket, liveEvidenceReport })
   const outDir = path.resolve(opts.outDir || path.join(DEFAULT_OUTPUT_ROOT, nowStamp()))
   await mkdir(outDir, { recursive: true })
   const jsonPath = path.join(outDir, 'integration-k3wise-delivery-readiness.json')
@@ -336,8 +460,10 @@ export {
   INTERNAL_READY_DECISION,
   K3WiseDeliveryReadinessError,
   buildReadinessReport,
+  compactSqlExecutorDiagnostic,
   decide,
   evaluateLiveEvidenceReport,
+  evaluatePackageVerify,
   evaluatePostdeploySmoke,
   evaluatePreflightPacket,
   parseArgs,

--- a/scripts/ops/integration-k3wise-delivery-readiness.test.mjs
+++ b/scripts/ops/integration-k3wise-delivery-readiness.test.mjs
@@ -26,6 +26,45 @@ function postdeployPass() {
   }
 }
 
+function postdeployPassWithSqlExecutorMissing() {
+  return {
+    ...postdeployPass(),
+    summary: { pass: 12, skipped: 1, fail: 0 },
+    checks: [
+      {
+        id: 'sqlserver-executor-availability',
+        status: 'skipped',
+        code: 'SQLSERVER_EXECUTOR_MISSING',
+        reason: 'K3 WISE SQL Server source is configured but the deployment has not injected the allowlisted queryExecutor; staging-to-K3 smoke signoff can still pass.',
+        systemsChecked: 1,
+        blockedSystems: [
+          {
+            id: 'sys_sql',
+              name: 'K3 SQL Source',
+              role: 'source',
+              status: 'error',
+              rawConnectionString: 'server=hidden;credential=should-not-copy',
+            },
+          ],
+        },
+    ],
+  }
+}
+
+function packageVerifyPass(overrides = {}) {
+  return {
+    ok: true,
+    packageName: 'metasheet-multitable-onprem-v2.5.0-k3wise.zip',
+    archiveType: 'zip',
+    checks: [
+      { name: 'checksum', status: 'PASS' },
+      { name: 'required-content', status: 'PASS', requiredCount: 48 },
+      { name: 'no-github-links', status: 'PASS' },
+    ],
+    ...overrides,
+  }
+}
+
 function preflightReadyPacket(overrides = {}) {
   return {
     status: 'preflight-ready',
@@ -60,13 +99,37 @@ test('reports internal readiness after authenticated postdeploy smoke passes', (
 
   assert.equal(report.decision, INTERNAL_READY_DECISION)
   assert.equal(report.gates.find((gate) => gate.id === 'postdeploy-smoke').status, 'pass')
+  assert.equal(report.gates.find((gate) => gate.id === 'package-verify').status, 'pending')
   assert.equal(report.gates.find((gate) => gate.id === 'preflight-packet').status, 'pending')
-  assert.match(report.nextAction, /Wait for customer GATE/)
+  assert.match(report.nextAction, /Run the on-prem package verifier/)
+})
+
+test('carries optional SQL executor diagnostic without blocking readiness', () => {
+  const report = buildReadinessReport({
+    postdeploySmoke: postdeployPassWithSqlExecutorMissing(),
+  }, { generatedAt: '2026-05-06T00:00:00.000Z' })
+
+  assert.equal(report.decision, INTERNAL_READY_DECISION)
+  const postdeploy = report.gates.find((gate) => gate.id === 'postdeploy-smoke')
+  assert.equal(postdeploy.status, 'pass')
+  assert.equal(postdeploy.advancedSqlSource.status, 'skipped')
+  assert.equal(postdeploy.advancedSqlSource.code, 'SQLSERVER_EXECUTOR_MISSING')
+  assert.equal(postdeploy.advancedSqlSource.systemsChecked, 1)
+  assert.deepEqual(postdeploy.advancedSqlSource.blockedSystems, [
+    {
+      id: 'sys_sql',
+      name: 'K3 SQL Source',
+      role: 'source',
+      status: 'error',
+    },
+  ])
+  assert.equal(JSON.stringify(postdeploy).includes('should-not-copy'), false)
 })
 
 test('reports customer trial ready after postdeploy and preflight pass', () => {
   const report = buildReadinessReport({
     postdeploySmoke: postdeployPass(),
+    packageVerify: packageVerifyPass(),
     preflightPacket: preflightReadyPacket(),
   }, { generatedAt: '2026-05-06T00:00:00.000Z' })
 
@@ -78,6 +141,7 @@ test('reports customer trial ready after postdeploy and preflight pass', () => {
 test('reports customer trial signed off after live evidence report passes', () => {
   const report = buildReadinessReport({
     postdeploySmoke: postdeployPass(),
+    packageVerify: packageVerifyPass(),
     preflightPacket: preflightReadyPacket(),
     liveEvidenceReport: liveEvidencePass(),
   }, { generatedAt: '2026-05-06T00:00:00.000Z' })
@@ -90,6 +154,7 @@ test('reports customer trial signed off after live evidence report passes', () =
 test('blocks readiness when preflight packet loses Save-only safety', () => {
   const report = buildReadinessReport({
     postdeploySmoke: postdeployPass(),
+    packageVerify: packageVerifyPass(),
     preflightPacket: preflightReadyPacket({
       safety: {
         saveOnly: true,
@@ -106,9 +171,39 @@ test('blocks readiness when preflight packet loses Save-only safety', () => {
   assert.match(preflight.reason, /autoSubmit must be false/)
 })
 
+test('blocks customer trial readiness when package verify report is failing', () => {
+  const report = buildReadinessReport({
+    postdeploySmoke: postdeployPass(),
+    packageVerify: packageVerifyPass({
+      checks: [
+        { name: 'checksum', status: 'PASS' },
+        { name: 'required-content', status: 'FAIL' },
+      ],
+    }),
+    preflightPacket: preflightReadyPacket(),
+  }, { generatedAt: '2026-05-06T00:00:00.000Z' })
+
+  assert.equal(report.decision, BLOCKED_DECISION)
+  const packageGate = report.gates.find((gate) => gate.id === 'package-verify')
+  assert.equal(packageGate.status, 'fail')
+  assert.match(packageGate.reason, /required-content:FAIL/)
+})
+
+test('keeps customer trial pending until package verify report is provided', () => {
+  const report = buildReadinessReport({
+    postdeploySmoke: postdeployPass(),
+    preflightPacket: preflightReadyPacket(),
+  }, { generatedAt: '2026-05-06T00:00:00.000Z' })
+
+  assert.equal(report.decision, INTERNAL_READY_DECISION)
+  assert.equal(report.gates.find((gate) => gate.id === 'package-verify').status, 'pending')
+  assert.match(report.nextAction, /Run the on-prem package verifier/)
+})
+
 test('blocks readiness when live evidence is partial or failed', () => {
   const report = buildReadinessReport({
     postdeploySmoke: postdeployPass(),
+    packageVerify: packageVerifyPass(),
     preflightPacket: preflightReadyPacket(),
     liveEvidenceReport: {
       decision: 'PARTIAL',
@@ -124,7 +219,8 @@ test('blocks readiness when live evidence is partial or failed', () => {
 
 test('renders markdown gate table and production caveat', () => {
   const report = buildReadinessReport({
-    postdeploySmoke: postdeployPass(),
+    postdeploySmoke: postdeployPassWithSqlExecutorMissing(),
+    packageVerify: packageVerifyPass(),
     preflightPacket: preflightReadyPacket(),
   }, { generatedAt: '2026-05-06T00:00:00.000Z' })
 
@@ -132,22 +228,29 @@ test('renders markdown gate table and production caveat', () => {
 
   assert.match(md, /Readiness: \*\*CUSTOMER_TRIAL_READY\*\*/)
   assert.match(md, /Production use ready: \*\*no\*\*/)
+  assert.match(md, /\| On-prem package verification \| pass \|/)
   assert.match(md, /\| Customer GATE preflight packet \| pass \|/)
+  assert.match(md, /Advanced Diagnostics/)
+  assert.match(md, /SQLSERVER_EXECUTOR_MISSING/)
+  assert.doesNotMatch(md, /should-not-copy/)
 })
 
 test('CLI writes JSON and Markdown readiness artifacts', async () => {
   const outDir = makeTmpDir()
   try {
     const postdeployPath = path.join(outDir, 'postdeploy.json')
+    const packageVerifyPath = path.join(outDir, 'package-verify.json')
     const packetPath = path.join(outDir, 'packet.json')
     const reportPath = path.join(outDir, 'evidence-report.json')
     const readinessOut = path.join(outDir, 'readiness')
     writeFileSync(postdeployPath, `${JSON.stringify(postdeployPass())}\n`)
+    writeFileSync(packageVerifyPath, `${JSON.stringify(packageVerifyPass())}\n`)
     writeFileSync(packetPath, `${JSON.stringify(preflightReadyPacket())}\n`)
     writeFileSync(reportPath, `${JSON.stringify(liveEvidencePass())}\n`)
 
     const code = await runCli([
       '--postdeploy-smoke', postdeployPath,
+      '--package-verify', packageVerifyPath,
       '--preflight-packet', packetPath,
       '--live-evidence-report', reportPath,
       '--out-dir', readinessOut,


### PR DESCRIPTION
## Summary
- Add a package-verify gate to integration-k3wise-delivery-readiness so CUSTOMER_TRIAL_READY requires a verified on-prem package report.
- Preserve the optional sqlserver-executor-availability diagnostic as advancedSqlSource in readiness JSON/Markdown without blocking staging-to-K3 signoff.
- Keep SQL Server direct-source execution explicitly outside this slice.

## Verification
- node --test scripts/ops/integration-k3wise-delivery-readiness.test.mjs (10/10)
- node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs (24/24)
- node --check scripts/ops/integration-k3wise-delivery-readiness.mjs
- git diff --check origin/main...HEAD

## Deployment impact
No DB migration, no adapter/runtime behavior change, no API contract change. Adds one ops-script CLI input: --package-verify.

## Relation to open PRs
Independent of #1580 and #1581: this PR only changes delivery-readiness evidence compilation.