### PR TITLE
docs(attendance): record all-users report-records sync evidence

### DIFF
--- a/docs/development/attendance-report-records-bulk-sync-live-closeout-development-20260519.md
+++ b/docs/development/attendance-report-records-bulk-sync-live-closeout-development-20260519.md
@@ -82,4 +82,28 @@ metasheet-staging-backend ghcr.io/zensgit/metasheet2-backend:01d4134017febcdac5a
 - 值核对：三天分别为 `480/12/0/late`、`450/0/30/early_leave`、`0/0/0/absent`
 - 重跑：`skipped=3`、`created=0`、`patched=0`、`failed=0`
 
-`allUsers` 分页入口也执行了一次，返回 `ok=true`、`userSelection=allUsers`、`totalUsers=0`。这是 staging 环境事实：`user_orgs` 当前为空表，因此无法形成 active-membership bulk write 样本；该限制已在 verification MD 中明确标注。
+`allUsers` 分页入口也执行了一次，返回 `ok=true`、`userSelection=allUsers`、`totalUsers=0`。这是 staging 环境事实：`user_orgs` 当前为空表，因此第一次只能证明分页入口接受参数，不能证明 active membership 写入路径。
+
+## Active-Membership Bulk Evidence
+
+随后补充一个 staging-only 临时 membership fixture：
+
+- 插入 `user_orgs(default, 8b35cbe1-9fd6-4650-9d16-42b2c4d028d1, true)`
+- 执行 `POST /api/attendance/report-records/sync?orgId=default`
+- body `{ from: '2026-05-15', to: '2026-05-17', allUsers: true, page: 1, pageSize: 5 }`
+- 清理临时 `user_orgs` 行，确认 staging membership state 回到 0
+
+结果：
+
+- `userSelection=allUsers`
+- `totalUsers=1`
+- `usersScanned=1`
+- `usersSynced=1`
+- `synced=3`
+- `created=0`
+- `patched=0`
+- `skipped=3`
+- `failed=0`
+- `duplicateRowKeys=0`
+
+这证明 #1648 的 active-membership bulk branch 可以真实扫描用户、调用 report-records writer，并复用双 fingerprint 幂等 skip。临时 membership 已删除，只保留可重建的 report-records 派生行。

--- a/docs/development/attendance-report-records-bulk-sync-live-closeout-verification-20260519.md
+++ b/docs/development/attendance-report-records-bulk-sync-live-closeout-verification-20260519.md
@@ -26,7 +26,8 @@
 | Explicit user sync | PASS: 3 rows patched, 0 failed, 0 duplicate row keys |
 | Multitable readback | PASS: 3 rows, 3 distinct row keys, fingerprints and `synced_at` present, values matched fixture |
 | Idempotent rerun | PASS: 3 rows skipped, 0 created, 0 patched, 0 failed |
-| Staging allUsers/pageSize sync | PASS-BY-ENV: endpoint accepted `{allUsers:true,page,pageSize}` and returned an empty page because staging `user_orgs` has 0 active memberships |
+| Staging allUsers/pageSize sync | PASS: temporary active membership fixture scanned 1 user and synced 3 rows via `{allUsers:true,page,pageSize}` |
+| Staging fixture cleanup | PASS: temporary `user_orgs` membership was removed after evidence; staging returned to 0 memberships |
 | `git diff --check` | PASS |
 
 ## Commands
