### PR TITLE
fix(data-factory): alias staging physical fields for dry-run

### DIFF
--- a/docs/development/data-factory-staging-field-alias-design-20260519.md
+++ b/docs/development/data-factory-staging-field-alias-design-20260519.md
@@ -1,0 +1,73 @@
+# Data Factory staging field alias design - 2026-05-19
+
+## Purpose
+
+Close the #1526 P0 gap where Data Factory Workbench presents staging fields as logical names
+such as `code`, `name`, and `uom`, while the multitable record reader returns provisioned
+physical field IDs such as `fld_*`.
+
+The symptom on the bridge machine was:
+
+- `Standard Materials` multitable contained a sample row.
+- Workbench saved a `standard_materials -> material` pipeline with logical mappings.
+- Dry-run failed with `IDEMPOTENCY_FAILED` because the runner could not resolve the logical
+  idempotency field `code`.
+- The same pipeline worked when manually patched to use the physical field IDs, proving the
+  runner and data path were otherwise healthy.
+
+## Design
+
+The narrow fix lives in `plugins/plugin-integration-core/lib/adapters/metasheet-staging-source-adapter.cjs`.
+
+The staging source adapter now:
+
+1. Reads the staging source system `config.projectId`.
+2. Reads each configured staging object ID, for example `standard_materials`.
+3. Resolves logical field names through the host multitable provisioning API:
+   `context.api.multitable.provisioning.resolveFieldIds({ projectId, objectId, fieldIds })`.
+4. Inverts the result into a physical-to-logical alias map.
+5. When reading rows, copies physical field values into their logical aliases if the logical
+   key is absent.
+
+Example:
+
+```json
+{
+  "fld_abc123": "MAT-001"
+}
+```
+
+becomes:
+
+```json
+{
+  "fld_abc123": "MAT-001",
+  "code": "MAT-001"
+}
+```
+
+Physical keys are deliberately preserved so any temporarily patched pipeline that already uses
+physical field IDs keeps working. Logical keys are not overwritten if a record already contains
+them, which keeps manual or legacy configs stable.
+
+## Fallbacks
+
+- If the provisioning API is unavailable, behavior remains unchanged.
+- If `config.projectId` is unavailable, behavior remains unchanged.
+- Operators may provide `config.objects.<objectId>.fieldIdMap` as an explicit
+  `logicalField -> physicalField` map for diagnostic/manual systems without provisioning.
+
+## Scope
+
+Included:
+
+- MetaSheet staging source read normalization.
+- Regression tests for provisioned physical IDs and explicit `fieldIdMap`.
+
+Excluded:
+
+- SQL Server executor injection.
+- K3 WebAPI read/list runtime.
+- Relationship resolver runtime.
+- DB migrations.
+- K3 Save / Submit / Audit behavior.

--- a/docs/development/data-factory-staging-field-alias-verification-20260519.md
+++ b/docs/development/data-factory-staging-field-alias-verification-20260519.md
@@ -1,0 +1,92 @@
+# Data Factory staging field alias verification - 2026-05-19
+
+## Local verification
+
+### Focused adapter regression
+
+Command:
+
+```bash
+node plugins/plugin-integration-core/__tests__/metasheet-staging-source-adapter.test.cjs
+```
+
+Result:
+
+```text
+PASS - metasheet-staging-source-adapter: read-only multitable source tests passed
+```
+
+Covered cases:
+
+- Existing logical staging rows still read as before.
+- Provisioned physical rows such as `fld_code` are exposed as logical `code`.
+- Physical keys remain present for manually patched pipelines.
+- Existing logical keys are not overwritten by physical aliases.
+- `config.objects.<objectId>.fieldIdMap` works without a provisioning API.
+
+### Plugin integration-core regression
+
+Command:
+
+```bash
+pnpm -F plugin-integration-core test
+```
+
+Result:
+
+```text
+PASS - 23 plugin-integration-core test files completed
+```
+
+Notes:
+
+- The isolated worktree reused the already-installed root/core-backend `node_modules`
+  symlinks only for the local verification run; those symlinks were removed afterward.
+- The PoC route harness needed a test-only `deleteExternalSystem` stub so the full suite
+  matches the current `registerIntegrationRoutes()` service contract.
+
+### K3 WISE offline PoC regression
+
+Command:
+
+```bash
+pnpm verify:integration-k3wise:poc
+```
+
+Result:
+
+```text
+PASS - K3 WISE PoC mock chain verified end-to-end
+```
+
+## Expected bridge-machine retest
+
+After deploying a package that contains this change, repeat the #1526 bridge smoke path:
+
+1. Open Data Factory Workbench.
+2. Use `Standard Materials` as the MetaSheet staging source.
+3. Use K3 WISE `material` as the target template.
+4. Keep the default logical mapping:
+   - `code -> FNumber`
+   - `name -> FName`
+   - `uom -> FBaseUnitID`
+5. Keep idempotency field `code`.
+6. Save the pipeline.
+7. Run dry-run only.
+
+Expected:
+
+- No `IDEMPOTENCY_FAILED` caused by missing `code`.
+- `rowsRead` reflects the staging sample row count.
+- `rowsCleaned` advances for valid rows.
+- `rowsWritten` remains `0` during dry-run.
+- Preview still redacts secrets.
+
+## Non-goals
+
+This verification does not claim:
+
+- SQL Server source is available. `SQLSERVER_EXECUTOR_MISSING` remains separate.
+- K3 WebAPI read/list runtime is available.
+- Relationship mapping runtime is available.
+- Any real K3 write path has been executed.

