### PR TITLE
feat(ops): add staging migration schema probe plan

### DIFF
--- a/docs/development/staging-migration-probe-plan-development-20260520.md
+++ b/docs/development/staging-migration-probe-plan-development-20260520.md
@@ -1,0 +1,62 @@
+# Staging Migration Probe Plan Development
+
+Date: 2026-05-20
+
+## Summary
+
+This slice extends the read-only staging migration alignment report with a
+schema probe plan. The goal is to turn a pending migration list into an
+operator-friendly rehearsal checklist without connecting to the database or
+executing migrations.
+
+The probe plan is deliberately conservative:
+
+- it only scans migration `up()` paths;
+- it extracts obvious static table, column, and index targets;
+- it treats complex or dynamic DDL as manual review work;
+- it does not classify a migration as safe to replay.
+
+## Files
+
+| File | Change |
+| --- | --- |
+| `scripts/ops/staging-migration-alignment-report.mjs` | Adds schema target extraction and a `schemaProbePlan` section to JSON/Markdown output. |
+| `scripts/ops/staging-migration-alignment-report.test.mjs` | Adds regression tests for SQL table/column probes, Kysely create-table probes, down-path boundaries, and same-statement alter-column extraction. |
+| `docs/operations/staging-migration-alignment-runbook.md` | Documents how operators should use the new Schema Probe Plan section. |
+| `docs/development/staging-migration-probe-plan-development-20260520.md` | This design/development record. |
+| `docs/development/staging-migration-probe-plan-verification-20260520.md` | Verification record for this slice. |
+
+## Extraction Rules
+
+| Target | Supported static patterns |
+| --- | --- |
+| Tables | SQL `CREATE TABLE`, SQL `ALTER TABLE`, Kysely `.createTable('...')`, Kysely `.alterTable('...')`. |
+| Columns | SQL `CREATE TABLE (...)` top-level column declarations, SQL `ALTER TABLE ... ADD COLUMN ...`, Kysely `.addColumn('...')` inside static create/alter chains. |
+| Indexes | SQL `CREATE INDEX ... ON ...`, Kysely `.createIndex('...').on('...')`. |
+
+The extractor strips comments before scanning. For TypeScript migrations, it
+first narrows the scan to `up()` and ignores rollback-only `down()` DDL.
+
+## Guardrails
+
+- The script remains a report generator, not a migration runner.
+- No DB connection is opened.
+- No `kysely_migration` row is written.
+- No staging/prod secret is read.
+- Local `output/` evidence is intentionally untracked.
+- The Markdown report explains that the Schema Probe Plan is a checklist, not a
+  safety proof.
+
+## Operator Value
+
+Before this slice, operators saw that staging had `Applied: 86 / Pending: 77`
+and a risk bucket summary. After this slice, they also get a first-pass list of
+objects to inspect on a rehearsal database, such as:
+
+- pending plugin infrastructure tables;
+- audit tables and partitions;
+- approval template tables, altered columns, and indexes;
+- the already-aligned report sync job operational table.
+
+This makes the next rehearsal step more mechanical while keeping the current
+production/staging databases untouched.

