### PR TITLE
feat(attendance): provision attendance_report_records object (PR1)

### DIFF
--- a/docs/development/attendance-report-records-sync-development-20260515.md
+++ b/docs/development/attendance-report-records-sync-development-20260515.md
@@ -1,0 +1,51 @@
+# 考勤 attendance_report_records 同步层开发记录 — PR1
+
+Date: 2026-05-15
+
+## Scope（PR1 only）
+
+PR1 = descriptor + ensure helper + 字段 id 解析 + degraded fallback + 单测 + ensureObject 补字段行为 orientation 实测。**不碰 writer / 路由 / 前端**（PR2 做 writer，PR3 做前端）。
+
+边界（硬，未破）：`attendance_*` 仍是唯一事实源；本对象只存可重建报表快照；不裸写 `meta_*`，全程经 `context.api.multitable.provisioning`；PR1 无 records 写入。
+
+## Backend 改动
+
+`plugins/plugin-attendance/index.cjs`（接在 `ensureAttendanceReportFieldCatalog` 之后）：
+
+- `ATTENDANCE_REPORT_RECORDS_OBJECT_ID = 'attendance_report_records'`
+- `ATTENDANCE_REPORT_RECORDS_FIELDS`（10 个固定逻辑字段：`row_key/org_id/user_id/employee_name/department/attendance_group/work_date/field_fingerprint/source_fingerprint/synced_at`）
+- `getAttendanceReportRecordsDescriptor()`：镜像 catalog descriptor 模式；类型用 provisioning contract `string/date/dateTime`（**无 `text`**）；`row_key` `validation.required`
+- `ensureAttendanceReportRecords(context,orgId,logger)`：镜像 `ensureAttendanceReportFieldCatalog`——`provisioning.ensureObject({projectId,descriptor})` + `resolveFieldIds`/`getFieldId` 解析物理 id；`!provisioning?.ensureObject` → `{available:false,reason:'MULTITABLE_API_UNAVAILABLE'}` 不抛；`ensureObject` 抛 → catch → `{available:false,reason:'PROVISIONING_FAILED'}` 不抛
+- test surface 导出 4 个：`getAttendanceReportRecordsDescriptor` / `ensureAttendanceReportRecords` / `ATTENDANCE_REPORT_RECORDS_OBJECT_ID` / `ATTENDANCE_REPORT_RECORDS_FIELDS`
+
+## Orientation 实测结论（ensureObject 补字段行为，钉死）
+
+读 `packages/core-backend/src/multitable/provisioning.ts`：
+
+- `ensureObject({projectId,descriptor})` → `ensureSheet` + `ensureFields`，每个 descriptor field 的物理 id = `stableMetaId('fld', projectId, descriptor.id, field.id)`——**确定性**：同一逻辑 code 永远映射同一 `fld_xxx`（坐实 MD「同 code 稳定映射同 fld_xxx」）。
+- `ensureFields`：对每个 descriptor field 执行 `INSERT INTO meta_fields ... ON CONFLICT (id) DO UPDATE SET name/type/property/order`——**纯 upsert，从不 DELETE 不在 descriptor 里的字段**。
+- 推论 1（坐实 MD「ensureObject 补缺列」）：PR2 在 sync 时把 value 列（静态统计/动态 subtype/公式）加进 descriptor 再调 `ensureObject`，新列会被 INSERT 补上，已存在列被 UPDATE，**幂等**。
+- 推论 2（坐实 MD「orphan/stale columns known behavior」）：字段从 descriptor 移除后 `meta_fields` 旧列**不会被删**——orphan 列保留是已知行为，cleanup = P2 follow-up。
+
+**PR1 范围精化（基于上述结论）**：PR1 descriptor 只发固定 identity/provenance 骨架（10 列）。value 列（静态统计/动态 subtype/公式）改为 **PR2 在 sync 时按 live catalog 解析后经同一 `ensureObject` upsert 补列**——而非 PR1 硬编码一份静态统计列。理由：驱动 value 列来自 sync 时的 live catalog，避免 PR1 硬编码列表与 catalog 漂移，且让 列集/fld id/fingerprint 跨 sync 确定性。此为对 MD「PR1 先定固定列 + 系统统计列」的小幅强化（更强的 no-drift 性质），非矛盾；已在代码注释 + 本记录写明。
+
+## Compatibility
+
+- 无新 migration、无 `attendance_*` 改动、无 `meta_*` 裸写。
+- PR1 无路由、无 records 写入、无前端；纯 provision 蓝图 + ensure helper。
+- 既有 catalog/formula/subtype 路径零触碰（28 backend 单测全绿，无回归）。
+
+## Changed files (PR1)
+
+| 文件 | 改动 |
+| --- | --- |
+| `plugins/plugin-attendance/index.cjs` | +OBJECT_ID/FIELDS 常量、+`getAttendanceReportRecordsDescriptor`、+`ensureAttendanceReportRecords`、+test surface 导出 4 项 |
+| `packages/core-backend/tests/unit/attendance-report-field-catalog.test.ts` | +1 test（descriptor 稳定 / 类型契约 / 幂等 ensure / 两条 degraded 不抛） |
+| `docs/development/attendance-report-records-sync-{todo,development,verification}-20260515.md` | 计划（前轮已 review 钉死）+ 本记录 + 验证 |
+
+## Out of scope（PR2/PR3，已在 todo MD 钉死）
+
+- PR2：`POST /api/attendance/report-records/sync` writer（复用 export 路径、物理 fld id upsert、source+field fingerprint 双等 skip、stale 列写 null、重复 row_key 保险丝）
+- PR3：前端同步入口 + fingerprint 链 mock acceptance
+- period 汇总行 / 全员同步分页 / orphan 列 dedup 清理 / 内联公式编辑器 = 各自 follow-up
+- staging 真实 sync evidence（P1 补强，无凭据不伪造）

