### PR TITLE
feat(attendance): add bulk report-records sync

### DIFF
--- a/apps/web/src/views/attendance/AttendanceReportFieldsSection.vue
+++ b/apps/web/src/views/attendance/AttendanceReportFieldsSection.vue
@@ -522,8 +522,41 @@
             id="attendance-report-record-sync-user"
             v-model="recordSyncUserId"
             type="text"
-            :placeholder="tr('Required in v1', 'v1 必填')"
+            :disabled="recordSyncAllUsers"
+            :placeholder="recordSyncAllUsers ? tr('All users mode', '全员模式') : tr('Required for single user', '单员工必填')"
             data-report-record-sync-user
+          >
+        </label>
+        <label class="attendance-report-fields__filter attendance-report-fields__filter--inline" for="attendance-report-record-sync-all-users">
+          <span>{{ tr('All active users', '全部活跃员工') }}</span>
+          <input
+            id="attendance-report-record-sync-all-users"
+            v-model="recordSyncAllUsers"
+            type="checkbox"
+            data-report-record-sync-all-users
+          >
+        </label>
+        <label class="attendance-report-fields__filter" for="attendance-report-record-sync-page">
+          <span>{{ tr('Page', '页码') }}</span>
+          <input
+            id="attendance-report-record-sync-page"
+            v-model.number="recordSyncPage"
+            type="number"
+            min="1"
+            :disabled="!recordSyncAllUsers"
+            data-report-record-sync-page
+          >
+        </label>
+        <label class="attendance-report-fields__filter" for="attendance-report-record-sync-page-size">
+          <span>{{ tr('Page size', '每页数量') }}</span>
+          <input
+            id="attendance-report-record-sync-page-size"
+            v-model.number="recordSyncPageSize"
+            type="number"
+            min="1"
+            max="100"
+            :disabled="!recordSyncAllUsers"
+            data-report-record-sync-page-size
           >
         </label>
         <button
