### PR TITLE
feat(attendance): add report sync job state skeleton

### DIFF
--- a/docs/development/attendance-report-sync-jobs-pr1-development-20260519.md
+++ b/docs/development/attendance-report-sync-jobs-pr1-development-20260519.md
@@ -1,0 +1,66 @@
+# 考勤报表同步任务化 PR1 开发记录
+
+Date: 2026-05-19
+
+## Summary
+
+本轮落地 PR1：为 daily `attendance_report_records` 与 period `attendance_report_period_summaries` 的后续任务化 runner 增加运营状态表和 helper skeleton。
+
+范围保持最小：
+
+- 新增 `plugin_attendance_report_sync_jobs` 运营状态表 migration。
+- 在考勤插件新增纯/薄 DB helper，用于 normalize create body、构建 insert row、map DB row、create job、load job。
+- 更新 TODO 指针与本开发 / 验证记录。
+
+本轮不做 runner、不加 route、不改前端、不触碰现有 sync writer 行为。
+
+## Files
+
+| File | Change |
+| --- | --- |
+| `packages/core-backend/src/db/migrations/zzzz20260519070000_create_plugin_attendance_report_sync_jobs.ts` | 新增现代 Kysely migration，创建运营状态表、check constraints、索引与 idempotency unique index |
+| `plugins/plugin-attendance/index.cjs` | 新增 report sync job helper skeleton，并导出到 `__attendanceReportFieldCatalogForTests` |
+| `packages/core-backend/tests/unit/attendance-report-field-catalog.test.ts` | 增加 migration source / normalize / insert-load helper 单测 |
+| `docs/development/attendance-report-sync-jobs-todo-20260519.md` | PR1 勾选并指向开发 / 验证 MD |
+| `docs/development/attendance-report-sync-jobs-pr1-*.md` | 本轮开发与验证记录 |
+
+## Design
+
+### Storage
+
+表名：`plugin_attendance_report_sync_jobs`。
+
+它是控制面 / 运营状态表，不是考勤事实表，不被查询 / 导出读取。表内只保存：
+
+- `kind`: `daily_records` / `period_summaries`
+- `status`: `queued` / `running` / `paused` / `completed` / `failed` / `canceled`
+- `mode`: `manual_step` / `enqueue`
+- `period_source`: `{ from, to }` 或 `{ cycleId }`
+- `user_selection`: `{ userId }` / `{ userIds }` / `{ allUsers: true }`
+- `cursor`, `totals`, `last_result`, `error`, lock 与时间戳
+
+### Helpers
+
+新增 helper 只做三件事：
+
+- Normalize: 校验 `kind`、`periodSource`、`userSelection`、`mode`、`pageSize`。
+- Projection: DB row 映射成 API-friendly job object。
+- Persistence skeleton: `createAttendanceReportSyncJob()` / `loadAttendanceReportSyncJob()`。
+
+PR2 runner 会在这些 helper 之上增加 route、lock transition、run-next-page，并委托现有 writer：
+
+- daily: `syncAttendanceReportRecordsForUsers()`
+- period: `syncAttendanceReportPeriodSummariesForUsers()`
+
+## Boundaries
+
+- 不直接写 `meta_*`。
+- 不新增 `attendance_*` fact migration。
+- 不把 job row 当作 report/fact source。
+- 不复写 daily / period report statistics。
+- 不移除 immediate sync endpoints / UI。
+- 不写 staging / production。
+
+## Claude
+
+本轮无需 Claude 开发。若 PR1 需要二审，Claude 适合按 report sync governance 做 independent review。

