### PR TITLE
feat(multitable): localize core table chrome to zh-CN (T3A1)

### DIFF
--- a/apps/web/src/multitable/components/MetaGridTable.vue
+++ b/apps/web/src/multitable/components/MetaGridTable.vue
@@ -1,11 +1,11 @@
 <template>
-  <div class="meta-grid" :class="[rowDensity ? `meta-grid--${rowDensity}` : '']" tabindex="0" role="grid" aria-label="Data grid" @keydown="onKeydown">
+  <div class="meta-grid" :class="[rowDensity ? `meta-grid--${rowDensity}` : '']" tabindex="0" role="grid" :aria-label="l('grid.aria')" @keydown="onKeydown">
     <div v-if="enableMultiSelect && selectedIds.size > 0" class="meta-grid__bulk-bar">
-      <span class="meta-grid__bulk-count">{{ selectedIds.size }} selected</span>
-      <button v-if="canBulkEdit" class="meta-grid__bulk-btn" aria-label="Set field on selected records" @click="onBulkEdit('set')">Set field</button>
-      <button v-if="canBulkEdit" class="meta-grid__bulk-btn" aria-label="Clear field on selected records" @click="onBulkEdit('clear')">Clear field</button>
-      <button v-if="canDelete" class="meta-grid__bulk-btn meta-grid__bulk-btn--danger" aria-label="Delete selected records" @click="onBulkDelete">Delete selected</button>
-      <button class="meta-grid__bulk-btn" aria-label="Clear selection" @click="selectedIds = new Set(); emit('selection-change', [])">Clear</button>
+      <span class="meta-grid__bulk-count">{{ selectedCount(selectedIds.size, isZh) }}</span>
+      <button v-if="canBulkEdit" class="meta-grid__bulk-btn" :aria-label="l('grid.setFieldAria')" @click="onBulkEdit('set')">{{ l('grid.setField') }}</button>
+      <button v-if="canBulkEdit" class="meta-grid__bulk-btn" :aria-label="l('grid.clearFieldAria')" @click="onBulkEdit('clear')">{{ l('grid.clearField') }}</button>
+      <button v-if="canDelete" class="meta-grid__bulk-btn meta-grid__bulk-btn--danger" :aria-label="l('grid.deleteSelectedAria')" @click="onBulkDelete">{{ l('grid.deleteSelected') }}</button>
+      <button class="meta-grid__bulk-btn" :aria-label="l('grid.clearSelection')" @click="selectedIds = new Set(); emit('selection-change', [])">{{ l('grid.clear') }}</button>
     </div>
     <div class="meta-grid__table-wrap">
       <table class="meta-grid__table">
@@ -58,7 +58,7 @@
                     type="button"
                     class="meta-grid__comment-action"
                     :class="rowCommentActionClass(row.id)"
-                    :aria-label="`Comments for row ${startIndex + flatIndex(group, ri) + 1}`"
+                    :aria-label="commentForRow(startIndex + flatIndex(group, ri) + 1, isZh)"
                     @click.stop="emit('open-comments', row.id)"
                     @keydown="onRowCommentKeydown($event, row.id)"
                   >
@@ -99,7 +99,7 @@
                     type="button"
                     class="meta-grid__field-comment-action"
                     :class="fieldCommentActionClass(row.id, field.id)"
-                    :aria-label="`Comments for ${field.name}`"
+                    :aria-label="commentForField(field.name, isZh)"
                     @click.stop="emit('open-field-comments', { recordId: row.id, fieldId: field.id })"
                     @keydown="onFieldCommentKeydown($event, row.id, field.id)"
                   >
@@ -112,8 +112,8 @@
           <tr v-if="!rows.length && !loading">
             <td :colspan="colSpan" class="meta-grid__empty">
               <div class="meta-grid__empty-icon">&#x1F4CB;</div>
-              <div class="meta-grid__empty-title">No records yet</div>
-              <div class="meta-grid__empty-hint">Click <strong>+ New Record</strong> to add your first row</div>
+              <div class="meta-grid__empty-title">{{ l('grid.noRecordsTitle') }}</div>
+              <div class="meta-grid__empty-hint">{{ l('grid.noRecordsHintPrefix') }} <strong>{{ l('grid.noRecordsHintAction') }}</strong> {{ l('grid.noRecordsHintSuffix') }}</div>
             </td>
           </tr>
         </tbody>
@@ -131,14 +131,14 @@
                 <input type="checkbox" :checked="selectedIds.has(row.id)" :disabled="!rowAllowsAnyBulkAction(row.id)" @change="toggleSelectRow(row.id)" />
               </td>
               <td class="meta-grid__row-num">
-                <button class="meta-grid__expand-btn" :class="{ 'meta-grid__expand-btn--open': expandedRowIds.has(row.id) }" :aria-label="expandedRowIds.has(row.id) ? 'Collapse row' : 'Expand row'" @click.stop="toggleRowExpand(row.id)">&#x25B6;</button>
+                <button class="meta-grid__expand-btn" :class="{ 'meta-grid__expand-btn--open': expandedRowIds.has(row.id) }" :aria-label="expandedRowIds.has(row.id) ? l('grid.collapseRow') : l('grid.expandRow')" @click.stop="toggleRowExpand(row.id)">&#x25B6;</button>
                 <span>{{ startIndex + ri + 1 }}</span>
                 <button
                   v-if="resolveRowActions(row.id).canComment"
                   type="button"
                   class="meta-grid__comment-action"
                   :class="rowCommentActionClass(row.id)"
-                  :aria-label="`Comments for row ${startIndex + ri + 1}`"
+                  :aria-label="commentForRow(startIndex + ri + 1, isZh)"
                   @click.stop="emit('open-comments', row.id)"
                   @keydown="onRowCommentKeydown($event, row.id)"
                 >
@@ -183,7 +183,7 @@
                   type="button"
                   class="meta-grid__field-comment-action"
                   :class="fieldCommentActionClass(row.id, field.id)"
-                  :aria-label="`Comments for ${field.name}`"
+                  :aria-label="commentForField(field.name, isZh)"
                   @click.stop="emit('open-field-comments', { recordId: row.id, fieldId: field.id })"
                   @keydown="onFieldCommentKeydown($event, row.id, field.id)"
                 >
@@ -213,13 +213,13 @@
             <td :colspan="colSpan" class="meta-grid__empty">
               <template v-if="searchText">
                 <div class="meta-grid__empty-icon">&#x1F50D;</div>
-                <div class="meta-grid__empty-title">No matching records</div>
-                <div class="meta-grid__empty-hint">Try a different search term</div>
+                <div class="meta-grid__empty-title">{{ l('grid.noMatchingTitle') }}</div>
+                <div class="meta-grid__empty-hint">{{ l('grid.noMatchingHint') }}</div>
               </template>
               <template v-else>
                 <div class="meta-grid__empty-icon">&#x1F4CB;</div>
-                <div class="meta-grid__empty-title">No records yet</div>
-                <div class="meta-grid__empty-hint">Click <strong>+ New Record</strong> to add your first row</div>
+                <div class="meta-grid__empty-title">{{ l('grid.noRecordsTitle') }}</div>
+                <div class="meta-grid__empty-hint">{{ l('grid.noRecordsHintPrefix') }} <strong>{{ l('grid.noRecordsHintAction') }}</strong> {{ l('grid.noRecordsHintSuffix') }}</div>
               </template>
             </td>
           </tr>
@@ -227,11 +227,11 @@
       </table>
     </div>
     <div v-if="totalPages > 1" class="meta-grid__pagination">
-      <button class="meta-grid__page-btn" :disabled="currentPage <= 1" @click="emit('go-to-page', currentPage - 1)">&lsaquo; Prev</button>
+      <button class="meta-grid__page-btn" :disabled="currentPage <= 1" @click="emit('go-to-page', currentPage - 1)">&lsaquo; {{ l('grid.prev') }}</button>
       <span class="meta-grid__page-info">{{ currentPage }} / {{ totalPages }}</span>
-      <button class="meta-grid__page-btn" :disabled="currentPage >= totalPages" @click="emit('go-to-page', currentPage + 1)">Next &rsaquo;</button>
+      <button class="meta-grid__page-btn" :disabled="currentPage >= totalPages" @click="emit('go-to-page', currentPage + 1)">{{ l('grid.next') }} &rsaquo;</button>
     </div>
-    <div v-if="loading" class="meta-grid__loading" aria-live="polite" aria-label="Loading data">
+    <div v-if="loading" class="meta-grid__loading" aria-live="polite" :aria-label="l('grid.loading')">
       <div class="meta-grid__skeleton">
         <div v-for="i in 5" :key="i" class="meta-grid__skeleton-row">
           <div v-for="j in Math.min(visibleFields.length || 4, 6)" :key="j" class="meta-grid__skeleton-cell"></div>
@@ -270,6 +270,15 @@ import {
   resolveRecordCommentAffordance,
 } from '../utils/comment-affordance'
 import { isSystemField } from '../utils/system-fields'
+import { useLocale } from '../../composables/useLocale'
+import {
+  metaCoreLabel,
+  selectedCount,
+  commentForRow,
+  commentForField,
+  groupNoValue,
+  type MetaCoreLabelKey,
+} from '../utils/meta-core-labels'
 
 const EDITABLE = new Set(['string', 'number', 'boolean', 'date', 'select', 'link', 'attachment'])
 
@@ -317,6 +326,9 @@ const emit = defineEmits<{
   (e: 'bulk-edit', payload: { mode: 'set' | 'clear'; recordIds: string[] }): void
   (e: 'reorder-field', fromFieldId: string, toFieldId: string): void
 }>()
+
+const { isZh } = useLocale()
+const l = (key: MetaCoreLabelKey) => metaCoreLabel(key, isZh.value)
 
 const editCell = ref<EditingCell | null>(null)
 const focusRow = ref(-1)
@@ -380,7 +392,7 @@ const groupedRows = computed<RowGroup[] | null>(() => {
   }
   const groups: RowGroup[] = []
   for (const [key, rows] of map) {
-    groups.push({ key, label: key === '__ungrouped__' ? '(No value)' : key, rows, count: rows.length })
+    groups.push({ key, label: key === '__ungrouped__' ? groupNoValue(isZh.value) : key, rows, count: rows.length })
   }
   return groups
 })

--- a/apps/web/src/multitable/components/MetaToolbar.vue
+++ b/apps/web/src/multitable/components/MetaToolbar.vue
@@ -1,10 +1,10 @@
 <template>
-  <div class="meta-toolbar" role="toolbar" aria-label="Grid toolbar">
+  <div class="meta-toolbar" role="toolbar" :aria-label="l('toolbar.aria')">
     <div class="meta-toolbar__left">
       <!-- Hide Fields -->
       <div class="meta-toolbar__dropdown">
         <button class="meta-toolbar__btn" @click="showFieldPicker = !showFieldPicker">
-          <span class="meta-toolbar__btn-icon">&#x2630;</span> Fields
+          <span class="meta-toolbar__btn-icon">&#x2630;</span> {{ l('toolbar.fields') }}
           <span v-if="hiddenCount" class="meta-toolbar__badge">{{ hiddenCount }}</span>
         </button>
         <div v-if="showFieldPicker" class="meta-toolbar__panel" @keydown.escape="showFieldPicker = false">
@@ -18,7 +18,7 @@
       <!-- Sort -->
       <div class="meta-toolbar__dropdown">
         <button class="meta-toolbar__btn" @click="showSortPanel = !showSortPanel">
-          <span class="meta-toolbar__btn-icon">&#x2195;</span> Sort
+          <span class="meta-toolbar__btn-icon">&#x2195;</span> {{ l('toolbar.sort') }}
           <span v-if="sortRules.length" class="meta-toolbar__badge">{{ sortRules.length }}</span>
         </button>
         <div v-if="showSortPanel" class="meta-toolbar__panel" @keydown.escape="showSortPanel = false">
