### PR TITLE
feat(multitable): add home base search

### DIFF
--- a/apps/web/src/views/MultitableHomeView.vue
+++ b/apps/web/src/views/MultitableHomeView.vue
@@ -77,16 +77,32 @@
 
     <section class="multitable-home__panel">
       <div class="multitable-home__panel-head">
-        <h2>可访问的 Base</h2>
-        <span>{{ bases.length }} 个</span>
+        <div>
+          <h2>可访问的 Base</h2>
+          <p v-if="bases.length" class="multitable-home__panel-subtitle">
+            {{ baseSearch.trim() ? `匹配 ${filteredBases.length} / ${bases.length} 个` : `${bases.length} 个` }}
+          </p>
+        </div>
+        <label v-if="bases.length" class="multitable-home__search">
+          <span>搜索 Base</span>
+          <input
+            v-model="baseSearch"
+            type="search"
+            placeholder="按名称或 ID 搜索"
+            aria-label="Search bases"
+          />
+        </label>
       </div>
 
       <div v-if="loading" class="multitable-home__state">正在加载多维表...</div>
       <div v-else-if="!bases.length" class="multitable-home__empty">
         暂无可访问的 Base。你可以新建一个，或从数据工厂/考勤等业务入口生成多维表。
       </div>
+      <div v-else-if="!filteredBases.length" class="multitable-home__empty">
+        没有匹配的 Base。请调整搜索关键词。
+      </div>
       <div v-else class="multitable-home__grid">
-        <article v-for="base in bases" :key="base.id" class="multitable-home__card">
+        <article v-for="base in filteredBases" :key="base.id" class="multitable-home__card">
           <div class="multitable-home__card-icon" :style="{ background: base.color || '#2563eb' }">
             {{ base.icon || base.name.slice(0, 1).toUpperCase() }}
           </div>
@@ -108,7 +124,7 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { multitableClient } from '../multitable/api/client'
 import type {
@@ -133,6 +149,15 @@ const installingTemplateId = ref<string | null>(null)
 const errorMessage = ref('')
 const templateError = ref('')
 const newBaseName = ref('')
+const baseSearch = ref('')
+
+const filteredBases = computed(() => {
+  const query = baseSearch.value.trim().toLowerCase()
+  if (!query) return bases.value
+  return bases.value.filter((base) => {
+    return base.name.toLowerCase().includes(query) || base.id.toLowerCase().includes(query)
+  })
+})
 
 function resolveOpenTarget(context: MetaContext): { sheet: MetaSheet; view: MetaView } | null {
   const sheet = context.sheet ?? context.sheets[0] ?? null
@@ -382,6 +407,7 @@ onMounted(loadHomeData)
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 16px;
   padding: 22px 24px;
   border-bottom: 1px solid #e2e8f0;
 }
@@ -389,6 +415,29 @@ onMounted(loadHomeData)
 .multitable-home__panel-head h2 {
   margin: 0;
   font-size: 18px;
+}
+
+.multitable-home__panel-subtitle {
+  margin: 6px 0 0;
+  color: #64748b;
+  font-size: 13px;
+}
+
+.multitable-home__search {
+  display: grid;
+  gap: 6px;
+  min-width: min(300px, 100%);
+  color: #64748b;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.multitable-home__search input {
+  border: 1px solid #cbd5e1;
+  border-radius: 999px;
+  padding: 10px 14px;
+  color: #0f172a;
+  font-size: 14px;
 }
 
 .multitable-home__state,
@@ -527,7 +576,8 @@ button:disabled {
   }
 
   .multitable-home__hero,
-  .multitable-home__create {
+  .multitable-home__create,
+  .multitable-home__panel-head {
     display: grid;
   }
 

--- a/apps/web/tests/multitable-home-view.spec.ts
+++ b/apps/web/tests/multitable-home-view.spec.ts
@@ -102,6 +102,40 @@ describe('MultitableHomeView', () => {
     })
   })
 
