### PR TITLE
docs(integration): add K3 WISE GATE intake template

### DIFF
--- a/docs/development/integration-k3wise-gate-intake-template-development-20260515.md
+++ b/docs/development/integration-k3wise-gate-intake-template-development-20260515.md
@@ -1,0 +1,60 @@
+# K3 WISE GATE Intake Template Development - 2026-05-15
+
+## Purpose
+
+Close the first remaining Stage D gap in
+`docs/operations/integration-k3wise-live-gate-execution-package.md`: a
+customer-facing GATE intake template that can be sent before the customer
+returns live K3 WISE answers.
+
+The existing `gate-sample.json` remains the engineer-facing sample that tracks
+`integration-k3wise-live-poc-preflight.mjs --print-sample`. This change adds a
+separate operator/customer template with inline A.1-A.6 guidance while keeping
+the same accepted JSON shape.
+
+## Changes
+
+- Added
+  `scripts/ops/fixtures/integration-k3wise/gate-intake-template.json`.
+- Updated fixture contract tests to prove the new template is accepted by the
+  live preflight packet builder.
+- Updated
+  `docs/operations/integration-k3wise-live-gate-execution-package.md` so the
+  runbook points operators to the template and marks the previous
+  customer-facing intake gap as closed.
+- Updated
+  `scripts/ops/fixtures/integration-k3wise/README.md` to distinguish
+  engineer-facing samples from customer-facing intake.
+- Updated `scripts/ops/multitable-onprem-package-verify.sh` so future
+  on-prem packages must include the template and must keep its core safety
+  strings.
+
+## Template Contract
+
+The checked-in template:
+
+- Uses only safe example non-secret values and `<fill-outside-git>` credential
+  placeholders.
+- Defaults `k3Wise.autoSubmit=false` and `k3Wise.autoAudit=false`.
+- Defaults the advanced SQL Server channel to disabled.
+- Carries A.1-A.6 section labels and review notes for implementation
+  operators.
+- Is accepted by `buildPacket()` as `status=preflight-ready`.
+- Does not carry raw token/query secret values, JWT-like strings, or raw
+  Postgres userinfo.
+
+Filled customer copies must stay outside Git. The repo template is the shape
+and review checklist, not the place to store customer credentials.
+
+## Deployment Impact
+
+No runtime service code changed. The only deploy-facing behavior is package
+content verification: once this lands, the on-prem package verifier requires
+`scripts/ops/fixtures/integration-k3wise/gate-intake-template.json` and checks
+that the live GATE runbook documents it.
+
+## Claude Code
+
+Claude Code is not needed for this slice. It is useful later for bridge-machine
+work that requires live Windows/K3 connectivity, but this change is
+repo-local: fixture, runbook, package-verifier contract, and tests.