--- a/docs/development/staging-migration-probe-plan-verification-20260520.md
+++ b/docs/development/staging-migration-probe-plan-verification-20260520.md
@@ -1,0 +1,66 @@
+# Staging Migration Probe Plan Verification
+
+Date: 2026-05-20
+
+## Scope
+
+Verify the schema probe plan extension for the read-only staging migration
+alignment report.
+
+No staging DB migration was executed. No `kysely_migration` row was written.
+
+## Checks
+
+| Check | Result |
+| --- | --- |
+| `node --check scripts/ops/staging-migration-alignment-report.mjs` | PASS |
+| `node --test scripts/ops/staging-migration-alignment-report.test.mjs` | PASS, 6 tests |
+| `git diff --check` | PASS |
+| Live staging read-only report generation | PASS |
+
+## Unit Coverage
+
+The test suite now locks:
+
+- staging-style pending classification still returns
+  `decision=do_not_run_full_migrate`;
+- non-idempotent SQL `CREATE TABLE` is still high risk;
+- SQL table and column probes are emitted for `20250926_create_audit_tables`;
+- partition child tables do not receive fake copied column probes;
+- TypeScript `down()` drops are ignored for replay risk and probe extraction;
+- Kysely `.createTable().addColumn()` chains emit table, column, and index
+  targets for `zzzz20260519070000_create_plugin_attendance_report_sync_jobs`;
+- SQL `ALTER TABLE ... ADD COLUMN ...` probes stay within the same statement,
+  preventing cross-statement column misattribution.
+
+## Live Staging Read-Only Report
+
+Generated from 8082 staging `migrate --list` output on 2026-05-20 without
+executing migrations:
+
+| Metric | Value |
+| --- | --- |
+| Applied migrations | 86 |
+| Pending migrations | 77 |
+| Decision | `do_not_run_full_migrate` |
+| Probe plan entries | 76 |
+
+Risk counts:
+
+| Risk | Count |
+| --- | --- |
+| `high` | 12 |
+| `ledger_review` | 29 |
+| `medium` | 5 |
+| `low` | 31 |
+
+The generated report was written under local untracked `output/` and is not
+committed.
+
+## Boundary Verification
+
+- No token/JWT paths were used or committed.
+- The script still supports file/stdin/`--run-list` inputs only.
+- The live staging step only captured `migrate --list` output.
+- The schema probe plan is static analysis output and does not query staging
+  schema directly.

--- a/docs/operations/staging-migration-alignment-runbook.md
+++ b/docs/operations/staging-migration-alignment-runbook.md
@@ -20,6 +20,12 @@ pending names into superseded legacy no-op markers, executable legacy SQL,
 timestamp SQL, and modern migrations, and flags obvious replay risks such as
 `CREATE TABLE` without `IF NOT EXISTS`.
 
+The report also includes a **Schema Probe Plan** section. Treat that section as
+a read-only rehearsal checklist: it lists obvious table, column, and index
+targets extracted from migration `up()` paths so operators know what to inspect
+on a cloned or backed-up DB. The probe plan is not a safety proof and does not
+replace a real rehearsal.
+
 Do **not** apply Option A or run full `migrate --latest` when the report says
 `do_not_run_full_migrate`. Use a cloned or backed-up rehearsal DB first.
 

--- a/scripts/ops/staging-migration-alignment-report.mjs
+++ b/scripts/ops/staging-migration-alignment-report.mjs
@@ -149,19 +149,22 @@ function analyzeMigrationFile(filePath) {
       hasAlterTable: false,
       hasIfNotExists: false,
       hasCheckTableExistsGuard: false,
+      schemaTargets: emptySchemaTargets(),
     }
   }
   const source = readFileSync(filePath, 'utf8')
   const upSource = extractUpSource(source)
