### PR TITLE
fix(data-factory): surface validation and project scope feedback

### DIFF
--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -137,10 +137,59 @@ function normalizeApiErrorPayload(body: unknown): ApiErrorPayload {
   if (!body || typeof body !== 'object') return {}
   const record = body as Record<string, unknown>
   const error = record.error
-  if (typeof error === 'string') return { message: error }
-  if (error && typeof error === 'object') return error as ApiErrorPayload
-  if (typeof record.message === 'string') return { message: record.message }
+  if (typeof error === 'string') {
+    return {
+      code: error,
+      message: typeof record.message === 'string' ? record.message : error,
+      fieldErrors: normalizeFieldErrors(record.fieldErrors),
+    }
+  }
+  if (error && typeof error === 'object') {
+    const payload = error as ApiErrorPayload & { fieldErrors?: unknown }
+    return {
+      ...payload,
+      fieldErrors: normalizeFieldErrors(payload.fieldErrors),
+    }
+  }
+  if (typeof record.message === 'string') {
+    return {
+      message: record.message,
+      fieldErrors: normalizeFieldErrors(record.fieldErrors),
+    }
+  }
   return {}
+}
+
+function normalizeFieldErrors(fieldErrors: unknown): Record<string, string> | undefined {
+  if (Array.isArray(fieldErrors)) {
+    const normalized: Record<string, string> = {}
+    fieldErrors.forEach((entry, index) => {
+      if (!entry || typeof entry !== 'object') return
+      const candidate = entry as { fieldId?: unknown; message?: unknown }
+      const fieldId = typeof candidate.fieldId === 'string' && candidate.fieldId.trim()
+        ? candidate.fieldId.trim()
+        : `field_${index + 1}`
+      const message = typeof candidate.message === 'string' && candidate.message.trim()
+        ? candidate.message.trim()
+        : 'Validation failed'
+      normalized[fieldId] = message
+    })
+    return Object.keys(normalized).length > 0 ? normalized : undefined
+  }
+
+  if (fieldErrors && typeof fieldErrors === 'object') {
+    const normalized = Object.fromEntries(
+      Object.entries(fieldErrors as Record<string, unknown>)
+        .filter(([fieldId]) => fieldId.trim().length > 0)
+        .map(([fieldId, message]) => [
+          fieldId,
+          typeof message === 'string' && message.trim() ? message.trim() : 'Validation failed',
+        ]),
+    )
+    return Object.keys(normalized).length > 0 ? normalized : undefined
+  }
+
+  return undefined
 }
 
 function defaultApiErrorMessage(code: string | undefined, status: number): string {

--- a/apps/web/src/views/IntegrationK3WiseSetupView.vue
+++ b/apps/web/src/views/IntegrationK3WiseSetupView.vue
@@ -668,9 +668,20 @@
           <div class="k3-setup__grid">
             <label class="k3-setup__field">
               <span>Project ID（高级，可选）</span>
-              <input v-model.trim="form.projectId" autocomplete="off" data-testid="k3-setup-project-id" placeholder="留空自动使用 tenant:integration-core" />
+              <input
+                :value="form.projectId"
+                autocomplete="off"
+                data-testid="k3-setup-project-id"
+                placeholder="留空自动使用 tenant:integration-core"
+                @input="onK3SetupProjectIdInput"
+                @change="onK3SetupProjectIdInput"
+                @blur="onK3SetupProjectIdInput"
+              />
               <small class="k3-setup__hint" data-testid="k3-setup-project-id-hint">
                 留空时安装会自动使用插件专用作用域 <code>tenant:integration-core</code>；若自定义，结尾必须是 <code>:integration-core</code>，否则会触发 plugin-scope 警告。
+              </small>
+              <small class="k3-setup__hint" data-testid="k3-setup-project-id-scope-status">
+                {{ k3SetupProjectIdScopeStatus }}
               </small>
             </label>
             <div
@@ -966,6 +977,12 @@ const k3SetupProjectIdScopeWarning = computed(() => {
   if (!value || isIntegrationScopedProjectId(value)) return ''
   return `Project ID「${value}」不是 integration 作用域，安装会触发 plugin-scope 警告。留空可自动作用域，或一键规范化为以 :integration-core 结尾。`
 })
+const k3SetupProjectIdScopeStatus = computed(() => {
+  const value = form.projectId.trim()
+  if (!value) return `当前将使用 ${(form.tenantId.trim() || 'default')}:integration-core`
+  if (isIntegrationScopedProjectId(value)) return `当前将使用 ${value}`
+  return `当前为非 integration 作用域：${value}`
+})
 const webApiConnectionStatus = computed(() => {
   if (testingWebApi.value) {
     return {
@@ -1090,6 +1107,11 @@ function normalizeK3SetupProjectIdToScope(): void {
   const normalized = normalizeIntegrationProjectId(form.projectId, form.tenantId || 'default')
   form.projectId = normalized
   setStatus(`Project ID 已规范化为 ${normalized}`, 'info')
+}
+
+function onK3SetupProjectIdInput(event: Event): void {
+  const target = event.target as HTMLInputElement | null
+  form.projectId = target?.value ?? ''
 }
 
 function setStatus(message: string, kind: 'info' | 'success' | 'error' = 'info'): void {

--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -345,7 +345,17 @@
       <div class="integration-workbench__grid integration-workbench__grid--compact">
         <label>
           <span>Project ID（高级，可选）</span>
-          <input v-model="stagingProjectId" data-testid="staging-project-id" placeholder="留空自动使用 tenant:integration-core" />
+          <input
+            :value="stagingProjectId"
+            data-testid="staging-project-id"
+            placeholder="留空自动使用 tenant:integration-core"
+            @input="onStagingProjectIdInput"
+            @change="onStagingProjectIdInput"
+            @blur="onStagingProjectIdInput"
+          />
+          <small class="integration-workbench__staging-note" data-testid="staging-project-id-scope-status">
+            {{ stagingProjectIdScopeStatus }}
+          </small>
         </label>
         <label>
           <span>Base ID（可选）</span>
@@ -1047,6 +1057,18 @@ const stagingProjectIdScopeWarning = computed(() => {
   if (!value || isIntegrationScopedProjectId(value)) return ''
   return `Project ID「${value}」不是 integration 作用域，安装会触发 plugin-scope 警告。留空可自动作用域，或一键规范化为以 :integration-core 结尾。`
 })
+
+const stagingProjectIdScopeStatus = computed(() => {
+  const value = stagingProjectId.value.trim()
+  if (!value) return `当前将使用 ${defaultStagingProjectId()}`
+  if (isIntegrationScopedProjectId(value)) return `当前将使用 ${value}`
+  return `当前为非 integration 作用域：${value}`
+})
+
+function onStagingProjectIdInput(event: Event): void {
+  const target = event.target as HTMLInputElement | null
+  stagingProjectId.value = target?.value ?? ''
+}
 
 function normalizeStagingProjectIdToScope(): void {
   const normalized = normalizeIntegrationProjectId(stagingProjectId.value, currentScope().tenantId)

--- a/apps/web/tests/IntegrationK3WiseSetupView.spec.ts
+++ b/apps/web/tests/IntegrationK3WiseSetupView.spec.ts
@@ -252,22 +252,28 @@ describe('IntegrationK3WiseSetupView', () => {
     await flushUi()
 
     const projectInput = inputByLabel(container, 'Project ID')
+    const scopeStatus = container.querySelector('[data-testid="k3-setup-project-id-scope-status"]') as HTMLElement
     expect(container.querySelector('[data-testid="k3-setup-project-id-scope-warning"]')).toBeNull()
+    expect(scopeStatus.textContent).toContain('default:integration-core')
 
     projectInput.value = 'project_default'
     projectInput.dispatchEvent(new Event('input', { bubbles: true }))
+    projectInput.dispatchEvent(new Event('change', { bubbles: true }))
+    projectInput.dispatchEvent(new Event('blur', { bubbles: true }))
     await flushUi()
 
     const warning = container.querySelector('[data-testid="k3-setup-project-id-scope-warning"]') as HTMLElement | null
     expect(warning).not.toBeNull()
     expect(warning!.textContent).toContain('不是 integration 作用域')
     expect(warning!.textContent).toContain('规范化为 integration 作用域')
+    expect(scopeStatus.textContent).toContain('当前为非 integration 作用域：project_default')
 
     ;(container.querySelector('[data-testid="normalize-k3-setup-project-id"]') as HTMLButtonElement).click()
     await flushUi()
 
     expect(projectInput.value).toBe('project_default:integration-core')
     expect(container.querySelector('[data-testid="k3-setup-project-id-scope-warning"]')).toBeNull()
+    expect(scopeStatus.textContent).toContain('project_default:integration-core')
     expect(container.textContent).toContain('Project ID 已规范化为 project_default:integration-core')
   })
 

--- a/apps/web/tests/IntegrationWorkbenchView.spec.ts
+++ b/apps/web/tests/IntegrationWorkbenchView.spec.ts
@@ -911,26 +911,34 @@ describe('IntegrationWorkbenchView', () => {
     await flushUi()
 
     const projectIdInput = container.querySelector('[data-testid="staging-project-id"]') as HTMLInputElement
+    const scopeStatus = container.querySelector('[data-testid="staging-project-id-scope-status"]') as HTMLElement
     expect(container.querySelector('[data-testid="staging-project-id-scope-warning"]')).toBeNull()
+    expect(scopeStatus.textContent).toContain('default:integration-core')
 
     projectIdInput.value = 'project_default'
-    projectIdInput.dispatchEvent(new Event('input'))
+    projectIdInput.dispatchEvent(new Event('input', { bubbles: true }))
+    projectIdInput.dispatchEvent(new Event('change', { bubbles: true }))
+    projectIdInput.dispatchEvent(new Event('blur', { bubbles: true }))
     await flushUi()
 
     const warning = container.querySelector('[data-testid="staging-project-id-scope-warning"]') as HTMLElement | null
     expect(warning).not.toBeNull()
     expect(warning!.textContent).toContain('不是 integration 作用域')
+    expect(scopeStatus.textContent).toContain('当前为非 integration 作用域：project_default')
 
     ;(container.querySelector('[data-testid="normalize-staging-project-id"]') as HTMLButtonElement).click()
     await flushUi()
 
     expect(projectIdInput.value).toBe('project_default:integration-core')
     expect(container.querySelector('[data-testid="staging-project-id-scope-warning"]')).toBeNull()
+    expect(scopeStatus.textContent).toContain('project_default:integration-core')
     expect(container.textContent).toContain('Project ID 已规范化为 project_default:integration-core')
 
     projectIdInput.value = ''
-    projectIdInput.dispatchEvent(new Event('input'))
+    projectIdInput.dispatchEvent(new Event('input', { bubbles: true }))
+    projectIdInput.dispatchEvent(new Event('change', { bubbles: true }))
     await flushUi()
     expect(container.querySelector('[data-testid="staging-project-id-scope-warning"]')).toBeNull()
+    expect(scopeStatus.textContent).toContain('default:integration-core')
   })
 })

--- a/apps/web/tests/multitable-client.spec.ts
+++ b/apps/web/tests/multitable-client.spec.ts
@@ -556,6 +556,31 @@ describe('MultitableApiClient', () => {
     })
   })
 
+  it('normalizes legacy createRecord validation arrays into field errors', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      error: 'VALIDATION_FAILED',
+      message: 'Record validation failed',
+      fieldErrors: [
+        { fieldId: 'fld_code', message: 'Material Code is required' },
+      ],
+    }), { status: 422 }))
+    const client = new MultitableApiClient({ fetchFn })
+
+    await expect(client.createRecord({
+      sheetId: 'sheet_standard_materials',
+      viewId: 'view_grid',
+      data: {},
+    })).rejects.toMatchObject({
+      name: 'MultitableApiError',
+      status: 422,
+      code: 'VALIDATION_FAILED',
+      message: 'Material Code is required',
+      fieldErrors: {
+        fld_code: 'Material Code is required',
+      },
+    })
+  })
+
   it('loads and normalizes record history entries', async () => {
     const fetchFn = vi.fn().mockResolvedValue(new Response(JSON.stringify({
       ok: true,

--- a/docs/development/data-factory-issue651-validation-projectid-followup-development-20260516.md
+++ b/docs/development/data-factory-issue651-validation-projectid-followup-development-20260516.md
@@ -1,0 +1,66 @@
+# Data Factory Issue 651 Validation + Project ID Follow-up Development
+
+Date: 2026-05-16
+
+## Scope
+
+This slice closes the two remaining Issue #651 checks after Gate A/B, C2, and C4 had already passed on the on-prem box:
+
+- C1: the real `/multitable` entry reaches `+ New Record`, but blank required fields returned `500 Failed to create meta record` instead of a field-level required message.
+- C3: the Data Factory / K3 setup Project ID warning and normalize affordance were not reliably visible after entering a plain project id such as `project_default`.
+
+No migration, integration-core runtime, adapter, or package-build workflow changes are included.
+
+## C1 Design
+
+`RecordService.createRecord()` already runs direct field validation before insert. The weak point was the route/API surface:
+
+- `RecordValidationFailedError` had no code/status metadata.
+- `POST /api/multitable/records` returned the old top-level validation shape for one path and could fall through to the generic 500 path if the class identity did not match in a packaged runtime.
+- The web client expected `error.fieldErrors` as a map, while direct validation produces an array of `{ fieldId, message }` objects.
+
+The fix makes create-record validation match the multitable client contract:
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "Record validation failed",
+    "fieldErrors": {
+      "fld_code": "Material Code is required"
+    }
+  }
+}
+```
+
+Implementation notes:
+
+- `RecordValidationFailedError` now carries `code = VALIDATION_ERROR` and `statusCode = 422`.
+- The route uses a defensive guard that accepts both `instanceof RecordValidationFailedError` and the runtime-safe `{ name: "RecordValidationFailedError", fieldErrors }` shape.
+- Route-level field errors are normalized from array or object into `Record<string, string>`.
+- The frontend multitable API client also accepts the legacy top-level `{ error, message, fieldErrors: [] }` shape so stale servers still produce a useful toast instead of a generic API message.
+
+## C3 Design
+
+The Project ID logic was correct in computed state, but the on-prem rehearsal showed the interaction was not operator-obvious or robust enough.
+
+The fix keeps the same backend rule:
+
+- empty Project ID means `tenant:integration-core`;
+- already-scoped values ending in `:integration-core` or `:plugin-integration-core` pass;
+- plain values are warned and can be normalized with one click.
+
+Frontend changes:
+
+- Data Factory Workbench and K3 setup Project ID inputs now use explicit `input`, `change`, and `blur` handlers.
+- Both pages render a stable scope status line, so operators can see the effective value even before warning state appears.
+- Existing warning + normalize buttons remain, now covered with input/change/blur tests.
+
+## Deployment Impact
+
+- Backend behavior changes only for invalid record-create payloads: `500` becomes `422` with field errors.
+- Valid record creation is unchanged.
+- Frontend-only Project ID changes affect display/input handling only.
+- No database migration required.
+

--- a/docs/development/data-factory-issue651-validation-projectid-followup-verification-20260516.md
+++ b/docs/development/data-factory-issue651-validation-projectid-followup-verification-20260516.md
@@ -1,0 +1,65 @@
+# Data Factory Issue 651 Validation + Project ID Follow-up Verification
+
+Date: 2026-05-16
+
+## Local Verification
+
+All commands were run from `/tmp/ms2-issue651-validation-projectid` on branch `codex/issue651-validation-projectid-20260516`.
+
+| Command | Result |
+| --- | --- |
+| `pnpm --filter @metasheet/web exec vitest run tests/multitable-client.spec.ts tests/IntegrationWorkbenchView.spec.ts tests/IntegrationK3WiseSetupView.spec.ts --watch=false` | PASS: 3 files, 32 tests |
+| `pnpm --filter @metasheet/core-backend exec vitest run tests/integration/field-validation-flow.test.ts tests/unit/record-service.test.ts` | PASS: 2 files, 32 tests |
+| `pnpm --filter @metasheet/web exec vue-tsc --noEmit` | PASS |
+| `pnpm --filter @metasheet/core-backend build` | PASS |
+| `pnpm --filter @metasheet/web build` | PASS |
+| `git diff --check origin/main...HEAD` | PASS |
+
+Notes:
+
+- The frontend Vitest run printed `WebSocket server error: Port is already in use`, but all selected tests passed. This is a local Vitest server-port warning, not a test failure.
+- The production web build printed existing chunk-size and mixed static/dynamic import warnings. Build exit code was 0.
+
+## C1 Acceptance
+
+Regression coverage:
+
+- `field-validation-flow.test.ts` now verifies `POST /api/multitable/records` returns:
+  - HTTP `422`;
+  - `ok: false`;
+  - `error.code: VALIDATION_ERROR`;
+  - `error.fieldErrors.fld_code: Material Code is required`.
+- `multitable-client.spec.ts` verifies the web client surfaces the first field error as the thrown message for create-record failures.
+- A second client test verifies the legacy top-level array field-error shape is normalized into a field-error map.
+
+Expected on-prem behavior:
+
+- From the true `/multitable` entry, clicking `+ New Record` on a staging table with required fields should show the first required-field message, such as `Material Code is required`.
+- The backend should no longer return `500 Failed to create meta record` for direct required-field validation failures.
+
+## C3 Acceptance
+
+Regression coverage:
+
+- `IntegrationWorkbenchView.spec.ts` verifies:
+  - blank Project ID shows the effective `default:integration-core` status;
+  - entering `project_default` through input/change/blur shows the integration-scope warning;
+  - the normalize button changes the value to `project_default:integration-core`;
+  - clearing the field returns to the default scoped status.
+- `IntegrationK3WiseSetupView.spec.ts` verifies the same warning and normalize flow on the K3 setup page.
+
+Expected on-prem behavior:
+
+- Data Factory Workbench and K3 setup page both show a visible Project ID scope status.
+- Plain `project_default` shows a warning and a one-click normalize button.
+- Blank remains valid and resolves to `tenant:integration-core`.
+
+## Package Retest Guidance
+
+After this PR is merged and a new on-prem package is generated, rerun the Issue #651 gate sequence:
+
+1. Gate A: package verify confirms the new web bundle and backend route are included.
+2. Gate B: deployment SOP migration/auth round-trip.
+3. C1: open a real `/multitable` staging link and click `+ New Record`; expect required-field toast instead of `500`.
+4. C3: enter `project_default` in Project ID; expect warning + normalize button.
+

--- a/packages/core-backend/src/multitable/record-service.ts
+++ b/packages/core-backend/src/multitable/record-service.ts
@@ -129,6 +129,9 @@ export class RecordPermissionError extends Error {
 }
 
 export class RecordValidationFailedError extends Error {
+  public readonly code = 'VALIDATION_ERROR'
+  public readonly statusCode = 422
+
   constructor(public fieldErrors: unknown) {
     super('Record validation failed')
     this.name = 'RecordValidationFailedError'

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -1948,6 +1948,43 @@ function getDbNotReadyMessage(err: unknown): string | null {
   return null
 }
 
+function isRecordCreateValidationError(err: unknown): err is { fieldErrors: unknown } {
+  if (err instanceof RecordCreateValidationFailedError) return true
+  if (!err || typeof err !== 'object') return false
+  const candidate = err as { name?: unknown; fieldErrors?: unknown }
+  return candidate.name === 'RecordValidationFailedError' && 'fieldErrors' in candidate
+}
+
+function normalizeRecordCreateFieldErrors(fieldErrors: unknown): Record<string, string> {
+  if (Array.isArray(fieldErrors)) {
+    const normalized: Record<string, string> = {}
+    fieldErrors.forEach((entry, index) => {
+      if (!entry || typeof entry !== 'object') return
+      const error = entry as { fieldId?: unknown; message?: unknown }
+      const fieldId = typeof error.fieldId === 'string' && error.fieldId.trim()
+        ? error.fieldId.trim()
+        : `field_${index + 1}`
+      const message = typeof error.message === 'string' && error.message.trim()
+        ? error.message.trim()
+        : 'Validation failed'
+      normalized[fieldId] = message
+    })
+    return normalized
+  }
+
+  if (fieldErrors && typeof fieldErrors === 'object') {
+    return Object.fromEntries(
+      Object.entries(fieldErrors as Record<string, unknown>)
+        .map(([fieldId, message]) => [
+          fieldId,
+          typeof message === 'string' && message.trim() ? message.trim() : 'Validation failed',
+        ]),
+    )
+  }
+
+  return {}
+}
+
 function invalidateSheetSummaryCache(sheetId: string): void {
   metaSheetSummaryCache.delete(sheetId)
 }
@@ -7421,11 +7458,15 @@ export function univerMetaRouter(): Router {
         },
       })
     } catch (err) {
-      if (err instanceof RecordCreateValidationFailedError) {
+      if (isRecordCreateValidationError(err)) {
+        const fieldErrors = normalizeRecordCreateFieldErrors(err.fieldErrors)
         return res.status(422).json({
-          error: 'VALIDATION_FAILED',
-          message: 'Record validation failed',
-          fieldErrors: err.fieldErrors,
+          ok: false,
+          error: {
+            code: 'VALIDATION_ERROR',
+            message: 'Record validation failed',
+            fieldErrors,
+          },
         })
       }
       if (err instanceof RecordServiceFieldForbiddenError) {

--- a/packages/core-backend/tests/integration/field-validation-flow.test.ts
+++ b/packages/core-backend/tests/integration/field-validation-flow.test.ts
@@ -445,3 +445,41 @@ describe('Field validation — form submit', () => {
     expect(resTooLow.body.fieldErrors[0].rule).toBe('min')
   })
 })
+
+describe('Field validation — direct record create', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.resetModules()
+  })
+
+  test('create with required field missing returns multitable error envelope', async () => {
+    const { app } = await createApp({
+      tokenPerms: ['multitable:read', 'multitable:write'],
+      queryHandler: defaultQueryHandler([
+        {
+          id: 'fld_code',
+          name: 'Material Code',
+          type: 'string',
+          property: { validation: [{ type: 'required', message: 'Material Code is required' }] },
+          order: 1,
+        },
+      ]),
+    })
+
+    const res = await request(app)
+      .post('/api/multitable/records')
+      .send({ sheetId: SHEET_ID, data: {} })
+
+    expect(res.status).toBe(422)
+    expect(res.body).toEqual({
+      ok: false,
+      error: {
+        code: 'VALIDATION_ERROR',
+        message: 'Record validation failed',
+        fieldErrors: {
+          fld_code: 'Material Code is required',
+        },
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Refs #651. This follow-up fixes the two remaining on-prem checks after Gate A/B, C2, and C4 had passed:

- C1: direct `+ New Record` required-field failures now return a 422 multitable error envelope with `error.fieldErrors`, so the web client can show the field-level required toast instead of `500 Failed to create meta record`.
- C3: Data Factory and K3 setup Project ID inputs now have explicit input/change/blur syncing plus visible effective-scope status, warning, and one-click normalize behavior.
- Adds development and verification MDs for the Issue #651 follow-up.

## Verification

- `pnpm --filter @metasheet/web exec vitest run tests/multitable-client.spec.ts tests/IntegrationWorkbenchView.spec.ts tests/IntegrationK3WiseSetupView.spec.ts --watch=false` — PASS, 32 tests
- `pnpm --filter @metasheet/core-backend exec vitest run tests/integration/field-validation-flow.test.ts tests/unit/record-service.test.ts` — PASS, 32 tests
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit` — PASS
- `pnpm --filter @metasheet/core-backend build` — PASS
- `pnpm --filter @metasheet/web build` — PASS
- `git diff --check` — PASS

## Deployment impact

- No migration.
- No integration-core runtime or adapter changes.
- Invalid direct record-create payloads now return 422 with field errors instead of generic 500.
- Valid record creation is unchanged.

## On-prem retest target

After package rebuild/deploy, rerun #651 checks C1 and C3:

- C1: true `/multitable` entry -> `+ New Record` should show required-field toast.
- C3: entering `project_default` should show scope warning and normalize button; blank should show default `tenant:integration-core` status.