### PR TITLE
feat(multitable): add home template quickstart

### DIFF
--- a/apps/web/src/views/MultitableHomeView.vue
+++ b/apps/web/src/views/MultitableHomeView.vue
@@ -8,7 +8,7 @@
           打开 Base、继续清洗表或从模板开始。Grid 和 Spreadsheets 仍保留旧链接，但默认工作入口收敛到多维表。
         </p>
       </div>
-      <button class="multitable-home__refresh" :disabled="loading" @click="loadBases">
+      <button class="multitable-home__refresh" :disabled="loading" @click="loadHomeData">
         {{ loading ? '刷新中...' : '刷新' }}
       </button>
     </header>
@@ -33,6 +33,47 @@
     </section>
 
     <p v-if="errorMessage" class="multitable-home__error" role="alert">{{ errorMessage }}</p>
+    <p v-if="templateError" class="multitable-home__warning" role="status">{{ templateError }}</p>
+
+    <section class="multitable-home__panel" aria-label="Template quick start">
+      <div class="multitable-home__panel-head">
+        <h2>模板快速开始</h2>
+        <span>{{ templates.length }} 个</span>
+      </div>
+
+      <div v-if="templateLoading" class="multitable-home__state">正在加载模板...</div>
+      <div v-else-if="!templates.length" class="multitable-home__empty">
+        暂无可用模板。你仍可直接新建空白 Base。
+      </div>
+      <div v-else class="multitable-home__template-grid">
+        <article
+          v-for="template in templates"
+          :key="template.id"
+          class="multitable-home__template-card"
+          :style="{ borderColor: template.color || '#cbd5e1' }"
+        >
+          <div class="multitable-home__template-top">
+            <span class="multitable-home__template-icon" :style="{ background: template.color || '#2563eb' }">
+              {{ template.icon || template.name.slice(0, 1).toUpperCase() }}
+            </span>
+            <span class="multitable-home__template-category">{{ template.category }}</span>
+          </div>
+          <h3>{{ template.name }}</h3>
+          <p>{{ template.description }}</p>
+          <small>
+            {{ template.sheets.length }} 个 Sheet ·
+            {{ countTemplateViews(template) }} 个视图
+          </small>
+          <button
+            class="multitable-home__open multitable-home__open--wide"
+            :disabled="installingTemplateId === template.id"
+            @click="installTemplateAndOpen(template)"
+          >
+            {{ installingTemplateId === template.id ? '创建中...' : '使用模板' }}
+          </button>
+        </article>
+      </div>
+    </section>
 
     <section class="multitable-home__panel">
       <div class="multitable-home__panel-head">
