### PR TITLE
docs(attendance): plan report sync job runner

### DIFF
--- a/docs/development/attendance-report-period-rollup-sync-todo-20260519.md
+++ b/docs/development/attendance-report-period-rollup-sync-todo-20260519.md
@@ -20,7 +20,7 @@ Date: 2026-05-19
 - 不裸写 `meta_*`，全程经 `context.api.multitable.provisioning.ensureObject()` + `records.create/patchRecord`。
 - summary 动态 subtype 字段在周期层按 approved request 汇总，不默默返回全 0。
 - daily `attendance_report_records` 不改。
-- v1 支持 date range 与 payroll cycle 两种模式；后台任务队列、自动跨页全量跑批、period dedup cleanup 留后续。
+- v1 支持 date range 与 payroll cycle 两种模式；后台任务队列、自动跨页全量跑批进入 `attendance-report-sync-jobs-todo-20260519.md`；period dedup cleanup 留后续。
 
 ## Public Interfaces
 
@@ -100,7 +100,7 @@ Date: 2026-05-19
 - 不新增 `attendance_*` migration，不迁移事实源。
 - 不让多维表公式直读 `attendance_*`。
 - `attendance_report_period_summaries` 是可重建报表层，不作为查询 / 导出事实源。
-- v1 支持 date range 与 payroll cycle；后台任务队列、自动跨页全量跑批、period dedup cleanup 留后续。
+- v1 支持 date range 与 payroll cycle；后台任务队列、自动跨页全量跑批进入 `attendance-report-sync-jobs-todo-20260519.md`；period dedup cleanup 留后续。
 - summary 动态 subtype 字段在周期层按 approved request 汇总，不默默返回全 0。
 - daily `attendance_report_records` 不改；period rollup 是独立对象、独立 writer、独立 UI 入口。
 

--- a/docs/development/attendance-report-records-sync-todo-20260515.md
+++ b/docs/development/attendance-report-records-sync-todo-20260515.md
@@ -151,7 +151,7 @@ skip  iff  existing.source_fingerprint === next.source_fingerprint
 ## Out of scope（显式 follow-up）
 
 - period / 周期汇总行（复用 `loadAttendanceSummary`，下一条 slice）
-- **batch cursor / 后台任务队列**（全员同步与分页已由 2026-05-18 bulk sync slice 补齐；自动连续分页、后台任务化、超时恢复仍为 follow-up）
+- **batch cursor / 后台任务队列**（全员同步与分页已由 2026-05-18 bulk sync slice 补齐；自动连续分页、后台任务化、超时恢复进入 `attendance-report-sync-jobs-todo-20260519.md`）
 - **orphan / stale columns cleanup**（`ensureFields` 只 upsert 不删；字段隐藏/禁用/动态 subtype 消失后旧列保留——P2 cleanup follow-up）
 - **重复 row_key 行 dedup**（多维表无唯一约束；v1 只 patch 第一条 + warn，自动删重复 = cleanup follow-up）
 - 多维表侧公式/视图模板预置（归多维表配置，非本线）

