### PR TITLE
fix(integration): accept K3 session id in live preflight

### DIFF
--- a/docs/development/integration-k3wise-onprem-preflight-session-id-design-20260515.md
+++ b/docs/development/integration-k3wise-onprem-preflight-session-id-design-20260515.md
@@ -1,0 +1,67 @@
+# K3 WISE On-Prem Preflight Session ID Design - 2026-05-15
+
+## Purpose
+
+Close the C2/C3 credential mismatch in the live K3 WISE PoC flow.
+
+The live PoC packet builder already accepts either:
+
+- `credentials.sessionId`; or
+- `credentials.username` + `credentials.password`.
+
+Before this change, the on-prem live preflight only accepted
+`K3_USERNAME` + `K3_PASSWORD`. A customer who supplied only a K3 session id could
+pass packet validation but still fail C2 with `GATE_BLOCKED`.
+
+## Change
+
+`scripts/ops/integration-k3wise-onprem-preflight.mjs` now accepts:
+
+```text
+K3_API_URL
+K3_ACCT_ID
+K3_SESSION_ID
+```
+
+or:
+
+```text
+K3_API_URL
+K3_ACCT_ID
+K3_USERNAME
+K3_PASSWORD
+```
+
+The live-config check reports:
+
+- `authMode=sessionId` when `K3_SESSION_ID` is present;
+- `authMode=usernamePassword` when username/password is used;
+- `sessionIdPresent`, `usernamePresent`, and `passwordPresent` booleans.
+
+It never stores the raw `K3_SESSION_ID`, username password, or password value.
+
+## Safety Boundary
+
+The on-prem preflight remains read-only:
+
+- no K3 WebAPI call;
+- no DB write;
+- no migration run;
+- only a TCP probe to the K3 host/port in live mode.
+
+Session id support is a presence-contract fix, not an authentication or K3 API
+behavior change.
+
+## Documentation
+
+`docs/operations/integration-k3wise-live-gate-execution-package.md` now documents
+C2/C3 credential parity and maps:
+
+- `k3Wise.credentials.sessionId` to `K3_SESSION_ID`;
+- `k3Wise.credentials.username` to `K3_USERNAME`;
+- `k3Wise.credentials.password` to `K3_PASSWORD`.
+
+## Claude Code
+
+Claude Code is not required. The slice is fully repo-local and covered by the
+existing on-prem preflight tests.

--- a/docs/development/integration-k3wise-onprem-preflight-session-id-verification-20260515.md
+++ b/docs/development/integration-k3wise-onprem-preflight-session-id-verification-20260515.md
@@ -1,0 +1,67 @@
+# K3 WISE On-Prem Preflight Session ID Verification - 2026-05-15
+
+## Verification Date
+
+2026-05-15T09:23:38Z
+
+## Commands
+
+```bash
+node --check scripts/ops/integration-k3wise-onprem-preflight.mjs
+pnpm verify:integration-k3wise:onprem-preflight
+node --test scripts/ops/integration-k3wise-live-poc-preflight.test.mjs
+pnpm verify:integration-k3wise:delivery
+rg -n "K3_SESSION_ID|sessionId|K3_USERNAME|K3_PASSWORD|C2/C3 credential parity" \
+  scripts/ops/integration-k3wise-onprem-preflight.mjs \
+  scripts/ops/integration-k3wise-onprem-preflight.test.mjs \
+  docs/operations/integration-k3wise-live-gate-execution-package.md
+git diff --check origin/main...HEAD
+```
+
+## Expected Assertions
+
+| Area | Assertion |
+| --- | --- |
+| Live config | `K3_SESSION_ID` plus `K3_API_URL` and `K3_ACCT_ID` passes `k3.live-config`. |
+| Live config | Username/password still passes unchanged. |
+| Missing config | Missing credentials now reports `K3_USERNAME+K3_PASSWORD or K3_SESSION_ID`. |
+| Secret hygiene | Raw `K3_SESSION_ID` never appears in stdout, JSON, or Markdown. |
+| Docs | Live GATE package no longer documents C2/C3 divergence. |
+
+## Local Results
+
+| Command | Result |
+| --- | --- |
+| `node --check scripts/ops/integration-k3wise-onprem-preflight.mjs` | PASS |
+| `pnpm verify:integration-k3wise:onprem-preflight` | PASS, 15/15 |
+| `node --test scripts/ops/integration-k3wise-live-poc-preflight.test.mjs` | PASS, 21/21 |
+| `pnpm verify:integration-k3wise:delivery` | PASS, 10/10 |
+| `rg ...` contract scan | PASS |
+| `git diff --check origin/main...HEAD` | PASS |
+
+## Secret Scan
+
+```bash
+rg -n "(eyJ[A-Za-z0-9_-]{20,}|Bearer\\s+[A-Za-z0-9._-]+|password\\s*[:=]\\s*['\\\"][^<]|access_token=|api_key=|session_id=|postgres(ql)?://[^:/?@[:space:]]+:[^@[:space:]]+@)" \
+  scripts/ops/integration-k3wise-onprem-preflight.mjs \
+  scripts/ops/integration-k3wise-onprem-preflight.test.mjs \
+  docs/operations/integration-k3wise-live-gate-execution-package.md \
+  docs/development/integration-k3wise-onprem-preflight-session-id-design-20260515.md
+```
+
+Expected matches are test fixtures and `<fill-outside-git>` placeholders only:
+
+- redaction tests deliberately include secret-looking URL/query values;
+- the live GATE runbook contains a synthetic
+  `postgres://rehearsal:<fill-outside-git>@...` example.
+
+No real secret value is introduced.
+
+## Deployment Impact
+
+- No backend runtime change.
+- No database migration.
+- No frontend change.
+- No package-content change.
+- Operators can now run C2 live preflight for customers who provide a K3 session
+  id instead of username/password.

