### PR TITLE
docs(attendance): record period rollup live evidence

### DIFF
--- a/docs/development/attendance-report-period-rollup-sync-live-closeout-design-20260519.md
+++ b/docs/development/attendance-report-period-rollup-sync-live-closeout-design-20260519.md
@@ -1,0 +1,74 @@
+# 考勤 Period Rollup live closeout 设计记录
+
+Date: 2026-05-19
+
+## Summary
+
+本 slice 收口 `attendance_report_period_summaries` 的 staging live evidence。PR1 descriptor / ensure、PR2 writer / route、PR3 前端入口均已合并；本轮不新增功能代码，只执行 staging runtime 更新、真实同步、读回核验，并补充设计与验证记录。
+
+边界不变：
+
+- `attendance_*` 仍是事实源。
+- `attendance_report_period_summaries` 只做可重建周期汇总快照。
+- 写入只通过 `POST /api/attendance/report-period-summaries/sync` 触发插件 writer。
+- 不新增 migration，不让多维表公式直读 `attendance_*`。
+- 本轮只写 staging，不写 production。
+
+## Runtime Update
+
+PR #1662 merge commit：
+
+```text
+dc31d86688956bd474a3e3d65ca343c1672cbb16
+```
+
+staging 原 backend / web image：
+
+```text
+01d4134017febcdac5a95f6ce8898e66a81aa9aa
+```
+
+staging 更新目标 backend / web image：
+
+```text
+ghcr.io/zensgit/metasheet2-backend:dc31d86688956bd474a3e3d65ca343c1672cbb16
+ghcr.io/zensgit/metasheet2-web:dc31d86688956bd474a3e3d65ca343c1672cbb16
+```
+
+只重建 backend / web：
+
+- `docker compose -f docker-compose.app.staging.yml pull backend web`
+- `docker compose -f docker-compose.app.staging.yml up -d --no-deps backend web`
+
+`--no-deps` 保证 staging Postgres / Redis 不被重建。
+
+## Auth Handling
+
+旧 staging JWT 已过期，`/api/auth/me` 返回 `401 Invalid token`。本轮重新签发短期 admin JWT 到本地私有文件，权限为 `0600`，并通过 `/api/auth/me` 验证。
+
+约束：
+
+- token 内容不打印。
+- JWT secret 不打印。
+- 文档只记录文件式读取方式，不记录 token 值。
+
+## Live Sync Coverage
+
+本轮覆盖四条 live 路径：
+
+1. date range + single user：`2026-05-15..2026-05-17`，样本用户 `8b35cbe1-9fd6-4650-9d16-42b2c4d028d1`。
+2. date range rerun：同一 row key 重跑应通过 source + field fingerprint 进入 `skipped=1`。
+3. payroll cycle + single user：使用 staging 已存在 cycle `4a3173ab-4065-42f3-bbeb-cb02b4807db2`。
+4. allUsers pagination：staging 原 `user_orgs` 为 0；临时插入 1 条 active membership，跑完后删除回 0。
+
+## Readback Strategy
+
+读回只用于验证，不改变产品边界：
+
+- 通过 staging DB 查询 `meta_records` / `meta_fields` 验证私有多维表行。
+- 核对 row count、distinct row key、`field_fingerprint`、`source_fingerprint`、`synced_at`。
+- 核对 date range 行的汇总值：`total_work_minutes=930`、`total_late_minutes=12`、`total_early_leave_minutes=30`。
+
+## Follow-up
+
+后续若要把 period summaries 作为运营日常验收，可再补一个专用 `scripts/ops/attendance-report-period-summaries-live-acceptance.mjs`。本轮按既有 closeout 纪律手动执行，不把 live harness 纳入此 docs-only slice。

