### PR TITLE
fix(multitable): recover record create context from route referer

### DIFF
--- a/apps/web/src/multitable/composables/useMultitableGrid.ts
+++ b/apps/web/src/multitable/composables/useMultitableGrid.ts
@@ -202,35 +202,133 @@ function decodeRoutePart(value: string | undefined): string | undefined {
   }
 }
 
-function readCurrentPathname(): string {
+type RecordCreateLocationSnapshot = {
+  pathname?: string
+  search?: string
+  hash?: string
+  href?: string
+}
+
+type RecordCreateRouteContext = {
+  sheetId?: string
+  viewId?: string
+  isPublicFormRoute?: boolean
+}
+
+function readCurrentLocationSnapshot(): RecordCreateLocationSnapshot {
   try {
-    return globalThis.location?.pathname ?? ''
+    const location = globalThis.location
+    return {
+      pathname: location?.pathname ?? '',
+      search: location?.search ?? '',
+      hash: location?.hash ?? '',
+      href: location?.href ?? '',
+    }
   } catch {
-    return ''
+    return {}
+  }
+}
+
+function parseCreateRecordRouteContext(value: string | undefined): RecordCreateRouteContext {
+  const raw = typeof value === 'string' ? value.trim() : ''
+  if (!raw) return {}
+
+  const candidates = [raw]
+  try {
+    const url = new URL(raw, 'http://metasheet.local')
+    candidates.push(url.pathname)
+    if (url.hash) candidates.push(url.hash.slice(1))
+  } catch {
+    const hashIndex = raw.indexOf('#')
+    if (hashIndex >= 0) candidates.push(raw.slice(hashIndex + 1))
+  }
+
+  for (const candidate of candidates) {
+    const normalized = candidate.replace(/^#/, '').split(/[?#]/)[0]
+    const segments = normalized.split('/').filter(Boolean)
+    const multitableIndex = segments.lastIndexOf('multitable')
+    if (multitableIndex < 0) continue
+    if (segments[multitableIndex + 1] === 'public-form') {
+      return { isPublicFormRoute: true }
+    }
+    return {
+      sheetId: decodeRoutePart(segments[multitableIndex + 1]),
+      viewId: decodeRoutePart(segments[multitableIndex + 2]),
+    }
+  }
+
+  return {}
+}
+
+function parseCreateRecordQueryContext(value: string | undefined): { sheetId?: string; viewId?: string } {
+  const raw = typeof value === 'string' ? value.trim() : ''
+  if (!raw) return {}
+  try {
+    const url = raw.includes('?')
+      ? new URL(raw, 'http://metasheet.local')
+      : null
+    const search = url?.search ?? (raw.startsWith('?') ? raw : `?${raw}`)
+    const params = new URLSearchParams(search)
+    return {
+      sheetId: decodeRoutePart(params.get('sheetId') ?? undefined),
+      viewId: decodeRoutePart(params.get('viewId') ?? undefined),
+    }
+  } catch {
+    return {}
   }
 }
 
 export function resolveCreateRecordContext(args: {
   sheetId?: string | null
   viewId?: string | null
+  href?: string
+  hash?: string
   pathname?: string
+  search?: string
 }): { sheetId?: string; viewId?: string } {
   const sheetId = normalizeRecordContextId(args.sheetId)
   const viewId = normalizeRecordContextId(args.viewId)
-  const pathname = args.pathname ?? readCurrentPathname()
-  const segments = pathname.split('/').filter(Boolean)
-  const multitableIndex = segments.lastIndexOf('multitable')
-  const isPublicFormRoute = multitableIndex >= 0 && segments[multitableIndex + 1] === 'public-form'
-  const routeSheetId = !sheetId && !isPublicFormRoute && multitableIndex >= 0
-    ? decodeRoutePart(segments[multitableIndex + 1])
-    : undefined
-  const routeViewId = !viewId && !isPublicFormRoute && multitableIndex >= 0
-    ? decodeRoutePart(segments[multitableIndex + 2])
-    : undefined
+  if (sheetId && viewId) return { sheetId, viewId }
+
+  const location = readCurrentLocationSnapshot()
+  const routeCandidates = [
+    args.href,
+    args.pathname,
+    args.hash,
+    location.href,
+    location.pathname,
+    location.hash,
+  ]
+  let routeSheetId: string | undefined
+  let routeViewId: string | undefined
+  for (const candidate of routeCandidates) {
+    const routeContext = parseCreateRecordRouteContext(candidate)
+    if (routeContext.isPublicFormRoute) return { sheetId, viewId }
+    routeSheetId = routeSheetId ?? routeContext.sheetId
+    routeViewId = routeViewId ?? routeContext.viewId
+    if (routeSheetId && routeViewId) break
+  }
+
+  const queryCandidates = [
+    args.search,
+    args.href,
+    args.hash,
+    location.search,
+    location.href,
+    location.hash,
+  ]
+  let querySheetId: string | undefined
+  let queryViewId: string | undefined
+  for (const candidate of queryCandidates) {
+    const queryContext = parseCreateRecordQueryContext(candidate)
+    querySheetId = querySheetId ?? queryContext.sheetId
+    queryViewId = queryViewId ?? queryContext.viewId
+    if (querySheetId && queryViewId) break
+  }
 
   return {
-    sheetId: sheetId ?? routeSheetId,
-    viewId: viewId ?? routeViewId,
+    sheetId: sheetId ?? routeSheetId ?? querySheetId,
+    viewId: viewId ?? routeViewId ?? queryViewId,
   }
 }
 

--- a/apps/web/tests/multitable-grid.spec.ts
+++ b/apps/web/tests/multitable-grid.spec.ts
@@ -204,6 +204,28 @@ describe('useMultitableGrid', () => {
     })
   })
 
