### PR TITLE
test(attendance): add report sync job live acceptance mode

### DIFF
--- a/docs/development/attendance-report-sync-jobs-pr4-development-20260519.md
+++ b/docs/development/attendance-report-sync-jobs-pr4-development-20260519.md
@@ -1,0 +1,113 @@
+# 考勤报表同步任务化 PR4 开发记录
+
+Date: 2026-05-19
+
+## Summary
+
+本轮落地 PR4：给现有 live acceptance harness 增加可选 `JOB_MODE=1`，用于验证 PR2/PR3 的 report sync job 控制面。
+
+范围保持为 ops harness：
+
+- daily `attendance_report_records`：在 `attendance-report-fields-live-acceptance` 中增加 job mode。
+- period `attendance_report_period_summaries`：在 `attendance-report-period-summaries-live-acceptance` 中增加 job mode。
+- job mode 创建 `manual_step` 任务，循环调用 `run-next-page` 直到 `completed` 或超过 `JOB_MAX_PAGES`。
+- job 完成后再调用一次 `run-next-page`，断言后端返回 `409 JOB_TERMINAL`。
+- terminal rerun 被拒后再创建一个新 job 并立即 cancel，验证完成任务不阻塞后续新任务，同时不留下 queued job。
+- 默认不启用 job mode；没有 `JOB_MODE=1` 时只记录 skipped check。
+
+本轮不改 attendance 业务逻辑、不改 writer、不改 route、不改前端、不新增 migration。
+
+## Files
+
+| File | Change |
+| --- | --- |
+| `scripts/ops/attendance-report-fields-live-acceptance.mjs` | 增加 daily job-mode 配置、创建/逐页执行/terminal rerun 验证 |
+| `scripts/ops/attendance-report-fields-live-acceptance.test.mjs` | mock `report-sync-jobs` API，覆盖 daily job mode |
+| `scripts/ops/attendance-report-period-summaries-live-acceptance.mjs` | 增加 period date-range / optional payroll-cycle job-mode 验证 |
+| `scripts/ops/attendance-report-period-summaries-live-acceptance.test.mjs` | mock period job create/run/rerun，覆盖 date range 与 cycle |
+| `docs/development/attendance-report-sync-jobs-todo-20260519.md` | PR4 勾选并指向本轮开发 / 验证 MD |
+| `docs/development/attendance-report-sync-jobs-pr4-*.md` | 本轮开发与验证记录 |
+
+## Runtime Contract
+
+### Daily Job Mode
+
+`attendance-report-fields-live-acceptance` 仍先完成字段目录、records、export、CSV header 证据链。仅当 `JOB_MODE=1` 时追加 daily job 验证。
+
+Job body:
+
+```json
+{
+  "kind": "daily_records",
+  "mode": "manual_step",
+  "pageSize": 5,
+  "periodSource": { "from": "2026-05-01", "to": "2026-05-13" },
+  "userSelection": { "userId": "..." }
+}
+```
+
+Daily job mode 要求显式 user selection：
+
+- `USER_ID=<id>`；或
+- `JOB_USER_IDS=<id,id>` / `USER_IDS=<id,id>`；或
+- `JOB_ALL_USERS=1` / `ALL_USERS=1`。
+
+这样避免 operator 只想跑字段目录验收时误触发全员 report-records 写入。
+
+### Period Job Mode
+
+`attendance-report-period-summaries-live-acceptance` 仍先跑 immediate period sync 的 date range；若 `CYCLE_ID` 存在，也继续跑 payroll-cycle immediate sync。仅当 `JOB_MODE=1` 时追加对应 job 验证：
+
+- date range period job 永远验证；
+- payroll cycle period job 仅在 `CYCLE_ID` 存在时验证。
+
+Job body:
+
+```json
+{
+  "kind": "period_summaries",
+  "mode": "manual_step",
+  "pageSize": 5,
+  "periodSource": { "from": "2026-05-01", "to": "2026-05-13" },
+  "userSelection": { "userIds": ["u-1", "u-2"] }
+}
+```
+
+或：
+
+```json
+{
+  "kind": "period_summaries",
+  "mode": "manual_step",
+  "pageSize": 5,
+  "periodSource": { "cycleId": "..." },
+  "userSelection": { "allUsers": true }
+}
+```
+
+## Checks Added
+
+每个 job-mode flow 记录：
+
+- `*.job.created`
+- `*.job.completed`
+- `*.job.pages-within-limit`
+- `*.job.totals-present`
+- `*.job.terminal-rerun-rejected`
+- `*.job.new-job-created`
+- `*.job.new-job-canceled`
+
+`terminal-rerun-rejected` 锁定 PR2 contract：`completed` job 不能再次运行，必须返回 `409 JOB_TERMINAL`。
+
+## Boundaries
+
+- 不新增或修改 `attendance_*` migration。
+- 不让多维表成为考勤查询 / 导出的事实源。
+- 不直接写 `meta_*`。
+- 不改 `POST /api/attendance/report-sync-jobs` 或 writer 逻辑。
+- 不实现 scheduler / queue auto-run。
+- 不提交 staging JWT、token literal 或 live output。
+
+## Claude
+
+本轮由 Codex 实现。若需要二审，Claude 适合按 PR4 ops-harness contract review：确认 job mode 只调用既有 PR2 routes、没有改业务 writer、没有把 staging output 或 token 写入仓库。

