### PR TITLE
fix(web-test): jsdom localStorage baseline + real T2 Workbench render assertions

### DIFF
--- a/apps/web/tests/multitable-workbench-view.spec.ts
+++ b/apps/web/tests/multitable-workbench-view.spec.ts
@@ -875,6 +875,7 @@ vi.mock('../src/multitable/components/MetaToast.vue', () => ({
 }))
 
 import MultitableWorkbench from '../src/multitable/views/MultitableWorkbench.vue'
+import { useLocale } from '../src/composables/useLocale'
 
 async function flushUi(cycles = 5): Promise<void> {
   for (let i = 0; i < cycles; i += 1) {
@@ -1070,6 +1071,7 @@ describe('MultitableWorkbench view wiring', () => {
     pushSpy.mockReset()
     localStorage.removeItem(FAVORITE_BASES_KEY)
     localStorage.removeItem(RECENT_BASES_KEY)
+    useLocale().setLocale('en')
     vi.clearAllMocks()
   })
 
@@ -2470,5 +2472,32 @@ describe('MultitableWorkbench view wiring', () => {
       targetId: 'rec_2',
     }))
     expect(mentionInboxSummaryMock.markRead).toHaveBeenCalledWith({ spreadsheetId: 'sheet_orders' })
+  })
+
+  // T2 i18n: real Workbench locale render assertions (unblocked by the
+  // jsdom-localStorage baseline fix). Targets are only buttons that the
+  // DEFAULT workbenchMock renders: Fields/Access/Views (caps default true)
+  // + Comment Inbox/Dashboard/API & Webhooks (no capability gate).
+  // Workflow/Automations are excluded — canManageAutomation defaults false.
+  it('renders the workbench toolbar in zh-CN when locale is zh-CN', async () => {
+    useLocale().setLocale('zh-CN')
+    mountWorkbench()
+    await nextTick()
+    const text = container!.textContent ?? ''
+    for (const s of ['字段', '权限', '视图', '评论收件箱', '仪表盘', 'API 与 Webhook']) {
+      expect(text, `missing zh string: ${s}`).toContain(s)
+    }
+    expect(text).not.toContain('Comment Inbox')
+  })
+
+  it('renders the workbench toolbar in English when locale is en', async () => {
+    useLocale().setLocale('en')
+    mountWorkbench()
+    await nextTick()
+    const text = container!.textContent ?? ''
+    for (const s of ['Fields', 'Access', 'Views', 'Comment Inbox', 'Dashboard', 'API & Webhooks']) {
+      expect(text, `missing en string: ${s}`).toContain(s)
+    }
+    expect(text).not.toContain('评论收件箱')
   })
 })

--- a/apps/web/tests/setup/localstorage.ts
+++ b/apps/web/tests/setup/localstorage.ts
@@ -1,0 +1,63 @@
+// Global localStorage polyfill for the web test suite.
+//
+// Root cause (probed, vitest 1.6.1 + jsdom): the default about:blank
+// (opaque) origin yields a non-functional `localStorage` — at env baseline
+// it is a methodless plain `{}` (typeof object, no getItem/removeItem).
+// `environmentOptions.jsdom.url` did not take effect in this vitest version.
+// Specs that need localStorage historically each hand-rolled an in-memory
+// store; this setup file promotes that to one deterministic global fix.
+//
+// Install order matters (review #1): a spec's top-level `import` runs
+// BEFORE its `beforeEach`. Modules that read localStorage at module-init
+// (e.g. useLocale.ts resolveInitialLocale()/setDocumentLang()) would still
+// see the broken `{}` if we only installed in beforeEach. So install once
+// at setup-file load, then re-install a fresh store before every test.
+import { beforeEach } from 'vitest'
+
+function makeStorage(): Storage {
+  let store: Record<string, string> = {}
+  return {
+    get length() {
+      return Object.keys(store).length
+    },
+    clear() {
+      store = {}
+    },
+    getItem(key: string) {
+      return Object.prototype.hasOwnProperty.call(store, key) ? store[key] : null
+    },
+    key(index: number) {
+      return Object.keys(store)[index] ?? null
+    },
+    removeItem(key: string) {
+      delete store[key]
+    },
+    setItem(key: string, value: string) {
+      store[key] = String(value)
+    },
+  } as Storage
+}
+
+function installLocalStorage(): void {
+  const ls = makeStorage()
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: ls,
+    configurable: true,
+    writable: true,
+  })
+  if (typeof window !== 'undefined') {
+    Object.defineProperty(window, 'localStorage', {
+      value: ls,
+      configurable: true,
+      writable: true,
+    })
+  }
+}
+
+// ① at setup-file load (before any spec top-level import executes)
+installLocalStorage()
+
+// ② fresh store per test (isolation + heals specs that replaced it w/o restore)
+beforeEach(() => {
+  installLocalStorage()
+})

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -78,7 +78,12 @@ export default defineConfig(({ mode }) => {
       },
     },
     test: {
-      environment: 'jsdom'
+      environment: 'jsdom',
+      // jsdom's default about:blank origin yields a non-functional
+      // localStorage ({} without methods). This setup file installs an
+      // in-memory Storage polyfill (at load + per test). See
+      // docs/development/web-test-jsdom-localstorage-baseline-fix-20260519.md
+      setupFiles: ['./tests/setup/localstorage.ts']
     }
   }
 })