+  it('resolves record-create context from a hash-backed multitable route', () => {
+    expect(resolveCreateRecordContext({
+      sheetId: '',
+      viewId: '',
+      hash: '#/multitable/sheet_hash_materials/view_hash_grid?baseId=base_legacy',
+    })).toEqual({
+      sheetId: 'sheet_hash_materials',
+      viewId: 'view_hash_grid',
+    })
+  })
+
+  it('resolves record-create context from sheet and view query parameters', () => {
+    expect(resolveCreateRecordContext({
+      sheetId: '',
+      viewId: '',
+      href: 'http://localhost/grid?sheetId=sheet_query_materials&viewId=view_query_grid',
+    })).toEqual({
+      sheetId: 'sheet_query_materials',
+      viewId: 'view_query_grid',
+    })
+  })
+
   it('does not borrow public-form route ids for authenticated record creation', () => {
     expect(resolveCreateRecordContext({
       sheetId: '',

--- a/docs/development/data-factory-issue651-record-create-referer-context-development-20260517.md
+++ b/docs/development/data-factory-issue651-record-create-referer-context-development-20260517.md
@@ -1,0 +1,70 @@
+# Data Factory Issue #651 Record Create Context Follow-up
+
+Date: 2026-05-17
+
+## Purpose
+
+This change closes the remaining C1 failure reported from the Windows on-prem retest of package
+`metasheet-multitable-onprem-v2.5.0-issue651-c1-context-5b19e3.zip`.
+
+The previous fix changed the backend response from a generic 500 to a precise
+`400 VALIDATION_ERROR: sheetId or viewId is required`, proving the create request still reached
+`POST /api/multitable/records` without record-create context. This follow-up makes context recovery
+more tolerant of real deployed route shapes before the request reaches field validation.
+
+## Root Cause
+
+`useMultitableGrid.createRecord()` had a route fallback, but it only read `globalThis.location.pathname`.
+The physical retest showed the authenticated multitable route could be opened, while `+ New Record`
+still posted a bare `{ data: ... }` body.
+
+That leaves two credible production gaps:
+
+- The browser route context can be present in a full `href`, hash route, or query fallback rather than
+  only `pathname`.
+- Even if the frontend composable loses context during mount/navigation timing, the backend request
+  still carries a same-page `Referer` for authenticated `/multitable/:sheetId/:viewId` pages in normal
+  deployments.
+
+## Design
+
+### Frontend context recovery
+
+`apps/web/src/multitable/composables/useMultitableGrid.ts` now resolves create context from:
+
+- explicit composable refs: `opts.sheetId`, `opts.viewId`
+- full browser location: `href`, `pathname`, `hash`, `search`
+- authenticated `/multitable/:sheetId/:viewId` route segments
+- hash-backed routes such as `#/multitable/:sheetId/:viewId`
+- query fallbacks such as `?sheetId=...&viewId=...`
+
+Public-form routes remain excluded, so an authenticated record-create request does not borrow
+`/multitable/public-form/:sheetId/:viewId`.
+
+### Backend last-resort recovery
+
+`packages/core-backend/src/routes/univer-meta.ts` now exports and uses
+`extractMultitableRecordCreateContextFromUrl()`.
+
+If the request body omits both `sheetId` and `viewId`, `POST /api/multitable/records` tries to recover
+context from `Referer` / `Referrer`. The recovered context then goes through the existing
+`resolveMetaSheetId()` and capability checks. This is not a permission bypass: the authenticated user
+still needs sheet access, and public-form routes are ignored.
+
+## Expected Behavior
+
+For Data Factory staging links:
+
+1. User opens the generated authenticated `/multitable/...` staging table link.
+2. User clicks `+ New Record`.
+3. The create body includes `sheetId` / `viewId`, or the backend recovers them from Referer.
+4. The request reaches field-level validation.
+5. Empty Standard Materials create should surface required-field validation such as
+   `Material Code is required` instead of `sheetId or viewId is required`.
+
+## Deployment Impact
+
+- No migration.
+- No new API route.
+- No integration-core business-path change.
+- Safe to ship in the Windows on-prem package as a frontend/backend robustness fix.

--- a/docs/development/data-factory-issue651-record-create-referer-context-verification-20260517.md
+++ b/docs/development/data-factory-issue651-record-create-referer-context-verification-20260517.md
@@ -1,0 +1,101 @@
+# Data Factory Issue #651 Record Create Context Verification
+
+Date: 2026-05-17
+
+## Scope
+
+Verification covers the follow-up fix for the Windows on-prem C1 retest finding:
+
+```text
+400 VALIDATION_ERROR
+sheetId or viewId is required
+```
+
+The goal is to ensure `+ New Record` can recover `sheetId` / `viewId` from deployed multitable
+routes before field-level required validation runs.
+
+## Local Verification
+
+### Frontend grid regression
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-grid.spec.ts --watch=false
+```
+
+Result:
+
+```text
+45/45 pass
+```
+
+Coverage added:
+
+- authenticated `/multitable/:sheetId/:viewId` route fallback remains covered
+- hash-backed multitable route fallback
+- `sheetId` / `viewId` query fallback
+- public-form route exclusion remains covered
+- create request sends recovered `sheetId` / `viewId`
+
+### Backend context helper
+
+Command:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/multitable-record-create-context.test.ts --reporter=dot
+```
+
+Result:
+
+```text
+4/4 pass
+```
+
+Coverage added:
+
+- Referer-style authenticated multitable URL extracts `sheetId` / `viewId`
+- hash-backed multitable URL extracts `sheetId` / `viewId`
+- query fallback extracts `sheetId` / `viewId`
+- public-form URL is ignored
+
+### Typecheck and build gates
+
+Commands:
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/web build
+git diff --check origin/main...HEAD
+```
+
+Results:
+
+```text
+vue-tsc: pass
+core-backend build: pass
+web build: pass
+diff-check: pass
+```
+
+## Security Checks
+
+- Public-form context is not reused for authenticated record creation.
+- Referer-derived context still goes through existing sheet resolution and capability checks.
+- No token, password, SQL connection string, or K3 secret is logged or added to docs.
+
+## Expected Physical-Box Retest
+
+After merge and official Windows package rebuild:
+
+1. Deploy the new package.
+2. Open Data Factory.
+3. Use the Standard Materials staging card generated multitable link.
+4. Click `+ New Record`.
+
+Expected result:
+
+- No `sheetId or viewId is required`.
+- No generic `500 Failed to create meta record`.
+- Empty Standard Materials create reaches field-level validation and can show required-field toast.

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -2776,6 +2776,53 @@ async function resolveMetaSheetId(
   return { sheetId: viewId, view: null }
 }
 
+function normalizeRecordCreateContextId(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined
+}
+
+function decodeRecordCreateRoutePart(value: string | undefined): string | undefined {
+  if (!value) return undefined
+  try {
+    return normalizeRecordCreateContextId(decodeURIComponent(value))
+  } catch {
+    return normalizeRecordCreateContextId(value)
+  }
+}
+
+export function extractMultitableRecordCreateContextFromUrl(value: unknown): { sheetId?: string; viewId?: string } {
+  const raw = typeof value === 'string' ? value.trim() : ''
+  if (!raw) return {}
+
+  const candidates = [raw]
+  let queryContext: { sheetId?: string; viewId?: string } = {}
+  try {
+    const url = new URL(raw, 'http://metasheet.local')
+    candidates.push(url.pathname)
+    if (url.hash) candidates.push(url.hash.slice(1))
+    queryContext = {
+      sheetId: decodeRecordCreateRoutePart(url.searchParams.get('sheetId') ?? undefined),
+      viewId: decodeRecordCreateRoutePart(url.searchParams.get('viewId') ?? undefined),
+    }
+  } catch {
+    const hashIndex = raw.indexOf('#')
+    if (hashIndex >= 0) candidates.push(raw.slice(hashIndex + 1))
+  }
+
+  for (const candidate of candidates) {
+    const pathname = candidate.replace(/^#/, '').split(/[?#]/)[0]
+    const segments = pathname.split('/').filter(Boolean)
+    const multitableIndex = segments.lastIndexOf('multitable')
+    if (multitableIndex < 0) continue
+    if (segments[multitableIndex + 1] === 'public-form') return {}
+    const sheetId = decodeRecordCreateRoutePart(segments[multitableIndex + 1])
+    const viewId = decodeRecordCreateRoutePart(segments[multitableIndex + 2])
+    if (sheetId || viewId) return { sheetId, viewId }
+  }
+
+  if (queryContext.sheetId || queryContext.viewId) return queryContext
+  return {}
+}
+
 async function createSeededSheet(args: { sheetId: string; name: string; description?: string | null; query?: QueryFn }): Promise<void> {
   const pool = poolManager.get()
 
@@ -4347,9 +4394,12 @@ export function univerMetaRouter(): Router {
 
     try {
       const pool = poolManager.get()
+      const refererContext = extractMultitableRecordCreateContextFromUrl(
+        req.get('referer') ?? req.get('referrer'),
+      )
       const resolved = await resolveMetaSheetId(pool as unknown as { query: QueryFn }, {
-        sheetId: parsed.data.sheetId,
-        viewId: parsed.data.viewId,
+        sheetId: parsed.data.sheetId ?? refererContext.sheetId,
+        viewId: parsed.data.viewId ?? refererContext.viewId,
       })
       const sheetId = resolved.sheetId
       const viewConfig = resolved.view

--- a/packages/core-backend/tests/unit/multitable-record-create-context.test.ts
+++ b/packages/core-backend/tests/unit/multitable-record-create-context.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'vitest'
+import { extractMultitableRecordCreateContextFromUrl } from '../../src/routes/univer-meta'
+
+describe('multitable record-create context helpers', () => {
+  test('extracts sheet and view ids from an authenticated multitable route', () => {
+    expect(extractMultitableRecordCreateContextFromUrl(
+      'http://localhost:8081/multitable/sheet_standard_materials/view_grid?baseId=base_legacy',
+    )).toEqual({
+      sheetId: 'sheet_standard_materials',
+      viewId: 'view_grid',
+    })
+  })
+
+  test('extracts sheet and view ids from a hash-backed multitable route', () => {
+    expect(extractMultitableRecordCreateContextFromUrl(
+      'http://localhost:8081/#/multitable/sheet_hash_materials/view_hash_grid?baseId=base_legacy',
+    )).toEqual({
+      sheetId: 'sheet_hash_materials',
+      viewId: 'view_hash_grid',
+    })
+  })
+
+  test('extracts sheet and view ids from query parameters as a final fallback', () => {
+    expect(extractMultitableRecordCreateContextFromUrl(
+      'http://localhost:8081/grid?sheetId=sheet_query_materials&viewId=view_query_grid',
+    )).toEqual({
+      sheetId: 'sheet_query_materials',
+      viewId: 'view_query_grid',
+    })
+  })
+
+  test('does not extract public-form context for authenticated record creation', () => {
+    expect(extractMultitableRecordCreateContextFromUrl(
+      'http://localhost:8081/multitable/public-form/sheet_public/view_public',
+    )).toEqual({})
+  })
+})


### PR DESCRIPTION
## Summary

Closes the latest #651 C1 retest gap where the Windows package returned `400 VALIDATION_ERROR: sheetId or viewId is required` from `+ New Record` even after the authenticated multitable staging route opened successfully.

This PR adds two narrow fallbacks:
- Frontend `useMultitableGrid.createRecord()` now resolves create context from full browser location: href, pathname, hash, and query params, not only pathname.
- Backend `POST /api/multitable/records` recovers missing context from authenticated multitable Referer/Referrer as a last resort before existing sheet resolution and capability checks.

Public-form routes remain excluded.

## Verification

- `pnpm --filter @metasheet/web exec vitest run tests/multitable-grid.spec.ts --watch=false` — 45/45 pass
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/multitable-record-create-context.test.ts --reporter=dot` — 4/4 pass
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit` — pass
- `pnpm --filter @metasheet/core-backend build` — pass
- `pnpm --filter @metasheet/web build` — pass
- `git diff --check` — pass

## Deployment impact

No migration. No new route. No integration-core business-path change. Intended retest path after merge/package rebuild: Data Factory staging link -> real /multitable/... route -> + New Record should reach field-level required validation instead of failing with missing sheet/view context.