--- a/docs/operations/integration-k3wise-live-gate-execution-package.md
+++ b/docs/operations/integration-k3wise-live-gate-execution-package.md
@@ -76,22 +76,16 @@ deliberately omitted from this list.
 | K3 WISE version | `k3Wise.version` (audit) | non-empty string |
 | K3 WebAPI URL | `k3Wise.apiUrl` | http or https; URL must NOT contain userinfo and must NOT contain query parameters whose key matches secret patterns (`access_token` / `token` / `password` / `secret` / `sign[ature]` / `api_key` / `session_id` / `auth`) |
 | K3 account id (acctId) | `k3Wise.acctId` | non-empty string |
-| K3 credentials | one of: `credentials.sessionId`, OR `credentials.username` + `credentials.password` | C3 (live preflight) accepts either; **C2 (on-prem preflight `--live`) currently requires `K3_USERNAME` + `K3_PASSWORD` env regardless** — see C2-vs-C3 note below |
+| K3 credentials | one of: `credentials.sessionId`, OR `credentials.username` + `credentials.password` | C2 and C3 both accept either credential shape. For C2, inject `K3_SESSION_ID` for sessionId-only customers, or `K3_USERNAME` + `K3_PASSWORD` for username/password customers. |
 | `autoSubmit` | must be `false` (Save-only safety) | enforced — packet build throws if true |
 | `autoAudit` | must be `false` | enforced — packet build throws if true |
 