--- a/docs/development/attendance-report-sync-jobs-pr1-verification-20260519.md
+++ b/docs/development/attendance-report-sync-jobs-pr1-verification-20260519.md
@@ -1,0 +1,63 @@
+# 考勤报表同步任务化 PR1 验证记录
+
+Date: 2026-05-19
+
+## Scope
+
+验证 PR1 的 schema + helper skeleton。
+
+不验证 runner、route、UI、live staging，因为本轮没有实现这些能力。
+
+## Local Checks
+
+| Check | Result |
+| --- | --- |
+| `node --check plugins/plugin-attendance/index.cjs` | PASS |
+| `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-report-field-catalog.test.ts --reporter=dot` | PASS, 27 tests |
+| `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-report-field-catalog.test.ts tests/unit/attendance-report-field-formula-engine.test.ts --reporter=dot` | PASS, 51 tests |
+| `pnpm --filter @metasheet/core-backend build` | PASS |
+| `git diff --check` | 待最终执行 |
+| staged secret scan | 待最终执行 |
+
+`pnpm install --ignore-scripts` was run in the isolated worktree to hydrate local test dependencies. It produced unrelated tracked `node_modules` symlink noise under plugin/tool packages; those paths are intentionally left unstaged and excluded from this slice.
+
+## Unit Coverage Added
+
+- Migration source includes:
+  - `plugin_attendance_report_sync_jobs`
+  - `kind/status/mode` check constraints
+  - `period_source/user_selection/cursor/totals` JSONB state
+  - idempotency unique index
+  - no accidental `attendance_report_sync_jobs` fact-like table name
+- Create input normalization:
+  - date range job
+  - payroll cycle job
+  - `pageSize` max clamp
+  - `userIds` dedupe
+  - invalid kind
+  - cycleId plus from/to rejection
+  - ambiguous user selection rejection
+- Persistence helper skeleton:
+  - build insert row
+  - map DB row
+  - create job inserts JSONB payloads
+  - load job scopes by `org_id`
+  - invalid job id returns validation error
+
+## Deferred Checks
+
+These belong to PR2 runner/routes:
+
+- lock transition and stale-lock resume
+- `run-next-page`
+- daily writer delegation
+- period writer delegation
+- degraded writer marks job failed
+- cancel/completed terminal behavior
+
+## Boundary Verification
+
+- No `meta_*` SQL writes added.
+- No `attendance_*` fact schema migration added.
+- No route / frontend / live script changed.
+- Token and staging output are not committed.

--- a/docs/development/attendance-report-sync-jobs-todo-20260519.md
+++ b/docs/development/attendance-report-sync-jobs-todo-20260519.md
@@ -40,6 +40,7 @@ plugin_attendance_report_sync_jobs
 | `org_id` | text | tenant |
 | `kind` | text | `daily_records` / `period_summaries` |
 | `status` | text | `queued` / `running` / `paused` / `completed` / `failed` / `canceled` |
+| `mode` | text | `manual_step` / `enqueue` |
 | `created_by` | text | requester |
 | `period_source` | jsonb | `{from,to}` or `{cycleId}` |
 | `user_selection` | jsonb | `{userId}` / `{userIds}` / `{allUsers:true}` |
@@ -57,7 +58,7 @@ Indexes:
 
 - `(org_id, status, updated_at desc)`
 - `(org_id, created_at desc)`
-- optional unique `(org_id, idempotency_key)` if PR1 includes idempotency.
+- unique `(org_id, idempotency_key)` where `idempotency_key IS NOT NULL`.
 
 ### New APIs
 
@@ -176,16 +177,19 @@ Rules:
 
 ### PR1: Schema + Service Helpers
 
-- Add migration for `plugin_attendance_report_sync_jobs`.
-- Add helper functions inside attendance plugin:
+- [x] Add migration for `plugin_attendance_report_sync_jobs`.
+- [x] Add helper functions inside attendance plugin:
   - normalize job body
   - map job row
   - create job
   - load job
-  - update job progress
-  - validate transition
-- Add tests for schema-independent helpers and route body validation where possible.
-- No runner loop, no UI.
+  - initial cursor / totals skeleton
+- [x] Add tests for schema-independent helpers and migration source checks.
+- [x] No runner loop, no route, no UI.
+
+**PR1 implementation pointer:** `docs/development/attendance-report-sync-jobs-pr1-development-20260519.md`; verification: `docs/development/attendance-report-sync-jobs-pr1-verification-20260519.md`.
+
+**Deferred from PR1 to PR2:** update job progress, lock/transition validation, route validation and one-page runner. PR1 intentionally ships only storage + normalization + create/load helper skeleton so the runner PR can stay focused.
 
 ### PR2: Runner + Routes
 