--- a/docs/development/attendance-report-records-sync-todo-20260515.md
+++ b/docs/development/attendance-report-records-sync-todo-20260515.md
@@ -1,0 +1,187 @@
+# 考勤 P2 attendance_report_records 同步层计划（定稿）
+
+Date: 2026-05-15
+
+## Summary
+
+把考勤统计结果同步成插件私有多维表对象 `attendance_report_records`，让多维表承担二次公式 / 视图 / 筛选 / 权限 / 协作。3-PR 主线。内联公式编辑器后置（落地后很可能由多维表原生公式字段替代，届时再评估）。
+
+**边界（硬，不可破）**：
+
+- `attendance_*` 仍是唯一事实源。
+- 多维表只存可重建的报表快照，不替代/不迁移 `attendance_*`。
+- 不让多维表公式直读 `attendance_*`。
+- 不裸写 `meta_*`，全程经 `context.api.multitable.provisioning` + `records.create/patchRecord`。
+- 多维表公式用 `{fld_xxx}`（字段 id），考勤公式仍用 `{field_code}`（报表字段 code），两套 adapter 分离；底层 `FormulaService`/`FormulaEngine` 可共用，引用解析/权限/白名单/NOW-lookup 策略各自 adapter 管。
+
+参见跨会话记忆 `project_attendance_multitable_report_boundary.md`。
+
+## Orientation（离线坐实，无 DB/staging 凭据需求）
+
+| 假设 | 来源 | 结果 |
+| --- | --- | --- |
+| `provisioning.ensureObject(descriptor)` 通用、可建第 2 个对象 | `ensureAttendanceReportFieldCatalog:1422→1440` | ✅ |
+| descriptor 模式可镜像（`{id,fields,...}`） | `getAttendanceReportFieldCatalogDescriptor:951` + `ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS:256` | ✅ |
+| `records.patchRecord({sheetId,recordId,changes})` 存在且签名确切 | `plugin-after-sales/index.cjs:639` 等 10+ 处 | ✅ |
+| `records.createRecord({sheetId,data})` | `seedAttendanceReportFieldCatalogRecords:1406` | ✅ |
+| field-config fingerprint 可复用 | `buildAttendanceReportFieldConfigFingerprint:1830` | ✅ |
+| daily 数据源 = 既有 export 路径（`loadAttendanceRecordReportFields` + subtype-aware `loadApprovedMinutesRange` + `buildAttendanceRecordReportExportItemAsync`，产含动态 subtype 的 `report_values`） | PR#1601 已坐实 | ✅ |
+| period producer = `loadAttendanceSummary(db,orgId,userId,from,to)` | `:6545` | ✅（period 用，v1 不接） |
+
+## 关键决策：Row Grain = daily-only v1
+
+`workDate/period` 歧义在此钉死：**v1 只做 daily（每员工每工作日一行）**。
+
+理由：daily 1:1 复用既有 export 路径（已产含动态 subtype 的 `report_values` + field-config fingerprint），零新聚合逻辑，幂等键自然稳定；period rollup 走另一个 producer（`loadAttendanceSummary`，range-keyed，shape 不同），强行并入 v1 会重犯 subtype slice 那个「多 producer 无 chokepoint」错误。**period 汇总行 = 显式 follow-up（下一条 slice，复用 `loadAttendanceSummary`）。**
+
+## 幂等 upsert key（钉死）
+
+逻辑 row key = `orgId : userId : workDate`（`workDate` 为 `YYYY-MM-DD`）。
+
+- sync writer：`queryRecords` 按 `row_key` 查 → 命中 `patchRecord({sheetId,recordId,changes})`；未命中 `createRecord({sheetId,data})`。
+- **不做「删旧建新」fallback**（制造 recordId churn；`patchRecord` 已确认可用，直接用）。
+- 多维表对象内用稳定字段 `row_key`（= 拼接串）承载；`createRecord` 同时写 `row_key`，保证下次 `queryRecords` 命中。
+
+### 物理 field id 规则（钉死，review 修正点 3）
+
+`queryRecords` 的 filters / `createRecord` 的 data / `patchRecord` 的 changes **只接受真实物理 `fld_xxx` field id**，不接受逻辑字段名。所以：
+
+- filter：`filters: { [fieldIds.rowKey]: rowKey }`（`fieldIds` 来自 `provisioning.resolveFieldIds`）
+- create data / patch changes：同样全部用 resolved 物理 field id 作 key（沿用 catalog 的 `buildAttendanceReportFieldCatalogRecordData(field, fieldIds)` 那套 logical→physical 映射模式，新建 `buildAttendanceReportRecordData(stat, fieldIds)`）
+- 逻辑字段名（`row_key`/`work_date`/统计 code）**只用于 descriptor 定义与 mapping 表**，绝不直接作为 record data / filter key
+
+## 字段映射（descriptor `ATTENDANCE_REPORT_RECORDS_FIELDS`）
+
+multitable provisioning contract 类型（review 修正点 4）：`string` / `date` / `dateTime` / `number` / `boolean`（**不是** `text`）。
+
+| 逻辑字段 | descriptor 类型 | 来源 |
+| --- | --- | --- |
+| `row_key` | string | `orgId:userId:workDate`（幂等键） |
+| `org_id` / `user_id` / `employee_name` / `department` / `attendance_group` | string | export item 固定字段 |
+| `work_date` | date | 每日粒度 |
+| 系统统计值（`work_duration`/`late_duration`/`early_leave_duration`/`leave_duration`/`overtime_approval_duration`/…） | number | export `report_values` |
+| 动态 subtype 值（`leave_type_*_duration`/`overtime_rule_*_duration`） | number | export `report_values`（PR#1601） |
+| 公式字段结果 | 按 output type 映射（见下） | export `report_values` |
+| `field_fingerprint` | string | `reportFieldConfig.fieldsFingerprint.value`（本行用哪版字段配置算的） |
+| `source_fingerprint` | string | 本行源数据 sha1（复算追溯 + 跳过未变行） |
+| `synced_at` | dateTime | 同步时间戳 |
+
+**公式/统计字段 → multitable 类型映射规则**（按 `formulaOutputType` / `unit`）：`number` / `duration_minutes` / `count` / `days` / `hours` → `number`；`date` → `date`；`boolean` → `boolean`；其余 → `string`。
+
+descriptor 字段集**动态**：固定基础列 + 当前 enabled/reportVisible 的 report fields（含动态 subtype）。PR1 先定固定列 + 系统统计列；动态 subtype 列在 sync 时按当前 catalog 解析（provision 时补缺列，沿用 catalog 对象那套 `ensureObject` 补字段语义）。**`ensureFields` 只 upsert、不删除旧字段**——字段后来被隐藏/禁用、动态 subtype 消失时，多维表里旧列保留（known behavior）。v1 接受；orphan/stale columns cleanup = P2 follow-up。
+
+**动态字段确定性（钉死，review 追加点）**：动态 subtype 列的 descriptor 顺序必须确定性排序，键 `sortOrder → code`；字段的物理 id 由逻辑 code 稳定生成（同一 code 永远映射同一 `fld_xxx`）。保证列顺序、`fld_xxx`、fingerprint 三者跨 sync 不抖。
+
+**stale 值清空（钉死，review 修正点 2-补；PR2 必踩）**：`patchRecord` 是 **merge 语义**——某字段曾写过、后来隐藏/禁用/动态 subtype 消失，若 patch 时只是不再传该 key，旧值会留在 `meta_records.data` 里造成多维表残留旧统计。规则：patch 既有行时，**凡属 attendance-report-records 管理范围、但不在当前 active output fields 内的列，显式写 `null`/空值**（不是省略 key）。新建行不涉及（无旧值）。
+
+## Fingerprint（钉死，特别盯的风险）
+
+每行必写两个：
+
+- `field_fingerprint` = 复用 `buildAttendanceReportFieldConfigFingerprint`，标识「这行结果是哪版考勤字段配置算出的」——后续多维表公式结果可追溯版本。
+- `source_fingerprint` = 该行**要写入的稳定 payload** 的 sha1。构造规则（review 建议点 2，钉死）：取本次要落库的字段值 map，**排除 `synced_at` 与 fingerprint 字段自身**，对 key 做 sort 后再 hash —— 避免对象 key 顺序导致 fingerprint 抖动。
+
+### skip 判定（review 修正点 2，钉死）
+
+**不能只看 `source_fingerprint`**。字段配置变（`field_fingerprint` 变）但源数据没变时，只看 source 会跳过 patch，导致行里 `field_fingerprint` 留旧值、不可追溯。
+
+正确判定：
+
+```
+skip  iff  existing.source_fingerprint === next.source_fingerprint
+        && existing.field_fingerprint === next.field_fingerprint
+否则     → patchRecord（两个 fingerprint 都重写）
+```
+
+两个 fingerprint 均已按字段映射逐行落库，**不引入第 3 个派生列 / schemaVersion**（v1 保持最小；`row_fingerprint = sha1(source+field+schemaVersion)` 方案考虑过但拒绝——多一列与 schemaVersion 簿记，收益不抵复杂度）。
+
+## 失败降级（钉死，特别盯的风险）
+
+- sync 是**独立可选管理员动作**，失败**绝不**影响 `GET /records` / export / `/report-fields`（它们不依赖 report-records 对象）。
+- multitable provisioning/records 不可用或 `isDatabaseSchemaError` → 返回 **`{ ok: true, data: { degraded: true, reason, synced: 0 } }`**（review 建议点 1：这是可选同步层，不应让前端按主流程失败处理）。**只有真正的参数错误（如缺 `userId`/非法 `from-to`）才 `400`**。
+- 单行 write 失败 → 记 warn、计入 `failed`，继续下一行（不整批回滚；下次 sync 幂等重试）。
+- **sync 层永不成为事实源**：只读考勤算好的结果写多维表；考勤查询/导出永远直接走 `attendance_*`，从不读 report-records 对象。
+
+## 3-PR 主线
+
+### PR1 设计 + descriptor
+
+- TODO（本文件）/ development / verification MD
+- `ATTENDANCE_REPORT_RECORDS_OBJECT_ID` + `ATTENDANCE_REPORT_RECORDS_FIELDS` + `getAttendanceReportRecordsDescriptor()`
+- `ensureAttendanceReportRecords(context, orgId, logger)`（镜像 catalog ensure：`provisioning.ensureObject` + `resolveFieldIds`）
+- **不写 writer、不加路由、不前端**（纯 provision + 蓝图）
+- 单测：descriptor 字段稳定、ensure 幂等（二次不重复建）、provisioning 不可用 → degraded 不抛
+- orientation 子项：实测 `ensureObject` 对已存在对象补新字段的行为（确认动态 subtype 列可后补）
+
+### PR2 sync writer
+
+- `POST /api/attendance/report-records/sync`（`attendance:admin`，body `{ from, to, userId }`——**`userId` v1 必填**，review 修正点 1；沿用既有 `CONFIRM_SYNC` live 纪律）
+- 全员同步 / 分页 / batch cursor = follow-up（否则 PR2 从 medium 变 large：要解决跨员工 approvedMap、分页、超时、部分失败汇总）
+- 取数：复用既有 per-target-user export 构建流程（**单一权威路径，不另写聚合**）
+- 写入：per row 用物理 field id `queryRecords({ filters: { [fieldIds.rowKey]: rowKey } })` → `patchRecord`/`createRecord`；按上方 skip 判定（source+field fingerprint 双等才 skip）；patch 时清空 stale 列（写 null）
+- **重复行保险丝**：多维表无 `row_key` 唯一约束。若 `queryRecords(row_key)` 返回多条（并发/历史脏数据）→ v1 **patch 第一条**、其余计 `duplicateRowKeys` warn、**不自动删重复**（dedup = cleanup follow-up）
+- 返回 `{ ok:true, data: { synced, patched, created, skipped, failed, duplicateRowKeys, fieldFingerprint, syncedAt } }`
+- 单测：见测试矩阵
+
+### PR3 前端入口 + 验证
+
+- 考勤管理中心「同步到多维表报表」按钮 + 最近 syncedAt/记录数/fingerprint 展示 + 「打开多维表」入口
+- mock acceptance：catalog → records → multitable rows 一致性（fingerprint 链）
+- 一个 Vue 文件 + 一个 spec
+
+## 测试矩阵（钉死）
+
+| 类别 | 用例 |
+| --- | --- |
+| descriptor (PR1) | 字段稳定；ensure 幂等（二次不重复建）；provisioning 不可用 → degraded 不抛 |
+| upsert (PR2) | 首次 → createRecord；再次同 key → patchRecord（非新建，用物理 fld id filter）；source+field fingerprint 双等 → skip |
+| skip 边界 (PR2) | **源数据不变但字段配置变（field_fingerprint 变）→ 必须 patch，不 skip**（review 修正点 2 的回归红线）；两者皆不变 → skip |
+| 幂等 (PR2) | 同 (from,to,userId) 连跑两次，记录数不翻倍，第二次全 skip/patch；source_fingerprint 对 key-sorted payload 稳定（顺序无关） |
+| 字段 (PR2) | 隐藏/禁用字段不进新 row；动态 subtype 字段值正确进 row 且类型按映射规则；**字段先写后被隐藏 → patch 既有行时该列被显式写 null（不残留旧值）**（review 修正点 2-补回归红线）；动态列顺序按 `sortOrder→code` 确定性、同 code 同 `fld_xxx` |
+| 重复行保险丝 (PR2) | `queryRecords(row_key)` 返回多条 → v1 patch 第一条、计 `duplicateRowKeys` warn、不自动删重复（cleanup follow-up） |
+| fingerprint (PR2) | 每行有 field_fingerprint(=当前 catalog) + source_fingerprint；字段配置变 → field_fingerprint 变且行被 patch |
+| 降级 (PR2) | multitable 不可用 → `{ok:true,data:{degraded:true,reason,synced:0}}` 不抛、不影响 export；缺 userId/非法 from-to → 400；单行失败 → failed++ 继续 |
+| 边界 (PR2) | sync 失败后 `GET /report-fields`/export 仍正常（无耦合）；report-records 对象不被任何考勤查询读取 |
+| 前端 (PR3) | 按钮触发 sync、展示 syncedAt/数/fingerprint、打开多维表入口；数据驱动无新组件 |
+| 命令 | `node --check` / core-backend catalog+formula+sync vitest / web spec vitest / web type-check / core-backend build / `git diff --check` / 显式 stage（无 `-A`、无 node_modules） |
+
+## Out of scope（显式 follow-up）
+
+- period / 周期汇总行（复用 `loadAttendanceSummary`，下一条 slice）
+- **全员同步 / 分页 / batch cursor**（v1 `userId` 必填；全员需解决跨员工 approvedMap、分页、超时、部分失败汇总——单独 slice）
+- **orphan / stale columns cleanup**（`ensureFields` 只 upsert 不删；字段隐藏/禁用/动态 subtype 消失后旧列保留——P2 cleanup follow-up）
+- **重复 row_key 行 dedup**（多维表无唯一约束；v1 只 patch 第一条 + warn，自动删重复 = cleanup follow-up）
+- 多维表侧公式/视图模板预置（归多维表配置，非本线）
+- 内联公式编辑器（后置；落地后很可能由多维表原生公式字段替代，届时再评估。已归档修正：`patchRecord` 非 `updateRecord`、PUT body 加 name/category/unit/sortOrder、严格 code 正则 + 三类拒编辑、存盘前复用 validator、成功重建 catalog+fingerprint、不做删旧建新）
+- staging 真实 sync evidence（同既有，P1 补强，无凭据不伪造）
+
+## Assumptions / 红线
+
+- `provisioning.ensureObject` 支持给已存在对象补新字段（沿用 catalog 对象同语义；PR1 orientation 子项实测确认），但**只 upsert 不删**——orphan 列是 known behavior（P2 cleanup）
+- sync 永不成为事实源；考勤查询/导出永不读 report-records 对象
+- 不裸 SQL 写 `meta_*`；全程 multitable 插件 API；**所有 filter/data/changes key 用物理 `fld_xxx`（`resolveFieldIds`），逻辑名只用于 descriptor/mapping**
+- 幂等键 `orgId:userId:workDate` 稳定；`row_key` 字段落行；`userId` v1 必填
+- skip 仅当 `source_fingerprint` 与 `field_fingerprint` 双等；`source_fingerprint` 基于排除 `synced_at`+fingerprint 自身、key-sorted 的稳定 payload
+- patch 既有行时，管理范围内但非 active output 的列显式写 `null`（patchRecord 是 merge 语义，不传 key 会残留旧值）
+- 动态列确定性：descriptor 顺序 `sortOrder→code`，同 code 稳定映射同 `fld_xxx`，列顺序/fld_id/fingerprint 跨 sync 不抖
+- `row_key` 无唯一约束：重复行 v1 patch 第一条 + `duplicateRowKeys` warn，自动 dedup = follow-up
+- 降级返回 `{ok:true,data:{degraded:true}}`（可选层，非主流程失败）；仅参数错误 400
+- 多维表公式 `{fld_xxx}` 与考勤公式 `{field_code}` adapter 分离，不混用
+
+## Claude Code TODO
+
+### PR1
+- [ ] 本 TODO MD + development + verification MD
+- [ ] `ATTENDANCE_REPORT_RECORDS_OBJECT_ID` + `ATTENDANCE_REPORT_RECORDS_FIELDS` + `getAttendanceReportRecordsDescriptor()`
+- [ ] `ensureAttendanceReportRecords(context,orgId,logger)` + test surface 导出
+- [ ] 单测：descriptor 稳定 / ensure 幂等 / provisioning 不可用降级
+- [ ] orientation 子项：实测 ensureObject 补字段行为，结论写进 development MD
+
+### PR2（待 PR1 合并后）
+- [ ] `POST /api/attendance/report-records/sync` 路由 + writer（复用 export 路径）
+- [ ] upsert（queryRecords→patch/create）+ skip 仅当 source_fingerprint && field_fingerprint 双等
+- [ ] 单测矩阵（upsert/幂等/字段/fingerprint/降级/边界）
+
+### PR3（待 PR2 合并后）
+- [ ] 前端同步入口 + syncedAt/数/fingerprint 展示 + 打开多维表
+- [ ] mock acceptance fingerprint 链一致性

