### PR TITLE
feat(multitable): localize cell editor chrome to zh-CN (T3A2)

### DIFF
--- a/apps/web/src/multitable/components/cells/MetaCellEditor.vue
+++ b/apps/web/src/multitable/components/cells/MetaCellEditor.vue
@@ -47,7 +47,7 @@
       <MetaYjsPresenceChip
         v-if="yjsActive && yjsCollaborators.length > 0"
         class="meta-cell-editor__presence"
-        label="Editing"
+        :label="l('cell.editing')"
         :users="yjsCollaborators"
       />
     </div>
@@ -72,7 +72,7 @@
       class="meta-cell-editor__input"
       type="text"
       inputmode="text"
-      placeholder="Scan or enter barcode"
+      :placeholder="l('cell.barcodePlaceholder')"
       :value="textControlValue(modelValue)"
       @input="emit('update:modelValue', ($event.target as HTMLInputElement).value)"
       @keydown.enter="emit('confirm')"
@@ -85,7 +85,7 @@
       ref="inputRef"
       class="meta-cell-editor__input"
       type="text"
-      placeholder="Enter address"
+      :placeholder="l('cell.locationPlaceholder')"
       :value="locationAddressValue(modelValue)"
       @input="emit('update:modelValue', locationValueFromAddress(($event.target as HTMLInputElement).value))"
       @keydown.enter="emit('confirm')"
@@ -112,7 +112,7 @@
         :checked="!!modelValue"
         @change="emit('update:modelValue', ($event.target as HTMLInputElement).checked); emit('confirm')"
       />
-      <span>{{ modelValue ? 'Yes' : 'No' }}</span>
+      <span>{{ modelValue ? l('cell.yes') : l('cell.no') }}</span>
     </label>
 
     <!-- select -->
@@ -182,7 +182,7 @@
         type="button"
         class="meta-cell-editor__rating-clear"
         @click="onRatingPick(0)"
-      >Clear</button>
+      >{{ l('cell.clear') }}</button>
     </div>
 
     <!-- url / email / phone: validated text input -->
@@ -225,7 +225,7 @@
       <MetaAttachmentList
         :attachments="attachmentItems"
         removable
-        empty-label="No attachments"
+        :empty-label="l('cell.noAttachments')"
         @remove="onRemoveAttachment"
       />
       <div class="meta-cell-editor__attachment-actions">
@@ -252,11 +252,11 @@
           :disabled="!attachmentIds.length || !!attachmentActivity || uploading"
           @click="clearAttachments"
         >
-          Clear all
+          {{ l('cell.clearAll') }}
         </button>
       </div>
       <div v-if="attachmentActivity" class="meta-cell-editor__uploading">
-        {{ attachmentActivity === 'removing' ? 'Removing...' : attachmentActivity === 'clearing' ? 'Clearing...' : 'Uploading...' }}
+        {{ attachmentActivity ? attachmentActivityLabel(attachmentActivity, isZh) : '' }}
       </div>
       <div v-if="attachmentError" class="meta-cell-editor__error">{{ attachmentError }}</div>
     </div>
@@ -290,6 +290,13 @@ import {
   locationValueFromAddress,
 } from '../../utils/field-display'
 import { useYjsCellBinding, type YjsCellBinding } from '../../composables/useYjsCellBinding'
