### PR TITLE
docs(attendance): record staging report-records sync evidence

### DIFF
--- a/docs/development/attendance-report-records-bulk-sync-live-closeout-development-20260519.md
+++ b/docs/development/attendance-report-records-bulk-sync-live-closeout-development-20260519.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-本 slice 不新增功能代码，只收口 `attendance_report_records` 批量同步 PR #1648 的部署与 live evidence 状态，并修正 TODO 文档中残留的旧范围表述。
+本 slice 不新增功能代码，只收口 `attendance_report_records` 批量同步 PR #1648 的部署与 live evidence 状态，并修正 TODO 文档中残留的旧范围表述。2026-05-19 追加 staging runtime 更新和 live sync 实测证据。
 
 PR #1648 已将 `POST /api/attendance/report-records/sync` 从单员工 v1 扩展为：
 
@@ -41,19 +41,45 @@ metasheet-backend ghcr.io/zensgit/metasheet2-backend:2f211d161a301bc632165f9909b
 - #1648 的 deploy 已经在 production 确认。
 - allUsers/pageSize 是写入派生多维表的管理员动作，即使是可重建报表层，也不应在 production 上无明确样本授权地触发。
 
-尝试 staging live 前置时发现：
+初次尝试 staging live 前置时发现：
 
 - 8082 SSH tunnel 可达，`/api/health` 正常。
 - 当前 staging backend 仍运行旧镜像 `5ca91630307603eacbbb13ae8209721f1b4d5bf3`，早于 #1648。
 - 本地 staging admin JWT 文件已过期，`/api/auth/me` 返回 401。
 
-因此 staging allUsers/pageSize live sync 暂不可真实执行。该状态写入 verification MD，不伪造通过。
+该状态先写入 verification MD，未伪造通过。
 
-## Next Step
+## Staging Runtime Update
 
-若要补真实 live sync evidence，需要先满足：
+后续收到新的短期 staging admin JWT，并被明确授权更新 staging 后，执行了 staging runtime 更新：
 
-1. 将 staging backend 更新到包含 #1648 的镜像，或提供一个已更新的测试环境。
-2. 生成新的短期 staging admin JWT 文件。
-3. 使用小 pageSize（建议 `pageSize=1`）触发 `allUsers` 分页 sync。
-4. 核对 `attendance_report_records` 中的 `field_fingerprint`、`source_fingerprint`、`synced_at` 和 row count。
+- 尝试拉取最新 `origin/main` docs-only SHA `55f0c949...` 的 GHCR backend/web 镜像，结果为 `manifest unknown`。
+- 选择最新可用 runtime main 镜像 `01d4134017febcdac5a95f6ce8898e66a81aa9aa`，该 SHA 是 `55f0c949...` 的祖先且包含 #1648。
+- 更新 `/home/mainuser/metasheet2-dingtalk-staging/.env` 的 `IMAGE_TAG`。
+- `docker compose pull backend web` 成功。
+- 常规 `docker compose up -d backend web` 触发历史 Postgres/Redis 容器名冲突；随后使用 `up -d --no-deps backend web` 仅重建 web/backend，避免触碰 DB/Redis。
+
+更新后 staging 容器：
+
+```text
+metasheet-staging-web ghcr.io/zensgit/metasheet2-web:01d4134017febcdac5a95f6ce8898e66a81aa9aa
+metasheet-staging-backend ghcr.io/zensgit/metasheet2-backend:01d4134017febcdac5a95f6ce8898e66a81aa9aa
+```
+
+## Live Sync Result
+
+使用 staging 上已有的真实 fixture：
+
+- `orgId=default`
+- `userId=8b35cbe1-9fd6-4650-9d16-42b2c4d028d1`
+- `from=2026-05-15`
+- `to=2026-05-17`
+
+结果：
+
+- 首次 sync：`synced=3`、`patched=3`、`failed=0`、`duplicateRowKeys=0`
+- 多维表读回：3 行、3 个 distinct row key、`field_fingerprint`/`source_fingerprint`/`synced_at` 全部存在
+- 值核对：三天分别为 `480/12/0/late`、`450/0/30/early_leave`、`0/0/0/absent`
+- 重跑：`skipped=3`、`created=0`、`patched=0`、`failed=0`
+
+`allUsers` 分页入口也执行了一次，返回 `ok=true`、`userSelection=allUsers`、`totalUsers=0`。这是 staging 环境事实：`user_orgs` 当前为空表，因此无法形成 active-membership bulk write 样本；该限制已在 verification MD 中明确标注。

--- a/docs/development/attendance-report-records-bulk-sync-live-closeout-verification-20260519.md
+++ b/docs/development/attendance-report-records-bulk-sync-live-closeout-verification-20260519.md
@@ -2,11 +2,12 @@
 
 ## Scope
 
