### PR TITLE
feat(attendance): add period rollup sync writer

### DIFF
--- a/docs/development/attendance-report-period-rollup-sync-pr2-development-20260519.md
+++ b/docs/development/attendance-report-period-rollup-sync-pr2-development-20260519.md
@@ -1,0 +1,81 @@
+# 考勤 Period Rollup PR2 开发记录
+
+Date: 2026-05-19
+
+## Summary
+
+本轮实现 `attendance_report_period_summaries` 的后端 writer 与同步接口。PR1 已提供 descriptor / ensure；PR2 在此基础上把每员工每周期一行的 summary 快照写入插件私有多维表对象。
+
+边界保持不变：`attendance_*` 仍是事实源；period summaries 只是可重建报表层；写入只通过 `context.api.multitable.provisioning.ensureObject()` 与 `records.createRecord/patchRecord`，不裸写 `meta_*`，不新增 migration，不改前端。
+
+## Files
+
+- `plugins/plugin-attendance/index.cjs`
+  - 新增 period summary writer helper、row key、source fingerprint、动态 subtype 周期汇总、cycle/date-range period resolver。
+  - 新增 `POST /api/attendance/report-period-summaries/sync`。
+  - 导出 PR2 helper 到 `__attendanceReportFieldCatalogForTests`。
+- `packages/core-backend/tests/unit/attendance-report-field-catalog.test.ts`
+  - 新增 period helper / resolver / upsert / skip / duplicate / subtype / stale-null / bulk explicit users 单测。
+
+## Public Interface
+
+新增接口：
+
+`POST /api/attendance/report-period-summaries/sync`
+
+body 支持二选一 period source：
+
+- `{ from, to, userId | userIds | allUsers, page?, pageSize? }`
+- `{ cycleId, userId | userIds | allUsers, page?, pageSize? }`
+
+互斥规则：
+
+- `cycleId` 与 `from/to` 同传返回 400。
+- 缺少 `cycleId` 且缺少 `from/to` 返回 400。
+- `cycleId` 非 UUID 返回 400。
+- `cycleId` 不存在返回 404。
+- `allUsers` 与 `userId/userIds` 同传返回 400。
+- 未选择用户返回 400。
+
+row key：
+
+- date range：`${orgId}:${userId}:range:${from}:${to}`
+- payroll cycle：`${orgId}:${userId}:cycle:${cycleId}`
+
+period type：
+
+- date range：`date_range`
+- payroll cycle：`payroll_cycle`
+
+## Data Flow
+
+1. route 解析 period：
+   - date range 走 `resolveAttendanceDateRange()`。
+   - payroll cycle 读取 `attendance_payroll_cycles` 并映射 `startDate/endDate/name`。
+2. writer 确保 `attendance_report_period_summaries` 对象可用。
+3. 读取字段配置：
+   - summary 默认字段来自 `ATTENDANCE_SUMMARY_FORMULA_SOURCE_FIELDS`。
+   - summary 公式字段来自字段 catalog。
+   - 动态请假/加班 subtype 字段来自 `loadAttendanceReportDynamicSubtypeContext()`。
+4. 生成 managed value columns：
+   - summary 默认字段始终 managed。
+   - summary-scope 公式字段作为 managed superset，即使 disabled / hidden 也保留列，用于 stale-null。
+   - active dynamic subtype 字段进入 managed set。
+5. 计算值：
+   - 基础周期指标复用 `loadAttendanceSummary()`。
+   - subtype 周期值复用 `loadApprovedMinutesRange()` 的 `reportSubtypeMinutes`，按周期求和。
+   - summary 公式复用 `enrichAttendanceSummaryWithFormulaValues()`。
+6. upsert：
+   - 按物理 `fld_row_key` query。
+   - 无记录则 create。
+   - 有记录且 `source_fingerprint` + `field_fingerprint` 双等则 skip。
+   - 否则 patch。
+   - 多条同 row_key 只 patch 第一条，计 `duplicateRowKeys`，不自动删除。
+   - managed 但非 active 的值列显式写 `null`，防止停用字段残留脏值。
+
+## Notes
+
+- PR2 不实现前端入口；前端入口与 live evidence 留 PR3。
+- `allUsers` 分页复用 daily report-records 的 user page helper，优先 active org users，schema 缺失时 fallback 到 attendance_records owners。
+- period summary 可以在无 daily record 的周期写出 0 值 summary 行；员工名称来自 `users`，部门/考勤组来自周期内最近一条 attendance record meta，缺失则为空。
+- 动态 subtype schema 缺失时降级为空 subtype set，不阻断基础 summary。

--- a/docs/development/attendance-report-period-rollup-sync-pr2-verification-20260519.md
+++ b/docs/development/attendance-report-period-rollup-sync-pr2-verification-20260519.md
@@ -1,0 +1,63 @@
+# 考勤 Period Rollup PR2 验证记录
+
+Date: 2026-05-19
+
+## Scope
+
+验证范围是 period rollup PR2：后端 writer + route + 单测。前端入口、真实 staging live evidence、后台任务队列不在本轮。
+
+## Automated Checks
+
+| Check | Result |
+| --- | --- |
+| `node --check plugins/plugin-attendance/index.cjs` | PASS |
+| `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-report-field-catalog.test.ts tests/unit/attendance-report-field-formula-engine.test.ts --reporter=dot` | PASS, 48 tests |
+| `pnpm --filter @metasheet/core-backend build` | PASS |
+| `pnpm --filter @metasheet/web type-check` | PASS |
+| `git diff --check` | PASS |
+
+## Unit Coverage
+
+新增覆盖：
+
+- period value column helper：
+  - summary 默认字段进入 value columns。
+  - summary-scope formula 字段进入 managed set。
+  - record-scope formula 字段不进入 period managed set。
+  - period skeleton 字段不被 value columns 覆盖。
+- active value code helper：
+  - disabled summary formula 不参与输出，写入时会被 stale-null。
+- row key：
+  - date range row key：`${orgId}:${userId}:range:${from}:${to}`。
+  - payroll cycle row key：`${orgId}:${userId}:cycle:${cycleId}`。
+- source fingerprint：
+  - 排除 `synced_at`、`source_fingerprint`、`field_fingerprint`。
+  - key order 稳定。
+- period resolver：
+  - `cycleId` + `from/to` 同传返回 400。
+  - 缺 period source 返回 400。
+  - 非 UUID cycleId 返回 400。
+  - 不存在 cycle 返回 404。
+  - 有效 cycle 映射为 `payroll_cycle` 与正确 `from/to`。
+  - date range 映射为 `date_range` 与稳定 `periodKey`。
+- writer：
+  - 首次 sync create。
+  - 重跑 source + field fingerprint 双等 skip。
+  - field fingerprint stale 时 patch。
+  - duplicate row_key 计数但不删除。
+  - 动态请假 subtype 周期汇总写入非 0 值。
+  - disabled managed summary formula 旧值 patch 为 `null`。
+  - explicit `userIds` 去重并按用户聚合。
+
+## Boundary Checks
+
+- 不新增 `attendance_*` migration。
+- 不迁移 `attendance_records`。
+- 不让多维表公式直读 `attendance_*`。
+- 不裸写 `meta_*`。
+- writer 只写 `attendance_report_period_summaries`。
+- daily `attendance_report_records` 代码路径未改。
+
+## Pending
+
+- PR3 前端入口与 staging live evidence。