--- a/docs/development/attendance-report-sync-jobs-design-20260519.md
+++ b/docs/development/attendance-report-sync-jobs-design-20260519.md
@@ -1,0 +1,192 @@
+# 考勤报表同步任务化设计记录
+
+Date: 2026-05-19
+
+## Context
+
+已有能力：
+
+- daily `attendance_report_records`
+  - single user sync
+  - `userIds` batch sync
+  - `allUsers` explicit page sync
+  - staging live evidence
+- period `attendance_report_period_summaries`
+  - date range sync
+  - payroll cycle sync
+  - `userIds` / `allUsers` explicit page sync
+  - frontend入口
+  - staging live evidence
+  - live acceptance harness
+
+缺口：管理员仍要手动决定 page 并重复点击。大租户需要一个可恢复、可查询、可继续执行的 job/cursor 层。
+
+## Chosen Direction
+
+采用「SQL job state + existing writer delegation」。
+
+理由：
+
+- job 状态需要持久、可恢复、可分页查询，多维表 report object 不适合承载控制面状态。
+- `context.services.queue` 当前可以作为执行器，但 durable truth 仍需要 SQL job row。
+- daily / period 两条 writer 已经锁定 upsert、fingerprint、stale-null、duplicate row_key 语义；任务层重复实现会增加漂移。
+
+## Why Not
+
+### Not Direct Multitable Job State
+
+不把 job 状态写到 `attendance_report_records` 或 `attendance_report_period_summaries`：
+
+- report object 是报表快照，不是控制面。
+- report object 可重建；job 状态不可简单重建。
+- report object 的权限/视图/公式面向协作，不适合保存 runner lock。
+
+### Not A Single “Sync Everything” Endpoint
+
+不新增一次性全量同步端点直接跑到底：
+
+- HTTP 超时风险高。
+- 失败无法恢复到具体 page。
+- 无法给 UI 稳定进度和取消能力。
+
+### Not Cleanup/Dedup First
+
+重复 row_key dedup 和 orphan column cleanup 都是破坏性清理能力。任务化先提供观察、计数、失败恢复；清理由后续单独 slice 做。
+
+## Data Model
+
+`plugin_attendance_report_sync_jobs` 是运营状态表。
+
+它不属于考勤事实源，不被报表查询/导出读取。它只回答：
+
+- 要同步什么？
+- 现在同步到哪一页？
+- 已经同步了多少？
+- 是否失败，失败在哪里？
+
+建议 status:
+
+```text
+queued
+running
+paused
+completed
+failed
+canceled
+```
+
+建议 kind:
+
+```text
+daily_records
+period_summaries
+```
+
+`period_source` 与 `user_selection` 保持 JSONB，避免把 daily 与 period 的参数硬拆成多列；但 `org_id/status/created_at` 必须可索引。
+
+## Cursor Semantics
+
+`cursor` 最小 shape：
+
+```json
+{
+  "nextPage": 1,
+  "pageSize": 50,
+  "hasNextPage": true
+}
+```
+
+规则：
+
+- explicit `userId` / `userIds` job 一页完成。
+- `allUsers` job 根据 writer 返回的 `hasNextPage` 更新。
+- job runner 不自己查 users 表；它把 page/pageSize 交给现有 writer。
+- 如果 writer 返回 `usersScanned=0` 且 `hasNextPage=false`，job completed，totals 保持 0。
+
+## Totals
+
+`totals` 累加现有 writer 返回值：
+
+```json
+{
+  "usersScanned": 0,
+  "usersSynced": 0,
+  "usersFailed": 0,
+  "synced": 0,
+  "rowsSynced": 0,
+  "created": 0,
+  "patched": 0,
+  "skipped": 0,
+  "failed": 0,
+  "duplicateRowKeys": 0
+}
+```
+
+`fieldFingerprint`、`syncedAt`、`multitable` 保存在 `last_result`，不做累加。
+
+## Locking
+
+最小实现：
+
+- `run-next-page` 在 transaction 中把非 terminal job 从 `queued|paused|failed` 置为 `running` 并写 `locked_at=now()`。
+- 如果 job 已是 `running` 且 `locked_at` 未过期，返回 409。
+- page 执行结束后根据结果写回 `queued` / `completed` / `failed`。
+- lock TTL 建议 10 分钟，后续可配置。
+
+## API Response Shape
+
+Job projection:
+
+```json
+{
+  "id": "...",
+  "orgId": "default",
+  "kind": "daily_records",
+  "status": "running",
+  "periodSource": { "from": "2026-05-01", "to": "2026-05-31" },
+  "userSelection": { "allUsers": true },
+  "cursor": { "nextPage": 2, "pageSize": 50, "hasNextPage": true },
+  "totals": {},
+  "lastResult": {},
+  "error": null,
+  "createdAt": "...",
+  "updatedAt": "..."
+}
+```
+
+`run-next-page` returns:
+
+```json
+{
+  "ok": true,
+  "data": {
+    "job": {},
+    "pageResult": {}
+  }
+}
+```
+
+## Frontend
+
+PR3 UI should be quiet and operational:
+
+- no marketing copy
+- compact task table
+- status badge
+- progress text `page n / done`
+- totals columns
+- last error inline
+- actions: run next page, cancel, refresh, open multitable
+
+Keep existing immediate sync buttons as the “small tenant / emergency fallback”.
+
+## Review Contract
+
+每个 implementation PR 必须回答：
+
+- 是否只调用 existing daily / period sync writer？
+- 是否没有直接写 `meta_*`？
+- 是否没有把 job table 当事实源？
+- 是否保留 immediate sync endpoints？
+- 是否 token / staging output 不入库？
+- 是否失败可恢复到 page 级别？

