### PR TITLE
Approval Phase 1 (PR1 version-freeze + PR2 auto-approval-three-merge) rebased onto origin/main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ claudedocs/
 
 # Playwright artifacts (kept locally; referenced by docs/reports when needed)
 output/playwright/
+.playwright-mcp/
 
 # DingTalk P4 smoke and handoff artifacts may contain private env values,
 # remote evidence screenshots, or generated packets.

--- a/docs/development/approval-phase1-baseline-20260515.md
+++ b/docs/development/approval-phase1-baseline-20260515.md
@@ -1,0 +1,137 @@
+# Approval Phase 1 Baseline 2026-05-15
+
+## Context
+
+Baseline captured before starting PR1 `version-freeze-hardening` on branch:
+
+- `flow/version-freeze-hardening-20260515`
+
+Worktree:
+
+- `/Users/chouhua/Downloads/Github/metasheet2-flow-version-freeze-hardening-20260515`
+
+Base commit:
+
+- `bcdb4b4eb docs(research): add yida workflow phase1 plan`
+
+## Commands
+
+```bash
+pnpm --filter @metasheet/core-backend test:unit
+pnpm --filter @metasheet/core-backend test:integration
+pnpm install --frozen-lockfile --offline
+pnpm install --frozen-lockfile
+```
+
+## Result
+
+Initial test commands failed before entering Vitest because dependencies were not installed in this new worktree. An offline install also failed because the local pnpm store was missing `bcryptjs-3.0.3`.
+
+`pnpm install --frozen-lockfile` was then run successfully. It reused the local store and completed dependency installation.
+
+```text
+Done in 3.8s using pnpm v10.33.0
+```
+
+After dependencies were installed:
+
+- Unit baseline: passed.
+- Integration baseline: failed in existing environment.
+
+### Unit
+
+Command:
+
+```bash
+pnpm --filter @metasheet/core-backend test:unit
+```
+
+Result:
+
+```text
+Test Files  165 passed (165)
+Tests       2136 passed (2136)
+Duration    10.12s
+```
+
+### Integration
+
+Command:
+
+```bash
+pnpm --filter @metasheet/core-backend test:integration
+```
+
+Result:
+
+```text
+Test Files  11 failed | 20 passed | 11 skipped (42)
+Tests       13 failed | 423 passed | 50 skipped (554)
+Errors      4 errors
+Duration    45.16s
+Exit status 1
+```
+
+Primary failure classes:
+
+- Missing integration database configuration:
+  - `DATABASE_URL is required for after-sales plugin install integration tests`
+  - `database "chouhua" does not exist`
+- Hook or test timeouts caused by missing DB-backed services:
+  - `admin-users.api.test.ts`
+  - `kanban-plugin.test.ts`
+  - `kanban.mvp.api.test.ts`
+  - `snapshot-protection.test.ts`
+- Existing mocked-SQL expectation mismatches in multitable and spreadsheet integration suites:
+  - `multitable-attachments.api.test.ts`
+  - `multitable-record-form.api.test.ts`
+  - `multitable-sheet-realtime.api.test.ts`
+  - `spreadsheet-integration.test.ts`
+
+Failed suites/tests observed:
+
+```text
+after-sales-plugin.install.test.ts
+approval-pack1a-lifecycle.api.test.ts
+comments.api.test.ts
+kanban-plugin.test.ts
+kanban.mvp.api.test.ts
+snapshot-protection.test.ts
+admin-users.api.test.ts
+multitable-attachments.api.test.ts
+multitable-record-form.api.test.ts
+multitable-sheet-realtime.api.test.ts
+spreadsheet-integration.test.ts
+```
+
+## Initial Dependency Blocker
+
+The first test attempts failed before Vitest because `node_modules` was absent:
+
+```text
+sh: vitest: command not found
+ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL @metasheet/core-backend@2.5.0 test:unit
+WARN Local package.json exists, but node_modules missing, did you mean to install?
+```
+
+The offline install attempt failed because the local store missed one tarball:
+
+```text
+ERR_PNPM_NO_OFFLINE_TARBALL
+missing package: https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz
+```
+
+## Interpretation
+
+PR1 starts from a clean branch with dependencies installed and a known baseline:
+
+- Unit suite is green.
+- Full integration suite is not green in this local environment before PR1 code changes.
+- The main integration blockers are DB environment/configuration and existing mocked-SQL expectation drift, not approval version-freeze code.
+
+PR1 verification should therefore include:
+
+- The full unit suite.
+- Targeted approval unit/integration tests added or changed by PR1.
+- Full integration suite only after a valid local `DATABASE_URL` and scratch DB are available.
+- Any remaining full-integration failures must be compared against this baseline.

--- a/docs/development/approval-phase1-codex-claude-worksplit-todo-20260515.md
+++ b/docs/development/approval-phase1-codex-claude-worksplit-todo-20260515.md
@@ -1,0 +1,541 @@
+# Approval Phase 1 Codex/Claude Worksplit TODO 2026-05-15
+
+## 1. Purpose
+
+This document turns the confirmed YiDA workflow benchmark decisions into an executable Phase 1 plan.
+
+Phase 1 is limited to approval kernel correctness. It must not open new product surfaces before the K3 PoC gate is passed.
+
+Primary references:
+
+- `docs/research/yida-workflow-vs-metasheet2-comparison-20260514.md`
+- `docs/research/yida-workflow-automation-benchmark-improvement-plan-20260515.md`
+
+## 2. Confirmed Boundaries
+
+| Boundary | Decision | Phase 1 Rule |
+|---|---|---|
+| §5.1 unified business trigger approval entry | Defer. If K3 PoC requires it, use a hardcoded narrow path with no UI. | Do not add generic `approval_trigger_bindings` UI or productized public-form/multitable trigger configuration. |
+| §5.10 persistent queue | Do not implement. At most add `automation_scheduled_runs` audit if needed. | Do not replace the current timer scheduler with `automation_jobs` or worker claiming. |
+| Business calendar | Move first SLA calendar version to Phase 4: org calendar + holidays. Defer shifts and blackout windows. | Do not block Phase 1 on SLA calendar work. |
+| Add-sign graph runtime | Use assignment-level MVP. Graph-level effective runtime is a later ADR. | Do not mutate `ApprovalGraphExecutor` graph topology or add `runtimeInsertedNodes` behavior in Phase 1. |
+| Automation retry | Not in Phase 1. Must depend on idempotency before real retry. | No full execution retry unless action-level idempotency is implemented first. |
+
+## 3. Collaboration Model
+
+One agent owns code for each PR. The other agent owns scope gate, semantic review, and test matrix.
+
+Phase 1 uses a stacked, serial PR model. By default, `PR(N+1)` starts from `main` only after `PR(N)` is merged. A stacked branch from `PR(N)` may be opened as a `PR(N+1)` preview while `PR(N)` is in review. After `PR(N)` merges, the stacked branch must be rebased onto `main` before its own merge. This applies to any adjacent `(PR(N), PR(N+1))` pair in Phase 1.
+
+| Responsibility | Codex | Claude |
+|---|---|---|
+| Repo cleanup and branch/worktree preparation | Owner | Review checklist only |
+| Code implementation | Owner by PR | No parallel edits to core files unless explicitly handed off |
+| Migrations | Owner by PR | Review SQL rollback, constraints, and compatibility |
+| Unit/integration tests | Owner by PR | Review missing cases and edge-case coverage |
+| Semantic ADR/checklist | Consume and implement | Owner |
+| Diff review | Fix findings | Owner |
+| Final verification report | Owner | Review gates and residual risk |
+
+### 3.1 Stacked PR Rule
+
+- PR1 must merge before PR2 is cut from `main`.
+- PR2 must merge before PR3 is cut from `main`.
+- PR3 must merge before PR4 is cut from `main`.
+- A stacked branch may be used only to reduce waiting time during a review window.
+- Stacked preview branches are allowed for any adjacent pair: PR1 -> PR2, PR2 -> PR3, or PR3 -> PR4.
+- A stacked branch must be rebased onto `main` after the parent PR merges.
+- No two agents should independently edit the same approval runtime file in different branches and expect an automatic merge.
+
+Expected Phase 1 wall-clock time: 15-23 working days, or roughly 3-5 weeks after review, rebase, and verification queues are included.
+
+### 3.2 Ownership Locks
+
+Only the current PR owner may edit these files in a given PR:
+
+- `packages/core-backend/src/services/ApprovalProductService.ts`
+- `packages/core-backend/src/services/ApprovalGraphExecutor.ts`
+- `packages/core-backend/src/routes/approvals.ts`
+- `packages/core-backend/src/types/approval-product.ts`
+- `packages/core-backend/src/db/migrations/*approval*`
+- `packages/core-backend/tests/**/*approval*`
+- `apps/web/src/views/**/*Approval*`
+- `apps/web/src/components/**/*Approval*`
+
+These locks apply during overlap windows, especially stacked PRs in review or preview. Once a PR merges, its files return to the shared pool for the next PR owner.
+
+The primary code paths listed under each PR are automatically locked for that PR. Each Codex handoff must also list the intended function-level ownership, for example `(ApprovalProductService.ts, publishTemplate)` or `(routes/approvals.ts, POST /:id/jump)`. Another agent may review those functions but should not edit them without explicit handoff.
+
+Claude may propose patch suggestions in review text, but Codex applies them after review.
+
+## 4. Current Branch Preflight
+
+Current branch observed before this plan:
+
+- `codex/data-factory-issue1542-postdeploy-smoke-20260515`
+
+Current dirty assets must be resolved before Phase 1 begins.
+
+| Asset | Action | Owner | Done Criteria |
+|---|---|---|---|
+| 8 attendance/formula code changes | Assess completeness. If complete, ship as a separate `fix(attendance): formula engine hardening` PR. If incomplete, stash or move to a dedicated worktree. | Codex | `git status --short` has no unrelated attendance code changes before Phase 1 branch is cut. |
+| `docs/development/attendance-dingtalk-formula-*-20260515.md` | Keep with attendance PR if they describe the code changes. Otherwise move into research/deferred notes. | Codex | Docs are either committed with attendance PR or removed from Phase 1 worktree. |
+| `docs/research/yida-workflow-*.md` | Commit as `docs(research): yida workflow benchmark plan` before Phase 1 code work. | Codex | Research docs are on main or intentionally carried in a docs-only branch. |
+| `.tmp-*.mjs` scripts | Delete if one-off crawl/probe scripts. If reusable, move under `scripts/ops/` with reviewed naming and tests. | Codex | No root `.tmp-*.mjs` files remain. |
+| `.playwright-mcp/` artifacts | Add `.playwright-mcp/` to `.gitignore` in a standalone `chore: gitignore playwright-mcp artifacts` commit on `main` before the Phase 1 branch is cut. | Codex | No untracked Playwright MCP artifacts appear in Phase 1 worktree. |
+| Final clean branch | Cut from latest `main`. | Codex | New branch `flow/version-freeze-hardening-20260515` starts with clean `git status --short`. |
+
+## 5. Phase 1 PR Plan
+
+### PR1: version-freeze-hardening
+
+Estimate: 3-4 days.
+
+Branch:
+
+- `flow/version-freeze-hardening-20260515`
+
+Code owner:
+
+- Codex
+
+Review owner:
+
+- Claude
+
+Primary code paths:
+
+- `packages/core-backend/src/services/ApprovalProductService.ts`
+- `packages/core-backend/src/db/migrations/zzzz20260411120100_approval_templates_and_instance_extensions.ts`
+- `packages/core-backend/tests/unit/**/*approval*`
+- `packages/core-backend/tests/integration/**/*approval*`
+
+Current code baseline:
+
+- `publishTemplate()` already creates `approval_published_definitions.runtime_graph` and marks previous active definitions inactive.
+- `createApproval()` already stores `template_version_id`, `published_definition_id`, and `form_snapshot`.
+- `dispatchAction()` already reloads runtime graph from `approval_instances.published_definition_id`.
+
+Implementation TODO:
+
+- [ ] Add tests proving old instances continue on the old `published_definition_id` after a new template version is published.
+- [ ] Add tests proving form validation uses the instance-start schema snapshot, not a later draft or published schema.
+- [ ] Add service guard for hard-delete/archive attempts when unfinished instances reference a template version.
+- [ ] Add list/detail metadata needed for version governance: published at, active/history state, instance count, unfinished instance count.
+- [ ] Verify publish lifecycle is transactional under concurrent publish attempts.
+- [ ] Confirm stale published definitions remain readable for running instances.
+- [ ] Identify and remove any runtime path that advances an instance from the template's current `active_version_id` instead of the instance-bound `published_definition_id`.
+- [ ] Add regression coverage for rollback on publish failure.
+- [ ] Update API/OpenAPI docs if response shape changes.
+
+Claude scope gate checklist:
+
+- [ ] No generic business trigger binding work.
+- [ ] No scheduler or automation retry work.
+- [ ] No graph runtime insertion.
+- [ ] No unrelated frontend product surface.
+- [ ] Version deletion/archive behavior is explicitly tested.
+
+PR1 acceptance:
+
+- [ ] Existing instance advances with original runtime graph after new publish.
+- [ ] Existing instance keeps original form snapshot semantics.
+- [ ] Unfinished instance blocks destructive version deletion/archive.
+- [ ] Tests fail before the hardening change and pass after it.
+- [ ] `down()` migration is verified by running an up -> down -> up sequence on a scratch DB if PR1 adds or changes migrations.
+- [ ] Verification note lists exact commands run.
+
+Suggested verification:
+
+```bash
+pnpm --filter @metasheet/core-backend test:unit
+pnpm --filter @metasheet/core-backend test:integration
+pnpm --filter @metasheet/core-backend build
+pnpm type-check
+```
+
+### PR2: auto-approval-three-merge
+
+Estimate: 4-6 days.
+
+Branch:
+
+- `flow/auto-approval-three-merge-20260515`
+
+Code owner:
+
+- Codex
+
+Review owner:
+
+- Claude
+
+Primary code paths:
+
+- `packages/core-backend/src/services/ApprovalProductService.ts`
+- New service if useful: `packages/core-backend/src/services/ApprovalAutoApprovalPolicyService.ts`
+- `packages/core-backend/src/services/ApprovalGraphExecutor.ts`
+- `packages/core-backend/src/types/approval-product.ts`
+- `packages/core-backend/src/db/migrations/*approval*`
+- Approval product tests
+
+Design decision:
+
+- Policy evaluation should live in `ApprovalProductService` or a dedicated `ApprovalAutoApprovalPolicyService`, because it needs requester, approval records, active assignments, and instance metadata.
+- Keep `ApprovalGraphExecutor` focused on graph progression. It may continue returning auto-approval events for graph-local empty-assignee cases, but it should not become the main policy engine for requester/history/adjacent merge.
+
+Implementation TODO:
+
+- [ ] Add template/global `auto_approval_policy` storage.
+- [ ] Add node-level policy override in approval node metadata/config.
+- [ ] Implement `mergeWithRequester`.
+- [ ] Implement `mergeAdjacentApprover`, ignoring cc nodes and skipped auto nodes.
+- [ ] Implement `dedupeHistoricalApprover`, based on completed approval records in the same instance.
+- [ ] Define precedence: node policy override > template policy > default disabled.
+- [ ] Write `approval_records` for every auto approval with `actor_id = system:auto-approval`.
+- [ ] Include original approver, node key, strategy hit, and policy source in metadata.
+- [ ] Prevent infinite auto-advance loops with a max auto-step guard.
+- [ ] Ensure parallel branches and `approval_assignments.active_unique` constraints are handled.
+- [ ] Add UI display only if existing template detail already has a safe config surface; otherwise keep backend-only for Phase 1.
+
+Claude semantic matrix:
+
+- [ ] requester is assignee on first node.
+- [ ] requester is assignee after a condition node.
+- [ ] adjacent same user with cc in between.
+- [ ] adjacent same user across parallel branches.
+- [ ] historical user reappears after return/jump.
+- [ ] multiple assignees with `all` mode.
+- [ ] multiple assignees with `any` mode.
+- [ ] policy disabled globally but enabled on node.
+- [ ] policy enabled globally but disabled on node.
+
+PR2 acceptance:
+
+- [ ] Three merge rules work independently.
+- [ ] Node override precedence is covered.
+- [ ] Every auto approval has audit records.
+- [ ] No duplicate active assignment is created for the same instance/type/user.
+- [ ] No graph topology mutation is introduced.
+- [ ] `down()` migration is verified by running an up -> down -> up sequence on a scratch DB.
+
+Suggested verification:
+
+```bash
+pnpm --filter @metasheet/core-backend test:unit
+pnpm --filter @metasheet/core-backend test:integration
+pnpm --filter @metasheet/core-backend build
+pnpm type-check
+```
+
+### PR3: admin-jump-node
+
+Estimate: 3-5 days.
+
+Branch:
+
+- `flow/admin-jump-node-20260515`
+
+Code owner:
+
+- Codex
+
+Review owner:
+
+- Claude
+
+Primary code paths:
+
+- `packages/core-backend/src/routes/approvals.ts`
+- `packages/core-backend/src/services/ApprovalProductService.ts`
+- `packages/core-backend/src/services/ApprovalGraphExecutor.ts`
+- `packages/core-backend/src/guards/*`
+- Approval route/service tests
+
+API draft:
+
+```http
+POST /api/approvals/:id/jump
+```
+
+Request:
+
+```json
+{
+  "targetNodeKey": "approval_finance",
+  "reason": "original approver left company",
+  "version": 12
+}
+```
+
+Implementation TODO:
+
+- [ ] Add `approvals:admin` permission check.
+- [ ] Add `ApprovalProductService.adminJump()`.
+- [ ] Lock instance row with `FOR UPDATE`.
+- [ ] Reject terminal instances.
+- [ ] Enforce optimistic `version`.
+- [ ] Load instance-bound `published_definition_id`, not active template definition.
+- [ ] Validate `targetNodeKey` exists in the bound runtime graph.
+- [ ] Validate target node is downstream of the current node in the bound runtime graph.
+- [ ] First version allows forward jump only. Backward jump is out of scope and requires a separate ADR.
+- [ ] Validate target node is an approval node unless explicitly allowing end-state recovery in a later ADR.
+- [ ] Deactivate current active assignments.
+- [ ] Resolve assignments for target node from the bound runtime graph.
+- [ ] Insert new assignments.
+- [ ] Clear or rebuild `metadata.parallelBranchStates` safely.
+- [ ] Write `approval_records` action `jump` or existing allowed action plus metadata; update action constraint if needed.
+- [ ] Record old node, target node, old assignees, new assignees, admin actor, reason.
+- [ ] Always emit `approval.admin_jumped` with from node, to node, old assignees, new assignees, actor, reason, and instance id.
+- [ ] If some notification channels are not wired yet, scope the first delivery to audit record plus in-app/event-bus consumers at minimum.
+
+Claude security review checklist:
+
+- [ ] Non-admin receives 403.
+- [ ] Admin cannot jump a terminal instance.
+- [ ] Stale version receives 409.
+- [ ] Jump uses instance-bound runtime graph.
+- [ ] Invalid target receives 400.
+- [ ] Old assignee cannot act after jump.
+- [ ] Audit contains enough data to explain recovery.
+- [ ] No public-form route or automation route is changed.
+
+PR3 acceptance:
+
+- [ ] Stuck instance can be moved to a valid target approval node.
+- [ ] Backward jump is rejected in the first version.
+- [ ] Old active assignments are invalidated.
+- [ ] New target assignments can approve and continue the original bound runtime.
+- [ ] Audit timeline shows admin jump.
+- [ ] Jump does not alter template version or published definition.
+- [ ] `down()` migration is verified by running an up -> down -> up sequence on a scratch DB if PR3 adds or changes migrations.
+
+Suggested verification:
+
+```bash
+pnpm --filter @metasheet/core-backend test:unit
+pnpm --filter @metasheet/core-backend test:integration
+pnpm --filter @metasheet/core-backend build
+pnpm type-check
+```
+
+### PR4: add-sign-mvp-assignment-level
+
+Estimate: 5-8 days.
+
+Branch:
+
+- `flow/add-sign-mvp-20260515`
+
+Code owner:
+
+- Codex
+
+Review owner:
+
+- Claude
+
+Primary code paths:
+
+- `packages/core-backend/src/services/ApprovalProductService.ts`
+- `packages/core-backend/src/routes/approvals.ts`
+- `packages/core-backend/src/db/migrations/*approval*`
+- `packages/core-backend/src/services/ApprovalGraphExecutor.ts`
+- Approval route/service tests
+
+Design decision:
+
+- Do not add `runtimeInsertedNodes`.
+- Do not mutate `nodeMap`, `outgoingEdges`, or published `runtime_graph`.
+- Model add-sign as assignment-level child tasks tied to an existing approval node.
+
+Candidate schema:
+
+```sql
+CREATE TABLE approval_countersign_tasks (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  instance_id TEXT NOT NULL,
+  parent_assignment_id UUID NOT NULL REFERENCES approval_assignments(id) ON DELETE CASCADE,
+  child_assignment_id UUID REFERENCES approval_assignments(id) ON DELETE SET NULL,
+  mode TEXT NOT NULL CHECK (mode IN ('before', 'after', 'parallel')),
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'completed', 'cancelled')),
+  requested_by TEXT NOT NULL,
+  target_user_id TEXT NOT NULL,
+  reason TEXT,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  completed_at TIMESTAMPTZ,
+  cancelled_at TIMESTAMPTZ
+);
+```
+
+Fallback only if the Day 0 ADR rejects the independent table: add countersign columns to `approval_assignments`. The default plan is the independent table because it avoids mixing `approval_assignments.is_active` with countersign lifecycle state and keeps timeline joins explicit.
+
+Implementation TODO:
+
+- [ ] Day 0: Claude writes add-sign ADR covering before/after/parallel × single/all/any × reject/return/revoke/transfer/jump interactions. ADR file: `docs/development/approval-add-sign-adr-20260515.md`. Codex blocks on its merge before any PR4 code change.
+- [ ] Confirm FK types for `approval_instances.id` and `approval_assignments.id` before writing the migration.
+- [ ] Add migration for `approval_countersign_tasks` as the default storage model.
+- [ ] Add action request types for `add_sign_before`, `add_sign_after`, and `add_sign_parallel`.
+- [ ] Add permission rule: current active approver or admin can add sign; requester cannot unless explicitly permitted.
+- [ ] For before add-sign, suspend current assignment until child assignment completes.
+- [ ] For after add-sign, create child assignment that must complete before advancing to next graph node.
+- [ ] For parallel add-sign, add child assignment counted in current node completion.
+- [ ] Adjust current-node completion check in `ApprovalProductService` to include countersign children.
+- [ ] Preserve `ApprovalGraphExecutor` graph-only behavior.
+- [ ] Write `approval_records` for add-sign creation and completion.
+- [ ] Add metadata: parent assignment, countersign mode, inserted by, target user, reason.
+- [ ] Ensure transfer, reject, return, revoke, and admin jump cancel or close countersign tasks consistently.
+- [ ] Add UI only if existing action menu can expose it without broad task-center redesign; otherwise backend/API first.
+
+Claude ADR/checklist:
+
+- [ ] Define exact semantics for before/after/parallel add-sign.
+- [ ] Define how add-sign interacts with `single`, `all`, and `any` approval modes.
+- [ ] Define how add-sign interacts with reject, return, revoke, transfer, and admin jump.
+- [ ] Define how countersign appears in timeline.
+- [ ] Confirm no runtime graph insertion is required.
+
+PR4 acceptance:
+
+- [ ] Before add-sign blocks parent approver until child completes.
+- [ ] After add-sign requires child completion before node advances.
+- [ ] Parallel add-sign participates in node completion.
+- [ ] Reject/return/jump closes pending countersign tasks correctly.
+- [ ] Timeline clearly shows add-sign actor and target.
+- [ ] No mutation of published runtime graph or `ApprovalGraphExecutor` topology.
+- [ ] `down()` migration is verified by running an up -> down -> up sequence on a scratch DB.
+
+Suggested verification:
+
+```bash
+pnpm --filter @metasheet/core-backend test:unit
+pnpm --filter @metasheet/core-backend test:integration
+pnpm --filter @metasheet/core-backend build
+pnpm type-check
+```
+
+## 6. Phase 4 Red-Line TODO Before Automation Retry
+
+These items are not Phase 1 work, but they must be completed before enabling real retry in the automation running center.
+
+| Item | Required Before Retry |
+|---|---|
+| `AutomationAction.id` | Stable per-action id for persisted execution steps. |
+| `AutomationAction.idempotencyKeyTemplate?: string` | Required for side-effecting actions before retry is allowed. |
+| `automation_action_idempotency_keys` table | Stores key, action type, execution id, result status, created at, and conflict metadata. |
+| Action schema classification | Mark actions as side-effecting or naturally idempotent. |
+| Backend guard | Return 409 if retry is requested for a run containing non-idempotent side-effecting actions. |
+| UI guard | Retry button disabled with reason when idempotency is missing. |
+| Support packet redaction | Must redact webhook URLs, DingTalk secrets, bearer tokens, and JWT-like strings. |
+| Test matrix | For each action type, verify double execution with the same idempotency key returns the same result and does not duplicate external side effects. DingTalk, email, and webhook checks must use mocks. |
+
+## 7. Handoff Protocol Between Codex And Claude
+
+### 7.1 Before Each PR Starts
+
+Codex sends Claude:
+
+```text
+PR scope:
+Branch:
+Files expected to change:
+Explicit non-goals:
+Boundary checklist:
+Tests planned:
+```
+
+Claude returns:
+
+```text
+Scope gate:
+Semantic risks:
+Required tests:
+Do-not-cross lines:
+Review focus:
+```
+
+### 7.2 Before Review
+
+Codex sends Claude:
+
+```text
+Diff summary:
+Changed files:
+Migration summary:
+Tests run:
+Known gaps:
+```
+
+Claude returns findings in review order:
+
+1. Blocking correctness issues.
+2. Security or permission issues.
+3. Missing tests.
+4. Scope creep.
+5. Naming or maintainability comments.
+
+### 7.3 Merge Gate
+
+A PR is merge-ready only when:
+
+- [ ] Worktree contains only files for that PR.
+- [ ] Boundary checklist is green.
+- [ ] Claude review has no unresolved blocking findings.
+- [ ] Targeted unit/integration tests pass.
+- [ ] Build/type-check status is recorded.
+- [ ] Migration rollback behavior is documented.
+- [ ] Verification notes are committed in `docs/development/` if the PR is non-trivial.
+
+### 7.4 Response Expectations
+
+These are working-window expectations for coordination, not automated CI gates.
+
+| Step | Expected Response |
+|---|---|
+| Codex requests scope gate; Claude returns gate checklist | 4 hours within working window |
+| Codex requests review; Claude returns findings | 8 hours within working window |
+| Claude files blocking finding; Codex addresses or responds | Next working day |
+| Codex reports blocker requiring user decision | Same working day |
+
+## 8. User Decision Points
+
+The following decisions are already confirmed:
+
+| Decision | Confirmed Direction |
+|---|---|
+| PR3 admin jump direction | First version allows forward jump only. Backward jump requires a separate ADR. |
+| PR4 countersign storage | Use independent `approval_countersign_tasks` table by default. Do not add countersign lifecycle state to `approval_assignments` unless the Day 0 ADR rejects the table. |
+
+Only these items still require user confirmation during Phase 1:
+
+| Decision | When To Ask |
+|---|---|
+| K3 hardcoded trigger path exception | Only if PR2+ work is blocked by a concrete K3 PoC requirement. |
+| Add `jump` as a new `approval_records.action` value | During PR3 if reusing existing actions would obscure audit semantics. |
+| Add-sign UX exposure | During PR4 if backend API is complete and frontend action menu exposure is low risk. |
+
+## 9. Out Of Scope Until After Phase 1
+
+- Generic `approval_trigger_bindings` product UI.
+- Public-form submitted to approval generic configuration.
+- Multitable submitted to approval generic configuration.
+- Full `start_approval` automation action productization.
+- Persistent `automation_jobs` queue and worker.
+- Full cron parser and misfire policies.
+- Workflow DAG/branch/loop/delay/wait automation orchestration.
+- Business calendar beyond Phase 4 SLA first version.
+- Graph-level add-sign runtime insertion.
+- BPMN compatibility beyond existing approval bridge needs.
+- Analytics dashboards and process mining.
+
+## 10. Immediate TODO
+
+- [ ] Finish or stash current attendance/formula work.
+- [ ] Remove or relocate `.tmp-*.mjs` files.
+- [ ] Remove or ignore `.playwright-mcp/` artifacts.
+- [ ] Commit research docs separately.
+- [ ] Before opening PR1, run `pnpm --filter @metasheet/core-backend test:unit` and `pnpm --filter @metasheet/core-backend test:integration` on `main`; save the pass/fail baseline to `docs/development/approval-phase1-baseline-20260515.md`.
+- [ ] Cut `flow/version-freeze-hardening-20260515` from latest `main`.
+- [ ] Ask Claude for PR1 scope gate using this document.
+- [ ] Start PR1 implementation only after the worktree is clean.

--- a/docs/development/approval-phase1-followups-20260515.md
+++ b/docs/development/approval-phase1-followups-20260515.md
@@ -1,0 +1,110 @@
+# Approval Phase 1 Follow-ups 2026-05-15
+
+Source:
+
+- `docs/development/approval-pr1-review-response-20260515.md`
+- Merged PR1 commit: `c44fb72e8 feat(approval): harden template version freeze`
+
+These items do not block PR1 merge. They are retained here so PR2 and later
+Phase 1 work can absorb them deliberately instead of rediscovering them during
+review.
+
+## PR2 Candidates
+
+### A. Extract Terminal Statuses Constant
+
+Status: open, recommended for PR2.
+
+Current duplicate literals:
+
+- `packages/core-backend/src/services/ApprovalProductService.ts`
+- `packages/core-backend/tests/unit/approval-product-service.test.ts`
+
+Action:
+
+- Add `APPROVAL_TERMINAL_STATUSES` in `packages/core-backend/src/types/approval-product.ts`.
+- Reuse it in service code and approval product tests.
+
+Reason:
+
+PR2 auto-approval merge will likely need terminal-state checks. Centralizing the
+list avoids future drift if a terminal status such as `expired` or `withdrawn`
+is added.
+
+### B. Explain Delete Guard OR Clause
+
+Status: open, recommended for PR2.
+
+Location:
+
+- `ApprovalProductService.assertTemplateVersionDeletable()`
+
+Action:
+
+- Add a short comment above the `template_version_id = $1 OR published_definition_id IN (...)` predicate.
+
+Suggested wording:
+
+> Defend against historical instances where only one of `template_version_id`
+> or `published_definition_id` may have been backfilled.
+
+Reason:
+
+The query intentionally protects both direct and indirect references. Without
+the comment, a future refactor may simplify the predicate and break historical
+data safety.
+
+## Independent Follow-ups
+
+### C. Strengthen Guard Helper JSDoc
+
+Status: open, independent.
+
+Location:
+
+- `ApprovalProductService.assertTemplateVersionDeletable()`
+
+Action:
+
+- Add JSDoc stating that any future delete/archive path must call this guard
+  before mutating `approval_template_versions`, `approval_templates`, or
+  `approval_published_definitions`.
+- State explicitly that direct SQL bypasses this protection.
+
+Reason:
+
+PR1 intentionally added an internal helper only. Future product endpoints need
+a visible warning at the helper definition.
+
+### D. Add Real PostgreSQL Concurrent Publish Test
+
+Status: blocked by integration DB environment.
+
+Action:
+
+- After integration DB baseline is repaired, add an integration test that runs
+  two concurrent real PostgreSQL `publishTemplate()` calls for one template.
+- Assert exactly one `approval_published_definitions.is_active = TRUE` row
+  remains for that template.
+
+Reason:
+
+PR1 has unit-level lock-order and virtual two-publisher coverage. A real DB
+test would prove the unique partial index and `FOR UPDATE` path together.
+
+### E. Add Explicit T9 Form Schema Violation Test
+
+Status: deferred until an existing-instance form revalidation path exists.
+
+Action:
+
+- When a future PR adds resubmit/edit/revalidate behavior for existing approval
+  instances, add a test where the current template schema differs from the
+  stored `form_snapshot`.
+- Assert existing-instance handling uses the frozen snapshot semantics, not the
+  latest template schema.
+
+Reason:
+
+PR1 pins snapshot usage through frozen conditional routing. There is no current
+service path that revalidates submitted form data on an existing instance.

--- a/docs/development/approval-pr1-review-response-20260515.md
+++ b/docs/development/approval-pr1-review-response-20260515.md
@@ -1,0 +1,123 @@
+# Approval PR1 Review Response 2026-05-15
+
+Reviewing `c44fb72e8 feat(approval): harden template version freeze` against scope gate `docs/development/approval-pr1-scope-gate-response-20260515.md`.
+
+Reviewer: Claude
+Worktree: `/Users/chouhua/Downloads/Github/metasheet2-flow-version-freeze-hardening-20260515`
+Base verified: `be699941f docs: record approval phase1 baseline`
+Files touched: 4 (service + tests + dev doc + verification doc). Zero do-not-cross violations.
+
+## Verdict
+
+APPROVE for merge into `main`.
+
+P1 (option a, internal helper) honored. P2 (T1-T11 coverage) complete. T12 correctly skipped because R5 mitigation was doc comment, not call-site split.
+
+## Findings In §7.2 Priority Order
+
+### 1. Blocking Correctness Issues
+
+None.
+
+The implementation correctly preserves instance-bound version freeze:
+- `assertTemplateVersionDeletable` (ApprovalProductService.ts:1459-1499) defends both direct `approval_instances.template_version_id` and indirect `approval_instances.published_definition_id -> approval_published_definitions.template_version_id` references.
+- `loadTemplateBundleWithClient` doc comment (ApprovalProductService.ts:2437-2443) explicitly forbids reuse for advance and points to `dispatchAction()` as the correct path.
+
+Test invariants pin the right behavior:
+- approval-product-service.test.ts:1253-1254 asserts `dispatchAction` does NOT issue any SQL touching `approval_templates` or `active_version_id`. This is the strongest possible mock-pool assertion of the source-of-truth invariant.
+- approval-product-service.test.ts:1172 asserts the published-definition query uses `pub-old` (instance-bound), not the active definition.
+
+### 2. Security/Permission Issues
+
+None.
+
+The guard is service-internal with no HTTP exposure. Multi-tenant filtering responsibility correctly remains with future callers (a comment explaining this would be a nice-to-have, see finding 5.3).
+
+### 3. Missing Tests
+
+None blocking. Two acknowledged forward-looking gaps:
+
+3.1. **T9 explicit form-schema-violation coverage is implicit only**
+   - Current test (line 1122) pins the snapshot via conditional routing on `form_snapshot.legacyAmount`. This proves the stored snapshot governs evaluation, but does not exercise a "form schema rejects old data / accepts new data" path because no such re-validation path exists today.
+   - Verification doc line 91 correctly acknowledges this.
+   - Forward action: when any future PR adds form resubmit/edit on existing instances, it must include an explicit T9 form-schema-violation test using the stored snapshot, not the template's current schema. Track in PR3/PR4 reviews and Phase 2 design.
+
+3.2. **T8 concurrent publish is mock-pool, not real PG**
+   - Verification doc line 38, 54 already calls this out. The virtual-lock simulation is contract-level.
+   - Forward action: when integration env is repaired (current baseline failure is environmental, not approval-related), add an integration test that runs two concurrent real-PG `publishTemplate` calls and verifies the `is_active` constraint holds. Track as a Phase 1 follow-up.
+
+### 4. Scope Creep
+
+None. File diff list is:
+- `packages/core-backend/src/services/ApprovalProductService.ts` (allowed)
+- `packages/core-backend/tests/unit/approval-product-service.test.ts` (allowed)
+- `docs/development/approval-pr1-version-freeze-development-20260515.md` (allowed)
+- `docs/development/approval-pr1-version-freeze-verification-20260515.md` (allowed)
+
+Zero edits to `ApprovalGraphExecutor.ts`, `routes/approvals.ts`, `multitable/*`, `approval-sla-*`, `approval-breach-*`, `apps/web/**`, or any migration file.
+
+### 5. Naming/Maintainability
+
+Three polishing items. None blocking PR1 merge. Track as PR2/PR3 follow-ups.
+
+5.1. **Terminal status list hardcoded inline**
+   - Location: `ApprovalProductService.ts:1468` and `approval-product-service.test.ts:1277` both literal `'approved', 'rejected', 'revoked', 'cancelled'`.
+   - Risk: future addition of a terminal status (for example `'withdrawn'` or `'expired'`) will silently make the guard over-block, and the test will pass for the wrong reason.
+   - Recommendation: extract `APPROVAL_TERMINAL_STATUSES` constant in `types/approval-product.ts` and reuse from both production code and test. Suggested to land in PR2 because auto-approval merge will also need this concept.
+
+5.2. **OR clause intent not documented**
+   - Location: `ApprovalProductService.ts:1469-1477` uses `WHERE template_version_id = $1 OR published_definition_id IN (...)`.
+   - Risk: a future reader may not understand why both columns are required (the legacy / migration intent — defending against rows where only one column is populated).
+   - Recommendation: add a one-line comment above the OR clause. Suggested wording: "Defend against historical instances where only one of `template_version_id` or `published_definition_id` may have been backfilled."
+
+5.3. **Guard helper has no production caller and no compile-time enforcement**
+   - Location: `ApprovalProductService.assertTemplateVersionDeletable` is public but unreferenced in production code today.
+   - Risk: when a future PR adds a delete or archive endpoint, the developer must remember to call this helper. There is no static guarantee.
+   - Recommendation: add a stronger JSDoc warning at the helper definition: "Must be called by any future delete or archive code path before mutating `approval_template_versions`, `approval_templates`, or `approval_published_definitions` rows. Direct SQL bypasses this protection." Track a separate Phase 1 follow-up to add a grep-time CI check that no `DELETE FROM approval_template_versions` or status-flip-to-archived UPDATE exists outside this helper's caller graph. Phase 1 follow-up only, not PR1.
+
+## Verification Cross-Check
+
+- Unit suite delta is consistent: baseline 2136 → after 2143, exactly +7 new `it()` blocks (lines 1025, 1122, 1265, 1282, 1303, 1385, 1518).
+- Build PASS, type-check is bundled inside backend build.
+- No migration → rollback verification N/A is correct.
+- Integration environment failures inherited from baseline are correctly excluded from PR1 responsibility. PR1 does not introduce any new integration failure.
+
+## Test Effectiveness Spot-Check
+
+Selected three claimed-strongest assertions and confirmed they exercise the right path:
+
+E1. T7 negative-space assertion at line 1253-1254 — `statements.some(s => s.includes('approval_templates'))` and `.includes('active_version_id')` both `.toBe(false)`. This is the kind of test that fails noisily if any future refactor leaks a template lookup into `dispatchAction`. Strong.
+
+E2. T10 graph independence at line 1247 — final `currentNodeKey: 'approval_old_high'` is a node that only exists in `frozenRuntimeGraph`. If `dispatchAction` had loaded a different graph, the advance would either crash with "node not found" or route to a different node, failing the assertion. The chosen node and assertion correctly distinguish frozen from current graph. Strong.
+
+E3. T11 error shape at line 1291-1300 — both `details: { unfinishedCount: 2, sampleInstanceId: 'apr-pending-1' }` structured matcher AND `rejects.toThrow('apr-pending-1')` string-containment matcher. The string-containment ensures operator-visible message also carries the sample ID. Strong.
+
+## Merge Gate Summary
+
+Per worksplit §7.3:
+
+- Worktree contains only PR1 files: PASS.
+- Boundary checklist green: PASS (8/8 yes, P1 = option a, P2 commitments met).
+- Claude review has no unresolved blocking findings: PASS.
+- Targeted unit/integration tests pass: PASS for unit. Integration gated to baseline-failed environment, documented as residual.
+- Build/type-check recorded: PASS.
+- Migration rollback documented: N/A (no migration in PR1).
+- Verification note committed under `docs/development/`: PASS.
+
+Ready to merge.
+
+## Forward-Looking Track List
+
+For Phase 1 follow-up after PR1 merges (not blocking):
+
+- Item A: extract `APPROVAL_TERMINAL_STATUSES` constant (finding 5.1).
+- Item B: comment OR clause intent (finding 5.2).
+- Item C: strengthen guard helper JSDoc (finding 5.3).
+- Item D: real-PG concurrent publish integration test when env repaired (finding 3.2).
+- Item E: explicit T9 form-schema-violation test when any form re-validation path is added (finding 3.1).
+
+Items A and B are cleanest to bundle into PR2 (auto-approval-three-merge) since it will already touch related code and tests. Items C, D, E are independent.
+
+---
+
+End of review. Codex may proceed to merge PR1 into `main` and then cut PR2.

--- a/docs/development/approval-pr1-scope-gate-request-20260515.md
+++ b/docs/development/approval-pr1-scope-gate-request-20260515.md
@@ -141,4 +141,3 @@ Do-not-cross lines:
 Review focus:
 Go / no-go for Codex implementation:
 ```
-

--- a/docs/development/approval-pr1-scope-gate-request-20260515.md
+++ b/docs/development/approval-pr1-scope-gate-request-20260515.md
@@ -1,0 +1,144 @@
+# Approval PR1 Scope Gate Request 2026-05-15
+
+## Request
+
+Claude should review this request before Codex starts PR1 code changes.
+
+Claude scope:
+
+- Produce a scope gate checklist.
+- Identify semantic risks.
+- List required tests.
+- Mark do-not-cross lines.
+- Provide review focus for the eventual PR1 diff.
+
+Claude should not propose Phase 2/3/4 product work for PR1.
+
+## PR Scope
+
+PR:
+
+- `version-freeze-hardening`
+
+Branch:
+
+- `flow/version-freeze-hardening-20260515`
+
+Worktree:
+
+- `/Users/chouhua/Downloads/Github/metasheet2-flow-version-freeze-hardening-20260515`
+
+Base commit:
+
+- `be699941f docs: record approval phase1 baseline`
+
+Primary references:
+
+- `docs/development/approval-phase1-codex-claude-worksplit-todo-20260515.md`
+- `docs/development/approval-phase1-baseline-20260515.md`
+- `docs/research/yida-workflow-vs-metasheet2-comparison-20260514.md`
+- `docs/research/yida-workflow-automation-benchmark-improvement-plan-20260515.md`
+
+## Expected Files
+
+Expected implementation files:
+
+- `packages/core-backend/src/services/ApprovalProductService.ts`
+- `packages/core-backend/src/types/approval-product.ts` only if DTO or API response shape must expose version governance metadata.
+- `packages/core-backend/src/db/migrations/*approval*` only if a new archive/delete guard requires schema support.
+- `packages/core-backend/tests/unit/**/*approval*`
+- `packages/core-backend/tests/integration/**/*approval*`
+
+Expected documentation files:
+
+- `docs/development/approval-pr1-version-freeze-development-20260515.md`
+- `docs/development/approval-pr1-version-freeze-verification-20260515.md`
+
+## Current Code Baseline
+
+Known existing implementation:
+
+- `ApprovalProductService.publishTemplate()` already creates an immutable `approval_published_definitions.runtime_graph` row and marks previous active definitions inactive.
+- `ApprovalProductService.createApproval()` already stores `template_version_id`, `published_definition_id`, and `form_snapshot` on `approval_instances`.
+- `ApprovalProductService.dispatchAction()` already reloads runtime graph from the instance-bound `published_definition_id`.
+- Migration `zzzz20260411120100_approval_templates_and_instance_extensions.ts` already creates `approval_templates`, `approval_template_versions`, `approval_published_definitions`, and instance binding columns.
+
+Therefore PR1 should harden and verify version-freeze semantics. It should not rebuild the version model from scratch.
+
+## Explicit Non-Goals
+
+- No generic `approval_trigger_bindings`.
+- No public-form submitted-to-approval product UI.
+- No multitable submitted-to-approval product UI.
+- No `start_approval` automation action.
+- No persistent `automation_jobs` queue.
+- No automation retry.
+- No business calendar or SLA timeout action work.
+- No auto-approval three-merge implementation.
+- No admin jump implementation.
+- No add-sign implementation.
+- No graph runtime insertion or `runtimeInsertedNodes`.
+- No unrelated frontend product surface.
+
+## Boundary Checklist For Claude
+
+Claude should explicitly answer yes/no for each item:
+
+- Does PR1 stay limited to version-freeze hardening?
+- Does PR1 avoid adding new product surfaces?
+- Does PR1 avoid scheduler, automation, SLA, add-sign, and admin-jump work?
+- Does PR1 use instance-bound `published_definition_id` as the runtime source of truth?
+- Does PR1 prevent or guard destructive version operations when unfinished instances reference the version?
+- Does PR1 prove stale published definitions remain readable for running instances?
+- Does PR1 avoid reading template `active_version_id` when advancing an existing instance?
+- Does PR1 keep migration rollback behavior documented and tested if migrations change?
+
+## Tests Planned
+
+Codex should add or verify tests for:
+
+- Old instance advances with the original `published_definition_id` after a new template version is published.
+- Old instance keeps original form snapshot semantics after the template form schema changes.
+- New instance uses the latest active published definition after publish.
+- Destructive delete/archive of a referenced version is blocked when unfinished instances exist.
+- Stale published definition remains readable even after another version is active.
+- Publish failure rolls back active definition changes.
+- Any path that accidentally reads template `active_version_id` for an existing instance is covered or removed.
+
+Suggested targeted commands:
+
+```bash
+pnpm --filter @metasheet/core-backend test:unit
+pnpm --filter @metasheet/core-backend test:integration -- tests/integration/approval-pack1a-lifecycle.api.test.ts
+pnpm --filter @metasheet/core-backend build
+pnpm type-check
+```
+
+Baseline note:
+
+- Full unit suite passed before PR1 code changes: 165 files, 2136 tests.
+- Full integration suite is not green in this local environment before PR1 code changes; see `docs/development/approval-phase1-baseline-20260515.md`.
+
+## Review Focus Requested
+
+Claude should focus review on:
+
+1. Version source of truth: instance-bound runtime must win over active template state.
+2. Transactionality: publish should not leave multiple active definitions or half-written version state.
+3. Deletion/archive safety: no referenced active/running version can be destructively removed.
+4. Test effectiveness: regression tests should fail if instance advancement accidentally uses the current active template.
+5. Scope creep: no Phase 2+ behavior should be included.
+
+## Expected Claude Output
+
+Please return:
+
+```text
+Scope gate:
+Semantic risks:
+Required tests:
+Do-not-cross lines:
+Review focus:
+Go / no-go for Codex implementation:
+```
+

--- a/docs/development/approval-pr1-scope-gate-response-20260515.md
+++ b/docs/development/approval-pr1-scope-gate-response-20260515.md
@@ -1,0 +1,166 @@
+# Approval PR1 Scope Gate Response 2026-05-15
+
+Responding to `docs/development/approval-pr1-scope-gate-request-20260515.md`.
+
+Reviewer: Claude
+Worktree confirmed: `/Users/chouhua/Downloads/Github/metasheet2-flow-version-freeze-hardening-20260515`
+Base commit verified: `be699941f docs: record approval phase1 baseline`
+
+## Verification Findings (Code-Grounded)
+
+Before answering the boundary checklist, three code-level facts were verified directly against the worktree:
+
+F1. `ApprovalProductService.dispatchAction` already reads instance-bound `published_definition_id` and loads `runtime_graph` from `approval_published_definitions` directly (lines 1750-1770). It does NOT consult `approval_templates.active_version_id`. → Source-of-truth invariant is structurally correct at baseline.
+
+F2. `loadTemplateBundle` / `loadTemplateBundleWithClient` (lines 2391-2440) use `preferredVersion: 'active' | 'latest'` only at four call sites: lines 1162 (latest, get-detail), 1167 (explicit version), 1356 (latest, inside publish path), 1508 (latest, clone), 1597 (active, `createApproval`). None of these is an instance-advance path. → No latent regression bypass.
+
+F3. There is NO existing code path for deleting or archiving an `approval_template`, `approval_template_version`, or `approval_published_definition` in `ApprovalProductService.ts`. Grep on `deleteTemplate|archiveTemplate|deleteVersion|archiveVersion|DELETE FROM approval_template` returns empty. → "Add service guard for hard-delete/archive" in PR1 (worksplit §5 line 119) cannot harden an existing path; it must add a new internal helper or a new endpoint. This is a scope decision Codex/user must resolve before code starts. See R1 and P1 below.
+
+## Scope Gate
+
+Answers to the 8 boundary checklist items in the request:
+
+1. Does PR1 stay limited to version-freeze hardening?
+   YES — conditional on R1 below. If the delete/archive guard becomes a new HTTP endpoint, that conditional flips to NO.
+
+2. Does PR1 avoid adding new product surfaces?
+   YES — provided R1 resolves to "internal service helper, no new endpoint, no UI."
+
+3. Does PR1 avoid scheduler, automation, SLA, add-sign, and admin-jump work?
+   YES. Codex's Expected Files list excludes all such modules.
+
+4. Does PR1 use instance-bound `published_definition_id` as the runtime source of truth?
+   YES — already structurally true (F1). PR1's job is to add regression tests that pin this invariant against future drift.
+
+5. Does PR1 prevent or guard destructive version operations when unfinished instances reference the version?
+   YES — conditional on R1.
+
+6. Does PR1 prove stale published definitions remain readable for running instances?
+   YES — required via T5/T10 below.
+
+7. Does PR1 avoid reading template `active_version_id` when advancing an existing instance?
+   YES — already true (F1, F2). PR1 must add a mock-pool test that asserts `dispatchAction` issues `SELECT FROM approval_published_definitions WHERE id = $1` and zero `SELECT FROM approval_templates ... active_version_id` during advance.
+
+8. Does PR1 keep migration rollback behavior documented and tested if migrations change?
+   YES — required if PR1 introduces any schema change. If guard is purely service-internal with no schema delta, no migration is needed.
+
+## Semantic Risks
+
+R1. Delete/archive scope ambiguity (high impact).
+There is no existing delete/archive code path (F3). PR1 must choose:
+   (a) Add an internal helper such as `assertVersionDeletable(templateVersionId)` that throws when unfinished instances reference the version. No new endpoint, no UI. This keeps PR1 strictly hardening.
+   (b) Add a new HTTP endpoint such as `DELETE /api/approval-templates/:id/versions/:versionId` plus the guard.
+Claude recommends (a). If (b) is taken, it is arguably a new product surface and must be raised to the user before PR1 starts.
+
+R2. Concurrent publish race.
+`publishTemplate` performs `SELECT * FROM approval_templates WHERE id = $1 FOR UPDATE` (line 1389), serializing per-template publishes. However, `approval_template_versions` and `approval_published_definitions` rows are not separately locked. The template-row lock should be sufficient, but PR1 should pin it via a concurrent-publish regression test.
+
+R3. Form snapshot vs runtime graph independence.
+`approval_instances.form_snapshot` and `approval_published_definitions.runtime_graph` are two version-frozen artifacts that must remain stable for an instance's lifetime. PR1 tests must cover both independently. Editing the template's form schema must not change `formData` validation on existing instances; editing the template's graph must not change advance behavior on existing instances.
+
+R4. Rollback completeness on publish failure.
+`publishTemplate`'s try/catch invokes `rollbackQuietly(client)`. If the function swallows errors silently, an orphaned `approval_published_definitions` row could persist. PR1 should add a test that injects a failure mid-transaction and asserts no orphaned rows in any of the three tables involved.
+
+R5. `loadTemplateBundle` 'active' preference reuse risk.
+Line 2420 chooses `latest_version_id || active_version_id` (or the reverse) based on `preferredVersion`. This is correct for new instance creation and for editing/cloning. A future developer might mis-use `preferredVersion: 'active'` to "load the template state for an existing instance" — silently picking up a newer `active_version_id`. PR1 should either:
+   - Add a strong doc comment on `loadTemplateBundle` warning against use during instance advance, OR
+   - Split the helper into two named functions (e.g., `loadBundleForNewApproval`, `loadBundleForEditing`).
+Either is acceptable. Renaming is preferred for long-term clarity but the doc comment is sufficient for PR1.
+
+R6. DB-level safety residual.
+Any service-layer guard PR1 adds does not protect against direct SQL (`DELETE FROM approval_published_definitions WHERE id = ...` via psql or admin tools). Out of scope for PR1. PR1's verification doc should note this residual risk and recommend an `ON DELETE RESTRICT` FK or DB trigger as a future hardening.
+
+## Required Tests
+
+Codex listed 7 tests under "Tests Planned." Claude requires all 7 plus the following additions/strengthenings:
+
+T1. (listed) Old instance advances with original `published_definition_id` after a new template version is published.
+
+T2. (listed) Old instance keeps original form snapshot semantics after the template form schema changes.
+
+T3. (listed) New instance uses the latest active published definition after publish.
+
+T4. (listed; depends on R1) Destructive delete/archive of a referenced version is blocked when unfinished instances exist.
+
+T5. (listed) Stale published definition remains readable even after another version is active.
+
+T6. (listed, strengthened) Publish failure rolls back active definition changes AND leaves no orphaned `approval_published_definitions` row.
+
+T7. (listed, specified) Mock-pool test asserting `dispatchAction` issues `SELECT FROM approval_published_definitions WHERE id = $1` exactly once per advance and issues zero `SELECT FROM approval_templates ... active_version_id` SQL during advance.
+
+T8. (NEW — R2) Concurrent publish test: two parallel `publishTemplate` calls on the same template. Final state has exactly one row with `is_active = TRUE` in `approval_published_definitions` for that template; the losing call either succeeds (newer version becomes active) or fails cleanly (no orphan), but never leaves multiple active rows.
+
+T9. (NEW — R3) Form snapshot independence: instance created with form schema F1; template form schema updated and republished to F2; submitting `formData` violating F1 but matching F2 must still be rejected for the existing instance.
+
+T10. (NEW — R3) Runtime graph independence: instance created with graph G1; template graph updated and republished to G2 (with a new node or different routing); `dispatchAction` on the existing instance traverses G1's edges, not G2's.
+
+T11. (NEW — R1 option (a)) Guard ergonomics: when `assertVersionDeletable` (or equivalent) throws, the error message must include the count of unfinished instances and a sample `approval_instance.id` so operators can investigate. Pin via exact error shape.
+
+T12. (NEW — R5 if rename is taken) Static-style test: grep or AST check that ensures no file other than `createApproval` and clone/edit helpers calls `loadTemplateBundle` with `preferredVersion: 'active'`. If rename is taken, this becomes a typed call-site list. If only doc comment is added, this test is optional but recommended.
+
+## Do-Not-Cross Lines
+
+File-level (PR1 must not edit):
+
+- `packages/core-backend/src/services/ApprovalGraphExecutor.ts`
+- `packages/core-backend/src/routes/approvals.ts` — unless R1 resolves to (b) and a new endpoint is added; even then, additive only, no existing route changes.
+- `packages/core-backend/src/multitable/automation-*` — all automation files.
+- `packages/core-backend/src/services/approval-sla-*` or `approval-breach-*`.
+- `apps/web/src/views/**/*Approval*` — frontend is out of scope for PR1.
+- `packages/core-backend/src/db/migrations/zzzz20260411120100_approval_templates_and_instance_extensions.ts` — read-only. Any schema change must be a NEW migration file.
+
+Function-level locks (PR1 owns within `ApprovalProductService.ts`):
+
+- `publishTemplate`
+- `createApproval`
+- `dispatchAction` — regression tests only; no behavioral change.
+- `loadTemplateBundle` and `loadTemplateBundleWithClient` — doc-comment clarification or careful split only; no semantic change to existing call sites.
+- New: any `assertVersionDeletable` / `assertVersionArchivable` helper or equivalent.
+
+Out of scope even within `ApprovalProductService.ts`:
+
+- Auto-approval policy logic (PR2 owns).
+- Admin jump logic (PR3 owns).
+- Add-sign logic (PR4 owns).
+
+## Review Focus
+
+When Codex requests review on the PR diff, Claude will scrutinize in this order:
+
+1. Source-of-truth invariant verified by grep on the final diff: every `SELECT * FROM approval_published_definitions` during instance advance uses `instance.published_definition_id` as the WHERE clause input. No `SELECT ... active_version_id` from `approval_templates` is introduced.
+
+2. Migration rollback (if applicable): up → down → up sequence runs clean on a scratch DB. Schema constraints are reversible.
+
+3. Test effectiveness: each new test fails when the guarded behavior is removed/mutated. Codex must demonstrate this in the verification doc with explicit before/after lines (for example: "test T1 fails at commit X with message Y; passes at commit Z").
+
+4. Scope creep: no edits to `ApprovalGraphExecutor`, no edits to `routes/approvals.ts` other than the additive guard endpoint (if R1=b), no edits to UI files, no edits to automation or SLA files.
+
+5. R1 option documented: the PR1 development doc must explicitly state which option (a or b) was chosen and the reasoning.
+
+6. R2 concurrent-publish test exists (T8) and demonstrates correct serialization.
+
+7. R3 independence tests exist (T9 and T10) and cover both form snapshot and runtime graph separately.
+
+8. Verification report compares against baseline `docs/development/approval-phase1-baseline-20260515.md`. PR1 must not introduce new failures vs baseline. Existing baseline failures (DB env, mocked-SQL drift) are not PR1's to fix.
+
+9. R5 mitigation taken (rename or doc comment) is documented in the development doc.
+
+## Go / No-Go For Codex Implementation
+
+CONDITIONAL GO.
+
+Two prerequisites must be acknowledged in the PR1 development doc before Codex begins writing code:
+
+P1. R1 decision recorded. Codex (or user, if escalated) declares whether PR1 implements the version-deletion/archive guard as:
+   - (a) internal service helper, no new endpoint, no UI — Claude's recommended choice; OR
+   - (b) new HTTP endpoint with guard — requires user sign-off as a small product-surface addition.
+
+P2. Test plan acknowledgment. Codex commits to including T8, T9, T10, T11 in addition to the 7 tests listed in the scope gate request. For each test, the development doc must record that the test was demonstrated to fail without the corresponding hardening change (effectiveness evidence).
+
+Once P1 and P2 are recorded in `docs/development/approval-pr1-version-freeze-development-20260515.md`, Codex may begin implementation.
+
+If P1 lands on option (b), Codex must pause and surface the scope expansion to the user before any code change.
+
+---
+
+End of scope gate response.

--- a/docs/development/approval-pr1-version-freeze-development-20260515.md
+++ b/docs/development/approval-pr1-version-freeze-development-20260515.md
@@ -1,0 +1,63 @@
+# Approval PR1 Version Freeze Development 2026-05-15
+
+## Scope Gate Decisions
+
+### P1: Delete/Archive Guard Scope
+
+Decision: choose option (a).
+
+PR1 will add an internal service helper for version deletion/archive safety, for example `assertVersionDeletable(templateVersionId)`. It will not add an HTTP endpoint, UI, route, or product surface.
+
+Reason:
+
+- Claude verified there is no existing delete/archive template-version code path.
+- Adding a public endpoint would be a new product surface and would violate the Phase 1 hardening boundary.
+- An internal helper lets PR1 pin the safety invariant for future route work without exposing new behavior.
+
+If implementation discovers that a public endpoint is required, Codex must stop and ask the user before writing that endpoint.
+
+### P2: Test Commitment
+
+PR1 commits to covering T1-T11 from the Claude scope gate response. T12 is optional and will be implemented only if the `loadTemplateBundle` mitigation is done through call-site splitting rather than a doc comment.
+
+| ID | Test | Required |
+|---|---|---|
+| T1 | Old instance advances with original `published_definition_id` after a new template version is published. | Yes |
+| T2 | Old instance keeps original form snapshot semantics after the template form schema changes. | Yes |
+| T3 | New instance uses the latest active published definition after publish. | Yes |
+| T4 | Destructive delete/archive of a referenced version is blocked when unfinished instances exist. | Yes, via internal helper |
+| T5 | Stale published definition remains readable even after another version is active. | Yes |
+| T6 | Publish failure rolls back active definition changes and leaves no orphaned `approval_published_definitions` row. | Yes |
+| T7 | `dispatchAction` reads `approval_published_definitions` by `instance.published_definition_id` and does not read `approval_templates.active_version_id` during advance. | Yes |
+| T8 | Concurrent publish leaves exactly one active published definition. | Yes |
+| T9 | Form snapshot independence after schema update and republish. | Yes |
+| T10 | Runtime graph independence after graph update and republish. | Yes |
+| T11 | Guard error includes unfinished instance count and sample approval instance id. | Yes |
+| T12 | Static/AST call-site guard for `preferredVersion: 'active'`. | Optional |
+
+For every required test, the verification document must state whether the test was shown to fail before the corresponding hardening or whether it pins an already-correct baseline invariant.
+
+## Implementation Notes
+
+PR1 should harden the existing version-freeze model. It should not rebuild it.
+
+Known baseline invariants:
+
+- `createApproval()` persists `template_version_id`, `published_definition_id`, and `form_snapshot`.
+- `dispatchAction()` loads `runtime_graph` from `approval_published_definitions` using `instance.published_definition_id`.
+- `publishTemplate()` runs inside a transaction and locks the template row with `FOR UPDATE`.
+
+Expected code changes:
+
+- Add an internal version delete/archive guard helper.
+- Add a clear doc comment or small naming guard around `loadTemplateBundle` usage so it is not reused for existing-instance advancement.
+- Add regression tests for version freeze, snapshot independence, rollback, and concurrent publish.
+
+Out of scope:
+
+- HTTP delete/archive version endpoint.
+- Approval template UI changes.
+- `ApprovalGraphExecutor` changes.
+- `routes/approvals.ts` changes.
+- Automation/SLA/add-sign/admin-jump work.
+

--- a/docs/development/approval-pr1-version-freeze-development-20260515.md
+++ b/docs/development/approval-pr1-version-freeze-development-20260515.md
@@ -49,9 +49,9 @@ Known baseline invariants:
 
 Expected code changes:
 
-- Add an internal version delete/archive guard helper.
-- Add a clear doc comment or small naming guard around `loadTemplateBundle` usage so it is not reused for existing-instance advancement.
-- Add regression tests for version freeze, snapshot independence, rollback, and concurrent publish.
+- [x] Add an internal version delete/archive guard helper.
+- [x] Add a clear doc comment or small naming guard around `loadTemplateBundle` usage so it is not reused for existing-instance advancement.
+- [x] Add regression tests for version freeze, snapshot independence, rollback, and concurrent publish.
 
 Out of scope:
 
@@ -61,3 +61,34 @@ Out of scope:
 - `routes/approvals.ts` changes.
 - Automation/SLA/add-sign/admin-jump work.
 
+## Implementation Result
+
+Code changes:
+
+- `packages/core-backend/src/services/ApprovalProductService.ts`
+  - Added `assertTemplateVersionDeletable(templateVersionId)`.
+  - The guard checks unfinished instances by both direct `approval_instances.template_version_id` and indirect `approval_instances.published_definition_id -> approval_published_definitions.template_version_id`.
+  - Terminal statuses treated as safe: `approved`, `rejected`, `revoked`, `cancelled`.
+  - The 409 error includes `unfinishedCount` and `sampleInstanceId`.
+  - Added a `loadTemplateBundleWithClient()` comment that explicitly forbids reuse for existing-instance advancement.
+- `packages/core-backend/tests/unit/approval-product-service.test.ts`
+  - Added regression coverage for active-version create, stale published-definition advance, form snapshot routing, delete/archive guard, publish row-lock ordering, and publish rollback.
+
+No migration was added. `down()` rollback verification is not applicable for this PR.
+
+## Test Mapping
+
+| ID | Coverage | Evidence |
+|---|---|---|
+| T1 | Old instance advances with original `published_definition_id` after a new template version is published. | `advances existing approvals from the instance-bound stale published definition and form snapshot` uses `pub-old` / `ver-old` and asserts result stays bound to them. |
+| T2 | Old instance keeps original form snapshot semantics after schema change. | Same test routes by stored `form_snapshot.legacyAmount`, not a live template schema lookup. |
+| T3 | New instance uses latest active published definition after publish. | `creates new approvals from the currently active published definition` asserts inserted instance uses `ver-2` / `pub-2`. |
+| T4 | Delete/archive of referenced version blocked. | `blocks template version delete/archive checks with unfinished count and sample id`. |
+| T5 | Stale published definition remains readable after another version is active. | Stale `pub-old` row is returned with `is_active: false` and still advances. |
+| T6 | Publish failure rollback leaves no orphaned active definition row. | `rolls back publish when the active definition insert fails` asserts `ROLLBACK`, no `COMMIT`, and no template status update. |
+| T7 | `dispatchAction` reads by `instance.published_definition_id`, not `active_version_id`. | Stale advance test asserts the published definition query param is `pub-old` and no SQL mentions `approval_templates` or `active_version_id`. |
+| T8 | Concurrent publish leaves one active definition. | `serializes publish with a template row lock and template-scoped active definition swap` pins `FOR UPDATE` plus deactivate-before-insert order; `keeps only one active published definition across concurrent publish calls` simulates two concurrent publishes over a virtual lock-backed DB state. |
+| T9 | Form snapshot independence after schema update and republish. | Same snapshot routing test; no existing old-instance form resubmit path was found. |
+| T10 | Runtime graph independence after graph update and republish. | Same stale advance test uses frozen runtime graph to route to `approval_old_high`. |
+| T11 | Guard error includes unfinished instance count and sample ID. | Guard rejection test asserts `unfinishedCount: 2` and `sampleInstanceId: apr-pending-1`. |
+| T12 | Static/AST call-site guard for `preferredVersion: 'active'`. | Not implemented; PR1 used a code comment guard instead of call-site splitting, per P2 optional scope. |

--- a/docs/development/approval-pr1-version-freeze-verification-20260515.md
+++ b/docs/development/approval-pr1-version-freeze-verification-20260515.md
@@ -1,0 +1,54 @@
+# Approval PR1 Version Freeze Verification 2026-05-15
+
+## Scope
+
+Branch: `flow/version-freeze-hardening-20260515`
+
+This verification covers PR1 `version-freeze-hardening` only:
+
+- Internal delete/archive safety helper.
+- Existing-instance version freeze regression coverage.
+- Publish transaction and row-lock regression coverage.
+
+No HTTP endpoint, UI, route, automation, SLA, add-sign, admin-jump, or migration changes were added.
+
+## Commands
+
+| Command | Result | Notes |
+|---|---:|---|
+| `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-product-service.test.ts --watch=false` | PASS | 1 file, 16 tests. |
+| `pnpm --filter @metasheet/core-backend test:unit` | PASS | Final rerun: 165 files, 2143 tests. |
+| `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/plm-workbench-routes.test.ts --watch=false` | PASS | 36 tests. Run after one unrelated full-suite `ECONNRESET` flake in this file. |
+| `pnpm --filter @metasheet/core-backend build` | PASS | TypeScript compile passed. |
+| `pnpm --filter @metasheet/core-backend lint` | N/A | Package has no `lint` script. |
+
+Full integration was not rerun for PR1 because the recorded baseline already fails in the current local environment due missing DB setup (`database "chouhua" does not exist` / `DATABASE_URL is required`) and existing mock SQL drift. PR1 added no migration.
+
+## Regression Matrix
+
+| ID | Status | Test Evidence | Baseline / Failure Signal |
+|---|---|---|---|
+| T1 | PASS | `advances existing approvals from the instance-bound stale published definition and form snapshot` | Pins already-correct invariant. Would fail if advance used current active template instead of `instance.published_definition_id`. |
+| T2 | PASS | Same test uses `form_snapshot: { legacyAmount: 250 }` to route through the frozen condition graph. | Pins already-correct invariant. Would fail if advance reloaded current schema/form data. |
+| T3 | PASS | `creates new approvals from the currently active published definition` | Pins create path selecting active published definition. |
+| T4 | PASS | `blocks template version delete/archive checks with unfinished count and sample id` | New guard; before PR1 the method did not exist. |
+| T5 | PASS | Stale advance test returns `pub-old` with `is_active: false` and still advances. | Pins ability to read stale published definitions. |
+| T6 | PASS | `rolls back publish when the active definition insert fails` | Pins rollback path and prevents post-insert template status update on failure. |
+| T7 | PASS | Stale advance test asserts no SQL mentions `approval_templates` or `active_version_id`. | Pins source-of-truth invariant. |
+| T8 | PASS | `serializes publish with a template row lock and template-scoped active definition swap`; `keeps only one active published definition across concurrent publish calls` | Unit-level guard for `FOR UPDATE`, active swap order, and virtual two-publisher serialization; true DB concurrency replay remains integration-DB gated. |
+| T9 | PASS | Same stale advance test pins stored form snapshot routing. | No old-instance form resubmit/update path exists in current service. |
+| T10 | PASS | Same stale advance test pins frozen runtime graph routing to `approval_old_high`. | Pins runtime graph independence. |
+| T11 | PASS | Guard rejection test asserts `unfinishedCount` and `sampleInstanceId`. | New guard; before PR1 the method did not exist. |
+| T12 | SKIP | Optional. | Not needed because mitigation was a code comment, not helper splitting. |
+
+## Migration Rollback
+
+No migration was added in PR1. `up -> down -> up` rollback verification is not applicable.
+
+## Result
+
+PR1 implementation is ready for Claude review against the scope gate:
+
+- P1 is option (a): internal helper only, no product surface.
+- P2 required coverage T1-T11 is present at unit level.
+- Integration DB-gated concurrency replay remains a documented residual verification gap, not a code blocker for this local run.

--- a/docs/development/approval-pr2-auto-approval-three-merge-development-20260515.md
+++ b/docs/development/approval-pr2-auto-approval-three-merge-development-20260515.md
@@ -1,0 +1,145 @@
+# Approval PR2 Auto-Approval Three-Merge Development 2026-05-15
+
+## Scope Gate Acknowledgement
+
+Source gate:
+
+- `docs/development/approval-pr2-scope-gate-request-20260515.md`
+- `docs/development/approval-pr2-scope-gate-response-20260515.md`
+
+Decision: conditional GO accepted. Codex will implement only after the following
+three prerequisites are recorded here.
+
+### P1. Storage Stance
+
+PR2 stores `autoApproval` as part of `RuntimePolicy`, which is snapshotted into
+`approval_published_definitions.runtime_graph` by the existing
+`buildRuntimeGraph(approvalGraph, policy)` publish path.
+
+Implementation stance:
+
+- Extend `RuntimePolicy` with `autoApproval?: AutoApprovalPolicy`.
+- Extend `PublishApprovalTemplateRequest.policy` validation to accept optional
+  `autoApproval`.
+- Do not add `approval_template_versions.auto_approval_policy` in PR2.
+- During existing-instance advance, read policy only from the instance-bound
+  `published_definition_id` runtime graph.
+
+Reason:
+
+This preserves PR1 version-freeze semantics without a migration. Mutable
+template/version authoring storage can be added later, but it must never become
+the advance-time source of truth.
+
+### P2. Cross-Branch Decision
+
+PR2 implements refuse-and-warn for cross-branch adjacent merge.
+
+Implementation stance:
+
+- Do not atomically auto-merge the same user across sibling parallel branches.
+- When `mergeAdjacentApprover` would conflict with an active sibling branch for
+  the same assignee, skip the merge for that target and record structured
+  metadata:
+  - `skipped: true`
+  - `skipReason: 'cross_branch_adjacency_conflict'`
+  - `conflictBranches: [...]`
+- Atomic cross-branch merge is out of scope for PR2 and requires a separate ADR.
+
+Reason:
+
+`approval_assignments` has a partial active-unique index on
+`(instance_id, assignment_type, assignee_id)`. PR2 must not weaken that invariant
+or introduce ambiguous parallel branch state.
+
+### P3. Audit Taxonomy And Consumer Check
+
+Required reason codes:
+
+- `empty-assignee`
+- `auto-merge-requester`
+- `auto-merge-adjacent`
+- `auto-dedupe-historical`
+
+Required metadata for PR2 auto-approval records:
+
+```json
+{
+  "reason": "auto-merge-requester | auto-merge-adjacent | auto-dedupe-historical",
+  "policySource": "node | template",
+  "originalApprover": { "type": "user | role", "id": "..." },
+  "matchedAgainst": { "nodeKey": "...", "recordId": "..." },
+  "actorMode": "system | original_approver"
+}
+```
+
+`matchedAgainst` is required only for adjacent and historical matches.
+
+`actor_id` defaults to `system:auto-approval` when
+`actorMode === 'system'`.
+
+Reason consumer grep:
+
+```bash
+rg -n "empty-assignee|reason.*auto|autoApproved|metadata\\.reason|reason\\]" packages/core-backend/src packages/core-backend/tests
+```
+
+Result before code:
+
+- Runtime consumers are limited to `ApprovalGraphExecutor` emitting
+  `empty-assignee` and `ApprovalProductService.insertAutoApprovalEvents()`
+  persisting metadata.
+- Existing test consumers assert `empty-assignee` and `autoApproved` metadata.
+- No production switch or exhaustive match on `metadata.reason` was found.
+
+## Implementation Plan
+
+- Add `AutoApprovalPolicy`, reason-code types, and
+  `APPROVAL_TERMINAL_STATUSES` to `types/approval-product.ts`.
+- Extend runtime policy normalization and snapshot construction in
+  `ApprovalProductService.ts`.
+- Add a small policy evaluator helper inside `ApprovalProductService.ts` or a
+  dedicated `ApprovalAutoApprovalPolicyService` if the logic becomes too large.
+- Apply auto-approval after graph resolution returns candidate assignments and
+  before those assignments are inserted as active assignments.
+- Loop through chained automatic resolutions until a human-pending node or a
+  terminal state is reached, bounded by `APPROVAL_MAX_AUTO_STEPS = 50`.
+- Keep `ApprovalGraphExecutor` graph-local; do not move requester/history/
+  adjacent policy into the graph walker.
+- Preserve existing empty-assignee auto-approval behavior and reason code.
+- Absorb PR1 follow-ups A and B:
+  - Extract `APPROVAL_TERMINAL_STATUSES`.
+  - Add a short comment on the delete guard OR predicate.
+
+## Test Matrix
+
+Codex will cover the original PR2 scope tests plus Claude additions T17-T25:
+
+- requester merge on first approval node.
+- requester merge after condition routing.
+- adjacent merge across a `cc` node.
+- cross-branch adjacent refuse-and-warn.
+- historical approver dedupe.
+- `all` mode waits for remaining human approvers.
+- `any` mode completes the node and cancels/avoids siblings consistently.
+- node override disabled beats template enabled.
+- node override enabled beats template disabled.
+- deterministic precedence when multiple rules match.
+- full audit metadata for every PR2 auto approval.
+- max auto-step guard rollback.
+- empty-assignee behavior remains distinct and single-emission.
+- pre-PR2 runtime graphs without `policy.autoApproval` behave unchanged.
+- policy version-freeze regression using instance-bound runtime graph.
+
+## Verification Targets
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run packages/core-backend/tests/unit/approval-product-service.test.ts --watch=false
+pnpm --filter @metasheet/core-backend exec vitest run packages/core-backend/tests/unit/approval-graph-executor.test.ts --watch=false
+pnpm --filter @metasheet/core-backend test:unit
+pnpm --filter @metasheet/core-backend build
+pnpm type-check
+```
+
+Integration tests remain subject to the baseline DB environment blocker recorded
+in `docs/development/approval-phase1-baseline-20260515.md`.

--- a/docs/development/approval-pr2-auto-approval-three-merge-development-20260515.md
+++ b/docs/development/approval-pr2-auto-approval-three-merge-development-20260515.md
@@ -111,6 +111,31 @@ Result before code:
   - Extract `APPROVAL_TERMINAL_STATUSES`.
   - Add a short comment on the delete guard OR predicate.
 
+## R3 Chain Semantics
+
+Auto-completed approval nodes count as valid adjacent predecessors for later
+`mergeAdjacentApprover` checks in the same `dispatchAction`.
+
+Example:
+
+- `A(U)` is approved by human `U`.
+- `B(U)` has `mergeAdjacentApprover = true`, so B auto-approves against A.
+- `C(U)` also has `mergeAdjacentApprover = true`, so C auto-approves against B.
+
+This transitive behavior is intentional. It matches the customer expectation
+that repeated consecutive approvals by the same person collapse after the first
+human decision. The bounded loop is per dispatch and guarded by
+`APPROVAL_MAX_AUTO_STEPS = 50`; exceeding the guard throws
+`APPROVAL_AUTO_STEP_LIMIT_EXCEEDED` and rolls back the transaction.
+
+When multiple rules match the same assignment, precedence is deterministic:
+
+1. `mergeWithRequester`
+2. `mergeAdjacentApprover`
+3. `dedupeHistoricalApprover`
+
+The selected reason is the one persisted to `approval_records.metadata.reason`.
+
 ## Test Matrix
 
 Codex will cover the original PR2 scope tests plus Claude additions T17-T25:

--- a/docs/development/approval-pr2-auto-approval-three-merge-development-20260515.md
+++ b/docs/development/approval-pr2-auto-approval-three-merge-development-20260515.md
@@ -136,6 +136,19 @@ When multiple rules match the same assignment, precedence is deterministic:
 
 The selected reason is the one persisted to `approval_records.metadata.reason`.
 
+Node-level `autoApprovalPolicy` is an explicit override. A present but empty
+object (`autoApprovalPolicy: {}`) disables auto-approval for that node instead
+of inheriting the template-level policy.
+
+`asRuntimeGraph` validates `policy` before full graph validation so it can decide
+whether historical runtime snapshots may contain duplicate active approvers
+across parallel branches. This is behavior-equivalent for valid stored graphs.
+
+Cross-branch refused auto-merge warnings are stored as audit records with
+`action = 'sign'` because the legacy action enum has no skipped-automation
+action. Consumers must key off `metadata.skipped === true` and
+`metadata.skipReason === 'cross_branch_adjacency_conflict'`.
+
 ## Test Matrix
 
 Codex will cover the original PR2 scope tests plus Claude additions T17-T25:

--- a/docs/development/approval-pr2-auto-approval-three-merge-verification-20260515.md
+++ b/docs/development/approval-pr2-auto-approval-three-merge-verification-20260515.md
@@ -1,0 +1,94 @@
+# Approval PR2 Auto-Approval Three-Merge Verification 2026-05-15
+
+Branch:
+
+- `flow/auto-approval-three-merge-20260515`
+
+Latest implementation commits:
+
+- `30f0b7662 feat(approval): snapshot auto approval policy`
+- `43ccfa59f test(approval): cover auto approval overrides`
+- `298a939e1 test(approval): cover auto approval guardrails`
+- `5d6395df2 feat(approval): handle parallel auto approval conflicts`
+
+## Commands Run
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-product-service.test.ts --watch=false
+```
+
+Result:
+
+- PASS
+- 1 file
+- 29 tests
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-graph-executor.test.ts --watch=false
+```
+
+Result:
+
+- PASS
+- 1 file
+- 14 tests
+
+```bash
+pnpm --filter @metasheet/core-backend build
+```
+
+Result:
+
+- PASS
+
+```bash
+pnpm --filter @metasheet/core-backend test:unit
+```
+
+Result:
+
+- PASS
+- 165 files
+- 2156 tests
+
+```bash
+pnpm type-check
+```
+
+Result:
+
+- PASS
+- `pnpm -r type-check`
+- `apps/web type-check: Done`
+
+## Coverage Notes
+
+Covered in `approval-product-service.test.ts`:
+
+- `mergeWithRequester` on initial node.
+- node override disabled over template enabled.
+- node override enabled over template disabled.
+- deterministic precedence: requester > adjacent > historical.
+- `empty-assignee` does not double-emit with requester merge.
+- old runtime graphs with no `policy.autoApproval` behave unchanged.
+- all-mode requester auto-merge leaves remaining human assignees pending.
+- adjacent transitive chain semantics.
+- policy version-freeze regression: advance reads policy from instance-bound `published_definition_id`.
+- max auto-step guard: `APPROVAL_AUTO_STEP_LIMIT_EXCEEDED` rolls back.
+- independent parallel branch auto-merge without duplicate active assignments.
+- cross-branch duplicate adjacent merge refuse-and-warn with `skipReason`.
+- publish-time `autoApproval` is snapshotted into `runtime_graph`.
+
+## Migration And Rollback
+
+No migration was added.
+
+PR2 stores `autoApproval` inside existing `approval_published_definitions.runtime_graph.policy`.
+Migration rollback is N/A.
+
+## Known Gaps
+
+- Full integration suite remains subject to the baseline DB environment issue recorded before PR1.
+- PR2 intentionally adds no frontend policy authoring UI.
+- PR2 intentionally adds no `approval_template_versions.auto_approval_policy` authoring column.
+- Normal template authoring still rejects duplicate approvers across parallel branches. The runtime duplicate refuse-and-warn path is a defensive compatibility path for historical or otherwise pre-existing runtime snapshots.

--- a/docs/development/approval-pr2-auto-approval-three-merge-verification-20260515.md
+++ b/docs/development/approval-pr2-auto-approval-three-merge-verification-20260515.md
@@ -11,6 +11,17 @@ Latest implementation commits:
 - `298a939e1 test(approval): cover auto approval guardrails`
 - `5d6395df2 feat(approval): handle parallel auto approval conflicts`
 
+Post-review fix:
+
+- B1 corrected `approval-pack1a-lifecycle.api.test.ts` to find the
+  empty-assignee auto approval by `metadata.autoApproved` +
+  `metadata.reason = 'empty-assignee'` rather than the old
+  `actor_id = 'system'` literal.
+- M-T1 added unit assertions for persisted auto-approval actors:
+  `empty-assignee` records use `system:auto-approval`, and
+  `actorMode = 'original_approver'` records persist the original approver id.
+- M1/M2/M4 were handled with code comments and development-doc notes.
+
 ## Commands Run
 
 ```bash
@@ -70,6 +81,9 @@ Covered in `approval-product-service.test.ts`:
 - node override enabled over template disabled.
 - deterministic precedence: requester > adjacent > historical.
 - `empty-assignee` does not double-emit with requester merge.
+- `empty-assignee` persists the S3 automation actor id `system:auto-approval`.
+- `actorMode = 'original_approver'` persists the original approver id while the
+  in-memory chain continues to use the business approver for adjacency.
 - old runtime graphs with no `policy.autoApproval` behave unchanged.
 - all-mode requester auto-merge leaves remaining human assignees pending.
 - adjacent transitive chain semantics.
@@ -89,6 +103,9 @@ Migration rollback is N/A.
 ## Known Gaps
 
 - Full integration suite remains subject to the baseline DB environment issue recorded before PR1.
+- `approval-pack1a-lifecycle.api.test.ts` remains DB-gated locally, but its
+  empty-assignee assertion is now aligned with the S3 actor taxonomy and no
+  longer depends on the obsolete `actor_id = 'system'` literal.
 - PR2 intentionally adds no frontend policy authoring UI.
 - PR2 intentionally adds no `approval_template_versions.auto_approval_policy` authoring column.
 - Normal template authoring still rejects duplicate approvers across parallel branches. The runtime duplicate refuse-and-warn path is a defensive compatibility path for historical or otherwise pre-existing runtime snapshots.

--- a/docs/development/approval-pr2-review-request-20260515.md
+++ b/docs/development/approval-pr2-review-request-20260515.md
@@ -1,0 +1,115 @@
+# Approval PR2 Review Request 2026-05-15
+
+Claude should review PR2 according to the Phase 1 §7.2 protocol.
+
+## PR Scope
+
+PR:
+
+- `auto-approval-three-merge`
+
+Branch:
+
+- `flow/auto-approval-three-merge-20260515`
+
+Base:
+
+- `9501d990c docs(approval): track phase1 followups`
+
+## Diff Summary
+
+Implemented:
+
+- Extended `RuntimePolicy` with `autoApproval?: AutoApprovalPolicy`.
+- Snapshotted publish-time `autoApproval` into `approval_published_definitions.runtime_graph.policy`.
+- Added node-level `autoApprovalPolicy` override.
+- Implemented three merge rules:
+  - `mergeWithRequester`
+  - `mergeAdjacentApprover`
+  - `dedupeHistoricalApprover`
+- Added deterministic precedence:
+  - requester
+  - adjacent
+  - historical
+- Added per-dispatch guard:
+  - `APPROVAL_MAX_AUTO_STEPS = 50`
+  - error code `APPROVAL_AUTO_STEP_LIMIT_EXCEEDED`
+  - transaction rollback verified.
+- Kept `ApprovalGraphExecutor` graph-local.
+- Added audit taxonomy:
+  - `empty-assignee`
+  - `auto-merge-requester`
+  - `auto-merge-adjacent`
+  - `auto-dedupe-historical`
+- Added required metadata:
+  - `policySource`
+  - `originalApprover`
+  - `matchedAgainst` where applicable
+  - `actorMode`
+- Implemented parallel branch cascade for independent auto approvals.
+- Implemented duplicate cross-branch adjacent refuse-and-warn for historical runtime snapshots.
+- Absorbed PR1 follow-ups:
+  - `APPROVAL_TERMINAL_STATUSES`
+  - delete guard OR predicate comment.
+
+## Changed Files
+
+- `packages/core-backend/src/types/approval-product.ts`
+- `packages/core-backend/src/services/ApprovalGraphExecutor.ts`
+- `packages/core-backend/src/services/ApprovalProductService.ts`
+- `packages/core-backend/tests/unit/approval-product-service.test.ts`
+- `docs/development/approval-pr2-auto-approval-three-merge-development-20260515.md`
+- `docs/development/approval-pr2-auto-approval-three-merge-verification-20260515.md`
+- `docs/development/approval-pr2-scope-gate-response-20260515.md`
+- `docs/development/approval-pr2-review-request-20260515.md`
+
+## Migration Summary
+
+No migration.
+
+`autoApproval` is stored in existing `runtime_graph.policy` JSONB snapshots.
+`down()` migration verification is N/A.
+
+## Tests Run
+
+See `docs/development/approval-pr2-auto-approval-three-merge-verification-20260515.md`.
+
+Summary:
+
+- `approval-product-service.test.ts`: PASS, 29 tests.
+- `approval-graph-executor.test.ts`: PASS, 14 tests.
+- backend build: PASS.
+- backend full unit suite: PASS, 165 files / 2156 tests.
+- workspace type-check: PASS.
+
+## Known Gaps
+
+- Full integration suite is not re-run because the local DB baseline issue is pre-existing.
+- No frontend policy authoring UI.
+- No editable `approval_template_versions.auto_approval_policy` column.
+- Normal template authoring still rejects duplicate parallel assignees; the runtime duplicate warning path is defensive compatibility only.
+
+## Review Focus Requested
+
+Please review:
+
+1. Policy source of truth: no advance-time read from `approval_templates` or `approval_template_versions`.
+2. Auto-approval audit metadata and reason taxonomy.
+3. Rule precedence and chain semantics.
+4. `all`/`any`/parallel behavior.
+5. Cross-branch duplicate refuse-and-warn semantics.
+6. Loop guard rollback behavior.
+7. Backward compatibility with pre-PR2 runtime graphs.
+8. Scope: no automation, SLA, breach, admin-jump, add-sign, UI, or new routes.
+
+## Expected Claude Output
+
+```text
+Verdict:
+Blocking correctness issues:
+Security/permission issues:
+Missing tests:
+Scope creep:
+Naming/maintainability:
+Merge gate:
+```

--- a/docs/development/approval-pr2-review-response-20260515.md
+++ b/docs/development/approval-pr2-review-response-20260515.md
@@ -1,0 +1,112 @@
+# Approval PR2 Review Response 2026-05-15
+
+Reviewing PR2 `auto-approval-three-merge` (HEAD `fd58c7f19`) against scope gate `docs/development/approval-pr2-scope-gate-response-20260515.md` and Phase 1 §7.2 protocol.
+
+Reviewer: Claude
+Worktree: `/Users/chouhua/Downloads/Github/metasheet2-flow-auto-approval-three-merge-20260515`
+Base verified: `9501d990c docs(approval): track phase1 followups`
+
+## Verdict
+
+CONDITIONAL APPROVE. One blocking finding (B1), trivially cheap to fix. Resolve B1, then merge.
+
+Implementation quality is high. S1 version-freeze inheritance via `RuntimePolicy` snapshot is elegant and ships with zero migration. The cascade, double loop-guard, and cross-branch refuse-and-warn logic is careful and correct. R3 chain semantics are documented. All 9 Claude-required tests (T17-T25) are present; the two spot-checked (T17, T22) are effective.
+
+## Blocking Correctness Issues
+
+### B1. Empty-assignee actor_id change orphans a DB-gated integration assertion
+
+What changed: `insertAutoApprovalEvents` (ApprovalProductService.ts diff lines 831-852) replaced the hardcoded `actorId: 'system', actorName: 'System'` with `actorId: actorIdForAutoApprovalEvent(event)`. For an `empty-assignee` event (no `actorMode`, no `originalApprover`), `actorIdForAutoApprovalEvent` returns `'system:auto-approval'`. So pre-existing empty-assignee auto-approval records now persist `actor_id = 'system:auto-approval'` instead of `'system'`.
+
+This new value is correct and intended — scope gate S3 explicitly said `actor_id` defaults to `system:auto-approval` when `actorMode === 'system'`. The defect is not the behavior; it is the orphaned assertion.
+
+Orphaned assertion: `packages/core-backend/tests/integration/approval-pack1a-lifecycle.api.test.ts:450`:
+
+```js
+const autoApproveRecord = historyResult.rows.find((row) =>
+  row.action === 'approve' && row.actor_id === 'system' && row.metadata?.autoApproved === true)
+expect(autoApproveRecord).toBeTruthy()
+```
+
+This finds the empty-assignee auto-approve record by `actor_id === 'system'`. Post-PR2 that record has `actor_id === 'system:auto-approval'`, so `find` returns undefined and `expect(...).toBeTruthy()` fails. PR2 did not update this file (confirmed: the file is not in the PR2 diff).
+
+Why unit verification missed it: the unit suite (29 tests) does not assert `actor_id` on any auto-approval record (T22 asserts only `reason` and `nodeKey`). The assertion that breaks lives only in the integration suite, which is DB-gated (baseline failure: `database "chouhua" does not exist`) and was not run.
+
+Why this is blocking, not a follow-up: `approval-pack1a-lifecycle.api.test.ts` was already red at baseline due to the DB environment, so in the current local run there is no "new" failure. But the failure reason changes: once the DB environment is repaired (or in CI with a real DB), this test fails on the assertion, not on connection. This is a latent regression masked by an unreachable-stack skip — the exact pattern documented in project memory ([[feedback_metasheet2_skip_when_unreachable_blind_spot]]) that let PR #1435 and #1436 escape. The Phase 1 merge gate intent is "do not introduce latent breakage." The fix is ~2 lines. Leaving it for later means whoever repairs the DB env gets a context-free failure.
+
+Required fix (either is acceptable):
+
+- Minimal: change line 450 to `row.actor_id === 'system:auto-approval'`.
+- Better (recommended): drop the brittle actor_id literal and match on `row.action === 'approve' && row.metadata?.autoApproved === true && row.metadata?.reason === 'empty-assignee'`. This decouples the test from the actor-id taxonomy and is robust to future S3 evolution.
+
+Also required (test-gap remediation, see Missing Tests M-T1): add a unit-level assertion pinning the auto-approval `actor_id` so future drift is caught locally without a live DB.
+
+## Security/Permission Issues
+
+None. The policy is read exclusively from the instance-bound `published_definition_id` runtime graph (verified: ApprovalProductService.ts:2392-2410 loads `runtime.runtime_graph` from `instance.published_definition_id`; the cascade consumes that `runtimeGraph`). No advance-time read of `approval_templates` or `approval_template_versions` for policy. T17 pins this.
+
+## Missing Tests
+
+No required test (T17-T25) is missing. Coverage map confirmed by test name:
+
+- T17 — "uses the instance-bound runtime policy snapshot when auto-approving old instances" (line 1874). Spot-checked: line 1913 asserts the published-definition query param is the instance-bound `pub-old-policy`; line 1953-1954 throws if a human assignment is created (proving auto-merge fired from the frozen snapshot). Strong.
+- T18 — "auto-approves adjacent same-user chains transitively after a human approval".
+- T19 — "refuses and warns when adjacent merge would auto-approve duplicate parallel assignees".
+- T20 — "uses deterministic requester precedence when multiple auto-approval rules match".
+- T21 — "auto-approves independent parallel branches without duplicate active assignments".
+- T22 — "does not double-emit when empty-assignee auto approval coexists with requester merge policy" (line 1590). Spot-checked: asserts exactly one auto record with `reason: 'empty-assignee'`. Effective for the double-emit concern.
+- T23 — "keeps pre-pr2 runtime graphs without autoApproval behavior unchanged" (line 1646). Effective backward-compat.
+- T24 — "rolls back when chained auto-approval exceeds the per-dispatch guard".
+- T25 — "snapshots publish-time auto-approval policy into runtime_graph without a migration column".
+
+Test gap (remediation tied to B1):
+
+- M-T1: No unit test pins the persisted `actor_id` of any auto-approval record. Add to T22 (or a dedicated test) an assertion that the empty-assignee record carries `actor_id === 'system:auto-approval'`, and add a merge-rule test asserting that with `actorMode: 'original_approver'` the record carries the original user id. Had this existed, B1 would have been caught in the unit run.
+
+## Scope Creep
+
+None.
+
+- `ApprovalGraphExecutor.ts`: +4 lines, type-only (import `ApprovalAutoApprovalReason`, widen `reason` union, add optional `metadata?`). No business policy moved into the graph walker. Graph-local preserved per scope gate.
+- No edits to automation, SLA, breach notifier, admin-jump, add-sign, UI, or routes.
+- Zero migration. `autoApproval` rides existing `runtime_graph.policy` JSONB (S1).
+- PR1 follow-ups A (`APPROVAL_TERMINAL_STATUSES` constant, reused via `status <> ALL($2)`) and B (OR-predicate comment) absorbed as agreed.
+
+## Naming/Maintainability
+
+Non-blocking. Recommend addressing M1 and M2 in this PR if cheap; M3, M4 may be doc-only.
+
+- M1: Skipped cross-branch events are written with `action: 'sign'` (diff line 840). `'sign'` is constraint-valid (migration `zzzz20260423120000` CHECK includes it) but semantically `'sign'` is a countersign action (PR4 territory). A skipped record is informational ("this branch was NOT auto-merged"). `metadata.skipped=true` + `skipReason` disambiguates, so this is non-blocking, but document the choice in the dev doc or consider `action: 'comment'`.
+- M2: Deliberate dual identity — in-memory `appendAutoApprovalHistory` and DB-replay `loadApprovalHistory` both reconstruct `actorId = originalApprover.id`, while the persisted `approval_records.actor_id = 'system:auto-approval'`. This is necessary for transitive adjacency across dispatch boundaries and is correct, but subtle. Add a code comment at `loadApprovalHistory` and `appendAutoApprovalHistory` explaining the intentional divergence so a future maintainer does not "unify" them and silently break chains.
+- M3: `asRuntimeGraph` now validates policy before graph (diff lines 217-232) to compute `allowParallelDuplicateAssignees`. Behavior-equivalent for valid stored graphs; only changes which error surfaces first for a doubly-malformed system-generated graph. Acceptable; a one-line note in the dev doc suffices.
+- M4: A present-but-empty node override (`autoApprovalPolicy: {}`) yields `hasEnabledAutoApprovalRule({}) === false`, so `getEffectiveAutoApprovalPolicy` returns null and the node does NOT inherit the template policy. This is a defensible "explicit empty override = disabled" semantic and is consistent with the node-override-wins precedence, but it is not currently stated. Document it next to the precedence rule in the dev doc.
+
+## Merge Gate (§7.3)
+
+- Worktree clean: PASS
+- Boundary checklist: PASS — S1 (snapshot in runtime_graph, zero migration), S2 (refuse-and-warn), S3 (4 reason codes + metadata), S4 (per-dispatch guard, hard fail + rollback) all honored. T17-T25 present.
+- Claude review blocking findings: 1 (B1) — must resolve before merge.
+- Targeted unit tests pass: PASS (approval-product-service 29, approval-graph-executor 14, full unit 2156).
+- Integration: not run (DB-gated). B1 exists precisely because this gate is environmentally masked; B1 fix is mandatory for that reason.
+- Build/type-check: PASS.
+- Migration rollback: N/A (no migration) — correct.
+- Verification doc committed: PASS.
+
+## Required Before Merge
+
+1. Fix B1: update `approval-pack1a-lifecycle.api.test.ts:450` (recommend the metadata-based matcher, not the actor_id literal).
+2. Add M-T1: a unit assertion pinning auto-approval `actor_id` (empty-assignee → `system:auto-approval`; `actorMode: 'original_approver'` merge → original user id).
+3. Re-run `pnpm --filter @metasheet/core-backend test:unit` and confirm still green after adding M-T1.
+4. Record B1 + M-T1 resolution in `docs/development/approval-pr2-auto-approval-three-merge-verification-20260515.md`, and note in the verification doc that `approval-pak1a-lifecycle` remains DB-gated locally but the assertion was corrected to match the S3 actor taxonomy (so the next env repair does not surface a surprise failure).
+
+## Recommended (Non-Blocking, Track If Not Done Here)
+
+- M1 action-type choice for skipped events: document or switch to `comment`.
+- M2 code comments on the intentional history actorId divergence.
+- M4 document the empty-override-disables semantic in the dev doc.
+
+These can be bundled into the B1 fix commit since they are doc/comment-level and touch adjacent code.
+
+---
+
+End of review. Once B1 and M-T1 land and unit suite is re-confirmed green, PR2 is merge-ready.

--- a/docs/development/approval-pr2-scope-gate-request-20260515.md
+++ b/docs/development/approval-pr2-scope-gate-request-20260515.md
@@ -1,0 +1,197 @@
+# Approval PR2 Scope Gate Request 2026-05-15
+
+## Request
+
+Claude should review this request before Codex starts PR2 code changes.
+
+Claude scope:
+
+- Produce a scope gate checklist.
+- Identify semantic risks.
+- List required tests.
+- Mark do-not-cross lines.
+- Provide review focus for the eventual PR2 diff.
+
+Claude should not propose Phase 2/3/4 product work for PR2.
+
+## PR Scope
+
+PR:
+
+- `auto-approval-three-merge`
+
+Branch:
+
+- `flow/auto-approval-three-merge-20260515`
+
+Worktree:
+
+- `/Users/chouhua/Downloads/Github/metasheet2-flow-auto-approval-three-merge-20260515`
+
+Base commit:
+
+- `9501d990c docs(approval): track phase1 followups`
+
+Primary references:
+
+- `docs/development/approval-phase1-codex-claude-worksplit-todo-20260515.md`
+- `docs/development/approval-phase1-followups-20260515.md`
+- `docs/development/approval-pr1-version-freeze-development-20260515.md`
+- `docs/development/approval-pr1-version-freeze-verification-20260515.md`
+- `docs/research/yida-workflow-vs-metasheet2-comparison-20260514.md`
+- `docs/research/yida-workflow-automation-benchmark-improvement-plan-20260515.md`
+
+## Expected Files
+
+Expected implementation files:
+
+- `packages/core-backend/src/services/ApprovalProductService.ts`
+- `packages/core-backend/src/services/ApprovalAutoApprovalPolicyService.ts` if a dedicated policy evaluator keeps `ApprovalProductService` small.
+- `packages/core-backend/src/services/ApprovalGraphExecutor.ts` only for minimal type/reason integration; avoid turning it into the requester/history policy engine.
+- `packages/core-backend/src/types/approval-product.ts`
+- `packages/core-backend/src/db/migrations/*approval*` for `auto_approval_policy` storage if schema changes are needed.
+- `packages/core-backend/tests/unit/**/*approval*`
+- `packages/core-backend/tests/integration/**/*approval*` only if the existing local integration baseline permits useful coverage.
+
+Expected documentation files:
+
+- `docs/development/approval-pr2-auto-approval-three-merge-development-20260515.md`
+- `docs/development/approval-pr2-auto-approval-three-merge-verification-20260515.md`
+
+## Current Code Baseline
+
+Known existing implementation:
+
+- PR1 version-freeze hardening is merged to `main`; existing instance runtime advancement must continue to use `approval_instances.published_definition_id`.
+- `ApprovalGraphExecutor` currently emits auto-approval events only for graph-local empty-assignee cases with `reason: 'empty-assignee'`.
+- `ApprovalProductService.insertAutoApprovalEvents()` writes those graph-local events as `approval_records.action = 'approve'` with system actor metadata.
+- `ApprovalNodeConfig` supports `approvalMode` and `emptyAssigneePolicy`; there is no `AutoApprovalPolicy` type yet.
+- `approval_template_versions` and `approval_published_definitions` exist. Any PR2 policy storage must preserve version-freeze semantics for already-started instances.
+- `approval_assignments` has an active uniqueness index for `(instance_id, assignment_type, assignee_id)` where `is_active = TRUE`.
+- Graph validation already rejects duplicate approvers across parallel branches because the active-assignment unique index cannot represent the same active user in multiple branches.
+
+Therefore PR2 should add the three auto-approval merge rules without changing approval graph topology, without adding product UI, and without relaxing the active assignment invariant.
+
+## Proposed Implementation Stance For Review
+
+Codex intends to implement backend policy evaluation with these defaults unless Claude blocks them:
+
+- Add an `AutoApprovalPolicy` type:
+  - `mergeWithRequester?: boolean`
+  - `mergeAdjacentApprover?: boolean`
+  - `dedupeHistoricalApprover?: boolean`
+  - optional `actorMode?: 'system' | 'original_approver'` only if needed.
+- Store template/global policy as versioned data. Preferred storage is `approval_template_versions.auto_approval_policy JSONB` unless Claude recommends snapshotting it directly into `approval_published_definitions` for stronger freeze semantics.
+- Store node-level override inside approval node config, for example `node.config.autoApprovalPolicy`.
+- Resolve effective policy with precedence: node override > template/version policy > default disabled.
+- Keep `ApprovalGraphExecutor` focused on graph progression. Requester/history/adjacent policy should live in `ApprovalProductService` or `ApprovalAutoApprovalPolicyService`.
+- Evaluate auto-approval after candidate assignments are known and before they are persisted as active assignments where possible.
+- Write an `approval_records` row for every automatic approval with enough metadata to explain the strategy hit and original assignee.
+- Add a max auto-step guard so a bad graph or policy cannot infinite-loop through automatic approvals.
+
+Claude should explicitly accept, reject, or amend this stance.
+
+## Explicit Non-Goals
+
+- No generic `approval_trigger_bindings`.
+- No public-form submitted-to-approval product UI.
+- No multitable submitted-to-approval product UI.
+- No `start_approval` automation action.
+- No persistent `automation_jobs` queue.
+- No automation retry or rerun.
+- No business calendar or SLA timeout action work.
+- No admin jump implementation.
+- No add-sign implementation.
+- No graph runtime insertion or `runtimeInsertedNodes`.
+- No new frontend configuration surface.
+- No approval assignee resolver productization beyond what PR2 strictly needs for fixed user/role assignees.
+- No relaxation of the current duplicate active-assignment invariant unless Claude explicitly approves a smaller, tested exception.
+
+## Follow-ups To Absorb
+
+From `docs/development/approval-phase1-followups-20260515.md`:
+
+- A: extract `APPROVAL_TERMINAL_STATUSES` into `packages/core-backend/src/types/approval-product.ts` and reuse it in service/tests.
+- B: add a short comment explaining why `assertTemplateVersionDeletable()` checks both `template_version_id` and `published_definition_id`.
+
+These are the only PR1 follow-ups intended for PR2. Follow-ups C, D, and E remain independent/deferred.
+
+## Boundary Checklist For Claude
+
+Claude should explicitly answer yes/no for each item:
+
+- Does PR2 stay limited to auto-approval three-merge?
+- Does PR2 avoid adding new product surfaces or frontend configuration UI?
+- Does PR2 avoid scheduler, automation retry, SLA, admin-jump, and add-sign work?
+- Does PR2 preserve PR1 version-freeze semantics by evaluating policy from the instance-bound version/published definition path?
+- Does PR2 avoid mutating runtime graph topology or adding `runtimeInsertedNodes`?
+- Does PR2 keep `ApprovalGraphExecutor` graph-local and avoid moving requester/history/adjacent business policy into the graph walker?
+- Does PR2 keep default behavior disabled unless a policy explicitly enables a merge rule?
+- Does PR2 define and test node override > template policy > default disabled precedence?
+- Does PR2 write audit records for every auto approval?
+- Does PR2 include a max auto-step guard?
+- Does PR2 handle parallel branches without violating `approval_assignments.active_unique`?
+- Does PR2 document and verify migration rollback behavior if migrations change?
+
+## Tests Planned
+
+Codex should add or verify tests for:
+
+- `mergeWithRequester`: requester is assignee on the first approval node, so the node is automatically approved.
+- `mergeWithRequester`: requester appears after a condition node, so the node is automatically approved using the resolved runtime path.
+- `mergeAdjacentApprover`: adjacent same user with a `cc` node in between; the `cc` node does not break adjacency.
+- `mergeAdjacentApprover`: adjacent same user across parallel branches is either supported with explicit semantics or rejected/guarded without duplicate active assignments.
+- `dedupeHistoricalApprover`: a user who already completed approval in the same instance appears again after return/jump-like history and is automatically approved.
+- Multi-assignee `all` mode: auto approval should satisfy only the matching assignee and wait for remaining required approvers.
+- Multi-assignee `any` mode: auto approval should complete the node and cancel or avoid sibling active assignments according to existing any-mode semantics.
+- Global policy enabled and node override disabled: node does not auto approve.
+- Global policy disabled and node override enabled: node auto approves.
+- Multiple rules match the same assignee: metadata records deterministic strategy precedence.
+- Every auto approval writes `approval_records` with actor, original approver, node key, strategy hit, and policy source.
+- Max auto-step guard prevents an infinite automatic approval loop.
+- Existing empty-assignee auto approval still works and remains distinguishable from the three PR2 merge rules.
+- PR1 version-freeze regression: after a new template version is published, an old running instance evaluates auto-approval policy from its bound version/published definition path, not from the current active template.
+- Follow-up A: `APPROVAL_TERMINAL_STATUSES` is reused instead of duplicating terminal status literals.
+- Follow-up B: delete guard OR predicate intent is documented.
+
+Suggested targeted commands:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run packages/core-backend/tests/unit/approval-product-service.test.ts --watch=false
+pnpm --filter @metasheet/core-backend exec vitest run packages/core-backend/tests/unit/approval-graph-executor.test.ts --watch=false
+pnpm --filter @metasheet/core-backend test:unit
+pnpm --filter @metasheet/core-backend test:integration
+pnpm --filter @metasheet/core-backend build
+pnpm type-check
+```
+
+Baseline note:
+
+- Full unit suite passed after PR1: 165 files, 2143 tests.
+- Full integration suite was not green in this local environment before PR1 code changes; see `docs/development/approval-phase1-baseline-20260515.md` and PR1 verification notes.
+
+## Review Focus Requested
+
+Claude should focus review on:
+
+1. Version source of truth: auto-approval policy must not drift to the current active template for running instances.
+2. Policy semantics: requester, adjacent, and historical merge rules should be deterministic and auditable.
+3. Approval modes: `single`, `all`, and `any` must not accidentally bypass required human approvers.
+4. Parallel branches: implementation must not create duplicate active assignments or ambiguous adjacency.
+5. Audit quality: automatic approvals must be distinguishable from human approvals and empty-assignee auto approvals.
+6. Loop safety: max auto-step guard must fail closed with useful diagnostics.
+7. Migration safety: if policy storage changes schema, `up -> down -> up` rollback behavior must be verified on a scratch DB.
+8. Scope creep: no Phase 2+ product surfaces should be included.
+
+## Expected Claude Output
+
+Please return:
+
+```text
+Scope gate:
+Semantic risks:
+Required tests:
+Do-not-cross lines:
+Review focus:
+Go / no-go for Codex implementation:
+```

--- a/docs/development/approval-pr2-scope-gate-response-20260515.md
+++ b/docs/development/approval-pr2-scope-gate-response-20260515.md
@@ -1,0 +1,282 @@
+# Approval PR2 Scope Gate Response 2026-05-15
+
+Responding to `docs/development/approval-pr2-scope-gate-request-20260515.md`.
+
+Reviewer: Claude
+Worktree confirmed: `/Users/chouhua/Downloads/Github/metasheet2-flow-auto-approval-three-merge-20260515`
+Base commit verified: `9501d990c docs(approval): track phase1 followups`
+
+## Verification Findings (Code-Grounded)
+
+Before answering the boundary checklist, four code-level facts were verified directly against the worktree:
+
+F1. `approval_published_definitions.runtime_graph` is the canonical immutable snapshot. `publishTemplate` builds it via `buildRuntimeGraph(approvalGraph, policy)` at line 1416 of `ApprovalProductService.ts`, then INSERTs a fresh row. After publish, `approval_template_versions.approval_graph` is left untouched by publish itself, but is theoretically editable by other future code paths.
+
+F2. `RuntimeGraph` already carries `policy: RuntimePolicy` (`types/approval-product.ts:101-103`). `RuntimePolicy` today is `{ allowRevoke: boolean, revokeBeforeNodeKeys?: string[] }`. Extending `RuntimePolicy` with `autoApproval?: AutoApprovalPolicy` causes the new field to be embedded in `runtime_graph` automatically at publish time, with NO schema change to `approval_published_definitions`. Existing instance advance via `dispatchAction` loads `runtime_graph` from `instance.published_definition_id`, so version-freeze is inherited for free.
+
+F3. Auto-approval today lives only inside `ApprovalGraphExecutor` and emits `reason: 'empty-assignee'` from `emptyAssigneePolicy === 'auto-approve'` at executor.ts:752 and 1016. `ApprovalProductService.insertAutoApprovalEvents()` writes those events to `approval_records`. PR2's three new reasons must coexist with `empty-assignee` and be distinguishable in audit metadata.
+
+F4. `idx_approval_assignments_active_unique` is `UNIQUE(instance_id, assignment_type, assignee_id) WHERE is_active = TRUE` (migration `zzzz20260411120100`, line 110-112). The same user cannot be active in two parallel branches simultaneously. PR2's `mergeAdjacentApprover` across parallel branches must not violate this invariant.
+
+## Scope Gate
+
+Answers to the 12 boundary checklist items in the request:
+
+1. Does PR2 stay limited to auto-approval three-merge?
+   YES — conditional on stance amendments below (S1, S2, S3).
+
+2. Does PR2 avoid adding new product surfaces or frontend configuration UI?
+   YES — provided storage choice is per S1 below (no new HTTP endpoint or UI for policy authoring).
+
+3. Does PR2 avoid scheduler, automation retry, SLA, admin-jump, and add-sign work?
+   YES.
+
+4. Does PR2 preserve PR1 version-freeze semantics by evaluating policy from the instance-bound version/published definition path?
+   YES — REQUIRED via S1. Codex's default of storing policy only on `approval_template_versions` is REJECTED. See S1.
+
+5. Does PR2 avoid mutating runtime graph topology or adding `runtimeInsertedNodes`?
+   YES.
+
+6. Does PR2 keep `ApprovalGraphExecutor` graph-local and avoid moving requester/history/adjacent business policy into the graph walker?
+   YES.
+
+7. Does PR2 keep default behavior disabled unless a policy explicitly enables a merge rule?
+   YES — REQUIRED. See R7 below.
+
+8. Does PR2 define and test node override > template policy > default disabled precedence?
+   YES.
+
+9. Does PR2 write audit records for every auto approval?
+   YES — REQUIRED with distinct reason codes to coexist with `empty-assignee`. See S3.
+
+10. Does PR2 include a max auto-step guard?
+    YES — REQUIRED with concrete semantics. See S4.
+
+11. Does PR2 handle parallel branches without violating `approval_assignments.active_unique`?
+    YES — REQUIRED via the explicit S2 decision (refuse-and-warn for cross-branch adjacency).
+
+12. Does PR2 document and verify migration rollback behavior if migrations change?
+    YES — applies only if Codex adds editable storage to `approval_template_versions`; the snapshot path itself needs no schema change.
+
+## Stance Amendments (Required Before Code)
+
+These three decisions amend Codex's proposed stance and must be recorded in the PR2 development doc before implementation.
+
+### S1. Policy Storage — Snapshot Into `runtime_graph`, Not Onto `approval_template_versions` Alone
+
+REJECT the default "Preferred storage is `approval_template_versions.auto_approval_policy JSONB`."
+
+ACCEPT the alternative: extend `RuntimePolicy` with an optional `autoApproval` field. The policy is then snapshotted into `approval_published_definitions.runtime_graph` automatically at publish time via the existing `buildRuntimeGraph(approvalGraph, policy)` path (F1, F2). `dispatchAction` already reads `runtime_graph` via `instance.published_definition_id`, so version-freeze is inherited from PR1.
+
+Implementation:
+
+- Add `AutoApprovalPolicy` to `types/approval-product.ts`:
+  ```ts
+  export interface AutoApprovalPolicy {
+    mergeWithRequester?: boolean
+    mergeAdjacentApprover?: boolean
+    dedupeHistoricalApprover?: boolean
+    actorMode?: 'system' | 'original_approver'
+  }
+  ```
+- Extend `RuntimePolicy`:
+  ```ts
+  export interface RuntimePolicy {
+    allowRevoke: boolean
+    revokeBeforeNodeKeys?: string[]
+    autoApproval?: AutoApprovalPolicy
+  }
+  ```
+- Node-level override lives in `ApprovalNode.config.autoApprovalPolicy` (already part of the graph JSON, also snapshotted into `runtime_graph` via `buildRuntimeGraph`).
+- The publish-time API that accepts the policy (`PublishApprovalTemplateRequest`) is extended to accept `autoApproval` as an optional field; `assertRuntimePolicy` validates it.
+
+Editable source (optional, not required for PR2):
+
+- A separate `approval_template_versions.auto_approval_policy JSONB` column for draft-time edits is OPTIONAL. If added, it is a pure authoring concern and must NOT be read during instance advance.
+- If Codex chooses not to add the editable column in PR2, policy is only authored at publish time via the existing publish request, which is acceptable for PR2's "backend only, no UI" scope.
+
+This decision means PR2 may ship with ZERO schema changes if Codex chooses the publish-request-only path. The snapshot is in JSONB inside an existing column.
+
+### S2. Adjacent Merge Across Parallel Branches — Refuse And Warn
+
+REJECT auto-merging the same user across parallel branches in PR2.
+
+When `mergeAdjacentApprover = true` and the prospective auto-merge target is the same active user in a sibling parallel branch, PR2 MUST:
+
+- Refuse the merge for that branch.
+- Continue evaluation for other branches normally.
+- Emit a structured warning into the auto-approval audit record metadata: `{ skipped: true, skipReason: 'cross_branch_adjacency_conflict', conflictBranches: [...] }`.
+
+Reason: F4 shows that the same user cannot be `is_active = TRUE` in two assignments for the same instance. Atomic cross-branch auto-approval is solvable but introduces graph-shape-dependent edge cases. PR2 ships refuse-and-warn; atomic cross-branch handling is a separate ADR if a customer needs it.
+
+### S3. Auto-Approval Reason Taxonomy — Four Distinct Codes
+
+Audit records for auto-approval MUST be distinguishable. Required reason codes:
+
+- `empty-assignee` (existing, unchanged from `emptyAssigneePolicy === 'auto-approve'`)
+- `auto-merge-requester` (new, PR2)
+- `auto-merge-adjacent` (new, PR2)
+- `auto-dedupe-historical` (new, PR2)
+
+Required metadata fields on each PR2 auto-approval `approval_records.metadata`:
+
+```
+{
+  reason: 'auto-merge-requester' | 'auto-merge-adjacent' | 'auto-dedupe-historical',
+  policySource: 'node' | 'template',
+  originalApprover: { type: 'user' | 'role', id: string },
+  matchedAgainst?: { nodeKey: string, recordId?: string },  // for adjacent and historical
+  actorMode: 'system' | 'original_approver'
+}
+```
+
+`actor_id` defaults to `system:auto-approval` when `actorMode === 'system'`.
+
+### S4. Max Auto-Step Guard — Per-Dispatch Hard Fail
+
+Semantics:
+
+- Guard scope: per `dispatchAction` invocation (not per instance lifetime).
+- Limit: hard cap at a constant, suggested `APPROVAL_MAX_AUTO_STEPS = 50`. This is well above any realistic graph depth but low enough to detect runaway chains.
+- On breach: the `dispatchAction` MUST throw `ServiceError(message, 500, 'APPROVAL_AUTO_STEP_LIMIT_EXCEEDED', { instanceId, autoSteps, lastNodeKey, reasonChain })`.
+- The transaction MUST roll back; no partial advance is persisted.
+
+This is fail-closed: a misconfigured policy that would chain forever is detected and the instance is left at a recoverable state.
+
+## Semantic Risks
+
+R1. Policy storage drift (CRITICAL, addressed by S1).
+If policy storage is on `approval_template_versions` only and read at advance time, a future edit-the-version code path would silently mutate running instances. S1 routes all advance-time reads through `runtime_graph.policy` exclusively.
+
+R2. Cross-branch adjacency violates active_unique (HIGH, addressed by S2).
+See F4. S2 mandates refuse-and-warn.
+
+R3. Auto-chain semantics (HIGH).
+"Adjacent" merge requires defining whether the prior node must be human-completed or auto-completed. PR2 MUST decide:
+- Default recommendation: an auto-completed node counts as a valid adjacent predecessor for the next node's adjacency check.
+- This makes adjacency transitive across chains, which is what customers typically expect ("if I approved earlier, my auto-merge keeps propagating").
+- Required test: a chain `A -> B -> C` where all three are configured for the same user. With `mergeAdjacent=true` on B and C, A is completed by human U, B auto-merges, C also auto-merges. Combined with S4's guard, runaway chains are bounded.
+
+R4. Reason field consumer drift (MEDIUM).
+Existing consumers of `approval_records.metadata.reason` may rely on `empty-assignee` as the only auto-approval reason. Codex MUST grep for downstream consumers and confirm the new reason codes do not break:
+- Search: `grep -rn "empty-assignee\|reason.*auto" packages/core-backend/src packages/core-backend/tests`
+- Confirm that any switch/match on `reason` either is exhaustive (and PR2 adds the new cases) or defaults safely.
+
+R5. Empty-assignee plus mergeWithRequester collision (MEDIUM).
+If a node has zero candidate assignees AND its config equals the requester, the executor's empty-assignee path fires first. PR2 MUST NOT double-emit. Test required (T22 below).
+
+R6. Backward compatibility with pre-PR2 published definitions (HIGH).
+Existing `approval_published_definitions.runtime_graph` rows have no `policy.autoApproval`. PR2's policy reader MUST default to "all merge flags disabled" when the field is absent. Test required (T23 below).
+
+R7. Default disabled posture.
+A policy that is absent or has all flags false MUST behave identically to today's code. The only intentional behavior change is when explicit flags are set true.
+
+R8. Concurrent auto-approval race (LOW-MEDIUM).
+Two parallel branches may both reach auto-merge in the same advance window. PR2's advance path is already inside a transaction with row locks; the policy evaluator inherits this. Spot-check that no policy evaluator code performs writes outside the transaction.
+
+## Required Tests
+
+Codex listed 16 tests. Claude requires all 16 plus the following additions.
+
+T17. **Policy version-freeze regression** (parallel of PR1's T7/T1):
+Publish template v1 with policy P1 (mergeWithRequester=true) → create instance → publish template v2 with policy P2 (mergeWithRequester=false). When dispatchAction advances the old instance and the requester is the next assignee, the old instance MUST auto-approve (P1 applies), not require human action (P2 does NOT apply). Use mock-pool asserting that `dispatchAction` reads only `instance.published_definition_id`'s `runtime_graph.policy`, and never `approval_templates` or `approval_template_versions` for policy lookup during advance.
+
+T18. **Auto-chain adjacency transitive** (R3):
+Chain `A (human U) -> B (U, mergeAdjacent on) -> C (U, mergeAdjacent on)`. After human U approves A, B and C both auto-merge in the same advance. Final state: A approved by U, B and C auto-merged with `matchedAgainst.nodeKey` pointing to predecessor.
+
+T19. **Refuse-and-warn cross-branch adjacency** (S2):
+Parallel split with two branches both pointing to nodes assigned to user U after a common predecessor node also assigned to U. With `mergeAdjacent=true`, exactly one branch may auto-merge (the first to be evaluated; deterministic ordering required), the other branch records `skipReason: 'cross_branch_adjacency_conflict'` in `approval_records.metadata` and stays pending human action by U.
+
+T20. **Rule precedence determinism** (R3):
+A node where both `mergeWithRequester` and `dedupeHistoricalApprover` would apply. The audit record's `reason` MUST be set deterministically (recommend `mergeWithRequester` wins because it is the most specific). Document the precedence rule in the dev doc.
+
+T21. **Concurrent auto-approval race** (R8):
+Mock-pool test where two parallel branches both reach auto-merge in the same dispatchAction. Final state: both branches auto-approved, no duplicate active assignments, no orphan records. This is a contract test, real-PG version is a follow-up.
+
+T22. **Empty-assignee plus mergeWithRequester precedence** (R5):
+Node has empty assignees and `emptyAssigneePolicy = 'auto-approve'` AND `mergeWithRequester = true`. The executor's empty-assignee path fires (current behavior); only ONE `approval_records` row written; `reason: 'empty-assignee'` (not `auto-merge-requester`).
+
+T23. **Backward compatibility with pre-PR2 published definitions** (R6):
+Take a `runtime_graph` JSON that does NOT contain `policy.autoApproval` (representing a pre-PR2 publish), advance through nodes where the requester or historical approver appears. NO auto-merge happens. Audit records remain unchanged compared to pre-PR2 behavior.
+
+T24. **Max auto-step guard fires** (S4):
+Construct a graph that would chain auto-merge indefinitely (or use a synthetic upper bound). Verify that `dispatchAction` throws `APPROVAL_AUTO_STEP_LIMIT_EXCEEDED` with the diagnostic payload, the transaction rolls back, and the instance state is unchanged from before the dispatch.
+
+T25. **Policy snapshot vs publish-time policy edit** (S1 corollary):
+At publish, the policy supplied in `PublishApprovalTemplateRequest` is baked into `runtime_graph`. If a separate (optional) `approval_template_versions.auto_approval_policy` column exists and is later edited, the existing `approval_published_definitions.runtime_graph` MUST remain unchanged. Existing instances continue to use the snapshot.
+
+## Do-Not-Cross Lines
+
+File-level (PR2 must not edit):
+
+- `packages/core-backend/src/services/ApprovalAssigneeResolver.ts` if it exists (Phase 2 work).
+- `packages/core-backend/src/routes/approvals.ts` for any new auto-approval-specific endpoint. The only allowed edit is if `PublishApprovalTemplateRequest` validation is wired through this file and needs to accept the extended `policy`. No new HTTP routes.
+- `packages/core-backend/src/multitable/automation-*` — all automation files.
+- `packages/core-backend/src/services/approval-sla-*` or `approval-breach-*`.
+- `apps/web/src/views/**/*Approval*` — frontend out of scope for PR2.
+- `packages/core-backend/src/db/migrations/zzzz20260411120100_*` — read-only.
+- Any new migration file may add `auto_approval_policy` to `approval_template_versions` ONLY if Codex chooses to add editable storage. If Codex skips editable storage (publish-request-only path is acceptable), NO migration is needed for PR2.
+
+Function-level ownership inside `ApprovalProductService.ts` (PR2 owns):
+
+- `createApproval` (limited: read `runtime_graph.policy.autoApproval`, apply rules during initial assignment).
+- `dispatchAction` (limited: read `runtime_graph.policy.autoApproval`, apply rules after each candidate advance).
+- `insertAutoApprovalEvents` (extend to accept new reason codes; do not break empty-assignee path).
+- `publishTemplate` (limited: accept extended policy in request, pass to `buildRuntimeGraph`).
+- `loadTemplateBundle` / `loadTemplateBundleWithClient` — read-only; clarification comments only.
+- New: any `ApprovalAutoApprovalPolicyService` or equivalent helper that does the strategy evaluation.
+
+Out of scope even within `ApprovalProductService.ts`:
+
+- `assertTemplateVersionDeletable` — PR1 work, do not modify in PR2 unless absorbing follow-up A (constant extraction) or B (OR comment), which are explicitly permitted.
+- Admin jump or add-sign hooks (PR3/PR4 work).
+
+Inside `ApprovalGraphExecutor.ts`:
+
+- `emptyAssigneePolicy === 'auto-approve'` branch at lines 752 and 1016 may receive a `reason` metadata field update only to ensure round-tripping is correct. NO new business policy logic in the executor.
+
+## Review Focus
+
+When Codex requests review on the PR2 diff, Claude will scrutinize in this order:
+
+1. **Policy read path**: every read of `autoApproval` during advance comes from `instance.published_definition_id`'s `runtime_graph`. Grep the diff for any read of `approval_template_versions.auto_approval_policy` that is not strictly inside an authoring/edit code path.
+
+2. **Audit reason taxonomy**: PR2 introduces three new reason codes; all `approval_records` written by the new policy code carry the full S3 metadata fields. No reason code is silently reused for a different semantic.
+
+3. **Cross-branch adjacency refuse-and-warn**: exact code path that detects the same user already active in a sibling branch and refuses with the structured warning. Test T19 demonstrates this.
+
+4. **Auto-chain semantics**: T18 confirms transitive adjacency. Codex's dev doc documents the precedence rule for R3 explicitly.
+
+5. **Max auto-step guard**: T24 fires with full diagnostic. Transaction rollback verified. The constant `APPROVAL_MAX_AUTO_STEPS` is exposed (not magic) for future tuning.
+
+6. **Backward compatibility**: T23 demonstrates pre-PR2 published definitions advance unchanged.
+
+7. **Empty-assignee coexistence**: T22 demonstrates the executor's empty-assignee path is unchanged, not double-counted, and `reason: 'empty-assignee'` remains distinct.
+
+8. **Migration rollback** (only if Codex adds editable storage on `approval_template_versions`): `up -> down -> up` on a scratch DB. If no migration in PR2, this gate is N/A.
+
+9. **Scope creep**: no edits to automation, SLA, breach notifier, routes/approvals.ts (beyond the limited extended request validation), or UI files.
+
+10. **Follow-ups A and B absorbed**: `APPROVAL_TERMINAL_STATUSES` constant extracted; OR clause comment added; both verified by code-level grep on the final diff.
+
+11. **PR1 invariants preserved**: T17 confirms; no read of `approval_templates.active_version_id` during advance is introduced.
+
+## Go / No-Go For Codex Implementation
+
+CONDITIONAL GO.
+
+Three prerequisites must be acknowledged in the PR2 development doc before Codex begins writing code:
+
+P1. **Storage stance recorded**: PR2 stores `autoApproval` as part of `RuntimePolicy` snapshotted into `runtime_graph` (S1 accepted). Editable storage on `approval_template_versions` is optional. If editable storage is added, the dev doc records why it was needed and confirms it is never read during instance advance.
+
+P2. **Cross-branch decision recorded**: PR2 implements refuse-and-warn for cross-branch adjacency (S2 accepted). Atomic cross-branch merge is explicitly out of scope and tracked as a separate ADR.
+
+P3. **Audit taxonomy recorded**: Four reason codes (`empty-assignee`, `auto-merge-requester`, `auto-merge-adjacent`, `auto-dedupe-historical`) are documented with their metadata schemas (S3 accepted). Codex grep-confirms no existing consumer breaks (R4).
+
+Once P1, P2, P3 are recorded in `docs/development/approval-pr2-auto-approval-three-merge-development-20260515.md`, Codex may begin implementation.
+
+If any prerequisite needs alternative handling (for example a customer constraint forces atomic cross-branch merge), Codex MUST pause and escalate to the user before code.
+
+---
+
+End of scope gate response.

--- a/docs/research/yida-workflow-automation-benchmark-improvement-plan-20260515.md
+++ b/docs/research/yida-workflow-automation-benchmark-improvement-plan-20260515.md
@@ -1,8 +1,8 @@
 # 宜搭流程与集成自动化对标改善方案
 
-生成日期：2026-05-15  
-适用仓库：`metasheet2`  
-文档性质：对标改善方案，供后续 TODO、开发设计和验证拆分使用  
+生成日期：2026-05-15
+适用仓库：`metasheet2`
+文档性质：对标改善方案，供后续 TODO、开发设计和验证拆分使用
 前置对照文档：`docs/research/yida-workflow-vs-metasheet2-comparison-20260514.md`
 
 ## 1. 结论

--- a/docs/research/yida-workflow-automation-benchmark-improvement-plan-20260515.md
+++ b/docs/research/yida-workflow-automation-benchmark-improvement-plan-20260515.md
@@ -1,0 +1,1255 @@
+# 宜搭流程与集成自动化对标改善方案
+
+生成日期：2026-05-15  
+适用仓库：`metasheet2`  
+文档性质：对标改善方案，供后续 TODO、开发设计和验证拆分使用  
+前置对照文档：`docs/research/yida-workflow-vs-metasheet2-comparison-20260514.md`
+
+## 1. 结论
+
+MetaSheet2 当前已经具备流程与自动化开发的底座，但宜搭的成熟点不是单个 BPMN 引擎，而是“表单数据 - 审批任务 - 自动化编排 - 运行治理 - 通知与权限”的产品闭环。
+
+因此建议不要直接照搬成一个大而全的 BPMN 平台。更稳的路线是：
+
+1. 以多维表记录、公开表单、审批实例为统一业务入口。
+2. 先补审批人解析、字段权限、任务中心、审批动作和 SLA 超时。
+3. 再补自动化运行中心、失败重试、持久调度和编排节点。
+4. 最后把 Workflow Designer/BPMN 作为高级建模入口，映射到稳定的审批与自动化运行时。
+
+### 1.1 与 2026-05-14 对照文档的结合结论
+
+`docs/research/yida-workflow-vs-metasheet2-comparison-20260514.md` 与本文不是冲突关系，二者关注点不同：
+
+- 2026-05-14 文档更偏“审批/BPMN 内核打磨”，给出了高 ROI 的 Wave A/B：版本冻结、自动审批三合并、管理员跳转、加签、超时 5 动作、字段权限、dry-run。
+- 本文更偏“宜搭产品闭环”，把多维表、公开表单、审批实例、自动化运行治理串起来。
+
+结合后的总路线应改为“两层推进”：
+
+1. **内核正确性前置**：先做版本冻结、自动审批三合并、管理员跳转、加签。这些能力不增加新产品面，但能避免正在运行的审批实例被定义变更、人员变更和异常节点卡死影响。
+2. **业务闭环随后展开**：在内核语义稳定后，再做公开表单/多维表记录触发审批、审批结果回写、`start_approval` 自动化动作。
+3. **运行治理贯穿后续阶段**：自动化重跑、SLA 超时动作、工作日历、持久调度作为第二批稳定性能力进入。
+4. **BPMN 高级能力后置**：子流程、抄送节点、手写签名、流程分析、模板市场不进入第一轮核心闭环，除非客户明确要求。
+
+因此，本文后续优先级已按该结合结论调整：`版本冻结`、`自动审批三合并`、`管理员跳转`、`加签` 从“增强项”上调为第一阶段内核项。
+
+## 2. 对标来源
+
+本方案依据以下宜搭文档能力归纳：
+
+| 宜搭能力 | 参考链接 | 本方案使用点 |
+|---|---|---|
+| 流程简介 | https://docs.aliwork.com/docs/yida_support/_2/crwfii | 流程表单、流程生命周期、产品边界 |
+| 流程属性设置 | https://docs.aliwork.com/docs/yida_support/_2/qgaxvq | 版本、权限、通知、自动审批、超时 |
+| 审批人节点 | https://docs.aliwork.com/docs/yida_support/_2/trbqg6/rq8i94 | 审批人来源、空审批人、多人审批 |
+| 条件分支 | https://docs.aliwork.com/docs/yida_support/_2/trbqg6/_1/yv8dnv | 字段条件、分支执行语义 |
+| 流程权限设置 | https://docs.aliwork.com/docs/yida_support/_2/ef8e88/daeh3v | 发起权限、节点字段权限 |
+| 消息通知 | https://docs.aliwork.com/docs/yida_support/_2/ef8e88/aglbg3 | 节点通知、模板、钉钉/邮件 |
+| 流程任务中心 | https://docs.aliwork.com/docs/yida_support/_2/ea1o8cgypga0lh9t/hg13tb | 待办、已办、抄送、我发起 |
+| 集成&自动化 | https://docs.aliwork.com/docs/yida_support/_3/gqmveiswrxkgxu9s | 触发器、节点编排、运行日志 |
+| 自动化表单新增触发 | https://docs.aliwork.com/docs/yida_support/_3/yovph5uaoyxb6f02/yl45mtqgbwewybhk/ovoh2nmd58k21t97 | 表单事件触发自动化 |
+| 顺序执行节点 | https://docs.aliwork.com/docs/yida_support/_3/yovph5uaoyxb6f02/gd8wqzg0reppv4fk | 多步骤动作、执行链路 |
+| 自动化运行日志 | https://docs.aliwork.com/docs/yida_support/_3/scg1tid03znsk3px | 执行详情、异常定位、运行治理 |
+
+## 3. 当前代码基线
+
+### 3.1 自动化底座
+
+当前自动化已经有可继续演进的基础：
+
+- 触发器和动作白名单在 `packages/core-backend/src/multitable/automation-service.ts`。
+- 执行流水线在 `packages/core-backend/src/multitable/automation-executor.ts`。
+- 简化 cron 和 interval 调度在 `packages/core-backend/src/multitable/automation-scheduler.ts`。
+- 执行日志在 `packages/core-backend/src/multitable/automation-log-service.ts`。
+- 前端规则编辑器在 `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`。
+- 测试、日志和统计路由在 `packages/core-backend/src/routes/automation.ts`。
+
+已具备：
+
+- 记录创建、更新、删除，字段变更，定时，webhook received 触发类型。
+- 更新记录、创建记录、发送 webhook、站内通知、邮件、钉钉群、钉钉个人、锁定记录等动作。
+- 嵌套条件组。
+- 执行日志、统计、手动测试。
+- 调度 leader lock 和递归深度保护。
+
+主要缺口：
+
+- `webhook.received` 更像规则类型，缺少完整的 inbound endpoint、签名校验和触发审计。
+- 自动化动作当前偏线性，前端限制 1-3 步，缺分支、循环、错误处理节点。
+- 执行日志已有，但缺执行重跑、失败步骤重试、异常提醒、异常规则自动暂停。
+- 简化 cron 不足以支撑 timezone、misfire、工作日规则。
+- 没有持久任务队列，调度仍是内存 timer + leader lock。
+
+### 3.2 审批产品底座
+
+当前审批产品已有较多可复用能力：
+
+- 表单字段显隐和校验在 `packages/core-backend/src/services/ApprovalGraphExecutor.ts`。
+- 审批图推进、会签/或签、并行分支在 `ApprovalGraphExecutor`。
+- 审批模板、实例和动作在 `packages/core-backend/src/services/ApprovalProductService.ts` 与 `packages/core-backend/src/routes/approvals.ts`。
+- SLA 扫描在 `packages/core-backend/src/services/ApprovalSlaScheduler.ts`。
+- 前端审批中心路由在 `apps/web/src/router/appRoutes.ts`。
+
+已具备：
+
+- approval graph、form schema、field visibility rule。
+- `single`、`all`、`any` 审批模式。
+- 并行分支状态持久到实例 metadata。
+- 空审批人自动通过或报错的基础语义。
+- approve、reject、transfer、revoke、comment、return 动作入口。
+- remind 催办和 SLA breach notifier。
+- pending-count、read marker、审批历史、指标。
+
+主要缺口：
+
+- 审批人来源仍偏静态 user/role，缺字段取人、主管链、发起人自选、动态角色、组织成员组等解析。
+- 缺节点级字段权限三态：可编辑、只读、隐藏。
+- 缺代理/委托中心、加签、退回到指定节点、撤回后重新提交等完整人处理动作。
+- SLA 只有 hours 维度，缺节点级超时动作、重复提醒、工作日/不计时时段。
+- 审批实例与多维表记录/公开表单的触发和回写闭环不完整。
+
+### 3.3 Workflow Designer/BPMN 底座
+
+当前 Workflow Designer 适合作为高级建模入口，但不应作为第一阶段唯一运行时：
+
+- 工作流路由挂载在 `packages/core-backend/src/index.ts`。
+- 设计器 API 在 `packages/core-backend/src/routes/workflow-designer.ts`。
+- BPMN 引擎在 `packages/core-backend/src/workflow/BPMNWorkflowEngine.ts`。
+- 前端设计器在 `apps/web/src/views/WorkflowDesigner.vue`。
+- Workflow Hub 在 `apps/web/src/views/WorkflowHubView.vue`。
+
+已具备：
+
+- 模板、草稿、部署、验证、测试入口。
+- node catalog、team view、saved view、archive/restore。
+- BPMN 部署、启动实例、任务、message/signal 等基础路由。
+
+主要缺口：
+
+- 通用 BPMN runtime 与审批产品 runtime 没有清晰统一边界。
+- BPMN 节点没有完整映射到审批人解析、字段权限、任务中心、自动化运行日志。
+- 仍有 workflow mock endpoint，说明通用运行时还不应直接承载核心生产闭环。
+
+## 4. 功能对标改善矩阵
+
+| 对标能力 | 当前状态 | 改善做法 | 优先级 |
+|---|---|---|---|
+| 版本冻结 | 部分有 version 字段 | 发布版本快照、历史实例绑定版本、未完结实例禁止删除版本 | P0 |
+| 自动审批三合并 | 空审批人有基础，无发起人/相邻/历史审批人去重 | 新增 requester merge、adjacent merge、history dedupe，节点级优先于全局 | P0 |
+| 管理员跳转节点 | 缺 | 管理员可将 stuck 实例跳转到合法目标节点，关闭旧 assignment 并审计 | P0 |
+| 加签 | 缺 | 支持前加签、后加签、并行加签，写 runtime inserted nodes 和审计记录 | P0 |
+| 流程表单强绑定 | 多维表、公开表单、审批模板分散 | 建立“记录/表单提交触发审批”的统一绑定模型 | P0 |
+| 审批人来源 | user/role 静态为主 | 新增 `ApprovalAssigneeResolver`，支持字段、角色、发起人、主管链 | P0 |
+| 节点字段权限 | 有字段显隐，无节点权限三态 | 在模板版本中保存 node field permissions，运行时按节点裁剪 | P1 |
+| 任务中心 | 有审批中心和 pending-count | 聚合待办、已办、抄送、我发起、超时、来源筛选 | P1 |
+| 转交/退回/撤回/评论 | actions 入口有部分动作 | 明确状态机和审计记录，补 UI 与并发校验 | P1 |
+| 节点提交关联操作 | 缺审批动作到自动化 trigger 桥 | 发出 `approval.<action>.completed` 事件，由 multitable automation 处理回写/关联 | P1 |
+| 代理/委托 | 缺 | 新增 delegation 表与任务查询代理扩展 | P2 |
+| 超时动作 | 只有 SLA breach/remind | 节点级 timeout rules：提醒、转交、跳转、自动同意、自动拒绝 | P2 |
+| 工作日/不计时时段 | 缺 | 引入 business calendar，复用考勤节假日能力或独立日历表 | P2 |
+| 自动化运行日志 | 有日志和统计 | 新增执行详情、整条重跑、失败步骤重试、异常提醒 | P0 |
+| 自动化编排节点 | 当前偏 1-3 线性动作 | 增加 sequence、branch、loop、error handler 模型 | P3 |
+| 自动化持久调度 | 内存 timer + leader lock | 增加 persistent job queue、full cron、timezone、misfire 策略 | P2 |
+| BPMN 高级入口 | 已有设计器和引擎 | 先映射到审批/自动化运行时，再逐步硬化 BPMN engine | P3 |
+| 编辑器 dry-run | 有 test 入口但不完整 | 提供不写库的模拟执行 trace 和节点高亮 | P2 |
+| 子流程 callActivity | BPMN 名称露出但执行不完整 | 子实例、父实例等待、变量映射、错误传播 | P3 |
+| 抄送独立节点 | cc 仅为视图 tab | 非阻塞 cc 节点，发送通知后立即通过 | P3 |
+| 手写签名 | 缺 | 节点级签名开关、签名图片引用、移动端/PC 上传 | P3 |
+
+## 5. 详细改善方案
+
+### 5.1 统一“业务数据触发审批”入口
+
+#### 目标
+
+让多维表记录和公开表单提交能够直接触发审批流程，并在审批完成后回写记录。对标宜搭“流程表单”的核心价值。
+
+#### 建议模型
+
+新增或扩展绑定表：
+
+```sql
+CREATE TABLE approval_trigger_bindings (
+  id UUID PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
+  template_id UUID NOT NULL,
+  template_version_id UUID,
+  source_type TEXT NOT NULL,
+  sheet_id TEXT,
+  view_id TEXT,
+  trigger_event TEXT NOT NULL,
+  trigger_condition JSONB NOT NULL DEFAULT '{}'::jsonb,
+  form_field_mapping JSONB NOT NULL DEFAULT '{}'::jsonb,
+  result_mapping JSONB NOT NULL DEFAULT '{}'::jsonb,
+  enabled BOOLEAN NOT NULL DEFAULT TRUE,
+  created_by TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+```
+
+`source_type` 建议先支持：
+
+- `multitable_record`
+- `public_form_submission`
+- `manual`
+- 后续再扩展 `automation_action`
+
+`trigger_event` 建议先支持：
+
+- `record.created`
+- `record.updated`
+- `form.submitted`
+
+#### 后端改造
+
+1. 在 `univer-meta.ts` 的记录创建、公开表单提交成功路径发出领域事件。
+2. 新增 `ApprovalTriggerBindingService`：
+   - 查询启用绑定。
+   - 用 `trigger_condition` 匹配记录字段。
+   - 将记录字段映射为审批 `formData`。
+   - 调用 `ApprovalProductService` 创建审批实例。
+   - 将 `sourceSnapshot` 写入 `approval_instances.metadata`。
+3. 审批结束时发布 `approval.completed`、`approval.rejected` 事件。
+4. 新增结果回写服务：
+   - 根据 `result_mapping` 更新多维表记录状态、审批编号、审批人、完成时间、拒绝原因。
+
+#### 前端改造
+
+1. 在多维表视图或表单分享配置中增加“提交后发起审批”设置。
+2. 在审批模板详情增加“触发来源”页签。
+3. 在记录详情 drawer 中展示关联审批实例列表和当前状态。
+
+#### 验收标准
+
+- 管理员能把一个审批模板绑定到公开表单提交。
+- 匿名或钉钉受保护表单提交后，系统创建审批实例。
+- 审批通过后，多维表记录状态自动更新为 approved。
+- 审批拒绝后，多维表记录状态自动更新为 rejected，并写入拒绝原因。
+- 触发失败不影响原始表单提交，但必须写入错误日志和管理员可见告警。
+
+#### 测试建议
+
+- `packages/core-backend/tests/unit/approval-trigger-binding.test.ts`
+- `packages/core-backend/tests/integration/public-form-approval-trigger.test.ts`
+- `apps/web/tests/multitable-approval-trigger-settings.spec.ts`
+
+### 5.2 审批人解析器
+
+#### 目标
+
+把宜搭“审批人节点”的人来源能力产品化，避免所有审批节点都只能配置静态 user/role。
+
+#### 建议接口
+
+```ts
+export type AssigneeSource =
+  | { type: 'static_user'; userIds: string[] }
+  | { type: 'role'; roleIds: string[] }
+  | { type: 'requester' }
+  | { type: 'form_field_user'; fieldId: string }
+  | { type: 'form_field_member_group'; fieldId: string }
+  | { type: 'supervisor_chain'; from: 'requester' | 'field_user'; fieldId?: string; levels: number }
+  | { type: 'department_role'; departmentFieldId: string; roleId: string };
+
+export interface AssigneeResolutionResult {
+  assignments: Array<{
+    assignmentType: 'user' | 'role';
+    assigneeId: string;
+    source: AssigneeSource['type'];
+  }>;
+  warnings: string[];
+  snapshot: Record<string, unknown>;
+}
+```
+
+#### 策略配置
+
+审批节点配置建议扩展：
+
+```ts
+type ApprovalNodeConfig = {
+  assigneeSources: AssigneeSource[];
+  approvalMode: 'single' | 'all' | 'any';
+  emptyAssigneePolicy: 'error' | 'auto-approve' | 'skip-node' | 'escalate';
+  dedupePolicy?: {
+    requesterAutoApprove?: boolean;
+    adjacentSameApproverAutoApprove?: boolean;
+    historicalApproverAutoApprove?: boolean;
+  };
+  fallbackAssigneeSource?: AssigneeSource;
+};
+```
+
+#### 运行时规则
+
+1. 审批实例创建时解析审批人，并写入快照。
+2. 实例推进到某个节点时，默认使用快照，不因组织变更自动改变历史实例。
+3. 如果节点配置允许“实时解析”，必须在审计记录中写明重新解析原因。
+4. 空审批人按节点策略执行：
+   - `error`：阻断发起或阻断推进。
+   - `auto-approve`：生成 auto approval record。
+   - `skip-node`：直接跳到下一个节点，但记录跳过原因。
+   - `escalate`：转给兜底审批人。
+
+#### 代码落点
+
+- 新增 `packages/core-backend/src/services/ApprovalAssigneeResolver.ts`。
+- 扩展 `ApprovalProductService` 的 graph normalize 和 instance creation。
+- 扩展 `ApprovalGraphExecutor` 的 assignment 输出，保留兼容旧的 `assigneeType`/`assigneeIds`。
+- 前端模板详情、模板编辑器展示新配置。
+
+#### 验收标准
+
+- 能从表单字段读取用户作为审批人。
+- 能解析角色审批人。
+- 能配置发起人自动通过。
+- 能配置相邻审批人相同自动通过。
+- 能配置历史已审批人后续节点自动通过。
+- 空审批人能按策略报错、自动通过或转兜底人。
+
+### 5.3 节点字段权限三态
+
+#### 目标
+
+对标宜搭“节点字段权限”：发起、审批、执行、抄送、查看状态下，每个字段可以可编辑、只读、隐藏。
+
+#### 建议模型
+
+在模板版本或 approval graph 节点配置中保存：
+
+```ts
+type FieldPermission = 'editable' | 'readonly' | 'hidden';
+
+type NodeFieldPermissions = {
+  nodeKey: string;
+  defaultPermission: FieldPermission;
+  fields: Record<string, FieldPermission>;
+};
+```
+
+#### 后端规则
+
+1. 读取审批详情时，根据当前用户、当前节点、任务身份应用字段权限。
+2. 提交审批动作时，只接受当前节点允许编辑的字段。
+3. 隐藏字段不能出现在 API response 的 formData 中，或必须脱敏为空值。
+4. 只读字段可返回但不可修改。
+5. 字段显隐规则和字段权限同时存在时，优先级建议：
+   - 字段显隐规则先判断字段是否在当前表单逻辑中可见。
+   - 节点权限再决定 editable/readonly/hidden。
+   - 任一层 hidden 即 hidden。
+
+#### 前端规则
+
+1. `ApprovalDetailView` 根据权限渲染字段。
+2. `TemplateDetailView` 展示每个节点字段权限。
+3. 发起审批页按 start 节点权限渲染。
+
+#### 验收标准
+
+- 同一审批实例，不同节点看到的字段权限不同。
+- 抄送人只能只读或隐藏。
+- 后端拒绝修改只读/隐藏字段。
+- API 响应不泄露 hidden 字段值。
+
+### 5.4 审批任务中心增强
+
+#### 目标
+
+把当前审批中心升级为宜搭式任务中心：待办、已办、抄送、我发起、超时、来源筛选、搜索、批量操作。
+
+#### 建议 API
+
+```http
+GET /api/approvals/tasks?tab=pending|done|cc|requested|overdue|all
+GET /api/approvals/tasks/:taskId
+POST /api/approvals/tasks/bulk-action
+```
+
+查询参数：
+
+- `sourceSystem`
+- `workflowKey`
+- `templateId`
+- `requester`
+- `assignee`
+- `status`
+- `keyword`
+- `overdueOnly`
+- `cursor`/`limit`
+
+#### 数据规则
+
+1. pending：当前用户直接 assignment 或角色 assignment。
+2. done：用户已处理过的实例。
+3. cc：用户收到抄送但不阻塞流程。
+4. requested：用户发起的流程。
+5. overdue：当前用户待办且超时，或管理员查看全部超时。
+6. all：管理员或具有权限用户可见。
+
+#### 前端规则
+
+1. `ApprovalCenterView` 改成任务中心布局。
+2. 列表行展示：标题、来源、当前节点、发起人、到达时间、剩余时间、状态、操作。
+3. 支持从多维表记录进入审批详情，也支持从审批详情回到记录。
+4. 支持批量已读、批量催办、批量审批仅在策略允许时开放。
+
+#### 验收标准
+
+- 待办数量与列表一致。
+- 抄送不进入待办计数。
+- 角色审批人可以看到任务。
+- 已办列表基于 approval_records。
+- 多来源审批可以按来源系统过滤。
+
+### 5.5 人处理动作补齐
+
+#### 目标
+
+补齐宜搭类审批中的常用动作：加签、转交、代理、退回、撤回、重新提交、评论、催办。
+
+#### 动作语义
+
+| 动作 | 说明 | 状态影响 |
+|---|---|---|
+| approve | 同意当前任务 | 可能推进节点 |
+| reject | 拒绝流程 | 实例终态 rejected |
+| comment | 仅评论 | 不改变状态 |
+| remind | 催办 | 不改变状态，写记录和通知 |
+| transfer | 转交当前任务 | 当前 assignment 失效，新 assignment 生效 |
+| return | 退回指定节点或发起人 | currentNodeKey 改变，后续 assignment 重建 |
+| revoke | 发起人撤回 | 实例终态 revoked 或回到 draft |
+| resubmit | 撤回/退回后重新提交 | 创建新版本或复用实例继续 |
+| add_sign_before | 前加签 | 当前任务前插入临时审批节点 |
+| add_sign_after | 后加签 | 当前任务后插入临时审批节点 |
+
+#### 关键设计
+
+1. 所有动作必须写 `approval_records`。
+2. 所有状态变更必须校验 `version`，避免并发重复审批。
+3. 临时加签节点写入 `approval_instances.metadata.runtimeInsertedNodes`。
+4. 退回到指定节点必须校验目标节点存在且可达。
+5. 代理审批要在记录中标记 `actedBy` 和 `onBehalfOf`。
+
+#### 代理/委托表
+
+```sql
+CREATE TABLE approval_delegations (
+  id UUID PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
+  principal_user_id TEXT NOT NULL,
+  delegate_user_id TEXT NOT NULL,
+  scope JSONB NOT NULL DEFAULT '{}'::jsonb,
+  starts_at TIMESTAMPTZ NOT NULL,
+  ends_at TIMESTAMPTZ NOT NULL,
+  enabled BOOLEAN NOT NULL DEFAULT TRUE,
+  created_by TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+```
+
+`scope` 支持：
+
+- 全部审批
+- 指定模板
+- 指定来源系统
+- 指定时间范围
+
+#### 验收标准
+
+- 转交后原审批人不再能处理。
+- 代理人能在任务中心看到被代理任务。
+- 代理处理后审计记录展示代理关系。
+- 退回到指定节点会重建目标节点 assignment。
+- 加签节点能被处理并继续回到原流程。
+
+### 5.6 SLA 与超时动作
+
+#### 目标
+
+把当前 SLA breach 扩展为宜搭式节点超时规则。
+
+#### 建议模型
+
+```ts
+type TimeoutRule = {
+  enabled: boolean;
+  duration: {
+    unit: 'minute' | 'hour' | 'natural_day' | 'business_day';
+    value: number;
+    calendarId?: string;
+  };
+  reminders?: {
+    maxCount: number;
+    intervalMinutes: number;
+  };
+  action:
+    | { type: 'remind' }
+    | { type: 'transfer'; assigneeSource: AssigneeSource }
+    | { type: 'jump'; targetNodeKey: string }
+    | { type: 'auto_approve' }
+    | { type: 'auto_reject'; reasonTemplate?: string };
+};
+```
+
+#### 数据模型
+
+```sql
+CREATE TABLE approval_deadlines (
+  id UUID PRIMARY KEY,
+  instance_id TEXT NOT NULL,
+  assignment_id UUID,
+  node_key TEXT NOT NULL,
+  due_at TIMESTAMPTZ NOT NULL,
+  rule_snapshot JSONB NOT NULL,
+  reminder_count INT NOT NULL DEFAULT 0,
+  last_reminded_at TIMESTAMPTZ,
+  status TEXT NOT NULL DEFAULT 'pending',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+```
+
+#### 执行规则
+
+1. 创建 assignment 时生成 deadline。
+2. `ApprovalSlaScheduler` 改为扫描 `approval_deadlines`。
+3. 到期后按规则执行动作。
+4. 自动同意/拒绝必须写 approval record，actor 标记为 `system:timeout`.
+5. 超时转交和跳转必须保留原节点上下文，方便审计。
+
+#### 工作日与不计时时段
+
+第一阶段可以先实现：
+
+- natural day
+- hour
+- minute
+
+第二阶段接入 business calendar：
+
+- 复用考勤节假日表或新增 `business_calendars`。
+- 支持工作日计算。
+- 支持不计时时段。
+
+#### 验收标准
+
+- 超时提醒不会无限重复。
+- 自动拒绝/同意会推进实例到正确状态。
+- 超时转交后新审批人能看到任务。
+- 非 leader 节点不会重复执行超时动作。
+
+### 5.7 自动化运行中心
+
+#### 目标
+
+把当前“规则卡片 + 日志弹窗”升级为可运营的自动化运行中心，对标宜搭运行日志和异常提醒。
+
+#### 当前基础
+
+已有：
+
+- `multitable_automation_executions`。
+- `AutomationExecution.steps`。
+- logs、stats、manual test。
+- webhook 内部简单 retry。
+
+缺少：
+
+- 整条执行重跑。
+- 失败步骤重试。
+- 执行入队和持久 attempt。
+- 异常提醒。
+- 批量查看所有规则的失败运行。
+
+#### 建议数据模型
+
+```sql
+CREATE TABLE automation_execution_attempts (
+  id UUID PRIMARY KEY,
+  execution_id TEXT NOT NULL,
+  attempt_no INT NOT NULL,
+  status TEXT NOT NULL,
+  trigger_event JSONB NOT NULL,
+  started_at TIMESTAMPTZ NOT NULL,
+  finished_at TIMESTAMPTZ,
+  error TEXT,
+  created_by TEXT
+);
+```
+
+#### 建议 API
+
+```http
+GET /api/multitable/automation-executions?sheetId=&status=&ruleId=
+GET /api/multitable/automation-executions/:executionId
+POST /api/multitable/automation-executions/:executionId/retry
+POST /api/multitable/automation-executions/:executionId/support-packet
+```
+
+第一阶段先实现整条重跑，不做步骤级重跑。原因：
+
+- 整条重跑可以复用现有 `AutomationService.executeRule`。
+- 步骤级重跑需要动作幂等、上下文回放和前置步骤输出依赖，复杂度更高。
+
+#### 重跑语义
+
+1. 仅允许重跑 failed 或 skipped 的 execution。
+2. 重跑使用原始 `triggerEvent` 快照。
+3. 重跑必须写新 execution，不覆盖旧日志。
+4. 重跑必须记录操作者。
+5. 对会产生外部副作用的动作，要求规则显式声明 idempotency key 或弹出风险确认。
+
+#### 异常提醒
+
+新增规则级异常策略：
+
+```ts
+type AutomationFailurePolicy = {
+  notifyOwner: boolean;
+  notifyChannels: Array<'in_app' | 'email' | 'dingtalk'>;
+  autoDisableAfterConsecutiveFailures?: number;
+};
+```
+
+#### 前端改造
+
+1. 新增 Automation Runs 页面。
+2. 规则卡片展示最近失败、连续失败次数、最后执行时间。
+3. 日志详情展示 steps、输入、输出、错误、脱敏支持包。
+4. 提供 Retry 按钮。
+
+#### 验收标准
+
+- 失败执行可以从 UI 重跑。
+- 重跑产生新的 execution id。
+- 支持包不泄露 webhook token、DingTalk secret、Bearer token。
+- 连续失败达到阈值后规则自动 disabled，并写 audit log。
+
+### 5.8 自动化触发器和动作扩展
+
+#### 新增触发器
+
+建议加入：
+
+- `public_form.submitted`
+- `approval.created`
+- `approval.approved`
+- `approval.rejected`
+- `approval.returned`
+- `approval.timeout`
+- `automation.failed`
+
+#### 新增动作
+
+建议加入：
+
+- `start_approval`
+- `update_approval_context`
+- `comment_record`
+- `create_task`
+- `branch`
+- `loop_over_records`
+- `delay`
+- `wait_until`
+
+第一阶段只做 `start_approval` 和 `approval.*` 事件触发。
+
+#### `start_approval` 动作配置
+
+```ts
+type StartApprovalActionConfig = {
+  templateId: string;
+  formDataMapping: Record<string, string>;
+  sourceRecord?: {
+    sheetIdPath?: string;
+    recordIdPath?: string;
+  };
+  resultMapping?: Record<string, string>;
+};
+```
+
+#### 验收标准
+
+- 自动化规则能在记录创建时发起审批。
+- 审批完成能触发另一条自动化。
+- 触发链路受 `MAX_AUTOMATION_DEPTH` 或新的 chain guard 限制。
+
+### 5.9 自动化编排节点
+
+#### 目标
+
+对标宜搭“顺序执行、分支、循环、数据处理、连接器”，但分阶段做。
+
+#### 第一阶段
+
+保持现有 actions 数组，增加：
+
+- action name
+- continueOnError
+- timeoutMs
+- idempotencyKeyTemplate
+
+```ts
+type AutomationAction = {
+  id: string;
+  name?: string;
+  type: AutomationActionType;
+  config: Record<string, unknown>;
+  continueOnError?: boolean;
+  timeoutMs?: number;
+  idempotencyKeyTemplate?: string;
+};
+```
+
+#### 第二阶段
+
+引入 DAG 编排模型：
+
+```ts
+type AutomationNode =
+  | { id: string; type: 'action'; action: AutomationAction }
+  | { id: string; type: 'branch'; conditions: ConditionGroup[] }
+  | { id: string; type: 'loop'; collectionPath: string; body: AutomationNode[] };
+```
+
+#### 不建议立刻做
+
+- 可视化无限画布。
+- 任意脚本节点。
+- 任意外部连接器市场。
+
+这些能力需要沙箱、配额、安全审计和连接器凭证管理，建议在运行中心和队列稳定后再做。
+
+### 5.10 调度与持久队列
+
+#### 目标
+
+把当前内存 timer 调度升级为可靠执行。
+
+#### 改善项
+
+1. 使用 full cron parser，支持 timezone。
+2. 新增 persistent job 表：
+
+```sql
+CREATE TABLE automation_jobs (
+  id UUID PRIMARY KEY,
+  rule_id TEXT NOT NULL,
+  scheduled_at TIMESTAMPTZ NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending',
+  attempts INT NOT NULL DEFAULT 0,
+  locked_by TEXT,
+  locked_at TIMESTAMPTZ,
+  last_error TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+```
+
+3. scheduler 只负责生成 job。
+4. worker 负责领取 job、执行、重试。
+5. misfire 策略：
+   - `skip`
+   - `run_once`
+   - `catch_up_limited`
+
+#### 验收标准
+
+- 服务重启后不会丢失已计划任务。
+- 多副本下同一 job 只执行一次。
+- cron timezone 生效。
+- 错过窗口按配置处理。
+
+### 5.11 版本冻结与发布生命周期
+
+#### 目标
+
+对标宜搭“设计中/启用中/历史版本”和“历史数据不受新版本影响”。
+
+#### 状态模型
+
+```ts
+type ProcessVersionStatus = 'draft' | 'active' | 'history' | 'archived';
+```
+
+#### 规则
+
+1. 模板发布时生成 immutable version snapshot。
+2. 审批实例绑定 `template_version_id` 和 graph snapshot。
+3. 新发布版本不影响已发起实例。
+4. 有未完结实例的版本不能硬删除。
+5. 历史版本可以复制为新草稿。
+
+#### 代码落点
+
+- `approval_template_versions`
+- `approval_instances.template_version_id`
+- `workflow_definitions.status`
+- `workflow_templates`
+
+#### 验收标准
+
+- 修改模板后，旧实例仍按旧图推进。
+- 活跃实例存在时，版本删除被拒绝。
+- 版本列表可展示发布人、发布时间、备注、实例数。
+
+### 5.12 自动审批三合并
+
+#### 目标
+
+吸收 2026-05-14 对照文档中的高 ROI 建议，优先补齐宜搭式自动审批合并规则，降低重复审批噪音。
+
+#### 策略
+
+```ts
+type AutoApprovalPolicy = {
+  mergeWithRequester?: boolean;
+  mergeAdjacentApprover?: boolean;
+  dedupeHistoricalApprover?: boolean;
+  scope?: 'global' | 'node';
+  actorMode?: 'system' | 'original_approver';
+};
+```
+
+#### 执行语义
+
+1. 节点级策略优先于全局策略。
+2. `mergeWithRequester`：当前审批人等于发起人时自动通过。
+3. `mergeAdjacentApprover`：当前节点审批人与上一个阻塞审批节点处理人相同，则自动通过；抄送节点不参与相邻判断。
+4. `dedupeHistoricalApprover`：当前审批人已经在本实例内完成过审批，则自动通过。
+5. 所有自动通过都必须写 `approval_records`，`actor_id` 建议默认 `system:auto-approval`，metadata 记录命中的策略、原审批人和节点。
+
+#### 代码落点
+
+- `ApprovalGraphExecutor`：输出 auto approval events 已有基础，可扩展 reason。
+- `ApprovalProductService`：创建 assignment 前或节点推进时应用策略。
+- `approval_template_versions`：保存全局策略和节点覆盖策略。
+- 前端模板详情：展示策略来源和命中行为。
+
+#### 验收标准
+
+- 发起人审批自己时自动通过。
+- 相邻审批人相同时自动通过，且抄送不影响相邻判断。
+- 历史已审批人再次出现时自动通过。
+- 三种规则均有审计记录。
+- 关闭策略后不再自动通过。
+
+### 5.13 管理员跳转节点
+
+#### 目标
+
+提供运维兜底能力。对标宜搭在审批人离职、主管解析失败、流程 stuck 时的手工跳转节点能力。
+
+#### API 草案
+
+```http
+POST /api/approvals/:id/jump
+POST /api/workflow/instances/:id/jump
+```
+
+请求体：
+
+```json
+{
+  "targetNodeKey": "approval_finance",
+  "reason": "原审批人离职，管理员跳转到财务审批节点",
+  "version": 12
+}
+```
+
+#### 执行规则
+
+1. 调用者必须具备 `approvals:admin` 或专用 `workflow:admin_jump` 权限。
+2. 目标节点必须存在于当前实例绑定的版本快照中。
+3. 目标节点必须是可进入的运行节点，不能是非法结束态。
+4. 当前 active assignments 全部关闭，metadata 标记 `closedByJump=true`。
+5. 目标节点重新解析 assignments。
+6. 写入 `approval_records`，action 建议为 `jump`，记录 fromNode、toNode、reason、actor。
+7. 发布 `approval.jumped` 事件，用于通知和自动化联动。
+
+#### 与 return 的区别
+
+- `return` 是业务审批动作，通常由审批人发起，语义是退回修改。
+- `jump` 是管理员运维动作，用于恢复异常实例，必须强审计、强权限、不可静默。
+
+#### 验收标准
+
+- 无权限用户调用返回 403。
+- 跳转后旧审批人无法继续处理旧任务。
+- 新节点审批人能在任务中心看到任务。
+- 详情页时间线展示管理员跳转记录。
+- 跳转不改变实例绑定的版本快照。
+
+### 5.14 编辑器 dry-run 与 trace
+
+#### 目标
+
+吸收旧对照文档中的“编辑器模拟测试”建议。设计阶段能用样例变量跑出路径 trace，不写真实审批实例。
+
+#### API 草案
+
+```http
+POST /api/workflow-designer/workflows/:id/simulate
+POST /api/approval-templates/:id/simulate
+```
+
+响应：
+
+```ts
+type SimulationResult = {
+  status: 'completed' | 'pending' | 'stuck' | 'failed';
+  trace: Array<{
+    nodeKey: string;
+    nodeType: string;
+    enteredAt: string;
+    outcome: string;
+    inputs: Record<string, unknown>;
+    outputs: Record<string, unknown>;
+    warnings: string[];
+  }>;
+};
+```
+
+#### 验收标准
+
+- 不写 `approval_instances`。
+- 能展示条件分支命中路径。
+- 能展示审批人解析结果。
+- 缺字段、无审批人、条件无分支命中时返回可读 warning。
+
+## 6. 推荐分阶段计划
+
+### Phase 0：方案固化与现状清理
+
+预计 0.5-1 天。
+
+任务：
+
+- 确认本方案范围。
+- 将当前考勤/公式未提交改动隔离，避免新开发混入。
+- 从现有 comparison 文档拆出正式 TODO。
+
+产出：
+
+- `docs/development/workflow-automation-yida-benchmark-todo-20260515.md`
+- `docs/development/workflow-automation-yida-benchmark-development-20260515.md`
+- `docs/development/workflow-automation-yida-benchmark-verification-20260515.md`
+
+### Phase 1：审批内核正确性
+
+预计 7-10 天。
+
+范围：
+
+- 版本冻结与发布生命周期。
+- 自动审批三合并：发起人合并、相邻审批人合并、历史审批人去重。
+- 管理员跳转节点。
+- 加签：前加签、后加签、并行加签。
+
+验收：
+
+- 修改模板后，旧实例仍按旧版本推进。
+- 自动审批命中时写系统审计记录。
+- stuck 审批实例可以由管理员跳转到合法目标节点。
+- 加签任务能进入任务中心并正确回到原流程。
+- 旧审批人不能在跳转或转交后继续处理失效任务。
+
+### Phase 2：业务闭环 MVP
+
+预计 5-8 天。
+
+范围：
+
+- `ApprovalAssigneeResolver` 第一版：static user、role、requester、form field user。
+- 多维表/公开表单触发审批。
+- 审批结果回写记录。
+- 自动化新增 `start_approval` 动作。
+- 审批完成事件桥：`approval.approved`、`approval.rejected`、`approval.returned`。
+
+验收：
+
+- 公开表单提交后自动生成审批。
+- 审批完成后记录状态回写。
+- 记录创建自动化可以发起审批。
+- 审批完成可以触发自动化。
+- 审批实例 metadata 保留 source snapshot。
+
+### Phase 3：审批产品化增强
+
+预计 5-8 天。
+
+范围：
+
+- 节点字段权限三态。
+- 任务中心增强。
+- 转交、退回、撤回、评论动作状态机补齐。
+- 代理/委托中心第一版。
+- 编辑器 dry-run 与 trace。
+
+验收：
+
+- 不同节点字段权限不同。
+- 待办/已办/抄送/我发起列表一致。
+- 退回、转交、撤回有审计记录。
+- 代理任务能被代理人处理并保留 on-behalf-of 审计。
+- dry-run 不写实例，但能展示路径和审批人解析结果。
+
+### Phase 4：运行治理
+
+预计 6-10 天。
+
+范围：
+
+- 自动化运行中心。
+- 失败 execution 重跑。
+- 异常通知和连续失败自动停用。
+- 审批 SLA timeout actions 第一版：提醒、转交、跳转、自动同意、自动拒绝。
+- 工作日历第一版：natural day、hour、minute，预留 business day。
+
+验收：
+
+- 自动化失败可以重跑。
+- 支持包脱敏。
+- SLA 到期能提醒、转交或自动处理。
+- 运行中心能按失败状态过滤。
+- 超时动作不会重复执行。
+
+### Phase 5：可靠调度和工作日
+
+预计 5-10 天。
+
+范围：
+
+- persistent automation jobs。
+- full cron + timezone。
+- misfire 策略。
+- business calendar。
+- 不计时时段。
+
+验收：
+
+- 重启不丢定时任务。
+- 多副本不重复执行。
+- 工作日/自然日/小时/分钟 SLA 规则可配置。
+
+### Phase 6：高级流程设计器整合
+
+预计 8-15 天。
+
+范围：
+
+- Workflow Designer 节点映射到审批/自动化 runtime。
+- 节点 catalog 增加审批人、抄送、自动化动作、消息、数据操作。
+- 测试运行 trace。
+- BPMN runtime hardening。
+
+验收：
+
+- 设计器创建的流程能落到审批产品运行时。
+- 测试运行可看到节点 trace。
+- 高级 BPMN 仅承载已验证节点类型。
+
+## 7. 开发顺序建议
+
+优先顺序：
+
+1. 版本冻结与发布生命周期。
+2. 自动审批三合并。
+3. 管理员跳转节点。
+4. 加签。
+5. `ApprovalAssigneeResolver`。
+6. `approval_trigger_bindings`。
+7. 审批结果回写多维表。
+8. 自动化 `start_approval`。
+9. 审批完成事件桥。
+10. 任务中心增强。
+11. 节点字段权限。
+12. 自动化 execution retry。
+13. SLA timeout actions。
+14. 持久队列。
+15. Workflow Designer runtime 映射。
+
+原因：
+
+- 1-4 来自 2026-05-14 对照文档的 Wave A，是内核正确性和运维兜底，应该先于新业务面。
+- 5-9 形成宜搭式业务闭环，把多维表、公开表单、审批和自动化串起来。
+- 10-11 是用户每天使用流程时最明显的产品体验差距。
+- 12-13 解决运行治理和异常处理。
+- 14-15 是平台化能力，必须建立在前面稳定语义上。
+
+## 8. API 草案
+
+### 8.1 审批触发绑定
+
+```http
+GET /api/approval-templates/:templateId/triggers
+POST /api/approval-templates/:templateId/triggers
+PATCH /api/approval-templates/:templateId/triggers/:bindingId
+DELETE /api/approval-templates/:templateId/triggers/:bindingId
+```
+
+### 8.2 任务中心
+
+```http
+GET /api/approvals/tasks
+GET /api/approvals/tasks/:taskId
+POST /api/approvals/tasks/bulk-action
+```
+
+### 8.3 高级动作
+
+```http
+POST /api/approvals/:id/actions/transfer
+POST /api/approvals/:id/actions/return
+POST /api/approvals/:id/actions/revoke
+POST /api/approvals/:id/actions/add-sign
+POST /api/approvals/:id/actions/comment
+POST /api/approvals/:id/jump
+POST /api/workflow/instances/:id/jump
+```
+
+可以保留现有 `/api/approvals/:id/actions` 作为兼容入口，但新功能建议拆专用 endpoint，便于权限、参数和审计差异化。
+
+### 8.4 自动化运行中心
+
+```http
+GET /api/multitable/automation-executions
+GET /api/multitable/automation-executions/:executionId
+POST /api/multitable/automation-executions/:executionId/retry
+POST /api/multitable/automation-executions/:executionId/support-packet
+```
+
+### 8.5 模拟运行
+
+```http
+POST /api/workflow-designer/workflows/:id/simulate
+POST /api/approval-templates/:id/simulate
+```
+
+## 9. 数据迁移草案
+
+建议新增迁移按以下顺序拆小文件：
+
+1. `create_approval_template_version_snapshots`
+2. `add_approval_auto_approval_policy`
+3. `extend_approval_records_for_jump_and_auto_approval`
+4. `extend_approval_assignments_for_add_sign`
+5. `create_approval_trigger_bindings`
+6. `extend_approval_template_versions_for_assignee_sources`
+7. `add_approval_node_field_permissions`
+8. `create_approval_delegations`
+9. `create_approval_deadlines`
+10. `create_automation_execution_attempts`
+11. `create_automation_jobs`
+
+迁移原则：
+
+- 不破坏现有 approval graph JSON。
+- 新字段默认兼容旧模板。
+- 所有新表带 `tenant_id`。
+- 对外部副作用动作保留审计字段。
+- JSONB 字段先灵活承载，稳定后再拆列。
+
+## 10. 测试与验证计划
+
+### 10.1 后端单元测试
+
+建议新增：
+
+- `approval-version-freeze.test.ts`
+- `approval-auto-approval-policy.test.ts`
+- `approval-admin-jump.test.ts`
+- `approval-add-sign.test.ts`
+- `approval-assignee-resolver.test.ts`
+- `approval-trigger-binding.test.ts`
+- `approval-node-field-permissions.test.ts`
+- `approval-timeout-rules.test.ts`
+- `automation-execution-retry.test.ts`
+- `automation-start-approval-action.test.ts`
+
+### 10.2 后端集成测试
+
+建议新增：
+
+- `approval-version-freeze-flow.test.ts`
+- `approval-admin-jump-flow.test.ts`
+- `approval-add-sign-flow.test.ts`
+- `public-form-approval-trigger.test.ts`
+- `multitable-record-approval-roundtrip.test.ts`
+- `approval-task-center.test.ts`
+- `automation-run-center.test.ts`
+
+### 10.3 前端测试
+
+建议新增：
+
+- `approval-admin-jump.spec.ts`
+- `approval-add-sign.spec.ts`
+- `approval-trigger-settings.spec.ts`
+- `approval-task-center.spec.ts`
+- `approval-field-permissions.spec.ts`
+- `multitable-automation-start-approval.spec.ts`
+- `automation-run-center.spec.ts`
+
+### 10.4 推荐命令
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-version-freeze.test.ts tests/unit/approval-auto-approval-policy.test.ts tests/unit/approval-admin-jump.test.ts tests/unit/approval-add-sign.test.ts
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-assignee-resolver.test.ts tests/unit/approval-trigger-binding.test.ts
+pnpm --filter @metasheet/core-backend exec vitest run tests/integration/approval-version-freeze-flow.test.ts tests/integration/approval-admin-jump-flow.test.ts tests/integration/approval-add-sign-flow.test.ts
+pnpm --filter @metasheet/core-backend exec vitest run tests/integration/public-form-approval-trigger.test.ts
+pnpm --filter @metasheet/web exec vitest run tests/approval-task-center.spec.ts tests/automation-run-center.spec.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/web build
+```
+
+在阶段结束前再跑：
+
+```bash
+pnpm lint
+pnpm type-check
+pnpm test
+```
+
+如环境允许，最终跑：
+
+```bash
+pnpm validate:all
+```
+
+## 11. 不建议当前阶段投入的内容
+
+以下能力不是不重要，而是不适合在第一轮对标中先做：
+
+- 完整 BPMN 2.0 兼容引擎。
+- 任意脚本节点开放给业务用户。
+- 外部连接器市场。
+- 流程模板市场。
+- 大屏分析平台。
+- 复杂图形化自动化画布。
+
+这些能力需要更强的沙箱、凭证管理、配额、审计、运行隔离和产品治理。建议等审批/自动化闭环稳定后再进入。
+
+## 12. 当前仓库注意事项
+
+当前工作区已有考勤/公式相关未提交改动。开展本方案开发前，应先隔离当前改动：
+
+- 提交当前考勤/公式变更；或
+- 暂存当前变更；或
+- 使用独立 worktree/branch 开发流程自动化对标功能。
+
+不要把考勤公式修复和流程/自动化对标开发混在同一个 PR。
+
+## 13. 推荐第一张开发 TODO
+
+结合 2026-05-14 对照文档后，第一张 TODO 不再直接从“公开表单触发审批”开始，而是先做审批内核最小闭环，避免后续业务闭环建立在会漂移的版本和任务语义上。
+
+建议第一张 TODO：
+
+1. 固化审批模板版本快照，确保实例发起后绑定不可变版本。
+2. 新增自动审批三合并策略：发起人合并、相邻审批人合并、历史审批人去重。
+3. 新增管理员跳转节点能力，支持 stuck 实例恢复。
+4. 新增加签能力第一版：前加签、后加签、并行加签。
+5. 补齐审计记录和时间线展示所需 metadata。
+6. 增加后端单元和集成测试覆盖版本冻结、自动审批、跳转、加签。
+
+这张 TODO 与旧文档 Wave A 对齐，属于“已上线模块内核打磨”，不新增独立产品面。完成后再进入第二张 TODO：公开表单/多维表触发审批、审批结果回写、`start_approval` 自动化动作。

--- a/docs/research/yida-workflow-vs-metasheet2-comparison-20260514.md
+++ b/docs/research/yida-workflow-vs-metasheet2-comparison-20260514.md
@@ -1,0 +1,707 @@
+# 钉钉宜搭"流程设计"对照 MetaSheet V2 借鉴评估
+
+**生成日期**：2026-05-14
+**调研来源**：抓取 `docs.aliwork.com/docs/yida_support/_2/*` 共 9 个页面
+**对照对象**：`packages/core-backend/src/workflow/*`、`packages/core-backend/src/multitable/automation-*`、`packages/core-backend/src/services/approval-bridge-*`、`packages/core-backend/src/routes/{workflow,workflow-designer,automation,approvals}.ts`
+**阶段约束**：依据项目 memory K3 PoC 阶段一锁定，仅"已上线模块内核打磨"可以投入；新产品面（流程市场、分析看板、平台化产品）须等客户 GATE PASS
+
+---
+
+## 0. TL;DR（30 秒读完）
+
+| 维度 | 结论 |
+|---|---|
+| 是否可以开展流程/自动化开发 | **可以**，且无须开新战线 |
+| 推荐方向 | 直接打磨已交付的 3 个子系统：BPMN Engine / Multitable Automation / Approval Bridge |
+| 头号借鉴点 Top 3 | ①自动审批 3 合并规则 ②超时 5 动作 + 工时日历 ③运行时跳转节点 + 加签 |
+| 已具备但需补语义 | 流程版本冻结、子流程 callActivity 真执行、节点字段权限三态 |
+| 阶段一锁外（暂不做） | 流程分析看板、节点上限护栏、模板市场 |
+
+---
+
+## 1. 宜搭流程能力全景（抓取材料归纳）
+
+### 1.1 节点类型矩阵
+
+| 节点类别 | 子类型 | 关键能力 |
+|---|---|---|
+| **发起节点** | — | 一流程一个，不可删除；发起人对表单字段权限可配 |
+| **人工节点** | 审批人 | 同意/拒绝；多个候选人；可设"允许审批人为空" |
+| | 执行人 | 不做决策，只执行后返回继续 |
+| | 抄送人 | 只发消息提醒，不阻塞；权限为只读/隐藏二选一 |
+| **分支节点** | 条件分支 | 满足规则的多个分支都会执行 |
+| | 并行分支 | 多条线同时触发 |
+| | 子流程 | 独立子流程；多种参数触发模式；解耦/组织复用 |
+| **数据节点** | — | 与集成自动化共用的数据节点 |
+| **脚本节点** | — | 开发者节点，写代码 |
+| **消息节点** | 消息通知 | 钉钉工作通知/群通知 |
+| | 邮件通知 | 邮件模板 |
+
+**节点上限**：普通版 100 节点（含起止），专属版 150。超出报错且无法保存。
+
+### 1.2 流程属性矩阵
+
+#### 1.2.1 流程版本控制
+
+- **三态**：设计中 / 启用中 / 历史
+- **多草稿并行**：设计态可同时存在多个
+- **版本不可逆**：启用中版本只能查看，无法直接修改；历史版本可"再次发布"
+- **数据保护**：流程修改对历史数据**不生效**——版本号变更后，旧规则只作用于该版本下已提交的数据
+- **生命周期约束**：含有未完结实例的历史版本无法删除
+- **版本日志**：版本号、备注、创建人/时间、更新人/时间
+
+#### 1.2.2 权限设置
+
+| 维度 | 配置项 |
+|---|---|
+| 发起权限 | 谁能发起 + 发起页字段权限 |
+| 节点字段权限 | 审批/执行：**可编辑/只读/隐藏 三态**；抄送：只读/隐藏 二态 |
+| 全局查看态权限 | 默认查看态字段权限 |
+
+#### 1.2.3 自动审批规则
+
+三种内置策略（节点级 + 全局级，**节点级优先**）：
+
+1. **所有发起人合并**：审批/执行节点指向当前发起人时自动通过
+2. **相邻审批人合并**：与上一节点人员一致时自动通过（"相邻"指设计图上相邻，**抄送不占份额**）
+3. **审批人自动去重**：流程中已审批过的人，后续节点自动通过
+
+#### 1.2.4 超时处理规则（专业版+）
+
+- **5 种执行动作**
+  - 自动提醒（钉钉工作通知 + 待办消息）
+  - 自动转交（指定成员/字段成员/直属主管）
+  - 自动跳转（流程内其他节点）
+  - 自动同意（审批人专享）
+  - 自动拒绝（审批人专享）
+- **4 种时间维度**
+  - 法定工作日（去掉节假日 + 双休）：1-31 天
+  - 自然日：1-31 天
+  - 小时：1-744 小时（可设时间段）
+  - 分钟：10-44640 分钟
+- **不计时时间段**（仅全局可设，节点级开关）
+  - 按"星期 + 时间段"组合
+  - 例：每天 0-9 点、12-13 点、18-24 点不计时
+- **重复提醒**：默认 1 次，最高 10 次
+- **特殊语义**
+  - 转交时直属主管不存在→**终止转交**
+  - 超时规则对**历史数据不生效**
+
+#### 1.2.5 节点提交规则
+
+| 维度 | 选项 |
+|---|---|
+| 适用节点 | 开始节点 / 结束节点（同意/拒绝/撤销 三动作分别配）/ 流程中审批节点 |
+| 触发方式 | 任务完成执行（同意/拒绝/保存/退回 + 校验或关联）/ 节点完成执行（同意/拒绝 + 关联） |
+| 规则类型 | **校验规则**（可阻断当前操作）/ **关联操作**（不阻断，跑业务公式更新其他表） |
+
+文档中明确：**复杂的业务关联推荐用集成自动化（有画布视图）**——宜搭已经把"流程内联公式"和"集成自动化"做了分工。
+
+#### 1.2.6 手写签名
+
+- 仅适用于审批/执行人节点
+- **移动端**预设个人签字；PC 端需要扫码
+- 首次签字后默认沿用
+- 节点级开关 + 全局设置
+
+### 1.3 运营 & 实例语义
+
+- **流程任务中心**：个人代办的跨流程聚合
+- **代理中心**：代理别人审批
+- **流程分析**：内置数据集 + 报表，可下钻；默认本表过滤
+- **测试**：编辑器内"测试"按钮 → 启动测试 → trace 出来
+- **跳转节点**：异常时（如审批人离职）管理员**手工跳转**到任意节点，恢复 stuck 流程
+
+### 1.4 实例约束（很重要的设计意图）
+
+| 约束 | 说明 |
+|---|---|
+| **发起时刻冻结** | 发起人和发起部门在发起时刻已确定，后续部门调整不影响 |
+| **离职/调岗保护** | 流程发起后人员变动不影响发起态信息，但若审批节点依赖离职人的组织信息（如主管），流程会报错 → 用跳转节点解决 |
+| **消息模板需重刻版本** | 改了消息模板不会立即生效，要点"生成新版本" |
+| **关闭通知粒度** | "关闭移动端提交通知审批人"是组织维度，不可单流程关 |
+
+---
+
+## 2. MetaSheet V2 现状代码地图
+
+### 2.1 BPMN Engine 子系统
+
+**文件**：`packages/core-backend/src/workflow/`
+- `BPMNWorkflowEngine.ts` 1852 行
+- `WorkflowDesigner.ts` 924 行
+- `workflowDesignerDrafts.ts` / `workflowDesignerRouteModels.ts` / `workflowHubTeamViews.ts`
+
+**已实现的节点类型**（`BPMNWorkflowEngine.ts:341-369` switch case）：
+
+| 我方节点 | 对应宜搭 | 缺口 |
+|---|---|---|
+| startEvent | 发起节点 | 无"发起人字段权限"维度 |
+| endEvent | 结束节点 | 无"按节点动作分别配规则" |
+| userTask | 审批人/执行人 | **不区分"审批"vs"执行"**；无字段权限三态；无"允许为空" |
+| serviceTask | 数据节点的部分能力 | 通用 service 而非数据写入定向 |
+| scriptTask | 脚本节点 | 已有 `child_process` 等危险模式拦截 |
+| exclusiveGateway | 条件分支 | OK |
+| parallelGateway | 并行分支 | OK |
+| intermediateCatchEvent | 计时/消息/信号 | 计时器走自然时间，无工时日历 |
+
+**未实现但已在 BPMN names 列表里露脸**（`BPMNWorkflowEngine.ts:924-925`）：
+- `bpmn:callActivity` / `bpmn:subProcess` — **stub，无 case 执行**
+
+**完全缺失**：
+- 抄送节点（cc 是 approval tab 视图，不是流程节点）
+- 邮件通知节点（要走 serviceTask 自实现）
+- 钉钉消息节点（已在 multitable automation 实现，未挂到 BPMN）
+
+**运行时操作**：
+- `deployProcess` / `startProcess` / `executeActivity`
+- `completeUserTask` / `sendMessage` / `broadcastSignal`
+- incidents 解决 / shutdown
+
+### 2.2 Multitable Automation 子系统
+
+**文件**：`packages/core-backend/src/multitable/automation-*.ts`（合计 7458 行）
+
+**Triggers (7 种)** `automation-triggers.ts`：
+- record.created / record.updated / record.deleted
+- field.value_changed（支持 any / equals / changed_to）
+- schedule.cron / schedule.interval
+- webhook.received
+
+**Actions (8 种)** `automation-actions.ts`：
+- update_record / create_record
+- send_webhook
+- send_notification（站内通知）
+- send_email
+- send_dingtalk_group_message / send_dingtalk_person_message
+- lock_record
+
+**Conditions** `automation-conditions.ts`：
+- 12 个 operator：equals, not_equals, contains, not_contains, greater_than, less_than, greater_or_equal, less_or_equal, is_empty, is_not_empty, in, not_in
+- AND/OR 嵌套，最大 5 层
+- 按字段类型 allow-list（数值/文本/多选等使用不同 operator 子集）
+
+**调度与可观测性**：
+- `automation-scheduler.ts`：Redis Leader Lock + Prometheus gauge
+- `automation-log-service.ts`：日志写入
+- `automation-log-redact.ts` + `automation-log-support-packet.ts`：日志脱敏 & 支持包
+
+### 2.3 Approval Bridge 子系统
+
+**文件**：`packages/core-backend/src/services/approval-bridge-types.ts` + `routes/approvals.ts` + `routes/approval-history.ts` + `routes/approval-metrics.ts`
+
+**Actions (6 种)** `approval-bridge-types.ts:115`：
+- approve / reject / transfer / revoke / comment / return
+
+**已具备**：
+- SLA hours（`req.body.slaHours`）+ breach notifier（`approval-sla-scheduler` + `approval-breach-notifier`）
+- 平行区域：`currentNodeKeys` 长度 ≥ 2 表示并行（`approval-bridge-types.ts:34`）
+- 视图 tabs：pending / mine / cc / completed（`routes/approvals.ts:493`）
+- 桥接：PLM Approval Bridge / After-Sales Approval Bridge
+- breach_notified_at 字段防止重复通知
+
+**完全缺失**：
+- 自动审批合并规则
+- 跳转节点
+- 加签
+- 工时日历
+- 节点字段权限三态
+- 流程实例发起时刻冻结的语义验证
+
+### 2.4 Workflow Designer 子系统
+
+**文件**：`packages/core-backend/src/routes/workflow-designer.ts`（21 路由）+ `workflow/WorkflowDesigner.ts`
+
+**已具备**：
+- 节点 catalog `GET /node-types` → 8 个 builtin + `workflow_node_library` 自定义节点
+- 版本字段 `version: number`（`workflowDesignerDrafts.ts:40,52`）
+- drafts 表 + drafts 路由
+- 模板 `templates` API
+- Team-level Hub views
+
+**缺失**：
+- 个人任务中心
+- 模拟测试（编辑器一键 dry-run）
+- 流程实例版本冻结语义
+
+---
+
+## 3. 能力差矩阵（逐项比对）
+
+> 标注：✅=已具备且对齐；🟡=部分支持/需扩展；❌=完全缺失
+
+| 维度 | 子项 | 宜搭 | MetaSheet | 差距说明 |
+|---|---|---|---|---|
+| **节点** | 发起节点字段权限 | ✅ | ❌ | userTask 无 fieldPermissions |
+| | 审批 vs 执行 区分 | ✅ | ❌ | 全部归 userTask |
+| | 抄送节点（流程内非阻塞）| ✅ | 🟡 | cc 仅为视图 tab |
+| | 子流程（callActivity）| ✅ | 🟡 | BPMN names 列了但 case 未实现 |
+| | 数据节点（写入定向）| ✅ | 🟡 | 用 multitable automation 替代但未挂 BPMN |
+| | 消息/邮件 作为节点 | ✅ | 🟡 | multitable automation 已有 action，未挂 BPMN |
+| | 节点上限护栏 | ✅ 100/150 | ❌ | 无显式上限校验 |
+| **权限** | 节点字段权限三态 | ✅ | ❌ | — |
+| | 发起权限白名单 | ✅ | 🟡 | RBAC 层有但未流程化 |
+| **版本** | 设计中/启用中/历史 | ✅ | 🟡 | version int 有但状态机不完整 |
+| | 多草稿并行 | ✅ | 🟡 | drafts 表存在但生命周期未规范 |
+| | 历史实例冻结 | ✅ | ❌ | 没看到 instance.definitionVersion 不变的语义 |
+| | 含未完结实例的版本不可删 | ✅ | ❌ | — |
+| **自动审批** | 发起人合并 | ✅ | ❌ | — |
+| | 相邻审批人合并 | ✅ | ❌ | — |
+| | 审批人去重 | ✅ | ❌ | — |
+| | 全局 vs 节点级优先 | ✅ | ❌ | — |
+| **超时** | 5 种执行动作 | ✅ | 🟡 | 当前仅"提醒"（breach-notifier），缺转交/跳转/同意/拒绝 |
+| | 4 种时间维度 | ✅ | 🟡 | 仅 hours 单维 |
+| | 不计时时间段 | ✅ | ❌ | — |
+| | 重复提醒最多 10 次 | ✅ | 🟡 | breach_notified_at 但缺次数上限 |
+| | 法定节假日 / 工时日历 | ✅ | 🟡 | DB 已有 `attendance_holidays` + `is_workday` 但未接入 SLA |
+| **提交规则** | 校验规则 | ✅ | 🟡 | 用 exclusiveGateway condition 替代 |
+| | 关联操作（同步写别表）| ✅ | 🟡 | multitable automation 有 action 但未在审批完成时回调 |
+| | 触发方式细分 | ✅ | ❌ | 无"任务完成 vs 节点完成"区分 |
+| **签名** | 手写签名 | ✅ | ❌ | 国内合规缺项 |
+| **运营** | 跳转节点（管理员手工）| ✅ | ❌ | 流程 stuck 只能改 DB |
+| | 加签 | (常规 ISV 标配) | ❌ | — |
+| | 代理审批 | ✅ | ❌ | — |
+| | 个人任务中心 | ✅ | 🟡 | workflowHubTeamViews 仅 team 级 |
+| | 流程分析看板 | ✅ | ❌ | 阶段三再说 |
+| | 编辑器模拟测试 | ✅ | ❌ | 无 dry-run 端点 |
+| **实例语义** | 发起时刻冻结部门 | ✅ | 🟡 | 部门字段存了但无显式锁定语义 |
+| | 模板改完要重刻版本 | ✅ | ❌ | 当前应该会立即生效，可能有"幽灵更新" |
+
+---
+
+## 4. 借鉴清单（按 ROI / 阶段一锁兼容度排序）
+
+### 4.1 🟢 阶段一锁兼容（"已上线模块内核打磨"，可直接立项）
+
+---
+
+#### #1 自动审批 3 合并规则
+
+**ROI**：⭐⭐⭐⭐⭐（客户最常吐槽点）
+**预估工时**：2-3 天
+
+**现状缺口**：
+- `approval-bridge` 在分配节点 assignee 后直接进入待审状态
+- 同一人重复审批 / 发起人审批自己等场景没自动跳过
+
+**落地方案**：
+1. `approval-bridge-types.ts` 增 `AutoApprovalPolicy`：
+   ```ts
+   interface AutoApprovalPolicy {
+     mergeWithInitiator?: boolean
+     mergeAdjacent?: boolean        // 抄送不占份额
+     dedupApprovers?: boolean
+     scope?: 'rule' | 'global'      // rule 优先于 global
+   }
+   ```
+2. 在分配 assignee 前调用 `applyAutoApprovalRules(approval, policy, history)`：
+   - 命中 → 自动 approve + 写历史（action='approve', actor=system, reason=auto_merged_initiator|adjacent|dedup）
+3. 全局策略读 `org_settings.approval_auto_policy`；规则级覆盖全局
+
+**测试**：
+- `approval-graph-executor.test.ts` 加 3 case（每条规则一个）
+- 边界：抄送不占相邻份额；多条规则并存的优先级
+
+**风险**：
+- 自动批必须有审计日志区分人工/系统
+- 客户可能要求"自动审批人记为发起人"vs"系统账号"——做成可配置
+
+---
+
+#### #2 超时 5 动作 + 工时日历一体化
+
+**ROI**：⭐⭐⭐⭐⭐（运营效率核心）
+**预估工时**：4-5 天
+
+**现状缺口**：
+- `approval-sla-scheduler` + `approval-breach-notifier` 仅做"提醒"，缺自动转交/跳转/同意/拒绝
+- SLA 计算走自然时间，未利用已存在的 `attendance_holidays` / `is_workday` 表
+- 无"不计时时间段"机制
+- breach 重复提醒次数无上限
+
+**落地方案**：
+
+A. **BusinessCalendarService 抽取**（新建 `services/BusinessCalendarService.ts`）：
+   - 复用 `attendance_holidays`（org_id, holiday_date）
+   - 复用排班表的 is_workday 标识
+   - 提供 `nextBusinessTime(from, durationSpec)` API：支持 `{ unit: 'workday'|'natural_day'|'hour'|'minute', amount: int, businessHours?: {start,end}, blackouts?: [{dayOfWeek, ranges}] }`
+   - 节假日数据**复用** attendance 模块（避免"两套节假日"）
+
+B. **SLA 计算改造**：
+   - `approval-sla-scheduler` 把 due 时间通过 BusinessCalendarService 算出
+   - schema 加 `sla_unit`（workday/natural_day/hour/minute）、`sla_skip_ranges`（不计时时间段 JSON）
+
+C. **超时动作扩展**：
+   ```ts
+   type BreachAction =
+     | { kind: 'remind', recipients: ApproverSelector, template: string }
+     | { kind: 'transfer', target: ApproverSelector }
+     | { kind: 'jump', toNodeKey: string }
+     | { kind: 'auto_approve', reason: string }
+     | { kind: 'auto_reject', reason: string }
+   ```
+   `breach-notifier` 改为分发器，按 action.kind 调用 approval-bridge 对应方法
+
+D. **重复提醒次数**：
+   - 表加 `breach_remind_count`
+   - 配置中 `maxReminders`（默认 1，上限 10）
+   - 超过则停止；命中 transfer/jump/auto_* 后停止
+
+**测试**：
+- `approval-sla-scheduler.test.ts` 加 4 case（4 种时间维度）+ 4 case（5 动作除提醒外的 4 种）+ 不计时时间段命中/非命中
+- 边界：自动转交时主管不存在 → 行为对齐宜搭"终止转交"
+- 工时日历回归：原有用 hour 计算的旧 SLA 必须无破坏（迁移期默认 sla_unit='hour'）
+
+**风险**：
+- auto_approve / auto_reject 必须接 RBAC：流程定义里**显式允许**才生效（默认拒绝），避免静默批准
+- 与历史数据交互：宜搭"超时规则对历史数据不生效"，我方需要在 instance.definitionVersion 锁定后才能正确执行（依赖 #6）
+
+---
+
+#### #3 跳转节点（admin jump）
+
+**ROI**：⭐⭐⭐⭐（运维兜底刚需）
+**预估工时**：3 天
+
+**现状缺口**：
+- 审批人离职 + 主管字段为空 → 流程 stuck
+- 唯一解法是改 DB 或 transfer，但 transfer 需要一个具体人，找不到时无解
+
+**落地方案**：
+1. BPMN engine 加 `jumpToActivity(instanceId, targetActivityId, reason, actorId)`：
+   - 校验：actor 必须有 `workflow:admin_jump` 权限
+   - 校验：targetActivityId 在当前 process definition 内且非已完成的端点
+   - 完成当前 activity（标记 `outcome='admin_jump'`）+ 启动 target activity
+   - 写审计日志 + 发起事件 `workflow.admin_jumped`
+2. Approval bridge 镜像 `adminJump(approvalId, toNodeKey, reason)`：
+   - 关闭当前 assignments
+   - 创建 target 节点的 assignments
+3. `POST /api/workflow/instances/:id/jump` + `POST /api/approvals/:id/jump`
+
+**测试**：
+- BPMN engine 单测：跳转后流程 token 正确
+- 安全：无权限调用 → 403
+- 历史完整性：jump 记录必须在 instance.history 可见
+
+**风险**：
+- 必须有严格审计 + 同步发钉钉通知所有审批人
+- 不允许跳到已通过的节点（防回退混乱）；如要回退用 return action
+
+---
+
+#### #4 加签（运行时追加审批人）
+
+**ROI**：⭐⭐⭐⭐（国内审批刚需）
+**预估工时**：3-4 天
+
+**现状缺口**：
+- 当前 assignee 在节点配置时固定，运行时无法追加
+
+**落地方案**：
+1. Approval bridge 加 `addAssignee(approvalId, userId, mode, actorId)`：
+   ```ts
+   type CountersignMode =
+     | 'before'    // 我审之前先让某某审
+     | 'after'     // 我审之后再让某某审
+     | 'parallel'  // 与我同时审，全部通过才推进
+   ```
+2. Schema：`approval_assignments` 加 `countersign_origin`（actorId）+ `countersign_mode`
+3. 进入下一节点的条件改造：
+   - parallel：当前节点所有 assignments 完成
+   - before：新追加的 assignment 完成后回到原 assignee
+   - after：原 assignee 完成后才轮到追加的
+4. 历史中明确标注"XX 因为 YY 被 ZZ 加签"
+
+**测试**：
+- `approval-graph-executor.test.ts` 加 3 case（3 种 mode）
+- 边界：加签人不能是发起人 / 不能是已完成节点的审批人
+- 与平行区域并存
+
+**风险**：
+- 加签人必须有 `approvals:countersign` 权限
+- 与自动合并规则的交互（加签人=发起人时是否自动通过？应该不自动，因为加签是显式意图）
+
+---
+
+#### #5 节点字段权限三态
+
+**ROI**：⭐⭐⭐（数据脱敏 + 流程合规）
+**预估工时**：4-5 天（前后端都要改）
+
+**现状缺口**：
+- BPMN userTask 只配 assignee/candidateUsers/formKey，无字段级权限
+- 多维表已经有 field permission engine，但未挂流程
+
+**落地方案**：
+1. NodeTypeDefinition.properties 加 `fieldPermissions: { type: 'object', label: 'Field Permissions' }`
+2. 节点配置 schema：
+   ```ts
+   interface NodeFieldPermissions {
+     [fieldId: string]: 'edit' | 'readonly' | 'hidden'
+   }
+   ```
+3. 完成节点表单加载时（`completeUserTask` 前），读当前节点的 fieldPermissions
+4. 前端表单引擎按权限渲染
+5. 后端 `completeUserTask` 校验提交字段必须在 edit 范围内
+
+**测试**：
+- 单测：edit 字段可提交、readonly 字段提交被拒、hidden 字段不在返回 form schema
+- 集成测：从 startEvent 流到 userTask，字段权限按节点切换
+
+**风险**：
+- 与现有多维表字段权限引擎不冲突（应该是叠加优先 hidden）
+- 性能：大量字段时的 schema 计算
+
+---
+
+#### #6 流程版本冻结语义
+
+**ROI**：⭐⭐⭐⭐（数据正确性根基）
+**预估工时**：2-3 天
+
+**现状缺口**：
+- 我方有 `version: number` 字段但缺"实例发起后锁定 definitionVersion，后续 publish 不影响"的明确语义
+- 直接后果：改了流程定义可能把正在跑的实例也变了
+
+**落地方案**：
+1. `workflow_instance` 表加 `definition_version: int NOT NULL`（迁移：默认设当前 version）
+2. `startProcess` 时记录 `definition_version`
+3. `executeActivity` 加载 definition 时用 `definitionId + definitionVersion` 而非最新版
+4. 加 `workflow_definition_versions` 历史表：
+   ```sql
+   create table workflow_definition_versions (
+     definition_id text,
+     version int,
+     definition_json jsonb,
+     state text,            -- 'design' | 'active' | 'history'
+     created_at, created_by, ...
+     primary key (definition_id, version)
+   )
+   ```
+5. publish 流程：当前 active → history，新版本 → active
+6. 删除约束：状态=history 且无 instance.definition_version 引用 → 才可删
+
+**测试**：
+- 单测：实例发起后修改 definition，旧实例继续按旧版执行
+- 边界：尝试删除有未完结实例的 history 版本 → 拒绝
+
+**风险**：
+- 现有运行中实例的迁移（赋默认版本）
+
+---
+
+#### #7 编辑器模拟测试（dry-run）
+
+**ROI**：⭐⭐⭐⭐（设计效率倍增器）
+**预估工时**：3-4 天
+
+**现状缺口**：
+- 设计完流程必须真启动一个实例才能看分支走向
+- `routes/workflow-designer.ts` 21 个端点里没有 `test` 类
+
+**落地方案**：
+1. `POST /api/workflow-designer/:definitionId/simulate`：
+   ```ts
+   { startVariables: Record<string, unknown>, autoCompleteUserTasks?: boolean }
+   → { trace: ActivityTrace[], finalState: 'completed'|'stuck'|'rejected' }
+   ```
+2. `WorkflowDesigner.simulate(def, vars)`：
+   - 用一个 in-memory 引擎跑 definition（不写库）
+   - 用户任务可选自动通过（用于查看分支走向）/ 暂停（用于查看到达哪个节点）
+   - 输出每个 activity 的 input/output/duration/path
+
+3. 前端编辑器顶部"测试"按钮 → 模态：填变量 → 看 trace 高亮
+
+**测试**：
+- 单测：给定 definition + variables 输出 trace
+- 不影响真实运行实例
+- 失败原因可读（缺变量、条件无分支命中、达到上限）
+
+**风险**：
+- 用户任务的"自动通过"语义需要明确（区分模拟人为同意 vs 自动审批）
+
+---
+
+### 4.2 🟡 阶段一锁内 borderline（属于已上线模块但工作量大或边界模糊）
+
+---
+
+#### #8 个人任务中心
+
+**ROI**：⭐⭐⭐
+**预估工时**：3 天
+
+**落地方案**：
+- `GET /api/workflow/me/tasks?status=pending`：聚合 `bpmn_user_tasks` 中 assignee=me 的 + `approval_assignments` 中 actor=me 的
+- 视图层在 web 端做一个"我的待办"页（mock：`workflowHubTeamViews` 拷一份做 personal）
+
+---
+
+#### #9 代理中心
+
+**ROI**：⭐⭐
+**预估工时**：3-4 天
+
+**落地方案**：
+- 表 `approval_delegations(user_id, delegate_to, start_at, end_at, scopes jsonb)`
+- approval bridge 解析 assignee 时插一层 lookup：若 user_id 有有效代理，则 assignment 同时发给原人和代理人，二者任一处理即可
+- BPMN userTask 同理
+
+---
+
+#### #10 节点提交·关联操作
+
+**ROI**：⭐⭐⭐（已经有 multitable automation action 可复用）
+**预估工时**：2 天
+
+**落地方案**：
+- approval bridge 在 `approve` / `reject` / `return` 完成后发送 EventBus 事件 `approval.<action>.completed`
+- multitable automation 加 trigger type：`approval.completed`（subtype：approved/rejected/returned）
+- 配置端：在节点配置上挂"完成后触发的 automation rule"
+
+**收益**：节点完成时跑业务公式更新别表的需求**已经被 multitable automation 覆盖**，只缺 trigger 桥。
+
+---
+
+#### #11 子流程 callActivity 真实执行
+
+**ROI**：⭐⭐⭐
+**预估工时**：4-5 天
+
+**落地方案**：
+1. `BPMNWorkflowEngine.executeActivity` switch 加 case `callActivity` / `subProcess`：
+   - 加载被调用的 definition
+   - startProcess 一个子实例，记录 `parent_instance_id` / `parent_activity_id`
+   - 父实例进入等待
+   - 子实例 endEvent 时回写 output variables 到父实例 + 唤醒父 activity
+2. 变量传递：节点配置 inputMapping / outputMapping
+3. 错误传播：子流程异常 → 父流程 incident
+
+**测试**：
+- 父子嵌套 2 层、3 层
+- 子流程异常被父流程捕获
+- 变量映射
+
+---
+
+#### #12 抄送独立节点
+
+**ROI**：⭐⭐
+**预估工时**：2 天
+
+**落地方案**：
+- 加 BPMN 节点类型 `ccTask`（非阻塞，发完消息立即通过）
+- 复用 multitable automation 的 `send_dingtalk_*` action 作为执行体
+
+---
+
+#### #13 手写签名
+
+**ROI**：⭐⭐（合规客户必需）
+**预估工时**：3-4 天
+
+**落地方案**：
+- 新建 SignatureService：管理用户预设签字图（OSS 存储）
+- userTask 加 `requireSignature: boolean`
+- completeUserTask 时校验 signatureRefId 存在
+- 前端 mobile 实现 canvas 签字 + 上传
+
+---
+
+### 4.3 🔴 阶段一锁外（要等 K3 PoC GATE PASS）
+
+| # | 项目 | 阻塞原因 |
+|---|---|---|
+| 14 | 流程分析数据集 + 看板 | 新产品面（BI 视图层），属阶段三平台化基建 |
+| 15 | 设计器节点上限护栏 100/150 | 设计器层规则；目前没有用户压力，不急 |
+| 16 | 流程模板市场化 | 阶段四 Marketplace 范畴 |
+| 17 | 多语言流程定义（i18n on rule name） | 平台化能力，等阶段二 |
+
+---
+
+## 5. 推荐路线图
+
+### Wave A（2 周窗口，约 14 工作日）
+
+| 顺序 | 项 | 估时 | 依赖 |
+|---|---|---|---|
+| 1 | #6 流程版本冻结语义 | 2-3 天 | 无（是其他改动的前提） |
+| 2 | #1 自动审批 3 合并规则 | 2-3 天 | #6 |
+| 3 | #3 跳转节点 + #4 加签 | 6-7 天 | #6 |
+
+**理由**：
+- #6 是底座，先稳住数据正确性
+- #1/#3/#4 直接对外可感、风险低
+- Wave A 完成可对外宣称"V2 审批引擎升级"
+
+### Wave B（2 周窗口，约 14 工作日）
+
+| 顺序 | 项 | 估时 |
+|---|---|---|
+| 4 | #2 超时 5 动作 + 工时日历 | 4-5 天 |
+| 5 | #7 编辑器模拟测试 | 3-4 天 |
+| 6 | #5 节点字段权限三态 | 4-5 天 |
+
+### Wave C（机动队列，按客户压力调度）
+
+- #8 个人任务中心（3 天）
+- #9 代理中心（3-4 天）
+- #10 节点提交关联操作（2 天）
+- #11 子流程 callActivity（4-5 天）
+- #12 抄送独立节点（2 天）
+- #13 手写签名（3-4 天）
+
+---
+
+## 6. 阶段一锁兼容性自检
+
+✅ 全部 13 个借鉴点都**不触碰** `plugins/plugin-integration-core/*`
+✅ 全部 13 个借鉴点都**不开新产品面**（BPMN engine / approval-bridge / multitable automation 都是已交付模块）
+✅ 全部 13 个借鉴点**不动 K3 PoC 路径**（`lib/adapters/k3-wise-*.cjs` 无变更）
+✅ 工时日历复用现有 `attendance_holidays` 表，不引入新基础设施
+🟡 Wave A / B 体量较大，建议每个 wave 切独立分支并按 4-lane 策略走 contracts → runtime → frontend → integration
+
+---
+
+## 7. 设计借鉴的"反面"（哪些不要照抄）
+
+宜搭的某些约束源于 SaaS 多租户 + 极致简化，我方不一定需要：
+
+| 宜搭做法 | 不建议照抄的理由 |
+|---|---|
+| 节点上限 100/150 | 我方私有部署场景，客户可能需要更多；做成可配置阈值即可 |
+| 关闭通知是组织维度 | 我方 RBAC 体系更细，建议做成 流程级/角色级 双层 |
+| 关闭通知功能要"提交工单 3 工作日" | 这是 SaaS 工单流程，我方私有部署直接给管理员开关 |
+| 仅移动端手写签名 | PC 端如果有触控屏可以支持，没必要锁死 |
+| "测试版本"无独立环境 | 我方可借助 `definition_version` + state='design' 隔离，避免污染生产 |
+
+---
+
+## 8. 抓取页面索引（用于回溯）
+
+| 主题 | URL | 用途 |
+|---|---|---|
+| 流程简介 | `/docs/yida_support/_2/crwfii` | 总览、节点上限、常见问题 |
+| 快速开始 | `/docs/yida_support/_2/qgaxvq` | 请假流程实例 |
+| 流程节点介绍 | `/docs/yida_support/_2/trbqg6` | 7 类节点定义 |
+| 流程属性设置 | `/docs/yida_support/_2/ef8e88` | 6 个子页索引 |
+| 流程版本控制 | `/docs/yida_support/_2/ef8e88/daeh3v` | 三态、多草稿、回退 |
+| 权限设置 | `/docs/yida_support/_2/ef8e88/lagbfd` | 三态字段权限 |
+| 自动审批规则 | `/docs/yida_support/_2/ef8e88/eeykw4` | 3 种合并 |
+| 超时处理规则 | `/docs/yida_support/_2/ef8e88/aglbg3` | 5 动作 × 4 维度 × 不计时段 |
+| 节点提交规则 | `/docs/yida_support/_2/ef8e88/emt041` | 校验 vs 关联 |
+| 手写签名 | `/docs/yida_support/_2/ef8e88/ezdklv` | 移动端签字 |
+| 流程案例 | `/docs/yida_support/_2/bpnetv` | 13 个 ISV 常见场景列表 |
+
+---
+
+## 9. 下一步动作建议
+
+1. **不立项前**：把当前分支 `codex/data-factory-issue1542-postdeploy-smoke-20260515` 上 8 个未提交改动 + 13 个 `.tmp-*.mjs` 脚本归类整理（stash / 落分支 / 删除）
+2. **立项时**：从 main 切出 `flow/wave-a-approval-kernel-20260515`，按 4-lane 策略推 Wave A 三项
+3. **每完成一项**：单独 PR + 单测覆盖 + 升级 CHANGELOG
+4. **Wave A 完成后**：写一份"V2 审批引擎升级 Release Note"对外说明
+
+---
+
+*文档结束。本评估基于 2026-05-14 当日代码快照，如代码后续演进请重新比对。*

--- a/packages/core-backend/src/services/ApprovalGraphExecutor.ts
+++ b/packages/core-backend/src/services/ApprovalGraphExecutor.ts
@@ -1,4 +1,5 @@
 import type {
+  ApprovalAutoApprovalReason,
   ApprovalEdge,
   ApprovalMode,
   ApprovalNode,
@@ -29,7 +30,8 @@ export interface ApprovalGraphAutoApprovalEvent {
   nodeKey: string
   sourceStep: number
   approvalMode: ApprovalMode
-  reason: 'empty-assignee'
+  reason: ApprovalAutoApprovalReason
+  metadata?: Record<string, unknown>
 }
 
 /**

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -1414,6 +1414,8 @@ function appendAutoApprovalHistory(history: ApprovalHistoryEntry[], event: Appro
   const originalApproverId = typeof originalApprover?.id === 'string' ? originalApprover.id : null
   history.push({
     nodeKey: event.nodeKey,
+    // Keep the in-memory chain keyed by the business approver even when the
+    // audit row is persisted under the system automation actor.
     actorId: originalApproverId || actorIdForAutoApprovalEvent(event),
     reason: event.reason,
   })
@@ -1452,6 +1454,8 @@ export class ApprovalProductService {
         const originalApproverId = typeof originalApprover?.id === 'string' ? originalApprover.id : null
         return {
           nodeKey,
+          // Persisted actor_id may be the system automation actor; adjacency
+          // matching must use the original approver captured in metadata.
           actorId: originalApproverId || row.actor_id,
           recordId: String(row.id),
           reason: typeof metadata?.reason === 'string' ? metadata.reason : undefined,
@@ -3173,6 +3177,8 @@ export class ApprovalProductService {
   ): Promise<void> {
     for (const event of autoApprovalEvents) {
       const skipped = event.metadata?.skipped === true
+      // The legacy audit action enum has no "skipped automation" value; keep
+      // these informational warnings distinct through metadata.skipReason.
       await this.insertApprovalRecord(client, instanceId, {
         action: skipped ? 'sign' : 'approve',
         actorId: actorIdForAutoApprovalEvent(event),

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -523,7 +523,11 @@ function validateFormFieldVisibilityRules(
   fields.forEach((field) => visit(field.id, []))
 }
 
-function normalizeApprovalGraph(value: unknown, context: ValidationContext): ApprovalGraph {
+function normalizeApprovalGraph(
+  value: unknown,
+  context: ValidationContext,
+  options: { allowParallelDuplicateAssignees?: boolean } = {},
+): ApprovalGraph {
   if (!isRecord(value) || !Array.isArray(value.nodes) || !Array.isArray(value.edges)) {
     failValidation(context, 'approvalGraph must contain nodes and edges')
   }
@@ -728,16 +732,18 @@ function normalizeApprovalGraph(value: unknown, context: ValidationContext): App
       )
       assigneesPerBranch.push(branchAssignees)
     }
-    const seen = new Set<string>()
-    for (const branchAssignees of assigneesPerBranch) {
-      for (const assignee of branchAssignees) {
-        if (seen.has(assignee)) {
-          failValidation(
-            context,
-            `approvalGraph parallel node ${node.key} has duplicate approver '${assignee}' across branches`,
-          )
+    if (!options.allowParallelDuplicateAssignees) {
+      const seen = new Set<string>()
+      for (const branchAssignees of assigneesPerBranch) {
+        for (const assignee of branchAssignees) {
+          if (seen.has(assignee)) {
+            failValidation(
+              context,
+              `approvalGraph parallel node ${node.key} has duplicate approver '${assignee}' across branches`,
+            )
+          }
+          seen.add(assignee)
         }
-        seen.add(assignee)
       }
     }
   }
@@ -1080,8 +1086,12 @@ function applyTemplateVisibilityFilter(
   return index
 }
 
-function assertApprovalGraph(value: unknown, context: ValidationContext = REQUEST_VALIDATION_CONTEXT): ApprovalGraph {
-  return normalizeApprovalGraph(value, context)
+function assertApprovalGraph(
+  value: unknown,
+  context: ValidationContext = REQUEST_VALIDATION_CONTEXT,
+  options?: { allowParallelDuplicateAssignees?: boolean },
+): ApprovalGraph {
+  return normalizeApprovalGraph(value, context, options)
 }
 
 function asFormSchema(value: Record<string, unknown>): FormSchema {
@@ -1118,14 +1128,17 @@ function asRuntimeGraph(value: Record<string, unknown>): RuntimeGraph {
     failValidation(STORED_RUNTIME_CONTEXT, 'runtimeGraph must be an object')
   }
 
+  const policy = assertRuntimePolicy(value.policy, STORED_RUNTIME_CONTEXT)
   const graph = assertApprovalGraph(
     {
       nodes: value.nodes,
       edges: value.edges,
     },
     STORED_RUNTIME_CONTEXT,
+    {
+      allowParallelDuplicateAssignees: policy.autoApproval?.mergeAdjacentApprover === true,
+    },
   )
-  const policy = assertRuntimePolicy(value.policy, STORED_RUNTIME_CONTEXT)
 
   return deepFreeze({
     ...graph,
@@ -1269,6 +1282,32 @@ function buildAutoApprovalEvent(
   }
 }
 
+function buildSkippedAutoApprovalEvent(
+  assignment: ApprovalGraphAssignment,
+  approvalMode: ApprovalMode,
+  policy: EffectiveAutoApprovalPolicy,
+  conflictBranches: string[],
+): ApprovalGraphAutoApprovalEvent {
+  const actorMode = getAutoApprovalActorMode(policy.policy)
+  return {
+    nodeKey: assignment.nodeKey,
+    sourceStep: assignment.sourceStep,
+    approvalMode,
+    reason: 'auto-merge-adjacent',
+    metadata: {
+      skipped: true,
+      skipReason: 'cross_branch_adjacency_conflict',
+      conflictBranches,
+      policySource: policy.source,
+      originalApprover: {
+        type: assignment.assignmentType,
+        id: assignment.assigneeId,
+      },
+      actorMode,
+    },
+  }
+}
+
 function evaluateAutoApprovalAssignment(
   runtimeGraph: RuntimeGraph,
   executor: ApprovalGraphExecutor,
@@ -1334,6 +1373,23 @@ function evaluateAutoApprovalAssignment(
   }
 
   return null
+}
+
+function evaluateSkippedCrossBranchAdjacent(
+  runtimeGraph: RuntimeGraph,
+  executor: ApprovalGraphExecutor,
+  assignment: ApprovalGraphAssignment,
+  conflictBranches: string[],
+): ApprovalGraphAutoApprovalEvent | null {
+  if (assignment.assignmentType !== 'user') return null
+  const effectivePolicy = getEffectiveAutoApprovalPolicy(runtimeGraph, assignment.nodeKey)
+  if (!effectivePolicy?.policy.mergeAdjacentApprover) return null
+  return buildSkippedAutoApprovalEvent(
+    assignment,
+    executor.getApprovalMode(assignment.nodeKey),
+    effectivePolicy,
+    conflictBranches,
+  )
 }
 
 function actorIdForAutoApprovalEvent(event: ApprovalGraphAutoApprovalEvent): string {
@@ -1423,9 +1479,29 @@ export class ApprovalProductService {
       reasonChain.push(event.reason)
       appendAutoApprovalHistory(history, event)
     }
+    const blockedAutoAssignmentKeys = new Set<string>()
 
     while (resolution.status === 'pending' && resolution.assignments.length > 0) {
       const candidateNodeKeys = Array.from(new Set(resolution.assignments.map((assignment) => assignment.nodeKey)))
+      if (resolution.parallelState && resolution.currentNodeKey === resolution.parallelState.parallelNodeKey) {
+        const parallelStep = this.applyParallelAutoApprovalStep(
+          runtimeGraph,
+          executor,
+          resolution,
+          requesterId,
+          history,
+          autoSteps,
+          reasonChain,
+          instanceId,
+          blockedAutoAssignmentKeys,
+        )
+        if (!parallelStep.changed) {
+          return resolution
+        }
+        resolution = parallelStep.resolution
+        autoSteps = parallelStep.autoSteps
+        continue
+      }
       if (candidateNodeKeys.length !== 1) {
         return resolution
       }
@@ -1435,6 +1511,8 @@ export class ApprovalProductService {
       }
 
       const evaluations = resolution.assignments
+        .filter((assignment) =>
+          !blockedAutoAssignmentKeys.has(`${assignment.nodeKey}:${assignment.assignmentType}:${assignment.assigneeId}`))
         .map((assignment) => evaluateAutoApprovalAssignment(runtimeGraph, executor, assignment, requesterId, history))
         .filter((entry): entry is AutoApprovalEvaluation => Boolean(entry))
       if (evaluations.length === 0) {
@@ -1507,6 +1585,126 @@ export class ApprovalProductService {
     }
 
     return resolution
+  }
+
+  private applyParallelAutoApprovalStep(
+    runtimeGraph: RuntimeGraph,
+    executor: ApprovalGraphExecutor,
+    resolution: ApprovalGraphResolution,
+    requesterId: string | null,
+    history: ApprovalHistoryEntry[],
+    autoSteps: number,
+    reasonChain: ApprovalAutoApprovalReason[],
+    instanceId: string,
+    blockedAutoAssignmentKeys: Set<string>,
+  ): { changed: boolean; resolution: ApprovalGraphResolution; autoSteps: number } {
+    if (!resolution.parallelState) {
+      return { changed: false, resolution, autoSteps }
+    }
+
+    const evaluations = resolution.assignments
+      .filter((assignment) =>
+        !blockedAutoAssignmentKeys.has(`${assignment.nodeKey}:${assignment.assignmentType}:${assignment.assigneeId}`))
+      .map((assignment) => evaluateAutoApprovalAssignment(runtimeGraph, executor, assignment, requesterId, history))
+      .filter((entry): entry is AutoApprovalEvaluation => Boolean(entry))
+    if (evaluations.length === 0) {
+      return { changed: false, resolution, autoSteps }
+    }
+
+    const firstByAssignee = new Map<string, AutoApprovalEvaluation>()
+    const skippedEvents: ApprovalGraphAutoApprovalEvent[] = []
+    for (const evaluation of evaluations) {
+      const key = `${evaluation.assignment.assignmentType}:${evaluation.assignment.assigneeId}`
+      const existing = firstByAssignee.get(key)
+      if (!existing) {
+        firstByAssignee.set(key, evaluation)
+        continue
+      }
+      const skipped = evaluateSkippedCrossBranchAdjacent(
+        runtimeGraph,
+        executor,
+        evaluation.assignment,
+        [existing.assignment.nodeKey, evaluation.assignment.nodeKey],
+      )
+      if (skipped) {
+        skippedEvents.push(skipped)
+        blockedAutoAssignmentKeys.add(
+          `${evaluation.assignment.nodeKey}:${evaluation.assignment.assignmentType}:${evaluation.assignment.assigneeId}`,
+        )
+      }
+    }
+
+    if (skippedEvents.length > 0) {
+      resolution = {
+        ...resolution,
+        autoApprovalEvents: [...resolution.autoApprovalEvents, ...skippedEvents],
+      }
+    }
+
+    const evaluation = [...firstByAssignee.values()][0]
+    if (!evaluation) {
+      return { changed: skippedEvents.length > 0, resolution, autoSteps }
+    }
+
+    autoSteps += 1
+    reasonChain.push(evaluation.event.reason)
+    if (autoSteps > APPROVAL_MAX_AUTO_STEPS) {
+      throw new ServiceError(
+        'Approval auto-approval step limit exceeded',
+        500,
+        'APPROVAL_AUTO_STEP_LIMIT_EXCEEDED',
+        {
+          instanceId,
+          autoSteps,
+          lastNodeKey: evaluation.assignment.nodeKey,
+          reasonChain,
+        },
+      )
+    }
+    appendAutoApprovalHistory(history, evaluation.event)
+
+    const branchResolution = executor.resolveAfterApproveInParallel(
+      evaluation.assignment.nodeKey,
+      resolution.parallelState,
+    )
+    autoSteps += branchResolution.autoApprovalEvents.length
+    reasonChain.push(...branchResolution.autoApprovalEvents.map((event) => event.reason))
+    if (autoSteps > APPROVAL_MAX_AUTO_STEPS) {
+      throw new ServiceError(
+        'Approval auto-approval step limit exceeded',
+        500,
+        'APPROVAL_AUTO_STEP_LIMIT_EXCEEDED',
+        {
+          instanceId,
+          autoSteps,
+          lastNodeKey: branchResolution.currentNodeKey,
+          reasonChain,
+        },
+      )
+    }
+    for (const event of branchResolution.autoApprovalEvents) {
+      appendAutoApprovalHistory(history, event)
+    }
+
+    const remainingAssignments = resolution.assignments.filter((assignment) =>
+      assignment.nodeKey !== evaluation.assignment.nodeKey
+      || assignment.assignmentType !== evaluation.assignment.assignmentType
+      || assignment.assigneeId !== evaluation.assignment.assigneeId)
+
+    return {
+      changed: true,
+      autoSteps,
+      resolution: {
+        ...branchResolution,
+        assignments: [...remainingAssignments, ...branchResolution.assignments],
+        ccEvents: [...resolution.ccEvents, ...branchResolution.ccEvents],
+        autoApprovalEvents: [
+          ...resolution.autoApprovalEvents,
+          evaluation.event,
+          ...branchResolution.autoApprovalEvents,
+        ],
+      },
+    }
   }
 
   async listTemplates(query: ApprovalTemplateListQuery): Promise<{ data: ApprovalTemplateListItemDTO[]; total: number }> {
@@ -2974,8 +3172,9 @@ export class ApprovalProductService {
     autoApprovalEvents: ApprovalGraphAutoApprovalEvent[],
   ): Promise<void> {
     for (const event of autoApprovalEvents) {
+      const skipped = event.metadata?.skipped === true
       await this.insertApprovalRecord(client, instanceId, {
-        action: 'approve',
+        action: skipped ? 'sign' : 'approve',
         actorId: actorIdForAutoApprovalEvent(event),
         actorName: actorNameForAutoApprovalEvent(event),
         comment: null,

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -1456,6 +1456,46 @@ export class ApprovalProductService {
     }
   }
 
+  async assertTemplateVersionDeletable(templateVersionId: string): Promise<void> {
+    if (!pool) throw new Error('Database not available')
+
+    const result = await pool.query<{
+      unfinished_count: string
+      sample_instance_id: string | null
+    }>(
+      `SELECT COUNT(*)::text AS unfinished_count,
+              MIN(id)::text AS sample_instance_id
+       FROM approval_instances
+       WHERE status NOT IN ('approved', 'rejected', 'revoked', 'cancelled')
+         AND (
+           template_version_id = $1
+           OR published_definition_id IN (
+             SELECT id
+             FROM approval_published_definitions
+             WHERE template_version_id = $1
+           )
+         )`,
+      [templateVersionId],
+    )
+
+    const row = result.rows[0]
+    const unfinishedCount = Number.parseInt(row?.unfinished_count ?? '0', 10)
+    if (unfinishedCount > 0) {
+      const sampleInstanceId = row?.sample_instance_id ?? null
+      const message = [
+        `Approval template version cannot be deleted or archived because ${unfinishedCount} `
+          + 'unfinished approval instance(s) still reference it.',
+        `Sample instance id: ${sampleInstanceId ?? 'unknown'}.`,
+      ].join(' ')
+      throw new ServiceError(
+        message,
+        409,
+        'APPROVAL_TEMPLATE_VERSION_IN_USE',
+        { unfinishedCount, sampleInstanceId },
+      )
+    }
+  }
+
   /**
    * Wave 2 WP4 slice 1 — list distinct, non-null categories used by templates
    * in `approval_templates`. Drives the template center dropdown filter.
@@ -2399,6 +2439,12 @@ export class ApprovalProductService {
     return this.loadTemplateBundleWithClient(pool, templateId, explicitVersionId, preferredVersion, actor)
   }
 
+  /**
+   * Loads template authoring/creation bundles where choosing the active or
+   * latest template version is intentional. Existing approval instances must
+   * not use this helper to advance; `dispatchAction()` loads the runtime graph
+   * from `instance.published_definition_id` to preserve version-freeze semantics.
+   */
   private async loadTemplateBundleWithClient(
     client: { query: typeof pool.query },
     templateId: string,

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -2,6 +2,11 @@ import crypto from 'crypto'
 import { pool } from '../db/pg'
 import type {
   ApprovalActionRequest,
+  ApprovalAutoApprovalReason,
+  AutoApprovalActorMode,
+  AutoApprovalMergeReason,
+  AutoApprovalPolicy,
+  AutoApprovalPolicySource,
   ApprovalTemplateDetailDTO,
   ApprovalTemplateListItemDTO,
   ApprovalTemplateVisibilityScope,
@@ -19,9 +24,12 @@ import type {
   RuntimePolicy,
   UpdateApprovalTemplateRequest,
 } from '../types/approval-product'
+import { APPROVAL_TERMINAL_STATUSES } from '../types/approval-product'
 import {
   ApprovalGraphExecutor,
+  type ApprovalGraphAssignment,
   type ApprovalGraphAutoApprovalEvent,
+  type ApprovalGraphResolution,
   type ParallelInstanceState,
   pruneHiddenFormData,
   validateApprovalFormData,
@@ -166,6 +174,23 @@ type ApprovalRecordInsert = {
   targetUserId?: string | null
 }
 
+type ApprovalHistoryEntry = {
+  nodeKey: string
+  actorId: string
+  recordId?: string
+  reason?: ApprovalAutoApprovalReason | string
+}
+
+type AutoApprovalEvaluation = {
+  assignment: ApprovalGraphAssignment
+  event: ApprovalGraphAutoApprovalEvent
+}
+
+type EffectiveAutoApprovalPolicy = {
+  policy: AutoApprovalPolicy
+  source: AutoApprovalPolicySource
+}
+
 type ApprovalDbClient = {
   query: typeof pool.query
   release: () => void
@@ -213,6 +238,8 @@ const CONDITION_OPERATORS = new Set(['eq', 'neq', 'gt', 'gte', 'lt', 'lte', 'in'
 const APPROVAL_MODES = new Set<ApprovalMode>(['single', 'all', 'any'])
 const PARALLEL_JOIN_MODES = new Set(['all', 'any'])
 const EMPTY_ASSIGNEE_POLICIES = new Set<EmptyAssigneePolicy>(['error', 'auto-approve'])
+const AUTO_APPROVAL_ACTOR_MODES = new Set<AutoApprovalActorMode>(['system', 'original_approver'])
+const APPROVAL_MAX_AUTO_STEPS = 50
 
 function toNullableRecord(value: unknown): Record<string, unknown> | null {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
@@ -246,6 +273,56 @@ function normalizeEmptyAssigneePolicy(
     failValidation(context, `${path} must be error or auto-approve`)
   }
   return value as EmptyAssigneePolicy
+}
+
+function normalizeOptionalBoolean(
+  value: unknown,
+  context: ValidationContext,
+  path: string,
+): boolean | undefined {
+  if (value === undefined) return undefined
+  if (typeof value !== 'boolean') {
+    failValidation(context, `${path} must be a boolean`)
+  }
+  return value
+}
+
+function normalizeAutoApprovalPolicy(
+  value: unknown,
+  context: ValidationContext,
+  path: string,
+): AutoApprovalPolicy | undefined {
+  if (value === undefined) return undefined
+  if (!isRecord(value)) {
+    failValidation(context, `${path} must be an object`)
+  }
+
+  const mergeWithRequester = normalizeOptionalBoolean(
+    value.mergeWithRequester,
+    context,
+    `${path}.mergeWithRequester`,
+  )
+  const mergeAdjacentApprover = normalizeOptionalBoolean(
+    value.mergeAdjacentApprover,
+    context,
+    `${path}.mergeAdjacentApprover`,
+  )
+  const dedupeHistoricalApprover = normalizeOptionalBoolean(
+    value.dedupeHistoricalApprover,
+    context,
+    `${path}.dedupeHistoricalApprover`,
+  )
+  if (value.actorMode !== undefined
+    && (typeof value.actorMode !== 'string' || !AUTO_APPROVAL_ACTOR_MODES.has(value.actorMode as AutoApprovalActorMode))) {
+    failValidation(context, `${path}.actorMode must be system or original_approver`)
+  }
+
+  return {
+    ...(mergeWithRequester !== undefined ? { mergeWithRequester } : {}),
+    ...(mergeAdjacentApprover !== undefined ? { mergeAdjacentApprover } : {}),
+    ...(dedupeHistoricalApprover !== undefined ? { dedupeHistoricalApprover } : {}),
+    ...(value.actorMode ? { actorMode: value.actorMode as AutoApprovalActorMode } : {}),
+  }
 }
 
 function failValidation(context: ValidationContext, message: string): never {
@@ -490,11 +567,17 @@ function normalizeApprovalGraph(value: unknown, context: ValidationContext): App
             context,
             `approvalGraph.nodes[${index}].config.emptyAssigneePolicy`,
           )
+          const autoApprovalPolicy = normalizeAutoApprovalPolicy(
+            node.config.autoApprovalPolicy,
+            context,
+            `approvalGraph.nodes[${index}].config.autoApprovalPolicy`,
+          )
           normalizedNode.config = {
             assigneeType: node.config.assigneeType,
             assigneeIds: node.config.assigneeIds.map((entry) => entry.trim()),
             ...(approvalMode ? { approvalMode } : {}),
             ...(emptyAssigneePolicy ? { emptyAssigneePolicy } : {}),
+            ...(autoApprovalPolicy ? { autoApprovalPolicy } : {}),
           }
         }
         break
@@ -1009,7 +1092,7 @@ function assertRuntimePolicy(
   value: unknown,
   context: ValidationContext = REQUEST_VALIDATION_CONTEXT,
 ): RuntimePolicy {
-  const policy = value as { allowRevoke?: unknown; revokeBeforeNodeKeys?: unknown } | null
+  const policy = value as { allowRevoke?: unknown; revokeBeforeNodeKeys?: unknown; autoApproval?: unknown } | null
   if (typeof value !== 'object' || value === null || typeof policy?.allowRevoke !== 'boolean') {
     failValidation(context, 'policy.allowRevoke is required')
   }
@@ -1020,11 +1103,13 @@ function assertRuntimePolicy(
   ) {
     failValidation(context, 'policy.revokeBeforeNodeKeys must be a string array')
   }
+  const autoApproval = normalizeAutoApprovalPolicy(policy.autoApproval, context, 'policy.autoApproval')
   return {
     allowRevoke: policy.allowRevoke,
     revokeBeforeNodeKeys: Array.isArray(policy.revokeBeforeNodeKeys)
       ? policy.revokeBeforeNodeKeys.map((item) => item.trim())
       : undefined,
+    ...(autoApproval ? { autoApproval } : {}),
   }
 }
 
@@ -1055,6 +1140,7 @@ function buildRuntimeGraph(approvalGraph: ApprovalGraph, policy: RuntimePolicy):
     policy: {
       allowRevoke: policy.allowRevoke,
       ...(policy.revokeBeforeNodeKeys ? { revokeBeforeNodeKeys: [...policy.revokeBeforeNodeKeys] } : {}),
+      ...(policy.autoApproval ? { autoApproval: { ...policy.autoApproval } } : {}),
     },
   })
 }
@@ -1108,12 +1194,320 @@ function readParallelBranchStates(metadata: unknown): ParallelInstanceState | nu
   }
 }
 
+function hasEnabledAutoApprovalRule(policy: AutoApprovalPolicy | undefined): policy is AutoApprovalPolicy {
+  return Boolean(
+    policy?.mergeWithRequester ||
+    policy?.mergeAdjacentApprover ||
+    policy?.dedupeHistoricalApprover,
+  )
+}
+
+function getApprovalNodeConfig(runtimeGraph: RuntimeGraph, nodeKey: string): ApprovalGraph['nodes'][number]['config'] | null {
+  const node = runtimeGraph.nodes.find((entry) => entry.key === nodeKey)
+  return node?.type === 'approval' ? node.config : null
+}
+
+function getEffectiveAutoApprovalPolicy(
+  runtimeGraph: RuntimeGraph,
+  nodeKey: string,
+): EffectiveAutoApprovalPolicy | null {
+  const nodeConfig = getApprovalNodeConfig(runtimeGraph, nodeKey)
+  if (isRecord(nodeConfig) && nodeConfig.autoApprovalPolicy !== undefined) {
+    const policy = nodeConfig.autoApprovalPolicy as AutoApprovalPolicy
+    return hasEnabledAutoApprovalRule(policy) ? { policy, source: 'node' } : null
+  }
+  return hasEnabledAutoApprovalRule(runtimeGraph.policy.autoApproval)
+    ? { policy: runtimeGraph.policy.autoApproval, source: 'template' }
+    : null
+}
+
+function runtimeGraphHasAutoApprovalPolicy(runtimeGraph: RuntimeGraph): boolean {
+  return hasEnabledAutoApprovalRule(runtimeGraph.policy.autoApproval)
+    || runtimeGraph.nodes.some((node) => {
+      if (node.type !== 'approval' || !isRecord(node.config)) return false
+      return hasEnabledAutoApprovalRule(node.config.autoApprovalPolicy as AutoApprovalPolicy | undefined)
+    })
+}
+
+function getAutoApprovalActorMode(policy: AutoApprovalPolicy): AutoApprovalActorMode {
+  return policy.actorMode ?? 'system'
+}
+
+function findLatestApprovalHistory(
+  history: ApprovalHistoryEntry[],
+  predicate: (entry: ApprovalHistoryEntry) => boolean,
+): ApprovalHistoryEntry | null {
+  for (let index = history.length - 1; index >= 0; index -= 1) {
+    const entry = history[index]
+    if (predicate(entry)) return entry
+  }
+  return null
+}
+
+function buildAutoApprovalEvent(
+  assignment: ApprovalGraphAssignment,
+  approvalMode: ApprovalMode,
+  reason: AutoApprovalMergeReason,
+  policy: EffectiveAutoApprovalPolicy,
+  matchedAgainst?: { nodeKey: string; recordId?: string },
+): ApprovalGraphAutoApprovalEvent {
+  const actorMode = getAutoApprovalActorMode(policy.policy)
+  return {
+    nodeKey: assignment.nodeKey,
+    sourceStep: assignment.sourceStep,
+    approvalMode,
+    reason,
+    metadata: {
+      policySource: policy.source,
+      originalApprover: {
+        type: assignment.assignmentType,
+        id: assignment.assigneeId,
+      },
+      ...(matchedAgainst ? { matchedAgainst } : {}),
+      actorMode,
+    },
+  }
+}
+
+function evaluateAutoApprovalAssignment(
+  runtimeGraph: RuntimeGraph,
+  executor: ApprovalGraphExecutor,
+  assignment: ApprovalGraphAssignment,
+  requesterId: string | null,
+  history: ApprovalHistoryEntry[],
+): AutoApprovalEvaluation | null {
+  if (assignment.assignmentType !== 'user') return null
+
+  const effectivePolicy = getEffectiveAutoApprovalPolicy(runtimeGraph, assignment.nodeKey)
+  if (!effectivePolicy) return null
+
+  const approvalMode = executor.getApprovalMode(assignment.nodeKey)
+  if (effectivePolicy.policy.mergeWithRequester && requesterId && assignment.assigneeId === requesterId) {
+    return {
+      assignment,
+      event: buildAutoApprovalEvent(assignment, approvalMode, 'auto-merge-requester', effectivePolicy),
+    }
+  }
+
+  if (effectivePolicy.policy.mergeAdjacentApprover) {
+    const adjacent = findLatestApprovalHistory(
+      history,
+      (entry) => entry.nodeKey !== assignment.nodeKey,
+    )
+    if (adjacent?.actorId === assignment.assigneeId) {
+      return {
+        assignment,
+        event: buildAutoApprovalEvent(
+          assignment,
+          approvalMode,
+          'auto-merge-adjacent',
+          effectivePolicy,
+          {
+            nodeKey: adjacent.nodeKey,
+            ...(adjacent.recordId ? { recordId: adjacent.recordId } : {}),
+          },
+        ),
+      }
+    }
+  }
+
+  if (effectivePolicy.policy.dedupeHistoricalApprover) {
+    const historical = findLatestApprovalHistory(
+      history,
+      (entry) => entry.nodeKey !== assignment.nodeKey && entry.actorId === assignment.assigneeId,
+    )
+    if (historical) {
+      return {
+        assignment,
+        event: buildAutoApprovalEvent(
+          assignment,
+          approvalMode,
+          'auto-dedupe-historical',
+          effectivePolicy,
+          {
+            nodeKey: historical.nodeKey,
+            ...(historical.recordId ? { recordId: historical.recordId } : {}),
+          },
+        ),
+      }
+    }
+  }
+
+  return null
+}
+
+function actorIdForAutoApprovalEvent(event: ApprovalGraphAutoApprovalEvent): string {
+  const metadata = event.metadata ?? {}
+  if (metadata.actorMode === 'original_approver' && isRecord(metadata.originalApprover)) {
+    const id = metadata.originalApprover.id
+    if (typeof id === 'string' && id.trim().length > 0) return id
+  }
+  return 'system:auto-approval'
+}
+
+function actorNameForAutoApprovalEvent(event: ApprovalGraphAutoApprovalEvent): string {
+  return actorIdForAutoApprovalEvent(event) === 'system:auto-approval'
+    ? 'System Auto Approval'
+    : actorIdForAutoApprovalEvent(event)
+}
+
+function appendAutoApprovalHistory(history: ApprovalHistoryEntry[], event: ApprovalGraphAutoApprovalEvent): void {
+  const originalApprover = isRecord(event.metadata?.originalApprover)
+    ? event.metadata.originalApprover
+    : null
+  const originalApproverId = typeof originalApprover?.id === 'string' ? originalApprover.id : null
+  history.push({
+    nodeKey: event.nodeKey,
+    actorId: originalApproverId || actorIdForAutoApprovalEvent(event),
+    reason: event.reason,
+  })
+}
+
 export class ApprovalProductService {
   /**
    * Wave 2 WP5 slice 1 — optional metrics service injection so tests can
    * pass a stub. Production default uses the process-wide singleton.
    */
   constructor(private readonly metrics: ApprovalMetricsService = getApprovalMetricsService()) {}
+
+  private async loadApprovalHistory(
+    client: { query: typeof pool.query },
+    instanceId: string,
+  ): Promise<ApprovalHistoryEntry[]> {
+    const result = await client.query<{
+      id: string | number
+      actor_id: string
+      metadata: Record<string, unknown> | null
+    }>(
+      `SELECT id, actor_id, metadata
+       FROM approval_records
+       WHERE instance_id = $1
+         AND action = 'approve'
+       ORDER BY occurred_at ASC, id ASC`,
+      [instanceId],
+    )
+
+    const entries: Array<ApprovalHistoryEntry | null> = result.rows
+      .map((row): ApprovalHistoryEntry | null => {
+        const metadata = toNullableRecord(row.metadata)
+        const nodeKey = typeof metadata?.nodeKey === 'string' ? metadata.nodeKey : null
+        if (!nodeKey) return null
+        const originalApprover = toNullableRecord(metadata?.originalApprover)
+        const originalApproverId = typeof originalApprover?.id === 'string' ? originalApprover.id : null
+        return {
+          nodeKey,
+          actorId: originalApproverId || row.actor_id,
+          recordId: String(row.id),
+          reason: typeof metadata?.reason === 'string' ? metadata.reason : undefined,
+        }
+      })
+    return entries.filter((entry): entry is ApprovalHistoryEntry => Boolean(entry))
+  }
+
+  private applyAutoApprovalCascade(
+    instanceId: string,
+    runtimeGraph: RuntimeGraph,
+    executor: ApprovalGraphExecutor,
+    initialResolution: ApprovalGraphResolution,
+    requesterId: string | null,
+    history: ApprovalHistoryEntry[],
+  ): ApprovalGraphResolution {
+    let resolution: ApprovalGraphResolution = {
+      ...initialResolution,
+      autoApprovalEvents: [...initialResolution.autoApprovalEvents],
+      assignments: [...initialResolution.assignments],
+    }
+    let autoSteps = resolution.autoApprovalEvents.length
+    const reasonChain: ApprovalAutoApprovalReason[] = []
+    for (const event of resolution.autoApprovalEvents) {
+      reasonChain.push(event.reason)
+      appendAutoApprovalHistory(history, event)
+    }
+
+    while (resolution.status === 'pending' && resolution.assignments.length > 0) {
+      const candidateNodeKeys = Array.from(new Set(resolution.assignments.map((assignment) => assignment.nodeKey)))
+      if (candidateNodeKeys.length !== 1) {
+        return resolution
+      }
+      const nodeKey = candidateNodeKeys[0]
+      if (resolution.currentNodeKey !== nodeKey) {
+        return resolution
+      }
+
+      const evaluations = resolution.assignments
+        .map((assignment) => evaluateAutoApprovalAssignment(runtimeGraph, executor, assignment, requesterId, history))
+        .filter((entry): entry is AutoApprovalEvaluation => Boolean(entry))
+      if (evaluations.length === 0) {
+        return resolution
+      }
+
+      autoSteps += evaluations.length
+      reasonChain.push(...evaluations.map((entry) => entry.event.reason))
+      if (autoSteps > APPROVAL_MAX_AUTO_STEPS) {
+        throw new ServiceError(
+          'Approval auto-approval step limit exceeded',
+          500,
+          'APPROVAL_AUTO_STEP_LIMIT_EXCEEDED',
+          {
+            instanceId,
+            autoSteps,
+            lastNodeKey: nodeKey,
+            reasonChain,
+          },
+        )
+      }
+
+      const autoAssignmentKeys = new Set(
+        evaluations.map((entry) => `${entry.assignment.assignmentType}:${entry.assignment.assigneeId}`),
+      )
+      const remainingAssignments = resolution.assignments.filter((assignment) =>
+        !autoAssignmentKeys.has(`${assignment.assignmentType}:${assignment.assigneeId}`))
+      resolution = {
+        ...resolution,
+        autoApprovalEvents: [...resolution.autoApprovalEvents, ...evaluations.map((entry) => entry.event)],
+      }
+      for (const evaluation of evaluations) {
+        appendAutoApprovalHistory(history, evaluation.event)
+      }
+
+      const approvalMode = executor.getApprovalMode(nodeKey)
+      if (approvalMode === 'all' && remainingAssignments.length > 0) {
+        return {
+          ...resolution,
+          assignments: remainingAssignments,
+        }
+      }
+
+      const nextResolution = executor.resolveAfterApprove(nodeKey)
+      autoSteps += nextResolution.autoApprovalEvents.length
+      reasonChain.push(...nextResolution.autoApprovalEvents.map((event) => event.reason))
+      if (autoSteps > APPROVAL_MAX_AUTO_STEPS) {
+        throw new ServiceError(
+          'Approval auto-approval step limit exceeded',
+          500,
+          'APPROVAL_AUTO_STEP_LIMIT_EXCEEDED',
+          {
+            instanceId,
+            autoSteps,
+            lastNodeKey: nextResolution.currentNodeKey,
+            reasonChain,
+          },
+        )
+      }
+      for (const event of nextResolution.autoApprovalEvents) {
+        appendAutoApprovalHistory(history, event)
+      }
+      resolution = {
+        ...nextResolution,
+        autoApprovalEvents: [
+          ...resolution.autoApprovalEvents,
+          ...nextResolution.autoApprovalEvents,
+        ],
+      }
+    }
+
+    return resolution
+  }
 
   async listTemplates(query: ApprovalTemplateListQuery): Promise<{ data: ApprovalTemplateListItemDTO[]; total: number }> {
     if (!pool) throw new Error('Database not available')
@@ -1466,16 +1860,17 @@ export class ApprovalProductService {
       `SELECT COUNT(*)::text AS unfinished_count,
               MIN(id)::text AS sample_instance_id
        FROM approval_instances
-       WHERE status NOT IN ('approved', 'rejected', 'revoked', 'cancelled')
+       WHERE status <> ALL($2::text[])
          AND (
            template_version_id = $1
+           -- Defend historical rows where only one version reference column was backfilled.
            OR published_definition_id IN (
              SELECT id
              FROM approval_published_definitions
              WHERE template_version_id = $1
            )
          )`,
-      [templateVersionId],
+      [templateVersionId, [...APPROVAL_TERMINAL_STATUSES]],
     )
 
     const row = result.rows[0]
@@ -1664,8 +2059,11 @@ export class ApprovalProductService {
 
     const runtimeGraph = asRuntimeGraph(bundle.publishedDefinition.runtime_graph)
     const executor = new ApprovalGraphExecutor(runtimeGraph, normalizedFormData)
-    const initial = executor.resolveInitialState()
     const instanceId = crypto.randomUUID()
+    const initialResolution = executor.resolveInitialState()
+    const initial = runtimeGraphHasAutoApprovalPolicy(runtimeGraph)
+      ? this.applyAutoApprovalCascade(instanceId, runtimeGraph, executor, initialResolution, actor.userId, [])
+      : initialResolution
     const requestNo = await this.allocateRequestNo()
 
     const requesterSnapshot = {
@@ -1996,7 +2394,18 @@ export class ApprovalProductService {
         }
 
         await this.deactivateAllActiveAssignments(client, id)
-        const resolution = executor.resolveReturnToNode(targetNodeKey)
+        const returnResolution = executor.resolveReturnToNode(targetNodeKey)
+        const requesterId = toNullableRecord(instance.requester_snapshot)?.id
+        const resolution = runtimeGraphHasAutoApprovalPolicy(runtimeGraph)
+          ? this.applyAutoApprovalCascade(
+              id,
+              runtimeGraph,
+              executor,
+              returnResolution,
+              typeof requesterId === 'string' ? requesterId : null,
+              await this.loadApprovalHistory(client, id),
+            )
+          : returnResolution
         await client.query(
           `UPDATE approval_instances
            SET status = $2,
@@ -2148,9 +2557,25 @@ export class ApprovalProductService {
         }
       }
 
-      const resolution = isInParallelRegion && parallelState && actorBranchNodeKey
+      let resolution = isInParallelRegion && parallelState && actorBranchNodeKey
         ? executor.resolveAfterApproveInParallel(actorBranchNodeKey, parallelState)
         : executor.resolveAfterApprove(currentNodeKey)
+      if (runtimeGraphHasAutoApprovalPolicy(runtimeGraph)) {
+        const approvalHistory = await this.loadApprovalHistory(client, id)
+        approvalHistory.push({
+          nodeKey: currentNodeKey,
+          actorId: actor.userId,
+        })
+        const requesterId = toNullableRecord(instance.requester_snapshot)?.id
+        resolution = this.applyAutoApprovalCascade(
+          id,
+          runtimeGraph,
+          executor,
+          resolution,
+          typeof requesterId === 'string' ? requesterId : null,
+          approvalHistory,
+        )
+      }
 
       const parallelAnyWinner =
         isInParallelRegion
@@ -2551,8 +2976,8 @@ export class ApprovalProductService {
     for (const event of autoApprovalEvents) {
       await this.insertApprovalRecord(client, instanceId, {
         action: 'approve',
-        actorId: 'system',
-        actorName: 'System',
+        actorId: actorIdForAutoApprovalEvent(event),
+        actorName: actorNameForAutoApprovalEvent(event),
         comment: null,
         fromStatus: status,
         toStatus: status,
@@ -2564,6 +2989,7 @@ export class ApprovalProductService {
           approvalMode: event.approvalMode,
           autoApproved: true,
           reason: event.reason,
+          ...(event.metadata ?? {}),
         },
       })
     }

--- a/packages/core-backend/src/types/approval-product.ts
+++ b/packages/core-backend/src/types/approval-product.ts
@@ -14,6 +14,8 @@ export type ParallelJoinMode = 'all' | 'any'
 export type EmptyAssigneePolicy = 'error' | 'auto-approve'
 export type ApprovalActionType = 'approve' | 'reject' | 'transfer' | 'revoke' | 'comment' | 'return'
 export type ApprovalStatus = 'draft' | 'pending' | 'approved' | 'rejected' | 'revoked' | 'cancelled'
+export const APPROVAL_TERMINAL_STATUSES = ['approved', 'rejected', 'revoked', 'cancelled'] as const
+export type ApprovalTerminalStatus = typeof APPROVAL_TERMINAL_STATUSES[number]
 export type ApprovalTemplateStatus = 'draft' | 'published' | 'archived'
 export type ApprovalTemplateVisibilityType = 'all' | 'dept' | 'role' | 'user'
 export type FormFieldVisibilityOperator = 'eq' | 'neq' | 'in' | 'isEmpty' | 'notEmpty'
@@ -45,6 +47,7 @@ export interface ApprovalNodeConfig {
   assigneeIds: string[]
   approvalMode?: ApprovalMode
   emptyAssigneePolicy?: EmptyAssigneePolicy
+  autoApprovalPolicy?: AutoApprovalPolicy
 }
 
 export interface ConditionNodeConfig {
@@ -95,7 +98,23 @@ export interface ApprovalGraph {
 export interface RuntimePolicy {
   allowRevoke: boolean
   revokeBeforeNodeKeys?: string[]
+  autoApproval?: AutoApprovalPolicy
 }
+
+export interface AutoApprovalPolicy {
+  mergeWithRequester?: boolean
+  mergeAdjacentApprover?: boolean
+  dedupeHistoricalApprover?: boolean
+  actorMode?: AutoApprovalActorMode
+}
+
+export type AutoApprovalActorMode = 'system' | 'original_approver'
+export type AutoApprovalPolicySource = 'node' | 'template'
+export type AutoApprovalMergeReason =
+  | 'auto-merge-requester'
+  | 'auto-merge-adjacent'
+  | 'auto-dedupe-historical'
+export type ApprovalAutoApprovalReason = 'empty-assignee' | AutoApprovalMergeReason
 
 export interface RuntimeGraph extends ApprovalGraph {
   policy: RuntimePolicy

--- a/packages/core-backend/tests/integration/approval-pack1a-lifecycle.api.test.ts
+++ b/packages/core-backend/tests/integration/approval-pack1a-lifecycle.api.test.ts
@@ -447,7 +447,9 @@ describe('Approval Pack 1A lifecycle API', () => {
       [createdApproval.id],
     )
     const autoApproveRecord = historyResult.rows.find((row) =>
-      row.action === 'approve' && row.actor_id === 'system' && row.metadata?.autoApproved === true)
+      row.action === 'approve'
+      && row.metadata?.autoApproved === true
+      && row.metadata?.reason === 'empty-assignee')
     expect(autoApproveRecord).toBeTruthy()
     expect(autoApproveRecord?.to_status).toBe('pending')
     expect(autoApproveRecord?.metadata).toMatchObject({

--- a/packages/core-backend/tests/unit/approval-product-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-product-service.test.ts
@@ -489,6 +489,9 @@ describe('ApprovalProductService', () => {
       if (statement.startsWith('UPDATE approval_assignments SET is_active = FALSE')) {
         return { rows: [], rowCount: 1 }
       }
+      if (statement.startsWith('UPDATE approval_instances SET metadata = COALESCE')) {
+        return { rows: [], rowCount: 1 }
+      }
       if (statement.startsWith('UPDATE approval_instances SET status = $2')) {
         return { rows: [], rowCount: 1 }
       }
@@ -1811,6 +1814,9 @@ describe('ApprovalProductService', () => {
       if (statement.startsWith('UPDATE approval_assignments SET is_active = FALSE')) {
         return { rows: [], rowCount: 1 }
       }
+      if (statement.startsWith('UPDATE approval_instances SET metadata = COALESCE')) {
+        return { rows: [], rowCount: 1 }
+      }
       if (statement.startsWith('UPDATE approval_instances SET status = $2')) {
         return { rows: [], rowCount: 1 }
       }
@@ -2101,6 +2107,295 @@ describe('ApprovalProductService', () => {
       statement.startsWith('UPDATE approval_instances SET status = $2'))).toBe(false)
     expect(statements.some((statement) =>
       statement.startsWith('INSERT INTO approval_records'))).toBe(false)
+  })
+
+  it('auto-approves independent parallel branches without duplicate active assignments', async () => {
+    const runtimeGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        { key: 'approval_gate', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['lead-1'] } },
+        {
+          key: 'parallel_fork',
+          type: 'parallel',
+          config: {
+            branches: ['edge-fork-legal', 'edge-fork-compliance'],
+            joinMode: 'all',
+            joinNodeKey: 'end',
+          },
+        },
+        { key: 'legal-review', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['manager-1'] } },
+        { key: 'compliance-review', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['manager-2'] } },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-gate', source: 'start', target: 'approval_gate' },
+        { key: 'edge-gate-fork', source: 'approval_gate', target: 'parallel_fork' },
+        { key: 'edge-fork-legal', source: 'parallel_fork', target: 'legal-review' },
+        { key: 'edge-fork-compliance', source: 'parallel_fork', target: 'compliance-review' },
+        { key: 'edge-legal-end', source: 'legal-review', target: 'end' },
+        { key: 'edge-compliance-end', source: 'compliance-review', target: 'end' },
+      ],
+      policy: {
+        allowRevoke: true,
+        autoApproval: {
+          dedupeHistoricalApprover: true,
+        },
+      },
+    }
+
+    pgState.client.query.mockImplementation(async (sql: string) => {
+      const statement = normalize(sql)
+      if (statement === 'BEGIN' || statement === 'COMMIT' || statement === 'ROLLBACK') {
+        return { rows: [], rowCount: 0 }
+      }
+      if (statement.startsWith('SELECT * FROM approval_instances WHERE id = $1')) {
+        return {
+          rows: [buildInstanceRow({
+            current_node_key: 'approval_gate',
+            current_step: 1,
+            total_steps: 3,
+          })],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith('SELECT * FROM approval_published_definitions WHERE id = $1')) {
+        return {
+          rows: [{
+            id: 'pub-1',
+            template_id: 'tpl-1',
+            template_version_id: 'ver-1',
+            runtime_graph: runtimeGraph,
+            is_active: true,
+            published_at: new Date(),
+          }],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith('SELECT * FROM approval_assignments WHERE instance_id = $1')) {
+        return {
+          rows: [{
+            id: 'asg-gate',
+            instance_id: 'apr-1',
+            assignment_type: 'user',
+            assignee_id: 'lead-1',
+            source_step: 1,
+            node_key: 'approval_gate',
+            is_active: true,
+            metadata: {},
+            created_at: new Date(),
+            updated_at: new Date(),
+          }],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith('SELECT id, actor_id, metadata FROM approval_records')) {
+        return {
+          rows: [
+            { id: 10, actor_id: 'manager-1', metadata: { nodeKey: 'prior-legal' } },
+            { id: 11, actor_id: 'manager-2', metadata: { nodeKey: 'prior-compliance' } },
+          ],
+          rowCount: 2,
+        }
+      }
+      if (statement.startsWith('UPDATE approval_assignments SET is_active = FALSE')) {
+        return { rows: [], rowCount: 1 }
+      }
+      if (statement.startsWith('UPDATE approval_instances SET status = $2')) {
+        return { rows: [], rowCount: 1 }
+      }
+      if (statement.startsWith('INSERT INTO approval_assignments')) {
+        return { rows: [], rowCount: 1 }
+      }
+      if (statement.startsWith('INSERT INTO approval_records')) {
+        return { rows: [], rowCount: 1 }
+      }
+      throw new Error(`Unhandled query: ${statement}`)
+    })
+
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const service = new ApprovalProductService(buildNoopMetrics() as never)
+    vi.spyOn(service, 'getApproval').mockResolvedValue(buildApprovalDto({
+      status: 'approved',
+      currentStep: 3,
+      totalSteps: 3,
+      currentNodeKey: null,
+      assignments: [],
+    }))
+
+    const result = await service.dispatchAction(
+      'apr-1',
+      { action: 'approve' },
+      { userId: 'lead-1' },
+    )
+
+    expect(result.status).toBe('approved')
+    expect(pgState.client.query.mock.calls.some(([sql]) =>
+      normalize(sql as string).startsWith('INSERT INTO approval_assignments'))).toBe(false)
+
+    const autoRecords = pgState.client.query.mock.calls
+      .filter(([sql, params]) =>
+        normalize(sql as string).startsWith('INSERT INTO approval_records') &&
+        JSON.parse(String(params?.[9])).reason === 'auto-dedupe-historical')
+      .map(([, params]) => JSON.parse(String(params?.[9])))
+
+    expect(autoRecords).toHaveLength(2)
+    expect(autoRecords.map((entry) => entry.nodeKey)).toEqual(['legal-review', 'compliance-review'])
+    expect(autoRecords.map((entry) => entry.matchedAgainst.nodeKey)).toEqual(['prior-legal', 'prior-compliance'])
+  })
+
+  it('refuses and warns when adjacent merge would auto-approve duplicate parallel assignees', async () => {
+    const runtimeGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        { key: 'approval_gate', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['manager-1'] } },
+        {
+          key: 'parallel_fork',
+          type: 'parallel',
+          config: {
+            branches: ['edge-fork-legal', 'edge-fork-compliance'],
+            joinMode: 'all',
+            joinNodeKey: 'end',
+          },
+        },
+        { key: 'legal-review', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['manager-1'] } },
+        { key: 'compliance-review', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['manager-1'] } },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-gate', source: 'start', target: 'approval_gate' },
+        { key: 'edge-gate-fork', source: 'approval_gate', target: 'parallel_fork' },
+        { key: 'edge-fork-legal', source: 'parallel_fork', target: 'legal-review' },
+        { key: 'edge-fork-compliance', source: 'parallel_fork', target: 'compliance-review' },
+        { key: 'edge-legal-end', source: 'legal-review', target: 'end' },
+        { key: 'edge-compliance-end', source: 'compliance-review', target: 'end' },
+      ],
+      policy: {
+        allowRevoke: true,
+        autoApproval: {
+          mergeAdjacentApprover: true,
+        },
+      },
+    }
+
+    pgState.client.query.mockImplementation(async (sql: string) => {
+      const statement = normalize(sql)
+      if (statement === 'BEGIN' || statement === 'COMMIT' || statement === 'ROLLBACK') {
+        return { rows: [], rowCount: 0 }
+      }
+      if (statement.startsWith('SELECT * FROM approval_instances WHERE id = $1')) {
+        return {
+          rows: [buildInstanceRow({
+            current_node_key: 'approval_gate',
+            current_step: 1,
+            total_steps: 3,
+          })],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith('SELECT * FROM approval_published_definitions WHERE id = $1')) {
+        return {
+          rows: [{
+            id: 'pub-1',
+            template_id: 'tpl-1',
+            template_version_id: 'ver-1',
+            runtime_graph: runtimeGraph,
+            is_active: true,
+            published_at: new Date(),
+          }],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith('SELECT * FROM approval_assignments WHERE instance_id = $1')) {
+        return {
+          rows: [{
+            id: 'asg-gate',
+            instance_id: 'apr-1',
+            assignment_type: 'user',
+            assignee_id: 'manager-1',
+            source_step: 1,
+            node_key: 'approval_gate',
+            is_active: true,
+            metadata: {},
+            created_at: new Date(),
+            updated_at: new Date(),
+          }],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith('SELECT id, actor_id, metadata FROM approval_records')) {
+        return { rows: [], rowCount: 0 }
+      }
+      if (statement.startsWith('UPDATE approval_assignments SET is_active = FALSE')) {
+        return { rows: [], rowCount: 1 }
+      }
+      if (statement.startsWith('UPDATE approval_instances SET metadata = COALESCE')) {
+        return { rows: [], rowCount: 1 }
+      }
+      if (statement.startsWith('UPDATE approval_instances SET status = $2')) {
+        return { rows: [], rowCount: 1 }
+      }
+      if (statement.startsWith('INSERT INTO approval_assignments')) {
+        return { rows: [], rowCount: 1 }
+      }
+      if (statement.startsWith('INSERT INTO approval_records')) {
+        return { rows: [], rowCount: 1 }
+      }
+      throw new Error(`Unhandled query: ${statement}`)
+    })
+
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const service = new ApprovalProductService(buildNoopMetrics() as never)
+    vi.spyOn(service, 'getApproval').mockResolvedValue(buildApprovalDto({
+      status: 'pending',
+      currentNodeKey: 'parallel_fork',
+      currentNodeKeys: ['compliance-review'],
+      assignments: [{
+        id: 'asg-compliance',
+        type: 'user',
+        assigneeId: 'manager-1',
+        sourceStep: 2,
+        nodeKey: 'compliance-review',
+        isActive: true,
+        metadata: {},
+      }],
+    }))
+
+    const result = await service.dispatchAction(
+      'apr-1',
+      { action: 'approve' },
+      { userId: 'manager-1' },
+    )
+
+    expect(result.status).toBe('pending')
+    const assignmentInserts = pgState.client.query.mock.calls.filter(([sql]) =>
+      normalize(sql as string).startsWith('INSERT INTO approval_assignments'))
+    expect(assignmentInserts).toHaveLength(1)
+    expect(assignmentInserts[0]?.[1]).toEqual(['apr-1', 'user', 'manager-1', 3, 'compliance-review'])
+
+    const skippedRecord = pgState.client.query.mock.calls.find(([sql, params]) =>
+      normalize(sql as string).startsWith('INSERT INTO approval_records') &&
+      JSON.parse(String(params?.[9])).skipReason === 'cross_branch_adjacency_conflict')
+    expect(skippedRecord?.[1]?.[1]).toBe('sign')
+    expect(JSON.parse(String(skippedRecord?.[1]?.[9]))).toMatchObject({
+      nodeKey: 'compliance-review',
+      reason: 'auto-merge-adjacent',
+      skipped: true,
+      skipReason: 'cross_branch_adjacency_conflict',
+      conflictBranches: ['legal-review', 'compliance-review'],
+      originalApprover: {
+        type: 'user',
+        id: 'manager-1',
+      },
+    })
+
+    const autoRecord = pgState.client.query.mock.calls.find(([sql, params]) =>
+      normalize(sql as string).startsWith('INSERT INTO approval_records') &&
+      JSON.parse(String(params?.[9])).reason === 'auto-merge-adjacent' &&
+      JSON.parse(String(params?.[9])).skipped !== true)
+    expect(JSON.parse(String(autoRecord?.[1]?.[9]))).toMatchObject({
+      nodeKey: 'legal-review',
+      reason: 'auto-merge-adjacent',
+    })
   })
 
   it('advances existing approvals from the instance-bound stale published definition and form snapshot', async () => {

--- a/packages/core-backend/tests/unit/approval-product-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-product-service.test.ts
@@ -1119,6 +1119,251 @@ describe('ApprovalProductService', () => {
     expect(insertInstance?.[1]?.[12]).toBe('pub-2')
   })
 
+  it('auto-approves requester-owned initial nodes from the runtime policy snapshot', async () => {
+    const runtimeGraph = buildRuntimeGraph({
+      autoApproval: {
+        mergeWithRequester: true,
+      },
+    })
+
+    pgState.pool.query.mockImplementation(async (sql: string) => {
+      const statement = normalize(sql)
+      if (statement.startsWith('SELECT * FROM approval_templates WHERE id = $1')) {
+        return {
+          rows: [{
+            id: 'tpl-1',
+            key: 'travel',
+            name: 'Travel Approval',
+            description: null,
+            category: null,
+            visibility_scope: { type: 'all', ids: [] },
+            sla_hours: null,
+            status: 'published',
+            active_version_id: 'ver-1',
+            latest_version_id: 'ver-1',
+            created_at: new Date(),
+            updated_at: new Date(),
+          }],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith('SELECT * FROM approval_template_versions WHERE id = $1')) {
+        return {
+          rows: [{
+            id: 'ver-1',
+            template_id: 'tpl-1',
+            version: 1,
+            status: 'published',
+            form_schema: { fields: [] },
+            approval_graph: runtimeGraph,
+            created_at: new Date(),
+            updated_at: new Date(),
+          }],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith('SELECT * FROM approval_published_definitions')) {
+        return {
+          rows: [{
+            id: 'pub-1',
+            template_id: 'tpl-1',
+            template_version_id: 'ver-1',
+            runtime_graph: runtimeGraph,
+            is_active: true,
+            published_at: new Date(),
+          }],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith(`SELECT 'AP-' || nextval('approval_request_no_seq')::text AS request_no`)) {
+        return { rows: [{ request_no: 'AP-101002' }], rowCount: 1 }
+      }
+      throw new Error(`Unhandled pool query: ${statement}`)
+    })
+
+    pgState.client.query.mockImplementation(async (sql: string) => {
+      const statement = normalize(sql)
+      if (statement === 'BEGIN' || statement === 'COMMIT' || statement === 'ROLLBACK') {
+        return { rows: [], rowCount: 0 }
+      }
+      if (statement.startsWith('INSERT INTO approval_instances')) {
+        return { rows: [], rowCount: 1 }
+      }
+      if (statement.startsWith('INSERT INTO approval_assignments')) {
+        return { rows: [], rowCount: 1 }
+      }
+      if (statement.startsWith('INSERT INTO approval_records')) {
+        return { rows: [], rowCount: 1 }
+      }
+      throw new Error(`Unhandled client query: ${statement}`)
+    })
+
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const service = new ApprovalProductService(buildNoopMetrics() as never)
+    vi.spyOn(service, 'getApproval').mockResolvedValue(buildApprovalDto({
+      status: 'approved',
+      currentStep: 1,
+      currentNodeKey: null,
+      assignments: [],
+    }))
+
+    await service.createApproval(
+      { templateId: 'tpl-1', formData: {} },
+      { userId: 'manager-1' },
+    )
+
+    expect(pgState.client.query.mock.calls.some(([sql]) =>
+      normalize(sql as string).startsWith('INSERT INTO approval_assignments'))).toBe(false)
+    const insertInstance = pgState.client.query.mock.calls.find(([sql]) =>
+      normalize(sql as string).startsWith('INSERT INTO approval_instances'))
+    expect(insertInstance?.[1]?.[1]).toBe('approved')
+    expect(insertInstance?.[1]?.[15]).toBeNull()
+
+    const autoRecordCall = pgState.client.query.mock.calls.find(([sql, params]) =>
+      normalize(sql as string).startsWith('INSERT INTO approval_records') &&
+      JSON.parse(String(params?.[9])).reason === 'auto-merge-requester')
+    expect(autoRecordCall?.[1]?.[2]).toBe('system:auto-approval')
+    expect(JSON.parse(String(autoRecordCall?.[1]?.[9]))).toMatchObject({
+      nodeKey: 'approval_1',
+      autoApproved: true,
+      reason: 'auto-merge-requester',
+      policySource: 'template',
+      originalApprover: {
+        type: 'user',
+        id: 'manager-1',
+      },
+      actorMode: 'system',
+    })
+  })
+
+  it('auto-approves adjacent same-user chains transitively after a human approval', async () => {
+    const runtimeGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        { key: 'approval_a', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['manager-1'] } },
+        { key: 'approval_b', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['manager-1'] } },
+        { key: 'approval_c', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['manager-1'] } },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-a', source: 'start', target: 'approval_a' },
+        { key: 'edge-a-b', source: 'approval_a', target: 'approval_b' },
+        { key: 'edge-b-c', source: 'approval_b', target: 'approval_c' },
+        { key: 'edge-c-end', source: 'approval_c', target: 'end' },
+      ],
+      policy: {
+        allowRevoke: true,
+        autoApproval: {
+          mergeAdjacentApprover: true,
+        },
+      },
+    }
+
+    pgState.client.query.mockImplementation(async (sql: string) => {
+      const statement = normalize(sql)
+      if (statement === 'BEGIN' || statement === 'COMMIT' || statement === 'ROLLBACK') {
+        return { rows: [], rowCount: 0 }
+      }
+      if (statement.startsWith('SELECT * FROM approval_instances WHERE id = $1')) {
+        return {
+          rows: [buildInstanceRow({
+            current_node_key: 'approval_a',
+            current_step: 1,
+            total_steps: 3,
+          })],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith('SELECT * FROM approval_published_definitions WHERE id = $1')) {
+        return {
+          rows: [{
+            id: 'pub-1',
+            template_id: 'tpl-1',
+            template_version_id: 'ver-1',
+            runtime_graph: runtimeGraph,
+            is_active: true,
+            published_at: new Date(),
+          }],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith('SELECT * FROM approval_assignments WHERE instance_id = $1')) {
+        return {
+          rows: [{
+            id: 'asg-a',
+            instance_id: 'apr-1',
+            assignment_type: 'user',
+            assignee_id: 'manager-1',
+            source_step: 1,
+            node_key: 'approval_a',
+            is_active: true,
+            metadata: {},
+            created_at: new Date(),
+            updated_at: new Date(),
+          }],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith('SELECT id, actor_id, metadata FROM approval_records')) {
+        return { rows: [], rowCount: 0 }
+      }
+      if (statement.startsWith('UPDATE approval_assignments SET is_active = FALSE')) {
+        return { rows: [], rowCount: 1 }
+      }
+      if (statement.startsWith('UPDATE approval_instances SET status = $2')) {
+        return { rows: [], rowCount: 1 }
+      }
+      if (statement.startsWith('INSERT INTO approval_assignments')) {
+        return { rows: [], rowCount: 1 }
+      }
+      if (statement.startsWith('INSERT INTO approval_records')) {
+        return { rows: [], rowCount: 1 }
+      }
+      throw new Error(`Unhandled query: ${statement}`)
+    })
+
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const service = new ApprovalProductService(buildNoopMetrics() as never)
+    vi.spyOn(service, 'getApproval').mockResolvedValue(buildApprovalDto({
+      status: 'approved',
+      currentStep: 3,
+      totalSteps: 3,
+      currentNodeKey: null,
+      assignments: [],
+    }))
+
+    const result = await service.dispatchAction(
+      'apr-1',
+      { action: 'approve' },
+      { userId: 'manager-1' },
+    )
+
+    expect(result.status).toBe('approved')
+    expect(pgState.client.query.mock.calls.some(([sql]) =>
+      normalize(sql as string).startsWith('INSERT INTO approval_assignments'))).toBe(false)
+    const updateCall = pgState.client.query.mock.calls.find(([sql]) =>
+      normalize(sql as string).startsWith('UPDATE approval_instances SET status = $2'))
+    expect(updateCall?.[1]).toEqual(['apr-1', 'approved', 3, null, 3, 3])
+
+    const autoRecords = pgState.client.query.mock.calls
+      .filter(([sql, params]) =>
+        normalize(sql as string).startsWith('INSERT INTO approval_records') &&
+        JSON.parse(String(params?.[9])).reason === 'auto-merge-adjacent')
+      .map(([, params]) => JSON.parse(String(params?.[9])))
+
+    expect(autoRecords).toHaveLength(2)
+    expect(autoRecords[0]).toMatchObject({
+      nodeKey: 'approval_b',
+      reason: 'auto-merge-adjacent',
+      matchedAgainst: { nodeKey: 'approval_a' },
+    })
+    expect(autoRecords[1]).toMatchObject({
+      nodeKey: 'approval_c',
+      reason: 'auto-merge-adjacent',
+      matchedAgainst: { nodeKey: 'approval_b' },
+    })
+  })
+
   it('advances existing approvals from the instance-bound stale published definition and form snapshot', async () => {
     const frozenRuntimeGraph = {
       nodes: [
@@ -1274,9 +1519,12 @@ describe('ApprovalProductService', () => {
     await expect(service.assertTemplateVersionDeletable('ver-archive-safe')).resolves.toBeUndefined()
 
     const statement = normalize(pgState.pool.query.mock.calls[0]?.[0] as string)
-    expect(statement).toContain("status NOT IN ('approved', 'rejected', 'revoked', 'cancelled')")
+    expect(statement).toContain('status <> ALL($2::text[])')
     expect(statement).toContain('published_definition_id IN')
-    expect(pgState.pool.query.mock.calls[0]?.[1]).toEqual(['ver-archive-safe'])
+    expect(pgState.pool.query.mock.calls[0]?.[1]).toEqual([
+      'ver-archive-safe',
+      ['approved', 'rejected', 'revoked', 'cancelled'],
+    ])
   })
 
   it('blocks template version delete/archive checks with unfinished count and sample id', async () => {

--- a/packages/core-backend/tests/unit/approval-product-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-product-service.test.ts
@@ -110,6 +110,82 @@ function buildNoopMetrics() {
   }
 }
 
+function mockPublishedTemplatePool(runtimeGraph: Record<string, unknown>, requestNo = 'AP-101100') {
+  pgState.pool.query.mockImplementation(async (sql: string) => {
+    const statement = normalize(sql)
+    if (statement.startsWith('SELECT * FROM approval_templates WHERE id = $1')) {
+      return {
+        rows: [{
+          id: 'tpl-1',
+          key: 'travel',
+          name: 'Travel Approval',
+          description: null,
+          category: null,
+          visibility_scope: { type: 'all', ids: [] },
+          sla_hours: null,
+          status: 'published',
+          active_version_id: 'ver-1',
+          latest_version_id: 'ver-1',
+          created_at: new Date(),
+          updated_at: new Date(),
+        }],
+        rowCount: 1,
+      }
+    }
+    if (statement.startsWith('SELECT * FROM approval_template_versions WHERE id = $1')) {
+      return {
+        rows: [{
+          id: 'ver-1',
+          template_id: 'tpl-1',
+          version: 1,
+          status: 'published',
+          form_schema: { fields: [] },
+          approval_graph: runtimeGraph,
+          created_at: new Date(),
+          updated_at: new Date(),
+        }],
+        rowCount: 1,
+      }
+    }
+    if (statement.startsWith('SELECT * FROM approval_published_definitions')) {
+      return {
+        rows: [{
+          id: 'pub-1',
+          template_id: 'tpl-1',
+          template_version_id: 'ver-1',
+          runtime_graph: runtimeGraph,
+          is_active: true,
+          published_at: new Date(),
+        }],
+        rowCount: 1,
+      }
+    }
+    if (statement.startsWith(`SELECT 'AP-' || nextval('approval_request_no_seq')::text AS request_no`)) {
+      return { rows: [{ request_no: requestNo }], rowCount: 1 }
+    }
+    throw new Error(`Unhandled pool query: ${statement}`)
+  })
+}
+
+function mockInsertOnlyClient() {
+  pgState.client.query.mockImplementation(async (sql: string) => {
+    const statement = normalize(sql)
+    if (statement === 'BEGIN' || statement === 'COMMIT' || statement === 'ROLLBACK') {
+      return { rows: [], rowCount: 0 }
+    }
+    if (statement.startsWith('INSERT INTO approval_instances')) {
+      return { rows: [], rowCount: 1 }
+    }
+    if (statement.startsWith('INSERT INTO approval_assignments')) {
+      return { rows: [], rowCount: 1 }
+    }
+    if (statement.startsWith('INSERT INTO approval_records')) {
+      return { rows: [], rowCount: 1 }
+    }
+    throw new Error(`Unhandled client query: ${statement}`)
+  })
+}
+
 describe('ApprovalProductService', () => {
   beforeEach(() => {
     pgState.pool.connect.mockReset()
@@ -1472,6 +1548,195 @@ describe('ApprovalProductService', () => {
     })
   })
 
+  it('uses deterministic requester precedence when multiple auto-approval rules match', async () => {
+    const runtimeGraph = buildRuntimeGraph({
+      autoApproval: {
+        mergeWithRequester: true,
+        dedupeHistoricalApprover: true,
+      },
+    })
+    mockPublishedTemplatePool(runtimeGraph, 'AP-101005')
+    mockInsertOnlyClient()
+
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const service = new ApprovalProductService(buildNoopMetrics() as never)
+    vi.spyOn(service, 'getApproval').mockResolvedValue(buildApprovalDto({
+      status: 'approved',
+      currentNodeKey: null,
+      assignments: [],
+    }))
+
+    await service.createApproval(
+      { templateId: 'tpl-1', formData: {} },
+      { userId: 'manager-1' },
+    )
+
+    const autoRecordCall = pgState.client.query.mock.calls.find(([sql, params]) =>
+      normalize(sql as string).startsWith('INSERT INTO approval_records') &&
+      JSON.parse(String(params?.[9])).autoApproved === true)
+    expect(JSON.parse(String(autoRecordCall?.[1]?.[9]))).toMatchObject({
+      reason: 'auto-merge-requester',
+      policySource: 'template',
+      originalApprover: {
+        type: 'user',
+        id: 'manager-1',
+      },
+    })
+  })
+
+  it('does not double-emit when empty-assignee auto approval coexists with requester merge policy', async () => {
+    const runtimeGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        {
+          key: 'approval_1',
+          type: 'approval',
+          config: {
+            assigneeType: 'user',
+            assigneeIds: [],
+            emptyAssigneePolicy: 'auto-approve',
+            autoApprovalPolicy: { mergeWithRequester: true },
+          },
+        },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-approval', source: 'start', target: 'approval_1' },
+        { key: 'edge-approval-end', source: 'approval_1', target: 'end' },
+      ],
+      policy: {
+        allowRevoke: true,
+        autoApproval: {
+          mergeWithRequester: true,
+        },
+      },
+    }
+    mockPublishedTemplatePool(runtimeGraph, 'AP-101006')
+    mockInsertOnlyClient()
+
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const service = new ApprovalProductService(buildNoopMetrics() as never)
+    vi.spyOn(service, 'getApproval').mockResolvedValue(buildApprovalDto({
+      status: 'approved',
+      currentNodeKey: null,
+      assignments: [],
+    }))
+
+    await service.createApproval(
+      { templateId: 'tpl-1', formData: {} },
+      { userId: 'manager-1' },
+    )
+
+    const autoRecords = pgState.client.query.mock.calls
+      .filter(([sql, params]) =>
+        normalize(sql as string).startsWith('INSERT INTO approval_records') &&
+        JSON.parse(String(params?.[9])).autoApproved === true)
+      .map(([, params]) => JSON.parse(String(params?.[9])))
+
+    expect(autoRecords).toHaveLength(1)
+    expect(autoRecords[0]).toMatchObject({
+      reason: 'empty-assignee',
+      nodeKey: 'approval_1',
+    })
+  })
+
+  it('keeps pre-pr2 runtime graphs without autoApproval behavior unchanged', async () => {
+    const runtimeGraph = buildRuntimeGraph()
+    mockPublishedTemplatePool(runtimeGraph, 'AP-101007')
+    mockInsertOnlyClient()
+
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const service = new ApprovalProductService(buildNoopMetrics() as never)
+    vi.spyOn(service, 'getApproval').mockResolvedValue(buildApprovalDto({
+      currentNodeKey: 'approval_1',
+      assignments: [{
+        id: 'asg-manager-1',
+        type: 'user',
+        assigneeId: 'manager-1',
+        sourceStep: 1,
+        nodeKey: 'approval_1',
+        isActive: true,
+        metadata: {},
+      }],
+    }))
+
+    await service.createApproval(
+      { templateId: 'tpl-1', formData: {} },
+      { userId: 'manager-1' },
+    )
+
+    expect(pgState.client.query.mock.calls.some(([sql]) =>
+      normalize(sql as string).startsWith('INSERT INTO approval_assignments'))).toBe(true)
+    expect(pgState.client.query.mock.calls.some(([sql, params]) =>
+      normalize(sql as string).startsWith('INSERT INTO approval_records') &&
+      JSON.parse(String(params?.[9])).autoApproved === true)).toBe(false)
+  })
+
+  it('keeps all-mode approvals pending when requester auto-merge leaves human assignees', async () => {
+    const runtimeGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        {
+          key: 'approval_1',
+          type: 'approval',
+          config: {
+            assigneeType: 'user',
+            assigneeIds: ['manager-1', 'manager-2'],
+            approvalMode: 'all',
+          },
+        },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-approval', source: 'start', target: 'approval_1' },
+        { key: 'edge-approval-end', source: 'approval_1', target: 'end' },
+      ],
+      policy: {
+        allowRevoke: true,
+        autoApproval: {
+          mergeWithRequester: true,
+        },
+      },
+    }
+    mockPublishedTemplatePool(runtimeGraph, 'AP-101008')
+    mockInsertOnlyClient()
+
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const service = new ApprovalProductService(buildNoopMetrics() as never)
+    vi.spyOn(service, 'getApproval').mockResolvedValue(buildApprovalDto({
+      currentNodeKey: 'approval_1',
+      assignments: [{
+        id: 'asg-manager-2',
+        type: 'user',
+        assigneeId: 'manager-2',
+        sourceStep: 1,
+        nodeKey: 'approval_1',
+        isActive: true,
+        metadata: {},
+      }],
+    }))
+
+    await service.createApproval(
+      { templateId: 'tpl-1', formData: {} },
+      { userId: 'manager-1' },
+    )
+
+    const assignmentInserts = pgState.client.query.mock.calls.filter(([sql]) =>
+      normalize(sql as string).startsWith('INSERT INTO approval_assignments'))
+    expect(assignmentInserts).toHaveLength(1)
+    expect(assignmentInserts[0]?.[1]).toEqual([expect.any(String), 'user', 'manager-2', 1, 'approval_1'])
+
+    const autoRecordCall = pgState.client.query.mock.calls.find(([sql, params]) =>
+      normalize(sql as string).startsWith('INSERT INTO approval_records') &&
+      JSON.parse(String(params?.[9])).reason === 'auto-merge-requester')
+    expect(JSON.parse(String(autoRecordCall?.[1]?.[9]))).toMatchObject({
+      approvalMode: 'all',
+      originalApprover: {
+        id: 'manager-1',
+      },
+    })
+  })
+
   it('auto-approves adjacent same-user chains transitively after a human approval', async () => {
     const runtimeGraph = {
       nodes: [
@@ -1598,6 +1863,244 @@ describe('ApprovalProductService', () => {
       reason: 'auto-merge-adjacent',
       matchedAgainst: { nodeKey: 'approval_b' },
     })
+  })
+
+  it('uses the instance-bound runtime policy snapshot when auto-approving old instances', async () => {
+    const frozenRuntimeGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        { key: 'approval_1', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['manager-1'] } },
+        { key: 'approval_2', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['user-1'] } },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-approval-1', source: 'start', target: 'approval_1' },
+        { key: 'edge-approval-1-approval-2', source: 'approval_1', target: 'approval_2' },
+        { key: 'edge-approval-2-end', source: 'approval_2', target: 'end' },
+      ],
+      policy: {
+        allowRevoke: true,
+        autoApproval: {
+          mergeWithRequester: true,
+        },
+      },
+    }
+
+    pgState.client.query.mockImplementation(async (sql: string, params?: unknown[]) => {
+      const statement = normalize(sql)
+      if (statement === 'BEGIN' || statement === 'COMMIT' || statement === 'ROLLBACK') {
+        return { rows: [], rowCount: 0 }
+      }
+      if (statement.startsWith('SELECT * FROM approval_instances WHERE id = $1')) {
+        return {
+          rows: [buildInstanceRow({
+            template_version_id: 'ver-old',
+            published_definition_id: 'pub-old-policy',
+            current_step: 1,
+            total_steps: 2,
+            current_node_key: 'approval_1',
+          })],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith('SELECT * FROM approval_published_definitions WHERE id = $1')) {
+        expect(params).toEqual(['pub-old-policy'])
+        return {
+          rows: [{
+            id: 'pub-old-policy',
+            template_id: 'tpl-1',
+            template_version_id: 'ver-old',
+            runtime_graph: frozenRuntimeGraph,
+            is_active: false,
+            published_at: new Date(),
+          }],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith('SELECT * FROM approval_assignments WHERE instance_id = $1')) {
+        return {
+          rows: [{
+            id: 'asg-manager-1',
+            instance_id: 'apr-1',
+            assignment_type: 'user',
+            assignee_id: 'manager-1',
+            source_step: 1,
+            node_key: 'approval_1',
+            is_active: true,
+            metadata: {},
+            created_at: new Date(),
+            updated_at: new Date(),
+          }],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith('SELECT id, actor_id, metadata FROM approval_records')) {
+        return { rows: [], rowCount: 0 }
+      }
+      if (statement.startsWith('UPDATE approval_assignments SET is_active = FALSE')) {
+        return { rows: [], rowCount: 1 }
+      }
+      if (statement.startsWith('UPDATE approval_instances SET status = $2')) {
+        expect(params).toEqual(['apr-1', 'approved', 3, null, 2, 2])
+        return { rows: [], rowCount: 1 }
+      }
+      if (statement.startsWith('INSERT INTO approval_assignments')) {
+        throw new Error('auto-merged requester should not create a human assignment')
+      }
+      if (statement.startsWith('INSERT INTO approval_records')) {
+        return { rows: [], rowCount: 1 }
+      }
+      throw new Error(`Unhandled query: ${statement}`)
+    })
+
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const service = new ApprovalProductService(buildNoopMetrics() as never)
+    vi.spyOn(service, 'getApproval').mockResolvedValue(buildApprovalDto({
+      status: 'approved',
+      templateVersionId: 'ver-old',
+      publishedDefinitionId: 'pub-old-policy',
+      currentStep: 2,
+      totalSteps: 2,
+      currentNodeKey: null,
+      assignments: [],
+    }))
+
+    const result = await service.dispatchAction(
+      'apr-1',
+      { action: 'approve' },
+      { userId: 'manager-1' },
+    )
+
+    expect(result.status).toBe('approved')
+    const statements = [
+      ...pgState.client.query.mock.calls,
+      ...pgState.pool.query.mock.calls,
+    ].map(([sql]) => normalize(sql as string))
+    expect(statements.some((statement) => statement.includes('approval_templates'))).toBe(false)
+    expect(statements.some((statement) => statement.includes('approval_template_versions'))).toBe(false)
+    expect(statements.some((statement) => statement.includes('active_version_id'))).toBe(false)
+
+    const autoRecordCall = pgState.client.query.mock.calls.find(([sql, params]) =>
+      normalize(sql as string).startsWith('INSERT INTO approval_records') &&
+      JSON.parse(String(params?.[9])).reason === 'auto-merge-requester')
+    expect(JSON.parse(String(autoRecordCall?.[1]?.[9]))).toMatchObject({
+      nodeKey: 'approval_2',
+      policySource: 'template',
+      originalApprover: {
+        type: 'user',
+        id: 'user-1',
+      },
+    })
+  })
+
+  it('rolls back when chained auto-approval exceeds the per-dispatch guard', async () => {
+    const approvalNodes = Array.from({ length: 52 }, (_, index) => ({
+      key: `approval_${index + 1}`,
+      type: 'approval',
+      config: { assigneeType: 'user', assigneeIds: ['manager-1'] },
+    }))
+    const runtimeGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        ...approvalNodes,
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-approval-1', source: 'start', target: 'approval_1' },
+        ...Array.from({ length: 51 }, (_, index) => ({
+          key: `edge-approval-${index + 1}-${index + 2}`,
+          source: `approval_${index + 1}`,
+          target: `approval_${index + 2}`,
+        })),
+        { key: 'edge-approval-52-end', source: 'approval_52', target: 'end' },
+      ],
+      policy: {
+        allowRevoke: true,
+        autoApproval: {
+          mergeAdjacentApprover: true,
+        },
+      },
+    }
+
+    pgState.client.query.mockImplementation(async (sql: string) => {
+      const statement = normalize(sql)
+      if (statement === 'BEGIN' || statement === 'ROLLBACK') {
+        return { rows: [], rowCount: 0 }
+      }
+      if (statement === 'COMMIT') {
+        throw new Error('guard breach should not commit')
+      }
+      if (statement.startsWith('SELECT * FROM approval_instances WHERE id = $1')) {
+        return {
+          rows: [buildInstanceRow({
+            current_node_key: 'approval_1',
+            current_step: 1,
+            total_steps: 52,
+          })],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith('SELECT * FROM approval_published_definitions WHERE id = $1')) {
+        return {
+          rows: [{
+            id: 'pub-1',
+            template_id: 'tpl-1',
+            template_version_id: 'ver-1',
+            runtime_graph: runtimeGraph,
+            is_active: true,
+            published_at: new Date(),
+          }],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith('SELECT * FROM approval_assignments WHERE instance_id = $1')) {
+        return {
+          rows: [{
+            id: 'asg-approval-1',
+            instance_id: 'apr-1',
+            assignment_type: 'user',
+            assignee_id: 'manager-1',
+            source_step: 1,
+            node_key: 'approval_1',
+            is_active: true,
+            metadata: {},
+            created_at: new Date(),
+            updated_at: new Date(),
+          }],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith('SELECT id, actor_id, metadata FROM approval_records')) {
+        return { rows: [], rowCount: 0 }
+      }
+      if (statement.startsWith('UPDATE approval_assignments SET is_active = FALSE')) {
+        return { rows: [], rowCount: 1 }
+      }
+      throw new Error(`Unhandled query: ${statement}`)
+    })
+
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const service = new ApprovalProductService(buildNoopMetrics() as never)
+
+    await expect(service.dispatchAction(
+      'apr-1',
+      { action: 'approve' },
+      { userId: 'manager-1' },
+    )).rejects.toMatchObject({
+      code: 'APPROVAL_AUTO_STEP_LIMIT_EXCEEDED',
+      details: {
+        autoSteps: 51,
+        lastNodeKey: 'approval_52',
+      },
+    })
+
+    const statements = pgState.client.query.mock.calls.map(([sql]) => normalize(sql as string))
+    expect(statements).toContain('ROLLBACK')
+    expect(statements).not.toContain('COMMIT')
+    expect(statements.some((statement) =>
+      statement.startsWith('UPDATE approval_instances SET status = $2'))).toBe(false)
+    expect(statements.some((statement) =>
+      statement.startsWith('INSERT INTO approval_records'))).toBe(false)
   })
 
   it('advances existing approvals from the instance-bound stale published definition and form snapshot', async () => {
@@ -1864,6 +2367,94 @@ describe('ApprovalProductService', () => {
     expect(deactivateIndex).toBeGreaterThan(lockIndex)
     expect(insertIndex).toBeGreaterThan(deactivateIndex)
     expect(statements.filter((statement) => statement === 'COMMIT')).toHaveLength(1)
+  })
+
+  it('snapshots publish-time auto-approval policy into runtime_graph without a migration column', async () => {
+    const runtimeGraph = buildRuntimeGraph()
+    const template = {
+      id: 'tpl-1',
+      key: 'travel',
+      name: 'Travel Approval',
+      description: null,
+      category: null,
+      visibility_scope: { type: 'all', ids: [] },
+      sla_hours: null,
+      status: 'draft',
+      active_version_id: 'ver-1',
+      latest_version_id: 'ver-2',
+      created_at: new Date(),
+      updated_at: new Date(),
+    }
+    const version = {
+      id: 'ver-2',
+      template_id: 'tpl-1',
+      version: 2,
+      status: 'draft',
+      form_schema: { fields: [] },
+      approval_graph: runtimeGraph,
+      created_at: new Date(),
+      updated_at: new Date(),
+    }
+
+    pgState.client.query.mockImplementation(async (sql: string, params?: unknown[]) => {
+      const statement = normalize(sql)
+      if (statement === 'BEGIN' || statement === 'COMMIT' || statement === 'ROLLBACK') {
+        return { rows: [], rowCount: 0 }
+      }
+      if (statement.startsWith('SELECT * FROM approval_templates WHERE id = $1 FOR UPDATE')) {
+        return { rows: [template], rowCount: 1 }
+      }
+      if (statement.startsWith('SELECT * FROM approval_template_versions WHERE id = $1')) {
+        return { rows: [version], rowCount: 1 }
+      }
+      if (statement.startsWith('UPDATE approval_published_definitions SET is_active = FALSE')) {
+        return { rows: [], rowCount: 1 }
+      }
+      if (statement.startsWith('INSERT INTO approval_published_definitions')) {
+        const insertedRuntimeGraph = JSON.parse(String(params?.[2]))
+        expect(insertedRuntimeGraph.policy.autoApproval).toEqual({
+          mergeWithRequester: true,
+          mergeAdjacentApprover: true,
+          actorMode: 'system',
+        })
+        return {
+          rows: [{
+            id: 'pub-2',
+            template_id: 'tpl-1',
+            template_version_id: 'ver-2',
+            runtime_graph: insertedRuntimeGraph,
+            is_active: true,
+            published_at: new Date(),
+          }],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith("UPDATE approval_template_versions SET status = 'published'")) {
+        return { rows: [{ ...version, status: 'published' }], rowCount: 1 }
+      }
+      if (statement.startsWith("UPDATE approval_templates SET status = 'published'")) {
+        return { rows: [], rowCount: 1 }
+      }
+      throw new Error(`Unhandled query: ${statement}`)
+    })
+
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const service = new ApprovalProductService()
+
+    await service.publishTemplate('tpl-1', {
+      policy: {
+        allowRevoke: true,
+        autoApproval: {
+          mergeWithRequester: true,
+          mergeAdjacentApprover: true,
+          actorMode: 'system',
+        },
+      },
+    } as never)
+
+    const statements = pgState.client.query.mock.calls.map(([sql]) => normalize(sql as string))
+    expect(statements.some((statement) => statement.includes('auto_approval_policy'))).toBe(false)
+    expect(statements.some((statement) => statement.includes('ALTER TABLE'))).toBe(false)
   })
 
   it('keeps only one active published definition across concurrent publish calls', async () => {

--- a/packages/core-backend/tests/unit/approval-product-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-product-service.test.ts
@@ -1630,13 +1630,14 @@ describe('ApprovalProductService', () => {
       { userId: 'manager-1' },
     )
 
-    const autoRecords = pgState.client.query.mock.calls
+    const autoRecordCalls = pgState.client.query.mock.calls
       .filter(([sql, params]) =>
         normalize(sql as string).startsWith('INSERT INTO approval_records') &&
         JSON.parse(String(params?.[9])).autoApproved === true)
-      .map(([, params]) => JSON.parse(String(params?.[9])))
+    const autoRecords = autoRecordCalls.map(([, params]) => JSON.parse(String(params?.[9])))
 
     expect(autoRecords).toHaveLength(1)
+    expect(autoRecordCalls[0]?.[1]?.[2]).toBe('system:auto-approval')
     expect(autoRecords[0]).toMatchObject({
       reason: 'empty-assignee',
       nodeKey: 'approval_1',
@@ -1759,6 +1760,7 @@ describe('ApprovalProductService', () => {
         allowRevoke: true,
         autoApproval: {
           mergeAdjacentApprover: true,
+          actorMode: 'original_approver',
         },
       },
     }
@@ -1852,21 +1854,24 @@ describe('ApprovalProductService', () => {
       normalize(sql as string).startsWith('UPDATE approval_instances SET status = $2'))
     expect(updateCall?.[1]).toEqual(['apr-1', 'approved', 3, null, 3, 3])
 
-    const autoRecords = pgState.client.query.mock.calls
+    const autoRecordCalls = pgState.client.query.mock.calls
       .filter(([sql, params]) =>
         normalize(sql as string).startsWith('INSERT INTO approval_records') &&
         JSON.parse(String(params?.[9])).reason === 'auto-merge-adjacent')
-      .map(([, params]) => JSON.parse(String(params?.[9])))
+    const autoRecords = autoRecordCalls.map(([, params]) => JSON.parse(String(params?.[9])))
 
     expect(autoRecords).toHaveLength(2)
+    expect(autoRecordCalls.map(([, params]) => params?.[2])).toEqual(['manager-1', 'manager-1'])
     expect(autoRecords[0]).toMatchObject({
       nodeKey: 'approval_b',
       reason: 'auto-merge-adjacent',
+      actorMode: 'original_approver',
       matchedAgainst: { nodeKey: 'approval_a' },
     })
     expect(autoRecords[1]).toMatchObject({
       nodeKey: 'approval_c',
       reason: 'auto-merge-adjacent',
+      actorMode: 'original_approver',
       matchedAgainst: { nodeKey: 'approval_b' },
     })
   })

--- a/packages/core-backend/tests/unit/approval-product-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-product-service.test.ts
@@ -1236,6 +1236,242 @@ describe('ApprovalProductService', () => {
     })
   })
 
+  it('lets node auto-approval override disable an enabled template policy', async () => {
+    const runtimeGraph = {
+      ...buildRuntimeGraph({
+        autoApproval: {
+          mergeWithRequester: true,
+        },
+      }),
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        {
+          key: 'approval_1',
+          type: 'approval',
+          config: {
+            assigneeType: 'user',
+            assigneeIds: ['manager-1'],
+            autoApprovalPolicy: { mergeWithRequester: false },
+          },
+        },
+        { key: 'end', type: 'end', config: {} },
+      ],
+    }
+
+    pgState.pool.query.mockImplementation(async (sql: string) => {
+      const statement = normalize(sql)
+      if (statement.startsWith('SELECT * FROM approval_templates WHERE id = $1')) {
+        return {
+          rows: [{
+            id: 'tpl-1',
+            key: 'travel',
+            name: 'Travel Approval',
+            description: null,
+            category: null,
+            visibility_scope: { type: 'all', ids: [] },
+            sla_hours: null,
+            status: 'published',
+            active_version_id: 'ver-1',
+            latest_version_id: 'ver-1',
+            created_at: new Date(),
+            updated_at: new Date(),
+          }],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith('SELECT * FROM approval_template_versions WHERE id = $1')) {
+        return {
+          rows: [{
+            id: 'ver-1',
+            template_id: 'tpl-1',
+            version: 1,
+            status: 'published',
+            form_schema: { fields: [] },
+            approval_graph: runtimeGraph,
+            created_at: new Date(),
+            updated_at: new Date(),
+          }],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith('SELECT * FROM approval_published_definitions')) {
+        return {
+          rows: [{
+            id: 'pub-1',
+            template_id: 'tpl-1',
+            template_version_id: 'ver-1',
+            runtime_graph: runtimeGraph,
+            is_active: true,
+            published_at: new Date(),
+          }],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith(`SELECT 'AP-' || nextval('approval_request_no_seq')::text AS request_no`)) {
+        return { rows: [{ request_no: 'AP-101003' }], rowCount: 1 }
+      }
+      throw new Error(`Unhandled pool query: ${statement}`)
+    })
+
+    pgState.client.query.mockImplementation(async (sql: string) => {
+      const statement = normalize(sql)
+      if (statement === 'BEGIN' || statement === 'COMMIT' || statement === 'ROLLBACK') {
+        return { rows: [], rowCount: 0 }
+      }
+      if (statement.startsWith('INSERT INTO approval_instances')) {
+        return { rows: [], rowCount: 1 }
+      }
+      if (statement.startsWith('INSERT INTO approval_assignments')) {
+        return { rows: [], rowCount: 1 }
+      }
+      if (statement.startsWith('INSERT INTO approval_records')) {
+        return { rows: [], rowCount: 1 }
+      }
+      throw new Error(`Unhandled client query: ${statement}`)
+    })
+
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const service = new ApprovalProductService(buildNoopMetrics() as never)
+    vi.spyOn(service, 'getApproval').mockResolvedValue(buildApprovalDto({
+      currentNodeKey: 'approval_1',
+      assignments: [{
+        id: 'asg-manager-1',
+        type: 'user',
+        assigneeId: 'manager-1',
+        sourceStep: 1,
+        nodeKey: 'approval_1',
+        isActive: true,
+        metadata: {},
+      }],
+    }))
+
+    await service.createApproval(
+      { templateId: 'tpl-1', formData: {} },
+      { userId: 'manager-1' },
+    )
+
+    expect(pgState.client.query.mock.calls.some(([sql]) =>
+      normalize(sql as string).startsWith('INSERT INTO approval_assignments'))).toBe(true)
+    expect(pgState.client.query.mock.calls.some(([sql, params]) =>
+      normalize(sql as string).startsWith('INSERT INTO approval_records') &&
+      JSON.parse(String(params?.[9])).reason === 'auto-merge-requester')).toBe(false)
+  })
+
+  it('lets node auto-approval override enable a disabled template policy', async () => {
+    const runtimeGraph = {
+      ...buildRuntimeGraph(),
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        {
+          key: 'approval_1',
+          type: 'approval',
+          config: {
+            assigneeType: 'user',
+            assigneeIds: ['manager-1'],
+            autoApprovalPolicy: { mergeWithRequester: true },
+          },
+        },
+        { key: 'end', type: 'end', config: {} },
+      ],
+    }
+
+    pgState.pool.query.mockImplementation(async (sql: string) => {
+      const statement = normalize(sql)
+      if (statement.startsWith('SELECT * FROM approval_templates WHERE id = $1')) {
+        return {
+          rows: [{
+            id: 'tpl-1',
+            key: 'travel',
+            name: 'Travel Approval',
+            description: null,
+            category: null,
+            visibility_scope: { type: 'all', ids: [] },
+            sla_hours: null,
+            status: 'published',
+            active_version_id: 'ver-1',
+            latest_version_id: 'ver-1',
+            created_at: new Date(),
+            updated_at: new Date(),
+          }],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith('SELECT * FROM approval_template_versions WHERE id = $1')) {
+        return {
+          rows: [{
+            id: 'ver-1',
+            template_id: 'tpl-1',
+            version: 1,
+            status: 'published',
+            form_schema: { fields: [] },
+            approval_graph: runtimeGraph,
+            created_at: new Date(),
+            updated_at: new Date(),
+          }],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith('SELECT * FROM approval_published_definitions')) {
+        return {
+          rows: [{
+            id: 'pub-1',
+            template_id: 'tpl-1',
+            template_version_id: 'ver-1',
+            runtime_graph: runtimeGraph,
+            is_active: true,
+            published_at: new Date(),
+          }],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith(`SELECT 'AP-' || nextval('approval_request_no_seq')::text AS request_no`)) {
+        return { rows: [{ request_no: 'AP-101004' }], rowCount: 1 }
+      }
+      throw new Error(`Unhandled pool query: ${statement}`)
+    })
+
+    pgState.client.query.mockImplementation(async (sql: string) => {
+      const statement = normalize(sql)
+      if (statement === 'BEGIN' || statement === 'COMMIT' || statement === 'ROLLBACK') {
+        return { rows: [], rowCount: 0 }
+      }
+      if (statement.startsWith('INSERT INTO approval_instances')) {
+        return { rows: [], rowCount: 1 }
+      }
+      if (statement.startsWith('INSERT INTO approval_assignments')) {
+        return { rows: [], rowCount: 1 }
+      }
+      if (statement.startsWith('INSERT INTO approval_records')) {
+        return { rows: [], rowCount: 1 }
+      }
+      throw new Error(`Unhandled client query: ${statement}`)
+    })
+
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const service = new ApprovalProductService(buildNoopMetrics() as never)
+    vi.spyOn(service, 'getApproval').mockResolvedValue(buildApprovalDto({
+      status: 'approved',
+      currentNodeKey: null,
+      assignments: [],
+    }))
+
+    await service.createApproval(
+      { templateId: 'tpl-1', formData: {} },
+      { userId: 'manager-1' },
+    )
+
+    const autoRecordCall = pgState.client.query.mock.calls.find(([sql, params]) =>
+      normalize(sql as string).startsWith('INSERT INTO approval_records') &&
+      JSON.parse(String(params?.[9])).reason === 'auto-merge-requester')
+    expect(JSON.parse(String(autoRecordCall?.[1]?.[9]))).toMatchObject({
+      policySource: 'node',
+      originalApprover: {
+        type: 'user',
+        id: 'manager-1',
+      },
+    })
+  })
+
   it('auto-approves adjacent same-user chains transitively after a human approval', async () => {
     const runtimeGraph = {
       nodes: [

--- a/packages/core-backend/tests/unit/approval-product-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-product-service.test.ts
@@ -97,6 +97,19 @@ function buildApprovalDto(overrides: Record<string, unknown> = {}) {
   }
 }
 
+function buildNoopMetrics() {
+  return {
+    recordInstanceStart: vi.fn().mockResolvedValue(undefined),
+    recordTerminal: vi.fn().mockResolvedValue(undefined),
+    recordNodeActivation: vi.fn().mockResolvedValue(undefined),
+    recordNodeDecision: vi.fn().mockResolvedValue(undefined),
+    checkSlaBreaches: vi.fn().mockResolvedValue([]),
+    getMetricsSummary: vi.fn(),
+    getInstanceMetrics: vi.fn(),
+    listActiveBreaches: vi.fn(),
+  }
+}
+
 describe('ApprovalProductService', () => {
   beforeEach(() => {
     pgState.pool.connect.mockReset()
@@ -1007,5 +1020,559 @@ describe('ApprovalProductService', () => {
         terminalState: 'approved',
       }))
     })
+  })
+
+  it('creates new approvals from the currently active published definition', async () => {
+    const runtimeGraph = buildRuntimeGraph()
+
+    pgState.pool.query.mockImplementation(async (sql: string) => {
+      const statement = normalize(sql)
+      if (statement.startsWith('SELECT * FROM approval_templates WHERE id = $1')) {
+        return {
+          rows: [{
+            id: 'tpl-1',
+            key: 'travel',
+            name: 'Travel Approval',
+            description: null,
+            category: null,
+            visibility_scope: { type: 'all', ids: [] },
+            sla_hours: null,
+            status: 'published',
+            active_version_id: 'ver-2',
+            latest_version_id: 'ver-2',
+            created_at: new Date(),
+            updated_at: new Date(),
+          }],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith('SELECT * FROM approval_template_versions WHERE id = $1')) {
+        return {
+          rows: [{
+            id: 'ver-2',
+            template_id: 'tpl-1',
+            version: 2,
+            status: 'published',
+            form_schema: { fields: [] },
+            approval_graph: runtimeGraph,
+            created_at: new Date(),
+            updated_at: new Date(),
+          }],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith('SELECT * FROM approval_published_definitions')) {
+        return {
+          rows: [{
+            id: 'pub-2',
+            template_id: 'tpl-1',
+            template_version_id: 'ver-2',
+            runtime_graph: runtimeGraph,
+            is_active: true,
+            published_at: new Date(),
+          }],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith(`SELECT 'AP-' || nextval('approval_request_no_seq')::text AS request_no`)) {
+        return { rows: [{ request_no: 'AP-101001' }], rowCount: 1 }
+      }
+      throw new Error(`Unhandled pool query: ${statement}`)
+    })
+
+    pgState.client.query.mockImplementation(async (sql: string) => {
+      const statement = normalize(sql)
+      if (statement === 'BEGIN' || statement === 'COMMIT' || statement === 'ROLLBACK') {
+        return { rows: [], rowCount: 0 }
+      }
+      if (statement.startsWith('INSERT INTO approval_instances')) {
+        return { rows: [], rowCount: 1 }
+      }
+      if (statement.startsWith('INSERT INTO approval_assignments')) {
+        return { rows: [], rowCount: 1 }
+      }
+      if (statement.startsWith('INSERT INTO approval_records')) {
+        return { rows: [], rowCount: 1 }
+      }
+      throw new Error(`Unhandled client query: ${statement}`)
+    })
+
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const service = new ApprovalProductService(buildNoopMetrics() as never)
+    vi.spyOn(service, 'getApproval').mockResolvedValue(buildApprovalDto({
+      templateVersionId: 'ver-2',
+      publishedDefinitionId: 'pub-2',
+    }))
+
+    await service.createApproval(
+      { templateId: 'tpl-1', formData: {} },
+      { userId: 'requester-1' },
+    )
+
+    const versionSelect = pgState.pool.query.mock.calls.find(([sql]) =>
+      normalize(sql as string).startsWith('SELECT * FROM approval_template_versions WHERE id = $1'))
+    expect(versionSelect?.[1]).toEqual(['ver-2', 'tpl-1'])
+
+    const insertInstance = pgState.client.query.mock.calls.find(([sql]) =>
+      normalize(sql as string).startsWith('INSERT INTO approval_instances'))
+    expect(insertInstance?.[1]?.[11]).toBe('ver-2')
+    expect(insertInstance?.[1]?.[12]).toBe('pub-2')
+  })
+
+  it('advances existing approvals from the instance-bound stale published definition and form snapshot', async () => {
+    const frozenRuntimeGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        { key: 'approval_1', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['manager-1'] } },
+        {
+          key: 'legacy_condition',
+          type: 'condition',
+          config: {
+            branches: [{
+              edgeKey: 'edge-condition-old-high',
+              rules: [{ fieldId: 'legacyAmount', operator: 'gt', value: 100 }],
+            }],
+            defaultEdgeKey: 'edge-condition-old-low',
+          },
+        },
+        { key: 'approval_old_high', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['legacy-manager'] } },
+        { key: 'approval_old_low', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['fallback-manager'] } },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-approval', source: 'start', target: 'approval_1' },
+        { key: 'edge-approval-condition', source: 'approval_1', target: 'legacy_condition' },
+        { key: 'edge-condition-old-high', source: 'legacy_condition', target: 'approval_old_high' },
+        { key: 'edge-condition-old-low', source: 'legacy_condition', target: 'approval_old_low' },
+        { key: 'edge-old-high-end', source: 'approval_old_high', target: 'end' },
+        { key: 'edge-old-low-end', source: 'approval_old_low', target: 'end' },
+      ],
+      policy: { allowRevoke: true },
+    }
+
+    pgState.client.query.mockImplementation(async (sql: string, params?: unknown[]) => {
+      const statement = normalize(sql)
+      if (statement === 'BEGIN' || statement === 'COMMIT' || statement === 'ROLLBACK') {
+        return { rows: [], rowCount: 0 }
+      }
+      if (statement.startsWith('SELECT * FROM approval_instances WHERE id = $1')) {
+        return {
+          rows: [buildInstanceRow({
+            template_version_id: 'ver-old',
+            published_definition_id: 'pub-old',
+            form_snapshot: { legacyAmount: 250 },
+            current_step: 1,
+            total_steps: 3,
+            current_node_key: 'approval_1',
+          })],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith('SELECT * FROM approval_published_definitions WHERE id = $1')) {
+        expect(params).toEqual(['pub-old'])
+        return {
+          rows: [{
+            id: 'pub-old',
+            template_id: 'tpl-1',
+            template_version_id: 'ver-old',
+            runtime_graph: frozenRuntimeGraph,
+            is_active: false,
+            published_at: new Date('2026-04-11T00:00:00.000Z'),
+          }],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith('SELECT * FROM approval_assignments WHERE instance_id = $1')) {
+        return {
+          rows: [{
+            id: 'asg-manager-1',
+            instance_id: 'apr-1',
+            assignment_type: 'user',
+            assignee_id: 'manager-1',
+            source_step: 1,
+            node_key: 'approval_1',
+            is_active: true,
+            metadata: {},
+            created_at: new Date('2026-04-11T00:00:00.000Z'),
+            updated_at: new Date('2026-04-11T00:00:00.000Z'),
+          }],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith('UPDATE approval_assignments SET is_active = FALSE')) {
+        return { rows: [], rowCount: 1 }
+      }
+      if (statement.startsWith('UPDATE approval_instances SET status = $2')) {
+        expect(params).toEqual(['apr-1', 'pending', 3, 'approval_old_high', 2, 3])
+        return { rows: [], rowCount: 1 }
+      }
+      if (statement.startsWith('INSERT INTO approval_assignments')) {
+        expect(params).toEqual(['apr-1', 'user', 'legacy-manager', 2, 'approval_old_high'])
+        return { rows: [], rowCount: 1 }
+      }
+      if (statement.startsWith('INSERT INTO approval_records')) {
+        return { rows: [], rowCount: 1 }
+      }
+      throw new Error(`Unhandled query: ${statement}`)
+    })
+
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const service = new ApprovalProductService(buildNoopMetrics() as never)
+    vi.spyOn(service, 'getApproval').mockResolvedValue(buildApprovalDto({
+      templateVersionId: 'ver-old',
+      publishedDefinitionId: 'pub-old',
+      formSnapshot: { legacyAmount: 250 },
+      currentStep: 2,
+      totalSteps: 3,
+      currentNodeKey: 'approval_old_high',
+      assignments: [{
+        id: 'asg-legacy',
+        type: 'user',
+        assigneeId: 'legacy-manager',
+        sourceStep: 2,
+        nodeKey: 'approval_old_high',
+        isActive: true,
+        metadata: {},
+      }],
+    }))
+
+    const result = await service.dispatchAction(
+      'apr-1',
+      { action: 'approve', comment: 'use frozen runtime' },
+      { userId: 'manager-1' },
+    )
+
+    expect(result.templateVersionId).toBe('ver-old')
+    expect(result.publishedDefinitionId).toBe('pub-old')
+    expect(result.currentNodeKey).toBe('approval_old_high')
+
+    const statements = [
+      ...pgState.client.query.mock.calls,
+      ...pgState.pool.query.mock.calls,
+    ].map(([sql]) => normalize(sql as string))
+    expect(statements.some((statement) => statement.includes('approval_templates'))).toBe(false)
+    expect(statements.some((statement) => statement.includes('active_version_id'))).toBe(false)
+
+    const recordCall = pgState.client.query.mock.calls.find(([sql]) =>
+      normalize(sql as string).startsWith('INSERT INTO approval_records'))
+    expect(JSON.parse(String(recordCall?.[1]?.[9]))).toMatchObject({
+      nodeKey: 'approval_1',
+      nextNodeKey: 'approval_old_high',
+      aggregateComplete: true,
+    })
+  })
+
+  it('allows template version delete/archive checks when no unfinished instance references remain', async () => {
+    pgState.pool.query.mockResolvedValue({
+      rows: [{ unfinished_count: '0', sample_instance_id: null }],
+      rowCount: 1,
+    })
+
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const service = new ApprovalProductService()
+
+    await expect(service.assertTemplateVersionDeletable('ver-archive-safe')).resolves.toBeUndefined()
+
+    const statement = normalize(pgState.pool.query.mock.calls[0]?.[0] as string)
+    expect(statement).toContain("status NOT IN ('approved', 'rejected', 'revoked', 'cancelled')")
+    expect(statement).toContain('published_definition_id IN')
+    expect(pgState.pool.query.mock.calls[0]?.[1]).toEqual(['ver-archive-safe'])
+  })
+
+  it('blocks template version delete/archive checks with unfinished count and sample id', async () => {
+    pgState.pool.query.mockResolvedValue({
+      rows: [{ unfinished_count: '2', sample_instance_id: 'apr-pending-1' }],
+      rowCount: 1,
+    })
+
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const service = new ApprovalProductService()
+
+    await expect(service.assertTemplateVersionDeletable('ver-in-use')).rejects.toMatchObject({
+      message: expect.stringContaining('2 unfinished approval instance(s)'),
+      statusCode: 409,
+      code: 'APPROVAL_TEMPLATE_VERSION_IN_USE',
+      details: {
+        unfinishedCount: 2,
+        sampleInstanceId: 'apr-pending-1',
+      },
+    })
+    await expect(service.assertTemplateVersionDeletable('ver-in-use')).rejects.toThrow('apr-pending-1')
+  })
+
+  it('serializes publish with a template row lock and template-scoped active definition swap', async () => {
+    const runtimeGraph = buildRuntimeGraph()
+    const template = {
+      id: 'tpl-1',
+      key: 'travel',
+      name: 'Travel Approval',
+      description: null,
+      category: null,
+      visibility_scope: { type: 'all', ids: [] },
+      sla_hours: null,
+      status: 'draft',
+      active_version_id: 'ver-1',
+      latest_version_id: 'ver-2',
+      created_at: new Date(),
+      updated_at: new Date(),
+    }
+    const version = {
+      id: 'ver-2',
+      template_id: 'tpl-1',
+      version: 2,
+      status: 'draft',
+      form_schema: { fields: [] },
+      approval_graph: runtimeGraph,
+      created_at: new Date(),
+      updated_at: new Date(),
+    }
+
+    pgState.client.query.mockImplementation(async (sql: string) => {
+      const statement = normalize(sql)
+      if (statement === 'BEGIN' || statement === 'COMMIT' || statement === 'ROLLBACK') {
+        return { rows: [], rowCount: 0 }
+      }
+      if (statement.startsWith('SELECT * FROM approval_templates WHERE id = $1 FOR UPDATE')) {
+        return { rows: [template], rowCount: 1 }
+      }
+      if (statement.startsWith('SELECT * FROM approval_template_versions WHERE id = $1')) {
+        return { rows: [version], rowCount: 1 }
+      }
+      if (statement.startsWith('UPDATE approval_published_definitions SET is_active = FALSE')) {
+        return { rows: [], rowCount: 1 }
+      }
+      if (statement.startsWith('INSERT INTO approval_published_definitions')) {
+        return {
+          rows: [{
+            id: 'pub-2',
+            template_id: 'tpl-1',
+            template_version_id: 'ver-2',
+            runtime_graph: runtimeGraph,
+            is_active: true,
+            published_at: new Date(),
+          }],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith("UPDATE approval_template_versions SET status = 'published'")) {
+        return { rows: [{ ...version, status: 'published' }], rowCount: 1 }
+      }
+      if (statement.startsWith("UPDATE approval_templates SET status = 'published'")) {
+        return { rows: [], rowCount: 1 }
+      }
+      throw new Error(`Unhandled query: ${statement}`)
+    })
+
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const service = new ApprovalProductService()
+
+    const result = await service.publishTemplate('tpl-1', { policy: { allowRevoke: true } } as never)
+
+    expect(result.publishedDefinitionId).toBe('pub-2')
+    const statements = pgState.client.query.mock.calls.map(([sql]) => normalize(sql as string))
+    const lockIndex = statements.findIndex((statement) =>
+      statement.startsWith('SELECT * FROM approval_templates WHERE id = $1 FOR UPDATE'))
+    const deactivateIndex = statements.findIndex((statement) =>
+      statement.startsWith('UPDATE approval_published_definitions SET is_active = FALSE'))
+    const insertIndex = statements.findIndex((statement) =>
+      statement.startsWith('INSERT INTO approval_published_definitions'))
+    expect(lockIndex).toBeGreaterThanOrEqual(0)
+    expect(deactivateIndex).toBeGreaterThan(lockIndex)
+    expect(insertIndex).toBeGreaterThan(deactivateIndex)
+    expect(statements.filter((statement) => statement === 'COMMIT')).toHaveLength(1)
+  })
+
+  it('keeps only one active published definition across concurrent publish calls', async () => {
+    const runtimeGraph = buildRuntimeGraph()
+    const template = {
+      id: 'tpl-1',
+      key: 'travel',
+      name: 'Travel Approval',
+      description: null,
+      category: null,
+      visibility_scope: { type: 'all', ids: [] },
+      sla_hours: null,
+      status: 'draft',
+      active_version_id: 'ver-1',
+      latest_version_id: 'ver-2',
+      created_at: new Date(),
+      updated_at: new Date(),
+    }
+    const version = {
+      id: 'ver-2',
+      template_id: 'tpl-1',
+      version: 2,
+      status: 'draft',
+      form_schema: { fields: [] },
+      approval_graph: runtimeGraph,
+      created_at: new Date(),
+      updated_at: new Date(),
+    }
+    const publishedDefinitions = [
+      {
+        id: 'pub-1',
+        template_id: 'tpl-1',
+        template_version_id: 'ver-1',
+        runtime_graph: runtimeGraph,
+        is_active: true,
+        published_at: new Date(),
+      },
+    ]
+    let publishSequence = 1
+    let lockTail = Promise.resolve()
+    let releaseCurrentLock: (() => void) | null = null
+
+    async function acquireTemplateLock(): Promise<void> {
+      const previous = lockTail
+      let release!: () => void
+      lockTail = new Promise<void>((resolve) => {
+        release = resolve
+      })
+      await previous
+      releaseCurrentLock = release
+    }
+
+    function releaseTemplateLock(): void {
+      releaseCurrentLock?.()
+      releaseCurrentLock = null
+    }
+
+    function buildClient() {
+      const client = {
+        query: vi.fn(),
+        release: vi.fn(),
+      }
+      client.query.mockImplementation(async (sql: string) => {
+        const statement = normalize(sql)
+        if (statement === 'BEGIN') {
+          return { rows: [], rowCount: 0 }
+        }
+        if (statement === 'COMMIT' || statement === 'ROLLBACK') {
+          releaseTemplateLock()
+          return { rows: [], rowCount: 0 }
+        }
+        if (statement.startsWith('SELECT * FROM approval_templates WHERE id = $1 FOR UPDATE')) {
+          await acquireTemplateLock()
+          return { rows: [template], rowCount: 1 }
+        }
+        if (statement.startsWith('SELECT * FROM approval_template_versions WHERE id = $1')) {
+          return { rows: [version], rowCount: 1 }
+        }
+        if (statement.startsWith('UPDATE approval_published_definitions SET is_active = FALSE')) {
+          for (const definition of publishedDefinitions) {
+            if (definition.template_id === 'tpl-1') {
+              definition.is_active = false
+            }
+          }
+          return { rows: [], rowCount: publishedDefinitions.length }
+        }
+        if (statement.startsWith('INSERT INTO approval_published_definitions')) {
+          publishSequence += 1
+          const definition = {
+            id: `pub-${publishSequence}`,
+            template_id: 'tpl-1',
+            template_version_id: 'ver-2',
+            runtime_graph: runtimeGraph,
+            is_active: true,
+            published_at: new Date(),
+          }
+          publishedDefinitions.push(definition)
+          return { rows: [definition], rowCount: 1 }
+        }
+        if (statement.startsWith("UPDATE approval_template_versions SET status = 'published'")) {
+          return { rows: [{ ...version, status: 'published' }], rowCount: 1 }
+        }
+        if (statement.startsWith("UPDATE approval_templates SET status = 'published'")) {
+          template.status = 'published'
+          template.active_version_id = 'ver-2'
+          return { rows: [], rowCount: 1 }
+        }
+        throw new Error(`Unhandled query: ${statement}`)
+      })
+      return client
+    }
+
+    const clientA = buildClient()
+    const clientB = buildClient()
+    pgState.pool.connect
+      .mockResolvedValueOnce(clientA)
+      .mockResolvedValueOnce(clientB)
+
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const service = new ApprovalProductService()
+
+    await Promise.all([
+      service.publishTemplate('tpl-1', { policy: { allowRevoke: true } } as never),
+      service.publishTemplate('tpl-1', { policy: { allowRevoke: true } } as never),
+    ])
+
+    expect(publishedDefinitions.filter((definition) => definition.is_active)).toHaveLength(1)
+    expect(publishedDefinitions.at(-1)).toMatchObject({
+      template_version_id: 'ver-2',
+      is_active: true,
+    })
+    expect(clientA.release).toHaveBeenCalledTimes(1)
+    expect(clientB.release).toHaveBeenCalledTimes(1)
+  })
+
+  it('rolls back publish when the active definition insert fails', async () => {
+    const runtimeGraph = buildRuntimeGraph()
+    const template = {
+      id: 'tpl-1',
+      key: 'travel',
+      name: 'Travel Approval',
+      description: null,
+      category: null,
+      visibility_scope: { type: 'all', ids: [] },
+      sla_hours: null,
+      status: 'draft',
+      active_version_id: 'ver-1',
+      latest_version_id: 'ver-2',
+      created_at: new Date(),
+      updated_at: new Date(),
+    }
+    const version = {
+      id: 'ver-2',
+      template_id: 'tpl-1',
+      version: 2,
+      status: 'draft',
+      form_schema: { fields: [] },
+      approval_graph: runtimeGraph,
+      created_at: new Date(),
+      updated_at: new Date(),
+    }
+
+    pgState.client.query.mockImplementation(async (sql: string) => {
+      const statement = normalize(sql)
+      if (statement === 'BEGIN' || statement === 'ROLLBACK') {
+        return { rows: [], rowCount: 0 }
+      }
+      if (statement.startsWith('SELECT * FROM approval_templates WHERE id = $1 FOR UPDATE')) {
+        return { rows: [template], rowCount: 1 }
+      }
+      if (statement.startsWith('SELECT * FROM approval_template_versions WHERE id = $1')) {
+        return { rows: [version], rowCount: 1 }
+      }
+      if (statement.startsWith('UPDATE approval_published_definitions SET is_active = FALSE')) {
+        return { rows: [], rowCount: 1 }
+      }
+      if (statement.startsWith('INSERT INTO approval_published_definitions')) {
+        throw new Error('insert failed')
+      }
+      throw new Error(`Unhandled query: ${statement}`)
+    })
+
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const service = new ApprovalProductService()
+
+    await expect(service.publishTemplate('tpl-1', { policy: { allowRevoke: true } } as never))
+      .rejects.toThrow('insert failed')
+
+    const statements = pgState.client.query.mock.calls.map(([sql]) => normalize(sql as string))
+    expect(statements).toContain('ROLLBACK')
+    expect(statements).not.toContain('COMMIT')
+    expect(statements.some((statement) =>
+      statement.startsWith("UPDATE approval_templates SET status = 'published'"))).toBe(false)
+    expect(pgState.client.release).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
## Summary

Approval Phase 1 work — **PR1 `version-freeze-hardening`** + **PR2 `auto-approval-three-merge`** — re-homed onto the true `origin/main`.

The original lineage was developed on a local-only `main` that had diverged from `origin/main` (never an ancestor). This branch is the same 16-commit audited lineage replayed via `git rebase --onto origin/main <fork-point>` so it sits cleanly on real mainline. File overlap with the 18 intervening mainline commits was only `.gitignore` (auto-merged, both sides kept).

## What's included (16 commits, audit chain preserved — please do NOT squash)

- **PR1 version-freeze-hardening**: internal `assertTemplateVersionDeletable` guard (option a — no endpoint/UI), `loadTemplateBundle` misuse comment, regression tests pinning instance-bound `published_definition_id` as runtime source of truth, follow-ups A/B.
- **PR2 auto-approval-three-merge**: `RuntimePolicy.autoApproval` snapshotted into `runtime_graph` (zero migration), node-level override, three merge rules (requester / adjacent-transitive / historical-dedupe) with deterministic precedence, per-dispatch `APPROVAL_MAX_AUTO_STEPS=50` guard with rollback, S2 cross-branch refuse-and-warn, S3 audit reason taxonomy, B1 fix + M-T1 unit pin.
- Scope-gate / review-response / development / verification docs for both PRs and the yida benchmark research docs.

## Verification (run on top of real origin/main)

- `pnpm --filter @metasheet/core-backend test:unit` — PASS, 166 files / 2173 tests (approval + mainline tests green together, zero regression)
- `pnpm --filter @metasheet/core-backend build` — PASS (tsc clean)
- `pnpm type-check` — PASS (pnpm -r, apps/web Done)

## Changed files (expected: approval/yida docs + approval backend/test only)

- `docs/development/approval-pr1-*`, `docs/development/approval-pr2-*`, `docs/development/approval-phase1-*`
- `docs/research/yida-workflow-*`
- `packages/core-backend/src/services/ApprovalProductService.ts`, `ApprovalGraphExecutor.ts`
- `packages/core-backend/src/types/approval-product.ts`
- `packages/core-backend/tests/unit/approval-product-service.test.ts`
- `packages/core-backend/tests/integration/approval-pack1a-lifecycle.api.test.ts`
- `.gitignore` (union with mainline)

## Merge note

Single-maintainer self-review + admin-merge. **Preserve the 16-commit lineage (no squash)** so the per-PR scope-gate → implement → review → fix audit trail stays intact.

## Test plan

- [x] Backend unit suite green on origin/main base
- [x] Backend build + workspace type-check green
- [ ] Reviewer: confirm changed-files list on the PR page matches the expected approval/yida scope above
- [ ] Admin-merge without squash