### PR TITLE
feat(directory): connectivity diagnostic summary + sync-run diagnostics (Row27 clean-room salvage)

### DIFF
--- a/apps/web/src/views/DirectoryManagementView.vue
+++ b/apps/web/src/views/DirectoryManagementView.vue
@@ -1736,6 +1736,10 @@
 
         <section v-if="testResult" class="directory-admin__section">
           <h3>连通性测试</h3>
+          <div v-if="testResult.summary" class="directory-admin__diagnostic-summary">
+            <strong>{{ testResult.summary.title }}</strong>
+            <p class="directory-admin__hint">{{ testResult.summary.nextAction }}</p>
+          </div>
           <div class="directory-admin__chips">
             <span class="directory-admin__chip">部门样本 {{ testResult.departmentSampleCount }}</span>
             <span class="directory-admin__chip">用户样本 {{ testResult.userSampleCount }}</span>
@@ -1784,6 +1788,22 @@
             <p class="directory-admin__hint">
               账号 {{ readNumericStat(run.stats, 'accountsSynced') }} / 部门 {{ readNumericStat(run.stats, 'departmentsSynced') }} /
               待确认 {{ readNumericStat(run.stats, 'pendingCount') }} / 已链接 {{ readNumericStat(run.stats, 'linkedCount') }}
+            </p>
+            <p v-if="readStringStat(run.stats, 'diagnosticTitle')" class="directory-admin__hint">
+              诊断：{{ readStringStat(run.stats, 'diagnosticTitle') }}
+              · 子部门 {{ readNumericStat(run.stats, 'rootDepartmentChildCount') }}
+              · 根部门直属成员 {{ readNumericStat(run.stats, 'rootDepartmentDirectUserCount') }}
+              · 含受限 {{ readNumericStat(run.stats, 'rootDepartmentDirectUserCountWithAccessLimit') }}
+            </p>
+            <p v-if="readStringStat(run.stats, 'diagnosticNextAction')" class="directory-admin__hint">
+              建议：{{ readStringStat(run.stats, 'diagnosticNextAction') }}
+            </p>
+            <p
+              v-for="warning in readStringArrayStat(run.stats, 'diagnosticWarnings')"
+              :key="warning"
+              class="directory-admin__status directory-admin__status--error"
+            >
+              {{ warning }}
             </p>
             <p v-if="run.errorMessage" class="directory-admin__status directory-admin__status--error">{{ run.errorMessage }}</p>
           </article>
@@ -2090,6 +2110,11 @@ type TestResult = {
     rootDepartmentDirectUserHasMoreWithAccessLimit: boolean
     sampledRootDepartmentUsers: Array<{ userId: string; name: string }>
     sampledRootDepartmentUsersWithAccessLimit: Array<{ userId: string; name: string }>
+  }
+  summary?: {
+    code: string
+    title: string
+    nextAction: string
   }
   warnings: string[]
 }
@@ -5055,6 +5080,17 @@ function readNumericStat(stats: Record<string, unknown>, key: string): number {
   if (typeof value === 'number') return value
   if (typeof value === 'string' && value.trim().length > 0 && !Number.isNaN(Number(value))) return Number(value)
   return 0
+}
+
+function readStringStat(stats: Record<string, unknown>, key: string): string {
+  const value = stats[key]
+  return typeof value === 'string' ? value : ''
+}
+
+function readStringArrayStat(stats: Record<string, unknown>, key: string): string[] {
+  const value = stats[key]
+  if (!Array.isArray(value)) return []
+  return value.filter((item): item is string => typeof item === 'string')
 }
 
 function formatSampleUsers(users: Array<{ userId: string; name: string }>, hasMore: boolean): string {

--- a/apps/web/tests/directoryManagementView.spec.ts
+++ b/apps/web/tests/directoryManagementView.spec.ts
@@ -215,6 +215,11 @@ function createTestResultPayload(overrides: Record<string, unknown> = {}) {
           { userId: '0447654442691174', name: '林岚' },
         ],
       },
