### PR TITLE
feat(ops): add staging migration alignment report

### DIFF
--- a/docs/development/staging-migration-alignment-runbook-development-20260519.md
+++ b/docs/development/staging-migration-alignment-runbook-development-20260519.md
@@ -1,0 +1,104 @@
+# Staging Migration Alignment Runbook Development
+
+Date: 2026-05-19
+
+## Summary
+
+This slice turns the previous attendance staging migration audit into a reusable
+read-only operator tool and updates the staging migration runbook to require the
+tool before any alignment action.
+
+The implementation is intentionally non-mutating:
+
+- no DB connection is opened by the new script;
+- no migration is executed;
+- no `kysely_migration` row is written;
+- no staging/prod secret is read;
+- output goes under `output/` and is not committed.
+
+## Files
+
+| File | Change |
+| --- | --- |
+| `scripts/ops/staging-migration-alignment-report.mjs` | New read-only parser/classifier for `migrate --list` output. |
+| `scripts/ops/staging-migration-alignment-report.test.mjs` | Unit tests for staging-style pending list, non-idempotent SQL detection, aligned state, and missing input. |
+| `docs/operations/staging-migration-alignment-runbook.md` | Adds a 2026-05-20 safety update requiring the report before Option A or full migrate. |
+| `docs/development/staging-migration-alignment-runbook-development-20260519.md` | This development record. |
+| `docs/development/staging-migration-alignment-runbook-verification-20260519.md` | Verification record. |
+
+## Script Contract
+
+Input options:
+
+```bash
+node scripts/ops/staging-migration-alignment-report.mjs \
+  --migrate-list-file <file> \
+  --out-dir output/staging-migration-alignment-report/<run>
+```
+
+or:
+
+```bash
+node scripts/ops/staging-migration-alignment-report.mjs --run-list
+```
+
+or stdin:
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsx src/db/migrate.ts --list \
+  | node scripts/ops/staging-migration-alignment-report.mjs
+```
+
+Output:
+
+- `report.json`
+- `report.md`
+
+The script parses:
+
+- `Applied: N`
+- `Pending: N`
+- pending migration names under `Pending migrations (in load order):`
+
+It reads the local migration provider to classify superseded legacy SQL names
+instead of hard-coding the `032` through `055` range manually.
+
+## Classification
+
+| Category | Rule |
+| --- | --- |
+| `superseded_legacy_noop_marker` | Name appears in `SUPERSEDED_LEGACY_SQL_MIGRATIONS`. |
+| `legacy_executable_sql` | Name starts with a numeric legacy prefix and is not superseded. |
+| `timestamp_sql` | Name starts with an 8-digit timestamp prefix. |
+| `modern_timestamp_migration` | Name starts with `zzzz`. |
+| `other` | Fallback for unexpected names. |
+
+## Risk Heuristics
+
+| Risk | Rule |
+| --- | --- |
+| `ledger_review` | Superseded legacy no-op marker; requires ledger/schema review but does not imply DDL replay. |
+| `high` | Local migration up path contains `CREATE TABLE` without `IF NOT EXISTS`, Kysely `.createTable()` without `.ifNotExists()`, or a `DROP` statement. |
+| `medium` | Legacy/timestamp SQL, or unguarded-looking `ALTER TABLE`. |
+| `low` | No obvious replay risk detected by static scan. |
+| `unknown` | Local migration file was not found. |
+
+For TypeScript migrations, the static scan only examines the `up()` body. A
+rollback-only `down()` `DROP TABLE` is not treated as a replay risk for applying
+pending migrations.
+
+## Decision Heuristic
+
+| Decision | Meaning |
+| --- | --- |
+| `aligned` | `Pending: 0`; no action needed. |
+| `do_not_run_full_migrate` | At least one high-risk pending migration exists. Rehearse on clone/backup first. |
+| `rehearse_before_migrate` | Pending executable migrations exist but no high-risk static signal was found. |
+| `ledger_review_only` | Only superseded no-op marker names are pending. |
+
+## Boundaries
+
+- The script is a report generator, not a migration runner.
+- The script does not classify a migration as safe to replay based only on name.
+- The runbook now explicitly blocks blind synthetic catch-up when the report says `do_not_run_full_migrate`.
+- Claude is not needed for development; independent review is appropriate after PR creation.

--- a/docs/development/staging-migration-alignment-runbook-verification-20260519.md
+++ b/docs/development/staging-migration-alignment-runbook-verification-20260519.md
@@ -1,0 +1,115 @@
+# Staging Migration Alignment Runbook Verification
+
+Date: 2026-05-19
+
+## Scope
+
+Verify the read-only staging migration alignment report script and runbook
+update.
+
+No staging DB migration was executed.
+
+## Checks
+
+| Check | Result |
+| --- | --- |
+| `node --check scripts/ops/staging-migration-alignment-report.mjs` | PASS |
+| `node --test scripts/ops/staging-migration-alignment-report.test.mjs` | PASS |
+| Fixture: staging-style pending list classification | PASS |
+| Fixture: no pending migrations returns `aligned` | PASS |
+| Fixture: no input fails clearly | PASS |
+| Static scan: `20250926_create_audit_tables` flagged high risk | PASS |
+| Static scan: TypeScript `down()` drops are ignored for replay risk | PASS |
+| Live staging read-only report generation | PASS |
+| `git diff --check` | PASS |
+
+## Test Evidence
+
+The staging-style fixture intentionally mirrors the 2026-05-19 audit shape:
+
+- `Applied: 86`
+- `Pending: 77`
+- 29 superseded legacy no-op marker names
+- 5 legacy executable SQL names
+- 2 timestamp SQL names
+- several modern `zzzz` names
+
+The test asserts:
+
+- `fullMigrateRecommended=false`
+- `decision=do_not_run_full_migrate`
+- `categoryCounts.superseded_legacy_noop_marker=29`
+- `categoryCounts.legacy_executable_sql=5`
+- `categoryCounts.timestamp_sql=2`
+
+The non-idempotent SQL fixture asserts:
+
+- `20250926_create_audit_tables` is categorized as `timestamp_sql`
+- risk is `high`
+- `hasCreateTableWithoutIfNotExists=true`
+
+The TypeScript migration fixture asserts:
+
+- `zzzz20260519070000_create_plugin_attendance_report_sync_jobs` is categorized
+  as `modern_timestamp_migration`
+- `down()` contains rollback DDL but does not make the migration high risk
+- `hasDropStatement=false` for the scanned replay path
+
+## Live Staging Read-Only Report
+
+Generated from staging `migrate --list` output on 2026-05-19 without executing
+any migration:
+
+| Metric | Value |
+| --- | --- |
+| Applied migrations | 86 |
+| Pending migrations | 77 |
+| Parsed pending names | 77 |
+| Decision | `do_not_run_full_migrate` |
+| Full migrate recommended | `false` |
+
+Category counts:
+
+| Category | Count |
+| --- | --- |
+| `legacy_executable_sql` | 5 |
+| `superseded_legacy_noop_marker` | 29 |
+| `timestamp_sql` | 2 |
+| `modern_timestamp_migration` | 41 |
+
+Risk counts after the `up()`-only scan fix:
+
+| Risk | Count |
+| --- | --- |
+| `high` | 12 |
+| `ledger_review` | 29 |
+| `medium` | 5 |
+| `low` | 31 |
+
+The report output was written under local untracked `output/` for operator
+review and is intentionally not committed.
+
+## Boundary Verification
+
+- No token/JWT paths are used or committed.
+- No `DATABASE_URL` is required for fixture mode.
+- No DB write path exists in the new script.
+- The runbook update only adds a safety pre-step; it does not remove the historical runbook content.
+
+## Recommended Operator Use
+
+For staging:
+
+```bash
+docker compose -f docker-compose.app.staging.yml exec -T backend \
+  node packages/core-backend/dist/src/db/migrate.js --list \
+  > /tmp/staging-migrate-list.txt
+
+node scripts/ops/staging-migration-alignment-report.mjs \
+  --migrate-list-file /tmp/staging-migrate-list.txt \
+  --out-dir output/staging-migration-alignment-report/<run>
+```
+
+Then read `report.md`. If the decision is `do_not_run_full_migrate`, rehearse
+against a DB clone or backup before running migrations or editing
+`kysely_migration`.

--- a/docs/operations/staging-migration-alignment-runbook.md
+++ b/docs/operations/staging-migration-alignment-runbook.md
@@ -1,5 +1,28 @@
 # Staging Migration Alignment Runbook
 
+## 2026-05-20 Safety Update
+
+Before choosing any alignment option, generate a read-only migration alignment
+report:
+
+```bash
+docker compose -f docker-compose.app.staging.yml exec -T backend \
+  node packages/core-backend/dist/src/db/migrate.js --list \
+  > /tmp/staging-migrate-list.txt
+
+node scripts/ops/staging-migration-alignment-report.mjs \
+  --migrate-list-file /tmp/staging-migrate-list.txt \
+  --out-dir output/staging-migration-alignment-report/<run>
+```
+
+Read `report.md` before running or marking migrations. The report classifies
+pending names into superseded legacy no-op markers, executable legacy SQL,
+timestamp SQL, and modern migrations, and flags obvious replay risks such as
+`CREATE TABLE` without `IF NOT EXISTS`.
+
+Do **not** apply Option A or run full `migrate --latest` when the report says
+`do_not_run_full_migrate`. Use a cloned or backed-up rehearsal DB first.
+
 This runbook handles the case where a target env's `kysely_migration`
 table is **out of sync with the actual schema state** — typically
 manifests as `pnpm migrate` failing on an old migration that

--- a/scripts/ops/staging-migration-alignment-report.mjs
+++ b/scripts/ops/staging-migration-alignment-report.mjs
@@ -1,0 +1,382 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const REPO_ROOT = path.resolve(__dirname, '../..')
+
+function parseArgs(argv) {
+  const opts = {
+    migrateListFile: '',
+    outDir: 'output/staging-migration-alignment-report',
+    runList: false,
+    title: 'Staging migration alignment report',
+  }
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    if (arg === '--migrate-list-file') {
+      opts.migrateListFile = argv[++i] || ''
+    } else if (arg === '--out-dir') {
+      opts.outDir = argv[++i] || ''
+    } else if (arg === '--run-list') {
+      opts.runList = true
+    } else if (arg === '--title') {
+      opts.title = argv[++i] || opts.title
+    } else if (arg === '--help' || arg === '-h') {
+      opts.help = true
+    } else {
+      throw new Error(`Unknown argument: ${arg}`)
+    }
+  }
+
+  return opts
+}
+
+function printHelp() {
+  console.log(`Usage:
+  node scripts/ops/staging-migration-alignment-report.mjs --migrate-list-file <file> [--out-dir <dir>]
+  node scripts/ops/staging-migration-alignment-report.mjs --run-list [--out-dir <dir>]
+  cat migrate-list.txt | node scripts/ops/staging-migration-alignment-report.mjs [--out-dir <dir>]
+
+This script is read-only. It parses \`migrate --list\` output, classifies pending
+migrations, scans local migration files for obvious replay risk, and writes
+report.json + report.md.`)
+}
+
+function readStdinIfAvailable() {
+  if (process.stdin.isTTY) return ''
+  return readFileSync(0, 'utf8')
+}
+
+function runMigrateList() {
+  const result = spawnSync(
+    'pnpm',
+    ['--silent', '--filter', '@metasheet/core-backend', 'exec', 'tsx', 'src/db/migrate.ts', '--list'],
+    {
+      cwd: REPO_ROOT,
+      env: process.env,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  )
+
+  if (result.error) {
+    throw new Error(`Failed to spawn migrate --list: ${result.error.message}`)
+  }
+  if (result.status !== 0) {
+    throw new Error(`migrate --list failed with exit ${result.status}: ${String(result.stderr || '').slice(0, 1200)}`)
+  }
+  return result.stdout
+}
+
+function readMigrateList(opts) {
+  if (opts.migrateListFile) {
+    return readFileSync(path.resolve(opts.migrateListFile), 'utf8')
+  }
+  if (opts.runList) return runMigrateList()
+  const stdin = readStdinIfAvailable()
+  if (stdin.trim()) return stdin
+  throw new Error('Provide --migrate-list-file, --run-list, or pipe migrate --list output on stdin.')
+}
+
+function parseMigrateList(text) {
+  const appliedMatch = text.match(/Applied:\s*(\d+)/i)
+  const pendingMatch = text.match(/Pending:\s*(\d+)/i)
+  if (!appliedMatch || !pendingMatch) {
+    throw new Error('Unable to parse Applied/Pending counts from migrate --list output.')
+  }
+
+  const pending = []
+  let inPending = false
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = rawLine.trim()
+    if (/^Pending migrations/i.test(line)) {
+      inPending = true
+      continue
+    }
+    if (!inPending) continue
+    const match = line.match(/^-\s+(.+)$/)
+    if (match) pending.push(match[1].trim())
+  }
+
+  return {
+    applied: Number.parseInt(appliedMatch[1], 10),
+    pending: Number.parseInt(pendingMatch[1], 10),
+    pendingNames: pending,
+  }
+}
+
+function loadSupersededLegacyNames() {
+  const providerPath = path.join(REPO_ROOT, 'packages/core-backend/src/db/migration-provider.ts')
+  const source = readFileSync(providerPath, 'utf8')
+  const match = source.match(/SUPERSEDED_LEGACY_SQL_MIGRATIONS\s*=\s*\[([\s\S]*?)\]/)
+  if (!match) return new Set()
+  return new Set([...match[1].matchAll(/'([^']+)'/g)].map((it) => it[1]))
+}
+
+function findMigrationFile(name) {
+  const candidates = [
+    path.join(REPO_ROOT, 'packages/core-backend/src/db/migrations', `${name}.ts`),
+    path.join(REPO_ROOT, 'packages/core-backend/src/db/migrations', `${name}.js`),
+    path.join(REPO_ROOT, 'packages/core-backend/src/db/migrations', `${name}.sql`),
+    path.join(REPO_ROOT, 'packages/core-backend/migrations', `${name}.sql`),
+    path.join(REPO_ROOT, 'packages/core-backend/migrations', `${name}.ts`),
+    path.join(REPO_ROOT, 'packages/core-backend/migrations', `${name}.js`),
+  ]
+  return candidates.find((candidate) => existsSync(candidate)) || ''
+}
+
+function classifyName(name, supersededLegacyNames) {
+  if (supersededLegacyNames.has(name)) return 'superseded_legacy_noop_marker'
+  if (/^\d{3}_/.test(name)) return 'legacy_executable_sql'
+  if (/^\d{8}_/.test(name)) return 'timestamp_sql'
+  if (/^zzzz\d+_/.test(name)) return 'modern_timestamp_migration'
+  return 'other'
+}
+
+function analyzeMigrationFile(filePath) {
+  if (!filePath) {
+    return {
+      filePath: '',
+      fileKind: 'missing',
+      hasCreateTableWithoutIfNotExists: false,
+      hasKyselyCreateTableWithoutIfNotExists: false,
+      hasDropStatement: false,
+      hasAlterTable: false,
+      hasIfNotExists: false,
+      hasCheckTableExistsGuard: false,
+    }
+  }
+  const source = readFileSync(filePath, 'utf8')
+  const upSource = extractUpSource(source)
+  return {
+    filePath: path.relative(REPO_ROOT, filePath),
+    fileKind: path.extname(filePath).replace(/^\./, '') || 'unknown',
+    hasCreateTableWithoutIfNotExists: /CREATE\s+TABLE\s+(?!IF\s+NOT\s+EXISTS)/i.test(upSource),
+    hasKyselyCreateTableWithoutIfNotExists: hasUnguardedKyselyCreateTable(upSource),
+    hasDropStatement: /\bDROP\s+(TABLE|COLUMN|INDEX|CONSTRAINT|DATABASE)\b/i.test(upSource),
+    hasAlterTable: /\bALTER\s+TABLE\b/i.test(upSource),
+    hasIfNotExists: /IF\s+NOT\s+EXISTS|\.ifNotExists\s*\(/i.test(upSource),
+    hasCheckTableExistsGuard: /checkTableExists|to_regclass\s*\(/i.test(upSource),
+  }
+}
+
+function extractUpSource(source) {
+  const upMatch = source.match(/export\s+async\s+function\s+up\b|async\s+function\s+up\b/)
+  if (!upMatch || upMatch.index === undefined) return source
+  const downMatch = source.slice(upMatch.index + upMatch[0].length).match(/export\s+async\s+function\s+down\b|async\s+function\s+down\b/)
+  if (!downMatch || downMatch.index === undefined) return source.slice(upMatch.index)
+  return source.slice(upMatch.index, upMatch.index + upMatch[0].length + downMatch.index)
+}
+
+function hasUnguardedKyselyCreateTable(source) {
+  const calls = [...source.matchAll(/\.createTable\s*\([^)]*\)([\s\S]*?)(?=\.execute\s*\(\s*\)|;)/g)]
+  return calls.some((call) => !/\.ifNotExists\s*\(/.test(call[1]))
+}
+
+function riskFor(category, fileInfo) {
+  if (category === 'superseded_legacy_noop_marker') {
+    return {
+      level: 'ledger_review',
+      reason: 'Provider treats this legacy SQL name as a visible no-op marker by default.',
+    }
+  }
+  if (fileInfo.fileKind === 'missing') {
+    return {
+      level: 'unknown',
+      reason: 'No local migration file was found for this name.',
+    }
+  }
+  if (fileInfo.hasCreateTableWithoutIfNotExists || fileInfo.hasKyselyCreateTableWithoutIfNotExists || fileInfo.hasDropStatement) {
+    return {
+      level: 'high',
+      reason: 'Migration up path contains non-idempotent-looking CREATE TABLE or DROP statement.',
+    }
+  }
+  if (category === 'legacy_executable_sql' || category === 'timestamp_sql') {
+    return {
+      level: 'medium',
+      reason: 'Legacy/timestamp SQL should be rehearsed before replaying on a drifted DB.',
+    }
+  }
+  if (fileInfo.hasAlterTable && !fileInfo.hasIfNotExists && !fileInfo.hasCheckTableExistsGuard) {
+    return {
+      level: 'medium',
+      reason: 'ALTER TABLE migration lacks an obvious IF NOT EXISTS or table-existence guard.',
+    }
+  }
+  return {
+    level: 'low',
+    reason: 'No obvious replay risk detected by static scan.',
+  }
+}
+
+function countBy(items, key) {
+  const counts = {}
+  for (const item of items) {
+    const value = item[key]
+    counts[value] = (counts[value] || 0) + 1
+  }
+  return counts
+}
+
+function buildReport(migrateList, opts) {
+  const supersededLegacyNames = loadSupersededLegacyNames()
+  const items = migrateList.pendingNames.map((name) => {
+    const category = classifyName(name, supersededLegacyNames)
+    const filePath = findMigrationFile(name)
+    const fileInfo = analyzeMigrationFile(filePath)
+    const risk = riskFor(category, fileInfo)
+    return {
+      name,
+      category,
+      risk: risk.level,
+      riskReason: risk.reason,
+      ...fileInfo,
+    }
+  })
+
+  const highRisk = items.filter((item) => item.risk === 'high')
+  const executable = items.filter((item) => item.category !== 'superseded_legacy_noop_marker')
+  const decision = migrateList.pending === 0
+    ? 'aligned'
+    : highRisk.length > 0
+      ? 'do_not_run_full_migrate'
+      : executable.length > 0
+        ? 'rehearse_before_migrate'
+        : 'ledger_review_only'
+
+  const recommendation = {
+    decision,
+    fullMigrateRecommended: decision === 'aligned',
+    nextAction: decision === 'aligned'
+      ? 'No migration alignment action is required.'
+      : 'Use a cloned or backed-up staging DB for rehearsal before applying migrations to staging.',
+  }
+
+  return {
+    ok: true,
+    title: opts.title,
+    generatedAt: new Date().toISOString(),
+    applied: migrateList.applied,
+    pending: migrateList.pending,
+    pendingNamesParsed: migrateList.pendingNames.length,
+    categoryCounts: countBy(items, 'category'),
+    riskCounts: countBy(items, 'risk'),
+    recommendation,
+    items,
+  }
+}
+
+function markdownTable(rows, columns) {
+  const header = `| ${columns.map((col) => col.label).join(' | ')} |`
+  const sep = `| ${columns.map(() => '---').join(' | ')} |`
+  const body = rows.map((row) => `| ${columns.map((col) => String(col.value(row)).replace(/\|/g, '\\|')).join(' | ')} |`)
+  return [header, sep, ...body].join('\n')
+}
+
+function renderMarkdown(report) {
+  const categoryRows = Object.entries(report.categoryCounts).map(([category, count]) => ({ category, count }))
+  const riskRows = Object.entries(report.riskCounts).map(([risk, count]) => ({ risk, count }))
+  const highOrUnknown = report.items
+    .filter((item) => item.risk === 'high' || item.risk === 'unknown')
+    .slice(0, 25)
+
+  const lines = [
+    `# ${report.title}`,
+    '',
+    `Generated at: ${report.generatedAt}`,
+    '',
+    '## Summary',
+    '',
+    `- Applied migrations: ${report.applied}`,
+    `- Pending migrations: ${report.pending}`,
+    `- Parsed pending names: ${report.pendingNamesParsed}`,
+    `- Decision: \`${report.recommendation.decision}\``,
+    `- Full migrate recommended: \`${report.recommendation.fullMigrateRecommended}\``,
+    `- Next action: ${report.recommendation.nextAction}`,
+    '',
+    '## Category Counts',
+    '',
+    markdownTable(categoryRows, [
+      { label: 'Category', value: (row) => row.category },
+      { label: 'Count', value: (row) => row.count },
+    ]),
+    '',
+    '## Risk Counts',
+    '',
+    markdownTable(riskRows, [
+      { label: 'Risk', value: (row) => row.risk },
+      { label: 'Count', value: (row) => row.count },
+    ]),
+    '',
+    '## High / Unknown Replay Risk',
+    '',
+  ]
+
+  if (highOrUnknown.length === 0) {
+    lines.push('No high or unknown replay-risk migrations were detected by the static scan.')
+  } else {
+    lines.push(markdownTable(highOrUnknown, [
+      { label: 'Migration', value: (row) => row.name },
+      { label: 'Category', value: (row) => row.category },
+      { label: 'Risk', value: (row) => row.risk },
+      { label: 'File', value: (row) => row.filePath || '(missing)' },
+      { label: 'Reason', value: (row) => row.riskReason },
+    ]))
+  }
+
+  lines.push(
+    '',
+    '## Pending Migrations',
+    '',
+    markdownTable(report.items, [
+      { label: 'Migration', value: (row) => row.name },
+      { label: 'Category', value: (row) => row.category },
+      { label: 'Risk', value: (row) => row.risk },
+      { label: 'File', value: (row) => row.filePath || '(missing)' },
+    ]),
+    '',
+    '## Boundary',
+    '',
+    'This report is read-only. It does not run migrations, modify `kysely_migration`, or connect to the database directly.',
+  )
+
+  return `${lines.join('\n')}\n`
+}
+
+function writeOutputs(report, outDir) {
+  const absoluteOut = path.resolve(REPO_ROOT, outDir)
+  mkdirSync(absoluteOut, { recursive: true })
+  const jsonPath = path.join(absoluteOut, 'report.json')
+  const mdPath = path.join(absoluteOut, 'report.md')
+  writeFileSync(jsonPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8')
+  writeFileSync(mdPath, renderMarkdown(report), 'utf8')
+  return { jsonPath, mdPath }
+}
+
+function main() {
+  try {
+    const opts = parseArgs(process.argv.slice(2))
+    if (opts.help) {
+      printHelp()
+      return
+    }
+    const migrateListText = readMigrateList(opts)
+    const migrateList = parseMigrateList(migrateListText)
+    const report = buildReport(migrateList, opts)
+    const outputs = writeOutputs(report, opts.outDir)
+    console.log(`[staging-migration-alignment-report] decision=${report.recommendation.decision}`)
+    console.log(`[staging-migration-alignment-report] JSON: ${outputs.jsonPath}`)
+    console.log(`[staging-migration-alignment-report] MD: ${outputs.mdPath}`)
+  } catch (error) {
+    console.error(`[staging-migration-alignment-report] ERROR: ${error.message}`)
+    process.exitCode = 1
+  }
+}
+
+main()

--- a/scripts/ops/staging-migration-alignment-report.test.mjs
+++ b/scripts/ops/staging-migration-alignment-report.test.mjs
@@ -1,0 +1,166 @@
+import assert from 'node:assert/strict'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { test } from 'node:test'
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '../..')
+const SCRIPT = path.join(REPO_ROOT, 'scripts/ops/staging-migration-alignment-report.mjs')
+
+const STAGING_LIST = `Applied: 86
+Pending: 77
+
+Pending migrations (in load order):
+  - 008_plugin_infrastructure
+  - 032_create_approval_records
+  - 033_create_rbac_core
+  - 034_create_spreadsheets
+  - 035_create_files
+  - 036_create_spreadsheet_permissions
+  - 037_add_gallery_form_support
+  - 038_config_and_secrets
+  - 040_data_sources
+  - 041_script_sandbox
+  - 042_core_model_completion
+  - 042a_core_model_views
+  - 042b_external_data_model
+  - 042c_audit_placeholder
+  - 042d_audit_and_cache
+  - 042d_plugins_and_templates
+  - 043_core_model_views
+  - 044_external_data_model
+  - 045_audit_placeholder
+  - 046_plugins_and_templates
+  - 047_audit_and_cache
+  - 047_create_event_bus_tables
+  - 048_create_event_bus_tables
+  - 049_create_bpmn_workflow_tables
+  - 050_create_snapshot_core
+  - 051_create_minimal_views
+  - 052_recreate_minimal_views
+  - 053_create_protection_rules
+  - 054_create_users_table
+  - 055_create_attendance_import_tokens
+  - 056_add_users_must_change_password
+  - 057_create_integration_core_tables
+  - 058_integration_runs_running_unique
+  - 059_integration_runs_history_index
+  - 20250925_create_view_tables
+  - 20250926_create_audit_tables
+  - zzzz20260410100000_create_plugin_automation_rule_registry
+  - zzzz20260410101500_create_plugin_field_policy_registry
+  - zzzz20260411120000_approval_templates_and_instance_extensions
+  - zzzz20260519070000_create_plugin_attendance_report_sync_jobs`
+
+function run(args, input = '') {
+  return spawnSync('node', [SCRIPT, ...args], {
+    cwd: REPO_ROOT,
+    input,
+    encoding: 'utf8',
+  })
+}
+
+function makeTmp() {
+  return mkdtempSync(path.join(tmpdir(), 'ms2-migration-alignment-'))
+}
+
+test('classifies staging pending migrations and blocks full migrate recommendation', () => {
+  const tmp = makeTmp()
+  try {
+    const listFile = path.join(tmp, 'migrate-list.txt')
+    const outDir = path.join(tmp, 'out')
+    writeFileSync(listFile, STAGING_LIST)
+
+    const result = run(['--migrate-list-file', listFile, '--out-dir', outDir])
+    assert.equal(result.status, 0, result.stderr)
+
+    const report = JSON.parse(readFileSync(path.join(outDir, 'report.json'), 'utf8'))
+    assert.equal(report.applied, 86)
+    assert.equal(report.pending, 77)
+    assert.equal(report.categoryCounts.superseded_legacy_noop_marker, 29)
+    assert.equal(report.categoryCounts.legacy_executable_sql, 5)
+    assert.equal(report.categoryCounts.timestamp_sql, 2)
+    assert.equal(report.categoryCounts.modern_timestamp_migration, 4)
+    assert.equal(report.recommendation.fullMigrateRecommended, false)
+    assert.equal(report.recommendation.decision, 'do_not_run_full_migrate')
+  } finally {
+    rmSync(tmp, { recursive: true, force: true })
+  }
+})
+
+test('flags timestamp SQL with non-idempotent CREATE TABLE as high risk', () => {
+  const tmp = makeTmp()
+  try {
+    const outDir = path.join(tmp, 'out')
+    const input = `Applied: 1
+Pending: 1
+
+Pending migrations (in load order):
+  - 20250926_create_audit_tables
+`
+
+    const result = run(['--out-dir', outDir], input)
+    assert.equal(result.status, 0, result.stderr)
+
+    const report = JSON.parse(readFileSync(path.join(outDir, 'report.json'), 'utf8'))
+    const item = report.items.find((it) => it.name === '20250926_create_audit_tables')
+    assert.equal(item.category, 'timestamp_sql')
+    assert.equal(item.risk, 'high')
+    assert.equal(item.hasCreateTableWithoutIfNotExists, true)
+  } finally {
+    rmSync(tmp, { recursive: true, force: true })
+  }
+})
+
+test('reports aligned when there are no pending migrations', () => {
+  const tmp = makeTmp()
+  try {
+    const outDir = path.join(tmp, 'out')
+    const input = `Applied: 163
+Pending: 0
+
+No pending migrations — schema is up to date.
+`
+
+    const result = run(['--out-dir', outDir], input)
+    assert.equal(result.status, 0, result.stderr)
+
+    const report = JSON.parse(readFileSync(path.join(outDir, 'report.json'), 'utf8'))
+    assert.equal(report.pending, 0)
+    assert.equal(report.recommendation.decision, 'aligned')
+    assert.equal(report.recommendation.fullMigrateRecommended, true)
+  } finally {
+    rmSync(tmp, { recursive: true, force: true })
+  }
+})
+
+test('ignores down-path drops when scanning replay risk', () => {
+  const tmp = makeTmp()
+  try {
+    const outDir = path.join(tmp, 'out')
+    const input = `Applied: 1
+Pending: 1
+
+Pending migrations (in load order):
+  - zzzz20260519070000_create_plugin_attendance_report_sync_jobs
+`
+
+    const result = run(['--out-dir', outDir], input)
+    assert.equal(result.status, 0, result.stderr)
+
+    const report = JSON.parse(readFileSync(path.join(outDir, 'report.json'), 'utf8'))
+    const item = report.items.find((it) => it.name === 'zzzz20260519070000_create_plugin_attendance_report_sync_jobs')
+    assert.equal(item.category, 'modern_timestamp_migration')
+    assert.notEqual(item.risk, 'high')
+    assert.equal(item.hasDropStatement, false)
+  } finally {
+    rmSync(tmp, { recursive: true, force: true })
+  }
+})
+
+test('fails clearly when no migrate list input is provided', () => {
+  const result = run([])
+  assert.equal(result.status, 1)
+  assert.match(result.stderr, /Provide --migrate-list-file/)
+})


### PR DESCRIPTION
## Summary

Adds a read-only staging migration alignment report generator before any migration-ledger catch-up work. The script parses `migrate --list`, classifies pending migrations against the local migration provider, scans only migration `up()` paths for obvious replay risks, and emits `report.json` plus `report.md`.

Also updates the staging migration alignment runbook to require this report before Option A or a full migrate, and records development/verification MD for the slice.

## Verification

- [x] `node --check scripts/ops/staging-migration-alignment-report.mjs`
- [x] `node --test scripts/ops/staging-migration-alignment-report.test.mjs` (5 pass)
- [x] `git diff --check`
- [x] Live staging read-only report generated from 8082 `migrate --list`: Applied 86 / Pending 77 / decision `do_not_run_full_migrate` / high 12, ledger_review 29, medium 5, low 31

## Boundaries

- No DB writes and no migration execution
- No `kysely_migration` edits
- No secrets committed
- Local `output/` evidence is intentionally untracked
