### PR TITLE
feat(attendance): add report-records sync writer (PR2)

### DIFF
--- a/docs/development/attendance-report-records-sync-pr2-development-20260516.md
+++ b/docs/development/attendance-report-records-sync-pr2-development-20260516.md
@@ -1,0 +1,63 @@
+# 考勤 attendance_report_records 同步层开发记录 — PR2 (sync writer)
+
+Date: 2026-05-16
+
+## Scope（PR2 only）
+
+PR2 = `POST /api/attendance/report-records/sync` writer。复用既有 per-user export 构建路径，不重写聚合。**不碰前端**（PR3）。边界（硬，未破）：`attendance_*` 仍是唯一事实源；report-records 只存可重建快照；全程经 multitable 插件 API，不裸写 `meta_*`；无 migration。
+
+## Backend 改动
+
+`plugins/plugin-attendance/index.cjs`（接在 `ensureAttendanceReportRecords` 之后 + route block）：
+
+- `mapReportFieldToMultitableType(field)`：`number/duration_minutes/count/days/hours/minutes→number`、`date→date`、`dateTime→dateTime`、`boolean→boolean`、其余 `string`（formulaEnabled 取 `formulaOutputType`，否则 `unit`）
+- `buildAttendanceReportRecordsValueColumns(catalogItems)`：value 列 = **全 catalog（含 disabled）稳定超集**，跳过 raw alias reserved code，order 确定（catalog 上游已 `sortOrder→code` 排序，此处保序）
+- `attendanceReportRecordRowKey(orgId,userId,workDate)` = `orgId:userId:workDate`
+- `buildAttendanceReportRecordSourceFingerprint(logicalPayload)`：sha1，**排除 `synced_at`+两 fingerprint 自身**，key-sort 后 hash（顺序无关、确定性）
+- `syncAttendanceReportRecords(context,db,orgId,logger,{from,to,userId})`：
+  1. `ensureAttendanceReportRecords` → 不可用 `{degraded:true,reason}` 不抛
+  2. records API（query/create/patch）或 provisioning 缺 → `{degraded:true,reason:'MULTITABLE_RECORDS_API_UNAVAILABLE'}`
+  3. 复用 export build：`getAttendanceFormulaRuntimeOptions` + `buildAttendanceReportFieldCatalogResponse`(full items 超集) + `loadAttendanceRecordReportFields` + `buildAttendanceReportFieldConfig.fieldsFingerprint.value`=`field_fingerprint`
+  4. value 列经**同一 `ensureObject` upsert**补列（skeleton+valueColumns；ensureFields=INSERT ON CONFLICT DO UPDATE，幂等、不删——PR1 已坐实）
+  5. `resolveFieldIds` 解析 skeleton+value 全部逻辑 id→物理 `fld_xxx`
+  6. 复用 export 完全相同 SQL（`FROM attendance_records ar LEFT JOIN users u … user_id/org_id/work_date BETWEEN`）+ `loadApprovedMinutesRange`（subtype-aware）
+  7. per row：enrich meta（leave/overtime/reportSubtypeMinutes）→ `buildAttendanceRecordReportExportItemAsync` → logical payload（skeleton + 每个 value 列：active 取 exportItem 值 / managed 但非 active 写 `null`=stale 清空）→ `source_fingerprint` → 物理 fld 化 data（+field/source fp+synced_at）
+  8. `queryRecords({filters:{[physical rowKey]:rowKey}})` → 0 条 `createRecord` / ≥1 条：`>1` 计 `duplicateRowKeys`、patch 第一条；`existing.source==next.source && existing.field==next.field` → skip，否则 `patchRecord(changes=full data)`
+  9. 单行异常 → `failed++` warn 继续，不整批回滚
+  10. 返回 `{synced,patched,created,skipped,failed,duplicateRowKeys,fieldFingerprint,syncedAt}`
+- 路由 `POST /api/attendance/report-records/sync`（`attendance:admin`）：body `z.object({from,to,userId}).min(1)` 全必填，非法 → `400 VALIDATION_ERROR`；`result.degraded` → `{ok:true,data:{degraded:true,reason,synced:0}}`；否则 `emitEvent('attendance.report_records.synced',...)` + `{ok:true,data:result}`
+- test surface 导出 6 项（syncAttendanceReportRecords + 4 helpers + 已有常量）
+
+## 与钉死 todo MD 的对齐
+
+| todo 钉死项 | 落地 |
+| --- | --- |
+| userId v1 必填 | route zod `userId: string().min(1)`，缺 → 400 |
+| 复用 export 不重写聚合 | 完全复用 export endpoint 同款 SQL + loadApprovedMinutesRange + buildAttendanceRecordReportExportItemAsync |
+| 物理 fld id（filter/data/changes） | `resolveFieldIds` → `physical()`，queryRecords filter / create data / patch changes 全物理 id |
+| skip 仅 source+field 双等 | `existingSource===next && existingField===next` 才 skip |
+| stale managed 列写 null | value 列来自**全 catalog 超集**；active→exportItem 值，非 active→`null` |
+| 重复 row_key 保险丝 | `>1` → `duplicateRowKeys += len-1`、patch 第一条、不自动删 |
+| 降级 `{ok:true,data:{degraded:true}}` | route 对 `result.degraded` 返回该 shape；仅参数错误 400 |
+
+## 关于 CONFIRM_SYNC（todo MD 措辞精化）
+
+todo MD 写"沿用既有 `CONFIRM_SYNC` live 纪律"。orientation 实查：插件路由层**无** `CONFIRM_SYNC`——它是 ops live-acceptance 脚本（`scripts/ops/*`）的纪律，不是路由 gate。既有 `POST /report-fields/sync` 即「admin POST 即 gate，无额外 confirm」。PR2 `report-records/sync` **镜像 report-fields/sync**（admin POST gate，无路由层 CONFIRM_SYNC）。`CONFIRM_SYNC` 纪律归 PR3 的 mock/live acceptance 脚本。此为对 MD 措辞的精化，非行为偏移。
+
+## stale-null 负路径测试说明（诚实标注，不伪造）
+
+stale-null 正路径（active value 列取 exportItem 值、无 spurious null）由 writer 单测覆盖。负路径（field 曾 active 后被 disable → 该列 patch 写 null）是 writer loop 内联逻辑（`hasOwnProperty(exportItem,col.id) ? value : null`），其触发需「带 disabled 字段的 catalog config 记录」fixture——与单测用的 built-in fallback（全字段 active）冲突，强行双 mock 会大幅膨胀测试面。本轮**不伪造该负路径覆盖**：以代码引用 + 本说明 + verification MD 标注为「inline 逻辑 + reasoned guarantee」，完整负路径单测随 PR3 mock acceptance（用真实 catalog config fixture）或 staging 补。
+
+## Changed files (PR2)
+
+| 文件 | 改动 |
+| --- | --- |
+| `plugins/plugin-attendance/index.cjs` | +4 helper、+`syncAttendanceReportRecords`、+`POST /report-records/sync` route、+test surface 6 导出 |
+| `packages/core-backend/tests/unit/attendance-report-field-catalog.test.ts` | +2 test（纯 helper；writer upsert/skip/skip-boundary/duplicate/degraded/export-decoupling）|
+| `docs/development/attendance-report-records-sync-pr2-{development,verification}-20260516.md` | 本记录 + 验证 |
+
+## Out of scope（PR3 / follow-up，todo MD 已钉死）
+
+- PR3 前端同步入口 + fingerprint 链 mock acceptance（含 stale-null 负路径完整单测、disabled 字段 fixture）
+- period 汇总行 / 全员同步分页 / orphan 列 + 重复行 dedup cleanup / 内联公式编辑器
+- staging 真实 sync evidence（P1 补强，无凭据不伪造）