--- a/docs/development/attendance-report-sync-jobs-todo-20260519.md
+++ b/docs/development/attendance-report-sync-jobs-todo-20260519.md
@@ -1,0 +1,242 @@
+# 考勤报表同步任务化 TODO
+
+Date: 2026-05-19
+
+## Summary
+
+在 daily `attendance_report_records` 与 period `attendance_report_period_summaries` 都已具备分页同步、UI 入口、staging live evidence、live acceptance harness 后，下一步做统一的「报表同步任务层」。
+
+目标不是改写统计逻辑，而是把现有显式分页动作编排成可恢复的 job/cursor：
+
+- 管理员创建一个 daily 或 period sync job。
+- job 保存同步参数、当前页 cursor、累计统计和最近错误。
+- runner 每次只执行一个 page，复用现有 daily / period sync writer。
+- 支持查询状态、继续下一页、取消、失败后重试。
+- 前端展示任务进度，并保留现有手动同步入口作为低风险 fallback。
+
+## Governance
+
+- 默认由 Codex 驱动实现。
+- Claude 只做 independent review 或 docs-only closeout，不主导 report sync 主题开发。
+- 继续遵守 attendance 与 multitable report boundary：`attendance_*` 是事实源，多维表对象是可重建报表层，任务表只存运营状态。
+
+## Public Interfaces
+
+### New Operational Table
+
+新增运营状态表，建议命名：
+
+```text
+plugin_attendance_report_sync_jobs
+```
+
+它不是考勤事实表，不被考勤查询 / 导出读取，只用于管理员同步任务状态。
+
+最小字段：
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `id` | uuid pk | job id |
+| `org_id` | text | tenant |
+| `kind` | text | `daily_records` / `period_summaries` |
+| `status` | text | `queued` / `running` / `paused` / `completed` / `failed` / `canceled` |
+| `created_by` | text | requester |
+| `period_source` | jsonb | `{from,to}` or `{cycleId}` |
+| `user_selection` | jsonb | `{userId}` / `{userIds}` / `{allUsers:true}` |
+| `cursor` | jsonb | `nextPage`, `pageSize`, `hasNextPage`, optional checkpoint |
+| `totals` | jsonb | accumulated users / rows / created / patched / skipped / failed / duplicates |
+| `last_result` | jsonb | last page response, bounded |
+| `error` | text | latest terminal or page error |
+| `locked_at` | timestamptz | in-process / queue lock |
+| `started_at` | timestamptz | first runner start |
+| `finished_at` | timestamptz | terminal time |
+| `created_at` | timestamptz | insert time |
+| `updated_at` | timestamptz | update time |
+
+Indexes:
+
+- `(org_id, status, updated_at desc)`
+- `(org_id, created_at desc)`
+- optional unique `(org_id, idempotency_key)` if PR1 includes idempotency.
+
+### New APIs
+
+All routes require `attendance:admin`.
+
+```text
+POST /api/attendance/report-sync-jobs
+GET  /api/attendance/report-sync-jobs
+GET  /api/attendance/report-sync-jobs/:id
+POST /api/attendance/report-sync-jobs/:id/run-next-page
+POST /api/attendance/report-sync-jobs/:id/cancel
+```
+
+Create body:
+
+```json
+{
+  "kind": "daily_records",
+  "periodSource": { "from": "2026-05-01", "to": "2026-05-31" },
+  "userSelection": { "allUsers": true },
+  "pageSize": 50,
+  "mode": "manual_step"
+}
+```
+
+For period summaries:
+
+```json
+{
+  "kind": "period_summaries",
+  "periodSource": { "cycleId": "..." },
+  "userSelection": { "allUsers": true },
+  "pageSize": 50,
+  "mode": "manual_step"
+}
+```
+
+v1 `mode`:
+
+- `manual_step`: create job, administrator or frontend calls `run-next-page` until completed.
+- `enqueue`: optional PR2/PR3 extension; use `context.services.queue` when available, fallback to in-process `setImmediate`.
+
+## Execution Contract
+
+### Daily Job
+
+One page execution calls the existing daily bulk writer path with:
+
+```json
+{
+  "from": "...",
+  "to": "...",
+  "allUsers": true,
+  "page": cursor.nextPage,
+  "pageSize": cursor.pageSize
+}
+```
+
+or explicit user selection if the job was created with `userId` / `userIds`.
+
+Do not duplicate row-level logic. The existing writer remains responsible for:
+
+- value column resolution
+- row key
+- source / field fingerprint
+- stale-null patch behavior
+- duplicate row_key fuse
+- degraded handling
+
+### Period Job
+
+One page execution calls the existing period bulk writer path with:
+
+```json
+{
+  "from": "...",
+  "to": "...",
+  "allUsers": true,
+  "page": cursor.nextPage,
+  "pageSize": cursor.pageSize
+}
+```
+
+or:
+
+```json
+{
+  "cycleId": "...",
+  "allUsers": true,
+  "page": cursor.nextPage,
+  "pageSize": cursor.pageSize
+}
+```
+
+Again, do not reimplement summary formulas, subtype rollup, fingerprinting, or upsert.
+
+## Status Machine
+
+```text
+queued -> running -> completed
+queued -> running -> paused -> running -> completed
+queued -> running -> failed -> running
+queued -> canceled
+running -> canceled
+```
+
+Rules:
+
+- `run-next-page` may start `queued`, `paused`, or `failed` jobs.
+- `running` jobs require a lock check. If `locked_at` is fresh, return 409.
+- terminal `completed` / `canceled` jobs cannot run again; create a new job.
+- a page-level writer `degraded:true` marks the job `failed` with `error=reason`, because task progress cannot be trusted.
+- row-level failures from existing writer are accumulated in `totals.failed`; job can still continue unless all rows in a page fail.
+
+## PR Plan
+
+### PR1: Schema + Service Helpers
+
+- Add migration for `plugin_attendance_report_sync_jobs`.
+- Add helper functions inside attendance plugin:
+  - normalize job body
+  - map job row
+  - create job
+  - load job
+  - update job progress
+  - validate transition
+- Add tests for schema-independent helpers and route body validation where possible.
+- No runner loop, no UI.
+
+### PR2: Runner + Routes
+
+- Implement create / list / get / run-next-page / cancel routes.
+- Implement one-page runner that delegates to existing daily or period sync helpers.
+- Implement cursor update:
+  - `nextPage += 1` when `hasNextPage=true`
+  - terminal `completed` when explicit users done or `hasNextPage=false`
+- Accumulate totals deterministically.
+- Use `context.services.queue` only as an optional launcher. Durable truth remains SQL job row.
+- Tests:
+  - daily allUsers page 1 -> page 2 -> completed
+  - period cycle allUsers
+  - explicit userIds complete in one page
+  - degraded writer marks failed
+  - fresh lock returns 409
+  - canceled job cannot run
+
+### PR3: Frontend Job UI
+
+- Add “创建同步任务” mode beside existing immediate sync panels.
+- Job list with status, progress, totals, latest error, `updatedAt`.
+- Actions:
+  - create daily job
+  - create period job
+  - run next page
+  - cancel
+  - open report multitable object from latest result when present
+- Keep existing immediate daily / period sync controls as fallback.
+
+### PR4: Live Acceptance Harness
+
+- Extend existing report records and period summaries live acceptance with optional `JOB_MODE=1`.
+- Verify create job -> run pages -> completed.
+- Verify rerun completed job is rejected and new job can be created.
+- Staging live only after explicit authorization and file-based JWT.
+
+## Hard Boundaries
+
+- Do not make `attendance_report_records` or `attendance_report_period_summaries` a query/export fact source.
+- Do not let multitable formulas read `attendance_*`.
+- Do not directly write `meta_*`.
+- Do not implement automatic row dedup deletion in this slice.
+- Do not implement orphan column cleanup in this slice.
+- Do not remove existing immediate sync endpoints or UI.
+- Do not put token values or staging output into git.
+
+## Open Follow-ups
+
+- Scheduled recurring sync jobs.
+- Automatic cross-page worker that runs until completion without manual stepping.
+- Dedup cleanup for duplicate row_key records.
+- Orphan / stale column cleanup for removed fields.
+- Alerting when jobs fail or duplicateRowKeys increases.