+  const scanSource = stripComments(upSource)
   return {
     filePath: path.relative(REPO_ROOT, filePath),
     fileKind: path.extname(filePath).replace(/^\./, '') || 'unknown',
-    hasCreateTableWithoutIfNotExists: /CREATE\s+TABLE\s+(?!IF\s+NOT\s+EXISTS)/i.test(upSource),
-    hasKyselyCreateTableWithoutIfNotExists: hasUnguardedKyselyCreateTable(upSource),
-    hasDropStatement: /\bDROP\s+(TABLE|COLUMN|INDEX|CONSTRAINT|DATABASE)\b/i.test(upSource),
-    hasAlterTable: /\bALTER\s+TABLE\b/i.test(upSource),
-    hasIfNotExists: /IF\s+NOT\s+EXISTS|\.ifNotExists\s*\(/i.test(upSource),
-    hasCheckTableExistsGuard: /checkTableExists|to_regclass\s*\(/i.test(upSource),
+    hasCreateTableWithoutIfNotExists: /CREATE\s+TABLE\s+(?!IF\s+NOT\s+EXISTS)/i.test(scanSource),
+    hasKyselyCreateTableWithoutIfNotExists: hasUnguardedKyselyCreateTable(scanSource),
+    hasDropStatement: /\bDROP\s+(TABLE|COLUMN|INDEX|CONSTRAINT|DATABASE)\b/i.test(scanSource),
+    hasAlterTable: /\bALTER\s+TABLE\b/i.test(scanSource),
+    hasIfNotExists: /IF\s+NOT\s+EXISTS|\.ifNotExists\s*\(/i.test(scanSource),
+    hasCheckTableExistsGuard: /checkTableExists|to_regclass\s*\(/i.test(scanSource),
+    schemaTargets: extractSchemaTargets(scanSource),
   }
 }
 
@@ -173,9 +176,222 @@ function extractUpSource(source) {
   return source.slice(upMatch.index, upMatch.index + upMatch[0].length + downMatch.index)
 }
 
+function stripComments(source) {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/--[^\r\n]*/g, ' ')
+    .replace(/\/\/[^\r\n]*/g, ' ')
+}
+
 function hasUnguardedKyselyCreateTable(source) {
   const calls = [...source.matchAll(/\.createTable\s*\([^)]*\)([\s\S]*?)(?=\.execute\s*\(\s*\)|;)/g)]
   return calls.some((call) => !/\.ifNotExists\s*\(/.test(call[1]))
+}
+
+function emptySchemaTargets() {
+  return {
+    createTables: [],
+    alterTables: [],
+    addColumns: [],
+    indexes: [],
+  }
+}
+
+function cleanSqlIdentifier(identifier) {
+  return String(identifier || '')
+    .trim()
+    .replace(/[;,)]*$/g, '')
+    .split(/\s*\.\s*/)
+    .map((part) => part.trim().replace(/^["'`\[]/, '').replace(/["'`\]]$/, ''))
+    .filter(Boolean)
+    .join('.')
+}
+
+function uniqueSorted(values) {
+  return [...new Set(values.filter(Boolean))].sort((a, b) => a.localeCompare(b))
+}
+
+function uniqueColumnTargets(values) {
+  const seen = new Set()
+  const result = []
+  for (const value of values) {
+    if (!value.table || !value.column) continue
+    const key = `${value.table}.${value.column}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    result.push(value)
+  }
+  return result.sort((a, b) => `${a.table}.${a.column}`.localeCompare(`${b.table}.${b.column}`))
+}
+
+function uniqueIndexTargets(values) {
+  const seen = new Set()
+  const result = []
+  for (const value of values) {
+    if (!value.table || !value.index) continue
+    const key = `${value.table}.${value.index}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    result.push(value)
+  }
+  return result.sort((a, b) => `${a.table}.${a.index}`.localeCompare(`${b.table}.${b.index}`))
+}
+
+function splitStatementSegments(source) {
+  return source
+    .split(/;\s*|\.execute\s*\([^)]*\)/g)
+    .map((segment) => segment.trim())
+    .filter(Boolean)
+}
+
+function findMatchingParen(source, openIndex) {
+  let depth = 0
+  let quote = ''
+  for (let i = openIndex; i < source.length; i += 1) {
+    const char = source[i]
+    const prev = source[i - 1]
+    if (quote) {
+      if (char === quote && prev !== '\\') quote = ''
+      continue
+    }
+    if (char === '\'' || char === '"' || char === '`') {
+      quote = char
+      continue
+    }
+    if (char === '(') depth += 1
+    if (char === ')') {
+      depth -= 1
+      if (depth === 0) return i
+    }
+  }
+  return -1
+}
+
+function splitTopLevelComma(source) {
+  const parts = []
+  let start = 0
+  let depth = 0
+  let quote = ''
+  for (let i = 0; i < source.length; i += 1) {
+    const char = source[i]
+    const prev = source[i - 1]
+    if (quote) {
+      if (char === quote && prev !== '\\') quote = ''
+      continue
+    }
+    if (char === '\'' || char === '"' || char === '`') {
+      quote = char
+      continue
+    }
+    if (char === '(') depth += 1
+    if (char === ')') depth -= 1
+    if (char === ',' && depth === 0) {
+      parts.push(source.slice(start, i).trim())
+      start = i + 1
+    }
+  }
+  const tail = source.slice(start).trim()
+  if (tail) parts.push(tail)
+  return parts
+}
+
+function extractSqlCreateTableColumns(source, identifierPattern) {
+  const targets = []
+  const createTableRegex = new RegExp(String.raw`\bCREATE\s+(?:UNLOGGED\s+|TEMP(?:ORARY)?\s+)?TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(${identifierPattern})`, 'gi')
+  for (const match of source.matchAll(createTableRegex)) {
+    if (match.index === undefined) continue
+    const table = cleanSqlIdentifier(match[1])
+    const afterName = match.index + match[0].length
+    const nextText = source.slice(afterName, afterName + 80)
+    if (/^\s+PARTITION\s+OF\b/i.test(nextText)) continue
+    const openIndex = source.indexOf('(', afterName)
+    if (openIndex < 0 || openIndex > afterName + 200) continue
+    const closeIndex = findMatchingParen(source, openIndex)
+    if (closeIndex < 0) continue
+    for (const entry of splitTopLevelComma(source.slice(openIndex + 1, closeIndex))) {
+      const firstToken = entry.match(/^\s*("[^"]+"|`[^`]+`|'[^']+'|[A-Za-z_][A-Za-z0-9_$]*)/)
+      if (!firstToken) continue
+      const column = cleanSqlIdentifier(firstToken[1])
+      if (/^(PRIMARY|CONSTRAINT|FOREIGN|UNIQUE|CHECK|EXCLUDE|LIKE)$/i.test(column)) continue
+      targets.push({ table, column })
+    }
+  }
+  return targets
+}
+
+function extractSchemaTargets(source) {
+  const identifier = String.raw`(?:"[^"]+"|[A-Za-z_][A-Za-z0-9_$]*)(?:\s*\.\s*(?:"[^"]+"|[A-Za-z_][A-Za-z0-9_$]*))?`
+  const createTables = []
+  const alterTables = []
+  const addColumns = []
+  const indexes = []
+
+  for (const match of source.matchAll(new RegExp(String.raw`\bCREATE\s+(?:UNLOGGED\s+|TEMP(?:ORARY)?\s+)?TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(${identifier})`, 'gi'))) {
+    createTables.push(cleanSqlIdentifier(match[1]))
+  }
+
+  for (const match of source.matchAll(/\.createTable\s*\(\s*(['"`])([^'"`]+)\1\s*\)/g)) {
+    createTables.push(cleanSqlIdentifier(match[2]))
+  }
+
+  for (const match of source.matchAll(new RegExp(String.raw`\bCREATE\s+(?:UNIQUE\s+)?INDEX\s+(?:IF\s+NOT\s+EXISTS\s+)?(${identifier})\s+ON\s+(${identifier})`, 'gi'))) {
+    indexes.push({
+      index: cleanSqlIdentifier(match[1]),
+      table: cleanSqlIdentifier(match[2]),
+    })
+  }
+
+  for (const match of source.matchAll(/\.createIndex\s*\(\s*(['"`])([^'"`]+)\1\s*\)([\s\S]*?)(?=\.execute\s*\(\s*\)|;)/g)) {
+    const onMatch = match[3].match(/\.on\s*\(\s*(['"`])([^'"`]+)\1\s*\)/)
+    if (!onMatch) continue
+    indexes.push({
+      index: cleanSqlIdentifier(match[2]),
+      table: cleanSqlIdentifier(onMatch[2]),
+    })
+  }
+
+  addColumns.push(...extractSqlCreateTableColumns(source, identifier))
+
+  for (const segment of splitStatementSegments(source)) {
+    const alterMatch = segment.match(new RegExp(String.raw`\bALTER\s+TABLE\s+(?:IF\s+EXISTS\s+)?(${identifier})`, 'i'))
+    if (!alterMatch) continue
+    const table = cleanSqlIdentifier(alterMatch[1])
+    alterTables.push(table)
+    const addColumnMatch = segment.match(new RegExp(String.raw`\bADD\s+COLUMN\s+(?:IF\s+NOT\s+EXISTS\s+)?(${identifier})`, 'i'))
+    if (addColumnMatch) {
+      addColumns.push({
+        table,
+        column: cleanSqlIdentifier(addColumnMatch[1]),
+      })
+    }
+  }
+
+  for (const match of source.matchAll(/\.alterTable\s*\(\s*(['"`])([^'"`]+)\1\s*\)([\s\S]*?)(?=\.execute\s*\(\s*\)|;)/g)) {
+    const table = cleanSqlIdentifier(match[2])
+    for (const columnMatch of match[3].matchAll(/\.addColumn\s*\(\s*(['"`])([^'"`]+)\1/g)) {
+      addColumns.push({
+        table,
+        column: cleanSqlIdentifier(columnMatch[2]),
+      })
+    }
+  }
+
+  for (const match of source.matchAll(/\.createTable\s*\(\s*(['"`])([^'"`]+)\1\s*\)([\s\S]*?)(?=\.execute\s*\(\s*\)|;)/g)) {
+    const table = cleanSqlIdentifier(match[2])
+    for (const columnMatch of match[3].matchAll(/\.addColumn\s*\(\s*(['"`])([^'"`]+)\1/g)) {
+      addColumns.push({
+        table,
+        column: cleanSqlIdentifier(columnMatch[2]),
+      })
+    }
+  }
+
+  return {
+    createTables: uniqueSorted(createTables),
+    alterTables: uniqueSorted(alterTables),
+    addColumns: uniqueColumnTargets(addColumns),
+    indexes: uniqueIndexTargets(indexes),
+  }
 }
 
 function riskFor(category, fileInfo) {
@@ -224,6 +440,38 @@ function countBy(items, key) {
   return counts
 }
 
+function buildSchemaProbePlan(items) {
+  return items
+    .filter((item) => (
+      item.schemaTargets.createTables.length > 0
+      || item.schemaTargets.alterTables.length > 0
+      || item.schemaTargets.addColumns.length > 0
+      || item.schemaTargets.indexes.length > 0
+      || item.risk === 'high'
+      || item.risk === 'unknown'
+    ))
+    .map((item) => ({
+      migration: item.name,
+      category: item.category,
+      risk: item.risk,
+      filePath: item.filePath,
+      tablesToCheck: uniqueSorted([
+        ...item.schemaTargets.createTables,
+        ...item.schemaTargets.alterTables,
+        ...item.schemaTargets.addColumns.map((column) => column.table),
+        ...item.schemaTargets.indexes.map((index) => index.table),
+      ]),
+      columnsToCheck: item.schemaTargets.addColumns.map((column) => `${column.table}.${column.column}`),
+      indexesToCheck: item.schemaTargets.indexes.map((index) => `${index.table}.${index.index}`),
+      notes: item.schemaTargets.createTables.length === 0
+        && item.schemaTargets.alterTables.length === 0
+        && item.schemaTargets.addColumns.length === 0
+        && item.schemaTargets.indexes.length === 0
+        ? 'No obvious table/column targets were extracted; inspect the migration manually.'
+        : 'Verify these targets on a cloned or backed-up DB before applying or marking migrations.',
+    }))
+}
+
 function buildReport(migrateList, opts) {
   const supersededLegacyNames = loadSupersededLegacyNames()
   const items = migrateList.pendingNames.map((name) => {
@@ -268,6 +516,7 @@ function buildReport(migrateList, opts) {
     categoryCounts: countBy(items, 'category'),
     riskCounts: countBy(items, 'risk'),
     recommendation,
+    schemaProbePlan: buildSchemaProbePlan(items),
     items,
   }
 }
@@ -285,6 +534,7 @@ function renderMarkdown(report) {
   const highOrUnknown = report.items
     .filter((item) => item.risk === 'high' || item.risk === 'unknown')
     .slice(0, 25)
+  const schemaProbePlan = report.schemaProbePlan.slice(0, 40)
 
   const lines = [
     `# ${report.title}`,
@@ -327,6 +577,27 @@ function renderMarkdown(report) {
       { label: 'Risk', value: (row) => row.risk },
       { label: 'File', value: (row) => row.filePath || '(missing)' },
       { label: 'Reason', value: (row) => row.riskReason },
+    ]))
+  }
+
+  lines.push(
+    '',
+    '## Schema Probe Plan',
+    '',
+    'Use this as a read-only rehearsal checklist on a cloned or backed-up DB. It is not a safety proof.',
+    '',
+  )
+
+  if (schemaProbePlan.length === 0) {
+    lines.push('No obvious schema probe targets were extracted.')
+  } else {
+    lines.push(markdownTable(schemaProbePlan, [
+      { label: 'Migration', value: (row) => row.migration },
+      { label: 'Risk', value: (row) => row.risk },
+      { label: 'Tables to check', value: (row) => row.tablesToCheck.join(', ') || '(manual)' },
+      { label: 'Columns to check', value: (row) => row.columnsToCheck.join(', ') || '(none)' },
+      { label: 'Indexes to check', value: (row) => row.indexesToCheck.join(', ') || '(none)' },
+      { label: 'Note', value: (row) => row.notes },
     ]))
   }
 

--- a/scripts/ops/staging-migration-alignment-report.test.mjs
+++ b/scripts/ops/staging-migration-alignment-report.test.mjs
@@ -108,6 +108,18 @@ Pending migrations (in load order):
     assert.equal(item.category, 'timestamp_sql')
     assert.equal(item.risk, 'high')
     assert.equal(item.hasCreateTableWithoutIfNotExists, true)
+    assert.ok(item.schemaTargets.createTables.includes('audit_logs'))
+    assert.ok(item.schemaTargets.addColumns.some((target) => (
+      target.table === 'audit_logs' && target.column === 'event_id'
+    )))
+    assert.equal(item.schemaTargets.addColumns.some((target) => (
+      target.table === 'audit_logs_2025_01' && target.column === 'id'
+    )), false)
+    assert.ok(report.schemaProbePlan.some((entry) => (
+      entry.migration === '20250926_create_audit_tables'
+      && entry.tablesToCheck.includes('audit_logs')
+      && entry.columnsToCheck.includes('audit_logs.event_id')
+    )))
   } finally {
     rmSync(tmp, { recursive: true, force: true })
   }
@@ -154,6 +166,41 @@ Pending migrations (in load order):
     assert.equal(item.category, 'modern_timestamp_migration')
     assert.notEqual(item.risk, 'high')
     assert.equal(item.hasDropStatement, false)
+    assert.deepEqual(item.schemaTargets.createTables, ['plugin_attendance_report_sync_jobs'])
+    assert.ok(item.schemaTargets.addColumns.some((target) => (
+      target.table === 'plugin_attendance_report_sync_jobs' && target.column === 'status'
+    )))
+    assert.ok(item.schemaTargets.indexes.some((target) => (
+      target.table === 'plugin_attendance_report_sync_jobs'
+      && target.index === 'uq_plugin_attendance_report_sync_jobs_idempotency'
+    )))
+  } finally {
+    rmSync(tmp, { recursive: true, force: true })
+  }
+})
+
+test('keeps SQL alter-column probes within the same statement', () => {
+  const tmp = makeTmp()
+  try {
+    const outDir = path.join(tmp, 'out')
+    const input = `Applied: 1
+Pending: 1
+
+Pending migrations (in load order):
+  - zzzz20260411120100_approval_templates_and_instance_extensions
+`
+
+    const result = run(['--out-dir', outDir], input)
+    assert.equal(result.status, 0, result.stderr)
+
+    const report = JSON.parse(readFileSync(path.join(outDir, 'report.json'), 'utf8'))
+    const item = report.items.find((it) => it.name === 'zzzz20260411120100_approval_templates_and_instance_extensions')
+    assert.ok(item.schemaTargets.addColumns.some((target) => (
+      target.table === 'approval_assignments' && target.column === 'node_key'
+    )))
+    assert.equal(item.schemaTargets.addColumns.some((target) => (
+      target.table === 'approval_records' && target.column === 'node_key'
+    )), false)
   } finally {
     rmSync(tmp, { recursive: true, force: true })
   }


### PR DESCRIPTION
## Summary

Extends the read-only staging migration alignment report with a conservative Schema Probe Plan. The report now extracts obvious table, column, and index targets from migration `up()` paths so operators have a rehearsal checklist before applying or marking pending migrations.

This remains a static report generator: it does not connect to a DB, execute migrations, or write `kysely_migration`.

## Verification

- [x] `node --check scripts/ops/staging-migration-alignment-report.mjs`
- [x] `node --test scripts/ops/staging-migration-alignment-report.test.mjs` (6 pass)
- [x] `git diff --check`
- [x] Live 8082 staging read-only report generated from `migrate --list`: Applied 86 / Pending 77 / decision `do_not_run_full_migrate` / probe plan entries 76

## Boundaries

- No DB writes and no migration execution
- No `kysely_migration` edits
- No secrets committed
- Local `output/` evidence is intentionally untracked
