### PR TITLE
feat(multitable): add home recents and favorites

### DIFF
--- a/apps/web/src/multitable/utils/base-local-state.ts
+++ b/apps/web/src/multitable/utils/base-local-state.ts
@@ -1,0 +1,144 @@
+import type { MetaBase } from '../types'
+
+const FAVORITE_BASE_IDS_KEY = 'metasheet:multitable:favorite-base-ids:v1'
+const RECENT_BASE_OPENS_KEY = 'metasheet:multitable:recent-base-opens:v1'
+const RECENT_BASE_OPENS_LIMIT = 20
+
+export interface RecentBaseOpen {
+  baseId: string
+  openedAt: string
+}
+
+export interface DecoratedBase extends MetaBase {
+  isFavorite: boolean
+  lastOpenedAt: string | null
+}
+
+function getStorage(storage?: Storage | null): Storage | null {
+  if (storage !== undefined) return storage
+  return typeof localStorage === 'undefined' ? null : localStorage
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string')
+}
+
+function isRecentBaseOpen(value: unknown): value is RecentBaseOpen {
+  if (!value || typeof value !== 'object') return false
+  const record = value as Record<string, unknown>
+  return typeof record.baseId === 'string' && typeof record.openedAt === 'string'
+}
+
+function uniqueIds(ids: readonly string[]): string[] {
+  return Array.from(new Set(ids.filter((id) => id.trim().length > 0)))
+}
+
+export function readFavoriteBaseIds(storage?: Storage | null): string[] {
+  const target = getStorage(storage)
+  if (!target) return []
+
+  try {
+    const raw = target.getItem(FAVORITE_BASE_IDS_KEY)
+    if (!raw) return []
+    const parsed = JSON.parse(raw) as unknown
+    return isStringArray(parsed) ? uniqueIds(parsed) : []
+  } catch {
+    return []
+  }
+}
+
+export function writeFavoriteBaseIds(ids: readonly string[], storage?: Storage | null): void {
+  const target = getStorage(storage)
+  if (!target) return
+
+  try {
+    target.setItem(FAVORITE_BASE_IDS_KEY, JSON.stringify(uniqueIds(ids)))
+  } catch {
+    // Local UI preferences are non-critical; private-mode/quota failures should not block navigation.
+  }
+}
+
+export function toggleFavoriteBaseId(baseId: string, storage?: Storage | null): string[] {
+  const current = readFavoriteBaseIds(storage)
+  const next = current.includes(baseId) ? current.filter((id) => id !== baseId) : [baseId, ...current]
+  writeFavoriteBaseIds(next, storage)
+  return next
+}
+
+export function readRecentBaseOpens(storage?: Storage | null): RecentBaseOpen[] {
+  const target = getStorage(storage)
+  if (!target) return []
+
+  try {
+    const raw = target.getItem(RECENT_BASE_OPENS_KEY)
+    if (!raw) return []
+    const parsed = JSON.parse(raw) as unknown
+    return Array.isArray(parsed)
+      ? parsed
+        .filter(isRecentBaseOpen)
+        .sort((left, right) => right.openedAt.localeCompare(left.openedAt))
+        .slice(0, RECENT_BASE_OPENS_LIMIT)
+      : []
+  } catch {
+    return []
+  }
+}
+
+export function writeRecentBaseOpens(entries: readonly RecentBaseOpen[], storage?: Storage | null): void {
+  const target = getStorage(storage)
+  if (!target) return
+
+  try {
+    target.setItem(RECENT_BASE_OPENS_KEY, JSON.stringify(entries.slice(0, RECENT_BASE_OPENS_LIMIT)))
+  } catch {
+    // Recent-open ordering is best-effort local state only.
+  }
+}
+
+export function rememberRecentBaseOpen(baseId: string, storage?: Storage | null): RecentBaseOpen[] {
+  const nextEntry: RecentBaseOpen = {
+    baseId,
+    openedAt: new Date().toISOString(),
+  }
+  const next = [
+    nextEntry,
+    ...readRecentBaseOpens(storage).filter((entry) => entry.baseId !== baseId),
+  ].slice(0, RECENT_BASE_OPENS_LIMIT)
+  writeRecentBaseOpens(next, storage)
+  return next
+}
+
+export function decorateAndSortBases(
+  bases: readonly MetaBase[],
+  favoriteBaseIds: readonly string[],
+  recentBaseOpens: readonly RecentBaseOpen[],
+): DecoratedBase[] {
+  const baseIdSet = new Set(bases.map((base) => base.id))
+  const favoriteSet = new Set(favoriteBaseIds.filter((id) => baseIdSet.has(id)))
+  const recentByBaseId = new Map(
+    recentBaseOpens
+      .filter((entry) => baseIdSet.has(entry.baseId))
+      .map((entry) => [entry.baseId, entry.openedAt]),
+  )
+
+  return bases
+    .map((base, index) => ({
+      ...base,
+      isFavorite: favoriteSet.has(base.id),
+      lastOpenedAt: recentByBaseId.get(base.id) ?? null,
+      index,
+    }))
+    .sort((left, right) => {
+      const leftFavorite = left.isFavorite ? 1 : 0
+      const rightFavorite = right.isFavorite ? 1 : 0
+      if (leftFavorite !== rightFavorite) return rightFavorite - leftFavorite
+
+      const leftOpenedAt = left.lastOpenedAt ?? ''
+      const rightOpenedAt = right.lastOpenedAt ?? ''
+      if (leftOpenedAt !== rightOpenedAt) return rightOpenedAt.localeCompare(leftOpenedAt)
+
+      return left.index - right.index
+    })
+    .map(({ index: _index, ...base }) => base)
+}
+