@@ -27,59 +27,59 @@
               <option v-for="f in fields" :key="f.id" :value="f.id">{{ f.name }}</option>
             </select>
             <select :value="rule.direction" @change="onSortDirChange(idx, ($event.target as HTMLSelectElement).value as 'asc'|'desc')">
-              <option value="asc">A &#x2192; Z</option>
-              <option value="desc">Z &#x2192; A</option>
+              <option value="asc">{{ l('toolbar.sortAsc') }}</option>
+              <option value="desc">{{ l('toolbar.sortDesc') }}</option>
             </select>
             <button class="meta-toolbar__remove" @click="emit('remove-sort', rule.fieldId)">&times;</button>
           </div>
-          <button v-if="fields.length" class="meta-toolbar__add" @click="emit('add-sort', { fieldId: fields[0].id, direction: 'asc' })">+ Add sort</button>
-          <button v-if="sortRules.length" class="meta-toolbar__apply" @click="emit('apply-sort-filter')">Apply</button>
+          <button v-if="fields.length" class="meta-toolbar__add" @click="emit('add-sort', { fieldId: fields[0].id, direction: 'asc' })">{{ l('toolbar.addSort') }}</button>
+          <button v-if="sortRules.length" class="meta-toolbar__apply" @click="emit('apply-sort-filter')">{{ l('toolbar.apply') }}</button>
         </div>
       </div>
 
       <!-- Filter -->
       <div class="meta-toolbar__dropdown">
         <button class="meta-toolbar__btn" @click="showFilterPanel = !showFilterPanel">
-          <span class="meta-toolbar__btn-icon">&#x2A01;</span> Filter
+          <span class="meta-toolbar__btn-icon">&#x2A01;</span> {{ l('toolbar.filter') }}
           <span v-if="filterRules.length" class="meta-toolbar__badge">{{ filterRules.length }}</span>
         </button>
         <div v-if="showFilterPanel" class="meta-toolbar__panel meta-toolbar__panel--filter" @keydown.escape="showFilterPanel = false">
           <div v-if="filterRules.length > 1" class="meta-toolbar__conjunction">
-            <span>Where</span>
+            <span>{{ l('toolbar.where') }}</span>
             <select :value="filterConjunction" @change="emit('set-conjunction', ($event.target as HTMLSelectElement).value as 'and'|'or')">
-              <option value="and">all</option>
-              <option value="or">any</option>
+              <option value="and">{{ l('toolbar.all') }}</option>
+              <option value="or">{{ l('toolbar.any') }}</option>
             </select>
-            <span>conditions match</span>
+            <span>{{ l('toolbar.conditionsMatch') }}</span>
           </div>
           <div v-for="(rule, idx) in filterRules" :key="idx" class="meta-toolbar__filter-rule">
-            <select :value="rule.fieldId" aria-label="Filter field" @change="onFilterFieldChange(idx, ($event.target as HTMLSelectElement).value)">
+            <select :value="rule.fieldId" :aria-label="l('toolbar.filterField')" @change="onFilterFieldChange(idx, ($event.target as HTMLSelectElement).value)">
               <option v-for="f in fields" :key="f.id" :value="f.id">{{ f.name }}</option>
             </select>
             <span class="meta-toolbar__field-type">{{ getFilterFieldTypeLabel(rule.fieldId) }}</span>
-            <select :value="rule.operator" aria-label="Filter operator" @change="onFilterOperatorChange(idx, ($event.target as HTMLSelectElement).value)">
+            <select :value="rule.operator" :aria-label="l('toolbar.filterOperator')" @change="onFilterOperatorChange(idx, ($event.target as HTMLSelectElement).value)">
               <option v-for="op in getOperatorsForField(rule.fieldId)" :key="op.value" :value="op.value">{{ op.label }}</option>
             </select>
-            <span v-if="isUnaryOp(rule.operator)" class="meta-toolbar__filter-empty-hint">no value needed</span>
+            <span v-if="isUnaryOp(rule.operator)" class="meta-toolbar__filter-empty-hint">{{ l('toolbar.noValueNeeded') }}</span>
             <select
               v-else-if="isSelectLikeField(rule.fieldId)"
               class="meta-toolbar__filter-value"
               :value="String(rule.value ?? '')"
-              aria-label="Filter value"
+              :aria-label="l('toolbar.filterValue')"
               @change="onFilterValueChange(idx, ($event.target as HTMLSelectElement).value)"
             >
-              <option value="" disabled>{{ getSelectOptions(rule.fieldId).length ? 'Choose option...' : 'No options' }}</option>
+              <option value="" disabled>{{ getSelectOptions(rule.fieldId).length ? l('toolbar.chooseOption') : l('toolbar.noOptions') }}</option>
               <option v-for="option in getSelectOptions(rule.fieldId)" :key="option.value" :value="option.value">{{ option.label }}</option>
             </select>
             <select
               v-else-if="getFieldType(rule.fieldId) === 'boolean'"
               class="meta-toolbar__filter-value"
               :value="String(rule.value ?? 'true')"
-              aria-label="Filter value"
+              :aria-label="l('toolbar.filterValue')"
               @change="onFilterValueChange(idx, ($event.target as HTMLSelectElement).value)"
             >
-              <option value="true">checked / true</option>
-              <option value="false">unchecked / false</option>
+              <option value="true">{{ l('toolbar.checkedTrue') }}</option>
+              <option value="false">{{ l('toolbar.uncheckedFalse') }}</option>
             </select>
             <input
               v-else
@@ -87,66 +87,66 @@
               :type="getInputType(rule.fieldId)"
               :placeholder="getValuePlaceholder(rule.fieldId)"
               :value="rule.value ?? ''"
-              aria-label="Filter value"
+              :aria-label="l('toolbar.filterValue')"
               @change="onFilterValueChange(idx, ($event.target as HTMLInputElement).value)"
             />
             <button class="meta-toolbar__remove" @click="emit('remove-filter', idx)">&times;</button>
           </div>
           <div class="meta-toolbar__filter-actions">
-            <button v-if="fields.length" class="meta-toolbar__add" @click="onAddFilter">+ Add filter</button>
-            <button v-if="filterRules.length" class="meta-toolbar__add meta-toolbar__add--danger" @click="emit('clear-filters')">Clear all</button>
+            <button v-if="fields.length" class="meta-toolbar__add" @click="onAddFilter">{{ l('toolbar.addFilter') }}</button>
+            <button v-if="filterRules.length" class="meta-toolbar__add meta-toolbar__add--danger" @click="emit('clear-filters')">{{ l('toolbar.clearAll') }}</button>
           </div>
           <button v-if="filterRules.length" class="meta-toolbar__apply" @click="emit('apply-sort-filter')">{{ applyButtonLabel }}</button>
-          <p v-if="filterRules.length && sortFilterDirty" class="meta-toolbar__apply-hint">Filter changes are staged until applied.</p>
+          <p v-if="filterRules.length && sortFilterDirty" class="meta-toolbar__apply-hint">{{ l('toolbar.stagedHint') }}</p>
         </div>
       </div>
 
       <!-- Group By -->
       <div class="meta-toolbar__dropdown">
         <button class="meta-toolbar__btn" @click="showGroupPanel = !showGroupPanel">
-          <span class="meta-toolbar__btn-icon">&#x229E;</span> Group
+          <span class="meta-toolbar__btn-icon">&#x229E;</span> {{ l('toolbar.group') }}
           <span v-if="groupFieldId" class="meta-toolbar__badge">1</span>
         </button>
         <div v-if="showGroupPanel" class="meta-toolbar__panel" @keydown.escape="showGroupPanel = false">
           <label class="meta-toolbar__field-toggle">
             <input type="radio" name="groupBy" :checked="!groupFieldId" @change="emit('set-group-field', null)" />
-            <span class="meta-toolbar__group-none">None</span>
+            <span class="meta-toolbar__group-none">{{ l('toolbar.none') }}</span>
           </label>
           <label v-for="f in groupableFields" :key="f.id" class="meta-toolbar__field-toggle">
             <input type="radio" name="groupBy" :checked="groupFieldId === f.id" @change="emit('set-group-field', f.id)" />
             <span>{{ f.name }}</span>
-            <span class="meta-toolbar__field-type">{{ f.type }}</span>
+            <span class="meta-toolbar__field-type">{{ fieldTypeLabel(f.type, isZh) }}</span>
           </label>
         </div>
       </div>
 
       <!-- Undo/Redo -->
-      <button class="meta-toolbar__btn" :disabled="!canUndo" title="Undo (Ctrl+Z)" aria-label="Undo" @click="emit('undo')">&#x21A9;</button>
-      <button class="meta-toolbar__btn" :disabled="!canRedo" title="Redo (Ctrl+Y)" aria-label="Redo" @click="emit('redo')">&#x21AA;</button>
+      <button class="meta-toolbar__btn" :disabled="!canUndo" :title="l('toolbar.undoTitle')" :aria-label="l('toolbar.undo')" @click="emit('undo')">&#x21A9;</button>
+      <button class="meta-toolbar__btn" :disabled="!canRedo" :title="l('toolbar.redoTitle')" :aria-label="l('toolbar.redo')" @click="emit('redo')">&#x21AA;</button>
     </div>
     <div class="meta-toolbar__right">
       <div class="meta-toolbar__search" :class="{ 'meta-toolbar__search--active': !!searchText }" role="search">
         <span class="meta-toolbar__search-icon" aria-hidden="true">&#x1F50D;</span>
-        <input class="meta-toolbar__search-input" type="search" placeholder="Search records..." aria-label="Search records" :value="searchText" @input="emit('update:search-text', ($event.target as HTMLInputElement).value)" />
-        <button v-if="searchText" class="meta-toolbar__search-clear" aria-label="Clear search" @click="emit('update:search-text', '')">&times;</button>
+        <input class="meta-toolbar__search-input" type="search" :placeholder="l('toolbar.searchPlaceholder')" :aria-label="l('toolbar.searchAria')" :value="searchText" @input="emit('update:search-text', ($event.target as HTMLInputElement).value)" />
+        <button v-if="searchText" class="meta-toolbar__search-clear" :aria-label="l('toolbar.clearSearch')" @click="emit('update:search-text', '')">&times;</button>
       </div>
-      <span v-if="totalRows !== undefined" class="meta-toolbar__row-count">{{ totalRows }} rows</span>
+      <span v-if="totalRows !== undefined" class="meta-toolbar__row-count">{{ rowCount(totalRows, isZh) }}</span>
       <!-- Row density -->
       <div class="meta-toolbar__dropdown">
-        <button class="meta-toolbar__btn" title="Row height" aria-label="Row height" @click="showDensityPanel = !showDensityPanel">&#x2195; Rows</button>
+        <button class="meta-toolbar__btn" :title="l('toolbar.rowHeight')" :aria-label="l('toolbar.rowHeight')" @click="showDensityPanel = !showDensityPanel">&#x2195; {{ l('toolbar.rows') }}</button>
         <div v-if="showDensityPanel" class="meta-toolbar__panel meta-toolbar__panel--density" @keydown.escape="showDensityPanel = false">
           <label v-for="d in DENSITIES" :key="d.value" class="meta-toolbar__field-toggle">
             <input type="radio" name="density" :checked="rowDensity === d.value" @change="emit('set-row-density', d.value); showDensityPanel = false" />
-            <span>{{ d.label }}</span>
+            <span>{{ l(d.labelKey) }}</span>
           </label>
         </div>
       </div>
