### PR TITLE
docs(data-factory): record issue1542 closeout evidence

### DIFF
--- a/docs/development/data-factory-issue1542-closeout-development-20260517.md
+++ b/docs/development/data-factory-issue1542-closeout-development-20260517.md
@@ -1,0 +1,86 @@
+# Data Factory issue #1542 closeout development - 2026-05-17
+
+## Purpose
+
+Issue #1542 asks for a clearer new-connection flow in the Data Factory
+Workbench. This closeout is intentionally docs-only: it records the current
+`main` state and separates the #1542 onboarding scope from deeper runtime
+capabilities that should remain tracked elsewhere.
+
+Baseline inspected in this slice:
+
+```text
+main: 82242b380 docs(integration): record issue 651 C1 C3 UI closeout
+issue: #1542 Integration Workbench needs a clear new-connection flow
+state at inspection: OPEN
+```
+
+## Why this is a closeout, not another feature PR
+
+The originally reported operator confusion has been covered by the shipped Data
+Factory work:
+
+| Concern | Current behavior |
+| --- | --- |
+| "Where do I start?" | The Workbench starts with `数据工厂`, a visible `连接新系统` area, a K3 preset entry, a general connection guide action, and an SQL/high-connection action. |
+| "What is loaded?" | The summary expands into configured systems, adapter inventory, and staging multitable inventory. |
+| "Why can I not use SQL yet?" | SQL connections are hidden by default, marked as advanced, and when executor support is missing the UI explains `SQLSERVER_EXECUTOR_MISSING`. |
+| "How do I get a readable source without live PLM/K3 SQL?" | The Workbench exposes staging creation and `作为 Dry-run 来源` for installed staging tables. |
+| "Where is the real multitable entry?" | Staging cards use the backend-provided `/multitable/...` open link and explicitly warn against hand-writing `/grid` or `/spreadsheets/...` paths. |
+| "Can I save a draft pipeline?" | The issue #1542 smoke now verifies a staging-to-K3 material draft pipeline save path. |
+
+The remaining items frequently mentioned in the same discussion are not the
+same product problem:
+
+- A real SQL Server executor is a deployment/runtime capability behind the
+  advanced SQL channel. It must keep allowlist-only read guardrails and should
+  not be bundled into a UI wording closeout.
+- K3 WebAPI read/list runtime support touches `plugin-integration-core` and is
+  blocked by the customer GATE contract that was documented before runtime
+  changes.
+- Relationship mapping and unresolved-link handling are model/runtime work, not
+  the new-connection onboarding flow.
+
+## Current shipped slices that form the closeout
+
+| Area | Evidence in repo |
+| --- | --- |
+| Data Factory IA | `apps/web/src/views/IntegrationWorkbenchView.vue` renders the `数据工厂` title, four-step flow, connection onboarding, and staging dataset region. |
+| Issue #1542 P1 UX | `data-factory-issue1542-p1-ux-*` documents disabled SQL source states and staging creation CTAs. |
+| Save/Dry-run prerequisites | `data-factory-issue1542-p2-prereq-*` documents disabled save/dry-run controls until required state exists. |
+| Pipeline JSONB repair | `data-factory-issue1542-pipeline-jsonb-*` records the fix for draft pipeline save failures. |
+| Staging source install/signoff | `data-factory-issue1542-install-smoke-*`, `data-factory-issue1542-workflow-install-staging-*`, and `data-factory-issue1542-postdeploy-signoff-*` record automated staging-source checks. |
+| Package inclusion | `data-factory-issue1542-package-verify-*` records package-level inclusion of the smoke assets. |
+
+## Operator path after this closeout
+
+1. Open Data Factory at `/integrations/workbench`.
+2. Use `使用 K3 WISE 预设` for the first K3 material/BOM target path, or use the
+   general `连接新系统` guide for non-K3 systems.
+3. If no readable source exists, create staging multitables from the Workbench.
+4. Open the returned `/multitable/...` link to clean or add rows in the real
+   multitable surface.
+5. Select the staging table as Dry-run source and K3 WebAPI material/BOM as
+   target.
+6. Save the draft pipeline; then run dry-run. Save-only remains separate from
+   Submit/Audit and must be explicit.
+
+## Explicit non-goals
+
+- No new migration.
+- No new backend route.
+- No `plugin-integration-core` runtime change.
+- No SQL Server driver/executor implementation.
+- No K3 live write or Submit/Audit enablement.
+- No raw SQL, direct JavaScript transform, or secret-bearing example in docs.
+
+## Recommendation
+
+After this closeout PR is merged, issue #1542 can be closed as resolved for the
+Data Factory new-connection/onboarding flow. Follow-up work should stay in the
+more specific buckets already identified:
+
+- advanced SQL executor deployment and allowlist verification;
+- post-GATE K3 WebAPI read/list runtime support;
+- relationship mapping/unresolved-link behavior;
+- customer GATE live K3 validation.

