### PR TITLE
chore(integration): add K3 GATE contract checker

### DIFF
--- a/docs/development/data-factory-issue1526-gate-contract-check-design-20260518.md
+++ b/docs/development/data-factory-issue1526-gate-contract-check-design-20260518.md
@@ -1,0 +1,150 @@
+# Data Factory issue #1526 GATE contract checker design - 2026-05-18
+
+## Purpose
+
+#1526 still has three real runtime tracks: K3 WISE WebAPI read/list, SQL
+read-only sample preview, and relationship resolver runtime. The first and third
+are already narrowed into GATE-front contracts, but until now the customer
+answers were only described in Markdown.
+
+This slice adds a machine-checkable intake gate for those contracts. It lets the
+operator answer a concrete question before touching `plugin-integration-core`:
+
+> Did the customer return enough redacted evidence to start the post-GATE
+> runtime PR without guessing?
+
+## Scope
+
+Added:
+
+- `scripts/ops/integration-k3wise-gate-contract-check.mjs`
+- `scripts/ops/integration-k3wise-gate-contract-check.test.mjs`
+- `verify:integration-k3wise:gate-contract`
+- a short machine-check section in the WebAPI read/list customer manifest
+- a short machine-check section in the relationship mapping customer manifest
+
+Not changed:
+
+- no `plugins/plugin-integration-core`
+- no DB migration
+- no backend route/API
+- no frontend runtime
+- no K3 WISE network call
+- no Save/Submit/Audit behavior
+
+## Packet model
+
+The checker accepts one local JSON packet outside Git:
+
+```jsonc
+{
+  "webapiReadList": {
+    "answers": {
+      "O1-MAT": "/K3API/Material/List",
+      "O1-MAT-M": "POST",
+      "O1-BOM": "/K3API/BOM/List",
+      "O1-BOM-M": "POST",
+      "O2-P": "PageIndex/PageSize",
+      "O2-T": "Total",
+      "O2-C": "100",
+      "O3-F": "number, modifiedSince",
+      "O3-M": "ModifiedSince",
+      "O4-MAT": "FNumber,FName,FModel,FBaseUnitID",
+      "O4-BOM": "FParentItemNumber,FChildItemNumber,FQty,FUnitID,FEntryID",
+      "O6": "same token as Save"
+    },
+    "samples": {
+      "materialList": "sample-material-list.redacted.json",
+      "materialDetail": "sample-material-detail.redacted.json",
+      "bomList": "sample-bom-list.redacted.json",
+      "bomDetail": "sample-bom-detail.redacted.json"
+    }
+  },
+  "relationshipMapping": {
+    "answers": {
+      "R1": "flat lines",
+      "R2": "yes",
+      "R3": "parentCode + childCode + sequence",
+      "R4": "header with FChildItems[]",
+      "R5": "dead-letter-row",
+      "R6": "unit and sequence are mandatory",
+      "R7": "yes"
+    },
+    "samples": {
+      "flatBomLines": "relationship-flat-bom-lines.redacted.json",
+      "treeBom": "relationship-tree-bom.redacted.json",
+      "unresolvedChild": "relationship-unresolved-child.redacted.json",
+      "k3BomSaveShape": "relationship-k3-bom-save-shape.redacted.json"
+    }
+  }
+}
+```
+
+Sample paths are resolved relative to the packet file. This keeps the customer
+answer bundle portable between the bridge machine, a developer laptop, and CI
+artifact folders without committing customer evidence.
+
+## Decisions
+
+### Exit codes
+
+| Exit | Decision | Meaning |
+| --- | --- | --- |
+| `0` | `PASS` | Required answers and sample shapes are present; no secret-shaped values were found. |
+| `1` | `FAIL` | Safety violation or malformed unsafe input, such as absolute endpoint URL or secret-shaped sample value. |
+| `2` | `GATE_BLOCKED` | Customer packet is incomplete, missing sample files, or sample shape is insufficient. |
+
+This mirrors existing K3 preflight behavior: incomplete customer input is not a
+product regression, but it still blocks runtime work.
+
+### WebAPI read/list checks
+
+The checker validates:
+
+- all O1-O6 answer IDs are present;
+- Material/BOM methods are `GET` or `POST`;
+- read/list endpoints are relative paths, not absolute URLs;
+- endpoint paths do not contain secret-looking query parameters;
+- four redacted sample files exist and parse;
+- Material samples contain at least one material-like number/name row;
+- BOM samples contain parent, child, and quantity information.
+
+It does not assert a final K3 envelope. That remains the runtime PR's job after
+O1-O6 are confirmed.
+
+### Relationship mapping checks
+
+The checker validates:
+
+- all R1-R7 answers are present;
+- flat BOM sample contains `records[]` with `parentCode`, `childCode`, and
+  `quantity`;
+- tree BOM sample contains `root.children[]`;
+- unresolved child sample contains `record` and `expectedCustomerPolicy`;
+- K3 BOM Save body shape contains `Data` and is either flat or
+  `Data.FChildItems[]`.
+
+### Secret hygiene
+
+The checker recursively scans answers and sample files for:
+
+- JWT/Bearer-shaped values,
+- credentialed database URLs,
+- secret-looking URL query parameters,
+- secret-looking keys such as `password`, `token`, `api_key`, `session_id`,
+  `sign`, or `authorization` with non-redacted values.
+
+Reports intentionally include issue IDs and generic messages, not raw sample
+values. Evidence can therefore be shared internally without leaking the exact
+string that triggered a failure.
+
+## Stage 1 Lock
+
+This is allowed under the Stage 1 Lock because it is an ops/documentation gate.
+It makes future runtime work safer but does not implement runtime behavior.
+
+Runtime remains blocked until:
+
+- customer GATE is PASS;
+- this checker returns `PASS` for O1-O6/R1-R7 evidence;
+- the operator explicitly starts a post-GATE runtime PR.

