### PR TITLE
fix(data-factory): enable safe connector delete

### DIFF
--- a/apps/web/src/services/integration/workbench.ts
+++ b/apps/web/src/services/integration/workbench.ts
@@ -56,6 +56,11 @@ export interface WorkbenchExternalSystemUpsertRequest extends IntegrationScope {
   credentials?: unknown
 }
 
+export interface WorkbenchExternalSystemDeleteResult {
+  deleted: true
+  system: WorkbenchExternalSystem
+}
+
 export interface IntegrationConnectionTestResult {
   ok: boolean
   status?: string | number
@@ -358,6 +363,20 @@ export async function upsertWorkbenchExternalSystem(
     body: JSON.stringify(payload),
   })
   return parseIntegrationResponse<WorkbenchExternalSystem>(response)
+}
+
+export async function deleteWorkbenchExternalSystem(
+  systemId: string,
+  scope: IntegrationScope = {},
+): Promise<WorkbenchExternalSystemDeleteResult> {
+  const query = buildQueryString({
+    tenantId: scope.tenantId,
+    workspaceId: scope.workspaceId,
+  })
+  const response = await apiFetch(`/api/integration/external-systems/${encodeURIComponent(systemId)}${query ? `?${query}` : ''}`, {
+    method: 'DELETE',
+  })
+  return parseIntegrationResponse<WorkbenchExternalSystemDeleteResult>(response)
 }
 
 export async function listExternalSystemObjects(

--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -78,8 +78,8 @@
                 <button type="button" class="integration-workbench__icon-button" :data-testid="`deactivate-connection-${system.id}`" :disabled="system.status === 'inactive'" @click="deactivateConnection(system)">
                   停用
                 </button>
-                <button type="button" class="integration-workbench__icon-button" :data-testid="`delete-connection-${system.id}`" disabled title="当前后端未提供 DELETE /api/integration/external-systems/:id">
-                  删除待接口
+                <button type="button" class="integration-workbench__icon-button" :data-testid="`delete-connection-${system.id}`" :disabled="deletingConnectionId === system.id" title="只能删除未被 pipeline 引用的连接" @click="deleteConnection(system)">
+                  {{ deletingConnectionId === system.id ? '删除中' : '删除' }}
                 </button>
               </div>
             </li>
@@ -703,6 +703,7 @@ import { buildXlsxBuffer } from '../multitable/import/xlsx-mapping'
 import {
   canReadFromSystem,
   canWriteToSystem,
+  deleteWorkbenchExternalSystem,
   getDefaultIntegrationScope,
   isIntegrationScopedProjectId,
   normalizeIntegrationProjectId,
@@ -897,6 +898,7 @@ const connectionDraft = reactive<ConnectionDraft>({
 })
 const connectionDraftMode = ref<'new' | 'edit' | 'copy'>('new')
 const savingConnectionDraft = ref(false)
+const deletingConnectionId = ref('')
 
 const adapterMetadataByKind = computed(() => new Map(adapters.value.map((adapter) => [adapter.kind, adapter])))
 const inventorySummary = computed(() => `已加载 ${systems.value.length} 个连接 · ${adapters.value.length} 个适配器 · ${stagingDescriptors.value.length} 个 staging 表`)
@@ -1295,6 +1297,33 @@ async function deactivateConnection(system: WorkbenchExternalSystem): Promise<vo
     setStatus(`连接已停用：${system.name}`, 'success')
   } catch (error) {
     setStatus(error instanceof Error ? error.message : String(error), 'error')
+  }
+}
+
+function confirmConnectionDelete(system: WorkbenchExternalSystem): boolean {
+  if (typeof window === 'undefined' || typeof window.confirm !== 'function') return true
+  return window.confirm(`删除连接「${system.name}」？只有未被 pipeline 引用的连接会被后端删除。`)
+}
+
+function clearDeletedSystemState(systemId: string): void {
+  systems.value = systems.value.filter((system) => system.id !== systemId)
+  if (sourceSystemId.value === systemId) sourceSystemId.value = ''
+  if (targetSystemId.value === systemId) targetSystemId.value = ''
+  if (connectionDraft.id === systemId) resetConnectionDraft()
+  normalizeSystemSelections()
+}
+
+async function deleteConnection(system: WorkbenchExternalSystem): Promise<void> {
+  if (!confirmConnectionDelete(system)) return
+  deletingConnectionId.value = system.id
+  try {
+    await deleteWorkbenchExternalSystem(system.id, currentScope())
+    clearDeletedSystemState(system.id)
+    setStatus(`连接已删除：${system.name}`, 'success')
+  } catch (error) {
+    setStatus(error instanceof Error ? error.message : String(error), 'error')
+  } finally {
+    deletingConnectionId.value = ''
   }
 }
 

