### PR TITLE
feat(attendance): add report sync job runner routes

### DIFF
--- a/docs/development/attendance-report-sync-jobs-pr2-development-20260519.md
+++ b/docs/development/attendance-report-sync-jobs-pr2-development-20260519.md
@@ -1,0 +1,120 @@
+# 考勤报表同步任务化 PR2 开发记录
+
+Date: 2026-05-19
+
+## Summary
+
+本轮落地 PR2：在 PR1 的 `plugin_attendance_report_sync_jobs` 表与 helper skeleton 之上，增加管理员 job 控制面和单页 runner。
+
+范围保持在 orchestration 层：
+
+- 新增 create / list / get / run-next-page / cancel 五个 admin API。
+- 新增 lock、cursor、totals、lastResult、cancel 与 terminal guard helper。
+- `run-next-page` 每次只执行一页，daily 委托 `syncAttendanceReportRecordsForUsers()`，period 委托 `syncAttendanceReportPeriodSummariesForUsers()`。
+- 不复制 daily / period 的统计、fingerprint、stale-null、duplicate row_key、多维表 upsert 逻辑。
+
+本轮不做前端 UI、不做后台自动 loop、不做 scheduler、不新增 live staging 脚本。
+
+## Files
+
+| File | Change |
+| --- | --- |
+| `plugins/plugin-attendance/index.cjs` | 增加 job list/run/cancel helper、五个 admin route、runner 委托 daily/period writer |
+| `packages/core-backend/tests/unit/attendance-report-field-catalog.test.ts` | 增加 runner 状态机、分页、period delegation、degraded、fresh lock、cancel/list 单测 |
+| `docs/development/attendance-report-sync-jobs-todo-20260519.md` | PR2 勾选并指向本轮开发 / 验证 MD |
+| `docs/development/attendance-report-sync-jobs-pr2-*.md` | 本轮开发与验证记录 |
+
+## API
+
+所有路由都要求 `attendance:admin`：
+
+```text
+POST /api/attendance/report-sync-jobs
+GET  /api/attendance/report-sync-jobs
+GET  /api/attendance/report-sync-jobs/:id
+POST /api/attendance/report-sync-jobs/:id/run-next-page
+POST /api/attendance/report-sync-jobs/:id/cancel
+```
+
+`POST /api/attendance/report-sync-jobs` 复用 PR1 的 create input normalize：
+
+- `kind`: `daily_records` / `period_summaries`
+- `periodSource`: `{ from, to }` 或 `{ cycleId }`
+- `userSelection`: `{ userId }` / `{ userIds }` / `{ allUsers: true }`
+- `mode`: `manual_step` / `enqueue`
+- `pageSize`: clamp 到现有单页上限
+
+## Runner Design
+
+### Lock
+
+`run-next-page` 先用单条 `UPDATE ... RETURNING *` 获取运行锁：
+
+- `completed` / `canceled` 不可运行，返回 409。
+- `running` 且 `locked_at` 未超过 10 分钟 TTL，返回 409。
+- stale running lock 可被下一次 run 接管。
+
+### Delegation
+
+daily job：
+
+```js
+syncAttendanceReportRecordsForUsers(context, db, orgId, logger, {
+  from,
+  to,
+  allUsers: true,
+  page: cursor.nextPage,
+  pageSize: cursor.pageSize,
+})
+```
+
+period job：
+
+```js
+syncAttendanceReportPeriodSummariesForUsers(context, db, orgId, logger, {
+  period,
+  allUsers: true,
+  page: cursor.nextPage,
+  pageSize: cursor.pageSize,
+})
+```
+
+显式 `userId` / `userIds` job 一页完成；`allUsers` job 依赖 writer 返回的 `hasNextPage` 推进 `cursor.nextPage`。
+
+### Totals
+
+累计字段：
+
+- `usersScanned`
+- `usersSynced`
+- `usersFailed`
+- `synced`
+- `rowsSynced`
+- `created`
+- `patched`
+- `skipped`
+- `failed`
+- `duplicateRowKeys`
+
+`last_result` 只保存 bounded summary，不持久化大 payload 或敏感值。
+
+### Failure
+
+- writer 返回 `degraded:true`：job 标记 `failed`，cursor 不前进。
+- page 内存在 row/user 失败但不是整页失败：累计到 totals，job 可继续。
+- 整页 users 全失败：job 标记 `failed`，cursor 不前进。
+- unexpected error：job 标记 `failed` 并释放 lock。
+
+## Boundaries
+
+- 不把 job row 当作 report/fact source。
+- 不修改 daily / period sync writer 的统计口径。
+- 不直接写 `meta_*`。
+- 不新增 `attendance_*` fact migration。
+- 不删除重复 row_key。
+- 不移除 existing immediate sync endpoints。
+- 不写 staging / production。
+
+## Claude
+
+本轮由 Codex 实现。PR 打开后 Claude 适合按 report sync governance 做 independent review，重点看 writer delegation、lock/status transition、degraded handling 与边界合同。

