### PR TITLE
feat(multitable): localize workbench shell to zh-CN (T2 i18n)

### DIFF
--- a/apps/web/src/multitable/components/MetaTemplateCard.vue
+++ b/apps/web/src/multitable/components/MetaTemplateCard.vue
@@ -13,9 +13,9 @@
     <h3 class="meta-template-card__name">{{ template.name }}</h3>
     <p class="meta-template-card__description">{{ template.description }}</p>
     <small class="meta-template-card__meta">
-      {{ template.sheets.length }} 个 Sheet ·
-      {{ fieldCount }} 个字段 ·
-      {{ viewCount }} 个视图
+      {{ cardSheets(template.sheets.length, isZh) }} ·
+      {{ cardFields(fieldCount, isZh) }} ·
+      {{ cardViews(viewCount, isZh) }}
     </small>
     <button
       type="button"
@@ -23,7 +23,7 @@
       :disabled="installing"
       @click="emit('install', template)"
     >
-      {{ installing ? '创建中...' : '使用模板' }}
+      {{ installing ? workbenchLabel('card.installing', isZh) : workbenchLabel('card.install', isZh) }}
     </button>
   </article>
 </template>
@@ -32,6 +32,13 @@
 import { computed } from 'vue'
 import type { MetaTemplate } from '../types'
 import { categoryLabel } from '../utils/category-labels'