+  it('filters visible bases by name or id without changing the loaded list', async () => {
+    mocks.listBases.mockResolvedValue({
+      bases: [
+        { id: 'base_ops', name: 'Ops Base', color: '#0f766e' },
+        { id: 'base_sales', name: 'Sales Pipeline', color: '#f97316' },
+      ],
+    })
+    mocks.listTemplates.mockResolvedValue({ templates: [] })
+
+    const root = mountView()
+    await flushUi()
+
+    expect(root.textContent).toContain('Ops Base')
+    expect(root.textContent).toContain('Sales Pipeline')
+    expect(root.textContent).toContain('2 个')
+
+    const search = root.querySelector('input[aria-label="Search bases"]')
+    expect(search).toBeInstanceOf(HTMLInputElement)
+    ;(search as HTMLInputElement).value = 'sales'
+    search?.dispatchEvent(new Event('input'))
+    await flushUi()
+
+    expect(root.textContent).not.toContain('Ops Base')
+    expect(root.textContent).toContain('Sales Pipeline')
+    expect(root.textContent).toContain('匹配 1 / 2 个')
+
+    ;(search as HTMLInputElement).value = 'missing'
+    search?.dispatchEvent(new Event('input'))
+    await flushUi()
+
+    expect(root.textContent).toContain('没有匹配的 Base')
+    expect(root.textContent).not.toContain('暂无可访问的 Base')
+  })
+
   it('creates a base with a seeded sheet before opening multitable', async () => {
     mocks.listBases.mockResolvedValue({ bases: [] })
     mocks.listTemplates.mockResolvedValue({ templates: [] })

--- a/docs/development/multitable-home-base-search-development-20260518.md
+++ b/docs/development/multitable-home-base-search-development-20260518.md
@@ -1,0 +1,67 @@
+# Multitable Home Base Search Development - 2026-05-18
+
+## Why This PR Exists
+
+After `/multitable` became the primary table entry and gained template quickstart, the landing page still listed all accessible bases without a way to narrow the list. That is acceptable for a few bases, but it becomes noisy once users start using templates and data-factory generated bases.
+
+This PR adds a local search filter to the "可访问的 Base" panel.
+
+## Scope
+
+In scope:
+
+- Add a search input to the Base list panel when at least one Base is loaded.
+- Filter visible Base cards by name or ID.
+- Show matched count versus total count when a search query is active.
+- Show a no-match empty state when the loaded list has bases but none match the query.
+- Add focused frontend regression coverage.
+
+Out of scope:
+
+- No backend changes.
+- No new API query parameter.
+- No persistence of search state.
+- No sorting, favorites, recent history, or pagination.
+- No `/grid` or `/spreadsheets` behavior changes.
+
+## Implementation
+
+`MultitableHomeView.vue` now keeps:
+
+```ts
+const baseSearch = ref('')
+```
+
+and derives:
+
+```ts
+const filteredBases = computed(() => {
+  const query = baseSearch.value.trim().toLowerCase()
+  if (!query) return bases.value
+  return bases.value.filter((base) => {
+    return base.name.toLowerCase().includes(query) || base.id.toLowerCase().includes(query)
+  })
+})
+```
+
+The page renders `filteredBases` instead of `bases` and preserves the existing loaded `bases` array. Search is therefore UI-only and does not change API calls or loaded state.
+
+The panel count behaves as follows:
+
+- No search query: shows total base count.
+- Search query active: shows `匹配 X / Y 个`.
+- No match: shows `没有匹配的 Base。请调整搜索关键词。`
+
+## Files Changed
+
+- `apps/web/src/views/MultitableHomeView.vue`
+- `apps/web/tests/multitable-home-view.spec.ts`
+- `docs/development/multitable-home-base-search-development-20260518.md`
+- `docs/development/multitable-home-base-search-verification-20260518.md`
+
+## Risk Notes
+
+- Filtering is local and case-insensitive.
+- The loaded base list is not mutated.
+- Existing open/create/template flows remain unchanged.
+- The search field only renders when the user has at least one Base, avoiding an unnecessary control in the empty state.

--- a/docs/development/multitable-home-base-search-verification-20260518.md
+++ b/docs/development/multitable-home-base-search-verification-20260518.md
@@ -1,0 +1,95 @@
+# Multitable Home Base Search Verification - 2026-05-18
+
+## Result
+
+PASS.
+
+This verification covers the frontend-only `/multitable` home Base search slice.
+
+## Repository State
+
+- Base: `origin/main@ab4ef5b11`
+- Worktree: `/private/tmp/ms2-multitable-home-base-search-20260518`
+- Branch: `codex/multitable-home-base-search-20260518`
+
+## Parallel Read-Only Scout
+
+A read-only explorer confirmed:
+
+- `/multitable` home rendered `bases` directly with no home-level search/filter/sort state.
+- `MetaBasePicker.vue` has dropdown search behavior, but that belongs to the workbench picker, not the landing page.
+- Backend accessible-base filtering already exists and is unrelated to client-side search.
+- No backend/API tests are needed for this slice because `listBases()` parameters are unchanged.
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile --ignore-scripts
+```
+
+Result: PASS.
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/multitable-home-view.spec.ts \
+  tests/platform-shell-nav.spec.ts \
+  --watch=false
+```
+
+Result: PASS.
+
+```text
+Test Files  2 passed (2)
+Tests       7 passed (7)
+```
+
+Coverage added:
+
+- Search input renders after bases are loaded.
+- Search filters visible Base cards by name.
+- Search count shows matched versus total loaded bases.
+- Filtered-empty state is distinct from the global no-accessible-base empty state.
+
+```bash
+pnpm --filter @metasheet/web exec eslint \
+  "src/views/MultitableHomeView.vue" \
+  "tests/multitable-home-view.spec.ts" \
+  --max-warnings=0
+```
+
+Result: PASS.
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+```
+
+Result: PASS.
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+```
+
+Result: PASS.
+
+Backend type-check was run even though this slice is frontend-only.
+
+```bash
+git diff --check
+```
+
+Result: PASS.
+
+Secret-pattern scan over the touched source, test, and markdown files.
+
+Result: PASS, 0 matches.
+
+## What This Does Not Verify
+
+- Does not run a browser smoke.
+- Does not test server-side search because no server-side search was added.
+- Does not change or retest `/grid` and `/spreadsheets` beyond existing platform-shell navigation coverage.
+- Does not touch template install behavior from PR #1628 except through the retained home-view regression suite.
+
+## Final Verdict
+
+The `/multitable` landing page now supports local Base search without changing backend contracts or loaded Base state.


### PR DESCRIPTION
## Summary
- Add a local search box to the /multitable home Base list.
- Filter visible Base cards by name or ID while preserving the loaded Base list and existing open/create/template flows.
- Show matched/total counts and a filtered-empty state distinct from the no-accessible-base empty state.

## Verification
- pnpm --filter @metasheet/web exec vitest run tests/multitable-home-view.spec.ts tests/platform-shell-nav.spec.ts --watch=false
- pnpm --filter @metasheet/web exec eslint "src/views/MultitableHomeView.vue" "tests/multitable-home-view.spec.ts" --max-warnings=0
- pnpm --filter @metasheet/web exec vue-tsc --noEmit
- pnpm --filter @metasheet/core-backend exec tsc --noEmit
- git diff --check
- secret-pattern scan over touched files: 0 matches

## Scope
Frontend-only. No backend route, API params, migration, OpenAPI, K3, Data Factory, Attendance, DingTalk, plugin-integration-core, /grid, or /spreadsheets changes.