### PR TITLE
fix(multitable): create default Grid view on sheet create

### DIFF
--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -5502,6 +5502,19 @@ export function univerMetaRouter(): Router {
           throw new ConflictError(`Sheet already exists: ${sheetId}`)
         }
 
+        // Every sheet needs at least one view to be openable. A plain
+        // (un-seeded) create otherwise strands users on "这个 Base 还没有可打开
+        // 的 Sheet 或 View。" because GET /api/multitable/context — unlike
+        // GET /views — does not lazily create a default view (#1670). Seed the
+        // same default Grid view the /views fallback would create.
+        const defaultViewId = buildId('view')
+        await query(
+          `INSERT INTO meta_views (id, sheet_id, name, type, filter_info, sort_info, group_info, hidden_field_ids, config)
+           VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7::jsonb, $8::jsonb, $9::jsonb)
+           ON CONFLICT (id) DO NOTHING`,
+          [defaultViewId, sheetId, '默认视图', 'grid', '{}', '{}', '{}', '[]', '{}'],
+        )
+
         if (seed) {
           await createSeededSheet({ sheetId, name, description, query: query as unknown as QueryFn })
         }

--- a/packages/core-backend/tests/integration/multitable-context.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-context.api.test.ts
@@ -528,6 +528,9 @@ describe('Multitable context API', () => {
           ])
           return { rows: [], rowCount: 1 }
         }
+        if (sql.includes('INSERT INTO meta_views')) {
+          return { rows: [], rowCount: 1 }
+        }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })
@@ -540,6 +543,47 @@ describe('Multitable context API', () => {
     expect(response.body.ok).toBe(true)
     expect(response.body.data.sheet.baseId).toBe('base_legacy')
     expect(response.body.data.sheet.seeded).toBe(false)
+    expect(mockPool.transaction).toHaveBeenCalledTimes(1)
+  })
+
+  test('creates a default Grid view so a plain (un-seeded) sheet is immediately openable (#1670)', async () => {
+    let viewInsert: unknown[] | undefined
+    const { app, mockPool } = await createApp({
+      tokenPerms: ['multitable:write'],
+      queryHandler: async (sql, params) => {
+        if (sql.includes('INSERT INTO meta_bases')) {
+          return { rows: [], rowCount: 1 }
+        }
+        if (sql.includes('INSERT INTO meta_sheets')) {
+          return { rows: [], rowCount: 1 }
+        }
+        if (sql.includes('INSERT INTO meta_views')) {
+          viewInsert = params
+          return { rows: [], rowCount: 1 }
+        }
+        throw new Error(`Unhandled SQL in test: ${sql}`)
+      },
+    })
+
+    const response = await request(app)
+      .post('/api/multitable/sheets')
+      .send({ name: 'Plain Base Sheet' })
+      .expect(200)
+
+    expect(response.body.ok).toBe(true)
+    expect(response.body.data.sheet.seeded).toBe(false)
+    // The view must be created at sheet-create time. GET /context does not
+    // lazily create one (only GET /views does), so without this the base is
+    // unopenable: "这个 Base 还没有可打开的 Sheet 或 View。" (#1670)
+    expect(viewInsert).toBeDefined()
+    const [viewId, sheetId, viewName, viewType, filterInfo, sortInfo, groupInfo, hiddenFieldIds, config] =
+      viewInsert as string[]
+    expect(typeof viewId).toBe('string')
+    expect(viewId.length).toBeGreaterThan(0)
+    expect(sheetId).toBe(response.body.data.sheet.id)
+    expect(viewName).toBe('默认视图')
+    expect(viewType).toBe('grid')
+    expect([filterInfo, sortInfo, groupInfo, hiddenFieldIds, config]).toEqual(['{}', '{}', '{}', '[]', '{}'])
     expect(mockPool.transaction).toHaveBeenCalledTimes(1)
   })
 
@@ -802,6 +846,9 @@ describe('Multitable context API', () => {
             'Owned Sheet',
             'Created by base owner',
           ])
+          return { rows: [], rowCount: 1 }
+        }
+        if (sql.includes('INSERT INTO meta_views')) {
           return { rows: [], rowCount: 1 }
         }
         throw new Error(`Unhandled SQL in test: ${sql}`)


### PR DESCRIPTION
## Summary

Fixes #1670.

Plain Base/Sheet creation could leave a sheet without any `meta_views` row. `/api/multitable/context` does not lazily create a default view, so the newly-created Base could land on the empty-state error instead of opening a Grid.

This PR seeds the same default Grid view during `POST /api/multitable/sheets`, inside the existing transaction, for both legacy base creation and owned-base sheet creation paths.

## Changes

- Insert a default `grid` view in `meta_views` when creating a sheet.
- Keep seeded sheet behavior intact.
- Extend existing integration coverage so plain unseeded sheet creation asserts the default view insert.
- Update existing create-sheet specs to account for the new view insert.

## Verification

- `pnpm --filter @metasheet/core-backend exec vitest run tests/integration/multitable-context.api.test.ts --config vitest.integration.config.ts -t "returns 404 when deleting a missing multitable sheet"` ✅
- `pnpm --filter @metasheet/core-backend exec vitest run tests/integration/multitable-context.api.test.ts --config vitest.integration.config.ts` ✅ 22/22
- `pnpm --filter @metasheet/core-backend build` ✅
- `git diff --check origin/main...HEAD` ✅

Note: the first full-spec run had a one-off 403/404 mismatch in an unrelated delete-missing-sheet test; the isolated test and full rerun both passed cleanly.