@@ -70,16 +111,27 @@
 import { onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { multitableClient } from '../multitable/api/client'
-import type { MetaBase, MetaContext, MetaSheet, MetaView } from '../multitable/types'
+import type {
+  InstallTemplateResult,
+  MetaBase,
+  MetaContext,
+  MetaSheet,
+  MetaTemplate,
+  MetaView,
+} from '../multitable/types'
 import { AppRouteNames } from '../router/types'
 
 const router = useRouter()
 
 const bases = ref<MetaBase[]>([])
+const templates = ref<MetaTemplate[]>([])
 const loading = ref(false)
+const templateLoading = ref(false)
 const creating = ref(false)
 const openingBaseId = ref<string | null>(null)
+const installingTemplateId = ref<string | null>(null)
 const errorMessage = ref('')
+const templateError = ref('')
 const newBaseName = ref('')
 
 function resolveOpenTarget(context: MetaContext): { sheet: MetaSheet; view: MetaView } | null {
@@ -87,6 +139,17 @@ function resolveOpenTarget(context: MetaContext): { sheet: MetaSheet; view: Meta
   if (!sheet) return null
   const view = context.views.find((candidate) => candidate.sheetId === sheet.id) ?? context.views[0] ?? null
   return view ? { sheet, view } : null
+}
+
+function resolveTemplateTarget(result: InstallTemplateResult): { sheet: MetaSheet; view: MetaView } | null {
+  const sheet = result.sheets[0] ?? null
+  if (!sheet) return null
+  const view = result.views.find((candidate) => candidate.sheetId === sheet.id) ?? result.views[0] ?? null
+  return view ? { sheet, view } : null
+}
+
+function countTemplateViews(template: MetaTemplate): number {
+  return template.sheets.reduce((sum, sheet) => sum + sheet.views.length, 0)
 }
 
 async function loadBases(): Promise<void> {
@@ -100,6 +163,23 @@ async function loadBases(): Promise<void> {
   } finally {
     loading.value = false
   }
+}
+
+async function loadTemplates(): Promise<void> {
+  templateLoading.value = true
+  templateError.value = ''
+  try {
+    const data = await multitableClient.listTemplates()
+    templates.value = data.templates ?? []
+  } catch (error) {
+    templateError.value = error instanceof Error ? error.message : '模板加载失败，可继续新建空白 Base。'
+  } finally {
+    templateLoading.value = false
+  }
+}
+
+async function loadHomeData(): Promise<void> {
+  await Promise.all([loadBases(), loadTemplates()])
 }
 
 async function openBase(base: MetaBase): Promise<void> {
@@ -121,6 +201,33 @@ async function openBase(base: MetaBase): Promise<void> {
     errorMessage.value = error instanceof Error ? error.message : '打开多维表失败'
   } finally {
     openingBaseId.value = null
+  }
+}
+
+async function installTemplateAndOpen(template: MetaTemplate): Promise<void> {
+  if (installingTemplateId.value) return
+  installingTemplateId.value = template.id
+  errorMessage.value = ''
+  try {
+    const result = await multitableClient.installTemplate(template.id, { baseName: `${template.name} Base` })
+    if (!bases.value.some((base) => base.id === result.base.id)) {
+      bases.value = [result.base, ...bases.value]
+    }
+    const target = resolveTemplateTarget(result)
+    if (!target) {
+      errorMessage.value = '模板已创建，但默认视图尚未就绪。请刷新后重试。'
+      await loadBases()
+      return
+    }
+    await router.push({
+      name: AppRouteNames.MULTITABLE,
+      params: { sheetId: target.sheet.id, viewId: target.view.id },
+      query: { baseId: result.base.id },
+    })
+  } catch (error) {
+    errorMessage.value = error instanceof Error ? error.message : '模板创建失败'
+  } finally {
+    installingTemplateId.value = null
   }
 }
 
@@ -151,7 +258,7 @@ async function createBaseAndOpen(): Promise<void> {
   }
 }
 
-onMounted(loadBases)
+onMounted(loadHomeData)
 </script>
 
 <style scoped>
@@ -297,6 +404,64 @@ onMounted(loadBases)
   padding: 18px;
 }
 