--- a/docs/development/integration-k3wise-gate-intake-template-verification-20260515.md
+++ b/docs/development/integration-k3wise-gate-intake-template-verification-20260515.md
@@ -1,0 +1,131 @@
+# K3 WISE GATE Intake Template Verification - 2026-05-15
+
+## Summary
+
+This verification proves the new customer-facing GATE intake template compiles
+into a live preflight packet, does not weaken the K3 WISE mock PoC chain, and
+is enforced by the on-prem package verifier.
+
+## Commands
+
+### Fixture Contract
+
+```bash
+node --test scripts/ops/fixtures/integration-k3wise/fixture-contract.test.mjs
+```
+
+Result:
+
+```text
+tests 3
+pass 3
+fail 0
+```
+
+The new test asserts:
+
+- `_instructions.secretPlaceholder` is `<fill-outside-git>`.
+- A.1 and A.6 customer sections are present.
+- `buildPacket(template)` returns `status=preflight-ready`.
+- Save-only remains enforced.
+- SQL Server mode is `disabled`.
+- material and BOM pipelines are generated.
+- the generated packet does not contain `<fill-outside-git>`.
+
+### Live Preflight CLI
+
+```bash
+node scripts/ops/integration-k3wise-live-poc-preflight.mjs \
+  --input scripts/ops/fixtures/integration-k3wise/gate-intake-template.json \
+  --out-dir /tmp/ms2-gate-intake-template-packet
+```
+
+Result:
+
+```json
+{
+  "status": "preflight-ready",
+  "sqlServerMode": "disabled",
+  "externalSystems": 2,
+  "pipelines": 2,
+  "secretPlaceholderPresent": false
+}
+```
+
+### K3 WISE Offline PoC Regression
+
+```bash
+pnpm verify:integration-k3wise:poc
+```
+
+Result:
+
+```text
+live-poc-preflight.test.mjs: 21/21 pass
+live-poc-evidence.test.mjs: 50/50 pass
+fixture-contract.test.mjs: 3/3 pass
+mock-k3-webapi-server.test.mjs: 4/4 pass
+mock-sqlserver-executor.test.mjs: 12/12 pass
+run-mock-poc-demo.mjs: PASS
+```
+
+### Package Verifier Smoke
+
+Baseline official package used for the package-layout smoke:
+
+```text
+Workflow: Multitable On-Prem Package Build
+Run: 25911075364
+URL: https://github.com/zensgit/metasheet2/actions/runs/25911075364
+Head SHA: 48a71dd2d4c9f4c2400003448eeaf39bd2b9dd23
+Conclusion: success
+Artifact: multitable-onprem-package-25911075364-1
+```
+
+The official zip was extracted, this PR's template/runbook/verifier files were
+overlaid into the package root, and the updated verifier was run against the
+resulting smoke archive:
+
+```bash
+VERIFY_REPORT_JSON=/tmp/ms2-gate-intake-package-smoke/gate-intake-smoke.verify.json \
+VERIFY_REPORT_MD=/tmp/ms2-gate-intake-package-smoke/gate-intake-smoke.verify.md \
+  scripts/ops/multitable-onprem-package-verify.sh \
+  /tmp/ms2-gate-intake-package-smoke/metasheet-multitable-onprem-v2.5.0-gate-intake-smoke.zip
+```
+
+Result:
+
+```json
+{
+  "ok": true,
+  "archiveType": "zip",
+  "requiredCount": 72,
+  "checks": [
+    { "name": "checksum", "status": "PASS" },
+    { "name": "required-content", "status": "PASS" },
+    { "name": "no-github-links", "status": "PASS" }
+  ]
+}
+```
+
+This smoke verifies the package verifier contract. A fresh official package
+build after merge remains the authoritative full-build artifact.
+
+### Hygiene
+
+```bash
+git diff --check
+```
+
+Result: exit 0.
+
+Template secret scan:
+
+```json
+{
+  "rawUrlSecret": false,
+  "rawJwt": false,
+  "rawPg": false,
+  "forbiddenSecretValue": false
+}
+```

--- a/docs/operations/integration-k3wise-live-gate-execution-package.md
+++ b/docs/operations/integration-k3wise-live-gate-execution-package.md
@@ -26,7 +26,8 @@ preflight and Save-only PoC, which they only touch tangentially.
   signed off.
 - After the downloaded on-prem package has produced a package verifier JSON
   report.
-- Before sending the GATE intake template to the customer.
+- Before sending `scripts/ops/fixtures/integration-k3wise/gate-intake-template.json`
+  to the customer for completion outside Git.
 - During customer answer review (does the answer satisfy the hard contracts?).
 - During live PoC execution (which command runs when, what counts as PASS).
 
@@ -46,6 +47,11 @@ preflight and Save-only PoC, which they only touch tangentially.
   any artifact path under `artifacts/integration-k3wise/`. The schema uses
   `<fill-outside-git>` as the only sanctioned placeholder for credential
   values.