--- a/docs/development/multitable-workbench-i18n-t2-development-20260519.md
+++ b/docs/development/multitable-workbench-i18n-t2-development-20260519.md
@@ -233,7 +233,7 @@ const { isZh } = useLocale()
 | `apps/web/tests/multitable-workbench-i18n.spec.ts` | **新增**：`workbench-labels` 模块单测（key 完整性 + en≠zh + 9 个插值 helper） |
 | `apps/web/tests/multitable-home-view.spec.ts` + `multitable-template-center-view.spec.ts`（既有） | 加 `beforeEach setLocale('zh-CN')` + afterEach 复位——MetaTemplateCard 转 locale 感知后，这两 spec 的中文断言需显式 locale（jsdom 默认 'en'） |
 
-> **`multitable-workbench-view.spec.ts` 不改（诚实口径）**：该 spec 在本仓 jsdom env 存在既有 `localStorage.removeItem is not a function` afterEach baseline（53/53 全 fail，已用 stash 法在 clean origin/main 复核逐字一致，见 verification §3）。往其中加断言无意义——afterEach 必抛、新断言照样标 failed。故 **Workbench 本体的 zh-CN/en 渲染不做自动化 render 断言**；其正确性由 (a) label 模块 spec 确定性覆盖全部映射/helper + (b) `vue-tsc` 保证每个 `wb(key,…)` 调用的 key 是合法 `WorkbenchLabelKey`（错 key=编译错）+ (c) build + (d) 代码 diff / 人工审阅 共同保证。新挂载 mock-heavy Workbench 是早先评审明确警告要避免的，故不做。
+> **`multitable-workbench-view.spec.ts`（T2 合并时不改，后续 PR 已补真断言）**：T2 合并时该 spec 受 jsdom `localStorage` baseline 阻塞（53/53），故当时不加 render 断言。**该 baseline 已由后续 PR `web-test-jsdom-localstorage-baseline-fix-20260519` 根因修复**（全局 setupFile polyfill），并在该 spec 内**已补真实 Workbench locale render 断言**（复用既有重 mock，zh-CN/en 各一例，55/55 绿）。本节保留以记录 T2 合并时点的口径与交叉引用；Workbench 本体双语 render 现**有**自动化覆盖。
 
 不动：后端 / 契约 / migration / 其它 Meta\* 组件 / 其它视图 / `multitable-workbench-view.spec.ts`。
 
@@ -255,7 +255,7 @@ git diff --check origin/main..HEAD
 Acceptance：
 
 - `workbench-labels`：每 key en/zh 非空且不相等；`workbenchLabel(k,true)`→zh、`(k,false)`→en；插值 helper（presence.label en 单复数、presence.title 空态、conflict.message 可选 version、commentInboxTitle 0 分支、card.* 计数）代入正确。`<kbd>` 物理键名不翻译、不进表
-- Workbench 本体（zh-CN/en 渲染）：**无自动化 render 断言**（workbench-view spec 既有 localStorage baseline，见 §5 诚实口径）。正确性由 label spec（映射/helper 全覆盖）+ `vue-tsc`（key 合法性）+ build + 代码审阅保证。期望行为：`zh-CN` 工具栏/横幅/modal 显示「字段/权限/视图/自动化/评论收件箱/模板库/键盘快捷键/导航单元格」+ presence/conflict 中文；`en` 对应英文 —— 经人工审阅 diff 确认
+- Workbench 本体（zh-CN/en 渲染）：T2 合并时无自动化断言（workbench-view baseline 阻塞）；**后续 baseline-fix PR 已补真实 render 断言**（`multitable-workbench-view.spec.ts` zh-CN 断言「字段/权限/视图/评论收件箱/仪表盘/API 与 Webhook」、en 对应英文，55/55 绿）。Workflow/Automations 因默认 `canManageAutomation=false` 不在默认断言（可选增强）。当时口径下另由 label spec + `vue-tsc`（key 合法性）+ build + 人工 diff 兜底
 - MetaTemplateCard（精确口径）：**zh-CN（默认）下 Home/TemplateCenter 必须保持**「`{n} 个 Sheet` / `{n} 个字段` / `{n} 个视图` / `使用模板` / `创建中...`」——既有 home-view / template-center-view spec 文案断言零回归；**en 下显示**「`{n} sheet(s)` / `{n} field(s)` / `{n} view(s)` / `Use template` / `Installing...`」（计数 en 走单复数）
 - **静态 toast 全覆盖证明**：verification MD 附 `grep -nE "showSuccess\(|showError\(" MultitableWorkbench.vue` 全量，逐条标 `[T2-done]`/`[T3-deferred]`
 - `git diff --check` clean；diff 仅 §5 所列文件

