### PR TITLE
docs(attendance): record report sync job live evidence

### DIFF
--- a/docs/development/attendance-report-sync-jobs-live-evidence-development-20260519.md
+++ b/docs/development/attendance-report-sync-jobs-live-evidence-development-20260519.md
@@ -1,0 +1,93 @@
+# 考勤报表同步任务化 Live Evidence 开发记录
+
+Date: 2026-05-19
+
+## Summary
+
+本轮完成 PR4 后续真实 staging `JOB_MODE=1` 验收准备与环境修复。
+
+范围是 staging ops/evidence，不新增产品代码：
+
+- 将 8082 staging backend/web 更新到最新 `origin/main` 镜像 `a3cb70de1c9b5bd3676f0db8126d1f8ac9617ac1`。
+- 使用文件型短期 admin JWT，通过 `AUTH_TOKEN_FILE=/tmp/<staging-admin-jwt-file>.jwt` 读取，不在命令输出或文档中记录 token。
+- 发现 staging DB 未应用 `plugin_attendance_report_sync_jobs` operational table schema，且全量 migration list 有 77 个 pending。
+- 为避免超出本轮验收边界，没有运行全量 migration；仅按已合并 migration `zzzz20260519070000_create_plugin_attendance_report_sync_jobs` 的 DDL 创建 job runner operational table 与索引。
+- 重跑 daily report records 与 period summaries 的 live acceptance `JOB_MODE=1`，两条均通过。
+
+本轮不修改 `attendance_*` 事实源，不写 `meta_*`，不提交 generated `output/` evidence。
+
+## Staging Runtime Prep
+
+| Step | Result |
+| --- | --- |
+| Health before route validation | `/api/health` returned `ok` |
+| Route before schema fix | `GET /api/attendance/report-sync-jobs` returned `503 DB_NOT_READY` |
+| Latest main image | `a3cb70de1c9b5bd3676f0db8126d1f8ac9617ac1` |
+| Staging backend/web after update | `ghcr.io/zensgit/metasheet2-backend:a3cb70de1c9b5bd3676f0db8126d1f8ac9617ac1` and matching web image |
+| Migration preview | `--list` reported 77 pending migrations |
+| Narrow staging schema repair | Created only `plugin_attendance_report_sync_jobs` and indexes |
+| Route after schema fix | `GET /api/attendance/report-sync-jobs` returned `200 {"ok":true,"data":{"items":[]}}` |
+
+## Narrow DDL Rationale
+
+The job runner route requires `plugin_attendance_report_sync_jobs`.
+Running the full migration set on staging would have applied 77 pending migrations, which is larger than this live evidence slice.
+The narrow DDL follows the merged migration contract:
+
+- `id uuid primary key default gen_random_uuid()`
+- `org_id`, `kind`, `status`, `mode`
+- JSONB operational state: `period_source`, `user_selection`, `cursor`, `totals`, `last_result`
+- lock/progress timestamps
+- kind/status/mode check constraints
+- org/status and org/created indexes
+- unique idempotency index
+
+This table is operational cursor/progress state only. It is not an attendance fact source and is not read by attendance query/export paths.
+
+## Live Commands
+
+Daily report records job-mode acceptance:
+
+```bash
+AUTH_SOURCE=AUTH_TOKEN_FILE \
+AUTH_TOKEN_FILE=/tmp/<staging-admin-jwt-file>.jwt \
+API_BASE=http://localhost:8082 \
+ORG_ID=default \
+USER_ID=<sample-admin-user-id> \
+FROM_DATE=2026-05-15 \
+TO_DATE=2026-05-17 \
+JOB_MODE=1 \
+JOB_PAGE_SIZE=2 \
+JOB_MAX_PAGES=5 \
+CONFIRM_SYNC=1 \
+OUTPUT_DIR=output/attendance-report-fields-live-acceptance/2026-05-19-job-mode-daily-after-staging-update \
+pnpm run verify:attendance-report-fields:live
+```
+
+Period summaries job-mode acceptance:
+
+```bash
+AUTH_SOURCE=AUTH_TOKEN_FILE \
+AUTH_TOKEN_FILE=/tmp/<staging-admin-jwt-file>.jwt \
+API_BASE=http://localhost:8082 \
+ORG_ID=default \
+USER_ID=<sample-admin-user-id> \
+FROM_DATE=2026-05-15 \
+TO_DATE=2026-05-17 \
+CYCLE_ID=<sample-payroll-cycle-id> \
+JOB_MODE=1 \
+PAGE_SIZE=2 \
+JOB_MAX_PAGES=5 \
+CONFIRM_SYNC=1 \
+OUTPUT_DIR=output/attendance-report-period-summaries-live-acceptance/2026-05-19-job-mode-period-after-staging-update \
+pnpm run verify:attendance-report-period-summaries:live
+```
+
+## Boundaries
+
+- No product code was changed in this evidence slice.
+- No `attendance_*` fact-table migration was introduced or run specifically for this slice.
+- No `meta_*` table was written directly.
+- No token/JWT literal was printed into committed files.
+- Local `output/` evidence remains untracked and is intentionally not committed.
+- The staging schema repair is documented as an environment alignment step; the committed product migration remains the source of truth.

