### PR TITLE
Approval PR3: admin-jump-node (forward-only admin recovery jump)

### DIFF
--- a/docs/development/approval-pr3-admin-jump-node-development-20260515.md
+++ b/docs/development/approval-pr3-admin-jump-node-development-20260515.md
@@ -1,6 +1,6 @@
 # Approval PR3 admin-jump-node Development 2026-05-15
 
-PR: `admin-jump-node` · Branch: `flow/admin-jump-node-20260515` · Base: `origin/main` @ `0eb8c9639`
+PR: `admin-jump-node` · Branch: `flow/admin-jump-node-20260515` · Base: `origin/main` @ `e0721ed25`
 Gating scope gate: `docs/development/approval-pr3-scope-gate-response-20260515.md` (revised; verdict GO-after-prerequisites)
 Worksplit spec: `docs/development/approval-phase1-codex-claude-worksplit-todo-20260515.md` §5 PR3
 
@@ -10,7 +10,7 @@ This document records the prerequisite decisions and test commitment. Implementa
 
 ### PD1 — `approval_records.action` gains `'jump'` via new migration (option a)
 
-New migration `zzzz<ts>_add_jump_action_to_approval_records.ts`:
+New migration `zzzz20260515130000_add_jump_action_to_approval_records.ts`:
 
 - `up()`:
   - `ALTER TABLE approval_records DROP CONSTRAINT IF EXISTS approval_records_action_check`
@@ -31,7 +31,7 @@ Same new migration (or a sibling migration) also:
 
 Route gated: `r.post('/api/approvals/:id/jump', authenticate, rbacGuard('approvals:admin'), handler)`.
 
-`approvals` is in `NON_NAMESPACED_PERMISSION_RESOURCES` (`rbac/namespace-admission.ts`) → no namespace-admission entry/switch needed. Exact permission code: `approvals:admin`. Migration location: recorded here once the migration filename is created.
+`approvals` is in `NON_NAMESPACED_PERMISSION_RESOURCES` (`rbac/namespace-admission.ts`) → no namespace-admission entry/switch needed. Exact permission code: `approvals:admin`. Migration location: `packages/core-backend/src/db/migrations/zzzz20260515130000_add_jump_action_to_approval_records.ts`.
 
 ### PD3 — Parallel-region jump boundary (MVP)
 
@@ -62,7 +62,7 @@ Acceptance: `grep -rn "approval_records_action_check"` shows only the new migrat
 
 - `packages/core-backend/src/services/ApprovalProductService.ts` — new `adminJump(...)` + graph-local downstream-validation helper.
 - `packages/core-backend/src/routes/approvals.ts` — one new `POST /api/approvals/:id/jump`.
-- `packages/core-backend/src/db/migrations/zzzz<ts>_add_jump_action_to_approval_records.ts` — action constraint + `approvals:admin` permission/role_permission rows.
+- `packages/core-backend/src/db/migrations/zzzz20260515130000_add_jump_action_to_approval_records.ts` — action constraint + `approvals:admin` permission/role_permission rows.
 - `packages/core-backend/tests/helpers/approval-schema-bootstrap.ts` — CHECK sync (add `'jump'`).
 - `packages/core-backend/tests/unit/**/*approval*`, `packages/core-backend/tests/integration/**/*approval*` — test matrix below.
 - This dev doc + `approval-pr3-admin-jump-node-verification-20260515.md`.
@@ -99,10 +99,35 @@ pnpm type-check
 
 Migration rollback (T11) requires a scratch DB. If the local integration env remains DB-gated, the verification doc must explicitly state T11/T-bootstrap as DB-required and not silently skip (avoid [[feedback_metasheet2_skip_when_unreachable_blind_spot]]).
 
+## Implementation Record
+
+Implemented on top of `origin/main@e0721ed25` after two rebase checks (`behind > 0` was resolved before final docs). The implementation stayed inside the expected files plus this PR's verification/review docs.
+
+- Service: `ApprovalProductService.adminJump()` locks the instance with `FOR UPDATE`, checks optimistic `version`, rejects terminal/non-pending instances, loads the frozen runtime graph by `instance.published_definition_id`, validates approval-node targets, enforces forward-only reachability, clears parallel state, deactivates old assignments, inserts target assignments, writes a `jump` audit record with the real admin actor, emits `approval.admin_jumped`, and returns the refreshed approval DTO.
+- Parallel MVP: `parallelBranchStates` changes the reachability base to `joinNodeKey`; branch-contained targets return `APPROVAL_JUMP_PARALLEL_BRANCH_TARGET_UNSUPPORTED`; valid post-join jumps clear `parallelBranchStates`.
+- Route: `POST /api/approvals/:id/jump` is gated by `authenticate` + `rbacGuard('approvals:admin')` and requires `version`, `targetNodeKey`, and `reason` (or `comment` as a compatibility alias).
+- Migration/bootstrap: the new migration adds `jump` and `approvals:admin`; `down()` deletes `role_permissions` before `permissions` and restores the old action CHECK with `NOT VALID`. `approval-schema-bootstrap.ts` was bumped and synced with `'jump'`.
+
+## Test Coverage Map
+
+| ID | Local coverage |
+|---|---|
+| T1 | `approval-rbac-boundary.test.ts` covers no auth, `approvals:act` without admin, `approval-templates:manage` without admin, and `approvals:admin` handler reachability. |
+| T2/T3 | `approval-admin-jump-service.test.ts` rejects terminal state and stale version before mutation/runtime load. |
+| T4 | Service unit asserts frozen `approval_published_definitions` query uses `instance.published_definition_id` and no `approval_templates`/`approval_template_versions`/`active_version_id` SQL appears. |
+| T5 | Service unit covers nonexistent target and existing non-approval `cc` target. |
+| T6 | Service unit covers backward non-downstream target rejection. |
+| T7/T10/T13 | Service unit covers deactivation, target assignment insert, admin actor audit, event payload, and no template binding mutation. |
+| T8 | Service unit verifies the prior assignee cannot `approve` once only the target-node assignment remains active. |
+| T9 | Service unit covers in-branch target rejection and post-join jump state clear. |
+| T11 | Source/unit coverage asserts migration up/down shape, `NOT VALID`, and FK-safe delete order. Data-bearing up/down/up remains DB-required and is explicitly recorded in verification. |
+| T12 | Service unit covers stale second jump behavior (`version` mismatch -> 409) plus implementation uses `SELECT ... FOR UPDATE`. |
+| T-bootstrap | Source/unit coverage asserts bootstrap version bump and CHECK includes `'jump'`. |
+
 ## Out Of Scope
 
 Jump-into-specific-branch (separate ADR); backward jump (separate ADR, worksplit §8); add-sign (PR4); any PR2 auto-approval region; historical migration edits; UI.
 
 ## Status
 
-Prerequisites recorded. Ready for implementation on explicit opt-in ([[feedback_staged_optin_lineage]]).
+Implementation complete locally. Ready for §7.2 independent review after verification doc + review request are committed.

--- a/docs/development/approval-pr3-admin-jump-node-development-20260515.md
+++ b/docs/development/approval-pr3-admin-jump-node-development-20260515.md
@@ -1,0 +1,108 @@
+# Approval PR3 admin-jump-node Development 2026-05-15
+
+PR: `admin-jump-node` · Branch: `flow/admin-jump-node-20260515` · Base: `origin/main` @ `0eb8c9639`
+Gating scope gate: `docs/development/approval-pr3-scope-gate-response-20260515.md` (revised; verdict GO-after-prerequisites)
+Worksplit spec: `docs/development/approval-phase1-codex-claude-worksplit-todo-20260515.md` §5 PR3
+
+This document records the prerequisite decisions and test commitment. Implementation may begin once this is complete.
+
+## Prerequisite Decisions
+
+### PD1 — `approval_records.action` gains `'jump'` via new migration (option a)
+
+New migration `zzzz<ts>_add_jump_action_to_approval_records.ts`:
+
+- `up()`:
+  - `ALTER TABLE approval_records DROP CONSTRAINT IF EXISTS approval_records_action_check`
+  - `ADD CONSTRAINT approval_records_action_check CHECK (action IN ('created','approve','reject','return','revoke','transfer','sign','comment','cc','remind','jump'))`
+- `down()` (exact, no interpretation):
+  - `ALTER TABLE approval_records DROP CONSTRAINT IF EXISTS approval_records_action_check`
+  - `ADD CONSTRAINT approval_records_action_check CHECK (action IN ('created','approve','reject','return','revoke','transfer','sign','comment','cc','remind')) NOT VALID`
+  - `NOT VALID` is mandatory so pre-existing `'jump'` rows do not block the rollback while still rejecting new `'jump'` inserts.
+
+Rationale: admin-jump is a strong-permission, audit-critical recovery action; reusing `'transfer'` would obscure timeline semantics (worksplit §8). Accepting (a) makes PR3 a migration PR — T11 rollback verification is mandatory.
+
+### PD2 — `approvals:admin` permission, concrete registration
+
+Same new migration (or a sibling migration) also:
+
+- `up()`: inserts `permissions(code='approvals:admin', ...)`, then inserts `role_permissions` linking `approvals:admin` to the admin role.
+- `down()` (FK-safe order, mandatory): DELETE the `role_permissions` rows for `approvals:admin` FIRST, THEN DELETE the `permissions` row. Reversing the order violates the `role_permissions → permissions` FK.
+
+Route gated: `r.post('/api/approvals/:id/jump', authenticate, rbacGuard('approvals:admin'), handler)`.
+
+`approvals` is in `NON_NAMESPACED_PERMISSION_RESOURCES` (`rbac/namespace-admission.ts`) → no namespace-admission entry/switch needed. Exact permission code: `approvals:admin`. Migration location: recorded here once the migration filename is created.
+
+### PD3 — Parallel-region jump boundary (MVP)
+
+- Forward-reachability base: when `metadata.parallelBranchStates` is present, compute reachability from the parallel **JOIN node**, NOT from `current_node_key` (which is the fork; from the fork every branch node is reachable, which would wrongly admit sibling-branch targets).
+- A jump target located inside ANY parallel branch → `400`.
+- Only post-join downstream targets are valid. On a valid post-join jump: deactivate ALL active branch assignments, clear `metadata.parallelBranchStates`, re-resolve the target node.
+- Jump-into-a-specific-branch is OUT OF SCOPE for PR3 → tracked as a separate future ADR.
+
+### Target node-type rule (general)
+
+`targetNodeKey` MUST resolve to an `approval`-type node in the bound runtime graph. Only `approval` nodes create human assignments; jumping to `start`/`end`/`condition`/`cc`/parallel-fork/join nodes is semantically invalid → `400`. Enforced independently of forward-reachability and covered by T5(b).
+
+## B3 — Constraint Definition Sync Plan
+
+`approval_records_action_check` is defined in 4 files (full-repo sweep). Sync surface:
+
+- EDIT (must carry `'jump'`):
+  - the NEW PR3 migration (PD1)
+  - `packages/core-backend/tests/helpers/approval-schema-bootstrap.ts:180` — add `'jump'` to its rebuilt CHECK
+- DO NOT EDIT (applied/immutable history; superseded at runtime by the new migration):
+  - `packages/core-backend/src/db/migrations/zzzz20260411123000_add_created_action_to_approval_records.ts`
+  - `packages/core-backend/src/db/migrations/zzzz20260411120100_approval_templates_and_instance_extensions.ts`
+  - `packages/core-backend/src/db/migrations/zzzz20260423120000_add_remind_action_to_approval_records.ts`
+
+Acceptance: `grep -rn "approval_records_action_check"` shows only the new migration and schema-bootstrap carry `'jump'`; the 3 historical migrations are unchanged by this PR.
+
+## Expected Files
+
+- `packages/core-backend/src/services/ApprovalProductService.ts` — new `adminJump(...)` + graph-local downstream-validation helper.
+- `packages/core-backend/src/routes/approvals.ts` — one new `POST /api/approvals/:id/jump`.
+- `packages/core-backend/src/db/migrations/zzzz<ts>_add_jump_action_to_approval_records.ts` — action constraint + `approvals:admin` permission/role_permission rows.
+- `packages/core-backend/tests/helpers/approval-schema-bootstrap.ts` — CHECK sync (add `'jump'`).
+- `packages/core-backend/tests/unit/**/*approval*`, `packages/core-backend/tests/integration/**/*approval*` — test matrix below.
+- This dev doc + `approval-pr3-admin-jump-node-verification-20260515.md`.
+
+## Test Matrix Commitment
+
+All tests below are committed. For each, the verification doc must record that the test FAILS without the corresponding guard/change (effectiveness evidence), per [[feedback_metasheet2_pr_hardening_checklist]].
+
+| ID | Assertion | Fails-without |
+|---|---|---|
+| T1 | non-admin → 403; AND user with `approvals:act`/`approval-templates:manage` but NOT `approvals:admin` → still 403 | permission gate / privilege separation |
+| T2 | terminal instance (APPROVAL_TERMINAL_STATUSES) → rejected | terminal guard |
+| T3 | stale `version` → 409 | optimistic version |
+| T4 | mock-pool: published-def query keys on `instance.published_definition_id`; zero `approval_templates`/`active_version_id` read | version-freeze invariant |
+| T5 | invalid target → 400, covering BOTH: (a) nonexistent nodeKey, AND (b) existing node whose type is not `approval` (start/end/condition/cc/parallel-fork/join) | target existence + type check |
+| T6 | backward / lateral non-downstream target → 400 | forward-only check |
+| T7 | valid forward jump: old assignments deactivated, target assignments created, advances from target | core jump |
+| T8 | old assignee cannot act post-jump → rejected | assignment deactivation |
+| T9 | parallel: in-branch target → 400; valid post-join → all branch assignments deactivated + parallelBranchStates cleared + coherent advance; reachability base = join node | PD3 boundary |
+| T10 | audit payload complete; actor_id = admin user (not system:*) | audit |
+| T11 | up → insert jump row → down (succeeds w/ jump row) → fresh jump insert rejected → up → jump insert accepted | PD1 migration rollback (data-bearing) |
+| T12 | FOR UPDATE + optimistic version; 2nd concurrent jump → 409 | concurrency |
+| T13 | jump does NOT mutate `template_version_id` / `published_definition_id` | version binding |
+| T-bootstrap | `approval-schema-bootstrap.ts` rebuilt CHECK includes `'jump'` | B3 sync (PR2-B1-class regression guard) |
+
+## Verification Plan
+
+```bash
+pnpm --filter @metasheet/core-backend test:unit
+pnpm --filter @metasheet/core-backend test:integration   # DB-gated; compare against baseline, T11/T-bootstrap require DB
+pnpm --filter @metasheet/core-backend build
+pnpm type-check
+```
+
+Migration rollback (T11) requires a scratch DB. If the local integration env remains DB-gated, the verification doc must explicitly state T11/T-bootstrap as DB-required and not silently skip (avoid [[feedback_metasheet2_skip_when_unreachable_blind_spot]]).
+
+## Out Of Scope
+
+Jump-into-specific-branch (separate ADR); backward jump (separate ADR, worksplit §8); add-sign (PR4); any PR2 auto-approval region; historical migration edits; UI.
+
+## Status
+
+Prerequisites recorded. Ready for implementation on explicit opt-in ([[feedback_staged_optin_lineage]]).