--- a/docs/development/multitable-workbench-i18n-t2-verification-20260519.md
+++ b/docs/development/multitable-workbench-i18n-t2-verification-20260519.md
@@ -94,7 +94,7 @@ git stash (T2 改动) → 在 origin/main 原状跑 multitable-workbench-view.sp
 
 T2 实现与（评审三轮修订后的）dev MD 完全一致：工作台外壳 + §3.0 computed + 17 静态 toast + MetaTemplateCard + footer 全部中文化，预期响应顶部 en/zh-CN 开关。label 模块 8/8 单测绿，typecheck/build 绿，回归零净新增。T3 边界（Meta\* / templateLibraryError / 动态 toast）明确锚定。
 
-> **测试覆盖诚实声明**：Workbench 组件本体的双语 render **没有新增自动化断言**。原因：`multitable-workbench-view.spec.ts` 存在既有 `localStorage.removeItem` afterEach baseline failure（53/53，stash 法在 clean origin/main 复核逐字一致，§3），往其中加断言无意义（afterEach 必抛、新断言照样标 failed），而新挂载 mock-heavy Workbench 是早先评审明确警告要避免的。Workbench 本体的 zh-CN/en 正确性由 (a) `multitable-workbench-i18n.spec.ts` 8/8 确定性覆盖全部 en/zh 映射 + 9 helper + (b) `vue-tsc --noEmit` 保证每个 `wb(key,…)` 的 key 是合法 `WorkbenchLabelKey`（错 key = 编译失败）+ (c) build 通过 + (d) 代码 diff 人工审阅 共同保证，**非**通过 Workbench render assertion。若未来该 spec 的 localStorage baseline 被修复，应补真实 Workbench locale render 断言。
+> **测试覆盖（更新 2026-05-19）**：T2 合并时 Workbench 本体双语 render 无自动化断言（`multitable-workbench-view.spec.ts` 受 jsdom localStorage baseline 阻塞，53/53）。**该 baseline 已由后续 PR `web-test-jsdom-localstorage-baseline-fix-20260519` 根因修复**（全局 setupFile in-memory Storage polyfill；全套件失败 217→16、零回归、`comm -13` 空），并在 `multitable-workbench-view.spec.ts` 补了真实 Workbench locale render 断言（zh-CN 断言「字段/权限/视图/评论收件箱/仪表盘/API 与 Webhook」、en 断言对应英文，复用既有重 mock，55/55 绿）。因此 T2 §7 的"无自动化 render"残留风险**已消除**——保留此说明以记录历史与交叉引用。
 
 **待执行**：本地 commit → 停 push 前（沿用本会话节奏）→ 用户 review → push → CI → admin-merge。
 