--- a/docs/development/attendance-report-records-sync-verification-20260515.md
+++ b/docs/development/attendance-report-records-sync-verification-20260515.md
@@ -1,0 +1,63 @@
+# 考勤 attendance_report_records 同步层验证记录 — PR1
+
+Date: 2026-05-15
+
+## Commands Run
+
+```bash
+node --check plugins/plugin-attendance/index.cjs
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/attendance-report-field-catalog.test.ts \
+  tests/unit/attendance-report-field-formula-engine.test.ts \
+  --reporter=dot
+NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run \
+  tests/AttendanceReportFieldsSection.spec.ts tests/attendance-admin-regressions.spec.ts --watch=false
+pnpm --filter @metasheet/web type-check
+pnpm --filter @metasheet/core-backend build
+git diff --check
+```
+
+## Results
+
+| Check | Result |
+| --- | --- |
+| Plugin syntax (`plugin-attendance/index.cjs`) | PASS |
+| Backend catalog + formula unit tests | **PASS, 28 tests** (13 catalog + 15 formula; catalog +1 vs prior 12) |
+| Frontend report fields + admin regression specs | PASS（无前端改动；回归确认 PR1 不影响既有 UI） |
+| Web type-check (`vue-tsc -b`) | PASS |
+| core-backend build (`tsc`) | PASS |
+| `git diff --check` whitespace | PASS |
+
+## PR1 Hardening Evidence
+
+新增单测 `attendance_report_records: stable descriptor + idempotent ensure + degraded fallback`：
+
+1. `getAttendanceReportRecordsDescriptor()` 两次调用 `JSON.stringify` 全等 → descriptor 稳定
+2. `ATTENDANCE_REPORT_RECORDS_OBJECT_ID === 'attendance_report_records'`
+3. 字段 id 顺序锁定（10 列固定骨架），`row_key.property.validation.required === true`
+4. **类型契约**：`row_key`→`string`、`work_date`→`date`、`synced_at`→`dateTime`；**无任何 `text` 类型字段**（review 修正点 4 回归）
+5. 幂等 ensure：两次 `ensureAttendanceReportRecords` 结果 `JSON.stringify` 全等；两次传入 `ensureObject` 的 descriptor 全等
+6. fieldIds 解析：`fieldIds.row_key === 'fld_row_key'`、`fieldIds.synced_at === 'fld_synced_at'`
+7. degraded #1：`{api:{multitable:null}}` → `{available:false, reason:'MULTITABLE_API_UNAVAILABLE', sheetId:null, fieldIds:{}}`，**不抛**
+8. degraded #2：`ensureObject` 抛 `Error` → catch → `{available:false, reason:'PROVISIONING_FAILED', sheetId:null}`，**不抛**
+
+## Orientation 验证（ensureObject 补字段行为）
+
+读 `packages/core-backend/src/multitable/provisioning.ts`，坐实：
+
+- `ensureObject` → `ensureFields`，物理 id = `stableMetaId('fld',projectId,objectId,logicalId)`（确定性）
+- `ensureFields` = `INSERT ... ON CONFLICT (id) DO UPDATE`，**无 DELETE** → 补字段 upsert 幂等、移除字段 orphan 保留（known behavior）
+- 结论写进 `attendance-report-records-sync-development-20260515.md`，并据此精化 PR1 范围（骨架在 PR1，value 列在 PR2 sync 时按 live catalog upsert，避免硬编码漂移）
+
+## Acceptance Criteria（PR1）
+
+- descriptor 稳定、object id 固定、10 列骨架字段 id/类型/order 锁定
+- 类型用 provisioning contract（string/date/dateTime），无 `text`
+- ensure 幂等（同 descriptor、结果等价）
+- provisioning 不可用 / ensureObject 抛错两条路径均 degraded 不抛
+- 无 writer/路由/前端；无 migration；无 `attendance_*`/`meta_*` 裸写
+- 28 backend 单测全绿无回归；type-check + build + diff clean
+
+## Live Status
+
+PR1 无 records 写入，无 live 依赖。真实多维表 provision + sync evidence 属 PR2/PR3 + staging 凭据后补强（无凭据不伪造）。

