### PR TITLE
fix(integration): add SQL Server port field to K3 setup

### DIFF
--- a/apps/web/src/services/integration/k3WiseSetup.ts
+++ b/apps/web/src/services/integration/k3WiseSetup.ts
@@ -173,6 +173,7 @@ export interface K3WiseSetupForm {
   sqlName: string
   sqlMode: K3SqlServerMode
   sqlServer: string
+  sqlPort: string
   sqlDatabase: string
   sqlUsername: string
   sqlPassword: string
@@ -450,6 +451,33 @@ function optionalString(value: string): string | undefined {
   return normalized.length > 0 ? normalized : undefined
 }
 
+interface SqlServerEndpointParts {
+  server: string
+  port: string
+  embeddedPort: string
+}
+
+export function normalizeK3WiseSqlServerEndpoint(serverValue: string, portValue = ''): SqlServerEndpointParts {
+  const server = trim(serverValue)
+  const port = trim(portValue)
+  const hostPortMatch = server.match(/^([^,:]+)([:,])(\d+)$/)
+  if (!hostPortMatch) {
+    return { server, port, embeddedPort: '' }
+  }
+  const embeddedPort = hostPortMatch[3]
+  return {
+    server: hostPortMatch[1],
+    port: port || embeddedPort,
+    embeddedPort,
+  }
+}
+
+export function normalizeK3WiseSqlConnectionForm(form: K3WiseSetupForm): void {
+  const endpoint = normalizeK3WiseSqlServerEndpoint(form.sqlServer, form.sqlPort)
+  form.sqlServer = endpoint.server
+  form.sqlPort = endpoint.embeddedPort || endpoint.port
+}
+
 function cloneJson<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T
 }
@@ -537,6 +565,16 @@ function parseOptionalPositiveInteger(value: string): number | undefined {
   return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined
 }
 
+function parseOptionalTcpPort(value: string, field: keyof K3WiseSetupForm): number | undefined {
+  const normalized = trim(value)
+  if (!normalized) return undefined
+  const parsed = Number(normalized)
+  if (!Number.isInteger(parsed) || parsed <= 0 || parsed > 65535) {
+    throw new Error(`${field} must be a TCP port between 1 and 65535`)
+  }
+  return parsed
+}
+
 const BOOLEAN_TRUE_TEXT = new Set(['true', '1', 'yes', 'y', 'on', 'enable', 'enabled', '是', '启用', '开启'])
 const BOOLEAN_FALSE_TEXT = new Set(['false', '0', 'no', 'n', 'off', 'disable', 'disabled', '否', '禁用', '关闭'])
 