+      summary: {
+        code: 'scope_or_root_misconfigured',
+        title: '通讯录范围或根部门疑似配置不当',
+        nextAction: '请检查应用「通讯录管理」权限范围是否覆盖全员，并确认根部门 ID 是否正确。',
+      },
       warnings: [
         '根部门 1 未返回任何子部门。',
         '根部门 1 当前仅返回 1 个直属成员；如果钉钉企业通讯录里实际成员更多，通常是应用通讯录接口范围未覆盖，或根部门 ID 配置不正确。',
@@ -5373,6 +5378,55 @@ describe('DirectoryManagementView', () => {
     expect(container?.textContent).toContain('根部门子部门 0')
     expect(container?.textContent).toContain('根部门直属成员 1')
     expect(container?.textContent).toContain('根部门 1 当前仅返回 1 个直属成员')
+    expect(container?.querySelector('.directory-admin__diagnostic-summary')).toBeTruthy()
+    expect(container?.textContent).toContain('通讯录范围或根部门疑似配置不当')
+    expect(container?.textContent).toContain('请检查应用「通讯录管理」权限范围是否覆盖全员，并确认根部门 ID 是否正确。')
+  })
+
+  it('renders connectivity diagnostics without a summary for legacy responses', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: {
+          items: [createIntegration()],
+        },
+      }))
+      .mockResolvedValueOnce(createJsonResponse({
+        ok: true,
+        data: { items: [] },
+      }))
+      .mockResolvedValueOnce(createJsonResponse(
+        createScheduleSnapshotPayload(),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAlertListPayload([]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createReviewItemsPayload([]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createAccountListPayload([createAccount()]),
+      ))
+      .mockResolvedValueOnce(createJsonResponse(
+        createTestResultPayload({ summary: undefined }),
+      ))
+
+    app = createApp(DirectoryManagementView)
+    app.component('RouterLink', {
+      props: ['to'],
+      template: '<a><slot /></a>',
+    })
+    app.mount(container!)
+    await flushUi()
+
+    const testButton = Array.from(container!.querySelectorAll('button')).find((button) => button.textContent?.includes('测试连通性'))
+    expect(testButton).toBeTruthy()
+    testButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushUi(6)
+
+    expect(container?.textContent).toContain('根部门子部门 0')
+    expect(container?.textContent).toContain('根部门 1 当前仅返回 1 个直属成员')
+    expect(container?.querySelector('.directory-admin__diagnostic-summary')).toBeNull()
   })
 
   it('tests and saves DingTalk work notification Agent ID from the directory page', async () => {

--- a/docs/development/dingtalk-directory-diagnostics-20260411.md
+++ b/docs/development/dingtalk-directory-diagnostics-20260411.md
@@ -67,6 +67,39 @@
 - 根部门配置
 - 还是本地同步逻辑
 
+### 3. 结构化诊断结论与同步运行历史持久化
+
+在第 2 节原始计数/告警的基础上，进一步补充：
+
+后端 `testDirectoryIntegration` 现在额外返回结构化结论 `summary`：
+
+- `code`：稳定字符串枚举（落库后重命名需迁移），当前取值固定为：
+  - `healthy`：通讯录连通正常
+  - `no_child_departments`：根部门未返回子部门，但根直属成员看起来正常
+  - `scope_or_root_misconfigured`：无子部门且根直属成员稀少，疑似权限范围或根部门配置不当
+- `title`：人类可读结论标题
+- `nextAction`：建议的下一步动作
+
+`code` 由 `buildDirectoryIntegrationDiagnosticSummary` 从既有计数派生，与第 2 节诊断告警同源，不引入新的判定条件。
+
+手动同步（`triggerSource === 'manual'`）时，`syncDirectoryIntegration` 以 best-effort 方式采样一次根部门诊断，并写入该次运行的 `directory_sync_runs.stats`：
+
+- `rootDepartmentChildCount`
+- `rootDepartmentDirectUserCount`
+- `rootDepartmentDirectUserHasMore`
+- `rootDepartmentDirectUserCountWithAccessLimit`
+- `rootDepartmentDirectUserHasMoreWithAccessLimit`
+- `diagnosticCode` / `diagnosticTitle` / `diagnosticNextAction`
+- `diagnosticWarnings`
+- 两组根部门成员样本
+
+约束：
+
+- 诊断采样失败不影响同步本身（吞掉异常并 `logger.warn`，运行状态不因采样失败而判负）。
+- 仅在手动触发时采样；定时同步（`scheduler`）不采样，避免给每次自动同步增加额外钉钉调用。
+- 前端在运行记录卡片中渲染 `diagnosticTitle`、计数摘要、`diagnosticNextAction` 与诊断告警，管理员无需重跑连通性测试即可回看历史结论。
+- 前端连通性测试区在 `summary` 缺失时（旧响应）自动跳过结构化结论块，保持向后兼容。
+
 ## 操作建议
 
 部署后，在 `/admin/directory` 中执行：

--- a/packages/core-backend/src/directory/directory-sync.ts
+++ b/packages/core-backend/src/directory/directory-sync.ts
@@ -383,7 +383,14 @@ export type DirectoryIntegrationTestResult = {
     sampledRootDepartmentUsers: Array<{ userId: string; name: string }>
     sampledRootDepartmentUsersWithAccessLimit: Array<{ userId: string; name: string }>
   }
+  summary: DirectoryIntegrationDiagnosticSummary
   warnings: string[]
+}
+
+export type DirectoryIntegrationDiagnosticSummary = {
+  code: string
+  title: string
+  nextAction: string
 }
 
 export type DirectorySyncRunSummary = {
@@ -1656,6 +1663,111 @@ export function buildDirectoryIntegrationTestWarnings(result: {
   return warnings
 }
 
+export function buildDirectoryIntegrationDiagnosticSummary(result: {
+  departmentSampleCount: number
+  rootDepartmentDirectUserCount: number
+  rootDepartmentDirectUserHasMore: boolean
+}): DirectoryIntegrationDiagnosticSummary {
+  const hasNoChildDepartments = result.departmentSampleCount === 0
+  const hasSuspiciouslySparseRootMembers =
+    result.rootDepartmentDirectUserCount <= 1 && !result.rootDepartmentDirectUserHasMore
+
+  if (hasNoChildDepartments && hasSuspiciouslySparseRootMembers) {
+    return {
+      code: 'scope_or_root_misconfigured',
+      title: '通讯录范围或根部门疑似配置不当',
+      nextAction: '请检查应用「通讯录管理」权限范围是否覆盖全员，并确认根部门 ID 是否正确。',
+    }
+  }
+
+  if (hasNoChildDepartments) {
+    return {
+      code: 'no_child_departments',
+      title: '根部门未返回子部门',
+      nextAction: '如企业通讯录确有部门层级，请检查应用通讯录可见范围配置。',
+    }
+  }
+
+  return {
+    code: 'healthy',
+    title: '通讯录连通正常',
+    nextAction: '通讯录范围正常，可执行目录同步。',
+  }
+}
+
+export type DirectoryRootDepartmentDiagnosticSample = {
+  rootDepartmentChildCount: number
+  rootDepartmentDirectUserCount: number
+  rootDepartmentDirectUserHasMore: boolean
+  rootDepartmentDirectUserCountWithAccessLimit: number
+  rootDepartmentDirectUserHasMoreWithAccessLimit: boolean
+  sampledRootDepartmentUsers: Array<{ userId: string; name: string }>
+  sampledRootDepartmentUsersWithAccessLimit: Array<{ userId: string; name: string }>
+  summary: DirectoryIntegrationDiagnosticSummary
+  warnings: string[]
+}
+
+export async function sampleRootDepartmentDiagnostics(
+  config: DirectoryIntegrationConfig,
+): Promise<DirectoryRootDepartmentDiagnosticSample> {
+  const accessToken = await fetchDingTalkAppAccessToken({
+    appKey: config.appKey,
+    appSecret: config.appSecret,
+    baseUrl: config.baseUrl,
+  })
+  const departments = await listDingTalkDepartments(accessToken, config.rootDepartmentId, {
+    baseUrl: config.baseUrl,
+  })
+  const rootUsers = await listDingTalkDepartmentUsers(
+    accessToken,
+    config.rootDepartmentId,
+    0,
+    Math.min(config.pageSize ?? DEFAULT_PAGE_SIZE, 100),
+    { baseUrl: config.baseUrl },
+  )
+  const rootUsersWithAccessLimit = await listDingTalkDepartmentUsers(
+    accessToken,
+    config.rootDepartmentId,
+    0,
+    Math.min(config.pageSize ?? DEFAULT_PAGE_SIZE, 100),
+    { baseUrl: config.baseUrl, containAccessLimit: true },
+  )
+
+  const rootDepartmentChildCount = departments.length
+  const rootDepartmentDirectUserCount = rootUsers.users.length
+  const rootDepartmentDirectUserHasMore = rootUsers.hasMore
+  const rootDepartmentDirectUserCountWithAccessLimit = rootUsersWithAccessLimit.users.length
+  const rootDepartmentDirectUserHasMoreWithAccessLimit = rootUsersWithAccessLimit.hasMore
+
+  const warnings = buildDirectoryIntegrationTestWarnings({
+    rootDepartmentId: config.rootDepartmentId,
+    departmentSampleCount: rootDepartmentChildCount,
+    rootDepartmentDirectUserCount,
+    rootDepartmentDirectUserHasMore,
+    rootDepartmentDirectUserCountWithAccessLimit,
+    rootDepartmentDirectUserHasMoreWithAccessLimit,
+  })
+  const summary = buildDirectoryIntegrationDiagnosticSummary({
+    departmentSampleCount: rootDepartmentChildCount,
+    rootDepartmentDirectUserCount,
+    rootDepartmentDirectUserHasMore,
+  })
+
+  return {
+    rootDepartmentChildCount,
+    rootDepartmentDirectUserCount,
+    rootDepartmentDirectUserHasMore,
+    rootDepartmentDirectUserCountWithAccessLimit,
+    rootDepartmentDirectUserHasMoreWithAccessLimit,
+    sampledRootDepartmentUsers: rootUsers.users.slice(0, 10).map((user) => ({ userId: user.userId, name: user.name })),
+    sampledRootDepartmentUsersWithAccessLimit: rootUsersWithAccessLimit.users
+      .slice(0, 10)
+      .map((user) => ({ userId: user.userId, name: user.name })),
+    summary,
+    warnings,
+  }
+}
+
 export async function testDirectoryIntegration(input: DirectoryIntegrationTestInput): Promise<DirectoryIntegrationTestResult> {
   const current = await resolveDirectoryTestCurrentConfig(input)
   const normalized = normalizeIntegrationInput(input, current)
@@ -1715,6 +1827,11 @@ export async function testDirectoryIntegration(input: DirectoryIntegrationTestIn
     userSampleCount: users.length,
     sampledUsers: users.slice(0, 5).map((user) => ({ userId: user.userId, name: user.name })),
     diagnostics,
+    summary: buildDirectoryIntegrationDiagnosticSummary({
+      departmentSampleCount: departments.length,
+      rootDepartmentDirectUserCount: diagnostics.rootDepartmentDirectUserCount,
+      rootDepartmentDirectUserHasMore: diagnostics.rootDepartmentDirectUserHasMore,
+    }),
     warnings: buildDirectoryIntegrationTestWarnings({
       rootDepartmentId: normalized.rootDepartmentId,
       departmentSampleCount: departments.length,
@@ -1999,6 +2116,33 @@ export async function syncDirectoryIntegration(
     const departments = await fetchAllDepartments(config, integration.name)
     const departmentPathMap = buildDepartmentPathMap(departments)
     const users = await fetchAllUsers(config, departments)
+
+    let directoryDiagnosticStats: JsonRecord = {}
+    if (triggerSource === 'manual') {
+      try {
+        const diagnosticSample = await sampleRootDepartmentDiagnostics(config)
+        directoryDiagnosticStats = {
+          rootDepartmentChildCount: diagnosticSample.rootDepartmentChildCount,
+          rootDepartmentDirectUserCount: diagnosticSample.rootDepartmentDirectUserCount,
+          rootDepartmentDirectUserHasMore: diagnosticSample.rootDepartmentDirectUserHasMore,
+          rootDepartmentDirectUserCountWithAccessLimit: diagnosticSample.rootDepartmentDirectUserCountWithAccessLimit,
+          rootDepartmentDirectUserHasMoreWithAccessLimit:
+            diagnosticSample.rootDepartmentDirectUserHasMoreWithAccessLimit,
+          diagnosticCode: diagnosticSample.summary.code,
+          diagnosticTitle: diagnosticSample.summary.title,
+          diagnosticNextAction: diagnosticSample.summary.nextAction,
+          diagnosticWarnings: diagnosticSample.warnings,
+          sampledRootDepartmentUsers: diagnosticSample.sampledRootDepartmentUsers,
+          sampledRootDepartmentUsersWithAccessLimit: diagnosticSample.sampledRootDepartmentUsersWithAccessLimit,
+        }
+      } catch (error) {
+        directoryDiagnosticStats = {}
+        logger.warn(
+          `Failed to sample directory diagnostics for integration ${integrationId}: ${readErrorMessage(error, 'unknown error')}`,
+        )
+      }
+    }
+
     const syncTimestamp = new Date().toISOString()
     const autoAdmissionInvites: Array<{ userId: string; email: string; inviteToken: string }> = []
     const autoAdmissionOnboardingPackets: DirectoryAutoAdmissionOnboardingPacket[] = []
@@ -2395,6 +2539,7 @@ export async function syncDirectoryIntegration(
         memberGroupGovernedUserCount: memberGroupProjection.memberGroupGovernedUserCount,
         memberGroupDefaultRoleAssignmentsCount: memberGroupProjection.memberGroupDefaultRoleAssignmentsCount,
         memberGroupDefaultNamespaceAdmissionsCount: memberGroupProjection.memberGroupDefaultNamespaceAdmissionsCount,
+        ...directoryDiagnosticStats,
       }
 
       await client.query(

--- a/packages/core-backend/tests/unit/admin-directory-routes.test.ts
+++ b/packages/core-backend/tests/unit/admin-directory-routes.test.ts
@@ -408,6 +408,11 @@ describe('adminDirectoryRouter', () => {
         sampledRootDepartmentUsers: [{ userId: '0447654442691174', name: '林岚' }],
         sampledRootDepartmentUsersWithAccessLimit: [{ userId: '0447654442691174', name: '林岚' }],
       },
+      summary: {
+        code: 'scope_or_root_misconfigured',
+        title: '通讯录范围或根部门疑似配置不当',
+        nextAction: '请检查应用「通讯录管理」权限范围是否覆盖全员，并确认根部门 ID 是否正确。',
+      },
       warnings: ['根部门 1 未返回任何子部门。'],
     })
 
@@ -436,6 +441,11 @@ describe('adminDirectoryRouter', () => {
       data: {
         diagnostics: {
           rootDepartmentDirectUserCount: 1,
+        },
+        summary: {
+          code: 'scope_or_root_misconfigured',
+          title: '通讯录范围或根部门疑似配置不当',
+          nextAction: '请检查应用「通讯录管理」权限范围是否覆盖全员，并确认根部门 ID 是否正确。',
         },
         warnings: ['根部门 1 未返回任何子部门。'],
       },

--- a/packages/core-backend/tests/unit/directory-sync-warnings.test.ts
+++ b/packages/core-backend/tests/unit/directory-sync-warnings.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { buildDirectoryIntegrationTestWarnings } from '../../src/directory/directory-sync'
+import {
+  buildDirectoryIntegrationDiagnosticSummary,
+  buildDirectoryIntegrationTestWarnings,
+} from '../../src/directory/directory-sync'
 
 describe('buildDirectoryIntegrationTestWarnings', () => {
   it('keeps scope warnings when the root department returns no child departments', () => {
@@ -30,5 +33,49 @@ describe('buildDirectoryIntegrationTestWarnings', () => {
         rootDepartmentDirectUserHasMoreWithAccessLimit: false,
       }),
     ).toEqual([])
+  })
+})
+
+describe('buildDirectoryIntegrationDiagnosticSummary', () => {
+  it('flags scope/root misconfiguration when no child departments and sparse root members', () => {
+    expect(
+      buildDirectoryIntegrationDiagnosticSummary({
+        departmentSampleCount: 0,
+        rootDepartmentDirectUserCount: 1,
+        rootDepartmentDirectUserHasMore: false,
+      }),
+    ).toEqual({
+      code: 'scope_or_root_misconfigured',
+      title: '通讯录范围或根部门疑似配置不当',
+      nextAction: '请检查应用「通讯录管理」权限范围是否覆盖全员，并确认根部门 ID 是否正确。',
+    })
+  })
+
+  it('reports missing child departments when root members look healthy', () => {
+    expect(
+      buildDirectoryIntegrationDiagnosticSummary({
+        departmentSampleCount: 0,
+        rootDepartmentDirectUserCount: 42,
+        rootDepartmentDirectUserHasMore: true,
+      }),
+    ).toEqual({
+      code: 'no_child_departments',
+      title: '根部门未返回子部门',
+      nextAction: '如企业通讯录确有部门层级，请检查应用通讯录可见范围配置。',
+    })
+  })
+
+  it('reports healthy connectivity when child departments are present', () => {
+    expect(
+      buildDirectoryIntegrationDiagnosticSummary({
+        departmentSampleCount: 4,
+        rootDepartmentDirectUserCount: 1,
+        rootDepartmentDirectUserHasMore: false,
+      }),
+    ).toEqual({
+      code: 'healthy',
+      title: '通讯录连通正常',
+      nextAction: '通讯录范围正常，可执行目录同步。',
+    })
   })
 })


### PR DESCRIPTION
## Summary

Clean-room salvage of the unmerged **Row27** (`dingtalk-diagnostics-20260413`) increment. Re-derived from current `origin/main`, **not** cherry-picked from the stale worktree (its base predates #823/#832 directory growth, so a direct patch would conflict / regress).

- `testDirectoryIntegration` now returns a structured `summary` `{ code, title, nextAction }`, derived from the same root-department counts the existing `buildDirectoryIntegrationTestWarnings` uses (no new judgment conditions). Codes pinned: `healthy` / `no_child_departments` / `scope_or_root_misconfigured`.
- Manual directory sync (**`triggerSource === 'manual'` only**) best-effort samples root-department diagnostics and persists count + diagnostic fields into `directory_sync_runs.stats`. Sampling failure is logged and swallowed — never fails the sync. Scheduler syncs unaffected.
- `DirectoryManagementView` renders the summary above the connectivity chips (legacy responses without `summary` gracefully skip the block) and renders persisted diagnostic fields in sync run-history cards.

## Scope / constraints

- Stage-1 lock compliant: follow-up on already-merged #823/#832 DingTalk directory diagnostics; touches `packages/core-backend/src/directory/` + `apps/web` only — no `plugin-integration-core`, no K3 PoC path, not a new front.
- No OpenAPI impact: admin-directory routes are not OpenAPI-tracked.
- Sampling runs **outside** the DB transaction (no row lock across DingTalk RTT).

## Test plan

- [x] Backend `tsc --noEmit`: pass
- [x] Frontend `vue-tsc --noEmit`: pass
- [x] `directory-sync-warnings.test.ts` + `admin-directory-routes.test.ts`: 32/32 pass (3 new `buildDirectoryIntegrationDiagnosticSummary` contract tests + route passthrough)
- [x] `directoryManagementView.spec.ts`: 42/42 pass (new: summary render + legacy fallback)
- [ ] Codex review + regression verification (per owner assignment)

Codex: please diff against current `main` for any #823/#832 duplication and run route-level directory regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)