--- a/docs/development/attendance-report-sync-jobs-live-evidence-verification-20260519.md
+++ b/docs/development/attendance-report-sync-jobs-live-evidence-verification-20260519.md
@@ -1,0 +1,112 @@
+# 考勤报表同步任务化 Live Evidence 验证记录
+
+Date: 2026-05-19
+
+## Scope
+
+验证已合并 report sync job runner 的真实 staging `JOB_MODE=1` 路径：
+
+- daily `attendance_report_records`
+- period `attendance_report_period_summaries` date range
+- period `attendance_report_period_summaries` payroll cycle
+
+本轮使用文件型 staging admin JWT，不记录 token 值。
+
+## Environment
+
+| Item | Value |
+| --- | --- |
+| API base | `http://localhost:8082` |
+| Auth source | `AUTH_TOKEN_FILE` |
+| Staging image | `a3cb70de1c9b5bd3676f0db8126d1f8ac9617ac1` |
+| Health | PASS |
+| Job route after schema alignment | `200 {"ok":true,"data":{"items":[]}}` |
+| Sample org | `default` |
+| Sample date range | `2026-05-15` to `2026-05-17` |
+
+## Daily Report Records Result
+
+| Check | Result |
+| --- | --- |
+| Command | `pnpm run verify:attendance-report-fields:live` with `JOB_MODE=1` |
+| Overall | PASS |
+| Total checks | 59 |
+| Failed checks | 0 |
+| Daily job status | `completed` |
+| Daily job pages | 1 |
+| Users scanned | 1 |
+| Rows synced | 3 |
+| Failed rows/users | 0 |
+| Terminal rerun | `409 JOB_TERMINAL` PASS |
+| Replacement job create + cancel | PASS |
+
+Field fingerprint consistency:
+
+| Surface | Fingerprint |
+| --- | --- |
+| catalog | `684233f9c36205f9ea59248b29f9d050f88af0cd` |
+| records | `684233f9c36205f9ea59248b29f9d050f88af0cd` |
+| export | `684233f9c36205f9ea59248b29f9d050f88af0cd` |
+| CSV label header | `684233f9c36205f9ea59248b29f9d050f88af0cd` |
+| CSV code header | `684233f9c36205f9ea59248b29f9d050f88af0cd` |
+
+Formula evidence:
+
+| Item | Value |
+| --- | --- |
+| Formula field codes | `net_anomaly_minutes` |
+| Formula invalid codes | empty |
+
+## Period Summaries Result
+
+| Check | Result |
+| --- | --- |
+| Command | `pnpm run verify:attendance-report-period-summaries:live` with `JOB_MODE=1` |
+| Overall | PASS |
+| Total checks | 56 |
+| Failed checks | 0 |
+| Date range job status | `completed` |
+| Date range job pages | 1 |
+| Date range users scanned | 1 |
+| Date range rows synced | 1 |
+| Payroll cycle job status | `completed` |
+| Payroll cycle job pages | 1 |
+| Payroll cycle users scanned | 1 |
+| Payroll cycle rows synced | 1 |
+| Terminal rerun | `409 JOB_TERMINAL` PASS for date range and payroll cycle |
+| Replacement job create + cancel | PASS for date range and payroll cycle |
+
+Period fingerprint:
+
+| Surface | Fingerprint |
+| --- | --- |
+| date range | `ecefbf5d6311372c780830b1504b471afba022ec` |
+| payroll cycle | `ecefbf5d6311372c780830b1504b471afba022ec` |
+
+## Files Produced Locally
+
+Generated evidence remains local and untracked:
+
+- `output/attendance-report-fields-live-acceptance/2026-05-19-job-mode-daily-after-staging-update/report.json`
+- `output/attendance-report-fields-live-acceptance/2026-05-19-job-mode-daily-after-staging-update/report.md`
+- `output/attendance-report-period-summaries-live-acceptance/2026-05-19-job-mode-period-after-staging-update/report.json`
+- `output/attendance-report-period-summaries-live-acceptance/2026-05-19-job-mode-period-after-staging-update/report.md`
+
+These files are not committed because they are generated live evidence.
+
+## Boundary Verification
+
+- Staging writes were explicitly authorized for this evidence run.
+- Job mode used only the existing job routes:
+  - `POST /api/attendance/report-sync-jobs`
+  - `POST /api/attendance/report-sync-jobs/:id/run-next-page`
+  - `POST /api/attendance/report-sync-jobs/:id/cancel`
+- Daily and period jobs both completed through manual-step execution.
+- Completed jobs rejected rerun with `409 JOB_TERMINAL`.
+- Replacement jobs could be created and then canceled, so terminal jobs do not block future runs.
+- No secret or token literal appears in this document.
+
+## Residual Notes
+
+- Staging DB still reports many older pending migrations when using the generic migration lister. This evidence slice intentionally did not apply the full migration set.
+- The narrow staging schema alignment should be superseded naturally when the full migration runner is later applied; the merged migration is idempotent for an already existing job table.