@@ -590,6 +628,7 @@ export function buildK3WiseWebApiConnectionFingerprint(form: K3WiseSetupForm): s
 }
 
 export function buildK3WiseSqlConnectionFingerprint(form: K3WiseSetupForm): string {
+  const sqlEndpoint = normalizeK3WiseSqlServerEndpoint(form.sqlServer, form.sqlPort)
   return fingerprintJson({
     tenantId: trim(form.tenantId),
     workspaceId: trim(form.workspaceId),
@@ -598,7 +637,8 @@ export function buildK3WiseSqlConnectionFingerprint(form: K3WiseSetupForm): stri
     hasCredentials: form.sqlHasCredentials === true,
     credentialDraftTouched: hasSqlCredentialDraft(form),
     mode: form.sqlMode,
-    server: trim(form.sqlServer),
+    server: sqlEndpoint.server,
+    port: sqlEndpoint.port,
     database: trim(form.sqlDatabase),
     allowedTables: normalizeListFingerprint(form.sqlAllowedTables),
     middleTables: normalizeListFingerprint(form.sqlMiddleTables),
@@ -760,6 +800,7 @@ export function createDefaultK3WiseSetupForm(): K3WiseSetupForm {
     sqlName: 'K3 WISE SQL Server',
     sqlMode: 'readonly',
     sqlServer: '',
+    sqlPort: '1433',
     sqlDatabase: '',
     sqlUsername: '',
     sqlPassword: '',
@@ -831,7 +872,7 @@ export function validateK3WiseSetupForm(form: K3WiseSetupForm): K3WiseSetupValid
   }
   if (form.sqlEnabled) {
     if (!trim(form.sqlName)) issues.push({ field: 'sqlName', message: 'SQL Server system name is required' })
-    if (!trim(form.sqlServer)) issues.push({ field: 'sqlServer', message: 'SQL Server host is required' })
+    validateSqlServerEndpoint(form, issues)
     if (!trim(form.sqlDatabase)) issues.push({ field: 'sqlDatabase', message: 'SQL Server database is required' })
     if (splitList(form.sqlAllowedTables).length === 0) {
       issues.push({ field: 'sqlAllowedTables', message: 'At least one SQL Server table must be allowed' })
@@ -873,7 +914,27 @@ export function validateK3WiseGateDraftForm(form: K3WiseSetupForm): K3WiseSetupV
   if (form.sqlEnabled && form.sqlMode !== 'readonly' && splitList(form.sqlMiddleTables).some(isK3CoreBusinessTable)) {
     issues.push({ field: 'sqlMiddleTables', message: 'Live PoC may not write K3 WISE core business tables' })
   }
+  if (form.sqlEnabled) {
+    validateSqlServerEndpoint(form, issues)
+  }
   return issues
+}
+
+function validateSqlServerEndpoint(form: K3WiseSetupForm, issues: K3WiseSetupValidationIssue[]): void {
+  const sqlEndpoint = normalizeK3WiseSqlServerEndpoint(form.sqlServer, form.sqlPort)
+  if (!trim(sqlEndpoint.server)) issues.push({ field: 'sqlServer', message: 'SQL Server host is required' })
+  if (!trim(sqlEndpoint.port)) {
+    issues.push({ field: 'sqlPort', message: 'SQL Server port is required' })
+  } else {
+    try {
+      parseOptionalTcpPort(sqlEndpoint.port, 'sqlPort')
+    } catch (error) {
+      issues.push({ field: 'sqlPort', message: error instanceof Error ? error.message : String(error) })
+    }
+  }
+  if (sqlEndpoint.embeddedPort && trim(form.sqlPort) && trim(form.sqlPort) !== sqlEndpoint.embeddedPort) {
+    issues.push({ field: 'sqlPort', message: 'SQL Server port must match the port embedded in Server' })
+  }
 }
 
 export function validateK3WisePipelineTemplateForm(
@@ -1210,6 +1271,8 @@ export function buildK3WiseGateDraft(form: K3WiseSetupForm): Record<string, unkn
       username: trim(form.username) || credentialPlaceholder(),
       password: credentialPlaceholder(),
     }
+  const sqlEndpoint = normalizeK3WiseSqlServerEndpoint(form.sqlServer, form.sqlPort)
+  const sqlPort = form.sqlEnabled ? parseOptionalTcpPort(sqlEndpoint.port, 'sqlPort') : undefined
 
   return {
     tenantId: resolveTenantId(form),
@@ -1239,7 +1302,8 @@ export function buildK3WiseGateDraft(form: K3WiseSetupForm): Record<string, unkn
     sqlServer: {
       enabled: form.sqlEnabled,
       mode: form.sqlEnabled ? form.sqlMode : 'readonly',
-      ...(optionalString(form.sqlServer) ? { server: trim(form.sqlServer) } : {}),
+      ...(optionalString(sqlEndpoint.server) ? { server: sqlEndpoint.server } : {}),
+      ...(form.sqlEnabled && sqlPort ? { port: sqlPort } : {}),
       ...(optionalString(form.sqlDatabase) ? { database: trim(form.sqlDatabase) } : {}),
       allowedTables: splitList(form.sqlAllowedTables),
       middleTables: splitList(form.sqlMiddleTables),
@@ -1427,7 +1491,7 @@ function collectIgnoredSecretWarnings(value: unknown, path: string, warnings: Se
 }
 
 function hasImportedSqlConfig(sqlServer: Record<string, unknown>): boolean {
-  return ['mode', 'server', 'database', 'allowedTables', 'middleTables', 'storedProcedures'].some((key) => {
+  return ['mode', 'server', 'host', 'port', 'database', 'allowedTables', 'middleTables', 'storedProcedures'].some((key) => {
     if (!hasOwn(sqlServer, key)) return false
     const value = sqlServer[key]
     if (Array.isArray(value)) return value.length > 0
@@ -1529,6 +1593,12 @@ export function applyK3WiseGateJsonToForm(form: K3WiseSetupForm, jsonText: strin
     if (hasOwn(sqlServer, 'allowedTables')) next.sqlAllowedTables = importedListText(sqlServer.allowedTables)
     if (hasOwn(sqlServer, 'middleTables')) next.sqlMiddleTables = importedListText(sqlServer.middleTables)
     if (hasOwn(sqlServer, 'storedProcedures')) next.sqlStoredProcedures = importedListText(sqlServer.storedProcedures)
+    const sqlPort = firstImportedString(sqlServer, ['port'])
+    if (sqlHost || sqlPort) {
+      const endpoint = normalizeK3WiseSqlServerEndpoint(sqlHost || next.sqlServer, sqlPort)
+      next.sqlServer = endpoint.server
+      next.sqlPort = endpoint.port || next.sqlPort
+    }
   }
 
   const rollbackOwner = firstImportedString(rollback, ['owner'])
@@ -1712,6 +1782,8 @@ export function buildK3WiseSetupPayloads(form: K3WiseSetupForm): K3WiseSetupPayl
   const sqlCredentials: Record<string, unknown> = {}
   if (trim(form.sqlUsername)) sqlCredentials.username = trim(form.sqlUsername)
   if (trim(form.sqlPassword)) sqlCredentials.password = form.sqlPassword
+  const sqlEndpoint = normalizeK3WiseSqlServerEndpoint(form.sqlServer, form.sqlPort)
+  const sqlPort = parseOptionalTcpPort(sqlEndpoint.port, 'sqlPort')
   const sqlServer = {
     ...baseSystem,
     ...(optionalString(form.sqlSystemId) ? { id: trim(form.sqlSystemId) } : {}),
@@ -1720,7 +1792,8 @@ export function buildK3WiseSetupPayloads(form: K3WiseSetupForm): K3WiseSetupPayl
     role: 'bidirectional',
     config: {
       mode: form.sqlMode,
-      server: trim(form.sqlServer),
+      server: sqlEndpoint.server,
+      ...(sqlPort ? { port: sqlPort } : {}),
       database: trim(form.sqlDatabase),
       allowedTables,
       middleTables,
@@ -1884,7 +1957,12 @@ export function applyExternalSystemToForm(form: K3WiseSetupForm, system: Integra
     next.workspaceId = system.workspaceId || ''
     next.sqlName = system.name
     next.sqlMode = typeof config.mode === 'string' ? config.mode as K3SqlServerMode : next.sqlMode
-    next.sqlServer = typeof config.server === 'string' ? config.server : next.sqlServer
+    const sqlEndpoint = normalizeK3WiseSqlServerEndpoint(
+      typeof config.server === 'string' ? config.server : next.sqlServer,
+      typeof config.port === 'string' || typeof config.port === 'number' ? String(config.port) : '',
+    )
+    next.sqlServer = sqlEndpoint.server
+    next.sqlPort = sqlEndpoint.port || next.sqlPort
     next.sqlDatabase = typeof config.database === 'string' ? config.database : next.sqlDatabase
     next.sqlAllowedTables = Array.isArray(config.allowedTables) ? config.allowedTables.join('\n') : next.sqlAllowedTables
     next.sqlMiddleTables = Array.isArray(config.middleTables) ? config.middleTables.join('\n') : next.sqlMiddleTables

--- a/apps/web/src/views/IntegrationK3WiseSetupView.vue
+++ b/apps/web/src/views/IntegrationK3WiseSetupView.vue
@@ -564,8 +564,13 @@
               </select>
             </label>
             <label class="k3-setup__field">
-              <span>Server</span>
-              <input v-model.trim="form.sqlServer" autocomplete="off" />
+              <span>Server / Host</span>
+              <input v-model.trim="form.sqlServer" placeholder="10.0.0.8" autocomplete="off" @blur="normalizeSqlServerDraft" />
+              <small>只填主机名或 IP；粘贴 10.0.0.8,1433 / 10.0.0.8:1433 会自动拆出端口。</small>
+            </label>
+            <label class="k3-setup__field">
+              <span>Port</span>
+              <input v-model.trim="form.sqlPort" inputmode="numeric" placeholder="1433" autocomplete="off" @blur="normalizeSqlServerDraft" />
             </label>
             <label class="k3-setup__field">
               <span>Database</span>
@@ -864,6 +869,7 @@ import {
   listIntegrationPipelineRuns,
   listIntegrationStagingDescriptors,
   listIntegrationSystems,
+  normalizeK3WiseSqlConnectionForm,
   runIntegrationPipeline,
   stringifyK3WiseGateDraft,
   summarizeK3WiseDeployGateChecklist,
@@ -1122,6 +1128,10 @@ function normalizeK3SetupProjectIdToScope(): void {
 function onK3SetupProjectIdInput(event: Event): void {
   const target = event.target as HTMLInputElement | null
   form.projectId = target?.value ?? ''
+}
+
+function normalizeSqlServerDraft(): void {
+  normalizeK3WiseSqlConnectionForm(form)
 }
 
 function setStatus(message: string, kind: 'info' | 'success' | 'error' = 'info'): void {

--- a/apps/web/tests/IntegrationK3WiseSetupView.spec.ts
+++ b/apps/web/tests/IntegrationK3WiseSetupView.spec.ts
@@ -349,6 +349,38 @@ describe('IntegrationK3WiseSetupView', () => {
     expect(container.textContent).toContain('Project ID 已规范化为 project_default:integration-core')
   })
 
+  it('shows a dedicated SQL Server port field and splits pasted host-port input', async () => {
+    const View = (await import('../src/views/IntegrationK3WiseSetupView.vue')).default
+
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    registerRouterLinkStub(app)
+    app.mount(container)
+    await flushUi()
+
+    const sqlSection = Array.from(container.querySelectorAll('details'))
+      .find((item) => item.textContent?.includes('高级 SQL Server 通道')) as HTMLDetailsElement | undefined
+    expect(sqlSection).toBeTruthy()
+    const sqlToggle = sqlSection!.querySelector('input[type="checkbox"]') as HTMLInputElement
+    sqlToggle.checked = true
+    sqlToggle.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+
+    const serverInput = inputByLabel(container, 'Server / Host')
+    const portInput = inputByLabel(container, 'Port')
+    expect(portInput.value).toBe('1433')
+    expect(container.textContent).toContain('粘贴 10.0.0.8,1433')
+
+    serverInput.value = '10.0.0.9,14330'
+    serverInput.dispatchEvent(new Event('input', { bubbles: true }))
+    serverInput.dispatchEvent(new Event('blur', { bubbles: true }))
+    await flushUi()
+
+    expect(serverInput.value).toBe('10.0.0.9')
+    expect(portInput.value).toBe('14330')
+  })
+
   it('opens installed staging multitable sheets from the setup page', async () => {
     const View = (await import('../src/views/IntegrationK3WiseSetupView.vue')).default
 

--- a/apps/web/tests/k3WiseSetup.spec.ts
+++ b/apps/web/tests/k3WiseSetup.spec.ts
@@ -23,6 +23,8 @@ import {
   getIntegrationStagingFieldCount,
   getK3WisePipelineId,
   listK3WiseDocumentTemplates,
+  normalizeK3WiseSqlConnectionForm,
+  normalizeK3WiseSqlServerEndpoint,
   splitList,
   stringifyK3WiseGateDraft,
   summarizeK3WiseDeployGateChecklist,
@@ -57,6 +59,7 @@ describe('K3 WISE setup helpers', () => {
       password: 'secret',
       sqlEnabled: true,
       sqlServer: '10.0.0.10',
+      sqlPort: '14330',
       sqlDatabase: 'AIS_TEST',
       sqlAllowedTables: 'dbo.t_ICItem\ndbo.t_ICBOM, dbo.t_ICBomChild',
       sqlMiddleTables: 'dbo.integration_material_stage',
@@ -86,10 +89,38 @@ describe('K3 WISE setup helpers', () => {
       kind: 'erp:k3-wise-sqlserver',
       role: 'bidirectional',
       config: {
+        server: '10.0.0.10',
+        port: 14330,
         allowedTables: ['dbo.t_ICItem', 'dbo.t_ICBOM', 'dbo.t_ICBomChild'],
         middleTables: ['dbo.integration_material_stage'],
       },
     })
+  })
+
+  it('normalizes SQL Server host and port from dedicated and legacy endpoint inputs', () => {
+    expect(normalizeK3WiseSqlServerEndpoint('10.0.0.8,1433')).toEqual({
+      server: '10.0.0.8',
+      port: '1433',
+      embeddedPort: '1433',
+    })
+    expect(normalizeK3WiseSqlServerEndpoint('sql.local:14330', '14330')).toEqual({
+      server: 'sql.local',
+      port: '14330',
+      embeddedPort: '14330',
+    })
+    expect(normalizeK3WiseSqlServerEndpoint('K3-SQL\\WISE,1433')).toEqual({
+      server: 'K3-SQL\\WISE',
+      port: '1433',
+      embeddedPort: '1433',
+    })
+
+    const form = createDefaultK3WiseSetupForm()
+    form.sqlServer = '10.0.0.8,1433'
+    form.sqlPort = ''
+    normalizeK3WiseSqlConnectionForm(form)
+
+    expect(form.sqlServer).toBe('10.0.0.8')
+    expect(form.sqlPort).toBe('1433')
   })
 
   it('builds K3 API authority-code token payloads from the setup form', () => {
@@ -655,6 +686,7 @@ describe('K3 WISE setup helpers', () => {
         enabled: true,
         mode: 'middle-table',
         server: '10.0.0.10',
+        port: 1433,
         database: 'AIS_TEST',
         middleTables: ['dbo.integration_material_stage'],
         writeCoreTables: false,
@@ -770,7 +802,7 @@ describe('K3 WISE setup helpers', () => {
       sqlServer: {
         enabled: true,
         mode: 'middle-table',
-        server: '10.0.0.10',
+        server: '10.0.0.10,14330',
         database: 'AIS_TEST',
         username: 'sql-user',
         password: 'sql-secret',
@@ -808,6 +840,7 @@ describe('K3 WISE setup helpers', () => {
       sqlEnabled: true,
       sqlMode: 'middle-table',
       sqlServer: '10.0.0.10',
+      sqlPort: '14330',
       sqlDatabase: 'AIS_TEST',
       sqlUsername: 'sql-user',
       sqlPassword: '',
@@ -823,6 +856,29 @@ describe('K3 WISE setup helpers', () => {
     expect(result.warnings).toContain('plm.credentials.token ignored; enter it in the credential form if needed')
     expect(result.warnings).toContain('sqlServer.password ignored; enter it in the credential form if needed')
     expect(result.warnings).not.toContain('k3Wise.tokenPath ignored; enter it in the credential form if needed')
+  })
+
+  it('loads saved SQL Server systems with a canonical host and port', () => {
+    const form = createDefaultK3WiseSetupForm()
+    const next = applyExternalSystemToForm(form, {
+      id: 'sql_1',
+      tenantId: 'default',
+      workspaceId: null,
+      name: 'K3 SQL loaded',
+      kind: 'erp:k3-wise-sqlserver',
+      role: 'bidirectional',
+      status: 'active',
+      config: {
+        mode: 'readonly',
+        server: '10.0.0.8,14330',
+        database: 'AIS_TEST',
+        allowedTables: ['dbo.t_ICItem'],
+      },
+      capabilities: {},
+    })
+
+    expect(next.sqlServer).toBe('10.0.0.8')
+    expect(next.sqlPort).toBe('14330')
   })
 
   it('rejects invalid customer GATE JSON before applying it to the form', () => {

--- a/docs/development/data-factory-k3wise-sql-port-field-design-20260519.md
+++ b/docs/development/data-factory-k3wise-sql-port-field-design-20260519.md
@@ -1,0 +1,87 @@
+# Data Factory K3 WISE SQL port field design - 2026-05-19
+
+## Purpose
+
+This slice follows the entity-machine feedback that the K3 WISE SQL Server
+advanced connection form did not make port entry obvious. Operators had to know
+whether to put the port into `Server`, and the saved SQL connection payload did
+not carry an explicit `port` field for downstream verification.
+
+The runtime change is frontend-only, with one matching operator-script update so
+the live PoC preflight packet preserves the same `sqlServer.port` contract. It
+does not add migrations, backend routes, SQL executor behavior, K3 WebAPI
+read/list runtime, or integration-core changes.
+
+## Prior dependency
+
+PR #1684 was merged first and closed the backend/package wrapper gap for the
+same issue-1526 delivery path. This PR starts from `origin/main` after that
+merge (`66d74119a`) and only improves the K3 WISE setup form contract.
+
+## Changes
+
+### Dedicated SQL Server port field
+
+The K3 WISE setup page now shows two separate SQL Server endpoint inputs:
+
+- `Server / Host`
+- `Port`
+
+The port defaults to `1433`, matching SQL Server's standard TCP port and the
+existing operator expectation for K3 WISE deployments.
+
+### Legacy paste compatibility
+
+Operators can still paste either legacy endpoint shape into the host field:
+
+- `10.0.0.8,1433`
+- `10.0.0.8:1433`
+- `K3-SQL\WISE,1433`
+
+On blur, the form canonicalizes the values into:
+
+- `sqlServer = 10.0.0.8`
+- `sqlPort = 1433`
+
+If both an embedded host-port value and a dedicated port are present, validation
+requires them to match. This avoids silently saving a misleading pair such as
+`10.0.0.8,1433` plus `14330`.
+
+### Payload and GATE contract
+
+The setup helpers now persist SQL Server configuration as canonical host plus
+port:
+
+```json
+{
+  "config": {
+    "server": "10.0.0.10",
+    "port": 14330,
+    "database": "AIS_TEST"
+  }
+}
+```
+
+GATE draft export/import follows the same shape through
+`sqlServer.port`. Imported customer JSON may still provide a legacy host string
+with embedded port; the importer splits it before writing to the form.
+
+The live PoC preflight packet builder now also validates and copies
+`sqlServer.port` into the generated SQL external-system config. That keeps the
+operator-facing GATE package and the script-generated packet aligned for
+non-default SQL Server ports.
+
+### Saved-system reload
+
+When an existing `erp:k3-wise-sqlserver` external system is loaded back into the
+setup form, the helper normalizes `config.server` and `config.port` into the
+dedicated fields. This keeps old saved values readable while making the new UI
+unambiguous.
+
+## Non-goals
+
+- No SQL Server executor injection.
+- No K3 WebAPI read/list runtime.
+- No real K3 Save / Submit / Audit behavior change.
+- No Data Factory route or navigation change.
+- No package build or release workflow change.

--- a/docs/development/data-factory-k3wise-sql-port-field-verification-20260519.md
+++ b/docs/development/data-factory-k3wise-sql-port-field-verification-20260519.md
@@ -1,0 +1,145 @@
+# Data Factory K3 WISE SQL port field verification - 2026-05-19
+
+## Scope
+
+Branch: `codex/k3-sql-port-field-20260519`
+
+Files changed:
+
+- `apps/web/src/services/integration/k3WiseSetup.ts`
+- `apps/web/src/views/IntegrationK3WiseSetupView.vue`
+- `apps/web/tests/k3WiseSetup.spec.ts`
+- `apps/web/tests/IntegrationK3WiseSetupView.spec.ts`
+- `scripts/ops/integration-k3wise-live-poc-preflight.mjs`
+- `scripts/ops/integration-k3wise-live-poc-preflight.test.mjs`
+- `scripts/ops/fixtures/integration-k3wise/gate-sample.json`
+- `scripts/ops/fixtures/integration-k3wise/gate-intake-template.json`
+- `docs/development/data-factory-k3wise-sql-port-field-design-20260519.md`
+- `docs/development/data-factory-k3wise-sql-port-field-verification-20260519.md`
+
+No backend, plugin runtime, migration, API route, or package script changed. The
+ops script change is limited to preserving and validating `sqlServer.port` in
+the live PoC packet builder.
+
+## Local verification
+
+### Focused K3 setup specs
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/k3WiseSetup.spec.ts tests/IntegrationK3WiseSetupView.spec.ts --watch=false
+```
+
+Result:
+
+```text
+Test Files  2 passed (2)
+Tests       49 passed (49)
+```
+
+Covered assertions:
+
+- SQL Server setup payload writes canonical `server` plus numeric `port`.
+- GATE draft includes `sqlServer.port`.
+- Customer GATE JSON import splits `server: "10.0.0.10,14330"` into host and
+  port fields.
+- Legacy Windows named-instance input such as `K3-SQL\WISE,1433` is split
+  without dropping the instance segment.
+- Saved SQL Server external systems reload into canonical host and port fields.
+- The K3 WISE setup page displays a dedicated `Port` input with default `1433`.
+- Pasting `10.0.0.9,14330` into `Server / Host` splits the form on blur.
+
+### Live PoC preflight packet
+
+Command:
+
+```bash
+pnpm run verify:integration-k3wise:poc
+```
+
+Result:
+
+```text
+K3 WISE PoC mock chain verified end-to-end (PASS)
+exit 0
+```
+
+Covered assertions:
+
+- `sqlServer.port: "14330"` is validated and emitted as numeric
+  `config.port: 14330` in the generated SQL external-system packet.
+- Invalid SQL Server ports such as `0`, `65536`, `abc`, and `1433.5` are
+  rejected before packet generation.
+- `gate-sample.json` remains equivalent to `--print-sample`, including the new
+  `sqlServer.port` sample value.
+- `gate-intake-template.json` remains accepted by the preflight parser.
+- Existing Save-only, secret-redaction, SQL core-table guard, and K3/PLM
+  mapping checks remain green across the full offline PoC chain.
+
+### Type-check
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+```
+
+Result: exit 0.
+
+### Production build
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result:
+
+```text
+vue-tsc -b && vite build
+built in 5.79s
+exit 0
+```
+
+The build emitted the existing large-chunk warning and the existing
+`WorkflowDesigner.vue` dynamic/static import warning. Neither warning is caused
+by this SQL port field change.
+
+### Diff hygiene
+
+Command:
+
+```bash
+git diff --check origin/main...HEAD
+```
+
+Result: exit 0.
+
+## Behavior matrix
+
+| Scenario | Expected result | Covered by |
+| --- | --- | --- |
+| Fresh form | `sqlPort` defaults to `1433` | K3 setup view spec |
+| Paste `host,port` | Host and port split on blur | K3 setup view spec |
+| Paste `host:port` | Helper parses legacy colon form | K3 setup helper spec |
+| Save SQL connection | Payload stores `config.server` and `config.port` | K3 setup helper spec |
+| Export GATE draft | Draft includes `sqlServer.port` when SQL channel enabled | K3 setup helper spec |
+| Import GATE draft | Embedded port from `sqlServer.server` is preserved | K3 setup helper spec |
+| Reload saved system | Existing non-default host-port string is canonicalized without falling back to `1433` | K3 setup helper spec |
+| Build live PoC packet | Dedicated `sqlServer.port` reaches SQL external-system `config.port` | Preflight script spec |
+| Invalid live PoC port | Invalid TCP ports fail before packet generation | Preflight script spec |
+
+## Deployment impact
+
+This is a frontend/operator-form improvement plus a matching preflight packet
+contract update. Existing saved SQL Server connections remain readable because
+the loader accepts both:
+
+- legacy `config.server = "host,port"`
+- canonical `config.server = "host"` plus `config.port = 1433`
+
+The next on-prem package retest should confirm the K3 WISE setup page displays
+the separate port field and no longer asks operators to encode the port inside
+the server field.

--- a/scripts/ops/fixtures/integration-k3wise/gate-intake-template.json
+++ b/scripts/ops/fixtures/integration-k3wise/gate-intake-template.json
@@ -54,6 +54,7 @@
     "enabled": false,
     "mode": "disabled",
     "server": "<customer-sqlserver-host>",
+    "port": 1433,
     "database": "AIS_TEST",
     "allowedTables": [],
     "middleTables": [],

--- a/scripts/ops/fixtures/integration-k3wise/gate-sample.json
+++ b/scripts/ops/fixtures/integration-k3wise/gate-sample.json
@@ -29,6 +29,7 @@
     "enabled": true,
     "mode": "readonly",
     "server": "10.0.0.10",
+    "port": 1433,
     "database": "AIS_TEST",
     "allowedTables": ["t_ICItem", "t_MeasureUnit"]
   },

--- a/scripts/ops/integration-k3wise-live-poc-preflight.mjs
+++ b/scripts/ops/integration-k3wise-live-poc-preflight.mjs
@@ -135,6 +135,27 @@ function normalizeMaterialSampleLimit(value, field = 'k3Wise.sampleLimit') {
   return parsed
 }
 
+function normalizeOptionalTcpPort(value, field) {
+  if (value === undefined || value === null || value === '') return undefined
+  let parsed
+  if (typeof value === 'number') {
+    parsed = value
+  } else if (typeof value === 'string') {
+    const normalized = value.trim()
+    if (normalized.length === 0) return undefined
+    parsed = Number(normalized)
+  } else {
+    throw new LivePocPreflightError(`${field} must be a TCP port between 1 and 65535`, { field })
+  }
+  if (!Number.isInteger(parsed) || parsed <= 0 || parsed > 65535) {
+    throw new LivePocPreflightError(`${field} must be a TCP port between 1 and 65535`, {
+      field,
+      received: value,
+    })
+  }
+  return parsed
+}
+
 function normalizeSqlMode(value, sqlEnabled) {
   const fallback = sqlEnabled ? 'readonly' : 'disabled'
   const text = optionalString(value)
@@ -356,6 +377,7 @@ function normalizeGate(input) {
   const sqlEnabled = normalizeSafeBoolean(sqlServer.enabled, 'sqlServer.enabled')
   const sqlWriteCoreFlag = normalizeSafeBoolean(sqlServer.writeCoreTables, 'sqlServer.writeCoreTables')
   const sqlMode = normalizeSqlMode(sqlServer.mode, sqlEnabled)
+  const sqlPort = normalizeOptionalTcpPort(sqlServer.port, 'sqlServer.port')
   const allowedTables = optionalArray(sqlServer.allowedTables, 'sqlServer.allowedTables').map((table) => String(table))
   const writesCoreTable = allowedTables.some((table) => K3_CORE_TABLES.has(normalizeSqlObjectName(table)))
   if (sqlEnabled && sqlMode !== 'readonly' && (sqlWriteCoreFlag || writesCoreTable)) {
@@ -399,6 +421,18 @@ function normalizeGate(input) {
   requiredString(rollback.owner, 'rollback.owner')
   requiredString(rollback.strategy, 'rollback.strategy')
 
+  const normalizedSqlServer = {
+    ...sqlServer,
+    enabled: sqlEnabled,
+    writeCoreTables: sqlWriteCoreFlag,
+    mode: sqlMode,
+  }
+  if (sqlPort === undefined) {
+    delete normalizedSqlServer.port
+  } else {
+    normalizedSqlServer.port = sqlPort
+  }
+
   return {
     tenantId,
     workspaceId,
@@ -412,12 +446,7 @@ function normalizeGate(input) {
       sampleLimit: normalizeMaterialSampleLimit(k3Wise.sampleLimit),
     },
     plm,
-    sqlServer: {
-      ...sqlServer,
-      enabled: sqlEnabled,
-      writeCoreTables: sqlWriteCoreFlag,
-      mode: sqlMode,
-    },
+    sqlServer: normalizedSqlServer,
     rollback,
     fieldMappings,
     bom: {
@@ -521,6 +550,7 @@ function buildExternalSystems(gate) {
       config: {
         mode: gate.sqlMode,
         server: optionalString(gate.sqlServer.server) || '<provided-by-customer>',
+        ...(Number.isInteger(gate.sqlServer.port) ? { port: gate.sqlServer.port } : {}),
         database: optionalString(gate.sqlServer.database) || '<provided-by-customer>',
         allowedTables: optionalArray(gate.sqlServer.allowedTables, 'sqlServer.allowedTables'),
         middleTables: optionalArray(gate.sqlServer.middleTables, 'sqlServer.middleTables'),
@@ -767,6 +797,7 @@ function sampleGate() {
       enabled: true,
       mode: 'readonly',
       server: '10.0.0.10',
+      port: 1433,
       database: 'AIS_TEST',
       allowedTables: ['t_ICItem', 't_MeasureUnit'],
     },

--- a/scripts/ops/integration-k3wise-live-poc-preflight.test.mjs
+++ b/scripts/ops/integration-k3wise-live-poc-preflight.test.mjs
@@ -141,6 +141,40 @@ test('buildPacket normalizes safe customer formatting variants', () => {
   assert.equal(packet.externalSystems.find((system) => system.kind === 'erp:k3-wise-sqlserver').config.mode, 'readonly')
 })
 
+test('buildPacket preserves SQL Server port in external-system packet', () => {
+  const packet = buildPacket(gate({
+    sqlServer: {
+      enabled: true,
+      mode: 'readonly',
+      server: '10.0.0.10',
+      port: '14330',
+      allowedTables: ['T_ICITEM'],
+    },
+  }))
+  const sql = packet.externalSystems.find((system) => system.kind === 'erp:k3-wise-sqlserver')
+
+  assert.equal(sql.config.server, '10.0.0.10')
+  assert.equal(sql.config.port, 14330)
+})
+
+test('buildPacket rejects invalid SQL Server port values', () => {
+  for (const port of ['0', '65536', 'abc', 1433.5]) {
+    assert.throws(
+      () => buildPacket(gate({
+        sqlServer: {
+          enabled: true,
+          mode: 'readonly',
+          server: '10.0.0.10',
+          port,
+          allowedTables: ['T_ICITEM'],
+        },
+      })),
+      (error) => error instanceof LivePocPreflightError && error.details.field === 'sqlServer.port',
+      `port=${String(port)} must be rejected`,
+    )
+  }
+})
+
 test('buildPacket rejects truthy Submit/Audit strings and invalid flag values', () => {
   for (const k3Wise of [
     { autoSubmit: 'true' },


### PR DESCRIPTION
## Summary

- add a dedicated SQL Server `Port` field to the K3 WISE setup advanced SQL channel
- normalize pasted legacy `host,port` / `host:port` / Windows named-instance `HOST\INSTANCE,port` input into canonical host + port fields
- persist and reload SQL Server connections with explicit `config.port`, and include `sqlServer.port` in GATE draft import/export
- preserve and validate `sqlServer.port` in the live PoC preflight packet builder so GATE export and generated packets stay aligned
- add design and verification docs for the operator-facing contract

## Verification

- `pnpm --filter @metasheet/web exec vitest run tests/k3WiseSetup.spec.ts tests/IntegrationK3WiseSetupView.spec.ts --watch=false`
- `node --test scripts/ops/integration-k3wise-live-poc-preflight.test.mjs`
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit`
- `pnpm --filter @metasheet/web build`
- `git diff --check`

## Deployment impact

Frontend/operator-form change plus matching preflight packet contract update. No backend route, migration, plugin runtime, SQL executor, or K3 Save/Submit/Audit behavior changes. Existing saved SQL Server values remain readable because both legacy `server = host,port` and canonical `server + port` shapes are accepted.