--- a/packages/core-backend/src/db/migrations/zzzz20260519070000_create_plugin_attendance_report_sync_jobs.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260519070000_create_plugin_attendance_report_sync_jobs.ts
@@ -1,0 +1,76 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+import { checkTableExists, createIndexIfNotExists } from './_patterns'
+
+/**
+ * Operational cursor/progress state for attendance report multitable sync jobs.
+ *
+ * This table is not an attendance fact source and is not read by attendance
+ * query/export paths. It only lets the attendance plugin resume/cancel paged
+ * syncs into private report multitable objects.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`CREATE EXTENSION IF NOT EXISTS pgcrypto`.execute(db)
+
+  const exists = await checkTableExists(db, 'plugin_attendance_report_sync_jobs')
+  if (!exists) {
+    await db.schema
+      .createTable('plugin_attendance_report_sync_jobs')
+      .ifNotExists()
+      .addColumn('id', 'uuid', (col) => col.primaryKey().defaultTo(sql`gen_random_uuid()`))
+      .addColumn('org_id', 'text', (col) => col.notNull())
+      .addColumn('kind', 'varchar(32)', (col) => col.notNull())
+      .addColumn('status', 'varchar(20)', (col) => col.notNull().defaultTo('queued'))
+      .addColumn('mode', 'varchar(20)', (col) => col.notNull().defaultTo('manual_step'))
+      .addColumn('created_by', 'text')
+      .addColumn('period_source', 'jsonb', (col) => col.notNull().defaultTo(sql`'{}'::jsonb`))
+      .addColumn('user_selection', 'jsonb', (col) => col.notNull().defaultTo(sql`'{}'::jsonb`))
+      .addColumn('cursor', 'jsonb', (col) => col.notNull().defaultTo(sql`'{}'::jsonb`))
+      .addColumn('totals', 'jsonb', (col) => col.notNull().defaultTo(sql`'{}'::jsonb`))
+      .addColumn('last_result', 'jsonb', (col) => col.notNull().defaultTo(sql`'{}'::jsonb`))
+      .addColumn('error', 'text')
+      .addColumn('idempotency_key', 'text')
+      .addColumn('locked_at', 'timestamptz')
+      .addColumn('started_at', 'timestamptz')
+      .addColumn('finished_at', 'timestamptz')
+      .addColumn('created_at', 'timestamptz', (col) => col.notNull().defaultTo(sql`now()`))
+      .addColumn('updated_at', 'timestamptz', (col) => col.notNull().defaultTo(sql`now()`))
+      .addCheckConstraint(
+        'chk_plugin_attendance_report_sync_jobs_kind',
+        sql`kind IN ('daily_records', 'period_summaries')`,
+      )
+      .addCheckConstraint(
+        'chk_plugin_attendance_report_sync_jobs_status',
+        sql`status IN ('queued', 'running', 'paused', 'completed', 'failed', 'canceled')`,
+      )
+      .addCheckConstraint(
+        'chk_plugin_attendance_report_sync_jobs_mode',
+        sql`mode IN ('manual_step', 'enqueue')`,
+      )
+      .execute()
+  }
+
+  await createIndexIfNotExists(
+    db,
+    'idx_plugin_attendance_report_sync_jobs_org_status_updated',
+    'plugin_attendance_report_sync_jobs',
+    ['org_id', 'status', 'updated_at'],
+  )
+  await createIndexIfNotExists(
+    db,
+    'idx_plugin_attendance_report_sync_jobs_org_created',
+    'plugin_attendance_report_sync_jobs',
+    ['org_id', 'created_at'],
+  )
+
+  await sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS uq_plugin_attendance_report_sync_jobs_idempotency
+    ON plugin_attendance_report_sync_jobs(org_id, idempotency_key)
+    WHERE idempotency_key IS NOT NULL
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP INDEX IF EXISTS uq_plugin_attendance_report_sync_jobs_idempotency`.execute(db)
+  await db.schema.dropTable('plugin_attendance_report_sync_jobs').ifExists().cascade().execute()
+}

--- a/packages/core-backend/tests/unit/attendance-report-field-catalog.test.ts
+++ b/packages/core-backend/tests/unit/attendance-report-field-catalog.test.ts
@@ -1733,6 +1733,203 @@ describe('attendance report field catalog multitable foundation', () => {
     ])
   })
 
+  it('report sync jobs: migration defines an operational control-plane table', () => {
+    const source = readFileSync(
+      new URL('../../src/db/migrations/zzzz20260519070000_create_plugin_attendance_report_sync_jobs.ts', import.meta.url),
+      'utf8',
+    )
+
+    expect(source).toContain("checkTableExists(db, 'plugin_attendance_report_sync_jobs')")
+    expect(source).toContain(".addColumn('kind', 'varchar(32)'")
+    expect(source).toContain(".addColumn('status', 'varchar(20)'")
+    expect(source).toContain(".addColumn('mode', 'varchar(20)'")
+    expect(source).toContain(".addColumn('period_source', 'jsonb'")
+    expect(source).toContain(".addColumn('user_selection', 'jsonb'")
+    expect(source).toContain(".addColumn('cursor', 'jsonb'")
+    expect(source).toContain(".addColumn('totals', 'jsonb'")
+    expect(source).toContain('chk_plugin_attendance_report_sync_jobs_kind')
+    expect(source).toContain('chk_plugin_attendance_report_sync_jobs_status')
+    expect(source).toContain('uq_plugin_attendance_report_sync_jobs_idempotency')
+    expect(source).toContain('Operational cursor/progress state')
+    expect(source).not.toContain("createTable('attendance_report_sync_jobs')")
+  })
+
+  it('report sync jobs: normalizes create input and rejects ambiguous selections', () => {
+    const range = helpers.normalizeAttendanceReportSyncJobCreateInput({
+      kind: 'daily_records',
+      periodSource: { from: '2026-05-01', to: '2026-05-31' },
+      userSelection: { allUsers: true },
+      pageSize: 500,
+      mode: 'manual_step',
+      idempotencyKey: 'daily-may',
+    })
+    expect(range).toMatchObject({
+      ok: true,
+      value: {
+        kind: 'daily_records',
+        mode: 'manual_step',
+        periodType: 'date_range',
+        periodSource: { from: '2026-05-01', to: '2026-05-31' },
+        userSelection: { allUsers: true },
+        selectionType: 'allUsers',
+        idempotencyKey: 'daily-may',
+      },
+    })
+    expect(range.value.cursor).toEqual({ nextPage: 1, pageSize: 100, hasNextPage: true })
+    expect(range.value.totals).toMatchObject({ usersScanned: 0, synced: 0, duplicateRowKeys: 0 })
+
+    const cycleId = '11111111-1111-4111-8111-111111111111'
+    const cycle = helpers.normalizeAttendanceReportSyncJobCreateInput({
+      kind: 'period_summaries',
+      periodSource: { cycleId },
+      userSelection: { userIds: ['u-1', ' u-1 ', 'u-2', ''] },
+      mode: 'enqueue',
+    })
+    expect(cycle).toMatchObject({
+      ok: true,
+      value: {
+        kind: 'period_summaries',
+        mode: 'enqueue',
+        periodType: 'payroll_cycle',
+        periodSource: { cycleId },
+        userSelection: { userIds: ['u-1', 'u-2'] },
+        selectionType: 'userIds',
+      },
+    })
+
+    expect(helpers.normalizeAttendanceReportSyncJobCreateInput({
+      kind: 'bad',
+      periodSource: { from: '2026-05-01', to: '2026-05-31' },
+      userSelection: { allUsers: true },
+    })).toMatchObject({ ok: false, status: 400 })
+    expect(helpers.normalizeAttendanceReportSyncJobCreateInput({
+      kind: 'daily_records',
+      periodSource: { cycleId, from: '2026-05-01', to: '2026-05-31' },
+      userSelection: { allUsers: true },
+    })).toMatchObject({ ok: false, status: 400, message: 'Use either cycleId or from/to, not both' })
+    expect(helpers.normalizeAttendanceReportSyncJobCreateInput({
+      kind: 'daily_records',
+      periodSource: { from: '2026-05-01', to: '2026-05-31' },
+      userSelection: { allUsers: true, userId: 'u-1' },
+    })).toMatchObject({ ok: false, status: 400, message: 'Choose exactly one of userId, userIds, or allUsers' })
+  })
+
+  it('report sync jobs: builds rows, maps rows, creates jobs, and loads by org', async () => {
+    const built = helpers.buildAttendanceReportSyncJobInsertRow('org-1', 'admin-1', {
+      kind: 'daily_records',
+      periodSource: { from: '2026-05-01', to: '2026-05-31' },
+      userSelection: { userId: 'u-1' },
+      idempotencyKey: 'once',
+    })
+    expect(built).toMatchObject({
+      ok: true,
+      value: {
+        orgId: 'org-1',
+        kind: 'daily_records',
+        status: 'queued',
+        mode: 'manual_step',
+        createdBy: 'admin-1',
+        periodSource: { from: '2026-05-01', to: '2026-05-31' },
+        userSelection: { userId: 'u-1' },
+        lastResult: {},
+        error: null,
+        idempotencyKey: 'once',
+      },
+    })
+
+    const now = new Date('2026-05-19T01:02:03.000Z')
+    const mapped = helpers.mapAttendanceReportSyncJobRow({
+      id: '11111111-1111-4111-8111-111111111111',
+      org_id: 'org-1',
+      kind: 'period_summaries',
+      status: 'failed',
+      mode: 'enqueue',
+      created_by: 'admin-1',
+      period_source: { cycleId: '22222222-2222-4222-8222-222222222222' },
+      user_selection: { allUsers: true },
+      cursor: { nextPage: 3, pageSize: 50, hasNextPage: true },
+      totals: { usersScanned: 100, synced: 80 },
+      last_result: { synced: 50 },
+      error: 'boom',
+      idempotency_key: 'cycle-sync',
+      locked_at: now,
+      started_at: now,
+      finished_at: null,
+      created_at: now,
+      updated_at: now,
+    })
+    expect(mapped).toMatchObject({
+      id: '11111111-1111-4111-8111-111111111111',
+      orgId: 'org-1',
+      kind: 'period_summaries',
+      status: 'failed',
+      mode: 'enqueue',
+      createdBy: 'admin-1',
+      periodSource: { cycleId: '22222222-2222-4222-8222-222222222222' },
+      userSelection: { allUsers: true },
+      cursor: { nextPage: 3, pageSize: 50, hasNextPage: true },
+      totals: { usersScanned: 100, usersSynced: 0, synced: 80, duplicateRowKeys: 0 },
+      lastResult: { synced: 50 },
+      error: 'boom',
+      idempotencyKey: 'cycle-sync',
+      lockedAt: '2026-05-19T01:02:03.000Z',
+    })
+
+    const insertedRow = {
+      id: '33333333-3333-4333-8333-333333333333',
+      org_id: 'org-1',
+      kind: 'daily_records',
+      status: 'queued',
+      mode: 'manual_step',
+      created_by: 'admin-1',
+      period_source: { from: '2026-05-01', to: '2026-05-31' },
+      user_selection: { userId: 'u-1' },
+      cursor: { nextPage: 1, pageSize: 50, hasNextPage: true },
+      totals: {},
+      last_result: {},
+      error: null,
+      idempotency_key: null,
+      created_at: now,
+      updated_at: now,
+    }
+    const db = {
+      query: vi.fn(async (sql: string, params?: unknown[]) => {
+        if (/INSERT INTO plugin_attendance_report_sync_jobs/.test(sql)) {
+          expect(params?.[0]).toBe('org-1')
+          expect(params?.[1]).toBe('daily_records')
+          expect(params?.[3]).toBe('manual_step')
+          expect(JSON.parse(String(params?.[5]))).toEqual({ from: '2026-05-01', to: '2026-05-31' })
+          return [insertedRow]
+        }
+        if (/SELECT \* FROM plugin_attendance_report_sync_jobs/.test(sql)) {
+          expect(params).toEqual(['33333333-3333-4333-8333-333333333333', 'org-1'])
+          return [insertedRow]
+        }
+        return []
+      }),
+    }
+
+    const created = await helpers.createAttendanceReportSyncJob(db, 'org-1', 'admin-1', {
+      kind: 'daily_records',
+      periodSource: { from: '2026-05-01', to: '2026-05-31' },
+      userSelection: { userId: 'u-1' },
+    })
+    expect(created).toMatchObject({
+      ok: true,
+      status: 201,
+      job: {
+        id: '33333333-3333-4333-8333-333333333333',
+        orgId: 'org-1',
+        kind: 'daily_records',
+        status: 'queued',
+      },
+    })
+    const loaded = await helpers.loadAttendanceReportSyncJob(db, 'org-1', '33333333-3333-4333-8333-333333333333')
+    expect(loaded).toMatchObject({ ok: true, job: { id: '33333333-3333-4333-8333-333333333333' } })
+    expect(await helpers.loadAttendanceReportSyncJob(db, 'org-1', 'not-a-uuid'))
+      .toMatchObject({ ok: false, status: 400 })
+  })
+
   it('does not add direct meta table writes to the attendance plugin', () => {
     const source = readFileSync(
       new URL('../../../../plugins/plugin-attendance/index.cjs', import.meta.url),

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -2639,6 +2639,246 @@ async function syncAttendanceReportRecordsForUsers(context, db, orgId, logger, p
   return aggregate
 }
 
+// ── attendance report sync job control plane (PR1: schema + helper skeleton only) ──
+// The job row is operational cursor/progress state. It never becomes a report
+// fact source; PR2 runner must delegate page work to the existing daily/period
+// sync writers above instead of duplicating statistics or multitable upsert logic.
+const ATTENDANCE_REPORT_SYNC_JOB_TABLE = 'plugin_attendance_report_sync_jobs'
+const ATTENDANCE_REPORT_SYNC_JOB_KINDS = Object.freeze(['daily_records', 'period_summaries'])
+const ATTENDANCE_REPORT_SYNC_JOB_STATUSES = Object.freeze(['queued', 'running', 'paused', 'completed', 'failed', 'canceled'])
+const ATTENDANCE_REPORT_SYNC_JOB_MODES = Object.freeze(['manual_step', 'enqueue'])
+
+function createAttendanceReportSyncJobValidationError(message, code = 'VALIDATION_ERROR') {
+  return { ok: false, status: 400, code, message }
+}
+
+function normalizeAttendanceReportSyncJobKind(value) {
+  const kind = normalizeCatalogString(value)
+  return ATTENDANCE_REPORT_SYNC_JOB_KINDS.includes(kind) ? kind : null
+}
+
+function normalizeAttendanceReportSyncJobStatus(value) {
+  const status = normalizeCatalogString(value, 'queued')
+  return ATTENDANCE_REPORT_SYNC_JOB_STATUSES.includes(status) ? status : 'queued'
+}
+
+function normalizeAttendanceReportSyncJobMode(value) {
+  const mode = normalizeCatalogString(value, 'manual_step')
+  return ATTENDANCE_REPORT_SYNC_JOB_MODES.includes(mode) ? mode : null
+}
+
+function normalizeAttendanceReportSyncJobPeriodSource(value = {}) {
+  const source = normalizeMetadata(value)
+  const cycleIdInput = normalizeCatalogString(source.cycleId)
+  const hasCycleId = Boolean(cycleIdInput)
+  const hasFrom = source.from !== undefined && normalizeCatalogString(source.from) !== ''
+  const hasTo = source.to !== undefined && normalizeCatalogString(source.to) !== ''
+  if (hasCycleId && (hasFrom || hasTo)) {
+    return createAttendanceReportSyncJobValidationError('Use either cycleId or from/to, not both')
+  }
+  if (hasCycleId) {
+    const cycleId = normalizeUuidString(cycleIdInput)
+    if (!cycleId) {
+      return createAttendanceReportSyncJobValidationError('Invalid cycleId')
+    }
+    return { ok: true, value: { cycleId }, periodType: 'payroll_cycle' }
+  }
+  if (!hasFrom && !hasTo) {
+    return createAttendanceReportSyncJobValidationError('periodSource.cycleId or periodSource.from/to is required')
+  }
+  if (!hasFrom || !hasTo) {
+    return createAttendanceReportSyncJobValidationError('Both periodSource.from and periodSource.to are required')
+  }
+  const dateRange = resolveAttendanceDateRange(source.from, source.to)
+  if (!dateRange.ok) {
+    return createAttendanceReportSyncJobValidationError(dateRange.message)
+  }
+  return {
+    ok: true,
+    value: { from: dateRange.from, to: dateRange.to },
+    periodType: 'date_range',
+  }
+}
+
+function normalizeAttendanceReportSyncJobUserSelection(value = {}) {
+  const source = normalizeMetadata(value)
+  const allUsers = source.allUsers === true || String(source.allUsers ?? '').trim().toLowerCase() === 'true'
+  const userId = normalizeCatalogString(source.userId)
+  const userIds = normalizeAttendanceReportRecordsSyncUserIds(source.userIds)
+  const selectedCount = (allUsers ? 1 : 0) + (userId ? 1 : 0) + (userIds.length > 0 ? 1 : 0)
+  if (selectedCount !== 1) {
+    return createAttendanceReportSyncJobValidationError('Choose exactly one of userId, userIds, or allUsers')
+  }
+  if (allUsers) return { ok: true, value: { allUsers: true }, selectionType: 'allUsers' }
+  if (userId) return { ok: true, value: { userId }, selectionType: 'userId' }
+  return { ok: true, value: { userIds }, selectionType: 'userIds' }
+}
+
+function createAttendanceReportSyncJobEmptyTotals() {
+  return {
+    usersScanned: 0,
+    usersSynced: 0,
+    usersFailed: 0,
+    synced: 0,
+    rowsSynced: 0,
+    created: 0,
+    patched: 0,
+    skipped: 0,
+    failed: 0,
+    duplicateRowKeys: 0,
+  }
+}
+
+function createAttendanceReportSyncJobInitialCursor(pageSize) {
+  const normalized = normalizeAttendanceReportRecordsSyncPage(1, pageSize)
+  return {
+    nextPage: 1,
+    pageSize: normalized.pageSize,
+    hasNextPage: true,
+  }
+}
+
+function normalizeAttendanceReportSyncJobCreateInput(input = {}) {
+  const raw = normalizeMetadata(input)
+  const kind = normalizeAttendanceReportSyncJobKind(raw.kind)
+  if (!kind) {
+    return createAttendanceReportSyncJobValidationError('kind must be daily_records or period_summaries')
+  }
+  const periodSource = normalizeAttendanceReportSyncJobPeriodSource(raw.periodSource ?? raw)
+  if (!periodSource.ok) return periodSource
+  const userSelection = normalizeAttendanceReportSyncJobUserSelection(raw.userSelection ?? raw)
+  if (!userSelection.ok) return userSelection
+  const mode = normalizeAttendanceReportSyncJobMode(raw.mode)
+  if (!mode) {
+    return createAttendanceReportSyncJobValidationError('mode must be manual_step or enqueue')
+  }
+  const page = normalizeAttendanceReportRecordsSyncPage(1, raw.pageSize)
+  const idempotencyKey = normalizeCatalogString(raw.idempotencyKey)
+  return {
+    ok: true,
+    value: {
+      kind,
+      mode,
+      periodSource: periodSource.value,
+      periodType: periodSource.periodType,
+      userSelection: userSelection.value,
+      selectionType: userSelection.selectionType,
+      cursor: createAttendanceReportSyncJobInitialCursor(page.pageSize),
+      totals: createAttendanceReportSyncJobEmptyTotals(),
+      idempotencyKey: idempotencyKey || null,
+    },
+  }
+}
+
+function buildAttendanceReportSyncJobInsertRow(orgId, createdBy, input = {}) {
+  const parsed = normalizeAttendanceReportSyncJobCreateInput(input)
+  if (!parsed.ok) return parsed
+  const createdByText = normalizeCatalogString(createdBy)
+  return {
+    ok: true,
+    value: {
+      orgId: normalizeAttendanceReportFieldOrgId(orgId),
+      kind: parsed.value.kind,
+      status: 'queued',
+      createdBy: createdByText || null,
+      periodSource: parsed.value.periodSource,
+      userSelection: parsed.value.userSelection,
+      cursor: parsed.value.cursor,
+      totals: parsed.value.totals,
+      lastResult: {},
+      error: null,
+      idempotencyKey: parsed.value.idempotencyKey,
+      mode: parsed.value.mode,
+      periodType: parsed.value.periodType,
+      selectionType: parsed.value.selectionType,
+    },
+  }
+}
+
+function normalizeAttendanceReportSyncJobJson(value, fallback = {}) {
+  const normalized = normalizeMetadata(value)
+  return Object.keys(normalized).length > 0 ? normalized : fallback
+}
+
+function normalizeAttendanceReportSyncJobTimestamp(value) {
+  if (!value) return null
+  if (value instanceof Date) return value.toISOString()
+  const text = String(value)
+  const date = new Date(text)
+  return Number.isNaN(date.getTime()) ? text : date.toISOString()
+}
+
+function mapAttendanceReportSyncJobRow(row = {}) {
+  if (!row || typeof row !== 'object') return null
+  return {
+    id: row.id ? String(row.id) : null,
+    orgId: normalizeAttendanceReportFieldOrgId(row.org_id),
+    kind: normalizeAttendanceReportSyncJobKind(row.kind) || 'daily_records',
+    status: normalizeAttendanceReportSyncJobStatus(row.status),
+    mode: normalizeAttendanceReportSyncJobMode(row.mode) || 'manual_step',
+    createdBy: normalizeCatalogString(row.created_by) || null,
+    periodSource: normalizeAttendanceReportSyncJobJson(row.period_source),
+    userSelection: normalizeAttendanceReportSyncJobJson(row.user_selection),
+    cursor: normalizeAttendanceReportSyncJobJson(row.cursor, createAttendanceReportSyncJobInitialCursor()),
+    totals: {
+      ...createAttendanceReportSyncJobEmptyTotals(),
+      ...normalizeAttendanceReportSyncJobJson(row.totals),
+    },
+    lastResult: normalizeAttendanceReportSyncJobJson(row.last_result),
+    error: row.error == null ? null : String(row.error),
+    idempotencyKey: normalizeCatalogString(row.idempotency_key) || null,
+    lockedAt: normalizeAttendanceReportSyncJobTimestamp(row.locked_at),
+    startedAt: normalizeAttendanceReportSyncJobTimestamp(row.started_at),
+    finishedAt: normalizeAttendanceReportSyncJobTimestamp(row.finished_at),
+    createdAt: normalizeAttendanceReportSyncJobTimestamp(row.created_at),
+    updatedAt: normalizeAttendanceReportSyncJobTimestamp(row.updated_at),
+  }
+}
+
+async function createAttendanceReportSyncJob(db, orgId, createdBy, input = {}) {
+  const built = buildAttendanceReportSyncJobInsertRow(orgId, createdBy, input)
+  if (!built.ok) return built
+  const row = built.value
+  const rows = await db.query(
+    `INSERT INTO ${ATTENDANCE_REPORT_SYNC_JOB_TABLE}
+      (org_id, kind, status, mode, created_by, period_source, user_selection, cursor, totals, last_result, error, idempotency_key)
+     VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7::jsonb, $8::jsonb, $9::jsonb, $10::jsonb, $11, $12)
+     RETURNING *`,
+    [
+      row.orgId,
+      row.kind,
+      row.status,
+      row.mode,
+      row.createdBy,
+      JSON.stringify(row.periodSource),
+      JSON.stringify(row.userSelection),
+      JSON.stringify(row.cursor),
+      JSON.stringify(row.totals),
+      JSON.stringify(row.lastResult),
+      row.error,
+      row.idempotencyKey,
+    ],
+  )
+  return { ok: true, status: 201, job: mapAttendanceReportSyncJobRow(rows[0]) }
+}
+
+async function loadAttendanceReportSyncJob(db, orgId, jobId) {
+  const id = normalizeUuidString(jobId)
+  if (!id) {
+    return { ok: false, status: 400, code: 'VALIDATION_ERROR', message: 'Invalid job id' }
+  }
+  const rows = await db.query(
+    `SELECT * FROM ${ATTENDANCE_REPORT_SYNC_JOB_TABLE}
+     WHERE id = $1 AND org_id = $2
+     LIMIT 1`,
+    [id, normalizeAttendanceReportFieldOrgId(orgId)],
+  )
+  if (!rows.length) {
+    return { ok: false, status: 404, code: 'NOT_FOUND', message: 'Attendance report sync job not found' }
+  }
+  return { ok: true, job: mapAttendanceReportSyncJobRow(rows[0]) }
+}
+
 function resolveAttendanceReportPeriodSummaryManagedFormulaFields(items) {
   return (Array.isArray(items) ? items : [])
     .filter(field => (
@@ -11142,6 +11382,18 @@ module.exports = {
     syncAttendanceReportPeriodSummariesForUsers,
     syncAttendanceReportRecords,
     syncAttendanceReportRecordsForUsers,
+    ATTENDANCE_REPORT_SYNC_JOB_TABLE,
+    ATTENDANCE_REPORT_SYNC_JOB_KINDS,
+    ATTENDANCE_REPORT_SYNC_JOB_STATUSES,
+    normalizeAttendanceReportSyncJobCreateInput,
+    normalizeAttendanceReportSyncJobPeriodSource,
+    normalizeAttendanceReportSyncJobUserSelection,
+    createAttendanceReportSyncJobEmptyTotals,
+    createAttendanceReportSyncJobInitialCursor,
+    buildAttendanceReportSyncJobInsertRow,
+    mapAttendanceReportSyncJobRow,
+    createAttendanceReportSyncJob,
+    loadAttendanceReportSyncJob,
     normalizeAttendanceReportRecordsSyncUserIds,
     normalizeAttendanceReportRecordsSyncPage,
     loadAttendanceReportRecordsSyncUserPage,


### PR DESCRIPTION
## Summary

Adds PR1 for the attendance report sync job runner plan: an operational SQL state table plus helper skeletons for future daily/period paged sync jobs.

This does **not** add runner routes, frontend UI, live writes, or new report behavior. Existing immediate daily and period sync endpoints remain unchanged.

## Changes

- Add modern Kysely migration for `plugin_attendance_report_sync_jobs`
  - `kind`: `daily_records` / `period_summaries`
  - `status`: `queued` / `running` / `paused` / `completed` / `failed` / `canceled`
  - `mode`: `manual_step` / `enqueue`
  - JSONB state: `period_source`, `user_selection`, `cursor`, `totals`, `last_result`
  - idempotency unique index per org
- Add attendance plugin helper skeletons:
  - normalize create input
  - build insert row
  - map DB row
  - create/load job helpers
- Update the sync-jobs TODO with PR1 pointers
- Add development and verification MD

## Boundaries

- No route / runner / UI in this PR
- No direct `meta_*` writes
- No new attendance fact migration
- Job rows are operational state only, not report/fact source
- Future runner must delegate to existing daily / period sync writers

## Validation

- [x] `node --check plugins/plugin-attendance/index.cjs`
- [x] `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-report-field-catalog.test.ts --reporter=dot` — 27 tests
- [x] `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-report-field-catalog.test.ts tests/unit/attendance-report-field-formula-engine.test.ts --reporter=dot` — 51 tests
- [x] `pnpm --filter @metasheet/core-backend build`
- [x] staged boundary: 6 files, no `node_modules`

Note: `pnpm install --ignore-scripts` was run in the isolated worktree to hydrate dependencies and produced tracked `node_modules` symlink noise. It is intentionally unstaged and not part of the commit.
