### PR TITLE
fix(multitable): surface required create validation feedback

### DIFF
--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -1342,6 +1342,7 @@ async function onHierarchyReparentRecord(payload: {
 async function onAddRecord() {
   if (!ensureCanCreateRecord()) return
   await grid.createRecord()
+  if (grid.error.value) showError(grid.error.value)
 }
 async function onKanbanCreateRecord(data: Record<string, unknown>) {
   if (!ensureCanCreateRecord()) return

--- a/apps/web/tests/multitable-client.spec.ts
+++ b/apps/web/tests/multitable-client.spec.ts
@@ -528,6 +528,34 @@ describe('MultitableApiClient', () => {
     }))
   })
 
+  it('surfaces createRecord field validation errors from the server', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      ok: false,
+      error: {
+        code: 'VALIDATION_ERROR',
+        message: 'Record validation failed',
+        fieldErrors: {
+          fld_code: 'Material Code is required',
+        },
+      },
+    }), { status: 422 }))
+    const client = new MultitableApiClient({ fetchFn })
+
+    await expect(client.createRecord({
+      sheetId: 'sheet_standard_materials',
+      viewId: 'view_grid',
+      data: {},
+    })).rejects.toMatchObject({
+      name: 'MultitableApiError',
+      status: 422,
+      code: 'VALIDATION_ERROR',
+      message: 'Material Code is required',
+      fieldErrors: {
+        fld_code: 'Material Code is required',
+      },
+    })
+  })
+
   it('loads and normalizes record history entries', async () => {
     const fetchFn = vi.fn().mockResolvedValue(new Response(JSON.stringify({
       ok: true,

--- a/apps/web/tests/multitable-workbench-view.spec.ts
+++ b/apps/web/tests/multitable-workbench-view.spec.ts
@@ -216,7 +216,7 @@ vi.mock('../src/multitable/components/MetaToolbar.vue', () => ({
     props: {
       fields: { type: Array, default: () => [] },
     },
-    emits: ['import', 'export-csv'],
+    emits: ['add-record', 'import', 'export-csv'],
     render() {
       const fieldIds = (this.$props.fields as Array<{ id?: string }>)
         .map((field) => field.id ?? '')
@@ -226,6 +226,14 @@ vi.mock('../src/multitable/components/MetaToolbar.vue', () => ({
         'div',
         { 'data-toolbar-field-ids': fieldIds },
         [
+          h(
+            'button',
+            {
+              'data-add-record': 'true',
+              onClick: () => this.$emit('add-record'),
+            },
+            'add-record',
+          ),
           h(
             'button',
             {
@@ -1219,6 +1227,21 @@ describe('MultitableWorkbench view wiring', () => {
     expect(banner?.getAttribute('data-capability-origin-source')).toBe('sheet-scope')
     expect(banner?.textContent).toContain('Restricted sheet access')
     expect(banner?.textContent).toContain('record creation, editing, deletion, field changes, and sheet access changes are limited on this sheet')
+  })
+
+  it('surfaces create-record validation failures from required-field sheets', async () => {
+    gridMock.createRecord.mockImplementation(async () => {
+      gridMock.error.value = 'Material Code is required'
+    })
+
+    mountWorkbench()
+    await flushUi()
+
+    container!.querySelector<HTMLButtonElement>('[data-add-record="true"]')!.click()
+    await flushUi()
+
+    expect(gridMock.createRecord).toHaveBeenCalledTimes(1)
+    expect(showErrorSpy).toHaveBeenCalledWith('Material Code is required')
   })
 
   it('shows an explicit admin access banner for administrator contexts', async () => {

--- a/docs/development/multitable-required-create-feedback-development-20260515.md
+++ b/docs/development/multitable-required-create-feedback-development-20260515.md
@@ -1,0 +1,67 @@
+# Multitable Required-Field Create Feedback Development - 2026-05-15
+
+## Summary
+
+This change closes the issue #1526 P0 path where pressing `+ New Record` on a staging/multitable sheet with required fields could fail silently. The backend and API client already returned the required-field validation message. The missing piece was the workbench toolbar create path: it awaited `grid.createRecord()` but did not surface the `grid.error` value that the composable sets when the server rejects the empty record.
+
+## Scope
+
+- Surface `grid.error.value` through the existing workbench toast path immediately after toolbar `createRecord()`.
+- Keep the change UI-only. No backend route, schema, migration, plugin runtime, or integration pipeline behavior changes.
+- Add regression coverage at both the client boundary and the workbench event wiring boundary.
+
+## Implementation
+
+### Workbench Feedback
+
+`apps/web/src/multitable/views/MultitableWorkbench.vue`
+
+- `onAddRecord()` still delegates record creation to `grid.createRecord()`.
+- After the call completes, the workbench now calls `showError(grid.error.value)` when the grid composable recorded a server/client validation failure.
+- This preserves the existing composable ownership of API error parsing and avoids duplicating required-field logic in the view.
+
+### API Client Regression
+
+`apps/web/tests/multitable-client.spec.ts`
+
+- Adds coverage for a `POST /api/multitable/records` validation response shaped like the real API envelope:
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "Record validation failed",
+    "fieldErrors": {
+      "fld_code": "Material Code is required"
+    }
+  }
+}
+```
+
+- Verifies that `MultitableApiClient.createRecord()` throws `MultitableApiError` with:
+  - HTTP status `422`
+  - code `VALIDATION_ERROR`
+  - first field error as the user-visible message
+  - original `fieldErrors` preserved for structured callers
+
+### Workbench Regression
+
+`apps/web/tests/multitable-workbench-view.spec.ts`
+
+- Extends the mocked `MetaToolbar` with an `add-record` button so the real workbench handler is exercised.
+- Adds a regression where `grid.createRecord()` stores `grid.error.value = "Material Code is required"`.
+- Verifies the existing toast channel receives that exact message.
+
+## Design Boundaries
+
+- No pre-flight required-field inspection was added to the frontend view. The server remains the source of truth for sheet constraints.
+- No new modal/drawer was introduced. This fix intentionally uses the existing toast behavior for create failures.
+- No data factory or K3-specific behavior is included. The fix applies to all multitable required-field sheets, including integration staging tables.
+
+## Deployment Impact
+
+- Frontend-only behavior change.
+- No database migration.
+- No runtime configuration change.
+- Safe for Windows on-prem package inclusion because it changes bundled web code and tests only.

--- a/docs/development/multitable-required-create-feedback-verification-20260515.md
+++ b/docs/development/multitable-required-create-feedback-verification-20260515.md
@@ -1,0 +1,38 @@
+# Multitable Required-Field Create Feedback Verification - 2026-05-15
+
+## Verification Matrix
+
+| Check | Command | Result |
+| --- | --- | --- |
+| Install workspace links in temporary worktree | `pnpm install --frozen-lockfile` | PASS |
+| Targeted frontend regression tests | `pnpm --filter @metasheet/web exec vitest run tests/multitable-workbench-view.spec.ts tests/multitable-client.spec.ts --watch=false` | PASS, 2 files / 72 tests |
+| Frontend type check | `pnpm --filter @metasheet/web exec vue-tsc --noEmit` | PASS |
+| Whitespace/conflict marker scan | `git diff --check` | PASS |
+
+## Targeted Test Evidence
+
+```text
+Test Files  2 passed (2)
+Tests       72 passed (72)
+```
+
+Covered paths:
+
+- `MultitableApiClient.createRecord()` preserves server `fieldErrors` and uses the first field error as the thrown message.
+- `MultitableWorkbench` receives the toolbar `add-record` event.
+- A required-field create failure stored in `grid.error.value` is shown through the existing `showError()` toast path.
+
+## Negative Checks
+
+- No backend route changed.
+- No migration added.
+- No integration-core runtime behavior changed.
+- No K3 WISE Submit/Audit behavior changed.
+- No tracked install side effects were kept from `pnpm install`; generated `node_modules` shim drift was restored before commit.
+
+## Issue Coverage
+
+This closes the issue #1526 P0 symptom:
+
+- Before: `+ New Record` on a required-field staging/multitable sheet could fail without visible feedback.
+- After: the same server validation error is surfaced to the user as a toast, for example `Material Code is required`.


### PR DESCRIPTION
## Summary

Fixes the issue #1526 P0 path where pressing `+ New Record` on a required-field multitable/staging sheet could fail without visible feedback.

The backend/API client already returns structured `fieldErrors`; `useMultitableGrid.createRecord()` already records the failure in `grid.error`. The workbench toolbar create path now surfaces that existing error through the existing toast channel.

## Changes

- Show `grid.error.value` after toolbar `grid.createRecord()` completes.
- Add API client regression coverage for create-record validation `fieldErrors`.
- Add workbench regression coverage for toolbar `add-record` -> toast behavior.
- Add development and verification MDs:
  - `docs/development/multitable-required-create-feedback-development-20260515.md`
  - `docs/development/multitable-required-create-feedback-verification-20260515.md`

## Verification

- `pnpm install --frozen-lockfile` PASS
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-workbench-view.spec.ts tests/multitable-client.spec.ts --watch=false` PASS, 2 files / 72 tests
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit` PASS
- `pnpm --filter @metasheet/web build` PASS
- `git diff --cached --check` PASS

## Deployment Impact

- Frontend-only behavior change.
- No backend route changes.
- No DB migration.
- No integration-core or K3 WISE runtime behavior changes.
