### PR TITLE
ci(integration): upload on-prem package verify reports

### DIFF
--- a/.github/workflows/multitable-onprem-package-build.yml
+++ b/.github/workflows/multitable-onprem-package-build.yml
@@ -59,11 +59,26 @@ jobs:
           pkg_tgz="$(ls -1 output/releases/multitable-onprem/*.tgz | sort | tail -n 1)"
           pkg_zip="$(ls -1 output/releases/multitable-onprem/*.zip | sort | tail -n 1)"
           pkg_meta="${pkg_tgz%.tgz}.json"
-          scripts/ops/multitable-onprem-package-verify.sh "$pkg_tgz"
-          scripts/ops/multitable-onprem-package-verify.sh "$pkg_zip"
+          pkg_name="$(basename "${pkg_tgz%.tgz}")"
+          verify_dir="output/releases/multitable-onprem/verify"
+          mkdir -p "$verify_dir"
+          verify_tgz_json="${verify_dir}/${pkg_name}.tgz.verify.json"
+          verify_tgz_md="${verify_dir}/${pkg_name}.tgz.verify.md"
+          verify_zip_json="${verify_dir}/${pkg_name}.zip.verify.json"
+          verify_zip_md="${verify_dir}/${pkg_name}.zip.verify.md"
+          VERIFY_REPORT_JSON="$verify_tgz_json" \
+          VERIFY_REPORT_MD="$verify_tgz_md" \
+            scripts/ops/multitable-onprem-package-verify.sh "$pkg_tgz"
+          VERIFY_REPORT_JSON="$verify_zip_json" \
+          VERIFY_REPORT_MD="$verify_zip_md" \
+            scripts/ops/multitable-onprem-package-verify.sh "$pkg_zip"
           echo "PACKAGE_FILE=$pkg_tgz" >> "$GITHUB_ENV"
           echo "PACKAGE_FILE_ZIP=$pkg_zip" >> "$GITHUB_ENV"
           echo "PACKAGE_META_FILE=$pkg_meta" >> "$GITHUB_ENV"
+          echo "PACKAGE_VERIFY_TGZ_JSON=$verify_tgz_json" >> "$GITHUB_ENV"
+          echo "PACKAGE_VERIFY_TGZ_MD=$verify_tgz_md" >> "$GITHUB_ENV"
+          echo "PACKAGE_VERIFY_ZIP_JSON=$verify_zip_json" >> "$GITHUB_ENV"
+          echo "PACKAGE_VERIFY_ZIP_MD=$verify_zip_md" >> "$GITHUB_ENV"
 
       - name: Publish GitHub Release
         if: ${{ inputs.publish_release == 'true' }}
@@ -86,6 +101,10 @@ jobs:
             "${PACKAGE_FILE_ZIP}.sha256"
             "output/releases/multitable-onprem/SHA256SUMS"
             "$PACKAGE_META_FILE"
+            "$PACKAGE_VERIFY_TGZ_JSON"
+            "$PACKAGE_VERIFY_TGZ_MD"
+            "$PACKAGE_VERIFY_ZIP_JSON"
+            "$PACKAGE_VERIFY_ZIP_MD"
           )
 
           if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
