### PR TITLE
feat(attendance): period rollup PR1 — descriptor + ensure

### DIFF
--- a/docs/development/attendance-report-period-rollup-sync-todo-20260519.md
+++ b/docs/development/attendance-report-period-rollup-sync-todo-20260519.md
@@ -41,11 +41,13 @@ Date: 2026-05-19
 
 ## Key Changes
 
-### PR1：descriptor + ensure
+### PR1：descriptor + ensure — ✅ 已实现（2026-05-19）
 
 - 新增 `ATTENDANCE_REPORT_PERIOD_SUMMARIES_OBJECT_ID`、固定字段 descriptor、默认 view descriptor。
 - `ensureAttendanceReportPeriodSummaries()` 只通过 `context.api.multitable.provisioning.ensureObject()` provision，不裸写 `meta_*`。
 - 不加 writer、不加路由、不改前端。
+
+**落地状态：** PR1 由 Claude 按用户**显式 scoped 指派**实现（偏离本文件 Governance 的默认 Codex-driven —— 决策者明确指派单条 PR1 链，非自启、非 re-scope；记录在此保留 Codex review 连续性）。实现镜像既有 daily `attendance_report_records` 的 PR1 模式（descriptor / view descriptor / ensure / 测试 surface / degraded 语义一致）。`plugins/plugin-attendance/index.cjs` 新增 `ATTENDANCE_REPORT_PERIOD_SUMMARIES_{OBJECT_ID,FIELDS,VIEW_ID}` + `getAttendanceReportPeriodSummariesDescriptor()` + `getAttendanceReportPeriodSummariesViewDescriptor()` + `ensureAttendanceReportPeriodSummaries()`，并入 `__attendanceReportFieldCatalogForTests` 测试 surface；后端单测加在 `attendance-report-field-catalog.test.ts`（descriptor 稳定 / 类型只用 string·date·dateTime·number·boolean / row_key required / projectId=`${orgId}:attendance` / provisioning 缺失 degraded 不抛 / ensureView 失败不阻断 ensureObject 成功）。PR2（writer+route）/ PR3（前端+evidence）仍为后续，回归默认 Codex-driven 或另行显式指派。
 
 ### PR2：writer + route
 

