### PR TITLE
feat(ops): emit staging migration schema probe SQL

### DIFF
--- a/docs/development/staging-migration-probe-sql-development-20260520.md
+++ b/docs/development/staging-migration-probe-sql-development-20260520.md
@@ -1,0 +1,71 @@
+# Staging Migration Probe SQL Development
+
+Date: 2026-05-20
+
+## Summary
+
+This slice extends the staging migration alignment report with a companion
+`schema-probes.sql` file. The previous report already produced `report.json`,
+`report.md`, and a static Schema Probe Plan. This follow-up turns that plan into
+read-only PostgreSQL catalog queries that an operator can run on a cloned or
+backed-up rehearsal database.
+
+The script itself still does not connect to a database. It only writes files.
+
+## Files
+
+| File | Change |
+| --- | --- |
+| `scripts/ops/staging-migration-alignment-report.mjs` | Writes `schema-probes.sql` in addition to `report.json` and `report.md`; adds probe SQL counts to the JSON/Markdown summary. |
+| `scripts/ops/staging-migration-alignment-report.test.mjs` | Asserts the generated SQL is read-only and contains table/column/index catalog probes. |
+| `docs/operations/staging-migration-alignment-runbook.md` | Documents how operators should use `schema-probes.sql`. |
+| `docs/development/staging-migration-probe-sql-development-20260520.md` | This development record. |
+| `docs/development/staging-migration-probe-sql-verification-20260520.md` | Verification record for this slice. |
+
+## Probe SQL Shape
+
+The generated SQL uses one unified read-only `probe_plan` CTE over PostgreSQL
+`pg_catalog` tables:
+
+| Probe | Catalog source |
+| --- | --- |
+| Table existence | `pg_catalog.pg_class` + `pg_catalog.pg_namespace` |
+| Column existence | `pg_catalog.pg_attribute` + `pg_catalog.pg_class` + `pg_catalog.pg_namespace` |
+| Index existence | `pg_catalog.pg_index` + `pg_catalog.pg_class` + `pg_catalog.pg_namespace` |
+
+Every result row reports:
+
+- `probe_type`
+- `migration`
+- `target`
+- `exists`
+- `match_count`
+- `matched_schemas`
+
+Unqualified table names are not assumed to live in `public`; the SQL reports all
+non-system schemas that match.
+
+The file is wrapped in:
+
+```sql
+BEGIN READ ONLY;
+-- SELECT-only catalog probes
+ROLLBACK;
+```
+
+## Guardrails
+
+- No migration is executed.
+- No `kysely_migration` row is written.
+- The generated SQL contains no DDL.
+- The script does not read secrets or connect to staging/prod.
+- `schema-probes.sql` is an operator aid, not a proof that replaying a migration is
+  safe.
+
+## Operator Value
+
+For the current 8082 staging state, the report still says
+`do_not_run_full_migrate`. The generated `schema-probes.sql` gives the next rehearsal
+step a concrete shape: run read-only catalog checks on a cloned or backed-up DB,
+then decide whether specific pending migrations are already satisfied, genuinely
+missing, or require idempotency fixes before migration replay.

