### PR TITLE
fix(onprem): close issue1526 wrapper and sql port gaps

### DIFF
--- a/docs/development/data-factory-issue1526-wrapper-sql-followup-design-20260519.md
+++ b/docs/development/data-factory-issue1526-wrapper-sql-followup-design-20260519.md
@@ -1,0 +1,113 @@
+# Data Factory issue #1526 wrapper and SQL follow-up design - 2026-05-19
+
+## Context
+
+The bridge retest for
+`metasheet-multitable-onprem-v2.5.0-k3wise-1f6204b3.zip` moved the Windows
+on-prem package forward:
+
+- the generated dependency-refresh wrapper entered and reached
+  `pnpm install`;
+- with `CI=true` set manually on the host, the wrapper recorded
+  `pnpm install exit=0`;
+- the parent PowerShell apply script still stopped before migrations because
+  the child process exit code was logged as blank;
+- after manual migrations/restart/healthcheck, the K3 WISE SQL Server source
+  moved past `SQLSERVER_DRIVER_MISSING` and reached the real connection layer;
+- the next SQL failure showed a comma-port server value being treated as a
+  host and then combined with another `:1433` port.
+
+This follow-up intentionally keeps the scope small. It does not add K3 WebAPI
+read/list runtime, relationship resolution, SQL writes, or real K3 Save /
+Submit / Audit behavior.
+
+## Goals
+
+1. Make dependency refresh non-interactive by default for Windows scheduled
+   task deployments.
+2. Make a successful wrapper result (`pnpm install exit=0`) allow the apply
+   script to continue to migrations, PM2 restart, and healthcheck even when
+   `Start-Process` exposes a blank exit code.
+3. Normalize SQL Server `host,port` input so a K3 WISE operator can paste the
+   common SQL Server comma-port form without producing `host,1433:1433`.
+4. Keep future release packages gated on these markers through
+   `multitable-onprem-package-verify.sh`.
+
+## Windows dependency refresh changes
+
+`scripts/ops/multitable-onprem-apply-package.ps1` now writes these additional
+lines into the generated `dependency-refresh-*.cmd` wrapper:
+
+- `CI=true`;
+- `npm_config_yes=true`;
+- `npm_config_confirm_modules_purge=false`;
+- `PNPM_CONFIG_CONFIRM_MODULES_PURGE=false`;
+- a visible non-interactive environment diagnostic line.
+
+The intent is to make `pnpm install --frozen-lockfile` safe under scheduled
+task / SYSTEM execution, where interactive prompts cannot be answered.
+
+## Exit-code capture changes
+
+The parent PowerShell process now does a second exit-state synchronization
+before reading the child exit code:
+
+1. wait for process exit confirmation with `WaitForExit()`;
+2. refresh the process object with `Refresh()`;
+3. read `ExitCode`;
+4. if `ExitCode` is still blank, parse the wrapper stdout marker:
+   `[dependency-refresh-wrapper] pnpm install exit=<n>`;
+5. fail explicitly if neither the process nor wrapper marker provides a
+   readable exit code.
+
+This handles the bridge observation where the wrapper itself recorded exit `0`
+but the parent apply script logged an empty child exit code.
+
+## SQL Server host/port normalization
+
+`plugins/plugin-integration-core/lib/adapters/k3-wise-sqlserver-executor.cjs`
+already normalized `host:port` when no explicit `config.port` was provided.
+This change extends the same behavior to SQL Server's common comma-port form:
+
+```text
+10.0.0.8,1433  ->  server=10.0.0.8, port=1433
+sql.local:1433 ->  server=sql.local, port=1433
+```
+
+If both an embedded port and `system.config.port` are provided, the values must
+match. A mismatch raises `SQLSERVER_PORT_INVALID` rather than guessing.
+
+## Package verification
+
+`scripts/ops/multitable-onprem-package-verify.sh` now requires packaged apply
+helpers to contain:
+
+- non-interactive dependency-refresh markers;
+- the wrapper-exit-code recovery helper;
+- `WaitForExit()` before `ExitCode` use.
+
+The two design/verification documents for this follow-up are also added to the
+on-prem package manifest so operators can trace why the change exists.
+
+## Out of scope
+
+- Real K3 Save / Submit / Audit.
+- K3 WebAPI read/list runtime.
+- Relationship resolver runtime.
+- SQL middle-table writes.
+- Reworking the known self-overwrite behavior where the first apply run can
+  execute an already-loaded helper before the new package replaces it.
+
+## Expected bridge retest
+
+After merge and package publication:
+
+1. deploy the fresh Windows zip twice if the host still has the known
+   self-overwrite behavior;
+2. confirm the dependency wrapper logs non-interactive env markers;
+3. confirm dependency refresh completes without manually setting `CI=true`;
+4. confirm the apply script continues to migrations, PM2 restart, and
+   healthcheck after `pnpm install exit=0`;
+5. rerun the K3 WISE SQL Server source test with a comma-port host and verify
+   that the error, if any, is now a real network/auth/schema issue rather than
+   a doubled host/port parse.