--- a/docs/development/attendance-report-records-sync-pr2-development-20260516.md
+++ b/docs/development/attendance-report-records-sync-pr2-development-20260516.md
@@ -61,3 +61,12 @@ stale-null 正路径（active value 列取 exportItem 值、无 spurious null）
 - PR3 前端同步入口 + fingerprint 链 mock acceptance（含 stale-null 负路径完整单测、disabled 字段 fixture）
 - period 汇总行 / 全员同步分页 / orphan 列 + 重复行 dedup cleanup / 内联公式编辑器
 - staging 真实 sync evidence（P1 补强，无凭据不伪造）
+
+## Patch addendum (review round, 2026-05-16)
+
+Review 抓到 2 个具体问题，已小补丁修复（同 PR2 分支新 commit）：
+
+1. **valueColumns × fixed skeleton 碰撞（真 schema 覆盖 bug）**：`buildAttendanceReportRecordsValueColumns(catalog.items)` 原会把 `work_date`/`employee_name`/`department`/`attendance_group`（catalog 里也有这些 code）加成 value column。固定骨架 `work_date` 是 `date`，value column 会是 `string`；`[...skeleton, ...valueColumns]` 传给 `ensureObject`→`ensureFields`（INSERT ON CONFLICT DO UPDATE，同 logical id→同 stableMetaId 物理 id），后出现的 value column 会把 `work_date` 类型从 `date` 覆盖成 `string`。修法：`buildAttendanceReportRecordsValueColumns` 过滤掉 `Object.values(ATTENDANCE_REPORT_RECORDS_FIELDS)`（骨架已承载这 4 个 identity 值，value 列不应重复）。
+2. **路由未用 `resolveAttendanceDateRange`（契约/实现不一致）**：原路由仅 `z.string().min(1)`，TODO 要求非法 from-to → 400。修法：路由调 `resolveAttendanceDateRange(from,to)`，`!ok`→`400 VALIDATION_ERROR`，writer 用 normalized `from/to`，emitEvent 用 normalized 值。镜像既有 export-endpoint 同款 idiom（8 处在用、`resolveAttendanceDateRange` 久经验证），故不为该 pre-existing helper 补冗余单测。
+
+新增回归断言（catalog test）：value columns 与 skeleton 零交集；`[skeleton,...valueColumns]` 组合后 `work_date` 仅一次且 `type:'date'`、`employee_name/department/attendance_group` 各仅一次；writer 实测捕获传给 `ensureObject` 的 descriptor，`work_date` 仅一次且 `type:'date'`、`row_key` 等 skeleton 无重复。

--- a/docs/development/attendance-report-records-sync-pr2-verification-20260516.md
+++ b/docs/development/attendance-report-records-sync-pr2-verification-20260516.md
@@ -70,3 +70,14 @@ git diff --check
 ## Live Status
 
 writer 单测全绿。真实多维表 provision + sync + fingerprint 链一致性 + stale-null 负路径 = PR3 mock acceptance + staging 凭据后补强（无凭据不伪造）。
+
+## Patch addendum verification (review round, 2026-05-16)
+
+| Fix | 回归断言 | 结果 |
+| --- | --- | --- |
+| valueColumns 排除 skeleton id | `cols.some(c=>skeletonIds.has(c.id))===false`；`work_date/employee_name/department/attendance_group` 不在 value columns | PASS |
+| 组合 descriptor 无碰撞 | `[getAttendanceReportRecordsDescriptor().fields, ...cols]` 中 `work_date` 仅 1 个且 `type==='date'`；3 个 skeleton text 列各仅 1 个 | PASS |
+| writer 实测 ensureObject descriptor | 捕获传给 `provisioning.ensureObject` 的 fields：`work_date` 仅 1 个 `type:'date'`，`row_key`/`employee_name`/`department`/`attendance_group` 各仅 1 个 | PASS |
+| 路由 dateRange 400 | 镜像既有 export-endpoint `resolveAttendanceDateRange` idiom（8 call sites 在用，helper 久经验证）；`!ok`→400，writer 用 normalized from/to | 代码对齐（既有 helper 不补冗余单测） |
+
+backend 30 全绿（含上述新回归断言），frontend / type-check / build / diff 重跑见下。

