### PR TITLE
feat(attendance): add period rollup sync UI

### DIFF
--- a/apps/web/src/views/attendance/AttendanceReportFieldsSection.vue
+++ b/apps/web/src/views/attendance/AttendanceReportFieldsSection.vue
@@ -601,6 +601,187 @@
       </dl>
     </div>
 
+    <div
+      class="attendance-report-fields__basis attendance-report-fields__record-sync"
+      data-report-period-summary-sync-panel
+    >
+      <div class="attendance-report-fields__basis-header">
+        <div>
+          <div class="attendance-report-fields__basis-title">
+            {{ tr('Period summaries sync', '周期汇总同步') }}
+          </div>
+          <div class="attendance__section-meta">
+            {{ tr('One row per employee and period; facts remain in attendance tables.', '每员工每周期一行；考勤事实源仍保留在考勤表。') }}
+          </div>
+        </div>
+        <a
+          v-if="reportPeriodSummariesMultitableHref"
+          class="attendance__btn"
+          :href="reportPeriodSummariesMultitableHref"
+          target="_blank"
+          rel="noreferrer"
+          data-report-period-summary-open-multitable
+        >
+          {{ tr('Open period summaries', '打开周期汇总多维表') }}
+        </a>
+      </div>
+      <div class="attendance-report-fields__record-sync-form">
+        <label class="attendance-report-fields__filter" for="attendance-report-period-summary-sync-period-mode">
+          <span>{{ tr('Period source', '周期来源') }}</span>
+          <select
+            id="attendance-report-period-summary-sync-period-mode"
+            v-model="periodSummarySyncMode"
+            data-report-period-summary-sync-period-mode
+          >
+            <option value="date_range">{{ tr('Date range', '日期范围') }}</option>
+            <option value="payroll_cycle">{{ tr('Payroll cycle', '薪资周期') }}</option>
+          </select>
+        </label>
+        <label
+          v-if="periodSummarySyncMode === 'date_range'"
+          class="attendance-report-fields__filter"
+          for="attendance-report-period-summary-sync-from"
+        >
+          <span>{{ tr('From date', '开始日期') }}</span>
+          <input
+            id="attendance-report-period-summary-sync-from"
+            v-model="periodSummarySyncFrom"
+            type="date"
+            data-report-period-summary-sync-from
+          >
+        </label>
+        <label
+          v-if="periodSummarySyncMode === 'date_range'"
+          class="attendance-report-fields__filter"
+          for="attendance-report-period-summary-sync-to"
+        >
+          <span>{{ tr('To date', '结束日期') }}</span>
+          <input
+            id="attendance-report-period-summary-sync-to"
+            v-model="periodSummarySyncTo"
+            type="date"
+            data-report-period-summary-sync-to
+          >
+        </label>
+        <label
+          v-if="periodSummarySyncMode === 'payroll_cycle'"
+          class="attendance-report-fields__filter"
+          for="attendance-report-period-summary-sync-cycle"
+        >
+          <span>{{ tr('Cycle ID', '薪资周期 ID') }}</span>
+          <input
+            id="attendance-report-period-summary-sync-cycle"
+            v-model="periodSummarySyncCycleId"
+            type="text"
+            :placeholder="tr('Payroll cycle UUID', '薪资周期 UUID')"
+            data-report-period-summary-sync-cycle
+          >
+        </label>
+        <label class="attendance-report-fields__filter" for="attendance-report-period-summary-sync-user-mode">
+          <span>{{ tr('Users', '员工范围') }}</span>
+          <select
+            id="attendance-report-period-summary-sync-user-mode"
+            v-model="periodSummarySyncUserMode"
+            data-report-period-summary-sync-user-mode
+          >
+            <option value="single">{{ tr('Single user', '单员工') }}</option>
+            <option value="multiple">{{ tr('User ID list', '员工 ID 列表') }}</option>
+            <option value="all">{{ tr('All active users', '全部活跃员工') }}</option>
+          </select>
+        </label>
+        <label
+          v-if="periodSummarySyncUserMode === 'single'"
+          class="attendance-report-fields__filter"
+          for="attendance-report-period-summary-sync-user"
+        >
+          <span>{{ tr('User ID', '员工 ID') }}</span>
+          <input
+            id="attendance-report-period-summary-sync-user"
+            v-model="periodSummarySyncUserId"
+            type="text"
+            :placeholder="tr('Required for single user', '单员工必填')"
+            data-report-period-summary-sync-user
+          >
+        </label>
+        <label
+          v-if="periodSummarySyncUserMode === 'multiple'"
+          class="attendance-report-fields__filter"
+          for="attendance-report-period-summary-sync-user-ids"
+        >
+          <span>{{ tr('User IDs', '员工 ID 列表') }}</span>
+          <textarea
+            id="attendance-report-period-summary-sync-user-ids"
+            v-model="periodSummarySyncUserIdsText"
+            rows="2"
+            :placeholder="tr('Comma, space, or newline separated', '逗号、空格或换行分隔')"
+            data-report-period-summary-sync-user-ids
+          />
+        </label>
+        <label class="attendance-report-fields__filter" for="attendance-report-period-summary-sync-page">
+          <span>{{ tr('Page', '页码') }}</span>
+          <input
+            id="attendance-report-period-summary-sync-page"
+            v-model.number="periodSummarySyncPage"
+            type="number"
+            min="1"
+            :disabled="periodSummarySyncUserMode !== 'all'"
+            data-report-period-summary-sync-page
+          >
+        </label>
+        <label class="attendance-report-fields__filter" for="attendance-report-period-summary-sync-page-size">
+          <span>{{ tr('Page size', '每页数量') }}</span>
+          <input
+            id="attendance-report-period-summary-sync-page-size"
+            v-model.number="periodSummarySyncPageSize"
+            type="number"
+            min="1"
+            max="100"
+            :disabled="periodSummarySyncUserMode !== 'all'"
+            data-report-period-summary-sync-page-size
+          >
+        </label>
+        <button
+          class="attendance__btn"
+          type="button"
+          :disabled="periodSummarySyncing || !canSyncReportPeriodSummaries"
+          data-report-period-summary-sync-button
+          @click="syncReportPeriodSummaries"
+        >
+          {{ periodSummarySyncing ? tr('Syncing...', '同步中...') : tr('Sync period summaries', '同步周期汇总') }}
+        </button>
+      </div>
+      <div
+        v-if="periodSummarySyncStatusMessage"
+        class="attendance__status"
+        :class="{
+          'attendance__status--error': periodSummarySyncStatusKind === 'error',
+          'attendance__status--warn': periodSummarySyncStatusKind === 'warn',
+        }"
+        role="status"
+        data-report-period-summary-sync-status
+      >
+        {{ periodSummarySyncStatusMessage }}
+      </div>
+      <dl
+        v-if="reportPeriodSummarySyncDetailRows.length > 0"
+        class="attendance-report-fields__basis-details"
+        data-report-period-summary-sync-details
+      >
+        <div
+          v-for="row in reportPeriodSummarySyncDetailRows"
+          :key="row.key"
+          class="attendance-report-fields__basis-detail"
+          :data-report-period-summary-sync-detail="row.key"
+        >
+          <dt>{{ row.label }}</dt>
+          <dd>
+            <code v-if="row.monospace">{{ row.value }}</code>
+            <span v-else>{{ row.value }}</span>
+          </dd>
+        </div>
+      </dl>
+    </div>
+
     <div v-if="reportFields.length > 0 && filteredReportFields.length === 0" class="attendance__empty">
       {{ tr('No report fields match the current filters.', '当前筛选条件下没有匹配的统计字段。') }}
     </div>
