### PR TITLE
fix(integration): diagnose frontend base URL smoke failures

### DIFF
--- a/docs/development/k3wise-postdeploy-smoke-frontend-baseurl-diagnostic-design-20260518.md
+++ b/docs/development/k3wise-postdeploy-smoke-frontend-baseurl-diagnostic-design-20260518.md
@@ -1,0 +1,55 @@
+# K3 WISE Postdeploy Smoke Frontend Base URL Diagnostic Design - 2026-05-18
+
+## Context
+
+Issue #651 reported a deployment where authenticated backend checks passed but
+the frontend route checks failed:
+
+- `/api/auth/me`: pass
+- `/api/integration/*`: pass
+- staging install/schema/pipeline-save: pass
+- `/integrations/k3-wise`: 404
+- `/integrations/workbench`: 404
+
+The current package already contains the Vue routes and the built frontend
+chunks, and `multitable-onprem-package-verify.sh` gates both route strings in
+`apps/web/dist`. The likely operator fault is therefore not a missing bundle,
+but a postdeploy smoke `--base-url` pointed at the backend/API port instead of
+the frontend/nginx entry, or a reverse proxy without SPA history fallback.
+
+## Change
+
+`scripts/ops/integration-k3wise-postdeploy-smoke.mjs` now adds a targeted
+diagnostic when this shape occurs:
+
+- `/api/health` passed, proving the base URL reaches a MetaSheet backend.
+- A frontend SPA route returns HTTP 404.
+
+The failing route check remains a failure, but the check now includes:
+
+- `code: FRONTEND_ROUTE_NOT_FOUND`
+- `likelyCause`: backend/API-only URL or missing SPA fallback
+- `hint`: use the frontend/nginx URL and verify `/`, `/login`, and
+  `/integrations/*` return the app shell.
+
+The diagnostic is written to both JSON and Markdown evidence. Existing
+single-error Markdown formatting is preserved when no diagnostic fields exist.
+
+## Non-Goals
+
+- No change to frontend routing.
+- No change to nginx templates.
+- No relaxation of postdeploy smoke signoff.
+- No customer GATE behavior change and no K3 Save/Submit/Audit path change.
+
+## Operator Impact
+
+When the field team sees the #651 failure shape again, the artifact will point
+directly to the right next check:
+
+1. Try the smoke with the frontend URL, for example `http://127.0.0.1` or
+   `http://127.0.0.1:8081`.
+2. Confirm `/` and `/login` return the Vue app shell.
+3. If `/` works but `/integrations/*` still returns 404, fix the frontend
+   reverse proxy SPA fallback to `index.html`.
+

--- a/docs/development/k3wise-postdeploy-smoke-frontend-baseurl-diagnostic-verification-20260518.md
+++ b/docs/development/k3wise-postdeploy-smoke-frontend-baseurl-diagnostic-verification-20260518.md
@@ -1,0 +1,49 @@
+# K3 WISE Postdeploy Smoke Frontend Base URL Diagnostic Verification - 2026-05-18
+
+## Scope
+
+Verifies the #651 diagnostic improvement for the case where backend/API smoke
+checks pass but frontend SPA routes return 404.
+
+## Commands
+
+```bash
+node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
+node --check scripts/ops/integration-k3wise-postdeploy-smoke.mjs
+git diff --check
+```
+
+## Results
+
+| Command | Result |
+| --- | --- |
+| `node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs` | PASS, 25/25 |
+| `node --check scripts/ops/integration-k3wise-postdeploy-smoke.mjs` | PASS |
+| `git diff --check` | PASS |
+
+## New Coverage
+
+Added `postdeploy smoke diagnoses backend-only base URL when frontend routes
+return 404`.
+
+The test creates a fake deployment that:
+
+- returns 200 for `/api/health`;
+- returns 200 for `/api/integration/health`;
+- returns 404 for `/integrations/k3-wise`;
+- returns 404 for `/integrations/workbench`.
+
+Expected evidence:
+
+- `api-health`: `pass`
+- `k3-wise-frontend-route`: `fail`
+- `data-factory-frontend-route`: `fail`
+- both route checks include `code: FRONTEND_ROUTE_NOT_FOUND`
+- both route checks include a frontend/nginx base URL hint
+- Markdown evidence includes the diagnostic code and hint
+
+## Compatibility Check
+
+The existing Markdown escaping test remains green. This confirms the new
+diagnostic fields do not regress the old single-error table detail format.
+

--- a/scripts/ops/integration-k3wise-postdeploy-smoke.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-smoke.mjs
@@ -351,14 +351,27 @@ function result(id, status, details = {}) {
   }
 }
 