--- a/docs/development/web-test-jsdom-localstorage-baseline-fix-20260519.md
+++ b/docs/development/web-test-jsdom-localstorage-baseline-fix-20260519.md
@@ -1,0 +1,183 @@
+# 修复 web 测试 jsdom localStorage baseline + 补 T2 Workbench render 断言 — 开发计划
+
+- **日期**：2026-05-19
+- **范围**：`apps/web/vite.config.ts`（test 配置）+ 新增 `apps/web/tests/setup/localstorage.ts`（vitest setupFile）+ `apps/web/tests/multitable-workbench-view.spec.ts`（补 T2 locale render 断言，baseline 修复后才可行）
+- **K3 PoC 阶段一锁定**：合规（纯测试基建 + 测试新增；无产品代码 / 契约 / migration）
+- **关联**：T2 i18n（#1664 已合并）verification §7 锚定的"baseline 修复后应补真实 Workbench render 断言"
+
+---
+
+## 1. 根因（探针实证，非推测）
+
+零 import、单文件隔离运行的探针 spec：
+
+```
+PROBE typeof=object | ctor=undefined | hasRemoveItem=undefined
+      | hasGetItem=undefined | keys=[] | proto=Object
+```
+
+`globalThis.localStorage` 在 env baseline 即是一个**无方法的纯 `{}`**（非 jsdom `Storage`）。原因：**vitest 1.6.1 + jsdom 默认 `about:blank`（opaque origin）**，jsdom 不提供可用 `Storage`，落为占位 `{}`。
+
+- 非跨文件泄漏：探针单文件隔离仍复现（vitest 默认 `isolate:true`）。
+- 非某 spec 写坏：无 `define` / 无 setup 文件造 `{}`。
+- **Option A 已实测否决**：在 `vite.config.ts` test 块加 `environmentOptions.jsdom.url:'http://localhost/'` —— workbench-view+home-view 仍 **60 failed (60)**，localStorage 仍 `{}`。vitest 1.6.1 此路径不生效，已 `git checkout` 回退该 no-op 改动。
+
+现有能用 localStorage 的 spec（`useAuth.spec.ts`、`multitable-phase5.spec.ts` 等）都**各自手搓 in-memory storage**塞 `globalThis.localStorage` —— 即根因的 per-file workaround 散落多处。
+
+## 2. 选定修法：全局 setupFile in-memory Storage polyfill
+
+新增 `apps/web/tests/setup/localstorage.ts`，在 `vite.config.ts` test 配 `setupFiles`：
+
+```ts
+// apps/web/tests/setup/localstorage.ts
+import { beforeEach } from 'vitest'
+
+function makeStorage(): Storage {
+  let store: Record<string, string> = {}
+  return {
+    get length() { return Object.keys(store).length },
+    clear() { store = {} },
+    getItem(k: string) { return Object.prototype.hasOwnProperty.call(store, k) ? store[k] : null },
+    key(i: number) { return Object.keys(store)[i] ?? null },
+    removeItem(k: string) { delete store[k] },
+    setItem(k: string, v: string) { store[k] = String(v) },
+  } as Storage
+}
+
+function installLocalStorage(): void {
+  const ls = makeStorage()
+  Object.defineProperty(globalThis, 'localStorage', { value: ls, configurable: true, writable: true })
+  if (typeof window !== 'undefined') {
+    Object.defineProperty(window, 'localStorage', { value: ls, configurable: true, writable: true })
+  }
+}
+
+// ① INSTALL AT SETUP-FILE LOAD (module top-level), BEFORE any spec's
+//    top-level imports run. Modules that read localStorage at module-init
+//    time (e.g. useLocale.ts resolveInitialLocale()) would otherwise still
+//    observe the broken `{}` because spec `import` precedes `beforeEach`.
+installLocalStorage()
+
+// ② Re-install a fresh store before every test for isolation (cleared state
+//    + heals any spec that replaced localStorage without restoring).
+beforeEach(() => {
+  installLocalStorage()
+})
+```
+
+> **关键（评审 #1）**：必须 setup 文件加载时**先 `installLocalStorage()` 一次**，再 `beforeEach` 重装。否则 spec 顶层 `import`（早于 `beforeEach`）触发的模块初始化（如 `useLocale.ts` 的 `resolveInitialLocale()` / `setDocumentLang()`）仍读到坏的 `{}`。
+
+```ts
+// vite.config.ts
+test: {
+  environment: 'jsdom',
+  setupFiles: ['./tests/setup/localstorage.ts'],
+}
+```
+
+**为何 setupFile 而非逐 spec**：根因是 env 级，逐 spec 手搓是债务扩散；全局 setupFile 一次性确定性修复全部 spec，并让 useAuth/phase5 等的手搓 workaround 变为冗余（本 PR 不删它们——它们 `vi.stubGlobal` / 手动赋值 + 还原仍兼容 polyfill，删除是独立清理，超本 PR 范围）。
+
+**`configurable:true`**：使 `vi.stubGlobal('localStorage', …)` 与手动赋值仍能覆盖 + 还原（还原目标变为 polyfill，行为等价或更好）。
+
+## 3. 兼容性风险（全套件 blast radius）
+
+setupFiles 影响 **每个 web spec**。风险与缓解：
+
+| 风险 | 缓解 |
+|---|---|
+| 某 spec 依赖 `typeof localStorage === 'undefined'` 分支（生产 `api.ts` 有此 guard） | polyfill 让 localStorage **始终 defined**。需全套件 before/after 对比，定位是否有 spec 专测 undefined 分支；若有，单列豁免（该 spec 自行 `vi.stubGlobal('localStorage', undefined)`） |
+| `vi.stubGlobal('localStorage', x)` 的 spec | 兼容：stubGlobal 记录当前(polyfill)→设 x→`unstubAllGlobals` 还原 polyfill。✅ |
+| 手动 `globalThis.localStorage = original` 模式（useAuth.spec） | `original` 现 = polyfill（可用），还原 OK。✅ |
+| setupFile beforeEach 与 spec 自身 beforeEach 顺序 | vitest setupFile 的 beforeEach 先于 spec 内 beforeEach，spec 内若再 setLocale/塞数据均在干净 polyfill 上，符合预期 |
+
+**强制验收（评审 #2：失败清单 diff，不靠总数）**：总数下降无法证明无回归（A 失败消失 + B 新失败出现，总数仍可下降）。必须产出 before/after 的**失败用例全集**并做集合 diff：
+
+```bash
+# before（origin/main 原状，未加 setupFile）
+pnpm --filter @metasheet/web exec vitest run --watch=false --reporter=json --outputFile=/tmp/web-before.json 2>/dev/null || true
+# after（加 setupFile 后）
+pnpm --filter @metasheet/web exec vitest run --watch=false --reporter=json --outputFile=/tmp/web-after.json 2>/dev/null || true
+# 提取失败用例全名集合，做 diff
+jq -r '.testResults[].assertionResults[] | select(.status=="failed") | .fullName' /tmp/web-before.json | sort -u > /tmp/web-before-fail.txt
+jq -r '.testResults[].assertionResults[] | select(.status=="failed") | .fullName' /tmp/web-after.json  | sort -u > /tmp/web-after-fail.txt
+comm -13 /tmp/web-before-fail.txt /tmp/web-after-fail.txt   # ← 必须为空：after 新增失败 = 回归
+comm -23 /tmp/web-before-fail.txt /tmp/web-after-fail.txt   # ← 期望非空：被本修复治好的失败
+```
+
+`comm -13`（after 独有失败）**必须为空**。非空即回归，须逐条定位 + 豁免或修正后方可推进。verification MD **必须附** before-fail/after-fail 两个集合 + 两个 comm 输出。json reporter 不可用时退化为 `--reporter=verbose` 抓 `× ` 行排序去重。
+
+## 4. 第二步：补 T2 真 Workbench locale render 断言（baseline 修复后）
+
+baseline 修复后 `multitable-workbench-view.spec.ts` 应恢复绿（其 afterEach 的 `localStorage.removeItem` 现可用）。在该 spec **复用其既有重 mock 装配**（不新挂载）增量加。
+
+**断言目标必须只用默认 mock 下确定渲染的按钮（评审 #3 实证）**。workbench-view 默认 mock：`canManageFields/canManageSheetAccess/canManageViews = true`，但 **`canManageAutomation = false`** → 工具栏的 **Workflow / Automations 按钮默认不渲染**（二者 `v-if="caps.canManageAutomation.value"`）。无 capability 门控、始终渲染的 = **Comment Inbox / Dashboard / API & Webhooks**；默认 caps=true 下额外可见 = **Fields / Access / Views**。冲突横幅（`v-if="grid.conflict"`）、模板库 modal（`v-if="showTemplateLibrary"`）、快捷键 modal（`v-if="showShortcuts"`）默认态均不渲染，**不**作默认断言目标。
+
+确定的断言集（6 串，默认 mock 即可见，无需改 caps/state）：
+
+- `zh-CN` 用例：`useLocale().setLocale('zh-CN')` → 挂载 → 断言工具栏含「**字段 / 权限 / 视图 / 评论收件箱 / 仪表盘 / API 与 Webhook**」
+- `en` 用例：`setLocale('en')` → 断言含 `**Fields / Access / Views / Comment Inbox / Dashboard / API & Webhooks**`
+- afterEach 复位 locale 'en'（与 home/template-center spec 同范式）
+- **Workflow / Automations 排除在默认断言外**（capability-gated）。若要覆盖：单列一个用例显式 `workbenchMock.capabilities.value.canManageAutomation = true` 再断言「工作流 / 自动化」zh / en —— 作为可选增强，非默认必需。
+
+这把 T2 verification §7 的"无自动化 render 断言"残留风险**真正消除**，并回填 dev/verification MD 为"已加真实 Workbench render 断言"。
+
+## 5. 改动文件清单
+
+| 文件 | 改动 |
+|---|---|
+| `apps/web/tests/setup/localstorage.ts` | **新增**：in-memory Storage polyfill + `beforeEach` 安装 |
+| `apps/web/vite.config.ts` | test 块加 `setupFiles: ['./tests/setup/localstorage.ts']` |
+| `apps/web/tests/multitable-workbench-view.spec.ts` | baseline 修复后增量 2 个 locale render 用例（复用既有 mock） |
+| `docs/.../web-test-jsdom-localstorage-baseline-fix-20260519.md` | 本 MD + 配套 verification |
+| T2 dev/verification MD（#1664 已合并的两份） | **回填**：Workbench render 已有真实断言，撤销"无自动化"诚实声明（改为"已补，见本 PR"） |
+
+不动：产品代码 / 后端 / 契约 / migration / 现有 spec 的手搓 storage workaround（独立清理）。
+
+## 6. Test Plan
+
+```bash
+# baseline 修复验证（核心）
+pnpm --filter @metasheet/web test 2>&1 | tail -3      # 全量 before/after 对比，新失败必须=0
+pnpm --filter @metasheet/web exec vitest run tests/multitable-workbench-view.spec.ts --watch=false   # 应转绿
+pnpm --filter @metasheet/web exec vitest run tests/multitable-home-view.spec.ts --watch=false        # 7 fail 应清零
+pnpm --filter @metasheet/web exec vitest run tests/multitable-workbench-i18n.spec.ts --watch=false   # T2 label spec 仍 8/8
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+git diff --check origin/main..HEAD
+```
+
+Acceptance：
+
+- 全量套件：**`comm -13 before-fail after-fail` 为空**（after 无新增失败用例 = 0 回归）；`comm -23` 非空（≥60 localStorage 失败被治好）。**判据是失败用例集合 diff，非总数**
+- workbench-view spec：原 53 fail → 绿（含新增 2 个 locale render 用例：zh-CN 断言「字段/权限/视图/评论收件箱/仪表盘/API 与 Webhook」、en 断言对应英文；Workflow/Automations 不在默认断言）
+- home-view spec：原 7 fail → 绿
+- T2 label spec / template-center / platform-shell-nav 维持绿
+- 若发现专测 `localStorage===undefined` 的 spec 转 fail：定位 + 该 spec 内显式 `vi.stubGlobal('localStorage', undefined)` 豁免，记入 verification
+
+## 7. K3 PoC 阶段一锁定合规
+
+| 检查 | 状态 |
+|---|---|
+| 产品代码 / `/api/*` 契约 / migration | ❌ 不碰（纯测试基建 + 测试新增） |
+| plugin-integration-core / k3-wise / Data Factory | ❌ 不碰 |
+| 新产品面 / 平台化 | ❌ 否（测试可靠性打磨） |
+
+---
+
+## 8. 推荐执行顺序
+
+1. **审本 MD**（你现在做的）—— 重点确认 setupFile 方案 + 全套件 before/after 强制验收口径
+2. 建 setupFile + 配 vite.config → 跑全量 before/after，确认新失败=0
+3. workbench-view spec 补 2 个真 render 断言 → 跑该 spec 转绿
+4. 回填 T2 dev/verification MD（撤"无自动化 render"声明）
+5. 写本计划的 verification MD（附全套件 before/after 数字 + 任何豁免）
+6. 本地 commit + 停 push 前 → 你 review → push → CI → admin-merge
+
+---
+
+## 9. 变更日志
+
+- **2026-05-19 (1)** 初稿（zensgit + claude-opus-4-7 协作）
+- **2026-05-19 (2)** 评审 3 点改进：
+  - **#1** setupFile 改为「模块顶层 `installLocalStorage()` 一次 + beforeEach 重装」——否则 spec 顶层 import 触发的模块初始化（useLocale resolveInitialLocale）早于 beforeEach 仍读坏 `{}`
+  - **#2** 验收改为 before/after **失败用例集合 diff**（json reporter → `comm -13` 必空），不靠 `tail -3` 总数；verification 必附两集合 + comm 输出
+  - **#3** Workbench render 断言目标据实修正：默认 mock `canManageAutomation=false` → Workflow/Automations 默认不渲染；改用确定可见 6 串（字段/权限/视图/评论收件箱/仪表盘/API 与 Webhook），Workflow/Automations 转可选增强用例（需显式开 cap）

