### PR TITLE
feat(multitable): H-series install observation event + SOP

### DIFF
--- a/docs/operations/multitable-h-series-observation-sop-20260519.md
+++ b/docs/operations/multitable-h-series-observation-sop-20260519.md
@@ -1,0 +1,268 @@
+# Multitable H-Series Observation SOP
+
+**Date:** 2026-05-19
+**Status:** Operational runbook, no product behavior change
+**Scope:** Multitable H-series after H1/H2/H3 closeout
+
+## 1. Purpose
+
+The H-series shipped the main multitable onboarding path:
+
+- Home entry: recent bases, favorites, search, template quickstart.
+- Template center: `/multitable/templates`, category tabs, search, install action.
+- Industry templates: 8 built-in templates guarded by the template quality harness.
+
+This SOP defines how to observe whether that path is useful before starting more cleanup or new feature work.
+
+The current codebase does not provide full funnel analytics for page visits, category clicks, search terms, local favorites, or recent bases. Observation must therefore use two tracks:
+
+- Qualitative user feedback from a small, enumerable user set.
+- A minimal backend install event once `[multitable.template.install]` logging is available.
+
+## 2. Non-Goals
+
+This SOP does not authorize any of the following:
+
+- Frontend analytics for page views, search terms, category clicks, or localStorage behavior.
+- New Prometheus metrics.
+- New database tables or migrations.
+- Writes to `operation_audit_logs`.
+- Removing the `/grid` redirect before the Phase C observation gate.
+- Starting Phase E legacy view retirement.
+- Starting Phase D spreadsheet work.
+
+These remain separate decisions.
+
+## 3. Required Context
+
+Use this SOP after the following are true on the target environment:
+
+- H2 template center is deployed.
+- H3 industry templates are deployed.
+- The H-series closeout anchor is in `docs/development/views-consolidation-multitable-spreadsheets-plan-20260517.md`.
+
+If template install logging has not landed yet, run only the qualitative track and record that machine-readable install counts are unavailable.
+
+## 4. Qualitative Track
+
+Use this track as the primary signal while the user group is small.
+
+Interview 3 to 5 real internal or pilot users. Keep each interview under 5 minutes.
+
+Questions:
+
+1. Did you notice the multitable home page as the default entry?
+2. Did you see the "Template Center" entry?
+3. When creating a multitable base, did you start blank or install a template?
+4. If you used a template, which one did you choose and why?
+5. If you did not use a template, was it because you did not need one, could not find the right one, or did not notice the feature?
+6. Did category filtering help, or did you just scan the full template list?
+7. Did search help, or was it unused?
+8. Which missing scenario would make the template list useful for your team?
+9. After install, did the created base look immediately usable?
+10. What was the first thing you had to change after install?
+
+Record answers in a local note or issue using this shape:
+
+```md
+## Multitable H-Series Feedback - <date>
+
+- User/team:
+- Role:
+- Entry discovered from:
+- Blank vs template:
+- Template used:
+- Missing template:
+- First post-install edit:
+- Confusion/blocker:
+- Follow-up action:
+```
+
+Do not record private customer data, live business records, tokens, webhook URLs, or email addresses unless the user explicitly approves that content for internal tracking.
+
+## 5. Machine Track
+
+The only machine-readable signal worth collecting in the current architecture is template install.
+
+Expected backend event name:
+
+```text
+[multitable.template.install]
+```
+
+Expected successful event fields:
+
+```json
+{
+  "templateId": "contract-management",
+  "ok": true,
+  "userId": "<user-id>",
+  "baseId": "<created-base-id>",
+  "sheetId": "<first-created-sheet-id>"
+}
+```
+
+Expected failed event fields:
+
+```json
+{
+  "templateId": "contract-management",
+  "ok": false,
+  "userId": "<user-id-or-null>",
+  "statusCode": 404,
+  "errorCode": "NOT_FOUND"
+}
+```
+
+The event must not include `baseName`, request body, template content, email, token, workspace name, or arbitrary user-provided text.
+
+## 6. Log Collection
+
+Use the command that matches the deployment.
+
+There are two levels of evidence:
+
+- Event presence: `grep -F '[multitable.template.install]'` works for Docker stdout, local dev stdout, and JSON log files.
+- Field-level counting: `templateId` / `errorCode` extraction is reliable only when the captured line is JSON-formatted. Docker stdout uses the backend console formatter and may not preserve JSON fields in a sed-friendly shape.
+
+Docker container logs, event presence only:
+
+```bash
+docker logs metasheet-backend --since 168h 2>&1 \
+  | grep -F '[multitable.template.install]'
+```
+
+File or collector logs, event presence:
+
+```bash
+grep -F '[multitable.template.install]' /var/log/metasheet/backend*.log
+```
+
+Local development:
+
+```bash
+pnpm --filter @metasheet/core-backend dev 2>&1 \
+  | grep -F '[multitable.template.install]'
+```
+
+If the log source is JSON formatted, count installed templates:
+
+```bash
+grep -F '[multitable.template.install]' backend.log \
+  | grep '"ok":true' \
+  | sed -n 's/.*"templateId":"\([^"]*\)".*/\1/p' \
+  | sort \
+  | uniq -c \
+  | sort -nr
+```
+
+If the log source is JSON formatted, count failures:
+
+```bash
+grep -F '[multitable.template.install]' backend.log \
+  | grep '"ok":false' \
+  | sed -n 's/.*"errorCode":"\([^"]*\)".*/\1/p' \
+  | sort \
+  | uniq -c \
+  | sort -nr
+```
+
+If the logger output is not strict JSON, keep the raw event lines as evidence and summarize manually or through the log collector UI.
+
+## 7. Review Cadence
+
+Run two lightweight reviews:
+
+- Day 7 after deployment: check whether template install works and whether any H3 template is clearly unused.
+- Day 14 after deployment: decide whether to improve template content, change entry placement, or continue observing.
+
+Do not wait for statistically significant telemetry. This product stage has a small user pool. Use directional evidence.
+
+## 8. Decision Matrix
+
+| Observation | Interpretation | Action |
+| --- | --- | --- |
+| Users do not know template center exists | Entry/discovery problem | Move or strengthen template entry on multitable home |
+| Users install templates but immediately rewrite most fields | Template content mismatch | Revise that template instead of adding more templates |
+| 5 H3 templates receive zero installs while users are active | Template catalog mismatch | Interview users and replace low-value templates |
+| One or two templates dominate installs | Catalog has a useful direction | Add adjacent templates in that scenario |
+| Install events show `409` or `500` | Correctness issue | Fix install path before adding features |
+| Users only use home quickstart and never open `/multitable/templates` | Independent template center may be secondary | Consider surfacing more template-center capability on home |
+| Users ask for spreadsheet-like behavior | Spreadsheet need is real | Revisit Phase D only after license/package audit |
+| No `/grid` traffic after the Phase C observation window | Redirect is unused | Prepare Phase C redirect removal PR |
+| `/grid` traffic remains non-zero | Legacy links remain active | Keep redirect and identify source before removal |
+
+## 9. Phase C Preparation
+
+Phase C removes the `/grid` redirect only after the documented gate:
+
+- Earliest review: 2026-05-25.
+- Required signal: `/grid` hits are zero or explicitly accepted as removable.
+- Maintainer review trigger: 2026-06-30.
+
+`/grid` is a client-side Vue Router redirect:
+
+```ts
+{ path: '/grid', redirect: '/multitable' }
+```
+
+The backend only sees API traffic and must not be used as the primary `/grid` hit source. A backend log grep can return zero while real browsers still request `/grid` from the static frontend or reverse proxy layer.
+
+Before Phase C, collect `/grid` requests from the frontend/static/reverse-proxy access log, CDN log, or load-balancer access log:
+
+```bash
+grep -E '(GET|HEAD) /grid(\\?| |$)' /var/log/nginx/access.log* | tail -50
+```
+
+If the frontend is containerized, use the web/static container logs only if they include HTTP access logs:
+
+```bash
+docker logs metasheet-web --since 168h 2>&1 \
+  | grep -E '(GET|HEAD) /grid(\\?| |$)' \
+  | tail -50
+```
+
+If the deployment terminates HTTP at a CDN or external load balancer, use that access-log source instead. Record the exact source in the closeout report.
+
+Do not remove the redirect solely because the H-series is complete.
+
+## 10. Closeout Template
+
+Use this format when reporting an observation cycle:
+
+```md
+# Multitable H-Series Observation - <date>
+
+## Deployment
+
+- Commit/image:
+- Environment:
+- Observation window:
+
+## Qualitative Feedback
+
+- Users interviewed:
+- Template center discovered by:
+- Templates used:
+- Missing scenarios:
+- Main confusion:
+
+## Install Events
+
+- Total successful installs:
+- Installs by template:
+- Failures by code:
+- Raw log evidence location:
+
+## Phase C Signal
+
+- `/grid` hits:
+- Source if non-zero:
+- Recommendation:
+
+## Decision
+
+- Keep observing / improve template content / fix install bug / prepare Phase C:
+- Owner:
+- Next review date:
+```

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -72,6 +72,7 @@ import {
   installMultitableTemplate,
   listMultitableTemplates,
 } from '../multitable/template-library'
