### PR TITLE
chore(integration): package K3 readiness compiler handoff

### DIFF
--- a/docs/development/data-factory-readiness-package-verify-delivery-development-20260515.md
+++ b/docs/development/data-factory-readiness-package-verify-delivery-development-20260515.md
@@ -1,0 +1,88 @@
+# Data Factory Readiness Package Verify Delivery Development - 2026-05-15
+
+## Purpose
+
+This slice wires the existing K3 WISE delivery-readiness compiler into the
+operator package path.
+
+Before this change, `integration-k3wise-delivery-readiness.mjs` could consume a
+package verifier JSON report through `--package-verify`, but the on-prem package
+did not guarantee that the compiler itself was shipped. The live GATE runbook
+also stopped at the C10 live evidence compiler, leaving no packaged command path
+for producing the final `integration-k3wise-delivery-readiness.{json,md}`
+handoff record.
+
+The goal is to make the installable package self-contained:
+
+1. the package contains the readiness compiler;
+2. the package verifier requires it;
+3. the live GATE runbook shows how to capture `VERIFY_REPORT_JSON`;
+4. the final readiness command combines postdeploy smoke, package verify,
+   preflight packet, and optional live evidence.
+
+## Changed Files
+
+- `scripts/ops/multitable-onprem-package-build.sh`
+- `scripts/ops/multitable-onprem-package-verify.sh`
+- `docs/operations/integration-k3wise-live-gate-execution-package.md`
+- `docs/operations/integration-k3wise-internal-trial-runbook.md`
+- `docs/development/data-factory-readiness-package-verify-delivery-development-20260515.md`
+- `docs/development/data-factory-readiness-package-verify-delivery-verification-20260515.md`
+
+## Behavior
+
+### Package contents
+
+`multitable-onprem-package-build.sh` now includes:
+
+```text
+scripts/ops/integration-k3wise-delivery-readiness.mjs
+```
+
+It also includes the delivery-readiness development and verification notes so
+offline package reviewers can see why the readiness gate exists.
+
+### Package verifier
+
+`multitable-onprem-package-verify.sh` now requires:
+
+- the delivery-readiness compiler file to exist in the archive;
+- the compiler to support `--package-verify`;
+- the compiler to still emit the `CUSTOMER_TRIAL_READY` decision;
+- the live GATE runbook to document `VERIFY_REPORT_JSON`;
+- the live GATE runbook to document the `--package-verify` readiness gate.
+
+This turns a missing readiness compiler into a package verification failure
+instead of a deploy-time surprise.
+
+### Operator runbooks
+
+The live GATE package now has two explicit steps:
+
+- **C0.5 package verify report**: run the package verifier with
+  `VERIFY_REPORT_JSON` and `VERIFY_REPORT_MD`.
+- **C11 delivery readiness compiler**: combine package verify, authenticated
+  postdeploy smoke, preflight packet, and optional live evidence into one
+  readiness artifact.
+
+The internal-trial runbook now points operators from postdeploy smoke to the
+same delivery-readiness handoff path.
+
+## Scope Boundary
+
+This slice does not:
+
+- implement a SQL Server executor;
+- change K3 WebAPI or Data Factory runtime behavior;
+- add migrations;
+- change customer GATE requirements;
+- approve production use.
+
+It only tightens the operator delivery chain around existing scripts.
+
+## Claude Code
+
+Claude Code is not required for this slice. The work is local repo packaging,
+docs, and shell/Node test verification. Claude Code becomes useful again when
+the bridge machine needs a real allowlisted SQL executor implementation and
+live Windows/K3 connectivity checks.