-**C2 vs C3 K3-credential divergence** (sessionId-only customers): the live PoC
-preflight (`integration-k3wise-live-poc-preflight.mjs`'s `assertK3AuthContract`)
-accepts a `sessionId`-only credential bundle and PASSes. The on-prem preflight
-(`integration-k3wise-onprem-preflight.mjs --live`) does not have an env path
-for sessionId — it always requires `K3_USERNAME` and `K3_PASSWORD` env vars
-and reports `gate-blocked` otherwise. If the customer only supplies a
-sessionId, **C2 will fail with `GATE_BLOCKED` even when the GATE answer is
-contractually complete from C3's perspective.** Workarounds today: provide a
-synthetic placeholder env (not recommended — it lies about what is set), or
-skip C2 in the sessionId-only case and rely on C3 + the postdeploy auth
-smoke. A future on-prem-preflight enhancement would add `K3_SESSION_ID` env
-support.
+**C2/C3 credential parity**: the live PoC preflight
+(`integration-k3wise-live-poc-preflight.mjs`'s `assertK3AuthContract`) and the
+on-prem preflight (`integration-k3wise-onprem-preflight.mjs --live`) now accept
+the same two credential shapes: `sessionId`, or `username` + `password`. C2 only
+records presence booleans such as `sessionIdPresent=true`; it never writes the
+raw session id, username password, or password into artifacts.
 
 ### A.3 PLM source (required)
 
@@ -157,6 +151,7 @@ different points; the same answer feeds both.
 |---|---|---|
 | `k3Wise.apiUrl` | `K3_API_URL` (or `K3_BASE_URL`) | TCP-probe in C2; configured in K3 external system in C4 |
 | `k3Wise.acctId` | `K3_ACCT_ID` | preflight presence check; recorded in packet |
+| `k3Wise.credentials.sessionId` | `K3_SESSION_ID` | presence check only — value never persisted |
 | `k3Wise.credentials.username` | `K3_USERNAME` | presence check only — value never persisted |
 | `k3Wise.credentials.password` | `K3_PASSWORD` | presence check only — value never persisted |
 | `tenantId` | (consumed by metasheet runtime, not preflight env) | tenant scope for control-plane lists |
@@ -177,7 +172,7 @@ next step only after PASS.
 | **C0** | Mock chain smoke (no GATE needed) | Anytime | `pnpm verify:integration-k3wise:poc` | 37 unit tests + 9-step end-to-end mock chain all green (mock K3 WebAPI + mock SQL + Save-only upsert + safety guard rejects core-table INSERT + evidence compiler PASS) | Any sub-step fails |
 | **C0.5** | Package verify report | After downloading the on-prem zip/tgz and before deploy signoff | see [C0.5 package verify report](#c05-package-verify-report) | verifier exits 0 and writes `package-verify.json` with `ok=true`; `required-content` / `checksum` / `no-github-links` PASS | verifier exits non-zero, missing K3 readiness scripts/docs, checksum mismatch, or delivery docs contain forbidden GitHub links |
 | **C1** | On-prem preflight (mock mode) | After deploy, before GATE arrives | `node scripts/ops/integration-k3wise-onprem-preflight.mjs --mock --out-dir <art>` (see [C1 prerequisites](#c1-prerequisites) below) | exit 0; `decision=PASS`; `pg.tcp-reachable` / `pg.migrations-aligned` / `fixtures.k3wise-mock` all `pass`; all K3 / gate checks `skip` | exit 1 (mandatory env defect — `env.database-url` and/or `env.jwt-secret` not satisfied; see [C1 prerequisites](#c1-prerequisites)) |
-| **C2** | On-prem preflight `--live` | Once GATE answers received | `node scripts/ops/integration-k3wise-onprem-preflight.mjs --live --gate-file <path> --out-dir <art>` with `K3_API_URL` / `K3_ACCT_ID` / `K3_USERNAME` / `K3_PASSWORD` injected | exit 0; `k3.live-config` `pass` (4 fields present); `k3.live-reachable` `pass` (TCP to K3 host:port); `gate.file-present` `pass` | exit 1 (mandatory) or exit 2 (`GATE_BLOCKED` — customer field still missing). For per-error-code fix recipes (`ECONNREFUSED` / `ENOTFOUND` / `EHOSTUNREACH` / `ETIMEDOUT`) on `pg.tcp-reachable` and `k3.live-reachable`, see `docs/operations/k3-poc-onprem-preflight-runbook.md` § "Per-check failure recipes". |
+| **C2** | On-prem preflight `--live` | Once GATE answers received | `node scripts/ops/integration-k3wise-onprem-preflight.mjs --live --gate-file <path> --out-dir <art>` with `K3_API_URL` / `K3_ACCT_ID` plus either `K3_SESSION_ID` or `K3_USERNAME` + `K3_PASSWORD` injected | exit 0; `k3.live-config` `pass` (endpoint, acctId, and one credential shape present); `k3.live-reachable` `pass` (TCP to K3 host:port); `gate.file-present` `pass` | exit 1 (mandatory) or exit 2 (`GATE_BLOCKED` — customer field still missing). For per-error-code fix recipes (`ECONNREFUSED` / `ENOTFOUND` / `EHOSTUNREACH` / `ETIMEDOUT`) on `pg.tcp-reachable` and `k3.live-reachable`, see `docs/operations/k3-poc-onprem-preflight-runbook.md` § "Per-check failure recipes". |
 | **C3** | Build live PoC packet + GATE contract validation | After C2 PASS | `node scripts/ops/integration-k3wise-live-poc-preflight.mjs --input <gate.json> --out-dir <packet-dir>` | `integration-k3wise-live-poc-packet.{json,md}` written; `safety.saveOnly=true / autoSubmit=false / autoAudit=false`; checklist contains `GATE-01 / CONN-01 / CONN-02 / DRY-01 / SAVE-01 / FAIL-01 / ROLLBACK-01` (plus `BOM-01` when BOM enabled) | `normalizeGate` throws (error includes `field` path of the offending key) |
 | **C4** | testConnection — PLM + K3 (control plane) | After C3 | metasheet console: register both external systems → testConnection | both return `ok=true` | either non-ok (GATE field wrong / customer network / credentials) |
 | **C5** | Material dry-run, 1–3 rows | After C4 PASS | metasheet console: trigger dry-run pipeline | dry-run report shows mappings applied correctly; `preview.records[].targetPayload.Data` matches the material template (`FNumber`, `FName`, optional `FModel`, `FBaseUnitID`) and contains no secret fields | mapping incomplete or validation rule mismatch |

--- a/scripts/ops/integration-k3wise-onprem-preflight.mjs
+++ b/scripts/ops/integration-k3wise-onprem-preflight.mjs
@@ -378,12 +378,15 @@ function checkLiveK3Config(env, mode, summary) {
   const acctId = (env.K3_ACCT_ID || '').trim()
   const username = (env.K3_USERNAME || '').trim()
   const passwordPresent = Boolean((env.K3_PASSWORD || '').trim())
+  const sessionIdPresent = Boolean((env.K3_SESSION_ID || '').trim())
+  const usernamePasswordPresent = Boolean(username && passwordPresent)
 
   const missing = []
   if (!apiUrl) missing.push('K3_API_URL')
   if (!acctId) missing.push('K3_ACCT_ID')
-  if (!username) missing.push('K3_USERNAME')
-  if (!passwordPresent) missing.push('K3_PASSWORD')
+  if (!sessionIdPresent && !usernamePasswordPresent) {
+    missing.push('K3_USERNAME+K3_PASSWORD or K3_SESSION_ID')
+  }
 
   let parsedUrl = null
   if (apiUrl) {
@@ -415,8 +418,10 @@ function checkLiveK3Config(env, mode, summary) {
     // parsedUrl.hostname/port; it is never persisted.
     apiUrl: sanitizeUrl(apiUrl),
     acctId,
-    usernamePresent: true,
-    passwordPresent: true,
+    authMode: sessionIdPresent ? 'sessionId' : 'usernamePassword',
+    usernamePresent: Boolean(username),
+    passwordPresent,
+    sessionIdPresent,
   })
   return parsedUrl
 }
@@ -508,7 +513,7 @@ function renderMarkdown(summary) {
     '- Read-only: no DB writes, no migration runs, no K3 write calls.',
     '- Mock mode does not require any K3 endpoint or credentials.',
     '- Live mode performs only a TCP-level reachability probe on the K3 endpoint host:port; it does NOT call the K3 API.',
-    '- Secrets are redacted in all output paths — stdout/MD via `redactString` and preflight.json via `sanitizeUrl` at storage time. Covered: DATABASE_URL / K3_API_URL userinfo password; query params keyed `access_token` / `token` / `password` / `secret` / `sign(ature)` / `api_key` / `session_id` / `auth`; `Bearer …` headers; `eyJ…` JWT-shaped tokens; K3_PASSWORD value.',
+    '- Secrets are redacted in all output paths — stdout/MD via `redactString` and preflight.json via `sanitizeUrl` at storage time. Covered: DATABASE_URL / K3_API_URL userinfo password; query params keyed `access_token` / `token` / `password` / `secret` / `sign(ature)` / `api_key` / `session_id` / `auth`; `Bearer …` headers; `eyJ…` JWT-shaped tokens; K3_PASSWORD and K3_SESSION_ID values.',
     '',
   )
   return lines.join('\n') + '\n'
@@ -550,7 +555,8 @@ GATE has supplied real K3 answers.
 
 Options:
   --mock                  (default) skip live K3 endpoint and gate-file checks
-  --live                  require K3_API_URL/K3_ACCT_ID/K3_USERNAME/K3_PASSWORD
+  --live                  require K3_API_URL/K3_ACCT_ID plus either
+                          K3_USERNAME+K3_PASSWORD or K3_SESSION_ID
                           and TCP-reach the K3 endpoint host:port
   --gate-file <path>      Path to GATE answer JSON (required for --live)
   --out-dir <dir>         Override artifact directory

--- a/scripts/ops/integration-k3wise-onprem-preflight.test.mjs
+++ b/scripts/ops/integration-k3wise-onprem-preflight.test.mjs
@@ -15,6 +15,7 @@ const VALID_JWT = 'a'.repeat(48)
 const SHORT_JWT = 'shortsecret'
 const LIVE_K3_PASSWORD = 'k3-password-hunter2'
 const LIVE_K3_USERNAME = 'k3-test-user'
+const LIVE_K3_SESSION_ID = 'k3-session-id-secret-value'
 const LIVE_K3_ACCT_ID = 'AIS_TEST_LIVE'
 const LIVE_K3_URL = 'http://127.0.0.1:65431/K3API/'
 
@@ -148,7 +149,7 @@ test('exit 2 (GATE_BLOCKED) when --live and K3 env is missing', () => {
     assert.equal(liveConfig.status, 'gate-blocked')
     assert.deepEqual(
       liveConfig.details.missing.sort(),
-      ['K3_ACCT_ID', 'K3_API_URL', 'K3_PASSWORD', 'K3_USERNAME'].sort(),
+      ['K3_ACCT_ID', 'K3_API_URL', 'K3_USERNAME+K3_PASSWORD or K3_SESSION_ID'].sort(),
     )
     const gate = findCheck(json, 'gate.file-present')
     assert.equal(gate.status, 'gate-blocked')
@@ -281,10 +282,46 @@ test('output redacts real secret values in stdout, JSON, and MD', () => {
     assert.equal(liveConfig.details.acctId, LIVE_K3_ACCT_ID)
     assert.equal(liveConfig.details.passwordPresent, true)
     assert.equal(liveConfig.details.usernamePresent, true)
+    assert.equal(liveConfig.details.sessionIdPresent, false)
+    assert.equal(liveConfig.details.authMode, 'usernamePassword')
     assert.equal(liveConfig.details.apiUrl, LIVE_K3_URL)
     // The username field must be a presence boolean, not the value
     assert.ok(!('username' in liveConfig.details))
     assert.ok(!('password' in liveConfig.details))
+  } finally {
+    rmSync(tmp, { recursive: true, force: true })
+  }
+})
+
+test('live preflight accepts K3_SESSION_ID without username/password and does not leak it', () => {
+  const tmp = makeTmpDir()
+  try {
+    const out = path.join(tmp, 'r')
+    const result = runScript(
+      ['--live', '--skip-tcp', '--skip-migrations', '--out-dir', out],
+      {
+        DATABASE_URL: VALID_DB_URL,
+        JWT_SECRET: VALID_JWT,
+        K3_API_URL: LIVE_K3_URL,
+        K3_ACCT_ID: LIVE_K3_ACCT_ID,
+        K3_SESSION_ID: LIVE_K3_SESSION_ID,
+      },
+    )
+    const { json, md } = readOutputs(out)
+    const jsonText = JSON.stringify(json)
+
+    assertNoLeak(result.stdout, [LIVE_K3_SESSION_ID])
+    assertNoLeak(jsonText, [LIVE_K3_SESSION_ID])
+    assertNoLeak(md, [LIVE_K3_SESSION_ID])
+
+    const liveConfig = findCheck(json, 'k3.live-config')
+    assert.equal(liveConfig.status, 'pass')
+    assert.equal(liveConfig.details.acctId, LIVE_K3_ACCT_ID)
+    assert.equal(liveConfig.details.authMode, 'sessionId')
+    assert.equal(liveConfig.details.sessionIdPresent, true)
+    assert.equal(liveConfig.details.usernamePresent, false)
+    assert.equal(liveConfig.details.passwordPresent, false)
+    assert.ok(!('sessionId' in liveConfig.details))
   } finally {
     rmSync(tmp, { recursive: true, force: true })
   }


### PR DESCRIPTION
## Summary

- allow `integration-k3wise-onprem-preflight.mjs --live` to accept `K3_SESSION_ID` instead of requiring `K3_USERNAME` + `K3_PASSWORD`
- keep username/password support unchanged
- report credential state as presence booleans plus `authMode`, never raw session id/password values
- update the live GATE package to remove the documented C2/C3 credential mismatch
- add design and verification MD for the session-id live preflight contract

## Verification

- `node --check scripts/ops/integration-k3wise-onprem-preflight.mjs`
- `pnpm verify:integration-k3wise:onprem-preflight` (15/15)
- `node --test scripts/ops/integration-k3wise-live-poc-preflight.test.mjs` (21/21)
- `pnpm verify:integration-k3wise:delivery` (10/10)
- `rg -n "K3_SESSION_ID|sessionId|K3_USERNAME|K3_PASSWORD|C2/C3 credential parity" ...`
- `git diff --check origin/main...HEAD`

## Deployment Impact

No runtime backend change, no migration, no frontend change. Operators can now run C2 live preflight for customers who provide a K3 session id instead of username/password.

## Claude Code

Not needed. This is repo-local script/docs/test work; bridge-machine Claude Code remains relevant for the real SQL executor and live Windows/K3 connectivity checks.