@@ -817,6 +998,8 @@ import { readErrorMessage } from '../../utils/error'
 
 type TranslateFn = (en: string, zh: string) => string
 type ReportFieldStatusFilter = 'all' | 'configured' | 'formula' | 'formula_error' | 'disabled' | 'hidden'
+type PeriodSummarySyncMode = 'date_range' | 'payroll_cycle'
+type PeriodSummarySyncUserMode = 'single' | 'multiple' | 'all'
 
 interface AttendanceReportFieldCategory {
   id: string
@@ -942,6 +1125,15 @@ interface AttendanceReportRecordsSyncResult {
   }
 }
 
+interface AttendanceReportPeriodSummariesSyncResult extends AttendanceReportRecordsSyncResult {
+  periodType?: string
+  periodKey?: string
+  cycleId?: string | null
+  periodName?: string
+  from?: string
+  to?: string
+}
+
 interface FieldMappingRow {
   key: string
   label: string
@@ -1012,6 +1204,19 @@ const recordSyncAllUsers = ref(false)
 const recordSyncPage = ref(1)
 const recordSyncPageSize = ref(50)
 const reportRecordsSyncResult = ref<AttendanceReportRecordsSyncResult | null>(null)
+const periodSummarySyncing = ref(false)
+const periodSummarySyncStatusMessage = ref('')
+const periodSummarySyncStatusKind = ref<'info' | 'warn' | 'error'>('info')
+const periodSummarySyncMode = ref<PeriodSummarySyncMode>('date_range')
+const periodSummarySyncFrom = ref(dateInputValue(-30))
+const periodSummarySyncTo = ref(dateInputValue(0))
+const periodSummarySyncCycleId = ref('')
+const periodSummarySyncUserMode = ref<PeriodSummarySyncUserMode>('single')
+const periodSummarySyncUserId = ref('')
+const periodSummarySyncUserIdsText = ref('')
+const periodSummarySyncPage = ref(1)
+const periodSummarySyncPageSize = ref(50)
+const reportPeriodSummariesSyncResult = ref<AttendanceReportPeriodSummariesSyncResult | null>(null)
 const fieldSearchTerm = ref('')
 const fieldStatusFilter = ref<ReportFieldStatusFilter>('all')
 const fieldCategoryFilter = ref('all')
@@ -1279,6 +1484,68 @@ const reportRecordSyncDetailRows = computed<MultitableDetailRow[]>(() => {
     const normalized = String(value ?? '').trim()
     if (normalized) rows.push({ key, label, value: normalized, monospace })
   }
+  addNumber('totalUsers', tr('Total users', '总员工数'), result.totalUsers)
+  addNumber('page', tr('Page', '页码'), result.page)
+  addNumber('pageSize', tr('Page size', '每页数量'), result.pageSize)
+  if (typeof result.hasNextPage === 'boolean') {
+    rows.push({
+      key: 'hasNextPage',
+      label: tr('Has next page', '还有下一页'),
+      value: result.hasNextPage ? tr('Yes', '是') : tr('No', '否'),
+    })
+  }
+  addNumber('usersScanned', tr('Users scanned', '扫描员工'), result.usersScanned)
+  addNumber('usersSynced', tr('Users synced', '同步员工'), result.usersSynced)
+  addNumber('usersFailed', tr('Users failed', '失败员工'), result.usersFailed)
+  addNumber('synced', tr('Rows read', '读取行数'), result.synced)
+  addNumber('created', tr('Created', '新建'), result.created)
+  addNumber('patched', tr('Patched', '更新'), result.patched)
+  addNumber('skipped', tr('Skipped', '跳过'), result.skipped)
+  addNumber('failed', tr('Failed', '失败'), result.failed)
+  addNumber('duplicateRowKeys', tr('Duplicate row keys', '重复行键'), result.duplicateRowKeys)
+  addText('fieldFingerprint', tr('Field fingerprint', '字段指纹'), result.fieldFingerprint, true)
+  addText('syncedAt', tr('Synced at', '同步时间'), result.syncedAt)
+  addText('projectId', tr('Project ID', '项目 ID'), result.multitable?.projectId, true)
+  addText('objectId', tr('Object ID', '对象 ID'), result.multitable?.objectId, true)
+  addText('sheetId', tr('Sheet ID', '表格 ID'), result.multitable?.sheetId, true)
+  addText('viewId', tr('View ID', '视图 ID'), result.multitable?.viewId, true)
+  addText('reason', tr('Reason', '原因'), result.reason)
+  return rows
+})
+const canSyncReportPeriodSummaries = computed(() => {
+  const hasPeriod = periodSummarySyncMode.value === 'payroll_cycle'
+    ? periodSummarySyncCycleId.value.trim() !== ''
+    : periodSummarySyncFrom.value.trim() !== '' && periodSummarySyncTo.value.trim() !== ''
+  if (!hasPeriod) return false
+  if (periodSummarySyncUserMode.value === 'all') return true
+  if (periodSummarySyncUserMode.value === 'multiple') return parsePeriodSummarySyncUserIds().length > 0
+  return periodSummarySyncUserId.value.trim() !== ''
+})
+const reportPeriodSummariesMultitableHref = computed(() => {
+  const multitable = reportPeriodSummariesSyncResult.value?.multitable
+  if (!multitable?.sheetId || !multitable.viewId) return ''
+  const params = new URLSearchParams()
+  if (multitable.baseId) params.set('baseId', multitable.baseId)
+  const suffix = params.toString()
+  return `/multitable/${encodeURIComponent(multitable.sheetId)}/${encodeURIComponent(multitable.viewId)}${suffix ? `?${suffix}` : ''}`
+})
+const reportPeriodSummarySyncDetailRows = computed<MultitableDetailRow[]>(() => {
+  const result = reportPeriodSummariesSyncResult.value
+  if (!result) return []
+  const rows: MultitableDetailRow[] = []
+  const addNumber = (key: string, label: string, value?: number) => {
+    if (Number.isFinite(value)) rows.push({ key, label, value: String(value) })
+  }
+  const addText = (key: string, label: string, value?: string | null, monospace = false) => {
+    const normalized = String(value ?? '').trim()
+    if (normalized) rows.push({ key, label, value: normalized, monospace })
+  }
+  addText('periodType', tr('Period type', '周期类型'), result.periodType)
+  addText('periodKey', tr('Period key', '周期键'), result.periodKey, true)
+  addText('cycleId', tr('Cycle ID', '薪资周期 ID'), result.cycleId, true)
+  addText('periodName', tr('Period name', '周期名称'), result.periodName)
+  addText('from', tr('From date', '开始日期'), result.from)
+  addText('to', tr('To date', '结束日期'), result.to)
   addNumber('totalUsers', tr('Total users', '总员工数'), result.totalUsers)
   addNumber('page', tr('Page', '页码'), result.page)
   addNumber('pageSize', tr('Page size', '每页数量'), result.pageSize)
@@ -1699,6 +1966,15 @@ function dateInputValue(offsetDays: number): string {
   return `${year}-${month}-${day}`
 }
 
+function parsePeriodSummarySyncUserIds(): string[] {
+  const seen = new Set<string>()
+  for (const raw of periodSummarySyncUserIdsText.value.split(/[\s,，;；]+/)) {
+    const userId = raw.trim()
+    if (userId) seen.add(userId)
+  }
+  return Array.from(seen)
+}
+
 function buildReportRecordsSyncStatusMessage(data: AttendanceReportRecordsSyncResult): string {
   if (data.degraded) {
     const reason = String(data.reason ?? '').trim()
@@ -1719,6 +1995,32 @@ function buildReportRecordsSyncStatusMessage(data: AttendanceReportRecordsSyncRe
   ].filter(Boolean)
   const summary = details.length > 0 ? ` ${details.join(' · ')}` : ''
   return `${tr('Report records synchronized.', '报表记录已同步。')}${summary}`
+}
+
+function buildReportPeriodSummariesSyncStatusMessage(data: AttendanceReportPeriodSummariesSyncResult): string {
+  if (data.degraded) {
+    const reason = String(data.reason ?? '').trim()
+    return reason
+      ? `${tr('Period summaries sync degraded.', '周期汇总同步已降级。')} ${reason}`
+      : tr('Period summaries sync degraded.', '周期汇总同步已降级。')
+  }
+  const details = [
+    syncStatusMetric('Users', '员工', data.usersScanned),
+    syncStatusMetric('Synced users', '已同步员工', data.usersSynced),
+    syncStatusMetric('Failed users', '失败员工', data.usersFailed),
+    syncStatusMetric('Rows', '行数', data.synced),
+    syncStatusMetric('Created', '新建', data.created),
+    syncStatusMetric('Patched', '更新', data.patched),
+    syncStatusMetric('Skipped', '跳过', data.skipped),
+    syncStatusMetric('Failed', '失败', data.failed),
+    syncStatusMetric('Duplicate row keys', '重复行键', data.duplicateRowKeys),
+  ].filter(Boolean)
+  const period = data.periodType
+    ? `${tr('Period', '周期')}: ${data.periodType}${data.from && data.to ? ` ${data.from}..${data.to}` : ''}`
+    : ''
+  if (period) details.unshift(period)
+  const summary = details.length > 0 ? ` ${details.join(' · ')}` : ''
+  return `${tr('Period summaries synchronized.', '周期汇总已同步。')}${summary}`
 }
 
 async function loadReportFields(): Promise<void> {
@@ -1808,6 +2110,53 @@ async function syncReportRecords(): Promise<void> {
     recordSyncStatusMessage.value = readErrorMessage(error, tr('Failed to sync report records', '同步报表记录失败'))
   } finally {
     recordSyncing.value = false
+  }
+}
+
+function buildReportPeriodSummariesSyncBody(): Record<string, unknown> {
+  const body: Record<string, unknown> = {}
+  if (periodSummarySyncMode.value === 'payroll_cycle') {
+    body.cycleId = periodSummarySyncCycleId.value.trim()
+  } else {
+    body.from = periodSummarySyncFrom.value.trim()
+    body.to = periodSummarySyncTo.value.trim()
+  }
+  if (periodSummarySyncUserMode.value === 'all') {
+    body.allUsers = true
+    body.page = Number(periodSummarySyncPage.value) || 1
+    body.pageSize = Number(periodSummarySyncPageSize.value) || 50
+  } else if (periodSummarySyncUserMode.value === 'multiple') {
+    body.userIds = parsePeriodSummarySyncUserIds()
+  } else {
+    body.userId = periodSummarySyncUserId.value.trim()
+  }
+  return body
+}
+
+async function syncReportPeriodSummaries(): Promise<void> {
+  if (!canSyncReportPeriodSummaries.value) return
+  periodSummarySyncing.value = true
+  periodSummarySyncStatusMessage.value = ''
+  periodSummarySyncStatusKind.value = 'info'
+  try {
+    const response = await apiFetch(`/api/attendance/report-period-summaries/sync${attendanceOrgQuerySuffix()}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(buildReportPeriodSummariesSyncBody()),
+    })
+    const payload = await response.json()
+    if (!response.ok || payload?.ok === false) {
+      throw payload
+    }
+    const data = payload?.data ?? {}
+    reportPeriodSummariesSyncResult.value = data
+    periodSummarySyncStatusKind.value = data.degraded ? 'warn' : 'info'
+    periodSummarySyncStatusMessage.value = buildReportPeriodSummariesSyncStatusMessage(data)
+  } catch (error) {
+    periodSummarySyncStatusKind.value = 'error'
+    periodSummarySyncStatusMessage.value = readErrorMessage(error, tr('Failed to sync period summaries', '同步周期汇总失败'))
+  } finally {
+    periodSummarySyncing.value = false
   }
 }
 

--- a/apps/web/tests/AttendanceReportFieldsSection.spec.ts
+++ b/apps/web/tests/AttendanceReportFieldsSection.spec.ts
@@ -964,4 +964,280 @@ describe('AttendanceReportFieldsSection', () => {
     expect(container!.querySelector('[data-report-record-open-multitable]')).toBeNull()
     expect(container!.textContent).toContain('Report fields')
   })
+
+  it('syncs date-range period summaries for a single user and shows the multitable result', async () => {
+    vi.mocked(apiFetch)
+      .mockResolvedValueOnce(jsonResponse(200, populatedCatalogPayload()))
+      .mockResolvedValueOnce(jsonResponse(200, {
+        ok: true,
+        data: {
+          periodType: 'date_range',
+          periodKey: 'range:2026-05-01:2026-05-31',
+          from: '2026-05-01',
+          to: '2026-05-31',
+          synced: 1,
+          created: 1,
+          patched: 0,
+          skipped: 0,
+          failed: 0,
+          duplicateRowKeys: 0,
+          usersScanned: 1,
+          usersSynced: 1,
+          usersFailed: 0,
+          fieldFingerprint: 'period-field-fingerprint',
+          syncedAt: '2026-05-19T12:00:00.000Z',
+          multitable: {
+            available: true,
+            degraded: false,
+            projectId: 'org-1:attendance',
+            objectId: 'attendance_report_period_summaries',
+            baseId: 'base-period',
+            sheetId: 'sheet-period',
+            viewId: 'view-period',
+          },
+        },
+      }))
+
+    mountSection()
+    await flushUi()
+
+    const fromInput = container!.querySelector<HTMLInputElement>('[data-report-period-summary-sync-from]')
+    const toInput = container!.querySelector<HTMLInputElement>('[data-report-period-summary-sync-to]')
+    const userInput = container!.querySelector<HTMLInputElement>('[data-report-period-summary-sync-user]')
+    const syncButton = container!.querySelector<HTMLButtonElement>('[data-report-period-summary-sync-button]')
+    expect(fromInput).toBeTruthy()
+    expect(toInput).toBeTruthy()
+    expect(userInput).toBeTruthy()
+    expect(syncButton).toBeTruthy()
+    expect(syncButton!.disabled).toBe(true)
+
+    fromInput!.value = '2026-05-01'
+    fromInput!.dispatchEvent(new Event('input', { bubbles: true }))
+    toInput!.value = '2026-05-31'
+    toInput!.dispatchEvent(new Event('input', { bubbles: true }))
+    userInput!.value = 'u-1'
+    userInput!.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+    expect(syncButton!.disabled).toBe(false)
+
+    syncButton!.click()
+    await flushUi()
+
+    expect(apiFetch).toHaveBeenCalledWith('/api/attendance/report-period-summaries/sync?orgId=org-1', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ from: '2026-05-01', to: '2026-05-31', userId: 'u-1' }),
+    })
+    const status = container!.querySelector('[data-report-period-summary-sync-status]')
+    expect(status?.textContent).toContain('Period summaries synchronized.')
+    expect(status?.textContent).toContain('Period: date_range 2026-05-01..2026-05-31')
+    expect(status?.textContent).toContain('Rows: 1')
+    expect(status?.textContent).toContain('Created: 1')
+    expect(container!.querySelector('[data-report-period-summary-sync-detail="periodType"]')?.textContent).toContain('date_range')
+    expect(container!.querySelector('[data-report-period-summary-sync-detail="fieldFingerprint"]')?.textContent).toContain('period-field-fingerprint')
+    expect(container!.querySelector('[data-report-period-summary-sync-detail="syncedAt"]')?.textContent).toContain('2026-05-19T12:00:00.000Z')
+    expect(container!.querySelector('[data-report-period-summary-sync-detail="objectId"]')?.textContent).toContain('attendance_report_period_summaries')
+    expect(container!.querySelector<HTMLAnchorElement>('[data-report-period-summary-open-multitable]')?.getAttribute('href'))
+      .toBe('/multitable/sheet-period/view-period?baseId=base-period')
+  })
+
+  it('syncs payroll-cycle period summaries for an explicit user list', async () => {
+    vi.mocked(apiFetch)
+      .mockResolvedValueOnce(jsonResponse(200, populatedCatalogPayload()))
+      .mockResolvedValueOnce(jsonResponse(200, {
+        ok: true,
+        data: {
+          periodType: 'payroll_cycle',
+          periodKey: 'cycle:11111111-1111-4111-8111-111111111111',
+          cycleId: '11111111-1111-4111-8111-111111111111',
+          periodName: 'May payroll',
+          from: '2026-05-01',
+          to: '2026-05-31',
+          synced: 2,
+          created: 2,
+          patched: 0,
+          skipped: 0,
+          failed: 0,
+          duplicateRowKeys: 0,
+          usersScanned: 2,
+          usersSynced: 2,
+          usersFailed: 0,
+          fieldFingerprint: 'cycle-field-fingerprint',
+          syncedAt: '2026-05-19T12:10:00.000Z',
+          multitable: {
+            available: true,
+            degraded: false,
+            projectId: 'org-1:attendance',
+            objectId: 'attendance_report_period_summaries',
+            sheetId: 'sheet-period',
+            viewId: 'view-period',
+          },
+        },
+      }))
+
+    mountSection()
+    await flushUi()
+
+    const periodMode = container!.querySelector<HTMLSelectElement>('[data-report-period-summary-sync-period-mode]')!
+    const userMode = container!.querySelector<HTMLSelectElement>('[data-report-period-summary-sync-user-mode]')!
+    periodMode.value = 'payroll_cycle'
+    periodMode.dispatchEvent(new Event('change', { bubbles: true }))
+    userMode.value = 'multiple'
+    userMode.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+
+    const cycleInput = container!.querySelector<HTMLInputElement>('[data-report-period-summary-sync-cycle]')!
+    const userIdsInput = container!.querySelector<HTMLTextAreaElement>('[data-report-period-summary-sync-user-ids]')!
+    cycleInput.value = '11111111-1111-4111-8111-111111111111'
+    cycleInput.dispatchEvent(new Event('input', { bubbles: true }))
+    userIdsInput.value = 'u-1, u-2\nu-3'
+    userIdsInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+
+    container!.querySelector<HTMLButtonElement>('[data-report-period-summary-sync-button]')!.click()
+    await flushUi()
+
+    expect(apiFetch).toHaveBeenCalledWith('/api/attendance/report-period-summaries/sync?orgId=org-1', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ cycleId: '11111111-1111-4111-8111-111111111111', userIds: ['u-1', 'u-2', 'u-3'] }),
+    })
+    expect(container!.querySelector('[data-report-period-summary-sync-detail="cycleId"]')?.textContent)
+      .toContain('11111111-1111-4111-8111-111111111111')
+    expect(container!.querySelector('[data-report-period-summary-sync-detail="periodName"]')?.textContent).toContain('May payroll')
+    expect(container!.querySelector('[data-report-period-summary-sync-detail="usersScanned"]')?.textContent).toContain('2')
+  })
+
+  it('syncs period summaries for all users with pagination controls', async () => {
+    vi.mocked(apiFetch)
+      .mockResolvedValueOnce(jsonResponse(200, populatedCatalogPayload()))
+      .mockResolvedValueOnce(jsonResponse(200, {
+        ok: true,
+        data: {
+          periodType: 'date_range',
+          from: '2026-05-01',
+          to: '2026-05-31',
+          synced: 4,
+          created: 3,
+          patched: 1,
+          skipped: 0,
+          failed: 0,
+          duplicateRowKeys: 0,
+          usersScanned: 2,
+          usersSynced: 2,
+          usersFailed: 0,
+          totalUsers: 7,
+          page: 2,
+          pageSize: 2,
+          hasNextPage: true,
+          fieldFingerprint: 'period-bulk-field-fingerprint',
+          syncedAt: '2026-05-19T12:20:00.000Z',
+          multitable: {
+            available: true,
+            degraded: false,
+            projectId: 'org-1:attendance',
+            objectId: 'attendance_report_period_summaries',
+            sheetId: 'sheet-period',
+            viewId: 'view-period',
+          },
+        },
+      }))
+
+    mountSection()
+    await flushUi()
+
+    const userMode = container!.querySelector<HTMLSelectElement>('[data-report-period-summary-sync-user-mode]')!
+    const pageInput = container!.querySelector<HTMLInputElement>('[data-report-period-summary-sync-page]')!
+    const pageSizeInput = container!.querySelector<HTMLInputElement>('[data-report-period-summary-sync-page-size]')!
+    const syncButton = container!.querySelector<HTMLButtonElement>('[data-report-period-summary-sync-button]')!
+    expect(pageInput.disabled).toBe(true)
+    expect(pageSizeInput.disabled).toBe(true)
+
+    userMode.value = 'all'
+    userMode.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+    expect(pageInput.disabled).toBe(false)
+    expect(pageSizeInput.disabled).toBe(false)
+
+    container!.querySelector<HTMLInputElement>('[data-report-period-summary-sync-from]')!.value = '2026-05-01'
+    container!.querySelector<HTMLInputElement>('[data-report-period-summary-sync-from]')!.dispatchEvent(new Event('input', { bubbles: true }))
+    container!.querySelector<HTMLInputElement>('[data-report-period-summary-sync-to]')!.value = '2026-05-31'
+    container!.querySelector<HTMLInputElement>('[data-report-period-summary-sync-to]')!.dispatchEvent(new Event('input', { bubbles: true }))
+    pageInput.value = '2'
+    pageInput.dispatchEvent(new Event('input', { bubbles: true }))
+    pageSizeInput.value = '2'
+    pageSizeInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+    expect(syncButton.disabled).toBe(false)
+
+    syncButton.click()
+    await flushUi()
+
+    expect(apiFetch).toHaveBeenCalledWith('/api/attendance/report-period-summaries/sync?orgId=org-1', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ from: '2026-05-01', to: '2026-05-31', allUsers: true, page: 2, pageSize: 2 }),
+    })
+    expect(container!.querySelector('[data-report-period-summary-sync-status]')?.textContent).toContain('Users: 2')
+    expect(container!.querySelector('[data-report-period-summary-sync-status]')?.textContent).toContain('Rows: 4')
+    expect(container!.querySelector('[data-report-period-summary-sync-detail="totalUsers"]')?.textContent).toContain('7')
+    expect(container!.querySelector('[data-report-period-summary-sync-detail="page"]')?.textContent).toContain('2')
+    expect(container!.querySelector('[data-report-period-summary-sync-detail="hasNextPage"]')?.textContent).toContain('Yes')
+    expect(container!.querySelector('[data-report-period-summary-sync-detail="fieldFingerprint"]')?.textContent).toContain('period-bulk-field-fingerprint')
+  })
+
+  it('shows degraded period summary sync as a non-blocking warning', async () => {
+    vi.mocked(apiFetch)
+      .mockResolvedValueOnce(jsonResponse(200, populatedCatalogPayload()))
+      .mockResolvedValueOnce(jsonResponse(200, {
+        ok: true,
+        data: {
+          degraded: true,
+          reason: 'MULTITABLE_RECORDS_API_UNAVAILABLE',
+          periodType: 'date_range',
+          from: '2026-05-01',
+          to: '2026-05-31',
+          synced: 0,
+        },
+      }))
+
+    mountSection()
+    await flushUi()
+
+    const userInput = container!.querySelector<HTMLInputElement>('[data-report-period-summary-sync-user]')!
+    userInput.value = 'u-1'
+    userInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+
+    container!.querySelector<HTMLButtonElement>('[data-report-period-summary-sync-button]')!.click()
+    await flushUi()
+
+    const status = container!.querySelector('[data-report-period-summary-sync-status]')
+    expect(status?.textContent).toContain('Period summaries sync degraded.')
+    expect(status?.textContent).toContain('MULTITABLE_RECORDS_API_UNAVAILABLE')
+    expect(status?.className).toContain('attendance__status--warn')
+    expect(container!.querySelector('[data-report-period-summary-open-multitable]')).toBeNull()
+  })
+
+  it('shows period summary sync API errors without clearing the report fields panel', async () => {
+    vi.mocked(apiFetch)
+      .mockResolvedValueOnce(jsonResponse(200, populatedCatalogPayload()))
+      .mockResolvedValueOnce(jsonResponse(400, { ok: false }))
+
+    mountSection()
+    await flushUi()
+
+    const userInput = container!.querySelector<HTMLInputElement>('[data-report-period-summary-sync-user]')!
+    userInput.value = 'u-1'
+    userInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+
+    container!.querySelector<HTMLButtonElement>('[data-report-period-summary-sync-button]')!.click()
+    await flushUi()
+
+    const status = container!.querySelector('[data-report-period-summary-sync-status]')
+    expect(status?.textContent).toContain('Failed to sync period summaries')
+    expect(status?.className).toContain('attendance__status--error')
+    expect(container!.textContent).toContain('Report fields')
+  })
 })

--- a/docs/development/attendance-report-period-rollup-sync-pr3-design-20260519.md
+++ b/docs/development/attendance-report-period-rollup-sync-pr3-design-20260519.md
@@ -1,0 +1,55 @@
+# 考勤 Period Rollup PR3 设计记录
+
+Date: 2026-05-19
+
+## Summary
+
+本轮为 `attendance_report_period_summaries` 增加前端同步入口。PR1 已 provision 周期汇总对象，PR2 已提供 `POST /api/attendance/report-period-summaries/sync` writer；PR3 只在考勤统计字段区域接入 UI，不改后端计算、不改事实源、不新增 migration。
+
+边界保持不变：`attendance_*` 仍是事实源；周期汇总多维表只是可重建报表快照；前端只调用插件 API，不直接读写 `meta_*`。
+
+## Files
+
+- `apps/web/src/views/attendance/AttendanceReportFieldsSection.vue`
+  - 新增「Period summaries sync」面板。
+  - 支持 date range 与 payroll cycle 两种 period source。
+  - 支持 single user、userIds list、all active users + page/pageSize。
+  - 展示 synced / created / patched / skipped / failed / duplicate row keys / users counters / field fingerprint / syncedAt。
+  - 成功后提供打开 `attendance_report_period_summaries` 多维表 view 的入口。
+- `apps/web/tests/AttendanceReportFieldsSection.spec.ts`
+  - 增加 period sync UI 与请求 body、结果展示、degraded、error 路径测试。
+- `docs/development/attendance-report-period-rollup-sync-todo-20260519.md`
+  - 补充 PR3 落地指针。
+
+## UI Contract
+
+新增面板使用独立 `data-report-period-summary-sync-*` selector，不复用 daily sync selector，避免测试与行为互相污染。
+
+请求 body 由 UI 模式确定：
+
+- date range + single user：
+  - `{ from, to, userId }`
+- payroll cycle + userIds：
+  - `{ cycleId, userIds }`
+- date range / payroll cycle + all users：
+  - `{ from, to, allUsers, page, pageSize }` 或 `{ cycleId, allUsers, page, pageSize }`
+
+禁用规则：
+
+- date range 模式必须填写 `from` 与 `to`。
+- payroll cycle 模式必须填写 `cycleId`。
+- user scope 必须三选一：single user、userIds list、all users。
+- all users 模式才启用 `page` / `pageSize`。
+
+## Status Semantics
+
+- `data.degraded === true` 显示 warn 状态，不清空字段面板。
+- HTTP 非 2xx 或 `{ ok:false }` 显示 error 状态，不清空字段面板。
+- 成功结果展示 multitable object / sheet / view IDs，并生成 `/multitable/:sheetId/:viewId?baseId=...` 链接。
+
+## Boundary Notes
+
+- 不触 `plugins/plugin-attendance/index.cjs`。
+- 不新增后端 route、schema、migration。
+- 不让前端重写 period rollup 参数校验；最终校验仍在 PR2 后端 route。
+- staging live evidence 需要 PR3 合并并部署到 staging 后再补；本轮只做前端 mock/contract 验证。

--- a/docs/development/attendance-report-period-rollup-sync-pr3-verification-20260519.md
+++ b/docs/development/attendance-report-period-rollup-sync-pr3-verification-20260519.md
@@ -1,0 +1,52 @@
+# 考勤 Period Rollup PR3 验证记录
+
+Date: 2026-05-19
+
+## Summary
+
+本轮验证覆盖周期汇总同步入口的前端行为：date range、payroll cycle、single user、userIds、all users pagination、成功结果、degraded warning、API error。未运行真实 staging live evidence，因为 PR3 前端尚未合并部署到 staging；后续部署后可用真实 admin 会话补证据。
+
+## Commands
+
+```bash
+NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/AttendanceReportFieldsSection.spec.ts --watch=false
+NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/AttendanceReportFieldsSection.spec.ts tests/attendance-admin-regressions.spec.ts --watch=false
+pnpm --filter @metasheet/web type-check
+node --check plugins/plugin-attendance/index.cjs
+pnpm --filter @metasheet/web build
+pnpm --filter @metasheet/core-backend build
+git diff --check
+```
+
+结果：
+
+```text
+PASS tests/AttendanceReportFieldsSection.spec.ts
+26 tests passed
+
+PASS tests/AttendanceReportFieldsSection.spec.ts tests/attendance-admin-regressions.spec.ts
+37 tests passed
+
+vue-tsc -b PASS
+plugin syntax PASS
+web build PASS
+core-backend build PASS
+git diff --check PASS
+```
+
+## Coverage
+
+| Area | Evidence |
+| --- | --- |
+| date range + single user | 请求 `POST /api/attendance/report-period-summaries/sync?orgId=org-1`，body 为 `{ from, to, userId }` |
+| payroll cycle + userIds | body 为 `{ cycleId, userIds: [...] }`，不发送 `from/to` |
+| all users pagination | body 为 `{ from, to, allUsers:true, page, pageSize }` |
+| success display | 展示 `periodType`、`fieldFingerprint`、`syncedAt`、`attendance_report_period_summaries` object id |
+| multitable link | 生成 `/multitable/sheet-period/view-period?baseId=base-period` |
+| degraded | `degraded:true` 显示 warn，保留页面 |
+| error | HTTP 400 / `ok:false` 显示 error，保留页面 |
+
+## Deferred Evidence
+
+- Staging live evidence: pending after PR3 is merged and deployed to staging.
+- No production write was performed in this verification.

--- a/docs/development/attendance-report-period-rollup-sync-todo-20260519.md
+++ b/docs/development/attendance-report-period-rollup-sync-todo-20260519.md
@@ -67,6 +67,8 @@ Date: 2026-05-19
 - 展示 synced/created/patched/skipped/failed、`fieldFingerprint`、`syncedAt`、打开多维表入口。
 - staging live evidence 只在明确授权后执行，不写 production。
 
+**落地指针：** PR3 设计记录见 `docs/development/attendance-report-period-rollup-sync-pr3-design-20260519.md`；验证记录见 `docs/development/attendance-report-period-rollup-sync-pr3-verification-20260519.md`。
+
 ## Test Plan
 
 - 后端单测：


### PR DESCRIPTION
## Summary

Adds the PR3 frontend entry for attendance period rollup sync. The report fields admin section can now call `POST /api/attendance/report-period-summaries/sync` for date ranges or payroll cycles, with single-user, explicit user list, and all-users pagination modes.

This is frontend-only: no backend writer changes, no `attendance_*` migration, and no direct `meta_*` access. The period summaries multitable remains a rebuildable report layer backed by the PR1/PR2 plugin APIs.

## Test plan

- [x] `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/AttendanceReportFieldsSection.spec.ts --watch=false` — 26 pass
- [x] `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/AttendanceReportFieldsSection.spec.ts tests/attendance-admin-regressions.spec.ts --watch=false` — 37 pass
- [x] `pnpm --filter @metasheet/web type-check`
- [x] `node --check plugins/plugin-attendance/index.cjs`
- [x] `pnpm --filter @metasheet/web build`
- [x] `pnpm --filter @metasheet/core-backend build`
- [x] `git diff --check`

## Notes

- Staging live evidence is deferred until this frontend is merged and deployed to staging.
- `pnpm install` in the isolated worktree produced tracked `node_modules` symlink noise; the commit explicitly stages only the 5 PR files.
