### PR TITLE
feat(multitable): show holidays and lunar labels in calendar view

### DIFF
--- a/apps/web/src/composables/useCalendarDays.ts
+++ b/apps/web/src/composables/useCalendarDays.ts
@@ -1,0 +1,205 @@
+export interface CalendarVisibleRange {
+  from: string
+  to: string
+}
+
+export interface CalendarHoliday {
+  id: string
+  date: string
+  name?: string | null
+  isWorkingDay?: boolean
+}
+
+export interface CalendarDayCell<THoliday extends { date: string } = CalendarHoliday> {
+  date: string
+  dayNumber: number
+  isCurrentMonth: boolean
+  isToday: boolean
+  holidays: THoliday[]
+  lunarLabel?: string
+}
+
+interface DateTimeLabelOptions {
+  locale: string
+  timeZone?: string
+}
+
+interface LunarLabelOptions {
+  enabled: boolean
+  timeZone?: string
+}
+
+interface BuildCalendarDayOptions<THoliday extends { date: string }> {
+  currentMonth?: Date
+  holidays?: THoliday[]
+  holidaysByDate?: Map<string, THoliday[]>
+  isCurrentMonth?: boolean
+  lunarTimeZone?: string
+  showLunarCalendar?: boolean
+  today?: Date
+}
+
+interface BuildCalendarDaysOptions<THoliday extends { date: string }> extends BuildCalendarDayOptions<THoliday> {
+  days: number
+  startDate: Date
+}
+
+const DEFAULT_LUNAR_TIME_ZONE = 'Asia/Shanghai'
+
+export function toDateInput(date: Date): string {
+  return toDateKey(date)
+}
+
+export function toDateKey(date: Date): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+export function normalizeDateKey(value: string | null | undefined): string | null {
+  const raw = String(value || '').trim()
+  if (!raw) return null
+  const direct = raw.match(/^(\d{4}-\d{2}-\d{2})/)
+  if (direct) return direct[1]
+  const date = new Date(raw)
+  if (Number.isNaN(date.getTime())) return null
+  return toDateKey(date)
+}
+
+export function parseDateOnly(value: string | null | undefined): Date | null {
+  if (typeof value !== 'string') return null
+  const normalized = value.trim()
+  const match = normalized.match(/^(\d{4})-(\d{2})-(\d{2})$/)
+  if (!match) return null
+  const [, year, month, day] = match
+  const date = new Date(Number(year), Number(month) - 1, Number(day))
+  return Number.isNaN(date.getTime()) ? null : date
+}
+
+export function compareDateKeys(a: string, b: string): number {
+  if (a === b) return 0
+  return a < b ? -1 : 1
+}
+
+export function firstDayOfMonth(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), 1)
+}
+
+export function lastDayOfMonth(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth() + 1, 0)
+}
+
+export function isSameMonth(a: Date, b: Date): boolean {
+  return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth()
+}
+
+export function getCalendarVisibleRange(calendarMonth: Date): CalendarVisibleRange {
+  const monthStart = firstDayOfMonth(calendarMonth)
+  const monthEnd = lastDayOfMonth(calendarMonth)
+  const startOffset = (monthStart.getDay() + 6) % 7
+  const endOffset = 6 - ((monthEnd.getDay() + 6) % 7)
+  const visibleStart = new Date(monthStart)
+  visibleStart.setDate(visibleStart.getDate() - startOffset)
+  const visibleEnd = new Date(monthEnd)
+  visibleEnd.setDate(visibleEnd.getDate() + endOffset)
+  return {
+    from: toDateInput(visibleStart),
+    to: toDateInput(visibleEnd),
+  }
+}
+
+export function formatCalendarMonthLabel(date: Date, options: DateTimeLabelOptions): string {
+  const locale = String(options.locale || 'en-US')
+  const timeZone = String(options.timeZone || '').trim()
+  try {
+    return new Intl.DateTimeFormat(locale, {
+      year: 'numeric',
+      month: 'long',
+      ...(timeZone ? { timeZone } : {}),
+    }).format(date)
+  } catch {
+    return new Intl.DateTimeFormat(locale, {
+      year: 'numeric',
+      month: 'long',
+    }).format(date)
+  }
+}
+
+export function formatLunarDayLabel(date: Date, options: LunarLabelOptions): string | undefined {
+  if (!options.enabled || Number.isNaN(date.getTime())) return undefined
+  const timeZone = String(options.timeZone || DEFAULT_LUNAR_TIME_ZONE).trim()
+  try {
+    const text = new Intl.DateTimeFormat('zh-CN-u-ca-chinese', {
+      month: 'short',
+      day: 'numeric',
+      ...(timeZone ? { timeZone } : {}),
+    }).format(date)
+    const normalized = text.replace(/\s+/g, '')
+    if (normalized) return normalized
+  } catch {
+    // Fall back to the runtime timezone when the provided timezone is invalid.
+  }
+
+  try {
+    const text = new Intl.DateTimeFormat('zh-CN-u-ca-chinese', {
+      month: 'short',
+      day: 'numeric',
+    }).format(date)
+    const normalized = text.replace(/\s+/g, '')
+    return normalized || undefined
+  } catch {
+    return undefined
+  }
+}
+
+export function groupCalendarHolidaysByDate<THoliday extends { date: string }>(
+  holidays: readonly THoliday[],
+): Map<string, THoliday[]> {
+  const map = new Map<string, THoliday[]>()
+  for (const holiday of holidays) {
+    const key = normalizeDateKey(holiday.date)
+    if (!key) continue
+    if (!map.has(key)) map.set(key, [])
+    map.get(key)?.push(holiday)
+  }
+  return map
+}
+
+export function buildCalendarDay<THoliday extends { date: string }>(
+  date: Date,
+  options: BuildCalendarDayOptions<THoliday> = {},
+): CalendarDayCell<THoliday> {
+  const dateKey = toDateKey(date)
+  const holidaysByDate = options.holidaysByDate ?? groupCalendarHolidaysByDate(options.holidays ?? [])
+  const today = options.today ?? new Date()
+  return {
+    date: dateKey,
+    dayNumber: date.getDate(),
+    isCurrentMonth: typeof options.isCurrentMonth === 'boolean'
+      ? options.isCurrentMonth
+      : options.currentMonth
+        ? isSameMonth(date, options.currentMonth)
+        : true,
+    isToday: dateKey === toDateKey(today),
+    holidays: holidaysByDate.get(dateKey) ?? [],
+    lunarLabel: formatLunarDayLabel(date, {
+      enabled: Boolean(options.showLunarCalendar),
+      timeZone: options.lunarTimeZone,
+    }),
+  }
+}
+
+export function buildCalendarDays<THoliday extends { date: string }>(
+  options: BuildCalendarDaysOptions<THoliday>,
+): CalendarDayCell<THoliday>[] {
+  const holidaysByDate = options.holidaysByDate ?? groupCalendarHolidaysByDate(options.holidays ?? [])
+  return Array.from({ length: options.days }, (_, index) => {
+    const date = new Date(options.startDate)
+    date.setDate(options.startDate.getDate() + index)
+    return buildCalendarDay(date, {
+      ...options,
+      holidaysByDate,
+    })
+  })
+}