--- a/docs/development/staging-migration-probe-sql-verification-20260520.md
+++ b/docs/development/staging-migration-probe-sql-verification-20260520.md
@@ -1,0 +1,71 @@
+# Staging Migration Probe SQL Verification
+
+Date: 2026-05-20
+
+## Scope
+
+Verify the `schema-probes.sql` output added to the read-only staging migration
+alignment report.
+
+No staging DB migration was executed. No `kysely_migration` row was written.
+
+## Checks
+
+| Check | Result |
+| --- | --- |
+| `node --check scripts/ops/staging-migration-alignment-report.mjs` | PASS |
+| `node --test scripts/ops/staging-migration-alignment-report.test.mjs` | PASS, 7 tests |
+| `git diff --check` | PASS |
+| Live 8082 staging read-only report generation | PASS |
+
+## Unit Coverage
+
+The test suite now asserts:
+
+- `schema-probes.sql` is written next to `report.json` and `report.md`;
+- generated SQL starts a read-only transaction;
+- probes use `pg_catalog` directly rather than `information_schema`;
+- table, column, and index probes share one `probe_plan` CTE;
+- unqualified table names render as `schema_name IS NULL`, so matches can be
+  reported across non-system schemas instead of assuming `public`;
+- generated rows expose `exists`, `match_count`, and `matched_schemas`;
+- generated SQL does not contain DDL such as `CREATE TABLE`, `ALTER TABLE`, or
+  `DROP TABLE`;
+- the full Schema Probe Plan is emitted to SQL, even though the Markdown
+  preview is truncated for readability;
+- Kysely create-table migrations produce table, column, and index probe counts.
+
+## Live 8082 Staging Read-Only Output
+
+Generated from staging `migrate --list` output on 2026-05-20 without executing
+migrations:
+
+| Metric | Value |
+| --- | --- |
+| Applied migrations | 86 |
+| Pending migrations | 77 |
+| Decision | `do_not_run_full_migrate` |
+| Probe plan entries | 76 |
+| Probe SQL table targets | 207 |
+| Probe SQL column targets | 2069 |
+| Probe SQL index targets | 431 |
+| `schema-probes.sql` size | 270673 bytes |
+
+Risk counts:
+
+| Risk | Count |
+| --- | --- |
+| `high` | 12 |
+| `ledger_review` | 29 |
+| `medium` | 5 |
+| `low` | 31 |
+
+The generated `schema-probes.sql` was written under local untracked `output/` and is not
+committed.
+
+## Boundary Verification
+
+- The live step only captured `migrate --list` output from staging.
+- `schema-probes.sql` was generated locally from static analysis.
+- No token/JWT paths were committed.
+- The script still does not connect to the database.

--- a/docs/operations/staging-migration-alignment-runbook.md
+++ b/docs/operations/staging-migration-alignment-runbook.md
@@ -26,6 +26,13 @@ targets extracted from migration `up()` paths so operators know what to inspect
 on a cloned or backed-up DB. The probe plan is not a safety proof and does not
 replace a real rehearsal.
 
+The same run writes `schema-probes.sql` next to `report.json` and `report.md`.
+This SQL file contains only read-only PostgreSQL `pg_catalog` checks wrapped in
+a read-only transaction. Run it against a cloned or backed-up rehearsal DB when
+you need a machine-readable table/column/index existence matrix. Unqualified
+targets are not assumed to be in `public`; the output includes `match_count` and
+`matched_schemas` so operators can see ambiguity explicitly.
+
 Do **not** apply Option A or run full `migrate --latest` when the report says
 `do_not_run_full_migrate`. Use a cloned or backed-up rehearsal DB first.
 

