### PR TITLE
fix(onprem): bound dependency refresh diagnostics

### DIFF
--- a/docs/deployment/multitable-onprem-package-layout-20260319.md
+++ b/docs/deployment/multitable-onprem-package-layout-20260319.md
@@ -170,4 +170,12 @@ rerolls safe when the deploy root already has `node_modules` but the new package
 adds a workspace runtime dependency. Manual file-copy deployments must run the
 same command before migrations, PM2 restart, or admin bootstrap.
 
+On Windows, dependency refresh is a logged child process. The apply helper logs
+the resolved `pnpm` path/version, writes stdout/stderr to
+`output\logs\dependency-refresh-*.stdout.log` and
+`output\logs\dependency-refresh-*.stderr.log`, emits heartbeat progress while
+the install is still running, and fails the deployment after the configured
+timeout instead of hanging forever. Defaults are
+`DependencyRefreshTimeoutSec=1800` and `DependencyRefreshHeartbeatSec=60`.
+
 For a fresh Windows-only install, use `bootstrap-admin.bat` after `deploy.bat` so the customer can create the first admin account without needing bash or WSL.

--- a/docs/deployment/multitable-windows-onprem-easy-start-20260319.md
+++ b/docs/deployment/multitable-windows-onprem-easy-start-20260319.md
@@ -282,6 +282,21 @@ before migrations, PM2 restart, or `bootstrap-admin.bat`:
 pnpm install --frozen-lockfile
 ```
 
+The Windows apply helper runs that dependency refresh with diagnostics rather
+than as an unbounded silent command:
+
+- default timeout: 1800 seconds;
+- default heartbeat: 60 seconds;
+- stdout/stderr logs: `output\logs\dependency-refresh-*.stdout.log` and
+  `output\logs\dependency-refresh-*.stderr.log`;
+- tunables for exceptional hosts:
+  `-DependencyRefreshTimeoutSec <seconds>` and
+  `-DependencyRefreshHeartbeatSec <seconds>`.
+
+If a scheduled deployment appears stuck at dependency refresh, inspect
+`output\logs\deploy-remote.log` plus the two `dependency-refresh-*` logs before
+rerunning. A timeout is a deploy failure, not a valid SQL/K3 runtime test.
+
 The packaged Windows admin bootstrap helper also avoids `node -e` and writes a short-lived `.cjs` file into the package-local `.tmp/node-bootstrap` directory before invoking Node. This sidesteps the Node v24 + Windows PowerShell type-stripping issue and keeps bundled dependencies such as `bcryptjs` resolvable from the packaged app root.
 
 After `deploy.bat` completes on a fresh Windows-only install, create the first admin with:

--- a/docs/development/onprem-package-dependency-refresh-diagnostics-design-20260519.md
+++ b/docs/development/onprem-package-dependency-refresh-diagnostics-design-20260519.md
@@ -1,0 +1,94 @@
+# On-Prem Package Dependency Refresh Diagnostics - Design - 2026-05-19
+
+## Context
+
+Bridge retest after package `k3wise-905d1ea40` confirmed that the package now
+reaches the dependency refresh step during Windows apply:
+
+```text
+Refresh dependencies (pnpm install --frozen-lockfile)
+Scope: all 5 workspace projects
+```
+
+The scheduled deployment task then stayed `Running` and the apply log did not
+advance to migrations, PM2 restart, or final healthcheck. Because the deploy
+never completed, the SQL Server source test could not be used to judge whether
+`SQLSERVER_DRIVER_MISSING` was fixed.
+
+The gap is operational, not K3 runtime logic: dependency refresh was a direct
+PowerShell command with no child-process log paths, heartbeat, elapsed-time
+visibility, or timeout.
+
+## Change
+
+The Windows apply helper now runs dependency refresh through a bounded logged
+child-process wrapper.
+
+Default behavior:
+
+- command: `pnpm install --frozen-lockfile`;
+- timeout: `DependencyRefreshTimeoutSec=1800`;
+- heartbeat: `DependencyRefreshHeartbeatSec=60`;
+- stdout log: `output\logs\dependency-refresh-*.stdout.log`;
+- stderr log: `output\logs\dependency-refresh-*.stderr.log`.
+
+The helper also logs:
+
+- resolved `pnpm` command path;
+- `pnpm --version` when available;
+- working directory;
+- timeout and heartbeat configuration;
+- periodic "still running after ..." messages;
+- exit code and elapsed time;
+- stdout/stderr tail on non-zero exit or timeout.
+
+## Operator Controls
+
+The existing `InstallDeps=0` escape hatch is unchanged for advanced operators
+who deliberately refresh dependencies out of band.
+
+New controls:
+
+```powershell
+-DependencyRefreshTimeoutSec 3600
+-DependencyRefreshHeartbeatSec 30
+```
+
+These are intentionally deploy-helper options only. They do not alter product
+runtime, SQL executor behavior, K3 WebAPI behavior, or database migrations.
+
+## Package Guardrail
+
+`scripts/ops/multitable-onprem-package-verify.sh` now checks that packaged
+Windows apply helpers include:
+
+- dependency timeout option;
+- dependency heartbeat option;
+- dependency refresh stdout/stderr log marker;
+- `pnpm path` and `pnpm version` logging;
+- heartbeat text;
+- timeout failure text.
+
+This makes the packaging path fail if a future change reverts the helper to a
+silent unbounded install.
+
+## Expected Bridge Result
+
+After publishing a package with this change:
+
+1. dependency refresh either completes and deployment proceeds to migrations,
+   restart, and healthcheck;
+2. or dependency refresh times out with enough logs to diagnose path, version,
+   registry, lockfile, permissions, or network issues.
+
+Only after deployment reaches the final healthcheck should the bridge rerun the
+K3 WISE SQL Server source test. A still-running or timed-out dependency refresh
+is a deployment failure, not a valid SQL runtime result.
+
+## Non-Goals
+
+- No SQL executor logic changes.
+- No K3 WebAPI read/list runtime changes.
+- No relationship resolver changes.
+- No K3 Save / Submit / Audit changes.
+- No `node_modules` bundling.

--- a/docs/development/onprem-package-dependency-refresh-diagnostics-verification-20260519.md
+++ b/docs/development/onprem-package-dependency-refresh-diagnostics-verification-20260519.md
@@ -1,0 +1,121 @@
+# On-Prem Package Dependency Refresh Diagnostics - Verification - 2026-05-19
+
+## Issue Evidence
+
+Latest #1526 bridge feedback after package `k3wise-905d1ea40`:
+
+- Windows zip checksum and package metadata were verified on the test host.
+- `PACKAGE-METADATA.json` showed `dependencyInstallMode=refresh-on-apply`.
+- Deploy log reached:
+  - `Refresh dependencies (pnpm install --frozen-lockfile)`;
+  - `Scope: all 5 workspace projects`.
+- The scheduled deployment task stayed `Running`.
+- The apply log did not reach migrations, restart, or healthcheck.
+- SQL Server source retest was blocked because deployment had not finalized.
+
+## Files Changed
+
+- `scripts/ops/multitable-onprem-apply-package.ps1`
+- `scripts/ops/multitable-onprem-package-verify.sh`
+- `docs/deployment/multitable-windows-onprem-easy-start-20260319.md`
+- `docs/deployment/multitable-onprem-package-layout-20260319.md`
+- `docs/operations/integration-k3wise-internal-trial-runbook.md`
+- `docs/operations/integration-k3wise-sql-executor-bridge-handoff.md`
+- `docs/development/onprem-package-dependency-refresh-diagnostics-design-20260519.md`
+- `docs/development/onprem-package-dependency-refresh-diagnostics-verification-20260519.md`
+
+## Assertions
+
+| Area | Assertion |
+| --- | --- |
+| Timeout | Dependency refresh has `DependencyRefreshTimeoutSec`, default `1800`. |
+| Heartbeat | Dependency refresh has `DependencyRefreshHeartbeatSec`, default `60`, and emits "still running after ..." progress. |
+| Logs | Dependency refresh writes `dependency-refresh-*.stdout.log` and `dependency-refresh-*.stderr.log` under `output\logs`. |
+| Command identity | Apply log includes resolved `pnpm` path and `pnpm --version` when available. |
+| Failure mode | Timeout or non-zero exit includes log paths and stdout/stderr tail. |
+| Package verification | Package verifier fails if these diagnostic markers are absent from the packaged PowerShell helper. |
+| Scope | No SQL executor, K3 WebAPI, relationship resolver, DB migration, or real K3 write behavior changes. |
+
+## Local Verification Commands
+
+Executed from branch `codex/onprem-deps-refresh-timeout-20260519`:
+
+| Command | Result |
+| --- | --- |
+| `bash -n scripts/ops/multitable-onprem-package-build.sh` | PASS |
+| `bash -n scripts/ops/multitable-onprem-package-verify.sh` | PASS |
+| marker scan for timeout / heartbeat / logs / pnpm path / pnpm version / timeout text | PASS |
+| `git diff --check` | PASS |
+| `OUTPUT_DIR=/tmp/ms2-onprem-deps-timeout-package PACKAGE_TAG=deps-timeout-smoke INSTALL_DEPS=1 BUILD_WEB=1 BUILD_BACKEND=1 scripts/ops/multitable-onprem-package-build.sh` | PASS |
+| `scripts/ops/multitable-onprem-package-verify.sh /tmp/ms2-onprem-deps-timeout-package/metasheet-multitable-onprem-v2.5.0-deps-timeout-smoke.zip` | PASS |
+| `scripts/ops/multitable-onprem-package-verify.sh /tmp/ms2-onprem-deps-timeout-package/metasheet-multitable-onprem-v2.5.0-deps-timeout-smoke.tgz` | PASS |
+| zip spot-check for packaged PowerShell diagnostic markers | PASS |
+| `node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs` | PASS, 27/27 |
+| `node --test scripts/ops/integration-k3wise-postdeploy-summary.test.mjs` | PASS, 16/16 |
+| `pnpm verify:integration-k3wise:poc` | PASS |
+
+PowerShell parser validation was not run locally because `pwsh` is not
+installed in this macOS Codex environment.
+
+Reproduction commands:
+
+```bash
+bash -n scripts/ops/multitable-onprem-package-verify.sh
+
+rg --fixed-strings 'DependencyRefreshTimeoutSec' scripts/ops/multitable-onprem-apply-package.ps1
+rg --fixed-strings 'DependencyRefreshHeartbeatSec' scripts/ops/multitable-onprem-apply-package.ps1
+rg --fixed-strings 'dependency-refresh-' scripts/ops/multitable-onprem-apply-package.ps1
+rg --fixed-strings 'pnpm path:' scripts/ops/multitable-onprem-apply-package.ps1
+rg --fixed-strings 'pnpm version:' scripts/ops/multitable-onprem-apply-package.ps1
+rg --fixed-strings 'still running after' scripts/ops/multitable-onprem-apply-package.ps1
+rg --fixed-strings 'timed out after' scripts/ops/multitable-onprem-apply-package.ps1
+
+git diff --check origin/main...HEAD
+```
+
+Optional PowerShell syntax check when `pwsh` is available:
+
+```bash
+pwsh -NoProfile -Command \
+  '$null = [scriptblock]::Create((Get-Content -Raw scripts/ops/multitable-onprem-apply-package.ps1)); "syntax-ok"'
+```
+
+Package proof:
+
+```bash
+OUTPUT_DIR=/tmp/ms2-onprem-deps-timeout-package \
+PACKAGE_TAG=deps-timeout-smoke \
+  scripts/ops/multitable-onprem-package-build.sh
+
+scripts/ops/multitable-onprem-package-verify.sh \
+  /tmp/ms2-onprem-deps-timeout-package/metasheet-multitable-onprem-v2.5.0-deps-timeout-smoke.zip
+
+scripts/ops/multitable-onprem-package-verify.sh \
+  /tmp/ms2-onprem-deps-timeout-package/metasheet-multitable-onprem-v2.5.0-deps-timeout-smoke.tgz
+```
+
+The verifier must return `Package verify OK` for both archives.
+
+## Bridge Retest Plan
+
+After merge and package publish:
+
+1. Deploy the new Windows zip with `deploy.bat <package.zip>`.
+2. Confirm apply logs include:
+   - `pnpm path: ...`;
+   - `pnpm version: ...`;
+   - `Refresh dependencies (pnpm install --frozen-lockfile)`;
+   - heartbeat lines if the install runs longer than one heartbeat interval.
+3. If the install is slow, inspect:
+   - `output\logs\dependency-refresh-*.stdout.log`;
+   - `output\logs\dependency-refresh-*.stderr.log`.
+4. Confirm deployment reaches migrations, restart, and healthcheck.
+5. Rerun K3 WISE SQL Server source test.
+
+Expected SQL retest result after a completed deployment:
+
+- no `SQLSERVER_DRIVER_MISSING`;
+- either successful SQL source connection or a concrete SQL Server
+  config/network/auth/schema error.
+
+No real K3 Save / Submit / Audit is part of this verification.

--- a/docs/operations/integration-k3wise-internal-trial-runbook.md
+++ b/docs/operations/integration-k3wise-internal-trial-runbook.md
@@ -172,6 +172,19 @@ non-blocking `sqlserver-executor-availability` check:
   Re-apply the package with `InstallDeps=1` or run
   `pnpm install --frozen-lockfile` from the deploy root before restarting PM2.
 
+If a Windows package apply reaches dependency refresh but does not continue to
+migrations/restart/healthcheck, do not run the SQL source retest yet. Inspect
+`output\logs\deploy-remote.log` and the dependency logs written by the apply
+helper:
+
+- `output\logs\dependency-refresh-*.stdout.log`
+- `output\logs\dependency-refresh-*.stderr.log`
+
+The helper prints the resolved `pnpm` path/version, heartbeat progress, and a
+timeout failure if the install exceeds `DependencyRefreshTimeoutSec` (default
+1800 seconds). A stuck or timed-out dependency refresh is a deployment failure,
+not a valid SQL executor result.
+
 These SQL diagnostic states do not invalidate the #1542 staging-to-K3 metadata
 signoff. They mean direct SQL Server source execution is still blocked.
 Use `metasheet:staging` as the source for Data Factory retests until the package

--- a/docs/operations/integration-k3wise-sql-executor-bridge-handoff.md
+++ b/docs/operations/integration-k3wise-sql-executor-bridge-handoff.md
@@ -179,6 +179,20 @@ If the code is `SQLSERVER_DRIVER_MISSING`, runtime injection is working but the
 deploy root is missing `mssql`. Re-apply the package with `InstallDeps=1` or run
 `pnpm install --frozen-lockfile` from the deploy root, restart PM2, then retest.
 
+If the Windows scheduled deploy task reaches dependency refresh and stays
+running, wait for the apply helper's bounded result instead of treating the
+current service as a retest. The helper now runs dependency refresh as a logged
+child process with:
+
+- resolved `pnpm` path and version in the apply log;
+- heartbeat progress every `DependencyRefreshHeartbeatSec` seconds, default 60;
+- stdout/stderr logs under `output\logs\dependency-refresh-*`;
+- timeout failure after `DependencyRefreshTimeoutSec` seconds, default 1800.
+
+Only rerun the SQL source test after the deploy reaches migrations, restart,
+and healthcheck. If dependency refresh times out, collect
+`deploy-remote.log` plus the matching dependency stdout/stderr logs.
+
 ## What Claude Code Should Do On The Bridge Machine
 
 Claude Code can help on the Windows/K3 bridge machine once it has local access

--- a/scripts/ops/multitable-onprem-apply-package.ps1
+++ b/scripts/ops/multitable-onprem-apply-package.ps1
@@ -11,7 +11,9 @@ param(
   [string]$BuildWeb = '0',
   [string]$BuildBackend = '0',
   [string]$RunMigrations = '1',
-  [string]$RestartService = '1'
+  [string]$RestartService = '1',
+  [string]$DependencyRefreshTimeoutSec = '1800',
+  [string]$DependencyRefreshHeartbeatSec = '60'
 )
 
 $ErrorActionPreference = 'Stop'
@@ -66,6 +68,31 @@ function Require-Command {
   }
 }
 
+function Resolve-CommandPath {
+  param([string]$Name)
+
+  $command = Get-Command $Name -ErrorAction SilentlyContinue | Select-Object -First 1
+  if (-not $command) {
+    throw "Missing required command: $Name"
+  }
+
+  return $command.Source
+}
+
+function Convert-PositiveInt {
+  param(
+    [string]$Value,
+    [string]$Label
+  )
+
+  $parsed = 0
+  if (-not [int]::TryParse($Value, [ref]$parsed) -or $parsed -lt 1) {
+    throw "$Label must be a positive integer: $Value"
+  }
+
+  return $parsed
+}
+
 function Invoke-CheckedCommand {
   param(
     [string]$Description,
@@ -76,6 +103,92 @@ function Invoke-CheckedCommand {
   & $Command
   if ($LASTEXITCODE -ne 0) {
     throw "$Description failed"
+  }
+}
+
+function Write-LogTail {
+  param(
+    [string]$Path,
+    [string]$Label,
+    [int]$LineCount = 20
+  )
+
+  if (-not (Test-Path -LiteralPath $Path)) {
+    Write-Info "$Label log is unavailable: $Path"
+    return
+  }
+
+  Write-Info "$Label log tail ($Path):"
+  Get-Content -LiteralPath $Path -Tail $LineCount | ForEach-Object {
+    Write-Host "  $_"
+  }
+}
+
+function Invoke-LoggedProcess {
+  param(
+    [string]$Description,
+    [string]$FilePath,
+    [string[]]$Arguments,
+    [string]$WorkingDirectory,
+    [string]$LogPrefix,
+    [int]$TimeoutSec,
+    [int]$HeartbeatSec
+  )
+
+  $stdoutLog = "$LogPrefix.stdout.log"
+  $stderrLog = "$LogPrefix.stderr.log"
+  Remove-Item -LiteralPath $stdoutLog, $stderrLog -Force -ErrorAction SilentlyContinue
+
+  Write-Info $Description
+  Write-Info "Command: $FilePath $($Arguments -join ' ')"
+  Write-Info "Working directory: $WorkingDirectory"
+  Write-Info "Timeout: ${TimeoutSec}s; heartbeat: ${HeartbeatSec}s"
+  Write-Info "stdout log: $stdoutLog"
+  Write-Info "stderr log: $stderrLog"
+
+  $process = Start-Process `
+    -FilePath $FilePath `
+    -ArgumentList $Arguments `
+    -WorkingDirectory $WorkingDirectory `
+    -RedirectStandardOutput $stdoutLog `
+    -RedirectStandardError $stderrLog `
+    -PassThru
+
+  $startedAt = Get-Date
+  $nextHeartbeatAt = $startedAt.AddSeconds($HeartbeatSec)
+
+  while (-not $process.HasExited) {
+    Start-Sleep -Seconds 5
+    $now = Get-Date
+    $elapsedSec = [int]($now - $startedAt).TotalSeconds
+
+    if ($elapsedSec -ge $TimeoutSec) {
+      try {
+        $process.Kill()
+      }
+      catch {
+        Write-Info "Failed to kill timed-out process pid=$($process.Id): $($_.Exception.Message)"
+      }
+
+      Write-LogTail -Path $stdoutLog -Label 'stdout'
+      Write-LogTail -Path $stderrLog -Label 'stderr'
+      throw "$Description timed out after ${TimeoutSec}s; inspect logs: $stdoutLog ; $stderrLog"
+    }
+
+    if ($now -ge $nextHeartbeatAt) {
+      Write-Info "$Description still running after ${elapsedSec}s (pid=$($process.Id)); logs: $stdoutLog ; $stderrLog"
+      $nextHeartbeatAt = $now.AddSeconds($HeartbeatSec)
+    }
+  }
+
+  $exitCode = $process.ExitCode
+  $elapsedTotalSec = [int]((Get-Date) - $startedAt).TotalSeconds
+  Write-Info "$Description finished with exit code $exitCode after ${elapsedTotalSec}s"
+
+  if ($exitCode -ne 0) {
+    Write-LogTail -Path $stdoutLog -Label 'stdout'
+    Write-LogTail -Path $stderrLog -Label 'stderr'
+    throw "$Description failed with exit code $exitCode; inspect logs: $stdoutLog ; $stderrLog"
   }
 }
 
@@ -149,12 +262,30 @@ try {
   Set-Location $resolvedRoot
 
   Require-Command -Name 'node'
-  Require-Command -Name 'pnpm'
+  $pnpmPath = Resolve-CommandPath -Name 'pnpm'
 
   if ($InstallDeps -ne '0') {
-    Invoke-CheckedCommand 'Refresh dependencies (pnpm install --frozen-lockfile)' {
-      pnpm install --frozen-lockfile
+    $dependencyTimeoutSec = Convert-PositiveInt -Value $DependencyRefreshTimeoutSec -Label 'DependencyRefreshTimeoutSec'
+    $dependencyHeartbeatSec = Convert-PositiveInt -Value $DependencyRefreshHeartbeatSec -Label 'DependencyRefreshHeartbeatSec'
+    $dependencyLogPrefix = Join-Path $outputLogs ('dependency-refresh-' + (Get-Date -Format 'yyyyMMdd-HHmmss'))
+    Write-Info "pnpm path: $pnpmPath"
+    try {
+      $pnpmVersion = (& $pnpmPath --version 2>$null | Select-Object -First 1)
+      if (-not [string]::IsNullOrWhiteSpace($pnpmVersion)) {
+        Write-Info "pnpm version: $pnpmVersion"
+      }
     }
+    catch {
+      Write-Info "Unable to read pnpm version before dependency refresh: $($_.Exception.Message)"
+    }
+    Invoke-LoggedProcess `
+      -Description 'Refresh dependencies (pnpm install --frozen-lockfile)' `
+      -FilePath $pnpmPath `
+      -Arguments @('install', '--frozen-lockfile') `
+      -WorkingDirectory $resolvedRoot `
+      -LogPrefix $dependencyLogPrefix `
+      -TimeoutSec $dependencyTimeoutSec `
+      -HeartbeatSec $dependencyHeartbeatSec
   }
 
   if ($RunMigrations -ne '0') {

--- a/scripts/ops/multitable-onprem-package-build.sh
+++ b/scripts/ops/multitable-onprem-package-build.sh
@@ -117,6 +117,8 @@ REQUIRED_PATHS=(
   "docs/development/data-factory-sqlserver-readonly-executor-verification-20260519.md"
   "docs/development/onprem-package-dependency-refresh-design-20260519.md"
   "docs/development/onprem-package-dependency-refresh-verification-20260519.md"
+  "docs/development/onprem-package-dependency-refresh-diagnostics-design-20260519.md"
+  "docs/development/onprem-package-dependency-refresh-diagnostics-verification-20260519.md"
   "docs/development/data-factory-readiness-package-verify-delivery-development-20260515.md"
   "docs/development/data-factory-readiness-package-verify-delivery-verification-20260515.md"
   "docs/development/onprem-migration-gap-guard-development-20260514.md"

--- a/scripts/ops/multitable-onprem-package-verify.sh
+++ b/scripts/ops/multitable-onprem-package-verify.sh
@@ -50,6 +50,13 @@ function verify_windows_entrypoints() {
 
   local apply_helper="${root}/scripts/ops/multitable-onprem-apply-package.ps1"
   search_fixed_string 'Refresh dependencies (pnpm install --frozen-lockfile)' "$apply_helper" || die "PowerShell apply helper must refresh dependencies on package apply"
+  search_fixed_string 'DependencyRefreshTimeoutSec' "$apply_helper" || die "PowerShell apply helper must expose dependency refresh timeout"
+  search_fixed_string 'DependencyRefreshHeartbeatSec' "$apply_helper" || die "PowerShell apply helper must expose dependency refresh heartbeat"
+  search_fixed_string 'dependency-refresh-' "$apply_helper" || die "PowerShell apply helper must write dependency refresh stdout/stderr logs"
+  search_fixed_string 'pnpm path:' "$apply_helper" || die "PowerShell apply helper must log pnpm path before dependency refresh"
+  search_fixed_string 'pnpm version:' "$apply_helper" || die "PowerShell apply helper must log pnpm version before dependency refresh"
+  search_fixed_string 'still running after' "$apply_helper" || die "PowerShell apply helper must emit dependency refresh heartbeat progress"
+  search_fixed_string 'timed out after' "$apply_helper" || die "PowerShell apply helper must fail dependency refresh with a timeout"
   if search_fixed_string "-not (Test-Path -LiteralPath (Join-Path \$resolvedRoot 'node_modules'))" "$apply_helper"; then
     die "PowerShell apply helper must not skip dependency refresh just because root node_modules already exists"
   fi


### PR DESCRIPTION
## Summary

Fixes the latest #1526 bridge deployment stall after `k3wise-905d1ea40`: the Windows package apply reached `Refresh dependencies (pnpm install --frozen-lockfile)` and then stayed running without advancing to migrations/restart/healthcheck.

This PR keeps the #1667 refresh-on-apply policy, but makes dependency refresh diagnosable and bounded:

- runs `pnpm install --frozen-lockfile` as a logged child process;
- logs resolved pnpm path and pnpm version;
- writes stdout/stderr to `output\logs\dependency-refresh-*.stdout.log` and `.stderr.log`;
- emits heartbeat progress while still running;
- fails with a timeout instead of hanging forever;
- keeps `InstallDeps=0` as the advanced/manual escape hatch.

## Verification

- `bash -n scripts/ops/multitable-onprem-package-build.sh`
- `bash -n scripts/ops/multitable-onprem-package-verify.sh`
- `git diff --check`
- marker scan for timeout / heartbeat / logs / pnpm path / pnpm version / timeout text
- local package build: `OUTPUT_DIR=/tmp/ms2-onprem-deps-timeout-package PACKAGE_TAG=deps-timeout-smoke scripts/ops/multitable-onprem-package-build.sh`
- package verify OK for generated zip
- package verify OK for generated tgz
- zip spot-check confirms packaged PowerShell diagnostic markers
- `node --test scripts/ops/integration-k3wise-postdeploy-smoke.test.mjs` (27/27)
- `node --test scripts/ops/integration-k3wise-postdeploy-summary.test.mjs` (16/16)
- `pnpm verify:integration-k3wise:poc`

`pwsh` is not installed in this macOS Codex environment, so PowerShell parser validation is documented as a Windows-host optional check in the verification MD.

## Scope

Ops/docs only. No SQL executor logic, K3 WebAPI read/list runtime, relationship resolver, DB migration, or K3 Save/Submit/Audit behavior change.