-验证 PR #1648 的 post-merge 状态：
+验证 PR #1648 的 post-merge 和 staging live 状态：
 
 - PR 已合并到 `main`。
 - production deploy 已包含 #1648。
-- staging live sync 是否具备执行条件。
+- staging 是否已更新到包含 #1648 的 runtime 镜像。
+- staging live sync 是否可真实执行、读回和幂等。
 - TODO 文档是否从旧的 single-user v1 口径更新为 bulk-sync 已完成口径。
 
 ## Verification Matrix
@@ -17,10 +18,15 @@
 | `origin/main` contains #1648 | PASS: `2f211d161 feat(attendance): add bulk report-records sync (#1648)` |
 | Deploy to Production | PASS: run `26069092327`, conclusion `success`, head SHA `2f211d161a301bc632165f9909b604cc05e5559a` |
 | Production backend image | PASS: `ghcr.io/zensgit/metasheet2-backend:2f211d161a301bc632165f9909b604cc05e5559a` |
+| Latest `origin/main` image pull | EXPECTED MISS: `55f0c949...` is docs-only; GHCR runtime image was not published for this SHA |
+| Staging runtime update | PASS: staging web/backend updated from `5ca91630307603eacbbb13ae8209721f1b4d5bf3` to `01d4134017febcdac5a95f6ce8898e66a81aa9aa` |
+| Runtime ancestry | PASS: `01d413401...` contains #1648 (`2f211d161...`) and is the latest available runtime image before docs-only #1650 |
 | Staging tunnel | PASS: local `8082` reached staging `/api/health` |
-| Staging backend image | BLOCKED: staging still runs `5ca91630307603eacbbb13ae8209721f1b4d5bf3`, which predates #1648 |
-| Staging admin JWT | BLOCKED: local JWT file is expired; `/api/auth/me` returns 401 |
-| Staging allUsers/pageSize sync | NOT RUN: blocked by stale staging image and expired JWT |
+| Staging admin JWT | PASS: `/api/auth/me` returned success with the short-lived file token; token value was not printed |
+| Explicit user sync | PASS: 3 rows patched, 0 failed, 0 duplicate row keys |
+| Multitable readback | PASS: 3 rows, 3 distinct row keys, fingerprints and `synced_at` present, values matched fixture |
+| Idempotent rerun | PASS: 3 rows skipped, 0 created, 0 patched, 0 failed |
+| Staging allUsers/pageSize sync | PASS-BY-ENV: endpoint accepted `{allUsers:true,page,pageSize}` and returned an empty page because staging `user_orgs` has 0 active memberships |
 | `git diff --check` | PASS |
 
 ## Commands
@@ -54,9 +60,21 @@ curl -sS -H "Authorization: Bearer ${AUTH_TOKEN}" http://localhost:8082/api/auth
 
 The JWT value was not printed or committed.
 
-## Future Live Sync Procedure
+Staging runtime update:
 
-Once staging is updated to an image containing #1648 and a fresh admin JWT exists:
+```bash
+ssh -i ~/.ssh/metasheet2_deploy mainuser@142.171.239.56
+cd /home/mainuser/metasheet2-dingtalk-staging
+
+# IMAGE_TAG was updated to the latest available runtime main image:
+# 01d4134017febcdac5a95f6ce8898e66a81aa9aa
+docker compose -f docker-compose.app.staging.yml pull backend web
+docker compose -f docker-compose.app.staging.yml up -d --no-deps backend web
+```
+
+`--no-deps` was required because the long-running staging Postgres/Redis containers have historical generated names; backend/web were recreated without touching DB/Redis.
+
+Explicit sync:
 
 ```bash
 API_BASE=http://localhost:8082
@@ -65,18 +83,87 @@ AUTH_TOKEN="$(cat /tmp/<staging-admin-jwt-file>.jwt)"
 curl -sS -X POST "${API_BASE}/api/attendance/report-records/sync" \
   -H "Authorization: Bearer ${AUTH_TOKEN}" \
   -H "Content-Type: application/json" \
-  --data '{"from":"2026-05-01","to":"2026-05-31","allUsers":true,"page":1,"pageSize":1}'
+  --data '{"from":"2026-05-15","to":"2026-05-17","userId":"8b35cbe1-9fd6-4650-9d16-42b2c4d028d1"}'
 ```
 
-Expected evidence to capture:
+All-users pagination probe:
 
-- `usersScanned=1`
-- `totalUsers >= 1` when staging has active org users
-- `multitable.objectId=attendance_report_records`
-- `fieldFingerprint` present
-- `syncedAt` present
-- Matching row in `attendance_report_records` with `field_fingerprint`, `source_fingerprint`, and `synced_at`
+```bash
+curl -sS -X POST "${API_BASE}/api/attendance/report-records/sync?orgId=default" \
+  -H "Authorization: Bearer ${AUTH_TOKEN}" \
+  -H "Content-Type: application/json" \
+  --data '{"from":"2026-05-15","to":"2026-05-17","allUsers":true,"page":1,"pageSize":5}'
+```
 