--- a/docs/development/data-factory-issue1526-gate-contract-check-verification-20260518.md
+++ b/docs/development/data-factory-issue1526-gate-contract-check-verification-20260518.md
@@ -1,0 +1,56 @@
+# Data Factory issue #1526 GATE contract checker verification - 2026-05-18
+
+Companion to
+`docs/development/data-factory-issue1526-gate-contract-check-design-20260518.md`.
+
+## Verification matrix
+
+| Check | Evidence | Result |
+| --- | --- | --- |
+| Stage 1 Lock held | Diff touches ops script, tests, package script, and docs only. No `plugins/plugin-integration-core`, migration, backend route/API, or frontend runtime files. | PASS |
+| Complete packet accepted | Unit test writes complete O1-O6/R1-R7 answers plus eight redacted sample files and asserts decision `PASS`. | PASS |
+| Incomplete packet blocked | Unit test blanks `O1-BOM` and points one relationship sample at a missing file; report returns `GATE_BLOCKED` / exit 2. | PASS |
+| Unsafe endpoint rejected | Unit test sets a read endpoint to an absolute URL; report returns `FAIL`. | PASS |
+| Secret-shaped sample rejected | Unit test injects a raw password and access-token query into a sample; CLI exits 1. | PASS |
+| Failure evidence does not echo raw secret | Secret regression asserts generated JSON does not contain the raw injected password or token value. | PASS |
+| Customer manifests updated | WebAPI read/list and relationship manifests now point operators to the machine checker before runtime work. | PASS |
+
+## Commands run
+
+```bash
+pnpm verify:integration-k3wise:gate-contract
+node --check scripts/ops/integration-k3wise-gate-contract-check.mjs
+node --check scripts/ops/integration-k3wise-gate-contract-check.test.mjs
+git diff --check origin/main...HEAD
+```
+
+## Expected command results
+
+| Command | Result |
+| --- | --- |
+| `pnpm verify:integration-k3wise:gate-contract` | PASS |
+| `node --check scripts/ops/integration-k3wise-gate-contract-check.mjs` | PASS |
+| `node --check scripts/ops/integration-k3wise-gate-contract-check.test.mjs` | PASS |
+| `git diff --check origin/main...HEAD` | PASS |
+
+## Sample operator command
+
+```bash
+node scripts/ops/integration-k3wise-gate-contract-check.mjs \
+  --input /path/outside-git/k3wise-gate-contract-packet.json \
+  --out-dir artifacts/integration-k3wise/gate-contract-check
+```
+
+Expected decisions:
+
+| Decision | Meaning |
+| --- | --- |
+| `PASS` | Packet is complete enough for post-GATE runtime planning, assuming the broader customer GATE is also PASS. |
+| `GATE_BLOCKED` | Customer evidence is incomplete or sample shape is insufficient. |
+| `FAIL` | Safety issue; fix/redact the packet before using it for development. |
+
+## Scope boundary
+
+This PR does not close #1526. It reduces the remaining runtime risk by making
+the GATE-front contracts executable. K3 WebAPI read/list, SQL sample preview,
+and relationship resolver runtime still require a separate post-GATE PR.

--- a/docs/operations/integration-k3wise-relationship-mapping-customer-sample-manifest.md
+++ b/docs/operations/integration-k3wise-relationship-mapping-customer-sample-manifest.md
@@ -152,3 +152,20 @@ Runtime work should start only when:
 - K3 live policy still says Save-only, no Submit/Audit;
 - unresolved relationship policy is explicit;
 - the accepted K3 BOM body shape is confirmed.
+
+## Machine check before runtime
+
+After the customer returns R1-R7 and cases A-D, include those relationship files
+in the same local GATE contract packet used for WebAPI read/list, then run:
+
+```bash
+node scripts/ops/integration-k3wise-gate-contract-check.mjs \
+  --input /path/outside-git/k3wise-gate-contract-packet.json \
+  --out-dir artifacts/integration-k3wise/gate-contract-check
+```
+
+The checker must return `PASS` before relationship resolver runtime work starts.
+It verifies that R1-R7 are answered, the sample shapes are parseable, the K3 BOM
+body shape is explicit, and no token/password/connection-string shaped values
+were included. It is a pre-runtime evidence gate only; it does not contact K3
+WISE and does not enable Save/Submit/Audit.

--- a/docs/operations/integration-k3wise-webapi-read-list-customer-sample-manifest.md
+++ b/docs/operations/integration-k3wise-webapi-read-list-customer-sample-manifest.md
@@ -104,3 +104,19 @@ write template); confirm or correct in O4-BOM.
 Return Part A inline (redacted) and Part B as the four `*.redacted.json` files
 through the secure channel. On receipt and customer GATE PASS, the runtime slice
 proceeds per the post-GATE plan in the design and verification docs.
