### PR TITLE
fix(onprem): clarify deployable package artifacts

### DIFF
--- a/docs/deployment/multitable-onprem-package-layout-20260319.md
+++ b/docs/deployment/multitable-onprem-package-layout-20260319.md
@@ -42,6 +42,38 @@ The workflow builds:
 
 The workflow already supports GitHub Release publishing through `publish_release=true`.
 
+## Artifact type
+
+The `.zip` and `.tgz` assets are deployable on-prem application packages, not
+source-only archives. They intentionally preserve workspace-style runtime
+paths, because the app resolves built frontend/backend output, plugins,
+migrations, scripts, and deployment templates from those directories:
+
+- `apps/web/dist`
+- `packages/core-backend/dist`
+- `packages/core-backend/migrations`
+- `plugins/`
+- `scripts/ops/`
+- `docker/`
+- `ops/`
+- `docs/`
+
+That structure can look like a source tree after extraction, but the release
+asset is still the deployable package. It is not a single binary and it does
+not bundle `node_modules`.
+
+For upgrades, do not hand-copy selected directories over a running install.
+Copy the downloaded archive to the target host and run the apply entrypoint
+from the existing deploy root:
+
+```bat
+deploy.bat <downloaded-package.zip>
+```
+
+The package root includes `DEPLOYMENT.txt` and `PACKAGE-METADATA.json` so field
+operators can distinguish deployable packages from source/documentation assets
+without consulting GitHub issue history.
+
 For a corrective reroll such as `v2.5.1`, set:
 
 - `package_version=2.5.1`
@@ -69,6 +101,8 @@ pnpm verify:multitable-onprem:release-gate
 
 ```text
 metasheet/
+  DEPLOYMENT.txt
+  PACKAGE-METADATA.json
   bootstrap-admin.bat
   bootstrap-admin-runXX.bat
   deploy.bat

--- a/docs/deployment/multitable-windows-onprem-easy-start-20260319.md
+++ b/docs/deployment/multitable-windows-onprem-easy-start-20260319.md
@@ -10,6 +10,24 @@ PRODUCT_MODE=platform
 
 ## 1) Build or download the package
 
+The release `.zip` and `.tgz` assets are deployable on-prem application
+packages. They are not source-only archives, even though extracting them shows
+workspace-style directories such as `apps/`, `packages/`, `plugins/`,
+`scripts/`, `docker/`, `ops/`, and `docs/`. Those paths are part of the runtime
+layout and are required by the deploy helpers.
+
+Each package root includes:
+
+- `DEPLOYMENT.txt` — operator-facing explanation of fresh install vs upgrade.
+- `PACKAGE-METADATA.json` — machine-readable artifact kind and deploy mode.
+
+For upgrades, do not hand-copy selected directories over a running install. Use
+the existing deploy root's apply entrypoint:
+
+```bat
+deploy.bat <downloaded-package.zip>
+```
+
 Local build on the release machine:
 
 ```bash

--- a/docs/development/onprem-package-deployable-artifact-clarity-design-20260518.md
+++ b/docs/development/onprem-package-deployable-artifact-clarity-design-20260518.md
@@ -1,0 +1,67 @@
+# On-Prem Package Deployable Artifact Clarity Design - 2026-05-18
+
+## Context
+
+Issue #651 reported that the `multitable-onprem-k3wise-20260518-31d25abac`
+Release zip downloaded successfully and matched SHA256, but looked like a
+source/documentation tree after extraction. That made the field deployment path
+ambiguous: operators could not tell whether the asset was directly deployable,
+source-only, or meant for another wrapper.
+
+Inspection showed the asset is the expected deployable package. It contains
+built frontend output, built backend output, migrations, packaged plugins,
+ops scripts, environment templates, nginx examples, and runbooks. The package
+intentionally preserves workspace-style paths because the runtime and deploy
+helpers resolve files relative to those paths.
+
+The gap was artifact self-description, not missing runtime content.
+
+## Decision
+
+Keep the existing package layout. Do not convert it into a binary or bundle
+`node_modules`.
+
+Instead, make the deployability contract explicit in three places:
+
+1. `DEPLOYMENT.txt` inside the package root.
+2. `PACKAGE-METADATA.json` inside the package root.
+3. The external release metadata JSON and verify reports.
+
+The package verifier now treats this contract as required content. Future
+release assets that do not explain deployability, direct-replacement safety,
+or dependency policy fail verification before delivery.
+
+## Contract
+
+The package declares:
+
+- `artifactKind`: `deployable-onprem-app-package`
+- `deployMode`: `fresh-extract-or-existing-root-apply`
+- `directReplaceSafe`: `false`
+- `nodeModulesBundled`: `false`
+- `windowsEntryPoint`: `deploy.bat <package.zip|package.tgz>`
+
+`directReplaceSafe=false` is intentional. The archive should not be applied by
+hand-copying selected directories into a running installation. Upgrade flows
+must use the existing deploy root's apply helper, which extracts the archive,
+copies package contents consistently, installs dependencies when missing, runs
+migrations, restarts PM2, and healthchecks.
+
+## Non-Goals
+
+- No K3 runtime behavior changes.
+- No frontend routing changes.
+- No migration changes.
+- No packaging of `node_modules`.
+- No change to Release asset names in this PR.
+
+## Deployment Impact
+
+Future packages include two extra root files and richer metadata. Existing
+deployment scripts continue to work.
+
+For field operators, the intended flow becomes harder to miss:
+
+- Fresh install: extract the archive and follow the easy-start guide.
+- Upgrade/corrective reroll: run `deploy.bat <downloaded-package.zip>` from the
+  existing deploy root.