-      <button class="meta-toolbar__btn" title="Auto-fit columns" aria-label="Auto-fit columns" @click="emit('auto-fit-columns')">&#x2194; Fit</button>
-      <button class="meta-toolbar__btn" title="Print" aria-label="Print grid" @click="emit('print')">&#x1F5A8; Print</button>
-      <button v-if="canCreateRecord" class="meta-toolbar__btn" title="Import records" aria-label="Import records" @click="emit('import')">&#x2B71; Import</button>
-      <button v-if="canExport" class="meta-toolbar__btn" title="Export CSV" aria-label="Export CSV" @click="emit('export-csv')">&#x2B73; Export CSV</button>
-      <button v-if="canExport" class="meta-toolbar__btn" title="Export Excel (.xlsx)" aria-label="Export Excel" @click="emit('export-xlsx')">&#x2B73; Export XLSX</button>
-      <button v-if="canCreateRecord" class="meta-toolbar__btn meta-toolbar__btn--primary" @click="emit('add-record')">+ New Record</button>
+      <button class="meta-toolbar__btn" :title="l('toolbar.autoFitColumns')" :aria-label="l('toolbar.autoFitColumns')" @click="emit('auto-fit-columns')">&#x2194; {{ l('toolbar.fit') }}</button>
+      <button class="meta-toolbar__btn" :title="l('toolbar.print')" :aria-label="l('toolbar.printGrid')" @click="emit('print')">&#x1F5A8; {{ l('toolbar.print') }}</button>
+      <button v-if="canCreateRecord" class="meta-toolbar__btn" :title="l('toolbar.importRecords')" :aria-label="l('toolbar.importRecords')" @click="emit('import')">&#x2B71; {{ l('toolbar.import') }}</button>
+      <button v-if="canExport" class="meta-toolbar__btn" :title="l('toolbar.exportCsv')" :aria-label="l('toolbar.exportCsv')" @click="emit('export-csv')">&#x2B73; {{ l('toolbar.exportCsv') }}</button>
+      <button v-if="canExport" class="meta-toolbar__btn" :title="l('toolbar.exportExcelXlsx')" :aria-label="l('toolbar.exportExcel')" @click="emit('export-xlsx')">&#x2B73; {{ l('toolbar.exportXlsx') }}</button>
+      <button v-if="canCreateRecord" class="meta-toolbar__btn meta-toolbar__btn--primary" @click="emit('add-record')">{{ l('toolbar.newRecord') }}</button>
     </div>
   </div>
 </template>
@@ -156,6 +156,14 @@ import { ref, computed } from 'vue'
 import type { MetaField, RowDensity } from '../types'
 import type { SortRule, FilterRule, FilterConjunction } from '../composables/useMultitableGrid'
 import { FILTER_OPERATORS_BY_TYPE } from '../composables/useMultitableGrid'