--- a/docs/development/data-factory-issue1542-closeout-verification-20260517.md
+++ b/docs/development/data-factory-issue1542-closeout-verification-20260517.md
@@ -1,0 +1,116 @@
+# Data Factory issue #1542 closeout verification - 2026-05-17
+
+Companion to
+`docs/development/data-factory-issue1542-closeout-development-20260517.md`.
+
+## Verification matrix
+
+| Check | Evidence | Result |
+| --- | --- | --- |
+| Issue still open before closeout | `gh issue view 1542 --repo zensgit/metasheet2 --json number,title,state,updatedAt,url` returned `state=OPEN`. | PASS |
+| Workbench is branded as Data Factory | `IntegrationWorkbenchView.vue` renders `Data Factory`, `数据工厂`, and the 4-step flow. | PASS |
+| New-connection entry exists | Workbench renders `连接新系统`, `使用 K3 WISE 预设`, and `查看 SQL / 高级连接`. | PASS |
+| Inventory overview exists | Workbench summary expands into configured systems, available adapters, and staging multitables. | PASS |
+| SQL is advanced and guarded | SQL/high connections are hidden by default; when shown, missing executor state renders `SQLSERVER_EXECUTOR_MISSING`. | PASS |
+| Staging source entry exists | Empty-source state offers `创建 staging 多维表作为来源`; staging cards offer `作为 Dry-run 来源`. | PASS |
+| Correct multitable open path is documented in UI | Staging cards use `打开多维表（新建记录入口）` and warn not to hand-write `/grid` or `/spreadsheets/<id>`. | PASS |
+| Project scope hint remains connected | Existing Workbench tests assert blank scope resolves to `default:integration-core` and plain project id can be normalized. | PASS |
+| Postdeploy smoke covers the prior P0 blockers | Workflow evidence records `issue1542-staging-install`, `issue1542-staging-source-schema`, `issue1542-k3-material-schema`, and `issue1542-pipeline-save` passing. | PASS |
+
+## Local code evidence
+
+Targeted static inspection was run with:
+
+```bash
+rg -n "数据工厂|new connection|SQL|staging-project-id|创建 staging|使用 K3 WISE|打开多维表|use-staging-source|use-multitable-target|sqlChannelDisabledHint" \
+  apps/web/src/views/IntegrationWorkbenchView.vue \
+  apps/web/tests/IntegrationWorkbenchView.spec.ts \
+  apps/web/tests/integrationWorkbench.spec.ts \
+  docs/development/data-factory-issue1542-* \
+  -S
+```
+
+Key source findings:
+
+- `IntegrationWorkbenchView.vue` renders the Data Factory header, connection
+  onboarding, inventory overview, staging cards, and SQL executor-missing hint.
+- `IntegrationWorkbenchView.spec.ts` covers the Data Factory title/flow,
+  inventory overview, hidden advanced SQL default, disabled SQL source option,
+  staging CTA, `/multitable` open-link guidance, and Project ID scope
+  normalization.
+- The existing #1542 docs record the P1/P2 UI fixes, pipeline JSONB save
+  repair, package inclusion, install-staging smoke, and postdeploy signoff.
+
+## Existing postdeploy evidence
+
+The merged postdeploy signoff document records GitHub Actions run
+`25905364900`:
+
+```text
+Workflow: K3 WISE Postdeploy Smoke
+Commit: f612a04c00b05baaf7aeb6016a16defc6c72f871
+Conclusion: success
+Input: issue1542_install_staging=true
+Smoke: 17 pass / 0 skipped / 0 fail
+Signoff: internalTrial=pass
+```
+
+Issue #1542 specific checks passed in that run:
+
+- `issue1542-staging-install`
+- `issue1542-system-readiness`
+- `issue1542-staging-source-schema`
+- `issue1542-k3-material-schema`
+- `issue1542-pipeline-save`
+
+The same verification explicitly states that SQL Server executor availability
+is out of scope for this staging-as-source signoff.
+
+## Commands for this closeout PR
+
+Because this PR adds closeout documentation only, the relevant gates are doc and
+frontend-regression focused:
+
+```bash
+git diff --check origin/main...HEAD
+pnpm --filter @metasheet/web exec vitest run tests/IntegrationWorkbenchView.spec.ts tests/integrationWorkbench.spec.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/k3WiseSetup.spec.ts --watch=false
+rg -n "AdminPass|eyJ[A-Za-z0-9_-]+\\.|Bearer [A-Za-z0-9_-]{20,}|postgres://[^[:space:]]+:[^[:space:]@]+@" \
+  docs/development/data-factory-issue1542-closeout-development-20260517.md \
+  docs/development/data-factory-issue1542-closeout-verification-20260517.md \
+  | rg -v "^docs/development/data-factory-issue1542-closeout-verification-20260517\\.md:[0-9]+:rg -n "
+```
+
+Expected secret-check behavior: no matches. The closeout docs contain no K3
+authority code, token, password, JDBC URL, SQL connection string, or bearer
+header.
+
+## This PR verification result
+
+| Command | Result |
+| --- | --- |
+| `git diff --check origin/main...HEAD` | PASS |
+| `pnpm --filter @metasheet/web exec vitest run tests/IntegrationWorkbenchView.spec.ts tests/integrationWorkbench.spec.ts --watch=false` | PASS: 2 files / 27 tests |
+| `pnpm --filter @metasheet/web exec vitest run tests/k3WiseSetup.spec.ts --watch=false` | PASS: 1 file / 41 tests |
+| Secret-shape check above | PASS: no matches after filtering the command-line self-reference |
+
+The temporary verification worktree reused the existing local `node_modules`
+via symlinks to avoid mutating package metadata. The symlinks were removed after
+the test run and are not part of the PR.
+
+## Close criteria
+
+Issue #1542 should be considered closed when:
+
+1. this closeout PR is merged;
+2. the issue is updated with the closeout summary;
+3. any future SQL executor/read-list/relationship work is tracked under its own
+   issue or PR, not as a continuation of the new-connection onboarding bug.
+
+## Residual risk
+
+The closeout relies on existing automated and postdeploy evidence rather than
+rerunning a physical 142 deployment during this PR. That is acceptable because
+this PR changes no runtime code. If a new deployment package is generated, run
+the existing postdeploy smoke with `issue1542_install_staging=true` to refresh
+the machine-level evidence.


### PR DESCRIPTION
## Summary

Docs-only closeout for issue #1542. This PR records why the Data Factory new-connection/onboarding flow can be considered resolved on current main, while keeping SQL executor, post-GATE K3 read/list, and relationship mapping as separate runtime tracks.

## Verification

- git diff --check origin/main...HEAD
- pnpm --filter @metasheet/web exec vitest run tests/IntegrationWorkbenchView.spec.ts tests/integrationWorkbench.spec.ts --watch=false -> 27/27 pass
- pnpm --filter @metasheet/web exec vitest run tests/k3WiseSetup.spec.ts --watch=false -> 41/41 pass
- secret-shape scan over the new docs -> no matches after filtering the command-line self-reference

## Deployment impact

None. Documentation only; no runtime, migration, API, package, or plugin-integration-core change.

## Issue #1542

After this PR is merged, #1542 can be closed as resolved for the Data Factory new-connection flow. Remaining SQL executor/read-list/relationship work should stay on their dedicated tracks.