### PR TITLE
fix(onprem): refresh dependencies during package apply

### DIFF
--- a/docs/deployment/multitable-onprem-package-layout-20260319.md
+++ b/docs/deployment/multitable-onprem-package-layout-20260319.md
@@ -160,12 +160,14 @@ For Windows Server, these wrappers delegate to `scripts/ops/multitable-onprem-ap
 
 1. extracts the archive into a temporary directory,
 2. copies the package contents into the current deploy root,
-3. installs dependencies if needed, runs migrations, and restarts PM2,
+3. refreshes dependencies, runs migrations, and restarts PM2,
 4. preserves the existing `docker/app.env`.
 
 `node_modules` is intentionally excluded from the archive. The apply helper's
-default `InstallDeps=1` runs `pnpm install --frozen-lockfile` when
-`node_modules` is missing; manual file-copy deployments must run the same
-command before migrations, PM2 restart, or admin bootstrap.
+default `InstallDeps=1` refreshes dependencies with
+`pnpm install --frozen-lockfile` on every package apply. This keeps corrective
+rerolls safe when the deploy root already has `node_modules` but the new package
+adds a workspace runtime dependency. Manual file-copy deployments must run the
+same command before migrations, PM2 restart, or admin bootstrap.
 
 For a fresh Windows-only install, use `bootstrap-admin.bat` after `deploy.bat` so the customer can create the first admin account without needing bash or WSL.

--- a/docs/deployment/multitable-windows-onprem-easy-start-20260319.md
+++ b/docs/deployment/multitable-windows-onprem-easy-start-20260319.md
@@ -270,7 +270,13 @@ These wrappers now call `scripts/ops/multitable-onprem-apply-package.ps1`, so a 
 
 The PowerShell helper extracts the incoming archive into a short-lived system temp directory instead of a deep deploy-root subdirectory, which avoids common Windows long-path failures during `Expand-Archive`.
 
-The package intentionally does **not** bundle `node_modules`. `deploy.bat` defaults to `InstallDeps=1` and runs `pnpm install --frozen-lockfile` when `node_modules` is missing. If you copy package files manually instead of using `deploy.bat`, run this from the package root before migrations, PM2 restart, or `bootstrap-admin.bat`:
+The package intentionally does **not** bundle `node_modules`. `deploy.bat`
+defaults to `InstallDeps=1` and refreshes dependencies with
+`pnpm install --frozen-lockfile` on every package apply. This is intentional for
+upgrade installs: the deploy root may already have `node_modules`, but the new
+package can add runtime dependencies such as plugin drivers. If you copy package
+files manually instead of using `deploy.bat`, run this from the package root
+before migrations, PM2 restart, or `bootstrap-admin.bat`:
 
 ```bat
 pnpm install --frozen-lockfile