--- a/scripts/ops/staging-migration-alignment-report.mjs
+++ b/scripts/ops/staging-migration-alignment-report.mjs
@@ -44,7 +44,7 @@ function printHelp() {
 
 This script is read-only. It parses \`migrate --list\` output, classifies pending
 migrations, scans local migration files for obvious replay risk, and writes
-report.json + report.md.`)
+report.json + report.md + schema-probes.sql.`)
 }
 
 function readStdinIfAvailable() {
@@ -334,7 +334,7 @@ function extractSchemaTargets(source) {
     createTables.push(cleanSqlIdentifier(match[2]))
   }
 
-  for (const match of source.matchAll(new RegExp(String.raw`\bCREATE\s+(?:UNIQUE\s+)?INDEX\s+(?:IF\s+NOT\s+EXISTS\s+)?(${identifier})\s+ON\s+(${identifier})`, 'gi'))) {
+  for (const match of source.matchAll(new RegExp(String.raw`\bCREATE\s+(?:UNIQUE\s+)?INDEX\s+(?:CONCURRENTLY\s+)?(?:IF\s+NOT\s+EXISTS\s+)?(${identifier})\s+ON\s+(${identifier})`, 'gi'))) {
     indexes.push({
       index: cleanSqlIdentifier(match[1]),
       table: cleanSqlIdentifier(match[2]),
@@ -357,8 +357,8 @@ function extractSchemaTargets(source) {
     if (!alterMatch) continue
     const table = cleanSqlIdentifier(alterMatch[1])
     alterTables.push(table)
-    const addColumnMatch = segment.match(new RegExp(String.raw`\bADD\s+COLUMN\s+(?:IF\s+NOT\s+EXISTS\s+)?(${identifier})`, 'i'))
-    if (addColumnMatch) {
+    const addColumnMatches = [...segment.matchAll(new RegExp(String.raw`\bADD\s+COLUMN\s+(?:IF\s+NOT\s+EXISTS\s+)?(${identifier})`, 'gi'))]
+    for (const addColumnMatch of addColumnMatches) {
       addColumns.push({
         table,
         column: cleanSqlIdentifier(addColumnMatch[1]),
@@ -505,6 +505,7 @@ function buildReport(migrateList, opts) {
       ? 'No migration alignment action is required.'
       : 'Use a cloned or backed-up staging DB for rehearsal before applying migrations to staging.',
   }
+  const schemaProbePlan = buildSchemaProbePlan(items)
 
   return {
     ok: true,
@@ -516,9 +517,225 @@ function buildReport(migrateList, opts) {
     categoryCounts: countBy(items, 'category'),
     riskCounts: countBy(items, 'risk'),
     recommendation,
-    schemaProbePlan: buildSchemaProbePlan(items),
+    schemaProbePlan,
+    schemaProbeSqlCounts: countSchemaProbeSqlRows(schemaProbePlan),
     items,
   }
+}
+
+function splitSchemaName(identifier) {
+  const parts = String(identifier || '').split('.').filter(Boolean)
+  if (parts.length <= 1) {
+    return {
+      schema: null,
+      name: parts[0] || '',
+    }
+  }
+  return {
+    schema: parts[0],
+    name: parts.slice(1).join('.'),
+  }
+}
+
+function sqlLiteral(value) {
+  if (value === null || value === undefined || value === '') return 'NULL'
+  return `'${String(value).replace(/'/g, "''")}'`
+}
+
+function uniqueProbeRows(rows, keyFn) {
+  const seen = new Set()
+  const result = []
+  for (const row of rows) {
+    const key = keyFn(row)
+    if (seen.has(key)) continue
+    seen.add(key)
+    result.push(row)
+  }
+  return result.sort((a, b) => keyFn(a).localeCompare(keyFn(b)))
+}
+
+function buildSchemaProbeSqlRows(schemaProbePlan) {
+  const tableRows = []
+  const columnRows = []
+  const indexRows = []
+
+  for (const entry of schemaProbePlan) {
+    for (const table of entry.tablesToCheck) {
+      const parsed = splitSchemaName(table)
+      if (!parsed.name) continue
+      tableRows.push({
+        migration: entry.migration,
+        schema: parsed.schema,
+        table: parsed.name,
+      })
+    }
+
+    for (const columnTarget of entry.columnsToCheck) {
+      const parts = String(columnTarget).split('.').filter(Boolean)
+      if (parts.length < 2) continue
+      const column = parts.pop()
+      const parsed = splitSchemaName(parts.join('.'))
+      if (!parsed.name || !column) continue
+      columnRows.push({
+        migration: entry.migration,
+        schema: parsed.schema,
+        table: parsed.name,
+        column,
+      })
+    }
+
+    for (const indexTarget of entry.indexesToCheck) {
+      const parts = String(indexTarget).split('.').filter(Boolean)
+      if (parts.length < 2) continue
+      const index = parts.pop()
+      const parsed = splitSchemaName(parts.join('.'))
+      if (!parsed.name || !index) continue
+      indexRows.push({
+        migration: entry.migration,
+        schema: parsed.schema,
+        table: parsed.name,
+        index,
+      })
+    }
+  }
+
+  return {
+    tables: uniqueProbeRows(tableRows, (row) => `${row.migration}.${row.schema || ''}.${row.table}`),
+    columns: uniqueProbeRows(columnRows, (row) => `${row.migration}.${row.schema || ''}.${row.table}.${row.column}`),
+    indexes: uniqueProbeRows(indexRows, (row) => `${row.migration}.${row.schema || ''}.${row.table}.${row.index}`),
+  }
+}
+
+function countSchemaProbeSqlRows(schemaProbePlan) {
+  const rows = buildSchemaProbeSqlRows(schemaProbePlan)
+  return {
+    tables: rows.tables.length,
+    columns: rows.columns.length,
+    indexes: rows.indexes.length,
+  }
+}
+
+function renderValues(rows, columns) {
+  if (rows.length === 0) return ''
+  return rows
+    .map((row) => `    (${columns.map((column) => sqlLiteral(row[column])).join(', ')})`)
+    .join(',\n')
+}
+
+function buildUnifiedProbeRows(schemaProbePlan) {
+  const rows = buildSchemaProbeSqlRows(schemaProbePlan)
+  return [
+    ...rows.tables.map((row) => ({
+      kind: 'table',
+      migration: row.migration,
+      schema: row.schema,
+      table: row.table,
+      column: null,
+      index: null,
+    })),
+    ...rows.columns.map((row) => ({
+      kind: 'column',
+      migration: row.migration,
+      schema: row.schema,
+      table: row.table,
+      column: row.column,
+      index: null,
+    })),
+    ...rows.indexes.map((row) => ({
+      kind: 'index',
+      migration: row.migration,
+      schema: row.schema,
+      table: row.table,
+      column: null,
+      index: row.index,
+    })),
+  ].sort((a, b) => (
+    `${a.migration}.${a.kind}.${a.schema || ''}.${a.table}.${a.column || ''}.${a.index || ''}`
+      .localeCompare(`${b.migration}.${b.kind}.${b.schema || ''}.${b.table}.${b.column || ''}.${b.index || ''}`)
+  ))
+}
+
+function renderSchemaProbeSql(report) {
+  const rows = buildUnifiedProbeRows(report.schemaProbePlan)
+  const lines = [
+    '-- Staging migration alignment schema probe SQL',
+    `-- Generated at: ${report.generatedAt}`,
+    '-- Read-only catalog checks generated from migration up-path static analysis.',
+    '-- Run only against a cloned or backed-up rehearsal DB unless explicitly approved.',
+    '-- This is not a migration safety proof: index checks verify name/table presence, not definition equivalence.',
+    '-- Unqualified table names are not assumed to be public; matched_schemas reports every non-system schema match.',
+    '',
+    'BEGIN READ ONLY;',
+    '',
+  ]
+
+  if (rows.length > 0) {
+    lines.push(
+      'WITH probe_plan(kind, migration, schema_name, table_name, column_name, index_name) AS (',
+      '  VALUES',
+      renderValues(rows, ['kind', 'migration', 'schema', 'table', 'column', 'index']),
+      ')',
+      'SELECT',
+      '  p.kind AS probe_type,',
+      '  migration,',
+      '  concat_ws(',
+      "    '.',",
+      "    nullif(coalesce(p.schema_name, ''), ''),",
+      '    p.table_name,',
+      '    p.column_name,',
+      '    p.index_name',
+      '  ) AS target,',
+      '  probe.match_count > 0 AS exists,',
+      '  probe.match_count,',
+      "  coalesce(probe.matched_schemas, '') AS matched_schemas",
+      'FROM probe_plan p',
+      'CROSS JOIN LATERAL (',
+      '  SELECT count(*)::integer AS match_count, string_agg(DISTINCT schema_match, \', \' ORDER BY schema_match) AS matched_schemas',
+      '  FROM (',
+      '    SELECT n.nspname AS schema_match',
+      '    FROM pg_catalog.pg_class c',
+      '    JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace',
+      "    WHERE p.kind = 'table'",
+      '      AND c.relname = p.table_name',
+      "      AND c.relkind IN ('r', 'p')",
+      "      AND n.nspname NOT IN ('pg_catalog', 'information_schema')",
+      '      AND (p.schema_name IS NULL OR n.nspname = p.schema_name)',
+      '    UNION ALL',
+      '    SELECT n.nspname AS schema_match',
+      '    FROM pg_catalog.pg_attribute a',
+      '    JOIN pg_catalog.pg_class c ON c.oid = a.attrelid',
+      '    JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace',
+      "    WHERE p.kind = 'column'",
+      '      AND c.relname = p.table_name',
+      '      AND a.attname = p.column_name',
+      '      AND a.attnum > 0',
+      '      AND NOT a.attisdropped',
+      "      AND c.relkind IN ('r', 'p')",
+      "      AND n.nspname NOT IN ('pg_catalog', 'information_schema')",
+      '      AND (p.schema_name IS NULL OR n.nspname = p.schema_name)',
+      '    UNION ALL',
+      '    SELECT n.nspname AS schema_match',
+      '    FROM pg_catalog.pg_class i',
+      '    JOIN pg_catalog.pg_namespace n ON n.oid = i.relnamespace',
+      '    JOIN pg_catalog.pg_index ix ON ix.indexrelid = i.oid',
+      '    JOIN pg_catalog.pg_class t ON t.oid = ix.indrelid',
+      "    WHERE p.kind = 'index'",
+      '      AND i.relname = p.index_name',
+      '      AND t.relname = p.table_name',
+      "      AND i.relkind IN ('i', 'I')",
+      "      AND n.nspname NOT IN ('pg_catalog', 'information_schema')",
+      '      AND (p.schema_name IS NULL OR n.nspname = p.schema_name)',
+      '  ) matches',
+      ') probe',
+      'ORDER BY migration, probe_type, target;',
+      '',
+    )
+  } else {
+    lines.push('-- No schema probes extracted.', '')
+  }
+
+  lines.push('ROLLBACK;', '')
+  return `${lines.join('\n')}`
 }
 
 function markdownTable(rows, columns) {
@@ -549,6 +766,7 @@ function renderMarkdown(report) {
     `- Decision: \`${report.recommendation.decision}\``,
     `- Full migrate recommended: \`${report.recommendation.fullMigrateRecommended}\``,
     `- Next action: ${report.recommendation.nextAction}`,
+    `- Probe SQL targets: ${report.schemaProbeSqlCounts.tables} tables, ${report.schemaProbeSqlCounts.columns} columns, ${report.schemaProbeSqlCounts.indexes} indexes`,
     '',
     '## Category Counts',
     '',
@@ -585,6 +803,8 @@ function renderMarkdown(report) {
     '## Schema Probe Plan',
     '',
     'Use this as a read-only rehearsal checklist on a cloned or backed-up DB. It is not a safety proof.',
+    '',
+    'The companion `schema-probes.sql` file contains read-only PostgreSQL catalog queries for these extracted targets.',
     '',
   )
 
@@ -625,9 +845,11 @@ function writeOutputs(report, outDir) {
   mkdirSync(absoluteOut, { recursive: true })
   const jsonPath = path.join(absoluteOut, 'report.json')
   const mdPath = path.join(absoluteOut, 'report.md')
+  const probeSqlPath = path.join(absoluteOut, 'schema-probes.sql')
   writeFileSync(jsonPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8')
   writeFileSync(mdPath, renderMarkdown(report), 'utf8')
-  return { jsonPath, mdPath }
+  writeFileSync(probeSqlPath, renderSchemaProbeSql(report), 'utf8')
+  return { jsonPath, mdPath, probeSqlPath }
 }
 
 function main() {
@@ -644,6 +866,7 @@ function main() {
     console.log(`[staging-migration-alignment-report] decision=${report.recommendation.decision}`)
     console.log(`[staging-migration-alignment-report] JSON: ${outputs.jsonPath}`)
     console.log(`[staging-migration-alignment-report] MD: ${outputs.mdPath}`)
+    console.log(`[staging-migration-alignment-report] schema probes SQL: ${outputs.probeSqlPath}`)
   } catch (error) {
     console.error(`[staging-migration-alignment-report] ERROR: ${error.message}`)
     process.exitCode = 1

--- a/scripts/ops/staging-migration-alignment-report.test.mjs
+++ b/scripts/ops/staging-migration-alignment-report.test.mjs
@@ -104,10 +104,13 @@ Pending migrations (in load order):
     assert.equal(result.status, 0, result.stderr)
 
     const report = JSON.parse(readFileSync(path.join(outDir, 'report.json'), 'utf8'))
+    const probeSql = readFileSync(path.join(outDir, 'schema-probes.sql'), 'utf8')
     const item = report.items.find((it) => it.name === '20250926_create_audit_tables')
     assert.equal(item.category, 'timestamp_sql')
     assert.equal(item.risk, 'high')
     assert.equal(item.hasCreateTableWithoutIfNotExists, true)
+    assert.ok(report.schemaProbeSqlCounts.tables > 0)
+    assert.ok(report.schemaProbeSqlCounts.columns > 0)
     assert.ok(item.schemaTargets.createTables.includes('audit_logs'))
     assert.ok(item.schemaTargets.addColumns.some((target) => (
       target.table === 'audit_logs' && target.column === 'event_id'
@@ -120,6 +123,14 @@ Pending migrations (in load order):
       && entry.tablesToCheck.includes('audit_logs')
       && entry.columnsToCheck.includes('audit_logs.event_id')
     )))
+    assert.match(probeSql, /BEGIN READ ONLY/)
+    assert.match(probeSql, /WITH probe_plan/)
+    assert.match(probeSql, /pg_catalog\.pg_attribute/)
+    assert.match(probeSql, /matched_schemas/)
+    assert.match(probeSql, /\('column', '20250926_create_audit_tables', NULL, 'audit_logs', 'event_id', NULL\)/)
+    assert.doesNotMatch(probeSql, /to_regclass/)
+    assert.doesNotMatch(probeSql, /information_schema\.columns/)
+    assert.doesNotMatch(probeSql, /\b(CREATE|ALTER|DROP)\s+(TABLE|INDEX|COLUMN)\b/i)
   } finally {
     rmSync(tmp, { recursive: true, force: true })
   }
@@ -162,6 +173,7 @@ Pending migrations (in load order):
     assert.equal(result.status, 0, result.stderr)
 
     const report = JSON.parse(readFileSync(path.join(outDir, 'report.json'), 'utf8'))
+    const probeSql = readFileSync(path.join(outDir, 'schema-probes.sql'), 'utf8')
     const item = report.items.find((it) => it.name === 'zzzz20260519070000_create_plugin_attendance_report_sync_jobs')
     assert.equal(item.category, 'modern_timestamp_migration')
     assert.notEqual(item.risk, 'high')
@@ -174,6 +186,11 @@ Pending migrations (in load order):
       target.table === 'plugin_attendance_report_sync_jobs'
       && target.index === 'uq_plugin_attendance_report_sync_jobs_idempotency'
     )))
+    assert.equal(report.schemaProbeSqlCounts.tables, 1)
+    assert.equal(report.schemaProbeSqlCounts.indexes, 1)
+    assert.match(probeSql, /pg_catalog\.pg_index/)
+    assert.match(probeSql, /plugin_attendance_report_sync_jobs/)
+    assert.match(probeSql, /status/)
   } finally {
     rmSync(tmp, { recursive: true, force: true })
   }