--- a/docs/development/attendance-report-period-rollup-sync-todo-20260519.md
+++ b/docs/development/attendance-report-period-rollup-sync-todo-20260519.md
@@ -1,0 +1,112 @@
+# 考勤 Period Rollup 多维表同步计划（定稿）
+
+Date: 2026-05-19
+
+## Governance
+
+默认由 **Codex 驱动实现**；Claude 只做 independent review 或 docs-only merge/cleanup。本文件本身即 docs-only 落地——把先前散落的本地计划版本化为仓库内 NAMED artifact，供 Codex 实现对照、供后续每个 PR 的 boundary 合同 review pin 引用。参见跨会话记忆 `project_attendance_multitable_report_boundary.md`（Codex-driven 主题，Claude review-only，不注入 parallel scope-gate、不自启、不 re-scope）。
+
+## Summary
+
+在已完成的 daily `attendance_report_records` 之上，新增「周期汇总报表层」多维表对象：每个员工每个周期一行。周期可来自手动 `from/to` 日期范围，也可来自 `attendance_payroll_cycles`。考勤事实源仍是 `attendance_*`；多维表只存可重建的汇总快照，用于月报、薪资周期、二次公式、视图与协作。
+
+`attendance_report_period_summaries` 是 daily `attendance_report_records` 的**同级独立对象**：独立 descriptor、独立 writer、独立 UI 入口；daily sync 不改。
+
+## 边界（硬，不可破）
+
+- 不新增 `attendance_*` migration，不迁移事实源。
+- 不让多维表公式直读 `attendance_*`。
+- `attendance_report_period_summaries` 是可重建报表层，不作为查询 / 导出事实源。
+- 不裸写 `meta_*`，全程经 `context.api.multitable.provisioning.ensureObject()` + `records.create/patchRecord`。
+- summary 动态 subtype 字段在周期层按 approved request 汇总，不默默返回全 0。
+- daily `attendance_report_records` 不改。
+- v1 支持 date range 与 payroll cycle 两种模式；后台任务队列、自动跨页全量跑批、period dedup cleanup 留后续。
+
+## Public Interfaces
+
+- 新增插件私有多维表对象：`attendance_report_period_summaries`
+  - `projectId` 仍为 `${orgId}:attendance`
+  - 固定字段：`row_key`、`org_id`、`user_id`、`employee_name`、`department`、`attendance_group`、`period_type`、`period_key`、`cycle_id`、`period_name`、`period_start`、`period_end`、`field_fingerprint`、`source_fingerprint`、`synced_at`
+  - 动态值列：summary 基础字段、summary 公式字段、leave/overtime subtype 周期汇总字段
+- 新增接口：`POST /api/attendance/report-period-summaries/sync`
+  - 权限：`attendance:admin`
+  - body 必须二选一：
+    - `{ from, to, userId | userIds | allUsers, page?, pageSize? }`
+    - `{ cycleId, userId | userIds | allUsers, page?, pageSize? }`
+  - 禁止同时传 `cycleId` 和 `from/to`
+  - 返回 `{ ok:true, data:{ periodType, from, to, cycleId?, totalUsers?, page?, pageSize?, usersScanned, usersSynced, synced, created, patched, skipped, failed, duplicateRowKeys, fieldFingerprint, syncedAt, multitable } }`
+- row key 固定：
+  - date range：`${orgId}:${userId}:range:${from}:${to}`
+  - payroll cycle：`${orgId}:${userId}:cycle:${cycleId}`
+
+## Key Changes
+
+### PR1：descriptor + ensure
+
+- 新增 `ATTENDANCE_REPORT_PERIOD_SUMMARIES_OBJECT_ID`、固定字段 descriptor、默认 view descriptor。
+- `ensureAttendanceReportPeriodSummaries()` 只通过 `context.api.multitable.provisioning.ensureObject()` provision，不裸写 `meta_*`。
+- 不加 writer、不加路由、不改前端。
+
+### PR2：writer + route
+
+- 复用 `loadAttendanceSummary(db, orgId, userId, from, to)` 作为周期基础指标 producer。
+- payroll cycle 模式先读取 `attendance_payroll_cycles`，解析 `startDate/endDate/name/templateId`，再走同一 summary producer。
+- summary 公式复用现有 summary-scope 公式路径；动态 subtype 周期值由 `loadApprovedMinutesRange()` 汇总 `reportSubtypeMinutes` 后注入 summary value map。
+- value columns 由「summary 默认字段 + summary 公式字段 + active dynamic subtype 字段」确定性生成，排序按 `sortOrder/code`，同 code 映射稳定 `fld_xxx`。
+- upsert 规则沿用 daily sync：按物理 `fld_xxx` 的 `row_key` query，命中 patch，未命中 create；source + field fingerprint 双等才 skip；patch 时非 active managed 列显式写 `null`。
+- 多条相同 `row_key`：patch 第一条，计 `duplicateRowKeys`，不自动删重复。
+
+### PR3：前端入口 + live evidence
+
+- 在考勤统计字段区域增加「同步周期汇总到多维表」入口。
+- 支持 date range 与 payroll cycle 两种模式，支持单员工、`userIds`、`allUsers` 分页。
+- 展示 synced/created/patched/skipped/failed、`fieldFingerprint`、`syncedAt`、打开多维表入口。
+- staging live evidence 只在明确授权后执行，不写 production。
+
+## Test Plan
+
+- 后端单测：
+  - descriptor 稳定、字段类型合法、ensure degraded 不抛。
+  - date range 与 payroll cycle 参数校验：缺 user selection、同时传 `cycleId`/`from`/`to`、非法日期均返回 400。
+  - `cycleId` 能解析到正确 `from/to`；不存在 cycle 返回 404。
+  - 首次 sync create，重跑 skip，字段配置变化 patch。
+  - source fingerprint 排除 `synced_at` 与 fingerprint 字段，key 排序稳定。
+  - 动态 subtype 周期汇总正确，缺 schema 时降级为空 subtype 不阻断基础 summary。
+  - summary formula 字段参与输出与 fingerprint；公式失败只影响该字段。
+  - duplicate `row_key` 只 patch 第一条并计数。
+  - multitable API 不可用返回 `{ ok:true, data:{ degraded:true } }`。
+- 前端测试：
+  - period sync 面板能切换 date range / cycle 模式。
+  - `allUsers`/`page`/`pageSize` body 正确。
+  - 成功结果、degraded、错误状态、打开多维表链接都能展示。
+- 验证命令：
+  - `node --check plugins/plugin-attendance/index.cjs`
+  - `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-report-field-catalog.test.ts tests/unit/attendance-report-field-formula-engine.test.ts --reporter=dot`
+  - `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/AttendanceReportFieldsSection.spec.ts tests/attendance-admin-regressions.spec.ts --watch=false`
+  - `pnpm --filter @metasheet/web type-check`
+  - `pnpm --filter @metasheet/core-backend build`
+  - `git diff --check`
+
+## Assumptions
+
+- 不新增 `attendance_*` migration，不迁移事实源。
+- 不让多维表公式直读 `attendance_*`。
+- `attendance_report_period_summaries` 是可重建报表层，不作为查询 / 导出事实源。
+- v1 支持 date range 与 payroll cycle；后台任务队列、自动跨页全量跑批、period dedup cleanup 留后续。
+- summary 动态 subtype 字段在周期层按 approved request 汇总，不默默返回全 0。
+- daily `attendance_report_records` 不改；period rollup 是独立对象、独立 writer、独立 UI 入口。
+
+## Boundary 合同 cross-check（review-prep，非新增要求）
+
+对照 `project_attendance_multitable_report_boundary.md` 的 6 点 review 合同——本节只是把合同条款映射到本计划，供 PR1/2/3 review 时逐项实测，不引入计划之外的新约束：
+
+| # | 合同条款 | 本计划对应 |
+| --- | --- | --- |
+| 1 | multitable 不直接读/写 `attendance_*` | 不让多维表公式直读 `attendance_*`；`ensureObject()` provision、不裸写 `meta_*` |
+| 2 | sync 只写私有 report 对象 | 新私有对象 `attendance_report_period_summaries`，独立 writer / UI |
+| 3 | 每行带 source / fingerprint / period / syncedAt | 固定字段含 `source_fingerprint` / `field_fingerprint` / `synced_at` / `period_type` / `period_key` / `period_start` / `period_end` |
+| 4 | 可重建报表层，非 `attendance_*` 迁移 | 可重建，不作查询 / 导出事实源 |
+| 5 | 无新 `attendance_*` migration | 明确不新增、不迁移事实源 |
+| 6 | 测试覆盖 date / period sync + 字段配置 fingerprint + 重复 sync 幂等 | Test Plan 覆盖 create→skip→patch、source fp 排除 `synced_at`、dup `row_key` 只 patch 首条计数、degraded、cycleId 解析 / 404 |
+
+复用 daily sync（#1605）的 upsert / fingerprint / dup-row_key 纪律与 bulk sync（#1648）的参数互斥校验（`cycleId` 与 `from/to` 二选一→400、cycle 不存在→404）是一致性要求；review 时按 NAMED PR 逐 PR 实测。