--- a/apps/web/tests/IntegrationWorkbenchView.spec.ts
+++ b/apps/web/tests/IntegrationWorkbenchView.spec.ts
@@ -37,9 +37,11 @@ describe('IntegrationWorkbenchView', () => {
   let originalCreateObjectURL: typeof URL.createObjectURL | undefined
   let originalRevokeObjectURL: typeof URL.revokeObjectURL | undefined
   let originalAnchorClick: typeof HTMLAnchorElement.prototype.click | undefined
+  let originalConfirm: typeof window.confirm | undefined
   let createObjectURLMock: ReturnType<typeof vi.fn>
   let revokeObjectURLMock: ReturnType<typeof vi.fn>
   let anchorClickMock: ReturnType<typeof vi.fn>
+  let confirmMock: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
     apiFetchMock.mockReset()
@@ -47,12 +49,15 @@ describe('IntegrationWorkbenchView', () => {
     originalCreateObjectURL = URL.createObjectURL
     originalRevokeObjectURL = URL.revokeObjectURL
     originalAnchorClick = HTMLAnchorElement.prototype.click
+    originalConfirm = window.confirm
     createObjectURLMock = vi.fn(() => 'blob:data-factory-cleansed-export')
     revokeObjectURLMock = vi.fn()
     anchorClickMock = vi.fn()
+    confirmMock = vi.fn(() => true)
     Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: createObjectURLMock })
     Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: revokeObjectURLMock })
     Object.defineProperty(HTMLAnchorElement.prototype, 'click', { configurable: true, value: anchorClickMock })
+    Object.defineProperty(window, 'confirm', { configurable: true, value: confirmMock })
   })
 
   afterEach(() => {
@@ -61,6 +66,7 @@ describe('IntegrationWorkbenchView', () => {
     Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: originalCreateObjectURL })
     Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: originalRevokeObjectURL })
     Object.defineProperty(HTMLAnchorElement.prototype, 'click', { configurable: true, value: originalAnchorClick })
+    Object.defineProperty(window, 'confirm', { configurable: true, value: originalConfirm })
     app = null
     container = null
   })