+import { useLocale } from '../../../composables/useLocale'
+import {
+  metaCoreLabel,
+  attachmentActionHint as attachmentActionHintFn,
+  attachmentActivityLabel,
+  type MetaCoreLabelKey,
+} from '../../utils/meta-core-labels'
 
 const props = defineProps<{
   field: MetaField
@@ -328,6 +335,9 @@ const emit = defineEmits<{
    */
   (e: 'yjs-commit'): void
 }>()
+
+const { isZh } = useLocale()
+const l = (key: MetaCoreLabelKey) => metaCoreLabel(key, isZh.value)
 
 const readonlyDisplayValue = computed(() =>
   formatFieldDisplay({
@@ -407,6 +417,12 @@ function onMultiSelectChange(event: Event) {
 }
 
 const linkButtonLabel = computed(() => {
+  // T3A2 unreachable-fallback note: the surrounding `<button v-else-if="field.type === 'link'">`
+  // only renders when field.type === 'link', which makes this `!== 'link'` branch
+  // unreachable in the current render flow. We intentionally do NOT localize this
+  // static English string in T3A2 (would be a dead key per the merged dev MD §7.6).
+  // If a future refactor exposes this branch to the DOM, localize it together with
+  // `formatLinkActionLabel` (queued for T3B with the link picker/drawer slice).
   if (props.field.type !== 'link') return 'Choose linked records...'
   const count = Array.isArray(props.modelValue) ? props.modelValue.length : props.modelValue ? 1 : 0
   return formatLinkActionLabel(props.field, count)
@@ -427,10 +443,13 @@ const attachmentAllowsMultiple = computed(() => {
   if (props.field.type !== 'attachment') return true
   return resolveAttachmentFieldProperty(props.field.property).maxFiles !== 1
 })
-const attachmentActionHint = computed(() => {
-  if (attachmentAllowsMultiple.value) return 'Drop files or click to browse'
-  return attachmentIds.value.length ? 'Upload a new file to replace the current one' : 'Upload a file'
-})
+const attachmentActionHint = computed(() =>
+  attachmentActionHintFn(
+    attachmentAllowsMultiple.value,
+    attachmentIds.value.length > 0,
+    isZh.value,
+  ),
+)
 
 const attachmentItems = computed<MetaAttachment[]>(() => {
   const summaryById = new Map((props.attachmentSummaries ?? []).map((attachment) => [attachment.id, attachment]))
@@ -486,7 +505,7 @@ async function uploadFiles(files: FileList) {
     }
     setAttachmentValue(replaceExisting ? newIds : [...existingIds, ...newIds])
   } catch (error: any) {
-    attachmentError.value = error?.message ?? 'Failed to upload attachment'
+    attachmentError.value = error?.message ?? l('cell.uploadFailed')
   } finally {
     uploading.value = false
     attachmentActivity.value = null
@@ -552,7 +571,7 @@ async function onRemoveAttachment(attachmentId: string) {
     }
     setAttachmentValue(attachmentIds.value.filter((id) => id !== attachmentId))
   } catch (error: any) {
-    attachmentError.value = error?.message ?? 'Failed to remove attachment'
+    attachmentError.value = error?.message ?? l('cell.removeFailed')
   } finally {
     attachmentActivity.value = null
   }
@@ -572,7 +591,7 @@ async function clearAttachments() {
     }
     setAttachmentValue([])
   } catch (error: any) {
-    attachmentError.value = error?.message ?? 'Failed to clear attachments'
+    attachmentError.value = error?.message ?? l('cell.clearFailed')
   } finally {
     attachmentActivity.value = null
   }

--- a/apps/web/src/multitable/utils/meta-core-labels.ts
+++ b/apps/web/src/multitable/utils/meta-core-labels.ts
@@ -53,6 +53,12 @@ export type MetaCoreLabelKey =
   | 'grid.noMatchingTitle' | 'grid.noMatchingHint'
   | 'grid.collapseRow' | 'grid.expandRow'
   | 'grid.prev' | 'grid.next' | 'grid.loading'
+  // --- MetaCellEditor static (T3A2) ---
+  | 'cell.editing'
+  | 'cell.barcodePlaceholder' | 'cell.locationPlaceholder'
+  | 'cell.yes' | 'cell.no' | 'cell.clear'
+  | 'cell.noAttachments' | 'cell.clearAll'
+  | 'cell.uploadFailed' | 'cell.removeFailed' | 'cell.clearFailed'
 
 const META_CORE_LABELS: Record<MetaCoreLabelKey, { en: string; zh: string }> = {
   'toolbar.aria': { en: 'Grid toolbar', zh: '表格工具栏' },
@@ -136,6 +142,26 @@ const META_CORE_LABELS: Record<MetaCoreLabelKey, { en: string; zh: string }> = {
   'grid.prev': { en: 'Prev', zh: '上一页' },
   'grid.next': { en: 'Next', zh: '下一页' },
   'grid.loading': { en: 'Loading data', zh: '正在加载数据' },
+
+  // MetaCellEditor (T3A2): shallow chrome inside the grid cell editor.
+  // Excludes user data (option values, format examples like https://example.com),
+  // backend free-form errors, and link-button labels driven by formatLinkActionLabel
+  // (those are queued for T3B).
+  'cell.editing': { en: 'Editing', zh: '正在编辑' },
+  'cell.barcodePlaceholder': { en: 'Scan or enter barcode', zh: '扫描或输入条码' },
+  'cell.locationPlaceholder': { en: 'Enter address', zh: '输入地址' },
+  'cell.yes': { en: 'Yes', zh: '是' },
+  'cell.no': { en: 'No', zh: '否' },
+  'cell.clear': { en: 'Clear', zh: '清除' },
+  'cell.noAttachments': { en: 'No attachments', zh: '无附件' },
+  // Same en/zh as toolbar.clearAll but kept namespaced — different surface,
+  // different reviewer audit path.
+  'cell.clearAll': { en: 'Clear all', zh: '全部清除' },
+  // Fallback-only: backend error.message is preferred when present (kept raw,
+  // since it is user data); these are the frontend fallback for the `??` branch.
+  'cell.uploadFailed': { en: 'Failed to upload attachment', zh: '附件上传失败' },
+  'cell.removeFailed': { en: 'Failed to remove attachment', zh: '附件移除失败' },
+  'cell.clearFailed': { en: 'Failed to clear attachments', zh: '附件清空失败' },
 }
 
 export function metaCoreLabel(key: MetaCoreLabelKey, isZh: boolean): string {
@@ -200,4 +226,35 @@ export function filterValuePlaceholder(type: string, isZh: boolean): string {
   if (type === 'number') return isZh ? '输入数字' : 'Enter a number'
   if (type === 'date') return isZh ? '选择日期' : 'Pick a date'
   return isZh ? '输入筛选文本' : 'Enter filter text'
+}
+
+// --- T3A2: MetaCellEditor attachment helpers ---
+
+// attachmentActionHint: drop-target hint for the MetaCellEditor attachment
+// trigger. Three variants chosen by capability + existing-attachment state:
+//   - multi-file allowed → "Drop files or click to browse"
+//   - single-file + already has an attachment → "Upload a new file to replace the current one"
+//   - single-file + empty → "Upload a file"
+// `hasExisting` is a boolean — only >0-ness matters to copy, not the count.
+// User-confirmed zh choices (T3A2 AskUserQuestion, 2026-05-19): 拖拽文件或点击选择 /
+// 上传新文件以替换当前文件 / 上传文件.
+export function attachmentActionHint(
+  allowsMultiple: boolean,
+  hasExisting: boolean,
+  isZh: boolean,
+): string {
+  if (allowsMultiple) return isZh ? '拖拽文件或点击选择' : 'Drop files or click to browse'
+  if (hasExisting) return isZh ? '上传新文件以替换当前文件' : 'Upload a new file to replace the current one'
+  return isZh ? '上传文件' : 'Upload a file'
+}
+
+// attachmentActivityLabel: in-progress label below the attachment trigger.
+// Source enum matches MetaCellEditor's `attachmentActivity` ref union.
+export function attachmentActivityLabel(
+  activity: 'uploading' | 'removing' | 'clearing',
+  isZh: boolean,
+): string {
+  if (activity === 'removing') return isZh ? '正在移除...' : 'Removing...'
+  if (activity === 'clearing') return isZh ? '正在清空...' : 'Clearing...'
+  return isZh ? '正在上传...' : 'Uploading...'
 }

--- a/apps/web/tests/meta-cell-editor-i18n.spec.ts
+++ b/apps/web/tests/meta-cell-editor-i18n.spec.ts
@@ -1,0 +1,185 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, h, type App } from 'vue'
+import MetaCellEditor from '../src/multitable/components/cells/MetaCellEditor.vue'
+import type { MetaField } from '../src/multitable/types'
+import { useLocale } from '../src/composables/useLocale'
+
+let app: App<Element> | null = null
+let container: HTMLDivElement | null = null
+
+afterEach(() => {
+  app?.unmount()
+  app = null
+  container?.remove()
+  container = null
+  useLocale().setLocale('en')
+})
+
+function mountEditor(field: MetaField, modelValue: unknown, extraProps: Record<string, unknown> = {}) {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  app = createApp({
+    setup() {
+      return () => h(MetaCellEditor, {
+        field,
+        modelValue,
+        ...extraProps,
+      })
+    },
+  })
+  app.mount(container)
+  return container
+}
+
+describe('MetaCellEditor i18n — boolean', () => {
+  it('renders Yes/No in English', () => {
+    useLocale().setLocale('en')
+    const field: MetaField = { id: 'done', name: 'Done', type: 'boolean' }
+    expect((mountEditor(field, true)).textContent).toContain('Yes')
+    app?.unmount(); app = null; container?.remove(); container = null
+    expect((mountEditor(field, false)).textContent).toContain('No')
+  })
+
+  it('renders 是/否 in zh-CN', () => {
+    useLocale().setLocale('zh-CN')
+    const field: MetaField = { id: 'done', name: 'Done', type: 'boolean' }
+    const trueRoot = mountEditor(field, true)
+    expect(trueRoot.textContent).toContain('是')
+    expect(trueRoot.textContent).not.toContain('Yes')
+    app?.unmount(); app = null; container?.remove(); container = null
+    const falseRoot = mountEditor(field, false)
+    expect(falseRoot.textContent).toContain('否')
+    expect(falseRoot.textContent).not.toContain('No')
+  })
+})
+
+describe('MetaCellEditor i18n — static placeholders', () => {
+  it('localizes the barcode placeholder', () => {
+    const field: MetaField = { id: 'sku', name: 'SKU', type: 'barcode' as MetaField['type'] }
+
+    useLocale().setLocale('zh-CN')
+    let root = mountEditor(field, '')
+    let input = root.querySelector('input') as HTMLInputElement
+    expect(input.getAttribute('placeholder')).toBe('扫描或输入条码')
+
+    app?.unmount(); app = null; container?.remove(); container = null
+
+    useLocale().setLocale('en')
+    root = mountEditor(field, '')
+    input = root.querySelector('input') as HTMLInputElement
+    expect(input.getAttribute('placeholder')).toBe('Scan or enter barcode')
+  })
+
+  it('localizes the location placeholder', () => {
+    const field: MetaField = { id: 'addr', name: 'Address', type: 'location' as MetaField['type'] }
+    useLocale().setLocale('zh-CN')
+    const root = mountEditor(field, '')
+    expect((root.querySelector('input') as HTMLInputElement).getAttribute('placeholder')).toBe('输入地址')
+  })
+
+  it('preserves untranslated format examples for url/email/phone (user-data formats, not UI chrome)', () => {
+    useLocale().setLocale('zh-CN')
+    const urlField: MetaField = { id: 'u', name: 'URL', type: 'url' as MetaField['type'] }
+    const emailField: MetaField = { id: 'e', name: 'Email', type: 'email' as MetaField['type'] }
+    const phoneField: MetaField = { id: 'p', name: 'Phone', type: 'phone' as MetaField['type'] }
+
+    expect((mountEditor(urlField, '').querySelector('input') as HTMLInputElement).getAttribute('placeholder')).toBe('https://example.com')
+    app?.unmount(); app = null; container?.remove(); container = null
+
+    expect((mountEditor(emailField, '').querySelector('input') as HTMLInputElement).getAttribute('placeholder')).toBe('name@example.com')
+    app?.unmount(); app = null; container?.remove(); container = null
+
+    expect((mountEditor(phoneField, '').querySelector('input') as HTMLInputElement).getAttribute('placeholder')).toBe('+86 138 0000 0000')
+  })
+})
+
+describe('MetaCellEditor i18n — rating clear', () => {
+  it('renders the rating clear button localized when value > 0', () => {
+    const field: MetaField = { id: 'rate', name: 'Rate', type: 'rating' as MetaField['type'] }
+
+    useLocale().setLocale('zh-CN')
+    let root = mountEditor(field, 3)
+    let clearBtn = root.querySelector('.meta-cell-editor__rating-clear') as HTMLButtonElement
+    expect(clearBtn?.textContent?.trim()).toBe('清除')
+
+    app?.unmount(); app = null; container?.remove(); container = null
+
+    useLocale().setLocale('en')
+    root = mountEditor(field, 3)
+    clearBtn = root.querySelector('.meta-cell-editor__rating-clear') as HTMLButtonElement
+    expect(clearBtn?.textContent?.trim()).toBe('Clear')
+  })
+})
+
+describe('MetaCellEditor i18n — attachment chrome', () => {
+  const multiField: MetaField = {
+    id: 'files',
+    name: 'Files',
+    type: 'attachment' as MetaField['type'],
+    property: { maxFiles: 5 } as unknown as MetaField['property'],
+  }
+  const singleField: MetaField = {
+    id: 'avatar',
+    name: 'Avatar',
+    type: 'attachment' as MetaField['type'],
+    property: { maxFiles: 1 } as unknown as MetaField['property'],
+  }
+
+  it('multi-file empty: zh shows 拖拽文件或点击选择 + 全部清除 + 无附件', () => {
+    useLocale().setLocale('zh-CN')
+    const root = mountEditor(multiField, [])
+    const text = root.textContent ?? ''
+    expect(text).toContain('拖拽文件或点击选择')   // attachmentActionHint multi
+    expect(text).toContain('全部清除')             // cell.clearAll
+    expect(text).toContain('无附件')               // cell.noAttachments via MetaAttachmentList empty-label
+    expect(text).not.toContain('Drop files or click to browse')
+    expect(text).not.toContain('No attachments')
+  })
+
+  it('single-file empty: zh shows 上传文件 (action hint variant 3)', () => {
+    useLocale().setLocale('zh-CN')
+    const root = mountEditor(singleField, null)
+    expect(root.textContent ?? '').toContain('上传文件')
+    expect(root.textContent ?? '').not.toContain('Upload a file')
+  })
+
+  it('single-file with existing: zh shows 上传新文件以替换当前文件 (action hint variant 2)', () => {
+    useLocale().setLocale('zh-CN')
+    const root = mountEditor(singleField, ['attach-1'], {
+      attachmentSummaries: [
+        { id: 'attach-1', filename: 'a.png', mimeType: 'image/png', size: 0, url: '', thumbnailUrl: null, uploadedAt: '' },
+      ],
+    })
+    expect(root.textContent ?? '').toContain('上传新文件以替换当前文件')
+    expect(root.textContent ?? '').not.toContain('Upload a new file to replace the current one')
+  })
+
+  it('multi-file empty in en preserves the original English chrome', () => {
+    useLocale().setLocale('en')
+    const root = mountEditor(multiField, [])
+    const text = root.textContent ?? ''
+    expect(text).toContain('Drop files or click to browse')
+    expect(text).toContain('Clear all')
+    expect(text).toContain('No attachments')
+    expect(text).not.toContain('拖拽文件或点击选择')
+  })
+})
+
+describe('MetaCellEditor i18n — user-data preservation', () => {
+  it('select option values stay exactly as authored (user data)', () => {
+    useLocale().setLocale('zh-CN')
+    const field: MetaField = {
+      id: 'status',
+      name: 'Status',
+      type: 'select',
+      options: [{ value: 'todo' }, { value: 'done' }],
+    }
+    const root = mountEditor(field, 'todo')
+    const options = Array.from(root.querySelectorAll('option')).map((o) => o.textContent?.trim())
+    expect(options).toContain('todo')
+    expect(options).toContain('done')
+    // never translated
+    expect(options).not.toContain('待办')
+    expect(options).not.toContain('已完成')
+  })
+})

--- a/apps/web/tests/multitable-core-i18n.spec.ts
+++ b/apps/web/tests/multitable-core-i18n.spec.ts
@@ -8,6 +8,8 @@ import {
   groupNoValue,
   fieldTypeLabel,
   filterValuePlaceholder,
+  attachmentActionHint,
+  attachmentActivityLabel,
 } from '../src/multitable/utils/meta-core-labels'
 
 describe('meta-core-labels static keys', () => {
@@ -103,5 +105,60 @@ describe('meta-core-labels helpers', () => {
     expect(filterValuePlaceholder('date', true)).toBe('选择日期')
     expect(filterValuePlaceholder('string', true)).toBe('输入筛选文本')
     expect(filterValuePlaceholder('whatever', false)).toBe('Enter filter text')
+  })
+})
+
+describe('meta-core-labels MetaCellEditor static keys (T3A2)', () => {
+  it('localizes cell.editing / barcode / location / yes / no / clear / noAttachments / clearAll', () => {
+    expect(metaCoreLabel('cell.editing', true)).toBe('正在编辑')
+    expect(metaCoreLabel('cell.editing', false)).toBe('Editing')
+    expect(metaCoreLabel('cell.barcodePlaceholder', true)).toBe('扫描或输入条码')
+    expect(metaCoreLabel('cell.locationPlaceholder', true)).toBe('输入地址')
+    expect(metaCoreLabel('cell.yes', true)).toBe('是')
+    expect(metaCoreLabel('cell.no', true)).toBe('否')
+    expect(metaCoreLabel('cell.clear', true)).toBe('清除')
+    expect(metaCoreLabel('cell.noAttachments', true)).toBe('无附件')
+    expect(metaCoreLabel('cell.clearAll', true)).toBe('全部清除')
+  })
+
+  it('localizes attachment fallback error strings (frontend ?? branch only)', () => {
+    expect(metaCoreLabel('cell.uploadFailed', true)).toBe('附件上传失败')
+    expect(metaCoreLabel('cell.removeFailed', true)).toBe('附件移除失败')
+    expect(metaCoreLabel('cell.clearFailed', true)).toBe('附件清空失败')
+    // en preserved exactly to keep the existing `?? 'Failed to ...'` semantics
+    expect(metaCoreLabel('cell.uploadFailed', false)).toBe('Failed to upload attachment')
+    expect(metaCoreLabel('cell.removeFailed', false)).toBe('Failed to remove attachment')
+    expect(metaCoreLabel('cell.clearFailed', false)).toBe('Failed to clear attachments')
+  })
+
+  it('cell.clearAll is namespaced separately from toolbar.clearAll (same en/zh, different surface)', () => {
+    expect(metaCoreLabel('cell.clearAll', true)).toBe('全部清除')
+    expect(metaCoreLabel('toolbar.clearAll', true)).toBe('全部清除')
+    expect(metaCoreLabel('cell.clearAll', false)).toBe('Clear all')
+    expect(metaCoreLabel('toolbar.clearAll', false)).toBe('Clear all')
+  })
+})
+
+describe('meta-core-labels MetaCellEditor helpers (T3A2)', () => {
+  it('attachmentActionHint picks the multi-file copy when allowsMultiple', () => {
+    expect(attachmentActionHint(true, false, false)).toBe('Drop files or click to browse')
+    expect(attachmentActionHint(true, true, false)).toBe('Drop files or click to browse')
+    expect(attachmentActionHint(true, false, true)).toBe('拖拽文件或点击选择')
+  })
+
+  it('attachmentActionHint distinguishes single-file empty vs has-existing', () => {
+    expect(attachmentActionHint(false, false, false)).toBe('Upload a file')
+    expect(attachmentActionHint(false, false, true)).toBe('上传文件')
+    expect(attachmentActionHint(false, true, false)).toBe('Upload a new file to replace the current one')
+    expect(attachmentActionHint(false, true, true)).toBe('上传新文件以替换当前文件')
+  })
+
+  it('attachmentActivityLabel covers all three states matching MetaCellEditor activity ref', () => {
+    expect(attachmentActivityLabel('uploading', false)).toBe('Uploading...')
+    expect(attachmentActivityLabel('uploading', true)).toBe('正在上传...')
+    expect(attachmentActivityLabel('removing', false)).toBe('Removing...')
+    expect(attachmentActivityLabel('removing', true)).toBe('正在移除...')
+    expect(attachmentActivityLabel('clearing', false)).toBe('Clearing...')
+    expect(attachmentActivityLabel('clearing', true)).toBe('正在清空...')
   })
 })

--- a/docs/development/multitable-t3a2-cell-editor-i18n-verification-20260519.md
+++ b/docs/development/multitable-t3a2-cell-editor-i18n-verification-20260519.md
@@ -1,7 +1,7 @@
 # T3A2 — MetaCellEditor shallow chrome zh-CN i18n — Verification
 
 - **Date**: 2026-05-19
-- **Branch**: `frontend/multitable-t3a2-cell-editor-i18n-20260519` (rebased onto `origin/main` post #1685/#1686, ahead 2 / behind 0)
+- **Branch**: `frontend/multitable-t3a2-cell-editor-i18n-20260519` (rebased onto `origin/main` post #1685/#1686, ahead 3 / behind 0)
 - **Dev plan**: anchored in `docs/development/multitable-t3a-core-table-i18n-development-20260519.md` §3.3 / §5.6 / §7.4 / §13 (T3A2 deferral path from the merged T3A1 packet — no new dev MD).
 - **Type**: implementation + verification.
 - **K3 PoC stage-1 lock**: complies — no `/api/*` contract, no migration, no integration-core, no plugin-integration; touches only `meta-core-labels.ts` (frontend label module) + `MetaCellEditor.vue` (frontend chrome) + tests.
@@ -15,9 +15,11 @@ M  apps/web/src/multitable/utils/meta-core-labels.ts            (+76 lines: 11 c
 M  apps/web/src/multitable/components/cells/MetaCellEditor.vue  (locale-wired; 13 chrome strings + 3 fallback errors)
 M  apps/web/tests/multitable-core-i18n.spec.ts                  (+6 cases for cell.*/attachment helpers)
 A  apps/web/tests/meta-cell-editor-i18n.spec.ts                 (11 render cases)
+A  docs/development/multitable-t3a2-cell-editor-i18n-verification-20260519.md
+                                                                 (this verification packet)
 ```
 
-Pure T3A2; no attendance/Workbench/HomeView/backend/contract leakage (`git diff --name-status origin/main..HEAD` confirms 4 files only).
+Pure T3A2; no attendance/Workbench/HomeView/backend/contract leakage (`git diff --name-status origin/main..HEAD` confirms 5 files only: 4 frontend/test files + this verification MD).
 
 ## 2. Test Results (focused)
 
@@ -76,7 +78,7 @@ $ git diff --check origin/main..HEAD
 | 2 | en preserves existing English labels | ✓ (en cases + jsdom default locale) |
 | 3 | No translation of user data (option values, URLs, emails, phone, backend free-form errors) | ✓ (explicit spec assertions + `error?.message ??` pattern preserved) |
 | 4 | Cell editing behavior unchanged | ✓ (no event/emit changes; existing `confirm`/`cancel`/`yjs-commit`/`open-link-picker`/`update:modelValue` paths intact) |
-| 5 | No API contract / backend route / migration / K3 / plugin-integration / OpenAPI change | ✓ (`git diff --name-only origin/main..HEAD` = 4 files, all under `apps/web/`) |
+| 5 | No API contract / backend route / migration / K3 / plugin-integration / OpenAPI change | ✓ (`git diff --name-only origin/main..HEAD` = 5 files, all under `apps/web/` or `docs/development/`) |
 | 6 | New helpers have unit coverage for variants + fallbacks | ✓ (`attachmentActionHint` 3 variants × locales, `attachmentActivityLabel` 3 states × locales, fallback errors en+zh) |
 | 7 | Focused component tests cover both zh-CN and en render | ✓ (11 cases mixed) |
 | 8 | Verification MD records any intentionally deferred strings found by grep | ✓ (this §4) |
@@ -85,15 +87,16 @@ $ git diff --check origin/main..HEAD
 
 ```
 $ git log --oneline origin/main..HEAD
+0341dd272 docs(multitable): T3A2 verification report
 9615f6afa feat(multitable): localize MetaCellEditor cell chrome to zh-CN (T3A2)
 2f3de9e93 feat(multitable): extend core labels with cell editor helpers (T3A2)
 ```
 
-Rebase note: branch was created from `origin/main @ cbcc6bf32`; during T3A2 implementation `origin/main` advanced by 3 commits (#1685 multitable drawer/workflow fix, #1686 attendance staging migration audit docs, `66d74119a` onprem wrapper fix). Rebased clean (no conflicts — those commits don't touch `MetaCellEditor.vue` / `meta-core-labels.ts` / the 2 specs); post-rebase ahead 2/behind 0; vue-tsc + 44 focused specs re-verified green on rebased state.
+Rebase note: branch was created from `origin/main @ cbcc6bf32`; during T3A2 implementation `origin/main` advanced by 3 commits (#1685 multitable drawer/workflow fix, #1686 attendance staging migration audit docs, `66d74119a` onprem wrapper fix). Rebased clean (no conflicts — those commits don't touch `MetaCellEditor.vue` / `meta-core-labels.ts` / the 2 specs); post-rebase ahead 3/behind 0; vue-tsc + 44 focused specs re-verified green on rebased state.
 
 ## 7. Worktree-Contention Mitigation
 
-Per the `multitable-i18n` project memory durability-first rule: both feat commits landed early (immediately after focused-specs green), making the work durable in the branch-ref before any further worktree clobbering could affect it. No `git add -A` used — targeted adds only (worktree contains parallel-actor's uncommitted WIP on `MultitableWorkbench.vue` / `MultitableHomeView.vue` / `multitable-home-view.spec.ts` / `multitable-workbench-1672-1673.spec.ts` plus pre-existing `.tmp-*` and `docs/research/dingtalk-*` untracked — none ever entered any T3A2 commit, verified via `git diff --name-status origin/main..HEAD`).
+Per the `multitable-i18n` project memory durability-first rule: both feat commits landed early (immediately after focused-specs green), making the work durable in the branch-ref before any further worktree clobbering could affect it. No `git add -A` used — targeted adds only. Current untracked `.tmp-*`, `docs/research/dingtalk-*`, and `output/attendance-*` artifacts are pre-existing local noise and are not part of the T3A2 commits, verified via `git diff --name-status origin/main..HEAD`.
 
 ## 8. Regression Comm-Diff (pending)
 

--- a/docs/development/multitable-t3a2-cell-editor-i18n-verification-20260519.md
+++ b/docs/development/multitable-t3a2-cell-editor-i18n-verification-20260519.md
@@ -1,7 +1,7 @@
 # T3A2 — MetaCellEditor shallow chrome zh-CN i18n — Verification
 
 - **Date**: 2026-05-19
-- **Branch**: `frontend/multitable-t3a2-cell-editor-i18n-20260519` (rebased onto `origin/main` post #1685/#1686, ahead 3 / behind 0)
+- **Branch**: `frontend/multitable-t3a2-cell-editor-i18n-20260519` (rebased onto `origin/main` post #1685/#1686; no upstream drift at the time of verification)
 - **Dev plan**: anchored in `docs/development/multitable-t3a-core-table-i18n-development-20260519.md` §3.3 / §5.6 / §7.4 / §13 (T3A2 deferral path from the merged T3A1 packet — no new dev MD).
 - **Type**: implementation + verification.
 - **K3 PoC stage-1 lock**: complies — no `/api/*` contract, no migration, no integration-core, no plugin-integration; touches only `meta-core-labels.ts` (frontend label module) + `MetaCellEditor.vue` (frontend chrome) + tests.
@@ -85,14 +85,9 @@ $ git diff --check origin/main..HEAD
 
 ## 6. Git State
 
-```
-$ git log --oneline origin/main..HEAD
-0341dd272 docs(multitable): T3A2 verification report
-9615f6afa feat(multitable): localize MetaCellEditor cell chrome to zh-CN (T3A2)
-2f3de9e93 feat(multitable): extend core labels with cell editor helpers (T3A2)
-```
+The authoritative PR shape is the committed diff against `origin/main`; this packet intentionally avoids pinning an exact commit count because docs-only verification corrections can be appended before PR open and the PR will be squash-merged.
 
-Rebase note: branch was created from `origin/main @ cbcc6bf32`; during T3A2 implementation `origin/main` advanced by 3 commits (#1685 multitable drawer/workflow fix, #1686 attendance staging migration audit docs, `66d74119a` onprem wrapper fix). Rebased clean (no conflicts — those commits don't touch `MetaCellEditor.vue` / `meta-core-labels.ts` / the 2 specs); post-rebase ahead 3/behind 0; vue-tsc + 44 focused specs re-verified green on rebased state.
+Rebase note: branch was created from `origin/main @ cbcc6bf32`; during T3A2 implementation `origin/main` advanced by 3 commits (#1685 multitable drawer/workflow fix, #1686 attendance staging migration audit docs, `66d74119a` onprem wrapper fix). Rebased clean (no conflicts — those commits don't touch `MetaCellEditor.vue` / `meta-core-labels.ts` / the 2 specs); vue-tsc + 44 focused specs re-verified green on rebased state.
 
 ## 7. Worktree-Contention Mitigation
 

--- a/docs/development/multitable-t3a2-cell-editor-i18n-verification-20260519.md
+++ b/docs/development/multitable-t3a2-cell-editor-i18n-verification-20260519.md
@@ -1,0 +1,114 @@
+# T3A2 — MetaCellEditor shallow chrome zh-CN i18n — Verification
+
+- **Date**: 2026-05-19
+- **Branch**: `frontend/multitable-t3a2-cell-editor-i18n-20260519` (rebased onto `origin/main` post #1685/#1686, ahead 2 / behind 0)
+- **Dev plan**: anchored in `docs/development/multitable-t3a-core-table-i18n-development-20260519.md` §3.3 / §5.6 / §7.4 / §13 (T3A2 deferral path from the merged T3A1 packet — no new dev MD).
+- **Type**: implementation + verification.
+- **K3 PoC stage-1 lock**: complies — no `/api/*` contract, no migration, no integration-core, no plugin-integration; touches only `meta-core-labels.ts` (frontend label module) + `MetaCellEditor.vue` (frontend chrome) + tests.
+
+---
+
+## 1. Files Changed
+
+```
+M  apps/web/src/multitable/utils/meta-core-labels.ts            (+76 lines: 11 cell.* keys + 2 helpers)
+M  apps/web/src/multitable/components/cells/MetaCellEditor.vue  (locale-wired; 13 chrome strings + 3 fallback errors)
+M  apps/web/tests/multitable-core-i18n.spec.ts                  (+6 cases for cell.*/attachment helpers)
+A  apps/web/tests/meta-cell-editor-i18n.spec.ts                 (11 render cases)
+```
+
+Pure T3A2; no attendance/Workbench/HomeView/backend/contract leakage (`git diff --name-status origin/main..HEAD` confirms 4 files only).
+
+## 2. Test Results (focused)
+
+```
+$ pnpm --filter @metasheet/web exec vue-tsc --noEmit
+exit=0 (0 lines)
+
+$ pnpm --filter @metasheet/web exec vitest run \
+    tests/multitable-core-i18n.spec.ts \
+    tests/meta-cell-editor-i18n.spec.ts \
+    tests/meta-toolbar-filter-builder.spec.ts \
+    tests/meta-grid-table-i18n.spec.ts \
+    --watch=false
+
+✓ tests/multitable-core-i18n.spec.ts        (19 tests)   ← 13 T3A1 + 6 T3A2 unit
+✓ tests/meta-cell-editor-i18n.spec.ts       (11 tests)   ← T3A2 render
+✓ tests/meta-toolbar-filter-builder.spec.ts ( 8 tests)   ← T3A1 regression untouched
+✓ tests/meta-grid-table-i18n.spec.ts        ( 6 tests)   ← T3A1 regression untouched
+
+Test Files  4 passed (4)
+     Tests  44 passed (44)
+```
+
+```
+$ git diff --check origin/main..HEAD
+(clean)
+```
+
+## 3. Findings Resolutions (preflight against MD §5.6 vs real `MetaCellEditor.vue`)
+
+| Finding | Resolution |
+|---|---|
+| **F-T3A2-A**: MD §4 planned `linkButtonFallback` for `'Choose linked records...'` (L410), but the static branch is **unreachable** in current render flow — `<button v-else-if="field.type === 'link'">` and the computed guard `if (type !== 'link')` are contradictory predicates. Per merged dev MD §7.6 "no dead keys". | **Skipped**. Added inline note at `MetaCellEditor.vue` linkButtonLabel computed documenting why it stays English in T3A2 and that future exposure should be localized together with `formatLinkActionLabel` (T3B). |
+| **F-T3A2-B**: `cell.clearAll` has identical en/zh to `toolbar.clearAll` (T3A1). | **Kept namespaced** (own key, same values). Different surfaces, different reviewer audit paths. Spec asserts both keys explicitly. |
+| **F-T3A2-C**: 3 attachment-action-hint zh translations not pre-decided. | **User-confirmed** (2026-05-19 AskUserQuestion): `拖拽文件或点击选择` / `上传新文件以替换当前文件` / `上传文件`. Baked into `attachmentActionHint` helper + spec. |
+| **F-T3A2-D**: 3 attachment-activity zh per MD. | Taken from MD as-is: `正在移除... / 正在清空... / 正在上传...`. Consistent with workbench-labels loading-state convention. |
+| **F-T3A2-E (new)**: `MetaYjsPresenceChip.vue` L13 carries its own default label `'Collaborating now'` (en). `MetaCellEditor` always passes a label so the default is unreachable from this surface, but the chip is reusable. | **Deferred** out of T3A2 (component out of MD §3.1 scope). Queued for T3E or a dedicated presence-i18n slice. Localizing it requires editing a separate component used in multiple consumer paths. |
+
+## 4. Out-of-Scope (intentionally deferred to later slices)
+
+| Item | Slice | Reason |
+|---|---|---|
+| `MetaYjsPresenceChip` default `label='Collaborating now'` | T3E / presence-i18n slice | Component shared across consumers; T3A2 scope = MetaCellEditor only. |
+| `MetaAttachmentList` internal row UI (file remove buttons, size labels, etc.) | T3C field-management surface | Out of MD §3.1; T3A2 only touches the consumer-passed `:empty-label` prop. |
+| `validateAttachmentSelection(...)` messages | n/a (deferred indefinitely) | Field-config validation layer; MD §5.6 explicitly out of shallow-chrome scope. |
+| `formatLinkActionLabel(field, count)` output | T3B link picker/drawer slice | MD §5.6 explicitly defers; see F-T3A2-A inline note. |
+| Yjs presence chip render spec | optional Yjs integration spec | Per advisor: `useYjsCellBinding` mock complexity > test value at T3A2; chip rendering exercised indirectly when MetaCellEditor mounts with `recordId` absent (binding inert) but full Yjs-active path is integration-level. |
+| URL / email / phone placeholder examples (`https://example.com` / `name@example.com` / `+86 138 0000 0000`) | n/a (intentional) | User-data format examples per MD §5.6, NOT UI chrome. Spec asserts they stay raw in zh. |
+| `<option value="">—</option>` em-dash in `<select>` | n/a (intentional) | Locale-neutral symbol. |
+
+## 5. Acceptance Criteria (per T3A dev MD §8)
+
+| # | Criterion | Status |
+|---|---|---|
+| 1 | zh-CN renders localized cell-editor chrome for in-scope strings | ✓ (11 render-spec cases) |
+| 2 | en preserves existing English labels | ✓ (en cases + jsdom default locale) |
+| 3 | No translation of user data (option values, URLs, emails, phone, backend free-form errors) | ✓ (explicit spec assertions + `error?.message ??` pattern preserved) |
+| 4 | Cell editing behavior unchanged | ✓ (no event/emit changes; existing `confirm`/`cancel`/`yjs-commit`/`open-link-picker`/`update:modelValue` paths intact) |
+| 5 | No API contract / backend route / migration / K3 / plugin-integration / OpenAPI change | ✓ (`git diff --name-only origin/main..HEAD` = 4 files, all under `apps/web/`) |
+| 6 | New helpers have unit coverage for variants + fallbacks | ✓ (`attachmentActionHint` 3 variants × locales, `attachmentActivityLabel` 3 states × locales, fallback errors en+zh) |
+| 7 | Focused component tests cover both zh-CN and en render | ✓ (11 cases mixed) |
+| 8 | Verification MD records any intentionally deferred strings found by grep | ✓ (this §4) |
+
+## 6. Git State
+
+```
+$ git log --oneline origin/main..HEAD
+9615f6afa feat(multitable): localize MetaCellEditor cell chrome to zh-CN (T3A2)
+2f3de9e93 feat(multitable): extend core labels with cell editor helpers (T3A2)
+```
+
+Rebase note: branch was created from `origin/main @ cbcc6bf32`; during T3A2 implementation `origin/main` advanced by 3 commits (#1685 multitable drawer/workflow fix, #1686 attendance staging migration audit docs, `66d74119a` onprem wrapper fix). Rebased clean (no conflicts — those commits don't touch `MetaCellEditor.vue` / `meta-core-labels.ts` / the 2 specs); post-rebase ahead 2/behind 0; vue-tsc + 44 focused specs re-verified green on rebased state.
+
+## 7. Worktree-Contention Mitigation
+
+Per the `multitable-i18n` project memory durability-first rule: both feat commits landed early (immediately after focused-specs green), making the work durable in the branch-ref before any further worktree clobbering could affect it. No `git add -A` used — targeted adds only (worktree contains parallel-actor's uncommitted WIP on `MultitableWorkbench.vue` / `MultitableHomeView.vue` / `multitable-home-view.spec.ts` / `multitable-workbench-1672-1673.spec.ts` plus pre-existing `.tmp-*` and `docs/research/dingtalk-*` untracked — none ever entered any T3A2 commit, verified via `git diff --name-status origin/main..HEAD`).
+
+## 8. Regression Comm-Diff (pending)
+
+Per the session's pattern from T3A1 / #1671 / #1681 (failed-test-set diff, not totals), a full-web-suite `comm -13`/`comm -23` between origin/main and HEAD failed-test sets would ratify zero regression. Not executed inline here because the current shared worktree is under active parallel-actor contention (HEAD switched ≥3 times during T3A1; #1685 / #1686 pushed during T3A2 implementation), and a 3–4 minute full vitest run risks corruption by mid-run branch switches.
+
+**What we know without it**:
+- vue-tsc clean (post-rebase).
+- All 4 T3A2-relevant focused specs green (19 unit + 11 cell-editor + 8 toolbar + 6 grid).
+- Edits are additive (new keys/helpers) or locale-conditional (en branch returns the original string verbatim). No existing en-asserting spec should observe a behavioral change.
+- Default jsdom navigator language is `en-US` → `useLocale().isZh.value` starts as `false`; specs that don't call `setLocale('zh-CN')` continue to see English literals identical to the pre-T3A2 versions.
+
+**Recommended next step (operator)**: run the comm-diff once the parallel session is quiesced, or treat the focused-specs + vue-tsc + additive-edit reasoning as sufficient for PR open + CI as the regression gate (CI runs test 18.x / 20.x on a clean checkout, isolated from the local contended worktree). The T3A1 / #1681 PR was admin-squash-merged on the same logic + CI green.
+
+## 9. Next Steps
+
+1. **Hold push pending operator go** (consistent with session discipline: each push/PR is a separate explicit opt-in).
+2. On go: `git push -u origin frontend/multitable-t3a2-cell-editor-i18n-20260519` → open PR → wait for CI (especially `test (18.x)` / `test (20.x)`) green → admin squash merge → `git branch -D` local stale branch.
+3. After merge: T3B (MetaRecordDrawer + MetaFormView + comments drawer/composer/link picker) becomes the next anchored slice. Per the `multitable-i18n` memory it's deliberately the next, not skipped.


### PR DESCRIPTION
## Summary

- Extend `meta-core-labels.ts` with T3A2 cell-editor keys and attachment helpers.
- Localize shallow `MetaCellEditor` chrome for boolean, barcode/location placeholders, rating clear, attachment empty/action/activity/fallback error text.
- Add focused unit/render coverage plus a T3A2 verification packet.

## Scope Guard

This is a frontend i18n polish slice only.

No changes to:
- backend routes or API contracts
- migrations / OpenAPI
- K3 / integration-core paths
- Workbench/HomeView/attendance WIP

Intentional deferrals are recorded in the verification MD: link picker labels, MetaYjsPresenceChip default label, attachment-list internals, validation-layer messages, and URL/email/phone format examples.

## Verification

- `pnpm --filter @metasheet/web exec vitest run tests/multitable-core-i18n.spec.ts tests/meta-cell-editor-i18n.spec.ts tests/meta-toolbar-filter-builder.spec.ts tests/meta-grid-table-i18n.spec.ts --watch=false` -> 44/44 pass
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit` -> pass
- `git diff --check origin/main..HEAD` -> clean
- `git diff --name-status origin/main..HEAD` -> exactly 5 T3A2 files

## Review Notes

- `cell.clearAll` intentionally has its own key even though it shares text with `toolbar.clearAll`, because the surfaces and review paths differ.
- The old static `Choose linked records...` fallback remains English because it is unreachable under the current `field.type === 'link'` render path; it is queued for T3B with `formatLinkActionLabel` and link-picker/drawer work.
- Backend-provided `error.message` remains raw user/system text; only frontend fallback strings are localized.