--- a/docs/development/attendance-report-sync-jobs-pr4-verification-20260519.md
+++ b/docs/development/attendance-report-sync-jobs-pr4-verification-20260519.md
@@ -93,12 +93,19 @@ pnpm run verify:attendance-report-period-summaries:live
 - No migration changed.
 - No secret, JWT, or generated staging output is committed.
 
-## Deferred Live Evidence
+## Follow-up Live Evidence
 
-Real staging `JOB_MODE=1` evidence remains pending fresh credentials. The expected live evidence should include:
+Real staging `JOB_MODE=1` evidence was completed after fresh file-based staging credentials were provided.
+
+Follow-up evidence:
+
+- Development record: `docs/development/attendance-report-sync-jobs-live-evidence-development-20260519.md`
+- Verification record: `docs/development/attendance-report-sync-jobs-live-evidence-verification-20260519.md`
+
+Coverage:
 
 - daily job create -> run pages -> completed
 - period date-range job create -> run pages -> completed
-- optional period cycle job create -> run pages -> completed
+- period payroll-cycle job create -> run pages -> completed
 - completed job rerun rejected with `409 JOB_TERMINAL`
 - replacement job create + cancel

--- a/docs/development/attendance-report-sync-jobs-todo-20260519.md
+++ b/docs/development/attendance-report-sync-jobs-todo-20260519.md
@@ -234,6 +234,7 @@ Rules:
 - [x] Staging live only after explicit authorization and file-based JWT.
 
 **PR4 implementation pointer:** `docs/development/attendance-report-sync-jobs-pr4-development-20260519.md`; verification: `docs/development/attendance-report-sync-jobs-pr4-verification-20260519.md`.
+Follow-up staging evidence: `docs/development/attendance-report-sync-jobs-live-evidence-development-20260519.md`; verification: `docs/development/attendance-report-sync-jobs-live-evidence-verification-20260519.md`.
 
 ## Hard Boundaries
 


### PR DESCRIPTION
## Summary

Records real staging `JOB_MODE=1` live evidence for the attendance report sync job runner.

- Daily `attendance_report_records` job mode: 59 checks PASS, completed in 1 page, 3 rows synced, terminal rerun rejected with `409 JOB_TERMINAL`, replacement job created and canceled.
- Period `attendance_report_period_summaries` job mode: 56 checks PASS, date-range and payroll-cycle jobs completed in 1 page each, terminal reruns rejected, replacement jobs created and canceled.
- Documents the staging environment alignment needed for the run: backend/web updated to latest main image and the job-runner operational table aligned narrowly because the generic migration list had many older pending migrations.

## Boundaries

- Docs only.
- No product code changes.
- No generated `output/` evidence committed.
- No JWT/token literal or concrete JWT file path committed.
- No `attendance_*` fact-source migration and no direct `meta_*` write.

## Verification

- [x] Staging `/api/health` PASS
- [x] `GET /api/attendance/report-sync-jobs` returned 200 after schema alignment
- [x] `pnpm run verify:attendance-report-fields:live` with `JOB_MODE=1` PASS
- [x] `pnpm run verify:attendance-report-period-summaries:live` with `JOB_MODE=1` PASS
- [x] `git diff --cached --check` PASS
- [x] staged secret scan PASS