--- a/packages/core-backend/tests/unit/attendance-report-field-catalog.test.ts
+++ b/packages/core-backend/tests/unit/attendance-report-field-catalog.test.ts
@@ -838,6 +838,124 @@ describe('attendance report field catalog multitable foundation', () => {
     expect(failed).toMatchObject({ available: false, reason: 'PROVISIONING_FAILED', sheetId: null })
   })
 
+  it('attendance_report_period_summaries (PR1): stable descriptor + ensure + degraded fallback', async () => {
+    const d1 = helpers.getAttendanceReportPeriodSummariesDescriptor()
+    const d2 = helpers.getAttendanceReportPeriodSummariesDescriptor()
+    expect(d1.id).toBe('attendance_report_period_summaries')
+    expect(helpers.ATTENDANCE_REPORT_PERIOD_SUMMARIES_OBJECT_ID).toBe('attendance_report_period_summaries')
+    // descriptor stable across calls (same field ids/types/order)
+    expect(JSON.stringify(d1)).toBe(JSON.stringify(d2))
+    const ids = d1.fields.map((f: { id: string }) => f.id)
+    expect(ids).toEqual([
+      'row_key', 'org_id', 'user_id', 'employee_name', 'department', 'attendance_group',
+      'period_type', 'period_key', 'cycle_id', 'period_name', 'period_start', 'period_end',
+      'field_fingerprint', 'source_fingerprint', 'synced_at',
+    ])
+    expect(ids).toEqual(Object.values(helpers.ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS))
+    // provisioning field-type contract: only string/date/dateTime/number/boolean
+    const allowedTypes = new Set(['string', 'date', 'dateTime', 'number', 'boolean'])
+    expect(d1.fields.every((f: { type: string }) => allowedTypes.has(f.type))).toBe(true)
+    const typeByCode = Object.fromEntries(d1.fields.map((f: { id: string, type: string }) => [f.id, f.type]))
+    expect(typeByCode.row_key).toBe('string')
+    expect(typeByCode.period_start).toBe('date')
+    expect(typeByCode.period_end).toBe('date')
+    expect(typeByCode.synced_at).toBe('dateTime')
+    expect(d1.fields.some((f: { type: string }) => f.type === 'text')).toBe(false)
+    // row_key required
+    expect(d1.fields.find((f: { id: string }) => f.id === 'row_key')?.property?.validation?.required).toBe(true)
+
+    // ensure: ensureObject called with projectId `${orgId}:attendance`, same descriptor each call
+    const ensureCalls: unknown[] = []
+    const context = {
+      api: {
+        multitable: {
+          provisioning: {
+            ensureObject: async (input: unknown) => {
+              ensureCalls.push(input)
+              return { baseId: 'base_period', sheet: { id: 'sheet_period_summaries' } }
+            },
+            ensureView: vi.fn().mockResolvedValue({
+              id: 'view_period_summaries',
+              sheetId: 'sheet_period_summaries',
+              name: '按周期查看',
+              type: 'grid',
+            }),
+            resolveFieldIds: async ({ fieldIds }: { fieldIds: string[] }) =>
+              Object.fromEntries(fieldIds.map(fid => [fid, `fld_${fid}`])),
+          },
+        },
+      },
+    }
+    const r1 = await helpers.ensureAttendanceReportPeriodSummaries(context, 'org-a', { warn: vi.fn() })
+    const r2 = await helpers.ensureAttendanceReportPeriodSummaries(context, 'org-a', { warn: vi.fn() })
+    expect(r1).toMatchObject({
+      available: true,
+      reason: null,
+      projectId: 'org-a:attendance',
+      objectId: 'attendance_report_period_summaries',
+      sheetId: 'sheet_period_summaries',
+      viewId: 'view_period_summaries',
+    })
+    expect(r1.fieldIds.row_key).toBe('fld_row_key')
+    expect(r1.fieldIds.cycle_id).toBe('fld_cycle_id')
+    expect(r1.fieldIds.synced_at).toBe('fld_synced_at')
+    expect((ensureCalls[0] as { projectId: string }).projectId).toBe('org-a:attendance')
+    expect(JSON.stringify((ensureCalls[0] as { descriptor: unknown }).descriptor))
+      .toBe(JSON.stringify((ensureCalls[1] as { descriptor: unknown }).descriptor))
+    expect(helpers.getAttendanceReportPeriodSummariesViewDescriptor(r1.fieldIds)).toMatchObject({
+      id: helpers.ATTENDANCE_REPORT_PERIOD_SUMMARIES_VIEW_ID,
+      objectId: 'attendance_report_period_summaries',
+      sortInfo: {
+        rules: [
+          { fieldId: 'fld_period_start', direction: 'desc' },
+          { fieldId: 'fld_user_id', direction: 'asc' },
+          { fieldId: 'fld_synced_at', direction: 'desc' },
+        ],
+      },
+    })
+    expect(JSON.stringify(r2)).toBe(JSON.stringify(r1))
+
+    // degraded: provisioning API unavailable → no throw, available:false
+    const degraded = await helpers.ensureAttendanceReportPeriodSummaries({ api: { multitable: null } }, 'org-z', { warn: vi.fn() })
+    expect(degraded).toMatchObject({
+      available: false,
+      reason: 'MULTITABLE_API_UNAVAILABLE',
+      objectId: 'attendance_report_period_summaries',
+      sheetId: null,
+    })
+    expect(degraded.fieldIds).toEqual({})
+
+    // degraded: ensureObject throws → caught, available:false PROVISIONING_FAILED, no throw
+    const throwing = {
+      api: { multitable: { provisioning: { ensureObject: async () => { throw new Error('boom') } } } },
+    }
+    const failed = await helpers.ensureAttendanceReportPeriodSummaries(throwing, 'org-z', { warn: vi.fn() })
+    expect(failed).toMatchObject({ available: false, reason: 'PROVISIONING_FAILED', sheetId: null })
+
+    // ensureView failure does NOT block ensureObject success (inner try/catch → available:true, viewId:null)
+    const viewFailing = {
+      api: {
+        multitable: {
+          provisioning: {
+            ensureObject: async () => ({ baseId: 'base_period', sheet: { id: 'sheet_period_summaries' } }),
+            ensureView: async () => { throw new Error('view boom') },
+            resolveFieldIds: async ({ fieldIds }: { fieldIds: string[] }) =>
+              Object.fromEntries(fieldIds.map(fid => [fid, `fld_${fid}`])),
+          },
+        },
+      },
+    }
+    const viewFailed = await helpers.ensureAttendanceReportPeriodSummaries(viewFailing, 'org-a', { warn: vi.fn() })
+    expect(viewFailed).toMatchObject({
+      available: true,
+      reason: null,
+      objectId: 'attendance_report_period_summaries',
+      sheetId: 'sheet_period_summaries',
+      viewId: null,
+    })
+    expect(viewFailed.fieldIds.row_key).toBe('fld_row_key')
+  })
+
   it('report-records sync: pure helpers (type map / value columns / row key / source fingerprint)', () => {
     expect(helpers.mapReportFieldToMultitableType({ unit: 'minutes' })).toBe('number')
     expect(helpers.mapReportFieldToMultitableType({ unit: 'count' })).toBe('number')

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -328,6 +328,7 @@ function attachAttendanceImportMultiPunchMeta(meta, options = {}) {
 const ATTENDANCE_REPORT_FIELD_CATALOG_OBJECT_ID = 'attendance_report_field_catalog'
 const ATTENDANCE_REPORT_FIELD_CATALOG_VIEW_ID = 'fields_by_category'
 const ATTENDANCE_REPORT_RECORDS_VIEW_ID = 'records_by_date'
+const ATTENDANCE_REPORT_PERIOD_SUMMARIES_VIEW_ID = 'period_summaries_by_period'
 const ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS = Object.freeze({
   fieldCode: 'field_code',
   fieldName: 'field_name',
@@ -2098,6 +2099,154 @@ async function ensureAttendanceReportRecords(context, orgId, logger) {
       error: error instanceof Error ? error.message : String(error),
       projectId,
       objectId: ATTENDANCE_REPORT_RECORDS_OBJECT_ID,
+      baseId: null,
+      sheetId: null,
+      viewId: null,
+      fieldIds: {},
+    }
+  }
+}
+
+// ── attendance_report_period_summaries (period rollup PR1: descriptor + ensure only) ──
+// 每员工每周期一行的可重建报表层. PR1 只 ship 固定身份/溯源骨架 + ensure；
+// writer/route/frontend 是 PR2/PR3, 不在本 slice. attendance_* 仍是唯一事实源,
+// 全程经 context.api.multitable.provisioning, 不裸写 meta_*, 不新增 attendance_* migration.
+const ATTENDANCE_REPORT_PERIOD_SUMMARIES_OBJECT_ID = 'attendance_report_period_summaries'
+const ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS = Object.freeze({
+  rowKey: 'row_key',
+  orgId: 'org_id',
+  userId: 'user_id',
+  employeeName: 'employee_name',
+  department: 'department',
+  attendanceGroup: 'attendance_group',
+  periodType: 'period_type',
+  periodKey: 'period_key',
+  cycleId: 'cycle_id',
+  periodName: 'period_name',
+  periodStart: 'period_start',
+  periodEnd: 'period_end',
+  fieldFingerprint: 'field_fingerprint',
+  sourceFingerprint: 'source_fingerprint',
+  syncedAt: 'synced_at',
+})
+
+function getAttendanceReportPeriodSummariesDescriptor() {
+  return {
+    id: ATTENDANCE_REPORT_PERIOD_SUMMARIES_OBJECT_ID,
+    name: '考勤周期汇总报表（多维表报表层）',
+    description: '考勤插件私有周期汇总报表快照对象：每员工每周期一行（手动 from/to 或薪资周期），供多维表二次公式/视图/筛选/权限。可重建，非事实源；attendance_* 仍是唯一事实源。',
+    fields: [
+      { id: ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS.rowKey, name: '行键', type: 'string', order: 10, property: { validation: { required: true }, width: 280 } },
+      { id: ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS.orgId, name: '组织', type: 'string', order: 20, property: { width: 120 } },
+      { id: ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS.userId, name: '员工ID', type: 'string', order: 30, property: { width: 160 } },
+      { id: ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS.employeeName, name: '姓名', type: 'string', order: 40, property: { width: 120 } },
+      { id: ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS.department, name: '部门', type: 'string', order: 50, property: { width: 140 } },
+      { id: ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS.attendanceGroup, name: '考勤组', type: 'string', order: 60, property: { width: 140 } },
+      { id: ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS.periodType, name: '周期类型', type: 'string', order: 70, property: { width: 100 } },
+      { id: ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS.periodKey, name: '周期键', type: 'string', order: 80, property: { width: 220 } },
+      { id: ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS.cycleId, name: '薪资周期ID', type: 'string', order: 90, property: { width: 160 } },
+      { id: ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS.periodName, name: '周期名称', type: 'string', order: 100, property: { width: 160 } },
+      { id: ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS.periodStart, name: '周期开始', type: 'date', order: 110 },
+      { id: ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS.periodEnd, name: '周期结束', type: 'date', order: 120 },
+      { id: ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS.fieldFingerprint, name: '字段配置指纹', type: 'string', order: 130, property: { width: 200 } },
+      { id: ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS.sourceFingerprint, name: '源数据指纹', type: 'string', order: 140, property: { width: 200 } },
+      { id: ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS.syncedAt, name: '同步时间', type: 'dateTime', order: 150 },
+    ],
+  }
+}
+
+function getAttendanceReportPeriodSummariesViewDescriptor(fieldIds = {}) {
+  const periodStartFieldId = fieldIds[ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS.periodStart] || ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS.periodStart
+  const userIdFieldId = fieldIds[ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS.userId] || ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS.userId
+  const syncedAtFieldId = fieldIds[ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS.syncedAt] || ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS.syncedAt
+  return {
+    id: ATTENDANCE_REPORT_PERIOD_SUMMARIES_VIEW_ID,
+    objectId: ATTENDANCE_REPORT_PERIOD_SUMMARIES_OBJECT_ID,
+    name: '按周期查看',
+    type: 'grid',
+    sortInfo: {
+      rules: [
+        { fieldId: periodStartFieldId, direction: 'desc' },
+        { fieldId: userIdFieldId, direction: 'asc' },
+        { fieldId: syncedAtFieldId, direction: 'desc' },
+      ],
+    },
+    config: {
+      purpose: 'attendance-report-period-summaries',
+    },
+  }
+}
+
+// PR1 ships the fixed identity/provenance skeleton + ensure only. Value columns
+// (summary base / summary formula / dynamic subtype period rollup) are ensured at
+// sync time in PR2 via the same ensureObject upsert, driven from the live catalog —
+// mirrors the daily attendance_report_records PR1/PR2 split. No writer, route, or
+// frontend in PR1.
+async function ensureAttendanceReportPeriodSummaries(context, orgId, logger) {
+  const projectId = getAttendanceReportFieldProjectId(orgId)
+  const multitable = context?.api?.multitable
+  if (!multitable?.provisioning?.ensureObject) {
+    return {
+      available: false,
+      reason: 'MULTITABLE_API_UNAVAILABLE',
+      projectId,
+      objectId: ATTENDANCE_REPORT_PERIOD_SUMMARIES_OBJECT_ID,
+      baseId: null,
+      sheetId: null,
+      viewId: null,
+      fieldIds: {},
+    }
+  }
+  try {
+    const descriptor = getAttendanceReportPeriodSummariesDescriptor()
+    const provisioned = await multitable.provisioning.ensureObject({ projectId, descriptor })
+    const logicalFieldIds = Object.values(ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS)
+    let fieldIds = {}
+    if (typeof multitable.provisioning.resolveFieldIds === 'function') {
+      fieldIds = await multitable.provisioning.resolveFieldIds({
+        projectId,
+        objectId: ATTENDANCE_REPORT_PERIOD_SUMMARIES_OBJECT_ID,
+        fieldIds: logicalFieldIds,
+      })
+    } else if (typeof multitable.provisioning.getFieldId === 'function') {
+      fieldIds = Object.fromEntries(logicalFieldIds.map(fieldId => [
+        fieldId,
+        multitable.provisioning.getFieldId(projectId, ATTENDANCE_REPORT_PERIOD_SUMMARIES_OBJECT_ID, fieldId),
+      ]))
+    }
+
+    let viewId = null
+    if (typeof multitable.provisioning.ensureView === 'function') {
+      try {
+        const view = await multitable.provisioning.ensureView({
+          projectId,
+          sheetId: provisioned.sheet.id,
+          descriptor: getAttendanceReportPeriodSummariesViewDescriptor(fieldIds),
+        })
+        viewId = view?.id || null
+      } catch (error) {
+        logger?.warn?.('Failed to ensure attendance report period summaries view', error)
+      }
+    }
+
+    return {
+      available: true,
+      reason: null,
+      projectId,
+      objectId: ATTENDANCE_REPORT_PERIOD_SUMMARIES_OBJECT_ID,
+      baseId: provisioned.baseId || null,
+      sheetId: provisioned.sheet?.id || null,
+      viewId,
+      fieldIds,
+    }
+  } catch (error) {
+    logger?.warn?.('Attendance report period summaries provisioning degraded', error)
+    return {
+      available: false,
+      reason: 'PROVISIONING_FAILED',
+      error: error instanceof Error ? error.message : String(error),
+      projectId,
+      objectId: ATTENDANCE_REPORT_PERIOD_SUMMARIES_OBJECT_ID,
       baseId: null,
       sheetId: null,
       viewId: null,
@@ -10484,6 +10633,12 @@ module.exports = {
     loadAttendanceReportFieldCatalog,
     getAttendanceReportRecordsDescriptor,
     ensureAttendanceReportRecords,
+    ATTENDANCE_REPORT_PERIOD_SUMMARIES_OBJECT_ID,
+    ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS,
+    ATTENDANCE_REPORT_PERIOD_SUMMARIES_VIEW_ID,
+    getAttendanceReportPeriodSummariesDescriptor,
+    getAttendanceReportPeriodSummariesViewDescriptor,
+    ensureAttendanceReportPeriodSummaries,
     syncAttendanceReportRecords,
     syncAttendanceReportRecordsForUsers,
     normalizeAttendanceReportRecordsSyncUserIds,


### PR DESCRIPTION
## Summary

Period-rollup multitable report layer **PR1 only** (descriptor + ensure). Extends the prior docs-only todo MD on this branch into the full PR1 slice so the spec and its first implementation land together.

> **Governance note:** the source plan (`attendance-report-period-rollup-sync-todo-20260519.md`) defaults this theme to **Codex-driven, Claude review-only**. PR1 here was **Claude-implemented per the maintainer's explicit, scoped direction** (a deliberate single-link delegation — not auto-start, not re-scope). This deviation is recorded in the todo MD's PR1 section to preserve Codex review continuity. **PR2 (writer + route) and PR3 (frontend + live evidence) remain Codex-driven** unless separately and explicitly delegated.

Implementation mirrors the existing daily `attendance_report_records` PR1 pattern exactly (descriptor / view descriptor / ensure / test surface / degraded semantics).

### Changes (`plugins/plugin-attendance/index.cjs`)

- `ATTENDANCE_REPORT_PERIOD_SUMMARIES_OBJECT_ID = 'attendance_report_period_summaries'`
- `ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS` — 15 fixed identity/provenance fields: `row_key, org_id, user_id, employee_name, department, attendance_group, period_type, period_key, cycle_id, period_name, period_start, period_end, field_fingerprint, source_fingerprint, synced_at`
- `ATTENDANCE_REPORT_PERIOD_SUMMARIES_VIEW_ID` + `getAttendanceReportPeriodSummariesDescriptor()` + `getAttendanceReportPeriodSummariesViewDescriptor(fieldIds)`
- `ensureAttendanceReportPeriodSummaries(context, orgId, logger)` — `provisioning.ensureObject/resolveFieldIds/ensureView` only; `{ available:false, reason:'MULTITABLE_API_UNAVAILABLE' }` when provisioning missing; `{ available:false, reason:'PROVISIONING_FAILED' }` on `ensureObject` throw; `ensureView` failure does **not** block `ensureObject` success
- 6 helpers exposed on `__attendanceReportFieldCatalogForTests`
- Field types limited to `string` / `date` / `dateTime` (subset of allowed string/date/dateTime/number/boolean); `row_key` required

### Tests (`packages/core-backend/tests/unit/attendance-report-field-catalog.test.ts`)

One comprehensive `it` (matches file house style) covering all 6 spec assertions: stable descriptor, allowed field types only, `row_key` required, `ensureObject` `projectId = ${orgId}:attendance`, provisioning-missing degraded no-throw, `ensureView`-failure non-blocking.

## Boundaries honored

- No writer, no route (`POST /api/attendance/report-period-summaries/sync` NOT added), no frontend (`AttendanceReportFieldsSection.vue` untouched)
- No `meta_*` SQL, no new `attendance_*` migration
- No staging/prod sync run
- Explicit 3-file stage (no `git add -A`, no `node_modules` symlink noise)

## Test plan

- [x] `node --check plugins/plugin-attendance/index.cjs` — OK
- [x] `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-report-field-catalog.test.ts --reporter=dot` — **21 pass** (20 baseline + 1 new PR1 test)
- [x] sibling `tests/unit/attendance-report-field-formula-engine.test.ts` (shares the plugin file) — **24 pass**, additive change non-breaking
- [x] `pnpm --filter @metasheet/core-backend build` (tsc) — clean
- [x] `git diff --check` — clean
- [ ] CI green
- [ ] Reviewer confirms PR1 scope (no writer/route/frontend) + governance deviation note is acceptable

🤖 Generated with [Claude Code](https://claude.com/claude-code)