--- a/docs/development/onprem-package-deployable-artifact-clarity-verification-20260518.md
+++ b/docs/development/onprem-package-deployable-artifact-clarity-verification-20260518.md
@@ -1,0 +1,106 @@
+# On-Prem Package Deployable Artifact Clarity Verification - 2026-05-18
+
+## Scope
+
+This verifies the #651 follow-up that makes Multitable on-prem Release assets
+self-describing as deployable packages rather than source-only archives.
+
+## Static Checks
+
+Commands:
+
+```bash
+bash -n scripts/ops/multitable-onprem-package-build.sh
+bash -n scripts/ops/multitable-onprem-package-verify.sh
+git diff --check
+```
+
+Expected result:
+
+- shell syntax passes - PASS
+- whitespace/conflict-marker check passes - PASS
+
+## Build/Verify Checks
+
+Command:
+
+```bash
+INSTALL_DEPS=1 BUILD_WEB=1 BUILD_BACKEND=1 \
+  PACKAGE_TAG=clarity-local \
+  scripts/ops/multitable-onprem-package-build.sh
+
+VERIFY_REPORT_JSON=/tmp/metasheet-onprem-clarity/zip.verify.json \
+VERIFY_REPORT_MD=/tmp/metasheet-onprem-clarity/zip.verify.md \
+  scripts/ops/multitable-onprem-package-verify.sh \
+  output/releases/multitable-onprem/metasheet-multitable-onprem-v2.5.0-clarity-local.zip
+
+VERIFY_REPORT_JSON=/tmp/metasheet-onprem-clarity/tgz.verify.json \
+VERIFY_REPORT_MD=/tmp/metasheet-onprem-clarity/tgz.verify.md \
+  scripts/ops/multitable-onprem-package-verify.sh \
+  output/releases/multitable-onprem/metasheet-multitable-onprem-v2.5.0-clarity-local.tgz
+```
+
+Expected result:
+
+- zip verify returned `Package verify OK`
+- tgz verify returned `Package verify OK`
+- both package archives included `DEPLOYMENT.txt`
+- both package archives included `PACKAGE-METADATA.json`
+- verify reports included `deployability-contract`
+- external package metadata JSON included deployability fields
+
+Observed zip report excerpt:
+
+```json
+{
+  "name": "deployability-contract",
+  "status": "PASS",
+  "artifactKind": "deployable-onprem-app-package",
+  "deployMode": "fresh-extract-or-existing-root-apply",
+  "directReplaceSafe": false,
+  "nodeModulesBundled": false
+}
+```
+
+## Required Content Added
+
+The verifier now requires:
+
+- `DEPLOYMENT.txt`
+- `PACKAGE-METADATA.json`
+
+The verifier also checks these strings:
+
+- package is a deployable on-prem application package
+- package is not a source-only archive
+- direct replacement of a running install is unsafe
+- Windows upgrade entrypoint is `deploy.bat <downloaded-package.zip>`
+- `node_modules` are intentionally not bundled
+
+## Artifact Metadata
+
+`PACKAGE-METADATA.json` must contain:
+
+```json
+{
+  "artifactKind": "deployable-onprem-app-package",
+  "deployMode": "fresh-extract-or-existing-root-apply",
+  "directReplaceSafe": false,
+  "nodeModulesBundled": false,
+  "windowsEntryPoint": "deploy.bat <package.zip|package.tgz>"
+}
+```
+
+The external release metadata JSON mirrors the same fields.
+
+## Regression Boundary
+
+This PR does not validate entity-machine deployment. It only makes future
+release assets unambiguous before they are sent to the field team.
+
+The entity-machine retest remains:
+
+1. Download the rebuilt Release zip.
+2. Run package verify.
+3. Deploy with the documented apply entrypoint.
+4. Run K3 WISE postdeploy smoke with frontend/nginx `--base-url`.