-## Conclusion
+## Live Evidence
 
-#1648 is merged and deployed to production. The live staging sync remains pending because the staging backend image and JWT are not ready. This is an environment blocker, not a code failure.
+Explicit sync response:
+
+```text
+ok=true
+synced=3
+rowsSynced=3
+created=0
+patched=3
+skipped=0
+failed=0
+duplicateRowKeys=0
+fieldFingerprint=684233f9c36205f9ea59248b29f9d050f88af0cd
+syncedAt=2026-05-19T01:18:37.338Z
+projectId=default:attendance
+objectId=attendance_report_records
+sheetId=sheet_90fd4bdebbaabe12b76556bf
+viewId=view_f764653146213b44d955d2b1
+```
+
+Readback from `attendance_report_records`:
+
+```text
+row_count=3
+distinct_row_keys=3
+rows_with_field_fingerprint=3
+rows_with_source_fingerprint=3
+rows_with_synced_at=3
+
+2026-05-15 work_minutes=480 late_minutes=12 early_leave_minutes=0 status=late
+2026-05-16 work_minutes=450 late_minutes=0 early_leave_minutes=30 status=early_leave
+2026-05-17 work_minutes=0 late_minutes=0 early_leave_minutes=0 status=absent
+```
+
+Idempotent rerun:
+
+```text
+ok=true
+synced=3
+rowsSynced=3
+created=0
+patched=0
+skipped=3
+failed=0
+duplicateRowKeys=0
+fieldFingerprint=684233f9c36205f9ea59248b29f9d050f88af0cd
+```
+
+All-users pagination probe:
+
+```text
+ok=true
+userSelection=allUsers
+totalUsers=0
+page=1
+pageSize=5
+hasNextPage=false
+usersScanned=0
+synced=0
+```
+
+The empty all-users result is an environment fact: staging `user_orgs` currently has 0 rows. It verifies the bulk endpoint path accepts paging parameters, but not an active-membership bulk write. The explicit user sync above verifies the report-records writer against real staging attendance rows.
+
+## Boundaries
+
+- The short-lived JWT was read from a local file and not printed.
+- Production was not written by this verification.
+- Staging DB/Redis were not recreated during image update.
+- The attendance plugin still writes report-records only through the multitable API; the DB readback above was verification-only.
+
+#1648 is merged, deployed to production, and verified on staging after updating staging to the latest available main runtime image. The report-records writer successfully patched real staging rows, readback matched the fixture, and rerun skipped all rows by fingerprint. The only remaining gap is an active-membership `allUsers` bulk-write sample; current staging has no `user_orgs` memberships, so the all-users path returned an honest empty page.

--- a/docs/development/attendance-report-records-sync-todo-20260515.md
+++ b/docs/development/attendance-report-records-sync-todo-20260515.md
@@ -194,3 +194,5 @@ skip  iff  existing.source_fingerprint === next.source_fingerprint
 - [x] `allUsers` 分页同步入口 + page/pageSize 汇总
 - [x] 前端单员工/全员分页模式切换
 - [x] development / verification MD：`attendance-report-records-bulk-sync-development-20260518.md`、`attendance-report-records-bulk-sync-verification-20260518.md`
+- [x] staging runtime 更新 + live explicit sync/readback/rerun skip evidence：见 `attendance-report-records-bulk-sync-live-closeout-development-20260519.md`、`attendance-report-records-bulk-sync-live-closeout-verification-20260519.md`
+- [ ] active-membership `allUsers` bulk write evidence：当前 staging `user_orgs` 为空，`allUsers` 分页返回空页；待 staging 准备 active membership 样本后补


### PR DESCRIPTION
## Summary

Records the post-update staging evidence for attendance report-records sync:

- staging web/backend moved from the old 5ca916 runtime to the latest available main runtime image 01d413, which contains #1648
- explicit staging sync patched 3 real attendance report rows, then rerun skipped all 3 by fingerprint
- multitable readback verified 3 distinct row keys plus field/source fingerprints and synced_at
- allUsers pagination was probed and returned an honest empty page because staging user_orgs currently has 0 active memberships

## Verification

- staging /api/health: PASS
- staging /api/auth/me with short-lived file JWT: PASS, token not printed
- POST /api/attendance/report-records/sync?orgId=default explicit user: PASS, patched=3 failed=0
- readback from attendance_report_records: PASS, values matched fixture
- rerun same sync: PASS, skipped=3
- allUsers/page/pageSize probe: PASS-BY-ENV, totalUsers=0 due empty user_orgs
- git diff --check: PASS

No code changes, no migration, and no production write.