### PR TITLE
docs(attendance): close out bulk report-records sync live status

### DIFF
--- a/docs/development/attendance-report-records-bulk-sync-live-closeout-development-20260519.md
+++ b/docs/development/attendance-report-records-bulk-sync-live-closeout-development-20260519.md
@@ -1,0 +1,59 @@
+# 考勤 report-records 批量同步 live closeout 开发记录 2026-05-19
+
+## Summary
+
+本 slice 不新增功能代码，只收口 `attendance_report_records` 批量同步 PR #1648 的部署与 live evidence 状态，并修正 TODO 文档中残留的旧范围表述。
+
+PR #1648 已将 `POST /api/attendance/report-records/sync` 从单员工 v1 扩展为：
+
+- 旧兼容：`{ from, to, userId }`
+- 显式批量：`{ from, to, userIds }`
+- 全员分页：`{ from, to, allUsers: true, page, pageSize }`
+
+## Changes
+
+- `docs/development/attendance-report-records-sync-todo-20260515.md`
+  - 修正 Out-of-scope 中“全员同步/分页仍 follow-up”的旧口径。
+  - 保留 `batch cursor / 后台任务队列` 为后续项。
+  - 修正 Assumptions 中“userId v1 必填”的旧口径，说明旧单员工路径仍兼容，但也支持 `userIds` 和 `allUsers`。
+- 新增本 development MD。
+- 新增 live closeout verification MD。
+
+## Deployment Finding
+
+GitHub Actions 显示 #1648 merge commit `2f211d161a301bc632165f9909b604cc05e5559a` 已触发并完成 production deploy：
+
+- Workflow: `Deploy to Production`
+- Run id: `26069092327`
+- Head SHA: `2f211d161a301bc632165f9909b604cc05e5559a`
+- Conclusion: `success`
+
+远端容器也显示 production backend 已运行同一镜像 SHA：
+
+```text
+metasheet-backend ghcr.io/zensgit/metasheet2-backend:2f211d161a301bc632165f9909b604cc05e5559a
+```
+
+## Live Evidence Boundary
+
+本轮未对 production 执行 report-records sync 写入。原因：
+
+- #1648 的 deploy 已经在 production 确认。
+- allUsers/pageSize 是写入派生多维表的管理员动作，即使是可重建报表层，也不应在 production 上无明确样本授权地触发。
+
+尝试 staging live 前置时发现：
+
+- 8082 SSH tunnel 可达，`/api/health` 正常。
+- 当前 staging backend 仍运行旧镜像 `5ca91630307603eacbbb13ae8209721f1b4d5bf3`，早于 #1648。
+- 本地 staging admin JWT 文件已过期，`/api/auth/me` 返回 401。
+
+因此 staging allUsers/pageSize live sync 暂不可真实执行。该状态写入 verification MD，不伪造通过。
+
+## Next Step
+
+若要补真实 live sync evidence，需要先满足：
+
+1. 将 staging backend 更新到包含 #1648 的镜像，或提供一个已更新的测试环境。
+2. 生成新的短期 staging admin JWT 文件。
+3. 使用小 pageSize（建议 `pageSize=1`）触发 `allUsers` 分页 sync。
+4. 核对 `attendance_report_records` 中的 `field_fingerprint`、`source_fingerprint`、`synced_at` 和 row count。

--- a/docs/development/attendance-report-records-bulk-sync-live-closeout-verification-20260519.md
+++ b/docs/development/attendance-report-records-bulk-sync-live-closeout-verification-20260519.md
@@ -1,0 +1,82 @@
+# 考勤 report-records 批量同步 live closeout 验证记录 2026-05-19
+
+## Scope
+
+验证 PR #1648 的 post-merge 状态：
+
+- PR 已合并到 `main`。
+- production deploy 已包含 #1648。
+- staging live sync 是否具备执行条件。
+- TODO 文档是否从旧的 single-user v1 口径更新为 bulk-sync 已完成口径。
+
+## Verification Matrix
+
+| Check | Result |
+| --- | --- |
+| PR #1648 merge commit | PASS: `2f211d161a301bc632165f9909b604cc05e5559a` |
+| `origin/main` contains #1648 | PASS: `2f211d161 feat(attendance): add bulk report-records sync (#1648)` |
+| Deploy to Production | PASS: run `26069092327`, conclusion `success`, head SHA `2f211d161a301bc632165f9909b604cc05e5559a` |
+| Production backend image | PASS: `ghcr.io/zensgit/metasheet2-backend:2f211d161a301bc632165f9909b604cc05e5559a` |
+| Staging tunnel | PASS: local `8082` reached staging `/api/health` |
+| Staging backend image | BLOCKED: staging still runs `5ca91630307603eacbbb13ae8209721f1b4d5bf3`, which predates #1648 |
+| Staging admin JWT | BLOCKED: local JWT file is expired; `/api/auth/me` returns 401 |
+| Staging allUsers/pageSize sync | NOT RUN: blocked by stale staging image and expired JWT |
+| `git diff --check` | PASS |
+
+## Commands
+
+Deployment status:
+
+```bash
+gh run list --repo zensgit/metasheet2 --branch main --limit 20 \
+  --json databaseId,displayTitle,headSha,status,conclusion,workflowName,createdAt,updatedAt,url
+```
+
+Remote container image check:
+
+```bash
+ssh -i ~/.ssh/metasheet2_deploy mainuser@142.171.239.56 \
+  "docker ps --format '{{.Names}} {{.Image}}' | grep -E 'metasheet-(backend|staging-backend)'"
+```
+
+Staging health check:
+
+```bash
+curl -fsS http://localhost:8082/api/health
+```
+
+JWT validity check:
+
+```bash
+AUTH_TOKEN="$(cat /tmp/<staging-admin-jwt-file>.jwt)"
+curl -sS -H "Authorization: Bearer ${AUTH_TOKEN}" http://localhost:8082/api/auth/me
+```
+
+The JWT value was not printed or committed.
+
+## Future Live Sync Procedure
+
+Once staging is updated to an image containing #1648 and a fresh admin JWT exists:
+
+```bash
+API_BASE=http://localhost:8082
+AUTH_TOKEN="$(cat /tmp/<staging-admin-jwt-file>.jwt)"
+
+curl -sS -X POST "${API_BASE}/api/attendance/report-records/sync" \
+  -H "Authorization: Bearer ${AUTH_TOKEN}" \
+  -H "Content-Type: application/json" \
+  --data '{"from":"2026-05-01","to":"2026-05-31","allUsers":true,"page":1,"pageSize":1}'
+```
+
+Expected evidence to capture:
+
+- `usersScanned=1`
+- `totalUsers >= 1` when staging has active org users
+- `multitable.objectId=attendance_report_records`
+- `fieldFingerprint` present
+- `syncedAt` present
+- Matching row in `attendance_report_records` with `field_fingerprint`, `source_fingerprint`, and `synced_at`
+
+## Conclusion
+
+#1648 is merged and deployed to production. The live staging sync remains pending because the staging backend image and JWT are not ready. This is an environment blocker, not a code failure.