--- a/packages/core-backend/tests/unit/attendance-report-field-catalog.test.ts
+++ b/packages/core-backend/tests/unit/attendance-report-field-catalog.test.ts
@@ -581,6 +581,75 @@ describe('attendance report field catalog multitable foundation', () => {
     expect(entry.leaveMinutes).toBeGreaterThanOrEqual(leaveSubtypeSum)
   })
 
+  it('attendance_report_records: stable descriptor + idempotent ensure + degraded fallback', async () => {
+    const d1 = helpers.getAttendanceReportRecordsDescriptor()
+    const d2 = helpers.getAttendanceReportRecordsDescriptor()
+    expect(d1.id).toBe('attendance_report_records')
+    expect(helpers.ATTENDANCE_REPORT_RECORDS_OBJECT_ID).toBe('attendance_report_records')
+    // descriptor stable across calls (same field ids/types/order)
+    expect(JSON.stringify(d1)).toBe(JSON.stringify(d2))
+    const ids = d1.fields.map((f: { id: string }) => f.id)
+    expect(ids).toEqual([
+      'row_key', 'org_id', 'user_id', 'employee_name', 'department',
+      'attendance_group', 'work_date', 'field_fingerprint', 'source_fingerprint', 'synced_at',
+    ])
+    // provisioning field-type contract: string/date/dateTime only (no "text")
+    const typeByCode = Object.fromEntries(d1.fields.map((f: { id: string, type: string }) => [f.id, f.type]))
+    expect(typeByCode.row_key).toBe('string')
+    expect(typeByCode.work_date).toBe('date')
+    expect(typeByCode.synced_at).toBe('dateTime')
+    expect(d1.fields.some((f: { type: string }) => f.type === 'text')).toBe(false)
+    expect(d1.fields.find((f: { id: string }) => f.id === 'row_key')?.property?.validation?.required).toBe(true)
+
+    // idempotent ensure: ensureObject called once per ensure, same descriptor each time
+    const ensureCalls: unknown[] = []
+    const context = {
+      api: {
+        multitable: {
+          provisioning: {
+            ensureObject: async (input: unknown) => {
+              ensureCalls.push(input)
+              return { baseId: 'base_legacy', sheet: { id: 'sheet_report_records' } }
+            },
+            resolveFieldIds: async ({ fieldIds }: { fieldIds: string[] }) =>
+              Object.fromEntries(fieldIds.map(fid => [fid, `fld_${fid}`])),
+          },
+        },
+      },
+    }
+    const r1 = await helpers.ensureAttendanceReportRecords(context, 'org-a', { warn: vi.fn() })
+    const r2 = await helpers.ensureAttendanceReportRecords(context, 'org-a', { warn: vi.fn() })
+    expect(r1).toMatchObject({
+      available: true,
+      reason: null,
+      objectId: 'attendance_report_records',
+      sheetId: 'sheet_report_records',
+    })
+    expect(r1.fieldIds.row_key).toBe('fld_row_key')
+    expect(r1.fieldIds.synced_at).toBe('fld_synced_at')
+    // idempotent: second ensure returns equivalent result, descriptor passed unchanged
+    expect(JSON.stringify(r2)).toBe(JSON.stringify(r1))
+    expect(JSON.stringify((ensureCalls[0] as { descriptor: unknown }).descriptor))
+      .toBe(JSON.stringify((ensureCalls[1] as { descriptor: unknown }).descriptor))
+
+    // degraded: provisioning API unavailable → no throw, available:false
+    const degraded = await helpers.ensureAttendanceReportRecords({ api: { multitable: null } }, 'org-z', { warn: vi.fn() })
+    expect(degraded).toMatchObject({
+      available: false,
+      reason: 'MULTITABLE_API_UNAVAILABLE',
+      objectId: 'attendance_report_records',
+      sheetId: null,
+    })
+    expect(degraded.fieldIds).toEqual({})
+
+    // degraded: ensureObject throws → caught, available:false PROVISIONING_FAILED, no throw
+    const throwing = {
+      api: { multitable: { provisioning: { ensureObject: async () => { throw new Error('boom') } } } },
+    }
+    const failed = await helpers.ensureAttendanceReportRecords(throwing, 'org-z', { warn: vi.fn() })
+    expect(failed).toMatchObject({ available: false, reason: 'PROVISIONING_FAILED', sheetId: null })
+  })
+
   it('does not add direct meta table writes to the attendance plugin', () => {
     const source = readFileSync(
       new URL('../../../../plugins/plugin-attendance/index.cjs', import.meta.url),

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -1489,6 +1489,103 @@ async function ensureAttendanceReportFieldCatalog(context, orgId, logger, option
   }
 }
 
+// ── attendance_report_records 同步层 (PR1: descriptor + ensure only; no writer/route/frontend) ──
+// 边界: attendance_* 仍是唯一事实源; 本对象只存可重建报表快照, 经 multitable 插件 API, 不裸写 meta_*.
+const ATTENDANCE_REPORT_RECORDS_OBJECT_ID = 'attendance_report_records'
+const ATTENDANCE_REPORT_RECORDS_FIELDS = Object.freeze({
+  rowKey: 'row_key',
+  orgId: 'org_id',
+  userId: 'user_id',
+  employeeName: 'employee_name',
+  department: 'department',
+  attendanceGroup: 'attendance_group',
+  workDate: 'work_date',
+  fieldFingerprint: 'field_fingerprint',
+  sourceFingerprint: 'source_fingerprint',
+  syncedAt: 'synced_at',
+})
+
+function getAttendanceReportRecordsDescriptor() {
+  return {
+    id: ATTENDANCE_REPORT_RECORDS_OBJECT_ID,
+    name: '考勤报表记录（多维表报表层）',
+    description: '考勤插件私有报表快照对象：考勤算好的统计结果同步至此，供多维表二次公式/视图/筛选/权限。可重建，非事实源；attendance_* 仍是唯一事实源。',
+    fields: [
+      { id: ATTENDANCE_REPORT_RECORDS_FIELDS.rowKey, name: '行键', type: 'string', order: 10, property: { validation: { required: true }, width: 240 } },
+      { id: ATTENDANCE_REPORT_RECORDS_FIELDS.orgId, name: '组织', type: 'string', order: 20, property: { width: 120 } },
+      { id: ATTENDANCE_REPORT_RECORDS_FIELDS.userId, name: '员工ID', type: 'string', order: 30, property: { width: 160 } },
+      { id: ATTENDANCE_REPORT_RECORDS_FIELDS.employeeName, name: '姓名', type: 'string', order: 40, property: { width: 120 } },
+      { id: ATTENDANCE_REPORT_RECORDS_FIELDS.department, name: '部门', type: 'string', order: 50, property: { width: 140 } },
+      { id: ATTENDANCE_REPORT_RECORDS_FIELDS.attendanceGroup, name: '考勤组', type: 'string', order: 60, property: { width: 140 } },
+      { id: ATTENDANCE_REPORT_RECORDS_FIELDS.workDate, name: '工作日期', type: 'date', order: 70 },
+      { id: ATTENDANCE_REPORT_RECORDS_FIELDS.fieldFingerprint, name: '字段配置指纹', type: 'string', order: 80, property: { width: 200 } },
+      { id: ATTENDANCE_REPORT_RECORDS_FIELDS.sourceFingerprint, name: '源数据指纹', type: 'string', order: 90, property: { width: 200 } },
+      { id: ATTENDANCE_REPORT_RECORDS_FIELDS.syncedAt, name: '同步时间', type: 'dateTime', order: 100 },
+    ],
+  }
+}
+
+// PR1 ships the fixed identity/provenance skeleton only. Value columns (static stat /
+// dynamic subtype / formula) are ensured at sync time in PR2 via the same ensureObject
+// upsert (ensureFields = INSERT ON CONFLICT DO UPDATE, never deletes — confirmed in
+// packages/core-backend/src/multitable/provisioning.ts ensureFields). Driving the value
+// columns from the live catalog at sync time avoids a hardcoded PR1 stat list drifting
+// from the catalog and keeps column-set / fld id / fingerprint deterministic.
+async function ensureAttendanceReportRecords(context, orgId, logger) {
+  const projectId = getAttendanceReportFieldProjectId(orgId)
+  const multitable = context?.api?.multitable
+  if (!multitable?.provisioning?.ensureObject) {
+    return {
+      available: false,
+      reason: 'MULTITABLE_API_UNAVAILABLE',
+      projectId,
+      objectId: ATTENDANCE_REPORT_RECORDS_OBJECT_ID,
+      baseId: null,
+      sheetId: null,
+      fieldIds: {},
+    }
+  }
+  try {
+    const descriptor = getAttendanceReportRecordsDescriptor()
+    const provisioned = await multitable.provisioning.ensureObject({ projectId, descriptor })
+    const logicalFieldIds = Object.values(ATTENDANCE_REPORT_RECORDS_FIELDS)
+    let fieldIds = {}
+    if (typeof multitable.provisioning.resolveFieldIds === 'function') {
+      fieldIds = await multitable.provisioning.resolveFieldIds({
+        projectId,
+        objectId: ATTENDANCE_REPORT_RECORDS_OBJECT_ID,
+        fieldIds: logicalFieldIds,
+      })
+    } else if (typeof multitable.provisioning.getFieldId === 'function') {
+      fieldIds = Object.fromEntries(logicalFieldIds.map(fieldId => [
+        fieldId,
+        multitable.provisioning.getFieldId(projectId, ATTENDANCE_REPORT_RECORDS_OBJECT_ID, fieldId),
+      ]))
+    }
+    return {
+      available: true,
+      reason: null,
+      projectId,
+      objectId: ATTENDANCE_REPORT_RECORDS_OBJECT_ID,
+      baseId: provisioned.baseId || null,
+      sheetId: provisioned.sheet?.id || null,
+      fieldIds,
+    }
+  } catch (error) {
+    logger?.warn?.('Attendance report records provisioning degraded', error)
+    return {
+      available: false,
+      reason: 'PROVISIONING_FAILED',
+      error: error instanceof Error ? error.message : String(error),
+      projectId,
+      objectId: ATTENDANCE_REPORT_RECORDS_OBJECT_ID,
+      baseId: null,
+      sheetId: null,
+      fieldIds: {},
+    }
+  }
+}
+
 async function loadAttendanceReportFieldCatalog(context, orgId) {
   const projectId = getAttendanceReportFieldProjectId(orgId)
   const multitable = context?.api?.multitable
@@ -9196,6 +9293,10 @@ module.exports = {
     resolveAttendanceFormulaRawAliasesAllowed,
     readAttendanceFormulaRawAliasesEnvOverride,
     loadAttendanceReportFieldCatalog,
+    getAttendanceReportRecordsDescriptor,
+    ensureAttendanceReportRecords,
+    ATTENDANCE_REPORT_RECORDS_OBJECT_ID,
+    ATTENDANCE_REPORT_RECORDS_FIELDS,
     mergeAttendanceReportFieldDefinitions,
     getAttendanceReportFieldDroppedReservedCodes,
     isAttendanceDynamicSubtypeCode,


### PR DESCRIPTION
## Summary

**PR1 of the 3-PR attendance report-records sync mainline.** Descriptor + ensure helper only — **no writer / route / frontend** (PR2 = sync writer, PR3 = frontend entry).

- `ATTENDANCE_REPORT_RECORDS_OBJECT_ID` + `ATTENDANCE_REPORT_RECORDS_FIELDS` + `getAttendanceReportRecordsDescriptor()` — 10-col fixed identity/provenance skeleton (`row_key`/`org_id`/`user_id`/`employee_name`/`department`/`attendance_group`/`work_date`/`field_fingerprint`/`source_fingerprint`/`synced_at`). Provisioning-contract types `string`/`date`/`dateTime` (no `text`); `row_key` required.
- `ensureAttendanceReportRecords()` mirrors `ensureAttendanceReportFieldCatalog`: `provisioning.ensureObject` + `resolveFieldIds`; **degrades without throwing** on `MULTITABLE_API_UNAVAILABLE` and `PROVISIONING_FAILED`.

**Boundary held**: `attendance_*` stays the sole fact source; report-records is a rebuildable snapshot object written only via the multitable plugin API; no `meta_*` raw writes; no migration; PR1 writes zero records.

**Orientation confirmed** (`packages/core-backend/src/multitable/provisioning.ts`): `ensureFields` = `INSERT ... ON CONFLICT (id) DO UPDATE` (pure upsert, never deletes); field id = `stableMetaId` (deterministic from logical code). Consequence baked into the plan: value columns (static stat / dynamic subtype / formula) are deferred to **PR2** sync-time `ensureObject` upsert driven by the **live catalog** (no hardcoded PR1 stat list drifting from the catalog); orphan columns on field removal are a known behavior → P2 cleanup follow-up. Full nailed-down plan (row grain, idempotent upsert, physical fld id, double-fingerprint skip, stale-null clear, duplicate-row fuse) is in `docs/development/attendance-report-records-sync-todo-20260515.md`.

## Test plan

- [x] Backend catalog + formula: **28 pass** (13 catalog incl. new `stable descriptor + idempotent ensure + degraded fallback` test, 15 formula). Covers: descriptor stable across calls; object id; 10-col field id/type/order locked; type contract has no `text`; `row_key` required; idempotent ensure (same descriptor + equivalent result both calls); fieldIds resolution; degraded `MULTITABLE_API_UNAVAILABLE` no-throw; degraded `PROVISIONING_FAILED` (ensureObject throws) no-throw.
- [x] Frontend report fields + admin regression: **17 pass** (no UI change in PR1; regression clean).
- [x] Web type-check (`vue-tsc -b`) + core-backend build (`tsc`) + `git diff --check`: clean.
- [ ] *(PR2/PR3 + staging)* real provision + sync evidence — deferred (P1 follow-up, no creds → not faked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)