+- The customer-facing intake template is
+  `scripts/ops/fixtures/integration-k3wise/gate-intake-template.json`.
+  It is a fillable wrapper around the script sample: it keeps the same
+  accepted JSON shape, adds A.1–A.6 review notes, defaults SQL Server to
+  disabled, and must be copied outside Git before real values are entered.
 - **Live preflight (Stage C step C2 onward) is gated by customer GATE
   arrival**. Until the customer has supplied A.1–A.6 answers,
   `--live` runs return `exit 2 / decision=GATE_BLOCKED` by design (the
@@ -59,6 +65,17 @@ preflight and Save-only PoC, which they only touch tangentially.
 The customer must answer all rows below. Operator-side fields
 (`DATABASE_URL`, `JWT_SECRET`, etc.) are **not** customer-facing and are
 deliberately omitted from this list.
+
+Start from the checked-in customer template:
+
+```bash
+cp scripts/ops/fixtures/integration-k3wise/gate-intake-template.json \
+  /secure/customer-gate/k3wise-gate.json
+```
+
+Only the copied file should receive real customer values. Keep the checked-in
+template free of real hosts, account ids, passwords, tokens, and SQL
+credentials.
 
 ### A.1 Test scope (required)
 
@@ -268,6 +285,7 @@ Same prerequisites apply to C2 (which also runs `env.database-url` /
 | Resource | Path / entry | What it covers | Gap |
 |---|---|---|---|
 | GATE schema (authoritative) | `node scripts/ops/integration-k3wise-live-poc-preflight.mjs --print-sample` | Complete JSON template for A.1–A.6 | It's a schema, not a guide; raw JSON is unfriendly to a customer reviewer |
+| Customer-facing intake template | `scripts/ops/fixtures/integration-k3wise/gate-intake-template.json` | Fillable A.1–A.6 wrapper with inline review notes, secret placeholders, Save-only defaults, and SQL disabled by default | None for pre-answer intake; filled copies must stay outside Git |
 | GATE field semantics | `scripts/ops/integration-k3wise-live-poc-preflight.mjs` (`normalizeGate()` and its throws) | The exact text of every hard-constraint failure | No human-readable (especially Chinese) explanation for non-engineer reviewers |
 | On-prem preflight runbook | `docs/operations/k3-poc-onprem-preflight-runbook.md` (PR #1437) | C1 / C2 operations, fix recipes for all 8 check IDs, Docker bridge-IP recipe | Does not explain field semantics — points at the schema |
 | Internal-trial postdeploy | `docs/operations/integration-k3wise-internal-trial-runbook.md` | Post-deploy auth smoke (control plane) before K3 enters the picture; host-shell mint pattern | Concerns metasheet itself, not K3 / PLM |
@@ -277,22 +295,18 @@ Same prerequisites apply to C2 (which also runs `env.database-url` /
 
 **Remaining gaps (priority order)**:
 
-1. **Customer-facing GATE intake template** — semi-structured (e.g., a fillable
-   YAML or wiki page) carrying A.1–A.6 in plain language, with constraint
-   notes inline ("environment must not be production", "BOM mapping must
-   include FParentItemNumber"), and the `<fill-outside-git>` placeholder
-   convention for secrets. Useful **before** the customer answers.
-2. **On-site evidence collection template** — slot-per-step JSON skeleton
+1. **On-site evidence collection template** — slot-per-step JSON skeleton
    covering C4–C9 (runId, externalId / billNo, dead-letter row id, rollback
    evidence). Drops directly into `--evidence <file>` of the compiler.
    Useful **during** PoC execution.
-3. **Field-semantics explainer** (Chinese) — design intent behind each hard
+2. **Field-semantics explainer** (Chinese) — design intent behind each hard
    constraint ("why production is forbidden", "why BOM requires product
    scope", "why core-table writes are blocked"). Best written **after** the
    first real PoC, driven by actual customer questions.
 
-Items 1 and 2 are non-blocking but high-leverage; item 3 is best deferred
-until there is real friction to capture.
+The customer-facing GATE intake template is now covered by the checked-in
+fixture above. The remaining two items are non-blocking; the field-semantics
+explainer is best deferred until there is real friction to capture.
 
 ---
 
@@ -352,6 +366,7 @@ EXIT=$?
 ## See also
 
 - `scripts/ops/integration-k3wise-live-poc-preflight.mjs` — packet builder and `--print-sample` schema source.
+- `scripts/ops/fixtures/integration-k3wise/gate-intake-template.json` — customer-facing fillable GATE intake template.
 - `scripts/ops/integration-k3wise-live-poc-evidence.mjs` — evidence compiler with the C10 contract.
 - `scripts/ops/integration-k3wise-delivery-readiness.mjs` — final readiness compiler that consumes postdeploy smoke, package verify, preflight packet, and optional live evidence.
 - `scripts/ops/multitable-onprem-package-verify.sh` — package-content verifier; set `VERIFY_REPORT_JSON` to feed C11.

--- a/scripts/ops/fixtures/integration-k3wise/README.md
+++ b/scripts/ops/fixtures/integration-k3wise/README.md
@@ -9,7 +9,8 @@ Fixtures and mock server for the K3 WISE Live PoC chain. Used to:
 
 | File | Purpose |
 |---|---|
-| `gate-sample.json` | Customer GATE answer template. Customer copies, fills in real values (K3 version, URLs, credentials placeholders), saves outside Git. Endpoint URLs must not include inline username/password or secret-like query params; use credential fields instead. |
+| `gate-sample.json` | Engineer-facing sample that stays equivalent to `integration-k3wise-live-poc-preflight.mjs --print-sample`. Endpoint URLs must not include inline username/password or secret-like query params; use credential fields instead. |
+| `gate-intake-template.json` | Customer-facing GATE intake template. It wraps the same accepted JSON shape with A.1-A.6 review notes, Save-only defaults, SQL disabled by default, and `<fill-outside-git>` credential placeholders. Copy it outside Git before entering real customer values. |
 | `evidence-sample.json` | Customer-side evidence template after live PoC. Customer fills in run IDs, K3 record IDs, statuses, etc. |
 | `mock-k3-webapi-server.mjs` | Minimal in-process HTTP mock for K3 WISE WebAPI: Login / Health / Material / BOM Save / Submit / Audit. NOT a full K3 simulator. |
 | `mock-sqlserver-executor.mjs` | Mock SQL executor: implements the real K3 SQL channel `select()` / `insertMany()` contract, keeps legacy `query()` / `exec()` probes, and rejects core-table writes. |

--- a/scripts/ops/fixtures/integration-k3wise/fixture-contract.test.mjs
+++ b/scripts/ops/fixtures/integration-k3wise/fixture-contract.test.mjs
@@ -15,6 +15,7 @@ import {
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const gateFixturePath = path.join(__dirname, 'gate-sample.json')
+const gateIntakeTemplatePath = path.join(__dirname, 'gate-intake-template.json')
 const evidenceFixturePath = path.join(__dirname, 'evidence-sample.json')
 
 async function readJson(filePath) {
@@ -44,6 +45,24 @@ test('gate-sample.json stays equivalent to the exported preflight sample', async
   assert.equal(packet.safety.autoAudit, false)
   assert.equal(packet.externalSystems.length, 3)
   assert.equal(packet.pipelines.length, 2)
+  assert.equal(JSON.stringify(packet).includes('<fill-outside-git>'), false)
+})
+
+test('gate-intake-template.json is customer-facing and accepted by live preflight', async () => {
+  const template = await readJson(gateIntakeTemplatePath)
+  assert.equal(template._instructions.secretPlaceholder, '<fill-outside-git>')
+  assert.match(template._sections['A.1'], /Test scope/)
+  assert.match(template._sections['A.6'], /Rollback contract/)
+
+  const packet = buildPacket(template, { generatedAt: '2026-05-15T00:00:00.000Z' })
+  assert.equal(packet.status, 'preflight-ready')
+  assert.equal(packet.safety.saveOnly, true)
+  assert.equal(packet.safety.autoSubmit, false)
+  assert.equal(packet.safety.autoAudit, false)
+  assert.equal(packet.safety.sqlServerMode, 'disabled')
+  assert.equal(packet.pipelines.some((pipeline) => pipeline.targetObject === 'material'), true)
+  assert.equal(packet.pipelines.some((pipeline) => pipeline.targetObject === 'bom'), true)
+  assert.equal(packet.externalSystems.some((system) => system.kind === 'erp:k3-wise-sqlserver'), false)
   assert.equal(JSON.stringify(packet).includes('<fill-outside-git>'), false)
 })
 

--- a/scripts/ops/fixtures/integration-k3wise/gate-intake-template.json
+++ b/scripts/ops/fixtures/integration-k3wise/gate-intake-template.json
@@ -1,0 +1,87 @@
+{
+  "_comment": "Customer-facing K3 WISE live GATE intake template. Copy this file outside Git, replace the example non-secret values with customer values, put real credentials only in the credential fields, then run: node scripts/ops/integration-k3wise-live-poc-preflight.mjs --input <path> --out-dir <packet-dir>. Do not place password, token, api_key, sign, session_id, or auth query values in apiUrl/baseUrl fields.",
+  "_instructions": {
+    "owner": "Implementation operator fills this with the customer K3/PLM administrator. Keep the filled copy outside Git.",
+    "secretPlaceholder": "<fill-outside-git>",
+    "saveOnlyPolicy": "autoSubmit and autoAudit must remain false until a separately approved production change window.",
+    "acceptedCredentialShapes": [
+      "k3Wise.credentials.sessionId",
+      "k3Wise.credentials.username + k3Wise.credentials.password"
+    ],
+    "reviewBeforeLive": [
+      "environment is not production",
+      "K3 WebAPI URL has no secret query parameters",
+      "BOM product scope is present when bom.enabled=true",
+      "SQL Server mode is readonly unless the customer explicitly approved a middle-table/stored-procedure path",
+      "rollback.owner and rollback.strategy are named and testable"
+    ]
+  },
+  "_sections": {
+    "A.1": "Test scope: tenantId, workspaceId, operator, k3Wise.environment.",
+    "A.2": "K3 WISE connection: version, WebAPI URL, acctId, credentials, Save-only policy.",
+    "A.3": "PLM source: kind, read method, base URL, product scope, credentials.",
+    "A.4": "Field mappings: material and optional BOM mappings into K3 field names.",
+    "A.5": "SQL Server channel: optional advanced channel; readonly is the safe default.",
+    "A.6": "Rollback contract: named owner and rollback strategy."
+  },
+  "tenantId": "default",
+  "workspaceId": "customer-test-workspace",
+  "operator": "customer-k3-admin-and-metasheet-operator",
+  "k3Wise": {
+    "version": "K3 WISE 15.x test",
+    "apiUrl": "https://k3.example.test/K3API/",
+    "acctId": "AIS_TEST",
+    "environment": "test",
+    "credentials": {
+      "username": "k3-test-user",
+      "password": "<fill-outside-git>"
+    },
+    "autoSubmit": false,
+    "autoAudit": false,
+    "sampleLimit": 3
+  },
+  "plm": {
+    "kind": "plm:yuantus-wrapper",
+    "readMethod": "api",
+    "baseUrl": "https://plm.example.test/",
+    "defaultProductId": "PRODUCT-TEST-001",
+    "credentials": {
+      "username": "plm-test-user",
+      "password": "<fill-outside-git>"
+    }
+  },
+  "sqlServer": {
+    "enabled": false,
+    "mode": "disabled",
+    "server": "<customer-sqlserver-host>",
+    "database": "AIS_TEST",
+    "allowedTables": [],
+    "middleTables": [],
+    "storedProcedures": [],
+    "writeCoreTables": false
+  },
+  "rollback": {
+    "owner": "customer-k3-admin",
+    "strategy": "disable-test-records"
+  },
+  "bom": {
+    "enabled": true,
+    "productId": "PRODUCT-TEST-001"
+  },
+  "fieldMappings": {
+    "material": [
+      { "sourceField": "code", "targetField": "FNumber", "transform": ["trim", "upper"], "validation": [{ "type": "required" }] },
+      { "sourceField": "name", "targetField": "FName", "validation": [{ "type": "required" }] },
+      { "sourceField": "spec", "targetField": "FModel" },
+      { "sourceField": "uom", "targetField": "FBaseUnitID" }
+    ],
+    "bom": [
+      { "sourceField": "bomNumber", "targetField": "FNumber", "defaultValue": "BOM-TEST-001", "validation": [{ "type": "required" }] },
+      { "sourceField": "parentCode", "targetField": "FParentItemNumber", "validation": [{ "type": "required" }] },
+      { "sourceField": "childCode", "targetField": "FChildItems[].FItemNumber", "validation": [{ "type": "required" }] },
+      { "sourceField": "quantity", "targetField": "FChildItems[].FQty", "transform": { "type": "toNumber" }, "validation": [{ "type": "required" }] },
+      { "sourceField": "uom", "targetField": "FChildItems[].FUnitID" },
+      { "sourceField": "sequence", "targetField": "FChildItems[].FEntryID" }
+    ]
+  }
+}

--- a/scripts/ops/multitable-onprem-package-verify.sh
+++ b/scripts/ops/multitable-onprem-package-verify.sh
@@ -98,6 +98,7 @@ function verify_generic_integration_workbench_contract() {
   local issue1542_seed="${root}/scripts/ops/integration-issue1542-seed-workbench-systems.mjs"
   local postdeploy_summary="${root}/scripts/ops/integration-k3wise-postdeploy-summary.mjs"
   local live_gate_package="${root}/docs/operations/integration-k3wise-live-gate-execution-package.md"
+  local gate_intake_template="${root}/scripts/ops/fixtures/integration-k3wise/gate-intake-template.json"
 
   search_fixed_string '/integrations/workbench' "$web_dist" || die "web dist must include the Data Factory route"
   search_fixed_string '/integrations/k3-wise' "$web_dist" || die "web dist must include the K3 WISE setup route"
@@ -137,6 +138,12 @@ function verify_generic_integration_workbench_contract() {
   search_fixed_string 'integration-k3wise-delivery-readiness.mjs' "$live_gate_package" || die "live GATE package must document delivery readiness compiler"
   search_fixed_string 'VERIFY_REPORT_JSON' "$live_gate_package" || die "live GATE package must document package verifier report capture"
   search_fixed_string '--package-verify' "$live_gate_package" || die "live GATE package must document the package verify readiness gate"
+  search_fixed_string 'gate-intake-template.json' "$live_gate_package" || die "live GATE package must document the customer-facing GATE intake template"
+  search_fixed_string '"_sections"' "$gate_intake_template" || die "GATE intake template must carry A.1-A.6 customer-facing sections"
+  search_fixed_string '"A.6"' "$gate_intake_template" || die "GATE intake template must document rollback contract section A.6"
+  search_fixed_string '<fill-outside-git>' "$gate_intake_template" || die "GATE intake template must keep credential placeholders out of Git"
+  search_fixed_string '"autoSubmit": false' "$gate_intake_template" || die "GATE intake template must default autoSubmit=false"
+  search_fixed_string '"autoAudit": false' "$gate_intake_template" || die "GATE intake template must default autoAudit=false"
 }
 
 function write_optional_report() {
@@ -347,6 +354,7 @@ required=(
   "scripts/ops/integration-k3wise-postdeploy-smoke.mjs"
   "scripts/ops/integration-issue1542-seed-workbench-systems.mjs"
   "scripts/ops/integration-k3wise-postdeploy-summary.mjs"
+  "scripts/ops/fixtures/integration-k3wise/gate-intake-template.json"
   "scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs"
   "scripts/ops/multitable-onprem-bootstrap-admin.ps1"
   "scripts/ops/multitable-onprem-apply-package.sh"


### PR DESCRIPTION
## Summary
- add a customer-facing K3 WISE live GATE intake template with A.1-A.6 review notes and safe placeholders
- document the template in the live GATE execution package and fixture README
- require the template in the on-prem package verifier so future packages cannot omit it

## Verification
- node --test scripts/ops/fixtures/integration-k3wise/fixture-contract.test.mjs
- pnpm verify:integration-k3wise:poc
- bash -n scripts/ops/multitable-onprem-package-build.sh scripts/ops/multitable-onprem-package-verify.sh
- git diff --check
- overlay package verifier smoke using official workflow run 25911075364 + updated verifier: PASS, requiredCount=72

## Deployment impact
Docs/fixture/verifier-only. No runtime service code, no DB migration, no integration-core business path change. Future on-prem package verification now requires gate-intake-template.json.