@@ -157,13 +158,55 @@ usersScanned=0
 synced=0
 ```
 
-The empty all-users result is an environment fact: staging `user_orgs` currently has 0 rows. It verifies the bulk endpoint path accepts paging parameters, but not an active-membership bulk write. The explicit user sync above verifies the report-records writer against real staging attendance rows.
+The first all-users probe was an environment fact: staging `user_orgs` initially had 0 rows. It verified the bulk endpoint path accepted paging parameters, but not an active-membership bulk write.
+
+Active-membership all-users probe:
+
+```text
+temporary membership inserted:
+user_orgs_count=1
+org_id=default
+user_id=8b35cbe1-9fd6-4650-9d16-42b2c4d028d1
+is_active=true
+
+sync response:
+ok=true
+userSelection=allUsers
+totalUsers=1
+page=1
+pageSize=5
+hasNextPage=false
+usersScanned=1
+usersSynced=1
+usersFailed=0
+synced=3
+rowsSynced=3
+created=0
+patched=0
+skipped=3
+failed=0
+duplicateRowKeys=0
+fieldFingerprint=684233f9c36205f9ea59248b29f9d050f88af0cd
+syncedAt=2026-05-19T02:00:40.699Z
+projectId=default:attendance
+objectId=attendance_report_records
+sheetId=sheet_90fd4bdebbaabe12b76556bf
+viewId=view_f764653146213b44d955d2b1
+
+cleanup:
+deleted_memberships=1
+user_orgs_count=0
+report_record_rows_for_sample_user=3
+```
+
+This proves the active-membership all-users branch scans users, delegates to the same report-records writer, and preserves fingerprint idempotency. The temporary membership was removed after the probe so staging membership state returned to its original empty state.
 
 ## Boundaries
 
 - The short-lived JWT was read from a local file and not printed.
 - Production was not written by this verification.
 - Staging DB/Redis were not recreated during image update.
+- The active-membership fixture was temporary and was removed after the all-users probe.
 - The attendance plugin still writes report-records only through the multitable API; the DB readback above was verification-only.
 
-#1648 is merged, deployed to production, and verified on staging after updating staging to the latest available main runtime image. The report-records writer successfully patched real staging rows, readback matched the fixture, and rerun skipped all rows by fingerprint. The only remaining gap is an active-membership `allUsers` bulk-write sample; current staging has no `user_orgs` memberships, so the all-users path returned an honest empty page.
+#1648 is merged, deployed to production, and verified on staging after updating staging to the latest available main runtime image. The report-records writer successfully patched real staging rows, readback matched the fixture, rerun skipped all rows by fingerprint, and the active-membership `allUsers` path scanned 1 user and synced 3 rows with `skipped=3`.

--- a/docs/development/attendance-report-records-sync-todo-20260515.md
+++ b/docs/development/attendance-report-records-sync-todo-20260515.md
@@ -195,4 +195,4 @@ skip  iff  existing.source_fingerprint === next.source_fingerprint
 - [x] 前端单员工/全员分页模式切换
 - [x] development / verification MD：`attendance-report-records-bulk-sync-development-20260518.md`、`attendance-report-records-bulk-sync-verification-20260518.md`
 - [x] staging runtime 更新 + live explicit sync/readback/rerun skip evidence：见 `attendance-report-records-bulk-sync-live-closeout-development-20260519.md`、`attendance-report-records-bulk-sync-live-closeout-verification-20260519.md`
-- [ ] active-membership `allUsers` bulk write evidence：当前 staging `user_orgs` 为空，`allUsers` 分页返回空页；待 staging 准备 active membership 样本后补
+- [x] active-membership `allUsers` bulk write evidence：staging-only 临时 `user_orgs` fixture 扫描 1 个用户、同步 3 行、双 fingerprint skip 3 行，fixture 已清理；见 live closeout verification MD


### PR DESCRIPTION
## Summary

Completes the remaining live evidence gap for attendance report-records bulk sync:

- inserted a temporary staging-only active user_orgs membership for the existing sample attendance user
- ran POST /api/attendance/report-records/sync?orgId=default with allUsers=true,page=1,pageSize=5
- verified usersScanned=1, usersSynced=1, synced=3, skipped=3, failed=0, duplicateRowKeys=0
- removed the temporary membership and confirmed staging user_orgs returned to 0 rows
- updated the closeout development/verification docs and checked the TODO item

## Verification

- staging /api/health: PASS
- staging /api/auth/me with short-lived file JWT: PASS, token not printed
- active-membership allUsers sync: PASS
- fixture cleanup: PASS
- git diff --check: PASS

No code changes, no migrations, no production write.