--- a/docs/development/onprem-package-dependency-refresh-design-20260519.md
+++ b/docs/development/onprem-package-dependency-refresh-design-20260519.md
@@ -1,0 +1,55 @@
+# On-Prem Package Dependency Refresh - Design - 2026-05-19
+
+## Context
+
+The bridge retest after package `k3wise-316d3ca13` showed progress on #1526:
+the K3 WISE SQL Server source no longer reported `SQLSERVER_EXECUTOR_MISSING`.
+It instead reported `SQLSERVER_DRIVER_MISSING`, meaning the packaged executor
+was wired but the deployed runtime could not load `mssql`.
+
+The root cause is the Windows package apply path. The package intentionally does
+not bundle `node_modules`, and `deploy.bat` delegates to
+`scripts/ops/multitable-onprem-apply-package.ps1`. That helper only ran
+`pnpm install --frozen-lockfile` when root `node_modules` was missing. Upgrade
+deployments already have `node_modules`, so a corrective package that adds a
+new workspace dependency can copy the new `package.json` / lockfile without
+installing the new dependency.
+
+## Change
+
+The PowerShell apply helper now refreshes dependencies whenever `InstallDeps` is
+enabled:
+
+```powershell
+if ($InstallDeps -ne '0') {
+  pnpm install --frozen-lockfile
+}
+```
+
+This intentionally trades a little upgrade time for deterministic runtime
+dependencies. Operators can still pass `-InstallDeps 0` only when they have
+already refreshed dependencies out of band.
+
+The package metadata and docs now state the policy as `refresh-on-apply`, not
+"install only when node_modules is missing".
+
+## Guardrails
+
+- No runtime product behavior changes.
+- No database migration changes.
+- No K3 Save / Submit / Audit changes.
+- Bash/WSL package apply already goes through the package upgrade helper, which
+  runs dependency install when `INSTALL_DEPS=1`; this slice fixes the native
+  Windows PowerShell apply path that bridge testing uses.
+- Package verification now fails if the PowerShell helper reintroduces the
+  root-`node_modules` existence gate.
+
+## Expected Bridge Result
+
+After publishing and deploying a package with this fix, the bridge SQL source
+test should no longer fail with `SQLSERVER_DRIVER_MISSING` caused by missing
+`mssql`. The next expected outcomes are:
+
+- valid SQL Server config and credentials: connection succeeds;
+- invalid config or network: concrete SQL Server connection/config error;
+- built-in write attempt: still blocked with `SQLSERVER_WRITE_EXECUTOR_DISABLED`.

--- a/docs/development/onprem-package-dependency-refresh-verification-20260519.md
+++ b/docs/development/onprem-package-dependency-refresh-verification-20260519.md
@@ -1,0 +1,87 @@
+# On-Prem Package Dependency Refresh - Verification - 2026-05-19
+
+## Issue Evidence
+
+Bridge feedback on #1526 after deploying
+`metasheet-multitable-onprem-v2.5.0-k3wise-316d3ca13.zip`:
+
+- deployment, migrations, restart, and health checks passed;
+- staging-to-K3 dry-run stayed healthy;
+- SQL Server source no longer returned `SQLSERVER_EXECUTOR_MISSING`;
+- SQL Server source returned `SQLSERVER_DRIVER_MISSING`.
+
+Interpretation: executor injection works, but the deployed runtime did not
+install the new `mssql` dependency introduced by the package.
+
+## Files Verified
+
+- `scripts/ops/multitable-onprem-apply-package.ps1`
+- `scripts/ops/multitable-onprem-package-build.sh`
+- `scripts/ops/multitable-onprem-package-verify.sh`
+- `scripts/ops/integration-k3wise-postdeploy-smoke.mjs`
+- `scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs`
+- `docs/deployment/multitable-windows-onprem-easy-start-20260319.md`
+- `docs/deployment/multitable-onprem-package-layout-20260319.md`
+- `docs/operations/integration-k3wise-internal-trial-runbook.md`
+- `docs/operations/integration-k3wise-sql-executor-bridge-handoff.md`
+
+## Assertions
+
+| Area | Assertion |
+| --- | --- |
+| Windows apply helper | With default `InstallDeps=1`, the helper runs `pnpm install --frozen-lockfile` even when root `node_modules` already exists. |
+| Escape hatch | `InstallDeps=0` still skips dependency refresh for advanced/manual operators. |
+| Package metadata | Generated `PACKAGE-METADATA.json` declares `dependencyInstallMode: refresh-on-apply`. |
+| Package verifier | Verifier fails if the PowerShell helper gates install only on root `node_modules` existence. |
+| SQL diagnostic | Postdeploy smoke distinguishes `SQLSERVER_DRIVER_MISSING` from `SQLSERVER_EXECUTOR_MISSING` and gives the dependency refresh action. |
+| Docs | Windows/on-prem docs no longer tell operators dependency install only happens when `node_modules` is missing. |
+
+## Local Verification Commands
+
+Executed from branch `codex/onprem-package-refresh-deps-20260519`:
+
+| Command | Result |
+| --- | --- |
+| `bash -n scripts/ops/multitable-onprem-package-build.sh` | PASS |
+| `bash -n scripts/ops/multitable-onprem-package-verify.sh` | PASS |
+| `node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs` | PASS, 27/27 |
+| `node --test scripts/ops/integration-k3wise-postdeploy-summary.test.mjs` | PASS, 16/16 |
+| `pnpm verify:integration-k3wise:poc` | PASS |
+| `git diff --check` | PASS |
+
+Local package proof:
+
+```bash
+OUTPUT_DIR=/tmp/ms2-onprem-deps-refresh-package \
+PACKAGE_TAG=deps-refresh-smoke \
+  scripts/ops/multitable-onprem-package-build.sh
+
+scripts/ops/multitable-onprem-package-verify.sh \
+  /tmp/ms2-onprem-deps-refresh-package/metasheet-multitable-onprem-v2.5.0-deps-refresh-smoke.zip
+
+scripts/ops/multitable-onprem-package-verify.sh \
+  /tmp/ms2-onprem-deps-refresh-package/metasheet-multitable-onprem-v2.5.0-deps-refresh-smoke.tgz
+```
+
+Both package verifier runs returned `Package verify OK`. The package metadata
+now includes `"dependencyInstallMode": "refresh-on-apply"`, and the verifier
+checks the PowerShell apply helper for the refresh-on-apply marker.
+
+Optional PowerShell syntax check on a Windows host:
+
+```powershell
+powershell -NoProfile -Command "$null = [scriptblock]::Create((Get-Content -Raw scripts\ops\multitable-onprem-apply-package.ps1)); 'syntax-ok'"
+```
+
+## Bridge Retest Plan
+
+After merge and package publish:
+
+1. Deploy the new Windows zip with `deploy.bat <package.zip>`.
+2. Confirm deploy logs include `Refresh dependencies (pnpm install --frozen-lockfile)`.
+3. Confirm `plugins/plugin-integration-core/node_modules/mssql` resolves, or
+   use the UI SQL source test as the runtime proof.
+4. Rerun the SQL Server source test in Data Factory / K3 preset.
+5. Expected: no `SQLSERVER_DRIVER_MISSING`.
+
+No real K3 Save / Submit / Audit is part of this verification.