--- a/apps/web/src/multitable/components/MetaCalendarView.vue
+++ b/apps/web/src/multitable/components/MetaCalendarView.vue
@@ -51,7 +51,20 @@
             @click="canCreate && cell.inMonth && emit('create-record', buildCreateRecordData(cell.dateStr))"
             @keydown="onCellKeydown($event, cellIdx, monthCells)"
           >
-            <div class="meta-calendar__day-num">{{ cell.day }}</div>
+            <div class="meta-calendar__day-head">
+              <span class="meta-calendar__day-num">{{ cell.day }}</span>
+              <span v-if="cell.lunarLabel" class="meta-calendar__lunar">{{ cell.lunarLabel }}</span>
+            </div>
+            <div v-if="cell.holidays.length" class="meta-calendar__holidays">
+              <span
+                v-for="holiday in cell.holidays.slice(0, 2)"
+                :key="`${cell.dateStr}-${holiday.id}`"
+                class="meta-calendar__holiday"
+                :class="holiday.isWorkingDay ? 'meta-calendar__holiday--working' : 'meta-calendar__holiday--rest'"
+              >
+                {{ holiday.name || fallbackHolidayName(holiday) }}
+              </span>
+            </div>
             <div class="meta-calendar__events">
               <div
                 v-for="ev in cell.events"
@@ -119,7 +132,20 @@
             @click="canCreate && emit('create-record', buildCreateRecordData(cell.dateStr))"
             @keydown="onCellKeydown($event, cellIdx, weekCells)"
           >
-            <div class="meta-calendar__day-num">{{ cell.day }}</div>
+            <div class="meta-calendar__day-head">
+              <span class="meta-calendar__day-num">{{ cell.day }}</span>
+              <span v-if="cell.lunarLabel" class="meta-calendar__lunar">{{ cell.lunarLabel }}</span>
+            </div>
+            <div v-if="cell.holidays.length" class="meta-calendar__holidays">
+              <span
+                v-for="holiday in cell.holidays.slice(0, 2)"
+                :key="`${cell.dateStr}-${holiday.id}`"
+                class="meta-calendar__holiday"
+                :class="holiday.isWorkingDay ? 'meta-calendar__holiday--working' : 'meta-calendar__holiday--rest'"
+              >
+                {{ holiday.name || fallbackHolidayName(holiday) }}
+              </span>
+            </div>
             <div class="meta-calendar__events">
               <div
                 v-for="ev in cell.events"
@@ -172,6 +198,17 @@
         <div class="meta-calendar__day-view">
           <div class="meta-calendar__day-panel">
             <div class="meta-calendar__day-heading">{{ activeDayLabel }}</div>