--- a/plugins/plugin-integration-core/__tests__/http-routes-plm-k3wise-poc.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes-plm-k3wise-poc.test.cjs
@@ -292,6 +292,12 @@ function createExternalSystemRegistry() {
       const system = systems.get(input.id)
       return system && inScope(system, input) ? clone(system) : null
     },
+    async deleteExternalSystem(input = {}) {
+      const system = systems.get(input.id)
+      if (!system || !inScope(system, input)) return null
+      systems.delete(input.id)
+      return publicExternalSystem(system)
+    },
     async listExternalSystems(input = {}) {
       return Array.from(systems.values())
         .filter((system) => inScope(system, input))

--- a/plugins/plugin-integration-core/__tests__/metasheet-staging-source-adapter.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/metasheet-staging-source-adapter.test.cjs
@@ -10,7 +10,7 @@ const {
   createMetaSheetStagingSourceAdapter,
 } = require(path.join(__dirname, '..', 'lib', 'adapters', 'metasheet-staging-source-adapter.cjs'))
 
-function createContext({ rows = [] } = {}) {
+function createContext({ rows = [], provisioning = null } = {}) {
   const calls = []
   return {
     calls,
@@ -25,6 +25,7 @@ function createContext({ rows = [] } = {}) {
               return rows.slice(offset, offset + limit)
             },
           },
+          ...(provisioning ? { provisioning } : {}),
         },
       },
     },