--- a/docs/development/data-factory-issue1526-wrapper-sql-followup-verification-20260519.md
+++ b/docs/development/data-factory-issue1526-wrapper-sql-followup-verification-20260519.md
@@ -1,0 +1,150 @@
+# Data Factory issue #1526 wrapper and SQL follow-up verification - 2026-05-19
+
+## Scope
+
+This verification covers the #1526 bridge follow-up for:
+
+- Windows dependency refresh non-interactive defaults;
+- PowerShell child process exit-code recovery;
+- SQL Server comma-port normalization;
+- package verification markers and manifest inclusion.
+
+It does not validate real K3 writes or customer GATE runtime work.
+
+## Changed files
+
+- `scripts/ops/multitable-onprem-apply-package.ps1`
+- `scripts/ops/multitable-onprem-package-build.sh`
+- `scripts/ops/multitable-onprem-package-verify.sh`
+- `plugins/plugin-integration-core/lib/adapters/k3-wise-sqlserver-executor.cjs`
+- `plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs`
+- `docs/development/data-factory-issue1526-wrapper-sql-followup-design-20260519.md`
+- `docs/development/data-factory-issue1526-wrapper-sql-followup-verification-20260519.md`
+
+## Local checks
+
+### K3 WISE adapter and SQL executor tests
+
+```bash
+node plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
+```
+
+Result: PASS.
+
+- WebAPI adapter tests pass;
+- SQL Server channel tests pass;
+- SQL read-only executor keeps writes disabled;
+- `10.0.0.8,1433` resolves to `server=10.0.0.8`, `port=1433`;
+- `sql.local:14330` remains supported;
+- conflicting embedded/explicit ports throw `SQLSERVER_PORT_INVALID`.
+
+### Package script syntax
+
+```bash
+bash -n scripts/ops/multitable-onprem-package-build.sh
+bash -n scripts/ops/multitable-onprem-package-verify.sh
+```
+
+Result: PASS. Both commands returned exit code `0`.
+
+PowerShell parser note: `pwsh` is not installed in the local macOS validation
+environment, so the `.ps1` file could not be parsed locally with PowerShell.
+The Windows-specific behavior is guarded by marker scans, package verify, and
+the bridge retest acceptance criteria below.
+
+### Marker checks
+
+```bash
+rg --fixed-strings 'CI=true' scripts/ops/multitable-onprem-apply-package.ps1
+rg --fixed-strings 'PNPM_CONFIG_CONFIRM_MODULES_PURGE=false' scripts/ops/multitable-onprem-apply-package.ps1
+rg --fixed-strings 'Get-DependencyRefreshExitCodeFromLog' scripts/ops/multitable-onprem-apply-package.ps1
+rg --fixed-strings 'WaitForExit()' scripts/ops/multitable-onprem-apply-package.ps1
+rg --fixed-strings 'SQLSERVER_PORT_INVALID' plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
+```
+
+Result: PASS. All markers are present.
+
+### Package verification guard
+
+```bash
+rg --fixed-strings 'PNPM_CONFIG_CONFIRM_MODULES_PURGE=false' scripts/ops/multitable-onprem-package-verify.sh
+rg --fixed-strings 'Get-DependencyRefreshExitCodeFromLog' scripts/ops/multitable-onprem-package-verify.sh
+rg --fixed-strings 'data-factory-issue1526-wrapper-sql-followup-design-20260519.md' scripts/ops/multitable-onprem-package-build.sh scripts/ops/multitable-onprem-package-verify.sh
+```
+
+Result: PASS. Package verify and build manifests require the new safety
+markers and docs.
+
+### K3 WISE PoC regression
+
+```bash
+pnpm verify:integration-k3wise:poc
+```
+
+Result: PASS.
+
+- Live PoC preflight tests: 21/21 pass.
+- Evidence compiler tests: 51/51 pass.
+- Fixture contract tests: 4/4 pass.
+- Mock K3 WebAPI tests: 4/4 pass.
+- Mock SQL executor tests: 12/12 pass.
+- End-to-end mock PoC chain: PASS.
+
+### Local package build and verify
+
+The clean worktree initially lacked `node_modules`; `pnpm install
+--frozen-lockfile` was run once to provide build tools. The resulting
+`node_modules` symlink modifications were reverted before final status.
+
+```bash
+OUTPUT_DIR=/tmp/ms2-issue1526-wrapper-sql-package \
+PACKAGE_TAG=k3wise-issue1526-wrapper-sql-local \
+BUILD_WEB=1 \
+BUILD_BACKEND=1 \
+INSTALL_DEPS=0 \
+scripts/ops/multitable-onprem-package-build.sh
+```
+
+Result: PASS. The command produced:
+
+- `/tmp/ms2-issue1526-wrapper-sql-package/metasheet-multitable-onprem-v2.5.0-k3wise-issue1526-wrapper-sql-local.zip`
+- `/tmp/ms2-issue1526-wrapper-sql-package/metasheet-multitable-onprem-v2.5.0-k3wise-issue1526-wrapper-sql-local.tgz`
+
+```bash
+scripts/ops/multitable-onprem-package-verify.sh \
+  /tmp/ms2-issue1526-wrapper-sql-package/metasheet-multitable-onprem-v2.5.0-k3wise-issue1526-wrapper-sql-local.zip
+
+scripts/ops/multitable-onprem-package-verify.sh \
+  /tmp/ms2-issue1526-wrapper-sql-package/metasheet-multitable-onprem-v2.5.0-k3wise-issue1526-wrapper-sql-local.tgz
+```
+
+Result: PASS. Both zip and tgz returned `Package verify OK`.
+
+### Diff hygiene
+
+```bash
+git diff --check origin/main...HEAD
+```
+
+Result: PASS. No whitespace or conflict-marker issues.
+
+## Bridge retest acceptance
+
+After this lands and a fresh package is published, the entity-machine retest
+should record:
+
+1. dependency refresh wrapper starts without a manual `CI=true` workaround;
+2. wrapper stdout includes the non-interactive env diagnostic;
+3. wrapper stdout includes `pnpm install exit=0`;
+4. parent apply log reports exit `0` or explicitly reports use of the wrapper
+   exit marker;
+5. apply proceeds to migrations, PM2 restart, and healthcheck;
+6. SQL Server source test no longer produces a doubled `host,1433:1433`
+   resolution failure.
+
+## Safety notes
+
+- No secrets are added to docs or tests.
+- The SQL executor remains read-only.
+- Real K3 Save / Submit / Audit remains out of scope.
+- Customer GATE for WebAPI read/list and relationship runtime remains locked.