+import { Logger } from '../core/logger'
 import {
   queryRecordsWithCursor,
   buildRecordsCacheKey,
@@ -170,6 +171,13 @@ import {
 } from '../multitable/xlsx-service'
 
 const multitableFormulaEngine = new MultitableFormulaEngine()
+
+// Observation-readiness logger for the multitable H-series. Emits the stable
+// `[multitable.template.install]` event consumed by the H-series observation
+// SOP (docs/operations/multitable-h-series-observation-sop-20260519.md).
+// Structured fields only — never logs baseName / request body / token / email
+// / template content / arbitrary user text.
+const templateInstallLogger = new Logger('MultitableTemplates')
 
 /**
  * Module-level Yjs invalidator set by `index.ts` when the Yjs collab
@@ -3180,12 +3188,16 @@ export function univerMetaRouter(): Router {
       return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'templateId is required' } })
     }
 
+    // Hoisted so the catch block can attribute failures to the same user
+    // (access is block-scoped to the try). null = failure before auth resolved.
+    let userId: string | null = null
     try {
       const pool = poolManager.get()
       const access = await resolveRequestAccess(req)
       if (!access.userId) {
         return res.status(401).json({ ok: false, error: { code: 'UNAUTHENTICATED', message: 'Authentication required' } })
       }
+      userId = access.userId
 
       const result = await pool.transaction(async ({ query }) => installMultitableTemplate({
         query: query as unknown as QueryFn,
@@ -3196,18 +3208,52 @@ export function univerMetaRouter(): Router {
         idGenerator: (prefix) => buildId(prefix).slice(0, 50),
       }))
 
+      templateInstallLogger.info('[multitable.template.install]', {
+        templateId,
+        ok: true,
+        userId,
+        baseId: result.base.id,
+        sheetId: result.sheets[0]?.id ?? null,
+      })
       return res.status(201).json({ ok: true, data: result })
     } catch (err) {
+      let statusCode: number
+      let errorCode: string
+      let message: string
       if (err instanceof MultitableTemplateNotFoundError) {
-        return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: err.message } })
+        statusCode = 404
+        errorCode = 'NOT_FOUND'
+        message = err.message
+      } else if (err instanceof MultitableTemplateConflictError) {
+        statusCode = 409
+        errorCode = 'CONFLICT'
+        message = err.message
+      } else {
+        const hint = getDbNotReadyMessage(err)
+        if (hint) {
+          statusCode = 503
+          errorCode = 'DB_NOT_READY'
+          message = hint
+        } else {
+          statusCode = 500
+          errorCode = 'INTERNAL_ERROR'
+          message = 'Failed to install template'
+          // Raw exception/stack kept separate from the structured event
+          // (Logger.error only carries an Error, not arbitrary meta).
+          templateInstallLogger.error(
+            '[multitable.template.install] internal error',
+            err instanceof Error ? err : new Error(String(err)),
+          )
+        }
       }
-      if (err instanceof MultitableTemplateConflictError) {
-        return res.status(409).json({ ok: false, error: { code: 'CONFLICT', message: err.message } })
-      }
-      const hint = getDbNotReadyMessage(err)
-      if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })
-      console.error('[univer-meta] install multitable template failed:', err)
-      return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to install template' } })
+      templateInstallLogger.info('[multitable.template.install]', {
+        templateId,
+        ok: false,
+        userId,
+        statusCode,
+        errorCode,
+      })
+      return res.status(statusCode).json({ ok: false, error: { code: errorCode, message } })
     }
   })
 

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -3240,8 +3240,11 @@ export function univerMetaRouter(): Router {
           message = 'Failed to install template'
           // Raw exception/stack kept separate from the structured event
           // (Logger.error only carries an Error, not arbitrary meta).
+          // Message intentionally omits the stable `[multitable.template.install]`
+          // token so the SOP's event-name grep is not double-counted on the
+          // 500 path (this line + the structured ok:false event below).
           templateInstallLogger.error(
-            '[multitable.template.install] internal error',
+            'Install multitable template failed',
             err instanceof Error ? err : new Error(String(err)),
           )
         }

--- a/packages/core-backend/tests/integration/multitable-context.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-context.api.test.ts
@@ -719,6 +719,14 @@ describe('Multitable context API', () => {
       },
     })
 
+    // createApp() already ran vi.resetModules() + imported univer-meta, so
+    // importing core/logger now returns the same post-reset module instance
+    // the route's templateInstallLogger was constructed from. A prototype spy
+    // installed after construction still intercepts (info() resolves via the
+    // prototype at call time).
+    const { Logger } = await import('../../src/core/logger')
+    const infoSpy = vi.spyOn(Logger.prototype, 'info')
+
     const response = await request(app)
       .post('/api/multitable/templates/contract-management/install')
       .send({ baseName: 'Q3 Contracts' })
@@ -731,6 +739,48 @@ describe('Multitable context API', () => {
     expect(response.body.data.fields).toHaveLength(8)
     expect(response.body.data.views.map((view: any) => view.type)).toEqual(['grid', 'kanban', 'calendar'])
     expect(mockPool.transaction).toHaveBeenCalledTimes(1)
+
+    // Observation event: success path emits the stable install event with
+    // structured fields only (no baseName / body / token / email).
+    const successCall = infoSpy.mock.calls.find(([msg]) => msg === '[multitable.template.install]')
+    expect(successCall).toBeDefined()
+    const successMeta = successCall![1] as Record<string, unknown>
+    expect(successMeta).toMatchObject({
+      templateId: 'contract-management',
+      ok: true,
+      userId: 'user_multitable_1',
+    })
+    expect(successMeta).toHaveProperty('baseId')
+    expect(successMeta).toHaveProperty('sheetId')
+    expect(successMeta).not.toHaveProperty('baseName')
+    expect(JSON.stringify(successMeta)).not.toContain('Q3 Contracts')
+  })
+
+  test('logs a failed [multitable.template.install] event for an unknown template', async () => {
+    const { app } = await createApp({
+      tokenPerms: ['multitable:write'],
+      queryHandler: async () => ({ rows: [], rowCount: 0 }),
+    })
+
+    const { Logger } = await import('../../src/core/logger')
+    const infoSpy = vi.spyOn(Logger.prototype, 'info')
+
+    await request(app)
+      .post('/api/multitable/templates/no-such-template/install')
+      .send({ baseName: 'Whatever' })
+      .expect(404)
+
+    const failCall = infoSpy.mock.calls.find(([msg]) => msg === '[multitable.template.install]')
+    expect(failCall).toBeDefined()
+    const failMeta = failCall![1] as Record<string, unknown>
+    expect(failMeta).toMatchObject({
+      templateId: 'no-such-template',
+      ok: false,
+      statusCode: 404,
+      errorCode: 'NOT_FOUND',
+    })
+    expect(failMeta).not.toHaveProperty('baseName')
+    expect(JSON.stringify(failMeta)).not.toContain('Whatever')
   })
 
   test('allows create sheet under an owned base without global multitable write', async () => {


### PR DESCRIPTION
## Summary

H-series observation readiness. Adds the only machine-readable signal worth collecting in the current architecture (no frontend analytics, no multitable Prometheus metrics, favorites/recents are localStorage-only): a stable `[multitable.template.install]` backend event, plus the companion operations SOP for how to actually observe the H-series before deciding next steps.

This is the non-blocking "observation prep" the views-consolidation closeout anchor (#1656) endorsed as the next step — it does **not** start Phase C/D/E.

## Key Changes

### `packages/core-backend/src/routes/univer-meta.ts`

- Add `Logger('MultitableTemplates')` (project structured-logging convention; previously only a bare `console.error` on failure).
- Hoist `userId` above the `try` so the `catch` can attribute failures to the same user (`access` is block-scoped; `null` = failure before auth resolved).
- **Success**: emit `[multitable.template.install]` with `{ templateId, ok:true, userId, baseId, sheetId }` before the 201.
- **Failure**: compute `{ statusCode, errorCode }` once across all four branches (NOT_FOUND 404 / CONFLICT 409 / DB_NOT_READY 503 / INTERNAL_ERROR 500), then emit the same event with `{ templateId, ok:false, userId, statusCode, errorCode }` via `.info()` (`.error()` only carries an `Error`, not meta).
- 500-path raw exception logged separately via `.error('Install multitable template failed', err)` — **message intentionally omits the stable event token** so the SOP's `grep -F '[multitable.template.install]'` is not double-counted on the 500 path.
- Privacy: identifiers only. Never `baseName` / request body / template content / email / token / workspace name / arbitrary user text.

### `packages/core-backend/tests/integration/multitable-context.api.test.ts`

- Extend the contract-management install test: spy `Logger.prototype.info` (resolved from the post-`resetModules` `core/logger` module so it intercepts the route's already-constructed instance) and assert the success event shape + that the `baseName` value never leaks.
- New test: unknown template → 404 emits the failed event with `ok:false / statusCode:404 / errorCode:'NOT_FOUND'` and no `baseName`.

### `docs/operations/multitable-h-series-observation-sop-20260519.md`

Companion runbook. Qualitative-primary (small enumerable user pool) + machine-secondary. Notable accuracy points verified against code:
- §5 event schema matches the implementation exactly (success/failure/PII-exclusion).
- §6 two-level evidence: event-name `grep` works on docker stdout + JSON file logs; field-level `sed`/`uniq` counting only on the JSON file transport (winston console = `simple()`/colorized).
- §9 correctly notes `/grid` is a client-side Vue Router redirect (`appRoutes.ts:54`), so `backend.log` never contains it — the authoritative `/grid` hit source is the frontend/nginx/CDN/LB access log. (Prevents a false-safe Phase C signal.)

## Verification

- `pnpm --filter @metasheet/core-backend exec tsc --noEmit` — clean
- `vitest --config vitest.integration.config.ts run tests/integration/multitable-context.api.test.ts` — 21/21 passed (the file is in the default `vitest.config.ts` exclude list; integration config required)
- `git diff --check origin/main..HEAD` — clean
- Event-name spy confirms exactly one `[multitable.template.install]` call per request on both success and failure paths.

## Scope guard / K3 PoC stage-1 lock

- Observability polish on a shipped endpoint — no new product surface.
- No `/api/multitable/*` response-shape change, no DB migration, no `operation_audit_logs` write, no frontend analytics, no new Prometheus metric.
- No `plugins/plugin-integration-core/*`, `lib/adapters/k3-wise-*`, or Data Factory path touched.
- Does not start Phase C/D/E; Phase C `/grid` removal still gated by its observation window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)