--- a/docs/development/attendance-report-sync-jobs-verification-20260519.md
+++ b/docs/development/attendance-report-sync-jobs-verification-20260519.md
@@ -1,0 +1,80 @@
+# 考勤报表同步任务化验证记录
+
+Date: 2026-05-19
+
+## Scope
+
+本轮是 docs-only 设计切片，不实现 migration、route、runner 或 UI。
+
+验证目标：
+
+- 从现有代码和文档确认 daily / period sync 都已具备分页 writer。
+- 明确任务化层复用 existing writer，不重写报表统计。
+- 给后续 PR1/PR2/PR3/PR4 固定验证矩阵。
+
+## Orientation Evidence
+
+| Evidence | Result |
+| --- | --- |
+| daily bulk sync | `POST /api/attendance/report-records/sync` 已支持 `userIds` 与 `allUsers/page/pageSize` |
+| period bulk sync | `POST /api/attendance/report-period-summaries/sync` 已支持 date range / cycle + `userIds` / `allUsers/page/pageSize` |
+| live harness | period summaries live acceptance 已存在并在 staging smoke 中 34 checks PASS |
+| async import precedent | attendance import 已有 SQL job row + queue fallback 模式，可作为 shape 参考 |
+| queue service | `context.services.queue` 可作为执行器，但 durable truth 应在 SQL job row |
+
+## Commands
+
+```bash
+git fetch origin main --quiet
+rg -n "batch cursor|后台任务|allUsers|period|report-records|period-summaries|sync job|cursor|duplicateRowKeys|stale" docs/development
+rg -n "attendance_import_jobs|context.services.queue|processAsyncImportCommitJob" plugins/plugin-attendance/index.cjs packages/core-backend/src/services/QueueService.ts
+git diff --check
+```
+
+## Planned PR Validation Matrix
+
+### PR1: Schema + Helpers
+
+- migration applies and rolls back cleanly.
+- table is named `plugin_attendance_report_sync_jobs`, not a report object.
+- helper maps row JSON safely with bounded `last_result`.
+- invalid `kind`, invalid period source, mixed user selection all rejected.
+- no `meta_*` writes.
+
+### PR2: Runner + Routes
+
+- create daily allUsers job.
+- run next page delegates to daily writer and advances cursor.
+- create period cycle job.
+- run next page delegates to period writer and advances cursor.
+- explicit userIds job completes in one page.
+- fresh running lock returns 409.
+- stale lock can resume.
+- degraded writer marks job failed.
+- canceled job cannot run.
+- completed job cannot run again.
+
+### PR3: Frontend
+
+- create job form builds daily body.
+- create job form builds period cycle body.
+- job table renders status, cursor, totals, last error.
+- run next page calls route and refreshes job.
+- cancel disables further run.
+- immediate sync UI still exists.
+
+### PR4: Live Acceptance
+
+- create job on staging.
+- run pages until completed.
+- verify final totals are non-negative and page cursor terminal.
+- verify report object fingerprints still present through existing live harness.
+- token read from file only; no token literal in output.
+
+## Current Docs-only Validation
+
+Expected before PR:
+
+- `git diff --check` PASS.
+- sensitive literal scan over staged docs finds no JWT / private key / bearer token.
+- no code or migration file staged.


### PR DESCRIPTION
## Summary

Docs-only plan for a unified attendance report sync job runner over the existing daily `attendance_report_records` and period `attendance_report_period_summaries` sync writers.

This keeps the current report objects as rebuildable multitable snapshots and adds a future operational job/cursor layer for page-by-page resume, cancel, and progress tracking.

## Scope

- Adds `attendance-report-sync-jobs-{todo,design,verification}-20260519.md`
- Links the existing daily and period sync TODOs to the new job-runner follow-up
- No code, no migration, no plugin runtime changes, no frontend changes
- No staging/prod writes and no token material

## Validation

- [x] `git diff --check`
- [x] staged sensitive literal scan for JWT/private key/Bearer/API key patterns
- [x] staged boundary is 5 docs files only

## Implementation Boundaries For Future PRs

- Reuse existing daily / period sync writers; do not rewrite report calculations
- Do not directly write `meta_*`
- Do not make report objects or job rows attendance facts
- Keep immediate sync endpoints and UI as fallback
- Staging live evidence remains file-token only and explicitly authorized