+            <div v-if="activeDayCell.lunarLabel || activeDayCell.holidays.length" class="meta-calendar__day-calendar-meta">
+              <span v-if="activeDayCell.lunarLabel" class="meta-calendar__lunar">{{ activeDayCell.lunarLabel }}</span>
+              <span
+                v-for="holiday in activeDayCell.holidays"
+                :key="`${activeDayCell.dateStr}-${holiday.id}`"
+                class="meta-calendar__holiday"
+                :class="holiday.isWorkingDay ? 'meta-calendar__holiday--working' : 'meta-calendar__holiday--rest'"
+              >
+                {{ holiday.name || fallbackHolidayName(holiday) }}
+              </span>
+            </div>
             <div class="meta-calendar__day-meta">{{ currentDayEvents.length }} event{{ currentDayEvents.length === 1 ? '' : 's' }}</div>
             <button
               v-if="canCreate"
@@ -241,6 +278,14 @@ import { ref, computed, watch } from 'vue'
 import type { LinkedRecordSummary, MetaAttachment, MetaCalendarViewConfig, MetaField, MetaRecord, MultitableCommentPresenceSummary } from '../types'
 import { resolveCalendarViewConfig } from '../utils/view-config'
 import { formatFieldDisplay } from '../utils/field-display'
+import {
+  buildCalendarDay,
+  buildCalendarDays,
+  normalizeDateKey,
+  type CalendarDayCell as SharedCalendarDayCell,
+  type CalendarHoliday,
+  type CalendarVisibleRange,
+} from '../../composables/useCalendarDays'
 import MetaAttachmentList from './MetaAttachmentList.vue'
 import MetaCommentActionChip from './MetaCommentActionChip.vue'
 import MetaCommentAffordance from './MetaCommentAffordance.vue'
@@ -262,6 +307,7 @@ const props = defineProps<{
   viewConfig?: Record<string, unknown> | null
   linkSummaries?: Record<string, Record<string, LinkedRecordSummary[]>>
   attachmentSummaries?: Record<string, Record<string, MetaAttachment[]>>
+  calendarHolidays?: CalendarHoliday[]
   commentPresence?: Record<string, MultitableCommentPresenceSummary | undefined>
 }>()
 
@@ -271,6 +317,7 @@ const emit = defineEmits<{
   (e: 'open-field-comments', payload: { recordId: string; fieldId: string }): void
   (e: 'create-record', data: Record<string, unknown>): void
   (e: 'update-view-config', input: { config: Record<string, unknown> }): void
+  (e: 'visible-range-change', range: CalendarVisibleRange): void
 }>()
 
 const dateFieldId = ref<string | null>(null)
@@ -387,12 +434,11 @@ const eventsByDate = computed(() => {
   return map
 })
 