--- a/docs/development/approval-pr3-admin-jump-node-development-20260515.md
+++ b/docs/development/approval-pr3-admin-jump-node-development-20260515.md
@@ -104,6 +104,7 @@ Migration rollback (T11) requires a scratch DB. If the local integration env rem
 Implemented on top of `origin/main@e0721ed25` after two rebase checks (`behind > 0` was resolved before final docs). The implementation stayed inside the expected files plus this PR's verification/review docs.
 
 - Service: `ApprovalProductService.adminJump()` locks the instance with `FOR UPDATE`, checks optimistic `version`, rejects terminal/non-pending instances, loads the frozen runtime graph by `instance.published_definition_id`, validates approval-node targets, enforces forward-only reachability, clears parallel state, deactivates old assignments, inserts target assignments, writes a `jump` audit record with the real admin actor, emits `approval.admin_jumped`, and returns the refreshed approval DTO.
+- Auto-approval composition: after the admin jump resolves the target approval node, PR2 auto-approval policy is intentionally applied through the existing cascade path so node-entry behavior is consistent with create/advance.
 - Parallel MVP: `parallelBranchStates` changes the reachability base to `joinNodeKey`; branch-contained targets return `APPROVAL_JUMP_PARALLEL_BRANCH_TARGET_UNSUPPORTED`; valid post-join jumps clear `parallelBranchStates`.
 - Route: `POST /api/approvals/:id/jump` is gated by `authenticate` + `rbacGuard('approvals:admin')` and requires `version`, `targetNodeKey`, and `reason` (or `comment` as a compatibility alias).
 - Migration/bootstrap: the new migration adds `jump` and `approvals:admin`; `down()` deletes `role_permissions` before `permissions` and restores the old action CHECK with `NOT VALID`. `approval-schema-bootstrap.ts` was bumped and synced with `'jump'`.