--- a/docs/development/attendance-report-records-sync-todo-20260515.md
+++ b/docs/development/attendance-report-records-sync-todo-20260515.md
@@ -151,7 +151,7 @@ skip  iff  existing.source_fingerprint === next.source_fingerprint
 ## Out of scope（显式 follow-up）
 
 - period / 周期汇总行（复用 `loadAttendanceSummary`，下一条 slice）
-- **全员同步 / 分页 / batch cursor**（v1 `userId` 必填；全员需解决跨员工 approvedMap、分页、超时、部分失败汇总——单独 slice）
+- **batch cursor / 后台任务队列**（全员同步与分页已由 2026-05-18 bulk sync slice 补齐；自动连续分页、后台任务化、超时恢复仍为 follow-up）
 - **orphan / stale columns cleanup**（`ensureFields` 只 upsert 不删；字段隐藏/禁用/动态 subtype 消失后旧列保留——P2 cleanup follow-up）
 - **重复 row_key 行 dedup**（多维表无唯一约束；v1 只 patch 第一条 + warn，自动删重复 = cleanup follow-up）
 - 多维表侧公式/视图模板预置（归多维表配置，非本线）
@@ -163,7 +163,7 @@ skip  iff  existing.source_fingerprint === next.source_fingerprint
 - `provisioning.ensureObject` 支持给已存在对象补新字段（沿用 catalog 对象同语义；PR1 orientation 子项实测确认），但**只 upsert 不删**——orphan 列是 known behavior（P2 cleanup）
 - sync 永不成为事实源；考勤查询/导出永不读 report-records 对象
 - 不裸 SQL 写 `meta_*`；全程 multitable 插件 API；**所有 filter/data/changes key 用物理 `fld_xxx`（`resolveFieldIds`），逻辑名只用于 descriptor/mapping**
-- 幂等键 `orgId:userId:workDate` 稳定；`row_key` 字段落行；`userId` v1 必填
+- 幂等键 `orgId:userId:workDate` 稳定；`row_key` 字段落行；旧单员工 `{ userId }` 路径兼容，同时支持 `{ userIds }` 与 `{ allUsers, page, pageSize }`
 - skip 仅当 `source_fingerprint` 与 `field_fingerprint` 双等；`source_fingerprint` 基于排除 `synced_at`+fingerprint 自身、key-sorted 的稳定 payload
 - patch 既有行时，管理范围内但非 active output 的列显式写 `null`（patchRecord 是 merge 语义，不传 key 会残留旧值）
 - 动态列确定性：descriptor 顺序 `sortOrder→code`，同 code 稳定映射同 `fld_xxx`，列顺序/fld_id/fingerprint 跨 sync 不抖


### PR DESCRIPTION
## Summary

Docs-only closeout for #1648 bulk `attendance_report_records` sync.

- Records production deploy evidence for merge commit `2f211d161a301bc632165f9909b604cc05e5559a`
- Notes production backend image is running the #1648 SHA
- Records that staging live sync was not run because staging still uses the older `5ca916303...` backend image and the local staging admin JWT is expired
- Updates the report-records TODO to mark all-user/page pagination as completed, leaving only batch cursor/background job as follow-up

## Verification

- [x] `git diff --cached --check`
- [x] staged secret scan for JWT/private key/API key literals
- [x] production deploy run observed as success: `Deploy to Production` run `26069092327`
- [x] remote production backend image observed as `ghcr.io/zensgit/metasheet2-backend:2f211d161a301bc632165f9909b604cc05e5559a`
- [x] staging `/api/health` reachable through local `8082` tunnel
- [x] staging allUsers sync honestly marked NOT RUN due stale staging image + expired JWT

No code, no migrations, no runtime behavior changes.