--- a/docs/development/attendance-report-records-sync-pr2-verification-20260516.md
+++ b/docs/development/attendance-report-records-sync-pr2-verification-20260516.md
@@ -1,0 +1,72 @@
+# 考勤 attendance_report_records 同步层验证记录 — PR2
+
+Date: 2026-05-16
+
+## Commands Run
+
+```bash
+node --check plugins/plugin-attendance/index.cjs
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/attendance-report-field-catalog.test.ts \
+  tests/unit/attendance-report-field-formula-engine.test.ts \
+  --reporter=dot
+NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run \
+  tests/AttendanceReportFieldsSection.spec.ts tests/attendance-admin-regressions.spec.ts --watch=false
+pnpm --filter @metasheet/web type-check
+pnpm --filter @metasheet/core-backend build
+git diff --check
+```
+
+## Results
+
+| Check | Result |
+| --- | --- |
+| Plugin syntax | PASS |
+| Backend catalog + formula unit tests | **PASS, 30 tests** (15 catalog + 15 formula; catalog +2 vs prior 13) |
+| Frontend report fields + admin regression | PASS（PR2 无前端改动；回归确认无耦合） |
+| Web type-check (`vue-tsc -b`) | PASS |
+| core-backend build (`tsc`) | PASS |
+| `git diff --check` | PASS |
+
+## Hardening Evidence（钉死项逐条）
+
+### 纯 helper 测（`report-records sync: pure helpers`）
+
+- `mapReportFieldToMultitableType`：minutes/count→number、text→string、dateTime→dateTime、formula duration_minutes→number、formula boolean→boolean、formula date→date
+- `attendanceReportRecordRowKey` = `org:user:date`
+- `buildAttendanceReportRecordsValueColumns`：raw alias reserved（`late_minutes`）被跳过；`work_duration`/`leave_type_annual_duration` 保留；类型 number；顺序保序
+- `buildAttendanceReportRecordSourceFingerprint`：排除 `synced_at`+两 fingerprint、key-sort → 不同 key 顺序/不同 synced_at 与 fingerprint 值得到**相同** hash；payload 值变 → hash 变
+
+### writer 测（`report-records sync: upsert / skip / duplicate / degraded / export decoupling`）
+
+| 钉死项 | 断言 |
+| --- | --- |
+| 降级 | 无 multitable → `{degraded:true,synced:0,created:0,patched:0}`，不抛 |
+| export 无耦合 | degraded sync 后 `buildAttendanceRecordReportExportItem` 仍正常（无共享可变态/全局污染） |
+| upsert-create | sync#1 → `created:2`，store 2 行，含 `fld_field_fingerprint`/`fld_source_fingerprint` |
+| skip 双等 | sync#2 同数据 → `skipped:2,created:0,patched:0`，store 不增 |
+| **skip-boundary** | 篡改 store[0] `fld_field_fingerprint`=STALE（source 不变）→ sync#3 `patched:1,skipped:1`，该列被重写非 STALE（review 修正点 2 回归红线） |
+| 重复 row_key 保险丝 | 注入同 row_key 第 2 条 → `duplicateRowKeys≥1`，patch 第一条，重复行**不自动删**（v1，store 仍 2 条） |
+| 物理 fld id | store key 为 `fld_row_key`/`fld_field_fingerprint`/`fld_source_fingerprint`（resolveFieldIds 物理化生效） |
+
+### stale-null 负路径（诚实标注，未伪造）
+
+正路径（active value 列取 exportItem 值、无 spurious null）writer 测覆盖。负路径（曾 active 后 disable → 列 patch 写 `null`）为 writer loop 内联 `hasOwnProperty(exportItem,col.id) ? value : null`，触发需 disabled 字段 catalog config fixture，与本测的 built-in fallback（全 active）冲突；**本轮不伪造该负路径覆盖**，以代码引用 + dev MD 说明为 reasoned guarantee，完整负路径单测随 PR3 mock acceptance（disabled fixture）或 staging 补。符合本项目 anti-fake 纪律。
+
+## Acceptance Criteria（PR2）
+
+- `POST /report-records/sync` `attendance:admin`，`from/to/userId` 全必填（缺 → 400）
+- 复用 export 同款 SQL + loadApprovedMinutesRange + buildAttendanceRecordReportExportItemAsync，不重写聚合
+- value 列经同一 ensureObject upsert 补列（全 catalog 超集，确定性）
+- 物理 fld id 贯穿 filter/create data/patch changes
+- skip 仅 source+field fingerprint 双等；否则 patch 全量 data
+- stale managed 列（非 active）→ null（正路径测，负路径 reasoned + follow-up）
+- 重复 row_key → patch 第一条 + duplicateRowKeys，不自动删
+- 降级 `{ok:true,data:{degraded:true,reason,synced:0}}`；仅参数错误 400
+- 单行失败 failed++ 继续，不整批回滚
+- 不迁移 `attendance_*`、不裸写 `meta_*`、export/report-fields 无耦合
+- 30 backend 单测全绿、frontend 17 无回归、type-check + build + diff clean
+
+## Live Status
+
+writer 单测全绿。真实多维表 provision + sync + fingerprint 链一致性 + stale-null 负路径 = PR3 mock acceptance + staging 凭据后补强（无凭据不伪造）。