--- a/apps/web/src/views/MultitableHomeView.vue
+++ b/apps/web/src/views/MultitableHomeView.vue
@@ -80,7 +80,7 @@
         <div>
           <h2>可访问的 Base</h2>
           <p v-if="bases.length" class="multitable-home__panel-subtitle">
-            {{ baseSearch.trim() ? `匹配 ${filteredBases.length} / ${bases.length} 个` : `${bases.length} 个` }}
+            {{ baseSearch.trim() ? `匹配 ${visibleBases.length} / ${bases.length} 个` : `${bases.length} 个` }}
           </p>
         </div>
         <label v-if="bases.length" class="multitable-home__search">
@@ -98,18 +98,35 @@
       <div v-else-if="!bases.length" class="multitable-home__empty">
         暂无可访问的 Base。你可以新建一个，或从数据工厂/考勤等业务入口生成多维表。
       </div>
-      <div v-else-if="!filteredBases.length" class="multitable-home__empty">
+      <div v-else-if="!visibleBases.length" class="multitable-home__empty">
         没有匹配的 Base。请调整搜索关键词。
       </div>
       <div v-else class="multitable-home__grid">
-        <article v-for="base in filteredBases" :key="base.id" class="multitable-home__card">
+        <article v-for="base in visibleBases" :key="base.id" class="multitable-home__card">
           <div class="multitable-home__card-icon" :style="{ background: base.color || '#2563eb' }">
             {{ base.icon || base.name.slice(0, 1).toUpperCase() }}
           </div>
           <div class="multitable-home__card-body">
             <h3>{{ base.name }}</h3>
             <small>{{ base.id }}</small>
+            <div
+              v-if="base.isFavorite || base.lastOpenedAt"
+              class="multitable-home__badges"
+              aria-label="Base quick access state"
+            >
+              <span v-if="base.isFavorite">收藏</span>
+              <span v-if="base.lastOpenedAt">最近打开</span>
+            </div>
           </div>