--- a/scripts/ops/multitable-onprem-package-build.sh
+++ b/scripts/ops/multitable-onprem-package-build.sh
@@ -241,6 +241,79 @@ exit /b %ERRORLEVEL%
 EOF
 }
 
+function write_deployment_guides() {
+  cat > "${PACKAGE_ROOT}/DEPLOYMENT.txt" <<EOF
+MetaSheet Multitable On-Prem Deployable Package
+Version: ${PACKAGE_VERSION}
+Tag: ${PACKAGE_TAG}
+
+What this archive is:
+  This is a deployable on-prem application package. It contains the built
+  frontend bundle, built backend dist, migrations, packaged plugins, deploy
+  scripts, environment templates, nginx/systemd examples, and operator docs.
+
+Why it looks like a source tree:
+  The runtime uses workspace-relative paths, so the archive intentionally keeps
+  directories such as apps/web/dist, packages/core-backend/dist, plugins,
+  scripts, docker, ops, and docs. That layout does not mean this is a
+  source-only archive.
+
+What this archive is not:
+  It is not a single binary.
+  It is not a node_modules snapshot.
+  It is not meant to be applied by hand-copying only selected source folders.
+  It is not direct-replace-safe for a running installation without the apply
+  helper or documented install flow.
+
+Fresh install:
+  Extract the archive into a new deploy root, create docker/app.env from the
+  template, then follow:
+    docs/deployment/multitable-windows-onprem-easy-start-20260319.md
+
+Upgrade / corrective reroll:
+  Copy the downloaded package archive to the target host. From the existing
+  deploy root, run:
+    deploy.bat <downloaded-package.zip>
+
+  Or run the PowerShell helper directly:
+    powershell -NoProfile -ExecutionPolicy Bypass -File scripts\ops\multitable-onprem-apply-package.ps1 -RootDir . -PackageArchive <downloaded-package.zip>
+
+Dependency policy:
+  node_modules are intentionally not bundled. The apply helper defaults to
+  InstallDeps=1 and runs pnpm install --frozen-lockfile when node_modules is
+  missing. Manual deployments must run the same command before migrations,
+  PM2 restart, or admin bootstrap.
+
+Verification:
+  A valid delivery asset passes:
+    scripts/ops/multitable-onprem-package-verify.sh <package.zip|package.tgz>
+EOF
+
+  cat > "${PACKAGE_ROOT}/PACKAGE-METADATA.json" <<EOF
+{
+  "name": "${PACKAGE_NAME}",
+  "version": "${PACKAGE_VERSION}",
+  "tag": "${PACKAGE_TAG}",
+  "artifactKind": "deployable-onprem-app-package",
+  "deployMode": "fresh-extract-or-existing-root-apply",
+  "directReplaceSafe": false,
+  "nodeModulesBundled": false,
+  "windowsEntryPoint": "deploy.bat <package.zip|package.tgz>",
+  "linuxEntryPoint": "scripts/ops/multitable-onprem-package-install.sh",
+  "includedRuntimeRoots": [
+    "apps/web/dist",
+    "packages/core-backend/dist",
+    "packages/core-backend/migrations",
+    "plugins",
+    "scripts/ops",
+    "docker",
+    "ops",
+    "docs"
+  ]
+}
+EOF
+}
+
 function cleanup() {
   [[ -n "$checksum_tmp" ]] && rm -f "$checksum_tmp" || true
   rm -rf "$TMP_OUTPUT_DIR" || true
@@ -292,11 +365,26 @@ done
 stamp_packaged_version "package.json"
 stamp_packaged_version "packages/core-backend/package.json"
 write_windows_entrypoints
+write_deployment_guides
 
 cat > "${PACKAGE_ROOT}/INSTALL.txt" <<EOF
 MetaSheet Multitable On-Prem Package
 Version: ${PACKAGE_VERSION}
 Tag: ${PACKAGE_TAG}
+
+Artifact type:
+  deployable-onprem-app-package
+
+Read first:
+  DEPLOYMENT.txt
+
+Important:
+  This archive is a deployable on-prem package, not a source-only archive.
+  It intentionally preserves workspace-style runtime paths because the backend,
+  frontend, plugins, migrations, and ops scripts are resolved from those
+  locations. Do not hand-copy selected directories into a running installation.
+  For upgrades, run deploy.bat <package.zip|package.tgz> from the existing
+  deploy root, or use scripts/ops/multitable-onprem-apply-package.ps1.
 
 Install quickstart:
   docs/deployment/multitable-windows-onprem-easy-start-20260319.md
@@ -362,6 +450,11 @@ cat > "${METADATA_JSON_TMP_PATH}" <<EOF
   "name": "${PACKAGE_NAME}",
   "version": "${PACKAGE_VERSION}",
   "tag": "${PACKAGE_TAG}",
+  "artifactKind": "deployable-onprem-app-package",
+  "deployMode": "fresh-extract-or-existing-root-apply",
+  "directReplaceSafe": false,
+  "nodeModulesBundled": false,
+  "windowsEntryPoint": "deploy.bat <package.zip|package.tgz>",
   "attendanceOnly": false,
   "productMode": "platform",
   "includedPlugins": ["plugin-attendance", "plugin-integration-core"],

--- a/scripts/ops/multitable-onprem-package-verify.sh
+++ b/scripts/ops/multitable-onprem-package-verify.sh
@@ -72,6 +72,29 @@ function verify_root_runtime_dependencies() {
   search_fixed_string '"bcryptjs"' "$package_json" || die "root package.json must include bcryptjs for Windows bootstrap compatibility"
 }
 
+function verify_deployable_artifact_contract() {
+  local root="$1"
+  local deployment_txt="${root}/DEPLOYMENT.txt"
+  local install_txt="${root}/INSTALL.txt"
+  local metadata_json="${root}/PACKAGE-METADATA.json"
+
+  search_fixed_string 'deployable on-prem application package' "$deployment_txt" || die "DEPLOYMENT.txt must say the archive is deployable"
+  search_fixed_string 'source-only archive' "$deployment_txt" || die "DEPLOYMENT.txt must explain that the workspace layout is not source-only"
+  search_fixed_string 'not direct-replace-safe' "$deployment_txt" || die "DEPLOYMENT.txt must warn against direct replacement of a running install"
+  search_fixed_string 'deploy.bat <downloaded-package.zip>' "$deployment_txt" || die "DEPLOYMENT.txt must show the Windows upgrade entrypoint"
+  search_fixed_string 'node_modules are intentionally not bundled' "$deployment_txt" || die "DEPLOYMENT.txt must document node_modules policy"
+
+  search_fixed_string 'DEPLOYMENT.txt' "$install_txt" || die "INSTALL.txt must point operators at DEPLOYMENT.txt"
+  search_fixed_string 'deployable-onprem-app-package' "$install_txt" || die "INSTALL.txt must identify the artifact type"
+  search_fixed_string 'not a source-only archive' "$install_txt" || die "INSTALL.txt must distinguish deployable package from source-only archive"
+
+  search_fixed_string '"artifactKind": "deployable-onprem-app-package"' "$metadata_json" || die "PACKAGE-METADATA.json must identify deployable artifact kind"
+  search_fixed_string '"deployMode": "fresh-extract-or-existing-root-apply"' "$metadata_json" || die "PACKAGE-METADATA.json must document deploy mode"
+  search_fixed_string '"directReplaceSafe": false' "$metadata_json" || die "PACKAGE-METADATA.json must mark direct replacement unsafe"
+  search_fixed_string '"nodeModulesBundled": false' "$metadata_json" || die "PACKAGE-METADATA.json must document node_modules policy"
+  search_fixed_string '"windowsEntryPoint": "deploy.bat <package.zip|package.tgz>"' "$metadata_json" || die "PACKAGE-METADATA.json must document the Windows entrypoint"
+}
+
 function verify_migration_bridge_contract() {
   local root="$1"
   local provider="${root}/packages/core-backend/dist/src/db/migration-provider.js"
@@ -237,6 +260,14 @@ function write_optional_report() {
       "      \"requiredCount\": ${#required[@]}" \
       '    },' \
       '    {' \
+      '      "name": "deployability-contract",' \
+      '      "status": "PASS",' \
+      '      "artifactKind": "deployable-onprem-app-package",' \
+      '      "deployMode": "fresh-extract-or-existing-root-apply",' \
+      '      "directReplaceSafe": false,' \
+      '      "nodeModulesBundled": false' \
+      '    },' \
+      '    {' \
       '      "name": "no-github-links",' \
       "      \"status\": \"${link_status}\"" \
       '    }' \
@@ -266,6 +297,7 @@ function write_optional_report() {
       echo
       echo "- Checksum: \`${checksum_status}\`"
       echo "- Required content: \`PASS\` (${#required[@]} paths)"
+      echo "- Deployability contract: \`PASS\` (deployable-onprem-app-package, directReplaceSafe=false, nodeModulesBundled=false)"
       echo "- No GitHub links in delivery docs: \`${link_status}\`"
     } > "$report_md_tmp"
     mv "$report_md_tmp" "$VERIFY_REPORT_MD"
@@ -278,6 +310,7 @@ function verify_no_github_links() {
   local targets=()
 
   [[ -f "${root}/INSTALL.txt" ]] && targets+=("${root}/INSTALL.txt")
+  [[ -f "${root}/DEPLOYMENT.txt" ]] && targets+=("${root}/DEPLOYMENT.txt")
   [[ -d "${root}/docs/deployment" ]] && targets+=("${root}/docs/deployment")
 
   if [[ ${#targets[@]} -eq 0 ]]; then
@@ -374,6 +407,8 @@ pkg_name="$(head -n 1 "$list_file" | cut -d/ -f1)"
 pkg_root="${EXTRACT_ROOT}/${pkg_name}"
 
 required=(
+  "DEPLOYMENT.txt"
+  "PACKAGE-METADATA.json"
   "apps/web/dist/index.html"
   "apps/web/package.json"
   "packages/core-backend/dist/src/index.js"
@@ -474,6 +509,7 @@ bootstrap_run_wrapper="$(find "$pkg_root" -maxdepth 1 -type f -name 'bootstrap-a
 [[ -n "$bootstrap_run_wrapper" ]] || die "Required package content missing: bootstrap-admin-<run>.bat"
 verify_windows_entrypoints "$pkg_root"
 verify_root_runtime_dependencies "$pkg_root"
+verify_deployable_artifact_contract "$pkg_root"
 verify_migration_bridge_contract "$pkg_root"
 verify_generic_integration_workbench_contract "$pkg_root"
 


### PR DESCRIPTION
## Summary

Addresses the latest #651 Release feedback: the on-prem `.zip` is deployable, but after extraction it looks like a source/docs tree because the runtime intentionally keeps workspace-style paths (`apps/web/dist`, `packages/core-backend/dist`, `plugins`, `scripts`, `docker`, `ops`, `docs`). That made field deployment ambiguous.

This PR does not change runtime behavior or package layout. It makes the deployability contract explicit and machine-verified.

## Changes

- Adds generated package-root `DEPLOYMENT.txt` explaining:
  - the archive is a deployable on-prem application package
  - why the structure looks like a source tree
  - it is not source-only, not a single binary, and not direct-replace-safe
  - upgrade entrypoint: `deploy.bat <downloaded-package.zip>` from the existing deploy root
  - `node_modules` are intentionally not bundled
- Adds generated package-root `PACKAGE-METADATA.json` with:
  - `artifactKind: deployable-onprem-app-package`
  - `deployMode: fresh-extract-or-existing-root-apply`
  - `directReplaceSafe: false`
  - `nodeModulesBundled: false`
- Mirrors the same fields into the external Release metadata JSON.
- Strengthens `multitable-onprem-package-verify.sh` so missing or unclear deployability contract fails package verification.
- Updates deployment docs and adds design/verification MD.

## Verification

- `bash -n scripts/ops/multitable-onprem-package-build.sh`
- `bash -n scripts/ops/multitable-onprem-package-verify.sh`
- `git diff --check`
- Full local package build:
  - `INSTALL_DEPS=1 BUILD_WEB=1 BUILD_BACKEND=1 PACKAGE_TAG=clarity-local scripts/ops/multitable-onprem-package-build.sh`
- Local package verify:
  - zip: `Package verify OK`
  - tgz: `Package verify OK`
- Confirmed package archives include:
  - `DEPLOYMENT.txt`
  - `PACKAGE-METADATA.json`
- Confirmed verify JSON includes `deployability-contract`.

## Deployment Impact

Future Release packages become self-describing. Existing deploy/install scripts remain compatible. After this merges, a fresh on-prem package should be published so the downloadable Release zip includes the new root files and metadata.