+
+## Machine check before runtime
+
+Before opening the post-GATE runtime PR, copy the customer answers and the four
+sample files into a local packet outside Git, then run:
+
+```bash
+node scripts/ops/integration-k3wise-gate-contract-check.mjs \
+  --input /path/outside-git/k3wise-gate-contract-packet.json \
+  --out-dir artifacts/integration-k3wise/gate-contract-check
+```
+
+The checker must return `PASS` before runtime work starts. `GATE_BLOCKED` means
+the packet is incomplete; `FAIL` means a safety issue such as a secret-shaped
+value or unsafe endpoint path was found. The checker does not contact K3 WISE or
+MetaSheet and does not lift the broader customer GATE by itself.

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "verify:integration-k3wise:delivery": "node --test scripts/ops/integration-k3wise-delivery-readiness.test.mjs",
     "verify:integration-k3wise:onprem-preflight": "node --test scripts/ops/integration-k3wise-onprem-preflight.test.mjs",
     "verify:integration-k3wise:postdeploy-env-check": "node --test scripts/ops/integration-k3wise-postdeploy-env-check.test.mjs",
+    "verify:integration-k3wise:gate-contract": "node --test scripts/ops/integration-k3wise-gate-contract-check.test.mjs",
     "verify:integration-issue1542:seed-workbench": "node --test scripts/ops/integration-issue1542-seed-workbench-systems.test.mjs",
     "phase5:run-all": "bash scripts/phase5-run-all.sh",
     "build": "pnpm -r build",