--- a/docs/development/attendance-report-period-rollup-sync-todo-20260519.md
+++ b/docs/development/attendance-report-period-rollup-sync-todo-20260519.md
@@ -49,7 +49,7 @@ Date: 2026-05-19
 
 **落地状态：** PR1 由 Claude 按用户**显式 scoped 指派**实现（偏离本文件 Governance 的默认 Codex-driven —— 决策者明确指派单条 PR1 链，非自启、非 re-scope；记录在此保留 Codex review 连续性）。实现镜像既有 daily `attendance_report_records` 的 PR1 模式（descriptor / view descriptor / ensure / 测试 surface / degraded 语义一致）。`plugins/plugin-attendance/index.cjs` 新增 `ATTENDANCE_REPORT_PERIOD_SUMMARIES_{OBJECT_ID,FIELDS,VIEW_ID}` + `getAttendanceReportPeriodSummariesDescriptor()` + `getAttendanceReportPeriodSummariesViewDescriptor()` + `ensureAttendanceReportPeriodSummaries()`，并入 `__attendanceReportFieldCatalogForTests` 测试 surface；后端单测加在 `attendance-report-field-catalog.test.ts`（descriptor 稳定 / 类型只用 string·date·dateTime·number·boolean / row_key required / projectId=`${orgId}:attendance` / provisioning 缺失 degraded 不抛 / ensureView 失败不阻断 ensureObject 成功）。PR2（writer+route）/ PR3（前端+evidence）仍为后续，回归默认 Codex-driven 或另行显式指派。
 
-### PR2：writer + route
+### PR2：writer + route — ✅ 本分支实现中（2026-05-19）
 
 - 复用 `loadAttendanceSummary(db, orgId, userId, from, to)` 作为周期基础指标 producer。
 - payroll cycle 模式先读取 `attendance_payroll_cycles`，解析 `startDate/endDate/name/templateId`，再走同一 summary producer。
@@ -57,6 +57,8 @@ Date: 2026-05-19
 - value columns 由「summary 默认字段 + summary 公式字段 + active dynamic subtype 字段」确定性生成，排序按 `sortOrder/code`，同 code 映射稳定 `fld_xxx`。
 - upsert 规则沿用 daily sync：按物理 `fld_xxx` 的 `row_key` query，命中 patch，未命中 create；source + field fingerprint 双等才 skip；patch 时非 active managed 列显式写 `null`。
 - 多条相同 `row_key`：patch 第一条，计 `duplicateRowKeys`，不自动删重复。
+
+**落地指针：** 开发记录见 `docs/development/attendance-report-period-rollup-sync-pr2-development-20260519.md`；验证记录见 `docs/development/attendance-report-period-rollup-sync-pr2-verification-20260519.md`。
 
 ### PR3：前端入口 + live evidence
 

--- a/packages/core-backend/tests/unit/attendance-report-field-catalog.test.ts
+++ b/packages/core-backend/tests/unit/attendance-report-field-catalog.test.ts
@@ -1328,6 +1328,411 @@ describe('attendance report field catalog multitable foundation', () => {
     expect(store[0].data.fld_source_fingerprint).not.toBe('STALE-SOURCE')
   })
 