--- a/packages/core-backend/tests/unit/attendance-report-field-catalog.test.ts
+++ b/packages/core-backend/tests/unit/attendance-report-field-catalog.test.ts
@@ -662,6 +662,10 @@ describe('attendance report field catalog multitable foundation', () => {
     expect(helpers.attendanceReportRecordRowKey('org-1', 'u-1', '2026-05-13')).toBe('org-1:u-1:2026-05-13')
 
     const cols = helpers.buildAttendanceReportRecordsValueColumns([
+      { code: 'work_date', name: '工作日期', unit: 'dateTime' }, // fixed skeleton id → excluded
+      { code: 'employee_name', name: '姓名', unit: 'text' }, // skeleton → excluded
+      { code: 'department', name: '部门', unit: 'text' }, // skeleton → excluded
+      { code: 'attendance_group', name: '考勤组', unit: 'text' }, // skeleton → excluded
       { code: 'work_duration', name: '工作时长', unit: 'minutes' },
       { code: 'late_minutes', name: '迟到分钟(reserved)', unit: 'minutes' }, // raw alias reserved → skipped
       { code: 'leave_type_annual_duration', name: '年假时长', unit: 'minutes' },
@@ -670,6 +674,17 @@ describe('attendance report field catalog multitable foundation', () => {
     expect(cols.every((c: { type: string }) => c.type === 'number')).toBe(true)
     // deterministic order preserved (sortOrder upstream → index here), reserved excluded
     expect(cols.find((c: { id: string }) => c.id === 'late_minutes')).toBeUndefined()
+    // Fix-1 regression: value columns have ZERO intersection with the fixed skeleton ids
+    const skeletonIds = new Set(Object.values(helpers.ATTENDANCE_REPORT_RECORDS_FIELDS) as string[])
+    expect(cols.some((c: { id: string }) => skeletonIds.has(c.id))).toBe(false)
+    // composing [skeleton, ...valueColumns] for ensureObject: work_date appears ONCE, type stays 'date'
+    const composed = [...helpers.getAttendanceReportRecordsDescriptor().fields, ...cols]
+    const workDateFields = composed.filter((f: { id: string }) => f.id === 'work_date')
+    expect(workDateFields).toHaveLength(1)
+    expect(workDateFields[0].type).toBe('date')
+    for (const sk of ['employee_name', 'department', 'attendance_group']) {
+      expect(composed.filter((f: { id: string }) => f.id === sk)).toHaveLength(1)
+    }
 
     // source fingerprint: excludes synced_at + both fingerprints, key-sorted (order-independent)
     const a = helpers.buildAttendanceReportRecordSourceFingerprint({ b: 2, a: 1, synced_at: 'X', source_fingerprint: 'S', field_fingerprint: 'F' })
@@ -717,8 +732,12 @@ describe('attendance report field catalog multitable foundation', () => {
         return rec
       },
     }
+    const ensureObjectDescriptors: Array<{ fields: Array<{ id: string; type: string }> }> = []
     const provisioning = {
-      ensureObject: async () => ({ baseId: 'base_legacy', sheet: { id: 'sheet_rr' } }),
+      ensureObject: async (input: { descriptor?: { fields?: Array<{ id: string; type: string }> } }) => {
+        if (input?.descriptor?.fields) ensureObjectDescriptors.push({ fields: input.descriptor.fields })
+        return { baseId: 'base_legacy', sheet: { id: 'sheet_rr' } }
+      },
       resolveFieldIds: async ({ fieldIds }: { fieldIds: string[] }) =>
         Object.fromEntries(fieldIds.map(f => [f, `fld_${f}`])),
       // NO findObjectSheet → catalog falls back to deterministic built-in field set
@@ -739,6 +758,15 @@ describe('attendance report field catalog multitable foundation', () => {
     const r1 = await helpers.syncAttendanceReportRecords(context, db, 'org-1', { warn: vi.fn() }, { from: '2026-05-01', to: '2026-05-31', userId: 'u-1' })
     expect(r1).toMatchObject({ synced: 2, created: 2, patched: 0, skipped: 0, failed: 0, duplicateRowKeys: 0 })
     expect(store.length).toBe(2)
+    // Fix-1 integration: the descriptor handed to ensureObject (value-columns ensure) must
+    // carry work_date exactly once and still as type 'date' (no string overwrite collision)
+    const valueEnsure = ensureObjectDescriptors[ensureObjectDescriptors.length - 1]
+    const wd = valueEnsure.fields.filter(f => f.id === 'work_date')
+    expect(wd).toHaveLength(1)
+    expect(wd[0].type).toBe('date')
+    for (const sk of ['employee_name', 'department', 'attendance_group', 'row_key']) {
+      expect(valueEnsure.fields.filter(f => f.id === sk)).toHaveLength(1)
+    }
     expect(store[0].data[rowKeyFid]).toBe('org-1:u-1:2026-05-13')
     expect(typeof store[0].data['fld_field_fingerprint']).toBe('string')
     expect(typeof store[0].data['fld_source_fingerprint']).toBe('string')

--- a/packages/core-backend/tests/unit/attendance-report-field-catalog.test.ts
+++ b/packages/core-backend/tests/unit/attendance-report-field-catalog.test.ts
@@ -650,6 +650,118 @@ describe('attendance report field catalog multitable foundation', () => {
     expect(failed).toMatchObject({ available: false, reason: 'PROVISIONING_FAILED', sheetId: null })
   })
 
+  it('report-records sync: pure helpers (type map / value columns / row key / source fingerprint)', () => {
+    expect(helpers.mapReportFieldToMultitableType({ unit: 'minutes' })).toBe('number')
+    expect(helpers.mapReportFieldToMultitableType({ unit: 'count' })).toBe('number')
+    expect(helpers.mapReportFieldToMultitableType({ unit: 'text' })).toBe('string')
+    expect(helpers.mapReportFieldToMultitableType({ unit: 'dateTime' })).toBe('dateTime')
+    expect(helpers.mapReportFieldToMultitableType({ formulaEnabled: true, formulaOutputType: 'duration_minutes' })).toBe('number')
+    expect(helpers.mapReportFieldToMultitableType({ formulaEnabled: true, formulaOutputType: 'boolean' })).toBe('boolean')
+    expect(helpers.mapReportFieldToMultitableType({ formulaEnabled: true, formulaOutputType: 'date' })).toBe('date')
+
+    expect(helpers.attendanceReportRecordRowKey('org-1', 'u-1', '2026-05-13')).toBe('org-1:u-1:2026-05-13')
+
+    const cols = helpers.buildAttendanceReportRecordsValueColumns([
+      { code: 'work_duration', name: '工作时长', unit: 'minutes' },
+      { code: 'late_minutes', name: '迟到分钟(reserved)', unit: 'minutes' }, // raw alias reserved → skipped
+      { code: 'leave_type_annual_duration', name: '年假时长', unit: 'minutes' },
+    ])
+    expect(cols.map((c: { id: string }) => c.id)).toEqual(['work_duration', 'leave_type_annual_duration'])
+    expect(cols.every((c: { type: string }) => c.type === 'number')).toBe(true)
+    // deterministic order preserved (sortOrder upstream → index here), reserved excluded
+    expect(cols.find((c: { id: string }) => c.id === 'late_minutes')).toBeUndefined()
+
+    // source fingerprint: excludes synced_at + both fingerprints, key-sorted (order-independent)
+    const a = helpers.buildAttendanceReportRecordSourceFingerprint({ b: 2, a: 1, synced_at: 'X', source_fingerprint: 'S', field_fingerprint: 'F' })
+    const b = helpers.buildAttendanceReportRecordSourceFingerprint({ a: 1, b: 2, synced_at: 'Y', source_fingerprint: 'Z', field_fingerprint: 'Q' })
+    expect(a).toBe(b) // synced_at + fingerprints excluded, key order irrelevant
+    const c = helpers.buildAttendanceReportRecordSourceFingerprint({ a: 1, b: 3 })
+    expect(c).not.toBe(a) // payload value change → different fingerprint
+  })
+
+  it('report-records sync: upsert / skip / duplicate / degraded / export decoupling', async () => {
+    // degraded: no multitable provisioning → {degraded:true}, no throw
+    const degraded = await helpers.syncAttendanceReportRecords(
+      { api: { multitable: null, database: { query: async () => [] } } },
+      { query: async () => [] },
+      'org-1',
+      { warn: vi.fn() },
+      { from: '2026-05-01', to: '2026-05-31', userId: 'u-1' },
+    )
+    expect(degraded).toMatchObject({ degraded: true, synced: 0, created: 0, patched: 0 })
+
+    // export decoupling: a degraded sync must not break the independent export builder
+    const exportFields = helpers.resolveAttendanceRecordReportFields(
+      helpers.mergeAttendanceReportFieldDefinitions([], {}),
+    )
+    const exportRow = { work_date: '2026-05-13', status: 'normal', is_workday: true, meta: {}, work_minutes: 480 }
+    expect(() => helpers.buildAttendanceRecordReportExportItem(exportRow, exportFields)).not.toThrow()
+
+    // store-backed records mock (Map by physical row_key value) for upsert/skip/duplicate
+    const store: Array<{ id: string; data: Record<string, unknown> }> = []
+    let seq = 0
+    const rowKeyFid = 'fld_row_key'
+    const records = {
+      queryRecords: async ({ filters }: { filters?: Record<string, unknown> }) => {
+        const want = filters?.[rowKeyFid]
+        return store.filter(r => r.data[rowKeyFid] === want)
+      },
+      createRecord: async ({ data }: { data: Record<string, unknown> }) => {
+        const rec = { id: `rec-${++seq}`, data: { ...data } }
+        store.push(rec)
+        return rec
+      },
+      patchRecord: async ({ recordId, changes }: { recordId: string; changes: Record<string, unknown> }) => {
+        const rec = store.find(r => r.id === recordId)
+        if (rec) rec.data = { ...rec.data, ...changes }
+        return rec
+      },
+    }
+    const provisioning = {
+      ensureObject: async () => ({ baseId: 'base_legacy', sheet: { id: 'sheet_rr' } }),
+      resolveFieldIds: async ({ fieldIds }: { fieldIds: string[] }) =>
+        Object.fromEntries(fieldIds.map(f => [f, `fld_${f}`])),
+      // NO findObjectSheet → catalog falls back to deterministic built-in field set
+    }
+    const attendanceRows = [
+      { user_id: 'u-1', org_id: 'org-1', work_date: '2026-05-13', timezone: 'UTC', first_in_at: '2026-05-13T09:00:00Z', last_out_at: '2026-05-13T18:00:00Z', work_minutes: 480, late_minutes: 0, early_leave_minutes: 0, status: 'normal', is_workday: true, meta: {}, user_name: '张三', username: 'zhangsan' },
+      { user_id: 'u-1', org_id: 'org-1', work_date: '2026-05-14', timezone: 'UTC', first_in_at: '2026-05-14T09:10:00Z', last_out_at: '2026-05-14T18:00:00Z', work_minutes: 470, late_minutes: 10, early_leave_minutes: 0, status: 'late', is_workday: true, meta: {}, user_name: '张三', username: 'zhangsan' },
+    ]
+    const db = {
+      query: async (sql: string) => {
+        if (/FROM attendance_records ar/.test(sql)) return attendanceRows
+        return [] // system_configs / leave_types / overtime_rules / approved → empty (tolerated)
+      },
+    }
+    const context = { api: { multitable: { provisioning, records }, database: db } }
+
+    // sync #1 → all created
+    const r1 = await helpers.syncAttendanceReportRecords(context, db, 'org-1', { warn: vi.fn() }, { from: '2026-05-01', to: '2026-05-31', userId: 'u-1' })
+    expect(r1).toMatchObject({ synced: 2, created: 2, patched: 0, skipped: 0, failed: 0, duplicateRowKeys: 0 })
+    expect(store.length).toBe(2)
+    expect(store[0].data[rowKeyFid]).toBe('org-1:u-1:2026-05-13')
+    expect(typeof store[0].data['fld_field_fingerprint']).toBe('string')
+    expect(typeof store[0].data['fld_source_fingerprint']).toBe('string')
+
+    // sync #2 same data → all skipped (source+field fingerprint 双等)
+    const r2 = await helpers.syncAttendanceReportRecords(context, db, 'org-1', { warn: vi.fn() }, { from: '2026-05-01', to: '2026-05-31', userId: 'u-1' })
+    expect(r2).toMatchObject({ synced: 2, created: 0, skipped: 2, patched: 0 })
+    expect(store.length).toBe(2)
+
+    // skip-boundary: source unchanged but field_fingerprint stale → must patch, not skip
+    store[0].data['fld_field_fingerprint'] = 'STALE-FIELD-FP'
+    const r3 = await helpers.syncAttendanceReportRecords(context, db, 'org-1', { warn: vi.fn() }, { from: '2026-05-01', to: '2026-05-31', userId: 'u-1' })
+    expect(r3.patched).toBe(1)
+    expect(r3.skipped).toBe(1)
+    expect(store[0].data['fld_field_fingerprint']).not.toBe('STALE-FIELD-FP') // rewritten
+
+    // duplicate row_key fuse: inject a 2nd record same row_key → patch first, count duplicate
+    store.push({ id: 'rec-dup', data: { ...store[0].data } })
+    const r4 = await helpers.syncAttendanceReportRecords(context, db, 'org-1', { warn: vi.fn() }, { from: '2026-05-01', to: '2026-05-31', userId: 'u-1' })
+    expect(r4.duplicateRowKeys).toBeGreaterThanOrEqual(1)
+    expect(store.filter(r => r.data[rowKeyFid] === 'org-1:u-1:2026-05-13').length).toBe(2) // not auto-deleted (v1)
+  })
+
   it('does not add direct meta table writes to the attendance plugin', () => {
     const source = readFileSync(
       new URL('../../../../plugins/plugin-attendance/index.cjs', import.meta.url),

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -1600,9 +1600,19 @@ function mapReportFieldToMultitableType(field) {
 // Stable superset of value columns from the FULL catalog (incl. disabled) so the managed
 // column set is deterministic across syncs and disabled fields' columns can be nulled on
 // patch (stale-null). Truly-removed-from-catalog codes leave orphan columns = P2 cleanup.
+// MUST exclude fixed-skeleton field ids: a catalog code like `work_date` shares the
+// logical id of the skeleton column, and since ensureFields is INSERT ON CONFLICT DO
+// UPDATE the later (string) value column would overwrite the skeleton type (date). The
+// skeleton already carries work_date/employee_name/department/attendance_group values.
 function buildAttendanceReportRecordsValueColumns(catalogItems) {
+  const skeletonIds = new Set(Object.values(ATTENDANCE_REPORT_RECORDS_FIELDS))
   return (Array.isArray(catalogItems) ? catalogItems : [])
-    .filter(field => field && field.code && !ATTENDANCE_REPORT_FORMULA_RESERVED_CODES.has(field.code))
+    .filter(field => (
+      field
+      && field.code
+      && !ATTENDANCE_REPORT_FORMULA_RESERVED_CODES.has(field.code)
+      && !skeletonIds.has(field.code)
+    ))
     .map((field, index) => ({
       id: field.code,
       name: field.name || field.code,
@@ -21538,7 +21548,16 @@ module.exports = {
           res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
           return
         }
-        const result = await syncAttendanceReportRecords(context, db, orgId, logger, parsed.data)
+        const dateRange = resolveAttendanceDateRange(parsed.data.from, parsed.data.to)
+        if (!dateRange.ok) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: dateRange.message } })
+          return
+        }
+        const result = await syncAttendanceReportRecords(context, db, orgId, logger, {
+          from: dateRange.from,
+          to: dateRange.to,
+          userId: parsed.data.userId,
+        })
         if (result.degraded) {
           res.json({ ok: true, data: { degraded: true, reason: result.reason, synced: 0 } })
           return
@@ -21546,8 +21565,8 @@ module.exports = {
         emitEvent('attendance.report_records.synced', {
           orgId,
           userId: parsed.data.userId,
-          from: parsed.data.from,
-          to: parsed.data.to,
+          from: dateRange.from,
+          to: dateRange.to,
           synced: result.synced,
           patched: result.patched,
           created: result.created,

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -1586,6 +1586,186 @@ async function ensureAttendanceReportRecords(context, orgId, logger) {
   }
 }
 
+// ── attendance_report_records sync writer (PR2) ──
+// 复用既有 per-user export 构建路径; 不重写聚合; 全程经 multitable 插件 API; attendance_* 仍是唯一事实源.
+function mapReportFieldToMultitableType(field) {
+  const t = field?.formulaEnabled ? field.formulaOutputType : field?.unit
+  if (['number', 'duration_minutes', 'count', 'days', 'hours', 'minutes'].includes(t)) return 'number'
+  if (t === 'date') return 'date'
+  if (t === 'dateTime') return 'dateTime'
+  if (t === 'boolean') return 'boolean'
+  return 'string'
+}
+
+// Stable superset of value columns from the FULL catalog (incl. disabled) so the managed
+// column set is deterministic across syncs and disabled fields' columns can be nulled on
+// patch (stale-null). Truly-removed-from-catalog codes leave orphan columns = P2 cleanup.
+function buildAttendanceReportRecordsValueColumns(catalogItems) {
+  return (Array.isArray(catalogItems) ? catalogItems : [])
+    .filter(field => field && field.code && !ATTENDANCE_REPORT_FORMULA_RESERVED_CODES.has(field.code))
+    .map((field, index) => ({
+      id: field.code,
+      name: field.name || field.code,
+      type: mapReportFieldToMultitableType(field),
+      order: 1000 + index,
+    }))
+}
+
+function attendanceReportRecordRowKey(orgId, userId, workDate) {
+  return `${orgId}:${userId}:${workDate}`
+}
+
+function buildAttendanceReportRecordSourceFingerprint(logicalPayload) {
+  const excluded = new Set([
+    ATTENDANCE_REPORT_RECORDS_FIELDS.syncedAt,
+    ATTENDANCE_REPORT_RECORDS_FIELDS.fieldFingerprint,
+    ATTENDANCE_REPORT_RECORDS_FIELDS.sourceFingerprint,
+  ])
+  const canonical = Object.keys(logicalPayload)
+    .filter(key => !excluded.has(key))
+    .sort()
+    .map(key => [key, logicalPayload[key]])
+  return crypto.createHash('sha1').update(JSON.stringify(canonical)).digest('hex')
+}
+
+async function syncAttendanceReportRecords(context, db, orgId, logger, params) {
+  const userId = String(params?.userId || '').trim()
+  const from = String(params?.from || '').trim()
+  const to = String(params?.to || '').trim()
+  const empty = { synced: 0, patched: 0, created: 0, skipped: 0, failed: 0, duplicateRowKeys: 0 }
+
+  const ensured = await ensureAttendanceReportRecords(context, orgId, logger)
+  if (!ensured.available) {
+    return { degraded: true, reason: ensured.reason, ...empty }
+  }
+  const records = context?.api?.multitable?.records
+  const provisioning = context?.api?.multitable?.provisioning
+  if (!records?.queryRecords || !records?.createRecord || !records?.patchRecord || !provisioning?.ensureObject) {
+    return { degraded: true, reason: 'MULTITABLE_RECORDS_API_UNAVAILABLE', ...empty }
+  }
+
+  const formulaOptions = await getAttendanceFormulaRuntimeOptions(db)
+  const catalog = await buildAttendanceReportFieldCatalogResponse(context, orgId, logger, {
+    provision: false,
+    ...formulaOptions,
+  })
+  const reportFields = await loadAttendanceRecordReportFields(context, orgId, logger, formulaOptions)
+  const reportFieldConfig = buildAttendanceReportFieldConfig(reportFields)
+  const fieldFingerprint = reportFieldConfig?.fieldsFingerprint?.value || ''
+
+  // ensure value columns (stable superset) via the same ensureObject upsert (idempotent, never deletes)
+  const valueColumns = buildAttendanceReportRecordsValueColumns(catalog.items)
+  const baseDescriptor = getAttendanceReportRecordsDescriptor()
+  await provisioning.ensureObject({
+    projectId: ensured.projectId,
+    descriptor: { ...baseDescriptor, fields: [...baseDescriptor.fields, ...valueColumns] },
+  })
+  const logicalIds = [
+    ...Object.values(ATTENDANCE_REPORT_RECORDS_FIELDS),
+    ...valueColumns.map(column => column.id),
+  ]
+  const fieldIds = typeof provisioning.resolveFieldIds === 'function'
+    ? await provisioning.resolveFieldIds({
+      projectId: ensured.projectId,
+      objectId: ATTENDANCE_REPORT_RECORDS_OBJECT_ID,
+      fieldIds: logicalIds,
+    })
+    : Object.fromEntries(logicalIds.map(id => [id, id]))
+  const physical = logicalId => fieldIds?.[logicalId] || logicalId
+
+  const rows = await db.query(
+    `SELECT ar.user_id, ar.org_id, ar.work_date, ar.timezone, ar.first_in_at, ar.last_out_at,
+            ar.work_minutes, ar.late_minutes, ar.early_leave_minutes, ar.status, ar.is_workday,
+            ar.meta, u.name AS user_name, u.username AS username
+     FROM attendance_records ar
+     LEFT JOIN users u ON u.id = ar.user_id
+     WHERE ar.user_id = $1 AND ar.org_id = $2 AND ar.work_date BETWEEN $3 AND $4
+     ORDER BY ar.work_date DESC
+     LIMIT 5000`,
+    [userId, orgId, from, to]
+  )
+  const approvedMap = await loadApprovedMinutesRange(db, orgId, userId, from, to)
+
+  const result = { ...empty, synced: rows.length }
+  const syncedAt = new Date().toISOString()
+  for (const row of rows) {
+    try {
+      const workDate = normalizeDateOnly(row.work_date) ?? String(row.work_date ?? '').slice(0, 10)
+      const approved = approvedMap.get(workDate) ?? { leaveMinutes: 0, overtimeMinutes: 0, reportSubtypeMinutes: {} }
+      const enrichedRow = {
+        ...row,
+        work_date: workDate,
+        meta: {
+          ...normalizeMetadata(row.meta),
+          leave_minutes: approved.leaveMinutes,
+          overtime_minutes: approved.overtimeMinutes,
+          reportSubtypeMinutes: approved.reportSubtypeMinutes ?? {},
+        },
+      }
+      const exportItem = await buildAttendanceRecordReportExportItemAsync(
+        context,
+        enrichedRow,
+        reportFields.fields,
+        reportFields.formulaSourceFields,
+        formulaOptions,
+      )
+      const rowKey = attendanceReportRecordRowKey(orgId, userId, workDate)
+      const logical = {
+        [ATTENDANCE_REPORT_RECORDS_FIELDS.rowKey]: rowKey,
+        [ATTENDANCE_REPORT_RECORDS_FIELDS.orgId]: orgId,
+        [ATTENDANCE_REPORT_RECORDS_FIELDS.userId]: userId,
+        [ATTENDANCE_REPORT_RECORDS_FIELDS.employeeName]: firstNonEmptyValue(row.user_name, row.username, userId),
+        [ATTENDANCE_REPORT_RECORDS_FIELDS.department]: firstNonEmptyValue(readAttendanceRecordMeta(enrichedRow, ['department', '部门'])),
+        [ATTENDANCE_REPORT_RECORDS_FIELDS.attendanceGroup]: firstNonEmptyValue(readAttendanceRecordMeta(enrichedRow, ['attendanceGroup', 'attendance_group', '考勤组'])),
+        [ATTENDANCE_REPORT_RECORDS_FIELDS.workDate]: workDate,
+      }
+      for (const column of valueColumns) {
+        // active output → value; managed but not active (disabled etc.) → null (stale clear)
+        logical[column.id] = Object.prototype.hasOwnProperty.call(exportItem, column.id)
+          ? exportItem[column.id]
+          : null
+      }
+      const sourceFingerprint = buildAttendanceReportRecordSourceFingerprint(logical)
+
+      const data = {}
+      for (const [logicalId, value] of Object.entries(logical)) {
+        data[physical(logicalId)] = value
+      }
+      data[physical(ATTENDANCE_REPORT_RECORDS_FIELDS.fieldFingerprint)] = fieldFingerprint
+      data[physical(ATTENDANCE_REPORT_RECORDS_FIELDS.sourceFingerprint)] = sourceFingerprint
+      data[physical(ATTENDANCE_REPORT_RECORDS_FIELDS.syncedAt)] = syncedAt
+
+      const existing = await records.queryRecords({
+        sheetId: ensured.sheetId,
+        filters: { [physical(ATTENDANCE_REPORT_RECORDS_FIELDS.rowKey)]: rowKey },
+        limit: 50,
+      })
+      if (!Array.isArray(existing) || existing.length === 0) {
+        await records.createRecord({ sheetId: ensured.sheetId, data })
+        result.created += 1
+        continue
+      }
+      if (existing.length > 1) result.duplicateRowKeys += existing.length - 1
+      const target = existing[0]
+      const existingData = (target && target.data && typeof target.data === 'object') ? target.data : {}
+      const existingSource = existingData[physical(ATTENDANCE_REPORT_RECORDS_FIELDS.sourceFingerprint)]
+      const existingField = existingData[physical(ATTENDANCE_REPORT_RECORDS_FIELDS.fieldFingerprint)]
+      if (existingSource === sourceFingerprint && existingField === fieldFingerprint) {
+        result.skipped += 1
+        continue
+      }
+      await records.patchRecord({ sheetId: ensured.sheetId, recordId: target.id, changes: data })
+      result.patched += 1
+    } catch (error) {
+      result.failed += 1
+      logger?.warn?.('attendance report record sync row failed', {
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
+  return { ...result, fieldFingerprint, syncedAt }
+}
+
 async function loadAttendanceReportFieldCatalog(context, orgId) {
   const projectId = getAttendanceReportFieldProjectId(orgId)
   const multitable = context?.api?.multitable
@@ -9295,6 +9475,11 @@ module.exports = {
     loadAttendanceReportFieldCatalog,
     getAttendanceReportRecordsDescriptor,
     ensureAttendanceReportRecords,
+    syncAttendanceReportRecords,
+    buildAttendanceReportRecordsValueColumns,
+    mapReportFieldToMultitableType,
+    buildAttendanceReportRecordSourceFingerprint,
+    attendanceReportRecordRowKey,
     ATTENDANCE_REPORT_RECORDS_OBJECT_ID,
     ATTENDANCE_REPORT_RECORDS_FIELDS,
     mergeAttendanceReportFieldDefinitions,
@@ -21336,6 +21521,42 @@ module.exports = {
           syncedAt: new Date().toISOString(),
         })
         res.json({ ok: true, data })
+      })
+    )
+
+    context.api.http.addRoute(
+      'POST',
+      '/api/attendance/report-records/sync',
+      withPermission('attendance:admin', async (req, res) => {
+        const orgId = getOrgId(req)
+        const parsed = z.object({
+          from: z.string().min(1),
+          to: z.string().min(1),
+          userId: z.string().min(1),
+        }).safeParse(req.body ?? {})
+        if (!parsed.success) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
+          return
+        }
+        const result = await syncAttendanceReportRecords(context, db, orgId, logger, parsed.data)
+        if (result.degraded) {
+          res.json({ ok: true, data: { degraded: true, reason: result.reason, synced: 0 } })
+          return
+        }
+        emitEvent('attendance.report_records.synced', {
+          orgId,
+          userId: parsed.data.userId,
+          from: parsed.data.from,
+          to: parsed.data.to,
+          synced: result.synced,
+          patched: result.patched,
+          created: result.created,
+          skipped: result.skipped,
+          failed: result.failed,
+          duplicateRowKeys: result.duplicateRowKeys,
+          syncedAt: result.syncedAt,
+        })
+        res.json({ ok: true, data: result })
       })
     )
 


### PR DESCRIPTION
## Summary

**PR2 of the 3-PR attendance report-records sync mainline.** The `POST /api/attendance/report-records/sync` writer — no frontend (PR3).

- **Reuses the existing per-user export build path** (same `attendance_records` SQL + `loadApprovedMinutesRange` subtype-aware + `buildAttendanceRecordReportExportItemAsync` + `buildAttendanceReportFieldConfig` fieldsFingerprint). No aggregation rewrite — single authoritative path.
- **Value columns = stable superset from the full catalog** (incl. disabled), ensured via the same idempotent `ensureObject` upsert (PR1-confirmed `ensureFields` = `INSERT ON CONFLICT DO UPDATE`, never deletes).
- **Per-row upsert** keyed by physical fld-id `row_key` filter: create if absent; **skip only when `source_fingerprint` AND `field_fingerprint` both equal**; else patch full data. Managed-but-inactive value columns written `null` (stale-clear). Multiple `row_key` hits → patch first, count `duplicateRowKeys` (no auto-dedup in v1). Per-row failure → `failed++`, warn, continue. `source_fingerprint` = sha1 of key-sorted payload excluding `synced_at` + both fingerprints (deterministic).
- `userId` required (zod, 400 on missing). Degraded (no multitable / provisioning) → `{ ok:true, data:{ degraded:true, reason, synced:0 } }`; only param errors → 400. Route mirrors `report-fields/sync` (admin POST is the gate; `CONFIRM_SYNC` is ops-script discipline, not the route — todo MD wording refined, no behavior drift).

**Boundary held**: `attendance_*` stays the sole fact source; report-records is a rebuildable snapshot written only via the multitable plugin API; no `meta_*` raw writes; no migration; export / report-fields decoupled.

Full nailed-down plan (2 user review rounds) is in `attendance-report-records-sync-todo-20260515.md` (shipped with PR1 #1604).

## Test plan

- [x] Backend catalog + formula: **30 pass** (15 catalog incl. +2 PR2 tests, 15 formula). Pure helpers: type map / value-columns reserved-skip+order / row key / source-fingerprint determinism+exclusion. Writer: degraded no-throw, **export decoupling** (degraded sync doesn't break export builder), create×2, skip×2 (double-fingerprint), **skip-boundary** (source unchanged + field_fingerprint stale → patch not skip — review-correction-2 regression red line), **duplicate row_key fuse** (patch first + count, no auto-delete), physical fld-id wiring.
- [x] Frontend report fields + admin regression: **17 pass** (no UI change in PR2; regression clean).
- [x] Web type-check (`vue-tsc -b`) + core-backend build (`tsc`) + `git diff --check`: clean.
- [ ] **stale-null negative path** (field active→disabled → column patched null): inline-logic + reasoned guarantee; full unit needs a disabled-field catalog fixture → deferred to PR3 mock acceptance. **Not faked** (documented honestly in verification MD).
- [ ] *(PR3 + staging)* real provision + sync + fingerprint-chain consistency — deferred (P1 follow-up, no creds → not faked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)