### PR TITLE
feat(multitable): complete views nav consolidation

### DIFF
--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -18,10 +18,6 @@
             <router-link v-if="hasFeature('attendance')" to="/attendance" class="nav-link">{{ navLabels.attendance }}</router-link>
             <router-link to="/apps" class="nav-link">{{ navLabels.apps }}</router-link>
             <router-link to="/multitable" class="nav-link">{{ navLabels.multitable }}</router-link>
-            <router-link to="/kanban" class="nav-link">{{ navLabels.kanban }}</router-link>
-            <router-link to="/calendar" class="nav-link">{{ navLabels.calendar }}</router-link>
-            <router-link to="/gallery" class="nav-link">{{ navLabels.gallery }}</router-link>
-            <router-link to="/form" class="nav-link">{{ navLabels.form }}</router-link>
             <router-link v-if="hasFeature('workflow')" to="/workflows" class="nav-link">{{ navLabels.workflows }}</router-link>
             <router-link to="/approvals" class="nav-link">{{ navLabels.approvals }}</router-link>
             <router-link
@@ -119,10 +115,6 @@ const navLabels = computed(() => {
     return {
       attendance: '考勤',
       multitable: '多维表',
-      kanban: '看板',
-      calendar: '日历',
-      gallery: '画廊',
-      form: '表单',
       workflows: '流程',
       approvals: '审批中心',
       apps: '应用',
@@ -144,10 +136,6 @@ const navLabels = computed(() => {
   return {
     attendance: 'Attendance',
     multitable: 'Multitable',
-    kanban: 'Kanban',
-    calendar: 'Calendar',
-    gallery: 'Gallery',
-    form: 'Form',
     workflows: 'Workflows',
     approvals: 'Approvals',
     apps: 'Apps',

--- a/apps/web/src/router/appRoutes.ts
+++ b/apps/web/src/router/appRoutes.ts
@@ -55,31 +55,31 @@ export const appRoutes: RouteRecordRaw[] = [
     path: '/grid',
     name: 'grid',
     component: GridView,
-    meta: { title: 'Grid View', requiresAuth: true }
+    meta: { title: 'Grid View', requiresAuth: true, deprecated: true }
   },
   {
     path: '/kanban',
     name: 'kanban',
     component: KanbanView,
-    meta: { title: 'Kanban View', requiresAuth: true }
+    meta: { title: 'Kanban View', requiresAuth: true, deprecated: true }
   },
   {
     path: '/calendar',
     name: 'calendar',
     component: CalendarView,
-    meta: { title: 'Calendar View', requiresAuth: true }
+    meta: { title: 'Calendar View', requiresAuth: true, deprecated: true }
   },
   {
     path: '/gallery',
     name: 'gallery',
     component: GalleryView,
-    meta: { title: 'Gallery View', requiresAuth: true }
+    meta: { title: 'Gallery View', requiresAuth: true, deprecated: true }
   },
   {
     path: '/form',
     name: 'form',
     component: FormView,
-    meta: { title: 'Form View', requiresAuth: true }
+    meta: { title: 'Form View', requiresAuth: true, deprecated: true }
   },
   {
     path: '/attendance',

--- a/apps/web/src/router/types.ts
+++ b/apps/web/src/router/types.ts
@@ -282,6 +282,7 @@ export interface RouteMeta {
   icon?: string
   keepAlive?: boolean
   transition?: string
+  deprecated?: boolean
 
   // Product capability guard
   requiredFeature?: 'attendance' | 'workflow' | 'attendanceAdmin' | 'attendanceImport' | 'plm'
@@ -467,7 +468,7 @@ export const RouteGuards = {
   /**
    * Check if user is authenticated
    */
-  requiresAuth: (to: TypedRouteLocation, from: TypedRouteLocation) => {
+  requiresAuth: (to: TypedRouteLocation, _from: TypedRouteLocation) => {
     const token = localStorage.getItem('auth_token')
     if (!token && to.meta.requiresAuth) {
       return { name: AppRouteNames.LOGIN, query: { redirect: to.fullPath } }
@@ -478,7 +479,7 @@ export const RouteGuards = {
   /**
    * Check if user is guest (not authenticated)
    */
-  requiresGuest: (to: TypedRouteLocation, from: TypedRouteLocation) => {
+  requiresGuest: (to: TypedRouteLocation, _from: TypedRouteLocation) => {
     const token = localStorage.getItem('auth_token')
     if (token && to.meta.requiresGuest) {
       return { name: AppRouteNames.DASHBOARD }
@@ -489,7 +490,7 @@ export const RouteGuards = {
   /**
    * Check if user has required permissions
    */
-  requiresPermissions: (to: TypedRouteLocation, from: TypedRouteLocation) => {
+  requiresPermissions: (to: TypedRouteLocation, _from: TypedRouteLocation) => {
     const requiredPermissions = to.meta.permissions || []
     if (requiredPermissions.length === 0) return true
 
@@ -511,7 +512,7 @@ export const RouteGuards = {
   /**
    * Check if user has required roles
    */
-  requiresRoles: (to: TypedRouteLocation, from: TypedRouteLocation) => {
+  requiresRoles: (to: TypedRouteLocation, _from: TypedRouteLocation) => {
     const requiredRoles = to.meta.roles || []
     if (requiredRoles.length === 0) return true
 

--- a/apps/web/tests/platform-shell-nav.spec.ts
+++ b/apps/web/tests/platform-shell-nav.spec.ts
@@ -108,6 +108,10 @@ describe('platform shell navigation', () => {
     ]))
     expect(links.some((link) => link.href === '/grid')).toBe(false)
     expect(links.some((link) => link.href === '/spreadsheets')).toBe(false)
+    expect(links.some((link) => link.href === '/kanban')).toBe(false)
+    expect(links.some((link) => link.href === '/calendar')).toBe(false)
+    expect(links.some((link) => link.href === '/gallery')).toBe(false)
+    expect(links.some((link) => link.href === '/form')).toBe(false)
     expect(links.some((link) => link.href === '/plm')).toBe(false)
     expect(links.some((link) => link.href === '/plm/audit')).toBe(false)
     expect(links.some((link) => link.href === '/integrations/k3-wise')).toBe(false)
@@ -196,7 +200,23 @@ describe('platform shell navigation', () => {
     ]))
     expect(links.some((link) => link.href === '/grid')).toBe(false)
     expect(links.some((link) => link.href === '/spreadsheets')).toBe(false)
+    expect(links.some((link) => link.href === '/kanban')).toBe(false)
+    expect(links.some((link) => link.href === '/calendar')).toBe(false)
+    expect(links.some((link) => link.href === '/gallery')).toBe(false)
+    expect(links.some((link) => link.href === '/form')).toBe(false)
     expect(links.some((link) => link.href === '/admin/users')).toBe(false)
+  })
+
+  it('marks legacy table/view routes as deprecated while keeping deep links registered', async () => {
+    const source = await readFile(resolve(process.cwd(), 'src/router/appRoutes.ts'), 'utf8')
+    const deprecatedPaths = ['/grid', '/kanban', '/calendar', '/gallery', '/form']
+
+    for (const path of deprecatedPaths) {
+      const routePattern = new RegExp(
+        `path:\\s*'${path.replace('/', '\\/')}'[\\s\\S]*?meta:\\s*\\{[^}]*requiresAuth:\\s*true[^}]*deprecated:\\s*true`,
+      )
+      expect(source, `Expected ${path} route to remain registered and deprecated`).toMatch(routePattern)
+    }
   })
 
   it('keeps a dedicated approvals route in the platform shell', async () => {

--- a/docs/development/views-consolidation-nav-positioning-development-20260518.md
+++ b/docs/development/views-consolidation-nav-positioning-development-20260518.md
@@ -1,0 +1,93 @@
+# Views Consolidation Navigation Positioning Development Notes
+
+Date: 2026-05-18
+
+Branch: `codex/views-consolidation-nav-positioning-20260518`
+
+Base: `origin/main@cd3d6f6f9e97ccfc66756e7c35747758f121627f`
+
+## Result
+
+This PR implements the safe frontend-only part of the views consolidation plan:
+
+- The platform shell now presents Multitable as the only top-level table/view product entry.
+- Legacy top-level view links (`/kanban`, `/calendar`, `/gallery`, `/form`) are removed from the shell navigation.
+- Existing deep links stay registered and authenticated.
+- Legacy table/view routes are explicitly marked with route metadata `deprecated: true`.
+
+No backend route, OpenAPI contract, database migration, plugin-integration-core file, K3 adapter file, or multitable runtime contract changed.
+
+## Positioning Decision
+
+The reviewed consolidation draft is directionally correct: the long-term architecture should be "two pillars plus an internal view plugin mechanism".
+
+The product positioning should still be stricter than that architecture statement:
+
+- Primary product: Multitable.
+- Secondary capability: Spreadsheets, for free-cell / A1 formula scenarios.
+- Non-product surface: Grid and legacy top-level view routes.
+
+The reason is user-facing maturity. Multitable already owns the row-field-multiview product story. Spreadsheets has a real backend and A1 formula engine, but the frontend is not yet mature enough to deserve equal top-level marketing. Grid is an orphan layer between the two and should not be promoted as a product entry.
+
+This PR therefore does not add or promote a Spreadsheets nav entry. It keeps the current shell focused on Multitable while preserving existing routes.
+
+## Scope
+
+In scope:
+
+- Remove legacy top-level shell links for Kanban, Calendar, Gallery, and Form.
+- Keep `/grid`, `/kanban`, `/calendar`, `/gallery`, and `/form` route records alive.
+- Add `RouteMeta.deprecated` so future cleanup phases can reason about retained legacy deep links without guessing.
+- Extend platform shell tests to assert the navigation and metadata contract.
+
+Out of scope:
+
+- Delete dead Grid or legacy view files.
+- Redirect `/grid`.
+- Change Spreadsheets UI or backend behavior.
+- Change multitable APIs or view rendering.
+- Change feature flags, home route resolution, or data migration behavior.
+
+## Files Changed
+
+| Path | Purpose |
+| --- | --- |
+| `apps/web/src/App.vue` | Removes legacy top-level nav links and unused labels. |
+| `apps/web/src/router/appRoutes.ts` | Marks retained legacy table/view routes as deprecated. |
+| `apps/web/src/router/types.ts` | Adds `RouteMeta.deprecated`; also normalizes unused route guard args to `_from` so targeted lint stays clean. |
+| `apps/web/tests/platform-shell-nav.spec.ts` | Verifies legacy links are absent from shell nav and deep routes remain registered with deprecated metadata. |
+| `docs/development/views-consolidation-nav-positioning-development-20260518.md` | This development record. |
+| `docs/development/views-consolidation-nav-positioning-verification-20260518.md` | Verification record. |
+
+## Behavioral Contract
+
+The intended user-facing behavior after this PR:
+
+- Main navigation shows Multitable, not separate Kanban / Calendar / Gallery / Form products.
+- Users with saved or copied legacy links can still open those routes.
+- `/grid` remains intentionally unlinked from the shell and now has deprecated metadata for future Phase C retirement.
+- No data is deleted, migrated, or rewritten.
+
+## Why Not Redirect Now
+
+The reviewed plan notes that `/grid` historically writes to the Spreadsheets backend and may have user state tied to local storage or existing "Grid Workspace" spreadsheets.
+
+Redirecting or deleting `/grid` in this PR would mix product positioning with data-preservation work. That belongs in a separate Phase C PR with explicit route-gate behavior and rollback notes.
+
+## K3 / Stage-1 Lock Impact
+
+This slice is frontend shell and router metadata only.
+
+- `plugins/plugin-integration-core/**`: not touched.
+- `lib/adapters/k3-wise-*`: not touched.
+- `packages/core-backend/src/routes/integrations*.ts`: not touched.
+- `/api/multitable/*` contract: unchanged.
+- `/api/spreadsheets/*` contract: unchanged.
+
+## Follow-Ups
+
+Recommended next slices, in order:
+
+1. Dead-code deletion for confirmed unreachable Grid / formula / plugin-view-grid assets.
+2. `/grid` route-gate retirement with explicit preservation of existing Spreadsheet-backed user data.
+3. Spreadsheets UI upgrade only if Phase D is funded; until then, keep it secondary.

--- a/docs/development/views-consolidation-nav-positioning-verification-20260518.md
+++ b/docs/development/views-consolidation-nav-positioning-verification-20260518.md
@@ -1,0 +1,122 @@
+# Views Consolidation Navigation Positioning Verification
+
+Date: 2026-05-18
+
+Branch: `codex/views-consolidation-nav-positioning-20260518`
+
+## Result
+
+Status: PASS
+
+This verification covers the frontend-only navigation positioning slice for views consolidation.
+
+## Commands
+
+### V1 - Platform Shell Navigation Spec
+
+Command:
+
+```sh
+pnpm --filter @metasheet/web exec vitest run tests/platform-shell-nav.spec.ts --watch=false
+```
+
+Result:
+
+```text
+Test Files  1 passed (1)
+Tests       4 passed (4)
+```
+
+Coverage:
+
+- Multitable remains visible in platform shell navigation.
+- `/grid` and `/spreadsheets` remain absent from top-level shell links.
+- `/kanban`, `/calendar`, `/gallery`, and `/form` are no longer top-level shell links.
+- `/grid`, `/kanban`, `/calendar`, `/gallery`, and `/form` still have registered route records with `requiresAuth: true` and `deprecated: true`.
+
+### V2 - Targeted Frontend Lint
+
+Command:
+
+```sh
+pnpm --filter @metasheet/web exec eslint src/App.vue src/router/appRoutes.ts src/router/types.ts tests/platform-shell-nav.spec.ts
+```
+
+Result:
+
+```text
+Exit code 0
+0 errors
+10 warnings
+```
+
+The warnings are existing Vue test-fixture style warnings in `platform-shell-nav.spec.ts` for inline mocked `router-view` / `router-link` components. No lint errors remain.
+
+### V3 - Frontend Type Check
+
+Command:
+
+```sh
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+```
+
+Result:
+
+```text
+Exit code 0
+```
+
+### V4 - Backend Type Check
+
+Command:
+
+```sh
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+```
+
+Result:
+
+```text
+Exit code 0
+```
+
+### V5 - Diff Hygiene
+
+Command:
+
+```sh
+git diff --check
+```
+
+Result:
+
+```text
+Exit code 0
+```
+
+### V6 - Secret Scan
+
+Command:
+
+```sh
+git diff --cached -U0 -- <changed-files> | rg -n <secret-patterns> --no-heading
+```
+
+Result:
+
+```text
+0 matches
+```
+
+The concrete pattern set covered token-shaped, JWT-shaped, API-key-shaped, DingTalk-secret-shaped, credential-field, and query-token values. The literal pattern is intentionally not embedded in this verification note so the note does not match its own scan.
+
+## What This Does Not Verify
+
+- It does not execute a browser smoke against a running dev server.
+- It does not test legacy view rendering because those routes remain unchanged.
+- It does not verify Spreadsheets behavior because this PR does not change Spreadsheets.
+- It does not verify `/grid` data migration or route-gate behavior because that is explicitly deferred.
+
+## Final Verdict
+
+PASS.


### PR DESCRIPTION
## Summary
- remove legacy Kanban / Calendar / Gallery / Form links from the platform shell so Multitable is the only top-level table/view product entry
- keep `/grid`, `/kanban`, `/calendar`, `/gallery`, and `/form` deep links registered and mark them `meta.deprecated = true`
- add development + verification notes for the views consolidation positioning decision

## Product positioning
- Primary product surface: Multitable
- Secondary capability: Spreadsheets, reserved for free-cell / A1 formula work until Phase D is funded
- Non-product surface: Grid and legacy top-level view routes

## Verification
- `pnpm --filter @metasheet/web exec vitest run tests/platform-shell-nav.spec.ts --watch=false`
- `pnpm --filter @metasheet/web exec eslint src/App.vue src/router/appRoutes.ts src/router/types.ts tests/platform-shell-nav.spec.ts`
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit`
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit`
- `git diff --cached --check`
- diff-only secret scan: 0 matches

## K3 / Stage-1 lock impact
- no plugin-integration-core changes
- no K3 adapter changes
- no backend route, OpenAPI, migration, or multitable API contract changes
