### PR TITLE
feat(attendance): add report-records sync UI

### DIFF
--- a/apps/web/src/views/attendance/AttendanceReportFieldsSection.vue
+++ b/apps/web/src/views/attendance/AttendanceReportFieldsSection.vue
@@ -173,6 +173,98 @@
       </dl>
     </div>
 
+    <div
+      class="attendance-report-fields__basis attendance-report-fields__record-sync"
+      data-report-record-sync-panel
+    >
+      <div class="attendance-report-fields__basis-header">
+        <div>
+          <div class="attendance-report-fields__basis-title">
+            {{ tr('Report records sync', '报表记录同步') }}
+          </div>
+        </div>
+        <a
+          v-if="reportRecordsMultitableHref"
+          class="attendance__btn"
+          :href="reportRecordsMultitableHref"
+          target="_blank"
+          rel="noreferrer"
+          data-report-record-open-multitable
+        >
+          {{ tr('Open report records', '打开报表多维表') }}
+        </a>
+      </div>
+      <div class="attendance-report-fields__record-sync-form">
+        <label class="attendance-report-fields__filter" for="attendance-report-record-sync-from">
+          <span>{{ tr('From date', '开始日期') }}</span>
+          <input
+            id="attendance-report-record-sync-from"
+            v-model="recordSyncFrom"
+            type="date"
+            data-report-record-sync-from
+          >
+        </label>
+        <label class="attendance-report-fields__filter" for="attendance-report-record-sync-to">
+          <span>{{ tr('To date', '结束日期') }}</span>
+          <input
+            id="attendance-report-record-sync-to"
+            v-model="recordSyncTo"
+            type="date"
+            data-report-record-sync-to
+          >
+        </label>
+        <label class="attendance-report-fields__filter" for="attendance-report-record-sync-user">
+          <span>{{ tr('User ID', '员工 ID') }}</span>
+          <input
+            id="attendance-report-record-sync-user"
+            v-model="recordSyncUserId"
+            type="text"
+            :placeholder="tr('Required in v1', 'v1 必填')"
+            data-report-record-sync-user
+          >
+        </label>
+        <button
+          class="attendance__btn"
+          type="button"
+          :disabled="recordSyncing || !canSyncReportRecords"
+          data-report-record-sync-button
+          @click="syncReportRecords"
+        >
+          {{ recordSyncing ? tr('Syncing...', '同步中...') : tr('Sync report records', '同步报表记录') }}
+        </button>
+      </div>
+      <div
+        v-if="recordSyncStatusMessage"
+        class="attendance__status"
+        :class="{
+          'attendance__status--error': recordSyncStatusKind === 'error',
+          'attendance__status--warn': recordSyncStatusKind === 'warn',
+        }"
+        role="status"
+        data-report-record-sync-status
+      >
+        {{ recordSyncStatusMessage }}
+      </div>
+      <dl
+        v-if="reportRecordSyncDetailRows.length > 0"
+        class="attendance-report-fields__basis-details"
+        data-report-record-sync-details
+      >
+        <div
+          v-for="row in reportRecordSyncDetailRows"
+          :key="row.key"
+          class="attendance-report-fields__basis-detail"
+          :data-report-record-sync-detail="row.key"
+        >
+          <dt>{{ row.label }}</dt>
+          <dd>
+            <code v-if="row.monospace">{{ row.value }}</code>
+            <span v-else>{{ row.value }}</span>
+          </dd>
+        </div>
+      </dl>
+    </div>
+
     <div v-if="reportFields.length > 0 && filteredReportFields.length === 0" class="attendance__empty">
       {{ tr('No report fields match the current filters.', '当前筛选条件下没有匹配的统计字段。') }}
     </div>
@@ -351,6 +443,28 @@ interface MultitableDetailRow {
   monospace?: boolean
 }
 