--- a/docs/operations/integration-k3wise-internal-trial-runbook.md
+++ b/docs/operations/integration-k3wise-internal-trial-runbook.md
@@ -167,9 +167,13 @@ non-blocking `sqlserver-executor-availability` check:
   marked unavailable by the backend.
 - `skipped` with `code=SQLSERVER_EXECUTOR_MISSING` means the SQL source exists,
   but the package has not completed SQL executor wiring or dependency install.
+- `skipped` with `code=SQLSERVER_DRIVER_MISSING` means the built-in executor is
+  wired, but the deploy root did not install the packaged `mssql` dependency.
+  Re-apply the package with `InstallDeps=1` or run
+  `pnpm install --frozen-lockfile` from the deploy root before restarting PM2.
 
-`SQLSERVER_EXECUTOR_MISSING` does not invalidate the #1542 staging-to-K3
-metadata signoff. It means direct SQL Server source execution is still blocked.
+These SQL diagnostic states do not invalidate the #1542 staging-to-K3 metadata
+signoff. They mean direct SQL Server source execution is still blocked.
 Use `metasheet:staging` as the source for Data Factory retests until the package
 runtime can load the built-in read-only executor and the SQL source has been
 tested successfully. After fixing the runtime/dependency issue, retest the SQL

--- a/docs/operations/integration-k3wise-sql-executor-bridge-handoff.md
+++ b/docs/operations/integration-k3wise-sql-executor-bridge-handoff.md
@@ -143,12 +143,16 @@ Data Factory previews, smoke artifacts, or `external_systems.config`.
 
 ## Operator Verification Flow
 
-1. Deploy the current package and let `pnpm install --frozen-lockfile` install
-   the packaged `mssql` dependency.
+1. Deploy the current package with `deploy.bat` / the apply helper's default
+   `InstallDeps=1`, or manually run `pnpm install --frozen-lockfile` from the
+   deploy root. Upgrade installs must refresh dependencies even when
+   `node_modules` already exists, because packages can add workspace runtime
+   dependencies such as `mssql`.
 2. Configure the SQL Server source with `server`, `database`, credentials, and
    read allowlist.
 3. In Data Factory, test the `erp:k3-wise-sqlserver` source.
