### PR TITLE
feat(multitable): make multitable the default table entry

### DIFF
--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -17,8 +17,7 @@
           <template v-else>
             <router-link v-if="hasFeature('attendance')" to="/attendance" class="nav-link">{{ navLabels.attendance }}</router-link>
             <router-link to="/apps" class="nav-link">{{ navLabels.apps }}</router-link>
-            <router-link to="/grid" class="nav-link">{{ navLabels.grid }}</router-link>
-            <router-link to="/spreadsheets" class="nav-link">{{ navLabels.spreadsheets }}</router-link>
+            <router-link to="/multitable" class="nav-link">{{ navLabels.multitable }}</router-link>
             <router-link to="/kanban" class="nav-link">{{ navLabels.kanban }}</router-link>
             <router-link to="/calendar" class="nav-link">{{ navLabels.calendar }}</router-link>
             <router-link to="/gallery" class="nav-link">{{ navLabels.gallery }}</router-link>
@@ -119,8 +118,7 @@ const navLabels = computed(() => {
   if (isZh.value) {
     return {
       attendance: '考勤',
-      grid: '表格',
-      spreadsheets: '电子表格',
+      multitable: '多维表',
       kanban: '看板',
       calendar: '日历',
       gallery: '画廊',
@@ -145,8 +143,7 @@ const navLabels = computed(() => {
   }
   return {
     attendance: 'Attendance',
-    grid: 'Grid',
-    spreadsheets: 'Spreadsheets',
+    multitable: 'Multitable',
     kanban: 'Kanban',
     calendar: 'Calendar',
     gallery: 'Gallery',

--- a/apps/web/src/router/appRoutes.ts
+++ b/apps/web/src/router/appRoutes.ts
@@ -9,6 +9,7 @@ import FormView from '../views/FormView.vue'
 import PlmProductView from '../views/PlmProductView.vue'
 import SpreadsheetsView from '../views/SpreadsheetsView.vue'
 import SpreadsheetDetailView from '../views/SpreadsheetDetailView.vue'
+import MultitableHomeView from '../views/MultitableHomeView.vue'
 import MultitableCommentInboxView from '../views/MultitableCommentInboxView.vue'
 import PluginManagerView from '../views/PluginManagerView.vue'
 import PluginViewHost from '../views/PluginViewHost.vue'
@@ -109,6 +110,12 @@ export const appRoutes: RouteRecordRaw[] = [
     name: 'plugin-attendance-legacy-view',
     redirect: '/attendance',
     meta: { title: 'Attendance', titleZh: '考勤', requiresAuth: true, requiredFeature: 'attendance' },
+  },
+  {
+    path: ROUTE_PATHS.MULTITABLE_HOME,
+    name: AppRouteNames.MULTITABLE_HOME,
+    component: MultitableHomeView,
+    meta: { title: 'Multitable', titleZh: '多维表', requiresAuth: true },
   },
   buildPublicMultitableFormRoute(() => import('../views/PublicMultitableFormView.vue')),
   buildMultitableRoute(() => import('../multitable/views/MultitableEmbedHost.vue')),

--- a/apps/web/src/router/types.ts
+++ b/apps/web/src/router/types.ts
@@ -149,6 +149,7 @@ export interface AppRouteParams {
   'approval-pending': Record<string, never>
   'approval-history': Record<string, never>
   'attendance': Record<string, never>
+  'multitable-home': Record<string, never>
   'multitable': { sheetId: string; viewId: string }
   'multitable-public-form': { sheetId: string; viewId: string }
   'multitable-comment-inbox': Record<string, never>

--- a/apps/web/src/router/types.ts
+++ b/apps/web/src/router/types.ts
@@ -72,6 +72,7 @@ export const AppRouteNames = {
 
   // Attendance routes
   ATTENDANCE: 'attendance',
+  MULTITABLE_HOME: 'multitable-home',
   MULTITABLE: 'multitable',
   MULTITABLE_PUBLIC_FORM: 'multitable-public-form',
   MULTITABLE_COMMENT_INBOX: 'multitable-comment-inbox',
@@ -433,6 +434,7 @@ export const ROUTE_PATHS = {
 
   // Attendance
   ATTENDANCE: '/attendance',
+  MULTITABLE_HOME: '/multitable',
   MULTITABLE: '/multitable/:sheetId/:viewId',
   MULTITABLE_PUBLIC_FORM: '/multitable/public-form/:sheetId/:viewId',
   MULTITABLE_COMMENT_INBOX: '/multitable/comments/inbox',

--- a/apps/web/src/stores/featureFlags.ts
+++ b/apps/web/src/stores/featureFlags.ts
@@ -338,7 +338,7 @@ function resolveHomePath(): string {
   if (isAttendanceFocused()) return '/attendance'
   if (isPlmWorkbenchFocused()) return '/plm'
   if (state.features.attendance && !state.features.plm) return '/attendance'
-  return '/grid'
+  return '/multitable'
 }
 
 export function useFeatureFlags() {

--- a/apps/web/src/views/MultitableHomeView.vue
+++ b/apps/web/src/views/MultitableHomeView.vue
@@ -1,0 +1,360 @@
+<template>
+  <section class="multitable-home">
+    <header class="multitable-home__hero">
+      <div>
+        <p class="multitable-home__eyebrow">Multitable</p>
+        <h1>多维表</h1>
+        <p class="multitable-home__subtitle">
+          打开 Base、继续清洗表或从模板开始。Grid 和 Spreadsheets 仍保留旧链接，但默认工作入口收敛到多维表。
+        </p>
+      </div>
+      <button class="multitable-home__refresh" :disabled="loading" @click="loadBases">
+        {{ loading ? '刷新中...' : '刷新' }}
+      </button>
+    </header>
+
+    <section class="multitable-home__create" aria-label="Create multitable base">
+      <div>
+        <strong>新建 Base</strong>
+        <span>创建一个带默认 Sheet 和 Grid 视图的多维表工作区。</span>
+      </div>
+      <form class="multitable-home__create-form" @submit.prevent="createBaseAndOpen">
+        <input
+          v-model="newBaseName"
+          class="multitable-home__input"
+          maxlength="255"
+          placeholder="例如：项目跟进"
+          aria-label="Base name"
+        />
+        <button class="multitable-home__primary" :disabled="creating">
+          {{ creating ? '创建中...' : '创建并打开' }}
+        </button>
+      </form>
+    </section>
+
+    <p v-if="errorMessage" class="multitable-home__error" role="alert">{{ errorMessage }}</p>
+
+    <section class="multitable-home__panel">
+      <div class="multitable-home__panel-head">
+        <h2>可访问的 Base</h2>
+        <span>{{ bases.length }} 个</span>
+      </div>
+
+      <div v-if="loading" class="multitable-home__state">正在加载多维表...</div>
+      <div v-else-if="!bases.length" class="multitable-home__empty">
+        暂无可访问的 Base。你可以新建一个，或从数据工厂/考勤等业务入口生成多维表。
+      </div>
+      <div v-else class="multitable-home__grid">
+        <article v-for="base in bases" :key="base.id" class="multitable-home__card">
+          <div class="multitable-home__card-icon" :style="{ background: base.color || '#2563eb' }">
+            {{ base.icon || base.name.slice(0, 1).toUpperCase() }}
+          </div>
+          <div class="multitable-home__card-body">
+            <h3>{{ base.name }}</h3>
+            <small>{{ base.id }}</small>
+          </div>
+          <button
+            class="multitable-home__open"
+            :disabled="openingBaseId === base.id"
+            @click="openBase(base)"
+          >
+            {{ openingBaseId === base.id ? '打开中...' : '打开' }}
+          </button>
+        </article>
+      </div>
+    </section>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { multitableClient } from '../multitable/api/client'
+import type { MetaBase, MetaContext, MetaSheet, MetaView } from '../multitable/types'
+import { AppRouteNames } from '../router/types'
+
+const router = useRouter()
+
+const bases = ref<MetaBase[]>([])
+const loading = ref(false)
+const creating = ref(false)
+const openingBaseId = ref<string | null>(null)
+const errorMessage = ref('')
+const newBaseName = ref('')
+
+function resolveOpenTarget(context: MetaContext): { sheet: MetaSheet; view: MetaView } | null {
+  const sheet = context.sheet ?? context.sheets[0] ?? null
+  if (!sheet) return null
+  const view = context.views.find((candidate) => candidate.sheetId === sheet.id) ?? context.views[0] ?? null
+  return view ? { sheet, view } : null
+}
+
+async function loadBases(): Promise<void> {
+  loading.value = true
+  errorMessage.value = ''
+  try {
+    const data = await multitableClient.listBases()
+    bases.value = data.bases ?? []
+  } catch (error) {
+    errorMessage.value = error instanceof Error ? error.message : '加载多维表失败'
+  } finally {
+    loading.value = false
+  }
+}
+
+async function openBase(base: MetaBase): Promise<void> {
+  openingBaseId.value = base.id
+  errorMessage.value = ''
+  try {
+    const context = await multitableClient.loadContext({ baseId: base.id })
+    const target = resolveOpenTarget(context)
+    if (!target) {
+      errorMessage.value = '这个 Base 还没有可打开的 Sheet 或 View。'
+      return
+    }
+    await router.push({
+      name: AppRouteNames.MULTITABLE,
+      params: { sheetId: target.sheet.id, viewId: target.view.id },
+      query: { baseId: base.id },
+    })
+  } catch (error) {
+    errorMessage.value = error instanceof Error ? error.message : '打开多维表失败'
+  } finally {
+    openingBaseId.value = null
+  }
+}
+
+async function createBaseAndOpen(): Promise<void> {
+  if (creating.value) return
+  creating.value = true
+  errorMessage.value = ''
+  try {
+    const name = newBaseName.value.trim() || 'Untitled Base'
+    const { base } = await multitableClient.createBase({ name })
+    const { sheet } = await multitableClient.createSheet({ baseId: base.id, name: 'Sheet 1', seed: true })
+    const context = await multitableClient.loadContext({ baseId: base.id, sheetId: sheet.id })
+    const target = resolveOpenTarget(context)
+    if (!target) {
+      errorMessage.value = 'Base 已创建，但默认视图尚未就绪。请刷新后重试。'
+      await loadBases()
+      return
+    }
+    await router.push({
+      name: AppRouteNames.MULTITABLE,
+      params: { sheetId: target.sheet.id, viewId: target.view.id },
+      query: { baseId: base.id },
+    })
+  } catch (error) {
+    errorMessage.value = error instanceof Error ? error.message : '创建多维表失败'
+  } finally {
+    creating.value = false
+  }
+}
+
+onMounted(loadBases)
+</script>
+
+<style scoped>
+.multitable-home {
+  min-height: calc(100vh - 64px);
+  padding: 32px;
+  background:
+    radial-gradient(circle at 12% 8%, rgba(37, 99, 235, 0.12), transparent 28%),
+    linear-gradient(135deg, #f8fafc 0%, #eef2ff 48%, #f8fafc 100%);
+  color: #0f172a;
+}
+
+.multitable-home__hero,
+.multitable-home__create,
+.multitable-home__panel {
+  max-width: 1120px;
+  margin: 0 auto;
+}
+
+.multitable-home__hero {
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  align-items: flex-start;
+}
+
+.multitable-home__eyebrow {
+  margin: 0 0 8px;
+  color: #2563eb;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.multitable-home h1 {
+  margin: 0;
+  font-size: clamp(32px, 5vw, 58px);
+  line-height: 0.95;
+}
+
+.multitable-home__subtitle {
+  max-width: 720px;
+  margin: 16px 0 0;
+  color: #475569;
+  font-size: 16px;
+  line-height: 1.7;
+}
+
+.multitable-home__refresh,
+.multitable-home__primary,
+.multitable-home__open {
+  border: 0;
+  border-radius: 999px;
+  padding: 10px 16px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.multitable-home__refresh {
+  background: #fff;
+  color: #1e293b;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+}
+
+.multitable-home__create {
+  margin-top: 28px;
+  display: flex;
+  justify-content: space-between;
+  gap: 20px;
+  align-items: center;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  border-radius: 24px;
+  padding: 18px;
+  background: rgba(255, 255, 255, 0.76);
+  backdrop-filter: blur(14px);
+}
+
+.multitable-home__create strong,
+.multitable-home__create span {
+  display: block;
+}
+
+.multitable-home__create span {
+  margin-top: 4px;
+  color: #64748b;
+  font-size: 13px;
+}
+
+.multitable-home__create-form {
+  display: flex;
+  gap: 10px;
+  min-width: min(460px, 100%);
+}
+
+.multitable-home__input {
+  flex: 1;
+  min-width: 0;
+  border: 1px solid #cbd5e1;
+  border-radius: 999px;
+  padding: 10px 14px;
+  font-size: 14px;
+}
+
+.multitable-home__primary,
+.multitable-home__open {
+  background: #2563eb;
+  color: #fff;
+}
+
+.multitable-home__panel {
+  margin-top: 24px;
+  border: 1px solid rgba(148, 163, 184, 0.36);
+  border-radius: 28px;
+  background: rgba(255, 255, 255, 0.82);
+  box-shadow: 0 24px 70px rgba(15, 23, 42, 0.08);
+  overflow: hidden;
+}
+
+.multitable-home__panel-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 22px 24px;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.multitable-home__panel-head h2 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.multitable-home__state,
+.multitable-home__empty {
+  padding: 32px 24px;
+  color: #64748b;
+}
+
+.multitable-home__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 14px;
+  padding: 18px;
+}
+
+.multitable-home__card {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 12px;
+  align-items: center;
+  border: 1px solid #e2e8f0;
+  border-radius: 18px;
+  padding: 14px;
+  background: #fff;
+}
+
+.multitable-home__card-icon {
+  width: 42px;
+  height: 42px;
+  border-radius: 14px;
+  display: grid;
+  place-items: center;
+  color: #fff;
+  font-weight: 800;
+}
+
+.multitable-home__card-body h3 {
+  margin: 0;
+  font-size: 15px;
+}
+
+.multitable-home__card-body small {
+  color: #64748b;
+}
+
+.multitable-home__error {
+  max-width: 1120px;
+  margin: 18px auto 0;
+  border: 1px solid #fecaca;
+  border-radius: 16px;
+  padding: 12px 14px;
+  background: #fef2f2;
+  color: #b91c1c;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.62;
+}
+
+@media (max-width: 760px) {
+  .multitable-home {
+    padding: 20px;
+  }
+
+  .multitable-home__hero,
+  .multitable-home__create {
+    display: grid;
+  }
+
+  .multitable-home__create-form {
+    min-width: 0;
+    display: grid;
+  }
+}
+</style>

--- a/apps/web/tests/multitable-home-view.spec.ts
+++ b/apps/web/tests/multitable-home-view.spec.ts
@@ -1,0 +1,138 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick, type App as VueApp, type Component } from 'vue'
+import MultitableHomeView from '../src/views/MultitableHomeView.vue'
+import { AppRouteNames } from '../src/router/types'
+
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  listBases: vi.fn(),
+  loadContext: vi.fn(),
+  createBase: vi.fn(),
+  createSheet: vi.fn(),
+}))
+
+vi.mock('vue-router', async () => {
+  const actual = await vi.importActual<typeof import('vue-router')>('vue-router')
+  return {
+    ...actual,
+    useRouter: () => ({
+      push: mocks.push,
+    }),
+  }
+})
+
+vi.mock('../src/multitable/api/client', () => ({
+  multitableClient: {
+    listBases: mocks.listBases,
+    loadContext: mocks.loadContext,
+    createBase: mocks.createBase,
+    createSheet: mocks.createSheet,
+  },
+}))
+
+async function flushUi(cycles = 4): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+function findButton(container: HTMLElement, text: string, opts: { exact?: boolean } = {}): HTMLButtonElement {
+  const button = Array.from(container.querySelectorAll('button'))
+    .find((node) => {
+      const content = node.textContent?.trim() ?? ''
+      return opts.exact ? content === text : content.includes(text)
+    })
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error(`Button not found: ${text}`)
+  }
+  return button
+}
+
+describe('MultitableHomeView', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+    vi.clearAllMocks()
+  })
+
+  function mountView() {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(MultitableHomeView as Component)
+    app.component('router-link', {
+      props: ['to'],
+      render() {
+        return h('a', { href: this.$props.to }, this.$slots.default ? this.$slots.default() : [])
+      },
+    })
+    app.mount(container)
+    return container
+  }
+
+  it('lists bases and opens the first sheet/view for a base', async () => {
+    mocks.listBases.mockResolvedValue({
+      bases: [{ id: 'base_ops', name: 'Ops Base', color: '#0f766e' }],
+    })
+    mocks.loadContext.mockResolvedValue({
+      base: { id: 'base_ops', name: 'Ops Base' },
+      sheet: { id: 'sheet_ops', baseId: 'base_ops', name: 'Orders' },
+      sheets: [{ id: 'sheet_ops', baseId: 'base_ops', name: 'Orders' }],
+      views: [{ id: 'view_grid', sheetId: 'sheet_ops', name: 'Grid', type: 'grid' }],
+      capabilities: {},
+    })
+
+    const root = mountView()
+    await flushUi()
+
+    expect(root.textContent).toContain('Ops Base')
+
+    findButton(root, '打开', { exact: true }).click()
+    await flushUi()
+
+    expect(mocks.loadContext).toHaveBeenCalledWith({ baseId: 'base_ops' })
+    expect(mocks.push).toHaveBeenCalledWith({
+      name: AppRouteNames.MULTITABLE,
+      params: { sheetId: 'sheet_ops', viewId: 'view_grid' },
+      query: { baseId: 'base_ops' },
+    })
+  })
+
+  it('creates a base with a seeded sheet before opening multitable', async () => {
+    mocks.listBases.mockResolvedValue({ bases: [] })
+    mocks.createBase.mockResolvedValue({ base: { id: 'base_new', name: 'Project Tracker' } })
+    mocks.createSheet.mockResolvedValue({ sheet: { id: 'sheet_new', baseId: 'base_new', name: 'Sheet 1', seeded: true } })
+    mocks.loadContext.mockResolvedValue({
+      base: { id: 'base_new', name: 'Project Tracker' },
+      sheet: { id: 'sheet_new', baseId: 'base_new', name: 'Sheet 1' },
+      sheets: [{ id: 'sheet_new', baseId: 'base_new', name: 'Sheet 1' }],
+      views: [{ id: 'view_new', sheetId: 'sheet_new', name: 'Grid', type: 'grid' }],
+      capabilities: {},
+    })
+
+    const root = mountView()
+    await flushUi()
+
+    const input = root.querySelector('input[aria-label="Base name"]')
+    expect(input).toBeInstanceOf(HTMLInputElement)
+    ;(input as HTMLInputElement).value = 'Project Tracker'
+    input?.dispatchEvent(new Event('input'))
+
+    findButton(root, '创建并打开').click()
+    await flushUi()
+
+    expect(mocks.createBase).toHaveBeenCalledWith({ name: 'Project Tracker' })
+    expect(mocks.createSheet).toHaveBeenCalledWith({ baseId: 'base_new', name: 'Sheet 1', seed: true })
+    expect(mocks.loadContext).toHaveBeenCalledWith({ baseId: 'base_new', sheetId: 'sheet_new' })
+    expect(mocks.push).toHaveBeenCalledWith({
+      name: AppRouteNames.MULTITABLE,
+      params: { sheetId: 'sheet_new', viewId: 'view_new' },
+      query: { baseId: 'base_new' },
+    })
+  })
+})

--- a/apps/web/tests/platform-shell-nav.spec.ts
+++ b/apps/web/tests/platform-shell-nav.spec.ts
@@ -103,8 +103,11 @@ describe('platform shell navigation', () => {
 
     expect(links).toEqual(expect.arrayContaining([
       expect.objectContaining({ href: '/attendance', text: '考勤' }),
+      expect.objectContaining({ href: '/multitable', text: '多维表' }),
       expect.objectContaining({ href: '/approvals', text: '审批中心' }),
     ]))
+    expect(links.some((link) => link.href === '/grid')).toBe(false)
+    expect(links.some((link) => link.href === '/spreadsheets')).toBe(false)
     expect(links.some((link) => link.href === '/plm')).toBe(false)
     expect(links.some((link) => link.href === '/plm/audit')).toBe(false)
     expect(links.some((link) => link.href === '/integrations/k3-wise')).toBe(false)
@@ -188,8 +191,11 @@ describe('platform shell navigation', () => {
     }))
 
     expect(links).toEqual(expect.arrayContaining([
+      expect.objectContaining({ href: '/multitable', text: '多维表' }),
       expect.objectContaining({ href: '/integrations/workbench', text: '数据工厂' }),
     ]))
+    expect(links.some((link) => link.href === '/grid')).toBe(false)
+    expect(links.some((link) => link.href === '/spreadsheets')).toBe(false)
     expect(links.some((link) => link.href === '/admin/users')).toBe(false)
   })
 

--- a/docs/development/multitable-default-entry-development-20260517.md
+++ b/docs/development/multitable-default-entry-development-20260517.md
@@ -1,0 +1,82 @@
+# Multitable Default Entry Development - 2026-05-17
+
+## Purpose
+
+This change makes Multitable the default table-facing product entry.
+
+Before this slice, the platform shell exposed legacy `/grid` and `/spreadsheets` links as first-class navigation items and the platform home redirect defaulted to `/grid`. That was misleading because `/grid` and `/spreadsheets` are legacy spreadsheet/cell-model surfaces, while the Feishu Base parity work lives under `/multitable/:sheetId/:viewId`.
+
+## Scope
+
+In scope:
+
+- Add a `/multitable` home route.
+- Add a lightweight Multitable home page that lists accessible bases and opens the first available sheet/view.
+- Allow creating a new Base plus seeded Sheet from the Multitable home page.
+- Remove `/grid` and `/spreadsheets` from the default platform navigation.
+- Keep `/grid` and `/spreadsheets` routes alive for backward compatibility.
+- Change platform home/onboarding defaults from `/grid` to `/multitable`.
+- Update tests for the new navigation contract and Multitable home behavior.
+
+Out of scope:
+
+- No deletion of legacy Grid or Spreadsheet routes.
+- No migration, schema change, or backend route rewrite.
+- No changes to the `/api/spreadsheets` cell model.
+- No changes to Data Factory, K3, Attendance, DingTalk, or Phase 3 deferred lanes.
+
+## Implementation
+
+### Route Contract
+
+`apps/web/src/router/types.ts` now defines:
+
+- `AppRouteNames.MULTITABLE_HOME`
+- `ROUTE_PATHS.MULTITABLE_HOME = '/multitable'`
+
+`apps/web/src/router/appRoutes.ts` registers the static `/multitable` route before the parameterized `/multitable/:sheetId/:viewId` route. This ordering is required so the home page is not interpreted as `{ sheetId: 'multitable' }`.
+
+### Home Page
+
+`apps/web/src/views/MultitableHomeView.vue` is intentionally small and uses the existing `MultitableApiClient`:
+
+- `listBases()` loads accessible bases.
+- `loadContext({ baseId })` resolves the first sheet/view when opening a base.
+- `createBase({ name })` plus `createSheet({ baseId, name: 'Sheet 1', seed: true })` creates an immediately usable workspace.
+- Navigation uses `AppRouteNames.MULTITABLE` and preserves `baseId` in query params.
+
+This avoids adding a new backend endpoint and keeps the home page aligned with existing workbench context semantics.
+
+### Navigation
+
+`apps/web/src/App.vue` now shows a single Multitable nav link in the default platform shell:
+
+- Removed primary nav links to `/grid` and `/spreadsheets`.
+- Added primary nav link to `/multitable`.
+
+The old routes still exist in `appRoutes.ts`, so existing deep links and legacy tests remain valid.
+
+### Default Home
+
+`apps/web/src/stores/featureFlags.ts` now returns `/multitable` for the generic platform home. Attendance-focused and PLM-focused modes keep their existing redirects.
+
+`packages/core-backend/src/auth/access-presets.ts` now sets platform onboarding `homePath` to `/multitable` and grants `multitable:read` / `multitable:write` in the platform presets while preserving legacy spreadsheet permissions.
+
+## Files
+
+- `apps/web/src/views/MultitableHomeView.vue`
+- `apps/web/src/router/types.ts`
+- `apps/web/src/router/appRoutes.ts`
+- `apps/web/src/App.vue`
+- `apps/web/src/stores/featureFlags.ts`
+- `apps/web/tests/multitable-home-view.spec.ts`
+- `apps/web/tests/platform-shell-nav.spec.ts`
+- `packages/core-backend/src/auth/access-presets.ts`
+
+## Compatibility Notes
+
+- `/grid` remains routable.
+- `/spreadsheets` and `/spreadsheets/:id` remain routable.
+- `/api/spreadsheets` remains untouched.
+- This change is presentation and entry-routing only; it does not merge the spreadsheet cell model into Multitable.
+

--- a/docs/development/multitable-default-entry-verification-20260517.md
+++ b/docs/development/multitable-default-entry-verification-20260517.md
@@ -1,0 +1,133 @@
+# Multitable Default Entry Verification - 2026-05-17
+
+## Result
+
+PASS.
+
+The change was validated in a clean worktree:
+
+`/private/tmp/ms2-multitable-entry-20260517`
+
+Base commit:
+
+`origin/main @ bded0c60a`
+
+## Commands
+
+### V1 - Install
+
+Command:
+
+```bash
+pnpm install --frozen-lockfile --ignore-scripts
+```
+
+Result:
+
+PASS.
+
+Notes:
+
+- Lockfile was already up to date.
+- No package or lockfile changes were produced.
+
+### V2 - Focused Frontend Tests
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/multitable-home-view.spec.ts \
+  tests/platform-shell-nav.spec.ts \
+  --watch=false
+```
+
+Result:
+
+PASS.
+
+Observed:
+
+- `tests/platform-shell-nav.spec.ts`: 3/3 pass.
+- `tests/multitable-home-view.spec.ts`: 2/2 pass.
+- Total: 5/5 pass.
+
+Non-blocking note:
+
+- Vitest printed `WebSocket server error: Port is already in use`.
+- The test process still exited 0 and all assertions passed.
+
+### V3 - Frontend Type Check
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+```
+
+Result:
+
+PASS.
+
+### V4 - Backend Type Check
+
+Command:
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+```
+
+Result:
+
+PASS.
+
+### V5 - Backend Preset Tests
+
+Command:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/admin-users-routes.test.ts \
+  tests/unit/attendance-import-permission.test.ts \
+  --run
+```
+
+Result:
+
+PASS.
+
+Observed:
+
+- 2 test files passed.
+- 63/63 tests passed.
+
+### V6 - Diff Hygiene
+
+Command:
+
+```bash
+git diff --check
+```
+
+Result:
+
+PASS.
+
+## Assertions Covered
+
+- Platform shell shows `/multitable` as the table entry.
+- Platform shell does not show `/grid`.
+- Platform shell does not show `/spreadsheets`.
+- Multitable home lists bases from `listBases()`.
+- Opening a base resolves context with `loadContext({ baseId })`.
+- Opening a base navigates to `AppRouteNames.MULTITABLE`.
+- Creating a base creates a seeded first sheet before navigation.
+- Platform onboarding presets now point at `/multitable`.
+- TypeScript accepts the new route constants and view.
+
+## Not Verified
+
+- No live browser smoke was run.
+- No backend integration DB test was run for real base creation.
+- No `/api/spreadsheets` behavior was re-tested because this slice intentionally does not modify legacy Spreadsheet APIs.
+

--- a/packages/core-backend/src/auth/access-presets.ts
+++ b/packages/core-backend/src/auth/access-presets.ts
@@ -34,10 +34,10 @@ const ACCESS_PRESETS: AccessPresetDefinition[] = [
     description: '适用于多维表与基础流程协作成员。',
     productMode: 'platform',
     role: 'user',
-    permissions: ['spreadsheet:read', 'spreadsheet:write', 'spreadsheets:read', 'spreadsheets:write', 'workflow:read'],
-    homePath: '/grid',
+    permissions: ['multitable:read', 'multitable:write', 'spreadsheet:read', 'spreadsheet:write', 'spreadsheets:read', 'spreadsheets:write', 'workflow:read'],
+    homePath: '/multitable',
     welcomeTitle: 'MetaSheet 平台协作',
-    checklist: ['登录后进入表格主页', '确认可访问表格与流程入口', '如需审批权限再由管理员追加授权'],
+    checklist: ['登录后进入多维表主页', '确认可访问多维表与流程入口', '如需审批权限再由管理员追加授权'],
   },
   {
     id: 'platform-viewer',
@@ -45,8 +45,8 @@ const ACCESS_PRESETS: AccessPresetDefinition[] = [
     description: '适用于只读查看表格与流程状态。',
     productMode: 'platform',
     role: 'user',
-    permissions: ['spreadsheet:read', 'spreadsheets:read', 'workflow:read'],
-    homePath: '/grid',
+    permissions: ['multitable:read', 'spreadsheet:read', 'spreadsheets:read', 'workflow:read'],
+    homePath: '/multitable',
     welcomeTitle: 'MetaSheet 平台只读访问',
     checklist: ['登录后确认只读访问范围', '如需编辑能力需管理员提升权限'],
   },
@@ -137,7 +137,7 @@ export function buildOnboardingPacket(options: {
   inviteToken?: string | null
 }): OnboardingPacket {
   const productMode = options.preset?.productMode || 'platform'
-  const homePath = options.preset?.homePath || '/grid'
+  const homePath = options.preset?.homePath || '/multitable'
   const loginPath = '/login'
   const acceptInvitePath = '/accept-invite'
   const appBase = resolvePublicAppBase()


### PR DESCRIPTION
## Summary

- Adds `/multitable` as the default Multitable home route with a Base list, open flow, and create-then-open flow.
- Removes legacy `/grid` and `/spreadsheets` from the default platform nav while keeping their routes intact for old links.
- Changes generic platform home/onboarding defaults from `/grid` to `/multitable` and grants platform presets multitable permissions.
- Adds development and verification MD under `docs/development/`.

## Verification

- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-home-view.spec.ts tests/platform-shell-nav.spec.ts --watch=false` — 5/5 pass
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit` — pass
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit` — pass
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/admin-users-routes.test.ts tests/unit/attendance-import-permission.test.ts --run` — 63/63 pass
- `git diff --check` — pass

## Notes

`/grid`, `/spreadsheets`, and `/api/spreadsheets` remain available; this PR only changes the primary product entry and navigation emphasis.
