### PR TITLE
feat(multitable): add workbench base quick access

### DIFF
--- a/apps/web/src/multitable/components/MetaBasePicker.vue
+++ b/apps/web/src/multitable/components/MetaBasePicker.vue
@@ -26,7 +26,22 @@
           @click="onSelect(base.id)"
         >
           <span class="meta-base-picker__item-icon" :style="{ background: base.color ?? '#409eff' }">{{ base.icon ?? '📋' }}</span>
-          <span class="meta-base-picker__item-name">{{ base.name }}</span>
+          <span class="meta-base-picker__item-copy">
+            <span class="meta-base-picker__item-name">{{ base.name }}</span>
+            <span v-if="base.isFavorite || base.lastOpenedAt" class="meta-base-picker__badges">
+              <span v-if="base.isFavorite">收藏</span>
+              <span v-if="base.lastOpenedAt">最近打开</span>
+            </span>
+          </span>
+          <button
+            type="button"
+            class="meta-base-picker__favorite"
+            :aria-pressed="base.isFavorite"
+            :aria-label="base.isFavorite ? `取消收藏 ${base.name}` : `收藏 ${base.name}`"
+            @click.stop="onToggleFavorite(base.id)"
+          >
+            {{ base.isFavorite ? '★' : '☆' }}
+          </button>
         </div>
         <div v-if="!filteredBases.length" class="meta-base-picker__empty">No bases found</div>
       </div>
@@ -45,10 +60,10 @@
 
 <script setup lang="ts">
 import { ref, computed } from 'vue'
-import type { MetaBase } from '../types'
+import type { DecoratedBase } from '../utils/base-local-state'
 
 const props = defineProps<{
-  bases: MetaBase[]
+  bases: DecoratedBase[]
   activeBaseId: string
   canCreate?: boolean
 }>()