@@ -120,6 +121,7 @@ Implemented on top of `origin/main@e0721ed25` after two rebase checks (`behind >
 | T7/T10/T13 | Service unit covers deactivation, target assignment insert, admin actor audit, event payload, and no template binding mutation. |
 | T8 | Service unit verifies the prior assignee cannot `approve` once only the target-node assignment remains active. |
 | T9 | Service unit covers in-branch target rejection and post-join jump state clear. |
+| NB1 | Service unit covers jump into a requester-merge target node and verifies the target auto-approval record plus next active assignment. |
 | T11 | Source/unit coverage asserts migration up/down shape, `NOT VALID`, and FK-safe delete order. Data-bearing up/down/up remains DB-required and is explicitly recorded in verification. |
 | T12 | Service unit covers stale second jump behavior (`version` mismatch -> 409) plus implementation uses `SELECT ... FOR UPDATE`. |
 | T-bootstrap | Source/unit coverage asserts bootstrap version bump and CHECK includes `'jump'`. |

--- a/docs/development/approval-pr3-admin-jump-node-verification-20260515.md
+++ b/docs/development/approval-pr3-admin-jump-node-verification-20260515.md
@@ -2,6 +2,7 @@
 
 Branch: `flow/admin-jump-node-20260515`  
 Base: `origin/main@e0721ed25`  
+Base recheck after §7.2 review: `git rev-list --count HEAD..origin/main` returned `0`.
 Scope: PR3 `admin-jump-node`
 
 ## Summary
@@ -10,6 +11,7 @@ Implemented and locally verified the PR3 admin jump backend slice:
 
 - `POST /api/approvals/:id/jump` with `approvals:admin`.
 - `ApprovalProductService.adminJump()` using the instance-bound frozen runtime graph.
+- Intentional composition with PR2 auto-approval policies when the jumped-to approval node qualifies for auto merge.
 - New `approval_records.action = 'jump'` migration plus `approvals:admin` RBAC seed.
 - `approval-schema-bootstrap.ts` action CHECK sync.
 - Unit coverage for T1-T13 semantics except the DB-required data-bearing rollback cycle, which is explicitly blocked by the local integration DB environment.
@@ -31,11 +33,11 @@ pnpm type-check
 
 | Command | Result |
 |---|---|
-| Target service unit | PASS: 1 file / 6 tests |
+| Target service unit | PASS: 1 file / 7 tests |
 | Target migration/bootstrap unit | PASS: 1 file / 5 tests |
 | Target RBAC unit | PASS: 1 file / 24 tests |
 | `@metasheet/core-backend build` | PASS: `tsc` clean |
-| `@metasheet/core-backend test:unit` | PASS: 168 files / 2192 tests |
+| `@metasheet/core-backend test:unit` | PASS: 168 files / 2193 tests |
 | `pnpm type-check` | PASS: workspace type-check completed |
 | `@metasheet/core-backend test:integration` | FAIL: 42 files = 11 failed / 20 passed / 11 skipped; local DB/integration baseline blockers, not PR3-specific |
 
@@ -61,6 +63,17 @@ T-bootstrap was verified by source/unit check:
 
 - `approval-schema-bootstrap.ts` version was bumped to `20260515-pr3-admin-jump-action`.
 - The rebuilt `approval_records_action_check` includes `'jump'`.
+
+## Review Follow-ups
+
+NB1 was handled in this PR:
+
+- `adminJump()` now has an inline comment documenting that jump node-entry intentionally composes with PR2 auto-approval.
+- `approval-admin-jump-service.test.ts` includes a jump-to-requester-merge test. It verifies that jumping to an approval node whose assignee is the requester auto-approves that target node, records an `auto-merge-requester` approval record, and persists the next active assignment.
+
+NB2 was handled with an inline comment explaining the `currentStep ?? instance.total_steps` fallback for terminal cascades.
+
+NB3 was rechecked after review. The branch is still based on `origin/main@e0721ed25` with `behind 0`, so the existing base string is current.
 
 ## Noise Handling
 

--- a/docs/development/approval-pr3-admin-jump-node-verification-20260515.md
+++ b/docs/development/approval-pr3-admin-jump-node-verification-20260515.md
@@ -1,0 +1,71 @@
+# Approval PR3 Admin Jump Verification 2026-05-15
+
+Branch: `flow/admin-jump-node-20260515`  
+Base: `origin/main@e0721ed25`  
+Scope: PR3 `admin-jump-node`
+
+## Summary
+
+Implemented and locally verified the PR3 admin jump backend slice:
+
+- `POST /api/approvals/:id/jump` with `approvals:admin`.
+- `ApprovalProductService.adminJump()` using the instance-bound frozen runtime graph.
+- New `approval_records.action = 'jump'` migration plus `approvals:admin` RBAC seed.
+- `approval-schema-bootstrap.ts` action CHECK sync.
+- Unit coverage for T1-T13 semantics except the DB-required data-bearing rollback cycle, which is explicitly blocked by the local integration DB environment.
+
+## Commands Run
+
+```bash
+pnpm install --frozen-lockfile
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-admin-jump-service.test.ts --watch=false
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-admin-jump-migration.test.ts --watch=false
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-rbac-boundary.test.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/core-backend test:unit
+pnpm --filter @metasheet/core-backend test:integration
+pnpm type-check
+```
+
+## Results
+
+| Command | Result |
+|---|---|
+| Target service unit | PASS: 1 file / 6 tests |
+| Target migration/bootstrap unit | PASS: 1 file / 5 tests |
+| Target RBAC unit | PASS: 1 file / 24 tests |
+| `@metasheet/core-backend build` | PASS: `tsc` clean |
+| `@metasheet/core-backend test:unit` | PASS: 168 files / 2192 tests |
+| `pnpm type-check` | PASS: workspace type-check completed |
+| `@metasheet/core-backend test:integration` | FAIL: 42 files = 11 failed / 20 passed / 11 skipped; local DB/integration baseline blockers, not PR3-specific |
+
+## Integration Blockers
+
+The full integration suite remains blocked in this local environment. Final run result: 11 failed files, 20 passed files, 11 skipped files; 13 failed tests, 423 passed tests, 50 skipped tests. Key errors observed:
+
+- `DATABASE_URL is required for after-sales plugin install integration tests`
+- `database "chouhua" does not exist`
+- `approval-pack1a-lifecycle.api.test.ts` failed while running `ensureApprovalSchemaReady()` at `approval-schema-bootstrap.ts:57`.
+
+The run also surfaced existing non-approval integration failures/timeouts in multitable, spreadsheet, kanban, snapshot, and admin-user suites. Because `approval-pack1a-lifecycle.api.test.ts` cannot connect to a real DB here, the data-bearing T11 cycle was not executed.
+
+## T11 / T-bootstrap Status
+
+T11 was not silently skipped:
+
+- Source/unit checks verify the new migration has `up()`/`down()`, includes `'jump'` in `up()`, restores the pre-jump CHECK with `NOT VALID` in `down()`, and deletes `role_permissions` before `permissions`.
+- A real DB data cycle remains required: `up -> insert jump row -> down -> reject fresh jump -> up -> accept fresh jump`.
+- The attempted integration run confirms the blocker is environment-level DB availability (`database "chouhua" does not exist`), not a green-but-unexecuted approval path.
+
+T-bootstrap was verified by source/unit check:
+
+- `approval-schema-bootstrap.ts` version was bumped to `20260515-pr3-admin-jump-action`.
+- The rebuilt `approval_records_action_check` includes `'jump'`.
+
+## Noise Handling
+
+`pnpm install --frozen-lockfile` was required because this isolated worktree did not have `node_modules`. It rewrote a few tracked plugin/tool `node_modules` symlink files; those dependency-link changes were restored and are not part of the PR diff.
+
+## Residual Risk
+
+The remaining risk is DB-only: the migration's data-bearing rollback sequence must be run on a scratch PostgreSQL database before merge if the reviewer requires strict T11 completion. The unit/source checks make the intended DDL explicit, but they are not a substitute for the data-cycle run.

--- a/docs/development/approval-pr3-review-request-20260515.md
+++ b/docs/development/approval-pr3-review-request-20260515.md
@@ -4,6 +4,7 @@ Requesting §7.2 independent review for PR3 `admin-jump-node`.
 
 Branch: `flow/admin-jump-node-20260515`  
 Base: `origin/main@e0721ed25`  
+Base recheck after §7.2 review: `git rev-list --count HEAD..origin/main` returned `0`.
 Worktree: `/Users/chouhua/Downloads/Github/metasheet2-flow-admin-jump-node-20260515`
 
 ## Diff Summary
@@ -12,6 +13,7 @@ Adds backend-only admin jump support for platform approvals:
 
 - New `POST /api/approvals/:id/jump` route gated by `approvals:admin`.
 - New `ApprovalProductService.adminJump()` that locks the instance, validates stale version/terminal state, validates forward-only approval-node targets on the frozen runtime graph, deactivates old assignments, creates target assignments, clears parallel state when needed, writes a `jump` audit record, emits `approval.admin_jumped`, and returns the refreshed approval.
+- PR2 auto-approval composition is intentional: after jump node-entry, enabled requester/adjacent/historical auto policies can advance the target node through the same cascade used by create/advance.
 - New migration adding `approval_records.action = 'jump'` and seeding `approvals:admin`.
 - Bootstrap CHECK sync and unit coverage for T1-T13 / T-bootstrap boundaries.
 
@@ -57,9 +59,9 @@ pnpm type-check
 
 Results:
 
-- Target units: PASS (`6 + 5 + 24` tests).
+- Target units: PASS (`7 + 5 + 24` tests).
 - Backend build: PASS.
-- Full backend unit: PASS (`168 files / 2192 tests`).
+- Full backend unit: PASS (`168 files / 2193 tests`).
 - Workspace type-check: PASS.
 - Integration: FAIL (`11 failed / 20 passed / 11 skipped` files) due local DB/baseline blockers, including `DATABASE_URL is required` and `database "chouhua" does not exist`; see verification doc.
 

--- a/docs/development/approval-pr3-review-request-20260515.md
+++ b/docs/development/approval-pr3-review-request-20260515.md
@@ -1,0 +1,79 @@
+# Approval PR3 Review Request 2026-05-15
+
+Requesting §7.2 independent review for PR3 `admin-jump-node`.
+
+Branch: `flow/admin-jump-node-20260515`  
+Base: `origin/main@e0721ed25`  
+Worktree: `/Users/chouhua/Downloads/Github/metasheet2-flow-admin-jump-node-20260515`
+
+## Diff Summary
+
+Adds backend-only admin jump support for platform approvals:
+
+- New `POST /api/approvals/:id/jump` route gated by `approvals:admin`.
+- New `ApprovalProductService.adminJump()` that locks the instance, validates stale version/terminal state, validates forward-only approval-node targets on the frozen runtime graph, deactivates old assignments, creates target assignments, clears parallel state when needed, writes a `jump` audit record, emits `approval.admin_jumped`, and returns the refreshed approval.
+- New migration adding `approval_records.action = 'jump'` and seeding `approvals:admin`.
+- Bootstrap CHECK sync and unit coverage for T1-T13 / T-bootstrap boundaries.
+
+## Changed Files
+
+Expected PR3 files only:
+
+- `docs/development/approval-pr3-admin-jump-node-development-20260515.md`
+- `docs/development/approval-pr3-admin-jump-node-verification-20260515.md`
+- `docs/development/approval-pr3-review-request-20260515.md`
+- `packages/core-backend/src/db/migrations/zzzz20260515130000_add_jump_action_to_approval_records.ts`
+- `packages/core-backend/src/routes/approvals.ts`
+- `packages/core-backend/src/services/ApprovalProductService.ts`
+- `packages/core-backend/tests/helpers/approval-schema-bootstrap.ts`
+- `packages/core-backend/tests/unit/approval-admin-jump-migration.test.ts`
+- `packages/core-backend/tests/unit/approval-admin-jump-service.test.ts`
+- `packages/core-backend/tests/unit/approval-rbac-boundary.test.ts`
+
+No UI, automation, SLA, breach, PR2 auto-approval region, or historical migration edits.
+
+## Migration Summary
+
+Migration: `zzzz20260515130000_add_jump_action_to_approval_records.ts`
+
+- `up()` drops/recreates `approval_records_action_check` with `'jump'`.
+- `up()` inserts `permissions(code='approvals:admin')`.
+- `up()` inserts `role_permissions(role_id='admin', permission_code='approvals:admin')`.
+- `down()` deletes `role_permissions` first, then `permissions`.
+- `down()` restores the old action CHECK without `'jump'` using `NOT VALID`.
+- `approval-schema-bootstrap.ts` was bumped and synced with the new action list.
+
+## Tests Run
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-admin-jump-service.test.ts --watch=false
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-admin-jump-migration.test.ts --watch=false
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-rbac-boundary.test.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/core-backend test:unit
+pnpm --filter @metasheet/core-backend test:integration
+pnpm type-check
+```
+
+Results:
+
+- Target units: PASS (`6 + 5 + 24` tests).
+- Backend build: PASS.
+- Full backend unit: PASS (`168 files / 2192 tests`).
+- Workspace type-check: PASS.
+- Integration: FAIL (`11 failed / 20 passed / 11 skipped` files) due local DB/baseline blockers, including `DATABASE_URL is required` and `database "chouhua" does not exist`; see verification doc.
+
+## Known Gaps
+
+- T11 data-bearing migration rollback was not executed because the local integration DB is unavailable. Source/unit checks cover DDL shape, `NOT VALID`, FK-safe down order, and bootstrap sync; a scratch PostgreSQL data-cycle remains required for strict DB verification.
+- Full integration suite has existing unrelated failures/timeouts in multitable/spreadsheet/kanban/snapshot/admin-user areas on this machine.
+
+## Review Focus
+
+1. Version-freeze invariant: target graph validation must read only `instance.published_definition_id`.
+2. Forward-only semantics and PD3 parallel base = join node.
+3. Parallel cleanup: all active branch assignments deactivated and `parallelBranchStates` removed.
+4. Audit/event payload: real admin `actor_id`, reason, old/new assignees, from/to nodes.
+5. Migration DDL: `jump`, `approvals:admin`, FK-safe `down()`, `NOT VALID`.
+6. B3 sync: new migration + bootstrap only; historical migrations untouched.
+7. Scope boundary: no automation/SLA/breach/UI/PR2-auto-approval edits.

--- a/docs/development/approval-pr3-review-response-20260515.md
+++ b/docs/development/approval-pr3-review-response-20260515.md
@@ -1,0 +1,82 @@
+# Approval PR3 Review Response 2026-05-15
+
+§7.2 independent review of PR3 `admin-jump-node`, commit `f262b95de feat(approval): add admin jump node`, against revised scope gate `approval-pr3-scope-gate-response-20260515.md` + dev doc.
+
+Reviewer: Claude
+Worktree: `/Users/chouhua/Downloads/Github/metasheet2-flow-admin-jump-node-20260515`
+Branch state: ahead 2 / behind 0 (anchor `3d0262b86` + impl `f262b95de`); worktree clean.
+
+## Verdict
+
+APPROVE. No blocking findings. The implementation faithfully realizes PD1/PD2/PD3 + Fix1/Fix2 + B3 and preserves the PR1 version-freeze invariant. One acknowledged residual (T11 data-bearing rollback requires scratch PG) is explicitly documented, not hidden, and the migration is verified correct by inspection. Three non-blocking follow-ups recommended.
+
+## Code-Grounded Verification
+
+R1 — Version-freeze (HIGH): `adminJump` loads runtime ONLY via `SELECT * FROM approval_published_definitions WHERE id = $1` keyed on `instance.published_definition_id` (svc diff L175-185); all target/forward validation runs on that frozen `runtimeGraph`. Zero read of `approval_templates`/`active_version_id`. T4 negative-asserts exactly this (`.some(includes('approval_templates'))===false`, same for `approval_template_versions`, `active_version_id`). Invariant preserved. ✅
+
+R5 — Concurrency: `... FOR UPDATE` on the instance row (L139) + optimistic `version` mismatch → 409 `APPROVAL_VERSION_CONFLICT` (L146-153); BEGIN/COMMIT + `rollbackQuietly` on error. T6/T12 cover stale double-jump → 409. ✅
+
+Guards: terminal status → 409 (L154-160, uses `APPROVAL_TERMINAL_STATUSES`); non-`pending` → 409 (L161-167); no `published_definition_id` → 409; no `current_node_key` → 409; `COALESCE(source_system,'platform')='platform'` correctly scopes to platform approvals only (excludes after-sales/legacy bridges). ✅
+
+Fix2 — Target node-type: target not found → 400; `targetNode.type !== 'approval'` → 400 `APPROVAL_JUMP_TARGET_INVALID` (L186-192). T5 covers both (a) nonexistent and (b) non-approval node. ✅
+
+PD3 — Parallel base = JOIN: when `parallelState` present, in-branch target → 400 `APPROVAL_JUMP_PARALLEL_BRANCH_TARGET_UNSUPPORTED` (L199-205); `reachabilityBaseNodeKey = parallelState.joinNodeKey` (L206) — base is the JOIN node, NOT the fork. T9 verifies both (branch target → 400; post-join target succeeds + parallel state cleared). ✅
+
+R3 — Parallel cleanup: `deactivateAllActiveAssignments` + `metadata = COALESCE(metadata,'{}'::jsonb) - 'parallelBranchStates'` (L238-246). T9 asserts the JSONB key removal in the UPDATE. ✅
+
+Forward-only: `isReachableDownstream(runtimeGraph, reachabilityBaseNodeKey, targetNodeKey)` on the frozen graph; backward/lateral → 400 `APPROVAL_JUMP_TARGET_NOT_FORWARD` (L209-215). T6 covers backward rejection. ✅
+
+R4 — Audit/event: `insertApprovalRecord` action `'jump'`, `actorId = actor.userId` (REAL admin, not `system:*`), full metadata (fromNodeKey/toNodeKey/nextNodeKey/oldAssignees/newAssignees/reason/actorId/parallelStateCleared); `eventBus.emit('approval.admin_jumped', …)` emitted AFTER `COMMIT` (L283/L309-311) so no event on rollback. T4/T10 assert audit + event payload incl. `actorId:'admin-1'`. ✅
+
+PD1 migration `zzzz20260515130000`: `up()` DROP+ADD CHECK incl. `'jump'`; `down()` DROP+ADD old set `NOT VALID` (pre-existing jump rows don't block rollback; new jump inserts rejected post-down). DDL shape matches PD1 exactly. ✅
+
+PD2 migration: `up()` inserts `permissions(code,name,description)` + `role_permissions(role_id,permission_code)` (column names verified against `20250924190000_create_rbac_tables.ts` — exact match), both `ON CONFLICT DO NOTHING`; `down()` deletes `role_permissions` FIRST then `permissions` (FK-safe order = Fix1). ✅
+
+B3 sync: `approval-schema-bootstrap.ts:180` CHECK now includes `'jump'` AND `APPROVAL_SCHEMA_BOOTSTRAP_VERSION` bumped to `20260515-pr3-admin-jump-action` (forces re-bootstrap so the new constraint takes effect). 3 historical migrations untouched. ✅
+
+T1 strengthened: `describe('PR3: Admin jump boundary')` — `approvals:act` w/o `approvals:admin` → 403; `approval-templates:manage` w/o `approvals:admin` → 403; `approvals:admin` → reaches handler; no-auth → 401. Privilege separation fully covered. ✅
+
+## Findings (§7.2 order)
+
+1. Blocking correctness: NONE.
+2. Security/permission: NONE. RBAC gate + privilege separation tested; non-repudiable admin actor; platform-only scoping.
+3. Missing tests: NONE required missing (T1-T13 + T-bootstrap present; spot-checked T4/T9/T1 effective). Two emergent-interaction notes below.
+4. Scope creep: NONE. 10 files all in expected list. `ApprovalProductService.ts +283` adds `adminJump` and CALLS PR2 `applyAutoApprovalCascade` (permitted — do-not-cross was EDITING PR2 regions, not calling). No automation/SLA/UI/historical-migration edits.
+5. Naming/maintainability: 3 minor (M1-M3 below).
+
+## Non-Blocking Follow-ups
+
+NB1 (document emergent interaction): `adminJump` composes with PR2 auto-approval — if the jumped-to node's assignee triggers an enabled policy, `applyAutoApprovalCascade` runs (svc L225-234). This is correct and consistent (uniform node-entry behavior) but was not anticipated by the scope gate. Add: (a) an inline comment at L225 noting the intentional composition + link to PR2; (b) a test "jump to node whose assignee = requester with mergeWithRequester → auto-approves at target". Track for this PR if cheap, else a Phase-1 follow-up.
+
+NB2 (M1): `currentStep: resolution.currentStep ?? instance.total_steps` (L254) — falling back `currentStep` to `total_steps` is semantically odd. Add a one-line comment justifying, or revisit the fallback. Non-blocking.
+
+NB3 (doc accuracy): review-request/verification "Base: origin/main@e0721ed25" does not match the actual rebased base (branch is behind 0 vs current origin/main). Update the recorded Base SHA in the verification doc to the actual tip to avoid future confusion.
+
+## Acknowledged Residual (acceptable, not blocking)
+
+T11 data-bearing migration rollback (up → insert jump row → down → reject fresh jump → up → accept) NOT executed: local integration DB unavailable (`DATABASE_URL`/`database "chouhua"`). Per [[feedback_metasheet2_skip_when_unreachable_blind_spot]] discipline it is explicitly marked DB-required and NOT silently skipped. Migration correctness is established by inspection: DDL shape, `NOT VALID` semantics, FK-safe down order, and RBAC column names all verified against actual schema; T-bootstrap + migration unit tests cover the source-level shape. Same class of integration-gated residual as PR1/PR2. Requirement: run the scratch-PG T11 data cycle before/at deploy as a tracked item; record the result in the verification doc when executed.
+
+## Merge Gate (§7.3)
+
+- Worktree clean: PASS
+- Boundary checklist (PD1/PD2/PD3/Fix1/Fix2/B3): PASS
+- Claude review blocking findings: 0
+- Targeted unit (7+5+24) + full unit (168 files / 2193): PASS
+- Build + workspace type-check: PASS
+- Integration: DB-gated residual (T11 data-cycle pending scratch PG), documented, consistent with PR1/PR2 precedent — not a new failure vs baseline
+- Migration rollback: code correct by inspection; data-cycle tracked residual
+- Verification doc committed: PASS
+
+Ready to merge. Recommend addressing NB1 (at least the inline comment + verification-doc note) in this PR since it is cheap and clarifies a composed semantic; NB2/NB3 may ride along or be follow-ups. The T11 scratch-PG cycle must be a tracked pre-deploy item.
+
+## Codex Post-Review Disposition
+
+Addressed locally after review:
+
+- NB1: added an inline service comment and a unit test for admin jump into a requester-merge target node. The test verifies the `auto-merge-requester` audit record and the next active assignment after cascade.
+- NB2: added an inline comment for the `currentStep ?? instance.total_steps` fallback used when a cascade reaches a terminal-like no-step result.
+- NB3: rechecked the branch against `origin/main`; `git rev-list --count HEAD..origin/main` returned `0`, and the recorded base `origin/main@e0721ed25` remains current.
+
+---
+
+End of PR3 §7.2 review.

--- a/docs/development/approval-pr3-scope-gate-response-20260515.md
+++ b/docs/development/approval-pr3-scope-gate-response-20260515.md
@@ -52,7 +52,8 @@ F7. `namespace-admission.ts` `NON_NAMESPACED_PERMISSION_RESOURCES` includes `'ap
 
 ### PD2. `approvals:admin` — ACCEPTED, concrete registration
 
-- New migration inserts `permissions(code='approvals:admin', ...)` and `role_permissions` linking it to the admin role.
+- New migration `up()` inserts `permissions(code='approvals:admin', ...)` then `role_permissions` linking it to the admin role.
+- New migration `down()` (FK-safe order, mandatory): DELETE `role_permissions` for `approvals:admin` FIRST, THEN DELETE the `permissions` row (reverse order violates the `role_permissions → permissions` FK).
 - Route gated `authenticate, rbacGuard('approvals:admin')`, consistent with the `approvals:` family.
 - `approvals` is non-namespaced (F7) — no namespace-admission entry/switch required. Record exact permission code + migration location in the dev doc.
 
@@ -78,7 +79,7 @@ T1. Authorization separation (STRENGTHENED): plain non-admin → 403; AND a user
 T2. Terminal instance → rejected.
 T3. Stale `version` → 409.
 T4. Jump uses instance-bound runtime graph (mock-pool: published-def query keys on `instance.published_definition_id`; zero `approval_templates`/`active_version_id` read).
-T5. Invalid target nodeKey → 400.
+T5. Invalid target → 400, covering BOTH (a) nonexistent nodeKey AND (b) existing node whose type is not `approval` (start/end/condition/cc/parallel-fork/join). Target MUST be an `approval`-type node — only those create human assignments.
 T6. Backward / lateral (non-downstream) target → 400.
 T7. Valid forward jump: old assignments deactivated; target assignments created from bound graph; advances from target.
 T8. Old assignee cannot act post-jump → rejected.

--- a/packages/core-backend/src/db/migrations/zzzz20260515130000_add_jump_action_to_approval_records.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260515130000_add_jump_action_to_approval_records.ts
@@ -1,0 +1,73 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+import { checkTableExists } from './_patterns'
+
+const APPROVALS_ADMIN_PERMISSION = 'approvals:admin'
+const ACTIONS_WITH_JUMP = [
+  'created',
+  'approve',
+  'reject',
+  'return',
+  'revoke',
+  'transfer',
+  'sign',
+  'comment',
+  'cc',
+  'remind',
+  'jump',
+]
+const ACTIONS_WITHOUT_JUMP = ACTIONS_WITH_JUMP.filter((action) => action !== 'jump')
+
+function actionCheck(actions: string[]): string {
+  return `action IN (${actions.map((action) => `'${action}'`).join(', ')})`
+}
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`ALTER TABLE approval_records DROP CONSTRAINT IF EXISTS approval_records_action_check`.execute(db)
+  await sql.raw(`ALTER TABLE approval_records
+    ADD CONSTRAINT approval_records_action_check
+    CHECK (${actionCheck(ACTIONS_WITH_JUMP)})`).execute(db)
+
+  const permissionsExists = await checkTableExists(db, 'permissions')
+  if (permissionsExists) {
+    await sql`
+      INSERT INTO permissions (code, name, description)
+      VALUES (${APPROVALS_ADMIN_PERMISSION}, 'Approvals Admin', 'Perform administrative approval recovery actions')
+      ON CONFLICT (code) DO NOTHING
+    `.execute(db)
+  }
+
+  const rolePermissionsExists = await checkTableExists(db, 'role_permissions')
+  if (permissionsExists && rolePermissionsExists) {
+    await sql`
+      INSERT INTO role_permissions (role_id, permission_code)
+      SELECT 'admin', p.code
+      FROM permissions p
+      WHERE p.code = ${APPROVALS_ADMIN_PERMISSION}
+      ON CONFLICT DO NOTHING
+    `.execute(db)
+  }
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  const rolePermissionsExists = await checkTableExists(db, 'role_permissions')
+  if (rolePermissionsExists) {
+    await sql`
+      DELETE FROM role_permissions
+      WHERE permission_code = ${APPROVALS_ADMIN_PERMISSION}
+    `.execute(db)
+  }
+
+  const permissionsExists = await checkTableExists(db, 'permissions')
+  if (permissionsExists) {
+    await sql`
+      DELETE FROM permissions
+      WHERE code = ${APPROVALS_ADMIN_PERMISSION}
+    `.execute(db)
+  }
+
+  await sql`ALTER TABLE approval_records DROP CONSTRAINT IF EXISTS approval_records_action_check`.execute(db)
+  await sql.raw(`ALTER TABLE approval_records
+    ADD CONSTRAINT approval_records_action_check
+    CHECK (${actionCheck(ACTIONS_WITHOUT_JUMP)}) NOT VALID`).execute(db)
+}

--- a/packages/core-backend/src/routes/approvals.ts
+++ b/packages/core-backend/src/routes/approvals.ts
@@ -1145,6 +1145,75 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
     }
   })
 
+  r.post('/api/approvals/:id/jump', authenticate, rbacGuard('approvals:admin'), async (req: Request, res: Response) => {
+    try {
+      const productService = getProductService()
+      const userId = resolveApprovalActorId(req)
+      if (!userId) {
+        return res.status(401).json(
+          approvalErrorResponse('APPROVAL_USER_REQUIRED', 'User ID not found in token'),
+        )
+      }
+
+      const requestedVersion = normalizeApprovalVersion(req.body?.version)
+      if (requestedVersion === null) {
+        return res.status(400).json({
+          ok: false,
+          error: {
+            code: 'APPROVAL_VERSION_REQUIRED',
+            message: 'Approval version is required',
+          },
+        })
+      }
+
+      const targetNodeKey = normalizeApprovalText(req.body?.targetNodeKey)
+      if (!targetNodeKey) {
+        return res.status(400).json(
+          approvalErrorResponse('VALIDATION_ERROR', 'targetNodeKey is required'),
+        )
+      }
+      const reason = normalizeApprovalText(req.body?.reason) ?? normalizeApprovalText(req.body?.comment)
+      if (!reason) {
+        return res.status(400).json(
+          approvalErrorResponse('VALIDATION_ERROR', 'reason is required'),
+        )
+      }
+
+      const actor = {
+        userId,
+        userName: resolveApprovalActorName(req, userId),
+        roles: resolveApprovalActorRoles(req),
+        permissions: resolveApprovalActorPermissions(req),
+        tenantId: resolveApprovalTenantId(req),
+        ip: req.ip || null,
+        userAgent: req.get('user-agent') || null,
+      }
+      const approval = await productService.adminJump(
+        req.params.id,
+        { version: requestedVersion, targetNodeKey, reason },
+        actor,
+      )
+
+      const activeDirectAssignees = await listDirectApprovalAssigneeIds(req.params.id)
+      await publishApprovalCountsForUsers(
+        options,
+        [
+          { userId, roles: actor.roles },
+          ...activeDirectAssignees.map((assigneeId) => ({ userId: assigneeId })),
+        ],
+        'admin-jump',
+      )
+      res.json(approval)
+    } catch (error) {
+      handleApprovalsError(
+        res,
+        error,
+        'APPROVAL_ADMIN_JUMP_FAILED',
+        'Failed to jump approval',
+      )
+    }
+  })
+
   r.post('/api/approvals/:id/actions', authenticate, rbacGuard('approvals', 'act'), async (req: Request, res: Response) => {
     try {
       const bridgeService = getBridgeService(options)

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -2562,6 +2562,8 @@ export class ApprovalProductService {
       const executor = new ApprovalGraphExecutor(runtimeGraph, toNullableRecord(instance.form_snapshot) || {})
       const jumpResolution = executor.resolveReturnToNode(targetNodeKey)
       const requesterId = toNullableRecord(instance.requester_snapshot)?.id
+      // Admin jump enters the target through the same node-entry path as create/advance,
+      // so PR2 auto-approval policies intentionally compose after the jump.
       const resolution = runtimeGraphHasAutoApprovalPolicy(runtimeGraph)
         ? this.applyAutoApprovalCascade(
             id,
@@ -2591,6 +2593,8 @@ export class ApprovalProductService {
           resolution.status,
           nextVersion,
           resolution.currentNodeKey,
+          // Terminal cascades can return a null step; keep a stable numeric
+          // snapshot instead of writing NULL to the legacy progress column.
           resolution.currentStep ?? instance.total_steps,
           resolution.totalSteps,
         ],

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -44,6 +44,7 @@ import { APPROVAL_ERROR_CODES } from './approval-bridge-types'
 import { ServiceError } from './ApprovalBridgeService'
 import { getApprovalMetricsService, type ApprovalMetricsService, type ApprovalTerminalState } from './ApprovalMetricsService'
 import { Logger } from '../core/logger'
+import { eventBus } from '../integration/events/event-bus'
 
 const metricsLogger = new Logger('ApprovalMetricsHook')
 
@@ -189,6 +190,33 @@ type AutoApprovalEvaluation = {
 type EffectiveAutoApprovalPolicy = {
   policy: AutoApprovalPolicy
   source: AutoApprovalPolicySource
+}
+
+type ApprovalAdminJumpRequest = {
+  version: number
+  targetNodeKey: string
+  reason: string
+}
+
+type AdminJumpAuditAssignee = {
+  assignmentType: string
+  assigneeId: string
+  nodeKey: string | null
+  sourceStep: number | null
+}
+
+type AdminJumpEventPayload = {
+  instanceId: string
+  fromNodeKey: string | null
+  toNodeKey: string
+  oldAssignees: AdminJumpAuditAssignee[]
+  newAssignees: AdminJumpAuditAssignee[]
+  actorId: string
+  actorName: string
+  reason: string
+  fromVersion: number
+  toVersion: number
+  publishedDefinitionId: string
 }
 
 type ApprovalDbClient = {
@@ -1205,6 +1233,67 @@ function readParallelBranchStates(metadata: unknown): ParallelInstanceState | nu
     joinMode: states.joinMode as 'all' | 'any',
     branches,
   }
+}
+
+function findRuntimeGraphNode(runtimeGraph: RuntimeGraph, nodeKey: string): RuntimeGraph['nodes'][number] | null {
+  return runtimeGraph.nodes.find((node) => node.key === nodeKey) ?? null
+}
+
+function listOutgoingNodeKeys(runtimeGraph: RuntimeGraph, nodeKey: string): string[] {
+  return runtimeGraph.edges
+    .filter((edge) => edge.source === nodeKey)
+    .map((edge) => edge.target)
+}
+
+function isReachableDownstream(runtimeGraph: RuntimeGraph, fromNodeKey: string, targetNodeKey: string): boolean {
+  const visited = new Set<string>([fromNodeKey])
+  const queue = listOutgoingNodeKeys(runtimeGraph, fromNodeKey)
+  while (queue.length > 0) {
+    const next = queue.shift()!
+    if (next === targetNodeKey) return true
+    if (visited.has(next)) continue
+    visited.add(next)
+    queue.push(...listOutgoingNodeKeys(runtimeGraph, next))
+  }
+  return false
+}
+
+function collectParallelBranchNodeKeys(runtimeGraph: RuntimeGraph, parallelState: ParallelInstanceState): Set<string> {
+  const branchNodeKeys = new Set<string>()
+  for (const branch of Object.values(parallelState.branches)) {
+    const edge = runtimeGraph.edges.find((candidate) => candidate.key === branch.edgeKey)
+    if (!edge) continue
+    const queue = [edge.target]
+    const visitedNodes = new Set<string>()
+    while (queue.length > 0) {
+      const nodeKey = queue.shift()!
+      if (nodeKey === parallelState.joinNodeKey || visitedNodes.has(nodeKey)) continue
+      visitedNodes.add(nodeKey)
+      branchNodeKeys.add(nodeKey)
+      for (const outgoing of runtimeGraph.edges.filter((candidate) => candidate.source === nodeKey)) {
+        queue.push(outgoing.target)
+      }
+    }
+  }
+  return branchNodeKeys
+}
+
+function assignmentRowsForAudit(assignments: ApprovalAssignmentRow[]): AdminJumpAuditAssignee[] {
+  return assignments.map((assignment) => ({
+    assignmentType: assignment.assignment_type,
+    assigneeId: assignment.assignee_id,
+    nodeKey: assignment.node_key ?? null,
+    sourceStep: assignment.source_step ?? null,
+  }))
+}
+
+function graphAssignmentsForAudit(assignments: ApprovalGraphAssignment[]): AdminJumpAuditAssignee[] {
+  return assignments.map((assignment) => ({
+    assignmentType: assignment.assignmentType,
+    assigneeId: assignment.assigneeId,
+    nodeKey: assignment.nodeKey,
+    sourceStep: assignment.sourceStep,
+  }))
 }
 
 function hasEnabledAutoApprovalRule(policy: AutoApprovalPolicy | undefined): policy is AutoApprovalPolicy {
@@ -2369,6 +2458,200 @@ export class ApprovalProductService {
     const approval = await this.getApproval(instanceId)
     if (!approval) {
       throw new ServiceError('Approval not found after creation', 500, 'APPROVAL_CREATE_FAILED')
+    }
+    return approval
+  }
+
+  async adminJump(
+    id: string,
+    request: ApprovalAdminJumpRequest,
+    actor: CreateApprovalActor & { ip?: string | null; userAgent?: string | null },
+  ): Promise<UnifiedApprovalDTO> {
+    if (!pool) throw new Error('Database not available')
+
+    let jumpEvent: AdminJumpEventPayload | null = null
+    let client: ApprovalDbClient | null = null
+    try {
+      client = await pool.connect()
+      await client.query('BEGIN')
+
+      const instanceResult = await client.query<ApprovalInstanceRow>(
+        `SELECT * FROM approval_instances WHERE id = $1 AND COALESCE(source_system, 'platform') = 'platform' FOR UPDATE`,
+        [id],
+      )
+      const instance = instanceResult.rows[0]
+      if (!instance) {
+        throw new ServiceError('Approval not found', 404, APPROVAL_ERROR_CODES.APPROVAL_NOT_FOUND)
+      }
+      if (instance.version !== request.version) {
+        throw new ServiceError(
+          'Approval instance version mismatch',
+          409,
+          'APPROVAL_VERSION_CONFLICT',
+          { currentVersion: instance.version },
+        )
+      }
+      if (APPROVAL_TERMINAL_STATUSES.includes(instance.status as typeof APPROVAL_TERMINAL_STATUSES[number])) {
+        throw new ServiceError(
+          `Cannot jump: current status is ${instance.status}`,
+          409,
+          APPROVAL_ERROR_CODES.INVALID_STATUS_TRANSITION,
+        )
+      }
+      if (instance.status !== 'pending') {
+        throw new ServiceError(
+          `Cannot jump: current status is ${instance.status}`,
+          409,
+          APPROVAL_ERROR_CODES.INVALID_STATUS_TRANSITION,
+        )
+      }
+      if (!instance.published_definition_id) {
+        throw new ServiceError('Approval is not managed by the template runtime', 409, 'APPROVAL_RUNTIME_UNSUPPORTED')
+      }
+      if (!instance.current_node_key) {
+        throw new ServiceError('Approval does not have an active node', 409, APPROVAL_ERROR_CODES.INVALID_STATUS_TRANSITION)
+      }
+
+      const runtimeResult = await client.query<PublishedDefinitionRow>(
+        `SELECT * FROM approval_published_definitions WHERE id = $1`,
+        [instance.published_definition_id],
+      )
+      const runtime = runtimeResult.rows[0]
+      if (!runtime) {
+        throw new ServiceError('Published definition not found', 404, 'APPROVAL_PUBLISHED_DEFINITION_NOT_FOUND')
+      }
+
+      const targetNodeKey = request.targetNodeKey.trim()
+      const runtimeGraph = asRuntimeGraph(runtime.runtime_graph)
+      const targetNode = findRuntimeGraphNode(runtimeGraph, targetNodeKey)
+      if (!targetNode) {
+        throw new ServiceError('Jump target node not found', 400, 'APPROVAL_JUMP_TARGET_INVALID')
+      }
+      if (targetNode.type !== 'approval') {
+        throw new ServiceError('Jump target must be an approval node', 400, 'APPROVAL_JUMP_TARGET_INVALID')
+      }
+
+      const parallelState = readParallelBranchStates(instance.metadata)
+      let reachabilityBaseNodeKey = instance.current_node_key
+      let targetMatchesReachabilityBase = false
+      if (parallelState) {
+        const branchNodeKeys = collectParallelBranchNodeKeys(runtimeGraph, parallelState)
+        if (branchNodeKeys.has(targetNodeKey)) {
+          throw new ServiceError(
+            'Jump target cannot be inside a parallel branch',
+            400,
+            'APPROVAL_JUMP_PARALLEL_BRANCH_TARGET_UNSUPPORTED',
+          )
+        }
+        reachabilityBaseNodeKey = parallelState.joinNodeKey
+        targetMatchesReachabilityBase = targetNodeKey === parallelState.joinNodeKey
+      }
+      if (!targetMatchesReachabilityBase && !isReachableDownstream(runtimeGraph, reachabilityBaseNodeKey, targetNodeKey)) {
+        throw new ServiceError(
+          'Jump target must be downstream of the current approval node',
+          400,
+          'APPROVAL_JUMP_TARGET_NOT_FORWARD',
+        )
+      }
+
+      const activeAssignments = await client.query<ApprovalAssignmentRow>(
+        `SELECT * FROM approval_assignments WHERE instance_id = $1 AND is_active = TRUE ORDER BY created_at ASC`,
+        [id],
+      )
+      const oldAssignees = assignmentRowsForAudit(activeAssignments.rows)
+      const executor = new ApprovalGraphExecutor(runtimeGraph, toNullableRecord(instance.form_snapshot) || {})
+      const jumpResolution = executor.resolveReturnToNode(targetNodeKey)
+      const requesterId = toNullableRecord(instance.requester_snapshot)?.id
+      const resolution = runtimeGraphHasAutoApprovalPolicy(runtimeGraph)
+        ? this.applyAutoApprovalCascade(
+            id,
+            runtimeGraph,
+            executor,
+            jumpResolution,
+            typeof requesterId === 'string' ? requesterId : null,
+            await this.loadApprovalHistory(client, id),
+          )
+        : jumpResolution
+      const nextVersion = instance.version + 1
+      const newAssignees = graphAssignmentsForAudit(resolution.assignments)
+
+      await this.deactivateAllActiveAssignments(client, id)
+      await client.query(
+        `UPDATE approval_instances
+         SET status = $2,
+             version = $3,
+             current_node_key = $4,
+             current_step = $5,
+             total_steps = $6,
+             metadata = COALESCE(metadata, '{}'::jsonb) - 'parallelBranchStates',
+             updated_at = now()
+         WHERE id = $1`,
+        [
+          id,
+          resolution.status,
+          nextVersion,
+          resolution.currentNodeKey,
+          resolution.currentStep ?? instance.total_steps,
+          resolution.totalSteps,
+        ],
+      )
+      await this.insertAssignments(client, id, resolution.assignments)
+      await this.insertApprovalRecord(client, id, {
+        action: 'jump',
+        actorId: actor.userId,
+        actorName: actor.userName || actor.userId,
+        comment: request.reason,
+        fromStatus: instance.status,
+        toStatus: resolution.status,
+        fromVersion: instance.version,
+        toVersion: nextVersion,
+        metadata: {
+          adminJump: true,
+          instanceId: id,
+          fromNodeKey: instance.current_node_key,
+          toNodeKey: targetNodeKey,
+          nextNodeKey: resolution.currentNodeKey,
+          oldAssignees,
+          newAssignees,
+          reason: request.reason,
+          actorId: actor.userId,
+          parallelStateCleared: Boolean(parallelState),
+        },
+      }, actor)
+      await this.insertAutoApprovalEvents(client, id, nextVersion, resolution.status, resolution.autoApprovalEvents)
+      await this.insertCcEvents(client, id, nextVersion, resolution.status, resolution.ccEvents)
+      await client.query('COMMIT')
+
+      jumpEvent = {
+        instanceId: id,
+        fromNodeKey: instance.current_node_key,
+        toNodeKey: targetNodeKey,
+        oldAssignees,
+        newAssignees,
+        actorId: actor.userId,
+        actorName: actor.userName || actor.userId,
+        reason: request.reason,
+        fromVersion: instance.version,
+        toVersion: nextVersion,
+        publishedDefinitionId: instance.published_definition_id,
+      }
+
+      if (resolution.currentNodeKey) {
+        this.emitNodeActivationMetric(id, resolution.currentNodeKey)
+      }
+    } catch (error) {
+      await rollbackQuietly(client)
+      throw error
+    } finally {
+      client?.release()
+    }
+
+    if (jumpEvent) {
+      eventBus.emit('approval.admin_jumped', jumpEvent)
+    }
+    const approval = await this.getApproval(id)
+    if (!approval) {
+      throw new ServiceError('Approval not found after jump', 404, APPROVAL_ERROR_CODES.APPROVAL_NOT_FOUND)
     }
     return approval
   }

--- a/packages/core-backend/tests/helpers/approval-schema-bootstrap.ts
+++ b/packages/core-backend/tests/helpers/approval-schema-bootstrap.ts
@@ -1,7 +1,7 @@
 import { poolManager } from '../../src/integration/db/connection-pool'
 
 const APPROVAL_SCHEMA_BOOTSTRAP_KEY = 'approval-schema-bootstrap'
-const APPROVAL_SCHEMA_BOOTSTRAP_VERSION = '20260426-wp5-breach-notified-at'
+const APPROVAL_SCHEMA_BOOTSTRAP_VERSION = '20260515-pr3-admin-jump-action'
 
 /**
  * Ensures the approval schema (tables, constraints, indexes, sequences) is
@@ -177,7 +177,7 @@ export async function ensureApprovalSchemaReady(): Promise<void> {
     await client.query(`
       ALTER TABLE approval_records
       ADD CONSTRAINT approval_records_action_check
-      CHECK (action IN ('created', 'approve', 'reject', 'return', 'revoke', 'transfer', 'sign', 'comment', 'cc', 'remind'))
+      CHECK (action IN ('created', 'approve', 'reject', 'return', 'revoke', 'transfer', 'sign', 'comment', 'cc', 'remind', 'jump'))
     `)
     await client.query(`CREATE INDEX IF NOT EXISTS idx_approval_records_instance ON approval_records(instance_id)`)
     await client.query(`CREATE INDEX IF NOT EXISTS idx_approval_records_instance_action_time ON approval_records(instance_id, action, occurred_at DESC)`)

--- a/packages/core-backend/tests/unit/approval-admin-jump-migration.test.ts
+++ b/packages/core-backend/tests/unit/approval-admin-jump-migration.test.ts
@@ -1,0 +1,67 @@
+import { promises as fs } from 'fs'
+import * as path from 'path'
+import { describe, expect, it } from 'vitest'
+
+const MIGRATIONS_DIR = path.join(__dirname, '../../src/db/migrations')
+const BOOTSTRAP_PATH = path.join(__dirname, '../helpers/approval-schema-bootstrap.ts')
+const JUMP_MIGRATION = path.join(MIGRATIONS_DIR, 'zzzz20260515130000_add_jump_action_to_approval_records.ts')
+const HISTORICAL_ACTION_MIGRATIONS = [
+  'zzzz20260411123000_add_created_action_to_approval_records.ts',
+  'zzzz20260411120100_approval_templates_and_instance_extensions.ts',
+  'zzzz20260423120000_add_remind_action_to_approval_records.ts',
+]
+
+describe('approval admin jump migration and bootstrap sync', () => {
+  it('T11 exposes reversible up/down functions for the jump migration', async () => {
+    const migration = await import('../../src/db/migrations/zzzz20260515130000_add_jump_action_to_approval_records')
+
+    expect(typeof migration.up).toBe('function')
+    expect(typeof migration.down).toBe('function')
+    expect(migration.up.length).toBe(1)
+    expect(migration.down.length).toBe(1)
+  })
+
+  it('T11 adds jump in up() and restores the non-jump constraint with NOT VALID in down()', async () => {
+    const source = await fs.readFile(JUMP_MIGRATION, 'utf8')
+    const [upSource, downSource] = source.split('export async function down')
+
+    expect(upSource).toContain("'jump'")
+    expect(upSource).toContain('approval_records_action_check')
+    expect(upSource).toContain('ACTIONS_WITH_JUMP')
+    expect(downSource).toContain('ACTIONS_WITHOUT_JUMP')
+    expect(downSource).toContain('NOT VALID')
+  })
+
+  it('PD2 removes role_permissions before permissions in down() for FK safety', async () => {
+    const source = await fs.readFile(JUMP_MIGRATION, 'utf8')
+    const downSource = source.split('export async function down')[1] ?? ''
+    const roleDeleteIndex = downSource.indexOf('DELETE FROM role_permissions')
+    const permissionDeleteIndex = downSource.indexOf('DELETE FROM permissions')
+
+    expect(source).toContain('approvals:admin')
+    expect(roleDeleteIndex).toBeGreaterThanOrEqual(0)
+    expect(permissionDeleteIndex).toBeGreaterThanOrEqual(0)
+    expect(roleDeleteIndex).toBeLessThan(permissionDeleteIndex)
+  })
+
+  it('T-bootstrap keeps approval_schema_bootstrap action check aligned with jump', async () => {
+    const source = await fs.readFile(BOOTSTRAP_PATH, 'utf8')
+
+    expect(source).toContain("APPROVAL_SCHEMA_BOOTSTRAP_VERSION = '20260515-pr3-admin-jump-action'")
+    expect(source).toContain("'remind', 'jump'")
+  })
+
+  it('does not mutate immutable historical approval action migrations', async () => {
+    const sources = await Promise.all(
+      HISTORICAL_ACTION_MIGRATIONS.map(async (fileName) => ({
+        fileName,
+        source: await fs.readFile(path.join(MIGRATIONS_DIR, fileName), 'utf8'),
+      })),
+    )
+
+    for (const { fileName, source } of sources) {
+      expect(source, fileName).not.toContain("'jump'")
+      expect(source, fileName).not.toContain('approvals:admin')
+    }
+  })
+})

--- a/packages/core-backend/tests/unit/approval-admin-jump-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-admin-jump-service.test.ts
@@ -106,6 +106,24 @@ function buildLinearGraph() {
   }
 }
 
+function buildRequesterMergeGraph() {
+  return {
+    ...buildLinearGraph(),
+    nodes: [
+      { key: 'start', type: 'start', config: {} },
+      { key: 'manager_review', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['manager-1'] } },
+      { key: 'finance_review', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['requester-1'] } },
+      { key: 'cc_notify', type: 'cc', config: { targetType: 'user', targetIds: ['audit-1'] } },
+      { key: 'director_review', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['director-1'] } },
+      { key: 'end', type: 'end', config: {} },
+    ],
+    policy: {
+      allowRevoke: true,
+      autoApproval: { mergeWithRequester: true },
+    },
+  }
+}
+
 function buildParallelGraph() {
   return {
     nodes: [
@@ -373,6 +391,66 @@ describe('ApprovalProductService adminJump', () => {
       actorId: 'admin-1',
       publishedDefinitionId: 'pub-frozen',
     }))
+  })
+
+  it('NB1 composes admin jump with PR2 requester auto-approval at the target node', async () => {
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const service = new ApprovalProductService(buildNoopMetrics() as never)
+    installGetApprovalStub(service)
+    mockAdminJumpQueries({ runtimeGraph: buildRequesterMergeGraph() })
+
+    await service.adminJump(
+      'apr-1',
+      { version: 2, targetNodeKey: 'finance_review', reason: 'jump into requester merge' },
+      adminActor(),
+    )
+
+    const updateCall = findInstanceUpdate()
+    expect(updateCall?.[1]).toEqual([
+      'apr-1',
+      'pending',
+      3,
+      'director_review',
+      3,
+      3,
+    ])
+
+    const assignmentInsert = pgState.client.query.mock.calls.find(([sql, params]) =>
+      normalize(String(sql)).startsWith('INSERT INTO approval_assignments')
+      && Array.isArray(params)
+      && params[4] === 'director_review')
+    expect(assignmentInsert?.[1]).toEqual([
+      'apr-1',
+      'user',
+      'director-1',
+      3,
+      'director_review',
+    ])
+
+    const autoRecordCall = findRecordInsert('approve')
+    expect(autoRecordCall?.[1]?.[2]).toBe('system:auto-approval')
+    const autoMetadata = JSON.parse(String((autoRecordCall?.[1] as unknown[])[9])) as Record<string, unknown>
+    expect(autoMetadata).toMatchObject({
+      autoApproved: true,
+      nodeKey: 'finance_review',
+      reason: 'auto-merge-requester',
+      policySource: 'template',
+      originalApprover: { type: 'user', id: 'requester-1' },
+      actorMode: 'system',
+    })
+
+    const jumpRecordCall = findRecordInsert('jump')
+    const jumpMetadata = JSON.parse(String((jumpRecordCall?.[1] as unknown[])[9])) as Record<string, unknown>
+    expect(jumpMetadata).toMatchObject({
+      toNodeKey: 'finance_review',
+      nextNodeKey: 'director_review',
+      newAssignees: [{
+        assignmentType: 'user',
+        assigneeId: 'director-1',
+        nodeKey: 'director_review',
+        sourceStep: 3,
+      }],
+    })
   })
 
   it('T5 rejects missing targets and existing non-approval target nodes', async () => {

--- a/packages/core-backend/tests/unit/approval-admin-jump-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-admin-jump-service.test.ts
@@ -1,0 +1,467 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const pgState = vi.hoisted(() => ({
+  client: {
+    query: vi.fn(),
+    release: vi.fn(),
+  },
+  pool: {
+    query: vi.fn(),
+    connect: vi.fn(),
+  },
+}))
+
+const eventBusState = vi.hoisted(() => ({
+  emit: vi.fn(),
+}))
+
+vi.mock('../../src/db/pg', () => ({
+  pool: pgState.pool,
+}))
+
+vi.mock('../../src/integration/events/event-bus', () => ({
+  eventBus: eventBusState,
+}))
+
+function normalize(sql: string): string {
+  return sql.replace(/\s+/g, ' ').trim()
+}
+
+function buildNoopMetrics() {
+  return {
+    recordInstanceStart: vi.fn().mockResolvedValue(undefined),
+    recordTerminal: vi.fn().mockResolvedValue(undefined),
+    recordNodeActivation: vi.fn().mockResolvedValue(undefined),
+    recordNodeDecision: vi.fn().mockResolvedValue(undefined),
+    checkSlaBreaches: vi.fn().mockResolvedValue([]),
+    getMetricsSummary: vi.fn(),
+    getInstanceMetrics: vi.fn(),
+    listActiveBreaches: vi.fn(),
+  }
+}
+
+function adminActor(overrides: Record<string, unknown> = {}) {
+  return {
+    userId: 'admin-1',
+    userName: 'Admin One',
+    roles: ['admin'],
+    permissions: ['approvals:admin'],
+    tenantId: 'default',
+    ip: '127.0.0.1',
+    userAgent: 'vitest',
+    ...overrides,
+  }
+}
+
+function buildInstanceRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'apr-1',
+    status: 'pending',
+    version: 2,
+    source_system: 'platform',
+    external_approval_id: null,
+    workflow_key: 'approval-product-template',
+    business_key: 'travel-request',
+    title: 'Travel Request',
+    requester_snapshot: { id: 'requester-1', name: 'Requester One' },
+    subject_snapshot: {},
+    policy_snapshot: { allowRevoke: true },
+    metadata: {},
+    current_step: 1,
+    total_steps: 3,
+    source_updated_at: null,
+    last_synced_at: null,
+    sync_status: 'ok',
+    sync_error: null,
+    template_id: 'tpl-1',
+    template_version_id: 'ver-active',
+    published_definition_id: 'pub-frozen',
+    request_no: 'AP-100001',
+    form_snapshot: {},
+    current_node_key: 'manager_review',
+    created_at: new Date('2026-05-15T00:00:00.000Z'),
+    updated_at: new Date('2026-05-15T00:05:00.000Z'),
+    ...overrides,
+  }
+}
+
+function buildLinearGraph() {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', config: {} },
+      { key: 'manager_review', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['manager-1'] } },
+      { key: 'finance_review', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['finance-1'] } },
+      { key: 'cc_notify', type: 'cc', config: { targetType: 'user', targetIds: ['audit-1'] } },
+      { key: 'director_review', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['director-1'] } },
+      { key: 'end', type: 'end', config: {} },
+    ],
+    edges: [
+      { key: 'e-start-manager', source: 'start', target: 'manager_review' },
+      { key: 'e-manager-finance', source: 'manager_review', target: 'finance_review' },
+      { key: 'e-finance-cc', source: 'finance_review', target: 'cc_notify' },
+      { key: 'e-cc-director', source: 'cc_notify', target: 'director_review' },
+      { key: 'e-director-end', source: 'director_review', target: 'end' },
+    ],
+    policy: { allowRevoke: true },
+  }
+}
+
+function buildParallelGraph() {
+  return {
+    nodes: [
+      { key: 'start', type: 'start', config: {} },
+      { key: 'parallel_fork', type: 'parallel', config: { branches: ['e-fork-legal', 'e-fork-finance'], joinNodeKey: 'post_join', joinMode: 'all' } },
+      { key: 'legal_review', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['legal-1'] } },
+      { key: 'finance_branch_review', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['finance-branch-1'] } },
+      { key: 'post_join', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['post-join-1'] } },
+      { key: 'end', type: 'end', config: {} },
+    ],
+    edges: [
+      { key: 'e-start-fork', source: 'start', target: 'parallel_fork' },
+      { key: 'e-fork-legal', source: 'parallel_fork', target: 'legal_review' },
+      { key: 'e-fork-finance', source: 'parallel_fork', target: 'finance_branch_review' },
+      { key: 'e-legal-join', source: 'legal_review', target: 'post_join' },
+      { key: 'e-finance-join', source: 'finance_branch_review', target: 'post_join' },
+      { key: 'e-join-end', source: 'post_join', target: 'end' },
+    ],
+    policy: { allowRevoke: true },
+  }
+}
+
+function buildAssignment(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'asg-1',
+    instance_id: 'apr-1',
+    assignment_type: 'user',
+    assignee_id: 'manager-1',
+    source_step: 1,
+    node_key: 'manager_review',
+    is_active: true,
+    metadata: {},
+    created_at: new Date('2026-05-15T00:06:00.000Z'),
+    updated_at: new Date('2026-05-15T00:06:00.000Z'),
+    ...overrides,
+  }
+}
+
+function buildParallelState() {
+  return {
+    parallelNodeKey: 'parallel_fork',
+    joinNodeKey: 'post_join',
+    joinMode: 'all',
+    branches: {
+      'e-fork-legal': { edgeKey: 'e-fork-legal', currentNodeKey: 'legal_review', complete: false },
+      'e-fork-finance': { edgeKey: 'e-fork-finance', currentNodeKey: 'finance_branch_review', complete: false },
+    },
+  }
+}
+
+function mockAdminJumpQueries(options: {
+  instance?: Record<string, unknown> | null
+  runtimeGraph?: Record<string, unknown>
+  assignments?: Array<Record<string, unknown>>
+  historyRows?: Array<Record<string, unknown>>
+}) {
+  const instance = options.instance === undefined ? buildInstanceRow() : options.instance
+  const runtimeGraph = options.runtimeGraph ?? buildLinearGraph()
+  const assignments = options.assignments ?? [buildAssignment()]
+  const historyRows = options.historyRows ?? []
+
+  pgState.client.query.mockImplementation(async (sql: string, params?: unknown[]) => {
+    const statement = normalize(sql)
+    if (statement === 'BEGIN' || statement === 'COMMIT' || statement === 'ROLLBACK') {
+      return { rows: [], rowCount: 0 }
+    }
+    if (statement.startsWith('SELECT * FROM approval_instances WHERE id = $1')) {
+      return { rows: instance ? [instance] : [], rowCount: instance ? 1 : 0 }
+    }
+    if (statement.startsWith('SELECT * FROM approval_published_definitions WHERE id = $1')) {
+      expect(params).toEqual([instance?.published_definition_id ?? 'pub-frozen'])
+      return {
+        rows: [{
+          id: instance?.published_definition_id ?? 'pub-frozen',
+          template_id: 'tpl-1',
+          template_version_id: 'ver-frozen',
+          runtime_graph: runtimeGraph,
+          is_active: true,
+          published_at: new Date('2026-05-15T00:00:00.000Z'),
+        }],
+        rowCount: 1,
+      }
+    }
+    if (statement.startsWith('SELECT * FROM approval_assignments WHERE instance_id = $1 AND is_active = TRUE')) {
+      return { rows: assignments, rowCount: assignments.length }
+    }
+    if (statement.startsWith('SELECT id, actor_id, metadata FROM approval_records')) {
+      return { rows: historyRows, rowCount: historyRows.length }
+    }
+    if (statement.startsWith('UPDATE approval_assignments SET is_active = FALSE')) {
+      return { rows: [], rowCount: assignments.length }
+    }
+    if (statement.startsWith('UPDATE approval_instances')) {
+      return { rows: [], rowCount: 1 }
+    }
+    if (statement.startsWith('INSERT INTO approval_assignments')) {
+      return { rows: [], rowCount: 1 }
+    }
+    if (statement.startsWith('INSERT INTO approval_records')) {
+      return { rows: [], rowCount: 1 }
+    }
+    throw new Error(`Unhandled client query: ${statement}`)
+  })
+}
+
+function mockDispatchQueriesForOldAssignee() {
+  const instance = buildInstanceRow({
+    current_node_key: 'finance_review',
+    version: 3,
+  })
+  pgState.client.query.mockImplementation(async (sql: string) => {
+    const statement = normalize(sql)
+    if (statement === 'BEGIN' || statement === 'ROLLBACK') {
+      return { rows: [], rowCount: 0 }
+    }
+    if (statement.startsWith('SELECT * FROM approval_instances WHERE id = $1')) {
+      return { rows: [instance], rowCount: 1 }
+    }
+    if (statement.startsWith('SELECT * FROM approval_published_definitions WHERE id = $1')) {
+      return {
+        rows: [{
+          id: 'pub-frozen',
+          template_id: 'tpl-1',
+          template_version_id: 'ver-frozen',
+          runtime_graph: buildLinearGraph(),
+          is_active: true,
+          published_at: new Date('2026-05-15T00:00:00.000Z'),
+        }],
+        rowCount: 1,
+      }
+    }
+    if (statement.startsWith('SELECT * FROM approval_assignments WHERE instance_id = $1 AND is_active = TRUE')) {
+      return {
+        rows: [buildAssignment({ id: 'asg-finance', assignee_id: 'finance-1', node_key: 'finance_review', source_step: 2 })],
+        rowCount: 1,
+      }
+    }
+    throw new Error(`Unhandled client query: ${statement}`)
+  })
+}
+
+function installGetApprovalStub(service: { getApproval: (id: string) => Promise<unknown> }) {
+  return vi.spyOn(service, 'getApproval').mockResolvedValue({
+    id: 'apr-1',
+    status: 'pending',
+    currentNodeKey: 'finance_review',
+    version: 3,
+    assignments: [],
+  })
+}
+
+function findRecordInsert(action: string) {
+  return pgState.client.query.mock.calls.find(([sql, params]) =>
+    normalize(String(sql)).startsWith('INSERT INTO approval_records')
+    && Array.isArray(params)
+    && params[1] === action)
+}
+
+function findInstanceUpdate() {
+  return pgState.client.query.mock.calls.find(([sql]) =>
+    normalize(String(sql)).startsWith('UPDATE approval_instances'))
+}
+
+function allSqlStatements(): string[] {
+  return [
+    ...pgState.client.query.mock.calls.map(([sql]) => normalize(String(sql))),
+    ...pgState.pool.query.mock.calls.map(([sql]) => normalize(String(sql))),
+  ]
+}
+
+describe('ApprovalProductService adminJump', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    pgState.pool.connect.mockReset()
+    pgState.pool.query.mockReset()
+    pgState.client.query.mockReset()
+    pgState.client.release.mockReset()
+    eventBusState.emit.mockReset()
+    pgState.pool.connect.mockResolvedValue(pgState.client)
+  })
+
+  it('T2/T3 rejects terminal or stale instances before mutating jump state', async () => {
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const service = new ApprovalProductService(buildNoopMetrics() as never)
+
+    mockAdminJumpQueries({ instance: buildInstanceRow({ status: 'approved' }) })
+    await expect(service.adminJump('apr-1', { version: 2, targetNodeKey: 'finance_review', reason: 'ops fix' }, adminActor()))
+      .rejects.toMatchObject({ statusCode: 409 })
+    expect(allSqlStatements().some((statement) => statement.includes('approval_published_definitions'))).toBe(false)
+    expect(pgState.client.query.mock.calls.some(([sql]) => normalize(String(sql)) === 'ROLLBACK')).toBe(true)
+
+    pgState.client.query.mockReset()
+    mockAdminJumpQueries({ instance: buildInstanceRow({ version: 3 }) })
+    await expect(service.adminJump('apr-1', { version: 2, targetNodeKey: 'finance_review', reason: 'stale' }, adminActor()))
+      .rejects.toMatchObject({ statusCode: 409, details: { currentVersion: 3 } })
+    expect(allSqlStatements().some((statement) => statement.includes('UPDATE approval_instances'))).toBe(false)
+  })
+
+  it('T4/T7/T10/T12/T13 jumps using the frozen runtime graph and records admin audit/event state', async () => {
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const service = new ApprovalProductService(buildNoopMetrics() as never)
+    installGetApprovalStub(service)
+    mockAdminJumpQueries({ runtimeGraph: buildLinearGraph() })
+
+    const result = await service.adminJump(
+      'apr-1',
+      { version: 2, targetNodeKey: 'finance_review', reason: 'skip broken node' },
+      adminActor(),
+    )
+
+    expect(result).toMatchObject({ id: 'apr-1', currentNodeKey: 'finance_review' })
+    const statements = allSqlStatements()
+    expect(statements.some((statement) => statement.includes('approval_templates'))).toBe(false)
+    expect(statements.some((statement) => statement.includes('approval_template_versions'))).toBe(false)
+    expect(statements.some((statement) => statement.includes('active_version_id'))).toBe(false)
+
+    const updateCall = findInstanceUpdate()
+    expect(updateCall?.[1]).toEqual([
+      'apr-1',
+      'pending',
+      3,
+      'finance_review',
+      2,
+      3,
+    ])
+    expect(normalize(String(updateCall?.[0]))).not.toContain('template_version_id')
+    expect(normalize(String(updateCall?.[0]))).not.toContain('published_definition_id')
+
+    const assignmentInsert = pgState.client.query.mock.calls.find(([sql]) =>
+      normalize(String(sql)).startsWith('INSERT INTO approval_assignments'))
+    expect(assignmentInsert?.[1]).toEqual([
+      'apr-1',
+      'user',
+      'finance-1',
+      2,
+      'finance_review',
+    ])
+
+    const recordCall = findRecordInsert('jump')
+    expect(recordCall).toBeTruthy()
+    const recordParams = recordCall?.[1] as unknown[]
+    expect(recordParams[2]).toBe('admin-1')
+    expect(recordParams[4]).toBe('skip broken node')
+    expect(recordParams[7]).toBe(2)
+    expect(recordParams[8]).toBe(3)
+    const metadata = JSON.parse(String(recordParams[9])) as Record<string, unknown>
+    expect(metadata).toMatchObject({
+      adminJump: true,
+      fromNodeKey: 'manager_review',
+      toNodeKey: 'finance_review',
+      nextNodeKey: 'finance_review',
+      actorId: 'admin-1',
+      parallelStateCleared: false,
+    })
+    expect(metadata.oldAssignees).toEqual([{
+      assignmentType: 'user',
+      assigneeId: 'manager-1',
+      nodeKey: 'manager_review',
+      sourceStep: 1,
+    }])
+    expect(eventBusState.emit).toHaveBeenCalledWith('approval.admin_jumped', expect.objectContaining({
+      instanceId: 'apr-1',
+      fromNodeKey: 'manager_review',
+      toNodeKey: 'finance_review',
+      actorId: 'admin-1',
+      publishedDefinitionId: 'pub-frozen',
+    }))
+  })
+
+  it('T5 rejects missing targets and existing non-approval target nodes', async () => {
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const service = new ApprovalProductService(buildNoopMetrics() as never)
+
+    mockAdminJumpQueries({ runtimeGraph: buildLinearGraph() })
+    await expect(service.adminJump('apr-1', { version: 2, targetNodeKey: 'missing_node', reason: 'bad' }, adminActor()))
+      .rejects.toMatchObject({ statusCode: 400, code: 'APPROVAL_JUMP_TARGET_INVALID' })
+
+    pgState.client.query.mockReset()
+    mockAdminJumpQueries({ runtimeGraph: buildLinearGraph() })
+    await expect(service.adminJump('apr-1', { version: 2, targetNodeKey: 'cc_notify', reason: 'bad' }, adminActor()))
+      .rejects.toMatchObject({ statusCode: 400, code: 'APPROVAL_JUMP_TARGET_INVALID' })
+
+    expect(allSqlStatements().some((statement) => statement.includes('INSERT INTO approval_records'))).toBe(false)
+  })
+
+  it('T6 rejects backward jumps and T12 rejects stale double-jump versions with 409', async () => {
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const service = new ApprovalProductService(buildNoopMetrics() as never)
+
+    mockAdminJumpQueries({
+      instance: buildInstanceRow({ current_node_key: 'finance_review' }),
+      runtimeGraph: buildLinearGraph(),
+    })
+    await expect(service.adminJump('apr-1', { version: 2, targetNodeKey: 'manager_review', reason: 'backward' }, adminActor()))
+      .rejects.toMatchObject({ statusCode: 400, code: 'APPROVAL_JUMP_TARGET_NOT_FORWARD' })
+
+    pgState.client.query.mockReset()
+    mockAdminJumpQueries({ instance: buildInstanceRow({ version: 3 }) })
+    await expect(service.adminJump('apr-1', { version: 2, targetNodeKey: 'finance_review', reason: 'stale second jump' }, adminActor()))
+      .rejects.toMatchObject({ statusCode: 409, details: { currentVersion: 3 } })
+  })
+
+  it('T8 prevents old assignees from acting after jump deactivates their assignment', async () => {
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const service = new ApprovalProductService(buildNoopMetrics() as never)
+    mockDispatchQueriesForOldAssignee()
+
+    await expect(service.dispatchAction(
+      'apr-1',
+      { action: 'approve', version: 3 },
+      { ...adminActor({ userId: 'manager-1', userName: 'Manager One', roles: [], permissions: ['approvals:act'] }) },
+    )).rejects.toMatchObject({ statusCode: 403, code: 'APPROVAL_ASSIGNMENT_REQUIRED' })
+  })
+
+  it('T9 applies PD3 parallel boundaries: branch targets fail, post-join targets clear branch state', async () => {
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const service = new ApprovalProductService(buildNoopMetrics() as never)
+    installGetApprovalStub(service)
+    const parallelGraph = buildParallelGraph()
+    const parallelInstance = buildInstanceRow({
+      current_node_key: 'parallel_fork',
+      metadata: { parallelBranchStates: buildParallelState() },
+    })
+
+    mockAdminJumpQueries({ instance: parallelInstance, runtimeGraph: parallelGraph })
+    await expect(service.adminJump('apr-1', { version: 2, targetNodeKey: 'legal_review', reason: 'bad branch' }, adminActor()))
+      .rejects.toMatchObject({ statusCode: 400, code: 'APPROVAL_JUMP_PARALLEL_BRANCH_TARGET_UNSUPPORTED' })
+
+    pgState.client.query.mockReset()
+    mockAdminJumpQueries({
+      instance: parallelInstance,
+      runtimeGraph: parallelGraph,
+      assignments: [
+        buildAssignment({ id: 'asg-legal', assignee_id: 'legal-1', node_key: 'legal_review' }),
+        buildAssignment({ id: 'asg-finance', assignee_id: 'finance-branch-1', node_key: 'finance_branch_review' }),
+      ],
+    })
+
+    await service.adminJump('apr-1', { version: 2, targetNodeKey: 'post_join', reason: 'join recovery' }, adminActor())
+
+    const updateCall = findInstanceUpdate()
+    expect(normalize(String(updateCall?.[0]))).toContain("metadata = COALESCE(metadata, '{}'::jsonb) - 'parallelBranchStates'")
+    expect(updateCall?.[1]).toEqual([
+      'apr-1',
+      'pending',
+      3,
+      'post_join',
+      3,
+      3,
+    ])
+    const recordCall = findRecordInsert('jump')
+    const metadata = JSON.parse(String((recordCall?.[1] as unknown[])[9])) as Record<string, unknown>
+    expect(metadata).toMatchObject({
+      fromNodeKey: 'parallel_fork',
+      toNodeKey: 'post_join',
+      parallelStateCleared: true,
+    })
+  })
+})

--- a/packages/core-backend/tests/unit/approval-rbac-boundary.test.ts
+++ b/packages/core-backend/tests/unit/approval-rbac-boundary.test.ts
@@ -82,6 +82,10 @@ function templateManager() {
   return { id: 'u-mgr', name: 'Manager', permissions: ['approvals:read', 'approval-templates:manage'] }
 }
 
+function approvalAdminUser() {
+  return { id: 'u-approval-admin', name: 'Approval Admin', permissions: ['approvals:admin'] }
+}
+
 function adminUser() {
   return { id: 'u-admin', name: 'Admin', role: 'admin', permissions: [] }
 }
@@ -154,6 +158,13 @@ describe('Approval RBAC boundary verification', () => {
       const res = await request(app)
         .post('/api/approvals/apr-1/actions')
         .send({ action: 'approve', version: 0 })
+      expect(res.status).toBe(401)
+    })
+
+    it('POST /api/approvals/:id/jump without auth → 401', async () => {
+      const res = await request(app)
+        .post('/api/approvals/apr-1/jump')
+        .send({ version: 0, targetNodeKey: 'finance_review', reason: 'ops recovery' })
       expect(res.status).toBe(401)
     })
   })
@@ -311,6 +322,42 @@ describe('Approval RBAC boundary verification', () => {
   })
 
   // =========================================================================
+  // Admin jump boundary: only approvals:admin can reach the handler
+  // =========================================================================
+  describe('PR3: Admin jump boundary', () => {
+    it('POST /api/approvals/:id/jump with approvals:act but no approvals:admin → 403', async () => {
+      authState.user = actorUser()
+
+      const res = await request(app)
+        .post('/api/approvals/apr-1/jump')
+        .send({ version: 0, targetNodeKey: 'finance_review', reason: 'ops recovery' })
+
+      expect(res.status).toBe(403)
+    })
+
+    it('POST /api/approvals/:id/jump with template manage but no approvals:admin → 403', async () => {
+      authState.user = templateManager()
+
+      const res = await request(app)
+        .post('/api/approvals/apr-1/jump')
+        .send({ version: 0, targetNodeKey: 'finance_review', reason: 'ops recovery' })
+
+      expect(res.status).toBe(403)
+    })
+
+    it('POST /api/approvals/:id/jump with approvals:admin reaches the handler', async () => {
+      authState.user = approvalAdminUser()
+
+      const res = await request(app)
+        .post('/api/approvals/apr-1/jump')
+        .send({ version: 0, targetNodeKey: 'finance_review', reason: 'ops recovery' })
+
+      expect(res.status).not.toBe(401)
+      expect(res.status).not.toBe(403)
+    })
+  })
+
+  // =========================================================================
   // Permission matrix integration
   // =========================================================================
   describe('Permission matrix integration', () => {
@@ -324,6 +371,7 @@ describe('Approval RBAC boundary verification', () => {
         request(app).get('/api/approvals/a'),
         request(app).post('/api/approvals').send({ templateId: 't', formData: {} }),
         request(app).post('/api/approvals/a/actions').send({ action: 'approve', version: 0 }),
+        request(app).post('/api/approvals/a/jump').send({ version: 0, targetNodeKey: 'n2', reason: 'ops recovery' }),
       ])
 
       for (const res of results) {


### PR DESCRIPTION
## Summary

PR3 of approval Phase 1 — backend-only admin recovery jump. 3-commit audited lineage (scope-gate anchor + implementation + post-review follow-up), **do NOT squash**.

- `POST /api/approvals/:id/jump` gated by `approvals:admin`.
- `ApprovalProductService.adminJump()`: instance `FOR UPDATE` + optimistic version (409), terminal/pending/runtime guards, forward-only target validation on the **instance-bound frozen runtime graph** (PR1 version-freeze preserved), target must be an `approval` node, PD3 parallel boundary (base = JOIN node; in-branch target → 400; `parallelBranchStates` cleared), old-assignment deactivation, target assignment creation, `jump` audit record (real admin actor), `approval.admin_jumped` event emitted post-commit. Intentionally composes with PR2 auto-approval cascade at the target node.
- New migration `zzzz20260515130000`: adds `approval_records.action='jump'`; seeds `approvals:admin` permission + admin role_permission; `down()` FK-safe order + `NOT VALID` constraint restore.
- `approval-schema-bootstrap.ts` synced (CHECK incl. `jump`, bootstrap version bumped); 3 historical migrations untouched.

## Commits (preserve, no squash)

- `3d0262b86` docs(approval): record pr3 admin jump scope gate
- `f262b95de` feat(approval): add admin jump node
- `64896f964` test(approval): cover admin jump auto approval composition (NB1/NB2/NB3 review follow-up)

## Verification

- Backend build: PASS
- Workspace type-check: PASS
- Backend full unit: PASS (168 files / 2193 tests)
- §7.2 independent review: **APPROVE**, no blocking findings; NB1/NB2/NB3 addressed (`docs/development/approval-pr3-review-response-20260515.md`)

## Tracked pre-deploy residual (not a merge blocker)

- T11 data-bearing migration rollback (up → insert jump row → down → reject fresh jump → up → accept) requires a scratch PostgreSQL — local integration DB unavailable. Explicitly DB-required, NOT silently skipped. Migration correctness established by inspection (DDL shape, `NOT VALID`, FK-safe down order, RBAC column names vs actual schema) + source/unit + T-bootstrap. Same class of integration-gated residual as PR1/PR2. **Must run scratch-PG T11 cycle before/at deploy and record in the verification doc.**

## Merge note

Single-maintainer self-review + admin-merge. **Merge commit, NOT squash** — preserve the 3-commit scope-gate → implement → review-follow-up audit chain.

## Test plan

- [x] Unit (targeted + full) green
- [x] Build + type-check green
- [x] §7.2 review APPROVE
- [ ] Reviewer: confirm changed-files = expected PR3 scope (service/route/migration/bootstrap/tests/docs only)
- [ ] Admin-merge without squash
- [ ] Post-merge: schedule scratch-PG T11 data-cycle as tracked pre-deploy item