--- a/docs/development/attendance-report-period-rollup-sync-live-closeout-verification-20260519.md
+++ b/docs/development/attendance-report-period-rollup-sync-live-closeout-verification-20260519.md
@@ -1,0 +1,229 @@
+# 考勤 Period Rollup live closeout 验证记录
+
+Date: 2026-05-19
+
+## Verification Matrix
+
+| Check | Result |
+| --- | --- |
+| PR #1662 merge commit | PASS: `dc31d86688956bd474a3e3d65ca343c1672cbb16` |
+| `origin/main` contains #1662 | PASS: `dc31d8668 feat(attendance): add period rollup sync UI (#1662)` |
+| Production deploy | PASS: Deploy to Production run `26078413056`, conclusion `success`, head SHA `dc31d86688956bd474a3e3d65ca343c1672cbb16` |
+| Staging tunnel | PASS: local `8082` reached staging `/api/health` |
+| Staging runtime before update | `01d4134017febcdac5a95f6ce8898e66a81aa9aa` |
+| Staging runtime after update | PASS: backend / web image `dc31d86688956bd474a3e3d65ca343c1672cbb16` |
+| Staging DB / Redis | PASS: not recreated; backend / web updated with `--no-deps` |
+| Staging admin JWT | PASS: regenerated short-lived file token, mode `0600`, `/api/auth/me` returned admin user; token value not printed |
+| Date range sync | PASS: `created=1`, `failed=0`, `duplicateRowKeys=0` |
+| Date range idempotent rerun | PASS: `skipped=1`, `created=0`, `patched=0`, `failed=0` |
+| Payroll cycle sync | PASS: `periodType=payroll_cycle`, `created=1`, `failed=0` |
+| Payroll cycle idempotent rerun | PASS: `skipped=1`, `created=0`, `patched=0`, `failed=0` |
+| allUsers pagination initial state | PASS: staging `user_orgs` initially scanned 0 users |
+| allUsers active membership probe | PASS: temporary membership scanned 1 user, `skipped=1`, `failed=0` |
+| Fixture cleanup | PASS: temporary `user_orgs` membership deleted; staging returned to 0 memberships |
+| Multitable readback | PASS: 2 rows, 2 distinct row keys, fingerprints and `synced_at` present on all rows |
+| `git diff --check` | PASS |
+
+## Commands
+
+Health:
+
+```bash
+curl -fsS http://localhost:8082/api/health
+```
+
+Auth:
+
+```bash
+AUTH_TOKEN="$(cat /tmp/<staging-admin-jwt-file>.jwt)"
+curl -sS -H "Authorization: Bearer ${AUTH_TOKEN}" http://localhost:8082/api/auth/me
+```
+
+The JWT value was not printed or committed.
+
+Staging update:
+
+```bash
+cd /home/mainuser/metasheet2-dingtalk-staging
+docker compose -f docker-compose.app.staging.yml pull backend web
+docker compose -f docker-compose.app.staging.yml up -d --no-deps backend web
+```
+
+Date range sync:
+
+```bash
+curl -sS -X POST "${API_BASE}/api/attendance/report-period-summaries/sync?orgId=default" \
+  -H "Authorization: Bearer ${AUTH_TOKEN}" \
+  -H "Content-Type: application/json" \
+  --data '{"from":"2026-05-15","to":"2026-05-17","userId":"8b35cbe1-9fd6-4650-9d16-42b2c4d028d1"}'
+```
+
+Payroll cycle sync:
+
+```bash
+curl -sS -X POST "${API_BASE}/api/attendance/report-period-summaries/sync?orgId=default" \
+  -H "Authorization: Bearer ${AUTH_TOKEN}" \
+  -H "Content-Type: application/json" \
+  --data '{"cycleId":"4a3173ab-4065-42f3-bbeb-cb02b4807db2","userId":"8b35cbe1-9fd6-4650-9d16-42b2c4d028d1"}'
+```
+
+allUsers pagination probe:
+
+```bash
+curl -sS -X POST "${API_BASE}/api/attendance/report-period-summaries/sync?orgId=default" \
+  -H "Authorization: Bearer ${AUTH_TOKEN}" \
+  -H "Content-Type: application/json" \
+  --data '{"from":"2026-05-15","to":"2026-05-17","allUsers":true,"page":1,"pageSize":5}'
+```
+
+## Live Evidence
+
+Date range first sync:
+
+```text
+ok=true
+periodType=date_range
+periodKey=range:2026-05-15:2026-05-17
+from=2026-05-15
+to=2026-05-17
+synced=1
+rowsSynced=1
+created=1
+patched=0
+skipped=0
+failed=0
+duplicateRowKeys=0
+fieldFingerprint=ecefbf5d6311372c780830b1504b471afba022ec
+syncedAt=2026-05-19T05:46:28.971Z
+projectId=default:attendance
+objectId=attendance_report_period_summaries
+sheetId=sheet_f88393b5901293621cab1262
+viewId=view_56cb1aa1126315cc5a35d19a
+```
+
+Date range rerun:
+
+```text
+ok=true
+synced=1
+rowsSynced=1
+created=0
+patched=0
+skipped=1
+failed=0
+duplicateRowKeys=0
+fieldFingerprint=ecefbf5d6311372c780830b1504b471afba022ec
+```
+
+Payroll cycle first sync:
+
+```text
+ok=true
+periodType=payroll_cycle
+periodKey=cycle:4a3173ab-4065-42f3-bbeb-cb02b4807db2
+cycleId=4a3173ab-4065-42f3-bbeb-cb02b4807db2
+from=2099-05-09
+to=2099-05-09
+synced=1
+created=1
+patched=0
+skipped=0
+failed=0
+duplicateRowKeys=0
+fieldFingerprint=ecefbf5d6311372c780830b1504b471afba022ec
+```
+
+Payroll cycle rerun:
+
+```text
+ok=true
+periodType=payroll_cycle
+synced=1
+created=0
+patched=0
+skipped=1
+failed=0
+duplicateRowKeys=0
+fieldFingerprint=ecefbf5d6311372c780830b1504b471afba022ec
+```
+
+allUsers initial state:
+
+```text
+ok=true
+userSelection=allUsers
+totalUsers=0
+page=1
+pageSize=5
+hasNextPage=false
+usersScanned=0
+synced=0
+```
+
+allUsers with temporary active membership:
+
+```text
+temporary membership inserted:
+user_orgs_count=1
+
+sync response:
+ok=true
+userSelection=allUsers
+totalUsers=1
+page=1
+pageSize=5
+hasNextPage=false
+usersScanned=1
+usersSynced=1
+usersFailed=0
+synced=1
+rowsSynced=1
+created=0
+patched=0
+skipped=1
+failed=0
+duplicateRowKeys=0
+fieldFingerprint=ecefbf5d6311372c780830b1504b471afba022ec
+
+cleanup:
+deleted_memberships=1
+user_orgs_count=0
+```
+
+Readback from `attendance_report_period_summaries`:
+
+```text
+row_count=2
+distinct_row_keys=2
+rows_with_field_fingerprint=2
+rows_with_source_fingerprint=2
+rows_with_synced_at=2
+
+payroll_cycle cycle:4a3173ab-4065-42f3-bbeb-cb02b4807db2
+total_work_minutes=0 total_late_minutes=0 total_early_leave_minutes=0
+field_fp=ecefbf5d6311372c780830b1504b471afba022ec
+source_fp=3addd9b9b0d1fe9cc1bbe35b120f918deeb68650
+
+date_range range:2026-05-15:2026-05-17
+total_work_minutes=930 total_late_minutes=12 total_early_leave_minutes=30
+field_fp=ecefbf5d6311372c780830b1504b471afba022ec
+source_fp=bb1f53e6a8e814b0e1c4ef151a5d89738fb3b146
+```
+
+The date range totals match the staging fixture:
+
+```text
+2026-05-15 work_minutes=480 late_minutes=12 early_leave_minutes=0
+2026-05-16 work_minutes=450 late_minutes=0 early_leave_minutes=30
+2026-05-17 work_minutes=0 late_minutes=0 early_leave_minutes=0
+```
+
+## Boundaries
+
+- No production write was performed.
+- Staging DB / Redis were not recreated.
+- Temporary `user_orgs` fixture was removed.
+- Token / JWT secret values were not printed or committed.
+- Readback SQL touched `meta_*` only as verification; product code still writes through the attendance plugin API.
+
+Period Rollup PR1 / PR2 / PR3 is now merged, deployed, and live-verified on staging.