-4. Confirm the system reports connected instead of `SQLSERVER_EXECUTOR_MISSING`.
+4. Confirm the system reports connected instead of `SQLSERVER_EXECUTOR_MISSING`
+   or `SQLSERVER_DRIVER_MISSING`.
 5. Run the postdeploy smoke:
 
 ```bash
@@ -170,6 +174,10 @@ If `sqlserver-executor-availability.status=skipped` with
 `code=SQLSERVER_EXECUTOR_MISSING`, the package wiring or dependency install is
 incomplete. The staging-to-K3 path can remain signed off, but direct SQL Server
 source execution is not ready.
+
+If the code is `SQLSERVER_DRIVER_MISSING`, runtime injection is working but the
+deploy root is missing `mssql`. Re-apply the package with `InstallDeps=1` or run
+`pnpm install --frozen-lockfile` from the deploy root, restart PM2, then retest.
 
 ## What Claude Code Should Do On The Bridge Machine
 

--- a/scripts/ops/integration-k3wise-postdeploy-smoke.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-smoke.mjs
@@ -8,6 +8,7 @@ const DEFAULT_OUTPUT_ROOT = 'output/integration-k3wise-postdeploy-smoke'
 const ISSUE1542_SMOKE_PIPELINE_ID = 'issue1542_postdeploy_staging_material_smoke'
 const SQLSERVER_SYSTEM_KIND = 'erp:k3-wise-sqlserver'
 const SQLSERVER_EXECUTOR_MISSING_PATTERN = /SQLSERVER_EXECUTOR_MISSING|queryExecutor|executor|injected|注入|执行器/i
+const SQLSERVER_DRIVER_MISSING_PATTERN = /SQLSERVER_DRIVER_MISSING|mssql dependency|Cannot find module ['"]mssql['"]|找不到.*mssql/i
 const REQUIRED_ADAPTERS = [
   'http',
   'plm:yuantus-wrapper',
@@ -409,16 +410,28 @@ function sqlServerExecutorAvailabilityCheck(body) {
 
   const unavailableSystems = sqlSystems.filter((system) => {
     const lastError = typeof system.lastError === 'string' ? system.lastError : ''
-    return system.status === 'error' || SQLSERVER_EXECUTOR_MISSING_PATTERN.test(lastError)
+    return system.status === 'error' ||
+      SQLSERVER_EXECUTOR_MISSING_PATTERN.test(lastError) ||
+      SQLSERVER_DRIVER_MISSING_PATTERN.test(lastError)
   })
   if (unavailableSystems.length > 0) {
+    const missingDriverSystems = unavailableSystems.filter((system) => {
+      const lastError = typeof system.lastError === 'string' ? system.lastError : ''
+      return SQLSERVER_DRIVER_MISSING_PATTERN.test(lastError)
+    })
     const missingExecutorSystems = unavailableSystems.filter((system) => {
       const lastError = typeof system.lastError === 'string' ? system.lastError : ''
       return SQLSERVER_EXECUTOR_MISSING_PATTERN.test(lastError)
     })
     return result('sqlserver-executor-availability', 'skipped', {
-      code: missingExecutorSystems.length > 0 ? 'SQLSERVER_EXECUTOR_MISSING' : 'SQLSERVER_CHANNEL_UNAVAILABLE',
-      reason: missingExecutorSystems.length > 0
+      code: missingDriverSystems.length > 0
+        ? 'SQLSERVER_DRIVER_MISSING'
+        : missingExecutorSystems.length > 0
+          ? 'SQLSERVER_EXECUTOR_MISSING'
+          : 'SQLSERVER_CHANNEL_UNAVAILABLE',
+      reason: missingDriverSystems.length > 0
+        ? 'K3 WISE SQL Server source reached the built-in executor, but the mssql runtime dependency is missing; rerun the package apply helper with InstallDeps=1 or run pnpm install --frozen-lockfile from the deploy root.'
+        : missingExecutorSystems.length > 0
         ? 'K3 WISE SQL Server source is configured but this package has not completed SQL executor wiring or dependency install; staging-to-K3 smoke signoff can still pass.'
         : 'K3 WISE SQL Server source is configured but currently unavailable; staging-to-K3 smoke signoff can still pass.',
       systemsChecked: sqlSystems.length,

--- a/scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
@@ -215,6 +215,10 @@ const SQL_EXECUTOR_READY_SYSTEM = {
   status: 'active',
   lastError: null,
 }
+const SQL_DRIVER_MISSING_SYSTEM = {
+  ...SQL_EXECUTOR_MISSING_SYSTEM,
+  lastError: 'SQLSERVER_DRIVER_MISSING: mssql dependency is not available; run pnpm install from the deploy root',
+}
 const DEFAULT_STAGING_OBJECTS = [
   {
     name: 'standard_materials',
@@ -851,6 +855,41 @@ test('authenticated postdeploy smoke records missing SQL executor as a non-block
       request.query.tenantId === 'tenant-smoke' &&
       request.query.limit === '100'
     )))
+  } finally {
+    await fake.close()
+    rmSync(outDir, { recursive: true, force: true })
+  }
+})
+
+test('authenticated postdeploy smoke diagnoses missing SQL Server driver dependency', async () => {
+  const fake = createFakeServer({ externalSystems: [...DEFAULT_SYSTEMS, SQL_DRIVER_MISSING_SYSTEM] })
+  const baseUrl = await fake.listen()
+  const outDir = makeTmpDir()
+  try {
+    const result = await runScript([
+      '--base-url', baseUrl,
+      '--auth-token', 'test.jwt.token',
+      '--require-auth',
+      '--out-dir', outDir,
+    ])
+
+    assert.equal(result.status, 0, result.stderr)
+    const evidence = JSON.parse(readFileSync(path.join(outDir, 'integration-k3wise-postdeploy-smoke.json'), 'utf8'))
+    assert.equal(evidence.summary.fail, 0)
+    const sqlDiagnostic = evidence.checks.find((check) => check.id === 'sqlserver-executor-availability')
+    assert.equal(sqlDiagnostic.status, 'skipped')
+    assert.equal(sqlDiagnostic.code, 'SQLSERVER_DRIVER_MISSING')
+    assert.match(sqlDiagnostic.reason, /pnpm install --frozen-lockfile/)
+    assert.equal(sqlDiagnostic.systemsChecked, 1)
+    assert.deepEqual(sqlDiagnostic.blockedSystems, [
+      {
+        id: 'k3_sql_source_1',
+        name: 'K3 SQL Read Channel',
+        role: 'source',
+        status: 'error',
+      },
+    ])
+    assert.doesNotMatch(JSON.stringify(sqlDiagnostic.blockedSystems), /lastError|mssql dependency/)
   } finally {
     await fake.close()
     rmSync(outDir, { recursive: true, force: true })

--- a/scripts/ops/multitable-onprem-apply-package.ps1
+++ b/scripts/ops/multitable-onprem-apply-package.ps1
@@ -151,8 +151,8 @@ try {
   Require-Command -Name 'node'
   Require-Command -Name 'pnpm'
 
-  if ($InstallDeps -ne '0' -and -not (Test-Path -LiteralPath (Join-Path $resolvedRoot 'node_modules'))) {
-    Invoke-CheckedCommand 'Install dependencies (pnpm install --frozen-lockfile)' {
+  if ($InstallDeps -ne '0') {
+    Invoke-CheckedCommand 'Refresh dependencies (pnpm install --frozen-lockfile)' {
       pnpm install --frozen-lockfile
     }
   }

--- a/scripts/ops/multitable-onprem-package-build.sh
+++ b/scripts/ops/multitable-onprem-package-build.sh
@@ -115,6 +115,8 @@ REQUIRED_PATHS=(
   "docs/development/data-factory-issue1526-delivery-readiness-gate-contract-verification-20260518.md"
   "docs/development/data-factory-sqlserver-readonly-executor-design-20260519.md"
   "docs/development/data-factory-sqlserver-readonly-executor-verification-20260519.md"
+  "docs/development/onprem-package-dependency-refresh-design-20260519.md"
+  "docs/development/onprem-package-dependency-refresh-verification-20260519.md"
   "docs/development/data-factory-readiness-package-verify-delivery-development-20260515.md"
   "docs/development/data-factory-readiness-package-verify-delivery-verification-20260515.md"
   "docs/development/onprem-migration-gap-guard-development-20260514.md"
@@ -282,9 +284,11 @@ Upgrade / corrective reroll:
 
 Dependency policy:
   node_modules are intentionally not bundled. The apply helper defaults to
-  InstallDeps=1 and runs pnpm install --frozen-lockfile when node_modules is
-  missing. Manual deployments must run the same command before migrations,
-  PM2 restart, or admin bootstrap.
+  InstallDeps=1 and refreshes dependencies with pnpm install --frozen-lockfile
+  on every package apply. This is deliberate for corrective rerolls: an
+  existing deploy root may already have node_modules while the new package adds
+  a workspace runtime dependency. Manual deployments must run the same command
+  before migrations, PM2 restart, or admin bootstrap.
 
 Verification:
   A valid delivery asset passes:
@@ -300,6 +304,7 @@ EOF
   "deployMode": "fresh-extract-or-existing-root-apply",
   "directReplaceSafe": false,
   "nodeModulesBundled": false,
+  "dependencyInstallMode": "refresh-on-apply",
   "windowsEntryPoint": "deploy.bat <package.zip|package.tgz>",
   "linuxEntryPoint": "scripts/ops/multitable-onprem-package-install.sh",
   "includedRuntimeRoots": [
@@ -427,9 +432,11 @@ K3 WISE PoC operator tools (Node only; no Docker needed to run these):
 
 Runtime dependencies:
   node_modules are intentionally not bundled. deploy.bat defaults to
-  InstallDeps=1 and runs pnpm install --frozen-lockfile when node_modules is
-  missing. If applying files manually without deploy.bat, run pnpm install
-  --frozen-lockfile from the package root before migrations/bootstrap.
+  InstallDeps=1 and refreshes dependencies with pnpm install --frozen-lockfile
+  on every package apply. This prevents upgrade roots with existing
+  node_modules from missing newly added workspace runtime dependencies. If
+  applying files manually without deploy.bat, run pnpm install --frozen-lockfile
+  from the package root before migrations/bootstrap.
 EOF
 
 run rm -f "$ARCHIVE_TGZ_TMP_PATH" "$ARCHIVE_ZIP_TMP_PATH" "$ARCHIVE_TGZ_SHA_TMP_PATH" "$ARCHIVE_ZIP_SHA_TMP_PATH" "$METADATA_JSON_TMP_PATH"

--- a/scripts/ops/multitable-onprem-package-verify.sh
+++ b/scripts/ops/multitable-onprem-package-verify.sh
@@ -48,6 +48,12 @@ function verify_windows_entrypoints() {
     die "deploy.bat must not require bash or the .sh apply helper"
   fi
 
+  local apply_helper="${root}/scripts/ops/multitable-onprem-apply-package.ps1"
+  search_fixed_string 'Refresh dependencies (pnpm install --frozen-lockfile)' "$apply_helper" || die "PowerShell apply helper must refresh dependencies on package apply"
+  if search_fixed_string "-not (Test-Path -LiteralPath (Join-Path \$resolvedRoot 'node_modules'))" "$apply_helper"; then
+    die "PowerShell apply helper must not skip dependency refresh just because root node_modules already exists"
+  fi
+
   if ! search_fixed_string 'deploy-remote.log' "$remote_script"; then
     die "deploy-remote.bat must continue writing output\\logs\\deploy-remote.log"
   fi
@@ -105,6 +111,7 @@ function verify_deployable_artifact_contract() {
   search_fixed_string '"deployMode": "fresh-extract-or-existing-root-apply"' "$metadata_json" || die "PACKAGE-METADATA.json must document deploy mode"
   search_fixed_string '"directReplaceSafe": false' "$metadata_json" || die "PACKAGE-METADATA.json must mark direct replacement unsafe"
   search_fixed_string '"nodeModulesBundled": false' "$metadata_json" || die "PACKAGE-METADATA.json must document node_modules policy"
+  search_fixed_string '"dependencyInstallMode": "refresh-on-apply"' "$metadata_json" || die "PACKAGE-METADATA.json must document dependency refresh policy"
   search_fixed_string '"windowsEntryPoint": "deploy.bat <package.zip|package.tgz>"' "$metadata_json" || die "PACKAGE-METADATA.json must document the Windows entrypoint"
 }
 
@@ -506,6 +513,8 @@ required=(
   "docs/development/data-factory-issue1526-delivery-readiness-gate-contract-verification-20260518.md"
   "docs/development/data-factory-sqlserver-readonly-executor-design-20260519.md"
   "docs/development/data-factory-sqlserver-readonly-executor-verification-20260519.md"
+  "docs/development/onprem-package-dependency-refresh-design-20260519.md"
+  "docs/development/onprem-package-dependency-refresh-verification-20260519.md"
   "docs/development/data-factory-readiness-package-verify-delivery-development-20260515.md"
   "docs/development/data-factory-readiness-package-verify-delivery-verification-20260515.md"
   "docs/development/onprem-migration-gap-guard-development-20260514.md"


### PR DESCRIPTION
## Summary

Follow-up for #1526 after bridge package `k3wise-316d3ca13`: SQL Server source advanced from `SQLSERVER_EXECUTOR_MISSING` to `SQLSERVER_DRIVER_MISSING`, which means executor injection works but the deployed runtime did not install the new `mssql` dependency.

This PR fixes the Windows native package apply path:

- `multitable-onprem-apply-package.ps1` now runs `pnpm install --frozen-lockfile` whenever `InstallDeps != 0`, even if root `node_modules` already exists
- package metadata/doc copy now declares dependency install mode as `refresh-on-apply`
- package verifier fails if the PowerShell helper reintroduces a root-`node_modules` existence gate
- postdeploy smoke distinguishes `SQLSERVER_DRIVER_MISSING` from `SQLSERVER_EXECUTOR_MISSING` and tells operators to rerun dependency refresh
- added design + verification MD

## Scope

- No product runtime behavior change outside deploy/ops.
- No DB migration.
- No K3 Save / Submit / Audit.
- No SQL write enablement.

## Verification

```bash
bash -n scripts/ops/multitable-onprem-package-build.sh
bash -n scripts/ops/multitable-onprem-package-verify.sh
node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs
node --test scripts/ops/integration-k3wise-postdeploy-summary.test.mjs
pnpm verify:integration-k3wise:poc
git diff --check
```

Results: PASS.

Local package proof:

```bash
OUTPUT_DIR=/tmp/ms2-onprem-deps-refresh-package PACKAGE_TAG=deps-refresh-smoke scripts/ops/multitable-onprem-package-build.sh
scripts/ops/multitable-onprem-package-verify.sh /tmp/ms2-onprem-deps-refresh-package/metasheet-multitable-onprem-v2.5.0-deps-refresh-smoke.zip
scripts/ops/multitable-onprem-package-verify.sh /tmp/ms2-onprem-deps-refresh-package/metasheet-multitable-onprem-v2.5.0-deps-refresh-smoke.tgz
```

Both verifier runs returned `Package verify OK`.

## Expected bridge retest

After merge + new package publish, deploy with `deploy.bat <package.zip>`. The deploy log should include `Refresh dependencies (pnpm install --frozen-lockfile)`. SQL source should no longer fail with `SQLSERVER_DRIVER_MISSING`; valid config should connect, invalid config should produce a concrete SQL Server config/connection error.