--- a/scripts/ops/integration-k3wise-gate-contract-check.mjs
+++ b/scripts/ops/integration-k3wise-gate-contract-check.mjs
@@ -1,0 +1,509 @@
+#!/usr/bin/env node
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+
+const DEFAULT_OUTPUT_ROOT = 'output/integration-k3wise-gate-contract-check'
+const READ_ANSWER_IDS = [
+  'O1-MAT',
+  'O1-MAT-M',
+  'O1-BOM',
+  'O1-BOM-M',
+  'O2-P',
+  'O2-T',
+  'O2-C',
+  'O3-F',
+  'O3-M',
+  'O4-MAT',
+  'O4-BOM',
+  'O6',
+]
+const READ_METHOD_IDS = ['O1-MAT-M', 'O1-BOM-M']
+const READ_PATH_IDS = ['O1-MAT', 'O1-BOM']
+const READ_SAMPLES = {
+  materialList: {
+    label: 'Material list sample',
+    validator: assertMaterialSample,
+  },
+  materialDetail: {
+    label: 'Material detail sample',
+    validator: assertMaterialSample,
+  },
+  bomList: {
+    label: 'BOM list sample',
+    validator: assertBomSample,
+  },
+  bomDetail: {
+    label: 'BOM detail sample',
+    validator: assertBomSample,
+  },
+}
+const RELATIONSHIP_ANSWER_IDS = ['R1', 'R2', 'R3', 'R4', 'R5', 'R6', 'R7']
+const RELATIONSHIP_SAMPLES = {
+  flatBomLines: {
+    label: 'Flat PLM BOM lines sample',
+    validator: assertFlatBomLinesSample,
+  },
+  treeBom: {
+    label: 'Tree PLM BOM sample',
+    validator: assertTreeBomSample,
+  },
+  unresolvedChild: {
+    label: 'Unresolved child material sample',
+    validator: assertUnresolvedChildSample,
+  },
+  k3BomSaveShape: {
+    label: 'K3 BOM Save body shape sample',
+    validator: assertK3BomSaveShape,
+  },
+}
+const PLACEHOLDER_PATTERN = /^(|<fill>|<fill-outside-git>|todo|tbd|\?|待填写|待确认)$/i
+const JWT_PATTERN = /[A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{16,}/
+const BEARER_PATTERN = /Bearer\s+[A-Za-z0-9._-]{16,}/i
+const CONNECTION_STRING_PATTERN = /\b(postgres|postgresql|mysql|mssql|sqlserver|jdbc):\/\/[^/\s:]+:[^@\s]+@/i
+const SECRET_QUERY_PATTERN = /[?&](access[_-]?token|api[_-]?key|auth|authorization|credential|jwt|password|secret|session[_-]?id|sign|signature|token)=([^&#\s]+)/i
+const SECRET_KEY_PATTERN = /(access[_-]?token|api[_-]?key|auth|authorization|credential|jwt|password|secret|session[_-]?id|sign|signature|token)/i
+const REDACTED_VALUE_PATTERN = /^(<redacted>|<fill-outside-git>|\*\*\*|redacted)$/i
+
+class GateContractCheckError extends Error {
+  constructor(message, details = {}) {
+    super(message)
+    this.name = 'GateContractCheckError'
+    this.details = details
+  }
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/ops/integration-k3wise-gate-contract-check.mjs --input <packet.json> [options]
+
+Validates the customer GATE-front packet for #1526 before any K3 WISE read/list,
+SQL sample, or relationship runtime work starts. The checker is read-only and
+does not contact MetaSheet or K3.
+
+Options:
+  --input <path>      JSON packet with WebAPI read/list and relationship answers
+  --out-dir <dir>    Evidence output directory, default ${DEFAULT_OUTPUT_ROOT}/<timestamp>
+  --help             Show this help
+
+Packet shape:
+{
+  "webapiReadList": {
+    "answers": { "O1-MAT": "/K3API/...", "O1-MAT-M": "POST", ... },
+    "samples": {
+      "materialList": "sample-material-list.redacted.json",
+      "materialDetail": "sample-material-detail.redacted.json",
+      "bomList": "sample-bom-list.redacted.json",
+      "bomDetail": "sample-bom-detail.redacted.json"
+    }
+  },
+  "relationshipMapping": {
+    "answers": { "R1": "flat lines", ... },
+    "samples": {
+      "flatBomLines": "relationship-flat-bom-lines.redacted.json",
+      "treeBom": "relationship-tree-bom.redacted.json",
+      "unresolvedChild": "relationship-unresolved-child.redacted.json",
+      "k3BomSaveShape": "relationship-k3-bom-save-shape.redacted.json"
+    }
+  }
+}`)
+}
+
+function readRequiredValue(argv, index, flag) {
+  const next = argv[index + 1]
+  if (!next || next.startsWith('--')) {
+    throw new GateContractCheckError(`${flag} requires a value`, { flag })
+  }
+  return next
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+  const opts = {
+    input: '',
+    outDir: '',
+    help: false,
+  }
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    switch (arg) {
+      case '--input':
+        opts.input = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--out-dir':
+        opts.outDir = readRequiredValue(argv, i, arg)
+        i += 1
+        break
+      case '--help':
+      case '-h':
+        opts.help = true
+        break
+      default:
+        throw new GateContractCheckError(`unknown option: ${arg}`, { arg })
+    }
+  }
+  if (!opts.help && !opts.input) {
+    throw new GateContractCheckError('--input is required')
+  }
+  return opts
+}
+
+function nowStamp(date = new Date()) {
+  return date.toISOString().replace(/[:.]/g, '-')
+}
+
+function isFilled(value) {
+  if (value === null || value === undefined) return false
+  if (Array.isArray(value)) return value.length > 0
+  if (typeof value === 'object') return Object.keys(value).length > 0
+  return !PLACEHOLDER_PATTERN.test(String(value).trim())
+}
+
+function decisionFromIssues(issues) {
+  if (issues.some((issue) => issue.status === 'fail')) return { decision: 'FAIL', exitCode: 1 }
+  if (issues.some((issue) => issue.status === 'blocked')) return { decision: 'GATE_BLOCKED', exitCode: 2 }
+  return { decision: 'PASS', exitCode: 0 }
+}
+
+function addIssue(issues, status, id, message, details = {}) {
+  issues.push({ id, status, message, ...details })
+}
+
+function valueAtPath(value, pathName) {
+  return pathName.split('.').reduce((current, segment) => {
+    if (!current || typeof current !== 'object') return undefined
+    return current[segment]
+  }, value)
+}
+
+function getObject(value, pathName) {
+  const object = valueAtPath(value, pathName)
+  return object && typeof object === 'object' && !Array.isArray(object) ? object : {}
+}
+
+function validateRequiredAnswers({ answers, ids, sectionId, issues }) {
+  for (const id of ids) {
+    if (!isFilled(answers[id])) {
+      addIssue(issues, 'blocked', `${sectionId}.${id}`, `${id} is required before runtime work starts`)
+    }
+  }
+}
+
+function validateReadAnswerSemantics(answers, issues) {
+  for (const id of READ_METHOD_IDS) {
+    const method = String(answers[id] || '').trim().toUpperCase()
+    if (!method) continue
+    if (method !== 'GET' && method !== 'POST') {
+      addIssue(issues, 'blocked', `webapiReadList.${id}`, `${id} must be GET or POST`, { value: method })
+    }
+  }
+  for (const id of READ_PATH_IDS) {
+    const endpoint = String(answers[id] || '').trim()
+    if (!endpoint) continue
+    if (/^https?:\/\//i.test(endpoint)) {
+      addIssue(issues, 'fail', `webapiReadList.${id}`, `${id} must be a relative endpoint path, not an absolute URL`)
+    } else if (!endpoint.startsWith('/')) {
+      addIssue(issues, 'blocked', `webapiReadList.${id}`, `${id} should start with /`)
+    }
+    if (SECRET_QUERY_PATTERN.test(endpoint)) {
+      addIssue(issues, 'fail', `webapiReadList.${id}`, `${id} contains a secret-looking query parameter`)
+    }
+  }
+}
+
+function scanSecrets(value, issues, context) {
+  const visit = (current, pathName) => {
+    if (Array.isArray(current)) {
+      current.forEach((item, index) => visit(item, `${pathName}[${index}]`))
+      return
+    }
+    if (current && typeof current === 'object') {
+      for (const [key, child] of Object.entries(current)) {
+        const childPath = pathName ? `${pathName}.${key}` : key
+        if (SECRET_KEY_PATTERN.test(key) && typeof child === 'string' && child && !REDACTED_VALUE_PATTERN.test(child.trim())) {
+          addIssue(issues, 'fail', `${context}.secret.${childPath}`, 'secret-looking key has a non-redacted value')
+        }
+        visit(child, childPath)
+      }
+      return
+    }
+    if (typeof current !== 'string') return
+    if (JWT_PATTERN.test(current) || BEARER_PATTERN.test(current)) {
+      addIssue(issues, 'fail', `${context}.secret.${pathName}`, 'JWT/Bearer-shaped value is not allowed in GATE samples')
+    }
+    if (CONNECTION_STRING_PATTERN.test(current)) {
+      addIssue(issues, 'fail', `${context}.secret.${pathName}`, 'database connection string with credentials is not allowed in GATE samples')
+    }
+    if (SECRET_QUERY_PATTERN.test(current)) {
+      addIssue(issues, 'fail', `${context}.secret.${pathName}`, 'URL query secret is not allowed in GATE samples')
+    }
+  }
+  visit(value, '')
+}
+
+function firstObjectMatching(value, predicate) {
+  if (Array.isArray(value)) {
+    for (const child of value) {
+      const found = firstObjectMatching(child, predicate)
+      if (found) return found
+    }
+    return null
+  }
+  if (!value || typeof value !== 'object') return null
+  if (predicate(value)) return value
+  for (const child of Object.values(value)) {
+    const found = firstObjectMatching(child, predicate)
+    if (found) return found
+  }
+  return null
+}
+
+function hasAnyKey(object, keys) {
+  return keys.some((key) => Object.prototype.hasOwnProperty.call(object, key))
+}
+
+function assertMaterialSample(sample) {
+  const material = firstObjectMatching(sample, (object) => hasAnyKey(object, ['FNumber', 'Number', 'MaterialNumber']) && hasAnyKey(object, ['FName', 'Name', 'MaterialName']))
+  if (!material) {
+    throw new GateContractCheckError('Material sample must include at least one material-like row with number and name fields')
+  }
+}
+
+function assertBomSample(sample) {
+  const bom = firstObjectMatching(sample, (object) => {
+    const hasParent = hasAnyKey(object, ['FParentItemNumber', 'parentCode', 'ParentNumber'])
+    const childRows = Array.isArray(object.FChildItems) ? object.FChildItems : []
+    const hasChildArray = childRows.some((child) => child && typeof child === 'object' && hasAnyKey(child, ['FItemNumber', 'FChildItemNumber', 'childCode']) && hasAnyKey(child, ['FQty', 'quantity', 'Qty']))
+    const hasChild = hasAnyKey(object, ['FChildItemNumber', 'childCode', 'FItemNumber']) || hasChildArray
+    const hasQty = hasAnyKey(object, ['FQty', 'quantity', 'Qty']) || hasChildArray
+    return hasParent && hasChild && hasQty
+  })
+  if (!bom) {
+    throw new GateContractCheckError('BOM sample must include parent, child, and quantity fields')
+  }
+}
+
+function assertFlatBomLinesSample(sample) {
+  const records = Array.isArray(sample.records) ? sample.records : null
+  if (!records || records.length === 0) {
+    throw new GateContractCheckError('flat BOM sample must contain records[]')
+  }
+  const invalid = records.find((record) => !record || !record.parentCode || !record.childCode || record.quantity === undefined)
+  if (invalid) {
+    throw new GateContractCheckError('flat BOM records must include parentCode, childCode, and quantity')
+  }
+}
+
+function assertTreeBomSample(sample) {
+  const root = sample && sample.root
+  if (!root || typeof root !== 'object' || !Array.isArray(root.children) || root.children.length === 0) {
+    throw new GateContractCheckError('tree BOM sample must contain root.children[]')
+  }
+}
+
+function assertUnresolvedChildSample(sample) {
+  if (!sample || typeof sample !== 'object' || !sample.record || !sample.expectedCustomerPolicy) {
+    throw new GateContractCheckError('unresolved child sample must contain record and expectedCustomerPolicy')
+  }
+  if (!sample.record.parentCode || !sample.record.childCode) {
+    throw new GateContractCheckError('unresolved child record must include parentCode and childCode')
+  }
+}
+
+function assertK3BomSaveShape(sample) {
+  const data = sample && sample.Data
+  if (!data || typeof data !== 'object') {
+    throw new GateContractCheckError('K3 BOM Save shape must contain Data')
+  }
+  const flat = data.FParentItemNumber && data.FChildItemNumber && data.FQty !== undefined
+  const childArray = data.FParentItemNumber && Array.isArray(data.FChildItems) && data.FChildItems.length > 0
+  if (!flat && !childArray) {
+    throw new GateContractCheckError('K3 BOM Save shape must be either flat fields or Data.FChildItems[]')
+  }
+}
+
+async function readJsonFile(filePath) {
+  try {
+    return JSON.parse(await readFile(filePath, 'utf8'))
+  } catch (error) {
+    throw new GateContractCheckError(`cannot read JSON: ${error.message}`, { file: filePath })
+  }
+}
+
+async function validateSamples({ samples, sampleSpecs, baseDir, sectionId, issues }) {
+  const sampleResults = []
+  for (const [key, spec] of Object.entries(sampleSpecs)) {
+    const rawPath = samples[key]
+    if (!isFilled(rawPath)) {
+      addIssue(issues, 'blocked', `${sectionId}.sample.${key}`, `${spec.label} file is required`)
+      sampleResults.push({ key, status: 'blocked', label: spec.label })
+      continue
+    }
+    const resolved = path.resolve(baseDir, String(rawPath))
+    let sample
+    try {
+      sample = await readJsonFile(resolved)
+    } catch (error) {
+      addIssue(issues, 'blocked', `${sectionId}.sample.${key}`, error.message)
+      sampleResults.push({ key, status: 'blocked', label: spec.label })
+      continue
+    }
+    scanSecrets(sample, issues, `${sectionId}.sample.${key}`)
+    try {
+      spec.validator(sample)
+      sampleResults.push({ key, status: 'present', label: spec.label })
+    } catch (error) {
+      addIssue(issues, 'blocked', `${sectionId}.sample.${key}`, error.message)
+      sampleResults.push({ key, status: 'blocked', label: spec.label })
+    }
+  }
+  return sampleResults
+}
+
+export async function buildGateContractReport(packet, { inputPath = '', generatedAt = new Date().toISOString() } = {}) {
+  const issues = []
+  const baseDir = inputPath ? path.dirname(path.resolve(inputPath)) : process.cwd()
+  const webapiReadList = getObject(packet, 'webapiReadList')
+  const relationshipMapping = getObject(packet, 'relationshipMapping')
+  const readAnswers = getObject(webapiReadList, 'answers')
+  const relationshipAnswers = getObject(relationshipMapping, 'answers')
+
+  validateRequiredAnswers({
+    answers: readAnswers,
+    ids: READ_ANSWER_IDS,
+    sectionId: 'webapiReadList',
+    issues,
+  })
+  validateReadAnswerSemantics(readAnswers, issues)
+
+  validateRequiredAnswers({
+    answers: relationshipAnswers,
+    ids: RELATIONSHIP_ANSWER_IDS,
+    sectionId: 'relationshipMapping',
+    issues,
+  })
+
+  scanSecrets(readAnswers, issues, 'webapiReadList.answers')
+  scanSecrets(relationshipAnswers, issues, 'relationshipMapping.answers')
+
+  const readSamples = await validateSamples({
+    samples: getObject(webapiReadList, 'samples'),
+    sampleSpecs: READ_SAMPLES,
+    baseDir,
+    sectionId: 'webapiReadList',
+    issues,
+  })
+  const relationshipSamples = await validateSamples({
+    samples: getObject(relationshipMapping, 'samples'),
+    sampleSpecs: RELATIONSHIP_SAMPLES,
+    baseDir,
+    sectionId: 'relationshipMapping',
+    issues,
+  })
+
+  const decision = decisionFromIssues(issues)
+  return {
+    ok: decision.exitCode === 0,
+    generatedAt,
+    inputPath: inputPath ? path.resolve(inputPath) : '',
+    decision: decision.decision,
+    exitCode: decision.exitCode,
+    stage1Lock: {
+      status: 'held',
+      note: 'This checker validates customer evidence only; it does not touch plugin runtime, DB migrations, routes, or K3.',
+    },
+    sections: {
+      webapiReadList: {
+        requiredAnswers: READ_ANSWER_IDS.length,
+        answered: READ_ANSWER_IDS.filter((id) => isFilled(readAnswers[id])).length,
+        samples: readSamples,
+      },
+      relationshipMapping: {
+        requiredAnswers: RELATIONSHIP_ANSWER_IDS.length,
+        answered: RELATIONSHIP_ANSWER_IDS.filter((id) => isFilled(relationshipAnswers[id])).length,
+        samples: relationshipSamples,
+      },
+    },
+    issues,
+    summary: {
+      fail: issues.filter((issue) => issue.status === 'fail').length,
+      blocked: issues.filter((issue) => issue.status === 'blocked').length,
+      pass: decision.exitCode === 0 ? 1 : 0,
+    },
+  }
+}
+
+function renderMarkdown(report) {
+  const lines = [
+    '# K3 WISE GATE Contract Check',
+    '',
+    `- Generated at: \`${report.generatedAt}\``,
+    `- Decision: \`${report.decision}\``,
+    `- Exit code: \`${report.exitCode}\``,
+    `- Stage 1 Lock: \`${report.stage1Lock.status}\``,
+    `- Summary: ${report.summary.pass} pass / ${report.summary.blocked} blocked / ${report.summary.fail} fail`,
+    '',
+    '## Sections',
+    '',
+    '| Section | Answers | Samples |',
+    '| --- | ---: | ---: |',
+  ]
+  for (const [id, section] of Object.entries(report.sections)) {
+    const sampleOk = section.samples.filter((sample) => sample.status === 'present').length
+    lines.push(`| \`${id}\` | ${section.answered}/${section.requiredAnswers} | ${sampleOk}/${section.samples.length} |`)
+  }
+  lines.push('', '## Issues', '')
+  if (report.issues.length === 0) {
+    lines.push('No issues. Runtime work can start only if the broader customer GATE is also PASS.')
+  } else {
+    lines.push('| Status | ID | Message |', '| --- | --- | --- |')
+    for (const issue of report.issues) {
+      lines.push(`| \`${issue.status}\` | \`${issue.id}\` | ${String(issue.message).replace(/\|/g, '\\|')} |`)
+    }
+  }
+  lines.push('', '## Non-Goals', '')
+  lines.push('- This check does not contact K3 WISE or MetaSheet.')
+  lines.push('- This check does not enable WebAPI read/list, SQL sampling, or relationship runtime.')
+  lines.push('- This check does not lift the customer GATE.')
+  return `${lines.join('\n')}\n`
+}
+
+async function writeOutputs(report, outDir) {
+  await mkdir(outDir, { recursive: true })
+  const jsonPath = path.join(outDir, 'integration-k3wise-gate-contract-check.json')
+  const mdPath = path.join(outDir, 'integration-k3wise-gate-contract-check.md')
+  await writeFile(jsonPath, `${JSON.stringify(report, null, 2)}\n`)
+  await writeFile(mdPath, renderMarkdown(report))
+  return { jsonPath, mdPath }
+}
+
+async function main() {
+  const opts = parseArgs()
+  if (opts.help) {
+    printHelp()
+    return 0
+  }
+  const packet = await readJsonFile(opts.input)
+  const report = await buildGateContractReport(packet, { inputPath: opts.input })
+  const outDir = opts.outDir || path.join(DEFAULT_OUTPUT_ROOT, nowStamp())
+  const outputs = await writeOutputs(report, outDir)
+  console.log(JSON.stringify({
+    ok: report.ok,
+    decision: report.decision,
+    exitCode: report.exitCode,
+    summary: report.summary,
+    jsonPath: outputs.jsonPath,
+    mdPath: outputs.mdPath,
+  }, null, 2))
+  return report.exitCode
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main()
+    .then((code) => {
+      process.exitCode = code
+    })
+    .catch((error) => {
+      const details = error && error.details ? ` ${JSON.stringify(error.details)}` : ''
+      console.error(`${error.name || 'Error'}: ${error.message}${details}`)
+      process.exitCode = 1
+    })
+}

--- a/scripts/ops/integration-k3wise-gate-contract-check.test.mjs
+++ b/scripts/ops/integration-k3wise-gate-contract-check.test.mjs
@@ -1,0 +1,194 @@
+import assert from 'node:assert/strict'
+import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import test from 'node:test'
+
+import { buildGateContractReport } from './integration-k3wise-gate-contract-check.mjs'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const repoRoot = path.resolve(__dirname, '..', '..')
+const scriptPath = path.join(__dirname, 'integration-k3wise-gate-contract-check.mjs')
+
+async function makeDir() {
+  return mkdtemp(path.join(os.tmpdir(), 'k3wise-gate-contract-'))
+}
+
+async function writeJson(filePath, value) {
+  await mkdir(path.dirname(filePath), { recursive: true })
+  await writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`)
+}
+
+function completePacket() {
+  return {
+    webapiReadList: {
+      answers: {
+        'O1-MAT': '/K3API/Material/List',
+        'O1-MAT-M': 'POST',
+        'O1-BOM': '/K3API/BOM/List',
+        'O1-BOM-M': 'POST',
+        'O2-P': 'PageIndex/PageSize',
+        'O2-T': 'Total',
+        'O2-C': '100',
+        'O3-F': 'number and modifiedSince',
+        'O3-M': 'ModifiedSince',
+        'O4-MAT': 'FNumber,FName,FModel,FBaseUnitID',
+        'O4-BOM': 'FParentItemNumber,FChildItemNumber,FQty,FUnitID,FEntryID',
+        O6: 'same token scope as Save',
+      },
+      samples: {
+        materialList: 'sample-material-list.redacted.json',
+        materialDetail: 'sample-material-detail.redacted.json',
+        bomList: 'sample-bom-list.redacted.json',
+        bomDetail: 'sample-bom-detail.redacted.json',
+      },
+    },
+    relationshipMapping: {
+      answers: {
+        R1: 'flat lines',
+        R2: 'yes, parentCode and childCode are K3 FNumber values',
+        R3: 'parentCode + childCode + sequence',
+        R4: 'header body with FChildItems[]',
+        R5: 'dead-letter-row',
+        R6: 'unit and sequence are mandatory',
+        R7: 'yes',
+      },
+      samples: {
+        flatBomLines: 'relationship-flat-bom-lines.redacted.json',
+        treeBom: 'relationship-tree-bom.redacted.json',
+        unresolvedChild: 'relationship-unresolved-child.redacted.json',
+        k3BomSaveShape: 'relationship-k3-bom-save-shape.redacted.json',
+      },
+    },
+  }
+}
+
+async function writeCompleteSamples(dir, overrides = {}) {
+  const samples = {
+    'sample-material-list.redacted.json': {
+      ResponseStatus: { IsSuccess: true },
+      Data: [{ FNumber: 'MAT-001', FName: 'Sample material', FModel: 'Spec', FBaseUnitID: 'PCS' }],
+    },
+    'sample-material-detail.redacted.json': {
+      ResponseStatus: { IsSuccess: true },
+      Data: { FNumber: 'MAT-001', FName: 'Sample material' },
+    },
+    'sample-bom-list.redacted.json': {
+      ResponseStatus: { IsSuccess: true },
+      Data: [{ FParentItemNumber: 'FG-001', FChildItemNumber: 'MAT-001', FQty: 2, FUnitID: 'PCS' }],
+    },
+    'sample-bom-detail.redacted.json': {
+      ResponseStatus: { IsSuccess: true },
+      Data: { FParentItemNumber: 'FG-001', FChildItems: [{ FItemNumber: 'MAT-001', FQty: 2 }] },
+    },
+    'relationship-flat-bom-lines.redacted.json': {
+      case: 'flat-bom-lines',
+      records: [{ parentCode: 'FG-001', childCode: 'MAT-001', quantity: 2 }],
+    },
+    'relationship-tree-bom.redacted.json': {
+      case: 'tree-bom',
+      root: { code: 'FG-001', children: [{ code: 'MAT-001', quantity: 2 }] },
+    },
+    'relationship-unresolved-child.redacted.json': {
+      case: 'unresolved-child-material',
+      record: { parentCode: 'FG-001', childCode: 'MAT-MISSING' },
+      expectedCustomerPolicy: 'dead-letter-row',
+    },
+    'relationship-k3-bom-save-shape.redacted.json': {
+      Data: {
+        FParentItemNumber: 'FG-001',
+        FChildItems: [{ FItemNumber: 'MAT-001', FQty: 2, FUnitID: 'PCS', FEntryID: 1 }],
+      },
+    },
+    ...overrides,
+  }
+  await Promise.all(Object.entries(samples).map(([fileName, value]) => writeJson(path.join(dir, fileName), value)))
+}
+
+function runCli(args, cwd = repoRoot) {
+  return spawnSync(process.execPath, [scriptPath, ...args], {
+    cwd,
+    encoding: 'utf8',
+  })
+}
+
+test('complete GATE contract packet passes and writes JSON/Markdown evidence', async () => {
+  const dir = await makeDir()
+  await writeCompleteSamples(dir)
+  const packetPath = path.join(dir, 'packet.json')
+  const outDir = path.join(dir, 'out')
+  await writeJson(packetPath, completePacket())
+
+  const result = runCli(['--input', packetPath, '--out-dir', outDir])
+  assert.equal(result.status, 0, result.stderr)
+  assert.match(result.stdout, /"decision": "PASS"/)
+
+  const evidence = JSON.parse(await readFile(path.join(outDir, 'integration-k3wise-gate-contract-check.json'), 'utf8'))
+  assert.equal(evidence.decision, 'PASS')
+  assert.equal(evidence.sections.webapiReadList.answered, 12)
+  assert.equal(evidence.sections.relationshipMapping.answered, 7)
+  assert.equal(evidence.issues.length, 0)
+
+  const markdown = await readFile(path.join(outDir, 'integration-k3wise-gate-contract-check.md'), 'utf8')
+  assert.match(markdown, /Decision: `PASS`/)
+  assert.match(markdown, /Stage 1 Lock: `held`/)
+})
+
+test('missing answers or sample files block runtime work with exit 2', async () => {
+  const dir = await makeDir()
+  await writeCompleteSamples(dir)
+  const packet = completePacket()
+  packet.webapiReadList.answers['O1-BOM'] = '<fill>'
+  packet.relationshipMapping.samples.treeBom = 'missing-tree.redacted.json'
+  const report = await buildGateContractReport(packet, {
+    inputPath: path.join(dir, 'packet.json'),
+    generatedAt: '2026-05-18T00:00:00.000Z',
+  })
+
+  assert.equal(report.decision, 'GATE_BLOCKED')
+  assert.equal(report.exitCode, 2)
+  assert(report.issues.some((issue) => issue.id === 'webapiReadList.O1-BOM'))
+  assert(report.issues.some((issue) => issue.id === 'relationshipMapping.sample.treeBom'))
+})
+
+test('absolute read endpoints are rejected before runtime work', async () => {
+  const dir = await makeDir()
+  await writeCompleteSamples(dir)
+  const packet = completePacket()
+  packet.webapiReadList.answers['O1-MAT'] = 'https://k3.example.test/K3API/Material/List'
+
+  const report = await buildGateContractReport(packet, {
+    inputPath: path.join(dir, 'packet.json'),
+    generatedAt: '2026-05-18T00:00:00.000Z',
+  })
+
+  assert.equal(report.decision, 'FAIL')
+  assert(report.issues.some((issue) => issue.id === 'webapiReadList.O1-MAT' && issue.status === 'fail'))
+})
+
+test('secret-looking sample values fail and evidence does not echo raw secret', async () => {
+  const dir = await makeDir()
+  await writeCompleteSamples(dir, {
+    'sample-material-detail.redacted.json': {
+      ResponseStatus: { IsSuccess: true },
+      Data: {
+        FNumber: 'MAT-001',
+        FName: 'Sample material',
+        password: 'RAW-PASSWORD-SHOULD-NOT-LEAK',
+        callback: 'https://k3.example.test/K3API/?access_token=RAW-TOKEN-SHOULD-NOT-LEAK',
+      },
+    },
+  })
+  const packetPath = path.join(dir, 'packet.json')
+  const outDir = path.join(dir, 'out')
+  await writeJson(packetPath, completePacket())
+
+  const result = runCli(['--input', packetPath, '--out-dir', outDir])
+  assert.equal(result.status, 1)
+  const evidenceText = await readFile(path.join(outDir, 'integration-k3wise-gate-contract-check.json'), 'utf8')
+  assert.match(evidenceText, /secret-looking key/)
+  assert.equal(evidenceText.includes('RAW-PASSWORD-SHOULD-NOT-LEAK'), false)
+  assert.equal(evidenceText.includes('RAW-TOKEN-SHOULD-NOT-LEAK'), false)
+})


### PR DESCRIPTION
## Summary
- add an ops-only checker for #1526 WebAPI read/list O1-O6 and relationship R1-R7 customer evidence
- validate required answers, relative read endpoints, redacted sample JSON shapes, and secret hygiene before any runtime PR starts
- update the WebAPI read/list and relationship customer manifests to point operators at the checker
- add design and verification MD for the Stage 1 Lock-safe slice

## Verification
- pnpm verify:integration-k3wise:gate-contract
- node --check scripts/ops/integration-k3wise-gate-contract-check.mjs
- node --check scripts/ops/integration-k3wise-gate-contract-check.test.mjs
- git diff --check origin/main...HEAD
- pnpm verify:integration-k3wise:poc

## Stage 1 Lock / Deployment Impact
- no plugin-integration-core runtime changes
- no DB migration, backend route/API, frontend runtime, or K3 network call
- does not lift customer GATE; it only machine-checks the returned evidence before post-GATE runtime work

Relates to #1526.