--- a/docs/development/attendance-report-period-rollup-sync-pr3-verification-20260519.md
+++ b/docs/development/attendance-report-period-rollup-sync-pr3-verification-20260519.md
@@ -4,7 +4,7 @@ Date: 2026-05-19
 
 ## Summary
 
-本轮验证覆盖周期汇总同步入口的前端行为：date range、payroll cycle、single user、userIds、all users pagination、成功结果、degraded warning、API error。未运行真实 staging live evidence，因为 PR3 前端尚未合并部署到 staging；后续部署后可用真实 admin 会话补证据。
+本轮验证覆盖周期汇总同步入口的前端行为：date range、payroll cycle、single user、userIds、all users pagination、成功结果、degraded warning、API error。PR3 合并并部署到 staging 后已补真实 live evidence，见 `docs/development/attendance-report-period-rollup-sync-live-closeout-verification-20260519.md`。
 
 ## Commands
 
@@ -46,7 +46,7 @@ git diff --check PASS
 | degraded | `degraded:true` 显示 warn，保留页面 |
 | error | HTTP 400 / `ok:false` 显示 error，保留页面 |
 
-## Deferred Evidence
+## Live Evidence
 
-- Staging live evidence: pending after PR3 is merged and deployed to staging.
+- Staging live evidence: completed after PR3 was merged and deployed to staging. See `docs/development/attendance-report-period-rollup-sync-live-closeout-verification-20260519.md`.
 - No production write was performed in this verification.