--- a/docs/development/data-factory-readiness-package-verify-delivery-verification-20260515.md
+++ b/docs/development/data-factory-readiness-package-verify-delivery-verification-20260515.md
@@ -1,0 +1,82 @@
+# Data Factory Readiness Package Verify Delivery Verification - 2026-05-15
+
+## Verification Date
+
+2026-05-15T08:59:49Z
+
+## Commands
+
+```bash
+bash -n scripts/ops/multitable-onprem-package-build.sh scripts/ops/multitable-onprem-package-verify.sh
+pnpm verify:integration-k3wise:delivery
+node --test scripts/ops/integration-k3wise-delivery-readiness.test.mjs
+node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
+rg -n "integration-k3wise-delivery-readiness.mjs|VERIFY_REPORT_JSON|--package-verify|CUSTOMER_TRIAL_READY" \
+  scripts/ops/multitable-onprem-package-build.sh \
+  scripts/ops/multitable-onprem-package-verify.sh \
+  docs/operations/integration-k3wise-live-gate-execution-package.md \
+  docs/operations/integration-k3wise-internal-trial-runbook.md
+git diff --check origin/main...HEAD
+```
+
+## Expected Assertions
+
+| Area | Assertion |
+| --- | --- |
+| Package build | `scripts/ops/integration-k3wise-delivery-readiness.mjs` is copied into the on-prem archive. |
+| Package build | delivery-readiness development and verification notes are copied into the archive. |
+| Package verify | missing readiness compiler fails required-content verification. |
+| Package verify | packaged readiness compiler must expose `--package-verify`. |
+| Package verify | packaged readiness compiler must still expose `CUSTOMER_TRIAL_READY`. |
+| Live GATE runbook | C0.5 captures `VERIFY_REPORT_JSON` from the package verifier. |
+| Live GATE runbook | C11 runs `integration-k3wise-delivery-readiness.mjs` with package verify evidence. |
+| Internal-trial runbook | postdeploy smoke now hands off to the same readiness compiler. |
+
+## Local Results
+
+| Command | Result |
+| --- | --- |
+| `bash -n scripts/ops/multitable-onprem-package-build.sh scripts/ops/multitable-onprem-package-verify.sh` | PASS |
+| `pnpm verify:integration-k3wise:delivery` | PASS, 10/10 |
+| `node --test scripts/ops/integration-k3wise-delivery-readiness.test.mjs` | PASS, 10/10 |
+| `node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs` | PASS, 24/24 |
+| `rg ...` contract scan | PASS, readiness script/package verify/runbook references found |
+| `git diff --check origin/main...HEAD` | PASS, no whitespace or conflict-marker issues |
+
+## Secret Scan
+
+```bash
+rg -n "(eyJ[A-Za-z0-9_-]{20,}|Bearer\\s+[A-Za-z0-9._-]+|password\\s*[:=]\\s*['\\\"][^<]|access_token=|api_key=|session_id=|postgres(ql)?://[^:/?@[:space:]]+:[^@[:space:]]+@)" \
+  docs/development/data-factory-readiness-package-verify-delivery-development-20260515.md \
+  docs/operations/integration-k3wise-live-gate-execution-package.md \
+  docs/operations/integration-k3wise-internal-trial-runbook.md \
+  scripts/ops/multitable-onprem-package-build.sh \
+  scripts/ops/multitable-onprem-package-verify.sh
+```
+
+Result: no real secret value found. The only match is the intentional
+`postgres://rehearsal:<fill-outside-git>@...` placeholder in the live GATE
+runbook. This verification file is excluded from the scan because it contains
+the literal secret-pattern strings being documented.
+
+## Secret Hygiene
+
+This slice adds no real secret values. The docs use placeholders only:
+
+- `<metasheet-multitable-onprem.zip-or.tgz>`
+- `<packet-dir>`
+- `<evidence-dir>`
+
+No token, password, K3 session, bearer header, or SQL connection string is
+introduced in tracked files.
+
+## Deployment Impact
+
+- No database migration.
+- No API contract change.
+- No frontend route change.
+- No backend runtime change.
+- Next package build will include one additional readiness script and two
+  additional audit docs.
+- Operators get an explicit package verify JSON input for the readiness
+  compiler before customer live work starts.