+  it('period-summary sync: pure helpers and period resolver stay deterministic', async () => {
+    const managedFormulas = helpers.resolveAttendanceReportPeriodSummaryManagedFormulaFields([
+      {
+        code: 'period_efficiency',
+        name: '周期效率',
+        unit: 'number',
+        sortOrder: 30,
+        enabled: true,
+        reportVisible: true,
+        formulaEnabled: true,
+        formulaExpression: '={total_minutes}/{total_days}',
+        formulaScope: 'summary',
+        formulaOutputType: 'number',
+      },
+      {
+        code: 'disabled_period_score',
+        name: '停用周期分',
+        unit: 'number',
+        sortOrder: 20,
+        enabled: false,
+        reportVisible: true,
+        formulaEnabled: true,
+        formulaExpression: '={total_minutes}',
+        formulaScope: 'summary',
+        formulaOutputType: 'number',
+      },
+      {
+        code: 'record_formula_ignored',
+        formulaEnabled: true,
+        formulaScope: 'record',
+      },
+    ])
+    expect(managedFormulas.map((field: { code: string }) => field.code)).toEqual([
+      'disabled_period_score',
+      'period_efficiency',
+    ])
+
+    const valueFields = helpers.buildAttendanceReportPeriodSummaryValueFields(managedFormulas, [
+      { code: 'leave_type_annual_duration', name: '年假时长', unit: 'minutes', sortOrder: 10 },
+    ])
+    const columns = helpers.buildAttendanceReportPeriodSummaryValueColumns(valueFields)
+    expect(columns.map((column: { id: string }) => column.id)).toContain('total_minutes')
+    expect(columns.map((column: { id: string }) => column.id)).toContain('disabled_period_score')
+    expect(columns.map((column: { id: string }) => column.id)).toContain('leave_type_annual_duration')
+    expect(columns.every((column: { type: string }) => ['number', 'string'].includes(column.type))).toBe(true)
+    const skeletonIds = new Set(Object.values(helpers.ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS) as string[])
+    expect(columns.some((column: { id: string }) => skeletonIds.has(column.id))).toBe(false)
+
+    const activeCodes = helpers.buildAttendanceReportPeriodSummaryActiveValueCodes(
+      managedFormulas.filter((field: { enabled?: boolean }) => field.enabled !== false),
+      [{ code: 'leave_type_annual_duration' }],
+    )
+    expect(activeCodes.has('total_minutes')).toBe(true)
+    expect(activeCodes.has('period_efficiency')).toBe(true)
+    expect(activeCodes.has('disabled_period_score')).toBe(false)
+
+    expect(helpers.attendanceReportPeriodSummaryRowKey('org-1', 'u-1', {
+      periodType: 'date_range',
+      from: '2026-05-01',
+      to: '2026-05-31',
+    })).toBe('org-1:u-1:range:2026-05-01:2026-05-31')
+    expect(helpers.attendanceReportPeriodSummaryRowKey('org-1', 'u-1', {
+      periodType: 'payroll_cycle',
+      cycleId: '11111111-1111-4111-8111-111111111111',
+      from: '2026-05-01',
+      to: '2026-05-31',
+    })).toBe('org-1:u-1:cycle:11111111-1111-4111-8111-111111111111')
+
+    const fpA = helpers.buildAttendanceReportPeriodSummarySourceFingerprint({
+      b: 2,
+      a: 1,
+      synced_at: 'A',
+      source_fingerprint: 'B',
+      field_fingerprint: 'C',
+    })
+    const fpB = helpers.buildAttendanceReportPeriodSummarySourceFingerprint({
+      field_fingerprint: 'X',
+      source_fingerprint: 'Y',
+      synced_at: 'Z',
+      a: 1,
+      b: 2,
+    })
+    expect(fpA).toBe(fpB)
+    expect(helpers.buildAttendanceReportPeriodSummarySourceFingerprint({ a: 1, b: 3 })).not.toBe(fpA)
+
+    const subtypeTotals = helpers.buildAttendancePeriodSummarySubtypeTotals(new Map([
+      ['2026-05-01', { reportSubtypeMinutes: { leave_type_annual_duration: 60 } }],
+      ['2026-05-02', { reportSubtypeMinutes: { leave_type_annual_duration: 30, overtime_rule_r1_duration: 45 } }],
+    ]))
+    expect(subtypeTotals).toEqual({
+      leave_type_annual_duration: 90,
+      overtime_rule_r1_duration: 45,
+    })
+
+    const cycleId = '11111111-1111-4111-8111-111111111111'
+    const db = {
+      query: vi.fn(async (_sql: string, params?: unknown[]) => (
+        params?.[0] === cycleId
+          ? [{
+              id: cycleId,
+              org_id: 'org-1',
+              name: '2026-05 薪资周期',
+              start_date: '2026-05-01',
+              end_date: '2026-05-31',
+              status: 'open',
+            }]
+          : []
+      )),
+    }
+    expect(await helpers.resolveAttendanceReportPeriodSyncPeriod(db, 'org-1', { cycleId, from: '2026-05-01', to: '2026-05-31' }))
+      .toMatchObject({ ok: false, status: 400 })
+    expect(await helpers.resolveAttendanceReportPeriodSyncPeriod(db, 'org-1', {}))
+      .toMatchObject({ ok: false, status: 400 })
+    expect(await helpers.resolveAttendanceReportPeriodSyncPeriod(db, 'org-1', { from: '2026-05-01' }))
+      .toMatchObject({ ok: false, status: 400 })
+    expect(await helpers.resolveAttendanceReportPeriodSyncPeriod(db, 'org-1', { cycleId: 'not-a-uuid' }))
+      .toMatchObject({ ok: false, status: 400 })
+    expect(await helpers.resolveAttendanceReportPeriodSyncPeriod(db, 'org-1', { cycleId: '22222222-2222-4222-8222-222222222222' }))
+      .toMatchObject({ ok: false, status: 404 })
+    const cycle = await helpers.resolveAttendanceReportPeriodSyncPeriod(db, 'org-1', { cycleId })
+    expect(cycle).toMatchObject({
+      ok: true,
+      period: {
+        periodType: 'payroll_cycle',
+        periodKey: `cycle:${cycleId}`,
+        cycleId,
+        from: '2026-05-01',
+        to: '2026-05-31',
+      },
+    })
+    const range = await helpers.resolveAttendanceReportPeriodSyncPeriod(db, 'org-1', {
+      from: '2026-05-01',
+      to: '2026-05-31',
+    })
+    expect(range).toMatchObject({
+      ok: true,
+      period: {
+        periodType: 'date_range',
+        periodKey: 'range:2026-05-01:2026-05-31',
+      },
+    })
+  })
+
+  it('period-summary sync: upsert / skip / duplicate / subtype values / stale formula null', async () => {
+    const catalogFieldIds = Object.fromEntries(
+      Object.values(helpers.ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS).map((fieldId) => [fieldId, `fld_${fieldId}`]),
+    )
+    const disabledSummaryFormulaRecord = {
+      id: 'cfg-disabled-period-score',
+      data: {
+        fld_field_code: 'period_score',
+        fld_field_name: '周期得分',
+        fld_category: '出勤统计字段',
+        fld_source: 'custom',
+        fld_unit: 'number',
+        fld_enabled: false,
+        fld_report_visible: true,
+        fld_sort_order: 9500,
+        fld_dingtalk_field_name: '周期得分',
+        fld_description: '停用周期公式字段应清空旧值',
+        fld_internal_key: 'formula.period_score',
+        fld_formula_enabled: true,
+        fld_formula_expression: '={total_minutes}',
+        fld_formula_scope: 'summary',
+        fld_formula_output_type: 'number',
+      },
+    }
+    const store: Array<{ id: string; data: Record<string, unknown> }> = []
+    let seq = 0
+    const records = {
+      queryRecords: vi.fn(async ({ sheetId, filters }: { sheetId: string; filters?: Record<string, unknown> }) => {
+        if (sheetId === 'sheet_catalog') return [disabledSummaryFormulaRecord]
+        const want = filters?.fld_row_key
+        return store.filter(record => record.data.fld_row_key === want)
+      }),
+      createRecord: vi.fn(async ({ data }: { data: Record<string, unknown> }) => {
+        const record = { id: `rec-${++seq}`, data: { ...data } }
+        store.push(record)
+        return record
+      }),
+      patchRecord: vi.fn(async ({ recordId, changes }: { recordId: string; changes: Record<string, unknown> }) => {
+        const record = store.find(item => item.id === recordId)
+        if (record) record.data = { ...record.data, ...changes }
+        return record
+      }),
+    }
+    const ensureObjectDescriptors: Array<{ fields: Array<{ id: string; type: string }> }> = []
+    const provisioning = {
+      ensureObject: vi.fn(async (input: { descriptor?: { fields?: Array<{ id: string; type: string }> } }) => {
+        if (input?.descriptor?.fields) ensureObjectDescriptors.push({ fields: input.descriptor.fields })
+        return { baseId: 'base_period', sheet: { id: 'sheet_period' } }
+      }),
+      ensureView: vi.fn(async () => ({ id: 'view_period', sheetId: 'sheet_period' })),
+      findObjectSheet: vi.fn(async ({ objectId }: { objectId: string }) => (
+        objectId === 'attendance_report_field_catalog'
+          ? { id: 'sheet_catalog', baseId: 'base_catalog' }
+          : null
+      )),
+      resolveFieldIds: vi.fn(async ({ objectId, fieldIds }: { objectId: string; fieldIds: string[] }) => (
+        objectId === 'attendance_report_field_catalog'
+          ? Object.fromEntries(fieldIds.map(fieldId => [fieldId, catalogFieldIds[fieldId] || `fld_${fieldId}`]))
+          : Object.fromEntries(fieldIds.map(fieldId => [fieldId, `fld_${fieldId}`]))
+      )),
+    }
+    const db = {
+      query: vi.fn(async (sql: string) => {
+        if (/FROM attendance_leave_types/.test(sql)) {
+          return [{ id: 'leave-annual', code: 'annual', name: '年假', is_active: true }]
+        }
+        if (/FROM attendance_overtime_rules/.test(sql)) return []
+        if (/SELECT\s+COALESCE\(SUM\(CASE WHEN is_workday THEN 1 ELSE 0 END\)/.test(sql)) {
+          return [{
+            total_days: 2,
+            total_minutes: 960,
+            total_late_minutes: 10,
+            total_early_leave_minutes: 5,
+            normal_days: 1,
+            late_days: 1,
+            early_leave_days: 0,
+            late_early_days: 0,
+            partial_days: 0,
+            absent_days: 0,
+            adjusted_days: 0,
+            off_days: 0,
+          }]
+        }
+        if (/SELECT request_type,\s+COALESCE\(SUM/.test(sql) && /GROUP BY request_type/.test(sql)) {
+          return [{ request_type: 'leave', total_minutes: 240 }]
+        }
+        if (/metadata->'leaveType'->>'code'/.test(sql)) {
+          return [{ work_date: '2026-05-02', request_type: 'leave', subtype_key: 'annual', total_minutes: 240 }]
+        }
+        if (/SELECT work_date,\s+request_type/.test(sql) && /GROUP BY work_date, request_type/.test(sql)) {
+          return [{ work_date: '2026-05-02', request_type: 'leave', total_minutes: 240 }]
+        }
+        if (/FROM users u/.test(sql)) {
+          return [{
+            user_name: '张三',
+            username: 'zhangsan',
+            meta: { department: '研发', attendanceGroup: '默认考勤组' },
+          }]
+        }
+        return []
+      }),
+    }
+    const context = { api: { multitable: { provisioning, records }, database: db } }
+    const period = {
+      periodType: 'date_range',
+      periodKey: 'range:2026-05-01:2026-05-31',
+      cycleId: null,
+      periodName: '2026-05-01..2026-05-31',
+      from: '2026-05-01',
+      to: '2026-05-31',
+      periodStart: '2026-05-01',
+      periodEnd: '2026-05-31',
+    }
+
+    const first = await helpers.syncAttendanceReportPeriodSummary(
+      context,
+      db,
+      'org-1',
+      { warn: vi.fn() },
+      { period, userId: 'u-1' },
+    )
+    expect(first).toMatchObject({ synced: 1, usersScanned: 1, usersSynced: 1, created: 1, patched: 0, skipped: 0, failed: 0 })
+    expect(first.multitable).toMatchObject({
+      objectId: 'attendance_report_period_summaries',
+      sheetId: 'sheet_period',
+      viewId: 'view_period',
+    })
+    expect(store).toHaveLength(1)
+    expect(store[0].data.fld_row_key).toBe('org-1:u-1:range:2026-05-01:2026-05-31')
+    expect(store[0].data.fld_period_type).toBe('date_range')
+    expect(store[0].data.fld_period_start).toBe('2026-05-01')
+    expect(store[0].data.fld_total_minutes).toBe(960)
+    expect(store[0].data.fld_leave_minutes).toBe(240)
+    expect(store[0].data.fld_leave_type_annual_duration).toBe(240)
+    expect(store[0].data.fld_period_score).toBeNull()
+    const periodEnsure = ensureObjectDescriptors[ensureObjectDescriptors.length - 1]
+    expect(periodEnsure.fields.filter(field => field.id === 'period_start')).toHaveLength(1)
+    expect(periodEnsure.fields.filter(field => field.id === 'row_key')).toHaveLength(1)
+
+    const second = await helpers.syncAttendanceReportPeriodSummary(
+      context,
+      db,
+      'org-1',
+      { warn: vi.fn() },
+      { period, userId: 'u-1' },
+    )
+    expect(second).toMatchObject({ synced: 1, created: 0, patched: 0, skipped: 1 })
+
+    store[0].data.fld_field_fingerprint = 'STALE-FIELD'
+    store[0].data.fld_period_score = 99
+    const third = await helpers.syncAttendanceReportPeriodSummary(
+      context,
+      db,
+      'org-1',
+      { warn: vi.fn() },
+      { period, userId: 'u-1' },
+    )
+    expect(third).toMatchObject({ patched: 1, skipped: 0, duplicateRowKeys: 0 })
+    const patch = records.patchRecord.mock.calls.at(-1)?.[0]
+    expect(patch.changes.fld_period_score).toBeNull()
+    expect(store[0].data.fld_period_score).toBeNull()
+    expect(store[0].data.fld_field_fingerprint).not.toBe('STALE-FIELD')
+
+    store.push({ id: 'rec-duplicate', data: { ...store[0].data } })
+    const fourth = await helpers.syncAttendanceReportPeriodSummary(
+      context,
+      db,
+      'org-1',
+      { warn: vi.fn() },
+      { period, userId: 'u-1' },
+    )
+    expect(fourth.duplicateRowKeys).toBeGreaterThanOrEqual(1)
+    expect(store.filter(row => row.data.fld_row_key === 'org-1:u-1:range:2026-05-01:2026-05-31')).toHaveLength(2)
+  })
+
+  it('period-summary sync: explicit users aggregate per user', async () => {
+    const store: Array<{ id: string; data: Record<string, unknown> }> = []
+    let seq = 0
+    const records = {
+      queryRecords: async ({ filters }: { filters?: Record<string, unknown> }) => {
+        const want = filters?.fld_row_key
+        return store.filter(record => record.data.fld_row_key === want)
+      },
+      createRecord: async ({ data }: { data: Record<string, unknown> }) => {
+        const record = { id: `rec-${++seq}`, data: { ...data } }
+        store.push(record)
+        return record
+      },
+      patchRecord: async ({ recordId, changes }: { recordId: string; changes: Record<string, unknown> }) => {
+        const record = store.find(item => item.id === recordId)
+        if (record) record.data = { ...record.data, ...changes }
+        return record
+      },
+    }
+    const provisioning = {
+      ensureObject: async () => ({ baseId: 'base_period', sheet: { id: 'sheet_period' } }),
+      ensureView: async () => ({ id: 'view_period', sheetId: 'sheet_period' }),
+      resolveFieldIds: async ({ fieldIds }: { fieldIds: string[] }) =>
+        Object.fromEntries(fieldIds.map(fieldId => [fieldId, `fld_${fieldId}`])),
+    }
+    const db = {
+      query: async (sql: string) => {
+        if (/FROM attendance_leave_types/.test(sql) || /FROM attendance_overtime_rules/.test(sql)) return []
+        if (/SELECT\s+COALESCE\(SUM\(CASE WHEN is_workday THEN 1 ELSE 0 END\)/.test(sql)) {
+          return [{
+            total_days: 1,
+            total_minutes: 480,
+            total_late_minutes: 0,
+            total_early_leave_minutes: 0,
+            normal_days: 1,
+            late_days: 0,
+            early_leave_days: 0,
+            late_early_days: 0,
+            partial_days: 0,
+            absent_days: 0,
+            adjusted_days: 0,
+            off_days: 0,
+          }]
+        }
+        if (/FROM users u/.test(sql)) return [{ user_name: '员工', username: 'employee', meta: {} }]
+        return []
+      },
+    }
+    const context = { api: { multitable: { provisioning, records }, database: db } }
+    const period = {
+      periodType: 'date_range',
+      periodKey: 'range:2026-05-01:2026-05-31',
+      cycleId: null,
+      periodName: '2026-05-01..2026-05-31',
+      from: '2026-05-01',
+      to: '2026-05-31',
+      periodStart: '2026-05-01',
+      periodEnd: '2026-05-31',
+    }
+
+    const result = await helpers.syncAttendanceReportPeriodSummariesForUsers(
+      context,
+      db,
+      'org-1',
+      { warn: vi.fn() },
+      { period, userIds: ['u-1', ' u-1 ', 'u-2'] },
+    )
+    expect(result).toMatchObject({
+      userSelection: 'explicit',
+      totalUsers: 2,
+      usersScanned: 2,
+      usersSynced: 2,
+      synced: 2,
+      rowsSynced: 2,
+      created: 2,
+      patched: 0,
+      skipped: 0,
+      failed: 0,
+      hasNextPage: false,
+      periodType: 'date_range',
+    })
+    expect(store.map(row => row.data.fld_row_key)).toEqual([
+      'org-1:u-1:range:2026-05-01:2026-05-31',
+      'org-1:u-2:range:2026-05-01:2026-05-31',
+    ])
+  })
+
   it('does not add direct meta table writes to the attendance plugin', () => {
     const source = readFileSync(
       new URL('../../../../plugins/plugin-attendance/index.cjs', import.meta.url),

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -2639,6 +2639,496 @@ async function syncAttendanceReportRecordsForUsers(context, db, orgId, logger, p
   return aggregate
 }
 
+function resolveAttendanceReportPeriodSummaryManagedFormulaFields(items) {
+  return (Array.isArray(items) ? items : [])
+    .filter(field => (
+      field
+      && field.code
+      && field.formulaEnabled === true
+      && normalizeAttendanceReportFormulaScope(field.formulaScope) === 'summary'
+    ))
+    .map(field => ({
+      code: field.code,
+      name: field.name || field.code,
+      category: field.category || 'formula',
+      source: field.source || 'custom',
+      unit: field.unit || 'text',
+      sortOrder: Number(field.sortOrder) || 0,
+      configured: Boolean(field.configured),
+      systemDefined: field.systemDefined !== false,
+      enabled: field.enabled !== false,
+      reportVisible: field.reportVisible !== false,
+      formulaEnabled: true,
+      formulaExpression: field.formulaExpression || '',
+      formulaScope: 'summary',
+      formulaOutputType: normalizeAttendanceReportFormulaOutputType(field.formulaOutputType, field.unit),
+      formulaValid: field.formulaValid !== false,
+      formulaError: field.formulaError || null,
+      formulaReferences: Array.isArray(field.formulaReferences) ? field.formulaReferences : [],
+    }))
+    .sort((left, right) => {
+      if (left.sortOrder !== right.sortOrder) return left.sortOrder - right.sortOrder
+      return left.code.localeCompare(right.code)
+    })
+}
+
+function buildAttendanceReportPeriodSummaryValueFields(summaryFormulaFields = [], dynamicSubtypeDefinitions = []) {
+  const fields = []
+  const seen = new Set(Object.values(ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS))
+  for (const [index, field] of ATTENDANCE_SUMMARY_FORMULA_SOURCE_FIELDS.entries()) {
+    if (!field?.code || seen.has(field.code)) continue
+    seen.add(field.code)
+    fields.push({
+      ...field,
+      category: 'summary',
+      source: 'system',
+      sortOrder: 1000 + index,
+      systemDefined: true,
+      formulaEnabled: false,
+    })
+  }
+  for (const [index, field] of (Array.isArray(summaryFormulaFields) ? summaryFormulaFields : []).entries()) {
+    if (!field?.code || seen.has(field.code)) continue
+    seen.add(field.code)
+    fields.push({
+      ...field,
+      category: 'formula',
+      source: field.source || 'custom',
+      sortOrder: 2000 + (Number(field.sortOrder) || index),
+      configured: true,
+      systemDefined: field.systemDefined !== false,
+      formulaEnabled: true,
+    })
+  }
+  const sortedSubtypeDefinitions = [...(Array.isArray(dynamicSubtypeDefinitions) ? dynamicSubtypeDefinitions : [])]
+    .filter(field => field?.code)
+    .sort((left, right) => {
+      const leftSort = Number(left.sortOrder) || 0
+      const rightSort = Number(right.sortOrder) || 0
+      if (leftSort !== rightSort) return leftSort - rightSort
+      return String(left.code).localeCompare(String(right.code))
+    })
+  for (const [index, field] of sortedSubtypeDefinitions.entries()) {
+    if (!field?.code || seen.has(field.code)) continue
+    seen.add(field.code)
+    fields.push({
+      ...field,
+      sortOrder: 3000 + (Number(field.sortOrder) || index),
+      systemDefined: true,
+      formulaEnabled: false,
+    })
+  }
+  return fields
+}
+
+function buildAttendanceReportPeriodSummaryActiveValueCodes(summaryFormulaFields = [], dynamicSubtypeDefinitions = []) {
+  const codes = new Set(ATTENDANCE_SUMMARY_FORMULA_SOURCE_FIELDS.map(field => field.code))
+  for (const field of (Array.isArray(summaryFormulaFields) ? summaryFormulaFields : [])) {
+    if (field?.code) codes.add(field.code)
+  }
+  for (const field of (Array.isArray(dynamicSubtypeDefinitions) ? dynamicSubtypeDefinitions : [])) {
+    if (field?.code) codes.add(field.code)
+  }
+  return codes
+}
+
+function buildAttendanceReportPeriodSummaryValueColumns(valueFields) {
+  const skeletonIds = new Set(Object.values(ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS))
+  return (Array.isArray(valueFields) ? valueFields : [])
+    .filter(field => field?.code && !skeletonIds.has(field.code))
+    .map((field, index) => ({
+      id: field.code,
+      name: field.name || field.code,
+      type: mapReportFieldToMultitableType(field),
+      order: 1000 + index,
+    }))
+}
+
+function attendanceReportPeriodSummaryRowKey(orgId, userId, period) {
+  if (period?.cycleId) {
+    return `${orgId}:${userId}:cycle:${period.cycleId}`
+  }
+  return `${orgId}:${userId}:range:${period?.from}:${period?.to}`
+}
+
+function buildAttendanceReportPeriodSummarySourceFingerprint(logicalPayload) {
+  const excluded = new Set([
+    ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS.syncedAt,
+    ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS.fieldFingerprint,
+    ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS.sourceFingerprint,
+  ])
+  const canonical = Object.keys(logicalPayload)
+    .filter(key => !excluded.has(key))
+    .sort()
+    .map(key => [key, logicalPayload[key]])
+  return crypto.createHash('sha1').update(JSON.stringify(canonical)).digest('hex')
+}
+
+function buildAttendancePeriodSummarySubtypeTotals(approvedMap) {
+  const totals = {}
+  if (!(approvedMap instanceof Map)) return totals
+  for (const entry of approvedMap.values()) {
+    const subtypes = entry?.reportSubtypeMinutes && typeof entry.reportSubtypeMinutes === 'object'
+      ? entry.reportSubtypeMinutes
+      : {}
+    for (const [code, value] of Object.entries(subtypes)) {
+      totals[code] = (totals[code] ?? 0) + Number(value ?? 0)
+    }
+  }
+  return totals
+}
+
+function getAttendancePeriodSummaryFieldValue(summary, code) {
+  if (!summary || !code) return ''
+  const formulaValues = summary.formula_values && typeof summary.formula_values === 'object'
+    ? summary.formula_values
+    : {}
+  if (Object.prototype.hasOwnProperty.call(formulaValues, code)) return formulaValues[code]
+  const subtypeValues = summary.reportSubtypeMinutes && typeof summary.reportSubtypeMinutes === 'object'
+    ? summary.reportSubtypeMinutes
+    : {}
+  if (Object.prototype.hasOwnProperty.call(subtypeValues, code)) return subtypeValues[code]
+  return getAttendancePayrollSummaryFieldValue(summary, code)
+}
+
+async function loadAttendancePeriodSummaryEmployeeInfo(db, orgId, userId, from, to) {
+  const rows = await db.query(
+    `SELECT u.name AS user_name,
+            u.username AS username,
+            ar.meta AS meta
+     FROM users u
+     LEFT JOIN LATERAL (
+       SELECT meta
+       FROM attendance_records
+       WHERE user_id = u.id
+         AND org_id = $2
+         AND work_date BETWEEN $3 AND $4
+       ORDER BY work_date DESC
+       LIMIT 1
+     ) ar ON true
+     WHERE u.id = $1
+     LIMIT 1`,
+    [userId, orgId, from, to],
+  )
+  const row = rows[0] ?? {}
+  const metaRow = { meta: normalizeMetadata(row.meta) }
+  return {
+    employeeName: firstNonEmptyValue(row.user_name, row.username, userId),
+    department: firstNonEmptyValue(readAttendanceRecordMeta(metaRow, ['department', '部门'])),
+    attendanceGroup: firstNonEmptyValue(readAttendanceRecordMeta(metaRow, ['attendanceGroup', 'attendance_group', '考勤组'])),
+  }
+}
+
+async function resolveAttendanceReportPeriodSyncPeriod(db, orgId, params = {}) {
+  const cycleIdRaw = String(params?.cycleId || '').trim()
+  const hasCycle = Boolean(cycleIdRaw)
+  const hasFrom = params?.from !== undefined
+  const hasTo = params?.to !== undefined
+  const hasDateRangeInput = hasFrom || hasTo
+  if (hasCycle && hasDateRangeInput) {
+    return {
+      ok: false,
+      status: 400,
+      code: 'VALIDATION_ERROR',
+      message: 'Use either cycleId or from/to, not both',
+    }
+  }
+  if (hasCycle) {
+    const cycleId = normalizeUuidString(cycleIdRaw)
+    if (!cycleId) {
+      return { ok: false, status: 400, code: 'VALIDATION_ERROR', message: 'Invalid cycleId' }
+    }
+    const rows = await db.query(
+      'SELECT * FROM attendance_payroll_cycles WHERE id = $1 AND org_id = $2',
+      [cycleId, orgId],
+    )
+    if (!rows.length) {
+      return { ok: false, status: 404, code: 'NOT_FOUND', message: 'Payroll cycle not found' }
+    }
+    const cycle = mapPayrollCycleRow(rows[0])
+    return {
+      ok: true,
+      period: {
+        periodType: 'payroll_cycle',
+        periodKey: `cycle:${cycle.id}`,
+        cycleId: cycle.id,
+        periodName: cycle.name || cycle.id,
+        from: cycle.startDate,
+        to: cycle.endDate,
+        periodStart: cycle.startDate,
+        periodEnd: cycle.endDate,
+        cycle,
+      },
+    }
+  }
+  if (!hasDateRangeInput) {
+    return {
+      ok: false,
+      status: 400,
+      code: 'VALIDATION_ERROR',
+      message: 'cycleId or from/to is required',
+    }
+  }
+  if (!hasFrom || !hasTo) {
+    return {
+      ok: false,
+      status: 400,
+      code: 'VALIDATION_ERROR',
+      message: 'Both from and to are required for date range period sync',
+    }
+  }
+  const dateRange = resolveAttendanceDateRange(params?.from, params?.to)
+  if (!dateRange.ok) {
+    return { ok: false, status: 400, code: 'VALIDATION_ERROR', message: dateRange.message }
+  }
+  return {
+    ok: true,
+    period: {
+      periodType: 'date_range',
+      periodKey: `range:${dateRange.from}:${dateRange.to}`,
+      cycleId: null,
+      periodName: `${dateRange.from}..${dateRange.to}`,
+      from: dateRange.from,
+      to: dateRange.to,
+      periodStart: dateRange.from,
+      periodEnd: dateRange.to,
+    },
+  }
+}
+
+async function syncAttendanceReportPeriodSummary(context, db, orgId, logger, params) {
+  const userId = String(params?.userId || '').trim()
+  const period = params?.period
+  const empty = { synced: 0, patched: 0, created: 0, skipped: 0, failed: 0, duplicateRowKeys: 0 }
+  if (!userId || !period?.from || !period?.to) {
+    return { ...empty, failed: 1, reason: 'INVALID_SYNC_PARAMS' }
+  }
+
+  const ensured = await ensureAttendanceReportPeriodSummaries(context, orgId, logger)
+  if (!ensured.available) {
+    return { degraded: true, reason: ensured.reason, ...empty }
+  }
+  const records = context?.api?.multitable?.records
+  const provisioning = context?.api?.multitable?.provisioning
+  if (!records?.queryRecords || !records?.createRecord || !records?.patchRecord || !provisioning?.ensureObject) {
+    return { degraded: true, reason: 'MULTITABLE_RECORDS_API_UNAVAILABLE', ...empty }
+  }
+
+  const formulaOptions = await getAttendanceFormulaRuntimeOptions(db)
+  const catalog = await buildAttendanceReportFieldCatalogResponse(context, orgId, logger, {
+    provision: false,
+    ...formulaOptions,
+  })
+  const summaryFormulaFields = resolveAttendanceSummaryFormulaFields(catalog.items)
+  const managedSummaryFormulaFields = resolveAttendanceReportPeriodSummaryManagedFormulaFields(catalog.items)
+  const dynamicSubtype = await loadAttendanceReportDynamicSubtypeContext(db, orgId, logger)
+  const valueFields = buildAttendanceReportPeriodSummaryValueFields(managedSummaryFormulaFields, dynamicSubtype.definitions)
+  const valueColumns = buildAttendanceReportPeriodSummaryValueColumns(valueFields)
+  const activeValueCodes = buildAttendanceReportPeriodSummaryActiveValueCodes(summaryFormulaFields, dynamicSubtype.definitions)
+  const fieldFingerprint = buildAttendanceReportFieldConfigFingerprint(valueFields).value
+
+  const baseDescriptor = getAttendanceReportPeriodSummariesDescriptor()
+  await provisioning.ensureObject({
+    projectId: ensured.projectId,
+    descriptor: { ...baseDescriptor, fields: [...baseDescriptor.fields, ...valueColumns] },
+  })
+  const logicalIds = [
+    ...Object.values(ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS),
+    ...valueColumns.map(column => column.id),
+  ]
+  const fieldIds = typeof provisioning.resolveFieldIds === 'function'
+    ? await provisioning.resolveFieldIds({
+      projectId: ensured.projectId,
+      objectId: ATTENDANCE_REPORT_PERIOD_SUMMARIES_OBJECT_ID,
+      fieldIds: logicalIds,
+    })
+    : Object.fromEntries(logicalIds.map(id => [id, id]))
+  const physical = logicalId => fieldIds?.[logicalId] || logicalId
+
+  const result = { ...empty, synced: 1 }
+  const syncedAt = new Date().toISOString()
+  try {
+    const summary = await loadAttendanceSummary(db, orgId, userId, period.from, period.to)
+    const approvedMap = await loadApprovedMinutesRange(db, orgId, userId, period.from, period.to)
+    const reportSubtypeMinutes = buildAttendancePeriodSummarySubtypeTotals(approvedMap)
+    const summaryWithSubtype = {
+      ...summary,
+      ...reportSubtypeMinutes,
+      reportSubtypeMinutes,
+    }
+    const summaryWithFormulas = await enrichAttendanceSummaryWithFormulaValues(
+      context,
+      summaryWithSubtype,
+      summaryFormulaFields,
+    )
+    const employee = await loadAttendancePeriodSummaryEmployeeInfo(db, orgId, userId, period.from, period.to)
+    const rowKey = attendanceReportPeriodSummaryRowKey(orgId, userId, period)
+    const logical = {
+      [ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS.rowKey]: rowKey,
+      [ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS.orgId]: orgId,
+      [ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS.userId]: userId,
+      [ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS.employeeName]: employee.employeeName,
+      [ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS.department]: employee.department,
+      [ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS.attendanceGroup]: employee.attendanceGroup,
+      [ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS.periodType]: period.periodType,
+      [ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS.periodKey]: period.periodKey,
+      [ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS.cycleId]: period.cycleId || null,
+      [ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS.periodName]: period.periodName || '',
+      [ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS.periodStart]: period.periodStart || period.from,
+      [ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS.periodEnd]: period.periodEnd || period.to,
+    }
+    for (const column of valueColumns) {
+      if (!activeValueCodes.has(column.id)) {
+        logical[column.id] = null
+        continue
+      }
+      const value = getAttendancePeriodSummaryFieldValue(summaryWithFormulas, column.id)
+      logical[column.id] = value === '' && isAttendanceDynamicSubtypeCode(column.id) ? 0 : value
+    }
+    const sourceFingerprint = buildAttendanceReportPeriodSummarySourceFingerprint(logical)
+
+    const data = {}
+    for (const [logicalId, value] of Object.entries(logical)) {
+      data[physical(logicalId)] = value
+    }
+    data[physical(ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS.fieldFingerprint)] = fieldFingerprint
+    data[physical(ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS.sourceFingerprint)] = sourceFingerprint
+    data[physical(ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS.syncedAt)] = syncedAt
+
+    const existing = await records.queryRecords({
+      sheetId: ensured.sheetId,
+      filters: { [physical(ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS.rowKey)]: rowKey },
+      limit: 50,
+    })
+    if (!Array.isArray(existing) || existing.length === 0) {
+      await records.createRecord({ sheetId: ensured.sheetId, data })
+      result.created += 1
+    } else {
+      if (existing.length > 1) result.duplicateRowKeys += existing.length - 1
+      const target = existing[0]
+      const existingData = (target && target.data && typeof target.data === 'object') ? target.data : {}
+      const existingSource = existingData[physical(ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS.sourceFingerprint)]
+      const existingField = existingData[physical(ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS.fieldFingerprint)]
+      if (existingSource === sourceFingerprint && existingField === fieldFingerprint) {
+        result.skipped += 1
+      } else {
+        await records.patchRecord({ sheetId: ensured.sheetId, recordId: target.id, changes: data })
+        result.patched += 1
+      }
+    }
+  } catch (error) {
+    result.failed += 1
+    logger?.warn?.('attendance report period summary sync row failed', {
+      userId,
+      periodKey: period?.periodKey,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+
+  return {
+    ...result,
+    rowsSynced: result.synced,
+    usersScanned: 1,
+    usersSynced: result.failed > 0 ? 0 : 1,
+    usersFailed: result.failed > 0 ? 1 : 0,
+    failedUsers: result.failed > 0 ? [{ userId, failedRows: result.failed }] : [],
+    periodType: period.periodType,
+    periodKey: period.periodKey,
+    cycleId: period.cycleId || null,
+    from: period.from,
+    to: period.to,
+    fieldFingerprint,
+    syncedAt,
+    multitable: {
+      available: true,
+      degraded: false,
+      projectId: ensured.projectId,
+      objectId: ensured.objectId,
+      baseId: ensured.baseId || null,
+      sheetId: ensured.sheetId || null,
+      viewId: ensured.viewId || null,
+    },
+  }
+}
+
+async function syncAttendanceReportPeriodSummariesForUsers(context, db, orgId, logger, params) {
+  const period = params?.period
+  const explicitUserIds = normalizeAttendanceReportRecordsSyncUserIds(params?.userIds)
+  const selection = explicitUserIds.length > 0
+    ? {
+        userIds: explicitUserIds,
+        totalUsers: explicitUserIds.length,
+        page: 1,
+        pageSize: explicitUserIds.length,
+        hasNextPage: false,
+        userSelection: 'explicit',
+      }
+    : await loadAttendanceReportRecordsSyncUserPage(db, orgId, period.from, period.to, {
+      page: params?.page,
+      pageSize: params?.pageSize,
+    })
+
+  const aggregate = createAttendanceReportRecordsSyncEmptyResult({
+    totalUsers: selection.totalUsers,
+    page: selection.page,
+    pageSize: selection.pageSize,
+    hasNextPage: selection.hasNextPage,
+    userSelection: selection.userSelection,
+    periodType: period.periodType,
+    periodKey: period.periodKey,
+    cycleId: period.cycleId || null,
+    from: period.from,
+    to: period.to,
+  })
+
+  for (const userId of selection.userIds) {
+    aggregate.usersScanned += 1
+    try {
+      const result = await syncAttendanceReportPeriodSummary(context, db, orgId, logger, { period, userId })
+      if (result.degraded) {
+        return {
+          ...aggregate,
+          ...result,
+          rowsSynced: aggregate.synced,
+          totalUsers: selection.totalUsers,
+          page: selection.page,
+          pageSize: selection.pageSize,
+          hasNextPage: selection.hasNextPage,
+          userSelection: selection.userSelection,
+        }
+      }
+      aggregate.usersSynced += 1
+      aggregate.synced += Number(result.synced ?? 0)
+      aggregate.rowsSynced = aggregate.synced
+      aggregate.created += Number(result.created ?? 0)
+      aggregate.patched += Number(result.patched ?? 0)
+      aggregate.skipped += Number(result.skipped ?? 0)
+      aggregate.failed += Number(result.failed ?? 0)
+      aggregate.duplicateRowKeys += Number(result.duplicateRowKeys ?? 0)
+      if (Number(result.failed ?? 0) > 0) {
+        aggregate.failedUsers.push({ userId, failedRows: Number(result.failed ?? 0) })
+      }
+      if (result.fieldFingerprint) aggregate.fieldFingerprint = result.fieldFingerprint
+      if (result.syncedAt) aggregate.syncedAt = result.syncedAt
+      if (result.multitable) aggregate.multitable = result.multitable
+    } catch (error) {
+      aggregate.usersFailed += 1
+      aggregate.failed += 1
+      aggregate.failedUsers.push({
+        userId,
+        error: error instanceof Error ? error.message : String(error),
+      })
+      logger?.warn?.('attendance report period summaries user sync failed', {
+        userId,
+        periodKey: period?.periodKey,
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
+  aggregate.usersFailed = aggregate.failedUsers.length
+  return aggregate
+}
+
 async function loadAttendanceReportFieldCatalog(context, orgId) {
   const projectId = getAttendanceReportFieldProjectId(orgId)
   const multitable = context?.api?.multitable
@@ -10639,6 +11129,17 @@ module.exports = {
     getAttendanceReportPeriodSummariesDescriptor,
     getAttendanceReportPeriodSummariesViewDescriptor,
     ensureAttendanceReportPeriodSummaries,
+    resolveAttendanceReportPeriodSummaryManagedFormulaFields,
+    buildAttendanceReportPeriodSummaryValueFields,
+    buildAttendanceReportPeriodSummaryValueColumns,
+    buildAttendanceReportPeriodSummaryActiveValueCodes,
+    attendanceReportPeriodSummaryRowKey,
+    buildAttendanceReportPeriodSummarySourceFingerprint,
+    buildAttendancePeriodSummarySubtypeTotals,
+    getAttendancePeriodSummaryFieldValue,
+    resolveAttendanceReportPeriodSyncPeriod,
+    syncAttendanceReportPeriodSummary,
+    syncAttendanceReportPeriodSummariesForUsers,
     syncAttendanceReportRecords,
     syncAttendanceReportRecordsForUsers,
     normalizeAttendanceReportRecordsSyncUserIds,
@@ -22849,6 +23350,135 @@ module.exports = {
           syncedAt: result.syncedAt,
         })
         res.json({ ok: true, data: result })
+      })
+    )
+
+    context.api.http.addRoute(
+      'POST',
+      '/api/attendance/report-period-summaries/sync',
+      withPermission('attendance:admin', async (req, res) => {
+        const orgId = getOrgId(req)
+        const parsed = z.object({
+          from: z.string().min(1).optional(),
+          to: z.string().min(1).optional(),
+          cycleId: z.string().min(1).optional(),
+          userId: z.string().min(1).optional(),
+          userIds: z.array(z.string().min(1)).max(ATTENDANCE_REPORT_RECORDS_SYNC_MAX_PAGE_SIZE).optional(),
+          allUsers: z.boolean().optional(),
+          page: z.coerce.number().int().min(1).optional(),
+          pageSize: z.coerce.number().int().min(1).max(ATTENDANCE_REPORT_RECORDS_SYNC_MAX_PAGE_SIZE).optional(),
+        }).safeParse(req.body ?? {})
+        if (!parsed.success) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
+          return
+        }
+        const explicitUserIds = normalizeAttendanceReportRecordsSyncUserIds([
+          parsed.data.userId,
+          ...(parsed.data.userIds ?? []),
+        ])
+        if (parsed.data.allUsers === true && explicitUserIds.length > 0) {
+          res.status(400).json({
+            ok: false,
+            error: {
+              code: 'VALIDATION_ERROR',
+              message: 'Use either allUsers or userId/userIds, not both',
+            },
+          })
+          return
+        }
+        if (parsed.data.allUsers !== true && explicitUserIds.length === 0) {
+          res.status(400).json({
+            ok: false,
+            error: {
+              code: 'VALIDATION_ERROR',
+              message: 'userId, userIds, or allUsers is required',
+            },
+          })
+          return
+        }
+        if (explicitUserIds.length > ATTENDANCE_REPORT_RECORDS_SYNC_MAX_PAGE_SIZE) {
+          res.status(400).json({
+            ok: false,
+            error: {
+              code: 'VALIDATION_ERROR',
+              message: `At most ${ATTENDANCE_REPORT_RECORDS_SYNC_MAX_PAGE_SIZE} userIds can be synced in one request`,
+            },
+          })
+          return
+        }
+
+        try {
+          const resolvedPeriod = await resolveAttendanceReportPeriodSyncPeriod(db, orgId, parsed.data)
+          if (!resolvedPeriod.ok) {
+            res.status(resolvedPeriod.status || 400).json({
+              ok: false,
+              error: {
+                code: resolvedPeriod.code || 'VALIDATION_ERROR',
+                message: resolvedPeriod.message || 'Invalid period sync request',
+              },
+            })
+            return
+          }
+          const period = resolvedPeriod.period
+          const result = explicitUserIds.length === 1 && parsed.data.allUsers !== true && !Array.isArray(parsed.data.userIds)
+            ? await syncAttendanceReportPeriodSummary(context, db, orgId, logger, {
+              period,
+              userId: explicitUserIds[0],
+            })
+            : await syncAttendanceReportPeriodSummariesForUsers(context, db, orgId, logger, {
+              period,
+              userIds: explicitUserIds,
+              allUsers: parsed.data.allUsers,
+              page: parsed.data.page,
+              pageSize: parsed.data.pageSize,
+            })
+          if (result.degraded) {
+            res.json({
+              ok: true,
+              data: {
+                ...result,
+                degraded: true,
+                reason: result.reason,
+                periodType: period.periodType,
+                from: period.from,
+                to: period.to,
+                cycleId: period.cycleId || undefined,
+                synced: 0,
+              },
+            })
+            return
+          }
+          emitEvent('attendance.report_period_summaries.synced', {
+            orgId,
+            userId: explicitUserIds.length === 1 ? explicitUserIds[0] : undefined,
+            userIds: explicitUserIds.length > 1 ? explicitUserIds : undefined,
+            allUsers: parsed.data.allUsers === true,
+            periodType: period.periodType,
+            periodKey: period.periodKey,
+            cycleId: period.cycleId || undefined,
+            from: period.from,
+            to: period.to,
+            usersScanned: result.usersScanned,
+            usersSynced: result.usersSynced,
+            usersFailed: result.usersFailed,
+            synced: result.synced,
+            rowsSynced: result.rowsSynced,
+            patched: result.patched,
+            created: result.created,
+            skipped: result.skipped,
+            failed: result.failed,
+            duplicateRowKeys: result.duplicateRowKeys,
+            syncedAt: result.syncedAt,
+          })
+          res.json({ ok: true, data: result })
+        } catch (error) {
+          if (isDatabaseSchemaError(error)) {
+            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance tables missing' } })
+            return
+          }
+          logger.error('Attendance report period summaries sync failed', error)
+          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to sync attendance report period summaries' } })
+        }
       })
     )
 


### PR DESCRIPTION
## Summary

Implements PR2 for attendance period rollup sync: backend writer + route for the private multitable object `attendance_report_period_summaries`.

- Adds `POST /api/attendance/report-period-summaries/sync` with date-range or payroll-cycle period resolution
- Reuses `loadAttendanceSummary`, summary-scope formulas, and `loadApprovedMinutesRange` subtype aggregation
- Mirrors daily report-records upsert discipline: physical `row_key` lookup, create/patch, source+field fingerprint skip, duplicate-row fuse, and stale managed values patched to `null`
- Keeps boundaries: no attendance migration, no direct `meta_*` writes, no frontend in PR2

## Docs

- `docs/development/attendance-report-period-rollup-sync-pr2-development-20260519.md`
- `docs/development/attendance-report-period-rollup-sync-pr2-verification-20260519.md`
- Updates PR2 status in `attendance-report-period-rollup-sync-todo-20260519.md`

## Test plan

- [x] `node --check plugins/plugin-attendance/index.cjs`
- [x] `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-report-field-catalog.test.ts tests/unit/attendance-report-field-formula-engine.test.ts --reporter=dot` (48 tests)
- [x] `pnpm --filter @metasheet/core-backend build`
- [x] `pnpm --filter @metasheet/web type-check`
- [x] `git diff --check`

## Notes

PR3 remains frontend entry + live/staging evidence. This PR intentionally leaves the pnpm-install node_modules symlink noise unstaged and out of the commit.