@@ -881,11 +914,21 @@ interface AttendanceReportRecordsSyncResult {
   degraded?: boolean
   reason?: string | null
   synced?: number
+  rowsSynced?: number
   patched?: number
   created?: number
   skipped?: number
   failed?: number
   duplicateRowKeys?: number
+  usersScanned?: number
+  usersSynced?: number
+  usersFailed?: number
+  totalUsers?: number
+  page?: number
+  pageSize?: number
+  hasNextPage?: boolean
+  userSelection?: string
+  failedUsers?: Array<{ userId?: string; error?: string; failedRows?: number }>
   fieldFingerprint?: string
   syncedAt?: string
   multitable?: {
@@ -965,6 +1008,9 @@ const recordSyncStatusKind = ref<'info' | 'warn' | 'error'>('info')
 const recordSyncFrom = ref(dateInputValue(-30))
 const recordSyncTo = ref(dateInputValue(0))
 const recordSyncUserId = ref('')
+const recordSyncAllUsers = ref(false)
+const recordSyncPage = ref(1)
+const recordSyncPageSize = ref(50)
 const reportRecordsSyncResult = ref<AttendanceReportRecordsSyncResult | null>(null)
 const fieldSearchTerm = ref('')
 const fieldStatusFilter = ref<ReportFieldStatusFilter>('all')
@@ -1212,7 +1258,7 @@ const multitableDetailRows = computed<MultitableDetailRow[]>(() => {
 const canSyncReportRecords = computed(() => (
   recordSyncFrom.value.trim() !== ''
   && recordSyncTo.value.trim() !== ''
-  && recordSyncUserId.value.trim() !== ''
+  && (recordSyncAllUsers.value || recordSyncUserId.value.trim() !== '')
 ))
 const reportRecordsMultitableHref = computed(() => {
   const multitable = reportRecordsSyncResult.value?.multitable
@@ -1233,6 +1279,19 @@ const reportRecordSyncDetailRows = computed<MultitableDetailRow[]>(() => {
     const normalized = String(value ?? '').trim()
     if (normalized) rows.push({ key, label, value: normalized, monospace })
   }
+  addNumber('totalUsers', tr('Total users', '总员工数'), result.totalUsers)
+  addNumber('page', tr('Page', '页码'), result.page)
+  addNumber('pageSize', tr('Page size', '每页数量'), result.pageSize)
+  if (typeof result.hasNextPage === 'boolean') {
+    rows.push({
+      key: 'hasNextPage',
+      label: tr('Has next page', '还有下一页'),
+      value: result.hasNextPage ? tr('Yes', '是') : tr('No', '否'),
+    })
+  }
+  addNumber('usersScanned', tr('Users scanned', '扫描员工'), result.usersScanned)
+  addNumber('usersSynced', tr('Users synced', '同步员工'), result.usersSynced)
+  addNumber('usersFailed', tr('Users failed', '失败员工'), result.usersFailed)
   addNumber('synced', tr('Rows read', '读取行数'), result.synced)
   addNumber('created', tr('Created', '新建'), result.created)
   addNumber('patched', tr('Patched', '更新'), result.patched)
@@ -1648,6 +1707,9 @@ function buildReportRecordsSyncStatusMessage(data: AttendanceReportRecordsSyncRe
       : tr('Report records sync degraded.', '报表记录同步已降级。')
   }
   const details = [
+    syncStatusMetric('Users', '员工', data.usersScanned),
+    syncStatusMetric('Synced users', '已同步员工', data.usersSynced),
+    syncStatusMetric('Failed users', '失败员工', data.usersFailed),
     syncStatusMetric('Rows', '行数', data.synced),
     syncStatusMetric('Created', '新建', data.created),
     syncStatusMetric('Patched', '更新', data.patched),
@@ -1717,14 +1779,21 @@ async function syncReportRecords(): Promise<void> {
     const orgId = props.orgId?.trim()
     if (orgId) params.set('orgId', orgId)
     const suffix = params.toString()
+    const body: Record<string, unknown> = {
+      from: recordSyncFrom.value.trim(),
+      to: recordSyncTo.value.trim(),
+    }
+    if (recordSyncAllUsers.value) {
+      body.allUsers = true
+      body.page = Number(recordSyncPage.value) || 1
+      body.pageSize = Number(recordSyncPageSize.value) || 50
+    } else {
+      body.userId = recordSyncUserId.value.trim()
+    }
     const response = await apiFetch(`/api/attendance/report-records/sync${suffix ? `?${suffix}` : ''}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        from: recordSyncFrom.value.trim(),
-        to: recordSyncTo.value.trim(),
-        userId: recordSyncUserId.value.trim(),
-      }),
+      body: JSON.stringify(body),
     })
     const payload = await response.json()
     if (!response.ok || payload?.ok === false) {
@@ -1968,6 +2037,17 @@ watch(
 
 .attendance-report-fields__record-sync-form .attendance-report-fields__filter {
   flex: 1 1 180px;
+}
+
+.attendance-report-fields__record-sync-form .attendance-report-fields__filter--inline {
+  flex: 0 0 auto;
+  min-width: 140px;
+}
+
+.attendance-report-fields__filter--inline input[type="checkbox"] {
+  width: 18px;
+  min-height: 18px;
+  padding: 0;
 }
 
 .attendance-report-fields__formula-reference-layout {

--- a/apps/web/tests/AttendanceReportFieldsSection.spec.ts
+++ b/apps/web/tests/AttendanceReportFieldsSection.spec.ts
@@ -846,6 +846,88 @@ describe('AttendanceReportFieldsSection', () => {
       .toBe('/multitable/sheet-rr/view-rr?baseId=base-rr')
   })
 
+  it('syncs report records for all users with pagination controls', async () => {
+    vi.mocked(apiFetch)
+      .mockResolvedValueOnce(jsonResponse(200, populatedCatalogPayload()))
+      .mockResolvedValueOnce(jsonResponse(200, {
+        ok: true,
+        data: {
+          synced: 4,
+          rowsSynced: 4,
+          created: 3,
+          patched: 1,
+          skipped: 0,
+          failed: 0,
+          duplicateRowKeys: 0,
+          usersScanned: 2,
+          usersSynced: 2,
+          usersFailed: 0,
+          totalUsers: 5,
+          page: 2,
+          pageSize: 2,
+          hasNextPage: true,
+          fieldFingerprint: 'bulk-field-fingerprint',
+          syncedAt: '2026-05-18T12:00:00.000Z',
+          multitable: {
+            available: true,
+            degraded: false,
+            projectId: 'org-1:attendance',
+            objectId: 'attendance_report_records',
+            sheetId: 'sheet-rr',
+            viewId: 'view-rr',
+          },
+        },
+      }))
+
+    mountSection()
+    await flushUi()
+
+    const fromInput = container!.querySelector<HTMLInputElement>('[data-report-record-sync-from]')!
+    const toInput = container!.querySelector<HTMLInputElement>('[data-report-record-sync-to]')!
+    const userInput = container!.querySelector<HTMLInputElement>('[data-report-record-sync-user]')!
+    const allUsersInput = container!.querySelector<HTMLInputElement>('[data-report-record-sync-all-users]')!
+    const pageInput = container!.querySelector<HTMLInputElement>('[data-report-record-sync-page]')!
+    const pageSizeInput = container!.querySelector<HTMLInputElement>('[data-report-record-sync-page-size]')!
+    const syncButton = container!.querySelector<HTMLButtonElement>('[data-report-record-sync-button]')!
+
+    fromInput.value = '2026-05-01'
+    fromInput.dispatchEvent(new Event('input', { bubbles: true }))
+    toInput.value = '2026-05-31'
+    toInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+    expect(syncButton.disabled).toBe(true)
+
+    allUsersInput.click()
+    await flushUi()
+    expect(userInput.disabled).toBe(true)
+    expect(pageInput.disabled).toBe(false)
+    expect(pageSizeInput.disabled).toBe(false)
+
+    pageInput.value = '2'
+    pageInput.dispatchEvent(new Event('input', { bubbles: true }))
+    pageSizeInput.value = '2'
+    pageSizeInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+    expect(syncButton.disabled).toBe(false)
+
+    syncButton.click()
+    await flushUi()
+
+    expect(apiFetch).toHaveBeenCalledWith('/api/attendance/report-records/sync?orgId=org-1', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ from: '2026-05-01', to: '2026-05-31', allUsers: true, page: 2, pageSize: 2 }),
+    })
+    const status = container!.querySelector('[data-report-record-sync-status]')
+    expect(status?.textContent).toContain('Users: 2')
+    expect(status?.textContent).toContain('Synced users: 2')
+    expect(status?.textContent).toContain('Rows: 4')
+    expect(container!.querySelector('[data-report-record-sync-detail="totalUsers"]')?.textContent).toContain('5')
+    expect(container!.querySelector('[data-report-record-sync-detail="page"]')?.textContent).toContain('2')
+    expect(container!.querySelector('[data-report-record-sync-detail="hasNextPage"]')?.textContent).toContain('Yes')
+    expect(container!.querySelector('[data-report-record-sync-detail="fieldFingerprint"]')?.textContent).toContain('bulk-field-fingerprint')
+  })
+
   it('shows degraded report-records sync as a non-blocking warning', async () => {
     vi.mocked(apiFetch)
       .mockResolvedValueOnce(jsonResponse(200, populatedCatalogPayload()))

--- a/docs/development/attendance-report-records-bulk-sync-development-20260518.md
+++ b/docs/development/attendance-report-records-bulk-sync-development-20260518.md
@@ -1,0 +1,52 @@
+# 考勤报表记录多维表批量同步开发记录 2026-05-18
+
+## Summary
+
+本 slice 扩展 `attendance_report_records` 同步层，从原来的单员工 `{ from, to, userId }` 增加两种管理员批量入口：
+
+- 显式员工列表：`{ from, to, userIds: [...] }`
+- 全员分页：`{ from, to, allUsers: true, page, pageSize }`
+
+原单员工请求保持兼容，仍走既有 `syncAttendanceReportRecords()` 路径。批量同步只做调度与汇总，每个员工仍复用 PR2 已合并的单员工 writer，不重写考勤聚合、不迁移 `attendance_*`，也不让多维表成为事实源。
+
+## Backend
+
+- `plugins/plugin-attendance/index.cjs`
+  - 新增同步分页常量：默认 `pageSize=50`，最大 `100`。
+  - 新增 `normalizeAttendanceReportRecordsSyncUserIds()`，对显式 `userId/userIds` 做 trim、去空、去重。
+  - 新增 `normalizeAttendanceReportRecordsSyncPage()`，统一页码、页大小和 offset。
+  - 新增 `loadAttendanceReportRecordsSyncUserPage()`：
+    - 首选 `user_orgs + users` 中的活跃员工。
+    - 如果租户或环境缺 schema，降级到 `attendance_records` 日期区间内的 distinct user。
+  - 新增 `syncAttendanceReportRecordsForUsers()`：
+    - 显式列表或全员分页得到 userIds 后，逐个调用既有 `syncAttendanceReportRecords()`。
+    - 汇总 `usersScanned/usersSynced/usersFailed` 与行级 `synced/created/patched/skipped/failed/duplicateRowKeys`。
+    - 单用户异常只记入 `failedUsers` 并继续下一用户。
+  - 扩展 `POST /api/attendance/report-records/sync`：
+    - 继续接受旧 body `{ from, to, userId }`。
+    - 新增 `{ userIds }` 和 `{ allUsers, page, pageSize }`。
+    - 拒绝同时传 `allUsers` 和显式员工。
+    - 缺 `userId/userIds/allUsers` 仍返回 400。
+
+## Frontend
+
+- `apps/web/src/views/attendance/AttendanceReportFieldsSection.vue`
+  - 在“报表记录同步”区域增加“全部活跃员工”开关。
+  - 全员模式下禁用单员工输入，并启用 `page/pageSize` 控件。
+  - 旧单员工模式仍发送 `{ from, to, userId }`。
+  - 全员模式发送 `{ from, to, allUsers: true, page, pageSize }`。
+  - 同步结果展示新增用户维度：总员工、页码、页大小、是否还有下一页、扫描员工、同步员工、失败员工。
+
+## Boundaries
+
+- 不新增 migration。
+- 不直接写 `meta_*` 表。
+- 不改变 `attendance_records` 或薪资/导出事实源。
+- 不把 `attendance_report_records` 作为考勤查询事实源。
+- 不实现 cursor 或后台任务队列。全员同步 v1 采用显式分页，由管理员分批触发。
+
+## Follow-up
+
+- 后台 job/cursor 化全员同步。
+- 前端增加“下一页继续同步”便捷按钮。
+- Live staging evidence：使用真实样本租户验证 allUsers page 与多维表记录数。

--- a/docs/development/attendance-report-records-bulk-sync-verification-20260518.md
+++ b/docs/development/attendance-report-records-bulk-sync-verification-20260518.md
@@ -1,0 +1,39 @@
+# 考勤报表记录多维表批量同步验证记录 2026-05-18
+
+## Scope
+
+验证 `attendance_report_records` 批量同步扩展：
+
+- 单员工 `{ userId }` 兼容路径不变。
+- 显式 `{ userIds }` 去重后逐员工同步。
+- 全员 `{ allUsers, page, pageSize }` 通过活跃员工分页选择 userIds。
+- 前端可以在单员工和全员分页模式间切换。
+
+## Automated Checks
+
+| Check | Result |
+| --- | --- |
+| `node --check plugins/plugin-attendance/index.cjs` | PASS |
+| `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-report-field-catalog.test.ts --reporter=dot` | PASS, 20 tests |
+| `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-report-field-catalog.test.ts tests/unit/attendance-report-field-formula-engine.test.ts --reporter=dot` | PASS, 44 tests |
+| `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/AttendanceReportFieldsSection.spec.ts --watch=false` | PASS, 21 tests |
+| `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/AttendanceReportFieldsSection.spec.ts tests/attendance-admin-regressions.spec.ts --watch=false` | PASS, 32 tests |
+| `pnpm --filter @metasheet/web type-check` | PASS |
+| `pnpm --filter @metasheet/core-backend build` | PASS |
+| `git diff --check` | PASS |
+
+Frontend Vitest printed `WebSocket server error: Port is already in use`, but the target spec completed successfully.
+
+## Assertions Covered
+
+- Backend helper trims and deduplicates explicit user IDs.
+- Backend page helper clamps page size to 100 and computes offset deterministically.
+- Bulk explicit sync aggregates two users into one response and keeps second run idempotent.
+- All-user page loader prefers active org users and falls back to `attendance_records` distinct user IDs when user-org schema is absent.
+- Existing single-user frontend request body remains `{ from, to, userId }`.
+- All-user frontend mode sends `{ from, to, allUsers: true, page, pageSize }`.
+- Result details expose total users, page, page size, next-page flag, scanned users, synced users, and field fingerprint.
+
+## Local Worktree Note
+
+`pnpm install` in the isolated worktree rewrote tracked plugin/tool `node_modules` symlinks. They are intentionally left unstaged and must not be included in the PR. Stage only the seven source/doc/test files for this slice.

--- a/docs/development/attendance-report-records-sync-todo-20260515.md
+++ b/docs/development/attendance-report-records-sync-todo-20260515.md
@@ -115,8 +115,8 @@ skip  iff  existing.source_fingerprint === next.source_fingerprint
 
 ### PR2 sync writer
 
-- `POST /api/attendance/report-records/sync`（`attendance:admin`，body `{ from, to, userId }`——**`userId` v1 必填**，review 修正点 1；沿用既有 `CONFIRM_SYNC` live 纪律）
-- 全员同步 / 分页 / batch cursor = follow-up（否则 PR2 从 medium 变 large：要解决跨员工 approvedMap、分页、超时、部分失败汇总）
+- `POST /api/attendance/report-records/sync`（`attendance:admin`，PR2 body `{ from, to, userId }`；2026-05-18 bulk sync slice 扩展 `{ userIds }` 与 `{ allUsers, page, pageSize }`；沿用既有 `CONFIRM_SYNC` live 纪律）
+- 全员同步 / 分页 = 已由 `attendance-report-records-bulk-sync-development-20260518.md` 作为显式分页管理员动作补齐；batch cursor / 后台任务队列仍为 follow-up。
 - 取数：复用既有 per-target-user export 构建流程（**单一权威路径，不另写聚合**）
 - 写入：per row 用物理 field id `queryRecords({ filters: { [fieldIds.rowKey]: rowKey } })` → `patchRecord`/`createRecord`；按上方 skip 判定（source+field fingerprint 双等才 skip）；patch 时清空 stale 列（写 null）
 - **重复行保险丝**：多维表无 `row_key` 唯一约束。若 `queryRecords(row_key)` 返回多条（并发/历史脏数据）→ v1 **patch 第一条**、其余计 `duplicateRowKeys` warn、**不自动删重复**（dedup = cleanup follow-up）
@@ -188,3 +188,9 @@ skip  iff  existing.source_fingerprint === next.source_fingerprint
 ### PR3（待 PR2 合并后）
 - [x] 前端同步入口 + syncedAt/数/fingerprint 展示 + 打开多维表
 - [x] mock acceptance fingerprint 链一致性
+
+### Bulk sync follow-up（2026-05-18）
+- [x] 显式 `userIds` 批量同步 + 去重
+- [x] `allUsers` 分页同步入口 + page/pageSize 汇总
+- [x] 前端单员工/全员分页模式切换
+- [x] development / verification MD：`attendance-report-records-bulk-sync-development-20260518.md`、`attendance-report-records-bulk-sync-verification-20260518.md`

--- a/packages/core-backend/tests/unit/attendance-report-field-catalog.test.ts
+++ b/packages/core-backend/tests/unit/attendance-report-field-catalog.test.ts
@@ -983,6 +983,143 @@ describe('attendance report field catalog multitable foundation', () => {
     expect(store.filter(r => r.data[rowKeyFid] === 'org-1:u-1:2026-05-13').length).toBe(2) // not auto-deleted (v1)
   })
 
+  it('report-records sync: bulk explicit users dedupe and aggregate per-user results', async () => {
+    expect(helpers.normalizeAttendanceReportRecordsSyncUserIds(['u-1', ' u-1 ', '', null, 'u-2']))
+      .toEqual(['u-1', 'u-2'])
+    expect(helpers.normalizeAttendanceReportRecordsSyncPage('2', '500'))
+      .toMatchObject({ page: 2, pageSize: 100, offset: 100 })
+
+    const store: Array<{ id: string; data: Record<string, unknown> }> = []
+    let seq = 0
+    const rowKeyFid = 'fld_row_key'
+    const records = {
+      queryRecords: async ({ filters }: { filters?: Record<string, unknown> }) => {
+        const want = filters?.[rowKeyFid]
+        return store.filter(r => r.data[rowKeyFid] === want)
+      },
+      createRecord: async ({ data }: { data: Record<string, unknown> }) => {
+        const rec = { id: `rec-${++seq}`, data: { ...data } }
+        store.push(rec)
+        return rec
+      },
+      patchRecord: async ({ recordId, changes }: { recordId: string; changes: Record<string, unknown> }) => {
+        const rec = store.find(r => r.id === recordId)
+        if (rec) rec.data = { ...rec.data, ...changes }
+        return rec
+      },
+    }
+    const provisioning = {
+      ensureObject: async () => ({ baseId: 'base_rr', sheet: { id: 'sheet_rr' } }),
+      ensureView: async () => ({ id: 'view_rr', sheetId: 'sheet_rr' }),
+      resolveFieldIds: async ({ fieldIds }: { fieldIds: string[] }) =>
+        Object.fromEntries(fieldIds.map(fieldId => [fieldId, `fld_${fieldId}`])),
+    }
+    const rowsByUser: Record<string, Array<Record<string, unknown>>> = {
+      'u-1': [
+        { user_id: 'u-1', org_id: 'org-1', work_date: '2026-05-13', timezone: 'UTC', first_in_at: '2026-05-13T09:00:00Z', last_out_at: '2026-05-13T18:00:00Z', work_minutes: 480, late_minutes: 0, early_leave_minutes: 0, status: 'normal', is_workday: true, meta: {}, user_name: '张三', username: 'zhangsan' },
+        { user_id: 'u-1', org_id: 'org-1', work_date: '2026-05-14', timezone: 'UTC', first_in_at: '2026-05-14T09:10:00Z', last_out_at: '2026-05-14T18:00:00Z', work_minutes: 470, late_minutes: 10, early_leave_minutes: 0, status: 'late', is_workday: true, meta: {}, user_name: '张三', username: 'zhangsan' },
+      ],
+      'u-2': [
+        { user_id: 'u-2', org_id: 'org-1', work_date: '2026-05-13', timezone: 'UTC', first_in_at: '2026-05-13T09:00:00Z', last_out_at: '2026-05-13T18:00:00Z', work_minutes: 480, late_minutes: 0, early_leave_minutes: 0, status: 'normal', is_workday: true, meta: {}, user_name: '李四', username: 'lisi' },
+      ],
+    }
+    const db = {
+      query: async (sql: string, params?: unknown[]) => {
+        if (/FROM attendance_records ar/.test(sql)) return rowsByUser[String(params?.[0])] ?? []
+        return []
+      },
+    }
+    const context = { api: { multitable: { provisioning, records }, database: db } }
+
+    const result = await helpers.syncAttendanceReportRecordsForUsers(
+      context,
+      db,
+      'org-1',
+      { warn: vi.fn() },
+      { from: '2026-05-01', to: '2026-05-31', userIds: ['u-1', ' u-1 ', 'u-2', ''] },
+    )
+    expect(result).toMatchObject({
+      userSelection: 'explicit',
+      totalUsers: 2,
+      usersScanned: 2,
+      usersSynced: 2,
+      usersFailed: 0,
+      synced: 3,
+      rowsSynced: 3,
+      created: 3,
+      patched: 0,
+      skipped: 0,
+      failed: 0,
+      hasNextPage: false,
+    })
+    expect(store).toHaveLength(3)
+    expect(store.map(row => row.data[rowKeyFid])).toEqual([
+      'org-1:u-1:2026-05-13',
+      'org-1:u-1:2026-05-14',
+      'org-1:u-2:2026-05-13',
+    ])
+
+    const second = await helpers.syncAttendanceReportRecordsForUsers(
+      context,
+      db,
+      'org-1',
+      { warn: vi.fn() },
+      { from: '2026-05-01', to: '2026-05-31', userIds: ['u-1', 'u-2'] },
+    )
+    expect(second).toMatchObject({ synced: 3, created: 0, patched: 0, skipped: 3, usersScanned: 2 })
+  })
+
+  it('report-records sync: all-user pages prefer active org users and fall back to record owners', async () => {
+    const primaryDb = {
+      query: async (sql: string) => {
+        if (/COUNT\(\*\)::int AS total\s+FROM user_orgs/s.test(sql)) return [{ total: 5 }]
+        if (/SELECT uo\.user_id\s+FROM user_orgs/s.test(sql)) return [{ user_id: 'u-3' }, { user_id: 'u-4' }]
+        return []
+      },
+    }
+    const page = await helpers.loadAttendanceReportRecordsSyncUserPage(
+      primaryDb,
+      'org-1',
+      '2026-05-01',
+      '2026-05-31',
+      { page: 2, pageSize: 2 },
+    )
+    expect(page).toEqual({
+      userIds: ['u-3', 'u-4'],
+      totalUsers: 5,
+      page: 2,
+      pageSize: 2,
+      hasNextPage: true,
+      userSelection: 'allUsers',
+    })
+
+    const fallbackDb = {
+      query: async (sql: string) => {
+        if (/FROM user_orgs/.test(sql)) {
+          const error = new Error('relation "user_orgs" does not exist') as Error & { code: string }
+          error.code = '42P01'
+          throw error
+        }
+        if (/users_with_records/.test(sql)) return [{ total: 1 }]
+        if (/SELECT DISTINCT user_id/.test(sql)) return [{ user_id: 'u-record' }]
+        return []
+      },
+    }
+    const fallback = await helpers.loadAttendanceReportRecordsSyncUserPage(
+      fallbackDb,
+      'org-1',
+      '2026-05-01',
+      '2026-05-31',
+      { page: 1, pageSize: 50 },
+    )
+    expect(fallback).toMatchObject({
+      userIds: ['u-record'],
+      totalUsers: 1,
+      hasNextPage: false,
+      userSelection: 'attendanceRecordsFallback',
+    })
+  })
+
   it('report-records sync: disabled managed value columns are patched to null', async () => {
     const catalogFieldIds = Object.fromEntries(
       Object.values(helpers.ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS).map((fieldId) => [fieldId, `fld_${fieldId}`]),

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -2145,6 +2145,96 @@ function attendanceReportRecordRowKey(orgId, userId, workDate) {
   return `${orgId}:${userId}:${workDate}`
 }
 
+const ATTENDANCE_REPORT_RECORDS_SYNC_DEFAULT_PAGE_SIZE = 50
+const ATTENDANCE_REPORT_RECORDS_SYNC_MAX_PAGE_SIZE = 100
+
+function normalizeAttendanceReportRecordsSyncUserIds(values) {
+  const source = Array.isArray(values) ? values : [values]
+  const seen = new Set()
+  const userIds = []
+  for (const value of source) {
+    const userId = String(value ?? '').trim()
+    if (!userId || seen.has(userId)) continue
+    seen.add(userId)
+    userIds.push(userId)
+  }
+  return userIds
+}
+
+function normalizeAttendanceReportRecordsSyncPage(rawPage, rawPageSize) {
+  const page = Math.max(1, Math.floor(Number(rawPage) || 1))
+  const pageSize = Math.min(
+    ATTENDANCE_REPORT_RECORDS_SYNC_MAX_PAGE_SIZE,
+    Math.max(1, Math.floor(Number(rawPageSize) || ATTENDANCE_REPORT_RECORDS_SYNC_DEFAULT_PAGE_SIZE)),
+  )
+  return { page, pageSize, offset: (page - 1) * pageSize }
+}
+
+async function loadAttendanceReportRecordsSyncUserPage(db, orgId, from, to, options = {}) {
+  const { page, pageSize, offset } = normalizeAttendanceReportRecordsSyncPage(options.page, options.pageSize)
+  try {
+    const countRows = await db.query(
+      `SELECT COUNT(*)::int AS total
+       FROM user_orgs uo
+       JOIN users u ON u.id = uo.user_id
+       WHERE uo.org_id = $1
+         AND uo.is_active = true
+         AND u.is_active = true`,
+      [orgId]
+    )
+    const rows = await db.query(
+      `SELECT uo.user_id
+       FROM user_orgs uo
+       JOIN users u ON u.id = uo.user_id
+       WHERE uo.org_id = $1
+         AND uo.is_active = true
+         AND u.is_active = true
+       ORDER BY uo.user_id ASC
+       LIMIT $2 OFFSET $3`,
+      [orgId, pageSize, offset]
+    )
+    const totalUsers = Number(countRows[0]?.total ?? rows.length)
+    const userIds = normalizeAttendanceReportRecordsSyncUserIds(rows.map(row => row.user_id))
+    return {
+      userIds,
+      totalUsers,
+      page,
+      pageSize,
+      hasNextPage: offset + userIds.length < totalUsers,
+      userSelection: 'allUsers',
+    }
+  } catch (error) {
+    if (!isDatabaseSchemaError(error)) throw error
+    const countRows = await db.query(
+      `SELECT COUNT(*)::int AS total
+       FROM (
+         SELECT DISTINCT user_id
+         FROM attendance_records
+         WHERE org_id = $1 AND work_date BETWEEN $2 AND $3
+       ) users_with_records`,
+      [orgId, from, to]
+    )
+    const rows = await db.query(
+      `SELECT DISTINCT user_id
+       FROM attendance_records
+       WHERE org_id = $1 AND work_date BETWEEN $2 AND $3
+       ORDER BY user_id ASC
+       LIMIT $4 OFFSET $5`,
+      [orgId, from, to, pageSize, offset]
+    )
+    const totalUsers = Number(countRows[0]?.total ?? rows.length)
+    const userIds = normalizeAttendanceReportRecordsSyncUserIds(rows.map(row => row.user_id))
+    return {
+      userIds,
+      totalUsers,
+      page,
+      pageSize,
+      hasNextPage: offset + userIds.length < totalUsers,
+      userSelection: 'attendanceRecordsFallback',
+    }
+  }
+}
+
 function buildAttendanceReportRecordSourceFingerprint(logicalPayload) {
   const excluded = new Set([
     ATTENDANCE_REPORT_RECORDS_FIELDS.syncedAt,
@@ -2156,6 +2246,23 @@ function buildAttendanceReportRecordSourceFingerprint(logicalPayload) {
     .sort()
     .map(key => [key, logicalPayload[key]])
   return crypto.createHash('sha1').update(JSON.stringify(canonical)).digest('hex')
+}
+
+function createAttendanceReportRecordsSyncEmptyResult(extra = {}) {
+  return {
+    synced: 0,
+    rowsSynced: 0,
+    patched: 0,
+    created: 0,
+    skipped: 0,
+    failed: 0,
+    duplicateRowKeys: 0,
+    usersScanned: 0,
+    usersSynced: 0,
+    usersFailed: 0,
+    failedUsers: [],
+    ...extra,
+  }
 }
 
 async function syncAttendanceReportRecords(context, db, orgId, logger, params) {
@@ -2295,6 +2402,7 @@ async function syncAttendanceReportRecords(context, db, orgId, logger, params) {
   }
   return {
     ...result,
+    rowsSynced: result.synced,
     fieldFingerprint,
     syncedAt,
     multitable: {
@@ -2307,6 +2415,79 @@ async function syncAttendanceReportRecords(context, db, orgId, logger, params) {
       viewId: ensured.viewId || null,
     },
   }
+}
+
+async function syncAttendanceReportRecordsForUsers(context, db, orgId, logger, params) {
+  const from = String(params?.from || '').trim()
+  const to = String(params?.to || '').trim()
+  const explicitUserIds = normalizeAttendanceReportRecordsSyncUserIds(params?.userIds)
+  const selection = explicitUserIds.length > 0
+    ? {
+        userIds: explicitUserIds,
+        totalUsers: explicitUserIds.length,
+        page: 1,
+        pageSize: explicitUserIds.length,
+        hasNextPage: false,
+        userSelection: 'explicit',
+      }
+    : await loadAttendanceReportRecordsSyncUserPage(db, orgId, from, to, {
+      page: params?.page,
+      pageSize: params?.pageSize,
+    })
+
+  const aggregate = createAttendanceReportRecordsSyncEmptyResult({
+    totalUsers: selection.totalUsers,
+    page: selection.page,
+    pageSize: selection.pageSize,
+    hasNextPage: selection.hasNextPage,
+    userSelection: selection.userSelection,
+  })
+
+  for (const userId of selection.userIds) {
+    aggregate.usersScanned += 1
+    try {
+      const result = await syncAttendanceReportRecords(context, db, orgId, logger, { from, to, userId })
+      if (result.degraded) {
+        return {
+          ...aggregate,
+          ...result,
+          rowsSynced: aggregate.synced,
+          totalUsers: selection.totalUsers,
+          page: selection.page,
+          pageSize: selection.pageSize,
+          hasNextPage: selection.hasNextPage,
+          userSelection: selection.userSelection,
+        }
+      }
+      aggregate.usersSynced += 1
+      aggregate.synced += Number(result.synced ?? 0)
+      aggregate.rowsSynced = aggregate.synced
+      aggregate.created += Number(result.created ?? 0)
+      aggregate.patched += Number(result.patched ?? 0)
+      aggregate.skipped += Number(result.skipped ?? 0)
+      aggregate.failed += Number(result.failed ?? 0)
+      aggregate.duplicateRowKeys += Number(result.duplicateRowKeys ?? 0)
+      if (Number(result.failed ?? 0) > 0) {
+        aggregate.failedUsers.push({ userId, failedRows: Number(result.failed ?? 0) })
+      }
+      if (result.fieldFingerprint) aggregate.fieldFingerprint = result.fieldFingerprint
+      if (result.syncedAt) aggregate.syncedAt = result.syncedAt
+      if (result.multitable) aggregate.multitable = result.multitable
+    } catch (error) {
+      aggregate.usersFailed += 1
+      aggregate.failed += 1
+      aggregate.failedUsers.push({
+        userId,
+        error: error instanceof Error ? error.message : String(error),
+      })
+      logger?.warn?.('attendance report records user sync failed', {
+        userId,
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
+  aggregate.usersFailed = aggregate.failedUsers.length
+  return aggregate
 }
 
 async function loadAttendanceReportFieldCatalog(context, orgId) {
@@ -10304,6 +10485,10 @@ module.exports = {
     getAttendanceReportRecordsDescriptor,
     ensureAttendanceReportRecords,
     syncAttendanceReportRecords,
+    syncAttendanceReportRecordsForUsers,
+    normalizeAttendanceReportRecordsSyncUserIds,
+    normalizeAttendanceReportRecordsSyncPage,
+    loadAttendanceReportRecordsSyncUserPage,
     buildAttendanceReportRecordsValueColumns,
     mapReportFieldToMultitableType,
     buildAttendanceReportRecordSourceFingerprint,
@@ -22422,10 +22607,48 @@ module.exports = {
         const parsed = z.object({
           from: z.string().min(1),
           to: z.string().min(1),
-          userId: z.string().min(1),
+          userId: z.string().min(1).optional(),
+          userIds: z.array(z.string().min(1)).max(ATTENDANCE_REPORT_RECORDS_SYNC_MAX_PAGE_SIZE).optional(),
+          allUsers: z.boolean().optional(),
+          page: z.coerce.number().int().min(1).optional(),
+          pageSize: z.coerce.number().int().min(1).max(ATTENDANCE_REPORT_RECORDS_SYNC_MAX_PAGE_SIZE).optional(),
         }).safeParse(req.body ?? {})
         if (!parsed.success) {
           res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
+          return
+        }
+        const explicitUserIds = normalizeAttendanceReportRecordsSyncUserIds([
+          parsed.data.userId,
+          ...(parsed.data.userIds ?? []),
+        ])
+        if (parsed.data.allUsers === true && explicitUserIds.length > 0) {
+          res.status(400).json({
+            ok: false,
+            error: {
+              code: 'VALIDATION_ERROR',
+              message: 'Use either allUsers or userId/userIds, not both',
+            },
+          })
+          return
+        }
+        if (parsed.data.allUsers !== true && explicitUserIds.length === 0) {
+          res.status(400).json({
+            ok: false,
+            error: {
+              code: 'VALIDATION_ERROR',
+              message: 'userId, userIds, or allUsers is required',
+            },
+          })
+          return
+        }
+        if (explicitUserIds.length > ATTENDANCE_REPORT_RECORDS_SYNC_MAX_PAGE_SIZE) {
+          res.status(400).json({
+            ok: false,
+            error: {
+              code: 'VALIDATION_ERROR',
+              message: `At most ${ATTENDANCE_REPORT_RECORDS_SYNC_MAX_PAGE_SIZE} userIds can be synced in one request`,
+            },
+          })
           return
         }
         const dateRange = resolveAttendanceDateRange(parsed.data.from, parsed.data.to)
@@ -22433,21 +22656,36 @@ module.exports = {
           res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: dateRange.message } })
           return
         }
-        const result = await syncAttendanceReportRecords(context, db, orgId, logger, {
-          from: dateRange.from,
-          to: dateRange.to,
-          userId: parsed.data.userId,
-        })
+        const result = explicitUserIds.length === 1 && parsed.data.allUsers !== true && !Array.isArray(parsed.data.userIds)
+          ? await syncAttendanceReportRecords(context, db, orgId, logger, {
+            from: dateRange.from,
+            to: dateRange.to,
+            userId: explicitUserIds[0],
+          })
+          : await syncAttendanceReportRecordsForUsers(context, db, orgId, logger, {
+            from: dateRange.from,
+            to: dateRange.to,
+            userIds: explicitUserIds,
+            allUsers: parsed.data.allUsers,
+            page: parsed.data.page,
+            pageSize: parsed.data.pageSize,
+          })
         if (result.degraded) {
-          res.json({ ok: true, data: { degraded: true, reason: result.reason, synced: 0 } })
+          res.json({ ok: true, data: { ...result, degraded: true, reason: result.reason, synced: 0 } })
           return
         }
         emitEvent('attendance.report_records.synced', {
           orgId,
-          userId: parsed.data.userId,
+          userId: explicitUserIds.length === 1 ? explicitUserIds[0] : undefined,
+          userIds: explicitUserIds.length > 1 ? explicitUserIds : undefined,
+          allUsers: parsed.data.allUsers === true,
+          usersScanned: result.usersScanned,
+          usersSynced: result.usersSynced,
+          usersFailed: result.usersFailed,
           from: dateRange.from,
           to: dateRange.to,
           synced: result.synced,
+          rowsSynced: result.rowsSynced,
           patched: result.patched,
           created: result.created,
           skipped: result.skipped,


### PR DESCRIPTION
## Summary

Adds a bulk sync path for `attendance_report_records` while keeping the existing single-user sync compatible.

- Preserves `{ from, to, userId }` and the existing per-user writer
- Adds explicit list sync with `{ userIds }`
- Adds all-user paginated sync with `{ allUsers: true, page, pageSize }`
- Reuses the existing per-user export/sync pipeline instead of rewriting attendance aggregation
- Extends the admin UI with an all-active-users toggle and page/pageSize controls
- Adds development and verification docs for the slice

## Boundaries

- No migration
- No direct `meta_*` writes
- No change to `attendance_*` fact-source ownership
- `attendance_report_records` remains a rebuildable report layer, not a query fact source
- `pnpm install` produced tracked node_modules symlink noise in the local worktree; it was intentionally left unstaged and is not in this PR

## Test plan

- [x] `node --check plugins/plugin-attendance/index.cjs`
- [x] `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-report-field-catalog.test.ts --reporter=dot`
- [x] `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-report-field-catalog.test.ts tests/unit/attendance-report-field-formula-engine.test.ts --reporter=dot`
- [x] `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/AttendanceReportFieldsSection.spec.ts --watch=false`
- [x] `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/AttendanceReportFieldsSection.spec.ts tests/attendance-admin-regressions.spec.ts --watch=false`
- [x] `pnpm --filter @metasheet/web type-check`
- [x] `pnpm --filter @metasheet/core-backend build`
- [x] `git diff --check`

Note: frontend Vitest printed `WebSocket server error: Port is already in use`, but the target specs passed.
