### PR TITLE
feat(multitable): template center route + page (Phase H2)

### DIFF
--- a/apps/web/src/multitable/components/MetaTemplateCard.vue
+++ b/apps/web/src/multitable/components/MetaTemplateCard.vue
@@ -1,0 +1,136 @@
+<template>
+  <article
+    class="meta-template-card"
+    :style="{ borderColor: template.color || '#cbd5e1' }"
+    :data-template-id="template.id"
+  >
+    <div class="meta-template-card__top">
+      <span class="meta-template-card__icon" :style="{ background: template.color || '#2563eb' }">
+        {{ template.icon || template.name.slice(0, 1).toUpperCase() }}
+      </span>
+      <span class="meta-template-card__category">{{ categoryDisplay }}</span>
+    </div>
+    <h3 class="meta-template-card__name">{{ template.name }}</h3>
+    <p class="meta-template-card__description">{{ template.description }}</p>
+    <small class="meta-template-card__meta">
+      {{ template.sheets.length }} 个 Sheet ·
+      {{ fieldCount }} 个字段 ·
+      {{ viewCount }} 个视图
+    </small>
+    <button
+      type="button"
+      class="meta-template-card__install"
+      :disabled="installing"
+      @click="emit('install', template)"
+    >
+      {{ installing ? '创建中...' : '使用模板' }}
+    </button>
+  </article>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { MetaTemplate } from '../types'
+import { categoryLabel } from '../utils/category-labels'
+
+const props = defineProps<{
+  template: MetaTemplate
+  installing?: boolean
+}>()
+
+const emit = defineEmits<{
+  (e: 'install', template: MetaTemplate): void
+}>()
+
+const categoryDisplay = computed(() => categoryLabel(props.template.category))
+
+const fieldCount = computed(() => {
+  return props.template.sheets.reduce((sum, sheet) => sum + sheet.fields.length, 0)
+})
+
+const viewCount = computed(() => {
+  return props.template.sheets.reduce((sum, sheet) => sum + sheet.views.length, 0)
+})
+</script>
+
+<style scoped>
+.meta-template-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  border: 2px solid #cbd5e1;
+  border-radius: 12px;
+  background: #ffffff;
+  padding: 1rem;
+  min-height: 200px;
+}
+
+.meta-template-card__top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.meta-template-card__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 8px;
+  color: #ffffff;
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.meta-template-card__category {
+  font-size: 0.75rem;
+  color: #64748b;
+  background: #f1f5f9;
+  border-radius: 999px;
+  padding: 0.125rem 0.625rem;
+  white-space: nowrap;
+}
+
+.meta-template-card__name {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.meta-template-card__description {
+  margin: 0;
+  font-size: 0.875rem;
+  color: #475569;
+  flex: 1 1 auto;
+}
+
+.meta-template-card__meta {
+  font-size: 0.75rem;
+  color: #94a3b8;
+}
+
+.meta-template-card__install {
+  margin-top: auto;
+  border: 1px solid #2563eb;
+  background: #2563eb;
+  color: #ffffff;
+  border-radius: 8px;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.meta-template-card__install:disabled {
+  opacity: 0.6;
+  cursor: progress;
+}
+
+.meta-template-card__install:hover:not(:disabled) {
+  background: #1d4ed8;
+  border-color: #1d4ed8;
+}
+</style>

--- a/apps/web/src/multitable/composables/useTemplateInstall.ts
+++ b/apps/web/src/multitable/composables/useTemplateInstall.ts
@@ -1,0 +1,66 @@
+// useTemplateInstall — shared install + redirect composable.
+//
+// Consumed only by MultitableHomeView and MultitableTemplateCenterView.
+// Workbench template install is intentionally NOT routed through here because
+// its lifecycle (confirmDiscardContextChanges -> workbench.client.installTemplate
+// -> workbench.syncExternalContext -> showSuccess) depends on the current
+// workbench context, not on router.push to a freshly created base.
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { multitableClient } from '../api/client'
+import type { MetaSheet, MetaTemplate, MetaView } from '../types'
+import { AppRouteNames } from '../../router/types'
+
+export interface TemplateInstallSuccess {
+  baseId: string
+  sheet: MetaSheet
+  view: MetaView
+}
+
+export type TemplateInstallOutcome =
+  | { status: 'installed-and-opened'; success: TemplateInstallSuccess }
+  | { status: 'installed-no-view'; baseId: string }
+  | { status: 'failed'; error: string }
+
+export function useTemplateInstall() {
+  const router = useRouter()
+  const installingTemplateId = ref<string | null>(null)
+  const errorMessage = ref('')
+
+  async function installAndOpen(
+    template: MetaTemplate,
+    opts?: { baseName?: string },
+  ): Promise<TemplateInstallOutcome | null> {
+    if (installingTemplateId.value) return null
+    installingTemplateId.value = template.id
+    errorMessage.value = ''
+    try {
+      const result = await multitableClient.installTemplate(template.id, {
+        baseName: opts?.baseName ?? `${template.name} Base`,
+      })
+      const sheet = result.sheets[0]
+      const view = sheet ? result.views.find((v) => v.sheetId === sheet.id) ?? result.views[0] : null
+      if (!sheet || !view) {
+        errorMessage.value = '模板已创建，但默认视图尚未就绪。请刷新后重试。'
+        return { status: 'installed-no-view', baseId: result.base.id }
+      }
+      await router.push({
+        name: AppRouteNames.MULTITABLE,
+        params: { sheetId: sheet.id, viewId: view.id },
+        query: { baseId: result.base.id },
+      })
+      return {
+        status: 'installed-and-opened',
+        success: { baseId: result.base.id, sheet, view },
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : '模板创建失败'
+      errorMessage.value = message
+      return { status: 'failed', error: message }
+    } finally {
+      installingTemplateId.value = null
+    }
+  }
+
+  return { installingTemplateId, errorMessage, installAndOpen }
+}

--- a/apps/web/src/multitable/utils/category-labels.ts
+++ b/apps/web/src/multitable/utils/category-labels.ts
@@ -1,0 +1,26 @@
+// Multitable template category translation map.
+//
+// Data layer keeps English category strings (Sales / Project management / etc.)
+// so existing template-library.ts and any test assertions on category names
+// stay stable. UI displays Chinese labels via this lookup; un-mapped categories
+// fall through to the original string (safe default, never fails).
+
+const CATEGORY_LABELS_ZH: Record<string, string> = {
+  'Project management': '项目管理',
+  Sales: 'CRM',
+  Engineering: '工程',
+  Contract: '合同管理',
+  Inspection: '巡检',
+  Recruitment: '招聘',
+  Operations: '运营',
+  General: '通用',
+}
+
+export function categoryLabel(category: string, locale: 'zh-CN' | 'en' = 'zh-CN'): string {
+  if (locale !== 'zh-CN') return category
+  return CATEGORY_LABELS_ZH[category] ?? category
+}
+
+export function listCategoryLabels(categories: string[], locale: 'zh-CN' | 'en' = 'zh-CN'): Array<{ value: string; label: string }> {
+  return categories.map((value) => ({ value, label: categoryLabel(value, locale) }))
+}

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -72,23 +72,24 @@
       <div v-if="templateLibraryLoading" class="mt-template-library__state">Loading templates...</div>
       <div v-else-if="templateLibraryError" class="mt-template-library__state mt-template-library__state--error">{{ templateLibraryError }}</div>
       <div v-else class="mt-template-library__grid">
-        <article v-for="template in templates" :key="template.id" class="mt-template-library__card" :style="{ borderColor: template.color }">
-          <div class="mt-template-library__card-top">
-            <span class="mt-template-library__icon" :style="{ backgroundColor: template.color }">{{ template.icon }}</span>
-            <span class="mt-template-library__category">{{ template.category }}</span>
-          </div>
-          <h3>{{ template.name }}</h3>
-          <p>{{ template.description }}</p>
-          <small>{{ template.sheets.length }} sheet{{ template.sheets.length === 1 ? '' : 's' }} · {{ template.sheets[0]?.fields.length ?? 0 }} fields</small>
-          <button
-            class="mt-template-library__install"
-            :disabled="installingTemplateId === template.id"
-            @click="onInstallTemplate(template)"
-          >
-            {{ installingTemplateId === template.id ? 'Installing...' : 'Use template' }}
-          </button>
-        </article>
+        <MetaTemplateCard
+          v-for="template in templates"
+          :key="template.id"
+          :template="template"
+          :installing="installingTemplateId === template.id"
+          @install="onInstallTemplate"
+        />
       </div>
+      <footer class="mt-template-library__footer">
+        <router-link
+          class="mt-template-library__more"
+          :to="{ name: TemplateCenterRouteName }"
+          data-testid="multitable-workbench-template-center-link"
+          @click="showTemplateLibrary = false"
+        >
+          更多模板 →
+        </router-link>
+      </footer>
     </div>
     <div
       v-if="capabilityOriginNotice"
@@ -396,6 +397,7 @@
 <script setup lang="ts">
 import { ref, reactive, computed, nextTick, onMounted, onBeforeUnmount, watch } from 'vue'
 import { useRouter } from 'vue-router'
+import { AppRouteNames } from '../../router/types'
 import { useAuth } from '../../composables/useAuth'
 import type {
   LinkedRecordSummary,
@@ -437,6 +439,7 @@ import MetaFormView from '../components/MetaFormView.vue'
 import MetaRecordDrawer from '../components/MetaRecordDrawer.vue'
 import MetaCommentsDrawer from '../components/MetaCommentsDrawer.vue'
 import MetaLinkPicker from '../components/MetaLinkPicker.vue'
+import MetaTemplateCard from '../components/MetaTemplateCard.vue'
 import MetaFieldManager from '../components/MetaFieldManager.vue'
 import MetaViewManager from '../components/MetaViewManager.vue'
 import MetaSheetPermissionManager from '../components/MetaSheetPermissionManager.vue'
@@ -512,6 +515,7 @@ const showPermissionManager = ref(false)
 const showAutomationManager = ref(false)
 const showDashboardView = ref(false)
 const showTemplateLibrary = ref(false)
+const TemplateCenterRouteName = AppRouteNames.MULTITABLE_TEMPLATES
 const showFormShareManager = ref(false)
 const showApiTokenManager = ref(false)
 const fieldPermissionEntries = ref<MetaFieldPermissionEntry[]>([])

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -3016,23 +3016,9 @@ defineExpose({
 .mt-template-library__state { padding: 12px; border-radius: 10px; background: #fff; color: #475569; font-size: 12px; }
 .mt-template-library__state--error { color: #b91c1c; background: #fef2f2; }
 .mt-template-library__grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 12px; }
-.mt-template-library__card {
-  padding: 12px;
-  border: 1px solid;
-  border-radius: 12px;
-  background: rgba(255,255,255,.92);
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-.mt-template-library__card-top { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
-.mt-template-library__icon { min-width: 36px; height: 24px; padding: 0 8px; border-radius: 999px; display: inline-flex; align-items: center; justify-content: center; color: #fff; font-size: 11px; font-weight: 600; text-transform: uppercase; }
-.mt-template-library__category { color: #64748b; font-size: 11px; }
-.mt-template-library__card h3 { margin: 0; color: #111827; font-size: 14px; }
-.mt-template-library__card p { margin: 0; min-height: 36px; color: #475569; font-size: 12px; line-height: 1.5; }
-.mt-template-library__card small { color: #64748b; font-size: 11px; }
-.mt-template-library__install { margin-top: auto; padding: 7px 10px; border: 1px solid #2563eb; border-radius: 8px; background: #2563eb; color: #fff; cursor: pointer; font-size: 12px; }
-.mt-template-library__install:disabled { opacity: .7; cursor: wait; }
+.mt-template-library__footer { margin-top: 12px; display: flex; justify-content: flex-end; }
+.mt-template-library__more { font-size: 12px; color: #2563eb; text-decoration: none; }
+.mt-template-library__more:hover { text-decoration: underline; }
 .mt-workbench__shortcuts-overlay { position: fixed; inset: 0; z-index: 100; background: rgba(0,0,0,.3); display: flex; align-items: center; justify-content: center; }
 .mt-workbench__shortcuts { background: #fff; border-radius: 8px; padding: 20px 24px; min-width: 320px; box-shadow: 0 8px 24px rgba(0,0,0,.15); }
 .mt-workbench__shortcuts-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 16px; font-size: 15px; }

--- a/apps/web/src/router/appRoutes.ts
+++ b/apps/web/src/router/appRoutes.ts
@@ -115,6 +115,12 @@ export const appRoutes: RouteRecordRaw[] = [
     component: MultitableHomeView,
     meta: { title: 'Multitable', titleZh: '多维表', requiresAuth: true },
   },
+  {
+    path: ROUTE_PATHS.MULTITABLE_TEMPLATES,
+    name: AppRouteNames.MULTITABLE_TEMPLATES,
+    component: () => import('../views/MultitableTemplateCenterView.vue'),
+    meta: { title: 'Templates', titleZh: '模板中心', requiresAuth: true },
+  },
   buildPublicMultitableFormRoute(() => import('../views/PublicMultitableFormView.vue')),
   buildMultitableRoute(() => import('../multitable/views/MultitableEmbedHost.vue')),
   {

--- a/apps/web/src/router/types.ts
+++ b/apps/web/src/router/types.ts
@@ -73,6 +73,7 @@ export const AppRouteNames = {
   // Attendance routes
   ATTENDANCE: 'attendance',
   MULTITABLE_HOME: 'multitable-home',
+  MULTITABLE_TEMPLATES: 'multitable-templates',
   MULTITABLE: 'multitable',
   MULTITABLE_PUBLIC_FORM: 'multitable-public-form',
   MULTITABLE_COMMENT_INBOX: 'multitable-comment-inbox',
@@ -150,6 +151,7 @@ export interface AppRouteParams {
   'approval-history': Record<string, never>
   'attendance': Record<string, never>
   'multitable-home': Record<string, never>
+  'multitable-templates': Record<string, never>
   'multitable': { sheetId: string; viewId: string }
   'multitable-public-form': { sheetId: string; viewId: string }
   'multitable-comment-inbox': Record<string, never>
@@ -246,6 +248,9 @@ export interface AppRouteQuery {
   'multitable-public-form': {
     publicToken?: string
   }
+
+  // No query params; explicit entry for typing parity with AppRouteParams.
+  'multitable-templates': Record<string, never>
 
   // Default (no query params) - index signature for untyped routes
   [key: string]: Record<string, string | string[] | undefined>
@@ -438,6 +443,7 @@ export const ROUTE_PATHS = {
   // Attendance
   ATTENDANCE: '/attendance',
   MULTITABLE_HOME: '/multitable',
+  MULTITABLE_TEMPLATES: '/multitable/templates',
   MULTITABLE: '/multitable/:sheetId/:viewId',
   MULTITABLE_PUBLIC_FORM: '/multitable/public-form/:sheetId/:viewId',
   MULTITABLE_COMMENT_INBOX: '/multitable/comments/inbox',

--- a/apps/web/src/views/MultitableHomeView.vue
+++ b/apps/web/src/views/MultitableHomeView.vue
@@ -37,41 +37,33 @@
 
     <section class="multitable-home__panel" aria-label="Template quick start">
       <div class="multitable-home__panel-head">
-        <h2>模板快速开始</h2>
-        <span>{{ templates.length }} 个</span>
+        <div class="multitable-home__panel-title">
+          <h2>模板快速开始</h2>
+          <span class="multitable-home__panel-subtitle">{{ templates.length }} 个</span>
+        </div>
+        <router-link
+          class="multitable-home__panel-link"
+          :to="{ name: TemplateCenterRouteName }"
+          data-testid="multitable-home-template-center-link"
+        >
+          查看全部模板 →
+        </router-link>
       </div>
+
+      <p v-if="installError" class="multitable-home__error" role="alert">{{ installError }}</p>
 
       <div v-if="templateLoading" class="multitable-home__state">正在加载模板...</div>
       <div v-else-if="!templates.length" class="multitable-home__empty">
         暂无可用模板。你仍可直接新建空白 Base。
       </div>
       <div v-else class="multitable-home__template-grid">
-        <article
+        <MetaTemplateCard
           v-for="template in templates"
           :key="template.id"
-          class="multitable-home__template-card"
-          :style="{ borderColor: template.color || '#cbd5e1' }"
-        >
-          <div class="multitable-home__template-top">
-            <span class="multitable-home__template-icon" :style="{ background: template.color || '#2563eb' }">
-              {{ template.icon || template.name.slice(0, 1).toUpperCase() }}
-            </span>
-            <span class="multitable-home__template-category">{{ template.category }}</span>
-          </div>
-          <h3>{{ template.name }}</h3>
-          <p>{{ template.description }}</p>
-          <small>
-            {{ template.sheets.length }} 个 Sheet ·
-            {{ countTemplateViews(template) }} 个视图
-          </small>
-          <button
-            class="multitable-home__open multitable-home__open--wide"
-            :disabled="installingTemplateId === template.id"
-            @click="installTemplateAndOpen(template)"
-          >
-            {{ installingTemplateId === template.id ? '创建中...' : '使用模板' }}
-          </button>
-        </article>
+          :template="template"
+          :installing="installingTemplateId === template.id"
+          @install="installAndRemember"
+        />
       </div>
     </section>
 
@@ -145,7 +137,6 @@ import { computed, onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { multitableClient } from '../multitable/api/client'
 import type {
-  InstallTemplateResult,
   MetaBase,
   MetaContext,
   MetaSheet,
@@ -161,6 +152,10 @@ import {
   toggleFavoriteBaseId,
 } from '../multitable/utils/base-local-state'
 import { AppRouteNames } from '../router/types'
+import MetaTemplateCard from '../multitable/components/MetaTemplateCard.vue'
+import { useTemplateInstall } from '../multitable/composables/useTemplateInstall'
+
+const TemplateCenterRouteName = AppRouteNames.MULTITABLE_TEMPLATES
 
 const router = useRouter()
 
@@ -170,11 +165,12 @@ const loading = ref(false)
 const templateLoading = ref(false)
 const creating = ref(false)
 const openingBaseId = ref<string | null>(null)
-const installingTemplateId = ref<string | null>(null)
 const errorMessage = ref('')
 const templateError = ref('')
 const newBaseName = ref('')
 const baseSearch = ref('')
+
+const { installingTemplateId, errorMessage: installError, installAndOpen } = useTemplateInstall()
 
 const favoriteBaseIds = ref<string[]>(readFavoriteBaseIds())
 const recentBaseOpens = ref(readRecentBaseOpens())
@@ -206,17 +202,6 @@ function resolveOpenTarget(context: MetaContext): { sheet: MetaSheet; view: Meta
   if (!sheet) return null
   const view = context.views.find((candidate) => candidate.sheetId === sheet.id) ?? context.views[0] ?? null
   return view ? { sheet, view } : null
-}
-
-function resolveTemplateTarget(result: InstallTemplateResult): { sheet: MetaSheet; view: MetaView } | null {
-  const sheet = result.sheets[0] ?? null
-  if (!sheet) return null
-  const view = result.views.find((candidate) => candidate.sheetId === sheet.id) ?? result.views[0] ?? null
-  return view ? { sheet, view } : null
-}
-
-function countTemplateViews(template: MetaTemplate): number {
-  return template.sheets.reduce((sum, sheet) => sum + sheet.views.length, 0)
 }
 
 async function loadBases(): Promise<void> {
@@ -272,31 +257,16 @@ async function openBase(base: MetaBase): Promise<void> {
   }
 }
 
-async function installTemplateAndOpen(template: MetaTemplate): Promise<void> {
-  if (installingTemplateId.value) return
-  installingTemplateId.value = template.id
-  errorMessage.value = ''
-  try {
-    const result = await multitableClient.installTemplate(template.id, { baseName: `${template.name} Base` })
-    if (!bases.value.some((base) => base.id === result.base.id)) {
-      bases.value = [result.base, ...bases.value]
-    }
-    const target = resolveTemplateTarget(result)
-    if (!target) {
-      errorMessage.value = '模板已创建，但默认视图尚未就绪。请刷新后重试。'
-      await loadBases()
-      return
-    }
-    rememberRecentBase(result.base.id)
-    await router.push({
-      name: AppRouteNames.MULTITABLE,
-      params: { sheetId: target.sheet.id, viewId: target.view.id },
-      query: { baseId: result.base.id },
-    })
-  } catch (error) {
-    errorMessage.value = error instanceof Error ? error.message : '模板创建失败'
-  } finally {
-    installingTemplateId.value = null
+async function installAndRemember(template: MetaTemplate): Promise<void> {
+  const outcome = await installAndOpen(template)
+  if (!outcome) return
+  if (outcome.status === 'installed-and-opened') {
+    rememberRecentBase(outcome.success.baseId)
+    return
+  }
+  if (outcome.status === 'installed-no-view') {
+    // Stay on Home; refresh base list so the user can see the newly created base.
+    await loadBases()
   }
 }
 

--- a/apps/web/src/views/MultitableHomeView.vue
+++ b/apps/web/src/views/MultitableHomeView.vue
@@ -475,55 +475,21 @@ onMounted(loadHomeData)
   padding: 18px;
 }
 
-.multitable-home__template-card {
-  display: grid;
-  gap: 12px;
-  align-content: start;
-  border: 1px solid #cbd5e1;
-  border-radius: 20px;
-  padding: 16px;
-  background: linear-gradient(180deg, #fff 0%, #f8fafc 100%);
-}
-
-.multitable-home__template-top {
+.multitable-home__panel-title {
   display: flex;
-  justify-content: space-between;
-  gap: 12px;
-  align-items: center;
+  align-items: baseline;
+  gap: 0.5rem;
 }
 
-.multitable-home__template-icon {
-  width: 38px;
-  height: 38px;
-  border-radius: 14px;
-  display: grid;
-  place-items: center;
-  color: #fff;
-  font-weight: 800;
+.multitable-home__panel-link {
+  font-size: 0.875rem;
+  color: #2563eb;
+  text-decoration: none;
+  white-space: nowrap;
 }
 
-.multitable-home__template-category {
-  border-radius: 999px;
-  padding: 5px 9px;
-  background: #e0f2fe;
-  color: #0369a1;
-  font-size: 12px;
-  font-weight: 700;
-}
-
-.multitable-home__template-card h3,
-.multitable-home__template-card p {
-  margin: 0;
-}
-
-.multitable-home__template-card p {
-  color: #475569;
-  font-size: 13px;
-  line-height: 1.6;
-}
-
-.multitable-home__template-card small {
-  color: #64748b;
+.multitable-home__panel-link:hover {
+  text-decoration: underline;
 }
 
 .multitable-home__card {

--- a/apps/web/src/views/MultitableTemplateCenterView.vue
+++ b/apps/web/src/views/MultitableTemplateCenterView.vue
@@ -1,0 +1,358 @@
+<template>
+  <section class="multitable-templates" data-testid="multitable-template-center">
+    <header class="multitable-templates__hero">
+      <div>
+        <p class="multitable-templates__eyebrow">Multitable Templates</p>
+        <h1>模板中心</h1>
+        <p class="multitable-templates__subtitle">
+          从行业模板开始一个新的多维表 Base。安装时会自动跳转到新建 Base 的默认视图。
+        </p>
+      </div>
+      <div class="multitable-templates__hero-actions">
+        <router-link class="multitable-templates__back" :to="{ name: HomeRouteName }">
+          ← 返回多维表首页
+        </router-link>
+        <button class="multitable-templates__refresh" :disabled="loading" @click="loadTemplates">
+          {{ loading ? '加载中...' : '刷新' }}
+        </button>
+      </div>
+    </header>
+
+    <section class="multitable-templates__controls" aria-label="筛选与搜索">
+      <nav v-if="categories.length" class="multitable-templates__categories" aria-label="分类筛选">
+        <button
+          type="button"
+          class="multitable-templates__category-btn"
+          :class="{ 'multitable-templates__category-btn--active': activeCategory === ALL_CATEGORY }"
+          @click="activeCategory = ALL_CATEGORY"
+        >
+          全部
+          <span class="multitable-templates__category-count">{{ templates.length }}</span>
+        </button>
+        <button
+          v-for="cat in categories"
+          :key="cat.value"
+          type="button"
+          class="multitable-templates__category-btn"
+          :class="{ 'multitable-templates__category-btn--active': activeCategory === cat.value }"
+          :data-category-value="cat.value"
+          @click="activeCategory = cat.value"
+        >
+          {{ cat.label }}
+          <span class="multitable-templates__category-count">{{ cat.count }}</span>
+        </button>
+      </nav>
+      <label class="multitable-templates__search">
+        <span>搜索模板</span>
+        <input
+          v-model="searchQuery"
+          type="search"
+          placeholder="按名称、描述或分类搜索"
+          aria-label="Search templates"
+        />
+      </label>
+    </section>
+
+    <p v-if="visibleStats" class="multitable-templates__stats" role="status">
+      {{ visibleStats }}
+    </p>
+
+    <p v-if="errorMessage" class="multitable-templates__error" role="alert">
+      {{ errorMessage }}
+      <button class="multitable-templates__retry" @click="loadTemplates">重试</button>
+    </p>
+
+    <p v-if="installError" class="multitable-templates__warning" role="status">
+      {{ installError }}
+    </p>
+
+    <div v-if="loading && !templates.length" class="multitable-templates__state">
+      正在加载模板...
+    </div>
+    <div v-else-if="!templates.length && !errorMessage" class="multitable-templates__empty">
+      暂无可用模板。请刷新或返回首页直接新建空白 Base。
+    </div>
+    <div v-else-if="!visibleTemplates.length" class="multitable-templates__empty">
+      没有匹配的模板。请调整分类或搜索关键词。
+    </div>
+    <div v-else class="multitable-templates__grid">
+      <MetaTemplateCard
+        v-for="template in visibleTemplates"
+        :key="template.id"
+        :template="template"
+        :installing="installingTemplateId === template.id"
+        @install="onInstall"
+      />
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import MetaTemplateCard from '../multitable/components/MetaTemplateCard.vue'
+import { multitableClient } from '../multitable/api/client'
+import { useTemplateInstall } from '../multitable/composables/useTemplateInstall'
+import { categoryLabel } from '../multitable/utils/category-labels'
+import type { MetaTemplate } from '../multitable/types'
+import { AppRouteNames } from '../router/types'
+
+const ALL_CATEGORY = '__all__'
+const HomeRouteName = AppRouteNames.MULTITABLE_HOME
+
+const templates = ref<MetaTemplate[]>([])
+const loading = ref(false)
+const errorMessage = ref('')
+const activeCategory = ref<string>(ALL_CATEGORY)
+const searchQuery = ref('')
+
+const { installingTemplateId, errorMessage: installError, installAndOpen } = useTemplateInstall()
+
+const categories = computed(() => {
+  const counts = new Map<string, number>()
+  for (const tpl of templates.value) {
+    counts.set(tpl.category, (counts.get(tpl.category) ?? 0) + 1)
+  }
+  return Array.from(counts.entries())
+    .map(([value, count]) => ({ value, label: categoryLabel(value), count }))
+    .sort((a, b) => a.label.localeCompare(b.label, 'zh-CN'))
+})
+
+const visibleTemplates = computed<MetaTemplate[]>(() => {
+  const query = searchQuery.value.trim().toLowerCase()
+  return templates.value.filter((tpl) => {
+    if (activeCategory.value !== ALL_CATEGORY && tpl.category !== activeCategory.value) {
+      return false
+    }
+    if (!query) return true
+    return (
+      tpl.name.toLowerCase().includes(query) ||
+      tpl.description.toLowerCase().includes(query) ||
+      tpl.category.toLowerCase().includes(query) ||
+      categoryLabel(tpl.category).toLowerCase().includes(query)
+    )
+  })
+})
+
+const visibleStats = computed(() => {
+  if (loading.value || errorMessage.value) return ''
+  if (!templates.value.length) return ''
+  const total = templates.value.length
+  const shown = visibleTemplates.value.length
+  if (shown === total && activeCategory.value === ALL_CATEGORY && !searchQuery.value.trim()) {
+    return `共 ${total} 个模板`
+  }
+  return `匹配 ${shown} / ${total} 个模板`
+})
+
+async function loadTemplates(): Promise<void> {
+  loading.value = true
+  errorMessage.value = ''
+  try {
+    const data = await multitableClient.listTemplates()
+    templates.value = data.templates ?? []
+  } catch (error) {
+    errorMessage.value = error instanceof Error ? error.message : '加载模板失败'
+  } finally {
+    loading.value = false
+  }
+}
+
+async function onInstall(template: MetaTemplate): Promise<void> {
+  await installAndOpen(template)
+}
+
+onMounted(() => {
+  void loadTemplates()
+})
+</script>
+
+<style scoped>
+.multitable-templates {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 1.5rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.multitable-templates__hero {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.multitable-templates__eyebrow {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #64748b;
+}
+
+.multitable-templates__hero h1 {
+  margin: 0.25rem 0;
+  font-size: 1.5rem;
+  color: #0f172a;
+}
+
+.multitable-templates__subtitle {
+  margin: 0;
+  font-size: 0.875rem;
+  color: #475569;
+  max-width: 640px;
+}
+
+.multitable-templates__hero-actions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.multitable-templates__back {
+  font-size: 0.875rem;
+  color: #2563eb;
+  text-decoration: none;
+}
+
+.multitable-templates__back:hover {
+  text-decoration: underline;
+}
+
+.multitable-templates__refresh {
+  border: 1px solid #cbd5e1;
+  background: #ffffff;
+  color: #0f172a;
+  padding: 0.375rem 0.875rem;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.875rem;
+}
+
+.multitable-templates__refresh:disabled {
+  opacity: 0.6;
+  cursor: progress;
+}
+
+.multitable-templates__controls {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.multitable-templates__categories {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  overflow-x: auto;
+}
+
+.multitable-templates__category-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  border: 1px solid #cbd5e1;
+  background: #ffffff;
+  color: #0f172a;
+  padding: 0.375rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.875rem;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.multitable-templates__category-btn:hover {
+  border-color: #94a3b8;
+}
+
+.multitable-templates__category-btn--active {
+  border-color: #2563eb;
+  background: #eff6ff;
+  color: #1d4ed8;
+}
+
+.multitable-templates__category-count {
+  font-size: 0.75rem;
+  background: rgba(15, 23, 42, 0.06);
+  border-radius: 999px;
+  padding: 0 0.5rem;
+}
+
+.multitable-templates__category-btn--active .multitable-templates__category-count {
+  background: rgba(37, 99, 235, 0.12);
+  color: #1d4ed8;
+}
+
+.multitable-templates__search {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  color: #475569;
+}
+
+.multitable-templates__search input {
+  flex: 0 0 280px;
+  border: 1px solid #cbd5e1;
+  border-radius: 6px;
+  padding: 0.375rem 0.625rem;
+  font-size: 0.875rem;
+}
+
+.multitable-templates__stats {
+  margin: 0;
+  font-size: 0.75rem;
+  color: #94a3b8;
+}
+
+.multitable-templates__error {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border: 1px solid #fca5a5;
+  background: #fef2f2;
+  color: #b91c1c;
+  border-radius: 8px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.multitable-templates__retry {
+  background: transparent;
+  border: 1px solid #b91c1c;
+  color: #b91c1c;
+  border-radius: 6px;
+  padding: 0.25rem 0.625rem;
+  font-size: 0.75rem;
+  cursor: pointer;
+}
+
+.multitable-templates__warning {
+  margin: 0;
+  padding: 0.5rem 0.875rem;
+  background: #fef3c7;
+  border: 1px solid #f59e0b;
+  color: #92400e;
+  border-radius: 6px;
+  font-size: 0.875rem;
+}
+
+.multitable-templates__state,
+.multitable-templates__empty {
+  padding: 2rem;
+  text-align: center;
+  color: #64748b;
+  font-size: 0.875rem;
+  background: #f8fafc;
+  border-radius: 8px;
+}
+
+.multitable-templates__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 1rem;
+}
+</style>

--- a/apps/web/tests/multitable-home-view.spec.ts
+++ b/apps/web/tests/multitable-home-view.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { createApp, nextTick, type App as VueApp, type Component } from 'vue'
+import { createApp, h, nextTick, type App as VueApp, type Component } from 'vue'
 import MultitableHomeView from '../src/views/MultitableHomeView.vue'
 import { AppRouteNames } from '../src/router/types'
 
@@ -88,6 +88,13 @@ describe('MultitableHomeView', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     app = createApp(MultitableHomeView as Component)
+    app.component('router-link', {
+      props: ['to'],
+      render() {
+        const href = typeof this.$props.to === 'string' ? this.$props.to : JSON.stringify(this.$props.to)
+        return h('a', { href, 'data-router-link-to': href }, this.$slots.default ? this.$slots.default() : [])
+      },
+    })
     app.mount(container)
     return container
   }
@@ -281,7 +288,9 @@ describe('MultitableHomeView', () => {
     await flushUi()
 
     expect(root.textContent).toContain('Project Tracker')
-    expect(root.textContent).toContain('1 个 Sheet · 2 个视图')
+    // MetaTemplateCard now renders 3 metrics: sheets · fields · views.
+    // Project Tracker template has 1 sheet, 0 fields (mock), 2 views.
+    expect(root.textContent).toContain('1 个 Sheet · 0 个字段 · 2 个视图')
 
     findButton(root, '使用模板').click()
     await flushUi()
@@ -292,5 +301,18 @@ describe('MultitableHomeView', () => {
       params: { sheetId: 'sheet_template', viewId: 'view_template' },
       query: { baseId: 'base_template' },
     })
+  })
+
+  it('renders a link to the template center in the template section header', async () => {
+    mocks.listBases.mockResolvedValue({ bases: [] })
+    mocks.listTemplates.mockResolvedValue({ templates: [] })
+
+    const root = mountView()
+    await flushUi()
+
+    const link = root.querySelector<HTMLElement>('[data-testid="multitable-home-template-center-link"]')
+    expect(link).not.toBeNull()
+    expect(link?.textContent?.trim()).toContain('查看全部模板')
+    expect(link?.getAttribute('data-router-link-to')).toContain(AppRouteNames.MULTITABLE_TEMPLATES)
   })
 })

--- a/apps/web/tests/multitable-template-center-view.spec.ts
+++ b/apps/web/tests/multitable-template-center-view.spec.ts
@@ -1,0 +1,301 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick, type App as VueApp, type Component } from 'vue'
+import MultitableTemplateCenterView from '../src/views/MultitableTemplateCenterView.vue'
+import { AppRouteNames } from '../src/router/types'
+
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  listTemplates: vi.fn(),
+  installTemplate: vi.fn(),
+}))
+
+vi.mock('vue-router', async () => {
+  const actual = await vi.importActual<typeof import('vue-router')>('vue-router')
+  return {
+    ...actual,
+    useRouter: () => ({
+      push: mocks.push,
+    }),
+  }
+})
+
+vi.mock('../src/multitable/api/client', () => ({
+  multitableClient: {
+    listTemplates: mocks.listTemplates,
+    installTemplate: mocks.installTemplate,
+  },
+}))
+
+async function flushUi(cycles = 4): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+function makeTemplate(overrides: {
+  id: string
+  name: string
+  description?: string
+  category?: string
+  icon?: string
+  color?: string
+  sheets?: number
+  fields?: number
+  views?: number
+}) {
+  const sheets = Array.from({ length: overrides.sheets ?? 1 }, (_, i) => ({
+    id: `${overrides.id}-sheet-${i}`,
+    name: `Sheet ${i + 1}`,
+    fields: Array.from({ length: overrides.fields ?? 3 }, (__, j) => ({ id: `f${j}` })),
+    views: Array.from({ length: overrides.views ?? 2 }, (__, k) => ({
+      id: `v${k}`,
+      name: `View ${k + 1}`,
+      type: 'grid',
+    })),
+  }))
+  return {
+    id: overrides.id,
+    name: overrides.name,
+    description: overrides.description ?? '',
+    category: overrides.category ?? 'Project management',
+    icon: overrides.icon ?? overrides.name.slice(0, 1),
+    color: overrides.color ?? '#2563eb',
+    sheets,
+  }
+}
+
+function findButton(container: HTMLElement, text: string, opts: { exact?: boolean } = {}): HTMLButtonElement {
+  const button = Array.from(container.querySelectorAll('button')).find((node) => {
+    const content = node.textContent?.trim() ?? ''
+    return opts.exact ? content === text : content.includes(text)
+  })
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error(`Button not found: ${text}`)
+  }
+  return button
+}
+
+function findCategoryButton(container: HTMLElement, label: string): HTMLButtonElement {
+  const btn = Array.from(container.querySelectorAll<HTMLButtonElement>('.multitable-templates__category-btn'))
+    .find((node) => (node.textContent ?? '').includes(label))
+  if (!btn) throw new Error(`Category tab not found: ${label}`)
+  return btn
+}
+
+function readCardNames(container: HTMLElement): string[] {
+  return Array.from(container.querySelectorAll('.meta-template-card__name'))
+    .map((n) => n.textContent?.trim() ?? '')
+}
+
+describe('MultitableTemplateCenterView', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+    vi.clearAllMocks()
+  })
+
+  function mountView() {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(MultitableTemplateCenterView as Component)
+    app.component('router-link', {
+      props: ['to'],
+      render() {
+        const href = typeof this.$props.to === 'string' ? this.$props.to : JSON.stringify(this.$props.to)
+        return h('a', { href, 'data-router-link-to': href }, this.$slots.default ? this.$slots.default() : [])
+      },
+    })
+    app.mount(container)
+    return container
+  }
+
+  it('loads templates on mount and renders cards', async () => {
+    mocks.listTemplates.mockResolvedValue({
+      templates: [
+        makeTemplate({ id: 'project-tracker', name: 'Project Tracker', category: 'Project management' }),
+        makeTemplate({ id: 'sales-crm', name: 'Sales CRM', category: 'Sales' }),
+      ],
+    })
+
+    const root = mountView()
+    await flushUi()
+
+    expect(mocks.listTemplates).toHaveBeenCalledTimes(1)
+    expect(readCardNames(root)).toEqual(['Project Tracker', 'Sales CRM'])
+    expect(root.querySelector('[data-testid="multitable-template-center"]')).not.toBeNull()
+  })
+
+  it('filters templates by category tab', async () => {
+    mocks.listTemplates.mockResolvedValue({
+      templates: [
+        makeTemplate({ id: 't1', name: 'Tasks', category: 'Project management' }),
+        makeTemplate({ id: 't2', name: 'Deals', category: 'Sales' }),
+        makeTemplate({ id: 't3', name: 'Sprint', category: 'Project management' }),
+      ],
+    })
+
+    const root = mountView()
+    await flushUi()
+    expect(readCardNames(root)).toHaveLength(3)
+
+    findCategoryButton(root, 'CRM').click() // Sales -> CRM via translation
+    await flushUi()
+    expect(readCardNames(root)).toEqual(['Deals'])
+
+    findCategoryButton(root, '项目管理').click()
+    await flushUi()
+    expect(readCardNames(root).sort()).toEqual(['Sprint', 'Tasks'])
+
+    findCategoryButton(root, '全部').click()
+    await flushUi()
+    expect(readCardNames(root)).toHaveLength(3)
+  })
+
+  it('filters templates by search input matching name / description / category (raw + translated)', async () => {
+    mocks.listTemplates.mockResolvedValue({
+      templates: [
+        makeTemplate({ id: 't1', name: 'Project Tracker', description: 'Track project tasks', category: 'Project management' }),
+        makeTemplate({ id: 't2', name: 'Sales CRM', description: 'Customer relationships', category: 'Sales' }),
+        makeTemplate({ id: 't3', name: 'Issue Tracker', description: 'Bug triage', category: 'Engineering' }),
+      ],
+    })
+
+    const root = mountView()
+    await flushUi()
+
+    const searchInput = root.querySelector<HTMLInputElement>('.multitable-templates__search input')
+    if (!searchInput) throw new Error('Search input not found')
+
+    // match by name
+    searchInput.value = 'project'
+    searchInput.dispatchEvent(new Event('input'))
+    await flushUi()
+    expect(readCardNames(root)).toEqual(['Project Tracker'])
+
+    // match by description
+    searchInput.value = 'customer'
+    searchInput.dispatchEvent(new Event('input'))
+    await flushUi()
+    expect(readCardNames(root)).toEqual(['Sales CRM'])
+
+    // match by raw category string
+    searchInput.value = 'engineering'
+    searchInput.dispatchEvent(new Event('input'))
+    await flushUi()
+    expect(readCardNames(root)).toEqual(['Issue Tracker'])
+
+    // match by translated category label (Sales -> CRM)
+    searchInput.value = 'CRM'
+    searchInput.dispatchEvent(new Event('input'))
+    await flushUi()
+    expect(readCardNames(root)).toEqual(['Sales CRM'])
+  })
+
+  it('install success navigates to the new base sheet/view', async () => {
+    mocks.listTemplates.mockResolvedValue({
+      templates: [
+        makeTemplate({ id: 'project-tracker', name: 'Project Tracker' }),
+      ],
+    })
+    mocks.installTemplate.mockResolvedValue({
+      template: { id: 'project-tracker', name: 'Project Tracker' },
+      base: { id: 'base_new', name: 'Project Tracker Base' },
+      sheets: [{ id: 'sheet_new', baseId: 'base_new', name: 'Tasks' }],
+      fields: [],
+      views: [{ id: 'view_new', sheetId: 'sheet_new', name: 'Grid', type: 'grid' }],
+    })
+
+    const root = mountView()
+    await flushUi()
+
+    findButton(root, '使用模板').click()
+    await flushUi()
+
+    expect(mocks.installTemplate).toHaveBeenCalledWith('project-tracker', { baseName: 'Project Tracker Base' })
+    expect(mocks.push).toHaveBeenCalledWith({
+      name: AppRouteNames.MULTITABLE,
+      params: { sheetId: 'sheet_new', viewId: 'view_new' },
+      query: { baseId: 'base_new' },
+    })
+  })
+
+  it('install failure surfaces error and does not navigate', async () => {
+    mocks.listTemplates.mockResolvedValue({
+      templates: [makeTemplate({ id: 'project-tracker', name: 'Project Tracker' })],
+    })
+    mocks.installTemplate.mockRejectedValue(new Error('boom'))
+
+    const root = mountView()
+    await flushUi()
+
+    findButton(root, '使用模板').click()
+    await flushUi()
+
+    expect(mocks.push).not.toHaveBeenCalled()
+    expect(root.textContent).toContain('boom')
+  })
+
+  it('load failure shows a retryable error banner', async () => {
+    mocks.listTemplates.mockRejectedValueOnce(new Error('网络断了'))
+
+    const root = mountView()
+    await flushUi()
+
+    expect(root.textContent).toContain('网络断了')
+    const retry = findButton(root, '重试', { exact: true })
+
+    mocks.listTemplates.mockResolvedValueOnce({
+      templates: [makeTemplate({ id: 'project-tracker', name: 'Project Tracker' })],
+    })
+    retry.click()
+    await flushUi()
+
+    expect(mocks.listTemplates).toHaveBeenCalledTimes(2)
+    expect(readCardNames(root)).toEqual(['Project Tracker'])
+  })
+
+  it('shows empty state when server returns no templates', async () => {
+    mocks.listTemplates.mockResolvedValue({ templates: [] })
+
+    const root = mountView()
+    await flushUi()
+
+    expect(root.textContent).toContain('暂无可用模板')
+  })
+
+  it('shows filtered-empty state when search/category narrows to zero', async () => {
+    mocks.listTemplates.mockResolvedValue({
+      templates: [makeTemplate({ id: 't1', name: 'Project Tracker' })],
+    })
+
+    const root = mountView()
+    await flushUi()
+
+    const searchInput = root.querySelector<HTMLInputElement>('.multitable-templates__search input')
+    if (!searchInput) throw new Error('Search input not found')
+
+    searchInput.value = 'no-such-template-zzzzz'
+    searchInput.dispatchEvent(new Event('input'))
+    await flushUi()
+
+    expect(root.textContent).toContain('没有匹配的模板')
+  })
+
+  it('hero shows a link back to multitable home', async () => {
+    mocks.listTemplates.mockResolvedValue({ templates: [] })
+
+    const root = mountView()
+    await flushUi()
+
+    const backLink = root.querySelector<HTMLElement>('.multitable-templates__back')
+    expect(backLink).not.toBeNull()
+    expect(backLink?.textContent?.trim()).toContain('返回多维表首页')
+    expect(backLink?.getAttribute('data-router-link-to')).toContain(AppRouteNames.MULTITABLE_HOME)
+  })
+})

--- a/docs/development/multitable-template-center-h2-development-20260518.md
+++ b/docs/development/multitable-template-center-h2-development-20260518.md
@@ -1,0 +1,403 @@
+# H2 多维表模板中心 + H3 行业模板种子 — 开发计划
+
+- **日期**：2026-05-18
+- **范围**：`apps/web/src/views/`、`apps/web/src/multitable/components/`、`apps/web/src/multitable/composables/`、`apps/web/src/router/`、`packages/core-backend/src/multitable/template-library.ts`（H3 阶段）
+- **依赖**：Phase A (#1639) ✅、Phase H1 ✅、Phase B (#1642) ✅、Phase C 窗口文档 (#1646) ✅
+- **K3 PoC 阶段一锁定**：合规（详见 §6）
+- **关联**：[Views Consolidation Integration Plan §3 Phase H](./views-consolidation-multitable-spreadsheets-plan-20260517.md)、[Integration ERP Platform Roadmap](./integration-erp-platform-roadmap-20260425.md)
+
+---
+
+## 1. Summary
+
+目标：继续主推多维表，补齐飞书对标里的"模板中心"上手路径。
+
+**Scout 结论（详见 §10 附录）**：
+
+- H1 已实现模板 quickstart、Base 列表、收藏/最近打开、搜索、install 后跳转
+- 前端已有 `multitableClient.listTemplates()` 与 `installTemplate()`
+- 后端已有 `GET /api/multitable/templates` 与 `POST /api/multitable/templates/:id/install`
+- 现有 3 个模板（`project-tracker` / `sales-crm` / `issue-tracker`）来自静态库 `packages/core-backend/src/multitable/template-library.ts`，**非 DB 表**
+- 因此 **H2 范围缩小**为"独立模板中心页面"；**H3 紧随**做静态模板库扩充，**不**加 DB migration
+
+**分支策略**（普通 branch，不开 worktree）：
+
+```bash
+git fetch origin main
+git switch -c frontend/multitable-template-center-20260518 origin/main
+```
+
+---
+
+## 2. Key Changes
+
+### 2.1 H2 PR — 模板中心路由与页面
+
+#### 新增入口
+
+- 新 route：`/multitable/templates`
+- 新 route name：`AppRouteNames.MULTITABLE_TEMPLATES = 'multitable-templates'`
+- 新页面：`MultitableTemplateCenterView.vue`
+- `MultitableHomeView.vue` 的"模板快速开始"标题区加"查看全部模板 →"入口
+
+#### 页面能力
+
+- 调用现有 `GET /api/multitable/templates`
+- 展示模板卡片：名称、描述、分类、icon/color、sheet 数、field 数、view 数
+- **分类筛选**：`全部 / Project management / Sales / Engineering / ...`，分类**从返回数据动态聚合**（不 hard-code 分类列表，保证 H3 加新分类时无需改 H2）
+- **搜索**：按 template `name` / `description` / `category` **三字段**匹配（客户端 filter，无后端调用）
+- **明确支持的状态**：空状态 / 加载状态 / 错误状态 / 安装中状态
+- 点击"使用模板"调用现有 `POST /api/multitable/templates/:id/install`
+- install 成功后跳转到新建 base 的默认 sheet/view：
+
+```ts
+router.push({
+  name: AppRouteNames.MULTITABLE,
+  params: { sheetId: target.sheet.id, viewId: target.view.id },
+  query: { baseId: result.base.id },
+})
+```
+
+#### 复用策略
+
+- **不**新增后端 API
+- **不**改 `/api/multitable/templates` response shape
+- 抽 `useTemplateInstall` composable，**仅供 Home + Template Center 复用**——Workbench 安装走自己的 lifecycle，**不在复用范围**（详见 §3.5）
+- **不**做权限 / 租户新模型，沿用现有 `rbacGuard('multitable', 'read|write')`
+
+#### Workbench modal 改动（最小化）
+
+`MultitableWorkbench.vue` 的 template library modal：
+
+- ✅ 卡片渲染改用 `<MetaTemplateCard>`（统一展示组件）
+- ✅ Modal 底部加"更多模板 →"链接，跳 `/multitable/templates`
+- ❌ **`onInstallTemplate` 函数与 install lifecycle 完全不动**——保持 `confirmDiscardContextChanges → workbench.client.installTemplate → workbench.syncExternalContext → showSuccess` 链路
+
+理由：Workbench 安装依赖当前 base/sheet/view context，与 Home/Center 的"直接 push 到新 base"是不同 lifecycle，强行抽通用 composable 会把 H2 扩大为 Workbench 行为重构。
+
+### 2.2 H3 PR — 行业模板种子扩充
+
+不与 H2 同 PR；H2 design MD 同步 outline H3。
+
+#### 范围
+
+- 在 `packages/core-backend/src/multitable/template-library.ts` 数组追加 **5 个**新模板对象
+- **纯数据 PR**，无新代码逻辑
+- 不加 DB 表 / migration
+
+#### 5 个新模板（与目标 6 类对齐）
+
+| 模板 ID | Category (data layer) | 中文 UI 标签 | Sheets |
+|---|---|---|---|
+| `contract-management` | `Contract` | 合同管理 | Contracts + Payments |
+| `field-inspection` | `Inspection` | 巡检 | Tasks + Issues + Remediation |
+| `recruitment` | `Recruitment` | 招聘 | Candidates + Interviews + Offers |
+| `meeting-minutes` | `Operations` | 会议纪要 | Meetings + Action items |
+| `simple-list` | `General` | 通用清单 | List |
+
+**质量门（每个模板必须满足）**：
+
+- ≥ 5 字段，≤ 8 字段（覆盖业务核心，不堆砌）
+- ≥ 2 views，其中**必有 1 个 grid**，**必有 1 个业务视图**（kanban / calendar / timeline / gantt / hierarchy 中合适者）
+- 每个字段有 `description`
+- 视图配置完整（kanban 必须指定 `groupByFieldId`，calendar 必须指定 `dateFieldId`，等等）
+
+#### Category 命名口径（关键约束）
+
+| 现有模板 | Category（保持不变） | 中文 UI 标签 |
+|---|---|---|
+| `project-tracker` | `Project management` | 项目管理 |
+| `sales-crm` | `Sales` | CRM |
+| `issue-tracker` | `Engineering` | 工程 |
+
+**H3 不重命名现有 category**。`sales-crm` 保持 `Sales`，**不**改成 `CRM`。理由：
+
+1. 改 category 字符串 = 动既有 hard-coded TS 数据 = 扩 H3 scope 到"数据迁移"
+2. 任何对现有 category 名做 assert 的测试会破
+3. UI 翻译层（前端中文显示"CRM"）即可满足语义，**无需动数据**
+
+**架构**：底层 `template.category` 字符串全部保持英文（H2 + H3 一致），前端在 `MetaTemplateCard` 或 view 内部用翻译映射表显示中文标签。翻译表的位置由 H2 实现时决定（可能放 `apps/web/src/multitable/utils/category-labels.ts` 或就 inline 在 view 里）。
+
+#### H3 不改前端页面逻辑
+
+H2 页面的分类聚合是**从返回数据动态读取**，新加的 category 字符串会自动出现在 H2 的分类 tab 列表中。H3 PR 仅动后端 + 测试 expected ids，前端零代码改动。
+
+---
+
+## 3. 实现细节（H2）
+
+### 3.1 新增文件
+
+| 文件 | 体量 | 说明 |
+|---|---|---|
+| `apps/web/src/views/MultitableTemplateCenterView.vue` | ~200 行 | 新页面：hero + 分类导航 tab + 搜索框 + template grid + 状态分支 |
+| `apps/web/src/multitable/components/MetaTemplateCard.vue` | ~80 行 | **纯展示组件**：props `{ template: MetaTemplate, installing: boolean }`，emit `install`。**不**在组件内 import `useRouter` / `multitableClient`，业务副作用全在父组件 |
+| `apps/web/src/multitable/composables/useTemplateInstall.ts` | ~50 行 | 共享 install composable（详见 §3.5）—— 仅 Home + Template Center 复用 |
+| `apps/web/src/multitable/utils/category-labels.ts` | ~15 行 | category 英文 → 中文标签映射表（fallback 显示原值） |
+| `apps/web/tests/multitable-template-center-view.spec.ts` | ~120 行 | 页面完整行为测试 |
+| `apps/web/tests/multitable-home-view.spec.ts` 增量 | ~30 行 | **仅**补 "查看全部模板" 入口链接断言；**不**重测 install 流程 |
+
+### 3.2 修改文件
+
+| 文件 | 改动 |
+|---|---|
+| `apps/web/src/router/appRoutes.ts` | 加 `/multitable/templates` 路由项（component lazy import） |
+| `apps/web/src/router/types.ts` | **三处同步补齐**：(1) `AppRouteNames.MULTITABLE_TEMPLATES`；(2) `ROUTE_PATHS.MULTITABLE_TEMPLATES`；(3) `AppRouteParams['multitable-templates']: Record<string, never>` —— 与现有 typing 风格一致 |
+| `apps/web/src/views/MultitableHomeView.vue` | 模板 section 标题旁加 "查看全部模板 →" 链接；卡片渲染改用 `<MetaTemplateCard>`；安装逻辑改走 `useTemplateInstall` composable |
+| `apps/web/src/multitable/views/MultitableWorkbench.vue` | **仅最小改动**：modal 卡片改用 `<MetaTemplateCard>` + 加 footer link；`onInstallTemplate` 完全不动 |
+
+### 3.3 不动文件
+
+- `apps/web/src/multitable/api/client.ts` —— `listTemplates()` / `installTemplate()` 不变
+- `packages/core-backend/src/routes/univer-meta.ts` —— 后端 routes 不动
+- `packages/core-backend/src/multitable/template-library.ts` —— H2 不动（H3 才会动）
+- migrations / DB schema —— 零改动
+- K3 / integration-core / `/api/multitable/*` 契约 —— 零改动
+
+### 3.4 路由配置
+
+```ts
+// apps/web/src/router/types.ts 新增
+MULTITABLE_TEMPLATES: 'multitable-templates'
+ROUTE_PATHS.MULTITABLE_TEMPLATES: '/multitable/templates'
+
+// AppRouteParams 加
+'multitable-templates': Record<string, never>
+
+// apps/web/src/router/appRoutes.ts 新增（放在 MULTITABLE_HOME 之后）
+{
+  path: ROUTE_PATHS.MULTITABLE_TEMPLATES,
+  name: AppRouteNames.MULTITABLE_TEMPLATES,
+  component: () => import('../views/MultitableTemplateCenterView.vue'),
+  meta: { title: 'Templates', titleZh: '模板中心', requiresAuth: true }
+}
+```
+
+### 3.5 useTemplateInstall composable
+
+```ts
+// apps/web/src/multitable/composables/useTemplateInstall.ts
+//
+// 仅用于 router.push-style install（Home + Template Center）。
+// Workbench 的 install lifecycle 不通过此 composable。
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { multitableClient } from '../api/client'
+import type { MetaTemplate } from '../types'
+import { AppRouteNames } from '../../router/types'
+
+export function useTemplateInstall() {
+  const router = useRouter()
+  const installingTemplateId = ref<string | null>(null)
+  const errorMessage = ref('')
+
+  async function installAndOpen(template: MetaTemplate, opts?: { baseName?: string }) {
+    if (installingTemplateId.value) return
+    installingTemplateId.value = template.id
+    errorMessage.value = ''
+    try {
+      const result = await multitableClient.installTemplate(template.id, {
+        baseName: opts?.baseName ?? `${template.name} Base`,
+      })
+      const sheet = result.sheets[0]
+      const view = result.views.find((v) => v.sheetId === sheet?.id) ?? result.views[0]
+      if (!sheet || !view) {
+        errorMessage.value = '模板已创建，但默认视图尚未就绪。请刷新后重试。'
+        return { installed: result.base, openTarget: null }
+      }
+      await router.push({
+        name: AppRouteNames.MULTITABLE,
+        params: { sheetId: sheet.id, viewId: view.id },
+        query: { baseId: result.base.id },
+      })
+      return { installed: result.base, openTarget: { sheet, view } }
+    } catch (error) {
+      errorMessage.value = error instanceof Error ? error.message : '模板创建失败'
+      return null
+    } finally {
+      installingTemplateId.value = null
+    }
+  }
+
+  return { installingTemplateId, errorMessage, installAndOpen }
+}
+```
+
+---
+
+## 4. Deliverables
+
+### 4.1 H2 PR 交付
+
+- `docs/development/multitable-template-center-h2-development-20260518.md` **（本文档）**
+- `docs/development/multitable-template-center-h2-verification-20260518.md`（实现完成后产出）
+- `/multitable/templates` 页面 + 路由
+- Home 页面 "查看全部模板" 入口
+- `MultitableWorkbench.vue` modal 内的卡片统一 + footer link
+- Frontend 目标测试（§5.1 列表）
+
+### 4.2 H3 PR 交付
+
+- `docs/development/multitable-industry-templates-h3-development-20260518.md`（H3 开始时产出）
+- `docs/development/multitable-industry-templates-h3-verification-20260518.md`（实现完成后产出）
+- `template-library.ts` 5 个新模板扩充
+- 后端模板库 unit test + API integration test expected ids 更新
+
+---
+
+## 5. Test Plan
+
+### 5.1 H2 targeted tests
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-template-center-view.spec.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/multitable-home-view.spec.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/platform-shell-nav.spec.ts --watch=false
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+git diff --check origin/main..HEAD
+```
+
+### 5.2 H2 Acceptance Scenarios
+
+- `/multitable/templates` loads templates from existing API
+- Category filter narrows visible cards
+- Search filters by name / description / category
+- API load failure shows retryable error state
+- Empty state appears when no templates returned
+- "Installing..." state shows on clicked card during install
+- Install success navigates directly to `/multitable/:sheetId/:viewId?baseId=...`
+- Install failure shows error and does **not** navigate
+- Home "查看全部模板" navigates to `/multitable/templates`
+- Workbench modal "更多模板 →" navigates to `/multitable/templates`
+- Existing Home install + Workbench install flows **unchanged** (no regression)
+
+### 5.3 H3 targeted tests
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/multitable-template-library.test.ts
+pnpm --filter @metasheet/core-backend exec vitest run tests/integration/multitable-context.api.test.ts
+git diff --check origin/main..HEAD
+```
+
+### 5.4 H3 Acceptance Scenarios
+
+- `listMultitableTemplates()` includes the new 5 template ids
+- Each new template installs successfully
+- Installed template creates expected sheets / fields / views
+- Each template has ≥ 5 fields, ≤ 8 fields, ≥ 2 views (≥ 1 grid + ≥ 1 business view)
+- Existing `project-tracker` / `sales-crm` / `issue-tracker` behavior remains **unchanged**
+- No existing test fails (category strings, ids, fields all preserved for the 3 originals)
+
+---
+
+## 6. K3 PoC 阶段一锁定合规
+
+| 检查项 | 状态 |
+|---|---|
+| `plugins/plugin-integration-core/**` 触动 | ❌ 不动 |
+| `lib/adapters/k3-wise-*` 触动 | ❌ 不动 |
+| `packages/core-backend/src/routes/integrations*.ts` 触动 | ❌ 不动 |
+| `IntegrationWorkbenchView.vue` / `IntegrationK3WiseSetupView.vue` 触动 | ❌ 不动 |
+| `/api/multitable/*` 契约改动 | ❌ 路径 / 请求体 / 响应字段 / 状态码全部不变 |
+| `/api/spreadsheets/*` 契约改动 | ❌ 不动 |
+| 数据库 migration | ❌ 零新增 |
+| 触发"平台化"红线（workspace shell / 租户隔离 / marketplace） | ❌ 用户级体验 + hard-coded 模板，不涉及平台化 |
+
+按 [Integration ERP Platform Roadmap (2026-04-25)](./integration-erp-platform-roadmap-20260425.md) 的阶段一锁定条款：
+
+- 阶段一明确"不开新战线、不投入平台化代码"，但允许"内核打磨"已发布功能
+- H1 → H2 → H3 是多维表内核（已 ship 的 home + template 能力）的延续打磨，非新产品面
+- 用户级收藏 / 用户级最近打开 已在 H1 落地（属于"内核打磨"允许范围）
+- 组织级模板发布 / 模板市场 / 计费 = 平台化 = 阶段三 = 本设计**不**触及
+
+---
+
+## 7. 风险登记
+
+| 风险 | 等级 | 缓解 |
+|---|---|---|
+| `MetaTemplateCard` 抽取破坏 Home view 现有渲染 | 低 | 抽取前 snapshot 测试 Home view；抽取后 DOM 结构 diff 比对 |
+| `useTemplateInstall` 替换两处时漏一处 | 低 | grep `installTemplateAndOpen` 全仓确认；分多 commit 替换（先 Home 后 Center） |
+| 路由 `/multitable/templates` 与现有 `/multitable/:sheetId/:viewId` 冲突 | 极低 | 字面量路由优先于参数路由（Vue Router 4 默认顺序）；platform-shell-nav.spec.ts 增加保护断言 |
+| H3 新模板 install 后字段类型 / 视图类型不匹配 | 低 | 每个 H3 模板手测安装一次；参考已 production-proven 的 `project-tracker` 结构 |
+| 分类 tab 数量增长（H3 后 7+ 类）UI 溢出 | 极低 | tab 横向滚动 / wrap；CSS `overflow-x: auto` |
+| category 翻译表 fallback 失败 | 极低 | 未命中翻译时直接显示原英文字符串，永不失败 |
+
+---
+
+## 8. Assumptions
+
+- 使用普通 branch，不开 worktree
+- H2 不加后端 API、DB 表、migration、OpenAPI 契约
+- H3 沿用静态模板库（`template-library.ts`），因当前 codebase **无** `multitable_templates` DB 表使用
+- Spreadsheets 仍为附属能力，**不**在 H2/H3 范围
+- Phase C `/grid` route removal 等已文档化的观察窗口（见 #1646），**不**与 H2/H3 捆绑
+- K3 / `plugin-integration-core` / Data Factory 路径全程不动
+- 现有 3 个模板的 `id` / `category` / 结构字段全部保持不变（H3 acceptance scenarios 守护）
+
+---
+
+## 9. 推荐执行顺序
+
+1. **审本 development MD**（你现在做的）
+2. 审过 → 起 H2 实现 commits（按 §3.1 / §3.2 文件清单）
+3. H2 实现完 → 写 verification MD（`multitable-template-center-h2-verification-20260518.md`）
+4. H2 PR 走 CI + self-review → admin-merge
+5. H2 merge 后立即起 H3 分支（独立 PR）
+6. H3 写 H3-development MD → 实现 → 写 H3-verification MD → CI + self-review → merge
+
+---
+
+## 10. 附录：Scout 报告原文
+
+### 10.1 H1 已 ship 的 surface（`MultitableHomeView.vue`）
+
+| 元素 | 现状 |
+|---|---|
+| Hero + 创建新 Base 表单 + 创建并打开 | ✅ |
+| Base 列表 + 搜索 + 收藏 + 最近打开 | ✅ |
+| **模板快速开始** section（template grid + install + redirect 全流程） | ✅ |
+| `installTemplateAndOpen()` | ✅ POST install → 用返回的 base/sheet/view `router.push` |
+
+### 10.2 Workbench template library（`MultitableWorkbench.vue:64-91`）
+
+- ✅ 顶部 "📁 Templates" 按钮 + modal + grid + install + redirect
+- ❌ 无分类导航 / 搜索（**不在 H2 修复范围**，仅 swap card + 加 footer link）
+
+### 10.3 后端 API（全部就绪）
+
+| 路由 | 文件位置 |
+|---|---|
+| `GET /api/multitable/templates` | `packages/core-backend/src/routes/univer-meta.ts:3163` |
+| `POST /api/multitable/templates/:templateId/install` | `packages/core-backend/src/routes/univer-meta.ts:3167` |
+| `listMultitableTemplates()` 静态数据源 | `packages/core-backend/src/multitable/template-library.ts:229` |
+
+### 10.4 现有 3 个模板
+
+| ID | Category | Sheets | 测试用途 |
+|---|---|---|---|
+| `project-tracker` | `Project management` | 1 (Tasks) | H3 acceptance "existing behavior unchanged" 基准 |
+| `sales-crm` | `Sales` | 1 (Deals) | 同上；**不**重命名 category 为 CRM |
+| `issue-tracker` | `Engineering` | 1 (Issues) | 同上 |
+
+### 10.5 路由与 DB
+
+- ❌ `/multitable/templates` 路由**不存在**（H2 新增）
+- migration `042d_plugins_and_templates.sql` 仅创建 `plugin_manifests` / `plugin_dependencies`，**多维表模板不走数据库**
+
+---
+
+## 11. 变更日志
+
+- **2026-05-18 (1)** 初稿 `multitable-template-center-design-20260518.md`
+- **2026-05-18 (2)** 评审修订 8 处（Workbench 不抽 composable、memory 路径替换、H3 category 不重命名、AppRouteParams 补 typing、MetaTemplateCard 纯展示、测试 spec 拆分、Workbench 最小改动、验证命令格式）
+- **2026-05-18 (3)** 融合 zensgit 的开发计划版本，重命名为 `multitable-template-center-h2-development-20260518.md`：
+  - 顶层结构对齐 repo PR 模板风格（Summary / Key Changes / Deliverables / Test Plan / Assumptions）
+  - 命名对齐 repo `*-development-*.md` / `*-verification-*.md` 惯例
+  - H3 模板数 4 → 5（加 `meeting-minutes`），并加质量门（≥5 字段 ≤8、≥2 views 含 grid + 业务视图）
+  - 搜索字段从 name/description 扩展到 name/description/category 三字段
+  - 状态分支明确列出（空 / 加载 / 错误 / 安装中）
+  - 新增 `apps/web/src/multitable/utils/category-labels.ts` 翻译映射文件，解决"CRM 显示语义 vs Sales 数据稳定"的矛盾
+  - 加 Assumptions section
+  - Acceptance scenarios 改为 bullet list（便于 PR description 复用）
+  - 验证命令统一为 `pnpm --filter @metasheet/web exec vitest run ... --watch=false` 格式

--- a/docs/development/multitable-template-center-h2-development-20260518.md
+++ b/docs/development/multitable-template-center-h2-development-20260518.md
@@ -85,7 +85,9 @@ router.push({
 - **纯数据 PR**，无新代码逻辑
 - 不加 DB 表 / migration
 
-#### 5 个新模板（与目标 6 类对齐）
+#### 5 个新模板（覆盖业务常见场景）
+
+> **Category 命名说明**：data-layer `Category` 字符串保持英文（与现有 `Project management` / `Sales` / `Engineering` 风格一致），UI 显示中文标签通过 `category-labels.ts` 翻译表实现。**不**新增 `CRM` 这个 data-layer category 值；`sales-crm` 的 `Sales` 保持不动，"CRM" 仅作为 UI 显示标签。
 
 | 模板 ID | Category (data layer) | 中文 UI 标签 | Sheets |
 |---|---|---|---|
@@ -142,7 +144,7 @@ H2 页面的分类聚合是**从返回数据动态读取**，新加的 category 
 | 文件 | 改动 |
 |---|---|
 | `apps/web/src/router/appRoutes.ts` | 加 `/multitable/templates` 路由项（component lazy import） |
-| `apps/web/src/router/types.ts` | **三处同步补齐**：(1) `AppRouteNames.MULTITABLE_TEMPLATES`；(2) `ROUTE_PATHS.MULTITABLE_TEMPLATES`；(3) `AppRouteParams['multitable-templates']: Record<string, never>` —— 与现有 typing 风格一致 |
+| `apps/web/src/router/types.ts` | **四处同步补齐**：(1) `AppRouteNames.MULTITABLE_TEMPLATES`；(2) `ROUTE_PATHS.MULTITABLE_TEMPLATES`；(3) `AppRouteParams['multitable-templates']: Record<string, never>`；(4) `AppRouteQuery['multitable-templates']: Record<string, never>` —— 与现有 typing 风格一致（虽然 query 有 index signature 默认兜底，显式补齐更一致） |
 | `apps/web/src/views/MultitableHomeView.vue` | 模板 section 标题旁加 "查看全部模板 →" 链接；卡片渲染改用 `<MetaTemplateCard>`；安装逻辑改走 `useTemplateInstall` composable |
 | `apps/web/src/multitable/views/MultitableWorkbench.vue` | **仅最小改动**：modal 卡片改用 `<MetaTemplateCard>` + 加 footer link；`onInstallTemplate` 完全不动 |
 
@@ -162,6 +164,9 @@ MULTITABLE_TEMPLATES: 'multitable-templates'
 ROUTE_PATHS.MULTITABLE_TEMPLATES: '/multitable/templates'
 
 // AppRouteParams 加
+'multitable-templates': Record<string, never>
+
+// AppRouteQuery 加（与现有 typing 风格一致；index signature 默认兜底，显式补齐）
 'multitable-templates': Record<string, never>
 
 // apps/web/src/router/appRoutes.ts 新增（放在 MULTITABLE_HOME 之后）
@@ -361,7 +366,7 @@ git diff --check origin/main..HEAD
 
 ### 10.2 Workbench template library（`MultitableWorkbench.vue:64-91`）
 
-- ✅ 顶部 "📁 Templates" 按钮 + modal + grid + install + redirect
+- ✅ 顶部 "📁 Templates" 按钮 + modal + grid + **install + context sync 闭环**（区别于 Home / Center 的 install + router.push；Workbench 走 `confirmDiscardContextChanges → workbench.client.installTemplate → workbench.syncExternalContext → showSuccess`）
 - ❌ 无分类导航 / 搜索（**不在 H2 修复范围**，仅 swap card + 加 footer link）
 
 ### 10.3 后端 API（全部就绪）
@@ -391,6 +396,10 @@ git diff --check origin/main..HEAD
 
 - **2026-05-18 (1)** 初稿 `multitable-template-center-design-20260518.md`
 - **2026-05-18 (2)** 评审修订 8 处（Workbench 不抽 composable、memory 路径替换、H3 category 不重命名、AppRouteParams 补 typing、MetaTemplateCard 纯展示、测试 spec 拆分、Workbench 最小改动、验证命令格式）
+- **2026-05-18 (4)** 第二轮评审 3 处小修：
+  - §10.2 Workbench 描述纠正：从 "install + redirect" → "install + context sync 闭环"（区别于 Home/Center 的 router.push 路径）
+  - §2.2 (5 个新模板) 标题"6 类对齐"改为"覆盖业务常见场景"，并加 Category 命名说明强调 data-layer 不新增 `CRM`，仅 UI 翻译显示
+  - §3.2 + §3.4 路由 typing 补齐 `AppRouteQuery['multitable-templates']: Record<string, never>`，与 AppRouteParams 对称
 - **2026-05-18 (3)** 融合 zensgit 的开发计划版本，重命名为 `multitable-template-center-h2-development-20260518.md`：
   - 顶层结构对齐 repo PR 模板风格（Summary / Key Changes / Deliverables / Test Plan / Assumptions）
   - 命名对齐 repo `*-development-*.md` / `*-verification-*.md` 惯例


### PR DESCRIPTION
## Summary

Phase H2 of the [views consolidation plan](https://github.com/zensgit/metasheet2/blob/main/docs/development/views-consolidation-multitable-spreadsheets-plan-20260517.md) — adds a dedicated multitable template center as the next \"对标飞书\" upstream UX after H1's home page, completing the home → templates → install → new base loop.

- New route \`/multitable/templates\` rendering \`MultitableTemplateCenterView.vue\`.
- New \`MetaTemplateCard\` pure presentational component shared by Home, Workbench modal, and the new view.
- New \`useTemplateInstall\` composable shared by Home + Template Center (Workbench install lifecycle stays untouched).
- New \`category-labels.ts\` translation map letting UI display \"CRM\" while the data-layer category stays \`Sales\` — no rename of existing \`sales-crm\` data.
- Home view gets a \"查看全部模板 →\" link in the template section header.
- Workbench template-library modal gets a footer \"更多模板 →\" link to the new center.

H3 (industry template seed extension) is in a separate follow-up PR per the development plan §4.2.

## Key Changes

### Route + types

- \`apps/web/src/router/types.ts\` — \`AppRouteNames.MULTITABLE_TEMPLATES\`, \`ROUTE_PATHS.MULTITABLE_TEMPLATES\`, \`AppRouteParams['multitable-templates']\`, \`AppRouteQuery['multitable-templates']\` (four-way typing parity).
- \`apps/web/src/router/appRoutes.ts\` — \`/multitable/templates\` registered as a lazy-loaded route, placed before the \`:sheetId/:viewId\` dynamic multitable route so the literal path wins.

### New files

- \`apps/web/src/views/MultitableTemplateCenterView.vue\` (~358 LoC) — hero, dynamic category tabs (no hard-coded category list), search (name / description / raw category / translated category), template grid, four state branches (loading / error+retry / empty / filtered-empty), per-card installing state.
- \`apps/web/src/multitable/components/MetaTemplateCard.vue\` (~136 LoC) — props \`{ template, installing }\`, emit \`install\`; no \`useRouter\` / \`multitableClient\` imports so business side effects stay in the parent.
- \`apps/web/src/multitable/composables/useTemplateInstall.ts\` (~66 LoC) — \`installAndOpen\` returns a discriminated outcome (\`installed-and-opened\` / \`installed-no-view\` / \`failed\`); Workbench is intentionally NOT a consumer because its \`syncExternalContext\` lifecycle differs from Home/Center's \`router.push\`.
- \`apps/web/src/multitable/utils/category-labels.ts\` (~26 LoC) — English data-layer → Chinese UI label map with safe fallback.

### Modified files

- \`apps/web/src/views/MultitableHomeView.vue\` — template card markup replaced with \`<MetaTemplateCard>\`; install path moved to \`useTemplateInstall\` + thin \`installAndRemember\` wrapper that preserves Home-specific side effects (\`rememberRecentBaseOpen\`, no-view loadBases refresh); separate \`installError\` banner; \"查看全部模板\" router-link added.
- \`apps/web/src/multitable/views/MultitableWorkbench.vue\` — modal card markup replaced with \`<MetaTemplateCard>\`; footer \"更多模板 →\" router-link added; \`onInstallTemplate\` and its \`confirmDiscardContextChanges → syncExternalContext → showSuccess\` lifecycle **completely untouched**.

### Tests

- \`apps/web/tests/multitable-template-center-view.spec.ts\` (new, 9 tests, all pass) — initial load, card rendering, category filter (incl. translated CRM tab matching \`Sales\`), search across name/description/category (raw + translated), install success → navigate, install failure → no navigation, load failure with retry, empty + filtered-empty states, hero back-to-home link.
- \`apps/web/tests/multitable-home-view.spec.ts\` — card metric assertion bumped to \"1 个 Sheet · 0 个字段 · 2 个视图\" matching \`MetaTemplateCard\`'s 3-metric format; new test asserts the \"查看全部模板\" link with href to \`MULTITABLE_TEMPLATES\`; mountView gains a router-link stub.

## Verification

- \`pnpm --filter @metasheet/web build\` — clean, 6.23s.
- \`pnpm --filter @metasheet/web exec vue-tsc --noEmit\` — clean.
- \`pnpm --filter @metasheet/web exec vitest run tests/multitable-template-center-view.spec.ts --watch=false\` — 9/9.
- \`pnpm --filter @metasheet/web exec vitest run tests/platform-shell-nav.spec.ts --watch=false\` — 5/5 (regression check).
- \`git diff --check origin/main..HEAD\` — clean.
- Full \`pnpm --filter @metasheet/web test\` ledger: 217 failed / 2212 passed (vs Phase B's 216 / 2196 — net **+16 passing**, **+1 failing**). The +1 failure is the new home-view \"查看全部模板\" link assertion which triggers the same pre-existing \`afterEach localStorage TypeError\` baseline issue that already fails 6 of the home-view spec's existing tests; the test body's assertions themselves pass.

## Scope guard

- No \`plugins/plugin-integration-core/*\` change.
- No \`lib/adapters/k3-wise-*\` change.
- No \`/api/multitable/*\` backend contract change (only the existing \`GET /api/multitable/templates\` + \`POST /api/multitable/templates/:id/install\` consumed).
- No \`/api/spreadsheets/*\` change.
- No DB migration / schema change.
- Workbench install lifecycle untouched (only card UI + footer link swap inside the modal).
- Existing \`sales-crm\` template's data-layer \`category: 'Sales'\` preserved unchanged — \"CRM\" is a UI-only translated label via \`category-labels.ts\`.

## Development plan reference

See \`docs/development/multitable-template-center-h2-development-20260518.md\` (committed in this branch) for the full design, scope decisions (incl. Workbench non-coupling, Sales/CRM split, AppRouteQuery typing parity), risk register, and H3 outline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)