@@ -201,6 +218,33 @@ Pending migrations (in load order):
     assert.equal(item.schemaTargets.addColumns.some((target) => (
       target.table === 'approval_records' && target.column === 'node_key'
     )), false)
+  } finally {
+    rmSync(tmp, { recursive: true, force: true })
+  }
+})
+
+test('emits full schema probe SQL from the whole probe plan', () => {
+  const tmp = makeTmp()
+  try {
+    const outDir = path.join(tmp, 'out')
+    const result = run(['--out-dir', outDir], STAGING_LIST)
+    assert.equal(result.status, 0, result.stderr)
+
+    const report = JSON.parse(readFileSync(path.join(outDir, 'report.json'), 'utf8'))
+    const markdown = readFileSync(path.join(outDir, 'report.md'), 'utf8')
+    const probeSql = readFileSync(path.join(outDir, 'schema-probes.sql'), 'utf8')
+
+    const planRowsInSql = [...probeSql.matchAll(/\('(?:table|column|index)', /g)].length
+    const expectedRows = report.schemaProbeSqlCounts.tables
+      + report.schemaProbeSqlCounts.columns
+      + report.schemaProbeSqlCounts.indexes
+
+    assert.equal(planRowsInSql, expectedRows)
+    assert.equal(report.schemaProbePlan.length, 40)
+    assert.match(markdown, /The companion `schema-probes\.sql`/)
+    assert.match(probeSql, /Unqualified table names are not assumed to be public/)
+    assert.match(probeSql, /coalesce\(probe\.matched_schemas, ''\) AS matched_schemas/)
+    assert.match(probeSql, /\('table', '008_plugin_infrastructure', NULL, 'plugin_registry', NULL, NULL\)/)
   } finally {
     rmSync(tmp, { recursive: true, force: true })
   }


### PR DESCRIPTION
## Summary

Adds a generated `schema-probes.sql` companion to the staging migration alignment report. The SQL is built from the existing Schema Probe Plan and stays read-only: one `probe_plan` CTE over PostgreSQL `pg_catalog`, returning `exists`, `match_count`, and `matched_schemas` for extracted table/column/index targets.

Also tightens static extraction for `CREATE INDEX CONCURRENTLY` and multiple `ADD COLUMN` clauses in one statement, and documents the operator workflow in the staging migration alignment runbook.

## Boundaries

- No migration execution
- No DB connection from the script
- No `kysely_migration` writes
- No secret/JWT paths committed
- Live evidence only captures staging `migrate --list` and generates local untracked output

## Verification

- [x] `node --check scripts/ops/staging-migration-alignment-report.mjs`
- [x] `node --test scripts/ops/staging-migration-alignment-report.test.mjs` — 7 tests
- [x] `git diff --check`
- [x] Live 8082 staging read-only report generation: 86 applied / 77 pending, decision `do_not_run_full_migrate`, probe SQL targets 207 tables / 2069 columns / 431 indexes

Design and verification docs:
- `docs/development/staging-migration-probe-sql-development-20260520.md`
- `docs/development/staging-migration-probe-sql-verification-20260520.md`