--- a/docs/development/web-test-jsdom-localstorage-baseline-fix-verification-20260519.md
+++ b/docs/development/web-test-jsdom-localstorage-baseline-fix-verification-20260519.md
@@ -1,0 +1,100 @@
+# 修复 web 测试 jsdom localStorage baseline + 补 T2 Workbench render 断言 — 验证报告
+
+- **日期**：2026-05-19
+- **配套**：[web-test-jsdom-localstorage-baseline-fix-20260519.md](./web-test-jsdom-localstorage-baseline-fix-20260519.md)
+- **分支**：`frontend/fix-jsdom-localstorage-baseline-20260519`
+
+---
+
+## 1. 实现摘要
+
+| 文件 | 改动 |
+|---|---|
+| `apps/web/tests/setup/localstorage.ts` | **新增**：in-memory `Storage` polyfill；setup-file 加载时 `installLocalStorage()` 一次（早于 spec 顶层 import）+ `beforeEach` 重装（隔离） |
+| `apps/web/vite.config.ts` | test 块加 `setupFiles: ['./tests/setup/localstorage.ts']` |
+| `apps/web/tests/multitable-workbench-view.spec.ts` | import `useLocale`；afterEach 加 `setLocale('en')` 复位；末尾 +2 个真 Workbench locale render 用例（zh-CN / en，复用既有重 mock） |
+| `docs/.../web-test-jsdom-localstorage-baseline-fix-20260519.md` + 本 verification | 设计 + 验证 |
+| `docs/.../multitable-workbench-i18n-t2-development-20260519.md` + `-verification-` | **回填**：撤"无自动化 render"诚实声明 → "后续 PR 已补真实断言"+交叉引用 |
+
+## 2. 安全点 #1：setupFile 确被加载（实测）
+
+零 import 探针 spec + label spec 同跑：
+
+```
+probe: typeof localStorage.removeItem === 'function' ✓ getItem ✓ set/get/remove 往返 ✓
+Test Files 2 passed (2) | Tests 9 passed (9)   ← 1 probe + 8 label
+```
+
+证明 vitest 以 `apps/web` 为 root 正确解析 `./tests/setup/localstorage.ts`，且 polyfill 在 spec 代码前生效。
+
+## 3. 安全点 #2：JSON reporter shape 实录
+
+`vitest run --reporter=json --outputFile` 产出的 JSON：
+
+```
+topKeys: numTotalTestSuites,numPassedTestSuites,…,numTotalTests,numPassedTests,
+         numFailedTests,…,testResults
+.testResults[].assertionResults[]  存在（数组），.status / .fullName 可用
+```
+
+→ MD §3 的 `jq -r '.testResults[].assertionResults[] | select(.status=="failed") | .fullName'` 路径**有效**，未触发退化分支。
+
+## 4. 强制验收：失败用例集合 diff（非总数）
+
+| | failed | passed | total |
+|---|---|---|---|
+| BEFORE（origin/main `266f47564`，无 setupFile） | 217 | 2227 | 2444 |
+| AFTER（加 setupFile） | **16** | **2428** | 2444 |
+
+```
+comm -13 /tmp/web-before-fail.txt /tmp/web-after-fail.txt   → 0 行   ← 回归红线：空 ✓
+comm -23 /tmp/web-before-fail.txt /tmp/web-after-fail.txt   → 201 行 ← 被本修复治好的失败
+comm -12 (before∩after, 残留)                                → 16 行  ← 预存非本切片
+```
+
+**`comm -13` 为空 = AFTER 无任何新增失败用例 = 零回归**（判据是失败用例**全名集合** diff，非 `tail -3` 总数）。
+
+残留 16 分布（均 BEFORE 即在、非 localStorage、本修复不触及）：Attendance record timeline ×4 / Attendance import batch ×4 / featureFlags ×3 / useAttendanceAdminRail ×1 / date field type ×1 / MultitableWorkbench manager-driven config ×1 / ApprovalCenterView ×1 / API Utils getApiBase ×1。属其它预存 issue，超本切片范围。
+
+## 5. 第二步：T2 真 Workbench render 断言（已落地）
+
+`multitable-workbench-view.spec.ts` baseline 修复后转绿，**复用其既有重 mock 装配**新增 2 用例：
+
+- `renders the workbench toolbar in zh-CN when locale is zh-CN`：`setLocale('zh-CN')` → 挂载 → 断言含「字段 / 权限 / 视图 / 评论收件箱 / 仪表盘 / API 与 Webhook」且**不含** `Comment Inbox`
+- `renders the workbench toolbar in English when locale is en`：`setLocale('en')` → 断言含 `Fields / Access / Views / Comment Inbox / Dashboard / API & Webhooks` 且**不含** 评论收件箱
+
+实测：`Test Files 1 passed | Tests 55 passed (55)`（原 53 + 2）。Workflow/Automations 按评审 #3 排除在默认断言外（默认 `canManageAutomation=false`）。
+
+→ T2 verification §7 的"无自动化 Workbench render 断言"残留风险**已真正消除**；两份 T2 MD 已回填交叉引用。
+
+## 6. 其余验收
+
+```
+pnpm --filter @metasheet/web exec vue-tsc --noEmit          → clean
+git diff --check (staged)                                   → clean
+multitable-workbench-i18n.spec.ts (T2 label)                → 8/8（未受影响）
+multitable-home-view.spec.ts                                → 原 7 fail → 绿
+multitable-workbench-view.spec.ts                           → 55/55（53 + 2 render）
+```
+
+## 7. K3 PoC 阶段一锁定合规
+
+| 检查 | 状态 |
+|---|---|
+| 产品代码 / `/api/*` 契约 / migration | ❌ 不碰（纯 test 基建 + test 新增 + 文档回填） |
+| plugin-integration-core / k3-wise / Data Factory | ❌ 不碰 |
+| 新产品面 / 平台化 | ❌ 否（测试可靠性根因修复） |
+
+`git diff --name-only` = setupFile + vite.config + workbench-view spec + 本切片 3 份 MD（含 2 份 T2 回填）。无产品逻辑改动。
+
+## 8. 结论
+
+jsdom localStorage baseline 根因级修复：全套件 `217 → 16` failed、**零回归（comm -13 空）**、治好 201。安全点 #1（setup 加载）/#2（JSON shape）均实测确认。T2 Workbench 双语 render 真断言已补（55/55），T2 §7 残留风险消除，两份 T2 MD 回填。
+
+**待执行**：本地 commit → 停 push 前 → 用户 review → push → CI → admin-merge。
+
+---
+
+## 9. 变更日志
+
+- 2026-05-19 验证报告（zensgit + claude-opus-4-7 协作）


