### PR TITLE
fix(multitable): repair on-prem record create schema gap

### DIFF
--- a/docs/development/data-factory-issue651-c1-record-create-repair-development-20260516.md
+++ b/docs/development/data-factory-issue651-c1-record-create-repair-development-20260516.md
@@ -1,0 +1,84 @@
+# Data Factory Issue 651 C1 Record Create Repair - Development Notes
+
+Date: 2026-05-16
+
+## Context
+
+Run29 confirmed the Data Factory and K3 setup frontend package was updated: Gate A/B, C2, and C4 passed, and C3 started showing the effective `default:integration-core` scope. C1 still failed on the physical on-prem box:
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "INTERNAL_ERROR",
+    "message": "Failed to create meta record"
+  }
+}
+```
+
+The observed path is the real staging multitable route:
+
+1. Data Factory staging card creates or resolves open links.
+2. Operator opens the generated `/multitable/<sheetId>/<viewId>?baseId=...` route.
+3. `+ New Record` calls `POST /api/multitable/records`.
+4. Empty record creation should stop at field validation and show a required-field toast.
+
+## Root-Cause Model
+
+The code path already converts `RecordValidationFailedError` into HTTP 422. If the physical box still returns generic 500, the likely failure is earlier/later than that exact error type:
+
+- older on-prem staging fields may exist without `property.validation`, so empty creates do not stop at required-field validation;
+- then record creation reaches schema dependencies such as `meta_record_revisions`;
+- if upgraded databases have a schema gap or a missing record-history table, that failure is currently classified as a generic 500 because `getDbNotReadyMessage()` did not recognize `meta_record_revisions`.
+
+## Changes
+
+### 1. On-Prem Repair Migration
+
+Added `zzzz20260516113000_repair_onprem_multitable_record_create.ts`.
+
+It is intentionally idempotent and additive:
+
+- `ALTER TABLE meta_records ADD COLUMN IF NOT EXISTS created_by`;
+- `ALTER TABLE meta_records ADD COLUMN IF NOT EXISTS modified_by`;
+- `CREATE TABLE IF NOT EXISTS meta_record_revisions`;
+- recreates the related revision indexes with `IF NOT EXISTS`;
+- backfills `property.validation=[{ "type": "required" }]` onto existing `plugin-integration-core` staging fields by object and field name.
+
+This makes the deployed database self-heal during migration instead of relying on operators to reinstall staging tables manually.
+
+### 2. DB-Not-Ready Classification
+
+`getDbNotReadyMessage()` now recognizes:
+
+- `meta_record_revisions`;
+- `meta_record_subscriptions`;
+- `meta_record_subscription_notifications`;
+- `plugin_multitable_object_registry`.
+
+If a future upgraded box still has a missing multitable dependency, the API returns `503 DB_NOT_READY` instead of a misleading `500 INTERNAL_ERROR`.
+
+### 3. Tests
+
+Added a migration structure unit test and extended direct record-create integration coverage:
+
+- required-field create still returns the multitable 422 envelope;
+- missing `meta_record_revisions` now maps to `503 DB_NOT_READY`.
+
+## Deployment Impact
+
+This is backend, migration, and package-verifier only. It does not touch
+integration-core runtime code, frontend routes, or K3 WebAPI behavior.
+
+`scripts/ops/multitable-onprem-package-verify.sh` now requires the built package
+to include `zzzz20260516113000_repair_onprem_multitable_record_create.js` and
+checks that the packaged migration contains both the record-history repair and
+the integration staging validation repair. That turns a stale on-prem package
+into a Gate A failure before it reaches the physical box.
+
+Expected on-prem effect after deploying a rebuilt package:
+
+- migrations run the repair automatically;
+- old staging fields gain required validation;
+- `+ New Record` on Standard Materials should return field-level validation instead of inserting a blank row or falling through to record-history schema errors;
+- if the DB has a deeper missing multitable dependency, the response becomes `DB_NOT_READY` and points to migrations instead of hiding behind the generic create-record failure.

--- a/docs/development/data-factory-issue651-c1-record-create-repair-verification-20260516.md
+++ b/docs/development/data-factory-issue651-c1-record-create-repair-verification-20260516.md
@@ -1,0 +1,178 @@
+# Data Factory Issue 651 C1 Record Create Repair - Verification
+
+Date: 2026-05-16
+
+## Local Verification
+
+### Migration Structure
+
+Command:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/onprem-multitable-record-create-repair-migration.test.ts --watch=false
+```
+
+Result:
+
+```text
+2/2 tests passed
+```
+
+Coverage:
+
+- repair migration adds `created_by` and `modified_by` idempotently;
+- repair migration creates `meta_record_revisions` idempotently;
+- repair migration targets `plugin_multitable_object_registry`;
+- repair migration backfills required validation for `standard_materials` and `bom_cleanse` required fields.
+
+### Record Create Error Mapping
+
+Command:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/integration/field-validation-flow.test.ts --watch=false
+```
+
+Result:
+
+```text
+15/15 tests passed
+```
+
+Coverage:
+
+- direct record create with missing required field returns:
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "Record validation failed",
+    "fieldErrors": {
+      "fld_code": "Material Code is required"
+    }
+  }
+}
+```
+
+- direct record create with missing `meta_record_revisions` returns:
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "DB_NOT_READY",
+    "message": "Database schema not ready ..."
+  }
+}
+```
+
+### Backend Build
+
+Command:
+
+```bash
+pnpm --filter @metasheet/core-backend build
+```
+
+Result:
+
+```text
+exit 0
+```
+
+### Package Verifier Syntax
+
+Command:
+
+```bash
+bash -n scripts/ops/multitable-onprem-package-verify.sh
+```
+
+Result:
+
+```text
+exit 0
+```
+
+Coverage:
+
+- package verification requires the built repair migration at
+  `packages/core-backend/dist/src/db/migrations/zzzz20260516113000_repair_onprem_multitable_record_create.js`;
+- package verification checks the migration body for `meta_record_revisions`
+  and `plugin_multitable_object_registry` so a stale package fails before
+  on-prem deployment.
+
+### Local On-Prem Package Smoke
+
+Command:
+
+```bash
+PACKAGE_TAG=issue651-c1-repair-local BUILD_WEB=1 BUILD_BACKEND=0 INSTALL_DEPS=0 \
+  scripts/ops/multitable-onprem-package-build.sh
+```
+
+Result:
+
+```text
+exit 0
+```
+
+Then:
+
+```bash
+scripts/ops/multitable-onprem-package-verify.sh \
+  output/releases/multitable-onprem/metasheet-multitable-onprem-v2.5.0-issue651-c1-repair-local.zip
+
+scripts/ops/multitable-onprem-package-verify.sh \
+  output/releases/multitable-onprem/metasheet-multitable-onprem-v2.5.0-issue651-c1-repair-local.tgz
+```
+
+Result:
+
+```text
+Package verify OK
+Package verify OK
+```
+
+The local package smoke proves the new package verifier requirement resolves
+against the built backend migration output and passes for both Windows zip and
+Linux tgz artifacts.
+
+### Diff Check
+
+Command:
+
+```bash
+git diff --check
+```
+
+Result:
+
+```text
+exit 0
+```
+
+## Physical Box Retest Plan
+
+After this PR is merged and a new Windows on-prem package is built:
+
+1. Deploy the new package.
+2. Confirm deploy migrations complete.
+3. Open `/integrations/workbench`.
+4. Click staging card `生成打开链接` if needed.
+5. Open `Standard Materials` via `打开多维表（新建记录入口）`.
+6. Click `+ New Record`.
+
+Expected C1 result:
+
+- no generic `500 INTERNAL_ERROR / Failed to create meta record`;
+- either field-level required toast such as `Material Code is required`, or if the DB has a deeper schema gap, a `DB_NOT_READY` response that identifies migration readiness instead of masking the failure.
+
+## Gate Status
+
+- Gate A/B: unchanged, expected to remain PASS.
+- C2/C4: unchanged, expected to remain PASS.
+- C3: unchanged in this PR; run29 already showed effective scope text.
+- C1: primary target of this PR.

--- a/packages/core-backend/src/db/migrations/zzzz20260516113000_repair_onprem_multitable_record_create.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260516113000_repair_onprem_multitable_record_create.ts
@@ -1,0 +1,113 @@
+import { sql, type Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`CREATE EXTENSION IF NOT EXISTS pgcrypto`.execute(db)
+
+  await sql`
+    ALTER TABLE meta_records
+    ADD COLUMN IF NOT EXISTS created_by text
+  `.execute(db)
+
+  await sql`
+    ALTER TABLE meta_records
+    ADD COLUMN IF NOT EXISTS modified_by text
+  `.execute(db)
+
+  await sql`
+    UPDATE meta_records
+    SET modified_by = created_by
+    WHERE modified_by IS NULL AND created_by IS NOT NULL
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_meta_records_created_by
+    ON meta_records(sheet_id, created_by)
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_meta_records_modified_by
+    ON meta_records(modified_by)
+  `.execute(db)
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS meta_record_revisions (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      sheet_id text NOT NULL,
+      record_id text NOT NULL,
+      version integer NOT NULL,
+      action text NOT NULL CHECK (action IN ('create', 'update', 'delete')),
+      source text NOT NULL DEFAULT 'rest',
+      actor_id text,
+      changed_field_ids text[] NOT NULL DEFAULT ARRAY[]::text[],
+      patch jsonb NOT NULL DEFAULT '{}'::jsonb,
+      snapshot jsonb,
+      created_at timestamptz NOT NULL DEFAULT now()
+    )
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_meta_record_revisions_sheet_record_version
+    ON meta_record_revisions(sheet_id, record_id, version DESC)
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_meta_record_revisions_record_created_at
+    ON meta_record_revisions(record_id, created_at DESC)
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_meta_record_revisions_actor_created_at
+    ON meta_record_revisions(actor_id, created_at DESC)
+  `.execute(db)
+
+  await sql`
+    CREATE OR REPLACE FUNCTION __metasheet_add_required_field_validation(input jsonb)
+    RETURNS jsonb
+    LANGUAGE plpgsql
+    AS $$
+    DECLARE
+      prop jsonb := CASE WHEN jsonb_typeof(input) = 'object' THEN input ELSE '{}'::jsonb END;
+      rules jsonb := CASE WHEN jsonb_typeof(prop->'validation') = 'array' THEN prop->'validation' ELSE '[]'::jsonb END;
+    BEGIN
+      IF EXISTS (
+        SELECT 1
+        FROM jsonb_array_elements(rules) AS rule
+        WHERE rule->>'type' = 'required'
+      ) THEN
+        RETURN jsonb_set(prop, '{validation}', rules, true);
+      END IF;
+
+      RETURN jsonb_set(prop, '{validation}', rules || '[{"type":"required"}]'::jsonb, true);
+    END
+    $$;
+  `.execute(db)
+
+  await sql`
+    DO $$
+    BEGIN
+      IF to_regclass('public.meta_fields') IS NOT NULL
+        AND to_regclass('public.plugin_multitable_object_registry') IS NOT NULL
+      THEN
+        UPDATE meta_fields AS f
+        SET property = __metasheet_add_required_field_validation(f.property)
+        FROM plugin_multitable_object_registry AS r
+        WHERE f.sheet_id = r.sheet_id
+          AND r.plugin_name = 'plugin-integration-core'
+          AND (
+            (r.object_id = 'plm_raw_items' AND f.name IN ('Source System', 'Object Type', 'Source ID'))
+            OR (r.object_id = 'standard_materials' AND f.name IN ('Material Code', 'Material Name', 'Status'))
+            OR (r.object_id = 'bom_cleanse' AND f.name IN ('Parent Code', 'Child Code', 'Quantity', 'Status'))
+            OR (r.object_id = 'integration_exceptions' AND f.name IN ('Pipeline ID', 'Run ID', 'Error Code', 'Error Message', 'Status'))
+            OR (r.object_id = 'integration_run_log' AND f.name IN ('Pipeline ID', 'Run ID', 'Mode', 'Triggered By', 'Status'))
+          );
+      END IF;
+    END
+    $$;
+  `.execute(db)
+
+  await sql`DROP FUNCTION IF EXISTS __metasheet_add_required_field_validation(jsonb)`.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP FUNCTION IF EXISTS __metasheet_add_required_field_validation(jsonb)`.execute(db)
+}

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -1938,8 +1938,12 @@ function getDbNotReadyMessage(err: unknown): string | null {
     msg.includes('meta_sheets') ||
     msg.includes('meta_fields') ||
     msg.includes('meta_records') ||
+    msg.includes('meta_record_revisions') ||
+    msg.includes('meta_record_subscriptions') ||
+    msg.includes('meta_record_subscription_notifications') ||
     msg.includes('meta_views') ||
     msg.includes('meta_links') ||
+    msg.includes('plugin_multitable_object_registry') ||
     msg.includes('base_id')
   ) {
     return 'Database schema not ready (meta tables missing). Run `pnpm --filter @metasheet/core-backend migrate` and ensure `DATABASE_URL` points to the dev DB.'

--- a/packages/core-backend/tests/integration/field-validation-flow.test.ts
+++ b/packages/core-backend/tests/integration/field-validation-flow.test.ts
@@ -482,4 +482,33 @@ describe('Field validation — direct record create', () => {
       },
     })
   })
+
+  test('create maps missing record revision schema to DB_NOT_READY instead of generic 500', async () => {
+    const { app } = await createApp({
+      tokenPerms: ['multitable:read', 'multitable:write'],
+      queryHandler: async (sql, params) => {
+        if (sql.includes('INSERT INTO meta_record_revisions')) {
+          const err = new Error('relation "meta_record_revisions" does not exist') as Error & { code?: string }
+          err.code = '42P01'
+          throw err
+        }
+        return defaultQueryHandler([
+          { id: 'fld_title', name: 'Title', type: 'string', property: {}, order: 1 },
+        ])(sql, params)
+      },
+    })
+
+    const res = await request(app)
+      .post('/api/multitable/records')
+      .send({ sheetId: SHEET_ID, data: {} })
+
+    expect(res.status).toBe(503)
+    expect(res.body).toEqual({
+      ok: false,
+      error: {
+        code: 'DB_NOT_READY',
+        message: expect.stringContaining('Database schema not ready'),
+      },
+    })
+  })
 })

--- a/packages/core-backend/tests/unit/onprem-multitable-record-create-repair-migration.test.ts
+++ b/packages/core-backend/tests/unit/onprem-multitable-record-create-repair-migration.test.ts
@@ -1,0 +1,34 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+const migrationPath = path.resolve(
+  __dirname,
+  '../../src/db/migrations/zzzz20260516113000_repair_onprem_multitable_record_create.ts',
+)
+
+describe('on-prem multitable record-create repair migration', () => {
+  it('repairs record-create schema dependencies idempotently', async () => {
+    const source = await readFile(migrationPath, 'utf8')
+
+    expect(source).toContain('ADD COLUMN IF NOT EXISTS created_by')
+    expect(source).toContain('ADD COLUMN IF NOT EXISTS modified_by')
+    expect(source).toContain('CREATE TABLE IF NOT EXISTS meta_record_revisions')
+    expect(source).toContain('CREATE INDEX IF NOT EXISTS idx_meta_record_revisions_sheet_record_version')
+  })
+
+  it('backfills required validation for existing integration staging fields', async () => {
+    const source = await readFile(migrationPath, 'utf8')
+
+    expect(source).toContain('plugin_multitable_object_registry')
+    expect(source).toContain("to_regclass('public.plugin_multitable_object_registry')")
+    expect(source).toContain("r.plugin_name = 'plugin-integration-core'")
+    expect(source).toContain("r.object_id = 'standard_materials'")
+    expect(source).toContain("'Material Code', 'Material Name', 'Status'")
+    expect(source).toContain("r.object_id = 'bom_cleanse'")
+    expect(source).toContain("'Parent Code', 'Child Code', 'Quantity', 'Status'")
+    expect(source).toContain('__metasheet_add_required_field_validation')
+    expect(source).toContain("rule->>'type' = 'required'")
+  })
+})

--- a/scripts/ops/multitable-onprem-package-verify.sh
+++ b/scripts/ops/multitable-onprem-package-verify.sh
@@ -77,6 +77,7 @@ function verify_migration_bridge_contract() {
   local provider="${root}/packages/core-backend/dist/src/db/migration-provider.js"
   local legacy_must_change="${root}/packages/core-backend/migrations/056_add_users_must_change_password.sql"
   local timestamp_must_change="${root}/packages/core-backend/dist/src/db/migrations/zzzz20260512100000_add_users_must_change_password.js"
+  local onprem_record_create_repair="${root}/packages/core-backend/dist/src/db/migrations/zzzz20260516113000_repair_onprem_multitable_record_create.js"
 
   search_fixed_string 'MIGRATION_INCLUDE_SUPERSEDED_LEGACY_SQL' "$provider" || die "migration-provider.js must expose the superseded legacy SQL opt-in"
   search_fixed_string '032_create_approval_records' "$provider" || die "migration-provider.js must carry the superseded legacy SQL skip list"
@@ -84,6 +85,8 @@ function verify_migration_bridge_contract() {
   search_fixed_string '038_config_and_secrets' "$provider" || die "migration-provider.js must no-op superseded config/secrets SQL on upgraded on-prem DBs"
   search_fixed_string "to_regclass('public.users') IS NOT NULL" "$legacy_must_change" || die "056_add_users_must_change_password.sql must no-op when users table is absent"
   search_fixed_string 'must_change_password' "$timestamp_must_change" || die "timestamp users must_change_password bridge migration must be packaged"
+  search_fixed_string 'meta_record_revisions' "$onprem_record_create_repair" || die "on-prem record-create repair migration must create meta_record_revisions"
+  search_fixed_string 'plugin_multitable_object_registry' "$onprem_record_create_repair" || die "on-prem record-create repair migration must repair integration staging field validation"
 }
 
 function verify_generic_integration_workbench_contract() {
@@ -349,6 +352,7 @@ required=(
   "packages/core-backend/dist/src/db/migrate.js"
   "packages/core-backend/dist/src/db/migration-provider.js"
   "packages/core-backend/dist/src/db/migrations/zzzz20260512100000_add_users_must_change_password.js"
+  "packages/core-backend/dist/src/db/migrations/zzzz20260516113000_repair_onprem_multitable_record_create.js"
   "packages/core-backend/package.json"
   "packages/core-backend/migrations/056_add_users_must_change_password.sql"
   "packages/core-backend/migrations/057_create_integration_core_tables.sql"


### PR DESCRIPTION
## Summary

Fixes the remaining #651 C1 failure path where `+ New Record` on the staging multitable returned `500 INTERNAL_ERROR / Failed to create meta record` instead of surfacing required-field validation.

- adds an idempotent on-prem repair migration for `meta_records.created_by`, `meta_records.modified_by`, `meta_record_revisions`, and existing plugin-integration-core staging required-field validation
- maps missing multitable dependencies such as `meta_record_revisions` to `503 DB_NOT_READY` instead of generic 500
- extends package verification so stale on-prem packages fail Gate A if the repair migration is missing
- adds development and verification MD for the run29 diagnosis and retest path

## Verification

- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/onprem-multitable-record-create-repair-migration.test.ts --watch=false` — 2/2 pass
- `pnpm --filter @metasheet/core-backend exec vitest run tests/integration/field-validation-flow.test.ts --watch=false` — 15/15 pass
- `pnpm --filter @metasheet/core-backend build` — pass
- `bash -n scripts/ops/multitable-onprem-package-verify.sh` — pass
- `PACKAGE_TAG=issue651-c1-repair-local BUILD_WEB=1 BUILD_BACKEND=0 INSTALL_DEPS=0 scripts/ops/multitable-onprem-package-build.sh` — pass
- `scripts/ops/multitable-onprem-package-verify.sh output/releases/multitable-onprem/metasheet-multitable-onprem-v2.5.0-issue651-c1-repair-local.zip` — Package verify OK
- `scripts/ops/multitable-onprem-package-verify.sh output/releases/multitable-onprem/metasheet-multitable-onprem-v2.5.0-issue651-c1-repair-local.tgz` — Package verify OK
- `git diff --check` — pass

## Deployment / retest

After merge, rebuild the Windows on-prem package and deploy to the physical box. C1 should no longer show generic 500: expected result is either field-level required validation toast, or `DB_NOT_READY` if a deeper schema dependency is still missing. Gate A/B and C2/C4 should remain unchanged; C3 is not touched by this PR.