@@ -716,6 +722,7 @@ describe('IntegrationWorkbenchView', () => {
 
   it('explains source/target connector split and supports safe connection draft management', async () => {
     const upsertBodies: Array<Record<string, unknown>> = []
+    const deleteUrls: string[] = []
     apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
       if (url === '/api/integration/adapters') {
         return jsonResponse([
@@ -768,6 +775,21 @@ describe('IntegrationWorkbenchView', () => {
           capabilities: body.capabilities,
         })
       }
+      if (url === '/api/integration/external-systems/k3_target?tenantId=default' && init?.method === 'DELETE') {
+        deleteUrls.push(url)
+        return jsonResponse({
+          deleted: true,
+          system: {
+            id: 'k3_target',
+            tenantId: 'default',
+            workspaceId: null,
+            name: 'K3 Target',
+            kind: 'erp:k3-wise-webapi',
+            role: 'target',
+            status: 'active',
+          },
+        })
+      }
       if (url === '/api/integration/staging/descriptors') {
         return jsonResponse([])
       }
@@ -807,8 +829,8 @@ describe('IntegrationWorkbenchView', () => {
     ;(container.querySelector('[data-testid="toggle-inventory-overview"]') as HTMLButtonElement).click()
     await flushUi()
     const deleteButton = container.querySelector('[data-testid="delete-connection-k3_target"]') as HTMLButtonElement
-    expect(deleteButton.disabled).toBe(true)
-    expect(deleteButton.textContent).toContain('删除待接口')
+    expect(deleteButton.disabled).toBe(false)
+    expect(deleteButton.textContent).toContain('删除')
 
     ;(container.querySelector('[data-testid="copy-connection-k3_target"]') as HTMLButtonElement).click()
     await flushUi()
@@ -859,6 +881,13 @@ describe('IntegrationWorkbenchView', () => {
       status: 'inactive',
     })
     expect(container.textContent).toContain('连接已停用：PLM Source')
+
+    ;(container.querySelector('[data-testid="delete-connection-k3_target"]') as HTMLButtonElement).click()
+    await flushUi(8)
+    expect(confirmMock).toHaveBeenCalledWith(expect.stringContaining('删除连接'))
+    expect(deleteUrls).toEqual(['/api/integration/external-systems/k3_target?tenantId=default'])
+    expect(container.textContent).toContain('连接已删除：K3 Target Edited')
+    expect(container.textContent).not.toContain('K3 Target · erp:k3-wise-webapi')
   })
 
   it('does not mark error-state source or target systems as dry-run ready', async () => {

--- a/docs/development/data-factory-issue651-external-system-delete-design-20260517.md
+++ b/docs/development/data-factory-issue651-external-system-delete-design-20260517.md
@@ -1,0 +1,129 @@
+# Data Factory issue #651 external-system delete design - 2026-05-17
+
+## Purpose
+
+Close the remaining connector-management gap from issue #651: the Data Factory
+inventory showed edit/copy/deactivate controls, but physical delete was still a
+disabled UI placeholder because the backend did not expose
+`DELETE /api/integration/external-systems/:id`.
+
+This change makes delete real without changing the pipeline model, migrations,
+or K3 WISE runtime behavior.
+
+## Scope
+
+Included:
+
+- Add a backend registry method to delete unused external systems.
+- Add an HTTP route for `DELETE /api/integration/external-systems/:id`.
+- Add frontend service/view wiring so the inventory delete button calls the
+  backend and removes the connection from local state.
+- Add tests for registry, route, and Data Factory UI behavior.
+
+Excluded:
+
+- No new table or migration.
+- No hard delete for connections still referenced by pipelines.
+- No K3 WebAPI read/list runtime work.
+- No SQL executor or relationship-mapping work.
+
+## Backend Behavior
+
+The delete path is intentionally conservative.
+
+1. Resolve `tenantId`, `workspaceId`, and `id` using the same scoped input path
+   as existing external-system routes.
+2. Load the row from `integration_external_systems`.
+3. Count references in `integration_pipelines` for both:
+   - `source_system_id = id`
+   - `target_system_id = id`
+4. If either count is non-zero, throw `ExternalSystemConflictError`.
+5. If there are no references, delete the row with the scoped `WHERE`.
+6. Return a public-safe result:
+
+```json
+{
+  "deleted": true,
+  "system": {
+    "id": "sys_1",
+    "tenantId": "default",
+    "workspaceId": null,
+    "name": "K3 Target",
+    "kind": "erp:k3-wise-webapi",
+    "role": "target",
+    "status": "inactive",
+    "hasCredentials": true,
+    "credentialFingerprint": "fp_..."
+  }
+}
+```
+
+Credentials remain write-only. The deleted row is returned through the same
+public serializer as `GET` and `LIST`, so plaintext credentials and ciphertext
+are not exposed.
+
+## HTTP Contract
+
+New route:
+
+```text
+DELETE /api/integration/external-systems/:id?tenantId=default&workspaceId=...
+```
+
+Success:
+
+- Status: `200`
+- Body: `{ ok: true, data: { deleted: true, system } }`
+
+Failure:
+
+- Missing auth: existing `401` / `403`
+- Missing row: `404 ExternalSystemNotFoundError`
+- Referenced by pipeline: `409 ExternalSystemConflictError`
+- Invalid tenant/scope: existing route guard behavior
+
+Conflict details include:
+
+```json
+{
+  "referencedPipelineCount": 2,
+  "sourcePipelineCount": 1,
+  "targetPipelineCount": 1
+}
+```
+
+## Frontend Behavior
+
+Data Factory inventory now shows a real `删除` button instead of `删除待接口`.
+
+The UI flow:
+
+1. User clicks `删除`.
+2. Browser confirm explains that only unreferenced connections can be deleted.
+3. UI calls `deleteWorkbenchExternalSystem(system.id, currentScope())`.
+4. On success:
+   - remove the system from `systems`
+   - clear source/target selections if they pointed at the deleted system
+   - reset the draft if the draft was editing the deleted system
+   - normalize source/target selections
+   - show `连接已删除：...`
+5. On failure, show the backend error message in the existing status bar.
+
+This keeps #1620's safe-draft model intact: users can still edit/copy/deactivate,
+and physical delete is available only when the backend confirms it is safe.
+
+## Compatibility
+
+- Uses existing `integration_external_systems` and `integration_pipelines`.
+- Relies on existing migration FK shape:
+  `integration_pipelines.source_system_id / target_system_id` reference
+  external systems with `ON DELETE RESTRICT`.
+- The registry performs a preflight reference count before delete so the user
+  receives a clear 409 instead of an opaque DB FK error.
+- No public API route is removed or changed.
+
+## Deployment Impact
+
+No migration is required. Existing deployments only need the updated backend and
+web bundle. Old clients continue to work because this is additive.
+

--- a/docs/development/data-factory-issue651-external-system-delete-verification-20260517.md
+++ b/docs/development/data-factory-issue651-external-system-delete-verification-20260517.md
@@ -1,0 +1,126 @@
+# Data Factory issue #651 external-system delete verification - 2026-05-17
+
+## Summary
+
+This verification covers the small #651 follow-up that turns the Data Factory
+connection inventory delete control into a real backend-protected operation.
+
+## Local Commands
+
+### Backend registry
+
+```bash
+node plugins/plugin-integration-core/__tests__/external-systems.test.cjs
+```
+
+Result:
+
+```text
+PASS - external-systems: registry + credential boundary tests passed
+```
+
+Coverage added:
+
+- referenced external systems throw `ExternalSystemConflictError`
+- conflict counts are scoped by tenant/workspace
+- unused external systems are removed
+- deleted public system output does not expose credentials
+- missing delete target throws `ExternalSystemNotFoundError`
+- registry construction requires `deleteRows` and `countRows`
+
+### Backend HTTP routes
+
+```bash
+node plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+```
+
+Result:
+
+```text
+PASS - http-routes: REST auth/list/upsert/run/dry-run/staging/replay tests passed
+```
+
+Coverage added:
+
+- `DELETE /api/integration/external-systems/:id` is registered
+- write-permission user can call delete
+- scoped `{ id, tenantId, workspaceId }` is passed to the registry
+- registry conflict maps to HTTP `409`
+
+### Frontend Data Factory view
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/IntegrationWorkbenchView.spec.ts --watch=false
+```
+
+Result:
+
+```text
+PASS - 1 file, 7 tests
+```
+
+Coverage added:
+
+- inventory delete button is enabled
+- click confirms the destructive action
+- frontend calls `DELETE /api/integration/external-systems/k3_target?tenantId=default`
+- deleted connection is removed from the rendered inventory
+- success status shows `连接已删除：...`
+
+### Frontend type check
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+```
+
+Result:
+
+```text
+PASS - exit 0
+```
+
+### Frontend production build
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result:
+
+```text
+PASS - vite build completed
+```
+
+Notes:
+
+- Vite reported the existing WorkflowDesigner dynamic/static import warning.
+- Vite reported existing large chunk warnings.
+- No build error was produced.
+
+### Diff hygiene
+
+```bash
+git diff --check
+```
+
+Result:
+
+```text
+PASS - exit 0
+```
+
+## Notes
+
+`pnpm install --frozen-lockfile --ignore-scripts` was needed in the isolated
+worktree before running frontend tests. It temporarily changed several tracked
+plugin/tool `node_modules` symlinks; those install-side effects were restored and
+are not part of this change.
+
+## Risk Checks
+
+- No migration added.
+- No `plugin-integration-core` K3 read/list runtime added.
+- No SQL executor or relationship mapping touched.
+- Delete is scoped and bounded by `tenantId`, `workspaceId`, and `id`.
+- Referenced connections are blocked before the DB FK can fire.
+- Public delete response uses the existing redacted serializer.

--- a/plugins/plugin-integration-core/__tests__/external-systems.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/external-systems.test.cjs
@@ -4,6 +4,7 @@ const assert = require('node:assert/strict')
 const path = require('node:path')
 const {
   createExternalSystemRegistry,
+  ExternalSystemConflictError,
   ExternalSystemNotFoundError,
   ExternalSystemValidationError,
   __internals,
@@ -31,6 +32,7 @@ function createMockCredentialStore() {
 
 function createMockDb() {
   const rows = []
+  const pipelineRows = []
   const calls = []
 
   function matchesWhere(row, where) {
@@ -42,6 +44,7 @@ function createMockDb() {
 
   return {
     rows,
+    pipelineRows,
     calls,
     async selectOne(table, where) {
       calls.push(['selectOne', table, { ...where }])
@@ -66,8 +69,23 @@ function createMockDb() {
     },
     async select(table, options = {}) {
       calls.push(['select', table, JSON.parse(JSON.stringify(options))])
-      const filtered = rows.filter(row => matchesWhere(row, options.where || {}))
+      const tableRows = table === 'integration_pipelines' ? pipelineRows : rows
+      const filtered = tableRows.filter(row => matchesWhere(row, options.where || {}))
       return filtered.slice(options.offset || 0, (options.offset || 0) + (options.limit || 1000))
+    },
+    async countRows(table, where) {
+      calls.push(['countRows', table, { ...where }])
+      const tableRows = table === 'integration_pipelines' ? pipelineRows : rows
+      return tableRows.filter(row => matchesWhere(row, where)).length
+    },
+    async deleteRows(table, where) {
+      calls.push(['deleteRows', table, { ...where }])
+      const tableRows = table === 'integration_pipelines' ? pipelineRows : rows
+      const before = tableRows.length
+      for (let index = tableRows.length - 1; index >= 0; index -= 1) {
+        if (matchesWhere(tableRows[index], where)) tableRows.splice(index, 1)
+      }
+      return before - tableRows.length
     },
   }
 }
@@ -280,6 +298,16 @@ async function main() {
   }
   assert.ok(badDb, 'db helper without select rejected')
 
+  const dbWithoutDelete = { ...db }
+  delete dbWithoutDelete.deleteRows
+  let badDeleteDb = null
+  try {
+    createExternalSystemRegistry({ db: dbWithoutDelete, credentialStore })
+  } catch (error) {
+    badDeleteDb = error
+  }
+  assert.ok(badDeleteDb, 'db helper without deleteRows rejected')
+
   const raceDb = createMockDb()
   const raceRegistry = createExternalSystemRegistry({
     db: {
@@ -452,6 +480,75 @@ async function main() {
   })
   assert.equal(sameKindRole.name, 'immutable-sys renamed', 'update with unchanged kind/role succeeds')
   assert.equal(sameKindRole.status, 'inactive', 'status update applied')
+
+  // --- 10. delete protects referenced systems and returns public shape ----
+  const deleteDb = createMockDb()
+  const deleteRegistry = createExternalSystemRegistry({
+    db: deleteDb,
+    credentialStore,
+    idGenerator: () => 'sys_delete',
+  })
+  await deleteRegistry.upsertExternalSystem({
+    tenantId: 'tenant_1',
+    workspaceId: null,
+    name: 'delete-me',
+    kind: 'http',
+    role: 'source',
+    credentials: { token: 'delete-secret' },
+  })
+  deleteDb.pipelineRows.push({
+    id: 'pipe_source',
+    tenant_id: 'tenant_1',
+    workspace_id: null,
+    source_system_id: 'sys_delete',
+    target_system_id: 'target_1',
+  })
+  deleteDb.pipelineRows.push({
+    id: 'pipe_other_workspace',
+    tenant_id: 'tenant_1',
+    workspace_id: 'other',
+    source_system_id: 'sys_delete',
+    target_system_id: 'target_1',
+  })
+
+  let deleteConflict = null
+  try {
+    await deleteRegistry.deleteExternalSystem({
+      tenantId: 'tenant_1',
+      workspaceId: null,
+      id: 'sys_delete',
+    })
+  } catch (error) {
+    deleteConflict = error
+  }
+  assert.ok(deleteConflict instanceof ExternalSystemConflictError, 'referenced external system cannot be deleted')
+  assert.equal(deleteConflict.details.referencedPipelineCount, 1, 'conflict counts only matching tenant/workspace references')
+  assert.equal(deleteConflict.details.sourcePipelineCount, 1)
+  assert.equal(deleteConflict.details.targetPipelineCount, 0)
+  assert.equal(deleteDb.rows.length, 1, 'conflict does not delete the system')
+
+  deleteDb.pipelineRows.length = 0
+  const deleteResult = await deleteRegistry.deleteExternalSystem({
+    tenantId: 'tenant_1',
+    workspaceId: null,
+    id: 'sys_delete',
+  })
+  assert.equal(deleteResult.deleted, true)
+  assert.equal(deleteResult.system.id, 'sys_delete')
+  assert.equal(deleteResult.system.credentials, undefined, 'deleted public system does not expose credentials')
+  assert.equal(deleteDb.rows.length, 0, 'unused external system is removed')
+
+  let deleteMissing = null
+  try {
+    await deleteRegistry.deleteExternalSystem({
+      tenantId: 'tenant_1',
+      workspaceId: null,
+      id: 'sys_delete',
+    })
+  } catch (error) {
+    deleteMissing = error
+  }
+  assert.ok(deleteMissing instanceof ExternalSystemNotFoundError, 'deleting missing external system reports not found')
 
   console.log('✓ external-systems: registry + credential boundary tests passed')
 }

--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -129,6 +129,10 @@ function createMockServices(overrides = {}) {
         calls.push(['getExternalSystem', input])
         return { ...system, id: input.id }
       },
+      async deleteExternalSystem(input) {
+        calls.push(['deleteExternalSystem', input])
+        return { deleted: true, system: { ...system, id: input.id } }
+      },
       async getExternalSystemForAdapter(input) {
         calls.push(['getExternalSystemForAdapter', input])
         return { ...system, id: input.id, credentials: { bearerToken: 'secret-token' } }
@@ -334,6 +338,10 @@ async function testExternalSystemRoutes() {
     registered.includes('GET /api/integration/external-systems'),
     'external systems list route registered',
   )
+  assert.ok(
+    registered.includes('DELETE /api/integration/external-systems/:id'),
+    'external systems delete route registered',
+  )
 
   let res = await invoke(routes, 'GET', '/api/integration/external-systems', {
     user: READ_USER,
@@ -395,6 +403,20 @@ async function testExternalSystemRoutes() {
     workspaceId: 'workspace_1',
   })
 
+  res = await invoke(routes, 'DELETE', '/api/integration/external-systems/:id', {
+    user: WRITE_USER,
+    params: { id: 'sys_2' },
+    query: { workspaceId: 'workspace_1' },
+  })
+  assertOkResponse(res, 200)
+  assert.equal(res.body.data.deleted, true)
+  assert.equal(res.body.data.system.id, 'sys_2')
+  assert.deepEqual(findCall(calls, 'deleteExternalSystem')[1], {
+    id: 'sys_2',
+    tenantId: 'tenant_1',
+    workspaceId: 'workspace_1',
+  })
+
   res = await invoke(routes, 'POST', '/api/integration/external-systems/:id/test', {
     user: WRITE_USER,
     params: { id: 'sys_2' },
@@ -427,6 +449,31 @@ async function testExternalSystemRoutes() {
     lastError: null,
   })
   assert.ok(!Number.isNaN(Date.parse(statusUpdates[1][1].lastTestedAt)), 'test status update stores ISO timestamp')
+
+  calls.length = 0
+  const { routes: conflictRoutes } = mountRoutes(createMockServices({
+    externalSystemRegistry: {
+      async deleteExternalSystem(input) {
+        calls.push(['deleteExternalSystem', input])
+        const error = new Error('external system is used by pipelines')
+        error.name = 'ExternalSystemConflictError'
+        error.details = {
+          referencedPipelineCount: 2,
+          sourcePipelineCount: 1,
+          targetPipelineCount: 1,
+        }
+        throw error
+      },
+    },
+  }).services)
+  const conflict = await invoke(conflictRoutes, 'DELETE', '/api/integration/external-systems/:id', {
+    user: WRITE_USER,
+    params: { id: 'sys_referenced' },
+    query: { workspaceId: 'workspace_1' },
+  })
+  assertErrorResponse(conflict, [409])
+  assert.equal(conflict.body.error.code, 'ExternalSystemConflictError')
+  assert.equal(conflict.body.error.details.referencedPipelineCount, 2)
 }
 
 async function testExternalSystemTestPersistsFailureAndPreservesInactive() {

--- a/plugins/plugin-integration-core/lib/external-systems.cjs
+++ b/plugins/plugin-integration-core/lib/external-systems.cjs
@@ -31,6 +31,14 @@ class ExternalSystemNotFoundError extends Error {
   }
 }
 
+class ExternalSystemConflictError extends Error {
+  constructor(message, details = {}) {
+    super(message)
+    this.name = 'ExternalSystemConflictError'
+    this.details = details
+  }
+}
+
 function requiredString(value, field) {
   if (typeof value !== 'string' || value.trim().length === 0) {
     throw new ExternalSystemValidationError(`${field} is required`, { field })
@@ -198,7 +206,9 @@ function createExternalSystemRegistry({ db, credentialStore, idGenerator = crypt
     typeof db.selectOne !== 'function' ||
     typeof db.insertOne !== 'function' ||
     typeof db.updateRow !== 'function' ||
-    typeof db.select !== 'function'
+    typeof db.select !== 'function' ||
+    typeof db.deleteRows !== 'function' ||
+    typeof db.countRows !== 'function'
   ) {
     throw new Error('createExternalSystemRegistry: scoped db helper is required')
   }
@@ -316,6 +326,66 @@ function createExternalSystemRegistry({ db, credentialStore, idGenerator = crypt
     return rowToAdapterExternalSystem(row, credentials)
   }
 
+  async function countPipelineReferences({ tenantId, workspaceId, id }) {
+    const where = scopeWhere({ tenantId, workspaceId })
+    const [sourcePipelineCount, targetPipelineCount] = await Promise.all([
+      db.countRows('integration_pipelines', {
+        ...where,
+        source_system_id: id,
+      }),
+      db.countRows('integration_pipelines', {
+        ...where,
+        target_system_id: id,
+      }),
+    ])
+    return {
+      sourcePipelineCount: Number(sourcePipelineCount) || 0,
+      targetPipelineCount: Number(targetPipelineCount) || 0,
+    }
+  }
+
+  async function deleteExternalSystem(input) {
+    const tenantId = requiredString(input?.tenantId, 'tenantId')
+    const workspaceId = normalizeWorkspaceId(input?.workspaceId)
+    const id = requiredString(input?.id, 'id')
+    const where = {
+      tenant_id: tenantId,
+      workspace_id: workspaceId,
+      id,
+    }
+    const row = await db.selectOne(TABLE, where)
+    if (!row) {
+      throw new ExternalSystemNotFoundError('external system not found', { id, tenantId, workspaceId })
+    }
+
+    const references = await countPipelineReferences({ tenantId, workspaceId, id })
+    const referencedPipelineCount = references.sourcePipelineCount + references.targetPipelineCount
+    if (referencedPipelineCount > 0) {
+      throw new ExternalSystemConflictError('external system is used by pipelines', {
+        id,
+        tenantId,
+        workspaceId,
+        referencedPipelineCount,
+        ...references,
+      })
+    }
+
+    const deleted = await publicRow(credentialStore, row)
+    const deleteResult = await db.deleteRows(TABLE, where)
+    const deletedCount = Array.isArray(deleteResult)
+      ? deleteResult.length
+      : Array.isArray(deleteResult?.rows)
+        ? deleteResult.rows.length
+        : Number(deleteResult) || 0
+    if (deletedCount < 1) {
+      throw new ExternalSystemNotFoundError('external system not found during delete', { id, tenantId, workspaceId })
+    }
+    return {
+      deleted: true,
+      system: deleted,
+    }
+  }
+
   async function listExternalSystems(input = {}) {
     const tenantId = requiredString(input.tenantId, 'tenantId')
     const workspaceId = normalizeWorkspaceId(input.workspaceId)
@@ -342,6 +412,7 @@ function createExternalSystemRegistry({ db, credentialStore, idGenerator = crypt
     upsertExternalSystem,
     getExternalSystem,
     getExternalSystemForAdapter,
+    deleteExternalSystem,
     listExternalSystems,
   }
 }
@@ -350,6 +421,7 @@ module.exports = {
   createExternalSystemRegistry,
   ExternalSystemValidationError,
   ExternalSystemNotFoundError,
+  ExternalSystemConflictError,
   __internals: {
     TABLE,
     VALID_ROLES,

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -14,6 +14,7 @@ const ROUTES = [
   ['GET', '/api/integration/external-systems', 'externalSystemsList'],
   ['POST', '/api/integration/external-systems', 'externalSystemsUpsert'],
   ['GET', '/api/integration/external-systems/:id', 'externalSystemsGet'],
+  ['DELETE', '/api/integration/external-systems/:id', 'externalSystemsDelete'],
   ['POST', '/api/integration/external-systems/:id/test', 'externalSystemsTest'],
   ['GET', '/api/integration/external-systems/:id/objects', 'externalSystemObjects'],
   ['GET', '/api/integration/external-systems/:id/schema', 'externalSystemSchema'],
@@ -672,7 +673,7 @@ function createHandlers(services) {
     return service
   }
 
-  const externalSystems = requireService('externalSystemRegistry', ['upsertExternalSystem', 'getExternalSystem', 'listExternalSystems'])
+  const externalSystems = requireService('externalSystemRegistry', ['upsertExternalSystem', 'getExternalSystem', 'deleteExternalSystem', 'listExternalSystems'])
   const adapterRegistry = requireService('adapterRegistry', ['createAdapter', 'listAdapterKinds'])
   const pipelineRegistry = requireService('pipelineRegistry', ['upsertPipeline', 'getPipeline', 'listPipelines', 'listPipelineRuns'])
   const runner = requireService('pipelineRunner', ['runPipeline'])
@@ -712,6 +713,11 @@ function createHandlers(services) {
     async externalSystemsGet(req, res) {
       requireAccess(req, 'read')
       return sendOk(res, await externalSystems.getExternalSystem(scopedInput(req, { id: requestParams(req).id })))
+    },
+
+    async externalSystemsDelete(req, res) {
+      requireAccess(req, 'write')
+      return sendOk(res, await externalSystems.deleteExternalSystem(scopedInput(req, { id: requestParams(req).id })))
     },
 
     async externalSystemsTest(req, res) {


### PR DESCRIPTION
## Summary
- add DELETE /api/integration/external-systems/:id with tenant/workspace scoping
- block physical delete when any pipeline references the connection as source or target, returning 409 ExternalSystemConflictError
- wire the Data Factory inventory delete button to the backend and remove deleted connections from local UI state
- add design and verification docs for the #651 follow-up

## Verification
- node plugins/plugin-integration-core/__tests__/external-systems.test.cjs
- node plugins/plugin-integration-core/__tests__/http-routes.test.cjs
- pnpm --filter @metasheet/web exec vitest run tests/IntegrationWorkbenchView.spec.ts --watch=false
- pnpm --filter @metasheet/web exec vue-tsc --noEmit
- pnpm --filter @metasheet/web build
- git diff --check

## Deployment impact
- no migration
- additive API route only
- referenced connections remain protected by preflight counts plus existing DB FK shape

Follow-up to #651.