-function failResult(id, error) {
+function failResult(id, error, extra = {}) {
   const details = error && error.details && typeof error.details === 'object'
     ? { details: sanitizeBody(error.details) }
     : {}
   return result(id, 'fail', {
     error: error && error.message ? redactText(error.message) : redactText(String(error)),
     ...details,
+    ...extra,
   })
+}
+
+function isHttpStatusError(error, status) {
+  return Boolean(error && error.details && Number(error.details.status) === status)
+}
+
+function frontendRouteNotFoundHint(baseUrl) {
+  return {
+    code: 'FRONTEND_ROUTE_NOT_FOUND',
+    likelyCause: 'The base URL reaches the backend API, but frontend SPA routes return 404. The smoke may be pointed at the backend/API port instead of the frontend/nginx entry, or the reverse proxy lacks SPA history fallback.',
+    hint: `Use the frontend/nginx URL for --base-url, not the backend API port. Verify ${baseUrl}/ and ${baseUrl}/login return the app shell, and ensure the frontend proxy falls back to index.html for /integrations/* routes.`,
+  }
 }
 
 function systemSummary(system) {
@@ -1138,6 +1151,7 @@ function extractTenantId(authBody) {
 
 async function runSmoke(opts) {
   const checks = []
+  let apiHealthPassed = false
   const resolvedToken = await resolveToken(opts)
   const token = resolvedToken.token
   if (resolvedToken.check) checks.push(resolvedToken.check)
@@ -1155,6 +1169,7 @@ async function runSmoke(opts) {
       plugins: health.body?.plugins ?? null,
       pluginsSummary: summary,
     }))
+    apiHealthPassed = true
   } catch (error) {
     checks.push(failResult('api-health', error))
   }
@@ -1184,14 +1199,22 @@ async function runSmoke(opts) {
     const page = await requestText(opts.baseUrl, '/integrations/k3-wise', { timeoutMs: opts.timeoutMs })
     checks.push(result('k3-wise-frontend-route', 'pass', assertFrontendAppShell(page, 'K3 WISE')))
   } catch (error) {
-    checks.push(failResult('k3-wise-frontend-route', error))
+    checks.push(failResult(
+      'k3-wise-frontend-route',
+      error,
+      apiHealthPassed && isHttpStatusError(error, 404) ? frontendRouteNotFoundHint(opts.baseUrl) : {},
+    ))
   }
 
   try {
     const page = await requestText(opts.baseUrl, '/integrations/workbench', { timeoutMs: opts.timeoutMs })
     checks.push(result('data-factory-frontend-route', 'pass', assertFrontendAppShell(page, 'Data Factory')))
   } catch (error) {
-    checks.push(failResult('data-factory-frontend-route', error))
+    checks.push(failResult(
+      'data-factory-frontend-route',
+      error,
+      apiHealthPassed && isHttpStatusError(error, 404) ? frontendRouteNotFoundHint(opts.baseUrl) : {},
+    ))
   }
 
   if (!token) {
@@ -1342,11 +1365,26 @@ function renderMarkdown(evidence) {
     '| --- | --- | --- |',
   ]
   for (const check of evidence.checks) {
-    const detail = check.error || check.reason || JSON.stringify({ ...check, id: undefined, status: undefined })
+    const detail = markdownCheckDetail(check)
     lines.push(`| ${markdownTableCodeCell(check.id)} | ${markdownTableCodeCell(check.status)} | ${markdownTableCodeCell(detail)} |`)
   }
   lines.push('')
   return `${lines.join('\n')}\n`
+}
+
+function markdownCheckDetail(check) {
+  const hasDiagnosticFields = ['code', 'likelyCause', 'hint'].some((key) => typeof check[key] === 'string' && check[key].trim())
+  if (!hasDiagnosticFields && typeof check.error === 'string' && check.error.trim()) return check.error
+  if (!hasDiagnosticFields && typeof check.reason === 'string' && check.reason.trim()) return check.reason
+
+  const parts = []
+  for (const key of ['code', 'error', 'reason', 'likelyCause', 'hint']) {
+    if (typeof check[key] === 'string' && check[key].trim()) {
+      parts.push(`${key}: ${check[key].trim()}`)
+    }
+  }
+  if (parts.length > 0) return parts.join(' | ')
+  return JSON.stringify({ ...check, id: undefined, status: undefined })
 }
 
 async function runCli(argv = process.argv.slice(2)) {

--- a/scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
@@ -388,11 +388,19 @@ function createFakeServer(options = {}) {
     }
 
     if (req.method === 'GET' && url.pathname === '/integrations/k3-wise') {
+      if (options.frontendRoutesNotFound) {
+        sendJson(res, 404, { ok: false, error: { message: 'not found: /integrations/k3-wise' } })
+        return
+      }
       sendHtml(res, 200, '<!doctype html><html><body><div id="app"></div><script src="/assets/app.js"></script></body></html>')
       return
     }
 
     if (req.method === 'GET' && url.pathname === '/integrations/workbench') {
+      if (options.frontendRoutesNotFound) {
+        sendJson(res, 404, { ok: false, error: { message: 'not found: /integrations/workbench' } })
+        return
+      }
       sendHtml(res, 200, '<!doctype html><html><body><div id="app"></div><script src="/assets/app.js"></script></body></html>')
       return
     }
@@ -654,6 +662,43 @@ test('public postdeploy smoke skips plugin health when the deployment protects i
     assert.equal(evidence.checks.find((check) => check.id === 'integration-plugin-health').status, 'skipped')
     assert.equal(evidence.checks.find((check) => check.id === 'k3-wise-frontend-route').status, 'pass')
     assert.equal(evidence.checks.find((check) => check.id === 'data-factory-frontend-route').status, 'pass')
+  } finally {
+    await fake.close()
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('postdeploy smoke diagnoses backend-only base URL when frontend routes return 404', async () => {
+  const fake = createFakeServer({ frontendRoutesNotFound: true })
+  const baseUrl = await fake.listen()
+  const outDir = makeTmpDir()
+  try {
+    const result = await runScript([
+      '--base-url', baseUrl,
+      '--out-dir', outDir,
+    ])
+
+    assert.equal(result.status, 1)
+    const stdout = JSON.parse(result.stdout)
+    assert.equal(stdout.ok, false)
+    assert.equal(stdout.summary.fail, 2)
+
+    const evidence = JSON.parse(readFileSync(path.join(outDir, 'integration-k3wise-postdeploy-smoke.json'), 'utf8'))
+    assert.equal(evidence.checks.find((check) => check.id === 'api-health').status, 'pass')
+    const k3Route = evidence.checks.find((check) => check.id === 'k3-wise-frontend-route')
+    const workbenchRoute = evidence.checks.find((check) => check.id === 'data-factory-frontend-route')
+    for (const check of [k3Route, workbenchRoute]) {
+      assert.equal(check.status, 'fail')
+      assert.equal(check.details.status, 404)
+      assert.equal(check.code, 'FRONTEND_ROUTE_NOT_FOUND')
+      assert.match(check.likelyCause, /backend API/)
+      assert.match(check.hint, /frontend\/nginx URL/)
+      assert.match(check.hint, /index\.html/)
+    }
+
+    const markdown = readFileSync(path.join(outDir, 'integration-k3wise-postdeploy-smoke.md'), 'utf8')
+    assert.match(markdown, /FRONTEND_ROUTE_NOT_FOUND/)
+    assert.match(markdown, /frontend\/nginx URL/)
   } finally {
     await fake.close()
     rmSync(outDir, { recursive: true, force: true })


### PR DESCRIPTION
## Summary

Addresses the latest #651 deployment feedback where backend/auth/staging checks pass but the postdeploy smoke reports 404 for:

- `/integrations/k3-wise`
- `/integrations/workbench`

The frontend routes and package assets already exist, so this PR does not change frontend routing or K3 runtime. It makes the smoke artifact diagnose the likely operator/deployment issue: `--base-url` is reaching the backend/API surface or a frontdoor without SPA history fallback, rather than the frontend/nginx entrypoint.

## Changes

- Adds `FRONTEND_ROUTE_NOT_FOUND` diagnostic metadata when frontend route checks return 404 after `/api/health` has passed.
- Includes actionable hints in JSON and Markdown reports:
  - use the frontend/nginx URL for `--base-url`
  - verify `/` and `/login`
  - ensure `/integrations/*` falls back to `index.html`
- Adds regression coverage for the backend-only-base-url scenario.
- Adds design and verification docs for the #651 diagnostic path.

## Verification

- `node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs` — 25/25 pass
- `node --check scripts/ops/integration-k3wise-postdeploy-smoke.mjs` — pass
- `git diff --check` — pass

## Scope / Deployment Impact

- Ops + docs only.
- No frontend route changes.
- No nginx template changes.
- No `plugin-integration-core` runtime changes.
- No migration, DB, or API route changes.
- Does not execute or enable real K3 Save / Submit / Audit.