+          <button
+            type="button"
+            class="multitable-home__favorite"
+            :aria-pressed="base.isFavorite"
+            :aria-label="base.isFavorite ? `取消收藏 ${base.name}` : `收藏 ${base.name}`"
+            @click="toggleFavoriteBase(base.id)"
+          >
+            {{ base.isFavorite ? '已收藏' : '收藏' }}
+          </button>
           <button
             class="multitable-home__open"
             :disabled="openingBaseId === base.id"
@@ -135,6 +152,14 @@ import type {
   MetaTemplate,
   MetaView,
 } from '../multitable/types'
+import {
+  decorateAndSortBases,
+  type DecoratedBase,
+  readFavoriteBaseIds,
+  readRecentBaseOpens,
+  rememberRecentBaseOpen,
+  toggleFavoriteBaseId,
+} from '../multitable/utils/base-local-state'
 import { AppRouteNames } from '../router/types'
 
 const router = useRouter()
@@ -151,13 +176,30 @@ const templateError = ref('')
 const newBaseName = ref('')
 const baseSearch = ref('')
 
-const filteredBases = computed(() => {
+const favoriteBaseIds = ref<string[]>(readFavoriteBaseIds())
+const recentBaseOpens = ref(readRecentBaseOpens())
+
+const decoratedBases = computed(() => {
+  return decorateAndSortBases(bases.value, favoriteBaseIds.value, recentBaseOpens.value)
+})
+
+const searchedBases = computed<DecoratedBase[]>(() => {
   const query = baseSearch.value.trim().toLowerCase()
-  if (!query) return bases.value
-  return bases.value.filter((base) => {
+  if (!query) return decoratedBases.value
+  return decoratedBases.value.filter((base) => {
     return base.name.toLowerCase().includes(query) || base.id.toLowerCase().includes(query)
   })
 })
+
+const visibleBases = computed(() => searchedBases.value)
+
+function toggleFavoriteBase(baseId: string): void {
+  favoriteBaseIds.value = toggleFavoriteBaseId(baseId)
+}
+
+function rememberRecentBase(baseId: string): void {
+  recentBaseOpens.value = rememberRecentBaseOpen(baseId)
+}
 
 function resolveOpenTarget(context: MetaContext): { sheet: MetaSheet; view: MetaView } | null {
   const sheet = context.sheet ?? context.sheets[0] ?? null
@@ -217,6 +259,7 @@ async function openBase(base: MetaBase): Promise<void> {
       errorMessage.value = '这个 Base 还没有可打开的 Sheet 或 View。'
       return
     }
+    rememberRecentBase(base.id)
     await router.push({
       name: AppRouteNames.MULTITABLE,
       params: { sheetId: target.sheet.id, viewId: target.view.id },
@@ -244,6 +287,7 @@ async function installTemplateAndOpen(template: MetaTemplate): Promise<void> {
       await loadBases()
       return
     }
+    rememberRecentBase(result.base.id)
     await router.push({
       name: AppRouteNames.MULTITABLE,
       params: { sheetId: target.sheet.id, viewId: target.view.id },
@@ -271,6 +315,7 @@ async function createBaseAndOpen(): Promise<void> {
       await loadBases()
       return
     }
+    rememberRecentBase(base.id)
     await router.push({
       name: AppRouteNames.MULTITABLE,
       params: { sheetId: target.sheet.id, viewId: target.view.id },
@@ -513,7 +558,7 @@ onMounted(loadHomeData)
 
 .multitable-home__card {
   display: grid;
-  grid-template-columns: auto 1fr auto;
+  grid-template-columns: auto 1fr auto auto;
   gap: 12px;
   align-items: center;
   border: 1px solid #e2e8f0;
@@ -539,6 +584,38 @@ onMounted(loadHomeData)
 
 .multitable-home__card-body small {
   color: #64748b;
+}
+
+.multitable-home__badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.multitable-home__badges span {
+  border-radius: 999px;
+  padding: 3px 7px;
+  background: #eff6ff;
+  color: #1d4ed8;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.multitable-home__favorite {
+  border: 1px solid #bfdbfe;
+  border-radius: 999px;
+  padding: 9px 12px;
+  background: #eff6ff;
+  color: #1d4ed8;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.multitable-home__favorite[aria-pressed='true'] {
+  border-color: #f59e0b;
+  background: #fffbeb;
+  color: #92400e;
 }
 
 .multitable-home__error {

--- a/apps/web/tests/multitable-base-local-state.spec.ts
+++ b/apps/web/tests/multitable-base-local-state.spec.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest'
+import type { MetaBase } from '../src/multitable/types'
+import {
+  decorateAndSortBases,
+  readFavoriteBaseIds,
+  readRecentBaseOpens,
+  rememberRecentBaseOpen,
+  toggleFavoriteBaseId,
+} from '../src/multitable/utils/base-local-state'
+
+const FAVORITE_BASES_KEY = 'metasheet:multitable:favorite-base-ids:v1'
+const RECENT_BASES_KEY = 'metasheet:multitable:recent-base-opens:v1'
+
+function createMemoryStorage() {
+  const store = new Map<string, string>()
+  return {
+    getItem(key: string) {
+      return store.get(key) ?? null
+    },
+    setItem(key: string, value: string) {
+      store.set(key, value)
+    },
+    removeItem(key: string) {
+      store.delete(key)
+    },
+    clear() {
+      store.clear()
+    },
+    key(index: number) {
+      return Array.from(store.keys())[index] ?? null
+    },
+    get length() {
+      return store.size
+    },
+  } as Storage
+}
+
+function base(id: string, name = id): MetaBase {
+  return { id, name }
+}
+
+describe('multitable base local state', () => {
+  it('reads corrupted localStorage payloads defensively', () => {
+    const storage = createMemoryStorage()
+    storage.setItem(FAVORITE_BASES_KEY, '{bad')
+    storage.setItem(RECENT_BASES_KEY, JSON.stringify([{ baseId: 'base_a' }, null, 'bad']))
+
+    expect(readFavoriteBaseIds(storage)).toEqual([])
+    expect(readRecentBaseOpens(storage)).toEqual([])
+  })
+
+  it('toggles favorite base ids and de-duplicates stored ids', () => {
+    const storage = createMemoryStorage()
+    storage.setItem(FAVORITE_BASES_KEY, JSON.stringify(['base_a', 'base_a']))
+
+    expect(toggleFavoriteBaseId('base_b', storage)).toEqual(['base_b', 'base_a'])
+    expect(toggleFavoriteBaseId('base_a', storage)).toEqual(['base_b'])
+    expect(readFavoriteBaseIds(storage)).toEqual(['base_b'])
+  })
+
+  it('remembers recent opens with de-dupe and newest-first ordering', () => {
+    const storage = createMemoryStorage()
+
+    rememberRecentBaseOpen('base_a', storage)
+    rememberRecentBaseOpen('base_b', storage)
+    rememberRecentBaseOpen('base_a', storage)
+
+    const recent = readRecentBaseOpens(storage)
+    expect(recent.map((entry) => entry.baseId)).toEqual(['base_a', 'base_b'])
+    expect(recent[0]?.openedAt).toBeTypeOf('string')
+  })
+
+  it('sorts favorites before recents and preserves API order fallback', () => {
+    const bases = [
+      base('base_a', 'A'),
+      base('base_b', 'B'),
+      base('base_c', 'C'),
+      base('base_d', 'D'),
+    ]
+
+    const sorted = decorateAndSortBases(
+      bases,
+      ['base_c', 'missing_base'],
+      [
+        { baseId: 'base_b', openedAt: '2026-05-18T10:00:00.000Z' },
+        { baseId: 'base_d', openedAt: '2026-05-18T09:00:00.000Z' },
+        { baseId: 'missing_base', openedAt: '2026-05-18T11:00:00.000Z' },
+      ],
+    )
+
+    expect(sorted.map((item) => item.id)).toEqual(['base_c', 'base_b', 'base_d', 'base_a'])
+    expect(sorted[0]).toMatchObject({ id: 'base_c', isFavorite: true, lastOpenedAt: null })
+    expect(sorted[1]).toMatchObject({ id: 'base_b', isFavorite: false, lastOpenedAt: '2026-05-18T10:00:00.000Z' })
+    expect(sorted[3]).toMatchObject({ id: 'base_a', isFavorite: false, lastOpenedAt: null })
+  })
+})
+

--- a/apps/web/tests/multitable-home-view.spec.ts
+++ b/apps/web/tests/multitable-home-view.spec.ts
@@ -13,6 +13,9 @@ const mocks = vi.hoisted(() => ({
   installTemplate: vi.fn(),
 }))
 
+const FAVORITE_BASES_KEY = 'metasheet:multitable:favorite-base-ids:v1'
+const RECENT_BASES_KEY = 'metasheet:multitable:recent-base-opens:v1'
+
 vi.mock('vue-router', async () => {
   const actual = await vi.importActual<typeof import('vue-router')>('vue-router')
   return {
@@ -53,6 +56,20 @@ function findButton(container: HTMLElement, text: string, opts: { exact?: boolea
   return button
 }
 
+function findCardButton(container: HTMLElement, cardTitle: string, buttonText: string): HTMLButtonElement {
+  const card = Array.from(container.querySelectorAll('.multitable-home__card'))
+    .find((node) => node.textContent?.includes(cardTitle))
+  if (!(card instanceof HTMLElement)) {
+    throw new Error(`Card not found: ${cardTitle}`)
+  }
+  return findButton(card, buttonText, { exact: true })
+}
+
+function readBaseCardNames(container: HTMLElement): string[] {
+  return Array.from(container.querySelectorAll('.multitable-home__card h3'))
+    .map((node) => node.textContent?.trim() ?? '')
+}
+
 describe('MultitableHomeView', () => {
   let app: VueApp<Element> | null = null
   let container: HTMLDivElement | null = null
@@ -62,6 +79,8 @@ describe('MultitableHomeView', () => {
     if (container) container.remove()
     app = null
     container = null
+    localStorage.removeItem(FAVORITE_BASES_KEY)
+    localStorage.removeItem(RECENT_BASES_KEY)
     vi.clearAllMocks()
   })
 
@@ -134,6 +153,61 @@ describe('MultitableHomeView', () => {
 
     expect(root.textContent).toContain('没有匹配的 Base')
     expect(root.textContent).not.toContain('暂无可访问的 Base')
+  })
+
+  it('promotes favorite bases and persists the favorite marker', async () => {
+    mocks.listBases.mockResolvedValue({
+      bases: [
+        { id: 'base_ops', name: 'Ops Base', color: '#0f766e' },
+        { id: 'base_sales', name: 'Sales Pipeline', color: '#f97316' },
+      ],
+    })
+    mocks.listTemplates.mockResolvedValue({ templates: [] })
+
+    const root = mountView()
+    await flushUi()
+
+    expect(readBaseCardNames(root)).toEqual(['Ops Base', 'Sales Pipeline'])
+
+    findCardButton(root, 'Sales Pipeline', '收藏').click()
+    await flushUi()
+
+    expect(readBaseCardNames(root)).toEqual(['Sales Pipeline', 'Ops Base'])
+    expect(root.textContent).toContain('已收藏')
+    expect(JSON.parse(localStorage.getItem(FAVORITE_BASES_KEY) ?? '[]')).toEqual(['base_sales'])
+  })
+
+  it('promotes recently opened bases without pinning them above favorites', async () => {
+    mocks.listBases.mockResolvedValue({
+      bases: [
+        { id: 'base_ops', name: 'Ops Base', color: '#0f766e' },
+        { id: 'base_sales', name: 'Sales Pipeline', color: '#f97316' },
+        { id: 'base_hr', name: 'Hiring Base', color: '#9333ea' },
+      ],
+    })
+    mocks.listTemplates.mockResolvedValue({ templates: [] })
+    mocks.loadContext.mockResolvedValue({
+      base: { id: 'base_sales', name: 'Sales Pipeline' },
+      sheet: { id: 'sheet_sales', baseId: 'base_sales', name: 'Deals' },
+      sheets: [{ id: 'sheet_sales', baseId: 'base_sales', name: 'Deals' }],
+      views: [{ id: 'view_sales', sheetId: 'sheet_sales', name: 'Grid', type: 'grid' }],
+      capabilities: {},
+    })
+    localStorage.setItem(FAVORITE_BASES_KEY, JSON.stringify(['base_hr']))
+
+    const root = mountView()
+    await flushUi()
+
+    expect(readBaseCardNames(root)).toEqual(['Hiring Base', 'Ops Base', 'Sales Pipeline'])
+
+    findCardButton(root, 'Sales Pipeline', '打开').click()
+    await flushUi()
+
+    expect(readBaseCardNames(root)).toEqual(['Hiring Base', 'Sales Pipeline', 'Ops Base'])
+    expect(root.textContent).toContain('最近打开')
+    expect(JSON.parse(localStorage.getItem(RECENT_BASES_KEY) ?? '[]')).toEqual([
+      expect.objectContaining({ baseId: 'base_sales' }),
+    ])
   })
 
   it('creates a base with a seeded sheet before opening multitable', async () => {

--- a/docs/development/multitable-home-recents-favorites-development-20260518.md
+++ b/docs/development/multitable-home-recents-favorites-development-20260518.md
@@ -1,0 +1,56 @@
+# Multitable Home Recents And Favorites Development
+
+Date: 2026-05-18
+
+Branch: `codex/multitable-home-recents-favorites-20260518`
+
+## Goal
+
+Improve the `/multitable` default entry after the Base search and template quickstart work by making frequently used Bases easier to reopen without adding backend schema, route, or permission changes.
+
+## Scope
+
+In scope:
+
+- Add client-side favorite Base pins on the `/multitable` home Base cards.
+- Add client-side recent-open ordering for successfully opened Bases.
+- Preserve Base search, template quickstart, create-base, and legacy routing behavior.
+- Add focused unit coverage for storage parsing, ordering, and home UI behavior.
+
+Out of scope:
+
+- No backend route, migration, OpenAPI, permission, or template changes.
+- No cross-device/server-side favorites.
+- No Workbench Base picker changes; this PR only upgrades the default home entry.
+
+## Design
+
+The implementation adds `apps/web/src/multitable/utils/base-local-state.ts` as a small browser-local state utility:
+
+- `metasheet:multitable:favorite-base-ids:v1` stores `string[]` of Base IDs.
+- `metasheet:multitable:recent-base-opens:v1` stores `{ baseId, openedAt }[]`.
+- Reads are defensive: missing storage, invalid JSON, or malformed entries return an empty state.
+- Writes are best-effort and swallowed so private-mode or quota failures do not block navigation.
+- `decorateAndSortBases()` filters stored IDs to currently loaded Bases, then sorts favorites first, recent opens by newest timestamp, and untouched Bases by original API order.
+
+`MultitableHomeView.vue` now renders a favorite action per Base card and "收藏" / "最近打开" badges. It calls `rememberRecentBaseOpen()` only after a Base has a resolvable sheet/view target, so failed opens do not pollute local recents.
+
+## Parallel Scout
+
+A read-only scout checked existing storage patterns before implementation. The final PR reused the defensive localStorage approach from existing workflow/attendance utilities while keeping the product scope home-only.
+
+## Files
+
+- `apps/web/src/multitable/utils/base-local-state.ts`
+- `apps/web/src/views/MultitableHomeView.vue`
+- `apps/web/tests/multitable-base-local-state.spec.ts`
+- `apps/web/tests/multitable-home-view.spec.ts`
+- `docs/development/multitable-home-recents-favorites-development-20260518.md`
+- `docs/development/multitable-home-recents-favorites-verification-20260518.md`
+
+## Risk Notes
+
+- Local favorites/recents are intentionally browser-local and may not roam across devices.
+- Stored Base IDs that are no longer accessible are ignored during decoration and sorting.
+- This is frontend-only, so no migration or rollback step is needed.
+

--- a/docs/development/multitable-home-recents-favorites-verification-20260518.md
+++ b/docs/development/multitable-home-recents-favorites-verification-20260518.md
@@ -1,0 +1,84 @@
+# Multitable Home Recents And Favorites Verification
+
+Date: 2026-05-18
+
+Branch: `codex/multitable-home-recents-favorites-20260518`
+
+## Result
+
+PASS. The `/multitable` home Base list now supports browser-local favorite pins and recent-open ordering without backend changes.
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile --ignore-scripts
+```
+
+Result: PASS.
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/multitable-base-local-state.spec.ts \
+  tests/multitable-home-view.spec.ts \
+  --watch=false
+```
+
+Result: PASS, 2 files / 10 tests.
+
+```bash
+pnpm --filter @metasheet/web exec eslint \
+  src/views/MultitableHomeView.vue \
+  src/multitable/utils/base-local-state.ts \
+  tests/multitable-base-local-state.spec.ts \
+  tests/multitable-home-view.spec.ts
+```
+
+Result: PASS.
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+```
+
+Result: PASS.
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+```
+
+Result: PASS.
+
+## Coverage
+
+- Favorite toggle persists a Base ID and promotes the card above non-favorites.
+- Recent-open state is recorded after a successful open and promotes the Base below favorites.
+- Search still filters the sorted list and keeps the no-match state separate from the empty-list state.
+- Corrupted localStorage payloads fail closed to empty state.
+- Unknown/stale stored Base IDs are ignored during sorting.
+
+## Scope Check
+
+- No backend source changes.
+- No database migration changes.
+- No OpenAPI changes.
+- No route or permission changes.
+- No Data Factory, K3, DingTalk, Attendance, or Phase 3 TODO status changes.
+
+## Final Checks
+
+```bash
+git diff --check
+```
+
+Result: PASS.
+
+Secret-pattern scan over the touched source, test, and documentation files:
+
+Result: PASS after removing a self-referential example scan pattern from this verification document. No credential-like values remain in the changed files.
+
+## Install Noise Cleanup
+
+```bash
+git diff --name-only | rg '(^plugins/.*/node_modules|^tools/cli/node_modules)' | xargs git restore --
+```
+
+Result: PASS. The only remaining changed files are the intended source, test, and documentation files.


### PR DESCRIPTION
## Summary

- add browser-local favorite Base pins and recent-open ordering to the `/multitable` home Base list
- extract defensive localStorage helpers in `base-local-state.ts` for corrupt JSON fallback, write failure tolerance, stale ID pruning, and deterministic sorting
- add focused unit coverage plus development and verification docs

## Scope

- frontend-only: no backend routes, migrations, OpenAPI, permissions, Data Factory, K3, DingTalk, Attendance, or Phase 3 TODO status changes
- Workbench/BasePicker reuse is intentionally left for a later slice; this PR only upgrades the default multitable home entry

## Verification

- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-base-local-state.spec.ts tests/multitable-home-view.spec.ts --watch=false` — 2 files / 10 tests PASS
- `pnpm --filter @metasheet/web exec eslint src/views/MultitableHomeView.vue src/multitable/utils/base-local-state.ts tests/multitable-base-local-state.spec.ts tests/multitable-home-view.spec.ts` — PASS
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit` — PASS
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit` — PASS
- `git diff --check` — PASS
- secret-pattern scan over touched files — 0 matches