--- a/docs/development/attendance-report-sync-jobs-pr2-verification-20260519.md
+++ b/docs/development/attendance-report-sync-jobs-pr2-verification-20260519.md
@@ -1,0 +1,74 @@
+# 考勤报表同步任务化 PR2 验证记录
+
+Date: 2026-05-19
+
+## Scope
+
+验证 PR2 的 job route + one-page runner。
+
+不验证前端 UI、scheduler、自动跨页 loop、live staging job harness，因为这些属于后续 PR3/PR4。
+
+## Local Checks
+
+| Check | Result |
+| --- | --- |
+| `node --check plugins/plugin-attendance/index.cjs` | PASS |
+| `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-report-field-catalog.test.ts --reporter=dot` | PASS, 32 tests |
+| `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-report-field-catalog.test.ts tests/unit/attendance-report-field-formula-engine.test.ts --reporter=dot` | PASS, 56 tests |
+| `pnpm --filter @metasheet/core-backend build` | PASS |
+| `git diff --check` | PASS |
+| staged secret scan | PASS |
+
+`pnpm install --ignore-scripts` was run in the isolated PR2 worktree to hydrate local test dependencies. It produced unrelated tracked `node_modules` symlink noise; those paths are intentionally left unstaged and excluded from this slice.
+
+## Unit Coverage Added
+
+- Daily `allUsers` job:
+  - first page runs existing daily writer
+  - `cursor.nextPage` advances from 1 to 2 when `hasNextPage=true`
+  - second page completes when `hasNextPage=false`
+  - totals accumulate deterministically across pages
+- Period cycle job:
+  - resolves `cycleId` through the period resolver
+  - delegates to existing period writer
+  - explicit `userIds` selection completes in one page even if writer returns `hasNextPage=true`
+- Degraded writer:
+  - `degraded:true` marks job `failed`
+  - cursor is not advanced
+  - totals remain trusted only up to the previous completed page
+- Lock / terminal guard:
+  - fresh running lock returns 409
+  - completed job returns 409 on rerun
+- List / cancel:
+  - status-filtered list returns scoped jobs
+  - cancel sets `canceled`, clears lock, sets `finishedAt`
+  - canceling a terminal job returns 409
+
+## Route Coverage
+
+Routes are thin wrappers over tested helpers:
+
+- create route calls `createAttendanceReportSyncJob()`
+- list route calls `listAttendanceReportSyncJobs()`
+- get route calls `loadAttendanceReportSyncJob()`
+- run-next-page route calls `runAttendanceReportSyncJobNextPage()`
+- cancel route calls `cancelAttendanceReportSyncJob()`
+
+The route layer adds only permission wrapping, HTTP status mapping, DB schema degraded handling, and event emission.
+
+## Boundary Verification
+
+- No direct `meta_*` SQL writes added.
+- No new `attendance_*` fact migration added.
+- Existing immediate daily / period sync endpoints remain unchanged.
+- Job runner delegates to existing writer functions; it does not duplicate report statistics or multitable upsert logic.
+- Token and staging output are not committed.
+
+## Deferred Checks
+
+These belong to PR3/PR4:
+
+- Frontend job list and action UI.
+- Live acceptance harness with `JOB_MODE=1`.
+- Staging run after explicit authorization and file-based JWT.
+- Optional queue launcher for `mode=enqueue`.

--- a/docs/development/attendance-report-sync-jobs-todo-20260519.md
+++ b/docs/development/attendance-report-sync-jobs-todo-20260519.md
@@ -193,20 +193,24 @@ Rules:
 
 ### PR2: Runner + Routes
 
-- Implement create / list / get / run-next-page / cancel routes.
-- Implement one-page runner that delegates to existing daily or period sync helpers.
-- Implement cursor update:
+- [x] Implement create / list / get / run-next-page / cancel routes.
+- [x] Implement one-page runner that delegates to existing daily or period sync helpers.
+- [x] Implement cursor update:
   - `nextPage += 1` when `hasNextPage=true`
   - terminal `completed` when explicit users done or `hasNextPage=false`
-- Accumulate totals deterministically.
-- Use `context.services.queue` only as an optional launcher. Durable truth remains SQL job row.
-- Tests:
+- [x] Accumulate totals deterministically.
+- [ ] Use `context.services.queue` only as an optional launcher. Durable truth remains SQL job row.
+- [x] Tests:
   - daily allUsers page 1 -> page 2 -> completed
   - period cycle allUsers
   - explicit userIds complete in one page
   - degraded writer marks failed
   - fresh lock returns 409
   - canceled job cannot run
+
+**PR2 implementation pointer:** `docs/development/attendance-report-sync-jobs-pr2-development-20260519.md`; verification: `docs/development/attendance-report-sync-jobs-pr2-verification-20260519.md`.
+
+**Deferred from PR2 to PR3/PR4:** optional queue launcher for `mode=enqueue`, frontend job UI, and live `JOB_MODE=1` acceptance. PR2 intentionally keeps execution manual-step and SQL-row durable so route/writer semantics can settle before scheduler work.
 
 ### PR3: Frontend Job UI
 

--- a/packages/core-backend/tests/unit/attendance-report-field-catalog.test.ts
+++ b/packages/core-backend/tests/unit/attendance-report-field-catalog.test.ts
@@ -1930,6 +1930,308 @@ describe('attendance report field catalog multitable foundation', () => {
       .toMatchObject({ ok: false, status: 400 })
   })
 