+import { useLocale } from '../../composables/useLocale'
+import {
+  metaCoreLabel,
+  rowCount,
+  fieldTypeLabel,
+  filterValuePlaceholder,
+  type MetaCoreLabelKey,
+} from '../utils/meta-core-labels'
 
 const props = defineProps<{
   fields: MetaField[]
@@ -198,15 +206,18 @@ const emit = defineEmits<{
   (e: 'auto-fit-columns'): void
 }>()
 
+const { isZh } = useLocale()
+const l = (key: MetaCoreLabelKey) => metaCoreLabel(key, isZh.value)
+
 const showFieldPicker = ref(false)
 const showSortPanel = ref(false)
 const showFilterPanel = ref(false)
 const showGroupPanel = ref(false)
 const showDensityPanel = ref(false)
-const DENSITIES: Array<{ value: RowDensity; label: string }> = [
-  { value: 'compact', label: 'Compact' },
-  { value: 'normal', label: 'Normal' },
-  { value: 'expanded', label: 'Expanded' },
+const DENSITIES: Array<{ value: RowDensity; labelKey: MetaCoreLabelKey }> = [
+  { value: 'compact', labelKey: 'density.compact' },
+  { value: 'normal', labelKey: 'density.normal' },
+  { value: 'expanded', labelKey: 'density.expanded' },
 ]
 const GROUPABLE_TYPES = new Set(['select', 'string', 'boolean', 'number', 'date'])
 const groupableFields = computed(() => props.fields.filter((f) => GROUPABLE_TYPES.has(f.type)))
@@ -226,31 +237,17 @@ const getOperatorsForField = (id: string) => {
   }
   return FILTER_OPERATORS_BY_TYPE[type] ?? FILTER_OPERATORS_BY_TYPE.string
 }
-const applyButtonLabel = computed(() => props.sortFilterDirty ? 'Apply filter changes' : 'Apply filters')
+const applyButtonLabel = computed(() => props.sortFilterDirty
+  ? metaCoreLabel('toolbar.applyFilterChanges', isZh.value)
+  : metaCoreLabel('toolbar.applyFilters', isZh.value))
 const getInputType = (id: string) => {
   const t = getFieldType(id)
   if (t === 'number') return 'number'
   if (t === 'date') return 'date'
   return 'text'
 }
-const getFilterFieldTypeLabel = (id: string) => {
-  const labels: Record<string, string> = {
-    string: 'text',
-    longText: 'long text',
-    number: 'number',
-    boolean: 'checkbox',
-    select: 'select',
-    multiSelect: 'multi-select',
-    date: 'date',
-  }
-  return labels[getFieldType(id)] ?? getFieldType(id)
-}
-const getValuePlaceholder = (id: string) => {
-  const t = getFieldType(id)
-  if (t === 'number') return 'Enter a number'
-  if (t === 'date') return 'Pick a date'
-  return 'Enter filter text'
-}
+const getFilterFieldTypeLabel = (id: string) => fieldTypeLabel(String(getFieldType(id)), isZh.value)
+const getValuePlaceholder = (id: string) => filterValuePlaceholder(String(getFieldType(id)), isZh.value)
 function getSelectOptions(id: string): Array<{ value: string; label: string }> {
   const field = getField(id)
   const rawOptions = field?.options ?? (Array.isArray(field?.property?.options) ? field.property.options : [])

--- a/apps/web/src/multitable/utils/meta-core-labels.ts
+++ b/apps/web/src/multitable/utils/meta-core-labels.ts
@@ -1,0 +1,203 @@
+// Core table chrome string table — single source for MetaToolbar.vue and
+// MetaGridTable.vue (T3A1) localization.
+//
+// EN + ZH both explicit (same convention as workbench-labels.ts; unlike
+// category-labels.ts where the data layer is English and we only translate).
+// Components read `useLocale().isZh` and call `metaCoreLabel(key, isZh)` for
+// static strings, or the interpolation helpers below for strings with
+// counts / field names / type-driven variants.
+//
+// Scope: see docs/development/multitable-t3a-core-table-i18n-development-20260519.md.
+// T3A1 = core table chrome only (toolbar + grid). Cell-editor strings are
+// T3A2 and are intentionally absent here (no dead keys, per MD §7.6).
+//
+// NOT translated (user/data values): field names, option values, group
+// values, view names, record values, ids, URLs, emails, phone examples,
+// backend free-form errors. The only group label localized is the synthetic
+// "(No value)" fallback (see groupNoValue / MetaGridTable __ungrouped__).
+
+export type MetaCoreLabelKey =
+  // --- MetaToolbar static ---
+  | 'toolbar.aria'
+  | 'toolbar.fields'
+  | 'toolbar.sort'
+  | 'toolbar.sortAsc' | 'toolbar.sortDesc'        // F1: sort-direction options
+  | 'toolbar.addSort' | 'toolbar.apply'
+  | 'toolbar.filter' | 'toolbar.where' | 'toolbar.all' | 'toolbar.any'
+  | 'toolbar.conditionsMatch'
+  | 'toolbar.filterField' | 'toolbar.filterOperator' | 'toolbar.filterValue'  // F4: filter aria
+  | 'toolbar.noValueNeeded' | 'toolbar.chooseOption' | 'toolbar.noOptions'
+  | 'toolbar.checkedTrue' | 'toolbar.uncheckedFalse'
+  | 'toolbar.addFilter' | 'toolbar.clearAll'
+  | 'toolbar.applyFilterChanges' | 'toolbar.applyFilters' | 'toolbar.stagedHint'
+  | 'toolbar.group' | 'toolbar.none'
+  | 'toolbar.undo' | 'toolbar.undoTitle'          // F3: aria vs shortcut-bearing title
+  | 'toolbar.redo' | 'toolbar.redoTitle'
+  | 'toolbar.searchPlaceholder' | 'toolbar.searchAria' | 'toolbar.clearSearch'
+  | 'toolbar.rowHeight' | 'toolbar.rows'
+  | 'toolbar.autoFitColumns' | 'toolbar.fit'
+  | 'toolbar.print' | 'toolbar.printGrid'
+  | 'toolbar.importRecords' | 'toolbar.import'
+  | 'toolbar.exportCsv' | 'toolbar.exportExcel' | 'toolbar.exportExcelXlsx' | 'toolbar.exportXlsx'
+  | 'toolbar.newRecord'
+  // --- Row density ---
+  | 'density.compact' | 'density.normal' | 'density.expanded'
+  // --- MetaGridTable static ---
+  | 'grid.aria'
+  | 'grid.setField' | 'grid.setFieldAria'
+  | 'grid.clearField' | 'grid.clearFieldAria'
+  | 'grid.deleteSelected' | 'grid.deleteSelectedAria'
+  | 'grid.clear' | 'grid.clearSelection'
+  | 'grid.noRecordsTitle'
+  | 'grid.noRecordsHintPrefix' | 'grid.noRecordsHintAction' | 'grid.noRecordsHintSuffix'
+  | 'grid.noMatchingTitle' | 'grid.noMatchingHint'
+  | 'grid.collapseRow' | 'grid.expandRow'
+  | 'grid.prev' | 'grid.next' | 'grid.loading'
+
+const META_CORE_LABELS: Record<MetaCoreLabelKey, { en: string; zh: string }> = {
+  'toolbar.aria': { en: 'Grid toolbar', zh: '表格工具栏' },
+  'toolbar.fields': { en: 'Fields', zh: '字段' },
+  'toolbar.sort': { en: 'Sort', zh: '排序' },
+  // F1 + user-confirmed: en keeps the alphabet arrows, zh uses 升序/降序.
+  'toolbar.sortAsc': { en: 'A → Z', zh: '升序' },
+  'toolbar.sortDesc': { en: 'Z → A', zh: '降序' },
+  'toolbar.addSort': { en: '+ Add sort', zh: '+ 添加排序' },
+  'toolbar.apply': { en: 'Apply', zh: '应用' },
+  'toolbar.filter': { en: 'Filter', zh: '筛选' },
+  'toolbar.where': { en: 'Where', zh: '当' },
+  'toolbar.all': { en: 'all', zh: '全部' },
+  'toolbar.any': { en: 'any', zh: '任一' },
+  'toolbar.conditionsMatch': { en: 'conditions match', zh: '条件匹配' },
+  // F4: filter-control aria labels (§3.1 in-scope; absent from §5.1 key table).
+  'toolbar.filterField': { en: 'Filter field', zh: '筛选字段' },
+  'toolbar.filterOperator': { en: 'Filter operator', zh: '筛选运算符' },
+  'toolbar.filterValue': { en: 'Filter value', zh: '筛选值' },
+  'toolbar.noValueNeeded': { en: 'no value needed', zh: '无需填写值' },
+  'toolbar.chooseOption': { en: 'Choose option...', zh: '选择选项...' },
+  'toolbar.noOptions': { en: 'No options', zh: '无可用选项' },
+  'toolbar.checkedTrue': { en: 'checked / true', zh: '已勾选 / true' },
+  'toolbar.uncheckedFalse': { en: 'unchecked / false', zh: '未勾选 / false' },
+  'toolbar.addFilter': { en: '+ Add filter', zh: '+ 添加筛选' },
+  'toolbar.clearAll': { en: 'Clear all', zh: '全部清除' },
+  'toolbar.applyFilterChanges': { en: 'Apply filter changes', zh: '应用筛选更改' },
+  'toolbar.applyFilters': { en: 'Apply filters', zh: '应用筛选' },
+  'toolbar.stagedHint': {
+    en: 'Filter changes are staged until applied.',
+    zh: '筛选更改将在应用后生效。',
+  },
+  'toolbar.group': { en: 'Group', zh: '分组' },
+  'toolbar.none': { en: 'None', zh: '无' },
+  'toolbar.undo': { en: 'Undo', zh: '撤销' },
+  // F3: keep the physical-key shortcut literal (workbench-labels.ts kbd.* convention).
+  'toolbar.undoTitle': { en: 'Undo (Ctrl+Z)', zh: '撤销 (Ctrl+Z)' },
+  'toolbar.redo': { en: 'Redo', zh: '重做' },
+  'toolbar.redoTitle': { en: 'Redo (Ctrl+Y)', zh: '重做 (Ctrl+Y)' },
+  'toolbar.searchPlaceholder': { en: 'Search records...', zh: '搜索记录...' },
+  'toolbar.searchAria': { en: 'Search records', zh: '搜索记录' },
+  'toolbar.clearSearch': { en: 'Clear search', zh: '清除搜索' },
+  'toolbar.rowHeight': { en: 'Row height', zh: '行高' },
+  // user-confirmed: button text en stays "Rows"; zh uses 行高 (单字 "行" 歧义).
+  'toolbar.rows': { en: 'Rows', zh: '行高' },
+  'toolbar.autoFitColumns': { en: 'Auto-fit columns', zh: '自动适应列宽' },
+  'toolbar.fit': { en: 'Fit', zh: '适应' },
+  'toolbar.print': { en: 'Print', zh: '打印' },
+  'toolbar.printGrid': { en: 'Print grid', zh: '打印表格' },
+  'toolbar.importRecords': { en: 'Import records', zh: '导入记录' },
+  'toolbar.import': { en: 'Import', zh: '导入' },
+  'toolbar.exportCsv': { en: 'Export CSV', zh: '导出 CSV' },
+  'toolbar.exportExcel': { en: 'Export Excel', zh: '导出 Excel' },
+  'toolbar.exportExcelXlsx': { en: 'Export Excel (.xlsx)', zh: '导出 Excel (.xlsx)' },
+  'toolbar.exportXlsx': { en: 'Export XLSX', zh: '导出 XLSX' },
+  'toolbar.newRecord': { en: '+ New Record', zh: '+ 新建记录' },
+
+  'density.compact': { en: 'Compact', zh: '紧凑' },
+  'density.normal': { en: 'Normal', zh: '标准' },
+  'density.expanded': { en: 'Expanded', zh: '宽松' },
+
+  'grid.aria': { en: 'Data grid', zh: '数据表格' },
+  'grid.setField': { en: 'Set field', zh: '设置字段' },
+  'grid.setFieldAria': { en: 'Set field on selected records', zh: '为所选记录设置字段' },
+  'grid.clearField': { en: 'Clear field', zh: '清空字段' },
+  'grid.clearFieldAria': { en: 'Clear field on selected records', zh: '清空所选记录的字段' },
+  'grid.deleteSelected': { en: 'Delete selected', zh: '删除所选' },
+  'grid.deleteSelectedAria': { en: 'Delete selected records', zh: '删除所选记录' },
+  'grid.clear': { en: 'Clear', zh: '清除' },
+  'grid.clearSelection': { en: 'Clear selection', zh: '清除选择' },
+  'grid.noRecordsTitle': { en: 'No records yet', zh: '暂无记录' },
+  // Empty hint is split so the inline <strong>+ New Record</strong> emphasis
+  // is preserved while the surrounding sentence is localized (MD §5.5 note).
+  'grid.noRecordsHintPrefix': { en: 'Click', zh: '点击' },
+  'grid.noRecordsHintAction': { en: '+ New Record', zh: '+ 新建记录' },
+  'grid.noRecordsHintSuffix': { en: 'to add your first row', zh: '添加第一行' },
+  'grid.noMatchingTitle': { en: 'No matching records', zh: '没有匹配的记录' },
+  'grid.noMatchingHint': { en: 'Try a different search term', zh: '试试其他搜索词' },
+  'grid.collapseRow': { en: 'Collapse row', zh: '收起行' },
+  'grid.expandRow': { en: 'Expand row', zh: '展开行' },
+  'grid.prev': { en: 'Prev', zh: '上一页' },
+  'grid.next': { en: 'Next', zh: '下一页' },
+  'grid.loading': { en: 'Loading data', zh: '正在加载数据' },
+}
+
+export function metaCoreLabel(key: MetaCoreLabelKey, isZh: boolean): string {
+  const entry = META_CORE_LABELS[key]
+  return isZh ? entry.zh : entry.en
+}
+
+// --- Interpolation helpers (not keys) ---
+
+// rowCount: toolbar row-count badge. Source was English-only `{n} rows`
+// (no singular). en is fixed to be plural-correct; zh has no plural.
+export function rowCount(n: number, isZh: boolean): string {
+  if (isZh) return `${n} 行`
+  return `${n} row${n === 1 ? '' : 's'}`
+}
+
+// selectedCount: bulk-bar count. en "selected" does not inflect; zh uses 条.
+export function selectedCount(n: number, isZh: boolean): string {
+  return isZh ? `已选择 ${n} 条` : `${n} selected`
+}
+
+// commentForRow: row-comment aria label. Row number is UI-generated (1-based).
+export function commentForRow(rowNumber: number, isZh: boolean): string {
+  return isZh ? `第 ${rowNumber} 行评论` : `Comments for row ${rowNumber}`
+}
+
+// commentForField: field-comment aria label. The field name is user data and
+// is interpolated raw — never translated.
+export function commentForField(fieldName: string, isZh: boolean): string {
+  return isZh ? `${fieldName} 的评论` : `Comments for ${fieldName}`
+}
+
+// groupNoValue: the synthetic "(No value)" group label only. Real group
+// values are user data and must remain exactly as stored.
+export function groupNoValue(isZh: boolean): string {
+  return isZh ? '(无值)' : '(No value)'
+}
+
+// fieldTypeLabel: stable field-type display labels. F2 — used by BOTH the
+// filter panel and the group panel so the two stay consistent (before T3A1
+// the group panel showed the raw `f.type`; reusing this helper there also
+// normalizes its English, e.g. `longText` → `long text`). Unknown/custom
+// types fall back to the raw type string unchanged, in both locales.
+const FIELD_TYPE_LABELS: Record<string, { en: string; zh: string }> = {
+  string: { en: 'text', zh: '文本' },
+  longText: { en: 'long text', zh: '长文本' },
+  number: { en: 'number', zh: '数字' },
+  boolean: { en: 'checkbox', zh: '复选框' },
+  select: { en: 'select', zh: '单选' },
+  multiSelect: { en: 'multi-select', zh: '多选' },
+  date: { en: 'date', zh: '日期' },
+}
+export function fieldTypeLabel(type: string, isZh: boolean): string {
+  const entry = FIELD_TYPE_LABELS[type]
+  if (!entry) return type
+  return isZh ? entry.zh : entry.en
+}
+
+// filterValuePlaceholder: stable frontend placeholders for the filter value
+// input, keyed by field type.
+export function filterValuePlaceholder(type: string, isZh: boolean): string {
+  if (type === 'number') return isZh ? '输入数字' : 'Enter a number'
+  if (type === 'date') return isZh ? '选择日期' : 'Pick a date'
+  return isZh ? '输入筛选文本' : 'Enter filter text'
+}

--- a/apps/web/tests/meta-grid-table-i18n.spec.ts
+++ b/apps/web/tests/meta-grid-table-i18n.spec.ts
@@ -1,0 +1,137 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, h, nextTick, type App } from 'vue'
+import MetaGridTable from '../src/multitable/components/MetaGridTable.vue'
+import type { MetaField, MetaRecord } from '../src/multitable/types'
+import { useLocale } from '../src/composables/useLocale'
+
+let app: App<Element> | null = null
+let container: HTMLDivElement | null = null
+
+afterEach(() => {
+  app?.unmount()
+  app = null
+  container?.remove()
+  container = null
+  useLocale().setLocale('en')
+})
+
+const TITLE_FIELD: MetaField = { id: 'title', name: 'Title', type: 'string' }
+
+type GridProps = Record<string, unknown>
+
+function mountGrid(props: GridProps) {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  app = createApp({
+    setup() {
+      return () => h(MetaGridTable, {
+        rows: [],
+        visibleFields: [TITLE_FIELD],
+        sortRules: [],
+        loading: false,
+        currentPage: 1,
+        totalPages: 1,
+        startIndex: 0,
+        canEdit: true,
+        canDelete: true,
+        canBulkEdit: true,
+        enableMultiSelect: true,
+        searchText: '',
+        rowDensity: 'normal',
+        canComment: true,
+        ...props,
+      })
+    },
+  })
+  app.mount(container)
+  return container
+}
+
+describe('MetaGridTable i18n', () => {
+  it('localizes the empty-records state and grid aria in zh-CN', () => {
+    useLocale().setLocale('zh-CN')
+    const root = mountGrid({ rows: [] })
+    const text = root.textContent ?? ''
+    expect(text).toContain('暂无记录')
+    expect(text).toContain('点击')
+    expect(text).toContain('+ 新建记录')
+    expect(text).toContain('添加第一行')
+    expect(root.querySelector('[role="grid"]')?.getAttribute('aria-label')).toBe('数据表格')
+    expect(text).not.toContain('No records yet')
+  })
+
+  it('preserves the English empty state when locale is en', () => {
+    useLocale().setLocale('en')
+    const root = mountGrid({ rows: [] })
+    const text = root.textContent ?? ''
+    expect(text).toContain('No records yet')
+    expect(text).toContain('+ New Record')
+    expect(text).not.toContain('暂无记录')
+    expect(root.querySelector('[role="grid"]')?.getAttribute('aria-label')).toBe('Data grid')
+  })
+
+  it('localizes the no-search-match empty state in zh-CN', () => {
+    useLocale().setLocale('zh-CN')
+    const root = mountGrid({ rows: [], searchText: 'abc' })
+    const text = root.textContent ?? ''
+    expect(text).toContain('没有匹配的记录')
+    expect(text).toContain('试试其他搜索词')
+    expect(text).not.toContain('No matching records')
+  })
+
+  it('localizes the bulk action bar after selecting a row in zh-CN', async () => {
+    useLocale().setLocale('zh-CN')
+    const rows: MetaRecord[] = [{ id: 'r1', version: 1, data: { title: 'Hello' } }]
+    const root = mountGrid({ rows })
+    const rowCheckbox = root.querySelector('tbody tr .meta-grid__check-col input') as HTMLInputElement | null
+    expect(rowCheckbox).toBeTruthy()
+    expect(rowCheckbox!.disabled).toBe(false)
+    rowCheckbox!.checked = true
+    rowCheckbox!.dispatchEvent(new Event('change'))
+    await nextTick()
+
+    const bar = root.querySelector('.meta-grid__bulk-bar') as HTMLElement | null
+    expect(bar).toBeTruthy()
+    const text = bar!.textContent ?? ''
+    expect(text).toContain('已选择 1 条')
+    expect(text).toContain('设置字段')
+    expect(text).toContain('清空字段')
+    expect(text).toContain('删除所选')
+    expect(text).toContain('清除')
+    expect(bar!.querySelector('[aria-label="删除所选记录"]')).toBeTruthy()
+    expect(bar!.querySelector('[aria-label="清除选择"]')).toBeTruthy()
+    expect(text).not.toContain('selected')
+  })
+
+  it('localizes pagination and loading chrome in zh-CN', () => {
+    useLocale().setLocale('zh-CN')
+    const root = mountGrid({ rows: [], totalPages: 2, currentPage: 1, loading: true })
+    const text = root.textContent ?? ''
+    expect(text).toContain('上一页')
+    expect(text).toContain('下一页')
+    expect(root.querySelector('.meta-grid__loading')?.getAttribute('aria-label')).toBe('正在加载数据')
+    expect(text).not.toContain('Prev')
+    expect(text).not.toContain('Loading data')
+  })
+
+  it('localizes only the synthetic (No value) group — never user field/group data', () => {
+    useLocale().setLocale('zh-CN')
+    const statusField: MetaField = { id: 'status', name: 'Status', type: 'select' }
+    const rows: MetaRecord[] = [
+      { id: 'r1', version: 1, data: { title: 'A', status: 'Needs Review' } },
+      { id: 'r2', version: 1, data: { title: 'B', status: '' } },
+    ]
+    const root = mountGrid({
+      rows,
+      visibleFields: [TITLE_FIELD, statusField],
+      groupField: statusField,
+    })
+    const text = root.textContent ?? ''
+    // field name + real group value stay exactly as authored
+    expect(text).toContain('Status')
+    expect(text).toContain('Needs Review')
+    // only the synthetic fallback group label is localized
+    expect(text).toContain('(无值)')
+    expect(text).not.toContain('(No value)')
+  })
+})

--- a/apps/web/tests/meta-toolbar-filter-builder.spec.ts
+++ b/apps/web/tests/meta-toolbar-filter-builder.spec.ts
@@ -3,6 +3,7 @@ import { createApp, h, nextTick, reactive, type App } from 'vue'
 import MetaToolbar from '../src/multitable/components/MetaToolbar.vue'
 import type { FilterConjunction, FilterRule, SortRule } from '../src/multitable/composables/useMultitableGrid'
 import type { MetaField } from '../src/multitable/types'
+import { useLocale } from '../src/composables/useLocale'
 
 type ToolbarState = {
   fields: MetaField[]
@@ -21,6 +22,10 @@ afterEach(() => {
   app = null
   container?.remove()
   container = null
+  // localeState is a module-level ref; the #1671 localStorage reinstall does
+  // not reset it, so an explicit reset keeps the en-asserting tests above
+  // independent of locale-mutating tests below.
+  useLocale().setLocale('en')
 })
 
 function mountToolbar(initial: Partial<ToolbarState> = {}) {
@@ -174,5 +179,88 @@ describe('MetaToolbar filter builder', () => {
     const valueSelect = panel.querySelector('select[aria-label="Filter value"]') as HTMLSelectElement | null
     expect(valueSelect).toBeTruthy()
     expect(Array.from(valueSelect!.options).map((option) => option.value)).toEqual(['', 'urgent', 'vip'])
+  })
+})
+
+async function openFilterPanelI18n(root: HTMLElement): Promise<HTMLElement> {
+  const button = Array.from(root.querySelectorAll('.meta-toolbar__left button'))
+    .find((b) => /Filter|筛选/.test(b.textContent ?? '')) as HTMLButtonElement | undefined
+  expect(button).toBeTruthy()
+  button?.click()
+  await nextTick()
+  const panel = root.querySelector('.meta-toolbar__panel--filter') as HTMLElement | null
+  expect(panel).toBeTruthy()
+  return panel!
+}
+
+describe('MetaToolbar i18n', () => {
+  // mountToolbar() passes canCreateRecord:true + canExport:true, so the
+  // capability-gated Import / Export / New Record controls render — this is
+  // why the zh assertions for `导出 CSV` / `+ 新建记录` are reachable
+  // (MD §7.2 capability-gating note).
+  it('renders zh-CN toolbar chrome when locale is zh-CN', () => {
+    useLocale().setLocale('zh-CN')
+    const { container: root } = mountToolbar()
+    const text = root.textContent ?? ''
+    for (const zh of ['字段', '排序', '筛选', '分组', '导出 CSV', '+ 新建记录']) {
+      expect(text).toContain(zh)
+    }
+    expect(text).not.toContain('Fields')
+    expect(text).not.toContain('+ New Record')
+    expect(root.querySelector('[role="toolbar"]')?.getAttribute('aria-label')).toBe('表格工具栏')
+    // search copy lives in attributes, not textContent — assert on the node.
+    const search = root.querySelector('.meta-toolbar__search-input') as HTMLInputElement
+    expect(search.getAttribute('placeholder')).toBe('搜索记录...')
+    expect(search.getAttribute('aria-label')).toBe('搜索记录')
+  })
+
+  it('renders English toolbar chrome when locale is en', () => {
+    useLocale().setLocale('en')
+    const { container: root } = mountToolbar()
+    const text = root.textContent ?? ''
+    for (const en of ['Fields', 'Sort', 'Filter', 'Group', 'Export CSV', '+ New Record']) {
+      expect(text).toContain(en)
+    }
+    expect(text).not.toContain('字段')
+    const search = root.querySelector('.meta-toolbar__search-input') as HTMLInputElement
+    expect(search.getAttribute('placeholder')).toBe('Search records...')
+  })
+
+  it('localizes the filter panel conjunction / options / type labels in zh-CN', async () => {
+    useLocale().setLocale('zh-CN')
+    const { container: root } = mountToolbar({
+      filterRules: [
+        { fieldId: 'status', operator: 'is', value: 'todo' },
+        { fieldId: 'approved', operator: 'is', value: true },
+      ],
+      filterConjunction: 'and',
+    })
+    const panel = await openFilterPanelI18n(root)
+    const text = panel.textContent ?? ''
+    expect(text).toContain('当')             // Where (filterRules.length > 1)
+    expect(text).toContain('全部')           // all (conjunction option)
+    expect(text).toContain('条件匹配')       // conditions match
+    expect(text).toContain('已勾选 / true')  // boolean option keeps literal token
+    expect(text).toContain('未勾选 / false')
+    expect(text).toContain('+ 添加筛选')     // + Add filter
+    expect(text).toContain('全部清除')       // Clear all
+    expect(text).toContain('单选')           // F2: select field-type label localized
+    expect(text).toContain('复选框')         // F2: boolean field-type label localized
+    // F4: filter-control aria labels localized
+    expect(panel.querySelector('select[aria-label="筛选字段"]')).toBeTruthy()
+    expect(panel.querySelector('select[aria-label="筛选运算符"]')).toBeTruthy()
+    expect(text).not.toContain('conditions match')
+  })
+
+  it('localizes dirty apply copy in zh-CN', async () => {
+    useLocale().setLocale('zh-CN')
+    const { container: root } = mountToolbar({
+      filterRules: [{ fieldId: 'status', operator: 'is', value: 'todo' }],
+      sortFilterDirty: true,
+    })
+    const panel = await openFilterPanelI18n(root)
+    expect(panel.textContent).toContain('应用筛选更改')
+    expect(panel.textContent).toContain('筛选更改将在应用后生效。')
+    expect(panel.textContent).not.toContain('Apply filter changes')
   })
 })

--- a/apps/web/tests/multitable-core-i18n.spec.ts
+++ b/apps/web/tests/multitable-core-i18n.spec.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest'
+import {
+  metaCoreLabel,
+  rowCount,
+  selectedCount,
+  commentForRow,
+  commentForField,
+  groupNoValue,
+  fieldTypeLabel,
+  filterValuePlaceholder,
+} from '../src/multitable/utils/meta-core-labels'
+
+describe('meta-core-labels static keys', () => {
+  it('returns zh for isZh=true and en for isZh=false', () => {
+    expect(metaCoreLabel('toolbar.fields', true)).toBe('字段')
+    expect(metaCoreLabel('toolbar.fields', false)).toBe('Fields')
+    expect(metaCoreLabel('grid.aria', true)).toBe('数据表格')
+    expect(metaCoreLabel('grid.aria', false)).toBe('Data grid')
+    expect(metaCoreLabel('toolbar.aria', true)).toBe('表格工具栏')
+  })
+
+  it('F1: sort-direction options — en keeps alphabet arrows, zh is 升序/降序', () => {
+    expect(metaCoreLabel('toolbar.sortAsc', false)).toBe('A → Z')
+    expect(metaCoreLabel('toolbar.sortDesc', false)).toBe('Z → A')
+    expect(metaCoreLabel('toolbar.sortAsc', true)).toBe('升序')
+    expect(metaCoreLabel('toolbar.sortDesc', true)).toBe('降序')
+  })
+
+  it('F3: undo/redo title keeps the physical-key shortcut literal in both locales', () => {
+    expect(metaCoreLabel('toolbar.undo', true)).toBe('撤销')
+    expect(metaCoreLabel('toolbar.undoTitle', true)).toBe('撤销 (Ctrl+Z)')
+    expect(metaCoreLabel('toolbar.undoTitle', false)).toBe('Undo (Ctrl+Z)')
+    expect(metaCoreLabel('toolbar.redoTitle', true)).toBe('重做 (Ctrl+Y)')
+    expect(metaCoreLabel('toolbar.redoTitle', false)).toBe('Redo (Ctrl+Y)')
+  })
+
+  it('F4: filter-control aria labels are present', () => {
+    expect(metaCoreLabel('toolbar.filterField', true)).toBe('筛选字段')
+    expect(metaCoreLabel('toolbar.filterOperator', true)).toBe('筛选运算符')
+    expect(metaCoreLabel('toolbar.filterValue', true)).toBe('筛选值')
+    expect(metaCoreLabel('toolbar.filterField', false)).toBe('Filter field')
+  })
+
+  it('user-confirmed: Rows density button zh=行高, en stays Rows; distinct from rowHeight key', () => {
+    expect(metaCoreLabel('toolbar.rows', false)).toBe('Rows')
+    expect(metaCoreLabel('toolbar.rows', true)).toBe('行高')
+    expect(metaCoreLabel('toolbar.rowHeight', false)).toBe('Row height')
+    expect(metaCoreLabel('toolbar.rowHeight', true)).toBe('行高')
+  })
+
+  it('checkbox / boolean filter option labels keep the literal true/false token', () => {
+    expect(metaCoreLabel('toolbar.checkedTrue', true)).toBe('已勾选 / true')
+    expect(metaCoreLabel('toolbar.uncheckedFalse', true)).toBe('未勾选 / false')
+  })
+})
+
+describe('meta-core-labels helpers', () => {
+  it('rowCount fixes en pluralization; zh has no plural', () => {
+    expect(rowCount(1, false)).toBe('1 row')
+    expect(rowCount(2, false)).toBe('2 rows')
+    expect(rowCount(0, false)).toBe('0 rows')
+    expect(rowCount(1, true)).toBe('1 行')
+    expect(rowCount(2, true)).toBe('2 行')
+  })
+
+  it('selectedCount: en "selected" does not inflect; zh uses 已选择 N 条', () => {
+    expect(selectedCount(1, false)).toBe('1 selected')
+    expect(selectedCount(2, false)).toBe('2 selected')
+    expect(selectedCount(1, true)).toBe('已选择 1 条')
+    expect(selectedCount(3, true)).toBe('已选择 3 条')
+  })
+
+  it('commentForRow uses the UI-generated 1-based row number', () => {
+    expect(commentForRow(3, false)).toBe('Comments for row 3')
+    expect(commentForRow(3, true)).toBe('第 3 行评论')
+  })
+
+  it('commentForField interpolates the field name raw — never translated', () => {
+    expect(commentForField('Status', false)).toBe('Comments for Status')
+    expect(commentForField('Status', true)).toBe('Status 的评论')
+    // a Chinese-authored field name also passes through unchanged
+    expect(commentForField('负责人', true)).toBe('负责人 的评论')
+  })
+
+  it('groupNoValue localizes only the synthetic fallback label', () => {
+    expect(groupNoValue(false)).toBe('(No value)')
+    expect(groupNoValue(true)).toBe('(无值)')
+  })
+
+  it('fieldTypeLabel translates known types and falls back to the raw type', () => {
+    expect(fieldTypeLabel('longText', false)).toBe('long text')
+    expect(fieldTypeLabel('longText', true)).toBe('长文本')
+    expect(fieldTypeLabel('multiSelect', true)).toBe('多选')
+    expect(fieldTypeLabel('boolean', true)).toBe('复选框')
+    // unknown / custom type: returned unchanged in BOTH locales
+    expect(fieldTypeLabel('formula', false)).toBe('formula')
+    expect(fieldTypeLabel('formula', true)).toBe('formula')
+  })
+
+  it('filterValuePlaceholder is keyed by field type with a text fallback', () => {
+    expect(filterValuePlaceholder('number', false)).toBe('Enter a number')
+    expect(filterValuePlaceholder('number', true)).toBe('输入数字')
+    expect(filterValuePlaceholder('date', true)).toBe('选择日期')
+    expect(filterValuePlaceholder('string', true)).toBe('输入筛选文本')
+    expect(filterValuePlaceholder('whatever', false)).toBe('Enter filter text')
+  })
+})

--- a/docs/development/multitable-t3a-core-table-i18n-development-20260519.md
+++ b/docs/development/multitable-t3a-core-table-i18n-development-20260519.md
@@ -1,0 +1,659 @@
+# T3A Core Table Chrome i18n Development Plan
+
+- **Date**: 2026-05-19
+- **Type**: development plan / implementation-ready design
+- **Status**: Read-only design packet. Implementation requires explicit operator approval.
+- **Preceded by**:
+  - `docs/development/multitable-t3-meta-i18n-scout-20260519.md`
+  - `docs/development/multitable-workbench-i18n-t2-development-20260519.md`
+  - `docs/development/multitable-workbench-i18n-t2-verification-20260519.md`
+- **Goal**: localize the highest-frequency multitable table surface to zh-CN without changing table behavior, API contracts, schema, migrations, K3 paths, or plugin integration code.
+
+---
+
+## 1. Executive Summary
+
+T3A should localize the core table chrome only:
+
+- `MetaToolbar.vue`: fields, sort, filter, group, search, row count, density, print/import/export, new-record controls.
+- `MetaGridTable.vue`: grid aria label, bulk action bar, empty states, group no-value label, comment aria labels, pagination, loading label.
+- `MetaCellEditor.vue`: only shallow static edit affordances that are visible inside grid cells.
+- New typed label module: `apps/web/src/multitable/utils/meta-core-labels.ts`.
+- Tests: label helper unit spec plus focused toolbar/grid/cell render assertions in zh-CN and en.
+
+Do not translate user data: field names, option values, view names, record values, group values, user names, ids, URLs, emails, or backend-provided free-form error messages.
+
+This is intentionally smaller than "T3 all". The goal is to make the everyday table path feel Chinese after H-series and T2, while leaving manager panels, record drawer, comments, import, automation, and dynamic Workbench toasts to later T3 slices.
+
+---
+
+## 2. Code Scout Evidence
+
+### 2.1 Files Read
+
+Current implementation was inspected directly:
+
+```text
+apps/web/src/multitable/components/MetaToolbar.vue
+apps/web/src/multitable/components/MetaGridTable.vue
+apps/web/src/multitable/components/cells/MetaCellEditor.vue
+apps/web/src/multitable/components/MetaFieldHeader.vue
+apps/web/src/multitable/utils/workbench-labels.ts
+apps/web/tests/meta-toolbar-filter-builder.spec.ts
+apps/web/tests/multitable-grid.spec.ts
+apps/web/tests/multitable-workbench-view.spec.ts
+```
+
+### 2.2 Existing Test Surface
+
+| File | Current Role | T3A Use |
+|---|---|---|
+| `apps/web/tests/meta-toolbar-filter-builder.spec.ts` | Mounts real `MetaToolbar` with reactive state; already checks filter controls, typed defaults, dirty apply copy. | Extend with locale-aware zh-CN/en assertions. |
+| `apps/web/tests/multitable-grid.spec.ts` | Tests `useMultitableGrid` composable, not `MetaGridTable` component. | Keep as regression only; do not overload it with component i18n. |
+| `apps/web/tests/multitable-workbench-view.spec.ts` | Full Workbench mount. T2 render assertions now reliable after #1671. | Do not use for T3A except optional smoke; focused component specs are cheaper and clearer. |
+
+### 2.3 Existing Label Pattern
+
+`apps/web/src/multitable/utils/workbench-labels.ts` is the closest precedent:
+
+- Explicit `en` + `zh` mapping.
+- Typed key union.
+- Helper functions for interpolated strings.
+- Components read `useLocale().isZh`.
+- Template usage can rely on computed auto-unwrapping; script usage must use `.value`.
+
+T3A should follow this pattern but should not keep expanding `workbench-labels.ts`. The Workbench label module should remain the T2 shell module. T3A needs a separate core-table label module.
+
+---
+
+## 3. Scope
+
+### 3.1 In Scope
+
+| Surface | File | In-Scope Strings |
+|---|---|---|
+| Toolbar shell | `MetaToolbar.vue` | `Grid toolbar`, `Fields`, `Sort`, `Filter`, `Group`, `Rows`, `Fit`, `Print`, `Import`, `Export CSV`, `Export XLSX`, `+ New Record` |
+| Sort panel | `MetaToolbar.vue` | `+ Add sort`, `Apply` |
+| Filter panel | `MetaToolbar.vue` | `Where`, `all`, `any`, `conditions match`, `Filter field`, `Filter operator`, `Filter value`, `no value needed`, `Choose option...`, `No options`, `checked / true`, `unchecked / false`, `+ Add filter`, `Clear all`, `Apply filter changes`, `Apply filters`, `Filter changes are staged until applied.` |
+| Field type labels | `MetaToolbar.vue` | `text`, `long text`, `number`, `checkbox`, `select`, `multi-select`, `date` |
+| Filter placeholders | `MetaToolbar.vue` | `Enter a number`, `Pick a date`, `Enter filter text` |
+| Group panel | `MetaToolbar.vue` | `None` |
+| Undo/search/density aria/title | `MetaToolbar.vue` | `Undo`, `Redo`, `Search records...`, `Search records`, `Clear search`, `Row height`, `Auto-fit columns`, `Print grid`, `Import records`, `Export Excel` |
+| Row count/density labels | `MetaToolbar.vue` | `{n} rows`, `Compact`, `Normal`, `Expanded` |
+| Grid root and bulk bar | `MetaGridTable.vue` | `Data grid`, `{n} selected`, `Set field`, `Clear field`, `Delete selected`, `Clear`, relevant aria labels |
+| Empty states | `MetaGridTable.vue` | `No records yet`, `Click + New Record to add your first row`, `No matching records`, `Try a different search term` |
+| Row expand/comment aria | `MetaGridTable.vue` | `Collapse row`, `Expand row`, `Comments for row {n}`, `Comments for {field}` |
+| Group no-value label | `MetaGridTable.vue` | `(No value)` |
+| Pagination/loading | `MetaGridTable.vue` | `Prev`, `Next`, `Loading data` |
+| Shallow cell editor strings | `MetaCellEditor.vue` | `Editing`, `Scan or enter barcode`, `Enter address`, `Yes`, `No`, `Clear`, link button fallback, attachment action hints, upload activity labels, fallback attachment errors |
+
+### 3.2 Out of Scope
+
+| Surface | Reason |
+|---|---|
+| `MetaRecordDrawer.vue`, `MetaFormView.vue`, comments drawer/composer/link picker | T3B. These are record-detail and form-edit surfaces, not core table chrome. |
+| `MetaFieldManager.vue`, `MetaViewManager.vue`, permission/share/API manager panels | T3C. Larger admin surface with higher wording risk. |
+| `MetaAutomationManager.vue`, automation rule editor/log viewers | T3D. DingTalk and automation semantics need dedicated review. |
+| `MultitableWorkbench.vue` dynamic toasts and `templateLibraryError` | T3E. Dynamic pluralization/backend fallback needs separate helpers and tests. |
+| `MetaImportModal.vue`, `MetaBulkEditDialog.vue`, conditional formatting | T3C/T3E. These are modal workflows, not default table chrome. |
+| Field names, option labels, group values, view names, record values | User data; must remain as authored. |
+| Backend error messages or validation messages from services | Do not translate free-form backend text in T3A. Only map stable frontend-owned strings. |
+| `MetaFieldHeader.vue` field type icon map | Mostly icons/data labels. Do not change unless adding aria labels later. |
+
+### 3.3 MetaCellEditor Boundary
+
+`MetaCellEditor.vue` is included only because it appears inline inside the grid when users edit a cell. Keep T3A limited to shallow, static user-facing text:
+
+- Include: placeholders, boolean `Yes/No`, rating `Clear`, Yjs chip label `Editing`, attachment static action hints, activity labels, fallback error strings.
+- Do not redesign attachment upload errors.
+- Do not translate option values in select/multi-select.
+- Do not translate URL/email/phone example placeholders; they are example data formats, not UI copy.
+- If the implementation becomes noisy, split `MetaCellEditor` into a follow-up T3A2 and keep initial T3A to `MetaToolbar` + `MetaGridTable`.
+
+---
+
+## 4. Proposed Label Module
+
+Create:
+
+```text
+apps/web/src/multitable/utils/meta-core-labels.ts
+```
+
+Pattern:
+
+```ts
+export type MetaCoreLabelKey =
+  | 'toolbar.aria'
+  | 'toolbar.fields'
+  // ...
+
+const META_CORE_LABELS: Record<MetaCoreLabelKey, { en: string; zh: string }> = {
+  'toolbar.fields': { en: 'Fields', zh: '字段' },
+}
+
+export function metaCoreLabel(key: MetaCoreLabelKey, isZh: boolean): string {
+  const entry = META_CORE_LABELS[key]
+  return isZh ? entry.zh : entry.en
+}
+```
+
+Helper functions:
+
+| Helper | English | Chinese | Notes |
+|---|---|---|---|
+| `rowCount(n, isZh)` | `1 row`, `N rows` | `N 行` | Fix existing English-only `{n} rows`; keep plural correct in en. |
+| `selectedCount(n, isZh)` | `1 selected`, `N selected` | `已选择 N 条` | Bulk bar. |
+| `commentForRow(rowNumber, isZh)` | `Comments for row 3` | `第 3 行评论` | Row number is UI-generated. |
+| `commentForField(fieldName, isZh)` | `Comments for Status` | `Status 的评论` | Field name remains untranslated. |
+| `groupNoValue(isZh)` | `(No value)` | `(无值)` | Data group fallback only. |
+| `filterFieldTypeLabel(type, isZh)` | `long text` | `长文本` | Stable field type labels only. |
+| `filterValuePlaceholder(type, isZh)` | `Enter a number` | `输入数字` | Stable frontend placeholders. |
+| `linkButtonFallback(isZh)` | `Choose linked records...` | `选择关联记录...` | Only fallback; `formatLinkActionLabel` output may need separate T3B work if field-specific. |
+| `attachmentActionHint(allowsMultiple, hasExisting, isZh)` | current three variants | Chinese variants | Keep logic in helper for testability. |
+| `attachmentActivityLabel(activity, isZh)` | `Uploading...` etc. | Chinese variants | Include `uploading/removing/clearing`. |
+
+Why helpers instead of keys for dynamic strings:
+
+- Avoid ad-hoc template string assembly in components.
+- Keep en pluralization and zh non-plural behavior tested in one place.
+- Make field/user data interpolation explicit and auditable.
+
+---
+
+## 5. Exact Key Table
+
+### 5.1 Static Toolbar Keys
+
+| Key | EN | ZH |
+|---|---|---|
+| `toolbar.aria` | Grid toolbar | 表格工具栏 |
+| `toolbar.fields` | Fields | 字段 |
+| `toolbar.sort` | Sort | 排序 |
+| `toolbar.addSort` | + Add sort | + 添加排序 |
+| `toolbar.apply` | Apply | 应用 |
+| `toolbar.filter` | Filter | 筛选 |
+| `toolbar.where` | Where | 当 |
+| `toolbar.all` | all | 全部 |
+| `toolbar.any` | any | 任一 |
+| `toolbar.conditionsMatch` | conditions match | 条件匹配 |
+| `toolbar.noValueNeeded` | no value needed | 无需填写值 |
+| `toolbar.chooseOption` | Choose option... | 选择选项... |
+| `toolbar.noOptions` | No options | 无可用选项 |
+| `toolbar.checkedTrue` | checked / true | 已勾选 / true |
+| `toolbar.uncheckedFalse` | unchecked / false | 未勾选 / false |
+| `toolbar.addFilter` | + Add filter | + 添加筛选 |
+| `toolbar.clearAll` | Clear all | 全部清除 |
+| `toolbar.applyFilterChanges` | Apply filter changes | 应用筛选更改 |
+| `toolbar.applyFilters` | Apply filters | 应用筛选 |
+| `toolbar.stagedHint` | Filter changes are staged until applied. | 筛选更改将在应用后生效。 |
+| `toolbar.group` | Group | 分组 |
+| `toolbar.none` | None | 无 |
+| `toolbar.undo` | Undo | 撤销 |
+| `toolbar.redo` | Redo | 重做 |
+| `toolbar.searchPlaceholder` | Search records... | 搜索记录... |
+| `toolbar.searchAria` | Search records | 搜索记录 |
+| `toolbar.clearSearch` | Clear search | 清除搜索 |
+| `toolbar.rowHeight` | Row height | 行高 |
+| `toolbar.rows` | Rows | 行 |
+| `toolbar.autoFitColumns` | Auto-fit columns | 自动适应列宽 |
+| `toolbar.fit` | Fit | 适应 |
+| `toolbar.print` | Print | 打印 |
+| `toolbar.printGrid` | Print grid | 打印表格 |
+| `toolbar.importRecords` | Import records | 导入记录 |
+| `toolbar.import` | Import | 导入 |
+| `toolbar.exportCsv` | Export CSV | 导出 CSV |
+| `toolbar.exportExcel` | Export Excel | 导出 Excel |
+| `toolbar.exportExcelXlsx` | Export Excel (.xlsx) | 导出 Excel (.xlsx) |
+| `toolbar.exportXlsx` | Export XLSX | 导出 XLSX |
+| `toolbar.newRecord` | + New Record | + 新建记录 |
+
+### 5.2 Density Keys
+
+| Key | EN | ZH |
+|---|---|---|
+| `density.compact` | Compact | 紧凑 |
+| `density.normal` | Normal | 标准 |
+| `density.expanded` | Expanded | 宽松 |
+
+### 5.3 Field Type Labels
+
+| Field Type | EN | ZH |
+|---|---|---|
+| `string` | text | 文本 |
+| `longText` | long text | 长文本 |
+| `number` | number | 数字 |
+| `boolean` | checkbox | 复选框 |
+| `select` | select | 单选 |
+| `multiSelect` | multi-select | 多选 |
+| `date` | date | 日期 |
+| fallback | original type | original type | Unknown/custom values stay as-is. |
+
+### 5.4 Filter Placeholder Helpers
+
+| Field Type | EN | ZH |
+|---|---|---|
+| `number` | Enter a number | 输入数字 |
+| `date` | Pick a date | 选择日期 |
+| fallback | Enter filter text | 输入筛选文本 |
+
+### 5.5 Grid Static Keys
+
+| Key | EN | ZH |
+|---|---|---|
+| `grid.aria` | Data grid | 数据表格 |
+| `grid.setField` | Set field | 设置字段 |
+| `grid.setFieldAria` | Set field on selected records | 为所选记录设置字段 |
+| `grid.clearField` | Clear field | 清空字段 |
+| `grid.clearFieldAria` | Clear field on selected records | 清空所选记录的字段 |
+| `grid.deleteSelected` | Delete selected | 删除所选 |
+| `grid.deleteSelectedAria` | Delete selected records | 删除所选记录 |
+| `grid.clear` | Clear | 清除 |
+| `grid.clearSelection` | Clear selection | 清除选择 |
+| `grid.noRecordsTitle` | No records yet | 暂无记录 |
+| `grid.noRecordsHintPrefix` | Click | 点击 |
+| `grid.noRecordsHintAction` | + New Record | + 新建记录 |
+| `grid.noRecordsHintSuffix` | to add your first row | 添加第一行 |
+| `grid.noMatchingTitle` | No matching records | 没有匹配的记录 |
+| `grid.noMatchingHint` | Try a different search term | 试试其他搜索词 |
+| `grid.collapseRow` | Collapse row | 收起行 |
+| `grid.expandRow` | Expand row | 展开行 |
+| `grid.prev` | Prev | 上一页 |
+| `grid.next` | Next | 下一页 |
+| `grid.loading` | Loading data | 正在加载数据 |
+
+Note: the current empty hint uses an inline `<strong>+ New Record</strong>`. Implementation should preserve emphasis while localizing the sentence. It can use three label segments or a small helper.
+
+### 5.6 Cell Editor Keys
+
+| Key / Helper | EN | ZH | Notes |
+|---|---|---|---|
+| `cell.editing` | Editing | 正在编辑 | Yjs presence chip label. |
+| `cell.barcodePlaceholder` | Scan or enter barcode | 扫描或输入条码 | Static placeholder. |
+| `cell.locationPlaceholder` | Enter address | 输入地址 | Static placeholder. |
+| `cell.yes` | Yes | 是 | Boolean editor. |
+| `cell.no` | No | 否 | Boolean editor. |
+| `cell.clear` | Clear | 清除 | Rating clear. |
+| `cell.noAttachments` | No attachments | 无附件 | Passed to `MetaAttachmentList`. |
+| `cell.clearAll` | Clear all | 全部清除 | Attachment action. |
+| `attachmentActionHint(...)` | current three variants | Chinese variants | Helper. |
+| `attachmentActivityLabel(...)` | Removing/Clearing/Uploading... | 正在移除/清空/上传... | Helper. |
+| `cell.uploadFailed` | Failed to upload attachment | 附件上传失败 | Fallback only. |
+| `cell.removeFailed` | Failed to remove attachment | 附件移除失败 | Fallback only. |
+| `cell.clearFailed` | Failed to clear attachments | 附件清空失败 | Fallback only. |
+
+Do not localize these in T3A:
+
+| Existing Text | Reason |
+|---|---|
+| `https://example.com` | Format example, not UI chrome. |
+| `name@example.com` | Format example, not UI chrome. |
+| `+86 138 0000 0000` | Format example, already locale-relevant. |
+| Select/multi-select option text | User/data value. |
+| `formatLinkActionLabel` output | Comes from link-field utility; if it contains English, handle in T3B with link picker/drawer. |
+| `validateAttachmentSelection(...)` message | Field-config validation layer, not shallow chrome. |
+
+---
+
+## 6. Component Wiring Plan
+
+### 6.1 Common Import Pattern
+
+In `MetaToolbar.vue`, `MetaGridTable.vue`, and optional `MetaCellEditor.vue`:
+
+```ts
+import { useLocale } from '../../composables/useLocale'
+import { metaCoreLabel, rowCount } from '../utils/meta-core-labels'
+
+const { isZh } = useLocale()
+const l = (key: MetaCoreLabelKey) => metaCoreLabel(key, isZh.value)
+```
+
+Path examples must be adjusted by file location:
+
+- From `components/MetaToolbar.vue`: `../utils/meta-core-labels`, `../../composables/useLocale`
+- From `components/MetaGridTable.vue`: `../utils/meta-core-labels`, `../../composables/useLocale`
+- From `components/cells/MetaCellEditor.vue`: `../../utils/meta-core-labels`, `../../../composables/useLocale`
+
+### 6.2 Template Usage
+
+Preferred:
+
+```vue
+<button>{{ l('toolbar.fields') }}</button>
+```
+
+Acceptable for helpers:
+
+```vue
+<span>{{ rowCount(totalRows, isZh) }}</span>
+```
+
+Vue templates auto-unwrap computed refs, so `isZh` is fine in templates. In script/computed functions, use `isZh.value`.
+
+### 6.3 Script Computed Usage
+
+Examples:
+
+```ts
+const applyButtonLabel = computed(() =>
+  props.sortFilterDirty
+    ? metaCoreLabel('toolbar.applyFilterChanges', isZh.value)
+    : metaCoreLabel('toolbar.applyFilters', isZh.value),
+)
+
+function getFilterFieldTypeLabel(fieldId: string): string {
+  const type = getFieldType(fieldId)
+  return filterFieldTypeLabel(type, isZh.value)
+}
+```
+
+### 6.4 Preserve Data-Layer Values
+
+Do not wrap these:
+
+```vue
+{{ field.name }}
+{{ option.label }}
+{{ option.value }}
+{{ group.label }} // except the special fallback group "(No value)"
+{{ row.data[field.id] }}
+```
+
+Only the fallback group label should be localized:
+
+```ts
+label: key === '__ungrouped__' ? groupNoValue(isZh.value) : key
+```
+
+If grouping values include English user data, they must remain exactly as stored.
+
+---
+
+## 7. Test Plan
+
+### 7.1 New Label Spec
+
+Create:
+
+```text
+apps/web/tests/multitable-core-i18n.spec.ts
+```
+
+Coverage:
+
+| Case | Assertions |
+|---|---|
+| Static labels | `metaCoreLabel('toolbar.fields', true) === '字段'`; `false === 'Fields'`. |
+| Row count | en `1 row` / `2 rows`; zh `1 行` / `2 行`. |
+| Selected count | en `1 selected` / `2 selected`; zh `已选择 1 条` / `已选择 2 条`. |
+| Comment aria helpers | field name remains raw: `Status 的评论`, not translated. |
+| Field type helper | known labels translate; unknown type returns original. |
+| Attachment helpers | all three action hints and three activity states covered. |
+
+### 7.2 MetaToolbar Render Spec
+
+Extend `apps/web/tests/meta-toolbar-filter-builder.spec.ts` rather than creating a second toolbar harness.
+
+Capability-gated strings must be made reachable explicitly. The existing `mountToolbar()` helper currently passes `canCreateRecord: true` and `canExport: true`, which is why `Import`, `Export CSV`, `Export XLSX`, and `+ New Record` render. If the helper is refactored or a new harness is introduced, the T3A render tests must set:
+
+```ts
+canCreateRecord: true
+canExport: true
+```
+
+Do not assert capability-gated strings from a mount where those capabilities are false or omitted. This is the same class of false-negative risk as the T2 Workbench `Workflow` / `Automations` gating issue.
+
+New cases:
+
+| Case | Setup | Assertions |
+|---|---|---|
+| zh-CN toolbar shell | `useLocale().setLocale('zh-CN')`, mount with `canCreateRecord: true`, `canExport: true` | Contains `字段`, `排序`, `筛选`, `分组`, `搜索记录`, `导出 CSV`, `+ 新建记录`; does not contain `Fields` / `Search records...`. |
+| en toolbar shell | `useLocale().setLocale('en')` | Existing English strings still render. |
+| zh-CN filter panel | Open filter panel with select/boolean fields | Contains `当`, `全部`, `条件匹配`, `无可用选项` or `选择选项...`, `已勾选 / true`, `未勾选 / false`, `添加筛选`. |
+| zh-CN dirty apply copy | `sortFilterDirty: true` | Contains `应用筛选更改`, `筛选更改将在应用后生效。` |
+
+After each test, reset:
+
+```ts
+useLocale().setLocale('en')
+```
+
+### 7.3 MetaGridTable Render Spec
+
+Create focused component spec:
+
+```text
+apps/web/tests/meta-grid-table-i18n.spec.ts
+```
+
+Do not use full Workbench mount. Directly mount `MetaGridTable` with an explicit, real prop set. Do not rely on "minimal props" by guesswork.
+
+Baseline mount props:
+
+```ts
+{
+  rows,
+  visibleFields,
+  sortRules: [],
+  loading: false,
+  currentPage: 1,
+  totalPages: 1,
+  startIndex: 0,
+  canEdit: true,
+  canDelete: true,
+  canBulkEdit: true,
+  enableMultiSelect: true,
+  searchText: '',
+  rowDensity: 'normal',
+  groupField: null,
+  fieldReadOnlyIds: [],
+  rowActionOverrides: {},
+  columnWidths: {},
+  linkSummaries: {},
+  attachmentSummaries: {},
+  canComment: true,
+  commentPresence: {},
+}
+```
+
+Bulk-delete assertions are capability-gated by `canDelete`; bulk set/clear assertions are gated by `canBulkEdit`; selection UI is gated by `enableMultiSelect`. If any of those props are false or omitted, do not assert the gated strings.
+
+`apps/web/tests/multitable-grid.spec.ts` currently targets the `useMultitableGrid` composable rather than `MetaGridTable` component render. Treat it as a regression check only after confirming that remains true at implementation time.
+
+Cases:
+
+| Case | Setup | Assertions |
+|---|---|---|
+| zh-CN empty grid | rows `[]`, visible fields `[Title]`, loading false | Contains `暂无记录`, `点击`, `+ 新建记录`, `添加第一行`; root aria-label `数据表格`. |
+| en empty grid | locale en | Contains `No records yet`, `+ New Record`. |
+| zh-CN search empty | `searchText: 'abc'`, rows `[]` | Contains `没有匹配的记录`, `试试其他搜索词`. |
+| zh-CN bulk bar | rows with selectable ids, enable multi-select, simulate checkbox selection | Contains `已选择 1 条`, `设置字段`, `清空字段`, `删除所选`, `清除`; aria labels localized. |
+| zh-CN pagination/loading | totalPages > 1 and loading true | Contains `上一页`, `下一页`; loading aria-label `正在加载数据`. |
+| no user-data translation | field name `Status`, group value `Needs Review` | These remain raw while fallback `(No value)` becomes `(无值)`. |
+
+### 7.4 MetaCellEditor Render Spec
+
+Add to an existing cell editor spec if appropriate, or create:
+
+```text
+apps/web/tests/meta-cell-editor-i18n.spec.ts
+```
+
+Cases:
+
+| Case | Assertions |
+|---|---|
+| boolean zh/en | `是/否` in zh, `Yes/No` in en. |
+| barcode/location placeholders | zh placeholders render in zh. |
+| rating clear | zh `清除`, en `Clear`. |
+| attachment fallback chrome | `无附件`, `上传文件`, `全部清除` where visible. |
+| option values untouched | select option value `todo` remains `todo`. |
+
+If this spec grows too much, defer `MetaCellEditor` implementation to T3A2 and keep this MD as the boundary record.
+
+### 7.5 Validation Commands
+
+Required focused checks:
+
+The file paths above are repository-relative. The commands below run through `pnpm --filter @metasheet/web exec`, so Vitest's working directory is `apps/web`; spec paths must be package-relative (`tests/...`), not `apps/web/tests/...`.
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-core-i18n.spec.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/meta-toolbar-filter-builder.spec.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/meta-grid-table-i18n.spec.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run tests/meta-cell-editor-i18n.spec.ts --watch=false
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+pnpm --filter @metasheet/web build
+git diff --check origin/main..HEAD
+```
+
+If `MetaCellEditor` is deferred, omit its spec command and explicitly record the deferral in verification MD.
+
+Optional broader web test check:
+
+```bash
+pnpm --filter @metasheet/web test
+```
+
+This is useful after #1671, but T3A should not block solely on unrelated pre-existing web test failures if focused and CI checks are green.
+
+### 7.6 Implementation Preflight Grep
+
+Before writing code, verify each planned key has a current call-site. Do not create dead keys from the design table.
+
+Required grep pass:
+
+```bash
+rg -n "Fields|Sort|Filter|Group|Rows|Fit|Print|Import|Export CSV|Export XLSX|\\+ New Record|Search records|No records yet|No matching records|Prev|Next|Loading data|Scan or enter barcode|Enter address|No attachments|Failed to upload attachment" \
+  apps/web/src/multitable/components/MetaToolbar.vue \
+  apps/web/src/multitable/components/MetaGridTable.vue \
+  apps/web/src/multitable/components/cells/MetaCellEditor.vue
+```
+
+For each key:
+
+| Outcome | Required Action |
+|---|---|
+| Call-site exists | Wire the key or helper. |
+| Call-site does not exist | Do not implement the key; record it as removed from scope in verification MD. |
+| Call-site is user/data value | Do not translate; record as intentionally preserved. |
+| Call-site is capability-gated | Make it reachable in tests or exclude it from that assertion set. |
+
+---
+
+## 8. Acceptance Criteria
+
+T3A is complete when all are true:
+
+1. zh-CN locale renders localized toolbar/grid/cell-editor chrome for the in-scope strings.
+2. en locale preserves existing English labels and behavior.
+3. Field names, option values, group values, record values, IDs, URLs, email examples, phone examples, and backend error strings remain untranslated.
+4. Sort/filter/group/search/bulk selection behavior is unchanged.
+5. No API contract, backend route, migration, K3 adapter, plugin integration, or OpenAPI file changes.
+6. New label helpers have unit coverage for pluralization/interpolation and unknown fallbacks.
+7. Focused component tests cover both zh-CN and en render.
+8. Verification MD records any intentionally deferred strings found by grep.
+
+---
+
+## 9. Implementation Order
+
+Recommended commits:
+
+| Commit | Scope |
+|---|---|
+| `docs(multitable): T3A core table i18n development plan` | This MD only, if not bundled with implementation. |
+| `feat(multitable): add core table i18n label helpers` | `meta-core-labels.ts` + label helper tests. |
+| `feat(multitable): localize toolbar and grid chrome` | `MetaToolbar.vue`, `MetaGridTable.vue`, toolbar/grid render tests. |
+| `feat(multitable): localize shallow cell editor chrome` | `MetaCellEditor.vue` + cell editor render tests, only if kept in T3A. |
+| `docs(multitable): T3A verification` | Verification MD with command output and deferred-string ledger. |
+
+If keeping the PR smaller, split cell editor into a follow-up:
+
+- T3A1: label module + toolbar + grid.
+- T3A2: shallow cell editor chrome.
+
+The safer default is T3A1 first if review bandwidth is limited.
+
+---
+
+## 10. Risks and Mitigations
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Translating user data | High | Explicit non-translation list; tests include English field/option/group values that must remain unchanged. |
+| Large `MetaCellEditor` scope creep | Medium | Keep only shallow static strings; defer attachments/link utility if noisy. |
+| Existing tests assert English copy | Medium | Update tests deliberately; add en render assertions so English path stays stable. |
+| Helper import path mistakes | Low | Use `vue-tsc --noEmit`; components live at different folder depths. |
+| Pluralization mistakes | Low-medium | Helper unit tests for en singular/plural and zh count forms. |
+| Label module sprawl | Medium | Keep T3A common table chrome only in `meta-core-labels.ts`; do not absorb manager/automation strings. |
+| Accessibility label drift | Medium | Include aria/title labels in key table and render tests. |
+
+---
+
+## 11. Review Checklist
+
+Reviewer should verify:
+
+- `meta-core-labels.ts` contains no user-data mapping.
+- Unknown field types fall back to the original type string.
+- `MetaToolbar` still emits the same events and payloads.
+- `MetaGridTable` still emits the same row selection, bulk, comment, and pagination events.
+- `MetaCellEditor` still emits the same `update:modelValue`, `confirm`, `cancel`, `yjs-commit`, and `open-link-picker` events.
+- No K3/integration-core/backend files are touched.
+- Verification MD includes:
+  - focused test results,
+  - `vue-tsc` result,
+  - build result,
+  - `git diff --check`,
+  - deferred string ledger for T3B/T3C/T3D/T3E leftovers.
+
+---
+
+## 12. Proposed PR Title and Body Skeleton
+
+Title:
+
+```text
+feat(multitable): localize core table chrome to zh-CN (T3A)
+```
+
+Body outline:
+
+```markdown
+## What changed
+
+- Added typed `meta-core-labels.ts` for core table UI strings.
+- Localized `MetaToolbar` and `MetaGridTable` chrome to zh-CN while preserving en.
+- [Optional] Localized shallow `MetaCellEditor` static chrome.
+- Added zh/en render tests and helper unit tests.
+
+## What this does not change
+
+- No backend/API/OpenAPI/migration changes.
+- No K3 or plugin-integration-core changes.
+- Does not translate user data, field names, option values, group values, record values, URLs, ids, or backend free-form errors.
+- Does not cover Meta* manager panels, automation, record drawer, comments, import, or dynamic Workbench toasts.
+
+## Verification
+
+- pnpm --filter @metasheet/web exec vitest run ...
+- pnpm --filter @metasheet/web exec vue-tsc --noEmit
+- pnpm --filter @metasheet/web build
+- git diff --check origin/main..HEAD
+```
+
+---
+
+## 13. Recommendation
+
+Start implementation with **T3A1 only**:
+
+1. Add `meta-core-labels.ts`.
+2. Localize `MetaToolbar.vue`.
+3. Localize `MetaGridTable.vue`.
+4. Add label + toolbar + grid render tests.
+5. Write verification MD.
+
+Keep `MetaCellEditor.vue` as T3A2 unless the initial diff remains small. This avoids mixing cell attachment/link/Yjs edge cases into the first core-table PR while still giving zh-CN users the most visible improvement.


### PR DESCRIPTION
## Summary

- Add `meta-core-labels.ts` with typed zh-CN/en label helpers for core multitable table chrome.
- Localize `MetaToolbar` and `MetaGridTable` chrome strings while preserving user-authored field/value data and backend error text.
- Add focused label, toolbar, and grid i18n tests plus the T3A development plan.

## Scope Guard

This PR intentionally uses a clean branch rebuilt from `origin/main` with only the three T3A commits. The earlier local branch `frontend/multitable-t3a1-core-table-i18n-20260519` picked up an unrelated `#1670` default Grid view commit and is not the PR source.

No changes to:
- `packages/core-backend/**`
- K3 / integration-core paths
- migrations or API contracts
- Workbench/HomeView WIP from parallel sessions

## Verification

- `pnpm --filter @metasheet/web exec vitest run tests/multitable-core-i18n.spec.ts tests/meta-toolbar-filter-builder.spec.ts tests/meta-grid-table-i18n.spec.ts --watch=false` -> 27/27 pass
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit` -> pass
- `git diff --check origin/main..HEAD` -> clean
- `git diff --name-status origin/main..HEAD` -> exactly 7 T3A files

## Notes

The clean verification worktree installed dependencies, which produced local `node_modules` symlink noise in that temporary worktree only. Those files are uncommitted and are not part of the PR diff.