### PR DESCRIPTION
## Summary

Root-cause fix for the long-standing web test-suite `localStorage` baseline failures, plus the real T2 Workbench locale render assertions it unblocks (closes the T2 #1664 verification §7 residual risk). Test infra + test only — no product code / contract / migration.

## Root cause (probed, not guessed)

A zero-import, isolated probe spec showed `globalThis.localStorage` at env baseline = a **methodless plain `{}`** (`typeof object`, no `getItem`/`removeItem`). Cause: **vitest 1.6.1 + jsdom default `about:blank` (opaque origin)**. Option A (`environmentOptions.jsdom.url`) was implemented and **empirically rejected** — still 60/60 failing, localStorage still `{}` (that no-op config change was reverted). Specs needing localStorage each hand-rolled an in-memory store; this promotes that to one deterministic global fix.

## Changes (7 files, slice-clean)

- **`apps/web/tests/setup/localstorage.ts`** (new) — in-memory `Storage` polyfill. Installed at **setup-file load** (before any spec top-level import, so module-init readers like `useLocale.resolveInitialLocale()` see a working store) **and** per `beforeEach` (isolation + heals specs that replace localStorage without restoring). `configurable:true` keeps `vi.stubGlobal` / manual-assign+restore patterns working.
- **`apps/web/vite.config.ts`** — `test.setupFiles: ['./tests/setup/localstorage.ts']`.
- **`apps/web/tests/multitable-workbench-view.spec.ts`** — unblocked by the fix; `import useLocale`, `afterEach setLocale('en')` reset, **+2 real Workbench locale render assertions reusing the existing heavy mock** (NOT new-mount): zh-CN asserts 字段/权限/视图/评论收件箱/仪表盘/API 与 Webhook (and not `Comment Inbox`); en asserts the English equivalents (and not the zh). Workflow/Automations excluded — default mock `canManageAutomation=false`.
- **`web-test-jsdom-localstorage-baseline-fix-20260519.md`** + verification — design (3 review rounds incl. install-timing #1, comm-diff #2, render-target #3) + actual results.
- **`multitable-workbench-i18n-t2-{development,verification}-20260519.md`** — backfilled: the "no automated Workbench render assertion" honest caveat is **withdrawn** (a real assertion now exists), cross-referenced.

## Verification — failed-test-set diff (not totals)

| | failed | passed | total |
|---|---|---|---|
| BEFORE (origin/main, no setupFile) | 217 | 2227 | 2444 |
| AFTER | **16** | **2428** | 2444 |

```
comm -13 before-fail after-fail  → 0    ← regressions: ZERO (hard red line)
comm -23 before-fail after-fail  → 201  ← healed
comm -12 (residual)              → 16   ← pre-existing, non-localStorage, out of slice
```

Safeguards (reviewer-requested) both empirically confirmed:
- **#1 setupFile actually loaded**: probe spec confirms working `localStorage` methods before spec code; vitest resolves `./tests/setup/localstorage.ts` with apps/web root.
- **#2 JSON reporter shape**: `.testResults[].assertionResults[]` with `.status`/`.fullName` confirmed present — jq path valid, no fallback needed (recorded in verification §3).

Post-rebase onto origin/main `ae8fd3142`: `git diff --name-status` = exactly the 7 slice files; `git diff --check` clean; `vue-tsc --noEmit` clean; `multitable-workbench-view` 55/55 (53 + 2 render); `multitable-home-view` 7/7; T2 label spec 8/8 unaffected.

## Scope guard / K3 PoC stage-1 lock

- Test infra + test + docs only. No product logic, `/api/*` contract, DB migration, or `plugins/plugin-integration-core` / `lib/adapters/k3-wise-*` / Data Factory.
- `git diff --name-status origin/main..HEAD` = 7 files (the apparent attendance-doc noise in earlier diffs was the behind-N reverse-diff artifact; merge-base..HEAD is and was clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)