@@ -120,6 +121,82 @@ async function main() {
   assert.equal(secondPage.records[0].code, 'MAT-002')
   assert.equal(secondPage.nextCursor, null)
   assert.equal(secondPage.done, true)
+
+  const fieldAliasCalls = []
+  const { context: physicalContext } = createContext({
+    rows: [
+      {
+        id: 'r3',
+        sheetId: 'sheet_materials',
+        version: 5,
+        data: {
+          fld_code: 'MAT-003',
+          fld_name: 'Screw',
+          fld_quantity: '8',
+        },
+      },
+      {
+        id: 'r4',
+        sheetId: 'sheet_materials',
+        version: 6,
+        data: {
+          code: 'MAT-004-LOGICAL',
+          fld_code: 'MAT-004-PHYSICAL',
+          fld_name: 'Washer',
+          fld_quantity: '13',
+        },
+      },
+    ],
+    provisioning: {
+      async resolveFieldIds(input) {
+        fieldAliasCalls.push(input)
+        return {
+          code: 'fld_code',
+          name: 'fld_name',
+          quantity: 'fld_quantity',
+        }
+      },
+    },
+  })
+  const physicalAdapter = createMetaSheetStagingSourceAdapter({
+    system: createSystem({ projectId: 'default:integration-core' }),
+    context: physicalContext,
+  })
+  const physicalRows = await physicalAdapter.read({ object: 'standard_materials', limit: 10 })
+  assert.equal(physicalRows.records[0].code, 'MAT-003')
+  assert.equal(physicalRows.records[0].name, 'Screw')
+  assert.equal(physicalRows.records[0].quantity, '8')
+  assert.equal(physicalRows.records[0].fld_code, 'MAT-003', 'physical field id is preserved for manually patched pipelines')
+  assert.equal(physicalRows.records[1].code, 'MAT-004-LOGICAL', 'existing logical fields are not overwritten')
+  assert.deepEqual(fieldAliasCalls, [{
+    projectId: 'default:integration-core',
+    objectId: 'standard_materials',
+    fieldIds: ['code', 'name', 'quantity'],
+  }])
+
+  const explicitMapAdapter = createMetaSheetStagingSourceAdapter({
+    system: createSystem({
+      objects: {
+        standard_materials: {
+          name: 'Standard Materials',
+          sheetId: 'sheet_materials',
+          fieldDetails: [
+            { id: 'code', name: 'Code', type: 'string' },
+          ],
+          fieldIdMap: {
+            code: 'fld_code',
+          },
+        },
+      },
+    }),
+    context: createContext({
+      rows: [
+        { id: 'r5', sheetId: 'sheet_materials', version: 1, data: { fld_code: 'MAT-005' } },
+      ],
+    }).context,
+  })
+  const explicitMapRows = await explicitMapAdapter.read({ object: 'standard_materials', limit: 1 })
+  assert.equal(explicitMapRows.records[0].code, 'MAT-005', 'explicit fieldIdMap works without provisioning API')
 
   await assert.rejects(
     () => adapter.read({ object: 'unknown', limit: 1 }),

--- a/plugins/plugin-integration-core/lib/adapters/metasheet-staging-source-adapter.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/metasheet-staging-source-adapter.cjs
@@ -48,6 +48,20 @@ function normalizeField(field) {
   }
 }
 
+function normalizeFieldIdMap(value, field) {
+  if (value === undefined || value === null) return {}
+  if (!isPlainObject(value)) {
+    throw new AdapterValidationError(`${field} must be an object`, { field })
+  }
+  const normalized = {}
+  for (const [logicalField, physicalField] of Object.entries(value)) {
+    const logical = optionalString(logicalField)
+    const physical = optionalString(physicalField)
+    if (logical && physical) normalized[logical] = physical
+  }
+  return normalized
+}
+
 function descriptorFieldsForObject(objectId) {
   const descriptor = listStagingDescriptors().find((item) => item.id === objectId)
   if (!descriptor) return []
@@ -86,6 +100,7 @@ function targetArrayToObjects(targets) {
 function normalizeObjects(config = {}) {
   const rawObjects = isPlainObject(config.objects) ? config.objects : targetArrayToObjects(config.targets)
   const objects = {}
+  const configProjectId = optionalString(config.projectId)
   for (const [objectId, objectConfig] of Object.entries(rawObjects)) {
     if (!isPlainObject(objectConfig)) {
       throw new AdapterValidationError(`config.objects.${objectId} must be an object`, {
@@ -102,7 +117,9 @@ function normalizeObjects(config = {}) {
       viewId: optionalString(objectConfig.viewId),
       baseId: optionalString(objectConfig.baseId),
       openLink: optionalString(objectConfig.openLink),
+      projectId: optionalString(objectConfig.projectId) || configProjectId,
       fields: normalizeFields(objectConfig, objectId),
+      fieldIdMap: normalizeFieldIdMap(objectConfig.fieldIdMap, `config.objects.${objectId}.fieldIdMap`),
     }
   }
   return objects
@@ -118,6 +135,69 @@ function getRecordsApi(context) {
   return recordsApi
 }
 
+function getProvisioningApi(context) {
+  return context && context.api && context.api.multitable && context.api.multitable.provisioning
+    ? context.api.multitable.provisioning
+    : null
+}
+
+function logicalFieldNames(objectConfig) {
+  return Array.from(new Set((objectConfig.fields || [])
+    .map((field) => optionalString(field && field.name))
+    .filter(Boolean)))
+}
+
+async function resolveProvisionedFieldIdMap(context, objectConfig) {
+  const projectId = optionalString(objectConfig.projectId)
+  const fieldIds = logicalFieldNames(objectConfig)
+  if (!projectId || fieldIds.length === 0) return {}
+  const provisioning = getProvisioningApi(context)
+  if (!provisioning) return {}
+
+  if (typeof provisioning.resolveFieldIds === 'function') {
+    return provisioning.resolveFieldIds({
+      projectId,
+      objectId: objectConfig.objectId,
+      fieldIds,
+    })
+  }
+
+  if (typeof provisioning.getFieldId === 'function') {
+    const resolved = {}
+    for (const fieldId of fieldIds) {
+      const physical = provisioning.getFieldId(projectId, objectConfig.objectId, fieldId)
+      if (physical) resolved[fieldId] = physical
+    }
+    return resolved
+  }
+
+  return {}
+}
+
+function invertFieldIdMap(fieldIdMap = {}) {
+  const aliases = {}
+  for (const [logicalField, physicalField] of Object.entries(fieldIdMap)) {
+    const logical = optionalString(logicalField)
+    const physical = optionalString(physicalField)
+    if (logical && physical && logical !== physical) aliases[physical] = logical
+  }
+  return aliases
+}
+
+function applyLogicalFieldAliases(data, physicalToLogical = {}) {
+  if (!isPlainObject(data)) return data
+  const normalized = { ...data }
+  for (const [physicalField, logicalField] of Object.entries(physicalToLogical)) {
+    if (
+      Object.prototype.hasOwnProperty.call(normalized, physicalField) &&
+      !Object.prototype.hasOwnProperty.call(normalized, logicalField)
+    ) {
+      normalized[logicalField] = normalized[physicalField]
+    }
+  }
+  return normalized
+}
+
 function parseOffsetCursor(cursor) {
   if (cursor === null || cursor === undefined || cursor === '') return 0
   const numeric = Number(cursor)
@@ -127,10 +207,10 @@ function parseOffsetCursor(cursor) {
   return numeric
 }
 
-function recordData(row, sheetId) {
+function recordData(row, sheetId, physicalToLogical = {}) {
   if (isPlainObject(row && row.data)) {
     return {
-      ...row.data,
+      ...applyLogicalFieldAliases(row.data, physicalToLogical),
       _metaRecordId: row.id || null,
       _metaRecordVersion: Number.isInteger(row.version) ? row.version : null,
       _metaSheetId: row.sheetId || sheetId,
@@ -143,6 +223,7 @@ function recordData(row, sheetId) {
 function createMetaSheetStagingSourceAdapter({ system, context } = {}) {
   const normalizedSystem = normalizeExternalSystemForAdapter(system)
   const objects = normalizeObjects(normalizedSystem.config)
+  const fieldAliasCache = new Map()
 
   function getObjectConfig(object) {
     const objectConfig = objects[object]
@@ -150,6 +231,17 @@ function createMetaSheetStagingSourceAdapter({ system, context } = {}) {
       throw new AdapterValidationError(`MetaSheet staging object is not configured: ${object}`, { object })
     }
     return objectConfig
+  }
+
+  async function fieldAliasesForObject(objectConfig) {
+    if (fieldAliasCache.has(objectConfig.objectId)) return fieldAliasCache.get(objectConfig.objectId)
+    const resolved = {
+      ...objectConfig.fieldIdMap,
+      ...await resolveProvisionedFieldIdMap(context, objectConfig),
+    }
+    const aliases = invertFieldIdMap(resolved)
+    fieldAliasCache.set(objectConfig.objectId, aliases)
+    return aliases
   }
 
   return {
@@ -203,7 +295,8 @@ function createMetaSheetStagingSourceAdapter({ system, context } = {}) {
         limit: request.limit,
         offset,
       })
-      const records = Array.isArray(rows) ? rows.map((row) => recordData(row, objectConfig.sheetId)) : []
+      const physicalToLogical = await fieldAliasesForObject(objectConfig)
+      const records = Array.isArray(rows) ? rows.map((row) => recordData(row, objectConfig.sheetId, physicalToLogical)) : []
       const nextOffset = offset + records.length
       return createReadResult({
         records,
@@ -233,6 +326,9 @@ module.exports = {
     normalizeObjects,
     normalizeFields,
     descriptorFieldsForObject,
+    normalizeFieldIdMap,
+    invertFieldIdMap,
+    applyLogicalFieldAliases,
     parseOffsetCursor,
     recordData,
   },


### PR DESCRIPTION
## Summary

Fixes the #1526 P0 staging dry-run gap where Data Factory Workbench saved logical mappings (`code`, `name`, `uom`) but the MetaSheet staging reader returned provisioned physical field IDs (`fld_*`) at runtime.

This PR keeps the Workbench/user-facing contract logical:

- staging source adapter resolves logical staging fields through `context.api.multitable.provisioning.resolveFieldIds({ projectId, objectId, fieldIds })`;
- read records are enriched with logical aliases when only physical field IDs are present;
- physical keys are preserved for manually patched pipelines;
- existing logical keys are not overwritten;
- explicit `config.objects.<objectId>.fieldIdMap` is supported as a fallback without provisioning.

Also updates the PLM/K3 route PoC test harness with the current `deleteExternalSystem` service stub so the full plugin test script matches the current route contract.

## Verification

- `node plugins/plugin-integration-core/__tests__/metasheet-staging-source-adapter.test.cjs` PASS
- `pnpm -F plugin-integration-core test` PASS
- `pnpm verify:integration-k3wise:poc` PASS
- `git diff --check origin/main...HEAD` PASS

## Notes

- No migration.
- No SQL executor change; `SQLSERVER_EXECUTOR_MISSING` remains a separate #1526 item.
- No K3 WebAPI read/list runtime change.
- No relationship resolver runtime change.
- No real K3 Save / Submit / Audit path executed.