+  function createReportSyncJobRunnerDb(initialRows: Array<Record<string, unknown>>) {
+    const rows = initialRows.map(row => ({ ...row }))
+    const db = {
+      rows,
+      query: vi.fn(async (sql: string, params?: unknown[]) => {
+        if (/UPDATE plugin_attendance_report_sync_jobs\s+SET status = 'running'/.test(sql)) {
+          const [id, orgId, lockedAt, staleBefore] = params ?? []
+          const row = rows.find(item => item.id === id && item.org_id === orgId)
+          if (!row) return []
+          if (row.status === 'completed' || row.status === 'canceled') return []
+          if (
+            row.status === 'running'
+            && row.locked_at
+            && new Date(String(row.locked_at)).getTime() >= new Date(String(staleBefore)).getTime()
+          ) {
+            return []
+          }
+          row.status = 'running'
+          row.locked_at = lockedAt
+          row.started_at = row.started_at ?? lockedAt
+          row.updated_at = lockedAt
+          return [{ ...row }]
+        }
+        if (/UPDATE plugin_attendance_report_sync_jobs\s+SET status = \$3/.test(sql)) {
+          const [id, orgId, status, cursorJson, totalsJson, lastResultJson, error, finishedAt, updatedAt] = params ?? []
+          const row = rows.find(item => item.id === id && item.org_id === orgId)
+          if (!row) return []
+          row.status = status
+          row.cursor = JSON.parse(String(cursorJson))
+          row.totals = JSON.parse(String(totalsJson))
+          row.last_result = JSON.parse(String(lastResultJson))
+          row.error = error
+          row.locked_at = null
+          row.finished_at = finishedAt ?? row.finished_at ?? null
+          row.updated_at = updatedAt
+          return [{ ...row }]
+        }
+        if (/UPDATE plugin_attendance_report_sync_jobs\s+SET status = 'canceled'/.test(sql)) {
+          const [id, orgId, finishedAt] = params ?? []
+          const row = rows.find(item => item.id === id && item.org_id === orgId)
+          if (!row) return []
+          row.status = 'canceled'
+          row.locked_at = null
+          row.finished_at = finishedAt
+          row.updated_at = finishedAt
+          return [{ ...row }]
+        }
+        if (/SELECT \* FROM plugin_attendance_report_sync_jobs\s+WHERE id = \$1 AND org_id = \$2/.test(sql)) {
+          const [id, orgId] = params ?? []
+          const row = rows.find(item => item.id === id && item.org_id === orgId)
+          return row ? [{ ...row }] : []
+        }
+        if (/SELECT \* FROM plugin_attendance_report_sync_jobs\s+WHERE org_id = \$1/.test(sql)) {
+          const orgId = params?.[0]
+          const status = /status =/.test(sql) ? params?.find(value => value === 'queued' || value === 'running' || value === 'paused' || value === 'completed' || value === 'failed' || value === 'canceled') : null
+          return rows
+            .filter(row => row.org_id === orgId)
+            .filter(row => (status ? row.status === status : true))
+            .map(row => ({ ...row }))
+        }
+        return []
+      }),
+    }
+    return db
+  }
+
+  function createReportSyncJobRow(overrides: Record<string, unknown> = {}) {
+    return {
+      id: '44444444-4444-4444-8444-444444444444',
+      org_id: 'org-1',
+      kind: 'daily_records',
+      status: 'queued',
+      mode: 'manual_step',
+      created_by: 'admin-1',
+      period_source: { from: '2026-05-01', to: '2026-05-31' },
+      user_selection: { allUsers: true },
+      cursor: { nextPage: 1, pageSize: 1, hasNextPage: true },
+      totals: helpers.createAttendanceReportSyncJobEmptyTotals(),
+      last_result: {},
+      error: null,
+      idempotency_key: null,
+      locked_at: null,
+      started_at: null,
+      finished_at: null,
+      created_at: '2026-05-19T00:00:00.000Z',
+      updated_at: '2026-05-19T00:00:00.000Z',
+      ...overrides,
+    }
+  }
+
+  it('report sync jobs: runs daily allUsers pages and completes when writer has no next page', async () => {
+    const db = createReportSyncJobRunnerDb([createReportSyncJobRow()])
+    const dailyWriter = vi.fn()
+      .mockResolvedValueOnce({
+        usersScanned: 1,
+        usersSynced: 1,
+        usersFailed: 0,
+        synced: 2,
+        rowsSynced: 2,
+        created: 2,
+        patched: 0,
+        skipped: 0,
+        failed: 0,
+        duplicateRowKeys: 0,
+        page: 1,
+        pageSize: 1,
+        hasNextPage: true,
+        fieldFingerprint: 'fp-1',
+        syncedAt: '2026-05-19T01:00:00.000Z',
+      })
+      .mockResolvedValueOnce({
+        usersScanned: 1,
+        usersSynced: 1,
+        usersFailed: 0,
+        synced: 3,
+        rowsSynced: 3,
+        created: 0,
+        patched: 3,
+        skipped: 0,
+        failed: 0,
+        duplicateRowKeys: 1,
+        page: 2,
+        pageSize: 1,
+        hasNextPage: false,
+        fieldFingerprint: 'fp-1',
+        syncedAt: '2026-05-19T01:01:00.000Z',
+      })
+
+    const first = await helpers.runAttendanceReportSyncJobNextPage({}, db, 'org-1', { warn: vi.fn() }, '44444444-4444-4444-8444-444444444444', {
+      dailyWriter,
+      now: new Date('2026-05-19T01:00:00.000Z'),
+    })
+    expect(first).toMatchObject({
+      ok: true,
+      job: {
+        status: 'queued',
+        cursor: { nextPage: 2, pageSize: 1, hasNextPage: true },
+        totals: { usersScanned: 1, synced: 2, rowsSynced: 2, created: 2 },
+      },
+    })
+
+    const second = await helpers.runAttendanceReportSyncJobNextPage({}, db, 'org-1', { warn: vi.fn() }, '44444444-4444-4444-8444-444444444444', {
+      dailyWriter,
+      now: new Date('2026-05-19T01:01:00.000Z'),
+    })
+    expect(second).toMatchObject({
+      ok: true,
+      job: {
+        status: 'completed',
+        cursor: { nextPage: 2, pageSize: 1, hasNextPage: false },
+        totals: { usersScanned: 2, usersSynced: 2, synced: 5, rowsSynced: 5, created: 2, patched: 3, duplicateRowKeys: 1 },
+        finishedAt: '2026-05-19T01:01:00.000Z',
+      },
+    })
+    expect(dailyWriter).toHaveBeenNthCalledWith(1, {}, db, 'org-1', expect.any(Object), {
+      from: '2026-05-01',
+      to: '2026-05-31',
+      allUsers: true,
+      page: 1,
+      pageSize: 1,
+    })
+    expect(dailyWriter).toHaveBeenNthCalledWith(2, {}, db, 'org-1', expect.any(Object), {
+      from: '2026-05-01',
+      to: '2026-05-31',
+      allUsers: true,
+      page: 2,
+      pageSize: 1,
+    })
+  })
+
+  it('report sync jobs: delegates period cycle jobs and explicit user selections complete in one page', async () => {
+    const cycleId = '55555555-5555-4555-8555-555555555555'
+    const db = createReportSyncJobRunnerDb([
+      createReportSyncJobRow({
+        kind: 'period_summaries',
+        period_source: { cycleId },
+        user_selection: { userIds: ['u-1', 'u-2'] },
+        cursor: { nextPage: 1, pageSize: 50, hasNextPage: true },
+      }),
+    ])
+    const period = {
+      periodType: 'payroll_cycle',
+      periodKey: `cycle:${cycleId}`,
+      cycleId,
+      periodName: '五月考勤',
+      from: '2026-05-01',
+      to: '2026-05-31',
+    }
+    const resolvePeriod = vi.fn().mockResolvedValue({ ok: true, period })
+    const periodWriter = vi.fn().mockResolvedValue({
+      usersScanned: 2,
+      usersSynced: 2,
+      usersFailed: 0,
+      synced: 2,
+      rowsSynced: 2,
+      created: 2,
+      patched: 0,
+      skipped: 0,
+      failed: 0,
+      duplicateRowKeys: 0,
+      page: 1,
+      pageSize: 50,
+      hasNextPage: true,
+      periodType: 'payroll_cycle',
+    })
+
+    const result = await helpers.runAttendanceReportSyncJobNextPage({}, db, 'org-1', { warn: vi.fn() }, '44444444-4444-4444-8444-444444444444', {
+      resolvePeriod,
+      periodWriter,
+      now: new Date('2026-05-19T02:00:00.000Z'),
+    })
+
+    expect(result).toMatchObject({
+      ok: true,
+      job: {
+        status: 'completed',
+        totals: { usersScanned: 2, usersSynced: 2, synced: 2 },
+        cursor: { nextPage: 1, pageSize: 50, hasNextPage: false },
+      },
+    })
+    expect(resolvePeriod).toHaveBeenCalledWith(db, 'org-1', { cycleId })
+    expect(periodWriter).toHaveBeenCalledWith({}, db, 'org-1', expect.any(Object), {
+      period,
+      userIds: ['u-1', 'u-2'],
+    })
+  })
+
+  it('report sync jobs: degraded writer marks the job failed without advancing the cursor', async () => {
+    const db = createReportSyncJobRunnerDb([createReportSyncJobRow()])
+    const dailyWriter = vi.fn().mockResolvedValue({
+      degraded: true,
+      reason: 'MULTITABLE_API_UNAVAILABLE',
+      usersScanned: 0,
+      synced: 0,
+    })
+
+    const result = await helpers.runAttendanceReportSyncJobNextPage({}, db, 'org-1', { warn: vi.fn() }, '44444444-4444-4444-8444-444444444444', {
+      dailyWriter,
+      now: new Date('2026-05-19T03:00:00.000Z'),
+    })
+
+    expect(result).toMatchObject({
+      ok: true,
+      job: {
+        status: 'failed',
+        error: 'MULTITABLE_API_UNAVAILABLE',
+        cursor: { nextPage: 1, pageSize: 1, hasNextPage: true },
+        totals: { usersScanned: 0, synced: 0 },
+      },
+      pageResult: { degraded: true, reason: 'MULTITABLE_API_UNAVAILABLE' },
+    })
+  })
+
+  it('report sync jobs: fresh locks and terminal statuses block run-next-page', async () => {
+    const lockedDb = createReportSyncJobRunnerDb([
+      createReportSyncJobRow({
+        status: 'running',
+        locked_at: '2026-05-19T04:00:00.000Z',
+      }),
+    ])
+    expect(helpers.isAttendanceReportSyncJobFreshlyLocked(
+      helpers.mapAttendanceReportSyncJobRow(lockedDb.rows[0]),
+      new Date('2026-05-19T04:01:00.000Z'),
+    )).toBe(true)
+    const locked = await helpers.runAttendanceReportSyncJobNextPage({}, lockedDb, 'org-1', { warn: vi.fn() }, '44444444-4444-4444-8444-444444444444', {
+      dailyWriter: vi.fn(),
+      now: new Date('2026-05-19T04:01:00.000Z'),
+    })
+    expect(locked).toMatchObject({ ok: false, status: 409, code: 'JOB_LOCKED' })
+
+    const completedDb = createReportSyncJobRunnerDb([
+      createReportSyncJobRow({ status: 'completed', finished_at: '2026-05-19T04:00:00.000Z' }),
+    ])
+    const completed = await helpers.runAttendanceReportSyncJobNextPage({}, completedDb, 'org-1', { warn: vi.fn() }, '44444444-4444-4444-8444-444444444444', {
+      dailyWriter: vi.fn(),
+      now: new Date('2026-05-19T04:01:00.000Z'),
+    })
+    expect(completed).toMatchObject({ ok: false, status: 409, code: 'JOB_TERMINAL' })
+  })
+
+  it('report sync jobs: can list and cancel non-terminal jobs', async () => {
+    const db = createReportSyncJobRunnerDb([
+      createReportSyncJobRow({ status: 'queued' }),
+      createReportSyncJobRow({ id: '55555555-5555-4555-8555-555555555555', status: 'completed' }),
+    ])
+    const listed = await helpers.listAttendanceReportSyncJobs(db, 'org-1', { status: 'queued', limit: 10 })
+    expect(listed).toMatchObject({ ok: true, jobs: [{ id: '44444444-4444-4444-8444-444444444444', status: 'queued' }] })
+
+    const canceled = await helpers.cancelAttendanceReportSyncJob(db, 'org-1', '44444444-4444-4444-8444-444444444444', new Date('2026-05-19T05:00:00.000Z'))
+    expect(canceled).toMatchObject({
+      ok: true,
+      job: {
+        id: '44444444-4444-4444-8444-444444444444',
+        status: 'canceled',
+        finishedAt: '2026-05-19T05:00:00.000Z',
+      },
+    })
+
+    const canceledAgain = await helpers.cancelAttendanceReportSyncJob(db, 'org-1', '44444444-4444-4444-8444-444444444444', new Date('2026-05-19T05:01:00.000Z'))
+    expect(canceledAgain).toMatchObject({ ok: false, status: 409, code: 'JOB_TERMINAL' })
+  })
+
   it('does not add direct meta table writes to the attendance plugin', () => {
     const source = readFileSync(
       new URL('../../../../plugins/plugin-attendance/index.cjs', import.meta.url),

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -2879,6 +2879,366 @@ async function loadAttendanceReportSyncJob(db, orgId, jobId) {
   return { ok: true, job: mapAttendanceReportSyncJobRow(rows[0]) }
 }
 
+const ATTENDANCE_REPORT_SYNC_JOB_LOCK_TTL_MS = 10 * 60 * 1000
+const ATTENDANCE_REPORT_SYNC_JOB_LIST_DEFAULT_LIMIT = 50
+const ATTENDANCE_REPORT_SYNC_JOB_LIST_MAX_LIMIT = 100
+const ATTENDANCE_REPORT_SYNC_JOB_TERMINAL_STATUSES = new Set(['completed', 'canceled'])
+const ATTENDANCE_REPORT_SYNC_JOB_TOTAL_KEYS = Object.freeze([
+  'usersScanned',
+  'usersSynced',
+  'usersFailed',
+  'synced',
+  'rowsSynced',
+  'created',
+  'patched',
+  'skipped',
+  'failed',
+  'duplicateRowKeys',
+])
+
+function isAttendanceReportSyncJobTerminalStatus(status) {
+  return ATTENDANCE_REPORT_SYNC_JOB_TERMINAL_STATUSES.has(normalizeAttendanceReportSyncJobStatus(status))
+}
+
+function isAttendanceReportSyncJobFreshlyLocked(job, now = new Date()) {
+  if (!job || normalizeAttendanceReportSyncJobStatus(job.status) !== 'running' || !job.lockedAt) return false
+  const lockedAtMs = new Date(job.lockedAt).getTime()
+  const nowMs = now instanceof Date ? now.getTime() : new Date(now).getTime()
+  if (!Number.isFinite(lockedAtMs) || !Number.isFinite(nowMs)) return false
+  return nowMs - lockedAtMs < ATTENDANCE_REPORT_SYNC_JOB_LOCK_TTL_MS
+}
+
+function normalizeAttendanceReportSyncJobLimit(value) {
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed)) return ATTENDANCE_REPORT_SYNC_JOB_LIST_DEFAULT_LIMIT
+  return Math.min(Math.max(Math.floor(parsed), 1), ATTENDANCE_REPORT_SYNC_JOB_LIST_MAX_LIMIT)
+}
+
+function normalizeAttendanceReportSyncJobTotalNumber(value) {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0
+}
+
+function mergeAttendanceReportSyncJobTotals(existingTotals = {}, pageResult = {}) {
+  const merged = {
+    ...createAttendanceReportSyncJobEmptyTotals(),
+    ...normalizeAttendanceReportSyncJobJson(existingTotals),
+  }
+  for (const key of ATTENDANCE_REPORT_SYNC_JOB_TOTAL_KEYS) {
+    merged[key] = normalizeAttendanceReportSyncJobTotalNumber(merged[key])
+      + normalizeAttendanceReportSyncJobTotalNumber(pageResult[key])
+  }
+  merged.rowsSynced = merged.synced
+  const failedUsers = [
+    ...(Array.isArray(merged.failedUsers) ? merged.failedUsers : []),
+    ...(Array.isArray(pageResult.failedUsers) ? pageResult.failedUsers : []),
+  ].slice(0, 50)
+  if (failedUsers.length > 0) merged.failedUsers = failedUsers
+  return merged
+}
+
+function sanitizeAttendanceReportSyncJobLastResult(pageResult = {}) {
+  const allowedKeys = [
+    'periodType',
+    'periodKey',
+    'cycleId',
+    'from',
+    'to',
+    'totalUsers',
+    'page',
+    'pageSize',
+    'hasNextPage',
+    'usersScanned',
+    'usersSynced',
+    'usersFailed',
+    'synced',
+    'rowsSynced',
+    'created',
+    'patched',
+    'skipped',
+    'failed',
+    'duplicateRowKeys',
+    'fieldFingerprint',
+    'syncedAt',
+    'reason',
+    'degraded',
+  ]
+  const output = {}
+  for (const key of allowedKeys) {
+    if (pageResult[key] !== undefined) output[key] = pageResult[key]
+  }
+  if (Array.isArray(pageResult.failedUsers) && pageResult.failedUsers.length > 0) {
+    output.failedUsers = pageResult.failedUsers.slice(0, 20)
+  }
+  if (pageResult.multitable && typeof pageResult.multitable === 'object') {
+    output.multitable = {
+      available: pageResult.multitable.available,
+      projectId: pageResult.multitable.projectId,
+      sheetId: pageResult.multitable.sheetId,
+      viewId: pageResult.multitable.viewId,
+    }
+  }
+  return output
+}
+
+function isAttendanceReportSyncJobExplicitUserSelection(job) {
+  const selection = normalizeMetadata(job?.userSelection)
+  if (normalizeCatalogString(selection.userId)) return true
+  return Array.isArray(selection.userIds) && normalizeAttendanceReportRecordsSyncUserIds(selection.userIds).length > 0
+}
+
+function buildAttendanceReportSyncJobUserParams(job) {
+  const selection = normalizeMetadata(job?.userSelection)
+  if (normalizeCatalogString(selection.userId)) {
+    return { userIds: [normalizeCatalogString(selection.userId)] }
+  }
+  const userIds = normalizeAttendanceReportRecordsSyncUserIds(selection.userIds)
+  if (userIds.length > 0) return { userIds }
+  const cursor = normalizeAttendanceReportSyncJobJson(job?.cursor, createAttendanceReportSyncJobInitialCursor())
+  const page = normalizeAttendanceReportRecordsSyncPage(cursor.nextPage, cursor.pageSize)
+  return {
+    allUsers: true,
+    page: page.page,
+    pageSize: page.pageSize,
+  }
+}
+
+async function listAttendanceReportSyncJobs(db, orgId, filters = {}) {
+  const clauses = ['org_id = $1']
+  const params = [normalizeAttendanceReportFieldOrgId(orgId)]
+  const rawKind = normalizeCatalogString(filters.kind)
+  const kind = normalizeAttendanceReportSyncJobKind(rawKind)
+  if (rawKind && !kind) {
+    return createAttendanceReportSyncJobValidationError('Invalid job kind')
+  }
+  if (kind) {
+    params.push(kind)
+    clauses.push(`kind = $${params.length}`)
+  }
+  const rawStatus = normalizeCatalogString(filters.status)
+  if (rawStatus) {
+    const status = normalizeAttendanceReportSyncJobStatus(rawStatus)
+    if (!ATTENDANCE_REPORT_SYNC_JOB_STATUSES.includes(rawStatus)) {
+      return createAttendanceReportSyncJobValidationError('Invalid job status')
+    }
+    params.push(status)
+    clauses.push(`status = $${params.length}`)
+  }
+  params.push(normalizeAttendanceReportSyncJobLimit(filters.limit))
+  const rows = await db.query(
+    `SELECT * FROM ${ATTENDANCE_REPORT_SYNC_JOB_TABLE}
+     WHERE ${clauses.join(' AND ')}
+     ORDER BY created_at DESC, id DESC
+     LIMIT $${params.length}`,
+    params,
+  )
+  return { ok: true, jobs: rows.map(mapAttendanceReportSyncJobRow).filter(Boolean) }
+}
+
+async function lockAttendanceReportSyncJobForRun(db, orgId, jobId, now = new Date()) {
+  const id = normalizeUuidString(jobId)
+  if (!id) return { ok: false, status: 400, code: 'VALIDATION_ERROR', message: 'Invalid job id' }
+  const lockedAt = now instanceof Date ? now : new Date(now)
+  const staleBefore = new Date(lockedAt.getTime() - ATTENDANCE_REPORT_SYNC_JOB_LOCK_TTL_MS)
+  const rows = await db.query(
+    `UPDATE ${ATTENDANCE_REPORT_SYNC_JOB_TABLE}
+     SET status = 'running',
+         locked_at = $3::timestamptz,
+         started_at = COALESCE(started_at, $3::timestamptz),
+         updated_at = $3::timestamptz
+     WHERE id = $1
+       AND org_id = $2
+       AND status NOT IN ('completed', 'canceled')
+       AND (status <> 'running' OR locked_at IS NULL OR locked_at < $4::timestamptz)
+     RETURNING *`,
+    [id, normalizeAttendanceReportFieldOrgId(orgId), lockedAt.toISOString(), staleBefore.toISOString()],
+  )
+  if (rows.length > 0) {
+    return { ok: true, job: mapAttendanceReportSyncJobRow(rows[0]) }
+  }
+  const existing = await loadAttendanceReportSyncJob(db, orgId, id)
+  if (!existing.ok) return existing
+  if (isAttendanceReportSyncJobTerminalStatus(existing.job.status)) {
+    return { ok: false, status: 409, code: 'JOB_TERMINAL', message: 'Completed or canceled attendance report sync jobs cannot run again' }
+  }
+  if (isAttendanceReportSyncJobFreshlyLocked(existing.job, lockedAt)) {
+    return { ok: false, status: 409, code: 'JOB_LOCKED', message: 'Attendance report sync job is already running' }
+  }
+  return { ok: false, status: 409, code: 'JOB_CONFLICT', message: 'Attendance report sync job cannot be locked for running' }
+}
+
+async function persistAttendanceReportSyncJobPageState(db, orgId, jobId, state = {}, now = new Date()) {
+  const id = normalizeUuidString(jobId)
+  if (!id) return { ok: false, status: 400, code: 'VALIDATION_ERROR', message: 'Invalid job id' }
+  const status = normalizeAttendanceReportSyncJobStatus(state.status)
+  const finishedAt = isAttendanceReportSyncJobTerminalStatus(status) ? now.toISOString() : null
+  const rows = await db.query(
+    `UPDATE ${ATTENDANCE_REPORT_SYNC_JOB_TABLE}
+     SET status = $3,
+         cursor = $4::jsonb,
+         totals = $5::jsonb,
+         last_result = $6::jsonb,
+         error = $7,
+         locked_at = NULL,
+         finished_at = COALESCE($8::timestamptz, finished_at),
+         updated_at = $9::timestamptz
+     WHERE id = $1 AND org_id = $2
+     RETURNING *`,
+    [
+      id,
+      normalizeAttendanceReportFieldOrgId(orgId),
+      status,
+      JSON.stringify(state.cursor ?? createAttendanceReportSyncJobInitialCursor()),
+      JSON.stringify(state.totals ?? createAttendanceReportSyncJobEmptyTotals()),
+      JSON.stringify(state.lastResult ?? {}),
+      state.error ?? null,
+      finishedAt,
+      now.toISOString(),
+    ],
+  )
+  if (!rows.length) {
+    return { ok: false, status: 404, code: 'NOT_FOUND', message: 'Attendance report sync job not found' }
+  }
+  return { ok: true, job: mapAttendanceReportSyncJobRow(rows[0]) }
+}
+
+async function resolveAttendanceReportSyncJobDateRange(db, orgId, job, options = {}) {
+  const periodSource = normalizeMetadata(job?.periodSource)
+  if (periodSource.cycleId) {
+    const resolver = options.resolvePeriod || resolveAttendanceReportPeriodSyncPeriod
+    const resolved = await resolver(db, orgId, periodSource)
+    if (!resolved.ok) return resolved
+    return { ok: true, from: resolved.period.from, to: resolved.period.to, period: resolved.period }
+  }
+  const dateRange = resolveAttendanceDateRange(periodSource.from, periodSource.to)
+  if (!dateRange.ok) {
+    return { ok: false, status: 400, code: 'VALIDATION_ERROR', message: dateRange.message }
+  }
+  return { ok: true, from: dateRange.from, to: dateRange.to }
+}
+
+async function executeAttendanceReportSyncJobPage(context, db, orgId, logger, job, options = {}) {
+  const userParams = buildAttendanceReportSyncJobUserParams(job)
+  if (job.kind === 'daily_records') {
+    const dateRange = await resolveAttendanceReportSyncJobDateRange(db, orgId, job, options)
+    if (!dateRange.ok) return dateRange
+    const writer = options.dailyWriter || syncAttendanceReportRecordsForUsers
+    return {
+      ok: true,
+      result: await writer(context, db, orgId, logger, {
+        from: dateRange.from,
+        to: dateRange.to,
+        ...userParams,
+      }),
+    }
+  }
+  if (job.kind === 'period_summaries') {
+    const resolver = options.resolvePeriod || resolveAttendanceReportPeriodSyncPeriod
+    const resolvedPeriod = await resolver(db, orgId, job.periodSource)
+    if (!resolvedPeriod.ok) return resolvedPeriod
+    const writer = options.periodWriter || syncAttendanceReportPeriodSummariesForUsers
+    return {
+      ok: true,
+      result: await writer(context, db, orgId, logger, {
+        period: resolvedPeriod.period,
+        ...userParams,
+      }),
+    }
+  }
+  return { ok: false, status: 400, code: 'VALIDATION_ERROR', message: 'Unsupported report sync job kind' }
+}
+
+function buildAttendanceReportSyncJobCursorAfterPage(job, pageResult = {}, completed = false) {
+  const current = normalizeAttendanceReportSyncJobJson(job?.cursor, createAttendanceReportSyncJobInitialCursor())
+  const page = normalizeAttendanceReportRecordsSyncPage(current.nextPage, current.pageSize)
+  const hasNextPage = completed ? false : pageResult.hasNextPage === true
+  return {
+    ...current,
+    nextPage: hasNextPage ? page.page + 1 : page.page,
+    pageSize: page.pageSize,
+    hasNextPage,
+  }
+}
+
+async function runAttendanceReportSyncJobNextPage(context, db, orgId, logger, jobId, options = {}) {
+  const now = options.now instanceof Date ? options.now : new Date()
+  const locked = await lockAttendanceReportSyncJobForRun(db, orgId, jobId, now)
+  if (!locked.ok) return locked
+  const job = locked.job
+  try {
+    const page = await executeAttendanceReportSyncJobPage(context, db, orgId, logger, job, options)
+    if (!page.ok) {
+      const failed = await persistAttendanceReportSyncJobPageState(db, orgId, job.id, {
+        status: 'failed',
+        cursor: job.cursor,
+        totals: job.totals,
+        lastResult: { error: page.message, code: page.code },
+        error: page.message || 'Failed to run attendance report sync job page',
+      }, now)
+      return { ok: true, job: failed.job, pageResult: { error: page.message, code: page.code } }
+    }
+    const pageResult = page.result || {}
+    if (pageResult.degraded) {
+      const failed = await persistAttendanceReportSyncJobPageState(db, orgId, job.id, {
+        status: 'failed',
+        cursor: job.cursor,
+        totals: job.totals,
+        lastResult: sanitizeAttendanceReportSyncJobLastResult(pageResult),
+        error: pageResult.reason || 'DEGRADED',
+      }, now)
+      return { ok: true, job: failed.job, pageResult }
+    }
+    const totals = mergeAttendanceReportSyncJobTotals(job.totals, pageResult)
+    const explicitUsers = isAttendanceReportSyncJobExplicitUserSelection(job)
+    const allRowsFailed = normalizeAttendanceReportSyncJobTotalNumber(pageResult.usersScanned) > 0
+      && normalizeAttendanceReportSyncJobTotalNumber(pageResult.usersFailed) >= normalizeAttendanceReportSyncJobTotalNumber(pageResult.usersScanned)
+    const completed = explicitUsers || pageResult.hasNextPage !== true
+    const status = allRowsFailed ? 'failed' : (completed ? 'completed' : 'queued')
+    const cursor = buildAttendanceReportSyncJobCursorAfterPage(job, pageResult, completed || allRowsFailed)
+    const saved = await persistAttendanceReportSyncJobPageState(db, orgId, job.id, {
+      status,
+      cursor,
+      totals,
+      lastResult: sanitizeAttendanceReportSyncJobLastResult(pageResult),
+      error: allRowsFailed ? 'All users in the page failed' : null,
+    }, now)
+    return { ok: true, job: saved.job, pageResult }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    logger?.warn?.('attendance report sync job page failed', { jobId: job.id, error: message })
+    const failed = await persistAttendanceReportSyncJobPageState(db, orgId, job.id, {
+      status: 'failed',
+      cursor: job.cursor,
+      totals: job.totals,
+      lastResult: { error: message },
+      error: message,
+    }, now)
+    return { ok: true, job: failed.job, pageResult: { error: message } }
+  }
+}
+
+async function cancelAttendanceReportSyncJob(db, orgId, jobId, now = new Date()) {
+  const loaded = await loadAttendanceReportSyncJob(db, orgId, jobId)
+  if (!loaded.ok) return loaded
+  if (isAttendanceReportSyncJobTerminalStatus(loaded.job.status)) {
+    return { ok: false, status: 409, code: 'JOB_TERMINAL', message: 'Completed or canceled attendance report sync jobs cannot be canceled again' }
+  }
+  const rows = await db.query(
+    `UPDATE ${ATTENDANCE_REPORT_SYNC_JOB_TABLE}
+     SET status = 'canceled',
+         locked_at = NULL,
+         finished_at = $3::timestamptz,
+         updated_at = $3::timestamptz
+     WHERE id = $1 AND org_id = $2
+     RETURNING *`,
+    [loaded.job.id, normalizeAttendanceReportFieldOrgId(orgId), now.toISOString()],
+  )
+  if (!rows.length) {
+    return { ok: false, status: 404, code: 'NOT_FOUND', message: 'Attendance report sync job not found' }
+  }
+  return { ok: true, job: mapAttendanceReportSyncJobRow(rows[0]) }
+}
+
 function resolveAttendanceReportPeriodSummaryManagedFormulaFields(items) {
   return (Array.isArray(items) ? items : [])
     .filter(field => (
@@ -11394,6 +11754,14 @@ module.exports = {
     mapAttendanceReportSyncJobRow,
     createAttendanceReportSyncJob,
     loadAttendanceReportSyncJob,
+    listAttendanceReportSyncJobs,
+    isAttendanceReportSyncJobTerminalStatus,
+    isAttendanceReportSyncJobFreshlyLocked,
+    mergeAttendanceReportSyncJobTotals,
+    sanitizeAttendanceReportSyncJobLastResult,
+    buildAttendanceReportSyncJobUserParams,
+    runAttendanceReportSyncJobNextPage,
+    cancelAttendanceReportSyncJob,
     normalizeAttendanceReportRecordsSyncUserIds,
     normalizeAttendanceReportRecordsSyncPage,
     loadAttendanceReportRecordsSyncUserPage,
@@ -23504,6 +23872,157 @@ module.exports = {
           syncedAt: new Date().toISOString(),
         })
         res.json({ ok: true, data })
+      })
+    )
+
+    context.api.http.addRoute(
+      'POST',
+      '/api/attendance/report-sync-jobs',
+      withPermission('attendance:admin', async (req, res) => {
+        try {
+          const orgId = getOrgId(req)
+          const created = await createAttendanceReportSyncJob(db, orgId, getUserId(req), req.body ?? {})
+          if (!created.ok) {
+            res.status(created.status || 400).json({
+              ok: false,
+              error: { code: created.code || 'VALIDATION_ERROR', message: created.message },
+            })
+            return
+          }
+          emitEvent('attendance.report_sync_job.created', {
+            orgId,
+            jobId: created.job.id,
+            kind: created.job.kind,
+            status: created.job.status,
+            createdAt: created.job.createdAt,
+          })
+          res.status(201).json({ ok: true, data: created.job })
+        } catch (error) {
+          if (isDatabaseSchemaError(error)) {
+            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance report sync job table missing' } })
+            return
+          }
+          logger.error('Attendance report sync job create failed', error)
+          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to create attendance report sync job' } })
+        }
+      })
+    )
+
+    context.api.http.addRoute(
+      'GET',
+      '/api/attendance/report-sync-jobs',
+      withPermission('attendance:admin', async (req, res) => {
+        try {
+          const orgId = getOrgId(req)
+          const listed = await listAttendanceReportSyncJobs(db, orgId, req.query ?? {})
+          if (!listed.ok) {
+            res.status(listed.status || 400).json({
+              ok: false,
+              error: { code: listed.code || 'VALIDATION_ERROR', message: listed.message },
+            })
+            return
+          }
+          res.json({ ok: true, data: { items: listed.jobs } })
+        } catch (error) {
+          if (isDatabaseSchemaError(error)) {
+            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance report sync job table missing' } })
+            return
+          }
+          logger.error('Attendance report sync job list failed', error)
+          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to list attendance report sync jobs' } })
+        }
+      })
+    )
+
+    context.api.http.addRoute(
+      'POST',
+      '/api/attendance/report-sync-jobs/:id/run-next-page',
+      withPermission('attendance:admin', async (req, res) => {
+        try {
+          const orgId = getOrgId(req)
+          const result = await runAttendanceReportSyncJobNextPage(context, db, orgId, logger, req.params.id)
+          if (!result.ok) {
+            res.status(result.status || 400).json({
+              ok: false,
+              error: { code: result.code || 'VALIDATION_ERROR', message: result.message },
+            })
+            return
+          }
+          emitEvent('attendance.report_sync_job.page_ran', {
+            orgId,
+            jobId: result.job.id,
+            kind: result.job.kind,
+            status: result.job.status,
+            totals: result.job.totals,
+            updatedAt: result.job.updatedAt,
+          })
+          res.json({ ok: true, data: { job: result.job, pageResult: result.pageResult } })
+        } catch (error) {
+          if (isDatabaseSchemaError(error)) {
+            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance report sync job table missing' } })
+            return
+          }
+          logger.error('Attendance report sync job run failed', error)
+          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to run attendance report sync job page' } })
+        }
+      })
+    )
+
+    context.api.http.addRoute(
+      'POST',
+      '/api/attendance/report-sync-jobs/:id/cancel',
+      withPermission('attendance:admin', async (req, res) => {
+        try {
+          const orgId = getOrgId(req)
+          const canceled = await cancelAttendanceReportSyncJob(db, orgId, req.params.id)
+          if (!canceled.ok) {
+            res.status(canceled.status || 400).json({
+              ok: false,
+              error: { code: canceled.code || 'VALIDATION_ERROR', message: canceled.message },
+            })
+            return
+          }
+          emitEvent('attendance.report_sync_job.canceled', {
+            orgId,
+            jobId: canceled.job.id,
+            kind: canceled.job.kind,
+            canceledAt: canceled.job.finishedAt,
+          })
+          res.json({ ok: true, data: canceled.job })
+        } catch (error) {
+          if (isDatabaseSchemaError(error)) {
+            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance report sync job table missing' } })
+            return
+          }
+          logger.error('Attendance report sync job cancel failed', error)
+          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to cancel attendance report sync job' } })
+        }
+      })
+    )
+
+    context.api.http.addRoute(
+      'GET',
+      '/api/attendance/report-sync-jobs/:id',
+      withPermission('attendance:admin', async (req, res) => {
+        try {
+          const orgId = getOrgId(req)
+          const loaded = await loadAttendanceReportSyncJob(db, orgId, req.params.id)
+          if (!loaded.ok) {
+            res.status(loaded.status || 400).json({
+              ok: false,
+              error: { code: loaded.code || 'VALIDATION_ERROR', message: loaded.message },
+            })
+            return
+          }
+          res.json({ ok: true, data: loaded.job })
+        } catch (error) {
+          if (isDatabaseSchemaError(error)) {
+            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance report sync job table missing' } })
+            return
+          }
+          logger.error('Attendance report sync job load failed', error)
+          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to load attendance report sync job' } })
+        }
       })
     )
 


### PR DESCRIPTION
## Summary

Adds the PR2 control plane for attendance report sync jobs on top of the PR1 `plugin_attendance_report_sync_jobs` table.

- Adds admin APIs for create / list / get / run-next-page / cancel
- Adds one-page runner with fresh-lock guard, terminal-state guard, cursor advancement, totals accumulation, bounded `last_result`, degraded failure handling, and cancel state transition
- Delegates actual report writes to existing daily / period writers (`syncAttendanceReportRecordsForUsers`, `syncAttendanceReportPeriodSummariesForUsers`) so statistics, fingerprinting, stale-null behavior, duplicate row-key fuse, and multitable upsert logic stay in one place
- Adds PR2 design + verification docs and updates the sync-job TODO

## Boundaries

- No new migration in this PR
- No frontend UI yet
- No scheduler / automatic loop yet
- No direct `meta_*` writes
- No new `attendance_*` fact migration
- Existing immediate daily / period sync endpoints remain unchanged

## Test plan

- [x] `node --check plugins/plugin-attendance/index.cjs`
- [x] `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-report-field-catalog.test.ts --reporter=dot` (32 tests)
- [x] `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-report-field-catalog.test.ts tests/unit/attendance-report-field-formula-engine.test.ts --reporter=dot` (56 tests)
- [x] `pnpm --filter @metasheet/core-backend build`
- [x] `git diff --check`
- [x] staged secret scan

## Follow-up

PR3 should add the frontend job UI; PR4 should extend live acceptance with optional `JOB_MODE=1`. Claude independent review is appropriate for this PR because it touches runner state transitions and report/multitable boundaries.
