### PR TITLE
fix(data-factory): guide staging target pairing

### DIFF
--- a/apps/web/src/services/integration/k3WiseSetup.ts
+++ b/apps/web/src/services/integration/k3WiseSetup.ts
@@ -881,7 +881,12 @@ export function validateK3WisePipelineTemplateForm(
   descriptors: IntegrationStagingDescriptor[] = [],
 ): K3WiseSetupValidationIssue[] {
   const issues: K3WiseSetupValidationIssue[] = []
-  if (!trim(form.sourceSystemId)) issues.push({ field: 'sourceSystemId', message: 'PLM source system ID is required' })
+  if (!trim(form.sourceSystemId)) {
+    issues.push({
+      field: 'sourceSystemId',
+      message: 'PLM source system ID is required for the K3 preset; use Data Factory with MetaSheet staging source when starting from existing staging tables',
+    })
+  }
   if (!trim(form.webApiSystemId)) issues.push({ field: 'webApiSystemId', message: 'Save or select a K3 WISE WebAPI system before creating pipelines' })
   if (!trim(form.materialPipelineName)) issues.push({ field: 'materialPipelineName', message: 'Material pipeline name is required' })
   if (!trim(form.bomPipelineName)) issues.push({ field: 'bomPipelineName', message: 'BOM pipeline name is required' })
@@ -1060,7 +1065,7 @@ export function buildK3WiseDeployGateChecklist(form: K3WiseSetupForm): K3WiseDep
       trim(form.sourceSystemId) ? 'ready' : 'external',
       trim(form.sourceSystemId)
         ? '已选择或粘贴 PLM source system ID，可创建清洗 pipeline'
-        : '当前页面只粘贴 sourceSystemId；第三方 PLM 连接本身仍需先通过 integration API/种子/后续 PLM UI 创建',
+        : 'K3 预设页是 PLM-first 创建器；若已在 MetaSheet staging 多维表清洗，请进入数据工厂选择 staging 来源创建 pipeline',
       'sourceSystemId',
     ),
     gateItem(
@@ -1080,7 +1085,7 @@ export function buildK3WiseDeployGateChecklist(form: K3WiseSetupForm): K3WiseDep
       pipelineTemplateReady ? 'ready' : 'missing',
       pipelineTemplateReady
         ? 'PLM source、K3 target 和 staging 对象已具备，可创建 draft pipeline'
-        : '需先保存 K3 WebAPI、准备 PLM source system，并选择物料/BOM staging 对象',
+        : '需先保存 K3 WebAPI、准备 PLM source system，并选择物料/BOM staging 对象；staging-first 场景请改用数据工厂',
       pipelineTemplateReady ? undefined : 'sourceSystemId',
     ),
     gateItem(

--- a/apps/web/src/views/IntegrationK3WiseSetupView.vue
+++ b/apps/web/src/views/IntegrationK3WiseSetupView.vue
@@ -111,7 +111,13 @@
             {{ testingSql ? '测试中' : '测试 SQL Server' }}
           </button>
           <p v-if="hasUnsavedSqlConnectionDraft" class="k3-setup__hint">SQL Server 通道配置有未保存改动，请先保存再测试。</p>
-          <pre v-if="testResult" class="k3-setup__test-result">{{ testResult }}</pre>
+          <p v-if="testResultSummary" class="k3-setup__test-summary" data-testid="connection-test-summary">
+            {{ testResultSummary }}
+          </p>
+          <details v-if="testResult" class="k3-setup__diagnostics" data-testid="connection-test-diagnostics">
+            <summary>展开原始诊断 JSON（排障用）</summary>
+            <pre class="k3-setup__test-result">{{ testResult }}</pre>
+          </details>
         </div>
 
         <div class="k3-setup__panel">
@@ -707,6 +713,9 @@
             <label class="k3-setup__field">
               <span>PLM Source System ID</span>
               <input v-model.trim="form.sourceSystemId" autocomplete="off" />
+              <small class="k3-setup__hint" data-testid="plm-source-fallback-hint">
+                K3 预设页是 PLM-first 创建器；如果当前只有 MetaSheet staging 多维表，请进入数据工厂，选择 MetaSheet staging 来源后创建清洗流程。
+              </small>
             </label>
             <label class="k3-setup__field">
               <span>K3 Target System ID</span>
@@ -896,6 +905,7 @@ const observedPipelineTarget = ref<K3WisePipelineTarget>('material')
 const statusMessage = ref('')
 const statusKind = ref<'info' | 'success' | 'error'>('info')
 const testResult = ref('')
+const testResultSummary = ref('')
 const stagingResult = ref('')
 const stagingInstallResult = ref<IntegrationStagingInstallResult | null>(null)
 const pipelineResult = ref('')
@@ -1240,8 +1250,23 @@ function buildConnectionTestPayload(): Record<string, unknown> {
 function loadSystemIntoForm(system: IntegrationExternalSystem): void {
   Object.assign(form, applyExternalSystemToForm(form, system))
   testResult.value = ''
+  testResultSummary.value = ''
   webApiLastTest.value = null
   setStatus(`已载入 ${system.name}`, 'info')
+}
+
+function summarizeConnectionTestResult(result: Record<string, unknown>, label: string): string {
+  const ok = result.ok === true
+  const code = typeof result.code === 'string' ? result.code : ''
+  const message = typeof result.message === 'string' ? result.message : ''
+  const testedSystem = getTestResultSystem(result)
+  const lastError = typeof testedSystem?.lastError === 'string' ? testedSystem.lastError : ''
+  if (ok) return `${label} 测试通过。原始响应已收起，可展开排障 JSON。`
+  const errorText = message || lastError || code || 'unknown error'
+  const concise = /SQLSERVER_EXECUTOR_MISSING|queryExecutor|executor|执行器|注入/i.test(errorText)
+    ? 'SQLSERVER_EXECUTOR_MISSING：当前部署未注入 SQL 执行器，SQL 只读通道暂不能作为数据源。'
+    : `${label} 测试失败：${errorText}`
+  return `${concise} 原始响应已收起，可展开排障 JSON。`
 }
 
 async function loadSystems(silent = false): Promise<void> {
@@ -1300,9 +1325,11 @@ async function testWebApi(): Promise<void> {
   if (!form.webApiSystemId || hasUnsavedWebApiConnectionDraft.value) return
   testingWebApi.value = true
   testResult.value = ''
+  testResultSummary.value = ''
   try {
     const result = await testIntegrationSystem(form.webApiSystemId, buildConnectionTestPayload())
     testResult.value = JSON.stringify(result, null, 2)
+    testResultSummary.value = summarizeConnectionTestResult(result, 'WebAPI')
     const testedSystem = getTestResultSystem(result)
     if (testedSystem) upsertLocalWebApiSystem(testedSystem)
     const lastTestedAt = testedSystem?.lastTestedAt || new Date().toISOString()
@@ -1317,6 +1344,7 @@ async function testWebApi(): Promise<void> {
     void loadSystems(true)
     setStatus(result.ok === true ? 'WebAPI 连接测试完成' : 'WebAPI 连接测试失败', result.ok === true ? 'success' : 'error')
   } catch (error) {
+    testResultSummary.value = `WebAPI 测试失败：${formatError(error)}`
     webApiLastTest.value = {
       systemId: form.webApiSystemId,
       ok: false,
@@ -1333,12 +1361,15 @@ async function testSqlServer(): Promise<void> {
   if (!form.sqlSystemId || hasUnsavedSqlConnectionDraft.value) return
   testingSql.value = true
   testResult.value = ''
+  testResultSummary.value = ''
   try {
     const result = await testIntegrationSystem(form.sqlSystemId, buildConnectionTestPayload())
     testResult.value = JSON.stringify(result, null, 2)
+    testResultSummary.value = summarizeConnectionTestResult(result, 'SQL Server')
     await loadSystems(true)
     setStatus('SQL Server 通道测试完成', 'success')
   } catch (error) {
+    testResultSummary.value = `SQL Server 测试失败：${formatError(error)}`
     setStatus(formatError(error), 'error')
   } finally {
     testingSql.value = false
@@ -2140,6 +2171,27 @@ onMounted(() => {
   background: #0f172a;
   color: #e2e8f0;
   font-size: 12px;
+}
+
+.k3-setup__test-summary,
+.k3-setup__diagnostics {
+  margin: 10px 0 0;
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.k3-setup__test-summary {
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  padding: 8px;
+  background: #f8fafc;
+  color: #334155;
+  overflow-wrap: anywhere;
+}
+
+.k3-setup__diagnostics summary {
+  color: #475569;
+  cursor: pointer;
 }
 
 .k3-setup__template-grid {

--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -336,6 +336,18 @@
       <div v-if="protocolSplitNotice" class="integration-workbench__hint" data-testid="protocol-split-notice">
         {{ protocolSplitNotice }}
       </div>
+      <div v-if="stagingTargetMismatchNotice" class="integration-workbench__hint integration-workbench__hint--strong" data-testid="source-target-mismatch-notice">
+        <span>{{ stagingTargetMismatchNotice }}</span>
+        <button
+          v-if="recommendedStagingSourceObject"
+          type="button"
+          class="integration-workbench__button"
+          data-testid="use-recommended-staging-source"
+          @click="useRecommendedStagingSource"
+        >
+          切换到 {{ stagingDatasetCopy[recommendedStagingSourceObject]?.name || recommendedStagingSourceObject }}
+        </button>
+      </div>
     </section>
 
     <section class="integration-workbench__panel">
@@ -856,6 +868,10 @@ const stagingDatasetCopy: Record<string, { area: string; name: string; descripti
     description: '记录 dry-run、Save-only 推送、外部 ID、单据号和错误摘要。',
   },
 }
+const recommendedStagingSourceByTarget: Record<string, string> = {
+  material: 'standard_materials',
+  bom: 'bom_cleanse',
+}
 
 const transformOptions: Array<{ value: TransformFn, label: string }> = [
   { value: '', label: '无转换' },
@@ -1097,6 +1113,21 @@ const protocolSplitNotice = computed(() => {
   }
   return ''
 })
+const recommendedStagingSourceObject = computed(() => {
+  const recommended = recommendedStagingSourceByTarget[targetObjectName.value]
+  if (!recommended) return ''
+  if (!stagingDescriptors.value.some((descriptor) => descriptor.id === recommended)) return ''
+  return recommended
+})
+const stagingTargetMismatchNotice = computed(() => {
+  if (selectedSourceSystem.value?.kind !== 'metasheet:staging') return ''
+  const recommended = recommendedStagingSourceObject.value
+  if (!recommended || !sourceObjectName.value || sourceObjectName.value === recommended) return ''
+  const sourceLabel = stagingDatasetCopy[sourceObjectName.value]?.name || sourceObjectName.value
+  const recommendedLabel = stagingDatasetCopy[recommended]?.name || recommended
+  const targetLabel = selectedTargetObject.value?.label || targetObjectName.value
+  return `当前目标模板「${targetLabel}」建议使用「${recommendedLabel}」作为来源；你选择的是「${sourceLabel}」，dry-run 可能成功但返回 0 条可处理记录。`
+})
 const hasMappingRules = computed(() => mappings.value.some((mapping) => mapping.sourceField.trim() && mapping.targetField.trim()))
 const hasIdempotencyFields = computed(() => parseList(idempotencyFieldsText.value).length > 0)
 const generatedPipelineName = computed(() => defaultPipelineName())
@@ -1124,6 +1155,12 @@ const savePipelineReadinessItems = computed(() => [
     label: '选择目标数据集 / 模板',
     ready: Boolean(targetObjectName.value),
     detail: targetObjectName.value || '加载目标模板后才能生成 payload 或保存 pipeline。',
+  },
+  {
+    id: 'source-target-pairing',
+    label: '确认来源与目标匹配',
+    ready: !stagingTargetMismatchNotice.value,
+    detail: stagingTargetMismatchNotice.value || '来源数据集与目标模板匹配。',
   },
   {
     id: 'mapping',
@@ -1173,6 +1210,12 @@ const dryRunReadinessItems = computed(() => [
     label: '选择目标数据集 / 模板',
     ready: Boolean(targetObjectName.value),
     detail: targetObjectName.value || '加载目标模板后才能生成 payload 或保存 pipeline。',
+  },
+  {
+    id: 'source-target-pairing',
+    label: '确认来源与目标匹配',
+    ready: !stagingTargetMismatchNotice.value,
+    detail: stagingTargetMismatchNotice.value || '来源数据集与目标模板匹配。',
   },
   {
     id: 'mapping',
@@ -1586,7 +1629,9 @@ function buildStagingSourceObjects(): IntegrationSystemObject[] {
 }
 
 function preferredStagingSourceObjectId(): string {
+  const targetPreferred = recommendedStagingSourceByTarget[targetObjectName.value] || ''
   const candidates = [
+    targetPreferred,
     stagingSheetId.value,
     'standard_materials',
     stagingOpenTargets.value[0]?.id || '',
@@ -1914,6 +1959,12 @@ async function useStagingAsSource(objectId: string): Promise<void> {
   await activateStagingAsSource(objectId)
 }
 
+async function useRecommendedStagingSource(): Promise<void> {
+  const objectId = recommendedStagingSourceObject.value
+  if (!objectId) return
+  await activateStagingAsSource(objectId, `已按目标模板切换到 ${stagingDatasetCopy[objectId]?.name || objectId} 作为 Dry-run 来源`)
+}
+
 async function activateStagingAsSource(objectId: string, successMessage?: string): Promise<void> {
   const descriptor = stagingDescriptors.value.find((item) => item.id === objectId) || null
   const target = stagingOpenTargetById.value.get(objectId)
@@ -2195,6 +2246,7 @@ function buildPipelinePayload() {
   if (!targetSystemId.value) throw new Error('请选择目标系统')
   if (!sourceObjectName.value) throw new Error('请选择来源数据集')
   if (!targetObjectName.value) throw new Error('请选择目标数据集')
+  if (stagingTargetMismatchNotice.value) throw new Error(stagingTargetMismatchNotice.value)
   if (fieldMappings.length === 0) throw new Error('请至少配置一条清洗映射规则')
   if (idempotencyKeyFields.length === 0) throw new Error('请至少配置一个幂等字段')
 

--- a/apps/web/tests/IntegrationK3WiseSetupView.spec.ts
+++ b/apps/web/tests/IntegrationK3WiseSetupView.spec.ts
@@ -154,6 +154,7 @@ describe('IntegrationK3WiseSetupView', () => {
     expect(container.textContent).toContain('高级 SQL Server 通道')
     expect(container.textContent).toContain('allowlist 表/视图')
     expect(container.textContent).toContain('多维表清洗准备')
+    expect(container.textContent).toContain('如果当前只有 MetaSheet staging 多维表')
     expect(container.textContent).toContain('K3 单据模板')
     expect(container.textContent).toContain('K3 WISE 物料')
     expect(container.textContent).toContain('FNumber')
@@ -239,6 +240,77 @@ describe('IntegrationK3WiseSetupView', () => {
 
     expect(container.textContent).toContain('connected')
     expect(container.textContent).toContain('WebAPI 连接测试完成')
+  })
+
+  it('keeps SQL executor diagnostics collapsed behind a concise operator summary', async () => {
+    const longDiagnostic = 'x'.repeat(3200)
+    const sqlSystem = {
+      id: 'k3_sql_1',
+      tenantId: 'default',
+      workspaceId: null,
+      name: 'K3 WISE SQL Server',
+      kind: 'erp:k3-wise-sqlserver',
+      role: 'source',
+      status: 'error',
+      hasCredentials: true,
+      config: {
+        mode: 'readonly',
+        server: 'sql.local',
+        database: 'AIS_TEST',
+        allowedTables: ['dbo.t_ICItem'],
+      },
+    }
+    apiFetchMock.mockImplementation(async (url: string) => {
+      if (url.startsWith('/api/integration/external-systems?kind=erp%3Ak3-wise-webapi')) {
+        return jsonResponse([])
+      }
+      if (url.startsWith('/api/integration/external-systems?kind=erp%3Ak3-wise-sqlserver')) {
+        return jsonResponse([sqlSystem])
+      }
+      if (url === '/api/integration/external-systems/k3_sql_1/test?tenantId=default') {
+        return jsonResponse({
+          ok: false,
+          code: 'SQLSERVER_EXECUTOR_MISSING',
+          message: `SQLSERVER_EXECUTOR_MISSING: ${longDiagnostic}`,
+          diagnostics: {
+            server: 'sql.local',
+            package: longDiagnostic,
+          },
+          system: {
+            ...sqlSystem,
+            lastError: 'SQLSERVER_EXECUTOR_MISSING: inject queryExecutor when creating K3WiseSqlServerChannel',
+          },
+        })
+      }
+      if (url === '/api/integration/staging/descriptors') {
+        return jsonResponse([])
+      }
+      return jsonResponse({})
+    })
+
+    const View = (await import('../src/views/IntegrationK3WiseSetupView.vue')).default
+
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    registerRouterLinkStub(app)
+    app.mount(container)
+    await flushUi()
+
+    const button = Array.from(container.querySelectorAll('button')).find((item) => item.textContent?.includes('测试 SQL Server')) as HTMLButtonElement
+    expect(button.disabled).toBe(false)
+    button.click()
+    await flushUi(8)
+
+    const summary = container.querySelector('[data-testid="connection-test-summary"]') as HTMLElement | null
+    const diagnostics = container.querySelector('[data-testid="connection-test-diagnostics"]') as HTMLDetailsElement | null
+    expect(summary).not.toBeNull()
+    expect(summary!.textContent).toContain('SQLSERVER_EXECUTOR_MISSING')
+    expect(summary!.textContent).toContain('当前部署未注入 SQL 执行器')
+    expect(summary!.textContent).not.toContain(longDiagnostic.slice(0, 80))
+    expect(diagnostics).not.toBeNull()
+    expect(diagnostics!.open).toBe(false)
+    expect(diagnostics!.textContent).toContain('展开原始诊断 JSON')
   })
 
   it('warns and normalizes a plain Project ID on the K3 setup page', async () => {

--- a/apps/web/tests/IntegrationWorkbenchView.spec.ts
+++ b/apps/web/tests/IntegrationWorkbenchView.spec.ts
@@ -527,6 +527,23 @@ describe('IntegrationWorkbenchView', () => {
     ;(container.querySelector('[data-testid="load-target-objects"]') as HTMLButtonElement).click()
     await flushUi(8)
 
+    ;(container.querySelector('[data-testid="use-staging-source-bom_cleanse"]') as HTMLButtonElement).click()
+    await flushUi(12)
+    expect((container.querySelector('[data-testid="source-object"]') as HTMLSelectElement).value).toBe('bom_cleanse')
+    const mismatchNotice = container.querySelector('[data-testid="source-target-mismatch-notice"]') as HTMLElement | null
+    expect(mismatchNotice).not.toBeNull()
+    expect(mismatchNotice!.textContent).toContain('目标模板')
+    expect(mismatchNotice!.textContent).toContain('物料清洗')
+    expect(mismatchNotice!.textContent).toContain('BOM 清洗')
+    expect((container.querySelector('[data-testid="save-pipeline"]') as HTMLButtonElement).disabled).toBe(true)
+    expect(container.querySelector('[data-testid="save-readiness-summary"]')?.textContent).toContain('确认来源与目标匹配')
+
+    ;(container.querySelector('[data-testid="use-recommended-staging-source"]') as HTMLButtonElement).click()
+    await flushUi(12)
+    expect((container.querySelector('[data-testid="source-object"]') as HTMLSelectElement).value).toBe('standard_materials')
+    expect(container.querySelector('[data-testid="source-target-mismatch-notice"]')).toBeNull()
+    expect(container.textContent).toContain('已按目标模板切换到 物料清洗')
+
     expect((container.querySelector('[data-testid="source-field-0"]') as HTMLInputElement).value).toBe('code')
     expect((container.querySelector('[data-testid="target-field-0"]') as HTMLInputElement).value).toBe('FNumber')
     expect((container.querySelector('[data-testid="transform-fn-0"]') as HTMLSelectElement).value).toBe('trim')
@@ -678,8 +695,8 @@ describe('IntegrationWorkbenchView', () => {
 
     ;(container.querySelector('[data-testid="use-multitable-target-standard_materials"]') as HTMLButtonElement).click()
     await flushUi(10)
-    expect(externalSystemBodies).toHaveLength(2)
-    expect(externalSystemBodies[1]).toMatchObject({
+    const multitableTargetBody = externalSystemBodies.find((body) => body.kind === 'metasheet:multitable')
+    expect(multitableTargetBody).toMatchObject({
       id: 'metasheet_target_project_1',
       tenantId: 'default',
       workspaceId: null,
@@ -695,7 +712,7 @@ describe('IntegrationWorkbenchView', () => {
         upsert: true,
       },
     })
-    expect(externalSystemBodies[1].config).toMatchObject({
+    expect(multitableTargetBody?.config).toMatchObject({
       projectId: 'project_1',
       objects: {
         standard_materials: {

--- a/apps/web/tests/k3WiseSetup.spec.ts
+++ b/apps/web/tests/k3WiseSetup.spec.ts
@@ -856,9 +856,9 @@ describe('K3 WISE setup helpers', () => {
     })
 
     const messages = validateK3WisePipelineTemplateForm(form).map((issue) => issue.message)
-    expect(messages).toContain('PLM source system ID is required')
+    expect(messages).toContain('PLM source system ID is required for the K3 preset; use Data Factory with MetaSheet staging source when starting from existing staging tables')
     expect(messages).toContain('Save or select a K3 WISE WebAPI system before creating pipelines')
-    expect(() => buildK3WisePipelinePayloads(form)).toThrow('PLM source system ID is required')
+    expect(() => buildK3WisePipelinePayloads(form)).toThrow('use Data Factory with MetaSheet staging source')
   })
 
   it('keeps pipeline staging object validation permissive until descriptors are loaded', () => {
@@ -1055,6 +1055,7 @@ describe('K3 WISE setup helpers', () => {
     expect(byId['webapi-credentials']?.status).toBe('ready')
     expect(byId['sql-channel']?.status).toBe('warning')
     expect(byId['plm-source']?.status).toBe('external')
+    expect(byId['plm-source']?.message).toContain('MetaSheet staging 多维表')
     // Post-#1572 an empty projectId is valid: the server auto-scopes to
     // tenant:integration-core, so the staging gate is READY (not missing).
     expect(byId.staging?.status).toBe('ready')

--- a/docs/development/data-factory-issue1526-ux-followups-design-20260518.md
+++ b/docs/development/data-factory-issue1526-ux-followups-design-20260518.md
@@ -1,0 +1,65 @@
+# Data Factory issue #1526 UX follow-ups design - 2026-05-18
+
+## Scope
+
+This slice addresses the remaining operator-facing gaps found during the bridge smoke after the `dd1b87eb` package:
+
+- Data Factory Workbench allowed an accidental `bom_cleanse -> material` pairing. The dry-run could succeed with zero records, which looked like a product pass while not testing the material path.
+- K3 WISE preset pipeline creation still looked like a dead end when a PLM source system ID was absent, even when the operator already had MetaSheet staging tables available.
+- SQL Server connection testing rendered the full diagnostic JSON inline. The known `SQLSERVER_EXECUTOR_MISSING` condition should be a concise operator message first, with raw diagnostics collapsed for implementers.
+
+The change is intentionally frontend/UX/docs only. It does not touch `plugins/plugin-integration-core`, migrations, backend routes, SQL executor wiring, K3 WebAPI read/list runtime, relationship resolver runtime, or real K3 writes.
+
+## Workbench source/target pairing guard
+
+The Workbench now has a small K3 staging pairing table:
+
+| Target template | Recommended staging source |
+| --- | --- |
+| `material` | `standard_materials` |
+| `bom` | `bom_cleanse` |
+
+When the selected source is a MetaSheet staging source and the selected target is a known K3 template, the page compares the actual source object with the recommended staging object.
+
+If they differ, the page:
+
+- shows a strong warning explaining that the dry-run can succeed with zero processable rows;
+- exposes a one-click action to switch to the recommended staging source;
+- adds a readiness item named `确认来源与目标匹配`;
+- blocks save/dry-run by making the readiness item false;
+- throws the same message from `buildPipelinePayload()` as a last guard.
+
+The staging install auto-source selection also now prefers the target-specific staging object before falling back to the generic `standard_materials` default. This keeps the material smoke path on `standard_materials -> material` while still allowing a BOM target to prefer `bom_cleanse`.
+
+## K3 preset PLM-first wording
+
+The K3 preset remains a PLM-first creation page for material/BOM pipelines. It still requires `sourceSystemId` when the operator asks this page to create those preset pipelines.
+
+The page and service validation now explain the alternative path:
+
+- if a PLM source system exists, paste/select its source system ID and create preset pipelines here;
+- if the operator already has MetaSheet staging tables and wants a staging-first flow, use `/integrations/workbench`, select the MetaSheet staging source, and create the pipeline there.
+
+This preserves the current API contract while removing the "I have staging data but this page blocks me" ambiguity.
+
+## SQL test diagnostics
+
+Connection tests now write:
+
+- a short `connection-test-summary` for normal operators;
+- the full raw JSON under a collapsed `details` block for diagnostics.
+
+For `SQLSERVER_EXECUTOR_MISSING` and equivalent query-executor wording, the summary is normalized to:
+
+`SQLSERVER_EXECUTOR_MISSING: current deployment has no SQL executor injected, so the SQL read channel cannot act as a data source yet.`
+
+This is a UI presentation change only. It does not hide the SQL source as fixed, does not inject an executor, and does not change backend test results.
+
+## Non-goals
+
+- No SQL Server executor implementation.
+- No K3 WebAPI read/list runtime.
+- No relationship resolver runtime.
+- No new migration or table.
+- No real K3 Save / Submit / Audit path.
+- No removal of raw diagnostics for implementers; diagnostics are collapsed, not discarded.

--- a/docs/development/data-factory-issue1526-ux-followups-verification-20260518.md
+++ b/docs/development/data-factory-issue1526-ux-followups-verification-20260518.md
@@ -1,0 +1,97 @@
+# Data Factory issue #1526 UX follow-ups verification - 2026-05-18
+
+## Verification targets
+
+This PR verifies three frontend-only behaviors:
+
+1. `material` target no longer silently proceeds with `bom_cleanse` as the MetaSheet staging source.
+2. K3 preset pipeline creation guidance explicitly points staging-first operators to Data Factory when PLM source system ID is absent.
+3. SQL executor-missing diagnostics show a concise operator summary, with raw JSON collapsed behind an expandable diagnostic block.
+
+## Automated coverage
+
+### Workbench pairing guard
+
+`apps/web/tests/IntegrationWorkbenchView.spec.ts` now exercises:
+
+- staging install creates `standard_materials` and `bom_cleanse` open targets;
+- the operator can intentionally select `bom_cleanse` as source while target is `material`;
+- the page renders `source-target-mismatch-notice`;
+- save is blocked and readiness includes `确认来源与目标匹配`;
+- one-click normalization switches the source back to `standard_materials`;
+- the normal material preview/save/dry-run path still uses `standard_materials -> material`.
+
+### K3 preset guidance
+
+`apps/web/tests/k3WiseSetup.spec.ts` now verifies:
+
+- missing `sourceSystemId` still blocks K3 preset pipeline creation;
+- the validation message explains that staging-first flows should use Data Factory with MetaSheet staging source;
+- the deploy-gate `plm-source` message references MetaSheet staging fallback.
+
+`apps/web/tests/IntegrationK3WiseSetupView.spec.ts` also verifies the visible PLM source fallback hint in the setup page.
+
+### SQL diagnostic summary
+
+`apps/web/tests/IntegrationK3WiseSetupView.spec.ts` now feeds a long synthetic `SQLSERVER_EXECUTOR_MISSING` response through the SQL test UI and verifies:
+
+- the operator summary contains the normalized missing-executor wording;
+- the huge diagnostic body is not copied into the summary;
+- the raw JSON remains available in a collapsed diagnostic details block.
+
+## Commands to run
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/IntegrationWorkbenchView.spec.ts \
+  tests/IntegrationK3WiseSetupView.spec.ts \
+  tests/k3WiseSetup.spec.ts \
+  --watch=false
+
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+
+pnpm --filter @metasheet/web build
+
+git diff --check origin/main...HEAD
+```
+
+## Local result
+
+Run from branch `codex/data-factory-ux-followups-20260518`:
+
+| Command | Result |
+| --- | --- |
+| `pnpm --filter @metasheet/web exec vitest run tests/IntegrationWorkbenchView.spec.ts tests/IntegrationK3WiseSetupView.spec.ts tests/k3WiseSetup.spec.ts --watch=false` | PASS, 53/53 tests |
+| `pnpm --filter @metasheet/web exec vue-tsc --noEmit` | PASS |
+| `pnpm --filter @metasheet/web build` | PASS; Vite emitted existing chunk-size warnings only |
+| `git diff --check origin/main...HEAD` | PASS |
+
+## Manual bridge retest expectation
+
+After packaging and redeploying the resulting main commit:
+
+- Gate A/B should remain PASS.
+- C2/C4 should remain PASS.
+- Workbench material dry-run should guide to `standard_materials -> material`.
+- If an operator selects `bom_cleanse -> material`, the page should block save and show the mismatch warning instead of allowing a misleading zero-record dry-run.
+- K3 preset page should explain that missing PLM source system ID is a PLM-first limitation and that existing staging tables should be used from Data Factory.
+- SQL Server test may still fail with `SQLSERVER_EXECUTOR_MISSING`; that is expected until executor injection is implemented, but the UI should show a concise summary by default.
+
+## Stage 1 Lock check
+
+Touched areas:
+
+- `apps/web/src/views/IntegrationWorkbenchView.vue`
+- `apps/web/src/views/IntegrationK3WiseSetupView.vue`
+- `apps/web/src/services/integration/k3WiseSetup.ts`
+- frontend tests
+- docs
+
+Untouched areas:
+
+- `plugins/plugin-integration-core`
+- backend migrations
+- backend routes/API runtime
+- SQL executor runtime
+- K3 WebAPI read/list runtime
+- relationship resolver runtime


### PR DESCRIPTION
## Summary

- Add Data Factory Workbench guard for accidental MetaSheet staging/K3 template mismatches such as `bom_cleanse -> material`; save/dry-run readiness now points operators to `standard_materials -> material` and offers one-click correction.
- Clarify K3 WISE preset as PLM-first and direct staging-first operators to the Data Factory workbench when no PLM source system ID exists.
- Collapse raw K3 SQL test diagnostics behind an expandable block and show concise `SQLSERVER_EXECUTOR_MISSING` guidance by default.
- Add design and verification notes for this #1526 UX follow-up.

## Verification

- `pnpm --filter @metasheet/web exec vitest run tests/IntegrationWorkbenchView.spec.ts tests/IntegrationK3WiseSetupView.spec.ts tests/k3WiseSetup.spec.ts --watch=false` -> PASS, 53/53
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit` -> PASS
- `pnpm --filter @metasheet/web build` -> PASS; existing Vite chunk-size warnings only
- `git diff --check origin/main...HEAD` -> PASS

## Stage 1 Lock

No `plugins/plugin-integration-core`, backend route/API runtime, migration, SQL executor, K3 read/list runtime, relationship resolver, or real K3 write changes.

Refs #1526