--- a/docs/development/attendance-report-period-rollup-sync-todo-20260519.md
+++ b/docs/development/attendance-report-period-rollup-sync-todo-20260519.md
@@ -67,7 +67,7 @@ Date: 2026-05-19
 - 展示 synced/created/patched/skipped/failed、`fieldFingerprint`、`syncedAt`、打开多维表入口。
 - staging live evidence 只在明确授权后执行，不写 production。
 
-**落地指针：** PR3 设计记录见 `docs/development/attendance-report-period-rollup-sync-pr3-design-20260519.md`；验证记录见 `docs/development/attendance-report-period-rollup-sync-pr3-verification-20260519.md`。
+**落地指针：** PR3 设计记录见 `docs/development/attendance-report-period-rollup-sync-pr3-design-20260519.md`；验证记录见 `docs/development/attendance-report-period-rollup-sync-pr3-verification-20260519.md`；staging live closeout 见 `docs/development/attendance-report-period-rollup-sync-live-closeout-design-20260519.md` 与 `docs/development/attendance-report-period-rollup-sync-live-closeout-verification-20260519.md`。
 
 ## Test Plan
 


### PR DESCRIPTION
## Summary

Records the staging live closeout for `attendance_report_period_summaries` after PR1/PR2/PR3 were merged and PR3 was deployed. This is docs-only: no code, no migration, no production write.

Captured evidence:
- Staging backend/web updated to PR3 image `dc31d86688956bd474a3e3d65ca343c1672cbb16` with `--no-deps`
- Short-lived staging admin JWT regenerated as a local 0600 file and validated via `/api/auth/me`; token value is not recorded
- Date-range sync created one row, rerun skipped by fingerprint
- Payroll-cycle sync created one row, rerun skipped by fingerprint
- allUsers pagination verified with a temporary active membership and cleaned up
- Multitable readback confirmed 2 rows, distinct row keys, fingerprints, synced_at, and expected date-range totals

## Verification

- [x] `git diff --check`
- [x] Staged content scanned for JWT/private-key/API-key/bearer-token literals
- [x] Staging live date-range sync: create + idempotent skip
- [x] Staging live payroll-cycle sync: create + idempotent skip
- [x] Staging live allUsers pagination probe + fixture cleanup
- [x] Readback from private `attendance_report_period_summaries` object

## Boundaries

- No production write was performed
- No `attendance_*` migration or facts-source change
- Product writes still go through the attendance plugin API; `meta_*` readback is verification-only
- Staging DB/Redis were not recreated
- Temporary `user_orgs` fixture was removed