+.multitable-home__template-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 16px;
+  padding: 18px;
+}
+
+.multitable-home__template-card {
+  display: grid;
+  gap: 12px;
+  align-content: start;
+  border: 1px solid #cbd5e1;
+  border-radius: 20px;
+  padding: 16px;
+  background: linear-gradient(180deg, #fff 0%, #f8fafc 100%);
+}
+
+.multitable-home__template-top {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: center;
+}
+
+.multitable-home__template-icon {
+  width: 38px;
+  height: 38px;
+  border-radius: 14px;
+  display: grid;
+  place-items: center;
+  color: #fff;
+  font-weight: 800;
+}
+
+.multitable-home__template-category {
+  border-radius: 999px;
+  padding: 5px 9px;
+  background: #e0f2fe;
+  color: #0369a1;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.multitable-home__template-card h3,
+.multitable-home__template-card p {
+  margin: 0;
+}
+
+.multitable-home__template-card p {
+  color: #475569;
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.multitable-home__template-card small {
+  color: #64748b;
+}
+
 .multitable-home__card {
   display: grid;
   grid-template-columns: auto 1fr auto;
@@ -335,6 +500,20 @@ onMounted(loadBases)
   padding: 12px 14px;
   background: #fef2f2;
   color: #b91c1c;
+}
+
+.multitable-home__warning {
+  max-width: 1120px;
+  margin: 18px auto 0;
+  border: 1px solid #fde68a;
+  border-radius: 16px;
+  padding: 12px 14px;
+  background: #fffbeb;
+  color: #92400e;
+}
+
+.multitable-home__open--wide {
+  justify-self: start;
 }
 
 button:disabled {

--- a/apps/web/tests/multitable-home-view.spec.ts
+++ b/apps/web/tests/multitable-home-view.spec.ts
@@ -1,14 +1,16 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { createApp, h, nextTick, type App as VueApp, type Component } from 'vue'
+import { createApp, nextTick, type App as VueApp, type Component } from 'vue'
 import MultitableHomeView from '../src/views/MultitableHomeView.vue'
 import { AppRouteNames } from '../src/router/types'
 
 const mocks = vi.hoisted(() => ({
   push: vi.fn(),
   listBases: vi.fn(),
+  listTemplates: vi.fn(),
   loadContext: vi.fn(),
   createBase: vi.fn(),
   createSheet: vi.fn(),
+  installTemplate: vi.fn(),
 }))
 
 vi.mock('vue-router', async () => {
@@ -24,9 +26,11 @@ vi.mock('vue-router', async () => {
 vi.mock('../src/multitable/api/client', () => ({
   multitableClient: {
     listBases: mocks.listBases,
+    listTemplates: mocks.listTemplates,
     loadContext: mocks.loadContext,
     createBase: mocks.createBase,
     createSheet: mocks.createSheet,
+    installTemplate: mocks.installTemplate,
   },
 }))
 
@@ -65,12 +69,6 @@ describe('MultitableHomeView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(MultitableHomeView as Component)
-    app.component('router-link', {
-      props: ['to'],
-      render() {
-        return h('a', { href: this.$props.to }, this.$slots.default ? this.$slots.default() : [])
-      },
-    })
     app.mount(container)
     return container
   }
@@ -79,6 +77,7 @@ describe('MultitableHomeView', () => {
     mocks.listBases.mockResolvedValue({
       bases: [{ id: 'base_ops', name: 'Ops Base', color: '#0f766e' }],
     })
+    mocks.listTemplates.mockResolvedValue({ templates: [] })
     mocks.loadContext.mockResolvedValue({
       base: { id: 'base_ops', name: 'Ops Base' },
       sheet: { id: 'sheet_ops', baseId: 'base_ops', name: 'Orders' },
@@ -105,6 +104,7 @@ describe('MultitableHomeView', () => {
 
   it('creates a base with a seeded sheet before opening multitable', async () => {
     mocks.listBases.mockResolvedValue({ bases: [] })
+    mocks.listTemplates.mockResolvedValue({ templates: [] })
     mocks.createBase.mockResolvedValue({ base: { id: 'base_new', name: 'Project Tracker' } })
     mocks.createSheet.mockResolvedValue({ sheet: { id: 'sheet_new', baseId: 'base_new', name: 'Sheet 1', seeded: true } })
     mocks.loadContext.mockResolvedValue({
@@ -133,6 +133,56 @@ describe('MultitableHomeView', () => {
       name: AppRouteNames.MULTITABLE,
       params: { sheetId: 'sheet_new', viewId: 'view_new' },
       query: { baseId: 'base_new' },
+    })
+  })
+
+  it('loads templates and opens an installed template base', async () => {
+    mocks.listBases.mockResolvedValue({ bases: [] })
+    mocks.listTemplates.mockResolvedValue({
+      templates: [
+        {
+          id: 'project-tracker',
+          name: 'Project Tracker',
+          description: 'Track launch tasks and owners.',
+          category: 'Project management',
+          icon: 'P',
+          color: '#2563eb',
+          sheets: [
+            {
+              id: 'template-sheet',
+              name: 'Tasks',
+              fields: [],
+              views: [
+                { id: 'template-view-grid', name: 'Grid', type: 'grid' },
+                { id: 'template-view-kanban', name: 'Kanban', type: 'kanban' },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+    mocks.installTemplate.mockResolvedValue({
+      template: { id: 'project-tracker', name: 'Project Tracker' },
+      base: { id: 'base_template', name: 'Project Tracker Base' },
+      sheets: [{ id: 'sheet_template', baseId: 'base_template', name: 'Tasks' }],
+      fields: [],
+      views: [{ id: 'view_template', sheetId: 'sheet_template', name: 'Grid', type: 'grid' }],
+    })
+
+    const root = mountView()
+    await flushUi()
+
+    expect(root.textContent).toContain('Project Tracker')
+    expect(root.textContent).toContain('1 个 Sheet · 2 个视图')
+
+    findButton(root, '使用模板').click()
+    await flushUi()
+
+    expect(mocks.installTemplate).toHaveBeenCalledWith('project-tracker', { baseName: 'Project Tracker Base' })
+    expect(mocks.push).toHaveBeenCalledWith({
+      name: AppRouteNames.MULTITABLE,
+      params: { sheetId: 'sheet_template', viewId: 'view_template' },
+      query: { baseId: 'base_template' },
     })
   })
 })

--- a/docs/development/multitable-home-template-quickstart-development-20260518.md
+++ b/docs/development/multitable-home-template-quickstart-development-20260518.md
@@ -1,0 +1,88 @@
+# Multitable Home Template Quickstart Development - 2026-05-18
+
+## Why This PR Exists
+
+PR #1618 made `/multitable` the primary table entry, but the landing page still behaved mostly as a base list plus blank-base creator. The hero copy already promised "from templates"; this PR wires the existing template APIs into the home page so users can start from a template without first entering the full workbench.
+
+## Scope
+
+In scope:
+
+- Load the existing multitable template library on `/multitable`.
+- Render template cards with category, description, sheet count, and view count.
+- Install a template through the existing `MultitableApiClient.installTemplate` method.
+- Route the user into the first installed sheet/view with `baseId` preserved in query params.
+- Keep the existing blank Base creation flow unchanged.
+- Add focused frontend regression coverage.
+
+Out of scope:
+
+- No backend route, migration, OpenAPI, schema, or permission changes.
+- No change to `/grid` or `/spreadsheets` legacy compatibility.
+- No change to `MultitableWorkbench.vue` template-library behavior.
+- No new template definitions.
+- No staging deploy or browser smoke in this PR.
+
+## Implementation
+
+### Template Loading
+
+`MultitableHomeView.vue` now loads bases and templates together through:
+
+- `multitableClient.listBases()`
+- `multitableClient.listTemplates()`
+
+Each loader catches its own error. A template-library failure does not block the base list or blank-base creation flow; it renders a warning and lets users continue with an empty Base.
+
+### Template Cards
+
+The home page renders a new "模板快速开始" panel. Each card shows:
+
+- template icon / fallback first letter
+- category
+- name
+- description
+- sheet count
+- total view count across template sheets
+
+The view count is computed client-side from `template.sheets[].views`.
+
+### Install And Open
+
+Clicking "使用模板" calls:
+
+```ts
+multitableClient.installTemplate(template.id, { baseName: `${template.name} Base` })
+```
+
+After install, the page:
+
+1. Prepends the installed base to the local base list if it is not already present.
+2. Resolves the first installed sheet and its matching first view.
+3. Navigates to `AppRouteNames.MULTITABLE` with `{ sheetId, viewId }` params and `{ baseId }` query.
+4. If the install response has no usable sheet/view, shows a user-facing error and refreshes bases.
+
+This matches the existing blank-base create path: create or install first, then route directly into the workbench.
+
+## Files Changed
+
+- `apps/web/src/views/MultitableHomeView.vue`
+- `apps/web/tests/multitable-home-view.spec.ts`
+- `docs/development/multitable-home-template-quickstart-development-20260518.md`
+- `docs/development/multitable-home-template-quickstart-verification-20260518.md`
+
+## Parallel Read-Only Scout
+
+A parallel read-only explorer confirmed:
+
+- `/multitable` already routes to `MultitableHomeView`.
+- `MultitableApiClient` already exposes `listBases`, `createBase`, `listTemplates`, `installTemplate`, `createSheet`, and `createView`.
+- Backend routes for `/bases`, `/templates`, and `/templates/:templateId/install` already exist.
+- Existing tests cover base list/open and blank-base creation; the useful missing home-level behavior was template install/open.
+
+## Risk Notes
+
+- Template install uses existing backend authorization and validation.
+- The PR does not invent a new data shape; it consumes existing `MetaTemplate` and `InstallTemplateResult`.
+- The panel is additive. If templates fail to load, existing base workflows continue.
+- The direct legacy route compatibility policy from #1618 is unchanged.

--- a/docs/development/multitable-home-template-quickstart-verification-20260518.md
+++ b/docs/development/multitable-home-template-quickstart-verification-20260518.md
@@ -1,0 +1,89 @@
+# Multitable Home Template Quickstart Verification - 2026-05-18
+
+## Result
+
+PASS.
+
+This verification covers the frontend-only `/multitable` home template quickstart slice.
+
+## Repository State
+
+- Base: `origin/main@32ef0ee75`
+- Worktree: `/private/tmp/ms2-multitable-home-quickstart-20260518`
+- Branch: `codex/multitable-home-quickstart-20260518`
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile --ignore-scripts
+```
+
+Result: PASS.
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/multitable-home-view.spec.ts \
+  tests/platform-shell-nav.spec.ts \
+  --watch=false
+```
+
+Result: PASS.
+
+```text
+Test Files  2 passed (2)
+Tests       6 passed (6)
+```
+
+Coverage added:
+
+- Existing base list/open regression remains covered.
+- Existing blank Base creation/open regression remains covered.
+- New template load/install/open regression covers:
+  - rendering a template card,
+  - displaying sheet/view counts,
+  - calling `installTemplate(template.id, { baseName })`,
+  - routing into the installed base's first sheet/view.
+
+```bash
+pnpm --filter @metasheet/web exec eslint \
+  "src/views/MultitableHomeView.vue" \
+  "tests/multitable-home-view.spec.ts" \
+  --max-warnings=0
+```
+
+Result: PASS.
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+```
+
+Result: PASS.
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+```
+
+Result: PASS.
+
+Backend type-check was run even though the PR is frontend-only, to verify no shared type imports or workspace state regressed.
+
+```bash
+git diff --check
+```
+
+Result: PASS.
+
+Secret-pattern scan over the touched source, test, and markdown files.
+
+Result: PASS, 0 matches.
+
+## What This Does Not Verify
+
+- Does not perform a browser smoke against local dev or staging.
+- Does not execute a real template install against a live database.
+- Does not validate template library content; existing backend tests and client tests cover endpoint shape.
+- Does not change or retest `/grid` and `/spreadsheets` beyond the existing platform-shell nav regression.
+
+## Final Verdict
+
+The `/multitable` home page now has a practical template quickstart path using already-shipped multitable template APIs. The change is additive, frontend-only, and verified with focused unit tests, lint, and type checks.


### PR DESCRIPTION
## Summary
- Add a template quickstart panel to the /multitable landing page.
- Load existing multitable templates, render category/description/sheet-view counts, and install a selected template through the existing API client.
- Route directly into the installed base's first sheet/view while keeping the existing blank Base flow unchanged.

## Verification
- pnpm --filter @metasheet/web exec vitest run tests/multitable-home-view.spec.ts tests/platform-shell-nav.spec.ts --watch=false
- pnpm --filter @metasheet/web exec eslint "src/views/MultitableHomeView.vue" "tests/multitable-home-view.spec.ts" --max-warnings=0
- pnpm --filter @metasheet/web exec vue-tsc --noEmit
- pnpm --filter @metasheet/core-backend exec tsc --noEmit
- git diff --check
- secret-pattern scan over touched files: 0 matches

## Scope
Frontend-only. No backend route, migration, OpenAPI, K3, Data Factory, Attendance, DingTalk, plugin-integration-core, /grid, or /spreadsheets changes.