--- a/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
@@ -16,6 +16,7 @@ const {
   createK3WiseSqlServerChannelFactory,
 } = require(path.join(__dirname, '..', 'lib', 'adapters', 'k3-wise-sqlserver-channel.cjs'))
 const {
+  __internals: sqlExecutorInternals,
   createK3WiseSqlServerReadOnlyExecutor,
 } = require(path.join(__dirname, '..', 'lib', 'adapters', 'k3-wise-sqlserver-executor.cjs'))
 
@@ -180,6 +181,45 @@ function createFakeMssqlDriver({ rows = [{ FItemID: 1, FNumber: 'MAT-001' }], fa
   }
 
   return { driver: { ConnectionPool }, calls }
+}
+
+function testSqlServerConnectionConfigNormalization() {
+  const credentials = { credentials: { username: 'readonly_user', password: 'readonly-password' } }
+
+  const commaPort = sqlExecutorInternals.resolveConnectionConfig(createSqlSystem({
+    server: '10.0.0.8,1433',
+    database: 'AIS_TEST',
+  }, credentials))
+  assert.equal(commaPort.server, '10.0.0.8')
+  assert.equal(commaPort.port, 1433)
+
+  const colonPort = sqlExecutorInternals.resolveConnectionConfig(createSqlSystem({
+    server: 'sql.local:14330',
+    database: 'AIS_TEST',
+  }, credentials))
+  assert.equal(colonPort.server, 'sql.local')
+  assert.equal(colonPort.port, 14330)
+
+  const matchingExplicitPort = sqlExecutorInternals.resolveConnectionConfig(createSqlSystem({
+    server: 'sql.local,1433',
+    port: '1433',
+    database: 'AIS_TEST',
+  }, credentials))
+  assert.equal(matchingExplicitPort.server, 'sql.local')
+  assert.equal(matchingExplicitPort.port, 1433)
+
+  let conflictingPort = null
+  try {
+    sqlExecutorInternals.resolveConnectionConfig(createSqlSystem({
+      server: 'sql.local,1433',
+      port: '1434',
+      database: 'AIS_TEST',
+    }, credentials))
+  } catch (error) {
+    conflictingPort = error
+  }
+  assert.equal(conflictingPort && conflictingPort.code, 'SQLSERVER_PORT_INVALID')
+  assert.match(conflictingPort.message, /must match/)
 }
 
 async function testK3WebApiAdapter() {
@@ -810,6 +850,7 @@ async function testK3WebApiAutoFlagCoercion() {
 async function main() {
   await testK3WebApiAdapter()
   await testK3WebApiAuthorityCodeToken()
+  testSqlServerConnectionConfigNormalization()
   await testK3SqlServerChannel()
   await testK3WebApiAutoFlagCoercion()
   console.log('✓ k3-wise-adapters: WebAPI, SQL Server channel, and auto-flag coercion tests passed')

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-sqlserver-executor.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-sqlserver-executor.cjs
@@ -92,15 +92,22 @@ function parseServerAndPort(serverValue, portValue) {
     })
   }
 
-  const hostPortMatch = server.match(/^([^,:\\]+):(\d+)$/)
-  if (hostPortMatch && configuredPort === null) {
-    const parsedPort = Number(hostPortMatch[2])
+  const hostPortMatch = server.match(/^([^,:\\]+)([:,])(\d+)$/)
+  if (hostPortMatch) {
+    const parsedPort = Number(hostPortMatch[3])
     if (!Number.isInteger(parsedPort) || parsedPort <= 0 || parsedPort > 65535) {
       throw new SqlServerExecutorError('SQLSERVER_PORT_INVALID', 'system.config.server contains an invalid port', {
         field: 'system.config.server',
       })
     }
-    return { server: hostPortMatch[1], port: parsedPort }
+    if (configuredPort !== null && configuredPort !== parsedPort) {
+      throw new SqlServerExecutorError(
+        'SQLSERVER_PORT_INVALID',
+        'system.config.server port must match system.config.port when both are provided',
+        { field: 'system.config.server' },
+      )
+    }
+    return { server: hostPortMatch[1], port: configuredPort === null ? parsedPort : configuredPort }
   }
   return { server, port: configuredPort }
 }

--- a/scripts/ops/multitable-onprem-apply-package.ps1
+++ b/scripts/ops/multitable-onprem-apply-package.ps1
@@ -150,7 +150,12 @@ function New-DependencyRefreshCommandWrapper {
   $lines = @(
     '@echo off',
     'setlocal EnableExtensions DisableDelayedExpansion',
+    'set "CI=true"',
+    'set "npm_config_yes=true"',
+    'set "npm_config_confirm_modules_purge=false"',
+    'set "PNPM_CONFIG_CONFIRM_MODULES_PURGE=false"',
     'echo [dependency-refresh-wrapper] wrapper entered',
+    'echo [dependency-refresh-wrapper] non-interactive env: CI=true npm_config_confirm_modules_purge=false PNPM_CONFIG_CONFIRM_MODULES_PURGE=false',
     "echo [dependency-refresh-wrapper] root=$quotedRootDir",
     'echo [dependency-refresh-wrapper] cwd before cd=%CD%',
     "cd /d $quotedRootDir",
@@ -179,6 +184,23 @@ function New-DependencyRefreshCommandWrapper {
   )
 
   Set-Content -LiteralPath $WrapperPath -Value $lines -Encoding ASCII
+}
+
+function Get-DependencyRefreshExitCodeFromLog {
+  param([string]$Path)
+
+  if (-not (Test-Path -LiteralPath $Path)) {
+    return $null
+  }
+
+  $exitLine = Get-Content -LiteralPath $Path -Tail 80 |
+    Where-Object { $_ -match '\[dependency-refresh-wrapper\] pnpm install exit=(\d+)' } |
+    Select-Object -Last 1
+  if ($exitLine -and $exitLine -match 'exit=(\d+)') {
+    return [int]$matches[1]
+  }
+
+  return $null
 }
 
 function Stop-ProcessTree {
@@ -289,8 +311,41 @@ function Invoke-LoggedProcess {
     }
   }
 
-  $exitCode = $process.ExitCode
+  try {
+    $process.WaitForExit()
+  }
+  catch {
+    Write-Info "Failed while waiting for process exit confirmation pid=$($process.Id): $($_.Exception.Message)"
+  }
+  try {
+    $process.Refresh()
+  }
+  catch {
+    Write-Info "Failed to refresh process state pid=$($process.Id): $($_.Exception.Message)"
+  }
+
+  $exitCode = $null
+  try {
+    $exitCode = $process.ExitCode
+  }
+  catch {
+    Write-Info "Unable to read process exit code pid=$($process.Id): $($_.Exception.Message)"
+  }
+  if ($null -eq $exitCode -or [string]::IsNullOrWhiteSpace([string]$exitCode)) {
+    $wrapperExitCode = Get-DependencyRefreshExitCodeFromLog -Path $stdoutLog
+    if ($null -ne $wrapperExitCode) {
+      $exitCode = $wrapperExitCode
+      Write-Info "$Description using wrapper exit marker $exitCode from stdout log"
+    }
+  }
+
   $elapsedTotalSec = [int]((Get-Date) - $startedAt).TotalSeconds
+  if ($null -eq $exitCode -or [string]::IsNullOrWhiteSpace([string]$exitCode)) {
+    Write-LogTail -Path $stdoutLog -Label 'stdout'
+    Write-LogTail -Path $stderrLog -Label 'stderr'
+    throw "$Description finished without a readable process exit code after ${elapsedTotalSec}s; inspect logs: $stdoutLog ; $stderrLog"
+  }
+
   Write-Info "$Description finished with exit code $exitCode after ${elapsedTotalSec}s"
 
   if ($exitCode -ne 0) {

--- a/scripts/ops/multitable-onprem-package-build.sh
+++ b/scripts/ops/multitable-onprem-package-build.sh
@@ -121,6 +121,8 @@ REQUIRED_PATHS=(
   "docs/development/onprem-package-dependency-refresh-diagnostics-verification-20260519.md"
   "docs/development/onprem-package-dependency-refresh-wrapper-design-20260519.md"
   "docs/development/onprem-package-dependency-refresh-wrapper-verification-20260519.md"
+  "docs/development/data-factory-issue1526-wrapper-sql-followup-design-20260519.md"
+  "docs/development/data-factory-issue1526-wrapper-sql-followup-verification-20260519.md"
   "docs/development/data-factory-readiness-package-verify-delivery-development-20260515.md"
   "docs/development/data-factory-readiness-package-verify-delivery-verification-20260515.md"
   "docs/development/onprem-migration-gap-guard-development-20260514.md"

--- a/scripts/ops/multitable-onprem-package-verify.sh
+++ b/scripts/ops/multitable-onprem-package-verify.sh
@@ -59,6 +59,8 @@ function verify_windows_entrypoints() {
   search_fixed_string 'pnpm.cmd' "$apply_helper" || die "PowerShell apply helper must prefer pnpm.cmd for Windows scheduled-task install"
   search_fixed_string 'cmd.exe' "$apply_helper" || die "PowerShell apply helper must run dependency refresh through cmd.exe"
   search_fixed_string 'dependency-refresh-wrapper' "$apply_helper" || die "PowerShell apply helper must generate a dependency refresh command wrapper"
+  search_fixed_string 'CI=true' "$apply_helper" || die "PowerShell apply helper must force dependency refresh into non-interactive CI mode"
+  search_fixed_string 'PNPM_CONFIG_CONFIRM_MODULES_PURGE=false' "$apply_helper" || die "PowerShell apply helper must disable pnpm module purge confirmation"
   search_fixed_string '--reporter=append-only' "$apply_helper" || die "PowerShell apply helper must use append-only pnpm reporter for deploy logs"
   search_fixed_string '--store-dir' "$apply_helper" || die "PowerShell apply helper must pin a deploy-local pnpm store"
   search_fixed_string '.pnpm-store' "$apply_helper" || die "PowerShell apply helper must create a deploy-local pnpm store"
@@ -67,6 +69,8 @@ function verify_windows_entrypoints() {
   search_fixed_string 'taskkill.exe' "$apply_helper" || die "PowerShell apply helper must kill the dependency refresh process tree on timeout"
   search_fixed_string 'still running after' "$apply_helper" || die "PowerShell apply helper must emit dependency refresh heartbeat progress"
   search_fixed_string 'timed out after' "$apply_helper" || die "PowerShell apply helper must fail dependency refresh with a timeout"
+  search_fixed_string 'Get-DependencyRefreshExitCodeFromLog' "$apply_helper" || die "PowerShell apply helper must recover the wrapper exit marker when Start-Process exit code is blank"
+  search_fixed_string 'WaitForExit()' "$apply_helper" || die "PowerShell apply helper must wait for process exit before reading ExitCode"
   if search_fixed_string "-not (Test-Path -LiteralPath (Join-Path \$resolvedRoot 'node_modules'))" "$apply_helper"; then
     die "PowerShell apply helper must not skip dependency refresh just because root node_modules already exists"
   fi
@@ -536,6 +540,8 @@ required=(
   "docs/development/onprem-package-dependency-refresh-diagnostics-verification-20260519.md"
   "docs/development/onprem-package-dependency-refresh-wrapper-design-20260519.md"
   "docs/development/onprem-package-dependency-refresh-wrapper-verification-20260519.md"
+  "docs/development/data-factory-issue1526-wrapper-sql-followup-design-20260519.md"
+  "docs/development/data-factory-issue1526-wrapper-sql-followup-verification-20260519.md"
   "docs/development/data-factory-readiness-package-verify-delivery-development-20260515.md"
   "docs/development/data-factory-readiness-package-verify-delivery-verification-20260515.md"
   "docs/development/onprem-migration-gap-guard-development-20260514.md"


### PR DESCRIPTION
## Summary
- make Windows dependency refresh non-interactive by default and recover the wrapper pnpm exit marker when Start-Process exposes a blank exit code
- normalize K3 WISE SQL Server host:port and host,port inputs, with explicit mismatch rejection
- add design/verification docs and package verification markers so future on-prem builds include the fix

## Verification
- node plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
- bash -n scripts/ops/multitable-onprem-package-build.sh
- bash -n scripts/ops/multitable-onprem-package-verify.sh
- pnpm verify:integration-k3wise:poc
- local on-prem package build with BUILD_WEB=1 BUILD_BACKEND=1 after pnpm install --frozen-lockfile
- scripts/ops/multitable-onprem-package-verify.sh on local zip and tgz
- git diff --check origin/main...HEAD

## Deployment impact
- Windows apply helper only; next package retest should verify pnpm install proceeds without manual CI=true and reaches migrations/restart/healthcheck
- SQL Server read source should no longer produce doubled host,port:port lookup for comma-port input
- no real K3 Save / Submit / Audit behavior change