@@ -56,6 +71,7 @@ const props = defineProps<{
 const emit = defineEmits<{
   (e: 'select', baseId: string): void
   (e: 'create', name: string): void
+  (e: 'toggle-favorite', baseId: string): void
 }>()
 
 const open = ref(false)
@@ -82,6 +98,10 @@ function onCreate() {
   emit('create', name)
   newBaseName.value = ''
 }
+
+function onToggleFavorite(baseId: string) {
+  emit('toggle-favorite', baseId)
+}
 </script>
 
 <style scoped>
@@ -99,7 +119,12 @@ function onCreate() {
 .meta-base-picker__item:hover { background: #f5f7fa; }
 .meta-base-picker__item--active { background: #ecf5ff; }
 .meta-base-picker__item-icon { width: 20px; height: 20px; border-radius: 3px; display: flex; align-items: center; justify-content: center; font-size: 12px; color: #fff; flex-shrink: 0; }
+.meta-base-picker__item-copy { min-width: 0; flex: 1; display: grid; gap: 4px; }
 .meta-base-picker__item-name { font-size: 13px; color: #333; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.meta-base-picker__badges { display: flex; flex-wrap: wrap; gap: 4px; }
+.meta-base-picker__badges span { border-radius: 999px; padding: 2px 6px; background: #eff6ff; color: #1d4ed8; font-size: 10px; font-weight: 700; }
+.meta-base-picker__favorite { flex-shrink: 0; width: 28px; height: 28px; border: 1px solid #dbeafe; border-radius: 999px; background: #f8fbff; color: #2563eb; cursor: pointer; font-size: 14px; line-height: 1; }
+.meta-base-picker__favorite[aria-pressed='true'] { border-color: #f59e0b; background: #fffbeb; color: #92400e; }
 .meta-base-picker__empty { padding: 16px; text-align: center; color: #999; font-size: 12px; }
 .meta-base-picker__create { display: flex; gap: 6px; padding: 8px; border-top: 1px solid #eee; }
 .meta-base-picker__create-input { flex: 1; padding: 4px 8px; border: 1px solid #ddd; border-radius: 4px; font-size: 12px; }

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -12,8 +12,15 @@
         <button class="mt-workbench__conflict-btn" @click="grid.dismissConflict()">Dismiss</button>
       </div>
     </div>
-    <div v-if="bases.length" class="mt-workbench__base-bar">
-      <MetaBasePicker :bases="bases" :active-base-id="activeBaseId" :can-create="canCreateBasesAndSheets" @select="onSelectBase" @create="onCreateBase" />
+    <div v-if="basePickerBases.length" class="mt-workbench__base-bar">
+      <MetaBasePicker
+        :bases="basePickerBases"
+        :active-base-id="activeBaseId"
+        :can-create="canCreateBasesAndSheets"
+        @select="onSelectBase"
+        @create="onCreateBase"
+        @toggle-favorite="onToggleFavoriteBase"
+      />
     </div>
     <MetaViewTabBar :sheets="workbench.sheets.value" :views="visibleWorkbenchViews" :active-sheet-id="workbench.activeSheetId.value" :active-view-id="workbench.activeViewId.value" :can-create-sheet="canCreateBasesAndSheets" @select-sheet="onSelectSheet" @select-view="onSelectView" @create-sheet="onCreateSheet" />
     <div class="mt-workbench__actions">
@@ -456,6 +463,13 @@ import { filterPropertyVisibleFields } from '../utils/field-permissions'
 import { isLinkField, isPersonField } from '../utils/link-fields'
 import { addPeopleLookupToken, inferPeopleLookupKind, resolvePeopleImportValue } from '../utils/people-import'
 import { buildRecordFormattingMap, extractRulesFromConfig } from '../utils/conditional-formatting'
+import {
+  decorateAndSortBases,
+  readFavoriteBaseIds,
+  readRecentBaseOpens,
+  rememberRecentBaseOpen,
+  toggleFavoriteBaseId,
+} from '../utils/base-local-state'
 
 const props = defineProps<{ sheetId?: string; viewId?: string; baseId?: string; recordId?: string; commentId?: string; fieldId?: string; openComments?: boolean; mode?: string; role?: MultitableRole }>()
 const emit = defineEmits<{
@@ -504,6 +518,9 @@ const fieldPermissionEntries = ref<MetaFieldPermissionEntry[]>([])
 const viewPermissionEntries = ref<MetaViewPermissionEntry[]>([])
 const showViewManager = ref(false)
 const bases = ref<MetaBase[]>([])
+const favoriteBaseIds = ref<string[]>(readFavoriteBaseIds())
+const recentBaseOpens = ref(readRecentBaseOpens())
+const basePickerBases = computed(() => decorateAndSortBases(bases.value, favoriteBaseIds.value, recentBaseOpens.value))
 const activeBaseId = computed(() => workbench.activeBaseId.value)
 const toastRef = ref<InstanceType<typeof MetaToast> | null>(null)
 const commentDraft = ref('')
@@ -1762,7 +1779,19 @@ async function onSelectBase(baseId: string) {
   if (baseId === workbench.activeBaseId.value) return
   if (!confirmDiscardContextChanges()) return
   const ok = await workbench.switchBase(baseId)
-  if (!ok) showError(workbench.error.value ?? 'Failed to load base')
+  if (!ok) {
+    showError(workbench.error.value ?? 'Failed to load base')
+    return
+  }
+  rememberWorkbenchBaseOpen(baseId)
+}
+
+function onToggleFavoriteBase(baseId: string) {
+  favoriteBaseIds.value = toggleFavoriteBaseId(baseId)
+}
+
+function rememberWorkbenchBaseOpen(baseId: string) {
+  recentBaseOpens.value = rememberRecentBaseOpen(baseId)
 }
 
 function onSelectSheet(sheetId: string) {
@@ -2104,6 +2133,7 @@ async function onInstallTemplate(template: MetaTemplate) {
       showError(workbench.error.value ?? 'Installed template but failed to refresh workbench context')
       return
     }
+    rememberWorkbenchBaseOpen(result.base.id)
     showTemplateLibrary.value = false
     showSuccess(`Installed ${result.template.name}`)
   } catch (e: any) {
@@ -2807,8 +2837,9 @@ onMounted(async () => {
   }).catch(() => undefined)
   try {
     await loadBases()
+    let contextLoaded = false
     if (workbench.activeBaseId.value) {
-      await workbench.loadBaseContext(workbench.activeBaseId.value, {
+      contextLoaded = await workbench.loadBaseContext(workbench.activeBaseId.value, {
         sheetId: props.sheetId,
         viewId: props.viewId,
       })
@@ -2816,9 +2847,13 @@ onMounted(async () => {
       // Sheet-anchored URL with no baseId: let /context derive the
       // owning base from the sheet itself. syncContextState then sets
       // activeBaseId from ctx.sheet.baseId.
-      await workbench.loadSheetMeta(props.sheetId, { viewId: props.viewId })
+      contextLoaded = await workbench.loadSheetMeta(props.sheetId, { viewId: props.viewId })
     } else {
       await workbench.loadSheets()
+      contextLoaded = !workbench.error.value
+    }
+    if (contextLoaded && workbench.activeBaseId.value) {
+      rememberWorkbenchBaseOpen(workbench.activeBaseId.value)
     }
     await commentInboxState.refreshUnreadCount().catch(() => undefined)
     const deepRecordId = props.recordId ?? parseDeepLink()

--- a/apps/web/tests/meta-base-picker.spec.ts
+++ b/apps/web/tests/meta-base-picker.spec.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, nextTick, type App as VueApp, type Component } from 'vue'
+import MetaBasePicker from '../src/multitable/components/MetaBasePicker.vue'
+import type { DecoratedBase } from '../src/multitable/utils/base-local-state'
+
+async function flushUi(cycles = 3): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+describe('MetaBasePicker', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+  })
+
+  function mountPicker(options?: {
+    bases?: DecoratedBase[]
+    activeBaseId?: string
+    onSelect?: (baseId: string) => void
+    onToggleFavorite?: (baseId: string) => void
+  }) {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(MetaBasePicker as Component, {
+      bases: options?.bases ?? [
+        { id: 'base_sales', name: 'Sales Base', isFavorite: true, lastOpenedAt: null },
+        { id: 'base_ops', name: 'Ops Base', isFavorite: false, lastOpenedAt: '2026-05-18T08:00:00.000Z' },
+      ],
+      activeBaseId: options?.activeBaseId ?? 'base_ops',
+      onSelect: options?.onSelect,
+      onToggleFavorite: options?.onToggleFavorite,
+    })
+    app.mount(container)
+    return container
+  }
+
+  it('renders decorated base badges in provided order', async () => {
+    const root = mountPicker()
+    await flushUi()
+
+    root.querySelector<HTMLElement>('.meta-base-picker__current')?.click()
+    await flushUi()
+
+    const names = Array.from(root.querySelectorAll('.meta-base-picker__item-name'))
+      .map((node) => node.textContent?.trim())
+    expect(names).toEqual(['Sales Base', 'Ops Base'])
+    expect(root.textContent).toContain('收藏')
+    expect(root.textContent).toContain('最近打开')
+  })
+
+  it('emits favorite toggles without selecting the base', async () => {
+    const onSelect = vi.fn()
+    const onToggleFavorite = vi.fn()
+    const root = mountPicker({ onSelect, onToggleFavorite })
+    await flushUi()
+
+    root.querySelector<HTMLElement>('.meta-base-picker__current')?.click()
+    await flushUi()
+
+    root.querySelector<HTMLButtonElement>('[aria-label="取消收藏 Sales Base"]')?.click()
+    await flushUi()
+
+    expect(onToggleFavorite).toHaveBeenCalledWith('base_sales')
+    expect(onSelect).not.toHaveBeenCalled()
+
+    root.querySelector<HTMLElement>('.meta-base-picker__item')?.click()
+    await flushUi()
+
+    expect(onSelect).toHaveBeenCalledWith('base_sales')
+  })
+})
+

--- a/apps/web/tests/multitable-workbench-view.spec.ts
+++ b/apps/web/tests/multitable-workbench-view.spec.ts
@@ -17,6 +17,9 @@ const { authAccessSnapshot, bulkImportRecordsMock } = vi.hoisted(() => ({
   bulkImportRecordsMock: vi.fn(),
 }))
 
+const FAVORITE_BASES_KEY = 'metasheet:multitable:favorite-base-ids:v1'
+const RECENT_BASES_KEY = 'metasheet:multitable:recent-base-opens:v1'
+
 vi.mock('vue-router', async () => {
   const actual = await vi.importActual<typeof import('vue-router')>('vue-router')
   return {
@@ -811,12 +814,29 @@ vi.mock('../src/multitable/components/MetaBasePicker.vue', () => ({
   default: defineComponent({
     name: 'MetaBasePicker',
     props: {
+      bases: { type: Array, default: () => [] },
       activeBaseId: { type: String, default: '' },
       canCreate: { type: Boolean, default: false },
     },
-    emits: ['select', 'create'],
+    emits: ['select', 'create', 'toggle-favorite'],
     render() {
+      const bases = this.$props.bases as Array<{ id: string; name: string; isFavorite?: boolean; lastOpenedAt?: string | null }>
       return h('div', [
+        h(
+          'div',
+          { 'data-base-picker-order': 'true' },
+          bases.map((base) => `${base.id}:${base.isFavorite ? 'favorite' : 'normal'}:${base.lastOpenedAt ? 'recent' : 'stale'}`).join('|'),
+        ),
+        ...bases.map((base) =>
+          h(
+            'button',
+            {
+              'data-toggle-favorite-base': base.id,
+              onClick: () => this.$emit('toggle-favorite', base.id),
+            },
+            `favorite-${base.id}`,
+          ),
+        ),
         h(
           'button',
           {
@@ -1018,6 +1038,8 @@ describe('MultitableWorkbench view wiring', () => {
   let container: HTMLDivElement | null = null
 
   beforeEach(() => {
+    localStorage.removeItem(FAVORITE_BASES_KEY)
+    localStorage.removeItem(RECENT_BASES_KEY)
     loadCommentsSpy = vi.fn()
     addCommentSpy = vi.fn()
     resolveCommentSpy = vi.fn()
@@ -1046,6 +1068,8 @@ describe('MultitableWorkbench view wiring', () => {
     showErrorSpy.mockReset()
     showSuccessSpy.mockReset()
     pushSpy.mockReset()
+    localStorage.removeItem(FAVORITE_BASES_KEY)
+    localStorage.removeItem(RECENT_BASES_KEY)
     vi.clearAllMocks()
   })
 
@@ -1627,6 +1651,44 @@ describe('MultitableWorkbench view wiring', () => {
 
     expect(workbenchMock.switchBase).toHaveBeenCalledWith('base_sales')
     expect(showErrorSpy).toHaveBeenCalledWith('base switch failed')
+    expect(localStorage.getItem(RECENT_BASES_KEY)).not.toContain('base_sales')
+  })
+
+  it('records successful workbench base switches as recent opens', async () => {
+    mountWorkbench()
+    await flushUi()
+
+    workbenchMock.switchBase.mockImplementation(async (baseId: string) => {
+      workbenchMock.activeBaseId.value = baseId
+      return true
+    })
+
+    container!.querySelector<HTMLButtonElement>('[data-select-base="base_sales"]')!.click()
+    await flushUi()
+
+    const recent = JSON.parse(localStorage.getItem(RECENT_BASES_KEY) ?? '[]') as Array<{ baseId: string }>
+    expect(recent.map((entry) => entry.baseId)).toEqual(['base_sales', 'base_ops'])
+    expect(container!.querySelector('[data-base-picker-order]')?.textContent).toContain('base_sales:normal:recent')
+  })
+
+  it('sorts workbench base picker favorites and toggles them without switching base', async () => {
+    localStorage.setItem(FAVORITE_BASES_KEY, JSON.stringify(['base_sales']))
+
+    mountWorkbench()
+    await flushUi()
+
+    expect(container!.querySelector('[data-base-picker-order]')?.textContent).toBe(
+      'base_sales:favorite:stale|base_ops:normal:recent',
+    )
+
+    container!.querySelector<HTMLButtonElement>('[data-toggle-favorite-base="base_sales"]')!.click()
+    await flushUi()
+
+    expect(workbenchMock.switchBase).not.toHaveBeenCalled()
+    expect(JSON.parse(localStorage.getItem(FAVORITE_BASES_KEY) ?? '[]')).toEqual([])
+    expect(container!.querySelector('[data-base-picker-order]')?.textContent).toBe(
+      'base_ops:normal:recent|base_sales:normal:stale',
+    )
   })
 
   it('prompts before switching sheets when context-level drafts are present', async () => {

--- a/docs/development/multitable-workbench-base-picker-quick-access-development-20260518.md
+++ b/docs/development/multitable-workbench-base-picker-quick-access-development-20260518.md
@@ -1,0 +1,75 @@
+# Multitable Workbench Base Picker Quick Access Development
+
+Date: 2026-05-18
+
+Branch: `codex/multitable-workbench-base-picker-quick-access-20260518`
+
+## Goal
+
+Carry the `/multitable` home quick-access model into the Workbench base switcher so the primary in-product Base picker honors browser-local favorites and recent opens.
+
+## Scope
+
+In scope:
+
+- Reuse `base-local-state.ts` for Workbench Base picker ordering.
+- Render favorite and recent badges in `MetaBasePicker`.
+- Let users toggle favorite state from the Workbench picker without selecting/switching the Base.
+- Record recent opens after successful Workbench context loads, successful Base switches, and successful template installs.
+- Add focused component and Workbench tests.
+
+Out of scope:
+
+- No backend routes, database migrations, OpenAPI changes, or permission changes.
+- No server-side/cross-device favorites.
+- No Data Factory, K3, DingTalk, Attendance, or Phase 3 TODO changes.
+
+## Design
+
+`MultitableWorkbench.vue` continues to keep raw API Bases in `bases`. It now derives `basePickerBases` through:
+
+```ts
+decorateAndSortBases(bases.value, favoriteBaseIds.value, recentBaseOpens.value)
+```
+
+This keeps sorting deterministic and aligned with the `/multitable` home entry:
+
+- favorites first
+- recent opens by newest `openedAt`
+- untouched Bases in original API order
+- stale localStorage IDs ignored
+
+`MetaBasePicker.vue` remains presentational. It receives decorated Bases, renders badges, emits `toggle-favorite`, and uses `@click.stop` on the favorite button so toggling does not also emit `select`.
+
+## Recent Recording
+
+Recent-open state is updated only after successful context transitions:
+
+- initial Workbench context load returns success and has an active Base
+- `workbench.switchBase(baseId)` returns `true`
+- `workbench.syncExternalContext(...)` returns `true` after template install
+
+Failed switches or failed context loads do not update localStorage.
+
+## Parallel Scout
+
+A read-only scout inspected `MetaBasePicker.vue`, `MultitableWorkbench.vue`, and Workbench tests. Its main constraints were adopted:
+
+- keep localStorage best-effort and non-blocking
+- preserve sheet-anchored URL behavior
+- use `@click.stop` for favorite toggles
+- extend the existing Workbench stub rather than broadening the test harness
+
+## Files
+
+- `apps/web/src/multitable/components/MetaBasePicker.vue`
+- `apps/web/src/multitable/views/MultitableWorkbench.vue`
+- `apps/web/tests/meta-base-picker.spec.ts`
+- `apps/web/tests/multitable-workbench-view.spec.ts`
+- `docs/development/multitable-workbench-base-picker-quick-access-development-20260518.md`
+- `docs/development/multitable-workbench-base-picker-quick-access-verification-20260518.md`
+
+## Rollback
+
+Revert this PR. No persistent backend state is introduced. Browser-local favorite/recent keys are harmless if the UI stops reading them.
+

--- a/docs/development/multitable-workbench-base-picker-quick-access-verification-20260518.md
+++ b/docs/development/multitable-workbench-base-picker-quick-access-verification-20260518.md
@@ -1,0 +1,86 @@
+# Multitable Workbench Base Picker Quick Access Verification
+
+Date: 2026-05-18
+
+Branch: `codex/multitable-workbench-base-picker-quick-access-20260518`
+
+## Result
+
+PASS. The Workbench Base picker now reuses the same browser-local favorite and recent-open state as the `/multitable` home entry.
+
+## Commands
+
+```bash
+pnpm install --frozen-lockfile --ignore-scripts
+```
+
+Result: PASS.
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/meta-base-picker.spec.ts \
+  tests/multitable-base-local-state.spec.ts \
+  tests/multitable-workbench-view.spec.ts \
+  --watch=false
+```
+
+Result: PASS, 3 files / 59 tests.
+
+## Coverage
+
+- `MetaBasePicker` renders decorated Bases in provided order.
+- Favorite toggle emits `toggle-favorite` and does not emit `select`.
+- Workbench records successful Base switches as recent opens.
+- Workbench failed Base switches do not record the failed Base.
+- Workbench favorite state reorders picker props and persists through localStorage.
+- Existing `base-local-state` corruption fallback and deterministic sorting tests still pass.
+
+## Scope Check
+
+- No backend source changes.
+- No database migration changes.
+- No OpenAPI changes.
+- No route or permission changes.
+- No Data Factory, K3, DingTalk, Attendance, or Phase 3 TODO status changes.
+
+## Additional Verification
+
+```bash
+pnpm --filter @metasheet/web exec eslint \
+  src/multitable/components/MetaBasePicker.vue \
+  src/multitable/views/MultitableWorkbench.vue \
+  tests/meta-base-picker.spec.ts \
+  tests/multitable-workbench-view.spec.ts
+```
+
+Result: PASS with warning-only output from existing lint rules (`vue/one-component-per-file` in the long Workbench test file and one pre-existing Workbench template linebreak warning). No lint errors.
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+```
+
+Result: PASS.
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+```
+
+Result: PASS.
+
+```bash
+git diff --check
+```
+
+Result: PASS.
+
+Secret-pattern scan over touched files:
+
+Result: PASS, 0 matches.
+
+Install noise cleanup:
+
+```bash
+git diff --name-only | rg '(^plugins/.*/node_modules|^tools/cli/node_modules)' | xargs git restore --
+```
+
+Result: PASS. Remaining changes are limited to the intended source, test, and documentation files.


### PR DESCRIPTION
## Summary

- reuse the multitable home favorite/recent local state in the Workbench Base picker
- show favorite/recent badges and a stop-propagated favorite toggle in `MetaBasePicker`
- record recent opens only after successful Workbench context transitions, base switches, and template installs
- add focused component/workbench coverage plus development and verification docs

## Scope

- frontend-only: no backend routes, migrations, OpenAPI, permissions, Data Factory, K3, DingTalk, Attendance, or Phase 3 TODO changes
- browser-local state only; no server-side favorites or cross-device sync

## Verification

- `pnpm install --frozen-lockfile --ignore-scripts` — PASS
- `pnpm --filter @metasheet/web exec vitest run tests/meta-base-picker.spec.ts tests/multitable-base-local-state.spec.ts tests/multitable-workbench-view.spec.ts --watch=false` — 3 files / 59 tests PASS
- `pnpm --filter @metasheet/web exec eslint src/multitable/components/MetaBasePicker.vue src/multitable/views/MultitableWorkbench.vue tests/meta-base-picker.spec.ts tests/multitable-workbench-view.spec.ts` — PASS with warning-only existing lint output
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit` — PASS
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit` — PASS
- `git diff --check` — PASS
- secret-pattern scan over touched files — 0 matches