--- a/docs/development/attendance-report-sync-jobs-pr4-verification-20260519.md
+++ b/docs/development/attendance-report-sync-jobs-pr4-verification-20260519.md
@@ -1,0 +1,104 @@
+# 考勤报表同步任务化 PR4 验证记录
+
+Date: 2026-05-19
+
+## Scope
+
+验证 PR4 的 live acceptance job mode。
+
+本轮只验证脚本、mock live harness 与文档，不运行真实 staging 写入。当前会话里上一份 staging JWT 已于 `2026-05-19T07:44:10Z` 过期；真实 staging `JOB_MODE=1` 需要 operator 重新提供文件型短期 admin JWT，并显式确认写入。
+
+## Local Checks
+
+| Check | Result |
+| --- | --- |
+| `node --check scripts/ops/attendance-report-fields-live-acceptance.mjs` | PASS |
+| `node --check scripts/ops/attendance-report-fields-live-acceptance.test.mjs` | PASS |
+| `node --check scripts/ops/attendance-report-period-summaries-live-acceptance.mjs` | PASS |
+| `node --check scripts/ops/attendance-report-period-summaries-live-acceptance.test.mjs` | PASS |
+| `node --test scripts/ops/attendance-report-fields-live-acceptance.test.mjs` | PASS, 19 tests |
+| `node --test scripts/ops/attendance-report-period-summaries-live-acceptance.test.mjs` | PASS, 7 tests |
+| `pnpm run verify:attendance-report-fields:live:test` | PASS, 19 tests |
+| `pnpm run verify:attendance-report-period-summaries:live:test` | PASS, 7 tests |
+| `git diff --check` | PASS |
+
+## Unit Coverage Added
+
+### Daily report-records job mode
+
+- `JOB_MODE=1` requires explicit user selection.
+- Harness creates `daily_records` job with:
+  - `mode=manual_step`
+  - `periodSource={from,to}`
+  - `userSelection={userId}`
+  - configured `JOB_PAGE_SIZE`
+- Harness calls `run-next-page` until `completed`.
+- Harness verifies totals exist on the final job.
+- Harness verifies completed job rerun is rejected with `409 JOB_TERMINAL`.
+- Harness verifies a replacement job can be created after terminal rejection, then cancels it so no queued job is left behind.
+- Markdown output includes job status but does not include token material.
+
+### Period summaries job mode
+
+- Harness creates period `date_range` job when `JOB_MODE=1`.
+- Harness creates optional `payroll_cycle` job when `CYCLE_ID` is present.
+- Harness maps `USER_IDS` into `userSelection={userIds:[...]}`.
+- Harness verifies each job reaches `completed`.
+- Harness verifies terminal rerun is rejected with `409 JOB_TERMINAL`.
+- Harness verifies replacement date-range / cycle jobs can be created and canceled.
+
+## Staging Command Template
+
+Use only after a fresh file-based admin JWT is available and staging writes are explicitly authorized:
+
+```bash
+AUTH_SOURCE=AUTH_TOKEN_FILE \
+AUTH_TOKEN_FILE=/tmp/<staging-admin-jwt-file>.jwt \
+API_BASE=http://localhost:8082 \
+ORG_ID=default \
+USER_ID=<sample-user-id> \
+FROM_DATE=2026-05-01 \
+TO_DATE=2026-05-13 \
+JOB_MODE=1 \
+JOB_PAGE_SIZE=2 \
+CONFIRM_SYNC=1 \
+OUTPUT_DIR=output/attendance-report-fields-live-acceptance/<run> \
+pnpm run verify:attendance-report-fields:live
+```
+
+```bash
+AUTH_SOURCE=AUTH_TOKEN_FILE \
+AUTH_TOKEN_FILE=/tmp/<staging-admin-jwt-file>.jwt \
+API_BASE=http://localhost:8082 \
+ORG_ID=default \
+USER_IDS=<sample-user-id> \
+FROM_DATE=2026-05-01 \
+TO_DATE=2026-05-13 \
+CYCLE_ID=<optional-cycle-id> \
+JOB_MODE=1 \
+PAGE_SIZE=2 \
+CONFIRM_SYNC=1 \
+OUTPUT_DIR=output/attendance-report-period-summaries-live-acceptance/<run> \
+pnpm run verify:attendance-report-period-summaries:live
+```
+
+## Boundary Verification
+
+- Job mode calls only existing PR2 routes:
+  - `POST /api/attendance/report-sync-jobs`
+  - `POST /api/attendance/report-sync-jobs/:id/run-next-page`
+- Existing immediate sync and report-field checks remain intact.
+- No plugin writer or route logic changed.
+- No frontend code changed.
+- No migration changed.
+- No secret, JWT, or generated staging output is committed.
+
+## Deferred Live Evidence
+
+Real staging `JOB_MODE=1` evidence remains pending fresh credentials. The expected live evidence should include:
+
+- daily job create -> run pages -> completed
+- period date-range job create -> run pages -> completed
+- optional period cycle job create -> run pages -> completed
+- completed job rerun rejected with `409 JOB_TERMINAL`
+- replacement job create + cancel

--- a/docs/development/attendance-report-sync-jobs-todo-20260519.md
+++ b/docs/development/attendance-report-sync-jobs-todo-20260519.md
@@ -228,10 +228,12 @@ Rules:
 
 ### PR4: Live Acceptance Harness
 
-- Extend existing report records and period summaries live acceptance with optional `JOB_MODE=1`.
-- Verify create job -> run pages -> completed.
-- Verify rerun completed job is rejected and new job can be created.
-- Staging live only after explicit authorization and file-based JWT.
+- [x] Extend existing report records and period summaries live acceptance with optional `JOB_MODE=1`.
+- [x] Verify create job -> run pages -> completed.
+- [x] Verify rerun completed job is rejected and a replacement job can be created.
+- [x] Staging live only after explicit authorization and file-based JWT.
+
+**PR4 implementation pointer:** `docs/development/attendance-report-sync-jobs-pr4-development-20260519.md`; verification: `docs/development/attendance-report-sync-jobs-pr4-verification-20260519.md`.
 
 ## Hard Boundaries
 

--- a/scripts/ops/attendance-report-fields-live-acceptance.mjs
+++ b/scripts/ops/attendance-report-fields-live-acceptance.mjs
@@ -20,6 +20,19 @@ export function parseBoolean(value) {
   return value === '1' || value === 'true' || value === 'TRUE' || value === 'yes'
 }
 