+import { useLocale } from '../../composables/useLocale'
+import {
+  cardSheets,
+  cardFields,
+  cardViews,
+  workbenchLabel,
+} from '../utils/workbench-labels'
 
 const props = defineProps<{
   template: MetaTemplate
@@ -42,7 +49,13 @@ const emit = defineEmits<{
   (e: 'install', template: MetaTemplate): void
 }>()
 
-const categoryDisplay = computed(() => categoryLabel(props.template.category))
+// useLocale().isZh is already a ComputedRef<boolean>; template auto-unwraps it,
+// script reads isZh.value.
+const { isZh } = useLocale()
+
+const categoryDisplay = computed(() =>
+  categoryLabel(props.template.category, isZh.value ? 'zh-CN' : 'en'),
+)
 
 const fieldCount = computed(() => {
   return props.template.sheets.reduce((sum, sheet) => sum + sheet.fields.length, 0)

--- a/apps/web/src/multitable/utils/workbench-labels.ts
+++ b/apps/web/src/multitable/utils/workbench-labels.ts
@@ -1,0 +1,169 @@
+// Workbench UI string table — single source for MultitableWorkbench.vue (T2)
+// localization, plus MetaTemplateCard's count/button strings.
+//
+// EN + ZH both explicit (unlike category-labels.ts, where the data layer is
+// English and we only translate). Components read `useLocale().isZh` and call
+// `workbenchLabel(key, isZh)` for static strings, or the interpolation helpers
+// below for strings with counts / ids / optional segments.
+//
+// Scope: see docs/development/multitable-workbench-i18n-t2-development-20260519.md.
+// `<kbd>` physical key names are NOT translated and are NOT in this table.
+// Dynamic / interpolated / permission / host-context / "Failed to ..." toasts
+// are T3 and intentionally absent here.
+
+export type WorkbenchLabelKey =
+  // §3.0 script-computed shell (interpolated variants live in the helpers)
+  | 'conflict.fieldFallback'
+  // §3.1 conflict banner
+  | 'conflict.title' | 'conflict.reload' | 'conflict.retry' | 'conflict.dismiss'
+  // §3.2 toolbar
+  | 'toolbar.commentInbox' | 'toolbar.fields' | 'toolbar.access' | 'toolbar.views'
+  | 'toolbar.workflow' | 'toolbar.automations' | 'toolbar.templates'
+  | 'toolbar.dashboard' | 'toolbar.shareForm' | 'toolbar.apiWebhooks'
+  | 'toolbar.mentions'
+  // §3.3 template library modal
+  | 'tpl.title' | 'tpl.subtitle' | 'tpl.loading' | 'tpl.more'
+  // §3.4 keyboard shortcuts modal (explanatory text only)
+  | 'kbd.title' | 'kbd.navigateCells' | 'kbd.editCell' | 'kbd.cancelClose'
+  | 'kbd.nextCell' | 'kbd.copy' | 'kbd.paste' | 'kbd.undo' | 'kbd.redo'
+  | 'kbd.toggleHelp'
+  // §3.5 static (non-interpolated) toast subset
+  | 'toast.recordCreateBlocked' | 'toast.recordEditBlocked' | 'toast.recordDeleteBlocked'
+  | 'toast.datesUpdated' | 'toast.hierarchyUpdated' | 'toast.recordDeleted'
+  | 'toast.loadedLatest' | 'toast.changeReapplied' | 'toast.recordUpdated'
+  | 'toast.formSubmitted' | 'toast.commentUpdated' | 'toast.commentAdded'
+  | 'toast.commentResolved' | 'toast.commentDeleted' | 'toast.linkedRecordsUpdated'
+  | 'toast.viewSettingsSaved'
+  // §3.6 MetaTemplateCard button (counts use the card* helpers below)
+  | 'card.install' | 'card.installing'
+
+const WORKBENCH_LABELS: Record<WorkbenchLabelKey, { en: string; zh: string }> = {
+  'conflict.fieldFallback': { en: 'cell', zh: '单元格' },
+
+  'conflict.title': { en: 'Update conflict', zh: '更新冲突' },
+  'conflict.reload': { en: 'Reload latest', zh: '重新加载最新' },
+  'conflict.retry': { en: 'Retry change', zh: '重试本次修改' },
+  'conflict.dismiss': { en: 'Dismiss', zh: '忽略' },
+
+  'toolbar.commentInbox': { en: 'Comment Inbox', zh: '评论收件箱' },
+  'toolbar.fields': { en: 'Fields', zh: '字段' },
+  'toolbar.access': { en: 'Access', zh: '权限' },
+  'toolbar.views': { en: 'Views', zh: '视图' },
+  'toolbar.workflow': { en: 'Workflow', zh: '工作流' },
+  'toolbar.automations': { en: 'Automations', zh: '自动化' },
+  'toolbar.templates': { en: 'Templates', zh: '模板' },
+  'toolbar.dashboard': { en: 'Dashboard', zh: '仪表盘' },
+  'toolbar.shareForm': { en: 'Share Form', zh: '分享表单' },
+  'toolbar.apiWebhooks': { en: 'API & Webhooks', zh: 'API 与 Webhook' },
+  'toolbar.mentions': { en: 'Mentions', zh: '提及' },
+
+  'tpl.title': { en: 'Template Library', zh: '模板库' },
+  'tpl.subtitle': {
+    en: 'Start a new base from a built-in workspace pattern.',
+    zh: '从内置工作区模板新建一个 Base',
+  },
+  'tpl.loading': { en: 'Loading templates...', zh: '正在加载模板...' },
+  'tpl.more': { en: 'More templates →', zh: '更多模板 →' },
+
+  'kbd.title': { en: 'Keyboard Shortcuts', zh: '键盘快捷键' },
+  'kbd.navigateCells': { en: 'Navigate cells', zh: '导航单元格' },
+  'kbd.editCell': { en: 'Edit cell', zh: '编辑单元格' },
+  'kbd.cancelClose': { en: 'Cancel edit / close', zh: '取消编辑 / 关闭' },
+  'kbd.nextCell': { en: 'Next cell', zh: '下一个单元格' },
+  'kbd.copy': { en: 'Copy cell value', zh: '复制单元格值' },
+  'kbd.paste': { en: 'Paste into cell', zh: '粘贴到单元格' },
+  'kbd.undo': { en: 'Undo', zh: '撤销' },
+  'kbd.redo': { en: 'Redo', zh: '重做' },
+  'kbd.toggleHelp': { en: 'Toggle this help', zh: '切换此帮助' },
+
+  'toast.recordCreateBlocked': {
+    en: 'Record creation is not allowed in this view.',
+    zh: '当前视图不允许创建记录。',
+  },
+  'toast.recordEditBlocked': {
+    en: 'Record editing is not allowed for this row.',
+    zh: '该行不允许编辑记录。',
+  },
+  'toast.recordDeleteBlocked': {
+    en: 'Record deletion is not allowed for this row.',
+    zh: '该行不允许删除记录。',
+  },
+  'toast.datesUpdated': { en: 'Dates updated', zh: '日期已更新' },
+  'toast.hierarchyUpdated': { en: 'Hierarchy updated', zh: '层级已更新' },
+  'toast.recordDeleted': { en: 'Record deleted', zh: '记录已删除' },
+  'toast.loadedLatest': { en: 'Loaded the latest row state', zh: '已加载最新行状态' },
+  'toast.changeReapplied': { en: 'Change reapplied', zh: '修改已重新应用' },
+  'toast.recordUpdated': { en: 'Record updated', zh: '记录已更新' },
+  'toast.formSubmitted': { en: 'Form submitted', zh: '表单已提交' },
+  'toast.commentUpdated': { en: 'Comment updated', zh: '评论已更新' },
+  'toast.commentAdded': { en: 'Comment added', zh: '评论已添加' },
+  'toast.commentResolved': { en: 'Comment resolved', zh: '评论已解决' },
+  'toast.commentDeleted': { en: 'Comment deleted', zh: '评论已删除' },
+  'toast.linkedRecordsUpdated': { en: 'Linked records updated', zh: '关联记录已更新' },
+  'toast.viewSettingsSaved': { en: 'View settings saved', zh: '视图设置已保存' },
+
+  'card.install': { en: 'Use template', zh: '使用模板' },
+  'card.installing': { en: 'Installing...', zh: '创建中...' },
+}
+
+export function workbenchLabel(key: WorkbenchLabelKey, isZh: boolean): string {
+  const entry = WORKBENCH_LABELS[key]
+  return isZh ? entry.zh : entry.en
+}
+
+// --- Interpolation helpers (not keys) ---
+
+// conflictMessage: `{field} changed elsewhere.[ Latest version is {v}.] Reload
+// the row or retry your edit.` — the version segment is OPTIONAL (omitted when
+// version is not a finite number). Output never contains literal `[` / `]`.
+export function conflictMessage(field: string, version: number | null | undefined, isZh: boolean): string {
+  const hasVersion = typeof version === 'number' && Number.isFinite(version)
+  if (isZh) {
+    const versionPart = hasVersion ? ` 最新版本为 ${version}。` : ''
+    return `${field} 已在别处被修改。${versionPart} 请重新加载该行或重试你的修改。`
+  }
+  const versionPart = hasVersion ? ` Latest version is ${version}.` : ''
+  return `${field} changed elsewhere.${versionPart} Reload the row or retry your edit.`
+}
+
+// presenceLabel: en pluralizes ("1 active collaborator" / "N active
+// collaborators"); zh has no plural.
+export function presenceLabel(n: number, isZh: boolean): string {
+  if (isZh) return `${n} 位活跃协作者`
+  return `${n} active collaborator${n === 1 ? '' : 's'}`
+}
+
+// presenceTitle: ids joined as-is (user ids are not translated); empty -> a
+// "no collaborators" message.
+export function presenceTitle(ids: string[], isZh: boolean): string {
+  if (ids.length === 0) return isZh ? '无活跃协作者' : 'No active collaborators'
+  return isZh ? `当前在线：${ids.join(', ')}` : `Active now: ${ids.join(', ')}`
+}
+
+// commentInboxTitle: n>0 -> "{n} comment updates need attention"; n===0 ->
+// "Open comment inbox" (the no-badge title).
+export function commentInboxTitle(n: number, isZh: boolean): string {
+  if (n > 0) return isZh ? `${n} 条评论待处理` : `${n} comment updates need attention`
+  return isZh ? '打开评论收件箱' : 'Open comment inbox'
+}
+
+export function mentionsUnread(n: number, isZh: boolean): string {
+  return isZh ? `${n} 条未读` : `${n} unread`
+}
+
+export function mentionsRecords(n: number, isZh: boolean): string {
+  return isZh ? `${n} 条记录` : `${n} record${n === 1 ? '' : 's'}`
+}
+
+// MetaTemplateCard counts: zh "{n} 个 Sheet/字段/视图"; en pluralized.
+export function cardSheets(n: number, isZh: boolean): string {
+  return isZh ? `${n} 个 Sheet` : `${n} sheet${n === 1 ? '' : 's'}`
+}
+
+export function cardFields(n: number, isZh: boolean): string {
+  return isZh ? `${n} 个字段` : `${n} field${n === 1 ? '' : 's'}`
+}
+
+export function cardViews(n: number, isZh: boolean): string {
+  return isZh ? `${n} 个视图` : `${n} view${n === 1 ? '' : 's'}`
+}

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -3,13 +3,13 @@
     <MetaToast ref="toastRef" />
     <div v-if="grid.conflict.value" class="mt-workbench__conflict" role="alert">
       <div class="mt-workbench__conflict-copy">
-        <strong>Update conflict</strong>
+        <strong>{{ wb('conflict.title', isZh) }}</strong>
         <span>{{ conflictMessage }}</span>
       </div>
       <div class="mt-workbench__conflict-actions">
-        <button class="mt-workbench__conflict-btn" @click="onReloadConflict">Reload latest</button>
-        <button class="mt-workbench__conflict-btn mt-workbench__conflict-btn--primary" @click="onRetryConflict">Retry change</button>
-        <button class="mt-workbench__conflict-btn" @click="grid.dismissConflict()">Dismiss</button>
+        <button class="mt-workbench__conflict-btn" @click="onReloadConflict">{{ wb('conflict.reload', isZh) }}</button>
+        <button class="mt-workbench__conflict-btn mt-workbench__conflict-btn--primary" @click="onRetryConflict">{{ wb('conflict.retry', isZh) }}</button>
+        <button class="mt-workbench__conflict-btn" @click="grid.dismissConflict()">{{ wb('conflict.dismiss', isZh) }}</button>
       </div>
     </div>
     <div v-if="basePickerBases.length" class="mt-workbench__base-bar">
@@ -38,38 +38,38 @@
         :class="{ 'mt-workbench__mention-chip--unread': mentionInboxState.unreadMentionCount.value > 0 }"
         @click="onMentionChipClick"
       >
-        &#x1F4EC; Mentions <strong>{{ mentionInboxState.unreadMentionCount.value || mentionInboxState.summary.value.unresolvedMentionCount }}</strong>
-        <span v-if="mentionInboxState.unreadMentionCount.value > 0" class="mt-workbench__mention-chip-unread">{{ mentionInboxState.unreadMentionCount.value }} unread</span>
-        <span class="mt-workbench__mention-chip-records">{{ mentionInboxState.summary.value.mentionedRecordCount }} records</span>
+        &#x1F4EC; {{ wb('toolbar.mentions', isZh) }} <strong>{{ mentionInboxState.unreadMentionCount.value || mentionInboxState.summary.value.unresolvedMentionCount }}</strong>
+        <span v-if="mentionInboxState.unreadMentionCount.value > 0" class="mt-workbench__mention-chip-unread">{{ fmtMentionsUnread(mentionInboxState.unreadMentionCount.value, isZh) }}</span>
+        <span class="mt-workbench__mention-chip-records">{{ fmtMentionsRecords(mentionInboxState.summary.value.mentionedRecordCount, isZh) }}</span>
       </button>
       <button
         class="mt-workbench__mgr-btn"
         :class="{ 'mt-workbench__mgr-btn--attention': commentInboxBadgeCount > 0 }"
-        :title="commentInboxBadgeCount > 0 ? `${commentInboxBadgeCount} comment updates need attention` : 'Open comment inbox'"
+        :title="fmtCommentInboxTitle(commentInboxBadgeCount, isZh)"
         @click="openCommentInbox()"
       >
-        &#x1F4AC; Comment Inbox
+        &#x1F4AC; {{ wb('toolbar.commentInbox', isZh) }}
         <span v-if="commentInboxBadgeCount > 0" class="mt-workbench__mgr-badge">{{ commentInboxBadgeCount }}</span>
       </button>
-      <button v-if="caps.canManageFields.value" class="mt-workbench__mgr-btn" @click="showFieldManager = true">&#x2699; Fields</button>
-      <button v-if="caps.canManageSheetAccess.value" class="mt-workbench__mgr-btn" @click="showPermissionManager = true; void loadPermissionEntries()">&#x1F512; Access</button>
-      <button v-if="caps.canManageViews.value && canConfigureCurrentView" class="mt-workbench__mgr-btn" @click="showViewManager = true">&#x2630; Views</button>
-      <button v-if="caps.canManageAutomation.value" class="mt-workbench__mgr-btn" @click="openWorkflowDesigner()">&#x2699; Workflow</button>
-      <button v-if="caps.canManageAutomation.value" class="mt-workbench__mgr-btn" @click="showAutomationManager = true">&#x26A1; Automations</button>
-      <button v-if="canCreateBasesAndSheets" class="mt-workbench__mgr-btn" data-action="open-template-library" @click="openTemplateLibrary">&#x1F5C2; Templates</button>
-      <button class="mt-workbench__mgr-btn" :class="{ 'mt-workbench__mgr-btn--active': showDashboardView }" @click="showDashboardView = !showDashboardView" data-action="toggle-dashboard">&#x1F4CA; Dashboard</button>
-      <button v-if="activeViewType === 'form'" class="mt-workbench__mgr-btn" @click="showFormShareManager = true">&#x1F517; Share Form</button>
-      <button class="mt-workbench__mgr-btn" @click="showApiTokenManager = true">&#x1F511; API &amp; Webhooks</button>
+      <button v-if="caps.canManageFields.value" class="mt-workbench__mgr-btn" @click="showFieldManager = true">&#x2699; {{ wb('toolbar.fields', isZh) }}</button>
+      <button v-if="caps.canManageSheetAccess.value" class="mt-workbench__mgr-btn" @click="showPermissionManager = true; void loadPermissionEntries()">&#x1F512; {{ wb('toolbar.access', isZh) }}</button>
+      <button v-if="caps.canManageViews.value && canConfigureCurrentView" class="mt-workbench__mgr-btn" @click="showViewManager = true">&#x2630; {{ wb('toolbar.views', isZh) }}</button>
+      <button v-if="caps.canManageAutomation.value" class="mt-workbench__mgr-btn" @click="openWorkflowDesigner()">&#x2699; {{ wb('toolbar.workflow', isZh) }}</button>
+      <button v-if="caps.canManageAutomation.value" class="mt-workbench__mgr-btn" @click="showAutomationManager = true">&#x26A1; {{ wb('toolbar.automations', isZh) }}</button>
+      <button v-if="canCreateBasesAndSheets" class="mt-workbench__mgr-btn" data-action="open-template-library" @click="openTemplateLibrary">&#x1F5C2; {{ wb('toolbar.templates', isZh) }}</button>
+      <button class="mt-workbench__mgr-btn" :class="{ 'mt-workbench__mgr-btn--active': showDashboardView }" @click="showDashboardView = !showDashboardView" data-action="toggle-dashboard">&#x1F4CA; {{ wb('toolbar.dashboard', isZh) }}</button>
+      <button v-if="activeViewType === 'form'" class="mt-workbench__mgr-btn" @click="showFormShareManager = true">&#x1F517; {{ wb('toolbar.shareForm', isZh) }}</button>
+      <button class="mt-workbench__mgr-btn" @click="showApiTokenManager = true">&#x1F511; {{ wb('toolbar.apiWebhooks', isZh) }}</button>
     </div>
     <div v-if="showTemplateLibrary" class="mt-template-library" data-testid="multitable-template-library">
       <div class="mt-template-library__header">
         <div>
-          <strong>Template Library</strong>
-          <span>Start a new base from a built-in workspace pattern.</span>
+          <strong>{{ wb('tpl.title', isZh) }}</strong>
+          <span>{{ wb('tpl.subtitle', isZh) }}</span>
         </div>
         <button class="mt-template-library__close" @click="showTemplateLibrary = false">&times;</button>
       </div>
-      <div v-if="templateLibraryLoading" class="mt-template-library__state">Loading templates...</div>
+      <div v-if="templateLibraryLoading" class="mt-template-library__state">{{ wb('tpl.loading', isZh) }}</div>
       <div v-else-if="templateLibraryError" class="mt-template-library__state mt-template-library__state--error">{{ templateLibraryError }}</div>
       <div v-else class="mt-template-library__grid">
         <MetaTemplateCard
@@ -87,7 +87,7 @@
           data-testid="multitable-workbench-template-center-link"
           @click="showTemplateLibrary = false"
         >
-          更多模板 →
+          {{ wb('tpl.more', isZh) }}
         </router-link>
       </footer>
     </div>
@@ -299,19 +299,19 @@
     <div v-if="showShortcuts" class="mt-workbench__shortcuts-overlay" @click.self="showShortcuts = false">
       <div class="mt-workbench__shortcuts">
         <div class="mt-workbench__shortcuts-header">
-          <strong>Keyboard Shortcuts</strong>
+          <strong>{{ wb('kbd.title', isZh) }}</strong>
           <button class="mt-workbench__shortcuts-close" @click="showShortcuts = false">&times;</button>
         </div>
         <div class="mt-workbench__shortcuts-grid">
-          <div class="mt-workbench__shortcut"><kbd>&#x2191; &#x2193; &#x2190; &#x2192;</kbd><span>Navigate cells</span></div>
-          <div class="mt-workbench__shortcut"><kbd>Enter</kbd><span>Edit cell</span></div>
-          <div class="mt-workbench__shortcut"><kbd>Escape</kbd><span>Cancel edit / close</span></div>
-          <div class="mt-workbench__shortcut"><kbd>Tab</kbd><span>Next cell</span></div>
-          <div class="mt-workbench__shortcut"><kbd>Ctrl+C</kbd><span>Copy cell value</span></div>
-          <div class="mt-workbench__shortcut"><kbd>Ctrl+V</kbd><span>Paste into cell</span></div>
-          <div class="mt-workbench__shortcut"><kbd>Ctrl+Z</kbd><span>Undo</span></div>
-          <div class="mt-workbench__shortcut"><kbd>Ctrl+Y</kbd><span>Redo</span></div>
-          <div class="mt-workbench__shortcut"><kbd>?</kbd><span>Toggle this help</span></div>
+          <div class="mt-workbench__shortcut"><kbd>&#x2191; &#x2193; &#x2190; &#x2192;</kbd><span>{{ wb('kbd.navigateCells', isZh) }}</span></div>
+          <div class="mt-workbench__shortcut"><kbd>Enter</kbd><span>{{ wb('kbd.editCell', isZh) }}</span></div>
+          <div class="mt-workbench__shortcut"><kbd>Escape</kbd><span>{{ wb('kbd.cancelClose', isZh) }}</span></div>
+          <div class="mt-workbench__shortcut"><kbd>Tab</kbd><span>{{ wb('kbd.nextCell', isZh) }}</span></div>
+          <div class="mt-workbench__shortcut"><kbd>Ctrl+C</kbd><span>{{ wb('kbd.copy', isZh) }}</span></div>
+          <div class="mt-workbench__shortcut"><kbd>Ctrl+V</kbd><span>{{ wb('kbd.paste', isZh) }}</span></div>
+          <div class="mt-workbench__shortcut"><kbd>Ctrl+Z</kbd><span>{{ wb('kbd.undo', isZh) }}</span></div>
+          <div class="mt-workbench__shortcut"><kbd>Ctrl+Y</kbd><span>{{ wb('kbd.redo', isZh) }}</span></div>
+          <div class="mt-workbench__shortcut"><kbd>?</kbd><span>{{ wb('kbd.toggleHelp', isZh) }}</span></div>
         </div>
       </div>
     </div>
@@ -399,6 +399,16 @@ import { ref, reactive, computed, nextTick, onMounted, onBeforeUnmount, watch } 
 import { useRouter } from 'vue-router'
 import { AppRouteNames } from '../../router/types'
 import { useAuth } from '../../composables/useAuth'
+import { useLocale } from '../../composables/useLocale'
+import {
+  workbenchLabel as wb,
+  conflictMessage as fmtConflictMessage,
+  presenceLabel as fmtPresenceLabel,
+  presenceTitle as fmtPresenceTitle,
+  commentInboxTitle as fmtCommentInboxTitle,
+  mentionsUnread as fmtMentionsUnread,
+  mentionsRecords as fmtMentionsRecords,
+} from '../utils/workbench-labels'
 import type {
   LinkedRecordSummary,
   MetaAttachment,
@@ -488,6 +498,9 @@ const emit = defineEmits<{
 const role = ref<MultitableRole>(props.role ?? 'editor')
 const router = useRouter()
 const auth = useAuth()
+// useLocale().isZh is a ComputedRef<boolean>; template auto-unwraps it,
+// script reads isZh.value (see T2 i18n dev MD).
+const { isZh } = useLocale()
 const workbench = useMultitableWorkbench({ initialBaseId: props.baseId, initialSheetId: props.sheetId, initialViewId: props.viewId })
 const capabilitySource = computed(() => workbench.capabilities.value ?? role.value)
 const caps = useMultitableCapabilities(capabilitySource)
@@ -606,21 +619,21 @@ function showSuccess(msg: string) {
 
 function ensureCanCreateRecord(): boolean {
   if (caps.canCreateRecord.value) return true
-  showError('Record creation is not allowed in this view.')
+  showError(wb('toast.recordCreateBlocked', isZh.value))
   return false
 }
 
 function ensureCanEditRecord(recordId?: string | null): boolean {
   const allowed = recordId ? (grid.resolveRowActions(recordId)?.canEdit ?? effectiveRowActions.value.canEdit) : effectiveRowActions.value.canEdit
   if (allowed) return true
-  showError('Record editing is not allowed for this row.')
+  showError(wb('toast.recordEditBlocked', isZh.value))
   return false
 }
 
 function ensureCanDeleteRecord(recordId?: string | null): boolean {
   const allowed = recordId ? (grid.resolveRowActions(recordId)?.canDelete ?? effectiveRowActions.value.canDelete) : effectiveRowActions.value.canDelete
   if (allowed) return true
-  showError('Record deletion is not allowed for this row.')
+  showError(wb('toast.recordDeleteBlocked', isZh.value))
   return false
 }
 
@@ -877,22 +890,21 @@ const commentComposerInitialMentions = computed(() => (
 ))
 const commentInboxBadgeCount = computed(() => commentInboxState.unreadCount.value)
 const sheetPresenceLabel = computed(() => (
-  `${sheetPresenceState.activeCollaboratorCount.value} ${sheetPresenceState.activeCollaboratorCount.value === 1 ? 'active collaborator' : 'active collaborators'}`
+  fmtPresenceLabel(sheetPresenceState.activeCollaboratorCount.value, isZh.value)
 ))
 const sheetPresenceTitle = computed(() => {
   const ids = sheetPresenceState.activeCollaborators.value.map((user) => user.id)
-  return ids.length > 0 ? `Active now: ${ids.join(', ')}` : 'No active collaborators'
+  return fmtPresenceTitle(ids, isZh.value)
 })
 const conflictFieldName = computed(() => {
   const fieldId = grid.conflict.value?.fieldId
-  if (!fieldId) return 'cell'
+  if (!fieldId) return wb('conflict.fieldFallback', isZh.value)
   return grid.fields.value.find((field) => field.id === fieldId)?.name ?? fieldId
 })
 const conflictMessage = computed(() => {
   const current = grid.conflict.value
   if (!current) return ''
-  const versionPart = typeof current.serverVersion === 'number' ? ` Latest version is ${current.serverVersion}.` : ''
-  return `${conflictFieldName.value} changed elsewhere.${versionPart} Reload the row or retry your edit.`
+  return fmtConflictMessage(conflictFieldName.value, current.serverVersion, isZh.value)
 })
 const hasUnsavedWorkbenchDrafts = computed(() => (
   formDirty.value ||
@@ -1326,7 +1338,7 @@ async function onTimelinePatchDates(payload: {
     if (selectedRecordId.value === payload.recordId) {
       await resolveDeepLink(payload.recordId)
     }
-    showSuccess('Dates updated')
+    showSuccess(wb('toast.datesUpdated', isZh.value))
   } catch (error: any) {
     showError(error?.message ?? 'Failed to update timeline dates')
   }
@@ -1355,7 +1367,7 @@ async function onHierarchyReparentRecord(payload: {
     if (selectedRecordId.value === payload.recordId) {
       await resolveDeepLink(payload.recordId)
     }
-    showSuccess('Hierarchy updated')
+    showSuccess(wb('toast.hierarchyUpdated', isZh.value))
   } catch (error: any) {
     showError(error?.message ?? 'Failed to update hierarchy parent')
   }
@@ -1377,7 +1389,7 @@ async function onDeleteRecord() {
     selectedRecordId.value = null
     showComments.value = false
     commentDraft.value = ''
-    showSuccess('Record deleted')
+    showSuccess(wb('toast.recordDeleted', isZh.value))
     return
   }
   if (grid.error.value) showError(grid.error.value)
@@ -1388,7 +1400,7 @@ async function onReloadConflict() {
   if (selectedRecordId.value) {
     await resolveDeepLink(selectedRecordId.value)
   }
-  showSuccess('Loaded the latest row state')
+  showSuccess(wb('toast.loadedLatest', isZh.value))
 }
 
 async function onRetryConflict() {
@@ -1397,7 +1409,7 @@ async function onRetryConflict() {
     if (selectedRecordId.value) {
       await resolveDeepLink(selectedRecordId.value)
     }
-    showSuccess('Change reapplied')
+    showSuccess(wb('toast.changeReapplied', isZh.value))
     return
   }
   if (grid.error.value) showError(grid.error.value)
@@ -1419,7 +1431,7 @@ async function onDrawerPatch(fieldId: string, value: unknown) {
       data: { ...deepLinkedRecord.value.data, [fieldId]: value },
     }
   }
-  showSuccess('Record updated')
+  showSuccess(wb('toast.recordUpdated', isZh.value))
 }
 
 async function onFormSubmit(data: Record<string, unknown>) {
@@ -1444,7 +1456,7 @@ async function onFormSubmit(data: Record<string, unknown>) {
       await grid.loadViewData(grid.page.value.offset)
       formSuccessMessage.value = result.mode === 'create' ? 'Record created' : 'Changes saved'
       formFieldErrors.value = {}
-      showSuccess('Form submitted')
+      showSuccess(wb('toast.formSubmitted', isZh.value))
     } catch (e: any) {
       const message = e.message ?? 'Form submit failed'
       formErrorMessage.value = message
@@ -1461,7 +1473,7 @@ async function onFormSubmit(data: Record<string, unknown>) {
     if (changes.length) {
       await workbench.client.patchRecords({ sheetId: workbench.activeSheetId.value || undefined, viewId: viewId || undefined, changes })
       await grid.loadViewData(grid.page.value.offset)
-      showSuccess('Record updated')
+      showSuccess(wb('toast.recordUpdated', isZh.value))
     }
   } else {
     if (!ensureCanCreateRecord()) return
@@ -1477,7 +1489,7 @@ async function onSubmitComment(payload: { content: string; mentions: string[] })
         content: payload.content,
         mentions: payload.mentions,
       })
-      showSuccess('Comment updated')
+      showSuccess(wb('toast.commentUpdated', isZh.value))
     } else {
       await commentsState.addComment({
         ...selectedRecordCommentsScope.value,
@@ -1486,7 +1498,7 @@ async function onSubmitComment(payload: { content: string; mentions: string[] })
         targetFieldId: activeCommentFieldId.value ?? undefined,
         parentId: selectedReplyCommentId.value ?? undefined,
       })
-      showSuccess('Comment added')
+      showSuccess(wb('toast.commentAdded', isZh.value))
     }
     commentDraft.value = ''
     selectedReplyCommentId.value = null
@@ -1499,7 +1511,7 @@ async function onSubmitComment(payload: { content: string; mentions: string[] })
 async function onResolveComment(commentId: string) {
   try {
     await commentsState.resolveComment(commentId)
-    showSuccess('Comment resolved')
+    showSuccess(wb('toast.commentResolved', isZh.value))
   } catch (e: any) {
     showError(commentsState.error.value ?? e.message ?? 'Failed to resolve comment')
   }
@@ -1528,7 +1540,7 @@ async function onDeleteComment(commentId: string) {
     if (highlightedCommentId.value === commentId) {
       highlightedCommentId.value = null
     }
-    showSuccess('Comment deleted')
+    showSuccess(wb('toast.commentDeleted', isZh.value))
   } catch (e: any) {
     showError(commentsState.error.value ?? e.message ?? 'Failed to delete comment')
   }
@@ -1577,7 +1589,7 @@ async function onLinkPickerConfirm(payload: { recordIds: string[]; summaries: Li
   } else {
     return
   }
-  showSuccess('Linked records updated')
+  showSuccess(wb('toast.linkedRecordsUpdated', isZh.value))
 }
 
 // --- Field management ---
@@ -1685,7 +1697,7 @@ async function updateViewInternal(
     await workbench.client.updateView(viewId, input)
     await workbench.loadSheetMeta(workbench.activeSheetId.value)
     await grid.loadViewData(grid.page.value.offset)
-    if (notify) showSuccess('View settings saved')
+    if (notify) showSuccess(wb('toast.viewSettingsSaved', isZh.value))
   } catch (e: any) { showError(e.message ?? 'Failed to update view') }
 }
 

--- a/apps/web/tests/multitable-home-view.spec.ts
+++ b/apps/web/tests/multitable-home-view.spec.ts
@@ -1,7 +1,8 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, h, nextTick, type App as VueApp, type Component } from 'vue'
 import MultitableHomeView from '../src/views/MultitableHomeView.vue'
 import { AppRouteNames } from '../src/router/types'
+import { useLocale } from '../src/composables/useLocale'
 
 const mocks = vi.hoisted(() => ({
   push: vi.fn(),
@@ -74,6 +75,13 @@ describe('MultitableHomeView', () => {
   let app: VueApp<Element> | null = null
   let container: HTMLDivElement | null = null
 
+  // MetaTemplateCard is now locale-aware (T2 i18n). These specs assert the
+  // Chinese product copy, so pin zh-CN before each mount; jsdom's default
+  // resolveInitialLocale() would otherwise yield 'en'.
+  beforeEach(() => {
+    useLocale().setLocale('zh-CN')
+  })
+
   afterEach(() => {
     if (app) app.unmount()
     if (container) container.remove()
@@ -81,6 +89,7 @@ describe('MultitableHomeView', () => {
     container = null
     localStorage.removeItem(FAVORITE_BASES_KEY)
     localStorage.removeItem(RECENT_BASES_KEY)
+    useLocale().setLocale('en')
     vi.clearAllMocks()
   })
 

--- a/apps/web/tests/multitable-template-center-view.spec.ts
+++ b/apps/web/tests/multitable-template-center-view.spec.ts
@@ -1,7 +1,8 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, h, nextTick, type App as VueApp, type Component } from 'vue'
 import MultitableTemplateCenterView from '../src/views/MultitableTemplateCenterView.vue'
 import { AppRouteNames } from '../src/router/types'
+import { useLocale } from '../src/composables/useLocale'
 
 const mocks = vi.hoisted(() => ({
   push: vi.fn(),
@@ -92,11 +93,18 @@ describe('MultitableTemplateCenterView', () => {
   let app: VueApp<Element> | null = null
   let container: HTMLDivElement | null = null
 
+  // MetaTemplateCard is now locale-aware (T2 i18n); pin zh-CN so the Chinese
+  // product-copy assertions hold (jsdom default would be 'en').
+  beforeEach(() => {
+    useLocale().setLocale('zh-CN')
+  })
+
   afterEach(() => {
     if (app) app.unmount()
     if (container) container.remove()
     app = null
     container = null
+    useLocale().setLocale('en')
     vi.clearAllMocks()
   })
 

--- a/apps/web/tests/multitable-workbench-i18n.spec.ts
+++ b/apps/web/tests/multitable-workbench-i18n.spec.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest'
+import {
+  workbenchLabel,
+  conflictMessage,
+  presenceLabel,
+  presenceTitle,
+  commentInboxTitle,
+  mentionsUnread,
+  mentionsRecords,
+  cardSheets,
+  cardFields,
+  cardViews,
+  type WorkbenchLabelKey,
+} from '../src/multitable/utils/workbench-labels'
+
+// Every static key the T2 dev MD §3 enumerates. If a key is added/removed
+// this list must change in lockstep — that is the point of the test.
+const ALL_KEYS: WorkbenchLabelKey[] = [
+  'conflict.fieldFallback',
+  'conflict.title', 'conflict.reload', 'conflict.retry', 'conflict.dismiss',
+  'toolbar.commentInbox', 'toolbar.fields', 'toolbar.access', 'toolbar.views',
+  'toolbar.workflow', 'toolbar.automations', 'toolbar.templates',
+  'toolbar.dashboard', 'toolbar.shareForm', 'toolbar.apiWebhooks',
+  'toolbar.mentions',
+  'tpl.title', 'tpl.subtitle', 'tpl.loading', 'tpl.more',
+  'kbd.title', 'kbd.navigateCells', 'kbd.editCell', 'kbd.cancelClose',
+  'kbd.nextCell', 'kbd.copy', 'kbd.paste', 'kbd.undo', 'kbd.redo',
+  'kbd.toggleHelp',
+  'toast.recordCreateBlocked', 'toast.recordEditBlocked', 'toast.recordDeleteBlocked',
+  'toast.datesUpdated', 'toast.hierarchyUpdated', 'toast.recordDeleted',
+  'toast.loadedLatest', 'toast.changeReapplied', 'toast.recordUpdated',
+  'toast.formSubmitted', 'toast.commentUpdated', 'toast.commentAdded',
+  'toast.commentResolved', 'toast.commentDeleted', 'toast.linkedRecordsUpdated',
+  'toast.viewSettingsSaved',
+  'card.install', 'card.installing',
+]
+
+describe('workbench-labels static table', () => {
+  it('every key resolves to a non-empty en and zh string', () => {
+    for (const key of ALL_KEYS) {
+      const en = workbenchLabel(key, false)
+      const zh = workbenchLabel(key, true)
+      expect(en, `en empty for ${key}`).toBeTruthy()
+      expect(zh, `zh empty for ${key}`).toBeTruthy()
+    }
+  })
+
+  it('en and zh differ for every translatable key', () => {
+    for (const key of ALL_KEYS) {
+      const en = workbenchLabel(key, false)
+      const zh = workbenchLabel(key, true)
+      expect(en, `en===zh for ${key}: ${en}`).not.toBe(zh)
+    }
+  })
+
+  it('isZh selects the correct branch for a representative sample', () => {
+    expect(workbenchLabel('toolbar.fields', true)).toBe('字段')
+    expect(workbenchLabel('toolbar.fields', false)).toBe('Fields')
+    expect(workbenchLabel('conflict.fieldFallback', true)).toBe('单元格')
+    expect(workbenchLabel('conflict.fieldFallback', false)).toBe('cell')
+    expect(workbenchLabel('card.install', true)).toBe('使用模板')
+    expect(workbenchLabel('card.installing', false)).toBe('Installing...')
+  })
+})
+
+describe('workbench-labels interpolation helpers', () => {
+  it('conflictMessage includes the version segment only when version is finite, never literal brackets', () => {
+    const withVer = conflictMessage('Status', 7, true)
+    expect(withVer).toContain('Status')
+    expect(withVer).toContain('最新版本为 7')
+    expect(withVer).not.toContain('[')
+    expect(withVer).not.toContain(']')
+
+    const noVerZh = conflictMessage('Status', null, true)
+    expect(noVerZh).not.toContain('最新版本')
+    expect(noVerZh).not.toContain('[')
+
+    const noVerEn = conflictMessage('Status', undefined, false)
+    expect(noVerEn).toBe('Status changed elsewhere. Reload the row or retry your edit.')
+    expect(noVerEn).not.toContain('[')
+
+    // NaN / non-finite is treated as "no version"
+    expect(conflictMessage('Cell', Number.NaN, false)).not.toContain('Latest version')
+  })
+
+  it('presenceLabel pluralizes en, zh has no plural', () => {
+    expect(presenceLabel(1, false)).toBe('1 active collaborator')
+    expect(presenceLabel(3, false)).toBe('3 active collaborators')
+    expect(presenceLabel(1, true)).toBe('1 位活跃协作者')
+    expect(presenceLabel(3, true)).toBe('3 位活跃协作者')
+  })
+
+  it('presenceTitle handles empty and non-empty id lists, ids are not translated', () => {
+    expect(presenceTitle([], false)).toBe('No active collaborators')
+    expect(presenceTitle([], true)).toBe('无活跃协作者')
+    expect(presenceTitle(['u_1', 'u_2'], false)).toBe('Active now: u_1, u_2')
+    expect(presenceTitle(['u_1', 'u_2'], true)).toBe('当前在线：u_1, u_2')
+  })
+
+  it('commentInboxTitle switches on the badge count (0 = open-inbox title)', () => {
+    expect(commentInboxTitle(0, false)).toBe('Open comment inbox')
+    expect(commentInboxTitle(0, true)).toBe('打开评论收件箱')
+    expect(commentInboxTitle(5, false)).toBe('5 comment updates need attention')
+    expect(commentInboxTitle(5, true)).toBe('5 条评论待处理')
+  })
+
+  it('mentions + card count helpers interpolate n and pluralize en', () => {
+    expect(mentionsUnread(2, true)).toBe('2 条未读')
+    expect(mentionsUnread(2, false)).toBe('2 unread')
+    expect(mentionsRecords(1, false)).toBe('1 record')
+    expect(mentionsRecords(4, false)).toBe('4 records')
+    expect(mentionsRecords(4, true)).toBe('4 条记录')
+
+    expect(cardSheets(1, true)).toBe('1 个 Sheet')
+    expect(cardSheets(1, false)).toBe('1 sheet')
+    expect(cardSheets(2, false)).toBe('2 sheets')
+    expect(cardFields(0, true)).toBe('0 个字段')
+    expect(cardFields(0, false)).toBe('0 fields')
+    expect(cardViews(3, true)).toBe('3 个视图')
+    expect(cardViews(1, false)).toBe('1 view')
+  })
+})

--- a/docs/development/multitable-workbench-i18n-t2-development-20260519.md
+++ b/docs/development/multitable-workbench-i18n-t2-development-20260519.md
@@ -1,0 +1,324 @@
+# T2 多维表工作台中文化 — 开发计划
+
+- **日期**：2026-05-19
+- **范围**：`apps/web/src/multitable/views/MultitableWorkbench.vue` + 新增 `apps/web/src/multitable/utils/workbench-labels.ts`
+- **方式**：轻量 locale label 模块（仿 `category-labels.ts`，用户已选定）
+- **依赖**：无（H 系列已 merged）；不依赖部署
+- **K3 PoC 阶段一锁定**：合规 —— 已发布 UI 的本地化属"内核打磨"，无新战线 / 无 integration-core / 无契约 / 无 migration
+- **关联**：[H 系列收官锚点](./views-consolidation-multitable-spreadsheets-plan-20260517.md)
+
+---
+
+## 1. Summary
+
+多维表当前 i18n 三段割裂（详见 [上一轮 scout]）：导航/首页/模板中心硬编码中文，**工作台 + Meta\* 组件硬编码英文**，全线不读 `useLocale`。T2 只做**工作台外壳**（`MultitableWorkbench.vue`）中文化，让它响应顶部 en/zh-CN 开关，与中文导航/首页一致，对标飞书界面一致性。
+
+**不做** Meta\* 子组件（MetaGridTable/MetaRecordDrawer/MetaViewManager/Kanban/Form/...）—— 那是 T3，本 PR 明确不碰（见 §4 边界）。
+
+---
+
+## 2. label 模块设计
+
+新增 `apps/web/src/multitable/utils/workbench-labels.ts`，仿 `category-labels.ts` 形态但 en/zh 双显式：
+
+```ts
+// Workbench UI string table. Single source for MultitableWorkbench.vue
+// localization. EN + ZH both explicit (unlike category-labels where the
+// data layer is English). Components read useLocale().isZh and call
+// workbenchLabel(key, isZh). Interpolated strings take params.
+
+// ⚠ 下方 key 联合为**示意骨架**。**完整、权威的 key 清单以 §3 全量字符串清单为准**
+// （含 §3.0 conflict.* / presence.* / conflict.fieldFallback、§3.4 kbd.navigateCells、
+// §3.6 card.*）。实现者必须照 §3 逐表建 key，勿仅照此示意抄（会漏 key）。
+export type WorkbenchLabelKey =
+  // §3.0 脚本 computed 外壳（插值见 helper 区）
+  | 'conflict.fieldFallback'
+  // §3.1 冲突横幅
+  | 'conflict.title' | 'conflict.reload' | 'conflict.retry' | 'conflict.dismiss'
+  // §3.2 工具栏
+  | 'toolbar.commentInbox' | 'toolbar.fields' | 'toolbar.access' | 'toolbar.views'
+  | 'toolbar.workflow' | 'toolbar.automations' | 'toolbar.templates'
+  | 'toolbar.dashboard' | 'toolbar.shareForm' | 'toolbar.apiWebhooks'
+  | 'toolbar.mentions'
+  // §3.3 模板库 modal
+  | 'tpl.title' | 'tpl.subtitle' | 'tpl.loading' | 'tpl.more'
+  // §3.4 快捷键 modal（kbd.* 为说明文案，需译；<kbd> 物理键名不进表）
+  | 'kbd.title' | 'kbd.navigateCells' | 'kbd.editCell' | 'kbd.cancelClose' | 'kbd.nextCell'
+  | 'kbd.copy' | 'kbd.paste' | 'kbd.undo' | 'kbd.redo' | 'kbd.toggleHelp'
+  // §3.5 静态 toast 子集（~17；动态/插值族见 §3.5 = T3）
+  | 'toast.recordCreateBlocked' | 'toast.recordEditBlocked' | 'toast.recordDeleteBlocked'
+  | 'toast.datesUpdated' | 'toast.hierarchyUpdated' | 'toast.recordDeleted'
+  | 'toast.loadedLatest' | 'toast.changeReapplied' | 'toast.recordUpdated'
+  | 'toast.formSubmitted' | 'toast.commentUpdated' | 'toast.commentAdded'
+  | 'toast.commentResolved' | 'toast.commentDeleted' | 'toast.linkedRecordsUpdated'
+  | 'toast.viewSettingsSaved'
+  // §3.6 MetaTemplateCard 按钮（计数走插值 helper card.sheets/fields/views）
+  | 'card.install' | 'card.installing'
+
+// 插值 helper（非 key，单列）：conflict.message(field, version?) /
+// presence.label(n) / presence.title(ids) / commentInboxTitle(n) /
+// mentionsUnread(n) / mentionsRecords(n) / card.sheets(n) / card.fields(n) /
+// card.views(n) —— 各含 §3 注明的 en 单复数 / 空态 / 0 分支 / 可选段。
+
+const WORKBENCH_LABELS: Record<WorkbenchLabelKey, { en: string; zh: string }> = { /* §3 */ }
+
+export function workbenchLabel(key: WorkbenchLabelKey, isZh: boolean): string {
+  const entry = WORKBENCH_LABELS[key]
+  return isZh ? entry.zh : entry.en
+}
+
+// interpolated helpers
+export function mentionsUnread(n: number, isZh: boolean): string  // "{n} unread" / "{n} 条未读"
+export function mentionsRecords(n: number, isZh: boolean): string
+export function commentInboxTitle(n: number, isZh: boolean): string
+```
+
+Workbench 侧接入：
+
+```ts
+import { useLocale } from '../../composables/useLocale'
+import { workbenchLabel as wb /* + helpers */ } from '../utils/workbench-labels'
+const { isZh } = useLocale()
+// 模板内：{{ wb('toolbar.fields', isZh) }}
+// 脚本内 toast：showSuccess(wb('toast.recordDeleted', isZh.value))
+```
+
+`isZh` 是 computed，模板/脚本读它天然响应顶部语言开关，无需额外订阅。
+
+---
+
+## 3. 全量字符串清单（en → zh，按位置）
+
+### 3.0 脚本 computed 外壳文案（评审补：之前漏进清单，实为工作台可见）
+
+这些在脚本里是 `computed`，模板 `{{ }}` 直接渲染，**是工作台外壳可见文案，必须本地化**：
+
+| key（helper） | 源（行） | en | zh |
+|---|---|---|---|
+| `conflict.message(field, version?)` | `conflictMessage` L891 | `{field} changed elsewhere.[ Latest version is {v}.] Reload the row or retry your edit.` | `{field} 已在别处被修改。[ 最新版本为 {v}。] 请重新加载该行或重试你的修改。` |
+| `conflict.fieldFallback` | `conflictFieldName` L886 | `cell` | `单元格` |
+| `presence.label(n)` | `sheetPresenceLabel` L879 | `{n} active collaborator` / `{n} active collaborators` | `{n} 位活跃协作者` |
+| `presence.title(ids)` | `sheetPresenceTitle` L882 | `Active now: {ids}` / `No active collaborators` | `当前在线：{ids}` / `无活跃协作者` |
+
+实现：把这 4 个 computed 改为读 `isZh` 后用 helper 拼装（`conflict.message` / `presence.label` / `presence.title` 是插值 helper，`conflict.fieldFallback` 是普通 key）。
+
+> **实现陷阱（评审提示）**：上表 `conflict.message` 里的 `[ … ]` 是 **optional 段标记，不是字面方括号**——`version` 为数字时插入「 Latest version is {v}.」/「 最新版本为 {v}。」，否则该段整体省略。**输出里绝不能出现 `[` `]` 字符**。`presence.title` 的 `{ids}` 若是 user id（非姓名），id 本身不翻译，仅译外层模板。
+
+### 3.1 冲突横幅（L4-13）
+
+| key | en | zh |
+|---|---|---|
+| conflict.title | Update conflict | 更新冲突 |
+| conflict.reload | Reload latest | 重新加载最新 |
+| conflict.retry | Retry change | 重试本次修改 |
+| conflict.dismiss | Dismiss | 忽略 |
+
+### 3.2 工具栏（L26-62）
+
+| key | en | zh |
+|---|---|---|
+| toolbar.mentions | Mentions | 提及 |
+| (interp) mentionsUnread | {n} unread | {n} 条未读 |
+| (interp) mentionsRecords | {n} records | {n} 条记录 |
+| (interp) commentInboxTitle | {n} comment updates need attention | {n} 条评论待处理 |
+| toolbar.commentInbox | Comment Inbox | 评论收件箱 |
+| toolbar.fields | Fields | 字段 |
+| toolbar.access | Access | 权限 |
+| toolbar.views | Views | 视图 |
+| toolbar.workflow | Workflow | 工作流 |
+| toolbar.automations | Automations | 自动化 |
+| toolbar.templates | Templates | 模板 |
+| toolbar.dashboard | Dashboard | 仪表盘 |
+| toolbar.shareForm | Share Form | 分享表单 |
+| toolbar.apiWebhooks | API & Webhooks | API 与 Webhook |
+
+> `Open comment inbox`（title 无 badge 时）→ `打开评论收件箱`，并入 commentInboxTitle helper 的 0 分支。
+
+### 3.3 模板库 modal（L64-92）
+
+| key | en | zh |
+|---|---|---|
+| tpl.title | Template Library | 模板库 |
+| tpl.subtitle | Start a new base from a built-in workspace pattern. | 从内置工作区模板新建一个 Base |
+| tpl.loading | Loading templates... | 正在加载模板... |
+| tpl.more | More templates → | 更多模板 → |
+
+> 注：footer 当前**硬编码中文** `更多模板 →`，是英文工作台里的孤立中文。T2 用 `tpl.more` 统一为双语（消除这处不一致）。`templateLibraryError` 是脚本动态串，**不在 T2**（错误文案本地化属更深层，单列）。
+
+### 3.4 键盘快捷键 modal（L302-314）
+
+| key | en | zh |
+|---|---|---|
+| kbd.title | Keyboard Shortcuts | 键盘快捷键 |
+| kbd.navigateCells | Navigate cells | 导航单元格 |
+| kbd.editCell | Edit cell | 编辑单元格 |
+| kbd.cancelClose | Cancel edit / close | 取消编辑 / 关闭 |
+| kbd.nextCell | Next cell | 下一个单元格 |
+| kbd.copy | Copy cell value | 复制单元格值 |
+| kbd.paste | Paste into cell | 粘贴到单元格 |
+| kbd.undo | Undo | 撤销 |
+| kbd.redo | Redo | 重做 |
+| kbd.toggleHelp | Toggle this help | 切换此帮助 |
+
+> `<kbd>Enter/Escape/Tab/Ctrl+C…</kbd>` 是按键名，**不翻译**（保持物理键名）。
+
+### 3.5 脚本 toast（showSuccess/showError：静态子集 ~17 进 T2 + 动态族列 T3）
+
+| key | en | zh |
+|---|---|---|
+| toast.recordCreateBlocked | Record creation is not allowed in this view. | 当前视图不允许创建记录。 |
+| toast.recordEditBlocked | Record editing is not allowed for this row. | 该行不允许编辑记录。 |
+| toast.recordDeleteBlocked | Record deletion is not allowed for this row. | 该行不允许删除记录。 |
+| toast.datesUpdated | Dates updated | 日期已更新 |
+| toast.hierarchyUpdated | Hierarchy updated | 层级已更新 |
+| toast.recordDeleted | Record deleted | 记录已删除 |
+| toast.loadedLatest | Loaded the latest row state | 已加载最新行状态 |
+| toast.changeReapplied | Change reapplied | 修改已重新应用 |
+| toast.recordUpdated | Record updated | 记录已更新 |
+| toast.formSubmitted | Form submitted | 表单已提交 |
+| toast.commentUpdated | Comment updated | 评论已更新 |
+| toast.commentAdded | Comment added | 评论已添加 |
+| toast.commentResolved | Comment resolved | 评论已解决 |
+| toast.commentDeleted | Comment deleted | 评论已删除 |
+
+**实测：`grep -cE "showSuccess\(|showError\("` = 70 个，远多于初稿的 ~15。** T2 **只做上表的静态非插值子集**（约 17 个：3 个 not-allowed 阻断 + datesUpdated/hierarchyUpdated/recordDeleted/loadedLatest/changeReapplied/recordUpdated/formSubmitted/4 个 comment* + linkedRecordsUpdated + viewSettingsSaved）。
+
+**明确转 T3 边界（本 PR 不做，verification 必列）**：
+
+- 动态插值：`Installed ${result.template.name}`、`${n} record(s) imported/skipped/failed/deleted`、`Record not found: ${recordId}`
+- 权限/host-context 文案：`* requires multitable write access.`、`Host multitable context change …`
+- `Failed to …` 后端错误 fallback 系列
+- `Import cancelled` 及 import/bulk-edit 计数族
+
+**验收口径改为**：静态 toast 全覆盖；动态/后端/插值错误文案列入 T3。verification MD **必须附** `grep -nE "showSuccess\(|showError\(" MultitableWorkbench.vue` 全量输出，逐条标 `[T2-done]` / `[T3-deferred]`，证明无静态漏译、动态项是有意识 defer 而非遗漏。
+
+---
+
+### 3.6 MetaTemplateCard（评审补：纳入 T2，避免模板库 modal 中英混杂）
+
+`MetaTemplateCard.vue` 当前**硬编码中文**（L16-18 `个 Sheet · 个字段 · 个视图`、L26 `创建中.../使用模板`），未用 `useLocale`。它被工作台模板库 modal 渲染——与 footer `更多模板 →` 同理：英文工作台里的孤立中文。**纳入 T2**（小改、低风险），且因它同时被首页/模板中心（已中文页）复用，双语化是全局净改进。
+
+| key | en | zh |
+|---|---|---|
+| card.sheets(n) | {n} sheet / {n} sheets | {n} 个 Sheet |
+| card.fields(n) | {n} field / {n} fields | {n} 个字段 |
+| card.views(n) | {n} view / {n} views | {n} 个视图 |
+| card.install | Use template | 使用模板 |
+| card.installing | Installing... | 创建中... |
+
+实现：`MetaTemplateCard.vue` import `useLocale`，5 处串改 helper；计数行 en 用单复数 helper。它有独立组件测试面（home/template-center spec 已覆盖渲染），改后跑相关 spec 回归。
+
+## 4. 范围边界（明确写清）
+
+| 在 T2 | 不在 T2（= T3 或单列） |
+|---|---|
+| `MultitableWorkbench.vue` 模板可见 chrome（冲突横幅 / 工具栏 / 模板库 modal 标题&状态 / 快捷键 modal） | 子组件 Meta\*（GridTable/RecordDrawer/ViewManager/Kanban/Form/Calendar/Gallery/Timeline…）—— 表体/抽屉/管理面板**保持英文** |
+| §3.0 脚本 computed 外壳文案（conflict.message / presence.label / presence.title / conflict.fieldFallback） | `templateLibraryError` 脚本动态错误文案（**T2 不译；最易在打开模板库时被看到，PR body + verification 必须显式声明此英文残留**） |
+| Workbench 脚本**静态非插值** toast（§3.5 ~17 个） | §3.5 动态/插值/权限/host-context/Failed-to/import 计数族 toast（→ T3） |
+| `MetaTemplateCard.vue` 计数行 + 按钮双语（§3.6） | App.vue / 其它非多维表页（不碰） |
+| 统一 footer `更多模板 →` 为双语 | 引入 vue-i18n 框架（明确不做） |
+| 新增 `workbench-labels.ts` + 测试 | — |
+
+**T2 已知局限（须在 PR/verification 写明）**：①工作台外壳中文，但点开表格/记录抽屉/视图·字段·权限管理面板**仍英文**（Meta\* 未本地化，T3）；②`templateLibraryError` 模板库加载失败文案**仍英文**；③动态/插值 toast（"Installed X"、"N 条已导入"、"Record not found: id" 等）**仍英文**（T3）。均为 T2 预期边界，非 bug。
+
+---
+
+## 5. 改动文件清单
+
+| 文件 | 改动 |
+|---|---|
+| `apps/web/src/multitable/utils/workbench-labels.ts` | **新增** ~160 行：key 联合类型 + EN/ZH 表 + `workbenchLabel` + 插值 helper（presence.label 含 en 单复数、presence.title 含空态、conflict.message 含可选 version、commentInboxTitle 含 0 分支、card.sheets/fields/views 计数） |
+| `apps/web/src/multitable/views/MultitableWorkbench.vue` | import `useLocale` + `workbench-labels`；模板 ~25 处 + §3.0 的 4 个 computed 改读 isZh；脚本静态 toast ~17 处 → `wb(key, isZh.value)`；footer 统一 |
+| `apps/web/src/multitable/components/MetaTemplateCard.vue` | import `useLocale`；§3.6 的 5 处串改 helper（计数行 + 按钮） |
+| `apps/web/tests/multitable-workbench-i18n.spec.ts` | **新增**：`workbench-labels` 模块单测（key 完整性 + 插值 helper en/zh） |
+| `apps/web/tests/multitable-workbench-view.spec.ts`（既有，复用其 mock 范式增量） | 加 locale 断言（zh-CN/en 各渲染关键串）；**不新挂载**——复用既有重 mock 装配，避免被 composable/router/child 依赖拖垮 |
+| `apps/web/tests/multitable-home-view.spec.ts` + `multitable-template-center-view.spec.ts`（既有） | MetaTemplateCard 改动回归（这两 spec 已断言 card 渲染；确认 zh 默认下文案不变） |
+
+不动：后端 / 契约 / migration / 其它 Meta\* 组件 / 其它视图。
+
+---
+
+## 6. Test Plan
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+pnpm --filter @metasheet/web exec vitest run tests/multitable-workbench-i18n.spec.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/multitable-workbench-view.spec.ts --watch=false      # 复用既有 mock 范式 + locale 断言
+pnpm --filter @metasheet/web exec vitest run tests/multitable-home-view.spec.ts --watch=false           # MetaTemplateCard 回归
+pnpm --filter @metasheet/web exec vitest run tests/multitable-template-center-view.spec.ts --watch=false # MetaTemplateCard 回归
+pnpm --filter @metasheet/web exec vitest run tests/platform-shell-nav.spec.ts --watch=false             # 回归：locale 开关未破
+git diff --check origin/main..HEAD
+```
+
+Acceptance：
+
+- `workbench-labels`：每 key en/zh 非空且不相等；`workbenchLabel(k,true)`→zh、`(k,false)`→en；插值 helper（presence.label en 单复数、presence.title 空态、conflict.message 可选 version、commentInboxTitle 0 分支、card.* 计数）代入正确。`<kbd>` 物理键名不翻译、不进表
+- Workbench：`zh-CN` 渲染含「字段/权限/视图/自动化/评论收件箱/模板库/键盘快捷键/导航单元格」+ presence/conflict 中文；`en` 对应英文
+- MetaTemplateCard（精确口径）：**zh-CN（默认）下 Home/TemplateCenter 必须保持**「`{n} 个 Sheet` / `{n} 个字段` / `{n} 个视图` / `使用模板` / `创建中...`」——既有 home-view / template-center-view spec 文案断言零回归；**en 下显示**「`{n} sheet(s)` / `{n} field(s)` / `{n} view(s)` / `Use template` / `Installing...`」（计数 en 走单复数）
+- **静态 toast 全覆盖证明**：verification MD 附 `grep -nE "showSuccess\(|showError\(" MultitableWorkbench.vue` 全量，逐条标 `[T2-done]`/`[T3-deferred]`
+- `git diff --check` clean；diff 仅 §5 所列文件
+
+---
+
+## 7. K3 PoC 阶段一锁定合规
+
+| 检查 | 状态 |
+|---|---|
+| plugin-integration-core / k3-wise / Data Factory | ❌ 不碰 |
+| `/api/multitable/*` 等任何契约 | ❌ 不碰（纯前端文案） |
+| DB migration / schema | ❌ 零 |
+| 新产品面 / 平台化 | ❌ 否（本地化已发布 UI = 内核打磨） |
+| vue-i18n 等框架级改动 | ❌ 不做（仅轻量 label 模块） |
+
+---
+
+## 8. 风险登记
+
+| 风险 | 等级 | 缓解 |
+|---|---|---|
+| 漏译（某字面量未替换） | 中 | §3 清单逐条核对；组件测试抽样两语言关键串；实现后 `grep` 残留英文 chrome |
+| 脚本 toast 含动态拼接，套 `wb()` 破坏插值 | 中 | §3.5 注明：纯静态先做，含动态片段的转 helper 或记 T2 边界转 T3 |
+| `sheetPresenceLabel`/`sheetPresenceTitle`/`conflictMessage` 是脚本 computed，可能含英文 | 中 | 实现时 grep 这些 computed 定义；含英文则并入 label 模块，否则记录为既有（多为后端/纯数据）不在 T2 |
+| 改 25+ 处字面量引入语法错误 | 低 | 分段改 + 每段后 `vue-tsc --noEmit`；组件测试守护渲染 |
+| footer 既有中文被测试断言依赖 | 低 | 改前 grep `更多模板` 在 tests/ 的引用；H2 测试断的是 router-link 存在性非文案，安全 |
+
+---
+
+## 9. PR 拆分
+
+```
+分支: frontend/multitable-workbench-i18n-20260519   (已建，off origin/main)
+Lane: frontend
+体量: S–M（1 新模块 + 1 视图改 + 1 测试）
+预计 PR: 1
+```
+
+---
+
+## 10. 推荐执行顺序
+
+1. **审本 MD**（你现在做的）—— 重点确认 §3 译文措辞 + §4 边界（Meta\* 不在 T2）
+2. 审过 → 建 `workbench-labels.ts`（全 key + 译文）
+3. Workbench 接入（模板段 → 脚本 toast 段，每段后 typecheck）
+4. 写组件 + 模块测试
+5. 跑 §6 验证 → 写 verification MD
+6. 本地 commit + 停 push 前（沿用本会话节奏）→ 你 review → push → CI → admin-merge
+
+---
+
+## 11. 变更日志
+
+- **2026-05-19 (1)** 初稿（zensgit + claude-opus-4-7 协作）
+- **2026-05-19 (2)** 评审修订（3 Must + 3 Should）：
+  - **Must1**：补 §3.0 脚本 computed 外壳文案——`conflictMessage`(L891)/`conflictFieldName`(L886 'cell' fallback)/`sheetPresenceLabel`(L879)/`sheetPresenceTitle`(L882)；§3.4 补 `kbd.navigateCells`(L306 漏的首行)
+  - **Must2**：MetaTemplateCard 纳入 T2（§3.6）——modal 内孤立中文计数/按钮，与 footer 同理；它也被 home/template-center 复用，双语化全局净改进
+  - **Must3**：§3.5 修正——实测 `showSuccess/showError` = **70** 个（非 ~15）；T2 只做静态非插值子集（~17），动态/插值/权限/host-context/Failed-to/import 计数族明列 T3；验收改为"静态全覆盖 + verification 附全量 grep 分类 [T2-done]/[T3-deferred]"
+  - **Should1**：测试改为复用 `multitable-workbench-view.spec.ts` 既有重 mock 范式 + home/template-center spec 回归，不新挂载
+  - **Should2**：实现 review 须盯——`wb` 模板内 computed 自动 unwrap、脚本内统一 `isZh.value`
+  - **Should3**：`templateLibraryError` 不译，PR body + verification + §4 边界**显式声明**英文残留（打开模板库最易见的错误态之一）
+- **2026-05-19 (3)** 实现前最后 3 个文档一致性修订：
+  - §2 key 联合补全（presence/conflict/card/kbd.navigateCells 分组）+ 顶部加"示意骨架，完整以 §3 为准 + 插值 helper 单列"声明，防实现者照旧 §2 漏 key
+  - §3.5 标题从"~15 个"改为"静态子集 ~17 进 T2 + 动态族列 T3"，消除标题/正文矛盾
+  - §6 acceptance MetaTemplateCard 精确化：zh-CN（默认）Home/TemplateCenter 必保「个 Sheet/个字段/个视图/使用模板/创建中...」零回归，en 显示 sheet(s)/field(s)/view(s)/Use template/Installing...
+  - §3.0 加实现陷阱：`conflict.message` 的 `[ ]` 是 optional 段标记非字面方括号，输出禁现 `[`/`]`；`presence.title` ids 若为 user id 不译 id 本身
+  - 译文/边界经评审确认：presence.*/conflict.message/card.sheets(保留 "Sheet" 不改"个表") 措辞接受；T3 边界（templateLibraryError/动态 toast/Meta\*）确认

--- a/docs/development/multitable-workbench-i18n-t2-development-20260519.md
+++ b/docs/development/multitable-workbench-i18n-t2-development-20260519.md
@@ -230,9 +230,12 @@ const { isZh } = useLocale()
 | `apps/web/src/multitable/utils/workbench-labels.ts` | **新增** ~160 行：key 联合类型 + EN/ZH 表 + `workbenchLabel` + 插值 helper（presence.label 含 en 单复数、presence.title 含空态、conflict.message 含可选 version、commentInboxTitle 含 0 分支、card.sheets/fields/views 计数） |
 | `apps/web/src/multitable/views/MultitableWorkbench.vue` | import `useLocale` + `workbench-labels`；模板 ~25 处 + §3.0 的 4 个 computed 改读 isZh；脚本静态 toast ~17 处 → `wb(key, isZh.value)`；footer 统一 |
 | `apps/web/src/multitable/components/MetaTemplateCard.vue` | import `useLocale`；§3.6 的 5 处串改 helper（计数行 + 按钮） |
-| `apps/web/tests/multitable-workbench-i18n.spec.ts` | **新增**：`workbench-labels` 模块单测（key 完整性 + 插值 helper en/zh） |
-| `apps/web/tests/multitable-workbench-view.spec.ts`（既有，复用其 mock 范式增量） | 加 locale 断言（zh-CN/en 各渲染关键串）；**不新挂载**——复用既有重 mock 装配，避免被 composable/router/child 依赖拖垮 |
-| `apps/web/tests/multitable-home-view.spec.ts` + `multitable-template-center-view.spec.ts`（既有） | MetaTemplateCard 改动回归（这两 spec 已断言 card 渲染；确认 zh 默认下文案不变） |
+| `apps/web/tests/multitable-workbench-i18n.spec.ts` | **新增**：`workbench-labels` 模块单测（key 完整性 + en≠zh + 9 个插值 helper） |
+| `apps/web/tests/multitable-home-view.spec.ts` + `multitable-template-center-view.spec.ts`（既有） | 加 `beforeEach setLocale('zh-CN')` + afterEach 复位——MetaTemplateCard 转 locale 感知后，这两 spec 的中文断言需显式 locale（jsdom 默认 'en'） |
+
+> **`multitable-workbench-view.spec.ts` 不改（诚实口径）**：该 spec 在本仓 jsdom env 存在既有 `localStorage.removeItem is not a function` afterEach baseline（53/53 全 fail，已用 stash 法在 clean origin/main 复核逐字一致，见 verification §3）。往其中加断言无意义——afterEach 必抛、新断言照样标 failed。故 **Workbench 本体的 zh-CN/en 渲染不做自动化 render 断言**；其正确性由 (a) label 模块 spec 确定性覆盖全部映射/helper + (b) `vue-tsc` 保证每个 `wb(key,…)` 调用的 key 是合法 `WorkbenchLabelKey`（错 key=编译错）+ (c) build + (d) 代码 diff / 人工审阅 共同保证。新挂载 mock-heavy Workbench 是早先评审明确警告要避免的，故不做。
+
+不动：后端 / 契约 / migration / 其它 Meta\* 组件 / 其它视图 / `multitable-workbench-view.spec.ts`。
 
 不动：后端 / 契约 / migration / 其它 Meta\* 组件 / 其它视图。
 
@@ -242,8 +245,7 @@ const { isZh } = useLocale()
 
 ```bash
 pnpm --filter @metasheet/web exec vue-tsc --noEmit
-pnpm --filter @metasheet/web exec vitest run tests/multitable-workbench-i18n.spec.ts --watch=false
-pnpm --filter @metasheet/web exec vitest run tests/multitable-workbench-view.spec.ts --watch=false      # 复用既有 mock 范式 + locale 断言
+pnpm --filter @metasheet/web exec vitest run tests/multitable-workbench-i18n.spec.ts --watch=false       # label 模块（核心覆盖）
 pnpm --filter @metasheet/web exec vitest run tests/multitable-home-view.spec.ts --watch=false           # MetaTemplateCard 回归
 pnpm --filter @metasheet/web exec vitest run tests/multitable-template-center-view.spec.ts --watch=false # MetaTemplateCard 回归
 pnpm --filter @metasheet/web exec vitest run tests/platform-shell-nav.spec.ts --watch=false             # 回归：locale 开关未破
@@ -253,7 +255,7 @@ git diff --check origin/main..HEAD
 Acceptance：
 
 - `workbench-labels`：每 key en/zh 非空且不相等；`workbenchLabel(k,true)`→zh、`(k,false)`→en；插值 helper（presence.label en 单复数、presence.title 空态、conflict.message 可选 version、commentInboxTitle 0 分支、card.* 计数）代入正确。`<kbd>` 物理键名不翻译、不进表
-- Workbench：`zh-CN` 渲染含「字段/权限/视图/自动化/评论收件箱/模板库/键盘快捷键/导航单元格」+ presence/conflict 中文；`en` 对应英文
+- Workbench 本体（zh-CN/en 渲染）：**无自动化 render 断言**（workbench-view spec 既有 localStorage baseline，见 §5 诚实口径）。正确性由 label spec（映射/helper 全覆盖）+ `vue-tsc`（key 合法性）+ build + 代码审阅保证。期望行为：`zh-CN` 工具栏/横幅/modal 显示「字段/权限/视图/自动化/评论收件箱/模板库/键盘快捷键/导航单元格」+ presence/conflict 中文；`en` 对应英文 —— 经人工审阅 diff 确认
 - MetaTemplateCard（精确口径）：**zh-CN（默认）下 Home/TemplateCenter 必须保持**「`{n} 个 Sheet` / `{n} 个字段` / `{n} 个视图` / `使用模板` / `创建中...`」——既有 home-view / template-center-view spec 文案断言零回归；**en 下显示**「`{n} sheet(s)` / `{n} field(s)` / `{n} view(s)` / `Use template` / `Installing...`」（计数 en 走单复数）
 - **静态 toast 全覆盖证明**：verification MD 附 `grep -nE "showSuccess\(|showError\(" MultitableWorkbench.vue` 全量，逐条标 `[T2-done]`/`[T3-deferred]`
 - `git diff --check` clean；diff 仅 §5 所列文件
@@ -322,3 +324,8 @@ Lane: frontend
   - §6 acceptance MetaTemplateCard 精确化：zh-CN（默认）Home/TemplateCenter 必保「个 Sheet/个字段/个视图/使用模板/创建中...」零回归，en 显示 sheet(s)/field(s)/view(s)/Use template/Installing...
   - §3.0 加实现陷阱：`conflict.message` 的 `[ ]` 是 optional 段标记非字面方括号，输出禁现 `[`/`]`；`presence.title` ids 若为 user id 不译 id 本身
   - 译文/边界经评审确认：presence.*/conflict.message/card.sheets(保留 "Sheet" 不改"个表") 措辞接受；T3 边界（templateLibraryError/动态 toast/Meta\*）确认
+- **2026-05-19 (4)** 实现后评审 P1/P2 修正（验证声称诚实化）：
+  - §5：删除"`multitable-workbench-view.spec.ts` 加 locale 断言"行（该 spec 既有 localStorage baseline 53/53，往里加断言无意义）；改为诚实口径——Workbench 本体 render **无**自动化断言，正确性由 label spec + vue-tsc(key 合法性) + build + 人工 diff 审阅保证
+  - §6：移除 workbench-view spec 命令 + "Workbench zh-CN/en 渲染断言"验收项，改为诚实表述
+  - verification §7 加"测试覆盖诚实声明"段（P2）：Workbench 双语 render 未新增自动化，附原因 + 未来 baseline 修复后应补真实断言
+  - 实际改动 spec 仅 2 个（home-view/template-center 的 setLocale 回归处理）+ 1 新增（workbench-i18n label spec）

--- a/docs/development/multitable-workbench-i18n-t2-verification-20260519.md
+++ b/docs/development/multitable-workbench-i18n-t2-verification-20260519.md
@@ -1,0 +1,103 @@
+# T2 多维表工作台中文化 — 验证报告
+
+- **日期**：2026-05-19
+- **配套**：[multitable-workbench-i18n-t2-development-20260519.md](./multitable-workbench-i18n-t2-development-20260519.md)
+- **分支**：`frontend/multitable-workbench-i18n-20260519`
+
+---
+
+## 1. 实现摘要
+
+| 文件 | 改动 |
+|---|---|
+| `apps/web/src/multitable/utils/workbench-labels.ts` | **新增** ~200 行：`WorkbenchLabelKey` 联合（47 静态 key）+ EN/ZH 表 + `workbenchLabel` + 9 个插值 helper（conflictMessage / presenceLabel / presenceTitle / commentInboxTitle / mentionsUnread / mentionsRecords / cardSheets / cardFields / cardViews） |
+| `apps/web/src/multitable/views/MultitableWorkbench.vue` | import `useLocale` + label 模块；§3.0 四个 computed 改 helper；模板 ~25 处字面量 → `wb()` / helper；脚本 17 处静态 toast → `wb(key, isZh.value)`；footer `更多模板 →` → `wb('tpl.more', isZh)` |
+| `apps/web/src/multitable/components/MetaTemplateCard.vue` | import `useLocale`；计数行 3 串 → cardSheets/Fields/Views；按钮 → `card.install`/`card.installing`；categoryDisplay 传 locale |
+| `apps/web/tests/multitable-workbench-i18n.spec.ts` | **新增**：label 模块单测（key 完整性 + en≠zh + 9 helper） |
+| `apps/web/tests/multitable-home-view.spec.ts` | beforeEach `setLocale('zh-CN')` + afterEach 复位（MetaTemplateCard 转 locale 感知后的回归处理） |
+| `apps/web/tests/multitable-template-center-view.spec.ts` | 同上 |
+
+---
+
+## 2. 测试结果（实测）
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc --noEmit                                              → clean
+pnpm --filter @metasheet/web build                                                              → ✓ 6.20s
+pnpm --filter @metasheet/web exec vitest run tests/multitable-workbench-i18n.spec.ts            → 8/8 pass
+pnpm --filter @metasheet/web exec vitest run tests/multitable-template-center-view.spec.ts      → 9/9 pass
+pnpm --filter @metasheet/web exec vitest run tests/platform-shell-nav.spec.ts                   → 5/5 pass
+pnpm --filter @metasheet/web exec vitest run tests/multitable-home-view.spec.ts                 → 7 fail（见 §3 baseline）
+pnpm --filter @metasheet/web exec vitest run tests/multitable-workbench-view.spec.ts            → 53 fail（见 §3 baseline）
+git diff --check                                                                                → clean
+```
+
+## 3. baseline 诚实声明（home-view / workbench-view 失败非 T2 回归）
+
+`multitable-home-view.spec.ts`（7 fail）与 `multitable-workbench-view.spec.ts`（53 fail）的失败**全部**是 `localStorage.removeItem is not a function`（spec afterEach 在本 jsdom env 的既有问题），与本会话 Phase B/B3/H2 记录的同一 baseline。
+
+**已用 stash 法在 clean origin/main 复核**：
+
+```
+git stash (T2 改动) → 在 origin/main 原状跑 multitable-workbench-view.spec.ts
+→ 同样 53 failed (53)  ← 与带 T2 改动结果逐字一致
+```
+
+证明：workbench-view 53/53 是**预存 env baseline**，非 T2 引入。T2 对测试账本**净新增失败 = 0**；新增 8（label spec）全绿。
+
+> MetaTemplateCard 转 locale 感知**确曾**让 home/template-center 的中文断言短暂回归（jsdom 默认 `en`）。已在两 spec 加 `beforeEach setLocale('zh-CN')` 修复——修复后 MetaTemplateCard 中文断言（`1 个 Sheet · 0 个字段 · 2 个视图` / `使用模板`）全部通过；template-center 9/9 全绿，home-view 仅剩与 MetaTemplateCard 无关的 localStorage afterEach baseline。
+
+## 4. 静态 toast 全覆盖证明（MD §3.5 强制项）
+
+`grep -nE "showSuccess\(|showError\(" MultitableWorkbench.vue` 全量分类：
+
+### [T2-done] 17 个 → `wb('toast.*', isZh.value)`
+
+`changeReapplied` `commentAdded` `commentDeleted` `commentResolved` `commentUpdated` `datesUpdated` `formSubmitted` `hierarchyUpdated` `linkedRecordsUpdated` `loadedLatest` `recordCreateBlocked` `recordDeleteBlocked` `recordDeleted` `recordEditBlocked` `recordUpdated`(×2 站点) `viewSettingsSaved`
+
+### [T3-deferred] 15 个（动态/插值/权限/host-context，**非遗漏，MD §3.5 已明列**）
+
+| 行 | 内容 | 归类 |
+|---|---|---|
+| 1757 | `Sheet creation requires multitable write access.` | 权限 |
+| 2040/2042 | `Host multitable context change …` ×2 | host-context |
+| 2097 | `Base creation requires multitable write access.` | 权限 |
+| 2122/2133 | `Template installation requires multitable write access.` ×2 | 权限 |
+| 2154 | `` `Installed ${result.template.name}` `` | 动态插值 |
+| 2239/2245/2247/2249/2253 | `` `${n} record(s) imported/failed/skipped` `` ×5 | 动态插值 |
+| 2261 | `Import cancelled` | import 族 |
+| 2470 | `` `${n} record(s) deleted` `` | 动态插值 |
+| 2568 | `` `Record not found: ${recordId}` `` | 动态插值 |
+
+**结论**：每个 T2 静态 toast 已转 `wb()`；每个 T3-deferred 项确为动态/插值/权限/host-context（与 MD §3.5 预测逐条吻合），无任何静态字符串被遗漏。
+
+## 5. T2 已知局限（须随 PR 显式声明，非 bug）
+
+1. **Meta\* 子组件仍英文**：工作台外壳已中文，但点开表格（MetaGridTable）/记录抽屉（MetaRecordDrawer）/字段·视图·权限管理面板（MetaViewManager 等）**仍英文** —— T3。
+2. **`templateLibraryError` 仍英文**：打开模板库若加载失败，错误文案为英文（脚本动态错误，T3）。这是打开模板库最易见的错误态之一，**显式声明**。
+3. **15 个动态/插值 toast 仍英文**：`Installed X`、`N 条已导入`、`Record not found: id`、权限/host-context 提示等 —— T3。
+
+均为 T2 预期边界，已在 dev MD §4 锚定。
+
+## 6. K3 PoC 阶段一锁定合规
+
+| 检查 | 状态 |
+|---|---|
+| plugin-integration-core / k3-wise / Data Factory | ❌ 不碰 |
+| `/api/multitable/*` 等任何契约 | ❌ 不碰（纯前端文案 + 一个新前端 util） |
+| DB migration / schema | ❌ 零 |
+| 新产品面 / 平台化 / vue-i18n 框架 | ❌ 否（轻量 label 模块，本地化已发布 UI = 内核打磨） |
+
+`git diff --name-only origin/main..HEAD` 仅含：dev MD + 本 verification MD + workbench-labels.ts + MultitableWorkbench.vue + MetaTemplateCard.vue + 3 个 spec。
+
+## 7. 结论
+
+T2 实现与（评审三轮修订后的）dev MD 完全一致：工作台外壳 + §3.0 computed + 17 静态 toast + MetaTemplateCard + footer 全部中文化，响应顶部 en/zh-CN 开关。label 模块 8/8 单测绿，typecheck/build 绿，回归零净新增。T3 边界（Meta\* / templateLibraryError / 动态 toast）明确锚定。
+
+**待执行**：本地 commit → 停 push 前（沿用本会话节奏）→ 用户 review → push → CI → admin-merge。
+
+---
+
+## 8. 变更日志
+
+- 2026-05-19 验证报告（zensgit + claude-opus-4-7 协作）

--- a/docs/development/multitable-workbench-i18n-t2-verification-20260519.md
+++ b/docs/development/multitable-workbench-i18n-t2-verification-20260519.md
@@ -92,7 +92,9 @@ git stash (T2 改动) → 在 origin/main 原状跑 multitable-workbench-view.sp
 
 ## 7. 结论
 
-T2 实现与（评审三轮修订后的）dev MD 完全一致：工作台外壳 + §3.0 computed + 17 静态 toast + MetaTemplateCard + footer 全部中文化，响应顶部 en/zh-CN 开关。label 模块 8/8 单测绿，typecheck/build 绿，回归零净新增。T3 边界（Meta\* / templateLibraryError / 动态 toast）明确锚定。
+T2 实现与（评审三轮修订后的）dev MD 完全一致：工作台外壳 + §3.0 computed + 17 静态 toast + MetaTemplateCard + footer 全部中文化，预期响应顶部 en/zh-CN 开关。label 模块 8/8 单测绿，typecheck/build 绿，回归零净新增。T3 边界（Meta\* / templateLibraryError / 动态 toast）明确锚定。
+
+> **测试覆盖诚实声明**：Workbench 组件本体的双语 render **没有新增自动化断言**。原因：`multitable-workbench-view.spec.ts` 存在既有 `localStorage.removeItem` afterEach baseline failure（53/53，stash 法在 clean origin/main 复核逐字一致，§3），往其中加断言无意义（afterEach 必抛、新断言照样标 failed），而新挂载 mock-heavy Workbench 是早先评审明确警告要避免的。Workbench 本体的 zh-CN/en 正确性由 (a) `multitable-workbench-i18n.spec.ts` 8/8 确定性覆盖全部 en/zh 映射 + 9 helper + (b) `vue-tsc --noEmit` 保证每个 `wb(key,…)` 的 key 是合法 `WorkbenchLabelKey`（错 key = 编译失败）+ (c) build 通过 + (d) 代码 diff 人工审阅 共同保证，**非**通过 Workbench render assertion。若未来该 spec 的 localStorage baseline 被修复，应补真实 Workbench locale render 断言。
 
 **待执行**：本地 commit → 停 push 前（沿用本会话节奏）→ 用户 review → push → CI → admin-merge。
 


### PR DESCRIPTION
## Summary

T2 of multitable Chinese localization: the workbench shell now responds to the top-bar en/zh-CN switch, matching the already-Chinese nav / home / template-center surfaces. Done via a lightweight locale label module (user-selected scope + approach), no vue-i18n framework.

Before T2 the multitable surface was 3-way split: nav/home/template-center hardcoded Chinese, **workbench + Meta\* hardcoded English, nothing read `useLocale`**. T2 fixes the workbench shell.

## Key Changes

**New `apps/web/src/multitable/utils/workbench-labels.ts`** — `WorkbenchLabelKey` union (static keys) + explicit EN/ZH table + `workbenchLabel(key,isZh)` + 9 interpolation helpers (`conflictMessage` with optional version segment that never emits literal brackets, `presenceLabel` en-plural, `presenceTitle` empty-state + untranslated ids, `commentInboxTitle` 0→open-inbox, `mentionsUnread/Records`, `cardSheets/Fields/Views`).

**`MultitableWorkbench.vue`** — import `useLocale`; §3.0 computeds (`sheetPresenceLabel/Title`, `conflictFieldName`, `conflictMessage`) rebuilt on helpers; ~25 template literals (conflict banner, toolbar buttons/chips, template-library modal header/loading, keyboard-shortcuts modal) → `wb()`/helpers (`<kbd>` physical keys left untranslated); 17 static `showSuccess/showError` toasts → `wb(key, isZh.value)`; footer `更多模板 →` (an isolated zh literal in an English shell) unified.

**`MetaTemplateCard.vue`** — `useLocale`-aware count line + install button + categoryDisplay (used by home/template-center too → net-consistent improvement).

## Test coverage (honest)

- **NEW `multitable-workbench-i18n.spec.ts` 8/8** — label-module unit test: key completeness, en≠zh for every key, all 9 interpolation helpers (incl. `conflictMessage` never containing `[`/`]`).
- `multitable-home-view.spec.ts` / `multitable-template-center-view.spec.ts` — added `beforeEach setLocale('zh-CN')` + afterEach restore: MetaTemplateCard became locale-aware so the Chinese-copy assertions need an explicit locale (jsdom default is `en`). template-center 9/9 green after the fix.
- **Workbench-body bilingual render is NOT automated.** `multitable-workbench-view.spec.ts` has a pre-existing 53/53 `localStorage.removeItem` afterEach jsdom baseline (verified identical on clean origin/main via stash); adding assertions there is futile (afterEach throws regardless) and new-mounting the mock-heavy Workbench was explicitly warned against in review. Workbench correctness is guaranteed by: (a) the label spec (all en/zh mappings + helpers), (b) `vue-tsc` — every `wb(key,…)` must be a valid `WorkbenchLabelKey` or compilation fails, (c) build, (d) code-diff review. If that spec's baseline is ever fixed, a real Workbench locale render assertion should be added. See `docs/development/multitable-workbench-i18n-t2-verification-20260519.md` §7.

### Verification (post-rebase onto origin/main `dc31d8668`)

```
vue-tsc --noEmit                                            → clean
build                                                       → ✓
multitable-workbench-i18n.spec.ts                           → 8/8
multitable-template-center-view.spec.ts                     → 9/9
platform-shell-nav.spec.ts                                  → 5/5
git diff --check origin/main..HEAD                          → clean
net new test failures                                       → 0 (workbench-view 53 / home-view 7 are the pre-existing localStorage baseline, identical on clean main)
```

Static toast full-coverage proof (verification MD §4): `[T2-done]×17` wb()-wrapped, `[T3-deferred]×15` all dynamic/interpolated/permission/host-context — zero static string omitted.

## T2 boundary (by design, not bugs)

- Meta\* children (MetaGridTable / MetaRecordDrawer / MetaViewManager / Kanban / Form / …) **stay English** → T3.
- `templateLibraryError` (template-library load-failure copy, the most visible error state when opening the modal) **stays English** → T3.
- 15 dynamic/interpolated toasts (`Installed X`, `N record(s) imported`, `Record not found: id`, permission/host-context) **stay English** → T3.

## Scope guard / K3 PoC stage-1 lock

- Localization of shipped UI = polish. No backend / `/api/multitable/*` contract / migration / new product surface / vue-i18n framework.
- `git diff --name-only origin/main..HEAD` = 8 T2 files only (2 dev/verification MD + label module + Workbench + MetaTemplateCard + 3 spec).
- No `plugins/plugin-integration-core/*`, `lib/adapters/k3-wise-*`, or Data Factory touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)