@@ -106,6 +125,8 @@ jobs:
             output/releases/multitable-onprem/*.sha256
             output/releases/multitable-onprem/SHA256SUMS
             output/releases/multitable-onprem/*.json
+            output/releases/multitable-onprem/verify/*.json
+            output/releases/multitable-onprem/verify/*.md
           retention-days: 14
 
       - name: Step summary
@@ -115,6 +136,8 @@ jobs:
             echo ""
             echo "- Package (.tgz): \`${PACKAGE_FILE}\`"
             echo "- Package (.zip): \`${PACKAGE_FILE_ZIP}\`"
+            echo "- Verify (.tgz JSON): \`${PACKAGE_VERIFY_TGZ_JSON}\`"
+            echo "- Verify (.zip JSON): \`${PACKAGE_VERIFY_ZIP_JSON}\`"
             echo "- Artifact: \`multitable-onprem-package-${{ github.run_id }}-${{ github.run_attempt }}\`"
             if [[ "${{ inputs.publish_release }}" == "true" ]]; then
               echo "- Release tag: \`${{ inputs.release_tag }}\`"

--- a/docs/development/onprem-package-workflow-verify-reports-development-20260515.md
+++ b/docs/development/onprem-package-workflow-verify-reports-development-20260515.md
@@ -1,0 +1,66 @@
+# On-Prem Package Workflow Verify Reports Development - 2026-05-15
+
+## Purpose
+
+The K3/Data Factory delivery-readiness compiler now consumes the JSON report
+from `scripts/ops/multitable-onprem-package-verify.sh` through
+`--package-verify`.
+
+Before this change, the manual `Multitable On-Prem Package Build` workflow ran
+the verifier against both `.tgz` and `.zip`, but it did not persist the verifier
+JSON/Markdown reports. Operators could download the package artifact and still
+need to rerun the verifier locally just to get the JSON evidence required by
+the readiness compiler.
+
+This slice makes the official package workflow produce those reports as first
+class artifacts.
+
+## Changed Files
+
+- `.github/workflows/multitable-onprem-package-build.yml`
+- `docs/development/onprem-package-workflow-verify-reports-development-20260515.md`
+- `docs/development/onprem-package-workflow-verify-reports-verification-20260515.md`
+
+## Behavior
+
+The workflow now writes:
+
+```text
+output/releases/multitable-onprem/verify/<PACKAGE_NAME>.tgz.verify.json
+output/releases/multitable-onprem/verify/<PACKAGE_NAME>.tgz.verify.md
+output/releases/multitable-onprem/verify/<PACKAGE_NAME>.zip.verify.json
+output/releases/multitable-onprem/verify/<PACKAGE_NAME>.zip.verify.md
+```
+
+It exports those paths through `GITHUB_ENV` so later workflow steps can:
+
+- upload them in the workflow artifact;
+- publish them to GitHub Releases when `publish_release=true`;
+- show the JSON paths in the step summary.
+
+## Operator Impact
+
+After the next official package workflow run, the downloaded artifact contains
+the package and its verifier evidence together. A deployment operator can feed
+the JSON directly into:
+
+```bash
+node scripts/ops/integration-k3wise-delivery-readiness.mjs \
+  --package-verify output/releases/multitable-onprem/verify/<PACKAGE_NAME>.zip.verify.json \
+  ...
+```
+
+No local rerun is needed unless the operator wants to re-verify a copied or
+modified archive.
+
+## Scope Boundary
+
+This does not change package contents, package verification rules, backend
+runtime behavior, migrations, frontend code, or K3/Data Factory business logic.
+It only persists verifier reports that the workflow already has enough evidence
+to generate.
+
+## Claude Code
+
+Claude Code is not required. This is a GitHub Actions packaging workflow
+change, plus documentation and static validation.

--- a/docs/development/onprem-package-workflow-verify-reports-verification-20260515.md
+++ b/docs/development/onprem-package-workflow-verify-reports-verification-20260515.md
@@ -1,0 +1,47 @@
+# On-Prem Package Workflow Verify Reports Verification - 2026-05-15
+
+## Verification Date
+
+2026-05-15T09:18:46Z
+
+## Commands
+
+```bash
+ruby -e "require 'yaml'; YAML.load_file('.github/workflows/multitable-onprem-package-build.yml')"
+rg -n "VERIFY_REPORT_JSON|PACKAGE_VERIFY_TGZ_JSON|PACKAGE_VERIFY_ZIP_JSON|output/releases/multitable-onprem/verify" \
+  .github/workflows/multitable-onprem-package-build.yml
+git diff --check origin/main...HEAD
+```
+
+## Expected Assertions
+
+| Area | Assertion |
+| --- | --- |
+| Workflow syntax | GitHub Actions YAML parses successfully. |
+| Verifier command | Both `.tgz` and `.zip` verifier runs set `VERIFY_REPORT_JSON` and `VERIFY_REPORT_MD`. |
+| Artifact upload | Workflow artifact includes `output/releases/multitable-onprem/verify/*.json` and `*.md`. |
+| Release publish | `publish_release=true` includes all four verifier reports in release assets. |
+| Step summary | Summary prints the tgz/zip verifier JSON paths. |
+
+## Local Results
+
+| Command | Result |
+| --- | --- |
+| `ruby -e "require 'yaml'; YAML.load_file(...)"` | PASS |
+| `rg ... workflow contract scan` | PASS |
+| `git diff --check origin/main...HEAD` | PASS |
+| secret-pattern scan over workflow and docs | PASS, 0 matches |
+
+## Deployment Impact
+
+- No runtime change.
+- No package-content change.
+- No migration.
+- Next official package workflow artifact gains four verifier report files.
+- Release publishing gains four verifier report assets when enabled.
+
+## Secret Hygiene
+
+The verifier reports are structural package evidence. They contain package
+names, archive type, check names, and paths; they do not contain K3 credentials,
+MetaSheet bearer tokens, SQL connection strings, or passwords.


### PR DESCRIPTION
## Summary

- make the manual Multitable On-Prem Package Build workflow persist package verifier JSON/MD reports for both tgz and zip artifacts
- include those verifier reports in workflow artifacts and optional GitHub Release assets
- show verifier JSON paths in the workflow step summary
- add development and verification MD for this workflow packaging handoff

## Verification

- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/multitable-onprem-package-build.yml')"`\n- `rg -n "VERIFY_REPORT_JSON|PACKAGE_VERIFY_TGZ_JSON|PACKAGE_VERIFY_ZIP_JSON|output/releases/multitable-onprem/verify" .github/workflows/multitable-onprem-package-build.yml`\n- `git diff --check origin/main...HEAD`\n- secret-pattern scan over the workflow and docs: 0 matches\n\n## Deployment Impact\n\nNo runtime, migration, or package-content change. The next official on-prem package workflow artifact will include four verifier report files under `output/releases/multitable-onprem/verify/`, so the K3 delivery-readiness compiler can consume package evidence directly without an operator rerunning the verifier locally.\n\n## Claude Code\n\nNot needed. This is GitHub Actions packaging metadata and docs only.