+function parsePositiveInteger(value, fallback) {
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback
+  return Math.floor(parsed)
+}
+
+function splitCsv(value) {
+  return String(value || '')
+    .split(',')
+    .map(item => item.trim())
+    .filter(Boolean)
+}
+
 export function normalizeBaseUrl(value) {
   const normalized = String(value || '').trim().replace(/\/+$/, '')
   return normalized || DEFAULT_API_BASE
@@ -78,6 +91,11 @@ export function parseConfig(env = process.env, now = new Date()) {
     expectVisibleCode: String(env.EXPECT_VISIBLE_CODE || 'work_date').trim(),
     expectHiddenCode: String(env.EXPECT_HIDDEN_CODE || '').trim(),
     expectFormulaCode: String(env.EXPECT_FORMULA_CODE || '').trim(),
+    jobMode: parseBoolean(env.JOB_MODE),
+    jobUserIds: splitCsv(env.JOB_USER_IDS || env.USER_IDS),
+    jobAllUsers: parseBoolean(env.JOB_ALL_USERS || env.ALL_USERS),
+    jobPageSize: parsePositiveInteger(env.JOB_PAGE_SIZE || env.PAGE_SIZE, 5),
+    jobMaxPages: parsePositiveInteger(env.JOB_MAX_PAGES || env.MAX_JOB_PAGES, 10),
     devUserId: String(env.DEV_USER_ID || 'dev-admin').trim(),
     outputDir,
     reportPath: String(env.REPORT_JSON || path.join(outputDir, 'report.json')),
@@ -108,6 +126,10 @@ export function validateConfig(config) {
   if (!isValidHostHeader(config.hostHeader)) missing.push('API_HOST_HEADER host[:port]')
   if (!/^\d{4}-\d{2}-\d{2}$/.test(config.from)) missing.push('FROM_DATE yyyy-mm-dd')
   if (!/^\d{4}-\d{2}-\d{2}$/.test(config.to)) missing.push('TO_DATE yyyy-mm-dd')
+  if (!config.preflightOnly && config.jobMode) {
+    const selectedCount = (config.userId ? 1 : 0) + (config.jobUserIds.length > 0 ? 1 : 0) + (config.jobAllUsers ? 1 : 0)
+    if (selectedCount !== 1) missing.push('USER_ID/JOB_USER_IDS or JOB_ALL_USERS=1 for JOB_MODE=1')
+  }
   return missing
 }
 
@@ -332,11 +354,17 @@ async function fetchJson(url, options = {}, timeoutMs = DEFAULT_TIMEOUT_MS, host
 
 async function requestJson(config, token, route, options = {}) {
   const url = `${config.apiBase}${route}`
+  const body = options.body === undefined || options.body === null
+    ? options.body
+    : typeof options.body === 'string' || Buffer.isBuffer(options.body)
+      ? options.body
+      : JSON.stringify(options.body)
   return fetchJson(url, {
     ...options,
+    body,
     headers: {
       ...(token ? { Authorization: `Bearer ${token}` } : {}),
-      ...(options.body ? { 'Content-Type': 'application/json' } : {}),
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
       ...(options.headers || {}),
     },
   }, config.timeoutMs, config.hostHeader)
@@ -368,6 +396,134 @@ function ensureOk(name, result) {
 
 function payloadData(json) {
   return json?.data && typeof json.data === 'object' ? json.data : {}
+}
+
+function reportSyncJobUserSelection(config) {
+  if (config.jobAllUsers) return { allUsers: true }
+  if (config.jobUserIds.length > 0) return { userIds: config.jobUserIds }
+  return { userId: config.userId }
+}
+
+function reportSyncJobBody(config, kind = 'daily_records', periodSource = { from: config.from, to: config.to }) {
+  return {
+    kind,
+    mode: 'manual_step',
+    pageSize: config.jobPageSize,
+    periodSource,
+    userSelection: reportSyncJobUserSelection(config),
+  }
+}
+
+function isTerminalJobStatus(status) {
+  return ['completed', 'canceled', 'failed'].includes(String(status || '').trim())
+}
+
+function jobTotalsPresent(job) {
+  const totals = job?.totals && typeof job.totals === 'object' ? job.totals : null
+  return Boolean(totals && Number.isFinite(Number(totals.usersScanned)) && Number.isFinite(Number(totals.synced)))
+}
+
+async function runReportSyncJobAcceptance(config, token, label, body, record) {
+  const created = payloadData(await checkedRequest(
+    config,
+    token,
+    `/api/attendance/report-sync-jobs?${buildQuery(config)}`,
+    `api.${label}.job.create`,
+    'POST /api/attendance/report-sync-jobs',
+    record,
+    { method: 'POST', body },
+  ))
+  const jobId = String(created?.id || '')
+  record(`${label}.job.created`, Boolean(jobId), {
+    jobId: jobId || 'missing',
+    kind: created?.kind || 'missing',
+    status: created?.status || 'missing',
+  })
+
+  let job = created
+  let pageCount = 0
+  const pageStatuses = []
+  while (jobId && !isTerminalJobStatus(job?.status) && pageCount < config.jobMaxPages) {
+    pageCount += 1
+    const pageData = payloadData(await checkedRequest(
+      config,
+      token,
+      `/api/attendance/report-sync-jobs/${encodeURIComponent(jobId)}/run-next-page?${buildQuery(config)}`,
+      `api.${label}.job.run-page`,
+      'POST /api/attendance/report-sync-jobs/:id/run-next-page',
+      record,
+      { method: 'POST' },
+    ))
+    job = pageData.job || job
+    pageStatuses.push(job?.status || 'missing')
+  }
+
+  record(`${label}.job.completed`, job?.status === 'completed', {
+    jobId: jobId || 'missing',
+    status: job?.status || 'missing',
+    pages: pageCount,
+  })
+  record(`${label}.job.pages-within-limit`, pageCount > 0 && pageCount <= config.jobMaxPages, {
+    pages: pageCount,
+    maxPages: config.jobMaxPages,
+    statuses: pageStatuses.join(','),
+  })
+  record(`${label}.job.totals-present`, jobTotalsPresent(job), {
+    usersScanned: job?.totals?.usersScanned ?? 'missing',
+    synced: job?.totals?.synced ?? 'missing',
+    failed: job?.totals?.failed ?? 'missing',
+  })
+
+  if (jobId && job?.status === 'completed') {
+    const rerun = await requestJson(
+      config,
+      token,
+      `/api/attendance/report-sync-jobs/${encodeURIComponent(jobId)}/run-next-page?${buildQuery(config)}`,
+      { method: 'POST' },
+    )
+    const errorCode = rerun?.json?.error?.code || ''
+    record(`${label}.job.terminal-rerun-rejected`, rerun.res.status === 409 && errorCode === 'JOB_TERMINAL', {
+      status: rerun.res.status,
+      code: errorCode || 'missing',
+    })
+    const replacement = payloadData(await checkedRequest(
+      config,
+      token,
+      `/api/attendance/report-sync-jobs?${buildQuery(config)}`,
+      `api.${label}.job.create-after-terminal`,
+      'POST /api/attendance/report-sync-jobs',
+      record,
+      { method: 'POST', body },
+    ))
+    const replacementJobId = String(replacement?.id || '')
+    record(`${label}.job.new-job-created`, Boolean(replacementJobId && replacementJobId !== jobId), {
+      jobId: replacementJobId || 'missing',
+      previousJobId: jobId,
+      status: replacement?.status || 'missing',
+    })
+    if (replacementJobId) {
+      const canceled = payloadData(await checkedRequest(
+        config,
+        token,
+        `/api/attendance/report-sync-jobs/${encodeURIComponent(replacementJobId)}/cancel?${buildQuery(config)}`,
+        `api.${label}.job.cancel-new-job`,
+        'POST /api/attendance/report-sync-jobs/:id/cancel',
+        record,
+        { method: 'POST' },
+      ))
+      record(`${label}.job.new-job-canceled`, canceled?.status === 'canceled', {
+        jobId: replacementJobId,
+        status: canceled?.status || 'missing',
+      })
+    }
+  } else {
+    record(`${label}.job.terminal-rerun-rejected`, false, {
+      reason: 'job did not reach completed status',
+      status: job?.status || 'missing',
+    })
+  }
+
+  return { jobId, job, pageCount }
 }
 
 function extractCategoryIds(categories) {
@@ -602,6 +758,10 @@ export function renderHelp() {
     '  EXPECT_VISIBLE_CODE=work_date',
     '  EXPECT_HIDDEN_CODE=<field_code>',
     '  EXPECT_FORMULA_CODE=<formula_field_code>',
+    '  JOB_MODE=1',
+    '  JOB_ALL_USERS=1 or JOB_USER_IDS=<id,id> (USER_ID also works)',
+    '  JOB_PAGE_SIZE=5',
+    '  JOB_MAX_PAGES=10',
     '  AUTH_SOURCE=AUTH_TOKEN|AUTH_TOKEN_FILE|ALLOW_DEV_TOKEN',
     '  OUTPUT_DIR=output/attendance-report-fields-live-acceptance/<run>',
     '',
@@ -626,6 +786,17 @@ const MARKDOWN_CHECK_DETAIL_KEYS = Object.freeze([
   'csvCodeBacking',
   'exportBacking',
   'fieldCount',
+  'jobId',
+  'kind',
+  'pages',
+  'maxPages',
+  'statuses',
+  'synced',
+  'created',
+  'patched',
+  'skipped',
+  'failed',
+  'usersScanned',
   'selected',
   'present',
   'ignored',
@@ -669,6 +840,9 @@ const EVIDENCE_SUMMARY_METADATA_KEYS = Object.freeze([
   ['CSV code field codes', 'csvCodeFieldCodes'],
   ['Formula field codes', 'formulaFieldCodes'],
   ['Formula invalid codes', 'formulaInvalidCodes'],
+  ['Daily job id', 'dailyJobId'],
+  ['Daily job status', 'dailyJobStatus'],
+  ['Daily job pages', 'dailyJobPages'],
   ['CSV backing', 'csvBacking'],
   ['CSV code backing', 'csvCodeBacking'],
 ])
@@ -1092,6 +1266,22 @@ export async function runAttendanceReportFieldsAcceptance(config) {
     report.metadata.csvCodeFieldFingerprint = csvCodeFieldFingerprint
     report.metadata.csvCodeFieldCodes = csvCodeFieldCodes.join(',')
     report.metadata.csvCodeBacking = csvCodeBackingFingerprint
+
+    if (config.jobMode) {
+      const dailyJob = await runReportSyncJobAcceptance(
+        config,
+        token,
+        'daily-records',
+        reportSyncJobBody(config, 'daily_records'),
+        record,
+      )
+      report.metadata.dailyJobId = dailyJob.jobId
+      report.metadata.dailyJobStatus = dailyJob.job?.status || ''
+      report.metadata.dailyJobPages = dailyJob.pageCount
+    } else {
+      record('daily-records.job.skipped', true, { reason: 'JOB_MODE not set' })
+    }
+
     record('runner.completed', true)
   } catch (error) {
     report.ok = false

--- a/scripts/ops/attendance-report-fields-live-acceptance.test.mjs
+++ b/scripts/ops/attendance-report-fields-live-acceptance.test.mjs
@@ -23,6 +23,22 @@ function sendText(res, status, text, contentType = 'text/plain; charset=utf-8', 
   res.end(text)
 }
 
+function readBody(req) {
+  return new Promise((resolve) => {
+    const chunks = []
+    req.setEncoding('utf8')
+    req.on('data', chunk => chunks.push(chunk))
+    req.on('end', () => {
+      const text = chunks.join('')
+      try {
+        resolve(text ? JSON.parse(text) : {})
+      } catch {
+        resolve({})
+      }
+    })
+  })
+}
+
 const categories = [
   { id: 'fixed', label: '固定字段' },
   { id: 'basic', label: '基础字段' },
@@ -114,8 +130,11 @@ function catalogPayload() {
 
 async function startMockServer() {
   const calls = []
+  const bodies = []
   const hostHeaders = []
-  const server = http.createServer((req, res) => {
+  const jobRunCounts = new Map()
+  let jobCreateCount = 0
+  const server = http.createServer(async (req, res) => {
     const url = new URL(req.url || '/', 'http://127.0.0.1')
     calls.push(`${req.method} ${url.pathname}`)
     hostHeaders.push(req.headers.host || '')
@@ -173,6 +192,66 @@ async function startMockServer() {
       })
       return
     }
+    if (url.pathname === '/api/attendance/report-sync-jobs' && req.method === 'POST') {
+      const body = await readBody(req)
+      bodies.push(body)
+      jobCreateCount += 1
+      const jobId = `daily-job-${jobCreateCount}`
+      send(res, 201, {
+        ok: true,
+        data: {
+          id: jobId,
+          kind: body.kind,
+          status: 'queued',
+          mode: body.mode,
+          periodSource: body.periodSource,
+          userSelection: body.userSelection,
+          cursor: { nextPage: 1, pageSize: body.pageSize, hasNextPage: true },
+          totals: { usersScanned: 0, usersSynced: 0, usersFailed: 0, synced: 0, rowsSynced: 0, created: 0, patched: 0, skipped: 0, failed: 0, duplicateRowKeys: 0 },
+        },
+      })
+      return
+    }
+    const jobCancelMatch = url.pathname.match(/^\/api\/attendance\/report-sync-jobs\/([^/]+)\/cancel$/)
+    if (jobCancelMatch && req.method === 'POST') {
+      const jobId = decodeURIComponent(jobCancelMatch[1])
+      send(res, 200, {
+        ok: true,
+        data: {
+          id: jobId,
+          kind: 'daily_records',
+          status: 'canceled',
+          totals: { usersScanned: 0, usersSynced: 0, usersFailed: 0, synced: 0, rowsSynced: 0, created: 0, patched: 0, skipped: 0, failed: 0, duplicateRowKeys: 0 },
+        },
+      })
+      return
+    }
+    const jobRunMatch = url.pathname.match(/^\/api\/attendance\/report-sync-jobs\/([^/]+)\/run-next-page$/)
+    if (jobRunMatch && req.method === 'POST') {
+      const jobId = decodeURIComponent(jobRunMatch[1])
+      const runCount = (jobRunCounts.get(jobId) || 0) + 1
+      jobRunCounts.set(jobId, runCount)
+      if (runCount > 2) {
+        send(res, 409, { ok: false, error: { code: 'JOB_TERMINAL', message: 'Completed or canceled attendance report sync jobs cannot run again' } })
+        return
+      }
+      const completed = runCount === 2
+      send(res, 200, {
+        ok: true,
+        data: {
+          job: {
+            id: jobId,
+            kind: 'daily_records',
+            status: completed ? 'completed' : 'queued',
+            cursor: { nextPage: completed ? 2 : 2, pageSize: 2, hasNextPage: !completed },
+            totals: { usersScanned: runCount, usersSynced: runCount, usersFailed: 0, synced: runCount, rowsSynced: runCount, created: runCount, patched: 0, skipped: 0, failed: 0, duplicateRowKeys: 0 },
+            lastResult: { usersScanned: 1, synced: 1, hasNextPage: !completed },
+          },
+          pageResult: { usersScanned: 1, synced: 1, hasNextPage: !completed },
+        },
+      })
+      return
+    }
 
     send(res, 404, { ok: false, error: { code: 'NOT_FOUND', message: url.pathname } })
   })
@@ -182,6 +261,7 @@ async function startMockServer() {
   return {
     baseUrl: `http://127.0.0.1:${address.port}`,
     calls,
+    bodies,
     hostHeaders,
     close: () => new Promise((resolve) => server.close(resolve)),
   }
@@ -259,6 +339,20 @@ test('validateConfig rejects invalid API host headers', () => {
     TO_DATE: '2026-05-13',
   })
   assert.deepEqual(validateConfig(config), ['API_HOST_HEADER host[:port]'])
+})
+
+test('validateConfig requires an explicit user selection for job mode', () => {
+  const config = parseConfig({
+    API_BASE: 'https://staging.example.test/',
+    AUTH_TOKEN: 'jwt-from-env',
+    CONFIRM_SYNC: '1',
+    JOB_MODE: '1',
+    FROM_DATE: '2026-05-01',
+    TO_DATE: '2026-05-13',
+  })
+  assert.deepEqual(validateConfig(config), [
+    'USER_ID/JOB_USER_IDS or JOB_ALL_USERS=1 for JOB_MODE=1',
+  ])
 })
 
 test('validateConfig allows preflight without auth or sync confirmation', () => {
@@ -644,6 +738,60 @@ test('runAttendanceReportFieldsAcceptance verifies catalog, records, export, and
     assert.ok(markdown.includes('- CSV backing: `default:attendance|attendance_report_field_catalog|sheet_attendance_report_fields|fields_by_category`'))
     assert.ok(markdown.includes('- CSV code backing: `default:attendance|attendance_report_field_catalog|sheet_attendance_report_fields|fields_by_category`'))
     assert.match(markdown, /Auth source: `AUTH_TOKEN_FILE`/)
+    assert.doesNotMatch(markdown, /unit-test-token/)
+  } finally {
+    await server.close()
+  }
+})
+
+test('JOB_MODE runs daily report sync job to completion and rejects terminal rerun', async () => {
+  const server = await startMockServer()
+  const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'attendance-report-fields-job-mode-'))
+  const tokenFile = path.join(outputDir, 'admin.jwt')
+  fs.writeFileSync(tokenFile, 'unit-test-token\n', { mode: 0o600 })
+  try {
+    const report = await runAttendanceReportFieldsAcceptance(parseConfig({
+      API_BASE: server.baseUrl,
+      AUTH_TOKEN_FILE: tokenFile,
+      CONFIRM_SYNC: '1',
+      ORG_ID: 'default',
+      USER_ID: 'user-1',
+      FROM_DATE: '2026-05-01',
+      TO_DATE: '2026-05-13',
+      JOB_MODE: '1',
+      JOB_PAGE_SIZE: '2',
+      OUTPUT_DIR: outputDir,
+    }))
+
+    assert.equal(report.ok, true)
+    assert.equal(report.metadata.dailyJobId, 'daily-job-1')
+    assert.equal(report.metadata.dailyJobStatus, 'completed')
+    assert.equal(report.metadata.dailyJobPages, 2)
+    assert.deepEqual(server.bodies, [
+      {
+        kind: 'daily_records',
+        mode: 'manual_step',
+        pageSize: 2,
+        periodSource: { from: '2026-05-01', to: '2026-05-13' },
+        userSelection: { userId: 'user-1' },
+      },
+      {
+        kind: 'daily_records',
+        mode: 'manual_step',
+        pageSize: 2,
+        periodSource: { from: '2026-05-01', to: '2026-05-13' },
+        userSelection: { userId: 'user-1' },
+      },
+    ])
+    assert.ok(report.checks.some((check) => check.name === 'daily-records.job.created' && check.ok))
+    assert.ok(report.checks.some((check) => check.name === 'daily-records.job.completed' && check.ok))
+    assert.ok(report.checks.some((check) => check.name === 'daily-records.job.pages-within-limit' && check.ok))
+    assert.ok(report.checks.some((check) => check.name === 'daily-records.job.totals-present' && check.ok))
+    assert.ok(report.checks.some((check) => check.name === 'daily-records.job.terminal-rerun-rejected' && check.ok))
+    assert.ok(report.checks.some((check) => check.name === 'daily-records.job.new-job-created' && check.ok))
+    assert.ok(report.checks.some((check) => check.name === 'daily-records.job.new-job-canceled' && check.ok))
+    const markdown = fs.readFileSync(path.join(outputDir, 'report.md'), 'utf8')
+    assert.match(markdown, /Daily job status: `completed`/)
     assert.doesNotMatch(markdown, /unit-test-token/)
   } finally {
     await server.close()

--- a/scripts/ops/attendance-report-period-summaries-live-acceptance.mjs
+++ b/scripts/ops/attendance-report-period-summaries-live-acceptance.mjs
@@ -94,6 +94,8 @@ export function parseConfig(env = process.env, now = new Date()) {
     cycleId: String(env.CYCLE_ID || '').trim(),
     page: parsePositiveInteger(env.PAGE, DEFAULT_PAGE),
     pageSize: parsePositiveInteger(env.PAGE_SIZE, DEFAULT_PAGE_SIZE),
+    jobMode: parseBoolean(env.JOB_MODE),
+    jobMaxPages: parsePositiveInteger(env.JOB_MAX_PAGES || env.MAX_JOB_PAGES, 10),
     expectObjectId: String(env.EXPECT_OBJECT_ID || EXPECTED_OBJECT_ID).trim(),
     expectFieldFingerprint: String(env.EXPECT_FIELD_FINGERPRINT || '').trim(),
     expectUsersScanned: env.EXPECT_USERS_SCANNED === undefined ? null : Number(env.EXPECT_USERS_SCANNED),
@@ -434,6 +436,130 @@ function createdOrPatched(data) {
   return Number(data?.created ?? 0) + Number(data?.patched ?? 0) > 0
 }
 
+function isTerminalJobStatus(status) {
+  return ['completed', 'canceled', 'failed'].includes(String(status || '').trim())
+}
+
+function jobTotalsPresent(job) {
+  const totals = job?.totals && typeof job.totals === 'object' ? job.totals : null
+  return Boolean(totals && Number.isFinite(Number(totals.usersScanned)) && Number.isFinite(Number(totals.synced)))
+}
+
+function reportSyncJobUserSelection(config) {
+  if (config.allUsers) return { allUsers: true }
+  if (config.userIds.length > 0) return { userIds: config.userIds }
+  return { userId: config.userId }
+}
+
+function reportSyncJobBody(config, periodSource) {
+  return {
+    kind: 'period_summaries',
+    mode: 'manual_step',
+    pageSize: config.pageSize,
+    periodSource,
+    userSelection: reportSyncJobUserSelection(config),
+  }
+}
+
+async function runReportSyncJobAcceptance(config, token, label, body, record) {
+  const created = payloadData(await checkedRequest(
+    config,
+    token,
+    `/api/attendance/report-sync-jobs?${buildQuery(config)}`,
+    `api.${label}.job.create`,
+    record,
+    { method: 'POST', body },
+  ))
+  const jobId = String(created?.id || '')
+  record(`${label}.job.created`, Boolean(jobId), {
+    jobId: jobId || 'missing',
+    kind: created?.kind || 'missing',
+    status: created?.status || 'missing',
+  })
+
+  let job = created
+  let pageCount = 0
+  const pageStatuses = []
+  while (jobId && !isTerminalJobStatus(job?.status) && pageCount < config.jobMaxPages) {
+    pageCount += 1
+    const pageData = payloadData(await checkedRequest(
+      config,
+      token,
+      `/api/attendance/report-sync-jobs/${encodeURIComponent(jobId)}/run-next-page?${buildQuery(config)}`,
+      `api.${label}.job.run-page`,
+      record,
+      { method: 'POST' },
+    ))
+    job = pageData.job || job
+    pageStatuses.push(job?.status || 'missing')
+  }
+
+  record(`${label}.job.completed`, job?.status === 'completed', {
+    jobId: jobId || 'missing',
+    status: job?.status || 'missing',
+    pages: pageCount,
+  })
+  record(`${label}.job.pages-within-limit`, pageCount > 0 && pageCount <= config.jobMaxPages, {
+    pages: pageCount,
+    maxPages: config.jobMaxPages,
+    statuses: pageStatuses.join(','),
+  })
+  record(`${label}.job.totals-present`, jobTotalsPresent(job), {
+    usersScanned: job?.totals?.usersScanned ?? 'missing',
+    synced: job?.totals?.synced ?? 'missing',
+    failed: job?.totals?.failed ?? 'missing',
+  })
+
+  if (jobId && job?.status === 'completed') {
+    const rerun = await requestJson(
+      config,
+      token,
+      `/api/attendance/report-sync-jobs/${encodeURIComponent(jobId)}/run-next-page?${buildQuery(config)}`,
+      { method: 'POST' },
+    )
+    const errorCode = rerun?.json?.error?.code || ''
+    record(`${label}.job.terminal-rerun-rejected`, rerun.res.status === 409 && errorCode === 'JOB_TERMINAL', {
+      status: rerun.res.status,
+      code: errorCode || 'missing',
+    })
+    const replacement = payloadData(await checkedRequest(
+      config,
+      token,
+      `/api/attendance/report-sync-jobs?${buildQuery(config)}`,
+      `api.${label}.job.create-after-terminal`,
+      record,
+      { method: 'POST', body },
+    ))
+    const replacementJobId = String(replacement?.id || '')
+    record(`${label}.job.new-job-created`, Boolean(replacementJobId && replacementJobId !== jobId), {
+      jobId: replacementJobId || 'missing',
+      previousJobId: jobId,
+      status: replacement?.status || 'missing',
+    })
+    if (replacementJobId) {
+      const canceled = payloadData(await checkedRequest(
+        config,
+        token,
+        `/api/attendance/report-sync-jobs/${encodeURIComponent(replacementJobId)}/cancel?${buildQuery(config)}`,
+        `api.${label}.job.cancel-new-job`,
+        record,
+        { method: 'POST' },
+      ))
+      record(`${label}.job.new-job-canceled`, canceled?.status === 'canceled', {
+        jobId: replacementJobId,
+        status: canceled?.status || 'missing',
+      })
+    }
+  } else {
+    record(`${label}.job.terminal-rerun-rejected`, false, {
+      reason: 'job did not reach completed status',
+      status: job?.status || 'missing',
+    })
+  }
+
+  return { jobId, job, pageCount }
+}
+
 function usersScannedMatches(data, config) {
   if (config.expectUsersScanned === null) return true
   return Number(data?.usersScanned ?? data?.synced ?? 0) === config.expectUsersScanned
@@ -549,6 +675,8 @@ export function renderHelp() {
     '  CYCLE_ID=<optional-payroll-cycle-id>',
     '  PAGE=1',
     '  PAGE_SIZE=5',
+    '  JOB_MODE=1',
+    '  JOB_MAX_PAGES=10',
     '  EXPECT_USERS_SCANNED=1',
     '  EXPECT_CREATED_OR_PATCHED=1',
     '  AUTH_SOURCE=AUTH_TOKEN|AUTH_TOKEN_FILE|ALLOW_DEV_TOKEN',
@@ -577,6 +705,12 @@ const MARKDOWN_CHECK_DETAIL_KEYS = Object.freeze([
   'failed',
   'duplicateRowKeys',
   'usersScanned',
+  'jobId',
+  'kind',
+  'pages',
+  'maxPages',
+  'statuses',
+  'synced',
   'expected',
   'objectId',
   'fingerprint',
@@ -719,12 +853,42 @@ export async function runAttendanceReportPeriodSummariesAcceptance(config) {
     report.metadata.dateRangeSheetId = dateRange.second.multitable?.sheetId || dateRange.first.multitable?.sheetId || ''
     report.metadata.dateRangeViewId = dateRange.second.multitable?.viewId || dateRange.first.multitable?.viewId || ''
 
+    if (config.jobMode) {
+      const dateRangeJob = await runReportSyncJobAcceptance(
+        config,
+        token,
+        'date-range',
+        reportSyncJobBody(config, { from: config.from, to: config.to }),
+        record,
+      )
+      report.metadata.dateRangeJobId = dateRangeJob.jobId
+      report.metadata.dateRangeJobStatus = dateRangeJob.job?.status || ''
+      report.metadata.dateRangeJobPages = dateRangeJob.pageCount
+    } else {
+      record('date-range.job.skipped', true, { reason: 'JOB_MODE not set' })
+    }
+
     if (config.cycleId) {
       const cycle = await syncPeriodTwice(config, token, 'payroll-cycle', buildCycleBody(config), record)
       report.metadata.cycleFieldFingerprint = cycle.second.fieldFingerprint || cycle.first.fieldFingerprint || ''
       report.metadata.cycleId = config.cycleId
+      if (config.jobMode) {
+        const cycleJob = await runReportSyncJobAcceptance(
+          config,
+          token,
+          'payroll-cycle',
+          reportSyncJobBody(config, { cycleId: config.cycleId }),
+          record,
+        )
+        report.metadata.cycleJobId = cycleJob.jobId
+        report.metadata.cycleJobStatus = cycleJob.job?.status || ''
+        report.metadata.cycleJobPages = cycleJob.pageCount
+      } else {
+        record('payroll-cycle.job.skipped', true, { reason: 'JOB_MODE not set' })
+      }
     } else {
       record('payroll-cycle.skipped', true, { reason: 'CYCLE_ID not set' })
+      record('payroll-cycle.job.skipped', true, { reason: 'CYCLE_ID not set' })
     }
 
     record('runner.completed', report.ok)

--- a/scripts/ops/attendance-report-period-summaries-live-acceptance.test.mjs
+++ b/scripts/ops/attendance-report-period-summaries-live-acceptance.test.mjs
@@ -78,6 +78,10 @@ function syncPayload(body, count) {
 async function startMockServer() {
   const calls = []
   const bodies = []
+  const jobBodies = []
+  const jobRunCounts = new Map()
+  let dateJobCreateCount = 0
+  let cycleJobCreateCount = 0
   let dateSyncCount = 0
   let cycleSyncCount = 0
   const server = http.createServer(async (req, res) => {
@@ -104,6 +108,67 @@ async function startMockServer() {
       send(res, 200, syncPayload(body, dateSyncCount))
       return
     }
+    if (url.pathname === '/api/attendance/report-sync-jobs' && req.method === 'POST') {
+      const body = await readBody(req)
+      jobBodies.push(body)
+      const isCycle = Boolean(body.periodSource?.cycleId)
+      const id = isCycle
+        ? `period-cycle-job-${++cycleJobCreateCount}`
+        : `period-date-job-${++dateJobCreateCount}`
+      send(res, 201, {
+        ok: true,
+        data: {
+          id,
+          kind: body.kind,
+          status: 'queued',
+          mode: body.mode,
+          periodSource: body.periodSource,
+          userSelection: body.userSelection,
+          cursor: { nextPage: 1, pageSize: body.pageSize, hasNextPage: true },
+          totals: { usersScanned: 0, usersSynced: 0, usersFailed: 0, synced: 0, rowsSynced: 0, created: 0, patched: 0, skipped: 0, failed: 0, duplicateRowKeys: 0 },
+        },
+      })
+      return
+    }
+    const jobCancelMatch = url.pathname.match(/^\/api\/attendance\/report-sync-jobs\/([^/]+)\/cancel$/)
+    if (jobCancelMatch && req.method === 'POST') {
+      const jobId = decodeURIComponent(jobCancelMatch[1])
+      send(res, 200, {
+        ok: true,
+        data: {
+          id: jobId,
+          kind: 'period_summaries',
+          status: 'canceled',
+          totals: { usersScanned: 0, usersSynced: 0, usersFailed: 0, synced: 0, rowsSynced: 0, created: 0, patched: 0, skipped: 0, failed: 0, duplicateRowKeys: 0 },
+        },
+      })
+      return
+    }
+    const jobRunMatch = url.pathname.match(/^\/api\/attendance\/report-sync-jobs\/([^/]+)\/run-next-page$/)
+    if (jobRunMatch && req.method === 'POST') {
+      const jobId = decodeURIComponent(jobRunMatch[1])
+      const runCount = (jobRunCounts.get(jobId) || 0) + 1
+      jobRunCounts.set(jobId, runCount)
+      if (runCount > 1) {
+        send(res, 409, { ok: false, error: { code: 'JOB_TERMINAL', message: 'Completed or canceled attendance report sync jobs cannot run again' } })
+        return
+      }
+      send(res, 200, {
+        ok: true,
+        data: {
+          job: {
+            id: jobId,
+            kind: 'period_summaries',
+            status: 'completed',
+            cursor: { nextPage: 1, pageSize: 5, hasNextPage: false },
+            totals: { usersScanned: 1, usersSynced: 1, usersFailed: 0, synced: 1, rowsSynced: 1, created: 1, patched: 0, skipped: 0, failed: 0, duplicateRowKeys: 0 },
+            lastResult: { usersScanned: 1, synced: 1, hasNextPage: false },
+          },
+          pageResult: { usersScanned: 1, synced: 1, hasNextPage: false },
+        },
+      })
+      return
+    }
 
     send(res, 404, { ok: false, error: { code: 'NOT_FOUND', message: url.pathname } })
   })
@@ -114,6 +179,7 @@ async function startMockServer() {
     baseUrl: `http://127.0.0.1:${address.port}`,
     calls,
     bodies,
+    jobBodies,
     close: () => new Promise(resolve => server.close(resolve)),
   }
 }
@@ -184,6 +250,70 @@ test('run acceptance syncs date range and optional cycle twice', async () => {
     ])
     assert.equal(report.checks.some(check => check.name === 'date-range.rerun-skipped' && check.ok), true)
     assert.equal(report.checks.some(check => check.name === 'payroll-cycle.rerun-skipped' && check.ok), true)
+  } finally {
+    await server.close()
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('JOB_MODE runs period summary sync jobs and rejects terminal reruns', async () => {
+  const server = await startMockServer()
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'period-summaries-job-mode-'))
+  try {
+    const tokenFile = writeTokenFile(tmpDir)
+    const outputDir = path.join(tmpDir, 'out')
+    const config = parseConfig({
+      API_BASE: server.baseUrl,
+      AUTH_SOURCE: 'AUTH_TOKEN_FILE',
+      AUTH_TOKEN_FILE: tokenFile,
+      CONFIRM_SYNC: '1',
+      USER_IDS: 'user-1,user-2',
+      FROM_DATE: '2026-05-01',
+      TO_DATE: '2026-05-13',
+      CYCLE_ID: 'cycle-1',
+      JOB_MODE: '1',
+      PAGE_SIZE: '4',
+      OUTPUT_DIR: outputDir,
+    })
+
+    const report = await runAttendanceReportPeriodSummariesAcceptance(config)
+    assert.equal(report.ok, true)
+    assert.equal(report.metadata.dateRangeJobId, 'period-date-job-1')
+    assert.equal(report.metadata.dateRangeJobStatus, 'completed')
+    assert.equal(report.metadata.dateRangeJobPages, 1)
+    assert.equal(report.metadata.cycleJobId, 'period-cycle-job-1')
+    assert.equal(report.metadata.cycleJobStatus, 'completed')
+    const dateJobBody = {
+      kind: 'period_summaries',
+      mode: 'manual_step',
+      pageSize: 4,
+      periodSource: { from: '2026-05-01', to: '2026-05-13' },
+      userSelection: { userIds: ['user-1', 'user-2'] },
+    }
+    const cycleJobBody = {
+      kind: 'period_summaries',
+      mode: 'manual_step',
+      pageSize: 4,
+      periodSource: { cycleId: 'cycle-1' },
+      userSelection: { userIds: ['user-1', 'user-2'] },
+    }
+    assert.deepEqual(server.jobBodies, [
+      dateJobBody,
+      dateJobBody,
+      cycleJobBody,
+      cycleJobBody,
+    ])
+    assert.ok(report.checks.some(check => check.name === 'date-range.job.completed' && check.ok))
+    assert.ok(report.checks.some(check => check.name === 'date-range.job.terminal-rerun-rejected' && check.ok))
+    assert.ok(report.checks.some(check => check.name === 'date-range.job.new-job-created' && check.ok))
+    assert.ok(report.checks.some(check => check.name === 'date-range.job.new-job-canceled' && check.ok))
+    assert.ok(report.checks.some(check => check.name === 'payroll-cycle.job.completed' && check.ok))
+    assert.ok(report.checks.some(check => check.name === 'payroll-cycle.job.terminal-rerun-rejected' && check.ok))
+    assert.ok(report.checks.some(check => check.name === 'payroll-cycle.job.new-job-created' && check.ok))
+    assert.ok(report.checks.some(check => check.name === 'payroll-cycle.job.new-job-canceled' && check.ok))
+    const markdown = fs.readFileSync(path.join(outputDir, 'report.md'), 'utf8')
+    assert.match(markdown, /dateRangeJobStatus: `completed`/)
+    assert.doesNotMatch(markdown, /unit-test-token/)
   } finally {
     await server.close()
     fs.rmSync(tmpDir, { recursive: true, force: true })


### PR DESCRIPTION
## Summary

Adds optional `JOB_MODE=1` coverage to the attendance live acceptance harnesses.

- daily report-fields harness can now create a `daily_records` sync job, run pages to `completed`, verify terminal rerun returns `409 JOB_TERMINAL`, then create+cancel a replacement job
- period summaries harness can now do the same for date-range and optional payroll-cycle `period_summaries` jobs
- docs record PR4 design and verification, with staging live evidence deferred until a fresh file-based admin JWT is provided

No backend writer/route/frontend/migration changes.

## Test plan

- [x] `node --check scripts/ops/attendance-report-fields-live-acceptance.mjs`
- [x] `node --check scripts/ops/attendance-report-fields-live-acceptance.test.mjs`
- [x] `node --check scripts/ops/attendance-report-period-summaries-live-acceptance.mjs`
- [x] `node --check scripts/ops/attendance-report-period-summaries-live-acceptance.test.mjs`
- [x] `pnpm run verify:attendance-report-fields:live:test` — 19 pass
- [x] `pnpm run verify:attendance-report-period-summaries:live:test` — 7 pass
- [x] `git diff --check`
- [x] staged secret scan — no JWT/token/private key/home-path matches

## Deferred live evidence

Real staging `JOB_MODE=1` was not run in this PR because the previous staging JWT had expired by local UTC time. Run after fresh file-based credentials and explicit staging-write authorization.