+interface AttendanceReportRecordsSyncResult {
+  degraded?: boolean
+  reason?: string | null
+  synced?: number
+  patched?: number
+  created?: number
+  skipped?: number
+  failed?: number
+  duplicateRowKeys?: number
+  fieldFingerprint?: string
+  syncedAt?: string
+  multitable?: {
+    available?: boolean
+    degraded?: boolean
+    projectId?: string
+    objectId?: string | null
+    baseId?: string | null
+    sheetId?: string | null
+    viewId?: string | null
+  }
+}
+
 interface FieldMappingRow {
   key: string
   label: string
@@ -369,6 +483,13 @@ const syncing = ref(false)
 const loadError = ref('')
 const syncStatusMessage = ref('')
 const syncStatusKind = ref<'info' | 'error'>('info')
+const recordSyncing = ref(false)
+const recordSyncStatusMessage = ref('')
+const recordSyncStatusKind = ref<'info' | 'warn' | 'error'>('info')
+const recordSyncFrom = ref(dateInputValue(-30))
+const recordSyncTo = ref(dateInputValue(0))
+const recordSyncUserId = ref('')
+const reportRecordsSyncResult = ref<AttendanceReportRecordsSyncResult | null>(null)
 const fieldSearchTerm = ref('')
 const fieldStatusFilter = ref<ReportFieldStatusFilter>('all')
 const fieldCategoryFilter = ref('all')
@@ -493,6 +614,45 @@ const multitableDetailRows = computed<MultitableDetailRow[]>(() => {
   addId('reason', tr('Reason', '原因'), multitable.reason)
   const error = String(multitable.error ?? '').trim()
   if (error) rows.push({ key: 'error', label: tr('Error', '错误'), value: error })
+  return rows
+})
+const canSyncReportRecords = computed(() => (
+  recordSyncFrom.value.trim() !== ''
+  && recordSyncTo.value.trim() !== ''
+  && recordSyncUserId.value.trim() !== ''
+))
+const reportRecordsMultitableHref = computed(() => {
+  const multitable = reportRecordsSyncResult.value?.multitable
+  if (!multitable?.sheetId || !multitable.viewId) return ''
+  const params = new URLSearchParams()
+  if (multitable.baseId) params.set('baseId', multitable.baseId)
+  const suffix = params.toString()
+  return `/multitable/${encodeURIComponent(multitable.sheetId)}/${encodeURIComponent(multitable.viewId)}${suffix ? `?${suffix}` : ''}`
+})
+const reportRecordSyncDetailRows = computed<MultitableDetailRow[]>(() => {
+  const result = reportRecordsSyncResult.value
+  if (!result) return []
+  const rows: MultitableDetailRow[] = []
+  const addNumber = (key: string, label: string, value?: number) => {
+    if (Number.isFinite(value)) rows.push({ key, label, value: String(value) })
+  }
+  const addText = (key: string, label: string, value?: string | null, monospace = false) => {
+    const normalized = String(value ?? '').trim()
+    if (normalized) rows.push({ key, label, value: normalized, monospace })
+  }
+  addNumber('synced', tr('Rows read', '读取行数'), result.synced)
+  addNumber('created', tr('Created', '新建'), result.created)
+  addNumber('patched', tr('Patched', '更新'), result.patched)
+  addNumber('skipped', tr('Skipped', '跳过'), result.skipped)
+  addNumber('failed', tr('Failed', '失败'), result.failed)
+  addNumber('duplicateRowKeys', tr('Duplicate row keys', '重复行键'), result.duplicateRowKeys)
+  addText('fieldFingerprint', tr('Field fingerprint', '字段指纹'), result.fieldFingerprint, true)
+  addText('syncedAt', tr('Synced at', '同步时间'), result.syncedAt)
+  addText('projectId', tr('Project ID', '项目 ID'), result.multitable?.projectId, true)
+  addText('objectId', tr('Object ID', '对象 ID'), result.multitable?.objectId, true)
+  addText('sheetId', tr('Sheet ID', '表格 ID'), result.multitable?.sheetId, true)
+  addText('viewId', tr('View ID', '视图 ID'), result.multitable?.viewId, true)
+  addText('reason', tr('Reason', '原因'), result.reason)
   return rows
 })
 
@@ -677,6 +837,34 @@ function buildSyncStatusMessage(data: AttendanceReportFieldsPayload): string {
   return `${tr('Report field catalog synchronized.', '统计字段目录已同步。')}${summary}`
 }
 
+function dateInputValue(offsetDays: number): string {
+  const date = new Date()
+  date.setDate(date.getDate() + offsetDays)
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+function buildReportRecordsSyncStatusMessage(data: AttendanceReportRecordsSyncResult): string {
+  if (data.degraded) {
+    const reason = String(data.reason ?? '').trim()
+    return reason
+      ? `${tr('Report records sync degraded.', '报表记录同步已降级。')} ${reason}`
+      : tr('Report records sync degraded.', '报表记录同步已降级。')
+  }
+  const details = [
+    syncStatusMetric('Rows', '行数', data.synced),
+    syncStatusMetric('Created', '新建', data.created),
+    syncStatusMetric('Patched', '更新', data.patched),
+    syncStatusMetric('Skipped', '跳过', data.skipped),
+    syncStatusMetric('Failed', '失败', data.failed),
+    syncStatusMetric('Duplicate row keys', '重复行键', data.duplicateRowKeys),
+  ].filter(Boolean)
+  const summary = details.length > 0 ? ` ${details.join(' · ')}` : ''
+  return `${tr('Report records synchronized.', '报表记录已同步。')}${summary}`
+}
+
 async function loadReportFields(): Promise<void> {
   loading.value = true
   loadError.value = ''
@@ -722,6 +910,41 @@ async function syncReportFields(): Promise<void> {
     syncStatusMessage.value = readErrorMessage(error, tr('Failed to sync report fields', '同步统计字段失败'))
   } finally {
     syncing.value = false
+  }
+}
+
+async function syncReportRecords(): Promise<void> {
+  if (!canSyncReportRecords.value) return
+  recordSyncing.value = true
+  recordSyncStatusMessage.value = ''
+  recordSyncStatusKind.value = 'info'
+  try {
+    const params = new URLSearchParams()
+    const orgId = props.orgId?.trim()
+    if (orgId) params.set('orgId', orgId)
+    const suffix = params.toString()
+    const response = await apiFetch(`/api/attendance/report-records/sync${suffix ? `?${suffix}` : ''}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        from: recordSyncFrom.value.trim(),
+        to: recordSyncTo.value.trim(),
+        userId: recordSyncUserId.value.trim(),
+      }),
+    })
+    const payload = await response.json()
+    if (!response.ok || payload?.ok === false) {
+      throw payload
+    }
+    const data = payload?.data ?? {}
+    reportRecordsSyncResult.value = data
+    recordSyncStatusKind.value = data.degraded ? 'warn' : 'info'
+    recordSyncStatusMessage.value = buildReportRecordsSyncStatusMessage(data)
+  } catch (error) {
+    recordSyncStatusKind.value = 'error'
+    recordSyncStatusMessage.value = readErrorMessage(error, tr('Failed to sync report records', '同步报表记录失败'))
+  } finally {
+    recordSyncing.value = false
   }
 }
 
@@ -930,6 +1153,21 @@ watch(
 
 .attendance-report-fields__basis-detail code {
   font-size: 12px;
+}
+
+.attendance-report-fields__record-sync {
+  gap: 12px;
+}
+
+.attendance-report-fields__record-sync-form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: end;
+}
+
+.attendance-report-fields__record-sync-form .attendance-report-fields__filter {
+  flex: 1 1 180px;
 }
 
 .attendance-report-fields__category {

--- a/apps/web/tests/AttendanceReportFieldsSection.spec.ts
+++ b/apps/web/tests/AttendanceReportFieldsSection.spec.ts
@@ -360,4 +360,109 @@ describe('AttendanceReportFieldsSection', () => {
     const codes = Array.from(container!.querySelectorAll('code')).map(node => node.textContent)
     expect(codes).toEqual(expect.arrayContaining(['leave_type_annual_duration', 'overtime_rule_ota_duration']))
   })
+
+  it('syncs report records into the multitable object and shows the fingerprint chain', async () => {
+    vi.mocked(apiFetch)
+      .mockResolvedValueOnce(jsonResponse(200, populatedCatalogPayload()))
+      .mockResolvedValueOnce(jsonResponse(200, {
+        ok: true,
+        data: {
+          synced: 2,
+          created: 1,
+          patched: 1,
+          skipped: 0,
+          failed: 0,
+          duplicateRowKeys: 0,
+          fieldFingerprint: 'rr-field-fingerprint',
+          syncedAt: '2026-05-16T12:00:00.000Z',
+          multitable: {
+            available: true,
+            degraded: false,
+            projectId: 'org-1:attendance',
+            objectId: 'attendance_report_records',
+            baseId: 'base-rr',
+            sheetId: 'sheet-rr',
+            viewId: 'view-rr',
+          },
+        },
+      }))
+
+    mountSection()
+    await flushUi()
+
+    const fromInput = container!.querySelector<HTMLInputElement>('[data-report-record-sync-from]')
+    const toInput = container!.querySelector<HTMLInputElement>('[data-report-record-sync-to]')
+    const userInput = container!.querySelector<HTMLInputElement>('[data-report-record-sync-user]')
+    const syncButton = container!.querySelector<HTMLButtonElement>('[data-report-record-sync-button]')
+    expect(fromInput).toBeTruthy()
+    expect(toInput).toBeTruthy()
+    expect(userInput).toBeTruthy()
+    expect(syncButton).toBeTruthy()
+    expect(syncButton!.disabled).toBe(true)
+
+    fromInput!.value = '2026-05-01'
+    fromInput!.dispatchEvent(new Event('input', { bubbles: true }))
+    toInput!.value = '2026-05-31'
+    toInput!.dispatchEvent(new Event('input', { bubbles: true }))
+    userInput!.value = 'u-1'
+    userInput!.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+    expect(syncButton!.disabled).toBe(false)
+
+    syncButton!.click()
+    await flushUi()
+
+    expect(apiFetch).toHaveBeenCalledWith('/api/attendance/report-records/sync?orgId=org-1', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ from: '2026-05-01', to: '2026-05-31', userId: 'u-1' }),
+    })
+    const status = container!.querySelector('[data-report-record-sync-status]')
+    expect(status?.textContent).toContain('Report records synchronized.')
+    expect(status?.textContent).toContain('Rows: 2')
+    expect(status?.textContent).toContain('Created: 1')
+    expect(status?.textContent).toContain('Patched: 1')
+    expect(container!.querySelector('[data-report-record-sync-detail="fieldFingerprint"]')?.textContent).toContain('rr-field-fingerprint')
+    expect(container!.querySelector('[data-report-record-sync-detail="syncedAt"]')?.textContent).toContain('2026-05-16T12:00:00.000Z')
+    expect(container!.querySelector('[data-report-record-sync-detail="objectId"]')?.textContent).toContain('attendance_report_records')
+    expect(container!.querySelector<HTMLAnchorElement>('[data-report-record-open-multitable]')?.getAttribute('href'))
+      .toBe('/multitable/sheet-rr/view-rr?baseId=base-rr')
+  })
+
+  it('shows degraded report-records sync as a non-blocking warning', async () => {
+    vi.mocked(apiFetch)
+      .mockResolvedValueOnce(jsonResponse(200, populatedCatalogPayload()))
+      .mockResolvedValueOnce(jsonResponse(200, {
+        ok: true,
+        data: {
+          degraded: true,
+          reason: 'MULTITABLE_RECORDS_API_UNAVAILABLE',
+          synced: 0,
+        },
+      }))
+
+    mountSection()
+    await flushUi()
+
+    const fromInput = container!.querySelector<HTMLInputElement>('[data-report-record-sync-from]')!
+    const toInput = container!.querySelector<HTMLInputElement>('[data-report-record-sync-to]')!
+    const userInput = container!.querySelector<HTMLInputElement>('[data-report-record-sync-user]')!
+    fromInput.value = '2026-05-01'
+    fromInput.dispatchEvent(new Event('input', { bubbles: true }))
+    toInput.value = '2026-05-31'
+    toInput.dispatchEvent(new Event('input', { bubbles: true }))
+    userInput.value = 'u-1'
+    userInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+
+    container!.querySelector<HTMLButtonElement>('[data-report-record-sync-button]')!.click()
+    await flushUi()
+
+    const status = container!.querySelector('[data-report-record-sync-status]')
+    expect(status?.textContent).toContain('Report records sync degraded.')
+    expect(status?.textContent).toContain('MULTITABLE_RECORDS_API_UNAVAILABLE')
+    expect(status?.className).toContain('attendance__status--warn')
+    expect(container!.querySelector('[data-report-record-open-multitable]')).toBeNull()
+    expect(container!.textContent).toContain('Report fields')
+  })
 })

--- a/docs/development/attendance-report-records-sync-pr3-development-20260516.md
+++ b/docs/development/attendance-report-records-sync-pr3-development-20260516.md
@@ -1,0 +1,60 @@
+# 考勤 report-records 同步层 PR3 开发记录
+
+## Summary
+
+本 slice 完成 `attendance_report_records` 同步层的管理入口与可见证据链：管理员可在统计字段区域输入 `from/to/userId`，触发 `POST /api/attendance/report-records/sync`，并在同一页面看到同步计数、字段指纹、同步时间和打开报表多维表的入口。
+
+## Scope
+
+- 前端：`AttendanceReportFieldsSection.vue` 新增「Report records sync / 报表记录同步」面板。
+- 后端：`ensureAttendanceReportRecords()` 同步确保 report-records grid view，并把 `multitable` 定位信息返回给 sync 结果。
+- 测试：补 report-records sync 前端用例、degraded warning 用例、stale-null 负路径单测。
+- 文档：补 PR3 development / verification，并更新 TODO 状态。
+
+## Key Decisions
+
+- 保持 daily-only v1：表单仍要求 `from`、`to`、`userId`，不做全员、分页、period 汇总。
+- `attendance_*` 仍是事实源；sync 只把可重建快照写入插件私有多维表。
+- 前端不重写聚合逻辑，只调用 PR2 已落地 writer。
+- 打开多维表入口依赖后端返回 `sheetId + viewId`；若 degraded 或 view 不可用，不展示入口。
+- `patchRecord` stale-null 规则继续由 writer 执行；PR3 只补一个禁用字段旧值被写 `null` 的完整回归用例。
+
+## Implementation
+
+- `plugins/plugin-attendance/index.cjs`
+  - 新增 `ATTENDANCE_REPORT_RECORDS_VIEW_ID = records_by_date`。
+  - 新增 `getAttendanceReportRecordsViewDescriptor()`，按 `work_date desc`、`user_id asc`、`synced_at desc` 排序。
+  - `ensureAttendanceReportRecords()` 在 `ensureObject + resolveFieldIds` 后尝试 `ensureView`，失败只 warn，不阻断 sync。
+  - `syncAttendanceReportRecords()` 返回 `multitable`：`projectId/objectId/baseId/sheetId/viewId`。
+
+- `apps/web/src/views/attendance/AttendanceReportFieldsSection.vue`
+  - 新增报表记录同步表单：`from/to/userId`。
+  - 成功后展示 `synced/created/patched/skipped/failed/duplicateRowKeys`。
+  - 展示 `fieldFingerprint/syncedAt` 和 report-records 多维表定位信息。
+  - `degraded:true` 显示 warning，不影响统计字段区继续使用。
+
+- `packages/core-backend/tests/unit/attendance-report-field-catalog.test.ts`
+  - 扩展 ensure 测试，锁定 report-records view descriptor。
+  - 补 stale-null 负路径：禁用的 managed 字段旧值必须被 patch 为 `null`。
+
+- `apps/web/tests/AttendanceReportFieldsSection.spec.ts`
+  - 新增成功同步用例，锁定 POST body、fingerprint 展示和多维表 href。
+  - 新增 degraded warning 用例。
+
+## Out Of Scope
+
+- 不做 period/周期汇总。
+- 不做全员同步、分页、batch cursor。
+- 不做 report-records 多维表公式/视图模板预置。
+- 不把 report-records 作为考勤查询/导出的事实源。
+- 不做 staging live evidence；缺凭据时只记录为待补。
+
+## Handoff
+
+PR3 合并后，`attendance_report_records` 三段主线闭合：
+
+1. PR1：descriptor + ensure。
+2. PR2：sync writer + 幂等/fingerprint/stale-null。
+3. PR3：管理员入口 + 可见验证链。
+
+后续建议按产品优先级选择 period 汇总或全员分页同步；两者都应单独 slice。

--- a/docs/development/attendance-report-records-sync-pr3-verification-20260516.md
+++ b/docs/development/attendance-report-records-sync-pr3-verification-20260516.md
@@ -1,0 +1,46 @@
+# 考勤 report-records 同步层 PR3 验证记录
+
+## Verification Matrix
+
+| Layer | Command | Result |
+| --- | --- | --- |
+| Plugin syntax | `node --check plugins/plugin-attendance/index.cjs` | PASS |
+| Backend unit | `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-report-field-catalog.test.ts tests/unit/attendance-report-field-formula-engine.test.ts --reporter=dot` | PASS, 31 tests |
+| Frontend unit | `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/AttendanceReportFieldsSection.spec.ts tests/attendance-admin-regressions.spec.ts --watch=false` | PASS, 19 tests |
+| Web type-check | `pnpm --filter @metasheet/web type-check` | PASS |
+| Core backend build | `pnpm --filter @metasheet/core-backend build` | PASS |
+| Diff hygiene | `git diff --check -- <slice files>` | PASS |
+
+## Evidence
+
+- Report-records view descriptor is deterministic:
+  - view id: `records_by_date`
+  - sort: `work_date desc`, `user_id asc`, `synced_at desc`
+  - purpose: `attendance-report-records`
+- Sync response includes the multitable locator:
+  - `projectId`
+  - `objectId = attendance_report_records`
+  - `baseId`
+  - `sheetId`
+  - `viewId`
+- Frontend sync panel posts exactly:
+  - `POST /api/attendance/report-records/sync?orgId=<orgId>`
+  - body `{ from, to, userId }`
+- Frontend displays:
+  - `synced/created/patched/skipped/failed/duplicateRowKeys`
+  - `fieldFingerprint`
+  - `syncedAt`
+  - report-records multitable open link when `sheetId + viewId` are present
+- Degraded sync returns warning UI and does not break report-field rendering.
+- Stale-null full path is locked: if `late_duration` is disabled but an existing report-record row has old `fld_late_duration`, sync patches it to `null`.
+
+## Boundaries Checked
+
+- No `attendance_*` migration.
+- No direct `meta_*` SQL write from the attendance plugin.
+- Report-records remains a rebuildable multitable report layer, not a fact source.
+- PR3 does not implement period sync, all-user sync, pagination, or formula editor.
+
+## Pending Evidence
+
+- Real staging sync evidence is not run in this slice. It needs a short-lived admin JWT plus a sample tenant with attendance records; without credentials this remains a follow-up and is not marked as passed.

--- a/docs/development/attendance-report-records-sync-todo-20260515.md
+++ b/docs/development/attendance-report-records-sync-todo-20260515.md
@@ -128,6 +128,9 @@ skip  iff  existing.source_fingerprint === next.source_fingerprint
 - 考勤管理中心「同步到多维表报表」按钮 + 最近 syncedAt/记录数/fingerprint 展示 + 「打开多维表」入口
 - mock acceptance：catalog → records → multitable rows 一致性（fingerprint 链）
 - 一个 Vue 文件 + 一个 spec
+- 落地记录：
+  - development: `docs/development/attendance-report-records-sync-pr3-development-20260516.md`
+  - verification: `docs/development/attendance-report-records-sync-pr3-verification-20260516.md`
 
 ## 测试矩阵（钉死）
 
@@ -171,17 +174,17 @@ skip  iff  existing.source_fingerprint === next.source_fingerprint
 ## Claude Code TODO
 
 ### PR1
-- [ ] 本 TODO MD + development + verification MD
-- [ ] `ATTENDANCE_REPORT_RECORDS_OBJECT_ID` + `ATTENDANCE_REPORT_RECORDS_FIELDS` + `getAttendanceReportRecordsDescriptor()`
-- [ ] `ensureAttendanceReportRecords(context,orgId,logger)` + test surface 导出
-- [ ] 单测：descriptor 稳定 / ensure 幂等 / provisioning 不可用降级
-- [ ] orientation 子项：实测 ensureObject 补字段行为，结论写进 development MD
+- [x] 本 TODO MD + development + verification MD
+- [x] `ATTENDANCE_REPORT_RECORDS_OBJECT_ID` + `ATTENDANCE_REPORT_RECORDS_FIELDS` + `getAttendanceReportRecordsDescriptor()`
+- [x] `ensureAttendanceReportRecords(context,orgId,logger)` + test surface 导出
+- [x] 单测：descriptor 稳定 / ensure 幂等 / provisioning 不可用降级
+- [x] orientation 子项：实测 ensureObject 补字段行为，结论写进 development MD
 
 ### PR2（待 PR1 合并后）
-- [ ] `POST /api/attendance/report-records/sync` 路由 + writer（复用 export 路径）
-- [ ] upsert（queryRecords→patch/create）+ skip 仅当 source_fingerprint && field_fingerprint 双等
-- [ ] 单测矩阵（upsert/幂等/字段/fingerprint/降级/边界）
+- [x] `POST /api/attendance/report-records/sync` 路由 + writer（复用 export 路径）
+- [x] upsert（queryRecords→patch/create）+ skip 仅当 source_fingerprint && field_fingerprint 双等
+- [x] 单测矩阵（upsert/幂等/字段/fingerprint/降级/边界）
 
 ### PR3（待 PR2 合并后）
-- [ ] 前端同步入口 + syncedAt/数/fingerprint 展示 + 打开多维表
-- [ ] mock acceptance fingerprint 链一致性
+- [x] 前端同步入口 + syncedAt/数/fingerprint 展示 + 打开多维表
+- [x] mock acceptance fingerprint 链一致性

--- a/packages/core-backend/tests/unit/attendance-report-field-catalog.test.ts
+++ b/packages/core-backend/tests/unit/attendance-report-field-catalog.test.ts
@@ -611,6 +611,12 @@ describe('attendance report field catalog multitable foundation', () => {
               ensureCalls.push(input)
               return { baseId: 'base_legacy', sheet: { id: 'sheet_report_records' } }
             },
+            ensureView: vi.fn().mockResolvedValue({
+              id: 'view_report_records',
+              sheetId: 'sheet_report_records',
+              name: '按日期查看',
+              type: 'grid',
+            }),
             resolveFieldIds: async ({ fieldIds }: { fieldIds: string[] }) =>
               Object.fromEntries(fieldIds.map(fid => [fid, `fld_${fid}`])),
           },
@@ -624,9 +630,21 @@ describe('attendance report field catalog multitable foundation', () => {
       reason: null,
       objectId: 'attendance_report_records',
       sheetId: 'sheet_report_records',
+      viewId: 'view_report_records',
     })
     expect(r1.fieldIds.row_key).toBe('fld_row_key')
     expect(r1.fieldIds.synced_at).toBe('fld_synced_at')
+    expect(helpers.getAttendanceReportRecordsViewDescriptor(r1.fieldIds)).toMatchObject({
+      id: helpers.ATTENDANCE_REPORT_RECORDS_VIEW_ID,
+      objectId: 'attendance_report_records',
+      sortInfo: {
+        rules: [
+          { fieldId: 'fld_work_date', direction: 'desc' },
+          { fieldId: 'fld_user_id', direction: 'asc' },
+          { fieldId: 'fld_synced_at', direction: 'desc' },
+        ],
+      },
+    })
     // idempotent: second ensure returns equivalent result, descriptor passed unchanged
     expect(JSON.stringify(r2)).toBe(JSON.stringify(r1))
     expect(JSON.stringify((ensureCalls[0] as { descriptor: unknown }).descriptor))
@@ -757,6 +775,11 @@ describe('attendance report field catalog multitable foundation', () => {
     // sync #1 → all created
     const r1 = await helpers.syncAttendanceReportRecords(context, db, 'org-1', { warn: vi.fn() }, { from: '2026-05-01', to: '2026-05-31', userId: 'u-1' })
     expect(r1).toMatchObject({ synced: 2, created: 2, patched: 0, skipped: 0, failed: 0, duplicateRowKeys: 0 })
+    expect(r1.multitable).toMatchObject({
+      available: true,
+      objectId: 'attendance_report_records',
+      sheetId: 'sheet_rr',
+    })
     expect(store.length).toBe(2)
     // Fix-1 integration: the descriptor handed to ensureObject (value-columns ensure) must
     // carry work_date exactly once and still as type 'date' (no string overwrite collision)
@@ -788,6 +811,96 @@ describe('attendance report field catalog multitable foundation', () => {
     const r4 = await helpers.syncAttendanceReportRecords(context, db, 'org-1', { warn: vi.fn() }, { from: '2026-05-01', to: '2026-05-31', userId: 'u-1' })
     expect(r4.duplicateRowKeys).toBeGreaterThanOrEqual(1)
     expect(store.filter(r => r.data[rowKeyFid] === 'org-1:u-1:2026-05-13').length).toBe(2) // not auto-deleted (v1)
+  })
+
+  it('report-records sync: disabled managed value columns are patched to null', async () => {
+    const catalogFieldIds = Object.fromEntries(
+      Object.values(helpers.ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS).map((fieldId) => [fieldId, `fld_${fieldId}`]),
+    )
+    const disabledLateDurationRecord = {
+      id: 'cfg-late-duration',
+      data: {
+        fld_field_code: 'late_duration',
+        fld_field_name: '迟到时长',
+        fld_category: '异常统计字段',
+        fld_source: 'system',
+        fld_unit: 'minutes',
+        fld_enabled: false,
+        fld_report_visible: true,
+        fld_sort_order: 4010,
+        fld_dingtalk_field_name: '迟到时长',
+        fld_description: '已停用字段应该清空报表记录旧值',
+        fld_internal_key: 'summary.lateMinutes',
+        fld_formula_enabled: false,
+        fld_formula_expression: '',
+        fld_formula_scope: 'record',
+        fld_formula_output_type: 'duration_minutes',
+      },
+    }
+
+    const store = [{
+      id: 'rec-existing',
+      data: {
+        fld_row_key: 'org-1:u-1:2026-05-13',
+        fld_field_fingerprint: 'STALE-FIELD',
+        fld_source_fingerprint: 'STALE-SOURCE',
+        fld_late_duration: 12,
+      },
+    }]
+    const records = {
+      queryRecords: async ({ sheetId, filters }: { sheetId: string; filters?: Record<string, unknown> }) => {
+        if (sheetId === 'sheet_catalog') return [disabledLateDurationRecord]
+        const want = filters?.fld_row_key
+        return store.filter(r => r.data.fld_row_key === want)
+      },
+      createRecord: vi.fn(),
+      patchRecord: vi.fn(async ({ recordId, changes }: { recordId: string; changes: Record<string, unknown> }) => {
+        const rec = store.find(r => r.id === recordId)
+        if (rec) rec.data = { ...rec.data, ...changes }
+        return rec
+      }),
+    }
+    const provisioning = {
+      ensureObject: async () => ({ baseId: 'base_rr', sheet: { id: 'sheet_rr' } }),
+      ensureView: async () => ({ id: 'view_rr', sheetId: 'sheet_rr' }),
+      findObjectSheet: async ({ objectId }: { objectId: string }) => (
+        objectId === 'attendance_report_field_catalog'
+          ? { id: 'sheet_catalog', baseId: 'base_catalog' }
+          : null
+      ),
+      resolveFieldIds: async ({ objectId, fieldIds }: { objectId: string; fieldIds: string[] }) => (
+        objectId === 'attendance_report_field_catalog'
+          ? Object.fromEntries(fieldIds.map(fieldId => [fieldId, catalogFieldIds[fieldId] || `fld_${fieldId}`]))
+          : Object.fromEntries(fieldIds.map(fieldId => [fieldId, `fld_${fieldId}`]))
+      ),
+    }
+    const attendanceRows = [
+      { user_id: 'u-1', org_id: 'org-1', work_date: '2026-05-13', timezone: 'UTC', first_in_at: '2026-05-13T09:00:00Z', last_out_at: '2026-05-13T18:00:00Z', work_minutes: 480, late_minutes: 12, early_leave_minutes: 0, status: 'late', is_workday: true, meta: {}, user_name: '张三', username: 'zhangsan' },
+    ]
+    const db = {
+      query: async (sql: string) => {
+        if (/FROM attendance_records ar/.test(sql)) return attendanceRows
+        return []
+      },
+    }
+    const context = { api: { multitable: { provisioning, records }, database: db } }
+
+    const result = await helpers.syncAttendanceReportRecords(
+      context,
+      db,
+      'org-1',
+      { warn: vi.fn() },
+      { from: '2026-05-01', to: '2026-05-31', userId: 'u-1' },
+    )
+
+    expect(result).toMatchObject({ synced: 1, patched: 1, created: 0, skipped: 0, failed: 0 })
+    expect(records.createRecord).not.toHaveBeenCalled()
+    expect(records.patchRecord).toHaveBeenCalledTimes(1)
+    const patch = records.patchRecord.mock.calls[0]?.[0]
+    expect(patch.changes.fld_late_duration).toBeNull()
+    expect(store[0].data.fld_late_duration).toBeNull()
+    expect(store[0].data.fld_field_fingerprint).not.toBe('STALE-FIELD')
+    expect(store[0].data.fld_source_fingerprint).not.toBe('STALE-SOURCE')
   })
 
   it('does not add direct meta table writes to the attendance plugin', () => {

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -253,6 +253,7 @@ const IMPORT_REQUIRED_FIELD_ALIASES = {
 
 const ATTENDANCE_REPORT_FIELD_CATALOG_OBJECT_ID = 'attendance_report_field_catalog'
 const ATTENDANCE_REPORT_FIELD_CATALOG_VIEW_ID = 'fields_by_category'
+const ATTENDANCE_REPORT_RECORDS_VIEW_ID = 'records_by_date'
 const ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS = Object.freeze({
   fieldCode: 'field_code',
   fieldName: 'field_name',
@@ -932,6 +933,15 @@ function getAttendanceReportFieldCatalogViewId(projectId) {
   )
 }
 
+function getAttendanceReportRecordsViewId(projectId) {
+  return stableAttendanceMultitableId(
+    'view',
+    projectId,
+    ATTENDANCE_REPORT_RECORDS_OBJECT_ID,
+    ATTENDANCE_REPORT_RECORDS_VIEW_ID,
+  )
+}
+
 function getAttendanceReportFieldCategory(value) {
   const normalized = String(value ?? '').trim()
   if (!normalized) return ATTENDANCE_REPORT_FIELD_CATEGORIES[0]
@@ -1525,6 +1535,28 @@ function getAttendanceReportRecordsDescriptor() {
   }
 }
 
+function getAttendanceReportRecordsViewDescriptor(fieldIds = {}) {
+  const workDateFieldId = fieldIds[ATTENDANCE_REPORT_RECORDS_FIELDS.workDate] || ATTENDANCE_REPORT_RECORDS_FIELDS.workDate
+  const userIdFieldId = fieldIds[ATTENDANCE_REPORT_RECORDS_FIELDS.userId] || ATTENDANCE_REPORT_RECORDS_FIELDS.userId
+  const syncedAtFieldId = fieldIds[ATTENDANCE_REPORT_RECORDS_FIELDS.syncedAt] || ATTENDANCE_REPORT_RECORDS_FIELDS.syncedAt
+  return {
+    id: ATTENDANCE_REPORT_RECORDS_VIEW_ID,
+    objectId: ATTENDANCE_REPORT_RECORDS_OBJECT_ID,
+    name: '按日期查看',
+    type: 'grid',
+    sortInfo: {
+      rules: [
+        { fieldId: workDateFieldId, direction: 'desc' },
+        { fieldId: userIdFieldId, direction: 'asc' },
+        { fieldId: syncedAtFieldId, direction: 'desc' },
+      ],
+    },
+    config: {
+      purpose: 'attendance-report-records',
+    },
+  }
+}
+
 // PR1 ships the fixed identity/provenance skeleton only. Value columns (static stat /
 // dynamic subtype / formula) are ensured at sync time in PR2 via the same ensureObject
 // upsert (ensureFields = INSERT ON CONFLICT DO UPDATE, never deletes — confirmed in
@@ -1542,6 +1574,7 @@ async function ensureAttendanceReportRecords(context, orgId, logger) {
       objectId: ATTENDANCE_REPORT_RECORDS_OBJECT_ID,
       baseId: null,
       sheetId: null,
+      viewId: null,
       fieldIds: {},
     }
   }
@@ -1562,6 +1595,21 @@ async function ensureAttendanceReportRecords(context, orgId, logger) {
         multitable.provisioning.getFieldId(projectId, ATTENDANCE_REPORT_RECORDS_OBJECT_ID, fieldId),
       ]))
     }
+
+    let viewId = null
+    if (typeof multitable.provisioning.ensureView === 'function') {
+      try {
+        const view = await multitable.provisioning.ensureView({
+          projectId,
+          sheetId: provisioned.sheet.id,
+          descriptor: getAttendanceReportRecordsViewDescriptor(fieldIds),
+        })
+        viewId = view?.id || null
+      } catch (error) {
+        logger?.warn?.('Failed to ensure attendance report records view', error)
+      }
+    }
+
     return {
       available: true,
       reason: null,
@@ -1569,6 +1617,7 @@ async function ensureAttendanceReportRecords(context, orgId, logger) {
       objectId: ATTENDANCE_REPORT_RECORDS_OBJECT_ID,
       baseId: provisioned.baseId || null,
       sheetId: provisioned.sheet?.id || null,
+      viewId,
       fieldIds,
     }
   } catch (error) {
@@ -1581,6 +1630,7 @@ async function ensureAttendanceReportRecords(context, orgId, logger) {
       objectId: ATTENDANCE_REPORT_RECORDS_OBJECT_ID,
       baseId: null,
       sheetId: null,
+      viewId: null,
       fieldIds: {},
     }
   }
@@ -1773,7 +1823,20 @@ async function syncAttendanceReportRecords(context, db, orgId, logger, params) {
       })
     }
   }
-  return { ...result, fieldFingerprint, syncedAt }
+  return {
+    ...result,
+    fieldFingerprint,
+    syncedAt,
+    multitable: {
+      available: true,
+      degraded: false,
+      projectId: ensured.projectId,
+      objectId: ensured.objectId,
+      baseId: ensured.baseId || null,
+      sheetId: ensured.sheetId || null,
+      viewId: ensured.viewId || null,
+    },
+  }
 }
 
 async function loadAttendanceReportFieldCatalog(context, orgId) {
@@ -9472,6 +9535,7 @@ module.exports = {
     ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS,
     ATTENDANCE_REPORT_FIELD_CATALOG_OBJECT_ID,
     ATTENDANCE_REPORT_FIELD_CATALOG_VIEW_ID,
+    ATTENDANCE_REPORT_RECORDS_VIEW_ID,
     buildAttendanceReportFieldCatalogRecordData,
     buildAttendanceReportFieldCatalogResponse,
     cloneAttendanceReportFieldCategories,
@@ -9480,6 +9544,8 @@ module.exports = {
     getAttendanceRecordReportFieldValue,
     getAttendanceReportFieldCatalogDescriptor,
     getAttendanceReportFieldProjectId,
+    getAttendanceReportRecordsViewDescriptor,
+    getAttendanceReportRecordsViewId,
     resolveAttendanceFormulaRawAliasesAllowed,
     readAttendanceFormulaRawAliasesEnvOverride,
     loadAttendanceReportFieldCatalog,


### PR DESCRIPTION
## Summary

Completes PR3 for the attendance_report_records sync line. Adds the admin-center sync panel, report-records multitable view metadata, visible sync counts/fingerprint/syncedAt evidence, and an open-multitable entry when sheet/view metadata is available.

## Implementation

- Ensures a deterministic `records_by_date` view for `attendance_report_records` and returns multitable locator metadata from `POST /api/attendance/report-records/sync`.
- Adds a compact report-records sync panel in `AttendanceReportFieldsSection.vue` for daily v1 `{ from, to, userId }` sync.
- Shows `synced/created/patched/skipped/failed/duplicateRowKeys`, `fieldFingerprint`, `syncedAt`, and degraded warnings without breaking the report-fields section.
- Adds a stale-null backend regression proving disabled managed columns patch old values to `null`.
- Adds PR3 development and verification MD; marks PR1/PR2/PR3 todo items complete.

## Test plan

- [x] `node --check plugins/plugin-attendance/index.cjs`
- [x] `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-report-field-catalog.test.ts tests/unit/attendance-report-field-formula-engine.test.ts --reporter=dot` (31 tests)
- [x] `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/AttendanceReportFieldsSection.spec.ts tests/attendance-admin-regressions.spec.ts --watch=false` (19 tests)
- [x] `pnpm --filter @metasheet/web type-check`
- [x] `pnpm --filter @metasheet/core-backend build`
- [x] `git diff --cached --check`

## Boundaries

- No attendance_* migration.
- No direct meta_* SQL write.
- report-records remains a rebuildable multitable report layer, not a fact source.
- Period sync, all-user sync, pagination, and staging live evidence remain follow-ups.