--- a/docs/operations/integration-k3wise-internal-trial-runbook.md
+++ b/docs/operations/integration-k3wise-internal-trial-runbook.md
@@ -178,6 +178,38 @@ node scripts/ops/integration-k3wise-postdeploy-summary.mjs \
   --require-auth-signoff
 ```
 
+## Delivery Readiness Handoff
+
+The postdeploy smoke proves the deployed MetaSheet control plane is usable.
+Before customer GATE work starts, pair that smoke artifact with the package
+verifier JSON and let the delivery-readiness compiler produce the handoff
+record.
+
+First verify the exact on-prem package that was installed or will be installed:
+
+```bash
+VERIFY_REPORT_JSON=artifacts/integration-k3wise/delivery-readiness/package-verify.json \
+VERIFY_REPORT_MD=artifacts/integration-k3wise/delivery-readiness/package-verify.md \
+  scripts/ops/multitable-onprem-package-verify.sh <metasheet-multitable-onprem.zip-or.tgz>
+```
+
+Then compile readiness. Before customer GATE answers arrive this usually ends
+at `INTERNAL_READY_WAITING_CUSTOMER_GATE`; after the live preflight packet is
+available it can advance to `CUSTOMER_TRIAL_READY`.
+
+```bash
+node scripts/ops/integration-k3wise-delivery-readiness.mjs \
+  --postdeploy-smoke artifacts/integration-k3wise/internal-trial/postdeploy-smoke/integration-k3wise-postdeploy-smoke.json \
+  --package-verify artifacts/integration-k3wise/delivery-readiness/package-verify.json \
+  --preflight-packet <packet-dir>/integration-k3wise-live-poc-packet.json \
+  --out-dir artifacts/integration-k3wise/delivery-readiness/customer-ready \
+  --fail-on-blocked
+```
+
+After the live PoC evidence compiler returns `decision=PASS`, rerun with
+`--live-evidence-report` to produce `CUSTOMER_TRIAL_SIGNED_OFF`. The output is
+still a customer-trial signoff only; it does not approve production use.
+
 ## Host-Shell Mint and Smoke (deploy host, no GHA)
 
 When you have shell access to the deploy host and need a one-off internal-trial

--- a/docs/operations/integration-k3wise-live-gate-execution-package.md
+++ b/docs/operations/integration-k3wise-live-gate-execution-package.md
@@ -14,6 +14,8 @@ This document does **not** repeat content already covered by:
 - `docs/operations/integration-k3wise-internal-trial-runbook.md` — post-deploy
   authenticated smoke (signoff that the metasheet control plane is alive
   before any K3 conversation begins).
+- `scripts/ops/multitable-onprem-package-verify.sh` — package-content verifier
+  that proves the deployed zip/tgz contains the K3 operator scripts and docs.
 
 Read this package alongside those two; this one focuses on the live PoC
 preflight and Save-only PoC, which they only touch tangentially.
@@ -22,6 +24,8 @@ preflight and Save-only PoC, which they only touch tangentially.
 
 - After the on-prem deploy is up and the internal-trial postdeploy smoke
   signed off.
+- After the downloaded on-prem package has produced a package verifier JSON
+  report.
 - Before sending the GATE intake template to the customer.
 - During customer answer review (does the answer satisfy the hard contracts?).
 - During live PoC execution (which command runs when, what counts as PASS).
@@ -171,6 +175,7 @@ next step only after PASS.
 | Step | Name | When | Command / Entry | PASS | FAIL |
 |---|---|---|---|---|---|
 | **C0** | Mock chain smoke (no GATE needed) | Anytime | `pnpm verify:integration-k3wise:poc` | 37 unit tests + 9-step end-to-end mock chain all green (mock K3 WebAPI + mock SQL + Save-only upsert + safety guard rejects core-table INSERT + evidence compiler PASS) | Any sub-step fails |
+| **C0.5** | Package verify report | After downloading the on-prem zip/tgz and before deploy signoff | see [C0.5 package verify report](#c05-package-verify-report) | verifier exits 0 and writes `package-verify.json` with `ok=true`; `required-content` / `checksum` / `no-github-links` PASS | verifier exits non-zero, missing K3 readiness scripts/docs, checksum mismatch, or delivery docs contain forbidden GitHub links |
 | **C1** | On-prem preflight (mock mode) | After deploy, before GATE arrives | `node scripts/ops/integration-k3wise-onprem-preflight.mjs --mock --out-dir <art>` (see [C1 prerequisites](#c1-prerequisites) below) | exit 0; `decision=PASS`; `pg.tcp-reachable` / `pg.migrations-aligned` / `fixtures.k3wise-mock` all `pass`; all K3 / gate checks `skip` | exit 1 (mandatory env defect — `env.database-url` and/or `env.jwt-secret` not satisfied; see [C1 prerequisites](#c1-prerequisites)) |
 | **C2** | On-prem preflight `--live` | Once GATE answers received | `node scripts/ops/integration-k3wise-onprem-preflight.mjs --live --gate-file <path> --out-dir <art>` with `K3_API_URL` / `K3_ACCT_ID` / `K3_USERNAME` / `K3_PASSWORD` injected | exit 0; `k3.live-config` `pass` (4 fields present); `k3.live-reachable` `pass` (TCP to K3 host:port); `gate.file-present` `pass` | exit 1 (mandatory) or exit 2 (`GATE_BLOCKED` — customer field still missing). For per-error-code fix recipes (`ECONNREFUSED` / `ENOTFOUND` / `EHOSTUNREACH` / `ETIMEDOUT`) on `pg.tcp-reachable` and `k3.live-reachable`, see `docs/operations/k3-poc-onprem-preflight-runbook.md` § "Per-check failure recipes". |
 | **C3** | Build live PoC packet + GATE contract validation | After C2 PASS | `node scripts/ops/integration-k3wise-live-poc-preflight.mjs --input <gate.json> --out-dir <packet-dir>` | `integration-k3wise-live-poc-packet.{json,md}` written; `safety.saveOnly=true / autoSubmit=false / autoAudit=false`; checklist contains `GATE-01 / CONN-01 / CONN-02 / DRY-01 / SAVE-01 / FAIL-01 / ROLLBACK-01` (plus `BOM-01` when BOM enabled) | `normalizeGate` throws (error includes `field` path of the offending key) |
@@ -181,6 +186,56 @@ next step only after PASS.
 | **C8** | Dead-letter replay | After C6 PASS | introduce a controlled failure → enters dead-letter → fix → replay | replayed run writes successfully | replay still fails |
 | **C9** | Rollback rehearsal | After C8 PASS | customer K3 admin executes per `rollback.owner` / `rollback.strategy` | test rows identifiable (e.g., `TEST-` prefix) and removed/disabled per strategy | owner unreachable or strategy not exercised |
 | **C10** | **Evidence compiler signoff** | After C9 PASS | `node scripts/ops/integration-k3wise-live-poc-evidence.mjs --packet <packet.json> --evidence <evidence.json>` | `decision=PASS` and `issues=[]` | `decision=FAIL` if any of `SAVE_ONLY_VIOLATED` / `SAVE_ONLY_ROW_COUNT` / `SAVE_ONLY_RUN_ID_REQUIRED` / `K3_RECORD_REQUIRED` / `BOM_PRODUCT_SCOPE_REQUIRED` / `BOM_RUN_ID_REQUIRED` / `BOM_ROW_COUNT` / `BOM_K3_RECORD_REQUIRED` / `BOM_K3_RESPONSE_REQUIRED` / `LEGACY_BOM_PRODUCT_ID_USED` fires; `decision=PARTIAL` when non-fail issues remain (typically checklist gaps) |
+| **C11** | **Delivery readiness compiler** | After C10 PASS, or earlier to show what remains blocked | see [C11 delivery readiness compiler](#c11-delivery-readiness-compiler) | before C10: `decision=CUSTOMER_TRIAL_READY`; after C10: `decision=CUSTOMER_TRIAL_SIGNED_OFF`; `productionUse.ready=false` remains explicit | `decision=BLOCKED`, missing package verify JSON, failed postdeploy smoke, failed preflight packet, or failed live evidence |
+
+### C0.5 package verify report
+
+Run this against the exact package that will be installed. Capture both JSON
+and Markdown reports; the JSON report becomes an input to the delivery
+readiness compiler.
+
+```bash
+VERIFY_REPORT_JSON=artifacts/integration-k3wise/delivery-readiness/package-verify.json \
+VERIFY_REPORT_MD=artifacts/integration-k3wise/delivery-readiness/package-verify.md \
+  scripts/ops/multitable-onprem-package-verify.sh <metasheet-multitable-onprem.zip-or.tgz>
+```
+
+The verifier must find `scripts/ops/integration-k3wise-delivery-readiness.mjs`
+inside the package and must prove this runbook documents the
+`--package-verify` readiness gate. If either check fails, do not deploy the
+package for customer GATE work.
+
+### C11 delivery readiness compiler
+
+After C3, run the compiler without live evidence to get a customer-trial-ready
+record:
+
+```bash
+node scripts/ops/integration-k3wise-delivery-readiness.mjs \
+  --postdeploy-smoke artifacts/integration-k3wise/internal-trial/postdeploy-smoke/integration-k3wise-postdeploy-smoke.json \
+  --package-verify artifacts/integration-k3wise/delivery-readiness/package-verify.json \
+  --preflight-packet <packet-dir>/integration-k3wise-live-poc-packet.json \
+  --out-dir artifacts/integration-k3wise/delivery-readiness/customer-ready \
+  --fail-on-blocked
+```
+
+After C10 PASS, add the live evidence report to produce the final customer
+trial signoff artifact:
+
+```bash
+node scripts/ops/integration-k3wise-delivery-readiness.mjs \
+  --postdeploy-smoke artifacts/integration-k3wise/internal-trial/postdeploy-smoke/integration-k3wise-postdeploy-smoke.json \
+  --package-verify artifacts/integration-k3wise/delivery-readiness/package-verify.json \
+  --preflight-packet <packet-dir>/integration-k3wise-live-poc-packet.json \
+  --live-evidence-report <evidence-dir>/integration-k3wise-live-poc-evidence-report.json \
+  --out-dir artifacts/integration-k3wise/delivery-readiness/customer-signed-off \
+  --fail-on-blocked
+```
+
+The output files are `integration-k3wise-delivery-readiness.json` and
+`integration-k3wise-delivery-readiness.md`. They are readiness records, not
+production approval. Production use still requires customer signoff,
+backup/rollback approval, and a scheduled change window.
 
 ### C1 prerequisites
 
@@ -221,6 +276,7 @@ Same prerequisites apply to C2 (which also runs `env.database-url` /
 | GATE field semantics | `scripts/ops/integration-k3wise-live-poc-preflight.mjs` (`normalizeGate()` and its throws) | The exact text of every hard-constraint failure | No human-readable (especially Chinese) explanation for non-engineer reviewers |
 | On-prem preflight runbook | `docs/operations/k3-poc-onprem-preflight-runbook.md` (PR #1437) | C1 / C2 operations, fix recipes for all 8 check IDs, Docker bridge-IP recipe | Does not explain field semantics — points at the schema |
 | Internal-trial postdeploy | `docs/operations/integration-k3wise-internal-trial-runbook.md` | Post-deploy auth smoke (control plane) before K3 enters the picture; host-shell mint pattern | Concerns metasheet itself, not K3 / PLM |
+| Package verifier + delivery readiness | `scripts/ops/multitable-onprem-package-verify.sh` + `scripts/ops/integration-k3wise-delivery-readiness.mjs` | C0.5 package evidence and C11 readiness decisions (`INTERNAL_READY_WAITING_CUSTOMER_GATE` / `CUSTOMER_TRIAL_READY` / `CUSTOMER_TRIAL_SIGNED_OFF`) | Does not replace customer evidence; it compiles existing evidence into one signoff artifact |
 | Mock chain | `scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs` + `pnpm verify:integration-k3wise:poc` | C0 end-to-end | Already complete |
 | Evidence compiler | `scripts/ops/integration-k3wise-live-poc-evidence.mjs` (`evaluateMaterialSaveOnly` / `evaluateBom` / `determineDecision`) | C10 issue codes and their triggers | No on-site evidence-collection template |
 
@@ -302,6 +358,8 @@ EXIT=$?
 
 - `scripts/ops/integration-k3wise-live-poc-preflight.mjs` — packet builder and `--print-sample` schema source.
 - `scripts/ops/integration-k3wise-live-poc-evidence.mjs` — evidence compiler with the C10 contract.
+- `scripts/ops/integration-k3wise-delivery-readiness.mjs` — final readiness compiler that consumes postdeploy smoke, package verify, preflight packet, and optional live evidence.
+- `scripts/ops/multitable-onprem-package-verify.sh` — package-content verifier; set `VERIFY_REPORT_JSON` to feed C11.
 - `scripts/ops/integration-k3wise-onprem-preflight.mjs` — on-prem preflight (C1 / C2).
 - `scripts/ops/integration-k3wise-postdeploy-smoke.mjs` — internal-trial smoke (after backend boot, before K3 conversation).
 - `scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs` — mock chain (C0).

--- a/scripts/ops/multitable-onprem-package-build.sh
+++ b/scripts/ops/multitable-onprem-package-build.sh
@@ -56,8 +56,9 @@ REQUIRED_PATHS=(
   "scripts/ops/multitable-onprem-package-upgrade.sh"
   "scripts/ops/multitable-onprem-healthcheck.sh"
   # K3 WISE PoC operator tooling — preflight (C1/C2), live PoC packet builder
-  # (C3), evidence compiler (C10), postdeploy smoke + summary, the #1542
-  # metadata seed helper, mock fixtures, and the three K3 operator runbooks.
+  # (C3), evidence compiler (C10), delivery readiness compiler, postdeploy
+  # smoke + summary, the #1542 metadata seed helper, mock fixtures, and the
+  # K3 operator runbooks.
   # The package also ships
   # plugins/plugin-integration-core above so the backend registers
   # /api/integration/* routes and the offline mock chain can resolve its
@@ -65,6 +66,7 @@ REQUIRED_PATHS=(
   "scripts/ops/integration-k3wise-onprem-preflight.mjs"
   "scripts/ops/integration-k3wise-live-poc-preflight.mjs"
   "scripts/ops/integration-k3wise-live-poc-evidence.mjs"
+  "scripts/ops/integration-k3wise-delivery-readiness.mjs"
   "scripts/ops/integration-k3wise-postdeploy-smoke.mjs"
   "scripts/ops/integration-issue1542-seed-workbench-systems.mjs"
   "scripts/ops/integration-k3wise-postdeploy-summary.mjs"
@@ -95,6 +97,10 @@ REQUIRED_PATHS=(
   "docs/development/data-factory-sql-executor-diagnostic-verification-20260515.md"
   "docs/development/data-factory-sql-executor-bridge-handoff-development-20260515.md"
   "docs/development/data-factory-sql-executor-bridge-handoff-verification-20260515.md"
+  "docs/development/data-factory-delivery-readiness-evidence-gates-development-20260515.md"
+  "docs/development/data-factory-delivery-readiness-evidence-gates-verification-20260515.md"
+  "docs/development/data-factory-readiness-package-verify-delivery-development-20260515.md"
+  "docs/development/data-factory-readiness-package-verify-delivery-verification-20260515.md"
   "docs/development/onprem-migration-gap-guard-development-20260514.md"
   "docs/development/onprem-migration-gap-guard-verification-20260514.md"
   "docker/app.env.example"

--- a/scripts/ops/multitable-onprem-package-verify.sh
+++ b/scripts/ops/multitable-onprem-package-verify.sh
@@ -94,8 +94,10 @@ function verify_generic_integration_workbench_contract() {
   local sql_executor_handoff="${root}/docs/operations/integration-k3wise-sql-executor-bridge-handoff.md"
   local bridge_codex_handoff="${root}/docs/development/k3wise-bridge-machine-codex-handoff-20260513.md"
   local postdeploy_smoke="${root}/scripts/ops/integration-k3wise-postdeploy-smoke.mjs"
+  local delivery_readiness="${root}/scripts/ops/integration-k3wise-delivery-readiness.mjs"
   local issue1542_seed="${root}/scripts/ops/integration-issue1542-seed-workbench-systems.mjs"
   local postdeploy_summary="${root}/scripts/ops/integration-k3wise-postdeploy-summary.mjs"
+  local live_gate_package="${root}/docs/operations/integration-k3wise-live-gate-execution-package.md"
 
   search_fixed_string '/integrations/workbench' "$web_dist" || die "web dist must include the Data Factory route"
   search_fixed_string '/integrations/k3-wise' "$web_dist" || die "web dist must include the K3 WISE setup route"
@@ -122,6 +124,8 @@ function verify_generic_integration_workbench_contract() {
   search_fixed_string 'data-factory-frontend-route' "$postdeploy_smoke" || die "postdeploy smoke must check the Data Factory frontend route"
   search_fixed_string 'data-factory-adapter-discovery' "$postdeploy_smoke" || die "postdeploy smoke must check Data Factory adapter discovery"
   search_fixed_string 'sqlserver-executor-availability' "$postdeploy_smoke" || die "postdeploy smoke must report SQL executor availability"
+  search_fixed_string '--package-verify' "$delivery_readiness" || die "delivery readiness must consume package verify evidence"
+  search_fixed_string 'CUSTOMER_TRIAL_READY' "$delivery_readiness" || die "delivery readiness must still emit customer-trial ready decision"
   search_fixed_string '--issue1542-workbench-smoke' "$postdeploy_smoke" || die "postdeploy smoke must include Data Factory issue #1542 workbench retest flag"
   search_fixed_string '--issue1542-install-staging' "$postdeploy_smoke" || die "postdeploy smoke must include Data Factory issue #1542 install-staging retest flag"
   search_fixed_string '--issue1542-workbench-smoke' "$k3_runbook" || die "K3 runbook must document the Data Factory issue #1542 workbench retest"
@@ -130,6 +134,9 @@ function verify_generic_integration_workbench_contract() {
   search_fixed_string 'metasheet:staging' "$issue1542_seed" || die "issue #1542 seed helper must create the staging source system"
   search_fixed_string 'erp:k3-wise-webapi' "$issue1542_seed" || die "issue #1542 seed helper must create the K3 target system"
   search_fixed_string 'invalidAdapters' "$postdeploy_summary" || die "postdeploy summary must render Data Factory adapter drift details"
+  search_fixed_string 'integration-k3wise-delivery-readiness.mjs' "$live_gate_package" || die "live GATE package must document delivery readiness compiler"
+  search_fixed_string 'VERIFY_REPORT_JSON' "$live_gate_package" || die "live GATE package must document package verifier report capture"
+  search_fixed_string '--package-verify' "$live_gate_package" || die "live GATE package must document the package verify readiness gate"
 }
 
 function write_optional_report() {
@@ -336,6 +343,7 @@ required=(
   "scripts/ops/integration-k3wise-onprem-preflight.mjs"
   "scripts/ops/integration-k3wise-live-poc-preflight.mjs"
   "scripts/ops/integration-k3wise-live-poc-evidence.mjs"
+  "scripts/ops/integration-k3wise-delivery-readiness.mjs"
   "scripts/ops/integration-k3wise-postdeploy-smoke.mjs"
   "scripts/ops/integration-issue1542-seed-workbench-systems.mjs"
   "scripts/ops/integration-k3wise-postdeploy-summary.mjs"
@@ -372,6 +380,10 @@ required=(
   "docs/development/data-factory-issue1542-seed-workbench-systems-verification-20260515.md"
   "docs/development/data-factory-issue1542-install-smoke-development-20260515.md"
   "docs/development/data-factory-issue1542-install-smoke-verification-20260515.md"
+  "docs/development/data-factory-delivery-readiness-evidence-gates-development-20260515.md"
+  "docs/development/data-factory-delivery-readiness-evidence-gates-verification-20260515.md"
+  "docs/development/data-factory-readiness-package-verify-delivery-development-20260515.md"
+  "docs/development/data-factory-readiness-package-verify-delivery-verification-20260515.md"
   "docs/development/onprem-migration-gap-guard-development-20260514.md"
   "docs/development/onprem-migration-gap-guard-verification-20260514.md"
   "docs/deployment/multitable-platform-rc-notes-20260404.md"


### PR DESCRIPTION
## Summary

- package `scripts/ops/integration-k3wise-delivery-readiness.mjs` in the multitable on-prem archive
- make `multitable-onprem-package-verify.sh` require the readiness compiler and the live GATE package's `--package-verify` / `VERIFY_REPORT_JSON` handoff
- extend the K3 live GATE and internal-trial runbooks with C0.5 package verify and C11 delivery-readiness compiler commands
- add development and verification MD for this package/readiness handoff slice

## Verification

- `bash -n scripts/ops/multitable-onprem-package-build.sh scripts/ops/multitable-onprem-package-verify.sh`
- `pnpm verify:integration-k3wise:delivery`
- `node --test scripts/ops/integration-k3wise-delivery-readiness.test.mjs`
- `node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs`
- `rg -n "integration-k3wise-delivery-readiness.mjs|VERIFY_REPORT_JSON|--package-verify|CUSTOMER_TRIAL_READY" ...`
- `git diff --check origin/main...HEAD`

## Deployment Impact

No migration, no backend runtime change, no frontend route change. The next on-prem package build will carry one additional K3 readiness script plus the paired audit docs, and package verification will fail if that handoff path is missing.

## Claude Code

Not needed for this slice. This is local packaging/runbook verification; Claude Code becomes useful again when implementing or validating a real bridge-machine SQL executor.