-interface CalendarCell {
+interface CalendarCell extends SharedCalendarDayCell<CalendarHoliday> {
   key: string
   day: number
   dateStr: string
   inMonth: boolean
-  isToday: boolean
   events: CalendarEvent[]
   overflow: number
 }
@@ -412,14 +458,19 @@ function addDays(date: Date, days: number): Date {
 }
 
 function buildCell(date: Date, inMonth: boolean): CalendarCell {
-  const dateStr = fmt(date.getFullYear(), date.getMonth() + 1, date.getDate())
+  const calendarDay = buildCalendarDay(date, {
+    holidays: props.calendarHolidays ?? [],
+    isCurrentMonth: inMonth,
+    showLunarCalendar: true,
+  })
+  const dateStr = calendarDay.date
   const all = eventsByDate.value[dateStr] ?? []
   return {
+    ...calendarDay,
     key: dateStr,
-    day: date.getDate(),
+    day: calendarDay.dayNumber,
     dateStr,
     inMonth,
-    isToday: dateStr === todayStr.value,
     events: all.slice(0, MAX_EVENTS_PER_CELL),
     overflow: Math.max(0, all.length - MAX_EVENTS_PER_CELL),
   }
@@ -431,27 +482,18 @@ const todayStr = computed(() => {
 })
 
 const monthCells = computed<CalendarCell[]>(() => {
-  const cells: CalendarCell[] = []
   const first = new Date(viewDate.value.getFullYear(), viewDate.value.getMonth(), 1)
-  const startDay = (first.getDay() - calendarConfig.value.weekStartsOn + 7) % 7
-
-  const prevLast = new Date(viewDate.value.getFullYear(), viewDate.value.getMonth(), 0)
-  for (let i = startDay - 1; i >= 0; i--) {
-    const d = prevLast.getDate() - i
-    cells.push(buildCell(new Date(prevLast.getFullYear(), prevLast.getMonth(), d), false))
-  }
-
-  const daysInMonth = new Date(viewDate.value.getFullYear(), viewDate.value.getMonth() + 1, 0).getDate()
-  for (let d = 1; d <= daysInMonth; d++) {
-    cells.push(buildCell(new Date(viewDate.value.getFullYear(), viewDate.value.getMonth(), d), true))
-  }
-
-  const remaining = 42 - cells.length
-  for (let d = 1; d <= remaining; d++) {
-    cells.push(buildCell(new Date(viewDate.value.getFullYear(), viewDate.value.getMonth() + 1, d), false))
-  }
-
-  return cells
+  const start = startOfWeek(first)
+  return buildCalendarDays({
+    startDate: start,
+    days: 42,
+    currentMonth: first,
+    holidays: props.calendarHolidays ?? [],
+    showLunarCalendar: true,
+  }).map((day) => {
+    const date = parseDateForCell(day.date)
+    return buildCell(date, day.isCurrentMonth)
+  })
 })
 
 const weekCells = computed<CalendarCell[]>(() => {
@@ -460,6 +502,19 @@ const weekCells = computed<CalendarCell[]>(() => {
 })
 
 const currentDayEvents = computed(() => eventsByDate.value[activeDayStr.value] ?? [])
+const activeDayCell = computed(() => buildCell(parseDateForCell(activeDayStr.value), true))
+
+const visibleRange = computed<CalendarVisibleRange | null>(() => {
+  if (!dateField.value) return null
+  if (viewMode.value === 'month') return rangeFromCells(monthCells.value)
+  if (viewMode.value === 'week') return rangeFromCells(weekCells.value)
+  return { from: activeDayStr.value, to: activeDayStr.value }
+})
+const visibleRangeKey = computed(() => visibleRange.value ? `${visibleRange.value.from}|${visibleRange.value.to}` : '')
+
+watch(visibleRangeKey, () => {
+  if (visibleRange.value) emit('visible-range-change', visibleRange.value)
+}, { immediate: true })
 
 function rowCommentAffordance(recordId: string) {
   return resolveRecordCommentAffordance(props.commentPresence?.[recordId])
@@ -510,11 +565,24 @@ function fmt(y: number, m: number, d: number): string {
 }
 
 function normalizeDate(raw: string): string | null {
-  const m = raw.match(/^(\d{4})[-/](\d{1,2})[-/](\d{1,2})/)
-  if (m) return fmt(Number(m[1]), Number(m[2]), Number(m[3]))
-  const d = new Date(raw)
-  if (!isNaN(d.getTime())) return fmt(d.getFullYear(), d.getMonth() + 1, d.getDate())
-  return null
+  return normalizeDateKey(raw)
+}
+
+function parseDateForCell(dateStr: string): Date {
+  const [year, month, day] = dateStr.split('-').map(Number)
+  return new Date(year, month - 1, day)
+}
+
+function rangeFromCells(cells: CalendarCell[]): CalendarVisibleRange | null {
+  if (!cells.length) return null
+  return {
+    from: cells[0]!.dateStr,
+    to: cells[cells.length - 1]!.dateStr,
+  }
+}
+
+function fallbackHolidayName(holiday: CalendarHoliday): string {
+  return holiday.isWorkingDay ? 'Working day' : 'Holiday'
 }
 
 function onPickDateField(e: Event) {
@@ -593,7 +661,12 @@ function cellAriaLabel(cell: CalendarCell): string {
   const d = new Date(cell.dateStr + 'T00:00:00')
   const dateLabel = d.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })
   const total = cell.events.length + cell.overflow
-  if (total > 0) return `${dateLabel}, ${total} event${total > 1 ? 's' : ''}`
+  const annotations = [
+    cell.lunarLabel,
+    ...cell.holidays.map((holiday) => holiday.name || fallbackHolidayName(holiday)),
+    total > 0 ? `${total} event${total > 1 ? 's' : ''}` : null,
+  ].filter(Boolean)
+  if (annotations.length) return `${dateLabel}, ${annotations.join(', ')}`
   return dateLabel
 }
 
@@ -651,7 +724,14 @@ function onCellKeydown(e: KeyboardEvent, cellIdx: number, cells: CalendarCell[])
 .meta-calendar__cell--today { background: #ecf5ff; }
 .meta-calendar__cell--today .meta-calendar__day-num { color: #409eff; font-weight: 700; }
 .meta-calendar__cell--week { min-height: 120px; }
+.meta-calendar__day-head { display: flex; align-items: baseline; justify-content: space-between; gap: 4px; margin-bottom: 2px; }
 .meta-calendar__day-num { font-size: 12px; color: #666; margin-bottom: 2px; }
+.meta-calendar__lunar { color: #8a5c2e; font-size: 10px; line-height: 1.25; white-space: nowrap; }
+.meta-calendar__holidays,
+.meta-calendar__day-calendar-meta { display: flex; align-items: center; gap: 4px; flex-wrap: wrap; margin-bottom: 3px; }
+.meta-calendar__holiday { display: inline-flex; align-items: center; max-width: 100%; padding: 1px 5px; border-radius: 999px; font-size: 10px; line-height: 1.35; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.meta-calendar__holiday--rest { background: #ffe8e8; color: #9a1a1a; }
+.meta-calendar__holiday--working { background: #e5f7ec; color: #15693a; }
 .meta-calendar__events { display: flex; flex-direction: column; gap: 2px; }
 .meta-calendar__event { padding: 2px 4px; background: #409eff; color: #fff; border-radius: 3px; font-size: 11px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; cursor: pointer; display: flex; align-items: center; gap: 6px; }
 .meta-calendar__event:hover { background: #337ecc; }

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -185,6 +185,7 @@
           :rows="grid.rows.value" :fields="scopedAllFields" :loading="grid.loading.value"
           :view-config="workbench.activeView.value?.config"
           :link-summaries="grid.linkSummaries.value" :attachment-summaries="grid.attachmentSummaries.value"
+          :calendar-holidays="calendarHolidays"
           :can-create="caps.canCreateRecord.value"
           :can-comment="effectiveRowActions.canComment"
           :comment-presence="commentPresenceState.presenceByRecordId.value"
@@ -192,6 +193,7 @@
           @open-comments="onOpenRecordComments"
           @open-field-comments="onOpenGridFieldComments"
           @update-view-config="onPersistActiveViewConfig"
+          @visible-range-change="onCalendarVisibleRangeChange"
         />
         <MetaTimelineView
           v-else-if="activeViewType === 'timeline'"
@@ -400,6 +402,8 @@ import { useRouter } from 'vue-router'
 import { AppRouteNames } from '../../router/types'
 import { useAuth } from '../../composables/useAuth'
 import { useLocale } from '../../composables/useLocale'
+import { apiFetch } from '../../utils/api'
+import type { CalendarHoliday, CalendarVisibleRange } from '../../composables/useCalendarDays'
 import { useFeatureFlags } from '../../stores/featureFlags'
 import {
   workbenchLabel as wb,
@@ -558,6 +562,9 @@ const searchText = ref('')
 const templates = ref<MetaTemplate[]>([])
 const templateLibraryLoading = ref(false)
 const templateLibraryError = ref<string | null>(null)
+const calendarHolidays = ref<CalendarHoliday[]>([])
+const calendarHolidayRangeKey = ref<string | null>(null)
+let calendarHolidayLoadVersion = 0
 const installingTemplateId = ref<string | null>(null)
 const showShortcuts = ref(false)
 const showImportModal = ref(false)
@@ -2775,6 +2782,53 @@ function openCommentInbox() {
   void router.push({
     name: 'multitable-comment-inbox',
   })
+}
+
+function normalizeCalendarHoliday(item: unknown): CalendarHoliday | null {
+  const row = item && typeof item === 'object' ? item as Record<string, unknown> : null
+  if (!row) return null
+  const date = typeof row.date === 'string' ? row.date.trim() : ''
+  if (!date) return null
+  const id = typeof row.id === 'string' && row.id.trim() ? row.id.trim() : `holiday:${date}:${String(row.name ?? '')}`
+  const name = typeof row.name === 'string' ? row.name : null
+  const isWorkingDay = typeof row.isWorkingDay === 'boolean'
+    ? row.isWorkingDay
+    : typeof row.is_workday === 'boolean'
+      ? row.is_workday
+      : undefined
+  return {
+    id,
+    date,
+    name,
+    isWorkingDay,
+  }
+}
+
+async function loadCalendarHolidays(range: CalendarVisibleRange) {
+  const from = String(range.from || '').trim()
+  const to = String(range.to || '').trim()
+  if (!from || !to) return
+  const rangeKey = `${from}|${to}`
+  if (calendarHolidayRangeKey.value === rangeKey) return
+  calendarHolidayRangeKey.value = rangeKey
+  const loadVersion = ++calendarHolidayLoadVersion
+  try {
+    const query = new URLSearchParams({ from, to })
+    const response = await apiFetch(`/api/attendance/holidays?${query.toString()}`, {
+      suppressUnauthorizedRedirect: true,
+    })
+    const data = await response.json().catch(() => null)
+    if (!response.ok || data?.ok === false) throw new Error('Failed to load calendar holidays')
+    if (loadVersion !== calendarHolidayLoadVersion) return
+    const items = Array.isArray(data?.data?.items) ? data.data.items : []
+    calendarHolidays.value = items.map(normalizeCalendarHoliday).filter(Boolean) as CalendarHoliday[]
+  } catch {
+    if (loadVersion === calendarHolidayLoadVersion) calendarHolidays.value = []
+  }
+}
+
+function onCalendarVisibleRangeChange(range: CalendarVisibleRange) {
+  void loadCalendarHolidays(range)
 }
 
 watch(

--- a/apps/web/src/views/attendance/AttendanceHolidayDataSection.vue
+++ b/apps/web/src/views/attendance/AttendanceHolidayDataSection.vue
@@ -129,7 +129,16 @@
 <script setup lang="ts">
 import { computed, ref, watch, type Ref } from 'vue'
 import type { AttendanceHoliday } from './useAttendanceAdminScheduling'
-import { formatLunarDayLabel } from '../attendanceCalendarUtils'
+import {
+  buildCalendarDays,
+  firstDayOfMonth,
+  groupCalendarHolidaysByDate,
+  isSameMonth,
+  lastDayOfMonth,
+  parseDateOnly,
+  toDateInput,
+  type CalendarDayCell as SharedCalendarDayCell,
+} from '../../composables/useCalendarDays'
 
 type Translate = (en: string, zh: string) => string
 type MaybePromise<T> = T | Promise<T>
@@ -158,14 +167,7 @@ interface HolidayDataBindings {
   deleteHoliday: (id: string) => MaybePromise<void>
 }
 
-interface CalendarDayCell {
-  date: string
-  dayNumber: number
-  isCurrentMonth: boolean
-  isToday: boolean
-  holidays: AttendanceHoliday[]
-  lunarLabel?: string
-}
+type CalendarDayCell = SharedCalendarDayCell<AttendanceHoliday>
 
 const props = defineProps<{
   holiday: HolidayDataBindings
@@ -198,35 +200,6 @@ const weekdayLabels = computed(() => [
   tr('Sat', '周六'),
 ])
 
-function parseDateOnly(value: string | null | undefined): Date | null {
-  if (typeof value !== 'string') return null
-  const normalized = value.trim()
-  const match = normalized.match(/^(\d{4})-(\d{2})-(\d{2})$/)
-  if (!match) return null
-  const [, year, month, day] = match
-  const date = new Date(Number(year), Number(month) - 1, Number(day))
-  return Number.isNaN(date.getTime()) ? null : date
-}
-
-function toDateInput(date: Date): string {
-  const year = date.getFullYear()
-  const month = String(date.getMonth() + 1).padStart(2, '0')
-  const day = String(date.getDate()).padStart(2, '0')
-  return `${year}-${month}-${day}`
-}
-
-function firstDayOfMonth(date: Date): Date {
-  return new Date(date.getFullYear(), date.getMonth(), 1)
-}
-
-function lastDayOfMonth(date: Date): Date {
-  return new Date(date.getFullYear(), date.getMonth() + 1, 0)
-}
-
-function sameMonth(a: Date, b: Date): boolean {
-  return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth()
-}
-
 function fallbackHolidayName(isWorkingDay: boolean): string {
   return isWorkingDay
     ? tr('Working day override', '调班工作日')
@@ -237,14 +210,7 @@ const today = new Date()
 const selectedDate = ref(holidayForm.date || toDateInput(today))
 const calendarMonth = ref(firstDayOfMonth(parseDateOnly(holidayForm.date) ?? today))
 
-const holidayMap = computed(() => {
-  const map = new Map<string, AttendanceHoliday[]>()
-  for (const holiday of holidays.value) {
-    if (!map.has(holiday.date)) map.set(holiday.date, [])
-    map.get(holiday.date)?.push(holiday)
-  }
-  return map
-})
+const holidayMap = computed(() => groupCalendarHolidaysByDate(holidays.value))
 
 const selectedDateHolidays = computed(() => holidayMap.value.get(selectedDate.value) ?? [])
 
@@ -256,23 +222,15 @@ const calendarLabel = computed(() => {
 
 const calendarDays = computed<CalendarDayCell[]>(() => {
   const start = firstDayOfMonth(calendarMonth.value)
-  const startOffset = start.getDay()
   const firstCell = new Date(start)
-  firstCell.setDate(start.getDate() - startOffset)
-  return Array.from({ length: 42 }, (_, index) => {
-    const date = new Date(firstCell)
-    date.setDate(firstCell.getDate() + index)
-    const key = toDateInput(date)
-    return {
-      date: key,
-      dayNumber: date.getDate(),
-      isCurrentMonth: sameMonth(date, calendarMonth.value),
-      isToday: key === toDateInput(today),
-      holidays: holidayMap.value.get(key) ?? [],
-      lunarLabel: formatLunarDayLabel(date, {
-        enabled: Boolean(props.showLunarCalendar),
-      }),
-    }
+  firstCell.setDate(start.getDate() - start.getDay())
+  return buildCalendarDays({
+    startDate: firstCell,
+    days: 42,
+    currentMonth: calendarMonth.value,
+    holidaysByDate: holidayMap.value,
+    showLunarCalendar: Boolean(props.showLunarCalendar),
+    today,
   })
 })
 
@@ -326,7 +284,7 @@ watch(
     const date = parseDateOnly(value)
     if (!date) return
     selectedDate.value = toDateInput(date)
-    if (!sameMonth(date, calendarMonth.value)) {
+    if (!isSameMonth(date, calendarMonth.value)) {
       await setCalendarMonth(date)
     }
   }

--- a/apps/web/src/views/attendanceCalendarUtils.ts
+++ b/apps/web/src/views/attendanceCalendarUtils.ts
@@ -1,101 +1,22 @@
-export interface CalendarVisibleRange {
-  from: string
-  to: string
-}
+export {
+  buildCalendarDay,
+  buildCalendarDays,
+  compareDateKeys,
+  firstDayOfMonth,
+  formatCalendarMonthLabel,
+  formatLunarDayLabel,
+  getCalendarVisibleRange,
+  groupCalendarHolidaysByDate,
+  isSameMonth,
+  lastDayOfMonth,
+  normalizeDateKey,
+  parseDateOnly,
+  toDateInput,
+  toDateKey,
+} from '../composables/useCalendarDays'
 
-interface DateTimeLabelOptions {
-  locale: string
-  timeZone?: string
-}
-
-interface LunarLabelOptions {
-  enabled: boolean
-  timeZone?: string
-}
-
-const DEFAULT_LUNAR_TIME_ZONE = 'Asia/Shanghai'
-
-export function toDateInput(date: Date): string {
-  return toDateKey(date)
-}
-
-export function toDateKey(date: Date): string {
-  const year = date.getFullYear()
-  const month = String(date.getMonth() + 1).padStart(2, '0')
-  const day = String(date.getDate()).padStart(2, '0')
-  return `${year}-${month}-${day}`
-}
-
-export function normalizeDateKey(value: string | null | undefined): string | null {
-  const raw = String(value || '').trim()
-  if (!raw) return null
-  const direct = raw.match(/^(\d{4}-\d{2}-\d{2})/)
-  if (direct) return direct[1]
-  const date = new Date(raw)
-  if (Number.isNaN(date.getTime())) return null
-  return toDateKey(date)
-}
-
-export function compareDateKeys(a: string, b: string): number {
-  if (a === b) return 0
-  return a < b ? -1 : 1
-}
-
-export function getCalendarVisibleRange(calendarMonth: Date): CalendarVisibleRange {
-  const monthStart = new Date(calendarMonth.getFullYear(), calendarMonth.getMonth(), 1)
-  const monthEnd = new Date(calendarMonth.getFullYear(), calendarMonth.getMonth() + 1, 0)
-  const startOffset = (monthStart.getDay() + 6) % 7
-  const endOffset = 6 - ((monthEnd.getDay() + 6) % 7)
-  const visibleStart = new Date(monthStart)
-  visibleStart.setDate(visibleStart.getDate() - startOffset)
-  const visibleEnd = new Date(monthEnd)
-  visibleEnd.setDate(visibleEnd.getDate() + endOffset)
-  return {
-    from: toDateInput(visibleStart),
-    to: toDateInput(visibleEnd),
-  }
-}
-
-export function formatCalendarMonthLabel(date: Date, options: DateTimeLabelOptions): string {
-  const locale = String(options.locale || 'en-US')
-  const timeZone = String(options.timeZone || '').trim()
-  try {
-    return new Intl.DateTimeFormat(locale, {
-      year: 'numeric',
-      month: 'long',
-      ...(timeZone ? { timeZone } : {}),
-    }).format(date)
-  } catch {
-    return new Intl.DateTimeFormat(locale, {
-      year: 'numeric',
-      month: 'long',
-    }).format(date)
-  }
-}
-
-export function formatLunarDayLabel(date: Date, options: LunarLabelOptions): string | undefined {
-  if (!options.enabled || Number.isNaN(date.getTime())) return undefined
-  const timeZone = String(options.timeZone || DEFAULT_LUNAR_TIME_ZONE).trim()
-  try {
-    const text = new Intl.DateTimeFormat('zh-CN-u-ca-chinese', {
-      month: 'short',
-      day: 'numeric',
-      ...(timeZone ? { timeZone } : {}),
-    }).format(date)
-    const normalized = text.replace(/\s+/g, '')
-    if (normalized) return normalized
-  } catch {
-    // Fall back to the runtime timezone when the provided timezone is invalid.
-  }
-
-  try {
-    const text = new Intl.DateTimeFormat('zh-CN-u-ca-chinese', {
-      month: 'short',
-      day: 'numeric',
-    }).format(date)
-    const normalized = text.replace(/\s+/g, '')
-    return normalized || undefined
-  } catch {
-    return undefined
-  }
-}
+export type {
+  CalendarDayCell,
+  CalendarHoliday,
+  CalendarVisibleRange,
+} from '../composables/useCalendarDays'

--- a/apps/web/tests/multitable-calendar-view.spec.ts
+++ b/apps/web/tests/multitable-calendar-view.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createApp, h, nextTick } from 'vue'
 import MetaCalendarView from '../src/multitable/components/MetaCalendarView.vue'
 
@@ -10,6 +10,10 @@ function isoDate(offsetDays = 0): string {
 }
 
 describe('MetaCalendarView', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('renders persisted default view and emits config changes when switching modes', async () => {
     const container = document.createElement('div')
     document.body.appendChild(container)
@@ -114,6 +118,59 @@ describe('MetaCalendarView', () => {
       fld_start: expectedDate,
       fld_end: expectedDate,
     })
+
+    app.unmount()
+    container.remove()
+  })
+
+  it('renders shared lunar and holiday metadata in the multitable calendar grid', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-02-03T12:00:00Z'))
+
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const visibleRangeSpy = vi.fn()
+
+    const app = createApp({
+      render() {
+        return h(MetaCalendarView, {
+          rows: [
+            {
+              id: 'rec_1',
+              version: 1,
+              data: {
+                fld_title: 'Contract renewal',
+                fld_start: '2026-02-17',
+              },
+            },
+          ],
+          fields: [
+            { id: 'fld_title', name: 'Title', type: 'string' },
+            { id: 'fld_start', name: 'Start', type: 'date' },
+          ],
+          loading: false,
+          calendarHolidays: [
+            { id: 'holiday_spring', date: '2026-02-17', name: '春节', isWorkingDay: false },
+            { id: 'working_sat', date: '2026-02-21', name: '调休', isWorkingDay: true },
+          ],
+          viewConfig: {
+            dateFieldId: 'fld_start',
+            titleFieldId: 'fld_title',
+            defaultView: 'month',
+            weekStartsOn: 0,
+          },
+          onVisibleRangeChange: visibleRangeSpy,
+        })
+      },
+    })
+
+    app.mount(container)
+    await nextTick()
+
+    expect(container.textContent).toContain('春节')
+    expect(container.textContent).toContain('调休')
+    expect(container.querySelector('.meta-calendar__lunar')?.textContent?.trim()).toBeTruthy()
+    expect(visibleRangeSpy).toHaveBeenCalledWith({ from: '2026-02-01', to: '2026-03-14' })
 
     app.unmount()
     container.remove()

--- a/apps/web/tests/useCalendarDays.spec.ts
+++ b/apps/web/tests/useCalendarDays.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  buildCalendarDays,
+  formatLunarDayLabel,
+  getCalendarVisibleRange,
+  groupCalendarHolidaysByDate,
+} from '../src/composables/useCalendarDays'
+
+describe('useCalendarDays shared calendar helpers', () => {
+  it('builds reusable day cells with holidays, working-day overrides, today, and lunar labels', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-02-17T12:00:00Z'))
+
+    const holidays = [
+      { id: 'holiday_spring', date: '2026-02-17', name: '春节', isWorkingDay: false },
+      { id: 'working_sat', date: '2026-02-21', name: '调休', isWorkingDay: true },
+    ]
+    const days = buildCalendarDays({
+      startDate: new Date(2026, 1, 15),
+      days: 7,
+      currentMonth: new Date(2026, 1, 1),
+      holidays,
+      showLunarCalendar: true,
+    })
+
+    const springFestival = days.find((day) => day.date === '2026-02-17')
+    expect(springFestival?.isToday).toBe(true)
+    expect(springFestival?.holidays).toEqual([holidays[0]])
+    expect(springFestival?.lunarLabel).toBeTruthy()
+
+    const workingOverride = days.find((day) => day.date === '2026-02-21')
+    expect(workingOverride?.holidays[0]?.isWorkingDay).toBe(true)
+
+    vi.useRealTimers()
+  })
+
+  it('normalizes holiday dates before grouping and preserves calendar visible range compatibility', () => {
+    const grouped = groupCalendarHolidaysByDate([
+      { id: 'holiday_1', date: '2026-02-17T00:00:00.000Z', name: 'Holiday' },
+    ])
+    expect(grouped.get('2026-02-17')?.[0]?.id).toBe('holiday_1')
+
+    expect(getCalendarVisibleRange(new Date(2026, 1, 1))).toEqual({
+      from: '2026-01-26',
+      to: '2026-03-01',
+    })
+  })
+
+  it('keeps lunar formatting optional for consumers that only need plain date grids', () => {
+    const date = new Date('2026-02-17T12:00:00Z')
+    expect(formatLunarDayLabel(date, { enabled: false })).toBeUndefined()
+    expect(formatLunarDayLabel(date, { enabled: true })).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #1674.

Multitable Calendar view now reuses shared calendar-day helpers for lunar labels and holiday/workday metadata instead of depending on attendance page internals.

## Changes

- Add `useCalendarDays` shared helpers for date keys, visible ranges, lunar labels, holiday grouping, and reusable calendar day cells.
- Keep `attendanceCalendarUtils` as a compatibility re-export while moving the reusable implementation out of the attendance view folder.
- Update `AttendanceHolidayDataSection` to consume the shared day-cell builder, preserving existing holiday/lunar behavior.
- Load holiday metadata for the visible multitable calendar range from the existing holiday API via the workbench container.
- Render lunar labels plus holiday/workday chips in multitable month/week/day calendar surfaces.
- Add focused tests for shared calendar helpers and multitable calendar holiday rendering.

## Verification

- `pnpm install --frozen-lockfile` in the isolated worktree to create dependency links ✅
- `pnpm --filter @metasheet/web exec vitest run tests/useCalendarDays.spec.ts tests/attendance-calendar-utils.spec.ts tests/AttendanceHolidayDataSection.spec.ts tests/multitable-calendar-view.spec.ts --watch=false` ✅ 15/15
- `pnpm --filter @metasheet/web type-check` ✅
- `git diff --check origin/main...HEAD` ✅

## Notes

- No backend migration or attendance data model change.
- The multitable component receives normalized calendar holiday metadata from the workbench; it does not import or render attendance page components.
